### PR TITLE
Fix crash when exit to Windows

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1162,7 +1162,10 @@ void Game::shutdown()
 	g_touchscreengui->hide();
 #endif
 
+#ifndef _MSC_VER
+	// calling draw_load_screen while deinitalizing crashes graphic driver.
 	showOverlayMessage(N_("Shutting down..."), 0, 0, false);
+#endif // !_MSC_VER
 
 	if (clouds)
 		clouds->drop();


### PR DESCRIPTION
When using the Exit to OS button while on a server the game crashes silently, no settings are saved.

I'm not sure if this is compiler or platform specific.
Edit: The official Windows 5.3.0 build is broken too

This Pr fixes the issue, as it avoids rendering a loading screen while deinitialising.

## To do

- [ ] test on other platforms

This PR is a Work in Progress
<!-- ^ delete one -->


## How to test

Download a build from GitHub actions, join a server, click exit To OS

Before this PR -> no minetest.conf is generated, `Ausnahme ausgelöst bei 0x00007FFD21A35883 (ig9icd64.dll) in minetest.exe: 0xC0000005: Zugriffsverletzung beim Lesen an Position 0xFFFFFFFFFFFFFFFF. `
With this PR -> minetest.conf is generated, clean exit
<!-- Example code or instructions -->
