### PR TITLE
Add register_on_removeplayer to remove player data in mod storage or databases

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -598,6 +598,7 @@ core.registered_on_respawnplayers, core.register_on_respawnplayer = make_registr
 core.registered_on_prejoinplayers, core.register_on_prejoinplayer = make_registration()
 core.registered_on_joinplayers, core.register_on_joinplayer = make_registration()
 core.registered_on_leaveplayers, core.register_on_leaveplayer = make_registration()
+core.registered_on_removeplayers, core.register_on_removeplayer = make_registration()
 core.registered_on_player_receive_fields, core.register_on_player_receive_fields = make_registration_reverse()
 core.registered_on_cheats, core.register_on_cheat = make_registration()
 core.registered_on_crafts, core.register_on_craft = make_registration()

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -34,6 +34,7 @@ local register_functions = {
 	register_on_prejoinplayer = 0,
 	register_on_joinplayer = 0,
 	register_on_leaveplayer = 0,
+	register_on_removeplayer = 0,
 	register_on_cheat = 0,
 	register_on_chat_message = 0,
 	register_on_player_receive_fields = 0,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4497,6 +4497,9 @@ Call these functions only at load time!
 * `minetest.register_on_leaveplayer(function(ObjectRef, timed_out))`
     * Called when a player leaves the game
     * `timed_out`: True for timeout, false for other reasons.
+* `minetest.register_on_removeplayer(function(name))`
+    * Called after minetest.remove_player
+    * Remove player data in databases or mod storages on this callback
 * `minetest.register_on_authplayer(function(name, ip, is_success))`
     * Called when a client attempts to log into an account.
     * `name`: The name of the account being authenticated.

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -177,6 +177,17 @@ void ScriptApiPlayer::on_leaveplayer(ServerActiveObject *player,
 	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
 }
 
+void ScriptApiPlayer::on_removeplayer(const std::string &name)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_removeplayers
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_removeplayers");
+	lua_pushstring(L, name.c_str());
+	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
+}
+
 void ScriptApiPlayer::on_cheat(ServerActiveObject *player,
 		const std::string &cheat_type)
 {

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -43,6 +43,7 @@ public:
 	bool can_bypass_userlimit(const std::string &name, const std::string &ip);
 	void on_joinplayer(ServerActiveObject *player, s64 last_login);
 	void on_leaveplayer(ServerActiveObject *player, bool timeout);
+	void on_removeplayer(const std::string &name);
 	void on_cheat(ServerActiveObject *player, const std::string &cheat_type);
 	bool on_punchplayer(ServerActiveObject *player, ServerActiveObject *hitter,
 			float time_from_last_punch, const ToolCapabilities *toolcap,

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -546,7 +546,11 @@ void ServerEnvironment::removePlayer(RemotePlayer *player)
 
 bool ServerEnvironment::removePlayerFromDatabase(const std::string &name)
 {
-	return m_player_database->removePlayer(name);
+	if (m_player_database->removePlayer(name)) {
+		m_script->on_removeplayer(name);
+		return true;
+	}
+	return false;
 }
 
 void ServerEnvironment::kickAllPlayers(AccessDeniedCode reason,


### PR DESCRIPTION
## Problem

Mods store more and more player data in mod-storages and other databases
If you want to delete a player with all it's data you have to do this for each mod extra.
This can be really annoying and often even impossible as a lot of mods doesn't provide a function to remove their data.

## Solution

This PR adds a minetest.register_on_removeplayer(function(name)) register.
It will be called on successful minetest.remove_player
This allows and pushes mod creators to create a function for player removal.

## How to test

``` Lua
minetest.register_on_removeplayer(function(name)
  minetest.log("error", "removed "..name)
end)
```
