### PR TITLE
minetest.serialize: Reversible number serialization

### DIFF
--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -120,15 +120,8 @@ function core.serialize(x)
 		elseif tp == "function" then
 			return string.format("loadstring(%q)", string.dump(x))
 		elseif tp == "number"   then
-			-- Serialize integers with string.format to prevent
-			-- scientific notation, which doesn't preserve
-			-- precision and breaks things like node position
-			-- hashes.  Serialize floats normally.
-			if math.floor(x) == x then
-				return string.format("%d", x)
-			else
-				return tostring(x)
-			end
+			-- Serialize numbers reversibly with string.format
+			return string.format("%.30g", x)
 		elseif tp == "table" then
 			local vals = {}
 			local idx_dumped = {}

--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -121,7 +121,7 @@ function core.serialize(x)
 			return string.format("loadstring(%q)", string.dump(x))
 		elseif tp == "number"   then
 			-- Serialize numbers reversibly with string.format
-			return string.format("%.30g", x)
+			return string.format("%.17g", x)
 		elseif tp == "table" then
 			local vals = {}
 			local idx_dumped = {}

--- a/builtin/common/tests/serialize_spec.lua
+++ b/builtin/common/tests/serialize_spec.lua
@@ -18,6 +18,18 @@ describe("serialize", function()
 		assert.same(test_in, test_out)
 	end)
 
+	it("handles precise numbers", function()
+		local test_in = math.random()
+		local test_out = core.deserialize(core.serialize(test_in))
+		assert.same(test_in, test_out)
+	end)
+
+	it("handles big integers", function()
+		local test_in = 269594915894577
+		local test_out = core.deserialize(core.serialize(test_in))
+		assert.same(test_in, test_out)
+	end)
+
 	it("handles recursive structures", function()
 		local test_in = { hello = "world" }
 		test_in.foo = test_in

--- a/builtin/common/tests/serialize_spec.lua
+++ b/builtin/common/tests/serialize_spec.lua
@@ -19,7 +19,7 @@ describe("serialize", function()
 	end)
 
 	it("handles precise numbers", function()
-		local test_in = math.random()
+		local test_in = 0.2695949158945771
 		local test_out = core.deserialize(core.serialize(test_in))
 		assert.same(test_in, test_out)
 	end)


### PR DESCRIPTION
The hexadecimal format is less human-readable, but for human-readable output the dump function should be used instead of minetest.serialize anyways.

This should fix #7925.
Please test and review.