### PR TITLE
set_fov: Add support for time-based transitions

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5980,15 +5980,18 @@ object you are working with still exists.
         * max: bubbles bar is not shown
         * See [Object properties] for more information
     * Is limited to range 0 ... 65535 (2^16 - 1)
-* `set_fov(fov, is_multiplier)`: Sets player's FOV
+* `set_fov(fov, is_multiplier, transition_time)`: Sets player's FOV
     * `fov`: FOV value.
     * `is_multiplier`: Set to `true` if the FOV value is a multiplier.
       Defaults to `false`.
-    * Set to 0 to clear FOV override.
-* `get_fov()`:
-    * Returns player's FOV override in degrees, and a boolean depending on whether
-      the value is a multiplier.
-    * Returns 0 as first value if player's FOV hasn't been overridden.
+    * `transition_time`: If defined, enables smooth FOV transition.
+      Interpreted as the time (in seconds) to reach target FOV.
+      If set to 0, FOV change is instantaneous. Defaults to 0.
+    * Set `fov` to 0 to clear FOV override.
+* `get_fov()`: Returns the following:
+    * Server-sent FOV value. Returns 0 if an FOV override doesn't exist.
+    * Boolean indicating whether the FOV value is a multiplier.
+    * Time (in seconds) taken for the FOV transition. Set by `set_fov`.
 * `set_attribute(attribute, value)`:  DEPRECATED, use get_meta() instead
     * Sets an extra attribute with value on player.
     * `value` must be a string, or a number which will be converted to a

--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -112,6 +112,9 @@ public:
 		return MYMAX(m_fov_x, m_fov_y);
 	}
 
+	// Notify about new server-sent FOV and initialize smooth FOV transition
+	void notifyFovChange();
+
 	// Checks if the constructor was able to create the scene nodes
 	bool successfullyCreated(std::string &error_message);
 
@@ -186,12 +189,23 @@ private:
 
 	Client *m_client;
 
+	// Default Client FOV (as defined by the "fov" setting)
+	f32 m_cache_fov;
+
 	// Absolute camera position
 	v3f m_camera_position;
 	// Absolute camera direction
 	v3f m_camera_direction;
 	// Camera offset
 	v3s16 m_camera_offset;
+
+	// Server-sent FOV variables
+	bool m_server_sent_fov = false;
+	f32 m_curr_fov_degrees, m_old_fov_degrees, m_target_fov_degrees;
+
+	// FOV transition variables
+	bool m_fov_transition_active = false;
+	f32 m_fov_diff, m_transition_time;
 
 	v2f m_wieldmesh_offset = v2f(55.0f, -35.0f);
 	v2f m_arm_dir;
@@ -230,7 +244,6 @@ private:
 
 	f32 m_cache_fall_bobbing_amount;
 	f32 m_cache_view_bobbing_amount;
-	f32 m_cache_fov;
 	bool m_arm_inertia;
 
 	std::list<Nametag *> m_nametags;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/client.h"
 
 #include "util/base64.h"
+#include "client/camera.h"
 #include "chatmessage.h"
 #include "client/clientmedia.h"
 #include "log.h"
@@ -530,11 +531,21 @@ void Client::handleCommand_Movement(NetworkPacket* pkt)
 void Client::handleCommand_Fov(NetworkPacket *pkt)
 {
 	f32 fov;
-	bool is_multiplier;
+	bool is_multiplier = false;
+	f32 transition_time = 0.0f;
+
 	*pkt >> fov >> is_multiplier;
 
+	// Wrap transition_time extraction within a
+	// try-catch to preserve backwards compat
+	try {
+		*pkt >> transition_time;
+	} catch (PacketError &e) {};
+
 	LocalPlayer *player = m_env.getLocalPlayer();
-	player->setFov({ fov, is_multiplier });
+	assert(player);
+	player->setFov({ fov, is_multiplier, transition_time });
+	m_camera->notifyFovChange();
 }
 
 void Client::handleCommand_HP(NetworkPacket *pkt)

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -384,8 +384,9 @@ enum ToClientCommand
 	/*
 		Sends an FOV override/multiplier to client.
 
-		float fov
+		f32 fov
 		bool is_multiplier
+		f32 transition_time
 	*/
 
 	TOCLIENT_DEATHSCREEN = 0x37,

--- a/src/player.h
+++ b/src/player.h
@@ -35,7 +35,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 struct PlayerFovSpec
 {
 	f32 fov;
+
+	// Whether to multiply the client's FOV or to override it
 	bool is_multiplier;
+
+	// The time to be take to trasition to the new FOV value.
+	// Transition is instantaneous if omitted. Omitted by default.
+	f32 transition_time;
 };
 
 struct PlayerControl
