### PR TITLE
Install the `locale` directory in a standard location without subfolder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ elseif(UNIX) # Linux, BSD etc
 		set(XDG_APPS_DIR "${CMAKE_INSTALL_PREFIX}/share/applications")
 		set(APPDATADIR "${CMAKE_INSTALL_PREFIX}/share/metainfo")
 		set(ICONDIR "${CMAKE_INSTALL_PREFIX}/share/icons")
-		set(LOCALEDIR "${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/locale")
+		set(LOCALEDIR "${CMAKE_INSTALL_PREFIX}/share/locale")
 	endif()
 endif()
 
@@ -325,4 +325,3 @@ if(DOXYGEN_FOUND)
 		COMMENT "Generating API documentation with Doxygen" VERBATIM
 	)
 endif()
-


### PR DESCRIPTION
Other established FOSS projects don't seem to be doing this (try `ls /usr/share/locale`).

This PR was inspired by the patch currently used in the Flatpak distribution: https://github.com/flathub/net.minetest.Minetest/blob/5844f665b2686278f9e288e1d8112f0668458021/minetest-i18n.patch

## To do

This PR is Ready for Review.

## How to test

Build Minetest and install it using `make install`.