### PR TITLE
Add warning when disabling secure.enable_security

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1324,7 +1324,6 @@ csm_restriction_noderange (Client side node lookup range restriction) int 0
 [*Security]
 
 #    Prevent mods from doing insecure things like running shell commands.
-#    Deprecated: Disabling this should never be done.
 secure.enable_security (Enable mod security) bool true
 
 #    Comma-separated list of trusted mods that are allowed to access insecure

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1323,7 +1323,7 @@ csm_restriction_noderange (Client side node lookup range restriction) int 0
 
 [*Security]
 
-#    Prevent mods from doing insecure things like running shell commands.
+#    Prevent mods from doing insecure things like running shell commands. Deprecated: Disabling this should never be done.
 secure.enable_security (Enable mod security) bool true
 
 #    Comma-separated list of trusted mods that are allowed to access insecure

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1323,7 +1323,8 @@ csm_restriction_noderange (Client side node lookup range restriction) int 0
 
 [*Security]
 
-#    Prevent mods from doing insecure things like running shell commands. Deprecated: Disabling this should never be done.
+#    Prevent mods from doing insecure things like running shell commands.
+#    Deprecated: Disabling this should never be done.
 secure.enable_security (Enable mod security) bool true
 
 #    Comma-separated list of trusted mods that are allowed to access insecure

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -62,6 +62,9 @@ ServerScripting::ServerScripting(Server* server):
 
 	if (g_settings->getBool("secure.enable_security")) {
 		initializeSecurity();
+	} else {
+		warningstream << "Disabling mod security is deprecated, and should not be done. "
+				<< "Mods should use minetest.request_insecure_environment() instead" << std::endl;
 	}
 
 	lua_getglobal(L, "core");

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -63,8 +63,8 @@ ServerScripting::ServerScripting(Server* server):
 	if (g_settings->getBool("secure.enable_security")) {
 		initializeSecurity();
 	} else {
-		warningstream << "\\!/ Disabling mod security should not be done, as it allows any mod to "
-				<< "access the host computer."
+		warningstream << "\\!/ Mod security should never be disabled, as it allows any mod to "
+				<< "access the host machine."
 				<< "Mods should use minetest.request_insecure_environment() instead \\!/" << std::endl;
 	}
 

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -63,8 +63,9 @@ ServerScripting::ServerScripting(Server* server):
 	if (g_settings->getBool("secure.enable_security")) {
 		initializeSecurity();
 	} else {
-		warningstream << "Disabling mod security is deprecated, and should not be done. "
-				<< "Mods should use minetest.request_insecure_environment() instead" << std::endl;
+		warningstream << "\\!/ Disabling mod security should not be done, as it allows any mod to "
+				<< "access the host computer."
+				<< "Mods should use minetest.request_insecure_environment() instead \\!/" << std::endl;
 	}
 
 	lua_getglobal(L, "core");


### PR DESCRIPTION
Disabling mod security is never needed as mods can use `minetest.request_insecure_environment()` instead.

Showing a warning is the bare minimum, removing the setting should be considered at a later date