### PR TITLE
Add all src folders to doxygen

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -25,13 +25,22 @@ STRIP_FROM_PATH        = @CMAKE_CURRENT_SOURCE_DIR@/src
 INPUT = @CMAKE_CURRENT_SOURCE_DIR@/doc/main_page.dox \
 	@CMAKE_CURRENT_SOURCE_DIR@/src/ \
 	@CMAKE_CURRENT_SOURCE_DIR@/src/client \
+	@CMAKE_CURRENT_SOURCE_DIR@/src/client/meshgen \
+	@CMAKE_CURRENT_SOURCE_DIR@/src/client/render \
+	@CMAKE_CURRENT_SOURCE_DIR@/src/content \
+	@CMAKE_CURRENT_SOURCE_DIR@/src/database \
+	@CMAKE_CURRENT_SOURCE_DIR@/src/gui \
+	@CMAKE_CURRENT_SOURCE_DIR@/src/irrlicht_changes \
+	@CMAKE_CURRENT_SOURCE_DIR@/src/mapgen \
 	@CMAKE_CURRENT_SOURCE_DIR@/src/network \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/util \
 	@CMAKE_CURRENT_SOURCE_DIR@/src/script \
 	@CMAKE_CURRENT_SOURCE_DIR@/src/script/common \
 	@CMAKE_CURRENT_SOURCE_DIR@/src/script/cpp_api \
 	@CMAKE_CURRENT_SOURCE_DIR@/src/script/lua_api \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/threading
+	@CMAKE_CURRENT_SOURCE_DIR@/src/server \
+	@CMAKE_CURRENT_SOURCE_DIR@/src/threading \
+	@CMAKE_CURRENT_SOURCE_DIR@/src/unittest \
+	@CMAKE_CURRENT_SOURCE_DIR@/src/util
 
 # Dot graphs
 HAVE_DOT               = @DOXYGEN_DOT_FOUND@

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -20,27 +20,10 @@ PREDEFINED             = "USE_SPATIAL=1" \
 		"USE_GETTEXT=1"
 
 # Input
-RECURSIVE              = NO
+RECURSIVE              = YES
 STRIP_FROM_PATH        = @CMAKE_CURRENT_SOURCE_DIR@/src
 INPUT = @CMAKE_CURRENT_SOURCE_DIR@/doc/main_page.dox \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/ \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/client \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/client/meshgen \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/client/render \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/content \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/database \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/gui \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/irrlicht_changes \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/mapgen \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/network \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/script \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/script/common \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/script/cpp_api \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/script/lua_api \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/server \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/threading \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/unittest \
-	@CMAKE_CURRENT_SOURCE_DIR@/src/util
+	@CMAKE_CURRENT_SOURCE_DIR@/src/
 
 # Dot graphs
 HAVE_DOT               = @DOXYGEN_DOT_FOUND@


### PR DESCRIPTION
- Goal of the PR:
Currently doxygen ignores files in `gui`, `server` and co.. This PR fixes that.
- How does the PR work?
Adds all the paths to `Doxyfile.in`.
- This is a bugfix.

## To do

This PR is a Ready for Review.

## How to test

- Use cmake.
- Do `make doc`.
- Open `<your minetest folder>/doc/html/files.html` and see that there's everything.