### PR TITLE
Implement unloading of static_save=false objects according to existing docs

### DIFF
--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -42,6 +42,7 @@ public:
 	void step(float dtime, bool send_recommended);
 	std::string getClientInitializationData(u16 protocol_version);
 	bool isStaticAllowed() const { return m_prop.static_save; }
+	bool shouldUnload() const { return true; }
 	void getStaticData(std::string *result) const;
 	u16 punch(v3f dir, const ToolCapabilities *toolcap = nullptr,
 			ServerActiveObject *puncher = nullptr,

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -83,6 +83,7 @@ public:
 	void addedToEnvironment(u32 dtime_s);
 	void removingFromEnvironment();
 	bool isStaticAllowed() const { return false; }
+	bool shouldUnload() const { return false; }
 	std::string getClientInitializationData(u16 protocol_version);
 	void getStaticData(std::string *result) const;
 	void step(float dtime, bool send_recommended);

--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -125,12 +125,21 @@ public:
 		assert(isStaticAllowed());
 		*result = "";
 	}
+
 	/*
 		Return false in here to never save and instead remove object
 		on unload. getStaticData() will not be called in that case.
 	*/
 	virtual bool isStaticAllowed() const
 	{return true;}
+
+	/*
+		Return false here to never unload the object.
+		isStaticAllowed && shouldUnload -> unload when out of active block range
+		!isStaticAllowed && shouldUnload -> unload when block is unloaded
+	*/
+	virtual bool shouldUnload() const
+	{ return true; }
 
 	// Returns tool wear
 	virtual u16 punch(v3f dir,

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1887,8 +1887,8 @@ void ServerEnvironment::deactivateFarObjects(bool _force_delete)
 		// force_delete might be overriden per object
 		bool force_delete = _force_delete;
 
-		// Do not deactivate if static data creation not allowed
-		if (!force_delete && !obj->isStaticAllowed())
+		// Do not deactivate if disallowed
+		if (!force_delete && !obj->shouldUnload())
 			return false;
 
 		// removeRemovedObjects() is responsible for these
@@ -1917,7 +1917,10 @@ void ServerEnvironment::deactivateFarObjects(bool _force_delete)
 		}
 
 		// If block is still active, don't remove
-		if (!force_delete && m_active_blocks.contains(blockpos_o))
+		bool still_active = obj->isStaticAllowed() ?
+			m_active_blocks.contains(blockpos_o) :
+			getMap().getBlockNoCreateNoEx(blockpos_o) != nullptr;
+		if (!force_delete && still_active)
 			return false;
 
 		verbosestream << "ServerEnvironment::deactivateFarObjects(): "


### PR DESCRIPTION
It wasn't so complicated after all.
fixes #9821


## To do

This PR is Ready for Review.

## How to test

Observe when the `ServerEnvironment::deactivateFarObjects(): eactivating object id=x on inactive block` appears after moving (far enough) away from an entity:
* with static_save = true: as soon as leaving the active block range

* with static_save = false: after max 30s when the block gets unloaded