### PR TITLE
Preserve model animation frame when expiring visuals

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -920,14 +920,21 @@ void GenericCAO::pushMeshAnimFrame(float dtime)
 	if (m_animated_meshnode) {
 		// Compensate for the time lost remaking the scene node.
 		// Not an exact fix - the time may be a tiny bit ahead.
-		s32 delta = (s32)(dtime / m_animated_meshnode->getAnimationSpeed() + 1);
+		s32 delta = (s32)ceil(dtime * (float)m_animated_meshnode->getAnimationSpeed());
 		// Stash animation frame (with an offset)
 		m_mesh_anim_frame = m_animated_meshnode->getFrameNr() + delta;
-		if ( m_mesh_anim_frame > m_animated_meshnode->getEndFrame()) {
-			if ( m_animated_meshnode->getLoopMode() )
-				m_mesh_anim_frame = m_animated_meshnode->getStartFrame();
+		s32 start = m_animated_meshnode->getStartFrame();
+		s32 end = m_animated_meshnode->getEndFrame();
+		if (m_mesh_anim_frame > end) {
+			s32 length = end - start;
+			if (m_animated_meshnode->getLoopMode() && length > 0) {
+				s32 relative = m_mesh_anim_frame - start;
+				m_mesh_anim_frame = relative % length + start;
+			}
 			else
-				m_mesh_anim_frame = m_animated_meshnode->getEndFrame();
+			{	
+				m_mesh_anim_frame = end;
+			}
 		}
 	}
 }

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -100,6 +100,9 @@ private:
 	float m_animation_speed = 15.0f;
 	float m_animation_blend = 0.0f;
 	bool m_animation_loop = true;
+	// Mesh animation frame stashed when expiring the visuals.
+	// Not used for anything else.
+	s32 m_mesh_anim_frame = 0;
 	// stores position and rotation for each bone name
 	std::unordered_map<std::string, core::vector2d<v3f>> m_bone_position;
 
@@ -230,6 +233,10 @@ public:
 	void removeFromScene(bool permanent);
 
 	void addToScene(ITextureSource *tsrc);
+
+	void pushMeshAnimFrame(float dtime);
+
+	void popMeshAnimFrame();
 
 	inline void expireVisuals()
 	{


### PR DESCRIPTION
Closes #10017
Closes #9129

![anim](https://user-images.githubusercontent.com/42101236/84334997-0ecc4900-ab94-11ea-81ac-13dfc024b3e9.gif)
_And there was much rejoicing._

This is another pure bug fix where I did not try to figure out why exactly does minetest do things the way it does. Remaking the whole scene node to change some textures stinks badly to me, but I'll roll with it for now.