### PR TITLE
Lua API: Add `rmdir`, `cpdir` and `mvdir`

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4628,11 +4628,12 @@ Utilities
     * Removes a directory specified by `path`.
     * If `recursive` is set to `true`, the directory is recursively removed.
       Otherwise, the directory will only be removed if it is empty.
-* `minetest.cpdir(source, destination, remove_source)`: returns success.
+* `minetest.cpdir(source, destination)`: returns success.
     * Copies a directory specified by `path` to `destination`, `destination` is
       overwritten if it already exists.
-    * If `remove_source` is set to `true`, the `source` directory is removed
-      after copying to the `destination`.
+* `minetest.mvdir(source, destination)`: returns success.
+    * Moves a directory specified by `path` to `destination`, `destination` is
+      overwritten if it already exists.
 * `minetest.get_dir_list(path, [is_dir])`: returns list of entry names
     * is_dir is one of:
         * nil: return all entries,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4624,6 +4624,15 @@ Utilities
 * `minetest.mkdir(path)`: returns success.
     * Creates a directory specified by `path`, creating parent directories
       if they don't exist.
+* `minetest.rmdir(path, recursive)`: returns success.
+    * Removes a directory specified by `path`.
+    * If `recursive` is set to `true`, the directory is recursively removed.
+      Otherwise, the directory will only be removed if it is empty.
+* `minetest.cpdir(source, destination, remove_source)`: returns success.
+    * Copies a directory specified by `path` to `destination`, `destination` is
+      overwritten if it already exists.
+    * If `remove_source` is set to `true`, the `source` directory is removed
+      after copying to the `destination`.
 * `minetest.get_dir_list(path, [is_dir])`: returns list of entry names
     * is_dir is one of:
         * nil: return all entries,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4628,12 +4628,15 @@ Utilities
     * Removes a directory specified by `path`.
     * If `recursive` is set to `true`, the directory is recursively removed.
       Otherwise, the directory will only be removed if it is empty.
+    * Returns true on success, false on failure.
 * `minetest.cpdir(source, destination)`: returns success.
-    * Copies a directory specified by `path` to `destination`, `destination` is
-      overwritten if it already exists.
+    * Copies a directory specified by `path` to `destination`
+    * Any files in `destination` will be overwritten if they already exist.
+    * Returns true on success, false on failure.
 * `minetest.mvdir(source, destination)`: returns success.
-    * Moves a directory specified by `path` to `destination`, `destination` is
-      overwritten if it already exists.
+    * Moves a directory specified by `path` to `destination`.
+    * If the `destination` is a non-empty directory, then the move will fail.
+    * Returns true on success, false on failure.
 * `minetest.get_dir_list(path, [is_dir])`: returns list of entry names
     * is_dir is one of:
         * nil: return all entries,

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -356,10 +356,7 @@ int ModApiUtil::l_rmdir(lua_State *L)
 	const char *path = luaL_checkstring(L, 1);
 	CHECK_SECURE_PATH(L, path, true);
 
-	bool recursive = false;
-
-	if (!lua_isnil(L, 2))
-		recursive = lua_toboolean(L, 2);
+	bool recursive = readParam<bool>(L, 2, false);
 
 	if (recursive)
 		lua_pushboolean(L, fs::RecursiveDelete(path));

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -369,7 +369,7 @@ int ModApiUtil::l_rmdir(lua_State *L)
 	return 1;
 }
 
-// cpdir(source, destination, remove_source)
+// cpdir(source, destination)
 int ModApiUtil::l_cpdir(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -378,18 +378,20 @@ int ModApiUtil::l_cpdir(lua_State *L)
 	CHECK_SECURE_PATH(L, source, false);
 	CHECK_SECURE_PATH(L, destination, true);
 
-	bool remove_source = false;
+	lua_pushboolean(L, fs::CopyDir(source, destination));
+	return 1;
+}
 
-	if (!lua_isnil(L, 3))
-		remove_source = lua_toboolean(L, 3);
+// mpdir(source, destination)
+int ModApiUtil::l_mvdir(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	const char *source = luaL_checkstring(L, 1);
+	const char *destination = luaL_checkstring(L, 2);
+	CHECK_SECURE_PATH(L, source, false);
+	CHECK_SECURE_PATH(L, destination, true);
 
-	bool retval = fs::CopyDir(source, destination);
-
-	if (retval && (remove_source)) {
-		CHECK_SECURE_PATH(L, source, true);
-		retval &= fs::RecursiveDelete(source);
-	}
-	lua_pushboolean(L, retval);
+	lua_pushboolean(L, fs::MoveDir(source, destination));
 	return 1;
 }
 
