### PR TITLE
Improve layout of main menu local tab

### DIFF
--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -114,44 +114,44 @@ local function get_formspec(tabview, name, tabdata)
 				)
 
 	retval = retval ..
-			"button[4,3.9;2.65,1;world_delete;".. fgettext("Delete") .. "]" ..
-			"button[6.525,3.9;2.65,1;world_configure;".. fgettext("Configure") .. "]" ..
-			"button[9.05,3.9;2.65,1;world_create;".. fgettext("New") .. "]" ..
-			"label[4,-0.1;".. fgettext("Select World:") .. "]"..
-			"checkbox[0.25,-0.20;cb_creative_mode;".. fgettext("Creative Mode") .. ";" ..
+			"button[3.9,3.8;2.8,1;world_delete;".. fgettext("Delete") .. "]" ..
+			"button[6.55,3.8;2.8,1;world_configure;".. fgettext("Configure") .. "]" ..
+			"button[9.2,3.8;2.8,1;world_create;".. fgettext("New") .. "]" ..
+			"label[3.9,-0.05;".. fgettext("Select World:") .. "]"..
+			"checkbox[0,-0.20;cb_creative_mode;".. fgettext("Creative Mode") .. ";" ..
 			dump(core.settings:get_bool("creative_mode")) .. "]"..
-			"checkbox[0.25,0.25;cb_enable_damage;".. fgettext("Enable Damage") .. ";" ..
+			"checkbox[0,0.25;cb_enable_damage;".. fgettext("Enable Damage") .. ";" ..
 			dump(core.settings:get_bool("enable_damage")) .. "]"..
-			"checkbox[0.25,0.7;cb_server;".. fgettext("Host Server") ..";" ..
+			"checkbox[0,0.7;cb_server;".. fgettext("Host Server") ..";" ..
 			dump(core.settings:get_bool("enable_server")) .. "]" ..
-			"textlist[4,0.4;7.5,3.5;sp_worlds;" ..
+			"textlist[3.9,0.4;7.9,3.45;sp_worlds;" ..
 			menu_render_worldlist() ..
 			";" .. index .. "]"
 
 	if core.settings:get_bool("enable_server") then
 		retval = retval ..
-				"button[7.75,4.8;3.95,1;play;".. fgettext("Host Game") .. "]" ..
-				"checkbox[0.25,1.15;cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
+				"button[7.9,4.75;4.1,1;play;".. fgettext("Host Game") .. "]" ..
+				"checkbox[0,1.15;cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
 				dump(core.settings:get_bool("server_announce")) .. "]" ..
-				"field[0.55,2.9;3.5,0.5;te_playername;" .. fgettext("Name") .. ";" ..
+				"field[0.3,2.85;3.8,0.5;te_playername;" .. fgettext("Name") .. ";" ..
 				core.formspec_escape(core.settings:get("name")) .. "]" ..
-				"pwdfield[0.55,4.1;3.5,0.5;te_passwd;" .. fgettext("Password") .. "]"
+				"pwdfield[0.3,4.05;3.8,0.5;te_passwd;" .. fgettext("Password") .. "]"
 
 		local bind_addr = core.settings:get("bind_address")
 		if bind_addr ~= nil and bind_addr ~= "" then
 			retval = retval ..
-				"field[0.55,5.3;2.25,0.5;te_serveraddr;" .. fgettext("Bind Address") .. ";" ..
+				"field[0.3,5.25;2.5,0.5;te_serveraddr;" .. fgettext("Bind Address") .. ";" ..
 				core.formspec_escape(core.settings:get("bind_address")) .. "]" ..
-				"field[2.8,5.3;1.25,0.5;te_serverport;" .. fgettext("Port") .. ";" ..
+				"field[2.85,5.25;1.25,0.5;te_serverport;" .. fgettext("Port") .. ";" ..
 				core.formspec_escape(core.settings:get("port")) .. "]"
 		else
 			retval = retval ..
-				"field[0.55,5.3;3.5,0.5;te_serverport;" .. fgettext("Server Port") .. ";" ..
+				"field[0.3,5.25;3.8,0.5;te_serverport;" .. fgettext("Server Port") .. ";" ..
 				core.formspec_escape(core.settings:get("port")) .. "]"
 		end
 	else
 		retval = retval ..
-				"button[7.75,4.8;3.95,1;play;" .. fgettext("Play Game") .. "]"
+				"button[7.9,4.75;4.1,1;play;" .. fgettext("Play Game") .. "]"
 	end
 
 	return retval

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -114,23 +114,23 @@ local function get_formspec(tabview, name, tabdata)
 				)
 
 	retval = retval ..
