### PR TITLE
Add minetest.register_player_on_step

### DIFF
--- a/builtin/game/init.lua
+++ b/builtin/game/init.lua
@@ -34,5 +34,6 @@ dofile(gamepath .. "voxelarea.lua")
 dofile(gamepath .. "forceloading.lua")
 dofile(gamepath .. "statbars.lua")
 dofile(gamepath .. "knockback.lua")
+dofile(gamepath .. "player_on_step.lua")
 
 profiler = nil

--- a/builtin/game/player_on_step.lua
+++ b/builtin/game/player_on_step.lua
@@ -1,18 +1,18 @@
 
--- stuff for core.register_player_on_slow_step
+-- stuff for core.register_on_player_interval
 local time = 0.0
 local time_next = math.huge
 local step_sizes = {}
 local expiring_times = {}
 
--- override core.register_player_on_slow_step to also store the step size in
+-- override core.register_on_player_interval to also store the step size in
 -- step_sizes and update expiring_times and time_next
-local old_register_player_on_slow_step = core.register_player_on_slow_step
+local old_register_on_player_interval = core.register_on_player_interval
 
-function core.register_player_on_slow_step(step_size, func)
-	old_register_player_on_slow_step(func)
+function core.register_on_player_interval(step_size, func)
+	old_register_on_player_interval(func)
 
-	local index = #core.registered_player_on_slow_steps
+	local index = #core.registered_on_player_intervals
 	step_sizes[index] = step_size
 	expiring_times[index] = step_size
 	time_next = math.min(time_next, step_size)
