### PR TITLE
content_cao: Support texture animation for upright_sprite

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6032,8 +6032,8 @@ object you are working with still exists.
       (x: column, y: row), default: `{x=0, y=0}`
     * `num_frames`: number, default: `1`
     * `framelength`: number, default: `0.2`
-    * `select_horiz_by_yawpitch`: boolean, this was once used for the Dungeon
-      Master mob, default: `false`
+    * `select_horiz_by_yawpitch`: boolean, default: `false`
+      only possible with visual = `sprite`
 * `get_entity_name()` (**Deprecated**: Will be removed in a future version)
 * `get_luaentity()`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6025,15 +6025,15 @@ object you are working with still exists.
 * `get_yaw()`: returns number in radians
 * `set_texture_mod(mod)`
 * `get_texture_mod()` returns current texture modifier
-* `set_sprite(p, num_frames, framelength, select_horiz_by_yawpitch)`
-    * Select sprite from spritesheet with optional animation and Dungeon Master
-      style texture selection based on yaw relative to camera
-    * `p`: {x=number, y=number}, the coordinate of the first frame
-      (x: column, y: row), default: `{x=0, y=0}`
-    * `num_frames`: number, default: `1`
-    * `framelength`: number, default: `0.2`
-    * `select_horiz_by_yawpitch`: boolean, default: `false`
-      only possible with visual = `sprite`
+* `set_sprite(p, num_frames, framelength, select_x_by_camera)`
+    * Specifies and starts a sprite animation
+    * Animations iterate along the frame `y` position.
+    * `p`: {x=column number, y=row number}, the coordinate of the first frame
+      default: `{x=0, y=0}`
+    * `num_frames`: Total frames in the texture, default: `1`
+    * `framelength`: Time per animated frame in seconds, default: `0.2`
+    * `select_x_by_camera`: Only for visual = `sprite`. Changes the frame `x`
+      position according to the view direction. default: `false`.
 * `get_entity_name()` (**Deprecated**: Will be removed in a future version)
 * `get_luaentity()`
 

--- a/games/devtest/mods/testentities/visuals.lua
+++ b/games/devtest/mods/testentities/visuals.lua
@@ -68,7 +68,7 @@ minetest.register_entity("testentities:mesh_unshaded", {
 
 -- Advanced visual tests
 
--- A test entity for testing animated and yaw-modulated sprites
+-- An entity for testing animated and yaw-modulated sprites
 minetest.register_entity("testentities:yawsprite", {
 	initial_properties = {
 		selectionbox = {-0.3, -0.5, -0.3, 0.3, 0.3, 0.3},
@@ -79,6 +79,18 @@ minetest.register_entity("testentities:yawsprite", {
 		initial_sprite_basepos = {x=0, y=0},
 	},
 	on_activate = function(self, staticdata)
-		self.object:set_sprite({x=0, y=0}, 1, 0, true)
+		self.object:set_sprite({x=0, y=0}, 3, 0.5, true)
+	end,
+})
+
+-- An entity for testing animated upright sprites
+minetest.register_entity("testentities:upright_animated", {
+	initial_properties = {
+		visual = "upright_sprite",
+		textures = {"testnodes_anim.png"},
+		spritediv = {x = 1, y = 4},
+	},
+	on_activate = function(self)
+		self.object:set_sprite({x=0, y=0}, 4, 1.0, false)
 	end,
 })

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1176,6 +1176,7 @@ void GenericCAO::updateTexturePos()
 		int row = m_tx_basepos.Y;
 		int col = m_tx_basepos.X;
 
+		// Yawpitch goes rightwards
 		if (m_tx_select_horiz_by_yawpitch) {
 			if (cam_to_entity.Y > 0.75)
 				col += 5;
@@ -1205,6 +1206,27 @@ void GenericCAO::updateTexturePos()
 		float txs = m_tx_size.X;
 		float tys = m_tx_size.Y;
 		setBillboardTextureMatrix(m_spritenode, txs, tys, col, row);
+	}
+
+	else if (m_meshnode) {
+		if (m_prop.visual == "upright_sprite") {
+			int row = m_tx_basepos.Y;
+			int col = m_tx_basepos.X;
+
+			// Animation goes downwards
+			row += m_anim_frame;
+
+			const auto &tx = m_tx_size;
+			v2f t[4] = { // cf. vertices in GenericCAO::addToScene()
+				tx * v2f(col+1, row+1),
+				tx * v2f(col, row+1),
+				tx * v2f(col, row),
+				tx * v2f(col+1, row),
+			};
+			auto mesh = m_meshnode->getMesh();
+			setMeshBufferTextureCoords(mesh->getMeshBuffer(0), t, 4);
+			setMeshBufferTextureCoords(mesh->getMeshBuffer(1), t, 4);
+		}
 	}
 }
 
@@ -1247,7 +1269,7 @@ void GenericCAO::updateTextures(std::string mod)
 		}
 	}
 
-	if (m_animated_meshnode) {
+	else if (m_animated_meshnode) {
 		if (m_prop.visual == "mesh") {
 			for (u32 i = 0; i < m_prop.textures.size() &&
 					i < m_animated_meshnode->getMaterialCount(); ++i) {
@@ -1296,8 +1318,8 @@ void GenericCAO::updateTextures(std::string mod)
 			}
 		}
 	}
-	if(m_meshnode)
-	{
+
+	else if (m_meshnode) {
 		if(m_prop.visual == "cube")
 		{
 			for (u32 i = 0; i < 6; ++i)

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -203,6 +203,15 @@ void setMeshColor(scene::IMesh *mesh, const video::SColor &color)
 		setMeshBufferColor(mesh->getMeshBuffer(j), color);
 }
 
+void setMeshBufferTextureCoords(scene::IMeshBuffer *buf, const v2f *uv, u32 count)
+{
+	const u32 stride = getVertexPitchFromType(buf->getVertexType());
+	assert(buf->getVertexCount() >= count);
+	u8 *vertices = (u8 *) buf->getVertices();
+	for (u32 i = 0; i < count; i++)
+		((video::S3DVertex*) (vertices + i * stride))->TCoords = uv[i];
+}
+
 template <typename F>
 static void applyToMesh(scene::IMesh *mesh, const F &fn)
 {

--- a/src/client/mesh.h
+++ b/src/client/mesh.h
@@ -58,6 +58,13 @@ void setMeshBufferColor(scene::IMeshBuffer *buf, const video::SColor &color);
 */
 void setMeshColor(scene::IMesh *mesh, const video::SColor &color);
 
+
+/*
+	Sets texture coords for vertices in the mesh buffer.
+	`uv[]` must have `count` elements
+*/
+void setMeshBufferTextureCoords(scene::IMeshBuffer *buf, const v2f *uv, u32 count);
+
 /*
 	Set a constant color for an animated mesh
 */


### PR DESCRIPTION
## To do

This PR is a Ready for Review.

## How to test

1. spawn the upright_animated entity in devtest and verify that the animation works (at 1 frame/s)
2. (devtest-only change) spawn the yawsprite entity and verify that the dungeon master is walking :)