### PR TITLE
Rework functionality of leveled nodes

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -126,14 +126,19 @@ core.register_entity(":__builtin:falling_node", {
 		-- Set collision box (certain nodeboxes only for now)
 		local nb_types = {fixed=true, leveled=true, connected=true}
 		if def.drawtype == "nodebox" and def.node_box and
-			nb_types[def.node_box.type] and type(def.node_box.fixed[1]) ~= "table" then
+			nb_types[def.node_box.type] then
 			local box = table.copy(def.node_box.fixed)
-			if def.paramtype2 == "leveled" and (self.node.level or 0) > 0 then
-				box[5] = -0.5 + self.node.level / 64
+			if type(box[1]) == "table" then
+				box = #box == 1 and box[1] or nil -- We can only use a single box
 			end
-			self.object:set_properties({
-				collisionbox = box
-			})
+			if box then
+				if def.paramtype2 == "leveled" and (self.node.level or 0) > 0 then
+					box[5] = -0.5 + self.node.level / 64
+				end
+				self.object:set_properties({
+					collisionbox = box
+				})
+			end
 		end
 
 		-- Rotate entity

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -199,7 +199,7 @@ core.register_entity(":__builtin:falling_node", {
 		if bcd and bcd.paramtype2 == "leveled" and
 				bcn.name == self.node.name then
 			local addlevel = self.node.param2 % 128
-			if bcd.leveled and addlevel == 0 then
+			if addlevel == 0 and bcd.leveled then
 				addlevel = bcd.leveled
 			end
 			if core.add_node_level(bcp, addlevel) == 0 then

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -463,16 +463,16 @@ function core.check_single_for_falling(p)
 			local same = n.name == n_bottom.name
 			-- Let leveled nodes fall if it can merge with the bottom node
 			if same and d_bottom.paramtype2 == "leveled" and
-				core.get_node_level(p_bottom) <
-				core.get_node_max_level(p_bottom) then
+					core.get_node_level(p_bottom) <
+					core.get_node_max_level(p_bottom) then
 				convert_to_falling_node(p, n)
 				return true
 			end
 			-- Otherwise only if the bottom node is considered "fall through"
 			if not same and
-				(not d_bottom.walkable or d_bottom.buildable_to) and
-				(core.get_item_group(n.name, "float") == 0 or
-				d_bottom.liquidtype == "none") then
+					(not d_bottom.walkable or d_bottom.buildable_to) and
+					(core.get_item_group(n.name, "float") == 0 or
+					d_bottom.liquidtype == "none") then
 				convert_to_falling_node(p, n)
 				return true
 			end

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -196,10 +196,10 @@ core.register_entity(":__builtin:falling_node", {
 	try_place = function(self, bcp, bcn)
 		local bcd = core.registered_nodes[bcn.name]
 		-- Add levels if dropped on same leveled node
-		if bcd and bcd.leveled and
+		if bcd and bcd.paramtype2 == "leveled" and
 				bcn.name == self.node.name then
-			local addlevel = self.node.level
-			if not addlevel or addlevel <= 0 then
+			local addlevel = self.node.param2 % 128
+			if bcd.leveled and addlevel == 0 then
 				addlevel = bcd.leveled
 			end
 			if core.add_node_level(bcp, addlevel) == 0 then
@@ -441,7 +441,8 @@ function core.check_single_for_falling(p)
 				(core.get_item_group(n.name, "float") == 0 or
 				d_bottom.liquidtype == "none") and
 
-				(n.name ~= n_bottom.name or (d_bottom.leveled and
+				(n.name ~= n_bottom.name or
+				(d_bottom.paramtype2 == "leveled" and
 				core.get_node_level(p_bottom) <
 				core.get_node_max_level(p_bottom))) and
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7002,7 +7002,11 @@ Used by `minetest.register_node`.
         -- Only valid for "nodebox" drawtype with 'type = "leveled"'.
         -- Allows defining the nodebox height without using param2.
         -- The nodebox height is 'leveled' / 64 nodes.
-        -- The maximum value of 'leveled' is 127.
+        -- The maximum value of 'leveled' is `leveled_max`.
+
+        leveled_max = 127,
+        -- Maximum value for `leveled` (0-127), enforced in
+        -- `minetest.set_node_level` and `minetest.add_node_level`.
 
         liquid_range = 8,  -- Number of flowing nodes around source (max. 8)
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4872,7 +4872,7 @@ Environment access
 * `minetest.add_node_level(pos, level)`
     * increase level of leveled node by level, default `level` equals `1`
     * if `totallevel > maxlevel`, returns rest (`total-max`)
-    * can be negative for decreasing
+    * `level` must be between -127 and 127
 * `minetest.fix_light(pos1, pos2)`: returns `true`/`false`
     * resets the light in a cuboid-shaped part of
       the map and removes lighting bugs.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6998,7 +6998,7 @@ Used by `minetest.register_node`.
         -- If true, a new liquid source can be created by placing two or more
         -- sources nearby
 
-        leveled = 16,
+        leveled = 0,
         -- Only valid for "nodebox" drawtype with 'type = "leveled"'.
         -- Allows defining the nodebox height without using param2.
         -- The nodebox height is 'leveled' / 64 nodes.

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -608,9 +608,9 @@ u8 MapNode::getLevel(const NodeDefManager *nodemgr) const
 	return f.leveled;
 }
 
-u8 MapNode::setLevel(const NodeDefManager *nodemgr, s8 level)
+s8 MapNode::setLevel(const NodeDefManager *nodemgr, s16 level)
 {
-	u8 rest = 0;
+	s8 rest = 0;
 	const ContentFeatures &f = nodemgr->get(*this);
 	if (f.param_type_2 == CPT2_FLOWINGLIQUID
 			|| f.liquid_type == LIQUID_FLOWING
@@ -640,21 +640,11 @@ u8 MapNode::setLevel(const NodeDefManager *nodemgr, s8 level)
 	return rest;
 }
 
-u8 MapNode::addLevel(const NodeDefManager *nodemgr, s8 add)
+s8 MapNode::addLevel(const NodeDefManager *nodemgr, s16 add)
 {
-	s16 tmpLevel = getLevel(nodemgr);
-	tmpLevel += add;
-	u8 rest = 0;
-	if (tmpLevel > LEVELED_MAX) {
-		rest = tmpLevel - LEVELED_MAX;
-		tmpLevel = LEVELED_MAX;
-	} else if (tmpLevel < 0) {
-		rest = -tmpLevel;
-		tmpLevel = 0;
-	}
-	s8 level = (s8) tmpLevel;
-	setLevel(nodemgr, level);
-	return rest;
+	s16 level = getLevel(nodemgr);
+	level += add;
+	return setLevel(nodemgr, level);
 }
 
 u32 MapNode::serializedLength(u8 version)

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -584,7 +584,7 @@ u8 MapNode::getMaxLevel(const NodeDefManager *nodemgr) const
 	if( f.liquid_type == LIQUID_FLOWING || f.param_type_2 == CPT2_FLOWINGLIQUID)
 		return LIQUID_LEVEL_MAX;
 	if(f.leveled || f.param_type_2 == CPT2_LEVELED)
-		return LEVELED_MAX;
+		return f.leveled_max;
 	return 0;
 }
 
@@ -603,8 +603,8 @@ u8 MapNode::getLevel(const NodeDefManager *nodemgr) const
 		if (level)
 			return level;
 	}
-	if (f.leveled > LEVELED_MAX)
-		return LEVELED_MAX;
+	if (f.leveled > f.leveled_max)
+		return f.leveled_max;
 	return f.leveled;
 }
 
@@ -631,9 +631,9 @@ s8 MapNode::setLevel(const NodeDefManager *nodemgr, s16 level)
 		if (level < 0) { // zero means default for a leveled nodebox
 			rest = level;
 			level = 0;
-		} else if (level > LEVELED_MAX) {
-			rest = level - LEVELED_MAX;
-			level = LEVELED_MAX;
+		} else if (level > f.leveled_max) {
+			rest = level - f.leveled_max;
+			level = f.leveled_max;
 		}
 		setParam2((level & LEVELED_MASK) | (getParam2() & ~LEVELED_MASK));
 	}

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -642,9 +642,19 @@ u8 MapNode::setLevel(const NodeDefManager *nodemgr, s8 level)
 
 u8 MapNode::addLevel(const NodeDefManager *nodemgr, s8 add)
 {
-	s8 level = getLevel(nodemgr);
-	level += add;
-	return setLevel(nodemgr, level);
+	s16 tmpLevel = getLevel(nodemgr);
+	tmpLevel += add;
+	u8 rest = 0;
+	if (tmpLevel > LEVELED_MAX) {
+		rest = tmpLevel - LEVELED_MAX;
+		tmpLevel = LEVELED_MAX;
+	} else if (tmpLevel < 0) {
+		rest = -tmpLevel;
+		tmpLevel = 0;
+	}
+	s8 level = (s8) tmpLevel;
+	setLevel(nodemgr, level);
+	return rest;
 }
 
 u32 MapNode::serializedLength(u8 version)

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -603,6 +603,7 @@ u8 MapNode::getLevel(const NodeDefManager *nodemgr) const
 		if (level)
 			return level;
 	}
+	// Return static value from nodedef if param2 isn't used for level
 	if (f.leveled > f.leveled_max)
 		return f.leveled_max;
 	return f.leveled;

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -268,12 +268,12 @@ struct MapNode
 		std::vector<aabb3f> *boxes, u8 neighbors = 0) const;
 
 	/*
-		Liquid helpers
+		Liquid/leveled helpers
 	*/
 	u8 getMaxLevel(const NodeDefManager *nodemgr) const;
 	u8 getLevel(const NodeDefManager *nodemgr) const;
-	u8 setLevel(const NodeDefManager *nodemgr, s8 level = 1);
-	u8 addLevel(const NodeDefManager *nodemgr, s8 add = 1);
+	s8 setLevel(const NodeDefManager *nodemgr, s16 level = 1);
+	s8 addLevel(const NodeDefManager *nodemgr, s16 add = 1);
 
 	/*
 		Serialization functions

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -588,12 +588,11 @@ void ContentFeatures::deSerialize(std::istream &is)
 
 	try {
 		node_dig_prediction = deSerializeString(is);
+		u8 tmp_leveled_max = readU8(is);
+		if (is.eof()) /* readU8 doesn't throw exceptions so we have to do this */
+			throw SerializationError("");
+		leveled_max = tmp_leveled_max;
 	} catch(SerializationError &e) {};
-
-	u8 tmp_leveled_max = readU8(is);
-	if (is.eof())
-		throw SerializationError("Nodedef: Missing leveled_max");
-	leveled_max = tmp_leveled_max;
 }
 
 #ifndef SERVER

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -436,7 +436,6 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 		writeU16(os, connects_to_id);
 	writeARGB8(os, post_effect_color);
 	writeU8(os, leveled);
