### PR TITLE
Clean up sound_fade

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5186,9 +5186,10 @@ Sounds
 * `minetest.sound_fade(handle, step, gain)`
     * `handle` is a handle returned by `minetest.sound_play`
     * `step` determines how fast a sound will fade.
-      Negative step will lower the sound volume, positive step will increase
-      the sound volume.
+      The gain will change by this much per second,
+      until it reaches the target gain.
     * `gain` the target gain for the fade.
+      Fading to zero will delete the sound.
 
 Timing
 ------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5188,6 +5188,8 @@ Sounds
     * `step` determines how fast a sound will fade.
       The gain will change by this much per second,
       until it reaches the target gain.
+      Note: Older versions used a signed step. This is deprecated, but old
+      code will still work. (the client uses abs(step) to correct it)
     * `gain` the target gain for the fade.
       Fading to zero will delete the sound.
 

--- a/src/client/sound_openal.cpp
+++ b/src/client/sound_openal.cpp
@@ -617,6 +617,7 @@ public:
 		// Ignore the command if step isn't valid.
 		if (step == 0)
 			return;
+		float current_gain = getSoundGain(soundid);
 		step = gain - current_gain > 0 ? abs(step) : -abs(step);
 		if (m_sounds_fading.find(soundid) != m_sounds_fading.end()) {
 			auto current_fade = m_sounds_fading[soundid];
@@ -625,7 +626,6 @@ public:
 				return;
 			m_sounds_fading.erase(soundid);
 		}
-		float current_gain = getSoundGain(soundid);
 		gain = rangelim(gain, 0, 1);
 		m_sounds_fading[soundid] = FadeState(step, current_gain, gain);
 	}

--- a/src/client/sound_openal.cpp
+++ b/src/client/sound_openal.cpp
@@ -623,7 +623,7 @@ public:
 		}
 		float current_gain = getSoundGain(soundid);
 		gain = rangelim(gain, 0, 1);
-		step = ( gain - current_gain ) > 0 ? abs(step) : -abs(step);
+		step = gain - current_gain > 0 ? abs(step) : -abs(step);
 		m_sounds_fading[soundid] = FadeState(step, current_gain, gain);
 	}
 

--- a/src/client/sound_openal.cpp
+++ b/src/client/sound_openal.cpp
@@ -337,14 +337,12 @@ private:
 	};
 
 	std::unordered_map<int, FadeState> m_sounds_fading;
-	float m_fade_delay;
 public:
 	OpenALSoundManager(SoundManagerSingleton *smg, OnDemandSoundFetcher *fetcher):
 		m_fetcher(fetcher),
 		m_device(smg->m_device.get()),
 		m_context(smg->m_context.get()),
-		m_next_id(1),
-		m_fade_delay(0)
+		m_next_id(1)
 	{
 		infostream << "Audio: Initialized: OpenAL " << std::endl;
 	}
@@ -616,38 +614,40 @@ public:
 
 	void fadeSound(int soundid, float step, float gain)
 	{
-		m_sounds_fading[soundid] = FadeState(step, getSoundGain(soundid), gain);
+		if (step == 0)
+			return;
+		if (m_sounds_fading.find(soundid) != m_sounds_fading.end()) {
+			if(m_sounds_fading[soundid].target_gain == gain)
+				return;
+			m_sounds_fading.erase(soundid);
+		}
+		float current_gain = getSoundGain(soundid);
+		gain = rangelim(gain, 0, 1);
+		step = ( gain - current_gain ) > 0 ? abs(step) : -abs(step);
+		m_sounds_fading[soundid] = FadeState(step, current_gain, gain);
 	}
 
 	void doFades(float dtime)
 	{
-		m_fade_delay += dtime;
+		for (auto i = m_sounds_fading.begin(); i != m_sounds_fading.end();) {
+			i->second.current_gain += (i->second.step * dtime);
 
-		if (m_fade_delay < 0.1f)
-			return;
-
-		float chkGain = 0;
-		for (auto i = m_sounds_fading.begin();
-				i != m_sounds_fading.end();) {
 			if (i->second.step < 0.f)
-				chkGain = -(i->second.current_gain);
+				i->second.current_gain = std::max(i->second.current_gain, i->second.target_gain);
 			else
-				chkGain = i->second.current_gain;
+				i->second.current_gain = std::min(i->second.current_gain, i->second.target_gain);
 
-			if (chkGain < i->second.target_gain) {
-				i->second.current_gain += (i->second.step * m_fade_delay);
-				i->second.current_gain = rangelim(i->second.current_gain, 0, 1);
-
+			if (i->second.current_gain <= 0.f)
+				stopSound(i->first);
+			else
 				updateSoundGain(i->first, i->second.current_gain);
-				++i;
-			} else {
-				if (i->second.target_gain <= 0.f)
-					stopSound(i->first);
 
+			// The increment must happen during the erase call, or else it'll segfault.
+			if (i->second.current_gain == i->second.target_gain)
 				m_sounds_fading.erase(i++);
-			}
+			else
+				i++;
 		}
-		m_fade_delay = 0;
 	}
 
 	bool soundExists(int sound)


### PR DESCRIPTION
`minetest.sound_fade` has horrible documentation and even worse code:
- No mention of the units that `step` is in
- No mention of zero gain quietly deleting a sound (!)
- Asking for a _signed speed_ while also specifying a target gain (aaaaaaaa _why_)
- Easy to bug out by specifying a mismatching speed and target, or zero speed (duh)
- Pegged to 10 frames per second, resulting in audible artifacts. Undocumented, of course.

And even when I followed the stupid parameter conventions, I couldn't get it to work properly. So I'm not entirely sure if this code _ever_ worked, doesn't seem like many people are using it.

This PR does:
- Make the step parameter unsigned (compatible with old code via abs)
- Document the function properly
- Handle edge cases (suggestions welcome here, can be anything as long as we at least _define_ the behavior)
- Remove the cringeworthy 10 fps "optimization" (you're welcome to argue about this... and lose)
- Move the gain to target exactly. (I think the original overshoots it)
- Clamp when receiving the gain, not every time it's moved.
- Make the intent of the C++ code clear (I'll defend this to death, the original is probably the most convoluted "move towards" function I've seen in my life.)