### PR TITLE
Fix ObjectRef crashes due to lua_isnil()

### DIFF
--- a/src/script/common/helper.cpp
+++ b/src/script/common/helper.cpp
@@ -62,9 +62,6 @@ template <> s16 LuaHelper::readParam(lua_State *L, int index)
 
 template <> int LuaHelper::readParam(lua_State *L, int index)
 {
-	if (isNaN(L, index))
-		throw LuaError("NaN value is not allowed.");
-
 	return luaL_checkint(L, index);
 }
 

--- a/src/script/common/helper.cpp
+++ b/src/script/common/helper.cpp
@@ -56,7 +56,7 @@ template <> bool LuaHelper::readParam(lua_State *L, int index)
 
 template <> bool LuaHelper::readParam(lua_State *L, int index, const bool &default_value)
 {
-	if (lua_isnil(L, index))
+	if (lua_type(L, index) == LUA_TNONE)
 		return default_value;
 
 	return lua_toboolean(L, index) != 0;

--- a/src/script/common/helper.cpp
+++ b/src/script/common/helper.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cmath>
 #include <sstream>
 #include <irr_v2d.h>
+#include <irr_v3d.h>
 #include "c_types.h"
 #include "c_internal.h"
 
@@ -54,17 +55,17 @@ template <> bool LuaHelper::readParam(lua_State *L, int index)
 	return lua_toboolean(L, index) != 0;
 }
 
-template <> bool LuaHelper::readParam(lua_State *L, int index, const bool &default_value)
-{
-	if (lua_isnoneornil(L, index))
-		return default_value;
-
-	return lua_toboolean(L, index) != 0;
-}
-
 template <> s16 LuaHelper::readParam(lua_State *L, int index)
 {
 	return lua_tonumber(L, index);
+}
+
+template <> int LuaHelper::readParam(lua_State *L, int index)
+{
+	if (isNaN(L, index))
+		throw LuaError("NaN value is not allowed.");
+
+	return luaL_checkint(L, index);
 }
 
 template <> float LuaHelper::readParam(lua_State *L, int index)
@@ -105,24 +106,30 @@ template <> v2f LuaHelper::readParam(lua_State *L, int index)
 	return p;
 }
 
+template <> v3f LuaHelper::readParam(lua_State *L, int index)
+{
+	v3f p;
+	CHECK_POS_TAB(index);
+	lua_getfield(L, index, "x");
+	CHECK_POS_COORD("x");
+	p.X = readParam<float>(L, -1);
+	lua_pop(L, 1);
+	lua_getfield(L, index, "y");
+	CHECK_POS_COORD("y");
+	p.Y = readParam<float>(L, -1);
+	lua_pop(L, 1);
+	lua_getfield(L, index, "z");
+	CHECK_POS_COORD("z");
+	p.Z = readParam<float>(L, -1);
+	lua_pop(L, 1);
+	return p;
+}
+
 template <> std::string LuaHelper::readParam(lua_State *L, int index)
 {
 	size_t length;
 	std::string result;
 	const char *str = luaL_checklstring(L, index, &length);
 	result.assign(str, length);
-	return result;
-}
-
-template <>
-std::string LuaHelper::readParam(
-		lua_State *L, int index, const std::string &default_value)
-{
-	std::string result;
-	const char *str = lua_tostring(L, index);
-	if (str)
-		result.append(str);
-	else
-		result = default_value;
 	return result;
 }

