### PR TITLE
Remove all bump mapping and parallax occlusion related code.

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -187,31 +187,23 @@ local function formspec(tabview, name, tabdata)
 
 	if shaders_enabled then
 		tab_string = tab_string ..
-			"checkbox[8.25,0.5;cb_bumpmapping;" .. fgettext("Bump Mapping") .. ";"
-					.. dump(core.settings:get_bool("enable_bumpmapping")) .. "]" ..
-			"checkbox[8.25,1;cb_tonemapping;" .. fgettext("Tone Mapping") .. ";"
+			"checkbox[8.25,0.5;cb_tonemapping;" .. fgettext("Tone Mapping") .. ";"
 					.. dump(core.settings:get_bool("tone_mapping")) .. "]" ..
-			"checkbox[8.25,1.5;cb_parallax;" .. fgettext("Parallax Occlusion") .. ";"
-					.. dump(core.settings:get_bool("enable_parallax_occlusion")) .. "]" ..
-			"checkbox[8.25,2;cb_waving_water;" .. fgettext("Waving Liquids") .. ";"
+			"checkbox[8.25,1;cb_waving_water;" .. fgettext("Waving Liquids") .. ";"
 					.. dump(core.settings:get_bool("enable_waving_water")) .. "]" ..
-			"checkbox[8.25,2.5;cb_waving_leaves;" .. fgettext("Waving Leaves") .. ";"
+			"checkbox[8.25,1.5;cb_waving_leaves;" .. fgettext("Waving Leaves") .. ";"
 					.. dump(core.settings:get_bool("enable_waving_leaves")) .. "]" ..
-			"checkbox[8.25,3;cb_waving_plants;" .. fgettext("Waving Plants") .. ";"
+			"checkbox[8.25,2;cb_waving_plants;" .. fgettext("Waving Plants") .. ";"
 					.. dump(core.settings:get_bool("enable_waving_plants")) .. "]"
 	else
 		tab_string = tab_string ..
 			"label[8.38,0.7;" .. core.colorize("#888888",
-					fgettext("Bump Mapping")) .. "]" ..
-			"label[8.38,1.2;" .. core.colorize("#888888",
 					fgettext("Tone Mapping")) .. "]" ..
