### PR TITLE
[NO SQUASH!] TouchScreen control bug fixes and code cleanup

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1171,6 +1171,10 @@ void Game::shutdown()
 	if (formspec)
 		formspec->quitMenu();
 
+#ifdef HAVE_TOUCHSCREENGUI
+	g_touchscreengui->hide();
+#endif
+
 	showOverlayMessage(N_("Shutting down..."), 0, 0, false);
 
 	if (clouds)

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3599,6 +3599,10 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 	tooltip_offset_y  = 0;
 	if (m_pointer.X > (s32)screenSize.X / 2)
 		tooltip_offset_x = -(tooltip_offset_x + tooltip_width);
+
+	// Hide tooltip after ETIE_LEFT_UP
+	if (m_pointer.X == 0)
+		return;
 #endif
 
 	// Calculate and set the tooltip position

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -28,8 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "touchscreengui.h"
 #endif
 
-// clang-format off
-GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent, s32 id,
+GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
 		IMenuManager *menumgr) :
 		IGUIElement(gui::EGUIET_ELEMENT, env, parent, id,
 				core::rect<s32>(0, 0, 100, 100)),
@@ -153,8 +152,8 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 			if (((gui::IGUIEditBox *)hovered)->isPasswordBox())
 				type = 3;
 
-			porting::showInputDialog(gettext("ok"), "",
-				wide_to_utf8(((gui::IGUIEditBox *)hovered)->getText()),	type);
+			porting::showInputDialog(gettext("OK"), "",
+				wide_to_utf8(((gui::IGUIEditBox *)hovered)->getText()), type);
 			return retval;
 		}
 	}
@@ -167,17 +166,16 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 
 		if (!root) {
 			errorstream << "GUIModalMenu::preprocessEvent"
-			            << " unable to get root element" << std::endl;
+				    << " unable to get root element" << std::endl;
 			return false;
 		}
-		gui::IGUIElement *hovered = root->getElementFromPoint(
-			core::position2d<s32>(event.TouchInput.X, event.TouchInput.Y));
+		gui::IGUIElement *hovered =
+				root->getElementFromPoint(core::position2d<s32>(
+						event.TouchInput.X, event.TouchInput.Y));
 
 		translated.MouseInput.X = event.TouchInput.X;
 		translated.MouseInput.Y = event.TouchInput.Y;
 		translated.MouseInput.Control = false;
-
-		bool dont_send_event = false;
 
 		if (event.TouchInput.touchedCount == 1) {
 			switch (event.TouchInput.Event) {
@@ -205,11 +203,7 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 				m_down_pos = v2s32(0, 0);
 				break;
 			default:
-				dont_send_event = true;
-				// this is not supposed to happen
-				errorstream << "GUIModalMenu::preprocessEvent"
-				            << " unexpected usecase Event="
-				            << event.TouchInput.Event << std::endl;
+				break;
 			}
 		} else if ((event.TouchInput.touchedCount == 2) &&
 				(event.TouchInput.Event == ETIE_PRESSED_DOWN)) {
@@ -219,50 +213,37 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 			translated.MouseInput.ButtonStates = EMBSM_LEFT | EMBSM_RIGHT;
 			translated.MouseInput.X = m_pointer.X;
 			translated.MouseInput.Y = m_pointer.Y;
-			if (hovered) {
+			if (hovered)
 				hovered->OnEvent(translated);
-			}
 
 			translated.MouseInput.Event = EMIE_RMOUSE_LEFT_UP;
 			translated.MouseInput.ButtonStates = EMBSM_LEFT;
 
-			if (hovered) {
+			if (hovered)
 				hovered->OnEvent(translated);
-			}
-			dont_send_event = true;
-		}
-		// ignore unhandled 2 touch events ... accidental moving for example
-		else if (event.TouchInput.touchedCount == 2) {
-			dont_send_event = true;
-		}
-		else if (event.TouchInput.touchedCount > 2) {
-			errorstream << "GUIModalMenu::preprocessEvent"
-			            << " to many multitouch events "
-			            << event.TouchInput.touchedCount << " ignoring them"
-			            << std::endl;
-		}
 
-		if (dont_send_event) {
+			return true;
+		} else {
+			// ignore unhandled 2 touch events (accidental moving for example)
 			return true;
 		}
 
 		// check if translated event needs to be preprocessed again
-		if (preprocessEvent(translated)) {
+		if (preprocessEvent(translated))
 			return true;
-		}
+
 		if (hovered) {
 			grab();
 			bool retval = hovered->OnEvent(translated);
 
-			if (event.TouchInput.Event == ETIE_LEFT_UP) {
+			if (event.TouchInput.Event == ETIE_LEFT_UP)
 				// reset pointer
 				m_pointer = v2s32(0, 0);
-			}
+
 			drop();
 			return retval;
 		}
 	}
-	// clang-format on
 #endif
 	return false;
 }
