### PR TITLE
Scale inventory image for scaled allfaces nodes

### DIFF
--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -514,6 +514,15 @@ local scale = function(subname, desc_double, desc_half)
 	minetest.register_node("testnodes:"..subname.."_half", def)
 end
 
+scale("allfaces",
+	S("Double-sized Allfaces Drawtype Test Node"),
+	S("Half-sized Allfaces Drawtype Test Node"))
+scale("allfaces_optional",
+	S("Double-sized Allfaces Optional Drawtype Test Node"),
+	S("Half-sized Allfaces Optional Drawtype Test Node"))
+scale("allfaces_optional_waving",
+	S("Double-sized Waving Allfaces Optional Drawtype Test Node"),
+	S("Half-sized Waving Allfaces Optional Drawtype Test Node"))
 scale("plantlike",
 	S("Double-sized Plantlike Drawtype Test Node"),
 	S("Half-sized Plantlike Drawtype Test Node"))

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -562,6 +562,8 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 			// add overlays
 			postProcessNodeMesh(mesh, f, false, false, nullptr,
 				&result->buffer_colors, true);
+			if (f.drawtype == NDT_ALLFACES)
+				scaleMesh(mesh, v3f(f.visual_scale, f.visual_scale, f.visual_scale));
 			break;
 		}
 		case NDT_PLANTLIKE: {

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -563,7 +563,7 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 			postProcessNodeMesh(mesh, f, false, false, nullptr,
 				&result->buffer_colors, true);
 			if (f.drawtype == NDT_ALLFACES)
-				scaleMesh(mesh, v3f(f.visual_scale, f.visual_scale, f.visual_scale));
+				scaleMesh(mesh, v3f(f.visual_scale));
 			break;
 		}
 		case NDT_PLANTLIKE: {


### PR DESCRIPTION
This PR does 2 things:

* The inventory image size of the inventory image of nodes with drawtype `allfaces` (and related) is scaled as well if `visual_scale` is set (previously, the inventory image size was always the same)
* Adds test nodes to `devtest`