### PR TITLE
Startup screen code reorg

### DIFF
--- a/builtin/mainmenu/textures.lua
+++ b/builtin/mainmenu/textures.lua
@@ -55,14 +55,14 @@ function mm_texture.reset()
 
 	mm_texture.clear("header")
 	mm_texture.clear("footer")
-	core.set_clouds(false)
+	core.set_background_type("texture")
 
 	mm_texture.set_generic("footer")
 	mm_texture.set_generic("header")
 
 	if not have_bg then
 		if core.settings:get_bool("menu_clouds") then
-			core.set_clouds(true)
+			core.set_background_type("sky")
 		else
 			mm_texture.set_dirt_bg()
 		end
@@ -84,12 +84,12 @@ function mm_texture.update_game(gamedetails)
 
 	mm_texture.clear("header")
 	mm_texture.clear("footer")
-	core.set_clouds(false)
+	core.set_background_type("texture")
 
 	if not have_bg then
 
 		if core.settings:get_bool("menu_clouds") then
-			core.set_clouds(true)
+			core.set_background_type("sky")
 		else
 			mm_texture.set_dirt_bg()
 		end
@@ -103,7 +103,7 @@ end
 
 --------------------------------------------------------------------------------
 function mm_texture.clear(identifier)
-	core.set_background(identifier,"")
+	core.set_background_texture(identifier,"")
 end
 
 --------------------------------------------------------------------------------
@@ -112,7 +112,7 @@ function mm_texture.set_generic(identifier)
 	if mm_texture.texturepack ~= nil then
 		local path = mm_texture.texturepack .. DIR_DELIM .."menu_" ..
 										identifier .. ".png"
-		if core.set_background(identifier,path) then
+		if core.set_background_texture(identifier,path) then
 			return true
 		end
 	end
@@ -120,7 +120,7 @@ function mm_texture.set_generic(identifier)
 	if mm_texture.defaulttexturedir ~= nil then
 		local path = mm_texture.defaulttexturedir .. DIR_DELIM .."menu_" ..
 										identifier .. ".png"
-		if core.set_background(identifier,path) then
+		if core.set_background_texture(identifier,path) then
 			return true
 		end
 	end
@@ -138,7 +138,7 @@ function mm_texture.set_game(identifier, gamedetails)
 	if mm_texture.texturepack ~= nil then
 		local path = mm_texture.texturepack .. DIR_DELIM ..
 			gamedetails.id .. "_menu_" .. identifier .. ".png"
-		if core.set_background(identifier, path) then
+		if core.set_background_texture(identifier, path) then
 			return true
 		end
 	end
@@ -164,7 +164,7 @@ function mm_texture.set_game(identifier, gamedetails)
 
 	local path = gamedetails.path .. DIR_DELIM .. "menu" ..
 		DIR_DELIM .. filename
-	if core.set_background(identifier, path) then
+	if core.set_background_texture(identifier, path) then
 		return true
 	end
 
@@ -174,12 +174,12 @@ end
 function mm_texture.set_dirt_bg()
 	if mm_texture.texturepack ~= nil then
 		local path = mm_texture.texturepack .. DIR_DELIM .."default_dirt.png"
-		if core.set_background("background", path, true, 128) then
+		if core.set_background_texture("background", path, true, 128) then
 			return true
 		end
 	end
 
 	-- Use universal fallback texture in textures/base/pack
 	local minimalpath = defaulttexturedir .. "menu_bg.png"
-	core.set_background("background", minimalpath, true, 128)
+	core.set_background_texture("background", minimalpath, true, 128)
 end

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -174,12 +174,17 @@ core.set_formspec_prepend(formspec)
 GUI
 ---
 
-core.set_background(type, texturepath,[tile],[minsize])
+core.set_background_type(type)
+^ type: "color", "texture" or "sky"
+^ Set type of background for startup screen
+core.set_background_color(type, color)
+^ type: "background", "sky", "clouds" or "message"
+^ color: color spec of the color to be set to that startup screen element
+core.set_background_texture(type, texturepath,[tile],[minsize])
 ^ type: "background", "overlay", "header" or "footer"
 ^ tile: tile the image instead of scaling (background only)
 ^ minsize: minimum tile size, images are scaled to at least this size prior
 ^   doing tiling (background only)
-core.set_clouds(<true/false>)
 core.set_topleft_text(text)
 core.show_keys_menu()
 core.show_path_select_dialog(formname, caption, is_file_select)

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -56,6 +56,7 @@ set(client_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/renderingengine.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/shader.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/sky.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/startup_screen.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/tile.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/wieldmesh.cpp
 	PARENT_SCOPE

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -57,6 +57,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "game.h"
 #include "chatmessage.h"
 #include "translation.h"
+#include "startup_screen.h"
 
 extern gui::IGUIEnvironment* guienv;
 
@@ -1714,8 +1715,8 @@ void texture_update_progress(void *args, u32 progress, u32 max_progress)
 			targs->last_time_ms = time_ms;
 			std::basic_stringstream<wchar_t> strm;
 			strm << targs->text_base << " " << targs->last_percent << "%...";
-			RenderingEngine::draw_load_screen(strm.str(), targs->guienv, targs->tsrc, 0,
-				72 + (u16) ((18. / 100.) * (double) targs->last_percent), true);
+			g_startup_screen->setMessage(strm.str().c_str(),
+				72 + (u16) ((18. / 100.) * (double) targs->last_percent));
 		}
 }
 
@@ -1735,21 +1736,21 @@ void Client::afterContentReceived()
 
 	// Rebuild inherited images and recreate textures
 	infostream<<"- Rebuilding images and textures"<<std::endl;
-	RenderingEngine::draw_load_screen(text, guienv, m_tsrc, 0, 70);
+	g_startup_screen->setMessage(text, 70);
 	m_tsrc->rebuildImagesAndTextures();
 	delete[] text;
 
 	// Rebuild shaders
 	infostream<<"- Rebuilding shaders"<<std::endl;
 	text = wgettext("Rebuilding shaders...");
