### PR TITLE
Remove "generate normal maps" feature

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -248,15 +248,13 @@ local function formspec(tabview, name, tabdata)
 					.. dump(core.settings:get_bool("enable_bumpmapping")) .. "]" ..
 			"checkbox[8.25,1;cb_tonemapping;" .. fgettext("Tone Mapping") .. ";"
 					.. dump(core.settings:get_bool("tone_mapping")) .. "]" ..
-			"checkbox[8.25,1.5;cb_generate_normalmaps;" .. fgettext("Generate Normal Maps") .. ";"
-					.. dump(core.settings:get_bool("generate_normalmaps")) .. "]" ..
-			"checkbox[8.25,2;cb_parallax;" .. fgettext("Parallax Occlusion") .. ";"
+			"checkbox[8.25,1.5;cb_parallax;" .. fgettext("Parallax Occlusion") .. ";"
 					.. dump(core.settings:get_bool("enable_parallax_occlusion")) .. "]" ..
-			"checkbox[8.25,2.5;cb_waving_water;" .. fgettext("Waving Liquids") .. ";"
+			"checkbox[8.25,2;cb_waving_water;" .. fgettext("Waving Liquids") .. ";"
 					.. dump(core.settings:get_bool("enable_waving_water")) .. "]" ..
-			"checkbox[8.25,3;cb_waving_leaves;" .. fgettext("Waving Leaves") .. ";"
+			"checkbox[8.25,2.5;cb_waving_leaves;" .. fgettext("Waving Leaves") .. ";"
 					.. dump(core.settings:get_bool("enable_waving_leaves")) .. "]" ..
-			"checkbox[8.25,3.5;cb_waving_plants;" .. fgettext("Waving Plants") .. ";"
+			"checkbox[8.25,3;cb_waving_plants;" .. fgettext("Waving Plants") .. ";"
 					.. dump(core.settings:get_bool("enable_waving_plants")) .. "]"
 	else
 		tab_string = tab_string ..
@@ -265,14 +263,12 @@ local function formspec(tabview, name, tabdata)
 			"label[8.38,1.2;" .. core.colorize("#888888",
 					fgettext("Tone Mapping")) .. "]" ..
 			"label[8.38,1.7;" .. core.colorize("#888888",
-					fgettext("Generate Normal Maps")) .. "]" ..
-			"label[8.38,2.2;" .. core.colorize("#888888",
 					fgettext("Parallax Occlusion")) .. "]" ..
-			"label[8.38,2.7;" .. core.colorize("#888888",
+			"label[8.38,2.2;" .. core.colorize("#888888",
 					fgettext("Waving Liquids")) .. "]" ..
-			"label[8.38,3.2;" .. core.colorize("#888888",
+			"label[8.38,2.7;" .. core.colorize("#888888",
 					fgettext("Waving Leaves")) .. "]" ..
-			"label[8.38,3.7;" .. core.colorize("#888888",
+			"label[8.38,3.2;" .. core.colorize("#888888",
 					fgettext("Waving Plants")) .. "]"
 	end
 
@@ -330,10 +326,6 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 	end
 	if fields["cb_tonemapping"] then
 		core.settings:set("tone_mapping", fields["cb_tonemapping"])
-		return true
-	end
-	if fields["cb_generate_normalmaps"] then
-		core.settings:set("generate_normalmaps", fields["cb_generate_normalmaps"])
 		return true
 	end
 	if fields["cb_parallax"] then

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -543,21 +543,9 @@ tone_mapping (Filmic tone mapping) bool false
 
 [***Bumpmapping]
 
-#    Enables bumpmapping for textures. Normalmaps need to be supplied by the texture pack
-#    or need to be auto-generated.
+#    Enables bumpmapping for textures. Normalmaps need to be supplied by the texture pack.
 #    Requires shaders to be enabled.
 enable_bumpmapping (Bumpmapping) bool false
-
-#    Enables on the fly normalmap generation (Emboss effect).
-#    Requires bumpmapping to be enabled.
-generate_normalmaps (Generate normalmaps) bool false
-
-#    Strength of generated normalmaps.
-normalmaps_strength (Normalmaps strength) float 0.6
-
-#    Defines sampling step of texture.
-#    A higher value results in smoother normal maps.
-normalmaps_smooth (Normalmaps sampling) int 0 0 2
 
 [***Parallax Occlusion]
 

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -149,18 +149,13 @@ void main(void)
 			float h = normal.a * scale - bias;
 			uv += h * normal.z * eyeRay;
 		}
+	}
 #endif
-
 #if PARALLAX_OCCLUSION_MODE == 1
 	// Relief mapping
 	if (normalTexturePresent && area_enable_parallax > 0.0) {
 		vec2 ds = eyeRay * PARALLAX_OCCLUSION_SCALE;
 		float dist = find_intersection(uv, ds);
-		uv += dist * ds;
-#endif
-	} else if (GENERATE_NORMALMAPS == 1 && area_enable_parallax > 0.0) {
-		vec2 ds = eyeRay * PARALLAX_OCCLUSION_SCALE;
-		float dist = find_intersectionRGB(uv, ds);
 		uv += dist * ds;
 	}
 #endif
@@ -172,22 +167,6 @@ void main(void)
 	}
 #endif
 
