### PR TITLE
Add font styling options to tables and textlists

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1225,6 +1225,7 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 
 		auto style = getDefaultStyleForElement("table", name);
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+		e->setOverrideFont(style.getFont());
 
 		m_tables.emplace_back(spec, e);
 		m_fields.push_back(spec);
@@ -1302,6 +1303,7 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 
 		auto style = getDefaultStyleForElement("textlist", name);
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+		e->setOverrideFont(style.getFont());
 
 		m_tables.emplace_back(spec, e);
 		m_fields.push_back(spec);

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -56,7 +56,7 @@ GUITable::GUITable(gui::IGUIEnvironment *env,
 	m_font = skin->getFont();
 	if (m_font) {
 		m_font->grab();
-		m_rowheight = m_font->getDimension(L"A").Height + 4;
+		m_rowheight = m_font->getDimension(L"Ay").Height + 4;
 		m_rowheight = MYMAX(m_rowheight, 1);
 	}
 
@@ -584,6 +584,31 @@ void GUITable::setSelected(s32 index)
 	if (m_selected != old_selected || selection_invisible) {
 		autoScroll();
 	}
+}
+
+void GUITable::setOverrideFont(IGUIFont *font)
+{
+	if (m_font == font)
+		return;
+
+	if (font == nullptr)
+		font = Environment->getSkin()->getFont();
+
+	if (m_font)
+		m_font->drop();
+
+	m_font = font;
+	m_font->grab();
+
+	m_rowheight = m_font->getDimension(L"Ay").Height + 4;
+	m_rowheight = MYMAX(m_rowheight, 1);
+
+	updateScrollBar();
+}
+
+IGUIFont *GUITable::getOverrideFont() const
+{
+	return m_font;
 }
 
 GUITable::DynamicData GUITable::getDynamicData() const

--- a/src/gui/guiTable.h
+++ b/src/gui/guiTable.h
@@ -123,6 +123,12 @@ public:
 	// Autoscroll to make the selected row fully visible
 	void setSelected(s32 index);
 
+	//! Sets another skin independent font. If this is set to zero, the button uses the font of the skin.
+	virtual void setOverrideFont(gui::IGUIFont *font = nullptr);
+
+	//! Gets the override font (if any)
+	virtual gui::IGUIFont *getOverrideFont() const;
+
 	/* Get selection, scroll position and opened (sub)trees */
 	DynamicData getDynamicData() const;
 


### PR DESCRIPTION
Fixes #10194 by adding the ability to style fonts for tables and textlists.

![image](https://user-images.githubusercontent.com/31123645/87862761-6e8ee000-c908-11ea-917c-c6eb02199c37.png)

## To do

This PR is Ready for Review.  It's a simple one.

## How to test

The above formspec:
```
formspec_version[3]
size[12,7]
style_type[button;font=bold;font_size=+1]
button[0,0;12,0.5;;Table and Textlist Fonts]
style_type[table,field;font=mono;font_size=-1]
table[0,0.5;6,6;;Minetest DOS Version 3.14.159,Copyright (c) 2020 TestMine Corporation,,/this/is/a/table> cd /,/> _;5]
style_type[textlist;font=italic]
textlist[6,0.5;6,6;;#FF0000Textlist Warning:,Extreme fonts detected! Proceed with caution.,,Press the Any key to continue...]
field[0,6.5;12,0.5;f;;md fonts-are-cool]
```