### PR TITLE
Remove null bytes from TOCLIENT_BLOCKDATA

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2338,7 +2338,7 @@ void Server::SendBlockNoLock(session_t peer_id, MapBlock *block, u8 ver,
 	block->serializeNetworkSpecific(os);
 	std::string s = os.str();
 
-	NetworkPacket pkt(TOCLIENT_BLOCKDATA, 2 + 2 + 2 + 2 + s.size(), peer_id);
+	NetworkPacket pkt(TOCLIENT_BLOCKDATA, 2 + 2 + 2 + s.size(), peer_id);
 
 	pkt << block->getPos();
 	pkt.putRawString(s.c_str(), s.size());


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR

Stop sending two null bytes after every TOCLIENT_BLOCKDATA

- How does the PR work?

By decreasing the size of the packet by 2 bytes.

- Does it resolve any reported issue?

#10403

- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is Ready for Review.

- [ ] Testing

## How to test

Ensure Minetest works correctly and possibly inspect the packet with Wireshark.