### PR TITLE
[NO SQUASH] Node texture appearance for particles+particlespawners

### DIFF
--- a/build/android/native/jni/Android.mk
+++ b/build/android/native/jni/Android.mk
@@ -164,6 +164,7 @@ LOCAL_SRC_FILES := \
 	../../../src/noise.cpp                          \
 	../../../src/objdef.cpp                         \
 	../../../src/object_properties.cpp              \
+	../../../src/particles.cpp                      \
 	../../../src/pathfinder.cpp                     \
 	../../../src/player.cpp                         \
 	../../../src/porting.cpp                        \

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7831,6 +7831,8 @@ Used by `minetest.add_particle`.
 
         size = 1,
         -- Scales the visual size of the particle texture.
+        -- If `node` is set, size can be set to 0 to spawn a randomly-sized
+        -- particle (just like actual node dig particles).
 
         collisiondetection = false,
         -- If true collides with `walkable` nodes and, depending on the
@@ -7849,6 +7851,7 @@ Used by `minetest.add_particle`.
         -- If true faces player using y axis only
 
         texture = "image.png",
+        -- The texture of the particle
 
         playername = "singleplayer",
         -- Optional, if specified spawns particle only on the player's client
@@ -7859,6 +7862,17 @@ Used by `minetest.add_particle`.
         glow = 0
         -- Optional, specify particle self-luminescence in darkness.
         -- Values 0-14.
+
+        node = {name = "ignore", param2 = 0},
+        -- Optional, if specified the particle will have the same appearance as
+        -- node dig particles for the given node.
+        -- `texture` and `animation` will be ignored if this is set.
+
+        node_tile = 0,
+        -- Optional, only valid in combination with `node`
+        -- If set to a valid number 1-6, specifies the tile from which the
+        -- particle texture is picked.
+        -- Otherwise, the default behavior is used. (currently: any random tile)
     }
 
 
@@ -7888,7 +7902,9 @@ Used by `minetest.add_particlespawner`.
         maxsize = 1,
         -- The particles' properties are random values between the min and max
         -- values.
-        -- pos, velocity, acceleration, expirationtime, size
+        -- applies to: pos, velocity, acceleration, expirationtime, size
+        -- If `node` is set, min and maxsize can be set to 0 to spawn
+        -- randomly-sized particles (just like actual node dig particles).
 
         collisiondetection = false,
         -- If true collide with `walkable` nodes and, depending on the
@@ -7911,6 +7927,7 @@ Used by `minetest.add_particlespawner`.
         -- If true face player using y axis only
 
         texture = "image.png",
+        -- The texture of the particle
 
         playername = "singleplayer",
         -- Optional, if specified spawns particles only on the player's client
@@ -7921,6 +7938,17 @@ Used by `minetest.add_particlespawner`.
         glow = 0
         -- Optional, specify particle self-luminescence in darkness.
         -- Values 0-14.
+
+        node = {name = "ignore", param2 = 0},
+        -- Optional, if specified the particles will have the same appearance as
+        -- node dig particles for the given node.
+        -- `texture` and `animation` will be ignored if this is set.
+
+        node_tile = 0,
+        -- Optional, only valid in combination with `node`
+        -- If set to a valid number 1-6, specifies the tile from which the
+        -- particle texture is picked.
+        -- Otherwise, the default behavior is used. (currently: any random tile)
     }
 
 `HTTPRequest` definition

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -42,7 +42,7 @@ class Particle : public scene::ISceneNode
 		video::ITexture *texture,
 		v2f texpos,
 		v2f texsize,
-		video::SColor color = video::SColor(0xFFFFFFFF)
+		video::SColor color
 	);
 	~Particle() = default;
 
@@ -171,7 +171,7 @@ public:
 protected:
 	static bool getNodeParticleParams(const MapNode &n, const ContentFeatures &f,
 		ParticleParameters &p, video::ITexture **texture, v2f &texpos,
-		v2f &texsize, video::SColor *color);
+		v2f &texsize, video::SColor *color, u8 tilenum = 0);
 
 	void addParticle(Particle* toadd);
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1003,6 +1003,16 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 	p.glow = readU8(is);
 	p.object_collision = readU8(is);
 
+	// This is kinda awful
+	do {
+		u16 tmp_param0 = readU16(is);
+		if (is.eof())
+			break;
+		p.node.param0 = tmp_param0;
+		p.node.param2 = readU8(is);
+		p.node_tile   = readU8(is);
+	} while (0);
+
 	auto event = new ClientEvent();
 	event->type                            = CE_ADD_PARTICLESPAWNER;
 	event->add_particlespawner.p           = new ParticleSpawnerParameters(p);

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -34,6 +34,9 @@ void ParticleParameters::serialize(std::ostream &os, u16 protocol_ver) const
 	animation.serialize(os, 6); /* NOT the protocol ver */
 	writeU8(os, glow);
 	writeU8(os, object_collision);
+	writeU16(os, node.param0);
+	writeU8(os, node.param2);
+	writeU8(os, node_tile);
 }
 
 void ParticleParameters::deSerialize(std::istream &is, u16 protocol_ver)
@@ -50,4 +53,11 @@ void ParticleParameters::deSerialize(std::istream &is, u16 protocol_ver)
 	animation.deSerialize(is, 6); /* NOT the protocol ver */
 	glow               = readU8(is);
 	object_collision   = readU8(is);
