### PR TITLE
Allow more than 255 biomes

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7443,6 +7443,10 @@ Biome definition
 
 Used by `minetest.register_biome`.
 
+The maximum number of biomes that can be used is 65535. However, using an
+excessive number of biomes will slow down map generation. Depending on desired
+performance and computing power the practical limit is much lower.
+
     {
         name = "tundra",
 

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -69,7 +69,7 @@ CavesNoiseIntersection::~CavesNoiseIntersection()
 
 
 void CavesNoiseIntersection::generateCaves(MMVManip *vm,
-	v3s16 nmin, v3s16 nmax, u8 *biomemap)
+	v3s16 nmin, v3s16 nmax, u16 *biomemap)
 {
 	assert(vm);
 	assert(biomemap);

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -1,8 +1,8 @@
 /*
 Minetest
-Copyright (C) 2010-2018 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2010-2018 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
-Copyright (C) 2015-2018 paramat
+Copyright (C) 2010-2020 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2015-2020 paramat
+Copyright (C) 2010-2016 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -69,7 +69,7 @@ CavesNoiseIntersection::~CavesNoiseIntersection()
 
 
 void CavesNoiseIntersection::generateCaves(MMVManip *vm,
-	v3s16 nmin, v3s16 nmax, u16 *biomemap)
+	v3s16 nmin, v3s16 nmax, biome_t *biomemap)
 {
 	assert(vm);
 	assert(biomemap);

--- a/src/mapgen/cavegen.h
+++ b/src/mapgen/cavegen.h
@@ -1,7 +1,7 @@
 /*
 Minetest
-Copyright (C) 2010-2018 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
-Copyright (C) 2015-2018 paramat
+Copyright (C) 2015-2020 paramat
+Copyright (C) 2010-2016 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -21,6 +21,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #define VMANIP_FLAG_CAVE VOXELFLAG_CHECKED1
+
+typedef u16 biome_t;  // copy from mg_biome.h to avoid an unnecessary include
 
 class GenerateNotifier;
 
@@ -44,7 +46,7 @@ public:
 		NoiseParams *np_cave2, s32 seed, float cave_width);
 	~CavesNoiseIntersection();
 
-	void generateCaves(MMVManip *vm, v3s16 nmin, v3s16 nmax, u16 *biomemap);
+	void generateCaves(MMVManip *vm, v3s16 nmin, v3s16 nmax, biome_t *biomemap);
 
 private:
 	const NodeDefManager *m_ndef;

--- a/src/mapgen/cavegen.h
+++ b/src/mapgen/cavegen.h
@@ -44,7 +44,7 @@ public:
 		NoiseParams *np_cave2, s32 seed, float cave_width);
 	~CavesNoiseIntersection();
 
-	void generateCaves(MMVManip *vm, v3s16 nmin, v3s16 nmax, u8 *biomemap);
+	void generateCaves(MMVManip *vm, v3s16 nmin, v3s16 nmax, u16 *biomemap);
 
 private:
 	const NodeDefManager *m_ndef;

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -38,7 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MG_DECORATIONS 0x20
 #define MG_BIOMES      0x40
 
-typedef u8 biome_t;  // copy from mg_biome.h to avoid an unnecessary include
+typedef u16 biome_t;  // copy from mg_biome.h to avoid an unnecessary include
 
 class Settings;
 class MMVManip;

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -1,8 +1,8 @@
 /*
 Minetest
-Copyright (C) 2010-2018 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2013-2018 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
-Copyright (C) 2015-2018 paramat
+Copyright (C) 2010-2020 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2015-2020 paramat
+Copyright (C) 2013-2016 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -1,7 +1,7 @@
 /*
 Minetest
-Copyright (C) 2014-2018 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
-Copyright (C) 2014-2018 paramat
+Copyright (C) 2014-2020 paramat
+Copyright (C) 2014-2016 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -32,7 +32,7 @@ class BiomeManager;
 //// Biome
 ////
 
-typedef u8 biome_t;
+typedef u16 biome_t;
 
 #define BIOME_NONE ((biome_t)0)
 

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -206,8 +206,7 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 				// All-surfaces decorations
 				// Check biome of column
 				if (mg->biomemap && !biomes.empty()) {
-					std::unordered_set<u16>::const_iterator iter =
-						biomes.find(mg->biomemap[mapindex]);
+					auto iter = biomes.find(mg->biomemap[mapindex]);
 					if (iter == biomes.end())
 						continue;
 				}
@@ -259,8 +258,7 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 					continue;
 
 				if (mg->biomemap && !biomes.empty()) {
-					std::unordered_set<u16>::const_iterator iter =
-						biomes.find(mg->biomemap[mapindex]);
+					auto iter = biomes.find(mg->biomemap[mapindex]);
 					if (iter == biomes.end())
 						continue;
 				}

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -206,7 +206,7 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 				// All-surfaces decorations
 				// Check biome of column
 				if (mg->biomemap && !biomes.empty()) {
-					std::unordered_set<u8>::const_iterator iter =
+					std::unordered_set<u16>::const_iterator iter =
 						biomes.find(mg->biomemap[mapindex]);
 					if (iter == biomes.end())
 						continue;
@@ -259,7 +259,7 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 					continue;
 
 				if (mg->biomemap && !biomes.empty()) {
-					std::unordered_set<u8>::const_iterator iter =
+					std::unordered_set<u16>::const_iterator iter =
 						biomes.find(mg->biomemap[mapindex]);
 					if (iter == biomes.end())
 						continue;

--- a/src/mapgen/mg_decoration.h
+++ b/src/mapgen/mg_decoration.h
@@ -25,6 +25,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "noise.h"
 #include "nodedef.h"
 
+typedef u16 biome_t;  // copy from mg_biome.h to avoid an unnecessary include
+
 class Mapgen;
 class MMVManip;
 class PcgRandom;
@@ -72,7 +74,7 @@ public:
 	s16 nspawnby;
 	s16 place_offset_y = 0;
 
-	std::unordered_set<u16> biomes;
+	std::unordered_set<biome_t> biomes;
 
 protected:
 	void cloneTo(Decoration *def) const;

--- a/src/mapgen/mg_decoration.h
+++ b/src/mapgen/mg_decoration.h
@@ -72,7 +72,7 @@ public:
 	s16 nspawnby;
 	s16 place_offset_y = 0;
 
-	std::unordered_set<u8> biomes;
+	std::unordered_set<u16> biomes;
 
 protected:
 	void cloneTo(Decoration *def) const;

--- a/src/mapgen/mg_ore.cpp
+++ b/src/mapgen/mg_ore.cpp
@@ -170,7 +170,7 @@ void OreScatter::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 		if (biomemap && !biomes.empty()) {
 			u32 index = sizex * (z0 - nmin.Z) + (x0 - nmin.X);
-			std::unordered_set<u16>::const_iterator it = biomes.find(biomemap[index]);
+			auto it = biomes.find(biomemap[index]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -237,7 +237,7 @@ void OreSheet::generate(MMVManip *vm, int mapseed, u32 blockseed,
 			continue;
 
 		if (biomemap && !biomes.empty()) {
-			std::unordered_set<u16>::const_iterator it = biomes.find(biomemap[index]);
+			auto it = biomes.find(biomemap[index]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -312,7 +312,7 @@ void OrePuff::generate(MMVManip *vm, int mapseed, u32 blockseed,
 			continue;
 
 		if (biomemap && !biomes.empty()) {
-			std::unordered_set<u16>::const_iterator it = biomes.find(biomemap[index]);
+			auto it = biomes.find(biomemap[index]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -388,7 +388,7 @@ void OreBlob::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 		if (biomemap && !biomes.empty()) {
 			u32 bmapidx = sizex * (z0 - nmin.Z) + (x0 - nmin.X);
-			std::unordered_set<u16>::const_iterator it = biomes.find(biomemap[bmapidx]);
+			auto it = biomes.find(biomemap[bmapidx]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -485,7 +485,7 @@ void OreVein::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 		if (biomemap && !biomes.empty()) {
 			u32 bmapidx = sizex * (z - nmin.Z) + (x - nmin.X);
-			std::unordered_set<u16>::const_iterator it = biomes.find(biomemap[bmapidx]);
+			auto it = biomes.find(biomemap[bmapidx]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -560,7 +560,7 @@ void OreStratum::generate(MMVManip *vm, int mapseed, u32 blockseed,
 	for (int z = nmin.Z; z <= nmax.Z; z++)
 	for (int x = nmin.X; x <= nmax.X; x++, index++) {
 		if (biomemap && !biomes.empty()) {
-			std::unordered_set<u16>::const_iterator it = biomes.find(biomemap[index]);
+			auto it = biomes.find(biomemap[index]);
 			if (it == biomes.end())
 				continue;
 		}

--- a/src/mapgen/mg_ore.cpp
+++ b/src/mapgen/mg_ore.cpp
@@ -1,7 +1,7 @@
 /*
 Minetest
-Copyright (C) 2014-2018 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
-Copyright (C) 2015-2018 paramat
+Copyright (C) 2015-2020 paramat
+Copyright (C) 2014-2016 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -146,7 +146,7 @@ ObjDef *OreScatter::clone() const
 
 
 void OreScatter::generate(MMVManip *vm, int mapseed, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, u16 *biomemap)
+	v3s16 nmin, v3s16 nmax, biome_t *biomemap)
 {
 	PcgRandom pr(blockseed);
 	MapNode n_ore(c_ore, 0, ore_param2);
@@ -208,7 +208,7 @@ ObjDef *OreSheet::clone() const
 
 
 void OreSheet::generate(MMVManip *vm, int mapseed, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, u16 *biomemap)
+	v3s16 nmin, v3s16 nmax, biome_t *biomemap)
 {
 	PcgRandom pr(blockseed + 4234);
 	MapNode n_ore(c_ore, 0, ore_param2);
@@ -285,7 +285,7 @@ ObjDef *OrePuff::clone() const
 
 
 void OrePuff::generate(MMVManip *vm, int mapseed, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, u16 *biomemap)
+	v3s16 nmin, v3s16 nmax, biome_t *biomemap)
 {
 	PcgRandom pr(blockseed + 4234);
 	MapNode n_ore(c_ore, 0, ore_param2);
@@ -366,7 +366,7 @@ ObjDef *OreBlob::clone() const
 
 
 void OreBlob::generate(MMVManip *vm, int mapseed, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, u16 *biomemap)
+	v3s16 nmin, v3s16 nmax, biome_t *biomemap)
 {
 	PcgRandom pr(blockseed + 2404);
 	MapNode n_ore(c_ore, 0, ore_param2);
@@ -451,7 +451,7 @@ ObjDef *OreVein::clone() const
 
 
 void OreVein::generate(MMVManip *vm, int mapseed, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, u16 *biomemap)
+	v3s16 nmin, v3s16 nmax, biome_t *biomemap)
 {
 	PcgRandom pr(blockseed + 520);
 	MapNode n_ore(c_ore, 0, ore_param2);
@@ -532,7 +532,7 @@ ObjDef *OreStratum::clone() const
 
 
 void OreStratum::generate(MMVManip *vm, int mapseed, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, u16 *biomemap)
+	v3s16 nmin, v3s16 nmax, biome_t *biomemap)
 {
 	PcgRandom pr(blockseed + 4234);
 	MapNode n_ore(c_ore, 0, ore_param2);

--- a/src/mapgen/mg_ore.cpp
+++ b/src/mapgen/mg_ore.cpp
@@ -146,7 +146,7 @@ ObjDef *OreScatter::clone() const
 
 
 void OreScatter::generate(MMVManip *vm, int mapseed, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, u8 *biomemap)
+	v3s16 nmin, v3s16 nmax, u16 *biomemap)
 {
 	PcgRandom pr(blockseed);
 	MapNode n_ore(c_ore, 0, ore_param2);
@@ -170,7 +170,7 @@ void OreScatter::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 		if (biomemap && !biomes.empty()) {
 			u32 index = sizex * (z0 - nmin.Z) + (x0 - nmin.X);
-			std::unordered_set<u8>::const_iterator it = biomes.find(biomemap[index]);
+			std::unordered_set<u16>::const_iterator it = biomes.find(biomemap[index]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -208,7 +208,7 @@ ObjDef *OreSheet::clone() const
 
 
 void OreSheet::generate(MMVManip *vm, int mapseed, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, u8 *biomemap)
+	v3s16 nmin, v3s16 nmax, u16 *biomemap)
 {
 	PcgRandom pr(blockseed + 4234);
 	MapNode n_ore(c_ore, 0, ore_param2);
@@ -237,7 +237,7 @@ void OreSheet::generate(MMVManip *vm, int mapseed, u32 blockseed,
 			continue;
 
 		if (biomemap && !biomes.empty()) {
-			std::unordered_set<u8>::const_iterator it = biomes.find(biomemap[index]);
+			std::unordered_set<u16>::const_iterator it = biomes.find(biomemap[index]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -285,7 +285,7 @@ ObjDef *OrePuff::clone() const
 
 
 void OrePuff::generate(MMVManip *vm, int mapseed, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, u8 *biomemap)
+	v3s16 nmin, v3s16 nmax, u16 *biomemap)
 {
 	PcgRandom pr(blockseed + 4234);
 	MapNode n_ore(c_ore, 0, ore_param2);
@@ -312,7 +312,7 @@ void OrePuff::generate(MMVManip *vm, int mapseed, u32 blockseed,
 			continue;
 
 		if (biomemap && !biomes.empty()) {
-			std::unordered_set<u8>::const_iterator it = biomes.find(biomemap[index]);
+			std::unordered_set<u16>::const_iterator it = biomes.find(biomemap[index]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -366,7 +366,7 @@ ObjDef *OreBlob::clone() const
 
 
 void OreBlob::generate(MMVManip *vm, int mapseed, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, u8 *biomemap)
+	v3s16 nmin, v3s16 nmax, u16 *biomemap)
 {
 	PcgRandom pr(blockseed + 2404);
 	MapNode n_ore(c_ore, 0, ore_param2);
@@ -388,7 +388,7 @@ void OreBlob::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 		if (biomemap && !biomes.empty()) {
 			u32 bmapidx = sizex * (z0 - nmin.Z) + (x0 - nmin.X);
-			std::unordered_set<u8>::const_iterator it = biomes.find(biomemap[bmapidx]);
+			std::unordered_set<u16>::const_iterator it = biomes.find(biomemap[bmapidx]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -451,7 +451,7 @@ ObjDef *OreVein::clone() const
 
 
 void OreVein::generate(MMVManip *vm, int mapseed, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, u8 *biomemap)
+	v3s16 nmin, v3s16 nmax, u16 *biomemap)
 {
 	PcgRandom pr(blockseed + 520);
 	MapNode n_ore(c_ore, 0, ore_param2);
@@ -485,7 +485,7 @@ void OreVein::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 		if (biomemap && !biomes.empty()) {
 			u32 bmapidx = sizex * (z - nmin.Z) + (x - nmin.X);
-			std::unordered_set<u8>::const_iterator it = biomes.find(biomemap[bmapidx]);
+			std::unordered_set<u16>::const_iterator it = biomes.find(biomemap[bmapidx]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -532,7 +532,7 @@ ObjDef *OreStratum::clone() const
 
 
 void OreStratum::generate(MMVManip *vm, int mapseed, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, u8 *biomemap)
+	v3s16 nmin, v3s16 nmax, u16 *biomemap)
 {
 	PcgRandom pr(blockseed + 4234);
 	MapNode n_ore(c_ore, 0, ore_param2);
@@ -560,7 +560,7 @@ void OreStratum::generate(MMVManip *vm, int mapseed, u32 blockseed,
 	for (int z = nmin.Z; z <= nmax.Z; z++)
 	for (int x = nmin.X; x <= nmax.X; x++, index++) {
 		if (biomemap && !biomes.empty()) {
-			std::unordered_set<u8>::const_iterator it = biomes.find(biomemap[index]);
+			std::unordered_set<u16>::const_iterator it = biomes.find(biomemap[index]);
 			if (it == biomes.end())
 				continue;
 		}

--- a/src/mapgen/mg_ore.h
+++ b/src/mapgen/mg_ore.h
@@ -66,7 +66,7 @@ public:
 	float nthresh;      // threshold for noise at which an ore is placed
 	NoiseParams np;     // noise for distribution of clusters (NULL for uniform scattering)
 	Noise *noise = nullptr;
-	std::unordered_set<u16> biomes;
+	std::unordered_set<biome_t> biomes;
 
 	Ore() = default;;
 	virtual ~Ore();

--- a/src/mapgen/mg_ore.h
+++ b/src/mapgen/mg_ore.h
@@ -1,7 +1,7 @@
 /*
 Minetest
-Copyright (C) 2014-2018 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
-Copyright (C) 2015-2018 paramat
+Copyright (C) 2015-2020 paramat
+Copyright (C) 2014-2016 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -24,6 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "objdef.h"
 #include "noise.h"
 #include "nodedef.h"
+
+typedef u16 biome_t;  // copy from mg_biome.h to avoid an unnecessary include
 
 class Noise;
 class Mapgen;
@@ -73,7 +75,7 @@ public:
 
 	size_t placeOre(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u16 *biomemap) = 0;
+		v3s16 nmin, v3s16 nmax, biome_t *biomemap) = 0;
 
 protected:
 	void cloneTo(Ore *def) const;
@@ -86,7 +88,7 @@ public:
 	ObjDef *clone() const;
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u16 *biomemap);
+		v3s16 nmin, v3s16 nmax, biome_t *biomemap);
 };
 
 class OreSheet : public Ore {
@@ -100,7 +102,7 @@ public:
 	float column_midpoint_factor;
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u16 *biomemap);
+		v3s16 nmin, v3s16 nmax, biome_t *biomemap);
 };
 
 class OrePuff : public Ore {
@@ -118,7 +120,7 @@ public:
 	virtual ~OrePuff();
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u16 *biomemap);
+		v3s16 nmin, v3s16 nmax, biome_t *biomemap);
 };
 
 class OreBlob : public Ore {
@@ -128,7 +130,7 @@ public:
 	ObjDef *clone() const;
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u16 *biomemap);
+		v3s16 nmin, v3s16 nmax, biome_t *biomemap);
 };
 
 class OreVein : public Ore {
@@ -145,7 +147,7 @@ public:
 	virtual ~OreVein();
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u16 *biomemap);
+		v3s16 nmin, v3s16 nmax, biome_t *biomemap);
 };
 
 class OreStratum : public Ore {
@@ -162,7 +164,7 @@ public:
 	virtual ~OreStratum();
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u16 *biomemap);
+		v3s16 nmin, v3s16 nmax, biome_t *biomemap);
 };
 
 class OreManager : public ObjDefManager {

--- a/src/mapgen/mg_ore.h
+++ b/src/mapgen/mg_ore.h
@@ -64,7 +64,7 @@ public:
 	float nthresh;      // threshold for noise at which an ore is placed
 	NoiseParams np;     // noise for distribution of clusters (NULL for uniform scattering)
 	Noise *noise = nullptr;
-	std::unordered_set<u8> biomes;
+	std::unordered_set<u16> biomes;
 
 	Ore() = default;;
 	virtual ~Ore();
@@ -73,7 +73,7 @@ public:
 
 	size_t placeOre(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u8 *biomemap) = 0;
+		v3s16 nmin, v3s16 nmax, u16 *biomemap) = 0;
 
 protected:
 	void cloneTo(Ore *def) const;
@@ -86,7 +86,7 @@ public:
 	ObjDef *clone() const;
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u8 *biomemap);
+		v3s16 nmin, v3s16 nmax, u16 *biomemap);
 };
 
 class OreSheet : public Ore {
@@ -100,7 +100,7 @@ public:
 	float column_midpoint_factor;
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u8 *biomemap);
+		v3s16 nmin, v3s16 nmax, u16 *biomemap);
 };
 
 class OrePuff : public Ore {
@@ -118,7 +118,7 @@ public:
 	virtual ~OrePuff();
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u8 *biomemap);
+		v3s16 nmin, v3s16 nmax, u16 *biomemap);
 };
 
 class OreBlob : public Ore {
@@ -128,7 +128,7 @@ public:
 	ObjDef *clone() const;
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u8 *biomemap);
+		v3s16 nmin, v3s16 nmax, u16 *biomemap);
 };
 
 class OreVein : public Ore {
@@ -145,7 +145,7 @@ public:
 	virtual ~OreVein();
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u8 *biomemap);
+		v3s16 nmin, v3s16 nmax, u16 *biomemap);
 };
 
 class OreStratum : public Ore {
@@ -162,7 +162,7 @@ public:
 	virtual ~OreStratum();
 
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, u8 *biomemap);
+		v3s16 nmin, v3s16 nmax, u16 *biomemap);
 };
 
 class OreManager : public ObjDefManager {

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -97,7 +97,7 @@ Biome *get_or_load_biome(lua_State *L, int index,
 	BiomeManager *biomemgr);
 Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef);
 size_t get_biome_list(lua_State *L, int index,
-	BiomeManager *biomemgr, std::unordered_set<u16> *biome_id_list);
+	BiomeManager *biomemgr, std::unordered_set<biome_t> *biome_id_list);
 
 Schematic *get_or_load_schematic(lua_State *L, int index,
 	SchematicManager *schemmgr, StringMap *replace_names);
@@ -425,7 +425,7 @@ Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef)
 
 
 size_t get_biome_list(lua_State *L, int index,
-	BiomeManager *biomemgr, std::unordered_set<u16> *biome_id_list)
+	BiomeManager *biomemgr, std::unordered_set<biome_t> *biome_id_list)
 {
 	if (index < 0)
 		index = lua_gettop(L) + 1 + index;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -97,7 +97,7 @@ Biome *get_or_load_biome(lua_State *L, int index,
 	BiomeManager *biomemgr);
 Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef);
 size_t get_biome_list(lua_State *L, int index,
-	BiomeManager *biomemgr, std::unordered_set<u8> *biome_id_list);
+	BiomeManager *biomemgr, std::unordered_set<u16> *biome_id_list);
 
 Schematic *get_or_load_schematic(lua_State *L, int index,
 	SchematicManager *schemmgr, StringMap *replace_names);
@@ -425,7 +425,7 @@ Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef)
 
 
 size_t get_biome_list(lua_State *L, int index,
-	BiomeManager *biomemgr, std::unordered_set<u8> *biome_id_list)
+	BiomeManager *biomemgr, std::unordered_set<u16> *biome_id_list)
 {
 	if (index < 0)
 		index = lua_gettop(L) + 1 + index;

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -21,6 +21,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "lua_api/l_base.h"
 
+typedef u16 biome_t;  // copy from mg_biome.h to avoid an unnecessary include
+
 class ModApiMapgen : public ModApiBase
 {
 private:


### PR DESCRIPTION
Closes #9694 

~As far as i can tell~ the limitation to 255 (in master branch) only occurs in the biomemap, as that is the only place 'biome_t' is used.
The early testing in the issue seemed to show that if the biomemap is not used, more than 255 biomes are possible (in a crude way). However, placement of decorations, oregen and cavegen all depend on the biomemap, so much would be broken.