### PR TITLE
Inventory: Protect Craft and Drop actions

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -601,7 +601,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 	std::istringstream is(datastring, std::ios_base::binary);
 	// Create an action
 	std::unique_ptr<InventoryAction> a(InventoryAction::deSerialize(is));
-	if (!a.get()) {
+	if (!a) {
 		infostream << "TOSERVER_INVENTORY_ACTION: "
 				<< "InventoryAction::deSerialize() returned NULL"
 				<< std::endl;


### PR DESCRIPTION
Same as #10341 but without memory leaks and additional protections fro `Craft` and `Drop`.

## To do

This PR is Ready for Review.

## How to test

1) Host a server
2) Join with a client and revoke its interact priv
3) Player can still move items in its inventory
4) Check the cheats - I don't have a patch to test this one