### PR TITLE
Add FormSpec font styling options

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2717,6 +2717,18 @@ Some types may inherit styles from parent types.
                      button's content when set.
     * bgimg_pressed - background image when pressed. Defaults to bgimg when not provided.
         * This is deprecated, use states instead.
+    * font - Sets font type. This is a comma separated list of options. Valid options:
+      * Main font type options. These cannot be combined with each other:
+        * `normal`: Default font
+        * `mono`: Monospaced font
+      * Font modification options. If used without a main font type, `normal` is used:
+        * `bold`: Makes font bold.
+        * `italic`: Makes font italic.
+      Default `normal`.
+    * font_size - Sets font size. Default is user-set. Can have multiple values:
+      * `<number>`: Sets absolute font size to `number`.
+      * `+<number>`/`-<number>`: Offsets default font size by `number` points.
+      * `*<number>`: Multiplies default font size by `number`, similar to CSS `em`.
     * border - boolean, draw border. Set to false to hide the bevelled button pane. Default true.
     * content_offset - 2d vector, shifts the position of the button's content without resizing it.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
@@ -2728,11 +2740,15 @@ Some types may inherit styles from parent types.
 * scrollbar
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 * table, textlist
+    * font - Sets font type. See button `font` property for more information.
+    * font_size - Sets font size. See button `font_size` property for more information.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 * dropdown
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 * field, pwdfield, textarea
     * border - set to false to hide the textbox background and border. Default true.
+    * font - Sets font type. See button `font` property for more information.
+    * font_size - Sets font size. See button `font_size` property for more information.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
     * textcolor - color. Default white.
 * image
@@ -2741,6 +2757,8 @@ Some types may inherit styles from parent types.
 * item_image
     * noclip - boolean, set to true to allow the element to exceed formspec bounds. Default to false.
 * label, vertlabel
+    * font - Sets font type. See button `font` property for more information.
+    * font_size - Sets font size. See button `font_size` property for more information.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 * image_button (additional properties)
     * fgimg - standard image. Defaults to none.

--- a/src/client/fontengine.cpp
+++ b/src/client/fontengine.cpp
@@ -186,6 +186,21 @@ unsigned int FontEngine::getDefaultFontSize()
 	return m_default_size[m_currentMode];
 }
 
