### PR TITLE
Extended motion mechanics API for LuaEntitySAOs

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1501,13 +1501,22 @@ Exact pointing location (currently only `Raycast` supports these fields):
 `move_result`
 ---------------
 
-* `{collides_xz, collides_y, is_standing, touched_objects, collisions}`
+* `{collides_xz, collides_y, standing, touched_objects, collisions}`
     * Result of collision processing for physical objects.
-    * `collides_xz`: whether a collision occured along the X or Z axis
-    * `collides_y`: whether a collision occured along the Y axis
-    * `is_standing`: whether the object is standing on top of a node
-    * `touched_objects`: ObjectRefs that the object is actively touching
-    * `collisions`: node positions intersecting the object's collision box
+    * `collides_xz`: whether this object collided along the X or Z axis
+    * `collides_y`: whether this object collided along the Y axis
+    * `steps_up`: whether this object stepped onto a stair node
+    * `standing`: whether this object is standing on a node or other object
+    * `touched_objects`: list of ObjectRefs actively touched by this object
+    * `collisions`: list of nodes intersecting this object's collision box,
+       each subtable consisting of three fields:
+        * `side`: relative direction of the collision as a unit vector
+        * `node_pos`: position of the collided node in world coordinates
+        * `is_impact`: whether the collision caused a change in velocity
+    * Note that an object-object collision is only reported for one physical
+      object being culpable for hitting another, but not the reverse. When
+      necessary, the hitter object should manually notify all objects that
+      have been hit of the resulting collision.
 
 
 Flag Specifier Format
@@ -6257,26 +6266,37 @@ object you are working with still exists.
     * Note that this will disable acceleration along the X and Z axes.
 * `unlock_velocity()`: frees the velocity along the X and Z axes
 * `is_velocity_locked()`: returns true if the velocity has been fixed
-* `set_speed(speed)`
+* `set_speed(speed, yaw_offset)`
     * Automatically fixes the velocity along the X and Z axes to correspond 
       with the current heading (yaw).
     * `speed` is a number equal to the length of the vector (vel_x,vel_z).
     * `yaw_offset` is a number representing the angular offset from normal in 
       radians, where `0` is forward and `pi` is backward (default: `0`).
+    * The object's normal is determined by its `yaw_origin` property.
     * Player-like side-stepping can be achieved with either of the following 
       values for `yaw_offset`:
-       * `pi / 2`: strafe left
-       * `-pi / 2`: strafe right
+        * `pi / 2`: strafe left
+        * `-pi / 2`: strafe right
     * A negative value for `speed` may also be used for back-tracking.
+* `add_speed(speed): increases or decreases the speed
+    * `speed` is a number
 * `set_speed_lateral(speed_x, speed_y)`
     * Similar to `set_speed()` but calculates the angular offset from normal
-      given the magnitude of speed within 2-dimensions.
+      given the magnitude of speed as a 2-dimensional vector (x,y) within the
+      object's local reference frame.
     * `speed_x` is a number representing lateral motion, where negative moves
       left, positive moves right, and zero stops (default: `0`)
     * `speed_y` is a number, where positive moves forward, negative moves
       backward, and zero stops (default: `0`)
+    * If `speed_x` is zero, then this method is equivalent to `set_speed()`
+      with `nil` for the second parameter. Other equivalencies include
+        * `set_speed_lateral(0, speed)` -> `set_speed(speed)`
+        * `set_speed_lateral(0, -speed)` -> `set_speed(-speed)`
+        * `set_speed_lateral(0, -speed)` -> `set_speed(speed, pi)`
+        * `set_speed_lateral(-speed)` -> `set_speed(speed, pi / 2)`
+        * `set_speed_lateral(speed)` -> `set_speed(speed, -pi / 2)`
     * If the model is not oriented correctly, it may be necessary to set the
-      `yaw_origin` object property.
+      object's `yaw_origin` property to correspond with its normal.
 * `set_acceleration(acc)`
     * `acc` is a vector
 * `set_acceleration_vert(acc_y)`:
@@ -6285,9 +6305,9 @@ object you are working with still exists.
 * `get_acceleration()`: returns the acceleration, a vector
 * `set_rotation(rot)`
     * `rot` is a vector in radians.
-       * `x` is pitch (elevation)
-       * `y` is yaw (heading)
-       * `z` is roll (bank)
+        * `x` is pitch (elevation)
+        * `y` is yaw (heading)
+        * `z` is roll (bank)
 * `get_rotation()`: returns the rotation, a vector, in radians
 * `set_yaw(yaw)`: sets the yaw (heading)
     * `yaw` is a number in radians (default: `0`)
@@ -6928,7 +6948,8 @@ Player properties need to be saved manually.
         automatic_face_movement_dir = 0.0,
         -- Automatically set yaw to movement direction, offset in degrees.
         -- 'false' to disable.
-        -- This property is ignored when speed is applied.
+        -- This property is ignored when speed is applied via the ObjectRef
+        -- methods `set_speed()`, `add_speed()` and `set_speed_lateral().
 
         automatic_face_movement_max_rotation_per_sec = -1,
         -- Limit automatic rotation to this value in degrees per second.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1501,17 +1501,18 @@ Exact pointing location (currently only `Raycast` supports these fields):
 `move_result`
 ---------------
 
-* `{collides_xz, collides_y, standing, touched_objects, collisions}`
+* `{collides_xz, collides_y, standing, collisions}`
     * Result of collision processing for physical objects.
     * `collides_xz`: whether this object collided along the X or Z axis
     * `collides_y`: whether this object collided along the Y axis
     * `steps_up`: whether this object stepped onto a stair node
     * `standing`: whether this object is standing on a node or other object
     * `touched_objects`: list of ObjectRefs actively touched by this object
-    * `collisions`: list of nodes intersecting this object's collision box,
-       each subtable consisting of three fields:
+    * `collisions`: list of nodes or ObjectRefs intersecting this object's
+       collision box, each subtable consisting of three fields:
         * `side`: relative direction of the collision as a unit vector
         * `node_pos`: position of the collided node in world coordinates
+        * `object`: ObjectRef of the collided object (see note below)
         * `is_impact`: whether the collision caused a change in velocity
     * Note that an object-object collision is only reported for one physical
       object being culpable for hitting another, but not the reverse. When

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1498,7 +1498,16 @@ Exact pointing location (currently only `Raycast` supports these fields):
   Is a null vector `{x = 0, y = 0, z = 0}` when the pointer is inside the
   selection box.
 
+`move_result`
+---------------
 
+* `{collides_xz, collides_y, is_standing, touched_objects, collisions}`
+    * Result of collision processing for physical objects.
+    * `collides_xz`: whether a collision occured along the X or Z axis
+    * `collides_y`: whether a collision occured along the Y axis
+    * `is_standing`: whether the object is standing on top of a node
+    * `touched_objects`: ObjectRefs that the object is actively touching
+    * `collisions`: node positions intersecting the object's collision box
 
 
 Flag Specifier Format
@@ -4155,14 +4164,30 @@ Functions receive a "luaentity" as `self`:
 
 Callbacks:
 
