### PR TITLE
FormSpec: Allow `no_prepend` to exclude certain element types

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2098,10 +2098,11 @@ Elements
 * `position` and `anchor` elements need suitable values to avoid a formspec
   extending off the game window due to particular game window sizes.
 
-### `no_prepend[]`
+### `no_prepend[<exclude 1>,<exclude 2>,...]`
 
 * Must be used after the `size`, `position`, and `anchor` elements (if present).
-* Disables player:set_formspec_prepend() from applying to this formspec.
+* `exclude`: List of element types in `player:set_formspec_prepend()` to exclude
+  from the formspec. If blank, all elements are excluded.
 
 ### `real_coordinates[<bool>]`
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -355,6 +355,8 @@ private:
 
 	typedef struct {
 		bool explicit_size;
+		bool enable_prepends;
+		std::vector<std::string> no_prepend_elements;
 		bool real_coordinates;
 		u8 simple_field_count;
 		v2f invsize;
@@ -394,7 +396,7 @@ private:
 	std::string current_field_enter_pending = "";
 	std::vector<std::string> m_hovered_item_tooltips;
 
-	void parseElement(parserData* data, const std::string &element);
+	void parseElement(parserData* data, const std::string &element, bool in_prepend);
 
 	void parseSize(parserData* data, const std::string &element);
 	void parseContainer(parserData* data, const std::string &element);
@@ -442,6 +444,7 @@ private:
 	void parsePosition(parserData *data, const std::string &element);
 	bool parseAnchorDirect(parserData *data, const std::string &element);
 	void parseAnchor(parserData *data, const std::string &element);
+	bool parseNoPrepend(parserData *data, const std::string &element);
 	bool parseStyle(parserData *data, const std::string &element, bool style_type);
 	void parseSetFocus(const std::string &element);
 


### PR DESCRIPTION
Closes #8338 by allowing a list of element types to exclude in `no_prepend` with the form `no_prepend[<exclude 1>,<exclude 2>,...]`, e.g. `no_prepend[background,background9]`.  No parameters still excludes all elements.

## To do

This PR is Ready for Review.

## How to test

Mess around with making prepends and `no_prepend`ing some of the elements.