### PR TITLE
Fix box[]es not being clipped

### DIFF
--- a/src/gui/guiBox.cpp
+++ b/src/gui/guiBox.cpp
@@ -107,10 +107,11 @@ void GUIBox::draw()
 	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	driver->draw2DRectangle(main_rect, m_colors[0], m_colors[1], m_colors[3],
-		m_colors[2], nullptr);
+		m_colors[2], &AbsoluteClippingRect);
 
 	for (size_t i = 0; i <= 3; i++)
-		driver->draw2DRectangle(m_bordercolors[i], border_rects[i], nullptr);
+		driver->draw2DRectangle(m_bordercolors[i], border_rects[i],
+				&AbsoluteClippingRect);
 
 	IGUIElement::draw();
 }


### PR DESCRIPTION
- Fixes a regression of #8676.
- See also: http://irrlicht.sourceforge.net/docu/classirr_1_1video_1_1_i_video_driver.html#ac7f452fae0ef8abe01768a78ba7033b7

## To do

This PR is a Ready for Review.

## How to test

In devtest open the test formspec and go to the scroll container tab.