### PR TITLE
Add Collada to supported formats

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -714,7 +714,7 @@ bool Client::loadMedia(const std::string &data, const std::string &filename)
 	}
 
 	const char *model_ext[] = {
-		".x", ".b3d", ".md2", ".obj",
+		".x", ".b3d", ".dae", ".md2", ".obj",
 		NULL
 	};
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2472,7 +2472,7 @@ void Server::fillMediaCache()
 				".png", ".jpg", ".bmp", ".tga",
 				".pcx", ".ppm", ".psd", ".wal", ".rgb",
 				".ogg",
-				".x", ".b3d", ".md2", ".obj",
+				".x", ".b3d", ".dae", ".md2", ".obj",
 				// Custom translation file format
 				".tr",
 				NULL


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR: Support Collada (`.dae`) as it's (partially) supported by Irrlicht
- How does the PR work? Pretty trival currently; just adds `.dae` to the list of supported formats.
- Does it resolve any reported issue? Partially attends to #9673

## To do

This PR is a Work in Progress

- [ ] Make animations work (which Irrlicht doesn't seem to support...)

## How to test

Use a Collada mesh.