### PR TITLE
Add WorldSettings object & env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,24 @@ Configuration file
 - A run-in-place build will look for the configuration file in
     `location_of_exe/../minetest.conf` and also `location_of_exe/../../minetest.conf`
 
+Configuration from environment variables
+----------------------------------------
+
+Minetest reads some environment variables to overwrite the configuration files.
+
+We currently support the following _world.mt_ overwrite variables:
+
+- WORLD_BACKEND: backend (default: `sqlite3`).
+- WORLD_AUTH_BACKEND: authentication backend (default: `sqlite3`).
+- WORLD_PLAYER_BACKEND: player backend (default: `sqlite3`).
+- WORLD_READONLY_BACKEND: readonly_backend flag.
+- WORLD_POSTGRESQL_CONNECTION: PostgreSQL connection string (applied on `postgresql` backend).
+- WORLD_PLAYER_POSTGRESQL_CONNECTION: PostgreSQL player DB connection string (applied on `postgresql`) auth backend.
+- WORLD_REDIS_ADDRESS: Redis address (applied on `redis` backend).
+- WORLD_REDIS_HASH: Redis hash (applied on `redis` backend).
+- WORLD_REDIS_PASSWORD: Redis password (if any, applied on `redis` backend).
+- WORLD_REDIS_PORT: Redis port (applied on `redis` backend)
+
 Command-line options
 --------------------
 - Use `--help`

--- a/src/database/database-redis.h
+++ b/src/database/database-redis.h
@@ -27,12 +27,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include "database.h"
 
