### PR TITLE
Apply camera smoothing to 'not touching_ground' stepheight

### DIFF
--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -343,7 +343,11 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 		player_position = player->getParent()->getPosition();
 
 	// Smooth the camera movement when the player instantly moves upward due to stepheight
-	if (player_position.Y > old_player_position.Y) {
+	// Disable smoothing if climbing, swimming upwards, or flying, to avoid upwards offset
+	// of player model when seen in 3rd person view.
+	if (player_position.Y > old_player_position.Y && !player->is_climbing &&
+			!player->swimming_vertical &&
+			!(g_settings->getBool("free_move") && m_client->checkLocalPrivilege("fly"))) {
 		f32 oldy = old_player_position.Y;
 		f32 newy = player_position.Y;
 		f32 t = std::exp(-23 * frametime);

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -345,9 +345,9 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	// Smooth the camera movement when the player instantly moves upward due to stepheight
 	// Disable smoothing if climbing, swimming upwards, or flying, to avoid upwards offset
 	// of player model when seen in 3rd person view.
+	bool flying = g_settings->getBool("free_move") && m_client->checkLocalPrivilege("fly");
 	if (player_position.Y > old_player_position.Y && !player->is_climbing &&
-			!player->swimming_vertical &&
-			!(g_settings->getBool("free_move") && m_client->checkLocalPrivilege("fly"))) {
+			!player->swimming_vertical && !flying) {
 		f32 oldy = old_player_position.Y;
 		f32 newy = player_position.Y;
 		f32 t = std::exp(-23 * frametime);
@@ -610,14 +610,11 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	const bool walking = movement_XZ && player->touching_ground;
 	const bool swimming = (movement_XZ || player->swimming_vertical) && player->in_liquid;
 	const bool climbing = movement_Y && player->is_climbing;
-	if ((walking || swimming || climbing) &&
-			(!g_settings->getBool("free_move") || !m_client->checkLocalPrivilege("fly"))) {
+	if ((walking || swimming || climbing) && !flying) {
 		// Start animation
 		m_view_bobbing_state = 1;
 		m_view_bobbing_speed = MYMIN(speed.getLength(), 70);
-	}
-	else if (m_view_bobbing_state == 1)
-	{
+	} else if (m_view_bobbing_state == 1) {
 		// Stop animation
 		m_view_bobbing_state = 2;
 		m_view_bobbing_speed = 60;

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -342,9 +342,8 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	if (player->getParent())
 		player_position = player->getParent()->getPosition();
 
-	if(player->touching_ground &&
-			player_position.Y > old_player_position.Y)
-	{
+	// Smooth the camera movement when the player instantly moves upward due to stepheight
+	if (player_position.Y > old_player_position.Y) {
 		f32 oldy = old_player_position.Y;
 		f32 newy = player_position.Y;
 		f32 t = std::exp(-23 * frametime);

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -342,12 +342,13 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	if (player->getParent())
 		player_position = player->getParent()->getPosition();
 
-	// Smooth the camera movement when the player instantly moves upward due to stepheight
-	// Disable smoothing if climbing, swimming upwards, or flying, to avoid upwards offset
-	// of player model when seen in 3rd person view.
+	// Smooth the camera movement when the player instantly moves upward due to stepheight.
+	// To smooth the 'not touching_ground' stepheight, smoothing is necessary when jumping
+	// or swimming (for when moving from liquid to land).
+	// Disable smoothing if climbing or flying, to avoid upwards offset of player model
+	// when seen in 3rd person view.
 	bool flying = g_settings->getBool("free_move") && m_client->checkLocalPrivilege("fly");
-	if (player_position.Y > old_player_position.Y && !player->is_climbing &&
-			!player->swimming_vertical && !flying) {
+	if (player_position.Y > old_player_position.Y && !player->is_climbing && !flying) {
 		f32 oldy = old_player_position.Y;
 		f32 newy = player_position.Y;
 		f32 t = std::exp(-23 * frametime);


### PR DESCRIPTION
Fixes #9725 
~No problems seen on a quick test, but needs consideration and testing for possible problematic side-effects. I cannot yet think of any problems caused.~
See https://github.com/minetest/minetest/issues/9725#issuecomment-642245930 for more details on why the bug occurred and what this fix does.

I tested using the method shown in https://github.com/minetest/minetest/issues/9725#issuecomment-640130523
The player model seen in 3rd person now twitches upwards when jumping up the full node, this indicates that camera smoothing is now functional in that situation.
In 1st person, the sharp camera movement no longer happens.

The code i am changing here is 8 years old. It may have been written before air stepheight existed, such that the author thought camera smoothing was not necessary when the player was in air, but of course it is necessary if we have air stepheight.