-* `on_activate(self, staticdata, dtime_s)`
-    * Called when the object is instantiated.
-    * `dtime_s` is the time passed since the object was unloaded, which can be
-      used for updating the entity state.
-* `on_step(self, dtime)`
+* `on_activate(self, staticdata, dtime_s, id)`
+    * Called immediately after the object is added to the environment.
+    * `dtime_s`: time passed since the object was unloaded, which can be used
+      for updating the entity state.
+    * `id`: active object identifier used internally by the engine and stored
+      in the `minetest.luaentities` table
+    * Note that value of `id` is only guaranteed to be unique for the lifetime 
+      of the object and should never be referenced once deactivated.
+* `on_deactivate(self, id)`
+    * Called immediately before the object is removed from the environment,
+      whether as the result of the mapblock unloading, the object being outside
+      the active-object radius, an explicit call to `remove()`, etc.
+* `on_step(self, dtime, pos, rot, new_vel, old_vel, move_result)`
     * Called on every server tick, after movement and collision processing.
-      `dtime` is usually 0.1 seconds, as per the `dedicated_server_step` setting
+    * `dtime` is usually 0.1 seconds, as per the `dedicated_server_step` setting
       in `minetest.conf`.
+    * `pos`: current position of the object
+    * `rot`: current rotation of the object
+    * `new_vel`: calculated velocity of the object as a result of acceleration,
+      angular velocity, and collisions
+    * `old_vel`: velocity of the object prior to movement/collision processing
+    * `move_result`: the result of collision processing (refer to the section
+      "Representations of simple things" for details)
+    * Note that `new_vel` may not correspond with an object's fixed velocity.
 * `on_punch(self, puncher, time_from_last_punch, tool_capabilities, dir, damage)`
     * Called when somebody punches the object.
     * Note that you probably want to handle most punches using the automatic
@@ -6210,15 +6235,76 @@ object you are working with still exists.
       no effect and returning `nil`.
 * `set_velocity(vel)`
     * `vel` is a vector, e.g. `{x=0.0, y=2.3, z=1.0}`
+    * If the object's velocity is fixed by `lock_velocity()` or `set_speed()`,
+      then only the Y component will be set.
+* `set_velocity_vert(vel_y)`
+    * Sets only the Y component of the velocity vector.
+    * `vel_y` is a number (default: `0.0`)
+* `set_velocity_horz(vel_x, vel_z)`
+    * Sets only the X and Z components of the  velocity vector.
+    * `vel_x` is a number (default: `0.0`)
+    * `vel_z` is a number (default: `0.0`)
+    * If the object's velocity is fixed by `lock_velocity()` or `set_speed()`,
+      then it will remain unchanged.
+* `add_velocity(vel)`
+    * `vel` is a vector, e.g. `{x=0.0, y=2.3, z=1.0}`
+    * In comparison to using get_velocity, adding the velocity and then using
+      set_velocity, this method is supposed to avoid synchronization problems.
+* `get_velocity()`: returns the velocity, a vector
+* `lock_velocity()`: fixes the velocity along the X and Z axes
+    * Can prove useful to maintain a specific heading after encountering an
+      obstacle, rather than continuously calling `set_velocity()`.
+    * Note that this will disable acceleration along the X and Z axes.
+* `unlock_velocity()`: frees the velocity along the X and Z axes
+* `is_velocity_locked()`: returns true if the velocity has been fixed
+* `set_speed(speed)`
+    * Automatically fixes the velocity along the X and Z axes to correspond 
+      with the current heading (yaw).
+    * `speed` is a number equal to the length of the vector (vel_x,vel_z).
+    * `yaw_offset` is a number representing the angular offset from normal in 
+      radians, where `0` is forward and `pi` is backward (default: `0`).
+    * Player-like side-stepping can be achieved with either of the following 
+      values for `yaw_offset`:
+       * `pi / 2`: strafe left
+       * `-pi / 2`: strafe right
+    * A negative value for `speed` may also be used for back-tracking.
+* `set_speed_lateral(speed_x, speed_y)`
+    * Similar to `set_speed()` but calculates the angular offset from normal
+      given the magnitude of speed within 2-dimensions.
+    * `speed_x` is a number representing lateral motion, where negative moves
+      left, positive moves right, and zero stops (default: `0`)
+    * `speed_y` is a number, where positive moves forward, negative moves
+      backward, and zero stops (default: `0`)
+    * If the model is not oriented correctly, it may be necessary to set the
+      `yaw_origin` object property.
 * `set_acceleration(acc)`
     * `acc` is a vector
+* `set_acceleration_vert(acc_y)`:
+    * Sets only the Y component of the acceleration vector.
+    * `acc_y` is a number (default: 0.0)
 * `get_acceleration()`: returns the acceleration, a vector
 * `set_rotation(rot)`
-    * `rot` is a vector (radians). X is pitch (elevation), Y is yaw (heading)
-      and Z is roll (bank).
-* `get_rotation()`: returns the rotation, a vector (radians)
-* `set_yaw(yaw)`: sets the yaw in radians (heading).
+    * `rot` is a vector in radians.
+       * `x` is pitch (elevation)
+       * `y` is yaw (heading)
+       * `z` is roll (bank)
+* `get_rotation()`: returns the rotation, a vector, in radians
+* `set_yaw(yaw)`: sets the yaw (heading)
+    * `yaw` is a number in radians (default: `0`)
+    * When speed is applied, this will automatically change the velocity to
+      correspond with new yaw (heading).
+* `add_yaw(yaw)`: increases or decreases the yaw
+    * `yaw` is a number in radians
 * `get_yaw()`: returns number in radians
