### PR TITLE
Allow setting state to rotate camera about parent object

### DIFF
--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -378,6 +378,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 					m_playernode->setParent(player->getParent()->getSceneNode());
 				}
 				player_position = v3f(0,0,0);
+//				player->setYaw(player->getYaw() + player->getParent()->getSceneNode()->getAbsoluteTransformation().getRotationDegrees().Y);
 			break;
 			case 3:
 				if (!player->eyes_attached)
@@ -496,13 +497,18 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	// Compute absolute camera position and target
 	m_headnode->getAbsoluteTransformation().transformVect(m_camera_position, rel_cam_pos);
 
+	m_headnode->getAbsoluteTransformation().rotateVect(m_camera_direction, rel_cam_target - rel_cam_pos);
+
 	if (player_parent && (player->eye_attach_state == 2 || player->eye_attach_state == 4))
 	{
 		v3f temp_pos = m_headnode->getAbsolutePosition() - m_playernode->getAbsolutePosition();
 		m_camera_position = player->getParent()->getPosition() + temp_pos;
 	}
-
-	m_headnode->getAbsoluteTransformation().rotateVect(m_camera_direction, rel_cam_target - rel_cam_pos);
+	
+	// Get absolute camera yaw by projecting the direction vector onto the xz plane
+	v3f xz_plane_normal = v3f(0,1,0);
+	v3f projected_dir = m_camera_direction - (m_camera_direction.dotProduct(xz_plane_normal)) * xz_plane_normal;
+	player->abs_camera_yaw = (atan2(projected_dir.Z, projected_dir.X) * core::RADTODEG - 90);
 
 	v3f abs_cam_up;
 	m_headnode->getAbsoluteTransformation().rotateVect(abs_cam_up, rel_cam_up);

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -378,7 +378,6 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 					m_playernode->setParent(player->getParent()->getSceneNode());
 				}
 				player_position = v3f(0,0,0);
-//				player->setYaw(player->getYaw() + player->getParent()->getSceneNode()->getAbsoluteTransformation().getRotationDegrees().Y);
 			break;
 			case 3:
 				if (!player->eyes_attached)
@@ -496,8 +495,10 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 
 	// Compute absolute camera position and target
 	m_headnode->getAbsoluteTransformation().transformVect(m_camera_position, rel_cam_pos);
-
 	m_headnode->getAbsoluteTransformation().rotateVect(m_camera_direction, rel_cam_target - rel_cam_pos);
+	player->camera_direction = m_camera_direction;
+
+//	std::cout << m_camera_direction.X << " " << m_camera_direction.Y << " " << m_camera_direction.Z << std::endl;
 
 	if (player_parent && (player->eye_attach_state == 2 || player->eye_attach_state == 4))
 	{
@@ -506,10 +507,23 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	}
 	
 	// Get absolute camera yaw by projecting the direction vector onto the xz plane
-	v3f xz_plane_normal = v3f(0,1,0);
-	v3f projected_dir = m_camera_direction - (m_camera_direction.dotProduct(xz_plane_normal)) * xz_plane_normal;
-	player->abs_camera_yaw = (atan2(projected_dir.Z, projected_dir.X) * core::RADTODEG - 90);
-
+//	v3f xz_plane_normal = v3f(0,1,0);
+//	v3f projected_dir = m_camera_direction - (m_camera_direction.dotProduct(xz_plane_normal)) * xz_plane_normal;
+//	player->abs_camera_yaw = (atan2(projected_dir.Z, projected_dir.X) * core::RADTODEG - 90);
+//	abs_cam_yaw = player->abs_camera_yaw;
+//
+//	float temp_yaw = atan2(-m_camera_direction.X, -m_camera_direction.Z) * core::RADTODEG;
+//	
+//	std::cout << abs_cam_yaw << " " << temp_yaw << std::endl;
+	
+	player->abs_camera_yaw = 360 - ((-(atan2(m_camera_direction.X, -m_camera_direction.Z) * core::RADTODEG)) + 180);
+	abs_cam_yaw = player->abs_camera_yaw;
+	
+	player->abs_camera_pitch = -asin(-m_camera_direction.Y) * core::RADTODEG;
+	abs_cam_pitch = player->abs_camera_pitch;
+	
+	std::cout << player->abs_camera_yaw << " " << player->abs_camera_pitch << std::endl;
+	
 	v3f abs_cam_up;
 	m_headnode->getAbsoluteTransformation().rotateVect(abs_cam_up, rel_cam_up);
 

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -336,9 +336,6 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	v3f old_player_position = m_playernode->getPosition();
 	v3f player_position;
 
