### PR TITLE
Rely on max_simultaneous_block_sends_per_client to limit blocks sent to the client.

### DIFF
--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -364,7 +364,6 @@ private:
 	std::set<v3s16> m_blocks_sent;
 	s16 m_nearest_unsent_d = 0;
 	v3s16 m_last_center;
-	float m_nearest_unsent_reset_timer = 0.0f;
 
 	const u16 m_max_simul_sends;
 	const float m_min_time_from_building;


### PR DESCRIPTION
In clientiface we have two mechanisms to limit how many blocks are sent to the client simultaneously:

1. The `max_simultaneous_block_sends_per_client` setting (defaults to 40 blocks)
2. A hardcoded mechanism that send blocks in rounds of increasing distance.

(2) tends to severely limit data sent per roundtrip, which slows down the transfer of blocks from the server to the client, especially on client with high network latency.

We should instead only rely the explicit setting.

With a local server and a view-range of 240 that reduces the time to transfer the blocks by 50%! (i.e. the scene is rendered twice as fast)

This also gets rid of some old creaky code where we every 20s reset the last sent-distance and start again from 0 in case there any bugs. (?)

Have a look. I'm always looking for way for MT to increase the view distance without loosing performance.