### PR TITLE
Add ObjectRef:get_children()

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6206,6 +6206,8 @@ object you are working with still exists.
        should appear in first person.
 * `get_attach()`: returns parent, bone, position, rotation, forced_visible, 
     or nil if it isn't attached.
+* `get_children()`: returns children of the object as a table, or nil if there
+    are none.
 * `set_detach()`
 * `set_bone_position(bone, position, rotation)`
     * `bone`: string

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6206,8 +6206,8 @@ object you are working with still exists.
        should appear in first person.
 * `get_attach()`: returns parent, bone, position, rotation, forced_visible, 
     or nil if it isn't attached.
-* `get_children()`: returns children of the object as a table, or nil if there
-    are none.
+* `get_children()`: returns children of the object as a table, or an empty one
+    if there aren't any.
 * `set_detach()`
 * `set_bone_position(bone, position, rotation)`
     * `bone`: string

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6206,8 +6206,8 @@ object you are working with still exists.
        should appear in first person.
 * `get_attach()`: returns parent, bone, position, rotation, forced_visible, 
     or nil if it isn't attached.
-* `get_children()`: returns children of the object as a table, or an empty one
-    if there aren't any.
+* `get_children()`: returns a list of ObjectRefs that are attached to the
+    object.
 * `set_detach()`
 * `set_bone_position(bone, position, rotation)`
     * `bone`: string

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -738,6 +738,32 @@ int ObjectRef::l_get_attach(lua_State *L)
 	return 5;
 }
 
+// get_children(self)
+int ObjectRef::l_get_children(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *sao = getobject(ref);
+	if (sao == NULL)
+		return 0;
+
+	//Do it
+	const std::unordered_set<int> child_ids = sao->getAttachmentChildIds();
+	if (child_ids.empty())
+		return 0;
+
+	int i = 0;
+	lua_createtable(L, child_ids.size(), 0);
+	for (const int &id : child_ids) {
+		ServerActiveObject *child = env->getActiveObject(id);
+		getScriptApiBase(L)->objectrefGetOrCreate(L, child);
+		lua_rawseti(L, -2, ++i);
+	}
+	return 1;
+}
+
+
 // set_detach(self)
 int ObjectRef::l_set_detach(lua_State *L)
 {
@@ -2337,6 +2363,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_bone_position),
 	luamethod(ObjectRef, set_attach),
 	luamethod(ObjectRef, get_attach),
+	luamethod(ObjectRef, get_children),
 	luamethod(ObjectRef, set_detach),
 	luamethod(ObjectRef, set_properties),
 	luamethod(ObjectRef, get_properties),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -750,9 +750,6 @@ int ObjectRef::l_get_children(lua_State *L)
 
 	//Do it
 	const std::unordered_set<int> child_ids = sao->getAttachmentChildIds();
-	if (child_ids.empty())
-		return 0;
-
 	int i = 0;
 	lua_createtable(L, child_ids.size(), 0);
 	for (const int &id : child_ids) {

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -763,7 +763,6 @@ int ObjectRef::l_get_children(lua_State *L)
 	return 1;
 }
 
-
 // set_detach(self)
 int ObjectRef::l_set_detach(lua_State *L)
 {

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -745,14 +745,13 @@ int ObjectRef::l_get_children(lua_State *L)
 
 	ObjectRef *ref = checkobject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
-	if (sao == NULL)
+	if (sao == nullptr)
 		return 0;
 
-	//Do it
 	const std::unordered_set<int> child_ids = sao->getAttachmentChildIds();
 	int i = 0;
 	lua_createtable(L, child_ids.size(), 0);
-	for (const int &id : child_ids) {
+	for (const int id : child_ids) {
 		ServerActiveObject *child = env->getActiveObject(id);
 		getScriptApiBase(L)->objectrefGetOrCreate(L, child);
 		lua_rawseti(L, -2, ++i);

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -143,6 +143,9 @@ private:
 	// get_attach(self)
 	static int l_get_attach(lua_State *L);
 
+	// get_children(self)
+	static int l_get_children(lua_State *L);
+
 	// set_detach(self)
 	static int l_set_detach(lua_State *L);
 


### PR DESCRIPTION
- Goal of the PR
Retrieving an ObjectRef's children
- How does the PR work?
whateverobject:get_children() returns a table containing its children, or nil if there are none
- Does it resolve any reported issue?
It implements part of #10475. Partly because it's my first PR operating with C++ and Lua, so I didn't want to overdo (especially if I made mistakes)

## To do

This PR is Ready for Review.

## How to test

```
minetest.register_chatcommand("children", {
  func = function(sender, param)
    local player = minetest.get_player_by_name(sender)
    local children = player:get_children() or {}
    
    minetest.chat_send_player(sender, "Your children amount is " .. #children)
    for id, child in pairs(children) do
        minetest.chat_send_player(sender, "#" .. id .. ": " .. dump(children[id]))
    end
    return true
  end
})
```

* attach a few entities onto you
* run /children