### PR TITLE
Patch fast/teleport vulnerability when attached to an entity

### DIFF
--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -583,13 +583,7 @@ bool PlayerSAO::checkMovementCheat()
 		supposed_pos.rotateXZBy(90 + parent_rot * 180 / core::PI, parent_pos);
 		v3f diffvec = pos - supposed_pos;
 		f32 diff = abs(diffvec.X) + abs(diffvec.Y) + abs(diffvec.Z);
-		actionstream
-			<< "parent_pos " << parent_pos.X << " " << parent_pos.Y << " " << parent_pos.Z << std::endl
-			<< "pos " << pos.X << " " << pos.Y << " " << pos.Z << std::endl
-			<< "supposed_pos " << supposed_pos.X << " " << supposed_pos.Y << " " << supposed_pos.Z << std::endl
-			<< "attachment_pos " << attachment_pos.X << " " << attachment_pos.Y << " " << attachment_pos.Z << std::endl
-			;
-		if (diff > 1) {
+		if (diff > 10) {
 			setBasePosition(supposed_pos);
 			actionstream << "Server: " << m_player->getName()
 					<< " moved away from parent; diff=" << diff

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -564,12 +564,16 @@ bool PlayerSAO::checkMovementCheat()
 		return false;
 	}
 
-	if (isAttached()) {
+	ServerActiveObject *parentSAO = getParent();
+
+	if (parentSAO) {
+		UnitSAO *parent = dynamic_cast<UnitSAO *>(parentSAO);
+		if (! parent)
+			return false;
 		int parent_id;
 		std::string bone;
 		v3f attachment_pos, attachment_rot;
 		getAttachment(&parent_id, &bone, &attachment_pos, &attachment_rot);
-		UnitSAO *parent = (UnitSAO *)getParent();
 		v3f pos = getBasePosition();
 		f32 radius = sqrt(attachment_pos.X * attachment_pos.X + attachment_pos.Z * attachment_pos.Z);
 		v3f parent_pos = parent->getBasePosition();
@@ -587,8 +591,7 @@ bool PlayerSAO::checkMovementCheat()
 					<< " resetting position." << std::endl;
 			return true;
 		}
-		else
-			return false;
+		return false;
 	}
 
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -582,7 +582,7 @@ bool PlayerSAO::checkMovementCheat()
 		v3f supposed_pos = parent_pos + attachment_pos;
 		supposed_pos.rotateXZBy(90 + parent_rot * 180 / core::PI, parent_pos);
 		v3f diffvec = pos - supposed_pos;
-		f32 diff = abs(diffvec.X) + abs(diffvec.Y) + abs(diffvec.Z);
+		f32 diff = diffvec.getLength();
 		if (diff > 10) {
 			setBasePosition(supposed_pos);
 			actionstream << "Server: " << m_player->getName()

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -575,16 +575,21 @@ bool PlayerSAO::checkMovementCheat()
 		v3f attachment_pos, attachment_rot;
 		getAttachment(&parent_id, &bone, &attachment_pos, &attachment_rot);
 		v3f pos = getBasePosition();
-		f32 radius = sqrt(attachment_pos.X * attachment_pos.X + attachment_pos.Z * attachment_pos.Z);
 		v3f parent_pos = parent->getBasePosition();
-		f32 parent_rot = parent->getRadYawDep() + acos(1 / radius);
-		attachment_pos.X = cos(parent_rot) * radius;
-		attachment_pos.Z = sin(parent_rot) * radius;
-		attachment_pos *= 3;
-		v3f supposed_pos = parent_pos - attachment_pos;
+		f32 parent_rot = parent->getRadYawDep();
+		attachment_pos *= -3;
+		attachment_pos.Y *= -1;
+		v3f supposed_pos = parent_pos + attachment_pos;
+		supposed_pos.rotateXZBy(90 + parent_rot * 180 / core::PI, parent_pos);
 		v3f diffvec = pos - supposed_pos;
-		int diff = abs(diffvec.X) + abs(diffvec.Y) + abs(diffvec.Z);
-		if (diff > 10) {
+		f32 diff = abs(diffvec.X) + abs(diffvec.Y) + abs(diffvec.Z);
+		actionstream
+			<< "parent_pos " << parent_pos.X << " " << parent_pos.Y << " " << parent_pos.Z << std::endl
+			<< "pos " << pos.X << " " << pos.Y << " " << pos.Z << std::endl
+			<< "supposed_pos " << supposed_pos.X << " " << supposed_pos.Y << " " << supposed_pos.Z << std::endl
+			<< "attachment_pos " << attachment_pos.X << " " << attachment_pos.Y << " " << attachment_pos.Z << std::endl
+			;
+		if (diff > 1) {
 			setBasePosition(supposed_pos);
 			actionstream << "Server: " << m_player->getName()
 					<< " moved away from parent; diff=" << diff

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -577,10 +577,8 @@ bool PlayerSAO::checkMovementCheat()
 		v3f pos = getBasePosition();
 		v3f parent_pos = parent->getBasePosition();
 		f32 parent_rot = parent->getRadYawDep();
-		attachment_pos *= -3;
-		attachment_pos.Y *= -1;
-		v3f supposed_pos = parent_pos + attachment_pos;
-		supposed_pos.rotateXZBy(90 + parent_rot * 180 / core::PI, parent_pos);
+		v3f supposed_pos = parent_pos + attachment_pos * v3f(-3, 3, -3);
+		supposed_pos.rotateXZBy(90 + core::radToDeg(parent_rot), parent_pos);
 		v3f diffvec = pos - supposed_pos;
 		f32 diff = diffvec.getLength();
 		if (diff > 10) {

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -574,15 +574,10 @@ bool PlayerSAO::checkMovementCheat()
 		std::string bone;
 		v3f attachment_pos, attachment_rot;
 		getAttachment(&parent_id, &bone, &attachment_pos, &attachment_rot);
-		v3f pos = getBasePosition();
 		v3f parent_pos = parent->getBasePosition();
-		f32 parent_rot = parent->getRadYawDep();
-		v3f supposed_pos = parent_pos + attachment_pos * v3f(-3, 3, -3);
-		supposed_pos.rotateXZBy(90 + core::radToDeg(parent_rot), parent_pos);
-		v3f diffvec = pos - supposed_pos;
-		f32 diff = diffvec.getLength();
+		f32 diff = (getBasePosition() - parent_pos).getLength() - (attachment_pos * 3).getLength();
 		if (diff > 10) {
-			setBasePosition(supposed_pos);
+			setBasePosition(parent_pos);
 			actionstream << "Server: " << m_player->getName()
 					<< " moved away from parent; diff=" << diff
 					<< " resetting position." << std::endl;

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -575,7 +575,7 @@ bool PlayerSAO::checkMovementCheat()
 		v3f attachment_pos, attachment_rot;
 		getAttachment(&parent_id, &bone, &attachment_pos, &attachment_rot);
 		v3f parent_pos = parent->getBasePosition();
-		f32 diff = (getBasePosition() - parent_pos).getLength() - (attachment_pos * 3).getLength();
+		f32 diff = m_base_position.getDistanceFromSQ(parent_pos) - attachment_pos.getLengthSQ() * 9.0f;
 		if (diff > 10) {
 			setBasePosition(parent_pos);
 			actionstream << "Server: " << m_player->getName()


### PR DESCRIPTION
Hi,
I am the developer of the [dragonfire hackclient](https://github.com/EliasFleckenstein03/dragonfireclient), which I created for playing on an anarchy server. I published it so other players can use it on this server, but they are abusing it to hack on non-anarchy servers, so I decided that I'm going to patch the most important exploits included in the client.
GodMode was probably the most powerful one. It allowed bypassing movement anticheat, teleporting anywhere on the map or flying around invisible by making use of anticheat being disabled when attached to an entity.
## How to test
Run a local server (use MineClone2 or Minetest game), download dragonfireclient and use it to connect to the local server. Then get into a boat and enable Movement->God Mode in the Cheat menu. Now try flying away from the boat into unloaded MapBlocks. If the local server includes this patch, it will not load the mapblocks and also print a message into the server log, if not it will be possible to load the MapBlocks.