+unsigned int FontEngine::getFontSize(FontMode mode)
+{
+	if (m_currentMode == FM_Simple) {
+		if (mode == FM_Mono || mode == FM_SimpleMono)
+			return m_default_size[FM_SimpleMono];
+		else
+			return m_default_size[FM_Simple];
+	}
+
+	if (mode == FM_Unspecified)
+		return m_default_size[FM_Standard];
+
+	return m_default_size[mode];
+}
+
 /******************************************************************************/
 void FontEngine::readSettings()
 {

--- a/src/client/fontengine.h
+++ b/src/client/fontengine.h
@@ -124,6 +124,9 @@ public:
 	/** get default font size */
 	unsigned int getDefaultFontSize();
 
+	/** get font size for a specific mode */
+	unsigned int getFontSize(FontMode mode);
+
 	/** initialize font engine */
 	void initialize(Settings* main_settings, gui::IGUIEnvironment* env);
 

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -259,9 +259,7 @@ public:
 		if (!size.empty()) {
 			int calc_size = 1;
 
-			if (size.size() == 0) {
-				calc_size = 0;
-			} else if (size[0] == '*') {
+			if (size[0] == '*') {
 				std::string new_size = size.substr(1); // Remove '*' (invalid for stof)
 				calc_size = stof(new_size) * g_fontengine->getFontSize(spec.mode);
 			} else if (size[0] == '+' || size[0] == '-') {

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -210,7 +210,6 @@ public:
 		return rect;
 	}
 
-<<<<<<< HEAD
 	irr::core::vector2d<s32> getVector2i(Property prop, irr::core::vector2d<s32> def) const
 	{
 		const auto &val = properties[prop];
@@ -232,7 +231,8 @@ public:
 		irr::core::vector2d<s32> vec;
 		parseVector2i(val, &vec);
 		return vec;
-=======
+	}
+
 	gui::IGUIFont *getFont() const
 	{
 		FontSpec spec(FONT_SIZE_UNSPECIFIED, FM_Standard, false, false);
@@ -262,8 +262,8 @@ public:
 			if (size.size() == 0) {
 				calc_size = 0;
 			} else if (size[0] == '*') {
-				std::string new_size = size.substr(1); // Remove '*' (invalid for stoi)
-				calc_size = stoi(new_size) * g_fontengine->getFontSize(spec.mode);
+				std::string new_size = size.substr(1); // Remove '*' (invalid for stof)
+				calc_size = stof(new_size) * g_fontengine->getFontSize(spec.mode);
 			} else if (size[0] == '+' || size[0] == '-') {
 				calc_size = stoi(size) + g_fontengine->getFontSize(spec.mode);
 			} else {
@@ -274,7 +274,6 @@ public:
 		}
 
 		return g_fontengine->getFont(spec);
->>>>>>> Add FormSpec font styling options
 	}
 
 	video::ITexture *getTexture(Property prop, ISimpleTextureSource *tsrc,

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -18,9 +18,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "client/tile.h" // ITextureSource
+#include "client/fontengine.h"
 #include "debug.h"
 #include "irrlichttypes_extrabloated.h"
 #include "util/string.h"
+#include <algorithm>
 #include <array>
 
 #pragma once
@@ -46,6 +48,8 @@ public:
 		ALPHA,
 		CONTENT_OFFSET,
 		PADDING,
+		FONT,
+		FONT_SIZE,
 		NUM_PROPERTIES,
 		NONE
 	};
@@ -98,6 +102,10 @@ public:
 			return CONTENT_OFFSET;
 		} else if (name == "padding") {
 			return PADDING;
+		} else if (name == "font") {
+			return FONT;
+		} else if (name == "font_size") {
+			return FONT_SIZE;
 		} else {
 			return NONE;
 		}
@@ -202,6 +210,7 @@ public:
 		return rect;
 	}
 
+<<<<<<< HEAD
 	irr::core::vector2d<s32> getVector2i(Property prop, irr::core::vector2d<s32> def) const
 	{
 		const auto &val = properties[prop];
@@ -223,6 +232,49 @@ public:
 		irr::core::vector2d<s32> vec;
 		parseVector2i(val, &vec);
 		return vec;
+=======
+	gui::IGUIFont *getFont() const
+	{
+		FontSpec spec(FONT_SIZE_UNSPECIFIED, FM_Standard, false, false);
+
+		const std::string &font = properties[FONT];
+		const std::string &size = properties[FONT_SIZE];
+
+		if (font.empty() && size.empty())
+			return nullptr;
+
+		std::vector<std::string> modes = split(font, ',');
+
+		for (size_t i = 0; i < modes.size(); i++) {
+			if (modes[i] == "normal")
+				spec.mode = FM_Standard;
+			else if (modes[i] == "mono")
+				spec.mode = FM_Mono;
+			else if (modes[i] == "bold")
+				spec.bold = true;
+			else if (modes[i] == "italic")
+				spec.italic = true;
+		}
+
+		if (!size.empty()) {
+			int calc_size = 1;
+
+			if (size.size() == 0) {
+				calc_size = 0;
+			} else if (size[0] == '*') {
+				std::string new_size = size.substr(1); // Remove '*' (invalid for stoi)
+				calc_size = stoi(new_size) * g_fontengine->getFontSize(spec.mode);
+			} else if (size[0] == '+' || size[0] == '-') {
+				calc_size = stoi(size) + g_fontengine->getFontSize(spec.mode);
+			} else {
+				calc_size = stoi(size);
+			}
+
+			spec.size = (unsigned)std::min(std::max(calc_size, 1), 999);
+		}
+
+		return g_fontengine->getFont(spec);
+>>>>>>> Add FormSpec font styling options
 	}
 
 	video::ITexture *getTexture(Property prop, ISimpleTextureSource *tsrc,

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -788,6 +788,7 @@ void GUIButton::setFromStyle(const StyleSpec& style)
 	setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 	setDrawBorder(style.getBool(StyleSpec::BORDER, true));
 	setUseAlphaChannel(style.getBool(StyleSpec::ALPHA, true));
+	setOverrideFont(style.getFont());
 
 	if (style.isNotDefault(StyleSpec::BGIMG)) {
 		video::ITexture *texture = style.getTexture(StyleSpec::BGIMG,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -24,8 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <limits>
 #include <sstream>
 #include "guiFormSpecMenu.h"
-#include "guiScrollBar.h"
-#include "guiTable.h"
 #include "constants.h"
 #include "gamedef.h"
 #include "client/keycode.h"
@@ -64,9 +62,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiEditBoxWithScrollbar.h"
 #include "guiInventoryList.h"
 #include "guiItemImage.h"
-#include "guiScrollBar.h"
 #include "guiScrollContainer.h"
-#include "guiTable.h"
 #include "intlGUIEditBox.h"
 #include "guiHyperText.h"
 
@@ -1477,6 +1473,7 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 		e->setDrawBorder(style.getBool(StyleSpec::BORDER, true));
 		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		e->setOverrideFont(style.getFont());
 
 		irr::SEvent evt;
 		evt.EventType            = EET_KEY_INPUT_EVENT;
@@ -1560,6 +1557,7 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 		if (style.get(StyleSpec::BGCOLOR, "") == "transparent") {
 			e->setDrawBackground(false);
 		}
+		e->setOverrideFont(style.getFont());
 
 		e->drop();
 	}
@@ -1773,6 +1771,11 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 
 		std::vector<std::string> lines = split(text, '\n');
 
+		auto style = getDefaultStyleForElement("label", "");
+		gui::IGUIFont *font = style.getFont();
+		if (!font)
+			font = m_font;
+
 		for (unsigned int i = 0; i != lines.size(); i++) {
 			std::wstring wlabel_colors = translate_string(
 				utf8_to_wide(unescape_string(lines[i])));
@@ -1794,7 +1797,7 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 
 				rect = core::rect<s32>(
 					pos.X, pos.Y,
-					pos.X + m_font->getDimension(wlabel_plain.c_str()).Width,
+					pos.X + font->getDimension(wlabel_plain.c_str()).Width,
 					pos.Y + imgsize.Y);
 
 			} else {
@@ -1816,7 +1819,7 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 
 				rect = core::rect<s32>(
 					pos.X, pos.Y - m_btn_height,
-					pos.X + m_font->getDimension(wlabel_plain.c_str()).Width,
+					pos.X + font->getDimension(wlabel_plain.c_str()).Width,
 					pos.Y + m_btn_height);
 			}
 
@@ -1832,9 +1835,9 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 					spec.fid);
 			e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_CENTER);
 
-			auto style = getDefaultStyleForElement("label", spec.fname);
 			e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 			e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+			e->setOverrideFont(font);
 
 			m_fields.push_back(spec);
 
@@ -1862,6 +1865,11 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 
 		MY_CHECKPOS("vertlabel",1);
 
+		auto style = getDefaultStyleForElement("vertlabel", "", "label");
+		gui::IGUIFont *font = style.getFont();
+		if (!font)
+			font = m_font;
+
 		v2s32 pos;
 		core::rect<s32> rect;
 
@@ -1875,7 +1883,7 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 			// isn't quite tall enough and cuts off the text.
 			rect = core::rect<s32>(pos.X, pos.Y,
 				pos.X + imgsize.X,
-				pos.Y + font_line_height(m_font) *
+				pos.Y + font_line_height(font) *
 				(text.length() + 1));
 
 		} else {
@@ -1887,7 +1895,7 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 			rect = core::rect<s32>(
 				pos.X, pos.Y+((imgsize.Y/2) - m_btn_height),
 				pos.X+15, pos.Y +
-					font_line_height(m_font) *
+					font_line_height(font) *
 					(text.length() + 1) +
 					((imgsize.Y/2) - m_btn_height));
 		}
@@ -1912,9 +1920,9 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 				rect, false, false, data->current_parent, spec.fid);
 		e->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_CENTER);
 
