### PR TITLE
Android: some java-part improvements

### DIFF
--- a/build/android/app/build.gradle
+++ b/build/android/app/build.gradle
@@ -2,12 +2,11 @@ apply plugin: 'com.android.application'
 android {
 	compileSdkVersion 29
 	buildToolsVersion '29.0.3'
-	ndkVersion '21.0.6113669'
+	ndkVersion '21.1.6352462'
 	defaultConfig {
 		applicationId 'net.minetest.minetest'
 		minSdkVersion 16
-		//noinspection OldTargetApi
-		targetSdkVersion 28 // Workaround for using `/sdcard` instead of the `data` patch for assets
+		targetSdkVersion 29
 		versionName "${versionMajor}.${versionMinor}.${versionPatch}"
 		versionCode project.versionCode
 	}

--- a/build/android/app/src/main/AndroidManifest.xml
+++ b/build/android/app/src/main/AndroidManifest.xml
@@ -7,11 +7,18 @@
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
+	<!--
+		`android:requestLegacyExternalStorage="true"` is workaround for using `/sdcard`
+		instead of the `getFilesDir()` patch for assets. Check link below for more information:
+		https://developer.android.com/training/data-storage/compatibility
+	-->
+
 	<application
 		android:allowBackup="false"
 		android:icon="@mipmap/ic_launcher"
 		android:label="@string/label"
 		android:resizeableActivity="false"
+		android:requestLegacyExternalStorage="true"
 		tools:ignore="UnusedAttribute">
 
 		<meta-data

--- a/build/android/app/src/main/java/net/minetest/minetest/CopyZipTask.java
+++ b/build/android/app/src/main/java/net/minetest/minetest/CopyZipTask.java
@@ -23,7 +23,7 @@ package net.minetest.minetest;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
-import android.util.Log;
+import android.widget.Toast;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -40,7 +40,7 @@ public class CopyZipTask extends AsyncTask<String, Void, String> {
 	}
 
 	protected String doInBackground(String... params) {
-		copyAssets(params);
+		copyAsset(params[0]);
 		return params[0];
 	}
 
@@ -49,20 +49,13 @@ public class CopyZipTask extends AsyncTask<String, Void, String> {
 		startUnzipService(result);
 	}
 
-	private void copyAsset(String zipName) throws IOException {
+	private void copyAsset(String zipName) {
 		String filename = zipName.substring(zipName.lastIndexOf("/") + 1);
 		try (InputStream in = contextRef.get().getAssets().open(filename);
 		     OutputStream out = new FileOutputStream(zipName)) {
 			copyFile(in, out);
-		}
-	}
-
-	private void copyAssets(String[] zips) {
-		try {
-			for (String zipName : zips)
-				copyAsset(zipName);
 		} catch (IOException e) {
-			Log.e("CopyZipTask", e.getLocalizedMessage());
+			Toast.makeText(contextRef.get(), e.getLocalizedMessage(), Toast.LENGTH_LONG).show();
 			cancel(true);
 		}
 	}

--- a/build/android/app/src/main/java/net/minetest/minetest/MainActivity.java
+++ b/build/android/app/src/main/java/net/minetest/minetest/MainActivity.java
@@ -43,6 +43,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static net.minetest.minetest.UnzipService.ACTION_PROGRESS;
+import static net.minetest.minetest.UnzipService.ACTION_UPDATE;
+import static net.minetest.minetest.UnzipService.FAILURE;
+import static net.minetest.minetest.UnzipService.SUCCESS;
+
 public class MainActivity extends AppCompatActivity {
 	private final static int versionCode = BuildConfig.VERSION_CODE;
 	private final static int PERMISSIONS = 1;
@@ -58,14 +63,16 @@ public class MainActivity extends AppCompatActivity {
 		public void onReceive(Context context, Intent intent) {
 			int progress = 0;
 			if (intent != null)
-				progress = intent.getIntExtra(UnzipService.ACTION_PROGRESS, 0);
+				progress = intent.getIntExtra(ACTION_PROGRESS, 0);
 			if (progress >= 0) {
 				if (mProgressBar != null) {
 					mProgressBar.setVisibility(View.VISIBLE);
 					mProgressBar.setProgress(progress);
 				}
 				mTextView.setVisibility(View.VISIBLE);
-			} else
+			} else if (progress == FAILURE) {
+				finish();
+			} else if (progress == SUCCESS)
 				startNative();
 		}
 	};
@@ -74,7 +81,7 @@ public class MainActivity extends AppCompatActivity {
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_main);
-		IntentFilter filter = new IntentFilter(UnzipService.ACTION_UPDATE);
+		IntentFilter filter = new IntentFilter(ACTION_UPDATE);
 		registerReceiver(myReceiver, filter);
 		mProgressBar = findViewById(R.id.progressBar);
 		mTextView = findViewById(R.id.textView);

--- a/build/android/app/src/main/java/net/minetest/minetest/UnzipService.java
+++ b/build/android/app/src/main/java/net/minetest/minetest/UnzipService.java
@@ -28,11 +28,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Environment;
-import android.util.Log;
+import android.widget.Toast;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -44,9 +43,12 @@ public class UnzipService extends IntentService {
 	public static final String ACTION_UPDATE = "net.minetest.minetest.UPDATE";
 	public static final String ACTION_PROGRESS = "net.minetest.minetest.PROGRESS";
 	public static final String EXTRA_KEY_IN_FILE = "file";
+	public static final int SUCCESS = -1;
+	public static final int FAILURE = -2;
 	private static final String TAG = "UnzipService";
 	private final int id = 1;
 	private NotificationManager mNotifyManager;
+	private boolean isSuccess = true;
 
 	public UnzipService() {
 		super("net.minetest.minetest.UnzipService");
@@ -120,10 +122,9 @@ public class UnzipService extends IntentService {
 				}
 				zipFile.delete();
 			}
-		} catch (FileNotFoundException e) {
-			Log.e(TAG, e.getLocalizedMessage());
 		} catch (IOException e) {
-			Log.e(TAG, e.getLocalizedMessage());
+			isSuccess = false;
+			Toast.makeText(this, e.getLocalizedMessage(), Toast.LENGTH_LONG).show();
 		}
 	}
 
@@ -139,7 +140,7 @@ public class UnzipService extends IntentService {
 			ZipFile zipSize = new ZipFile(zip);
 			size += zipSize.size();
 		} catch (IOException e) {
-			Log.e(TAG, e.getLocalizedMessage());
+			Toast.makeText(this, e.getLocalizedMessage(), Toast.LENGTH_LONG).show();
 		}
 		return size;
 	}
