### PR TITLE
(WIP) Fix particles depth sorting

### DIFF
--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -76,6 +76,7 @@ Particle::Particle(
 	m_material.setFlag(video::EMF_BACK_FACE_CULLING, false);
 	m_material.setFlag(video::EMF_BILINEAR_FILTER, false);
 	m_material.setFlag(video::EMF_FOG_ENABLE, true);
+	m_material.setFlag(video::EMF_ZWRITE_ENABLE, true);
 	m_material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 	m_material.setTexture(0, texture);
 	m_texpos = texpos;
@@ -170,6 +171,10 @@ void Particle::step(float dtime)
 
 	// Update model
 	updateVertices();
+
+	// Update position
+	v3s16 camera_offset = m_env->getCameraOffset();
+	setPosition(m_pos*BS - intToFloat(camera_offset, BS));
 }
 
 void Particle::updateLight()
@@ -227,7 +232,7 @@ void Particle::updateVertices()
 	m_vertices[3] = video::S3DVertex(-m_size / 2, m_size / 2,
 		0, 0, 0, 0, m_color, tx0, ty0);
 
-	v3s16 camera_offset = m_env->getCameraOffset();
+	m_box.reset(v3f());
 	for (video::S3DVertex &vertex : m_vertices) {
 		if (m_vertical) {
 			v3f ppos = m_player->getPosition()/BS;
@@ -238,7 +243,6 @@ void Particle::updateVertices()
 			vertex.Pos.rotateXZBy(m_player->getYaw());
 		}
 		m_box.addInternalPoint(vertex.Pos);
-		vertex.Pos += m_pos*BS - intToFloat(camera_offset, BS);
 	}
 }
 


### PR DESCRIPTION
This fixes the transparency sort issue in #10383, and would conflict with the PR #10384, which also aims to solve the issue. This post compares this PR with the other one.

This PR changes particles to use `ISceneNode::setPosition` instead of baking the translation into its mesh. For the impatient, here is a summary of the approaches I compared:
- Z-writing, baked translation (Current Minetest) - Opaque particles are fine because of depth buffering, transparent particles dig holes into the particles behind them.
- No Z-writing, baked translation - Particles can be drawn incorrectly in the opposite way, with background particles drawn on top of foreground particles. This is most apparent with opaque particles.
- Z-writing, `setPosition` - Most errors fixed, particles close together may still have swapped order, causing output errors with transparency. Opaque particles are fine because of depth buffering. This approach doesn't break opaque particles, while improving the accuracy of transparent particles.
- No Z-writing, `setPosition` - Same errors as the previous, except now opaque particles are affected too. The errors for partially transparent particles are less apparent, because it at least does incorrect blending, instead of no blending. This approach makes transparent particles look the best, but breaks opaque particles a little bit.

I would like @nerzhul's input if possible on the original decision to bake the translation into the particle's mesh, in case it has performance implications or could cause rendering errors in some way. If anyone else has some knowledge on this, please let me know too.

# Comparisons
## Transparent particles
These are what are currently rendered badly. Here is a comparison of different approaches

Z-Write enabled, no `setPosition` (Current Minetest)
![original_transparent](https://user-images.githubusercontent.com/5734399/93127762-15d38d80-f694-11ea-86fe-a567484a2c58.png)

Z-Write disabled, no `setPosition`
![unzwrite_transparent](https://user-images.githubusercontent.com/5734399/93127759-15d38d80-f694-11ea-915f-43c352f4b0fa.png)

Z-Write enabled, `setPosition`
![sort_transparent](https://user-images.githubusercontent.com/5734399/93127755-153af700-f694-11ea-8b9a-3d9c24cd2d3a.png)

Z-Write disabled, `setPosition` (Current `HEAD` of this PR)
![both_transparent](https://user-images.githubusercontent.com/5734399/93127757-153af700-f694-11ea-933a-f1bd28d316dd.png)

## Opaque particles
Opaque particles are currently fine, as they are handled by depth buffering. We want to preserve their behavior.

Z-Write enabled, no `setPosition` (Current Minetest)
![original_opaque](https://user-images.githubusercontent.com/5734399/93127761-15d38d80-f694-11ea-8f3b-27e490aa7678.png)

Z-Write disabled, no `setPosition`
![unzwrite_opaque](https://user-images.githubusercontent.com/5734399/93127758-15d38d80-f694-11ea-9f0b-ef73ee7eb1d3.png)

Z-Write enabled, `setPosition`
![sort_opaque](https://user-images.githubusercontent.com/5734399/93127753-14a26080-f694-11ea-8669-10f4030ced34.png)

Z-Write disabled, `setPosition` (Current `HEAD` of this PR)
![both_opaque](https://user-images.githubusercontent.com/5734399/93127756-153af700-f694-11ea-99b0-ec99d82531a9.png)

Takeaways from these comparisons
- In the current `master`, unsorted draw orders can cause foreground particles to prevent background particles from drawing, even when the foreground particle is partially transparent, because of they write a depth value to the buffer that blocks the background particle's fragment. Fully-transparent pixels are ok, presumably they are discarded and no write happens.
- Just disabling depth buffer writes, as in #10384, breaks opaque particles. You can see that different particles are in the foreground when comparing the current output with the output with just disabling depth writes. It improves the look of transparent particles, but the output is still wrong, it is just harder to tell because the transparency blurs it.
- Using `ISceneNode::setPosition` instead of baking the position into the mesh seems to mostly fix the draw order. The screenshots with `setPosition` and depth buffer writing enabled shows that there are still some errors, though. It's not possible to tell from the screenshots, but the particles can be made to draw in the right order by changing the camera angle a little, meaning that these errors only happen for particles that are close together.
- Doing both makes transparency look nicer, but we know from the screenshot with z-writing that the output is still a little bit wrong.
- Without Z-writing, the node selection wireframe is often rendered on top of particles.

# To do

This PR is a Work in Progress.


- [ ] Find out if there are important reasons the code wasn't doing this before
- [ ] Fix draw order issue of selection box
- [ ] Try to figure out remaining sorting issues, or if not possible, settle on a solution that breaks existing working functionality the least.

# How to test

Use the attached mod (adapted from #10384). `test:particle_stick` spawns transparent particles, while `test:particle_stick2` spawns opaque ones.

[particles_test.zip](https://github.com/minetest/minetest/files/5220639/particles_test.zip)

<!-- Example code or instructions -->
