### PR TITLE
Pass the PointedThing to the after_use callback

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -552,7 +552,7 @@ function core.node_dig(pos, node, digger, old_pt)
 	local log = make_log(diggername)
 	local def = core.registered_nodes[node.name]
 	if def and (not def.diggable or
-			(def.can_dig and not def.can_dig(pos, digger))) then
+			(def.can_dig and not def.can_dig(pos, digger, old_pt))) then
 		log("info", diggername .. " tried to dig "
 			.. node.name .. " which is not diggable "
 			.. core.pos_to_string(pos))
@@ -633,7 +633,7 @@ function core.node_dig(pos, node, digger, old_pt)
 		-- Copy pos and node because callback can modify them
 		local pos_copy = {x=pos.x, y=pos.y, z=pos.z}
 		local node_copy = {name=node.name, param1=node.param1, param2=node.param2}
-		def.after_dig_node(pos_copy, node_copy, oldmetadata, digger)
+		def.after_dig_node(pos_copy, node_copy, oldmetadata, digger, old_pt)
 	end
 
 	-- Run script hook
@@ -646,7 +646,7 @@ function core.node_dig(pos, node, digger, old_pt)
 		-- Copy pos and node because callback can modify them
 		local pos_copy = {x=pos.x, y=pos.y, z=pos.z}
 		local node_copy = {name=node.name, param1=node.param1, param2=node.param2}
-		callback(pos_copy, node_copy, digger)
+		callback(pos_copy, node_copy, digger, old_pt)
 	end
 end
 

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -547,7 +547,7 @@ function core.handle_node_drops(pos, drops, digger)
 	end
 end
 
-function core.node_dig(pos, node, digger)
+function core.node_dig(pos, node, digger, old_pt)
 	local diggername = user_name(digger)
 	local log = make_log(diggername)
 	local def = core.registered_nodes[node.name]
@@ -579,7 +579,7 @@ function core.node_dig(pos, node, digger)
 		local tp = wielded:get_tool_capabilities()
 		local dp = core.get_dig_params(def and def.groups, tp)
 		if wdef and wdef.after_use then
-			wielded = wdef.after_use(wielded, digger, node, dp) or wielded
+			wielded = wdef.after_use(wielded, digger, node, dp, old_pt) or wielded
 		else
 			-- Wear out tool
 			if not core.is_creative_enabled(diggername) then

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -551,8 +551,11 @@ function core.node_dig(pos, node, digger, old_pt)
 	local diggername = user_name(digger)
 	local log = make_log(diggername)
 	local def = core.registered_nodes[node.name]
+	-- Copy pos and pointed_thing because the callback can modify them.
+	local pos_copy = {x=pos.x, y=pos.y, z=pos.z}
+	local pt_copy = old_pt and table.copy(old_pt)
 	if def and (not def.diggable or
-			(def.can_dig and not def.can_dig(pos, digger, old_pt))) then
+			(def.can_dig and not def.can_dig(pos_copy, digger, pt_copy))) then
 		log("info", diggername .. " tried to dig "
 			.. node.name .. " which is not diggable "
 			.. core.pos_to_string(pos))
@@ -579,7 +582,10 @@ function core.node_dig(pos, node, digger, old_pt)
 		local tp = wielded:get_tool_capabilities()
 		local dp = core.get_dig_params(def and def.groups, tp)
 		if wdef and wdef.after_use then
-			wielded = wdef.after_use(wielded, digger, node, dp, old_pt) or wielded
+			-- Copy node and pointed_thing because the callback can modify them.
+			local node_copy = {name=node.name, param1=node.param1, param2=node.param2}
+			local pt_copy = old_pt and table.copy(old_pt)
+			wielded = wdef.after_use(wielded, digger, node_copy, dp, pt_copy) or wielded
 		else
 			-- Wear out tool
 			if not core.is_creative_enabled(diggername) then
@@ -630,10 +636,11 @@ function core.node_dig(pos, node, digger, old_pt)
 
 	-- Run callback
 	if def and def.after_dig_node then
-		-- Copy pos and node because callback can modify them
+		-- Copy pos, node and pointed_thing because callback can modify them
 		local pos_copy = {x=pos.x, y=pos.y, z=pos.z}
 		local node_copy = {name=node.name, param1=node.param1, param2=node.param2}
