### PR TITLE
Chatcommands: Show the execution time if the command takes a long time

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -95,7 +95,7 @@ core.register_on_chat_message(function(name, message)
 						minetest.colorize("#f3d2ff", " (%.5g s)"):format(delay)
 				else
 					result = minetest.colorize("#f3d2ff",
-						"Chatcommand executed after %.5f s"):format(delay)
+						"Chat command executed after %.5f s"):format(delay)
 				end
 			end
 			if result then

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -48,7 +48,7 @@ end
 core.chatcommands = core.registered_chatcommands -- BACKWARDS COMPATIBILITY
 
 local msg_time_threshold =
-	tonumber(core.settings:get("chatcommand_msg_time_threshold")) or 0.01
+	tonumber(core.settings:get("chatcommand_msg_time_threshold")) or 0.1
 core.register_on_chat_message(function(name, message)
 	if message:sub(1,1) ~= "/" then
 		return
@@ -95,7 +95,7 @@ core.register_on_chat_message(function(name, message)
 						minetest.colorize("#f3d2ff", " (%.5g s)"):format(delay)
 				else
 					result = minetest.colorize("#f3d2ff",
-						"Chat command executed after %.5f s"):format(delay)
+						"Command execution took %.5f s"):format(delay)
 				end
 			end
 			if result then

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -47,6 +47,8 @@ end
 
 core.chatcommands = core.registered_chatcommands -- BACKWARDS COMPATIBILITY
 
+local msg_time_threshold =
+	tonumber(core.settings:get("chatcommand_msg_time_threshold")) or 0.01
 core.register_on_chat_message(function(name, message)
 	if message:sub(1,1) ~= "/" then
 		return
@@ -73,7 +75,9 @@ core.register_on_chat_message(function(name, message)
 	local has_privs, missing_privs = core.check_player_privs(name, cmd_def.privs)
 	if has_privs then
 		core.set_last_run_mod(cmd_def.mod_origin)
+		local t_before = minetest.get_us_time()
 		local success, result = cmd_def.func(name, param)
+		local delay = (minetest.get_us_time() - t_before) / 1000000
 		if success == false and result == nil then
 			core.chat_send_player(name, "-!- "..S("Invalid command usage."))
 			local help_def = core.registered_chatcommands["help"]
@@ -83,8 +87,20 @@ core.register_on_chat_message(function(name, message)
 					core.chat_send_player(name, helpmsg)
 				end
 			end
-		elseif result then
-			core.chat_send_player(name, result)
+		else
+			if delay > msg_time_threshold then
+				-- Show how much time it took to execute the command
+				if result then
+					result = result ..
+						minetest.colorize("#f3d2ff", " (%.5g s)"):format(delay)
+				else
+					result = minetest.colorize("#f3d2ff",
+						"Chatcommand executed after %.5f s"):format(delay)
+				end
+			end
+			if result then
+				core.chat_send_player(name, result)
+			end
 		end
 	else
 		core.chat_send_player(name,

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1136,9 +1136,9 @@ enable_rollback_recording (Rollback recording) bool false
 #    @name, @message, @timestamp (optional)
 chat_message_format (Chat message format) string <@name> @message
 
-#    If the execution of a chatcommand takes longer than this specified time in
-#    seconds, add the time information to the chatcommand message
-chatcommand_msg_time_threshold (Chatcommand time message threshold) float 0.01
+#    If the execution of a chat command takes longer than this specified time in
+#    seconds, add the time information to the chat command message
+chatcommand_msg_time_threshold (Chat command time message threshold) float 0.01
 
 #    A message to be displayed to all clients when the server shuts down.
 kick_msg_shutdown (Shutdown message) string Server shutting down.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1136,6 +1136,10 @@ enable_rollback_recording (Rollback recording) bool false
 #    @name, @message, @timestamp (optional)
 chat_message_format (Chat message format) string <@name> @message
 
+#    If the execution of a chatcommand takes longer than this specified time in
+#    seconds, add the time information to the chatcommand message
+chatcommand_msg_time_threshold (Chatcommand time message threshold) float 0.01
+
 #    A message to be displayed to all clients when the server shuts down.
 kick_msg_shutdown (Shutdown message) string Server shutting down.
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1138,7 +1138,7 @@ chat_message_format (Chat message format) string <@name> @message
 
 #    If the execution of a chat command takes longer than this specified time in
 #    seconds, add the time information to the chat command message
-chatcommand_msg_time_threshold (Chat command time message threshold) float 0.01
+chatcommand_msg_time_threshold (Chat command time message threshold) float 0.1
 
 #    A message to be displayed to all clients when the server shuts down.
 kick_msg_shutdown (Shutdown message) string Server shutting down.


### PR DESCRIPTION
This is a configurable version of my [chatcommand_delays](https://github.com/HybridDog/chatcommand_delays) mod, implemented in builtin.
> This mod tells the time a chatcommand took to get executed.
So for example if you want to know how long it takes to set 100x100x100 nodes using worldedit,
you only need to have this mod, it automatically adds the delay to the message sent to the player (if no message is returned, the delay gets sent in an own line).
Currently the time is added in brackets at the end of the message.
If the delay is very short, e.g. when you just teleport somewhere, the time isn't added to not cause spamming.

My mod overrides the builtin chatcommand function to show time information: https://github.com/HybridDog/chatcommand_delays/blob/34482193a544120f293f28e6b1afe730216b5085/init.lua#L8
I always need to update that code when a new feature is added to the builtin chatcommand function and I could not find a clean way to use the latest code from builtin automatically.
Chatcommand delay messages are helpful in my opinion because when a chatcommand takes a long time, it causes server lag, so it either has a bug (or bad implementation) or is inherently time-intensive (e.g. big map changes with worldedit).
The time threshold is configurable. Within years of implicit testing I noticed that the threshold `0.01` works well to show the delays only for computationally-intensive chatcommands.  


## How to test

Execute chatcommands


## Additional information

I can change the default time threshold if you want it, e.g. to `10` to almost always hide the delay. 
The setting name may not be optimal. Suggestions are welcome.