### PR TITLE
Add in-place versions for vector operations

### DIFF
--- a/builtin/common/tests/vector_spec.lua
+++ b/builtin/common/tests/vector_spec.lua
@@ -44,6 +44,12 @@ describe("vector", function()
 		assert.same({ x = 2, y = 4, z = 6 }, vector.add(vector.new(1, 2, 3), { x = 1, y = 2, z = 3 }))
 	end)
 
+	it("add_assign()", function()
+		local v = vector.new(1, 2, 3)
+		vector.add_assign(v, {x = 1, y = 2, z = 3})
+		assert.same({x = 2, y = 4, z = 6}, v)
+	end)
+
 	-- This function is needed because of floating point imprecision.
 	local function almost_equal(a, b)
 		if type(a) == "number" then

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -55,6 +55,12 @@ function vector.apply(v, func)
 	}
 end
 
+function vector.apply_assign(v, func)
+	v.x = func(v.x)
+	v.y = func(v.y)
+	v.z = func(v.z)
+end
+
 function vector.distance(a, b)
 	local x = a.x - b.x
 	local y = a.y - b.y
@@ -134,6 +140,54 @@ function vector.divide(a, b)
 		return {x = a.x / b,
 			y = a.y / b,
 			z = a.z / b}
+	end
+end
+
+function vector.add_assign(a, b)
+	if type(b) == "table" then
+		a.x = a.x + b.x
+		a.y = a.y + b.y
+		a.z = a.z + b.z
+	else
+		a.x = a.x + b
+		a.y = a.y + b
+		a.z = a.z + b
+	end
+end
+
+function vector.sub_assign(a, b)
+	if type(b) == "table" then
+		a.x = a.x - b.x
+		a.y = a.y - b.y
+		a.z = a.z - b.z
+	else
+		a.x = a.x - b
+		a.y = a.y - b
+		a.z = a.z - b
+	end
+end
+
+function vector.mul_assign(a, b)
+	if type(b) == "table" then
+		a.x = a.x * b.x
+		a.y = a.y * b.y
+		a.z = a.z * b.z
+	else
+		a.x = a.x * b
+		a.y = a.y * b
+		a.z = a.z * b
+	end
+end
+
+function vector.div_assign(a, b)
+	if type(b) == "table" then
+		a.x = a.x / b.x
+		a.y = a.y / b.y
+		a.z = a.z / b.z
+	else
+		a.x = a.x / b
+		a.y = a.y / b
+		a.z = a.z / b
 	end
 end
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3056,6 +3056,8 @@ For the following functions, `v`, `v1`, `v2` are vectors,
 * `vector.apply(v, func)`:
     * Returns a vector where the function `func` has been applied to each
       component.
+* `vector.apply_assign(v, func)`:
+    * Does the same as `vector.apply` but works in-place.
 * `vector.equals(v1, v2)`:
     * Returns a boolean, `true` if the vectors are identical.
 * `vector.sort(v1, v2)`:
@@ -3081,6 +3083,14 @@ For the following functions `x` can be either a vector or a number:
     * Returns a scaled vector or Schur product.
 * `vector.divide(v, x)`:
     * Returns a scaled vector or Schur quotient.
+* `vector.add_assign(v, x)`:
+    * Does the same as `vector.add` but works in-place.
+* `vector.sub_assign(v, x)`:
+    * Does the same as `vector.subtract` but works in-place.
+* `vector.mul_assign(v, x)`:
+    * Does the same as `vector.multiply` but works in-place.
+* `vector.div_assign(v, x)`:
+    * Does the same as `vector.divide` but works in-place.
 
 For the following functions `a` is an angle in radians and `r` is a rotation
 vector ({x = <pitch>, y = <yaw>, z = <roll>}) where pitch, yaw and roll are


### PR DESCRIPTION
- I'm always frustrated when there are no in-place operations for vectors when I want to eg. add a vector to another vector.
- `vector.add` and co. always create a new vector. => much copying
- This PR adds the functions `vector.add_assign`, `vector.sub_assign`, `vector.mul_assign`, `vector.div_assign` and `vector.apply_assign` that work like their not-assign versions but instead modify the given vector in-place.
- Example:
  ```lua
  -- old:
  v = vector.add(v, w)
  -- new:
  vector.add_assign(v, w)
  ```

## To do

This PR is a Ready for Review.

## How to test

There's a unittest for `vector.add_assign`, the other functions work similar.
`busted builtin`
