### PR TITLE
PlayerSAO: Run on_player_hpchange raw change values

### DIFF
--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -463,9 +463,6 @@ void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
 	if (m_hp <= 0 && hp < (s32)m_hp)
 		return; // Cannot take more damage
 
-	if (m_hp >= m_prop.hp_max && hp > (s32)m_hp)
-		return; // Cannot heal more
-
 	{
 		s32 hp_change = m_env->getScriptIface()->on_player_hpchange(this, hp - m_hp, reason);
 		if (hp_change == 0)
@@ -478,7 +475,7 @@ void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
 	hp = rangelim(hp, 0, m_prop.hp_max);
 
 	if (hp < oldhp && isImmortal())
-		return; // Only allow healing immortal players
+		return; // Do not allow immortal players to be damaged
 
 	m_hp = hp;
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -457,20 +457,28 @@ u16 PlayerSAO::punch(v3f dir,
 
 void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
 {
-	s32 oldhp = m_hp;
+	if (hp == (s32)m_hp)
+		return; // Nothing to do
 
-	hp = rangelim(hp, 0, m_prop.hp_max);
+	if (m_hp <= 0 && hp < (s32)m_hp)
+		return; // Cannot take more damage
 
-	if (oldhp != hp) {
-		s32 hp_change = m_env->getScriptIface()->on_player_hpchange(this, hp - oldhp, reason);
+	if (m_hp >= m_prop.hp_max && hp > (s32)m_hp)
+		return; // Cannot heal more
+
+	{
+		s32 hp_change = m_env->getScriptIface()->on_player_hpchange(this, hp - m_hp, reason);
 		if (hp_change == 0)
 			return;
 
-		hp = rangelim(oldhp + hp_change, 0, m_prop.hp_max);
+		hp = m_hp + hp_change;
 	}
 
+	s32 oldhp = m_hp;
+	hp = rangelim(hp, 0, m_prop.hp_max);
+
 	if (hp < oldhp && isImmortal())
-		return;
+		return; // Only allow healing immortal players
 
 	m_hp = hp;
 


### PR DESCRIPTION
The callback is only run when a change in HP is to be expected.
Following cases will not trigger the callback:
 * Dead player damaged further
 * Healing full-health player
 * Change of 0 HP

Fixes #10377
Previous changes in this area: #8494 and #8264

## To do

This PR is Ready for Review.

## How to test

Take damage and eat bread. Code:
```Lua
minetest.register_on_player_hpchange(function(player, hp_change, reason)
	print(player:get_player_name(), "hpchange", "change=" .. hp_change .. " reason=" .. reason.type)
end, false)

minetest.register_on_punchplayer(function(player, _, _, _, _, damage)
	print(player:get_player_name(), "punch   ", "change=" .. -damage)
end)
```

```
Krock   punch           change=-5
Krock   hpchange        change=-5 reason=punch
ACTION[Server]: player Krock2 (id=2, hp=20) punched player Krock (id=1, hp=0), damage=4
ACTION[Server]: Krock dies at (20,4,-10). No bones placed
Krock   punch           change=-6
ACTION[Server]: player Krock2 (id=2, hp=20) punched player Krock (id=1, hp=0), damage=0
Krock   punch           change=-3
ACTION[Server]: player Krock2 (id=2, hp=20) punched player Krock (id=1, hp=0), damage=0
Krock   hpchange        change=20 reason=respawn
```
