### PR TITLE
Add 'content_offset' and 'padding' style properties for buttons

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2666,7 +2666,10 @@ Some types may inherit styles from parent types.
                      See background9[] documentation for more details
     * bgimg_pressed - background image when pressed. Defaults to bgimg when not provided.
     * border - boolean, draw border. Set to false to hide the bevelled button pane. Default true.
+    * content_offset - 2d vector, shifts the position of the button's content without resizing it.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
+    * padding - rect, adds space between the edges of the button and the content. Defaults to
+                the same value as bgimg_middle.
     * textcolor - color, default white.
 * checkbox
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2663,13 +2663,14 @@ Some types may inherit styles from parent types.
     * bgimg - standard background image. Defaults to none.
     * bgimg_hovered - background image when hovered. Defaults to bgimg when not provided.
     * bgimg_middle - Makes the bgimg textures render in 9-sliced mode and defines the middle rect.
-                     See background9[] documentation for more details
+                     See background9[] documentation for more details. This property also pads the
+                     button's content when set.
     * bgimg_pressed - background image when pressed. Defaults to bgimg when not provided.
     * border - boolean, draw border. Set to false to hide the bevelled button pane. Default true.
     * content_offset - 2d vector, shifts the position of the button's content without resizing it.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
-    * padding - rect, adds space between the edges of the button and the content. Defaults to
-                the same value as bgimg_middle.
+    * padding - rect, adds space between the edges of the button and the content. This value is
+                relative to bgimg_middle.
     * textcolor - color, default white.
 * checkbox
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.

--- a/games/minimal/mods/test/formspec.lua
+++ b/games/minimal/mods/test/formspec.lua
@@ -65,7 +65,7 @@ local style_fs = [[
 	style[one_btn13;border=false]
 	item_image_button[1.25,8.35;1,1;default:sword_steel;one_btn13;NoBor]
 
-	style[one_btn14;border=false;bgimg=test_bg.png;fgimg=bubble.png]
+	style[one_btn14;border=false;bgimg=test_bg.png;fgimg=bubble.png;padding=8]
 	style[one_btn14:hovered;bgimg=test_bg_hovered.png;fgimg=default_apple.png;textcolor=red]
 	style[one_btn14:pressed;bgimg=test_bg_pressed.png;fgimg=heart.png;textcolor=green]
 	style[one_btn14:hovered+pressed;textcolor=blue]
@@ -75,6 +75,7 @@ local style_fs = [[
 	item_image_button[1.25,9.6;1,1;default:sword_steel;one_btn15;Bg]
 
 	style[one_btn16;border=false;bgimg=test_bg_9slice.png;bgimg_hovered=test_bg_9slice_hovered.png;bgimg_pressed=test_bg_9slice_pressed.png;bgimg_middle=4,6]
+	style[one_btn16:pressed;content_offset=0,1]
 	button[2.5,9.6;2,1;one_btn16;9-Slice Bg]
 
 

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -44,6 +44,8 @@ public:
 		FGIMG_HOVERED, // Note: Deprecated property
 		FGIMG_PRESSED, // Note: Deprecated property
 		ALPHA,
+		CONTENT_OFFSET,
+		PADDING,
 		NUM_PROPERTIES,
 		NONE
 	};
@@ -92,6 +94,10 @@ public:
 			return FGIMG_PRESSED;
 		} else if (name == "alpha") {
 			return ALPHA;
+		} else if (name == "content_offset") {
+			return CONTENT_OFFSET;
+		} else if (name == "padding") {
+			return PADDING;
 		} else {
 			return NONE;
 		}
@@ -196,6 +202,29 @@ public:
 		return rect;
 	}
 
+	irr::core::vector2d<s32> getVector2i(Property prop, irr::core::vector2d<s32> def) const
+	{
+		const auto &val = properties[prop];
+		if (val.empty())
+			return def;
+
+		irr::core::vector2d<s32> vec;
+		if (!parseVector2i(val, &vec))
+			return def;
+
+		return vec;
+	}
+
+	irr::core::vector2d<s32> getVector2i(Property prop) const
+	{
+		const auto &val = properties[prop];
+		FATAL_ERROR_IF(val.empty(), "Unexpected missing property");
+
+		irr::core::vector2d<s32> vec;
+		parseVector2i(val, &vec);
+		return vec;
+	}
+
 	video::ITexture *getTexture(Property prop, ISimpleTextureSource *tsrc,
 			video::ITexture *def) const
 	{
@@ -283,6 +312,31 @@ private:
 		}
 
 		*parsed_rect = rect;
+
+		return true;
+	}
+
+	bool parseVector2i(const std::string &value, irr::core::vector2d<s32> *parsed_vec) const
+	{
+		irr::core::vector2d<s32> vec;
+		std::vector<std::string> v_vector = split(value, ',');
+
+		if (v_vector.size() == 1) {
+			s32 x = stoi(v_vector[0]);
+			vec.X = x;
+			vec.Y = x;
+		} else if (v_vector.size() == 2) {
+			s32 x = stoi(v_vector[0]);
+			s32 y =	stoi(v_vector[1]);
+			vec.X = x;
+			vec.Y = y;
+		} else {
+			warningstream << "Invalid vector2d string format: \"" << value
+					<< "\"" << std::endl;
+			return false;
+		}
+
+		*parsed_vec = vec;
 
 		return true;
 	}

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -804,7 +804,10 @@ void GUIButton::setFromStyle(const StyleSpec& style)
 	BgMiddle = style.getRect(StyleSpec::BGIMG_MIDDLE, BgMiddle);
 
 	// Child padding and offset
