### PR TITLE
Prevent games from setting secure settings

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -512,7 +512,7 @@ static bool read_config_file(const Settings &cmd_args)
 	sanity_check(g_settings_path == "");	// Sanity check
 
 	if (cmd_args.exists("config")) {
-		bool r = g_settings->readConfigFile(cmd_args.get("config").c_str());
+		bool r = g_settings->readConfigFile(cmd_args.get("config").c_str(), true);
 		if (!r) {
 			errorstream << "Could not read configuration from \""
 			            << cmd_args.get("config") << "\"" << std::endl;
@@ -534,7 +534,7 @@ static bool read_config_file(const Settings &cmd_args)
 #endif
 
 		for (const std::string &filename : filenames) {
-			bool r = g_settings->readConfigFile(filename.c_str());
+			bool r = g_settings->readConfigFile(filename.c_str(), true);
 			if (r) {
 				g_settings_path = filename;
 				break;

--- a/src/settings.h
+++ b/src/settings.h
@@ -104,13 +104,13 @@ public:
 	 ***********************/
 
 	// Read configuration file.  Returns success.
-	bool readConfigFile(const char *filename);
-	//Updates configuration file.  Returns success.
+	bool readConfigFile(const char *filename, bool allowSecureSettings = false);
+	// Updates configuration file.  Returns success.
 	bool updateConfigFile(const char *filename);
 	// NOTE: Types of allowed_options are ignored.  Returns success.
 	bool parseCommandLine(int argc, char *argv[],
 			std::map<std::string, ValueSpec> &allowed_options);
-	bool parseConfigLines(std::istream &is, const std::string &end = "");
+	bool parseConfigLines(std::istream &is, const std::string &end = "", bool allowSecureSettings = false);
 	void writeLines(std::ostream &os, u32 tab_depth=0) const;
 
 	SettingsParseEvent parseConfigObject(const std::string &line,


### PR DESCRIPTION
Previously, games could provide `secure.` settings to escape the sandbox. This is no longer possible

## To do

- [ ] Check whether the settings are updated any other way

## How to test

<!-- Example code or instructions -->
