### PR TITLE
Add HTTP API to main menu

### DIFF
--- a/builtin/fstk/dialog.lua
+++ b/builtin/fstk/dialog.lua
@@ -75,7 +75,7 @@ function messagebox(name, message)
 					formspec_version[3]
 					size[8,3]
 					textarea[0.375,0.375;7.25,1.2;;;%s]
-					button[3,1.825;2,0.8;back;%s]"
+					button[3,1.825;2,0.8;back;%s]
 				]]):format(message, fgettext("Back"))
 			end,
 			function(this, fields)

--- a/builtin/fstk/dialog.lua
+++ b/builtin/fstk/dialog.lua
@@ -67,3 +67,22 @@ function dialog_create(name,get_formspec,buttonhandler,eventhandler)
 	ui.add(self)
 	return self
 end
+
+function messagebox(name, message)
+	return dialog_create(name,
+			function()
+				return ([[
+					formspec_version[3]
+					size[8,3]
+					textarea[0.375,0.375;7.25,1.2;;;%s]
+					button[3,1.825;2,0.8;back;%s]"
+				]]):format(message, fgettext("Back"))
+			end,
+			function(this, fields)
+				if fields.back then
+					this:delete()
+					return true
+				end
+			end,
+			nil)
+end

--- a/builtin/fstk/dialog.lua
+++ b/builtin/fstk/dialog.lua
@@ -75,11 +75,11 @@ function messagebox(name, message)
 					formspec_version[3]
 					size[8,3]
 					textarea[0.375,0.375;7.25,1.2;;;%s]
-					button[3,1.825;2,0.8;back;%s]
-				]]):format(message, fgettext("Back"))
+					button[3,1.825;2,0.8;ok;%s]
+				]]):format(message, fgettext("OK"))
 			end,
 			function(this, fields)
-				if fields.back then
+				if fields.ok then
 					this:delete()
 					return true
 				end

--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -85,7 +85,7 @@ function ui.update()
 			"box[0.5,1.2;13,5;#000]",
 			("textarea[0.5,1.2;13,5;;%s;%s]"):format(
 				error_title, error_message),
-			"button[5,6.6;4,1;btn_error_confirm;" .. fgettext("Ok") .. "]"
+			"button[5,6.6;4,1;btn_error_confirm;" .. fgettext("OK") .. "]"
 		}
 	else
 		local active_toplevel_ui_elements = 0

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -36,6 +36,7 @@ dofile(commonpath .. "misc_helpers.lua")
 
 if INIT == "game" then
 	dofile(gamepath .. "init.lua")
+	assert(not core.get_http_api)
 elseif INIT == "mainmenu" then
 	local mm_script = core.settings:get("main_menu_script")
 	if mm_script and mm_script ~= "" then

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -15,9 +15,17 @@
 --with this program; if not, write to the Free Software Foundation, Inc.,
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+if not minetest.get_http_api then
+	function create_store_dlg()
+		local msg = fgettext("ContentDB is not available when Minetest was compiled without cURL")
+		return messagebox("store", msg)
+	end
+	return
+end
+
 local store = { packages = {}, packages_full = {} }
 
-local http = minetest.request_http_api()
+local http = minetest.get_http_api()
 
 -- Screenshot
 local screenshot_dir = core.get_cache_path() .. DIR_DELIM .. "cdb"

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -17,8 +17,8 @@
 
 if not minetest.get_http_api then
 	function create_store_dlg()
-		local msg = fgettext("ContentDB is not available when Minetest was compiled without cURL")
-		return messagebox("store", msg)
+		return messagebox("store",
+				fgettext("ContentDB is not available when Minetest was compiled without cURL"))
 	end
 	return
 end

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -1,5 +1,5 @@
 --Minetest
---Copyright (C) 2018 rubenwardy
+--Copyright (C) 2018-20 rubenwardy
 --
 --This program is free software; you can redistribute it and/or modify
 --it under the terms of the GNU Lesser General Public License as published by

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -194,7 +194,8 @@ function store.load()
 		end
 	end
 
