### PR TITLE
Send attachments instantly before set_pos

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1805,6 +1805,9 @@ void Server::SendMovePlayer(session_t peer_id)
 	PlayerSAO *sao = player->getPlayerSAO();
 	assert(sao);
 
+	// Send attachment updates instantly to the client prior updating position
+	sao->sendOutdatedData();
+
 	NetworkPacket pkt(TOCLIENT_MOVE_PLAYER, sizeof(v3f) + sizeof(f32) * 2, peer_id);
 	pkt << sao->getBasePosition() << sao->getLookPitch() << sao->getRotation().Y;
 

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -483,6 +483,9 @@ void LuaEntitySAO::sendPosition(bool do_interpolate, bool is_movement_end)
 	if(isAttached())
 		return;
 
+	// Send attachment updates instantly to the client prior updating position
+	sendOutdatedData();
+
 	m_last_sent_move_precision = m_base_position.getDistanceFrom(
 			m_last_sent_position);
 	m_last_sent_position_timer = 0;


### PR DESCRIPTION
Fixes #9825
The attachment data is usually sent each entity step, but is sent instantly prior position updates. Both packets are within the same channel, so this should work pretty reliably.

## To do

This PR is  Ready for Review.

## How to test

```diff
diff --git a/mods/boats/init.lua b/mods/boats/init.lua
index f9ae8e0..3a110f6 100644
--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -60,9 +60,7 @@ function boat.on_rightclick(self, clicker)
                player_api.set_animation(clicker, "stand" , 30)
                local pos = clicker:get_pos()
                pos = {x = pos.x, y = pos.y + 0.2, z = pos.z}
-               minetest.after(0.1, function()
-                       clicker:set_pos(pos)
-               end)
+               clicker:set_pos(pos)
        elseif not self.driver then
                local attach = clicker:get_attach()
                if attach and attach:get_luaentity() then
```

1) Ride a boat
2) Attach and detach