### PR TITLE
Remove unwanted truncate speed when no collision detected

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -482,7 +482,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 		if (nearest_collided == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
-			*pos_f += truncate(*speed_f * dtime, 100.0f);
+			*pos_f += *speed_f * dtime;
 			dtime = 0;  // Set to 0 to avoid "infinite" loop due to small FP numbers
 		} else {
 			// Otherwise, a collision occurred.


### PR DESCRIPTION
Closes #10543. Replaces #10546 (please refer to it for details)

Removes a truncate operation on speed that induce some player position and speed bugs.

## To do

This PR is ready for test

Code given in #10543 should display (0, 0, 0) when player stands still on the ground.

Player movements are concerned, should be tested (sneak, climb, fall ...)


