### PR TITLE
Devtest: Extend item tooltips and other help

### DIFF
--- a/games/devtest/README.md
+++ b/games/devtest/README.md
@@ -25,7 +25,7 @@ Basically, just create a world and start. A few important things to note:
 * Check out the game settings and server commands for additional tests and features
 * Creative Mode does nothing (apart from default engine behavior)
 
-Confused by a certain node or item? Check out for inline code comments.
+Confused by a certain node or item? Check out for inline code comments. The usages of most tools are explained in their tooltips.
 
 ### Example tests
 

--- a/games/devtest/mods/basenodes/init.lua
+++ b/games/devtest/mods/basenodes/init.lua
@@ -124,7 +124,8 @@ minetest.register_node("basenodes:pine_needles", {
 })
 
 minetest.register_node("basenodes:water_source", {
-	description = "Water Source",
+	description = "Water Source".."\n"..
+		"Drowning damage: 1",
 	drawtype = "liquid",
 	tiles = {"default_water.png"},
 	special_tiles = {
@@ -148,7 +149,8 @@ minetest.register_node("basenodes:water_source", {
 })
 
 minetest.register_node("basenodes:water_flowing", {
-	description = "Flowing Water",
+	description = "Flowing Water".."\n"..
+		"Drowning damage: 1",
 	drawtype = "flowingliquid",
 	tiles = {"default_water_flowing.png"},
 	special_tiles = {
@@ -173,7 +175,8 @@ minetest.register_node("basenodes:water_flowing", {
 })
 
 minetest.register_node("basenodes:river_water_source", {
-	description = "River Water Source",
+	description = "River Water Source".."\n"..
+		"Drowning damage: 1",
 	drawtype = "liquid",
 	tiles = { "default_river_water.png" },
 	special_tiles = {
@@ -199,7 +202,8 @@ minetest.register_node("basenodes:river_water_source", {
 })
 
 minetest.register_node("basenodes:river_water_flowing", {
-	description = "Flowing River Water",
+	description = "Flowing River Water".."\n"..
+		"Drowning damage: 1",
 	drawtype = "flowingliquid",
 	tiles = {"default_river_water_flowing.png"},
 	special_tiles = {
@@ -226,7 +230,9 @@ minetest.register_node("basenodes:river_water_flowing", {
 })
 
 minetest.register_node("basenodes:lava_flowing", {
-	description = "Flowing Lava",
+	description = "Flowing Lava".."\n"..
+		"4 damage per second".."\n"..
+		"Drowning damage: 1",
 	drawtype = "flowingliquid",
 	tiles = {"default_lava_flowing.png"},
 	special_tiles = {
@@ -251,7 +257,9 @@ minetest.register_node("basenodes:lava_flowing", {
 })
 
 minetest.register_node("basenodes:lava_source", {
-	description = "Lava Source",
+	description = "Lava Source".."\n"..
+		"4 damage per second".."\n"..
+		"Drowning damage: 1",
 	drawtype = "liquid",
 	tiles = { "default_lava.png" },
 	special_tiles = {
@@ -290,7 +298,8 @@ minetest.register_node("basenodes:mossycobble", {
 })
 
 minetest.register_node("basenodes:apple", {
-	description = "Apple",
+	description = "Apple".."\n"..
+		"Food (+2)",
 	drawtype = "plantlike",
 	tiles ={"default_apple.png"},
 	inventory_image = "default_apple.png",

--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -42,7 +42,8 @@ minetest.register_item(":", {
 
 -- Mese Pickaxe: special tool that digs "everything" instantly
 minetest.register_tool("basetools:pick_mese", {
-	description = "Mese Pickaxe",
+	description = "Mese Pickaxe".."\n"..
+			"Digs diggable nodes instantly",
 	inventory_image = "basetools_mesepick.png",
 	tool_capabilities = {
 		full_punch_interval = 1.0,
@@ -65,7 +66,9 @@ minetest.register_tool("basetools:pick_mese", {
 
 -- This should break after only 1 use
 minetest.register_tool("basetools:pick_dirt", {
-	description = "Dirt Pickaxe",
+	description = "Dirt Pickaxe".."\n"..
+		"Digs cracky=3".."\n"..
+		"1 use only",
 	inventory_image = "basetools_dirtpick.png",
 	tool_capabilities = {
 		max_drop_level=0,
@@ -76,7 +79,8 @@ minetest.register_tool("basetools:pick_dirt", {
 })
 
 minetest.register_tool("basetools:pick_wood", {
-	description = "Wooden Pickaxe",
+	description = "Wooden Pickaxe".."\n"..
+		"Digs cracky=3",
 	inventory_image = "basetools_woodpick.png",
 	tool_capabilities = {
 		max_drop_level=0,
@@ -86,7 +90,8 @@ minetest.register_tool("basetools:pick_wood", {
 	},
 })
 minetest.register_tool("basetools:pick_stone", {
-	description = "Stone Pickaxe",
+	description = "Stone Pickaxe".."\n"..
+		"Digs cracky=2..3",
 	inventory_image = "basetools_stonepick.png",
 	tool_capabilities = {
 		max_drop_level=0,
@@ -96,7 +101,8 @@ minetest.register_tool("basetools:pick_stone", {
 	},
 })
 minetest.register_tool("basetools:pick_steel", {
-	description = "Steel Pickaxe",
+	description = "Steel Pickaxe".."\n"..
+		"Digs cracky=1..3",
 	inventory_image = "basetools_steelpick.png",
 	tool_capabilities = {
 		max_drop_level=1,
@@ -106,7 +112,9 @@ minetest.register_tool("basetools:pick_steel", {
 	},
 })
 minetest.register_tool("basetools:pick_steel_l1", {
-	description = "Steel Pickaxe Level 1",
+	description = "Steel Pickaxe Level 1".."\n"..
+		"Digs cracky=1..3".."\n"..
+		"maxlevel=1",
 	inventory_image = "basetools_steelpick_l1.png",
 	tool_capabilities = {
 		max_drop_level=1,
@@ -116,7 +124,9 @@ minetest.register_tool("basetools:pick_steel_l1", {
 	},
 })
 minetest.register_tool("basetools:pick_steel_l2", {
-	description = "Steel Pickaxe Level 2",
+	description = "Steel Pickaxe Level 2".."\n"..
+		"Digs cracky=1..3".."\n"..
+		"maxlevel=2",
 	inventory_image = "basetools_steelpick_l2.png",
 	tool_capabilities = {
 		max_drop_level=1,
@@ -131,7 +141,8 @@ minetest.register_tool("basetools:pick_steel_l2", {
 --
 
 minetest.register_tool("basetools:shovel_wood", {
-	description = "Wooden Shovel",
+	description = "Wooden Shovel".."\n"..
+		"Digs crumbly=3",
 	inventory_image = "basetools_woodshovel.png",
 	tool_capabilities = {
 		max_drop_level=0,
@@ -141,7 +152,8 @@ minetest.register_tool("basetools:shovel_wood", {
 	},
 })
 minetest.register_tool("basetools:shovel_stone", {
-	description = "Stone Shovel",
+	description = "Stone Shovel".."\n"..
+		"Digs crumbly=2..3",
 	inventory_image = "basetools_stoneshovel.png",
 	tool_capabilities = {
 		max_drop_level=0,
@@ -151,7 +163,8 @@ minetest.register_tool("basetools:shovel_stone", {
 	},
 })
 minetest.register_tool("basetools:shovel_steel", {
-	description = "Steel Shovel",
+	description = "Steel Shovel".."\n"..
+		"Digs crumbly=1..3",
 	inventory_image = "basetools_steelshovel.png",
 	tool_capabilities = {
 		max_drop_level=1,
@@ -166,7 +179,8 @@ minetest.register_tool("basetools:shovel_steel", {
 --
 
 minetest.register_tool("basetools:axe_wood", {
-	description = "Wooden Axe",
+	description = "Wooden Axe".."\n"..
+		"Digs choppy=3",
 	inventory_image = "basetools_woodaxe.png",
 	tool_capabilities = {
 		max_drop_level=0,
@@ -176,7 +190,8 @@ minetest.register_tool("basetools:axe_wood", {
 	},
 })
 minetest.register_tool("basetools:axe_stone", {
-	description = "Stone Axe",
+	description = "Stone Axe".."\n"..
+		"Digs choppy=2..3",
 	inventory_image = "basetools_stoneaxe.png",
 	tool_capabilities = {
 		max_drop_level=0,
@@ -186,7 +201,8 @@ minetest.register_tool("basetools:axe_stone", {
 	},
 })
 minetest.register_tool("basetools:axe_steel", {
-	description = "Steel Axe",
+	description = "Steel Axe".."\n"..
+		"Digs choppy=1..3",
 	inventory_image = "basetools_steelaxe.png",
 	tool_capabilities = {
 		max_drop_level=1,
@@ -201,7 +217,8 @@ minetest.register_tool("basetools:axe_steel", {
 --
 
 minetest.register_tool("basetools:shears_wood", {
-	description = "Wooden Shears",
+	description = "Wooden Shears".."\n"..
+		"Digs snappy=3",
 	inventory_image = "basetools_woodshears.png",
 	tool_capabilities = {
 		max_drop_level=0,
@@ -211,7 +228,8 @@ minetest.register_tool("basetools:shears_wood", {
 	},
 })
 minetest.register_tool("basetools:shears_stone", {
-	description = "Stone Shears",
+	description = "Stone Shears".."\n"..
+		"Digs snappy=2..3",
 	inventory_image = "basetools_stoneshears.png",
 	tool_capabilities = {
 		max_drop_level=0,
@@ -221,7 +239,8 @@ minetest.register_tool("basetools:shears_stone", {
 	},
 })
 minetest.register_tool("basetools:shears_steel", {
-	description = "Steel Shears",
+	description = "Steel Shears".."\n"..
+		"Digs snappy=1..3",
 	inventory_image = "basetools_steelshears.png",
 	tool_capabilities = {
 		max_drop_level=1,
@@ -236,7 +255,8 @@ minetest.register_tool("basetools:shears_steel", {
 --
 
 minetest.register_tool("basetools:sword_wood", {
-	description = "Wooden Sword",
+	description = "Wooden Sword".."\n"..
+		"Damage: fleshy=2",
 	inventory_image = "basetools_woodsword.png",
 	tool_capabilities = {
 		full_punch_interval = 1.0,
@@ -244,7 +264,8 @@ minetest.register_tool("basetools:sword_wood", {
 	}
 })
 minetest.register_tool("basetools:sword_stone", {
-	description = "Stone Sword",
+	description = "Stone Sword".."\n"..
+		"Damage: fleshy=4",
 	inventory_image = "basetools_stonesword.png",
 	tool_capabilities = {
 		full_punch_interval = 1.0,
@@ -253,7 +274,8 @@ minetest.register_tool("basetools:sword_stone", {
 	}
 })
 minetest.register_tool("basetools:sword_steel", {
-	description = "Steel Sword",
+	description = "Steel Sword".."\n"..
+		"Damage: fleshy=6",
 	inventory_image = "basetools_steelsword.png",
 	tool_capabilities = {
 		full_punch_interval = 1.0,
@@ -264,7 +286,8 @@ minetest.register_tool("basetools:sword_steel", {
 
 -- Fire/Ice sword: Deal damage to non-fleshy damage groups
 minetest.register_tool("basetools:sword_fire", {
-	description = "Fire Sword",
+	description = "Fire Sword".."\n"..
+		"Damage: icy=6",
 	inventory_image = "basetools_firesword.png",
 	tool_capabilities = {
 		full_punch_interval = 1.0,
@@ -273,12 +296,13 @@ minetest.register_tool("basetools:sword_fire", {
 	}
 })
 minetest.register_tool("basetools:sword_ice", {
-	description = "Ice Sword",
+	description = "Ice Sword".."\n"..
+		"Damage: fiery=6",
 	inventory_image = "basetools_icesword.png",
 	tool_capabilities = {
 		full_punch_interval = 1.0,
 		max_drop_level=0,
-		damage_groups = {firy=6},
+		damage_groups = {fiery=6},
 	}
 })
 
@@ -286,7 +310,9 @@ minetest.register_tool("basetools:sword_ice", {
 -- Dagger: Low damage, fast punch interval
 --
 minetest.register_tool("basetools:dagger_steel", {
-	description = "Steel Dagger",
+	description = "Steel Dagger".."\n"..
+		"Damage: fleshy=2".."\n"..
+		"Full Punch Interval: 0.5s",
 	inventory_image = "basetools_steeldagger.png",
 	tool_capabilities = {
 		full_punch_interval = 0.5,

--- a/games/devtest/mods/bucket/init.lua
+++ b/games/devtest/mods/bucket/init.lua
@@ -1,7 +1,8 @@
 -- Bucket: Punch liquid source or flowing liquid to collect it
 
 minetest.register_tool("bucket:bucket", {
-	description = "Bucket",
+	description = "Bucket".."\n"..
+		"Picks up liquid nodes",
 	inventory_image = "bucket.png",
 	stack_max = 1,
 	liquids_pointable = true,

--- a/games/devtest/mods/chest/init.lua
+++ b/games/devtest/mods/chest/init.lua
@@ -1,5 +1,6 @@
 minetest.register_node("chest:chest", {
-	description = "Chest",
+	description = "Chest" .. "\n" ..
+		"32 inventory slots",
 	tiles ={"chest_chest.png^[sheet:2x2:0,0", "chest_chest.png^[sheet:2x2:0,0",
 		"chest_chest.png^[sheet:2x2:1,0", "chest_chest.png^[sheet:2x2:1,0",
 		"chest_chest.png^[sheet:2x2:1,0", "chest_chest.png^[sheet:2x2:0,1"},

--- a/games/devtest/mods/chest_of_everything/init.lua
+++ b/games/devtest/mods/chest_of_everything/init.lua
@@ -43,7 +43,8 @@ local function get_chest_formspec(page)
 end
 
 minetest.register_node("chest_of_everything:chest", {
-	description = "Chest of Everything",
+	description = "Chest of Everything" .. "\n" ..
+		"Grants access to all items",
 	tiles ={"chest_of_everything_chest.png^[sheet:2x2:0,0", "chest_of_everything_chest.png^[sheet:2x2:0,0",
 		"chest_of_everything_chest.png^[sheet:2x2:1,0", "chest_of_everything_chest.png^[sheet:2x2:1,0",
 		"chest_of_everything_chest.png^[sheet:2x2:1,0", "chest_of_everything_chest.png^[sheet:2x2:0,1"},

--- a/games/devtest/mods/experimental/items.lua
+++ b/games/devtest/mods/experimental/items.lua
@@ -44,7 +44,8 @@ minetest.register_node("experimental:callback_node", {
 })
 
 minetest.register_tool("experimental:privatizer", {
-	description = "Node Meta Privatizer",
+	description = "Node Meta Privatizer".."\n"..
+		"Punch: Marks 'infotext' and 'formspec' meta fields of chest as private",
 	inventory_image = "experimental_tester_tool_1.png",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_use = function(itemstack, user, pointed_thing)
@@ -67,7 +68,8 @@ minetest.register_tool("experimental:privatizer", {
 })
 
 minetest.register_tool("experimental:particle_spawner", {
-	description = "Particle Spawner",
+	description = "Particle Spawner".."\n"..
+		"Punch: Spawn random test particle",
 	inventory_image = "experimental_tester_tool_1.png^[invert:g",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_use = function(itemstack, user, pointed_thing)

--- a/games/devtest/mods/soundstuff/init.lua
+++ b/games/devtest/mods/soundstuff/init.lua
@@ -107,7 +107,8 @@ minetest.register_node("soundstuff:footstep_climbable", {
 
 
 minetest.register_craftitem("soundstuff:eat", {
-	description = "Eat Sound Item",
+	description = "Eat Sound Item".."\n"..
+		"Makes a sound when 'eaten' (with punch key)",
 	inventory_image = "soundstuff_eat.png",
 	on_use = minetest.item_eat(0),
 	sound = {
@@ -116,7 +117,9 @@ minetest.register_craftitem("soundstuff:eat", {
 })
 
 minetest.register_tool("soundstuff:breaks", {
-	description = "Break Sound Tool",
+	description = "Break Sound Tool".."\n"..
+		"Digs cracky=3 and more".."\n"..
+		"Makes a sound when it breaks",
 	inventory_image = "soundstuff_node_dug.png",
 	sound = {
 		breaks = { name = "soundstuff_mono", gain = 1.0 },

--- a/games/devtest/mods/testentities/armor.lua
+++ b/games/devtest/mods/testentities/armor.lua
@@ -3,7 +3,7 @@
 
 local phasearmor = {
 	[0]={icy=100},
-	[1]={firy=100},
+	[1]={fiery=100},
 	[2]={fleshy=100},
 	[3]={immortal=1},
 	[4]={punch_operable=1},

--- a/games/devtest/mods/testnodes/light.lua
+++ b/games/devtest/mods/testnodes/light.lua
@@ -22,7 +22,8 @@ end
 -- Lets light through, but not sunlight, leading to a
 -- reduction in light level when light passes through
 minetest.register_node("testnodes:sunlight_filter", {
-	description = S("Sunlight Filter"),
+	description = S("Sunlight Filter") .."\n"..
+		S("Lets light through, but weakens sunlight"),
 	paramtype = "light",
 
 
@@ -35,7 +36,8 @@ minetest.register_node("testnodes:sunlight_filter", {
 
 -- Lets light and sunlight through without obstruction
 minetest.register_node("testnodes:sunlight_propagator", {
-	description = S("Sunlight Propagator"),
+	description = S("Sunlight Propagator") .."\n"..
+		S("Lets all light through"),
 	paramtype = "light",
 	sunlight_propagates = true,
 

--- a/games/devtest/mods/testpathfinder/init.lua
+++ b/games/devtest/mods/testpathfinder/init.lua
@@ -121,7 +121,11 @@ end
 -- Sneak+punch: Select pathfinding algorithm
 -- Place: Select destination node
 minetest.register_tool("testpathfinder:testpathfinder", {
-	description = S("Pathfinder Tester"),
+	description = S("Pathfinder Tester") .."\n"..
+		S("Finds path between 2 points") .."\n"..
+		S("Place on node: Select destination") .."\n"..
+		S("Punch: Find path from here") .."\n"..
+		S("Sneak+Punch: Change algorithm"),
 	inventory_image = "testpathfinder_testpathfinder.png",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_use = find_path_or_set_algorithm,

--- a/games/devtest/mods/testtools/init.lua
+++ b/games/devtest/mods/testtools/init.lua
@@ -3,13 +3,13 @@ local F = minetest.formspec_escape
 
 -- TODO: Add a Node Metadata tool
 
--- Param 2 Tool: Set param2 value of tools
--- Punch: +1
--- Punch+Shift:	+8
--- Place: -1
--- Place+Shift:	-8
 minetest.register_tool("testtools:param2tool", {
-	description = S("Param2 Tool"),
+	description = S("Param2 Tool") .."\n"..
+		S("Modify param2 value of nodes") .."\n"..
+		S("Punch: +1") .."\n"..
+		S("Sneak+Punch: +8") .."\n"..
+		S("Place: -1") .."\n"..
+		S("Sneak+Place: -8"),
 	inventory_image = "testtools_param2tool.png",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_use = function(itemstack, user, pointed_thing)
@@ -47,7 +47,11 @@ minetest.register_tool("testtools:param2tool", {
 })
 
 minetest.register_tool("testtools:node_setter", {
-	description = S("Node Setter"),
+	description = S("Node Setter") .."\n"..
+		S("Replace pointed node with something else") .."\n"..
+		S("Punch: Select pointed node") .."\n"..
+		S("Place on node: Replace node with selected node") .."\n"..
+		S("Place in air: Manually select a node"),
 	inventory_image = "testtools_node_setter.png",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_use = function(itemstack, user, pointed_thing)
@@ -125,7 +129,8 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 end)
 
 minetest.register_tool("testtools:remover", {
-	description = S("Remover"),
+	description = S("Remover") .."\n"..
+		S("Punch: Remove pointed node or object"),
 	inventory_image = "testtools_remover.png",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_use = function(itemstack, user, pointed_thing)
@@ -136,13 +141,17 @@ minetest.register_tool("testtools:remover", {
 			local obj = pointed_thing.ref
 			if not obj:is_player() then
 				obj:remove()
+			else
+				minetest.chat_send_player(user:get_player_name(), S("Can't remove players!"))
 			end
 		end
 	end,
 })
 
 minetest.register_tool("testtools:falling_node_tool", {
-	description = S("Falling Node Tool"),
+	description = S("Falling Node Tool") .."\n"..
+		S("Punch: Make pointed node fall") .."\n"..
+		S("Place: Move pointed node 2 units upwards, then make it fall"),
 	inventory_image = "testtools_falling_node_tool.png",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_place = function(itemstack, user, pointed_thing)
@@ -191,7 +200,11 @@ minetest.register_tool("testtools:falling_node_tool", {
 })
 
 minetest.register_tool("testtools:rotator", {
-	description = S("Entity Rotator"),
+	description = S("Entity Rotator") .. "\n" ..
+		S("Rotate pointed entity") .."\n"..
+		S("Punch: Yaw") .."\n"..
+		S("Sneak+Punch: Pitch") .."\n"..
+		S("Aux1+Punch: Roll"),
 	inventory_image = "testtools_entity_rotator.png",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_use = function(itemstack, user, pointed_thing)
@@ -244,7 +257,12 @@ local mover_config = function(itemstack, user, pointed_thing)
 end
 
 minetest.register_tool("testtools:object_mover", {
-	description = S("Object Mover"),
+	description = S("Object Mover") .."\n"..
+		S("Move pointed object towards or away from you") .."\n"..
+		S("Punch: Move by distance").."\n"..
+		S("Sneak+Punch: Move by negative distance").."\n"..
+		S("Place: Increase distance").."\n"..
+		S("Sneak+Place: Decrease distance"),
 	inventory_image = "testtools_object_mover.png",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_place = mover_config,
@@ -287,7 +305,10 @@ minetest.register_tool("testtools:object_mover", {
 
 
 minetest.register_tool("testtools:entity_scaler", {
-	description = S("Entity Visual Scaler"),
+	description = S("Entity Visual Scaler") .."\n"..
+		S("Scale visual size of entities") .."\n"..
+		S("Punch: Increase size") .."\n"..
+		S("Sneak+Punch: Decrease scale"),
 	inventory_image = "testtools_entity_scaler.png",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_use = function(itemstack, user, pointed_thing)
@@ -342,14 +363,21 @@ local function get_entity_list()
 	return entity_list
 end
 minetest.register_tool("testtools:entity_spawner", {
-	description = S("Entity Spawner"),
+	description = S("Entity Spawner") .."\n"..
+		S("Spawns entities") .."\n"..
+		S("Punch: Select entity to spawn") .."\n"..
+		S("Place: Spawn selected entity"),
 	inventory_image = "testtools_entity_spawner.png",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_place = function(itemstack, user, pointed_thing)
 		local name = user:get_player_name()
-		if selections[name] and pointed_thing.type == "node" then
-			local pos = pointed_thing.above
-			minetest.add_entity(pos, get_entity_list()[selections[name]])
+		if pointed_thing.type == "node" then
+			if selections[name] then
+				local pos = pointed_thing.above
+				minetest.add_entity(pos, get_entity_list()[selections[name]])
+			else
+				minetest.chat_send_player(name, S("Select an entity first (with punch key)!"))
+			end
 		end
 	end,
 	on_use = function(itemstack, user, pointed_thing)
@@ -435,7 +463,10 @@ local editor_formspec = function(playername, obj, value, sel)
 end
 
 minetest.register_tool("testtools:object_editor", {
-	description = S("Object Property Editor"),
+	description = S("Object Property Editor") .."\n"..
+		S("Edit properties of objects") .."\n"..
+		S("Punch object: Edit object") .."\n"..
+		S("Punch air: Edit yourself"),
 	inventory_image = "testtools_object_editor.png",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_use = function(itemstack, user, pointed_thing)
@@ -515,7 +546,14 @@ local attacher_config = function(itemstack, user, pointed_thing)
 end
 
 minetest.register_tool("testtools:object_attacher", {
-	description = S("Object Attacher"),
+	description = S("Object Attacher") .."\n"..
+		S("Attach object to another") .."\n"..
+		S("Punch objects to first select parent object, then the child object to attach") .."\n"..
+		S("Punch air to select yourself") .."\n"..
+		S("Place: Incease attachment Y offset") .."\n"..
+		S("Sneak+Place: Decease attachment Y offset") .."\n"..
+		S("Aux1+Place: Incease attachment rotation") .."\n"..
+		S("Aux1+Sneak+Place: Decrease attachment rotation"),
 	inventory_image = "testtools_object_attacher.png",
 	groups = { testtool = 1, disable_repair = 1 },
 	on_place = attacher_config,


### PR DESCRIPTION
Goal of the PR:
Make Devtest a bit easier to use, because some people complained they were confused by X

How does the PR work?
It extends item tooltips with information about the various obscure tools, items and nodes for convenience, since most tools are not obvious to use, and make heavy use of unconventional controls that aren't obvious either.
All tooltip extensions are made after an initial newline, so the help text could be truncated safely, should the need ever arise (just drop all text from the `description` after the first newline).

There are also 2 small error messages added if a tool was used incorrectly.

Does it resolve any reported issue?
No.

If not a bug fix, why is this PR needed? What usecases does it solve?
Usability, and makes using Devtest a bit more convnient because you don't have to look things up all the time.

## To do

This PR is ready for review.

## How to test

Just hover all items in the Chest of Everything and tell me if everything makes sense to you.

For the error messages:
* Place an entity with the Entity Spawner before selecting any
* Try to remove a player with the Remover

(Both should trigger an error message)

## Caveats

The key “Aux1” aka “Aux” aka “AUX” aka “Special” aka “special1” aka “Use” is referred to as “Aux1” in all tooltips. However, currently, Minetest does NOT have a consistent name for this key (yet). This PR is basically anticipating the merge of #9417, which does the rename.

Note this PR is technically NOT blocked by any other PR, I just wanted to mention it here as a small warning.