### PR TITLE
Avoid resetting the unsent distance unnecessarily on the server.

### DIFF
--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -364,6 +364,7 @@ private:
 	std::set<v3s16> m_blocks_sent;
 	s16 m_nearest_unsent_d = 0;
 	v3s16 m_last_center;
+	v3f m_last_camera_dir;
 
 	const u16 m_max_simul_sends;
 	const float m_min_time_from_building;
@@ -383,10 +384,10 @@ private:
 	std::map<v3s16, float> m_blocks_sending;
 
 	/*
-		Blocks that have been modified since last sending them.
-		These blocks will not be marked as sent, even if the
-		client reports it has received them to account for blocks
-		that are being modified while on the line.
+		Blocks that have been modified since blocks were
+		sent to the client last (getNextBlocks()).
+		This is used to reset the unsent distance, so that
+		modified blocks are resent to the client.
 
 		List of block positions.
 	*/


### PR DESCRIPTION
Each time a block is changed the nearest distance to resend block on the server is set to 0.
Now near blocks are considered again, even when server has progressed to farther blocks, and that takes the server longer to get the far blocks again.

This PR calculates the distances of any refreshed block from the viewer and resets the redraw-distance to that (if smaller than the current redraw-distance).

For large view_ranges (300 or 400) this cuts close to 50% off the time to render a scene on the client.
Zoom at lower view ranges is also rendered about 2x as fast, since it is not constantly resetting the distance to 0 and starting from there. 

For that to work I need to pass the server environment to the the calls that mark a block as unsent... If anyone can think of a better/simpler solution, I'd like to hear it!

A real(tm) solution would be to have the client request exactly the blocks it needs to render the scene with the server only doing range checks on where the blocks are requested, and the server also only pushing any changes to blocks. That is *not* how it works now (see RemoteClient::getNextBlocks(...) in clientiface.cpp. The server knows where the viewer is and keeps sending all blocks the viewer can see - with some weird "nothing to send timers" to reduce the load a bit.
