### PR TITLE
fix transparency on GC7000L where mesa doesn't implement GL_ALPHA_TEST

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -190,6 +190,14 @@ void main(void)
 #endif
 	vec4 base = texture2D(baseTexture, uv).rgba;
 
+#ifdef USE_DISCARD
+	// If alpha is zero, we can just discard the pixel. This fixes transparency
+	// on GPUs like GC7000L, where GL_ALPHA_TEST is not implemented in mesa.
+	if (base.a == 0.0) {
+		discard;
+	}
+#endif
+
 #ifdef ENABLE_BUMPMAPPING
 	if (use_normalmap) {
 		vec3 L = normalize(lightVec);

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -129,6 +129,14 @@ void main(void)
 
 	vec4 base = texture2D(baseTexture, uv).rgba;
 
+#ifdef USE_DISCARD
+	// If alpha is zero, we can just discard the pixel. This fixes transparency
+	// on GPUs like GC7000L, where GL_ALPHA_TEST is not implemented in mesa.
+	if (base.a == 0.0) {
+		discard;
+	}
+#endif
+
 #ifdef ENABLE_BUMPMAPPING
 	if (use_normalmap) {
 		vec3 L = normalize(lightVec);

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -38,6 +38,16 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gamedef.h"
 #include "client/tile.h"
 
+#if ENABLE_GLES
+#ifdef _IRR_COMPILE_WITH_OGLES1_
+#include <GLES/gl.h>
+#else
+#include <GLES2/gl2.h>
+#endif
+#else
+#include <GL/gl.h>
+#endif
+
 /*
 	A cache from shader name to shader path
 */
@@ -604,6 +614,14 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 
 	// Create shaders header
 	std::string shaders_header = "#version 120\n";
+
+#ifdef __unix__
+	// For renderers that should use discard instead of GL_ALPHA_TEST
+	const char* gl_renderer = (const char*)glGetString(GL_RENDERER);
+	if (strstr(gl_renderer, "GC7000")) {
+		shaders_header += "#define USE_DISCARD\n";
+	}
+#endif
 
 	static const char* drawTypes[] = {
 		"NDT_NORMAL",


### PR DESCRIPTION
On chips with Vivante GC7000L GPU powered by the open-source etnaviv driver, GL_ALPHA_TEST is not implemented, so pixels in objects and nodes that should be transparent are black or another opaque color. This fix uses the discard shader operation to skip painting pixels with alpha value of 0.0.

## To do

This PR is Ready for Review.

## How to test

Just start minetest and look at plants and other objects with transparency. Hopefully, there should be no change on other GPUs.
