### PR TITLE
Allow placing auto-rotating nodes on other nodes in on_rightclick

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -290,7 +290,8 @@ if INIT == "game" then
 			return
 		end
 		local undef = core.registered_nodes[unode.name]
-		if undef and undef.on_rightclick then
+		local sneaking = placer and placer:get_player_control().sneak
+		if undef and undef.on_rightclick and not sneaking then
 			return undef.on_rightclick(pointed_thing.under, unode, placer,
 					itemstack, pointed_thing)
 		end


### PR DESCRIPTION
- Goal of the PR
Nodes that call on_place=minetest.rotate_node cannot be placed off of nodes with on_rightclick defined, even if shifting. This PR fixes this bug.

- How does the PR work?
Before calling on_rightclick in rotate_and_place, check that the player is not sneaking.

- Does it resolve any reported issue?
In MTG, default:tree and its variants as well as default:cactus cannot be placed off of chests. A similar bug is present in MineClone 2. A minimal reproducible example mod is below, where testmod:treelike cannot be placed off of testmod:chestlike, but will instead call the on_rightclick of testmod:chestlike, even if the player is sneaking:

```lua
minetest.register_node("testmod:treelike", {
  groups = {oddly_breakable_by_hand = 3},
  on_place = minetest.rotate_node
})

minetest.register_node("testmod:chestlike", {
  groups = {oddly_breakable_by_hand = 3},
  on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
    minetest.chat_send_all("Right Clicked")
  end
})
```

## To do

This PR is Ready for Review.

## How to test
1. Start Minetest Game
2. Place a tree on a chest


Copy of #9856
I accidentally deleted my previous pull request