### PR TITLE
Fix Lua panic when error() message is not a string

### DIFF
--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -187,7 +187,9 @@ void ScriptApiBase::loadScript(const std::string &script_path)
 	}
 	ok = ok && !lua_pcall(L, 0, 0, error_handler);
 	if (!ok) {
-		std::string error_msg = readParam<std::string>(L, -1);
+		const char *error_msg = lua_tostring(L, -1);
+		if (!error_msg)
+			error_msg = "(error object is not a string)";
 		lua_pop(L, 2); // Pop error message and error handler
 		throw ModError("Failed to load and run script from " +
 				script_path + ":\n" + error_msg);
@@ -219,7 +221,9 @@ void ScriptApiBase::loadModFromMemory(const std::string &mod_name)
 	if (ok)
 		ok = !lua_pcall(L, 0, 0, error_handler);
 	if (!ok) {
-		std::string error_msg = luaL_checkstring(L, -1);
+		const char *error_msg = lua_tostring(L, -1);
+		if (!error_msg)
+			error_msg = "(error object is not a string)";
 		lua_pop(L, 2); // Pop error message and error handler
 		throw ModError("Failed to load and run mod \"" +
 				mod_name + "\":\n" + error_msg);


### PR DESCRIPTION
Fixes #9987 

## How to test

Call `error` with a non-string message at mod load time.
