### PR TITLE
Decouple entity minimap markers from nametags 

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6885,6 +6885,10 @@ Player properties need to be saved manually.
 
         shaded = true,
         -- Setting this to 'false' disables diffuse lighting of entity
+
+        show_on_minimap = false,
+        -- Defaults to true for players, false for other entities.
+        -- If set to true the entity will show as a marker on the minimap.
     }
 
 Entity definition

--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -169,8 +169,6 @@ public:
 
 	void removeNametag(Nametag *nametag);
 
-	const std::list<Nametag *> &getNametags() { return m_nametags; }
-
 	void drawNametags();
 
 	inline void addArmInertia(f32 player_yaw);

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -326,6 +326,8 @@ Client::~Client()
 	}
 
 	delete m_minimap;
+	m_minimap = nullptr;
+
 	delete m_media_downloader;
 }
 

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class Camera;
 class Client;
 struct Nametag;
+struct MinimapMarker;
 
 /*
 	SmoothTranslator
@@ -84,6 +85,7 @@ private:
 	scene::IBillboardSceneNode *m_spritenode = nullptr;
 	scene::IDummyTransformationSceneNode *m_matrixnode = nullptr;
 	Nametag *m_nametag = nullptr;
+	MinimapMarker *m_marker = nullptr;
 	v3f m_position = v3f(0.0f, 10.0f * BS, 0);
 	v3f m_velocity;
 	v3f m_acceleration;
@@ -253,6 +255,8 @@ public:
 	u16 getLightPosition(v3s16 *pos);
 
 	void updateNametag();
+
+	void updateMarker();
 
 	void updateNodePos();
 

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -48,6 +48,13 @@ struct MinimapModeDef {
 	u16 scale;
 };
 
+struct MinimapMarker {
+	MinimapMarker(scene::ISceneNode *parent_node):
+		parent_node(parent_node)
+	{
+	}
+	scene::ISceneNode *parent_node;
+};
 struct MinimapPixel {
 	//! The topmost node that the minimap displays.
 	MapNode n;
@@ -142,6 +149,9 @@ public:
 
 	scene::SMeshBuffer *getMinimapMeshBuffer();
 
+	MinimapMarker* addMarker(scene::ISceneNode *parent_node);
+	void removeMarker(MinimapMarker **marker);
+
 	void updateActiveMarkers();
 	void drawMinimap();
 	void drawMinimap(core::rect<s32> rect);
@@ -162,5 +172,6 @@ private:
 	u16 m_surface_mode_scan_height;
 	f32 m_angle;
 	std::mutex m_mutex;
+	std::list<MinimapMarker*> m_markers;
 	std::list<v2f> m_active_markers;
 };

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -70,6 +70,7 @@ std::string ObjectProperties::dump()
 	os << ", use_texture_alpha=" << use_texture_alpha;
 	os << ", damage_texture_modifier=" << damage_texture_modifier;
 	os << ", shaded=" << shaded;
+	os << ", show_on_minimap=" << show_on_minimap;
 	return os.str();
 }
 
@@ -118,6 +119,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeU8(os, use_texture_alpha);
 	os << serializeString16(damage_texture_modifier);
 	writeU8(os, shaded);
+	writeU8(os, show_on_minimap);
 
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
@@ -174,7 +176,11 @@ void ObjectProperties::deSerialize(std::istream &is)
 		damage_texture_modifier = deSerializeString16(is);
 		u8 tmp = readU8(is);
 		if (is.eof())
-			throw SerializationError("");
+			return;
 		shaded = tmp;
+		tmp = readU8(is);
+		if (is.eof())
+			return;
+		show_on_minimap = tmp;
 	} catch (SerializationError &e) {}
 }

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -62,6 +62,7 @@ struct ObjectProperties
 	float zoom_fov = 0.0f;
 	bool use_texture_alpha = false;
 	bool shaded = true;
+	bool show_on_minimap = false;
 
 	ObjectProperties();
 	std::string dump();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -328,6 +328,7 @@ void read_object_properties(lua_State *L, int index,
 	getfloatfield(L, -1, "zoom_fov", prop->zoom_fov);
 	getboolfield(L, -1, "use_texture_alpha", prop->use_texture_alpha);
 	getboolfield(L, -1, "shaded", prop->shaded);
+	getboolfield(L, -1, "show_on_minimap", prop->show_on_minimap);
 
 	getstringfield(L, -1, "damage_texture_modifier", prop->damage_texture_modifier);
 }
@@ -416,6 +417,8 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "shaded");
 	lua_pushlstring(L, prop->damage_texture_modifier.c_str(), prop->damage_texture_modifier.size());
 	lua_setfield(L, -2, "damage_texture_modifier");
+	lua_pushboolean(L, prop->show_on_minimap);
+	lua_setfield(L, -2, "show_on_minimap");
 }
 
 /******************************************************************************/

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -55,6 +55,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t p
 	m_prop.backface_culling = false;
 	m_prop.makes_footstep_sound = true;
 	m_prop.stepheight = PLAYER_DEFAULT_STEPHEIGHT * BS;
+	m_prop.show_on_minimap = true;
 	m_hp = m_prop.hp_max;
 	m_breath = m_prop.breath_max;
 	// Disable zoom in survival mode using a value of 0


### PR DESCRIPTION
implements https://github.com/minetest/minetest/issues/9512#issuecomment-692623306

closes #9512

## To do

This PR is Ready for Review.

## How to test

1. Verify that players show up on minimap as markers
2. Verify that entities with a nametag don't
3. To test the property define a tool with
```lua
	on_secondary_use = function(itemstack, user, pointed_thing)
		if pointed_thing.type == "object" then
			local e = pointed_thing.ref
			e:set_properties({
				show_on_minimap = not e:get_properties().show_on_minimap
			})
		end
		return itemstack
	end,
```
