### PR TITLE
Fix CSMs on arm64

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -629,7 +629,11 @@ int ScriptApiSecurity::sl_g_loadfile(lua_State *L)
 {
 #ifndef SERVER
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
+#if INDIRECT_SCRIPTAPI_RIDX
+	ScriptApiBase *script = (ScriptApiBase *) *(void**)(lua_touserdata(L, -1));
+#else
 	ScriptApiBase *script = (ScriptApiBase *) lua_touserdata(L, -1);
+#endif
 	lua_pop(L, 1);
 
 	// Client implementation


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR

Fixes CSMs on arm64/aarch64 architectures.

- How does the PR work?

This fixes a usage of `CUSTOM_RIDX_SCRIPTAPI` when `INDIRECT_SCRIPTAPI_RIDX` is true. Without this fix, the `script->getType()` call near line 636 will return a value from an incorrect memory location.

- Does it resolve any reported issue?

This fixes #9702.

## To do

This PR is a ready for review.

## How to test

Compile MT on arm64, enable CSMs, and make sure they load correctly.
