### PR TITLE
Fix key input issues

### DIFF
--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -339,6 +339,7 @@ KeyPress::KeyPress(const irr::SEvent::SKeyInput &in)
 		try {
 			m_name = lookup_keykey(in.Key).Name;
 			Key = in.Key;
+			Char = L'\0';
 			return;
 		} catch (UnknownKeycode &e) {}
 	}

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -46,7 +46,10 @@ public:
 
 	bool operator==(const KeyPress &o) const
 	{
-		return (Char > 0 && Char == o.Char) || (valid_kcode(Key) && Key == o.Key);
+		if (valid_kcode(Key))
+			return Key == o.Key;
+
+		return Char == o.Char;
 	}
 
 	const char *sym() const;

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -42,7 +42,7 @@ public:
 
 	KeyPress(const char *name);
 
-	KeyPress(const irr::SEvent::SKeyInput &in, bool prefer_character = false);
+	KeyPress(const irr::SEvent::SKeyInput &in);
 
 	bool operator==(const KeyPress &o) const
 	{
@@ -69,7 +69,7 @@ namespace std
 	{
 		size_t operator()(const KeyPress &key) const
 		{
-			return key.Key;
+			return KeyPress::valid_kcode(key.Key) ? (size_t)key.Key << 24 : (size_t)key.Char;
 		}
 	};
 }

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -438,7 +438,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			return true;
 		}
 
