### PR TITLE
Restore visual_scale support for nodeboxes (and allfaces)

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6929,7 +6929,7 @@ Used by `minetest.register_node`.
 
         visual_scale = 1.0,
         -- Supported for drawtypes "plantlike", "signlike", "torchlike",
-        -- "firelike", "mesh".
+        -- "firelike", "mesh", "nodebox", "allfaces".
         -- For plantlike and firelike, the image will start at the bottom of the
         -- node. For torchlike, the image will start at the surface to which the
         -- node "attaches". For the other drawtypes the image will be centered

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -366,6 +366,7 @@ void MapblockMeshGenerator::generateCuboidTextureCoords(const aabb3f &box, f32 *
 void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box, const f32 *txc,
 	TileSpec *tiles, int tile_count)
 {
+	bool scale = std::fabs(f->visual_scale - 1.0) > 1e-3;
 	f32 texture_coord_buf[24];
 	f32 dx1 = box.MinEdge.X;
 	f32 dy1 = box.MinEdge.Y;
@@ -373,6 +374,14 @@ void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box, const f32 *txc,
 	f32 dx2 = box.MaxEdge.X;
 	f32 dy2 = box.MaxEdge.Y;
 	f32 dz2 = box.MaxEdge.Z;
+	if (scale) {
+		if (!txc) { // generate texture coords before scaling
+			generateCuboidTextureCoords(box, texture_coord_buf);
+			txc = texture_coord_buf;
+		}
+		box.MinEdge *= f->visual_scale;
+		box.MaxEdge *= f->visual_scale;
+	}
 	box.MinEdge += origin;
 	box.MaxEdge += origin;
 	if (!txc) {
@@ -1323,11 +1332,8 @@ void MapblockMeshGenerator::drawNodeboxNode()
 
 	std::vector<aabb3f> boxes;
 	n.getNodeBoxes(nodedef, &boxes, neighbors_set);
-	for (auto &box : boxes) {
-		box.MinEdge *= f->visual_scale;
-		box.MaxEdge *= f->visual_scale;
+	for (auto &box : boxes)
 		drawAutoLightedCuboid(box, nullptr, tiles, 6);
-	}
 }
 
 void MapblockMeshGenerator::drawMeshNode()

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -366,7 +366,7 @@ void MapblockMeshGenerator::generateCuboidTextureCoords(const aabb3f &box, f32 *
 void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box, const f32 *txc,
 	TileSpec *tiles, int tile_count)
 {
-	bool scale = std::fabs(f->visual_scale - 1.0) > 1e-3;
+	bool scale = std::fabs(f->visual_scale - 1.0f) > 1e-3f;
 	f32 texture_coord_buf[24];
 	f32 dx1 = box.MinEdge.X;
 	f32 dy1 = box.MinEdge.Y;

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1323,8 +1323,11 @@ void MapblockMeshGenerator::drawNodeboxNode()
 
 	std::vector<aabb3f> boxes;
 	n.getNodeBoxes(nodedef, &boxes, neighbors_set);
-	for (const auto &box : boxes)
+	for (auto &box : boxes) {
+		box.MinEdge *= f->visual_scale;
+		box.MaxEdge *= f->visual_scale;
 		drawAutoLightedCuboid(box, nullptr, tiles, 6);
+	}
 }
 
 void MapblockMeshGenerator::drawMeshNode()


### PR DESCRIPTION
Fix #8400 

`master` | Larger nodebox | This PR
---|---|---
![screenshot_20200521_155301](https://user-images.githubusercontent.com/7352626/82561193-9e756d80-9b7b-11ea-9941-ae8cfef1b9ea.png) | ![screenshot_20200521_155236](https://user-images.githubusercontent.com/7352626/82561195-9fa69a80-9b7b-11ea-8d67-d885462bf735.png) | ![screenshot_20200521_160831](https://user-images.githubusercontent.com/7352626/82562352-bb12a500-9b7d-11ea-89e8-503804f1a8cd.png)

## To do

This PR is Ready for Review.

## How to test

Place any node with nodebox (or allfaces) drawtype and visual_scale≠1, like
```lua
minetest.register_node("mese_crystals:mese_pack", {
	description = "Mese pack",
	tiles = {"default_mese_block.png"},
	drawtype = "nodebox",
	node_box = {
		type = "fixed",
		fixed = {-0.4, -0.4, -0.1, 0.4, 0.4, 0.1},
	},
	paramtype = "light",
	paramtype2 = "facedir",
	color = color,
	groups = {cracky = 1},
	use_texture_alpha = true,
	sounds = sounds,
	light_source = 9,
	visual_scale = 2.0,
})
```

Note: glasslike_framed and fencelike will probably look weird with visual scale applied.