### PR TITLE
FormSpec: Add toggleable buttons and `:checked` state

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2379,6 +2379,13 @@ Elements
 * When clicked, fields will be sent and the form will quit.
 * Same as `image_button` in all other respects.
 
+### `make_toggleable[<name>;<state>]`
+
+* Changes any type of button into a toggleable on/off button
+* `name`: Name of the button to make toggleable
+* `state`: `true` if the button should be toggled on by default
+* **Note**: This element must come after the button it makes toggleable
+
 ### `textlist[<X>,<Y>;<W>,<H>;<name>;<listelem 1>,<listelem 2>,...,<listelem n>]`
 
 * Scrollable item list showing arbitrary text elements
@@ -2806,6 +2813,8 @@ Some types may inherit styles from parent types.
 * *all elements*
     * default - Equivalent to providing no states
 * button, button_exit, image_button, item_image_button
+    * checked - Active when the button is toggled on
+        * **Note**: Only applicable to buttons made toggleable with `make_toggleable[]`
     * hovered - Active when the mouse is hovering over the element
     * pressed - Active when the button is pressed
 
@@ -4522,7 +4531,7 @@ Call these functions only at load time!
     * Called when the server received input from `player` in a formspec with
       the given `formname`. Specifically, this is called on any of the
       following events:
-          * a button was pressed,
+          * a button was pressed or toggled,
           * Enter was pressed while the focus was on a text field
           * a checkbox was toggled,
           * something was selected in a dropdown list,
@@ -4536,8 +4545,11 @@ Call these functions only at load time!
       the `name` parameter as index for each. The value depends on the
       formspec element type:
         * `animated_image`: Returns the index of the current frame.
-        * `button` and variants: If pressed, contains the user-facing button
-          text as value. If not pressed, is `nil`
+        * `button` and variants:
+            * If toggleable by `make_toggleable`, returns `"true"` if
+              toggled on, `"false"` if toggled off, or `nil` if not toggled.
+            * If not toggleable and is pressed, contains the user-facing
+              button text as a value. If not pressed, is `nil`.
         * `field`, `textarea` and variants: Text in the field
         * `dropdown`: Either the index or value, depending on the `index event`
           dropdown argument.

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -56,10 +56,11 @@ public:
 	enum State
 	{
 		STATE_DEFAULT = 0,
-		STATE_HOVERED = 1 << 0,
-		STATE_PRESSED = 1 << 1,
-		NUM_STATES = 1 << 2,
-		STATE_INVALID = 1 << 3,
+		STATE_CHECKED = 1 << 0,
+		STATE_HOVERED = 1 << 1,
+		STATE_PRESSED = 1 << 2,
+		NUM_STATES = 1 << 3,
+		STATE_INVALID = 1 << 4,
 	};
 
 private:
@@ -128,6 +129,8 @@ public:
 	{
 		if (name == "default") {
 			return STATE_DEFAULT;
+		} else if (name == "checked") {
+			return STATE_CHECKED;
 		} else if (name == "hovered") {
 			return STATE_HOVERED;
 		} else if (name == "pressed") {

--- a/src/gui/guiButton.h
+++ b/src/gui/guiButton.h
@@ -169,7 +169,7 @@ public:
 	//! Checks whether the button is a push button
 	virtual bool isPushButton() const override;
 
-	//! Sets the pressed state of the button if this is a pushbutton
+	//! Sets the pressed state of the button
 	virtual void setPressed(bool pressed=true) override;
 
 	//! Returns if the button is currently pressed
@@ -178,6 +178,12 @@ public:
 	// PATCH
 	//! Returns if this element (or one of its direct children) is hovered
 	bool isHovered() const;
+
+	//! Sets the toggled state of the button if this is a pushbutton
+	virtual void setToggled(bool toggled=true);
+
+	//! Returns the toggled state of the button if this is a pushbutton
+	virtual bool isToggled() const;
 	// END PATCH
 
 	//! Sets if the button should use the skin to draw its border
@@ -224,10 +230,10 @@ public:
 	void setFromState();
 
 	//! Set element properties from a StyleSpec
-	virtual void setFromStyle(const StyleSpec& style);
+	virtual void setFromStyle(const StyleSpec &style);
 
 	//! Set the styles used for each state
-	void setStyles(const std::array<StyleSpec, StyleSpec::NUM_STATES>& styles);
+	void setStyles(const std::array<StyleSpec, StyleSpec::NUM_STATES> &styles);
 	// END PATCH
 
 
@@ -330,6 +336,8 @@ private:
 
 	video::SColor Colors[4];
 	// PATCH
+	bool Toggled;
+
 	bool WasHovered = false;
 	ISimpleTextureSource *TSrc;
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -409,6 +409,7 @@ private:
 	void parseItemImage(parserData* data, const std::string &element);
 	void parseButton(parserData* data, const std::string &element,
 			const std::string &typ);
+	void parseMakeToggleable(parserData *data, const std::string &element);
 	void parseBackground(parserData* data, const std::string &element);
 	void parseTableOptions(parserData* data, const std::string &element);
 	void parseTableColumns(parserData* data, const std::string &element);


### PR DESCRIPTION
This PR adds toggleable buttons through the forms `make_toggleable[<name>;<state>]`.  It uses this form as opposed to another parameter to work with all buttons without adding a parameter to every single one.  This must come after the button it makes toggleable.  In addition, the `:checked` state has been added to style the togglebuttons, which has a lower precedence than `:hovered` and `:pressed`.

The default colors for togglebuttons are like so:  If the button is unchecked, everything is like a normal button.  When checked, the button always uses the pressed color unless it is hovered, in which case it uses the hovered color.  Also, the button always appears depressed when checked, even when hovered.  I experimented with a darker than the normal pressed color, but it didn't feel right to have three colors.  It also adheres to more traditional togglebuttons in existing GUI frameworks this way.

Callbacks are like checkboxes:  `"true"` if toggled on, `"false"` if toggled off, `nil` if not toggled at all.  The default button callbacks are unmodified.

## To do

This PR is Ready for Review.

## How to test

Use this testing formspec:

```
formspec_version[3]
size[9.5,5]
style_type[button:default;bgcolor=gray]
style_type[button:hovered;bgcolor=red]
style_type[button:pressed;bgcolor=yellow]
style_type[button:hovered+pressed;bgcolor=green]
style_type[button:checked;bgcolor=cyan;textcolor=yellow]
style_type[button:checked+hovered;bgcolor=blue]
style_type[button:checked+pressed;bgcolor=violet]
style_type[button:checked+hovered+pressed;bgcolor=white]
button[.5,.5;4,1;button;Button]
image_button[.5,2;4,1;logo.png;image_button;Image Button]
item_image_button[.5,3.5;4,1;air;item_image_button;Item Image Button]
button[5,.5;4,1;togglebutton;Togglebutton]
image_button[5,2;4,1;logo.png;image_togglebutton;Image Togglebutton]
item_image_button[5,3.5;4,1;air;item_image_togglebutton;Item Image Togglebutton]
make_toggleable[togglebutton;false]
make_toggleable[image_togglebutton;true]
make_toggleable[item_image_togglebutton;false]
```

With the callback code:

```lua
minetest.register_on_player_receive_fields(function(player, formname, fields)
	for k, v in pairs(fields) do
		minetest.chat_send_all(k .. " = \"" .. v .. "\"")
	end
end)
```