-	writeU8(os, leveled_max);
 
 	// lighting
 	writeU8(os, light_propagates);
@@ -480,6 +479,7 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	writeU8(os, legacy_wallmounted);
 
 	os << serializeString(node_dig_prediction);
+	writeU8(os, leveled_max);
 }
 
 void ContentFeatures::correctAlpha(TileDef *tiles, int length)
@@ -543,7 +543,6 @@ void ContentFeatures::deSerialize(std::istream &is)
 		connects_to_ids.push_back(readU16(is));
 	post_effect_color = readARGB8(is);
 	leveled = readU8(is);
-	leveled_max = readU8(is);
 
 	// lighting-related
 	light_propagates = readU8(is);
@@ -590,6 +589,11 @@ void ContentFeatures::deSerialize(std::istream &is)
 	try {
 		node_dig_prediction = deSerializeString(is);
 	} catch(SerializationError &e) {};
+
+	u8 tmp_leveled_max = readU8(is);
+	if (is.eof())
+		throw SerializationError("Nodedef: Missing leveled_max");
+	leveled_max = tmp_leveled_max;
 }
 
 #ifndef SERVER

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -368,6 +368,7 @@ void ContentFeatures::reset()
 	floodable = false;
 	rightclickable = true;
 	leveled = 0;
