### PR TITLE
Periodically release all mesh HW buffers to avoid an Irrlicht bottleneck

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -917,6 +917,7 @@ private:
 
 	bool m_does_lost_focus_pause_game = false;
 
+	int m_reset_HW_buffer_counter = 0;
 #ifdef __ANDROID__
 	bool m_cache_hold_aux1;
 	bool m_android_chat_open;
@@ -3694,7 +3695,6 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 	camera->setDigging(0);  // Dig animation
 }
 
-
 void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		const CameraOrientation &cam)
 {
@@ -3945,6 +3945,27 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	/*
 		End scene
 	*/
+	if (++m_reset_HW_buffer_counter > 500) {
+		/*
+		  Periodically remove all mesh HW buffers.
+
+		  Work around for a quirk in Irrlicht where a HW buffer is only
+		  released after 20000 iterations (triggered from endScene()).
+
+		  Without this, all loaded but unused meshes will retain their HW
+		  buffers for at least 5 minutes, at which point looking up the HW buffers
+		  becomes a bottleneck and the framerate drops (as much as 30%).
+
+		  Tests showed that numbers between 50 and 1000 are good, so picked 500.
+		  There are no other public Irrlicht APIs that allow interacting with the
+		  HW buffers without tracking the status of every individual mesh.
+
+		  The HW buffers for _visible_ meshes will be reinitialized in the next frame.
+		*/
+		infostream << "Game::updateFrame(): Removing all HW buffers." << std::endl;
+		driver->removeAllHardwareBuffers();
+		m_reset_HW_buffer_counter = 0;
+	}
 	driver->endScene();
 
 	stats->drawtime = tt_draw.stop(true);


### PR DESCRIPTION
See long discussion in #10499

Two many cached meshes with HW buffers slow down Irrlicht's buffer lookup during rendering.
The meshes are in the client's cache and many (most) of them are not actually visible, but they still hold on to their HW buffers (VBO).

Determining for which meshes we can release these buffers is not practical. So this simple release all HW buffers periodically. The next frame update will simple reinitialize these buffers, but - crucially - only for visible meshes. Then these buffer are cache for the next few hundred frame, and then released again.

There is no discernable slowdown on the one frame when the buffers are released, since it happens only for a single frame.
I tried this with NVidia and Intel Iris graphics drivers, and this completely gets rid of the severe slowdown described in #10499 of up to 1/3 of FPS with default setting. (I earlier had non-default settings, in which case the slowdown was even worse).

Please have a look.
