### PR TITLE
Allow starting local server using --go again

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -327,13 +327,13 @@ void ClientLauncher::init_args(GameStartData &start_data, const Settings &cmd_ar
 		// Join a remote server
 		start_data.address = cmd_args.get("address");
 		start_data.world_path.clear();
+		start_data.name = g_settings->get("name");
 	}
 	if (!start_data.world_path.empty()) {
 		// Start a singleplayer instance
 		start_data.address = "";
 	}
 
-	start_data.name = g_settings->get("name");
 	if (cmd_args.exists("name"))
 		start_data.name = cmd_args.get("name");
 
@@ -419,7 +419,6 @@ bool ClientLauncher::launch_game(std::string &error_message,
 	/* Show the GUI menu
 	 */
 	std::string server_name, server_description;
-	start_data.local_server = false;
 	if (!skip_main_menu) {
 		// Initialize menu data
 		// TODO: Re-use existing structs (GameStartData)
@@ -467,6 +466,9 @@ bool ClientLauncher::launch_game(std::string &error_message,
 
 		start_data.local_server = !menudata.simple_singleplayer_mode &&
 			start_data.address.empty();
+	} else {
+		start_data.local_server = !start_data.world_path.empty() &&
+			start_data.address.empty() && !start_data.name.empty();
 	}
 
 	if (!RenderingEngine::run())


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/pull/10160#issuecomment-663932456

Apparently it was possible to start a local server by providing an empty address value. This is somewhat unintuitive, so here's a proper solution.


## To do

This PR is Ready for Review.

## How to test

```sh
# Local server
minetest --go --worldname WORLDNAME --name foobar

# Singleplayer
minetest --go --worldname WORLDNAME

# Remote server
minetest --go --address daconcepts.com --port 30001 --name foobar --password foobaz

# Remote server: Port and login from minetest.conf
minetest --go --address daconcepts.com
```
PS: The main menu is not touched at all, feel free to test it anyway if you feel like it.