### PR TITLE
Items: on_wield and on_unwield callbacks implemented

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6887,7 +6887,7 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         -- Shall drop item and return the leftover itemstack.
         -- The dropper may be any ObjectRef or nil.
         -- default: minetest.item_drop
-        
+
         on_wield = function(itemstack, user),
         -- default: nil
         -- Called when the player switches to this item in the hotbar.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6890,7 +6890,7 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         
         on_wield = function(itemstack, user),
         -- default: nil
-        -- It defines the behaviour of an item when it's wielded by a player.
+        -- Called when the player switches to this item in the hotbar.
         -- The user may be any ObjectRef or nil.
 
         on_use = function(itemstack, user, pointed_thing),

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6893,6 +6893,11 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         -- Called when the player switches to this item in the hotbar.
         -- The user may be any ObjectRef or nil.
 
+        on_unwield = function(itemstack, user),
+         -- default: nil
+         -- Called when the player switches from this item to another slot in the hotbar.
+         -- The user may be any ObjectRef or nil.
+
         on_use = function(itemstack, user, pointed_thing),
         -- default: nil
         -- Function must return either nil if no item shall be removed from

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6887,6 +6887,11 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         -- Shall drop item and return the leftover itemstack.
         -- The dropper may be any ObjectRef or nil.
         -- default: minetest.item_drop
