### PR TITLE
Use multiple light positions for CAO lighting

### DIFF
--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -43,7 +43,6 @@ public:
 	virtual void removeFromScene(bool permanent) {}
 
 	virtual void updateLight(u32 day_night_ratio) {}
-	virtual v3s16 getLightPosition() { return v3s16(0, 0, 0); }
 
 	virtual bool getCollisionBox(aabb3f *toset) const { return false; }
 	virtual bool getSelectionBox(aabb3f *toset) const { return false; }

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -240,7 +240,10 @@ public:
 
 	void setNodeLight(u8 light);
 
-	v3s16 getLightPosition();
+	/* Get light position(s).
+	 * returns number of positions written into pos[], which must have space
+	 * for at least 3 vectors. */
+	u16 getLightPosition(v3s16 *pos);
 
 	void updateNametag();
 


### PR DESCRIPTION
fixes #2467
alternative approach to #9996 or #9777 

How it works:
Takes the maximum light of the minimum collisionbox edge, maximum collisionbox edge and center of collisionbox. 

## To do

This PR is a Ready for Review.

## How to test

1. Test the shown arrangement with an incorrectly(!) defined slab:
![screenshot_20200607_195652](https://user-images.githubusercontent.com/1042418/83976631-7ae05000-a8fb-11ea-90aa-650edcfa6670.png)
```lua
minetest.register_node("test2:slab", {
	description = "Test Slab",
	drawtype = "nodebox",
	tiles = {"default_tree.png"},
	groups = {snappy = 2},
	node_box = {
		type = "fixed",
		fixed = {-0.5, -0.5, -0.5, 0.5, 0, 0.5},
	},
})
```

2. Experiment with noclipping the player into a ceiling / floor until only the small parts are left visible.
