### PR TITLE
Ability to remove minetest.after once set

### DIFF
--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -38,4 +38,11 @@ function core.after(after, func, ...)
 		mod_origin = core.get_last_run_mod()
 	}
 	time_next = math.min(time_next, expire)
+	return #jobs
+end
+
+function core.remove_after(num)
+	if jobs[num] then
+		jobs[num] = nil
+	end
 end

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -31,20 +31,18 @@ function core.after(after, func, ...)
 	assert(tonumber(after) and type(func) == "function",
 		"Invalid minetest.after invocation")
 	local expire = time + after
-	jobs[#jobs + 1] = {
+	local new_job = {
 		func = func,
 		expire = expire,
 		arg = {...},
 		mod_origin = core.get_last_run_mod()
 	}
+	jobs[#jobs + 1] = new_job
 	time_next = math.min(time_next, expire)
-	return #jobs, expire
+	return new_job
 end
 
 function core.remove_after(num, expire)
-	if jobs[num] and jobs[num].expire == expire then
-		jobs[num].func = function() end
-		return true
-	end
-	return false
+	assert(type(job) == "table", "Invalid minetest.remove_after job table")
+	job.func = function() end
 end

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -42,6 +42,7 @@ function core.after(after, func, ...)
 	return new_job
 end
 
-function core.remove_after(num, expire)
+function core.remove_after(job)
+	assert(type(job) == "table", "Invalid minetest.remove_after job table")
 	job.func = function() end
 end

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -43,6 +43,5 @@ function core.after(after, func, ...)
 end
 
 function core.remove_after(num, expire)
-	assert(type(job) == "table", "Invalid minetest.remove_after job table")
 	job.func = function() end
 end

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -36,9 +36,6 @@ function core.after(after, func, ...)
 		expire = expire,
 		arg = {...},
 		mod_origin = core.get_last_run_mod(),
-		cancel = function(self)
-			self.func = function() end
-		end
 	}
 	jobs[#jobs + 1] = new_job
 	time_next = math.min(time_next, expire)

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -38,11 +38,13 @@ function core.after(after, func, ...)
 		mod_origin = core.get_last_run_mod()
 	}
 	time_next = math.min(time_next, expire)
-	return #jobs
+	return #jobs, expire
 end
 
-function core.remove_after(num)
-	if jobs[num] then
+function core.remove_after(num, expire)
+	if jobs[num] and jobs[num].expire == expire then
 		jobs[num].func = function() end
+		return true
 	end
+	return false
 end

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -35,14 +35,12 @@ function core.after(after, func, ...)
 		func = func,
 		expire = expire,
 		arg = {...},
-		mod_origin = core.get_last_run_mod()
+		mod_origin = core.get_last_run_mod(),
+		cancel = function(self)
+			self.func = function() end
+		end
 	}
 	jobs[#jobs + 1] = new_job
 	time_next = math.min(time_next, expire)
-	return new_job
-end
-
-function core.remove_after(job)
-	assert(type(job) == "table", "Invalid minetest.remove_after job table")
-	job.func = function() end
+	return { cancel = function() new_job.func = function() end end }
 end

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -43,6 +43,6 @@ end
 
 function core.remove_after(num)
 	if jobs[num] then
-		jobs[num] = nil
+		jobs[num].func = function() end
 	end
 end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5193,11 +5193,11 @@ Sounds
 Timing
 ------
 
-* `minetest.after(time, func, ...)` : returns handle and expire timer
+* `minetest.after(time, func, ...)` : returns job table
     * Call the function `func` after `time` seconds, may be fractional
     * Optional: Variable number of arguments that are passed to `func`
 
-* `minetest.remove_after(handle, expire)`
+* `minetest.remove_after(job table)`
     * Removes already registered minetest.after function.
 
 Server

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5198,8 +5198,7 @@ Timing
     * Optional: Variable number of arguments that are passed to `func`
 
 * `job:cancel()`
-    * Removes already registered minetest.after function and replaces
-    it with a cancel function instead.
+    * Cancels the job function from being called
 
 Server
 ------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5193,12 +5193,13 @@ Sounds
 Timing
 ------
 
-* `minetest.after(time, func, ...)` : returns job table
+* `minetest.after(time, func, ...)` : returns job table to use as below.
     * Call the function `func` after `time` seconds, may be fractional
     * Optional: Variable number of arguments that are passed to `func`
 
-* `minetest.remove_after(job table)`
-    * Removes already registered minetest.after function.
+* `job.cancel()`
+    * Removes already registered minetest.after function and replaces
+    it with a cancel function instead.
 
 Server
 ------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5193,11 +5193,11 @@ Sounds
 Timing
 ------
 
-* `minetest.after(time, func, ...)` : returns table handle
+* `minetest.after(time, func, ...)` : returns handle and expire timer
     * Call the function `func` after `time` seconds, may be fractional
     * Optional: Variable number of arguments that are passed to `func`
 
-* `minetest.remove_after(table handle)`
+* `minetest.remove_after(handle, expire)`
     * Removes already registered minetest.after function.
 
 Server

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5197,7 +5197,7 @@ Timing
     * Call the function `func` after `time` seconds, may be fractional
     * Optional: Variable number of arguments that are passed to `func`
 
-* `job.cancel()`
+* `job:cancel()`
     * Removes already registered minetest.after function and replaces
     it with a cancel function instead.
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5193,9 +5193,12 @@ Sounds
 Timing
 ------
 
-* `minetest.after(time, func, ...)`
+* `minetest.after(time, func, ...)` : returns table handle
     * Call the function `func` after `time` seconds, may be fractional
     * Optional: Variable number of arguments that are passed to `func`
+
+* `minetest.remove_after(table handle)`
+    * Removes already registered minetest.after function.
 
 Server
 ------


### PR DESCRIPTION
This change allows a mod to remove any minetest.after once it has been set e.g.
```
local job = minetest.after(10.0, function()
    print("--- this will never be displayed")
end)

minetest.after(5.0, function()
    print("--- this one will")
end)

if job then
   job:cancel()
end