### PR TITLE
add integration test skeleton

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,37 @@
+name: build
+
+# build on c/cpp changes or workflow changes
+on:
+  push:
+    paths:
+      - 'lib/**.[ch]'
+      - 'lib/**.cpp'
+      - 'src/**.[ch]'
+      - 'src/**.cpp'
+      - '**/CMakeLists.txt'
+      - 'cmake/Modules/**'
+      - 'util/buildbot/**'
+      - 'util/ci/**'
+      - '.github/workflows/**.yml'
+  pull_request:
+    paths:
+      - 'lib/**.[ch]'
+      - 'lib/**.cpp'
+      - 'src/**.[ch]'
+      - 'src/**.cpp'
+      - '**/CMakeLists.txt'
+      - 'cmake/Modules/**'
+      - 'util/buildbot/**'
+      - 'util/ci/**'
+      - '.github/workflows/**.yml'
+
+jobs:
+  integration-test:
+    name: "Docker integration test"
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and test docker image
+        run: |
+          docker build . -t minetest
+          ./util/integration-test.sh

--- a/games/devtest/mods/integration_test/init.lua
+++ b/games/devtest/mods/integration_test/init.lua
@@ -1,0 +1,32 @@
+
+if not minetest.settings:get_bool("enable_integration_test") then
+  return
+end
+
+minetest.log("warning", "[TEST] integration-test enabled!")
+
+local pos1 = { x=0, y=-50, z=0 }
+local pos2 = { x=30, y=50, z=30 }
+
+minetest.register_on_mods_loaded(function()
+	minetest.log("warning", "[TEST] starting tests")
+	minetest.after(0, function()
+		minetest.log("warning", "[TEST] emerging area")
+		minetest.emerge_area(pos1, pos2, function(blockpos, _, calls_remaining)
+			minetest.log("action", "Emerged: " .. minetest.pos_to_string(blockpos))
+			if calls_remaining > 0 then
+				return
+			end
+
+			local file = io.open(minetest.get_worldpath().."/test_passed", "w" );
+			if file then
+				file:write("ok")
+				file:close()
+			end
+
+			minetest.log("warning", "[TEST] integration tests done!")
+			minetest.request_shutdown("success")
+
+		end)
+	end)
+end)

--- a/games/devtest/mods/integration_test/mod.conf
+++ b/games/devtest/mods/integration_test/mod.conf
@@ -1,0 +1,3 @@
+name = integration_test
+description = Adds automated integration tests for the engine
+depends = unittests

--- a/util/integration-test.sh
+++ b/util/integration-test.sh
@@ -3,7 +3,7 @@
 CFG=/tmp/minetest.conf
 MINETEST_VOLUME=minetest
 
-docker run --rm -it -v ${MINETEST_VOLUME}:/minetest alpine /bin/sh -c "chown -R 30000.30000 /minetest"
+docker run --rm -i -v ${MINETEST_VOLUME}:/minetest alpine /bin/sh -c "chown -R 30000.30000 /minetest"
 
 # settings
 cat <<EOF > ${CFG}
@@ -17,4 +17,4 @@ docker run --rm -i \
 	-v ${MINETEST_VOLUME}:/var/lib/minetest/.minetest \
 	minetest
 
-docker run --rm -it -v ${MINETEST_VOLUME}:/minetest alpine /bin/sh -c "test -f /minetest/worlds/world/test_passed" && exit 0 || exit 1
+docker run --rm -i -v ${MINETEST_VOLUME}:/minetest alpine /bin/sh -c "test -f /minetest/worlds/world/test_passed" && exit 0 || exit 1

--- a/util/integration-test.sh
+++ b/util/integration-test.sh
@@ -7,6 +7,7 @@ docker run --rm -i -v ${MINETEST_VOLUME}:/minetest alpine /bin/sh -c "chown -R 3
 
 # settings
 cat <<EOF > ${CFG}
