### PR TITLE
Stop sending "Issued command:"

### DIFF
--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -7,9 +7,6 @@ core.register_on_sending_chat_message(function(message)
 	end
 
 	local first_char = message:sub(1,1)
-	if first_char == "/" or first_char == "." then
-		core.display_chat_message(core.gettext("issued command: ") .. message)
-	end
 
 	if first_char ~= "." then
 		return false

--- a/src/terminal_chat_console.cpp
+++ b/src/terminal_chat_console.cpp
@@ -138,11 +138,6 @@ void TerminalChatConsole::typeChatMessage(const std::wstring &msg)
 	// Send to server
 	m_chat_interface->command_queue.push_back(
 		new ChatEventChat(m_nick, msg));
-
-	// Print if its a command (gets eaten by server otherwise)
-	if (msg[0] == L'/') {
-		m_chat_backend.addMessage(L"", (std::wstring)L"Issued command: " + msg);
-	}
 }
 
 void TerminalChatConsole::handleInput(int ch, bool &complete_redraw_needed)


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

Goal of the PR
To stop users from thinking client mods are enabled even if they aren't. To stop unnecessary spam in the chat dialogue window.

How does the PR work?
Removes "Issued command", since unnecessary along with the fact that it gets loaded even if the server doesn't allow CSM.

Does it resolve any reported issue?
No, but it resolves users thinking client mods are loading when they aren't.

If not a bug fix, why is this PR needed? What usecases does it solve?
Fixes users thinking client mods are enabled even when they aren't. Stops chat dialogue window spam with unnecessary command dialogue redundancy.

Ready for Review.

Reference
Days lost trying to find a bug that does not exist.