@@ -271,14 +252,12 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 bool GUIModalMenu::hasAndroidUIInput()
 {
 	// no dialog shown
-	if (m_jni_field_name.empty()) {
+	if (m_jni_field_name.empty())
 		return false;
-	}
 
 	// still waiting
-	if (porting::getInputDialogState() == -1) {
+	if (porting::getInputDialogState() == -1)
 		return true;
-	}
 
 	// no value abort dialog processing
 	if (porting::getInputDialogState() != 0) {

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -1211,7 +1211,12 @@ void TouchScreenGUI::step(float dtime)
 	}
 
 	// joystick
-	applyJoystickStatus();
+	for (unsigned int i = 0; i < 4; i++) {
+		if (m_joystick_status[i]) {
+			applyJoystickStatus();
+			break;
+		}
+	}
 
 	// if a new placed pointer isn't moved for some time start digging
 	if ((m_move_id != -1) &&

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -34,19 +34,16 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <ISceneCollisionManager.h>
 
-// Very slow button repeat frequency (in seconds)
-#define SLOW_BUTTON_REPEAT	(1.0f)
-
 using namespace irr::core;
 
-const char **touchgui_button_imagenames = (const char *[]) {
+const char **button_imagenames = (const char *[]) {
 	"jump_btn.png",
 	"down.png",
 	"zoom.png",
 	"aux_btn.png"
 };
 
-const char **touchgui_joystick_imagenames = (const char *[]) {
+const char **joystick_imagenames = (const char *[]) {
 	"joystick_off.png",
 	"joystick_bg.png",
 	"joystick_center.png"
@@ -113,15 +110,17 @@ static irr::EKEY_CODE id2keycode(touch_gui_button_id id)
 		case range_id:
 			key = "rangeselect";
 			break;
+		default:
+			break;
 	}
-	assert(key != "");
+	assert(!key.empty());
 	return keyname_to_keycode(g_settings->get("keymap_" + key).c_str());
 }
 
 TouchScreenGUI *g_touchscreengui;
 
 static void load_button_texture(button_info *btn, const char *path,
-		rect<s32> button_rect, ISimpleTextureSource *tsrc, video::IVideoDriver *driver)
+		const rect<s32> &button_rect, ISimpleTextureSource *tsrc, video::IVideoDriver *driver)
 {
 	unsigned int tid;
 	video::ITexture *texture = guiScalingImageButton(driver,
@@ -141,7 +140,7 @@ static void load_button_texture(button_info *btn, const char *path,
 		}
 		btn->guibutton->setDrawBorder(false);
 		btn->guibutton->setText(L"");
-		}
+	}
 }
 
 AutoHideButtonBar::AutoHideButtonBar(IrrlichtDevice *device,
@@ -153,8 +152,8 @@ AutoHideButtonBar::AutoHideButtonBar(IrrlichtDevice *device,
 }
 
 void AutoHideButtonBar::init(ISimpleTextureSource *tsrc,
-		const char *starter_img, int button_id, v2s32 UpperLeft,
-		v2s32 LowerRight, autohide_button_bar_dir dir, float timeout)
+		const char *starter_img, int button_id, const v2s32 &UpperLeft,
+		const v2s32 &LowerRight, autohide_button_bar_dir dir, float timeout)
 {
 	m_texturesource = tsrc;
 
@@ -166,7 +165,7 @@ void AutoHideButtonBar::init(ISimpleTextureSource *tsrc,
 	irr::core::rect<int> current_button = rect<s32>(UpperLeft.X, UpperLeft.Y,
 			LowerRight.X, LowerRight.Y);
 
-	m_starter.guibutton         = m_guienv->addButton(current_button, 0, button_id, L"", 0);
+	m_starter.guibutton         = m_guienv->addButton(current_button, nullptr, button_id, L"", nullptr);
 	m_starter.guibutton->grab();
 	m_starter.repeatcounter     = -1;
 	m_starter.keycode           = KEY_OEM_8; // use invalid keycode as it's not relevant
@@ -201,16 +200,14 @@ void AutoHideButtonBar::addButton(touch_gui_button_id button_id,
 	}
 	int button_size = 0;
 
-	if ((m_dir == AHBB_Dir_Top_Bottom) || (m_dir == AHBB_Dir_Bottom_Top)) {
+	if ((m_dir == AHBB_Dir_Top_Bottom) || (m_dir == AHBB_Dir_Bottom_Top))
 		button_size = m_lower_right.X - m_upper_left.X;
-	} else {
+	else
 		button_size = m_lower_right.Y - m_upper_left.Y;
-	}
 
 	irr::core::rect<int> current_button;
 
 	if ((m_dir == AHBB_Dir_Right_Left) || (m_dir == AHBB_Dir_Left_Right)) {
-
 		int x_start = 0;
 		int x_end = 0;
 
@@ -227,8 +224,8 @@ void AutoHideButtonBar::addButton(touch_gui_button_id button_id,
 		current_button = rect<s32>(x_start, m_upper_left.Y, x_end,
 				m_lower_right.Y);
 	} else {
-		int y_start = 0;
-		int y_end = 0;
+		double y_start = 0;
+		double y_end = 0;
 
 		if (m_dir == AHBB_Dir_Top_Bottom) {
 			y_start = m_lower_right.X + (button_size * 1.25 * m_buttons.size())
@@ -240,12 +237,13 @@ void AutoHideButtonBar::addButton(touch_gui_button_id button_id,
 			y_start = y_end - button_size;
 		}
 
-		current_button = rect<s32>(m_upper_left.X, y_start, m_lower_right.Y,
-				y_end);
+		current_button = rect<s32>(m_upper_left.X, y_start,
+				m_lower_right.Y, y_end);
 	}
 
-	button_info *btn       = new button_info();
-	btn->guibutton         = m_guienv->addButton(current_button, 0, button_id, caption, 0);
+	auto *btn              = new button_info();
+	btn->guibutton         = m_guienv->addButton(current_button,
+					nullptr, button_id, caption, nullptr);
 	btn->guibutton->grab();
 	btn->guibutton->setVisible(false);
 	btn->guibutton->setEnabled(false);
@@ -275,26 +273,23 @@ bool AutoHideButtonBar::isButton(const SEvent &event)
 {
 	IGUIElement *rootguielement = m_guienv->getRootGUIElement();
 
-	if (rootguielement == NULL) {
+	if (rootguielement == nullptr)
 		return false;
-	}
 
 	gui::IGUIElement *element = rootguielement->getElementFromPoint(
 			core::position2d<s32>(event.TouchInput.X, event.TouchInput.Y));
 
-	if (element == NULL) {
+	if (element == nullptr)
 		return false;
-	}
 
 	if (m_active) {
 		// check for all buttons in vector
-
-		std::vector<button_info *>::iterator iter = m_buttons.begin();
+		auto iter = m_buttons.begin();
 
 		while (iter != m_buttons.end()) {
 			if ((*iter)->guibutton == element) {
 
-				SEvent *translated = new SEvent();
+				auto *translated = new SEvent();
 				memset(translated, 0, sizeof(SEvent));
 				translated->EventType            = irr::EET_KEY_INPUT_EVENT;
 				translated->KeyInput.Key         = (*iter)->keycode;
@@ -341,7 +336,7 @@ bool AutoHideButtonBar::isButton(const SEvent &event)
 			m_active = true;
 			m_timeout = 0;
 
-			std::vector<button_info*>::iterator iter = m_buttons.begin();
+			auto iter = m_buttons.begin();
 
 			while (iter != m_buttons.end()) {
 				(*iter)->guibutton->setVisible(true);
@@ -355,41 +350,13 @@ bool AutoHideButtonBar::isButton(const SEvent &event)
 	return false;
 }
 
-bool AutoHideButtonBar::isReleaseButton(int eventID)
-{
-	std::vector<int>::iterator id = std::find(m_starter.ids.begin(),
-			m_starter.ids.end(), eventID);
-
-	if (id != m_starter.ids.end()) {
-		m_starter.ids.erase(id);
-		return true;
-	}
-
-	std::vector<button_info *>::iterator iter = m_buttons.begin();
-
-	while (iter != m_buttons.end()) {
-		std::vector<int>::iterator id = std::find((*iter)->ids.begin(),
-				(*iter)->ids.end(), eventID);
-
-		if (id != (*iter)->ids.end()) {
-			(*iter)->ids.erase(id);
-			// TODO handle settings button release
-			return true;
-		}
-		++iter;
-	}
-
-	return false;
-}
-
 void AutoHideButtonBar::step(float dtime)
 {
 	if (m_active) {
 		m_timeout += dtime;
 
-		if (m_timeout > m_timeout_value) {
+		if (m_timeout > m_timeout_value)
 			deactivate();
-		}
 	}
 }
 
@@ -401,11 +368,11 @@ void AutoHideButtonBar::deactivate()
 	}
 	m_active = false;
 
-	std::vector<button_info *>::iterator iter = m_buttons.begin();
+	auto iter = m_buttons.begin();
 
 	while (iter != m_buttons.end()) {
-			(*iter)->guibutton->setVisible(false);
-			(*iter)->guibutton->setEnabled(false);
+		(*iter)->guibutton->setVisible(false);
+		(*iter)->guibutton->setEnabled(false);
 		++iter;
 	}
 }
@@ -416,7 +383,7 @@ void AutoHideButtonBar::hide()
 	m_starter.guibutton->setVisible(false);
 	m_starter.guibutton->setEnabled(false);
 
-	std::vector<button_info *>::iterator iter = m_buttons.begin();
+	auto iter = m_buttons.begin();
 
 	while (iter != m_buttons.end()) {
 		(*iter)->guibutton->setVisible(false);
@@ -430,7 +397,7 @@ void AutoHideButtonBar::show()
 	m_visible = true;
 
 	if (m_active) {
-		std::vector<button_info *>::iterator iter = m_buttons.begin();
+		auto iter = m_buttons.begin();
 
 		while (iter != m_buttons.end()) {
 			(*iter)->guibutton->setVisible(true);
@@ -450,24 +417,26 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, IEventReceiver *receiver)
 	m_settingsbar(device, receiver),
 	m_rarecontrolsbar(device, receiver)
 {
-	for (unsigned int i=0; i < after_last_element_id; i++) {
-		m_buttons[i].guibutton     =  0;
-		m_buttons[i].repeatcounter = -1;
-		m_buttons[i].repeatdelay   = BUTTON_REPEAT_DELAY;
+	for (auto &button : m_buttons) {
+		button.guibutton     = nullptr;
+		button.repeatcounter = -1;
+		button.repeatdelay   = BUTTON_REPEAT_DELAY;
 	}
 
 	m_touchscreen_threshold = g_settings->getU16("touchscreen_threshold");
 	m_fixed_joystick = g_settings->getBool("fixed_virtual_joystick");
 	m_joystick_triggers_special1 = g_settings->getBool("virtual_joystick_triggers_aux");
 	m_screensize = m_device->getVideoDriver()->getScreenSize();
+	button_size = MYMIN(m_screensize.Y / 4.5f,
+			porting::getDisplayDensity() *
+			g_settings->getFloat("hud_scaling") * 65.0f);
 }
 
-void TouchScreenGUI::initButton(touch_gui_button_id id, rect<s32> button_rect,
-		std::wstring caption, bool immediate_release, float repeat_delay)
+void TouchScreenGUI::initButton(touch_gui_button_id id, const rect<s32> &button_rect,
+		const std::wstring &caption, bool immediate_release, float repeat_delay)
 {
-
 	button_info *btn       = &m_buttons[id];
-	btn->guibutton         = m_guienv->addButton(button_rect, 0, id, caption.c_str());
+	btn->guibutton         = m_guienv->addButton(button_rect, nullptr, id, caption.c_str());
 	btn->guibutton->grab();
 	btn->repeatcounter     = -1;
 	btn->repeatdelay       = repeat_delay;
@@ -475,42 +444,29 @@ void TouchScreenGUI::initButton(touch_gui_button_id id, rect<s32> button_rect,
 	btn->immediate_release = immediate_release;
 	btn->ids.clear();
 
-	load_button_texture(btn, touchgui_button_imagenames[id], button_rect,
+	load_button_texture(btn, button_imagenames[id], button_rect,
 			m_texturesource, m_device->getVideoDriver());
 }
 
-button_info *TouchScreenGUI::initJoystickButton(touch_gui_button_id id, rect<s32> button_rect,
-		int texture_id, bool visible)
+button_info *TouchScreenGUI::initJoystickButton(touch_gui_button_id id,
+		const rect<s32> &button_rect, int texture_id, bool visible)
 {
-	button_info *btn = new button_info();
-	btn->guibutton   = m_guienv->addButton(button_rect, 0, id, L"O");
+	auto *btn = new button_info();
+	btn->guibutton = m_guienv->addButton(button_rect, nullptr, id, L"O");
 	btn->guibutton->setVisible(visible);
 	btn->guibutton->grab();
 	btn->ids.clear();
 
-	load_button_texture(btn, touchgui_joystick_imagenames[texture_id], button_rect,
-			m_texturesource, m_device->getVideoDriver());
+	load_button_texture(btn, joystick_imagenames[texture_id],
+			button_rect, m_texturesource, m_device->getVideoDriver());
 
 	return btn;
-}
-
-static int getMaxControlPadSize(float density) {
-	return 200 * density * g_settings->getFloat("hud_scaling");
-}
-
-int TouchScreenGUI::getGuiButtonSize()
-{
-	u32 control_pad_size = MYMIN((2 * m_screensize.Y) / 3,
-			getMaxControlPadSize(porting::getDisplayDensity()));
-
-	return control_pad_size / 3;
 }
 
 void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 {
 	assert(tsrc);
 
-	u32 button_size = getGuiButtonSize();
 	m_visible       = true;
 	m_texturesource = tsrc;
 
@@ -608,35 +564,31 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 	m_rarecontrolsbar.addButton(chat_id,      L"Chat", "chat_btn.png");
 	m_rarecontrolsbar.addButton(inventory_id, L"inv",  "inventory_btn.png");
 	m_rarecontrolsbar.addButton(drop_id,      L"drop", "drop_btn.png");
-
 }
 
 touch_gui_button_id TouchScreenGUI::getButtonID(s32 x, s32 y)
 {
 	IGUIElement *rootguielement = m_guienv->getRootGUIElement();
 
-	if (rootguielement != NULL) {
+	if (rootguielement != nullptr) {
 		gui::IGUIElement *element =
 				rootguielement->getElementFromPoint(core::position2d<s32>(x, y));
 
-		if (element) {
-			for (unsigned int i=0; i < after_last_element_id; i++) {
-				if (element == m_buttons[i].guibutton) {
+		if (element)
+			for (unsigned int i = 0; i < after_last_element_id; i++)
+				if (element == m_buttons[i].guibutton)
 					return (touch_gui_button_id) i;
-				}
-			}
-		}
 	}
+
 	return after_last_element_id;
 }
 
-touch_gui_button_id TouchScreenGUI::getButtonID(int eventID)
+touch_gui_button_id TouchScreenGUI::getButtonID(size_t eventID)
 {
-	for (unsigned int i=0; i < after_last_element_id; i++) {
+	for (unsigned int i = 0; i < after_last_element_id; i++) {
 		button_info *btn = &m_buttons[i];
 
-		std::vector<int>::iterator id =
-				std::find(btn->ids.begin(), btn->ids.end(), eventID);
+		auto id = std::find(btn->ids.begin(), btn->ids.end(), eventID);
 
 		if (id != btn->ids.end())
 			return (touch_gui_button_id) i;
@@ -648,55 +600,30 @@ touch_gui_button_id TouchScreenGUI::getButtonID(int eventID)
 bool TouchScreenGUI::isHUDButton(const SEvent &event)
 {
 	// check if hud item is pressed
-	for (std::map<int, rect<s32> >::iterator iter = m_hud_rects.begin();
-			iter != m_hud_rects.end(); ++iter) {
-		if (iter->second.isPointInside(
-				v2s32(event.TouchInput.X,
-						event.TouchInput.Y)
-			)) {
-			if ( iter->first < 8) {
-				SEvent *translated = new SEvent();
-				memset(translated, 0, sizeof(SEvent));
-				translated->EventType = irr::EET_KEY_INPUT_EVENT;
-				translated->KeyInput.Key         = (irr::EKEY_CODE) (KEY_KEY_1 + iter->first);
-				translated->KeyInput.Control     = false;
-				translated->KeyInput.Shift       = false;
-				translated->KeyInput.PressedDown = true;
-				m_receiver->OnEvent(*translated);
-				m_hud_ids[event.TouchInput.ID]   = translated->KeyInput.Key;
-				delete translated;
-				return true;
-			}
+	for (auto &hud_rect : m_hud_rects) {
+		if (hud_rect.second.isPointInside(v2s32(event.TouchInput.X,
+				event.TouchInput.Y))) {
+			auto *translated = new SEvent();
+			memset(translated, 0, sizeof(SEvent));
+			translated->EventType = irr::EET_KEY_INPUT_EVENT;
+			translated->KeyInput.Key         = (irr::EKEY_CODE) (KEY_KEY_1 + hud_rect.first);
+			translated->KeyInput.Control     = false;
+			translated->KeyInput.Shift       = false;
+			translated->KeyInput.PressedDown = true;
+			m_receiver->OnEvent(*translated);
+			m_hud_ids[event.TouchInput.ID]   = translated->KeyInput.Key;
+			delete translated;
+			return true;
 		}
 	}
 	return false;
 }
 
-bool TouchScreenGUI::isReleaseHUDButton(int eventID)
-{
-	std::map<int, irr::EKEY_CODE>::iterator iter = m_hud_ids.find(eventID);
-
-	if (iter != m_hud_ids.end()) {
-		SEvent *translated = new SEvent();
-		memset(translated, 0, sizeof(SEvent));
-		translated->EventType            = irr::EET_KEY_INPUT_EVENT;
-		translated->KeyInput.Key         = iter->second;
-		translated->KeyInput.PressedDown = false;
-		translated->KeyInput.Control     = false;
-		translated->KeyInput.Shift       = false;
-		m_receiver->OnEvent(*translated);
-		m_hud_ids.erase(iter);
-		delete translated;
-		return true;
-	}
-	return false;
-}
-
 void TouchScreenGUI::handleButtonEvent(touch_gui_button_id button,
-		int eventID, bool action)
+		size_t eventID, bool action)
 {
 	button_info *btn = &m_buttons[button];
-	SEvent *translated = new SEvent();
+	auto *translated = new SEvent();
 	memset(translated, 0, sizeof(SEvent));
 	translated->EventType            = irr::EET_KEY_INPUT_EVENT;
 	translated->KeyInput.Key         = btn->keycode;
@@ -717,16 +644,16 @@ void TouchScreenGUI::handleButtonEvent(touch_gui_button_id button,
 		translated->KeyInput.Key = btn->keycode;
 		m_receiver->OnEvent(*translated);
 	}
+
 	// remove event
 	if ((!action) || (btn->immediate_release)) {
-
-		std::vector<int>::iterator pos =
-				std::find(btn->ids.begin(), btn->ids.end(), eventID);
+		auto pos = std::find(btn->ids.begin(), btn->ids.end(), eventID);
 		// has to be in touch list
 		assert(pos != btn->ids.end());
 		btn->ids.erase(pos);
 
-		if (btn->ids.size() > 0)  { return; }
+		if (!btn->ids.empty())
+			return;
 
 		translated->KeyInput.PressedDown = false;
 		btn->repeatcounter               = -1;
@@ -735,30 +662,21 @@ void TouchScreenGUI::handleButtonEvent(touch_gui_button_id button,
 	delete translated;
 }
 
-
-void TouchScreenGUI::handleReleaseEvent(int evt_id)
+void TouchScreenGUI::handleReleaseEvent(size_t evt_id)
 {
 	touch_gui_button_id button = getButtonID(evt_id);
 
-	// handle button events
+
 	if (button != after_last_element_id) {
+		// handle button events
 		handleButtonEvent(button, evt_id, false);
-	}
-	// handle hud button events
-	else if (isReleaseHUDButton(evt_id)) {
-		// nothing to do here
-	} else if (m_settingsbar.isReleaseButton(evt_id)) {
-		// nothing to do here
-	} else if (m_rarecontrolsbar.isReleaseButton(evt_id)) {
-		// nothing to do here
-	}
-	// handle the point used for moving view
-	else if (evt_id == m_move_id) {
+	} else if (evt_id == m_move_id) {
+		// handle the point used for moving view
 		m_move_id = -1;
 
 		// if this pointer issued a mouse event issue symmetric release here
 		if (m_move_sent_as_mouse_event) {
-			SEvent *translated = new SEvent;
+			auto *translated = new SEvent;
 			memset(translated, 0, sizeof(SEvent));
 			translated->EventType               = EET_MOUSE_INPUT_EVENT;
 			translated->MouseInput.X            = m_move_downlocation.X;
@@ -769,32 +687,31 @@ void TouchScreenGUI::handleReleaseEvent(int evt_id)
 			translated->MouseInput.Event        = EMIE_LMOUSE_LEFT_UP;
 			m_receiver->OnEvent(*translated);
 			delete translated;
-		}
-		else {
+		} else {
 			// do double tap detection
 			doubleTapDetection();
 		}
 	}
+
 	// handle joystick
 	else if (evt_id == m_joystick_id) {
 		m_joystick_id = -1;
 
 		// reset joystick
-		for (unsigned int i = 0; i < 4; i ++)
+		for (unsigned int i = 0; i < 4; i++)
 			m_joystick_status[i] = false;
 		applyJoystickStatus();
 
 		m_joystick_btn_off->guibutton->setVisible(true);
 		m_joystick_btn_bg->guibutton->setVisible(false);
 		m_joystick_btn_center->guibutton->setVisible(false);
-	}
-	else {
+	} else {
 		infostream
 			<< "TouchScreenGUI::translateEvent released unknown button: "
 			<< evt_id << std::endl;
 	}
 
-	for (std::vector<id_status>::iterator iter = m_known_ids.begin();
+	for (auto iter = m_known_ids.begin();
 			iter != m_known_ids.end(); ++iter) {
 		if (iter->id == evt_id) {
 			m_known_ids.erase(iter);
@@ -806,18 +723,19 @@ void TouchScreenGUI::handleReleaseEvent(int evt_id)
 void TouchScreenGUI::translateEvent(const SEvent &event)
 {
 	if (!m_visible) {
-		infostream << "TouchScreenGUI::translateEvent got event but not visible?!" << std::endl;
+		infostream
+			<< "TouchScreenGUI::translateEvent got event but not visible!"
+			<< std::endl;
 		return;
 	}
 
-	if (event.EventType != EET_TOUCH_INPUT_EVENT) {
+	if (event.EventType != EET_TOUCH_INPUT_EVENT)
 		return;
-	}
 
 	if (event.TouchInput.Event == ETIE_PRESSED_DOWN) {
-
-		/* add to own copy of eventlist ...
-		 * android would provide this information but irrlicht guys don't
+		/*
+		 * Add to own copy of event list...
+		 * android would provide this information but Irrlicht guys don't
 		 * wanna design a efficient interface
 		 */
 		id_status toadd;
@@ -826,7 +744,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 		toadd.Y  = event.TouchInput.Y;
 		m_known_ids.push_back(toadd);
 
-		int eventID = event.TouchInput.ID;
+		size_t eventID = event.TouchInput.ID;
 
 		touch_gui_button_id button =
 				getButtonID(event.TouchInput.X, event.TouchInput.Y);
@@ -846,21 +764,19 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 		} else if (m_rarecontrolsbar.isButton(event)) {
 			m_settingsbar.deactivate();
 			// already handled in isSettingsBarButton()
-		}
-		// handle non button events
-		else {
+		} else {
+			// handle non button events
 			m_settingsbar.deactivate();
 			m_rarecontrolsbar.deactivate();
 
-			u32 button_size = getGuiButtonSize();
-			s32 dxj = event.TouchInput.X - button_size * 5 / 2;
-			s32 dyj = event.TouchInput.Y - m_screensize.Y + button_size * 5 / 2;
+			s32 dxj = event.TouchInput.X - button_size * 5.0f / 2.0f;
+			s32 dyj = event.TouchInput.Y - m_screensize.Y + button_size * 5.0f / 2.0f;
 
 			/* Select joystick when left 1/3 of screen dragged or
 			 * when joystick tapped (fixed joystick position)
 			 */
 			if ((m_fixed_joystick && dxj * dxj + dyj * dyj <= button_size * button_size * 1.5 * 1.5) ||
-					(!m_fixed_joystick && event.TouchInput.X < m_screensize.X / 3)) {
+					(!m_fixed_joystick && event.TouchInput.X < m_screensize.X / 3.0f)) {
 				// If we don't already have a starting point for joystick make this the one.
 				if (m_joystick_id == -1) {
 					m_joystick_id               = event.TouchInput.ID;
@@ -871,14 +787,14 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 					m_joystick_btn_center->guibutton->setVisible(true);
 
 					// If it's a fixed joystick, don't move the joystick "button".
-					if (!m_fixed_joystick) {
+					if (!m_fixed_joystick)
 						m_joystick_btn_bg->guibutton->setRelativePosition(v2s32(
-								event.TouchInput.X - button_size * 3 / 2,
-								event.TouchInput.Y - button_size * 3 / 2));
-					}
+								event.TouchInput.X - button_size * 3.0f / 2.0f,
+								event.TouchInput.Y - button_size * 3.0f / 2.0f));
+
 					m_joystick_btn_center->guibutton->setRelativePosition(v2s32(
-							event.TouchInput.X - button_size / 2,
-							event.TouchInput.Y - button_size / 2));
+							event.TouchInput.X - button_size / 2.0f,
+							event.TouchInput.Y - button_size / 2.0f));
 				}
 			} else {
 				// If we don't already have a moving point make this the moving one.
@@ -895,17 +811,15 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 		m_pointerpos[event.TouchInput.ID] = v2s32(event.TouchInput.X, event.TouchInput.Y);
 	}
 	else if (event.TouchInput.Event == ETIE_LEFT_UP) {
-		verbosestream << "Up event for pointerid: " << event.TouchInput.ID << std::endl;
+		verbosestream
+			<< "Up event for pointerid: " << event.TouchInput.ID << std::endl;
 		handleReleaseEvent(event.TouchInput.ID);
-	}
-	else {
+	} else {
 		assert(event.TouchInput.Event == ETIE_MOVED);
-		int move_idx = event.TouchInput.ID;
 
 		if (m_pointerpos[event.TouchInput.ID] ==
-				v2s32(event.TouchInput.X, event.TouchInput.Y)) {
+				v2s32(event.TouchInput.X, event.TouchInput.Y))
 			return;
-		}
 
 		if (m_move_id != -1) {
 			if ((event.TouchInput.ID == m_move_id) &&
@@ -928,9 +842,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 					s32 dy = Y - m_pointerpos[event.TouchInput.ID].Y;
 
 					// adapt to similar behaviour as pc screen
-					double d         = g_settings->getFloat("mouse_sensitivity") * 4;
-					double old_yaw   = m_camera_yaw_change;
-					double old_pitch = m_camera_pitch;
+					double d = g_settings->getFloat("mouse_sensitivity") * 3.0f;
 
 					m_camera_yaw_change -= dx * d;
 					m_camera_pitch = MYMIN(MYMAX(m_camera_pitch + (dy * d), -180), 180);
@@ -942,8 +854,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 							->getRayFromScreenCoordinates(v2s32(X, Y));
 					m_pointerpos[event.TouchInput.ID] = v2s32(X, Y);
 				}
-			}
-			else if ((event.TouchInput.ID == m_move_id) &&
+			} else if ((event.TouchInput.ID == m_move_id) &&
 					(m_move_sent_as_mouse_event)) {
 				m_shootline = m_device
 						->getSceneManager()
@@ -954,7 +865,6 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 		}
 
 		if (m_joystick_id != -1 && event.TouchInput.ID == m_joystick_id) {
-			u32 button_size = getGuiButtonSize();
 			s32 X = event.TouchInput.X;
 			s32 Y = event.TouchInput.Y;
 
@@ -967,8 +877,8 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 
 			double distance_sq = dx * dx + dy * dy;
 
-			s32 dxj = event.TouchInput.X - button_size * 5 / 2;
-			s32 dyj = event.TouchInput.Y - m_screensize.Y + button_size * 5 / 2;
+			s32 dxj = event.TouchInput.X - button_size * 5.0f / 2.0f;
+			s32 dyj = event.TouchInput.Y - m_screensize.Y + button_size * 5.0f / 2.0f;
 			bool inside_joystick = (dxj * dxj + dyj * dyj <= button_size * button_size * 1.5 * 1.5);
 
 			if (m_joystick_has_really_moved ||
@@ -986,8 +896,8 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 				angle = fmod(angle + 180 + 22.5, 360);
 
 				// reset state before applying
-				for (unsigned int i = 0; i < 5; i ++)
-					m_joystick_status[i] = false;
+				for (bool & joystick_status : m_joystick_status)
+					joystick_status = false;
 
 				if (distance <= m_touchscreen_threshold) {
 					// do nothing
@@ -1016,8 +926,8 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 				if (distance > button_size) {
 					m_joystick_status[j_special1] = true;
 					// move joystick "button"
-					s32 ndx = (s32) button_size * dx / distance - (s32) button_size / 2;
-					s32 ndy = (s32) button_size * dy / distance - (s32) button_size / 2;
+					s32 ndx = button_size * dx / distance - button_size / 2.0f;
+					s32 ndy = button_size * dy / distance - button_size / 2.0f;
 					if (m_fixed_joystick) {
 						m_joystick_btn_center->guibutton->setRelativePosition(v2s32(
 							button_size * 5 / 2 + ndx,
@@ -1028,64 +938,54 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 							m_pointerpos[event.TouchInput.ID].Y + ndy));
 					}
 				} else {
-					m_joystick_btn_center->guibutton->setRelativePosition(v2s32(
-						X - button_size / 2, Y - button_size / 2));
+					m_joystick_btn_center->guibutton->setRelativePosition(
+							v2s32(X - button_size / 2, Y - button_size / 2));
 				}
 			}
 		}
 
-		if (m_move_id == -1 && m_joystick_id == -1) {
+		if (m_move_id == -1 && m_joystick_id == -1)
 			handleChangedButton(event);
-		}
 	}
 }
 
 void TouchScreenGUI::handleChangedButton(const SEvent &event)
 {
 	for (unsigned int i = 0; i < after_last_element_id; i++) {
-
-		if (m_buttons[i].ids.empty()) {
+		if (m_buttons[i].ids.empty())
 			continue;
-		}
-		for (std::vector<int>::iterator iter = m_buttons[i].ids.begin();
+
+		for (auto iter = m_buttons[i].ids.begin();
 				iter != m_buttons[i].ids.end(); ++iter) {
-
 			if (event.TouchInput.ID == *iter) {
-
 				int current_button_id =
 						getButtonID(event.TouchInput.X, event.TouchInput.Y);
 
-				if (current_button_id == i) {
+				if (current_button_id == i)
 					continue;
-				}
 
 				// remove old button
 				handleButtonEvent((touch_gui_button_id) i, *iter, false);
 
-				if (current_button_id == after_last_element_id) {
+				if (current_button_id == after_last_element_id)
 					return;
-				}
+
 				handleButtonEvent((touch_gui_button_id) current_button_id, *iter, true);
 				return;
-
 			}
 		}
 	}
 
 	int current_button_id = getButtonID(event.TouchInput.X, event.TouchInput.Y);
 
-	if (current_button_id == after_last_element_id) {
+	if (current_button_id == after_last_element_id)
 		return;
-	}
 
 	button_info *btn = &m_buttons[current_button_id];
 	if (std::find(btn->ids.begin(), btn->ids.end(), event.TouchInput.ID)
 			== btn->ids.end())
-	{
 		handleButtonEvent((touch_gui_button_id) current_button_id,
 				event.TouchInput.ID, true);
-	}
-
 }
 
 bool TouchScreenGUI::doubleTapDetection()
@@ -1102,14 +1002,15 @@ bool TouchScreenGUI::doubleTapDetection()
 		return false;
 
 	double distance = sqrt(
-			(m_key_events[0].x - m_key_events[1].x) * (m_key_events[0].x - m_key_events[1].x) +
-			(m_key_events[0].y - m_key_events[1].y) * (m_key_events[0].y - m_key_events[1].y));
-
+			(m_key_events[0].x - m_key_events[1].x) *
+			(m_key_events[0].x - m_key_events[1].x) +
+			(m_key_events[0].y - m_key_events[1].y) *
+			(m_key_events[0].y - m_key_events[1].y));
 
 	if (distance > (20 + m_touchscreen_threshold))
 		return false;
 
-	SEvent *translated = new SEvent();
+	auto *translated = new SEvent();
 	memset(translated, 0, sizeof(SEvent));
 	translated->EventType               = EET_MOUSE_INPUT_EVENT;
 	translated->MouseInput.X            = m_key_events[0].x;
@@ -1129,21 +1030,20 @@ bool TouchScreenGUI::doubleTapDetection()
 	m_receiver->OnEvent(*translated);
 
 	translated->MouseInput.ButtonStates = 0;
-	translated->MouseInput.Event        = EMIE_RMOUSE_LEFT_UP;
+	translated->MouseInput.Event = EMIE_RMOUSE_LEFT_UP;
 	verbosestream << "TouchScreenGUI::translateEvent right click release" << std::endl;
 	m_receiver->OnEvent(*translated);
 	delete translated;
 	return true;
-
 }
 
 void TouchScreenGUI::applyJoystickStatus()
 {
-	for (unsigned int i = 0; i < 5; i ++) {
+	for (unsigned int i = 0; i < 5; i++) {
 		if (i == 4 && !m_joystick_triggers_special1)
 			continue;
 
-		SEvent translated{};
+		SEvent translated;
 		translated.EventType            = irr::EET_KEY_INPUT_EVENT;
 		translated.KeyInput.Key         = id2keycode(m_joystick_names[i]);
 		translated.KeyInput.PressedDown = false;
@@ -1158,50 +1058,48 @@ void TouchScreenGUI::applyJoystickStatus()
 
 TouchScreenGUI::~TouchScreenGUI()
 {
-	for (unsigned int i = 0; i < after_last_element_id; i++) {
-		button_info *btn = &m_buttons[i];
-		if (btn->guibutton) {
-			btn->guibutton->drop();
-			btn->guibutton = NULL;
+	for (auto &button : m_buttons) {
+		if (button.guibutton) {
+			button.guibutton->drop();
+			button.guibutton = nullptr;
 		}
 	}
 
 	if (m_joystick_btn_off->guibutton) {
 		m_joystick_btn_off->guibutton->drop();
-		m_joystick_btn_off->guibutton = NULL;
+		m_joystick_btn_off->guibutton = nullptr;
 	}
 
 	if (m_joystick_btn_bg->guibutton) {
 		m_joystick_btn_bg->guibutton->drop();
-		m_joystick_btn_bg->guibutton = NULL;
+		m_joystick_btn_bg->guibutton = nullptr;
 	}
 
 	if (m_joystick_btn_center->guibutton) {
 		m_joystick_btn_center->guibutton->drop();
-		m_joystick_btn_center->guibutton = NULL;
+		m_joystick_btn_center->guibutton = nullptr;
 	}
 }
 
 void TouchScreenGUI::step(float dtime)
 {
 	// simulate keyboard repeats
-	for (unsigned int i = 0; i < after_last_element_id; i++) {
-		button_info *btn = &m_buttons[i];
-
-		if (btn->ids.size() > 0) {
-			btn->repeatcounter += dtime;
+	for (auto &button : m_buttons) {
+		if (!button.ids.empty()) {
+			button.repeatcounter += dtime;
 
 			// in case we're moving around digging does not happen
 			if (m_move_id != -1)
 				m_move_has_really_moved = true;
 
-			if (btn->repeatcounter < btn->repeatdelay) continue;
+			if (button.repeatcounter < button.repeatdelay)
+				continue;
 
-			btn->repeatcounter              = 0;
+			button.repeatcounter            = 0;
 			SEvent translated;
 			memset(&translated, 0, sizeof(SEvent));
 			translated.EventType            = irr::EET_KEY_INPUT_EVENT;
-			translated.KeyInput.Key         = btn->keycode;
+			translated.KeyInput.Key         = button.keycode;
 			translated.KeyInput.PressedDown = false;
 			m_receiver->OnEvent(translated);
 
@@ -1264,22 +1162,18 @@ void TouchScreenGUI::registerHudItem(int index, const rect<s32> &rect)
 void TouchScreenGUI::Toggle(bool visible)
 {
 	m_visible = visible;
-	for (unsigned int i = 0; i < after_last_element_id; i++) {
-		button_info *btn = &m_buttons[i];
-		if (btn->guibutton) {
-			btn->guibutton->setVisible(visible);
-		}
+	for (auto &button : m_buttons) {
+		if (button.guibutton)
+			button.guibutton->setVisible(visible);
 	}
 
-	if (m_joystick_btn_off->guibutton) {
+	if (m_joystick_btn_off->guibutton)
 		m_joystick_btn_off->guibutton->setVisible(visible);
-	}
 
 	// clear all active buttons
 	if (!visible) {
-		while (m_known_ids.size() > 0) {
+		while (!m_known_ids.empty())
 			handleReleaseEvent(m_known_ids.begin()->id);
-		}
 
 		m_settingsbar.hide();
 		m_rarecontrolsbar.hide();

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -80,21 +80,22 @@ typedef enum
 } autohide_button_bar_dir;
 
 #define MIN_DIG_TIME_MS 500
-#define MAX_TOUCH_COUNT 64
 #define BUTTON_REPEAT_DELAY 0.2f
-
 #define SETTINGS_BAR_Y_OFFSET 5
 #define RARE_CONTROLS_BAR_Y_OFFSET 5
 
-extern const char **touchgui_button_imagenames;
-extern const char **touchgui_joystick_imagenames;
+// Very slow button repeat frequency
+#define SLOW_BUTTON_REPEAT 1.0f
+
+extern const char **button_imagenames;
+extern const char **joystick_imagenames;
 
 struct button_info
 {
 	float repeatcounter;
 	float repeatdelay;
 	irr::EKEY_CODE keycode;
-	std::vector<int> ids;
+	std::vector<size_t> ids;
 	IGUIButton *guibutton = nullptr;
 	bool immediate_release;
 
@@ -109,8 +110,8 @@ public:
 	AutoHideButtonBar(IrrlichtDevice *device, IEventReceiver *receiver);
 
 	void init(ISimpleTextureSource *tsrc, const char *starter_img, int button_id,
-			v2s32 UpperLeft, v2s32 LowerRight, autohide_button_bar_dir dir,
-			float timeout);
+			const v2s32 &UpperLeft, const v2s32 &LowerRight,
+			autohide_button_bar_dir dir, float timeout);
 
 	~AutoHideButtonBar();
 
@@ -124,9 +125,6 @@ public:
 
 	// detect settings bar button events
 	bool isButton(const SEvent &event);
-
-	// handle released hud buttons
-	bool isReleaseButton(int eventID);
 
 	// step handler
 	void step(float dtime);
@@ -182,7 +180,7 @@ public:
 
 	double getPitch() { return m_camera_pitch; }
 
-	/*!
+	/*
 	 * Returns a line which describes what the player is pointing at.
 	 * The starting point and looking direction are significant,
 	 * the line should be scaled to match its length to the actual distance
@@ -206,9 +204,10 @@ private:
 	IEventReceiver *m_receiver;
 	ISimpleTextureSource *m_texturesource;
 	v2u32 m_screensize;
+	s32 button_size;
 	double m_touchscreen_threshold;
 	std::map<int, rect<s32>> m_hud_rects;
-	std::map<int, irr::EKEY_CODE> m_hud_ids;
+	std::map<size_t, irr::EKEY_CODE> m_hud_ids;
 	bool m_visible; // is the gui visible
 
 	// value in degree
@@ -220,7 +219,7 @@ private:
 			forward_id, backward_id, left_id, right_id, special1_id};
 	bool m_joystick_status[5] = {false, false, false, false, false};
 
-	/*!
+	/*
 	 * A line starting at the camera and pointing towards the
 	 * selected object.
 	 * The line ends on the camera's far plane.
@@ -248,23 +247,24 @@ private:
 	touch_gui_button_id getButtonID(s32 x, s32 y);
 
 	// gui button by eventID
-	touch_gui_button_id getButtonID(int eventID);
+	touch_gui_button_id getButtonID(size_t eventID);
 
 	// check if a button has changed
 	void handleChangedButton(const SEvent &event);
 
 	// initialize a button
-	void initButton(touch_gui_button_id id, rect<s32> button_rect,
-			std::wstring caption, bool immediate_release,
+	void initButton(touch_gui_button_id id, const rect<s32> &button_rect,
+			const std::wstring &caption, bool immediate_release,
 			float repeat_delay = BUTTON_REPEAT_DELAY);
 
 	// initialize a joystick button
-	button_info *initJoystickButton(touch_gui_button_id id, rect<s32> button_rect,
-			int texture_id, bool visible = true);
+	button_info *initJoystickButton(touch_gui_button_id id,
+			const rect<s32> &button_rect, int texture_id,
+			bool visible = true);
 
 	struct id_status
 	{
-		int id;
+		size_t id;
 		int X;
 		int Y;
 	};
@@ -273,27 +273,21 @@ private:
 	std::vector<id_status> m_known_ids;
 
 	// handle a button event
-	void handleButtonEvent(touch_gui_button_id bID, int eventID, bool action);
+	void handleButtonEvent(touch_gui_button_id bID, size_t eventID, bool action);
 
 	// handle pressed hud buttons
 	bool isHUDButton(const SEvent &event);
-
-	// handle released hud buttons
-	bool isReleaseHUDButton(int eventID);
 
 	// handle double taps
 	bool doubleTapDetection();
 
 	// handle release event
-	void handleReleaseEvent(int evt_id);
+	void handleReleaseEvent(size_t evt_id);
 
 	// apply joystick status
 	void applyJoystickStatus();
 
-	// get size of regular gui control button
-	int getGuiButtonSize();
-
-	// doubleclick detection variables
+	// double-click detection variables
 	struct key_event
 	{
 		u64 down_time;
@@ -302,9 +296,9 @@ private:
 	};
 
 	// array for saving last known position of a pointer
-	v2s32 m_pointerpos[MAX_TOUCH_COUNT];
+	std::map<size_t, v2s32> m_pointerpos;
 
-	// array for doubletap detection
+	// array for double tap detection
 	key_event m_key_events[2];
 
 	// settings bar
@@ -313,4 +307,5 @@ private:
 	// rare controls bar
 	AutoHideButtonBar m_rarecontrolsbar;
 };
+
 extern TouchScreenGUI *g_touchscreengui;


### PR DESCRIPTION
The PR series "fix Android and make it better" continues.

- Goal of the PR
Improving touchscreengui. (cpp and h) code style, fixing warnings, minor cleanup
TouchScreen Control: fix some bugs, cleanup
Hide tooltip after ETIE_LEFT_UP
Restore real keyboard support
- How does the PR work?
Fix bugs, improve code styling, fix compiler warnings
- Does it resolve any reported issue?
Yes, use the search and tell me
- If not a bug fix, why is this PR needed? What usecases does it solve?
This PR contain bug fixes and code style improvements

This PR is Ready for Review.

Resolved: #8879 #8424

## How to test
Compile Android port. Run. Play. Enjoy 😎
From MultiCraft with ❤️