@@ -21,13 +21,13 @@ end
 core.register_globalstep(function(dtime)
 	local players = core.get_connected_players()
 
-	-- core.register_player_on_step
-	for i = 1, #players do
+	-- core.register_on_player_step
+	for k = 1, #players do
 		-- the callback mode does not matter
-		core.run_callbacks(core.registered_player_on_steps, 0, players[i], dtime)
+		core.run_callbacks(core.registered_on_player_steps, 0, players[k], dtime)
 	end
 
-	-- core.register_player_on_slow_step
+	-- core.register_on_player_interval
 	time = time + dtime
 
 	if time < time_next then
@@ -41,7 +41,7 @@ core.register_globalstep(function(dtime)
 		if time >= exp_time then
 			-- time expired
 			-- call it
-			local func = core.registered_player_on_slow_steps[i]
+			local func = core.registered_on_player_intervals[i]
 			core.set_last_run_mod(core.callback_origins[func])
 			for i = 1, #players do
 				func(players[i])

--- a/builtin/game/player_on_step.lua
+++ b/builtin/game/player_on_step.lua
@@ -1,9 +1,57 @@
 
-core.register_globalstep(function(...)
+-- stuff for core.register_player_on_slow_step
+local time = 0.0
+local time_next = math.huge
+local step_sizes = {}
+local expiring_times = {}
+
+-- override core.register_player_on_slow_step to also store the step size in
+-- step_sizes and update expiring_times and time_next
+local old_register_player_on_slow_step = core.register_player_on_slow_step
+
+function core.register_player_on_slow_step(step_size, func)
+	old_register_player_on_slow_step(func)
+
+	local index = #core.registered_player_on_slow_steps
+	step_sizes[index] = step_size
+	expiring_times[index] = step_size
+	time_next = math.min(time_next, step_size)
+end
+
+core.register_globalstep(function(dtime)
 	local players = core.get_connected_players()
+
+	-- core.register_player_on_step
 	for i = 1, #players do
-		-- callback mode 5: RUN_CALLBACKS_MODE_OR_SC
-		-- if any callback returns true, the player is kicked or similar
-		core.run_callbacks(core.registered_player_on_steps, 5, players[i], ...)
+		-- the callback mode does not matter
+		core.run_callbacks(core.registered_player_on_steps, 0, players[i], dtime)
+	end
+
+	-- core.register_player_on_slow_step
+	time = time + dtime
+
+	if time < time_next then
+		return
+	end
+
+	time_next = math.huge
+
+	for i = 1, #expiring_times do
+		local exp_time = expiring_times[i]
+		if time >= exp_time then
+			-- time expired
+			-- call it
+			local func = core.registered_player_on_slow_steps[i]
+			core.set_last_run_mod(core.callback_origins[func])
+			for i = 1, #players do
+				func(players[i])
+			end
+			-- reset the timer
+			exp_time = time + step_sizes[i]
+			expiring_times[i] = exp_time
+		end
+		if time_next > exp_time then
+			time_next = exp_time
+		end
 	end
 end)

--- a/builtin/game/player_on_step.lua
+++ b/builtin/game/player_on_step.lua
@@ -1,0 +1,9 @@
+
+core.register_globalstep(function(...)
+	local players = core.get_connected_players()
+	for i = 1, #players do
+		-- callback mode 5: RUN_CALLBACKS_MODE_OR_SC
+		-- if any callback returns true, the player is kicked or similar
+		core.run_callbacks(core.registered_player_on_steps, 5, players[i], ...)
+	end
+end)

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -612,6 +612,7 @@ core.registered_on_modchannel_message, core.register_on_modchannel_message = mak
 core.registered_on_auth_fail, core.register_on_auth_fail = make_registration()
 core.registered_on_player_inventory_actions, core.register_on_player_inventory_action = make_registration()
 core.registered_allow_player_inventory_actions, core.register_allow_player_inventory_action = make_registration()
+core.registered_player_on_steps, core.register_player_on_step = make_registration()
 
 --
 -- Compatibility for on_mapgen_init()

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -613,6 +613,7 @@ core.registered_on_auth_fail, core.register_on_auth_fail = make_registration()
 core.registered_on_player_inventory_actions, core.register_on_player_inventory_action = make_registration()
 core.registered_allow_player_inventory_actions, core.register_allow_player_inventory_action = make_registration()
 core.registered_player_on_steps, core.register_player_on_step = make_registration()
+core.registered_player_on_slow_steps, core.register_player_on_slow_step = make_registration()
 
 --
 -- Compatibility for on_mapgen_init()

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -612,8 +612,8 @@ core.registered_on_modchannel_message, core.register_on_modchannel_message = mak
 core.registered_on_auth_fail, core.register_on_auth_fail = make_registration()
 core.registered_on_player_inventory_actions, core.register_on_player_inventory_action = make_registration()
 core.registered_allow_player_inventory_actions, core.register_allow_player_inventory_action = make_registration()
-core.registered_player_on_steps, core.register_player_on_step = make_registration()
-core.registered_player_on_slow_steps, core.register_player_on_slow_step = make_registration()
+core.registered_on_player_steps, core.register_on_player_step = make_registration()
+core.registered_on_player_intervals, core.register_on_player_interval = make_registration()
 
 --
 -- Compatibility for on_mapgen_init()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4375,6 +4375,12 @@ Call these functions only at load time!
 * `minetest.register_on_leaveplayer(function(ObjectRef, timed_out))`
     * Called when a player leaves the game
     * `timed_out`: True for timeout, false for other reasons.
+* `minetest.register_player_on_step(function(ObjectRef, dtime))`
+    * Called for every player on every server step.
+    * `ObjectRef`: The player.
+    * `dtime`: Time from last step (see also `minetest.register_globalstep`).
+    * Return `true` to avoid further `on_step`-callbacks to be called on this player (ie. if the
+      `ObjectRef` is no longer valid).
 * `minetest.register_on_auth_fail(function(name, ip))`
     * Called when a client attempts to log into an account but supplies the
       wrong password.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4375,11 +4375,11 @@ Call these functions only at load time!
 * `minetest.register_on_leaveplayer(function(ObjectRef, timed_out))`
     * Called when a player leaves the game
     * `timed_out`: True for timeout, false for other reasons.
-* `minetest.register_player_on_step(function(ObjectRef, dtime))`
+* `minetest.register_on_player_step(function(ObjectRef, dtime))`
     * Called for every player on every server step.
     * `ObjectRef`: The player.
     * `dtime`: Time from last step (see also `minetest.register_globalstep`).
-* `minetest.register_player_on_slow_step(step_size, function(ObjectRef))`
+* `minetest.register_on_player_interval(step_size, function(ObjectRef))`
     * Called for every player in specified intervals.
     * `step_size`: The size of the time intervals, in seconds.
     * `ObjectRef`: The player.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4379,8 +4379,10 @@ Call these functions only at load time!
     * Called for every player on every server step.
     * `ObjectRef`: The player.
     * `dtime`: Time from last step (see also `minetest.register_globalstep`).
-    * Return `true` to avoid further `on_step`-callbacks to be called on this player (ie. if the
-      `ObjectRef` is no longer valid).
+* `minetest.register_player_on_slow_step(step_size, function(ObjectRef))`
+    * Called for every player in specified intervals.
+    * `step_size`: The size of the time intervals, in seconds.
+    * `ObjectRef`: The player.
 * `minetest.register_on_auth_fail(function(name, ip))`
     * Called when a client attempts to log into an account but supplies the
       wrong password.


### PR DESCRIPTION
- Implements, and hence closes #9707.
- To avoid the objref becoming invalid, it's also possible to return `true` to avoid further calls on this player.

@nerzhul 

## To do

This PR is a Ready for Review.

## How to test

```lua
local flood_chat = false

minetest.register_on_player_step(function(player, dtime)
	if not flood_chat then
		return
	end
	minetest.chat_send_all(string.format("(1) player_on_step called for %q; dtime is: %f",
			player:get_player_name(), dtime))
end)

minetest.register_on_player_step(function(player, dtime)
	if not flood_chat then
		return
	end
	minetest.chat_send_all(string.format("(2) player_on_step called for %q; dtime is: %f",
			player:get_player_name(), dtime))
	return player:get_player_name() == "singleplayer"
end)

minetest.register_on_player_step(function(player, dtime)
	if not flood_chat then
		return
	end
	minetest.chat_send_all(string.format("(3) player_on_step called for %q; dtime is: %f",
			player:get_player_name(), dtime))
end)

minetest.register_on_player_interval(1, function(player)
	minetest.chat_send_all(string.format("player_on_slow_step with step size 1 called for %q",
			player:get_player_name()))
	flood_chat = not flood_chat
end)
```