-#if GENERATE_NORMALMAPS == 1
-	if (normalTexturePresent == false) {
-		float tl = get_rgb_height(vec2(uv.x - SAMPLE_STEP, uv.y + SAMPLE_STEP));
-		float t  = get_rgb_height(vec2(uv.x - SAMPLE_STEP, uv.y - SAMPLE_STEP));
-		float tr = get_rgb_height(vec2(uv.x + SAMPLE_STEP, uv.y + SAMPLE_STEP));
-		float r  = get_rgb_height(vec2(uv.x + SAMPLE_STEP, uv.y));
-		float br = get_rgb_height(vec2(uv.x + SAMPLE_STEP, uv.y - SAMPLE_STEP));
-		float b  = get_rgb_height(vec2(uv.x, uv.y - SAMPLE_STEP));
-		float bl = get_rgb_height(vec2(uv.x -SAMPLE_STEP, uv.y - SAMPLE_STEP));
-		float l  = get_rgb_height(vec2(uv.x - SAMPLE_STEP, uv.y));
-		float dX = (tr + 2.0 * r + br) - (tl + 2.0 * l + bl);
-		float dY = (bl + 2.0 * b + br) - (tl + 2.0 * t + tr);
-		bump = vec4(normalize(vec3 (dX, dY, NORMALMAPS_STRENGTH)), 1.0);
-		use_normalmap = true;
-	}
-#endif
 	vec4 base = texture2D(baseTexture, uv).rgba;
 
 #ifdef ENABLE_BUMPMAPPING

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -71,11 +71,6 @@ void get_texture_flags()
 	}
 }
 
-float intensity(vec3 color)
-{
-	return (color.r + color.g + color.b) / 3.0;
-}
-
 vec4 get_normal_map(vec2 uv)
 {
 	vec4 bump = texture2D(normalTexture, uv).rgba;

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -76,11 +76,6 @@ float intensity(vec3 color)
 	return (color.r + color.g + color.b) / 3.0;
 }
 
-float get_rgb_height(vec2 uv)
-{
-	return intensity(texture2D(baseTexture, uv).rgb);
-}
-
 vec4 get_normal_map(vec2 uv)
 {
 	vec4 bump = texture2D(normalTexture, uv).rgba;
@@ -113,19 +108,6 @@ float find_intersection(vec2 dp, vec2 ds)
 		}
 	}
 	return best_depth;
-}
-
-float find_intersectionRGB(vec2 dp, vec2 ds)
-{
-	const float depth_step = 1.0 / 24.0;
-	float depth = 1.0;
-	for (int i = 0 ; i < 24 ; i++) {
-		float h = get_rgb_height(dp + ds * depth);
-		if (h >= depth)
-			break;
-		depth -= depth_step;
-	}
-	return depth;
 }
 
 void main(void)

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -141,6 +141,7 @@ void main(void)
 		uv += dist * ds;
 	}
 #endif
+#endif
 
 #if USE_NORMALMAPS == 1
 	if (normalTexturePresent) {

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -79,15 +79,6 @@ float intensity(vec3 color)
 	return (color.r + color.g + color.b) / 3.0;
 }
 
-float get_rgb_height(vec2 uv)
-{
-	if (texSeamless) {
-		return intensity(texture2D(baseTexture, uv).rgb);
-	} else {
-		return intensity(texture2D(baseTexture, clamp(uv, 0.0, 0.999)).rgb);
-	}
-}
-
 vec4 get_normal_map(vec2 uv)
 {
 	vec4 bump = texture2D(normalTexture, uv).rgba;

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -110,23 +110,6 @@ void main(void)
 	}
 #endif
 
-#if GENERATE_NORMALMAPS == 1
-	if (normalTexturePresent == false) {
-		float tl = get_rgb_height(vec2(uv.x - SAMPLE_STEP, uv.y + SAMPLE_STEP));
-		float t  = get_rgb_height(vec2(uv.x - SAMPLE_STEP, uv.y - SAMPLE_STEP));
-		float tr = get_rgb_height(vec2(uv.x + SAMPLE_STEP, uv.y + SAMPLE_STEP));
-		float r  = get_rgb_height(vec2(uv.x + SAMPLE_STEP, uv.y));
-		float br = get_rgb_height(vec2(uv.x + SAMPLE_STEP, uv.y - SAMPLE_STEP));
-		float b  = get_rgb_height(vec2(uv.x, uv.y - SAMPLE_STEP));
-		float bl = get_rgb_height(vec2(uv.x -SAMPLE_STEP, uv.y - SAMPLE_STEP));
-		float l  = get_rgb_height(vec2(uv.x - SAMPLE_STEP, uv.y));
-		float dX = (tr + 2.0 * r + br) - (tl + 2.0 * l + bl);
-		float dY = (bl + 2.0 * b + br) - (tl + 2.0 * t + tr);
-		bump = vec4(normalize(vec3 (dX, dY, NORMALMAPS_STRENGTH)), 1.0);
-		use_normalmap = true;
-	}
-#endif
-
 	vec4 base = texture2D(baseTexture, uv).rgba;
 
 #ifdef ENABLE_BUMPMAPPING

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -74,11 +74,6 @@ void get_texture_flags()
 	}
 }
 
