### PR TITLE
Added serialization routines for double precision floating point.

### DIFF
--- a/src/unittest/test_serialization.cpp
+++ b/src/unittest/test_serialization.cpp
@@ -714,46 +714,33 @@ void TestSerialization::testFloatFormat()
 void TestSerialization::testDoubleFormat()
 {
 	std::ostringstream os(std::ios_base::binary);
+	std::vector[u8] vec;
 
 	for (int i = 0; i < 150; i++)
 	{
-		writeD1000(os, test_double_data[i]);
-		writeD(os, test_double_data[i]);
-		writeF32(os, test_double_data[i]);
-		writeF32(os, test_double_data[i]);
+		writeF64(os, test_double_data[i]);
+		putF64(vec, test_double_data[i]);
 	}
-	for (int i = 0; i < 150; i += 3)
-	{
-		v3d p(test_double_data[i], test_double_data[i+1], test_double_data[i+2]);
-		writeV3D1000(os, p);
-		writeV3D(os, p);
-		writeV3F32(os, p);
-		writeV3F32(os, v3f((f32)p.X, (f32)p.Y, (f32)p.Z));
-	}
+
+	v3d p(test_double_data[0], test_double_data[1], test_double_data[2]);
+	writeV3F64(os, p);
+	putV3F64(vec, p);
 
 	std::istringstream is(os.str(), std::ios_base::binary);
 	for (int i = 0; i < 150; i++)
 	{
-		double actual;
                 double expected = test_double_data[i];
-                actual = readD1000(is);
-		UTEST(irr::core::equals(actual, expected, 0.001), "readD1000[%d] %f == %f delta %f", i, actual, expected, actual - expected );
-		actual = readD(is);
-		UTEST(irr::core::equals(actual, expected, 0.0005), "readD[%d] %f == %f delta %f", i, actual, expected, actual - expected );
-		UASSERTEQ(f32, readF32(is), readF32(is));
+		double actual = readF64(is);
+		UTEST(irr::core::equals(actual, expected, 0.0005), "readF64[%d] %f == %f delta %f", i, actual, expected, actual - expected );
+		actual = getF64(vec);
+		UTEST(irr::core::equals(actual, expected, 0.0005), "getF64[%d] %f == %f delta %f", i, actual, expected, actual - expected );
 	}
-	for (int i = 0; i < 150; i += 3)
-	{
-		v3d a;
-		v3d p(test_double_data[i], test_double_data[i+1], test_double_data[i+2]);
-		a = readV3D1000(is);
-		UTEST(p.equals(a, 0.001), "readV3D1000[%d] (%f, %f, %f) == (%f, %f, %f) delta (%f, %f, %f)", i, a.X, a.Y, a.Z, p.X, p.Y, p.Z, a.X - p.X, a.Y - p.Y, a.Z - p.Z);
-		a = readV3D(is);
-		UTEST(p.equals(a, 1.5e-8), "readV3D[%d] (%f, %f, %f) == (%f, %f, %f) delta (%f, %f, %f)", i, a.X, a.Y, a.Z, p.X, p.Y, p.Z, a.X - p.X, a.Y - p.Y, a.Z - p.Z);
-		v3f af = readV3F32(is);
-		v3f bf = readV3F32(is);
-		UTEST(af == bf, "readV3F32[%d] (%f, %f, %f) == (%f, %f, %f) delta (%f, %f, %f)", i, af.X, af.Y, af.Z, bf.X, bf.Y, bf.Z, af.X - bf.X, af.Y - bf.Y, af.Z - bf.Z);
-	}
+
+	v3d p(test_double_data[0], test_double_data[1], test_double_data[2]);
+	v3d a = readV3F64(is);
+	UTEST(p.equals(a, 1.5e-8), "readV3F64 (%f, %f, %f) == (%f, %f, %f) delta (%f, %f, %f)", a.X, a.Y, a.Z, p.X, p.Y, p.Z, a.X - p.X, a.Y - p.Y, a.Z - p.Z);
+	a = getV3F64(vec);
+	UTEST(p.equals(a, 1.5e-8), "getV3F64 (%f, %f, %f) == (%f, %f, %f) delta (%f, %f, %f)", a.X, a.Y, a.Z, p.X, p.Y, p.Z, a.X - p.X, a.Y - p.Y, a.Z - p.Z);
 }
 
 const u8 TestSerialization::test_serialized_data[12 * 13 - 8] = {

--- a/src/unittest/test_serialization.cpp
+++ b/src/unittest/test_serialization.cpp
@@ -714,32 +714,33 @@ void TestSerialization::testFloatFormat()
 void TestSerialization::testDoubleFormat()
 {
 	std::ostringstream os(std::ios_base::binary);
-	std::vector[u8] vec;
+	std::vector<u8> vec;
 
 	for (int i = 0; i < 150; i++)
 	{
 		writeF64(os, test_double_data[i]);
-		putF64(vec, test_double_data[i]);
+		putF64(&vec, test_double_data[i]);
 	}
 
 	v3d p(test_double_data[0], test_double_data[1], test_double_data[2]);
 	writeV3F64(os, p);
-	putV3F64(vec, p);
+	putV3F64(&vec, p);
 
 	std::istringstream is(os.str(), std::ios_base::binary);
+	BufReader buf(&vec.front(), vec.size());
+
 	for (int i = 0; i < 150; i++)
 	{
                 double expected = test_double_data[i];
 		double actual = readF64(is);
 		UTEST(irr::core::equals(actual, expected, 0.0005), "readF64[%d] %f == %f delta %f", i, actual, expected, actual - expected );
-		actual = getF64(vec);
+		actual = buf.getF64();
 		UTEST(irr::core::equals(actual, expected, 0.0005), "getF64[%d] %f == %f delta %f", i, actual, expected, actual - expected );
 	}
 
-	v3d p(test_double_data[0], test_double_data[1], test_double_data[2]);
 	v3d a = readV3F64(is);
 	UTEST(p.equals(a, 1.5e-8), "readV3F64 (%f, %f, %f) == (%f, %f, %f) delta (%f, %f, %f)", a.X, a.Y, a.Z, p.X, p.Y, p.Z, a.X - p.X, a.Y - p.Y, a.Z - p.Z);
-	a = getV3F64(vec);
+	a = buf.getV3F64();
 	UTEST(p.equals(a, 1.5e-8), "getV3F64 (%f, %f, %f) == (%f, %f, %f) delta (%f, %f, %f)", a.X, a.Y, a.Z, p.X, p.Y, p.Z, a.X - p.X, a.Y - p.Y, a.Z - p.Z);
 }
 

--- a/src/unittest/test_serialization.cpp
+++ b/src/unittest/test_serialization.cpp
@@ -734,16 +734,25 @@ void TestSerialization::testDoubleFormat()
 	std::istringstream is(os.str(), std::ios_base::binary);
 	for (int i = 0; i < 150; i++)
 	{
-		UASSERT(irr::core::equals(readD1000(is), test_double_data[i], 0.0005));
-		UASSERT(irr::core::equals(readD(is), test_double_data[i], 1.5e-8));
-		UASSERT(readF32(is) == readF32(is));
+		double actual;
+                double expected = test_double_data[i];
+                actual = readD1000(is);
+		UTEST(irr::core::equals(actual, expected, 0.001), "readD1000[%d] %f == %f delta %f", i, actual, expected, actual - expected );
+		actual = readD(is);
+		UTEST(irr::core::equals(actual, expected, 0.0005), "readD[%d] %f == %f delta %f", i, actual, expected, actual - expected );
+		UASSERTEQ(f32, readF32(is), readF32(is));
 	}
 	for (int i = 0; i < 150; i += 3)
 	{
+		v3d a;
 		v3d p(test_double_data[i], test_double_data[i+1], test_double_data[i+2]);
-		UASSERT(p.equals(readV3D1000(is), 0.0005));
-		UASSERT(p.equals(readV3D(is), 1.5e-8));
-		UASSERT(readV3F32(is) == readV3F32(is));
+		a = readV3D1000(is);
+		UTEST(p.equals(a, 0.001), "readV3D1000[%d] (%f, %f, %f) == (%f, %f, %f) delta (%f, %f, %f)", i, a.X, a.Y, a.Z, p.X, p.Y, p.Z, a.X - p.X, a.Y - p.Y, a.Z - p.Z);
+		a = readV3D(is);
+		UTEST(p.equals(a, 1.5e-8), "readV3D[%d] (%f, %f, %f) == (%f, %f, %f) delta (%f, %f, %f)", i, a.X, a.Y, a.Z, p.X, p.Y, p.Z, a.X - p.X, a.Y - p.Y, a.Z - p.Z);
+		v3f af = readV3F32(is);
+		v3f bf = readV3F32(is);
+		UTEST(af == bf, "readV3F32[%d] (%f, %f, %f) == (%f, %f, %f) delta (%f, %f, %f)", i, af.X, af.Y, af.Z, bf.X, bf.Y, bf.Z, af.X - bf.X, af.Y - bf.Y, af.Z - bf.Z);
 	}
 }
 

