### PR TITLE
Prevent players accessing inventories of other players

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -629,13 +629,19 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		if (ma->from_inv != ma->to_inv)
 			m_inventory_mgr->setInventoryModified(ma->to_inv);
 
-		bool from_inv_is_current_player =
-			(ma->from_inv.type == InventoryLocation::PLAYER) &&
-			(ma->from_inv.name == player->getName());
-
-		bool to_inv_is_current_player =
-			(ma->to_inv.type == InventoryLocation::PLAYER) &&
-			(ma->to_inv.name == player->getName());
+		bool from_inv_is_current_player;
+		if (ma->from_inv.type == InventoryLocation::PLAYER) {
+			if (ma->from_inv.name != player->getName())
+				return;
+			from_inv_is_current_player = true;
+		}
+		
+		bool to_inv_is_current_player;
+		if (ma->to_inv.type == InventoryLocation::PLAYER) {
+			if (ma->to_inv.name != player->getName())
+				return;
+			to_inv_is_current_player = true;
+		}
 
 		InventoryLocation *remote = from_inv_is_current_player ?
 			&ma->to_inv : &ma->from_inv;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -629,14 +629,14 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		if (ma->from_inv != ma->to_inv)
 			m_inventory_mgr->setInventoryModified(ma->to_inv);
 
-		bool from_inv_is_current_player = ma->from_inv.type == InventoryLocation::CURRENT_PLAYER;
+		bool from_inv_is_current_player = false;
 		if (ma->from_inv.type == InventoryLocation::PLAYER) {
 			if (ma->from_inv.name != player->getName())
 				return;
 			from_inv_is_current_player = true;
 		}
 		
-		bool to_inv_is_current_player = ma->to_inv.type == InventoryLocation::CURRENT_PLAYER;
+		bool to_inv_is_current_player = false;
 		if (ma->to_inv.type == InventoryLocation::PLAYER) {
 			if (ma->to_inv.name != player->getName())
 				return;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -629,19 +629,21 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		if (ma->from_inv != ma->to_inv)
 			m_inventory_mgr->setInventoryModified(ma->to_inv);
 
-		bool from_inv_is_current_player;
+		bool from_inv_is_current_player = false;
 		if (ma->from_inv.type == InventoryLocation::PLAYER) {
 			if (ma->from_inv.name != player->getName())
 				return;
 			from_inv_is_current_player = true;
-		}
+		} else if (ma->from_inv.type != InventoryLocation::CURRENT_PLAYER)
+			from_inv_is_current_player = true;
 		
-		bool to_inv_is_current_player;
+		bool to_inv_is_current_player = false;
 		if (ma->to_inv.type == InventoryLocation::PLAYER) {
 			if (ma->to_inv.name != player->getName())
 				return;
 			to_inv_is_current_player = true;
-		}
+		} else if (ma->to_inv.type != InventoryLocation::CURRENT_PLAYER)
+			to_inv_is_current_player = true;
 
 		InventoryLocation *remote = from_inv_is_current_player ?
 			&ma->to_inv : &ma->from_inv;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -629,21 +629,19 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		if (ma->from_inv != ma->to_inv)
 			m_inventory_mgr->setInventoryModified(ma->to_inv);
 
-		bool from_inv_is_current_player = false;
+		bool from_inv_is_current_player = ma->from_inv.type != InventoryLocation::CURRENT_PLAYER;
 		if (ma->from_inv.type == InventoryLocation::PLAYER) {
 			if (ma->from_inv.name != player->getName())
 				return;
 			from_inv_is_current_player = true;
-		} else if (ma->from_inv.type != InventoryLocation::CURRENT_PLAYER)
-			from_inv_is_current_player = true;
+		}
 		
-		bool to_inv_is_current_player = false;
+		bool to_inv_is_current_player = ma->to_inv.type != InventoryLocation::CURRENT_PLAYER;
 		if (ma->to_inv.type == InventoryLocation::PLAYER) {
 			if (ma->to_inv.name != player->getName())
 				return;
 			to_inv_is_current_player = true;
-		} else if (ma->to_inv.type != InventoryLocation::CURRENT_PLAYER)
-			to_inv_is_current_player = true;
+		}
 
 		InventoryLocation *remote = from_inv_is_current_player ?
 			&ma->to_inv : &ma->from_inv;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -629,14 +629,14 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		if (ma->from_inv != ma->to_inv)
 			m_inventory_mgr->setInventoryModified(ma->to_inv);
 
-		bool from_inv_is_current_player = ma->from_inv.type != InventoryLocation::CURRENT_PLAYER;
+		bool from_inv_is_current_player = ma->from_inv.type == InventoryLocation::CURRENT_PLAYER;
 		if (ma->from_inv.type == InventoryLocation::PLAYER) {
 			if (ma->from_inv.name != player->getName())
 				return;
 			from_inv_is_current_player = true;
 		}
 		
-		bool to_inv_is_current_player = ma->to_inv.type != InventoryLocation::CURRENT_PLAYER;
+		bool to_inv_is_current_player = ma->to_inv.type == InventoryLocation::CURRENT_PLAYER;
 		if (ma->to_inv.type == InventoryLocation::PLAYER) {
 			if (ma->to_inv.name != player->getName())
 				return;


### PR DESCRIPTION
Title says it all. Fixes this cheat. Unfortunately also requires invhack mods to implement workarounds, but they seem to already be doing this.