-	bool eyes_attached = player->eyes_attached;
-	char eye_rotationstate = player->eye_attach_state;
-
 	// Calculate and translate the head SceneNode offsets
 	v3f eye_offset = player->getEyeOffset();
 	if (m_camera_mode == CAMERA_MODE_FIRST)
@@ -361,31 +358,31 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	if (!player_parent)
 	{
 		player_position = player->getPosition();
-		if (eyes_attached)
+		if (player->eyes_attached)
 		{
-			eyes_attached = false;
+			player->eyes_attached = false;
 			scene::ISceneManager *smgr = RenderingEngine::get_scene_manager();
 			m_playernode->setParent(smgr->getRootSceneNode());
 			m_headnode->setParent(m_playernode);
 		}
 	} else {
-		switch (eye_rotationstate)
+		switch (player->eye_attach_state)
 		{
 			case 1:
 				player_position = player_parent->getPosition();
 			break;
 			case 2:
-				if (!eyes_attached)
+				if (!player->eyes_attached)
 				{
-					eyes_attached = true;
+					player->eyes_attached = true;
 					m_playernode->setParent(player->getParent()->getSceneNode());
 				}
 				player_position = v3f(0,0,0);
 			break;
 			case 3:
-				if (!eyes_attached)
+				if (!player->eyes_attached)
 				{
-					eyes_attached = true;
+					player->eyes_attached = true;
 					scene::ISceneManager *smgr = RenderingEngine::get_scene_manager();
 					m_headnode->setParent(smgr->getRootSceneNode());
 					m_playernode->setParent(player_parent->getSceneNode());
@@ -397,9 +394,9 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 				head_rot.Y = body_rot.Y;
 			break;
 			case 4:
-				if (!eyes_attached)
+				if (!player->eyes_attached)
 				{
-					eyes_attached = true;
+					player->eyes_attached = true;
 					m_playernode->setParent(player->getParent()->getSceneNode());
 				}
 				player_position = v3f(0,0,0);
@@ -408,7 +405,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 			break;
 		}	
 	}
-	
+
 	if(player->touching_ground &&
 			player_position.Y > old_player_position.Y)
 	{
@@ -498,13 +495,13 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 
 	// Compute absolute camera position and target
 	m_headnode->getAbsoluteTransformation().transformVect(m_camera_position, rel_cam_pos);
-	
-	if (player_parent && (eye_rotationstate == 2 || eye_rotationstate == 4))
+
+	if (player_parent && (player->eye_attach_state == 2 || player->eye_attach_state == 4))
 	{
 		v3f temp_pos = m_headnode->getAbsolutePosition() - m_playernode->getAbsolutePosition();
 		m_camera_position = player->getParent()->getPosition() + temp_pos;
 	}
-	
+
 	m_headnode->getAbsoluteTransformation().rotateVect(m_camera_direction, rel_cam_target - rel_cam_pos);
 
 	v3f abs_cam_up;

--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -174,7 +174,8 @@ public:
 	void drawNametags();
 
 	inline void addArmInertia(f32 player_yaw);
-
+	float abs_cam_yaw = 0.0f;
+	float abs_cam_pitch = 0.0f;
 private:
 	// Nodes
 	scene::ISceneNode *m_playernode = nullptr;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -935,8 +935,8 @@ void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *
 {
 	v3f pf           = myplayer->getPosition() * 100;
 	v3f sf           = myplayer->getSpeed() * 100;
-	s32 pitch        = myplayer->getPitch() * 100;
-	s32 yaw          = myplayer->getYaw() * 100;
+	s32 pitch        = myplayer->abs_camera_pitch * 100;
+	s32 yaw          = myplayer->abs_camera_yaw * 100;
 	u32 keyPressed   = myplayer->keyPressed;
 	// scaled by 80, so that pi can fit into a u8
 	u8 fov           = clientMap->getCameraFov() * 80;
@@ -1317,7 +1317,7 @@ void Client::sendPlayerPos()
 	player->last_position     = player->getPosition();
 	player->last_speed        = player->getSpeed();
 	player->last_pitch        = player->getPitch();
-	player->last_yaw          = player->getYaw();
+	player->last_yaw          = player->abs_camera_yaw;
 	player->last_keyPressed   = player->keyPressed;
 	player->last_camera_fov   = camera_fov;
 	player->last_wanted_range = wanted_range;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -215,6 +215,7 @@ public:
 	void handleCommand_OverrideDayNightRatio(NetworkPacket* pkt);
 	void handleCommand_LocalPlayerAnimations(NetworkPacket* pkt);
 	void handleCommand_EyeOffset(NetworkPacket* pkt);
+	void handleCommand_EyeAttachState(NetworkPacket* pkt);
 	void handleCommand_UpdatePlayerList(NetworkPacket* pkt);
 	void handleCommand_ModChannelMsg(NetworkPacket *pkt);
 	void handleCommand_ModChannelSignal(NetworkPacket *pkt);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3960,7 +3960,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	*/
 	if (mapper && m_game_ui->m_flags.show_minimap && m_game_ui->m_flags.show_hud) {
 		mapper->setPos(floatToInt(player->getPosition(), BS));
-		mapper->setAngle(player->getYaw());
+		mapper->setAngle(player->abs_camera_yaw);
 	}
 
 	/*

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -133,9 +133,9 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			<< "pos: (" << (player_position.X / BS)
 			<< ", " << (player_position.Y / BS)
 			<< ", " << (player_position.Z / BS)
-			<< ") | yaw: " << (wrapDegrees_0_360(cam.camera_yaw)) << "\xC2\xB0 "
-			<< yawToDirectionString(cam.camera_yaw)
-			<< " | pitch: " << (-wrapDegrees_180(cam.camera_pitch)) << "\xC2\xB0"
+			<< ") | yaw: " << (wrapDegrees_0_360(player->abs_camera_yaw)) << "\xC2\xB0 "
+			<< yawToDirectionString(player->abs_camera_yaw)
+			<< " | pitch: " << (-wrapDegrees_180(player->abs_camera_pitch)) << "\xC2\xB0"
 			<< " | seed: " << ((u64)client->getMapSeed());
 
 		if (pointed_old.type == POINTEDTHING_NODE) {

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -135,6 +135,8 @@ void RemoteClient::GetNextBlocks (
 	// Camera position and direction
 	v3f camera_pos = sao->getEyePosition();
 	v3f camera_dir = v3f(0,0,1);
+//	camera_dir = sao->getPlayer()->camera_direction;
+//	std::cout << sao->m_player->camera_direction.X << " " << sao->m_player->camera_direction.Y << " " << sao->m_player->camera_direction.Z << std::endl;
 	camera_dir.rotateYZBy(sao->getLookPitch());
 	camera_dir.rotateXZBy(sao->getRotation().Y);
 

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -122,6 +122,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_handler,
 	{ "TOCLIENT_SRP_BYTES_S_B",            TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_SrpBytesSandB }, // 0x60
 	{ "TOCLIENT_FORMSPEC_PREPEND",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FormspecPrepend }, // 0x61,
+	{ "TOCLIENT_EYE_ATTACH_STATE",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_EyeAttachState }, // 0x62
 };
 
 const static ServerCommandFactory null_command_factory = { "TOSERVER_NULL", 0, false };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1388,6 +1388,18 @@ void Client::handleCommand_EyeOffset(NetworkPacket* pkt)
 	*pkt >> player->eye_offset_first >> player->eye_offset_third;
 }
 
+void Client::handleCommand_EyeAttachState(NetworkPacket* pkt)
+{
+	LocalPlayer *player = m_env.getLocalPlayer();
+	assert(player != NULL);
+
+	// Reset so that camera attachment
+	// hierarchy is reset for new state
+	player->eyes_attached = false;
+
+	*pkt >> player->eye_attach_state;
+}
+
 void Client::handleCommand_UpdatePlayerList(NetworkPacket* pkt)
 {
 	u8 type;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -762,7 +762,12 @@ enum ToClientCommand
 		u8[len] formspec
 	*/
 
-	TOCLIENT_NUM_MSG_TYPES = 0x62,
+	TOCLIENT_EYE_ATTACH_STATE = 0x62,
+	/*
+		char state
+	*/
+
+	TOCLIENT_NUM_MSG_TYPES = 0x63,
 };
 
 enum ToServerCommand

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -221,4 +221,5 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_factory, // 0x5f
 	{ "TOSERVER_SRP_BYTES_S_B",            0, true }, // 0x60
 	{ "TOCLIENT_FORMSPEC_PREPEND",         0, true }, // 0x61
+	{ "TOCLIENT_EYE_ATTACH_STATE",         0, true }, // 0x62
 };

--- a/src/player.h
+++ b/src/player.h
@@ -159,6 +159,19 @@ public:
 	v3f eye_offset_first;
 	v3f eye_offset_third;
 
+	// Eye rotation state for when player attached to an object
+	// States:
+	// 1 = default float head at parent origin with eye offset
+	// 2 = rotate camera pos, target, and up about parent origin 
+	//     at eye_offset radius (player free to move camera)
+	// 3 = rotate camera pos about parent origin but get target
+	//     and up vectors in their absolute directions
+	// 4 = rotate camera about parent origin but fix camera
+	//     view strictly to the defined target direction (target
+	//     direction direction is rotated/relative to parent rotation)
+	char eye_attach_state = 2;
+	bool eyes_attached = false;
+
 	Inventory inventory;
 
 	f32 movement_acceleration_default;

--- a/src/player.h
+++ b/src/player.h
@@ -169,9 +169,11 @@ public:
 	// 4 = rotate camera about parent origin but fix camera
 	//     view strictly to the defined target direction (target
 	//     direction direction is rotated/relative to parent rotation)
-	char eye_attach_state = 2;
+	char eye_attach_state = 4;
 	bool eyes_attached = false;
 	float abs_camera_yaw = 0.0f;
+	float abs_camera_pitch = 0.0f;
+	v3f camera_direction = v3f(0,0,0);
 
 	Inventory inventory;
 

--- a/src/player.h
+++ b/src/player.h
@@ -171,6 +171,7 @@ public:
 	//     direction direction is rotated/relative to parent rotation)
 	char eye_attach_state = 2;
 	bool eyes_attached = false;
+	float abs_camera_yaw = 0.0f;
 
 	Inventory inventory;
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -583,6 +583,39 @@ int ObjectRef::l_get_eye_offset(lua_State *L)
 	return 2;
 }
 
