### PR TITLE
Auto focus on OK button in main menu error messages

### DIFF
--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -64,6 +64,7 @@ function ui.update()
 		formspec = {
 			"size[14,8]",
 			"real_coordinates[true]",
+			"set_focus[btn_reconnect_yes;true]",
 			"box[0.5,1.2;13,5;#000]",
 			("textarea[0.5,1.2;13,5;;%s;%s]"):format(
 				fgettext("The server has requested a reconnect:"), error_message),
@@ -82,6 +83,7 @@ function ui.update()
 		formspec = {
 			"size[14,8]",
 			"real_coordinates[true]",
+			"set_focus[btn_error_confirm;true]",
 			"box[0.5,1.2;13,5;#000]",
 			("textarea[0.5,1.2;13,5;;%s;%s]"):format(
 				error_title, error_message),


### PR DESCRIPTION
Fixes #8930.  Just focuses the button with `set_focus`.