### PR TITLE
Pass ContentFeatures as reference to read_content_features

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -488,12 +488,10 @@ TileDef read_tiledef(lua_State *L, int index, u8 drawtype)
 }
 
 /******************************************************************************/
-ContentFeatures read_content_features(lua_State *L, int index)
+void read_content_features(lua_State *L, ContentFeatures &f, int index)
 {
 	if(index < 0)
 		index = lua_gettop(L) + 1 + index;
-
-	ContentFeatures f;
 
 	/* Cache existence of some callbacks */
 	lua_getfield(L, index, "on_construct");
@@ -797,7 +795,6 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	getstringfield(L, index, "node_dig_prediction",
 		f.node_dig_prediction);
 
-	return f;
 }
 
 void push_content_features(lua_State *L, const ContentFeatures &c)

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -67,7 +67,8 @@ struct collisionMoveResult;
 
 extern struct EnumString es_TileAnimationType[];
 
-ContentFeatures    read_content_features     (lua_State *L, int index);
+void               read_content_features     (lua_State *L, ContentFeatures &f,
+                                              int index);
 void               push_content_features     (lua_State *L,
                                               const ContentFeatures &c);
 

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -559,7 +559,8 @@ int ModApiItemMod::l_register_item_raw(lua_State *L)
 
 	// Read the node definition (content features) and register it
 	if (def.type == ITEM_NODE) {
-		ContentFeatures f = read_content_features(L, table);
+		ContentFeatures f;
+		read_content_features(L, f, table);
 		// when a mod reregisters ignore, only texture changes and such should
 		// be done
 		if (f.name == "ignore")


### PR DESCRIPTION
- Goal of the PR
Improve code structure and increase performance.
- How does the PR work?
By passing a ContentFeatures struct to read_content_features by reference instead of creating it in read_content_features, read_content_features is more versatile, and performance is gained.
- Does it resolve any reported issue?
Nope.
- If not a bug fix, why is this PR needed? What usecases does it solve?
This PR is needed to keep the code fast and maintainable.
## To do
Nothing.

Ready for Review.

## How to test
Build, compile, and run.