### PR TITLE
Fix alias handling of get_content_id

### DIFF
--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -270,17 +270,16 @@ public:
 		// Convert name according to possible alias
 		std::string name = getAlias(name_);
 		// Get the definition
-		std::map<std::string, ItemDefinition*>::const_iterator i;
-		i = m_item_definitions.find(name);
-		if(i == m_item_definitions.end())
+		auto i = m_item_definitions.find(name);
+		if (i == m_item_definitions.cend())
 			i = m_item_definitions.find("unknown");
-		assert(i != m_item_definitions.end());
+		assert(i != m_item_definitions.cend());
 		return *(i->second);
 	}
 	virtual const std::string &getAlias(const std::string &name) const
 	{
-		StringMap::const_iterator it = m_aliases.find(name);
-		if (it != m_aliases.end())
+		auto it = m_aliases.find(name);
+		if (it != m_aliases.cend())
 			return it->second;
 		return name;
 	}
@@ -300,8 +299,7 @@ public:
 		// Convert name according to possible alias
 		std::string name = getAlias(name_);
 		// Get the definition
-		std::map<std::string, ItemDefinition*>::const_iterator i;
-		return m_item_definitions.find(name) != m_item_definitions.end();
+		return m_item_definitions.find(name) != m_item_definitions.cend();
 	}
 #ifndef SERVER
 public:
@@ -443,11 +441,9 @@ public:
 	}
 	void clear()
 	{
-		for(std::map<std::string, ItemDefinition*>::const_iterator
-				i = m_item_definitions.begin();
-				i != m_item_definitions.end(); ++i)
+		for (auto &i : m_item_definitions)
 		{
-			delete i->second;
+			delete i.second;
 		}
 		m_item_definitions.clear();
 		m_aliases.clear();
@@ -520,10 +516,8 @@ public:
 		u16 count = m_item_definitions.size();
 		writeU16(os, count);
 
-		for (std::map<std::string, ItemDefinition *>::const_iterator
-				it = m_item_definitions.begin();
-				it != m_item_definitions.end(); ++it) {
-			ItemDefinition *def = it->second;
+		for (const auto &it : m_item_definitions) {
+			ItemDefinition *def = it.second;
 			// Serialize ItemDefinition and write wrapped in a string
 			std::ostringstream tmp_os(std::ios::binary);
 			def->serialize(tmp_os, protocol_version);
@@ -532,11 +526,9 @@ public:
 
 		writeU16(os, m_aliases.size());
 
-		for (StringMap::const_iterator
-				it = m_aliases.begin();
-				it != m_aliases.end(); ++it) {
-			os << serializeString(it->first);
-			os << serializeString(it->second);
+		for (const auto &it : m_aliases) {
+			os << serializeString(it.first);
+			os << serializeString(it.second);
 		}
 	}
 	void deSerialize(std::istream &is)


### PR DESCRIPTION
...also some miscellaneous cleanups in itemdef.cpp 
fixes #9632

## To do

This PR is a Ready for Review.

## How to test

<b>Put the following code in the top level of a mod, not inside a callback or chatcommand.</b>

Test that the following code succeeds:
```lua
minetest.register_alias("aliastest1", "air")
assert(minetest.get_content_id("aliastest1") == minetest.get_content_id("air"))
```

Test that the following code throws an error:
```lua
minetest.register_alias("aliastest2", "asdf:asdf")
minetest.get_content_id("aliastest2")
```