-		def.after_dig_node(pos_copy, node_copy, oldmetadata, digger, old_pt)
+		local pt_copy = old_pt and table.copy(old_pt)
+		def.after_dig_node(pos_copy, node_copy, oldmetadata, digger, pt_copy)
 	end
 
 	-- Run script hook
@@ -643,10 +650,11 @@ function core.node_dig(pos, node, digger, old_pt)
 			core.set_last_run_mod(origin.mod)
 		end
 
-		-- Copy pos and node because callback can modify them
+		-- Copy pos, node and pointed_thing because callback can modify them
 		local pos_copy = {x=pos.x, y=pos.y, z=pos.z}
 		local node_copy = {name=node.name, param1=node.param1, param2=node.param2}
-		callback(pos_copy, node_copy, digger, old_pt)
+		local pt_copy = old_pt and table.copy(old_pt)
+		callback(pos_copy, node_copy, digger, pt_copy)
 	end
 end
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5343,7 +5343,7 @@ Defaults for the `on_punch` and `on_dig` node definition callbacks
 
 * `minetest.node_punch(pos, node, puncher, pointed_thing)`
     * Calls functions registered by `minetest.register_on_punchnode()`
-* `minetest.node_dig(pos, node, digger, pointed_thing)`
+* `minetest.node_dig(pos, node[, digger][, pointed_thing])`
     * Checks if node can be dug, puts item into inventory, removes node
     * Calls functions registered by `minetest.registered_on_dignodes()`
 
@@ -7233,6 +7233,9 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         --     return itemstack
         --   end
         -- The user may be any ObjectRef or nil.
+        -- The pointed_thing should be the node dug, but it can also be of 
+        -- type "nothing" or nil, eg, if node_dig was called without the
+        -- player actually mining a node.
 
         _custom_field = whatever,
         -- Add your own custom fields. By convention, all custom field names
@@ -7554,9 +7557,12 @@ Used by `minetest.register_node`.
         -- This function does not get triggered by clients <=0.4.16 if the
         -- "formspec" node metadata field is set.
 
-        on_dig = function(pos, node, digger),
+        on_dig = function(pos, node, digger, pointed_thing),
         -- default: minetest.node_dig
         -- By default checks privileges, wears out tool and removes node.
+        -- The pointed_thing should be the node dug, but it can also be of 
+        -- type "nothing" or nil, eg, if node_dig was called without the
+        -- player actually mining a node.
 
         on_timer = function(pos, elapsed),
         -- default: nil

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5343,7 +5343,7 @@ Defaults for the `on_punch` and `on_dig` node definition callbacks
 
 * `minetest.node_punch(pos, node, puncher, pointed_thing)`
     * Calls functions registered by `minetest.register_on_punchnode()`
-* `minetest.node_dig(pos, node, digger)`
+* `minetest.node_dig(pos, node, digger, pointed_thing)`
     * Checks if node can be dug, puts item into inventory, removes node
     * Calls functions registered by `minetest.registered_on_dignodes()`
 
@@ -7223,7 +7223,7 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         -- The user may be any ObjectRef or nil.
         -- The default functions handle regular use cases.
 
-        after_use = function(itemstack, user, node, digparams),
+        after_use = function(itemstack, user, node, digparams, pointed_thing),
         -- default: nil
         -- If defined, should return an itemstack and will be called instead of
         -- wearing out the tool. If returns nil, does nothing.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4540,8 +4540,11 @@ Call these functions only at load time!
     * `placer` may be any valid ObjectRef or nil.
     * **Not recommended**; use `on_construct` or `after_place_node` in node
       definition whenever possible.
-* `minetest.register_on_dignode(function(pos, oldnode, digger))`
+* `minetest.register_on_dignode(function(pos, oldnode, digger, pointed_thing))`
     * Called when a node has been dug.
+    * The pointed_thing should be the node dug, but it can also be of 
+      type "nothing" or nil, eg, if node_dig was called without the
+      player actually mining a node.
     * **Not recommended**; Use `on_destruct` or `after_dig_node` in node
       definition whenever possible.
 * `minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing))`
