### PR TITLE
ObjectRef configurable light sampling anchor

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6594,6 +6594,13 @@ Player properties need to be saved manually.
         -- For faking self-lighting, UI style entities, or programmatic coloring
         -- in mods.
 
+        light_anchor = {x = 0, y = 0, z = 0},
+        -- Use this position when sampling light from the world.
+        -- The anchor is relative to the entity, Z being the local front & back,
+        -- and X being the local left & right.
+        -- Player objects have a different default light anchor,
+        -- { x = 0, y = 0.5, z = 0 } instead of the one above.
+
         nametag = "",
         -- By default empty, for players their name is shown if empty
 

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -845,12 +845,30 @@ void GenericCAO::setNodeLight(u8 light)
 	}
 }
 
+m4x4f GenericCAO::getTransform()
+{
+	scene::ISceneNode *node = getSceneNode();
+	if (node)
+		return node->getAbsoluteTransformation();
+
+	return m4x4f(m4x4f::EM4CONST_IDENTITY);
+}
+
 v3s16 GenericCAO::getLightPosition()
 {
-	if (m_is_player)
-		return floatToInt(m_position + v3f(0, 0.5 * BS, 0), BS);
+	// Players and entities now both use a property to define the light sampling offset.
+	// The offset is in the entity's local space.
 
-	return floatToInt(m_position, BS);
+	v3f offset = v3f(m_prop.light_anchor);
+	if (offset == v3f(0,0,0)) {
+		// No transformation is applied if the offset is zero.
+		return floatToInt(m_position, BS);
+	}
+
+	m4x4f transform = getTransform();
+	transform.rotateVect(offset);
+
+	return floatToInt(m_position + offset, BS);
 }
 
 void GenericCAO::updateNametag()

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -173,6 +173,8 @@ public:
 
 	scene::ISceneNode *getSceneNode() const;
 
+	m4x4f getTransform();
+
 	scene::IAnimatedMeshSceneNode *getAnimatedMeshSceneNode() const;
 
 	// m_matrixnode controls the position and rotation of the child node

--- a/src/irr_matrix.h
+++ b/src/irr_matrix.h
@@ -1,0 +1,26 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes.h"
+
+#include <matrix4.h>
+
+typedef core::CMatrix4<float> m4x4f;

--- a/src/irrlichttypes_bloated.h
+++ b/src/irrlichttypes_bloated.h
@@ -24,5 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irr_v2d.h"
 #include "irr_v3d.h"
 #include "irr_aabb3d.h"
+#include "irr_matrix.h"
 
 #include <SColor.h>

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -69,6 +69,7 @@ std::string ObjectProperties::dump()
 	os << ", zoom_fov=" << zoom_fov;
 	os << ", use_texture_alpha=" << use_texture_alpha;
 	os << ", damage_texture_modifier=" << damage_texture_modifier;
+	os << ", light_anchor=" << PP(light_anchor);
 	return os.str();
 }
 
@@ -116,6 +117,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeF32(os, zoom_fov);
 	writeU8(os, use_texture_alpha);
 	os << serializeString(damage_texture_modifier);
+	writeV3F1000(os, light_anchor);
 
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
@@ -171,4 +173,5 @@ void ObjectProperties::deSerialize(std::istream &is)
 	try {
 		damage_texture_modifier = deSerializeString(is);
 	} catch (SerializationError &e) {}
+	light_anchor = readV3F1000(is);
 }

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -61,6 +61,7 @@ struct ObjectProperties
 	float eye_height = 1.625f;
 	float zoom_fov = 0.0f;
 	bool use_texture_alpha = false;
+	v3f light_anchor = v3f(0.0f, 0.0f, 0.0f);
 
 	ObjectProperties();
 	std::string dump();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -329,6 +329,12 @@ void read_object_properties(lua_State *L, int index,
 	getboolfield(L, -1, "use_texture_alpha", prop->use_texture_alpha);
 
 	getstringfield(L, -1, "damage_texture_modifier", prop->damage_texture_modifier);
+
+	lua_getfield(L, -1, "light_anchor");
+	bool has_light_anchor = lua_istable(L, -1);
+	if (has_light_anchor)
+		prop->light_anchor = read_v3f(L, -1);
+	lua_pop(L, 1);
 }
 
 /******************************************************************************/

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -59,6 +59,8 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t p
 	m_breath = m_prop.breath_max;
 	// Disable zoom in survival mode using a value of 0
 	m_prop.zoom_fov = g_settings->getBool("creative_mode") ? 15.0f : 0.0f;
+	// Emulate old light anchor
+	m_prop.light_anchor = v3f(0.0f, 0.5f, 0.0f);
 
 	if (!g_settings->getBool("enable_damage"))
 		m_armor_groups["immortal"] = 1;


### PR DESCRIPTION
Redo of #7626
_Works On My Machine™_
No code has been changed. Some whitespace errors were caught.

Adds a configurable light sampling anchor point to ObjectRef. The default is 0,0,0 for entities and 0,.5,0 for players, which emulates old behavior. Mitigates the bug where entities and attached players standing on solid slabs would be dimmed or turned black.

Some matrix related functionality was added to CAO to support this. The matrix multiply is avoided if the anchor is at the entity's origin.