### PR TITLE
Auto build client appimage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,36 +142,6 @@ deploy:debian-10:
 ## Ubuntu
 ##
 
-# Trusty
-
-build:ubuntu-14.04:
-  extends: .build_template
-  image: ubuntu:trusty
-  before_script:
-    - echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main" > /etc/apt/sources.list.d/uptodate-toolchain.list
-    - apt-key adv --keyserver keyserver.ubuntu.com --recv BA9EF27F
-    - apt-get update -y
-    - apt-get -y install build-essential gcc-6 g++-6 libirrlicht-dev cmake libbz2-dev libpng-dev libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev
-  variables:
-    CC: gcc-6
-    CXX: g++-6
-
-package:ubuntu-14.04:
-  extends: .debpkg_template
-  image: ubuntu:trusty
-  dependencies:
-    - build:ubuntu-14.04
-  variables:
-    LEVELDB_PKG: libleveldb1
-
-deploy:ubuntu-14.04:
-  extends: .debpkg_install
-  image: ubuntu:trusty
-  dependencies:
-    - package:ubuntu-14.04
-  variables:
-    LEVELDB_PKG: libleveldb1
-
 # Xenial
 
 build:ubuntu-16.04:
@@ -194,6 +164,31 @@ deploy:ubuntu-16.04:
   image: ubuntu:xenial
   dependencies:
     - package:ubuntu-16.04
+  variables:
+    LEVELDB_PKG: libleveldb1v5
+
+# Bionic
+
+build:ubuntu-18.04:
+  extends: .build_template
+  image: ubuntu:bionic
+  before_script:
+    - apt-get update -y
+    - apt-get -y install build-essential libirrlicht-dev cmake libbz2-dev libpng-dev libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev
+
+package:ubuntu-18.04:
+  extends: .debpkg_template
+  image: ubuntu:bionic
+  dependencies:
+    - build:ubuntu-18.04
+  variables:
+    LEVELDB_PKG: libleveldb1v5
+
+deploy:ubuntu-18.04:
+  extends: .debpkg_install
+  image: ubuntu:bionic
+  dependencies:
+    - package:ubuntu-18.04
   variables:
     LEVELDB_PKG: libleveldb1v5
 
@@ -307,4 +302,3 @@ pages:
       - public
   only:
     - master
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ variables:
     - cp misc/debpkg-control build/deb/minetest/DEBIAN/control
     - cp -Rp artifact/minetest/usr build/deb/minetest/
   script:
-    - git clone $MINETEST_GAME_REPO build/deb/minetest/usr/share/minetest/games/minetest
+    - git clone $MINETEST_GAME_REPO build/deb/minetest/usr/share/minetest/games/minetest_game
     - rm -Rf build/deb/minetest/usr/share/minetest/games/minetest/.git
     - sed -i 's/DATEPLACEHOLDER/'$(date +%y.%m.%d)'/g' build/deb/minetest/DEBIAN/control
     - sed -i 's/LEVELDB_PLACEHOLDER/'$LEVELDB_PKG'/g' build/deb/minetest/DEBIAN/control
@@ -302,3 +302,29 @@ pages:
       - public
   only:
     - master
+
+package:appimage-client:
+  stage: package
+  image: appimagecrafters/appimage-builder
+  dependencies:
+    - build:ubuntu-18.04
+  before_script:
+    - apt-get update -y
+    - apt-get install -y git wget
+    # Collect files
+    - mkdir AppDir
+    - cp -a artifact/minetest/usr/ AppDir/usr/
+    - rm AppDir/usr/bin/minetestserver
+    - cp -R clientmods AppDir/usr/share/minetest
+  script:
+    - git clone $MINETEST_GAME_REPO AppDir/usr/share/minetest/games/minetest_game
+    - rm -Rf AppDir/usr/share/minetest/games/minetest/.git
+    - export VERSION=$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA
+    # Remove PrefersNonDefaultGPU=true
+    - sed -i '/PrefersNonDefaultGPU=true/d' AppDir/usr/share/applications/net.minetest.minetest.desktop
+    - appimage-builder --skip-test
+  artifacts:
+    when: on_success
+    expire_in: 90 day
+    paths:
+      - ./*.AppImage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -320,8 +320,8 @@ package:appimage-client:
     - git clone $MINETEST_GAME_REPO AppDir/usr/share/minetest/games/minetest_game
     - rm -Rf AppDir/usr/share/minetest/games/minetest/.git
     - export VERSION=$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA
-    # Remove PrefersNonDefaultGPU=true
-    - sed -i '/PrefersNonDefaultGPU=true/d' AppDir/usr/share/applications/net.minetest.minetest.desktop
+    # Remove PrefersNonDefaultGPU property due to validation errors
+    - sed -i '/PrefersNonDefaultGPU/d' AppDir/usr/share/applications/net.minetest.minetest.desktop
     - appimage-builder --skip-test
   artifacts:
     when: on_success

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -23,7 +23,6 @@ AppDir:
       - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-backports main universe
       - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-security main universe
 
-# Included stuff: libirrlicht-dev libbz2-dev libpng-dev libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev
     include:
       - libirrlicht1.8
       - libxxf86vm1

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,0 +1,52 @@
+version: 1
+
+AppDir:
+  path: ./AppDir
+
+  app_info:
+    id: minetest
+    name: Minetest
+    icon: minetest
+    version: !ENV ${VERSION}
+    exec: usr/bin/minetest
+    exec_args: $@
+  runtime:
+    env:
+      APPDIR_LIBRARY_PATH: $APPDIR/usr/lib/x86_64-linux-gnu
+
+  apt:
+    arch: amd64
+    sources:
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic main universe
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3b4fe6acc0b21f32'
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-updates main universe
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-backports main universe
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-security main universe
+
+# Included stuff: libirrlicht-dev libbz2-dev libpng-dev libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev
+    include:
+      - libirrlicht1.8
+      - libxxf86vm1
+      - libgl1-mesa-glx
+      - libsqlite3-0
+      - libogg0
+      - libvorbis0a
+      - libopenal1
+      - libcurl3-gnutls
+      - libfreetype6
+      - zlib1g
+      - libgmp10
+      - libjsoncpp1
+
+  files:
+    exclude:
+      - usr/share/man
+      - usr/share/doc/*/README.*
+      - usr/share/doc/*/changelog.*
+      - usr/share/doc/*/NEWS.*
+      - usr/share/doc/*/TODO.*
+
+AppImage:
+  update-information: None
+  sign-key: None
+  arch: x86_64


### PR DESCRIPTION
Appimages are easy to use cross compatible files including everything to run the application.
This PR adds an automated build to create a client appimage using appimagebuilder to the gitlab ci

Such appimages are portable and don't require any additional installations.

Thanks to @An0n3m0us and @Calinou for the helping me out!

PR also removes the old ubuntu:14-04 build with the new ubuntu:18-04 build

## To do

This PR is ready to review. Might need some library changes for OS support

- [ ] Test on different linux distributions (Done: Ubuntu, Debian)
- [x] Resolve the Problem in the Desktop file (The builder complains about PrefersNonDefaultGPU=true)
- [x] Clean library list

## How to test

I created a [gitlab Ci](https://gitlab.com/lejo1/minetest/-/pipelines) for my minetest fork.
[Download Appimage](https://gitlab.com/lejo1/minetest/-/jobs/823672224/artifacts/download)