### PR TITLE
FormSpec: Add universal style selector `*`

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2553,7 +2553,7 @@ Elements
 
 * Set the style for the element(s) matching `selector` by name.
 * `selector` can be one of:
-    * `<name>` - An element name.
+    * `<name>` - An element name. Includes `*`, which represents every element.
     * `<name>:<state>` - An element name, a colon, and one or more states.
 * `state` is a list of states separated by the `+` character.
     * If a state is provided, the style will only take effect when the element is in that state.
@@ -2566,7 +2566,7 @@ Elements
 
 * Set the style for the element(s) matching `selector` by type.
 * `selector` can be one of:
-    * `<type>` - An element type.
+    * `<type>` - An element type. Includes `*`, which represents every element.
     * `<type>:<state>` - An element type, a colon, and one or more states.
 * `state` is a list of states separated by the `+` character.
     * If a state is provided, the style will only take effect when the element is in that state.
@@ -2632,6 +2632,8 @@ A name/type can optionally be a comma separated list of names/types, like so:
 
     world_delete,world_create,world_configure
     button,image_button
+
+A `*` type can be used to select every element in the formspec.
 
 Any name/type in the list can also be accompanied by a `+`-separated list of states, like so:
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4619,20 +4619,32 @@ StyleSpec GUIFormSpecMenu::getDefaultStyleForElement(const std::string &type,
 	return getStyleForElement(type, name, parent_type)[StyleSpec::STATE_DEFAULT];
 }
 
-std::array<StyleSpec, StyleSpec::NUM_STATES> GUIFormSpecMenu::getStyleForElement(const std::string &type,
-		const std::string &name, const std::string &parent_type)
+std::array<StyleSpec, StyleSpec::NUM_STATES> GUIFormSpecMenu::getStyleForElement(
+	const std::string &type, const std::string &name, const std::string &parent_type)
 {
 	std::array<StyleSpec, StyleSpec::NUM_STATES> ret;
 
+	auto it = theme_by_type.find("*");
+	if (it != theme_by_type.end()) {
+		for (const StyleSpec &spec : it->second)
+			ret[(u32)spec.getState()] |= spec;
+	}
+
+	it = theme_by_name.find("*");
+	if (it != theme_by_name.end()) {
+		for (const StyleSpec &spec : it->second)
+			ret[(u32)spec.getState()] |= spec;
+	}
+
 	if (!parent_type.empty()) {
-		auto it = theme_by_type.find(parent_type);
+		it = theme_by_type.find(parent_type);
 		if (it != theme_by_type.end()) {
 			for (const StyleSpec &spec : it->second)
 				ret[(u32)spec.getState()] |= spec;
 		}
 	}
 
-	auto it = theme_by_type.find(type);
+	it = theme_by_type.find(type);
 	if (it != theme_by_type.end()) {
 		for (const StyleSpec &spec : it->second)
 			ret[(u32)spec.getState()] |= spec;


### PR DESCRIPTION
This PR adds the universal selector `*` to `style` and `style_type`.  It can be combined with state selectors.  This makes it easier to style everything, e.g. set `noclip` or `textcolor` on everything.

## To do

This PR is Ready for Review.

## How to test

```
formspec_version[3]
size[1,2.5]
position[0.35,0.5]
style_type[*;noclip=true]
style[*;textcolor=green]
button[2,0;3,1;;Button]
label[2,2;Label]
style[*:hovered;textcolor=yellow]
style_type[*:pressed;bgcolor=purple]
button[6,0;3,1;;Button]
image_button[6,1.5;3,1;;;Image Button]
```