### PR TITLE
[NO SQUASH] Three misc changes

### DIFF
--- a/builtin/mainmenu/async_event.lua
+++ b/builtin/mainmenu/async_event.lua
@@ -8,15 +8,7 @@ local function handle_job(jobid, serialized_retval)
 	core.async_jobs[jobid] = nil
 end
 
-if core.register_globalstep then
-	core.register_globalstep(function(dtime)
-		for i, job in ipairs(core.get_finished_jobs()) do
-			handle_job(job.jobid, job.retval)
-		end
-	end)
-else
-	core.async_event_handler = handle_job
-end
+core.async_event_handler = handle_job
 
 function core.handle_async(func, parameter, callback)
 	-- Serialize function

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -20,20 +20,18 @@ mt_color_blue  = "#6389FF"
 mt_color_green = "#72FF63"
 mt_color_dark_green = "#25C191"
 
---for all other colors ask sfan5 to complete his work!
-
 local menupath = core.get_mainmenu_path()
 local basepath = core.get_builtin_path()
 local menustyle = core.settings:get("main_menu_style")
 defaulttexturedir = core.get_texturepath_share() .. DIR_DELIM .. "base" ..
 					DIR_DELIM .. "pack" .. DIR_DELIM
 
-dofile(basepath .. "common" .. DIR_DELIM .. "async_event.lua")
 dofile(basepath .. "common" .. DIR_DELIM .. "filterlist.lua")
 dofile(basepath .. "fstk" .. DIR_DELIM .. "buttonbar.lua")
 dofile(basepath .. "fstk" .. DIR_DELIM .. "dialog.lua")
 dofile(basepath .. "fstk" .. DIR_DELIM .. "tabview.lua")
 dofile(basepath .. "fstk" .. DIR_DELIM .. "ui.lua")
+dofile(menupath .. DIR_DELIM .. "async_event.lua")
 dofile(menupath .. DIR_DELIM .. "common.lua")
 dofile(menupath .. DIR_DELIM .. "pkgmgr.lua")
 dofile(menupath .. DIR_DELIM .. "textures.lua")

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -64,6 +64,14 @@ extern gui::IGUIEnvironment* guienv;
 	Utility classes
 */
 
+u32 PacketCounter::sum() const
+{
+	u32 n = 0;
+	for (const auto &it : m_packets)
+		n += it.second;
+	return n;
+}
+
 void PacketCounter::print(std::ostream &o) const
 {
 	for (const auto &it : m_packets) {
@@ -357,9 +365,11 @@ void Client::step(float dtime)
 		if(counter <= 0.0f)
 		{
 			counter = 30.0f;
+			u32 sum = m_packetcounter.sum();
+			float avg = sum / counter;
 
-			infostream << "Client packetcounter (" << m_packetcounter_timer
-					<< "s):"<<std::endl;
+			infostream << "Client packetcounter (" << counter << "s): "
+					<< "sum=" << sum << " avg=" << avg << "/s" << std::endl;
 			m_packetcounter.print(infostream);
 			m_packetcounter.clear();
 		}

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -94,11 +94,12 @@ public:
 		m_packets.clear();
 	}
 
+	u32 sum() const;
 	void print(std::ostream &o) const;
 
 private:
 	// command, count
-	std::map<u16, u16> m_packets;
+	std::map<u16, u32> m_packets;
 };
 
 class ClientScripting;


### PR DESCRIPTION
<b>DO NOT SQUASH</b>

The reason for "content_mapblock: Move static initialization out of functions" is that the compiler cannot statically initialize a `v3s16` and does it inside the function (with mutexes), if moved outside it happens at process startup.

## To do

This PR is Ready for Review.