-	local response = http.fetch_sync({ url = url })
+	local timeout = tonumber(minetest.settings:get("curl_file_download_timeout"))
+	local response = http.fetch_sync({ url = url, timeout = timeout })
 	if not response.succeeded then
 		return
 	end

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -194,7 +194,7 @@ function store.load()
 		end
 	end
 
-	local response = http.fetch_sync({ url = url, timeout = 10 })
+	local response = http.fetch_sync({ url = url })
 	if not response.succeeded then
 		return
 	end

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -17,8 +17,7 @@
 
 local store = { packages = {}, packages_full = {} }
 
-local http = assert(minetest.request_http_api())
-print(dump(http))
+local http = minetest.request_http_api()
 
 -- Screenshot
 local screenshot_dir = core.get_cache_path() .. DIR_DELIM .. "cdb"

--- a/doc/fst_api.txt
+++ b/doc/fst_api.txt
@@ -101,6 +101,9 @@ dialog_create(name, cbf_formspec, cbf_button_handler, cbf_events)
 ^ cbf_events: function to handle events
 	function(dialog, event)
 
+messagebox(name, message)
+^ creates a message dialog
+
 Class reference dialog:
 
 methods:
@@ -113,13 +116,13 @@ methods:
   ^ hide dialog
 - delete()
   ^ delete dialog from ui
-  
+
 members:
 - data
   ^ variable data attached to this dialog
 - parent
   ^ parent component to return to on exit
-  
+
 File: fst/buttonbar.lua
 -----------------------
 

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -27,10 +27,13 @@ The "gamedata" table is read when calling core.start(). It should contain:
 
 Functions
 ---------
+
 core.start()
 core.close()
 
-Filesystem:
+Filesystem
+----------
+
 core.get_builtin_path()
 ^ returns path to builtin root
 core.create_dir(absolute_path) (possible in async calls)
@@ -48,10 +51,6 @@ core.extract_zip(zipfile,destination) [unzip within path required]
 ^ zipfile to extract
 ^ destination folder to extract to
 ^ returns true/false
-core.download_file(url,target) (possible in async calls)
-^ url to download
-^ target to store to
-^ returns true/false
 core.get_version() (possible in async calls)
 ^ returns current core version
 core.sound_play(spec, looped) -> handle
@@ -67,7 +66,88 @@ core.get_mapgen_names([include_hidden=false]) -> table of map generator algorith
     registered in the core (possible in async calls)
 core.get_cache_path() -> path of cache
 
-Formspec:
+HTTP Requests
+-------------
+* core.download_file(url, target) (possible in async calls)
+	* url to download, and target to store to
+	* returns true/false
+* `minetest.request_http_api()` (possible in async calls)
+    * returns `HTTPApiTable` containing http functions if the calling mod has
+      been granted access by being listed in the `secure.http_mods` or
+      `secure.trusted_mods` setting, otherwise returns `nil`.
+    * The returned table contains the functions `fetch`, `fetch_async` and
+      `fetch_async_get` described below.
+    * Only works at init time and must be called from the mod's main scope
+      (not from a function).
+    * Function only exists if minetest server was built with cURL support.
+    * **DO NOT ALLOW ANY OTHER MODS TO ACCESS THE RETURNED TABLE, STORE IT IN
+      A LOCAL VARIABLE!**
+* `HTTPApiTable.fetch(HTTPRequest req, callback)`
+    * Performs given request asynchronously and calls callback upon completion
+    * callback: `function(HTTPRequestResult res)`
+    * Use this HTTP function if you are unsure, the others are for advanced use
+* `HTTPApiTable.fetch_async(HTTPRequest req)`: returns handle
+    * Performs given request asynchronously and returns handle for
+      `HTTPApiTable.fetch_async_get`
+* `HTTPApiTable.fetch_async_get(handle)`: returns HTTPRequestResult
+    * Return response data for given asynchronous HTTP request
+
+### `HTTPRequest` definition
+
+Used by `HTTPApiTable.fetch` and `HTTPApiTable.fetch_async`.
+
+    {
+        url = "http://example.org",
+
+        timeout = 10,
+        -- Timeout for connection in seconds. Default is 3 seconds.
+
+        post_data = "Raw POST request data string" OR {field1 = "data1", field2 = "data2"},
+        -- Optional, if specified a POST request with post_data is performed.
+        -- Accepts both a string and a table. If a table is specified, encodes
+        -- table as x-www-form-urlencoded key-value pairs.
+        -- If post_data is not specified, a GET request is performed instead.
+
+        user_agent = "ExampleUserAgent",
+        -- Optional, if specified replaces the default minetest user agent with
+        -- given string
+
+        extra_headers = { "Accept-Language: en-us", "Accept-Charset: utf-8" },
+        -- Optional, if specified adds additional headers to the HTTP request.
+        -- You must make sure that the header strings follow HTTP specification
+        -- ("Key: Value").
+
+        multipart = boolean
+        -- Optional, if true performs a multipart HTTP request.
+        -- Default is false.
+    }
+
+### `HTTPRequestResult` definition
+
+Passed to `HTTPApiTable.fetch` callback. Returned by
+`HTTPApiTable.fetch_async_get`.
+
+    {
+        completed = true,
+        -- If true, the request has finished (either succeeded, failed or timed
+        -- out)
+
+        succeeded = true,
+        -- If true, the request was successful
+
+        timeout = false,
+        -- If true, the request timed out
+
+        code = 200,
+        -- HTTP status code
+
+        data = "response"
+    }
+
+
+Formspec
+--------
+
 core.update_formspec(formspec)
 core.get_table_index(tablename) -> index
 ^ can also handle textlists
