### PR TITLE
Remove std::shared_ptr use in TileLayer

### DIFF
--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -25,7 +25,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <vector>
 #include <SMaterial.h>
-#include <memory>
 #include "util/numeric.h"
 #include "config.h"
 
@@ -284,7 +283,7 @@ struct TileLayer
 	//! If true, the tile has its own color.
 	bool has_color = false;
 
-	std::shared_ptr<std::vector<FrameSpec>> frames = nullptr;
+	std::vector<FrameSpec> *frames = nullptr;
 
 	/*!
 	 * The color of the tile, or if the tile does not own

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -317,6 +317,18 @@ ContentFeatures::ContentFeatures()
 	reset();
 }
 
+ContentFeatures::~ContentFeatures()
+{
+#ifndef SERVER
+	for (u16 j = 0; j < 6; j++) {
+		delete tiles[j].layers[0].frames;
+		delete tiles[j].layers[1].frames;
+	}
+	for (u16 j = 0; j < CF_SPECIAL_COUNT; j++)
+		delete special_tiles[j].layers[0].frames;
+#endif
+}
+
 void ContentFeatures::reset()
 {
 	/*
@@ -662,7 +674,7 @@ static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 	} else {
 		std::ostringstream os(std::ios::binary);
 		if (!layer->frames) {
-			layer->frames = std::make_shared<std::vector<FrameSpec>>();
+			layer->frames = new std::vector<FrameSpec>();
 		}
 		layer->frames->resize(frame_count);
 

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -409,7 +409,7 @@ struct ContentFeatures
 	*/
 
 	ContentFeatures();
-	~ContentFeatures() = default;
+	~ContentFeatures();
 	void reset();
 	void serialize(std::ostream &os, u16 protocol_version) const;
 	void deSerialize(std::istream &is);


### PR DESCRIPTION
`std::shared_ptr` introduces unnecessary overhead when copying the structure and the benefits of it aren't necessary here (it's trivial to decide on a class that owns the allocation).

## To do

This PR is Ready for Review.