+	leveled_max = LEVELED_MAX;
 	liquid_type = LIQUID_NONE;
 	liquid_alternative_flowing = "";
 	liquid_alternative_source = "";
@@ -435,6 +436,7 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 		writeU16(os, connects_to_id);
 	writeARGB8(os, post_effect_color);
 	writeU8(os, leveled);
+	writeU8(os, leveled_max);
 
 	// lighting
 	writeU8(os, light_propagates);
@@ -541,6 +543,7 @@ void ContentFeatures::deSerialize(std::istream &is)
 		connects_to_ids.push_back(readU16(is));
 	post_effect_color = readARGB8(is);
 	leveled = readU8(is);
+	leveled_max = readU8(is);
 
 	// lighting-related
 	light_propagates = readU8(is);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -326,8 +326,10 @@ struct ContentFeatures
 	std::vector<content_t> connects_to_ids;
 	// Post effect color, drawn when the camera is inside the node.
 	video::SColor post_effect_color;
-	// Flowing liquid or snow, value = default level
+	// Flowing liquid or leveled nodebox, value = default level
 	u8 leveled;
+	// Maximum value for leveled nodes
+	u8 leveled_max;
 
 	// --- LIGHTING-RELATED ---
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -690,6 +690,8 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	f.liquid_range = getintfield_default(L, index,
 			"liquid_range", f.liquid_range);
 	f.leveled = getintfield_default(L, index, "leveled", f.leveled);
