### PR TITLE
Fix light overflow of u8 if light is saturated at 255

### DIFF
--- a/src/light.cpp
+++ b/src/light.cpp
@@ -81,9 +81,11 @@ void set_light_table(float gamma)
 		// Strictly speaking, rangelim is not necessary here—if the implementation
 		// is conforming. But we don’t want problems in any case.
 		light_LUT[i] = rangelim((s32)(255.0f * brightness), 0, 255);
+
 		// Ensure light brightens with each level
-		if (i > 1 && light_LUT[i] <= light_LUT[i - 1])
-			light_LUT[i] = light_LUT[i - 1] + 1;
+		if (i > 0 && light_LUT[i] <= light_LUT[i - 1]) {
+			light_LUT[i] = std::min((u8) 254, light_LUT[i - 1]) + 1;
+		}
 	}
 }
 


### PR DESCRIPTION
### Overview

There is a problem with light boost when the lighting lookup table runs into saturation. Using advanced debugging techniques like `printf` statements and taking screenshots, I was able to understand the bug and verify the solution.

### How to reproduce

Use the following settings:

```
Graphics/In-Game/Advanced/lighting_boost (Light curve boost) = 0.4
Graphics/In-Game/Advanced/lighting_boost_center (Light curve boost center) = 1
Graphics/In-Game/Advanced/lighting_boost_spread (Light curve boost spread) = 0.4
```

Then go into the game. You will see many weird, black shadows in brightly lit areas, as shown in the following screenshot:

![screenshot_20200821_003619_bad_light](https://user-images.githubusercontent.com/28017860/90833896-3cc6ca00-e349-11ea-9abd-c2aa39503cab.png)

I dumped the light lookup table, which sheds light on the overflow problem.

```
light_LUT[1]: 8
light_LUT[2]: 16
light_LUT[3]: 28
light_LUT[4]: 43
light_LUT[5]: 63
light_LUT[6]: 86
light_LUT[7]: 112
light_LUT[8]: 141
light_LUT[9]: 172
light_LUT[10]: 204
light_LUT[11]: 237
light_LUT[12]: 255
light_LUT[13]: 0
light_LUT[14]: 255
```

As you can see, the logic will try to add `1` if `light_LUT[i] <= light_LUT[i - 1]`, which is unfortunately also the case at `255`.

### The fix

The fix is really simple. Let's make sure we don't increment 255. I also changed `i > 1` to `i > 0` to enforce the strict monotonic growth (up to saturation) for the entire table to make sure `light_LUT[1]` will be at least `1`.

Screenshot:

![screenshot_20200821_003428_good_light](https://user-images.githubusercontent.com/28017860/90834205-f6be3600-e349-11ea-910f-5f4859b1a0b9.png)

```
light_LUT[1]: 8
light_LUT[2]: 16
light_LUT[3]: 28
light_LUT[4]: 43
light_LUT[5]: 63
light_LUT[6]: 86
light_LUT[7]: 112
light_LUT[8]: 141
light_LUT[9]: 172
light_LUT[10]: 204
light_LUT[11]: 237
light_LUT[12]: 255
light_LUT[13]: 255
light_LUT[14]: 255
```

The fix is small and does not change the appearance of the game if the light lookup table does not run into saturation (with the exception that light_LUT[1] will now be at least `1` when previously it could be zero).