+ devtest_unittests_autostart = true
  enable_integration_test = true
  default_game = devtest
 EOF

--- a/util/integration-test.sh
+++ b/util/integration-test.sh
@@ -1,21 +1,25 @@
 #!/bin/sh
 
+# configuration file location and volume name
 CFG=/tmp/minetest.conf
 MINETEST_VOLUME=minetest
 
+# set proper permissions in the volume
 docker run --rm -i -v ${MINETEST_VOLUME}:/minetest alpine /bin/sh -c "chown -R 30000.30000 /minetest"
 
-# settings
+# generate minetest.conf
 cat <<EOF > ${CFG}
  devtest_unittests_autostart = true
  enable_integration_test = true
  default_game = devtest
 EOF
 
+# start the container
 docker run --rm -i \
 	-v ${CFG}:/etc/minetest/minetest.conf \
 	-v $(pwd)/games:/usr/local/share/minetest/games \
 	-v ${MINETEST_VOLUME}:/var/lib/minetest/.minetest \
 	minetest
 
+# check if the marker file for success exists
 docker run --rm -i -v ${MINETEST_VOLUME}:/minetest alpine /bin/sh -c "test -f /minetest/worlds/world/test_passed" && exit 0 || exit 1

--- a/util/integration-test.sh
+++ b/util/integration-test.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+CFG=/tmp/minetest.conf
+MINETEST_VOLUME=minetest
+
+docker run --rm -it -v ${MINETEST_VOLUME}:/minetest alpine /bin/sh -c "chown -R 30000.30000 /minetest"
+
+# settings
+cat <<EOF > ${CFG}
+ enable_integration_test = true
+ default_game = devtest
+EOF
+
+docker run --rm -i \
+	-v ${CFG}:/etc/minetest/minetest.conf \
+  -v $(pwd)/games:/usr/local/share/minetest/games \
+	-v ${MINETEST_VOLUME}:/var/lib/minetest/.minetest \
+	minetest
+
+docker run --rm -it -v ${MINETEST_VOLUME}:/minetest alpine /bin/sh -c "test -f /minetest/worlds/world/test_passed" && exit 0 || exit 1

--- a/util/integration-test.sh
+++ b/util/integration-test.sh
@@ -14,7 +14,7 @@ EOF
 
 docker run --rm -i \
 	-v ${CFG}:/etc/minetest/minetest.conf \
-  -v $(pwd)/games:/usr/local/share/minetest/games \
+	-v $(pwd)/games:/usr/local/share/minetest/games \
 	-v ${MINETEST_VOLUME}:/var/lib/minetest/.minetest \
 	minetest
 


### PR DESCRIPTION
Work-in-progress / Draft

This PR adds a skeleton to execute integration tests on pull-requests.
The current workflow:
* build the docker image
* spin up a container with the `devtest` mod and settings to enable testing `enable_integration_test = true`
* the `integration_test` mod will emerge some blocks and create a marker file `test_passed` if everything goes well
* the `integration_test.sh` script tests for this file upon container exit

The goal is to have more test coverage with internal non-unittestable functions, for example mapgen, node-interactions, etc

## To do

This PR is a Work in Progress

- [x] fix build script (file-permission issues)
- [ ] prevent building the image twice (not critical but will conserve some cpu cycles :evergreen_tree:)
- [x] properly document shell script
- [ ] remove dummy test-case and add an actually useful test
- [ ] general feedback from devs

## How to test

* Observe the CI output
Or:
* Execute the `./util/integration-test.sh` script directly (needs a working docker setup)

## Related

I'm doing frequent integration-tests with my mods and servers, you can see quickly if something is wrong or fails completely:
* Server-mods: https://github.com/pandorabox-io/pandorabox-mods/pull/1043
* Mods: https://github.com/mt-mods/jumpdrive/blob/master/integration_test.lua

## Future work

Maybe someday (:tm:) we have a bot-framework that can join the integration-test environment and do some player related stuff