### PR TITLE
Fix game crashing if dropped an item with undefined light_source

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -55,8 +55,8 @@ core.register_entity(":__builtin:item", {
 		local count = math.min(stack:get_count(), max_count)
 		local size = 0.2 + 0.1 * (count / max_count) ^ (1 / 3)
 		local def = core.registered_items[itemname]
-		local glow = def and def.light_source
-			and math.floor(def.light_source / 2 + 0.5)
+		local glow = def and def.light_source and
+			math.floor(def.light_source / 2 + 0.5)
 
 		self.object:set_properties({
 			is_visible = true,

--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -55,7 +55,8 @@ core.register_entity(":__builtin:item", {
 		local count = math.min(stack:get_count(), max_count)
 		local size = 0.2 + 0.1 * (count / max_count) ^ (1 / 3)
 		local def = core.registered_items[itemname]
-		local glow = def and math.floor(def.light_source / 2 + 0.5)
+		local glow = def and def.light_source
+			and math.floor(def.light_source / 2 + 0.5)
 
 		self.object:set_properties({
 			is_visible = true,


### PR DESCRIPTION
Fix issue #10349
Just add a check on existing light_source field before involving it in calculation.

## To do

This PR is  Ready for Review.

## How to test

Launch game, set night, drop a "default:book" and a "default:torch".

Should not crash, torch should appear lighter that book.