--- a/src/script/common/helper.cpp
+++ b/src/script/common/helper.cpp
@@ -56,7 +56,7 @@ template <> bool LuaHelper::readParam(lua_State *L, int index)
 
 template <> bool LuaHelper::readParam(lua_State *L, int index, const bool &default_value)
 {
-	if (lua_type(L, index) == LUA_TNONE)
+	if (lua_isnoneornil(L, index))
 		return default_value;
 
 	return lua_toboolean(L, index) != 0;

--- a/src/script/common/helper.h
+++ b/src/script/common/helper.h
@@ -50,5 +50,8 @@ protected:
 	 * @return read value from Lua or default value if nil
 	 */
 	template <typename T>
-	static T readParam(lua_State *L, int index, const T &default_value);
+	static inline T readParam(lua_State *L, int index, const T &default_value)
+	{
+		return lua_isnoneornil(L, index) ? default_value : readParam<T>(L, index);
+	}
 };

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -629,7 +629,11 @@ int ScriptApiSecurity::sl_g_loadfile(lua_State *L)
 {
 #ifndef SERVER
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
+#if INDIRECT_SCRIPTAPI_RIDX
+	ScriptApiBase *script = (ScriptApiBase *) *(void**)(lua_touserdata(L, -1));
+#else
 	ScriptApiBase *script = (ScriptApiBase *) lua_touserdata(L, -1);
+#endif
 	lua_pop(L, 1);
 
 	// Client implementation

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -169,11 +169,9 @@ int ObjectRef::l_punch(lua_State *L)
 	if (sao == nullptr || puncher == nullptr)
 		return 0;
 
-	float time_from_last_punch = lua_isnone(L, 3) ?
-		1000000.0f : readParam<float>(L, 3);
+	float time_from_last_punch = readParam<float>(L, 3, 1000000.0f);
 	ToolCapabilities toolcap = read_tool_capabilities(L, 4);
-	v3f dir = lua_isnone(L, 5) ?
-		sao->getBasePosition() - puncher->getBasePosition() : check_v3f(L, 5);
+	v3f dir = readParam<v3f>(L, 5, sao->getBasePosition() - puncher->getBasePosition());
 
 	dir.normalize();
 	u16 src_original_hp = sao->getHP();
@@ -383,9 +381,9 @@ int ObjectRef::l_set_animation(lua_State *L)
 	if (sao == nullptr)
 		return 0;
 
-	v2f frame_range   = lua_isnone(L, 2) ? v2f(1, 1) : readParam<v2f>(L, 2);
-	float frame_speed = lua_isnone(L, 3) ? 15.0f : readParam<float>(L, 3);
-	float frame_blend = lua_isnone(L, 4) ? 0.0f  : readParam<float>(L, 4);
+	v2f frame_range   = readParam<v2f>(L,  2, v2f(1, 1));
+	float frame_speed = readParam<float>(L, 3, 15.0f);
+	float frame_blend = readParam<float>(L, 4, 0.0f);
 	bool frame_loop   = readParam<bool>(L, 5, true);
 
 	sao->setAnimation(frame_range, frame_speed, frame_blend, frame_loop);
@@ -428,7 +426,7 @@ int ObjectRef::l_set_local_animation(lua_State *L)
 		if (!lua_isnoneornil(L, 2+1))
 			frames[i] = read_v2s32(L, 2+i);
 	}
-	float frame_speed = lua_isnone(L, 6) ? 30.0f : readParam<float>(L, 6);
+	float frame_speed = readParam<float>(L, 6, 30.0f);
 
 	getServer(L)->setLocalPlayerAnimations(player, frames, frame_speed);
 	lua_pushboolean(L, true);
@@ -957,9 +955,9 @@ int ObjectRef::l_set_sprite(lua_State *L)
 	if (entitysao == nullptr)
 		return 0;
 
-	v2s16 start_frame = lua_isnone(L, 2) ? v2s16(0,0) : readParam<v2s16>(L, 2);
-	int num_frames    = lua_isnone(L, 3) ? 1 : luaL_checkint(L, 3);
-	float framelength = lua_isnone(L, 4) ? 0.2f : readParam<float>(L, 4);
+	v2s16 start_frame = readParam<v2s16>(L, 2, v2s16(0,0));
+	int num_frames    = readParam<int>(L, 3, 1);
+	float framelength = readParam<float>(L, 4, 0.2f);
 	bool select_x_by_camera = readParam<bool>(L, 5, false);
 
 	entitysao->setSprite(start_frame, num_frames, framelength, select_x_by_camera);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -384,8 +384,8 @@ int ObjectRef::l_set_animation(lua_State *L)
 		return 0;
 
 	v2f frames = lua_type(L, 2) == LUA_TNONE ? v2f(1, 1) : readParam<v2f>(L, 2);
