### PR TITLE
Fix bone-attached entities

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1457,6 +1457,7 @@ void GenericCAO::updateBonePosition()
 		if (bone && bone->getParent() == m_animated_meshnode) {
 			// Update entire skeleton.
 			bone->updateAbsolutePositionOfAllChildren();
+			break;
 		}
 	}
 }

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1147,17 +1147,6 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		m_animated_meshnode->updateAbsolutePosition();
 		m_animated_meshnode->animateJoints();
 		updateBonePosition();
-		// The following is needed for set_bone_pos to propagate to
-		// attached objects correctly.
-		// Irrlicht ought to do this, but doesn't.
-		for (u32 i = 0; i < m_animated_meshnode->getJointCount(); ++i) {
-			auto bone = m_animated_meshnode->getJointNode(i);
-			if (!bone)
-				continue;
-			if (bone->getParent() == m_animated_meshnode) {
-				bone->updateAbsolutePositionOfAllChildren();
-			}
-		}
 	}
 }
 
@@ -1458,6 +1447,17 @@ void GenericCAO::updateBonePosition()
 		if (offset > 179.9f && offset < 180.1f) {
 			bone->setRotation(bone_rot);
 			bone->updateAbsolutePosition();
+		}
+	}
+	// The following is needed for set_bone_pos to propagate to
+	// attached objects correctly.
+	// Irrlicht ought to do this, but doesn't when using EJUOR_CONTROL.
+	for (u32 i = 0; i < m_animated_meshnode->getJointCount(); ++i) {
+		auto bone = m_animated_meshnode->getJointNode(i);
+		// Look for the root bone.
+		if (bone != NULL && bone->getParent() == m_animated_meshnode) {
+			// Update entire skeleton.
+			bone->updateAbsolutePositionOfAllChildren();
 		}
 	}
 }

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -162,6 +162,15 @@ static void setBillboardTextureMatrix(scene::IBillboardSceneNode *bill,
 	matrix.setTextureScale(txs, tys);
 }
 
+// Evaluate transform chain recursively; irrlicht does not do this for us
+static void updatePositionRecursive(scene::ISceneNode *node) {
+	scene::ISceneNode *parent = node->getParent();
+	if (parent != NULL) {
+		updatePositionRecursive(parent);
+	}
+	node->updateAbsolutePosition();
+}
+
 /*
 	TestCAO
 */
@@ -917,11 +926,6 @@ void GenericCAO::updateNodePos()
 
 void GenericCAO::step(float dtime, ClientEnvironment *env)
 {
-	if (m_animated_meshnode) {
-		m_animated_meshnode->animateJoints();
-		updateBonePosition();
-	}
-
 	// Handle model animations and update positions instantly to prevent lags
 	if (m_is_local_player) {
 		LocalPlayer *player = m_env->getLocalPlayer();
@@ -1130,6 +1134,30 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 
 		rot_translator.val_current = m_rotation;
 		updateNodePos();
+	}
+
+	if (m_animated_meshnode) {
+		// Everything must be updated; the whole transform
+		// chain as well as the animated mesh node.
+		// Otherwise, bone attachments would be relative to
+		// a position that's one frame old.
+		if(m_matrixnode){
+			updatePositionRecursive(m_matrixnode);
+		}
+		m_animated_meshnode->updateAbsolutePosition();
+		m_animated_meshnode->animateJoints();
+		updateBonePosition();
+		// The following is needed for set_bone_pos to propagate to
+		// attached objects correctly.
+		// Irrlicht ought to do this, but doesn't.
+		for (u32 i = 0; i < m_animated_meshnode->getJointCount(); ++i) {
+			auto bone = m_animated_meshnode->getJointNode(i);
+			if (!bone)
+				continue;
+			if (bone->getParent() == m_animated_meshnode) {
+				bone->updateAbsolutePositionOfAllChildren();
+			}
+		}
 	}
 }
 

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1454,7 +1454,7 @@ void GenericCAO::updateBonePosition()
 	for (u32 i = 0; i < m_animated_meshnode->getJointCount(); ++i) {
 		auto bone = m_animated_meshnode->getJointNode(i);
 		// Look for the root bone.
-		if (bone && bone->getParent() == m_animated_meshnode)
+		if (bone && bone->getParent() == m_animated_meshnode) {
 			// Update entire skeleton.
 			bone->updateAbsolutePositionOfAllChildren();
 		}

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -163,11 +163,11 @@ static void setBillboardTextureMatrix(scene::IBillboardSceneNode *bill,
 }
 
 // Evaluate transform chain recursively; irrlicht does not do this for us
-static void updatePositionRecursive(scene::ISceneNode *node) {
+static void updatePositionRecursive(scene::ISceneNode *node)
+{
 	scene::ISceneNode *parent = node->getParent();
-	if (parent != NULL) {
+	if (parent)
 		updatePositionRecursive(parent);
-	}
 	node->updateAbsolutePosition();
 }
 
@@ -1141,9 +1141,8 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		// chain as well as the animated mesh node.
 		// Otherwise, bone attachments would be relative to
 		// a position that's one frame old.
-		if(m_matrixnode){
+		if (m_matrixnode)
 			updatePositionRecursive(m_matrixnode);
-		}
 		m_animated_meshnode->updateAbsolutePosition();
 		m_animated_meshnode->animateJoints();
 		updateBonePosition();
@@ -1455,7 +1454,7 @@ void GenericCAO::updateBonePosition()
 	for (u32 i = 0; i < m_animated_meshnode->getJointCount(); ++i) {
 		auto bone = m_animated_meshnode->getJointNode(i);
 		// Look for the root bone.
-		if (bone != NULL && bone->getParent() == m_animated_meshnode) {
+		if (bone && bone->getParent() == m_animated_meshnode)
 			// Update entire skeleton.
 			bone->updateAbsolutePositionOfAllChildren();
 		}


### PR DESCRIPTION
Closes #2813 after a mere five years. May close #10010. Fixes other bugs that may or may not be known.

Skeletal animations were updated without evaluating parent transforms first. This meant that depending on the order in which things were processed by irrlicht, the parent might not have had a chance to update the absolute position, and would still use the position from its previous frame.
![laghat](https://user-images.githubusercontent.com/42101236/84087027-8ca02100-a9e9-11ea-9eab-7eb7fea6343d.png)


Additionally, a subtle bug was caught while looking for the above. Due to a bug in irrlicht, positions of joints would not be updated internally when EJUOR_CONTROL is used. This would result in things being attached to the animated bone position, and not the one set by the user.
![offhat](https://user-images.githubusercontent.com/42101236/84087182-e274c900-a9e9-11ea-9445-0a9d837bf063.png)
**Upgrade note: if you were querying bone positions and resetting attachments to work around this, you might have to delete that code.** Attachment positions on bones are now always in the bone's local space, even if the bone has an override on it.

Here is a testing mod with a skinned mesh player wearing a hat and using set_bone_position on the head bone.
[coolhat.zip](https://github.com/minetest/minetest/files/4754858/coolhat.zip)


