### PR TITLE
LuaItemStack: Add __eq metamethod

### DIFF
--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -29,6 +29,16 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 
 
+// ItemStack metamethod
+// __eq(item1, item2) -> true/false
+int LuaItemStack::itemstack_compare(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushboolean(L, checkobject(L, 1)->m_stack == checkobject(L, 2)->m_stack);
+	return 1;
+}
+
+
 // garbage collector
 int LuaItemStack::gc_object(lua_State *L)
 {
@@ -458,6 +468,10 @@ void LuaItemStack::Register(lua_State *L)
 
 	lua_pushliteral(L, "__gc");
 	lua_pushcfunction(L, gc_object);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__eq");
+	lua_pushcfunction(L, itemstack_compare);
 	lua_settable(L, metatable);
 
 	lua_pop(L, 1);  // drop metatable

--- a/src/script/lua_api/l_item.h
+++ b/src/script/lua_api/l_item.h
@@ -31,6 +31,9 @@ private:
 
 	// Exported functions
 
+	// __eq metamethod
+	static int itemstack_compare(lua_State *L);
+
 	// garbage collector
 	static int gc_object(lua_State *L);
 


### PR DESCRIPTION
(Alternative to #9864)

This allows mods to compare itemstacks using the == operator, as suggested by @rubenwardy in https://github.com/minetest/minetest/pull/9864#issuecomment-629347029.

I've tested for equality and non-equality after using various `ItemStack:*` methods and the results were accurate every time. PR is ready for review.

Any idea how this can be documented? Does this require documentation?

### How to test

Run the following chat-command; ensure that it returns a success message, and doesn't crash MT.

```lua
minetest.register_chatcommand("compare_stack", {
	func = function()
		local stack1, stack2
		stack1 = ItemStack("default:stone 42 666")
		stack2 = ItemStack(stack1)
		assert(stack1 == stack2)

		stack1:get_meta():set_string("key", "meta1")
		stack2:get_meta():set_string("key", "meta2")
		assert(stack1 ~= stack2)

		return true, "Tests completed successfully!"
	end
})
```

Or if you prefer `luacmd`, the following shouldn't crash MT:

```lua
/lua assert(ItemStack("default:stone") == ItemStack("default:stone"))
/lua assert(ItemStack("default:sand") ~= ItemStack("default:gravel"))
```