### PR TITLE
Unittest/collision

### DIFF
--- a/src/gamedef.h
+++ b/src/gamedef.h
@@ -48,7 +48,7 @@ struct ModSpec;
 class IGameDef
 {
 public:
-	~IGameDef() = default;
+	virtual ~IGameDef() = default;
 
 	// These are thread-safe IF they are not edited while running threads.
 	// Thus, first they are set up and then they are only read.

--- a/src/gamedef.h
+++ b/src/gamedef.h
@@ -48,6 +48,8 @@ struct ModSpec;
 class IGameDef
 {
 public:
+	~IGameDef() = default;
+
 	// These are thread-safe IF they are not edited while running threads.
 	// Thus, first they are set up and then they are only read.
 	virtual IItemDefManager* getItemDefManager()=0;

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -1,4 +1,5 @@
 set (UNITTEST_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/mockgame.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_address.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_authdatabase.cpp

--- a/src/unittest/mockgame.cpp
+++ b/src/unittest/mockgame.cpp
@@ -38,7 +38,7 @@ MapBlock *MockMap::emergeBlock(v3s16 p, bool create_blank)
 {
 	MapBlock *block = getBlockNoCreateNoEx(p);
 
-	if(block != nullptr)
+	if (block != nullptr)
 		return block;
 
 	// Get the MapSector
@@ -48,7 +48,7 @@ MapBlock *MockMap::emergeBlock(v3s16 p, bool create_blank)
 	block = sector->createBlankBlock(p.Y);
 	block->reallocate();
 	MapNode *n = block->getData();
-        for(u32 i = 0; i < block->nodecount; i++, n++)
+	for(u32 i = 0; i < block->nodecount; i++, n++)
 		n->setContent(CONTENT_AIR);
 	return block;
 }

--- a/src/unittest/mockgame.cpp
+++ b/src/unittest/mockgame.cpp
@@ -22,18 +22,19 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mockgame.h"
 #include "nodedef.h"
 
-MapSector * MockMap::emergeSector(v2s16 p)
+MapSector *MockMap::emergeSector(v2s16 p)
 {
 	MapSector *sector = getSectorNoGenerateNoLock(p);
 
-	if (sector) return sector;
+	if (sector)
+		return sector;
 
 	sector = new MapSector(this, p, m_gamedef);
 	m_sectors[p] = sector;
 	return sector;
 }
 
-MapBlock * MockMap::emergeBlock(v3s16 p, bool create_blank)
+MapBlock *MockMap::emergeBlock(v3s16 p, bool create_blank)
 {
 	MapBlock *block = getBlockNoCreateNoEx(p);
 
@@ -47,7 +48,7 @@ MapBlock * MockMap::emergeBlock(v3s16 p, bool create_blank)
 	block = sector->createBlankBlock(p.Y);
 	block->reallocate();
 	MapNode *n = block->getData();
-        for(u32 i=0; i < block->nodecount; i++, n++)
+        for(u32 i = 0; i < block->nodecount; i++, n++)
 		n->setContent(CONTENT_AIR);
 	return block;
 }

--- a/src/unittest/mockgame.cpp
+++ b/src/unittest/mockgame.cpp
@@ -2,7 +2,7 @@
 #include "nodedef.h"
 
 MockGameDef::MockGameDef(std::ostream &dout):
-	dout(dout), m_ndef()
+	dout(dout), m_ndef(), m_modspec()
 {
 	ContentFeatures cf;
 	cf.name = "X";
@@ -12,7 +12,7 @@ MockGameDef::MockGameDef(std::ostream &dout):
         m_ndef.set(cf.name, cf);
 }
 
-bool MockMap::CreateSector(v2s16 p2d, string definition)
+bool MockMap::CreateSector(const v2s16 &p2d, const std::string &definition)
 {
 	// Create a MapSector using the definition.
 	const NodeDefManager  &ndef = *m_gamedef.ndef();

--- a/src/unittest/mockgame.cpp
+++ b/src/unittest/mockgame.cpp
@@ -1,3 +1,22 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
 #include "mapblock.h"
 #include "mapsector.h"
 #include "mockgame.h"

--- a/src/unittest/mockgame.cpp
+++ b/src/unittest/mockgame.cpp
@@ -48,7 +48,7 @@ MapBlock *MockMap::emergeBlock(v3s16 p, bool create_blank)
 	block = sector->createBlankBlock(p.Y);
 	block->reallocate();
 	MapNode *n = block->getData();
-	for(u32 i = 0; i < block->nodecount; i++, n++)
+	for (u32 i = 0; i < block->nodecount; i++, n++)
 		n->setContent(CONTENT_AIR);
 	return block;
 }

--- a/src/unittest/mockgame.cpp
+++ b/src/unittest/mockgame.cpp
@@ -1,3 +1,5 @@
+#include "mapblock.h"
+#include "mapsector.h"
 #include "mockgame.h"
 #include "nodedef.h"
 
@@ -15,19 +17,20 @@ MockGameDef::MockGameDef(std::ostream &dout):
 bool MockMap::CreateSector(const v2s16 &p2d, const std::string &definition)
 {
 	// Create a MapSector using the definition.
-	const NodeDefManager  &ndef = *m_gamedef.ndef();
+	const NodeDefManager  &ndef = *m_gamedef->ndef();
 	MapSector *sector = new MapSector(this, p2d, m_gamedef);
 	content_t solid, air;
 
-	ndef.get("S", solid);
-	ndef.get(" ", air);
+	ndef.getId("S", solid);
+	ndef.getId(" ", air);
 	size_t len = definition.length();
         size_t p = 0;
         s16 y=0;
         while(p < len)
 	{
-		MapNode *n = sector->createBlankBlock(y++)->getData();
-        	for(int i=0; i < MapBlock::MapBlock.nodecount; i++, p++, n++)
+		MapBlock *bl = sector->createBlankBlock(y++);
+		MapNode *n = bl->getData();
+        	for(int i=0; i < bl->nodecount; i++, p++, n++)
 			switch(definition[p])
 			{
 			case 'S':
@@ -40,5 +43,6 @@ bool MockMap::CreateSector(const v2s16 &p2d, const std::string &definition)
 
 	// Append it onto m_sectors
 	m_sectors[p2d] = sector;
+	return true;
 }
 

--- a/src/unittest/mockgame.cpp
+++ b/src/unittest/mockgame.cpp
@@ -1,0 +1,44 @@
+#include "mockgame.h"
+#include "nodedef.h"
+
+MockGameDef::MockGameDef(std::ostream &dout):
+	dout(dout), m_ndef()
+{
+	ContentFeatures cf;
+	cf.name = "X";
+        m_ndef.set(cf.name, cf);
+        cf.name = " ";
+        cf.walkable = false;
+        m_ndef.set(cf.name, cf);
+}
+
+bool CreateSector(v2s16 p2d, string definition)
+{
+	// Create a MapSector using the definition.
+	const NodeDefManager  &ndef = *m_gamedef.ndef();
+	MapSector *sector = new MapSector(this, p2d, m_gamedef);
+	content_t solid, air;
+
+	ndef.get("S", solid);
+	ndef.get(" ", air);
+	size_t len = definition.length();
+        size_t p = 0;
+        s16 y=0;
+        while(p < len)
+	{
+		MapNode *n = sector->createBlankBlock(y++)->getData();
+        	for(int i=0; i < MapBlock::MapBlock.nodecount; i++, p++, n++)
+			switch(definition[p])
+			{
+			case 'S':
+				n->setContent(solid);
+				break;
+			default:
+				n->setContent(air);
+			}
+	}
+
+	// Append it onto m_sectors
+	m_sectors[p2d] = sector;
+}
+

--- a/src/unittest/mockgame.cpp
+++ b/src/unittest/mockgame.cpp
@@ -12,7 +12,7 @@ MockGameDef::MockGameDef(std::ostream &dout):
         m_ndef.set(cf.name, cf);
 }
 
-bool CreateSector(v2s16 p2d, string definition)
+bool MockMap::CreateSector(v2s16 p2d, string definition)
 {
 	// Create a MapSector using the definition.
 	const NodeDefManager  &ndef = *m_gamedef.ndef();

--- a/src/unittest/mockgame.h
+++ b/src/unittest/mockgame.h
@@ -1,3 +1,22 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
 #include <iostream>
 
 #include "content/mods.h"

--- a/src/unittest/mockgame.h
+++ b/src/unittest/mockgame.h
@@ -31,7 +31,7 @@ public:
 	virtual u16 allocateUnknownNodeId(const std::string &name)
 		UNIMPLEMENTED(0)
 	virtual const std::vector<ModSpec> &getMods() const
-		UNIMPLEMENTED(std::vector<ModSpec>())
+		UNIMPLEMENTED(m_modspec)
 	virtual const ModSpec* getModSpec(const std::string &modname) const
 		UNIMPLEMENTED(NULL)
 	virtual std::string getModStoragePath() const
@@ -57,6 +57,7 @@ protected:
 
 	std::ostream &dout;
 	NodeDefManager m_ndef;
+	std::vector<ModSpec> m_modspec;
 };
 
 class MockMap: public Map

--- a/src/unittest/mockgame.h
+++ b/src/unittest/mockgame.h
@@ -4,7 +4,6 @@
 #include "environment.h"
 #include "gamedef.h"
 #include "map.h"
-#include "mapblock.h"
 #include "nodedef.h"
 
 /*
@@ -18,22 +17,23 @@
 class MockGameDef: public IGameDef
 {
 public:
-	MockGameDef(std::ostream &dout);
+	MockGameDef(std::ostream &dout):
+		dout(dout), m_ndef(), m_modspec() {};
 
-	virtual IItemDefManager* getItemDefManager() UNIMPLEMENTED(NULL)
+	virtual IItemDefManager* getItemDefManager() UNIMPLEMENTED(nullptr)
 
 	virtual const NodeDefManager* getNodeDefManager()
 	{
 		return &m_ndef;
 	}
 
-	virtual ICraftDefManager* getCraftDefManager() UNIMPLEMENTED(NULL)
+	virtual ICraftDefManager* getCraftDefManager() UNIMPLEMENTED(nullptr)
 	virtual u16 allocateUnknownNodeId(const std::string &name)
 		UNIMPLEMENTED(0)
 	virtual const std::vector<ModSpec> &getMods() const
 		UNIMPLEMENTED(m_modspec)
 	virtual const ModSpec* getModSpec(const std::string &modname) const
-		UNIMPLEMENTED(NULL)
+		UNIMPLEMENTED(nullptr)
 	virtual std::string getModStoragePath() const
 		UNIMPLEMENTED("")
 	virtual bool registerModStorage(ModMetadata *storage)
@@ -47,7 +47,11 @@ public:
 	virtual bool sendModChannelMessage(const std::string &channel,
 		const std::string &message) UNIMPLEMENTED(false)
 	virtual ModChannel *getModChannel(const std::string &channel)
-		UNIMPLEMENTED(NULL)
+		UNIMPLEMENTED(nullptr)
+	content_t registerContent(const std::string &name, const ContentFeatures &def)
+	{
+		return m_ndef.set(name, def);
+	}
 
 protected:
         void warn_unimplemented(const std::string &function) const
@@ -75,8 +79,10 @@ public:
 	{
 		out << "MockMap: ";
 	}
-
-	bool CreateSector(const v2s16 &p2d, const std::string &definition);
+	
+	virtual MapSector * emergeSector(v2s16 p);
+	virtual MapBlock * emergeBlock(v3s16 p, bool create_blank=true);
+	void setMockNode(v3s16 p, content_t c);
 };
 
 class MockEnvironment: public Environment
@@ -90,6 +96,10 @@ public:
 	virtual void getSelectedActiveObjects(const core::line3d<f32> &shootline_on_map,
                         std::vector<PointedThing> &objects) {}
 	MockMap &getMockMap() { return m_map; }
+	MockGameDef *getMockGameDef()
+	{
+		return dynamic_cast<MockGameDef *>(m_gamedef);
+	}
 protected:
 	MockMap m_map;
 	

--- a/src/unittest/mockgame.h
+++ b/src/unittest/mockgame.h
@@ -90,7 +90,7 @@ class MockMap : public Map
 {
 public:
 	MockMap(std::ostream &dout, IGameDef *gamedef) : Map(dout, gamedef) {}
-	~MockMap() = default;
+	virtual ~MockMap() = default;
 
 	virtual s32 mapType() const { return MAPTYPE_MOCK; }
 

--- a/src/unittest/mockgame.h
+++ b/src/unittest/mockgame.h
@@ -1,0 +1,92 @@
+#include <iostream>
+
+#include "environment.h"
+#include "gamedef.h"
+#include "map.h"
+
+/*
+        MapEditEvent
+*/
+
+#define MAPTYPE_MOCK 3
+
+#include UNIMPLEMENTED(retval) { warn_unimplemented(__FUNCTION__); return retval; }
+
+class MockGameDef: public IGameDef
+{
+public:
+	MockGameDef(std::ostream &dout);
+
+	virtual IItemDefManager* getItemDefManager() UNIMPLEMENTED(NULL)
+
+	virtual const NodeDefManager* getNodeDefManager()
+	{
+		return m_ndef;
+	}
+
+	virtual ICraftDefManager* getCraftDefManager() UNIMPLEMENTED(NULL)
+	virtual u16 allocateUnknownNodeId(const std::string &name)
+		UNIMPLEMENTED(0)
+	virtual const std::vector<ModSpec> &getMods() const
+		UNIMPLEMENTED(std::vector<ModSpec>())
+	virtual const ModSpec* getModSpec(const std::string &modname) const
+		UNIMPLEMENTED(NULL)
+	virtual std::string getModStoragePath() const
+		UNIMPLEMENTED("")
+	virtual bool registerModStorage(ModMetadata *storage)
+		UNIMPLEMENTED(false)
+	virtual void unregisterModStorage(const std::string &name)
+		UNIMPLEMENTED(;)
+	virtual bool joinModChannel(const std::string &channel)
+		UNIMPLEMENTED(false)
+	virtual bool leaveModChannel(const std::string &channel)
+		UNIMPLEMENTED(false)
+	virtual bool sendModChannelMessage(const std::string &channel,
+		const std::string &message) UNIMPLEMENTED(false)
+	virtual ModChannel *getModChannel(const std::string &channel)
+		UNIMPLEMENTED(NULL)
+
+protected:
+        void warn_unimplemented(string function)
+	{
+		dout << "Warning: Implement " << function << std::endl;
+	}
+
+	std::ostream &dout;
+	NodeDefManager m_ndef;
+};
+
+class MockMap: public Map
+{
+public:
+	MockMap(std::ostream &dout, IGameDef *gamedef): Map(dout, gamedef) {}
+
+	virtual s32 mapType() const
+        {
+                return MAPTYPE_MOCK;
+        }
+
+	// For debug printing. Prints "Map: ", "ServerMap: " or "ClientMap: "
+        virtual void PrintInfo(std::ostream &out)
+	{
+		out << "MockMap: ";
+	}
+
+	bool CreateSector(v2s16 p2d, string definition);
+};
+
+class MockEnvironment: public Environment
+{
+public:
+	MockEnvironment(std::ostream &dout):
+		Environment(new MockMap(dout)),
+		m_map(dout, m_gamedef) {}
+	virtual void step(f32 dtime) {}
+	virtual Map &getMap() { return m_map; }
+	virtual void getSelectedActiveObjects(const core::line3d<f32> &shootline_on_map,
+                        std::vector<PointedThing> &objects) {}
+	MockMap &getMockMap() { return m_map; }
+protected:
+	MockMap m_map;
+	
+};

--- a/src/unittest/mockgame.h
+++ b/src/unittest/mockgame.h
@@ -26,54 +26,93 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nodedef.h"
 
 /*
-        MapEditEvent
+       MapEditEvent
 */
 
 #define MAPTYPE_MOCK 3
 
-#define UNIMPLEMENTED(retval){warn_unimplemented(__FUNCTION__); return retval; }
+#define UNIMPLEMENTED(retval)				\
+	warn_unimplemented(__FUNCTION__);	\
+	return retval;
 
-class MockGameDef: public IGameDef
+class MockGameDef : public IGameDef
 {
 public:
-	MockGameDef(std::ostream &dout):
-		dout(dout), m_ndef(), m_modspec() {};
+	MockGameDef(std::ostream &dout) : dout(dout), m_ndef(), m_modspec() {};
 
-	virtual IItemDefManager* getItemDefManager() UNIMPLEMENTED(nullptr)
+	virtual IItemDefManager *getItemDefManager()
+	{
+		UNIMPLEMENTED(nullptr)
+	}
 
-	virtual const NodeDefManager* getNodeDefManager()
+	virtual const NodeDefManager *getNodeDefManager()
 	{
 		return &m_ndef;
 	}
 
-	virtual ICraftDefManager* getCraftDefManager() UNIMPLEMENTED(nullptr)
+	virtual ICraftDefManager *getCraftDefManager()
+	{
+		UNIMPLEMENTED(nullptr)
+	}
+
 	virtual u16 allocateUnknownNodeId(const std::string &name)
+	{
 		UNIMPLEMENTED(0)
+	}
+
 	virtual const std::vector<ModSpec> &getMods() const
+	{
 		UNIMPLEMENTED(m_modspec)
-	virtual const ModSpec* getModSpec(const std::string &modname) const
+	}
+
+	virtual const ModSpec *getModSpec(const std::string &modname) const
+	{
 		UNIMPLEMENTED(nullptr)
+	}
+
 	virtual std::string getModStoragePath() const
+	{
 		UNIMPLEMENTED("")
+	}
+
 	virtual bool registerModStorage(ModMetadata *storage)
+	{
 		UNIMPLEMENTED(false)
+	}
+
 	virtual void unregisterModStorage(const std::string &name)
+	{
 		UNIMPLEMENTED(;)
+	}
+
 	virtual bool joinModChannel(const std::string &channel)
+	{
 		UNIMPLEMENTED(false)
+	}
+
 	virtual bool leaveModChannel(const std::string &channel)
+	{
 		UNIMPLEMENTED(false)
+	}
+
 	virtual bool sendModChannelMessage(const std::string &channel,
-		const std::string &message) UNIMPLEMENTED(false)
+		const std::string &message)
+	{
+		UNIMPLEMENTED(false)
+	}
+
 	virtual ModChannel *getModChannel(const std::string &channel)
+	{
 		UNIMPLEMENTED(nullptr)
+	}
+
 	content_t registerContent(const std::string &name, const ContentFeatures &def)
 	{
 		return m_ndef.set(name, def);
 	}
 
 protected:
-        void warn_unimplemented(const std::string &function) const
+	void warn_unimplemented(const std::string &function) const
 	{
 		dout << "Warning: Implement " << function << std::endl;
 	}
@@ -83,43 +122,41 @@ protected:
 	std::vector<ModSpec> m_modspec;
 };
 
-class MockMap: public Map
+class MockMap : public Map
 {
 public:
-	MockMap(std::ostream &dout, IGameDef *gamedef): Map(dout, gamedef) {}
+	MockMap(std::ostream &dout, IGameDef *gamedef) : Map(dout, gamedef) {}
 
-	virtual s32 mapType() const
-        {
-                return MAPTYPE_MOCK;
-        }
+	virtual s32 mapType() const { return MAPTYPE_MOCK; }
 
 	// For debug printing. Prints "Map: ", "ServerMap: " or "ClientMap: "
-        virtual void PrintInfo(std::ostream &out)
-	{
-		out << "MockMap: ";
-	}
+        virtual void PrintInfo(std::ostream &out) { out << "MockMap: "; }
 	
-	virtual MapSector * emergeSector(v2s16 p);
-	virtual MapBlock * emergeBlock(v3s16 p, bool create_blank=true);
+	virtual MapSector *emergeSector(v2s16 p);
+	virtual MapBlock *emergeBlock(v3s16 p, bool create_blank=true);
 	void setMockNode(v3s16 p, content_t c);
 };
 
-class MockEnvironment: public Environment
+class MockEnvironment : public Environment
 {
 public:
-	MockEnvironment(std::ostream &dout):
-		Environment(new MockGameDef(dout)),
-		m_map(dout, m_gamedef) {}
+	MockEnvironment(std::ostream &dout) :
+		Environment(new MockGameDef(dout)), m_map(dout, m_gamedef)
+	{
+	}
+
 	virtual void step(f32 dtime) {}
 	virtual Map &getMap() { return m_map; }
+
 	virtual void getSelectedActiveObjects(const core::line3d<f32> &shootline_on_map,
-                        std::vector<PointedThing> &objects) {}
-	MockMap &getMockMap() { return m_map; }
-	MockGameDef *getMockGameDef()
+                        std::vector<PointedThing> &objects)
 	{
-		return dynamic_cast<MockGameDef *>(m_gamedef);
 	}
+
+	MockMap &getMockMap() { return m_map; }
+
+	MockGameDef *getMockGameDef() { return dynamic_cast<MockGameDef *>(m_gamedef); }
+
 protected:
 	MockMap m_map;
-	
 };

--- a/src/unittest/mockgame.h
+++ b/src/unittest/mockgame.h
@@ -107,6 +107,7 @@ public:
 	{
 	}
 
+	virtual ~MockEnvironment() { delete m_gamedef; }
 	virtual void step(f32 dtime) {}
 	virtual Map &getMap() { return m_map; }
 

--- a/src/unittest/mockgame.h
+++ b/src/unittest/mockgame.h
@@ -26,85 +26,41 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nodedef.h"
 
 /*
-       MapEditEvent
+	MapEditEvent
 */
 
 #define MAPTYPE_MOCK 3
 
-#define UNIMPLEMENTED(retval)				\
-	warn_unimplemented(__FUNCTION__);	\
+#define UNIMPLEMENTED(retval)						\
+	warn_unimplemented(__FUNCTION__);				\
 	return retval;
 
 class MockGameDef : public IGameDef
 {
 public:
-	MockGameDef(std::ostream &dout) : dout(dout), m_ndef(), m_modspec() {};
+	MockGameDef(std::ostream &dout) : dout(dout), m_ndef(), m_modspec(){};
 
-	virtual IItemDefManager *getItemDefManager()
-	{
-		UNIMPLEMENTED(nullptr)
-	}
+	virtual IItemDefManager *getItemDefManager() { UNIMPLEMENTED(nullptr) }
 
-	virtual const NodeDefManager *getNodeDefManager()
-	{
-		return &m_ndef;
-	}
+	virtual const NodeDefManager *getNodeDefManager() { return &m_ndef; }
 
-	virtual ICraftDefManager *getCraftDefManager()
-	{
-		UNIMPLEMENTED(nullptr)
-	}
-
-	virtual u16 allocateUnknownNodeId(const std::string &name)
-	{
-		UNIMPLEMENTED(0)
-	}
-
-	virtual const std::vector<ModSpec> &getMods() const
-	{
-		UNIMPLEMENTED(m_modspec)
-	}
-
-	virtual const ModSpec *getModSpec(const std::string &modname) const
-	{
-		UNIMPLEMENTED(nullptr)
-	}
-
-	virtual std::string getModStoragePath() const
-	{
-		UNIMPLEMENTED("")
-	}
-
-	virtual bool registerModStorage(ModMetadata *storage)
-	{
-		UNIMPLEMENTED(false)
-	}
-
-	virtual void unregisterModStorage(const std::string &name)
-	{
-		UNIMPLEMENTED(;)
-	}
-
-	virtual bool joinModChannel(const std::string &channel)
-	{
-		UNIMPLEMENTED(false)
-	}
-
-	virtual bool leaveModChannel(const std::string &channel)
-	{
-		UNIMPLEMENTED(false)
-	}
+	virtual ICraftDefManager *getCraftDefManager() { UNIMPLEMENTED(nullptr) }
+	virtual u16 allocateUnknownNodeId(const std::string &name) { UNIMPLEMENTED(0) }
+	virtual const std::vector<ModSpec> &getMods() const { UNIMPLEMENTED(m_modspec) }
+	virtual const ModSpec *getModSpec(const std::string &modname) const { UNIMPLEMENTED(nullptr) }
+	virtual std::string getModStoragePath() const { UNIMPLEMENTED("") }
+	virtual bool registerModStorage(ModMetadata *storage) { UNIMPLEMENTED(false) }
+	virtual void unregisterModStorage(const std::string &name) { UNIMPLEMENTED(;) }
+	virtual bool joinModChannel(const std::string &channel) { UNIMPLEMENTED(false) }
+	virtual bool leaveModChannel(const std::string &channel) { UNIMPLEMENTED(false) }
 
 	virtual bool sendModChannelMessage(const std::string &channel,
-		const std::string &message)
+			const std::string &message)
 	{
 		UNIMPLEMENTED(false)
 	}
 
-	virtual ModChannel *getModChannel(const std::string &channel)
-	{
-		UNIMPLEMENTED(nullptr)
-	}
+	virtual ModChannel *getModChannel(const std::string &channel) { UNIMPLEMENTED(nullptr) }
 
 	content_t registerContent(const std::string &name, const ContentFeatures &def)
 	{
@@ -130,7 +86,7 @@ public:
 	virtual s32 mapType() const { return MAPTYPE_MOCK; }
 
 	// For debug printing. Prints "Map: ", "ServerMap: " or "ClientMap: "
-        virtual void PrintInfo(std::ostream &out) { out << "MockMap: "; }
+	virtual void PrintInfo(std::ostream &out) { out << "MockMap: "; }
 	
 	virtual MapSector *emergeSector(v2s16 p);
 	virtual MapBlock *emergeBlock(v3s16 p, bool create_blank=true);
@@ -149,7 +105,7 @@ public:
 	virtual Map &getMap() { return m_map; }
 
 	virtual void getSelectedActiveObjects(const core::line3d<f32> &shootline_on_map,
-                        std::vector<PointedThing> &objects)
+			std::vector<PointedThing> &objects)
 	{
 	}
 

--- a/src/unittest/mockgame.h
+++ b/src/unittest/mockgame.h
@@ -40,6 +40,8 @@ class MockGameDef : public IGameDef
 public:
 	MockGameDef(std::ostream &dout) : dout(dout), m_ndef(), m_modspec(){};
 
+	virtual ~MockGameDef() = default;
+
 	virtual IItemDefManager *getItemDefManager() { UNIMPLEMENTED(nullptr) }
 
 	virtual const NodeDefManager *getNodeDefManager() { return &m_ndef; }
@@ -88,6 +90,7 @@ class MockMap : public Map
 {
 public:
 	MockMap(std::ostream &dout, IGameDef *gamedef) : Map(dout, gamedef) {}
+	~MockMap() = default;
 
 	virtual s32 mapType() const { return MAPTYPE_MOCK; }
 

--- a/src/unittest/mockgame.h
+++ b/src/unittest/mockgame.h
@@ -31,8 +31,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define MAPTYPE_MOCK 3
 
-#define UNIMPLEMENTED(retval)						\
-	warn_unimplemented(__FUNCTION__);				\
+#define UNIMPLEMENTED(retval)								\
+	warn_unimplemented(__FUNCTION__);						\
 	return retval;
 
 class MockGameDef : public IGameDef
@@ -47,20 +47,28 @@ public:
 	virtual ICraftDefManager *getCraftDefManager() { UNIMPLEMENTED(nullptr) }
 	virtual u16 allocateUnknownNodeId(const std::string &name) { UNIMPLEMENTED(0) }
 	virtual const std::vector<ModSpec> &getMods() const { UNIMPLEMENTED(m_modspec) }
-	virtual const ModSpec *getModSpec(const std::string &modname) const { UNIMPLEMENTED(nullptr) }
+
+	virtual const ModSpec *getModSpec(const std::string &modname) const
+	{
+		UNIMPLEMENTED(nullptr)
+	}
+
 	virtual std::string getModStoragePath() const { UNIMPLEMENTED("") }
 	virtual bool registerModStorage(ModMetadata *storage) { UNIMPLEMENTED(false) }
 	virtual void unregisterModStorage(const std::string &name) { UNIMPLEMENTED(;) }
 	virtual bool joinModChannel(const std::string &channel) { UNIMPLEMENTED(false) }
 	virtual bool leaveModChannel(const std::string &channel) { UNIMPLEMENTED(false) }
 
-	virtual bool sendModChannelMessage(const std::string &channel,
-			const std::string &message)
+	virtual bool sendModChannelMessage(
+			const std::string &channel, const std::string &message)
 	{
 		UNIMPLEMENTED(false)
 	}
 
-	virtual ModChannel *getModChannel(const std::string &channel) { UNIMPLEMENTED(nullptr) }
+	virtual ModChannel *getModChannel(const std::string &channel)
+	{
+		UNIMPLEMENTED(nullptr)
+	}
 
 	content_t registerContent(const std::string &name, const ContentFeatures &def)
 	{
@@ -87,9 +95,9 @@ public:
 
 	// For debug printing. Prints "Map: ", "ServerMap: " or "ClientMap: "
 	virtual void PrintInfo(std::ostream &out) { out << "MockMap: "; }
-	
+
 	virtual MapSector *emergeSector(v2s16 p);
-	virtual MapBlock *emergeBlock(v3s16 p, bool create_blank=true);
+	virtual MapBlock *emergeBlock(v3s16 p, bool create_blank = true);
 	void setMockNode(v3s16 p, content_t c);
 };
 
@@ -97,7 +105,7 @@ class MockEnvironment : public Environment
 {
 public:
 	MockEnvironment(std::ostream &dout) :
-		Environment(new MockGameDef(dout)), m_map(dout, m_gamedef)
+			Environment(new MockGameDef(dout)), m_map(dout, m_gamedef)
 	{
 	}
 

--- a/src/unittest/mockgame.h
+++ b/src/unittest/mockgame.h
@@ -1,8 +1,11 @@
 #include <iostream>
 
+#include "content/mods.h"
 #include "environment.h"
 #include "gamedef.h"
 #include "map.h"
+#include "mapblock.h"
+#include "nodedef.h"
 
 /*
         MapEditEvent
@@ -10,7 +13,7 @@
 
 #define MAPTYPE_MOCK 3
 
-#include UNIMPLEMENTED(retval) { warn_unimplemented(__FUNCTION__); return retval; }
+#define UNIMPLEMENTED(retval){warn_unimplemented(__FUNCTION__); return retval; }
 
 class MockGameDef: public IGameDef
 {
@@ -21,7 +24,7 @@ public:
 
 	virtual const NodeDefManager* getNodeDefManager()
 	{
-		return m_ndef;
+		return &m_ndef;
 	}
 
 	virtual ICraftDefManager* getCraftDefManager() UNIMPLEMENTED(NULL)
@@ -47,7 +50,7 @@ public:
 		UNIMPLEMENTED(NULL)
 
 protected:
-        void warn_unimplemented(string function)
+        void warn_unimplemented(const std::string &function) const
 	{
 		dout << "Warning: Implement " << function << std::endl;
 	}
@@ -72,14 +75,14 @@ public:
 		out << "MockMap: ";
 	}
 
-	bool CreateSector(v2s16 p2d, string definition);
+	bool CreateSector(const v2s16 &p2d, const std::string &definition);
 };
 
 class MockEnvironment: public Environment
 {
 public:
 	MockEnvironment(std::ostream &dout):
-		Environment(new MockMap(dout)),
+		Environment(new MockGameDef(dout)),
 		m_map(dout, m_gamedef) {}
 	virtual void step(f32 dtime) {}
 	virtual Map &getMap() { return m_map; }

--- a/src/unittest/mockgame.h
+++ b/src/unittest/mockgame.h
@@ -31,8 +31,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define MAPTYPE_MOCK 3
 
-#define UNIMPLEMENTED(retval)								\
-	warn_unimplemented(__FUNCTION__);						\
+#define UNIMPLEMENTED(retval)                                                            \
+	warn_unimplemented(__FUNCTION__);                                                \
 	return retval;
 
 class MockGameDef : public IGameDef
@@ -65,10 +65,8 @@ public:
 		UNIMPLEMENTED(false)
 	}
 
-	virtual ModChannel *getModChannel(const std::string &channel)
-	{
-		UNIMPLEMENTED(nullptr)
-	}
+	virtual ModChannel *getModChannel(const std::string &channel){
+			UNIMPLEMENTED(nullptr)}
 
 	content_t registerContent(const std::string &name, const ContentFeatures &def)
 	{

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -263,6 +263,7 @@ bool run_tests()
 	g_logger.setLevelSilenced(LL_ERROR, true);
 
 	u32 num_modules_failed     = 0;
+	u32 num_total_tests_exp_failed = 0;
 	u32 num_total_tests_failed = 0;
 	u32 num_total_tests_run    = 0;
 	std::vector<TestBase *> &testmods = TestManager::getTestModules();
@@ -270,8 +271,10 @@ bool run_tests()
 		if (!testmods[i]->testModule(&gamedef))
 			num_modules_failed++;
 
+		num_total_tests_exp_failed += testmods[i]->num_tests_exp_failed;
 		num_total_tests_failed += testmods[i]->num_tests_failed;
 		num_total_tests_run += testmods[i]->num_tests_run;
+		rawstream << num_total_tests_exp_failed << std::endl;
 	}
 
 	u64 tdiff = porting::getTimeMs() - t1;
@@ -285,8 +288,9 @@ bool run_tests()
 		<< "++++++++++++++++++++++++++++++++++++++++" << std::endl
 		<< "Unit Test Results: " << overall_status << std::endl
 		<< "    " << num_modules_failed << " / " << testmods.size()
-		<< " failed modules (" << num_total_tests_failed << " / "
-		<< num_total_tests_run << " failed individual tests)." << std::endl
+		<< " failed modules (" << num_total_tests_failed << " + " 
+		<< num_total_tests_exp_failed << " / "
+		<< num_total_tests_run << " failed + expected failed individual tests)." << std::endl
 		<< "    Testing took " << tdiff << "ms total." << std::endl
 		<< "++++++++++++++++++++++++++++++++++++++++"
 		<< "++++++++++++++++++++++++++++++++++++++++" << std::endl;
@@ -308,8 +312,8 @@ bool TestBase::testModule(IGameDef *gamedef)
 
 	u64 tdiff = porting::getTimeMs() - t1;
 	rawstream << "======== Module " << getName() << " "
-		<< (num_tests_failed ? "failed" : "passed") << " (" << num_tests_failed
-		<< " failures / " << num_tests_run << " tests) - " << tdiff
+		<< (num_tests_failed ? "failed" : (num_tests_exp_failed ? "expected-failed" : "passed")) << " (" << num_tests_failed
+		<< " failures + " << num_tests_exp_failed << " expected failures / " << num_tests_run << " tests) - " << tdiff
 		<< "ms" << std::endl;
 
 	if (!m_test_dir.empty())

--- a/src/unittest/test.h
+++ b/src/unittest/test.h
@@ -65,16 +65,6 @@ class TestExpFailedException : public std::exception {
 	}
 
 // Asserts the specified condition is true, or fails the current unit test
-// This failure is expected, and does not stop a build.
-#define UASSERT_EXP(x)                                              \
-	if (!(x)) {                                                 \
-		rawstream << "Test assertion failed (but expected): " #x << std::endl  \
-			<< "    at " << fs::GetFilenameFromPath(__FILE__)   \
-			<< ":" << __LINE__ << std::endl;                    \
-		throw TestExpFailedException();                            \
-	}
-
-// Asserts the specified condition is true, or fails the current unit test
 // and prints the format specifier fmt
 #define UTEST(x, fmt, ...)                                               \
 	if (!(x)) {                                                          \
@@ -84,18 +74,6 @@ class TestExpFailedException : public std::exception {
 			<< "    at " << fs::GetFilenameFromPath(__FILE__)            \
 			<< ":" << __LINE__ << std::endl;                             \
 		throw TestFailedException();                                     \
-	}
-
-// Asserts the specified condition is true, or fails the current unit test
-// and prints the format specifier fmt
-#define UTEST_EXP(x, fmt, ...)                                               \
-	if (!(x)) {                                                          \
-		char utest_buf[1024];                                            \
-		snprintf(utest_buf, sizeof(utest_buf), fmt, __VA_ARGS__);        \
-		rawstream << "Test assertion failed (but expected): " << utest_buf << std::endl \
-			<< "    at " << fs::GetFilenameFromPath(__FILE__)            \
-			<< ":" << __LINE__ << std::endl;                             \
-		throw TestExpFailedException();                                     \
 	}
 
 // Asserts the comparison specified by CMP is true, or fails the current unit test
@@ -114,25 +92,7 @@ class TestExpFailedException : public std::exception {
 	}                                                                     \
 }
 
-// Asserts the comparison specified by CMP is true, or fails the current unit test
-#define UASSERTCMP_EXP(T, CMP, actual, expected) {                            \
-	T a = (actual);                                                       \
-	T e = (expected);                                                     \
-	if (!(a CMP e)) {                                                     \
-		rawstream                                                         \
-			<< "Test assertion failed (but expected): " << #actual << " " << #CMP << " " \
-			<< #expected << std::endl                                     \
-			<< "    at " << fs::GetFilenameFromPath(__FILE__) << ":"      \
-			<< __LINE__ << std::endl                                      \
-			<< "    actual:   " << a << std::endl << "    expected: "     \
-			<< e << std::endl;                                            \
-		throw TestExpFailedException();                                      \
-	}                                                                     \
-}
-
 #define UASSERTEQ(T, actual, expected) UASSERTCMP(T, ==, actual, expected)
-
-#define UASSERTEQ_EXP(T, actual, expected) UASSERTCMP_EXP(T, ==, actual, expected)
 
 // UASSERTs that the specified exception occurs
 #define EXCEPTION_CHECK(EType, code) {    \
@@ -145,16 +105,13 @@ class TestExpFailedException : public std::exception {
 	UASSERT(exception_thrown);            \
 }
 
-// UASSERT_EXPs that the specified exception occurs
-#define EXCEPTION_CHECK_EXP(EType, code) {    \
-	bool exception_thrown = false;        \
-	try {                                 \
-		code;                             \
-	} catch (EType &e) {                  \
-		exception_thrown = true;          \
-	}                                     \
-	UASSERT_EXP(exception_thrown);            \
-}
+// Calls an code containing assertion macros, but treats failures as expected failures.
+#define EXPECT_FAIL(code) 	\
+	try {	\
+		code;	\
+	} catch (TestFailedException &e) {	\
+		throw TestExpFailedException();	\
+	}
 
 class IGameDef;
 

--- a/src/unittest/test.h
+++ b/src/unittest/test.h
@@ -29,6 +29,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class TestFailedException : public std::exception {
 };
+// Expected failure
+class TestExpFailedException : public std::exception {
+};
 
 // Runs a unit test and reports results
 #define TEST(fxn, ...) {                                                      \
@@ -39,6 +42,9 @@ class TestFailedException : public std::exception {
 	} catch (TestFailedException &e) {                                        \
 		rawstream << "[FAIL] ";                                               \
 		num_tests_failed++;                                                   \
+	} catch (TestExpFailedException &e) {                                        \
+		rawstream << "[EXPECTED][FAIL] ";                                               \
+		num_tests_exp_failed++;                                                   \
 	} catch (std::exception &e) {                                             \
 		rawstream << "Caught unhandled exception: " << e.what() << std::endl; \
 		rawstream << "[FAIL] ";                                               \
@@ -59,6 +65,16 @@ class TestFailedException : public std::exception {
 	}
 
 // Asserts the specified condition is true, or fails the current unit test
+// This failure is expected, and does not stop a build.
+#define UASSERT_EXP(x)                                              \
+	if (!(x)) {                                                 \
+		rawstream << "Test assertion failed (but expected): " #x << std::endl  \
+			<< "    at " << fs::GetFilenameFromPath(__FILE__)   \
+			<< ":" << __LINE__ << std::endl;                    \
+		throw TestExpFailedException();                            \
+	}
+
+// Asserts the specified condition is true, or fails the current unit test
 // and prints the format specifier fmt
 #define UTEST(x, fmt, ...)                                               \
 	if (!(x)) {                                                          \
@@ -68,6 +84,18 @@ class TestFailedException : public std::exception {
 			<< "    at " << fs::GetFilenameFromPath(__FILE__)            \
 			<< ":" << __LINE__ << std::endl;                             \
 		throw TestFailedException();                                     \
+	}
+
+// Asserts the specified condition is true, or fails the current unit test
+// and prints the format specifier fmt
+#define UTEST_EXP(x, fmt, ...)                                               \
+	if (!(x)) {                                                          \
+		char utest_buf[1024];                                            \
+		snprintf(utest_buf, sizeof(utest_buf), fmt, __VA_ARGS__);        \
+		rawstream << "Test assertion failed (but expected): " << utest_buf << std::endl \
+			<< "    at " << fs::GetFilenameFromPath(__FILE__)            \
+			<< ":" << __LINE__ << std::endl;                             \
+		throw TestExpFailedException();                                     \
 	}
 
 // Asserts the comparison specified by CMP is true, or fails the current unit test
@@ -86,7 +114,25 @@ class TestFailedException : public std::exception {
 	}                                                                     \
 }
 
+// Asserts the comparison specified by CMP is true, or fails the current unit test
+#define UASSERTCMP_EXP(T, CMP, actual, expected) {                            \
+	T a = (actual);                                                       \
+	T e = (expected);                                                     \
+	if (!(a CMP e)) {                                                     \
+		rawstream                                                         \
+			<< "Test assertion failed (but expected): " << #actual << " " << #CMP << " " \
+			<< #expected << std::endl                                     \
+			<< "    at " << fs::GetFilenameFromPath(__FILE__) << ":"      \
+			<< __LINE__ << std::endl                                      \
+			<< "    actual:   " << a << std::endl << "    expected: "     \
+			<< e << std::endl;                                            \
+		throw TestExpFailedException();                                      \
+	}                                                                     \
+}
+
 #define UASSERTEQ(T, actual, expected) UASSERTCMP(T, ==, actual, expected)
+
+#define UASSERTEQ_EXP(T, actual, expected) UASSERTCMP_EXP(T, ==, actual, expected)
 
 // UASSERTs that the specified exception occurs
 #define EXCEPTION_CHECK(EType, code) {    \
@@ -97,6 +143,17 @@ class TestFailedException : public std::exception {
 		exception_thrown = true;          \
 	}                                     \
 	UASSERT(exception_thrown);            \
+}
+
+// UASSERT_EXPs that the specified exception occurs
+#define EXCEPTION_CHECK_EXP(EType, code) {    \
+	bool exception_thrown = false;        \
+	try {                                 \
+		code;                             \
+	} catch (EType &e) {                  \
+		exception_thrown = true;          \
+	}                                     \
+	UASSERT_EXP(exception_thrown);            \
 }
 
 class IGameDef;
@@ -110,6 +167,7 @@ public:
 	virtual void runTests(IGameDef *gamedef) = 0;
 	virtual const char *getName() = 0;
 
+	u32 num_tests_exp_failed;
 	u32 num_tests_failed;
 	u32 num_tests_run;
 

--- a/src/unittest/test_collision.cpp
+++ b/src/unittest/test_collision.cpp
@@ -290,9 +290,9 @@ void TestCollision::testCollisionMoveSimple_ceiling()
 		v3f(), nullptr,
 		false);
 	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
-	UASSERT(res.collides);
-	UASSERT(pos_f.equals(v3f(11.f * BS, 10.f * BS, 10.f * BS), 0.01));
-	UASSERT(speed_f.equals(v3f(), 0.01));
+	UASSERT_EXP(res.collides);
+	UASSERT_EXP(pos_f.equals(v3f(11.f * BS, 10.f * BS, 10.f * BS), 0.01));
+	UASSERT_EXP(speed_f.equals(v3f(), 0.01));
 }
 
 void TestCollision::testCollisionMoveSimple_giantstepup()
@@ -322,9 +322,9 @@ void TestCollision::testCollisionMoveSimple_giantstepup()
 		v3f(), nullptr,
 		false);
 	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
-	UASSERT(!res.collides);
-	UASSERT(pos_f.equals(v3f(12.f * BS, 13.f * BS, 10.f * BS), 0.01));
-	UASSERT(speed_f.equals(v3f(4.f, 0.f, 0.f) * BS, 0.01));
+	UASSERT_EXP(!res.collides);
+	UASSERT_EXP(pos_f.equals(v3f(12.f * BS, 13.f * BS, 10.f * BS), 0.01));
+	UASSERT_EXP(speed_f.equals(v3f(4.f, 0.f, 0.f) * BS, 0.01));
 }
 
 void TestCollision::testCollisionMoveSimple_giantceiling()
@@ -425,9 +425,9 @@ void TestCollision::testCollisionMoveSimple_longclimb()
 		v3f(), nullptr,
 		false);
 	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
-	UASSERT(res.collides);
-	UASSERT(pos_f.equals(v3f(13.f * BS, 12.f * BS, 10.f * BS), 0.01));
-	UASSERT(speed_f.equals(v3f(), 0.01));
+	UASSERT_EXP(res.collides);
+	UASSERT_EXP(pos_f.equals(v3f(13.f * BS, 12.f * BS, 10.f * BS), 0.01));
+	UASSERT_EXP(speed_f.equals(v3f(), 0.01));
 }
 
 void TestCollision::testCollisionMoveSimple_shortstepup()
@@ -492,9 +492,9 @@ void TestCollision::testCollisionMoveSimple_bouncy()
 		v3f(), nullptr,
 		false);
 	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
-	UASSERT(!res.collides);
-	UASSERT(pos_f.equals(v3f(8.f * BS, 10.f * BS, 10.f * BS), 0.01));
-	UASSERT(speed_f.equals(v3f(), 0.01));
+	UASSERT_EXP(!res.collides);
+	UASSERT_EXP(pos_f.equals(v3f(8.f * BS, 10.f * BS, 10.f * BS), 0.01));
+	UASSERT_EXP(speed_f.equals(v3f(), 0.01));
 }
 
 void TestCollision::testCollisionMoveSimple_corner()
@@ -522,7 +522,7 @@ void TestCollision::testCollisionMoveSimple_corner()
 		v3f(), nullptr,
 		false);
 	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
-	UASSERT(res.collides);
-	UASSERT(pos_f.equals(v3f(11.f * BS, 10.f * BS, 11.f * BS), 0.01));
-	UASSERT(speed_f.equals(v3f(), 0.01));
+	UASSERT_EXP(res.collides);
+	UASSERT_EXP(pos_f.equals(v3f(11.f * BS, 10.f * BS, 11.f * BS), 0.01));
+	UASSERT_EXP(speed_f.equals(v3f(), 0.01));
 }

--- a/src/unittest/test_collision.cpp
+++ b/src/unittest/test_collision.cpp
@@ -31,7 +31,9 @@ public:
 	void runTests(IGameDef *gamedef);
 
 	void testAxisAlignedCollision();
-	void testCollisionMoveSimple();
+	void testCollisionMoveSimple_collide();
+	void testCollisionMoveSimple_stepup();
+	void testCollisionMoveSimple_ceiling();
 };
 
 static TestCollision g_test_instance;
@@ -39,7 +41,9 @@ static TestCollision g_test_instance;
 void TestCollision::runTests(IGameDef *gamedef)
 {
 	TEST(testAxisAlignedCollision);
-	TEST(testCollisionMoveSimple);
+	TEST(testCollisionMoveSimple_collide);
+	TEST(testCollisionMoveSimple_stepup);
+	TEST(testCollisionMoveSimple_ceiling);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -185,7 +189,7 @@ void TestCollision::testAxisAlignedCollision()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TestCollision::testCollisionMoveSimple()
+void TestCollision::testCollisionMoveSimple_collide()
 {
 	// Create test environment
 	MockEnvironment env(std::cerr);
@@ -202,10 +206,72 @@ void TestCollision::testCollisionMoveSimple()
 	v3f pos_f(10.f * BS, 10.f * BS, 10.f * BS);
 	v3f speed_f(3.f * BS, 0.f * BS, 0.f * BS);
 	
-	// Run test
+	// Run simple test
 	collisionMoveResult res = collisionMoveSimple(&env, env.getGameDef(),
 		BS*0.25, box_0,
 		0.0f, 0.5f,
+		&pos_f, &speed_f,
+		v3f(), nullptr,
+		false);
+	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
+	UASSERT(res.collides);
+	UASSERT(pos_f.equals(v3f(11.f * BS, 10.f * BS, 10.f * BS), 0.01));
+	UASSERT(speed_f.equals(v3f(), 0.01));
+}
+
+void TestCollision::testCollisionMoveSimple_stepup()
+{
+	// Create test environment
+	MockEnvironment env(std::cerr);
+	ContentFeatures cf;
+	cf.name = "solid";
+	cf.walkable = true;
+	content_t solid = env.getMockGameDef()->registerContent(cf.name, cf);
+	MockMap &map = env.getMockMap();
+	
+	map.setMockNode(v3s16(12, 10, 10), solid);
+
+	// Set up test
+	aabb3f box_0(-.5f * BS, -.5f * BS, -.5f * BS, .5f * BS, .5f * BS, .5f * BS);
+	v3f pos_f(10.f * BS, 10.f * BS, 10.f * BS);
+	v3f speed_f(4.f * BS, 0.f * BS, 0.f * BS);
+	
+	// Run simple test
+	collisionMoveResult res = collisionMoveSimple(&env, env.getGameDef(),
+		0.25*BS, box_0,
+		1.1f*BS, 0.5f,
+		&pos_f, &speed_f,
+		v3f(), nullptr,
+		false);
+	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
+	UASSERT(!res.collides);
+	UASSERT(pos_f.equals(v3f(12.f * BS, 11.f * BS, 10.f * BS), 0.01));
+	UASSERT(speed_f.equals(v3f(4.f, 0.f, 0.f) * BS, 0.01));
+}
+
+void TestCollision::testCollisionMoveSimple_ceiling()
+{
+	// Create test environment
+	MockEnvironment env(std::cerr);
+	ContentFeatures cf;
+	cf.name = "solid";
+	cf.walkable = true;
+	content_t solid = env.getMockGameDef()->registerContent(cf.name, cf);
+	MockMap &map = env.getMockMap();
+	
+	map.setMockNode(v3s16(12, 10, 10), solid);
+	map.setMockNode(v3s16(11, 11, 10), solid);
+
+	aabb3f box_0(-.5f * BS, -.5f * BS, -.5f * BS, .5f * BS, .5f * BS, .5f * BS);
+	v3f pos_f(10.f * BS, 10.f * BS, 10.f * BS);
+	v3f speed_f(4.f * BS, 0.f * BS, 0.f * BS);
+	
+	// 1. stepbox is used to detect collisions with the ceiling when
+	// stepping up, but it is computed at time dtime instead of 
+	// nearest_dtime, so is checking in the wrong location.
+	collisionMoveResult res = collisionMoveSimple(&env, env.getGameDef(),
+		0.25*BS, box_0,
+		1.1f*BS, 0.5f,
 		&pos_f, &speed_f,
 		v3f(), nullptr,
 		false);

--- a/src/unittest/test_collision.cpp
+++ b/src/unittest/test_collision.cpp
@@ -40,6 +40,7 @@ public:
 	void testCollisionMoveSimple_stepuproom();
 	void testCollisionMoveSimple_longclimb();
 	void testCollisionMoveSimple_bouncy();
+	void testCollisionMoveSimple_corner();
 };
 
 static TestCollision g_test_instance;
@@ -56,6 +57,7 @@ void TestCollision::runTests(IGameDef *gamedef)
 	TEST(testCollisionMoveSimple_stepuproom);
 	TEST(testCollisionMoveSimple_longclimb);
 	TEST(testCollisionMoveSimple_bouncy);
+	TEST(testCollisionMoveSimple_corner);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -492,5 +494,35 @@ void TestCollision::testCollisionMoveSimple_bouncy()
 	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
 	UASSERT(!res.collides);
 	UASSERT(pos_f.equals(v3f(8.f * BS, 10.f * BS, 10.f * BS), 0.01));
+	UASSERT(speed_f.equals(v3f(), 0.01));
+}
+
+void TestCollision::testCollisionMoveSimple_corner()
+{
+	// Create test environment
+	MockEnvironment env(std::cerr);
+	ContentFeatures cf;
+	cf.name = "solid";
+	cf.walkable = true;
+	content_t solid = env.getMockGameDef()->registerContent(cf.name, cf);
+	MockMap &map = env.getMockMap();
+	
+	map.setMockNode(v3s16(12, 10, 12), solid);
+
+	// Set up test
+	aabb3f box_0(-.5f * BS, -.5f * BS, -.5f * BS, .5f * BS, .5f * BS, .5f * BS);
+	v3f pos_f(10.f * BS, 10.f * BS, 10.f * BS);
+	v3f speed_f(4.f * BS, 0.f * BS, 4.f * BS);
+	
+	// Run simple test
+	collisionMoveResult res = collisionMoveSimple(&env, env.getGameDef(),
+		BS*0.25, box_0,
+		0.0f, 0.5f,
+		&pos_f, &speed_f,
+		v3f(), nullptr,
+		false);
+	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
+	UASSERT(res.collides);
+	UASSERT(pos_f.equals(v3f(11.f * BS, 10.f * BS, 11.f * BS), 0.01));
 	UASSERT(speed_f.equals(v3f(), 0.01));
 }

--- a/src/unittest/test_collision.cpp
+++ b/src/unittest/test_collision.cpp
@@ -290,9 +290,9 @@ void TestCollision::testCollisionMoveSimple_ceiling()
 		v3f(), nullptr,
 		false);
 	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
-	UASSERT_EXP(res.collides);
-	UASSERT_EXP(pos_f.equals(v3f(11.f * BS, 10.f * BS, 10.f * BS), 0.01));
-	UASSERT_EXP(speed_f.equals(v3f(), 0.01));
+	EXPECT_FAIL(UASSERT(res.collides));
+	EXPECT_FAIL(UASSERT(pos_f.equals(v3f(11.f * BS, 10.f * BS, 10.f * BS), 0.01)));
+	EXPECT_FAIL(UASSERT(speed_f.equals(v3f(), 0.01)));
 }
 
 void TestCollision::testCollisionMoveSimple_giantstepup()
@@ -322,9 +322,9 @@ void TestCollision::testCollisionMoveSimple_giantstepup()
 		v3f(), nullptr,
 		false);
 	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
-	UASSERT_EXP(!res.collides);
-	UASSERT_EXP(pos_f.equals(v3f(12.f * BS, 13.f * BS, 10.f * BS), 0.01));
-	UASSERT_EXP(speed_f.equals(v3f(4.f, 0.f, 0.f) * BS, 0.01));
+	EXPECT_FAIL(UASSERT(!res.collides));
+	EXPECT_FAIL(UASSERT(pos_f.equals(v3f(12.f * BS, 13.f * BS, 10.f * BS), 0.01)));
+	EXPECT_FAIL(UASSERT(speed_f.equals(v3f(4.f, 0.f, 0.f) * BS, 0.01)));
 }
 
 void TestCollision::testCollisionMoveSimple_giantceiling()
@@ -425,9 +425,9 @@ void TestCollision::testCollisionMoveSimple_longclimb()
 		v3f(), nullptr,
 		false);
 	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
-	UASSERT_EXP(res.collides);
-	UASSERT_EXP(pos_f.equals(v3f(13.f * BS, 12.f * BS, 10.f * BS), 0.01));
-	UASSERT_EXP(speed_f.equals(v3f(), 0.01));
+	EXPECT_FAIL(UASSERT(res.collides));
+	EXPECT_FAIL(UASSERT(pos_f.equals(v3f(13.f * BS, 12.f * BS, 10.f * BS), 0.01)));
+	EXPECT_FAIL(UASSERT(speed_f.equals(v3f(), 0.01)));
 }
 
 void TestCollision::testCollisionMoveSimple_shortstepup()
@@ -492,9 +492,9 @@ void TestCollision::testCollisionMoveSimple_bouncy()
 		v3f(), nullptr,
 		false);
 	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
-	UASSERT_EXP(!res.collides);
-	UASSERT_EXP(pos_f.equals(v3f(8.f * BS, 10.f * BS, 10.f * BS), 0.01));
-	UASSERT_EXP(speed_f.equals(v3f(), 0.01));
+	EXPECT_FAIL(UASSERT(!res.collides));
+	EXPECT_FAIL(UASSERT(pos_f.equals(v3f(8.f * BS, 10.f * BS, 10.f * BS), 0.01)));
+	EXPECT_FAIL(UASSERT(speed_f.equals(v3f(), 0.01)));
 }
 
 void TestCollision::testCollisionMoveSimple_corner()
@@ -522,7 +522,7 @@ void TestCollision::testCollisionMoveSimple_corner()
 		v3f(), nullptr,
 		false);
 	rawstream << "Now at (" << pos_f.X << ',' << pos_f.Y << ',' << pos_f.Z << ')' << std::endl;
-	UASSERT_EXP(res.collides);
-	UASSERT_EXP(pos_f.equals(v3f(11.f * BS, 10.f * BS, 11.f * BS), 0.01));
-	UASSERT_EXP(speed_f.equals(v3f(), 0.01));
+	EXPECT_FAIL(UASSERT(res.collides));
+	EXPECT_FAIL(UASSERT(pos_f.equals(v3f(11.f * BS, 10.f * BS, 11.f * BS), 0.01)));
+	EXPECT_FAIL(UASSERT(speed_f.equals(v3f(), 0.01)));
 }

--- a/src/unittest/test_collision.cpp
+++ b/src/unittest/test_collision.cpp
@@ -199,18 +199,18 @@ void TestCollision::testCollisionMoveSimple()
         setDef(definition, 11, 11, 10, 'S');
         setDef(definition, 12, 11, 10, 'S');
         setDef(definition, 13, 11, 10, 'S');
-	MockEnvironment env(std::stderr);
+	MockEnvironment env(std::cerr);
 	env.getMockMap().CreateSector(v2s16(0,0), definition);
 	aabb3f box_0(9.5f, 9.5f, 9.5f, 10.5f, 10.5f, 10.5f);
 	v3f pos_f(10.f, 10.f, 10.f);
 	v3f speed_f(3.f, 0.f, 0.f);
 	
-	UASSERT(collisionMoveSimple(&env, env.getGameDef(),
-                BS*0.25, box_0,
-                0.0f, 0.5f,
-                &pos_f, &speed_f,
-                v3f(), NULL,
-                false).collides);
-	UASSERT(pos_f.equals(v3f(11f, 10f, 10f), 0.01));
-	UASSERT(speed_f.equals(v3f(), 0.01));
+//	UASSERT(collisionMoveSimple(&env, env.getGameDef(),
+//                BS*0.25, box_0,
+//                0.0f, 0.5f,
+//                &pos_f, &speed_f,
+//                v3f(), NULL,
+//                false).collides);
+//	UASSERT(pos_f.equals(v3f(11.f, 10.f, 10.f), 0.01));
+//	UASSERT(speed_f.equals(v3f(), 0.01));
 }

--- a/src/unittest/test_collision.cpp
+++ b/src/unittest/test_collision.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "test.h"
 
 #include "collision.h"
+#include "mockgame.h"
 
 class TestCollision : public TestBase {
 public:
@@ -29,6 +30,7 @@ public:
 	void runTests(IGameDef *gamedef);
 
 	void testAxisAlignedCollision();
+	void testCollisionMoveSimple();
 };
 
 static TestCollision g_test_instance;
@@ -36,6 +38,7 @@ static TestCollision g_test_instance;
 void TestCollision::runTests(IGameDef *gamedef)
 {
 	TEST(testAxisAlignedCollision);
+	TEST(testCollisionMoveSimple);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -177,4 +180,37 @@ void TestCollision::testAxisAlignedCollision()
 			UASSERT(fabs(dtime - 16.1) < 0.001);
 		}
 	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void setDef(std::string &definition, s16 x, s16 y, s16 z, char c)
+{
+	s16 b = y / MAP_BLOCKSIZE;
+        y -= b * MAP_BLOCKSIZE;
+	definition[b * MapBlock::nodecount + z * MapBlock::zstride + y * MapBlock::ystride + x] = c;
+}
+
+void TestCollision::testCollisionMoveSimple()
+{
+	std::string definition(MapBlock::nodecount, ' ');
+        setDef(definition, 12, 10, 10, 'S');
+        setDef(definition, 13, 10, 10, 'S');
+        setDef(definition, 11, 11, 10, 'S');
+        setDef(definition, 12, 11, 10, 'S');
+        setDef(definition, 13, 11, 10, 'S');
+	MockEnvironment env(std::stderr);
+	env.getMockMap().CreateSector(v2s16(0,0), definition);
+	aabb3f box_0(9.5f, 9.5f, 9.5f, 10.5f, 10.5f, 10.5f);
+	v3f pos_f(10.f, 10.f, 10.f);
+	v3f speed_f(3.f, 0.f, 0.f);
+	
+	UASSERT(collisionMoveSimple(&env, env.getGameDef(),
+                BS*0.25, box_0,
+                0.0f, 0.5f,
+                &pos_f, &speed_f,
+                v3f(), NULL,
+                false).collides);
+	UASSERT(pos_f.equals(v3f(11f, 10f, 10f), 0.01));
+	UASSERT(speed_f.equals(v3f(), 0.01));
 }


### PR DESCRIPTION
This PR adds unittests to help clarify issues with collision detection code (Issue 5966).

There are a set of classes in `unittest/mockgame.h` and `mockgame.cpp` to create a mock environment for conducting the tests. Each test sets up a map with a few nodes and tests one initial condition for collisionMoveSimple(). The final entity position is written to `rawstream` to aid with understanding why the test failed. 

## To do
* `unittest.cpp` also creates a mock game and makes it available to the unittests. The two mock game implementations should be merged.
* The test cases have extensive code in common. They should be refactored to improve maintainability.
* The current set of tests is optimized to highlight suspected problems found in a code review. The set of test cases should be expanded to identify more potential bugs. In particular, the tests only exercise motion in one direction.
* Some of the physics underlying the collision logic is not well-defined. I avoided a few test cases because I wasn't sure what the correct behavior ought to be.
* I have only tested on Windows compiled with `buildbot`.

This PR is Ready for Review.

## How to test
1. Ensure CMake is configured with `BUILD_UNITTESTS` enabled.
2. Build minetest. Install if necessary.
2. Open a console and change directory to where the minetest binary is located.
2. I recommend deleting or archiving the `../debug.txt` to make it easier to find the unittest results.
3. Execute `minetest --run-unittests`.
4. Inspect `../debug.txt`. Search for "Collision."  You should see 10 tests in this section, with 4 of them failing.
