### PR TITLE
Refactor texture overrides and add new features

### DIFF
--- a/doc/texture_packs.txt
+++ b/doc/texture_packs.txt
@@ -145,7 +145,7 @@ are placeholders intended to be overwritten by the game.
 Texture Overrides
 -----------------
 
-You can override the textures of a node or other item from a
+You can override the textures of nodes and items from a
 texture pack using texture overrides. To do this, create one or
 more files in a texture pack called override.txt
 
@@ -165,7 +165,7 @@ You can list multiple targets on one line as a comma-separated list:
 
 	default:tree top,bottom my_special_tree.png
 
-You can use ^ operators as usual:
+You can use texture modifiers, as usual:
 
 	default:dirt_with_grass sides default_stone.png^[brighten
 

--- a/doc/texture_packs.txt
+++ b/doc/texture_packs.txt
@@ -145,34 +145,51 @@ are placeholders intended to be overwritten by the game.
 Texture Overrides
 -----------------
 
-You can override the textures of a node from a texture pack using
-texture overrides. To do this, create a file in a texture pack
-called override.txt
+You can override the textures of a node or other item from a
+texture pack using texture overrides. To do this, create one or
+more files in a texture pack called override.txt
 
 Each line in an override.txt file is a rule. It consists of
 
-	nodename face-selector texture
+	itemname target texture
 
 For example,
 
 	default:dirt_with_grass sides default_stone.png
 
+or
+
+	default:sword_steel inventory my_steel_sword.png
+
+You can list multiple targets on one line as a comma-separated list:
+
+	default:tree top,bottom my_special_tree.png
+
 You can use ^ operators as usual:
 
 	default:dirt_with_grass sides default_stone.png^[brighten
 
-Here are face selectors you can choose from:
+Finally, if a line is empty or starts with '#' it will be considered
+a comment and not read as a rule. You can use this to better organize
+your override.txt files.
 
-| face-selector | behavior                                          |
+Here are targets you can choose from:
+
+| target        | behavior                                          |
 |---------------|---------------------------------------------------|
-| left          | x-                                                |
-| right         | x+                                                |
-| front         | z-                                                |
-| back          | z+                                                |
-| top           | y+                                                |
-| bottom        | y-                                                |
-| sides         | x-, x+, z-, z+                                    |
+| left          | x- face                                           |
+| right         | x+ face                                           |
+| front         | z- face                                           |
+| back          | z+ face                                           |
+| top           | y+ face                                           |
+| bottom        | y- face                                           |
+| sides         | x-, x+, z-, z+ faces                              |
 | all           | All faces. You can also use '*' instead of 'all'. |
+| inventory     | The inventory texture                             |
+| wield         | The texture used when held by the player          |
+
+Nodes support all targets, but other items only support 'inventory'
+and 'wield'
 
 Designing leaves textures for the leaves rendering options
 ----------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -426,6 +426,7 @@ set(common_SRCS
 	settings.cpp
 	staticobject.cpp
 	terminal_chat_console.cpp
+	texture_override.cpp
 	tileanimation.cpp
 	tool.cpp
 	translation.cpp

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1723,7 +1723,7 @@ void Client::afterContentReceived()
 	RenderingEngine::draw_load_screen(text, guienv, m_tsrc, 0, 72);
 	m_nodedef->updateAliases(m_itemdef);
 	for (const auto &path : getTextureDirs()) {
-		CTextureOverrideSource override_source(path + DIR_DELIM + "override.txt");
+		TextureOverrideSource override_source(path + DIR_DELIM + "override.txt");
 		m_nodedef->applyTextureOverrides(override_source.getNodeTileOverrides());
 		m_itemdef->applyTextureOverrides(override_source.getItemTextureOverrides());
 	}

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1722,8 +1722,11 @@ void Client::afterContentReceived()
 	text = wgettext("Initializing nodes...");
 	RenderingEngine::draw_load_screen(text, guienv, m_tsrc, 0, 72);
 	m_nodedef->updateAliases(m_itemdef);
-	for (const auto &path : getTextureDirs())
-		m_nodedef->applyTextureOverrides(path + DIR_DELIM + "override.txt");
+	for (const auto &path : getTextureDirs()) {
+		CTextureOverrideSource override_source(path + DIR_DELIM + "override.txt");
+		m_nodedef->applyTextureOverrides(override_source.getNodeTileOverrides());
+		m_itemdef->applyTextureOverrides(override_source.getItemTextureOverrides());
+	}
 	m_nodedef->setNodeRegistrationStatus(true);
 	m_nodedef->runNodeResolveCallbacks();
 	delete[] text;

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -422,6 +422,25 @@ public:
 		return get(stack.name).color;
 	}
 #endif
+	void applyTextureOverrides(std::vector<TextureOverride> overrides)
+	{
+		infostream << "ItemDefManager::applyTextureOverrides(): Applying "
+			"overrides to textures" << std::endl;
+
+		for (const TextureOverride& texture_override : overrides) {
+			if (m_item_definitions.find(texture_override.id) == m_item_definitions.end()) {
+				continue; // Ignore unknown item
+			}
+
+			ItemDefinition* itemdef = m_item_definitions[texture_override.id];
+
+			if ((texture_override.target & static_cast<u8>(OverrideTarget::INVENTORY)) != 0)
+				itemdef->inventory_image = texture_override.texture;
+
+			if ((texture_override.target & static_cast<u8>(OverrideTarget::WIELD)) != 0)
+				itemdef->wield_image = texture_override.texture;
+		}
+	}
 	void clear()
 	{
 		for(std::map<std::string, ItemDefinition*>::const_iterator

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -434,10 +434,10 @@ public:
 
 			ItemDefinition* itemdef = m_item_definitions[texture_override.id];
 
-			if ((texture_override.target & static_cast<u8>(OverrideTarget::INVENTORY)) != 0)
+			if (texture_override.hasTarget(OverrideTarget::INVENTORY))
 				itemdef->inventory_image = texture_override.texture;
 
-			if ((texture_override.target & static_cast<u8>(OverrideTarget::WIELD)) != 0)
+			if (texture_override.hasTarget(OverrideTarget::WIELD))
 				itemdef->wield_image = texture_override.texture;
 		}
 	}

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -422,7 +422,7 @@ public:
 		return get(stack.name).color;
 	}
 #endif
-	void applyTextureOverrides(std::vector<TextureOverride> overrides)
+	void applyTextureOverrides(const std::vector<TextureOverride> &overrides)
 	{
 		infostream << "ItemDefManager::applyTextureOverrides(): Applying "
 			"overrides to textures" << std::endl;

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -160,7 +160,7 @@ public:
 
 	// Replace the textures of registered nodes with the ones specified in
 	// the texture pack's override.txt files
-	virtual void applyTextureOverrides(std::vector<TextureOverride> overrides)=0;
+	virtual void applyTextureOverrides(const std::vector<TextureOverride> &overrides)=0;
 
 	// Remove all registered item and node definitions and aliases
 	// Then re-add the builtin item definitions

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <set>
 #include "itemgroup.h"
 #include "sound.h"
+#include "texture_override.h" // TextureOverride
 class IGameDef;
 class Client;
 struct ToolCapabilities;
@@ -156,6 +157,10 @@ public:
 	virtual ItemMesh* getWieldMesh(const std::string &name,
 		Client *client) const=0;
 #endif
+
+	// Replace the textures of registered nodes with the ones specified in
+	// the texture pack's override.txt files
+	virtual void applyTextureOverrides(std::vector<TextureOverride> overrides)=0;
 
 	// Remove all registered item and node definitions and aliases
 	// Then re-add the builtin item definitions

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1304,60 +1304,35 @@ void NodeDefManager::updateAliases(IItemDefManager *idef)
 	}
 }
 
