### PR TITLE
FormSpec: Add `animated_image` to clickthrough elements

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -915,7 +915,9 @@ void GUIFormSpecMenu::parseAnimatedImage(parserData *data, const std::string &el
 
 	auto style = getDefaultStyleForElement("animated_image", spec.fname, "image");
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-	e->drop();
+
+	// Animated images should let events through
+	m_clickthrough_elements.push_back(e);
 
 	m_fields.push_back(spec);
 }


### PR DESCRIPTION
Notable missing from #9534 were `animated_image`s.  These obviously don't have user interaction, so they shouldn't block input.  This PR fixes that.

## Todo
This PR is Ready for Review.

## How to Test

Nice 'n' easy:
```
formspec_version[3]
size[3,3]
button[0.5,0.5;2,2;;Button]
animated_image[1,1;1,1;;air.png;2;500]
```