### PR TITLE
Give unnamed world names incremental numbers. Format 'world<number>'

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -363,10 +363,18 @@ local function create_world_buttonhandler(this, fields)
 		local gameindex = core.get_textlist_index("games")
 
 		if gameindex ~= nil then
+			-- For unnamed worlds use the generated name 'world<number>',
+			-- where the number increments: it is set to 1 larger than the largest
+			-- generated name number found.
 			if worldname == "" then
-				local random_number = math.random(10000, 99999)
-				local random_world_name = "Unnamed" .. random_number
-				worldname = random_world_name
+				local worldnum_max = 0
+				for _, world in ipairs(menudata.worldlist:get_list()) do
+					if world.name:match("^world%d+$") then
+						local worldnum = tonumber(world.name:sub(6))
+						worldnum_max = math.max(worldnum_max, worldnum)
+					end
+				end
+				worldname = "world" .. worldnum_max + 1
 			end
 
 			core.settings:set("fixed_map_seed", fields["te_seed"])


### PR DESCRIPTION
![Screenshot from 2020-08-06 18-28-21](https://user-images.githubusercontent.com/3686677/89565204-23d0fb80-d816-11ea-9114-4873236b8f22.png)

Closes #8598 
Code created with help from @sirrobzeroone and @pauloue , thanks, i added a credit to you in the commit message.

Generates incremental world numbers, as suggested by other core devs in the issue.
First generated name is 'world1', then the world number increments: it is set to 1 larger than the largest generated name number found.
The string matching pattern only recognises a name of format `world<number>` where `number` is a continuous sequence of digits.
The relevant string-matching Lua documentation to help reviewers:

> you can use the string functions in object-oriented style. For instance, string.byte(s,i) can be written as s:byte(i).

> string.match (s, pattern [, init])
Looks for the first match of pattern in the string s. If it finds one, then match returns the captures from the pattern; otherwise it returns nil.

> A character class is used to represent a set of characters.
%d: represents all digits.

> a single character class followed by '+', which matches 1 or more repetitions of characters in the class.

> A caret '^' at the beginning of a pattern anchors the match at the beginning of the subject string. A '$' at the end of a pattern anchors the match at the end of the subject string.

> string.sub (s, i [, j])
Returns the substring of s that starts at i and continues until j; i and j can be negative. If j is absent, then it is assumed to be equal to -1 (which is the same as the string length).