+// set_eye_attach_state(self, state)
+int ObjectRef::l_set_eye_attach_state(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+	
+	// Init at default state
+	char state = 1;
+	
+	if (!lua_isnil(L, 2))
+		state = readParam<s16>(L, 2);
+
+	getServer(L)->setPlayerEyeAttachState(player, state);
+	lua_pushboolean(L, true);
+	return 1;
+}
+
+// get_eye_attach_state(self)
+int ObjectRef::l_get_eye_attach_state(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+	
+	lua_pushnumber(L, player->eye_attach_state);
+	return 2;
+}
+
 // send_mapblock(self, pos)
 int ObjectRef::l_send_mapblock(lua_State *L)
 {
@@ -2356,6 +2389,8 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_local_animation),
 	luamethod(ObjectRef, set_eye_offset),
 	luamethod(ObjectRef, get_eye_offset),
+	luamethod(ObjectRef, set_eye_attach_state),
+	luamethod(ObjectRef, get_eye_attach_state),
 	luamethod(ObjectRef, send_mapblock),
 	{0,0}
 };

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -374,6 +374,12 @@ private:
 
 	// get_eye_offset(self)
 	static int l_get_eye_offset(lua_State *L);
+	
+	// set_eye_attach_state(self, state)
+	static int l_set_eye_attach_state(lua_State *L);
+
+	// get_eye_attach_state(self)
+	static int l_get_eye_attach_state(lua_State *L);
 
 	// set_nametag_attributes(self, attributes)
 	static int l_set_nametag_attributes(lua_State *L);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1844,6 +1844,13 @@ void Server::SendEyeOffset(session_t peer_id, v3f first, v3f third)
 	Send(&pkt);
 }
 
