### PR TITLE
Allow disabling elements; add `:focused` and `:disabled` states

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2614,19 +2614,39 @@ Elements
   re-sent formspecs with the same name so that player-set focus is kept.
   `true` sets the focus to the specified element for every sent formspec.
 * The following elements have the ability to be focused:
-    * checkbox
     * button
     * button_exit
+    * checkbox
+    * dropdown
+    * field
     * image_button
     * image_button_exit
     * item_image_button
+    * pwdfield
+    * scrollbar
     * table
+    * textarea
     * textlist
+
+### `set_disabled[<name 1>,<name 2>,...]`
+
+* Makes the named elements disabled and unresponsive to user input.
+* **Note**: This element must be placed before the elements it disables.
+* The following elements can be disabled:
+    * button
+    * button_exit
+    * checkbox
     * dropdown
     * field
+    * image_button
+    * image_button_exit
+    * item_image_button
     * pwdfield
-    * textarea
     * scrollbar
+    * tabheader
+    * table
+    * textarea
+    * textlist
 
 Migrating to Real Coordinates
 -----------------------------
@@ -2805,9 +2825,11 @@ Some types may inherit styles from parent types.
 
 * *all elements*
     * default - Equivalent to providing no states
-* button, button_exit, image_button, item_image_button
+* button, button_exit, image_button, image_button_exit, item_image_button
+    * focused - Active when the element has focus
     * hovered - Active when the mouse is hovering over the element
-    * pressed - Active when the button is pressed
+    * pressed - Active when the element is pressed
+    * disabled - Active when the element is disabled with the `set_disabled[]` element
 
 Markup Language
 ---------------

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -56,10 +56,12 @@ public:
 	enum State
 	{
 		STATE_DEFAULT = 0,
-		STATE_HOVERED = 1 << 0,
-		STATE_PRESSED = 1 << 1,
-		NUM_STATES = 1 << 2,
-		STATE_INVALID = 1 << 3,
+		STATE_FOCUSED = 1 << 0,
+		STATE_HOVERED = 1 << 1,
+		STATE_PRESSED = 1 << 2,
+		STATE_DISABLED = 1 << 3,
+		NUM_STATES = 1 << 4,
+		STATE_INVALID = 1 << 5,
 	};
 
 private:
