### PR TITLE
Swap out -ffast-math for a safe subset of optimization flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -713,6 +713,11 @@ else()
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32_LEAN_AND_MEAN")
 	endif()
 
+	# Use a safe subset of flags to speed up math calculations:
+	# - we don't need errno or math exceptions
+	# - we don't deal with Inf/NaN or signed zero
+	set(MATH_FLAGS "-fno-math-errno -fno-trapping-math -ffinite-math-only -fno-signed-zeros")
+
 	set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG ${RELEASE_WARNING_FLAGS} ${WARNING_FLAGS} ${OTHER_FLAGS} -Wall -pipe -funroll-loops")
 	if(CMAKE_SYSTEM_NAME MATCHES "(Darwin|BSD|DragonFly)")
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Os")
@@ -723,7 +728,7 @@ else()
 				AND CMAKE_CXX_COMPILER_VERSION MATCHES "^9\\.")
 			# Clang 9 has broken -ffast-math on glibc
 		else()
-			set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffast-math")
+			set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${MATH_FLAGS}")
 		endif()
 	endif(CMAKE_SYSTEM_NAME MATCHES "(Darwin|BSD|DragonFly)")
 	set(CMAKE_CXX_FLAGS_SEMIDEBUG "-g -O1 -Wall -Wabi ${WARNING_FLAGS} ${OTHER_FLAGS}")

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -32,6 +32,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/timetaker.h"
 #include "profiler.h"
 
+#ifdef __FAST_MATH__
+#warning "-ffast-math is known to cause bugs in collision code, do not use!"
+#endif
 
 struct NearbyCollisionInfo {
 	NearbyCollisionInfo(bool is_ul, bool is_obj, int bouncy,


### PR DESCRIPTION
fixes #3943, fixes #5330 
prevents very visible item collision issues in #9668

All flags used are supported since (at least) gcc 4.7: https://gcc.gnu.org/onlinedocs/gcc-4.7.4/gcc.pdf
clang keeps flag-compatibility with gcc

## Can't this break anything?

Not at all. The BSDs build without this flag, Debian/Ubuntu **always** built without it (until recently).
The debug builds that were running our unittests (CI) build without this.
The only thing this can "break" is performance, but from a quick test with the collision code there is no observable difference.

