### PR TITLE
network: Replace a fatal_error with just error logging

### DIFF
--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -336,11 +336,9 @@ bool ConnectionSendThread::rawSendAsPacket(session_t peer_id, u8 channelnum,
 {
 	PeerHelper peer = m_connection->getPeerNoEx(peer_id);
 	if (!peer) {
-		LOG(dout_con << m_connection->getDesc()
-			<< " INFO: dropped packet for non existent peer_id: "
-			<< peer_id << std::endl);
-		FATAL_ERROR_IF(!reliable,
-			"Trying to send raw packet reliable but no peer found!");
+		LOG(errorstream << m_connection->getDesc()
+			<< " dropped " << (reliable ? "reliable " : "")
+			<< "packet for non existent peer_id: " << peer_id << std::endl);
 		return false;
 	}
 	Channel *channel = &(dynamic_cast<UDPPeer *>(&peer)->channels[channelnum]);


### PR DESCRIPTION
There *should* be no way for the peer to just disappear at that point.
But if it does we don't gain anything by taking down the whole server.

## To do

This PR is a Ready for Review.
