### PR TITLE
devtest: Fix assertion failure when player HP == 3

### DIFF
--- a/games/minimal/mods/unittests/player.lua
+++ b/games/minimal/mods/unittests/player.lua
@@ -1,8 +1,20 @@
 --
 -- HP Change Reasons
 --
+local tests_enabled = false
 local expect = nil
 local function run_hpchangereason_tests(player)
+	-- Cache old HP; temporarily set to max_hp
+	-- This prevents unintended behavior.
+	local old_hp = player:get_hp()
+	player:set_hp(player:get_properties().hp_max)
+
+	--
+	-- Tests begin
+	--
+
+	tests_enabled = true
+
 	expect = { type = "set_hp", from = "mod" }
 	player:set_hp(3)
 	assert(expect == nil)
@@ -15,7 +27,14 @@ local function run_hpchangereason_tests(player)
 	player:set_hp(10, { type = "fall", df = 3458973454 })
 	assert(expect == nil)
 
-	player:set_hp(20)
+	tests_enabled = false
+
+	--
+	-- Tests end
+	--
+
+	-- Restore old HP
+	player:set_hp(old_hp)
 end
 
 local function run_player_meta_tests(player)
@@ -48,7 +67,7 @@ end
 
 function unittests.test_player(player)
 	minetest.register_on_player_hpchange(function(player, hp, reason)
-		if not expect then
+		if not tests_enabled then
 			return
 		end
 


### PR DESCRIPTION
This PR fixes an assertion failure in L13 (`master`) if the player's HP is exactly equal to 3. This had bugged my minimal worlds twice, before I realised the cause. This is indirectly related to the behavioural changes introduced by c4578aef, and was fixed in 96f250ed. But this is something I didn't foresee. :) 

- Now, player's HP is set to `max_hp` before enabling the tests (via a simple boolean).
- Once the tests are over, the player's HP is set back to the old value again, and the tests are "disabled" by setting the bool to `false`.

A very relevant wall of text on IRC: http://irc.minetest.net/minetest-dev/2020-05-24#i_5692349

Tested; works. This PR is Ready for Review.

## How to test

- Set player's HP from 0 to `max_hp` (either in-game, or using an external SQLite DB editor), and join each time.
- Verify that the tests pass every single time (you'll also see `All tests pass!` in the chat).
  - In `master`, an HP of exactly 3 crashes minimal.
<!-- Example code or instructions -->