-			"button[4,3.95;2.6,1;world_delete;".. fgettext("Delete") .. "]" ..
-			"button[6.5,3.95;2.8,1;world_configure;".. fgettext("Configure") .. "]" ..
-			"button[9.2,3.95;2.5,1;world_create;".. fgettext("New") .. "]" ..
-			"label[4,-0.25;".. fgettext("Select World:") .. "]"..
+			"button[4,3.9;2.65,1;world_delete;".. fgettext("Delete") .. "]" ..
+			"button[6.525,3.9;2.65,1;world_configure;".. fgettext("Configure") .. "]" ..
+			"button[9.05,3.9;2.65,1;world_create;".. fgettext("New") .. "]" ..
+			"label[4,-0.1;".. fgettext("Select World:") .. "]"..
 			"checkbox[0.25,-0.20;cb_creative_mode;".. fgettext("Creative Mode") .. ";" ..
 			dump(core.settings:get_bool("creative_mode")) .. "]"..
 			"checkbox[0.25,0.25;cb_enable_damage;".. fgettext("Enable Damage") .. ";" ..
 			dump(core.settings:get_bool("enable_damage")) .. "]"..
 			"checkbox[0.25,0.7;cb_server;".. fgettext("Host Server") ..";" ..
 			dump(core.settings:get_bool("enable_server")) .. "]" ..
-			"textlist[4,0.25;7.5,3.7;sp_worlds;" ..
+			"textlist[4,0.4;7.5,3.5;sp_worlds;" ..
 			menu_render_worldlist() ..
 			";" .. index .. "]"
 
 	if core.settings:get_bool("enable_server") then
 		retval = retval ..
-				"button[8.5,4.8;3.2,1;play;".. fgettext("Host Game") .. "]" ..
+				"button[7.75,4.8;3.95,1;play;".. fgettext("Host Game") .. "]" ..
 				"checkbox[0.25,1.15;cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
 				dump(core.settings:get_bool("server_announce")) .. "]" ..
 				"field[0.55,2.9;3.5,0.5;te_playername;" .. fgettext("Name") .. ";" ..
@@ -151,7 +151,7 @@ local function get_formspec(tabview, name, tabdata)
 		end
 	else
 		retval = retval ..
-				"button[8.5,4.8;3.2,1;play;" .. fgettext("Play Game") .. "]"
+				"button[7.75,4.8;3.95,1;play;" .. fgettext("Play Game") .. "]"
 	end
 
 	return retval

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -118,11 +118,11 @@ local function get_formspec(tabview, name, tabdata)
 			"button[6.5,3.95;2.8,1;world_configure;".. fgettext("Configure") .. "]" ..
 			"button[9.2,3.95;2.5,1;world_create;".. fgettext("New") .. "]" ..
 			"label[4,-0.25;".. fgettext("Select World:") .. "]"..
-			"checkbox[0.25,0.25;cb_creative_mode;".. fgettext("Creative Mode") .. ";" ..
+			"checkbox[0.25,-0.20;cb_creative_mode;".. fgettext("Creative Mode") .. ";" ..
 			dump(core.settings:get_bool("creative_mode")) .. "]"..
-			"checkbox[0.25,0.7;cb_enable_damage;".. fgettext("Enable Damage") .. ";" ..
+			"checkbox[0.25,0.25;cb_enable_damage;".. fgettext("Enable Damage") .. ";" ..
 			dump(core.settings:get_bool("enable_damage")) .. "]"..
-			"checkbox[0.25,1.15;cb_server;".. fgettext("Host Server") ..";" ..
+			"checkbox[0.25,0.7;cb_server;".. fgettext("Host Server") ..";" ..
 			dump(core.settings:get_bool("enable_server")) .. "]" ..
 			"textlist[4,0.25;7.5,3.7;sp_worlds;" ..
 			menu_render_worldlist() ..
@@ -131,28 +131,27 @@ local function get_formspec(tabview, name, tabdata)
 	if core.settings:get_bool("enable_server") then
 		retval = retval ..
 				"button[8.5,4.8;3.2,1;play;".. fgettext("Host Game") .. "]" ..
-				"checkbox[0.25,1.6;cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
+				"checkbox[0.25,1.15;cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
 				dump(core.settings:get_bool("server_announce")) .. "]" ..
