### PR TITLE
Add short names for vector operations

### DIFF
--- a/builtin/common/tests/vector_spec.lua
+++ b/builtin/common/tests/vector_spec.lua
@@ -41,7 +41,26 @@ describe("vector", function()
 	end)
 
 	it("add()", function()
-		assert.same({ x = 2, y = 4, z = 6 }, vector.add(vector.new(1, 2, 3), { x = 1, y = 2, z = 3 }))
+		assert.same({x = 2, y = 4, z = 6}, vector.add(vector.new(1, 2, 3), {x = 1, y = 2, z = 3}))
+		assert.same({x = 3, y = 4, z = 5}, vector.add(vector.new(1, 2, 3), 2))
+	end)
+
+	it("subtract()", function()
+		assert.same({x = 0, y = 2, z = 0}, vector.subtract(vector.new(1, 4, 3), {x = 1, y = 2, z = 3}))
+		assert.same({x = 0, y = 2, z = 0}, vector.sub(vector.new(1, 4, 3), {x = 1, y = 2, z = 3}))
+		assert.same({x = 0, y = 3, z = 2}, vector.sub(vector.new(1, 4, 3), 1))
+	end)
+
+	it("multiply()", function()
+		assert.same({x = 2, y = 8, z = 6}, vector.multiply(vector.new(1, 4, 3), 2))
+		assert.same({x = 2, y = 8, z = 6}, vector.mul(vector.new(1, 4, 3), 2))
+		assert.same({x = 1, y = 8, z = 9}, vector.mul(vector.new(1, 4, 3), {x = 1, y = 2, z = 3}))
+	end)
+
+	it("divide()", function()
+		assert.same({x = 0.5, y = 2, z = 1.5}, vector.divide(vector.new(1, 4, 3), 2))
+		assert.same({x = 0.5, y = 2, z = 1.5}, vector.div(vector.new(1, 4, 3), 2))
+		assert.same({x = 1, y = 2, z = 1}, vector.div(vector.new(1, 4, 3), {x = 1, y = 2, z = 3}))
 	end)
 
 	-- This function is needed because of floating point imprecision.

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -112,6 +112,7 @@ function vector.subtract(a, b)
 			z = a.z - b}
 	end
 end
+vector.sub = vector.subtract
 
 function vector.multiply(a, b)
 	if type(b) == "table" then
@@ -124,6 +125,7 @@ function vector.multiply(a, b)
 			z = a.z * b}
 	end
 end
+vector.mul = vector.multiply
 
 function vector.divide(a, b)
 	if type(b) == "table" then
@@ -136,6 +138,7 @@ function vector.divide(a, b)
 			z = a.z / b}
 	end
 end
+vector.div = vector.divide
 
 function vector.sort(a, b)
 	return {x = math.min(a.x, b.x), y = math.min(a.y, b.y), z = math.min(a.z, b.z)},

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3073,13 +3073,13 @@ For the following functions `x` can be either a vector or a number:
     * Returns a vector.
     * If `x` is a vector: Returns the sum of `v` and `x`.
     * If `x` is a number: Adds `x` to each component of `v`.
-* `vector.subtract(v, x)`:
+* `vector.subtract(v, x)` or `vector.sub(v, x)`:
     * Returns a vector.
     * If `x` is a vector: Returns the difference of `v` subtracted by `x`.
     * If `x` is a number: Subtracts `x` from each component of `v`.
-* `vector.multiply(v, x)`:
+* `vector.multiply(v, x)` or `vector.mul(v, x)`:
     * Returns a scaled vector or Schur product.
-* `vector.divide(v, x)`:
+* `vector.divide(v, x)` or `vector.div(v, x)`:
     * Returns a scaled vector or Schur quotient.
 
 For the following functions `a` is an angle in radians and `r` is a rotation


### PR DESCRIPTION
- `vector.subtract` and co. are too long to write (compared to `vector.add`).
This PR adds the short names sub, mul and div.
- (More justification: lua also calls them sub, mul and div: http://www.lua.org/manual/5.1/manual.html#2.8)
- I've also added unittests to sub, mul and div.

## To do

This PR is a Ready for Review.

## How to test

There are unittests:
`busted builtin`