-	RenderingEngine::draw_load_screen(text, guienv, m_tsrc, 0, 71);
+	g_startup_screen->setMessage(text, 71);
 	m_shsrc->rebuildShaders();
 	delete[] text;
 
 	// Update node aliases
 	infostream<<"- Updating node aliases"<<std::endl;
 	text = wgettext("Initializing nodes...");
-	RenderingEngine::draw_load_screen(text, guienv, m_tsrc, 0, 72);
+	g_startup_screen->setMessage(text, 72);
 	m_nodedef->updateAliases(m_itemdef);
 	for (const auto &path : getTextureDirs()) {
 		TextureOverrideSource override_source(path + DIR_DELIM + "override.txt");
@@ -1782,7 +1783,7 @@ void Client::afterContentReceived()
 		m_script->on_client_ready(m_env.getLocalPlayer());
 
 	text = wgettext("Done!");
-	RenderingEngine::draw_load_screen(text, guienv, m_tsrc, 0, 100);
+	g_startup_screen->setMessage(text, 100);
 	infostream<<"Client::afterContentReceived() done"<<std::endl;
 	delete[] text;
 }

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -64,6 +64,7 @@ class NetworkPacket;
 namespace con {
 class Connection;
 }
+class StartupScreen;
 
 enum LocalClientState {
 	LC_Created,
@@ -124,7 +125,8 @@ public:
 			ISoundManager *sound,
 			MtEventManager *event,
 			bool ipv6,
-			GameUI *game_ui
+			GameUI *game_ui,
+			StartupScreen *startup_screen
 	);
 
 	~Client();
@@ -579,6 +581,8 @@ private:
 	LocalClientState m_state;
 
 	GameUI *m_game_ui;
+
+	StartupScreen *m_startup_screen;
 
 	// Used for saving server map to disk client-side
 	MapDatabase *m_localdb = nullptr;

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -18,7 +18,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "gui/mainmenumanager.h"
-#include "startup_screen.h"
 #include "server.h"
 #include "filesys.h"
 #include "gui/guiMainMenu.h"
@@ -33,6 +32,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "version.h"
 #include "renderingengine.h"
 #include "network/networkexceptions.h"
+#include "client/startup_screen.h"
 
 #if USE_SOUND
 	#include "sound_openal.h"
@@ -183,8 +183,8 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	skin->setColor(gui::EGDC_FOCUSED_EDITABLE, video::SColor(255, 96, 134, 49));
 #endif
 
-	g_startup_screen = new StartupScreen();
-	g_startup_screen->step(false);
+	m_startup_screen = new StartupScreen();
+	m_startup_screen->step(false);
 
 	/*
 		GUI stuff
@@ -257,6 +257,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 			the_game(
 				kill,
 				input,
+				m_startup_screen,
 				start_data,
 				error_message,
 				chat_backend,
@@ -264,7 +265,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 			);
 			RenderingEngine::get_scene_manager()->clear();
 
-			g_startup_screen->clearMessage();
+			m_startup_screen->clearMessage();
 
 
 #ifdef HAVE_TOUCHSCREENGUI
@@ -299,7 +300,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 		}
 	} // Menu-game loop
 
-	delete g_startup_screen;
+	delete m_startup_screen;
 
 	return retval;
 }
@@ -557,7 +558,7 @@ void ClientLauncher::main_menu(MainMenuData *menudata)
 #endif
 
 	/* show main menu */
-	GUIEngine mymenu(&input->joystick, guiroot, &g_menumgr, menudata, *kill);
+	GUIEngine mymenu(&input->joystick, m_startup_screen, guiroot, &g_menumgr, menudata, *kill);
 
 	/* leave scene manager in a clean state */
 	RenderingEngine::get_scene_manager()->clear();

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -52,4 +52,5 @@ private:
 	InputHandler *input = nullptr;
 	MyEventReceiver *receiver = nullptr;
 	gui::IGUISkin *skin = nullptr;
+	StartupScreen *m_startup_screen = nullptr;
 };

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -24,14 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "constants.h"
 #include "cloudparams.h"
 
