### PR TITLE
Add sized labels and text alignment to various FormSpec elements

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2761,6 +2761,8 @@ Some types may inherit styles from parent types.
       * `*<number>`: Multiplies default font size by `number`, similar to CSS `em`.
     * border - boolean, draw border. Set to false to hide the bevelled button pane. Default true.
     * content_offset - 2d vector, shifts the position of the button's content without resizing it.
+    * halign - `left/center/right`: Horizontal alignment of text. Default `center`.
+    * valign - `top/center/bottom`: Vertical alignment of text. Default `center`.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
     * padding - rect, adds space between the edges of the button and the content. This value is
                 relative to bgimg_middle.
@@ -2779,6 +2781,8 @@ Some types may inherit styles from parent types.
     * border - set to false to hide the textbox background and border. Default true.
     * font - Sets font type. See button `font` property for more information.
     * font_size - Sets font size. See button `font_size` property for more information.
+    * halign - `left/center/right`: Horizontal alignment of text. Default `left`.
+    * valign - `top/center/bottom`: Vertical alignment of text, only for textarea. Default `top`.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
     * textcolor - color. Default white.
 * image

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2318,16 +2318,23 @@ Elements
 
 ### `label[<X>,<Y>;<label>]`
 
-* The label formspec element displays the text set in `label`
-  at the specified position.
+* Displays the text `label` at the specified position.
 * **Note**: If the new coordinate system is enabled, labels are
   positioned from the center of the text, not the top.
 * The text is displayed directly without automatic line breaking,
-  so label should not be used for big text chunks.  Newlines can be
+  so label should not be used for big text chunks. Newlines can be
   used to make labels multiline.
 * **Note**: With the new coordinate system, newlines are spaced with
   half a coordinate.  With the old system, newlines are spaced 2/5 of
   an inventory slot.
+
+### `label[<X>,<Y>;<label>;<W>,<H>]`
+
+* Displays the text `label` at the specified position with a width and height
+  for alignment (see [Styling Formspecs]) and text clipping.
+**Note:**: Requires formspec version 4 or higher.
+* The text has no automatic line breaking or scrolling, but newlines can be added for
+  forced line breaks.
 
 ### `hypertext[<X>,<Y>;<W>,<H>;<name>;<text>]`
 * Displays a static formatted text with hyperlinks.
@@ -2794,6 +2801,9 @@ Some types may inherit styles from parent types.
     * font - Sets font type. See button `font` property for more information.
     * font_size - Sets font size. See button `font_size` property for more information.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
+* label (additional properties, sized labels only)
+    * halign - `left/center/right`: Horizontal alignment of text. Default `left`.
+    * valign - `top/center/bottom`: Vertical alignment of text. Default `center`.
 * image_button (additional properties)
     * fgimg - standard image. Defaults to none.
     * fgimg_hovered - image when hovered. Defaults to fgimg when not provided.

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -50,6 +50,8 @@ public:
 		PADDING,
 		FONT,
 		FONT_SIZE,
+		HALIGN,
+		VALIGN,
 		NUM_PROPERTIES,
 		NONE
 	};
@@ -106,6 +108,10 @@ public:
 			return FONT;
 		} else if (name == "font_size") {
 			return FONT_SIZE;
+		} else if (name == "halign") {
+			return HALIGN;
+		} else if (name == "valign") {
+			return VALIGN;
 		} else {
 			return NONE;
 		}
@@ -164,6 +170,22 @@ public:
 		}
 
 		return temp;
+	}
+
+	gui::EGUI_ALIGNMENT getAlignment(Property prop, gui::EGUI_ALIGNMENT def) const
+	{
+		const auto &val = properties[prop];
+		if (val.empty())
+			return def;
+
+		if (val == "left" || val == "top")
+			return gui::EGUIA_UPPERLEFT;
+		else if (val == "center")
+			return gui::EGUIA_CENTER;
+		else if (val == "right" || val == "bottom")
+			return gui::EGUIA_LOWERRIGHT;
+		else
+			return def;
 	}
 
 	video::SColor getColor(Property prop, video::SColor def) const

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -826,6 +826,11 @@ void GUIButton::setFromStyle(const StyleSpec& style)
 	for (IGUIElement *child : getChildren()) {
 		child->setRelativePosition(childBounds);
 	}
+
+	StaticText->setTextAlignment(
+		style.getAlignment(StyleSpec::HALIGN, gui::EGUIA_CENTER),
+		style.getAlignment(StyleSpec::VALIGN, gui::EGUIA_CENTER)
+	);
 }
 
 //! Set the styles used for each state

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1471,6 +1471,10 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		e->setDrawBorder(style.getBool(StyleSpec::BORDER, true));
 		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
 		e->setOverrideFont(style.getFont());
+		e->setTextAlignment(
+			style.getAlignment(StyleSpec::HALIGN, gui::EGUIA_UPPERLEFT),
+			gui::EGUIA_CENTER
+		);
 
 		irr::SEvent evt;
 		evt.EventType            = EET_KEY_INPUT_EVENT;
