### PR TITLE
Fix long infotext letter cutoff, add ellipsis

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2030,7 +2030,9 @@ Node metadata contains two things:
 Some of the values in the key-value store are handled specially:
 
 * `formspec`: Defines a right-click inventory menu. See [Formspec].
-* `infotext`: Text shown on the screen when the node is pointed at
+* `infotext`: Text shown on the screen when the node is pointed at.
+              Line-breaks will be applied automatically.
+              If the infotext is very long, it will be truncated.
 
 Example:
 
@@ -7092,7 +7094,7 @@ Player properties need to be saved manually.
         -- Default: false
 
         infotext = "",
-        -- By default empty, text to be shown when pointed at object
+        -- Same as infotext for nodes. Empty by default
 
         static_save = true,
         -- If false, never save this object statically. It will simply be

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -71,14 +71,27 @@ void GameUI::init()
 			chat_font_size, FM_Unspecified));
 	}
 
-	// At the middle of the screen
-	// Object infos are shown in this
+	// Infotext of nodes and objects.
+	// If in debug mode, object debug infos shown here, too.
+	// Located on the left on the screen, below chat.
 	u32 chat_font_height = m_guitext_chat->getActiveFont()->getDimension(L"Ay").Height;
+	u16 info_offset = chat_font_height *
+		(g_settings->getU16("recent_chat_messages") + 3);
+
 	m_guitext_info = gui::StaticText::add(guienv, L"",
-		core::rect<s32>(0, 0, 400, g_fontengine->getTextHeight() * 5 + 5) +
-			v2s32(100, chat_font_height *
-			(g_settings->getU16("recent_chat_messages") + 3)),
+		core::rect<s32>(0, 0, 400, g_fontengine->getTextHeight() * INFOTEXT_LINES)
+			+ v2s32(100, info_offset),
 			false, true, guiroot);
+
+	// Add ellipsis at end if text above was too long
+	m_guitext_info_excess = gui::StaticText::add(guienv, L"",
+		core::rect<s32>(0, 0, 400, g_fontengine->getTextHeight())
+			+ v2s32(100, info_offset +
+			(g_fontengine->getTextHeight() * INFOTEXT_LINES)),
+			false, true, guiroot);
+	/*~ This is an ellipsis which is written when the text in the infotext GUI
+	element is too long */
+	setStaticText(m_guitext_info_excess, wgettext("(...)"));
 
 	// Status text (displays info when showing and hiding GUI stuff, etc.)
 	m_guitext_status = gui::StaticText::add(guienv, L"<Status>",
@@ -165,7 +178,14 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 	m_guitext2->setVisible(m_flags.show_basic_debug);
 
 	setStaticText(m_guitext_info, m_infotext.c_str());
-	m_guitext_info->setVisible(m_flags.show_hud && g_menumgr.menuCount() == 0);
+	bool info_visible = m_flags.show_hud && g_menumgr.menuCount() == 0;
+	m_guitext_info->setVisible(info_visible);
+	// Enable infotext ellipsis if infotext is too long to fit in box
+	if ((m_guitext_info->getTextHeight()) > g_fontengine->getTextHeight() * INFOTEXT_LINES) {
+		m_guitext_info_excess->setVisible(info_visible);
+	} else {
+		m_guitext_info_excess->setVisible(false);
+	}
 
 	static const float statustext_time_max = 1.5f;
 

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -113,6 +113,7 @@ private:
 	gui::IGUIStaticText *m_guitext2 = nullptr; // Second line of debug text
 
 	gui::IGUIStaticText *m_guitext_info = nullptr; // At the middle of the screen
+	gui::IGUIStaticText *m_guitext_info_excess = nullptr; // Ellipsis if infotext is too long
 	std::wstring m_infotext;
 
 	gui::IGUIStaticText *m_guitext_status = nullptr;

--- a/src/constants.h
+++ b/src/constants.h
@@ -112,3 +112,4 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define TTF_DEFAULT_FONT_SIZE (16)
 #define DEFAULT_FONT_SIZE (10)
+#define INFOTEXT_LINES (6)


### PR DESCRIPTION
Fixes #10285.

The infotext GUI has been reworked a bit. It now supports up to 6 lines, all of which render properly now.
If the infotext is still too long, an ellipsis is added at the end (“(...)”) to indicate that some text is missing.

Documentation now mentions that long infotexts might not show in full.

## To do

This PR is ready.

## How to test

* Add an infotext to a node with exactly 6 short lines (should be visible in full)
* Add an infotext to a node with exactly 7 short lines (only lines 1-6 should be visible, the 7th line is an ellipsis)
* Add a very long infotext to a node
* Test with different settings and combinations thereof: `font_size`, `recent_chat_messages`, `chat_font_size` and verify the infotexts always render correctly

### How to set the infotext?

Use the Node Meta Editor in DevTest on any node and set `infotext` variable to anything you like.
