### PR TITLE
Split vector.new into 3 constructors

### DIFF
--- a/builtin/common/tests/vector_spec.lua
+++ b/builtin/common/tests/vector_spec.lua
@@ -31,6 +31,21 @@ describe("vector", function()
 		end)
 	end)
 
+	it("zero()", function()
+		assert.same({x = 0, y = 0, z = 0}, vector.zero())
+		assert.same(vector.new(), vector.zero())
+		assert.equal(vector.new(), vector.zero())
+		assert.is_true(vector.check(vector.zero()))
+	end)
+
+	it("copy()", function()
+		local v = vector.new(1, 2, 3)
+		assert.same(v, vector.copy(v))
+		assert.same(vector.new(v), vector.copy(v))
+		assert.equal(vector.new(v), vector.copy(v))
+		assert.is_true(vector.check(vector.copy(v)))
+	end)
+
 	it("indexes", function()
 		local some_vector = vector.new(24, 42, 13)
 		assert.equal(24, some_vector[1])
@@ -114,25 +129,25 @@ describe("vector", function()
 	end)
 
 	it("equals()", function()
-			local function assertE(a, b)
-				assert.is_true(vector.equals(a, b))
-			end
-			local function assertNE(a, b)
-				assert.is_false(vector.equals(a, b))
-			end
+		local function assertE(a, b)
+			assert.is_true(vector.equals(a, b))
+		end
+		local function assertNE(a, b)
+			assert.is_false(vector.equals(a, b))
+		end
 
-			assertE({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
-			assertE({x = -1, y = 0, z = 1}, {x = -1, y = 0, z = 1})
-			assertE({x = -1, y = 0, z = 1}, vector.new(-1, 0, 1))
-			local a = {x = 2, y = 4, z = -10}
-			assertE(a, a)
-			assertNE({x = -1, y = 0, z = 1}, a)
+		assertE({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
+		assertE({x = -1, y = 0, z = 1}, {x = -1, y = 0, z = 1})
+		assertE({x = -1, y = 0, z = 1}, vector.new(-1, 0, 1))
+		local a = {x = 2, y = 4, z = -10}
+		assertE(a, a)
+		assertNE({x = -1, y = 0, z = 1}, a)
 
-			assert.equal(vector.new(1, 2, 3), vector.new(1, 2, 3))
-			assert.is_true(vector.new(1, 2, 3):equals(vector.new(1, 2, 3)))
-			assert.not_equal(vector.new(1, 2, 3), vector.new(1, 2, 4))
-			assert.is_true(vector.new(1, 2, 3) == vector.new(1, 2, 3))
-			assert.is_false(vector.new(1, 2, 3) == vector.new(1, 3, 3))
+		assert.equal(vector.new(1, 2, 3), vector.new(1, 2, 3))
+		assert.is_true(vector.new(1, 2, 3):equals(vector.new(1, 2, 3)))
+		assert.not_equal(vector.new(1, 2, 3), vector.new(1, 2, 4))
+		assert.is_true(vector.new(1, 2, 3) == vector.new(1, 2, 3))
+		assert.is_false(vector.new(1, 2, 3) == vector.new(1, 3, 3))
 	end)
 
 	it("metatable is same", function()

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -30,14 +30,26 @@ local function fast_new(x, y, z)
 end
 
 function vector.new(a, b, c)
-	if type(a) == "table" then
-		assert(a.x and a.y and a.z, "Invalid vector passed to vector.new()")
-		return fast_new(a.x, a.y, a.z)
-	elseif a then
-		assert(b and c, "Invalid arguments for vector.new()")
+	if a and b and c then
 		return fast_new(a, b, c)
 	end
+
+	-- deprecated, use vector.copy and vector.zero directly
+	if type(a) == "table" then
+		return vector.copy(a)
+	else
+		assert(not a, "Invalid arguments for vector.new()")
+		return vector.zero()
+	end
+end
+
+function vector.zero()
 	return fast_new(0, 0, 0)
+end
+
+function vector.copy(v)
+	assert(v.x and v.y and v.z, "Invalid vector passed to vector.copy()")
+	return fast_new(v.x, v.y, v.z)
 end
 
 function vector.from_string(s, init)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3259,10 +3259,13 @@ For the following functions, `v`, `v1`, `v2` are vectors,
 vectors are written like this: `(x, y, z)`:
 
 * `vector.new([a[, b, c]])`:
-    * Returns a vector.
-    * A copy of `a` if `a` is a vector.
-    * `(a, b, c)`, if all of `a`, `b`, `c` are defined numbers.
-    * `(0, 0, 0)`, if no arguments are given.
+    * Returns a new vector `(a, b, c)`.
+    * Deprecated: `vector.new()` does the same as `vector.zero()` and
+      `vector.new(v)` does the same as `vector.copy(v)`
+* `vector.zero()`:
+    * Returns a new vector `(0, 0, 0)`.
+* `vector.copy(v)`:
+    * Returns a copy of the vector `v`.
 * `vector.from_string(s[, init])`:
     * Returns `v, np`, where `v` is a vector read from the given string `s` and
       `np` is the next position in the string after the vector.


### PR DESCRIPTION
- `vector.new` has several disadvantages:
  - It has to look at its arguments to decide what it does. It has 3 functions in 1. This costs speed, (maybe not much).
  - There are assertions that are pretty unnecessary. They only show the programmer that they're using the function wrongly. This also costs speed. Edit: asserts were added back in, it is possible that they are pretty cheap. `¯\_(ツ)_/¯`
(Note that while _you_ might see the performance differences as negligible, others will stick because of it to the raw `{x=...}` and do not use `vector.new`.)
  - When reading code, you have to look at the parameter count to see what the function will do. Having 3 separate constructors is much clearer. (This is the important argument here.)
- This PR adds 2 new constructors for vectors: `vector.zero()` and `vector.copy(v)`.
One can directly read from the names what they do.
-  `vector.zero()` and `vector.copy(v)` functionality in `vector.new` is now deprecated.

## To do

This PR is a Ready for Review.

## How to test

There are unit tests.
`busted builtin`
