### PR TITLE
Make Mapgen (mostly) work multithreaded again

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2110,9 +2110,6 @@ emergequeue_limit_diskonly (Limit of emerge queues on disk) int 64
 emergequeue_limit_generate (Limit of emerge queues to generate) int 64
 
 #    Number of emerge threads to use.
-#    WARNING: Currently there are multiple bugs that may cause crashes when
-#    'num_emerge_threads' is larger than 1. Until this warning is removed it is
-#    strongly recommended this value is set to the default '1'.
 #    Value 0:
 #    -    Automatic selection. The number of emerge threads will be
 #    -    'number of processors - 2', with a lower limit of 1.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -3261,9 +3261,6 @@
 # emergequeue_limit_generate = 64
 
 #    Number of emerge threads to use.
-#    WARNING: Currently there are multiple bugs that may cause crashes when
-#    'num_emerge_threads' is larger than 1. Until this warning is removed it is
-#    strongly recommended this value is set to the default '1'.
 #    Value 0:
 #    -    Automatic selection. The number of emerge threads will be
 #    -    'number of processors - 2', with a lower limit of 1.

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -110,6 +110,28 @@ private:
 	VoxelArea *m_ignorevariable;
 };
 
+EmergeParams::~EmergeParams()
+{
+	infostream << "EmergeParams: destroying " << this << std::endl;
+	// Delete everything that was cloned on creation of EmergeParams
+	delete biomemgr;
+	delete oremgr;
+	delete decomgr;
+	delete schemmgr;
+}
+
+EmergeParams::EmergeParams(EmergeManager *parent, const BiomeManager *biomemgr,
+	const OreManager *oremgr, const DecorationManager *decomgr,
+	const SchematicManager *schemmgr) :
+	ndef(parent->ndef),
+	enable_mapgen_debug_info(parent->enable_mapgen_debug_info),
+	gen_notify_on(parent->gen_notify_on),
+	gen_notify_on_deco_ids(&parent->gen_notify_on_deco_ids),
+	biomemgr(biomemgr->clone()), oremgr(oremgr->clone()),
+	decomgr(decomgr->clone()), schemmgr(schemmgr->clone())
+{
+}
+
 ////
 //// EmergeManager
 ////
@@ -183,14 +205,48 @@ EmergeManager::~EmergeManager()
 }
 
 
+BiomeManager *EmergeManager::getWritableBiomeManager()
+{
+	FATAL_ERROR_IF(!m_mapgens.empty(),
+		"Writable managers can only be returned before mapgen init");
+	return biomemgr;
+}
+
+OreManager *EmergeManager::getWritableOreManager()
+{
+	FATAL_ERROR_IF(!m_mapgens.empty(),
+		"Writable managers can only be returned before mapgen init");
+	return oremgr;
+}
+
+DecorationManager *EmergeManager::getWritableDecorationManager()
+{
+	FATAL_ERROR_IF(!m_mapgens.empty(),
+		"Writable managers can only be returned before mapgen init");
+	return decomgr;
+}
+
+SchematicManager *EmergeManager::getWritableSchematicManager()
+{
+	FATAL_ERROR_IF(!m_mapgens.empty(),
+		"Writable managers can only be returned before mapgen init");
+	return schemmgr;
+}
+
+
 void EmergeManager::initMapgens(MapgenParams *params)
 {
 	FATAL_ERROR_IF(!m_mapgens.empty(), "Mapgen already initialised.");
 
 	mgparams = params;
 
-	for (u32 i = 0; i != m_threads.size(); i++)
-		m_mapgens.push_back(Mapgen::createMapgen(params->mgtype, params, this));
+	for (u32 i = 0; i != m_threads.size(); i++) {
+		EmergeParams *p = new EmergeParams(
+			this, biomemgr, oremgr, decomgr, schemmgr);
+		infostream << "EmergeManager: Created params " << p
+			<< " for thread " << i << std::endl;
+		m_mapgens.push_back(Mapgen::createMapgen(params->mgtype, params, p));
+	}
 }
 
 

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -44,6 +44,7 @@ class OreManager;
 class DecorationManager;
 class SchematicManager;
 class Server;
