### PR TITLE
[no squash] Builtin entity related fixes

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -323,7 +323,7 @@ core.register_entity(":__builtin:falling_node", {
 					z = vel.z
 				})
 				self.object:set_pos(vector.add(self.object:get_pos(),
-					{x = 0, y = -0.2, z = 0}))
+					{x = 0, y = -0.5, z = 0}))
 			end
 			return
 		elseif bcn.name == "ignore" then

--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -27,8 +27,6 @@ core.register_entity(":__builtin:item", {
 		visual = "wielditem",
 		visual_size = {x = 0.4, y = 0.4},
 		textures = {""},
-		spritediv = {x = 1, y = 1},
-		initial_sprite_basepos = {x = 0, y = 0},
 		is_visible = false,
 	},
 
@@ -56,7 +54,6 @@ core.register_entity(":__builtin:item", {
 		local max_count = stack:get_stack_max()
 		local count = math.min(stack:get_count(), max_count)
 		local size = 0.2 + 0.1 * (count / max_count) ^ (1 / 3)
-		local coll_height = size * 0.75
 		local def = core.registered_nodes[itemname]
 		local glow = def and math.floor(def.light_source / 2 + 0.5)
 
@@ -65,9 +62,7 @@ core.register_entity(":__builtin:item", {
 			visual = "wielditem",
 			textures = {itemname},
 			visual_size = {x = size, y = size},
-			collisionbox = {-size, -coll_height, -size,
-				size, coll_height, size},
-			selectionbox = {-size, -size, -size, size, size, size},
+			collisionbox = {-size, -size, -size, size, size, size},
 			automatic_rotate = math.pi * 0.5 * 0.2 / size,
 			wield_item = self.itemstring,
 			glow = glow,


### PR DESCRIPTION
Ground view of new item collisionboxes:
![screenshot_20200527_153256](https://user-images.githubusercontent.com/1042418/83027798-d9bae500-a030-11ea-8ef9-6c18552e1340.png)

The sapling uses the full 16x16 texture (previously sunk into ground), the apple does not.
Having the bottom exactly sit on the ground isn't easily possible.

## To do

This PR is Ready for Review.

