### PR TITLE
enable luajit on the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /usr/src/minetest
 RUN apk add --no-cache git build-base irrlicht-dev cmake bzip2-dev libpng-dev \
 		jpeg-dev libxxf86vm-dev mesa-dev sqlite-dev libogg-dev \
 		libvorbis-dev openal-soft-dev curl-dev freetype-dev zlib-dev \
-		gmp-dev jsoncpp-dev postgresql-dev ca-certificates && \
+		gmp-dev jsoncpp-dev postgresql-dev luajit-dev ca-certificates && \
 	git clone --depth=1 -b ${MINETEST_GAME_VERSION} https://github.com/minetest/minetest_game.git ./games/minetest_game && \
 	rm -fr ./games/minetest_game/.git
 
@@ -51,7 +51,7 @@ RUN mkdir build && \
 
 FROM alpine:3.11
 
-RUN apk add --no-cache sqlite-libs curl gmp libstdc++ libgcc libpq && \
+RUN apk add --no-cache sqlite-libs curl gmp libstdc++ libgcc libpq luajit && \
 	adduser -D minetest --uid 30000 -h /var/lib/minetest && \
 	chown -R minetest:minetest /var/lib/minetest
 


### PR DESCRIPTION
## Overview

This PR adds `luajit` to the "stock" minetest docker image.

It will allow faster lua execution through the `luajit` library.

There are 2 stages in the `Dockerfile`: build and package.
In the build stage the `luajit-dev` package is pulled in with all the libraries and headers.
In the package stage only the `luajit` package with the previously linked libraries is included.
The size-increase is around 800 kb.

## Stats

In my tests i had a 20x to 30x decrease in processing time for lua mapgens with jit enabled.

## State

This PR is Ready for Review.

## How to test

```bash
# buid the image locally
docker build . -t minetest-jit

# start the server part with the new image
docker run --rm -it --network host minetest-jit

# connect with a client to 127.0.0.1:30000
# everything should work as before (or faster)
```