### PR TITLE
Fix build for Visual Studio (explicitly cast pointers)

### DIFF
--- a/src/util/md32_common.h
+++ b/src/util/md32_common.h
@@ -301,7 +301,7 @@
 
 int HASH_UPDATE(HASH_CTX *c, const void *data_, size_t len)
 {
-    const unsigned char *data = data_;
+    const unsigned char *data = (const unsigned char *)data_;
     unsigned char *p;
     HASH_LONG l;
     size_t n;

--- a/src/util/sha256.c
+++ b/src/util/sha256.c
@@ -18,13 +18,13 @@ const char SHA256_version[] = "SHA-256" OPENSSL_VERSION_PTEXT;
 unsigned static char cleanse_ctr = 0;
 static void OPENSSL_cleanse(void *ptr, size_t len)
 {
-    unsigned char *p = ptr;
+    unsigned char *p = (unsigned char *)ptr;
     size_t loop = len, ctr = cleanse_ctr;
     while (loop--) {
         *(p++) = (unsigned char)ctr;
         ctr += (17 + ((size_t)p & 0xF));
     }
-    p = memchr(ptr, (unsigned char)ctr, len);
+    p = (unsigned char *)memchr(ptr, (unsigned char)ctr, len);
     if (p)
         ctr += (63 + (size_t)p);
     cleanse_ctr = (unsigned char)ctr;
@@ -262,7 +262,7 @@ static void sha256_block_data_order(SHA256_CTX *ctx, const void *in,
     unsigned MD32_REG_T a, b, c, d, e, f, g, h, s0, s1, T1;
     SHA_LONG X[16];
     int i;
-    const unsigned char *data = in;
+    const unsigned char *data = (const unsigned char *)in;
     const union {
         long one;
         char little;


### PR DESCRIPTION
This fixes the recent CI errors with Visual Studio

32-bit: https://github.com/minetest/minetest/runs/935560647#step:5:428
64-bit: https://github.com/minetest/minetest/runs/935560651#step:5:433

```
src\util\sha256.c(21,27): error C2440: 'initializing': cannot convert from 'void *' to 'unsigned char *' 
src\util\sha256.c(21,22): message : Conversion from 'void*' to pointer to non-'void' requires an explicit cast
```

```
src\util\sha256.c(27,45): error C2440: '=': cannot convert from 'void *' to 'unsigned char *'
src\util\sha256.c(27,15): message : Conversion from 'void*' to pointer to non-'void' requires an explicit cast
```

```
src\util\md32_common.h(304,38): error C2440: 'initializing': cannot convert from 'const void *' to 'const unsigned char *'
src\util\md32_common.h(304,31): message : Conversion from 'void*' to pointer to non-'void' requires an explicit cast
```

```
src\util\sha256.c(265,35): error C2440: 'initializing': cannot convert from 'const void *' to 'const unsigned char *'
src\util\sha256.c(265,31): message : Conversion from 'void*' to pointer to non-'void' requires an explicit cast
```