### PR TITLE
Change default ambient occlusion gamma to 1.8

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -228,7 +228,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("show_entity_selectionbox", "true");
 	settings->setDefault("texture_clean_transparent", "false");
 	settings->setDefault("texture_min_size", "64");
-	settings->setDefault("ambient_occlusion_gamma", "2.2");
+	settings->setDefault("ambient_occlusion_gamma", "1.8");
 #if ENABLE_GLES
 	settings->setDefault("enable_shaders", "false");
 #else


### PR DESCRIPTION
implements #9865 (compromise) 

The change is subtle but adds more depth to terrain:
![screenshot_20200714_135125](https://user-images.githubusercontent.com/1042418/87423712-04f69500-c5db-11ea-8669-d98475089df8.png)
<b>⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓⇓</b>
![screenshot_20200714_135103](https://user-images.githubusercontent.com/1042418/87423754-1c358280-c5db-11ea-9aa8-31aa735d0c4b.png)


## To do

This PR is Ready for Review.
