### PR TITLE
Prevent interacting with items out of the hotbar.

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -636,7 +636,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 				return;
 			from_inv_is_current_player = true;
 		}
-		
+
 		bool to_inv_is_current_player = false;
 		if (ma->to_inv.type == InventoryLocation::PLAYER) {
 			if (ma->to_inv.name != player->getName())
@@ -869,6 +869,15 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 
 	*pkt >> item;
 
+	if (item >= player->getHotbarItemcount()) {
+		actionstream << "Player: " << player->getName()
+			<< " tried to access item=" << item
+			<< " out of hotbar_itemcount="
+			<< player->getHotbarItemcount()
+			<< "; ignoring." << std::endl;
+		return;
+	}
+
 	playersao->getPlayer()->setWieldIndex(item);
 }
 
@@ -984,6 +993,16 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 	v3f player_pos = playersao->getLastGoodPosition();
 
 	// Update wielded item
+
+	if (item_i >= player->getHotbarItemcount()) {
+		actionstream << "Player: " << player->getName()
+			<< " tried to access item=" << item_i
+			<< " out of hotbar_itemcount="
+			<< player->getHotbarItemcount()
+			<< "; ignoring." << std::endl;
+		return;
+	}
+
 	playersao->getPlayer()->setWieldIndex(item_i);
 
 	// Get pointed to object (NULL if not POINTEDTYPE_OBJECT)


### PR DESCRIPTION
Prevents to select and interact with items in the players inventory which are not on the hotbar.

Shall I add an on_cheat Callback?

## How to test

There's a Next Item function in the dragonfire hackclient which also allows accessing out of the hotbar.
When interacting with a item outside the hotbar, the server will ignore the action.

Info: The hackclient doesn't send the selection package so you will only get informed on interaction.