### PR TITLE
Fix missing #10286 - Translated strings in hypertext fields are broken if they contain spaces 

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1740,7 +1740,7 @@ void GUIFormSpecMenu::parseHyperText(parserData *data, const std::string &elemen
 
 	FieldSpec spec(
 		name,
-		utf8_to_wide(unescape_string(text)),
+		translate_string(utf8_to_wide(unescape_string(text))),
 		L"",
 		258 + m_fields.size()
 	);


### PR DESCRIPTION
Fixes #10286
Trivial, call to `translate_string` was missing for hypertext elements.
## To do

This PR is a Ready for Review.
## How to test
Use test case from issue:
```
"hypertext[3.1,2.9;3,1;test;" .. S("Try to translate me") .. "]"
```
Expected : should correctly show "Try to translate me" (without extra space) if English enabled, should correctly translate string if other language enabled (and proper .tr file present).