### PR TITLE
Android: add OpenGL ES 2 support

### DIFF
--- a/build/android/app/build.gradle
+++ b/build/android/app/build.gradle
@@ -63,8 +63,12 @@ task prepareAssets() {
 	copy {
 		from "${projRoot}/builtin" into "${assetsFolder}/builtin"
 	}
-	copy {
+	/*copy {
+		// ToDo: fix Minetest shaders that currently don't work with OpenGL ES
 		from "${projRoot}/client/shaders" into "${assetsFolder}/client/shaders"
+	}*/
+	copy {
+		from "../native/deps/Android/Irrlicht/shaders" into "${assetsFolder}/client/shaders/Irrlicht"
 	}
 	copy {
 		from "${projRoot}/fonts" include "*.ttf" into "${assetsFolder}/fonts"
@@ -73,8 +77,7 @@ task prepareAssets() {
 		from "${projRoot}/games/${gameToCopy}" into "${assetsFolder}/games/${gameToCopy}"
 	}
 	/*copy {
-		// locales broken right now
-		// ToDo: fix it!
+		// ToDo: fix broken locales
 		from "${projRoot}/po" into "${assetsFolder}/po"
 	}*/
 	copy {

--- a/build/android/build.gradle
+++ b/build/android/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:3.6.2'
+		classpath 'com.android.tools.build:gradle:3.6.3'
 		classpath 'org.ajoberstar.grgit:grgit-gradle:4.0.2'
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -130,12 +130,9 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	params.HighPrecisionFPU = g_settings->getBool("high_precision_fpu");
 	params.ZBufferBits = 24;
 #ifdef __ANDROID__
-	// clang-format off
 	params.PrivateData = porting::app_global;
-	params.OGLES2ShaderPath = std::string(porting::path_user + DIR_DELIM + "media" +
-		DIR_DELIM + "Shaders" + DIR_DELIM).c_str();
-	// clang-format on
-#elif ENABLE_GLES
+#endif
+#if ENABLE_GLES
 	// there is no standardized path for these on desktop
 	std::string rel_path = std::string("client") + DIR_DELIM
 			+ "shaders" + DIR_DELIM + "Irrlicht";


### PR DESCRIPTION
Won't work without latest commits from:
https://github.com/MultiCraft/deps/commits/master

The name PR speaks for itself.
**ogle2** is (most often) better performance, better compatibility, and a slightly newer (for several years) technology.

Resolves: https://github.com/minetest/minetest/issues/9710, https://github.com/minetest/minetest/issues/5929