### PR TITLE
Avoid server-side occlusion unnecessarily.

### DIFF
--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -394,6 +394,12 @@ private:
 	std::set<v3s16> m_blocks_modified;
 
 	/*
+		Blocks that have already been occlusion culled, so
+		that we can avoid doing the expensive calculation again.
+	 */
+	std::set<v3s16> m_blocks_culled;
+
+	/*
 		Count of excess GotBlocks().
 		There is an excess amount because the client sometimes
 		gets a block so late that the server sends it again,


### PR DESCRIPTION
Blocked that are occlusion culled are not sent to the client. This is very effective, avoiding sending 10.000's of blocks to the client. Larger viewing_ranges would not be possible without this,

But... It is also somewhat computationally expensive.
So this caches the culled blocks - invalidating when needed.

When I tried with two client and viewing_range of 500. One client having loaded the entire scene.

The second client then took almost exactly 5 minutes to load the scene (from disk, not generated).
With this change the second client loaded the same scene in 59s.
