### PR TITLE
Add MSVC build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
           NO_PACKAGE: 1
   msvc:
     name: VS 2019 ${{ matrix.config.arch }}-${{ matrix.type }}
-    runs-on: windows-latest 
+    runs-on: windows-2019 
     env:
       VCPKG_VERSION: c7ab9d3110813979a873b2dbac630a9ab79850dc
 #                    2020.04
@@ -235,4 +235,3 @@ jobs:
         with:
           name: msvc-${{ matrix.config.arch }}-${{ matrix.type }}
           path: .\Package\
-          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,3 +169,70 @@ jobs:
         env:
           NO_MINETEST_GAME: 1
           NO_PACKAGE: 1
+  msvc:
+    name: VS 2019 ${{ matrix.config.arch }}-${{ matrix.type }}
+    runs-on: windows-latest 
+    env:
+      VCPKG_VERSION: c7ab9d3110813979a873b2dbac630a9ab79850dc
+#                    2020.04
+      vcpkg_packages: irrlicht zlib curl[winssl] openal-soft libvorbis libogg sqlite3 freetype luajit
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+              arch: x86,
+              generator: "-G'Visual Studio 16 2019' -A Win32",
+              vcpkg_triplet: x86-windows
+            }
+          - {
+              arch: x64,
+              generator: "-G'Visual Studio 16 2019' -A x64",
+              vcpkg_triplet: x64-windows
+            }
+        type: [portable, installer]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Restore from cache and run vcpkg
+        uses: lukka/run-vcpkg@v2
+        with:
+          vcpkgArguments: ${{env.vcpkg_packages}}
+          vcpkgDirectory: '${{ github.workspace }}\vcpkg'
+          appendedCacheKey: ${{ matrix.config.vcpkg_triplet }}
+          vcpkgGitCommitId: ${{ env.VCPKG_VERSION }}
+          vcpkgTriplet: ${{ matrix.config.vcpkg_triplet }}
+
+      - name: CMake
+        run: |
+          cmake ${{matrix.config.generator}}  `
+          -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake"  `
+          -DCMAKE_BUILD_TYPE=Release  `
+          -DRUN_IN_PLACE=${{ contains(matrix.type, 'portable') }} .
+
+      - name: Build
+        run: cmake --build . --config Release
+
+      - name: CPack
+        run: |
+          If ($env:TYPE -eq "installer")
+          {
+            cpack -G WIX -B "$env:GITHUB_WORKSPACE\Package"
+          }
+          ElseIf($env:TYPE -eq "portable")
+          {
+            cpack -G ZIP -B "$env:GITHUB_WORKSPACE\Package"
+          }
+        env:
+          TYPE: ${{matrix.type}}
+
+      - name: Package Clean
+        run: rm -r $env:GITHUB_WORKSPACE\Package\_CPack_Packages
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: msvc-${{ matrix.config.arch }}-${{ matrix.type }}
+          path: .\Package\
+          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,6 +169,7 @@ jobs:
         env:
           NO_MINETEST_GAME: 1
           NO_PACKAGE: 1
+
   msvc:
     name: VS 2019 ${{ matrix.config.arch }}-${{ matrix.type }}
     runs-on: windows-2019 
@@ -190,7 +191,10 @@ jobs:
               generator: "-G'Visual Studio 16 2019' -A x64",
               vcpkg_triplet: x64-windows
             }
-        type: [portable, installer]
+        type: [portable]
+#        type: [portable, installer]
+# The installer type is working, but disabled, to save runner jobs.
+# Enable it, when working on the installer.
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This adds MSVC builds to GitHub actions including x86, x64, portable and installer

## To do

This PR is Ready for Review.


## How to test

Wait until build completes, go to Actions download artifact and try it.