-class Settings;
+class WorldSettings;
 
 class Database_Redis : public MapDatabase
 {
 public:
-	Database_Redis(Settings &conf);
+	Database_Redis(WorldSettings &conf);
 	~Database_Redis();
 
 	void beginSave();

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -24,7 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "scripting_server.h"
 #include "server.h"
 #include "daynightratio.h"
-#include "emerge.h"
+#include "nodedef.h"
+#include "settings.h"
 
 
 Environment::Environment(IGameDef *gamedef):

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "player.h"
 #include "porting.h"
 #include "network/socket.h"
+#include "server/worldsettings.h"
 #if USE_CURSES
 	#include "terminal_chat_console.h"
 #endif
@@ -939,14 +940,13 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 static bool migrate_map_database(const GameParams &game_params, const Settings &cmd_args)
 {
 	std::string migrate_to = cmd_args.get("migrate");
-	Settings world_mt;
-	std::string world_mt_path = game_params.world_path + DIR_DELIM + "world.mt";
-	if (!world_mt.readConfigFile(world_mt_path.c_str())) {
+	WorldSettings world_mt(game_params.world_path);
+	if (!world_mt.load(true)) {
 		errorstream << "Cannot read world.mt!" << std::endl;
 		return false;
 	}
 
-	if (!world_mt.exists("backend")) {
+	if (!world_mt.isBackendSet()) {
 		errorstream << "Please specify your current backend in world.mt:"
 			<< std::endl
 			<< "	backend = {sqlite3|leveldb|redis|dummy|postgresql}"
@@ -954,7 +954,7 @@ static bool migrate_map_database(const GameParams &game_params, const Settings &
 		return false;
 	}
 
-	std::string backend = world_mt.get("backend");
+	std::string backend = world_mt.getMapBackend();
 	if (backend == migrate_to) {
 		errorstream << "Cannot migrate: new backend is same"
 			<< " as the old one" << std::endl;
@@ -995,11 +995,6 @@ static bool migrate_map_database(const GameParams &game_params, const Settings &
 	delete new_db;
 
 	actionstream << "Successfully migrated " << count << " blocks" << std::endl;
-	world_mt.set("backend", migrate_to);
-	if (!world_mt.updateConfigFile(world_mt_path.c_str()))
-		errorstream << "Failed to update world.mt!" << std::endl;
-	else
-		actionstream << "world.mt updated" << std::endl;
-
+	world_mt.setMapBackend(migrate_to, true);
 	return true;
 }

--- a/src/map.h
+++ b/src/map.h
@@ -35,7 +35,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "map_settings_manager.h"
 #include "debug.h"
 
-class Settings;
 class MapDatabase;
 class ClientMap;
 class MapSector;
@@ -46,6 +45,7 @@ class IGameDef;
 class IRollbackManager;
 class EmergeManager;
 class ServerEnvironment;
+class WorldSettings;
 struct BlockMakeData;
 
 /*
@@ -384,7 +384,7 @@ public:
 	/*
 		Database functions
 	*/
-	static MapDatabase *createDatabase(const std::string &name, const std::string &savedir, Settings &conf);
+	static MapDatabase *createDatabase(const std::string &name, const std::string &savedir, WorldSettings &conf);
 
 	// Call these before and after saving of blocks
 	void beginSave();

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "content/mods.h"
 #include "profiler.h"
 #include "server.h"
+#include "settings.h"
 #include <algorithm>
 #include <cmath>
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -5,4 +5,5 @@ set(server_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/player_sao.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/serveractiveobject.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/unit_sao.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/worldsettings.cpp
 	PARENT_SCOPE)

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "scripting_server.h"
 #include "server.h"
 #include "serverenvironment.h"
+#include "settings.h"
 
 PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t peer_id_,
 		bool is_singleplayer):

--- a/src/server/worldsettings.cpp
+++ b/src/server/worldsettings.cpp
@@ -1,0 +1,199 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2013-2020 Minetest core developers & community
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "worldsettings.h"
+#include "filesys.h"
+#include "log.h"
+
+#define MAP_BACKEND_KEY "backend"
+#define DEFAULT_BACKEND "sqlite3"
+#define MAP_READONLY_BACKEND_KEY "readonly_backend"
+#define AUTH_BACKEND_KEY "auth_backend"
+#define PLAYER_BACKEND_KEY "player_backend"
+
+#if USE_REDIS
+#define REDIS_ADDR_KEY "redis_address"
+#define REDIS_HASH_KEY "redis_hash"
+#define REDIS_PASSWORD_KEY "redis_password"
+#define REDIS_PORT_KEY "redis_port"
+#endif
+#if USE_POSTGRESQL
+#define PGSQL_CONN_KEY "pgsql_connection"
+#define PGSQL_PLAYER_CONN_KEY "pgsql_player_connection"
+#endif
+
+WorldSettings::WorldSettings(const std::string &savedir) :
+		m_conf_path(savedir + DIR_DELIM + "world.mt"), m_savedir(savedir)
+{
+}
+
+bool WorldSettings::load(bool return_on_config_read)
+{
+	bool succeeded = readConfigFile(m_conf_path.c_str());
+
+	bool player_backend_exists = exists(PLAYER_BACKEND_KEY);
+	// player backend is not set, assume it's legacy file backend.
+	if (!player_backend_exists) {
+		// fall back to files
+		set(PLAYER_BACKEND_KEY, "files");
+		infostream << "No " << PLAYER_BACKEND_KEY << " key found, assuming files."
+			   << std::endl;
+
+		if (!updateConfigFile()) {
+			errorstream << "WorldSettings::load(): "
+				    << "Failed to update world.mt!" << std::endl;
+		}
+	}
+
+	bool auth_backend_exists = exists(AUTH_BACKEND_KEY);
+	// auth backend is not set, assume it's legacy file backend.
+	if (!auth_backend_exists) {
+		set(AUTH_BACKEND_KEY, "files");
+		infostream << "No " << AUTH_BACKEND_KEY << " key found, assuming files."
+			   << std::endl;
+
+		if (!updateConfigFile()) {
+			errorstream << "WorldSettings::load(): "
+				    << "Failed to update world.mt!" << std::endl;
+		}
+	}
+
+	// Now read env vars
+	if (const char *backend = std::getenv("WORLD_BACKEND"))
+		set(MAP_BACKEND_KEY, std::string(backend));
+
+	if (const char *readonly_backend = std::getenv("WORLD_READONLY_BACKEND"))
+		set(MAP_READONLY_BACKEND_KEY, std::string(readonly_backend));
+
+	if (const char *backend = std::getenv("WORLD_AUTH_BACKEND"))
+		set(AUTH_BACKEND_KEY, std::string(backend));
+
+	if (const char *backend = std::getenv("WORLD_PLAYER_BACKEND"))
+		set(PLAYER_BACKEND_KEY, std::string(backend));
+
+#if USE_REDIS
+	if (const char *redis_addr = std::getenv("WORLD_REDIS_ADDRESS"))
+		set(REDIS_ADDR_KEY, std::string(redis_addr));
+
+	if (const char *redis_hash = std::getenv("WORLD_REDIS_HASH"))
+		set(REDIS_HASH_KEY, std::string(redis_hash));
+
+	if (const char *redis_password = std::getenv("WORLD_REDIS_PASSWORD"))
+		set(REDIS_PASSWORD_KEY, std::string(redis_password));
+
+	if (const char *redis_port = std::getenv("WORLD_REDIS_PORT")) {
+		setU16(REDIS_PORT_KEY, std::atoi(redis_port));
+	}
+#endif
+
+#if USE_POSTGRESQL
+	if (const char *pgsql_conn_str = std::getenv("WORLD_POSTGRESQL_CONNECTION"))
+		set(PGSQL_CONN_KEY, std::string(pgsql_conn_str));
+
+	if (const char *pgsql_conn_str =
+					std::getenv("WORLD_PLAYER_POSTGRESQL_CONNECTION"))
+		set(PGSQL_PLAYER_CONN_KEY, std::string(pgsql_conn_str));
+#endif
+
+	if (return_on_config_read) {
+		return succeeded;
+	}
+
+	if (!succeeded || !exists(MAP_BACKEND_KEY)) {
+		// fall back to sqlite3
+		set(MAP_BACKEND_KEY, DEFAULT_BACKEND);
+	}
+
+	m_backend = get(MAP_BACKEND_KEY);
+
+	if (exists(MAP_READONLY_BACKEND_KEY)) {
+		m_readonly_backend = get(MAP_READONLY_BACKEND_KEY);
+	}
+
+	return true;
+}
+
+std::string WorldSettings::getReadOnlyDir() const
+{
+	return m_savedir + DIR_DELIM + "readonly";
+}
+
+std::string WorldSettings::getAuthBackend() const
+{
+	std::string backend_name;
+	getNoEx(PLAYER_BACKEND_KEY, backend_name);
+	return backend_name;
+}
+
+void WorldSettings::setMapBackend(const std::string &backend, bool save)
+{
+	m_backend = backend;
+	set(MAP_BACKEND_KEY, backend);
+	if (save) {
+		if (!updateConfigFile())
+			errorstream << "Failed to update world.mt!" << std::endl;
+		else
+			actionstream << "world.mt updated" << std::endl;
+	}
+}
+void WorldSettings::setAuthBackend(const std::string &backend, bool save)
+{
+	set(AUTH_BACKEND_KEY, backend);
+	if (save) {
+		if (!updateConfigFile())
+			errorstream << "Failed to update world.mt!" << std::endl;
+		else
+			actionstream << "world.mt updated" << std::endl;
+	}
+}
+
+void WorldSettings::setPlayerBackend(const std::string &backend, bool save)
+{
+	set(PLAYER_BACKEND_KEY, backend);
+	if (save) {
+		if (!updateConfigFile())
+			errorstream << "Failed to update world.mt!" << std::endl;
+		else
+			actionstream << "world.mt updated" << std::endl;
+	}
+}
+
+std::string WorldSettings::getPlayerBackend() const
+{
+	std::string backend_name;
+	getNoEx(PLAYER_BACKEND_KEY, backend_name);
+	return backend_name;
+}
+
+#if USE_POSTGRESQL
+std::string WorldSettings::getMapPostgreSQLConnectionString() const
+{
+	std::string connection_string;
+	getNoEx(PGSQL_CONN_KEY, connection_string);
+	return connection_string;
+}
+
+std::string WorldSettings::getPlayerPostgresConnectionString() const
+{
+	std::string connection_string;
+	getNoEx(PGSQL_PLAYER_CONN_KEY, connection_string);
+	return connection_string;
+}
+#endif

--- a/src/server/worldsettings.cpp
+++ b/src/server/worldsettings.cpp
@@ -48,9 +48,8 @@ bool WorldSettings::load(bool return_on_config_read)
 {
 	bool succeeded = readConfigFile(m_conf_path.c_str());
 
-	bool player_backend_exists = exists(PLAYER_BACKEND_KEY);
 	// player backend is not set, assume it's legacy file backend.
-	if (!player_backend_exists) {
+	if (!exists(PLAYER_BACKEND_KEY)) {
 		// fall back to files
 		set(PLAYER_BACKEND_KEY, "files");
 		infostream << "No " << PLAYER_BACKEND_KEY << " key found, assuming files."
@@ -62,9 +61,8 @@ bool WorldSettings::load(bool return_on_config_read)
 		}
 	}
 
-	bool auth_backend_exists = exists(AUTH_BACKEND_KEY);
 	// auth backend is not set, assume it's legacy file backend.
-	if (!auth_backend_exists) {
+	if (!exists(AUTH_BACKEND_KEY)) {
 		set(AUTH_BACKEND_KEY, "files");
 		infostream << "No " << AUTH_BACKEND_KEY << " key found, assuming files."
 			   << std::endl;
@@ -138,7 +136,7 @@ std::string WorldSettings::getReadOnlyDir() const
 std::string WorldSettings::getAuthBackend() const
 {
 	std::string backend_name;
-	getNoEx(PLAYER_BACKEND_KEY, backend_name);
+	getNoEx(AUTH_BACKEND_KEY, backend_name);
 	return backend_name;
 }
 

--- a/src/server/worldsettings.h
+++ b/src/server/worldsettings.h
@@ -1,0 +1,70 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2013-2020 Minetest core developers & community
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "settings.h"
+#include "cmake_config.h"
+
+class WorldSettings : private Settings
+{
+public:
+	WorldSettings() = delete;
+	WorldSettings(const std::string &savedir);
+	bool load(bool return_on_config_read = false);
+	inline const std::string &getMapBackend() const { return m_backend; }
+	void setMapBackend(const std::string &backend, bool save = false);
+	void setAuthBackend(const std::string &backend, bool save = false);
+	void setPlayerBackend(const std::string &backend, bool save = false);
+	bool isPlayerBackendDefined() const { return exists("player_backend"); }
+	std::string getPlayerBackend() const;
+	std::string getAuthBackend() const;
+	inline const std::string &getReadOnlyBackend() const
+	{
+		return m_readonly_backend;
+	}
+	bool isBackendSet() const { return exists("backend"); }
+	std::string getReadOnlyDir() const;
+	bool updateConfigFile()
+	{
+		return Settings::updateConfigFile(m_conf_path.c_str());
+	}
+#if USE_REDIS
+	const std::string &getRedisAddr() const { return get("redis_address"); }
+	const std::string &getRedisHash() const { return get("redis_hash"); }
+	std::string getRedisPassword() const
+	{
+		return exists("redis_password") ? get("redis_password") : "";
+	}
+	u16 getRedisPort() const
+	{
+		return exists("redis_port") ? getU16("redis_port") : 6379;
+	}
+#endif
+#if USE_POSTGRESQL
+	std::string getMapPostgreSQLConnectionString() const;
+	std::string getPlayerPostgresConnectionString() const;
+#endif
+private:
+	std::string m_conf_path;
+	std::string m_savedir;
+	std::string m_backend;
+	std::string m_readonly_backend;
+};

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -2048,9 +2048,8 @@ PlayerDatabase *ServerEnvironment::openPlayerDatabase(const std::string &name,
 	if (name == "dummy")
 		return new Database_Dummy();
 #if USE_POSTGRESQL
-	if (name == "postgresql") {
+	if (name == "postgresql")
 		return new PlayerDatabasePostgreSQL(conf.getPlayerPostgresConnectionString());
-	}
 #endif
 	if (name == "files")
 		return new PlayerDatabaseFiles(savedir + DIR_DELIM + "players");

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -22,7 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "activeobject.h"
 #include "environment.h"
 #include "mapnode.h"
-#include "settings.h"
 #include "server/activeobjectmgr.h"
 #include "util/numeric.h"
 #include <set>
@@ -41,7 +40,9 @@ class ActiveBlockModifier;
 struct StaticObject;
 class ServerActiveObject;
 class Server;
+class Settings;
 class ServerScripting;
+class WorldSettings;
 
 /*
 	{Active, Loading} block modifier interface.
@@ -365,9 +366,9 @@ private:
 	void loadDefaultMeta();
 
 	static PlayerDatabase *openPlayerDatabase(const std::string &name,
-			const std::string &savedir, const Settings &conf);
+			const std::string &savedir, const WorldSettings &conf);
 	static AuthDatabase *openAuthDatabase(const std::string &name,
-			const std::string &savedir, const Settings &conf);
+			const std::string &savedir, const WorldSettings &conf);
 	/*
 		Internal ActiveObject interface
 		-------------------------------------------


### PR DESCRIPTION
This object protects the low level Settings object and handle all we need in terms of settings for Worlds
Add environment variable support for all WorldSettings available

This permits minetestserver to become more friendly with systemd units files and containers through Docker or Kubernetes

## To do

This PR is Ready for Review.

## How to test
Create a basic world.mt and change some one of the configuration using env vars from the shell
