### PR TITLE
Fix falling image of torchlike if paramtype2="none"

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -84,6 +84,9 @@ core.register_entity(":__builtin:falling_node", {
 			local textures
 			if def.tiles and def.tiles[1] then
 				local tile = def.tiles[1]
+				if def.drawtype == "torchlike" and def.paramtype2 ~= "wallmounted" then
+					tile = def.tiles[2] or def.tiles[1]
+				end
 				if type(tile) == "table" then
 					tile = tile.name
 				end
@@ -144,7 +147,11 @@ core.register_entity(":__builtin:falling_node", {
 
 		-- Rotate entity
 		if def.drawtype == "torchlike" then
-			self.object:set_yaw(math.pi*0.25)
+			if def.paramtype2 == "wallmounted" then
+				self.object:set_yaw(math.pi*0.25)
+			else
+				self.object:set_yaw(-math.pi*0.25)
+			end
 		elseif (node.param2 ~= 0 and (def.wield_image == ""
 				or def.wield_image == nil))
 				or def.drawtype == "signlike"

--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -145,6 +145,23 @@ minetest.register_node("testnodes:fencelike", {
 })
 
 minetest.register_node("testnodes:torchlike", {
+	description = S("Torchlike Drawtype Test Node"),
+	drawtype = "torchlike",
+	paramtype = "light",
+	tiles = {
+		"testnodes_torchlike_floor.png",
+		"testnodes_torchlike_ceiling.png",
+		"testnodes_torchlike_wall.png",
+	},
+
+
+	walkable = false,
+	sunlight_propagates = true,
+	groups = { dig_immediate = 3 },
+	inventory_image = fallback_image("testnodes_torchlike_floor.png"),
+})
+
+minetest.register_node("testnodes:torchlike_wallmounted", {
 	description = S("Wallmounted Torchlike Drawtype Test Node"),
 	drawtype = "torchlike",
 	paramtype = "light",
@@ -161,6 +178,8 @@ minetest.register_node("testnodes:torchlike", {
 	groups = { dig_immediate = 3 },
 	inventory_image = fallback_image("testnodes_torchlike_floor.png"),
 })
+
+
 
 minetest.register_node("testnodes:signlike", {
 	description = S("Wallmounted Signlike Drawtype Test Node"),
@@ -526,7 +545,7 @@ scale("allfaces_optional_waving",
 scale("plantlike",
 	S("Double-sized Plantlike Drawtype Test Node"),
 	S("Half-sized Plantlike Drawtype Test Node"))
-scale("torchlike",
+scale("torchlike_wallmounted",
 	S("Double-sized Wallmounted Torchlike Drawtype Test Node"),
 	S("Half-sized Wallmounted Torchlike Drawtype Test Node"))
 scale("signlike",


### PR DESCRIPTION
When a `torchlike` node falls and `paramtype2=="none"`, the falling node appearance is incorrectly rotated and has a wrong image. This PR will fix it. A new test node is also added to DevTest.

(Note: This might seem esoteric, but such nodes are actually used in Voxelgarden (it's the flowers)).

## To do

This PR is ready.

## How to test

In DevTest, place a `testnodes:torchlike` node and use the falling node tool on it to make it fall. Check if the falling node images matches the node appearance.
