### PR TITLE
Add support for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.3"
+services:
+  minetest:
+    # If you want to build from the cloned source, uncomment the build line and comment the image line.
+    # build: .
+    image: registry.gitlab.com/minetest/minetest/server:latest
+    volumes:
+      - minetest_conf:/etc/minetest
+      - minetest_var_lib:/root/
+    ports:
+      - 30000:30000/udp
+    restart: unless-stopped
+
+volumes:
+    minetest_conf:
+    minetest_var_lib:


### PR DESCRIPTION
This PR adds the ability to spin up a server by using docker-compose.
It solves the usecase where you want to use docker-compose to spin up a minetest server (templates wanted this info from me :grin: )
