### PR TITLE
Server class code cleanups

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1302,7 +1302,6 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 	}
 
 	server = new Server(map_dir, gamespec, simple_singleplayer_mode, bind_addr, false);
-	server->init();
 	server->start();
 
 	return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -887,7 +887,6 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 			// Create server
 			Server server(game_params.world_path, game_params.game_spec,
 					false, bind_addr, true, &iface);
-			server.init();
 
 			g_term_console.setup(&iface, &kill, admin_nick);
 
@@ -922,7 +921,6 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 			// Create server
 			Server server(game_params.world_path, game_params.game_spec, false,
 				bind_addr, true);
-			server.init();
 			server.start();
 
 			// Run server

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -322,9 +322,6 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 			SendActiveObjectRemoveAdd(client, sao);
 	}
 
-	// Send detached inventories
-	sendDetachedInventories(peer_id, false);
-
 	// Send player movement settings
 	SendMovement(peer_id);
 
@@ -398,6 +395,9 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 
 	if (pkt->getRemainingBytes() >= 2)
 		*pkt >> playersao->getPlayer()->formspec_version;
+
+	// Send detached inventories
+	sendDetachedInventories(peer_id, false);
 
 	const std::vector<std::string> &players = m_clients.getPlayerNames();
 	NetworkPacket list_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, peer_id);

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -34,6 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "network/networkprotocol.h"
 #include "network/serveropcodes.h"
 #include "server/player_sao.h"
+#include "server/serverinventorymgr.h"
 #include "util/auth.h"
 #include "util/base64.h"
 #include "util/pointedthing.h"
@@ -622,9 +623,9 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		ma->from_inv.applyCurrentPlayer(player->getName());
 		ma->to_inv.applyCurrentPlayer(player->getName());
 
-		setInventoryModified(ma->from_inv);
+		m_inventory_mgr->setInventoryModified(ma->from_inv);
 		if (ma->from_inv != ma->to_inv)
-			setInventoryModified(ma->to_inv);
+			m_inventory_mgr->setInventoryModified(ma->to_inv);
 
 		bool from_inv_is_current_player =
 			(ma->from_inv.type == InventoryLocation::PLAYER) &&
@@ -689,7 +690,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 
 		da->from_inv.applyCurrentPlayer(player->getName());
 
