### PR TITLE
Avoid drawing clipped out formspec elements

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3439,7 +3439,9 @@ void GUIFormSpecMenu::drawMenu()
 	*/
 	core::list<IGUIElement*>::Iterator it = Children.begin();
 	for (; it != Children.end(); ++it)
-		if (AbsoluteClippingRect.isRectCollided((*it)->getAbsolutePosition()))
+		if ((*it)->isNotClipped() ||
+				AbsoluteClippingRect.isRectCollided(
+						(*it)->getAbsolutePosition()))
 			(*it)->draw();
 
 	for (gui::IGUIElement *e : m_clickthrough_elements)

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3435,10 +3435,12 @@ void GUIFormSpecMenu::drawMenu()
 		e->setVisible(true);
 
 	/*
-		Call base class
-		(This is where all the drawing happens.)
+		This is where all the drawing happens.
 	*/
-	gui::IGUIElement::draw();
+	core::list<IGUIElement*>::Iterator it = Children.begin();
+	for (; it != Children.end(); ++it)
+		if (AbsoluteClippingRect.isRectCollided((*it)->getAbsolutePosition()))
+			(*it)->draw();
 
 	for (gui::IGUIElement *e : m_clickthrough_elements)
 		e->setVisible(false);

--- a/src/gui/guiScrollContainer.cpp
+++ b/src/gui/guiScrollContainer.cpp
@@ -56,6 +56,17 @@ bool GUIScrollContainer::OnEvent(const SEvent &event)
 	return IGUIElement::OnEvent(event);
 }
 
+void GUIScrollContainer::draw()
+{
+	if (isVisible()) {
+		core::list<IGUIElement *>::Iterator it = Children.begin();
+		for (; it != Children.end(); ++it)
+			if (AbsoluteClippingRect.isRectCollided(
+					    (*it)->getAbsolutePosition()))
+				(*it)->draw();
+	}
+}
+
 void GUIScrollContainer::updateScrolling()
 {
 	s32 pos = m_scrollbar->getPos();

--- a/src/gui/guiScrollContainer.cpp
+++ b/src/gui/guiScrollContainer.cpp
@@ -61,8 +61,9 @@ void GUIScrollContainer::draw()
 	if (isVisible()) {
 		core::list<IGUIElement *>::Iterator it = Children.begin();
 		for (; it != Children.end(); ++it)
-			if (AbsoluteClippingRect.isRectCollided(
-					    (*it)->getAbsolutePosition()))
+			if ((*it)->isNotClipped() ||
+					AbsoluteClippingRect.isRectCollided(
+							(*it)->getAbsolutePosition()))
 				(*it)->draw();
 	}
 }

--- a/src/gui/guiScrollContainer.h
+++ b/src/gui/guiScrollContainer.h
@@ -32,6 +32,8 @@ public:
 
 	virtual bool OnEvent(const SEvent &event) override;
 
+	virtual void draw() override;
+
 	inline void onScrollEvent(gui::IGUIElement *caller)
 	{
 		if (caller == m_scrollbar)


### PR DESCRIPTION
This PR avoid drawing formspecs elements that are outside of their clipping rect.

This is done by avoiding calling Irrlicht `IGUIElement::draw()` method to draw child element, replacing it by:
- A `draw()` method in `GUIScrollContainer`;
- A loop in `GUIFormSpecMenu::drawMenu()`;

Both of these loops over child element (like default `draw` method does) and check if their position rectangle intersects clipping rectangle.

Now we have `GUIScrollContainer`, it is possible to have huge containers (with complex children) with only a small part displayed. Drawing all hidden stuff could cause some FPS drops.

## To do

Ready for Review.

## How to test

1 - Formspecs should be displayed correctly (no change);
2 - Big scroll containers should induce much less FPS drop;