### PR TITLE
Devtest hand: Update capabilities, add creative mode capabilities

### DIFF
--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -6,7 +6,7 @@
 
 Tool types:
 
-* Hand: basic tool/weapon (just for convenience, not optimized for testing)
+* Hand: basic tool/weapon (special capabilities in creative mode)
 * Pickaxe: dig cracky
 * Axe: dig choppy
 * Shovel: dig crumbly
@@ -24,21 +24,49 @@ Tool materials:
 ]]
 
 -- The hand
-minetest.register_item(":", {
-	type = "none",
-	wield_image = "wieldhand.png",
-	wield_scale = {x=1,y=1,z=2.5},
-	tool_capabilities = {
-		full_punch_interval = 1.0,
-		max_drop_level = 0,
-		groupcaps = {
-			crumbly = {times={[3]=1.50}, uses=0, maxlevel=0},
-			snappy = {times={[3]=1.50}, uses=0, maxlevel=0},
-			oddly_breakable_by_hand = {times={[1]=7.00,[2]=4.00,[3]=2.00}, uses=0, maxlevel=0},
-		},
-		damage_groups = {fleshy=1},
-	}
-})
+if minetest.settings:get_bool("creative_mode") then
+	local digtime = 42
+	local caps = {times = {digtime, digtime, digtime}, uses = 0, maxlevel = 256}
+
+	minetest.register_item(":", {
+		type = "none",
+		wield_image = "wieldhand.png",
+		wield_scale = {x = 1, y = 1, z = 2.5},
+		range = 10,
+		tool_capabilities = {
+			full_punch_interval = 0.5,
+			max_drop_level = 3,
+			groupcaps = {
+				crumbly = caps,
+				cracky  = caps,
+				snappy  = caps,
+				choppy  = caps,
+				oddly_breakable_by_hand = caps,
+				-- dig_immediate group doesn't use value 1. Value 3 is instant dig
+				dig_immediate =
+					{times = {[2] = digtime, [3] = 0}, uses = 0, maxlevel = 256},
+			},
+			damage_groups = {fleshy = 10},
+		}
+	})
+else
+	minetest.register_item(":", {
+		type = "none",
+		wield_image = "wieldhand.png",
+		wield_scale = {x = 1, y = 1, z = 2.5},
+		tool_capabilities = {
+			full_punch_interval = 0.9,
+			max_drop_level = 0,
+			groupcaps = {
+				crumbly = {times = {[2] = 3.00, [3] = 0.70}, uses = 0, maxlevel = 1},
+				snappy = {times = {[3] = 0.40}, uses = 0, maxlevel = 1},
+				oddly_breakable_by_hand =
+					{times = {[1] = 3.50, [2] = 2.00, [3] = 0.70}, uses = 0}
+			},
+			damage_groups = {fleshy = 1},
+		}
+	})
+end
 
 -- Mese Pickaxe: special tool that digs "everything" instantly
 minetest.register_tool("basetools:pick_mese", {


### PR DESCRIPTION
Since it was improved i am using the devtest game more now, but i have been repeatedly frustrated by the lack of an option for special hand tool capabilities, like in MTG in 'creative mode'. Building and altering test structures is slow and awkward.
Although a powerful mesepick is given to the player for digging, the primary problem is the lack of an extended 'range' when building or digging.
Many core devs are used to MTG 'creative mode' and usually use devtest in a 'creative mode' way. It is convenient and time-and-effort-saving to have a familiar interaction in devtest.

Another problem is that the devtest hand has old capabilites that are underpowered compared to the MTG non-'creative mode' hand.

This PR:
* Gives the hand tool special capabilities when 'creative mode' is enabled. Capabilities are copied from the MTG 'creative' mod for familiarity.
* Updates the non-'creative mode' hand tool capabilities to that of the slightly more powerful MTG non-'creative mode' hand tool.

This PR is very simple and fairly trivial. Both hand registrations are copy-paste from MTG. Not much need to test, this perhaps just needs concept approval.