### PR TITLE
Block attempts to connect to the client.

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1566,7 +1566,7 @@ void Connection::sendAck(session_t peer_id, u8 channelnum, u16 seqnum)
 
 UDPPeer* Connection::createServerPeer(Address& address)
 {
-	if (getPeerNoEx(PEER_ID_SERVER) != 0)
+	if (ConnectedToServer())
 	{
 		throw ConnectionException("Already connected to a server");
 	}

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -809,6 +809,11 @@ protected:
 	void putEvent(ConnectionEvent &e);
 
 	void TriggerSend();
+	
+	bool ConnectedToServer() 
+	{
+		return getPeerNoEx(PEER_ID_SERVER) != nullptr;
+	}
 private:
 	MutexedQueue<ConnectionEvent> m_event_queue;
 

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -956,8 +956,11 @@ void ConnectionReceiveThread::receive(SharedBuffer<u8> &packetdata,
 			// command was sent reliably.
 		}
 
-		/* The peer was not found in our lists. Add it. */
 		if (peer_id == PEER_ID_INEXISTENT) {
+			/* Ignore it if we are a client */
+			if (m_connection->ConnectedToServer())
+				return;
+			/* The peer was not found in our lists. Add it. */
 			peer_id = m_connection->createPeer(sender, MTP_MINETEST_RELIABLE_UDP, 0);
 		}
 


### PR DESCRIPTION
A Minetest peer initiates a connection by sending a packet with an invalid peer_id, for whatever reason the code for doing this ran on both the client and the server meaning you could connect to a client if you knew what the address:port tuple it was listening on.

This PR makes network code first check whatever we are a client or a server before creating a peer, this isn't really a bug fix, the client creating peers doesn't seem to cause any issues but it's unexpected and it seems better to avoid it.

## How to test

Start a client and connect to a server, get the port it's listening on

Use the python code from `doc/protocol.txt` with localhost and the port to see if it responds.
If the patch works it should report the "server" as down.