### PR TITLE
introducing .worldsaving [ on | off | toggle | status ] client side c…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ gtags.files
 build/.cmake/
 # Gradle
 .gradle
+*.user
 
 ## Files related to Minetest development cycle
 /*.patch

--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -65,6 +65,33 @@ core.register_chatcommand("clear_chat_queue", {
 	end,
 })
 
+core.register_chatcommand("worldsaving", {
+	params="[ on | off | toggle | status ]",
+	description = core.gettext("Switch local world saving on/off"),
+	func = function(param)
+		local onoff
+
+		if ((param == "") or (param == "status")) then
+			onoff = core.get_worldsaving()
+			return true, core.gettext("Currently world saving is turned " .. onoff .. ".")
+		end
+
+		if ((param ~= "on") and (param ~= "off") and (param ~= "toggle")) then
+			return false, core.gettext("Try .help worldsaving first please")
+		end
+
+		core.set_worldsaving(param)
+
+		onoff = param
+
+		if (param == "toggle") then
+			onoff = core.get_worldsaving()
+		end
+
+		return true, core.gettext("OK, Worldsaving toggled " .. onoff)
+	end,
+})
+
 function core.run_server_chatcommand(cmd, param)
 	core.send_chat_message("/" .. cmd .. " " .. param)
 end

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -830,6 +830,10 @@ Call these functions only at load time!
     * Returns [server info](#server-info).
 * `minetest.send_respawn()`
     * Sends a respawn request to the server.
+* `minetest.set_worldsaving("on|off|toggle")`
+    * Instructs the client to start/stop world saving
+* `minetest.get_worldsaving()`
+     * Returns either "on" or "off" based on the current value of enable_local_map_saving
 
 ### Storage API
 * `minetest.get_mod_storage()`:

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -115,6 +115,7 @@ public:
 	Client(
 			const char *playername,
 			const std::string &password,
+			const Address &address,
 			const std::string &address_name,
 			MapDrawControl &control,
 			IWritableTextureSource *tsrc,
@@ -124,7 +125,8 @@ public:
 			ISoundManager *sound,
 			MtEventManager *event,
 			bool ipv6,
-			GameUI *game_ui
+			GameUI *game_ui,
+			bool localGame
 	);
 
 	~Client();
@@ -150,7 +152,7 @@ public:
 		The name of the local player should already be set when
 		calling this, as it is sent in the initialization.
 	*/
-	void connect(Address address, bool is_local_server);
+	void connect();
 
 	/*
 		Stuff that references the environment is valid only as
@@ -241,6 +243,9 @@ public:
 	void sendDamage(u16 damage);
 	void sendRespawn();
 	void sendReady();
+
+	void startLocalMapSaving();
+	void stopLocalMapSaving();
 
 	ClientEnvironment& getEnv() { return m_env; }
 	ITextureSource *tsrc() { return getTextureSource(); }
@@ -442,8 +447,8 @@ private:
 	void deletingPeer(con::Peer *peer, bool timeout) override;
 
 	void initLocalMapSaving(const Address &address,
-			const std::string &hostname,
-			bool is_local_server);
+		const std::string &hostname,
+		bool is_local_server);
 
 	void ReceiveAll();
 
@@ -484,6 +489,7 @@ private:
 	ClientEnvironment m_env;
 	ParticleManager m_particle_manager;
 	std::unique_ptr<con::Connection> m_con;
+	Address m_address;
 	std::string m_address_name;
 	Camera *m_camera = nullptr;
 	Minimap *m_minimap = nullptr;
@@ -595,4 +601,6 @@ private:
 	u32 m_csm_restriction_noderange = 8;
 
 	std::unique_ptr<ModChannelMgr> m_modchannel_mgr;
+
+	bool m_is_local_server;
 };

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1499,10 +1499,11 @@ bool Game::connectToServer(const std::string &playername,
 		return false;
 	}
 
-	client = new Client(playername.c_str(), password, *address,
-			*draw_control, texture_src, shader_src,
-			itemdef_manager, nodedef_manager, sound, eventmgr,
-			connect_address.isIPv6(), m_game_ui.get());
+	client = new Client(playername.c_str(), password, connect_address, *address,
+		*draw_control, texture_src, shader_src,
+		itemdef_manager, nodedef_manager, sound, eventmgr,
+		connect_address.isIPv6(), m_game_ui.get(),
+		simple_singleplayer_mode || local_server_mode);
 
 	if (!client)
 		return false;
@@ -1513,8 +1514,7 @@ bool Game::connectToServer(const std::string &playername,
 	connect_address.print(&infostream);
 	infostream << std::endl;
 
-	client->connect(connect_address,
-		simple_singleplayer_mode || local_server_mode);
+	client->connect();
 
 	/*
 		Wait for server to accept connection

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -144,6 +144,51 @@ int ModApiClient::l_clear_out_chat_queue(lua_State *L)
 	return 0;
 }
 
+
+// set_worldsaving("(on|off|toggle)")
+int ModApiClient::l_set_worldsaving(lua_State *L)
+{
+	if (! lua_isstring(L, 1))
+		return 0;
+
+	std::string param = luaL_checkstring(L, 1);
+	Client *client = getClient(L);
+	bool turnOn;
+	if (param == "on") {
+		turnOn = true;
+	}
+	else if (param == "off") {
+		turnOn = false;
+	}
+	else if (param == "toggle") {
+		turnOn = ! g_settings->getBool("enable_local_map_saving");
+	}
+	else
+	{
+		return 0;
+	}
+
+	g_settings->setBool("enable_local_map_saving",turnOn);
+
+	if (turnOn) {
+		client->startLocalMapSaving();
+	}
+	else {
+		client->stopLocalMapSaving();
+	}
+
+	return 0;
+}
+
+
+// get_worldsaving(), returns "on" or "off"
+int ModApiClient::l_get_worldsaving(lua_State *L)
+{
+	lua_pushstring(L, g_settings->getBool("enable_local_map_saving") ? "on" : "off");
+	return 1;
+}
+
+
 // get_player_names()
 int ModApiClient::l_get_player_names(lua_State *L)
 {
@@ -441,4 +486,6 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(get_builtin_path);
 	API_FCT(get_language);
 	API_FCT(get_csm_restrictions);
+	API_FCT(set_worldsaving);
+	API_FCT(get_worldsaving);
 }

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -45,6 +45,12 @@ private:
 	// clear_out_chat_queue()
 	static int l_clear_out_chat_queue(lua_State *L);
 
+	// set_worldsaving("(on|off|toggle)")
+	static int l_set_worldsaving(lua_State *L);
+
+	// get_worldsaving(), returns "on" or "off"
+	static int l_get_worldsaving(lua_State *L);
+
 	// get_player_names()
 	static int l_get_player_names(lua_State *L);
 


### PR DESCRIPTION
introducing .worldsaving [ on | off | toggle | status ] client side command to start/stop saving the world while in-game

- Goal of the PR? -let users start/stop local worldsaving while they are in-game
- If not a bug fix, why is this PR needed? What usecases does it solve? -prevents players from logging in and out of a server, while also possibly preserver disk space on user machine

## To do

This PR is Ready for Review.
<!-- ^ delete one -->

- [ ] Rebase to master
- [x] List
- [x] Things
- [x] To do

## How to test
join an online game and issue .help worldsaving the rest should be self explanatory
<!-- Example code or instructions -->
