### PR TITLE
Various cleanups

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -717,8 +717,9 @@ core.register_chatcommand("spawnentity", {
 			end
 		end
 		p.y = p.y + 1
-		core.add_entity(p, entityname)
-		return true, ("%q spawned."):format(entityname)
+		local obj = core.add_entity(p, entityname)
+		local msg = obj and "%q spawned." or "%q failed to spawn."
+		return true, msg:format(entityname)
 	end,
 })
 

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -136,8 +136,10 @@ protected:
 	Environment* getEnv() { return m_environment; }
 	void setEnv(Environment* env) { m_environment = env; }
 
+#ifndef SERVER
 	GUIEngine* getGuiEngine() { return m_guiengine; }
 	void setGuiEngine(GUIEngine* guiengine) { m_guiengine = guiengine; }
+#endif
 
 	void objectrefGetOrCreate(lua_State *L, ServerActiveObject *cobj);
 
@@ -158,6 +160,8 @@ private:
 
 	IGameDef       *m_gamedef = nullptr;
 	Environment    *m_environment = nullptr;
+#ifndef SERVER
 	GUIEngine      *m_guiengine = nullptr;
+#endif
 	ScriptingType  m_type;
 };

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -62,10 +62,12 @@ Environment *ModApiBase::getEnv(lua_State *L)
 	return getScriptApiBase(L)->getEnv();
 }
 
+#ifndef SERVER
 GUIEngine *ModApiBase::getGuiEngine(lua_State *L)
 {
 	return getScriptApiBase(L)->getGuiEngine();
 }
+#endif
 
 std::string ModApiBase::getCurrentModPath(lua_State *L)
 {

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -32,12 +32,12 @@ extern "C" {
 
 #ifndef SERVER
 class Client;
+class GUIEngine;
 #endif
 
 class ScriptApiBase;
 class Server;
 class Environment;
-class GUIEngine;
 
 class ModApiBase : protected LuaHelper {
 
@@ -46,12 +46,13 @@ public:
 	static Server*          getServer(lua_State *L);
 	#ifndef SERVER
 	static Client*          getClient(lua_State *L);
+	static GUIEngine*       getGuiEngine(lua_State *L);
 	#endif // !SERVER
 
 	static IGameDef*        getGameDef(lua_State *L);
 
 	static Environment*     getEnv(lua_State *L);
-	static GUIEngine*       getGuiEngine(lua_State *L);
+
 	// When we are not loading the mod, this function returns "."
 	static std::string      getCurrentModPath(lua_State *L);
 

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -589,19 +589,19 @@ int ModApiEnvMod::l_add_entity(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	// pos
 	v3f pos = checkFloatPos(L, 1);
-	// content
 	const char *name = luaL_checkstring(L, 2);
-	// staticdata
 	const char *staticdata = luaL_optstring(L, 3, "");
-	// Do it
+
 	ServerActiveObject *obj = new LuaEntitySAO(env, pos, name, staticdata);
 	int objectid = env->addActiveObject(obj);
 	// If failed to add, return nothing (reads as nil)
 	if(objectid == 0)
 		return 0;
-	// Return ObjectRef
+
+	// If already deleted (can happen in on_activate), return nil
+	if (obj->isGone())
+		return 0;
 	getScriptApiBase(L)->objectrefGetOrCreate(L, obj);
 	return 1;
 }

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -52,8 +52,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // not represent the full range, but rather the largest safe range, of values on
 // all supported architectures.  Note: This definition makes assumptions on
 // platform float-to-int conversion behavior.
-#define F1000_MIN ((float)(s32)((-0x7FFFFFFF - 1) / FIXEDPOINT_FACTOR))
-#define F1000_MAX ((float)(s32)((0x7FFFFFFF) / FIXEDPOINT_FACTOR))
+#define F1000_MIN ((float)(s32)((float)(-0x7FFFFFFF - 1) / FIXEDPOINT_FACTOR))
+#define F1000_MAX ((float)(s32)((float)(0x7FFFFFFF) / FIXEDPOINT_FACTOR))
 
 #define STRING_MAX_LEN 0xFFFF
 #define WIDE_STRING_MAX_LEN 0xFFFF


### PR DESCRIPTION
(<b>don't squash</b>)

## To do

This PR is a Ready for Review.

## How to test

1. Install latest version of WorldEdit
2. Run `/spawnentity worldedit:pos1`
3. Check that it says `"worldedit:pos1" failed to spawn.`
and that `ScriptApiBase::objectrefGetOrCreate(): Pushing ObjectRef to removed/deactivated object, this is probably a bug.` does NOT appear
