### PR TITLE
Mapgen: Fix on-by-default flags broken since eca6ee9

### DIFF
--- a/src/map_settings_manager.cpp
+++ b/src/map_settings_manager.cpp
@@ -32,6 +32,10 @@ MapSettingsManager::MapSettingsManager(Settings *user_settings,
 	m_user_settings(user_settings)
 {
 	assert(m_user_settings != NULL);
+
+	Mapgen::setDefaultSettings(m_map_settings);
+	// This inherits the combined defaults provided by loadGameConfAndInitWorld.
+	m_map_settings->overrideDefaults(user_settings);
 }
 
 
@@ -179,20 +183,8 @@ MapgenParams *MapSettingsManager::makeMapgenParams()
 
 	params->mgtype = mgtype;
 
-	// Load the mapgen param defaults
-	/* FIXME: Why is it done like this? MapgenParams should just
-	 * set the defaults in its constructor instead. */
-	{
-		Settings default_settings;
-		Mapgen::setDefaultSettings(&default_settings);
-		params->MapgenParams::readParams(&default_settings);
-		params->readParams(&default_settings);
-	}
-
 	// Load the rest of the mapgen params from our active settings
-	params->MapgenParams::readParams(m_user_settings);
 	params->MapgenParams::readParams(m_map_settings);
-	params->readParams(m_user_settings);
 	params->readParams(m_map_settings);
 
 	// Hold onto our params


### PR DESCRIPTION
Corrects the on-by-default flags when they're yet not present in `map_meta.txt`.
See https://github.com/minetest/minetest/pull/10276#issuecomment-671087672
This PR does...
1) Add default mapgen flags to `map_meta.txt`
2) Combine the `map_meta.txt` _defaults_ using the `user_settings` (which is game conf + global conf) active settings
3) Read out the resulting values using `readParams` (`map_meta.txt` values + defaults)

## To do

This PR is Ready for Review.

## How to test

0) Apply #10276
1) Files with following contents (using format for minetest.conf):
```
# defaultsettings: caves, dungeons, light, decorations, biomes, ores
#  + Game   .conf: nocaves, nodungeons, light
#  + Global .conf: caves, nodecorations
#  + map_meta.txt: decorations, nobiomes
#
#          wanted: caves, nodungeons, light, decorations, nobiomes, ores
#             got: caves, nodungeons, light, decorations, nobiomes, ores
mg_flags = caves, nodecorations
```
2) Join the modified world and check whether `mg_flags` turn into the `got` values shown above.

Also test slightly varying configurations. Seems to work, but I'm afraid there's still a malfunctioning edge case.