-void NodeDefManager::applyTextureOverrides(const std::string &override_filepath)
+void NodeDefManager::applyTextureOverrides(std::vector<TextureOverride> overrides)
 {
 	infostream << "NodeDefManager::applyTextureOverrides(): Applying "
-		"overrides to textures from " << override_filepath << std::endl;
+		"overrides to textures" << std::endl;
 
-	std::ifstream infile(override_filepath.c_str());
-	std::string line;
-	int line_c = 0;
-	while (std::getline(infile, line)) {
-		line_c++;
-		// Also trim '\r' on DOS-style files
-		line = trim(line);
-		if (line.empty())
-			continue;
-
-		std::vector<std::string> splitted = str_split(line, ' ');
-		if (splitted.size() != 3) {
-			errorstream << override_filepath
-				<< ":" << line_c << " Could not apply texture override \""
-				<< line << "\": Syntax error" << std::endl;
-			continue;
-		}
-
+	for (const TextureOverride& texture_override : overrides) {
 		content_t id;
-		if (!getId(splitted[0], id))
+		if (!getId(texture_override.id, id))
 			continue; // Ignore unknown node
 
 		ContentFeatures &nodedef = m_content_features[id];
 
-		if (splitted[1] == "top")
-			nodedef.tiledef[0].name = splitted[2];
-		else if (splitted[1] == "bottom")
-			nodedef.tiledef[1].name = splitted[2];
-		else if (splitted[1] == "right")
-			nodedef.tiledef[2].name = splitted[2];
-		else if (splitted[1] == "left")
-			nodedef.tiledef[3].name = splitted[2];
-		else if (splitted[1] == "back")
-			nodedef.tiledef[4].name = splitted[2];
-		else if (splitted[1] == "front")
-			nodedef.tiledef[5].name = splitted[2];
-		else if (splitted[1] == "all" || splitted[1] == "*")
-			for (TileDef &i : nodedef.tiledef)
-				i.name = splitted[2];
-		else if (splitted[1] == "sides")
-			for (int i = 2; i < 6; i++)
-				nodedef.tiledef[i].name = splitted[2];
-		else {
-			errorstream << override_filepath
-				<< ":" << line_c << " Could not apply texture override \""
-				<< line << "\": Unknown node side \""
-				<< splitted[1] << "\"" << std::endl;
-			continue;
-		}
+		if ((texture_override.target & static_cast<u8>(OverrideTarget::TOP)) != 0)
+			nodedef.tiledef[0].name = texture_override.texture;
+
+		if ((texture_override.target & static_cast<u8>(OverrideTarget::BOTTOM)) != 0)
+			nodedef.tiledef[1].name = texture_override.texture;
+
+		if ((texture_override.target & static_cast<u8>(OverrideTarget::RIGHT)) != 0)
+			nodedef.tiledef[2].name = texture_override.texture;
+
+		if ((texture_override.target & static_cast<u8>(OverrideTarget::LEFT)) != 0)
+			nodedef.tiledef[3].name = texture_override.texture;
+
+		if ((texture_override.target & static_cast<u8>(OverrideTarget::BACK)) != 0)
+			nodedef.tiledef[4].name = texture_override.texture;
+
+		if ((texture_override.target & static_cast<u8>(OverrideTarget::FRONT)) != 0)
+			nodedef.tiledef[5].name = texture_override.texture;
 	}
 }
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1304,7 +1304,7 @@ void NodeDefManager::updateAliases(IItemDefManager *idef)
 	}
 }
 
