### PR TITLE
Show RTT in ms with 2 digits of precision

### DIFF
--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -116,8 +116,8 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			<< std::setprecision(1)
 			<< " | view range: "
 			<< (draw_control->range_all ? "All" : itos(draw_control->wanted_range))
-			<< std::setprecision(3)
-			<< " | RTT: " << client->getRTT() << "s";
+			<< std::setprecision(2)
+			<< " | RTT: " << (client->getRTT() * 1000.0f) << "ms";
 		setStaticText(m_guitext, utf8_to_wide(os.str()).c_str());
 
 		m_guitext->setRelativePosition(core::rect<s32>(5, 5, screensize.X,


### PR DESCRIPTION
If your ping is in seconds, you probably have other problems.

This PR is a follow-up to a comment from @Calinou on the #minetest IRC channel, that the RTT would make more sense displayed in milliseconds rather than in seconds.