### PR TITLE
Implemented disconnect_player

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -4,6 +4,16 @@
 -- Misc. API functions
 --
 
+-- @spec core.kick_player(String, String) :: Boolean
+function core.kick_player(player_name, reason)
+	if type(reason) == "string" then
+		reason = "Kicked: " .. reason
+	else
+		reason = "Kicked."
+	end
+	return core.disconnect_player(player_name, reason)
+end
+
 function core.check_player_privs(name, ...)
 	if core.is_player(name) then
 		name = name:get_player_name()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5435,7 +5435,7 @@ Bans
     * Returns boolean indicating success (false if player nonexistant)
 * `minetest.disconnect_player(name, [reason])`: disconnect a player with an
   optional reason, this will not prefix with 'Kicked: ' like kick_player.
-  If no reason is given defaults to 'Disconnected.'
+  If no reason is given, it will default to 'Disconnected.'
     * Returns boolean indicating success (false if player nonexistant)
 
 Particles

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5433,6 +5433,10 @@ Bans
 * `minetest.kick_player(name, [reason])`: disconnect a player with an optional
   reason.
     * Returns boolean indicating success (false if player nonexistant)
+* `minetest.disconnect_player(name, [reason])`: disconnect a player with an
+  optional reason, this will not prefix with 'Kicked: ' like kick_player.
+  If no reason is given defaults to 'Disconnected.'
+    * Returns boolean indicating success (false if player nonexistant)
 
 Particles
 ---------

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -317,16 +317,16 @@ int ModApiServer::l_ban_player(lua_State *L)
 	return 1;
 }
 
-// kick_player(name, [reason]) -> success
-int ModApiServer::l_kick_player(lua_State *L)
+// disconnect_player(name, [reason]) -> success
+int ModApiServer::l_disconnect_player(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	const char *name = luaL_checkstring(L, 1);
-	std::string message("Kicked");
+	std::string message;
 	if (lua_isstring(L, 2))
-		message.append(": ").append(readParam<std::string>(L, 2));
+		message.append(readParam<std::string>(L, 2));
 	else
-		message.append(".");
+		message.append("Disconnected.");
 
 	RemotePlayer *player = dynamic_cast<ServerEnvironment *>(getEnv(L))->getPlayer(name);
 	if (player == NULL) {
@@ -561,7 +561,7 @@ void ModApiServer::Initialize(lua_State *L, int top)
 	API_FCT(get_ban_list);
 	API_FCT(get_ban_description);
 	API_FCT(ban_player);
-	API_FCT(kick_player);
+	API_FCT(disconnect_player);
 	API_FCT(remove_player);
 	API_FCT(unban_player_or_ip);
 	API_FCT(notify_authentication_modified);

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -94,8 +94,8 @@ private:
 	// unban_player_or_ip()
 	static int l_unban_player_or_ip(lua_State *L);
 
-	// kick_player(name, [message]) -> success
-	static int l_kick_player(lua_State *L);
+	// disconnect_player(name, [reason]) -> success
+	static int l_disconnect_player(lua_State *L);
 
 	// remove_player(name)
 	static int l_remove_player(lua_State *L);


### PR DESCRIPTION
By reusing `kick_player`'s original implementation but removing the default prefix (i.e. Kicked) and then reimplementing `kick_player/2` in lua using `disconnect_player/2` as the backend

Fixes #10490

I do have one question, when is:

```cpp
// 13/03/15: remove this function when protocol version 25 will become
// the minimum version for MT users, maybe in 1 year
void Server::DenyAccess_Legacy(session_t peer_id, const std::wstring &reason)
```

Going to be removed, seeing as that note is over 5 years old

## To do

* [x] Test, ~~I don't have a server at the moment to test this with, unless I can disconnect myself~~ Lejo1 has confirmed it works

## How to test

```lua
-- minetest.disconnect_player(player_name, [reason])

minetest.disconnect_player("HackerMan", "we don't appreciate hackers")

-- console displays:
--   Access Denied: we don't appreciate hackers
```