@@ -82,7 +162,9 @@ core.explode_textlist_event(string) -> table
 core.set_formspec_prepend(formspec)
 ^ string to be added to every mainmenu formspec, to be used for theming.
 
-GUI:
+GUI
+---
+
 core.set_background(type, texturepath,[tile],[minsize])
 ^ type: "background", "overlay", "header" or "footer"
 ^ tile: tile the image instead of scaling (background only)

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -92,7 +92,7 @@ HTTP Requests
     * The returned table contains the functions `fetch_sync`, `fetch_async` and
       `fetch_async_get` described below.
     * Function only exists if minetest server was built with cURL support.
-* `HTTPApiTable.fetch_sync(HTTPRequest req, callback)`: returns HTTPRequestResult
+* `HTTPApiTable.fetch_sync(HTTPRequest req)`: returns HTTPRequestResult
     * Performs given request synchronously
 * `HTTPApiTable.fetch_async(HTTPRequest req)`: returns handle
     * Performs given request asynchronously and returns handle for

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -3,33 +3,49 @@ Minetest Lua Mainmenu API Reference 5.3.0
 
 Introduction
 -------------
+
 The main menu is defined as a formspec by Lua in builtin/mainmenu/
 Description of formspec language to show your menu is in lua_api.txt
 
+
 Callbacks
 ---------
+
 core.buttonhandler(fields): called when a button is pressed.
 ^ fields = {name1 = value1, name2 = value2, ...}
 core.event_handler(event)
 ^ event: "MenuQuit", "KeyEnter", "ExitButton" or "EditBoxEnter"
 
+
 Gamedata
 --------
+
 The "gamedata" table is read when calling core.start(). It should contain:
 {
-	playername     = <name>,
-	password       = <password>,
-	address        = <IP/adress>,
-	port           = <port>,
-	selected_world = <index>, -- 0 for client mode
-	singleplayer   = <true/false>,
+    playername     = <name>,
+    password       = <password>,
+    address        = <IP/adress>,
+    port           = <port>,
+    selected_world = <index>, -- 0 for client mode
+    singleplayer   = <true/false>,
 }
+
 
 Functions
 ---------
 
 core.start()
 core.close()
+core.get_min_supp_proto()
+^ returns the minimum supported network protocol version
+core.get_max_supp_proto()
+^ returns the maximum supported network protocol version
+core.open_url(url)
+^ opens the URL in a web browser, returns false on failure.
+^ Must begin with http:// or https://
+core.get_version() (possible in async calls)
+^ returns current core version
+
 
 Filesystem
 ----------
@@ -51,8 +67,6 @@ core.extract_zip(zipfile,destination) [unzip within path required]
 ^ zipfile to extract
 ^ destination folder to extract to
 ^ returns true/false