-void NodeDefManager::applyTextureOverrides(std::vector<TextureOverride> overrides)
+void NodeDefManager::applyTextureOverrides(const std::vector<TextureOverride> &overrides)
 {
 	infostream << "NodeDefManager::applyTextureOverrides(): Applying "
 		"overrides to textures" << std::endl;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1316,7 +1316,7 @@ void NodeDefManager::applyTextureOverrides(const std::vector<TextureOverride> &o
 
 		ContentFeatures &nodedef = m_content_features[id];
 
-		if ((texture_override.hasTarget(OverrideTarget::TOP)) != 0)
+		if (texture_override.hasTarget(OverrideTarget::TOP))
 			nodedef.tiledef[0].name = texture_override.texture;
 
 		if ((texture_override.hasTarget(OverrideTarget::BOTTOM)) != 0)

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1316,22 +1316,22 @@ void NodeDefManager::applyTextureOverrides(const std::vector<TextureOverride> &o
 
 		ContentFeatures &nodedef = m_content_features[id];
 
-		if ((texture_override.target & static_cast<u8>(OverrideTarget::TOP)) != 0)
+		if ((texture_override.hasTarget(OverrideTarget::TOP)) != 0)
 			nodedef.tiledef[0].name = texture_override.texture;
 
-		if ((texture_override.target & static_cast<u8>(OverrideTarget::BOTTOM)) != 0)
+		if ((texture_override.hasTarget(OverrideTarget::BOTTOM)) != 0)
 			nodedef.tiledef[1].name = texture_override.texture;
 
-		if ((texture_override.target & static_cast<u8>(OverrideTarget::RIGHT)) != 0)
+		if ((texture_override.hasTarget(OverrideTarget::RIGHT)) != 0)
 			nodedef.tiledef[2].name = texture_override.texture;
 
-		if ((texture_override.target & static_cast<u8>(OverrideTarget::LEFT)) != 0)
+		if ((texture_override.hasTarget(OverrideTarget::LEFT)) != 0)
 			nodedef.tiledef[3].name = texture_override.texture;
 
-		if ((texture_override.target & static_cast<u8>(OverrideTarget::BACK)) != 0)
+		if ((texture_override.hasTarget(OverrideTarget::BACK)) != 0)
 			nodedef.tiledef[4].name = texture_override.texture;
 
-		if ((texture_override.target & static_cast<u8>(OverrideTarget::FRONT)) != 0)
+		if ((texture_override.hasTarget(OverrideTarget::FRONT)) != 0)
 			nodedef.tiledef[5].name = texture_override.texture;
 	}
 }

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1319,19 +1319,19 @@ void NodeDefManager::applyTextureOverrides(const std::vector<TextureOverride> &o
 		if (texture_override.hasTarget(OverrideTarget::TOP))
 			nodedef.tiledef[0].name = texture_override.texture;
 
-		if ((texture_override.hasTarget(OverrideTarget::BOTTOM)) != 0)
+		if (texture_override.hasTarget(OverrideTarget::BOTTOM))
 			nodedef.tiledef[1].name = texture_override.texture;
 
-		if ((texture_override.hasTarget(OverrideTarget::RIGHT)) != 0)
+		if (texture_override.hasTarget(OverrideTarget::RIGHT))
 			nodedef.tiledef[2].name = texture_override.texture;
 
-		if ((texture_override.hasTarget(OverrideTarget::LEFT)) != 0)
+		if (texture_override.hasTarget(OverrideTarget::LEFT))
 			nodedef.tiledef[3].name = texture_override.texture;
 
-		if ((texture_override.hasTarget(OverrideTarget::BACK)) != 0)
+		if (texture_override.hasTarget(OverrideTarget::BACK))
 			nodedef.tiledef[4].name = texture_override.texture;
 
-		if ((texture_override.hasTarget(OverrideTarget::FRONT)) != 0)
+		if (texture_override.hasTarget(OverrideTarget::FRONT))
 			nodedef.tiledef[5].name = texture_override.texture;
 	}
 }

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -589,7 +589,7 @@ public:
 	 *
 	 * @param overrides the texture overrides
 	 */