-		setInventoryModified(da->from_inv);
+		m_inventory_mgr->setInventoryModified(da->from_inv);
 
 		/*
 			Disable dropping items out of craftpreview
@@ -725,7 +726,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 
 		ca->craft_inv.applyCurrentPlayer(player->getName());
 
-		setInventoryModified(ca->craft_inv);
+		m_inventory_mgr->setInventoryModified(ca->craft_inv);
 
 		//bool craft_inv_is_current_player =
 		//	(ca->craft_inv.type == InventoryLocation::PLAYER) &&
@@ -741,7 +742,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 	}
 
 	// Do the action
-	a->apply(this, playersao, this);
+	a->apply(m_inventory_mgr.get(), playersao, this);
 	// Eat the action
 	delete a;
 }

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -322,6 +322,9 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 			SendActiveObjectRemoveAdd(client, sao);
 	}
 
+	// Send detached inventories
+	sendDetachedInventories(peer_id, false);
+
 	// Send player movement settings
 	SendMovement(peer_id);
 
@@ -395,9 +398,6 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 
 	if (pkt->getRemainingBytes() >= 2)
 		*pkt >> playersao->getPlayer()->formspec_version;
-
-	// Send detached inventories
-	sendDetachedInventories(peer_id, false);
 
 	const std::vector<std::string> &players = m_clients.getPlayerNames();
 	NetworkPacket list_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, peer_id);

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -45,6 +45,11 @@ Server *ModApiBase::getServer(lua_State *L)
 	return getScriptApiBase(L)->getServer();
 }
 
+ServerInventoryManager *ModApiBase::getServerInventoryMgr(lua_State *L)
+{
+	return getScriptApiBase(L)->getServer()->getInventoryMgr();
+}
+
 #ifndef SERVER
 Client *ModApiBase::getClient(lua_State *L)
 {

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -38,12 +38,14 @@ class GUIEngine;
 class ScriptApiBase;
 class Server;
 class Environment;
+class ServerInventoryManager;
 
 class ModApiBase : protected LuaHelper {
 
 public:
 	static ScriptApiBase*   getScriptApiBase(lua_State *L);
 	static Server*          getServer(lua_State *L);
+	static ServerInventoryManager *getServerInventoryMgr(lua_State *L);
 	#ifndef SERVER
 	static Client*          getClient(lua_State *L);
 	static GUIEngine*       getGuiEngine(lua_State *L);

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include "server.h"
+#include "server/serverinventorymgr.h"
 #include "remoteplayer.h"
 
 /*
@@ -38,7 +39,7 @@ InvRef* InvRef::checkobject(lua_State *L, int narg)
 
 Inventory* InvRef::getinv(lua_State *L, InvRef *ref)
 {
-	return getServer(L)->getInventory(ref->m_loc);
+	return getServerInventoryMgr(L)->getInventory(ref->m_loc);
 }
 
 InventoryList* InvRef::getlist(lua_State *L, InvRef *ref,
@@ -54,7 +55,7 @@ InventoryList* InvRef::getlist(lua_State *L, InvRef *ref,
 void InvRef::reportInventoryChange(lua_State *L, InvRef *ref)
 {
 	// Inform other things that the inventory has changed
-	getServer(L)->setInventoryModified(ref->m_loc);
+	getServerInventoryMgr(L)->setInventoryModified(ref->m_loc);
 }
 
 // Exported functions
@@ -497,7 +498,7 @@ int ModApiInventory::l_get_inventory(lua_State *L)
 		v3s16 pos = check_v3s16(L, -1);
 		loc.setNodeMeta(pos);
 
-		if (getServer(L)->getInventory(loc) != NULL)
+		if (getServerInventoryMgr(L)->getInventory(loc) != NULL)
 			InvRef::create(L, loc);
 		else
 			lua_pushnil(L);
@@ -515,7 +516,7 @@ int ModApiInventory::l_get_inventory(lua_State *L)
 		lua_pop(L, 1);
 	}
 
-	if (getServer(L)->getInventory(loc) != NULL)
+	if (getServerInventoryMgr(L)->getInventory(loc) != NULL)
 		InvRef::create(L, loc);
 	else
 		lua_pushnil(L);
@@ -530,7 +531,7 @@ int ModApiInventory::l_create_detached_inventory_raw(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	const char *name = luaL_checkstring(L, 1);
 	std::string player = readParam<std::string>(L, 2, "");
-	if (getServer(L)->createDetachedInventory(name, player) != NULL) {
+	if (getServerInventoryMgr(L)->createDetachedInventory(name, getServer(L)->idef(), player) != NULL) {
 		InventoryLocation loc;
 		loc.setDetached(name);
 		InvRef::create(L, loc);
@@ -545,7 +546,7 @@ int ModApiInventory::l_remove_detached_inventory_raw(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	const std::string &name = luaL_checkstring(L, 1);
-	lua_pushboolean(L, getServer(L)->removeDetachedInventory(name));
+	lua_pushboolean(L, getServerInventoryMgr(L)->removeDetachedInventory(name));
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2167,9 +2167,7 @@ int ObjectRef::l_override_day_night_ratio(lua_State *L)
 		ratio = readParam<float>(L, 2);
 	}
 
-	if (!getServer(L)->overrideDayNightRatio(player, do_override, ratio))
-		return 0;
-
+	getServer(L)->overrideDayNightRatio(player, do_override, ratio);
 	lua_pushboolean(L, true);
 	return 1;
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -33,6 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "scripting_server.h"
 #include "server/luaentity_sao.h"
 #include "server/player_sao.h"
+#include "server/serverinventorymgr.h"
 
 /*
 	ObjectRef
@@ -289,7 +290,7 @@ int ObjectRef::l_get_inventory(lua_State *L)
 	if (co == NULL) return 0;
 	// Do it
 	InventoryLocation loc = co->getInventoryLocation();
-	if (getServer(L)->getInventory(loc) != NULL)
+	if (getServerInventoryMgr(L)->getInventory(loc) != NULL)
 		InvRef::create(L, loc);
 	else
 		lua_pushnil(L); // An object may have no inventory (nil)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3442,15 +3442,12 @@ void Server::setClouds(RemotePlayer *player, const CloudParams &params)
 	SendCloudParams(player->getPeerId(), params);
 }
 
-bool Server::overrideDayNightRatio(RemotePlayer *player, bool do_override,
+void Server::overrideDayNightRatio(RemotePlayer *player, bool do_override,
 	float ratio)
 {
-	if (!player)
-		return false;
-
+	sanity_check(player);
 	player->overrideDayNightRatio(do_override, ratio);
 	SendOverrideDayNightRatio(player->getPeerId(), do_override, ratio);
-	return true;
 }
 
 void Server::notifyPlayers(const std::wstring &msg)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -64,6 +64,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "chat_interface.h"
 #include "remoteplayer.h"
 #include "server/player_sao.h"
+#include "server/serverinventorymgr.h"
 #include "translation.h"
 
 class ClientNotFoundException : public BaseException
@@ -218,10 +219,8 @@ Server::Server(
 	m_path_world(path_world),
 	m_gamespec(gamespec),
 	m_simple_singleplayer_mode(simple_singleplayer_mode),
-	m_max_chatmessage_length(g_settings->getU16("chat_message_max_size")),
 	m_dedicated(dedicated),
 	m_async_fatal_error(""),
-	m_liquid_transform_every(g_settings->getFloat("liquid_update")),
 	m_con(std::make_shared<con::Connection>(PROTOCOL_ID,
 			512,
 			CONNECTION_TIMEOUT,
@@ -230,12 +229,9 @@ Server::Server(
 	m_itemdef(createItemDefManager()),
 	m_nodedef(createNodeDefManager()),
 	m_craftdef(createCraftDefManager()),
-	m_lag(g_settings->getFloat("dedicated_server_step")),
 	m_thread(new ServerThread(this)),
 	m_clients(m_con),
 	m_admin_chat(iface),
-	m_csm_restriction_flags(g_settings->getU64("csm_restriction_flags")),
-	m_csm_restriction_noderange(g_settings->getU32("csm_restriction_noderange")),
 	m_modchannel_mgr(new ModChannelMgr())
 {
 	if (m_path_world.empty())
@@ -343,11 +339,6 @@ Server::~Server()
 	infostream << "Server: Deinitializing scripting" << std::endl;
 	delete m_script;
 
-	// Delete detached inventories
-	for (auto &detached_inventory : m_detached_inventories) {
-		delete detached_inventory.second;
-	}
-
 	while (!m_unsent_map_edit_queue.empty()) {
 		delete m_unsent_map_edit_queue.front();
 		m_unsent_map_edit_queue.pop();
@@ -393,6 +384,9 @@ void Server::init()
 
 	m_script = new ServerScripting(this);
 
+	// Must be created before mod loading because we have some inventory creation
+	m_inventory_mgr = std::unique_ptr<ServerInventoryManager>(new ServerInventoryManager());
+
 	m_script->loadMod(getBuiltinLuaPath() + DIR_DELIM "init.lua", BUILTIN_MOD_NAME);
 
 	m_modmgr->loadMods(m_script);
@@ -427,6 +421,7 @@ void Server::init()
 	// Initialize Environment
 	m_env = new ServerEnvironment(servermap, m_script, this, m_path_world);
 
+	m_inventory_mgr->setEnv(m_env);
 	m_clients.setEnv(m_env);
 
 	if (!servermap->settings_mgr.makeMapgenParams())
@@ -447,6 +442,13 @@ void Server::init()
 	servermap->addEventReceiver(this);
 
 	m_env->loadMeta();
+
+	// Those settings can be overwritten in world.mt, they are
+	// intended to be cached after environment loading.
+	m_liquid_transform_every = g_settings->getFloat("liquid_update");
+	m_max_chatmessage_length = g_settings->getU16("chat_message_max_size");
+	m_csm_restriction_flags = g_settings->getU64("csm_restriction_flags");
+	m_csm_restriction_noderange = g_settings->getU32("csm_restriction_noderange");
 }
 
 void Server::start()
@@ -1180,82 +1182,6 @@ void Server::onMapEditEvent(const MapEditEvent &event)
 		return;
 
 	m_unsent_map_edit_queue.push(new MapEditEvent(event));
-}
-
-Inventory* Server::getInventory(const InventoryLocation &loc)
-{
-	switch (loc.type) {
-	case InventoryLocation::UNDEFINED:
-	case InventoryLocation::CURRENT_PLAYER:
-		break;
-	case InventoryLocation::PLAYER:
-	{
-		RemotePlayer *player = m_env->getPlayer(loc.name.c_str());
-		if(!player)
-			return NULL;
-		PlayerSAO *playersao = player->getPlayerSAO();
-		if(!playersao)
-			return NULL;
-		return playersao->getInventory();
-	}
-		break;
-	case InventoryLocation::NODEMETA:
-	{
-		NodeMetadata *meta = m_env->getMap().getNodeMetadata(loc.p);
-		if(!meta)
-			return NULL;
-		return meta->getInventory();
-	}
-		break;
-	case InventoryLocation::DETACHED:
-	{
-		if(m_detached_inventories.count(loc.name) == 0)
-			return NULL;
-		return m_detached_inventories[loc.name];
-	}
-		break;
-	default:
-		sanity_check(false); // abort
-		break;
-	}
-	return NULL;
-}
-
-void Server::setInventoryModified(const InventoryLocation &loc)
-{
-	switch(loc.type){
-	case InventoryLocation::UNDEFINED:
-		break;
-	case InventoryLocation::PLAYER:
-	{
-
-		RemotePlayer *player = m_env->getPlayer(loc.name.c_str());
-
-		if (!player)
-			return;
-
-		player->setModified(true);
-		player->inventory.setModified(true);
-		// Updates are sent in ServerEnvironment::step()
-	}
-		break;
-	case InventoryLocation::NODEMETA:
-	{
-		MapEditEvent event;
-		event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
-		event.p = loc.p;
-		m_env->getMap().dispatchEvent(event);
-	}
-		break;
-	case InventoryLocation::DETACHED:
-	{
-		// Updates are sent in ServerEnvironment::step()
-	}
-		break;
-	default:
-		sanity_check(false); // abort
-		break;
-	}
 }
 
 void Server::SetBlocksNotSent(std::map<v3s16, MapBlock *>& block)
@@ -2714,40 +2640,20 @@ void Server::sendRequestedMedia(session_t peer_id,
 	}
 }
 
-void Server::sendDetachedInventory(const std::string &name, session_t peer_id)
+void Server::sendDetachedInventory(Inventory *inventory, const std::string &name, session_t peer_id)
 {
-	const auto &inv_it = m_detached_inventories.find(name);
-	const auto &player_it = m_detached_inventories_player.find(name);
-
-	if (player_it == m_detached_inventories_player.end() ||
-			player_it->second.empty()) {
-		// OK. Send to everyone
-	} else {
-		if (!m_env)
-			return; // Mods are not done loading
-
-		RemotePlayer *p = m_env->getPlayer(player_it->second.c_str());
-		if (!p)
-			return; // Player is offline
-
-		if (peer_id != PEER_ID_INEXISTENT && peer_id != p->getPeerId())
-			return; // Caller requested send to a different player, so don't send.
-
-		peer_id = p->getPeerId();
-	}
-
 	NetworkPacket pkt(TOCLIENT_DETACHED_INVENTORY, 0, peer_id);
 	pkt << name;
 
-	if (inv_it == m_detached_inventories.end()) {
+	if (!inventory) {
 		pkt << false; // Remove inventory
 	} else {
 		pkt << true; // Update inventory
 
 		// Serialization & NetworkPacket isn't a love story
 		std::ostringstream os(std::ios_base::binary);
-		inv_it->second->serialize(os);
-		inv_it->second->setModified(false);
+		inventory->serialize(os);
+		inventory->setModified(false);
 
 		const std::string &os_str = os.str();
 		pkt << static_cast<u16>(os_str.size()); // HACK: to keep compatibility with 5.0.0 clients
@@ -2762,16 +2668,23 @@ void Server::sendDetachedInventory(const std::string &name, session_t peer_id)
 
 void Server::sendDetachedInventories(session_t peer_id, bool incremental)
 {
-	for (const auto &detached_inventory : m_detached_inventories) {
-		const std::string &name = detached_inventory.first;
-		if (incremental) {
-			Inventory *inv = detached_inventory.second;
-			if (!inv || !inv->checkModified())
-				continue;
+	// Lookup player name, to filter detached inventories just after
+	std::string peer_name;
+	if (peer_id != PEER_ID_INEXISTENT) {
+		if (RemotePlayer *player = m_env->getPlayer(peer_id))
+			peer_name = player->getName();
+		else {
+			warningstream << "Failed to send detached inventories to peer_id=" << peer_id
+				<< ", player not found." << std::endl;
+			return; // Player not found, warn admin
 		}
-
-		sendDetachedInventory(name, peer_id);
 	}
+
+	auto send_cb = [this, peer_id](const std::string &name, Inventory *inv) {
+		sendDetachedInventory(inv, name, peer_id);
+	};
+
+	m_inventory_mgr->sendDetachedInventories(peer_name, incremental, send_cb);
 }
 
 /*
@@ -3540,52 +3453,6 @@ void Server::deleteParticleSpawner(const std::string &playername, u32 id)
 	SendDeleteParticleSpawner(peer_id, id);
 }
 
-Inventory* Server::createDetachedInventory(const std::string &name, const std::string &player)
-{
-	if(m_detached_inventories.count(name) > 0){
-		infostream<<"Server clearing detached inventory \""<<name<<"\""<<std::endl;
-		delete m_detached_inventories[name];
-	} else {
-		infostream<<"Server creating detached inventory \""<<name<<"\""<<std::endl;
-	}
-	Inventory *inv = new Inventory(m_itemdef);
-	sanity_check(inv);
-	m_detached_inventories[name] = inv;
-	if (!player.empty())
-		m_detached_inventories_player[name] = player;
-
-	//TODO find a better way to do this
-	sendDetachedInventory(name,PEER_ID_INEXISTENT);
-	return inv;
-}
-
-bool Server::removeDetachedInventory(const std::string &name)
-{
-	const auto &inv_it = m_detached_inventories.find(name);
-	if (inv_it == m_detached_inventories.end())
-		return false;
-
-	delete inv_it->second;
-	m_detached_inventories.erase(inv_it);
-
-	if (!m_env) // Mods are not done loading
-		return true;
-
-	const auto &player_it = m_detached_inventories_player.find(name);
-	if (player_it != m_detached_inventories_player.end()) {
-		RemotePlayer *player = m_env->getPlayer(player_it->second.c_str());
-
-		if (player && player->getPeerId() != PEER_ID_INEXISTENT)
-			sendDetachedInventory(name, player->getPeerId());
-
-		m_detached_inventories_player.erase(player_it);
-	} else {
-		// Notify all players about the change
-		sendDetachedInventory(name, PEER_ID_INEXISTENT);
-	}
-	return true;
-}
-
 // actions: time-reversed list
 // Return value: success/failure
 bool Server::rollbackRevertActions(const std::list<RollbackAction> &actions,
@@ -3606,7 +3473,7 @@ bool Server::rollbackRevertActions(const std::list<RollbackAction> &actions,
 
 	for (const RollbackAction &action : actions) {
 		num_tried++;
-		bool success = action.applyRevert(map, this, this);
+		bool success = action.applyRevert(map, m_inventory_mgr.get(), this);
 		if(!success){
 			num_failed++;
 			std::ostringstream os;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2671,13 +2671,7 @@ void Server::sendDetachedInventories(session_t peer_id, bool incremental)
 	// Lookup player name, to filter detached inventories just after
 	std::string peer_name;
 	if (peer_id != PEER_ID_INEXISTENT) {
-		if (RemotePlayer *player = m_env->getPlayer(peer_id))
-			peer_name = player->getName();
-		else {
-			warningstream << "Failed to send detached inventories to peer_id=" << peer_id
-				<< ", player not found." << std::endl;
-			return; // Player not found, warn admin
-		}
+		peer_name = getClient(peer_id, CS_Created)->getName();
 	}
 
 	auto send_cb = [this, peer_id](const std::string &name, Inventory *inv) {

--- a/src/server.h
+++ b/src/server.h
@@ -247,7 +247,7 @@ public:
 
 	void deleteParticleSpawner(const std::string &playername, u32 id);
 
-	ServerInventoryManager *getInventoryMgr() { return m_inventory_mgr.get(); }
+	ServerInventoryManager *getInventoryMgr() const { return m_inventory_mgr.get(); }
 	void sendDetachedInventory(Inventory *inventory, const std::string &name, session_t peer_id);
 
 	// Envlock and conlock should be locked when using scriptapi

--- a/src/server.h
+++ b/src/server.h
@@ -318,7 +318,7 @@ public:
 
 	void setClouds(RemotePlayer *player, const CloudParams &params);
 
-	bool overrideDayNightRatio(RemotePlayer *player, bool do_override, float brightness);
+	void overrideDayNightRatio(RemotePlayer *player, bool do_override, float brightness);
 
 	/* con::PeerHandler implementation. */
 	void peerAdded(con::Peer *peer);

