### PR TITLE
Document how to work with ClangFormat

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,6 +43,14 @@ Contributions are welcome! Here's how you can help:
 4. The code's interfaces are well designed, regardless of other aspects that might need more work in the future.
 5. It uses protocols and formats which include the required compatibility.
 
+### Important note about automated GitHub checks
+
+When you submit a pull request, GitHub automatically runs checks on the Minetest Engine combined with your changes. One of these checks is called 'cpp lint / clang format', which checks code formatting.
+Because formatting for readability requires human judgement this check often fails and often makes unsuitable formatting requests which make code readability worse.
+
+If this check fails, look at the details to check for any clear mistakes and correct those. However you should not apply everything ClangFormat requests, ignore requests that make code readability worse and any other clearly unsuitable requests.
+Discuss with a core developer if in any doubt and for how to progress.
+
 ## Issues
 
 If you experience an issue, we would like to know the details - especially when a stable release is on the way.


### PR DESCRIPTION
As discussed elsewhere, the ClangFormat check often makes unsuitable formatting requests and misleads contributors into thinking they must satisfy the all the requests, and we do not warn about this.
One example is #10408 , where the author added 3300 lines of changes to a 700 line change PR to satisfy unsuitable requests made by ClangFormat.
This PR explains how to work with ClangFormat and makes it clear that unsuitable ClangFormat requests should not be applied.
The added text is placed at the end of the 'Code' section.

![Screenshot from 2020-10-07 19-18-05](https://user-images.githubusercontent.com/3686677/95371310-eea65f80-08d1-11eb-8f03-7921529f8cd3.png)