### PR TITLE
Avoid "Please choose a name!" error on quit

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -452,7 +452,7 @@ bool ClientLauncher::launch_game(std::string &error_message,
 		return false;
 	}
 
-	if (menudata.name.empty() && !simple_singleplayer_mode) {
+	if (RenderingEngine::run() && menudata.name.empty() && !simple_singleplayer_mode) {
 		error_message = gettext("Please choose a name!");
 		errorstream << error_message << std::endl;
 		return false;


### PR DESCRIPTION
Fixes #8273

- Goal of the PR
Avoiding "Please choose a name!" error to be called when quitting MT with no player name specified

We had to check whether a player was in the main menu or not, but checking `isMenuActive()` returns false both when closing the game and when try logging in a server. Thus we opted for checking `RenderingEngine::run()`

## To do

This PR is Ready for Review.

## How to test

1. Delete minetest.conf if it exists
2. open Minetest
3. close Minetest

There should be no error