### PR TITLE
Revert "Auto delete MetaData when = 0"

### DIFF
--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -153,9 +153,7 @@ int MetaDataRef::l_set_int(lua_State *L)
 	MetaDataRef *ref = checkobject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	int a = luaL_checkint(L, 3);
-	std::string str;
-	if (a != 0)
-		str = itos(a);
+	std::string str = itos(a);
 
 	Metadata *meta = ref->getmeta(true);
 	if (meta == NULL || str == meta->getString(name))
@@ -193,9 +191,7 @@ int MetaDataRef::l_set_float(lua_State *L)
 	MetaDataRef *ref = checkobject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	float a = readParam<float>(L, 3);
-	std::string str;
-	if (a != 0)
-		str = ftos(a);
+	std::string str = ftos(a);
 
 	Metadata *meta = ref->getmeta(true);
 	if (meta == NULL || str == meta->getString(name))


### PR DESCRIPTION
Reverts minetest/minetest#8770, closes #10180

In a clean API, fields should only be deleted if set to `nil`. We are maintaining deletion of `""` values only for the sake of backwards compatibility.