### PR TITLE
L-System trees: Remove hardcoded use of 'mapgen_dirt' alias

### DIFF
--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -148,10 +148,6 @@ treegen::error spawn_ltree(ServerMap *map, v3s16 p0,
 treegen::error make_ltree(MMVManip &vmanip, v3s16 p0,
 	const NodeDefManager *ndef, TreeDef tree_definition)
 {
-	MapNode dirtnode(ndef->getId("mapgen_dirt"));
-	if (dirtnode == CONTENT_IGNORE)
-		errorstream << "Treegen (make_ltree): Mapgen alias 'mapgen_dirt' is invalid!" << std::endl;
-
 	s32 seed;
 	if (tree_definition.explicit_seed)
 		seed = tree_definition.seed + 14002;
@@ -229,43 +225,43 @@ treegen::error make_ltree(MMVManip &vmanip, v3s16 p0,
 		axiom = temp;
 	}
 
-	//make sure tree is not floating in the air
+	// Add trunk nodes below a wide trunk to avoid gaps when tree is on sloping ground
 	if (tree_definition.trunk_type == "double") {
-		tree_node_placement(
+		tree_trunk_placement(
 			vmanip,
 			v3f(position.X + 1, position.Y - 1, position.Z),
-			dirtnode
+			tree_definition
 		);
-		tree_node_placement(
+		tree_trunk_placement(
 			vmanip,
 			v3f(position.X, position.Y - 1, position.Z + 1),
-			dirtnode
+			tree_definition
 		);
-		tree_node_placement(
+		tree_trunk_placement(
 			vmanip,
 			v3f(position.X + 1, position.Y - 1, position.Z + 1),
-			dirtnode
+			tree_definition
 		);
 	} else if (tree_definition.trunk_type == "crossed") {
-		tree_node_placement(
+		tree_trunk_placement(
 			vmanip,
 			v3f(position.X + 1, position.Y - 1, position.Z),
-			dirtnode
+			tree_definition
 		);
-		tree_node_placement(
+		tree_trunk_placement(
 			vmanip,
 			v3f(position.X - 1, position.Y - 1, position.Z),
-			dirtnode
+			tree_definition
 		);
-		tree_node_placement(
+		tree_trunk_placement(
 			vmanip,
 			v3f(position.X, position.Y - 1, position.Z + 1),
-			dirtnode
+			tree_definition
 		);
-		tree_node_placement(
+		tree_trunk_placement(
 			vmanip,
 			v3f(position.X, position.Y - 1, position.Z - 1),
-			dirtnode
+			tree_definition
 		);
 	}
 
@@ -372,7 +368,7 @@ treegen::error make_ltree(MMVManip &vmanip, v3s16 p0,
 					!tree_definition.thin_branches)) {
 				tree_trunk_placement(
 					vmanip,
-					v3f(position.X +1 , position.Y, position.Z),
+					v3f(position.X + 1, position.Y, position.Z),
 					tree_definition
 				);
 				tree_trunk_placement(


### PR DESCRIPTION
Games often and increasingly do not use this mapgen alias, as it
is only required for Mapgen V6. Such games were triggering the
recently added error message.

Even if this mapgen alias was defined, dirt nodes placed under a
wide trunk were inconsistent with biomes that do not use dirt
surface nodes.

Place trunk nodes below a wide trunk instead of 'mapgen_dirt'.
On sloping ground, the trunk then extends down to the surface,
instead of the surface rising up to meet the trunk. This looks
more natural and does not alter the terrain.
///////////////////////////////

A simple PR that closes #9869 

Previously:

L-tree generation placed 'mapgen_dirt' nodes 1 node below the outer edges of a wide trunk.
This was done so that if a sapling was on sloping ground the outer edges of a wide trunk would not have air gaps below them.
The dirt nodes were inconsistent with most biomes:

![screenshot_20200524_204912](https://user-images.githubusercontent.com/3686677/82764665-5f0f8100-9e08-11ea-80e6-c1e256178082.png)

This PR:

"crossed" and "double" trunk types:

![screenshot_20200524_210610](https://user-images.githubusercontent.com/3686677/82764686-89f9d500-9e08-11ea-983c-d6c0d6da954a.png)

![screenshot_20200524_210655](https://user-images.githubusercontent.com/3686677/82764687-8f571f80-9e08-11ea-89fd-adb5a67fd889.png)

Testing code
-
A mod called 'ltree', used with MTG, depending on 'default'.
Comment/uncomment the 'trunk_type' line to check both wide trunk types.
```
minetest.register_node("ltree:sapling", {
	description = "L-Tree Sapling",
	drawtype = "plantlike",
	tiles = {"default_sapling.png"},
	inventory_image = "default_sapling.png",
	wield_image = "default_sapling.png",
	paramtype = "light",
	sunlight_propagates = true,
	walkable = false,
	selection_box = {
		type = "fixed",
		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
	},
	groups = {snappy = 2, dig_immediate = 3, flammable = 2,
		attached_node = 1, sapling = 1},
	sounds = default.node_sound_leaves_defaults(),
})

minetest.register_abm({
	label = "Grow L-Tree",
	nodenames = {"ltree:sapling"},
	interval = 3,
	chance = 1,
	action = function(pos, node)
		minetest.remove_node(pos)
		minetest.spawn_tree(pos, {
			axiom="FFFFFFFFFFFFFFFFFFFAFFBF",
			rules_a="[&&&FFFFF&&FFFF][&&&++++FFFFF&&FFFF][&&&----FFFFF&&FFFF]",
			rules_b="[&&&++FFFFF&&FFFF][&&&--FFFFF&&FFFF][&&&------FFFFF&&FFFF]",
			trunk="default:tree",
			leaves="default:leaves",
			angle=30,
			iterations=2,
			random_level=0,
			trunk_type="double",
			--trunk_type="crossed",
			thin_branches=true,
			fruit_chance= 0,
		})
	end
})
```