### PR TITLE
Formspec: allow lists to change size and existence while the formspec is open

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -489,36 +489,8 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 			start_i = stoi(startindex);
 
 		if (geom.X < 0 || geom.Y < 0 || start_i < 0) {
-			errorstream<< "Invalid list element: '" << element << "'"  << std::endl;
+			errorstream << "Invalid list element: '" << element << "'"  << std::endl;
 			return;
-		}
-
-		// check for the existence of inventory and list
-		Inventory *inv = m_invmgr->getInventory(loc);
-		if (!inv) {
-			warningstream << "GUIFormSpecMenu::parseList(): "
-					<< "The inventory location "
-					<< "\"" << loc.dump() << "\" doesn't exist"
-					<< std::endl;
-			return;
-		}
-		InventoryList *ilist = inv->getList(listname);
-		if (!ilist) {
-			warningstream << "GUIFormSpecMenu::parseList(): "
-					<< "The inventory list \"" << listname << "\" "
-					<< "@ \"" << loc.dump() << "\" doesn't exist"
-					<< std::endl;
-			return;
-		}
-
-		// trim geom if it is larger than the actual inventory size
-		s32 list_size = (s32)ilist->getSize();
-		if (list_size < geom.X * geom.Y + start_i) {
-			list_size -= MYMAX(start_i, 0);
-			geom.Y = list_size / geom.X;
-			geom.Y += list_size % geom.X > 0 ? 1 : 0;
-			if (geom.Y <= 1)
-				geom.X = list_size;
 		}
 
 		if (!data->explicit_size)

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -107,7 +107,7 @@ private:
 	const InventoryLocation m_inventoryloc;
 	const std::string m_listname;
 
-	// specifies the width and height of the inventorylist in itemslots
+	// the specified width and height of the shown inventorylist in itemslots
 	const v2s32 m_geom;
 	// the first item's index in inventory
 	const s32 m_start_item_i;
@@ -127,4 +127,7 @@ private:
 
 	// the index of the hovered item; -1 if no item is hovered
 	s32 m_hovered_i;
+
+	// we do not want to write a warning on every draw
+	bool m_already_warned;
 };


### PR DESCRIPTION
- Goal of the PR: Fix a regression.
- How does the PR work? (All functional are changes listed here to make reviewing easier.)
  - `GUIFormSpecMenu::parseList` no longer checks for the existence of the inventory.
  - `GUIInventoryList::m_geom` is now exactly the geom given in the formspec string. If only a smaller inventory should be drawn, that is decided in `GUIFormSpecMenu::draw`. (Inventories can change their size any time.) Hence there's no more trimming of geom.
  - To avoid a flood of warnings, there's now `GUIInventoryList::m_already_warned`. Only one warning is written in a row.
  - `GUIInventoryList::getItemIndexAtPos` is improved. It now also returns `-1` if there can not be an item at the specified position because the inventory list is too small.
- Fixes #9640.

## To do

This PR is a Ready for Review.

## How to test

- Use the code from here: https://github.com/minetest/minetest/issues/9640#issuecomment-612431262
- Try the [inventorybags](https://github.com/cx384/inventorybags) mod.