-	float frame_speed = lua_type(L, 3) == LUA_TNONE ? 15 : readParam<float>(L, 3);
-	float frame_blend = lua_type(L, 4) == LUA_TNONE ? 0  : readParam<float>(L, 4);
+	float frame_speed = lua_type(L, 3) == LUA_TNONE ? 15f : readParam<float>(L, 3);
+	float frame_blend = lua_type(L, 4) == LUA_TNONE ? 0f  : readParam<float>(L, 4);
 	bool frame_loop = readParam<bool>(L, 5, true);
 
 	sao->setAnimation(frames, frame_speed, frame_blend, frame_loop);
@@ -428,7 +428,7 @@ int ObjectRef::l_set_local_animation(lua_State *L)
 		if (!lua_isnil(L, 2+1))
 			frames[i] = read_v2s32(L, 2+i);
 	}
-	float frame_speed = lua_type(L, 6) == LUA_TNONE ? 30 : readParam<float>(L, 6);
+	float frame_speed = lua_type(L, 6) == LUA_TNONE ? 30f : readParam<float>(L, 6);
 
 	getServer(L)->setLocalPlayerAnimations(player, frames, frame_speed);
 	lua_pushboolean(L, true);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -384,8 +384,8 @@ int ObjectRef::l_set_animation(lua_State *L)
 		return 0;
 
 	v2f frames = lua_type(L, 2) == LUA_TNONE ? v2f(1, 1) : readParam<v2f>(L, 2);
-	float frame_speed = lua_type(L, 3) == LUA_TNONE ? 15f : readParam<float>(L, 3);
-	float frame_blend = lua_type(L, 4) == LUA_TNONE ? 0f  : readParam<float>(L, 4);
+	float frame_speed = lua_type(L, 3) == LUA_TNONE ? 15.0f : readParam<float>(L, 3);
+	float frame_blend = lua_type(L, 4) == LUA_TNONE ? 0.0f  : readParam<float>(L, 4);
 	bool frame_loop = readParam<bool>(L, 5, true);
 
 	sao->setAnimation(frames, frame_speed, frame_blend, frame_loop);
@@ -428,7 +428,7 @@ int ObjectRef::l_set_local_animation(lua_State *L)
 		if (!lua_isnil(L, 2+1))
 			frames[i] = read_v2s32(L, 2+i);
 	}
-	float frame_speed = lua_type(L, 6) == LUA_TNONE ? 30f : readParam<float>(L, 6);
+	float frame_speed = lua_type(L, 6) == LUA_TNONE ? 30.0f : readParam<float>(L, 6);
 
 	getServer(L)->setLocalPlayerAnimations(player, frames, frame_speed);
 	lua_pushboolean(L, true);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -354,7 +354,7 @@ int ObjectRef::l_set_armor_groups(lua_State *L)
 	if (sao == nullptr)
 		return 0;
 
-	ItemGlua_type(L, 5) == LUA_TNONEroupList groups;
+	ItemGroupList groups;
 
 	read_groups(L, 2, groups);
 	sao->setArmorGroups(groups);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -423,7 +423,7 @@ int ObjectRef::l_set_local_animation(lua_State *L)
 
 	v2s32 frames[4];
 	for (int i=0;i<4;i++) {
-		if (!lua_isnoneornil(L, 2+1))
+		if (!lua_isnil(L, 2+1))
 			frames[i] = read_v2s32(L, 2+i);
 	}
 	float frame_speed = readParam<float>(L, 6, 30.0f);
@@ -518,7 +518,7 @@ int ObjectRef::l_set_animation_frame_speed(lua_State *L)
 	if (sao == nullptr)
 		return 0;
 
