### PR TITLE
Cleanup ClientLauncher

### DIFF
--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -52,5 +52,4 @@ private:
 	InputHandler *input = nullptr;
 	MyEventReceiver *receiver = nullptr;
 	gui::IGUISkin *skin = nullptr;
-	gui::IGUIFont *font = nullptr;
 };

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -32,15 +32,15 @@ public:
 
 	~ClientLauncher();
 
-	bool run(GameParams &game_params, const Settings &cmd_args);
+	bool run(GameStartData &start_data, const Settings &cmd_args);
 
-protected:
-	void init_args(GameParams &game_params, const Settings &cmd_args);
+private:
+	void init_args(GameStartData &start_data, const Settings &cmd_args);
 	bool init_engine();
 	void init_input();
 
 	bool launch_game(std::string &error_message, bool reconnect_requested,
-		GameParams &game_params, const Settings &cmd_args);
+		GameStartData &start_data, const Settings &cmd_args);
 
 	void main_menu(MainMenuData *menudata);
 
@@ -49,11 +49,8 @@ protected:
 	bool list_video_modes = false;
 	bool skip_main_menu = false;
 	bool random_input = false;
-	GameStartData start_data{};
 	InputHandler *input = nullptr;
 	MyEventReceiver *receiver = nullptr;
 	gui::IGUISkin *skin = nullptr;
 	gui::IGUIFont *font = nullptr;
-	SubgameSpec gamespec;
-	WorldSpec worldspec;
 };

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -48,23 +48,12 @@ protected:
 
 	bool list_video_modes = false;
 	bool skip_main_menu = false;
-	bool use_freetype = false;
 	bool random_input = false;
-	std::string address = "";
-	std::string playername = "";
-	std::string password = "";
+	GameStartData start_data{};
 	InputHandler *input = nullptr;
 	MyEventReceiver *receiver = nullptr;
 	gui::IGUISkin *skin = nullptr;
 	gui::IGUIFont *font = nullptr;
 	SubgameSpec gamespec;
 	WorldSpec worldspec;
-	bool simple_singleplayer_mode = false;
-
-	// These are set up based on the menu and other things
-	// TODO: Are these required since there's already playername, password, etc
-	std::string current_playername = "inv£lid";
-	std::string current_password = "";
-	std::string current_address = "does-not-exist";
-	int current_port = 0;
 };

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -675,8 +675,7 @@ public:
 			const GameStartData &game_params,
 			std::string &error_message,
 			bool *reconnect,
-			ChatBackend *chat_backend,
-			const SubgameSpec &gamespec); // Used for local game
+			ChatBackend *chat_backend);
 
 	void run();
 	void shutdown();
