### PR TITLE
Fix luacheck warnings in builtin/common/tests/

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -72,3 +72,11 @@ files["builtin/mainmenu"] = {
 		"PLATFORM",
 	},
 }
+
+files["builtin/common/tests"] = {
+	read_globals = {
+		"describe",
+		"it",
+		"assert",
+	},
+}


### PR DESCRIPTION
Luacheck showed 112 warnings for me in the builtin unittest files, this is fixed now.

## To do

This PR is a Ready for Review.

## How to test

`luacheck builtin`
