### PR TITLE
[FormSpec] Add 'scaleup_hovered' styling property for buttons.

### DIFF
--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -53,6 +53,7 @@ local function get_formspec(tabview, name, tabdata)
 
 
 	local retval =
+        "style_type[button:hovered;scaleup_hovered=true]" ..
 		"label[0.05,-0.25;".. fgettext("Installed Packages:") .. "]" ..
 		"tablecolumns[color;tree;text]" ..
 		"table[0,0.25;5.1,4.3;pkglist;" ..

--- a/builtin/mainmenu/tab_credits.lua
+++ b/builtin/mainmenu/tab_credits.lua
@@ -102,6 +102,7 @@ return {
 		local version = core.get_version()
 		return "image[0.5,1;" .. core.formspec_escape(logofile) .. "]" ..
 			"label[0.5,2.8;" .. version.project .. " " .. version.string .. "]" ..
+            "style_type[button:hovered;scaleup_hovered=true]" ..
 			"button[0.5,3;2,2;homepage;minetest.net]" ..
 			"tablecolumns[color;text]" ..
 			"tableoptions[background=#00000000;highlight=#00000000;border=false]" ..

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -114,6 +114,7 @@ local function get_formspec(tabview, name, tabdata)
 				)
 
 	retval = retval ..
+            "style_type[button:hovered;scaleup_hovered=true]" ..
 			"button[4,3.95;2.6,1;world_delete;".. fgettext("Delete") .. "]" ..
 			"button[6.5,3.95;2.8,1;world_configure;".. fgettext("Configure") .. "]" ..
 			"button[9.2,3.95;2.5,1;world_create;".. fgettext("New") .. "]" ..

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -33,6 +33,7 @@ local function get_formspec(tabview, name, tabdata)
 
 	local retval =
 		-- Search
+        "style_type[button:hovered, image_button:hovered;scaleup_hovered=true]" ..
 		"field[0.15,0.075;5.91,1;te_search;;" .. core.formspec_escape(tabdata.search_for) .. "]" ..
 		"button[5.62,-0.25;1.5,1;btn_mp_search;" .. fgettext("Search") .. "]" ..
 		"image_button[6.97,-.165;.83,.83;" .. core.formspec_escape(defaulttexturedir .. "refresh.png")

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -125,6 +125,7 @@ end
 local function dlg_confirm_reset_formspec(data)
 	return  "size[8,3]" ..
 		"label[1,1;" .. fgettext("Are you sure to reset your singleplayer world?") .. "]" ..
+        "style_type[button:hovered;scaleup_hovered=true]" ..
 		"button[1,2;2.6,0.5;dlg_reset_singleplayer_confirm;" .. fgettext("Yes") .. "]" ..
 		"button[4,2;2.8,0.5;dlg_reset_singleplayer_cancel;" .. fgettext("No") .. "]"
 end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2747,6 +2747,7 @@ Some types may inherit styles from parent types.
                      button's content when set.
     * bgimg_pressed - background image when pressed. Defaults to bgimg when not provided.
         * This is deprecated, use states instead.
+    * scaleup_hovered - Scale up the button smoothly when hovered. Default to false.
     * font - Sets font type. This is a comma separated list of options. Valid options:
       * Main font type options. These cannot be combined with each other:
         * `normal`: Default font

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -3,6 +3,7 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiBackgroundImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiBox.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiButton.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/guiButtonAnimator.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiButtonImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiButtonItemImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiChatConsole.cpp

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -36,6 +36,7 @@ public:
 		BGCOLOR,
 		BGCOLOR_HOVERED, // Note: Deprecated property
 		BGCOLOR_PRESSED, // Note: Deprecated property
+        SCALEUP_HOVERED,
 		NOCLIP,
 		BORDER,
 		BGIMG,
