### PR TITLE
Password generator and selector

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -44,9 +44,8 @@ end
 
 local function get_password(key)
 	if type(key) ~= "string" then
-		key = string.format("pwd_%s:%d:%s",
+		key = string.format("pwd:%s:%s",
 			key.address,
-			key.port,
 			key.playername)
 	end
 	local pass = storage:get_string(key) or gen_password(key)


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

This draft PR/idea removes the password box when connecting to servers.
The client will generate, or use an existing, password for any username and server.

The generator randomly creates 64 visible ASCII characters for new passwords.
This gives great security where a normal player would likely pick an easily guessed/cracked one.
It also removes the burden of keeping a different password for each server and username.

**Need feedback and suggestions!**

## Todo

This PR is a **Work in Progress**
- [ ] *See if builtin can even use mod storage*
- [ ] Test that it always works as intended
- [ ] Make sure only the user or anything else with filesystem access is able to read stored passwords, not any unprivileged mods.
- [ ] Replace `Name / Password` in locale with just `Name`
- [ ] Make change password button not lock you out of a server

## How to test

1. Build or replace your tab_online.lua
2. Join some servers and look at the storage afterwards.
Key `pwd:server:username` is the key for a generated password