### PR TITLE
Fix connection bug of hardware-colored framed glass

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -723,7 +723,8 @@ void MapblockMeshGenerator::drawGlasslikeFramedNode()
 	for (auto &glass_tile : glass_tiles)
 		glass_tile = tiles[4];
 
-	u8 param2 = n.getParam2();
+	// Only respect H/V merge bits when paramtype2 = "glasslikeliquidlevel" (liquid tank)
+	u8 param2 = (f->param_type_2 == CPT2_GLASSLIKE_LIQUID_LEVEL) ? n.getParam2() : 0;
 	bool H_merge = !(param2 & 128);
 	bool V_merge = !(param2 & 64);
 	param2 &= 63;


### PR DESCRIPTION
Closes #9542 
See that issue for detailed discussion.

Simple fix, alteration or removal of the settable merge feature should probably be done later, but that will require some consideration so leaving that to later to not delay this bugfix.

I am not motivated to test hardware colouring for various reasons. So, i ask others to please test that the bug is fixed. Hardware coloured framed glass should merge horizontally and vertically.
@BuckarooBanzay

The settable horizontal/vertical merge feature is now only enabled when paramtype2 = "glasslikeliquidlevel" (liquid tank). This avoids other uses of param2, such as hardware colouring, affecting H/V merging.
With other uses of param2, framed glass is now hardcoded to merge horizontally and vertically.

The settable merge feature has never been documented, documentation is intentionally not added in this PR as the feature will probably be altered or removed in a folllow-up PR.

EDIT:
I tested framed glass liquid tanks, and framed glass without paramtype2 = "glasslikeliquidlevel".

![screenshot_20200923_210144](https://user-images.githubusercontent.com/3686677/94064524-b7b85000-fde1-11ea-9e3a-8f433584b8b5.png)