### PR TITLE
devtest: Improve tool and formspec usability

### DIFF
--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -54,6 +54,7 @@ minetest.register_tool("basetools:pick_mese", {
 			choppy={times={[1]=0.0, [2]=0.0, [3]=0.0}, maxlevel=255},
 			dig_immediate={times={[1]=0.0, [2]=0.0, [3]=0.0}, maxlevel=255},
 		},
+		damage_groups = {fleshy=100},
 	},
 })
 

--- a/games/devtest/mods/testentities/visuals.lua
+++ b/games/devtest/mods/testentities/visuals.lua
@@ -66,9 +66,9 @@ minetest.register_entity("testentities:yawsprite", {
 		textures = {"testentities_dungeon_master.png^[makealpha:128,0,0^[makealpha:128,128,0"},
 		spritediv = {x=6, y=5},
 		initial_sprite_basepos = {x=0, y=0},
-		on_activate = function(self, staticdata)
-			self.object:set_sprite({x=0, y=0}, 1, 0, true)
-		end,
 	},
+	on_activate = function(self, staticdata)
+		self.object:set_sprite({x=0, y=0}, 1, 0, true)
+	end,
 })
 

--- a/games/devtest/mods/testtools/init.lua
+++ b/games/devtest/mods/testtools/init.lua
@@ -429,6 +429,7 @@ local editor_formspec = function(playername, obj, value, sel)
 		"label[0,0;"..F(title).."]"..
 		"textlist[0,0.5;9,7.5;object_props;"..list..";"..sel..";false]"..
 		"field[0.2,8.75;8,1;value;"..F(S("Value"))..";"..F(value).."]"..
+		"field_close_on_enter[value;false]"..
 		"button[8,8.5;1,1;submit;"..F(S("Submit")).."]"
 	)
 end
@@ -665,7 +666,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 				return
 			end
 		end
-		if fields.submit then
+		if fields.key_enter_field == "value" or fields.submit then
 			local props = selected_objects[name]:get_properties()
 			local keys = property_formspec_data[name]
 			if (not property_formspec_index[name]) or (not props) then


### PR DESCRIPTION
There are two things that have been annoying me <b>a lot</b>:
* the object proprety setter formspec just disappears when you press enter
* unlike the hand, the mese pick deals no damage to the usual testentities

and a bugfix:
* the yawsprite entity never worked right, it now does.

## To do

This PR is a Ready for Review.
