### PR TITLE
Optional Animation with set_bone_position (possible close)

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5973,10 +5973,11 @@ object you are working with still exists.
 * `get_attach()`: returns parent, bone, position, rotation or nil if it isn't
   attached.
 * `set_detach()`
-* `set_bone_position(bone, position, rotation)`
+* `set_bone_position(bone, position, rotation, stop_animations)`
     * `bone`: string
     * `position`: `{x=num, y=num, z=num}` (relative)
     * `rotation`: `{x=num, y=num, z=num}`
+    * `stop_animations`: stop model animation (optional) default:true
 * `get_bone_position(bone)`: returns position and rotation of the bone
 * `set_properties(object property table)`
 * `get_properties()`: returns object property table

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -924,7 +924,9 @@ void GenericCAO::updateNodePos()
 void GenericCAO::step(float dtime, ClientEnvironment *env)
 {
 	if (m_animated_meshnode) {
-		m_animated_meshnode->animateJoints();
+		if (!m_stop_animations) {
+			m_animated_meshnode->animateJoints();
+		}
 		updateBonePosition();
 	}
 
@@ -1678,6 +1680,7 @@ void GenericCAO::processMessage(const std::string &data)
 		v3f position = readV3F32(is);
 		v3f rotation = readV3F32(is);
 		m_bone_position[bone] = core::vector2d<v3f>(position, rotation);
+		m_stop_animations = readU8(is);
 
 		// updateBonePosition(); now called every step
 	} else if (cmd == AO_CMD_ATTACH_TO) {

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -102,6 +102,7 @@ private:
 	bool m_animation_loop = true;
 	// stores position and rotation for each bone name
 	std::unordered_map<std::string, core::vector2d<v3f>> m_bone_position;
+	bool m_stop_animations = true;
 
 	int m_attachment_parent_id = 0;
 	std::unordered_set<int> m_attachment_child_ids;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -621,7 +621,7 @@ int ObjectRef::l_set_animation_frame_speed(lua_State *L)
 	return 1;
 }
 
-// set_bone_position(self, std::string bone, v3f position, v3f rotation)
+// set_bone_position(self, std::string bone, v3f position, v3f rotation, bool stop_animations)
 int ObjectRef::l_set_bone_position(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -638,7 +638,10 @@ int ObjectRef::l_set_bone_position(lua_State *L)
 	v3f rotation = v3f(0, 0, 0);
 	if (!lua_isnil(L, 4))
 		rotation = check_v3f(L, 4);
-	co->setBonePosition(bone, position, rotation);
+	bool stop_animations = true;
+	if (lua_isboolean(L, 5))
+		stop_animations = readParam<bool>(L, 5);
+	co->setBonePosition(bone, position, rotation, stop_animations);
 	return 0;
 }
 

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -238,7 +238,7 @@ std::string LuaEntitySAO::getClientInitializationData(u16 protocol_version)
 	msg_os << serializeLongString(generateUpdateAnimationCommand()); // 3
 	for (const auto &bone_pos : m_bone_position) {
 		msg_os << serializeLongString(generateUpdateBonePositionCommand(
-			bone_pos.first, bone_pos.second.X, bone_pos.second.Y)); // m_bone_position.size
+			bone_pos.first, bone_pos.second.X, bone_pos.second.Y, m_stop_animations)); // m_bone_position.size
 	}
 	msg_os << serializeLongString(generateUpdateAttachmentCommand()); // 4
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -122,7 +122,7 @@ std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 	msg_os << serializeLongString(generateUpdateAnimationCommand()); // 3
 	for (const auto &bone_pos : m_bone_position) {
 		msg_os << serializeLongString(generateUpdateBonePositionCommand(
-			bone_pos.first, bone_pos.second.X, bone_pos.second.Y)); // m_bone_position.size
+			bone_pos.first, bone_pos.second.X, bone_pos.second.Y, m_stop_animations)); // m_bone_position.size
 	}
 	msg_os << serializeLongString(generateUpdateAttachmentCommand()); // 4
 	msg_os << serializeLongString(generateUpdatePhysicsOverrideCommand()); // 5

--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -157,7 +157,7 @@ public:
 	{}
 	virtual void setAnimationSpeed(float frame_speed)
 	{}
-	virtual void setBonePosition(const std::string &bone, v3f position, v3f rotation)
+	virtual void setBonePosition(const std::string &bone, v3f position, v3f rotation, bool stop_animations)
 	{}
 	virtual void getBonePosition(const std::string &bone, v3f *position, v3f *lotation)
 	{}

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -75,11 +75,12 @@ void UnitSAO::setAnimationSpeed(float frame_speed)
 	m_animation_speed_sent = false;
 }
 
