### PR TITLE
Forbid object:attach(obj, ...)

### DIFF
--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -674,8 +674,13 @@ int ObjectRef::l_set_attach(lua_State *L)
 	ServerActiveObject *parent = getobject(parent_ref);
 	if (co == NULL)
 		return 0;
+
 	if (parent == NULL)
 		return 0;
+
+	if (co == parent)
+		throw LuaError("ObjectRef::set_attach: attaching object to itself is not allowed.");
+
 	// Do it
 	int parent_id = 0;
 	std::string bone;


### PR DESCRIPTION
Fixes #9761

## To do

This PR is Ready for Review.

## How to test

Before this code freeze MT. now it throw an error
```obj:attach(obj, "", vector.new(0,0,0), vector.new(0,0,0))```
