### PR TITLE
fix for shader to use support homebrew's glfw for OpenGL

### DIFF
--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -45,7 +45,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <GLES2/gl2.h>
 #endif
 #else
+#if defined(__APPLE__)
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
+#else
 #include <GL/gl.h>
+#include <GL/glu.h>
+#endif
 #endif
 
 /*


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

Includes to GL were failing on OSX; this fixes them. 

- Goal of the PR
Completely new to the project - just discovered it last night. But wanted to try my hand at compiling it and ran into issues on the Mac. Compilation errors around OpenGL lead to threads about the more recent OSX version's moving/removing Open GL, and recommending the following macro.

- How does the PR work?
Conditionally checks if OSX and adjusts included packages as needed

- Does it resolve any reported issue?
Did not see one specifically for this yet


This PR is a Work in Progress


- [ ] Someone who can get a Mac build to actually work should verify this
- [ ] I'd imagine tests would be good?

## How to test
Literally no idea, but I'd love to help :) 