-void UnitSAO::setBonePosition(const std::string &bone, v3f position, v3f rotation)
+void UnitSAO::setBonePosition(const std::string &bone, v3f position, v3f rotation, bool stop_animations)
 {
 	// store these so they can be updated to clients
 	m_bone_position[bone] = core::vector2d<v3f>(position, rotation);
 	m_bone_position_sent = false;
+	m_stop_animations = stop_animations;
 }
 
 void UnitSAO::getBonePosition(const std::string &bone, v3f *position, v3f *rotation)
@@ -110,7 +111,7 @@ void UnitSAO::sendOutdatedData()
 		m_bone_position_sent = true;
 		for (const auto &bone_pos : m_bone_position) {
 			m_messages_out.emplace(getId(), true, generateUpdateBonePositionCommand(
-				bone_pos.first, bone_pos.second.X, bone_pos.second.Y));
+				bone_pos.first, bone_pos.second.X, bone_pos.second.Y, m_stop_animations));
 		}
 	}
 
@@ -249,7 +250,7 @@ std::string UnitSAO::generateUpdateAttachmentCommand() const
 }
 
 std::string UnitSAO::generateUpdateBonePositionCommand(
-		const std::string &bone, const v3f &position, const v3f &rotation)
+		const std::string &bone, const v3f &position, const v3f &rotation, const bool &stop_animations)
 {
 	std::ostringstream os(std::ios::binary);
 	// command
@@ -258,6 +259,7 @@ std::string UnitSAO::generateUpdateBonePositionCommand(
 	os << serializeString(bone);
 	writeV3F32(os, position);
 	writeV3F32(os, rotation);
+	writeU8(os, stop_animations);
 	return os.str();
 }
 

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -75,7 +75,8 @@ void UnitSAO::setAnimationSpeed(float frame_speed)
 	m_animation_speed_sent = false;
 }
 
-void UnitSAO::setBonePosition(const std::string &bone, v3f position, v3f rotation, bool stop_animations)
+void UnitSAO::setBonePosition(
+		const std::string &bone, v3f position, v3f rotation, bool stop_animations)
 {
 	// store these so they can be updated to clients
 	m_bone_position[bone] = core::vector2d<v3f>(position, rotation);
@@ -249,8 +250,8 @@ std::string UnitSAO::generateUpdateAttachmentCommand() const
 	return os.str();
 }
 
-std::string UnitSAO::generateUpdateBonePositionCommand(
-		const std::string &bone, const v3f &position, const v3f &rotation, const bool &stop_animations)
+std::string UnitSAO::generateUpdateBonePositionCommand(const std::string &bone,
+		const v3f &position, const v3f &rotation, const bool &stop_animations)
 {
 	std::ostringstream os(std::ios::binary);
 	// command

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -57,7 +57,7 @@ public:
 	void setAnimationSpeed(float frame_speed);
 
 	// Bone position
-	void setBonePosition(const std::string &bone, v3f position, v3f rotation);
+	void setBonePosition(const std::string &bone, v3f position, v3f rotation, bool stop_animations);
 	void getBonePosition(const std::string &bone, v3f *position, v3f *rotation);
 
 	// Attachments
@@ -88,7 +88,7 @@ public:
 			bool do_interpolate, bool is_movement_end, f32 update_interval);
 	std::string generateSetPropertiesCommand(const ObjectProperties &prop) const;
 	static std::string generateUpdateBonePositionCommand(const std::string &bone,
-			const v3f &position, const v3f &rotation);
+			const v3f &position, const v3f &rotation, const bool &stop_animations);
 	void sendPunchCommand();
 
 protected:
@@ -104,6 +104,7 @@ protected:
 
 	// Stores position and rotation for each bone name
 	std::unordered_map<std::string, core::vector2d<v3f>> m_bone_position;
+	bool m_stop_animations = true;
 
 	int m_attachment_parent_id = 0;
 

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -57,7 +57,8 @@ public:
 	void setAnimationSpeed(float frame_speed);
 
 	// Bone position
-	void setBonePosition(const std::string &bone, v3f position, v3f rotation, bool stop_animations);
+	void setBonePosition(const std::string &bone, v3f position, v3f rotation,
+			bool stop_animations);
 	void getBonePosition(const std::string &bone, v3f *position, v3f *rotation);
 
 	// Attachments
@@ -88,7 +89,8 @@ public:
 			bool do_interpolate, bool is_movement_end, f32 update_interval);
 	std::string generateSetPropertiesCommand(const ObjectProperties &prop) const;
 	static std::string generateUpdateBonePositionCommand(const std::string &bone,
-			const v3f &position, const v3f &rotation, const bool &stop_animations);
+			const v3f &position, const v3f &rotation,
+			const bool &stop_animations);
 	void sendPunchCommand();
 
 protected:


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Resolve #9807
- Provides the ability to not animate the model when positioning bones with set_bone_position. Also is enabled by default providing backwards compatibility with older mods that relied on old behavior. 

This PR is Ready for Review.

## How to test
Use player animation mod to confirm backwards compatibility. May also use set_bone_positions new parameter "stop_animations" to "false" and confirm the animations work in the new expected way.   
