### PR TITLE
Allow to select en as language in settings menu

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1373,7 +1373,7 @@ name (Player name) string
 
 #    Set the language. Leave empty to use the system language.
 #    A restart is required after changing this.
-language (Language) enum   ,ar,ca,cs,da,de,dv,el,eo,es,et,eu,fil,fr,hu,id,it,ja,ja_KS,jbo,kk,kn,lo,lt,ms,my,nb,nl,nn,pl,pt,pt_BR,ro,ru,sl,sr_Cyrl,sv,sw,th,tr,uk,vi
+language (Language) enum   ,ar,ca,cs,da,de,dv,el,en,eo,es,et,eu,fil,fr,hu,id,it,ja,ja_KS,jbo,kk,kn,lo,lt,ms,my,nb,nl,nn,pl,pt,pt_BR,ro,ru,sl,sr_Cyrl,sv,sw,th,tr,uk,vi
 
 #    Level of logging to be written to debug.txt:
 #    -    <nothing> (no logging)


### PR DESCRIPTION
- Fixes #9599.
- https://github.com/minetest/minetest/commit/e80c0bdea5756089db1a7e11fa4510e19b3336a2 is the commit that removed en. ~~(But it added el, which seems to be another kind of english? (At least it makes everything english (and changes the font?).))~~

## To do

This PR is a Ready for Review.

## How to test

Select en as language in advanced settings and restart.