### PR TITLE
Damage texture modifier

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6546,7 +6546,7 @@ Player properties need to be saved manually.
         -- Defaults to 'true'.
 
         damage_texture_modifier = "^[brighten",
-        -- By default "^[brighten", texture modifier to be applied when object is hit
+        -- Texture modifier to be applied for a short duration when object is hit
     }
 
 Entity definition

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6544,6 +6544,9 @@ Player properties need to be saved manually.
         -- deleted when the block gets unloaded.
         -- The get_staticdata() callback is never called then.
         -- Defaults to 'true'.
+
+        damage_texture_modifier = "^[brighten",
+        -- By default "^[brighten", texture modifier to be applied when object is hit
     }
 
 Entity definition

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1691,7 +1691,7 @@ bool GenericCAO::directReportPunch(v3f dir, const ItemStack *punchitem,
 					v2f(m_prop.visual_size.X, m_prop.visual_size.Y) * BS);
 			m_env->addSimpleObject(simple);
 		}
-		if (m_reset_textures_timer < 0) {
+		if (m_reset_textures_timer < 0 && !m_prop.damage_texture_modifier.empty()) {
 			m_reset_textures_timer = 0.05;
 			if (result.damage >= 2)
 				m_reset_textures_timer += 0.05 * result.damage;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1502,7 +1502,7 @@ void GenericCAO::processMessage(const std::string &data)
 	} else if (cmd == AO_CMD_SET_TEXTURE_MOD) {
 		std::string mod = deSerializeString(is);
 
-		// immediatly reset a engine issued texture modifier if a mod sends a different one
+		// immediately reset a engine issued texture modifier if a mod sends a different one
 		if (m_reset_textures_timer > 0) {
 			m_reset_textures_timer = -1;
 			updateTextures(m_previous_texture_modifier);
@@ -1622,7 +1622,7 @@ void GenericCAO::processMessage(const std::string &data)
 				m_reset_textures_timer = 0.05;
 				if(damage >= 2)
 					m_reset_textures_timer += 0.05 * damage;
-				updateTextures(m_current_texture_modifier + "^[brighten");
+				updateTextures(m_current_texture_modifier + m_prop.damage_flash_texture_modifier);
 			}
 		}
 
@@ -1699,7 +1699,7 @@ bool GenericCAO::directReportPunch(v3f dir, const ItemStack *punchitem,
 			m_reset_textures_timer = 0.05;
 			if (result.damage >= 2)
 				m_reset_textures_timer += 0.05 * result.damage;
-			updateTextures(m_current_texture_modifier + "^[brighten");
+			updateTextures(m_current_texture_modifier + m_prop.damage_flash_texture_modifier);
 		}
 	}
 

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1699,7 +1699,7 @@ bool GenericCAO::directReportPunch(v3f dir, const ItemStack *punchitem,
 			m_reset_textures_timer = 0.05;
 			if (result.damage >= 2)
 				m_reset_textures_timer += 0.05 * result.damage;
-			updateTextures(m_current_texture_modifier + m_prop.damage_flash_texture_modifier);
+			updateTextures(m_current_texture_modifier + m_prop.damage_texture_modifier);
 		}
 	}
 

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1616,7 +1616,7 @@ void GenericCAO::processMessage(const std::string &data)
 						m_smgr, m_env, m_position,
 						v2f(m_prop.visual_size.X, m_prop.visual_size.Y) * BS);
 				m_env->addSimpleObject(simple);
-			} else if (m_reset_textures_timer < 0) {
+			} else if (m_reset_textures_timer < 0 && !m_prop.damage_texture_modifier.empty()) {
 				m_reset_textures_timer = 0.05;
 				if(damage >= 2)
 					m_reset_textures_timer += 0.05 * damage;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1622,7 +1622,7 @@ void GenericCAO::processMessage(const std::string &data)
 				m_reset_textures_timer = 0.05;
 				if(damage >= 2)
 					m_reset_textures_timer += 0.05 * damage;
-				updateTextures(m_current_texture_modifier + m_prop.damage_flash_texture_modifier);
+				updateTextures(m_current_texture_modifier + m_prop.damage_texture_modifier);
 			}
 		}
 
@@ -1693,8 +1693,6 @@ bool GenericCAO::directReportPunch(v3f dir, const ItemStack *punchitem,
 					v2f(m_prop.visual_size.X, m_prop.visual_size.Y) * BS);
 			m_env->addSimpleObject(simple);
 		}
-		// TODO: Execute defined fast response
-		// Flashing shall suffice as there is no definition
 		if (m_reset_textures_timer < 0) {
 			m_reset_textures_timer = 0.05;
 			if (result.damage >= 2)

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1617,8 +1617,6 @@ void GenericCAO::processMessage(const std::string &data)
 						v2f(m_prop.visual_size.X, m_prop.visual_size.Y) * BS);
 				m_env->addSimpleObject(simple);
 			} else if (m_reset_textures_timer < 0) {
-				// TODO: Execute defined fast response
-				// Flashing shall suffice as there is no definition
 				m_reset_textures_timer = 0.05;
 				if(damage >= 2)
 					m_reset_textures_timer += 0.05 * damage;

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -68,6 +68,7 @@ std::string ObjectProperties::dump()
 	os << ", eye_height=" << eye_height;
 	os << ", zoom_fov=" << zoom_fov;
 	os << ", use_texture_alpha=" << use_texture_alpha;
+	os << ", damage_texture_modifier=" << damage_texture_modifier;
 	return os.str();
 }
 
