### PR TITLE
Additional texture modifiers

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -636,6 +636,16 @@ the word "`alpha`", then each texture pixel will contain the RGB of
 `<color>` and the alpha of `<color>` multiplied by the alpha of the
 texture pixel.
 
+#### `[colorizehsl:<hue>:<saturation>:<lightness>`
+
+Colorize the texture to the given hue. All pixels will be converted
+to the specified hue while retaining their saturation and lightness, like
+"Colorize" in GIMP. Saturation and lightness can optionally be adjusted.
+
+`<hue>` should be from -180 to +180
+
+`<saturation>` and `<lightness>` are optional, and both from -100 to +100
+
 #### `[multiply:<color>`
 
 Multiplies texture colors with the given color.
@@ -643,6 +653,53 @@ Multiplies texture colors with the given color.
 Result is more like what you'd expect if you put a color on top of another
 color, meaning white surfaces get a lot of your new color while black parts
 don't change very much.
+
+#### `[screen:<color>`
+
+Apply a Screen blend with the given color. A Screen blend is the inverse of
+a Multiply blend, lightening images instead of darkening them.
+
+`<color>` is specified as a `ColorString`.
+
+#### `[hsl:<hue>:<saturation>:<lightness>`
+
+Adjust the hue, saturation, and lightness of the texture. Like
+"Hue-Saturation" in GIMP, but with 0 as the mid-point.
+
+`<hue>` should be from -180 to +180
+
+`<saturation>` and `<lightness>` are optional, and both from -100 to +100
+
+#### `[contrast:<contrast>:<brightness>`
+
+Adjust the brightness and contrast of the texture. Conceptually like
+GIMP's "Brightness-Contrast" feature but allows brightness to be wound 
+all the way up to white or down to black.
+
+`<contrast>` and `<brightness>` are both values from -127 to +127.
+
+`<brightness>` is optional.
+
+#### `[overlay:<file>`
+
+Applies an Overlay blend with the two textures, like the Overlay layer mode 
+in GIMP. Overlay is the same as Hard light but with the role of the two 
+textures swapped, see the `[hardlight` modifier description for more detail
+about these blend modes.
+
+#### `[hardlight:<file>`
+
+Applies a Hard light blend with the two textures, like the Hard light layer 
+mode in GIMP. 
+
+Hard light combines Multiply and Screen blend modes. Light parts of the 
+`<file>` texture will lighten (screen) the base texture, and dark parts of the
+`<file>` texture will darken (multiply) the base texture. This can be useful
+for applying embossing or chiselled effects to textures. A Hard light with the
+same texture looks like an S-curve.
+
+Hard light is the same as Overlay but with the roles of the two textures
+swapped, i.e. `A.png^[hardlight:B.png` is the same as `B.png^[overlay:A.png`
 
 #### `[png:<base64>`
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -594,7 +594,7 @@ Example:
 Creates an inventorycube with `grass.png`, `dirt.png^grass_side.png` and
 `dirt.png^grass_side.png` textures
 
-#### `[rect:<w>x<h>:<color>`
+#### `[fill:<w>x<h>:<color>`
 
 * `<w>`: width
 * `<h>`: height
@@ -605,7 +605,7 @@ in the colorstring.
 
 Example:
 
