### PR TITLE
Add chat_font_size setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -903,6 +903,10 @@ fallback_font_shadow_alpha (Fallback font shadow alpha) int 128 0 255
 #    This font will be used for certain languages or if the default font is unavailable.
 fallback_font_path (Fallback font path) filepath fonts/DroidSansFallbackFull.ttf
 
+#    Font size of the recent chat text and chat prompt in point (pt).
+#    Value 0 will use the default font size.
+chat_font_size (Chat font size) int 0
+
 #    Path to save screenshots at. Can be an absolute or relative path.
 #    The folder will be created if it doesn't already exist.
 screenshot_path (Screenshot folder) path screenshots

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -76,6 +76,11 @@ void GameUI::init()
 	m_guitext_chat = gui::StaticText::add(guienv, L"", core::rect<s32>(0, 0, 0, 0),
 		//false, false); // Disable word wrap as of now
 		false, true, guiroot);
+	u16 chat_font_size = g_settings->getU16("chat_font_size");
+	if (chat_font_size != 0) {
+		m_guitext_chat->setOverrideFont(g_fontengine->getFont(
+			chat_font_size, FM_Unspecified));
+	}
 
 	// Profiler text (size is updated when text is updated)
 	m_guitext_profiler = gui::StaticText::add(guienv, L"<Profiler>",
@@ -213,7 +218,6 @@ void GameUI::showTranslatedStatusText(const char *str)
 
 void GameUI::setChatText(const EnrichedString &chat_text, u32 recent_chat_count)
 {
-	setStaticText(m_guitext_chat, chat_text);
 
 	// Update gui element size and position
 	s32 chat_y = 5;
@@ -221,16 +225,15 @@ void GameUI::setChatText(const EnrichedString &chat_text, u32 recent_chat_count)
 	if (m_flags.show_debug)
 		chat_y += 2 * g_fontengine->getLineHeight();
 
-	// first pass to calculate height of text to be set
 	const v2u32 &window_size = RenderingEngine::get_instance()->getWindowSize();
-	s32 width = std::min(g_fontengine->getTextWidth(chat_text.c_str()) + 10,
-		window_size.X - 20);
-	m_guitext_chat->setRelativePosition(core::rect<s32>(10, chat_y, width,
-		chat_y + window_size.Y));
 
-	// now use real height of text and adjust rect according to this size
-	m_guitext_chat->setRelativePosition(core::rect<s32>(10, chat_y, width,
-		chat_y + m_guitext_chat->getTextHeight()));
+	core::rect<s32> chat_size(10, chat_y,
+		window_size.X - 20, 0);
+	chat_size.LowerRightCorner.Y = std::min((s32)window_size.Y - chat_y,
+		m_guitext_chat->getTextHeight() + chat_y);
+
+	m_guitext_chat->setRelativePosition(chat_size);
+	setStaticText(m_guitext_chat, chat_text);
 
 	m_recent_chat_count = recent_chat_count;
 }

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -229,7 +229,7 @@ void GameUI::setChatText(const EnrichedString &chat_text, u32 recent_chat_count)
 
 	core::rect<s32> chat_size(10, chat_y,
 		window_size.X - 20, 0);
-	chat_size.LowerRightCorner.Y = std::min((s32)window_size.Y - chat_y,
+	chat_size.LowerRightCorner.Y = std::min((s32)window_size.Y,
 		m_guitext_chat->getTextHeight() + chat_y);
 
 	m_guitext_chat->setRelativePosition(chat_size);

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -321,8 +321,12 @@ void set_default_settings(Settings *settings)
 
 	std::string font_size_str = std::to_string(DEFAULT_FONT_SIZE);
 #endif
+	// General font settings
 	settings->setDefault("font_size", font_size_str);
 	settings->setDefault("mono_font_size", font_size_str);
+	settings->setDefault("chat_font_size", "0"); // Default "font_size"
+
+	// ContentDB
 	settings->setDefault("contentdb_url", "https://content.minetest.net");
 #ifdef __ANDROID__
 	settings->setDefault("contentdb_flag_blacklist", "nonfree, android_default");

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -74,7 +74,9 @@ GUIChatConsole::GUIChatConsole(
 		m_background_color.setBlue(clamp_u8(myround(console_color.Z)));
 	}
 
-	m_font = g_fontengine->getFont(FONT_SIZE_UNSPECIFIED, FM_Mono);
+	u16 chat_font_size = g_settings->getU16("chat_font_size");
+	m_font = g_fontengine->getFont(chat_font_size != 0 ?
+		chat_font_size : FONT_SIZE_UNSPECIFIED, FM_Mono);
 
 	if (!m_font) {
 		errorstream << "GUIChatConsole: Unable to load mono font" << std::endl;


### PR DESCRIPTION
Closes #9660 (EDIT: autocomplete failed)
Default font sizes are used when the setting value is `0` or below (clamped by Settings).

## To do

This PR is Ready for Review.

## How to test

1) No settings change: test the chat prompt and the recent chat - must use the default sizes.
2) `chat_font_size = 35`: Huge fonts for the chat prompt and recent chat
