### PR TITLE
Add minetest.is_creative_enabled

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -345,18 +345,12 @@ if INIT == "game" then
 --Wrapper for rotate_and_place() to check for sneak and assume Creative mode
 --implies infinite stacks when performing a 6d rotation.
 --------------------------------------------------------------------------------
-	local creative_mode_cache = core.settings:get_bool("creative_mode")
-	local function is_creative(name)
-		return creative_mode_cache or
-				core.check_player_privs(name, {creative = true})
-	end
-
 	core.rotate_node = function(itemstack, placer, pointed_thing)
 		local name = placer and placer:get_player_name() or ""
 		local invert_wall = placer and placer:get_player_control().sneak or false
 		return core.rotate_and_place(itemstack, placer, pointed_thing,
-				is_creative(name),
-				{invert_wall = invert_wall}, true)
+			core.is_creative_enabled(name),
+			{invert_wall = invert_wall}, true)
 	end
 end
 

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -582,7 +582,7 @@ function core.node_dig(pos, node, digger)
 			wielded = wdef.after_use(wielded, digger, node, dp) or wielded
 		else
 			-- Wear out tool
-			if not core.settings:get_bool("creative_mode") then
+			if not core.is_creative_enabled(diggername) then
 				wielded:add_wear(dp.wear)
 				if wielded:get_count() == 0 and wdef.sound and wdef.sound.breaks then
 					core.sound_play(wdef.sound.breaks, {

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -164,6 +164,12 @@ function core.record_protection_violation(pos, name)
 	end
 end
 
+-- To be overridden by Creative mods
+
+local creative_mode_cache = core.settings:get_bool("creative_mode")
+function core.is_creative_enabled(name)
+	return creative_mode_cache
+end
 
 -- Checks if specified volume intersects a protected volume
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5475,6 +5475,13 @@ Misc.
 * `minetest.record_protection_violation(pos, name)`
     * This function calls functions registered with
       `minetest.register_on_protection_violation`.
+* `minetest.is_creative_enabled(name)`: returns boolean
+    * Returning `true` means that Creative Mode is enabled for player `name`.
+    * `name` will be `""` for non-players or if the player is unknown.
+    * This function should be overridden by Creative Mode-related mods to
+      implement a per-player Creative Mode.
+    * By default, this function returns `true` if the setting
+      `creative_mode` is `true` and `false` otherwise.
 * `minetest.is_area_protected(pos1, pos2, player_name, interval)`
     * Returns the position of the first node that `player_name` may not modify
       in the specified cuboid between `pos1` and `pos2`.

--- a/games/devtest/mods/util_commands/init.lua
+++ b/games/devtest/mods/util_commands/init.lua
@@ -66,7 +66,7 @@ if s_infplace == "true" then
 elseif s_infplace == "false" then
 	infplace = false
 else
-	infplace = minetest.settings:get_bool("creative_mode", false)
+	infplace = minetest.is_creative_enabled("")
 end
 
 minetest.register_chatcommand("infplace", {


### PR DESCRIPTION
Closes #8413.

This adds a function `minetest.creative_is_enabled_for(name)`.
It returns whether Creative Mode is enabled for the player `name` (can be `""` for non-players).
By default, it returns the value of the `creative_mode` setting (true or false).

This function is designed to be overridden by mods, in a similar fashion like `minetest.is_protected`. It allows games to add a per-player inventory very easily.

This allows games to introduce whatever type of Creative Mode (per-player or not) they want with relative ease.

## To-do
This is a draft for you to look at. Do NOT merge before #9450 is merged, because I plan to make an update after this.

Apart from that, I think it works fine.

## Justification
In one word: Decoupling.

This makes implementing a per-player Creative Mode a piece of cake. Without this, mods always had to rely on some game API, which of course will differ between games.

Using `minetest.creative_is_enabled_for` will become the preferred way to check for Creative Mode.

## Game updates
This section is informational only, it talks about what to do with games afterwards.

### Minetest Game update
Minetest Game already implements a per-player Creative Mode, but mods need to hard-depend on a mod to use it. This implementation will obviously need updating after this PR. If this MTG update has been done, mods can start to use `minetest.creative_is_enabled_for` without needing to depend on anything.

### Updates for other games and mods
Basically, all they have to do is to replace all instances of `minetest.settings:get_bool("creative_mode")` with `minetest.creative_is_enabled_for`.