-// Menu clouds
-class Clouds;
-extern Clouds *g_menuclouds;
-
-// Scene manager used for menu clouds
-namespace irr{namespace scene{class ISceneManager;}}
-extern irr::scene::ISceneManager *g_menucloudsmgr;
-
 class Clouds : public scene::ISceneNode
 {
 public:

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -26,6 +26,7 @@ class InputHandler;
 class ChatBackend;  /* to avoid having to include chat.h */
 struct SubgameSpec;
 struct GameStartData;
+class StartupScreen;
 
 struct Jitter {
 	f32 max, min, avg, counter, max_sample, min_sample, max_fraction;
@@ -45,6 +46,7 @@ struct CameraOrientation {
 
 void the_game(bool *kill,
 		InputHandler *input,
+		StartupScreen *startup_screen,
 		const GameStartData &start_data,
 		std::string &error_message,
 		ChatBackend &chat_backend,

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -102,20 +102,6 @@ public:
 		return s_singleton->m_device->getGUIEnvironment();
 	}
 
-	inline static void draw_load_screen(const std::wstring &text,
-			gui::IGUIEnvironment *guienv, ITextureSource *tsrc,
-			float dtime = 0, int percent = 0, bool clouds = true)
-	{
-		s_singleton->_draw_load_screen(
-				text, guienv, tsrc, dtime, percent, clouds);
-	}
-
-	inline static void draw_menu_scene(
-			gui::IGUIEnvironment *guienv, float dtime, bool clouds)
-	{
-		s_singleton->_draw_menu_scene(guienv, dtime, clouds);
-	}
-
 	inline static void draw_scene(video::SColor skycolor, bool show_hud,
 			bool show_minimap, bool draw_wield_tool, bool draw_crosshair)
 	{
@@ -140,13 +126,6 @@ public:
 	static std::vector<irr::video::E_DRIVER_TYPE> getSupportedVideoDrivers();
 
 private:
-	void _draw_load_screen(const std::wstring &text, gui::IGUIEnvironment *guienv,
-			ITextureSource *tsrc, float dtime = 0, int percent = 0,
-			bool clouds = true);
-
-	void _draw_menu_scene(gui::IGUIEnvironment *guienv, float dtime = 0,
-			bool clouds = true);
-
 	void _draw_scene(video::SColor skycolor, bool show_hud, bool show_minimap,
 			bool draw_wield_tool, bool draw_crosshair);
 

--- a/src/client/startup_screen.cpp
+++ b/src/client/startup_screen.cpp
@@ -29,8 +29,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "version.h"
 #include "filesys.h"
 
-StartupScreen *g_startup_screen;
-
 /**********************************************************************/
 StartupScreen::StartupScreen():
 	m_driver(RenderingEngine::get_video_driver())

--- a/src/client/startup_screen.cpp
+++ b/src/client/startup_screen.cpp
@@ -1,0 +1,442 @@
+/*
+Minetest
+Copyright (C) 2020 Pierre-Yves Rollo <dev@pyrollo.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <IGUIStaticText.h>
+#include "client/camera.h"
+#include "client/clouds.h"
+#include "client/fontengine.h"
+#include "client/guiscalingfilter.h"
+#include "client/renderingengine.h"
+#include "client/startup_screen.h"
+#include "gui/guiEngine.h" // For MenuTextureSource
+#include "gettext.h"
+#include "version.h"
+#include "filesys.h"
+
+StartupScreen *g_startup_screen;
+
+/**********************************************************************/
+StartupScreen::StartupScreen():
+	m_driver(RenderingEngine::get_video_driver())
+{
+	// Create specific texture source
+	m_tsrc = new MenuTextureSource(m_driver);
+
+	// Initialize colors
+	m_colors[COLOR_BACKGROUND] = video::SColor(255, 80, 58, 37);
+	m_colors[COLOR_SKY]        = video::SColor(255, 140, 186, 250);
+	m_colors[COLOR_CLOUDS]     = video::SColor(255, 240, 240, 255);
+	m_colors[COLOR_MESSAGE]    = video::SColor(255, 240, 240, 255);
+
+	// Initialize texture pointers
+	for (image_definition &texture : m_textures) {
+		texture.texture = nullptr;
+	}
+
+	// Default textures for progress bar
+	setTexture(TEX_LAYER_PROGRESS_FG, "textures/base/pack/progress_bar.png");
+	setTexture(TEX_LAYER_PROGRESS_BG, "textures/base/pack/progress_bar_bg.png");
+
+
+	m_last_time = RenderingEngine::get_timer_time();
+
+	// Get last recorded screen size. It will be updated, if needed, next step
+	m_screensize = v2u32(
+		g_settings->getU16("screen_w"),
+		g_settings->getU16("screen_h"));
+
+	setBackgroundType(BT_SKY);
+}
+
+/**********************************************************************/
+StartupScreen::~StartupScreen()
+{
+	// Shutdown scenes
+	shutdownClouds();
+
+	// Clean up texture pointers
+	for (image_definition &texture : m_textures) {
+		if (texture.texture)
+			RenderingEngine::get_video_driver()->removeTexture(texture.texture);
+	}
+
+	// Delete related objects
+	delete m_tsrc;
+}
+
+/**********************************************************************/
+void StartupScreen::setBackgroundType(backgroundType background_type)
+{
+	if (m_background_type == background_type)
+		return;
+
+	// Shutdown old background
+	if (m_background_type == BT_SKY)
+		shutdownClouds();
+
+	m_background_type = background_type;
+
+	// Start new background
+	if (m_background_type == BT_SKY)
+		startupClouds();
+}
+
+
+/**********************************************************************/
+bool StartupScreen::setTexture(textureLayer layer,
+		const std::string &texturepath,
+		bool tile_image,
+		unsigned int minsize)
+{
+	if (m_textures[layer].texture) {
+		m_driver->removeTexture(m_textures[layer].texture);
+		m_textures[layer].texture = NULL;
+	}
+
+	if (texturepath.empty() || !fs::PathExists(texturepath)) {
+		return false;
+	}
+
+	m_textures[layer].texture = m_driver->getTexture(texturepath.c_str());
+	m_textures[layer].tile    = tile_image;
+	m_textures[layer].minsize = minsize;
+
+	if (!m_textures[layer].texture) {
+		return false;
+	}
+
+	return true;
+}
+
+/**********************************************************************/
+void StartupScreen::setMessage(const wchar_t *msg, int percent)
+{
+	m_message = std::wstring(msg);
+	m_percent = percent;
+	step(false);
+}
+
+/**********************************************************************/
+void StartupScreen::setMessage(const char *msg, int percent)
+{
+	const wchar_t *wmsg = wgettext(msg);
+	setMessage(wmsg, percent);
+	delete[] wmsg;
+}
+
+/**********************************************************************/
+void StartupScreen::startupClouds()
+{
+	if (!m_cloudsmgr) {
+		m_cloudsmgr = RenderingEngine::get_scene_manager()
+				->createNewSceneManager();
+	}
+
+	if (!m_clouds) {
+		m_clouds = new Clouds(m_cloudsmgr, -1, rand());
+		m_clouds->setHeight(100.0f);
+		m_clouds->update(v3f(0, 0, 0), m_colors[COLOR_CLOUDS]);
+		scene::ICameraSceneNode* camera;
+		camera = m_cloudsmgr->addCameraSceneNode(NULL, v3f(0, 0, 0),
+				v3f(0, 60, 100));
+		camera->setFarValue(10000);
+		m_driver->setFog(m_colors[COLOR_SKY], video::EFT_FOG_LINEAR,
+				50.0f, 100.0f, 0, true, false);
+	}
+}
+
+/**********************************************************************/
+void StartupScreen::shutdownClouds()
+{
+	if (m_clouds)
+		m_clouds->drop();
+	if (m_cloudsmgr)
+		m_cloudsmgr->drop();
+	m_clouds = nullptr;
+	m_cloudsmgr = nullptr;
+}
+
+/**********************************************************************/
+void StartupScreen::drawClouds(float dtime)
+{
+	m_clouds->step(dtime * 3);
+	m_clouds->render();
+	m_cloudsmgr->drawAll();
+}
+
+/**********************************************************************/
+void StartupScreen::drawBackgroundTexture()
+{
+	video::ITexture* texture = m_textures[TEX_LAYER_BACKGROUND].texture;
+
+	if(!texture)
+		return;
+
+	v2u32 sourcesize = texture->getOriginalSize();
+
+	if (m_textures[TEX_LAYER_BACKGROUND].tile) {
+		/* Draw tiled background texture */
+		v2u32 tilesize(
+				MYMAX(sourcesize.X,m_textures[TEX_LAYER_BACKGROUND].minsize),
+				MYMAX(sourcesize.Y,m_textures[TEX_LAYER_BACKGROUND].minsize));
+		for (unsigned int x = 0; x < m_screensize.X; x += tilesize.X )
+		{
+			for (unsigned int y = 0; y < m_screensize.Y; y += tilesize.Y )
+			{
+				draw2DImageFilterScaled(m_driver, texture,
+					core::rect<s32>(x, y, x+tilesize.X, y+tilesize.Y),
+					core::rect<s32>(0, 0, sourcesize.X, sourcesize.Y),
+					NULL, NULL, true);
+			}
+		}
+	} else {
+		/* Draw stretched background texture */
+		draw2DImageFilterScaled(m_driver, texture,
+			core::rect<s32>(0, 0, m_screensize.X, m_screensize.Y),
+			core::rect<s32>(0, 0, sourcesize.X, sourcesize.Y),
+			NULL, NULL, true);
+	}
+}
+
+/**********************************************************************/
+void StartupScreen::drawOverlay()
+{
+	video::ITexture* texture = m_textures[TEX_LAYER_OVERLAY].texture;
+
+	/* If no texture, draw nothing */
+	if(!texture)
+		return;
+
+	/* Draw background texture */
+	v2u32 sourcesize = texture->getOriginalSize();
+	draw2DImageFilterScaled(m_driver, texture,
+		core::rect<s32>(0, 0, m_screensize.X, m_screensize.Y),
+		core::rect<s32>(0, 0, sourcesize.X, sourcesize.Y),
+		NULL, NULL, true);
+}
+
+/**********************************************************************/
+void StartupScreen::drawHeader()
+{
+	video::ITexture* texture = m_textures[TEX_LAYER_HEADER].texture;
+
+	/* If no texture, draw nothing */
+	if(!texture)
+		return;
+
+	f32 mult = (((f32)m_screensize.X / 2.0)) /
+			((f32)texture->getOriginalSize().Width);
+
+	v2s32 splashsize(((f32)texture->getOriginalSize().Width) * mult,
+			((f32)texture->getOriginalSize().Height) * mult);
+
+	// Don't draw the header if there isn't enough room
+	s32 free_space = (((s32)m_screensize.Y)-320)/2;
+
+	if (free_space > splashsize.Y) {
+		core::rect<s32> splashrect(0, 0, splashsize.X, splashsize.Y);
+		splashrect += v2s32((m_screensize.X/2)-(splashsize.X/2),
+				((free_space/2)-splashsize.Y/2)+10);
+
+	draw2DImageFilterScaled(m_driver, texture, splashrect,
+		core::rect<s32>(core::position2d<s32>(0,0),
+		core::dimension2di(texture->getOriginalSize())),
+		NULL, NULL, true);
+	}
+}
+
+/**********************************************************************/
+void StartupScreen::drawFooter()
+{
+	video::ITexture* texture = m_textures[TEX_LAYER_FOOTER].texture;
+
+	/* If no texture, draw nothing */
+	if(!texture)
+		return;
+
+	f32 mult = (((f32)m_screensize.X)) /
+			((f32)texture->getOriginalSize().Width);
+
+	v2s32 footersize(((f32)texture->getOriginalSize().Width) * mult,
+			((f32)texture->getOriginalSize().Height) * mult);
+
+	// Don't draw the footer if there isn't enough room
+	s32 free_space = (((s32)m_screensize.Y)-320)/2;
+
+	if (free_space > footersize.Y) {
+		core::rect<s32> rect(0,0,footersize.X,footersize.Y);
+		rect += v2s32(m_screensize.X/2,m_screensize.Y-footersize.Y);
+		rect -= v2s32(footersize.X/2, 0);
+
+		draw2DImageFilterScaled(m_driver, texture, rect,
+			core::rect<s32>(core::position2d<s32>(0,0),
+			core::dimension2di(texture->getOriginalSize())),
+			NULL, NULL, true);
+	}
+}
+
+/**********************************************************************/
+void StartupScreen::drawProgressBar()
+{
+	// Default textrect: whole screen, font drawing will center text
+	core::rect<s32> textrect(0, 0, m_screensize.X, m_screensize.Y);
+
+	// draw progress bar
+	if ((m_percent >= 0) && (m_percent <= 100)) {
+		video::ITexture *progress_img =
+				m_textures[TEX_LAYER_PROGRESS_FG].texture;
+		video::ITexture *progress_img_bg =
+				m_textures[TEX_LAYER_PROGRESS_BG].texture;
+
+		if (progress_img && progress_img_bg) {
+#ifndef __ANDROID__
+			const core::dimension2d<u32> &img_size =
+					progress_img_bg->getSize();
+			u32 imgW = rangelim(img_size.Width, 200, 600);
+			u32 imgH = rangelim(img_size.Height, 24, 72);
+#else
+			const core::dimension2d<u32> img_size(256, 48);
+			float imgRatio = (float)img_size.Height / img_size.Width;
+			u32 imgW = m_screensize.X / 2.2f;
+			u32 imgH = floor(imgW * imgRatio);
+#endif
+			v2s32 img_pos((m_screensize.X - imgW) / 2,
+					(m_screensize.Y - imgH) / 2);
+
+			// Textrect updated so text is clipped into progress bar
+			textrect = core::rect<s32>(
+				img_pos.X, img_pos.Y,
+				img_pos.X + imgW,
+				img_pos.Y + imgH);
+
+			draw2DImageFilterScaled(m_driver, progress_img_bg, textrect,
+					core::rect<s32>(0, 0, img_size.Width, img_size.Height),
+					0, 0, true);
+
+			draw2DImageFilterScaled(m_driver, progress_img,
+					core::rect<s32>(img_pos.X, img_pos.Y,
+							img_pos.X + (m_percent * imgW) / 100,
+							img_pos.Y + imgH),
+					core::rect<s32>(0, 0,
+							(m_percent * img_size.Width) / 100,
+							img_size.Height),
+					0, 0, true);
+		}
+	}
+
+	// Draw message
+	if (m_message != L"") {
+		g_fontengine->getFont()->draw(m_message.c_str(), textrect,
+			m_colors[COLOR_MESSAGE], true, true);
+	}
+}
+
+/**********************************************************************/
+void StartupScreen::drawAll(float dtime)
+{
+	switch (m_background_type) {
+		case BT_COLOR:
+			m_driver->beginScene(true, true, m_colors[COLOR_BACKGROUND]);
+			break;
+		case BT_TEXTURE:
+			m_driver->beginScene(true, true, m_colors[COLOR_BACKGROUND]);
+			drawBackgroundTexture();
+			break;
+		case BT_SKY:
+			m_driver->beginScene(true, true, m_colors[COLOR_SKY]);
+			drawClouds(dtime);
+			drawOverlay(); // ??
+			break;
+	}
+	if (m_percent >= 0 || m_message != L"")
+		drawProgressBar();
+
+	drawHeader();
+	drawFooter();
+
+	RenderingEngine::get_gui_env()->drawAll();
+
+	m_driver->endScene();
+}
+
+/**********************************************************************/
+void StartupScreen::setWindowsCaption()
+{
+	const wchar_t *text = wgettext("Main Menu");
+	RenderingEngine::get_raw_device()->setWindowCaption((
+				utf8_to_wide(PROJECT_NAME_C) +
+				L" " + utf8_to_wide(g_version_hash) +
+				L" [" + text + L"]"
+			).c_str());
+	delete[] text;
+}
+
+/**********************************************************************/
+void StartupScreen::step(bool limitFps)
+{
+	// Compute dtime
+	float dtime;
+
+	u32 time = RenderingEngine::get_timer_time();
+
+	if(time > m_last_time)
+		dtime = (time - m_last_time) / 1000.0;
+	else
+		dtime = 0;
+
+	m_last_time = time;
+
+	setWindowsCaption();
+
+	// Verify if window size has changed and save it if it's the case
+	// Ensure evaluating settings->getBool after verifying screensize
+	// First condition is cheaper
+	v2u32 screensize = m_driver->getScreenSize();
+
+	if (m_screensize != screensize && screensize != v2u32(0,0)) {
+		m_screensize = screensize;
+		if (g_settings->getBool("autosave_screensize")) {
+			g_settings->setU16("screen_w", m_screensize.X);
+			g_settings->setU16("screen_h", m_screensize.Y);
+		}
+	}
+
+	// Perform all graphic updates
+	drawAll(dtime);
+
+	// Limit FPS
+	float fps_max = g_settings->getFloat("pause_fps_max");
+
+	if (limitFps && fps_max > 0) {
+		// Time of frame without fps limit
+		u32 busytime_u32;
+
+		// not using getRealTime is necessary for wine
+		busytime_u32 = RenderingEngine::get_timer_time() - m_last_time;
+
+		// FPS limiter
+		u32 frametime_min = 1000./fps_max;
+
+		if (busytime_u32 < frametime_min) {
+			u32 sleeptime = frametime_min - busytime_u32;
+			RenderingEngine::get_raw_device()->sleep(sleeptime);
+		}
+	}
+}
+

--- a/src/client/startup_screen.h
+++ b/src/client/startup_screen.h
@@ -17,14 +17,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#pragma once
+
 #include <string>
 
 class Clouds;
 class MenuTextureSource;
 namespace irr{namespace scene{class ISceneManager;}}
-
-class StartupScreen;
-extern StartupScreen *g_startup_screen;
 
 struct TextureDefinition {
 	video::ITexture *texture = nullptr;

--- a/src/client/startup_screen.h
+++ b/src/client/startup_screen.h
@@ -26,46 +26,47 @@ namespace irr{namespace scene{class ISceneManager;}}
 class StartupScreen;
 extern StartupScreen *g_startup_screen;
 
-typedef struct {
+struct TextureDefinition {
 	video::ITexture *texture = nullptr;
 	bool             tile;
 	unsigned int     minsize;
-} image_definition;
+};
 
 class StartupScreen {
 public:
 	StartupScreen();
 	~StartupScreen();
 
-	enum backgroundType {
-		BT_COLOR,
-		BT_TEXTURE,
-		BT_SKY
+	enum class Background {
+		COLOR,   // TO
+		TEXTURE, // BE
+		SKY      // COMMENTED
 	};
 
-	enum textureLayer {
-		TEX_LAYER_BACKGROUND = 0,
-		TEX_LAYER_OVERLAY,
-		TEX_LAYER_HEADER,
-		TEX_LAYER_FOOTER,
-		TEX_LAYER_PROGRESS_FG,
-		TEX_LAYER_PROGRESS_BG,
-		TEX_LAYER_MAX
+	enum class Texture {
+		BACKGROUND = 0, //
+		OVERLAY,        // TO
+		HEADER,         // BE
+		FOOTER,         // COMMENTED
+		PROGRESS_FG,    //
+		PROGRESS_BG,    //
+		Count
 	};
 
-	enum colorType {
-		COLOR_BACKGROUND = 0,
-		COLOR_SKY,
-		COLOR_CLOUDS,
-		COLOR_MESSAGE,
-		COLOR_MAX
+	enum class Color {
+		BACKGROUND = 0, //
+		SKY,            // TO
+		CLOUDS,         // BE
+		MESSAGE,        // COMMENTED
+		Count           //
 	};
 
 	// Startup screen customization
-	void setBackgroundType(backgroundType background_type);
-	bool setTexture(textureLayer layer, const std::string &texturepath,
+	void setBackgroundType(Background type);
+	bool setTexture(Texture type, const std::string &texturepath,
 			bool tile_image = false, unsigned int minsize = 0);
-	inline void setColor(colorType type, const video::SColor &color) { m_colors[type] = color; };
+	inline void setColor(Color type, const video::SColor &color)
+		{ m_colors[static_cast<int>(type)] = color; };
 
 	// Loading message and progress management
 	void setMessage(const wchar_t *msg, int percent);
@@ -76,6 +77,11 @@ public:
 	void step(bool limitFps);
 
 protected:
+	// Access to customizations
+	inline const TextureDefinition& getTexture(Texture type) 
+		{ return m_textures[static_cast<int>(type)]; };
+	inline const video::SColor& getColor(Color type)
+		{ return m_colors[static_cast<int>(type)]; };
 
 	// Clouds scene
 	void startupClouds();
@@ -102,9 +108,9 @@ protected:
 	void setWindowsCaption();
 
 	// Background type, custom textures and colors
-	backgroundType m_background_type = BT_COLOR;
-	image_definition m_textures[TEX_LAYER_MAX];
-	video::SColor m_colors[COLOR_MAX];
+	Background        m_background_type = Background::COLOR;
+	TextureDefinition m_textures[static_cast<int>(Texture::Count)];
+	video::SColor     m_colors[static_cast<int>(Color::Count)];
 
 	// Internal variables
 	video::IVideoDriver *m_driver;

--- a/src/client/startup_screen.h
+++ b/src/client/startup_screen.h
@@ -1,0 +1,115 @@
+/*
+Minetest
+Copyright (C) 2020 Pierre-Yves Rollo <dev@pyrollo.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <string>
+
+class Clouds;
+class MenuTextureSource;
+namespace irr{namespace scene{class ISceneManager;}}
+
+class StartupScreen;
+extern StartupScreen *g_startup_screen;
+
+typedef struct {
+	video::ITexture *texture = nullptr;
+	bool             tile;
+	unsigned int     minsize;
+} image_definition;
+
+class StartupScreen {
+public:
+	StartupScreen();
+	~StartupScreen();
+
+	enum backgroundType {
+		BT_COLOR,
+		BT_TEXTURE,
+		BT_SKY
+	};
+
+	enum textureLayer {
+		TEX_LAYER_BACKGROUND = 0,
+		TEX_LAYER_OVERLAY,
+		TEX_LAYER_HEADER,
+		TEX_LAYER_FOOTER,
+		TEX_LAYER_PROGRESS_FG,
+		TEX_LAYER_PROGRESS_BG,
+		TEX_LAYER_MAX
+	};
+
+	enum colorType {
+		COLOR_BACKGROUND = 0,
+		COLOR_SKY,
+		COLOR_CLOUDS,
+		COLOR_MESSAGE,
+		COLOR_MAX
+	};
+
+	// Startup screen customization
+	void setBackgroundType(backgroundType background_type);
+	bool setTexture(textureLayer layer, const std::string &texturepath,
+			bool tile_image = false, unsigned int minsize = 0);
+	inline void setColor(colorType type, const video::SColor &color) { m_colors[type] = color; };
+
+	// Loading message and progress management
+	void setMessage(const wchar_t *msg, int percent);
+	void setMessage(const char *msg, int percent);
+	inline void clearMessage() { setMessage(L"", -1); };
+
+	// Step : draw and eventualy limit FPS
+	void step(bool limitFps);
+
+protected:
+
+	// Clouds scene
+	void startupClouds();
+	void shutdownClouds();
+	void drawClouds(float dtime);
+
+	Clouds *m_clouds = nullptr;
+	irr::scene::ISceneManager *m_cloudsmgr = nullptr;
+
+	// Progress bar stuff
+	void drawProgressBar();
+
+	std::wstring m_message;
+	int m_percent = -1;
+
+	// Other internal drawings
+	void drawBackgroundTexture();
+	void drawOverlay();
+	void drawHeader();
+	void drawFooter();
+
+	void drawAll(float dtime);
+
+	void setWindowsCaption();
+
+	// Background type, custom textures and colors
+	backgroundType m_background_type = BT_COLOR;
+	image_definition m_textures[TEX_LAYER_MAX];
+	video::SColor m_colors[COLOR_MAX];
+
+	// Internal variables
+	video::IVideoDriver *m_driver;
+	MenuTextureSource *m_tsrc;
+
+	v2u32 m_screensize;
+	u32 m_last_time;
+};

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -120,10 +120,12 @@ void MenuMusicFetcher::fetchSounds(const std::string &name,
 /** GUIEngine                                                                 */
 /******************************************************************************/
 GUIEngine::GUIEngine(JoystickController *joystick,
+		StartupScreen *startup_screen,
 		gui::IGUIElement *parent,
 		IMenuManager *menumgr,
 		MainMenuData *data,
 		bool &kill) :
+	m_startup_screen(startup_screen),
 	m_parent(parent),
 	m_menumanager(menumgr),
 	m_smgr(RenderingEngine::get_scene_manager()),
@@ -235,7 +237,7 @@ void GUIEngine::run()
 			text_height = g_fontengine->getTextHeight();
 		}
 
-		g_startup_screen->step(true);
+		m_startup_screen->step(true);
 		m_script->step();
 
 #ifdef __ANDROID__

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -33,7 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /******************************************************************************/
 class GUIEngine;
 class MainMenuScripting;
-class Clouds;
+class StartupScreen;
 struct MainMenuData;
 
 /******************************************************************************/
@@ -131,6 +131,7 @@ public:
 	 * @param data struct to transfer data to main game handling
 	 */
 	GUIEngine(JoystickController *joystick,
+			StartupScreen *startup_screen,
 			gui::IGUIElement *parent,
 			IMenuManager *menumgr,
 			MainMenuData *data,
@@ -159,6 +160,14 @@ public:
 	unsigned int queueAsync(const std::string &serialized_fct,
 			const std::string &serialized_params);
 
+	/**
+	 * return pointer to startup screen instance
+	 */
+	StartupScreen *getStartupScreen()
+	{
+		return m_startup_screen;
+	}
+
 private:
 
 	/** find and run the main menu script */
@@ -170,6 +179,8 @@ private:
 	/** update size of topleftext element */
 	void updateTopLeftTextSize();
 
+	/** startup screen background */
+	StartupScreen           *m_startup_screen = nullptr;
 	/** parent gui element */
 	gui::IGUIElement        *m_parent = nullptr;
 	/** manager to add menus to */
@@ -221,9 +232,6 @@ private:
 	irr::gui::IGUIStaticText *m_irr_toplefttext = nullptr;
 	/** and text that is in it */
 	EnrichedString m_toplefttext;
-
-	/** is drawing of clouds enabled atm */
-//	bool        m_clouds_enabled = true;
 
 	/** start playing a sound and return handle */
 	s32 playSound(const SimpleSoundSpec &spec, bool looped);

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -29,24 +29,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/enriched_string.h"
 
 /******************************************************************************/
-/* Typedefs and macros                                                        */
-/******************************************************************************/
-/** texture layer ids */
-typedef enum {
-	TEX_LAYER_BACKGROUND = 0,
-	TEX_LAYER_OVERLAY,
-	TEX_LAYER_HEADER,
-	TEX_LAYER_FOOTER,
-	TEX_LAYER_MAX
-} texture_layer;
-
-typedef struct {
-	video::ITexture *texture = nullptr;
-	bool             tile;
-	unsigned int     minsize;
-} image_definition;
-
-/******************************************************************************/
 /* forward declarations                                                       */
 /******************************************************************************/
 class GUIEngine;
@@ -223,43 +205,11 @@ private:
 	void setFormspecPrepend(const std::string &fs);
 
 	/**
-	 * draw background layer
-	 * @param driver to use for drawing
-	 */
-	void drawBackground(video::IVideoDriver *driver);
-	/**
-	 * draw overlay layer
-	 * @param driver to use for drawing
-	 */
-	void drawOverlay(video::IVideoDriver *driver);
-	/**
-	 * draw header layer
-	 * @param driver to use for drawing
-	 */
-	void drawHeader(video::IVideoDriver *driver);
-	/**
-	 * draw footer layer
-	 * @param driver to use for drawing
-	 */
-	void drawFooter(video::IVideoDriver *driver);
-
-	/**
-	 * load a texture for a specified layer
-	 * @param layer draw layer to specify texture
-	 * @param texturepath full path of texture to load
-	 */
-	bool setTexture(texture_layer layer, const std::string &texturepath,
-			bool tile_image, unsigned int minsize);
-
-	/**
 	 * download a file using curl
 	 * @param url url to download
 	 * @param target file to store to
 	 */
 	static bool downloadFile(const std::string &url, const std::string &target);
-
-	/** array containing pointers to current specified texture layers */
-	image_definition m_textures[TEX_LAYER_MAX];
 
 	/**
 	 * specify text to appear as top left string
@@ -272,29 +222,8 @@ private:
 	/** and text that is in it */
 	EnrichedString m_toplefttext;
 
-	/** initialize cloud subsystem */
-	void cloudInit();
-	/** do preprocessing for cloud subsystem */
-	void cloudPreProcess();
-	/** do postprocessing for cloud subsystem */
-	void cloudPostProcess();
-
-	/** internam data required for drawing clouds */
-	struct clouddata {
-		/** delta time since last cloud processing */
-		f32     dtime;
-		/** absolute time of last cloud processing */
-		u32     lasttime;
-		/** pointer to cloud class */
-		Clouds *clouds = nullptr;
-		/** camera required for drawing clouds */
-		scene::ICameraSceneNode *camera = nullptr;
-	};
-
 	/** is drawing of clouds enabled atm */
-	bool        m_clouds_enabled = true;
-	/** data used to draw clouds */
-	clouddata   m_cloud;
+//	bool        m_clouds_enabled = true;
 
 	/** start playing a sound and return handle */
 	s32 playSound(const SimpleSoundSpec &spec, bool looped);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -165,18 +165,21 @@ int ModApiMainMenu::l_close(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_set_background_type(lua_State *L)
 {
-	sanity_check(g_startup_screen != NULL);
+	GUIEngine* engine = getGuiEngine(L);
+	sanity_check(engine != NULL);
+	StartupScreen *startup_screen = engine->getStartupScreen();
+	sanity_check(startup_screen != NULL);
 
 	std::string backgroundtype(luaL_checkstring(L, 1));
 
 	if (backgroundtype == "sky")
-		g_startup_screen->setBackgroundType(StartupScreen::Background::SKY);
+		startup_screen->setBackgroundType(StartupScreen::Background::SKY);
 
 	if (backgroundtype == "color")
-		g_startup_screen->setBackgroundType(StartupScreen::Background::COLOR);
+		startup_screen->setBackgroundType(StartupScreen::Background::COLOR);
 
 	if (backgroundtype == "texture")
-		g_startup_screen->setBackgroundType(StartupScreen::Background::TEXTURE);
+		startup_screen->setBackgroundType(StartupScreen::Background::TEXTURE);
 
 	return 0;
 }
@@ -184,7 +187,10 @@ int ModApiMainMenu::l_set_background_type(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_set_background_color(lua_State *L)
 {
-	sanity_check(g_startup_screen != NULL);
+	GUIEngine* engine = getGuiEngine(L);
+	sanity_check(engine != NULL);
+	StartupScreen *startup_screen = engine->getStartupScreen();
+	sanity_check(startup_screen != NULL);
 
 	std::string backgroundcolor(luaL_checkstring(L, 1));
 	video::SColor color;
@@ -192,16 +198,16 @@ int ModApiMainMenu::l_set_background_color(lua_State *L)
 		return 0;
 
 	if (backgroundcolor == "background")
-		g_startup_screen->setColor(StartupScreen::Color::BACKGROUND, color);
+		startup_screen->setColor(StartupScreen::Color::BACKGROUND, color);
 
 	if (backgroundcolor == "sky")
-		g_startup_screen->setColor(StartupScreen::Color::SKY, color);
+		startup_screen->setColor(StartupScreen::Color::SKY, color);
 
 	if (backgroundcolor == "clouds")
-		g_startup_screen->setColor(StartupScreen::Color::CLOUDS, color);
+		startup_screen->setColor(StartupScreen::Color::CLOUDS, color);
 
 	if (backgroundcolor == "message")
-		g_startup_screen->setColor(StartupScreen::Color::MESSAGE, color);
+		startup_screen->setColor(StartupScreen::Color::MESSAGE, color);
 
 	return 0;
 }
@@ -209,7 +215,10 @@ int ModApiMainMenu::l_set_background_color(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_set_background_texture(lua_State *L)
 {
-	sanity_check(g_startup_screen != NULL);
+	GUIEngine* engine = getGuiEngine(L);
+	sanity_check(engine != NULL);
+	StartupScreen *startup_screen = engine->getStartupScreen();
+	sanity_check(startup_screen != NULL);
 
 	std::string backgroundlevel(luaL_checkstring(L, 1));
 	std::string texturename(luaL_checkstring(L, 2));
@@ -227,25 +236,25 @@ int ModApiMainMenu::l_set_background_texture(lua_State *L)
 	}
 
 	if (backgroundlevel == "background") {
-		retval |= g_startup_screen->setTexture(
+		retval |= startup_screen->setTexture(
 				StartupScreen::Texture::BACKGROUND,
 				texturename, tile_image, minsize);
 	}
 
 	if (backgroundlevel == "overlay") {
-		retval |= g_startup_screen->setTexture(
+		retval |= startup_screen->setTexture(
 				StartupScreen::Texture::OVERLAY,
 				texturename, tile_image, minsize);
 	}
 
 	if (backgroundlevel == "header") {
-		retval |= g_startup_screen->setTexture(
+		retval |= startup_screen->setTexture(
 				StartupScreen::Texture::HEADER,
 				texturename, tile_image, minsize);
 	}
 
 	if (backgroundlevel == "footer") {
-		retval |= g_startup_screen->setTexture(
+		retval |= startup_screen->setTexture(
 				StartupScreen::Texture::FOOTER,
 				texturename, tile_image, minsize);
 	}

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -170,13 +170,13 @@ int ModApiMainMenu::l_set_background_type(lua_State *L)
 	std::string backgroundtype(luaL_checkstring(L, 1));
 
 	if (backgroundtype == "sky")
-		g_startup_screen->setBackgroundType(StartupScreen::BT_SKY);
+		g_startup_screen->setBackgroundType(StartupScreen::Background::SKY);
 
 	if (backgroundtype == "color")
-		g_startup_screen->setBackgroundType(StartupScreen::BT_COLOR);
+		g_startup_screen->setBackgroundType(StartupScreen::Background::COLOR);
 
 	if (backgroundtype == "texture")
-		g_startup_screen->setBackgroundType(StartupScreen::BT_TEXTURE);
+		g_startup_screen->setBackgroundType(StartupScreen::Background::TEXTURE);
 
 	return 0;
 }
@@ -192,16 +192,16 @@ int ModApiMainMenu::l_set_background_color(lua_State *L)
 		return 0;
 
 	if (backgroundcolor == "background")
-		g_startup_screen->setColor(StartupScreen::COLOR_BACKGROUND, color);
+		g_startup_screen->setColor(StartupScreen::Color::BACKGROUND, color);
 
 	if (backgroundcolor == "sky")
-		g_startup_screen->setColor(StartupScreen::COLOR_SKY, color);
+		g_startup_screen->setColor(StartupScreen::Color::SKY, color);
 
 	if (backgroundcolor == "clouds")
-		g_startup_screen->setColor(StartupScreen::COLOR_CLOUDS, color);
+		g_startup_screen->setColor(StartupScreen::Color::CLOUDS, color);
 
 	if (backgroundcolor == "message")
-		g_startup_screen->setColor(StartupScreen::COLOR_MESSAGE, color);
+		g_startup_screen->setColor(StartupScreen::Color::MESSAGE, color);
 
 	return 0;
 }
@@ -228,25 +228,25 @@ int ModApiMainMenu::l_set_background_texture(lua_State *L)
 
 	if (backgroundlevel == "background") {
 		retval |= g_startup_screen->setTexture(
-				StartupScreen::TEX_LAYER_BACKGROUND, 
+				StartupScreen::Texture::BACKGROUND,
 				texturename, tile_image, minsize);
 	}
 
 	if (backgroundlevel == "overlay") {
 		retval |= g_startup_screen->setTexture(
-				StartupScreen::TEX_LAYER_OVERLAY, 
+				StartupScreen::Texture::OVERLAY,
 				texturename, tile_image, minsize);
 	}
 
 	if (backgroundlevel == "header") {
 		retval |= g_startup_screen->setTexture(
-				StartupScreen::TEX_LAYER_HEADER,
+				StartupScreen::Texture::HEADER,
 				texturename, tile_image, minsize);
 	}
 
 	if (backgroundlevel == "footer") {
 		retval |= g_startup_screen->setTexture(
-				StartupScreen::TEX_LAYER_FOOTER,
+				StartupScreen::Texture::FOOTER,
 				texturename, tile_image, minsize);
 	}
 

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -100,7 +100,11 @@ private:
 
 	static int l_get_table_index(lua_State *L);
 
-	static int l_set_background(lua_State *L);
+	static int l_set_background_type(lua_State *L);
+
+	static int l_set_background_color(lua_State *L);
+
+	static int l_set_background_texture(lua_State *L);
 
 	static int l_update_formspec(lua_State *L);
 


### PR DESCRIPTION
This PR is an attempt to reorganize start up screen code (main menu and loading screen).

I wanted to continue Kilbith's #9973 but I quickly got lost in code mess and duplication.

This PR gathers everything to manage startup screen except main menu in one single class. This class is will be responsible of drawing background (clouds or texture), header, footer and progress information (during loading).

Formerly, this was scattered in various files : guiEngine, RenderingEngine and Clientlauncher. Many other where using access to RenderingEngine singleton to update loading message. They all get now the instance of StartupScreen.

## To do

This PR is a Work in Progress

- There are still bugs to be fixed but mainly works (not tested all menu things).
- MenuTextureSource should be replaced by a StartupTextureSource;

In a (near or far) future: 
- Main menu could be reworked to offer possibility to plainly customize screen background and loading screen;
- Other scenes could be added instead of clouds;

## How to test

If you want, you can just compile, launch and observe main menu and loading screen. It should be close to what's already there.

Side effect (looks like an improvement): When launching a game, background is kept same as in main menu. So, game title and background are now displayed while loading.