### PR TITLE
Release mesh HW buffers after after new meshes were loaded.

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -558,6 +558,8 @@ void Client::step(float dtime)
 				blocks_to_ack.emplace_back(r.p);
 			}
 		}
+		m_new_mesh_count += num_processed_meshes;
+
 		if (blocks_to_ack.size() > 0) {
 				// Acknowledge block(s)
 				sendGotBlocks(blocks_to_ack);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -435,6 +435,12 @@ public:
 	{
 		return m_env.getLocalPlayer()->formspec_prepend;
 	}
+	u32 getNewMeshCount() {
+		return m_new_mesh_count;
+	}
+	void resetNewMeshCount() {
+		m_new_mesh_count = 0;
+	}
 private:
 	void loadMods();
 	bool checkBuiltinIntegrity();
@@ -600,4 +606,5 @@ private:
 	u32 m_csm_restriction_noderange = 8;
 
 	std::unique_ptr<ModChannelMgr> m_modchannel_mgr;
+	u32 m_new_mesh_count = 0;
 };


### PR DESCRIPTION
Alternate way to fix #10499
(other way is #10501)

This PR counts the new meshes since we last released all HW buffers in Irrlicht.
When we loaded a sufficiently number of new meshes (1000 tested well) we release the buffers again.

I do prefer #10501 for its simplicity and "safety", but this is fine too.