### PR TITLE
Add LevelDB player database.

### DIFF
--- a/doc/minetest.6
+++ b/doc/minetest.6
@@ -105,12 +105,12 @@ Migrate from current map backend to another. Possible values are sqlite3,
 leveldb, redis, postgresql, and dummy.
 .TP
 .B \-\-migrate-auth <value>
-Migrate from current auth backend to another. Possible values are sqlite3 and
-files.
+Migrate from current auth backend to another. Possible values are sqlite3,
+leveldb, and files.
 .TP
 .B \-\-migrate-players <value>
 Migrate from current players backend to another. Possible values are sqlite3,
-postgresql, dummy, and files.
+leveldb, postgresql, dummy, and files.
 .TP
 .B \-\-terminal
 Display an interactive terminal over ncurses during execution.

--- a/src/database/database-leveldb.cpp
+++ b/src/database/database-leveldb.cpp
@@ -117,7 +117,7 @@ PlayerDatabaseLevelDB::~PlayerDatabaseLevelDB()
 void PlayerDatabaseLevelDB::savePlayer(RemotePlayer *player)
 {
 	/*
-	u8 version = 0
+	u8 version = 1
 	u16 hp
 	v3f position
 	f32 pitch

--- a/src/database/database-leveldb.cpp
+++ b/src/database/database-leveldb.cpp
@@ -149,9 +149,7 @@ void PlayerDatabaseLevelDB::savePlayer(RemotePlayer *player)
 		os << serializeLongString(it.second);
 	}
 
-	std::ostringstream serialized_inventory;
-	player->inventory.serialize(serialized_inventory);
-	os << serializeLongString(serialized_inventory.str());
+	player->inventory.serialize(os);
 
 	leveldb::Status status = m_database->Put(leveldb::WriteOptions(),
 		player->getName(), os.str());
@@ -191,9 +189,9 @@ bool PlayerDatabaseLevelDB::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 	}
 	sao->getMeta().setModified(false);
 
-	std::istringstream serialized_inventory(deSerializeLongString(is));
+	// This should always be last.
 	try {
-		player->inventory.deSerialize(serialized_inventory);
+		player->inventory.deSerialize(is);
 	} catch (SerializationError &e) {
 		errorstream << "Failed to deserialize player inventory. player_name="
 			<< player->getName() << " " << e.what() << std::endl;

--- a/src/database/database-leveldb.h
+++ b/src/database/database-leveldb.h
@@ -45,6 +45,21 @@ private:
 	leveldb::DB *m_database;
 };
 
+class PlayerDatabaseLevelDB : public PlayerDatabase
+{
+public:
+	PlayerDatabaseLevelDB(const std::string &savedir);
+	~PlayerDatabaseLevelDB();
+
+	void savePlayer(RemotePlayer *player);
+	bool loadPlayer(RemotePlayer *player, PlayerSAO *sao);
+	bool removePlayer(const std::string &name);
+	void listPlayers(std::vector<std::string> &res);
+
+private:
+	leveldb::DB *m_database;
+};
+
 class AuthDatabaseLevelDB : public AuthDatabase
 {
 public:

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -2123,7 +2123,7 @@ bool ServerEnvironment::migratePlayersDatabase(const GameParams &game_params,
 	if (!world_mt.exists("player_backend")) {
 		errorstream << "Please specify your current backend in world.mt:"
 			<< std::endl
-			<< "	player_backend = {files|sqlite3|postgresql}"
+			<< "	player_backend = {files|sqlite3|leveldb|postgresql}"
 			<< std::endl;
 		return false;
 	}

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -2089,6 +2089,7 @@ PlayerDatabase *ServerEnvironment::openPlayerDatabase(const std::string &name,
 
 	if (name == "dummy")
 		return new Database_Dummy();
+
 #if USE_POSTGRESQL
 	if (name == "postgresql") {
 		std::string connect_string;
@@ -2096,6 +2097,12 @@ PlayerDatabase *ServerEnvironment::openPlayerDatabase(const std::string &name,
 		return new PlayerDatabasePostgreSQL(connect_string);
 	}
 #endif
+
+#if USE_LEVELDB
+	if (name == "leveldb")
+		return new PlayerDatabaseLevelDB(savedir);
+#endif
+
 	if (name == "files")
 		return new PlayerDatabaseFiles(savedir + DIR_DELIM + "players");
 


### PR DESCRIPTION
*Follow-up of https://github.com/minetest/minetest/pull/9476.*

- Goal of the PR

To allow LevelDB to be used as the players database (`players.sqlite`).

- Does it resolve any reported issue?

No.

- If not a bug fix, why is this PR needed? What usecases does it solve?

This provides an alternative player database format for people who do not want to use sqlite but don't want the performance hit of using the legacy file-based format.

## To do

This PR is ready for review.

## How to test

Create a new world and add `player_backend = leveldb` to world.mt.