--- a/src/unittest/test_serialization.cpp
+++ b/src/unittest/test_serialization.cpp
@@ -45,12 +45,14 @@ public:
 	void testStringLengthLimits();
 	void testBufReader();
 	void testFloatFormat();
+	void testDoubleFormat();
 
 	std::string teststring2;
 	std::wstring teststring2_w;
 	std::string teststring2_w_encoded;
 
 	static const u8 test_serialized_data[12 * 13 - 8];
+	static const double test_double_data[];
 };
 
 static TestSerialization g_test_instance;
@@ -73,6 +75,7 @@ void TestSerialization::runTests(IGameDef *gamedef)
 	TEST(testStringLengthLimits);
 	TEST(testBufReader);
 	TEST(testFloatFormat);
+	TEST(testDoubleFormat);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -708,6 +711,42 @@ void TestSerialization::testFloatFormat()
 		UASSERT(test_single(i));
 }
 
+void TestSerialization::testDoubleFormat()
+{
+	std::ostringstream os(std::ios_base::binary);
+
+	for (int i = 0; i < 150; i++)
+	{
+		writeD1000(os, test_double_data[i]);
+		writeD(os, test_double_data[i]);
+		writeF32(os, test_double_data[i]);
+		writeF32(os, test_double_data[i]);
+	}
+	for (int i = 0; i < 150; i += 3)
+	{
+		v3d p(test_double_data[i], test_double_data[i+1], test_double_data[i+2]);
+		writeV3D1000(os, p);
+		writeV3D(os, p);
+		writeV3F32(os, p);
+		writeV3F32(os, v3f((f32)p.X, (f32)p.Y, (f32)p.Z));
+	}
+
+	std::istringstream is(os.str(), std::ios_base::binary);
+	for (int i = 0; i < 150; i++)
+	{
+		UASSERT(irr::core::equals(readD1000(is), test_double_data[i], 0.0005));
+		UASSERT(irr::core::equals(readD(is), test_double_data[i], 1.5e-8));
+		UASSERT(readF32(is) == readF32(is));
+	}
+	for (int i = 0; i < 150; i += 3)
+	{
+		v3d p(test_double_data[i], test_double_data[i+1], test_double_data[i+2]);
+		UASSERT(p.equals(readV3D1000(is), 0.0005));
+		UASSERT(p.equals(readV3D(is), 1.5e-8));
+		UASSERT(readV3F32(is) == readV3F32(is));
+	}
+}
+
 const u8 TestSerialization::test_serialized_data[12 * 13 - 8] = {
 	0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc,
 	0xdd, 0xee, 0xff, 0x80, 0x75, 0x30, 0xff, 0xff, 0xff, 0xfa, 0xff, 0xff,
@@ -722,4 +761,37 @@ const u8 TestSerialization::test_serialized_data[12 * 13 - 8] = {
 	0xfd, 0x0f, 0xe4, 0xff, 0x80, 0x32, 0x80, 0x00, 0x00, 0x00, 0x17, 0x73,
 	0x6f, 0x6d, 0x65, 0x20, 0x6c, 0x6f, 0x6e, 0x67, 0x65, 0x72, 0x20, 0x73,
 	0x74, 0x72, 0x69, 0x6e, 0x67, 0x20, 0x68, 0x65, 0x72, 0x65, 0xF0, 0x0D,
+};
+
+const double TestSerialization::test_double_data[] = {
+	-16131.26789, -99.9309116, -12234.23762, -26729.93114, -12685.38472,
+	-27709.60151, -19240.13443, 29197.36426, -12444.92151, -22762.81007,
+	-18417.92435, -10870.37175, -4308.983026, -9875.596165, -29040.95346,
+	25270.46533, -25701.98492, -10910.86165, 25693.90276, 5912.171371,
+	15460.13208, 23938.55639, -9640.844721, 24655.44249, 66.69525239,
+	-18315.99044, 757.7224709, 13350.45634, -29867.86728, -26874.39932,
+	-21969.66307, 21484.45576, 23979.4328, 4983.785807, -8912.94693,
+	-16788.39344, -25633.56625, -31893.71107, -22140.93791, 23606.00351,
+	1253.457666, -5548.898773, 11214.72366, -18668.5665, -19063.33975,
+	27168.07547, -6544.885639, -30843.2287, 8867.172141, -19067.04993,
+	2520.649661, -31264.4239, 790.7114849, -31295.69114, -31502.09435,
+	-10068.27859, 25272.31296, 27006.65061, -4560.445655, 29709.04585,
+	-18810.9435, 24208.63772, 1037.778844, -8551.73457, -139.36837,
+	6378.401169, -21586.52826, 2392.316728, 10339.30306, 2602.217762,
+	-16543.63241, 3452.215348, -5052.729414, 27754.37573, -6267.750871,
+	-31263.53093, -28867.22373, 27424.5577, 6055.484632, -10638.92572,
+	26040.17251, 21618.48183, -31728.45456, -24832.81613, 14621.65348,
+	-208.9047649, -12690.72575, 18673.7416, 2121.614764, -10872.65718,
+	-9492.393825, 23164.19495, 1500.03944, -7025.277525, 742.8997793,
+	21909.90821, 24020.09571, 19936.11069, 747.1412911, -5996.252865,
+	-25094.33894, -3818.651907, -28666.71829, 11628.62356, -16234.66167,
+	5532.954396, -21140.74802, -5820.149489, 13139.47337, 1836.375751,
+	-4207.14269, 15368.7331, 894.6214134, -17387.46178, 12456.45156,
+	25537.86348, -3228.231299, -20135.87424, -23387.74476, -20203.38124,
+	20125.49106, -23279.01326, 7905.803486, -11120.79458, 10041.37951,
+	16061.55622, -5998.705562, 15009.95211, -9386.972708, 12276.28204,
+	-15165.18555, 16537.88528, 24970.45794, 3120.97778, -7446.72183,
+	-9895.564273, 6174.826066, 20719.76119, -13482.643, 29994.82279,
+	25556.24809, 8574.760033, 20264.25058, -26199.98694, 13597.41647,
+	22857.54563, 20977.39509, 18009.99258, -14577.99117, -1240.162216,
 };

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -693,13 +693,13 @@ inline void putF32(std::vector<u8> *dest, f32 val)
 
 inline void putF64(std::vector<u8> *dest, double val)
 {
-	// i contains 54 significant bits (53 bits of value plus the sign bit)
+	// val contains 54 significant bits (53 bits of value plus the sign bit)
 	// We need about 33 of them for correct movement logic.
-	f32 base = (f32)i;
+	f32 base = (f32)val;
 	// Base contains the most significant 25 bits of i.
 	putF32(dest, base);
-	// As a double, i - base contains the next 25 most significant bits, for a total of 50.
-	putF32(dest, i - base);
+	// As a double, val - base contains the next 25 most significant bits, for a total of 50.
+	putF32(dest, val - base);
 }
 
 inline void putV2S16(std::vector<u8> *dest, v2s16 val)

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -362,6 +362,11 @@ inline void writeF32(u8 *data, f32 i)
 	throw SerializationError("writeF32: Unreachable code");
 }
 
