### PR TITLE
Return to main menu if shaders fail to compile, and display an error message.

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -618,6 +618,8 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 				TILE_MATERIAL_PLAIN_ALPHA : TILE_MATERIAL_PLAIN;
 
 		u32 shader_id = shader_source->getShader("object_shader", material_type, NDT_NORMAL);
+		if (!shader_id)
+			m_client->setFatalError("Failed to compile object_shader! Check the log for details.");
 		m_material_type = shader_source->getShaderInfo(shader_id).material;
 	} else {
 		m_material_type = (m_prop.use_texture_alpha) ?

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -102,6 +102,9 @@ Hud::Hud(gui::IGUIEnvironment *guienv, Client *client, LocalPlayer *player,
 		u16 shader_id = shdrsrc->getShader(
 			m_mode == HIGHLIGHT_HALO ? "selection_shader" : "default_shader", TILE_MATERIAL_ALPHA);
 		m_selection_material.MaterialType = shdrsrc->getShaderInfo(shader_id).material;
+
+		if (!shader_id)
+			client->setFatalError("Failed to compile the selection shader! Check the log for details.");
 	} else {
 		m_selection_material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 	}

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -614,6 +614,9 @@ void Minimap::drawMinimap(core::rect<s32> rect) {
 
 	if (m_enable_shaders && data->mode.type == MINIMAP_TYPE_SURFACE) {
 		u16 sid = m_shdrsrc->getShader("minimap_shader", TILE_MATERIAL_ALPHA);
+		if (!sid)
+			client->setFatalError("Failed to compile minimap_shader! Check the log for details.");
+
 		material.MaterialType = m_shdrsrc->getShaderInfo(sid).material;
 	} else {
 		material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;

--- a/src/client/render/interlaced.cpp
+++ b/src/client/render/interlaced.cpp
@@ -41,6 +41,10 @@ void RenderingCoreInterlaced::initMaterial()
 	mat.ZWriteEnable = false;
 #endif
 	u32 shader = s->getShader("3d_interlaced_merge", TILE_MATERIAL_BASIC);
+
+	if (!shader)
+		client->setFatalError("Failed to compile 3d_interlaced_merge! Check the log for details.");
+
 	mat.MaterialType = s->getShaderInfo(shader).material;
 	for (int k = 0; k < 3; ++k) {
 		mat.TextureLayer[k].AnisotropicFilter = false;

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -469,7 +469,7 @@ u32 ShaderSource::getShaderIdDirect(const std::string &name,
 	infostream<<"getShaderIdDirect(): "
 			<<"Returning id="<<id<<" for name \""<<name<<"\""<<std::endl;
 
-	return id;
+	return info.shader_failed ? 0 : id;
 }
 
 
@@ -561,6 +561,8 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
 	if (!driver->queryFeature(video::EVDF_ARB_GLSL)) {
 		errorstream << "Shaders are enabled but GLSL is not supported by the driver\n";
+		shaderinfo.shader_failed = true;
+
 		return shaderinfo;
 	}
 	video::IGPUProgrammingServices *gpu = driver->getGPUProgrammingServices();
@@ -709,6 +711,8 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		dumpShaderProgram(warningstream, "Vertex", vertex_shader);
 		dumpShaderProgram(warningstream, "Fragment", fragment_shader);
 		dumpShaderProgram(warningstream, "Geometry", geometry_shader);
+		shaderinfo.shader_failed = true;
+
 		return shaderinfo;
 	}
 

--- a/src/client/shader.h
+++ b/src/client/shader.h
@@ -51,6 +51,8 @@ struct ShaderInfo {
 	NodeDrawType drawtype = NDT_NORMAL;
 	MaterialType material_type = TILE_MATERIAL_BASIC;
 
+	bool shader_failed = false;
+
 	ShaderInfo() = default;
 	virtual ~ShaderInfo() = default;
 };

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -363,6 +363,8 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 
 	if (m_enable_shaders) {
 		u32 shader_id = shdrsrc->getShader("object_shader", TILE_MATERIAL_BASIC, NDT_NORMAL);
+		if (!shader_id)
+			client->setFatalError("Failed to compile object_shader! Check the log for details.");
 		m_material_type = shdrsrc->getShaderInfo(shader_id).material;
 	}
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -906,6 +906,9 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 
 	u32 tile_shader = shdsrc->getShader("nodes_shader", material_type, drawtype);
 
+	if (!tile_shader)
+		client->setFatalError("Failed to compile nodes_shader! Check the log for details.");
+
 	MaterialType overlay_material = material_type;
 	if (overlay_material == TILE_MATERIAL_OPAQUE)
 		overlay_material = TILE_MATERIAL_BASIC;
@@ -913,6 +916,9 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 		overlay_material = TILE_MATERIAL_LIQUID_TRANSPARENT;
 
 	u32 overlay_shader = shdsrc->getShader("nodes_shader", overlay_material, drawtype);
+
+	if (!overlay_shader)
+		client->setFatalError("Failed to compile nodes_shader! Check the log for details.");
 
 	// Tiles (fill in f->tiles[])
 	for (u16 j = 0; j < 6; j++) {
@@ -935,6 +941,9 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 			special_material = TILE_MATERIAL_WAVING_LEAVES;
 	}
 	u32 special_shader = shdsrc->getShader("nodes_shader", special_material, drawtype);
+
+	if (!special_shader)
+		client->setFatalError("Failed to compile nodes_shader! Check the log for details.");
 
 	// Special tiles (fill in f->special_tiles[])
 	for (u16 j = 0; j < CF_SPECIAL_COUNT; j++)


### PR DESCRIPTION
Fixes #10097 

## To do
- [x] Find a way to display an error for object shaders as well.  

This PR is ready for review.

## How to test
Add some random text to any shader, open a world.