### PR TITLE
ContentCAO: Update light of all attached entities

### DIFF
--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -320,21 +320,8 @@ void ClientEnvironment::step(float dtime)
 		// Step object
 		cao->step(dtime, this);
 
-		if (update_lighting) {
-			// Update lighting
-			u8 light = 0;
-			bool pos_ok;
-
-			// Get node at head
-			v3s16 p = cao->getLightPosition();
-			MapNode n = this->m_map->getNode(p, &pos_ok);
-			if (pos_ok)
-				light = n.getLightBlend(day_night_ratio, m_client->ndef());
-			else
-				light = blend_light(day_night_ratio, LIGHT_SUN, 0);
-
-			cao->updateLight(light);
-		}
+		if (update_lighting)
+			cao->updateLight(day_night_ratio);
 	};
 
 	m_ao_manager.step(dtime, cb_state);
@@ -402,18 +389,7 @@ u16 ClientEnvironment::addActiveObject(ClientActiveObject *object)
 	object->addToScene(m_texturesource);
 
 	// Update lighting immediately
-	u8 light = 0;
-	bool pos_ok;
-
-	// Get node at head
-	v3s16 p = object->getLightPosition();
-	MapNode n = m_map->getNode(p, &pos_ok);
-	if (pos_ok)
-		light = n.getLightBlend(getDayNightRatio(), m_client->ndef());
-	else
-		light = blend_light(getDayNightRatio(), LIGHT_SUN, 0);
-
-	object->updateLight(light);
+	object->updateLight(getDayNightRatio());
 	return object->getId();
 }
 

--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -42,8 +42,7 @@ public:
 	virtual void addToScene(ITextureSource *tsrc) {}
 	virtual void removeFromScene(bool permanent) {}
 	// 0 <= light_at_pos <= LIGHT_SUN
-	virtual void updateLight(u8 light_at_pos) {}
-	virtual void updateLightNoCheck(u8 light_at_pos) {}
+	virtual void updateLight(u8 light_at_pos, bool ignore_parent = false) {}
 	virtual v3s16 getLightPosition() { return v3s16(0, 0, 0); }
 	virtual bool getCollisionBox(aabb3f *toset) const { return false; }
 	virtual bool getSelectionBox(aabb3f *toset) const { return false; }

--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -41,9 +41,10 @@ public:
 
 	virtual void addToScene(ITextureSource *tsrc) {}
 	virtual void removeFromScene(bool permanent) {}
-	// 0 <= light_at_pos <= LIGHT_SUN
-	virtual void updateLight(u8 light_at_pos, bool ignore_parent = false) {}
+
+	virtual void updateLight(u32 day_night_ratio) {}
 	virtual v3s16 getLightPosition() { return v3s16(0, 0, 0); }
+
 	virtual bool getCollisionBox(aabb3f *toset) const { return false; }
 	virtual bool getSelectionBox(aabb3f *toset) const { return false; }
 	virtual bool collideWithObjects() const { return false; }

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -181,7 +181,7 @@ public:
 
 	void addToScene(ITextureSource *tsrc);
 	void removeFromScene(bool permanent);
-	void updateLight(u8 light_at_pos, bool ignore_parent = false);
+	void updateLight(u32 day_night_ratio);
 	v3s16 getLightPosition();
 	void updateNodePos();
 
@@ -254,7 +254,7 @@ void TestCAO::removeFromScene(bool permanent)
 	m_node = NULL;
 }
 
-void TestCAO::updateLight(u8 light_at_pos, bool ignore_parent)
+void TestCAO::updateLight(u32 day_night_ratio)
 {
 }
 
@@ -784,25 +784,22 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 	setNodeLight(m_last_light);
 }
 
-void GenericCAO::updateLight(u8 light_at_pos, bool ignore_parent)
+void GenericCAO::updateLight(u32 day_night_ratio)
 {
-	// The topmost parent updates all its children
-	if (!ignore_parent && getParent())
-		return;
+	u8 light_at_pos = 0;
+	bool pos_ok;
 
-	if (m_glow >= 0) {
-		u8 li = decode_light(light_at_pos + m_glow);
+	v3s16 p = getLightPosition();
+	MapNode n = m_env->getMap().getNode(p, &pos_ok);
+	if (pos_ok)
+		light_at_pos = n.getLightBlend(day_night_ratio, m_client->ndef());
+	else
+		light_at_pos = blend_light(day_night_ratio, LIGHT_SUN, 0);
 
-		if (li != m_last_light)	{
-			m_last_light = li;
-			setNodeLight(li);
-		}
-	}
-
-	// Update light of all children
-	for (u16 i : m_attachment_child_ids) {
-		if (ClientActiveObject *obj = m_env->getActiveObject(i))
-			obj->updateLight(light_at_pos, true);
+	u8 light = decode_light(light_at_pos);
+	if (light != m_last_light) {
+		m_last_light = light;
+		setNodeLight(light);
 	}
 }
 

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -236,7 +236,7 @@ public:
 		m_visuals_expired = true;
 	}
 
-	void updateLight(u8 light_at_pos, bool ignore_parent = false);
+	void updateLight(u32 day_night_ratio);
 
 	void setNodeLight(u8 light);
 

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -236,9 +236,7 @@ public:
 		m_visuals_expired = true;
 	}
 
-	void updateLight(u8 light_at_pos);
-
-	void updateLightNoCheck(u8 light_at_pos);
+	void updateLight(u8 light_at_pos, bool ignore_parent = false);
 
 	void setNodeLight(u8 light);
 


### PR DESCRIPTION
Fixes #9216
Kind of reverts #2949 - no linked issues, no description. Obscure bugfix.

## To do

This PR is Ready for Review.

## How to test

1) Get following tools: entity spawner, remover and attach chain maker
2) Spawn some cubes as follows:
![screenshot_20200601_093543](https://user-images.githubusercontent.com/1497498/83386681-ba82d580-a3eb-11ea-8066-6ae40f48ea2f.jpg)
3) Switch day/night. The light updates for all of them

![screenshot_20200601_100638](https://user-images.githubusercontent.com/1497498/83389096-e99b4600-a3ef-11ea-9db9-b6caac9b41d3.jpg)
