### PR TITLE
Mark multiply and divide with two vectors as deprecated (Schur product and quotient)

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3067,12 +3067,17 @@ For the following functions, `v`, `v1`, `v2` are vectors,
     * Returns the dot product of `v1` and `v2`
 * `vector.cross(v1, v2)`
     * Returns the cross product of `v1` and `v2`
-* `vector.add(v1, v2)`:
-    * Returns the sum of both vectors.
-    * Deprecated: If `v2` is a number: Adds `v2` to each component of `v1`.
-* `vector.subtract(v1, v2)`:
-    * Returns the difference of `v1` subtracted by `v2`.
-    * Deprecated: If `v2` is a number: Subtracts `v2` from each component of `v1`.
+
+For the following functions `x` can be either a vector or a number:
+
+* `vector.add(v, x)`:
+    * Returns a vector.
+    * If `x` is a vector: Returns the sum of `v` and `x`.
+    * If `x` is a number: Adds `x` to each component of `v`.
+* `vector.subtract(v, x)`:
+    * Returns a vector.
+    * If `x` is a vector: Returns the difference of `v` subtracted by `x`.
+    * If `x` is a number: Subtracts `x` from each component of `v`.
 * `vector.multiply(v, s)`:
     * Returns a scaled vector.
     * Deprecated: If `s` is a vector: Returns the Schur product.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3033,7 +3033,8 @@ Internally, it is implemented as a table with the 3 fields
 `x`, `y` and `z`. Example: `{x = 0, y = 1, z = 0}`.
 
 For the following functions, `v`, `v1`, `v2` are vectors,
-`p1`, `p2` are positions:
+`p1`, `p2` are positions,
+`s` is a scalar (a number):
 
 * `vector.new(a[, b, c])`:
     * Returns a vector.
@@ -3066,21 +3067,18 @@ For the following functions, `v`, `v1`, `v2` are vectors,
     * Returns the dot product of `v1` and `v2`
 * `vector.cross(v1, v2)`
     * Returns the cross product of `v1` and `v2`
-
-For the following functions `x` can be either a vector or a number:
-
-* `vector.add(v, x)`:
-    * Returns a vector.
-    * If `x` is a vector: Returns the sum of `v` and `x`.
-    * If `x` is a number: Adds `x` to each component of `v`.
-* `vector.subtract(v, x)`:
-    * Returns a vector.
-    * If `x` is a vector: Returns the difference of `v` subtracted by `x`.
-    * If `x` is a number: Subtracts `x` from each component of `v`.
-* `vector.multiply(v, x)`:
-    * Returns a scaled vector or Schur product.
-* `vector.divide(v, x)`:
-    * Returns a scaled vector or Schur quotient.
+* `vector.add(v1, v2)`:
+    * Returns the sum of both vectors.
+    * Deprecated: If `v2` is a number: Adds `v2` to each component of `v1`.
+* `vector.subtract(v1, v2)`:
+    * Returns the difference of `v1` subtracted by `v2`.
+    * Deprecated: If `v2` is a number: Subtracts `v2` from each component of `v1`.
+* `vector.multiply(v, s)`:
+    * Returns a scaled vector.
+    * Deprecated: If `s` is a vector: Returns the Schur product.
+* `vector.divide(v, s)`:
+    * Returns a scaled vector.
+    * Deprecated: If `s` is a vector: Returns the Schur quotient.
 
 For the following functions `a` is an angle in radians and `r` is a rotation
 vector ({x = <pitch>, y = <yaw>, z = <roll>}) where pitch, yaw and roll are


### PR DESCRIPTION
- `vector.add` with a scalar in the second argument and mul with two vectors (and sub and div) is very unnatural and useless.
Who needs the Schur product or quotient or a value added or subbed to/from all components?
I do not think that I have seen them being used in code anywhere.
- Therefor these functions are marked as deprecated.

## To do

This PR is a Ready for Review.

## How to test

Look at the documentation.
