### PR TITLE
Disallow players being able to spam jump up nodes

### DIFF
--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -609,7 +609,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				at its starting value
 			*/
 			v3f speedJ = getSpeed();
-			if (speedJ.Y >= -0.5f * BS) {
+			if (speedJ.Y == 0.0f) {
 				speedJ.Y = movement_speed_jump * physics_override_jump;
 				setSpeed(speedJ);
 				m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_JUMP));


### PR DESCRIPTION
- What does the PR do?

This fixes the bug that allows players to jump up nodes irregularly and essentially negate having to have stairs by making "staircases" of nodes.

It also makes jumping feel more polished and consistent.

You can see this in action here:  https://youtu.be/K8Yse9Wh6rk

- How does the PR work?

I changed this at line 612 of localplayer.cpp:
```
>= -0.5f * BS
```

To: 
```
== 0.0f
```

- Does it resolve any reported issue?

I have no idea

Ready for Review.

## How to test

Change that line of code.
