### PR TITLE
use decrement(value) method to decrease average lag metric

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -653,7 +653,12 @@ void Server::AsyncRunStep(bool initial_step)
 	}
 	m_clients.step(dtime);
 
-	m_lag_gauge->increment((m_lag_gauge->get() > dtime ? -1 : 1) * dtime/100);
+	// increase/decrease lag gauge gradually
+	if (m_lag_gauge->get() > dtime) {
+		m_lag_gauge->decrement(dtime/100);
+	} else {
+		m_lag_gauge->increment(dtime/100);
+	}
 #if USE_CURL
 	// send masterserver announce
 	{


### PR DESCRIPTION
This PR fixes #10420

It uses the `decrement()` method to decrease the lag value

This PR is Ready for Review.

## How to test

Compile minetest with `prometheus` support
```bash
# compile and install metric server dependency
git clone --depth 1 https://github.com/jupp0r/prometheus-cpp.git -b v0.9.0 && \
  cd prometheus-cpp && \
  git submodule init && \
  git submodule update && \
  cmake . && make -j4 && make install

# minetest directory
cmake . -DENABLE_PROMETHEUS=TRUE && make -j4
```

Add the Test-~~lagatory~~mod:
```lua
-- lag simulation
local lag = 0
minetest.register_chatcommand("lag", {
  description = "simulate server lag",
  params = "<seconds>",
  func = function(_, param)
    lag = tonumber(param or "0") or 0
    return true, "lag = " .. lag .. " s"
  end
})

minetest.register_globalstep(function()
  if lag < 0.01 then
    -- ignore value
    return
  end

  local start = minetest.get_us_time()
  local stop = start + (lag * 1000 * 1000)

  while minetest.get_us_time() < stop do
    -- no-op
  end
end)
```

Start a default minetest game and observe the `minetest_core_latency` value on the metrics website: http://127.0.0.1:30000/metrics

Increase the lag with `/lag 0.5` or decrease again with `/lag 0`

The `minetest_core_latency` metric should rise and fall gradually