### PR TITLE
Formspec: Don't strip palette information on item_image_button[]

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2149,7 +2149,6 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 		std::string label = parts[4];
 
 		label = unescape_string(label);
-		item_name = unescape_string(item_name);
 
 		MY_CHECKPOS("itemimagebutton",0);
 		MY_CHECKGEOM("itemimagebutton",1);


### PR DESCRIPTION
Fixes #10459.

## How to test

In one of devtest's /test_formspec formspecs, use `minetest.itemstring_with_palette("testnodes:color", i)` where `i` is some palette index, on an `image_button` and `item_image_button`.  Make sure index 0 works (#10459 had a problem with that, but I can't reproduce).  For good measure, also test `minetest.itemstring_with_color("testnodes:color", color)` where `color` is some `ColorString`.

(Devtest is so useful and convenient)