@@ -634,6 +636,7 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 	API_FCT(mkdir);
 	API_FCT(rmdir);
 	API_FCT(cpdir);
+	API_FCT(mvdir);
 	API_FCT(get_dir_list);
 	API_FCT(safe_file_write);
 

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -385,7 +385,7 @@ int ModApiUtil::l_mvdir(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	const char *source = luaL_checkstring(L, 1);
 	const char *destination = luaL_checkstring(L, 2);
-	CHECK_SECURE_PATH(L, source, false);
+	CHECK_SECURE_PATH(L, source, true);
 	CHECK_SECURE_PATH(L, destination, true);
 
 	lua_pushboolean(L, fs::MoveDir(source, destination));

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -699,6 +699,7 @@ void ModApiUtil::InitializeAsync(lua_State *L, int top)
 	API_FCT(mkdir);
 	API_FCT(rmdir);
 	API_FCT(cpdir);
+	API_FCT(mvdir);
 	API_FCT(get_dir_list);
 
 	API_FCT(encode_base64);

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -80,6 +80,12 @@ private:
 	// mkdir(path)
 	static int l_mkdir(lua_State *L);
 
+	// rmdir(path, recursive)
+	static int l_rmdir(lua_State *L);
+
+	// cpdir(source, destination, remove_source)
+	static int l_cpdir(lua_State *L);
+
 	// get_dir_list(path, is_dir)
 	static int l_get_dir_list(lua_State *L);
 

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -86,6 +86,9 @@ private:
 	// cpdir(source, destination, remove_source)
 	static int l_cpdir(lua_State *L);
 
+	// mvdir(source, destination)
+	static int l_mvdir(lua_State *L);
+
 	// get_dir_list(path, is_dir)
 	static int l_get_dir_list(lua_State *L);
 


### PR DESCRIPTION
Pull request replaces #6119. All code style issues should be resolved and I believe I have addressed all other review comments.

Complements `mkdir`, complies with mod security.
- `rmdir`: Remove a directory at the path specified.
- `cpdir`: Copy a directory to another location, and remove the source directory if the third parameter is set to `true`.

These APIs are important because there is no way to remove directories in Windows (os.remove doesn't work for directories, and os.execute isn't an option at all). On other platforms a pure-Lua implementation is possible, but there are enough possible usecases for this that it would still make sense to provide an engine implementation.

## How to test

- Create a mod (a worldmod is fine) that attempts to copy, remove and move some directory.
<details>
<summary>Example test script</summary>

```lua
local path = minetest.get_worldpath()
minetest.log("About to test mkdir, rmdir and cpdir...")
local ok

-- This message should never print because my_dir doesn't exist.
if ok then ok = minetest.rmdir(path .. "/my_dir") end; if ok then
	minetest.log("error", "Shouldn't have removed non-existent directory at " .. path .. "/my_dir")
end

-- Make starting directory and write file.
ok = minetest.mkdir(path .. "/my_dir"); if ok then
	minetest.log("Made directory at " .. path .. "/my_dir")

	local file = io.open(path .. "/my_dir/hello.txt", "w")
	file:write("Hello world!")
	file:close()
end

-- Copy starting directory to new directory.
if ok then ok = minetest.cpdir(path .. "/my_dir", path .. "/new_dir") end; if ok then
    minetest.log("Copied " .. path .. "/my_dir" .. " to " .. path .. "/new_dir")
end

-- Attempt to non-recursively remove non-empty directory. Message should never print.
if ok then ok = minetest.rmdir(path .. "/new_dir") end; if ok then
    minetest.log("error", "Shouldn't have removed non-empty directory at " .. path .. "/new_dir")
end

-- Remove directory recursively.
if not ok then ok = minetest.rmdir(path .. "/new_dir", true) end; if ok then
	minetest.log("Recursively removed directory at " .. path .. "/new_dir")
end

-- Move directory and remove old source.
if ok then ok = minetest.cpdir(path .. "/my_dir", path .. "/new_dir", true) end; if ok then
    minetest.log("Moved directory at " .. path .. "/my_dir" .. " to " .. path .. "/new_dir")
end

-- Clean up. There should be no additional directories left.
minetest.rmdir(path .. "/new_dir", true)
minetest.log("...done testing mkdir, rmdir and cpdir")
```

**NOTE**: The above script should produce one error message in the logs:
```
ERROR[Main]: rmdir errno: 39: Directory not empty
```
It should show between the message alerting that a directory was copied and the message alerting that a directory was recursively removed.

At the end of this script there should be no additional sub-directories in the world directory.
</details>