### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ For Alpine users:
 
     sudo apk add build-base irrlicht-dev cmake bzip2-dev libpng-dev jpeg-dev libxxf86vm-dev mesa-dev sqlite-dev libogg-dev libvorbis-dev openal-soft-dev curl-dev freetype-dev zlib-dev gmp-dev jsoncpp-dev luajit-dev
 
+For OpenBSD users:
+
+    doas pkg_add cmake curl doxygen gmp irrlicht jsoncpp libvorbis luajit openal sqlite3
+
+
 #### Download
 
 You can install Git for easily keeping your copy up to date.
@@ -196,7 +201,7 @@ Download minetest_game, without using Git:
 Build a version that runs directly from the source directory:
 
     cmake . -DRUN_IN_PLACE=TRUE
-    make -j$(nproc)
+    make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)
 
 Run it:
 


### PR DESCRIPTION
- This PR adds OpenBSD instructions for compiling
- It doesn't solve any reported issues.
- It's needed because it helps OpenBSD users figuring out how to compile minetest.

## To do

This PR is Ready for Review.

## How to test

Compile minetest on a fresh OpenBSD installation.