### PR TITLE
FormSpec: Add list spacing, slot size, and noclip

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2113,7 +2113,7 @@ Examples
     list[current_player;main;0,3.5;8,4;]
     list[current_player;craft;3,0;3,3;]
     list[current_player;craftpreview;7,1;1,1;]
-   
+
 Version History
 ---------------
 
@@ -2226,7 +2226,8 @@ Elements
 * Show an inventory list if it has been sent to the client. Nothing will
   be shown if the inventory list is of size 0.
 * **Note**: With the new coordinate system, the spacing between inventory
-  slots is one-fourth the size of an inventory slot.
+  slots is one-fourth the size of an inventory slot by default. Also see
+  [Styling Formspecs] for changing the size of slots and spacing.
 
 ### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;<starting item index>]`
 
@@ -2809,6 +2810,7 @@ Some types may inherit styles from parent types.
 * image_button
 * item_image_button
 * label
+* list
 * model
 * pwdfield, inherits from field
 * scrollbar
@@ -2896,6 +2898,10 @@ Some types may inherit styles from parent types.
     * font - Sets font type. See button `font` property for more information.
     * font_size - Sets font size. See button `font_size` property for more information.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
+* list
+    * noclip - boolean, set to true to allow the element to exceed formspec bounds.
+    * size - 2d vector, sets the size of inventory slots in coordinates.
+    * spacing - 2d vector, sets the space between inventory slots in coordinates.
 * image_button (additional properties)
     * fgimg - standard image. Defaults to none.
     * fgimg_hovered - image when hovered. Defaults to fgimg when not provided.
@@ -7633,12 +7639,12 @@ Used by `minetest.register_node`.
         -- intensity: 1.0 = mid range of regular TNT.
         -- If defined, called when an explosion touches the node, instead of
         -- removing the node.
-        
+
         mod_origin = "modname",
         -- stores which mod actually registered a node
         -- if it can not find a source, returns "??"
         -- useful for getting what mod truly registered something
-        -- example: if a node is registered as ":othermodname:nodename", 
+        -- example: if a node is registered as ":othermodname:nodename",
         -- nodename will show "othermodname", but mod_orgin will say "modname"
     }
 

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -33,6 +33,15 @@ local tabheaders_fs = [[
 	tabheader[8,6;10,1.5;tabs_size2;Height=1.5;1;false;false]
 ]]
 
