### PR TITLE
[Trivial] TestBan: Cleanup properly after completing test

### DIFF
--- a/src/unittest/test_ban.cpp
+++ b/src/unittest/test_ban.cpp
@@ -61,6 +61,9 @@ void TestBan::runTests(IGameDef *gamedef)
 
 	reinitTestEnv();
 	TEST(testGetBanDescription);
+
+	// Delete leftover files
+	reinitTestEnv();
 }
 
 // This module is stateful due to disk writes, add helper to remove files


### PR DESCRIPTION
Tested; works.

Note: `testbm.txt` has already been added to `.gitignore`, so this isn't a major concern with regards to accidentally staging and committing the file.

## How to test
<!-- Example code or instructions -->

- Run unittests (`minetest --run-unittests`)
- Ensure that `testbm.txt` doesn't exist at the repo root after the tests are over.