### PR TITLE
lua_api.txt: Mention texture modifier colorspace

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -382,7 +382,9 @@ Texture modifiers
 -----------------
 
 There are various texture modifiers that can be used
-to generate textures on-the-fly.
+to let the client generate textures on-the-fly.
+The modifiers are applied directly in sRGB colorspace,
+i.e. without gamma-correction.
 
 ### Texture overlaying
 


### PR DESCRIPTION
Document that the texture modifiers are applied in sRGB colourspace and not on linear colour values
I have also mentioned that the client generates the textures.