### PR TITLE
Add support for socket activation using libsystemd.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -198,6 +198,7 @@ if(ENABLE_LEVELDB)
 	endif()
 endif(ENABLE_LEVELDB)
 
+find_library(SYSTEMD_LIBRARY NAMES systemd libsystemd)
 
 OPTION(ENABLE_REDIS "Enable Redis backend" TRUE)
 set(USE_REDIS FALSE)
@@ -614,6 +615,7 @@ if(BUILD_SERVER)
 		${LUA_LIBRARY}
 		${GMP_LIBRARY}
 		${PLATFORM_LIBS}
+		${SYSTEMD_LIBRARY}
 	)
 	set_target_properties(${PROJECT_NAME}server PROPERTIES
 			COMPILE_DEFINITIONS "SERVER")


### PR DESCRIPTION
The goal is to allow socket activation with minetest. 
It was initially proposed in #1628.
My use case for this PR is to reduce resource usage by minetest server to 0 when no one is connected. Many mods keep running in background even when no players are connected like advtrains, mesecons, etc. With this PR you can shutdown the server when no players are connected and have it automatically restarted when someone first tries to connect.

## To do

This PR is a Work in Progress.

- [ ] Fix CMake, it should check for libsystemd (I don't know much about CMake) 

## How to test

This is minetest.service:
```
[Service]
ExecStart=/bin/minetestserver --gameid minimal --world test-socket --verbose

[Install]
WantedBy=multi-user.target
```

This is minetest.socket:
```
[Socket]
ListenDatagram=30000

[Install]
WantedBy=sockets.target
```

Run `systemd enable --now minetest.socket` and try to connect with Minetest client. The server should automatically startup and the client should connect after the server has started (check with `journalctl -fu minetest.service`).

To shutdown the server when no one is playing, you can use a mod like https://github.com/minetest-mods/autoshutdown/.