### PR TITLE
-Wclass-memaccess only called when GCC > 7

### DIFF
--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -421,7 +421,9 @@ static void getNodeVertexDirs(const v3s16 &dir, v3s16 *vertex_dirs)
 
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
+#if __GNUC__ > 7
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
 #endif
 	memcpy(vertex_dirs, &vertex_dirs_table[idx], 4 * sizeof(v3s16));
 #if defined(__GNUC__) && !defined(__clang__)


### PR DESCRIPTION
-Wclass-memaccess was implemented in [GCC 8](https://gcc.gnu.org/gcc-8/changes.html). This avoids a warning if GCC version is 7 or lesser. First time touching `#if`s, I hope I did it correctly

## To do
This PR is Ready for Review.

## How to test

Compile it having GCC < 8 and it shouldn't throw a warning anymore