### PR TITLE
Rename "subgame" to "game" in 2 error messages

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -775,7 +775,7 @@ static bool determine_subgame(GameParams *game_params)
 			gamespec = findSubgame(g_settings->get("default_game"));
 			infostream << "Using default gameid [" << gamespec.id << "]" << std::endl;
 			if (!gamespec.isValid()) {
-				errorstream << "Subgame specified in default_game ["
+				errorstream << "Game specified in default_game ["
 				            << g_settings->get("default_game")
 				            << "] is invalid." << std::endl;
 				return false;
@@ -800,7 +800,7 @@ static bool determine_subgame(GameParams *game_params)
 	}
 
 	if (!gamespec.isValid()) {
-		errorstream << "Subgame [" << gamespec.id << "] could not be found."
+		errorstream << "Game [" << gamespec.id << "] could not be found."
 		            << std::endl;
 		return false;
 	}


### PR DESCRIPTION
2 error messages still used the word “subgame”, a term which we dropped ages ago. This trivial PR changes the word to “game”.

## To do

Nothing.

## How to test

Set `default_game` to invalid value, start Minetest and look at log.