### PR TITLE
Properly handle mod-errors in on_shutdown

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1300,7 +1300,8 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 		return false;
 	}
 
-	server = new Server(map_dir, gamespec, simple_singleplayer_mode, bind_addr, false);
+	server = new Server(map_dir, gamespec, simple_singleplayer_mode, bind_addr,
+			false, nullptr, error_message);
 	server->start();
 
 	return true;

--- a/src/server.h
+++ b/src/server.h
@@ -131,7 +131,8 @@ public:
 		bool simple_singleplayer_mode,
 		Address bind_addr,
 		bool dedicated,
-		ChatInterface *iface = nullptr
+		ChatInterface *iface = nullptr,
+		std::string *on_shutdown_errmsg = nullptr
 	);
 	~Server();
 	DISABLE_CLASS_COPY(Server);
@@ -595,6 +596,10 @@ private:
 
 	ChatInterface *m_admin_chat;
 	std::string m_admin_nick;
+
+	// if a mod-error occurs in the on_shutdown callback, the error message will
+	// be written into this
+	std::string *const m_on_shutdown_errmsg;
 
 	/*
 		Map edit event queue. Automatically receives all map edits.


### PR DESCRIPTION
- Fixes #5171.
- The `on_shutdown` callbacks are called in the destructor of `Server`. One should not throw an exception there. This mod catches the moderror exceptions, prints them out and writes them into the `error_msg` string that is given to the main-menu. A pointer to this string is given in the constructor of `Server` and stored in `Server`.
- See `the_game` on how other mod-errors are handled.
(The `on_shutdown` errors do not have the "look into description" text as I'm not sure how the translation thing works.)

## To do

This PR is a Ready for Review.

## How to test

```lua
--~ minetest.after(0, error, "after-error")

minetest.register_on_shutdown(function()
	error("on_shutdown-error")
	--~ print("printed")
end)
```
