### PR TITLE
Potential fix for GUI scaling filter clipping animated images and 9slice backgrounds

### DIFF
--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -91,7 +91,7 @@ void imageScaleNNAA(video::IImage *src, const core::rect<s32> &srcrect, video::I
 	u32 dy, dx;
 	video::SColor pxl;
 
-	// Cache rectsngle boundaries.
+	// Cache rectangle boundaries.
 	double sox = srcrect.UpperLeftCorner.X * 1.0;
 	double soy = srcrect.UpperLeftCorner.Y * 1.0;
 	double sw = srcrect.getWidth() * 1.0;
@@ -107,15 +107,15 @@ void imageScaleNNAA(video::IImage *src, const core::rect<s32> &srcrect, video::I
 		// Do some basic clipping, and for mirrored/flipped rects,
 		// make sure min/max are in the right order.
 		minsx = sox + (dx * sw / dim.Width);
-		minsx = rangelim(minsx, 0, sw);
+		minsx = rangelim(minsx, 0, sox + sw);
 		maxsx = minsx + sw / dim.Width;
-		maxsx = rangelim(maxsx, 0, sw);
+		maxsx = rangelim(maxsx, 0, sox + sw);
 		if (minsx > maxsx)
 			SWAP(double, minsx, maxsx);
 		minsy = soy + (dy * sh / dim.Height);
-		minsy = rangelim(minsy, 0, sh);
+		minsy = rangelim(minsy, 0, soy + sh);
 		maxsy = minsy + sh / dim.Height;
-		maxsy = rangelim(maxsy, 0, sh);
+		maxsy = rangelim(maxsy, 0, soy + sh);
 		if (minsy > maxsy)
 			SWAP(double, minsy, maxsy);
 


### PR DESCRIPTION
Probably fixes #9892

I don't know too much about the GUI scaling filter's operation, so I can't guarantee that this is the correct move. It definitely fixes animated images, though 9-slice textures still look odd (although they now display the full texture like they're supposed to).

I don't know enough about this feature to guarantee that this is correct behavior, but going by the comments in the code and the math being done, I'm pretty sure this is the right fix. Ideally, someone with more knowledge of the feature should thoroughly test this to ensure that it works correctly.