+class ModApiMapgen;
 
 // Structure containing inputs/outputs for chunk generation
 struct BlockMakeData {
@@ -111,6 +112,11 @@ private:
 };
 
 class EmergeManager {
+	/* The mod API needs unchecked access to allow:
+	 * - using decomgr or oremgr to place decos/ores
+	 * - using schemmgr to load and place schematics
+	 */
+	friend class ModApiMapgen;
 public:
 	const NodeDefManager *ndef;
 	bool enable_mapgen_debug_info;

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -86,6 +86,30 @@ struct BlockEmergeData {
 	EmergeCallbackList callbacks;
 };
 
+class EmergeParams {
+	friend class EmergeManager;
+public:
+	EmergeParams() = delete;
+	~EmergeParams();
+	DISABLE_CLASS_COPY(EmergeParams);
+
+	const NodeDefManager *ndef; // shared
+	bool enable_mapgen_debug_info;
+
+	u32 gen_notify_on;
+	const std::set<u32> *gen_notify_on_deco_ids; // shared
+
+	BiomeManager *biomemgr;
+	OreManager *oremgr;
+	DecorationManager *decomgr;
+	SchematicManager *schemmgr;
+
+private:
+	EmergeParams(EmergeManager *parent, const BiomeManager *biomemgr,
+		const OreManager *oremgr, const DecorationManager *decomgr,
+		const SchematicManager *schemmgr);
+};
+
 class EmergeManager {
 public:
 	const NodeDefManager *ndef;
@@ -106,16 +130,21 @@ public:
 	// Environment is not created until after script initialization.
 	MapSettingsManager *map_settings_mgr;
 
-	// Managers of various map generation-related components
-	BiomeManager *biomemgr;
-	OreManager *oremgr;
-	DecorationManager *decomgr;
-	SchematicManager *schemmgr;
-
 	// Methods
 	EmergeManager(Server *server);
 	~EmergeManager();
 	DISABLE_CLASS_COPY(EmergeManager);
+
+	// no usage restrictions
+	const BiomeManager *getBiomeManager() const { return biomemgr; }
+	const OreManager *getOreManager() const { return oremgr; }
+	const DecorationManager *getDecorationManager() const { return decomgr; }
+	const SchematicManager *getSchematicManager() const { return schemmgr; }
+	// only usable before mapgen init
+	BiomeManager *getWritableBiomeManager();
+	OreManager *getWritableOreManager();
+	DecorationManager *getWritableDecorationManager();
+	SchematicManager *getWritableSchematicManager();
 
 	void initMapgens(MapgenParams *mgparams);
 
@@ -159,6 +188,13 @@ private:
 	u16 m_qlimit_total;
 	u16 m_qlimit_diskonly;
 	u16 m_qlimit_generate;
+
+	// Managers of various map generation-related components
+	// Note that each Mapgen gets a copy(!) of these to work with
+	BiomeManager *biomemgr;
+	OreManager *oremgr;
+	DecorationManager *decomgr;
+	SchematicManager *schemmgr;
 
 	// Requires m_queue_mutex held
 	EmergeThread *getOptimalThread();

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -107,8 +107,8 @@ STATIC_ASSERT(
 //// Mapgen
 ////
 
-Mapgen::Mapgen(int mapgenid, MapgenParams *params, EmergeManager *emerge) :
-	gennotify(emerge->gen_notify_on, &emerge->gen_notify_on_deco_ids)
+Mapgen::Mapgen(int mapgenid, MapgenParams *params, EmergeParams *emerge) :
+	gennotify(emerge->gen_notify_on, emerge->gen_notify_on_deco_ids)
 {
 	id           = mapgenid;
 	water_level  = params->water_level;
@@ -157,7 +157,7 @@ const char *Mapgen::getMapgenName(MapgenType mgtype)
 
 
 Mapgen *Mapgen::createMapgen(MapgenType mgtype, MapgenParams *params,
-	EmergeManager *emerge)
+	EmergeParams *emerge)
 {
 	switch (mgtype) {
 	case MAPGEN_CARPATHIAN:
@@ -586,7 +586,7 @@ void Mapgen::spreadLight(const v3s16 &nmin, const v3s16 &nmax)
 //// MapgenBasic
 ////
 
-MapgenBasic::MapgenBasic(int mapgenid, MapgenParams *params, EmergeManager *emerge)
+MapgenBasic::MapgenBasic(int mapgenid, MapgenParams *params, EmergeParams *emerge)
 	: Mapgen(mapgenid, params, emerge)
 {
 	this->m_emerge = emerge;
@@ -636,6 +636,8 @@ MapgenBasic::~MapgenBasic()
 {
 	delete biomegen;
 	delete []heightmap;
+
+	delete m_emerge; // destroying EmergeParams is our responsibility
 }
 
 
@@ -968,7 +970,7 @@ void MapgenBasic::generateDungeons(s16 max_stone_y)
 ////
 
 GenerateNotifier::GenerateNotifier(u32 notify_on,
-	std::set<u32> *notify_on_deco_ids)
+	const std::set<u32> *notify_on_deco_ids)
 {
 	m_notify_on = notify_on;
 	m_notify_on_deco_ids = notify_on_deco_ids;
@@ -981,7 +983,8 @@ void GenerateNotifier::setNotifyOn(u32 notify_on)
 }
 
 
-void GenerateNotifier::setNotifyOnDecoIds(std::set<u32> *notify_on_deco_ids)
+void GenerateNotifier::setNotifyOnDecoIds(
+	const std::set<u32> *notify_on_deco_ids)
 {
 	m_notify_on_deco_ids = notify_on_deco_ids;
 }
@@ -993,7 +996,7 @@ bool GenerateNotifier::addEvent(GenNotifyType type, v3s16 pos, u32 id)
 		return false;
 
 	if (type == GENNOTIFY_DECORATION &&
-		m_notify_on_deco_ids->find(id) == m_notify_on_deco_ids->end())
+		m_notify_on_deco_ids->find(id) == m_notify_on_deco_ids->cend())
 		return false;
 
 	GenNotifyEvent gne;

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -51,6 +51,7 @@ class Biome;
 class BiomeGen;
 struct BiomeParams;
 class BiomeManager;
+class EmergeParams;
 class EmergeManager;
 class MapBlock;
 class VoxelManipulator;
@@ -87,10 +88,10 @@ struct GenNotifyEvent {
 class GenerateNotifier {
 public:
 	GenerateNotifier() = default;
-	GenerateNotifier(u32 notify_on, std::set<u32> *notify_on_deco_ids);
+	GenerateNotifier(u32 notify_on, const std::set<u32> *notify_on_deco_ids);
 
 	void setNotifyOn(u32 notify_on);
-	void setNotifyOnDecoIds(std::set<u32> *notify_on_deco_ids);
+	void setNotifyOnDecoIds(const std::set<u32> *notify_on_deco_ids);
 
 	bool addEvent(GenNotifyType type, v3s16 pos, u32 id=0);
 	void getEvents(std::map<std::string, std::vector<v3s16> > &event_map);
@@ -98,7 +99,7 @@ public:
 
 private:
 	u32 m_notify_on = 0;
-	std::set<u32> *m_notify_on_deco_ids;
+	const std::set<u32> *m_notify_on_deco_ids;
 	std::list<GenNotifyEvent> m_notify_events;
 };
 
@@ -176,7 +177,7 @@ public:
 	GenerateNotifier gennotify;
 
 	Mapgen() = default;
-	Mapgen(int mapgenid, MapgenParams *params, EmergeManager *emerge);
+	Mapgen(int mapgenid, MapgenParams *params, EmergeParams *emerge);
 	virtual ~Mapgen() = default;
 	DISABLE_CLASS_COPY(Mapgen);
 
@@ -215,7 +216,7 @@ public:
 	static MapgenType getMapgenType(const std::string &mgname);
 	static const char *getMapgenName(MapgenType mgtype);
 	static Mapgen *createMapgen(MapgenType mgtype, MapgenParams *params,
-		EmergeManager *emerge);
+		EmergeParams *emerge);
 	static MapgenParams *createMapgenParams(MapgenType mgtype);
 	static void getMapgenNames(std::vector<const char *> *mgnames, bool include_hidden);
 	static void setDefaultSettings(Settings *settings);
@@ -243,7 +244,7 @@ private:
 */
 class MapgenBasic : public Mapgen {
 public:
-	MapgenBasic(int mapgenid, MapgenParams *params, EmergeManager *emerge);
+	MapgenBasic(int mapgenid, MapgenParams *params, EmergeParams *emerge);
 	virtual ~MapgenBasic();
 
 	virtual void generateBiomes();
@@ -254,7 +255,7 @@ public:
 	virtual void generateDungeons(s16 max_stone_y);
 
 protected:
-	EmergeManager *m_emerge;
+	EmergeParams *m_emerge;
 	BiomeManager *m_bmgr;
 
 	Noise *noise_filler_depth;

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -50,7 +50,7 @@ FlagDesc flagdesc_mapgen_carpathian[] = {
 ///////////////////////////////////////////////////////////////////////////////
 
 
-MapgenCarpathian::MapgenCarpathian(MapgenCarpathianParams *params, EmergeManager *emerge)
+MapgenCarpathian::MapgenCarpathian(MapgenCarpathianParams *params, EmergeParams *emerge)
 	: MapgenBasic(MAPGEN_CARPATHIAN, params, emerge)
 {
 	base_level       = params->base_level;

--- a/src/mapgen/mapgen_carpathian.h
+++ b/src/mapgen/mapgen_carpathian.h
@@ -79,7 +79,7 @@ struct MapgenCarpathianParams : public MapgenParams
 class MapgenCarpathian : public MapgenBasic
 {
 public:
-	MapgenCarpathian(MapgenCarpathianParams *params, EmergeManager *emerge);
+	MapgenCarpathian(MapgenCarpathianParams *params, EmergeParams *emerge);
 	~MapgenCarpathian();
 
 	virtual MapgenType getType() const { return MAPGEN_CARPATHIAN; }

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -48,7 +48,7 @@ FlagDesc flagdesc_mapgen_flat[] = {
 ///////////////////////////////////////////////////////////////////////////////////////
 
 
-MapgenFlat::MapgenFlat(MapgenFlatParams *params, EmergeManager *emerge)
+MapgenFlat::MapgenFlat(MapgenFlatParams *params, EmergeParams *emerge)
 	: MapgenBasic(MAPGEN_FLAT, params, emerge)
 {
 	spflags            = params->spflags;

--- a/src/mapgen/mapgen_flat.h
+++ b/src/mapgen/mapgen_flat.h
@@ -64,7 +64,7 @@ struct MapgenFlatParams : public MapgenParams
 class MapgenFlat : public MapgenBasic
 {
 public:
-	MapgenFlat(MapgenFlatParams *params, EmergeManager *emerge);
+	MapgenFlat(MapgenFlatParams *params, EmergeParams *emerge);
 	~MapgenFlat();
 
 	virtual MapgenType getType() const { return MAPGEN_FLAT; }

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -48,7 +48,7 @@ FlagDesc flagdesc_mapgen_fractal[] = {
 ///////////////////////////////////////////////////////////////////////////////////////
 
 
-MapgenFractal::MapgenFractal(MapgenFractalParams *params, EmergeManager *emerge)
+MapgenFractal::MapgenFractal(MapgenFractalParams *params, EmergeParams *emerge)
 	: MapgenBasic(MAPGEN_FRACTAL, params, emerge)
 {
 	spflags            = params->spflags;

--- a/src/mapgen/mapgen_fractal.h
+++ b/src/mapgen/mapgen_fractal.h
@@ -72,7 +72,7 @@ struct MapgenFractalParams : public MapgenParams
 class MapgenFractal : public MapgenBasic
 {
 public:
-	MapgenFractal(MapgenFractalParams *params, EmergeManager *emerge);
+	MapgenFractal(MapgenFractalParams *params, EmergeParams *emerge);
 	~MapgenFractal();
 
 	virtual MapgenType getType() const { return MAPGEN_FRACTAL; }

--- a/src/mapgen/mapgen_singlenode.cpp
+++ b/src/mapgen/mapgen_singlenode.cpp
@@ -29,7 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "emerge.h"
 
 
-MapgenSinglenode::MapgenSinglenode(MapgenParams *params, EmergeManager *emerge)
+MapgenSinglenode::MapgenSinglenode(MapgenParams *params, EmergeParams *emerge)
 	: Mapgen(MAPGEN_SINGLENODE, params, emerge)
 {
 	const NodeDefManager *ndef = emerge->ndef;

--- a/src/mapgen/mapgen_singlenode.h
+++ b/src/mapgen/mapgen_singlenode.h
@@ -38,7 +38,7 @@ public:
 	content_t c_node;
 	u8 set_light;
 
-	MapgenSinglenode(MapgenParams *params, EmergeManager *emerge);
+	MapgenSinglenode(MapgenParams *params, EmergeParams *emerge);
 	~MapgenSinglenode() = default;
 
 	virtual MapgenType getType() const { return MAPGEN_SINGLENODE; }

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -45,7 +45,7 @@ FlagDesc flagdesc_mapgen_v5[] = {
 };
 
 
-MapgenV5::MapgenV5(MapgenV5Params *params, EmergeManager *emerge)
+MapgenV5::MapgenV5(MapgenV5Params *params, EmergeParams *emerge)
 	: MapgenBasic(MAPGEN_V5, params, emerge)
 {
 	spflags            = params->spflags;

--- a/src/mapgen/mapgen_v5.h
+++ b/src/mapgen/mapgen_v5.h
@@ -64,7 +64,7 @@ struct MapgenV5Params : public MapgenParams
 class MapgenV5 : public MapgenBasic
 {
 public:
-	MapgenV5(MapgenV5Params *params, EmergeManager *emerge);
+	MapgenV5(MapgenV5Params *params, EmergeParams *emerge);
 	~MapgenV5();
 
 	virtual MapgenType getType() const { return MAPGEN_V5; }

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -56,7 +56,7 @@ FlagDesc flagdesc_mapgen_v6[] = {
 /////////////////////////////////////////////////////////////////////////////
 
 
-MapgenV6::MapgenV6(MapgenV6Params *params, EmergeManager *emerge)
+MapgenV6::MapgenV6(MapgenV6Params *params, EmergeParams *emerge)
 	: Mapgen(MAPGEN_V6, params, emerge)
 {
 	m_emerge = emerge;
@@ -147,6 +147,8 @@ MapgenV6::~MapgenV6()
 	delete noise_humidity;
 
 	delete[] heightmap;
+
+	delete m_emerge; // our responsibility
 }
 
 

--- a/src/mapgen/mapgen_v6.h
+++ b/src/mapgen/mapgen_v6.h
@@ -83,7 +83,7 @@ struct MapgenV6Params : public MapgenParams {
 
 class MapgenV6 : public Mapgen {
 public:
-	EmergeManager *m_emerge;
+	EmergeParams *m_emerge;
 
 	int ystride;
 	u32 spflags;
@@ -133,7 +133,7 @@ public:
 	content_t c_stair_cobble;
 	content_t c_stair_desert_stone;
 
-	MapgenV6(MapgenV6Params *params, EmergeManager *emerge);
+	MapgenV6(MapgenV6Params *params, EmergeParams *emerge);
 	~MapgenV6();
 
 	virtual MapgenType getType() const { return MAPGEN_V6; }

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -52,7 +52,7 @@ FlagDesc flagdesc_mapgen_v7[] = {
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MapgenV7::MapgenV7(MapgenV7Params *params, EmergeManager *emerge)
+MapgenV7::MapgenV7(MapgenV7Params *params, EmergeParams *emerge)
 	: MapgenBasic(MAPGEN_V7, params, emerge)
 {
 	spflags            = params->spflags;

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -75,7 +75,7 @@ struct MapgenV7Params : public MapgenParams {
 
 class MapgenV7 : public MapgenBasic {
 public:
-	MapgenV7(MapgenV7Params *params, EmergeManager *emerge);
+	MapgenV7(MapgenV7Params *params, EmergeParams *emerge);
 	~MapgenV7();
 
 	virtual MapgenType getType() const { return MAPGEN_V7; }

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -54,7 +54,7 @@ FlagDesc flagdesc_mapgen_valleys[] = {
 };
 
 
-MapgenValleys::MapgenValleys(MapgenValleysParams *params, EmergeManager *emerge)
+MapgenValleys::MapgenValleys(MapgenValleysParams *params, EmergeParams *emerge)
 	: MapgenBasic(MAPGEN_VALLEYS, params, emerge)
 {
 	// NOTE: MapgenValleys has a hard dependency on BiomeGenOriginal

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -84,7 +84,7 @@ class MapgenValleys : public MapgenBasic {
 public:
 
 	MapgenValleys(MapgenValleysParams *params,
-		EmergeManager *emerge);
+		EmergeParams *emerge);
 	~MapgenValleys();
 
 	virtual MapgenType getType() const { return MAPGEN_VALLEYS; }

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -92,6 +92,16 @@ void BiomeManager::clear()
 }
 
 
+BiomeManager *BiomeManager::clone() const
+{
+	auto mgr = new BiomeManager();
+	assert(mgr);
+	ObjDefManager::cloneTo(mgr);
+	mgr->m_server = m_server;
+	return mgr;
+}
+
+
 // For BiomeGen type 'BiomeGenOriginal'
 float BiomeManager::getHeatAtPosOriginal(v3s16 pos, NoiseParams &np_heat,
 	NoiseParams &np_heat_blend, u64 seed)
@@ -320,6 +330,41 @@ Biome *BiomeGenOriginal::calcBiomeFromNoise(float heat, float humidity, v3s16 po
 
 
 ////////////////////////////////////////////////////////////////////////////////
+
+ObjDef *Biome::clone() const
+{
+	auto obj = new Biome();
+	ObjDef::cloneTo(obj);
+	NodeResolver::cloneTo(obj);
+
+	obj->flags = flags;
+
+	obj->c_top = c_top;
+	obj->c_filler = c_filler;
+	obj->c_stone = c_stone;
+	obj->c_water_top = c_water_top;
+	obj->c_water = c_water;
+	obj->c_river_water = c_river_water;
+	obj->c_riverbed = c_riverbed;
+	obj->c_dust = c_dust;
+	obj->c_cave_liquid = c_cave_liquid;
+	obj->c_dungeon = c_dungeon;
+	obj->c_dungeon_alt = c_dungeon_alt;
+	obj->c_dungeon_stair = c_dungeon_stair;
+
+	obj->depth_top = depth_top;
+	obj->depth_filler = depth_filler;
+	obj->depth_water_top = depth_water_top;
+	obj->depth_riverbed = depth_riverbed;
+
+	obj->min_pos = min_pos;
+	obj->max_pos = max_pos;
+	obj->heat_point = heat_point;
+	obj->humidity_point = humidity_point;
+	obj->vertical_blend = vertical_blend;
+
+	return obj;
+}
 
 void Biome::resolveNodeNames()
 {

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -78,7 +78,7 @@ void BiomeManager::clear()
 	EmergeManager *emerge = m_server->getEmergeManager();
 
 	// Remove all dangling references in Decorations
-	DecorationManager *decomgr = emerge->decomgr;
+	DecorationManager *decomgr = emerge->getWritableDecorationManager();
 	for (size_t i = 0; i != decomgr->getNumObjects(); i++) {
 		Decoration *deco = (Decoration *)decomgr->getRaw(i);
 		deco->biomes.clear();
@@ -104,7 +104,7 @@ BiomeManager *BiomeManager::clone() const
 
 // For BiomeGen type 'BiomeGenOriginal'
 float BiomeManager::getHeatAtPosOriginal(v3s16 pos, NoiseParams &np_heat,
-	NoiseParams &np_heat_blend, u64 seed)
+	NoiseParams &np_heat_blend, u64 seed) const
 {
 	return
 		NoisePerlin2D(&np_heat,       pos.X, pos.Z, seed) +
@@ -114,7 +114,7 @@ float BiomeManager::getHeatAtPosOriginal(v3s16 pos, NoiseParams &np_heat,
 
 // For BiomeGen type 'BiomeGenOriginal'
 float BiomeManager::getHumidityAtPosOriginal(v3s16 pos, NoiseParams &np_humidity,
-	NoiseParams &np_humidity_blend, u64 seed)
+	NoiseParams &np_humidity_blend, u64 seed) const
 {
 	return
 		NoisePerlin2D(&np_humidity,       pos.X, pos.Z, seed) +
@@ -123,7 +123,7 @@ float BiomeManager::getHumidityAtPosOriginal(v3s16 pos, NoiseParams &np_humidity
 
 
 // For BiomeGen type 'BiomeGenOriginal'
-Biome *BiomeManager::getBiomeFromNoiseOriginal(float heat, float humidity, v3s16 pos)
+Biome *BiomeManager::getBiomeFromNoiseOriginal(float heat, float humidity, v3s16 pos) const
 {
 	Biome *biome_closest = nullptr;
 	Biome *biome_closest_blend = nullptr;

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -123,7 +123,8 @@ float BiomeManager::getHumidityAtPosOriginal(v3s16 pos, NoiseParams &np_humidity
 
 
 // For BiomeGen type 'BiomeGenOriginal'
-Biome *BiomeManager::getBiomeFromNoiseOriginal(float heat, float humidity, v3s16 pos) const
+const Biome *BiomeManager::getBiomeFromNoiseOriginal(float heat,
+	float humidity, v3s16 pos) const
 {
 	Biome *biome_closest = nullptr;
 	Biome *biome_closest_blend = nullptr;

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -154,9 +154,11 @@ const Biome *BiomeManager::getBiomeFromNoiseOriginal(float heat,
 		}
 	}
 
-	mysrand(pos.Y + (heat + humidity) * 0.9f);
+	const u64 seed = pos.Y + (heat + humidity) * 0.9f;
+	PcgRandom rng(seed);
+
 	if (biome_closest_blend && dist_min_blend <= dist_min &&
-			myrand_range(0, biome_closest_blend->vertical_blend) >=
+			rng.range(0, biome_closest_blend->vertical_blend) >=
 			pos.Y - biome_closest_blend->max_pos.Y)
 		return biome_closest_blend;
 
@@ -319,10 +321,11 @@ Biome *BiomeGenOriginal::calcBiomeFromNoise(float heat, float humidity, v3s16 po
 	// Carefully tune pseudorandom seed variation to avoid single node dither
 	// and create larger scale blending patterns similar to horizontal biome
 	// blend.
-	mysrand(pos.Y + (heat + humidity) * 0.9f);
+	const u64 seed = pos.Y + (heat + humidity) * 0.9f;
+	PcgRandom rng(seed);
 
 	if (biome_closest_blend && dist_min_blend <= dist_min &&
-			myrand_range(0, biome_closest_blend->vertical_blend) >=
+			rng.range(0, biome_closest_blend->vertical_blend) >=
 			pos.Y - biome_closest_blend->max_pos.Y)
 		return biome_closest_blend;
 

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -42,6 +42,8 @@ enum BiomeType {
 
 class Biome : public ObjDef, public NodeResolver {
 public:
+	ObjDef *clone() const;
+
 	u32 flags;
 
 	content_t c_top;
@@ -191,6 +193,8 @@ public:
 	BiomeManager(Server *server);
 	virtual ~BiomeManager() = default;
 
+	BiomeManager *clone() const;
+
 	const char *getObjectTitle() const
 	{
 		return "biome";
@@ -232,6 +236,8 @@ public:
 	Biome *getBiomeFromNoiseOriginal(float heat, float humidity, v3s16 pos);
 
 private:
+	BiomeManager() {};
+
 	Server *m_server;
 
 };

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -90,6 +90,7 @@ struct BiomeParams {
 	s32 seed;
 };
 
+// WARNING: this class is not thread-safe
 class BiomeGen {
 public:
 	virtual ~BiomeGen() = default;
@@ -233,7 +234,8 @@ public:
 		NoiseParams &np_heat_blend, u64 seed) const;
 	float getHumidityAtPosOriginal(v3s16 pos, NoiseParams &np_humidity,
 		NoiseParams &np_humidity_blend, u64 seed) const;
-	Biome *getBiomeFromNoiseOriginal(float heat, float humidity, v3s16 pos) const;
+	const Biome *getBiomeFromNoiseOriginal(float heat, float humidity,
+		v3s16 pos) const;
 
 private:
 	BiomeManager() {};

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -230,10 +230,10 @@ public:
 
 	// For BiomeGen type 'BiomeGenOriginal'
 	float getHeatAtPosOriginal(v3s16 pos, NoiseParams &np_heat,
-		NoiseParams &np_heat_blend, u64 seed);
+		NoiseParams &np_heat_blend, u64 seed) const;
 	float getHumidityAtPosOriginal(v3s16 pos, NoiseParams &np_humidity,
-		NoiseParams &np_humidity_blend, u64 seed);
-	Biome *getBiomeFromNoiseOriginal(float heat, float humidity, v3s16 pos);
+		NoiseParams &np_humidity_blend, u64 seed) const;
+	Biome *getBiomeFromNoiseOriginal(float heat, float humidity, v3s16 pos) const;
 
 private:
 	BiomeManager() {};

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -391,6 +391,13 @@ size_t DecoSimple::generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling)
 ///////////////////////////////////////////////////////////////////////////////
 
 
+DecoSchematic::~DecoSchematic()
+{
+	if (was_cloned)
+		delete schematic;
+}
+
+
 ObjDef *DecoSchematic::clone() const
 {
 	auto def = new DecoSchematic();
@@ -398,9 +405,12 @@ ObjDef *DecoSchematic::clone() const
 	NodeResolver::cloneTo(def);
 
 	def->rotation = rotation;
-	/* FIXME: This is not ideal, we only have a pointer to the schematic despite
-	 * not owning it. Optimally this would be a handle. */
-	def->schematic = schematic; // not cloned
+	/* FIXME: We do not own this schematic, yet we only have a pointer to it
+	 * and not a handle. We are left with no option but to clone it ourselves.
+	 * This is a waste of memory and should be replaced with an alternative
+	 * approach sometime. */
+	def->schematic = dynamic_cast<Schematic*>(schematic->clone());
+	def->was_cloned = true;
 
 	return def;
 }

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -67,6 +67,13 @@ size_t DecorationManager::placeAllDecos(Mapgen *mg, u32 blockseed,
 	return nplaced;
 }
 
+DecorationManager *DecorationManager::clone() const
+{
+	auto mgr = new DecorationManager();
+	ObjDefManager::cloneTo(mgr);
+	return mgr;
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -269,7 +276,40 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 }
 
 
+void Decoration::cloneTo(Decoration *def) const
+{
+	ObjDef::cloneTo(def);
+	def->flags = flags;
+	def->mapseed = mapseed;
+	def->c_place_on = c_place_on;
+	def->sidelen = sidelen;
+	def->y_min = y_min;
+	def->y_max = y_max;
+	def->fill_ratio = fill_ratio;
+	def->np = np;
+	def->c_spawnby = c_spawnby;
+	def->nspawnby = nspawnby;
+	def->place_offset_y = place_offset_y;
+	def->biomes = biomes;
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////
+
+
+ObjDef *DecoSimple::clone() const
+{
+	auto def = new DecoSimple();
+	Decoration::cloneTo(def);
+
+	def->c_decos = c_decos;
+	def->deco_height = deco_height;
+	def->deco_height_max = deco_height_max;
+	def->deco_param2 = deco_param2;
+	def->deco_param2_max = deco_param2_max;
+
+	return def;
+}
 
 
 void DecoSimple::resolveNodeNames()
@@ -349,6 +389,21 @@ size_t DecoSimple::generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling)
 
 
 ///////////////////////////////////////////////////////////////////////////////
+
+
+ObjDef *DecoSchematic::clone() const
+{
+	auto def = new DecoSchematic();
+	Decoration::cloneTo(def);
+	NodeResolver::cloneTo(def);
+
+	def->rotation = rotation;
+	/* FIXME: This is not ideal, we only have a pointer to the schematic despite
+	 * not owning it. Optimally this would be a handle. */
+	def->schematic = schematic; // not cloned
+
+	return def;
+}
 
 
 size_t DecoSchematic::generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling)

--- a/src/mapgen/mg_decoration.h
+++ b/src/mapgen/mg_decoration.h
@@ -73,11 +73,16 @@ public:
 	s16 place_offset_y = 0;
 
 	std::unordered_set<u8> biomes;
+
+protected:
+	void cloneTo(Decoration *def) const;
 };
 
 
 class DecoSimple : public Decoration {
 public:
+	ObjDef *clone() const;
+
 	virtual void resolveNodeNames();
 	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling);
 
@@ -91,6 +96,8 @@ public:
 
 class DecoSchematic : public Decoration {
 public:
+	ObjDef *clone() const;
+
 	DecoSchematic() = default;
 
 	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling);
@@ -113,6 +120,8 @@ public:
 	DecorationManager(IGameDef *gamedef);
 	virtual ~DecorationManager() = default;
 
+	DecorationManager *clone() const;
+
 	const char *getObjectTitle() const
 	{
 		return "decoration";
@@ -133,4 +142,7 @@ public:
 	}
 
 	size_t placeAllDecos(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
+
+private:
+	DecorationManager() {};
 };

--- a/src/mapgen/mg_decoration.h
+++ b/src/mapgen/mg_decoration.h
@@ -99,11 +99,13 @@ public:
 	ObjDef *clone() const;
 
 	DecoSchematic() = default;
+	virtual ~DecoSchematic();
 
 	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling);
 
 	Rotation rotation;
 	Schematic *schematic = nullptr;
+	bool was_cloned = false; // see FIXME inside DecoSchemtic::clone()
 };
 
 

--- a/src/mapgen/mg_ore.cpp
+++ b/src/mapgen/mg_ore.cpp
@@ -72,6 +72,14 @@ void OreManager::clear()
 }
 
 
+OreManager *OreManager::clone() const
+{
+	auto mgr = new OreManager();
+	ObjDefManager::cloneTo(mgr);
+	return mgr;
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////
 
 
@@ -106,7 +114,35 @@ size_t Ore::placeOre(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 }
 
 
+void Ore::cloneTo(Ore *def) const
+{
+	ObjDef::cloneTo(def);
+	NodeResolver::cloneTo(def);
+	def->c_ore = c_ore;
+	def->c_wherein = c_wherein;
+	def->clust_scarcity = clust_scarcity;
+	def->clust_num_ores = clust_num_ores;
+	def->clust_size = clust_size;
+	def->y_min = y_min;
+	def->y_max = y_max;
+	def->ore_param2 = ore_param2;
+	def->flags = flags;
+	def->nthresh = nthresh;
+	def->np = np;
+	def->noise = nullptr; // cannot be shared! so created on demand
+	def->biomes = biomes;
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////
+
+
+ObjDef *OreScatter::clone() const
+{
+	auto def = new OreScatter();
+	Ore::cloneTo(def);
+	return def;
+}
 
 
 void OreScatter::generate(MMVManip *vm, int mapseed, u32 blockseed,
@@ -156,6 +192,19 @@ void OreScatter::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 
 ///////////////////////////////////////////////////////////////////////////////
+
+
+ObjDef *OreSheet::clone() const
+{
+	auto def = new OreSheet();
+	Ore::cloneTo(def);
+
+	def->column_height_max = column_height_max;
+	def->column_height_min = column_height_min;
+	def->column_midpoint_factor = column_midpoint_factor;
+
+	return def;
+}
 
 
 void OreSheet::generate(MMVManip *vm, int mapseed, u32 blockseed,
@@ -218,6 +267,20 @@ OrePuff::~OrePuff()
 {
 	delete noise_puff_top;
 	delete noise_puff_bottom;
+}
+
+
+ObjDef *OrePuff::clone() const
+{
+	auto def = new OrePuff();
+	Ore::cloneTo(def);
+
+	def->np_puff_top = np_puff_top;
+	def->np_puff_bottom = np_puff_bottom;
+	def->noise_puff_top = nullptr; // cannot be shared, on-demand
+	def->noise_puff_bottom = nullptr;
+
+	return def;
 }
 
 
@@ -294,6 +357,14 @@ void OrePuff::generate(MMVManip *vm, int mapseed, u32 blockseed,
 ///////////////////////////////////////////////////////////////////////////////
 
 
+ObjDef *OreBlob::clone() const
+{
+	auto def = new OreBlob();
+	Ore::cloneTo(def);
+	return def;
+}
+
+
 void OreBlob::generate(MMVManip *vm, int mapseed, u32 blockseed,
 	v3s16 nmin, v3s16 nmax, u8 *biomemap)
 {
@@ -366,6 +437,19 @@ OreVein::~OreVein()
 }
 
 
+ObjDef *OreVein::clone() const
+{
+	auto def = new OreVein();
+	Ore::cloneTo(def);
+
+	def->random_factor = random_factor;
+	def->noise2 = nullptr; // cannot be shared, on-demand
+	def->sizey_prev = sizey_prev;
+
+	return def;
+}
+
+
 void OreVein::generate(MMVManip *vm, int mapseed, u32 blockseed,
 	v3s16 nmin, v3s16 nmax, u8 *biomemap)
 {
@@ -431,6 +515,19 @@ void OreVein::generate(MMVManip *vm, int mapseed, u32 blockseed,
 OreStratum::~OreStratum()
 {
 	delete noise_stratum_thickness;
+}
+
+
+ObjDef *OreStratum::clone() const
+{
+	auto def = new OreStratum();
+	Ore::cloneTo(def);
+
+	def->np_stratum_thickness = np_stratum_thickness;
+	def->noise_stratum_thickness = nullptr; // cannot be shared, on-demand
+	def->stratum_thickness = stratum_thickness;
+
+	return def;
 }
 
 

--- a/src/mapgen/mg_ore.h
+++ b/src/mapgen/mg_ore.h
@@ -74,11 +74,16 @@ public:
 	size_t placeOre(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
 		v3s16 nmin, v3s16 nmax, u8 *biomemap) = 0;
+
+protected:
+	void cloneTo(Ore *def) const;
 };
 
 class OreScatter : public Ore {
 public:
 	static const bool NEEDS_NOISE = false;
+
+	ObjDef *clone() const;
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
 		v3s16 nmin, v3s16 nmax, u8 *biomemap);
@@ -87,6 +92,8 @@ public:
 class OreSheet : public Ore {
 public:
 	static const bool NEEDS_NOISE = true;
+
+	ObjDef *clone() const;
 
 	u16 column_height_min;
 	u16 column_height_max;
@@ -99,6 +106,8 @@ public:
 class OrePuff : public Ore {
 public:
 	static const bool NEEDS_NOISE = true;
+
+	ObjDef *clone() const;
 
 	NoiseParams np_puff_top;
 	NoiseParams np_puff_bottom;
@@ -116,6 +125,8 @@ class OreBlob : public Ore {
 public:
 	static const bool NEEDS_NOISE = true;
 
+	ObjDef *clone() const;
+
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
 		v3s16 nmin, v3s16 nmax, u8 *biomemap);
 };
@@ -123,6 +134,8 @@ public:
 class OreVein : public Ore {
 public:
 	static const bool NEEDS_NOISE = true;
+
+	ObjDef *clone() const;
 
 	float random_factor;
 	Noise *noise2 = nullptr;
@@ -139,6 +152,8 @@ class OreStratum : public Ore {
 public:
 	static const bool NEEDS_NOISE = false;
 
+	ObjDef *clone() const;
+
 	NoiseParams np_stratum_thickness;
 	Noise *noise_stratum_thickness = nullptr;
 	u16 stratum_thickness;
@@ -154,6 +169,8 @@ class OreManager : public ObjDefManager {
 public:
 	OreManager(IGameDef *gamedef);
 	virtual ~OreManager() = default;
+
+	OreManager *clone() const;
 
 	const char *getObjectTitle() const
 	{
@@ -183,4 +200,7 @@ public:
 	void clear();
 
 	size_t placeAllOres(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
+
+private:
+	OreManager() {};
 };

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -77,6 +77,11 @@ Schematic::~Schematic()
 	delete []slice_probs;
 }
 
+ObjDef *Schematic::clone() const
+{
+	FATAL_ERROR("not cloneable");
+}
+
 
 void Schematic::resolveNodeNames()
 {
@@ -93,6 +98,7 @@ void Schematic::resolveNodeNames()
 
 void Schematic::blitToVManip(MMVManip *vm, v3s16 p, Rotation rot, bool force_place)
 {
+	assert(schemdata && slice_probs);
 	sanity_check(m_ndef != NULL);
 
 	int xstride = 1;
@@ -177,7 +183,7 @@ bool Schematic::placeOnVManip(MMVManip *vm, v3s16 p, u32 flags,
 	Rotation rot, bool force_place)
 {
 	assert(vm != NULL);
-	assert(schemdata != NULL);
+	assert(schemdata && slice_probs);
 	sanity_check(m_ndef != NULL);
 
 	//// Determine effective rotation and effective schematic dimensions

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -359,7 +359,7 @@ bool Schematic::deserializeFromMts(std::istream *is,
 
 
 bool Schematic::serializeToMts(std::ostream *os,
-	const std::vector<std::string> &names)
+	const std::vector<std::string> &names) const
 {
 	std::ostream &ss = *os;
 
@@ -383,7 +383,8 @@ bool Schematic::serializeToMts(std::ostream *os,
 
 
 bool Schematic::serializeToLua(std::ostream *os,
-	const std::vector<std::string> &names, bool use_comments, u32 indent_spaces)
+	const std::vector<std::string> &names, bool use_comments,
+	u32 indent_spaces) const
 {
 	std::ostream &ss = *os;
 

--- a/src/mapgen/mg_schematic.h
+++ b/src/mapgen/mg_schematic.h
@@ -106,9 +106,10 @@ public:
 	bool getSchematicFromMap(Map *map, v3s16 p1, v3s16 p2);
 
 	bool deserializeFromMts(std::istream *is, std::vector<std::string> *names);
-	bool serializeToMts(std::ostream *os, const std::vector<std::string> &names);
+	bool serializeToMts(std::ostream *os,
+		const std::vector<std::string> &names) const;
 	bool serializeToLua(std::ostream *os, const std::vector<std::string> &names,
-		bool use_comments, u32 indent_spaces);
+		bool use_comments, u32 indent_spaces) const;
 
 	void blitToVManip(MMVManip *vm, v3s16 p, Rotation rot, bool force_place);
 	bool placeOnVManip(MMVManip *vm, v3s16 p, u32 flags, Rotation rot, bool force_place);

--- a/src/mapgen/mg_schematic.h
+++ b/src/mapgen/mg_schematic.h
@@ -95,6 +95,8 @@ public:
 	Schematic();
 	virtual ~Schematic();
 
+	ObjDef *clone() const;
+
 	virtual void resolveNodeNames();
 
 	bool loadSchematicFromFile(const std::string &filename,
@@ -127,6 +129,8 @@ class SchematicManager : public ObjDefManager {
 public:
 	SchematicManager(Server *server);
 	virtual ~SchematicManager() = default;
+
+	// not cloneable
 
 	virtual void clear();
 

--- a/src/mapgen/mg_schematic.h
+++ b/src/mapgen/mg_schematic.h
@@ -130,7 +130,7 @@ public:
 	SchematicManager(Server *server);
 	virtual ~SchematicManager() = default;
 
-	// not cloneable
+	SchematicManager *clone() const;
 
 	virtual void clear();
 
@@ -145,6 +145,8 @@ public:
 	}
 
 private:
+	SchematicManager() {};
+
 	Server *m_server;
 };
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1597,6 +1597,18 @@ NodeResolver::~NodeResolver()
 }
 
 
+void NodeResolver::cloneTo(NodeResolver *res) const
+{
+	FATAL_ERROR_IF(!m_resolve_done, "NodeResolver can only be cloned"
+		" after resolving has completed");
+	/* We don't actually do anything significant. Since the node resolving has
+	 * already completed, the class that called us will already have the
+	 * resolved IDs in its data structures (which it copies on its own) */
+	res->m_ndef = m_ndef;
+	res->m_resolve_done = true;
+}
+
+
 void NodeResolver::nodeResolveInternal()
 {
 	m_nodenames_idx   = 0;

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -741,6 +741,9 @@ public:
 	virtual ~NodeResolver();
 	virtual void resolveNodeNames() = 0;
 
+	// required because this class is used as mixin for ObjDef
+	void cloneTo(NodeResolver *res) const;
+
 	bool getIdFromNrBacklog(content_t *result_out,
 		const std::string &node_alt, content_t c_fallback,
 		bool error_on_fallback = true);

--- a/src/objdef.cpp
+++ b/src/objdef.cpp
@@ -182,3 +182,22 @@ bool ObjDefManager::decodeHandle(ObjDefHandle handle, u32 *index,
 	*uid   = get_bits(handle, 24, 7);
 	return true;
 }
+
+// Cloning
+
+void ObjDef::cloneTo(ObjDef *def) const
+{
+	def->index = index;
+	def->uid = uid;
+	def->handle = handle;
+	def->name = name;
+}
+
+void ObjDefManager::cloneTo(ObjDefManager *mgr) const
+{
+	mgr->m_ndef = m_ndef;
+	mgr->m_objects.reserve(m_objects.size());
+	for (const auto &obj : m_objects)
+		mgr->m_objects.push_back(obj->clone());
+	mgr->m_objtype = m_objtype;
+}

--- a/src/objdef.h
+++ b/src/objdef.h
@@ -66,6 +66,7 @@ protected:
 // WARNING: Ownership of ObjDefs is transferred to the ObjDefManager it is
 // added/set to.  Note that ObjDefs managed by ObjDefManager are NOT refcounted,
 // so the same ObjDef instance must not be referenced multiple
+// TODO: const correctness for getter methods
 class ObjDefManager {
 public:
 	ObjDefManager(IGameDef *gamedef, ObjDefType type);

--- a/src/objdef.h
+++ b/src/objdef.h
@@ -45,10 +45,22 @@ class ObjDef {
 public:
 	virtual ~ObjDef() = default;
 
+	// Only implemented by child classes (leafs in class hierarchy)
+	// Should create new object of its own type, call cloneTo() of parent class
+	// and copy its own instance variables over
+	virtual ObjDef *clone() const = 0;
+
 	u32 index;
 	u32 uid;
 	ObjDefHandle handle;
 	std::string name;
+
+protected:
+	// Only implemented by classes that have children themselves
+	// by copying the defintion and changing that argument type (!!!)
+	// Should defer to parent class cloneTo() if applicable and then copy
+	// over its own properties
+	void cloneTo(ObjDef *def) const;
 };
 
 // WARNING: Ownership of ObjDefs is transferred to the ObjDefManager it is
@@ -59,6 +71,8 @@ public:
 	ObjDefManager(IGameDef *gamedef, ObjDefType type);
 	virtual ~ObjDefManager();
 	DISABLE_CLASS_COPY(ObjDefManager);
+
+	// T *clone() const; // implemented in child class with correct type
 
 	virtual const char *getObjectTitle() const { return "ObjDef"; }
 
@@ -88,6 +102,10 @@ public:
 		ObjDefType *type, u32 *uid);
 
 protected:
+	ObjDefManager() {};
+	// Helper for child classes to implement clone()
+	void cloneTo(ObjDefManager *mgr) const;
+
 	const NodeDefManager *m_ndef;
 	std::vector<ObjDef *> m_objects;
 	ObjDefType m_objtype;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -490,7 +490,7 @@ int ModApiMapgen::l_get_biome_id(lua_State *L)
 	if (!bmgr)
 		return 0;
 
-	Biome *biome = (Biome *)bmgr->getByName(biome_str);
+	const Biome *biome = (Biome *)bmgr->getByName(biome_str);
 	if (!biome || biome->index == OBJDEF_INVALID_INDEX)
 		return 0;
 
@@ -512,7 +512,7 @@ int ModApiMapgen::l_get_biome_name(lua_State *L)
 	if (!bmgr)
 		return 0;
 
-	Biome *b = (Biome *)bmgr->getRaw(biome_id);
+	const Biome *b = (Biome *)bmgr->getRaw(biome_id);
 	lua_pushstring(L, b->name.c_str());
 
 	return 1;
@@ -551,8 +551,6 @@ int ModApiMapgen::l_get_heat(lua_State *L)
 		return 0;
 
 	float heat = bmgr->getHeatAtPosOriginal(pos, np_heat, np_heat_blend, seed);
-	if (!heat)
-		return 0;
 
 	lua_pushnumber(L, heat);
 
@@ -593,8 +591,6 @@ int ModApiMapgen::l_get_humidity(lua_State *L)
 
 	float humidity = bmgr->getHumidityAtPosOriginal(pos, np_humidity,
 		np_humidity_blend, seed);
-	if (!humidity)
-		return 0;
 
 	lua_pushnumber(L, humidity);
 
@@ -648,7 +644,7 @@ int ModApiMapgen::l_get_biome_data(lua_State *L)
 	if (!humidity)
 		return 0;
 
-	Biome *biome = (Biome *)bmgr->getBiomeFromNoiseOriginal(heat, humidity, pos);
+	const Biome *biome = bmgr->getBiomeFromNoiseOriginal(heat, humidity, pos);
 	if (!biome || biome->index == OBJDEF_INVALID_INDEX)
 		return 0;
 
@@ -1517,8 +1513,7 @@ int ModApiMapgen::l_generate_ores(lua_State *L)
 
 	u32 blockseed = Mapgen::getBlockSeed(pmin, mg.seed);
 
-	OreManager *oremgr = (OreManager*) emerge->getOreManager(); // FIXME FIXME
-	oremgr->placeAllOres(&mg, blockseed, pmin, pmax);
+	emerge->oremgr->placeAllOres(&mg, blockseed, pmin, pmax);
 
 	return 0;
 }
@@ -1544,8 +1539,7 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 
 	u32 blockseed = Mapgen::getBlockSeed(pmin, mg.seed);
 
-	DecorationManager *decomgr = (DecorationManager*) emerge->getDecorationManager(); // FIXME FIXME
-	decomgr->placeAllDecos(&mg, blockseed, pmin, pmax);
+	emerge->decomgr->placeAllDecos(&mg, blockseed, pmin, pmax);
 
 	return 0;
 }
@@ -1625,8 +1619,7 @@ int ModApiMapgen::l_place_schematic(lua_State *L)
 	GET_ENV_PTR;
 
 	ServerMap *map = &(env->getServerMap());
-	SchematicManager *schemmgr = (SchematicManager*)
-		getServer(L)->getEmergeManager()->getSchematicManager(); // FIXME FIXME
+	SchematicManager *schemmgr = getServer(L)->getEmergeManager()->schemmgr;
 
 	//// Read position
 	v3s16 p = check_v3s16(L, 1);
@@ -1671,8 +1664,7 @@ int ModApiMapgen::l_place_schematic_on_vmanip(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	SchematicManager *schemmgr = (SchematicManager*)
-		getServer(L)->getEmergeManager()->getSchematicManager(); // FIXME FIXME
+	SchematicManager *schemmgr = getServer(L)->getEmergeManager()->schemmgr;
 
 	//// Read VoxelManip object
 	MMVManip *vm = LuaVoxelManip::checkobject(L, 1)->vm;
@@ -1728,7 +1720,7 @@ int ModApiMapgen::l_serialize_schematic(lua_State *L)
 
 	//// Get schematic
 	bool was_loaded = false;
-	Schematic *schem = (Schematic *)get_objdef(L, 1, schemmgr);
+	const Schematic *schem = (Schematic *)get_objdef(L, 1, schemmgr);
 	if (!schem) {
 		schem = load_schematic(L, 1, NULL, NULL);
 		was_loaded = true;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -91,7 +91,7 @@ struct EnumString ModApiMapgen::es_SchematicFormatType[] =
 	{0, NULL},
 };
 
-ObjDef *get_objdef(lua_State *L, int index, ObjDefManager *objmgr);
+ObjDef *get_objdef(lua_State *L, int index, const ObjDefManager *objmgr);
 
 Biome *get_or_load_biome(lua_State *L, int index,
 	BiomeManager *biomemgr);
@@ -114,7 +114,7 @@ bool read_deco_schematic(lua_State *L, SchematicManager *schemmgr, DecoSchematic
 
 ///////////////////////////////////////////////////////////////////////////////
 
-ObjDef *get_objdef(lua_State *L, int index, ObjDefManager *objmgr)
+ObjDef *get_objdef(lua_State *L, int index, const ObjDefManager *objmgr)
 {
 	if (index < 0)
 		index = lua_gettop(L) + 1 + index;
@@ -486,7 +486,7 @@ int ModApiMapgen::l_get_biome_id(lua_State *L)
 	if (!biome_str)
 		return 0;
 
-	BiomeManager *bmgr = getServer(L)->getEmergeManager()->biomemgr;
+	const BiomeManager *bmgr = getServer(L)->getEmergeManager()->getBiomeManager();
 	if (!bmgr)
 		return 0;
 
@@ -508,7 +508,7 @@ int ModApiMapgen::l_get_biome_name(lua_State *L)
 
 	int biome_id = luaL_checkinteger(L, 1);
 
-	BiomeManager *bmgr = getServer(L)->getEmergeManager()->biomemgr;
+	const BiomeManager *bmgr = getServer(L)->getEmergeManager()->getBiomeManager();
 	if (!bmgr)
 		return 0;
 
@@ -546,7 +546,7 @@ int ModApiMapgen::l_get_heat(lua_State *L)
 	u64 seed;
 	ss >> seed;
 
-	BiomeManager *bmgr = getServer(L)->getEmergeManager()->biomemgr;
+	const BiomeManager *bmgr = getServer(L)->getEmergeManager()->getBiomeManager();
 	if (!bmgr)
 		return 0;
 
@@ -587,7 +587,7 @@ int ModApiMapgen::l_get_humidity(lua_State *L)
 	u64 seed;
 	ss >> seed;
 
-	BiomeManager *bmgr = getServer(L)->getEmergeManager()->biomemgr;
+	const BiomeManager *bmgr = getServer(L)->getEmergeManager()->getBiomeManager();
 	if (!bmgr)
 		return 0;
 
@@ -635,7 +635,7 @@ int ModApiMapgen::l_get_biome_data(lua_State *L)
 	u64 seed;
 	ss >> seed;
 
-	BiomeManager *bmgr = getServer(L)->getEmergeManager()->biomemgr;
+	const BiomeManager *bmgr = getServer(L)->getEmergeManager()->getBiomeManager();
 	if (!bmgr)
 		return 0;
 
@@ -1067,7 +1067,8 @@ int ModApiMapgen::l_get_decoration_id(lua_State *L)
 	if (!deco_str)
 		return 0;
 
-	DecorationManager *dmgr = getServer(L)->getEmergeManager()->decomgr;
+	const DecorationManager *dmgr =
+		getServer(L)->getEmergeManager()->getDecorationManager();
 
 	if (!dmgr)
 		return 0;
@@ -1092,7 +1093,7 @@ int ModApiMapgen::l_register_biome(lua_State *L)
 	luaL_checktype(L, index, LUA_TTABLE);
 
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
-	BiomeManager *bmgr = getServer(L)->getEmergeManager()->biomemgr;
+	BiomeManager *bmgr = getServer(L)->getEmergeManager()->getWritableBiomeManager();
 
 	Biome *biome = read_biome_def(L, index, ndef);
 	if (!biome)
@@ -1118,9 +1119,10 @@ int ModApiMapgen::l_register_decoration(lua_State *L)
 	luaL_checktype(L, index, LUA_TTABLE);
 
 	const NodeDefManager *ndef      = getServer(L)->getNodeDefManager();
-	DecorationManager *decomgr = getServer(L)->getEmergeManager()->decomgr;
-	BiomeManager *biomemgr     = getServer(L)->getEmergeManager()->biomemgr;
-	SchematicManager *schemmgr = getServer(L)->getEmergeManager()->schemmgr;
+	EmergeManager *emerge = getServer(L)->getEmergeManager();
+	DecorationManager *decomgr = emerge->getWritableDecorationManager();
+	BiomeManager *biomemgr     = emerge->getWritableBiomeManager();
+	SchematicManager *schemmgr = emerge->getWritableSchematicManager();
 
 	enum DecorationType decotype = (DecorationType)getenumfield(L, index,
 				"deco_type", es_DecorationType, -1);
@@ -1275,8 +1277,9 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 	luaL_checktype(L, index, LUA_TTABLE);
 
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
-	BiomeManager *bmgr    = getServer(L)->getEmergeManager()->biomemgr;
-	OreManager *oremgr    = getServer(L)->getEmergeManager()->oremgr;
+	EmergeManager *emerge = getServer(L)->getEmergeManager();
+	BiomeManager *bmgr    = emerge->getWritableBiomeManager();
+	OreManager *oremgr    = emerge->getWritableOreManager();
 
 	enum OreType oretype = (OreType)getenumfield(L, index,
 				"ore_type", es_OreType, ORE_SCATTER);
@@ -1423,7 +1426,8 @@ int ModApiMapgen::l_register_schematic(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	SchematicManager *schemmgr = getServer(L)->getEmergeManager()->schemmgr;
+	SchematicManager *schemmgr =
+		getServer(L)->getEmergeManager()->getWritableSchematicManager();
 
 	StringMap replace_names;
 	if (lua_istable(L, 2))
@@ -1450,7 +1454,8 @@ int ModApiMapgen::l_clear_registered_biomes(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	BiomeManager *bmgr = getServer(L)->getEmergeManager()->biomemgr;
+	BiomeManager *bmgr =
+		getServer(L)->getEmergeManager()->getWritableBiomeManager();
 	bmgr->clear();
 	return 0;
 }
@@ -1461,7 +1466,8 @@ int ModApiMapgen::l_clear_registered_decorations(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	DecorationManager *dmgr = getServer(L)->getEmergeManager()->decomgr;
+	DecorationManager *dmgr =
+		getServer(L)->getEmergeManager()->getWritableDecorationManager();
 	dmgr->clear();
 	return 0;
 }
@@ -1472,7 +1478,8 @@ int ModApiMapgen::l_clear_registered_ores(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	OreManager *omgr = getServer(L)->getEmergeManager()->oremgr;
+	OreManager *omgr =
+		getServer(L)->getEmergeManager()->getWritableOreManager();
 	omgr->clear();
 	return 0;
 }
@@ -1483,7 +1490,8 @@ int ModApiMapgen::l_clear_registered_schematics(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	SchematicManager *smgr = getServer(L)->getEmergeManager()->schemmgr;
+	SchematicManager *smgr =
+		getServer(L)->getEmergeManager()->getWritableSchematicManager();
 	smgr->clear();
 	return 0;
 }
@@ -1509,7 +1517,8 @@ int ModApiMapgen::l_generate_ores(lua_State *L)
 
 	u32 blockseed = Mapgen::getBlockSeed(pmin, mg.seed);
 
-	emerge->oremgr->placeAllOres(&mg, blockseed, pmin, pmax);
+	OreManager *oremgr = (OreManager*) emerge->getOreManager(); // FIXME FIXME
+	oremgr->placeAllOres(&mg, blockseed, pmin, pmax);
 
 	return 0;
 }
@@ -1535,7 +1544,8 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 
 	u32 blockseed = Mapgen::getBlockSeed(pmin, mg.seed);
 
-	emerge->decomgr->placeAllDecos(&mg, blockseed, pmin, pmax);
+	DecorationManager *decomgr = (DecorationManager*) emerge->getDecorationManager(); // FIXME FIXME
+	decomgr->placeAllDecos(&mg, blockseed, pmin, pmax);
 
 	return 0;
 }
@@ -1615,7 +1625,8 @@ int ModApiMapgen::l_place_schematic(lua_State *L)
 	GET_ENV_PTR;
 
 	ServerMap *map = &(env->getServerMap());
-	SchematicManager *schemmgr = getServer(L)->getEmergeManager()->schemmgr;
+	SchematicManager *schemmgr = (SchematicManager*)
+		getServer(L)->getEmergeManager()->getSchematicManager(); // FIXME FIXME
 
 	//// Read position
 	v3s16 p = check_v3s16(L, 1);
@@ -1660,7 +1671,8 @@ int ModApiMapgen::l_place_schematic_on_vmanip(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	SchematicManager *schemmgr = getServer(L)->getEmergeManager()->schemmgr;
+	SchematicManager *schemmgr = (SchematicManager*)
+		getServer(L)->getEmergeManager()->getSchematicManager(); // FIXME FIXME
 
 	//// Read VoxelManip object
 	MMVManip *vm = LuaVoxelManip::checkobject(L, 1)->vm;
@@ -1708,7 +1720,7 @@ int ModApiMapgen::l_serialize_schematic(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	SchematicManager *schemmgr = getServer(L)->getEmergeManager()->schemmgr;
+	const SchematicManager *schemmgr = getServer(L)->getEmergeManager()->getSchematicManager();
 
 	//// Read options
 	bool use_comments = getboolfield_default(L, 3, "lua_use_comments", false);
@@ -1759,7 +1771,8 @@ int ModApiMapgen::l_read_schematic(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	SchematicManager *schemmgr = getServer(L)->getEmergeManager()->schemmgr;
+	const SchematicManager *schemmgr =
+		getServer(L)->getEmergeManager()->getSchematicManager();
 
 	//// Read options
 	std::string write_yslice = getstringfield_default(L, 2, "write_yslice_prob", "all");


### PR DESCRIPTION
<b>DO NOT SQUASH WHEN MERGING</b>

Problem: The objects managed by `BiomeManager`, `OreManager`, `DecorationManager` and `SchematicManager` are not thread-safe at all, because:
* ore generation code caches noise as a member variable
* schematic may change loaded schematic data for rotation during placing
* many more

Solution: Create a copy of the managers for each mapgen thread, the implementation of the objects can then freely modify its member variables.

-- Why not teach the implementation to be thread-safe then?
This is unfortunately not as easy and likely requires a larger refactoring\*. You can't just e.g. mark the member variables `thread_local`. So instead I opted for creating a copy of everything, which is guaranteed to work fine with the current code.
The whole thing is misdesigned anyway, it mixes the ore/deco/... settings (which could easy be constant and shared between all mapgens) with mutable implementation details such as cached noise buffers.

\* `ObjDefManager` is also not const correct at all, you can receive mutable references from a `const ObjDefManager&`. This PR does not fix that.

## Consequences

fixes #8300
It is possible to safely run with `num_emerge_threads > 1` again, though doing so raises the probability of the following appearing again:

The infamous y=48 bug ~~(#1755, #5125)~~ [mgv7, reproducible 100% with `num_emerge_threads = 12` here]
![pic](https://user-images.githubusercontent.com/1042418/78995238-3c6c2600-7b42-11ea-8472-4a452c6b1ed5.png)

General decoration weirdness on chunk boundaries(?)
![pic](https://user-images.githubusercontent.com/1042418/78995335-6b829780-7b42-11ea-9be6-b148eae78ce1.png)

With more sane thread values (e.g. `num_emerge_threads = 2`), these issues are exceedingly rare. So perhaps multiple emerge threads can be enabled by default again soon.

## How to test

Test everything related to mapgen, including:
* Custom biome mods (in particular ones that overwrite biomes)
* Using Lua mapgens
* Any mapgen-related Lua API functions
* test with `num_emerge_threads` > 1