### PR TITLE
Stop stair detection from jolting up player and entities

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -499,6 +499,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			bool step_up = (nearest_collided != COLLISION_AXIS_Y) && // must not be Y direction
 					(movingbox.MinEdge.Y < cbox.MaxEdge.Y) &&
 					(movingbox.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
+					(speed_f->Y <= 0.f) &&
 					(!wouldCollideWithCeiling(cinfo, stepbox,
 							cbox.MaxEdge.Y - movingbox.MinEdge.Y,
 							d));

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -499,7 +499,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			bool step_up = (nearest_collided != COLLISION_AXIS_Y) && // must not be Y direction
 					(movingbox.MinEdge.Y < cbox.MaxEdge.Y) &&
 					(movingbox.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
-					(speed_f->Y <= 0.f) &&
+					(speed_f->Y <= 0.0f) &&
 					(!wouldCollideWithCeiling(cinfo, stepbox,
 							cbox.MaxEdge.Y - movingbox.MinEdge.Y,
 							d));


### PR DESCRIPTION
- Goal of the PR

To stop this from happening: https://youtu.be/_2waJc_NI7Q

If you notice the player will get jolted up when trying to jump over a node. This stops that from happening.

- How does the PR work?

Added: ```(speed_f->Y <= 0.0f) &&``` to stair detection, line 502 of collision.cpp

- Does it resolve any reported issue?

I'm not sure.

Ready for Review.

## How to test

Add it to your source code and walk around the world, testing nodes with it.