### PR TITLE
Revert "Replace non-ASCII characters in gameui debug display code"

### DIFF
--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -128,9 +128,9 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			<< "pos: (" << (player_position.X / BS)
 			<< ", " << (player_position.Y / BS)
 			<< ", " << (player_position.Z / BS)
-			<< ") | yaw: " << (wrapDegrees_0_360(cam.camera_yaw)) << "\xC2\xB0 "
+			<< ") | yaw: " << (wrapDegrees_0_360(cam.camera_yaw)) << "° "
 			<< yawToDirectionString(cam.camera_yaw)
-			<< " | pitch: " << (-wrapDegrees_180(cam.camera_pitch)) << "\xC2\xB0"
+			<< " | pitch: " << (-wrapDegrees_180(cam.camera_pitch)) << "°"
 			<< " | seed: " << ((u64)client->getMapSeed());
 
 		if (pointed_old.type == POINTEDTHING_NODE) {


### PR DESCRIPTION
Reverts minetest/minetest#8821

Reasons:

* PR did not add an explanatory comment and uses cryptic escape codes
* `°` is actually part of extended (8-bit) ASCII / Latin-1, well supported by fonts and found on most standard keyboards
* The previous form was far more readable
* Setting a precedent