+inline void writeF32(u8 *data, double i)
+{
+	writeF32(data, (f32)i);
+}
+
 inline void writeD1000(u8 *data, double i)
 {
 	// The limits are relevant to the 32 bit destination, not the float precision.
@@ -369,7 +374,7 @@ inline void writeD1000(u8 *data, double i)
 	writeS32(data, i * FIXEDPOINT_FACTOR);
 }
 
-inline void writeF32(u8 *data, double i)
+inline void writeD(u8 *data, double i)
 {
 	f32 base = (f32)i;
 	writeF32(&data[0], base);
@@ -425,6 +430,18 @@ inline void writeV3F32(u8 *data, v3f p)
 	writeF32(&data[0], p.X);
 	writeF32(&data[4], p.Y);
 	writeF32(&data[8], p.Z);
+
+inline void writeV2F32(u8 *data, v2d p)
+{
+	writeF32(&data[0], (f32)p.X);
+	writeF32(&data[4], (f32)p.Y);
+}
+
+inline void writeV3F32(u8 *data, v3d p)
+{
+	writeF32(&data[0], (f32)p.X);
+	writeF32(&data[4], (f32)p.Y);
+	writeF32(&data[8], (f32)p.Z);
 }
 
 inline void writeV3D1000(u8 *data, v3d p)
@@ -501,6 +518,7 @@ MAKE_STREAM_WRITE_FXN(s32,   S32,      4);
 MAKE_STREAM_WRITE_FXN(s64,   S64,      8);
 MAKE_STREAM_WRITE_FXN(f32,   F1000,    4);
 MAKE_STREAM_WRITE_FXN(f32,   F32,      4);
+MAKE_STREAM_WRITE_FXN(double,   F32,      4);
 MAKE_STREAM_WRITE_FXN(double,   D1000,    4);
 MAKE_STREAM_WRITE_FXN(double,   D,      8);
 MAKE_STREAM_WRITE_FXN(v2s16, V2S16,    4);
@@ -510,6 +528,8 @@ MAKE_STREAM_WRITE_FXN(v3s32, V3S32,   12);
 MAKE_STREAM_WRITE_FXN(v3f,   V3F1000, 12);
 MAKE_STREAM_WRITE_FXN(v2f,   V2F32,    8);
 MAKE_STREAM_WRITE_FXN(v3f,   V3F32,   12);
+MAKE_STREAM_WRITE_FXN(v2d,   V2F32,    8);
+MAKE_STREAM_WRITE_FXN(v3d,   V3F32,   12);
 MAKE_STREAM_WRITE_FXN(v3d,   V3D1000, 12);
 MAKE_STREAM_WRITE_FXN(v2d,   V2D,    16);
 MAKE_STREAM_WRITE_FXN(v3d,   V3D,   24);

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -295,17 +295,9 @@ inline v3d readV3D1000(const u8 *data)
 	return p;
 }
 
