### PR TITLE
Allow the ABM time budget to be configurable.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1282,6 +1282,10 @@ active_block_mgmt_interval (Active block management interval) float 2.0
 #    Length of time between Active Block Modifier (ABM) execution cycles
 abm_interval (ABM interval) float 1.0
 
+#    The time budget allowed for ABMs to execute on each step
+#    (as a fraction of the ABM Interval)
+abm_time_budget (ABM time budget) float 0.2 0.1 0.9
+
 #    Length of time between NodeTimer execution cycles
 nodetimer_interval (NodeTimer interval) float 0.2
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -403,6 +403,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("dedicated_server_step", "0.09");
 	settings->setDefault("active_block_mgmt_interval", "2.0");
 	settings->setDefault("abm_interval", "1.0");
+	settings->setDefault("abm_time_budget", "0.2");
 	settings->setDefault("nodetimer_interval", "0.2");
 	settings->setDefault("ignore_world_load_errors", "false");
 	settings->setDefault("remote_media", "");

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -36,6 +36,7 @@ Environment::Environment(IGameDef *gamedef):
 	m_cache_active_block_mgmt_interval = g_settings->getFloat("active_block_mgmt_interval");
 	m_cache_abm_interval = g_settings->getFloat("abm_interval");
 	m_cache_nodetimer_interval = g_settings->getFloat("nodetimer_interval");
+	m_cache_abm_time_budget = g_settings->getFloat("abm_time_budget");
 
 	m_time_of_day = g_settings->getU32("world_start_time");
 	m_time_of_day_f = (float)m_time_of_day / 24000.0f;

--- a/src/environment.h
+++ b/src/environment.h
@@ -147,6 +147,7 @@ protected:
 	float m_cache_active_block_mgmt_interval;
 	float m_cache_abm_interval;
 	float m_cache_nodetimer_interval;
+	float m_cache_abm_time_budget;
 
 	IGameDef *m_gamedef;
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1354,8 +1354,8 @@ void ServerEnvironment::step(float dtime)
 		std::shuffle(output.begin(), output.end(), m_rgen);
 
 		int i = 0;
-		// The time budget for ABMs is 20%.
-		u32 max_time_ms = m_cache_abm_interval * 1000 / 5;
+		// determine the time budget for ABMs
+		u32 max_time_ms = m_cache_abm_interval * 1000 * m_cache_abm_time_budget;
 		for (const v3s16 &p : output) {
 			MapBlock *block = m_map->getBlockNoCreateNoEx(p);
 			if (!block)


### PR DESCRIPTION
See #10068

Makes the fraction of the ABM interval to be used for active ABM processing configurable.
Defaults to 0.2 (20%), which is the value that was hardcoded before.

Allowed values are 0.1-0.9 (10-90%)
