### PR TITLE
New jumping behavior controlled by physics override

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6092,6 +6092,9 @@ object you are working with still exists.
           (default: `false`)
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behaviour (default: `true`)
+        * `new_jump`: use the new jump/bouncy jump code. When `false` the exact
+          old code is used for jumping and bouncy jumping behavior.
+          (default: `true`)
 * `get_physics_override()`: returns the table given to `set_physics_override`
 * `hud_add(hud definition)`: add a HUD element described by HUD def, returns ID
    number on success

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6094,7 +6094,7 @@ object you are working with still exists.
           is used for the specific old sneak behaviour (default: `true`)
         * `new_jump`: use the new jump/bouncy jump code. When `false` the exact
           old code is used for jumping and bouncy jumping behavior.
-          (default: `true`)
+          (default: `false`)
 * `get_physics_override()`: returns the table given to `set_physics_override`
 * `hud_add(hud definition)`: add a HUD element described by HUD def, returns ID
    number on success

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1593,7 +1593,7 @@ void GenericCAO::processMessage(const std::string &data)
 		bool sneak = !readU8(is);
 		bool sneak_glitch = !readU8(is);
 		bool new_move = !readU8(is);
-		bool new_jump = !readU8(is);
+		bool new_jump = readU8(is);
 
 
 		if(m_is_local_player)

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1593,6 +1593,7 @@ void GenericCAO::processMessage(const std::string &data)
 		bool sneak = !readU8(is);
 		bool sneak_glitch = !readU8(is);
 		bool new_move = !readU8(is);
+		bool new_jump = !readU8(is);
 
 
 		if(m_is_local_player)
@@ -1604,6 +1605,7 @@ void GenericCAO::processMessage(const std::string &data)
 			player->physics_override_sneak = sneak;
 			player->physics_override_sneak_glitch = sneak_glitch;
 			player->physics_override_new_move = new_move;
