### PR TITLE
Compact image-generation texture modifier

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -450,6 +450,23 @@ Example:
 
     [combine:16x32:0,0=default_cobble.png:0,16=default_wood.png
 
+#### `[image:<w>x<h>:<data>`
+
+Creates a new texture with given width and height.
+Data is a string of `RRGGBBAA` hex colors containing the rows of the image.
+Direction is from left to right and top to bottom.
+
+Example:
+
+    [image:2x2:FF0000FF00FF00FF0000FFFFFFFFFF00"
+
+Creates a 2x2 texture with:
+
+* Red in the top left corner
+* Green in the top right
+* Blue in the bottom left
+* (No) Alpha in the bottom right
+
 #### `[resize:<w>x<h>`
 
 Resizes the texture to the given dimensions.


### PR DESCRIPTION
- Goal of the PR: Allowing larger mod-generated images by implementing a more compact texture modifier
- How does the PR work? Takes width and height & colors as hex-string-RGBA-array
- Does it resolve any reported issue? Closes #6821

## Status

This PR is Ready for Review.

## How to test

```lua
minetest.register_craftitem("testmod:testitem", {
	inventory_image = "[image:2x2:".."FF0000FF".."00FF00FF".."0000FFFF".."FFFFFF00",
	description = "Test Item"
})
```

Results in this:

![Screenshot](https://user-images.githubusercontent.com/34514239/80397713-d8be5880-88b6-11ea-87ae-698a1a6eebdb.png)