### PR TITLE
Add iterators for vectors

### DIFF
--- a/builtin/common/tests/vector_spec.lua
+++ b/builtin/common/tests/vector_spec.lua
@@ -48,6 +48,24 @@ describe("vector", function()
 		assert.same({ x = 41, y = 52, z = 63 }, vector.offset(vector.new(1, 2, 3), 40, 50, 60))
 	end)
 
+	it("pairs()", function()
+		local out = {}
+		local vec = vector.new(10, 20, 30)
+		for k, v in vector.pairs(vec) do
+			out[k] = v
+		end
+		assert.same({x = 10, y = 20, z = 30}, out)
+	end)
+
+	it("ipairs()", function()
+		local out = {}
+		local vec = vector.new(10, 20, 30)
+		for k, v in vector.ipairs(vec) do
+			out[k] = v
+		end
+		assert.same({10, 20, 30}, out)
+	end)
+
 	-- This function is needed because of floating point imprecision.
 	local function almost_equal(a, b)
 		if type(a) == "number" then

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -148,6 +148,32 @@ function vector.sort(a, b)
 		{x = math.max(a.x, b.x), y = math.max(a.y, b.y), z = math.max(a.z, b.z)}
 end
 
+local function vector_pairs_next(v, i)
+	if not i then
+		return "x", v.x
+	elseif i == "x" then
+		return "y", v.y
+	elseif i == "y" then
+		return "z", v.z
+	end
+end
+function vector.pairs(v)
+	return vector_pairs_next, v, nil
+end
+
+local function vector_ipairs_next(v, i)
+	if not i then
+		return 1, v.x
+	elseif i == 1 then
+		return 2, v.y
+	elseif i == 2 then
+		return 3, v.z
+	end
+end
+function vector.ipairs(v)
+	return vector_ipairs_next, v, nil
+end
+
 local function sin(x)
 	if x % math.pi == 0 then
 		return 0

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3116,6 +3116,11 @@ For the following functions, `v`, `v1`, `v2` are vectors,
     * Returns the cross product of `v1` and `v2`.
 * `vector.offset(v, x, y, z)`:
     * Returns the sum of the vectors `v` and `{x = x, y = y, z = z}`.
+* `vector.pairs(v)`:
+    * Iterates over key-value pairs where the keys are "x", "y" and "z".
+    * It is recommended to use this instead of `pairs`.
+* `vector.ipairs(v)`:
+    * Iterates over key-value pairs where the keys are 1, 2 and 3.
 
 For the following functions `x` can be either a vector or a number:
 


### PR DESCRIPTION
- Adds `vector.pairs` and `vector.ipairs` to iterate over vectors.
- See the lua reference on how generic for-loops work: http://www.lua.org/manual/5.1/manual.html#2.4.5
- `pairs` is a NYI: http://wiki.luajit.org/NYI#libraries_base-library

## To do

This PR is a Ready for Review.

## How to test

There are unittests:
`busted builtin`