+			player->physics_override_new_jump = new_jump;
 		}
 	} else if (cmd == AO_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -444,8 +444,9 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	m_can_jump = ((touching_ground && !is_climbing) || sneak_can_jump) && !m_disable_jump;
 
 	// Jump key pressed while jumping off from a bouncy block
-	if (m_can_jump && control.jump && itemgroup_get(f.groups, "bouncy") &&
-		m_speed.Y >= -0.5f * BS) {
+	if ((!physics_override_new_jump && m_can_jump && control.jump && itemgroup_get(f.groups, "bouncy") && m_speed.Y >= -0.5f * BS)||
+		(physics_override_new_jump && control.jump && itemgroup_get(f.groups, "bouncy") && 
+		m_speed.Y >= -0.5f * BS && m_speed.Y <= itemgroup_get(f.groups, "bouncy"))) {
 		float jumpspeed = movement_speed_jump * physics_override_jump;
 		if (m_speed.Y > 1.0f) {
 			// Reduce boost when speed already is high
@@ -609,7 +610,8 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				at its starting value
 			*/
 			v3f speedJ = getSpeed();
-			if (speedJ.Y >= -0.5f * BS) {
+			if ((!physics_override_new_jump && speedJ.Y >= -0.5f * BS) ||
+				(physics_override_new_jump && touching_ground && speedJ.Y >= -0.5f * BS && speedJ.Y <= 0.5f * BS)) {
 				speedJ.Y = movement_speed_jump * physics_override_jump;
 				setSpeed(speedJ);
 				m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_JUMP));

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -441,11 +441,18 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	// Determine if jumping is possible
 	m_disable_jump = itemgroup_get(f.groups, "disable_jump") ||
 		itemgroup_get(f1.groups, "disable_jump");
+	
 	m_can_jump = ((touching_ground && !is_climbing) || sneak_can_jump) && !m_disable_jump;
+	//new bouncy jump style
+	if (physics_override_new_jump) {
+		m_can_bouncy_jump = (!is_climbing || sneak_can_jump && !m_disable_jump);
+	}else if(!physics_override_new_jump){ //old bouncy jump style
+		m_can_bouncy_jump = ((touching_ground && !is_climbing) || sneak_can_jump) && !m_disable_jump;
+	}
 
 	// Jump key pressed while jumping off from a bouncy block
-	if ((!physics_override_new_jump && m_can_jump && control.jump && itemgroup_get(f.groups, "bouncy") && m_speed.Y >= -0.5f * BS)||
-		(physics_override_new_jump && control.jump && itemgroup_get(f.groups, "bouncy") && 
+	if ((!physics_override_new_jump && m_can_bouncy_jump && control.jump && itemgroup_get(f.groups, "bouncy") && m_speed.Y >= -0.5f * BS)||
+		(physics_override_new_jump && m_can_bouncy_jump && control.jump && itemgroup_get(f.groups, "bouncy") && 
 		m_speed.Y >= -0.5f * BS && m_speed.Y <= itemgroup_get(f.groups, "bouncy"))) {
 		float jumpspeed = movement_speed_jump * physics_override_jump;
 		if (m_speed.Y > 1.0f) {

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -611,7 +611,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			*/
 			v3f speedJ = getSpeed();
 			if ((!physics_override_new_jump && speedJ.Y >= -0.5f * BS) ||
-				(physics_override_new_jump && touching_ground && speedJ.Y >= -0.5f * BS && speedJ.Y <= 0.5f * BS)) {
+				(physics_override_new_jump && touching_ground && fabsf(speedJ.Y) <= 0.5f * BS)) {
 				speedJ.Y = movement_speed_jump * physics_override_jump;
 				setSpeed(speedJ);
 				m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_JUMP));

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -194,6 +194,7 @@ private:
 
 	bool m_can_jump = false;
 	bool m_disable_jump = false;
+	bool m_can_bouncy_jump = false;
 	u16 m_breath = PLAYER_MAX_BREATH_DEFAULT;
 	f32 m_yaw = 0.0f;
 	f32 m_pitch = 0.0f;

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -66,6 +66,7 @@ public:
 	float physics_override_gravity = 1.0f;
 	bool physics_override_sneak = true;
 	bool physics_override_sneak_glitch = false;
+	bool physics_override_new_jump = true;
 	// Temporary option for old move code
 	bool physics_override_new_move = true;
 

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -66,7 +66,7 @@ public:
 	float physics_override_gravity = 1.0f;
 	bool physics_override_sneak = true;
 	bool physics_override_sneak_glitch = false;
-	bool physics_override_new_jump = true;
+	bool physics_override_new_jump = false;
 	// Temporary option for old move code
 	bool physics_override_new_move = true;
 

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -176,7 +176,7 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushboolean(L, player->physics_override_new_move);
 	lua_setfield(L, -2, "new_move");
 
-	lua_pushboolean(L, player->physics_override_new_move);
+	lua_pushboolean(L, player->physics_override_new_jump);
 	lua_setfield(L, -2, "new_jump");
 
 	return 1;

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -176,6 +176,9 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushboolean(L, player->physics_override_new_move);
 	lua_setfield(L, -2, "new_move");
 
+	lua_pushboolean(L, player->physics_override_new_move);
+	lua_setfield(L, -2, "new_jump");
+
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -386,7 +386,7 @@ int ObjectRef::l_get_armor_groups(lua_State *L)
 }
 
 // set_physics_override(self, physics_override_speed, physics_override_jump,
-//                      physics_override_gravity, sneak, sneak_glitch, new_move)
+//                      physics_override_gravity, sneak, sneak_glitch, new_move, new_jump)
 int ObjectRef::l_set_physics_override(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -407,6 +407,8 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 				L, 2, "sneak_glitch", co->m_physics_override_sneak_glitch);
 		co->m_physics_override_new_move = getboolfield_default(
 				L, 2, "new_move", co->m_physics_override_new_move);
+		co->m_physics_override_new_jump = getboolfield_default(
+				L, 2, "new_jump", co->m_physics_override_new_jump);
 		co->m_physics_override_sent = false;
 	} else {
 		// old, non-table format
@@ -448,6 +450,8 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "sneak_glitch");
 	lua_pushboolean(L, co->m_physics_override_new_move);
 	lua_setfield(L, -2, "new_move");
+	lua_pushboolean(L, co->m_physics_override_new_jump);
+	lua_setfield(L, -2, "new_jump");
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -116,7 +116,7 @@ private:
 	static int l_get_armor_groups(lua_State *L);
 
 	// set_physics_override(self, physics_override_speed, physics_override_jump,
-	//                      physics_override_gravity, sneak, sneak_glitch, new_move)
+	//                      physics_override_gravity, sneak, sneak_glitch, new_move, new_jump)
 	static int l_set_physics_override(lua_State *L);
 
 	// get_physics_override(self)

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -339,6 +339,7 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeU8(os, !m_physics_override_sneak);
 	writeU8(os, !m_physics_override_sneak_glitch);
 	writeU8(os, !m_physics_override_new_move);
+	writeU8(os, !m_physics_override_new_jump);
 	return os.str();
 }
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -339,7 +339,7 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeU8(os, !m_physics_override_sneak);
 	writeU8(os, !m_physics_override_sneak_glitch);
 	writeU8(os, !m_physics_override_new_move);
-	writeU8(os, !m_physics_override_new_jump);
+	writeU8(os, m_physics_override_new_jump);
 	return os.str();
 }
 

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -223,6 +223,7 @@ public:
 	bool m_physics_override_sneak = true;
 	bool m_physics_override_sneak_glitch = false;
 	bool m_physics_override_new_move = true;
+	bool m_physics_override_new_jump = true;
 	bool m_physics_override_sent = false;
 };
 

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -223,7 +223,7 @@ public:
 	bool m_physics_override_sneak = true;
 	bool m_physics_override_sneak_glitch = false;
 	bool m_physics_override_new_move = true;
-	bool m_physics_override_new_jump = true;
+	bool m_physics_override_new_jump = false;
 	bool m_physics_override_sent = false;
 };
 


### PR DESCRIPTION
## Goal of the PR

1) To create a new physics override that allows players and modders to select if they want the new consistent jumping code or the old floaty one.

2) To fix the bug that allows players to jump up nodes irregularly and essentially negate having to have stairs by making "staircases" of nodes.

3) To fix the glitch that players cannot jump on bouncy nodes unless coming to a halt.

## How does the PR work?

I've added in a new physics override `new_jump`.
It is on by default, but players and modders can select between the new and old code using:
```
player:set_physics_override({new_jump=boolean})
```

Here is a video: https://youtu.be/Jt7QFyiINbM

## Status

Ready for Review.

- [x] Make new_jump a physics_override.
- [x] Fix jumping to be consistent. (landing on node completely)
- [x] Fix not being able to keep bounce-jumping on bouncy node.

## How to test
Create a mod with this in the init.lua:
```Lua
local test = true
local function swap_physics()
	for _,player in ipairs(minetest.get_connected_players()) do
		player:set_physics_override({new_jump=test})
		minetest.chat_send_all("new_jump: "..tostring(test))
	end
	test = not test
	minetest.after(10,function()
		swap_physics()
	end)
end

swap_physics()
```
Then bounce and jump on nodes.

EDIT by SmallJoker: Format the post.