### PR TITLE
Add sized containers and unified container end[] element

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2114,18 +2114,26 @@ Elements
 * For information on converting forms to the new coordinate system, see `Migrating
   to Real Coordinates`.
 
-### `container[<X>,<Y>]`
+### `container[<X>,<Y>;<W>,<H>]`
 
 * Start of a container block, moves all physical elements in the container by
   (X, Y).
-* Must have matching `container_end`
-* Containers can be nested, in which case the offsets are added
-  (child containers are relative to parent containers)
+* `W`/`H` (optional): The width and height of the container. If defined, the container
+  has a width and height, and any elements extending outside of the container are
+  clipped to the container rectangle. Requires formspec version >= 4.
+* Must have a matching `end[]` element.
+* Containers can be nested, in which case the offsets are added, meaning the
+  child containers are relative to the parent containers.
+
+### `end[]`
+* End of any type of container; following elements are no longer bound to the
+  last opened container.
 
 ### `container_end[]`
 
 * End of a container, following elements are no longer relative to this
   container.
+* Deprecated; use `end[]` for all containers
 
 ### `scroll_container[<X>,<Y>;<W>,<H>;<scrollbar name>;<orientation>;<scroll factor>]`
 
@@ -2136,6 +2144,7 @@ Elements
   * be clipped to the rectangle defined by `X`, `Y`, `W` and `H`.
 * `orientation`: possible values are `vertical` and `horizontal`.
 * `scroll factor`: optional, defaults to `0.1`.
+* Must have a matching `end[]` element.
 * Nesting is possible.
 * Some elements might work a little different if they are in a scroll_container.
 * Note: If you want the scroll_container to actually work, you also need to add a
@@ -2146,6 +2155,7 @@ Elements
 
 * End of a scroll_container, following elements are no longer bound to this
   container.
+* Deprecated; use `end[]` for all containers
 
 ### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;]`
 
@@ -2711,6 +2721,8 @@ Some types may inherit styles from parent types.
 * button
 * button_exit, inherits from button
 * checkbox
+* container
+* scroll_container, inherits from container
 * scrollbar
 * table
 * textlist
@@ -2767,6 +2779,9 @@ Some types may inherit styles from parent types.
     * textcolor - color, default white.
 * checkbox
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
+* container, scroll_container
+    * noclip - boolean, set to true to allow the element to exceed formspec bounds.
+        * Note: Doesn't apply to unsized containers which do not clip ever
 * scrollbar
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 * table, textlist

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -289,8 +289,17 @@ protected:
 	v2f32 spacing;
 	v2s32 imgsize;
 	v2s32 offset;
+
+	enum ContainerType {
+		CONTAINER_UNSIZED,
+		CONTAINER_SIZED,
+		CONTAINER_SCROLL
+	};
+	std::vector<std::pair<ContainerType, v2f32>> container_stack;
 	v2f32 pos_offset;
-	std::stack<v2f32> container_stack;
+
+	void pushContainer(ContainerType type, v2f32 next_offset = v2f32(0.0f, 0.0f));
+	ContainerType popContainer();
 
 	InventoryManager *m_invmgr;
 	ISimpleTextureSource *m_tsrc;
@@ -398,9 +407,8 @@ private:
 
 	void parseSize(parserData* data, const std::string &element);
 	void parseContainer(parserData* data, const std::string &element);
-	void parseContainerEnd(parserData* data);
+	void parseEnd(parserData* data);
 	void parseScrollContainer(parserData *data, const std::string &element);
-	void parseScrollContainerEnd(parserData *data);
 	void parseList(parserData* data, const std::string &element);
 	void parseListRing(parserData* data, const std::string &element);
 	void parseCheckbox(parserData* data, const std::string &element);

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -240,6 +240,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		new element: scroll_container[]
 	FORMSPEC VERSION 4:
 		Allow dropdown indexing events
+		Sized and clipped containers, single end[] element for all containers.
 */
 #define FORMSPEC_API_VERSION 4
 


### PR DESCRIPTION
This PR partly addresses #9881 by adding a single `end[]` element for all container types.  `container_end[]` and `scroll_container_end[]` are now deprecated, and both act precisely like `end[]`.  In addition, it adds sized containers of the form `container[<X>,<Y>;<W>,<H>]` which clip their children to their rectangle.  Lastly, the `noclip` style property has been added to both `container`s and `scroll_container`s.

As for scoping, I think I'll leave that to another PR.  Properly scoping names, configuration elements, and other such stuff will be a lot of work (especially names), so it's probably best to split them.

## To do

This PR is Ready for Review.

## How to test

Use the following test code which tests out all the new stuff and nests tons of containers.  It should match the following screenshot:

![image](https://user-images.githubusercontent.com/31123645/89255785-622ca780-d5d7-11ea-8e12-846f894b875b.png)

<details><summary><b>Code:</b></summary>

```
formspec_version[4]
size[11,10]
container[-.5,1;3,3]
	box[0,0;3,3;darkturquoise]
	button[-.5,-.5;3,1.5;;Sized]
	button[.5,2;3,1.5;;Sized]
end[]
style_type[container;noclip=true]
container[-.5,5.5;3,3]
	box[0,0;3,3;darkturquoise]
	button[-.5,-.5;3,1.5;;Sized, Noclip]
	button[.5,2;3,1.5;;Sized, Noclip]
end[]
style_type[container;noclip=false]

container[4,1]
	box[0,0;3,3;silver]
	button[-.5,-.5;3,1.5;;Unsized]
	button[.5,2;3,1.5;;Unsized]
end[]
container[3.5,5]
	box[0,0;4,4;silver]
	container[.5,.5;3,3]
		box[0,0;3,3;darkturquoise]
		scrollbaroptions[min=0;max=10;thumbsize=7]
		scrollbar[2.5,.5;0.25,2;vertical;sbar3;3]
		scroll_container[.5,.5;2,2;sbar3;vertical]
			box[0,0;2,2;seagreen]
			container[.5,.5]
				box[0,0;1,1;silver]
				container[.33,.33;.33,.33]
					box[0,0;.33,.33;darkturquoise]
				end[]
			end[]
		end[]
	end[]
end[]

style_type[scrollbar;noclip=true]
scrollbaroptions[min=0;max=10;thumbsize=8]
scrollbar[11.5,1;0.25,3;vertical;sbar1;1]
scroll_container[8.5,1;3,3;sbar1;vertical]
	box[0,0;3,4;seagreen]
	button[-.5,-.5;3,1.5;;Scroll]
	button[.5,3;3,1.5;;Scroll]
end[]
scrollbar[11.5,5.5;0.25,3;vertical;sbar2;9]
style_type[scroll_container;noclip=true]
scroll_container[8.5,5.5;3,3;sbar2;vertical]
	box[0,0;3,4;seagreen]
	button[-.5,-.5;3,1.5;;Scroll, Noclip]
	button[.5,3;3,1.5;;Scroll, Noclip]
end[]
```
</details>