### PR TITLE
Add vector.offset

### DIFF
--- a/builtin/common/tests/vector_spec.lua
+++ b/builtin/common/tests/vector_spec.lua
@@ -44,6 +44,10 @@ describe("vector", function()
 		assert.same({ x = 2, y = 4, z = 6 }, vector.add(vector.new(1, 2, 3), { x = 1, y = 2, z = 3 }))
 	end)
 
+	it("offset()", function()
+		assert.same({ x = 41, y = 52, z = 63 }, vector.offset(vector.new(1, 2, 3), 40, 50, 60))
+	end)
+
 	-- This function is needed because of floating point imprecision.
 	local function almost_equal(a, b)
 		if type(a) == "number" then

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -137,6 +137,12 @@ function vector.divide(a, b)
 	end
 end
 
+function vector.offset(v, x, y, z)
+	return {x = v.x + x,
+		y = v.y + y,
+		z = v.z + z}
+end
+
 function vector.sort(a, b)
 	return {x = math.min(a.x, b.x), y = math.min(a.y, b.y), z = math.min(a.z, b.z)},
 		{x = math.max(a.x, b.x), y = math.max(a.y, b.y), z = math.max(a.z, b.z)}

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3062,10 +3062,12 @@ For the following functions, `v`, `v1`, `v2` are vectors,
     * Returns in order minp, maxp vectors of the cuboid defined by `v1`, `v2`.
 * `vector.angle(v1, v2)`:
     * Returns the angle between `v1` and `v2` in radians.
-* `vector.dot(v1, v2)`
-    * Returns the dot product of `v1` and `v2`
-* `vector.cross(v1, v2)`
-    * Returns the cross product of `v1` and `v2`
+* `vector.dot(v1, v2)`:
+    * Returns the dot product of `v1` and `v2`.
+* `vector.cross(v1, v2)`:
+    * Returns the cross product of `v1` and `v2`.
+* `vector.offset(v, x, y, z)`:
+    * Returns the sum of the vectors `v` and `{x = x, y = y, z = z}`.
 
 For the following functions `x` can be either a vector or a number:
 


### PR DESCRIPTION
- Adds a new function `vector.offset(v, x, y, z)` which returns a vector that is offset by the given values.
- #9444 had this included but was closed by author without leaving a comment.
- Usecases:
It happens very often that one has to just modify a vector by certain values.
Example: To get the node blow a given position `pos`:
  ```lua
  -- old variant (much longer)
  minetest.get_node(vector.add(pos, vector.new(0, -1, 0)))

  -- also possible, but 3 lines
  pos.y = pos.y - 1
  minetest.get_node(pos)
  pos.y = pos.y + 1 -- if `pos` is a parameter and one does not do this, it can end badly

  -- new code
  minetest.get_node(vector.offset(pos, 0, -1, 0))
  ```
  #9444 also has a list of links to concrete examples in code where it would be useful.

## To do

This PR is a Ready for Review.

## How to test

There's a new unit test, call it like this:
`busted builtin`
