### PR TITLE
Fix player-to-object attachment teleport bug

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -162,6 +162,15 @@ static void setBillboardTextureMatrix(scene::IBillboardSceneNode *bill,
 	matrix.setTextureScale(txs, tys);
 }
 
+// Evaluate transform chain recursively; irrlicht does not do this for us
+static void updatePositionRecursive(scene::ISceneNode *node) {
+	scene::ISceneNode *parent;
+	if(parent = node->getParent()) {
+		updatePositionRecursive(parent);
+	}
+	node->updateAbsolutePosition();
+}
+
 /*
 	TestCAO
 */
@@ -1466,7 +1475,7 @@ void GenericCAO::updateAttachments()
 			//setPitchYawRoll(getPosRotMatrix(), m_attachment_rotation);
 			// use Irrlicht eulers instead
 			getPosRotMatrix().setRotationDegrees(m_attachment_rotation);
-			parent_node->updateAbsolutePosition();
+			updatePositionRecursive( m_matrixnode );
 		}
 	}
 }

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -162,15 +162,6 @@ static void setBillboardTextureMatrix(scene::IBillboardSceneNode *bill,
 	matrix.setTextureScale(txs, tys);
 }
 
-// Evaluate transform chain recursively; irrlicht does not do this for us
-static void updatePositionRecursive(scene::ISceneNode *node) {
-	scene::ISceneNode *parent;
-	if(parent = node->getParent()) {
-		updatePositionRecursive(parent);
-	}
-	node->updateAbsolutePosition();
-}
-
 /*
 	TestCAO
 */
@@ -1462,6 +1453,7 @@ void GenericCAO::updateAttachments()
 	}
 	else // Attach
 	{
+		parent->updateAttachments();
 		scene::ISceneNode *parent_node = parent->getSceneNode();
 		scene::IAnimatedMeshSceneNode *parent_animated_mesh_node =
 				parent->getAnimatedMeshSceneNode();
@@ -1471,11 +1463,12 @@ void GenericCAO::updateAttachments()
 
 		if (m_matrixnode && parent_node) {
 			m_matrixnode->setParent(parent_node);
+			parent_node->updateAbsolutePosition();
 			getPosRotMatrix().setTranslation(m_attachment_position);
 			//setPitchYawRoll(getPosRotMatrix(), m_attachment_rotation);
 			// use Irrlicht eulers instead
 			getPosRotMatrix().setRotationDegrees(m_attachment_rotation);
-			updatePositionRecursive(m_matrixnode);
+			m_matrixnode->updateAbsolutePosition();
 		}
 	}
 }

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -910,7 +910,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		m_animated_meshnode->animateJoints();
 		updateBonePosition();
 	}
-	
+
 	// Handle model animations and update positions instantly to prevent lags
 	if (m_is_local_player) {
 		LocalPlayer *player = m_env->getLocalPlayer();
@@ -1392,7 +1392,7 @@ void GenericCAO::updateBonePosition()
 			bone->setRotation(it.second.Y);
 		}
 	}
-	
+
 	// search through bones to find mistakenly rotated bones due to bug in Irrlicht
 	for (u32 i = 0; i < m_animated_meshnode->getJointCount(); ++i) {
 		irr::scene::IBoneSceneNode *bone = m_animated_meshnode->getJointNode(i);
@@ -1416,7 +1416,7 @@ void GenericCAO::updateBonePosition()
 		// and update the bones transformation.
 		v3f bone_rot = bone->getRelativeTransformation().getRotationDegrees();
 		float offset = fabsf(bone_rot.X - bone->getRotation().X);
-		if (offset > 179.9f && offset < 180.1f) { 
+		if (offset > 179.9f && offset < 180.1f) {
 			bone->setRotation(bone_rot);
 			bone->updateAbsolutePosition();
 		}
@@ -1443,10 +1443,11 @@ void GenericCAO::updateAttachments()
 
 	if (!parent) { // Detach or don't attach
 		if (m_matrixnode) {
+			v3s16 camera_offset = m_env->getCameraOffset();
 			v3f old_pos = getPosition();
 
 			m_matrixnode->setParent(m_smgr->getRootSceneNode());
-			getPosRotMatrix().setTranslation(old_pos);
+			getPosRotMatrix().setTranslation(old_pos - intToFloat(camera_offset, BS));
 			m_matrixnode->updateAbsolutePosition();
 		}
 	}
@@ -1460,6 +1461,7 @@ void GenericCAO::updateAttachments()
 		}
 
 		if (m_matrixnode && parent_node) {
+			parent_node->updateAbsolutePosition();
 			m_matrixnode->setParent(parent_node);
 			getPosRotMatrix().setTranslation(m_attachment_position);
 			//setPitchYawRoll(getPosRotMatrix(), m_attachment_rotation);

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1461,13 +1461,12 @@ void GenericCAO::updateAttachments()
 		}
 
 		if (m_matrixnode && parent_node) {
-			parent_node->updateAbsolutePosition();
 			m_matrixnode->setParent(parent_node);
 			getPosRotMatrix().setTranslation(m_attachment_position);
 			//setPitchYawRoll(getPosRotMatrix(), m_attachment_rotation);
 			// use Irrlicht eulers instead
 			getPosRotMatrix().setRotationDegrees(m_attachment_rotation);
-			m_matrixnode->updateAbsolutePosition();
+			parent_node->updateAbsolutePosition();
 		}
 	}
 }

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1475,7 +1475,7 @@ void GenericCAO::updateAttachments()
 			//setPitchYawRoll(getPosRotMatrix(), m_attachment_rotation);
 			// use Irrlicht eulers instead
 			getPosRotMatrix().setRotationDegrees(m_attachment_rotation);
-			updatePositionRecursive( m_matrixnode );
+			updatePositionRecursive(m_matrixnode);
 		}
 	}
 }


### PR DESCRIPTION
Fixes and closes #9139 
Review ready but more testing is welcome, in particular with more complicated transform hierarchies.

There were two bugs behind this issue, at least in its current form.

The camera offset was not applied to an object while detaching, briefly placing the irrlicht matrixnode in world space. According to the comments, the same code path is taken when trying to attach to something that isn't yet known, like a freshly spawned entity. Normally, a CAO's position being wrong between detachment and step would not cause side effects, but here the corrupt matrixnode position could escape via GenericCAO::getPosition being used to update the player position server side. (since the condition for that was being attached to something, including possibly an incomplete attachment)

The other bug was that when attaching, the matrixnode's absolute position was evaluated without evaluating the parent first. If the parent is a freshly spawned entity, it might not have stepped yet, so its absolute position would still be zeroed out, propagating that to our own matrixnode.

Some unrelated trailing whitespace was caught while processing the file before commit. Hope this isn't a problem.