-inline v2d readV2D(const u8 *data)
-{
-	v2f d;
-	p.X = readD(&data[0]);
-	p.Y = readD(&data[8]);
-	return p;
-}
-
 inline v3d readV3D(const u8 *data)
 {
-	v3f p;
+	v3d p;
 	p.X = readD(&data[0]);
 	p.Y = readD(&data[8]);
 	p.Z = readD(&data[16]);
@@ -431,12 +423,6 @@ inline void writeV3F32(u8 *data, v3f p)
 	writeF32(&data[4], p.Y);
 	writeF32(&data[8], p.Z);
 
-inline void writeV2F32(u8 *data, v2d p)
-{
-	writeF32(&data[0], (f32)p.X);
-	writeF32(&data[4], (f32)p.Y);
-}
-
 inline void writeV3F32(u8 *data, v3d p)
 {
 	writeF32(&data[0], (f32)p.X);
@@ -449,12 +435,6 @@ inline void writeV3D1000(u8 *data, v3d p)
 	writeD1000(&data[0], p.X);
 	writeD1000(&data[4], p.Y);
 	writeD1000(&data[8], p.Z);
-}
-
-inline void writeV2D(u8 *data, v2d p)
-{
-	writeD(&data[0], p.X);
-	writeD(&data[8], p.Y);
 }
 
 inline void writeV3D(u8 *data, v3f p)
@@ -504,7 +484,6 @@ MAKE_STREAM_READ_FXN(v3f,   V3F1000, 12);
 MAKE_STREAM_READ_FXN(v2f,   V2F32,    8);
 MAKE_STREAM_READ_FXN(v3f,   V3F32,   12);
 MAKE_STREAM_READ_FXN(v3d,   V3D1000, 12);
-MAKE_STREAM_READ_FXN(v2d,   V2D,    16);
 MAKE_STREAM_READ_FXN(v3d,   V3D,   24);
 MAKE_STREAM_READ_FXN(video::SColor, ARGB8, 4);
 
@@ -528,10 +507,8 @@ MAKE_STREAM_WRITE_FXN(v3s32, V3S32,   12);
 MAKE_STREAM_WRITE_FXN(v3f,   V3F1000, 12);
 MAKE_STREAM_WRITE_FXN(v2f,   V2F32,    8);
 MAKE_STREAM_WRITE_FXN(v3f,   V3F32,   12);
-MAKE_STREAM_WRITE_FXN(v2d,   V2F32,    8);
 MAKE_STREAM_WRITE_FXN(v3d,   V3F32,   12);
 MAKE_STREAM_WRITE_FXN(v3d,   V3D1000, 12);
-MAKE_STREAM_WRITE_FXN(v2d,   V2D,    16);
 MAKE_STREAM_WRITE_FXN(v3d,   V3D,   24);
 MAKE_STREAM_WRITE_FXN(video::SColor, ARGB8, 4);
 

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -422,6 +422,7 @@ inline void writeV3F32(u8 *data, v3f p)
 	writeF32(&data[0], p.X);
 	writeF32(&data[4], p.Y);
 	writeF32(&data[8], p.Z);
+}
 
 inline void writeV3F32(u8 *data, v3d p)
 {

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -438,7 +438,7 @@ inline void writeV3D1000(u8 *data, v3d p)
 	writeD1000(&data[8], p.Z);
 }
 
