### PR TITLE
Lua API: Log incorrect parameter types as error

### DIFF
--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -28,6 +28,7 @@ extern "C" {
 #include "common/c_converter.h"
 #include "common/c_internal.h"
 #include "constants.h"
+#include <algorithm> // std::find
 
 
 #define CHECK_TYPE(index, name, type) { \
@@ -458,11 +459,28 @@ size_t read_stringlist(lua_State *L, int index, std::vector<std::string> *result
 
 bool check_field_or_nil(lua_State *L, int index, int type, const char *fieldname)
 {
-	if (lua_isnil(L, index))
+	static thread_local std::vector<u64> warned_msgs;
+
+	int t = lua_type(L, index);
+	if (t == LUA_TNIL)
 		return false;
 
-	CHECK_TYPE(index, std::string("field \"") + fieldname + '"', type);
-	return true;
+	if (t == type)
+		return true;
+
+	// Types mismatch. Log unique line.
+	std::string backtrace = std::string("Invalid field ") + fieldname +
+		" (expected " + lua_typename(L, type) +
+		" got " + lua_typename(L, t) + ").\n" + script_get_backtrace(L);
+
+	u64 hash = murmur_hash_64_ua(backtrace.data(), backtrace.length(), 0xBADBABE);
+	if (std::find(warned_msgs.begin(), warned_msgs.end(), hash)
+			== warned_msgs.end()) {
+		warningstream << backtrace << std::endl;
+		warned_msgs.push_back(hash);
+	}
+
+	return false;
 }
 
 bool getstringfield(lua_State *L, int table,

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -28,7 +28,6 @@ extern "C" {
 #include "common/c_converter.h"
 #include "common/c_internal.h"
 #include "constants.h"
-#include <algorithm> // std::find
 #include <set>
 
 

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -29,6 +29,7 @@ extern "C" {
 #include "common/c_internal.h"
 #include "constants.h"
 #include <algorithm> // std::find
+#include <set>
 
 
 #define CHECK_TYPE(index, name, type) { \
@@ -459,7 +460,7 @@ size_t read_stringlist(lua_State *L, int index, std::vector<std::string> *result
 
 bool check_field_or_nil(lua_State *L, int index, int type, const char *fieldname)
 {
-	static thread_local std::vector<u64> warned_msgs;
+	static thread_local std::set<u64> warned_msgs;
 
 	int t = lua_type(L, index);
 	if (t == LUA_TNIL)
@@ -474,10 +475,9 @@ bool check_field_or_nil(lua_State *L, int index, int type, const char *fieldname
 		" got " + lua_typename(L, t) + ").\n" + script_get_backtrace(L);
 
 	u64 hash = murmur_hash_64_ua(backtrace.data(), backtrace.length(), 0xBADBABE);
-	if (std::find(warned_msgs.begin(), warned_msgs.end(), hash)
-			== warned_msgs.end()) {
+	if (warned_msgs.find(hash) == warned_msgs.end()) {
 		warningstream << backtrace << std::endl;
-		warned_msgs.push_back(hash);
+		warned_msgs.insert(hash);
 	}
 
 	return false;

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -468,6 +468,15 @@ bool check_field_or_nil(lua_State *L, int index, int type, const char *fieldname
 	if (t == type)
 		return true;
 
+	// Check coercion types
+	if (type == LUA_TNUMBER) {
+		if (lua_isnumber(L, index))
+			return true;
+	} else if (type == LUA_TSTRING) {
+		if (lua_isstring(L, index))
+			return true;
+	}
+
 	// Types mismatch. Log unique line.
 	std::string backtrace = std::string("Invalid field ") + fieldname +
 		" (expected " + lua_typename(L, type) +
@@ -475,7 +484,7 @@ bool check_field_or_nil(lua_State *L, int index, int type, const char *fieldname
 
 	u64 hash = murmur_hash_64_ua(backtrace.data(), backtrace.length(), 0xBADBABE);
 	if (warned_msgs.find(hash) == warned_msgs.end()) {
-		warningstream << backtrace << std::endl;
+		errorstream << backtrace << std::endl;
 		warned_msgs.insert(hash);
 	}
 


### PR DESCRIPTION
Incorrect parameter types are logged as errors, taking coercion into account.
This is a workaround to ensure mod compatibility.
Duplicate warnings are ignored per server instance.

Closes #9950 
Fixes #9964

## To do

This PR is Ready for Review.

## How to test

1) `cd mods`
2) `git clone https://github.com/DokimiCU/aotearoa.git --depth 2`
3) Enable mod & start game
4) Warnings (but not repeating) in the logs
