### PR TITLE
Add options to partially or fully disable falling nodes

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1186,6 +1186,14 @@ chat_message_limit_per_10sec (Chat message count limit) float 10.0
 #    Kick players who sent more than X messages per 10 seconds.
 chat_message_limit_trigger_kick (Chat message kick threshold) int 50
 
+#    How to handle digging and placing of falling nodes.
+#    The 'drop' and 'none' options can safeguard against certain forms of griefing
+#    in multiplayer games.
+#    -    fall: Simulate falling as usual
+#    -    drop: Convert to dropped item(s)
+#    -    none: Treat like a non-falling node
+falling_node_behavior (Behavior of falling nodes)
+
 [**Physics]
 
 #    Horizontal and vertical acceleration on ground or when climbing,

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1424,6 +1424,14 @@
 #    type: int
 # chat_message_limit_trigger_kick = 50
 
+#    How to handle digging and placing of falling nodes.
+#    The 'drop' and 'none' options can safeguard against certain forms of griefing
+#    in multiplayer games.
+#    -    fall: Simulate falling as usual
+#    -    drop: Convert to dropped item(s)
+#    -    none: Treat like a non-falling node
+# falling_node_behavior = fall
+
 ### Physics
 
 #    Horizontal and vertical acceleration on ground or when climbing,


### PR DESCRIPTION
This PR resolves #4781 by providing a setting in minetest.conf to change the behavior of falling nodes in multiplayer games, thereby avoiding several common forms of griefing.

## To do

This PR is a Ready for Review.

## How to test

Change the setting `falling_node_behavior` in minetest.conf to `fall`, `drop`, or `none` and observe that the behavior is as expected when digging and placing above air. In `drop`, all adjacent nodes will drop as a stack of items. And in `none` their positions will remain fixed exactly like regular nodes.