+	f.leveled_max = getintfield_default(L, index,
+			"leveled_max", f.leveled_max);
 
 	getboolfield(L, index, "liquid_renewable", f.liquid_renewable);
 	f.drowning = getintfield_default(L, index,
@@ -856,6 +858,8 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 	lua_setfield(L, -2, "post_effect_color");
 	lua_pushnumber(L, c.leveled);
 	lua_setfield(L, -2, "leveled");
+	lua_pushnumber(L, c.leveled_max);
+	lua_setfield(L, -2, "leveled_max");
 	lua_pushboolean(L, c.sunlight_propagates);
 	lua_setfield(L, -2, "sunlight_propagates");
 	lua_pushnumber(L, c.light_source);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -529,13 +529,13 @@ int ModApiEnvMod::l_set_node_level(lua_State *L)
 
 // add_node_level(pos, level)
 // pos = {x=num, y=num, z=num}
-// level: 0..63
+// level: -127..127
 int ModApiEnvMod::l_add_node_level(lua_State *L)
 {
 	GET_ENV_PTR;
 
 	v3s16 pos = read_v3s16(L, 1);
-	u8 level = 1;
+	s16 level = 1;
 	if(lua_isnumber(L, 2))
 		level = lua_tonumber(L, 2);
 	MapNode n = env->getMap().getNode(pos);


### PR DESCRIPTION
## The problem

Falling nodes in `builtin` currently include code that is apparently supposed to handle a leveled node falling into another leveled node of the same type by increasing the node level.

However, this code is completely broken as it made several nonsensical assumptions about the Lua API: E.g. there is `node.level` (which doesn't exist) or `node_definition.leveled` is used to check whether a node is leveled (must check `paramtype2` instead).

Furthermore, the function `minetest.add_node_level`, on which the falling node code relies on, it also broken. If you add a high level value to a node with an already high level, there will be a wrap-around. E.g. `minetest.add_node_level(pos, 50)` when the node level was already 120 results in a wrap-around.

## What this PR does

* When a falling leveled node falls into another leveled node of the same type, the destination node's level is increased (which the code *already* tried to do, but failed to)
* Fixes `minetest.add_node_level` wrapping around. This is done by adding hard caps at 0 and `LEVELED_MAX` (=127).

## Limitations and oddities

1) A node can grow higher than 1 node height with this, because leveled nodes can grow up to 127, which is almost the double height of a single node. But this creates all sorts of oddities and weirdnesses in the falling behavior which are probably not easy to fix.
2) If a leveled node of height 0 falls into a leveled node with heigh 0, the resulting node will not grow. This is intended.
3) While a leveled node falls, the rendering will always use the default height of the node (it pretends `param2` is always 0). If `param2` is not 0, the rendered height of the falling leveled node might be incorrect. This is a separate bug that is out of scope for this PR.

Question: Should I allow nodes to have their level grow larger than 64 (=1 node height) with falling nodes? It might be a good idea to cap the node height to 64 with using falling nodes alone, to keep the code simple.

## HOW TO TEST

* Grab `devtest`
* Take some nodes of type `testnodes:nodebox_leveled`
* Place several of these around
* Set the node height with the Param2 Tool
* Make them fall into each other with the Falling Node Tool
* Try out different `param2` values