-		switch (key_code) { 
+		switch (key_code) {
 		case KEY_ESCAPE:
 			closeConsoleAtOnce();
 			m_close_on_enter = false;
@@ -616,7 +616,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		if (key_char != L'\0') {
 			#if defined(__linux__) && (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9)
 				wchar_t wc = L'_';
-				mbtowc( &wc, (char *) &key_char, sizeof(key_char) );
+				mbtowc(&wc, (char *)&key_char, sizeof(key_char));
 				prompt.input(wc);
 			#else
 				prompt.input(key_char);

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -412,6 +412,22 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 
 	if(event.EventType == EET_KEY_INPUT_EVENT && event.KeyInput.PressedDown)
 	{
+		irr::EKEY_CODE key_code = irr::KEY_KEY_CODES_COUNT;
+		wchar_t key_char = L'\0';
+		if (event.KeyInput.Char == L'\0' || event.KeyInput.Control
+				|| iswcntrl(event.KeyInput.Char)) {
+			/*
+				Separate the control characters. This includes:
+				* L'\0'     Home, Page Down
+				* Control   Combinations (Ctrl + A, Ctrl + U)
+				* iswcntrl  ASCII-Controls (Backspace \0x08)
+			*/
+			key_code = event.KeyInput.Key;
+		} else {
+			// Normal text characters
+			key_char = event.KeyInput.Char;
+		}
+
 		// Key input
 		if (KeyPress(event.KeyInput) == getKeySetting("keymap_console")) {
 			closeConsole();
@@ -422,25 +438,20 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			return true;
 		}
 
-		if (event.KeyInput.Key == KEY_ESCAPE) {
+		switch (key_code) { 
+		case KEY_ESCAPE:
 			closeConsoleAtOnce();
 			m_close_on_enter = false;
 			// inhibit open so the_game doesn't reopen immediately
 			m_open_inhibited = 1; // so the ESCAPE button doesn't open the "pause menu"
 			return true;
-		}
-		else if(event.KeyInput.Key == KEY_PRIOR)
-		{
+		case KEY_PRIOR:
 			m_chat_backend->scrollPageUp();
 			return true;
-		}
-		else if(event.KeyInput.Key == KEY_NEXT)
-		{
+		case KEY_NEXT:
 			m_chat_backend->scrollPageDown();
 			return true;
-		}
-		else if(event.KeyInput.Key == KEY_RETURN)
-		{
+		case KEY_RETURN: {
 			prompt.addToHistory(prompt.getLine());
 			std::wstring text = prompt.replace(L"");
 			m_client->typeChatMessage(text);
@@ -450,22 +461,18 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			}
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_UP)
-		{
+		case KEY_UP:
 			// Up pressed
 			// Move back in history
 			prompt.historyPrev();
 			return true;
-		}
-		else if(event.KeyInput.Key == KEY_DOWN)
-		{
+		case KEY_DOWN:
 			// Down pressed
 			// Move forward in history
 			prompt.historyNext();
 			return true;
-		}
-		else if(event.KeyInput.Key == KEY_LEFT || event.KeyInput.Key == KEY_RIGHT)
-		{
+		case KEY_LEFT:
+		case KEY_RIGHT: {
 			// Left/right pressed
 			// Move/select character/word to the left depending on control and shift keys
 			ChatPrompt::CursorOp op = event.KeyInput.Shift ?
@@ -480,8 +487,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			prompt.cursorOperation(op, dir, scope);
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_HOME)
-		{
+		case KEY_HOME:
 			// Home pressed
 			// move to beginning of line
 			prompt.cursorOperation(
@@ -489,9 +495,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				ChatPrompt::CURSOROP_DIR_LEFT,
 				ChatPrompt::CURSOROP_SCOPE_LINE);
 			return true;
-		}
-		else if(event.KeyInput.Key == KEY_END)
-		{
+		case KEY_END:
 			// End pressed
 			// move to end of line
 			prompt.cursorOperation(
@@ -499,9 +503,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				ChatPrompt::CURSOROP_DIR_RIGHT,
 				ChatPrompt::CURSOROP_SCOPE_LINE);
 			return true;
-		}
-		else if(event.KeyInput.Key == KEY_BACK)
-		{
+		case KEY_BACK: {
 			// Backspace or Ctrl-Backspace pressed
 			// delete character / word to the left
 			ChatPrompt::CursorOpScope scope =
@@ -514,8 +516,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				scope);
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_DELETE)
-		{
+		case KEY_DELETE: {
 			// Delete or Ctrl-Delete pressed
 			// delete character / word to the right
 			ChatPrompt::CursorOpScope scope =
@@ -528,96 +529,97 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				scope);
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_KEY_A && event.KeyInput.Control)
-		{
-			// Ctrl-A pressed
-			// Select all text
-			prompt.cursorOperation(
-				ChatPrompt::CURSOROP_SELECT,
-				ChatPrompt::CURSOROP_DIR_LEFT, // Ignored
-				ChatPrompt::CURSOROP_SCOPE_LINE);
-			return true;
-		}
-		else if(event.KeyInput.Key == KEY_KEY_C && event.KeyInput.Control)
-		{
-			// Ctrl-C pressed
-			// Copy text to clipboard
-			if (prompt.getCursorLength() <= 0)
-				return true;
-			std::wstring wselected = prompt.getSelection();
-			std::string selected = wide_to_utf8(wselected);
-			Environment->getOSOperator()->copyToClipboard(selected.c_str());
-			return true;
-		}
-		else if(event.KeyInput.Key == KEY_KEY_V && event.KeyInput.Control)
-		{
-			// Ctrl-V pressed
-			// paste text from clipboard
-			if (prompt.getCursorLength() > 0) {
-				// Delete selected section of text
-				prompt.cursorOperation(
-					ChatPrompt::CURSOROP_DELETE,
-					ChatPrompt::CURSOROP_DIR_LEFT, // Ignored
-					ChatPrompt::CURSOROP_SCOPE_SELECTION);
-			}
-			IOSOperator *os_operator = Environment->getOSOperator();
-			const c8 *text = os_operator->getTextFromClipboard();
-			if (!text)
-				return true;
-			std::basic_string<unsigned char> str((const unsigned char*)text);
-			prompt.input(std::wstring(str.begin(), str.end()));
-			return true;
-		}
-		else if(event.KeyInput.Key == KEY_KEY_X && event.KeyInput.Control)
-		{
-			// Ctrl-X pressed
-			// Cut text to clipboard
-			if (prompt.getCursorLength() <= 0)
-				return true;
-			std::wstring wselected = prompt.getSelection();
-			std::string selected = wide_to_utf8(wselected);
-			Environment->getOSOperator()->copyToClipboard(selected.c_str());
-			prompt.cursorOperation(
-				ChatPrompt::CURSOROP_DELETE,
-				ChatPrompt::CURSOROP_DIR_LEFT, // Ignored
-				ChatPrompt::CURSOROP_SCOPE_SELECTION);
-			return true;
-		}
-		else if(event.KeyInput.Key == KEY_KEY_U && event.KeyInput.Control)
-		{
-			// Ctrl-U pressed
-			// kill line to left end
-			prompt.cursorOperation(
-				ChatPrompt::CURSOROP_DELETE,
-				ChatPrompt::CURSOROP_DIR_LEFT,
-				ChatPrompt::CURSOROP_SCOPE_LINE);
-			return true;
-		}
-		else if(event.KeyInput.Key == KEY_KEY_K && event.KeyInput.Control)
-		{
-			// Ctrl-K pressed
-			// kill line to right end
-			prompt.cursorOperation(
-				ChatPrompt::CURSOROP_DELETE,
-				ChatPrompt::CURSOROP_DIR_RIGHT,
-				ChatPrompt::CURSOROP_SCOPE_LINE);
-			return true;
-		}
-		else if(event.KeyInput.Key == KEY_TAB)
-		{
+		case KEY_TAB: {
 			// Tab or Shift-Tab pressed
 			// Nick completion
 			std::list<std::string> names = m_client->getConnectedPlayerNames();
 			bool backwards = event.KeyInput.Shift;
 			prompt.nickCompletion(names, backwards);
 			return true;
-		} else if (!iswcntrl(event.KeyInput.Char) && !event.KeyInput.Control) {
+		}
+		default: break;
+		}
+
+		if (event.KeyInput.Control) {
+			switch (key_code) {
+			case KEY_KEY_A:
+				// Ctrl-A pressed
+				// Select all text
+				prompt.cursorOperation(
+					ChatPrompt::CURSOROP_SELECT,
+					ChatPrompt::CURSOROP_DIR_LEFT, // Ignored
+					ChatPrompt::CURSOROP_SCOPE_LINE);
+				return true;
+			case KEY_KEY_C: {
+				// Ctrl-C pressed
+				// Copy text to clipboard
+				if (prompt.getCursorLength() <= 0)
+					return true;
+				std::wstring wselected = prompt.getSelection();
+				std::string selected = wide_to_utf8(wselected);
+				Environment->getOSOperator()->copyToClipboard(selected.c_str());
+				return true;
+			}
+			case KEY_KEY_V: {
+				// Ctrl-V pressed
+				// paste text from clipboard
+				if (prompt.getCursorLength() > 0) {
+					// Delete selected section of text
+					prompt.cursorOperation(
+						ChatPrompt::CURSOROP_DELETE,
+						ChatPrompt::CURSOROP_DIR_LEFT, // Ignored
+						ChatPrompt::CURSOROP_SCOPE_SELECTION);
+				}
+				IOSOperator *os_operator = Environment->getOSOperator();
+				const c8 *text = os_operator->getTextFromClipboard();
+				if (!text)
+					return true;
+				std::basic_string<unsigned char> str((const unsigned char*)text);
+				prompt.input(std::wstring(str.begin(), str.end()));
+				return true;
+			}
+			case KEY_KEY_X: {
+				// Ctrl-X pressed
+				// Cut text to clipboard
+				if (prompt.getCursorLength() <= 0)
+					return true;
+				std::wstring wselected = prompt.getSelection();
+				std::string selected = wide_to_utf8(wselected);
+				Environment->getOSOperator()->copyToClipboard(selected.c_str());
+				prompt.cursorOperation(
+					ChatPrompt::CURSOROP_DELETE,
+					ChatPrompt::CURSOROP_DIR_LEFT, // Ignored
+					ChatPrompt::CURSOROP_SCOPE_SELECTION);
+				return true;
+			}
+			case KEY_KEY_U:
+				// Ctrl-U pressed
+				// kill line to left end
+				prompt.cursorOperation(
+					ChatPrompt::CURSOROP_DELETE,
+					ChatPrompt::CURSOROP_DIR_LEFT,
+					ChatPrompt::CURSOROP_SCOPE_LINE);
+				return true;
+			case KEY_KEY_K:
+				// Ctrl-K pressed
+				// kill line to right end
+				prompt.cursorOperation(
+					ChatPrompt::CURSOROP_DELETE,
+					ChatPrompt::CURSOROP_DIR_RIGHT,
+					ChatPrompt::CURSOROP_SCOPE_LINE);
+				return true;
+			default: break;
+			}
+		}
+
+		// Unhandled characters that are not controls
+		if (key_char != L'\0') {
 			#if defined(__linux__) && (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9)
 				wchar_t wc = L'_';
-				mbtowc( &wc, (char *) &event.KeyInput.Char, sizeof(event.KeyInput.Char) );
+				mbtowc( &wc, (char *) &key_char, sizeof(key_char) );
 				prompt.input(wc);
 			#else
-				prompt.input(event.KeyInput.Char);
+				prompt.input(key_char);
 			#endif
 			return true;
 		}

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -295,20 +295,12 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 	if (event.EventType == EET_KEY_INPUT_EVENT && active_key
 			&& event.KeyInput.PressedDown) {
 
-		bool prefer_character = shift_down;
-		KeyPress kp(event.KeyInput, prefer_character);
+		KeyPress kp(event.KeyInput);
 
 		if (event.KeyInput.Key == irr::KEY_DELETE)
 			kp = KeyPress(""); // To erase key settings
 		else if (event.KeyInput.Key == irr::KEY_ESCAPE)
 			kp = active_key->key; // Cancel
-
-		bool shift_went_down = false;
-		if(!shift_down &&
-				(event.KeyInput.Key == irr::KEY_SHIFT ||
-				event.KeyInput.Key == irr::KEY_LSHIFT ||
-				event.KeyInput.Key == irr::KEY_RSHIFT))
-			shift_went_down = true;
 
 		// Display Key already in use message
 		bool key_in_use = false;
@@ -341,10 +333,10 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 			delete[] text;
 
 			// Allow characters made with shift
-			if (shift_went_down){
-				shift_down = true;
+			if (event.KeyInput.Key == irr::KEY_SHIFT ||
+					event.KeyInput.Key == irr::KEY_LSHIFT ||
+					event.KeyInput.Key == irr::KEY_RSHIFT)
 				return false;
-			}
 
 			active_key = nullptr;
 			return true;
@@ -387,7 +379,6 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 					}
 					FATAL_ERROR_IF(!active_key, "Key setting not found");
 
-					shift_down = false;
 					const wchar_t *text = wgettext("press key");
 					active_key->button->setText(text);
 					delete[] text;

--- a/src/gui/guiKeyChangeMenu.h
+++ b/src/gui/guiKeyChangeMenu.h
@@ -71,8 +71,6 @@ private:
 
 	void add_key(int id, const wchar_t *button_name, const std::string &setting_name);
 
-	bool shift_down = false;
-
 	key_setting *active_key = nullptr;
 	gui::IGUIStaticText *key_used_text = nullptr;
 	std::vector<key_setting *> key_settings;

--- a/src/unittest/test_keycode.cpp
+++ b/src/unittest/test_keycode.cpp
@@ -101,10 +101,11 @@ void TestKeycode::testCreateFromSKeyInput()
 	UASSERTEQ_STR(k.sym(), "?");
 
 	// prefer_character mode
-	in.Key = irr::KEY_COMMA;
-	in.Char = L'G';
-	k = KeyPress(in, true);
-	UASSERTEQ_STR(k.sym(), "KEY_KEY_G");
+	in.Key = irr::KEY_KEY_7;
+	in.Char = L'/';
+	in.Shift = true;
+	k = KeyPress(in);
+	UASSERTEQ_STR(k.sym(), "/");
 }
 
 void TestKeycode::testCompare()

--- a/src/unittest/test_keycode.cpp
+++ b/src/unittest/test_keycode.cpp
@@ -119,6 +119,7 @@ void TestKeycode::testCompare()
 	irr::SEvent::SKeyInput in;
 	in.Key = irr::KEY_PLUS;
 	in.Char = L'=';
+	in.Shift = true;
 	UASSERT(KeyPress("=") == KeyPress(in));
 
 	// Matching keycode suffices
@@ -126,5 +127,8 @@ void TestKeycode::testCompare()
 	in.Key = in2.Key = irr::KEY_OEM_CLEAR;
 	in.Char = L'\0';
 	in2.Char = L';';
-	UASSERT(KeyPress(in) == KeyPress(in2));
+	KeyPress kp1(in);
+	KeyPress kp2(in2);
+	UASSERT(kp1 == kp2);
+	UASSERT(std::hash<KeyPress>{}(kp1) == std::hash<KeyPress>{}(kp2));
 }


### PR DESCRIPTION
Fixes #10440

This PR separates the case where `irr::` keys and where `wchar_t` keys are used. Wherever possible, only one (the more accurate one) is defined.
Kinda related, it should also allow more chat input characters, though warnings will still appear in the terminal.
+ Code cleanup in guiChatConsole


## To do

This PR is ~Ready for Review.~ WIP. **Currently causes malfunctions when Sneak-Moving**

## How to test

Tests with various keyboard layouts are much appreciated!

1) Unittests must pass
2) Change keys in-game and check whether combined keys (Shift + 7 or so) work
3) Test the changed keys
4) Open the chat dialogue and try all characters on your keyboard. More of them should be working now.
