### PR TITLE
Update API site build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -325,9 +325,8 @@ package:docker:
 
 pages:
   stage: deploy
-  image: python:3.7
+  image: python:3.8
   before_script:
-    - pip install pip==18.1
     - pip install git+https://github.com/Python-Markdown/markdown.git
     - pip install git+https://github.com/mkdocs/mkdocs.git
     - pip install pygments

--- a/doc/mkdocs/lua_highlight.patch
+++ b/doc/mkdocs/lua_highlight.patch
@@ -1,4 +1,4 @@
-@@ -77,7 +77,7 @@
+@@ -75,7 +75,7 @@
                   css_class="codehilite", lang=None, style='default',
                   noclasses=False, tab_length=4, hl_lines=None, use_pygments=True):
          self.src = src
@@ -7,13 +7,3 @@
          self.linenums = linenums
          self.guess_lang = guess_lang
          self.css_class = css_class
-@@ -119,7 +119,8 @@
-                                               cssclass=self.css_class,
-                                               style=self.style,
-                                               noclasses=self.noclasses,
--                                              hl_lines=self.hl_lines)
-+                                              hl_lines=self.hl_lines,
-+                                              wrapcode=True)
-             return highlight(self.src, lexer, formatter)
-         else:
-             # just escape and build markup usable by JS highlighting libs


### PR DESCRIPTION
- markdown fixed the bug that caused installation with newer pip versions to fail
- removed part of the markdown patch that is now in upstream markdown