### PR TITLE
Optimize get_objects_inside_radius calls

### DIFF
--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -681,22 +681,22 @@ int ModApiEnvMod::l_get_player_by_name(lua_State *L)
 int ModApiEnvMod::l_get_objects_inside_radius(lua_State *L)
 {
 	GET_ENV_PTR;
+	ScriptApiBase *script = getScriptApiBase(L);
 
 	// Do it
 	v3f pos = checkFloatPos(L, 1);
 	float radius = readParam<float>(L, 2) * BS;
-	std::vector<u16> ids;
-	env->getObjectsInsideRadius(ids, pos, radius);
-	ScriptApiBase *script = getScriptApiBase(L);
-	lua_createtable(L, ids.size(), 0);
-	std::vector<u16>::const_iterator iter = ids.begin();
-	for(u32 i = 0; iter != ids.end(); ++iter) {
-		ServerActiveObject *obj = env->getActiveObject(*iter);
-		if (!obj->isGone()) {
-			// Insert object reference into table
-			script->objectrefGetOrCreate(L, obj);
-			lua_rawseti(L, -2, ++i);
-		}
+	std::vector<ServerActiveObject *> objs;
+
+	auto includeObjCallback = [](ServerActiveObject *obj){ return !obj->isGone(); };
+	env->getObjectsInsideRadius(objs, pos, radius, includeObjCallback);
+
+	int i = 0;
+	lua_createtable(L, objs.size(), 0);
+	for (const auto obj : objs) {
+		// Insert object reference into table
+		script->objectrefGetOrCreate(L, obj);
+		lua_rawseti(L, -2, ++i);
 	}
 	return 1;
 }

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -688,8 +688,8 @@ int ModApiEnvMod::l_get_objects_inside_radius(lua_State *L)
 	float radius = readParam<float>(L, 2) * BS;
 	std::vector<ServerActiveObject *> objs;
 
-	auto includeObjCallback = [](ServerActiveObject *obj){ return !obj->isGone(); };
-	env->getObjectsInsideRadius(objs, pos, radius, includeObjCallback);
+	auto include_obj_cb = [](ServerActiveObject *obj){ return !obj->isGone(); };
+	env->getObjectsInsideRadius(objs, pos, radius, include_obj_cb);
 
 	int i = 0;
 	lua_createtable(L, objs.size(), 0);

--- a/src/server/activeobjectmgr.cpp
+++ b/src/server/activeobjectmgr.cpp
@@ -111,17 +111,19 @@ void ActiveObjectMgr::removeObject(u16 id)
 }
 
 // clang-format on
-void ActiveObjectMgr::getObjectsInsideRadius(
-		const v3f &pos, float radius, std::vector<u16> &result)
+void ActiveObjectMgr::getObjectsInsideRadius(const v3f &pos, float radius,
+		std::vector<ServerActiveObject *> &result,
+		std::function<bool(ServerActiveObject *obj)> include_obj_cb)
 {
 	float r2 = radius * radius;
 	for (auto &activeObject : m_active_objects) {
 		ServerActiveObject *obj = activeObject.second;
-		u16 id = activeObject.first;
 		const v3f &objectpos = obj->getBasePosition();
 		if (objectpos.getDistanceFromSQ(pos) > r2)
 			continue;
-		result.push_back(id);
+
+		if (!include_obj_cb || include_obj_cb(obj))
+			result.push_back(obj);
 	}
 }
 

--- a/src/server/activeobjectmgr.h
+++ b/src/server/activeobjectmgr.h
@@ -35,8 +35,9 @@ public:
 	bool registerObject(ServerActiveObject *obj) override;
 	void removeObject(u16 id) override;
 
