### PR TITLE
Add gettext support to the android version

### DIFF
--- a/build/android/app/build.gradle
+++ b/build/android/app/build.gradle
@@ -74,10 +74,13 @@ task prepareAssets() {
 	copy {
 		from "${projRoot}/games/${gameToCopy}" into "${assetsFolder}/games/${gameToCopy}"
 	}
-	/*copy {
-		// ToDo: fix broken locales
-		from "${projRoot}/po" into "${assetsFolder}/po"
-	}*/
+	fileTree("${projRoot}/po").include("**/*.po").forEach { poFile ->
+		def moPath = "${assetsFolder}/locale/${poFile.parentFile.name}/LC_MESSAGES/"
+		file(moPath).mkdirs()
+		exec {
+			commandLine 'msgfmt', '-o', "${moPath}/minetest.mo", poFile
+		}
+	}
 	copy {
 		from "${projRoot}/textures" into "${assetsFolder}/textures"
 	}

--- a/build/android/native/jni/Android.mk
+++ b/build/android/native/jni/Android.mk
@@ -60,6 +60,11 @@ include $(PREBUILT_STATIC_LIBRARY)
 #include $(PREBUILT_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE := GetText
+LOCAL_SRC_FILES := deps/Android/GetText/${NDK_TOOLCHAIN_VERSION}/$(APP_ABI)/libintl.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE := Vorbis
 LOCAL_SRC_FILES := deps/Android/Vorbis/${NDK_TOOLCHAIN_VERSION}/$(APP_ABI)/libvorbis.a
 include $(PREBUILT_STATIC_LIBRARY)
@@ -76,6 +81,8 @@ LOCAL_CFLAGS += \
 	-DUSE_FREETYPE=1                \
 	-DUSE_LEVELDB=0                 \
 	-DUSE_LUAJIT=1                  \
+	-DUSE_GETTEXT=1                 \
+	-DRUN_IN_PLACE=0                \
 	-DVERSION_MAJOR=${versionMajor} \
 	-DVERSION_MINOR=${versionMinor} \
 	-DVERSION_PATCH=${versionPatch} \
@@ -101,6 +108,7 @@ LOCAL_C_INCLUDES := \
 	deps/Android/Freetype/include                   \
 	deps/Android/Irrlicht/include                   \
 	deps/Android/LevelDB/include                    \
+	deps/Android/GetText/include                    \
 	deps/Android/libiconv/include                   \
 	deps/Android/libiconv/libcharset/include        \
 	deps/Android/LuaJIT/src                         \
@@ -206,7 +214,7 @@ LOCAL_SRC_FILES += \
 # SQLite3
 LOCAL_SRC_FILES += deps/Android/sqlite/sqlite3.c
 
-LOCAL_STATIC_LIBRARIES += Curl Freetype Irrlicht OpenAL mbedTLS mbedx509 mbedcrypto Vorbis LuaJIT android_native_app_glue $(PROFILER_LIBS) #LevelDB
+LOCAL_STATIC_LIBRARIES += Curl Freetype Irrlicht OpenAL mbedTLS mbedx509 mbedcrypto Vorbis LuaJIT GetText android_native_app_glue $(PROFILER_LIBS) #LevelDB
 #OpenSSL Crypto
 
 LOCAL_LDLIBS := -lEGL -lGLESv1_CM -lGLESv2 -landroid -lOpenSLES

--- a/build/android/native/jni/Android.mk
+++ b/build/android/native/jni/Android.mk
@@ -82,7 +82,6 @@ LOCAL_CFLAGS += \
 	-DUSE_LEVELDB=0                 \
 	-DUSE_LUAJIT=1                  \
 	-DUSE_GETTEXT=1                 \
-	-DRUN_IN_PLACE=0                \
 	-DVERSION_MAJOR=${versionMajor} \
 	-DVERSION_MINOR=${versionMinor} \
 	-DVERSION_PATCH=${versionPatch} \

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -127,6 +127,10 @@ void init_gettext(const char *path, const std::string &configured_language,
 		// Add user specified locale to environment
 		setenv("LANGUAGE", configured_language.c_str(), 1);
 
+#ifdef __ANDROID__
+		setenv("LANG", configured_language.c_str(), 1);
+#endif
+
 		// Reload locale with changed environment
 		setlocale(LC_ALL, "");
 #elif defined(_MSC_VER)

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gettext.h"
 #include "util/string.h"
 #include "log.h"
+#include "porting.h"
 
 #if USE_GETTEXT && defined(_MSC_VER)
 #include <windows.h>
@@ -206,7 +207,12 @@ void init_gettext(const char *path, const std::string &configured_language,
 #endif // ifndef _WIN32
 	}
 	else {
+#ifdef __ANDROID__
+		char lang[3] = {0};
 		 /* set current system default locale */
+		AConfiguration_getLanguage(porting::app_global->config, lang);
+		setenv("LANG", lang, 1);
+#endif
 		setlocale(LC_ALL, "");
 	}
 

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -139,7 +139,8 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 			std::string label = wide_to_utf8(getLabelByID(hovered->getID()));
 			if (label.empty())
 				label = "text";
-			message += gettext(label) + ":";
+			message += gettext(label.c_str());
+			message += ":";
 
 			// single line text input
 			int type = 2;

--- a/src/porting_android.cpp
+++ b/src/porting_android.cpp
@@ -190,6 +190,7 @@ void initializePathsAndroid()
 
 	path_user    = path_storage + DIR_DELIM + PROJECT_NAME_C;
 	path_share   = path_storage + DIR_DELIM + PROJECT_NAME_C;
+	path_locale  = path_storage + DIR_DELIM + PROJECT_NAME_C + DIR_DELIM + "locale" ;
 	path_cache   = getAndroidPath(nativeActivity,
 			app_global->activity->clazz, mt_getAbsPath, "getCacheDir");
 	migrateCachePath();


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
Add gettext and internationalization support in the android version

- How does the PR work?
Add dependency on a static version of gettext, and add mo files to the packaged android assets.
Depends on https://github.com/minetest/minetest_android_deps_binaries/pull/3

- Does it resolve any reported issue?
Solves #6093

## To do

This PR is Ready for Review.

## How to test

Build and launch an android client, set the language to something not english in the settings, restart and enjoy a translated mintest.
