### PR TITLE
Remove Thread::kill() and related unittest

### DIFF
--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -71,7 +71,32 @@ Thread::Thread(const std::string &name) :
 
 Thread::~Thread()
 {
-	kill();
+	// kill the thread if running
+	if (!m_running) {
+		wait();
+	} else {
+
+		m_running = false;
+
+#if defined(_WIN32)
+		// See https://msdn.microsoft.com/en-us/library/hh920601.aspx#thread__native_handle_method
+		TerminateThread((HANDLE) m_thread_obj->native_handle(), 0);
+		CloseHandle((HANDLE) m_thread_obj->native_handle());
+#else
+		// We need to pthread_kill instead on Android since NDKv5's pthread
+		// implementation is incomplete.
+# ifdef __ANDROID__
+		pthread_kill(getThreadHandle(), SIGKILL);
+# else
+		pthread_cancel(getThreadHandle());
+# endif
+		wait();
+#endif
+
+		m_retval       = nullptr;
+		m_joinable     = false;
+		m_request_stop = false;
+	}
 
 	// Make sure start finished mutex is unlocked before it's destroyed
 	if (m_start_finished_mutex.try_lock())
@@ -138,32 +163,6 @@ bool Thread::wait()
 
 bool Thread::kill()
 {
-	if (!m_running) {
-		wait();
-		return false;
-	}
-
-	m_running = false;
-
-#if defined(_WIN32)
-	// See https://msdn.microsoft.com/en-us/library/hh920601.aspx#thread__native_handle_method
-	TerminateThread((HANDLE) m_thread_obj->native_handle(), 0);
-	CloseHandle((HANDLE) m_thread_obj->native_handle());
-#else
-	// We need to pthread_kill instead on Android since NDKv5's pthread
-	// implementation is incomplete.
-# ifdef __ANDROID__
-	pthread_kill(getThreadHandle(), SIGKILL);
-# else
-	pthread_cancel(getThreadHandle());
-# endif
-	wait();
-#endif
-
-	m_retval       = nullptr;
-	m_joinable     = false;
-	m_request_stop = false;
-
 	return true;
 }
 

--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -92,10 +92,6 @@ Thread::~Thread()
 # endif
 		wait();
 #endif
-
-		m_retval       = nullptr;
-		m_joinable     = false;
-		m_request_stop = false;
 	}
 
 	// Make sure start finished mutex is unlocked before it's destroyed

--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -161,11 +161,6 @@ bool Thread::wait()
 }
 
 
-bool Thread::kill()
-{
-	return true;
-}
-
 
 bool Thread::getReturnValue(void **ret)
 {

--- a/src/threading/thread.h
+++ b/src/threading/thread.h
@@ -75,14 +75,6 @@ public:
 	bool stop();
 
 	/*
-	 * Immediately terminates the thread.
-	 * This should be used with extreme caution, as the thread will not have
-	 * any opportunity to release resources it may be holding (such as memory
-	 * or locks).
-	 */
-	bool kill();
-
-	/*
 	 * Waits for thread to finish.
 	 * Note:  This does not stop a thread, you have to do this on your own.
 	 * Returns false immediately if the thread is not started or has been waited

--- a/src/unittest/test_threading.cpp
+++ b/src/unittest/test_threading.cpp
@@ -31,7 +31,6 @@ public:
 	void runTests(IGameDef *gamedef);
 
 	void testStartStopWait();
-	void testThreadKill();
 	void testAtomicSemaphoreThread();
 };
 
@@ -40,7 +39,6 @@ static TestThreading g_test_instance;
 void TestThreading::runTests(IGameDef *gamedef)
 {
 	TEST(testStartStopWait);
-	TEST(testThreadKill);
 	TEST(testAtomicSemaphoreThread);
 }
 
@@ -110,29 +108,6 @@ void TestThreading::testStartStopWait()
 	delete thread;
 }
 
-
-void TestThreading::testThreadKill()
-{
-	SimpleTestThread *thread = new SimpleTestThread(300);
-
-	UASSERT(thread->start() == true);
-
-	// kill()ing is quite violent, so let's make sure our victim is sleeping
-	// before we do this... so we don't corrupt the rest of the program's state
-	sleep_ms(100);
-	UASSERT(thread->kill() == true);
-
-	// The state of the thread object should be reset if all went well
-	UASSERT(thread->isRunning() == false);
-	UASSERT(thread->start() == true);
-	UASSERT(thread->stop() == true);
-	UASSERT(thread->wait() == true);
-
-	// kill() after already waiting should fail.
-	UASSERT(thread->kill() == false);
-
-	delete thread;
-}
 
 
 class AtomicTestThread : public Thread {


### PR DESCRIPTION
The Thread kill() method isn't used outside testThreadKill unit test
and Thread destructor. It could be make private.

The testThreadKill test should be removed: it tests the kill() feature
in a way minetest doesn't use it (kill and restart a thread), specially
because some pthreads implementations on BSD will not allow to lock
again the m_start_finished_mutex which is hold when the thread is
killed.

Closes: #6065

This PR is Ready for Review.

Eventually, the `Thread::kill()` method could be merged inside `Thread::~Thread()`