### PR TITLE
Replace std::list<session_t> in networking code

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1269,7 +1269,8 @@ bool Connection::deletePeer(session_t peer_id, bool timeout)
 			return false;
 		peer = m_peers[peer_id];
 		m_peers.erase(peer_id);
-		m_peer_ids.remove(peer_id);
+		auto it = std::find(m_peer_ids.begin(), m_peer_ids.end(), peer_id);
+		m_peer_ids.erase(it);
 	}
 
 	Address peer_address;

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -30,7 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "networkprotocol.h"
 #include <iostream>
 #include <fstream>
-#include <list>
+#include <vector>
 #include <map>
 
 class NetworkPacket;
@@ -795,7 +795,7 @@ protected:
 
 	void PrintInfo(std::ostream &out);
 
-	std::list<session_t> getPeerIDs()
+	std::vector<session_t> getPeerIDs()
 	{
 		MutexAutoLock peerlock(m_peers_mutex);
 		return m_peer_ids;
@@ -816,7 +816,7 @@ private:
 	u32 m_protocol_id;
 
 	std::map<session_t, Peer *> m_peers;
-	std::list<session_t> m_peer_ids;
+	std::vector<session_t> m_peer_ids;
 	std::mutex m_peers_mutex;
 
 	std::unique_ptr<ConnectionSendThread> m_sendThread;

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -845,11 +845,9 @@ void *ConnectionReceiveThread::run()
 
 			std::vector<session_t> peerids = m_connection->getPeerIDs();
 
-			for (auto i = peerids.begin();
-					i != peerids.end();
-					i++)
+			for (auto id : peerids)
 			{
-				PeerHelper peer = m_connection->getPeerNoEx(*i);
+				PeerHelper peer = m_connection->getPeerNoEx(id);
 				if (!peer)
 					continue;
 

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -144,7 +144,7 @@ void ConnectionSendThread::Trigger()
 
 bool ConnectionSendThread::packetsQueued()
 {
-	std::list<session_t> peerIds = m_connection->getPeerIDs();
+	std::vector<session_t> peerIds = m_connection->getPeerIDs();
 
 	if (!m_outgoing_queue.empty() && !peerIds.empty())
 		return true;
@@ -171,8 +171,8 @@ bool ConnectionSendThread::packetsQueued()
 
 void ConnectionSendThread::runTimeouts(float dtime)
 {
-	std::list<session_t> timeouted_peers;
-	std::list<session_t> peerIds = m_connection->getPeerIDs();
+	std::vector<session_t> timeouted_peers;
+	std::vector<session_t> peerIds = m_connection->getPeerIDs();
 
 	for (session_t &peerId : peerIds) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerId);
@@ -548,7 +548,7 @@ void ConnectionSendThread::disconnect()
 
 
 	// Send to all
-	std::list<session_t> peerids = m_connection->getPeerIDs();
+	std::vector<session_t> peerids = m_connection->getPeerIDs();
 
 	for (session_t peerid : peerids) {
 		sendAsPacket(peerid, 0, data, false);
@@ -620,7 +620,7 @@ void ConnectionSendThread::sendReliable(ConnectionCommand &c)
 
 void ConnectionSendThread::sendToAll(u8 channelnum, const SharedBuffer<u8> &data)
 {
-	std::list<session_t> peerids = m_connection->getPeerIDs();
+	std::vector<session_t> peerids = m_connection->getPeerIDs();
 
 	for (session_t peerid : peerids) {
 		send(peerid, channelnum, data);
@@ -629,7 +629,7 @@ void ConnectionSendThread::sendToAll(u8 channelnum, const SharedBuffer<u8> &data
 
 void ConnectionSendThread::sendToAllReliable(ConnectionCommand &c)
 {
-	std::list<session_t> peerids = m_connection->getPeerIDs();
+	std::vector<session_t> peerids = m_connection->getPeerIDs();
 
 	for (session_t peerid : peerids) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerid);
@@ -643,8 +643,8 @@ void ConnectionSendThread::sendToAllReliable(ConnectionCommand &c)
 
 void ConnectionSendThread::sendPackets(float dtime)
 {
-	std::list<session_t> peerIds = m_connection->getPeerIDs();
-	std::list<session_t> pendingDisconnect;
+	std::vector<session_t> peerIds = m_connection->getPeerIDs();
+	std::vector<session_t> pendingDisconnect;
 	std::map<session_t, bool> pending_unreliable;
 
 	const unsigned int peer_packet_quota = m_iteration_packets_avaialble
@@ -843,9 +843,9 @@ void *ConnectionReceiveThread::run()
 		if (debug_print_timer > 20.0) {
 			debug_print_timer -= 20.0;
 
-			std::list<session_t> peerids = m_connection->getPeerIDs();
+			std::vector<session_t> peerids = m_connection->getPeerIDs();
 
-			for (std::list<session_t>::iterator i = peerids.begin();
+			for (auto i = peerids.begin();
 					i != peerids.end();
 					i++)
 			{
@@ -1039,7 +1039,7 @@ void ConnectionReceiveThread::receive(SharedBuffer<u8> &packetdata,
 
 bool ConnectionReceiveThread::getFromBuffers(session_t &peer_id, SharedBuffer<u8> &dst)
 {
-	std::list<session_t> peerids = m_connection->getPeerIDs();
+	std::vector<session_t> peerids = m_connection->getPeerIDs();
 
 	for (session_t peerid : peerids) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerid);


### PR DESCRIPTION
Putting a bunch of numbers into a linked-list is inefficient, which has been annoying me when reading the code.

## To do

This PR is Ready for Review.

## How to test

Test that networking still works. There should be no functional changes.