-float intensity(vec3 color)
-{
-	return (color.r + color.g + color.b) / 3.0;
-}
-
 vec4 get_normal_map(vec2 uv)
 {
 	vec4 bump = texture2D(normalTexture, uv).rgba;

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -604,25 +604,10 @@
 
 #### Bumpmapping
 
-#    Enables bumpmapping for textures. Normalmaps need to be supplied by the texture pack
-#    or need to be auto-generated.
+#    Enables bumpmapping for textures. Normalmaps need to be supplied by the texture pack.
 #    Requires shaders to be enabled.
 #    type: bool
 # enable_bumpmapping = false
-
-#    Enables on the fly normalmap generation (Emboss effect).
-#    Requires bumpmapping to be enabled.
-#    type: bool
-# generate_normalmaps = false
-
-#    Strength of generated normalmaps.
-#    type: float
-# normalmaps_strength = 0.6
-
-#    Defines sampling step of texture.
-#    A higher value results in smoother normal maps.
-#    type: int min: 0 max: 2
-# normalmaps_smooth = 0
 
 #### Parallax Occlusion
 

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -665,34 +665,6 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 	shaders_header += itos(drawtype);
 	shaders_header += "\n";
 
-	if (g_settings->getBool("generate_normalmaps")) {
-		shaders_header += "#define GENERATE_NORMALMAPS 1\n";
-	} else {
-		shaders_header += "#define GENERATE_NORMALMAPS 0\n";
-	}
-	shaders_header += "#define NORMALMAPS_STRENGTH ";
-	shaders_header += ftos(g_settings->getFloat("normalmaps_strength"));
-	shaders_header += "\n";
-	float sample_step;
-	int smooth = (int)g_settings->getFloat("normalmaps_smooth");
-	switch (smooth){
-	case 0:
-		sample_step = 0.0078125; // 1.0 / 128.0
-		break;
-	case 1:
-		sample_step = 0.00390625; // 1.0 / 256.0
-		break;
-	case 2:
-		sample_step = 0.001953125; // 1.0 / 512.0
-		break;
-	default:
-		sample_step = 0.0078125;
-		break;
-	}
-	shaders_header += "#define SAMPLE_STEP ";
-	shaders_header += ftos(sample_step);
-	shaders_header += "\n";
-
 	if (g_settings->getBool("enable_bumpmapping"))
 		shaders_header += "#define ENABLE_BUMPMAPPING\n";
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -253,9 +253,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("tone_mapping", "false");
 	settings->setDefault("enable_bumpmapping", "false");
 	settings->setDefault("enable_parallax_occlusion", "false");
-	settings->setDefault("generate_normalmaps", "false");
-	settings->setDefault("normalmaps_strength", "0.6");
-	settings->setDefault("normalmaps_smooth", "1");
 	settings->setDefault("parallax_occlusion_mode", "1");
 	settings->setDefault("parallax_occlusion_iterations", "4");
 	settings->setDefault("parallax_occlusion_scale", "0.08");

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -242,13 +242,7 @@ fake_function() {
 	gettext("Enables Hable's 'Uncharted 2' filmic tone mapping.\nSimulates the tone curve of photographic film and how this approximates the\nappearance of high dynamic range images. Mid-range contrast is slightly\nenhanced, highlights and shadows are gradually compressed.");
 	gettext("Bumpmapping");
 	gettext("Bumpmapping");
-	gettext("Enables bumpmapping for textures. Normalmaps need to be supplied by the texture pack\nor need to be auto-generated.\nRequires shaders to be enabled.");
-	gettext("Generate normalmaps");
-	gettext("Enables on the fly normalmap generation (Emboss effect).\nRequires bumpmapping to be enabled.");
-	gettext("Normalmaps strength");
-	gettext("Strength of generated normalmaps.");
-	gettext("Normalmaps sampling");
-	gettext("Defines sampling step of texture.\nA higher value results in smoother normal maps.");
+	gettext("Enables bumpmapping for textures. Normalmaps need to be supplied by the texture pack.\nRequires shaders to be enabled.");
 	gettext("Parallax Occlusion");
 	gettext("Parallax occlusion");
 	gettext("Enables parallax occlusion mapping.\nRequires shaders to be enabled.");


### PR DESCRIPTION
Fixes #10307

## To do

- [x] Erase all traces of normal "generation" from fragment shaders
- [x] Remove the "feature" from the engine and default config
- [x] Remove any leftover documentation of it
- [x] Test
