### PR TITLE
Add ObjectRef:has_priv(priv_name) Lua call

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4509,6 +4509,10 @@ Authentication
     * `player_or_name`: Either a Player object or the name of a player.
     * `...` is either a list of strings, e.g. `"priva", "privb"` or
       a table, e.g. `{ priva = true, privb = true }`.
+* `player:has_priv(priv_name)`:
+	* The simpler solution to check if player has a single privilege.
+	* Returns true if player has the privilege "priv_name".
+	* Returns nil if object is not a player reference.
 
 * `minetest.check_password_entry(name, entry, password)`
     * Returns true if the "password entry" for a player with name matches given

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1051,7 +1051,21 @@ int ObjectRef::l_get_luaentity(lua_State *L)
 }
 
 /* Player-only */
+// has_priv(self)
+int ObjectRef::l_has_priv(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (!player)
+		return 0;
 
+	std::string priv = readParam<std::string>(L, -1);
+
+	Server *server = getServer(L);
+	lua_pushboolean(L, server->checkPriv(player->getName(), priv));
+	return 1;
+}
 // is_player_connected(self)
 int ObjectRef::l_is_player_connected(lua_State *L)
 {
@@ -2295,6 +2309,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_entity_name),
 	luamethod(ObjectRef, get_luaentity),
 	// Player-only
+	luamethod(ObjectRef, has_priv),
 	luamethod(ObjectRef, is_player),
 	luamethod(ObjectRef, is_player_connected),
 	luamethod(ObjectRef, get_player_name),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -203,6 +203,9 @@ private:
 
 	/* Player-only */
 
+	// has_priv(self, name)
+	static int l_has_priv(lua_State *L);
+
 	// is_player_connected(self)
 	static int l_is_player_connected(lua_State *L);
 


### PR DESCRIPTION
Most of our calls are very generic and involved loading all the privileges from the Lua stack to the core then process & dump again to Lua.
With this call we offer a very short way to check if a ObjectRef loaded in game has a privilege directly.

This prevent the common way: `minetest.check_player_privs(player:get_player_name(), [interact])` which involved many callbacks to and from the core (loading privs from lua part, serializing, pushing, comparing the privs to the table in lua and then the modder should reverify the bool flag and the returned list).

Now just call player:has_priv(interact), it just involved lua load privs to core then verify the list and just push the boolean to the caller. Simple to use and very efficient in terms of heap allocations

Don't ignore short calls, it's less lua redundant code to write, and also less heap moves which can be costly on low end devices :)
it's not very common to check multiple privs at the same time too.

## To do

This PR is Ready for Review.

## How to test

Just run a lua snippet code on a object ref with a privilege to check
