### PR TITLE
Add minetest.find_node_sounds API for better inter-game compatibility

### DIFF
--- a/builtin/game/init.lua
+++ b/builtin/game/init.lua
@@ -34,5 +34,6 @@ dofile(gamepath .. "voxelarea.lua")
 dofile(gamepath .. "forceloading.lua")
 dofile(gamepath .. "statbars.lua")
 dofile(gamepath .. "knockback.lua")
+dofile(gamepath .. "sounds.lua")
 
 profiler = nil

--- a/builtin/game/sounds.lua
+++ b/builtin/game/sounds.lua
@@ -1,0 +1,74 @@
+-- Minetest: builtin/common/sounds.lua
+
+core.registered_sounds = {}
+
+local defaults = {}
+local pending = {}
+
+function core.register_node_sounds(names, spec)
+	setmetatable(spec, { __index = defaults })
+
+	for i=1, #names do
+		local cat = names[i]
+		core.registered_sounds[cat] = core.registered_sounds[cat] or spec
+	end
+end
+
+function core.get_node_sound_defaults()
+	return defaults
+end
+
+function core.set_node_sound_defaults(spec)
+	for key, value in pairs(spec) do
+		defaults[key] = value
+	end
+end
+
+function core.find_node_sounds(names, overrides)
+	if type(names) == "string" then
+		names = { names }
+	end
+
+	if pending then
+		pending[#pending + 1] = {
+			names = names,
+			overrides = overrides,
+			spec = {},
+		}
+		return pending[#pending].spec
+	end
+
+	for i=1, #names do
+		local sound = core.registered_sounds[names[i]]
+		if sound then
+			if overrides then
+				setmetatable(overrides, { __index = sound })
+				return overrides
+			else
+				return sound
+			end
+		end
+	end
+
+	return nil
+end
+
+local function resolve_node_sounds()
+	local to_resolve = pending
+	pending = nil
+
+	for i=1, #to_resolve do
+		local thing = to_resolve[i]
+		local result = core.find_node_sounds(thing.names)
+		for key, value in pairs(result) do
+			thing.spec[key] = value
+		end
+		for key, value in pairs(thing.overrides or {}) do
+			thing.spec[key] = value
+		end
+	end
+end
+
+core.register_on_mods_loaded(function()
+	resolve_node_sounds()
+end)

--- a/builtin/game/tests/sounds_spec.lua
+++ b/builtin/game/tests/sounds_spec.lua
@@ -1,0 +1,68 @@
+local function init(resolveSounds)
+	_G.core = {}
+	local func
+
+	core.register_on_mods_loaded = function(f)
+		func = f
+	end
+
+	dofile("builtin/game/sounds.lua")
+	if resolveSounds then
+		func()
+	else
+		return func
+	end
+end
+
+local spec = {
+	footstep = {name = "", gain = 1.0},
+	dug = {name = "default_dug_node", gain = 0.25},
+	place = {name = "default_place_node_hard", gain = 1.0},
+}
+
+local spec2 = {
+	footstep = {name = "2", gain = 1.0},
+	dug = {name = "2", gain = 0.25},
+	place = {name = "2", gain = 1.0},
+}
+
+describe("sounds", function()
+	it("registers", function()
+		init(true)
+
+		core.register_node_sounds({ "granite", "stone", "cracky" }, spec)
+		assert.is_equal(spec, core.registered_sounds["granite"])
+		assert.is_equal(spec, core.registered_sounds["stone"])
+		assert.is_equal(spec, core.registered_sounds["cracky"])
+	end)
+
+	it("finds", function()
+		init(true)
+
+		core.register_node_sounds({ "cracky" }, spec2)
+		core.register_node_sounds({ "granite", "stone", "cracky" }, spec)
+		assert.is_equal(spec, core.registered_sounds["granite"])
+		assert.is_equal(spec, core.registered_sounds["stone"])
+		assert.is_equal(spec2, core.registered_sounds["cracky"])
+
+		assert.is_equal(spec, core.find_node_sounds("granite"))
+		assert.is_equal(spec, core.find_node_sounds("stone"))
+		assert.is_equal(spec2, core.find_node_sounds("cracky"))
+		assert.is_equal(spec, core.find_node_sounds({ "stone", "cracky" }))
+		assert.is_equal(spec2, core.find_node_sounds({ "cracky", "stone" }))
+	end)
+
+	it("postpones resolve", function()
+		local resolveSounds = init(false)
+
+		local result = core.find_node_sounds("granite")
+		assert.are_same({}, result)
+
+		core.register_node_sounds({ "cracky" }, spec2)
+		core.register_node_sounds({ "granite", "stone", "cracky" }, spec)
+
+		resolveSounds()
+
+		assert.are_same(spec, result)
+	end)
+end)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5190,6 +5190,19 @@ Sounds
       the sound volume.
     * `gain` the target gain for the fade.
 
+Sounds Locator
+--------------
+
+It's common for a mod to reuse the sounds from another mod.
+The sounds locator is used to find sounds without needing to depend on another mod.
+
+* `minetest.register_node_sounds(names, spec)`
+    * Register a node sound set, see sounds in a node definition.
+* `minetest.find_node_sounds(names [, overrides])`
+    * Checks each name in order, and returns the first node sound set.
+    * `names` is a string or table of names.
+    * `overrides` is an optional table of overrides.
+
 Timing
 ------
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5202,6 +5202,8 @@ The sounds locator is used to find sounds without needing to depend on another m
     * Checks each name in order, and returns the first node sound set.
     * `names` is a string or table of names.
     * `overrides` is an optional table of overrides.
+* `minetest.get_node_sound_defaults()`
+* `minetest.set_node_sound_defaults(spec)`
 
 Timing
 ------
@@ -7157,6 +7159,9 @@ Used by `minetest.register_node`.
         sounds = {
             -- Definition of node sounds to be played at various events.
             -- All fields in this table are optional.
+
+            -- For getting sounds from another mod,
+            -- see minetest.find_node_sounds() in [Sound Locator]
 
             footstep = <SimpleSoundSpec>,
             -- If walkable, played when object walks on it. If node is


### PR DESCRIPTION
One remaining reason to depend on _default_ is to get a sound table from a function like `default.node_stone_defaults`. This PR will deprecate such default functions. Instead, mods should use find_sound like so:

```lua
minetest.register_node("mymod:name", {
	sounds = minetest.find_node_sounds({ "stone", "cracky" })
})
```

Closes #7972

## To do

- [ ] Better docs
- [ ] Update dev test

## How to test

<!-- Example code or instructions -->