-			"label[8.38,1.7;" .. core.colorize("#888888",
-					fgettext("Parallax Occlusion")) .. "]" ..
-			"label[8.38,2.2;" .. core.colorize("#888888",
+			"label[8.38,1.2;" .. core.colorize("#888888",
 					fgettext("Waving Liquids")) .. "]" ..
-			"label[8.38,2.7;" .. core.colorize("#888888",
+			"label[8.38,1.7;" .. core.colorize("#888888",
 					fgettext("Waving Leaves")) .. "]" ..
-			"label[8.38,3.2;" .. core.colorize("#888888",
+			"label[8.38,2.2;" .. core.colorize("#888888",
 					fgettext("Waving Plants")) .. "]"
 	end
 
@@ -263,16 +255,8 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 		end
 		return true
 	end
-	if fields["cb_bumpmapping"] then
-		core.settings:set("enable_bumpmapping", fields["cb_bumpmapping"])
-		return true
-	end
 	if fields["cb_tonemapping"] then
 		core.settings:set("tone_mapping", fields["cb_tonemapping"])
-		return true
-	end
-	if fields["cb_parallax"] then
-		core.settings:set("enable_parallax_occlusion", fields["cb_parallax"])
 		return true
 	end
 	if fields["cb_waving_water"] then

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -546,31 +546,6 @@ shader_path (Shader path) path
 #    enhanced, highlights and shadows are gradually compressed.
 tone_mapping (Filmic tone mapping) bool false
 
-[***Bumpmapping]
-
-#    Enables bumpmapping for textures. Normalmaps need to be supplied by the texture pack.
-#    Requires shaders to be enabled.
-enable_bumpmapping (Bumpmapping) bool false
-
-[***Parallax Occlusion]
-
-#    Enables parallax occlusion mapping.
-#    Requires shaders to be enabled.
-enable_parallax_occlusion (Parallax occlusion) bool false
-
-#    0 = parallax occlusion with slope information (faster).
-#    1 = relief mapping (slower, more accurate).
-parallax_occlusion_mode (Parallax occlusion mode) int 1 0 1
-
-#    Number of parallax occlusion iterations.
-parallax_occlusion_iterations (Parallax occlusion iterations) int 4
-
-#    Overall scale of parallax occlusion effect.
-parallax_occlusion_scale (Parallax occlusion scale) float 0.08
-
-#    Overall bias of parallax occlusion effect, usually scale/2.
-parallax_occlusion_bias (Parallax occlusion bias) float 0.04
-
 [***Waving Nodes]
 
 #    Set to true to enable waving liquids (like water).

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -1,6 +1,4 @@
 uniform sampler2D baseTexture;
-uniform sampler2D normalTexture;
-uniform sampler2D textureFlags;
 
 uniform vec4 skyBgColor;
 uniform float fogDistance;
@@ -17,17 +15,9 @@ varying vec3 vPosition;
 // cameraOffset + worldPosition (for large coordinates the limits of float
 // precision must be considered).
 varying vec3 worldPosition;
-varying float area_enable_parallax;
 
 varying vec3 eyeVec;
-varying vec3 tsEyeVec;
-varying vec3 lightVec;
-varying vec3 tsLightVec;
 
-bool normalTexturePresent = false;
-
-const float e = 2.718281828459;
-const float BS = 10.0;
 const float fogStart = FOG_START;
 const float fogShadingParameter = 1 / ( 1 - fogStart);
 
@@ -63,87 +53,10 @@ vec4 applyToneMapping(vec4 color)
 }
 #endif
 
-void get_texture_flags()
-{
-	vec4 flags = texture2D(textureFlags, vec2(0.0, 0.0));
-	if (flags.r > 0.5) {
-		normalTexturePresent = true;
-	}
-}
-
-vec4 get_normal_map(vec2 uv)
-{
-	vec4 bump = texture2D(normalTexture, uv).rgba;
-	bump.xyz = normalize(bump.xyz * 2.0 - 1.0);
-	return bump;
-}
-
-float find_intersection(vec2 dp, vec2 ds)
-{
-	float depth = 1.0;
-	float best_depth = 0.0;
-	float size = 0.0625;
-	for (int i = 0; i < 15; i++) {
-		depth -= size;
-		float h = texture2D(normalTexture, dp + ds * depth).a;
-		if (depth <= h) {
-			best_depth = depth;
-			break;
-		}
-	}
-	depth = best_depth;
-	for (int i = 0; i < 4; i++) {
-		size *= 0.5;
-		float h = texture2D(normalTexture,dp + ds * depth).a;
-		if (depth <= h) {
-			best_depth = depth;
-			depth += size;
-		} else {
-			depth -= size;
-		}
-	}
-	return best_depth;
-}
-
 void main(void)
 {
 	vec3 color;
-	vec4 bump;
 	vec2 uv = gl_TexCoord[0].st;
-	bool use_normalmap = false;
-	get_texture_flags();
-
-#ifdef ENABLE_PARALLAX_OCCLUSION
-	vec2 eyeRay = vec2 (tsEyeVec.x, -tsEyeVec.y);
-	const float scale = PARALLAX_OCCLUSION_SCALE / PARALLAX_OCCLUSION_ITERATIONS;
-	const float bias = PARALLAX_OCCLUSION_BIAS / PARALLAX_OCCLUSION_ITERATIONS;
-
-#if PARALLAX_OCCLUSION_MODE == 0
-	// Parallax occlusion with slope information
-	if (normalTexturePresent && area_enable_parallax > 0.0) {
-		for (int i = 0; i < PARALLAX_OCCLUSION_ITERATIONS; i++) {
-			vec4 normal = texture2D(normalTexture, uv.xy);
-			float h = normal.a * scale - bias;
-			uv += h * normal.z * eyeRay;
-		}
-	}
-#endif
-#if PARALLAX_OCCLUSION_MODE == 1
-	// Relief mapping
-	if (normalTexturePresent && area_enable_parallax > 0.0) {
-		vec2 ds = eyeRay * PARALLAX_OCCLUSION_SCALE;
-		float dist = find_intersection(uv, ds);
-		uv += dist * ds;
-	}
-#endif
-#endif
-
-#if USE_NORMALMAPS == 1
-	if (normalTexturePresent) {
-		bump = get_normal_map(uv);
-		use_normalmap = true;
-	}
-#endif
 
 	vec4 base = texture2D(baseTexture, uv).rgba;
 
@@ -155,19 +68,7 @@ void main(void)
 	}
 #endif
 
-#ifdef ENABLE_BUMPMAPPING
-	if (use_normalmap) {
-		vec3 L = normalize(lightVec);
-		vec3 E = normalize(eyeVec);
-		float specular = pow(clamp(dot(reflect(L, bump.xyz), E), 0.0, 1.0), 1.0);
-		float diffuse = dot(-E,bump.xyz);
-		color = (diffuse + 0.1 * specular) * base.rgb;
-	} else {
-		color = base.rgb;
-	}
-#else
 	color = base.rgb;
-#endif
 
 	vec4 col = vec4(color.rgb * gl_Color.rgb, 1.0); 
 	

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -18,10 +18,6 @@ varying vec3 vPosition;
 varying vec3 worldPosition;
 
 varying vec3 eyeVec;
-varying vec3 lightVec;
-varying vec3 tsEyeVec;
-varying vec3 tsLightVec;
-varying float area_enable_parallax;
 
 // Color of the light emitted by the light sources.
 const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
@@ -86,21 +82,9 @@ float snoise(vec3 p)
 void main(void)
 {
 	gl_TexCoord[0] = gl_MultiTexCoord0;
-	//TODO: make offset depending on view angle and parallax uv displacement
-	//thats for textures that doesnt align vertically, like dirt with grass
-	//gl_TexCoord[0].y += 0.008;
 
-	//Allow parallax/relief mapping only for certain kind of nodes
-	//Variable is also used to control area of the effect
-#if (DRAW_TYPE == NDT_NORMAL || DRAW_TYPE == NDT_LIQUID || DRAW_TYPE == NDT_FLOWINGLIQUID)
-	area_enable_parallax = 1.0;
-#else
-	area_enable_parallax = 0.0;
-#endif
-
-
-float disp_x;
-float disp_z;
+	float disp_x;
+	float disp_z;
 // OpenGL < 4.3 does not support continued preprocessor lines
 #if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES) || (MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS)
 	vec4 pos2 = mWorld * gl_Vertex;
@@ -148,32 +132,7 @@ float disp_z;
 
 	vPosition = gl_Position.xyz;
 
-	// Don't generate heightmaps when too far from the eye
-	float dist = distance (vec3(0.0, 0.0, 0.0), vPosition);
-	if (dist > 150.0) {
-		area_enable_parallax = 0.0;
-	}
-
-	vec3 sunPosition = vec3 (0.0, eyePosition.y * BS + 900.0, 0.0);
-
-	vec3 normal, tangent, binormal;
-	normal = normalize(gl_NormalMatrix * gl_Normal);
-	tangent = normalize(gl_NormalMatrix * gl_MultiTexCoord1.xyz);
-	binormal = normalize(gl_NormalMatrix * gl_MultiTexCoord2.xyz);
-
-	vec3 v;
-
-	lightVec = sunPosition - worldPosition;
-	v.x = dot(lightVec, tangent);
-	v.y = dot(lightVec, binormal);
-	v.z = dot(lightVec, normal);
-	tsLightVec = normalize (v);
-
 	eyeVec = -(gl_ModelViewMatrix * gl_Vertex).xyz;
-	v.x = dot(eyeVec, tangent);
-	v.y = dot(eyeVec, binormal);
-	v.z = dot(eyeVec, normal);
-	tsEyeVec = normalize (v);
 
 	// Calculate color.
 	// Red, green and blue components are pre-multiplied with

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -1,6 +1,4 @@
 uniform sampler2D baseTexture;
-uniform sampler2D normalTexture;
-uniform sampler2D textureFlags;
 
 uniform vec4 emissiveColor;
 uniform vec4 skyBgColor;
@@ -12,13 +10,7 @@ varying vec3 vPosition;
 varying vec3 worldPosition;
 
 varying vec3 eyeVec;
-varying vec3 lightVec;
 varying float vIDiff;
-
-bool normalTexturePresent = false;
-bool texTileableHorizontal = false;
-bool texTileableVertical = false;
-bool texSeamless = false;
 
 const float e = 2.718281828459;
 const float BS = 10.0;
@@ -57,44 +49,10 @@ vec4 applyToneMapping(vec4 color)
 }
 #endif
 
-void get_texture_flags()
-{
-	vec4 flags = texture2D(textureFlags, vec2(0.0, 0.0));
-	if (flags.r > 0.5) {
-		normalTexturePresent = true;
-	}
-	if (flags.g > 0.5) {
-		texTileableHorizontal = true;
-	}
-	if (flags.b > 0.5) {
-		texTileableVertical = true;
-	}
-	if (texTileableHorizontal && texTileableVertical) {
-		texSeamless = true;
-	}
-}
-
-vec4 get_normal_map(vec2 uv)
-{
-	vec4 bump = texture2D(normalTexture, uv).rgba;
-	bump.xyz = normalize(bump.xyz * 2.0 - 1.0);
-	return bump;
-}
-
 void main(void)
 {
 	vec3 color;
-	vec4 bump;
 	vec2 uv = gl_TexCoord[0].st;
-	bool use_normalmap = false;
-	get_texture_flags();
-
-#if USE_NORMALMAPS == 1
-	if (normalTexturePresent) {
-		bump = get_normal_map(uv);
-		use_normalmap = true;
-	}
-#endif
 
 	vec4 base = texture2D(baseTexture, uv).rgba;
 
@@ -106,19 +64,7 @@ void main(void)
 	}
 #endif
 
-#ifdef ENABLE_BUMPMAPPING
-	if (use_normalmap) {
-		vec3 L = normalize(lightVec);
-		vec3 E = normalize(eyeVec);
-		float specular = pow(clamp(dot(reflect(L, bump.xyz), E), 0.0, 1.0), 1.0);
-		float diffuse = dot(-E,bump.xyz);
-		color = (diffuse + 0.1 * specular) * base.rgb;
-	} else {
-		color = base.rgb;
-	}
-#else
 	color = base.rgb;
-#endif
 
 	vec4 col = vec4(color.rgb, base.a);
 

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -9,7 +9,6 @@ varying vec3 vPosition;
 varying vec3 worldPosition;
 
 varying vec3 eyeVec;
-varying vec3 lightVec;
 varying float vIDiff;
 
 const float e = 2.718281828459;
@@ -33,10 +32,6 @@ void main(void)
 	vPosition = gl_Position.xyz;
 	vNormal = gl_Normal;
 	worldPosition = (mWorld * gl_Vertex).xyz;
-
-	vec3 sunPosition = vec3 (0.0, eyePosition.y * BS + 900.0, 0.0);
-
-	lightVec = sunPosition - worldPosition;
 	eyeVec = -(gl_ModelViewMatrix * gl_Vertex).xyz;
 
 #if (MATERIAL_TYPE == TILE_MATERIAL_PLAIN) || (MATERIAL_TYPE == TILE_MATERIAL_PLAIN_ALPHA)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -401,35 +401,6 @@ stripping out the file extension:
 * e.g. `foomod_foothing`
 
 
-Normalmap Textures
-------------------
-
-If shaders and bumpmapping or parallax occlusion is enabled, Minetest tries
-to load normalmaps.
-Those image files have to end with `_normal.png` and start with the same name
-as their corresponding texture.
-For example a normalmap for `foomod_foothing.png` has to be called
-`foomod_foothing_normal.png`.
-
-The sRGB R, G and B colour values of a normalmap pixel are each directly
-mapped from `{0, ..., 255}` to `[-1, 1]` and, taken together,
-define the normal vector.
-The alpha channel defines the heightmap for parallax occlusion.
-To be safe, the alpha values should always be bigger than zero
-because the colour values, which define the normal vector,
-may be undefined for image formats where colour is discarded in fully
-transparent pixels.
-
-Bumpmapping and parallax occlusion are currently experimental features:
-
-* Bumpmapping in Minetest happens in an obscure way; there are no light sources
-  defined in the shaders except the sunlight direction.
-* Parallax occlusion with relief-mapping mode does not yet work correctly
-  together with Minetest's Fastfaces.
-* The normalmap files must end with `.png`, so other image files are not
-  supported.
-
-
 Texture modifiers
 -----------------
 
@@ -834,7 +805,7 @@ Example (colored grass block):
         -- Overlay tiles: define them in the same style
         -- The top and bottom tile does not have overlay
         overlay_tiles = {"", "",
-            {name = "default_grass_side.png", tileable_vertical = false}},
+            {name = "default_grass_side.png"}},
         -- Global color, used in inventory
         color = "green",
         -- Palette in the world
@@ -1204,7 +1175,7 @@ Look for examples in `games/devtest` or `games/minetest_game`.
       base cube without affecting them.
     * The base cube texture tiles are defined as normal, the `plantlike`
       extension uses the defined special tile, for example:
-      `special_tiles = {{name = "default_papyrus.png", tileable_vertical = true}},`
+      `special_tiles = {{name = "default_papyrus.png"}},`
 
 `*_optional` drawtypes need less rendering time if deactivated
 (always client-side).
@@ -7041,13 +7012,8 @@ Tile definition
 
 * `"image.png"`
 * `{name="image.png", animation={Tile Animation definition}}`
-* `{name="image.png", backface_culling=bool, tileable_vertical=bool,
-  tileable_horizontal=bool, align_style="node"/"world"/"user", scale=int}`
+* `{name="image.png", backface_culling=bool, align_style="node"/"world"/"user", scale=int}`
     * backface culling enabled by default for most nodes
-    * tileable flags are info for shaders, how they should treat texture
-      when displacement mapping is used.
-      Directions are from the point of view of the tile texture,
-      not the node it's on.
     * align style determines whether the texture will be rotated with the node
       or kept aligned with its surroundings. "user" means that client
       setting will be used, similar to `glasslike_framed_optional`.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -430,8 +430,6 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<float, 3> m_camera_offset_pixel;
 	CachedPixelShaderSetting<float, 3> m_camera_offset_vertex;
 	CachedPixelShaderSetting<SamplerLayer_t> m_base_texture;
-	CachedPixelShaderSetting<SamplerLayer_t> m_normal_texture;
-	CachedPixelShaderSetting<SamplerLayer_t> m_texture_flags;
 	Client *m_client;
 
 public:
@@ -464,8 +462,6 @@ public:
 		m_camera_offset_pixel("cameraOffset"),
 		m_camera_offset_vertex("cameraOffset"),
 		m_base_texture("baseTexture"),
-		m_normal_texture("normalTexture"),
-		m_texture_flags("textureFlags"),
 		m_client(client)
 	{
 		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
@@ -553,12 +549,8 @@ public:
 		m_camera_offset_pixel.set(camera_offset_array, services);
 		m_camera_offset_vertex.set(camera_offset_array, services);
 
-		SamplerLayer_t base_tex = 0,
-				normal_tex = 1,
-				flags_tex = 2;
+		SamplerLayer_t base_tex = 0;
 		m_base_texture.set(&base_tex, services);
-		m_normal_texture.set(&normal_tex, services);
-		m_texture_flags.set(&flags_tex, services);
 	}
 };
 

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -45,10 +45,8 @@ struct MeshMakeData
 
 	Client *m_client;
 	bool m_use_shaders;
