### PR TITLE
Handle world mods and world game mods in the config dialog.

### DIFF
--- a/builtin/common/filterlist.lua
+++ b/builtin/common/filterlist.lua
@@ -286,12 +286,19 @@ end
 function sort_mod_list(self)
 
 	table.sort(self.m_processed_list, function(a, b)
-		-- Show game mods at bottom
+		-- Show game and world mods at bottom
 		if a.type ~= b.type or a.loc ~= b.loc then
-			if b.type == "game" then
+			if b.loc == "game" then
+				return true
+			elseif b.type == "game" then
 				return a.loc ~= "game"
+			elseif b.loc == "world" then
+				return a.loc ~= "game" and a.type ~= "game"
+			elseif b.type == "world" then
+				return a.loc ~= "game" and a.type ~= "game" and a.loc ~= "world"
+			else
+				return false
 			end
-			return b.loc == "game"
 		end
 		-- If in same or no modpack, sort by name
 		if a.modpack == b.modpack then

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -73,9 +73,17 @@ local function get_formspec(data)
 		"label[0.5,0;" .. fgettext("World:") .. "]" ..
 		"label[1.75,0;" .. data.worldspec.name .. "]"
 
-	if mod.is_modpack or mod.type == "game" then
-		local info = minetest.formspec_escape(
-			core.get_content_info(mod.path).description)
+	if mod.is_modpack or mod.type == "game" or mod.type == "world" then
+		local info
+		if mod.path then
+			info = minetest.formspec_escape(
+				core.get_content_info(mod.path).description)
+		elseif mod.type == "game" then
+		       info = fgettext("In world game mods.")
+		elseif mod.type == "world" then
+		       info = fgettext("In world mods.")
+		end
+
 		if info == "" then
 			if mod.is_modpack then
 				info = fgettext("No modpack description provided.")


### PR DESCRIPTION
See #10422

Minetest offers various per world options to locate mods:
1. `world/<worldid>/game/mods`
2. `world/<worldid>/worldmods`

In the both cases these mods are always selected, and in the first case no other mods can be selected.

With this change both cases are handled. For (1) all mods are displayed as game-content, and no other mods are shown. For (2) the mods are shown inline with all other mods installed and also displayed as game-content (i.e. those mods cannot be disabled)

This is a bugfix handling existing MT features correctly in the UI.