### PR TITLE
Add missing type check to InvRef:set_lists()

### DIFF
--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -280,6 +280,7 @@ int InvRef::l_set_lists(lua_State *L)
 	Server *server = getServer(L);
 
 	lua_pushnil(L);
+	luaL_checktype(L, 2, LUA_TTABLE);
 	while (lua_next(L, 2)) {
 		const char *listname = lua_tostring(L, -2);
 		read_inventory_list(L, -1, tempInv, listname, server);


### PR DESCRIPTION
- Goal of the PR
Avoiding a segmentation fault crash (AKA the whole client)
- How does the PR work?
I've added a table check
- Does it resolve any reported issue?
One of the problems in #1794. I'd like to fix them all but I thought about starting with one

## To do

This PR is Ready for Review.

## How to test
```
minetest.register_on_joinplayer(function(player, last_login)
  minetest.after(1, function()
    player:get_inventory():set_lists()
  end)
end)
```
the client won't crash anymore (but the game will, of course)
