### PR TITLE
Implement get_item_defs() client-side call

### DIFF
--- a/clientmods/preview/init.lua
+++ b/clientmods/preview/init.lua
@@ -193,6 +193,15 @@ core.register_chatcommand("text", {
 	end,
 })
 
+core.register_chatcommand("count_items", {
+	func = function()
+		local count = 0
+		for _ in pairs(minetest.get_item_defs()) do
+			count = count + 1
+		end
+		return true, count .. " items are currently registered"
+	end
+})
 
 core.register_on_mods_loaded(function()
 	core.log("Yeah preview mod is loaded with other CSM mods.")

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1175,6 +1175,8 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
 	* Returns [node definition](#node-definition) table of `nodename`
 * `minetest.get_item_def(itemstring)`
 	* Returns item definition table of `itemstring`
+* `minetest.get_item_defs()`
+	* Returns table of item definitions indexed by `itemstring`
 
 #### Node Definition
 

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -357,6 +357,31 @@ int ModApiClient::l_get_item_def(lua_State *L)
 	return 1;
 }
 
+// get_item_defs()
+int ModApiClient::l_get_item_defs(lua_State *L)
+{
+	if (checkCSMRestrictionFlag(CSM_RF_READ_ITEMDEFS))
+		return 0;
+
+	IGameDef *gdef = getGameDef(L);
+	assert(gdef);
+
+	IItemDefManager *idef = gdef->idef();
+	assert(idef);
+
+	std::set<std::string> itemdefs;
+	idef->getAll(itemdefs);
+	lua_createtable(L, 0, itemdefs.size());
+	for (const std::string &item_name : itemdefs) {
+		const ItemDefinition &def = idef->get(item_name);
+		lua_pushstring(L, item_name.c_str());
+		push_item_definition_full(L, def);
+		lua_settable(L, -3);
+	}
+
+	return 1;
+}
+
 // get_node_def(nodename)
 int ModApiClient::l_get_node_def(lua_State *L)
 {
@@ -436,6 +461,7 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(sound_fade);
 	API_FCT(get_server_info);
 	API_FCT(get_item_def);
+	API_FCT(get_item_defs);
 	API_FCT(get_node_def);
 	API_FCT(get_privilege_list);
 	API_FCT(get_builtin_path);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -93,6 +93,9 @@ private:
 	// get_item_def(itemstring)
 	static int l_get_item_def(lua_State *L);
 
+	// get_item_defs(itemstring)
+	static int l_get_item_defs(lua_State *L);
+
 	// get_node_def(nodename)
 	static int l_get_node_def(lua_State *L);
 


### PR DESCRIPTION
Logical extension of `get_item_def`, another #10003 split-off.