-				"label[0.25,2.2;" .. fgettext("Name/Password") .. "]" ..
-				"field[0.55,3.2;3.5,0.5;te_playername;;" ..
+				"field[0.55,2.9;3.5,0.5;te_playername;" .. fgettext("Name") .. ";" ..
 				core.formspec_escape(core.settings:get("name")) .. "]" ..
-				"pwdfield[0.55,4;3.5,0.5;te_passwd;]"
+				"pwdfield[0.55,4.1;3.5,0.5;te_passwd;" .. fgettext("Password") .. "]"
 
 		local bind_addr = core.settings:get("bind_address")
 		if bind_addr ~= nil and bind_addr ~= "" then
 			retval = retval ..
-				"field[0.55,5.2;2.25,0.5;te_serveraddr;" .. fgettext("Bind Address") .. ";" ..
+				"field[0.55,5.3;2.25,0.5;te_serveraddr;" .. fgettext("Bind Address") .. ";" ..
 				core.formspec_escape(core.settings:get("bind_address")) .. "]" ..
-				"field[2.8,5.2;1.25,0.5;te_serverport;" .. fgettext("Port") .. ";" ..
+				"field[2.8,5.3;1.25,0.5;te_serverport;" .. fgettext("Port") .. ";" ..
 				core.formspec_escape(core.settings:get("port")) .. "]"
 		else
 			retval = retval ..
-				"field[0.55,5.2;3.5,0.5;te_serverport;" .. fgettext("Server Port") .. ";" ..
+				"field[0.55,5.3;3.5,0.5;te_serverport;" .. fgettext("Server Port") .. ";" ..
 				core.formspec_escape(core.settings:get("port")) .. "]"
 		end
 	else
 		retval = retval ..
-				"button[8.5,4.8;3.2,1;play;".. fgettext("Play Game") .. "]"
+				"button[8.5,4.8;3.2,1;play;" .. fgettext("Play Game") .. "]"
 	end
 
 	return retval


### PR DESCRIPTION
Closes #10362 
Field background colours are not altered in this PR, altering them might alter all field background colours, so best attend to that later.

The layout in master is sloppy, with 'Name' and 'Password' combined into 1 label placed above 2 vertically stacked fields, elements squeezed against each other or against formspec edge, edge spacing inconsistent with other menu tabs, unequal width buttons, unaligned buttons.
As the most viewed menu screen this will be giving a bad impression.

Most screenshots are at default game window size, one screenshot is 1920x1080 fullscreen.

PR screenshot:

![Screenshot from 2020-09-09 00-41-42](https://user-images.githubusercontent.com/3686677/92538426-8a42a280-f236-11ea-8401-06753b55b4d6.png)

Master screenshot for comparison:

![Screenshot from 2020-09-09 00-56-45](https://user-images.githubusercontent.com/3686677/92538747-6338a080-f237-11ea-841e-95d1dbe7498b.png)

More PR screenshots:

![Screenshot from 2020-09-09 00-41-55](https://user-images.githubusercontent.com/3686677/92538449-99295500-f236-11ea-80e2-d69890952ef8.png)

![Screenshot from 2020-09-09 00-41-07](https://user-images.githubusercontent.com/3686677/92538470-a3e3ea00-f236-11ea-8257-518430e97fdb.png)

![Screenshot from 2020-09-09 00-42-11](https://user-images.githubusercontent.com/3686677/92538480-ab0af800-f236-11ea-82de-dd44d2ad23ec.png)

Layout changes:
* Use a constant edge spacing consistent with 'Content' and 'Settings' menu tabs. This moves elements horizontally outwards, allowing 'Delete', 'Configure', 'New' buttons to be made equal in width without reducing the width of any of them, and without reducing space for any text. In fact there is now a little more space for the checkbox texts.
* Equalise widths of 'Delete', 'Configure', 'New' buttons without reducing the width of any of them. They were slightly unequal in width, causing a subconcious impression of sloppiness.
* Move checkboxes up, they were squeezed against 'Name/Password'.
* Label name and password fields separately, this clarifies the field labelling and increases space for translations.
* Move 'Select World' label down, it was squeezed against formspec edge
* Reduce height of world list as necessary according to the above changes. Approx 1 world is lost from view.
* Make 'Host Game'/'Play Game' button wider to become half the width of the world list, for a more pleasing alignment and proportion with buttons and world list above, and for its size to reflect the significance of starting a game. This also increases space for translations.

Translations:
Currently there is 1 translation for 'Name/Password', this would change to 2 translations, so translations will need to be updated, this is a little inconvenient, but needs to be done at some point when we move to a new main menu design, as it is bad and inflexible to have 'name' and 'password' combined into one label.