@@ -1013,8 +1012,7 @@ bool Game::startup(bool *kill,
 		const GameStartData &start_data,
 		std::string &error_message,
 		bool *reconnect,
-		ChatBackend *chat_backend,
-		const SubgameSpec &gamespec)
+		ChatBackend *chat_backend)
 {
 
 	// "cache"
@@ -1046,7 +1044,8 @@ bool Game::startup(bool *kill,
 	g_client_translations->clear();
 
 	// address can change if simple_singleplayer_mode
-	if (!init(start_data.map_dir, start_data.address, start_data.port, gamespec))
+	if (!init(start_data.world_spec.path, start_data.address,
+			start_data.socket_port, start_data.game_spec))
 		return false;
 
 	if (!createClient(start_data))
@@ -1457,7 +1456,7 @@ bool Game::connectToServer(const GameStartData &start_data,
 
 	showOverlayMessage(N_("Resolving address..."), 0, 15);
 
-	Address connect_address(0, 0, 0, 0, start_data.port);
+	Address connect_address(0, 0, 0, 0, start_data.socket_port);
 
 	try {
 		connect_address.Resolve(start_data.address.c_str());
@@ -4249,8 +4248,7 @@ void the_game(bool *kill,
 		const GameStartData &start_data,
 		std::string &error_message,
 		ChatBackend &chat_backend,
-		bool *reconnect_requested,
-		const SubgameSpec &gamespec) // Used for local game
+		bool *reconnect_requested) // Used for local game
 {
 	Game game;
 
@@ -4262,7 +4260,7 @@ void the_game(bool *kill,
 	try {
 
 		if (game.startup(kill, input, start_data, error_message,
-				reconnect_requested, &chat_backend, gamespec)) {
+				reconnect_requested, &chat_backend)) {
 			game.run();
 		}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -34,11 +34,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "clouds.h"
 #include "config.h"
 #include "content_cao.h"
+#include "content/subgames.h"
 #include "client/event_manager.h"
 #include "fontengine.h"
 #include "itemdef.h"
 #include "log.h"
 #include "filesys.h"
+#include "gameparams.h"
 #include "gettext.h"
 #include "gui/guiChatConsole.h"
 #include "gui/guiConfirmRegistration.h"
@@ -669,19 +671,12 @@ public:
 	~Game();
 
 	bool startup(bool *kill,
-			bool random_input,
 			InputHandler *input,
-			const std::string &map_dir,
-			const std::string &playername,
-			const std::string &password,
-			// If address is "", local server is used and address is updated
-			std::string *address,
-			u16 port,
+			const GameStartData &game_params,
 			std::string &error_message,
 			bool *reconnect,
 			ChatBackend *chat_backend,
-			const SubgameSpec &gamespec,    // Used for local game
-			bool simple_singleplayer_mode);
+			const SubgameSpec &gamespec); // Used for local game
 
 	void run();
 	void shutdown();
@@ -691,21 +686,18 @@ protected:
 	void extendedResourceCleanup();
 
 	// Basic initialisation
-	bool init(const std::string &map_dir, std::string *address,
-			u16 port,
-			const SubgameSpec &gamespec);
+	bool init(const std::string &map_dir, const std::string &address,
+			u16 port, const SubgameSpec &gamespec);
 	bool initSound();
 	bool createSingleplayerServer(const std::string &map_dir,
-			const SubgameSpec &gamespec, u16 port, std::string *address);
+			const SubgameSpec &gamespec, u16 port);
 
 	// Client creation
-	bool createClient(const std::string &playername,
-			const std::string &password, std::string *address, u16 port);
+	bool createClient(const GameStartData &start_data);
 	bool initGui();
 
 	// Client connection
-	bool connectToServer(const std::string &playername,
-			const std::string &password, std::string *address, u16 port,
+	bool connectToServer(const GameStartData &start_data,
 			bool *connect_ok, bool *aborted);
 	bool getServerContent(bool *aborted);
 
@@ -1017,28 +1009,22 @@ Game::~Game()
 }
 
 bool Game::startup(bool *kill,
-		bool random_input,
 		InputHandler *input,
-		const std::string &map_dir,
-		const std::string &playername,
-		const std::string &password,
-		std::string *address,     // can change if simple_singleplayer_mode
-		u16 port,
+		const GameStartData &start_data,
 		std::string &error_message,
 		bool *reconnect,
 		ChatBackend *chat_backend,
-		const SubgameSpec &gamespec,
-		bool simple_singleplayer_mode)
+		const SubgameSpec &gamespec)
 {
+
 	// "cache"
 	this->device              = RenderingEngine::get_raw_device();
 	this->kill                = kill;
 	this->error_message       = &error_message;
 	this->reconnect_requested = reconnect;
-	this->random_input        = random_input;
 	this->input               = input;
 	this->chat_backend        = chat_backend;
-	this->simple_singleplayer_mode = simple_singleplayer_mode;
+	this->simple_singleplayer_mode = start_data.isSinglePlayer();
 
 	input->keycache.populate();
 
@@ -1059,10 +1045,11 @@ bool Game::startup(bool *kill,
 
 	g_client_translations->clear();
 
-	if (!init(map_dir, address, port, gamespec))
+	// address can change if simple_singleplayer_mode
+	if (!init(start_data.map_dir, start_data.address, start_data.port, gamespec))
 		return false;
 
-	if (!createClient(playername, password, address, port))
+	if (!createClient(start_data))
 		return false;
 
 	RenderingEngine::initialize(client, hud);
@@ -1221,7 +1208,7 @@ void Game::shutdown()
 
 bool Game::init(
 		const std::string &map_dir,
-		std::string *address,
+		const std::string &address,
 		u16 port,
 		const SubgameSpec &gamespec)
 {
@@ -1245,8 +1232,8 @@ bool Game::init(
 		return false;
 
 	// Create a server if not connecting to an existing one
-	if (address->empty()) {
-		if (!createSingleplayerServer(map_dir, gamespec, port, address))
+	if (address.empty()) {
+		if (!createSingleplayerServer(map_dir, gamespec, port))
 			return false;
 	}
 
@@ -1281,7 +1268,7 @@ bool Game::initSound()
 }
 
 bool Game::createSingleplayerServer(const std::string &map_dir,
-		const SubgameSpec &gamespec, u16 port, std::string *address)
+		const SubgameSpec &gamespec, u16 port)
 {
 	showOverlayMessage(N_("Creating server..."), 0, 5);
 
@@ -1314,8 +1301,7 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 	return true;
 }
 
-bool Game::createClient(const std::string &playername,
-		const std::string &password, std::string *address, u16 port)
+bool Game::createClient(const GameStartData &start_data)
 {
 	showOverlayMessage(N_("Creating client..."), 0, 10);
 
@@ -1330,8 +1316,7 @@ bool Game::createClient(const std::string &playername,
 		g_touchscreengui->hide();
 	}
 #endif
-	if (!connectToServer(playername, password, address, port,
-			&could_connect, &connect_aborted))
+	if (!connectToServer(start_data, &could_connect, &connect_aborted))
 		return false;
 
 	if (!could_connect) {
@@ -1463,8 +1448,7 @@ bool Game::initGui()
 	return true;
 }
 
-bool Game::connectToServer(const std::string &playername,
-		const std::string &password, std::string *address, u16 port,
+bool Game::connectToServer(const GameStartData &start_data,
 		bool *connect_ok, bool *connection_aborted)
 {
 	*connect_ok = false;	// Let's not be overly optimistic
@@ -1473,10 +1457,10 @@ bool Game::connectToServer(const std::string &playername,
 
 	showOverlayMessage(N_("Resolving address..."), 0, 15);
 
-	Address connect_address(0, 0, 0, 0, port);
+	Address connect_address(0, 0, 0, 0, start_data.port);
 
 	try {
-		connect_address.Resolve(address->c_str());
+		connect_address.Resolve(start_data.address.c_str());
 
 		if (connect_address.isZero()) { // i.e. INADDR_ANY, IN6ADDR_ANY
 			//connect_address.Resolve("localhost");
@@ -1503,7 +1487,8 @@ bool Game::connectToServer(const std::string &playername,
 		return false;
 	}
 
-	client = new Client(playername.c_str(), password, *address,
+	client = new Client(start_data.name.c_str(),
+			start_data.password, start_data.address,
 			*draw_control, texture_src, shader_src,
 			itemdef_manager, nodedef_manager, sound, eventmgr,
 			connect_address.isIPv6(), m_game_ui.get());
@@ -1574,13 +1559,13 @@ bool Game::connectToServer(const std::string &playername,
 				} else {
 					registration_confirmation_shown = true;
 					(new GUIConfirmRegistration(guienv, guienv->getRootGUIElement(), -1,
-						   &g_menumgr, client, playername, password,
+						   &g_menumgr, client, start_data.name, start_data.password,
 						   connection_aborted, texture_src))->drop();
 				}
 			} else {
 				wait_time += dtime;
 				// Only time out if we aren't waiting for the server we started
-				if (!address->empty() && wait_time > 10) {
+				if (!start_data.isSinglePlayer() && wait_time > 10) {
 					*error_message = "Connection timed out.";
 					errorstream << *error_message << std::endl;
 					break;
@@ -2399,10 +2384,10 @@ void Game::checkZoomEnabled()
 void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 {
 	if ((device->isWindowActive() && device->isWindowFocused()
-			&& !isMenuActive()) || random_input) {
+			&& !isMenuActive()) || input->isRandom()) {
 
 #ifndef __ANDROID__
-		if (!random_input) {
+		if (!input->isRandom()) {
 			// Mac OSX gets upset if this is set every frame
 			if (device->getCursorControl()->isVisible())
 				device->getCursorControl()->setVisible(false);
@@ -3349,7 +3334,7 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 	}
 
 	// formspec in meta
-	if (meta && !meta->getString("formspec").empty() && !random_input
+	if (meta && !meta->getString("formspec").empty() && !input->isRandom()
 			&& !isKeyDown(KeyType::SNEAK)) {
 		// on_rightclick callbacks are called anyway
 		if (nodedef_manager->get(map.getNode(nodepos)).rightclickable)
@@ -4260,19 +4245,12 @@ void Game::showPauseMenu()
 /****************************************************************************/
 
 void the_game(bool *kill,
-		bool random_input,
 		InputHandler *input,
-		const std::string &map_dir,
-		const std::string &playername,
-		const std::string &password,
-		const std::string &address,         // If empty local server is created
-		u16 port,
-
+		const GameStartData &start_data,
 		std::string &error_message,
 		ChatBackend &chat_backend,
 		bool *reconnect_requested,
-		const SubgameSpec &gamespec,        // Used for local game
-		bool simple_singleplayer_mode)
+		const SubgameSpec &gamespec) // Used for local game
 {
 	Game game;
 
@@ -4280,14 +4258,11 @@ void the_game(bool *kill,
 	 * is created then this is updated and we don't want to change the value
 	 * passed to us by the calling function
 	 */
-	std::string server_address = address;
 
 	try {
 
-		if (game.startup(kill, random_input, input, map_dir,
-				playername, password, &server_address, port, error_message,
-				reconnect_requested, &chat_backend, gamespec,
-				simple_singleplayer_mode)) {
+		if (game.startup(kill, input, start_data, error_message,
+				reconnect_requested, &chat_backend, gamespec)) {
 			game.run();
 		}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -876,7 +876,6 @@ private:
 	bool *reconnect_requested;
 	scene::ISceneNode *skybox;
 
-	bool random_input;
 	bool simple_singleplayer_mode;
 	/* End 'cache' */
 

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -48,5 +48,4 @@ void the_game(bool *kill,
 		const GameStartData &start_data,
 		std::string &error_message,
 		ChatBackend &chat_backend,
-		bool *reconnect_requested,
-		const SubgameSpec &gamespec); // Used for local game
+		bool *reconnect_requested);

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class InputHandler;
 class ChatBackend;  /* to avoid having to include chat.h */
 struct SubgameSpec;
+struct GameStartData;
 
 struct Jitter {
 	f32 max, min, avg, counter, max_sample, min_sample, max_fraction;
@@ -41,16 +42,11 @@ struct CameraOrientation {
 	f32 camera_pitch;  // "up/down"
 };
 
+
 void the_game(bool *kill,
-		bool random_input,
 		InputHandler *input,
-		const std::string &map_dir,
-		const std::string &playername,
-		const std::string &password,
-		const std::string &address, // If "", local server is used
-		u16 port,
+		const GameStartData &start_data,
 		std::string &error_message,
 		ChatBackend &chat_backend,
 		bool *reconnect_requested,
-		const SubgameSpec &gamespec, // Used for local game
-		bool simple_singleplayer_mode);
+		const SubgameSpec &gamespec); // Used for local game

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -219,6 +219,11 @@ public:
 
 	virtual ~InputHandler() = default;
 
+	virtual bool isRandom() const
+	{
+		return false;
+	}
+
 	virtual bool isKeyDown(GameKeyType k) = 0;
 	virtual bool wasKeyDown(GameKeyType k) = 0;
 	virtual bool cancelPressed() = 0;
@@ -371,6 +376,11 @@ class RandomInputHandler : public InputHandler
 {
 public:
 	RandomInputHandler() = default;
+
+	bool isRandom() const
+	{
+		return true;
+	}
 
 	virtual bool isKeyDown(GameKeyType k) { return keydown[keycache.key[k]]; }
 	virtual bool wasKeyDown(GameKeyType k) { return false; }

--- a/src/gameparams.h
+++ b/src/gameparams.h
@@ -34,20 +34,16 @@ struct GameParams
 };
 
 // Information processed by main menu
-struct GameStartData {
+struct GameStartData : GameParams {
 	GameStartData() = default;
 
 	bool isSinglePlayer() const
 	{ return address.empty(); }
-	void setSinglePlayer()
-	{ address.clear(); }
-
-	bool isServer() const
-	{ return !map_dir.empty() && !address.empty(); }
 
 	std::string name;
 	std::string password;
-	std::string map_dir;
 	std::string address;
-	u16 port;
+
+	// "world_path" must be kept in sync!
+	WorldSpec world_spec;
 };

--- a/src/gameparams.h
+++ b/src/gameparams.h
@@ -23,10 +23,31 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 struct SubgameSpec;
 
+// Information provided from "main"
 struct GameParams
 {
+
 	u16 socket_port;
 	std::string world_path;
 	SubgameSpec game_spec;
 	bool is_dedicated_server;
+};
+
+// Information processed by main menu
+struct GameStartData {
+	GameStartData() = default;
+
+	bool isSinglePlayer() const
+	{ return address.empty(); }
+	void setSinglePlayer()
+	{ address.clear(); }
+
+	bool isServer() const
+	{ return !map_dir.empty() && !address.empty(); }
+
+	std::string name;
+	std::string password;
+	std::string map_dir;
+	std::string address;
+	u16 port;
 };

--- a/src/gameparams.h
+++ b/src/gameparams.h
@@ -38,11 +38,12 @@ struct GameStartData : GameParams {
 	GameStartData() = default;
 
 	bool isSinglePlayer() const
-	{ return address.empty(); }
+	{ return address.empty() && !local_server; }
 
 	std::string name;
 	std::string password;
 	std::string address;
+	bool local_server;
 
 	// "world_path" must be kept in sync!
 	WorldSpec world_spec;

--- a/src/gameparams.h
+++ b/src/gameparams.h
@@ -35,7 +35,8 @@ struct GameParams
 };
 
 // Information processed by main menu
-struct GameStartData : GameParams {
+struct GameStartData : GameParams
+{
 	GameStartData() = default;
 
 	bool isSinglePlayer() const { return address.empty() && !local_server; }

--- a/src/gameparams.h
+++ b/src/gameparams.h
@@ -26,6 +26,7 @@ struct SubgameSpec;
 // Information provided from "main"
 struct GameParams
 {
+	GameParams() = default;
 
 	u16 socket_port;
 	std::string world_path;
@@ -37,8 +38,7 @@ struct GameParams
 struct GameStartData : GameParams {
 	GameStartData() = default;
 
-	bool isSinglePlayer() const
-	{ return address.empty() && !local_server; }
+	bool isSinglePlayer() const { return address.empty() && !local_server; }
 
 	std::string name;
 	std::string password;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
 	}
 #endif
 
-	GameParams game_params;
+	GameStartData game_params;
 #ifdef SERVER
 	porting::attachOrCreateConsole();
 	game_params.is_dedicated_server = true;
@@ -604,10 +604,14 @@ static bool game_configure(GameParams *game_params, const Settings &cmd_args)
 
 static void game_configure_port(GameParams *game_params, const Settings &cmd_args)
 {
-	if (cmd_args.exists("port"))
+	if (cmd_args.exists("port")) {
 		game_params->socket_port = cmd_args.getU16("port");
-	else
-		game_params->socket_port = g_settings->getU16("port");
+	} else {
+		if (game_params->is_dedicated_server)
+			game_params->socket_port = g_settings->getU16("port");
+		else
+			game_params->socket_port = g_settings->getU16("remote_port");
+	}
 
 	if (game_params->socket_port == 0)
 		game_params->socket_port = DEFAULT_SERVER_PORT;


### PR DESCRIPTION
`ClientLauncher` handles the client-relevant CLI arguments and main menu information to start a client.
This PR now removes duplicated variables and unifies the startup data into a new (inherited) struct. It's still a mess, but I hope this goes into the right direction.

**Features:**
 * Easier to join singleplayer worlds (see examples below)


Fixes #8273 as a side-effect.

## To do

This PR is Ready for Review.

## How to test

```sh
# Singleplayer
minetest --go --worldname WORLDNAME

# Singleplayer: Ignored name input
minetest --go --worldname WORLDNAME --name foobar

# Remote server
minetest --go --address daconcepts.com --port 30001 --name Krock --password hunter2

# Remote server: Port and login from minetest.conf
minetest --go --address daconcepts.com

# Local server
minetest --server --worldname WORLDNAME --port 30001

# Local server: Port from minetest.conf
minetest --server --worldname WORLDNAME
```

Plus all main menu functions:
 * Local server
 * Singleplayer
 * Join remote server