### PR TITLE
Allow to make stars visible at day

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6535,6 +6535,9 @@ object you are working with still exists.
     * `star_parameters` is a table with the following optional fields:
         * `visible`: Boolean for whether the stars are visible.
             (default: `true`)
+        * `visible_at_day`: Boolean for whether the stars are visible at day.
+            No effect if `visible` is false.
+            (default: `false`)
         * `count`: Integer number to set the number of stars in
             the skybox. Only applies to `"skybox"` and `"regular"` sky types.
             (default: `1000`)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2843,6 +2843,7 @@ void Game::handleClientEvent_SetStars(ClientEvent *event, CameraOrientation *cam
 	sky->setStarCount(event->star_params->count, false);
 	sky->setStarColor(event->star_params->starcolor);
 	sky->setStarScale(event->star_params->scale);
+	sky->setStarsVisibleAtDay(event->star_params->visible_at_day);
 	delete event->star_params;
 }
 

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -700,7 +700,7 @@ void Sky::draw_stars(video::IVideoDriver * driver, float wicked_time_of_day)
 	if (m_star_params.visible_at_day)
 		starbrightness = 1.0f;
 	else
-		starbrightness = clamp((0.25f - fabsf(tod)) * 20.0f, 0.0f, 1.0f);
+		starbrightness = (0.25f - fabsf(tod)) * 20.0f;
 
 	m_star_color = m_star_params.starcolor;
 	m_star_color.a *= clamp(starbrightness, 0.0f, 1.0f);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -700,7 +700,8 @@ void Sky::draw_stars(video::IVideoDriver * driver, float wicked_time_of_day)
 	if (m_star_params.visible_at_day)
 		starbrightness = 1.0f;
 	else
-	starbrightness = clamp((0.25f - fabsf(tod)) * 20.0f, 0.0f, 1.0f);
+		starbrightness = clamp((0.25f - fabsf(tod)) * 20.0f, 0.0f, 1.0f);
+
 	m_star_color = m_star_params.starcolor;
 	m_star_color.a *= clamp(starbrightness, 0.0f, 1.0f);
 	if (m_star_color.a <= 0.0f) // Stars are only drawn when not fully transparent

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -696,7 +696,11 @@ void Sky::draw_stars(video::IVideoDriver * driver, float wicked_time_of_day)
 	// to time 4000.
 
 	float tod = wicked_time_of_day < 0.5f ? wicked_time_of_day : (1.0f - wicked_time_of_day);
-	float starbrightness = (0.25f - fabsf(tod)) * 20.0f;
+	float starbrightness;
+	if (m_star_params.visible_at_day)
+		starbrightness = 1.0f;
+	else
+	starbrightness = clamp((0.25f - fabsf(tod)) * 20.0f, 0.0f, 1.0f);
 	m_star_color = m_star_params.starcolor;
 	m_star_color.a *= clamp(starbrightness, 0.0f, 1.0f);
 	if (m_star_color.a <= 0.0f) // Stars are only drawn when not fully transparent

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -80,6 +80,7 @@ public:
 	void setStarCount(u16 star_count, bool force_update);
 	void setStarColor(video::SColor star_color) { m_star_params.starcolor = star_color; }
 	void setStarScale(f32 star_scale) { m_star_params.scale = star_scale; updateStars(); }
+	void setStarsVisibleAtDay(bool stars_visible_at_day) { m_star_params.visible_at_day = stars_visible_at_day; }
 
 	bool getCloudsVisible() const { return m_clouds_visible && m_clouds_enabled; }
 	const video::SColorf &getCloudColor() const { return m_cloudcolor_f; }

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1324,7 +1324,7 @@ void Client::handleCommand_HudSetMoon(NetworkPacket *pkt)
 
 void Client::handleCommand_HudSetStars(NetworkPacket *pkt)
 {
-	StarParams stars;
+	StarParams stars = SkyboxDefaults().getStarDefaults();
 
 	*pkt >> stars.visible >> stars.count
 		>> stars.starcolor >> stars.scale;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1328,6 +1328,9 @@ void Client::handleCommand_HudSetStars(NetworkPacket *pkt)
 
 	*pkt >> stars.visible >> stars.count
 		>> stars.starcolor >> stars.scale;
+	try {
+		*pkt >> stars.visible_at_day;
+	} catch (PacketError &e) {};
 
 	ClientEvent *event = new ClientEvent();
 	event->type        = CE_SET_STARS;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -734,6 +734,7 @@ enum ToClientCommand
 		u32 count
 		u8[4] starcolor (ARGB)
 		f32 scale
+		bool visible_at_day
 	*/
 
 	TOCLIENT_SRP_BYTES_S_B = 0x60,

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2044,6 +2044,9 @@ int ObjectRef::l_set_stars(lua_State *L)
 	star_params.scale = getfloatfield_default(L, 2,
 		"scale", star_params.scale);
 
+	star_params.visible_at_day = getboolfield_default(L, 2,
+		"visible_at_day", star_params.visible_at_day);
+
 	getServer(L)->setStars(player, star_params);
 	lua_pushboolean(L, true);
 	return 1;
@@ -2069,6 +2072,8 @@ int ObjectRef::l_get_stars(lua_State *L)
 	lua_setfield(L, -2, "star_color");
 	lua_pushnumber(L, star_params.scale);
 	lua_setfield(L, -2, "scale");
+	lua_pushboolean(L, star_params.visible_at_day);
+	lua_setfield(L, -2, "visible_at_day");
 	return 1;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1759,7 +1759,8 @@ void Server::SendSetStars(session_t peer_id, const StarParams &params)
 	NetworkPacket pkt(TOCLIENT_SET_STARS, 0, peer_id);
 
 	pkt << params.visible << params.count
-		<< params.starcolor << params.scale;
+		<< params.starcolor << params.scale
+		<< params.visible_at_day;
 
 	Send(&pkt);
 }

--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -66,6 +66,7 @@ struct StarParams
 	u32 count;
 	video::SColor starcolor;
 	f32 scale;
+	bool visible_at_day;
 };
 
 // Utility class for setting default sky, sun, moon, stars values:
@@ -116,6 +117,7 @@ public:
 		stars.count = 1000;
 		stars.starcolor = video::SColor(105, 235, 235, 255);
 		stars.scale = 1;
+		stars.visible_at_day = false;
 		return stars;
 	}
 };


### PR DESCRIPTION
This PR adds a new Lua API feature to `player:set_stars`: `visible_at_day`. This is a boolean that, if set to `true`, makes stars visible at the daytime as well. They will no longer fade out after sunrise, but instead they keep their full brightness.

Note: If the `visible` parameter is `false`, it takes precedence.

Fixes #9887.

## Justification

If you want to simulate being in a world with no atmosphere (like the Moon), you want to have the stars visible at any time of day.

## To do

This PR is ready for review.

## How to test

* Activate `luacmd`
* Start DevTest
* `/time 12000`
* Check sky (expected: no stars)
* `/lua me:set_stars({visible_at_day=true})`
* Check sky (expected: visible stars)
* `/lua me:set_stars({visible_at_day=false})`
* Check sky again (expected: no stars)
* `/time 0`
* Check sky again (expected: visible stars)
* `/lua me:set_stars({visible_at_day=true})`
* Check sky again (expected: visible stars)