### PR TITLE
FormSpec: Don't stop style parsing on unknown property

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2562,7 +2562,7 @@ bool GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element, b
 						<< "'" << std::endl;
 				property_warned.insert(propname);
 			}
-			return false;
+			continue;
 		}
 
 		spec.set(prop, value);
@@ -2603,7 +2603,7 @@ bool GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element, b
 			}
 		}
 
-		if(!state_valid) {
+		if (!state_valid) {
 			// Skip this selector
 			continue;
 		}


### PR DESCRIPTION
Currently, if `style` or `style_type` encounters an unknown property, it stops parsing and doesn't style anything.  This PR makes it so that it just ignores the property after issuing the warning so that an older client can render styles at least partially right.

## To do

This PR is Ready for Review.  Very trivial.

## How to test

Make a style with a valid property and an invalid property and verify that the valid property is used.