+        
+        on_wield = function(itemstack, user),
+        -- default: nil
+        -- It defines the behaviour of an item when it's wielded by a player.
+        -- The user may be any ObjectRef or nil.
 
         on_use = function(itemstack, user, pointed_thing),
         -- default: nil

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -614,7 +614,7 @@ struct FpsControl {
 
 /* The reason the following structs are not anonymous structs within the
  * class is that they are not used by the majority of member functions and
- * many functions that do require objects of thse types do not modify them
+ * many functions that do require objects of these types do not modify them
  * (so they can be passed as a const qualified parameter)
  */
 
@@ -2036,6 +2036,7 @@ void Game::processItemSelection(u16 *new_playeritem)
 		*new_playeritem = *new_playeritem < max_item ? *new_playeritem + 1 : 0;
 	else if (dir > 0)
 		*new_playeritem = *new_playeritem > 0 ? *new_playeritem - 1 : max_item;
+
 	// else dir == 0
 
 	/* Item selection using hotbar slot keys

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2036,7 +2036,6 @@ void Game::processItemSelection(u16 *new_playeritem)
 		*new_playeritem = *new_playeritem < max_item ? *new_playeritem + 1 : 0;
 	else if (dir > 0)
 		*new_playeritem = *new_playeritem > 0 ? *new_playeritem - 1 : max_item;
-
 	// else dir == 0
 
 	/* Item selection using hotbar slot keys

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -531,6 +531,17 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		}
 	}
 
+	if (from_inv.type == InventoryLocation::PLAYER || to_inv.type == InventoryLocation::PLAYER){
+		// if it's moved in the selected slot and there are no items like such already
+		if (to_i == player->getWieldIndex() &&
+			to_stack_was.name != src_item.name)
+			PLAYER_TO_SA(player)->item_OnWield(src_item, player);
+		// if the whole stack is moved away from the selected slot
+		else if (from_i == player->getWieldIndex() &&
+				 count == from_stack_was.count)
+			PLAYER_TO_SA(player)->item_OnUnwield(src_item, player);
+	}
+
 	mgr->setInventoryModified(from_inv);
 	if (inv_from != inv_to)
 		mgr->setInventoryModified(to_inv);
@@ -679,6 +690,11 @@ void IDropAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 
 			if (item2.count != actually_dropped_count)
 				errorstream<<"Could not take dropped count of items"<<std::endl;
+
+			// If players drop the last item in the stack they had in hand
+			if (from_i == player->getWieldIndex() &&
+					(src_item.count - actually_dropped_count == 0))
+				PLAYER_TO_SA(player)->item_OnUnwield(item2, player);
 		}
 
 		src_item.count = actually_dropped_count;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -858,6 +858,10 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 
 	*pkt >> item;
 
+	ItemStack previous_item;
+	playersao->getWieldedItem(&previous_item, nullptr);
+	m_script->item_OnUnWield(previous_item, playersao);
+
 	playersao->getPlayer()->setWieldIndex(item);
 
 	ItemStack selected_item;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -860,7 +860,7 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 
 	ItemStack previous_item;
 	playersao->getWieldedItem(&previous_item, nullptr);
-	m_script->item_OnUnWield(previous_item, playersao);
+	m_script->item_OnUnwield(previous_item, playersao);
 
 	playersao->getPlayer()->setWieldIndex(item);
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -858,15 +858,16 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 
 	*pkt >> item;
 
-	ItemStack previous_item;
-	playersao->getWieldedItem(&previous_item, nullptr);
-	m_script->item_OnUnwield(previous_item, playersao);
-
-	playersao->getPlayer()->setWieldIndex(item);
-
 	ItemStack selected_item;
-	playersao->getWieldedItem(&selected_item, nullptr);
-	m_script->item_OnWield(selected_item, playersao);
+	player->getWieldedItem(&selected_item, nullptr);
+	if (!selected_item.empty())
+		m_script->item_OnUnwield(selected_item, playersao);
+
+	player->setWieldIndex(item);
+
+	player->getWieldedItem(&selected_item, nullptr);
+	if (!selected_item.empty())
+		m_script->item_OnWield(selected_item, playersao);
 }
 
 void Server::handleCommand_Respawn(NetworkPacket* pkt)

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -859,6 +859,10 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 	*pkt >> item;
 
 	playersao->getPlayer()->setWieldIndex(item);
+
+    ItemStack selected_item;
+    playersao->getWieldedItem(&selected_item, nullptr);
+    m_script->item_OnWield(selected_item, playersao);
 }
 
 void Server::handleCommand_Respawn(NetworkPacket* pkt)

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -860,9 +860,9 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 
 	playersao->getPlayer()->setWieldIndex(item);
 
-    ItemStack selected_item;
-    playersao->getWieldedItem(&selected_item, nullptr);
-    m_script->item_OnWield(selected_item, playersao);
+	ItemStack selected_item;
+	playersao->getWieldedItem(&selected_item, nullptr);
+	m_script->item_OnWield(selected_item, playersao);
 }
 
 void Server::handleCommand_Respawn(NetworkPacket* pkt)

--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -88,6 +88,25 @@ bool ScriptApiItem::item_OnPlace(ItemStack &item,
 	return true;
 }
 
+bool ScriptApiItem::item_OnWield(const ItemStack &item,
+    ServerActiveObject *user)
+{
+	SCRIPTAPI_PRECHECKHEADER
+	
+	int error_handler = PUSH_ERROR_HANDLER(L);
+	
+	// Push callback function on stack
+	if (!getItemCallback(item.name.c_str(), "on_wield"))
+	  return false;
+		
+	// Call function
+	LuaItemStack::create(L, item);
+	objectrefGetOrCreate(L, user);
+	PCALL_RES(lua_pcall(L, 2, 1, error_handler));
+	lua_pop(L, 2);  // Pop item and error handler
+	return true;
+}
+
 bool ScriptApiItem::item_OnUse(ItemStack &item,
 		ServerActiveObject *user, const PointedThing &pointed)
 {
@@ -260,4 +279,3 @@ void ScriptApiItem::pushPointedThing(const PointedThing &pointed, bool hitpoint)
 
 	push_pointed_thing(L, pointed, false, hitpoint);
 }
-

--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -107,7 +107,7 @@ bool ScriptApiItem::item_OnWield(const ItemStack &item,
 	return true;
 }
 
-bool ScriptApiItem::item_OnUnWield(const ItemStack &item,
+bool ScriptApiItem::item_OnUnwield(const ItemStack &item,
 		ServerActiveObject *user)
 {
 	SCRIPTAPI_PRECHECKHEADER

--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -107,6 +107,25 @@ bool ScriptApiItem::item_OnWield(const ItemStack &item,
 	return true;
 }
 
+bool ScriptApiItem::item_OnUnWield(const ItemStack &item,
+		ServerActiveObject *user)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
+	// Push callback function on stack
+	if (!getItemCallback(item.name.c_str(), "on_unwield"))
+		return false;
+
+	// Call function
+	LuaItemStack::create(L, item);
+	objectrefGetOrCreate(L, user);
+	PCALL_RES(lua_pcall(L, 2, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
+	return true;
+}
+
 bool ScriptApiItem::item_OnUse(ItemStack &item,
 		ServerActiveObject *user, const PointedThing &pointed)
 {

--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -89,7 +89,7 @@ bool ScriptApiItem::item_OnPlace(ItemStack &item,
 }
 
 bool ScriptApiItem::item_OnWield(const ItemStack &item,
-    ServerActiveObject *user)
+		ServerActiveObject *user)
 {
 	SCRIPTAPI_PRECHECKHEADER
 	
@@ -102,8 +102,8 @@ bool ScriptApiItem::item_OnWield(const ItemStack &item,
 	// Call function
 	LuaItemStack::create(L, item);
 	objectrefGetOrCreate(L, user);
-	PCALL_RES(lua_pcall(L, 2, 1, error_handler));
-	lua_pop(L, 2);  // Pop item and error handler
+	PCALL_RES(lua_pcall(L, 2, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 	return true;
 }
 

--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -92,13 +92,13 @@ bool ScriptApiItem::item_OnWield(const ItemStack &item,
 		ServerActiveObject *user)
 {
 	SCRIPTAPI_PRECHECKHEADER
-	
+
 	int error_handler = PUSH_ERROR_HANDLER(L);
-	
+
 	// Push callback function on stack
 	if (!getItemCallback(item.name.c_str(), "on_wield"))
-	  return false;
-		
+		return false;
+
 	// Call function
 	LuaItemStack::create(L, item);
 	objectrefGetOrCreate(L, user);

--- a/src/script/cpp_api/s_item.h
+++ b/src/script/cpp_api/s_item.h
@@ -39,6 +39,8 @@ public:
 			ServerActiveObject *dropper, v3f pos);
 	bool item_OnPlace(ItemStack &item,
 			ServerActiveObject *placer, const PointedThing &pointed);
+	bool item_OnWield(const ItemStack &item,
+			ServerActiveObject *user);
 	bool item_OnUse(ItemStack &item,
 			ServerActiveObject *user, const PointedThing &pointed);
 	bool item_OnSecondaryUse(ItemStack &item,

--- a/src/script/cpp_api/s_item.h
+++ b/src/script/cpp_api/s_item.h
@@ -41,7 +41,7 @@ public:
 			ServerActiveObject *placer, const PointedThing &pointed);
 	bool item_OnWield(const ItemStack &item,
 			ServerActiveObject *user);
-	bool item_OnUnWield(const ItemStack &item,
+	bool item_OnUnwield(const ItemStack &item,
 			ServerActiveObject *user);
 	bool item_OnUse(ItemStack &item,
 			ServerActiveObject *user, const PointedThing &pointed);

--- a/src/script/cpp_api/s_item.h
+++ b/src/script/cpp_api/s_item.h
@@ -41,6 +41,8 @@ public:
 			ServerActiveObject *placer, const PointedThing &pointed);
 	bool item_OnWield(const ItemStack &item,
 			ServerActiveObject *user);
+	bool item_OnUnWield(const ItemStack &item,
+			ServerActiveObject *user);
 	bool item_OnUse(ItemStack &item,
 			ServerActiveObject *user, const PointedThing &pointed);
 	bool item_OnSecondaryUse(ItemStack &item,

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -360,8 +360,16 @@ u16 LuaEntitySAO::punch(v3f dir,
 			&tool_item,
 			time_from_last_punch);
 
+	ItemStack old_selected_item;
+	puncher->getWieldedItem(&old_selected_item, nullptr);
+
 	bool damage_handled = m_env->getScriptIface()->luaentity_Punch(m_id, puncher,
 			time_from_last_punch, toolcap, dir, result.did_punch ? result.damage : 0);
+
+	puncher->getWieldedItem(&selected_item, nullptr);
+	// If LUA script added something to the selected slot launch item_OnWield
+	if (old_selected_item != selected_item)
+		puncher->getEnv()->getScriptIface()->item_OnWield(selected_item, puncher);
 
 	if (!damage_handled) {
 		if (result.did_punch) {


### PR DESCRIPTION
- Goal of the PR
Add two new callbacks
- If not a bug fix, why is this PR needed? What usecases does it solve?
It adds two callbacks when an item is wielded and unwielded

## To do

 Ready for Review.

## How to test

Register a new node and assign the on_wield and the on_unwield callbacks 
`on_wield = function(itemstack, user)`
`on_unwield = function(itemstack, user)`