+* `turn_by(yaw_delta, period, cycles)
+    * Performs a continuous or periodic rotation about the Y-axis
+    * `yaw_delta` is a number in radians
+    * `period` is a number in seconds
+    * `cycles` is a number, either positive for a periodic rotation or `0`
+      for a continuous rotation (default: `1`)
+    * The rate of rotation is calculated as `yaw_delta / period`.
+    * When used in combination with `set_speed()` or `set_speed_lateral()`,
+      smooth turning motion is possible.
 * `set_texture_mod(mod)`
     * Set a texture modifier to the base texture, for sprites and meshes.
     * When calling `set_texture_mod` again, the previous one is discarded.
@@ -6239,7 +6325,7 @@ object you are working with still exists.
         * Fourth column: subject looking to the right
         * Fifth column:  subject viewed from above
         * Sixth column:  subject viewed from below
-* `get_entity_name()` (**Deprecated**: Will be removed in a future version)
+* `get_entity_name()`: returns the registered name of the entity
 * `get_luaentity()`
 
 #### Player only (no-op for other objects)
@@ -6842,6 +6928,7 @@ Player properties need to be saved manually.
         automatic_face_movement_dir = 0.0,
         -- Automatically set yaw to movement direction, offset in degrees.
         -- 'false' to disable.
+        -- This property is ignored when speed is applied.
 
         automatic_face_movement_max_rotation_per_sec = -1,
         -- Limit automatic rotation to this value in degrees per second.
@@ -6880,6 +6967,11 @@ Player properties need to be saved manually.
         show_on_minimap = false,
         -- Defaults to true for players, false for other entities.
         -- If set to true the entity will show as a marker on the minimap.
+
+        yaw_origin = 0.0,
+        -- The orientation of the model, in radians.
+        -- Used by `set_speed()` to compute the angular offset from normal.
+        -- `0` or `-pi / 2` is typical.
     }
 
 Entity definition
@@ -6898,12 +6990,12 @@ Used by `minetest.register_entity`.
         -- table is deprecated. Define object properties in this
         -- `initial_properties` table instead.
 
-        on_activate = function(self, staticdata, dtime_s),
+        on_activate = function(self, staticdata, dtime_s, id),
 
-        on_step = function(self, dtime, moveresult),
+        on_deactivate = function(self, id),
+
+        on_step = function(self, dtime, pos, rot, new_vel, old_vel, move_result),
         -- Called every server step
-        -- dtime: Elapsed time
-        -- moveresult: Table with collision info (only available if physical=true)
 
         on_punch = function(self, puncher, time_from_last_punch, tool_capabilities, dir),
 
@@ -6916,25 +7008,6 @@ Used by `minetest.register_entity`.
         _custom_field = whatever,
         -- You can define arbitrary member variables here (see Item definition
         -- for more info) by using a '_' prefix
-    }
-
-Collision info passed to `on_step`:
-
-    {
-        touching_ground = boolean,
-        collides = boolean,
-        standing_on_object = boolean,
-        collisions = {
-            {
-                type = string, -- "node" or "object",
-                axis = string, -- "x", "y" or "z"
-                node_pos = vector, -- if type is "node"
-                object = ObjectRef, -- if type is "object"
-                old_velocity = vector,
-                new_velocity = vector,
-            },
-            ...
-        }
     }
 
 ABM (ActiveBlockModifier) definition

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1096,7 +1096,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 			m_position = p_pos;
 			m_velocity = p_velocity;
 
-			bool is_end_position = moveresult.collides;
+			bool is_end_position = moveresult.collides_xz || moveresult.collides_y;
 			pos_translator.update(m_position, is_end_position, dtime);
 		} else {
 			m_position += dtime * m_velocity + 0.5 * dtime * dtime * m_acceleration;

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -417,7 +417,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		Report collisions
 	*/
 
-	if (result.standing_on_object && !touching_ground_was && touching_ground) {
+	if (!result.standing_on_object && !touching_ground_was && touching_ground) {
 		m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_REGAIN_GROUND));
 
 		// Set camera impact value to be used for view bobbing
@@ -1027,7 +1027,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		}
 	}
 
-	if (result.standing_on_object && !touching_ground_was && touching_ground) {
+	if (!result.standing_on_object && !touching_ground_was && touching_ground) {
 		m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_REGAIN_GROUND));
 		// Set camera impact value to be used for view bobbing
 		camera_impact = getSpeed().Y * -1.0f;

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -417,7 +417,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		Report collisions
 	*/
 
-	if (!result.standing_on_object && !touching_ground_was && touching_ground) {
+	if (result.standing_node_p.Y != -32768 && !touching_ground_was && touching_ground) {
 		m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_REGAIN_GROUND));
 
 		// Set camera impact value to be used for view bobbing
@@ -1027,7 +1027,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		}
 	}
 
-	if (!result.standing_on_object && !touching_ground_was && touching_ground) {
+	if (result.standing_node_p.Y != -32768 && !touching_ground_was && touching_ground) {
 		m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_REGAIN_GROUND));
 		// Set camera impact value to be used for view bobbing
 		camera_impact = getSpeed().Y * -1.0f;

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -417,7 +417,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		Report collisions
 	*/
 
-	if (result.standing_node_p.Y != -32768 && !touching_ground_was && touching_ground) {
+	if (result.standing_on_object && !touching_ground_was && touching_ground) {
 		m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_REGAIN_GROUND));
 
 		// Set camera impact value to be used for view bobbing
@@ -1027,7 +1027,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		}
 	}
 
-	if (result.standing_node_p.Y != -32768 && !touching_ground_was && touching_ground) {
+	if (result.standing_on_object && !touching_ground_was && touching_ground) {
 		m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_REGAIN_GROUND));
 		// Set camera impact value to be used for view bobbing
 		camera_impact = getSpeed().Y * -1.0f;

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -141,7 +141,7 @@ void Particle::step(float dtime)
 		collisionMoveResult r = collisionMoveSimple(m_env, m_gamedef, BS * 0.5f,
 			box, 0.0f, dtime, &p_pos, &p_velocity, m_acceleration * BS, nullptr,
 			m_object_collision);
-		if (m_collision_removal && r.collides) {
+		if (m_collision_removal && (r.collides_xz || r.collides_y)) {
 			// force expiration of the particle
 			m_expiration = -1.0;
 		} else {

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -569,7 +569,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				info.axis = nearest_collided;
 				result.collisions.push_back(info);
 
-				if (nearest_info.obj)
+				if (nearest_info.isObject())
 					result.touched_objects.push_back(nearest_info.obj);
 			}
 		}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -535,6 +535,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				info.type = COLLISION_NODE;
 
 			info.node_p = nearest_info.position;
+			info.object = nearest_info.obj;
 			info.old_speed = *speed_f;
 			info.plane = nearest_collided;
 
@@ -580,9 +581,6 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			if (is_collision) {
 				info.axis = nearest_collided;
 				result.collisions.push_back(info);
-
-				if (nearest_info.isObject())
-					result.touched_objects.push_back(nearest_info.obj);
 			}
 		}
 	}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -249,6 +249,8 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	} else {
 		time_notification_done = false;
 	}
+
+	v3f old_speed_f = *speed_f;
 	*speed_f += accel_f * dtime;
 
 	// If there is no speed, there are no collisions
@@ -540,24 +542,34 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			if (step_up) {
 				// Special case: Handle stairs
 				nearest_info.is_step_up = true;
+				result.steps_up = true;
 				is_collision = false;
 			} else if (nearest_collided == COLLISION_AXIS_X) {
+				if (old_speed_f.X != 0)
+					info.is_impact = true;
 				if (fabs(speed_f->X) > BS * 3)
 					speed_f->X *= bounce;
 				else
 					speed_f->X = 0;
+				info.side.X = old_speed_f.X > 0 ? 1 : -1;
 				result.collides_xz = true;
 			} else if (nearest_collided == COLLISION_AXIS_Y) {
+				if (old_speed_f.Y != 0)
+					info.is_impact = true;
 				if(fabs(speed_f->Y) > BS * 3)
 					speed_f->Y *= bounce;
 				else
 					speed_f->Y = 0;
+				info.side.Y = old_speed_f.Y > 0 ? 1 : -1;
 				result.collides_y = true;
 			} else if (nearest_collided == COLLISION_AXIS_Z) {
+				if (old_speed_f.Z != 0)
+					info.is_impact = true;
 				if (fabs(speed_f->Z) > BS * 3)
 					speed_f->Z *= bounce;
 				else
 					speed_f->Z = 0;
+				info.side.Z = old_speed_f.Z > 0 ? 1 : -1;
 				result.collides_xz = true;
 			}
 

--- a/src/collision.h
+++ b/src/collision.h
@@ -48,7 +48,6 @@ struct CollisionInfo
 	CollisionType type = COLLISION_NODE;
 	CollisionAxis axis = COLLISION_AXIS_NONE;
 	v3s16 node_p = v3s16(-32768,-32768,-32768); // COLLISION_NODE
-	ActiveObject *object = nullptr; // COLLISION_OBJECT
 	v3f old_speed;
 	v3f new_speed;
 	int plane = -1;
@@ -59,9 +58,11 @@ struct collisionMoveResult
 	collisionMoveResult() = default;
 
 	bool touching_ground = false;
-	bool collides = false;
+	bool collides_y = false;
+	bool collides_xz = false;
 	bool standing_on_object = false;
 	std::vector<CollisionInfo> collisions;
+	std::vector<ActiveObject*> touched_objects;
 };
 
 // Moves using a single iteration; speed should not exceed pos_max_d/dtime

--- a/src/collision.h
+++ b/src/collision.h
@@ -48,6 +48,7 @@ struct CollisionInfo
 	CollisionType type = COLLISION_NODE;
 	CollisionAxis axis = COLLISION_AXIS_NONE;
 	v3s16 node_p = v3s16(-32768,-32768,-32768); // COLLISION_NODE
+	ActiveObject *object = nullptr; // COLLISION_OBJECT
 	v3s16 side = v3s16(0,0,0);
 	v3f old_speed;
 	v3f new_speed;
@@ -65,7 +66,6 @@ struct collisionMoveResult
 	bool collides_xz = false;
 	bool standing_on_object = false;
 	std::vector<CollisionInfo> collisions;
-	std::vector<ActiveObject*> touched_objects;
 };
 
 // Moves using a single iteration; speed should not exceed pos_max_d/dtime

--- a/src/collision.h
+++ b/src/collision.h
@@ -48,8 +48,10 @@ struct CollisionInfo
 	CollisionType type = COLLISION_NODE;
 	CollisionAxis axis = COLLISION_AXIS_NONE;
 	v3s16 node_p = v3s16(-32768,-32768,-32768); // COLLISION_NODE
+	v3s16 side = v3s16(0,0,0);
 	v3f old_speed;
 	v3f new_speed;
+	bool is_impact = false;
 	int plane = -1;
 };
 
@@ -58,6 +60,7 @@ struct collisionMoveResult
 	collisionMoveResult() = default;
 
 	bool touching_ground = false;
+	bool steps_up = false;
 	bool collides_y = false;
 	bool collides_xz = false;
 	bool standing_on_object = false;

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -71,6 +71,8 @@ std::string ObjectProperties::dump()
 	os << ", damage_texture_modifier=" << damage_texture_modifier;
 	os << ", shaded=" << shaded;
 	os << ", show_on_minimap=" << show_on_minimap;
+	os << ", yaw_origin=" << yaw_origin;
+
 	return os.str();
 }
 

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -63,6 +63,7 @@ struct ObjectProperties
 	bool use_texture_alpha = false;
 	bool shaded = true;
 	bool show_on_minimap = false;
+	float yaw_origin = 0.0f;
 
 	ObjectProperties();
 	std::string dump();

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -63,7 +63,7 @@ struct ObjectProperties
 	bool use_texture_alpha = false;
 	bool shaded = true;
 	bool show_on_minimap = false;
-	float yaw_origin = 0.0f;
+	float yaw_origin = 0.0f; // Note: This is not currently sent to clients
 
 	ObjectProperties();
 	std::string dump();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -391,7 +391,7 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "stepheight");
 	lua_pushnumber(L, prop->eye_height);
 	lua_setfield(L, -2, "eye_height");
-	lua_pushnumber(L, prop->automatic_rotate * core::DEGTORAD);
+	lua_pushnumber(L, prop->automatic_rotate);
 	lua_setfield(L, -2, "automatic_rotate");
 	if (prop->automatic_face_movement_dir)
 		lua_pushnumber(L, prop->automatic_face_movement_dir_offset);
@@ -424,7 +424,7 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "damage_texture_modifier");
 	lua_pushboolean(L, prop->show_on_minimap);
 	lua_setfield(L, -2, "show_on_minimap");
-	lua_pushnumber(L, prop->yaw_origin);
+	lua_pushnumber(L, prop->yaw_origin * core::DEGTORAD);
 	lua_setfield(L, -2, "yaw_origin");
 }
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -21,7 +21,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_types.h"
 #include "nodedef.h"
 #include "object_properties.h"
-#include "collision.h"
 #include "cpp_api/s_node.h"
 #include "lua_api/l_object.h"
 #include "lua_api/l_item.h"
@@ -334,6 +333,9 @@ void read_object_properties(lua_State *L, int index,
 	getboolfield(L, -1, "show_on_minimap", prop->show_on_minimap);
 
 	getstringfield(L, -1, "damage_texture_modifier", prop->damage_texture_modifier);
+
+	if (getfloatfield(L, -1, "yaw_origin", prop->yaw_origin))
+		prop->yaw_origin *= core::RADTODEG;
 }
 
 /******************************************************************************/
@@ -389,7 +391,7 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "stepheight");
 	lua_pushnumber(L, prop->eye_height);
 	lua_setfield(L, -2, "eye_height");
-	lua_pushnumber(L, prop->automatic_rotate);
+	lua_pushnumber(L, prop->automatic_rotate * core::DEGTORAD);
 	lua_setfield(L, -2, "automatic_rotate");
 	if (prop->automatic_face_movement_dir)
 		lua_pushnumber(L, prop->automatic_face_movement_dir_offset);
@@ -422,6 +424,8 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "damage_texture_modifier");
 	lua_pushboolean(L, prop->show_on_minimap);
 	lua_setfield(L, -2, "show_on_minimap");
+	lua_pushnumber(L, prop->yaw_origin);
+	lua_setfield(L, -2, "yaw_origin");
 }
 
 /******************************************************************************/
@@ -2027,60 +2031,4 @@ HudElementStat read_hud_change(lua_State *L, HudElement *elem, void **value)
 			break;
 	}
 	return stat;
-}
-
-/******************************************************************************/
-
-// Indices must match values in `enum CollisionType` exactly!!
-static const char *collision_type_str[] = {
-	"node",
-	"object",
-};
-
-// Indices must match values in `enum CollisionAxis` exactly!!
-static const char *collision_axis_str[] = {
-	"x",
-	"y",
-	"z",
-};
-
-void push_collision_move_result(lua_State *L, const collisionMoveResult &res)
-{
-	lua_createtable(L, 0, 4);
-
-	setboolfield(L, -1, "touching_ground", res.touching_ground);
-	setboolfield(L, -1, "collides", res.collides);
-	setboolfield(L, -1, "standing_on_object", res.standing_on_object);
-
-	/* collisions */
-	lua_createtable(L, res.collisions.size(), 0);
-	int i = 1;
-	for (const auto &c : res.collisions) {
-		lua_createtable(L, 0, 5);
-
-		lua_pushstring(L, collision_type_str[c.type]);
-		lua_setfield(L, -2, "type");
-
-		assert(c.axis != COLLISION_AXIS_NONE);
-		lua_pushstring(L, collision_axis_str[c.axis]);
-		lua_setfield(L, -2, "axis");
-
-		if (c.type == COLLISION_NODE) {
-			push_v3s16(L, c.node_p);
-			lua_setfield(L, -2, "node_pos");
-		} else if (c.type == COLLISION_OBJECT) {
-			push_objectRef(L, c.object->getId());
-			lua_setfield(L, -2, "object");
-		}
-
-		push_v3f(L, c.old_speed / BS);
-		lua_setfield(L, -2, "old_velocity");
-
-		push_v3f(L, c.new_speed / BS);
-		lua_setfield(L, -2, "new_velocity");
-
-		lua_rawseti(L, -2, i++);
-	}
-	lua_setfield(L, -2, "collisions");
-	/**/
 }

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -63,7 +63,6 @@ struct EnumString;
 struct NoiseParams;
 class Schematic;
 class ServerActiveObject;
-struct collisionMoveResult;
 
 extern struct EnumString es_TileAnimationType[];
 
@@ -198,5 +197,3 @@ void               read_hud_element          (lua_State *L, HudElement *elem);
 void               push_hud_element          (lua_State *L, HudElement *elem);
 
 HudElementStat     read_hud_change           (lua_State *L, HudElement *elem, void **value);
-
-void               push_collision_move_result(lua_State *L, const collisionMoveResult &res);

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -49,6 +49,8 @@ if (value < F1000_MIN || value > F1000_MAX) { \
 	" got " << value << ")." << std::endl << traceback; \
 	throw LuaError(error_text.str()); \
 }
+// Note: Unlike the macro above, this is for validation of scalar floating point
+// values that should always be represented as real numbers.
 #define CHECK_FLOAT_RANGE2(value) \
 if (std::isnan(value) || value < F1000_MIN || value > F1000_MAX) { \
 	throw LuaError(std::string("Invalid floating point number.\n") + \

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -99,6 +99,11 @@ void               setfloatfield(lua_State *L, int table,
 void               setboolfield(lua_State *L, int table,
                              const char *fieldname, bool value);
 
+float               checkFloatYaw       (lua_State *L, int index);
+float               readFloatYaw        (lua_State *L, int index);
+float               check_float         (lua_State *L, int index);
+float               read_float          (lua_State *L, int index);
+
 v3f                 checkFloatPos       (lua_State *L, int index);
 v3f                 check_v3f           (lua_State *L, int index);
 v3s16               check_v3s16         (lua_State *L, int index);

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -233,7 +233,7 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime, v3f pos, v3f rotation,
 	pushFloatPos(L, old_velocity); // old_velocity
 
 	if (moveresult) {
-		lua_createtable(L, 0, 6);
+		lua_createtable(L, 0, 5);
 
 		// moveresult.collides_y
 		lua_pushboolean(L, moveresult->collides_y);
@@ -252,35 +252,28 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime, v3f pos, v3f rotation,
 		lua_pushboolean(L, moveresult->touching_ground);
 	      	lua_setfield(L, -2, "standing");
 
-		int index;
-
-		// moveresult.touched_objects (table)
-		lua_createtable(L, moveresult->touched_objects.size(), 0);
-		index = 0;
-		for (ActiveObject *obj : moveresult->touched_objects) {
-			objectrefGetOrCreate(L, (ServerActiveObject*)obj);
-       			lua_rawseti(L, -2, ++index);
-		}
-		lua_setfield(L, -2, "touched_objects");
-
 		// moveresult.collisions (table)
 		lua_createtable(L, moveresult->collisions.size(), 0);
-		index = 0;
+		int index = 0;
 		for (const CollisionInfo &colinfo : moveresult->collisions) {
+			lua_createtable(L, 0, 3);
+
+			push_v3s16(L, colinfo.side);
+			lua_setfield(L, -2, "side");
+
 			if (colinfo.type == COLLISION_NODE) {
-				lua_createtable(L, 0, 3);
-
-				push_v3s16(L, colinfo.side);
-				lua_setfield(L, -2, "side");
-
 				push_v3s16(L, colinfo.node_p);
 				lua_setfield(L, -2, "node_pos");
-
-				lua_pushboolean(L, colinfo.is_impact);
-				lua_setfield(L, -2, "is_impact");
-
-				lua_rawseti(L, -2, ++index);
 			}
+			else (colinfo.type == COLLISION_OBJECT) {
+				push_objectRef(L, colinfo.object->getId());
+				lua_setfield(L, -2, "object");
+			}
+
+			lua_pushboolean(L, colinfo.is_impact);
+			lua_setfield(L, -2, "is_impact");
+
+			lua_rawseti(L, -2, ++index);
 		}
 		lua_setfield(L, -2, "collisions");
 	}

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -233,7 +233,7 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime, v3f pos, v3f rotation,
 	pushFloatPos(L, old_velocity); // old_velocity
 
 	if (moveresult) {
-		lua_createtable(L, 0, 5);
+		lua_createtable(L, 0, 6);
 
 		// moveresult.collides_y
 		lua_pushboolean(L, moveresult->collides_y);
@@ -243,9 +243,14 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime, v3f pos, v3f rotation,
 		lua_pushboolean(L, moveresult->collides_xz);
 		lua_setfield(L, -2, "collides_xz");
 
-		// moveresult.is_standing
+
+		// moveresult.steps_up
+		lua_pushboolean(L, moveresult->steps_up);
+		lua_setfield(L, -2, "steps_up");
+
+		// moveresult.standing
 		lua_pushboolean(L, moveresult->touching_ground);
-	      	lua_setfield(L, -2, "is_standing");
+	      	lua_setfield(L, -2, "standing");
 
 		int index;
 
@@ -263,7 +268,17 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime, v3f pos, v3f rotation,
 		index = 0;
 		for (const CollisionInfo &colinfo : moveresult->collisions) {
 			if (colinfo.type == COLLISION_NODE) {
+				lua_createtable(L, 0, 3);
+
+				push_v3s16(L, colinfo.side);
+				lua_setfield(L, -2, "side");
+
 				push_v3s16(L, colinfo.node_p);
+				lua_setfield(L, -2, "node_pos");
+
+				lua_pushboolean(L, colinfo.is_impact);
+				lua_setfield(L, -2, "is_impact");
+
 				lua_rawseti(L, -2, ++index);
 			}
 		}

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -207,7 +207,7 @@ void ScriptApiEntity::luaentity_GetProperties(u16 id,
 }
 
 void ScriptApiEntity::luaentity_Step(u16 id, float dtime, v3f pos, v3f rotation,
-		v3f new_velocity, v3f old_velocity, collisionMoveResult *moveresult)
+		v3f new_velocity, v3f old_velocity, const collisionMoveResult *moveresult)
 {
 	SCRIPTAPI_PRECHECKHEADER
 

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -265,7 +265,7 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime, v3f pos, v3f rotation,
 				push_v3s16(L, colinfo.node_p);
 				lua_setfield(L, -2, "node_pos");
 			}
-			else (colinfo.type == COLLISION_OBJECT) {
+			else if (colinfo.type == COLLISION_OBJECT) {
 				push_objectRef(L, colinfo.object->getId());
 				lua_setfield(L, -2, "object");
 			}

--- a/src/script/cpp_api/s_entity.h
+++ b/src/script/cpp_api/s_entity.h
@@ -41,7 +41,7 @@ public:
 			ServerActiveObject *self, ObjectProperties *prop);
 	void luaentity_Step(u16 id, float dtime,
 			v3f pos, v3f rotation, v3f old_velocity, v3f new_velocity,
-			collisionMoveResult *moveresult);
+			const collisionMoveResult *moveresult);
 	bool luaentity_Punch(u16 id,
 			ServerActiveObject *puncher, float time_from_last_punch,
 			const ToolCapabilities *toolcap, v3f dir, s16 damage);

--- a/src/script/cpp_api/s_entity.h
+++ b/src/script/cpp_api/s_entity.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "cpp_api/s_base.h"
+#include "collision.h"
 #include "irr_v3d.h"
 
 struct ObjectProperties;
@@ -33,12 +34,14 @@ public:
 	bool luaentity_Add(u16 id, const char *name);
 	void luaentity_Activate(u16 id,
 			const std::string &staticdata, u32 dtime_s);
+	void luaentity_Deactivate(u16 id);
 	void luaentity_Remove(u16 id);
 	std::string luaentity_GetStaticdata(u16 id);
 	void luaentity_GetProperties(u16 id,
 			ServerActiveObject *self, ObjectProperties *prop);
 	void luaentity_Step(u16 id, float dtime,
-		const collisionMoveResult *moveresult);
+			v3f pos, v3f rotation, v3f old_velocity, v3f new_velocity,
+			collisionMoveResult *moveresult);
 	bool luaentity_Punch(u16 id,
 			ServerActiveObject *puncher, float time_from_last_punch,
 			const ToolCapabilities *toolcap, v3f dir, s16 damage);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -771,18 +771,148 @@ int ObjectRef::l_get_nametag_attributes(lua_State *L)
 
 /* LuaEntitySAO-only */
 
+// set_speed(self, speed, yaw_offset)
+int ObjectRef::l_set_speed(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
+		return 0;
+
+	float speed = check_float(L, 2) * BS;
+	float yaw_offset = readFloatYaw(L, 3);
+
+	entitysao->setSpeed(speed, yaw_offset);
+	return 0;
+}
+
+// set_speed_lateral(self, speed_x, speed_y)
+int ObjectRef::l_set_speed_lateral(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
+		return 0;
+
+	float speed_x = read_float(L, 2) * BS;
+	float speed_y = read_float(L, 3) * BS;
+
+	entitysao->setSpeedLateral(speed_x, speed_y);
+	return 0;
+}
+
+// add_speed(self, speed)
+int ObjectRef::l_add_speed(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
+		return 0;
+
+	float speed = check_float(L, 2) * BS;
+
+	entitysao->addSpeed(speed);
+	return 0;
+}
+
+// get_speed(self)
+int ObjectRef::l_get_speed(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
+		return 0;
+
+	lua_pushnumber(L, entitysao->getSpeed() / BS);
+	return 1;
+}
+
+// lock_velocity(self)
+int ObjectRef::l_lock_velocity(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
+		return 0;
+
+	entitysao->lockVelocity();
+	return 0;
+}
+
+// unlock_velocity(self)
+int ObjectRef::l_unlock_velocity(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
+		return 0;
+
+	entitysao->unlockVelocity();
+	return 0;
+}
+
+// is_velocity_locked(self)
+int ObjectRef::l_is_velocity_locked(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
+		return 0;
+
+	lua_pushboolean(L, entitysao->isVelocityLocked());
+	return 1;
+}
+
 // set_velocity(self, velocity)
 int ObjectRef::l_set_velocity(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	LuaEntitySAO *sao = getluaobject(ref);
-	if (sao == nullptr)
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
 		return 0;
 
 	v3f vel = checkFloatPos(L, 2);
 
-	sao->setVelocity(vel);
+	entitysao->setVelocity(vel);
+	return 0;
+}
+
+// set_velocity_horz(self, vel_x, vel_z)
+int ObjectRef::l_set_velocity_horz(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
+		return 0;
+
+	float vel_x = read_float(L, 2) * BS;
+	float vel_z = read_float(L, 3) * BS;
+
+	entitysao->setVelocityHorz(vel_x, vel_z);
+	return 0;
+}
+
+// set_velocity_vert(self, vel_y)
+int ObjectRef::l_set_velocity_vert(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
+		return 0;
+
+	float vel_y = read_float(L, 2) * BS;
+
+	entitysao->setVelocityVert(vel_y);
 	return 0;
 }
 
@@ -848,6 +978,21 @@ int ObjectRef::l_set_acceleration(lua_State *L)
 	return 0;
 }
 
+// set_acceleration_vert(self, acc_y)
+int ObjectRef::l_set_acceleration_vert(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
+		return 0;
+
+	float acc_y = read_float(L, 2) * BS;
+
+	entitysao->setAccelerationVert(acc_y);
+	return 0;
+}
+
 // get_acceleration(self)
 int ObjectRef::l_get_acceleration(lua_State *L)
 {
@@ -902,12 +1047,22 @@ int ObjectRef::l_set_yaw(lua_State *L)
 	if (entitysao == nullptr)
 		return 0;
 
-	if (isNaN(L, 2))
-		throw LuaError("ObjectRef::set_yaw: NaN value is not allowed.");
-
-	float yaw = readParam<float>(L, 2) * core::RADTODEG;
-
+	float yaw = readFloatYaw(L, 2);
 	entitysao->setRotation(v3f(0, yaw, 0));
+	return 0;
+}
+
+// add_yaw(self, radians)
+int ObjectRef::l_add_yaw(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
+		return 0;
+
+	float yaw = readFloatYaw(L, 2);
+	entitysao->addRotation(v3f(0, yaw, 0));
 	return 0;
 }
 
@@ -924,6 +1079,23 @@ int ObjectRef::l_get_yaw(lua_State *L)
 
 	lua_pushnumber(L, yaw);
 	return 1;
+}
+
+// turn_by(self, yaw_delta, period, cycles)
+int ObjectRef::l_turn_by(lua_State *L)
+{
+        NO_MAP_LOCK_REQUIRED;
+        ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *entitysao = getluaobject(ref);
+	if (entitysao == nullptr)
+		return 0;
+
+	float yaw_delta = checkFloatYaw(L, 2);
+	float period = luaL_checknumber(L, 3);
+	u16 cycles = luaL_optinteger(L, 4, 1);
+
+	entitysao->turnBy(yaw_delta, period, cycles);
+	return 0;
 }
 
 // set_texture_mod(self, mod)
@@ -974,19 +1146,16 @@ int ObjectRef::l_set_sprite(lua_State *L)
 	return 0;
 }
 
-// DEPRECATED
 // get_entity_name(self)
 int ObjectRef::l_get_entity_name(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
-	log_deprecated(L,"Deprecated call to \"get_entity_name");
 	if (entitysao == nullptr)
 		return 0;
 
 	std::string name = entitysao->getName();
-
 	lua_pushstring(L, name.c_str());
 	return 1;
 }
@@ -2315,19 +2484,31 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, set_nametag_attributes),
 	luamethod(ObjectRef, get_nametag_attributes),
 
-	luamethod_aliased(ObjectRef, set_velocity, setvelocity),
 	luamethod(ObjectRef, add_velocity),
 	{"add_player_velocity", ObjectRef::l_add_velocity},
 	luamethod_aliased(ObjectRef, get_velocity, getvelocity),
 	{"get_player_velocity", ObjectRef::l_get_velocity},
 
 	// LuaEntitySAO-only
+	luamethod(ObjectRef, set_speed),
+	luamethod(ObjectRef, set_speed_lateral),
+	luamethod(ObjectRef, add_speed),
+	luamethod(ObjectRef, get_speed),
+	luamethod(ObjectRef, lock_velocity),
+	luamethod(ObjectRef, unlock_velocity),
+	luamethod(ObjectRef, is_velocity_locked),
+	luamethod_aliased(ObjectRef, set_velocity, setvelocity),
+	luamethod(ObjectRef, set_velocity_horz),
+	luamethod(ObjectRef, set_velocity_vert),
 	luamethod_aliased(ObjectRef, set_acceleration, setacceleration),
+	luamethod(ObjectRef, set_acceleration_vert),
 	luamethod_aliased(ObjectRef, get_acceleration, getacceleration),
 	luamethod_aliased(ObjectRef, set_yaw, setyaw),
+	luamethod(ObjectRef, add_yaw),
 	luamethod_aliased(ObjectRef, get_yaw, getyaw),
 	luamethod(ObjectRef, set_rotation),
 	luamethod(ObjectRef, get_rotation),
+	luamethod(ObjectRef, turn_by),
 	luamethod_aliased(ObjectRef, set_texture_mod, settexturemod),
 	luamethod(ObjectRef, get_texture_mod),
 	luamethod_aliased(ObjectRef, set_sprite, setsprite),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1084,8 +1084,8 @@ int ObjectRef::l_get_yaw(lua_State *L)
 // turn_by(self, yaw_delta, period, cycles)
 int ObjectRef::l_turn_by(lua_State *L)
 {
-        NO_MAP_LOCK_REQUIRED;
-        ObjectRef *ref = checkobject(L, 1);
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -154,8 +154,35 @@ private:
 
 	/* LuaEntitySAO-only */
 
+	// set_speed(self, speed, yaw_offset)
+	static int l_set_speed(lua_State *L);
+
+	// set_speed_lateral(self, speed_x, speed_y)
+	static int l_set_speed_lateral(lua_State *L);
+
+	// add_speed(self, speed)
+	static int l_add_speed(lua_State *L);
+
+	// get_speed(self)
+	static int l_get_speed(lua_State *L);
+
+	// lock_velocity(self)
+	static int l_lock_velocity(lua_State *L);
+
+	// unlock_velocity(self)
+	static int l_unlock_velocity(lua_State *L);
+
+	// is_velocity_locked(self)
+	static int l_is_velocity_locked(lua_State *L);
+
 	// set_velocity(self, velocity)
 	static int l_set_velocity(lua_State *L);
+
+	// set_velocity_horz(self, vel_x, vel_z)
+	static int l_set_velocity_horz(lua_State *L);
+
+	// set_velocity_vert(self, vel_y)
+	static int l_set_velocity_vert(lua_State *L);
 
 	// add_velocity(self, velocity)
 	static int l_add_velocity(lua_State *L);
@@ -165,6 +192,9 @@ private:
 
 	// set_acceleration(self, acceleration)
 	static int l_set_acceleration(lua_State *L);
+
+	// setacceleration_vert(self, acc_y)
+	static int l_set_acceleration_vert(lua_State *L);
 
 	// get_acceleration(self)
 	static int l_get_acceleration(lua_State *L);
@@ -178,8 +208,14 @@ private:
 	// set_yaw(self, yaw)
 	static int l_set_yaw(lua_State *L);
 
+	// add_yaw(self, yaw)
+	static int l_add_yaw(lua_State *L);
+
 	// get_yaw(self)
 	static int l_get_yaw(lua_State *L);
+
+	// turn_by(self, yaw_delta, period, cycles)
+	static int l_turn_by(lua_State *L);
 
 	// set_texture_mod(self, mod)
 	static int l_set_texture_mod(lua_State *L);

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -270,7 +270,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		// TODO: Find a better way to overcome buggy client-side
 		// synchronization with velocity changes since the client
 		// does not correctly predict entity-player collisions.
-		float force_send = m_last_sent_position_timer > 0.5 &&
+		bool force_send = m_last_sent_position_timer > 0.5 &&
 			m_velocity.getLength() > 0.05 && m_prop.collideWithObjects;
 
 		if (force_send || pos_d > minchange || vel_d > minchange ||

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -123,7 +123,7 @@ void LuaEntitySAO::removingFromEnvironment()
 
 void LuaEntitySAO::step(float dtime, bool send_recommended)
 {
-	collisionMoveResult moveresult;
+	collisionMoveResult moveresult, *moveresult_p = nullptr;
 	v3f old_velocity;
 	v3f new_velocity;
 
@@ -223,6 +223,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 					pos_max_d, box, m_prop.stepheight, dtime,
 					&p_pos, &p_velocity, p_acceleration,
 					this, m_prop.collideWithObjects);
+			moveresult_p = &moveresult;
 
 			// Apply changes to position, acceleration, and velocity
 			if(!m_velocity_lock) {
@@ -248,7 +249,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 	if (m_registered) {
 		m_env->getScriptIface()->luaentity_Step(m_id, dtime,
 			m_base_position, m_rotation, new_velocity, old_velocity,
-			m_prop.physical ? &moveresult : nullptr);
+			moveresult_p);
 	}
 
 	if (!send_recommended)
@@ -518,7 +519,7 @@ void LuaEntitySAO::addSpeed(float speed)
 	m_velocity.Z = cos((m_rotation.Y + m_yaw_offset) * core::DEGTORAD) * m_speed;
 }
 
-float LuaEntitySAO::getSpeed()
+float LuaEntitySAO::getSpeed() const
 {
 	return m_speed;
 }
@@ -537,7 +538,7 @@ void LuaEntitySAO::unlockVelocity()
 	m_velocity_lock = false;
 }
 
-bool LuaEntitySAO::isVelocityLocked()
+bool LuaEntitySAO::isVelocityLocked() const
 {
 	return m_velocity_lock;
 }

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -271,7 +271,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		// TODO: Find a better way to overcome buggy client-side
 		// synchronization with velocity changes since the client
 		// does not correctly predict entity-player collisions.
-		bool force_send = m_last_sent_position_timer > 0.5 &&
+		bool force_send = m_velocity_lock && m_last_sent_position_timer > 0.5 &&
 			m_velocity.getLength() > 0.05 && m_prop.collideWithObjects;
 
 		if (force_send || pos_d > minchange || vel_d > minchange ||

--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -96,7 +96,7 @@ private:
 	std::string m_init_state;
 	bool m_registered = false;
 
-	float m_speed = 0.0f;	
+	float m_speed = 0.0f;
 	v3f m_velocity;
 	bool m_velocity_lock = false;
 	v3f m_acceleration;

--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -60,10 +60,10 @@ public:
 	void setSpeed(float speed, float yaw_offset);
 	void setSpeedLateral(float speed_x, float speed_y);
 	void addSpeed(float speed);
-	float getSpeed();
+	float getSpeed() const;
 	void lockVelocity();
 	void unlockVelocity();
-	bool isVelocityLocked();
+	bool isVelocityLocked() const;
 	void setVelocity(v3f velocity);
 	void setVelocityHorz(float vel_x, float vel_z);
 	void setVelocityVert(float vel_y);

--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -39,6 +39,7 @@ public:
 	ActiveObjectType getType() const { return ACTIVEOBJECT_TYPE_LUAENTITY; }
 	ActiveObjectType getSendType() const { return ACTIVEOBJECT_TYPE_GENERIC; }
 	virtual void addedToEnvironment(u32 dtime_s);
+	virtual void removingFromEnvironment();
 	void step(float dtime, bool send_recommended);
 	std::string getClientInitializationData(u16 protocol_version);
 	bool isStaticAllowed() const { return m_prop.static_save; }
@@ -56,11 +57,24 @@ public:
 	u16 getHP() const;
 
 	/* LuaEntitySAO-specific */
+	void setSpeed(float speed, float yaw_offset);
+	void setSpeedLateral(float speed_x, float speed_y);
+	void addSpeed(float speed);
+	float getSpeed();
+	void lockVelocity();
+	void unlockVelocity();
+	bool isVelocityLocked();
 	void setVelocity(v3f velocity);
-	void addVelocity(v3f velocity) { m_velocity += velocity; }
+	void setVelocityHorz(float vel_x, float vel_z);
+	void setVelocityVert(float vel_y);
+	void addVelocity(v3f velocity);
 	v3f getVelocity();
 	void setAcceleration(v3f acceleration);
+	void setAccelerationVert(float acc_y);
 	v3f getAcceleration();
+	void setRotation(v3f rotation);
+	void addRotation(v3f rotation);
+	void turnBy(float yaw_delta, float period, u16 cycles);
 
 	void setTextureMod(const std::string &mod);
 	std::string getTextureMod() const;
@@ -82,8 +96,13 @@ private:
 	std::string m_init_state;
 	bool m_registered = false;
 
+	float m_speed = 0.0f;	
 	v3f m_velocity;
+	bool m_velocity_lock = false;
 	v3f m_acceleration;
+	float m_yaw_offset = 0.0f;
+	float m_turn_rate = 0.0f;
+	float m_turn_period = 0.0f;
 
 	v3f m_last_sent_position;
 	v3f m_last_sent_velocity;

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -35,6 +35,7 @@ public:
 
 	// Rotation
 	void setRotation(v3f rotation) { m_rotation = rotation; }
+	void addRotation(v3f rotation) { m_rotation += rotation; }
 	const v3f &getRotation() const { return m_rotation; }
 	v3f getRadRotation() { return m_rotation * core::DEGTORAD; }
 


### PR DESCRIPTION
This PR is is a feature port from the Minetest S3 fork that aims to better facilitate mob development in Minetest. I've addressed several of the shortcomings with the current API for LuaEntitySAOs, in particular the difficulty of simulating player-like motion mechanics, as has been discussed on various occasions, such as [here](https://forum.minetest.net/viewtopic.php?f=5&t=11080) and [here](https://forum.minetest.net/viewtopic.php?f=5&t=24068). The PR resolves #5458, #3918, #9795, and #9867 in addition some concerns that were expressed by core developers in IRC a few months ago.

Here is a video demonstrating an early prototype of my [Avatars mod](https://forum.minetest.net/viewtopic.php?f=9&t=21688) that uses many of the same methods and callbacks implemented by this PR: https://vimeo.com/316098852

**ObjectRef Methods**
* obj:set_speed(speed, angle)
* obj:set_speed_lateral(speed_x, speed_y)  
* obj:add_speed(speed)
* obj:add_yaw(yaw)
* obj:set_velocity_horz(vel_x, vel_z)
* obj:set_velocity_vert(vel_y)
* obj:set_acceleration_vert(acc_y)
* obj:lock_velocity()
* obj:unlock_velocity()
* obj:is_velocity_locked()
* obj:turn_by(angle, interval, cycles)
* obj:get_entity_name()

**Object Properties**
* yaw_origin
* enable_swimming
* enable_climbing

**Entity Callbacks**
* entity.on_deactivate(self, id)
* entity.on_activate(self, dtime, id)
* entity.on_step(self, dtime, pos, yaw, new_vel, old_vel, move_result)

![dancing_reindeer](https://i.imgur.com/pHaoUd5.gif)

```
-- Jump in a continuous circle while dropping apples at each hop

