### PR TITLE
Semi-transparent background for nametags

### DIFF
--- a/games/devtest/mods/testentities/visuals.lua
+++ b/games/devtest/mods/testentities/visuals.lua
@@ -82,3 +82,33 @@ minetest.register_entity("testentities:yawsprite", {
 		self.object:set_sprite({x=0, y=0}, 1, 0, true)
 	end,
 })
+
+minetest.register_entity("testentities:nametag", {
+	initial_properties = {
+		visual = "sprite",
+		textures = { "testentities_sprite.png" },
+	},
+
+	on_activate = function(self, staticdata)
+		if staticdata ~= "" then
+			print(staticdata)
+			self.color = minetest.deserialize(staticdata).color
+		else
+			self.color = {
+				r = math.random(0, 255),
+				g = math.random(0, 255),
+				b = math.random(0, 255),
+			}
+		end
+
+		assert(self.color)
+		self.object:set_properties({
+			nametag = tostring(math.random(1000, 10000)),
+			nametag_color = self.color,
+		})
+	end,
+
+	get_staticdata = function(self)
+		return minetest.serialize({ color = self.color })
+	end,
+})

--- a/games/devtest/mods/testentities/visuals.lua
+++ b/games/devtest/mods/testentities/visuals.lua
@@ -91,7 +91,6 @@ minetest.register_entity("testentities:nametag", {
 
 	on_activate = function(self, staticdata)
 		if staticdata ~= "" then
-			print(staticdata)
 			self.color = minetest.deserialize(staticdata).color
 		else
 			self.color = {

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -718,6 +718,8 @@ void Camera::drawNametags()
 			screen_pos.Y = screensize.Y *
 				(0.5 - transformed_pos[1] * zDiv * 0.5) - textsize.Height / 2;
 			core::rect<s32> size(0, 0, textsize.Width, textsize.Height);
+			core::rect<s32> bg_size(-2, 0, textsize.Width+2, textsize.Height);
+			RenderingEngine::get_video_driver()->draw2DRectangle(video::SColor(50,0,0,0), bg_size + screen_pos);
 			g_fontengine->getFont()->draw(
 				translate_string(utf8_to_wide(nametag->nametag_text)).c_str(),
 				size + screen_pos, nametag->nametag_color);

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -719,7 +719,8 @@ void Camera::drawNametags()
 				(0.5 - transformed_pos[1] * zDiv * 0.5) - textsize.Height / 2;
 			core::rect<s32> size(0, 0, textsize.Width, textsize.Height);
 			core::rect<s32> bg_size(-2, 0, textsize.Width+2, textsize.Height);
-			RenderingEngine::get_video_driver()->draw2DRectangle(video::SColor(50,0,0,0), bg_size + screen_pos);
+			RenderingEngine::get_video_driver()->draw2DRectangle(
+				video::SColor(50,0,0,0), bg_size + screen_pos);
 			g_fontengine->getFont()->draw(
 				translate_string(utf8_to_wide(nametag->nametag_text)).c_str(),
 				size + screen_pos, nametag->nametag_color);

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -718,11 +718,18 @@ void Camera::drawNametags()
 				(0.5 - transformed_pos[1] * zDiv * 0.5) - textsize.Height / 2;
 			core::rect<s32> size(0, 0, textsize.Width, textsize.Height);
 			core::rect<s32> bg_size(-2, 0, textsize.Width+2, textsize.Height);
-			driver->draw2DRectangle(video::SColor(50, 0, 0, 0),
-				bg_size + screen_pos);
+
+			video::SColor textColor = nametag->nametag_color;
+
+			bool darkBackground = textColor.getLuminance() > 186;
+			video::SColor backgroundColor = darkBackground
+					? video::SColor(50, 50, 50, 50)
+					: video::SColor(50, 255, 255, 255);
+			driver->draw2DRectangle(backgroundColor, bg_size + screen_pos);
+
 			font->draw(
 				translate_string(utf8_to_wide(nametag->nametag_text)).c_str(),
-				size + screen_pos, nametag->nametag_color);
+				size + screen_pos, textColor);
 		}
 	}
 }

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -690,10 +690,11 @@ void Camera::drawNametags()
 	core::matrix4 trans = m_cameranode->getProjectionMatrix();
 	trans *= m_cameranode->getViewMatrix();
 
-	for (std::list<Nametag *>::const_iterator
-			i = m_nametags.begin();
-			i != m_nametags.end(); ++i) {
-		Nametag *nametag = *i;
+	gui::IGUIFont *font = g_fontengine->getFont();
+	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
+	v2u32 screensize = driver->getScreenSize();
+
+	for (const Nametag *nametag : m_nametags) {
 		if (nametag->nametag_color.getAlpha() == 0) {
 			// Enforce hiding nametag,
 			// because if freetype is enabled, a grey
@@ -706,12 +707,10 @@ void Camera::drawNametags()
 		if (transformed_pos[3] > 0) {
 			std::wstring nametag_colorless =
 				unescape_translate(utf8_to_wide(nametag->nametag_text));
-			core::dimension2d<u32> textsize =
-				g_fontengine->getFont()->getDimension(
+			core::dimension2d<u32> textsize = font->getDimension(
 				nametag_colorless.c_str());
 			f32 zDiv = transformed_pos[3] == 0.0f ? 1.0f :
 				core::reciprocal(transformed_pos[3]);
-			v2u32 screensize = RenderingEngine::get_video_driver()->getScreenSize();
 			v2s32 screen_pos;
 			screen_pos.X = screensize.X *
 				(0.5 * transformed_pos[0] * zDiv + 0.5) - textsize.Width / 2;
@@ -719,9 +718,9 @@ void Camera::drawNametags()
 				(0.5 - transformed_pos[1] * zDiv * 0.5) - textsize.Height / 2;
 			core::rect<s32> size(0, 0, textsize.Width, textsize.Height);
 			core::rect<s32> bg_size(-2, 0, textsize.Width+2, textsize.Height);
-			RenderingEngine::get_video_driver()->draw2DRectangle(
-				video::SColor(50,0,0,0), bg_size + screen_pos);
-			g_fontengine->getFont()->draw(
+			driver->draw2DRectangle(video::SColor(50, 0, 0, 0),
+				bg_size + screen_pos);
+			font->draw(
 				translate_string(utf8_to_wide(nametag->nametag_text)).c_str(),
 				size + screen_pos, nametag->nametag_color);
 		}


### PR DESCRIPTION
Sometimes reading names is not that easy: we thought about adding a semi-transparent background to increase contrast. This could work very well paired with #10013 . Also, for testing we set `font_shadow` to false but we did not touch it in the PR

![nametags_nobg](https://user-images.githubusercontent.com/63455151/86499468-aedc5300-bd8b-11ea-942d-ea16015d9b30.png)
![nametags](https://user-images.githubusercontent.com/63455151/86499469-b00d8000-bd8b-11ea-937c-2775824682a5.png)

## To do

This PR is Ready for Review.

## How to test
Spawn a few entities and set a name
