### PR TITLE
Use JSON for favorites, move server list code to Lua

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -62,24 +62,6 @@ function image_column(tooltip, flagname)
 		"5=" .. core.formspec_escape(defaulttexturedir .. "server_ping_1.png")
 end
 
---------------------------------------------------------------------------------
-function order_favorite_list(list)
-	local res = {}
-	--orders the favorite list after support
-	for i = 1, #list do
-		local fav = list[i]
-		if is_server_protocol_compat(fav.proto_min, fav.proto_max) then
-			res[#res + 1] = fav
-		end
-	end
-	for i = 1, #list do
-		local fav = list[i]
-		if not is_server_protocol_compat(fav.proto_min, fav.proto_max) then
-			res[#res + 1] = fav
-		end
-	end
-	return res
-end
 
 --------------------------------------------------------------------------------
 function render_serverlist_row(spec, is_favorite)
@@ -224,41 +206,6 @@ function menu_handle_key_up_down(fields, textlist, settingname)
 		return true
 	end
 	return false
-end
-
---------------------------------------------------------------------------------
-function asyncOnlineFavourites()
-	if not menudata.public_known then
-		menudata.public_known = {{
-			name = fgettext("Loading..."),
-			description = fgettext_ne("Try reenabling public serverlist and check your internet connection.")
-		}}
-	end
-	menudata.favorites = menudata.public_known
-	menudata.favorites_is_public = true
-
-	if not menudata.public_downloading then
-		menudata.public_downloading = true
-	else
-		return
-	end
-
-	core.handle_async(
-		function(param)
-			return core.get_favorites("online")
-		end,
-		nil,
-		function(result)
-			menudata.public_downloading = nil
-			local favs = order_favorite_list(result)
-			if favs[1] then
-				menudata.public_known = favs
-				menudata.favorites = menudata.public_known
-				menudata.favorites_is_public = true
-			end
-			core.event_handler("Refresh")
-		end
-	)
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -33,6 +33,7 @@ dofile(basepath .. "fstk" .. DIR_DELIM .. "ui.lua")
 dofile(menupath .. DIR_DELIM .. "async_event.lua")
 dofile(menupath .. DIR_DELIM .. "common.lua")
 dofile(menupath .. DIR_DELIM .. "pkgmgr.lua")
+dofile(menupath .. DIR_DELIM .. "serverlistmgr.lua")
 dofile(menupath .. DIR_DELIM .. "textures.lua")
 
 dofile(menupath .. DIR_DELIM .. "dlg_config_world.lua")

--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -1,0 +1,195 @@
+--Minetest
+--Copyright (C) 2020 rubenwardy
+--
+--This program is free software; you can redistribute it and/or modify
+--it under the terms of the GNU Lesser General Public License as published by
+--the Free Software Foundation; either version 2.1 of the License, or
+--(at your option) any later version.
+--
+--This program is distributed in the hope that it will be useful,
+--but WITHOUT ANY WARRANTY; without even the implied warranty of
+--MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--GNU Lesser General Public License for more details.
+--
+--You should have received a copy of the GNU Lesser General Public License along
+--with this program; if not, write to the Free Software Foundation, Inc.,
+--51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+serverlistmgr = {}
+local _favorites
+
+--------------------------------------------------------------------------------
+local function order_favorite_list(list)
+	local res = {}
+	--orders the favorite list after support
+	for i = 1, #list do
+		local fav = list[i]
+		if is_server_protocol_compat(fav.proto_min, fav.proto_max) then
+			res[#res + 1] = fav
+		end
+	end
+	for i = 1, #list do
+		local fav = list[i]
+		if not is_server_protocol_compat(fav.proto_min, fav.proto_max) then
+			res[#res + 1] = fav
+		end
+	end
+	return res
+end
+
+--------------------------------------------------------------------------------
+function serverlistmgr.sync()
+	if not menudata.public_known then
+		menudata.public_known = {{
+			name = fgettext("Loading..."),
+			description = fgettext_ne("Try reenabling public serverlist and check your internet connection.")
+		}}
+	end
+	menudata.favorites = menudata.public_known
+	menudata.favorites_is_public = true
+
+	if not menudata.public_downloading then
+		menudata.public_downloading = true
+	else
+		return
+	end
+
+	core.handle_async(
+		function(param)
+			-- TODO
+		end,
+		nil,
+		function(result)
+			menudata.public_downloading = nil
+			local favs = order_favorite_list(result)
+			if favs[1] then
+				menudata.public_known = favs
+				menudata.favorites = menudata.public_known
+				menudata.favorites_is_public = true
+			end
+			core.event_handler("Refresh")
+		end
+	)
+end
+
+--------------------------------------------------------------------------------
+function serverlistmgr.get_online(current_favourite)
+	return online
+end
+
+--------------------------------------------------------------------------------
+local function get_favorites_path()
+	local base = core.get_user_path() .. DIR_DELIM .. "client" .. DIR_DELIM .. "serverlist" .. DIR_DELIM
+	return base .. core.settings:get("serverlist_file")
+end
+
+--------------------------------------------------------------------------------
+local function save_favorites(favorites)
+	local filename = core.settings:get("serverlist_file")
+	if filename:sub(#filename - 3):lower() == ".txt" then
+		core.settings:set("serverlist_file", filename:sub(1, #filename - 4) .. ".json")
+	end
+
+	local path = get_favorites_path()
+	core.create_dir(path)
+	core.safe_write_file(path, core.write_json(favorites))
+end
+
+--------------------------------------------------------------------------------
+local function read_favorites()
+	local path = get_favorites_path()
+
+	if path:sub(#path - 4):lower() == ".json" then
+		local file = io.open(path, "r")
+		if file then
+			local json = file:read("*all")
+			file:close()
+			return core.parse_json(json)
+		end
+
+		path = path:sub(1, #path - 5) .. ".txt"
+	end
+
+	local file = io.open(path, "r")
+	if file then
+		local lines = {}
+		for line in file:lines() do
+			lines[#lines + 1] = line
+		end
+		file:close()
+
+		local favorites = {}
+
+		local i = 1
+		while i < #lines do
+			local function pop()
+				local line = lines[i]
+				i = i + 1
+				return line and line:trim()
+			end
+
+			if pop():lower() == "[SERVER]" then
+				local name = pop()
+				local address = pop()
+				local port = pop()
+				local description = pop()
+
+				if not address or #address < 3 then
+					core.log("warning", "Malformed favourites file, missing address at line " .. i)
+				end
+				if not port or port < 1 or port > 65535 then
+					core.log("warning", "Malformed favourites file, missing port at line " .. i)
+				end
+				if name:upper() == "[SERVER]" or address:upper() == "[SERVER]" or port:upper() == "[SERVER]" then
+					core.log("warning", "Potentially malformed favourites file, overran at line " .. i)
+				end
+
+				favorites[#favorites + 1] = {
+					name = name,
+					address = address,
+					port = tonumber(port),
+					description = description
+				}
+			end
+		end
+
+		return favorites
+	end
+
+	return nil
+end
+
+--------------------------------------------------------------------------------
+local function delete_favorite(favorites, current_favourite)
+
+end
+
+--------------------------------------------------------------------------------
+function serverlistmgr.get_favorites(current_favourite)
+	if _favorites then
+		return _favorites
+	end
+
+	_favorites = read_favorites(json)
+	return _favorites or {}
+end
+
+--------------------------------------------------------------------------------
+function serverlistmgr.add_favorite(current_favourite)
+	local favorites = serverlistmgr.get_favorites()
+	delete_favorite(favorites, current_favourite)
+	table.insert(favorites, {
+		name = current_favourite.name,
+		address = current_favourite.address,
+		port = tonumber(current_favourite.port),
+		description = current_favourite.description,
+	})
+	save_favorites(favorites)
+end
+
+--------------------------------------------------------------------------------
+function serverlistmgr.delete_favorite(current_favourite)
+	local favorites = serverlistmgr.get_favorites()
+	delete_favorite(favorites, current_favourite)
+	save_favorites(favorites)
+end

--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -101,60 +101,60 @@ end
 --------------------------------------------------------------------------------
 function serverlistmgr.read_legacy_favorites(path)
 	local file = io.open(path, "r")
-	if file then
-		local lines = {}
-		for line in file:lines() do
-			lines[#lines + 1] = line
-		end
-		file:close()
-
-		local favorites = {}
-
-		local i = 1
-		while i < #lines do
-			local function pop()
-				local line = lines[i]
-				i = i + 1
-				return line and line:trim()
-			end
-
-			if pop():lower() == "[server]" then
-				local name = pop()
-				local address = pop()
-				local port = tonumber(pop())
-				local description = pop()
-
-				if name == "" then
-					name = nil
-				end
-
-				if description == "" then
-					description = nil
-				end
-
-				if not address or #address < 3 then
-					core.log("warning", "Malformed favorites file, missing address at line " .. i)
-				elseif not port or port < 1 or port > 65535 then
-					core.log("warning", "Malformed favorites file, missing port at line " .. i)
-				elseif (name and name:upper() == "[SERVER]") or
-						(address and address:upper() == "[SERVER]") or
-						(description and description:upper() == "[SERVER]") then
-					core.log("warning", "Potentially malformed favorites file, overran at line " .. i)
-				else
-					favorites[#favorites + 1] = {
-						name = name,
-						address = address,
-						port = port,
-						description = description
-					}
-				end
-			end
-		end
-
-		return favorites
+	if not file then
+		return nil
 	end
 
-	return nil
+	local lines = {}
+	for line in file:lines() do
+		lines[#lines + 1] = line
+	end
+	file:close()
+
+	local favorites = {}
+
+	local i = 1
+	while i < #lines do
+		local function pop()
+			local line = lines[i]
+			i = i + 1
+			return line and line:trim()
+		end
+
+		if pop():lower() == "[server]" then
+			local name = pop()
+			local address = pop()
+			local port = tonumber(pop())
+			local description = pop()
+
+			if name == "" then
+				name = nil
+			end
+
+			if description == "" then
+				description = nil
+			end
+
+			if not address or #address < 3 then
+				core.log("warning", "Malformed favorites file, missing address at line " .. i)
+			elseif not port or port < 1 or port > 65535 then
+				core.log("warning", "Malformed favorites file, missing port at line " .. i)
+			elseif (name and name:upper() == "[SERVER]") or
+					(address and address:upper() == "[SERVER]") or
+					(description and description:upper() == "[SERVER]") then
+				core.log("warning", "Potentially malformed favorites file, overran at line " .. i)
+			else
+				favorites[#favorites + 1] = {
+					name = name,
+					address = address,
+					port = port,
+					description = description
+				}
+			end
+		end
+	end
+
+	return favorites
 end
 
 --------------------------------------------------------------------------------
@@ -195,7 +195,7 @@ function serverlistmgr.get_favorites()
 
 	serverlistmgr.favorites = {}
 
-	-- Add favourites, removing duplicates
+	-- Add favorites, removing duplicates
 	local seen = {}
 	for _, fav in ipairs(read_favorites() or {}) do
 		local key = ("%s:%d"):format(fav.address:lower(), fav.port)

--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -172,7 +172,12 @@ local function read_favorites()
 		path = path:sub(1, #path - 5) .. ".txt"
 	end
 
-	return serverlistmgr.read_legacy_favorites(path)
+	local favs = serverlistmgr.read_legacy_favorites(path)
+	if favs then
+		save_favorites(favs)
+		os.remove(path)
+	end
+	return favs
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -36,22 +36,21 @@ local function order_favorite_list(list)
 	return res
 end
 
+local public_downloading = false
+
 --------------------------------------------------------------------------------
 function serverlistmgr.sync()
-	if not serverlistmgr.public_known then
-		serverlistmgr.public_known = {{
+	if not serverlistmgr.servers then
+		serverlistmgr.servers = {{
 			name = fgettext("Loading..."),
 			description = fgettext_ne("Try reenabling public serverlist and check your internet connection.")
 		}}
 	end
-	serverlistmgr.favorites = serverlistmgr.public_known
-	serverlistmgr.favorites_is_public = true
 
-	if not serverlistmgr.public_downloading then
-		serverlistmgr.public_downloading = true
-	else
+	if public_downloading then
 		return
 	end
+	public_downloading = true
 
 	core.handle_async(
 		function(param)
@@ -71,12 +70,10 @@ function serverlistmgr.sync()
 		end,
 		nil,
 		function(result)
-			serverlistmgr.public_downloading = nil
+			public_downloading = nil
 			local favs = order_favorite_list(result)
 			if favs[1] then
-				serverlistmgr.public_known = favs
-				serverlistmgr.favorites = serverlistmgr.public_known
-				serverlistmgr.favorites_is_public = true
+				serverlistmgr.servers = favs
 			end
 			core.event_handler("Refresh")
 		end
@@ -189,13 +186,13 @@ local function delete_favorite(favorites, current_favorite)
 end
 
 --------------------------------------------------------------------------------
-function serverlistmgr.get_favorites(current_favorite)
-	if menudata.favorites then
-		return menudata.favorites
+function serverlistmgr.get_favorites()
+	if serverlistmgr.favorites then
+		return serverlistmgr.favorites
 	end
 
-	menudata.favorites = read_favorites()
-	return menudata.favorites or {}
+	serverlistmgr.favorites = read_favorites()
+	return serverlistmgr.favorites or {}
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -210,11 +210,13 @@ end
 
 --------------------------------------------------------------------------------
 function serverlistmgr.add_favorite(new_favorite)
-	-- Sanitise favorite
+	assert(type(new_favorite.port) == "number")
+
+	-- Whitelist favorite keys
 	new_favorite = {
 		name = new_favorite.name,
 		address = new_favorite.address,
-		port = tonumber(new_favorite.port),
+		port = new_favorite.port,
 		description = new_favorite.description,
 	}
 

--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -197,7 +197,7 @@ function serverlistmgr.get_favorites()
 
 	-- Add favourites, removing duplicates
 	local seen = {}
-	for _, fav in ipairs(read_favorites()) do
+	for _, fav in ipairs(read_favorites() or {}) do
 		local key = ("%s:%d"):format(fav.address:lower(), fav.port)
 		if not seen[key] then
 			seen[key] = true

--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -18,7 +18,7 @@
 serverlistmgr = {}
 
 --------------------------------------------------------------------------------
-local function order_favorite_list(list)
+local function order_server_list(list)
 	local res = {}
 	--orders the favorite list after support
 	for i = 1, #list do
@@ -71,7 +71,7 @@ function serverlistmgr.sync()
 		nil,
 		function(result)
 			public_downloading = nil
-			local favs = order_favorite_list(result)
+			local favs = order_server_list(result)
 			if favs[1] then
 				serverlistmgr.servers = favs
 			end
@@ -134,22 +134,20 @@ function serverlistmgr.read_legacy_favorites(path)
 
 				if not address or #address < 3 then
 					core.log("warning", "Malformed favorites file, missing address at line " .. i)
-				end
-				if not port or port < 1 or port > 65535 then
+				elseif not port or port < 1 or port > 65535 then
 					core.log("warning", "Malformed favorites file, missing port at line " .. i)
-				end
-				if (name and name:upper() == "[SERVER]") or
+				elseif (name and name:upper() == "[SERVER]") or
 						(address and address:upper() == "[SERVER]") or
 						(description and description:upper() == "[SERVER]") then
 					core.log("warning", "Potentially malformed favorites file, overran at line " .. i)
+				else
+					favorites[#favorites + 1] = {
+						name = name,
+						address = address,
+						port = port,
+						description = description
+					}
 				end
-
-				favorites[#favorites + 1] = {
-					name = name,
-					address = address,
-					port = port,
-					description = description
-				}
 			end
 		end
 
@@ -178,10 +176,10 @@ local function read_favorites()
 end
 
 --------------------------------------------------------------------------------
-local function delete_favorite(favorites, current_favorite)
+local function delete_favorite(favorites, del_favorite)
 	for i=1, #favorites do
 		local fav = favorites[i]
-		if fav.address == current_favorite.address and fav.port == current_favorite.port then
+		if fav.address == del_favorite.address and fav.port == del_favorite.port then
 			table.remove(favorites, i)
 			return
 		end
@@ -201,21 +199,21 @@ function serverlistmgr.get_favorites()
 end
 
 --------------------------------------------------------------------------------
-function serverlistmgr.add_favorite(current_favorite)
+function serverlistmgr.add_favorite(new_favorite)
 	local favorites = serverlistmgr.get_favorites()
-	delete_favorite(favorites, current_favorite)
+	delete_favorite(favorites, new_favorite)
 	table.insert(favorites, {
-		name = current_favorite.name,
-		address = current_favorite.address,
-		port = tonumber(current_favorite.port),
-		description = current_favorite.description,
+		name = new_favorite.name,
+		address = new_favorite.address,
+		port = tonumber(new_favorite.port),
+		description = new_favorite.description,
 	})
 	save_favorites(favorites)
 end
 
 --------------------------------------------------------------------------------
-function serverlistmgr.delete_favorite(current_favorite)
+function serverlistmgr.delete_favorite(del_favorite)
 	local favorites = serverlistmgr.get_favorites()
-	delete_favorite(favorites, current_favorite)
+	delete_favorite(favorites, del_favorite)
 	save_favorites(favorites)
 end

--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -99,20 +99,7 @@ local function save_favorites(favorites)
 end
 
 --------------------------------------------------------------------------------
-local function read_favorites()
-	local path = get_favorites_path()
-
-	if path:sub(#path - 4):lower() == ".json" then
-		local file = io.open(path, "r")
-		if file then
-			local json = file:read("*all")
-			file:close()
-			return core.parse_json(json)
-		end
-
-		path = path:sub(1, #path - 5) .. ".txt"
-	end
-
+function serverlistmgr.read_legacy_favorites(path)
 	local file = io.open(path, "r")
 	if file then
 		local lines = {}
@@ -170,6 +157,24 @@ local function read_favorites()
 	end
 
 	return nil
+end
+
+--------------------------------------------------------------------------------
+local function read_favorites()
+	local path = get_favorites_path()
+
+	if path:sub(#path - 4):lower() == ".json" then
+		local file = io.open(path, "r")
+		if file then
+			local json = file:read("*all")
+			file:close()
+			return core.parse_json(json)
+		end
+
+		path = path:sub(1, #path - 5) .. ".txt"
+	end
+
+	return serverlistmgr.read_legacy_favorites(path)
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -89,6 +89,7 @@ end
 --------------------------------------------------------------------------------
 local function save_favorites(favorites)
 	local filename = core.settings:get("serverlist_file")
+	-- If setting specifies legacy format change the filename to the new one
 	if filename:sub(#filename - 3):lower() == ".txt" then
 		core.settings:set("serverlist_file", filename:sub(1, #filename - 4) .. ".json")
 	end
@@ -161,6 +162,7 @@ end
 local function read_favorites()
 	local path = get_favorites_path()
 
+	-- If new format configured fall back to reading the legacy file
 	if path:sub(#path - 4):lower() == ".json" then
 		local file = io.open(path, "r")
 		if file then

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -86,7 +86,7 @@ local function get_formspec(tabview, name, tabdata)
 
 	if menudata.search_result then
 		for i = 1, #menudata.search_result do
-			local favs = core.get_favorites("local")
+			local favs = serverlistmgr.get_favorites()
 			local server = menudata.search_result[i]
 
 			for fav_id = 1, #favs do
@@ -103,7 +103,7 @@ local function get_formspec(tabview, name, tabdata)
 			retval = retval .. render_serverlist_row(server, server.is_favorite)
 		end
 	elseif #menudata.favorites > 0 then
-		local favs = core.get_favorites("local")
+		local favs = serverlistmgr.get_favorites()
 		if #favs > 0 then
 			for i = 1, #favs do
 			for j = 1, #menudata.favorites do
@@ -177,7 +177,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		if event.type == "CHG" then
 			if event.row <= #serverlist then
 				gamedata.fav = false
-				local favs = core.get_favorites("local")
+				local favs = serverlistmgr.get_favorites()
 				local address = fav.address
 				local port    = fav.port
 				gamedata.serverdescription = fav.description
@@ -234,8 +234,8 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		local current_favourite = core.get_table_index("favourites")
 		if not current_favourite then return end
 
-		core.delete_favorite(current_favourite)
-		asyncOnlineFavourites()
+		serverlistmgr.delete_favorite(current_favourite)
+		serverlistmgr.sync()
 		tabdata.fav_selected = nil
 
 		core.settings:set("address", "")
@@ -305,7 +305,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	end
 
 	if fields.btn_mp_refresh then
-		asyncOnlineFavourites()
+		serverlistmgr.sync()
 		return true
 	end
 
@@ -347,7 +347,7 @@ end
 
 local function on_change(type, old_tab, new_tab)
 	if type == "LEAVE" then return end
-	asyncOnlineFavourites()
+	serverlistmgr.sync()
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -85,10 +85,9 @@ local function get_formspec(tabview, name, tabdata)
 		"table[-0.15,0.6;7.75,5.15;favorites;"
 
 	if menudata.search_result then
+		local favs = serverlistmgr.get_favorites()
 		for i = 1, #menudata.search_result do
-			local favs = serverlistmgr.get_favorites()
 			local server = menudata.search_result[i]
-
 			for fav_id = 1, #favs do
 				if server.address == favs[fav_id].address and
 						server.port == favs[fav_id].port then

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -313,14 +313,14 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		gamedata.playername = fields.te_name
 		gamedata.password   = fields.te_pwd
 		gamedata.address    = fields.te_address
-		gamedata.port       = fields.te_port
+		gamedata.port       = tonumber(fields.te_port)
 		gamedata.selected_world = 0
 		local fav_idx = core.get_table_index("favorites")
 		local fav = serverlist[fav_idx]
 
 		if fav_idx and fav_idx <= #serverlist and
-				fav.address == fields.te_address and
-				fav.port    == fields.te_port then
+				fav.address == gamedata.address and
+				fav.port    == gamedata.port then
 
 			serverlistmgr.add_favorite(fav)
 
@@ -336,13 +336,13 @@ local function main_button_handler(tabview, fields, name, tabdata)
 			gamedata.serverdescription = ""
 
 			serverlistmgr.add_favorite({
-				address = fields.te_address,
-				port = fields.te_port,
+				address = gamedata.address,
+				port = gamedata.port,
 			})
 		end
 
-		core.settings:set("address",     fields.te_address)
-		core.settings:set("remote_port", fields.te_port)
+		core.settings:set("address",     gamedata.address)
+		core.settings:set("remote_port", gamedata.port)
 
 		core.start()
 		return true

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -323,6 +323,8 @@ local function main_button_handler(tabview, fields, name, tabdata)
 				fav.address == fields.te_address and
 				fav.port    == fields.te_port then
 
+			serverlistmgr.add_favorite(fav)
+
 			gamedata.servername        = fav.name
 			gamedata.serverdescription = fav.description
 
@@ -334,6 +336,11 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		else
 			gamedata.servername        = ""
 			gamedata.serverdescription = ""
+
+			serverlistmgr.add_favorite({
+				address = fields.te_address,
+				port = fields.te_port,
+			})
 		end
 
 		core.settings:set("address",     fields.te_address)

--- a/builtin/mainmenu/tests/favorites_wellformed.txt
+++ b/builtin/mainmenu/tests/favorites_wellformed.txt
@@ -1,0 +1,29 @@
+[server]
+
+127.0.0.1
+30000
+
+
+[server]
+
+localhost
+30000
+
+
+[server]
+
+vps.rubenwardy.com
+30001
+
+
+[server]
+
+gundul.ddnss.de
+39155
+
+
+[server]
+VanessaE's Dreambuilder creative Server
+daconcepts.com
+30000
+VanessaE's Dreambuilder creative-mode server. Lots of mods, whitelisted buckets.

--- a/builtin/mainmenu/tests/serverlistmgr_spec.lua
+++ b/builtin/mainmenu/tests/serverlistmgr_spec.lua
@@ -1,0 +1,36 @@
+_G.core = {}
+_G.unpack = table.unpack
+_G.serverlistmgr = {}
+
+dofile("builtin/common/misc_helpers.lua")
+dofile("builtin/mainmenu/serverlistmgr.lua")
+
+local base = "builtin/mainmenu/tests/"
+
+describe("legacy favorites", function()
+	it("loads well-formed correctly", function()
+		local favs = serverlistmgr.read_legacy_favorites(base .. "favorites_wellformed.txt")
+
+		local expected = {
+			{
+				address = "127.0.0.1",
+				port = 30000,
+			},
+
+			{ address = "localhost", port = 30000 },
+
+			{ address = "vps.rubenwardy.com", port = 30001 },
+
+			{ address = "gundul.ddnss.de", port = 39155 },
+
+			{
+				address = "daconcepts.com",
+				port = 30000,
+				name = "VanessaE's Dreambuilder creative Server",
+				description = "VanessaE's Dreambuilder creative-mode server. Lots of mods, whitelisted buckets."
+			},
+		}
+
+		assert.same(expected, favs)
+	end)
+end)

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -961,7 +961,7 @@ serverlist_url (Serverlist URL) string servers.minetest.net
 
 #    File in client/serverlist/ that contains your favorite servers displayed in the
 #    Multiplayer Tab.
-serverlist_file (Serverlist file) string favoriteservers.txt
+serverlist_file (Serverlist file) string favoriteservers.json
 
 #    Maximum size of the out chat queue.
 #    0 to disable queueing and -1 to make the queue size unlimited.

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -244,32 +244,6 @@ Package - content which is downloadable from the content db, may or may not be i
         }
 
 
-Favorites
----------
-
-core.get_favorites(location) -> list of favorites (possible in async calls)
-^ location: "local" or "online"
-^ returns {
-    [1] = {
-        clients       = <number of clients/nil>,
-        clients_max   = <maximum number of clients/nil>,
-        version       = <server version/nil>,
-        password      = <true/nil>,
-        creative      = <true/nil>,
-        damage        = <true/nil>,
-        pvp           = <true/nil>,
-        description   = <server description/nil>,
-        name          = <server name/nil>,
-        address       = <address of server/nil>,
-        port          = <port>
-        clients_list  = <array of clients/nil>
-        mods          = <array of mods/nil>
-    },
-    ...
-}
-core.delete_favorite(id, location) -> success
-
-
 Logging
 -------
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1375,7 +1375,7 @@
 # ask_reconnect_on_crash = false
 
 #    From how far clients know about objects, stated in mapblocks (16 nodes).
-#
+#    
 #    Setting this larger than active_block_range will also cause the server
 #    to maintain active objects up to this distance in the direction the
 #    player is looking. (This can avoid mobs suddenly disappearing from view)
@@ -1928,7 +1928,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -1941,7 +1941,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    3D noise defining giant caverns.
@@ -1954,7 +1954,7 @@
 #    octaves     = 5,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    3D noise defining terrain.
@@ -1980,7 +1980,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 ## Mapgen V6
@@ -2367,7 +2367,7 @@
 #    octaves     = 5,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    3D noise defining structure of river canyon walls.
@@ -2380,7 +2380,7 @@
 #    octaves     = 4,
 #    persistence = 0.75,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    3D noise defining structure of floatlands.
@@ -2396,7 +2396,7 @@
 #    octaves     = 4,
 #    persistence = 0.75,
 #    lacunarity  = 1.618,
-#    flags       =
+#    flags       = 
 # }
 
 #    3D noise defining giant caverns.
@@ -2409,7 +2409,7 @@
 #    octaves     = 5,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    First of two 3D noises that together define tunnels.
@@ -2422,7 +2422,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -2435,7 +2435,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    3D noise that determines number of dungeons per mapchunk.
@@ -2448,7 +2448,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 ## Mapgen Carpathian
@@ -2691,7 +2691,7 @@
 #    octaves     = 5,
 #    persistence = 0.55,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    First of two 3D noises that together define tunnels.
@@ -2704,7 +2704,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -2717,7 +2717,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    3D noise defining giant caverns.
@@ -2730,7 +2730,7 @@
 #    octaves     = 5,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    3D noise that determines number of dungeons per mapchunk.
@@ -2743,7 +2743,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 ## Mapgen Flat
@@ -2853,7 +2853,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -2866,7 +2866,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    3D noise that determines number of dungeons per mapchunk.
@@ -2879,7 +2879,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 ## Mapgen Fractal
@@ -3053,7 +3053,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -3066,7 +3066,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    3D noise that determines number of dungeons per mapchunk.
@@ -3079,7 +3079,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 ## Mapgen Valleys
@@ -3169,7 +3169,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -3182,7 +3182,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    The depth of dirt or other biome filler node.
@@ -3208,7 +3208,7 @@
 #    octaves     = 6,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    Defines large-scale river channel structure.
@@ -3260,7 +3260,7 @@
 #    octaves     = 6,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 #    Amplifies the valleys.
@@ -3299,7 +3299,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       =
+#    flags       = 
 # }
 
 ## Advanced

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1157,7 +1157,7 @@
 #    File in client/serverlist/ that contains your favorite servers displayed in the
 #    Multiplayer Tab.
 #    type: string
-# serverlist_file = favoriteservers.txt
+# serverlist_file = favoriteservers.json
 
 #    Maximum size of the out chat queue.
 #    0 to disable queueing and -1 to make the queue size unlimited.
@@ -1375,7 +1375,7 @@
 # ask_reconnect_on_crash = false
 
 #    From how far clients know about objects, stated in mapblocks (16 nodes).
-#    
+#
 #    Setting this larger than active_block_range will also cause the server
 #    to maintain active objects up to this distance in the direction the
 #    player is looking. (This can avoid mobs suddenly disappearing from view)
@@ -1928,7 +1928,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -1941,7 +1941,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise defining giant caverns.
@@ -1954,7 +1954,7 @@
 #    octaves     = 5,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise defining terrain.
@@ -1980,7 +1980,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 ## Mapgen V6
@@ -2367,7 +2367,7 @@
 #    octaves     = 5,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise defining structure of river canyon walls.
@@ -2380,7 +2380,7 @@
 #    octaves     = 4,
 #    persistence = 0.75,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise defining structure of floatlands.
@@ -2396,7 +2396,7 @@
 #    octaves     = 4,
 #    persistence = 0.75,
 #    lacunarity  = 1.618,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise defining giant caverns.
@@ -2409,7 +2409,7 @@
 #    octaves     = 5,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    First of two 3D noises that together define tunnels.
@@ -2422,7 +2422,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -2435,7 +2435,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise that determines number of dungeons per mapchunk.
@@ -2448,7 +2448,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 ## Mapgen Carpathian
@@ -2691,7 +2691,7 @@
 #    octaves     = 5,
 #    persistence = 0.55,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    First of two 3D noises that together define tunnels.
@@ -2704,7 +2704,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -2717,7 +2717,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise defining giant caverns.
@@ -2730,7 +2730,7 @@
 #    octaves     = 5,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise that determines number of dungeons per mapchunk.
@@ -2743,7 +2743,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 ## Mapgen Flat
@@ -2853,7 +2853,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -2866,7 +2866,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise that determines number of dungeons per mapchunk.
@@ -2879,7 +2879,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 ## Mapgen Fractal
@@ -3053,7 +3053,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -3066,7 +3066,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise that determines number of dungeons per mapchunk.
@@ -3079,7 +3079,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 ## Mapgen Valleys
@@ -3169,7 +3169,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -3182,7 +3182,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    The depth of dirt or other biome filler node.
@@ -3208,7 +3208,7 @@
 #    octaves     = 6,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Defines large-scale river channel structure.
@@ -3260,7 +3260,7 @@
 #    octaves     = 6,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Amplifies the valleys.
@@ -3299,7 +3299,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 ## Advanced

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -487,14 +487,6 @@ bool ClientLauncher::launch_game(std::string &error_message,
 		start_data.socket_port = myrand_range(49152, 65535);
 	} else {
 		g_settings->set("name", start_data.name);
-		if (!start_data.address.empty()) {
-			ServerListSpec server;
-			server["name"]        = server_name;
-			server["address"]     = start_data.address;
-			server["port"]        = itos(start_data.socket_port);
-			server["description"] = server_description;
-			ServerList::insert(server);
-		}
 	}
 
 	if (start_data.name.length() > PLAYERNAME_SIZE - 1) {

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -282,7 +282,7 @@ void set_default_settings(Settings *settings)
 
 	// Main menu
 	settings->setDefault("main_menu_path", "");
-	settings->setDefault("serverlist_file", "favoriteservers.txt");
+	settings->setDefault("serverlist_file", "favoriteservers.json");
 
 #if USE_FREETYPE
 	settings->setDefault("freetype", "true");

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -952,5 +952,7 @@ void ModApiMainMenu::InitializeAsync(lua_State *L, int top)
 	//API_FCT(extract_zip); //TODO remove dependency to GuiEngine
 	API_FCT(may_modify_path);
 	API_FCT(download_file);
+	API_FCT(get_min_supp_proto);
+	API_FCT(get_max_supp_proto);
 	//API_FCT(gettext); (gettext lib isn't threadsafe)
 }

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -275,207 +275,6 @@ int ModApiMainMenu::l_get_worlds(lua_State *L)
 }
 
 /******************************************************************************/
-int ModApiMainMenu::l_get_favorites(lua_State *L)
-{
-	std::string listtype = "local";
-
-	if (!lua_isnone(L, 1)) {
-		listtype = luaL_checkstring(L, 1);
-	}
-
-	std::vector<ServerListSpec> servers;
-
-	if(listtype == "online") {
-		servers = ServerList::getOnline();
-	} else {
-		servers = ServerList::getLocal();
-	}
-
-	lua_newtable(L);
-	int top = lua_gettop(L);
-	unsigned int index = 1;
-
-	for (const Json::Value &server : servers) {
-
-		lua_pushnumber(L, index);
-
-		lua_newtable(L);
-		int top_lvl2 = lua_gettop(L);
-
-		if (!server["clients"].asString().empty()) {
-			std::string clients_raw = server["clients"].asString();
-			char* endptr = 0;
-			int numbervalue = strtol(clients_raw.c_str(), &endptr,10);
-
-			if ((!clients_raw.empty()) && (*endptr == 0)) {
-				lua_pushstring(L, "clients");
-				lua_pushnumber(L, numbervalue);
-				lua_settable(L, top_lvl2);
-			}
-		}
-
-		if (!server["clients_max"].asString().empty()) {
-
-			std::string clients_max_raw = server["clients_max"].asString();
-			char* endptr = 0;
-			int numbervalue = strtol(clients_max_raw.c_str(), &endptr,10);
-
-			if ((!clients_max_raw.empty()) && (*endptr == 0)) {
-				lua_pushstring(L, "clients_max");
-				lua_pushnumber(L, numbervalue);
-				lua_settable(L, top_lvl2);
-			}
-		}
-
-		if (!server["version"].asString().empty()) {
-			lua_pushstring(L, "version");
-			std::string topush = server["version"].asString();
-			lua_pushstring(L, topush.c_str());
-			lua_settable(L, top_lvl2);
-		}
-
-		if (!server["proto_min"].asString().empty()) {
-			lua_pushstring(L, "proto_min");
-			lua_pushinteger(L, server["proto_min"].asInt());
-			lua_settable(L, top_lvl2);
-		}
-
-		if (!server["proto_max"].asString().empty()) {
-			lua_pushstring(L, "proto_max");
-			lua_pushinteger(L, server["proto_max"].asInt());
-			lua_settable(L, top_lvl2);
-		}
-
-		if (!server["password"].asString().empty()) {
-			lua_pushstring(L, "password");
-			lua_pushboolean(L, server["password"].asBool());
-			lua_settable(L, top_lvl2);
-		}
-
-		if (!server["creative"].asString().empty()) {
-			lua_pushstring(L, "creative");
-			lua_pushboolean(L, server["creative"].asBool());
-			lua_settable(L, top_lvl2);
-		}
-
-		if (!server["damage"].asString().empty()) {
-			lua_pushstring(L, "damage");
-			lua_pushboolean(L, server["damage"].asBool());
-			lua_settable(L, top_lvl2);
-		}
-
-		if (!server["pvp"].asString().empty()) {
-			lua_pushstring(L, "pvp");
-			lua_pushboolean(L, server["pvp"].asBool());
-			lua_settable(L, top_lvl2);
-		}
-
-		if (!server["description"].asString().empty()) {
-			lua_pushstring(L, "description");
-			std::string topush = server["description"].asString();
-			lua_pushstring(L, topush.c_str());
-			lua_settable(L, top_lvl2);
-		}
-
-		if (!server["name"].asString().empty()) {
-			lua_pushstring(L, "name");
-			std::string topush = server["name"].asString();
-			lua_pushstring(L, topush.c_str());
-			lua_settable(L, top_lvl2);
-		}
-
-		if (!server["address"].asString().empty()) {
-			lua_pushstring(L, "address");
-			std::string topush = server["address"].asString();
-			lua_pushstring(L, topush.c_str());
-			lua_settable(L, top_lvl2);
-		}
-
-		if (!server["port"].asString().empty()) {
-			lua_pushstring(L, "port");
-			std::string topush = server["port"].asString();
-			lua_pushstring(L, topush.c_str());
-			lua_settable(L, top_lvl2);
-		}
-
-		if (server.isMember("ping")) {
-			float ping = server["ping"].asFloat();
-			lua_pushstring(L, "ping");
-			lua_pushnumber(L, ping);
-			lua_settable(L, top_lvl2);
-		}
-
-		if (server["clients_list"].isArray()) {
-			unsigned int index_lvl2 = 1;
-			lua_pushstring(L, "clients_list");
-			lua_newtable(L);
-			int top_lvl3 = lua_gettop(L);
-			for (const Json::Value &client : server["clients_list"]) {
-				lua_pushnumber(L, index_lvl2);
-				std::string topush = client.asString();
-				lua_pushstring(L, topush.c_str());
-				lua_settable(L, top_lvl3);
-				index_lvl2++;
-			}
-			lua_settable(L, top_lvl2);
-		}
-
-		if (server["mods"].isArray()) {
-			unsigned int index_lvl2 = 1;
-			lua_pushstring(L, "mods");
-			lua_newtable(L);
-			int top_lvl3 = lua_gettop(L);
-			for (const Json::Value &mod : server["mods"]) {
-
-				lua_pushnumber(L, index_lvl2);
-				std::string topush = mod.asString();
-				lua_pushstring(L, topush.c_str());
-				lua_settable(L, top_lvl3);
-				index_lvl2++;
-			}
-			lua_settable(L, top_lvl2);
-		}
-
-		lua_settable(L, top);
-		index++;
-	}
-	return 1;
-}
-
-/******************************************************************************/
-int ModApiMainMenu::l_delete_favorite(lua_State *L)
-{
-	std::vector<ServerListSpec> servers;
-
-	std::string listtype = "local";
-
-	if (!lua_isnone(L,2)) {
-		listtype = luaL_checkstring(L,2);
-	}
-
-	if ((listtype != "local") &&
-		(listtype != "online"))
-		return 0;
-
-
-	if(listtype == "online") {
-		servers = ServerList::getOnline();
-	} else {
-		servers = ServerList::getLocal();
-	}
-
-	int fav_idx	= luaL_checkinteger(L,1) -1;
-
-	if ((fav_idx >= 0) &&
-			(fav_idx < (int) servers.size())) {
-
-		ServerList::deleteEntry(servers[fav_idx]);
-	}
-
-	return 0;
-}
-
-/******************************************************************************/
 int ModApiMainMenu::l_get_games(lua_State *L)
 {
 	std::vector<SubgameSpec> games = getAvailableGames();
@@ -1105,11 +904,9 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(get_content_info);
 	API_FCT(start);
 	API_FCT(close);
-	API_FCT(get_favorites);
 	API_FCT(show_keys_menu);
 	API_FCT(create_world);
 	API_FCT(delete_world);
-	API_FCT(delete_favorite);
 	API_FCT(set_background);
 	API_FCT(set_topleft_text);
 	API_FCT(get_mapgen_names);
@@ -1142,7 +939,6 @@ void ModApiMainMenu::InitializeAsync(lua_State *L, int top)
 {
 	API_FCT(get_worlds);
 	API_FCT(get_games);
-	API_FCT(get_favorites);
 	API_FCT(get_mapgen_names);
 	API_FCT(get_modpath);
 	API_FCT(get_clientmodpath);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -74,10 +74,6 @@ private:
 
 	static int l_get_mapgen_names(lua_State *L);
 
-	static int l_get_favorites(lua_State *L);
-
-	static int l_delete_favorite(lua_State *L);
-
 	static int l_gettext(lua_State *L);
 
 	//packages

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -259,6 +259,17 @@ int ModApiUtil::l_get_builtin_path(lua_State *L)
 	return 1;
 }
 
+// get_user_path()
+int ModApiUtil::l_get_user_path(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	std::string path = porting::path_user;
+	lua_pushstring(L, path.c_str());
+
+	return 1;
+}
+
 // compress(data, method, level)
 int ModApiUtil::l_compress(lua_State *L)
 {
@@ -496,6 +507,7 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 	API_FCT(is_nan);
 
 	API_FCT(get_builtin_path);
+	API_FCT(get_user_path);
 
 	API_FCT(compress);
 	API_FCT(decompress);
@@ -550,6 +562,7 @@ void ModApiUtil::InitializeAsync(lua_State *L, int top)
 	API_FCT(is_yes);
 
 	API_FCT(get_builtin_path);
+	API_FCT(get_user_path);
 
 	API_FCT(compress);
 	API_FCT(decompress);

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -71,6 +71,9 @@ private:
 	// get_builtin_path()
 	static int l_get_builtin_path(lua_State *L);
 
+	// get_user_path()
+	static int l_get_user_path(lua_State *L);
+
 	// compress(data, method, ...)
 	static int l_compress(lua_State *L);
 

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -24,8 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-typedef Json::Value ServerListSpec;
-
 namespace ServerList
 {
 #if USE_CURL

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -28,17 +28,6 @@ typedef Json::Value ServerListSpec;
 
 namespace ServerList
 {
-std::vector<ServerListSpec> getLocal();
-std::vector<ServerListSpec> getOnline();
-
-bool deleteEntry(const ServerListSpec &server);
-bool insert(const ServerListSpec &server);
-
-std::vector<ServerListSpec> deSerialize(const std::string &liststring);
-const std::string serialize(const std::vector<ServerListSpec> &serverlist);
-std::vector<ServerListSpec> deSerializeJson(const std::string &liststring);
-const std::string serializeJson(const std::vector<ServerListSpec> &serverlist);
-
 #if USE_CURL
 enum AnnounceAction {AA_START, AA_UPDATE, AA_DELETE};
 void sendAnnounce(AnnounceAction, u16 port,


### PR DESCRIPTION
- Favourites are now serialised using JSON. The old gross text format is supported for reading only.
- Move server list code to Lua
- This introduces a slight change in behaviour: joining a server using the command line won't add a favorite. I don't think this is a problem though.
- Fixes #5878  Fixes #9933

## To do

- [x] Set favorite on join server
- [x] Fix online server list
- [x] Remove favorites in `menudata`
- [x] Clean up serverlistmgr API

## How to test

<!-- Example code or instructions -->
