### PR TITLE
Add .nomedia file to Android assets

### DIFF
--- a/build/android/app/build.gradle
+++ b/build/android/app/build.gradle
@@ -83,6 +83,8 @@ task prepareAssets() {
 		from "${projRoot}/textures" into "${assetsFolder}/textures"
 	}
 
+	file("${assetsFolder}/.nomedia").text = "";
+
 	task zipAssets(type: Zip) {
 		archiveName "Minetest.zip"
 		from "${assetsFolder}"

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -1043,7 +1043,7 @@ void TouchScreenGUI::applyJoystickStatus()
 		if (i == 4 && !m_joystick_triggers_special1)
 			continue;
 
-		SEvent translated;
+		SEvent translated{};
 		translated.EventType            = irr::EET_KEY_INPUT_EVENT;
 		translated.KeyInput.Key         = id2keycode(m_joystick_names[i]);
 		translated.KeyInput.PressedDown = false;


### PR DESCRIPTION
.nomedia files prevent images from appearing in the phone's gallery app and other places.

This file was present in the old way of extracting/building assets

## To do

- [x] Check this works recursively
- [x] Testing

## How to test

Use Minetest, check gallery app

Gallery apps may cache the pictures, and won't recheck `.nomedia`. It also expects `.nomedia` to be the first file, which may not happen [if the folder is already indexed](https://stackoverflow.com/questions/5895992/android-nomedia-is-ignored-images-still-appear-on-the-gallery) (crazy assumption?!) I needed to delete the Minetest folder and reextract the assets for this to work. 