### PR TITLE
Fix chat/infotext overlap if many chat lines

### DIFF
--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -73,7 +73,7 @@ void GameUI::init()
 
 	// At the middle of the screen
 	// Object infos are shown in this
-	unsigned int chat_font_height = m_guitext_chat->getActiveFont()->getDimension(L"Ay").Height;
+	u32 chat_font_height = m_guitext_chat->getActiveFont()->getDimension(L"Ay").Height;
 	m_guitext_info = gui::StaticText::add(guienv, L"",
 		core::rect<s32>(0, 0, 400, g_fontengine->getTextHeight() * 5 + 5) +
 			v2s32(100, chat_font_height *

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -61,17 +61,6 @@ void GameUI::init()
 	m_guitext2 = gui::StaticText::add(guienv, L"", core::rect<s32>(0, 0, 0, 0), false,
 		false, guiroot);
 
-	// At the middle of the screen
-	// Object infos are shown in this
-	m_guitext_info = gui::StaticText::add(guienv, L"",
-		core::rect<s32>(0, 0, 400, g_fontengine->getTextHeight() * 5 + 5)
-			+ v2s32(100, 200), false, true, guiroot);
-
-	// Status text (displays info when showing and hiding GUI stuff, etc.)
-	m_guitext_status = gui::StaticText::add(guienv, L"<Status>",
-		core::rect<s32>(0, 0, 0, 0), false, false, guiroot);
-	m_guitext_status->setVisible(false);
-
 	// Chat text
 	m_guitext_chat = gui::StaticText::add(guienv, L"", core::rect<s32>(0, 0, 0, 0),
 		//false, false); // Disable word wrap as of now
@@ -81,6 +70,20 @@ void GameUI::init()
 		m_guitext_chat->setOverrideFont(g_fontengine->getFont(
 			chat_font_size, FM_Unspecified));
 	}
+
+	// At the middle of the screen
+	// Object infos are shown in this
+	unsigned int chat_font_height = m_guitext_chat->getActiveFont()->getDimension(L"Ay").Height;
+	m_guitext_info = gui::StaticText::add(guienv, L"",
+		core::rect<s32>(0, 0, 400, g_fontengine->getTextHeight() * 5 + 5) +
+			v2s32(100, chat_font_height *
+			(g_settings->getU16("recent_chat_messages") + 3)),
+			false, true, guiroot);
+
+	// Status text (displays info when showing and hiding GUI stuff, etc.)
+	m_guitext_status = gui::StaticText::add(guienv, L"<Status>",
+		core::rect<s32>(0, 0, 0, 0), false, false, guiroot);
+	m_guitext_status->setVisible(false);
 
 	// Profiler text (size is updated when text is updated)
 	m_guitext_profiler = gui::StaticText::add(guienv, L"<Profiler>",


### PR DESCRIPTION
Fixes #10364.

Previously, the infotext was placed at a static position exactly 200 pixels from the window top. This is OK under default settings, but breaks when `recent_chat_messages` is 8 or higher.

This PR moves the infotext depending on the value of the `recent_chat_messages` value + 2 additional lines to account for the 2 debug mode lines + 1 additional line as "buffer" for better readability if chat is full.
The higher `recent_chat_messages` is, the lower the infotext will go.

With testing, I have determined the following Y offsets (from the top):

`recent_chat_messages=6` (default): 203 (almost the same as the current offset)
`recent_chat_messages=20` (maximum): 483

So Y position 483 seems reasonable to me in the "worst case". Most modern screens should be good enough. And even if not, the user can always opt to reduce the `recent_chat_messages`.

I also tried with the maximum value with a font size of 24 and the infotext was still visible (screen height = 1080).

## Caveats
Since the infotext offset depends on a setting now, it is theoretically possible that the infotext might land outside the screen for small screens and extreme settings. I'd say if the user wants to screw with GUI options, they sometimes have to expect breakage, but they can always “unbreak” things be reverting to the default.
This caveat is pretty much theoretical anyway, because only small windows would be affected.

## To do

This PR is ready.

## How to test

* Use the settings menu to try out different `recent_chat_messages` values
* Start `devtest` and place a Chest of Everything and point at it
* Check if the infotext is visible and readable
* Fill the chat with text (to hit the `recent_chat_messages` limit
* Check if the infotext is STILL readable