-	void applyTextureOverrides(std::vector<TextureOverride> overrides);
+	void applyTextureOverrides(const std::vector<TextureOverride> &overrides);
 
 	/*!
 	 * Only the client uses this. Loads textures and shaders required for

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -33,6 +33,7 @@ class Client;
 #include "itemgroup.h"
 #include "sound.h" // SimpleSoundSpec
 #include "constants.h" // BS
+#include "texture_override.h" // TextureOverride
 #include "tileanimation.h"
 
 // PROTOCOL_VERSION >= 37
@@ -583,15 +584,12 @@ public:
 	void updateAliases(IItemDefManager *idef);
 
 	/*!
-	 * Reads the used texture pack's override.txt, and replaces the textures
-	 * of registered nodes with the ones specified there.
+	 * Replaces the textures of registered nodes with the ones specified in
+	 * the texturepack's override.txt file
 	 *
-	 * Format of the input file: in each line
-	 * `node_name top|bottom|right|left|front|back|all|*|sides texture_name.png`
-	 *
-	 * @param override_filepath path to 'texturepack/override.txt'
+	 * @param overrides the texture overrides
 	 */
-	void applyTextureOverrides(const std::string &override_filepath);
+	void applyTextureOverrides(std::vector<TextureOverride> overrides);
 
 	/*!
 	 * Only the client uses this. Loads textures and shaders required for

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -375,7 +375,7 @@ void Server::init()
 	fs::GetRecursiveDirs(paths, g_settings->get("texture_path"));
 	fs::GetRecursiveDirs(paths, m_gamespec.path + DIR_DELIM + "textures");
 	for (const std::string &path : paths) {
-		CTextureOverrideSource override_source(path + DIR_DELIM + "override.txt");
+		TextureOverrideSource override_source(path + DIR_DELIM + "override.txt");
 		m_nodedef->applyTextureOverrides(override_source.getNodeTileOverrides());
 		m_itemdef->applyTextureOverrides(override_source.getItemTextureOverrides());
 	}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -374,8 +374,11 @@ void Server::init()
 	std::vector<std::string> paths;
 	fs::GetRecursiveDirs(paths, g_settings->get("texture_path"));
 	fs::GetRecursiveDirs(paths, m_gamespec.path + DIR_DELIM + "textures");
-	for (const std::string &path : paths)
-		m_nodedef->applyTextureOverrides(path + DIR_DELIM + "override.txt");
+	for (const std::string &path : paths) {
+		CTextureOverrideSource override_source(path + DIR_DELIM + "override.txt");
+		m_nodedef->applyTextureOverrides(override_source.getNodeTileOverrides());
+		m_itemdef->applyTextureOverrides(override_source.getItemTextureOverrides());
+	}
 
 	m_nodedef->setNodeRegistrationStatus(true);
 

--- a/src/texture_override.cpp
+++ b/src/texture_override.cpp
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2020 Hugues Ross <hugues.ross@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/texture_override.cpp
+++ b/src/texture_override.cpp
@@ -1,0 +1,122 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "texture_override.h"
+
+#include "log.h"
+#include "util/string.h"
+#include <algorithm>
+#include <fstream>
+
+CTextureOverrideSource::CTextureOverrideSource(std::string filepath)
+{
+	std::ifstream infile(filepath.c_str());
+	std::string line;
+	int line_index = 0;
+	while (std::getline(infile, line)) {
+		line_index++;
+
+		// Also trim '\r' on DOS-style files
+		line = trim(line);
+
+		// Ignore empty lines and comments
+		if (line.empty() || line[0] == '#')
+			continue;
+
+		std::vector<std::string> splitted = str_split(line, ' ');
+		if (splitted.size() != 3) {
+			errorstream << filepath << ":" << line_index
+				<< " Syntax error in texture override \"" << line
+				<< "\": Expected 3 arguments, got " << splitted.size()
+				<< std::endl;
+			continue;
+		}
+
+		TextureOverride texture_override = { };
+		texture_override.id = splitted[0];
+		texture_override.texture = splitted[2];
+
+		// Parse the target mask
+		std::vector<std::string> targets = str_split(splitted[1], ',');
+		for (const std::string& target : targets) {
+			if (target == "top")
+				texture_override.target |= static_cast<u8>(OverrideTarget::TOP);
+			else if (target == "bottom")
+				texture_override.target |= static_cast<u8>(OverrideTarget::BOTTOM);
+			else if (target == "left")
+				texture_override.target |= static_cast<u8>(OverrideTarget::LEFT);
+			else if (target == "right")
+				texture_override.target |= static_cast<u8>(OverrideTarget::RIGHT);
+			else if (target == "front")
+				texture_override.target |= static_cast<u8>(OverrideTarget::FRONT);
+			else if (target == "back")
+				texture_override.target |= static_cast<u8>(OverrideTarget::BACK);
+			else if (target == "inventory")
+				texture_override.target |= static_cast<u8>(OverrideTarget::INVENTORY);
+			else if (target == "wield")
+				texture_override.target |= static_cast<u8>(OverrideTarget::WIELD);
+			else if (target == "sides")
+				texture_override.target |= static_cast<u8>(OverrideTarget::SIDES);
+			else if (target == "all" || target == "*")
+				texture_override.target |= static_cast<u8>(OverrideTarget::ALL_FACES);
+			else {
+				// Report invalid target
+				errorstream << filepath << ":" << line_index
+					<< " Syntax error in texture override \"" << line
+					<< "\": Unknown target \"" << target << "\""
+					<< std::endl;
+			}
+		}
+
+		// If there are no valid targets, skip adding this override
+		if (texture_override.target == static_cast<u8>(OverrideTarget::INVALID)) {
+			continue;
+		}
+
+		m_overrides.push_back(texture_override);
+	}
+}
+
+//! Get all overrides that apply to item definitions
+std::vector<TextureOverride> CTextureOverrideSource::getItemTextureOverrides()
+{
+	std::vector<TextureOverride> found_overrides;
+
+	for (const TextureOverride& texture_override : m_overrides) {
+		if ((texture_override.target
+					& static_cast<u8>(OverrideTarget::ITEM_TARGETS)) != 0)
+			found_overrides.push_back(texture_override);
+	}
+
+	return found_overrides;
+}
+
+//! Get all overrides that apply to node definitions
+std::vector<TextureOverride> CTextureOverrideSource::getNodeTileOverrides()
+{
+	std::vector<TextureOverride> found_overrides;
+
+	for (const TextureOverride& texture_override : m_overrides) {
+		if ((texture_override.target
+					& static_cast<u8>(OverrideTarget::ALL_FACES)) != 0)
+			found_overrides.push_back(texture_override);
+	}
+
+	return found_overrides;
+}

--- a/src/texture_override.cpp
+++ b/src/texture_override.cpp
@@ -98,7 +98,7 @@ std::vector<TextureOverride> TextureOverrideSource::getItemTextureOverrides()
 {
 	std::vector<TextureOverride> found_overrides;
 
-	for (const TextureOverride& texture_override : m_overrides) {
+	for (const TextureOverride &texture_override : m_overrides) {
 		if (texture_override.hasTarget(OverrideTarget::ITEM_TARGETS))
 			found_overrides.push_back(texture_override);
 	}
@@ -111,7 +111,7 @@ std::vector<TextureOverride> TextureOverrideSource::getNodeTileOverrides()
 {
 	std::vector<TextureOverride> found_overrides;
 
-	for (const TextureOverride& texture_override : m_overrides) {
+	for (const TextureOverride &texture_override : m_overrides) {
 		if (texture_override.hasTarget(OverrideTarget::ALL_FACES))
 			found_overrides.push_back(texture_override);
 	}

--- a/src/texture_override.cpp
+++ b/src/texture_override.cpp
@@ -42,19 +42,19 @@ CTextureOverrideSource::CTextureOverrideSource(std::string filepath)
 		std::vector<std::string> splitted = str_split(line, ' ');
 		if (splitted.size() != 3) {
 			errorstream << filepath << ":" << line_index
-				<< " Syntax error in texture override \"" << line
-				<< "\": Expected 3 arguments, got " << splitted.size()
-				<< std::endl;
+					<< " Syntax error in texture override \"" << line
+					<< "\": Expected 3 arguments, got " << splitted.size()
+					<< std::endl;
 			continue;
 		}
 
-		TextureOverride texture_override = { };
+		TextureOverride texture_override = {};
 		texture_override.id = splitted[0];
 		texture_override.texture = splitted[2];
 
 		// Parse the target mask
 		std::vector<std::string> targets = str_split(splitted[1], ',');
-		for (const std::string& target : targets) {
+		for (const std::string &target : targets) {
 			if (target == "top")
 				texture_override.target |= static_cast<u8>(OverrideTarget::TOP);
 			else if (target == "bottom")
@@ -78,9 +78,9 @@ CTextureOverrideSource::CTextureOverrideSource(std::string filepath)
 			else {
 				// Report invalid target
 				errorstream << filepath << ":" << line_index
-					<< " Syntax error in texture override \"" << line
-					<< "\": Unknown target \"" << target << "\""
-					<< std::endl;
+						<< " Syntax error in texture override \"" << line
+						<< "\": Unknown target \"" << target << "\""
+						<< std::endl;
 			}
 		}
 
@@ -99,8 +99,8 @@ std::vector<TextureOverride> CTextureOverrideSource::getItemTextureOverrides()
 	std::vector<TextureOverride> found_overrides;
 
 	for (const TextureOverride& texture_override : m_overrides) {
-		if ((texture_override.target
-					& static_cast<u8>(OverrideTarget::ITEM_TARGETS)) != 0)
+		if ((texture_override.target &
+					static_cast<u8>(OverrideTarget::ITEM_TARGETS)) != 0)
 			found_overrides.push_back(texture_override);
 	}
 
@@ -113,8 +113,8 @@ std::vector<TextureOverride> CTextureOverrideSource::getNodeTileOverrides()
 	std::vector<TextureOverride> found_overrides;
 
 	for (const TextureOverride& texture_override : m_overrides) {
-		if ((texture_override.target
-					& static_cast<u8>(OverrideTarget::ALL_FACES)) != 0)
+		if ((texture_override.target &
+					static_cast<u8>(OverrideTarget::ALL_FACES)) != 0)
 			found_overrides.push_back(texture_override);
 	}
 

--- a/src/texture_override.cpp
+++ b/src/texture_override.cpp
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <algorithm>
 #include <fstream>
 
-CTextureOverrideSource::CTextureOverrideSource(std::string filepath)
+TextureOverrideSource::TextureOverrideSource(std::string filepath)
 {
 	std::ifstream infile(filepath.c_str());
 	std::string line;
@@ -41,7 +41,7 @@ CTextureOverrideSource::CTextureOverrideSource(std::string filepath)
 
 		std::vector<std::string> splitted = str_split(line, ' ');
 		if (splitted.size() != 3) {
-			errorstream << filepath << ":" << line_index
+			warningstream << filepath << ":" << line_index
 					<< " Syntax error in texture override \"" << line
 					<< "\": Expected 3 arguments, got " << splitted.size()
 					<< std::endl;
@@ -77,7 +77,7 @@ CTextureOverrideSource::CTextureOverrideSource(std::string filepath)
 				texture_override.target |= static_cast<u8>(OverrideTarget::ALL_FACES);
 			else {
 				// Report invalid target
-				errorstream << filepath << ":" << line_index
+				warningstream << filepath << ":" << line_index
 						<< " Syntax error in texture override \"" << line
 						<< "\": Unknown target \"" << target << "\""
 						<< std::endl;
@@ -94,7 +94,7 @@ CTextureOverrideSource::CTextureOverrideSource(std::string filepath)
 }
 
 //! Get all overrides that apply to item definitions
-std::vector<TextureOverride> CTextureOverrideSource::getItemTextureOverrides()
+std::vector<TextureOverride> TextureOverrideSource::getItemTextureOverrides()
 {
 	std::vector<TextureOverride> found_overrides;
 
@@ -108,7 +108,7 @@ std::vector<TextureOverride> CTextureOverrideSource::getItemTextureOverrides()
 }
 
 //! Get all overrides that apply to node definitions
-std::vector<TextureOverride> CTextureOverrideSource::getNodeTileOverrides()
+std::vector<TextureOverride> TextureOverrideSource::getNodeTileOverrides()
 {
 	std::vector<TextureOverride> found_overrides;
 

--- a/src/texture_override.cpp
+++ b/src/texture_override.cpp
@@ -99,8 +99,7 @@ std::vector<TextureOverride> TextureOverrideSource::getItemTextureOverrides()
 	std::vector<TextureOverride> found_overrides;
 
 	for (const TextureOverride& texture_override : m_overrides) {
-		if ((texture_override.target &
-					static_cast<u8>(OverrideTarget::ITEM_TARGETS)) != 0)
+		if (texture_override.hasTarget(OverrideTarget::ITEM_TARGETS))
 			found_overrides.push_back(texture_override);
 	}
 
@@ -113,8 +112,7 @@ std::vector<TextureOverride> TextureOverrideSource::getNodeTileOverrides()
 	std::vector<TextureOverride> found_overrides;
 
 	for (const TextureOverride& texture_override : m_overrides) {
-		if ((texture_override.target &
-					static_cast<u8>(OverrideTarget::ALL_FACES)) != 0)
+		if (texture_override.hasTarget(OverrideTarget::ALL_FACES))
 			found_overrides.push_back(texture_override);
 	}
 

--- a/src/texture_override.h
+++ b/src/texture_override.h
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2020 Hugues Ross <hugues.ross@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/texture_override.h
+++ b/src/texture_override.h
@@ -44,6 +44,13 @@ struct TextureOverride {
 	std::string id;
 	std::string texture;
 	u8 target;
+
+	// Helper function for checking if an OverrideTarget is found in
+	// a TextureOverride without casting
+	inline bool hasTarget(const OverrideTarget& overrideTarget) const
+	{
+		return (target & static_cast<u8>(overrideTarget)) != 0;
+	}
 };
 
 //! Class that provides texture override information from a texture pack

--- a/src/texture_override.h
+++ b/src/texture_override.h
@@ -47,9 +47,9 @@ struct TextureOverride {
 };
 
 //! Class that provides texture override information from a texture pack
-class CTextureOverrideSource {
+class TextureOverrideSource {
 public:
-	CTextureOverrideSource(std::string filepath);
+	TextureOverrideSource(std::string filepath);
 
 	//! Get all overrides that apply to item definitions
 	std::vector<TextureOverride> getItemTextureOverrides();

--- a/src/texture_override.h
+++ b/src/texture_override.h
@@ -24,7 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <vector>
 
 //! Bitmask enum specifying what a texture override should apply to
-enum class OverrideTarget : u8 {
+enum class OverrideTarget : u8
+{
 	INVALID = 0,
 	TOP = 1 << 0,
 	BOTTOM = 1 << 1,
@@ -40,21 +41,23 @@ enum class OverrideTarget : u8 {
 	ITEM_TARGETS = INVENTORY | WIELD,
 };
 
-struct TextureOverride {
+struct TextureOverride
+{
 	std::string id;
 	std::string texture;
 	u8 target;
 
 	// Helper function for checking if an OverrideTarget is found in
 	// a TextureOverride without casting
-	inline bool hasTarget(const OverrideTarget& overrideTarget) const
+	inline bool hasTarget(OverrideTarget overrideTarget) const
 	{
 		return (target & static_cast<u8>(overrideTarget)) != 0;
 	}
 };
 
 //! Class that provides texture override information from a texture pack
-class TextureOverrideSource {
+class TextureOverrideSource
+{
 public:
 	TextureOverrideSource(std::string filepath);
 

--- a/src/texture_override.h
+++ b/src/texture_override.h
@@ -1,0 +1,62 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes.h"
+#include <string>
+#include <vector>
+
+//! Bitmask enum specifying what a texture override should apply to
+enum class OverrideTarget : u8 {
+	INVALID = 0,
+	TOP = 1 << 0,
+	BOTTOM = 1 << 1,
+	LEFT = 1 << 2,
+	RIGHT = 1 << 3,
+	FRONT = 1 << 4,
+	BACK = 1 << 5,
+	INVENTORY = 1 << 6,
+	WIELD = 1 << 7,
+
+	SIDES = LEFT | RIGHT | FRONT | BACK,
+	ALL_FACES = TOP | BOTTOM | SIDES,
+	ITEM_TARGETS = INVENTORY | WIELD,
+};
+
+struct TextureOverride {
+	std::string id;
+	std::string texture;
+	u8 target;
+};
+
+//! Class that provides texture override information from a texture pack
+class CTextureOverrideSource {
+public:
+	CTextureOverrideSource(std::string filepath);
+
+	//! Get all overrides that apply to item definitions
+	std::vector<TextureOverride> getItemTextureOverrides();
+
+	//! Get all overrides that apply to node definitions
+	std::vector<TextureOverride> getNodeTileOverrides();
+
+private:
+	std::vector<TextureOverride> m_overrides;
+};

--- a/util/travis/clang-format-whitelist.txt
+++ b/util/travis/clang-format-whitelist.txt
@@ -427,6 +427,7 @@ src/subgame.cpp
 src/subgame.h
 src/terminal_chat_console.cpp
 src/terminal_chat_console.h
+src/texture_override.cpp
 src/threading/atomic.h
 src/threading/event.cpp
 src/threading/mutex_auto_lock.h


### PR DESCRIPTION
Resolves #4197. This PR refactors texture override parsing into a dedicated class, and adds the following new features

- Texture overrides can support multiple targets in one line (ie `top,bottom`)
- Texture override files can have comment lines (any line starting with `#` is a comment)
- Item images/wield images can be overridden. This means that overrides now support tools and craftitems as well as nodes!

## How to Test

Grab your favorite override-using texture pack, and make sure it works as expected!
To test the new features, I've attached a texture pack that adds the following overrides:
[test_override.zip](https://github.com/minetest/minetest/files/4438023/test_override.zip)


- `default:sword_steel`: sheathed in inventory, custom unsheathed texture when wielded
- `default:stone`: It's a rock, both in inventory and when wielded
- `default:dirt_with_grass`: (poor) drawing of the node in inventory, but still looks normal when wielded
- `default:tree`: Custom top/bottom face texture

Also, the test texture pack contains errors. These were added deliberately to ensure that they're caught and reported.