-	bool m_use_tangent_vertices;
 
-	MeshMakeData(Client *client, bool use_shaders,
-			bool use_tangent_vertices = false);
+	MeshMakeData(Client *client, bool use_shaders);
 
 	/*
 		Copy block data manually (to allow optimizations by the caller)
@@ -136,7 +134,6 @@ private:
 	IShaderSource *m_shdrsrc;
 
 	bool m_enable_shaders;
-	bool m_use_tangent_vertices;
 	bool m_enable_vbo;
 
 	// Must animate() be called before rendering?

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -52,9 +52,6 @@ MeshUpdateQueue::MeshUpdateQueue(Client *client):
 	m_client(client)
 {
 	m_cache_enable_shaders = g_settings->getBool("enable_shaders");
-	m_cache_use_tangent_vertices = m_cache_enable_shaders && (
-		g_settings->getBool("enable_bumpmapping") ||
-		g_settings->getBool("enable_parallax_occlusion"));
 	m_cache_smooth_lighting = g_settings->getBool("smooth_lighting");
 	m_meshgen_block_cache_size = g_settings->getS32("meshgen_block_cache_size");
 }
@@ -207,8 +204,7 @@ CachedMapBlockData* MeshUpdateQueue::getCachedBlock(const v3s16 &p)
 
 void MeshUpdateQueue::fillDataFromMapBlockCache(QueuedMeshUpdate *q)
 {
-	MeshMakeData *data = new MeshMakeData(m_client, m_cache_enable_shaders,
-			m_cache_use_tangent_vertices);
+	MeshMakeData *data = new MeshMakeData(m_client, m_cache_enable_shaders);
 	q->data = data;
 
 	data->fillBlockDataBegin(q->p);

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -88,7 +88,6 @@ private:
 
 	// TODO: Add callback to update these when g_settings changes
 	bool m_cache_enable_shaders;
-	bool m_cache_use_tangent_vertices;
 	bool m_cache_smooth_lighting;
 	int m_meshgen_block_cache_size;
 

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -688,35 +688,6 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 	shaders_header += itos(drawtype);
 	shaders_header += "\n";
 
-	if (g_settings->getBool("enable_bumpmapping"))
-		shaders_header += "#define ENABLE_BUMPMAPPING\n";
-
-	if (g_settings->getBool("enable_parallax_occlusion")){
-		int mode = g_settings->getFloat("parallax_occlusion_mode");
-		float scale = g_settings->getFloat("parallax_occlusion_scale");
-		float bias = g_settings->getFloat("parallax_occlusion_bias");
-		int iterations = g_settings->getFloat("parallax_occlusion_iterations");
-		shaders_header += "#define ENABLE_PARALLAX_OCCLUSION\n";
-		shaders_header += "#define PARALLAX_OCCLUSION_MODE ";
-		shaders_header += itos(mode);
-		shaders_header += "\n";
-		shaders_header += "#define PARALLAX_OCCLUSION_SCALE ";
-		shaders_header += ftos(scale);
-		shaders_header += "\n";
-		shaders_header += "#define PARALLAX_OCCLUSION_BIAS ";
-		shaders_header += ftos(bias);
-		shaders_header += "\n";
-		shaders_header += "#define PARALLAX_OCCLUSION_ITERATIONS ";
-		shaders_header += itos(iterations);
-		shaders_header += "\n";
-	}
-
-	shaders_header += "#define USE_NORMALMAPS ";
-	if (g_settings->getBool("enable_bumpmapping") || g_settings->getBool("enable_parallax_occlusion"))
-		shaders_header += "1\n";
-	else
-		shaders_header += "0\n";
-
 	if (g_settings->getBool("enable_waving_water")){
 		shaders_header += "#define ENABLE_WAVING_WATER 1\n";
 		shaders_header += "#define WATER_WAVE_HEIGHT ";

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -305,7 +305,7 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 
 scene::SMesh *createSpecialNodeMesh(Client *client, content_t id, std::vector<ItemPartColor> *colors, const ContentFeatures &f)
 {
-	MeshMakeData mesh_make_data(client, false, false);
+	MeshMakeData mesh_make_data(client, false);
 	MeshCollector collector;
 	mesh_make_data.setSmoothLighting(false);
 	MapblockMeshGenerator gen(&mesh_make_data, &collector);

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -251,12 +251,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("bilinear_filter", "false");
 	settings->setDefault("trilinear_filter", "false");
 	settings->setDefault("tone_mapping", "false");
-	settings->setDefault("enable_bumpmapping", "false");
-	settings->setDefault("enable_parallax_occlusion", "false");
-	settings->setDefault("parallax_occlusion_mode", "1");
-	settings->setDefault("parallax_occlusion_iterations", "4");
-	settings->setDefault("parallax_occlusion_scale", "0.08");
-	settings->setDefault("parallax_occlusion_bias", "0.04");
 	settings->setDefault("enable_waving_water", "false");
 	settings->setDefault("water_wave_height", "1.0");
 	settings->setDefault("water_wave_length", "20.0");

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -266,9 +266,6 @@ void TextureSettings::readSettings()
 {
 	connected_glass                = g_settings->getBool("connected_glass");
 	opaque_water                   = g_settings->getBool("opaque_water");
-	bool enable_shaders            = g_settings->getBool("enable_shaders");
-	bool enable_bumpmapping        = g_settings->getBool("enable_bumpmapping");
-	bool enable_parallax_occlusion = g_settings->getBool("enable_parallax_occlusion");
 	bool smooth_lighting           = g_settings->getBool("smooth_lighting");
 	enable_mesh_cache              = g_settings->getBool("enable_mesh_cache");
 	enable_minimap                 = g_settings->getBool("enable_minimap");
@@ -281,8 +278,6 @@ void TextureSettings::readSettings()
 	if (smooth_lighting)
 		enable_mesh_cache = false;
 
-	use_normal_texture = enable_shaders &&
-		(enable_bumpmapping || enable_parallax_occlusion);
 	if (leaves_style_str == "fancy") {
 		leaves_style = LEAVES_FANCY;
 	} else if (leaves_style_str == "simple") {
@@ -635,10 +630,6 @@ static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 	if (!tile.world_aligned)
 		layer->scale = 1;
 
-	// Normal texture and shader flags texture
-	if (tsettings.use_normal_texture) {
-		layer->normal_texture = tsrc->getNormalTexture(tiledef.name);
-	}
 	layer->flags_texture = tsrc->getShaderFlagsTexture(layer->normal_texture ? true : false);
 
 	// Material flags

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -158,7 +158,6 @@ public:
 	int node_texture_size;
 	bool opaque_water;
 	bool connected_glass;
-	bool use_normal_texture;
 	bool enable_mesh_cache;
 	bool enable_minimap;
 


### PR DESCRIPTION
See #10479 for discussion.

This PR removes bump mapping, parallax occlusion, and normal mapping code, since it was buggy and not fully implemented.
This simplifies the shader code and hopefully makes it easier to start over.

Note that this also remove the normal texture feature - since it normal textures are no longer used for anything.