### PR TITLE
Add `table.len` method.

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -486,6 +486,17 @@ function table.copy(t, seen)
 end
 
 
+function table.len(t)
+    local counter = 0
+    
+    for i, v in pairs(t) do
+        counter = counter + 1
+    end
+    
+    return counter
+end
+
+
 function table.insert_all(t, other)
 	for i=1, #other do
 		t[#t + 1] = other[i]

--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -487,13 +487,13 @@ end
 
 
 function table.len(t)
-    local counter = 0
+    	local counter = 0
     
-    for i, v in pairs(t) do
-        counter = counter + 1
-    end
+    	for i, v in pairs(t) do
+        	counter = counter + 1
+    	end
     
-    return counter
+    	return counter
 end
 
 


### PR DESCRIPTION
If you want to retrieve a length of a list with using `#` operator, it works fine. However, if your table contains still fields with non-integer keys, they are ignored by those operator. It obviously will give an incorrect result. My small method `table.len()` counts **all** fields independing on their keys types.  

## To do
This PR is Ready for Review.

## How to test
Copypaste the function code from the source here and run this code:
```
local random_t = {mesh = "mesh.b3d", texture = "texture.png", 43, 56.5, function() return "nothing" end, {1, 2, 3}, nil}

print(table.len(random_t))
```