-	void getObjectsInsideRadius(
-			const v3f &pos, float radius, std::vector<u16> &result);
+	void getObjectsInsideRadius(const v3f &pos, float radius,
+			std::vector<ServerActiveObject *> &result,
+			std::function<bool(ServerActiveObject *obj)> include_obj_cb);
 
 	void getAddedActiveObjectsAroundPos(const v3f &player_pos, f32 radius,
 			f32 player_radius, std::set<u16> &current_objects,

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1603,14 +1603,12 @@ void ServerEnvironment::getSelectedActiveObjects(
 	const core::line3d<f32> &shootline_on_map,
 	std::vector<PointedThing> &objects)
 {
-	std::vector<u16> objectIds;
-	getObjectsInsideRadius(objectIds, shootline_on_map.start,
-		shootline_on_map.getLength() + 10.0f);
+	std::vector<ServerActiveObject *> objs;
+	getObjectsInsideRadius(objs, shootline_on_map.start,
+		shootline_on_map.getLength() + 10.0f, nullptr);
 	const v3f line_vector = shootline_on_map.getVector();
 
-	for (u16 objectId : objectIds) {
-		ServerActiveObject* obj = getActiveObject(objectId);
-
+	for (auto obj : objs) {
 		aabb3f selection_box;
 		if (!obj->getSelectionBox(&selection_box))
 			continue;
@@ -1625,7 +1623,7 @@ void ServerEnvironment::getSelectedActiveObjects(
 		if (boxLineCollision(offsetted_box, shootline_on_map.start, line_vector,
 				&current_intersection, &current_normal)) {
 			objects.emplace_back(
-				(s16) objectId, current_intersection, current_normal,
+				(s16) obj->getId(), current_intersection, current_normal,
 				(current_intersection - shootline_on_map.start).getLengthSQ());
 		}
 	}

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -323,9 +323,10 @@ public:
 	bool swapNode(v3s16 p, const MapNode &n);
 
 	// Find all active objects inside a radius around a point
-	void getObjectsInsideRadius(std::vector<u16> &objects, const v3f &pos, float radius)
+	void getObjectsInsideRadius(std::vector<ServerActiveObject *> &objects, const v3f &pos, float radius,
+			std::function<bool(ServerActiveObject *obj)> includeObjCallback)
 	{
-		return m_ao_manager.getObjectsInsideRadius(pos, radius, objects);
+		return m_ao_manager.getObjectsInsideRadius(pos, radius, objects, includeObjCallback);
 	}
 
 	// Clear objects, loading and going through every MapBlock

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -324,9 +324,9 @@ public:
 
 	// Find all active objects inside a radius around a point
 	void getObjectsInsideRadius(std::vector<ServerActiveObject *> &objects, const v3f &pos, float radius,
-			std::function<bool(ServerActiveObject *obj)> includeObjCallback)
+			std::function<bool(ServerActiveObject *obj)> include_obj_cb)
 	{
-		return m_ao_manager.getObjectsInsideRadius(pos, radius, objects, includeObjCallback);
+		return m_ao_manager.getObjectsInsideRadius(pos, radius, objects, include_obj_cb);
 	}
 
 	// Clear objects, loading and going through every MapBlock

--- a/src/unittest/test_serveractiveobjectmgr.cpp
+++ b/src/unittest/test_serveractiveobjectmgr.cpp
@@ -148,13 +148,25 @@ void TestServerActiveObjectMgr::testGetObjectsInsideRadius()
 		saomgr.registerObject(new TestServerActiveObject(p));
 	}
 
-	std::vector<u16> result;
-	saomgr.getObjectsInsideRadius(v3f(), 50, result);
+	std::vector<ServerActiveObject *> result;
+	saomgr.getObjectsInsideRadius(v3f(), 50, result, nullptr);
 	UASSERTCMP(int, ==, result.size(), 1);
 
 	result.clear();
-	saomgr.getObjectsInsideRadius(v3f(), 750, result);
+	saomgr.getObjectsInsideRadius(v3f(), 750, result, nullptr);
 	UASSERTCMP(int, ==, result.size(), 2);
+
+	result.clear();
+	saomgr.getObjectsInsideRadius(v3f(), 750000, result, nullptr);
+	UASSERTCMP(int, ==, result.size(), 5);
+
+	result.clear();
+	auto includeObjCallback = [](ServerActiveObject *obj) {
+		return (obj->getBasePosition().X != 10);
+	};
+
+	saomgr.getObjectsInsideRadius(v3f(), 750000, result, includeObjCallback);
+	UASSERTCMP(int, ==, result.size(), 4);
 
 	clearSAOMgr(&saomgr);
 }

--- a/src/unittest/test_serveractiveobjectmgr.cpp
+++ b/src/unittest/test_serveractiveobjectmgr.cpp
@@ -161,11 +161,11 @@ void TestServerActiveObjectMgr::testGetObjectsInsideRadius()
 	UASSERTCMP(int, ==, result.size(), 5);
 
 	result.clear();
-	auto includeObjCallback = [](ServerActiveObject *obj) {
+	auto include_obj_cb = [](ServerActiveObject *obj) {
 		return (obj->getBasePosition().X != 10);
 	};
 
-	saomgr.getObjectsInsideRadius(v3f(), 750000, result, includeObjCallback);
+	saomgr.getObjectsInsideRadius(v3f(), 750000, result, include_obj_cb);
 	UASSERTCMP(int, ==, result.size(), 4);
 
 	clearSAOMgr(&saomgr);


### PR DESCRIPTION
our previous implementation calls the ActiveObjectMgr to return ids and then lookup those ids in the same map and test each object
Instead now we call the global map to return the pointers directly and we ask filtering when building the list using lamba.

This drop double looping over ranges of active objects (and then filtered one) and drop x lookups on the map regarding the first call results

## To do

This PR is a Ready for Review.

## How to test

Have item_drops and a mob framework with mobs and just see it works (a little bit better)
