### PR TITLE
Adjust fog distance dynamically.

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -137,6 +137,8 @@ void ClientMap::updateDrawList()
 	u32 blocks_in_range_with_mesh = 0;
 	// Number of blocks occlusion culled
 	u32 blocks_occlusion_culled = 0;
+	// farthest distance
+	float farthest_dist = 0;
 
 	// No occlusion culling when free_move is on and camera is
 	// inside ground
@@ -205,6 +207,8 @@ void ClientMap::updateDrawList()
 				blocks_occlusion_culled++;
 				continue;
 			}
+			if (d > farthest_dist)
+				farthest_dist = d;
 
 			// This block is in range. Reset usage timer.
 			block->resetUsageTimer();
@@ -219,6 +223,7 @@ void ClientMap::updateDrawList()
 		if (sector_blocks_drawn != 0)
 			m_last_drawn_sectors.insert(sp);
 	}
+	m_control.farthest_dist = farthest_dist;
 
 	g_profiler->avg("MapBlock meshes in range [#]", blocks_in_range_with_mesh);
 	g_profiler->avg("MapBlocks occlusion culled [#]", blocks_occlusion_culled);

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -33,6 +33,7 @@ struct MapDrawControl
 	float wanted_range = 0.0f;
 	// show a wire frame for debugging
 	bool show_wireframe = false;
+	float farthest_dist = 0.0f;
 };
 
 class Client;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3703,7 +3703,11 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	if (draw_control->range_all) {
 		runData.fog_range = 100000 * BS;
 	} else {
-		runData.fog_range = draw_control->wanted_range * BS;
+		float new_range = std::min(draw_control->wanted_range * BS, draw_control->farthest_dist);
+		new_range = std::max(new_range, draw_control->wanted_range * BS / 4);
+		runData.fog_range = new_range > runData.fog_range ?
+			runData.fog_range * 0.95f + new_range * 0.05f :
+			runData.fog_range * 0.8f + new_range * 0.2f;
 	}
 
 	/*


### PR DESCRIPTION
This will adjust the fog distance based on the set of blocks already loaded into the client, making loading blocks appear smoother.
It uses exponential smoothing to avoid abrupt fog range changes.

Consider this a tech-demo to try out.

Edit: Specifically I will adjust the fog distance down to the farthest rendered block in the client view-cone (after occlusion culling)