-		auto style = getDefaultStyleForElement("vertlabel", spec.fname, "label");
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		e->setOverrideFont(font);
 
 		m_fields.push_back(spec);
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "inventorymanager.h"
 #include "modalMenu.h"
 #include "guiInventoryList.h"
+#include "guiScrollBar.h"
 #include "guiTable.h"
 #include "network/networkprotocol.h"
 #include "client/joystick_controller.h"
@@ -37,7 +38,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class InventoryManager;
 class ISimpleTextureSource;
 class Client;
-class GUIScrollBar;
 class TexturePool;
 class GUIScrollContainer;
 


### PR DESCRIPTION
This PR adds customizable fonts to `button`, `field`, `pwdfield`, `textarea`, `label`, and `vertlabel`.  Font size can be set (relative or absolute) and the font type can be set (normal, mono) with additional styling (bold and/or italics).

## From `lua_api.txt`:
* font - Sets font type. This is a comma separated list of options. Default `normal`. Valid options:
  * Main font type options. These cannot be combined with each other:
    * `normal`: Default font
    * `mono`: Monospaced font
  * Font modification options. If used without a main font type, `normal` is used:
    * `bold`: Makes font bold.
    * `italic`: Makes font italic.
* font_size - Sets font size. Default is user-set. Can have multiple values:
  * `<number>`: Sets absolute font size to `number`.
  * `+<number>`/`-<number>`: Offsets default font size by `number` points.
  * `*<number>`: Multiplies default font size by `number`, similar to CSS `em`.