+	// This is kinda awful
+	u16 tmp_param0 = readU16(is);
+	if (is.eof())
+		return;
+	node.param0 = tmp_param0;
+	node.param2 = readU8(is);
+	node_tile   = readU8(is);
 }

--- a/src/particles.h
+++ b/src/particles.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include "irrlichttypes_bloated.h"
 #include "tileanimation.h"
+#include "mapnode.h"
 
 // This file defines the particle-related structures that both the server and
 // client need. The ParticleManager and rendering is in client/particles.h
@@ -34,9 +35,12 @@ struct CommonParticleParams {
 	std::string texture;
 	struct TileAnimationParams animation;
 	u8 glow = 0;
+	MapNode node;
+	u8 node_tile = 0;
 
 	CommonParticleParams() {
 		animation.type = TAT_NONE;
+		node.setContent(CONTENT_IGNORE);
 	}
 
 	/* This helper is useful for copying params from
@@ -49,6 +53,8 @@ struct CommonParticleParams {
 		to.texture = texture;
 		to.animation = animation;
 		to.glow = glow;
+		to.node = node;
+		to.node_tile = node_tile;
 	}
 };
 

--- a/src/script/lua_api/l_particles.cpp
+++ b/src/script/lua_api/l_particles.cpp
@@ -111,6 +111,13 @@ int ModApiParticles::l_add_particle(lua_State *L)
 		p.texture = getstringfield_default(L, 1, "texture", p.texture);
 		p.glow = getintfield_default(L, 1, "glow", p.glow);
 
+		lua_getfield(L, 1, "node");
+		if (lua_istable(L, -1))
+			p.node = readnode(L, -1, getGameDef(L)->ndef());
+		lua_pop(L, 1);
+
+		p.node_tile = getintfield_default(L, 1, "node_tile", p.node_tile);
+
 		playername = getstringfield_default(L, 1, "playername", "");
 	}
 
@@ -231,6 +238,13 @@ int ModApiParticles::l_add_particlespawner(lua_State *L)
 		p.texture = getstringfield_default(L, 1, "texture", p.texture);
 		playername = getstringfield_default(L, 1, "playername", "");
 		p.glow = getintfield_default(L, 1, "glow", p.glow);
+
+		lua_getfield(L, 1, "node");
+		if (lua_istable(L, -1))
+			p.node = readnode(L, -1, getGameDef(L)->ndef());
+		lua_pop(L, 1);
+
+		p.node_tile = getintfield_default(L, 1, "node_tile", p.node_tile);
 	}
 
 	u32 id = getServer(L)->addParticleSpawner(p, attached, playername);

--- a/src/script/lua_api/l_particles_local.cpp
+++ b/src/script/lua_api/l_particles_local.cpp
@@ -67,6 +67,13 @@ int ModApiParticlesLocal::l_add_particle(lua_State *L)
 	p.texture = getstringfield_default(L, 1, "texture", p.texture);
 	p.glow = getintfield_default(L, 1, "glow", p.glow);
 
+	lua_getfield(L, 1, "node");
+	if (lua_istable(L, -1))
+		p.node = readnode(L, -1, getGameDef(L)->ndef());
+	lua_pop(L, 1);
+
+	p.node_tile = getintfield_default(L, 1, "node_tile", p.node_tile);
+
 	ClientEvent *event = new ClientEvent();
 	event->type           = CE_SPAWN_PARTICLE;
 	event->spawn_particle = new ParticleParameters(p);
@@ -133,6 +140,13 @@ int ModApiParticlesLocal::l_add_particlespawner(lua_State *L)
 	p.vertical = getboolfield_default(L, 1, "vertical", p.vertical);
 	p.texture = getstringfield_default(L, 1, "texture", p.texture);
 	p.glow = getintfield_default(L, 1, "glow", p.glow);
+
+	lua_getfield(L, 1, "node");
+	if (lua_istable(L, -1))
+		p.node = readnode(L, -1, getGameDef(L)->ndef());
+	lua_pop(L, 1);
+
+	p.node_tile = getintfield_default(L, 1, "node_tile", p.node_tile);
 
 	u64 id = getClient(L)->getParticleManager()->generateSpawnerId();
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1577,6 +1577,7 @@ void Server::SendAddParticleSpawner(session_t peer_id, u16 protocol_version,
 		pkt.putRawString(os.str());
 	}
 	pkt << p.glow << p.object_collision;
+	pkt << p.node.param0 << p.node.param2 << p.node_tile;
 
 	Send(&pkt);
 }


### PR DESCRIPTION
closes #9840

second commit is so that short-lived particlespawners are not sent to clients 1000s of nodes away

## To do

This PR is Ready for Review.

## How to test

```lua
core.register_on_punchnode(function(pos, node, puncher, pointed_thing)
	pos.y = pos.y + 0.55
	local g = vector.new(0, -9.81, 0)
	core.add_particlespawner({
		minpos = pos, maxpos = pos,
		minvel = vector.new(-1, 2.5, -1),
		maxvel = vector.new(1, 5, 1),
		minacc = g, maxacc = g,
		minsize = 0, maxsize = 0,
		time = 3.2,
		amount = 400,
		node = node,
		node_tile = 3,
	})
end)
```
* Punch a node and observe a fountain of dig particles that have the texture of a side(!) face
