### PR TITLE
CSM: Pass ChatMessage table instead of message to callback

### DIFF
--- a/clientmods/preview/init.lua
+++ b/clientmods/preview/init.lua
@@ -99,7 +99,7 @@ end)
 
 -- This is an example function to ensure it's working properly, should be removed before merge
 core.register_on_receiving_chat_message(function(message)
-	print("[PREVIEW] Received message " .. message)
+	print("[PREVIEW] Received message " .. dump(message))
 	return false
 end)
 

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -680,8 +680,8 @@ Call these functions only at load time!
     * Called when a client receive a message
     * `chat_message` is a table with following:
         * `type`:
-            * `raw` - No meta data attached, just a message.
-            * `normal` - Sent by a player, sender will be present.
+            * `raw` - Unknown type.
+            * `normal` - Sent by a player, `sender` will be present.
             * `announce` - A server gemeral announcement.
             * `system` - A server system announcement (ie: shutting down).
         * `message` - The full message.

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -676,12 +676,21 @@ Call these functions only at load time!
     * **Warning**: If the client terminates abnormally (i.e. crashes), the registered
       callbacks **will likely not be run**. Data should be saved at
       semi-frequent intervals as well as on server shutdown.
-* `minetest.register_on_receiving_chat_message(function(message))`
-    * Called always when a client receive a message
-    * Return `true` to mark the message as handled, which means that it will not be shown to chat
+* `minetest.register_on_receiving_chat_message(function(chat_message))`
+    * Called when a client receive a message
+    * `chat_message` is a table with following:
+        * `type`:
+            * `raw` - No meta data attached, just a message.
+            * `normal` - Sent by a player, sender will be present.
+            * `announce` - A server gemeral announcement.
+            * `system` - A server system announcement (ie: shutting down).
+        * `message` - The full message.
+        * `sender` (optional) - Player name of sender. Only with `normal` type.
+        * `timestamp` - UNIX timestamp
+    * Return `true` to mark the message as handled, which means that it will not be shown to chat.
 * `minetest.register_on_sending_chat_message(function(message))`
-    * Called always when a client send a message from chat
-    * Return `true` to mark the message as handled, which means that it will not be sent to server
+    * Called when the local player sends a chat message.
+    * Return `true` to mark the message as handled, which means that it will not be sent to the server.
 * `minetest.register_chatcommand(cmd, chatcommand definition)`
     * Adds definition to minetest.registered_chatcommands
 * `minetest.unregister_chatcommand(name)`

--- a/src/chatmessage.h
+++ b/src/chatmessage.h
@@ -48,7 +48,8 @@ struct ChatMessage
 	std::wstring sender = L"";
 	std::time_t timestamp = std::time(0);
 
-	const char *getType() const {
+	const char *getType() const
+	{
 		switch (type) {
 		case CHATMESSAGE_TYPE_RAW:
 			return "raw";
@@ -63,4 +64,3 @@ struct ChatMessage
 		}
 	}
 };
-

--- a/src/chatmessage.h
+++ b/src/chatmessage.h
@@ -48,7 +48,7 @@ struct ChatMessage
 	std::wstring sender = L"";
 	std::time_t timestamp = std::time(0);
 
-	std::string getType() const {
+	const char *getType() const {
 		switch (type) {
 		case CHATMESSAGE_TYPE_RAW:
 			return "raw";

--- a/src/chatmessage.h
+++ b/src/chatmessage.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <string>
 #include <ctime>
+#include "debug.h"
 
 enum ChatMessageType
 {
@@ -46,4 +47,20 @@ struct ChatMessage
 	std::wstring message = L"";
 	std::wstring sender = L"";
 	std::time_t timestamp = std::time(0);
+
+	std::string getType() const {
+		switch (type) {
+		case CHATMESSAGE_TYPE_RAW:
+			return "raw";
+		case CHATMESSAGE_TYPE_NORMAL:
+			return "normal";
+		case CHATMESSAGE_TYPE_ANNOUNCE:
+			return "announce";
+		case CHATMESSAGE_TYPE_SYSTEM:
+			return "system";
+		default:
+			FATAL_ERROR("Unexpected ChatMessageType error");
+		}
+	}
 };
+

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -57,6 +57,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "game.h"
 #include "chatmessage.h"
 #include "translation.h"
+#include "util/make_unique.h"
 
 extern gui::IGUIEnvironment* guienv;
 
@@ -1547,8 +1548,7 @@ bool Client::getChatMessage(std::wstring &res)
 	if (m_chat_queue.empty())
 		return false;
 
-	ChatMessage *chatMessage = m_chat_queue.front();
-	m_chat_queue.pop();
+	auto &chatMessage = m_chat_queue.front();
 
 	res = L"";
 
@@ -1569,7 +1569,7 @@ bool Client::getChatMessage(std::wstring &res)
 			break;
 	}
 
-	delete chatMessage;
+	m_chat_queue.pop();
 	return true;
 }
 
@@ -1860,7 +1860,7 @@ void Client::makeScreenshot()
 			} else {
 				sstr << "Failed to save screenshot '" << filename << "'";
 			}
