### PR TITLE
Check for valid base64 before decoding

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5449,7 +5449,7 @@ Misc.
     * Example: `minetest.rgba(10, 20, 30, 40)`, returns `"#0A141E28"`
 * `minetest.encode_base64(string)`: returns string encoded in base64
     * Encodes a string in base64.
-* `minetest.decode_base64(string)`: returns string
+* `minetest.decode_base64(string)`: returns string or nil for invalid base64
     * Decodes a string encoded in base64.
 * `minetest.is_protected(pos, name)`: returns boolean
     * Returning `true` restricts the player `name` from modifying (i.e. digging,

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -323,8 +323,7 @@ int ModApiUtil::l_decode_base64(lua_State *L)
 	const std::string data = std::string(d, size);
 
 	if (!base64_is_valid(data)) {
-		lua_pushnil(L);
-		return 1;
+		return 0;
 	}
 
 	std::string out = base64_decode(data);

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -318,9 +318,16 @@ int ModApiUtil::l_decode_base64(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 
 	size_t size;
-	const char *data = luaL_checklstring(L, 1, &size);
+	const char *d = luaL_checklstring(L, 1, &size);
 
-	std::string out = base64_decode(std::string(data, size));
+	const std::string data = std::string(d, size);
+
+	if (!base64_is_valid(data)) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	std::string out = base64_decode(data);
 
 	lua_pushlstring(L, out.data(), out.size());
 	return 1;


### PR DESCRIPTION
Returns nil instead of some supper-strange bytes if the string is not valid base64