### PR TITLE
Collision information for Lua entities

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -16,6 +16,7 @@ core.features = {
 	formspec_version_element = true,
 	area_store_persistent_ids = true,
 	pathfinder_works = true,
+	object_step_has_moveresult = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -34,7 +34,6 @@ core.register_entity(":__builtin:item", {
 
 	itemstring = "",
 	moving_state = true,
-	slippery_state = false,
 	physical_state = true,
 	-- Item expiry
 	age = 0,
@@ -157,7 +156,7 @@ core.register_entity(":__builtin:item", {
 		end
 	end,
 
-	on_step = function(self, dtime)
+	on_step = function(self, dtime, moveresult)
 		self.age = self.age + dtime
 		if time_to_live > 0 and self.age > time_to_live then
 			self.itemstring = ""
@@ -178,6 +177,36 @@ core.register_entity(":__builtin:item", {
 			return
 		end
 
+		if self.force_out then
+			-- This code runs after the entity got a push from the is_stuck code.
+			-- It makes sure the entity is entirely outside the solid node
+			local c = self.object:get_properties().collisionbox
+			local s = self.force_out_start
+			local f = self.force_out
+			local ok = (f.x > 0 and pos.x + c[1] > s.x + 0.5) or
+				(f.y > 0 and pos.y + c[2] > s.y + 0.5) or
+				(f.z > 0 and pos.z + c[3] > s.z + 0.5) or
+				(f.x < 0 and pos.x + c[4] < s.x - 0.5) or
+				(f.z < 0 and pos.z + c[6] < s.z - 0.5)
+			if ok then
+				-- Item was successfully forced out
+				self.force_out = nil
+				self:enable_physics()
+				return
+			end
+		end
+
+		if not self.physical_state then
+			return -- Don't do anything
+		end
+
+		assert(moveresult)
+		if not moveresult.collides then
+			-- future TODO: items should probably decelerate in air
+			return
+		end
+
+		-- Push item out when stuck inside solid node
 		local is_stuck = false
 		local snode = core.get_node_or_nil(pos)
 		if snode then
@@ -187,7 +216,6 @@ core.register_entity(":__builtin:item", {
 				and (sdef.node_box == nil or sdef.node_box.type == "regular")
 		end
 
-		-- Push item out when stuck inside solid node
 		if is_stuck then
 			local shootdir
 			local order = {
@@ -223,69 +251,49 @@ core.register_entity(":__builtin:item", {
 				self.force_out_start = vector.round(pos)
 				return
 			end
-		elseif self.force_out then
-			-- This code runs after the entity got a push from the above code.
-			-- It makes sure the entity is entirely outside the solid node
-			local c = self.object:get_properties().collisionbox
-			local s = self.force_out_start
-			local f = self.force_out
-			local ok = (f.x > 0 and pos.x + c[1] > s.x + 0.5) or
-				(f.y > 0 and pos.y + c[2] > s.y + 0.5) or
-				(f.z > 0 and pos.z + c[3] > s.z + 0.5) or
-				(f.x < 0 and pos.x + c[4] < s.x - 0.5) or
-				(f.z < 0 and pos.z + c[6] < s.z - 0.5)
-			if ok then
-				-- Item was successfully forced out
-				self.force_out = nil
-				self:enable_physics()
-			end
 		end
 
-		if not self.physical_state then
-			return -- Don't do anything
+		node = nil -- ground node we're colliding with
+		if moveresult.touching_ground then
+			for _, info in ipairs(moveresult.collisions) do
+				if info.axis == "y" then
+					node = core.get_node(info.node_pos)
+					break
+				end
+			end
 		end
 
 		-- Slide on slippery nodes
-		local vel = self.object:get_velocity()
 		local def = node and core.registered_nodes[node.name]
-		local is_moving = (def and not def.walkable) or
-			vel.x ~= 0 or vel.y ~= 0 or vel.z ~= 0
-		local is_slippery = false
+		local keep_movement = false
 
-		if def and def.walkable then
+		if def then
 			local slippery = core.get_item_group(node.name, "slippery")
-			is_slippery = slippery ~= 0
-			if is_slippery and (math.abs(vel.x) > 0.2 or math.abs(vel.z) > 0.2) then
+			local vel = self.object:get_velocity()
+			if slippery ~= 0 and (math.abs(vel.x) > 0.1 or math.abs(vel.z) > 0.1) then
 				-- Horizontal deceleration
-				local slip_factor = 4.0 / (slippery + 4)
-				self.object:set_acceleration({
-					x = -vel.x * slip_factor,
+				local factor = math.min(4 / (slippery + 4) * dtime, 1)
+				self.object:set_velocity({
+					x = vel.x * (1 - factor),
 					y = 0,
-					z = -vel.z * slip_factor
+					z = vel.z * (1 - factor)
 				})
-			elseif vel.y == 0 then
-				is_moving = false
+				keep_movement = true
 			end
 		end
 
-		if self.moving_state == is_moving and
-				self.slippery_state == is_slippery then
+		if not keep_movement then
+			self.object:set_velocity({x=0, y=0, z=0})
+		end
+
+		if self.moving_state == keep_movement then
 			-- Do not update anything until the moving state changes
 			return
 		end
+		self.moving_state = keep_movement
 
-		self.moving_state = is_moving
-		self.slippery_state = is_slippery
-
-		if is_moving then
-			self.object:set_acceleration({x = 0, y = -gravity, z = 0})
-		else
-			self.object:set_acceleration({x = 0, y = 0, z = 0})
-			self.object:set_velocity({x = 0, y = 0, z = 0})
-		end
-
-		--Only collect items if not moving
-		if is_moving then
+		-- Only collect items if not moving
+		if self.moving_state then
 			return
 		end
 		-- Collect the items around to merge with

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4147,6 +4147,8 @@ Utilities
           area_store_persistent_ids = true,
           -- Whether minetest.find_path is functional (5.2.0)
           pathfinder_works = true,
+          -- Whether Collision info is available to an objects' on_step (5.3.0)
+          object_step_has_moveresult = true,
       }
 
 * `minetest.has_feature(arg)`: returns `boolean, missing_features`
@@ -6579,7 +6581,10 @@ Used by `minetest.register_entity`.
 
         on_activate = function(self, staticdata, dtime_s),
 
-        on_step = function(self, dtime),
+        on_step = function(self, dtime, moveresult),
+        -- Called every server step
+        -- dtime: Elapsed time
+        -- moveresult: Table with collision info (only available if physical=true)
 
         on_punch = function(self, puncher, time_from_last_punch, tool_capabilities, dir),
 
@@ -6592,6 +6597,24 @@ Used by `minetest.register_entity`.
         _custom_field = whatever,
         -- You can define arbitrary member variables here (see Item definition
         -- for more info) by using a '_' prefix
+    }
+
+Collision info passed to `on_step`:
+
+    {
+        touching_ground = boolean,
+        collides = boolean,
+        standing_on_object = boolean,
+        collisions = {
+            {
+                type = string, -- "node" or "object",
+                axis = string, -- "x", "y" or "z"
+                node_pos = vector, -- if type is "node"
+                old_speed = vector,
+                new_speed = vector,
+            },
+            ...
+        }
     }
 
 ABM (ActiveBlockModifier) definition

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_types.h"
 #include "nodedef.h"
 #include "object_properties.h"
+#include "collision.h"
 #include "cpp_api/s_node.h"
 #include "lua_api/l_object.h"
 #include "lua_api/l_item.h"
@@ -1989,4 +1990,57 @@ HudElementStat read_hud_change(lua_State *L, HudElement *elem, void **value)
 			break;
 	}
 	return stat;
+}
+
+/******************************************************************************/
+
+// Indices must match values in `enum CollisionType` exactly!!
+static const char *collision_type_str[] = {
+	"node",
+	"object",
+};
+
+// Indices must match values in `enum CollisionAxis` exactly!!
+static const char *collision_axis_str[] = {
+	"x",
+	"y",
+	"z",
+};
+
+void push_collision_move_result(lua_State *L, const collisionMoveResult &res)
+{
+	lua_createtable(L, 0, 4);
+
+	setboolfield(L, -1, "touching_ground", res.touching_ground);
+	setboolfield(L, -1, "collides", res.collides);
+	setboolfield(L, -1, "standing_on_object", res.standing_on_object);
+
+	/* collisions */
+	lua_createtable(L, res.collisions.size(), 0);
+	int i = 1;
+	for (const auto &c : res.collisions) {
+		lua_createtable(L, 0, 5);
+
+		lua_pushstring(L, collision_type_str[c.type]);
+		lua_setfield(L, -2, "type");
+
+		assert(c.axis != COLLISION_AXIS_NONE);
+		lua_pushstring(L, collision_axis_str[c.axis]);
+		lua_setfield(L, -2, "axis");
+
+		if (c.type == COLLISION_NODE) {
+			push_v3s16(L, c.node_p);
+			lua_setfield(L, -2, "node_pos");
+		}
+
+		push_v3f(L, c.old_speed / BS);
+		lua_setfield(L, -2, "old_speed");
+
+		push_v3f(L, c.new_speed / BS);
+		lua_setfield(L, -2, "new_speed");
+
+		lua_rawseti(L, -2, i++);
+	}
+	lua_setfield(L, -2, "collisions");
+	/**/
 }

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -63,7 +63,9 @@ struct EnumString;
 struct NoiseParams;
 class Schematic;
 class ServerActiveObject;
+struct collisionMoveResult;
 
+extern struct EnumString es_TileAnimationType[];
 
 ContentFeatures    read_content_features     (lua_State *L, int index);
 void               push_content_features     (lua_State *L,
@@ -196,4 +198,4 @@ void               push_hud_element          (lua_State *L, HudElement *elem);
 
 HudElementStat     read_hud_change           (lua_State *L, HudElement *elem, void **value);
 
-extern struct EnumString es_TileAnimationType[];
+void               push_collision_move_result(lua_State *L, const collisionMoveResult &res);

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -178,11 +178,10 @@ void ScriptApiEntity::luaentity_GetProperties(u16 id,
 	lua_pop(L, 1);
 }
 
-void ScriptApiEntity::luaentity_Step(u16 id, float dtime)
+void ScriptApiEntity::luaentity_Step(u16 id, float dtime,
+	const collisionMoveResult *moveresult)
 {
 	SCRIPTAPI_PRECHECKHEADER
-
-	//infostream<<"scriptapi_luaentity_step: id="<<id<<std::endl;
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
@@ -199,9 +198,14 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime)
 	luaL_checktype(L, -1, LUA_TFUNCTION);
 	lua_pushvalue(L, object); // self
 	lua_pushnumber(L, dtime); // dtime
+	/* moveresult */
+	if (moveresult)
+		push_collision_move_result(L, *moveresult);
+	else
+		lua_pushnil(L);
 
 	setOriginFromTable(object);
-	PCALL_RES(lua_pcall(L, 2, 0, error_handler));
+	PCALL_RES(lua_pcall(L, 3, 0, error_handler));
 
 	lua_pop(L, 2); // Pop object and error handler
 }

--- a/src/script/cpp_api/s_entity.h
+++ b/src/script/cpp_api/s_entity.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 struct ObjectProperties;
 struct ToolCapabilities;
+struct collisionMoveResult;
 
 class ScriptApiEntity
 		: virtual public ScriptApiBase
@@ -36,7 +37,8 @@ public:
 	std::string luaentity_GetStaticdata(u16 id);
 	void luaentity_GetProperties(u16 id,
 			ServerActiveObject *self, ObjectProperties *prop);
-	void luaentity_Step(u16 id, float dtime);
+	void luaentity_Step(u16 id, float dtime,
+		const collisionMoveResult *moveresult);
 	bool luaentity_Punch(u16 id,
 			ServerActiveObject *puncher, float time_from_last_punch,
 			const ToolCapabilities *toolcap, v3f dir, s16 damage);

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -135,6 +135,8 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 
 	m_last_sent_position_timer += dtime;
 
+	collisionMoveResult moveresult, *moveresult_p = nullptr;
+
 	// Each frame, parent position is copied if the object is attached, otherwise it's calculated normally
 	// If the object gets detached this comes into effect automatically from the last known origin
 	if(isAttached())
@@ -150,7 +152,6 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 			aabb3f box = m_prop.collisionbox;
 			box.MinEdge *= BS;
 			box.MaxEdge *= BS;
-			collisionMoveResult moveresult;
 			f32 pos_max_d = BS*0.25; // Distance per iteration
 			v3f p_pos = m_base_position;
 			v3f p_velocity = m_velocity;
@@ -159,6 +160,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 					pos_max_d, box, m_prop.stepheight, dtime,
 					&p_pos, &p_velocity, p_acceleration,
 					this, m_prop.collideWithObjects);
+			moveresult_p = &moveresult;
 
 			// Apply results
 			m_base_position = p_pos;
@@ -188,8 +190,8 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		}
 	}
 
-	if(m_registered){
-		m_env->getScriptIface()->luaentity_Step(m_id, dtime);
+	if(m_registered) {
+		m_env->getScriptIface()->luaentity_Step(m_id, dtime, moveresult_p);
 	}
 
 	if (!send_recommended)


### PR DESCRIPTION
<b>don't squash</b>
The builtin item entity is no longer forced to implement buggy "collision" detection & handling on its own.

## To do

This PR is a Ready for Review.

## How to test

Test the things item entities usually do.
Test that #8967 is fixed.