### PR TITLE
Request the dedicated GPU when starting Minetest from the `.desktop` file

### DIFF
--- a/misc/net.minetest.minetest.desktop
+++ b/misc/net.minetest.minetest.desktop
@@ -11,6 +11,7 @@ Comment[tr]=Tek-Çok oyuncuyla küplerden sonsuz dünyalar inşa et
 Exec=minetest
 Icon=minetest
 Terminal=false
+PrefersNonDefaultGPU=true
 Type=Application
 Categories=Game;Simulation;
 StartupNotify=false


### PR DESCRIPTION
See <https://www.hadess.net/2020/05/dual-gpu-support-launch-on-discrete-gpu.html> for more information about this newly added `.desktop` entry property.

## To do

This PR is a Ready for Review.

## How to test

You need a very recent GNOME version for this to work (I don't think it has landed in a stable release yet). Either way, this property has no effect on systems that don't support it, so it should be fine to merge.