### PR TITLE
Reduce ServerEnvironment propagation (helps pathfinder to become client side friendly)

### DIFF
--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -25,7 +25,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h"
 #include "map.h"
 #include "mapblock.h"
-#include "serverenvironment.h"
 #include "nodedef.h"
 #include "treegen.h"
 #include "voxelalgorithms.h"
@@ -120,10 +119,9 @@ void make_tree(MMVManip &vmanip, v3s16 p0, bool is_apple_tree,
 
 
 // L-System tree LUA spawner
-treegen::error spawn_ltree(ServerEnvironment *env, v3s16 p0,
+treegen::error spawn_ltree(ServerMap *map, v3s16 p0,
 	const NodeDefManager *ndef, const TreeDef &tree_definition)
 {
-	ServerMap *map = &env->getServerMap();
 	std::map<v3s16, MapBlock*> modified_blocks;
 	MMVManip vmanip(map);
 	v3s16 tree_blockp = getNodeBlockPos(p0);

--- a/src/mapgen/treegen.h
+++ b/src/mapgen/treegen.h
@@ -26,8 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class MMVManip;
 class NodeDefManager;
-class ServerEnvironment;
-
+class ServerMap;
 
 namespace treegen {
 
@@ -73,7 +72,7 @@ namespace treegen {
 	treegen::error make_ltree(MMVManip &vmanip, v3s16 p0,
 		const NodeDefManager *ndef, TreeDef tree_definition);
 	// Spawn L-systems tree from LUA
-	treegen::error spawn_ltree (ServerEnvironment *env, v3s16 p0,
+	treegen::error spawn_ltree (ServerMap *map, v3s16 p0,
 		const NodeDefManager *ndef, const TreeDef &tree_definition);
 
 	// L-System tree gen helper functions

--- a/src/pathfinder.h
+++ b/src/pathfinder.h
@@ -29,7 +29,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /* Forward declarations                                                       */
 /******************************************************************************/
 
-class ServerEnvironment;
+class NodeDefManager;
+class Map;
 
 /******************************************************************************/
 /* Typedefs and macros                                                        */
@@ -54,10 +55,10 @@ typedef enum {
 /******************************************************************************/
 
 /** c wrapper function to use from scriptapi */
-std::vector<v3s16> get_path(ServerEnvironment *env,
-							v3s16 source,
-							v3s16 destination,
-							unsigned int searchdistance,
-							unsigned int max_jump,
-							unsigned int max_drop,
-							PathAlgorithm algo);
+std::vector<v3s16> get_path(Map *map, const NodeDefManager *ndef,
+		v3s16 source,
+		v3s16 destination,
+		unsigned int searchdistance,
+		unsigned int max_jump,
+		unsigned int max_drop,
+		PathAlgorithm algo);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -577,7 +577,7 @@ int ModApiEnvMod::l_get_node_timer(lua_State *L)
 
 	// Do it
 	v3s16 p = read_v3s16(L, 1);
-	NodeTimerRef::create(L, p, env);
+	NodeTimerRef::create(L, p, &env->getServerMap());
 	return 1;
 }
 
@@ -1193,7 +1193,7 @@ int ModApiEnvMod::l_find_path(lua_State *L)
 			algo = PA_DIJKSTRA;
 	}
 
-	std::vector<v3s16> path = get_path(env, pos1, pos2,
+	std::vector<v3s16> path = get_path(&env->getServerMap(), env->getGameDef()->ndef(), pos1, pos2,
 		searchdistance, max_jump, max_drop, algo);
 
 	if (!path.empty()) {
@@ -1257,8 +1257,9 @@ int ModApiEnvMod::l_spawn_tree(lua_State *L)
 	else
 		return 0;
 
+	ServerMap *map = &env->getServerMap();
 	treegen::error e;
-	if ((e = treegen::spawn_ltree (env, p0, ndef, tree_def)) != treegen::SUCCESS) {
+	if ((e = treegen::spawn_ltree (map, p0, ndef, tree_def)) != treegen::SUCCESS) {
 		if (e == treegen::UNBALANCED_BRACKETS) {
 			luaL_error(L, "spawn_tree(): closing ']' has no matching opening bracket");
 		} else {

--- a/src/script/lua_api/l_nodetimer.cpp
+++ b/src/script/lua_api/l_nodetimer.cpp
@@ -41,11 +41,9 @@ int NodeTimerRef::l_set(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 	NodeTimerRef *o = checkobject(L, 1);
-	ServerEnvironment *env = o->m_env;
-	if(env == NULL) return 0;
 	f32 t = readParam<float>(L,2);
 	f32 e = readParam<float>(L,3);
-	env->getMap().setNodeTimer(NodeTimer(t, e, o->m_p));
+	o->m_map->setNodeTimer(NodeTimer(t, e, o->m_p));
 	return 0;
 }
 
@@ -53,10 +51,8 @@ int NodeTimerRef::l_start(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 	NodeTimerRef *o = checkobject(L, 1);
-	ServerEnvironment *env = o->m_env;
-	if(env == NULL) return 0;
 	f32 t = readParam<float>(L,2);
-	env->getMap().setNodeTimer(NodeTimer(t, 0, o->m_p));
+	o->m_map->setNodeTimer(NodeTimer(t, 0, o->m_p));
 	return 0;
 }
 
@@ -64,9 +60,7 @@ int NodeTimerRef::l_stop(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 	NodeTimerRef *o = checkobject(L, 1);
-	ServerEnvironment *env = o->m_env;
-	if(env == NULL) return 0;
-	env->getMap().removeNodeTimer(o->m_p);
+	o->m_map->removeNodeTimer(o->m_p);
 	return 0;
 }
 
@@ -74,10 +68,7 @@ int NodeTimerRef::l_is_started(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 	NodeTimerRef *o = checkobject(L, 1);
-	ServerEnvironment *env = o->m_env;
-	if(env == NULL) return 0;
-
-	NodeTimer t = env->getMap().getNodeTimer(o->m_p);
+	NodeTimer t = o->m_map->getNodeTimer(o->m_p);
 	lua_pushboolean(L,(t.timeout != 0));
 	return 1;
 }
@@ -86,10 +77,7 @@ int NodeTimerRef::l_get_timeout(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 	NodeTimerRef *o = checkobject(L, 1);
-	ServerEnvironment *env = o->m_env;
-	if(env == NULL) return 0;
-
-	NodeTimer t = env->getMap().getNodeTimer(o->m_p);
+	NodeTimer t = o->m_map->getNodeTimer(o->m_p);
 	lua_pushnumber(L,t.timeout);
 	return 1;
 }
@@ -98,35 +86,19 @@ int NodeTimerRef::l_get_elapsed(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 	NodeTimerRef *o = checkobject(L, 1);
-	ServerEnvironment *env = o->m_env;
-	if(env == NULL) return 0;
-
-	NodeTimer t = env->getMap().getNodeTimer(o->m_p);
+	NodeTimer t = o->m_map->getNodeTimer(o->m_p);
 	lua_pushnumber(L,t.elapsed);
 	return 1;
 }
 
-
-NodeTimerRef::NodeTimerRef(v3s16 p, ServerEnvironment *env):
-	m_p(p),
-	m_env(env)
-{
-}
-
 // Creates an NodeTimerRef and leaves it on top of stack
 // Not callable from Lua; all references are created on the C side.
-void NodeTimerRef::create(lua_State *L, v3s16 p, ServerEnvironment *env)
+void NodeTimerRef::create(lua_State *L, v3s16 p, ServerMap *map)
 {
-	NodeTimerRef *o = new NodeTimerRef(p, env);
+	NodeTimerRef *o = new NodeTimerRef(p, map);
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
 	luaL_getmetatable(L, className);
 	lua_setmetatable(L, -2);
-}
-
-void NodeTimerRef::set_null(lua_State *L)
-{
-	NodeTimerRef *o = checkobject(L, -1);
-	o->m_env = NULL;
 }
 
 void NodeTimerRef::Register(lua_State *L)

--- a/src/script/lua_api/l_nodetimer.h
+++ b/src/script/lua_api/l_nodetimer.h
@@ -22,13 +22,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irr_v3d.h"
 #include "lua_api/l_base.h"
 
-class ServerEnvironment;
+class ServerMap;
 
 class NodeTimerRef : public ModApiBase
 {
 private:
 	v3s16 m_p;
-	ServerEnvironment *m_env = nullptr;
+	ServerMap *m_map;
 
 	static const char className[];
 	static const luaL_Reg methods[];
@@ -50,14 +50,12 @@ private:
 	static int l_get_elapsed(lua_State *L);
 
 public:
-	NodeTimerRef(v3s16 p, ServerEnvironment *env);
+	NodeTimerRef(v3s16 p, ServerMap *map) : m_p(p), m_map(map) {}
 	~NodeTimerRef() = default;
 
 	// Creates an NodeTimerRef and leaves it on top of stack
 	// Not callable from Lua; all references are created on the C side.
-	static void create(lua_State *L, v3s16 p, ServerEnvironment *env);
-
-	static void set_null(lua_State *L);
+	static void create(lua_State *L, v3s16 p, ServerMap *map);
 
 	static void Register(lua_State *L);
 };


### PR DESCRIPTION
ServerEnvironment is a huge class with many accessors. In various places it's not needed

Remove it to reduce the ServerEnvironment usage everywhere.

Idea here is to reduce size of some of our objects to transport lightweight managers and permit easier testing

Add compact, short information about your PR for easier understanding:

## To do

This PR is a Ready for Review.

## How to test
You can easily test it with any mod with pathfinding or nodetimers. It's just pointer types replacement no functional changes.
