### PR TITLE
Slight simplification and optimization of RemoteClient.

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -298,20 +298,14 @@ void RemoteClient::GetNextBlocks (
 			*/
 			MapBlock *block = env->getMap().getBlockNoCreateNoEx(p);
 
-			bool surely_not_found_on_disk = false;
-			bool block_is_invalid = false;
+			bool block_not_found = false;
 			if (block) {
 				// Reset usage timer, this block will be of use in the future.
 				block->resetUsageTimer();
 
-				// Block is dummy if data doesn't exist.
-				// It means it has been not found from disk and not generated
-				if (block->isDummy()) {
-					surely_not_found_on_disk = true;
-				}
-
-				if (!block->isGenerated())
-					block_is_invalid = true;
+				// Check whether the block exists (with data)
+				if (block->isDummy() || !block->isGenerated())
+					block_not_found = true;
 
 				/*
 					If block is not close, don't send it unless it is near
@@ -325,7 +319,7 @@ void RemoteClient::GetNextBlocks (
 						continue;
 				}
 
-				if (m_occ_cull && !block_is_invalid &&
+				if (m_occ_cull && !block_not_found &&
 						env->getMap().isBlockOccluded(block, cam_pos_nodes)) {
 					continue;
 				}
@@ -335,7 +329,7 @@ void RemoteClient::GetNextBlocks (
 				If block has been marked to not exist on disk (dummy) or is
 				not generated and generating new ones is not wanted, skip block.
 			*/
-			if (!generate && (surely_not_found_on_disk || block_is_invalid)) {
+			if (!generate && block_not_found) {
 				// get next one.
 				continue;
 			}
@@ -343,7 +337,7 @@ void RemoteClient::GetNextBlocks (
 			/*
 				Add inexistent block to emerge queue.
 			*/
-			if (block == NULL || surely_not_found_on_disk || block_is_invalid) {
+			if (block == NULL || block_not_found) {
 				if (emerge->enqueueBlockEmerge(peer_id, p, generate)) {
 					if (nearest_emerged_d == -1)
 						nearest_emerged_d = d;


### PR DESCRIPTION
This is a *very* slight improvement in RemoteClient::getNextBlock.

1. occlusion culling does not have to be performed for dummy blocks (since they will not be sent to the client anyway)
2. block_is_invalid and surely_not_found_on_disk are (now) used for the same purposes, so they can be combined