@@ -78,7 +79,9 @@ public:
 			return BGCOLOR_HOVERED;
 		} else if (name == "bgcolor_pressed") {
 			return BGCOLOR_PRESSED;
-		} else if (name == "noclip") {
+		} else if (name == "scaleup_hovered") {
+            return SCALEUP_HOVERED;
+        } else if (name == "noclip") {
 			return NOCLIP;
 		} else if (name == "border") {
 			return BORDER;

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -16,7 +16,6 @@
 #include "StyleSpec.h"
 #include "util/numeric.h"
 #include <cmath>
-#include "log.h"
 #include "guiButtonAnimator.h"
 
 using namespace irr;
@@ -116,13 +115,7 @@ void GUIButton::setRelRectSize(s32 w, s32 h) {
     
     s32 diff_w = std::abs(w - cur_w)/2;
     s32 diff_h = std::abs(h - cur_h)/2;
-    infostream << "diff_w: " << diff_w << "\n";
-    infostream << "diff_h: " << diff_h << "\n";
     
-    infostream << "-x: " << (cur_w < w ? pos1.X-diff_w : (cur_w > w ? pos1.X+diff_w : pos1.X)) << "\n";
-    infostream << "-y: " << (cur_h < h ? pos1.Y-diff_h : (cur_h > h ? pos1.Y+diff_h : pos1.Y)) << "\n";
-    infostream << "x: " << (cur_w < w ? pos2.X+diff_w : (cur_w > w ? pos2.X-diff_w : pos2.X)) << "\n";
-    infostream << "y: " << (cur_h < h ? pos2.Y+diff_h : (cur_h > h ? pos2.Y-diff_h : pos2.Y)) << "\n";
     core::rect<s32> new_rect{
         cur_w < w ? pos1.X-diff_w : (cur_w > w ? pos1.X+diff_w : pos1.X),
         cur_h < h ? pos1.Y-diff_h : (cur_h > h ? pos1.Y+diff_h : pos1.Y),
@@ -823,7 +816,6 @@ void GUIButton::setFromStyle(const StyleSpec& style)
             m_button_animator->smoothScale(m_button_animator->ANIMATION_SCALEUP);
         }
         else if (def) {
-            infostream << "default\n";
             m_button_animator->smoothScale(m_button_animator->ANIMATION_SCALEDOWN);
         }
     }

--- a/src/gui/guiButton.h
+++ b/src/gui/guiButton.h
@@ -67,6 +67,7 @@ using namespace irr;
 
 #endif
 
+class GUIButtonAnimator;
 class ISimpleTextureSource;
 
 class GUIButton : public gui::IGUIButton
@@ -142,6 +143,9 @@ public:
 	virtual void setSprite(gui::EGUI_BUTTON_STATE state, s32 index,
 						   video::SColor color=video::SColor(255,255,255,255),
 						   bool loop=false, bool scale=false);
+    
+    // Sets size of the relative rectangle
+    virtual void setRelRectSize(s32 w, s32 h);
 
 #if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 8)
 	void setSprite(gui::EGUI_BUTTON_STATE state, s32 index, video::SColor color, bool loop) override {
@@ -236,7 +240,9 @@ public:
 			const core::rect<s32>& rectangle, ISimpleTextureSource *tsrc,
 			IGUIElement* parent, s32 id, const wchar_t* text,
 			const wchar_t *tooltiptext=L"");
-
+    
+    // Button Animator, directly used in GUIButton::setFromStyle() method to set corresponding animation
+    GUIButtonAnimator* m_button_animator=nullptr;
 protected:
 	void drawSprite(gui::EGUI_BUTTON_STATE state, u32 startTime, const core::position2di& center);
 	gui::EGUI_BUTTON_IMAGE_STATE getImageState(bool pressed) const;

--- a/src/gui/guiButtonAnimator.cpp
+++ b/src/gui/guiButtonAnimator.cpp
@@ -1,0 +1,73 @@
+
+#include "guiButtonAnimator.h"
+#include "guiButton.h"
+#include "log.h"
+
+
+GUIButtonAnimator::GUIButtonAnimator(const string& tname, const array<s32, 2> default_size, GUIButton* but)
+    : m_button(but), m_default_size(default_size)
+{
+    m_thread = new ButtonSmoothScaleThread(tname, this);
+    
+    infostream << "default_size[0]: " << default_size[0] << "\n";
+    infostream << "default_size[1]: " << default_size[1] << "\n";
+    m_end_size[0] = default_size[0]/SIZE_DIV + default_size[0];
+    m_end_size[1] = default_size[1]/SIZE_DIV + default_size[1];
+        
+    infostream << "m_end_size[0] - m_default_size[1]: " << (m_end_size[0] - m_default_size[0]) << "\n";
+    m_size_change[0] = (m_end_size[0] - m_default_size[0])/SIZE_CHANGE_DIV;
+    m_size_change[1] = (m_end_size[1] - m_default_size[1])/SIZE_CHANGE_DIV;
+    
+    infostream << "m_size_change[0]: " << m_size_change[0] << "\n";
+    infostream << "m_size_change[1]: " << m_size_change[1] << "\n";
+}
+
+GUIButtonAnimator::~GUIButtonAnimator()
+{
+    m_button = nullptr;
+    m_thread = nullptr;
+}
+
+ void GUIButtonAnimator::smoothScale(AnimationType type) {
+        m_anim_type = type;
+        m_thread->start();
+}
+
+void* ButtonSmoothScaleThread::run() {
+    auto& iter = m_button_anim->m_iter;
+    auto& end_iter = m_button_anim->m_end_iter;
+    auto& anim_type = m_button_anim->m_anim_type;
+    auto& size_change = m_button_anim->m_size_change;
+            
+    while (iter != end_iter) {
+        static s32 cur_w = 0;
+        static s32 cur_h = 0;
+        
+        auto rel_pos = m_button_anim->m_button->getRelativePosition();
+        cur_w = rel_pos.getWidth();
+        cur_h = rel_pos.getHeight();
+                
+        s32 new_w = (anim_type == m_button_anim->ANIMATION_SCALEUP ? cur_w + size_change[0] : cur_w - size_change[0]);
+        s32 new_h = (anim_type == m_button_anim->ANIMATION_SCALEUP ? cur_h + size_change[1] : cur_h - size_change[1]);
+        
+        infostream << "new_w: " << new_w << "\n";
+        infostream << "new_h: " << new_h << "\n";
+        m_button_anim->m_button->setRelRectSize(new_w, new_h);
+                
+        ++iter;
+        infostream << iter << "\n";
+        infostream << "current width: " << rel_pos.getWidth() << ", current height: " << rel_pos.getHeight() << "\n";
+                
+        this_thread::sleep_for(chrono::milliseconds{20});
+                
+                
+    }
+            
+    iter = 0;
+    anim_type = m_button_anim->ANIMATION_NONE;
+            
+        
+    bool* finished = new bool(true);
+    return finished;
+}
+ 

--- a/src/gui/guiButtonAnimator.cpp
+++ b/src/gui/guiButtonAnimator.cpp
@@ -1,7 +1,6 @@
 
 #include "guiButtonAnimator.h"
 #include "guiButton.h"
-#include "log.h"
 
 
 GUIButtonAnimator::GUIButtonAnimator(const string& tname, const array<s32, 2> default_size, GUIButton* but)
@@ -9,17 +8,12 @@ GUIButtonAnimator::GUIButtonAnimator(const string& tname, const array<s32, 2> de
 {
     m_thread = new ButtonSmoothScaleThread(tname, this);
     
-    infostream << "default_size[0]: " << default_size[0] << "\n";
-    infostream << "default_size[1]: " << default_size[1] << "\n";
     m_end_size[0] = default_size[0]/SIZE_DIV + default_size[0];
     m_end_size[1] = default_size[1]/SIZE_DIV + default_size[1];
         
-    infostream << "m_end_size[0] - m_default_size[1]: " << (m_end_size[0] - m_default_size[0]) << "\n";
     m_size_change[0] = (m_end_size[0] - m_default_size[0])/SIZE_CHANGE_DIV;
     m_size_change[1] = (m_end_size[1] - m_default_size[1])/SIZE_CHANGE_DIV;
     
-    infostream << "m_size_change[0]: " << m_size_change[0] << "\n";
-    infostream << "m_size_change[1]: " << m_size_change[1] << "\n";
 }
 
 GUIButtonAnimator::~GUIButtonAnimator()
@@ -50,13 +44,9 @@ void* ButtonSmoothScaleThread::run() {
         s32 new_w = (anim_type == m_button_anim->ANIMATION_SCALEUP ? cur_w + size_change[0] : cur_w - size_change[0]);
         s32 new_h = (anim_type == m_button_anim->ANIMATION_SCALEUP ? cur_h + size_change[1] : cur_h - size_change[1]);
         
-        infostream << "new_w: " << new_w << "\n";
-        infostream << "new_h: " << new_h << "\n";
         m_button_anim->m_button->setRelRectSize(new_w, new_h);
                 
         ++iter;
-        infostream << iter << "\n";
-        infostream << "current width: " << rel_pos.getWidth() << ", current height: " << rel_pos.getHeight() << "\n";
                 
         this_thread::sleep_for(chrono::milliseconds{20});
                 

--- a/src/gui/guiButtonAnimator.h
+++ b/src/gui/guiButtonAnimator.h
@@ -10,12 +10,7 @@
 
 
 #define SIZE_DIV  6                       // Divide default button size by this value for specifying maximum change of the button size when hovering. The division is necessary for keeping the proportions.
-#define MAX_WIDTH(w)  (w / SIZE_DIV)      // Maximum change of the button width.
-#define MAX_HEIGHT(h)  (h / SIZE_DIV)     // Maximum change of the button height.
 #define SIZE_CHANGE_DIV  4
-#define SIZE_CHANGE_WIDTH(w)  (w / SIZE_CHANGE_DIV)
-#define SIZE_CHANGE_HEIGHT(h)  (h / SIZE_CHANGE_DIV)
-
 
 class GUIButton;
 class ButtonSmoothScaleThread;

--- a/src/gui/guiButtonAnimator.h
+++ b/src/gui/guiButtonAnimator.h
@@ -1,0 +1,66 @@
+#pragma once
+
+
+#include "irrlichttypes.h"
+#include "threading/thread.h"
+#include <string>
+#include <array>
+#include <cstddef>
+#include <chrono>
+
+
+#define SIZE_DIV  6                       // Divide default button size by this value for specifying maximum change of the button size when hovering. The division is necessary for keeping the proportions.
+#define MAX_WIDTH(w)  (w / SIZE_DIV)      // Maximum change of the button width.
+#define MAX_HEIGHT(h)  (h / SIZE_DIV)     // Maximum change of the button height.
+#define SIZE_CHANGE_DIV  4
+#define SIZE_CHANGE_WIDTH(w)  (w / SIZE_CHANGE_DIV)
+#define SIZE_CHANGE_HEIGHT(h)  (h / SIZE_CHANGE_DIV)
+
+
+class GUIButton;
+class ButtonSmoothScaleThread;
+
+using namespace std;
+
+class GUIButtonAnimator {
+public:
+    GUIButtonAnimator(const string& tname, const array<s32, 2> default_size, GUIButton* but);
+    
+    ~GUIButtonAnimator();
+    
+    
+    enum AnimationType {
+        ANIMATION_SCALEUP,
+        ANIMATION_SCALEDOWN,
+        ANIMATION_NONE
+    };
+    
+    void smoothScale(AnimationType type);
+    
+private:
+    size_t m_iter = 0;
+    const size_t m_end_iter = SIZE_CHANGE_DIV;
+    GUIButton* m_button;
+    ButtonSmoothScaleThread* m_thread;
+    
+    AnimationType m_anim_type = ANIMATION_NONE;
+    
+    array<s32, 2> m_default_size;
+    array<s32, 2> m_end_size;
+    array<s32, 2> m_size_change;
+    
+    friend class ButtonSmoothScaleThread;
+    friend class GUIButton;
+};
+
+class ButtonSmoothScaleThread : public Thread {
+public:
+    ButtonSmoothScaleThread(const string& name = "", GUIButtonAnimator* but_anim=nullptr) : Thread(name), m_button_anim(but_anim)
+    {
+    }
+    
+protected:
+    virtual void* run();
+private:
+    GUIButtonAnimator* m_button_anim;
+};

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -57,6 +57,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiBackgroundImage.h"
 #include "guiBox.h"
 #include "guiButton.h"
+#include "guiButtonAnimator.h"
 #include "guiButtonImage.h"
 #include "guiButtonItemImage.h"
 #include "guiEditBoxWithScrollbar.h"
@@ -1020,7 +1021,16 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 
 		auto style = getStyleForElement(type, name, (type != "button") ? "button" : "");
 		e->setStyles(style);
-
+        
+        /*auto scaleup_found = std::find_if(parts.begin(), parts.end(), [&](const std::string& v_elem) {
+            std::vector<std::string> v_scaleup = split(v_elem, '=');
+            return (v_scaleup.at(0) == "scaleup_hovered" && v_scaleup.at(1) == "true");
+        });
+        
+        if (scaleup_found != parts.end())
+            e->m_button_animator = new GUIButtonAnimator("bsst_main_" + e->getID(), {pos.X+geom.X, pos.Y+geom.Y}, e);
+        */
+        
 		if (spec.fname == m_focused_element) {
 			Environment->setFocus(e);
 		}


### PR DESCRIPTION
This is my first PR for the Minetest Engine, so I am unsure about accuracy of the code design and style. This adds new `scaleup_hovered` styling property for buttons that can be set only in the hovered state and has boolean value. If it is enabled, a button will be smoothly scaling up at little value:

![безымянный (2)](https://user-images.githubusercontent.com/25750346/89718140-5cfb9e00-d9c5-11ea-91f9-383940af9bad.gif)


## To do

* Fix: button size won`t scale down back after abrupt releasing by the cursor.
* Fix: button size may lose properties when hovered if do pretty smooth scaling.
* Fix: text on button mat be shifted from the center when hovered.
* Probably something else...

## How to test
1. Add any kind of the buttons (e. g. 'button' or 'image_button').
2. Add 'scaleup_hovered=true' property in 'styles[]' for that kind of the buttons.