--- a/src/server.h
+++ b/src/server.h
@@ -134,7 +134,6 @@ public:
 	~Server();
 	DISABLE_CLASS_COPY(Server);
 
-	void init();
 	void start();
 	void stop();
 	// This is mainly a way to pass the time to the server.
@@ -388,6 +387,8 @@ private:
 		private:
 			float m_timer = 0.0f;
 	};
+
+	void init();
 
 	void SendMovement(session_t peer_id);
 	void SendHP(session_t peer_id, u16 hp);

--- a/src/server.h
+++ b/src/server.h
@@ -68,6 +68,7 @@ struct MoonParams;
 struct StarParams;
 class ServerThread;
 class ServerModManager;
+class ServerInventoryMgr;
 
 enum ClientDeletionReason {
 	CDR_LEAVE,
@@ -116,7 +117,7 @@ struct ServerPlayingSound
 };
 
 class Server : public con::PeerHandler, public MapEventReceiver,
-		public InventoryManager, public IGameDef
+		public IGameDef
 {
 public:
 	/*
@@ -674,6 +675,9 @@ private:
 
 	// ModChannel manager
 	std::unique_ptr<ModChannelMgr> m_modchannel_mgr;
+
+	// Inventory manager
+	std::unique_ptr<ServerInventoryMgr> m_inventory_mgr;
 
 	// Global server metrics backend
 	std::unique_ptr<MetricsBackend> m_metrics_backend;

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -4,5 +4,6 @@ set(server_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/mods.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/player_sao.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/serveractiveobject.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/serverinventorymgr.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/unit_sao.cpp
 	PARENT_SCOPE)

--- a/src/server/serverinventorymgr.cpp
+++ b/src/server/serverinventorymgr.cpp
@@ -1,0 +1,191 @@
+/*
+Minetest
+Copyright (C) 2010-2020 Minetest core development team
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "serverinventorymgr.h"
+#include "map.h"
+#include "nodemetadata.h"
+#include "player_sao.h"
+#include "remoteplayer.h"
+#include "server.h"
+#include "serverenvironment.h"
+
+ServerInventoryManager::ServerInventoryManager() : InventoryManager()
+{
+}
+
+ServerInventoryManager::~ServerInventoryManager()
+{
+	// Delete detached inventories
+	for (auto &detached_inventory : m_detached_inventories) {
+		delete detached_inventory.second.inventory;
+	}
+}
+
+Inventory *ServerInventoryManager::getInventory(const InventoryLocation &loc)
+{
+	switch (loc.type) {
+	case InventoryLocation::UNDEFINED:
+	case InventoryLocation::CURRENT_PLAYER:
+		break;
+	case InventoryLocation::PLAYER: {
+		RemotePlayer *player = m_env->getPlayer(loc.name.c_str());
+		if (!player)
+			return NULL;
+		PlayerSAO *playersao = player->getPlayerSAO();
+		if (!playersao)
+			return NULL;
+		return playersao->getInventory();
+	} break;
+	case InventoryLocation::NODEMETA: {
+		NodeMetadata *meta = m_env->getMap().getNodeMetadata(loc.p);
+		if (!meta)
+			return NULL;
+		return meta->getInventory();
+	} break;
+	case InventoryLocation::DETACHED: {
+		if (m_detached_inventories.count(loc.name) == 0)
+			return NULL;
+		return m_detached_inventories[loc.name].inventory;
+	} break;
+	default:
+		sanity_check(false); // abort
+		break;
+	}
+	return NULL;
+}
+
+void ServerInventoryManager::setInventoryModified(const InventoryLocation &loc)
+{
+	switch (loc.type) {
+	case InventoryLocation::UNDEFINED:
+		break;
+	case InventoryLocation::PLAYER: {
+
+		RemotePlayer *player = m_env->getPlayer(loc.name.c_str());
+
+		if (!player)
+			return;
+
+		player->setModified(true);
+		player->inventory.setModified(true);
+		// Updates are sent in ServerEnvironment::step()
+	} break;
+	case InventoryLocation::NODEMETA: {
+		MapEditEvent event;
+		event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
+		event.p = loc.p;
+		m_env->getMap().dispatchEvent(event);
+	} break;
+	case InventoryLocation::DETACHED: {
+		// Updates are sent in ServerEnvironment::step()
+	} break;
+	default:
+		sanity_check(false); // abort
+		break;
+	}
+}
+
+Inventory *ServerInventoryManager::createDetachedInventory(
+		const std::string &name, IItemDefManager *idef, const std::string &player)
+{
+	if (m_detached_inventories.count(name) > 0) {
+		infostream << "Server clearing detached inventory \"" << name << "\""
+			   << std::endl;
+		delete m_detached_inventories[name].inventory;
+	} else {
+		infostream << "Server creating detached inventory \"" << name << "\""
+			   << std::endl;
+	}
+
+	Inventory *inv = new Inventory(idef);
+	sanity_check(inv);
+	m_detached_inventories[name].inventory = inv;
+	if (!player.empty()) {
+		m_detached_inventories[name].owner = player;
+
+		if (!m_env)
+			return inv; // Mods are not loaded yet, ignore
+
+		RemotePlayer *p = m_env->getPlayer(name.c_str());
+
+		// if player is connected, send him the inventory
+		if (p && p->getPeerId() != PEER_ID_INEXISTENT) {
+			m_env->getGameDef()->sendDetachedInventory(
+					inv, name, p->getPeerId());
+		}
+	} else {
+		if (!m_env)
+			return inv; // Mods are not loaded yet, don't send
+
+		// Inventory is for everybody, broadcast
+		m_env->getGameDef()->sendDetachedInventory(inv, name, PEER_ID_INEXISTENT);
+	}
+
+	return inv;
+}
+
+bool ServerInventoryManager::removeDetachedInventory(const std::string &name)
+{
+	const auto &inv_it = m_detached_inventories.find(name);
+	if (inv_it == m_detached_inventories.end())
+		return false;
+
+	delete inv_it->second.inventory;
+	const std::string &owner = inv_it->second.owner;
+
+	if (!owner.empty()) {
+		RemotePlayer *player = m_env->getPlayer(owner.c_str());
+
+		if (player && player->getPeerId() != PEER_ID_INEXISTENT)
+			m_env->getGameDef()->sendDetachedInventory(
+					nullptr, name, player->getPeerId());
+
+	} else {
+		// Notify all players about the change
+		m_env->getGameDef()->sendDetachedInventory(
+				nullptr, name, PEER_ID_INEXISTENT);
+	}
+
+	m_detached_inventories.erase(inv_it);
+
+	return true;
+}
+
+void ServerInventoryManager::sendDetachedInventories(const std::string &peer_name,
+		bool incremental,
+		std::function<void(const std::string &, Inventory *)> apply_cb)
+{
+	for (const auto &detached_inventory : m_detached_inventories) {
+		const DetachedInventory &dinv = detached_inventory.second;
+		if (incremental) {
+			if (!dinv.inventory || !dinv.inventory->checkModified())
+				continue;
+		}
+
+		// if we are pushing inventories to a specific player
+		// we should filter to send only the right inventories
+		if (!peer_name.empty()) {
+			const std::string &attached_player = dinv.owner;
+			if (!attached_player.empty() && peer_name != attached_player)
+				continue;
+		}
+
+		apply_cb(detached_inventory.first, detached_inventory.second.inventory);
+	}
+}

--- a/src/server/serverinventorymgr.cpp
+++ b/src/server/serverinventorymgr.cpp
@@ -59,9 +59,10 @@ Inventory *ServerInventoryManager::getInventory(const InventoryLocation &loc)
 		return meta->getInventory();
 	} break;
 	case InventoryLocation::DETACHED: {
-		if (m_detached_inventories.count(loc.name) == 0)
-			return NULL;
-		return m_detached_inventories[loc.name].inventory;
+		auto it = m_detached_inventories.find(loc.name);
+		if (it == m_detached_inventories.end())
+			return nullptr;
+		return it.second.inventory;
 	} break;
 	default:
 		sanity_check(false); // abort

--- a/src/server/serverinventorymgr.cpp
+++ b/src/server/serverinventorymgr.cpp
@@ -62,7 +62,7 @@ Inventory *ServerInventoryManager::getInventory(const InventoryLocation &loc)
 		auto it = m_detached_inventories.find(loc.name);
 		if (it == m_detached_inventories.end())
 			return nullptr;
-		return it.second.inventory;
+		return it->second.inventory;
 	} break;
 	default:
 		sanity_check(false); // abort

--- a/src/server/serverinventorymgr.h
+++ b/src/server/serverinventorymgr.h
@@ -1,0 +1,60 @@
+/*
+Minetest
+Copyright (C) 2010-2020 Minetest core development team
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "inventorymanager.h"
+#include <functional>
+
+class ServerEnvironment;
+
+class ServerInventoryManager : public InventoryManager
+{
+public:
+	ServerInventoryManager();
+	virtual ~ServerInventoryManager();
+
+	void setEnv(ServerEnvironment *env)
+	{
+		assert(!m_env);
+		m_env = env;
+	}
+
+	Inventory *getInventory(const InventoryLocation &loc);
+	void setInventoryModified(const InventoryLocation &loc);
+
+	// Creates or resets inventory
+	Inventory *createDetachedInventory(const std::string &name, IItemDefManager *idef,
+			const std::string &player = "");
+	bool removeDetachedInventory(const std::string &name);
+
+	void sendDetachedInventories(const std::string &peer_name, bool incremental,
+			std::function<void(const std::string &, Inventory *)> apply_cb);
+
+private:
+	struct DetachedInventory
+	{
+		Inventory *inventory;
+		std::string owner;
+	};
+
+	ServerEnvironment *m_env = nullptr;
+
+	std::unordered_map<std::string, DetachedInventory> m_detached_inventories;
+};


### PR DESCRIPTION
This PR is composed of 2 tiny cleanups & 1 responbitility split
* drop a useless bool return on overrideDayNightRatio
* make Server::init() private 
* Move inventory manager responsibility outside of Server, to a ServerInventoryMgr object

## To do

This PR is Ready for Review.

## How to test

Launch a server with bunch of detached inventories, it should work as intended

Note: during my refacto i saw that some code parts are not perfect, but i didn't refactored them, like the sendDetachedInventories() which will recheck by sendDetachedInventory call the peer_id.
This part is interesting because if i connect to a server i will send detached inventories to some attached to other players, whereas they doesn't care