-    [rect:16x16:#20F02080
+    [fill:16x16:#20F02080
 
 #### `[lowpart:<percent>:<file>`
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -594,18 +594,28 @@ Example:
 Creates an inventorycube with `grass.png`, `dirt.png^grass_side.png` and
 `dirt.png^grass_side.png` textures
 
-#### `[fill:<w>x<h>:<color>`
+#### `[fill:<w>x<h>:<x>,<y>:<color>`
 
 * `<w>`: width
 * `<h>`: height
+* `<x>`: x position
+* `<y>`: y position
 * `<color>`: a `ColorString`.
 
-Creates a texture of the given size and color, optionally with alpha specified
-in the colorstring.
+Creates a texture of the given size and color, optionally with an <x>,<y>
+position. An alpha value may be specified in the `Colorstring`.
 
-Example:
+The optional <x>,<y> position is only used if the [fill is being overlaid
+onto another texture with '^'.
+
+When [fill is overlaid onto another texture it will not upscale or change
+the resolution of the texture, the base texture will determine the output
+resolution.
+
+Examples:
 
     [fill:16x16:#20F02080
+    texture.png^[fill:8x8:4,4:red
 
 #### `[lowpart:<percent>:<file>`
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -641,7 +641,7 @@ which it assumes to be a tilesheet with dimensions w,h.
 
 Colorize the textures with the given color.
 `<color>` is specified as a `ColorString`.
-`<ratio>` is an int ranging from 0 to 255 or the word "`alpha`".  If
+`<ratio>` is an int ranging from 0 to 255 or the word "`alpha`". If
 it is an int, then it specifies how far to interpolate between the
 colors where 0 is only the texture color and 255 is only `<color>`. If
 omitted, the alpha of `<color>` will be used as the ratio.  If it is
@@ -667,7 +667,7 @@ Result is more like what you'd expect if you put a color on top of another
 color, meaning white surfaces get a lot of your new color while black parts
 don't change very much.
 
-A Multiply blend can be applied between two textures by using the overlay 
+A Multiply blend can be applied between two textures by using the overlay
 modifier with a brightness adjustment:
 
     textureA.png^[contrast:0:-64^[overlay:textureB.png
@@ -679,7 +679,7 @@ a Multiply blend, lightening images instead of darkening them.
 
 `<color>` is specified as a `ColorString`.
 
-A Screen blend can be applied between two textures by using the overlay 
+A Screen blend can be applied between two textures by using the overlay
 modifier with a brightness adjustment:
 
     textureA.png^[contrast:0:64^[overlay:textureB.png
@@ -696,30 +696,38 @@ Adjust the hue, saturation, and lightness of the texture. Like
 #### `[contrast:<contrast>:<brightness>`
 
 Adjust the brightness and contrast of the texture. Conceptually like
-GIMP's "Brightness-Contrast" feature but allows brightness to be wound 
+GIMP's "Brightness-Contrast" feature but allows brightness to be wound
 all the way up to white or down to black.
 
-`<contrast>` and `<brightness>` are both values from -127 to +127.
+`<contrast>` is a value from -127 to +127.
 
-`<brightness>` is optional.
+`<brightness>` is an optional value, from -127 to +127.
+
+If only a boost in contrast is required, an alternative technique is to
+hardlight blend the texture with itself, this increases contrast in the same
+way as an S-shaped color-curve, which avoids dark colors clipping to black
+and light colors clipping to white:
+
+    texture.png^[hardlight:texture.png
 
 #### `[overlay:<file>`
 
-Applies an Overlay blend with the two textures, like the Overlay layer mode 
-in GIMP. Overlay is the same as Hard light but with the role of the two 
+Applies an Overlay blend with the two textures, like the Overlay layer mode
+in GIMP. Overlay is the same as Hard light but with the role of the two
 textures swapped, see the `[hardlight` modifier description for more detail
 about these blend modes.
 
 #### `[hardlight:<file>`
 
-Applies a Hard light blend with the two textures, like the Hard light layer 
-mode in GIMP. 
+Applies a Hard light blend with the two textures, like the Hard light layer
+mode in GIMP.
 
-Hard light combines Multiply and Screen blend modes. Light parts of the 
+Hard light combines Multiply and Screen blend modes. Light parts of the
 `<file>` texture will lighten (screen) the base texture, and dark parts of the
 `<file>` texture will darken (multiply) the base texture. This can be useful
 for applying embossing or chiselled effects to textures. A Hard light with the
-same texture looks like an S-curve.
+same texture acts like applying an S-shaped color-curve, and can be used to
+increase contrast without clipping.
 
 Hard light is the same as Overlay but with the roles of the two textures
 swapped, i.e. `A.png^[hardlight:B.png` is the same as `B.png^[overlay:A.png`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -594,6 +594,19 @@ Example:
 Creates an inventorycube with `grass.png`, `dirt.png^grass_side.png` and
 `dirt.png^grass_side.png` textures
 
+#### `[rect:<w>x<h>:<color>`
+
+* `<w>`: width
+* `<h>`: height
+* `<color>`: a `ColorString`.
+
+Creates a texture of the given size and color, optionally with alpha specified
+in the colorstring.
+
+Example:
+
+    [rect:16x16:#20F02080
+
 #### `[lowpart:<percent>:<file>`
 
 Blit the lower `<percent>`% part of `<file>` on the texture.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -665,9 +665,13 @@ Colorize the texture to the given hue. All pixels will be converted
 to the specified hue while retaining their saturation and lightness, like
 "Colorize" in GIMP. Saturation and lightness can optionally be adjusted.
 
-`<hue>` should be from -180 to +180
+`<hue>` should be from -180 to +180. The hue at 0° on an HSL color wheel is
+red, 60° is yellow, 120° is green, and 180° is cyan, while -60° is magenta
+and -120° is blue.
 
-`<saturation>` and `<lightness>` are optional, and both from -100 to +100
+`<saturation>` and `<lightness>` are optional adjustments, both from
+-100 to +100, with a default of 0. If no adjustment is specified then 
+the original saturation and lightness value of each pixel is preserved.
 
 #### `[multiply:<color>`
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -654,12 +654,22 @@ Result is more like what you'd expect if you put a color on top of another
 color, meaning white surfaces get a lot of your new color while black parts
 don't change very much.
 
+A Multiply blend can be applied between two textures by using the overlay 
+modifier with a brightness adjustment:
+
+    textureA.png^[contrast:0:-64^[overlay:textureB.png
+
 #### `[screen:<color>`
 
 Apply a Screen blend with the given color. A Screen blend is the inverse of
 a Multiply blend, lightening images instead of darkening them.
 
 `<color>` is specified as a `ColorString`.
+
+A Screen blend can be applied between two textures by using the overlay 
+modifier with a brightness adjustment:
+
+    textureA.png^[contrast:0:64^[overlay:textureB.png
 
 #### `[hsl:<hue>:<saturation>:<lightness>`
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -661,22 +661,19 @@ texture pixel.
 
 #### `[colorizehsl:<hue>:<saturation>:<lightness>`
 
-Colorize the texture to the given hue. All pixels will be converted
-to the specified hue while retaining their saturation and lightness, like
-"Colorize" in GIMP. Saturation and lightness can optionally be adjusted.
+Colorize the texture to the given hue. The texture will be converted into a
+greyscale image as seen through a colored glass, like "Colorize" in GIMP.
+Saturation and lightness can optionally be adjusted.
 
 `<hue>` should be from -180 to +180. The hue at 0° on an HSL color wheel is
 red, 60° is yellow, 120° is green, and 180° is cyan, while -60° is magenta
 and -120° is blue.
 
-`<saturation>` and `<lightness>` are optional adjustments, both
-are percentages with a default of 0. If no adjustment is specified then the
-original saturation and lightness value of each pixel is preserved.
+`<saturation>` and `<lightness>` are optional adjustments.
 
-`<lightness>` is from -100 to +100.
+`<lightness>` is from -100 to +100, with a default of 0
 
-`<saturation>` goes down to -100 (fully desaturated) but may go above 100,
-allowing for even muted colors to become highly saturated.
+`<saturation>` is from 0 to 100, with a default of 50
 
 #### `[multiply:<color>`
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -669,9 +669,14 @@ to the specified hue while retaining their saturation and lightness, like
 red, 60° is yellow, 120° is green, and 180° is cyan, while -60° is magenta
 and -120° is blue.
 
-`<saturation>` and `<lightness>` are optional adjustments, both from
--100 to +100, with a default of 0. If no adjustment is specified then 
-the original saturation and lightness value of each pixel is preserved.
+`<saturation>` and `<lightness>` are optional adjustments, both
+are percentages with a default of 0. If no adjustment is specified then the
+original saturation and lightness value of each pixel is preserved.
+
+`<lightness>` is from -100 to +100.
+
+`<saturation>` goes down to -100 (fully desaturated) but may go above 100,
+allowing for even muted colors to become highly saturated.
 
 #### `[multiply:<color>`
 
@@ -705,7 +710,12 @@ Adjust the hue, saturation, and lightness of the texture. Like
 
 `<hue>` should be from -180 to +180
 
-`<saturation>` and `<lightness>` are optional, and both from -100 to +100
+`<saturation>` and `<lightness>` are optional, and both percentages.
+
+`<lightness>` is from -100 to +100.
+
+`<saturation>` goes down to -100 (fully desaturated) but may go above 100,
+allowing for even muted colors to become highly saturated.
 
 #### `[contrast:<contrast>:<brightness>`
 

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -1352,11 +1352,11 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			}
 		}
 		/*
-			[rect:WxH:color
+			[fill:WxH:color
 			Creates a texture of the given size and color, optionally with alpha
 			specified in the colorstring
 		*/
-		else if (str_starts_with(part_of_name, "[rect"))
+		else if (str_starts_with(part_of_name, "[fill"))
 		{
 			Strfnd sf(part_of_name);
 			sf.next(":");
@@ -1367,7 +1367,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			video::SColor color;
 			if (!parseColorString(color_str, color, false))
 				return false;
-
+			
 			if (baseimg != NULL) {
 				// Even though ^[combine hasn't conformed to this, the
 				// expected ^ overlay behavior is the lower resolution
@@ -1667,7 +1667,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 		}
 		/*
 		[multiply:color
-		or
+		or 
 		[screen:color
 			Multiply and Screen blend modes are basic blend modes for darkening and lightening
 			images, respectively.
@@ -1693,7 +1693,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			if (!parseColorString(color_str, color, false))
 				return false;
 			if (str_starts_with(part_of_name, "[multiply:")) {
-				apply_multiplication(baseimg, v2u32(0, 0),
+				apply_multiplication(baseimg, v2u32(0, 0), 
 					baseimg->getDimension(), color);
 			} else {
 				apply_screen(baseimg, v2u32(0, 0), baseimg->getDimension(), color);
@@ -1972,7 +1972,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 		}
 		/*
 			[hsl:hue:saturation:lightness
-			or
+			or 
 			[colorizehsl:hue:saturation:lightness
 
 			Adjust the hue, saturation, and lightness of the base image. Like
@@ -1983,7 +1983,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			Hue should be from -180 to +180
 			Saturation and lightness are optional, and both from -100 to +100
 		*/
-		else if (str_starts_with(part_of_name, "[hsl:") ||
+		else if (str_starts_with(part_of_name, "[hsl:") || 
 		         str_starts_with(part_of_name, "[colorizehsl:")) {
 
 			if (baseimg == NULL) {
@@ -2006,7 +2006,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 		}
 		/*
 			[overlay:filename
-			or
+			or 
 			[hardlight:filename
 
 			"A.png^[hardlight:B.png" is the same as "B.png^[overlay:A.Png"
@@ -2070,7 +2070,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			u32 contrast = mystoi(sf.next(":"), -127, 127);
 			u32 brightness = sf.at_end() ? 0 : mystoi(sf.next(":"), -127, 127);
 
-			apply_brightness_contrast(baseimg, v2u32(0, 0),
+			apply_brightness_contrast(baseimg, v2u32(0, 0), 
 				baseimg->getDimension(), brightness, contrast);
 		}
 		else
@@ -2329,14 +2329,14 @@ static void apply_overlay(video::IImage *blend, video::IImage *dst,
 	v2s32 blend_layer_pos = hardlight ? dst_pos : blend_pos;
 	v2s32 base_layer_pos  = hardlight ? blend_pos : dst_pos;
 
-	for (u32 y = 0; y < size.Y; y++)
+	for (u32 y = 0; y < size.Y; y++) 
 	for (u32 x = 0; x < size.X; x++) {
 		s32 base_x = x + base_layer_pos.X;
 		s32 base_y = y + base_layer_pos.Y;
 
 		video::SColor blend_c =
 			blend_layer->getPixel(x + blend_layer_pos.X, y + blend_layer_pos.Y);
-		video::SColor base_c = base_layer->getPixel(base_x, base_y);
+		video::SColor base_c = base_layer->getPixel(base_x, base_y);		
 		double blend_r = blend_c.getRed()   / 255.0;
 		double blend_g = blend_c.getGreen() / 255.0;
 		double blend_b = blend_c.getBlue()  / 255.0;
@@ -2355,7 +2355,7 @@ static void apply_overlay(video::IImage *blend, video::IImage *dst,
 	}
 }
 
-/*
+/* 
 	Adjust the brightness and contrast of the base image.
 
 	Conceptually like GIMP's "Brightness-Contrast" feature but allows brightness to be
@@ -2369,17 +2369,17 @@ static void apply_brightness_contrast(video::IImage *dst, v2u32 dst_pos, v2u32 s
 	// (we could technically allow -128/128 here as that would just result in 0 slope)
 	double norm_c = core::clamp(contrast,   -127, 127) / 128.0;
 	double norm_b = core::clamp(brightness, -127, 127) / 127.0;
-
+	
 	// Scale brightness so its range is -127.5 to 127.5, otherwise brightness
 	// adjustments will outputs values from 0.5 to 254.5 instead of 0 to 255.
 	double scaled_b = brightness * 127.5 / 127;
 
-	// Calculate a contrast slope such that that no colors will get clamped due
+	// Calculate a contrast slope such that that no colors will get clamped due 
 	// to the brightness setting.
 	// This allows the texture modifier to used as a brightness modifier without
 	// the user having to calculate a contrast to avoid clipping at that brightness.
 	double slope = 1 - std::fabs(norm_b);
-
+	
 	// Apply the user's contrast adjustment to the calculated slope, such that
 	// -127 will make it near-vertical and +127 will make it horizontal
 	double angle = std::atan(slope);

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -566,7 +566,8 @@ static void apply_screen(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 // If colorize is true then all pixels will be converted to the specified hue,
 // but retain their saturation and lightness, like "Colorize" in GIMP.
 // Hue should be from -180 to +180, or from 0 to 360.
-// Saturation and lightness are both from -100 to +100
+// Lightness is from - 100 to + 100.
+// Saturation goes down to - 100 (fully desaturated) but can go above 100
 static void apply_hue_saturation(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 		s32 hue, s32 saturation, s32 lightness, bool colorize);
 
@@ -1973,8 +1974,9 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			If colorize is true then all pixels will be converted to the
 			specified hue, but retain their saturation and lightness, like
 			"Colorize" in GIMP.
-			Hue should be from -180 to +180
-			Saturation and lightness are optional, and both from -100 to +100
+			Hue should be from -180 to +180, though 0 to 360 is also supported.
+			Saturation and lightness are optional, with lightness from -100 to
+			+100, and sauration from -100 to +100-or-higher.
 		*/
 		else if (str_starts_with(part_of_name, "[hsl:") || 
 		         str_starts_with(part_of_name, "[colorizehsl:")) {
@@ -1988,8 +1990,8 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 
 			Strfnd sf(part_of_name);
 			sf.next(":");
-			s32 hue = mystoi(sf.next(":"), -180, 180);
-			s32 saturation = sf.at_end() ? 0 : mystoi(sf.next(":"), -100, 100);
+			s32 hue = mystoi(sf.next(":"), -180, 360); 
+			s32 saturation = sf.at_end() ? 0 : mystoi(sf.next(":"), -100, 1000);
 			s32 lightness  = sf.at_end() ? 0 : mystoi(sf.next(":"), -100, 100);
 
 			bool colorize = str_starts_with(part_of_name, "[colorizehsl:");
@@ -2259,17 +2261,18 @@ static void apply_screen(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 	If colorize is true then all pixels will be converted to the specified hue,
 	but retain their saturation and lightness, like "Colorize" in GIMP.
 	Hue should be from -180 to +180, or from 0 to 360.
-	Saturation and lightness are both from -100 to +100
+	Saturation and Lightness are percentages.
+	Lightness is from -100 to +100.
+	Saturation goes down to -100 (fully desaturated) but can go above 100,
+	allowing for even muted colors to become saturated.
 */
 static void apply_hue_saturation(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 	s32 hue, s32 saturation, s32 lightness, bool colorize)
 {
 	video::SColorf colorf;
 	video::SColorHSL hsl;
-	f32 norm_s = core::clamp(saturation, -100, 100) / 100.0f;
+	f32 norm_s = core::clamp(saturation, -100, 1000) / 100.0f;
 	f32 norm_l = core::clamp(lightness,  -100, 100) / 100.0f;
-	f32 multiply_s = norm_s < 0 ? norm_s + 1 : 1 - norm_s;
-	f32 multiply_l = norm_l < 0 ? norm_l + 1 : 1 - norm_l;
 
 	for (u32 y = dst_pos.Y; y < dst_pos.Y + size.Y; y++)
 		for (u32 x = dst_pos.X; x < dst_pos.X + size.X; x++) {
@@ -2286,22 +2289,23 @@ static void apply_hue_saturation(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 				hsl.Hue += 360;
 
 			if (norm_l < 0) {
-				// Multiply-blend
-				hsl.Luminance *= multiply_l;
-			}
-			else if (norm_l > 0) {
-				// Screen-blend (invert -> multiply -> invert)
-				hsl.Luminance = 100.0f - (100.0f - hsl.Luminance) * multiply_l;
+				hsl.Luminance *= norm_l + 1.0f;
+			} else{
+				hsl.Luminance = hsl.Luminance + norm_l * (100.0f - hsl.Luminance);
 			}
 
-			if (norm_s < 0) {
-				// Multiply-blend
-				hsl.Saturation *= multiply_s;
-			}
-			else if (norm_s > 0) {
-				// Screen-blend (invert -> multiply -> invert)
-				hsl.Saturation = 100.0f - (100.0f - hsl.Saturation) * multiply_s;
-			}
+			// Adjusting saturation in the same manner as lightness resulted in
+			// muted colours being affected too much and bright colours not
+			// affected enough, so I'm borrowing a leaf out of gimp's book and
+			// using a different scaling approach for saturation.
+			// https://github.com/GNOME/gimp/blob/6cc1e035f1822bf5198e7e99a53f7fa6e281396a/app/operations/gimpoperationhuesaturation.c#L139-L145=
+			// This difference is why values over 100% are not necessary for
+			// lightness but are very useful with saturation. An alternative UI
+			// approach would be to have an upper saturation limit of 100, but
+			// multiply positive values by ~3 to make it a more useful positive
+			// range scale.
+			hsl.Saturation *= norm_s + 1.0f;
+			hsl.Saturation = core::clamp(hsl.Saturation, 0.0f, 100.0f);
 
 			// Convert back to RGB
 			hsl.toRGB(colorf);

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -2286,9 +2286,9 @@ static void apply_hue_saturation(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 
 			if (colorize) {
 				if (norm_l < 0) {
-					hsl.Luminance = hsl.Luminance * (norm_l + 1.0);
+					hsl.Luminance *= norm_l + 1.0f;
 				} else {
-					hsl.Luminance = hsl.Luminance * (1.0 - norm_l) + (100 * norm_l);
+					hsl.Luminance = hsl.Luminance * (1.0f - norm_l) + (100 * norm_l);
 				}
 				hsl.Hue = 0;
 				hsl.Saturation = core::clamp((f32)saturation, 0.0f, 100.0f);

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -565,7 +565,7 @@ static void apply_screen(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 // "Hue-Saturation" in GIMP, but with 0 being the mid-point.
 // If colorize is true then all pixels will be converted to the specified hue,
 // but retain their saturation and lightness, like "Colorize" in GIMP.
-// Hue should be from -180 to +180
+// Hue should be from -180 to +180, or from 0 to 360.
 // Saturation and lightness are both from -100 to +100
 static void apply_hue_saturation(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 		int hue, int saturation, int lightness, bool colorize);
@@ -1367,7 +1367,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			video::SColor color;
 			if (!parseColorString(color_str, color, false))
 				return false;
-			
+
 			if (baseimg != NULL) {
 				// Even though ^[combine hasn't conformed to this, the
 				// expected ^ overlay behavior is the lower resolution
@@ -1667,7 +1667,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 		}
 		/*
 		[multiply:color
-		or 
+		or
 		[screen:color
 			Multiply and Screen blend modes are basic blend modes for darkening and lightening
 			images, respectively.
@@ -1693,7 +1693,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			if (!parseColorString(color_str, color, false))
 				return false;
 			if (str_starts_with(part_of_name, "[multiply:")) {
-				apply_multiplication(baseimg, v2u32(0, 0), 
+				apply_multiplication(baseimg, v2u32(0, 0),
 					baseimg->getDimension(), color);
 			} else {
 				apply_screen(baseimg, v2u32(0, 0), baseimg->getDimension(), color);
@@ -1972,7 +1972,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 		}
 		/*
 			[hsl:hue:saturation:lightness
-			or 
+			or
 			[colorizehsl:hue:saturation:lightness
 
 			Adjust the hue, saturation, and lightness of the base image. Like
@@ -1983,7 +1983,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			Hue should be from -180 to +180
 			Saturation and lightness are optional, and both from -100 to +100
 		*/
-		else if (str_starts_with(part_of_name, "[hsl:") || 
+		else if (str_starts_with(part_of_name, "[hsl:") ||
 		         str_starts_with(part_of_name, "[colorizehsl:")) {
 
 			if (baseimg == NULL) {
@@ -2006,7 +2006,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 		}
 		/*
 			[overlay:filename
-			or 
+			or
 			[hardlight:filename
 
 			"A.png^[hardlight:B.png" is the same as "B.png^[overlay:A.Png"
@@ -2070,7 +2070,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			u32 contrast = mystoi(sf.next(":"), -127, 127);
 			u32 brightness = sf.at_end() ? 0 : mystoi(sf.next(":"), -127, 127);
 
-			apply_brightness_contrast(baseimg, v2u32(0, 0), 
+			apply_brightness_contrast(baseimg, v2u32(0, 0),
 				baseimg->getDimension(), brightness, contrast);
 		}
 		else
@@ -2265,110 +2265,57 @@ static void apply_screen(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 	"Hue-Saturation" in GIMP, but with 0 as the mid-point.
 	If colorize is true then all pixels will be converted to the specified hue,
 	but retain their saturation and lightness, like "Colorize" in GIMP.
-	Hue should be from -180 to +180
+	Hue should be from -180 to +180, or from 0 to 360.
 	Saturation and lightness are both from -100 to +100
 */
 static void apply_hue_saturation(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 	int hue, int saturation, int lightness, bool colorize)
 {
-	video::SColor dst_c;
+	video::SColorf colorf;
+	video::SColorHSL hsl;
 	double norm_s = core::clamp(saturation, -100, 100) / 100.0;
 	double norm_l = core::clamp(lightness,  -100, 100) / 100.0;
-
+	double multiply_s = norm_s < 0 ? norm_s + 1.0 : 1.0 - norm_s;
+	double multiply_l = norm_l < 0 ? norm_l + 1.0 : 1.0 - norm_l;
 
 	for (u32 y = dst_pos.Y; y < dst_pos.Y + size.Y; y++)
-	for (u32 x = dst_pos.X; x < dst_pos.X + size.X; x++) {
-		dst_c = dst->getPixel(x, y);
+		for (u32 x = dst_pos.X; x < dst_pos.X + size.X; x++) {
+			// convert the RGB to HSL
+			colorf = video::SColorf(dst->getPixel(x, y));
+			hsl.fromRGB(colorf);
 
-		// convert the RGB to HSL
-		double dst_r = dst_c.getRed()   / 255.0;
-		double dst_g = dst_c.getGreen() / 255.0;
-		double dst_b = dst_c.getBlue()  / 255.0;
+			if (colorize)
+				hsl.Hue = 0;
 
-		double dst_max = std::fmax(dst_r, std::fmax(dst_g, dst_b));
-		double dst_min = std::fmin(dst_r, std::fmin(dst_g, dst_b));
-		double delta = dst_max - dst_min;
+			// Apply the specified HSL adjustments
+			hsl.Hue = std::fmod(hsl.Hue + hue, 360);
+			if (hsl.Hue < 0)
+				hsl.Hue += 360;
 
-		double dst_h, dst_s, dst_l; // hue, saturation, lightness
-		dst_l = (dst_max + dst_min) / 2;
+			if (norm_l < 0) {
+				// Multiply-blend
+				hsl.Luminance *= multiply_l;
+			}
+			else if (norm_l > 0) {
+				// Screen-blend (invert -> multiply -> invert)
+				hsl.Luminance = 100.0 - (100.0 - hsl.Luminance) * multiply_l;
+			}
 
-		if (delta == 0) {
-			dst_s = 0;
-			dst_h = 0;
-		} else {
-			dst_s = delta / (1 - std::fabs(2 * dst_l - 1));
+			if (norm_s < 0) {
+				// Multiply-blend
+				hsl.Saturation *= multiply_s;
+			}
+			else if (norm_s > 0) {
+				// Screen-blend (invert -> multiply -> invert)
+				hsl.Saturation = 100.0 - (100.0 - hsl.Saturation) * multiply_s;
+			}
 
-			if (colorize) {
-				dst_h = 0;
-			} else {
-				if (dst_max == dst_r) {
-					dst_h = 60 * (dst_g - dst_b) / delta;
-					if (dst_h < 0) {
-						// conventional, but unecessary given how we will use dst_h
-						dst_h += 360;
-					}
-				} else if (dst_max == dst_g) {
-					dst_h = 60 * (2 + (dst_b - dst_r) / delta);
-				} else if (dst_max == dst_b) {
-					dst_h = 60 * (4 + (dst_r - dst_g) / delta);
-				}
-			}	
+			// Convert back to RGB
+			hsl.toRGB(colorf);
+			dst->setPixel(x, y, colorf.toSColor());
 		}
-
-		// Apply the specified HSL adjustments.
-		dst_h = std::fmod(dst_h + hue, 360);
-		if (dst_h < 0) 
-			dst_h += 360;
-
-		if (norm_l < 0) {
-			dst_l *= norm_l + 1;                    // Multiply
-		} else if (norm_l > 0) {
-			dst_l = 1 - (1 - dst_l) * (1 - norm_l); // Screen (invert -> multiply -> invert)
-		}
-
-		if (norm_s < 0) {
-			dst_s *= norm_s + 1;                    // Multiply
-		} else if (norm_s > 0) {
-			dst_s = 1 - (1 - dst_s) * (1 - norm_s); // Screen (invert -> multiply -> invert)
-		}
-
-		// Convert back to RGB
-		double chroma, secondary, hexrant;
-		chroma = (1 - std::fabs(2 * dst_l - 1)) * dst_s; //largest component of the color
-		hexrant = dst_h / 60;
-		secondary = chroma * (1 - std::fabs(std::fmod(hexrant, 2) - 1)); // 2nd largest
-			
-		dst_r = dst_g = dst_b = 0;
-		if (hexrant < 1) {
-			dst_r = chroma;
-			dst_g = secondary;
-		} else if (hexrant < 2) {
-			dst_r = secondary;
-			dst_g = chroma;
-		} else if (hexrant < 3) {
-			dst_g = chroma;
-			dst_b = secondary;
-		} else if (hexrant < 4) {
-			dst_g = secondary;
-			dst_b = chroma;
-		} else if (hexrant < 5) {
-			dst_r = secondary;
-			dst_b = chroma;
-		} else {
-			dst_r = chroma;
-			dst_b = secondary;
-		}
-
-		double m = dst_l - chroma / 2;
-		dst_c.set(
-			dst_c.getAlpha(),
-			(u32)((dst_r + m) * 255),
-			(u32)((dst_g + m) * 255),
-			(u32)((dst_b + m) * 255)
-		);
-		dst->setPixel(x, y, dst_c);
-	}
 }
+
 
 /*
 	Apply an Overlay blend to destination
@@ -2382,14 +2329,14 @@ static void apply_overlay(video::IImage *blend, video::IImage *dst,
 	v2s32 blend_layer_pos = hardlight ? dst_pos : blend_pos;
 	v2s32 base_layer_pos  = hardlight ? blend_pos : dst_pos;
 
-	for (u32 y = 0; y < size.Y; y++) 
+	for (u32 y = 0; y < size.Y; y++)
 	for (u32 x = 0; x < size.X; x++) {
 		s32 base_x = x + base_layer_pos.X;
 		s32 base_y = y + base_layer_pos.Y;
 
 		video::SColor blend_c =
 			blend_layer->getPixel(x + blend_layer_pos.X, y + blend_layer_pos.Y);
-		video::SColor base_c = base_layer->getPixel(base_x, base_y);		
+		video::SColor base_c = base_layer->getPixel(base_x, base_y);
 		double blend_r = blend_c.getRed()   / 255.0;
 		double blend_g = blend_c.getGreen() / 255.0;
 		double blend_b = blend_c.getBlue()  / 255.0;
@@ -2408,7 +2355,7 @@ static void apply_overlay(video::IImage *blend, video::IImage *dst,
 	}
 }
 
-/* 
+/*
 	Adjust the brightness and contrast of the base image.
 
 	Conceptually like GIMP's "Brightness-Contrast" feature but allows brightness to be
@@ -2422,17 +2369,17 @@ static void apply_brightness_contrast(video::IImage *dst, v2u32 dst_pos, v2u32 s
 	// (we could technically allow -128/128 here as that would just result in 0 slope)
 	double norm_c = core::clamp(contrast,   -127, 127) / 128.0;
 	double norm_b = core::clamp(brightness, -127, 127) / 127.0;
-	
+
 	// Scale brightness so its range is -127.5 to 127.5, otherwise brightness
 	// adjustments will outputs values from 0.5 to 254.5 instead of 0 to 255.
 	double scaled_b = brightness * 127.5 / 127;
 
-	// Calculate a contrast slope such that that no colors will get clamped due 
+	// Calculate a contrast slope such that that no colors will get clamped due
 	// to the brightness setting.
 	// This allows the texture modifier to used as a brightness modifier without
 	// the user having to calculate a contrast to avoid clipping at that brightness.
 	double slope = 1 - std::fabs(norm_b);
-	
+
 	// Apply the user's contrast adjustment to the calculated slope, such that
 	// -127 will make it near-vertical and +127 will make it horizontal
 	double angle = std::atan(slope);

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -1353,34 +1353,29 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 		}
 		/*
 			[fill:WxH:color
-			Creates a texture of the given size and color, optionally with alpha
-			specified in the colorstring
+			[fill:WxH:X,Y:color
+			Creates a texture of the given size and color, optionally with an <x>,<y>
+			position. An alpha value may be specified in the `Colorstring`.
 		*/
 		else if (str_starts_with(part_of_name, "[fill"))
 		{
+			u32 x = 0;
+			u32 y = 0;
+
 			Strfnd sf(part_of_name);
 			sf.next(":");
 			u32 width  = stoi(sf.next("x"));
 			u32 height = stoi(sf.next(":"));
-			std::string color_str = sf.next(":");
+			std::string color_or_x = sf.next(",");
 
 			video::SColor color;
-			if (!parseColorString(color_str, color, false))
-				return false;
-			
-			if (baseimg != NULL) {
-				// Even though ^[combine hasn't conformed to this, the
-				// expected ^ overlay behavior is the lower resolution
-				// texture is automatically upscaled to the higher
-				// resolution texture.
-				core::dimension2d<u32> base_dim = baseimg->getDimension();
-				if (width * height <= base_dim.Width * base_dim.Height) {
-					// As this texture is one color, we can scale dim here
-					// and then upscaleImagesToMatchLargest() doesn't have
-					// to do any work.
-					width  = base_dim.Width;
-					height = base_dim.Height;
-				}
+			if (!parseColorString(color_or_x, color, true)) {
+				x = stoi(color_or_x);
+				y = stoi(sf.next(":"));
+				std::string color_str = sf.next(":");
+
+				if (!parseColorString(color_str, color, false))
+					return false;
 			}
 			core::dimension2d<u32> dim(width, height);
 
@@ -1390,8 +1385,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			if (baseimg == NULL) {
 				baseimg = img;
 			} else {
-				upscaleImagesToMatchLargest(baseimg, img);
-				blit_with_alpha(img, baseimg, v2s32(0, 0), v2s32(0, 0), dim);
+				blit_with_alpha(img, baseimg, v2s32(0, 0), v2s32(x, y), dim);
 				img->drop();
 			}
 		}

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -2278,22 +2278,28 @@ static void apply_hue_saturation(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 	f32 norm_s = core::clamp(saturation, -100, 1000) / 100.0f;
 	f32 norm_l = core::clamp(lightness,  -100, 100) / 100.0f;
 
+	if (colorize) {
+		hsl.Saturation = core::clamp((f32)saturation, 0.0f, 100.0f);
+	}
+
 	for (u32 y = dst_pos.Y; y < dst_pos.Y + size.Y; y++)
 		for (u32 x = dst_pos.X; x < dst_pos.X + size.X; x++) {
-			// convert the RGB to HSL
-			colorf = video::SColorf(dst->getPixel(x, y));
-			hsl.fromRGB(colorf);
 
 			if (colorize) {
+				f32 lum = dst->getPixel(x, y).getLuminance() / 255.0f;
+
 				if (norm_l < 0) {
-					hsl.Luminance *= norm_l + 1.0f;
+					lum *= norm_l + 1.0f;
 				} else {
-					hsl.Luminance = hsl.Luminance * (1.0f - norm_l) + (100 * norm_l);
+					lum = lum * (1.0f - norm_l) + norm_l;
 				}
 				hsl.Hue = 0;
-				hsl.Saturation = core::clamp((f32)saturation, 0.0f, 100.0f);
+				hsl.Luminance = lum * 100;
 
 			} else {
+				// convert the RGB to HSL
+				colorf = video::SColorf(dst->getPixel(x, y));
+				hsl.fromRGB(colorf);
 
 				if (norm_l < 0) {
 					hsl.Luminance *= norm_l + 1.0f;

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -2029,7 +2029,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			sf.next(":");
 			std::string filename = unescape_string(sf.next_esc(":", escape), escape);
 
-			video::IImage *img = generateImage(filename);
+			video::IImage *img = generateImage(filename, source_image_names);
 			if (img) {
 				upscaleImagesToMatchLargest(baseimg, img);
 

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -2282,7 +2282,7 @@ static void apply_hue_saturation(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 				hsl.Hue = 0;
 
 			// Apply the specified HSL adjustments
-			hsl.Hue = std::fmod(hsl.Hue + hue, 360);
+			hsl.Hue = fmod(hsl.Hue + hue, 360);
 			if (hsl.Hue < 0)
 				hsl.Hue += 360;
 
@@ -2372,15 +2372,15 @@ static void apply_brightness_contrast(video::IImage *dst, v2u32 dst_pos, v2u32 s
 	// to the brightness setting.
 	// This allows the texture modifier to used as a brightness modifier without
 	// the user having to calculate a contrast to avoid clipping at that brightness.
-	double slope = 1 - std::fabs(norm_b);
+	double slope = 1 - fabs(norm_b);
 	
 	// Apply the user's contrast adjustment to the calculated slope, such that
 	// -127 will make it near-vertical and +127 will make it horizontal
-	double angle = std::atan(slope);
+	double angle = atan(slope);
 	angle += norm_c <= 0
 		? norm_c * angle // allow contrast slope to be lowered to 0
 		: norm_c * (M_PI_2 - angle); // allow contrast slope to be raised almost vert.
-	slope = std::tan(angle);
+	slope = tan(angle);
 
 	double c = slope <= 1
 		? -slope * 127.5 + 127.5 + scaled_b    // shift up/down when slope is horiz.

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -1352,6 +1352,50 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			}
 		}
 		/*
+			[rect:WxH:color
+			Creates a texture of the given size and color, optionally with alpha
+			specified in the colorstring
+		*/
+		else if (str_starts_with(part_of_name, "[rect"))
+		{
+			Strfnd sf(part_of_name);
+			sf.next(":");
+			u32 width  = stoi(sf.next("x"));
+			u32 height = stoi(sf.next(":"));
+			std::string color_str = sf.next(":");
+
+			video::SColor color;
+			if (!parseColorString(color_str, color, false))
+				return false;
+			
+			if (baseimg != NULL) {
+				// Even though ^[combine hasn't conformed to this, the
+				// expected ^ overlay behavior is the lower resolution
+				// texture is automatically upscaled to the higher
+				// resolution texture.
+				core::dimension2d<u32> base_dim = baseimg->getDimension();
+				if (width * height <= base_dim.Width * base_dim.Height) {
+					// As this texture is one color, we can scale dim here
+					// and then upscaleImagesToMatchLargest() doesn't have
+					// to do any work.
+					width  = base_dim.Width;
+					height = base_dim.Height;
+				}
+			}
+			core::dimension2d<u32> dim(width, height);
+
+			video::IImage *img = driver->createImage(video::ECF_A8R8G8B8, dim);
+			img->fill(color);
+
+			if (baseimg == NULL) {
+				baseimg = img;
+			} else {
+				upscaleImagesToMatchLargest(baseimg, img);
+				blit_with_alpha(img, baseimg, v2s32(0, 0), v2s32(0, 0), dim);
+				img->drop();
+			}
+		}
+		/*
 			[brighten
 		*/
 		else if (str_starts_with(part_of_name, "[brighten"))


### PR DESCRIPTION
Adds new texture modifiers to perform the following:
* Adjust hue, saturation, and lightness
* Colorize using hue, saturation, and lightness
* Adjust contrast & brightness
* Hard light
* Overlay
* Screen
* Create texture of a given size and color (added in extra commit - can be removed)

More power in the texture modifiers is better, but a use-case example: the ability to adjust and repurpose existing textures instead of a mod providing its own textures allows mods to be compatible with whichever texture pack the player/game is using, and if source textures are obtained from the registered nodes or aliases the mod can even become independent-ish of the game and other default mods - while still providing items and nodes in the same art style and resolution.

The ability to adjust or repurpose textures is extremely limited at the moment. There's no way to change colours or perform these operations, the existing `[colorize` fades a texture out to a colour, `[multiply` can only use colour components to the degree that they already existed in the texture, etc.

These new blend modes and colour tools should be both powerful and comfortable for people familiar with graphics programs like GIMP or Photoshop or mix-blend-mode in CSS. For anyone not already familiar, a short explanation for each is provided in the lua_api.txt part of this commit.

* Resolves #9055
* Some of these modifiers take many parameters simply because it's practical / ease of use, but that may also help with an issue of long modifier pipelines leaving textures from intermediate steps in the cache, by virtue of being able to accomplish multiple tasks in a single texture modifier. (I don't think that issue has a ticket, I just saw it mentioned a few times while looking for related PRs & tickets, though it's possible I misunderstand it)

## To do

This PR is Ready for Review.
<!-- ^ delete one -->

- [x] A [demonstration mod](https://github.com/Treer/texturemodifiertest) to aid testing
- [x] The new Screen modifier is a complement to the existing Multiply modifier, so it only takes a colour as an argument and can't screen blend two textures. I'll try to confirm that Screen and Multiply can now be performed between textures by `A.png^[contrast:0:-64^[overlay:B.png` and `A.png^[contrast:0:64^[overlay:B.png`, and if testing shows that to work flawlessly then I'll add the technique to the Screen and Multiply entries in lua_api.txt

## How to test

There is a [demo mod](https://github.com/Treer/texturemodifiertest) which creates 291 nodes covering edge cases, extremes and normal uses of the hsl, colorizehsl, contrast, overlay, hardlight, and screen texture modifiers.

With each node being a uniquely generated 736x736 texture, it's something of a speed/memory test too.

An example texture modifier for a mod with a `flowers` dependency 

    minetest.register_node("texturemodtest:fairyshroom", {
    	description = "Fairyshroom",
    	tiles = {"flowers_mushroom_red.png^[hsl:-123"},
    	inventory_image = "flowers_mushroom_red.png^[hsl:-123",
    	wield_image = "flowers_mushroom_red.png^[hsl:-123",
    	drawtype = "plantlike",
    	paramtype = "light",
    	sunlight_propagates = true,
    	walkable = false,
    	buildable_to = true,
    	groups = {mushroom = 1, food_mushroom = 1, snappy = 3, attached_node = 1, flammable = 1},
    })

creates a fairyshroom that works across existing art styles and resolutions:
![fairyshroom](https://user-images.githubusercontent.com/6390507/85763968-84b9de00-b758-11ea-90d3-55f1a4cf1233.png)![fairyshroom3](https://user-images.githubusercontent.com/6390507/85766506-72d93a80-b75a-11ea-95c9-10444ec010ca.png)
