### PR TITLE
Make bgcolor tint button background images

### DIFF
--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -164,7 +164,7 @@ local style_fs = [[
 	style[one_btn14:hovered+pressed;textcolor=purple]
 	image_button[0,9.6;1,1;testformspec_button_image.png;one_btn14;Bg]
 
-	style[one_btn15;border=false;bgimg=testformspec_bg.png;bgimg_hovered=testformspec_bg_hovered.png;bgimg_pressed=testformspec_bg_pressed.png]
+	style[one_btn15;border=false;bgcolor=#1cc;bgimg=testformspec_bg.png;bgimg_hovered=testformspec_bg_hovered.png;bgimg_pressed=testformspec_bg_pressed.png]
 	item_image_button[1.25,9.6;1,1;testformspec:item;one_btn15;Bg]
 
 	style[one_btn16;border=false;bgimg=testformspec_bg_9slice.png;bgimg_hovered=testformspec_bg_9slice_hovered.png;bgimg_pressed=testformspec_bg_9slice_pressed.png;bgimg_middle=4,6]

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -172,11 +172,8 @@ void draw2DImageFilterScaled(video::IVideoDriver *driver, video::ITexture *txr,
 
 void draw2DImage9Slice(video::IVideoDriver *driver, video::ITexture *texture,
 		const core::rect<s32> &rect, const core::rect<s32> &middle,
-		const core::rect<s32> *cliprect)
+		const core::rect<s32> *cliprect, const video::SColor *const colors)
 {
-	const video::SColor color(255,255,255,255);
-	const video::SColor colors[] = {color,color,color,color};
-
 	auto originalSize = texture->getOriginalSize();
 	core::vector2di lowerRightOffset = core::vector2di(originalSize.Width, originalSize.Height) - middle.LowerRightCorner;
 

--- a/src/client/guiscalingfilter.h
+++ b/src/client/guiscalingfilter.h
@@ -54,4 +54,5 @@ void draw2DImageFilterScaled(video::IVideoDriver *driver, video::ITexture *txr,
  */
 void draw2DImage9Slice(video::IVideoDriver *driver, video::ITexture *texture,
 		const core::rect<s32> &rect, const core::rect<s32> &middle,
-		const core::rect<s32> *cliprect = nullptr);
+		const core::rect<s32> *cliprect = nullptr,
+		const video::SColor *const colors = nullptr);

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -313,11 +313,12 @@ void GUIButton::draw()
 
 		// PATCH
 		video::ITexture* texture = ButtonImages[(u32)imageState].Texture;
+		video::SColor image_colors[] = { BgColor, BgColor, BgColor, BgColor };
 		if (BgMiddle.getArea() == 0) {
 			driver->draw2DImage(texture,
 					ScaleImage? AbsoluteRect : core::rect<s32>(pos, sourceRect.getSize()),
 					sourceRect, &AbsoluteClippingRect,
-					0, UseAlphaChannel);
+					image_colors, UseAlphaChannel);
 		} else {
 			core::rect<s32> middle = BgMiddle;
 			// `-x` is interpreted as `w - x`
@@ -327,7 +328,7 @@ void GUIButton::draw()
 				middle.LowerRightCorner.Y += texture->getOriginalSize().Height;
 			draw2DImage9Slice(driver, texture,
 					ScaleImage ? AbsoluteRect : core::rect<s32>(pos, sourceRect.getSize()),
-					middle, &AbsoluteClippingRect);
+					middle, &AbsoluteClippingRect, image_colors);
 		}
 		// END PATCH
 	}
@@ -722,6 +723,8 @@ GUIButton* GUIButton::addButton(IGUIEnvironment *environment,
 
 void GUIButton::setColor(video::SColor color)
 {
+	BgColor = color;
+
 	float d = 0.65f;
 	for (size_t i = 0; i < 4; i++) {
 		video::SColor base = Environment->getSkin()->getColor((gui::EGUI_DEFAULT_COLOR)i);
@@ -750,22 +753,26 @@ void GUIButton::setFromStyle(const StyleSpec& style)
 	bool pressed = (style.getState() & StyleSpec::STATE_PRESSED) != 0;
 
 	if (style.isNotDefault(StyleSpec::BGCOLOR)) {
-
 		setColor(style.getColor(StyleSpec::BGCOLOR));
 
 		// If we have a propagated hover/press color, we need to automatically
 		// lighten/darken it
 		if (!Styles[style.getState()].isNotDefault(StyleSpec::BGCOLOR)) {
-			for (size_t i = 0; i < 4; i++) {
 				if (pressed) {
-					Colors[i] = multiplyColorValue(Colors[i], COLOR_PRESSED_MOD);
+					BgColor = multiplyColorValue(BgColor, COLOR_PRESSED_MOD);
+
+					for (size_t i = 0; i < 4; i++)
+						Colors[i] = multiplyColorValue(Colors[i], COLOR_PRESSED_MOD);
 				} else if (hovered) {
-					Colors[i] = multiplyColorValue(Colors[i], COLOR_HOVERED_MOD);
+					BgColor = multiplyColorValue(BgColor, COLOR_HOVERED_MOD);
+
+					for (size_t i = 0; i < 4; i++)
+						Colors[i] = multiplyColorValue(Colors[i], COLOR_HOVERED_MOD);
 				}
-			}
 		}
 
 	} else {
+		BgColor = video::SColor(255, 255, 255, 255);
 		for (size_t i = 0; i < 4; i++) {
 			video::SColor base =
 					Environment->getSkin()->getColor((gui::EGUI_DEFAULT_COLOR)i);

--- a/src/gui/guiButton.h
+++ b/src/gui/guiButton.h
@@ -338,5 +338,6 @@ private:
 	core::rect<s32> BgMiddle;
 	core::rect<s32> Padding;
 	core::vector2d<s32> ContentOffset;
+	video::SColor BgColor;
 	// END PATCH
 };


### PR DESCRIPTION
This PR addresses one of the tasks in #9044 by making the `bgcolor_*` style properties tint button background images. This is very useful, because it lets users potentially set custom background images in a formspec prepend while still benefiting from the ability to make colored buttons.

This PR, like most of my recent button PRs, is relatively simple on the code side. The only notable change is exposing color tint to `draw2DImage9Slice`, but that function already *had* a color tint that it was setting be default so it's not a big change either.

## How to test
I'm still recovering from my health issues, so I haven't gone to the trouble of building a big test mod showcasing the possibilities. However, I've tinted one of the buttons in the `/formspec` styling tab, and further tests should be pretty straightforward: Just use `bgcolor` and `bgimg` on the same button elements.
