### PR TITLE
Restructure teleport command code

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -522,7 +522,7 @@ core.register_chatcommand("teleport", {
 			return teleport_to_player(teleportee_name, target_name)
 		end
 
-		return false, 'Invalid parameters "' .. param .. '"; see /help teleport'
+		return false
 	end,
 })
 

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -430,7 +430,7 @@ local function find_free_position_near(pos)
 	for _, d in ipairs(tries) do
 		local p = vector.add(pos, d)
 		local n = core.get_node_or_nil(p)
-		if n and n.name then
+		if n then
 			local def = core.registered_nodes[n.name]
 			if def and not def.walkable then
 				return p

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -253,57 +253,76 @@ core.register_chatcommand("grantme", {
 	end,
 })
 
+local function handle_revoke_command(caller, revokename, revokeprivstr)
+	local caller_privs = core.get_player_privs(caller)
+	if not (caller_privs.privs or caller_privs.basic_privs) then
+		return false, "Your privileges are insufficient."
+	end
+
+	if not core.get_auth_handler().get_auth(revokename) then
+		return false, "Player " .. revokename .. " does not exist."
+	end
+
+	local revokeprivs = core.string_to_privs(revokeprivstr)
+	local privs = core.get_player_privs(revokename)
+	local basic_privs =
+		core.string_to_privs(core.settings:get("basic_privs") or "interact,shout")
+	for priv, _ in pairs(revokeprivs) do
+		if not basic_privs[priv] and not caller_privs.privs then
+			return false, "Your privileges are insufficient."
+		end
+	end
+
+	if revokeprivstr == "all" then
+		revokeprivs = privs
+		privs = {}
+	else
+		for priv, _ in pairs(revokeprivs) do
+			privs[priv] = nil
+		end
+	end
+
+	for priv, _ in pairs(revokeprivs) do
+		-- call the on_revoke callbacks
+		core.run_priv_callbacks(revokename, priv, caller, "revoke")
+	end
+
+	core.set_player_privs(revokename, privs)
+	core.log("action", caller..' revoked ('
+			..core.privs_to_string(revokeprivs, ', ')
+			..') privileges from '..revokename)
+	if revokename ~= caller then
+		core.chat_send_player(revokename, caller
+			.. " revoked privileges from you: "
+			.. core.privs_to_string(revokeprivs, ' '))
+	end
+	return true, "Privileges of " .. revokename .. ": "
+		.. core.privs_to_string(
+			core.get_player_privs(revokename), ' ')
+end
+
 core.register_chatcommand("revoke", {
 	params = "<name> (<privilege> | all)",
 	description = "Remove privileges from player",
 	privs = {},
 	func = function(name, param)
-		if not core.check_player_privs(name, {privs=true}) and
-				not core.check_player_privs(name, {basic_privs=true}) then
-			return false, "Your privileges are insufficient."
-		end
-		local revoke_name, revoke_priv_str = string.match(param, "([^ ]+) (.+)")
-		if not revoke_name or not revoke_priv_str then
+		local revokename, revokeprivstr = string.match(param, "([^ ]+) (.+)")
+		if not revokename or not revokeprivstr then
 			return false, "Invalid parameters (see /help revoke)"
-		elseif not core.get_auth_handler().get_auth(revoke_name) then
-			return false, "Player " .. revoke_name .. " does not exist."
 		end
-		local revoke_privs = core.string_to_privs(revoke_priv_str)
-		local privs = core.get_player_privs(revoke_name)
-		local basic_privs =
-			core.string_to_privs(core.settings:get("basic_privs") or "interact,shout")
-		for priv, _ in pairs(revoke_privs) do
-			if not basic_privs[priv] and
-					not core.check_player_privs(name, {privs=true}) then
-				return false, "Your privileges are insufficient."
-			end
-		end
-		if revoke_priv_str == "all" then
-			revoke_privs = privs
-			privs = {}
-		else
-			for priv, _ in pairs(revoke_privs) do
-				privs[priv] = nil
-			end
-		end
+		return handle_revoke_command(name, revokename, revokeprivstr)
+	end,
+})
 