-			pushToChatQueue(new ChatMessage(CHATMESSAGE_TYPE_SYSTEM,
+			pushToChatQueue(std::make_unique<ChatMessage>(CHATMESSAGE_TYPE_SYSTEM,
 					narrow_to_wide(sstr.str())));
 			infostream << sstr.str() << std::endl;
 			image->drop();

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -384,9 +384,9 @@ public:
 
 	void makeScreenshot();
 
-	inline void pushToChatQueue(ChatMessage *cec)
+	inline void pushToChatQueue(std::unique_ptr<ChatMessage> &&cec)
 	{
-		m_chat_queue.push(cec);
+		m_chat_queue.push(std::move(cec));
 	}
 
 	ClientScripting *getScript() { return m_script; }
@@ -512,7 +512,7 @@ private:
 	std::queue<std::wstring> m_out_chat_queue;
 	u32 m_last_chat_message_sent;
 	float m_chat_message_allowance = 5.0f;
-	std::queue<ChatMessage *> m_chat_queue;
+	std::queue<std::unique_ptr<ChatMessage>> m_chat_queue;
 
 	// The authentication methods we can use to enter sudo mode (=change password)
 	u32 m_sudo_auth_methods;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -417,9 +417,8 @@ void Client::handleCommand_ChatMessage(NetworkPacket *pkt)
 
 	chatMessage->type = (ChatMessageType) message_type;
 
-	if (!modsLoaded() || !m_script->on_receiving_message(chatMessage.get())) {
+	if (!modsLoaded() || !m_script->on_receiving_message(chatMessage.get()))
 		pushToChatQueue(chatMessage.release());
-	}
 }
 
 void Client::handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt)

--- a/src/script/cpp_api/s_client.cpp
+++ b/src/script/cpp_api/s_client.cpp
@@ -23,7 +23,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/client.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
-#include "s_item.h"
 
 void ScriptApiClient::on_mods_loaded()
 {
@@ -60,15 +59,34 @@ bool ScriptApiClient::on_sending_message(const std::string &message)
 	return readParam<bool>(L, -1);
 }
 
-bool ScriptApiClient::on_receiving_message(const std::string &message)
+bool ScriptApiClient::on_receiving_message(const ChatMessage *chatMessage)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	std::string message = wide_to_utf8(chatMessage->message);
+	std::string sender = wide_to_utf8(chatMessage->sender);
+
 
 	// Get core.registered_on_chat_messages
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "registered_on_receiving_chat_message");
-	// Call callbacks
+
+	lua_newtable(L);
+
+	lua_pushstring(L, chatMessage->getType().c_str());
+	lua_setfield(L, -2, "type");
+
 	lua_pushstring(L, message.c_str());
+	lua_setfield(L, -2, "message");
+
+	if (!sender.empty()) {
+		lua_pushstring(L, sender.c_str());
+		lua_setfield(L, -2, "sender");
+	}
+
+	lua_pushnumber(L, chatMessage->timestamp);
+	lua_setfield(L, -2, "timestamp");
+
 	runCallbacks(1, RUN_CALLBACKS_MODE_OR_SC);
 	return readParam<bool>(L, -1);
 }

--- a/src/script/cpp_api/s_client.cpp
+++ b/src/script/cpp_api/s_client.cpp
@@ -73,7 +73,7 @@ bool ScriptApiClient::on_receiving_message(const ChatMessage *chatMessage)
 
 	lua_newtable(L);
 
-	lua_pushstring(L, chatMessage->getType().c_str());
+	lua_pushstring(L, chatMessage->getType());
 	lua_setfield(L, -2, "type");
 
 	lua_pushstring(L, message.c_str());

--- a/src/script/cpp_api/s_client.h
+++ b/src/script/cpp_api/s_client.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h"
 #include "util/pointedthing.h"
 #include "lua_api/l_item.h"
+#include "chatmessage.h"
 
 #ifdef _CRT_MSVCP_CURRENT
 #include <cstdint>
@@ -45,7 +46,7 @@ public:
 
 	// Chat message handlers
 	bool on_sending_message(const std::string &message);
-	bool on_receiving_message(const std::string &message);
+	bool on_receiving_message(const ChatMessage *chatMessage);
 
 	void on_damage_taken(int32_t damage_amount);
 	void on_hp_modification(int32_t newhp);

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -34,6 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "map.h"
 #include "util/string.h"
 #include "nodedef.h"
+#include "util/make_unique.h"
 
 #define checkCSMRestrictionFlag(flag) \
 	( getClient(L)->checkCSMRestrictionFlag(CSMRestrictionFlags::flag) )
@@ -116,7 +117,7 @@ int ModApiClient::l_display_chat_message(lua_State *L)
 		return 0;
 
 	std::string message = luaL_checkstring(L, 1);
-	getClient(L)->pushToChatQueue(new ChatMessage(utf8_to_wide(message)));
+	getClient(L)->pushToChatQueue(std::make_unique<ChatMessage>(utf8_to_wide(message)));
 	lua_pushboolean(L, true);
 	return 1;
 }

--- a/src/util/make_unique.h
+++ b/src/util/make_unique.h
@@ -1,0 +1,33 @@
+/*
+Minetest
+Copyright (C) 2020 rubenwardy
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#if __cplusplus == 201103L
+
+namespace std {
+
+	template<typename T, typename... Args>
+	std::unique_ptr<T> make_unique(Args &&... args) {
+		return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+	}
+
+}
+
+#endif

--- a/src/util/make_unique.h
+++ b/src/util/make_unique.h
@@ -21,12 +21,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #if __cplusplus == 201103L
 
-namespace std {
+namespace std
+{
 
-	template<typename T, typename... Args>
-	std::unique_ptr<T> make_unique(Args &&... args) {
-		return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-	}
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args &&... args)
+{
+	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
 
 }
 


### PR DESCRIPTION
This PR makes `register_on_receiving_chat_message` give a table to the callback functions instead of a string message.

```lua
{
	type = "raw",
	message = "*** rubenwardy joined the game.",
	timestamp = 1590502477
}
```

## TODO

- [ ] Call `os.date`, and provide a date object rather than a timestamp

## How to test

Load the preview mod, see the messages