@@ -128,10 +130,14 @@ public:
 	{
 		if (name == "default") {
 			return STATE_DEFAULT;
+		} else if (name == "focused") {
+			return STATE_FOCUSED;
 		} else if (name == "hovered") {
 			return STATE_HOVERED;
 		} else if (name == "pressed") {
 			return STATE_PRESSED;
+		} else if (name == "disabled") {
+			return STATE_DISABLED;
 		} else {
 			return STATE_INVALID;
 		}

--- a/src/gui/guiButton.h
+++ b/src/gui/guiButton.h
@@ -330,7 +330,11 @@ private:
 
 	video::SColor Colors[4];
 	// PATCH
+	bool WasFocused = false;
+	bool Focused = false;
 	bool WasHovered = false;
+	bool WasEnabled = true;
+
 	ISimpleTextureSource *TSrc;
 
 	gui::IGUIStaticText *StaticText;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -615,9 +615,10 @@ void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element
 		auto style = getDefaultStyleForElement("checkbox", name);
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 
-		if (spec.fname == m_focused_element) {
+		if (spec.fname == m_focused_element)
 			Environment->setFocus(e);
-		}
+		if (data->disabled_elements.find(spec.fname) != data->disabled_elements.end())
+			e->setEnabled(false);
 
 		e->grab();
 		m_checkboxes.emplace_back(spec, e);
@@ -691,9 +692,10 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 
 		e->setPageSize(scrollbar_size * (max - min + 1) / data->scrollbar_options.thumb_size);
 
-		if (spec.fname == m_focused_element) {
+		if (spec.fname == m_focused_element)
 			Environment->setFocus(e);
-		}
+		if (data->disabled_elements.find(spec.fname) != data->disabled_elements.end())
+			e->setEnabled(false);
 
 		m_scrollbars.emplace_back(spec,e);
 		m_fields.push_back(spec);
@@ -1021,9 +1023,10 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 		auto style = getStyleForElement(type, name, (type != "button") ? "button" : "");
 		e->setStyles(style);
 
-		if (spec.fname == m_focused_element) {
+		if (spec.fname == m_focused_element)
 			Environment->setFocus(e);
-		}
+		if (data->disabled_elements.find(spec.fname) != data->disabled_elements.end())
+			e->setEnabled(false);
 
 		m_fields.push_back(spec);
 		return;
@@ -1210,9 +1213,10 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 		GUITable *e = new GUITable(Environment, data->current_parent, spec.fid,
 				rect, m_tsrc);
 
-		if (spec.fname == m_focused_element) {
+		if (spec.fname == m_focused_element)
 			Environment->setFocus(e);
-		}
+		if (data->disabled_elements.find(spec.fname) != data->disabled_elements.end())
+			e->setEnabled(false);
 
 		e->setTable(data->table_options, data->table_columns, items);
 
@@ -1287,9 +1291,10 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 		GUITable *e = new GUITable(Environment, data->current_parent, spec.fid,
 				rect, m_tsrc);
 
-		if (spec.fname == m_focused_element) {
+		if (spec.fname == m_focused_element)
 			Environment->setFocus(e);
-		}
+		if (data->disabled_elements.find(spec.fname) != data->disabled_elements.end())
+			e->setEnabled(false);
 
 		e->setTextList(items, is_yes(str_transparent));
 
@@ -1365,9 +1370,10 @@ void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element
 		gui::IGUIComboBox *e = Environment->addComboBox(rect, data->current_parent,
 				spec.fid);
 
-		if (spec.fname == m_focused_element) {
+		if (spec.fname == m_focused_element)
 			Environment->setFocus(e);
-		}
+		if (data->disabled_elements.find(spec.fname) != data->disabled_elements.end())
+			e->setEnabled(false);
 
 		for (const std::string &item : items) {
 			e->addItem(unescape_translate(unescape_string(
@@ -1452,9 +1458,10 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		gui::IGUIEditBox *e = Environment->addEditBox(0, rect, true,
 				data->current_parent, spec.fid);
 
-		if (spec.fname == m_focused_element) {
+		if (spec.fname == m_focused_element)
 			Environment->setFocus(e);
-		}
+		if (data->disabled_elements.find(spec.fname) != data->disabled_elements.end())
+			e->setEnabled(false);
 
 		if (label.length() >= 1) {
 			int font_height = g_fontengine->getTextHeight();
@@ -1469,7 +1476,8 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		auto style = getDefaultStyleForElement("pwdfield", name, "field");
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 		e->setDrawBorder(style.getBool(StyleSpec::BORDER, true));
-		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, e->isEnabled() ?
+			video::SColor(255, 255, 255, 255) : video::SColor(255, 127, 127, 127)));
 		e->setOverrideFont(style.getFont());
 
 		irr::SEvent evt;
@@ -1532,6 +1540,8 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 	if (e) {
 		if (is_editable && spec.fname == m_focused_element)
 			Environment->setFocus(e);
+		if (data->disabled_elements.find(spec.fname) != data->disabled_elements.end())
+			e->setEnabled(false);
 
 		if (is_multiline) {
 			e->setMultiLine(true);
@@ -1550,7 +1560,8 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 		e->setDrawBorder(style.getBool(StyleSpec::BORDER, true));
-		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, e->isEnabled() ?
+			video::SColor(255, 255, 255, 255) : video::SColor(255, 127, 127, 127)));
 		if (style.get(StyleSpec::BGCOLOR, "") == "transparent") {
 			e->setDrawBackground(false);
 		}
@@ -1990,9 +2001,10 @@ void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &elem
 		GUIButtonImage *e = GUIButtonImage::addButton(Environment, rect, m_tsrc,
 				data->current_parent, spec.fid, spec.flabel.c_str());
 
-		if (spec.fname == m_focused_element) {
+		if (spec.fname == m_focused_element)
 			Environment->setFocus(e);
-		}
+		if (data->disabled_elements.find(spec.fname) != data->disabled_elements.end())
+			e->setEnabled(false);
 
 		auto style = getStyleForElement("image_button", spec.fname);
 
@@ -2120,6 +2132,9 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 				(tab_index < (int) buttons.size()))
 			e->setActiveTab(tab_index);
 
+		if (data->disabled_elements.find(spec.fname) != data->disabled_elements.end())
+			e->setEnabled(false);
+
 		m_fields.push_back(spec);
 		return;
 	}
@@ -2194,9 +2209,10 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 		auto style = getStyleForElement("item_image_button", spec_btn.fname, "image_button");
 		e_btn->setStyles(style);
 
-		if (spec_btn.fname == m_focused_element) {
+		if (spec_btn.fname == m_focused_element)
 			Environment->setFocus(e_btn);
-		}
+		if (data->disabled_elements.find(spec_btn.fname) != data->disabled_elements.end())
+			e_btn->setEnabled(false);
 
 		spec_btn.ftype = f_Button;
 		rect += data->basepos-padding;
@@ -2686,6 +2702,14 @@ void GUIFormSpecMenu::parseSetFocus(const std::string &element)
 		<< "'" << std::endl;
 }
 
+void GUIFormSpecMenu::parseSetDisabled(parserData *data, const std::string &element)
+{
+	std::vector<std::string> parts = split(element, ',');
+
+	for (size_t i = 0; i < parts.size(); i++)
+		data->disabled_elements[parts[i]] = true;
+}
+
 void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 {
 	//some prechecks
@@ -2882,6 +2906,11 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 		return;
 	}
 
+	if (type == "set_disabled") {
+		parseSetDisabled(data, description);
+		return;
+	}
+
 	// Ignore others
 	infostream << "Unknown DrawSpec: type=" << type << ", data=\"" << description << "\""
 			<< std::endl;
@@ -2907,7 +2936,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 		// Preserve focus
 		gui::IGUIElement *focused_element = Environment->getFocus();
-		if (focused_element && focused_element->getParent() == this) {
+		if (focused_element) {
 			s32 focused_id = focused_element->getID();
 			if (focused_id > 257) {
 				for (const GUIFormSpecMenu::FieldSpec &field : m_fields) {

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -367,6 +367,7 @@ private:
 		GUITable::TableOptions table_options;
 		GUITable::TableColumns table_columns;
 		gui::IGUIElement *current_parent = nullptr;
+		std::unordered_map<std::string, bool> disabled_elements;
 
 		GUIInventoryList::Options inventorylist_options;
 
@@ -444,6 +445,7 @@ private:
 	void parseAnchor(parserData *data, const std::string &element);
 	bool parseStyle(parserData *data, const std::string &element, bool style_type);
 	void parseSetFocus(const std::string &element);
+	void parseSetDisabled(parserData *data, const std::string &element);
 
 	void tryClose();
 


### PR DESCRIPTION
This PR allows formspec elements to be disabled with `set_disabled[<name 1>,<name 2>,...]` and styled with the `:focused` (last interacted with element) and `:disabled` style selectors.

Nearly all interactive elements can be disabled, with the effect of graying out the text for most of them (it all depends on what Irrlicht decides to do).  Disabled buttons, by default, have gray text and a `content_offset` of 0 when pressed.  The default button border also does not indent in the pressed state when disabled.  This cannot be changed, but I doubt anyone would want such behaviour on a disabled button anyway.

The `:focused` selector takes lower precedence than everything except `:default` whereas `:disabled` takes highest precedence.

This screenshot shows all the features.  The right elements are disabled elements, whereas the left are enabled.  The bottom two buttons use the `:focused` and `:disabled` selectors combined with other selectors.

![image](https://user-images.githubusercontent.com/31123645/90320867-6de26d00-def9-11ea-850a-e56e04e4e3fb.png)

## To do

This PR is Ready for Review.

## How to test

Make sure disabled elements don't interact at all, especially buttons; check that selectors work properly, including combination.  The above screenshot:
```
formspec_version[4]
size[9,13]

set_disabled[checkbox-2,button-2,image_button-2,item_image_button-2,table-2,textlist-2,dropdown-2,field-2,pwdfield-2,textarea-2,scrollbar-2,tabheader-2]

checkbox[1,0.5;checkbox-1;checkbox-1]
button[1,1;3,0.7;button-1;button-1]
image_button[1,2;3,0.7;air.png;image_button-1;image_button-1]
item_image_button[1,3;3,0.7;air;item_image_button-1;item_image_button-1]
table[1,4;3,0.7;table-1;table-1,-;1]
textlist[1,5;3,0.7;textlist-1;textlist-1,-;0]
dropdown[1,6;3,0.7;dropdown-1;dropdown-1,-;0]
field[1,7;3,0.7;field-1;field-1;field-1]
pwdfield[1,8;3,0.7;pwdfield-1;pwdfield-1]
textarea[1,9;3,0.7;textarea-1;textarea-1;textarea-1]
scrollbar[1,10;3,0.7;;scrollbar-1;scrollbar-1;0]
tabheader[1,11.7;3,0.7;tabheader-1;tabheader-1,-,-;1;;]

checkbox[5,0.5;checkbox-2;checkbox-2]
button[5,1;3,0.7;button-2;button-2]
image_button[5,2;3,0.7;air.png;image_button-2;image_button-2]
item_image_button[5,3;3,0.7;air;item_image_button-2;item_image_button-2]
table[5,4;3,0.7;table-2;table-2,-;1]
textlist[5,5;3,0.7;textlist-2;textlist-2,-;0]
dropdown[5,6;3,0.7;dropdown-2;dropdown-2,-;1]
field[5,7;3,0.7;field-2;field-2;field-2]
pwdfield[5,8;3,0.7;pwdfield-2;pwdfield-2]
textarea[5,9;3,0.7;textarea-2;textarea-2;textarea-2]
scrollbar[5,10;3,0.7;;scrollbar-2;scrollbar-2;0]
tabheader[5,11.7;3,0.7;tabheader-2;tabheader-2,-,-;1;;]
				
style_type[button:default;bgcolor=gray]

style_type[button:focused;bgcolor=red]
style_type[button:focused+hovered;bgcolor=orange]
style_type[button:focused+pressed;bgcolor=yellow]
set_focus[focus-style;true]
button[1,12;3,0.7;focus-style;Focused Styling]

style_type[button:disabled;bgcolor=green]
style_type[button:disabled+focused;bgcolor=violet]
style_type[button:disabled+hovered;bgcolor=cyan]
style_type[button:disabled+pressed;bgcolor=blue]
set_disabled[disable-style]
button[5,12;3,0.7;disable-style;Disabled Styling]
```