### PR TITLE
Expose zoom PlayerControl to lua

### DIFF
--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1459,6 +1459,8 @@ int ObjectRef::l_get_player_control(lua_State *L)
 	lua_setfield(L, -2, "LMB");
 	lua_pushboolean(L, control.RMB);
 	lua_setfield(L, -2, "RMB");
+	lua_pushboolean(L, control.zoom);
+	lua_setfield(L, -2, "zoom");
 	return 1;
 }
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
Expose is player is pressing the "zoom" key.

- How does the PR work?
Simply expose the boolean property to lua scripting.

- Does it resolve any reported issue?
No

- If not a bug fix, why is this PR needed? What usecases does it solve?
Expose the information to mods.

## To do

This PR is a Work in Progress / Ready for Review.
<!-- ^ delete one -->

- [ ] List
- [ ] Things
- [ ] To do

## How to test

<!-- Example code or instructions -->
