### PR TITLE
Add deprecation warning for initial properties directly inside definition

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -196,6 +196,43 @@ void push_item_definition_full(lua_State *L, const ItemDefinition &i)
 }
 
 /******************************************************************************/
+const std::array<const char *, 33> object_property_keys = {
+	"hp_max",
+	"breath_max",
+	"physical",
+	"collide_with_objects",
+	"collisionbox",
+	"selectionbox",
+	"pointable",
+	"visual",
+	"mesh",
+	"visual_size",
+	"textures",
+	"colors",
+	"spritediv",
+	"initial_sprite_basepos",
+	"is_visible",
+	"makes_footstep_sound",
+	"stepheight",
+	"eye_height",
+	"automatic_rotate",
+	"automatic_face_movement_dir",
+	"backface_culling",
+	"glow",
+	"nametag",
+	"nametag_color",
+	"automatic_face_movement_max_rotation_per_sec",
+	"infotext",
+	"static_save",
+	"wield_item",
+	"zoom_fov",
+	"use_texture_alpha",
+	"shaded",
+	"damage_texture_modifier",
+	"show_on_minimap"
+};
+
+/******************************************************************************/
 void read_object_properties(lua_State *L, int index,
 		ServerActiveObject *sao, ObjectProperties *prop, IItemDefManager *idef)
 {
@@ -362,6 +399,9 @@ void read_object_properties(lua_State *L, int index,
 	getboolfield(L, -1, "show_on_minimap", prop->show_on_minimap);
 
 	getstringfield(L, -1, "damage_texture_modifier", prop->damage_texture_modifier);
+
+	// Remember to update object_property_keys above
+	// when adding a new property
 }
 
 /******************************************************************************/
@@ -459,6 +499,9 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "damage_texture_modifier");
 	lua_pushboolean(L, prop->show_on_minimap);
 	lua_setfield(L, -2, "show_on_minimap");
+
+	// Remember to update object_property_keys above
+	// when adding a new property
 }
 
 /******************************************************************************/

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -33,6 +33,7 @@ extern "C" {
 
 #include <iostream>
 #include <vector>
+#include <array>
 
 #include "irrlichttypes_bloated.h"
 #include "util/string.h"
@@ -70,6 +71,9 @@ class ServerActiveObject;
 struct collisionMoveResult;
 
 extern struct EnumString es_TileAnimationType[];
+
+
+extern const std::array<const char *, 33> object_property_keys;
 
 void               read_content_features     (lua_State *L, ContentFeatures &f,
                                               int index);
@@ -118,6 +122,7 @@ void               read_object_properties    (lua_State *L, int index,
                                               ServerActiveObject *sao,
                                               ObjectProperties *prop,
                                               IItemDefManager *idef);
+
 void               push_object_properties    (lua_State *L,
                                               ObjectProperties *prop);
 

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -177,7 +177,8 @@ void log_deprecated(lua_State *L, std::string message, int stack_depth)
 	if (mode == DeprecatedHandlingMode::Ignore)
 		return;
 
-	script_log_add_source(L, message, stack_depth);
+	if (stack_depth >= 0)
+		script_log_add_source(L, message, stack_depth);
 	warningstream << message << std::endl;
 
 	if (mode == DeprecatedHandlingMode::Error)

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -147,7 +147,8 @@ DeprecatedHandlingMode get_deprecated_handling_mode();
  *
  * @param L Lua State
  * @param message The deprecation method
- * @param stack_depth How far on the stack to the first user function (ie: not builtin or core)
+ * @param stack_depth How far on the stack to the first user function
+ *        (ie: not builtin or core). -1 to disabled.
  */
 void log_deprecated(lua_State *L, std::string message, int stack_depth = 1);
 

--- a/src/script/cpp_api/s_entity.h
+++ b/src/script/cpp_api/s_entity.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_base.h"
 #include "irr_v3d.h"
+#include <unordered_set>
 
 struct ObjectProperties;
 struct ToolCapabilities;
@@ -37,7 +38,7 @@ public:
 	void luaentity_Remove(u16 id);
 	std::string luaentity_GetStaticdata(u16 id);
 	void luaentity_GetProperties(u16 id,
-			ServerActiveObject *self, ObjectProperties *prop);
+			ServerActiveObject *self, ObjectProperties *prop, const std::string &entity_name);
 	void luaentity_Step(u16 id, float dtime,
 		const collisionMoveResult *moveresult);
 	bool luaentity_Punch(u16 id,
@@ -51,4 +52,11 @@ public:
 private:
 	bool luaentity_run_simple_callback(u16 id, ServerActiveObject *sao,
 		const char *field);
+
+	void logDeprecationForExistingProperties(lua_State *L, int index, const std::string &name);
+
+	/** Stores names of entities that already caused a deprecation warning due to
+	 * properties being outside of initial_properties. If an entity's name is in here,
+	 * it won't cause any more of those deprecation warnings. */
+	std::unordered_set<std::string> deprecation_warned_init_properties;
 };

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -103,7 +103,7 @@ void LuaEntitySAO::addedToEnvironment(u32 dtime_s)
 	if(m_registered){
 		// Get properties
 		m_env->getScriptIface()->
-			luaentity_GetProperties(m_id, this, &m_prop);
+			luaentity_GetProperties(m_id, this, &m_prop, m_init_name);
 		// Initialize HP from properties
 		m_hp = m_prop.hp_max;
 		// Activate entity, supplying serialized state


### PR DESCRIPTION
Defining initial object properties outside of `initial_properties` has been deprecated for a long time now:

```lua
-- A table of object properties, see the `Object properties` section.
-- Object properties being read directly from the entity definition
-- table is deprecated. Define object properties in this
-- `initial_properties` table instead.
```

But has never been warned about. This adds a warning:

> Reading initial object properties directly from an entity definition is deprecated, move it to the 'initial_properties' table instead. (Property 'hp_max' in entity 'mobs_animal:cow')

## To do

This PR is a Work in Progress

- [x] Fix source - says `(at ?:?)` currently


## How to test

Use mobs redo, advtrains, and various other mods