on_activate = function (self)
     self.object:set_acceleration_vert(-10)
     self.object:set_speed(2.5)
     self.object:turn_by(math.pi / 4, 1.0, 0)
end,

on_step = function (self, dtime, pos, rot, new_vel, old_vel, res)
     if res.collides_y and old_vel.y < 0 then
          self.object:set_velocity_vert(8)
          minetest.add_item(pos, "default:apple")
     end
end,
```

The highlights of the PR include

* For physical objects, the positions of all intersecting nodes as well as the axes of collision are passed directly to the `on_step()` callback.
* Object-object collisions are also listed within the `move_result` table, so scripts no longer have to constantly query `get_objects_in_radius()`.
* Current rotation, position, and velocity information is reported at each server step, relieving the overhead of repetitive calls to the API.
* The new `on_deactivate()` callback permits mods to perform housekeeping immediately before a LuaEntitySAO is removed from the environment.
* Velocity along the X and Z axes can be fixed, so overcoming obstacles in the path of travel no longer requires continuous calls to `set_velocity()`.
* Realistic player-like motion can be achieved without complex trigonometry calculations via the `turn_by()` and `set_speed_lateral()` methods.
* A variety of shortcut methods like `set_velocity_horz()`, `set_acceleration_vert()`, and `add_yaw()` can be used to simplify and streamline code.
* Additional helper functions are provided in `script/common/c_converter.cpp` for validation and conversion of floating point inputs from Lua.
* Deprecation notices for `get_entity_by_name()` have been removed, as suggested by core devs.
http://irc.minetest.net/minetest-dev/2020-02-29#i_5646133
* Object IDs are made available to entities and properly documented, as suggested by core devs.
http://irc.minetest.net/minetest-dev/2020-02-28#i_5646052

## To do

This PR is a Work in Progress.

- [x] Workaround buggy client-side synchronization when velocity changes
- [x] Improve Lua API documentation per suggestions outlined by Wuzzy
- [x] Include `is_impact`, `side`, and `node_pos` fields for collided nodes
- [ ] Possibly rename `touching_ground` to `standing` in collision.cpp

I'll open a separate PR to incorporate  liquid and ladder checks once this is merged.

## Proof of concept

I adapted PilzAdam's "Simple Mobs" as a proof of concept for this PR. I figured the best way to test the reliability and usability. would be to migrate an existing mob engine over to the proposed API.

https://github.com/sorcerykid/mobs

## How to test

Install the following mod into Minimal Development Test.

https://github.com/sorcerykid/entity_test

After joining the game, type `/add` into chat to spawn a new entity. Then type `/cmd` to choose from a battery of preset test scripts. You can also write your own test scripts and execute them under the "(Custom)" preset.