### PR TITLE
Allow mods to override each other's textures

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2508,9 +2508,17 @@ void Server::fillMediaCache()
 				continue;
 
 			const std::string &filename = dln.name;
-			if (m_media.find(filename) != m_media.end()) // Do not override
-				continue;
+			if (m_media.find(filename) != m_media.end()) // Do not override parent texture
+			{
+				std::string parentpath = m_media.find(filename)->second.path;
 
+				// remove filename and / in front of it from path
+				parentpath = parentpath.substr(0, (parentpath.size()-filename.size())-1);
+
+				// Make sure parent is a parent and not a texture in another mod
+				if (mediapath.find(parentpath.substr(0, parentpath.find_last_of('/'))) == 0)
+					continue;
+			}
 			std::string filepath = mediapath;
 			filepath.append(DIR_DELIM).append(filename);
 			addMediaFile(filename, filepath);


### PR DESCRIPTION
https://github.com/minetest/minetest/pull/9065/ broke mods that override the textures of other mods by depending on the target mod so that the textures in the `textures` folder would override those in the target's folder

This is just a quick fix so it may not have been well though out.
I tested with [the broken mod](https://github.com/MT-CTF/seasonal_halloween/tree/master/texture_changes) and the devtest grass and it seemed to work.
#
If you see a problem you can fix it yourself if you want to save time, this is a simple PR
![image](https://user-images.githubusercontent.com/28972859/94763005-02941380-035e-11eb-88e0-5c6808f49965.png)
