### PR TITLE
scriptapi: Some small optimizations to value pushing

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -350,7 +350,7 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	push_v3f(L, prop->visual_size);
 	lua_setfield(L, -2, "visual_size");
 
-	lua_newtable(L);
+	lua_createtable(L, prop->textures.size(), 0);
 	u16 i = 1;
 	for (const std::string &texture : prop->textures) {
 		lua_pushlstring(L, texture.c_str(), texture.size());
@@ -358,7 +358,7 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	}
 	lua_setfield(L, -2, "textures");
 
-	lua_newtable(L);
+	lua_createtable(L, prop->colors.size(), 0);
 	i = 1;
 	for (const video::SColor &color : prop->colors) {
 		push_ARGB8(L, color);
@@ -840,7 +840,7 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 	lua_pushnumber(L, c.connect_sides);
 	lua_setfield(L, -2, "connect_sides");
 
-	lua_newtable(L);
+	lua_createtable(L, c.connects_to.size(), 0);
 	u16 i = 1;
 	for (const std::string &it : c.connects_to) {
 		lua_pushlstring(L, it.c_str(), it.size());
@@ -963,7 +963,7 @@ void push_nodebox(lua_State *L, const NodeBox &box)
 
 void push_box(lua_State *L, const std::vector<aabb3f> &box)
 {
-	lua_newtable(L);
+	lua_createtable(L, box.size(), 0);
 	u8 i = 1;
 	for (const aabb3f &it : box) {
 		push_aabb3f(L, it);
@@ -1040,7 +1040,7 @@ void read_soundspec(lua_State *L, int index, SimpleSoundSpec &spec)
 
 void push_soundspec(lua_State *L, const SimpleSoundSpec &spec)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, 3);
 	lua_pushstring(L, spec.name.c_str());
 	lua_setfield(L, -2, "name");
 	lua_pushnumber(L, spec.gain);
@@ -1125,12 +1125,12 @@ MapNode readnode(lua_State *L, int index, const NodeDefManager *ndef)
 /******************************************************************************/
 void pushnode(lua_State *L, const MapNode &n, const NodeDefManager *ndef)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, 3);
 	lua_pushstring(L, ndef->get(n).name.c_str());
 	lua_setfield(L, -2, "name");
-	lua_pushnumber(L, n.getParam1());
+	lua_pushinteger(L, n.getParam1());
 	lua_setfield(L, -2, "param1");
-	lua_pushnumber(L, n.getParam2());
+	lua_pushinteger(L, n.getParam2());
 	lua_setfield(L, -2, "param2");
 }
 
@@ -1163,7 +1163,7 @@ bool string_to_enum(const EnumString *spec, int &result,
 {
 	const EnumString *esp = spec;
 	while(esp->str){
-		if(str == std::string(esp->str)){
+		if (!strcmp(str.c_str(), esp->str)) {
 			result = esp->num;
 			return true;
 		}
@@ -1438,7 +1438,7 @@ ToolCapabilities read_tool_capabilities(
 /******************************************************************************/
 void push_dig_params(lua_State *L,const DigParams &params)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, 3);
 	setboolfield(L, -1, "diggable", params.diggable);
 	setfloatfield(L, -1, "time", params.time);
 	setintfield(L, -1, "wear", params.wear);
@@ -1447,7 +1447,7 @@ void push_dig_params(lua_State *L,const DigParams &params)
 /******************************************************************************/
 void push_hit_params(lua_State *L,const HitParams &params)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, 3);
 	setintfield(L, -1, "hp", params.hp);
 	setintfield(L, -1, "wear", params.wear);
 }
@@ -1540,9 +1540,9 @@ void read_groups(lua_State *L, int index, ItemGroupList &result)
 /******************************************************************************/
 void push_groups(lua_State *L, const ItemGroupList &groups)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, groups.size());
 	for (const auto &group : groups) {
-		lua_pushnumber(L, group.second);
+		lua_pushinteger(L, group.second);
 		lua_setfield(L, -2, group.first.c_str());
 	}
 }
@@ -1587,7 +1587,7 @@ void luaentity_get(lua_State *L, u16 id)
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "luaentities");
 	luaL_checktype(L, -1, LUA_TTABLE);
-	lua_pushnumber(L, id);
+	lua_pushinteger(L, id);
 	lua_gettable(L, -2);
 	lua_remove(L, -2); // Remove luaentities
 	lua_remove(L, -2); // Remove core
