### PR TITLE
Recalc mesh normals for CAOs

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -728,7 +728,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 
 			if (!checkMeshNormals(mesh)) {
 				infostream << "GenericCAO: recalculating normals for mesh "
-					   << m_prop.mesh << std::endl;
+					<< m_prop.mesh << std::endl;
 				m_smgr->getMeshManipulator()->
 						recalculateNormals(mesh, true, false);
 			}

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -725,6 +725,14 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 				addAnimatedMeshSceneNode(mesh, m_matrixnode);
 			m_animated_meshnode->grab();
 			mesh->drop(); // The scene node took hold of it
+
+			if (!checkMeshNormals(mesh)) {
+				infostream << "GenericCAO: recalculating normals for mesh "
+					   << m_prop.mesh << std::endl;
+				m_smgr->getMeshManipulator()->
+						recalculateNormals(mesh, true, false);
+			}
+
 			m_animated_meshnode->animateJoints(); // Needed for some animations
 			m_animated_meshnode->setScale(m_prop.visual_size);
 

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -330,17 +330,17 @@ void recalculateBoundingBox(scene::IMesh *src_mesh)
 
 bool checkMeshNormals(scene::IMesh *mesh)
 {
-	u32 buffersCount = mesh->getMeshBufferCount();
+	u32 buffer_count = mesh->getMeshBufferCount();
 
-	for (u32 i = 0; i < buffersCount; i++) {
+	for (u32 i = 0; i < buffer_count; i++) {
 		scene::IMeshBuffer *buffer = mesh->getMeshBuffer(i);
 
 		// Here we intentionally check only first normal, assuming that if buffer
 		// has it valid, then most likely all other ones are fine too. We can
 		// check all of the normals to have length, but it seems like an overkill
 		// hurting the performance and covering only really weird broken models.
-		core::vector3df firstNormal = buffer->getNormal(0);
-		f32 length = firstNormal.getLength();
+		core::vector3df first_normal = buffer->getNormal(0);
+		f32 length = first_normal.getLength();
 
 		if (length == 0 || isinf(length) || isnan(length))
 			return false;

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -341,7 +341,7 @@ bool checkMeshNormals(scene::IMesh *mesh)
 		// hurting the performance and covering only really weird broken models.
 		f32 length = buffer->getNormal(0).getLength();
 
-		if (length == 0 || !isfinite(length))
+		if (!isfinite(length) || fabs(length) < 1e-10)
 			return false;
 	}
 

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -339,8 +339,7 @@ bool checkMeshNormals(scene::IMesh *mesh)
 		// has it valid, then most likely all other ones are fine too. We can
 		// check all of the normals to have length, but it seems like an overkill
 		// hurting the performance and covering only really weird broken models.
-		core::vector3df first_normal = buffer->getNormal(0);
-		f32 length = first_normal.getLength();
+		f32 length = buffer->getNormal(0).getLength();
 
 		if (length == 0 || isinf(length) || isnan(length))
 			return false;

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -341,7 +341,7 @@ bool checkMeshNormals(scene::IMesh *mesh)
 		// hurting the performance and covering only really weird broken models.
 		f32 length = buffer->getNormal(0).getLength();
 
-		if (length == 0 || isinf(length) || isnan(length))
+		if (length == 0 || !isfinite(length))
 			return false;
 	}
 

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -328,6 +328,27 @@ void recalculateBoundingBox(scene::IMesh *src_mesh)
 	src_mesh->setBoundingBox(bbox);
 }
 
+bool checkMeshNormals(scene::IMesh *mesh)
+{
+	u32 buffersCount = mesh->getMeshBufferCount();
+
+	for (u32 i = 0; i < buffersCount; i++) {
+		scene::IMeshBuffer *buffer = mesh->getMeshBuffer(i);
+
+		// Here we intentionally check only first normal, assuming that if buffer
+		// has it valid, then most likely all other ones are fine too. We can
+		// check all of the normals to have length, but it seems like an overkill
+		// hurting the performance and covering only really weird broken models.
+		core::vector3df firstNormal = buffer->getNormal(0);
+		f32 length = firstNormal.getLength();
+
+		if (length == 0 || isinf(length) || isnan(length))
+			return false;
+	}
+
+	return true;
+}
+
 scene::IMeshBuffer* cloneMeshBuffer(scene::IMeshBuffer *mesh_buffer)
 {
 	switch (mesh_buffer->getVertexType()) {

--- a/src/client/mesh.h
+++ b/src/client/mesh.h
@@ -122,6 +122,12 @@ scene::IMesh* convertNodeboxesToMesh(const std::vector<aabb3f> &boxes,
 void recalculateBoundingBox(scene::IMesh *src_mesh);
 
 /*
+	Check if mesh has valid normals and return true if it does.
+	We assume normal to be valid when it's 0 < length < Inf. and not NaN
+ */
+bool checkMeshNormals(scene::IMesh *mesh);
+
+/*
 	Vertex cache optimization according to the Forsyth paper:
 	http://home.comcast.net/~tom_forsyth/papers/fast_vert_cache_opt.html
 	Ported from irrlicht 1.8


### PR DESCRIPTION
Checks if at least one buffer has invalid first normal, and if any buffer does, recalculates all mesh normals. Partial fix of #9985.

## To do

Ready for Review.

## How to test

Try to create CAO mesh with and without normals backed into the model. Meshes with valid normals should remain unchanged, while ones without should still be rendered correctly.