@@ -167,5 +168,7 @@ void ObjectProperties::deSerialize(std::istream &is)
 	eye_height = readF32(is);
 	zoom_fov = readF32(is);
 	use_texture_alpha = readU8(is);
-	damage_texture_modifier = deSerializeString(is);
+	try {
+		damage_texture_modifier = deSerializeString(is);
+	} catch (SerializationError &e) {}
 }

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -114,6 +114,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeF32(os, eye_height);
 	writeF32(os, zoom_fov);
 	writeU8(os, use_texture_alpha);
+	os << serializeString(damage_flash_texture_modifier);
 
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
@@ -166,4 +167,5 @@ void ObjectProperties::deSerialize(std::istream &is)
 	eye_height = readF32(is);
 	zoom_fov = readF32(is);
 	use_texture_alpha = readU8(is);
+	damage_flash_texture_modifier = deSerializeString(is);
 }

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -114,7 +114,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeF32(os, eye_height);
 	writeF32(os, zoom_fov);
 	writeU8(os, use_texture_alpha);
-	os << serializeString(damage_flash_texture_modifier);
+	os << serializeString(damage_texture_modifier);
 
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
@@ -167,5 +167,5 @@ void ObjectProperties::deSerialize(std::istream &is)
 	eye_height = readF32(is);
 	zoom_fov = readF32(is);
 	use_texture_alpha = readU8(is);
-	damage_flash_texture_modifier = deSerializeString(is);
+	damage_texture_modifier = deSerializeString(is);
 }

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -39,7 +39,7 @@ struct ObjectProperties
 	std::string mesh = "";
 	v3f visual_size = v3f(1, 1, 1);
 	std::vector<std::string> textures;
-	std::string damage_flash_texture_modifier = "^[brighten";
+	std::string damage_texture_modifier = "^[brighten";
 	std::vector<video::SColor> colors;
 	v2s16 spritediv = v2s16(1, 1);
 	v2s16 initial_sprite_basepos;

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -39,6 +39,7 @@ struct ObjectProperties
 	std::string mesh = "";
 	v3f visual_size = v3f(1, 1, 1);
 	std::vector<std::string> textures;
+	std::string damage_flash_texture_modifier = "^[brighten";
 	std::vector<video::SColor> colors;
 	v2s16 spritediv = v2s16(1, 1);
 	v2s16 initial_sprite_basepos;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -324,7 +324,7 @@ void read_object_properties(lua_State *L, int index,
 	getfloatfield(L, -1, "zoom_fov", prop->zoom_fov);
 	getboolfield(L, -1, "use_texture_alpha", prop->use_texture_alpha);
 
-	getstringfield(L, -1, "damage_flash_texture_modifier", prop->damage_flash_texture_modifier);
+	getstringfield(L, -1, "damage_texture_modifier", prop->damage_texture_modifier);
 }
 
 /******************************************************************************/
@@ -407,8 +407,8 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "zoom_fov");
 	lua_pushboolean(L, prop->use_texture_alpha);
 	lua_setfield(L, -2, "use_texture_alpha");
-	lua_pushlstring(L, prop->damage_flash_texture_modifier.c_str(), prop->damage_flash_texture_modifier.size());
-	lua_setfield(L, -2, "damage_flash_texture_modifier");
+	lua_pushlstring(L, prop->damage_texture_modifier.c_str(), prop->damage_texture_modifier.size());
+	lua_setfield(L, -2, "damage_texture_modifier");
 }
 
 /******************************************************************************/

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -323,6 +323,8 @@ void read_object_properties(lua_State *L, int index,
 
 	getfloatfield(L, -1, "zoom_fov", prop->zoom_fov);
 	getboolfield(L, -1, "use_texture_alpha", prop->use_texture_alpha);
+
+	getstringfield(L, -1, "damage_flash_texture_modifier", prop->damage_flash_texture_modifier);
 }
 
 /******************************************************************************/
@@ -405,6 +407,8 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "zoom_fov");
 	lua_pushboolean(L, prop->use_texture_alpha);
 	lua_setfield(L, -2, "use_texture_alpha");
+	lua_pushlstring(L, prop->damage_flash_texture_modifier.c_str(), prop->damage_flash_texture_modifier.size());
+	lua_setfield(L, -2, "damage_flash_texture_modifier");
 }
 
 /******************************************************************************/


### PR DESCRIPTION
- Implements damage texture modifiers
- Adds a new object property `damage_texture_modifier`
- Closes #9607

## To do

This PR is Ready for Review.

## How to test

```lua
minetest.register_on_joinplayer(function(player)
    player:set_properties{damage_texture_modifier = "^[invert:rgb"}
end)
```