@@ -1689,7 +1689,7 @@ static bool push_json_value_helper(lua_State *L, const Json::Value &value,
 			lua_pushboolean(L, value.asInt());
 			break;
 		case Json::arrayValue:
-			lua_newtable(L);
+			lua_createtable(L, value.size(), 0);
 			for (Json::Value::const_iterator it = value.begin();
 					it != value.end(); ++it) {
 				push_json_value_helper(L, *it, nullindex);
@@ -1697,7 +1697,7 @@ static bool push_json_value_helper(lua_State *L, const Json::Value &value,
 			}
 			break;
 		case Json::objectValue:
-			lua_newtable(L);
+			lua_createtable(L, 0, value.size());
 			for (Json::Value::const_iterator it = value.begin();
 					it != value.end(); ++it) {
 #ifndef JSONCPP_STRING
@@ -1824,7 +1824,7 @@ void push_objectRef(lua_State *L, const u16 id)
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "object_refs");
 	luaL_checktype(L, -1, LUA_TTABLE);
-	lua_pushnumber(L, id);
+	lua_pushinteger(L, id);
 	lua_gettable(L, -2);
 	lua_remove(L, -2); // object_refs
 	lua_remove(L, -2); // core

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -62,7 +62,7 @@ void push_float_string(lua_State *L, float value)
 
 void push_v3f(lua_State *L, v3f p)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, 3);
 	lua_pushnumber(L, p.X);
 	lua_setfield(L, -2, "x");
 	lua_pushnumber(L, p.Y);
@@ -73,7 +73,7 @@ void push_v3f(lua_State *L, v3f p)
 
 void push_v2f(lua_State *L, v2f p)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, 2);
 	lua_pushnumber(L, p.X);
 	lua_setfield(L, -2, "x");
 	lua_pushnumber(L, p.Y);
@@ -82,7 +82,7 @@ void push_v2f(lua_State *L, v2f p)
 
 void push_v3_float_string(lua_State *L, v3f p)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, 3);
 	push_float_string(L, p.X);
 	lua_setfield(L, -2, "x");
 	push_float_string(L, p.Y);
@@ -93,7 +93,7 @@ void push_v3_float_string(lua_State *L, v3f p)
 
 void push_v2_float_string(lua_State *L, v2f p)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, 2);
 	push_float_string(L, p.X);
 	lua_setfield(L, -2, "x");
 	push_float_string(L, p.Y);
@@ -115,19 +115,19 @@ v2s16 read_v2s16(lua_State *L, int index)
 
 void push_v2s16(lua_State *L, v2s16 p)
 {
-	lua_newtable(L);
-	lua_pushnumber(L, p.X);
+	lua_createtable(L, 0, 2);
+	lua_pushinteger(L, p.X);
 	lua_setfield(L, -2, "x");
-	lua_pushnumber(L, p.Y);
+	lua_pushinteger(L, p.Y);
 	lua_setfield(L, -2, "y");
 }
 
 void push_v2s32(lua_State *L, v2s32 p)
 {
-	lua_newtable(L);
-	lua_pushnumber(L, p.X);
+	lua_createtable(L, 0, 2);
+	lua_pushinteger(L, p.X);
 	lua_setfield(L, -2, "x");
-	lua_pushnumber(L, p.Y);
+	lua_pushinteger(L, p.Y);
 	lua_setfield(L, -2, "y");
 }
 
@@ -250,14 +250,14 @@ v3d check_v3d(lua_State *L, int index)
 
 void push_ARGB8(lua_State *L, video::SColor color)
 {
-	lua_newtable(L);
-	lua_pushnumber(L, color.getAlpha());
+	lua_createtable(L, 0, 4);
+	lua_pushinteger(L, color.getAlpha());
 	lua_setfield(L, -2, "a");
-	lua_pushnumber(L, color.getRed());
+	lua_pushinteger(L, color.getRed());
 	lua_setfield(L, -2, "r");
-	lua_pushnumber(L, color.getGreen());
+	lua_pushinteger(L, color.getGreen());
 	lua_setfield(L, -2, "g");
-	lua_pushnumber(L, color.getBlue());
+	lua_pushinteger(L, color.getBlue());
 	lua_setfield(L, -2, "b");
 }
 
@@ -274,12 +274,12 @@ v3f checkFloatPos(lua_State *L, int index)
 
 void push_v3s16(lua_State *L, v3s16 p)
 {
-	lua_newtable(L);
-	lua_pushnumber(L, p.X);
+	lua_createtable(L, 0, 3);
+	lua_pushinteger(L, p.X);
 	lua_setfield(L, -2, "x");
-	lua_pushnumber(L, p.Y);
+	lua_pushinteger(L, p.Y);
 	lua_setfield(L, -2, "y");
-	lua_pushnumber(L, p.Z);
+	lua_pushinteger(L, p.Z);
 	lua_setfield(L, -2, "z");
 }
 