-	Padding = style.getRect(StyleSpec::PADDING, BgMiddle);
+	Padding = style.getRect(StyleSpec::PADDING, core::rect<s32>());
+	Padding = core::rect<s32>(
+			Padding.UpperLeftCorner + BgMiddle.UpperLeftCorner,
+			Padding.LowerRightCorner + BgMiddle.LowerRightCorner);
 
 	GUISkin* skin = dynamic_cast<GUISkin*>(Environment->getSkin());
 	core::vector2d<s32> defaultPressOffset(

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -592,25 +592,6 @@ void GUIButton::setPressed(bool pressed)
 	{
 		ClickTime = porting::getTimeMs();
 		Pressed = pressed;
-
-		GUISkin* skin = dynamic_cast<GUISkin*>(Environment->getSkin());
-
-		for(IGUIElement *child : getChildren())
-		{
-			core::rect<s32> originalRect = child->getRelativePosition();
-			if (Pressed) {
-				child->setRelativePosition(originalRect +
-						core::dimension2d<s32>(
-							skin->getSize(irr::gui::EGDS_BUTTON_PRESSED_IMAGE_OFFSET_X),
-							skin->getSize(irr::gui::EGDS_BUTTON_PRESSED_IMAGE_OFFSET_Y)));
-			} else {
-				child->setRelativePosition(originalRect -
-						core::dimension2d<s32>(
-							skin->getSize(irr::gui::EGDS_BUTTON_PRESSED_IMAGE_OFFSET_X),
-							skin->getSize(irr::gui::EGDS_BUTTON_PRESSED_IMAGE_OFFSET_Y)));
-			}
-		}
-
 		setFromState();
 	}
 }
@@ -819,7 +800,28 @@ void GUIButton::setFromStyle(const StyleSpec& style)
 	} else {
 		setImage(nullptr);
 	}
+
 	BgMiddle = style.getRect(StyleSpec::BGIMG_MIDDLE, BgMiddle);
+
+	// Child padding and offset
+	Padding = style.getRect(StyleSpec::PADDING, BgMiddle);
+
+	GUISkin* skin = dynamic_cast<GUISkin*>(Environment->getSkin());
+	core::vector2d<s32> defaultPressOffset(
+			skin->getSize(irr::gui::EGDS_BUTTON_PRESSED_IMAGE_OFFSET_X),
+			skin->getSize(irr::gui::EGDS_BUTTON_PRESSED_IMAGE_OFFSET_Y));
+	ContentOffset = style.getVector2i(StyleSpec::CONTENT_OFFSET, isPressed()
+			? defaultPressOffset
+			: core::vector2d<s32>(0));
+
+	core::rect<s32> childBounds(Padding.UpperLeftCorner + ContentOffset,
+			core::position2d<s32>(AbsoluteRect.getSize()) + ContentOffset
+			+ Padding.LowerRightCorner);
+
+	for(IGUIElement *child : getChildren())
+	{
+		child->setRelativePosition(childBounds);
+	}
 }
 
 //! Set the styles used for each state

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -820,8 +820,7 @@ void GUIButton::setFromStyle(const StyleSpec& style)
 				AbsoluteRect.getWidth() + Padding.LowerRightCorner.X + ContentOffset.X,
 				AbsoluteRect.getHeight() + Padding.LowerRightCorner.Y + ContentOffset.Y);
 
-	for(IGUIElement *child : getChildren())
-	{
+	for(IGUIElement *child : getChildren()) {
 		child->setRelativePosition(childBounds);
 	}
 }

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -814,9 +814,11 @@ void GUIButton::setFromStyle(const StyleSpec& style)
 			? defaultPressOffset
 			: core::vector2d<s32>(0));
 
-	core::rect<s32> childBounds(Padding.UpperLeftCorner + ContentOffset,
-			core::position2d<s32>(AbsoluteRect.getSize()) + ContentOffset
-			+ Padding.LowerRightCorner);
+	core::rect<s32> childBounds(
+				Padding.UpperLeftCorner.X + ContentOffset.X,
+				Padding.UpperLeftCorner.Y + ContentOffset.Y,
+				AbsoluteRect.getWidth() + Padding.LowerRightCorner.X + ContentOffset.X,
+				AbsoluteRect.getHeight() + Padding.LowerRightCorner.Y + ContentOffset.Y);
 
 	for(IGUIElement *child : getChildren())
 	{

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -820,7 +820,7 @@ void GUIButton::setFromStyle(const StyleSpec& style)
 				AbsoluteRect.getWidth() + Padding.LowerRightCorner.X + ContentOffset.X,
 				AbsoluteRect.getHeight() + Padding.LowerRightCorner.Y + ContentOffset.Y);
 
-	for(IGUIElement *child : getChildren()) {
+	for (IGUIElement *child : getChildren()) {
 		child->setRelativePosition(childBounds);
 	}
 }

--- a/src/gui/guiButton.h
+++ b/src/gui/guiButton.h
@@ -336,5 +336,7 @@ private:
 	gui::IGUIStaticText *StaticText;
 
 	core::rect<s32> BgMiddle;
+	core::rect<s32> Padding;
+	core::vector2d<s32> ContentOffset;
 	// END PATCH
 };


### PR DESCRIPTION
Part of #9044, and resolves #9615.

This PR adds 2 new style properties for button formspec elements (`button`, `image_button`, and `item_image_button`):

- `padding` (rect): Adds padding between the button's content and its borders. Defaults to `bgimg_middle` for a good-looking default when using 9-slice background textures.
- `content_offset` (vector2d): Moves the button's content without resizing. This allows buttons to easily override the default 1px movement when pressed so that content follows the background consistently.

## How to test

I've attached a test mod with some examples of how the properties can be used:  [test_pad_offset.zip](https://github.com/minetest/minetest/files/4471886/test_pad_offset.zip)
It would also be worthwhile to test the default behavior with existing 5.2 mods that use `bgimg_middle`.