### PR TITLE
Fix player controls only being applied for the first move

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -459,12 +459,9 @@ void Client::step(float dtime)
 	/*
 		Handle environment
 	*/
-	// Control local player (0ms)
 	LocalPlayer *player = m_env.getLocalPlayer();
-	assert(player);
-	player->applyControl(dtime, &m_env);
 
-	// Step environment
+	// Step environment (also handles player controls)
 	m_env.step(dtime);
 	m_sound->step(dtime);
 

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -216,6 +216,9 @@ void ClientEnvironment::step(float dtime)
 		*/
 
 		{
+			// Control local player
+			lplayer->applyControl(dtime_part, this);
+
 			// Apply physics
 			if (!free_move && !is_climbing) {
 				// Gravity


### PR DESCRIPTION
suggestion from https://github.com/minetest/minetest/pull/9891#issuecomment-634490776 (hence the commit also has @TheTermos as author)

fixes #10136, also fixes #1460

## To do

This PR is Ready for Review.

## How to test

Attempt to do this: https://0x0.st/iyX8.mp4
If this movement is possible, the PR works correctly.