@@ -386,7 +386,7 @@ aabb3f read_aabb3f(lua_State *L, int index, f32 scale)
 
 void push_aabb3f(lua_State *L, aabb3f box)
 {
-	lua_newtable(L);
+	lua_createtable(L, 6, 0);
 	lua_pushnumber(L, box.MinEdge.X);
 	lua_rawseti(L, -2, 1);
 	lua_pushnumber(L, box.MinEdge.Y);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -73,7 +73,7 @@ void LuaABM::trigger(ServerEnvironment *env, v3s16 p, MapNode n,
 	lua_remove(L, -2); // Remove core
 
 	// Get registered_abms[m_id]
-	lua_pushnumber(L, m_id);
+	lua_pushinteger(L, m_id);
 	lua_gettable(L, -2);
 	if(lua_isnil(L, -1))
 		FATAL_ERROR("");
@@ -116,7 +116,7 @@ void LuaLBM::trigger(ServerEnvironment *env, v3s16 p, MapNode n)
 	lua_remove(L, -2); // Remove core
 
 	// Get registered_lbms[m_id]
-	lua_pushnumber(L, m_id);
+	lua_pushinteger(L, m_id);
 	lua_gettable(L, -2);
 	FATAL_ERROR_IF(lua_isnil(L, -1), "Entry with given id not found in registered_lbms table");
 	lua_remove(L, -2); // Remove registered_lbms
@@ -550,7 +550,7 @@ int ModApiEnvMod::l_find_nodes_with_meta(lua_State *L)
 	std::vector<v3s16> positions = env->getMap().findNodesWithMetadata(
 		check_v3s16(L, 1), check_v3s16(L, 2));
 
-	lua_newtable(L);
+	lua_createtable(L, positions.size(), 0);
 	for (size_t i = 0; i != positions.size(); i++) {
 		push_v3s16(L, positions[i]);
 		lua_rawseti(L, -2, i + 1);
@@ -1197,7 +1197,7 @@ int ModApiEnvMod::l_find_path(lua_State *L)
 		searchdistance, max_jump, max_drop, algo);
 
 	if (!path.empty()) {
-		lua_newtable(L);
+		lua_createtable(L, path.size(), 0);
 		int top = lua_gettop(L);
 		unsigned int index = 1;
 		for (const v3s16 &i : path) {

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -710,7 +710,7 @@ int ModApiMapgen::l_get_mapgen_object(lua_State *L)
 		if (!mg->heightmap)
 			return 0;
 
-		lua_newtable(L);
+		lua_createtable(L, maplen, 0);
 		for (size_t i = 0; i != maplen; i++) {
 			lua_pushinteger(L, mg->heightmap[i]);
 			lua_rawseti(L, -2, i + 1);
@@ -722,7 +722,7 @@ int ModApiMapgen::l_get_mapgen_object(lua_State *L)
 		if (!mg->biomegen)
 			return 0;
 
-		lua_newtable(L);
+		lua_createtable(L, maplen, 0);
 		for (size_t i = 0; i != maplen; i++) {
 			lua_pushinteger(L, mg->biomegen->biomemap[i]);
 			lua_rawseti(L, -2, i + 1);
@@ -736,7 +736,7 @@ int ModApiMapgen::l_get_mapgen_object(lua_State *L)
 
 		BiomeGenOriginal *bg = (BiomeGenOriginal *)mg->biomegen;
 
-		lua_newtable(L);
+		lua_createtable(L, maplen, 0);
 		for (size_t i = 0; i != maplen; i++) {
 			lua_pushnumber(L, bg->heatmap[i]);
 			lua_rawseti(L, -2, i + 1);
@@ -751,7 +751,7 @@ int ModApiMapgen::l_get_mapgen_object(lua_State *L)
 
 		BiomeGenOriginal *bg = (BiomeGenOriginal *)mg->biomegen;
 
-		lua_newtable(L);
+		lua_createtable(L, maplen, 0);
 		for (size_t i = 0; i != maplen; i++) {
 			lua_pushnumber(L, bg->humidmap[i]);
 			lua_rawseti(L, -2, i + 1);
@@ -761,13 +761,12 @@ int ModApiMapgen::l_get_mapgen_object(lua_State *L)
 	}
 	case MGOBJ_GENNOTIFY: {
 		std::map<std::string, std::vector<v3s16> >event_map;
-		std::map<std::string, std::vector<v3s16> >::iterator it;
 
 		mg->gennotify.getEvents(event_map);
 
-		lua_newtable(L);
-		for (it = event_map.begin(); it != event_map.end(); ++it) {
-			lua_newtable(L);
+		lua_createtable(L, 0, event_map.size());
+		for (auto it = event_map.begin(); it != event_map.end(); ++it) {
+			lua_createtable(L, it->second.size(), 0);
 
 			for (size_t j = 0; j != it->second.size(); j++) {
 				push_v3s16(L, it->second[j]);

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -171,9 +171,9 @@ int LuaPerlinNoiseMap::l_get_2d_map(lua_State *L)
 	Noise *n = o->noise;
 	n->perlinMap2D(p.X, p.Y);
 
-	lua_newtable(L);
+	lua_createtable(L, n->sy, 0);
 	for (u32 y = 0; y != n->sy; y++) {
-		lua_newtable(L);
+		lua_createtable(L, n->sx, 0);
 		for (u32 x = 0; x != n->sx; x++) {
 			lua_pushnumber(L, n->result[i++]);
 			lua_rawseti(L, -2, x + 1);
@@ -200,7 +200,7 @@ int LuaPerlinNoiseMap::l_get_2d_map_flat(lua_State *L)
 	if (use_buffer)
 		lua_pushvalue(L, 3);
 	else
-		lua_newtable(L);
+		lua_createtable(L, maplen, 0);
 
 	for (size_t i = 0; i != maplen; i++) {
 		lua_pushnumber(L, n->result[i]);
@@ -224,11 +224,11 @@ int LuaPerlinNoiseMap::l_get_3d_map(lua_State *L)
 	Noise *n = o->noise;
 	n->perlinMap3D(p.X, p.Y, p.Z);
 
-	lua_newtable(L);
+	lua_createtable(L, n->sz, 0);
 	for (u32 z = 0; z != n->sz; z++) {
-		lua_newtable(L);
+		lua_createtable(L, n->sy, 0);
 		for (u32 y = 0; y != n->sy; y++) {
-			lua_newtable(L);
+			lua_createtable(L, n->sx, 0);
 			for (u32 x = 0; x != n->sx; x++) {
 				lua_pushnumber(L, n->result[i++]);
 				lua_rawseti(L, -2, x + 1);
@@ -260,7 +260,7 @@ int LuaPerlinNoiseMap::l_get_3d_map_flat(lua_State *L)
 	if (use_buffer)
 		lua_pushvalue(L, 3);
 	else
-		lua_newtable(L);
+		lua_createtable(L, maplen, 0);
 
 	for (size_t i = 0; i != maplen; i++) {
 		lua_pushnumber(L, n->result[i]);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -123,14 +123,7 @@ int ObjectRef::l_get_pos(lua_State *L)
 	ObjectRef *ref = checkobject(L, 1);
 	ServerActiveObject *co = getobject(ref);
 	if (co == NULL) return 0;
-	v3f pos = co->getBasePosition() / BS;
-	lua_newtable(L);
-	lua_pushnumber(L, pos.X);
-	lua_setfield(L, -2, "x");
-	lua_pushnumber(L, pos.Y);
-	lua_setfield(L, -2, "y");
-	lua_pushnumber(L, pos.Z);
-	lua_setfield(L, -2, "z");
+	push_v3f(L, co->getBasePosition() / BS);
 	return 1;
 }
 

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -72,7 +72,7 @@ int LuaVoxelManip::l_get_data(lua_State *L)
 	if (use_buffer)
 		lua_pushvalue(L, 2);
 	else
-		lua_newtable(L);
+		lua_createtable(L, volume, 0);
 
 	for (u32 i = 0; i != volume; i++) {
 		lua_Integer cid = vm->m_data[i].getContent();
@@ -261,7 +261,7 @@ int LuaVoxelManip::l_get_light_data(lua_State *L)
 
 	u32 volume = vm->m_area.getVolume();
 
-	lua_newtable(L);
+	lua_createtable(L, volume, 0);
 	for (u32 i = 0; i != volume; i++) {
 		lua_Integer light = vm->m_data[i].param1;
 		lua_pushinteger(L, light);
@@ -309,7 +309,7 @@ int LuaVoxelManip::l_get_param2_data(lua_State *L)
 	if (use_buffer)
 		lua_pushvalue(L, 2);
 	else
-		lua_newtable(L);
+		lua_createtable(L, volume, 0);
 
 	for (u32 i = 0; i != volume; i++) {
 		lua_Integer param2 = vm->m_data[i].param2;


### PR DESCRIPTION
- Use `lua_createtable` wherever useful <i>(1)</i>
- Use `lua_pushinteger` to push integer values <i>(2)</i>

<i>(1)</i>: From https://pgl.yoyo.org/luai/i/lua_createtable
<pre>Creates a new empty table and pushes it onto the stack. The new table has space pre-allocated
for narr array elements and nrec non-array elements. This pre-allocation is useful when you
know exactly how many elements the table will have. Otherwise you can use the function
lua_newtable.</pre>

<i>(2)</i>: This is only theoretically useful since Lua internally casts these to floats anyway. LuaJIT might(?) have a feature that allows real integers.

## To do

This PR is Ready for Review.