-		for priv, _ in pairs(revoke_privs) do
-			-- call the on_revoke callbacks
-			core.run_priv_callbacks(revoke_name, priv, name, "revoke")
+core.register_chatcommand("revokeme", {
+	params = "<privilege> | all",
+	description = "Revoke privileges from yourself",
+	privs = {},
+	func = function(name, param)
+		if param == "" then
+			return false, "Invalid parameters (see /help revokeme)"
 		end
-
-		core.set_player_privs(revoke_name, privs)
-		core.log("action", name..' revoked ('
-				..core.privs_to_string(revoke_privs, ', ')
-				..') privileges from '..revoke_name)
-		if revoke_name ~= name then
-			core.chat_send_player(revoke_name, name
-					.. " revoked privileges from you: "
-					.. core.privs_to_string(revoke_privs, ' '))
-		end
-		return true, "Privileges of " .. revoke_name .. ": "
-			.. core.privs_to_string(
-				core.get_player_privs(revoke_name), ' ')
+		return handle_revoke_command(name, name, param)
 	end,
 })
 
@@ -733,8 +752,9 @@ core.register_chatcommand("spawnentity", {
 			end
 		end
 		p.y = p.y + 1
-		core.add_entity(p, entityname)
-		return true, ("%q spawned."):format(entityname)
+		local obj = core.add_entity(p, entityname)
+		local msg = obj and "%q spawned." or "%q failed to spawn."
+		return true, msg:format(entityname)
 	end,
 })
 
@@ -773,7 +793,7 @@ core.register_chatcommand("rollback_check", {
 	params = "[<range>] [<seconds>] [<limit>]",
 	description = "Check who last touched a node or a node near it"
 			.. " within the time specified by <seconds>. Default: range = 0,"
-			.. " seconds = 86400 = 24h, limit = 5",
+			.. " seconds = 86400 = 24h, limit = 5. Set <seconds> to inf for no time limit",
 	privs = {rollback=true},
 	func = function(name, param)
 		if not core.settings:get_bool("enable_rollback_recording") then
@@ -824,7 +844,7 @@ core.register_chatcommand("rollback_check", {
 
 core.register_chatcommand("rollback", {
 	params = "(<name> [<seconds>]) | (:<actor> [<seconds>])",
-	description = "Revert actions of a player. Default for <seconds> is 60",
+	description = "Revert actions of a player. Default for <seconds> is 60. Set <seconds> to inf for no time limit",
 	privs = {rollback=true},
 	func = function(name, param)
 		if not core.settings:get_bool("enable_rollback_recording") then
@@ -1052,7 +1072,7 @@ core.register_chatcommand("last-login", {
 			param = name
 		end
 		local pauth = core.get_auth_handler().get_auth(param)
-		if pauth and pauth.last_login then
+		if pauth and pauth.last_login and pauth.last_login ~= -1 then
 			-- Time in UTC, ISO 8601 format
 			return true, param.."'s last login time was " ..
 				os.date("!%Y-%m-%dT%H:%M:%SZ", pauth.last_login)

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -456,7 +456,7 @@ local function teleport_to_pos(name, p)
 			" is attached to an object!"
 	end
 	teleportee:set_pos(p)
-	return true, "Teleporting " .. name .. " to " .. core.pos_to_string(p, 1))
+	return true, "Teleporting " .. name .. " to " .. core.pos_to_string(p, 1)
 end
 
 -- Teleports player <name> next to player <target_name> if possible

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -479,7 +479,7 @@ local function teleport_to_player(name, target_name)
 	local p = find_free_position_near(target:get_pos())
 	teleportee:set_pos(p)
 	return true, "Teleporting " .. name .. " to " .. target_name .. " at " ..
-		core.pos_to_string(p)
+		core.pos_to_string(p, 1)
 end
 
 core.register_chatcommand("teleport", {

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -457,7 +457,7 @@ local function teleport_to_player(name, target_name)
 	if not target then
 		return false, "Cannot get target player with name " .. target_name
 	end
-	p = find_free_position_near(target:get_pos())
+	local p = find_free_position_near(target:get_pos())
 	teleportee:set_pos(p)
 	return true, "Teleporting " .. name .. " to " .. target_name .. " at " ..
 		core.pos_to_string(p)

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -456,7 +456,7 @@ local function teleport_to_pos(name, p)
 			" is attached to an object!"
 	end
 	teleportee:set_pos(p)
-	return true, "Teleporting " .. name .. " to " .. core.pos_to_string(p)
+	return true, "Teleporting " .. name .. " to " .. core.pos_to_string(p, 1))
 end
 
 -- Teleports player <name> next to player <target_name> if possible


### PR DESCRIPTION
I think the current (master) code is difficult to understand because the parameter existence testing is mixed with the actual teleport code, so I've changed the code.

There are also functional changes:
* The player who is teleported is always shown in the (success) messages
* A player cannot teleport to oneself (or bring a player to itself); this fixes #9704
* When the player does not exist, it shows a different message than the generic see /help one
* It is no longer possible to teleport outside of the map; before it was only possible with the bring privilege
* (There may be more changes not mentioned here)
