### PR TITLE
Fix "static_save = false" causing LuaEntities to never being unloaded.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6644,15 +6644,19 @@ Player properties need to be saved manually.
 
         static_save = true,
         -- If false, never save this object statically. It will simply be
-        -- deleted when the block gets unloaded.
+        -- deleted when the block it is in gets deactivated
+        -- (the active_block_range is left).
         -- The get_staticdata() callback is never called then.
         -- Defaults to 'true'.
+        -- Note: Since deactivated blocks might still be kept loaded, you
+        -- can not use an LBM to respawn entities when they're bound to a node.
 
         damage_texture_modifier = "^[brighten",
         -- Texture modifier to be applied for a short duration when object is hit
 
         shaded = true,
         -- Setting this to 'false' disables diffuse lighting of entity
+
     }
 
 Entity definition

--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -41,7 +41,9 @@ public:
 	virtual void addedToEnvironment(u32 dtime_s);
 	void step(float dtime, bool send_recommended);
 	std::string getClientInitializationData(u16 protocol_version);
-	bool isStaticAllowed() const { return m_prop.static_save; }
+
+	bool shouldSaveStatically() const { return m_prop.static_save; }
+
 	void getStaticData(std::string *result) const;
 	u16 punch(v3f dir, const ToolCapabilities *toolcap = nullptr,
 			ServerActiveObject *puncher = nullptr,

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -82,7 +82,13 @@ public:
 
 	void addedToEnvironment(u32 dtime_s);
 	void removingFromEnvironment();
-	bool isStaticAllowed() const { return false; }
+
+	bool shouldSaveStatically() const { return false; }
+	bool shouldNotUnload() const
+	{
+		return true;
+	} // deactivateFarObjects should not touch these
+
 	std::string getClientInitializationData(u16 protocol_version);
 	void getStaticData(std::string *result) const;
 	void step(float dtime, bool send_recommended);

--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -122,15 +122,25 @@ public:
 	*/
 	virtual void getStaticData(std::string *result) const
 	{
-		assert(isStaticAllowed());
+		assert(shouldSaveStatically());
 		*result = "";
 	}
 	/*
-		Return false in here to never save and instead remove object
-		on unload. getStaticData() will not be called in that case.
+		Whether object should be saved statically in blocks.
+		If set to false, getStaticData is not called and object is removed
+		when it's about to be unloaded.
 	*/
-	virtual bool isStaticAllowed() const
+	virtual bool shouldSaveStatically() const
 	{return true;}
+	
+	/*
+		Whether object should never be unloaded.
+		If true, deactivateFarObjects always skips this object, except in destructor.
+		
+		For more details, see deactivateFarObjects() in serverenvironment.cpp
+	*/
+	virtual bool shouldNotUnload() const
+	{return false;}
 
 	// Returns tool wear
 	virtual u16 punch(v3f dir,

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1662,7 +1662,7 @@ u16 ServerEnvironment::addActiveObjectRaw(ServerActiveObject *object,
 	object->addedToEnvironment(dtime_s);
 
 	// Add static data to block
-	if (object->isStaticAllowed()) {
+	if (object->shouldSaveStatically()) {
 		// Add static object to active static list of the block
 		v3f objectpos = object->getBasePosition();
 		StaticObject s_obj(object, objectpos);
@@ -1892,8 +1892,8 @@ void ServerEnvironment::deactivateFarObjects(bool _force_delete)
 		// force_delete might be overriden per object
 		bool force_delete = _force_delete;
 
-		// Do not deactivate if static data creation not allowed
-		if (!force_delete && !obj->isStaticAllowed())
+		// Do not deactivate if object requires it (e.g. players)
+		if (!force_delete && obj->shouldNotUnload())
 			return false;
 
 		// removeRemovedObjects() is responsible for these
@@ -1935,7 +1935,7 @@ void ServerEnvironment::deactivateFarObjects(bool _force_delete)
 		/*
 			Update the static data
 		*/
-		if (obj->isStaticAllowed()) {
+		if (obj->shouldSaveStatically()) {
 			// Create new static object
 			StaticObject s_obj(obj, objectpos);
 


### PR DESCRIPTION
The intention, and documented behavior behind setting "static_save=false" on entities is that the object is deleted when the block it resides in gets unloaded. Instead, the current behavior is to skip these objects and keep them loaded until the server shuts down. This PR corrects this behavior.

The "isStaticAllowed()" carried two semantics: 1. object can not be saved statically in blocks and 2. object should not be unloaded when block gets unloaded. This PR splits this function into two, one for each of the semantics. Players have shouldNotUnload()=true set.

Blockhead and gpcf discovered this problem on LinuxForks server. It caused that wagons from advtrains were never unloaded and consumed CPU, even if they were travelling through unloaded terrain.

## How to test

Create a world with advtrains enabled, place a train, and check in verbose log that the wagons are unloaded when you go away.

EDIT: the force-push was to resolve linter complaints