### PR TITLE
Joystick: Fix dig and place buttons

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2014,15 +2014,11 @@ void Game::processItemSelection(u16 *new_playeritem)
 
 	s32 dir = wheel;
 
-	if (input->joystick.wasKeyDown(KeyType::SCROLL_DOWN) ||
-			wasKeyDown(KeyType::HOTBAR_NEXT)) {
+	if (wasKeyDown(KeyType::HOTBAR_NEXT))
 		dir = -1;
-	}
 
-	if (input->joystick.wasKeyDown(KeyType::SCROLL_UP) ||
-			wasKeyDown(KeyType::HOTBAR_PREV)) {
+	if (wasKeyDown(KeyType::HOTBAR_PREV))
 		dir = 1;
-	}
 
 	if (dir < 0)
 		*new_playeritem = *new_playeritem < max_item ? *new_playeritem + 1 : 0;
@@ -3138,11 +3134,11 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 	input->clearWasKeyPressed();
 	input->clearWasKeyReleased();
 
-	input->joystick.clearWasKeyDown(KeyType::MOUSE_L);
-	input->joystick.clearWasKeyDown(KeyType::MOUSE_R);
+	input->joystick.clearWasKeyDown(KeyType::DIG);
+	input->joystick.clearWasKeyDown(KeyType::PLACE);
 
-	input->joystick.clearWasKeyReleased(KeyType::MOUSE_L);
-	input->joystick.clearWasKeyReleased(KeyType::MOUSE_R);
+	input->joystick.clearWasKeyReleased(KeyType::DIG);
+	input->joystick.clearWasKeyReleased(KeyType::PLACE);
 }
 
 

--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -74,8 +74,8 @@ JoystickLayout create_default_layout()
 
 	// Accessible without four modifier button pressed
 	// regardless whether start is pressed or not
-	JLO_B_PB(KeyType::MOUSE_L,    fb | 1 << 4, 1 << 4);
-	JLO_B_PB(KeyType::MOUSE_R,    fb | 1 << 5, 1 << 5);
+	JLO_B_PB(KeyType::DIG,        fb | 1 << 4, 1 << 4);
+	JLO_B_PB(KeyType::PLACE,      fb | 1 << 5, 1 << 5);
 
 	// Accessible without any modifier pressed
 	JLO_B_PB(KeyType::JUMP,       bm | 1 << 0, 1 << 0);
@@ -83,9 +83,9 @@ JoystickLayout create_default_layout()
 
 	// Accessible with start button not pressed, but four pressed
 	// TODO find usage for button 0
-	JLO_B_PB(KeyType::DROP,       bm | 1 << 1, fb | 1 << 1);
-	JLO_B_PB(KeyType::SCROLL_UP,  bm | 1 << 4, fb | 1 << 4);
-	JLO_B_PB(KeyType::SCROLL_DOWN,bm | 1 << 5, fb | 1 << 5);
+	JLO_B_PB(KeyType::DROP,        bm | 1 << 1, fb | 1 << 1);
+	JLO_B_PB(KeyType::HOTBAR_PREV, bm | 1 << 4, fb | 1 << 4);
+	JLO_B_PB(KeyType::HOTBAR_NEXT, bm | 1 << 5, fb | 1 << 5);
 
 	// Accessible with start button and four pressed
 	// TODO find usage for buttons 0, 1 and 4, 5
@@ -99,8 +99,8 @@ JoystickLayout create_default_layout()
 	JLO_A_PB(KeyType::RIGHT,    0, -1, 1024);
 
 	// Scroll buttons
-	JLO_A_PB(KeyType::SCROLL_UP,   2, -1, 1024);
-	JLO_A_PB(KeyType::SCROLL_DOWN, 5, -1, 1024);
+	JLO_A_PB(KeyType::HOTBAR_PREV, 2, -1, 1024);
+	JLO_A_PB(KeyType::HOTBAR_NEXT, 5, -1, 1024);
 
 	return jlo;
 }
@@ -134,10 +134,10 @@ JoystickLayout create_xbox_layout()
 	JLO_B_PB(KeyType::SNEAK,       1 << 12, 1 << 12); // right
 
 	// Triggers
-	JLO_B_PB(KeyType::MOUSE_L,     1 << 6,  1 << 6); // lt
-	JLO_B_PB(KeyType::MOUSE_R,     1 << 7,  1 << 7); // rt
-	JLO_B_PB(KeyType::SCROLL_UP,   1 << 4,  1 << 4); // lb
-	JLO_B_PB(KeyType::SCROLL_DOWN, 1 << 5,  1 << 5); // rb
+	JLO_B_PB(KeyType::DIG,         1 << 6,  1 << 6); // lt
+	JLO_B_PB(KeyType::PLACE,       1 << 7,  1 << 7); // rt
+	JLO_B_PB(KeyType::HOTBAR_PREV, 1 << 4,  1 << 4); // lb
+	JLO_B_PB(KeyType::HOTBAR_NEXT, 1 << 5,  1 << 5); // rb
 
 	// D-PAD
 	JLO_B_PB(KeyType::ZOOM,        1 << 15, 1 << 15); // up

--- a/src/client/keys.h
+++ b/src/client/keys.h
@@ -110,12 +110,6 @@ public:
 		SLOT_31,
 		SLOT_32,
 
-		// joystick specific keys
-		MOUSE_L,
-		MOUSE_R,
-		SCROLL_UP,
-		SCROLL_DOWN,
-
 		// Fake keycode for array size and internal checks
 		INTERNAL_ENUM_COUNT
 


### PR DESCRIPTION
They were mapped to the left and right mouse buttons, which doesn't seem to work anymore in current releases. This commit changes them to report the DIG and PLACE KeyTypes.

This PR is Ready for Review.

## How to test

Try to play with a gamepad. For me, pressing the dig and place buttons did nothing. With this patch, they work as expected.