### PR TITLE
Work around LuaJIT issues on aarch64

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -661,7 +661,7 @@ endif()
 
 # Set some optimizations and tweaks
 
-include(CheckCXXCompilerFlag)
+include(CheckCSourceCompiles)
 
 if(MSVC)
 	# Visual Studio
@@ -695,13 +695,19 @@ else()
 	else()
 		set(RELEASE_WARNING_FLAGS "")
 	endif()
-
 	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 		set(WARNING_FLAGS "${WARNING_FLAGS} -Wsign-compare")
 	endif()
+
 	if(APPLE AND USE_LUAJIT)
 		# required per http://luajit.org/install.html
 		SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -pagezero_size 10000 -image_base 100000000")
+	elseif(UNIX AND USE_LUAJIT)
+		check_c_source_compiles("#ifndef __aarch64__\n#error\n#endif\nint main(){}" IS_AARCH64)
+		if(IS_AARCH64)
+			# Move text segment below LuaJIT's 47-bit limit (see issue #9367)
+			SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Ttext-segment=0x200000000")
+		endif()
 	endif()
 
 	if(MINGW)

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -54,6 +54,15 @@ extern "C" {
 #define CUSTOM_RIDX_CURRENT_MOD_NAME    (CUSTOM_RIDX_BASE + 2)
 #define CUSTOM_RIDX_BACKTRACE           (CUSTOM_RIDX_BASE + 3)
 
+// Determine if CUSTOM_RIDX_SCRIPTAPI will hold a light or full userdata
+#if defined(__aarch64__) && USE_LUAJIT
+/* LuaJIT has a 47-bit limit for lightuserdata on this platform and we cannot
+ * assume that the ScriptApi class was allocated at a fitting address. */
+#define INDIRECT_SCRIPTAPI_RIDX 1
+#else
+#define INDIRECT_SCRIPTAPI_RIDX 0
+#endif
+
 // Pushes the error handler onto the stack and returns its index
 #define PUSH_ERROR_HANDLER(L) \
 	(lua_rawgeti((L), LUA_REGISTRYINDEX, CUSTOM_RIDX_BACKTRACE), lua_gettop((L)))

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -90,7 +90,11 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 		luaL_openlibs(m_luastack);
 
 	// Make the ScriptApiBase* accessible to ModApiBase
+#if INDIRECT_SCRIPTAPI_RIDX
+	*(void **)(lua_newuserdata(m_luastack, sizeof(void *))) = this;
+#else
 	lua_pushlightuserdata(m_luastack, this);
+#endif
 	lua_rawseti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
 
 	// Add and save an error handler

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -499,7 +499,12 @@ bool ScriptApiSecurity::checkPath(lua_State *L, const char *path,
 
 	// Get server from registry
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
-	ScriptApiBase *script = (ScriptApiBase *) lua_touserdata(L, -1);
+	ScriptApiBase *script;
+#if INDIRECT_SCRIPTAPI_RIDX
+	script = (ScriptApiBase *) *(void**)(lua_touserdata(L, -1));
+#else
+	script = (ScriptApiBase *) lua_touserdata(L, -1);
+#endif
 	lua_pop(L, 1);
 	const IGameDef *gamedef = script->getGameDef();
 	if (!gamedef)

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -30,7 +30,12 @@ ScriptApiBase *ModApiBase::getScriptApiBase(lua_State *L)
 {
 	// Get server from registry
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
-	ScriptApiBase *sapi_ptr = (ScriptApiBase*) lua_touserdata(L, -1);
+	ScriptApiBase *sapi_ptr;
+#if INDIRECT_SCRIPTAPI_RIDX
+	sapi_ptr = (ScriptApiBase*) *(void**)(lua_touserdata(L, -1));
+#else
+	sapi_ptr = (ScriptApiBase*) lua_touserdata(L, -1);
+#endif
 	lua_pop(L, 1);
 	return sapi_ptr;
 }


### PR DESCRIPTION
fixes #9367

two changes:
* Move the text segment below the 47-bit limit, needed for `script_exception_wrapper` which must be lightuserdata
* Replace `CUSTOM_RIDX_SCRIPTAPI` with full userdata (only on affected configurations)

Tested to work inside QEMU and on real hardware (both Arch Linux ARM).

## To do

This PR is a Ready for Review.