-core.get_version() (possible in async calls)
-^ returns current core version
 core.sound_play(spec, looped) -> handle
 ^ spec = SimpleSoundSpec (see lua-api.txt)
 ^ looped = bool
@@ -66,11 +80,13 @@ core.get_mapgen_names([include_hidden=false]) -> table of map generator algorith
     registered in the core (possible in async calls)
 core.get_cache_path() -> path of cache
 
+
 HTTP Requests
 -------------
+
 * core.download_file(url, target) (possible in async calls)
-	* url to download, and target to store to
-	* returns true/false
+    * url to download, and target to store to
+    * returns true/false
 * `minetest.request_http_api()` (possible in async calls)
     * returns `HTTPApiTable` containing http functions if the calling mod has
       been granted access by being listed in the `secure.http_mods` or
@@ -162,6 +178,7 @@ core.explode_textlist_event(string) -> table
 core.set_formspec_prepend(formspec)
 ^ string to be added to every mainmenu formspec, to be used for theming.
 
+
 GUI
 ---
 
@@ -184,86 +201,96 @@ core.show_path_select_dialog(formname, caption, is_file_select)
 ^ returns nil or selected file/folder
 core.get_screen_info()
 ^ returns {
-	density         = <screen density 0.75,1.0,2.0,3.0 ... (dpi)>,
-	display_width   = <width of display>,
-	display_height  = <height of display>,
-	window_width    = <current window width>,
-	window_height   = <current window height>
-	}
+    density         = <screen density 0.75,1.0,2.0,3.0 ... (dpi)>,
+    display_width   = <width of display>,
+    display_height  = <height of display>,
+    window_width    = <current window width>,
+    window_height   = <current window height>
+    }
 
-### Content and Packages
+
+Content and Packages
+--------------------
 
 Content - an installed mod, modpack, game, or texture pack (txt)
 Package - content which is downloadable from the content db, may or may not be installed.
 
 * core.get_modpath() (possible in async calls)
-	* returns path to global modpath
+    * returns path to global modpath
 * core.get_clientmodpath() (possible in async calls)
-	* returns path to global client-side modpath
+    * returns path to global client-side modpath
 * core.get_gamepath() (possible in async calls)
-	* returns path to global gamepath
+    * returns path to global gamepath
 * core.get_texturepath() (possible in async calls)
-	* returns path to default textures
+    * returns path to default textures
 * core.get_game(index)
-	* returns:
+    * returns:
 
-		{
-			id               = <id>,
-			path             = <full path to game>,
-			gamemods_path    = <path>,
-			name             = <name of game>,
-			menuicon_path    = <full path to menuicon>,
-			author           = "author",
-			DEPRECATED:
-			addon_mods_paths = {[1] = <path>,},
-		}
+        {
+            id               = <id>,
+            path             = <full path to game>,
+            gamemods_path    = <path>,
+            name             = <name of game>,
+            menuicon_path    = <full path to menuicon>,
+            author           = "author",
+            DEPRECATED:
+            addon_mods_paths = {[1] = <path>,},
+        }
 
 * core.get_games() -> table of all games in upper format (possible in async calls)
 * core.get_content_info(path)
-	* returns
+    * returns
 
