### PR TITLE
NetBSD build fix proposal.

### DIFF
--- a/src/noise.h
+++ b/src/noise.h
@@ -29,6 +29,13 @@
 #include "exceptions.h"
 #include "util/string.h"
 
+#if defined(RANDOM_MIN)
+#undef RANDOM_MIN
+#endif
+#if defined(RANDOM_MAX)
+#undef RANDOM_MAX
+#endif
+
 extern FlagDesc flagdesc_noiseparams[];
 
 // Note: this class is not polymorphic so that its high level of

--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -219,7 +219,7 @@ void Thread::setName(const std::string &name)
 
 #elif defined(__NetBSD__)
 
-	pthread_setname_np(pthread_self(), name.c_str());
+	pthread_setname_np(pthread_self(), "%s", const_cast<char*>(name.c_str()));
 
 #elif defined(__APPLE__)
 


### PR DESCRIPTION
Fixing thread naming call and let the class setting RANDOM_MIN/RANDOM_MAX.