### PR TITLE
Show Toast in UI thread and fix unpacking on Android 10

### DIFF
--- a/build/android/app/src/main/java/net/minetest/minetest/CopyZipTask.java
+++ b/build/android/app/src/main/java/net/minetest/minetest/CopyZipTask.java
@@ -20,10 +20,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 package net.minetest.minetest;
 
-import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -33,10 +34,10 @@ import java.lang.ref.WeakReference;
 
 public class CopyZipTask extends AsyncTask<String, Void, String> {
 
-	private final WeakReference<Context> contextRef;
+	private final WeakReference<AppCompatActivity> activityRef;
 
-	CopyZipTask(Context context) {
-		contextRef = new WeakReference<>(context);
+	CopyZipTask(AppCompatActivity activity) {
+		activityRef = new WeakReference<>(activity);
 	}
 
 	protected String doInBackground(String... params) {
@@ -51,11 +52,14 @@ public class CopyZipTask extends AsyncTask<String, Void, String> {
 
 	private void copyAsset(String zipName) {
 		String filename = zipName.substring(zipName.lastIndexOf("/") + 1);
-		try (InputStream in = contextRef.get().getAssets().open(filename);
+		try (InputStream in = activityRef.get().getAssets().open(filename);
 		     OutputStream out = new FileOutputStream(zipName)) {
 			copyFile(in, out);
 		} catch (IOException e) {
-			Toast.makeText(contextRef.get(), e.getLocalizedMessage(), Toast.LENGTH_LONG).show();
+			AppCompatActivity activity = activityRef.get();
+			if (activity != null) {
+				activity.runOnUiThread(() -> Toast.makeText(activityRef.get(), e.getLocalizedMessage(), Toast.LENGTH_LONG).show());
+			}
 			cancel(true);
 		}
 	}
@@ -68,8 +72,11 @@ public class CopyZipTask extends AsyncTask<String, Void, String> {
 	}
 
 	private void startUnzipService(String file) {
-		Intent intent = new Intent(contextRef.get(), UnzipService.class);
+		Intent intent = new Intent(activityRef.get(), UnzipService.class);
 		intent.putExtra(UnzipService.EXTRA_KEY_IN_FILE, file);
-		contextRef.get().startService(intent);
+		AppCompatActivity activity = activityRef.get();
+		if (activity != null) {
+			activity.startService(intent);
+		}
 	}
 }

--- a/build/android/app/src/main/java/net/minetest/minetest/MainActivity.java
+++ b/build/android/app/src/main/java/net/minetest/minetest/MainActivity.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static net.minetest.minetest.UnzipService.ACTION_FAILURE;
 import static net.minetest.minetest.UnzipService.ACTION_PROGRESS;
 import static net.minetest.minetest.UnzipService.ACTION_UPDATE;
 import static net.minetest.minetest.UnzipService.FAILURE;
@@ -71,6 +72,7 @@ public class MainActivity extends AppCompatActivity {
 				}
 				mTextView.setVisibility(View.VISIBLE);
 			} else if (progress == FAILURE) {
+				Toast.makeText(MainActivity.this, intent.getStringExtra(ACTION_FAILURE), Toast.LENGTH_LONG).show();
 				finish();
 			} else if (progress == SUCCESS)
 				startNative();
@@ -136,6 +138,11 @@ public class MainActivity extends AppCompatActivity {
 		Intent intent = new Intent(this, GameActivity.class);
 		intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK);
 		startActivity(intent);
+	}
+
+	@Override
+	public void onBackPressed() {
+		// Prevent abrupt interruption when copy game files from assets
 	}
 
 	@Override

--- a/build/android/app/src/main/java/net/minetest/minetest/UnzipService.java
+++ b/build/android/app/src/main/java/net/minetest/minetest/UnzipService.java
@@ -42,20 +42,21 @@ import java.util.zip.ZipInputStream;
 public class UnzipService extends IntentService {
 	public static final String ACTION_UPDATE = "net.minetest.minetest.UPDATE";
 	public static final String ACTION_PROGRESS = "net.minetest.minetest.PROGRESS";
+	public static final String ACTION_FAILURE = "net.minetest.minetest.FAILURE";
 	public static final String EXTRA_KEY_IN_FILE = "file";
 	public static final int SUCCESS = -1;
 	public static final int FAILURE = -2;
-	private static final String TAG = "UnzipService";
 	private final int id = 1;
 	private NotificationManager mNotifyManager;
 	private boolean isSuccess = true;
+	private String failureMessage;
 
 	public UnzipService() {
 		super("net.minetest.minetest.UnzipService");
 	}
 
 	private void isDir(String dir, String location) {
-		File f = new File(location + dir);
+		File f = new File(location, dir);
 		if (!f.isDirectory())
 			f.mkdirs();
 	}
@@ -99,7 +100,8 @@ public class UnzipService extends IntentService {
 
 	private void unzip(Intent intent) {
 		String zip = intent.getStringExtra(EXTRA_KEY_IN_FILE);
-		String location = Environment.getExternalStorageDirectory() + "/Minetest/";
+		isDir("Minetest", Environment.getExternalStorageDirectory().toString());
+		String location = Environment.getExternalStorageDirectory() + File.separator + "Minetest" + File.separator;
 		int per = 0;
 		int size = getSummarySize(zip);
 		File zipFile = new File(zip);
@@ -124,13 +126,14 @@ public class UnzipService extends IntentService {
 			}
 		} catch (IOException e) {
 			isSuccess = false;
-			Toast.makeText(this, e.getLocalizedMessage(), Toast.LENGTH_LONG).show();
+			failureMessage = e.getLocalizedMessage();
 		}
 	}
 
 	private void publishProgress(int progress) {
 		Intent intentUpdate = new Intent(ACTION_UPDATE);
 		intentUpdate.putExtra(ACTION_PROGRESS, progress);
+		if (!isSuccess) intentUpdate.putExtra(ACTION_FAILURE, failureMessage);
 		sendBroadcast(intentUpdate);
 	}
 


### PR DESCRIPTION
Show Toast messages in UI thread

- Goal of the PR
Fix Toast calling in the background
Fix unpack on Android 10
- How does the PR work?
Well, it works.
- Does it resolve any reported issue?
It improves #9760 where I originally replaced Log with Toast. And yes, forgot about background thread.
- If not a bug fix, why is this PR needed? What usecases does it solve?
It is a bug fix. Toast messages can't be shown in the background thread.

This PR is a Ready for Review.