### PR TITLE
Update serialize.lua to strip userdata

### DIFF
--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -115,6 +115,7 @@ function core.serialize(x)
 	function dump_val(x)
 		local  tp = type(x)
 		if     x  == nil        then return "nil"
+		elseif tp == "userdata" then return "nil"
 		elseif tp == "string"   then return string.format("%q", x)
 		elseif tp == "boolean"  then return x and "true" or "false"
 		elseif tp == "function" then


### PR DESCRIPTION
This change stops the following error by stripping userdata from serialized data (thanks MoNTE48):
```
LuaError: Runtime error from mod 'mobs_monster' in callback luaentity_GetStaticdata(): ...Library/Application Support/builtin/common/serialize.lua:151: Can't serialize data of type userdata stack traceback: