### PR TITLE
No damage effects on hp_max change

### DIFF
--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -62,6 +62,7 @@ struct ClientEvent
 		struct
 		{
 			u16 amount;
+			bool effect;
 		} player_damage;
 		struct
 		{

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2584,7 +2584,7 @@ void Game::handleClientEvent_PlayerDamage(ClientEvent *event, CameraOrientation 
 		client->getScript()->on_damage_taken(event->player_damage.amount);
 
 	// Damage flash and hurt tilt are not used at death
-	if (client->getHP() > 0) {
+	if (client->getHP() > 0 && event->player_damage.effect) {
 		runData.damage_flash += 95.0f + 3.2f * event->player_damage.amount;
 		runData.damage_flash = MYMIN(runData.damage_flash, 127.0f);
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -537,8 +537,6 @@ void Client::handleCommand_Fov(NetworkPacket *pkt)
 
 	*pkt >> fov >> is_multiplier;
 
-	// Wrap transition_time extraction within a
-	// try-catch to preserve backwards compat
 	try {
 		*pkt >> transition_time;
 	} catch (PacketError &e) {};
@@ -565,10 +563,13 @@ void Client::handleCommand_HP(NetworkPacket *pkt)
 		m_script->on_hp_modification(hp);
 
 	if (hp < oldhp) {
-		// Add to ClientEvent queue
 		ClientEvent *event = new ClientEvent();
 		event->type = CE_PLAYER_DAMAGE;
 		event->player_damage.amount = oldhp - hp;
+		event->player_damage.effect = true;
+		try {
+			*pkt >> event->player_damage.effect;
+		} catch (PacketError &e) {};
 		m_client_event_queue.push(event);
 	}
 }

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -197,7 +197,7 @@ void read_object_properties(lua_State *L, int index,
 			PlayerHPChangeReason reason(PlayerHPChangeReason::SET_HP);
 			sao->setHP(prop->hp_max, reason);
 			if (sao->getType() == ACTIVEOBJECT_TYPE_PLAYER)
-				sao->getEnv()->getGameDef()->SendPlayerHPOrDie((PlayerSAO *)sao, reason);
+				sao->getEnv()->getGameDef()->SendPlayerHPOrDie((PlayerSAO *)sao, reason, false);
 		}
 	}
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1326,7 +1326,7 @@ void Server::SendMovement(session_t peer_id)
 	Send(&pkt);
 }
 
-void Server::SendPlayerHPOrDie(PlayerSAO *playersao, const PlayerHPChangeReason &reason)
+void Server::SendPlayerHPOrDie(PlayerSAO *playersao, const PlayerHPChangeReason &reason, bool effect)
 {
 	if (playersao->isImmortal())
 		return;
@@ -1335,15 +1335,15 @@ void Server::SendPlayerHPOrDie(PlayerSAO *playersao, const PlayerHPChangeReason 
 	bool is_alive = playersao->getHP() > 0;
 
 	if (is_alive)
-		SendPlayerHP(peer_id);
+		SendPlayerHP(peer_id, effect);
 	else
 		DiePlayer(peer_id, reason);
 }
 
-void Server::SendHP(session_t peer_id, u16 hp)
+void Server::SendHP(session_t peer_id, u16 hp, bool effect)
 {
-	NetworkPacket pkt(TOCLIENT_HP, 1, peer_id);
-	pkt << hp;
+	NetworkPacket pkt(TOCLIENT_HP, 3, peer_id);
+	pkt << hp << effect;
 	Send(&pkt);
 }
 
@@ -1773,12 +1773,12 @@ void Server::SendTimeOfDay(session_t peer_id, u16 time, f32 time_speed)
 	}
 }
 
-void Server::SendPlayerHP(session_t peer_id)
+void Server::SendPlayerHP(session_t peer_id, bool effect)
 {
 	PlayerSAO *playersao = getPlayerSAO(peer_id);
 	assert(playersao);
 
-	SendHP(peer_id, playersao->getHP());
+	SendHP(peer_id, playersao->getHP(), effect);
 	m_script->player_event(playersao,"health_changed");
 
 	// Send to other clients

--- a/src/server.h
+++ b/src/server.h
@@ -322,7 +322,7 @@ public:
 
 	void printToConsoleOnly(const std::string &text);
 
-	void SendPlayerHPOrDie(PlayerSAO *player, const PlayerHPChangeReason &reason);
+	void SendPlayerHPOrDie(PlayerSAO *player, const PlayerHPChangeReason &reason, bool effect = true);
 	void SendPlayerBreath(PlayerSAO *sao);
 	void SendInventory(PlayerSAO *playerSAO, bool incremental);
 	void SendMovePlayer(session_t peer_id);
@@ -375,7 +375,7 @@ private:
 	void init();
 
 	void SendMovement(session_t peer_id);
-	void SendHP(session_t peer_id, u16 hp);
+	void SendHP(session_t peer_id, u16 hp, bool effect = true);
 	void SendBreath(session_t peer_id, u16 breath);
 	void SendAccessDenied(session_t peer_id, AccessDeniedCode reason,
 		const std::string &custom_reason, bool reconnect = false);
@@ -392,7 +392,7 @@ private:
 
 	virtual void SendChatMessage(session_t peer_id, const ChatMessage &message);
 	void SendTimeOfDay(session_t peer_id, u16 time, f32 time_speed);
-	void SendPlayerHP(session_t peer_id);
+	void SendPlayerHP(session_t peer_id, bool effect = true);
 
 	void SendLocalPlayerAnimations(session_t peer_id, v2s32 animation_frames[4],
 		f32 animation_speed);


### PR DESCRIPTION
Closes #7876 - should this also alter the punch command being sent, to suppress the punch effect?

Test using the following code (**EPILEPSY WARNING**):
```lua
minetest.register_globalstep(function()
    for _, player in pairs(minetest.get_connected_players()) do
        local hp_max = math.random(1, 20)
        player:set_properties{hp_max = hp_max}
        player:set_hp(hp_max)
    end
end)
```