+void Server::SendEyeAttachState(session_t peer_id, char state)
+{
+	NetworkPacket pkt(TOCLIENT_EYE_ATTACH_STATE, 0, peer_id);
+	pkt << state;
+	Send(&pkt);
+}
+
 void Server::SendPlayerPrivileges(session_t peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
@@ -3324,6 +3331,13 @@ void Server::setPlayerEyeOffset(RemotePlayer *player, const v3f &first, const v3
 	player->eye_offset_first = first;
 	player->eye_offset_third = third;
 	SendEyeOffset(player->getPeerId(), first, third);
+}
+
+void Server::setPlayerEyeAttachState(RemotePlayer *player, const char &state)
+{
+	sanity_check(player);
+	player->eye_attach_state = state;
+	SendEyeAttachState(player->getPeerId(), state);
 }
 
 void Server::setSky(RemotePlayer *player, const SkyboxParams &params)

--- a/src/server.h
+++ b/src/server.h
@@ -293,6 +293,7 @@ public:
 	void setLocalPlayerAnimations(RemotePlayer *player, v2s32 animation_frames[4],
 			f32 frame_speed);
 	void setPlayerEyeOffset(RemotePlayer *player, const v3f &first, const v3f &third);
+	void setPlayerEyeAttachState(RemotePlayer *player, const char &state);
 
 	void setSky(RemotePlayer *player, const SkyboxParams &params);
 	void setSun(RemotePlayer *player, const SunParams &params);
@@ -397,6 +398,7 @@ private:
 	void SendLocalPlayerAnimations(session_t peer_id, v2s32 animation_frames[4],
 		f32 animation_speed);
 	void SendEyeOffset(session_t peer_id, v3f first, v3f third);
+	void SendEyeAttachState(session_t peer_id, char state);
 	void SendPlayerPrivileges(session_t peer_id);
 	void SendPlayerInventoryFormspec(session_t peer_id);
 	void SendPlayerFormspecPrepend(session_t peer_id);

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -178,13 +178,13 @@ public:
 	float getZoomFOV() const;
 
 	inline Metadata &getMeta() { return m_meta; }
-
+	RemotePlayer *m_player = nullptr;
 private:
 	std::string getPropertyPacket();
 	void unlinkPlayerSessionAndSave();
 	std::string generateUpdatePhysicsOverrideCommand() const;
 
-	RemotePlayer *m_player = nullptr;
+	
 	session_t m_peer_id = 0;
 
 	// Cheat prevention

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -343,7 +343,7 @@ void ActiveBlockList::update(std::vector<PlayerSAO*> &active_players,
 		s16 player_ao_range = std::min(active_object_range, playersao->getWantedRange());
 		// only do this if this would add blocks
 		if (player_ao_range > active_block_range) {
-			v3f camera_dir = v3f(0,0,1);
+			v3f camera_dir = v3f(0,0,1); //playersao->m_player->camera_direction;//playersao->getPlayer()->camera_direction;
 			camera_dir.rotateYZBy(playersao->getLookPitch());
 			camera_dir.rotateXZBy(playersao->getRotation().Y);
 			fillViewConeBlock(pos,


### PR DESCRIPTION
The goal of this PR is to, ultimately, provide functionality allowing for the player camera to rotate about a parent object.

This PR works by using Irrlicht's built-in quaternion class to rotate specific objects and vectors the player's camera depends on.

**This is a draft**
Right now only the math of rotating some points relative to a parent objects/origin is done. Lua modding interface has not been completed yet. This PR is here as a draft so that, hopefully, others can join in on the discussion and help build this feature.

Here is an example of the state of this feature. Please note that at one point in the video the camera jolts, this is due to the boat rotation code, not this feature: [video](https://streamable.com/ujaywe)



## To do
This PR is a Work in Progress
<!-- ^ delete one -->

- [ ] Test, develop, and verify that the rotation math actually works
- [ ] Add Lua modding functions like get/set_eye_attach_state(parent, state)

The biggest issue right now is that the feature only works when a boat is placed in one direction. Even then the camera does not behave as expected. One of the biggest goals is to make sure when looking down it is always at the boat as if you were standing on it.

## How to test
Download minetest-game and replace init.lua in the default 'boats' mod with the below code:

<details>
  <summary>Boat init.lua rotation testing code</summary>
  
  ```--
-- Helper functions
--

local function is_water(pos)
	local nn = minetest.get_node(pos).name
	return minetest.get_item_group(nn, "water") ~= 0
end


local function get_sign(i)
	if i == 0 then
		return 0
	else
		return i / math.abs(i)
	end
end


local function get_velocity(v, yaw, y)
	local x = -math.sin(yaw) * v
	local z =  math.cos(yaw) * v
	return {x = x, y = y, z = z}
end


local function get_v(v)
	return math.sqrt(v.x ^ 2 + v.z ^ 2)
end

--
-- Boat entity
--

local boat = {
	initial_properties = {
		physical = true,
		-- Warning: Do not change the position of the collisionbox top surface,
		-- lowering it causes the boat to fall through the world if underwater
		collisionbox = {-0.5, -0.35, -0.5, 0.5, 0.3, 0.5},
		visual = "mesh",
		mesh = "boats_boat.obj",
		textures = {"default_wood.png"},
	},

	driver = nil,
	v = 0,
	last_v = 0,
	removed = false,
	auto = false
}


function boat.on_rightclick(self, clicker)
	if not clicker or not clicker:is_player() then
		return
	end
	local name = clicker:get_player_name()
	if self.driver and name == self.driver then
		self.driver = nil
		self.auto = false
		clicker:set_detach()
		player_api.player_attached[name] = false
		player_api.set_animation(clicker, "stand" , 30)
		local pos = clicker:get_pos()
		pos = {x = pos.x, y = pos.y + 0.2, z = pos.z}
		minetest.after(0.1, function()
			clicker:set_pos(pos)
		end)
	elseif not self.driver then
		local attach = clicker:get_attach()
		if attach and attach:get_luaentity() then
			local luaentity = attach:get_luaentity()
			if luaentity.driver then
				luaentity.driver = nil
			end
			clicker:set_detach()
		end
		self.driver = name
		clicker:set_attach(self.object, "",
			{x = 0.5, y = 1, z = -3}, {x = 0, y = 0, z = 0})
		player_api.player_attached[name] = true

		minetest.after(0.2, function()
			player_api.set_animation(clicker, "sit" , 30)
		end)
		clicker:set_look_horizontal(self.object:get_yaw())
	end
end


-- If driver leaves server while driving boat
function boat.on_detach_child(self, child)
	self.driver = nil
	self.auto = false
end


function boat.on_activate(self, staticdata, dtime_s)
	self.object:set_armor_groups({immortal = 1})
	if staticdata then
		self.v = tonumber(staticdata)
	end
	self.last_v = self.v
end


function boat.get_staticdata(self)
	return tostring(self.v)
end


function boat.on_punch(self, puncher)
	if not puncher or not puncher:is_player() or self.removed then
		return
	end

	local name = puncher:get_player_name()
	if self.driver and name == self.driver then
		self.driver = nil
		puncher:set_detach()
		player_api.player_attached[name] = false
	end
	if not self.driver then
		self.removed = true
		local inv = puncher:get_inventory()
		if not (creative and creative.is_enabled_for
				and creative.is_enabled_for(name))
				or not inv:contains_item("main", "boats:boat") then
			local leftover = inv:add_item("main", "boats:boat")
			-- if no room in inventory add a replacement boat to the world
			if not leftover:is_empty() then
				minetest.add_item(self.object:get_pos(), leftover)
			end
		end
		-- delay remove to ensure player is detached
		minetest.after(0.1, function()
			self.object:remove()
		end)
	end
end



local function mul_mat3mat3(c, a, b)
  c[1], c[2], c[3],
  c[4], c[5], c[6],
  c[7], c[8], c[9]
    = a[1] * b[1] + a[2] * b[4] + a[3] * b[7]
    , a[1] * b[2] + a[2] * b[5] + a[3] * b[8]
    , a[1] * b[3] + a[2] * b[6] + a[3] * b[9]
    , a[4] * b[1] + a[5] * b[4] + a[6] * b[7]
    , a[4] * b[2] + a[5] * b[5] + a[6] * b[8]
    , a[4] * b[3] + a[5] * b[6] + a[6] * b[9]
    , a[7] * b[1] + a[8] * b[4] + a[9] * b[7]
    , a[7] * b[2] + a[8] * b[5] + a[9] * b[8]
    , a[7] * b[3] + a[8] * b[6] + a[9] * b[9]
end

local sin, cos, atan2, sqrt = math.sin, math.cos, math.atan2, math.sqrt

local function euler2matrix(rot)
  local a1, a2, a3 = rot.z, rot.x, rot.y
  local c1, s1 = cos(a1), sin(a1)
  local c2, s2 = cos(a2), sin(a2)
  local c3, s3 = cos(a3), sin(a3)

  return s1 * s2 * s3 + c1 * c3, s1 * c2, s1 * s2 * c3 - c1 * s3,
         c1 * s2 * s3 - s1 * c3, c1 * c2, c1 * s2 * c3 + s1 * s3,
         c2 * s3,               -s2,      c2 * c3
end

local function matrix2euler(m00, m01, m02, m10, m11, m12, m20, m21, m22)
  -- matrix to ZXY
  local a1 = atan2(m01, m11)
  local c2 = sqrt(m22*m22 + m20*m20)
  local a2 = atan2(-m21, c2)

  -- Shoemake's original
--  local a3 = atan2(m20, m22)

  -- Mike Day's replacement
  -- https://www.semanticscholar.org/paper/Extracting-Euler-Angles-from-a-Rotation-Matrix-Day/668137fa4b875d890f446e689eea1e334bcf6bf6
  local c1, s1 = cos(a1), sin(a1)
  local a3 = atan2(s1*m12 - c1*m02, c1*m00 - s1*m10)

  return {x = a2, y = a3, z = a1}
end


local mat1 = {0,0,0,0,0,0,0,0,0}
local mat2 = {0,0,0,0,0,0,0,0,0}

local rotate = function(obj, angles)
  local x, y, z = angles.x, angles.y, angles.z
  angles = obj:get_rotation()
  angles.x, angles.y, angles.z = -angles.x, -angles.y, -angles.z
  mat1[1], mat1[2], mat1[3],
  mat1[4], mat1[5], mat1[6],
  mat1[7], mat1[8], mat1[9] = euler2matrix(angles)
  local rotated = false

  if y ~= 0 then
    local c, s = cos(y), sin(y)
    mat2[1], mat2[2], mat2[3] = c,  0,  s
    mat2[4], mat2[5], mat2[6] = 0,  1,  0
    mat2[7], mat2[8], mat2[9] =-s,  0,  c
    mul_mat3mat3(mat1, mat2, mat1)
    rotated = true
  end

  if x ~= 0 then
    local c, s = cos(x), sin(x)
    mat2[1], mat2[2], mat2[3] = 1,  0,  0
    mat2[4], mat2[5], mat2[6] = 0,  c, -s
    mat2[7], mat2[8], mat2[9] = 0,  s,  c
    mul_mat3mat3(mat1, mat2, mat1)
    rotated = true
  end

  if z ~= 0 then
    local c, s = cos(z), sin(z)
    mat2[1], mat2[2], mat2[3] = c, -s,  0
    mat2[4], mat2[5], mat2[6] = s,  c,  0
    mat2[7], mat2[8], mat2[9] = 0,  0,  1
    mul_mat3mat3(mat1, mat2, mat1)
    rotated = true
  end

  if rotated then
    angles = matrix2euler(mat1[1], mat1[2], mat1[3],
                          mat1[4], mat1[5], mat1[6],
                          mat1[7], mat1[8], mat1[9])
    angles.x, angles.y, angles.z = -angles.x, -angles.y, -angles.z
    obj:set_rotation(angles)
  end
end



local rot = {0,0,0}

function boat.on_step(self, dtime)
	if self.driver then
		local driver_objref = minetest.get_player_by_name(self.driver)
		if driver_objref then
			local ctrl = driver_objref:get_player_control()
                        rot.x = 0
                        rot.y = 0
                        rot.z = 0
			-- Local yaw
			if ctrl.left then
				rot.y = rot.y + dtime * 1
			end if ctrl.right then
				rot.y = rot.y - dtime * 1
			end
			-- Local pitch
			if ctrl.up then
				rot.x = rot.x + dtime * 1
			end if ctrl.down then
				rot.x = rot.x - dtime * 1
			end
			-- Local roll
			if ctrl.jump then
				rot.z = rot.z + dtime * 1
			end if ctrl.sneak then
				rot.z = rot.z - dtime * 1
			end
			-- Inteded to be used in future as:
			--   self.object:rotate(rot)
			-- but currently self.object is userdata, not a table
			-- so for now it has to be done this way from Lua
			rotate(self.object, rot)

			self.object:set_pos(self.object:get_pos())
		end
	end
end


function boat._on_step(self, dtime)
	self.v = get_v(self.object:get_velocity()) * get_sign(self.v)
	if self.driver then
		local driver_objref = minetest.get_player_by_name(self.driver)
		if driver_objref then
			local ctrl = driver_objref:get_player_control()
			if ctrl.up and ctrl.down then
				if not self.auto then
					self.auto = true
					minetest.chat_send_player(self.driver, "[boats] Cruise on")
				end
			elseif ctrl.down then
				self.v = self.v - dtime * 1.8
				if self.auto then
					self.auto = false
					minetest.chat_send_player(self.driver, "[boats] Cruise off")
				end
			elseif ctrl.up or self.auto then
				self.v = self.v + dtime * 1.8
			end
			if ctrl.left then
				if self.v < -0.001 then
					self.object:set_yaw(self.object:get_yaw() - dtime * 0.9)
				else
					self.object:set_yaw(self.object:get_yaw() + dtime * 0.9)
				end
			elseif ctrl.right then
				if self.v < -0.001 then
					self.object:set_yaw(self.object:get_yaw() + dtime * 0.9)
				else
					self.object:set_yaw(self.object:get_yaw() - dtime * 0.9)
				end
			end
		end
	end
	local velo = self.object:get_velocity()
	if self.v == 0 and velo.x == 0 and velo.y == 0 and velo.z == 0 then
		self.object:set_pos(self.object:get_pos())
		return
	end
	local s = get_sign(self.v)
	self.v = self.v - dtime * 0.6 * s
	if s ~= get_sign(self.v) then
		self.object:set_velocity({x = 0, y = 0, z = 0})
		self.v = 0
		return
	end
	if math.abs(self.v) > 5 then
		self.v = 5 * get_sign(self.v)
	end

	local p = self.object:get_pos()
	p.y = p.y - 0.5
	local new_velo
	local new_acce = {x = 0, y = 0, z = 0}
	if not is_water(p) then
		local nodedef = minetest.registered_nodes[minetest.get_node(p).name]
		if (not nodedef) or nodedef.walkable then
			self.v = 0
			new_acce = {x = 0, y = 1, z = 0}
		else
			new_acce = {x = 0, y = -9.8, z = 0}
		end
		new_velo = get_velocity(self.v, self.object:get_yaw(),
			self.object:get_velocity().y)
		self.object:set_pos(self.object:get_pos())
	else
		p.y = p.y + 1
		if is_water(p) then
			local y = self.object:get_velocity().y
			if y >= 5 then
				y = 5
			elseif y < 0 then
				new_acce = {x = 0, y = 20, z = 0}
			else
				new_acce = {x = 0, y = 5, z = 0}
			end
			new_velo = get_velocity(self.v, self.object:get_yaw(), y)
			self.object:set_pos(self.object:get_pos())
		else
			new_acce = {x = 0, y = 0, z = 0}
			if math.abs(self.object:get_velocity().y) < 1 then
				local pos = self.object:get_pos()
				pos.y = math.floor(pos.y) + 0.5
				self.object:set_pos(pos)
				new_velo = get_velocity(self.v, self.object:get_yaw(), 0)
			else
				new_velo = get_velocity(self.v, self.object:get_yaw(),
					self.object:get_velocity().y)
				self.object:set_pos(self.object:get_pos())
			end
		end
	end
	self.object:set_velocity(new_velo)
	self.object:set_acceleration(new_acce)
end


minetest.register_entity("boats:boat", boat)


minetest.register_craftitem("boats:boat", {
	description = "Boat",
	inventory_image = "boats_inventory.png",
	wield_image = "boats_wield.png",
	wield_scale = {x = 2, y = 2, z = 1},
	liquids_pointable = true,
	groups = {flammable = 2},

	on_place = function(itemstack, placer, pointed_thing)
		local under = pointed_thing.under
		local node = minetest.get_node(under)
		local udef = minetest.registered_nodes[node.name]
		if udef and udef.on_rightclick and
				not (placer and placer:is_player() and
				placer:get_player_control().sneak) then
			return udef.on_rightclick(under, node, placer, itemstack,
				pointed_thing) or itemstack
		end

		if pointed_thing.type ~= "node" then
			return itemstack
		end
		if not is_water(pointed_thing.under) then
			return itemstack
		end
		pointed_thing.under.y = pointed_thing.under.y + 2.5-- + 0.5
		boat = minetest.add_entity(pointed_thing.under, "boats:boat")
		if boat then
			if placer then
				boat:set_yaw(placer:get_look_horizontal())
			end
			local player_name = placer and placer:get_player_name() or ""
			if not (creative and creative.is_enabled_for and
					creative.is_enabled_for(player_name)) then
				itemstack:take_item()
			end
		end
		return itemstack
	end,
})


minetest.register_craft({
	output = "boats:boat",
	recipe = {
		{"",           "",           ""          },
		{"group:wood", "",           "group:wood"},
		{"group:wood", "group:wood", "group:wood"},
	},
})

minetest.register_craft({
	type = "fuel",
	recipe = "boats:boat",
	burntime = 20,
})

  ```
</details>