-	if (!lua_isnoneornil(L, 2)) {
+	if (!lua_isnil(L, 2)) {
 		float frame_speed = readParam<float>(L, 2);
 		sao->setAnimationSpeed(frame_speed);
 		lua_pushboolean(L, true);
@@ -1239,7 +1239,7 @@ int ObjectRef::l_set_attribute(lua_State *L)
 		return 0;
 
 	std::string attr = luaL_checkstring(L, 2);
-	if (lua_isnoneornil(L, 3)) {
+	if (lua_isnil(L, 3)) {
 		playersao->getMeta().removeString(attr);
 	} else {
 		std::string value = luaL_checkstring(L, 3);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -169,10 +169,10 @@ int ObjectRef::l_punch(lua_State *L)
 	if (sao == nullptr || puncher == nullptr)
 		return 0;
 
-	float time_from_last_punch = lua_isnil(L, 3) ?
+	float time_from_last_punch = lua_type(L, 3) == LUA_TNONE ?
 		1000000.0f : readParam<float>(L,3);
 	ToolCapabilities toolcap = read_tool_capabilities(L, 4);
-	v3f dir = lua_isnil(L, 5) ?
+	v3f dir = lua_type(L, 5) == LUA_TNONE ?
 		sao->getBasePosition() - puncher->getBasePosition() : check_v3f(L, 5);
 
 	dir.normalize();
@@ -383,18 +383,10 @@ int ObjectRef::l_set_animation(lua_State *L)
 	if (sao == nullptr)
 		return 0;
 
-	v2f frames = v2f(1, 1);
-	if (!lua_isnil(L, 2))
-		frames = readParam<v2f>(L, 2);
-	float frame_speed = 15;
-	if (!lua_isnil(L, 3))
-		frame_speed = lua_tonumber(L, 3);
-	float frame_blend = 0;
-	if (!lua_isnil(L, 4))
-		frame_blend = lua_tonumber(L, 4);
-	bool frame_loop = true;
-	if (lua_isboolean(L, 5))
-		frame_loop = readParam<bool>(L, 5);
+	v2f frames = lua_type(L, 2) == LUA_TNONE ? v2f(1, 1) : readParam<v2f>(L, 2);
+	float frame_speed = lua_type(L, 3) == LUA_TNONE ? 15 : readParam<float>(L, 3);
+	float frame_blend = lua_type(L, 4) == LUA_TNONE ? 0  : readParam<float>(L, 4);
+	bool frame_loop = readParam<bool>(L, 5, true);
 
 	sao->setAnimation(frames, frame_speed, frame_blend, frame_loop);
 	return 0;
@@ -436,7 +428,7 @@ int ObjectRef::l_set_local_animation(lua_State *L)
 		if (!lua_isnil(L, 2+1))
 			frames[i] = read_v2s32(L, 2+i);
 	}
-	float frame_speed = lua_isnil(L, 6) ? 30 : readParam<float>(L, 6);
+	float frame_speed = lua_type(L, 6) == LUA_TNONE ? 30 : readParam<float>(L, 6);
 
 	getServer(L)->setLocalPlayerAnimations(player, frames, frame_speed);
 	lua_pushboolean(L, true);
@@ -528,7 +520,7 @@ int ObjectRef::l_set_animation_frame_speed(lua_State *L)
 	if (sao == nullptr)
 		return 0;
 
-	if (!lua_isnil(L, 2)) {
+	if (lua_type(L, 2) != LUA_TNONE && !lua_isnil(L, 2)) {
 		float frame_speed = readParam<float>(L, 2);
 		sao->setAnimationSpeed(frame_speed);
 		lua_pushboolean(L, true);
@@ -965,9 +957,10 @@ int ObjectRef::l_set_sprite(lua_State *L)
 	if (entitysao == nullptr)
 		return 0;
 
-	v2s16 start_frame       = lua_isnil(L, 2) ? v2s16(0,0) : readParam<v2s16>(L, 2);
-	int num_frames          = lua_isnil(L, 3) ? 1 : luaL_checkint(L, 3);
-	float framelength       = lua_isnil(L, 4) ? 0.2 : lua_tonumber(L, 4);
+	v2s16 start_frame = lua_type(L, 2) == LUA_TNONE ?
+		v2s16(0,0) : readParam<v2s16>(L, 2);
+	int num_frames    = lua_type(L, 3) == LUA_TNONE ? 1 : luaL_checkint(L, 3);
+	float framelength = lua_type(L, 4) == LUA_TNONE ? 0.2f : readParam<float>(L, 4);
 	bool select_x_by_camera = readParam<bool>(L, 5, false);
 
 	entitysao->setSprite(start_frame, num_frames, framelength, select_x_by_camera);
@@ -1249,7 +1242,7 @@ int ObjectRef::l_set_attribute(lua_State *L)
 		return 0;
 
 	std::string attr = luaL_checkstring(L, 2);
-	if (lua_isnil(L, 3)) {
+	if (lua_type(L, 3) == LUA_TNONE || lua_isnil(L, 3)) {
 		playersao->getMeta().removeString(attr);
 	} else {
 		std::string value = luaL_checkstring(L, 3);
@@ -1707,8 +1700,9 @@ int ObjectRef::l_set_sky(lua_State *L)
 
 	if (lua_istable(L, 2) && !is_colorspec) {
 		lua_getfield(L, 2, "base_color");
-		if (!lua_isnil(L, -1))
+		if (!lua_isnil(L, -1)) {
 			read_color(L, -1, &sky_params.bgcolor);
+		}
 		lua_pop(L, 1);
 
 		lua_getfield(L, 2, "type");

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -169,10 +169,10 @@ int ObjectRef::l_punch(lua_State *L)
 	if (sao == nullptr || puncher == nullptr)
 		return 0;
 
-	float time_from_last_punch = lua_type(L, 3) == LUA_TNONE ?
-		1000000.0f : readParam<float>(L,3);
+	float time_from_last_punch = lua_isnone(L, 3) ?
+		1000000.0f : readParam<float>(L, 3);
 	ToolCapabilities toolcap = read_tool_capabilities(L, 4);
-	v3f dir = lua_type(L, 5) == LUA_TNONE ?
+	v3f dir = lua_isnone(L, 5) ?
 		sao->getBasePosition() - puncher->getBasePosition() : check_v3f(L, 5);
 
 	dir.normalize();
@@ -354,7 +354,7 @@ int ObjectRef::l_set_armor_groups(lua_State *L)
 	if (sao == nullptr)
 		return 0;
 
-	ItemGroupList groups;
+	ItemGlua_type(L, 5) == LUA_TNONEroupList groups;
 
 	read_groups(L, 2, groups);
 	sao->setArmorGroups(groups);
@@ -383,12 +383,12 @@ int ObjectRef::l_set_animation(lua_State *L)
 	if (sao == nullptr)
 		return 0;
 
-	v2f frames = lua_type(L, 2) == LUA_TNONE ? v2f(1, 1) : readParam<v2f>(L, 2);
-	float frame_speed = lua_type(L, 3) == LUA_TNONE ? 15.0f : readParam<float>(L, 3);
-	float frame_blend = lua_type(L, 4) == LUA_TNONE ? 0.0f  : readParam<float>(L, 4);
-	bool frame_loop = readParam<bool>(L, 5, true);
+	v2f frame_range   = lua_isnone(L, 2) ? v2f(1, 1) : readParam<v2f>(L, 2);
+	float frame_speed = lua_isnone(L, 3) ? 15.0f : readParam<float>(L, 3);
+	float frame_blend = lua_isnone(L, 4) ? 0.0f  : readParam<float>(L, 4);
+	bool frame_loop   = readParam<bool>(L, 5, true);
 
-	sao->setAnimation(frames, frame_speed, frame_blend, frame_loop);
+	sao->setAnimation(frame_range, frame_speed, frame_blend, frame_loop);
 	return 0;
 }
 
@@ -428,7 +428,7 @@ int ObjectRef::l_set_local_animation(lua_State *L)
 		if (!lua_isnil(L, 2+1))
 			frames[i] = read_v2s32(L, 2+i);
 	}
-	float frame_speed = lua_type(L, 6) == LUA_TNONE ? 30.0f : readParam<float>(L, 6);
+	float frame_speed = lua_isnone(L, 6) ? 30.0f : readParam<float>(L, 6);
 
 	getServer(L)->setLocalPlayerAnimations(player, frames, frame_speed);
 	lua_pushboolean(L, true);
@@ -520,7 +520,7 @@ int ObjectRef::l_set_animation_frame_speed(lua_State *L)
 	if (sao == nullptr)
 		return 0;
 
-	if (lua_type(L, 2) != LUA_TNONE && !lua_isnil(L, 2)) {
+	if (!lua_isnoneornil(L, 2)) {
 		float frame_speed = readParam<float>(L, 2);
 		sao->setAnimationSpeed(frame_speed);
 		lua_pushboolean(L, true);
@@ -957,10 +957,9 @@ int ObjectRef::l_set_sprite(lua_State *L)
 	if (entitysao == nullptr)
 		return 0;
 
-	v2s16 start_frame = lua_type(L, 2) == LUA_TNONE ?
-		v2s16(0,0) : readParam<v2s16>(L, 2);
-	int num_frames    = lua_type(L, 3) == LUA_TNONE ? 1 : luaL_checkint(L, 3);
-	float framelength = lua_type(L, 4) == LUA_TNONE ? 0.2f : readParam<float>(L, 4);
+	v2s16 start_frame = lua_isnone(L, 2) ? v2s16(0,0) : readParam<v2s16>(L, 2);
+	int num_frames    = lua_isnone(L, 3) ? 1 : luaL_checkint(L, 3);
+	float framelength = lua_isnone(L, 4) ? 0.2f : readParam<float>(L, 4);
 	bool select_x_by_camera = readParam<bool>(L, 5, false);
 
 	entitysao->setSprite(start_frame, num_frames, framelength, select_x_by_camera);
@@ -1242,7 +1241,7 @@ int ObjectRef::l_set_attribute(lua_State *L)
 		return 0;
 
 	std::string attr = luaL_checkstring(L, 2);
-	if (lua_type(L, 3) == LUA_TNONE || lua_isnil(L, 3)) {
+	if (lua_isnoneornil(L, 3)) {
 		playersao->getMeta().removeString(attr);
 	} else {
 		std::string value = luaL_checkstring(L, 3);
@@ -1700,9 +1699,8 @@ int ObjectRef::l_set_sky(lua_State *L)
 
 	if (lua_istable(L, 2) && !is_colorspec) {
 		lua_getfield(L, 2, "base_color");
-		if (!lua_isnil(L, -1)) {
+		if (!lua_isnil(L, -1))
 			read_color(L, -1, &sky_params.bgcolor);
-		}
 		lua_pop(L, 1);
 
 		lua_getfield(L, 2, "type");

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -425,7 +425,7 @@ int ObjectRef::l_set_local_animation(lua_State *L)
 
 	v2s32 frames[4];
 	for (int i=0;i<4;i++) {
-		if (!lua_isnil(L, 2+1))
+		if (!lua_isnoneornil(L, 2+1))
 			frames[i] = read_v2s32(L, 2+i);
 	}
 	float frame_speed = lua_isnone(L, 6) ? 30.0f : readParam<float>(L, 6);


### PR DESCRIPTION
So, according to Lua, when a value is not specified is not `nil`, but `no value`. And they're not the same. This should fix it

## To do

This PR is Ready for Review.

## How to test

Spawn an armorball and it shouldn't crash anymore
