### PR TITLE
Log server announce on updates and deletes too

### DIFF
--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -264,7 +264,7 @@ void sendAnnounce(AnnounceAction action,
 	} else {
 		infostream << "Announcing " << action << " to " <<
 			g_settings->get("serverlist_url") << std::endl;
-	}		
+	}
 
 	HTTPFetchRequest fetch_request;
 	fetch_request.url = g_settings->get("serverlist_url") + std::string("/announce");

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -258,7 +258,7 @@ void sendAnnounce(AnnounceAction action,
 			server["lag"] = lag;
 	}
 
-	actionstream << "Announcing " + action + " to " << g_settings->get("serverlist_url") << std::endl;
+	actionstream << "Announcing " << action << " to " << g_settings->get("serverlist_url") << std::endl;
 	HTTPFetchRequest fetch_request;
 	fetch_request.url = g_settings->get("serverlist_url") + std::string("/announce");
 	fetch_request.post_fields["json"] = fastWriteJson(server);

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -259,10 +259,10 @@ void sendAnnounce(AnnounceAction action,
 	}
 
 	if (action == AA_START) {
-		actionstream << "Announcing " << action << " to " <<
+		actionstream << "Announcing " << aa_names[action] << " to " <<
 			g_settings->get("serverlist_url") << std::endl;
 	} else {
-		infostream << "Announcing " << action << " to " <<
+		infostream << "Announcing " << aa_names[action] << " to " <<
 			g_settings->get("serverlist_url") << std::endl;
 	}
 

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -257,8 +257,14 @@ void sendAnnounce(AnnounceAction action,
 		if (lag)
 			server["lag"] = lag;
 	}
+	
+	if (action ==  AA_START) {
+		actionstream << "Announcing " << action << " to " << g_settings->get("serverlist_url") << std::endl;
+	} else {
+		infostream << "Announcing " << action << " to " << g_settings->get("serverlist_url") << std::endl;
+	}		
 
-	actionstream << "Announcing " << action << " to " << g_settings->get("serverlist_url") << std::endl;
+	
 	HTTPFetchRequest fetch_request;
 	fetch_request.url = g_settings->get("serverlist_url") + std::string("/announce");
 	fetch_request.post_fields["json"] = fastWriteJson(server);

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -253,12 +253,12 @@ void sendAnnounce(AnnounceAction action,
 		for (const ModSpec &mod : mods) {
 			server["mods"].append(mod.name);
 		}
-		actionstream << "Announcing to " << g_settings->get("serverlist_url") << std::endl;
 	} else if (action == AA_UPDATE) {
 		if (lag)
 			server["lag"] = lag;
 	}
 
+	actionstream << "Announcing " + action + " to " << g_settings->get("serverlist_url") << std::endl;
 	HTTPFetchRequest fetch_request;
 	fetch_request.url = g_settings->get("serverlist_url") + std::string("/announce");
 	fetch_request.post_fields["json"] = fastWriteJson(server);

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -257,14 +257,15 @@ void sendAnnounce(AnnounceAction action,
 		if (lag)
 			server["lag"] = lag;
 	}
-	
-	if (action ==  AA_START) {
-		actionstream << "Announcing " << action << " to " << g_settings->get("serverlist_url") << std::endl;
+
+	if (action == AA_START) {
+		actionstream << "Announcing " << action << " to " <<
+			g_settings->get("serverlist_url") << std::endl;
 	} else {
-		infostream << "Announcing " << action << " to " << g_settings->get("serverlist_url") << std::endl;
+		infostream << "Announcing " << action << " to " <<
+			g_settings->get("serverlist_url") << std::endl;
 	}		
 
-	
 	HTTPFetchRequest fetch_request;
 	fetch_request.url = g_settings->get("serverlist_url") + std::string("/announce");
 	fetch_request.post_fields["json"] = fastWriteJson(server);


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
I am troubleshooting an issue where the START announce seems to be sent, but the UPDATE never is... And I realized that the logs don't even tell you when the server is announcing itself. Seems to me like it should?

- How does the PR work?
Instead of only sending the announce-announcement when doing a START announce, send it any time you do any kind of announce.
- Does it resolve any reported issue?
Don't think so.
- If not a bug fix, why is this PR needed? What usecases does it solve?
The same use case as reporting the ANNOUNCE in the first place, but it also gives an indication of when the other announces are happening - which may be useful when troubleshooting things like... Why does my server get removed from the server list after 5 minutes.

## To do

Ready for Review. Though... somewhat lazily, because I don't really have a C++ environment so I'm kind of hoping that the tests will catch anything. Heads up to any reviewers... this PR is more of a suggestion than something thoroughly tested!
<!-- ^ delete one -->

## How to test

Start a server with announce enabled and stop it after 6 minutes. You should see a START announce, an UPDATE, and a DELETE.
