### PR TITLE
No falling node collision for non-walkable node

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -79,6 +79,10 @@ core.register_entity(":__builtin:falling_node", {
 		-- Cache whether we're supposed to float on water
 		self.floats = core.get_item_group(node.name, "float") ~= 0
 
+		-- Vars for set_properties
+		local props = {}
+		local set_props = false
+
 		-- Set entity visuals
 		if def.drawtype == "torchlike" or def.drawtype == "signlike" then
 			local textures
@@ -98,13 +102,12 @@ core.register_entity(":__builtin:falling_node", {
 				local s = def.visual_scale
 				vsize = {x = s, y = s, z = s}
 			end
-			self.object:set_properties({
-				is_visible = true,
-				visual = "upright_sprite",
-				visual_size = vsize,
-				textures = textures,
-				glow = def.light_source,
-			})
+			set_props = true
+			props.is_visible = true
+			props.visual = "upright_sprite"
+			props.visual_size = vsize
+			props.textures = textures
+			props.glow = def.light_source
 		elseif def.drawtype ~= "airlike" then
 			local itemstring = node.name
 			if core.is_colored_paramtype(def.paramtype2) then
@@ -116,12 +119,11 @@ core.register_entity(":__builtin:falling_node", {
 				local s = def.visual_scale * SCALE
 				vsize = {x = s, y = s, z = s}
 			end
-			self.object:set_properties({
-				is_visible = true,
-				wield_item = itemstring,
-				visual_size = vsize,
-				glow = def.light_source,
-			})
+			set_props = true
+			props.is_visible = true
+			props.wield_item = itemstring
+			props.visual_size = vsize
+			props.glow = def.light_source
 		end
 
 		-- Set collision box (certain nodeboxes only for now)
@@ -136,10 +138,20 @@ core.register_entity(":__builtin:falling_node", {
 				if def.paramtype2 == "leveled" and (self.node.level or 0) > 0 then
 					box[5] = -0.5 + self.node.level / 64
 				end
-				self.object:set_properties({
-					collisionbox = box
-				})
+				set_props = true
+				props.collisionbox = box
 			end
+		end
+
+		-- Only walkable nodes collide
+		if not def.walkable then
+			set_props = true
+			props.collide_with_objects = false
+		end
+
+		-- Set all properties at once
+		if set_props then
+			self.object:set_properties(props)
 		end
 
 		-- Rotate entity


### PR DESCRIPTION
The problem:

When a falling node falls, it collides with objects, which blocks players from walking into them. This makes sense if the node is a `walkable` one like sand but it does not make sense if a non-`walkable` node is falling.

This PR:
Will disable object collision of the falling node if it is a non-`walkable` one.

## To do

Ready.

## How to test

1. Start DevTest
2. Place any non-walkable node, like a sign
3. Place any walkable node, like dirt
4. Use the falling node test tool on both nodes and walk into the falling node

Expected behavior: You should collide with the dirt but not with the sign.
(For reference, the buggy behavior is: You will collide with both the dirt and the sign.)