-		{
-			name             = "name of content",
-			type             = "mod" or "modpack" or "game" or "txp",
-			description      = "description",
-			author           = "author",
-			path             = "path/to/content",
-			depends          = {"mod", "names"}, -- mods only
-			optional_depends = {"mod", "names"}, -- mods only
-		}
+        {
+            name             = "name of content",
+            type             = "mod" or "modpack" or "game" or "txp",
+            description      = "description",
+            author           = "author",
+            path             = "path/to/content",
+            depends          = {"mod", "names"}, -- mods only
+            optional_depends = {"mod", "names"}, -- mods only
+        }
 
 
-Favorites:
+Favorites
+---------
+
 core.get_favorites(location) -> list of favorites (possible in async calls)
 ^ location: "local" or "online"
 ^ returns {
-	[1] = {
-		clients       = <number of clients/nil>,
-		clients_max   = <maximum number of clients/nil>,
-		version       = <server version/nil>,
-		password      = <true/nil>,
-		creative      = <true/nil>,
-		damage        = <true/nil>,
-		pvp           = <true/nil>,
-		description   = <server description/nil>,
-		name          = <server name/nil>,
-		address       = <address of server/nil>,
-		port          = <port>
-		clients_list  = <array of clients/nil>
-		mods          = <array of mods/nil>
-	},
-	...
+    [1] = {
+        clients       = <number of clients/nil>,
+        clients_max   = <maximum number of clients/nil>,
+        version       = <server version/nil>,
+        password      = <true/nil>,
+        creative      = <true/nil>,
+        damage        = <true/nil>,
+        pvp           = <true/nil>,
+        description   = <server description/nil>,
+        name          = <server name/nil>,
+        address       = <address of server/nil>,
+        port          = <port>
+        clients_list  = <array of clients/nil>
+        mods          = <array of mods/nil>
+    },
+    ...
 }
 core.delete_favorite(id, location) -> success
 
-Logging:
+
+Logging
+-------
+
 core.debug(line) (possible in async calls)
 ^ Always printed to stderr and logfile (print() is redirected here)
 core.log(line) (possible in async calls)
 core.log(loglevel, line) (possible in async calls)
 ^ loglevel one of "error", "action", "info", "verbose"
 
-Settings:
+
+Settings
+--------
+
 core.settings:set(name, value)
 core.settings:get(name) -> string or nil (possible in async calls)
 core.settings:set_bool(name, value)
