### PR TITLE
Simplify how parseElement splits element string

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2668,24 +2668,12 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 	if (parseVersionDirect(element))
 		return;
 
-	std::vector<std::string> parts = split(element,'[');
-
-	// ugly workaround to keep compatibility
-	if (parts.size() > 2) {
-		if (trim(parts[0]) == "image") {
-			for (unsigned int i=2;i< parts.size(); i++) {
-				parts[1] += "[" + parts[i];
-			}
-		}
-		else { return; }
-	}
-
-	if (parts.size() < 2) {
+	size_t pos = element.find('[');
+	if (pos == std::string::npos)
 		return;
-	}
 
-	std::string type = trim(parts[0]);
-	std::string description = trim(parts[1]);
+	std::string type = trim(element.substr(0, pos));
+	std::string description = element.substr(pos+1);
 
 	if (type == "container") {
 		parseContainer(data, description);


### PR DESCRIPTION
Image buttons are not rendered in formspec if their texture uses modifiers.

This PR simply fix this by adding "image_button" to the compatibility workaround in `parseElement`.

By the way, I'm not sure about this workaround being still needed, maybe a better fix would be to remove it completely.

EDIT: Now this PR simplifies how parseElement splits element string in type/description parts.

## To do

This PR is a Ready for Review.

## How to test
My test code:
```
minetest.register_chatcommand("t", {
	params = "",
	description = "Test",
	func = function(name, param)
		minetest.show_formspec(name, "test", [[
			size[1,1]
			image_button[0,0;1,1;default_stone.png^[colorize:#F008;test;]
		]]);
	end
})
```
Without the fix --> Empty formspec
With the fix --> Expected image button displayed