-inline void writeV3D(u8 *data, v3f p)
+inline void writeV3D(u8 *data, v3d p)
 {
 	writeD(&data[0], p.X);
 	writeD(&data[8], p.Y);


### PR DESCRIPTION
- Goal of the PR
This PR adds serialization routines to make it possible to use double precision floating point for position state, thus solving problems with single precision near the borders of the worlds.

- How does the PR work?
Single precision has 24 bits of precision. 16 bits are used to identify the node location, leaving only 8 bits for the fine location with the node when near the edge of the world. 17 bits would be needed to meet design goals for reasonable movement during typical time steps. Double precision has 53 bits of precision, leaving 37 bits for the fine location.
This PR provides serialization routines that are efficient and portable to represent 48 bits of the double's precision, simultaneously avoiding the complexity of serializing double precision values in a portable way and representing plenty of precision even near the world boundary.
 
- Does it resolve any reported issue?
It makes it possible to resolved Issue #9346 by switching the datatype for storing positions from float to double. More work is needed to make that actually happen, including converting the data types used and defining a new protocol version that uses the new serialization routines.

## To do

This PR is a Ready for Review.

- [X] Add serialization routines that serialize double using existing float serialization (enable backward compatibility). 
- [X] Create unit tests.

## How to test

The unit test is the only way to test this PR at present. It tests that the precision is appropriate across the full range of world positions and that the backward compatibility formats work the same regardless of whether single or double precision is used.