### PR TITLE
Minor collision optimization.

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -281,8 +281,8 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		MYMAX(pos_f->Y, newpos_f.Y),
 		MYMAX(pos_f->Z, newpos_f.Z)
 	);
-	v3s16 min = floatToInt(minpos_f + box_0.MinEdge, BS) - v3s16(1, 1, 1);
-	v3s16 max = floatToInt(maxpos_f + box_0.MaxEdge, BS) + v3s16(1, 1, 1);
+	v3s16 min = floatToInt(minpos_f + box_0.MinEdge, BS) - v3s16(speed_f->X < 0, speed_f->Y < 0, speed_f->Z < 0);
+	v3s16 max = floatToInt(maxpos_f + box_0.MaxEdge, BS) + v3s16(speed_f->X > 0, speed_f->Y > 0, speed_f->Z > 0);
 
 	bool any_position_valid = false;
 


### PR DESCRIPTION
This is a minor collision optimization.
Only extend the bounding box by one in the direction of none-zero speed components.

I am not observing any bad side-effects.

For an entity laying on the ground, for example, it reduced 64 nodes to check to just 12 (specifics depend on exactly where the entity is laying between nodes).

Please test. You can test causing many TNT explosions, the dug entities quickly slow MT. After a few hundred it grinds to a halt.
You can see the number of entities using F6 (it's on the 2nd or 3rd pane).
