### PR TITLE
Android: fix maxAspectRatio (should be float)

### DIFF
--- a/build/android/app/src/main/AndroidManifest.xml
+++ b/build/android/app/src/main/AndroidManifest.xml
@@ -23,12 +23,12 @@
 
 		<meta-data
 			android:name="android.max_aspect"
-			android:value="3" />
+			android:value="3.0" />
 
 		<activity
 			android:name=".MainActivity"
 			android:configChanges="orientation|keyboardHidden|navigation|screenSize"
-			android:maxAspectRatio="3"
+			android:maxAspectRatio="3.0"
 			android:screenOrientation="sensorLandscape"
 			android:theme="@style/AppTheme">
 			<intent-filter>
@@ -42,7 +42,7 @@
 			android:configChanges="orientation|keyboard|keyboardHidden|navigation|screenSize|smallestScreenSize"
 			android:hardwareAccelerated="true"
 			android:launchMode="singleTask"
-			android:maxAspectRatio="3"
+			android:maxAspectRatio="3.0"
 			android:screenOrientation="sensorLandscape"
 			android:theme="@style/AppTheme">
 			<intent-filter>
@@ -55,7 +55,7 @@
 
 		<activity
 			android:name=".InputDialogActivity"
-			android:maxAspectRatio="3"
+			android:maxAspectRatio="3.0"
 			android:theme="@style/InputTheme" />
 
 		<service


### PR DESCRIPTION
PR, from which I am ashamed!
@rubenwardy, should be in 5.3, blocker pls.
Reported by edgy1.
I had to use float... Without this, on widescreen devices it would be like that.

![image](https://user-images.githubusercontent.com/6764600/85212404-95caaf80-b352-11ea-96f6-be446bf25f61.png)

Screenshot by edgy1 with MC, but no difference.