### PR TITLE
Error msg if trying to teleport attached player

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -443,6 +443,9 @@ core.register_chatcommand("teleport", {
 			end
 			local teleportee = core.get_player_by_name(name)
 			if teleportee then
+				if teleportee:get_attach() then
+					return false, "Can't teleport, you're attached to an object!"
+				end
 				teleportee:set_pos(p)
 				return true, "Teleporting to "..core.pos_to_string(p)
 			end
@@ -460,6 +463,9 @@ core.register_chatcommand("teleport", {
 		end
 
 		if teleportee and p then
+			if teleportee:get_attach() then
+				return false, "Can't teleport, you're attached to an object!"
+			end
 			p = find_free_position_near(p)
 			teleportee:set_pos(p)
 			return true, "Teleporting to " .. target_name
@@ -480,6 +486,9 @@ core.register_chatcommand("teleport", {
 			teleportee = core.get_player_by_name(teleportee_name)
 		end
 		if teleportee and p.x and p.y and p.z then
+			if teleportee:get_attach() then
+				return false, "Can't teleport, player is attached to an object!"
+			end
 			teleportee:set_pos(p)
 			return true, "Teleporting " .. teleportee_name
 					.. " to " .. core.pos_to_string(p)
@@ -498,6 +507,9 @@ core.register_chatcommand("teleport", {
 			end
 		end
 		if teleportee and p then
+			if teleportee:get_attach() then
+				return false, "Can't teleport, player is attached to an object!"
+			end
 			p = find_free_position_near(p)
 			teleportee:set_pos(p)
 			return true, "Teleporting " .. teleportee_name


### PR DESCRIPTION
Attends to #9823. It does not fix the issue, but it adds an error message to warn the player about what is going on.

Currently, when trying to teleport an attached player with `/teleport`, nothing happens, but the chat claims the teleportation succeeded.

This PR now will display an error message to the player when the teleportee is attached.

Note this PR is only a lightweight usability change to show to the player why the teleportation changed. It is NOT a functional change.