### PR TITLE
define environ variable on OpenBSD

### DIFF
--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -25,7 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "porting.h"
 
-#if defined(__FreeBSD__)  || defined(__NetBSD__) || defined(__DragonFly__)
+#if defined(__FreeBSD__)  || defined(__NetBSD__) || defined(__DragonFly__) || defined(__OpenBSD__)
 	#include <sys/types.h>
 	#include <sys/sysctl.h>
 	extern char **environ;


### PR DESCRIPTION
The build on OpenBSD of 5.3.0 is failing due to undefined `environ` variable in `src/porting.cpp`.

The PR adds `defined(__OpenBSD__)` in the list of BSDs which already defines it explicitly.

It makes the build to succeed on OpenBSD.

This PR is a Ready for Review.