### PR TITLE
Devtest: Automatically enable zoom capability

### DIFF
--- a/games/devtest/README.md
+++ b/games/devtest/README.md
@@ -23,7 +23,6 @@ Basically, just create a world and start. A few important things to note:
 * Use the `/infplace` command to toggle infinite node placement in-game
 * Use the Param2 Tool to change the param2 of nodes; it's useful to experiment with the various drawtype test nodes
 * Check out the game settings and server commands for additional tests and features
-* Creative Mode does nothing (apart from default engine behavior)
 
 Confused by a certain node or item? Check out for inline code comments. The usages of most tools are explained in their tooltips.
 

--- a/games/devtest/mods/util_commands/init.lua
+++ b/games/devtest/mods/util_commands/init.lua
@@ -36,8 +36,12 @@ minetest.register_chatcommand("hp", {
 	end,
 })
 
-minetest.register_chatcommand("zoom", {
-	params = "[<zoom_fov>]",
+minetest.register_on_joinplayer(function(player)
+	player:set_properties({zoom_fov = 15})
+end)
+
+minetest.register_chatcommand("zoomfov", {
+	params = "[<FOV>]",
 	description = "Set or display your zoom_fov",
 	func = function(name, param)
 		local player = minetest.get_player_by_name(name)
@@ -57,8 +61,6 @@ minetest.register_chatcommand("zoom", {
 		return true, "zoom_fov = "..tostring(fov)
 	end,
 })
-
-
 
 local s_infplace = minetest.settings:get("devtest_infplace")
 if s_infplace == "true" then


### PR DESCRIPTION
 Devtest: Automatically enable zoom capability

Make minor improvements to the zoom testing chat command.
Delete incorrect line about creative mode from README.md.
////////////////////////////////

Very simple PR.

Currently, the zoom key is not automatically functional in devtest as zoom FOV is a player property that defaults to disabled in the engine. To enable zoom the zoom FOV must be reset using the devtest zoom FOV chat command.

This PR automatically sets zoom FOV to 15 (the classic standard zoom strength and the zoom strength enabled in creative mode in MTG). This saves developer time. A medium power zoom is useful for testing in various ways.

This PR also:
* Changes the zoom chat command command name to make it more descriptive.
* Deletes an incorrect line in README.md. Creative mode enables infinite placement and special hand tool capabilities.