@@ -273,19 +300,25 @@ core.settings:save() -> nil, save all settings to config file
 For a complete list of methods of the Settings object see
 [lua_api.txt](https://github.com/minetest/minetest/blob/master/doc/lua_api.txt)
 
-Worlds:
+
+Worlds
+------
+
 core.get_worlds() -> list of worlds (possible in async calls)
 ^ returns {
-	[1] = {
-	path   = <full path to world>,
-	name   = <name of world>,
-	gameid = <gameid of world>,
-	},
+    [1] = {
+    path   = <full path to world>,
+    name   = <name of world>,
+    gameid = <gameid of world>,
+    },
 }
 core.create_world(worldname, gameid)
 core.delete_world(index)
 
-Helpers:
+
+Helpers
+-------
+
 core.get_us_time()
 ^ returns time with microsecond precision
 core.gettext(string) -> string
@@ -310,18 +343,10 @@ minetest.encode_base64(string) (possible in async calls)
 minetest.decode_base64(string) (possible in async calls)
 ^ Decodes a string encoded in base64.
 
-Version compat:
-core.get_min_supp_proto()
-^ returns the minimum supported network protocol version
-core.get_max_supp_proto()
-^ returns the maximum supported network protocol version
 
-Other:
-core.open_url(url)
-^ opens the URL in a web browser, returns false on failure.
-^ Must begin with http:// or https://
+Async
+-----
 
-Async:
 core.handle_async(async_job,parameters,finished)
 ^ execute a function asynchronously
 ^ async_job is a function receiving one parameter and returning one parameter
@@ -332,11 +357,13 @@ core.handle_async(async_job,parameters,finished)
 Limitations of Async operations
  -No access to global lua variables, don't even try
  -Limited set of available functions
-	e.g. No access to functions modifying menu like core.start,core.close,
-	core.show_path_select_dialog
+    e.g. No access to functions modifying menu like core.start,core.close,
+    core.show_path_select_dialog
+
 
 Background music
 ----------------
+
 The main menu supports background music.
 It looks for a `main_menu` sound in `$USER_PATH/sounds`. The same naming
 conventions as for normal sounds apply.

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -87,17 +87,11 @@ HTTP Requests
 * core.download_file(url, target) (possible in async calls)
     * url to download, and target to store to
     * returns true/false
-* `minetest.request_http_api()` (possible in async calls)
-    * returns `HTTPApiTable` containing http functions if the calling mod has
-      been granted access by being listed in the `secure.http_mods` or
-      `secure.trusted_mods` setting, otherwise returns `nil`.
-    * The returned table contains the functions `fetch`, `fetch_async` and
+* `minetest.get_http_api()` (possible in async calls)
+    * returns `HTTPApiTable` containing http functions.
+    * The returned table contains the functions `fetch_sync`, `fetch_async` and
       `fetch_async_get` described below.
-    * Only works at init time and must be called from the mod's main scope
-      (not from a function).
     * Function only exists if minetest server was built with cURL support.
-    * **DO NOT ALLOW ANY OTHER MODS TO ACCESS THE RETURNED TABLE, STORE IT IN
-      A LOCAL VARIABLE!**
 * `HTTPApiTable.fetch(HTTPRequest req, callback)`
     * Performs given request asynchronously and calls callback upon completion
     * callback: `function(HTTPRequestResult res)`

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -92,10 +92,8 @@ HTTP Requests
     * The returned table contains the functions `fetch_sync`, `fetch_async` and
       `fetch_async_get` described below.
     * Function only exists if minetest server was built with cURL support.
-* `HTTPApiTable.fetch(HTTPRequest req, callback)`
-    * Performs given request asynchronously and calls callback upon completion
-    * callback: `function(HTTPRequestResult res)`
-    * Use this HTTP function if you are unsure, the others are for advanced use
+* `HTTPApiTable.fetch_sync(HTTPRequest req, callback)`: returns HTTPRequestResult
+    * Performs given request synchronously
 * `HTTPApiTable.fetch_async(HTTPRequest req)`: returns handle
     * Performs given request asynchronously and returns handle for
       `HTTPApiTable.fetch_async_get`

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -54,7 +54,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("client_unload_unused_data_timeout", "600");
 	settings->setDefault("client_mapblock_limit", "5000");
 	settings->setDefault("enable_build_where_you_stand", "false");
-	settings->setDefault("curl_timeout", "10000");
+	settings->setDefault("curl_timeout", "5000");
 	settings->setDefault("curl_parallel_limit", "8");
 	settings->setDefault("curl_file_download_timeout", "300000");
 	settings->setDefault("curl_verify_cert", "true");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -54,7 +54,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("client_unload_unused_data_timeout", "600");
 	settings->setDefault("client_mapblock_limit", "5000");
 	settings->setDefault("enable_build_where_you_stand", "false");
-	settings->setDefault("curl_timeout", "5000");
+	settings->setDefault("curl_timeout", "10000");
 	settings->setDefault("curl_parallel_limit", "8");
 	settings->setDefault("curl_file_download_timeout", "300000");
 	settings->setDefault("curl_verify_cert", "true");

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -219,7 +219,7 @@ void ModApiHttp::Initialize(lua_State *L, int top)
 
 	bool isMainmenu = false;
 #ifndef SERVER
-	isMainmenu = ModApiBase::getGuiEngine(L);
+	isMainmenu = ModApiBase::getGuiEngine(L) != nullptr;
 #endif
 
 	if (isMainmenu) {

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -147,7 +147,9 @@ int ModApiHttp::l_request_http_api(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	if (ModApiBase::getGuiEngine(L) == nullptr) {
+	bool isMainmenu = ModApiBase::getGuiEngine(L) != nullptr;
+
+	if (!isMainmenu) {
 		// We have to make sure that this function is being called directly by
 		// a mod, otherwise a malicious mod could override this function and
 		// steal its return value.
@@ -193,7 +195,8 @@ int ModApiHttp::l_request_http_api(lua_State *L)
 	lua_newtable(L);
 	HTTP_API(fetch_async);
 	HTTP_API(fetch_async_get);
-	HTTP_API(fetch_sync);
+	if (isMainmenu)
+		HTTP_API(fetch_sync);
 
 	if (lua_isfunction(L, -2)) {
 		// Stack now looks like this:

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -83,6 +83,25 @@ void ModApiHttp::push_http_fetch_result(lua_State *L, HTTPFetchResult &res, bool
 	setstringfield(L, -1, "data", res.data);
 }
 
+// http_api.fetch_sync(HTTPRequest definition)
+int ModApiHttp::l_http_fetch_sync(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	HTTPFetchRequest req;
+	read_http_fetch_request(L, req);
+
+	infostream << "Mod performs HTTP request with URL " << req.url << std::endl;
+
+	HTTPFetchResult res;
+	httpfetch_sync(req, res);
+
+	push_http_fetch_result(L, res, true);
+
+	// Co
+	return 1;
+}
+
 // http_api.fetch_async(HTTPRequest definition)
 int ModApiHttp::l_http_fetch_async(lua_State *L)
 {
@@ -128,42 +147,44 @@ int ModApiHttp::l_request_http_api(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	// We have to make sure that this function is being called directly by
-	// a mod, otherwise a malicious mod could override this function and
-	// steal its return value.
-	lua_Debug info;
+	if (ModApiBase::getGuiEngine(L) == nullptr) {
+		// We have to make sure that this function is being called directly by
+		// a mod, otherwise a malicious mod could override this function and
+		// steal its return value.
+		lua_Debug info;
 
-	// Make sure there's only one item below this function on the stack...
-	if (lua_getstack(L, 2, &info)) {
-		return 0;
-	}
-	FATAL_ERROR_IF(!lua_getstack(L, 1, &info), "lua_getstack() failed");
-	FATAL_ERROR_IF(!lua_getinfo(L, "S", &info), "lua_getinfo() failed");
+		// Make sure there's only one item below this function on the stack...
+		if (lua_getstack(L, 2, &info)) {
+			return 0;
+		}
+		FATAL_ERROR_IF(!lua_getstack(L, 1, &info), "lua_getstack() failed");
+		FATAL_ERROR_IF(!lua_getinfo(L, "S", &info), "lua_getinfo() failed");
 
-	// ...and that that item is the main file scope.
-	if (strcmp(info.what, "main") != 0) {
-		return 0;
-	}
+		// ...and that that item is the main file scope.
+		if (strcmp(info.what, "main") != 0) {
+			return 0;
+		}
 
-	// Mod must be listed in secure.http_mods or secure.trusted_mods
-	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
-	if (!lua_isstring(L, -1)) {
-		return 0;
-	}
+		// Mod must be listed in secure.http_mods or secure.trusted_mods
+		lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
+		if (!lua_isstring(L, -1)) {
+			return 0;
+		}
 
-	std::string mod_name = readParam<std::string>(L, -1);
-	std::string http_mods = g_settings->get("secure.http_mods");
-	http_mods.erase(std::remove(http_mods.begin(), http_mods.end(), ' '), http_mods.end());
-	std::vector<std::string> mod_list_http = str_split(http_mods, ',');
+		std::string mod_name = readParam<std::string>(L, -1);
+		std::string http_mods = g_settings->get("secure.http_mods");
+		http_mods.erase(std::remove(http_mods.begin(), http_mods.end(), ' '), http_mods.end());
+		std::vector<std::string> mod_list_http = str_split(http_mods, ',');
 
-	std::string trusted_mods = g_settings->get("secure.trusted_mods");
-	trusted_mods.erase(std::remove(trusted_mods.begin(), trusted_mods.end(), ' '), trusted_mods.end());
-	std::vector<std::string> mod_list_trusted = str_split(trusted_mods, ',');
+		std::string trusted_mods = g_settings->get("secure.trusted_mods");
+		trusted_mods.erase(std::remove(trusted_mods.begin(), trusted_mods.end(), ' '), trusted_mods.end());
+		std::vector<std::string> mod_list_trusted = str_split(trusted_mods, ',');
 
-	mod_list_http.insert(mod_list_http.end(), mod_list_trusted.begin(), mod_list_trusted.end());
-	if (std::find(mod_list_http.begin(), mod_list_http.end(), mod_name) == mod_list_http.end()) {
-		lua_pushnil(L);
-		return 1;
+		mod_list_http.insert(mod_list_http.end(), mod_list_trusted.begin(), mod_list_trusted.end());
+		if (std::find(mod_list_http.begin(), mod_list_http.end(), mod_name) == mod_list_http.end()) {
+			lua_pushnil(L);
+			return 1;
+		}
 	}
 
 	lua_getglobal(L, "core");
@@ -172,11 +193,14 @@ int ModApiHttp::l_request_http_api(lua_State *L)
 	lua_newtable(L);
 	HTTP_API(fetch_async);
 	HTTP_API(fetch_async_get);
+	HTTP_API(fetch_sync);
 
-	// Stack now looks like this:
-	// <core.http_add_fetch> <table with fetch_async, fetch_async_get>
-	// Now call core.http_add_fetch to append .fetch(request, callback) to table
-	lua_call(L, 1, 1);
+	if (lua_isfunction(L, -2)) {
+		// Stack now looks like this:
+		// <core.http_add_fetch> <table with fetch_async, fetch_async_get>
+		// Now call core.http_add_fetch to append .fetch(request, callback) to table
+		lua_call(L, 1, 1);
+	}
 
 	return 1;
 }

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -210,15 +210,22 @@ int ModApiHttp::l_get_http_api(lua_State *L)
 
 	return 1;
 }
+
 #endif
 
 void ModApiHttp::Initialize(lua_State *L, int top)
 {
 #if USE_CURL
+
+#ifndef SERVER
 	if (ModApiBase::getGuiEngine(L) != nullptr) {
 		API_FCT(get_http_api);
 	} else {
+#endif
 		API_FCT(request_http_api);
+#ifndef SERVER
 	}
+#endif
+
 #endif
 }

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -217,15 +217,16 @@ void ModApiHttp::Initialize(lua_State *L, int top)
 {
 #if USE_CURL
 
+	bool isMainmenu = false;
 #ifndef SERVER
-	if (ModApiBase::getGuiEngine(L) != nullptr) {
+	isMainmenu = ModApiBase::getGuiEngine(L);
+#endif
+
+	if (isMainmenu) {
 		API_FCT(get_http_api);
 	} else {
-#endif
 		API_FCT(request_http_api);
-#ifndef SERVER
 	}
-#endif
 
 #endif
 }

--- a/src/script/lua_api/l_http.h
+++ b/src/script/lua_api/l_http.h
@@ -32,6 +32,9 @@ private:
 	static void read_http_fetch_request(lua_State *L, HTTPFetchRequest &req);
 	static void push_http_fetch_result(lua_State *L, HTTPFetchResult &res, bool completed = true);
 
+	// http_fetch_sync({url=, timeout=, post_data=})
+	static int l_http_fetch_sync(lua_State *L);
+
 	// http_fetch_async({url=, timeout=, post_data=})
 	static int l_http_fetch_async(lua_State *L);
 

--- a/src/script/lua_api/l_http.h
+++ b/src/script/lua_api/l_http.h
@@ -43,6 +43,9 @@ private:
 
 	// request_http_api()
 	static int l_request_http_api(lua_State *L);
+
+	// get_http_api()
+	static int l_get_http_api(lua_State *L);
 #endif
 
 public:

--- a/src/script/scripting_mainmenu.cpp
+++ b/src/script/scripting_mainmenu.cpp
@@ -17,11 +17,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <script/lua_api/l_http.h>
 #include "scripting_mainmenu.h"
 #include "content/mods.h"
 #include "cpp_api/s_internal.h"
 #include "lua_api/l_base.h"
+#include "lua_api/l_http.h"
 #include "lua_api/l_mainmenu.h"
 #include "lua_api/l_sound.h"
 #include "lua_api/l_util.h"

--- a/src/script/scripting_mainmenu.cpp
+++ b/src/script/scripting_mainmenu.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include <script/lua_api/l_http.h>
 #include "scripting_mainmenu.h"
 #include "content/mods.h"
 #include "cpp_api/s_internal.h"
@@ -67,6 +68,7 @@ void MainMenuScripting::initializeModApi(lua_State *L, int top)
 	ModApiMainMenu::Initialize(L, top);
 	ModApiUtil::Initialize(L, top);
 	ModApiSound::Initialize(L, top);
+	ModApiHttp::Initialize(L, top);
 
 	asyncEngine.registerStateInitializer(registerLuaClasses);
 	asyncEngine.registerStateInitializer(ModApiMainMenu::InitializeAsync);


### PR DESCRIPTION
Adds support for the HTTP API to the main menu Lua environment.

This does not include support for the `api.fetch` as that requires `minetest.after`

## How to test

Testing
