### PR TITLE
Open get_texture_mod to lua api

### DIFF
--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2299,6 +2299,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, set_rotation),
 	luamethod(ObjectRef, get_rotation),
 	luamethod_aliased(ObjectRef, set_texture_mod, settexturemod),
+	luamethod(ObjectRef, get_texture_mod),
 	luamethod_aliased(ObjectRef, set_sprite, setsprite),
 	luamethod(ObjectRef, get_entity_name),
 	luamethod(ObjectRef, get_luaentity),


### PR DESCRIPTION
get_texture_mod is listed in the lua api doc and the code is there, but it is not callable.
