### PR TITLE
fix models turn black when inside solid node

### DIFF
--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -330,7 +330,7 @@ void ClientEnvironment::step(float dtime)
 			MapNode n = this->m_map->getNode(p, &pos_ok);
 			if (pos_ok) {
 				const NodeDefManager *nodemgr = m_client->ndef();
-				//don't update if clipping with a solid node.
+				// Don't update if clipping with a solid node so object doesn't turn black
 				if (nodemgr->get(n).light_propagates) {
 					light = n.getLightBlend(day_night_ratio, nodemgr);
 					cao->updateLight(light);

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -328,12 +328,18 @@ void ClientEnvironment::step(float dtime)
 			// Get node at head
 			v3s16 p = cao->getLightPosition();
 			MapNode n = this->m_map->getNode(p, &pos_ok);
-			if (pos_ok)
-				light = n.getLightBlend(day_night_ratio, m_client->ndef());
-			else
+			if (pos_ok) {
+				const NodeDefManager *nodemgr = m_client->ndef();
+				//don't update if clipping with a solid node.
+				if (nodemgr->get(n).light_propagates) {
+					light = n.getLightBlend(day_night_ratio, nodemgr);
+					cao->updateLight(light);
+				}
+			}
+			else {
 				light = blend_light(day_night_ratio, LIGHT_SUN, 0);
-
-			cao->updateLight(light);
+				cao->updateLight(light);
+			}
 		}
 	};
 

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -335,8 +335,7 @@ void ClientEnvironment::step(float dtime)
 					light = n.getLightBlend(day_night_ratio, nodemgr);
 					cao->updateLight(light);
 				}
-			}
-			else {
+			} else {
 				light = blend_light(day_night_ratio, LIGHT_SUN, 0);
 				cao->updateLight(light);
 			}


### PR DESCRIPTION
This is a quick and easy fix for #2467

How it works:
Cao's light isn't updated anymore if calculated position is inside a node with `light_propagates ` being false.

There still may be some weird lightning e.g. if player is noclipping through cave floor in a specific way or objects are left inside nodes for a long time, but come on, this is basically a two liner, why not merge and worry about complex solutions later.

## To do

This PR is Ready for Review.

## How to test

Clip player and objects into nodes and see what happens.