### PR TITLE
Add smooth walking down stairs

### DIFF
--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -343,7 +343,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 		player_position = player->getParent()->getPosition();
 
 	if(player->touching_ground &&
-			player_position.Y > old_player_position.Y)
+			player_position.Y != old_player_position.Y)
 	{
 		f32 oldy = old_player_position.Y;
 		f32 newy = player_position.Y;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -598,6 +598,14 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				box = box_0;
 				box.MinEdge += *pos_f;
 				box.MaxEdge += *pos_f;
+			}else if((cbox.MaxEdge.X - cbox.MinEdge.X != 10 || cbox.MaxEdge.Y - cbox.MinEdge.Y != 10 || cbox.MaxEdge.Z - cbox.MinEdge.Z != 10) &&
+				box.MinEdge.Y > cbox.MaxEdge.Y && box.MinEdge.Y - (stepheight * 2) < cbox.MaxEdge.Y && 
+				speed_f->Y < 0.0f && speed_f->Y > -3.0f * BS){
+				pos_f->Y = cbox.MaxEdge.Y;
+				speed_f->Y = 0.0f;
+				box = box_0;
+				box.MinEdge += *pos_f;
+				box.MaxEdge += *pos_f;
 			}
 			if (std::fabs(cbox.MaxEdge.Y - box.MinEdge.Y) < 0.05f) {
 				result.touching_ground = true;


### PR DESCRIPTION
- Goal of the PR

To make walking down stairs smoother.

- How does the PR work?

Creates another hook at the end of collision detection to check if you're walking down something that could be considered a "stair". It also modified the smooth Y transition of the camera to allow for moving up or down.

It will not affect regular collisionbox nodes.

Here is a short video: https://youtu.be/K8r-X2KVUO4

- Does it resolve any reported issue?

None.

- If not a bug fix, why is this PR needed? What usecases does it solve?

To make the game more polished.

Ready for Review.

- [ ] Test, test, test

## How to test

Get some stairs or slabs, walk down them.