### PR TITLE
[NEEDS TESTING/DISCUSSION] Consistently apply client-side prediction for inventory moves

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3678,13 +3678,7 @@ ItemStack GUIFormSpecMenu::verifySelectedItem()
 				InventoryList *list = inv->getList(m_selected_item->listname);
 				if (list && (u32) m_selected_item->i < list->getSize()) {
 					ItemStack stack = list->getItem(m_selected_item->i);
-					if (!m_selected_swap.empty()) {
-						if (m_selected_swap.name == stack.name &&
-								m_selected_swap.count == stack.count)
-							m_selected_swap.clear();
-					} else {
-						m_selected_amount = std::min(m_selected_amount, stack.count);
-					}
+					m_selected_amount = std::min(m_selected_amount, stack.count);
 
 					if (!stack.empty())
 						return stack;
@@ -4258,17 +4252,8 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			// they are swapped
 			if (leftover.count == stack_from.count &&
 					leftover.name == stack_from.name) {
-
-				if (m_selected_swap.empty()) {
-					m_selected_amount = stack_to.count;
-					m_selected_dragging = false;
-
-					// WARNING: BLACK MAGIC, BUT IN A REDUCED SET
-					// Skip next validation checks due async inventory calls
-					m_selected_swap = stack_to;
-				} else {
-					move = false;
-				}
+				m_selected_amount = stack_to.count;
+				m_selected_dragging = false;
 			}
 			// Source stack goes fully into destination stack
 			else if (leftover.empty()) {
@@ -4371,7 +4356,6 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 		// If m_selected_amount has been decreased to zero, deselect
 		if (m_selected_amount == 0) {
-			m_selected_swap.clear();
 			delete m_selected_item;
 			m_selected_item = nullptr;
 			m_selected_amount = 0;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -322,7 +322,6 @@ protected:
 	GUIInventoryList::ItemSpec *m_selected_item = nullptr;
 	u16 m_selected_amount = 0;
 	bool m_selected_dragging = false;
-	ItemStack m_selected_swap;
 
 	gui::IGUIStaticText *m_tooltip_element = nullptr;
 

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -546,12 +546,6 @@ void IMoveAction::clientApply(InventoryManager *mgr, IGameDef *gamedef)
 	if (!inv_from || !inv_to)
 		return;
 
-	InventoryLocation current_player;
-	current_player.setCurrentPlayer();
-	Inventory *inv_player = mgr->getInventory(current_player);
-	if (inv_from != inv_player || inv_to != inv_player)
-		return;
-
 	InventoryList *list_from = inv_from->getList(from_list);
 	InventoryList *list_to = inv_to->getList(to_list);
 	if (!list_from || !list_to)


### PR DESCRIPTION
This PR removes a check from `IMoveAction::clientApply()` that caused the early client-side action to only trigger if both inventories involved belonged to the client's player. This seems to provide multiple effects:

- Swapping items on the client becomes effectively synchronous, rendering the 'black magic' introduced in #6520 unnecessary and simplifying the ongoing formspec refactor.
- The brief 'flicker' that occurs when swapping items between inventories no longer happens.
- Attempting to move/swap an item into an inventory that the server disallows will appear to work, then 'rubber-band' back to its previous state.

So far, I think the benefits outweigh the downsides. Formspec code is simplified, and the common case becomes smoother and the rare case less smooth.

**However**, there is a serious caveat: *I have not tested this change in a real online environment.* I cannot guarantee the safety of this change until it has been tested on a real server.

I'm opening this PR to start a discussion, and (if people generally support the idea behind this change) hopefully get some more thorough testing. What do you think?