### PR TITLE
Prevent games from setting secure settings

### DIFF
--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -34,10 +34,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // The maximum number of identical world names allowed
 #define MAX_WORLD_NAMES 100
 
+namespace
+{
+
 bool getGameMinetestConfig(const std::string &game_path, Settings &conf)
 {
 	std::string conf_path = game_path + DIR_DELIM + "minetest.conf";
 	return conf.readConfigFile(conf_path.c_str());
+}
+
 }
 
 struct GameFindPath
@@ -330,8 +335,11 @@ void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 	// files that were loaded before.
 	g_settings->clearDefaults();
 	set_default_settings(g_settings);
+
 	Settings game_defaults;
 	getGameMinetestConfig(gamespec.path, game_defaults);
+	game_defaults.removeSecureSettings();
+
 	g_settings->overrideDefaults(&game_defaults);
 
 	infostream << "Initializing world at " << final_path << std::endl;

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -53,9 +53,6 @@ struct SubgameSpec
 	bool isValid() const { return (!id.empty() && !path.empty()); }
 };
 
-// minetest.conf
-bool getGameMinetestConfig(const std::string &game_path, Settings &conf);
-
 SubgameSpec findSubgame(const std::string &id);
 SubgameSpec findWorldSubgame(const std::string &world_path);
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1039,6 +1039,18 @@ void Settings::deregisterChangedCallback(const std::string &name,
 	}
 }
 
+void Settings::removeSecureSettings() {
+	for (const auto &name : getNames()) {
+		if (name.compare(0, 7, "secure.") != 0)
+			continue;
+
+		errorstream << "Secure setting " << name
+					<< " isn't allowed, so was ignored."
+					<< std::endl;
+		remove(name);
+	}
+}
+
 void Settings::doCallbacks(const std::string &name) const
 {
 	MutexAutoLock lock(m_callback_mutex);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1039,14 +1039,15 @@ void Settings::deregisterChangedCallback(const std::string &name,
 	}
 }
 
-void Settings::removeSecureSettings() {
+void Settings::removeSecureSettings()
+{
 	for (const auto &name : getNames()) {
 		if (name.compare(0, 7, "secure.") != 0)
 			continue;
 
 		errorstream << "Secure setting " << name
-					<< " isn't allowed, so was ignored."
-					<< std::endl;
+				<< " isn't allowed, so was ignored."
+				<< std::endl;
 		remove(name);
 	}
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -207,6 +207,8 @@ public:
 	void deregisterChangedCallback(const std::string &name,
 		SettingsChangedCallback cbf, void *userdata = NULL);
 
+	void removeSecureSettings();
+
 private:
 	/***********************
 	 * Reading and writing *


### PR DESCRIPTION
Previously, games could provide secure. settings to escape the sandbox. This is no longer possible

Example output:

> Secure setting secure.trusted_mods isn't allowed, so was ignored.

## How to test

```lua
local ie = minetest.request_insecure_environment()
assert(not ie, "Was able to get insecure environment!")
```
