### PR TITLE
Server pushing media at runtime

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5198,6 +5198,20 @@ Server
     * Returns a code (0: successful, 1: no such player, 2: player is connected)
 * `minetest.remove_player_auth(name)`: remove player authentication data
     * Returns boolean indicating success (false if player nonexistant)
+* `minetest.dynamic_add_media(filepath)`
+    * Adds the file at the given path to the media sent to clients by the server
+      on startup and also pushes this file to already connected clients.
+      The file must be a supported image, sound or model format. It must not be
+      modified, deleted, moved or renamed after calling this function.
+      The list of dynamically added media is not persisted.
+    * Returns boolean indicating success (duplicate files count as error)
+    * The media will be ready to use (in e.g. entity textures, sound_play)
+      immediately after calling this function.
+      Old clients that lack support for this feature will not see the media
+      unless they reconnect to the server.
+    * Since media transferred this way does not use client caching or HTTP
+      transfers, dynamic media should not be used with big files or performance
+      will suffer.
 
 Bans
 ----

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -670,11 +670,9 @@ void Client::step(float dtime)
 	}
 }
 
-bool Client::loadMedia(const std::string &data, const std::string &filename)
+bool Client::loadMedia(const std::string &data, const std::string &filename,
+	bool from_media_push)
 {
-	// Silly irrlicht's const-incorrectness
-	Buffer<char> data_rw(data.c_str(), data.size());
-
 	std::string name;
 
 	const char *image_ext[] = {
@@ -689,6 +687,9 @@ bool Client::loadMedia(const std::string &data, const std::string &filename)
 
 		io::IFileSystem *irrfs = RenderingEngine::get_filesystem();
 		video::IVideoDriver *vdrv = RenderingEngine::get_video_driver();
+
+		// Silly irrlicht's const-incorrectness
+		Buffer<char> data_rw(data.c_str(), data.size());
 
 		// Create an irrlicht memory file
 		io::IReadFile *rfile = irrfs->createMemoryReadFile(
@@ -727,7 +728,6 @@ bool Client::loadMedia(const std::string &data, const std::string &filename)
 		".x", ".b3d", ".md2", ".obj",
 		NULL
 	};
-
 	name = removeStringEnd(filename, model_ext);
 	if (!name.empty()) {
 		verbosestream<<"Client: Storing model into memory: "
@@ -744,6 +744,8 @@ bool Client::loadMedia(const std::string &data, const std::string &filename)
 	};
 	name = removeStringEnd(filename, translate_ext);
 	if (!name.empty()) {
+		if (from_media_push)
+			return false;
 		TRACESTREAM(<< "Client: Loading translation: "
 				<< "\"" << filename << "\"" << std::endl);
 		g_client_translations->loadTranslation(data);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -377,7 +377,8 @@ public:
 
 	// The following set of functions is used by ClientMediaDownloader
 	// Insert a media file appropriately into the appropriate manager
-	bool loadMedia(const std::string &data, const std::string &filename);
+	bool loadMedia(const std::string &data, const std::string &filename,
+		bool from_media_push = false);
 	// Send a request for conventional media transfer
 	void request_media(const std::vector<std::string> &file_requests);
 
@@ -489,6 +490,7 @@ private:
 	Camera *m_camera = nullptr;
 	Minimap *m_minimap = nullptr;
 	bool m_minimap_disabled_by_server = false;
+
 	// Server serialization version
 	u8 m_server_ser_ver;
 
@@ -530,7 +532,6 @@ private:
 	AuthMechanism m_chosen_auth_mech;
 	void *m_auth_data = nullptr;
 
-
 	bool m_access_denied = false;
 	bool m_access_denied_reconnect = false;
 	std::string m_access_denied_reason = "";
@@ -539,7 +540,10 @@ private:
 	bool m_nodedef_received = false;
 	bool m_activeobjects_received = false;
 	bool m_mods_loaded = false;
+
 	ClientMediaDownloader *m_media_downloader;
+	// Set of media filenames pushed by server at runtime
+	std::unordered_set<std::string> m_media_pushed_files;
 
 	// time_of_day speed approximation for old protocol
 	bool m_time_of_day_set = false;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -222,6 +222,7 @@ public:
 	void handleCommand_FormspecPrepend(NetworkPacket *pkt);
 	void handleCommand_CSMRestrictionFlags(NetworkPacket *pkt);
 	void handleCommand_PlayerSpeed(NetworkPacket *pkt);
+	void handleCommand_MediaPush(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 

--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -35,6 +35,15 @@ static std::string getMediaCacheDir()
 	return porting::path_cache + DIR_DELIM + "media";
 }
 
+bool clientMediaUpdateCache(const std::string &raw_hash, const std::string &filedata)
+{
+	FileCache media_cache(getMediaCacheDir());
+	std::string sha1_hex = hex_encode(raw_hash);
+	if (!media_cache.exists(sha1_hex))
+		return media_cache.update(sha1_hex, filedata);
+	return true;
+}
+
 /*
 	ClientMediaDownloader
 */
@@ -558,7 +567,6 @@ bool ClientMediaDownloader::checkAndLoad(
 
 	return true;
 }
-
 
 /*
 	Minetest Hashset File Format

--- a/src/client/clientmedia.h
+++ b/src/client/clientmedia.h
@@ -33,6 +33,11 @@ struct HTTPFetchResult;
 #define MTHASHSET_FILE_SIGNATURE 0x4d544853 // 'MTHS'
 #define MTHASHSET_FILE_NAME "index.mth"
 
+// Store file into media cache (unless it exists already)
+// Validating the hash is responsibility of the caller
+bool clientMediaUpdateCache(const std::string &raw_hash,
+	const std::string &filedata);
+
 class ClientMediaDownloader
 {
 public:

--- a/src/client/filecache.cpp
+++ b/src/client/filecache.cpp
@@ -82,8 +82,16 @@ bool FileCache::update(const std::string &name, const std::string &data)
 	std::string path = m_dir + DIR_DELIM + name;
 	return updateByPath(path, data);
 }
+
 bool FileCache::load(const std::string &name, std::ostream &os)
 {
 	std::string path = m_dir + DIR_DELIM + name;
 	return loadByPath(path, os);
+}
+
+bool FileCache::exists(const std::string &name)
+{
+	std::string path = m_dir + DIR_DELIM + name;
+	std::ifstream fis(path.c_str(), std::ios_base::binary);
+	return fis.good();
 }

--- a/src/client/filecache.h
+++ b/src/client/filecache.h
@@ -33,6 +33,7 @@ public:
 
 	bool update(const std::string &name, const std::string &data);
 	bool load(const std::string &name, std::ostream &os);
+	bool exists(const std::string &name);
 
 private:
 	std::string m_dir;

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -691,6 +691,12 @@ std::string AbsolutePath(const std::string &path)
 const char *GetFilenameFromPath(const char *path)
 {
 	const char *filename = strrchr(path, DIR_DELIM_CHAR);
+	// Consistent with IsDirDelimiter this function handles '/' too
+	if (DIR_DELIM_CHAR != '/') {
+		const char *tmp = strrchr(path, '/');
+		if (tmp && tmp > filename)
+			filename = tmp;
+	}
 	return filename ? filename + 1 : path;
 }
 

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -68,7 +68,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_TIME_OF_DAY",              TOCLIENT_STATE_CONNECTED, &Client::handleCommand_TimeOfDay }, // 0x29
 	{ "TOCLIENT_CSM_RESTRICTION_FLAGS",    TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CSMRestrictionFlags }, // 0x2A
 	{ "TOCLIENT_PLAYER_SPEED",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_PlayerSpeed }, // 0x2B
-	null_command_handler,
+	{ "TOCLIENT_MEDIA_PUSH",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MediaPush }, // 0x2C
 	null_command_handler,
 	null_command_handler,
 	{ "TOCLIENT_CHAT_MESSAGE",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ChatMessage }, // 0x2F

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1471,6 +1471,20 @@ void Client::handleCommand_PlayerSpeed(NetworkPacket *pkt)
 	player->addVelocity(added_vel);
 }
 
+void Client::handleCommand_MediaPush(NetworkPacket *pkt)
+{
+	std::string filename, filedata;
+
+	*pkt >> filename;
+	filedata = pkt->readLongString();
+
+	verbosestream << "Server pushes media file \"" << filename << "\" with "
+		<< filedata.size() << " bytes of data" << std::endl;
+
+	// TODO: ensure it's an image file and doesn't exist already
+	loadMedia(filedata, filename);
+}
+
 /*
  * Mod channels
  */

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -324,6 +324,13 @@ enum ToClientCommand
 	 */
 
 	TOCLIENT_MEDIA_PUSH = 0x2C,
+	/*
+		std::string raw_hash
+		std::string filename
+		bool should_be_cached
+		u32 len
+		char filedata[len]
+	*/
 
 	// (oops, there is some gap here)
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -323,6 +323,8 @@ enum ToClientCommand
 		v3f added_vel
 	 */
 
+	TOCLIENT_MEDIA_PUSH = 0x2C,
+
 	// (oops, there is some gap here)
 
 	TOCLIENT_CHAT_MESSAGE = 0x2F,

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -167,7 +167,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_TIME_OF_DAY",              0, true }, // 0x29
 	{ "TOCLIENT_CSM_RESTRICTION_FLAGS",    0, true }, // 0x2A
 	{ "TOCLIENT_PLAYER_SPEED",             0, true }, // 0x2B
-	null_command_factory, // 0x2C
+	{ "TOCLIENT_MEDIA_PUSH",               0, true }, // 0x2C
 	null_command_factory, // 0x2D
 	null_command_factory, // 0x2E
 	{ "TOCLIENT_CHAT_MESSAGE",             0, true }, // 0x2F

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -167,7 +167,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_TIME_OF_DAY",              0, true }, // 0x29
 	{ "TOCLIENT_CSM_RESTRICTION_FLAGS",    0, true }, // 0x2A
 	{ "TOCLIENT_PLAYER_SPEED",             0, true }, // 0x2B
-	{ "TOCLIENT_MEDIA_PUSH",               0, true }, // 0x2C
+	{ "TOCLIENT_MEDIA_PUSH",               0, true }, // 0x2C (sent over channel 1 too)
 	null_command_factory, // 0x2D
 	null_command_factory, // 0x2E
 	{ "TOCLIENT_CHAT_MESSAGE",             0, true }, // 0x2F

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include "cpp_api/s_base.h"
+#include "cpp_api/s_security.h"
 #include "server.h"
 #include "environment.h"
 #include "remoteplayer.h"
@@ -474,6 +475,18 @@ int ModApiServer::l_sound_fade(lua_State *L)
 	return 0;
 }
 
+// runtime_add_media(filepath)
+int ModApiServer::l_runtime_add_media(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	std::string filepath = readParam<std::string>(L, 1);
+	CHECK_SECURE_PATH(L, filepath.c_str(), false);
+
+	bool ok = getServer(L)->runtimeAddMedia(filepath);
+	lua_pushboolean(L, ok);
+	return 1;
+}
+
 // is_singleplayer()
 int ModApiServer::l_is_singleplayer(lua_State *L)
 {
@@ -538,6 +551,7 @@ void ModApiServer::Initialize(lua_State *L, int top)
 	API_FCT(sound_play);
 	API_FCT(sound_stop);
 	API_FCT(sound_fade);
+	API_FCT(runtime_add_media);
 
 	API_FCT(get_player_information);
 	API_FCT(get_player_privs);

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -413,9 +413,6 @@ int ModApiServer::l_get_modnames(lua_State *L)
 	std::vector<std::string> modlist;
 	getServer(L)->getModNames(modlist);
 
-	// Take unsorted items from mods_unsorted and sort them into
-	// mods_sorted; not great performance but the number of mods on a
-	// server will likely be small.
 	std::sort(modlist.begin(), modlist.end());
 
 	// Package them up for Lua
@@ -475,14 +472,19 @@ int ModApiServer::l_sound_fade(lua_State *L)
 	return 0;
 }
 
-// runtime_add_media(filepath)
-int ModApiServer::l_runtime_add_media(lua_State *L)
+// dynamic_add_media(filepath)
+int ModApiServer::l_dynamic_add_media(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
+
+	// Reject adding media before the server has started up
+	if (!getEnv(L))
+		throw LuaError("Dynamic media cannot be added before server has started up");
+
 	std::string filepath = readParam<std::string>(L, 1);
 	CHECK_SECURE_PATH(L, filepath.c_str(), false);
 
-	bool ok = getServer(L)->runtimeAddMedia(filepath);
+	bool ok = getServer(L)->dynamicAddMedia(filepath);
 	lua_pushboolean(L, ok);
 	return 1;
 }
@@ -551,7 +553,7 @@ void ModApiServer::Initialize(lua_State *L, int top)
 	API_FCT(sound_play);
 	API_FCT(sound_stop);
 	API_FCT(sound_fade);
-	API_FCT(runtime_add_media);
+	API_FCT(dynamic_add_media);
 
 	API_FCT(get_player_information);
 	API_FCT(get_player_privs);

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -70,8 +70,8 @@ private:
 	// sound_fade(handle, step, gain)
 	static int l_sound_fade(lua_State *L);
 
-	// runtime_add_media(filepath)
-	static int l_runtime_add_media(lua_State *L);
+	// dynamic_add_media(filepath)
+	static int l_dynamic_add_media(lua_State *L);
 
 	// get_player_privs(name, text)
 	static int l_get_player_privs(lua_State *L);

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -70,6 +70,9 @@ private:
 	// sound_fade(handle, step, gain)
 	static int l_sound_fade(lua_State *L);
 
+	// runtime_add_media(filepath)
+	static int l_runtime_add_media(lua_State *L);
+
 	// get_player_privs(name, text)
 	static int l_get_player_privs(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2425,7 +2425,7 @@ bool Server::addMediaFile(const std::string &filename,
 		".tr",
 		NULL
 	};
-	if (removeStringEnd(filename, supported_ext).empty()){
+	if (removeStringEnd(filename, supported_ext).empty()) {
 		infostream << "Server: ignoring unsupported file extension: \""
 				<< filename << "\"" << std::endl;
 		return false;

--- a/src/server.h
+++ b/src/server.h
@@ -236,7 +236,7 @@ public:
 
 	void deleteParticleSpawner(const std::string &playername, u32 id);
 
-	bool runtimeAddMedia(const std::string &filepath);
+	bool dynamicAddMedia(const std::string &filepath);
 
 	ServerInventoryManager *getInventoryMgr() const { return m_inventory_mgr.get(); }
 	void sendDetachedInventory(Inventory *inventory, const std::string &name, session_t peer_id);
@@ -437,6 +437,8 @@ private:
 	// Sends blocks to clients (locks env and con on its own)
 	void SendBlocks(float dtime);
 
+	bool addMediaFile(const std::string &filename, const std::string &filepath,
+			std::string *filedata = nullptr, std::string *digest = nullptr);
 	void fillMediaCache();
 	void sendMediaAnnouncement(session_t peer_id, const std::string &lang_code);
 	void sendRequestedMedia(session_t peer_id,
@@ -457,8 +459,8 @@ private:
 		bool reliable = true);
 	void SendCSMRestrictionFlags(session_t peer_id);
 
-	void SendMediaPush(session_t peer_id, const std::string &filename,
-		const std::string &filedata);
+	void SendMediaPush(session_t peer_id, const std::string &raw_hash,
+		const std::string &filename, const std::string &filedata);
 
 	/*
 		Something random

--- a/src/server.h
+++ b/src/server.h
@@ -459,9 +459,6 @@ private:
 		bool reliable = true);
 	void SendCSMRestrictionFlags(session_t peer_id);
 
-	void SendMediaPush(session_t peer_id, const std::string &raw_hash,
-		const std::string &filename, const std::string &filedata);
-
 	/*
 		Something random
 	*/

--- a/src/server.h
+++ b/src/server.h
@@ -236,6 +236,8 @@ public:
 
 	void deleteParticleSpawner(const std::string &playername, u32 id);
 
+	bool runtimeAddMedia(const std::string &filepath);
+
 	ServerInventoryManager *getInventoryMgr() const { return m_inventory_mgr.get(); }
 	void sendDetachedInventory(Inventory *inventory, const std::string &name, session_t peer_id);
 
@@ -454,6 +456,9 @@ private:
 	void SendActiveObjectMessages(session_t peer_id, const std::string &datas,
 		bool reliable = true);
 	void SendCSMRestrictionFlags(session_t peer_id);
+
+	void SendMediaPush(session_t peer_id, const std::string &filename,
+		const std::string &filedata);
 
 	/*
 		Something random


### PR DESCRIPTION
Modders often want to send textures at runtime, which has previously used hacks like `[combine` to build a texture pixel by pixel.
Other suggested approaches are #9767, which packs pixels into a texture modifier (also bad) <i>or</i> adding a texture modifier that can read encoded PNG data.
The reason I dislike those approaches is that these workarounds can never be removed even if a proper solution arrives one day.

This PR implements (part of) "the" proper solution, which is:
* Mods can load additional media files at runtime
* New clients will receive them on connect
* Existing clients will have the files pushed to them, bypassing the usual media loading (e.g. caching or remote media)
* Mods can be sure that it is safe to use the texture immediately after calling `dynamic_add_media()`

## To do

This PR is a Work in Progress.

- [x] Should this apply to more than images?
- [x] Work out if client caching should/can be used
- [x] Figure out synchronization
- [x] Clean up code

## How to test

Standalone `/show` command that can show you images/audio/models ingame by specifying the filesystem path:
```lua
core.register_chatcommand("show", {
	func = function(name, param)
		if not core.dynamic_add_media(param) then return false, "error" end
		local basename = table.remove(string.split(param, "/"))
		local e = table.remove(string.split(basename, "."))
		basename = basename:gsub("%." .. e .. "$", "")
		if e == "ogg" then
			core.sound_play({name = basename}, {to_player = name})
		elseif e == "jpg" or e == "png" then
			core.get_player_by_name(name):hud_add({
				hud_elem_type = "image",
				position = {x = 0.5, y = 0.5},
				scale = {x = 1, y = 1},
				text = basename .. "." .. e
			})
		elseif e == "x" or e == "b3d" or e == "obj" then
			local pos = vector.add(core.get_player_by_name(name):get_pos(), {x=0, y=1, z=0})
			local entity = core.add_entity(pos, "__builtin:item")
			entity:get_luaentity():disable_physics()
			entity:set_properties({
				is_visible = true,
				visual = "mesh",
				visual_size = {x = 1, y = 1},
				textures = {"default_dirt.png"},
				mesh = basename .. "." .. e
			})
		else
			return false, "unhandeled " .. e 
		end
	end
})
```


For Crafter's skins mod:
```diff
diff --git a/mods/skins/init.lua b/mods/skins/init.lua
index c566736..c163786 100644
--- a/mods/skins/init.lua
+++ b/mods/skins/init.lua
@@ -114,13 +114,15 @@ end
 fetch_function = function(name)
     fetch_url("https://raw.githubusercontent.com/"..name.."/crafter_skindex/master/skin.png", function(data)
         if data then
+            local temppath = minetest.get_worldpath() .. "/skin_"..name..".png"
             local f = io.open(temppath, "wb")
             f:write(data)
             f:close()
 
-            local img = pngimage(temppath, nil, false, false)
+            local img = true
             if img then
-                local stored_texture = file_to_texture(img)
+                assert(minetest.dynamic_add_media(temppath))
+                local stored_texture = "skin_"..name..".png"
 
                 --print("===============================================================")
                 --print(stored_texture)
```
