### PR TITLE
Fix broken client if openal cannot be opened

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -105,7 +105,7 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 	}
 
 	RenderingEngine::get_instance()->setupTopLevelWindow(PROJECT_NAME_C);
-	
+
 	/*
 		This changes the minimum allowed number of vertices in a VBO.
 		Default is 500.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1249,7 +1249,7 @@ bool Game::init(
 bool Game::initSound()
 {
 #if USE_SOUND
-	if (g_settings->getBool("enable_sound")) {
+	if (g_settings->getBool("enable_sound") && g_sound_manager_singleton.get()) {
 		infostream << "Attempting to use OpenAL audio" << std::endl;
 		sound = createOpenALSoundManager(g_sound_manager_singleton.get(), &soundfetcher);
 		if (!sound)

--- a/src/client/sound_openal.cpp
+++ b/src/client/sound_openal.cpp
@@ -275,25 +275,38 @@ public:
 		m_device(nullptr, delete_alcdevice),
 		m_context(nullptr, delete_alccontext)
 	{
-		if (!(m_device = unique_ptr_alcdevice(alcOpenDevice(nullptr), delete_alcdevice)))
-			throw std::runtime_error("Audio: Global Initialization: Device Open");
+	}
+
+	bool init()
+	{
+		if (!(m_device = unique_ptr_alcdevice(alcOpenDevice(nullptr), delete_alcdevice))) {
+			errorstream << "Audio: Global Initialization: Failed to open device" << std::endl;
+			return false;
+		}
 
 		if (!(m_context = unique_ptr_alccontext(
 				alcCreateContext(m_device.get(), nullptr), delete_alccontext))) {
-			throw std::runtime_error("Audio: Global Initialization: Context Create");
+			errorstream << "Audio: Global Initialization: Failed to create context" << std::endl;
+			return false;
 		}
 
-		if (!alcMakeContextCurrent(m_context.get()))
-			throw std::runtime_error("Audio: Global Initialization: Context Current");
+		if (!alcMakeContextCurrent(m_context.get())) {
+			errorstream << "Audio: Global Initialization: Failed to make current context" << std::endl;
+			return false;
+		}
 
 		alDistanceModel(AL_INVERSE_DISTANCE_CLAMPED);
 
-		if (alGetError() != AL_NO_ERROR)
-			throw std::runtime_error("Audio: Global Initialization: OpenAL Error");
+		if (alGetError() != AL_NO_ERROR) {
+			errorstream << "Audio: Global Initialization: OpenAL Error " << alGetError() << std::endl;
+			return false;
+		}
 
 		infostream << "Audio: Global Initialized: OpenAL " << alGetString(AL_VERSION)
 			<< ", using " << alcGetString(m_device.get(), ALC_DEVICE_SPECIFIER)
 			<< std::endl;
+
+		return true;
 	}
 
 	~SoundManagerSingleton()
@@ -682,7 +695,11 @@ public:
 
 std::shared_ptr<SoundManagerSingleton> createSoundManagerSingleton()
 {
-	return std::shared_ptr<SoundManagerSingleton>(new SoundManagerSingleton());
+	auto smg = std::make_shared<SoundManagerSingleton>();
+	if (!smg->init()) {
+		smg.reset();
+	}
+	return smg;
 }
 
 ISoundManager *createOpenALSoundManager(SoundManagerSingleton *smg, OnDemandSoundFetcher *fetcher)

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -144,10 +144,10 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 	//create soundmanager
 	MenuMusicFetcher soundfetcher;
 #if USE_SOUND
-	if (g_settings->getBool("enable_sound"))
+	if (g_settings->getBool("enable_sound") && g_sound_manager_singleton.get())
 		m_sound_manager = createOpenALSoundManager(g_sound_manager_singleton.get(), &soundfetcher);
 #endif
-	if(!m_sound_manager)
+	if (!m_sound_manager)
 		m_sound_manager = &dummySoundManager;
 
 	//create topleft header


### PR DESCRIPTION
Change the way we initialize sound on client to handle the openal initialization failures as a non fatal errors

Fix #7250

## To do

This PR is Ready for Review.

## How to test

<!-- Example code or instructions -->
