### PR TITLE
Fix mapgen settings in minetest.conf being ignored

### DIFF
--- a/src/map_settings_manager.cpp
+++ b/src/map_settings_manager.cpp
@@ -32,7 +32,6 @@ MapSettingsManager::MapSettingsManager(Settings *user_settings,
 	m_user_settings(user_settings)
 {
 	assert(m_user_settings != NULL);
-	Mapgen::setDefaultSettings(m_map_settings);
 }
 
 
@@ -179,6 +178,16 @@ MapgenParams *MapSettingsManager::makeMapgenParams()
 		return nullptr;
 
 	params->mgtype = mgtype;
+
+	// Load the mapgen param defaults
+	/* FIXME: Why is it done like this? MapgenParams should just
+	 * set the defaults in its constructor instead. */
+	{
+		Settings default_settings;
+		Mapgen::setDefaultSettings(&default_settings);
+		params->MapgenParams::readParams(&default_settings);
+		params->readParams(&default_settings);
+	}
 
 	// Load the rest of the mapgen params from our active settings
 	params->MapgenParams::readParams(m_user_settings);


### PR DESCRIPTION
broken since e8a8185d24897ccf964327017effae81aa1c9d40

## To do

This PR is a Ready for Review.

## How to test

https://github.com/minetest/minetest/pull/9296#issuecomment-618700998