@@ -186,12 +192,12 @@ public:
 
 	void setFov(const PlayerFovSpec &spec)
 	{
-		m_fov_spec = spec;
+		m_fov_override_spec = spec;
 	}
 
 	const PlayerFovSpec &getFov() const
 	{
-		return m_fov_spec;
+		return m_fov_override_spec;
 	}
 
 	u32 keyPressed = 0;
@@ -208,7 +214,7 @@ protected:
 	char m_name[PLAYERNAME_SIZE];
 	v3f m_speed;
 	u16 m_wield_index = 0;
-	PlayerFovSpec m_fov_spec = { 0.0f, false };
+	PlayerFovSpec m_fov_override_spec = { 0.0f, false, 0.0f };
 
 	std::vector<HudElement *> hud;
 private:

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1252,7 +1252,7 @@ int ObjectRef::l_set_look_yaw(lua_State *L)
 	return 1;
 }
 
-// set_fov(self, degrees[, is_multiplier])
+// set_fov(self, degrees[, is_multiplier, transition_time])
 int ObjectRef::l_set_fov(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -1261,7 +1261,11 @@ int ObjectRef::l_set_fov(lua_State *L)
 	if (!player)
 		return 0;
 
-	player->setFov({ static_cast<f32>(luaL_checknumber(L, 2)), readParam<bool>(L, 3) });
+	player->setFov({
+		static_cast<f32>(luaL_checknumber(L, 2)),
+		readParam<bool>(L, 3, false),
+		lua_isnumber(L, 4) ? static_cast<f32>(luaL_checknumber(L, 4)) : 0.0f
+	});
 	getServer(L)->SendPlayerFov(player->getPeerId());
 
 	return 0;
@@ -1279,8 +1283,9 @@ int ObjectRef::l_get_fov(lua_State *L)
 	PlayerFovSpec fov_spec = player->getFov();
 	lua_pushnumber(L, fov_spec.fov);
 	lua_pushboolean(L, fov_spec.is_multiplier);
+	lua_pushnumber(L, fov_spec.transition_time);
 
-	return 2;
+	return 3;
 }
 
 // set_breath(self, breath)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1856,10 +1856,10 @@ void Server::SendMovePlayer(session_t peer_id)
 
 void Server::SendPlayerFov(session_t peer_id)
 {
-	NetworkPacket pkt(TOCLIENT_FOV, 4 + 1, peer_id);
+	NetworkPacket pkt(TOCLIENT_FOV, 4 + 1 + 4, peer_id);
 
 	PlayerFovSpec fov_spec = m_env->getPlayer(peer_id)->getFov();
-	pkt << fov_spec.fov << fov_spec.is_multiplier;
+	pkt << fov_spec.fov << fov_spec.is_multiplier << fov_spec.transition_time;
 
 	Send(&pkt);
 }


### PR DESCRIPTION
Closes #9696

This PR allows mods to specify a time-duration as the third argument to `ObjectRef:set_fov`, which allows for smooth FOV transitions. Omitting this argument or passing 0 makes the FOV change instantaneous. Unless explicitly specified, set_fov results in instantaneous FOV changes by default.

Video demonstration: https://youtu.be/dNl-yq5IcVw

This PR is ready for review.

## How to test

<details>
<summary>Here's a chat-command to help with testing this PR</summary>

```lua
-- /setfov <fov> <true|false> <time>
-- supports numbers with decimal points, like 1.25
-- e.g.    /setfov 0.5 true 5
minetest.register_chatcommand("setfov", {
	func = function(name, param)
		local fov, is_mult, time = param:match("^(%d+%.?%d*) (%a+) (%d+%.?%d*)$")
		minetest.chat_send_all("set_fov | fov = " .. fov .. ", is_mult = " .. is_mult .. ", time = " .. (time or "nil"))
		is_mult = minetest.is_yes(is_mult) and true or false
		minetest.get_player_by_name(name):set_fov(fov, is_mult, time)
	end
})
```

</details>

### Things to test

- FOV override (instantaneous)
- FOV multiplier (instantaneous)
- FOV override (w/ transition)
- FOV multiplier (w/ transition)
- `set_fov(0)` - should immediately clear server-sent FOV overrides, even if a transition is in progress. 
- FOV transition while another transition is already in progress (it's recommended to pass a large time value like 10 for ease of testing this). New transition should pick up right from where the old transition stopped. The new transition would still take the specified time to reach the target FOV.
- Combinations of builtin zooming (using zoom key) and various `set_fov` invokations. Builtin zooming **should not** work if server-sent FOV is enforced, even during a transition.