+local inv_style_fs = [[
+	style_type[list;noclip=true]
+	list[current_player;main;-1.125,-1.125;2,2]
+	style_type[list;spacing=.25,.125;size=.75,.875]
+	list[current_player;main;3,.5;3,3]
+	style_type[list;spacing=0;size=1]
+	list[current_player;main;.5,4;8,4]
+]]
+
 local hypertext_basic = [[
 <bigger>Normal test</bigger>
 This is a normal text.
@@ -310,6 +319,10 @@ local pages = {
 		"size[12,13]real_coordinates[true]" ..
 		"container[0.5,1.5]" .. tabheaders_fs .. "container_end[]",
 
+		-- Inv
+		"size[12,13]real_coordinates[true]" ..
+		"container[0.5,1.5]" .. inv_style_fs .. "container_end[]",
+
 	-- Animation
 		[[
 			formspec_version[3]
@@ -341,7 +354,7 @@ Number]
 local function show_test_formspec(pname, page_id)
 	page_id = page_id or 2
 
-	local fs = pages[page_id] .. "tabheader[0,0;8,0.65;maintabs;Real Coord,Styles,Noclip,Hypertext,Tabs,Anim,ScrollC;" .. page_id .. ";false;false]"
+	local fs = pages[page_id] .. "tabheader[0,0;8,0.65;maintabs;Real Coord,Styles,Noclip,Hypertext,Tabs,Invs,Anim,ScrollC;" .. page_id .. ";false;false]"
 
 	minetest.show_formspec(pname, "testformspec:formspec", fs)
 end

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -265,40 +265,40 @@ public:
 		return rect;
 	}
 
-	irr::core::vector2d<f32> getVector2f(Property prop, irr::core::vector2d<f32> def) const
+	v2f32 getVector2f(Property prop, v2f32 def) const
 	{
 		const auto &val = properties[prop];
 		if (val.empty())
 			return def;
 
-		irr::core::vector2d<f32> vec;
+		v2f32 vec;
 		if (!parseVector2f(val, &vec))
 			return def;
 
 		return vec;
 	}
 
-	irr::core::vector2d<s32> getVector2i(Property prop, irr::core::vector2d<s32> def) const
+	v2s32 getVector2i(Property prop, v2s32 def) const
 	{
 		const auto &val = properties[prop];
 		if (val.empty())
 			return def;
 
-		irr::core::vector2d<s32> vec;
-		if (!parseVector2i(val, &vec))
+		v2f32 vec;
+		if (!parseVector2f(val, &vec))
 			return def;
 
-		return vec;
+		return v2s32(vec.X, vec.Y);
 	}
 
-	irr::core::vector2d<s32> getVector2i(Property prop) const
+	v2s32 getVector2i(Property prop) const
 	{
 		const auto &val = properties[prop];
 		FATAL_ERROR_IF(val.empty(), "Unexpected missing property");
 
-		irr::core::vector2d<s32> vec;
-		parseVector2i(val, &vec);
-		return vec;
+		v2f32 vec;
+		parseVector2f(val, &vec);
+		return v2s32(vec.X, vec.Y);
 	}
 
 	gui::IGUIFont *getFont() const
@@ -451,9 +451,9 @@ private:
 		return true;
 	}
 
-	bool parseVector2f(const std::string &value, irr::core::vector2d<f32> *parsed_vec) const
+	bool parseVector2f(const std::string &value, v2f32 *parsed_vec) const
 	{
-		irr::core::vector2d<f32> vec;
+		v2f32 vec;
 		std::vector<std::string> v_vector = split(value, ',');
 
 		if (v_vector.size() == 1) {
@@ -464,30 +464,7 @@ private:
 			vec.X = stof(v_vector[0]);
 			vec.Y =	stof(v_vector[1]);
 		} else {
-			warningstream << "Invalid vector2d string format: \"" << value
-					<< "\"" << std::endl;
-			return false;
-		}
-
-		*parsed_vec = vec;
-
-		return true;
-	}
-
-	bool parseVector2i(const std::string &value, irr::core::vector2d<s32> *parsed_vec) const
-	{
-		irr::core::vector2d<s32> vec;
-		std::vector<std::string> v_vector = split(value, ',');
-
-		if (v_vector.size() == 1) {
-			s32 x = stoi(v_vector[0]);
-			vec.X = x;
-			vec.Y = x;
-		} else if (v_vector.size() == 2) {
-			vec.X = stoi(v_vector[0]);
-			vec.Y =	stoi(v_vector[1]);
-		} else {
-			warningstream << "Invalid vector2d string format: \"" << value
+			warningstream << "Invalid 2d vector string format: \"" << value
 					<< "\"" << std::endl;
 			return false;
 		}

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -55,6 +55,8 @@ public:
 		BORDERCOLORS,
 		BORDERWIDTHS,
 		SOUND,
+		SPACING,
+		SIZE,
 		NUM_PROPERTIES,
 		NONE
 	};
@@ -119,6 +121,10 @@ public:
 			return BORDERWIDTHS;
 		} else if (name == "sound") {
 			return SOUND;
+		} else if (name == "spacing") {
+			return SPACING;
+		} else if (name == "size") {
+			return SIZE;
 		} else {
 			return NONE;
 		}
@@ -257,6 +263,19 @@ public:
 		irr::core::rect<s32> rect;
 		parseRect(val, &rect);
 		return rect;
+	}
+
+	irr::core::vector2d<f32> getVector2f(Property prop, irr::core::vector2d<f32> def) const
+	{
+		const auto &val = properties[prop];
+		if (val.empty())
+			return def;
+
+		irr::core::vector2d<f32> vec;
+		if (!parseVector2f(val, &vec))
+			return def;
+
+		return vec;
 	}
 
 	irr::core::vector2d<s32> getVector2i(Property prop, irr::core::vector2d<s32> def) const
@@ -432,6 +451,29 @@ private:
 		return true;
 	}
 
+	bool parseVector2f(const std::string &value, irr::core::vector2d<f32> *parsed_vec) const
+	{
+		irr::core::vector2d<f32> vec;
+		std::vector<std::string> v_vector = split(value, ',');
+
+		if (v_vector.size() == 1) {
+			f32 x = stof(v_vector[0]);
+			vec.X = x;
+			vec.Y = x;
+		} else if (v_vector.size() == 2) {
+			vec.X = stof(v_vector[0]);
+			vec.Y =	stof(v_vector[1]);
+		} else {
+			warningstream << "Invalid vector2d string format: \"" << value
+					<< "\"" << std::endl;
+			return false;
+		}
+
+		*parsed_vec = vec;
+
+		return true;
+	}
+
 	bool parseVector2i(const std::string &value, irr::core::vector2d<s32> *parsed_vec) const
 	{
 		irr::core::vector2d<s32> vec;
@@ -442,10 +484,8 @@ private:
 			vec.X = x;
 			vec.Y = x;
 		} else if (v_vector.size() == 2) {
-			s32 x = stoi(v_vector[0]);
-			s32 y =	stoi(v_vector[1]);
-			vec.X = x;
-			vec.Y = y;
+			vec.X = stoi(v_vector[0]);
+			vec.Y =	stoi(v_vector[1]);
 		} else {
 			warningstream << "Invalid vector2d string format: \"" << value
 					<< "\"" << std::endl;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -497,19 +497,39 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 			3
 		);
 