@@ -7531,14 +7534,20 @@ Used by `minetest.register_node`.
         -- `placer` may be any valid ObjectRef or nil.
         -- default: nil
 
-        after_dig_node = function(pos, oldnode, oldmetadata, digger),
+        after_dig_node = function(pos, oldnode, oldmetadata, digger, pointed_thing),
         -- oldmetadata is in table format.
+        -- The pointed_thing should be the node dug, but it can also be of 
+        -- type "nothing" or nil, eg, if node_dig was called without the
+        -- player actually mining a node.
         -- Called after destructing node when node was dug using
         -- minetest.node_dig / minetest.dig_node.
         -- default: nil
 
-        can_dig = function(pos, [player]),
+        can_dig = function(pos, [player], pointed_thing),
         -- Returns true if node can be dug, or false if not.
+        -- The pointed_thing should be the node dug, but it can also be of 
+        -- type "nothing" or nil, eg, if node_dig was called without the
+        -- player actually mining a node.
         -- default: nil
 
         on_punch = function(pos, node, puncher, pointed_thing),

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1220,7 +1220,7 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 		/* Actually dig node */
 
 		if (is_valid_dig && n.getContent() != CONTENT_IGNORE)
-			m_script->node_on_dig(p_under, n, playersao);
+			m_script->node_on_dig(p_under, n, playersao, pointed);
 
 		v3s16 blockpos = getNodeBlockPos(p_under);
 		RemoteClient *client = getClient(peer_id);

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -117,7 +117,7 @@ bool ScriptApiNode::node_on_punch(v3s16 p, MapNode node,
 }
 
 bool ScriptApiNode::node_on_dig(v3s16 p, MapNode node,
-		ServerActiveObject *digger)
+		ServerActiveObject *digger, const PointedThing &pointed)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
@@ -133,7 +133,8 @@ bool ScriptApiNode::node_on_dig(v3s16 p, MapNode node,
 	push_v3s16(L, p);
 	pushnode(L, node, ndef);
 	objectrefGetOrCreate(L, digger);
-	PCALL_RES(lua_pcall(L, 3, 0, error_handler));
+	pushPointedThing(pointed);
+	PCALL_RES(lua_pcall(L, 4, 0, error_handler));
 	lua_pop(L, 1);  // Pop error handler
 	return true;
 }

--- a/src/script/cpp_api/s_node.h
+++ b/src/script/cpp_api/s_node.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_base.h"
 #include "cpp_api/s_nodemeta.h"
 #include "util/string.h"
+#include "util/pointedthing.h"
 
 struct MapNode;
 class ServerActiveObject;
@@ -38,7 +39,7 @@ public:
 	bool node_on_punch(v3s16 p, MapNode node,
 			ServerActiveObject *puncher, const PointedThing &pointed);
 	bool node_on_dig(v3s16 p, MapNode node,
-			ServerActiveObject *digger);
+			ServerActiveObject *digger, const PointedThing &pointed);
 	void node_on_construct(v3s16 p, MapNode node);
 	void node_on_destruct(v3s16 p, MapNode node);
 	bool node_on_flood(v3s16 p, MapNode node, MapNode newnode);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -498,7 +498,7 @@ int ModApiEnvMod::l_dig_node(lua_State *L)
 	}
 	// Dig it out with a NULL digger (appears in Lua as a
 	// non-functional ObjectRef)
-	bool success = scriptIfaceNode->node_on_dig(pos, n, NULL);
+	bool success = scriptIfaceNode->node_on_dig(pos, n, NULL, PointedThing());
 	lua_pushboolean(L, success);
 	return 1;
 }


### PR DESCRIPTION
### What/Why:
This PR passes the PointedThing the player is looking at to the after_use callback. This is to make tools behave differently depending on the side of the node on which it was dug. A specific use case are tools that dig nodes in an area like, eg, the hammers from Tinkers' Construct. A (still heavily WIP) [implementation](https://github.com/Schoggo/aoe_tools).

### To Do
This PR is Ready for Review.

### How to test
- Make sure the correct PointedThing is passed.
- Make sure it doesn't break other code using the after_use callback.

Edit: I read the part about not having a period at the end of the commit's first line and making the PR from a feature branch after starting to make the PR. If that's a problem and you're interested in the change, you can just close the PR and I'll make a correct one.