### PR TITLE
Avoid drawing invisible blocks on the client.

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -124,12 +124,6 @@ void ClientMap::updateDrawList()
 
 	v3f camera_position = m_camera_position;
 	v3f camera_direction = m_camera_direction;
-	f32 camera_fov = m_camera_fov;
-
-	// Use a higher fov to accomodate faster camera movements.
-	// Blocks are cropped better when they are drawn.
-	// Or maybe they aren't? Well whatever.
-	camera_fov *= 1.2;
 
 	v3s16 cam_pos_nodes = floatToInt(camera_position, BS);
 	v3s16 p_blocks_min;
@@ -190,7 +184,7 @@ void ClientMap::updateDrawList()
 
 			float d = 0.0;
 			if (!isBlockInSight(block->getPos(), camera_position,
-					camera_direction, camera_fov, range, &d))
+					camera_direction, m_camera_fov, range, &d))
 				continue;
 
 


### PR DESCRIPTION
See #10488

The client unnecessarily draws about 20% extra mablocks if (and only if) they are already loaded into the client.
Client and server use isBlockInSight to pick blocks to send or render, resp.

If the server has not sent the blocks this does noting on the client.

isBlockInSight already widens the fov by about 10% (on both client and server).

I tried rapid camera movements, and did not observe any negative effects.
Displaying 20% viewer blocks on the client is significant.
