### PR TITLE
Apply a scrollbar's default value to scroll containers

### DIFF
--- a/games/minimal/mods/test/formspec.lua
+++ b/games/minimal/mods/test/formspec.lua
@@ -251,7 +251,7 @@ Number]
 			"box[1,22.5;4,1;#a00a]"..
 		"scroll_container_end[]"..
 		"scrollbaroptions[max=170]".. -- lowest seen pos is: 0.1*170+6=23 (factor*max+height)
-		"scrollbar[7.5,0;0.3,4;vertical;scrbar;0]"..
+		"scrollbar[7.5,0;0.3,4;vertical;scrbar;20]"..
 		"scrollbar[8,0;0.3,4;vertical;scrbarhmmm;0]"..
 		"dropdown[0,6;2;hmdrpdwnnn;apple,bulb;1]",
 }

--- a/src/gui/guiScrollContainer.h
+++ b/src/gui/guiScrollContainer.h
@@ -38,7 +38,11 @@ public:
 			updateScrolling();
 	}
 
-	inline void setScrollBar(GUIScrollBar *scrollbar) { m_scrollbar = scrollbar; }
+	inline void setScrollBar(GUIScrollBar *scrollbar)
+	{
+		m_scrollbar = scrollbar;
+		updateScrolling();
+	}
 
 private:
 	enum OrientationEnum


### PR DESCRIPTION
- Fixes #9691.
- I've also updated the test formspec in minimal.
- `GUIScrollContainer::setScrollBar` now updates the scrolling, which makes sense, as there's a new scrollbar with an arbitrary scroll position.
(I thought about replacing the pointer parameter with a reference because the pointer must not be a nullptr. But the code style guidelines forbid this, it's too C++y.)

## To do

This PR is a Ready for Review.

## How to test

- Go to minimal and do `/formspec`. Then, after clicking the scroll container tab, try dragging the scrollbar and don't notice sudden jumps.
- Alternative: Do the steps in #9691.