Underlining/strikethrough is planned later by subclassing `IGUIFont` and adding to `draw`, but not for this PR in attempts to not make too many changes and make reviewing easier.

Here's a screenshot of the demo program:
![image](https://user-images.githubusercontent.com/31123645/80447744-2941b000-88cf-11ea-877b-fd2ebef284be.png)

## To do

This PR is Ready for Review.

## How to test

Mess around with this test program.  Use the chatcommand `/font` to open the formspec.  The panel on the right has the options which will appear on the left.

<details><summary><b>Code:</b></summary>

```lua
local font = {
	current = "label",
	label     = {font = "", size = "", bold = false, italic = false},
	vertlabel = {font = "", size = "", bold = false, italic = false},
	button    = {font = "", size = "", bold = false, italic = false},
	field     = {font = "", size = "", bold = false, italic = false},
	pwdfield  = {font = "", size = "", bold = false, italic = false},
	textarea  = {font = "", size = "", bold = false, italic = false},
	font_to_index = {
		[""] = "1",
		normal = "2",
		mono = "3",
	},
	current_to_index = {
		label = 1,
		vertlabel = 2,
		button = 3,
		field = 4,
		pwdfield = 5,
		textarea = 6,
	},
}

local function to_font(index)
	if font[index].font ~= "" then
		local ret = font[index].font
		if font[index].bold then
			ret = ret ..",bold"
		end
		if font[index].italic then
			ret = ret ..",italic"
		end
		return ret
	end
	if font[index].bold and font[index].italic then
		return "bold,italic"
	elseif font[index].bold then
		return "bold"
	elseif font[index].italic then
		return "italic"
	end
	return ""
end

local function update()
	minetest.show_formspec("singleplayer", "test:font",
		"formspec_version[3]"..
		"size[12,6.5]"..
		"bgcolor[#0000]"..
		"box[0,0;7.45,6.5;#0000008c]"..
		"box[7.55,0;3.95,6.5;#0000008c]"..
		
		"dropdown[8,.5;3,.75;type;label,vertlabel,button,field,pwdfield,textarea;".. font.current_to_index[font.current] .."]"..
		"dropdown[8,1.5;3,.75;base;,normal,mono;".. font.font_to_index[font[font.current].font] .."]"..
		"checkbox[8,2.75;bold;Bold;".. tostring(font[font.current].bold) .."]"..
		"checkbox[8,3.25;italic;Italic;".. tostring(font[font.current].italic) .."]"..
		"field[8,4;3,.75;size;Font Size;".. font[font.current].size .."]"..
		"button[8,5;3,.75;update;Update]"..
		
		"style_type[label;font=".. to_font("label") ..";font_size=".. font.label.size .."]"..
		"style_type[vertlabel;font=".. to_font("vertlabel") ..";font_size=".. font.vertlabel.size .."]"..
		"style_type[button;font=".. to_font("button") ..";font_size=".. font.button.size .."]"..
		"style_type[field;font=".. to_font("field") ..";font_size=".. font.field.size .."]"..
		"style_type[pwdfield;font=".. to_font("pwdfield") ..";font_size=".. font.pwdfield.size .."]"..
		"style_type[textarea;font=".. to_font("textarea") ..";font_size=".. font.textarea.size .."]"..
		
		"label[.5,.5;Super Cool Fonts!]"..
		"vertlabel[5,.5;WOW!]"..
		"button[.5,1;3,1;;Awesome Fonts!]"..
		"field[.5,2.5;3,1;_;;Best Fonts]"..
		"pwdfield[4,2.5;3,1;;]"..
		"textarea[.5,4;6.5,2;_;;Wow, isn't this great stuff? Yay!\nI'm just loving these fonts!]"
	)
end

minetest.register_chatcommand("font", {func = update})

minetest.register_on_player_receive_fields(function(player, formname, fields)
	if formname ~= "test:font" or not player or fields.quit then
		return
	end
	
	if fields.update then
		font[font.current].font = fields.base
		font[font.current].size = fields.size
		update()
	elseif fields.bold then
		font[font.current].bold = fields.bold == "true"
	elseif fields.italic  then
		font[font.current].italic = fields.italic == "true"
	elseif fields.type then
		font.current = fields.type
		update()
	end
end)
```
</details>