### PR TITLE
Add /upgrade_mapblocks command

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -1039,7 +1039,7 @@ core.register_chatcommand("clearobjects", {
 	end,
 })
 
-core.register_chatcommand("upgrade-mapblocks", {
+core.register_chatcommand("upgrade_mapblocks", {
 	params = "[version_threshold]",
 	description = "Upgrade all old MapBlocks below the specified version.",
 	privs = {server=true},

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -1039,6 +1039,24 @@ core.register_chatcommand("clearobjects", {
 	end,
 })
 
+core.register_chatcommand("upgrade-mapblocks", {
+	params = "[version_threshold]",
+	description = "Upgrade all old MapBlocks below the specified version.",
+	privs = {server=true},
+	func = function(name, param)
+		local version_threshold = tonumber(param) or 0
+
+		core.log("action", name .. " upgrades all mapblocks")
+		core.chat_send_all("Upgrading mapblocks. This may take a long time."
+				.. " You may experience a timeout. (by "
+				.. name .. ")")
+		core.upgrade_mapblocks(version_threshold)
+		core.log("action", "MapBlock upgrade done.")
+		core.chat_send_all("*** MapBlock upgrade done.")
+		return true
+	end,
+})
+
 core.register_chatcommand("msg", {
 	params = "<name> <message>",
 	description = "Send a direct message to a player",

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1257,7 +1257,8 @@ movement_gravity (Gravity) float 9.81
 #    -    error: abort on usage of deprecated call (suggested for mod developers).
 deprecated_lua_api_handling (Deprecated Lua API handling) enum legacy legacy,log,error
 
-#    Number of extra blocks that can be loaded by /clearobjects at once.
+#    Number of simultaneously loaded blocks when /clearobjects or
+#    /upgradeblocks is used.
 #    This is a trade-off between sqlite transaction overhead and
 #    memory consumption (4096=100MB, as a rule of thumb).
 max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1258,7 +1258,7 @@ movement_gravity (Gravity) float 9.81
 deprecated_lua_api_handling (Deprecated Lua API handling) enum legacy legacy,log,error
 
 #    Number of simultaneously loaded blocks when /clearobjects or
-#    /upgradeblocks is used.
+#    /upgrade-mapblocks is used.
 #    This is a trade-off between sqlite transaction overhead and
 #    memory consumption (4096=100MB, as a rule of thumb).
 max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1258,7 +1258,7 @@ movement_gravity (Gravity) float 9.81
 deprecated_lua_api_handling (Deprecated Lua API handling) enum legacy legacy,log,error
 
 #    Number of simultaneously loaded blocks when /clearobjects or
-#    /upgrade-mapblocks is used.
+#    /upgrade_mapblocks is used.
 #    This is a trade-off between sqlite transaction overhead and
 #    memory consumption (4096=100MB, as a rule of thumb).
 max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096

--- a/src/map.h
+++ b/src/map.h
@@ -374,15 +374,6 @@ public:
 	*/
 	MapBlock *getBlockOrEmerge(v3s16 p3d);
 
-	// Helper for placing objects on ground level
-	s16 findGroundLevel(v2s16 p2d);
-
-	/*
-		Misc. helper functions for fiddling with directory and file
-		names when saving
-	*/
-	void createDirs(const std::string &path);
-
 	/*
 		Database functions
 	*/
@@ -402,7 +393,7 @@ public:
 	static bool saveBlock(MapBlock *block, MapDatabase *db);
 	MapBlock* loadBlock(v3s16 p);
 	// Database version
-	void loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool save_after_load=false);
+	void loadBlock(std::string *blob, v3s16 p3d, MapSector *sector);
 
 	bool deleteBlock(v3s16 blockpos);
 
@@ -414,7 +405,6 @@ public:
 	bool isSavingEnabled(){ return m_map_saving_enabled; }
 
 	u64 getSeed();
-	s16 getWaterLevel();
 
 	/*!
 	 * Fixes lighting in one map block.
@@ -435,21 +425,13 @@ private:
 	std::string m_savedir;
 	bool m_map_saving_enabled;
 
-#if 0
-	// Chunk size in MapSectors
-	// If 0, chunks are disabled.
-	s16 m_chunksize;
-	// Chunks
-	core::map<v2s16, MapChunk*> m_chunks;
-#endif
-
 	/*
 		Metadata is re-written on disk only if this is true.
 		This is reset to false when written on disk.
 	*/
 	bool m_map_metadata_changed = true;
-	MapDatabase *dbase = nullptr;
-	MapDatabase *dbase_ro = nullptr;
+	MapDatabase *m_db_rw = nullptr;
+	MapDatabase *m_db_ro = nullptr;
 
 	MetricCounterPtr m_save_time_counter;
 };

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -365,6 +365,9 @@ void MapBlock::serialize(std::ostream &os, u8 version, bool disk)
 
 	FATAL_ERROR_IF(version < SER_FMT_VER_LOWEST_WRITE, "Serialisation version error");
 
+	if (disk)
+		m_version_disk = version;
+
 	// First byte
 	u8 flags = 0;
 	if(is_underground)
@@ -457,6 +460,9 @@ void MapBlock::deSerialize(std::istream &is, u8 version, bool disk)
 	TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())<<std::endl);
 
 	m_day_night_differs_expired = false;
+
+	if (disk)
+		m_version_disk = version;
 
 	if(version <= 21)
 	{

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -58,6 +58,7 @@ static const char *modified_reason_strings[] = {
 	"deactivateFarObjects: Static data moved out",
 	"deactivateFarObjects: Static data changed considerably",
 	"finishBlockMake: expireDayNightDiff",
+	"MapBlock version upgrade",
 	"unknown",
 };
 

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -64,7 +64,8 @@ class VoxelManipulator;
 #define MOD_REASON_STATIC_DATA_CHANGED       (1 << 17)
 #define MOD_REASON_EXPIRE_DAYNIGHTDIFF       (1 << 18)
 #define MOD_REASON_VMANIP                    (1 << 19)
-#define MOD_REASON_UNKNOWN                   (1 << 20)
+#define MOD_REASON_SER_FMT_UPGRADE           (1 << 20)
+#define MOD_REASON_UNKNOWN                   (1 << 21)
 
 ////
 //// MapBlock itself
@@ -487,6 +488,11 @@ public:
 	// unknown blocks from id-name mapping to wndef
 	void deSerialize(std::istream &is, u8 version, bool disk);
 
+	inline u8 getVersionDisk() const
+	{
+		return m_version_disk;
+	}
+
 	void serializeNetworkSpecific(std::ostream &os);
 	void deSerializeNetworkSpecific(std::istream &is);
 private:
@@ -618,6 +624,9 @@ private:
 		the list of blocks to be drawn.
 	*/
 	int m_refcount = 0;
+
+	// Version read out by the last deSerialize() from the disk
+	u8 m_version_disk = 0;
 };
 
 typedef std::vector<MapBlock*> MapBlockVect;

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1046,6 +1046,20 @@ int ModApiEnvMod::l_clear_objects(lua_State *L)
 	return 0;
 }
 
+// upgrade_mapblocks(threshold_version)
+// Upgrade all mapblocks below the threshold version
+int ModApiEnvMod::l_upgrade_mapblocks(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	// Range is sanity-checked in ServerEnvironment::upgradeMapBlocks
+	int version = luaL_checkint(L, 1);
+	env->upgradeMapBlocks(version);
+
+	return 0;
+}
+
+
 // line_of_sight(pos1, pos2) -> true/false, pos
 int ModApiEnvMod::l_line_of_sight(lua_State *L)
 {
@@ -1387,6 +1401,7 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(get_perlin_map);
 	API_FCT(get_voxel_manip);
 	API_FCT(clear_objects);
+	API_FCT(upgrade_mapblocks);
 	API_FCT(spawn_tree);
 	API_FCT(find_path);
 	API_FCT(line_of_sight);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -163,6 +163,9 @@ private:
 	// clear all objects in the environment
 	static int l_clear_objects(lua_State *L);
 
+	// upgrade_mapblocks(threshold_version)
+	static int l_upgrade_mapblocks(lua_State *L);
+
 	// spawn_tree(pos, treedef)
 	static int l_spawn_tree(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -327,8 +327,10 @@ Server::~Server()
 	}
 
 	// Delete things in the reverse order of creation
-	delete m_emerge;
 	delete m_env;
+	// ServerEnvironment::deactivateFarObjects
+	// requires EmergeManager to be alive
+	delete m_emerge;
 	delete m_rollback;
 	delete m_banmanager;
 	delete m_itemdef;

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -332,6 +332,9 @@ public:
 	// Clear objects, loading and going through every MapBlock
 	void clearObjects(ClearObjectsMode mode);
 
+	// Load and check every MapBlock for an update
+	void upgradeMapBlocks(int version);
+
 	// This makes stuff happen
 	void step(f32 dtime);
 


### PR DESCRIPTION
This command is designed to provide the easiest transition possible to update ancient maps.
In the future it will allow to remove support for very old maps (< 0.4.x) to get rid of the legacy code.

Removes unused code, minor code tidy.

## To do

This PR is Ready for Review.

## How to test

1) Have an old map, example: https://forum.minetest.net/viewtopic.php?f=12&t=3364
2) Ensure the log level is set to `action` or lower
3) Change the `world.mt`: `gameid = minetest`
4) Patch `minetest_game/mods/weather/init.lua`:
  * L91 `local humid = minetest.get_humidity(player:get_pos()) or 0`
5) Join the world
6) `/upgrade_mapblocks`
7) Check log output