### PR TITLE
Do not set a default for description in itemdef table

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -118,11 +118,9 @@ function core.register_item(name, itemdef)
 	end
 	itemdef.name = name
 
-	-- default description to item name
-	itemdef.description = itemdef.description or name
 	-- default short_description to first line of description
 	itemdef.short_description = itemdef.short_description or
-		itemdef.description:gsub("\n.*","")
+		(itemdef.description or ""):gsub("\n.*","")
 
 	-- Apply defaults and add to registered_* table
 	if itemdef.type == "node" then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6173,9 +6173,9 @@ object you are working with still exists.
     * `bone`: string
     * `position`: `{x=num, y=num, z=num}` (relative)
     * `rotation`: `{x=num, y=num, z=num}` = Rotation on each axis, in degrees
-    * `forced_visible`: Boolean to control whether the attached entity 
+    * `forced_visible`: Boolean to control whether the attached entity
        should appear in first person.
-* `get_attach()`: returns parent, bone, position, rotation, forced_visible, 
+* `get_attach()`: returns parent, bone, position, rotation, forced_visible,
     or nil if it isn't attached.
 * `get_children()`: returns a list of ObjectRefs that are attached to the
     object.
@@ -7069,7 +7069,8 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
     {
         description = "Steel Axe",
         -- Can contain new lines. "\n" has to be used as new line character.
-        -- Defaults to the item's name.
+        -- If not given or an empty string, the item's name is used instead
+        -- in some places.
 
         short_description = "Steel Axe",
         -- Must not contain new lines.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2023,10 +2023,10 @@ Item metadata only contains a key-value store.
 
 Some of the values in the key-value store are handled specially:
 
-* `description`: Set the item stack's description. Defaults to
-  `idef.description`.
-* `short_description`: Set the item stack's short description. Defaults
-   to `idef.short_description`.
+* `description`: Set the item stack's description.
+  See also: `get_description` in [`ItemStack`]
+* `short_description`: Set the item stack's short description.
+  See also: `get_short_description` in [`ItemStack`]
 * `color`: A `ColorString`, which sets the stack's color.
 * `palette_index`: If the item has a palette, this is used to get the
   current color from the palette.
@@ -5967,8 +5967,18 @@ an itemstring, a table or `nil`.
   stack).
 * `set_metadata(metadata)`: (DEPRECATED) Returns true.
 * `get_description()`: returns the description shown in inventory list tooltips.
+    * The engine uses the same as this function for item descriptions.
+    * Fields for finding the description, in order:
+        * `description` in item metadata (See [Item Metadata].)
+        * `description` in item definition
+        * item name
 * `get_short_description()`: returns the short description.
     * Unlike the description, this does not include new lines.
+    * The engine uses the same as this function for short item descriptions.
+    * Fields for finding the short description, in order:
+        * `short_description` in item metadata (See [Item Metadata].)
+        * `short_description` in item definition
+        * first line of the description (See `get_description()`.)
 * `clear()`: removes all items from the stack, making it empty.
 * `replace(item)`: replace the contents of this stack.
     * `item` can also be an itemstring or table.
@@ -7069,12 +7079,12 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
     {
         description = "Steel Axe",
         -- Can contain new lines. "\n" has to be used as new line character.
-        -- If not given or an empty string, the item's name is used instead
-        -- in some places.
+        -- See also: `get_description` in [`ItemStack`]
 
         short_description = "Steel Axe",
         -- Must not contain new lines.
         -- Defaults to the first line of description.
+        -- See also: `get_short_description` in [`ItemStack`]
 
         groups = {},
         -- key = name, value = rating; rating = 1..3.


### PR DESCRIPTION
- Since #8980, the item's name is used as default for the description in the itemdef table (not `"Steel Axe"`, which would be more consistent). (`item:get_description` also uses the name as default.)
- Some mods rely on being able to set nothing for the description. Eg. `minetest_game` uses this undocumented behaviour to determine whether a node should be in its "creative inventory" (see also https://github.com/minetest/minetest_game/issues/2754).
- This undocumented behaviour is restored.

## To do

This PR is a Ready for Review.

## How to test

- Run the unittests in devtest.
- Open creative inventory in mtg and see no bed top nodes or burning tnt (even though they are not `not_in_creative_inventory` `-´).