### PR TITLE
Improve performance of Camera::update

### DIFF
--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -112,8 +112,8 @@ public:
 		return MYMAX(m_fov_x, m_fov_y);
 	}
 
-	// Notify about new server-sent FOV and initialize smooth FOV transition
-	void notifyFovChange();
+	// Retrieve new server-sent FOV and initialize smooth FOV transition if required
+	void initServerSentFov();
 
 	// Checks if the constructor was able to create the scene nodes
 	bool successfullyCreated(std::string &error_message);
@@ -176,6 +176,9 @@ public:
 	inline void addArmInertia(f32 player_yaw);
 
 private:
+	// FOV-getter helper method
+	void updateCurrentFov(f32 frametime, f32 zoom_fov = 0.0f);
+
 	// Nodes
 	scene::ISceneNode *m_playernode = nullptr;
 	scene::ISceneNode *m_headnode = nullptr;
@@ -203,9 +206,17 @@ private:
 	bool m_server_sent_fov = false;
 	f32 m_curr_fov_degrees, m_old_fov_degrees, m_target_fov_degrees;
 
+	// Whether FOV needs to be updated.
+	// Used for server-sent FOV, zoom FOV, etc.
+	bool m_fov_dirty = false;
+
+	bool m_zoom_key_pressed = false;
+
 	// FOV transition variables
 	bool m_fov_transition_active = false;
 	f32 m_fov_diff, m_transition_time;
+
+	v2u32 m_window_size;
 
 	v2f m_wieldmesh_offset = v2f(55.0f, -35.0f);
 	v2f m_arm_dir;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -545,7 +545,7 @@ void Client::handleCommand_Fov(NetworkPacket *pkt)
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player);
 	player->setFov({ fov, is_multiplier, transition_time });
-	m_camera->notifyFovChange();
+	m_camera->initServerSentFov();
 }
 
 void Client::handleCommand_HP(NetworkPacket *pkt)


### PR DESCRIPTION
- Update `m_curr_fov_degrees` only if FOV value needs changing.
- Update aspect ratio and related calculation only when FOV or window size changes.

****

This is a performance-oriented PR. **It shouldn't introduce any behavioural changes to the existing code** - if it does, punch me in the face. While working on e0ea87f1, I noticed that a lot of code was unnecessarily being executed on every single run of `Camera::update`. Now:

- All of the FOV and aspect ratio calculating code has been moved to a separate private member function `Camera::updateCurrentFov` (will rename this to include aspect ratio calculations); `updateCurrentFov` is run only when FOV or aspect ratio needs updating.
- For :point_up_2: to happen, some of the data that was obtained at runtime before needs to be cached as class members now (like current window size).
- The function `Camera::notifyFovChange` (introduced in e0ea87f1) has been renamed to `Camera::initServerSentFov` to better describe its purpose.

****

I came across one weird issue while trying to measure the performance improvements: I wasn't able to notice a distinctive reduction in execution times of `Camera::update` (even when I measured only the changed FOV-and-aspect-ratio segment of the function). The function takes ~0.06ms in both branches, but what's weirder is that I get similar times, even if I time only the changed segments between the two branches (encapsulating only the FOV and aspect ratio calculations). So I'm suspecting the issue is at least partly on my side. I'm using `porting::getTimeMs` and `g_profiler->avg` to calculate the elapsed time, btw.

While there's the possibility that the code is somehow wrong, and `updateCurrentFov` is called all the time, I've tested this using debug statements and I can confidently say that isn't the case - the function is called if and only if at least one of the following conditions are true:

- Server-sent FOV update.
- Smooth FOV transition.
- `zoom_fov > 0.001f` and zoom key pressed.
- `zoom_fov` applied and zoom key released.
- Window is resized (aspect ratio needs to be re-calculated).

This leads me to believe that I'm somehow timing this incorrectly. It'd be very helpful if someone else could time the `Camera::update` function both in `master` and in this PR, and post their results here. I really hope this PR actually makes a difference - it ideally should, as a lot of the code that needlessly runs all the time now runs only if required.

****

### TODO

- Rename `Camera::m_fov_dirty` to a more generic name that indicates both FOV and aspect ratio updates.
- Rename `Camera::updateCurrentFov` to also describe aspect ratio re-calculation.

Suggestions for both renames welcome.

Apart from the TODOs, this PR is ready for review. I can confirm the following scenarios to work as expected (tested with and without print statements):

- Server-sent FOV changes, smooth FOV transitions.
- Zoom FOV toggling.
- Window resizing.
- Smooth transition interruptions.