-		v2f32 slot_spacing = data->real_coordinates ?
-				v2f32(imgsize.X * 1.25f, imgsize.Y * 1.25f) : spacing;
+		auto style = getDefaultStyleForElement("list", spec.fname);
 
-		v2s32 pos = data->real_coordinates ? getRealCoordinateBasePos(v_pos)
-				: getElementBasePos(&v_pos);
+		v2f32 slot_scale = style.getVector2f(StyleSpec::SIZE, v2f32(0, 0));
+		v2s32 slot_size(
+			slot_scale.X <= 0 ? imgsize.X : slot_scale.X * imgsize.X,
+			slot_scale.Y <= 0 ? imgsize.Y : slot_scale.Y * imgsize.Y
+		);
+
+		v2f32 slot_spacing = style.getVector2f(StyleSpec::SPACING, v2f32(-1, -1));
+		if (data->real_coordinates) {
+			slot_spacing.X = slot_spacing.X < 0 ? imgsize.X * 1.25f :
+					slot_spacing.X * imgsize.X + imgsize.X;
+			slot_spacing.Y = slot_spacing.Y < 0 ? imgsize.Y * 1.25f :
+					slot_spacing.Y * imgsize.Y + imgsize.Y;
+		} else {
+			slot_spacing.X = slot_spacing.X < 0 ? spacing.X :
+					slot_spacing.X * spacing.X;
+			slot_spacing.Y = slot_spacing.Y < 0 ? spacing.Y :
+					slot_spacing.Y * spacing.Y;
+		}
+
+		v2s32 pos = data->real_coordinates ? getRealCoordinateBasePos(v_pos) :
+				getElementBasePos(&v_pos);
 
 		core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y,
 				pos.X + (geom.X - 1) * slot_spacing.X + imgsize.X,
 				pos.Y + (geom.Y - 1) * slot_spacing.Y + imgsize.Y);
 
 		GUIInventoryList *e = new GUIInventoryList(Environment, data->current_parent,
-				spec.fid, rect, m_invmgr, loc, listname, geom, start_i, imgsize,
+				spec.fid, rect, m_invmgr, loc, listname, geom, start_i, slot_size,
 				slot_spacing, this, data->inventorylist_options, m_font);
+
+		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 
 		m_inventorylists.push_back(e);
 		m_fields.push_back(spec);


### PR DESCRIPTION
This is #9240, updated to use `GUIInventoryList` and styling, with a few more differences.  It adds three new styling properties to inventory lists:

* `noclip` - boolean, set to true to allow the element to exceed formspec bounds.
* `size` - 2d vector, sets the size of inventory slots in coordinates.  Slots can be rectangular as well as square.
* `spacing` - 2d vector, sets the space between inventory slots in coordinates.

This does not add border width unlike #9240; fancier list styling should come in a later PR, preferably with things like `bgimg` and state selection, etc. with the deprecation of `listcolors` as well (possibly).

I consider this PR useful since this is a non-modifiable thing, and I'm not happy with the defaults I chose for `real_coordinates`, looking back.  Those defaults don't feel the same as the old inventory lists and kind of look wrong as a result just because they're different.

Note that lists cannot be styled by name because they don't actually have one; their name refers to an inventory location and can be duplicated in another list in the same formspec, so it wouldn't really work.

![image](https://user-images.githubusercontent.com/31123645/85237738-f9e68580-b3dd-11ea-85ad-3a3eab266996.png)

## To do

This PR is Ready for Review.

## How to test

```
formspec_version[3]
size[9,8.5]
style_type[list;noclip=true]
list[current_player;main;-1.125,-1.125;2,2]
style_type[list;spacing=.25,.125;size=.75,.875]
list[current_player;main;3,.5;3,3]
style_type[list;spacing=0;size=1]
list[current_player;main;.5,4;8,4]
```