### PR TITLE
Fix wrong use of guiScalingImageButton in formspecs buttons

### DIFF
--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -789,13 +789,12 @@ void GUIButton::setFromStyle(const StyleSpec& style)
 	setDrawBorder(style.getBool(StyleSpec::BORDER, true));
 	setUseAlphaChannel(style.getBool(StyleSpec::ALPHA, true));
 
-	const core::position2di buttonCenter(AbsoluteRect.getCenter());
-	core::position2d<s32> geom(buttonCenter);
 	if (style.isNotDefault(StyleSpec::BGIMG)) {
 		video::ITexture *texture = style.getTexture(StyleSpec::BGIMG,
 				getTextureSource());
 		setImage(guiScalingImageButton(
-				Environment->getVideoDriver(), texture, geom.X, geom.Y));
+				Environment->getVideoDriver(), texture,
+						AbsoluteRect.getWidth(), AbsoluteRect.getHeight()));
 		setScaleImage(true);
 	} else {
 		setImage(nullptr);

--- a/src/gui/guiButtonImage.cpp
+++ b/src/gui/guiButtonImage.cpp
@@ -62,13 +62,12 @@ void GUIButtonImage::setFromStyle(const StyleSpec& style)
 
 	video::IVideoDriver *driver = Environment->getVideoDriver();
 
-	const core::position2di buttonCenter(AbsoluteRect.getCenter());
-	core::position2d<s32> geom(buttonCenter);
 	if (style.isNotDefault(StyleSpec::FGIMG)) {
 		video::ITexture *texture = style.getTexture(StyleSpec::FGIMG,
 				getTextureSource());
 
-		setForegroundImage(guiScalingImageButton(driver, texture, geom.X, geom.Y));
+		setForegroundImage(guiScalingImageButton(driver, texture,
+			AbsoluteRect.getWidth(), AbsoluteRect.getHeight()));
 		setScaleImage(true);
 	} else {
 		setForegroundImage(nullptr);


### PR DESCRIPTION
This PR fixes wrong use of `guiScalingImageButton` in `guiButton` and `guiImageButton`.

Last two arguments of `guiScalingImageButton` are supposed to be width and height of the resulting scaled texture, but button center coordinates are given instead.

If **gui_scaling_filter** is on, scaled textures are way larger than necessary and above all they are not cached (size is different for each button).

When a formspec uses many buttons styled with background textures, performances are very poor and (I guess) memory usage is much higher that necessary.

## To do

This PR is a Ready for Review.
This PR is trivial (passing width and height of absolute rect instead of coordinates).

## How to test

Here is a sample code that could show the performance problem (turn gui_scaling_filter on in settings before testing) :
```lua
minetest.register_chatcommand("test", {
	params="",
	description="test command",
	func = function(name, param)
		local fs = "size[20,10]"
				.. "style_type[button;bgimg=default_glass.png]"
		for x = 0, 19 do
			for y = 0, 9 do
				fs = fs .. "button["..x..","..y..";1,1;"..x.."_"..y..";]"
			end
		end
		minetest.show_formspec(name, "test:test", fs)
  		return true
  	end,
})
```
(you can try with or without the `style_type element`)