### PR TITLE
Rewrite falling entity + another feature

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -30,6 +30,8 @@ local facedir_to_euler = {
 	{y = math.pi/2, x = math.pi, z = 0}
 }
 
+local gravity = tonumber(core.settings:get("movement_gravity")) or 9.81
+
 --
 -- Falling stuff
 --
@@ -47,6 +49,7 @@ core.register_entity(":__builtin:falling_node", {
 
 	node = {},
 	meta = {},
+	floats = false,
 
 	set_node = function(self, node, meta)
 		self.node = node
@@ -71,6 +74,11 @@ core.register_entity(":__builtin:falling_node", {
 			return
 		end
 		self.meta = meta
+
+		-- Cache whether we're supposed to float on water
+		self.floats = core.get_item_group(node.name, "float") ~= 0
+
+		-- Set entity visuals
 		if def.drawtype == "torchlike" or def.drawtype == "signlike" then
 			local textures
 			if def.tiles and def.tiles[1] then
@@ -113,6 +121,7 @@ core.register_entity(":__builtin:falling_node", {
 				glow = def.light_source,
 			})
 		end
+
 		-- Rotate entity
 		if def.drawtype == "torchlike" then
 			self.object:set_yaw(math.pi*0.25)
@@ -172,6 +181,7 @@ core.register_entity(":__builtin:falling_node", {
 
 	on_activate = function(self, staticdata)
 		self.object:set_armor_groups({immortal = 1})
+		self.object:set_acceleration({x = 0, y = -gravity, z = 0})
 
 		local ds = core.deserialize(staticdata)
 		if ds and ds.node then
@@ -183,85 +193,137 @@ core.register_entity(":__builtin:falling_node", {
 		end
 	end,
 
-	on_step = function(self, dtime)
-		-- Set gravity
-		local acceleration = self.object:get_acceleration()
-		if not vector.equals(acceleration, {x = 0, y = -10, z = 0}) then
-			self.object:set_acceleration({x = 0, y = -10, z = 0})
+	try_place = function(self, bcp, bcn)
+		local bcd = core.registered_nodes[bcn.name]
+		-- Add levels if dropped on same leveled node
+		if bcd and bcd.leveled and
+				bcn.name == self.node.name then
+			local addlevel = self.node.level
+			if not addlevel or addlevel <= 0 then
+				addlevel = bcd.leveled
+			end
+			if core.add_node_level(bcp, addlevel) == 0 then
+				return true
+			end
 		end
-		-- Turn to actual node when colliding with ground, or continue to move
-		local pos = self.object:get_pos()
-		-- Position of bottom center point
-		local bcp = {x = pos.x, y = pos.y - 0.7, z = pos.z}
-		-- 'bcn' is nil for unloaded nodes
-		local bcn = core.get_node_or_nil(bcp)
-		-- Delete on contact with ignore at world edges
-		if bcn and bcn.name == "ignore" then
-			self.object:remove()
-			return
+
+		-- Decide if we're replacing the node or placing on top
+		local np = vector.new(bcp)
+		if bcd and bcd.buildable_to and
+				(not self.floats or bcd.liquidtype == "none") then
+			core.remove_node(bcp)
+		else
+			np.y = np.y + 1
 		end
-		local bcd = bcn and core.registered_nodes[bcn.name]
-		if bcn and
-				(not bcd or bcd.walkable or
-				(core.get_item_group(self.node.name, "float") ~= 0 and
-				bcd.liquidtype ~= "none")) then
-			if bcd and bcd.leveled and
-					bcn.name == self.node.name then
-				local addlevel = self.node.level
-				if not addlevel or addlevel <= 0 then
-					addlevel = bcd.leveled
+
+		-- Check what's here
+		local n2 = core.get_node(np)
+		local nd = core.registered_nodes[n2.name]
+		-- If it's not air or liquid, remove node and replace it with
+		-- it's drops
+		if n2.name ~= "air" and (not nd or nd.liquidtype == "none") then
+			if nd and nd.buildable_to == false then
+				nd.on_dig(np, n2, nil)
+				-- If it's still there, it might be protected
+				if core.get_node(np).name == n2.name then
+					return false
 				end
-				if core.add_node_level(bcp, addlevel) == 0 then
+			else
+				core.remove_node(np)
+			end
+		end
+
+		-- Create node
+		local def = core.registered_nodes[self.node.name]
+		if def then
+			core.add_node(np, self.node)
+			if self.meta then
+				core.get_meta(np):from_table(self.meta)
+			end
+			if def.sounds and def.sounds.place then
+				core.sound_play(def.sounds.place, {pos = np}, true)
+			end
+		end
+		core.check_for_falling(np)
+		return true
+	end,
+
+	on_step = function(self, dtime, moveresult)
+		-- Fallback code since collision detection can't tell us
+		-- about liquids (which do not collide)
+		if self.floats then
+			local pos = self.object:get_pos()
+
+			local bcp = vector.round({x = pos.x, y = pos.y - 0.7, z = pos.z})
+			local bcn = core.get_node(bcp)
+
+			local bcd = core.registered_nodes[bcn.name]
+			if bcd and bcd.liquidtype ~= "none" then
+				if self:try_place(bcp, bcn) then
 					self.object:remove()
 					return
 				end
-			elseif bcd and bcd.buildable_to and
-					(core.get_item_group(self.node.name, "float") == 0 or
-					bcd.liquidtype == "none") then
-				core.remove_node(bcp)
-				return
 			end
-			local np = {x = bcp.x, y = bcp.y + 1, z = bcp.z}
-			-- Check what's here
-			local n2 = core.get_node(np)
-			local nd = core.registered_nodes[n2.name]
-			-- If it's not air or liquid, remove node and replace it with
-			-- it's drops
-			if n2.name ~= "air" and (not nd or nd.liquidtype == "none") then
-				core.remove_node(np)
-				if nd and nd.buildable_to == false then
-					-- Add dropped items
-					local drops = core.get_node_drops(n2, "")
-					for _, dropped_item in pairs(drops) do
-						core.add_item(np, dropped_item)
-					end
-				end
-				-- Run script hook
-				for _, callback in pairs(core.registered_on_dignodes) do
-					callback(np, n2)
+		end
+
+		assert(moveresult)
+		if not moveresult.collides then
+			return -- Nothing to do :)
+		end
+
+		local bcp, bcn
+		if moveresult.touching_ground then
+			for _, info in ipairs(moveresult.collisions) do
+				if info.axis == "y" then
+					bcp = info.node_pos
+					bcn = core.get_node(bcp)
+					break
 				end
 			end
-			-- Create node and remove entity
-			local def = core.registered_nodes[self.node.name]
-			if def then
-				core.add_node(np, self.node)
-				if self.meta then
-					local meta = core.get_meta(np)
-					meta:from_table(self.meta)
-				end
-				if def.sounds and def.sounds.place then
-					core.sound_play(def.sounds.place, {pos = np}, true)
-				end
-			end
+		end
+
+		if not bcp then
+			-- We're colliding with something, but not the ground. Irrelevant to us.
+			return
+		elseif bcn.name == "ignore" then
+			-- Delete on contact with ignore at world edges
 			self.object:remove()
-			core.check_for_falling(np)
 			return
 		end
-		local vel = self.object:get_velocity()
-		if vector.equals(vel, {x = 0, y = 0, z = 0}) then
-			local npos = self.object:get_pos()
-			self.object:set_pos(vector.round(npos))
+
+		local failure = false
+
+		local pos = self.object:get_pos()
+		local distance = vector.apply(vector.subtract(pos, bcp), math.abs)
+		if distance.x >= 1 or distance.z >= 1 then
+			-- We're colliding with some part of a node that's sticking out
+			-- Since we don't want to visually teleport, drop as item
+			failure = true
+		elseif distance.y >= 2 then
+			-- Doors consist of a hidden top node and a bottom node that is
+			-- the actual door. Despite the top node being solid, the moveresult
+			-- almost always indicates collision with the bottom node.
+			-- Compensate for this by checking the top node
+			bcp.y = bcp.y + 1
+			bcn = core.get_node(bcp)
+			local def = core.registered_nodes[bcn.name]
+			if not (def and def.walkable) then
+				failure = true -- This is unexpected, fail
+			end
 		end
+
+		-- Try to actually place ourselves
+		if not failure then
+			failure = not self:try_place(bcp, bcn)
+		end
+
+		if failure then
+			local drops = core.get_node_drops(self.node, "")
+			for _, item in pairs(drops) do
+				core.add_item(pos, item)
+			end
+		end
+		self.object:remove()
 	end
 })
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6632,6 +6632,7 @@ Collision info passed to `on_step`:
                 type = string, -- "node" or "object",
                 axis = string, -- "x", "y" or "z"
                 node_pos = vector, -- if type is "node"
+                object = ObjectRef, -- if type is "object"
                 old_velocity = vector,
                 new_velocity = vector,
             },

--- a/src/collision.h
+++ b/src/collision.h
@@ -48,6 +48,7 @@ struct CollisionInfo
 	CollisionType type = COLLISION_NODE;
 	CollisionAxis axis = COLLISION_AXIS_NONE;
 	v3s16 node_p = v3s16(-32768,-32768,-32768); // COLLISION_NODE
+	ActiveObject *object = nullptr; // COLLISION_OBJECT
 	v3f old_speed;
 	v3f new_speed;
 	int plane = -1;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2043,6 +2043,9 @@ void push_collision_move_result(lua_State *L, const collisionMoveResult &res)
 		if (c.type == COLLISION_NODE) {
 			push_v3s16(L, c.node_p);
 			lua_setfield(L, -2, "node_pos");
+		} else if (c.type == COLLISION_OBJECT) {
+			push_objectRef(L, c.object->getId());
+			lua_setfield(L, -2, "object");
 		}
 
 		push_v3f(L, c.old_speed / BS);


### PR DESCRIPTION
<b>don't squash</b>

first commit: fixes #9787
second commit: fixes #4781, fixes #9293
third commit: fixes #5313

## To do

This PR is a Ready for Review.

## How to test

1 Drop sand on:
* a door
* a slab
* snow cover
* a torch
* a normal node

2 Run `//lua core.registered_nodes["default:gravel"].groups.float = 1` and drop gravel on water

3 Drop sand inside protected area (should drop as item instead of placing)

4 Create a high stack of sand and let it fall

5 Let sand fall on a players head

6 Find a falling & leveled node and let it fall on a node of the same type

7 Drop sand on a node with `walkable = false` and `diggable = false` 