@@ -1536,7 +1540,10 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 		if (is_multiline) {
 			e->setMultiLine(true);
 			e->setWordWrap(true);
-			e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_UPPERLEFT);
+			e->setTextAlignment(
+				style.getAlignment(StyleSpec::HALIGN, gui::EGUIA_UPPERLEFT),
+				style.getAlignment(StyleSpec::VALIGN, gui::EGUIA_UPPERLEFT)
+			);
 		} else {
 			irr::SEvent evt;
 			evt.EventType            = EET_KEY_INPUT_EVENT;
@@ -1546,6 +1553,11 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 			evt.KeyInput.Shift       = 0;
 			evt.KeyInput.PressedDown = true;
 			e->OnEvent(evt);
+
+			e->setTextAlignment(
+				style.getAlignment(StyleSpec::HALIGN, gui::EGUIA_UPPERLEFT),
+				gui::EGUIA_CENTER
+			);
 		}
 
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));

--- a/src/irrlicht_changes/static_text.cpp
+++ b/src/irrlicht_changes/static_text.cpp
@@ -85,14 +85,13 @@ void StaticText::draw()
 
 		core::rect<s32> r = frameRect;
 		s32 height_line = font->getDimension(L"A").Height + font->getKerningHeight();
-		s32 height_total = height_line * BrokenText.size();
 		if (VAlign == EGUIA_CENTER && WordWrap)
 		{
-			r.UpperLeftCorner.Y = r.getCenter().Y - (height_total / 2);
+			r.UpperLeftCorner.Y = r.getCenter().Y - (getTextHeight() / 2);
 		}
 		else if (VAlign == EGUIA_LOWERRIGHT)
 		{
-			r.UpperLeftCorner.Y = r.LowerRightCorner.Y - height_total;
+			r.UpperLeftCorner.Y = r.LowerRightCorner.Y - getTextHeight();
 		}
 		if (HAlign == EGUIA_LOWERRIGHT)
 		{

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -240,6 +240,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		new element: scroll_container[]
 	FORMSPEC VERSION 4:
 		Allow dropdown indexing events
+		Labels can have a size parameter
 */
 #define FORMSPEC_API_VERSION 4
 


### PR DESCRIPTION
Adds `halign` and `valign` properties to align text in buttons, textareas, and sized labels as well as just `halign` in fields and pwdfields.  This also adds sized labels of the form `label[<X>,<Y>;<label>;<W>,<H>]` and increases the formspec version number to 4 as a result.

Fields and pwdfields don't have `valign` because a) it isn't really useful and b) it isn't natively supported in Irrlicht anyway for some reason.

![image](https://user-images.githubusercontent.com/31123645/85215928-bd5e4f80-b333-11ea-8dfa-1f18d696d4b5.png)

## To do

This PR is Ready for Review.

## How to test

When using the screenshot code, also mess around with newlines and long lines of text to make sure Irrlicht's alignment works right.
<details><summary><b>Screenshot Code</b></summary>

```
formspec_version[3]
size[12,8]

style[left;halign=left]
style[hcenter;halign=center]
style[right;halign=right]
style[top;valign=top]
style[vcenter;valign=center]
style[bottom;valign=bottom]

button[1.5,0;3,1;;Default]
button[0,1;3,1;left;Left]
button[0,2;3,1;hcenter;Center]
button[0,3;3,1;right;Right]
button[3,1;3,1;top;Top]
button[3,2;3,1;vcenter;Center]
button[3,3;3,1;bottom;Bottom]

container[6,0]
textarea[1.5,0;3,1;def;;Default]
textarea[0,1;3,1;left;;Left]
textarea[0,2;3,1;hcenter;;Center]
textarea[0,3;3,1;right;;Right]
textarea[3,1;3,1;top;;Top]
textarea[3,2;3,1;vcenter;;Center]
textarea[3,3;3,1;bottom;;Bottom]
container_end[]

container[0,4]
field[0,0;3,1;def;;Default]
field[0,1;3,1;left;;Left]
field[0,2;3,1;hcenter;;Center]
field[0,3;3,1;right;;Right]
container_end[]

container[3,4]
pwdfield[0,0;3,1;def;]
pwdfield[0,1;3,1;left;]
pwdfield[0,2;3,1;hcenter;]
pwdfield[0,3;3,1;right;]
container_end[]

container[6,4]
box[3,0;3,1;#000]
label[0,0;Default;3,1]
style_type[label;halign=left]
box[0,1;3,1;#000]
label[0,1;Left;3,1]
style_type[label;halign=center]
label[0,2;Center;3,1]
style_type[label;halign=right]
box[0,3;3,1;#000]
label[0,3;Right;3,1]
style_type[label;halign=;valign=top]
label[3,1;Top;3,1]
style_type[label;valign=center]
box[3,2;3,1;#000]
label[3,2;Center;3,1]
style_type[label;valign=bottom]
label[3,3;Bottom;3,1]
container_end[]
```
</details>