### PR TITLE
Fix undeclared global in devtest

### DIFF
--- a/games/devtest/mods/experimental/commands.lua
+++ b/games/devtest/mods/experimental/commands.lua
@@ -113,6 +113,7 @@ local function place_nodes(param)
 	table.sort(nodes)
 	minetest.chat_send_player(name, "Placing nodes …")
 	local nodes_placed = 0
+	local aborted = false
 	for n=1, #nodes do
 		local itemstring = nodes[n]
 		local def = minetest.registered_nodes[itemstring]


### PR DESCRIPTION
Trivial PR that makes an accidental global variable in devtest local.