### PR TITLE
Add server API abstraction layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ build/.cmake/
 
 ## Non-static Minetest directories or symlinks to these
 /bin/
+*.so
 /games/*
 !/games/minimal/
 /cache

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -383,6 +383,7 @@ add_subdirectory(unittest)
 add_subdirectory(util)
 add_subdirectory(irrlicht_changes)
 add_subdirectory(server)
+add_subdirectory(libserver)
 
 set(common_SRCS
 	${database_SRCS}
@@ -552,6 +553,7 @@ if(BUILD_CLIENT)
 	add_dependencies(${PROJECT_NAME} GenerateVersion)
 	set(client_LIBS
 		${PROJECT_NAME}
+		${PROJECT_NAME}api
 		${ZLIB_LIBRARIES}
 		${IRRLICHT_LIBRARY}
 		${JPEG_LIBRARIES}
@@ -631,6 +633,7 @@ if(BUILD_SERVER)
 	add_dependencies(${PROJECT_NAME}server GenerateVersion)
 	target_link_libraries(
 		${PROJECT_NAME}server
+		${PROJECT_NAME}api
 		${ZLIB_LIBRARIES}
 		${SQLITE3_LIBRARY}
 		${JSON_LIBRARY}
@@ -702,7 +705,7 @@ if(MSVC)
 	if(CMAKE_SIZEOF_VOID_P EQUAL 4)
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /arch:SSE")
 	endif()
-	
+
 	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 		set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF")
 	else()

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -634,7 +634,7 @@ MapBlock *EmergeThread::finishGen(v3s16 pos, BlockMakeData *bmdata,
 		Run Lua on_generated callbacks
 	*/
 	try {
-		m_server->getScriptIface()->environment_OnGenerated(
+		m_server->getApiRouter()->environment_OnGenerated(
 			minp, maxp, m_mapgen->blockseed);
 	} catch (LuaError &e) {
 		m_server->setAsyncFatalError("Lua: finishGen" + std::string(e.what()));

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -29,7 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/strfnd.h"
 #include "util/basic_macros.h"
 
-#define PLAYER_TO_SA(p)   p->getEnv()->getScriptIface()
+#define PLAYER_TO_SA(p)   p->getEnv()->getApiRouter()
 
 /*
 	InventoryLocation

--- a/src/libserver/CMakeLists.txt
+++ b/src/libserver/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(libserver_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/libserver.cpp
+)
+
+add_library(${PROJECT_NAME}api SHARED ${libserver_SRCS})

--- a/src/libserver/libserver.cpp
+++ b/src/libserver/libserver.cpp
@@ -1,0 +1,55 @@
+#include "libserver.h"
+
+std::vector<std::shared_ptr<api::server::Entity>> get_minetest_entity_apis()
+{
+	// Register your api modules here
+	return {};
+}
+
+std::vector<std::shared_ptr<api::server::Environment>> get_minetest_environment_apis()
+{
+	// Register your api modules here
+	return {};
+}
+
+std::vector<std::shared_ptr<api::server::Global>> get_minetest_global_apis()
+{
+	// Register your api modules here
+	return {};
+}
+
+std::vector<std::shared_ptr<api::server::Inventory>> get_minetest_inventory_apis()
+{
+	// Register your api modules here
+	return {};
+}
+
+std::vector<std::shared_ptr<api::server::Item>> get_minetest_item_apis()
+{
+	// Register your api modules here
+	return {};
+}
+
+std::vector<std::shared_ptr<api::server::ModChannels>> get_minetest_modchannels_apis()
+{
+	// Register your api modules here
+	return {};
+}
+
+std::vector<std::shared_ptr<api::server::Node>> get_minetest_node_apis()
+{
+	// Register your api modules here
+	return {};
+}
+
+std::vector<std::shared_ptr<api::server::NodeMeta>> get_minetest_nodemeta_apis()
+{
+	// Register your api modules here
+	return {};
+}
+
+std::vector<std::shared_ptr<api::server::Player>> get_minetest_player_apis()
+{
+	// Register your api modules here
+	return {};
+}

--- a/src/libserver/libserver.h
+++ b/src/libserver/libserver.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+namespace api
+{
+namespace server
+{
+class Entity;
+class Environment;
+class Global;
+class Inventory;
+class Item;
+class ModChannels;
+class Node;
+class NodeMeta;
+class Player;
+}
+}
+
+extern std::vector<std::shared_ptr<api::server::Entity>> get_minetest_entity_apis();
+extern std::vector<std::shared_ptr<api::server::Environment>>
+get_minetest_environment_apis();
+extern std::vector<std::shared_ptr<api::server::Global>> get_minetest_global_apis();
+extern std::vector<std::shared_ptr<api::server::Inventory>> get_minetest_inventory_apis();
+extern std::vector<std::shared_ptr<api::server::Item>> get_minetest_item_apis();
+extern std::vector<std::shared_ptr<api::server::ModChannels>>
+get_minetest_modchannels_apis();
+extern std::vector<std::shared_ptr<api::server::Node>> get_minetest_node_apis();
+extern std::vector<std::shared_ptr<api::server::NodeMeta>> get_minetest_nodemeta_apis();
+extern std::vector<std::shared_ptr<api::server::Player>> get_minetest_player_apis();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -770,7 +770,7 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 
 		// on_flood() the node
 		if (floodable_node != CONTENT_AIR) {
-			if (env->getScriptIface()->node_on_flood(p0, n00, n0))
+			if (env->getApiRouter()->node_on_flood(p0, n00, n0))
 				continue;
 		}
 

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -336,65 +336,6 @@ void ScriptApiBase::setOriginFromTableRaw(int index, const char *fxn)
 #endif
 }
 
-/*
- * How ObjectRefs are handled in Lua:
- * When an active object is created, an ObjectRef is created on the Lua side
- * and stored in core.object_refs[id].
- * Methods that require an ObjectRef to a certain object retrieve it from that
- * table instead of creating their own.(*)
- * When an active object is removed, the existing ObjectRef is invalidated
- * using ::set_null() and removed from the core.object_refs table.
- * (*) An exception to this are NULL ObjectRefs and anonymous ObjectRefs
- *     for objects without ID.
- *     It's unclear what the latter are needed for and their use is problematic
- *     since we lose control over the ref and the contained pointer.
- */
-
-void ScriptApiBase::addObjectReference(ServerActiveObject *cobj)
-{
-	SCRIPTAPI_PRECHECKHEADER
-	//infostream<<"scriptapi_add_object_reference: id="<<cobj->getId()<<std::endl;
-
-	// Create object on stack
-	ObjectRef::create(L, cobj); // Puts ObjectRef (as userdata) on stack
-	int object = lua_gettop(L);
-
-	// Get core.object_refs table
-	lua_getglobal(L, "core");
-	lua_getfield(L, -1, "object_refs");
-	luaL_checktype(L, -1, LUA_TTABLE);
-	int objectstable = lua_gettop(L);
-
-	// object_refs[id] = object
-	lua_pushnumber(L, cobj->getId()); // Push id
-	lua_pushvalue(L, object); // Copy object to top of stack
-	lua_settable(L, objectstable);
-}
-
-void ScriptApiBase::removeObjectReference(ServerActiveObject *cobj)
-{
-	SCRIPTAPI_PRECHECKHEADER
-	//infostream<<"scriptapi_rm_object_reference: id="<<cobj->getId()<<std::endl;
-
-	// Get core.object_refs table
-	lua_getglobal(L, "core");
-	lua_getfield(L, -1, "object_refs");
-	luaL_checktype(L, -1, LUA_TTABLE);
-	int objectstable = lua_gettop(L);
-
-	// Get object_refs[id]
-	lua_pushnumber(L, cobj->getId()); // Push id
-	lua_gettable(L, objectstable);
-	// Set object reference to NULL
-	ObjectRef::set_null(L);
-	lua_pop(L, 1); // pop object
-
-	// Set object_refs[id] = nil
-	lua_pushnumber(L, cobj->getId()); // Push id
-	lua_pushnil(L);
-	lua_settable(L, objectstable);
-}
-
 // Creates a new anonymous reference if cobj=NULL or id=0
 void ScriptApiBase::objectrefGetOrCreate(lua_State *L,
 		ServerActiveObject *cobj)

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -97,10 +97,6 @@ public:
 	void runCallbacksRaw(int nargs,
 		RunCallbacksMode mode, const char *fxn);
 
-	/* object */
-	void addObjectReference(ServerActiveObject *cobj);
-	void removeObjectReference(ServerActiveObject *cobj);
-
 	IGameDef *getGameDef() { return m_gamedef; }
 	Server* getServer();
 	ScriptingType getType() { return m_type; }

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -19,11 +19,71 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_entity.h"
 #include "cpp_api/s_internal.h"
+#include "lua_api/l_object.h"
 #include "log.h"
 #include "object_properties.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include "server.h"
+
+/*
+ * How ObjectRefs are handled in Lua:
+ * When an active object is created, an ObjectRef is created on the Lua side
+ * and stored in core.object_refs[id].
+ * Methods that require an ObjectRef to a certain object retrieve it from that
+ * table instead of creating their own.(*)
+ * When an active object is removed, the existing ObjectRef is invalidated
+ * using ::set_null() and removed from the core.object_refs table.
+ * (*) An exception to this are NULL ObjectRefs and anonymous ObjectRefs
+ *     for objects without ID.
+ *     It's unclear what the latter are needed for and their use is problematic
+ *     since we lose control over the ref and the contained pointer.
+ */
+
+void ScriptApiEntity::addObjectReference(ServerActiveObject *cobj)
+{
+	SCRIPTAPI_PRECHECKHEADER
+	//infostream<<"scriptapi_add_object_reference: id="<<cobj->getId()<<std::endl;
+
+	// Create object on stack
+	ObjectRef::create(L, cobj); // Puts ObjectRef (as userdata) on stack
+	int object = lua_gettop(L);
+
+	// Get core.object_refs table
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "object_refs");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	int objectstable = lua_gettop(L);
+
+	// object_refs[id] = object
+	lua_pushnumber(L, cobj->getId()); // Push id
+	lua_pushvalue(L, object); // Copy object to top of stack
+	lua_settable(L, objectstable);
+}
+
+void ScriptApiEntity::removeObjectReference(ServerActiveObject *cobj)
+{
+	SCRIPTAPI_PRECHECKHEADER
+	//infostream<<"scriptapi_rm_object_reference: id="<<cobj->getId()<<std::endl;
+
+	// Get core.object_refs table
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "object_refs");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	int objectstable = lua_gettop(L);
+
+	// Get object_refs[id]
+	lua_pushnumber(L, cobj->getId()); // Push id
+	lua_gettable(L, objectstable);
+	// Set object reference to NULL
+	ObjectRef::set_null(L);
+	lua_pop(L, 1); // pop object
+
+	// Set object_refs[id] = nil
+	lua_pushnumber(L, cobj->getId()); // Push id
+	lua_pushnil(L);
+	lua_settable(L, objectstable);
+}
 
 bool ScriptApiEntity::luaentity_Add(u16 id, const char *name)
 {
@@ -178,7 +238,7 @@ void ScriptApiEntity::luaentity_GetProperties(u16 id,
 	lua_pop(L, 1);
 }
 
-void ScriptApiEntity::luaentity_Step(u16 id, float dtime,
+void ScriptApiEntity::on_entity_step(u16 id, float dtime,
 	const collisionMoveResult *moveresult)
 {
 	SCRIPTAPI_PRECHECKHEADER
@@ -212,13 +272,11 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime,
 
 // Calls entity:on_punch(ObjectRef puncher, time_from_last_punch,
 //                       tool_capabilities, direction, damage)
-bool ScriptApiEntity::luaentity_Punch(u16 id,
+bool ScriptApiEntity::on_entity_punched(u16 id,
 		ServerActiveObject *puncher, float time_from_last_punch,
 		const ToolCapabilities *toolcap, v3f dir, s16 damage)
 {
 	SCRIPTAPI_PRECHECKHEADER
-
-	//infostream<<"scriptapi_luaentity_step: id="<<id<<std::endl;
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
@@ -278,13 +336,13 @@ bool ScriptApiEntity::luaentity_run_simple_callback(u16 id,
 	return retval;
 }
 
-bool ScriptApiEntity::luaentity_on_death(u16 id, ServerActiveObject *killer)
+bool ScriptApiEntity::on_entity_death(u16 id, ServerActiveObject *killer)
 {
 	return luaentity_run_simple_callback(id, killer, "on_death");
 }
 
 // Calls entity:on_rightclick(ObjectRef clicker)
-void ScriptApiEntity::luaentity_Rightclick(u16 id, ServerActiveObject *clicker)
+void ScriptApiEntity::on_entity_rightclick(u16 id, ServerActiveObject *clicker)
 {
 	luaentity_run_simple_callback(id, clicker, "on_rightclick");
 }

--- a/src/script/cpp_api/s_entity.h
+++ b/src/script/cpp_api/s_entity.h
@@ -21,15 +21,21 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_base.h"
 #include "irr_v3d.h"
+#include "server/api_entity.h"
 
 struct ObjectProperties;
 struct ToolCapabilities;
 struct collisionMoveResult;
 
 class ScriptApiEntity
-		: virtual public ScriptApiBase
+		: virtual public ScriptApiBase,
+		  virtual public api::server::Entity
 {
 public:
+	/* object */
+	void addObjectReference(ServerActiveObject *cobj);
+	void removeObjectReference(ServerActiveObject *cobj);
+
 	bool luaentity_Add(u16 id, const char *name);
 	void luaentity_Activate(u16 id,
 			const std::string &staticdata, u32 dtime_s);
@@ -37,13 +43,13 @@ public:
 	std::string luaentity_GetStaticdata(u16 id);
 	void luaentity_GetProperties(u16 id,
 			ServerActiveObject *self, ObjectProperties *prop);
-	void luaentity_Step(u16 id, float dtime,
+	void on_entity_step(u16 id, float dtime,
 		const collisionMoveResult *moveresult);
-	bool luaentity_Punch(u16 id,
+	bool on_entity_punched(u16 id,
 			ServerActiveObject *puncher, float time_from_last_punch,
 			const ToolCapabilities *toolcap, v3f dir, s16 damage);
-	bool luaentity_on_death(u16 id, ServerActiveObject *killer);
-	void luaentity_Rightclick(u16 id, ServerActiveObject *clicker);
+	bool on_entity_death(u16 id, ServerActiveObject *killer);
+	void on_entity_rightclick(u16 id, ServerActiveObject *clicker);
 	void luaentity_on_attach_child(u16 id, ServerActiveObject *child);
 	void luaentity_on_detach_child(u16 id, ServerActiveObject *child);
 	void luaentity_on_detach(u16 id, ServerActiveObject *parent);

--- a/src/script/cpp_api/s_env.h
+++ b/src/script/cpp_api/s_env.h
@@ -21,11 +21,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_base.h"
 #include "irr_v3d.h"
+#include "server/api_environment.h"
 
 class ServerEnvironment;
 struct ScriptCallbackState;
 
-class ScriptApiEnv : virtual public ScriptApiBase
+class ScriptApiEnv : virtual public ScriptApiBase, virtual public api::server::Environment
 {
 public:
 	// Called on environment step

--- a/src/script/cpp_api/s_inventory.h
+++ b/src/script/cpp_api/s_inventory.h
@@ -20,12 +20,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "cpp_api/s_base.h"
+#include "server/api_inventory.h"
 
 struct MoveAction;
 struct ItemStack;
 
 class ScriptApiDetached
-		: virtual public ScriptApiBase
+		: virtual public ScriptApiBase, virtual public api::server::Inventory
 {
 public:
 	/* Detached inventory callbacks */

--- a/src/script/cpp_api/s_item.h
+++ b/src/script/cpp_api/s_item.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_base.h"
 #include "irr_v3d.h"
+#include "server/api_item.h"
 
 struct PointedThing;
 struct ItemStack;
@@ -32,7 +33,7 @@ class InventoryList;
 struct InventoryLocation;
 
 class ScriptApiItem
-: virtual public ScriptApiBase
+: virtual public ScriptApiBase, virtual public api::server::Item
 {
 public:
 	bool item_OnDrop(ItemStack &item,

--- a/src/script/cpp_api/s_modchannels.h
+++ b/src/script/cpp_api/s_modchannels.h
@@ -21,8 +21,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_base.h"
 #include "modchannels.h"
+#include "server/api_modchannels.h"
 
-class ScriptApiModChannels : virtual public ScriptApiBase
+class ScriptApiModChannels : virtual public ScriptApiBase,
+			     virtual public api::server::ModChannels
 {
 public:
 	void on_modchannel_message(const std::string &channel, const std::string &sender,

--- a/src/script/cpp_api/s_node.h
+++ b/src/script/cpp_api/s_node.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irr_v3d.h"
 #include "cpp_api/s_base.h"
 #include "cpp_api/s_nodemeta.h"
+#include "server/api_node.h"
 #include "util/string.h"
 
 struct MapNode;
@@ -29,7 +30,8 @@ class ServerActiveObject;
 
 class ScriptApiNode
 		: virtual public ScriptApiBase,
-		  public ScriptApiNodemeta
+		virtual public api::server::Node,
+		public ScriptApiNodemeta
 {
 public:
 	ScriptApiNode() = default;

--- a/src/script/cpp_api/s_nodemeta.h
+++ b/src/script/cpp_api/s_nodemeta.h
@@ -22,12 +22,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_base.h"
 #include "cpp_api/s_item.h"
 #include "irr_v3d.h"
+#include "server/api_nodemeta.h"
 
 struct MoveAction;
 struct ItemStack;
 
 class ScriptApiNodemeta
 		: virtual public ScriptApiBase,
+		  virtual public api::server::NodeMeta,
 		  public ScriptApiItem
 {
 public:

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_base.h"
 #include "irr_v3d.h"
 #include "util/string.h"
+#include "server/api_player.h"
 
 struct MoveAction;
 struct InventoryLocation;
@@ -30,7 +31,7 @@ struct ToolCapabilities;
 struct PlayerHPChangeReason;
 class ServerActiveObject;
 
-class ScriptApiPlayer : virtual public ScriptApiBase
+class ScriptApiPlayer : virtual public ScriptApiBase, virtual public api::server::Player
 {
 public:
 	virtual ~ScriptApiPlayer() = default;

--- a/src/script/cpp_api/s_server.h
+++ b/src/script/cpp_api/s_server.h
@@ -21,9 +21,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_base.h"
 #include <set>
+#include "server/api_server.h"
 
 class ScriptApiServer
-		: virtual public ScriptApiBase
+		: virtual public ScriptApiBase, virtual public api::server::Global
 {
 public:
 	// Calls on_chat_message handlers

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -59,7 +59,7 @@ struct EnumString ModApiEnvMod::es_ClearObjectsMode[] =
 void LuaABM::trigger(ServerEnvironment *env, v3s16 p, MapNode n,
 		u32 active_object_count, u32 active_object_count_wider)
 {
-	ServerScripting *scriptIface = env->getScriptIface();
+	ServerScripting *scriptIface = env->getApiRouter()->getLuaAPI();
 	scriptIface->realityCheck();
 
 	lua_State *L = scriptIface->getStack();
@@ -102,7 +102,7 @@ void LuaABM::trigger(ServerEnvironment *env, v3s16 p, MapNode n,
 
 void LuaLBM::trigger(ServerEnvironment *env, v3s16 p, MapNode n)
 {
-	ServerScripting *scriptIface = env->getScriptIface();
+	ServerScripting *scriptIface = env->getApiRouter()->getLuaAPI();
 	scriptIface->realityCheck();
 
 	lua_State *L = scriptIface->getStack();
@@ -1123,7 +1123,7 @@ int ModApiEnvMod::l_emerge_area(lua_State *L)
 		int args_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
 		state = new ScriptCallbackState;
-		state->script       = getServer(L)->getScriptIface();
+		state->script       = getServer(L)->getApiRouter()->getLuaAPI();
 		state->callback_ref = callback_ref;
 		state->args_ref     = args_ref;
 		state->refcount     = num_blocks;

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -23,6 +23,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "serverenvironment.h"
 #include "raycast.h"
 
+class ServerScripting;
+
 class ModApiEnvMod : public ModApiBase {
 private:
 	// set_node(pos, node)

--- a/src/script/scripting_server.h
+++ b/src/script/scripting_server.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_player.h"
 #include "cpp_api/s_server.h"
 #include "cpp_api/s_security.h"
+#include "server/api.h"
 
 /*****************************************************************************/
 /* Scripting <-> Server Game Interface                                       */
@@ -45,9 +46,6 @@ class ServerScripting:
 {
 public:
 	ServerScripting(Server* server);
-
-	// use ScriptApiBase::loadMod() to load mods
-
 private:
 	void InitializeModApi(lua_State *L, int top);
 };

--- a/src/server.h
+++ b/src/server.h
@@ -42,6 +42,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <map>
 #include <vector>
 
+namespace api { namespace server {
+class Router;
+}}
 class ChatEvent;
 struct ChatEventChat;
 struct ChatInterface;
@@ -251,7 +254,7 @@ public:
 	void sendDetachedInventory(Inventory *inventory, const std::string &name, session_t peer_id);
 
 	// Envlock and conlock should be locked when using scriptapi
-	ServerScripting *getScriptIface(){ return m_script; }
+	api::server::Router *getApiRouter() { return m_api_router.get(); }
 
 	// actions: time-reversed list
 	// Return value: success/failure
@@ -557,9 +560,8 @@ private:
 	// Emerge manager
 	EmergeManager *m_emerge = nullptr;
 
-	// Scripting
-	// Envlock and conlock should be locked when using Lua
-	ServerScripting *m_script = nullptr;
+	// Api call router
+	std::unique_ptr<api::server::Router> m_api_router;
 
 	// Item definition manager
 	IWritableItemDefManager *m_itemdef;

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(server_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/activeobjectmgr.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/api.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/luaentity_sao.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mods.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/player_sao.cpp

--- a/src/server/api.cpp
+++ b/src/server/api.cpp
@@ -1,0 +1,675 @@
+#include "api.h"
+#include "scripting_server.h"
+
+namespace api
+{
+namespace server
+{
+
+ServerScripting *Router::getLuaAPI()
+{
+	return (ServerScripting *)m_lua_api;
+}
+
+template <> void Router::registerAPI(std::shared_ptr<Entity> api)
+{
+	m_entity_implementations.push_back(api);
+}
+
+template <> void Router::registerAPI(std::shared_ptr<Environment> api)
+{
+	m_env_implementations.push_back(api);
+}
+
+template <> void Router::registerAPI(std::shared_ptr<Global> api)
+{
+	m_global_implementations.push_back(api);
+}
+
+template <> void Router::registerAPI(std::shared_ptr<Inventory> api)
+{
+	m_inv_implementations.push_back(api);
+}
+
+template <> void Router::registerAPI(std::shared_ptr<Item> api)
+{
+	m_item_implementations.push_back(api);
+}
+
+template <> void Router::registerAPI(std::shared_ptr<ModChannels> api)
+{
+	m_modchannel_implementations.push_back(api);
+}
+
+template <> void Router::registerAPI(std::shared_ptr<Node> api)
+{
+	m_node_implementations.push_back(api);
+}
+
+template <> void Router::registerAPI(std::shared_ptr<NodeMeta> api)
+{
+	m_node_meta_implementations.push_back(api);
+}
+
+template <> void Router::registerAPI(std::shared_ptr<Player> api)
+{
+	m_player_implementations.push_back(api);
+}
+/*
+ * Player routes
+ */
+
+void Router::on_newplayer(ServerActiveObject *player)
+{
+	for (const auto &impl : m_player_implementations)
+		impl->on_newplayer(player);
+}
+
+void Router::on_dieplayer(ServerActiveObject *player, const PlayerHPChangeReason &reason)
+{
+	for (const auto &impl : m_player_implementations)
+		impl->on_dieplayer(player, reason);
+}
+
+bool Router::on_respawnplayer(ServerActiveObject *player)
+{
+	for (const auto &impl : m_player_implementations) {
+		if (impl->on_respawnplayer(player))
+			return true;
+	}
+
+	return false;
+}
+bool Router::on_prejoinplayer(
+		const std::string &name, const std::string &ip, std::string *reason)
+{
+	for (const auto &impl : m_player_implementations) {
+		if (impl->on_prejoinplayer(name, ip, reason))
+			return true;
+	}
+
+	return false;
+}
+
+bool Router::can_bypass_userlimit(const std::string &name, const std::string &ip)
+{
+	for (const auto &impl : m_player_implementations) {
+		if (impl->can_bypass_userlimit(name, ip))
+			return true;
+	}
+
+	return false;
+}
+
+void Router::on_joinplayer(ServerActiveObject *player)
+{
+	for (const auto &impl : m_player_implementations)
+		impl->on_joinplayer(player);
+}
+
+void Router::on_leaveplayer(ServerActiveObject *player, bool timeout)
+{
+	for (const auto &impl : m_player_implementations)
+		impl->on_leaveplayer(player, timeout);
+}
+
+void Router::on_cheat(ServerActiveObject *player, const std::string &cheat_type)
+{
+	for (const auto &impl : m_player_implementations)
+		impl->on_cheat(player, cheat_type);
+}
+
+bool Router::on_punchplayer(ServerActiveObject *player, ServerActiveObject *hitter,
+		float time_from_last_punch, const ToolCapabilities *toolcap, v3f dir,
+		s16 damage)
+{
+	for (const auto &impl : m_player_implementations) {
+		if (impl->on_punchplayer(player, hitter, time_from_last_punch, toolcap,
+				    dir, damage))
+			return true;
+	}
+
+	return false;
+}
+
+s32 Router::on_player_hpchange(ServerActiveObject *player, s32 hp_change,
+		const PlayerHPChangeReason &reason)
+{
+	for (const auto &impl : m_player_implementations)
+		return impl->on_player_hpchange(player, hp_change, reason);
+
+	return 0;
+}
+
+void Router::on_playerReceiveFields(ServerActiveObject *player,
+		const std::string &formname, const StringMap &fields)
+{
+	for (const auto &impl : m_player_implementations)
+		impl->on_playerReceiveFields(player, formname, fields);
+}
+
+void Router::on_auth_failure(const std::string &name, const std::string &ip)
+{
+	for (const auto &impl : m_player_implementations)
+		impl->on_auth_failure(name, ip);
+}
+
+/*
+ * Player inventory routes
+ */
+
+// Return number of accepted items to be moved
+int Router::player_inventory_AllowMove(
+		const MoveAction &ma, int count, ServerActiveObject *player)
+{
+	for (const auto &impl : m_player_implementations) {
+		int new_count = impl->player_inventory_AllowMove(ma, count, player);
+		if (new_count != 0)
+			return new_count;
+	}
+
+	return 0;
+}
+
+// Return number of accepted items to be put
+int Router::player_inventory_AllowPut(
+		const MoveAction &ma, const ItemStack &stack, ServerActiveObject *player)
+{
+	for (const auto &impl : m_player_implementations) {
+		int new_count = impl->player_inventory_AllowPut(ma, stack, player);
+		if (new_count != 0)
+			return new_count;
+	}
+
+	return 0;
+}
+
+// Return number of accepted items to be taken
+int Router::player_inventory_AllowTake(
+		const MoveAction &ma, const ItemStack &stack, ServerActiveObject *player)
+{
+	for (const auto &impl : m_player_implementations) {
+		int new_count = impl->player_inventory_AllowTake(ma, stack, player);
+		if (new_count != 0)
+			return new_count;
+	}
+
+	return 0;
+}
+
+// Report moved items
+void Router::player_inventory_OnMove(
+		const MoveAction &ma, int count, ServerActiveObject *player)
+{
+	for (const auto &impl : m_player_implementations)
+		impl->player_inventory_OnMove(ma, count, player);
+}
+
+// Report put items
+void Router::player_inventory_OnPut(
+		const MoveAction &ma, const ItemStack &stack, ServerActiveObject *player)
+{
+	for (const auto &impl : m_player_implementations)
+		impl->player_inventory_OnPut(ma, stack, player);
+}
+
+// Report taken items
+void Router::player_inventory_OnTake(
+		const MoveAction &ma, const ItemStack &stack, ServerActiveObject *player)
+{
+	for (const auto &impl : m_player_implementations)
+		impl->player_inventory_OnTake(ma, stack, player);
+}
+
+/*
+ * Server routes
+ */
+
+bool Router::on_chat_message(const std::string &name, const std::string &message)
+{
+	for (const auto &impl : m_global_implementations) {
+		if (impl->on_chat_message(name, message))
+			return true;
+	}
+
+	return false;
+}
+
+void Router::on_shutdown()
+{
+	for (const auto &impl : m_global_implementations)
+		impl->on_shutdown();
+}
+
+std::string Router::formatChatMessage(const std::string &name, const std::string &message)
+{
+	for (const auto &impl : m_global_implementations)
+		return impl->formatChatMessage(name, message);
+
+	return "";
+}
+
+bool Router::getAuth(const std::string &playername, std::string *dst_password,
+		std::set<std::string> *dst_privs)
+{
+	for (const auto &impl : m_global_implementations) {
+		if (impl->getAuth(playername, dst_password, dst_privs))
+			return true;
+	}
+
+	return false;
+}
+
+void Router::createAuth(const std::string &playername, const std::string &password)
+{
+	for (const auto &impl : m_global_implementations) {
+		impl->createAuth(playername, password);
+	}
+}
+
+bool Router::setPassword(const std::string &playername, const std::string &password)
+{
+	for (const auto &impl : m_global_implementations) {
+		if (impl->setPassword(playername, password))
+			return true;
+	}
+
+	return false;
+}
+
+void Router::environment_Step(float dtime)
+{
+	for (const auto &impl : m_env_implementations)
+		impl->environment_Step(dtime);
+}
+
+void Router::environment_OnGenerated(v3s16 minp, v3s16 maxp, u32 blockseed)
+{
+	for (const auto &impl : m_env_implementations)
+		impl->environment_OnGenerated(minp, maxp, blockseed);
+}
+
+void Router::player_event(ServerActiveObject *player, const std::string &type)
+{
+	for (const auto &impl : m_env_implementations)
+		impl->player_event(player, type);
+}
+
+void Router::on_emerge_area_completion(v3s16 blockpos, int action, void *state)
+{
+	for (const auto &impl : m_env_implementations)
+		impl->on_emerge_area_completion(blockpos, action, state);
+}
+
+bool Router::node_on_punch(v3s16 p, MapNode node, ServerActiveObject *puncher,
+		const PointedThing &pointed)
+{
+	for (const auto &impl : m_node_implementations) {
+		if (impl->node_on_punch(p, node, puncher, pointed))
+			return true;
+	}
+
+	return false;
+}
+
+bool Router::node_on_dig(v3s16 p, MapNode node, ServerActiveObject *digger)
+{
+	for (const auto &impl : m_node_implementations) {
+		if (impl->node_on_dig(p, node, digger))
+			return true;
+	}
+
+	return false;
+}
+void Router::node_on_construct(v3s16 p, MapNode node)
+{
+	for (const auto &impl : m_node_implementations)
+		impl->node_on_construct(p, node);
+}
+
+void Router::node_on_destruct(v3s16 p, MapNode node)
+{
+	for (const auto &impl : m_node_implementations)
+		impl->node_on_destruct(p, node);
+}
+
+bool Router::node_on_flood(v3s16 p, MapNode node, MapNode newnode)
+{
+	for (const auto &impl : m_node_implementations) {
+		if (impl->node_on_flood(p, node, newnode))
+			return true;
+	}
+
+	return false;
+}
+
+void Router::node_after_destruct(v3s16 p, MapNode node)
+{
+	for (const auto &impl : m_node_implementations)
+		impl->node_after_destruct(p, node);
+}
+
+bool Router::node_on_timer(v3s16 p, MapNode node, f32 dtime)
+{
+	for (const auto &impl : m_node_implementations) {
+		if (impl->node_on_timer(p, node, dtime))
+			return true;
+	}
+
+	return false;
+}
+
+void Router::node_on_receive_fields(v3s16 p, const std::string &formname,
+		const StringMap &fields, ServerActiveObject *sender)
+{
+	for (const auto &impl : m_node_implementations)
+		impl->node_on_receive_fields(p, formname, fields, sender);
+}
+
+void Router::addObjectReference(ServerActiveObject *obj)
+{
+	for (const auto &impl : m_entity_implementations)
+		impl->addObjectReference(obj);
+}
+
+void Router::removeObjectReference(ServerActiveObject *obj)
+{
+	for (const auto &impl : m_entity_implementations)
+		impl->removeObjectReference(obj);
+}
+
+bool Router::luaentity_Add(u16 id, const char *name)
+{
+	for (const auto &impl : m_entity_implementations) {
+		if (impl->luaentity_Add(id, name))
+			return true;
+	}
+
+	return false;
+}
+
+void Router::luaentity_Activate(u16 id, const std::string &staticdata, u32 dtime_s)
+{
+	for (const auto &impl : m_entity_implementations)
+		impl->luaentity_Activate(id, staticdata, dtime_s);
+}
+
+void Router::luaentity_Remove(u16 id)
+{
+	for (const auto &impl : m_entity_implementations)
+		impl->luaentity_Remove(id);
+}
+
+std::string Router::luaentity_GetStaticdata(u16 id)
+{
+	for (const auto &impl : m_entity_implementations)
+		return impl->luaentity_GetStaticdata(id);
+
+	return "";
+}
+
+void Router::luaentity_GetProperties(
+		u16 id, ServerActiveObject *self, ObjectProperties *prop)
+{
+	for (const auto &impl : m_entity_implementations)
+		impl->luaentity_GetProperties(id, self, prop);
+}
+
+void Router::on_entity_step(u16 id, float dtime, const collisionMoveResult *moveresult)
+{
+	for (const auto &impl : m_entity_implementations)
+		impl->on_entity_step(id, dtime, moveresult);
+}
+
+bool Router::on_entity_punched(u16 id, ServerActiveObject *puncher,
+		float time_from_last_punch, const ToolCapabilities *toolcap, v3f dir,
+		s16 damage)
+{
+	for (const auto &impl : m_entity_implementations) {
+		if (impl->on_entity_punched(id, puncher, time_from_last_punch, toolcap,
+				    dir, damage))
+			return true;
+	}
+
+	return false;
+}
+
+bool Router::on_entity_death(u16 id, ServerActiveObject *killer)
+{
+	for (const auto &impl : m_entity_implementations) {
+		if (impl->on_entity_death(id, killer))
+			return true;
+	}
+
+	return false;
+}
+
+void Router::on_entity_rightclick(u16 id, ServerActiveObject *clicker)
+{
+	for (const auto &impl : m_entity_implementations)
+		impl->on_entity_rightclick(id, clicker);
+}
+
+void Router::luaentity_on_attach_child(u16 id, ServerActiveObject *child)
+{
+	for (const auto &impl : m_entity_implementations)
+		impl->luaentity_on_attach_child(id, child);
+}
+
+void Router::luaentity_on_detach_child(u16 id, ServerActiveObject *child)
+{
+	for (const auto &impl : m_entity_implementations)
+		impl->luaentity_on_detach_child(id, child);
+}
+
+void Router::luaentity_on_detach(u16 id, ServerActiveObject *parent)
+{
+	for (const auto &impl : m_entity_implementations)
+		impl->luaentity_on_detach(id, parent);
+}
+
+void Router::on_modchannel_message(const std::string &channel, const std::string &sender,
+		const std::string &message)
+{
+	for (const auto &impl : m_modchannel_implementations)
+		impl->on_modchannel_message(channel, sender, message);
+}
+
+void Router::on_modchannel_signal(const std::string &channel, ModChannelSignal signal)
+{
+	for (const auto &impl : m_modchannel_implementations)
+		impl->on_modchannel_signal(channel, signal);
+}
+
+bool Router::item_OnDrop(ItemStack &item, ServerActiveObject *dropper, v3f pos)
+{
+	for (const auto &impl : m_item_implementations) {
+		if (impl->item_OnDrop(item, dropper, pos))
+			return true;
+	}
+
+	return false;
+}
+
+bool Router::item_OnPlace(
+		ItemStack &item, ServerActiveObject *placer, const PointedThing &pointed)
+{
+	for (const auto &impl : m_item_implementations) {
+		if (impl->item_OnPlace(item, placer, pointed))
+			return true;
+	}
+
+	return false;
+}
+
+bool Router::item_OnUse(
+		ItemStack &item, ServerActiveObject *user, const PointedThing &pointed)
+{
+	for (const auto &impl : m_item_implementations) {
+		if (impl->item_OnUse(item, user, pointed))
+			return true;
+	}
+
+	return false;
+}
+
+bool Router::item_OnSecondaryUse(
+		ItemStack &item, ServerActiveObject *user, const PointedThing &pointed)
+{
+	for (const auto &impl : m_item_implementations) {
+		if (impl->item_OnSecondaryUse(item, user, pointed))
+			return true;
+	}
+
+	return false;
+}
+
+bool Router::item_OnCraft(ItemStack &item, ServerActiveObject *user,
+		const InventoryList *old_craft_grid, const InventoryLocation &craft_inv)
+{
+	for (const auto &impl : m_item_implementations) {
+		if (impl->item_OnCraft(item, user, old_craft_grid, craft_inv))
+			return true;
+	}
+
+	return false;
+}
+
+bool Router::item_CraftPredict(ItemStack &item, ServerActiveObject *user,
+		const InventoryList *old_craft_grid, const InventoryLocation &craft_inv)
+{
+	for (const auto &impl : m_item_implementations) {
+		if (impl->item_CraftPredict(item, user, old_craft_grid, craft_inv))
+			return true;
+	}
+
+	return false;
+}
+
+// Return number of accepted items to be moved
+int Router::nodemeta_inventory_AllowMove(
+		const MoveAction &ma, int count, ServerActiveObject *player)
+{
+	for (const auto &impl : m_node_meta_implementations) {
+		int changes = impl->nodemeta_inventory_AllowMove(ma, count, player);
+		if (changes != 0)
+			return changes;
+	}
+
+	return 0;
+}
+
+// Return number of accepted items to be put
+int Router::nodemeta_inventory_AllowPut(
+		const MoveAction &ma, const ItemStack &stack, ServerActiveObject *player)
+{
+	for (const auto &impl : m_node_meta_implementations) {
+		int changes = impl->nodemeta_inventory_AllowPut(ma, stack, player);
+		if (changes != 0)
+			return changes;
+	}
+
+	return 0;
+}
+
+// Return number of accepted items to be taken
+int Router::nodemeta_inventory_AllowTake(
+		const MoveAction &ma, const ItemStack &stack, ServerActiveObject *player)
+{
+	for (const auto &impl : m_node_meta_implementations) {
+		int changes = impl->nodemeta_inventory_AllowTake(ma, stack, player);
+		if (changes != 0)
+			return changes;
+	}
+
+	return 0;
+}
+
+// Report moved items
+void Router::nodemeta_inventory_OnMove(
+		const MoveAction &ma, int count, ServerActiveObject *player)
+{
+	for (const auto &impl : m_node_meta_implementations)
+		impl->nodemeta_inventory_OnMove(ma, count, player);
+}
+
+// Report put items
+void Router::nodemeta_inventory_OnPut(
+		const MoveAction &ma, const ItemStack &stack, ServerActiveObject *player)
+{
+	for (const auto &impl : m_node_meta_implementations)
+		impl->nodemeta_inventory_OnPut(ma, stack, player);
+}
+
+// Report taken items
+void Router::nodemeta_inventory_OnTake(
+		const MoveAction &ma, const ItemStack &stack, ServerActiveObject *player)
+{
+	for (const auto &impl : m_node_meta_implementations)
+		impl->nodemeta_inventory_OnTake(ma, stack, player);
+}
+
+// Return number of accepted items to be moved
+int Router::detached_inventory_AllowMove(
+		const MoveAction &ma, int count, ServerActiveObject *player)
+{
+	for (const auto &impl : m_inv_implementations) {
+		int changed = impl->detached_inventory_AllowMove(ma, count, player);
+		if (changed != 0)
+			return changed;
+	}
+
+	return 0;
+}
+
+// Return number of accepted items to be put
+int Router::detached_inventory_AllowPut(
+		const MoveAction &ma, const ItemStack &stack, ServerActiveObject *player)
+{
+	for (const auto &impl : m_inv_implementations) {
+		int changed = impl->detached_inventory_AllowPut(ma, stack, player);
+		if (changed != 0)
+			return changed;
+	}
+	return 0;
+}
+
+// Return number of accepted items to be taken
+int Router::detached_inventory_AllowTake(
+		const MoveAction &ma, const ItemStack &stack, ServerActiveObject *player)
+{
+	for (const auto &impl : m_inv_implementations) {
+		int changed = impl->detached_inventory_AllowTake(ma, stack, player);
+		if (changed != 0)
+			return changed;
+	}
+
+	return 0;
+}
+
+// Report moved items
+void Router::detached_inventory_OnMove(
+		const MoveAction &ma, int count, ServerActiveObject *player)
+{
+	for (const auto &impl : m_inv_implementations)
+		impl->detached_inventory_OnMove(ma, count, player);
+}
+
+// Report put items
+void Router::detached_inventory_OnPut(
+		const MoveAction &ma, const ItemStack &stack, ServerActiveObject *player)
+{
+	for (const auto &impl : m_inv_implementations)
+		impl->detached_inventory_OnPut(ma, stack, player);
+}
+
+// Report taken items
+void Router::detached_inventory_OnTake(
+		const MoveAction &ma, const ItemStack &stack, ServerActiveObject *player)
+{
+	for (const auto &impl : m_inv_implementations)
+		impl->detached_inventory_OnTake(ma, stack, player);
+}
+
+}
+}

--- a/src/server/api.h
+++ b/src/server/api.h
@@ -1,0 +1,247 @@
+#pragma once
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+#include "irrlichttypes_bloated.h"
+#include "mapnode.h"
+#include "modchannels.h"
+#include "util/string.h"
+
+class InventoryList;
+class ServerActiveObject;
+class ServerScripting;
+struct collisionMoveResult;
+struct InventoryLocation;
+struct ItemStack;
+struct MoveAction;
+struct ObjectProperties;
+struct PlayerHPChangeReason;
+struct PointedThing;
+struct ToolCapabilities;
+
+namespace api
+{
+namespace server
+{
+
+class Entity;
+class Environment;
+class Global;
+class Inventory;
+class Item;
+class ModChannels;
+class Node;
+class NodeMeta;
+class Player;
+
+class Router
+{
+public:
+	Router() = default;
+	~Router() = default;
+
+	template <typename T> void registerAPI(std::shared_ptr<T> api);
+
+	void setLuaAPI(ServerScripting *lua_pi)
+	{
+		assert(!m_lua_api);
+		m_lua_api = lua_pi;
+	}
+	ServerScripting *getLuaAPI();
+
+	/*
+	 * Server callback routes
+	 */
+
+	bool on_chat_message(const std::string &name, const std::string &message);
+	void on_shutdown();
+
+	std::string formatChatMessage(
+			const std::string &name, const std::string &message);
+
+	bool getAuth(const std::string &playername, std::string *dst_password,
+			std::set<std::string> *dst_privs);
+	void createAuth(const std::string &playername, const std::string &password);
+	bool setPassword(const std::string &playername, const std::string &password);
+
+	/*
+	 * Environment routes
+	 */
+
+	// Called on environment step
+	void environment_Step(float dtime);
+
+	// Called after generating a piece of map
+	void environment_OnGenerated(v3s16 minp, v3s16 maxp, u32 blockseed);
+
+	// Called on player event
+	void player_event(ServerActiveObject *player, const std::string &type);
+
+	// Called after emerge of a block queued from core.emerge_area()
+	void on_emerge_area_completion(v3s16 blockpos, int action, void *state);
+
+	/*
+	 * Player callback routes
+	 */
+	void on_newplayer(ServerActiveObject *player);
+	void on_dieplayer(ServerActiveObject *player, const PlayerHPChangeReason &reason);
+	bool on_respawnplayer(ServerActiveObject *player);
+	bool on_prejoinplayer(const std::string &name, const std::string &ip,
+			std::string *reason);
+	bool can_bypass_userlimit(const std::string &name, const std::string &ip);
+	void on_joinplayer(ServerActiveObject *player);
+	void on_leaveplayer(ServerActiveObject *player, bool timeout);
+	void on_cheat(ServerActiveObject *player, const std::string &cheat_type);
+	bool on_punchplayer(ServerActiveObject *player, ServerActiveObject *hitter,
+			float time_from_last_punch, const ToolCapabilities *toolcap,
+			v3f dir, s16 damage);
+	s32 on_player_hpchange(ServerActiveObject *player, s32 hp_change,
+			const PlayerHPChangeReason &reason);
+	void on_playerReceiveFields(ServerActiveObject *player,
+			const std::string &formname, const StringMap &fields);
+	void on_auth_failure(const std::string &name, const std::string &ip);
+
+	// Player inventory callbacks
+	// Return number of accepted items to be moved
+	int player_inventory_AllowMove(
+			const MoveAction &ma, int count, ServerActiveObject *player);
+	// Return number of accepted items to be put
+	int player_inventory_AllowPut(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player);
+	// Return number of accepted items to be taken
+	int player_inventory_AllowTake(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player);
+	// Report moved items
+	void player_inventory_OnMove(
+			const MoveAction &ma, int count, ServerActiveObject *player);
+	// Report put items
+	void player_inventory_OnPut(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player);
+	// Report taken items
+	void player_inventory_OnTake(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player);
+
+	/*
+	 * Items
+	 */
+
+	bool item_OnDrop(ItemStack &item, ServerActiveObject *dropper, v3f pos);
+	bool item_OnPlace(ItemStack &item, ServerActiveObject *placer,
+			const PointedThing &pointed);
+	bool item_OnUse(ItemStack &item, ServerActiveObject *user,
+			const PointedThing &pointed);
+	bool item_OnSecondaryUse(ItemStack &item, ServerActiveObject *user,
+			const PointedThing &pointed);
+	bool item_OnCraft(ItemStack &item, ServerActiveObject *user,
+			const InventoryList *old_craft_grid,
+			const InventoryLocation &craft_inv);
+	bool item_CraftPredict(ItemStack &item, ServerActiveObject *user,
+			const InventoryList *old_craft_grid,
+			const InventoryLocation &craft_inv);
+
+	/*
+	 * Detached inventory
+	 */
+
+	// Return number of accepted items to be moved
+	int detached_inventory_AllowMove(
+			const MoveAction &ma, int count, ServerActiveObject *player);
+	// Return number of accepted items to be put
+	int detached_inventory_AllowPut(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player);
+	// Return number of accepted items to be taken
+	int detached_inventory_AllowTake(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player);
+	// Report moved items
+	void detached_inventory_OnMove(
+			const MoveAction &ma, int count, ServerActiveObject *player);
+	// Report put items
+	void detached_inventory_OnPut(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player);
+	// Report taken items
+	void detached_inventory_OnTake(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player);
+
+	/*
+	 * Lua entities
+	 */
+
+	void addObjectReference(ServerActiveObject *obj);
+	void removeObjectReference(ServerActiveObject *obj);
+
+	bool luaentity_Add(u16 id, const char *name);
+	void luaentity_Activate(u16 id, const std::string &staticdata, u32 dtime_s);
+	void luaentity_Remove(u16 id);
+	std::string luaentity_GetStaticdata(u16 id);
+	void luaentity_GetProperties(
+			u16 id, ServerActiveObject *self, ObjectProperties *prop);
+	void on_entity_step(u16 id, float dtime, const collisionMoveResult *moveresult);
+	bool on_entity_punched(u16 id, ServerActiveObject *puncher,
+			float time_from_last_punch, const ToolCapabilities *toolcap,
+			v3f dir, s16 damage);
+	bool on_entity_death(u16 id, ServerActiveObject *killer);
+	void on_entity_rightclick(u16 id, ServerActiveObject *clicker);
+	void luaentity_on_attach_child(u16 id, ServerActiveObject *child);
+	void luaentity_on_detach_child(u16 id, ServerActiveObject *child);
+	void luaentity_on_detach(u16 id, ServerActiveObject *parent);
+
+	/*
+	 * Mod channels
+	 */
+	void on_modchannel_message(const std::string &channel, const std::string &sender,
+			const std::string &message);
+	void on_modchannel_signal(const std::string &channel, ModChannelSignal signal);
+
+	/*
+	 * Nodes
+	 */
+
+	bool node_on_punch(v3s16 p, MapNode node, ServerActiveObject *puncher,
+			const PointedThing &pointed);
+	bool node_on_dig(v3s16 p, MapNode node, ServerActiveObject *digger);
+	void node_on_construct(v3s16 p, MapNode node);
+	void node_on_destruct(v3s16 p, MapNode node);
+	bool node_on_flood(v3s16 p, MapNode node, MapNode newnode);
+	void node_after_destruct(v3s16 p, MapNode node);
+	bool node_on_timer(v3s16 p, MapNode node, f32 dtime);
+	void node_on_receive_fields(v3s16 p, const std::string &formname,
+			const StringMap &fields, ServerActiveObject *sender);
+
+	// Return number of accepted items to be moved
+	int nodemeta_inventory_AllowMove(
+			const MoveAction &ma, int count, ServerActiveObject *player);
+	// Return number of accepted items to be put
+	int nodemeta_inventory_AllowPut(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player);
+	// Return number of accepted items to be taken
+	int nodemeta_inventory_AllowTake(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player);
+	// Report moved items
+	void nodemeta_inventory_OnMove(
+			const MoveAction &ma, int count, ServerActiveObject *player);
+	// Report put items
+	void nodemeta_inventory_OnPut(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player);
+	// Report taken items
+	void nodemeta_inventory_OnTake(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player);
+
+private:
+	std::vector<std::shared_ptr<Entity>> m_entity_implementations;
+	std::vector<std::shared_ptr<Environment>> m_env_implementations;
+	std::vector<std::shared_ptr<Global>> m_global_implementations;
+	std::vector<std::shared_ptr<Inventory>> m_inv_implementations;
+	std::vector<std::shared_ptr<Item>> m_item_implementations;
+	std::vector<std::shared_ptr<ModChannels>> m_modchannel_implementations;
+	std::vector<std::shared_ptr<Node>> m_node_implementations;
+	std::vector<std::shared_ptr<NodeMeta>> m_node_meta_implementations;
+	std::vector<std::shared_ptr<Player>> m_player_implementations;
+
+	// Special route for lua embedded API for LuaLBM & LuaABM
+	ServerScripting *m_lua_api = nullptr;
+};
+
+}
+}

--- a/src/server/api_entity.h
+++ b/src/server/api_entity.h
@@ -1,0 +1,49 @@
+#pragma once
+
+struct collisionMoveResult;
+struct ObjectProperties;
+struct ToolCapabilities;
+
+namespace api
+{
+namespace server
+{
+/*
+ * Entity callback events
+ */
+
+class Entity
+{
+public:
+	virtual void addObjectReference(ServerActiveObject *obj) {}
+	virtual void removeObjectReference(ServerActiveObject *obj) {}
+
+	virtual bool luaentity_Add(u16 id, const char *name) { return false; }
+	virtual void luaentity_Activate(
+			u16 id, const std::string &staticdata, u32 dtime_s)
+	{
+	}
+	virtual void luaentity_Remove(u16 id) {}
+	virtual std::string luaentity_GetStaticdata(u16 id) { return ""; }
+	virtual void luaentity_GetProperties(
+			u16 id, ServerActiveObject *self, ObjectProperties *prop)
+	{
+	}
+	virtual void on_entity_step(
+			u16 id, float dtime, const collisionMoveResult *moveresult)
+	{
+	}
+	virtual bool on_entity_punched(u16 id, ServerActiveObject *puncher,
+			float time_from_last_punch, const ToolCapabilities *toolcap,
+			v3f dir, s16 damage)
+	{
+		return false;
+	}
+	virtual bool on_entity_death(u16 id, ServerActiveObject *killer) { return false; }
+	virtual void on_entity_rightclick(u16 id, ServerActiveObject *clicker) {}
+	virtual void luaentity_on_attach_child(u16 id, ServerActiveObject *child) {}
+	virtual void luaentity_on_detach_child(u16 id, ServerActiveObject *child) {}
+	virtual void luaentity_on_detach(u16 id, ServerActiveObject *parent) {}
+};
+}
+}

--- a/src/server/api_environment.h
+++ b/src/server/api_environment.h
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace api
+{
+namespace server
+{
+/*
+ * Environment callback events
+ */
+class Environment
+{
+public:
+	// Called on environment step
+	virtual void environment_Step(float dtime) {}
+
+	// Called after generating a piece of map
+	virtual void environment_OnGenerated(v3s16 minp, v3s16 maxp, u32 blockseed) {}
+
+	// Called on player event
+	virtual void player_event(ServerActiveObject *player, const std::string &type) {}
+
+	// Called after emerge of a block queued from core.emerge_area()
+	virtual void on_emerge_area_completion(v3s16 blockpos, int action, void *state) {}
+};
+}
+}

--- a/src/server/api_inventory.h
+++ b/src/server/api_inventory.h
@@ -1,0 +1,52 @@
+#pragma once
+
+struct ItemStack;
+struct MoveAction;
+
+namespace api
+{
+namespace server
+{
+/*
+ * Inventory callback events
+ */
+
+class Inventory
+{
+public:
+	// Return number of accepted items to be moved
+	virtual int detached_inventory_AllowMove(
+			const MoveAction &ma, int count, ServerActiveObject *player)
+	{
+		return 0;
+	}
+	// Return number of accepted items to be put
+	virtual int detached_inventory_AllowPut(const MoveAction &ma,
+			const ItemStack &stack, ServerActiveObject *player)
+	{
+		return 0;
+	}
+	// Return number of accepted items to be taken
+	virtual int detached_inventory_AllowTake(const MoveAction &ma,
+			const ItemStack &stack, ServerActiveObject *player)
+	{
+		return 0;
+	}
+	// Report moved items
+	virtual void detached_inventory_OnMove(
+			const MoveAction &ma, int count, ServerActiveObject *player)
+	{
+	}
+	// Report put items
+	virtual void detached_inventory_OnPut(const MoveAction &ma,
+			const ItemStack &stack, ServerActiveObject *player)
+	{
+	}
+	// Report taken items
+	virtual void detached_inventory_OnTake(const MoveAction &ma,
+			const ItemStack &stack, ServerActiveObject *player)
+	{
+	}
+};
+}
+}

--- a/src/server/api_item.h
+++ b/src/server/api_item.h
@@ -1,0 +1,53 @@
+#pragma once
+
+class InventoryList;
+struct InventoryLocation;
+struct ItemStack;
+struct PointedThing;
+
+namespace api
+{
+namespace server
+{
+/*
+ * Item callback events
+ */
+
+class Item
+{
+public:
+	virtual bool item_OnDrop(ItemStack &item, ServerActiveObject *dropper, v3f pos)
+	{
+		return false;
+	}
+	virtual bool item_OnPlace(ItemStack &item, ServerActiveObject *placer,
+			const PointedThing &pointed)
+	{
+		return false;
+	}
+	virtual bool item_OnUse(ItemStack &item, ServerActiveObject *user,
+			const PointedThing &pointed)
+	{
+		return false;
+	}
+	virtual bool item_OnSecondaryUse(ItemStack &item, ServerActiveObject *user,
+			const PointedThing &pointed)
+	{
+		return false;
+	}
+	virtual bool item_OnCraft(ItemStack &item, ServerActiveObject *user,
+			const InventoryList *old_craft_grid,
+			const InventoryLocation &craft_inv)
+	{
+		return false;
+	}
+	virtual bool item_CraftPredict(ItemStack &item, ServerActiveObject *user,
+			const InventoryList *old_craft_grid,
+			const InventoryLocation &craft_inv)
+	{
+		return false;
+	}
+};
+
+}
+}

--- a/src/server/api_modchannels.h
+++ b/src/server/api_modchannels.h
@@ -1,0 +1,25 @@
+#pragma once
+
+/*
+ * Mod channels callback events
+ */
+
+namespace api
+{
+namespace server
+{
+class ModChannels
+{
+public:
+	virtual void on_modchannel_message(const std::string &channel,
+			const std::string &sender, const std::string &message)
+	{
+	}
+	virtual void on_modchannel_signal(
+			const std::string &channel, ModChannelSignal signal)
+	{
+	}
+};
+
+}
+}

--- a/src/server/api_node.h
+++ b/src/server/api_node.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "mapnode.h"
+#include "util/string.h"
+
+namespace api
+{
+namespace server
+{
+/*
+ * Node callback events
+ */
+
+class Node
+{
+public:
+	virtual bool node_on_punch(v3s16 p, MapNode node, ServerActiveObject *puncher,
+			const PointedThing &pointed)
+	{
+		return false;
+	}
+	virtual bool node_on_dig(v3s16 p, MapNode node, ServerActiveObject *digger)
+	{
+		return false;
+	}
+	virtual void node_on_construct(v3s16 p, MapNode node) {}
+	virtual void node_on_destruct(v3s16 p, MapNode node) {}
+	virtual bool node_on_flood(v3s16 p, MapNode node, MapNode newnode)
+	{
+		return false;
+	}
+	virtual void node_after_destruct(v3s16 p, MapNode node) {}
+	virtual bool node_on_timer(v3s16 p, MapNode node, f32 dtime) { return false; }
+	virtual void node_on_receive_fields(v3s16 p, const std::string &formname,
+			const StringMap &fields, ServerActiveObject *sender)
+	{
+	}
+};
+}
+}

--- a/src/server/api_nodemeta.h
+++ b/src/server/api_nodemeta.h
@@ -1,0 +1,54 @@
+#pragma once
+
+struct MoveAction;
+class ServerActiveObject;
+
+namespace api
+{
+namespace server
+{
+
+/*
+ * NodeMeta callback events
+ */
+
+class NodeMeta
+{
+public:
+	// Return number of accepted items to be moved
+	virtual int nodemeta_inventory_AllowMove(
+			const MoveAction &ma, int count, ServerActiveObject *player)
+	{
+		return 0;
+	}
+	// Return number of accepted items to be put
+	virtual int nodemeta_inventory_AllowPut(const MoveAction &ma,
+			const ItemStack &stack, ServerActiveObject *player)
+	{
+		return 0;
+	}
+	// Return number of accepted items to be taken
+	virtual int nodemeta_inventory_AllowTake(const MoveAction &ma,
+			const ItemStack &stack, ServerActiveObject *player)
+	{
+		return 0;
+	}
+	// Report moved items
+	virtual void nodemeta_inventory_OnMove(
+			const MoveAction &ma, int count, ServerActiveObject *player)
+	{
+	}
+	// Report put items
+	virtual void nodemeta_inventory_OnPut(const MoveAction &ma,
+			const ItemStack &stack, ServerActiveObject *player)
+	{
+	}
+	// Report taken items
+	virtual void nodemeta_inventory_OnTake(const MoveAction &ma,
+			const ItemStack &stack, ServerActiveObject *player)
+	{
+	}
+};
+
+}
+}

--- a/src/server/api_player.h
+++ b/src/server/api_player.h
@@ -1,0 +1,90 @@
+#pragma once
+
+class ServerActiveObject;
+struct ItemStack;
+struct MoveAction;
+struct ToolCapabilities;
+
+namespace api
+{
+namespace server
+{
+/*
+ * Player callback events
+ */
+
+class Player
+{
+public:
+	virtual void on_newplayer(ServerActiveObject *player) {}
+	virtual void on_dieplayer(
+			ServerActiveObject *player, const PlayerHPChangeReason &reason)
+	{
+	}
+	virtual bool on_respawnplayer(ServerActiveObject *player) { return false; }
+	virtual bool on_prejoinplayer(const std::string &name, const std::string &ip,
+			std::string *reason)
+	{
+		return false;
+	}
+	virtual bool can_bypass_userlimit(const std::string &name, const std::string &ip)
+	{
+		return false;
+	}
+	virtual void on_joinplayer(ServerActiveObject *player) {}
+	virtual void on_leaveplayer(ServerActiveObject *player, bool timeout) {}
+	virtual void on_cheat(ServerActiveObject *player, const std::string &cheat_type)
+	{
+	}
+	virtual bool on_punchplayer(ServerActiveObject *player,
+			ServerActiveObject *hitter, float time_from_last_punch,
+			const ToolCapabilities *toolcap, v3f dir, s16 damage)
+	{
+		return false;
+	}
+	virtual s32 on_player_hpchange(ServerActiveObject *player, s32 hp_change,
+			const PlayerHPChangeReason &reason)
+	{
+		return 0;
+	}
+	virtual void on_playerReceiveFields(ServerActiveObject *player,
+			const std::string &formname, const StringMap &fields)
+	{
+	}
+	virtual void on_auth_failure(const std::string &name, const std::string &ip) {}
+
+	virtual int player_inventory_AllowMove(
+			const MoveAction &ma, int count, ServerActiveObject *player)
+	{
+		return 0;
+	}
+	// Return number of accepted items to be put
+	virtual int player_inventory_AllowPut(const MoveAction &ma,
+			const ItemStack &stack, ServerActiveObject *player)
+	{
+		return 0;
+	}
+	// Return number of accepted items to be taken
+	virtual int player_inventory_AllowTake(const MoveAction &ma,
+			const ItemStack &stack, ServerActiveObject *player)
+	{
+		return 0;
+	}
+	// Report moved items
+	virtual void player_inventory_OnMove(
+			const MoveAction &ma, int count, ServerActiveObject *player)
+	{
+	}
+	// Report put items
+	virtual void player_inventory_OnPut(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player)
+	{
+	}
+	// Report taken items
+	virtual void player_inventory_OnTake(const MoveAction &ma, const ItemStack &stack,
+			ServerActiveObject *player)
+	{
+	}
+};
+}
+}

--- a/src/server/api_server.h
+++ b/src/server/api_server.h
@@ -1,0 +1,48 @@
+#pragma once
+
+namespace api
+{
+namespace server
+{
+/*
+ * Global server callbacks
+ */
+
+class Global
+{
+public:
+	// Calls on_shutdown handlers
+	virtual void on_shutdown() {}
+
+	// Calls on_chat_message handlers
+	// Returns true if script handled message
+	virtual bool on_chat_message(const std::string &name, const std::string &message)
+	{
+		return false;
+	}
+
+	// Calls core.format_chat_message
+	virtual std::string formatChatMessage(
+			const std::string &name, const std::string &message)
+	{
+		return "";
+	}
+
+	/* auth */
+	virtual bool getAuth(const std::string &playername, std::string *dst_password,
+			std::set<std::string> *dst_privs)
+	{
+		return false;
+	}
+	virtual void createAuth(
+			const std::string &playername, const std::string &password)
+	{
+	}
+	virtual bool setPassword(
+			const std::string &playername, const std::string &password)
+	{
+		return false;
+	}
+};
+}
+}

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -225,7 +225,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
 		m_messages_out.push(aom);
-		m_env->getScriptIface()->player_event(this, "properties_changed");
+		m_env->getApiRouter()->player_event(this, "properties_changed");
 	}
 
 	// If attached, check that our parent is still there. If it isn't, detach.
@@ -462,7 +462,7 @@ u16 PlayerSAO::punch(v3f dir,
 
 	PlayerSAO *playersao = m_player->getPlayerSAO();
 
-	bool damage_handled = m_env->getScriptIface()->on_punchplayer(playersao,
+	bool damage_handled = m_env->getApiRouter()->on_punchplayer(playersao,
 				puncher, time_from_last_punch, toolcap, dir,
 				hitparams.hp);
 
@@ -492,7 +492,7 @@ void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
 	hp = rangelim(hp, 0, m_prop.hp_max);
 
 	if (oldhp != hp) {
-		s32 hp_change = m_env->getScriptIface()->on_player_hpchange(this, hp - oldhp, reason);
+		s32 hp_change = m_env->getApiRouter()->on_player_hpchange(this, hp - oldhp, reason);
 		if (hp_change == 0)
 			return;
 

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -172,7 +172,7 @@ void UnitSAO::onAttach(int parent_id)
 
 	if (parent->getType() == ACTIVEOBJECT_TYPE_LUAENTITY) {
 		// Call parent's on_attach field
-		m_env->getScriptIface()->luaentity_on_attach_child(parent_id, this);
+		m_env->getApiRouter()->luaentity_on_attach_child(parent_id, this);
 	}
 }
 
@@ -183,13 +183,13 @@ void UnitSAO::onDetach(int parent_id)
 
 	ServerActiveObject *parent = m_env->getActiveObject(parent_id);
 	if (getType() == ACTIVEOBJECT_TYPE_LUAENTITY)
-		m_env->getScriptIface()->luaentity_on_detach(m_id, parent);
+		m_env->getApiRouter()->luaentity_on_detach(m_id, parent);
 
 	if (!parent || parent->isGone())
 		return; // Do not try to notify soon gone parent
 
 	if (parent->getType() == ACTIVEOBJECT_TYPE_LUAENTITY)
-		m_env->getScriptIface()->luaentity_on_detach_child(parent_id, this);
+		m_env->getApiRouter()->luaentity_on_detach_child(parent_id, this);
 }
 
 ObjectProperties *UnitSAO::accessObjectProperties()

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -392,11 +392,11 @@ void ActiveBlockList::update(std::vector<PlayerSAO*> &active_players,
 static std::random_device seed;
 
 ServerEnvironment::ServerEnvironment(ServerMap *map,
-	ServerScripting *scriptIface, Server *server,
+	api::server::Router *router, Server *server,
 	const std::string &path_world):
 	Environment(server),
 	m_map(map),
-	m_script(scriptIface),
+	m_api_router(router),
 	m_server(server),
 	m_path_world(path_world),
 	m_rgen(seed())
@@ -980,7 +980,7 @@ void ServerEnvironment::activateBlock(MapBlock *block, u32 additional_dtime)
 		for (const NodeTimer &elapsed_timer : elapsed_timers) {
 			n = block->getNodeNoEx(elapsed_timer.position);
 			v3s16 p = elapsed_timer.position + block->getPosRelative();
-			if (m_script->node_on_timer(p, n, elapsed_timer.elapsed))
+			if (m_api_router->node_on_timer(p, n, elapsed_timer.elapsed))
 				block->setNodeTimer(NodeTimer(elapsed_timer.timeout, 0,
 					elapsed_timer.position));
 		}
@@ -1006,7 +1006,7 @@ bool ServerEnvironment::setNode(v3s16 p, const MapNode &n)
 
 	// Call destructor
 	if (cf_old.has_on_destruct)
-		m_script->node_on_destruct(p, n_old);
+		m_api_router->node_on_destruct(p, n_old);
 
 	// Replace node
 	if (!m_map->addNodeWithEvent(p, n))
@@ -1017,7 +1017,7 @@ bool ServerEnvironment::setNode(v3s16 p, const MapNode &n)
 
 	// Call post-destructor
 	if (cf_old.has_after_destruct)
-		m_script->node_after_destruct(p, n_old);
+		m_api_router->node_after_destruct(p, n_old);
 
 	// Retrieve node content features
 	// if new node is same as old, reuse old definition to prevent a lookup
@@ -1025,7 +1025,7 @@ bool ServerEnvironment::setNode(v3s16 p, const MapNode &n)
 
 	// Call constructor
 	if (cf_new.has_on_construct)
-		m_script->node_on_construct(p, n);
+		m_api_router->node_on_construct(p, n);
 
 	return true;
 }
@@ -1037,7 +1037,7 @@ bool ServerEnvironment::removeNode(v3s16 p)
 
 	// Call destructor
 	if (ndef->get(n_old).has_on_destruct)
-		m_script->node_on_destruct(p, n_old);
+		m_api_router->node_on_destruct(p, n_old);
 
 	// Replace with air
 	// This is slightly optimized compared to addNodeWithEvent(air)
@@ -1049,7 +1049,7 @@ bool ServerEnvironment::removeNode(v3s16 p)
 
 	// Call post-destructor
 	if (ndef->get(n_old).has_after_destruct)
-		m_script->node_after_destruct(p, n_old);
+		m_api_router->node_after_destruct(p, n_old);
 
 	// Air doesn't require constructor
 	return true;
@@ -1086,7 +1086,7 @@ void ServerEnvironment::clearObjects(ClearObjectsMode mode)
 		// Tell the object about removal
 		obj->removingFromEnvironment();
 		// Deregister in scripting api
-		m_script->removeObjectReference(obj);
+		m_api_router->removeObjectReference(obj);
 
 		// Delete active object
 		if (obj->environmentDeletes())
@@ -1331,7 +1331,7 @@ void ServerEnvironment::step(float dtime)
 				for (const NodeTimer &elapsed_timer: elapsed_timers) {
 					n = block->getNodeNoEx(elapsed_timer.position);
 					p2 = elapsed_timer.position + block->getPosRelative();
-					if (m_script->node_on_timer(p2, n, elapsed_timer.elapsed)) {
+					if (m_api_router->node_on_timer(p2, n, elapsed_timer.elapsed)) {
 						block->setNodeTimer(NodeTimer(
 							elapsed_timer.timeout, 0, elapsed_timer.position));
 					}
@@ -1394,7 +1394,7 @@ void ServerEnvironment::step(float dtime)
 	/*
 		Step script environment (run global on_step())
 	*/
-	m_script->environment_Step(dtime);
+	m_api_router->environment_Step(dtime);
 
 	/*
 		Step active objects
@@ -1655,7 +1655,7 @@ u16 ServerEnvironment::addActiveObjectRaw(ServerActiveObject *object,
 	}
 
 	// Register reference in scripting api (must be done before post-init)
-	m_script->addObjectReference(object);
+	m_api_router->addObjectReference(object);
 	// Post-initialize object
 	object->addedToEnvironment(dtime_s);
 
@@ -1745,7 +1745,7 @@ void ServerEnvironment::removeRemovedObjects()
 		// Tell the object about removal
 		obj->removingFromEnvironment();
 		// Deregister in scripting api
-		m_script->removeObjectReference(obj);
+		m_api_router->removeObjectReference(obj);
 
 		// Delete
 		if (obj->environmentDeletes())
@@ -2003,7 +2003,7 @@ void ServerEnvironment::deactivateFarObjects(bool _force_delete)
 		// Tell the object about removal
 		obj->removingFromEnvironment();
 		// Deregister in scripting api
-		m_script->removeObjectReference(obj);
+		m_api_router->removeObjectReference(obj);
 
 		// Delete active object
 		if (obj->environmentDeletes())

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -28,6 +28,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <set>
 #include <random>
 
+namespace api { namespace server {
+class Router;
+}}
 class IGameDef;
 class ServerMap;
 struct GameParams;
@@ -41,7 +44,7 @@ class ActiveBlockModifier;
 struct StaticObject;
 class ServerActiveObject;
 class Server;
-class ServerScripting;
+class Settings;
 
 /*
 	{Active, Loading} block modifier interface.
@@ -201,7 +204,7 @@ typedef std::unordered_map<u16, ServerActiveObject *> ServerActiveObjectMap;
 class ServerEnvironment : public Environment
 {
 public:
-	ServerEnvironment(ServerMap *map, ServerScripting *scriptIface,
+	ServerEnvironment(ServerMap *map, api::server::Router *router,
 		Server *server, const std::string &path_world);
 	~ServerEnvironment();
 
@@ -210,8 +213,8 @@ public:
 	ServerMap & getServerMap();
 
 	//TODO find way to remove this fct!
-	ServerScripting* getScriptIface()
-	{ return m_script; }
+	api::server::Router* getApiRouter()
+	{ return m_api_router; }
 
 	Server *getGameDef()
 	{ return m_server; }
@@ -421,8 +424,8 @@ private:
 
 	// The map
 	ServerMap *m_map;
-	// Lua state
-	ServerScripting* m_script;
+	// Api callback router
+	api::server::Router* m_api_router;
 	// Server definition
 	Server *m_server;
 	// Active Object Manager


### PR DESCRIPTION
This permit anybody to implement callback abstraction layer for any
language he wants.

The overhead of this if very very minimal on each api call, regarding the heaviness of the lua code which runs after calling this abstract layer.

The layer is intended to be run on server part only. Client has no sense to have other extension language than Lua as other are generally not so portable. It's intended to permit anyone with c++ skills to implement his own layer (JS, Python, Ruby, C++, PHP) layer behind minetest API to perform his calls

It implements stub libminetestapi.so permitting anyone to implement bindings on the api modules.

If we say we are an engine, engines are extensible, and yeah this usecase is one of the powerful possibilities to make an engine better :)

## To do

This PR is a Work in Progress

- [x] Review the code done by myself on github to ensure no callbacks are inverted
- [ ] Discuss about original function naming (rename some to have consistency across modules
- [x] Split module on the router permitting to have specialized modules only

## How to test

build & test, it just works
