### PR TITLE
Use TILE_MATERIAL_ALPHA for use_texture_alpha entity flag

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -584,7 +584,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 		IShaderSource *shader_source = m_client->getShaderSource();
 		u32 shader_id = shader_source->getShader(
 				"object_shader",
-				TILE_MATERIAL_BASIC,
+				(m_prop.use_texture_alpha) ? TILE_MATERIAL_ALPHA : TILE_MATERIAL_BASIC,
 				NDT_NORMAL);
 		m_material_type = shader_source->getShaderInfo(shader_id).material;
 	} else {


### PR DESCRIPTION
Fixes #9637.

Simple one-liner, [fix suggested by Df458](https://github.com/minetest/minetest/issues/9637#issuecomment-612268227).