### PR TITLE
Record player existence in dymmy database.

### DIFF
--- a/src/database/database-dummy.cpp
+++ b/src/database/database-dummy.cpp
@@ -22,6 +22,7 @@ Dummy database class
 */
 
 #include "database-dummy.h"
+#include "remoteplayer.h"
 
 
 bool Database_Dummy::saveBlock(const v3s16 &pos, const std::string &data)
@@ -57,3 +58,25 @@ void Database_Dummy::listAllLoadableBlocks(std::vector<v3s16> &dst)
 	}
 }
 
+void Database_Dummy::savePlayer(RemotePlayer *player)
+{
+	m_player_database.insert(player->getName());
+}
+
+bool Database_Dummy::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
+{
+	return m_player_database.find(player->getName()) != m_player_database.end();
+}
+
+bool Database_Dummy::removePlayer(const std::string &name)
+{
+	m_player_database.erase(name);
+	return true;
+}
+
+void Database_Dummy::listPlayers(std::vector<std::string> &res)
+{
+	for (const auto &player : m_player_database) {
+		res.emplace_back(player);
+	}
+}

--- a/src/database/database-dummy.h
+++ b/src/database/database-dummy.h
@@ -32,14 +32,15 @@ public:
 	bool deleteBlock(const v3s16 &pos);
 	void listAllLoadableBlocks(std::vector<v3s16> &dst);
 
-	void savePlayer(RemotePlayer *player) {}
-	bool loadPlayer(RemotePlayer *player, PlayerSAO *sao) { return true; }
-	bool removePlayer(const std::string &name) { return true; }
-	void listPlayers(std::vector<std::string> &res) {}
+	void savePlayer(RemotePlayer *player);
+	bool loadPlayer(RemotePlayer *player, PlayerSAO *sao);
+	bool removePlayer(const std::string &name);
+	void listPlayers(std::vector<std::string> &res);
 
 	void beginSave() {}
 	void endSave() {}
 
 private:
 	std::map<s64, std::string> m_database;
+	std::set<std::string> m_player_database;
 };


### PR DESCRIPTION
This is a simple improvement for the dummy database as player backend.

I noticed that when using the dummy player backend the player is initially always placed at 0, 0, 0.

That is due to the logic in ServerEnvironment::loadPlayer. That dummy player backend used to always return true for loadPlayer, and so the ServerEnvironment would not attempt to find a good spawn point.

This is the minimal change to fix that, it still does not save any player data, just records whether a player exists or not.
