### PR TITLE
Fix float argument check in minetest.set_timeofday()

### DIFF
--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -751,9 +751,9 @@ int ModApiEnvMod::l_set_timeofday(lua_State *L)
 
 	// Do it
 	float timeofday_f = readParam<float>(L, 1);
-	luaL_argcheck(L, timeofday_f >= 0.0 && timeofday_f <= 1.0, 1,
+	luaL_argcheck(L, timeofday_f >= 0.0f && timeofday_f <= 1.0f, 1,
 		"value must be between 0 and 1");
-	int timeofday_mh = (int)(timeofday_f * 24000.0);
+	int timeofday_mh = (int)(timeofday_f * 24000.0f);
 	// This should be set directly in the environment but currently
 	// such changes aren't immediately sent to the clients, so call
 	// the server instead.

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -751,7 +751,8 @@ int ModApiEnvMod::l_set_timeofday(lua_State *L)
 
 	// Do it
 	float timeofday_f = readParam<float>(L, 1);
-	sanity_check(timeofday_f >= 0.0 && timeofday_f <= 1.0);
+	luaL_argcheck(L, timeofday_f >= 0.0 && timeofday_f <= 1.0, 1,
+		"value must be between 0 and 1");
 	int timeofday_mh = (int)(timeofday_f * 24000.0);
 	// This should be set directly in the environment but currently
 	// such changes aren't immediately sent to the clients, so call


### PR DESCRIPTION
- Goal of the PR
Avoid an engine assumption crash
- How does the PR work?
I've changed the check, now it doesn't make the whole client crash anymore (only the game)
- Does it resolve any reported issue?
closes #1794 (I've tried all the listed functions, they crash as intended except `set_timeofday`)

I guess there are other functions that might not work as intended with weird values, but testing them all is a suicide. I suggest to solve them on the go, avoiding keeping an issue open - especially because the listed ones are all solved

## To do

This PR is Ready for Review.

## How to test
Make it crash with
```
minetest.register_on_joinplayer(function(player, last_login)
    minetest.set_timeofday(-1)
end)
```
