### PR TITLE
Fix object interaction distance not being checked

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4585,6 +4585,7 @@ Call these functions only at load time!
         * `moved_too_fast`
         * `interacted_too_far`
         * `interacted_while_dead`
+        * `interacted_wrong_direction`
         * `finished_unknown_dig`
         * `dug_unbreakable`
         * `dug_too_fast`
@@ -6173,9 +6174,9 @@ object you are working with still exists.
     * `bone`: string
     * `position`: `{x=num, y=num, z=num}` (relative)
     * `rotation`: `{x=num, y=num, z=num}` = Rotation on each axis, in degrees
-    * `forced_visible`: Boolean to control whether the attached entity 
+    * `forced_visible`: Boolean to control whether the attached entity
        should appear in first person.
-* `get_attach()`: returns parent, bone, position, rotation, forced_visible, 
+* `get_attach()`: returns parent, bone, position, rotation, forced_visible,
     or nil if it isn't attached.
 * `get_children()`: returns a list of ObjectRefs that are attached to the
     object.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4585,7 +4585,6 @@ Call these functions only at load time!
         * `moved_too_fast`
         * `interacted_too_far`
         * `interacted_while_dead`
-        * `interacted_wrong_direction`
         * `finished_unknown_dig`
         * `dug_unbreakable`
         * `dug_too_fast`

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1050,8 +1050,7 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 		}
 		float d = playersao->getEyePosition().getDistanceFrom(target_pos);
 
-		const auto what = pointed.dump();
-		if (!checkInteractDistance(player, d, what)) {
+		if (!checkInteractDistance(player, d, pointed.dump())) {
 			if (pointed.type == POINTEDTHING_NODE) {
 				// Re-send block to revert change on client-side
 				RemoteClient *client = getClient(peer_id);

--- a/src/server.h
+++ b/src/server.h
@@ -482,7 +482,7 @@ private:
 	void DeleteClient(session_t peer_id, ClientDeletionReason reason);
 	void UpdateCrafting(RemotePlayer *player);
 	bool checkInteractDistance(RemotePlayer *player, const f32 d, const std::string &what);
-	bool checkInteractDirection(RemotePlayer *player, v3f target_pos);
+	bool checkInteractDirection(RemotePlayer *player, v3f target_pos, const std::string &what);
 
 	void handleChatInterfaceEvent(ChatEvent *evt);
 

--- a/src/server.h
+++ b/src/server.h
@@ -482,7 +482,6 @@ private:
 	void DeleteClient(session_t peer_id, ClientDeletionReason reason);
 	void UpdateCrafting(RemotePlayer *player);
 	bool checkInteractDistance(RemotePlayer *player, const f32 d, const std::string &what);
-	bool checkInteractDirection(RemotePlayer *player, v3f target_pos, const std::string &what);
 
 	void handleChatInterfaceEvent(ChatEvent *evt);
 

--- a/src/server.h
+++ b/src/server.h
@@ -482,6 +482,7 @@ private:
 	void DeleteClient(session_t peer_id, ClientDeletionReason reason);
 	void UpdateCrafting(RemotePlayer *player);
 	bool checkInteractDistance(RemotePlayer *player, const f32 d, const std::string &what);
+	bool checkInteractDirection(RemotePlayer *player, v3f target_pos);
 
 	void handleChatInterfaceEvent(ChatEvent *evt);
 


### PR DESCRIPTION
This will check that the player is facing towards the thing they are interacting with, using a dot product - meaning a FOV of 180&deg;. It also fixes a bug where the distances between objects weren't checked when punching.

## How to test

You can use killaura from Dragonfire to check this
