### PR TITLE
Android: fix formspec input for AArch64 devices

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3346,28 +3346,25 @@ bool GUIFormSpecMenu::getAndroidUIInput()
 	if (!hasAndroidUIInput())
 		return false;
 
+	// still waiting
+	if (porting::getInputDialogState() == -1)
+		return true;
+
 	std::string fieldname = m_jni_field_name;
 	m_jni_field_name.clear();
 
-	for (std::vector<FieldSpec>::iterator iter =  m_fields.begin();
-			iter != m_fields.end(); ++iter) {
-
-		if (iter->fname != fieldname) {
+	for (const FieldSpec &field : m_fields) {
+		if (field.fname != fieldname)
 			continue;
-		}
-		IGUIElement *tochange = getElementFromId(iter->fid, true);
 
-		if (tochange == 0) {
-			return false;
-		}
+		IGUIElement *element = getElementFromId(field.fid, true);
 
-		if (tochange->getType() != irr::gui::EGUIET_EDIT_BOX) {
+		if ((element == nullptr) ||
+				(element->getType() != irr::gui::EGUIET_EDIT_BOX))
 			return false;
-		}
 
 		std::string text = porting::getInputDialogValue();
-
-		((gui::IGUIEditBox *)tochange)->setText(utf8_to_wide(text).c_str());
+		((gui::IGUIEditBox *)element)->setText(utf8_to_wide(text).c_str());
 	}
 	return false;
 }

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3359,8 +3359,7 @@ bool GUIFormSpecMenu::getAndroidUIInput()
 
 		IGUIElement *element = getElementFromId(field.fid, true);
 
-		if ((element == nullptr) ||
-				(element->getType() != irr::gui::EGUIET_EDIT_BOX))
+		if (!element || element->getType() != irr::gui::EGUIET_EDIT_BOX)
 			return false;
 
 		std::string text = porting::getInputDialogValue();


### PR DESCRIPTION
**The PR series "fix Android and make it better" continues.**

- Goal of the PR
Fixing formspec input for AArch64 devices

- How does the PR work?
Just like before formspecs refactoring
- Does it resolve any reported issue?
Not reported yet. Aarch64 support added only yesterday
- If not a bug fix, why is this PR needed? What usecases does it solve?
It's a bug fix!

This PR is Ready for Review.


## How to test
Install the arm64 assembly on your Android 10 phone and try entering text in any input field. Without this PR most often the text will not be entered, you will get an empty field. With this PR, it works as it should.