@@ -148,6 +149,6 @@ public class UnzipService extends IntentService {
 	public void onDestroy() {
 		super.onDestroy();
 		mNotifyManager.cancel(id);
-		publishProgress(-1);
+		publishProgress(isSuccess ? SUCCESS : FAILURE);
 	}
 }

--- a/build/android/native/build.gradle
+++ b/build/android/native/build.gradle
@@ -4,7 +4,7 @@ import org.ajoberstar.grgit.Grgit
 android {
 	compileSdkVersion 29
 	buildToolsVersion '29.0.3'
-	ndkVersion '21.0.6113669'
+	ndkVersion '21.1.6352462'
 	defaultConfig {
 		minSdkVersion 16
 		targetSdkVersion 29


### PR DESCRIPTION
- Replace Log to Toast.
- Start Native only after successful unpacking.
- Light refactoring in CopyZipTask.
- Update NDK version.

Add compact, short information about your PR for easier understanding:

- Goal of the PR
Various improvements to the Java-part of the Android port
- How does the PR work?
Excellent!
- Does it resolve any reported issue?
Resolved: https://github.com/minetest/minetest/issues/9709

- If not a bug fix, why is this PR needed? What usecases does it solve?
There is bugfix + some improvements.

This PR is Ready for Review.

## How to test
Compile for Android using Android Studio / command-line.
Install the new version (previously uninstalling the old version from the phone).
Start and make sure that the unpacking was successful. Otherwise, you will see an error message that tells you what happened wrong!