### PR TITLE
Fix gray screen on Lua error

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4276,7 +4276,6 @@ void the_game(bool *kill,
 				reconnect_requested, &chat_backend, gamespec,
 				simple_singleplayer_mode)) {
 			game.run();
-			game.shutdown();
 		}
 
 	} catch (SerializationError &e) {
@@ -4292,4 +4291,5 @@ void the_game(bool *kill,
 				strgettext("\nCheck debug.txt for details.");
 		errorstream << error_message << std::endl;
 	}
+	game.shutdown();
 }


### PR DESCRIPTION
Fixes #4482 

`Game::shutdown` was not being run when the server throws an exception, so the menus weren't getting deleted. So after `the_game` returns and [`main_menu`](https://github.com/minetest/minetest/blob/914dbeaa0be4b5ef87506b605ef4e241cd3732dc/src/client/clientlauncher.cpp#L537) is called, `isMenuActive()` returns true and the gray background is drawn. ~I have no idea what that code was supposed to do so I deleted it. It was added in https://github.com/minetest/minetest/commit/405347769a2f8c73aead3bc2b64fdc4d81763921.~

## To do

This PR is a Ready for Review.
<!-- ^ delete one -->

## How to test

Trigger a Lua error while the chat console or a form is open using e.g.:
```lua
minetest.after(4, function() fail() end)
```
Before: gray screen
After: shutdown message then error dialog in the main menu
<!-- Example code or instructions -->
