### PR TITLE
Replace MyEventReceiver KeyList with std::unordered_set

### DIFF
--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -112,7 +112,7 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 	// Remember whether each key is down or up
 	if (event.EventType == irr::EET_KEY_INPUT_EVENT) {
 		const KeyPress &keyCode = event.KeyInput;
-		if (keysListenedFor[keyCode]) {
+		if (keysListenedFor.count(keyCode)) {
 				// If the key is being held down then the OS may
 				// send a continuous stream of keydown events.
 				// In this case, we don't want to let this
@@ -120,15 +120,15 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 				// certain actions to repeat constantly.
 			if (event.KeyInput.PressedDown) {
 				if (!IsKeyDown(keyCode)) {
-					keyWasDown.set(keyCode);
-					keyWasPressed.set(keyCode);
+					keyWasDown.insert(keyCode);
+					keyWasPressed.insert(keyCode);
 				}
-				keyIsDown.set(keyCode);
+				keyIsDown.insert(keyCode);
 			} else {
 				if (IsKeyDown(keyCode))
-					keyWasReleased.set(keyCode);
+					keyWasReleased.insert(keyCode);
 
-				keyIsDown.unset(keyCode);
+				keyIsDown.erase(keyCode);
 			}
 
 			return true;
@@ -153,36 +153,36 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 		switch (event.MouseInput.Event) {
 		case EMIE_LMOUSE_PRESSED_DOWN:
 			key = "KEY_LBUTTON";
-			keyIsDown.set(key);
-			keyWasDown.set(key);
-			keyWasPressed.set(key);
+			keyIsDown.insert(key);
+			keyWasDown.insert(key);
+			keyWasPressed.insert(key);
 			break;
 		case EMIE_MMOUSE_PRESSED_DOWN:
 			key = "KEY_MBUTTON";
-			keyIsDown.set(key);
-			keyWasDown.set(key);
-			keyWasPressed.set(key);
+			keyIsDown.insert(key);
+			keyWasDown.insert(key);
+			keyWasPressed.insert(key);
 			break;
 		case EMIE_RMOUSE_PRESSED_DOWN:
 			key = "KEY_RBUTTON";
-			keyIsDown.set(key);
-			keyWasDown.set(key);
-			keyWasPressed.set(key);
+			keyIsDown.insert(key);
+			keyWasDown.insert(key);
+			keyWasPressed.insert(key);
 			break;
 		case EMIE_LMOUSE_LEFT_UP:
 			key = "KEY_LBUTTON";
-			keyIsDown.unset(key);
-			keyWasReleased.set(key);
+			keyIsDown.erase(key);
+			keyWasReleased.insert(key);
 			break;
 		case EMIE_MMOUSE_LEFT_UP:
 			key = "KEY_MBUTTON";
-			keyIsDown.unset(key);
-			keyWasReleased.set(key);
+			keyIsDown.erase(key);
+			keyWasReleased.insert(key);
 			break;
 		case EMIE_RMOUSE_LEFT_UP:
 			key = "KEY_RBUTTON";
-			keyIsDown.unset(key);
-			keyWasReleased.set(key);
+			keyIsDown.erase(key);
+			keyWasReleased.insert(key);
 			break;
 		case EMIE_MOUSE_WHEEL:
 			mouse_wheel += event.MouseInput.Wheel;
@@ -235,7 +235,11 @@ void RandomInputHandler::step(float dtime)
 		i.counter -= dtime;
 		if (i.counter < 0.0) {
 			i.counter = 0.1 * Rand(1, i.time_max);
-			keydown.toggle(getKeySetting(i.key.c_str()));
+			KeyPress k = getKeySetting(i.key.c_str());
+			if (keydown.count(k))
+				keydown.erase(k);
+			else
+				keydown.insert(k);
 		}
 	}
 	{

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -44,6 +44,8 @@ public:
 	const char *sym() const;
 	const char *name() const;
 
+	irr::EKEY_CODE keycode() const { return Key; }
+
 protected:
 	static bool valid_kcode(irr::EKEY_CODE k)
 	{
@@ -54,6 +56,17 @@ protected:
 	wchar_t Char = L'\0';
 	std::string m_name = "";
 };
+
+namespace std
+{
+    template <> struct hash<KeyPress>
+    {
+		size_t operator()(const KeyPress &key) const
+		{
+			return key.keycode();
+		}
+    };
+}
 
 extern const KeyPress EscapeKey;
 extern const KeyPress CancelKey;

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -24,12 +24,20 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IEventReceiver.h>
 #include <string>
 
+class KeyPress;
+namespace std
+{
+	template <> struct hash<KeyPress>;
+}
+
 /* A key press, consisting of either an Irrlicht keycode
    or an actual char */
 
 class KeyPress
 {
 public:
+	friend struct std::hash<KeyPress>;
+
 	KeyPress() = default;
 
 	KeyPress(const char *name);
@@ -43,8 +51,6 @@ public:
 
 	const char *sym() const;
 	const char *name() const;
-
-	irr::EKEY_CODE keycode() const { return Key; }
 
 protected:
 	static bool valid_kcode(irr::EKEY_CODE k)
@@ -63,7 +69,7 @@ namespace std
     {
 		size_t operator()(const KeyPress &key) const
 		{
-			return key.keycode();
+			return key.Key;
 		}
     };
 }

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -65,13 +65,13 @@ protected:
 
 namespace std
 {
-    template <> struct hash<KeyPress>
-    {
+	template <> struct hash<KeyPress>
+	{
 		size_t operator()(const KeyPress &key) const
 		{
 			return key.Key;
 		}
-    };
+	};
 }
 
 extern const KeyPress EscapeKey;


### PR DESCRIPTION
Currently, `MyEventReceiver` stores all keys (currently pressed, just released, listening for, etc.) in a wrapped `std::list` called `KeyList`, so whenever it checks for a key, it has to linearly search for the key.  Similarly, insertion and deletion are also linear because only one of each keycode must be stored, so the list has to be searched to see if the key exists.  `std::unordered_set` is perfect for this job because it has a constant search time at best, linear at absolute worst, and verifies that values are unique.

I would expect this to yield a very slight performance increase (although I haven't tested), but it shouldn't cause a decrease.  In any case, the code is simpler without `KeyList`.

## To do

This PR is Ready for Review.

## How to test

Make sure using keys isn't broken.