### PR TITLE
Fix optional dependencies causing cascading failures with dependent mods

### DIFF
--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -269,7 +269,7 @@ void ModsResolver::run()
 		// Setup the optional list based on what was actually seen
 		for (std::string modname : mod.optdepends) {
 			if (seenMods.count(modname) > 0) {
-				mod.unsatisfied_optdepends.push_back(modname);
+				mod.unsatisfied_optdepends.insert(modname);
 			}
 		}
 

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -219,13 +219,15 @@ std::vector<ModSpec> flattenMods(const std::map<std::string, ModSpec> &mods)
 }
 
 // Look ma, an inline class!
-class ModsResolver {
+class ModsResolver
+{
 public:
 	// the mods here is a copy of the ModConfiguration unsatisifed mods
-	ModsResolver(std::vector<ModSpec> mods) {
-	  for (ModSpec mod : mods) {
-	    modsByName[mod.name] = mod;
-	  }
+	ModsResolver(std::vector<ModSpec> mods)
+	{
+		for (ModSpec mod : mods) {
+			modsByName[mod.name] = mod;
+		}
 	};
 
 	// the main entry point to start resolving the graph
@@ -238,6 +240,7 @@ public:
 	// mods that are valid, but some or all of its optional dependencies
 	// could not be resolved
 	std::list<ModSpec> modsWithUnsatisfiedOptionals;
+
 private:
 	// resolve the mod by name, not spec, since a mod may not exist
 	void resolveMod(std::string &modname);
@@ -296,8 +299,8 @@ void ModsResolver::run()
 			if (mod.unsatisfied_depends.empty()) {
 				// if it has, it can be pushed unto the sortedMods list
 				sortedMods.push_back(mod);
-				// now to give the user some feedback, check if the mod also
-				// satisfied it's optional dependencies
+				// now to give the user some feedback, check if the mod
+				// also satisfied it's optional dependencies
 				if (!mod.unsatisfied_optdepends.empty()) {
 					// if not, then we push it unto the optionals list
 					modsWithUnsatisfiedOptionals.push_back(mod);
@@ -373,7 +376,7 @@ void ModConfiguration::printModsWithUnsatisfiedOptionalsWarning() const
 {
 	for (const ModSpec &mod : m_mods_with_unsatisfied_optionals) {
 		warningstream << "mod \"" << mod.name
-			    << "\" has unsatisfied dependencies (optional): ";
+			      << "\" has unsatisfied dependencies (optional): ";
 		for (const std::string &unsatisfied_depend : mod.unsatisfied_optdepends)
 			warningstream << " \"" << unsatisfied_depend << "\"";
 		warningstream << std::endl;
@@ -543,8 +546,11 @@ void ModConfiguration::resolveDependencies()
 	resolver.run();
 
 	m_sorted_mods.assign(resolver.sortedMods.begin(), resolver.sortedMods.end());
-	m_unsatisfied_mods.assign(resolver.unsatisfiedMods.begin(), resolver.unsatisfiedMods.end());
-	m_mods_with_unsatisfied_optionals.assign(resolver.modsWithUnsatisfiedOptionals.begin(), resolver.modsWithUnsatisfiedOptionals.end());
+	m_unsatisfied_mods.assign(
+			resolver.unsatisfiedMods.begin(), resolver.unsatisfiedMods.end());
+	m_mods_with_unsatisfied_optionals.assign(
+			resolver.modsWithUnsatisfiedOptionals.begin(),
+			resolver.modsWithUnsatisfiedOptionals.end());
 }
 
 #ifndef SERVER

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -112,9 +112,10 @@ class ModConfiguration
 {
 public:
 	// checks if all dependencies are fullfilled.
-	bool isConsistent() const {
+	bool isConsistent() const
+	{
 		return m_unsatisfied_mods.empty() &&
-					 m_mods_with_unsatisfied_optionals.empty();
+		       m_mods_with_unsatisfied_optionals.empty();
 	}
 
 	const std::vector<ModSpec> &getMods() const { return m_sorted_mods; }

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -47,6 +47,7 @@ struct ModSpec
 	std::unordered_set<std::string> depends;
 	std::unordered_set<std::string> optdepends;
 	std::unordered_set<std::string> unsatisfied_depends;
+	std::unordered_set<std::string> unsatisfied_optdepends;
 
 	bool part_of_modpack = false;
 	bool is_modpack = false;
@@ -111,7 +112,10 @@ class ModConfiguration
 {
 public:
 	// checks if all dependencies are fullfilled.
-	bool isConsistent() const { return m_unsatisfied_mods.empty(); }
+	bool isConsistent() const {
+		return m_unsatisfied_mods.empty() &&
+					 m_mods_with_unsatisfied_optionals.empty();
+	}
 
 	const std::vector<ModSpec> &getMods() const { return m_sorted_mods; }
 
@@ -121,6 +125,7 @@ public:
 	}
 
 	void printUnsatisfiedModsError() const;
+	void printModsWithUnsatisfiedOptionalsWarning() const;
 
 protected:
 	ModConfiguration(const std::string &worldpath);
@@ -162,6 +167,7 @@ private:
 	// this is where all mods are stored. Afterwards this contains
 	// only the ones with really unsatisfied dependencies.
 	std::vector<ModSpec> m_unsatisfied_mods;
+	std::vector<ModSpec> m_mods_with_unsatisfied_optionals;
 
 	// set of mod names for which an unresolved name conflict
 	// exists. A name conflict happens when two or more mods

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -410,8 +410,7 @@ void Server::init()
 	std::vector<ModSpec> unsatisfied_mods = m_modmgr->getUnsatisfiedMods();
 	// complain about mods with unsatisfied dependencies
 	if (!m_modmgr->isConsistent()) {
-		m_modmgr->printUnsatisfiedModsError();
-		m_modmgr->printModsWithUnsatisfiedOptionalsWarning();
+		m_modmgr->printConsistencyMessages();
 	}
 
 	//lock environment

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -411,6 +411,7 @@ void Server::init()
 	// complain about mods with unsatisfied dependencies
 	if (!m_modmgr->isConsistent()) {
 		m_modmgr->printUnsatisfiedModsError();
+		m_modmgr->printModsWithUnsatisfiedOptionalsWarning();
 	}
 
 	//lock environment


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

This is an attempt to fix #8601 

The mod resolution has function has been replaced by a simple class and recursive function that iterates through each dependency and attempts to resolve it as well.

From my quick test it resolved the issue as expected, but may require more testing for larger dependency trees, as recursion can get pretty dicey when not handled properly.

## To do

Maybe more testing?

## How to test

See #8601 for the failure case, and test if it loads as expected
