### PR TITLE
Chat Input: Allow more input keys

### DIFF
--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -569,8 +569,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				const c8 *text = os_operator->getTextFromClipboard();
 				if (!text)
 					return true;
-				std::basic_string<unsigned char> str((const unsigned char*)text);
-				prompt.input(std::wstring(str.begin(), str.end()));
+				prompt.input(utf8_to_wide(text));
 				return true;
 			}
 			case KEY_KEY_X: {


### PR DESCRIPTION
A harmless #10456 spin-off, without any fundamental key input changes and limited to the Chat Input dialogue.
This PR allows more chat input characters, though warnings will still appear in the terminal.

## To do

This PR is Ready for Review.

## How to test

1) Test all keys and combinations in chat. There should now be more characters working.