### PR TITLE
Android: Fix asset upgrade by renaming license file

### DIFF
--- a/build/android/app/build.gradle
+++ b/build/android/app/build.gradle
@@ -57,7 +57,6 @@ task prepareAssets() {
 	}
 	copy {
 		from "${projRoot}/doc/lgpl-2.1.txt" into "${assetsFolder}"
-		rename("lgpl-2.1.txt", "LICENSE.txt")
 	}
 	copy {
 		from "${projRoot}/builtin" into "${assetsFolder}/builtin"


### PR DESCRIPTION
The LGPL license technically requires it to be distributed to end users (although, this isn't always done in practice)

This is a super simple solution that should keep both parties happy, or at least equally unhappy

Fixes #10049

cc/ @MoNTE48 