### PR TITLE
[no squash] Lua API: Add boolean method ItemStack:compare

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5733,6 +5733,7 @@ an itemstring, a table or `nil`.
   stack).
 * `set_metadata(metadata)`: (DEPRECATED) Returns true.
 * `get_description()`: returns the description shown in inventory list tooltips.
+* `compare(item)`: returns `true` if this stack is equal to `item`.
 * `clear()`: removes all items from the stack, making it empty.
 * `replace(item)`: replace the contents of this stack.
     * `item` can also be an itemstring or table.

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -184,6 +184,18 @@ int LuaItemStack::l_get_description(lua_State *L)
 	return 1;
 }
 
+// compare(self, itemstack)
+int LuaItemStack::l_compare(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	const ItemStack stack_a = checkobject(L, 1)->getItem();
+	const ItemStack stack_b = checkobject(L, 2)->getItem();
+	lua_pushboolean(L, stack_a == stack_b);
+
+	return 1;
+}
+
 // clear(self) -> true
 int LuaItemStack::l_clear(lua_State *L)
 {
@@ -482,6 +494,7 @@ const luaL_Reg LuaItemStack::methods[] = {
 	luamethod(LuaItemStack, get_metadata),
 	luamethod(LuaItemStack, set_metadata),
 	luamethod(LuaItemStack, get_description),
+	luamethod(LuaItemStack, compare),
 	luamethod(LuaItemStack, clear),
 	luamethod(LuaItemStack, replace),
 	luamethod(LuaItemStack, to_string),

--- a/src/script/lua_api/l_item.h
+++ b/src/script/lua_api/l_item.h
@@ -69,6 +69,9 @@ private:
 	// get_description(self)
 	static int l_get_description(lua_State *L);
 
+	// compare(self, itemstack)
+	static int l_compare(lua_State *L);
+
 	// clear(self) -> true
 	static int l_clear(lua_State *L);
 

--- a/src/unittest/test_inventory.cpp
+++ b/src/unittest/test_inventory.cpp
@@ -32,6 +32,7 @@ public:
 	void runTests(IGameDef *gamedef);
 
 	void testSerializeDeserialize(IItemDefManager *idef);
+	void testItemStackComparison();
 
 	static const char *serialized_inventory_in;
 	static const char *serialized_inventory_out;
@@ -43,6 +44,7 @@ static TestInventory g_test_instance;
 void TestInventory::runTests(IGameDef *gamedef)
 {
 	TEST(testSerializeDeserialize, gamedef->getItemDefManager());
+	TEST(testItemStackComparison);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -78,6 +80,31 @@ void TestInventory::testSerializeDeserialize(IItemDefManager *idef)
 	leftover = inv.getList("main")->getItem(7);
 	wanted.count = 12;
 	UASSERT(leftover == wanted);
+}
+
+void TestInventory::testItemStackComparison()
+{
+	ItemStack stack_a, stack_b;
+	UASSERT(stack_a == stack_b);
+
+	ItemStackMetadata meta_a, meta_b;
+	sanity_check(meta_a.setString("key", "meta_a"));
+	sanity_check(meta_b.setString("key", "meta_b"));
+
+	stack_a.name = "stack_a";
+	stack_b.name = "stack_b";
+	UASSERT(stack_a != stack_b);
+
+	stack_a.name  = stack_b.name  = "stack";
+	stack_a.count = stack_b.count = 42;
+	stack_a.wear  = stack_b.wear  = 666;
+	stack_a.metadata = meta_a;
+	stack_b.metadata = meta_b;
+	UASSERT(stack_a != stack_b);
+
+	stack_b.metadata = meta_a;
+	UASSERT(stack_a.metadata == stack_b.metadata);
+	UASSERT(stack_a == stack_b);
 }
 
 const char *TestInventory::serialized_inventory_in =


### PR DESCRIPTION
This PR adds a convenience method to the Lua API, `ItemStack:compare`, that allows mods to compare two itemstacks in a more straight-forward way (i.e. in one single function call). This PR can be considered as a follow-up to 8e3b63b.

Tested; works. This PR is Ready for Review.

### Summary of changes

- New Lua API method - `ItemStack:compare(item)`.
  - Returns `true` if the stack is equal to `item`.
- New unit-test in `TestInventory` module to ensure consistency in a variety of ItemStack comparisons. Please note that this is my first time working with unit-tests in MT; please don't punch me in my (arguably) handsome face if I didn't observe certain conventions.

### Example

```lua
if item:compare(another_item) then
	-- item and another_item are equal, do something wacky
end
```

### Testing instructions

- Launch MT from command-line with the `--run-unittests` argument, like so:

  `minetest --run-unittests`

  All tests should pass.

- Use the following chat-command in-game:

  ```lua
  minetest.register_chatcommand("compare_stack", {
  	func = function()
  		local stack1, stack2
  		stack1 = ItemStack("default:stone 42 666")
  		stack2 = ItemStack(stack1)
  		assert(stack1:compare(stack2))
  		assert(stack2:compare(stack1))
  
  		stack1:get_meta():set_string("key", "stack1")
  		stack2:get_meta():set_string("key", "stack2")
  		assert(not stack1:compare(stack2))
  		assert(not stack2:compare(stack1))
  
  		return true, "Tests completed successfully!"
  	end
  })
  ```

  All assertions should pass, and you should be able to see `Tests completed successfully!` displayed in chat.