### PR TITLE
Increase default emerge queue limits and limit enqueue requests for active blocks.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2152,15 +2152,15 @@ chunksize (Chunk size) int 5
 enable_mapgen_debug_info (Mapgen debug) bool false
 
 #    Maximum number of blocks that can be queued for loading.
-emergequeue_limit_total (Absolute limit of queued blocks to emerge) int 512
+emergequeue_limit_total (Absolute limit of queued blocks to emerge) int 1024
 
 #    Maximum number of blocks to be queued that are to be loaded from file.
 #    This limit is enforced per player.
-emergequeue_limit_diskonly (Per-player limit of queued blocks load from disk) int 64
+emergequeue_limit_diskonly (Per-player limit of queued blocks load from disk) int 128
 
 #    Maximum number of blocks to be queued that are to be generated.
 #    This limit is enforced per player.
-emergequeue_limit_generate (Per-player limit of queued blocks to generate) int 64
+emergequeue_limit_generate (Per-player limit of queued blocks to generate) int 128
 
 #    Number of emerge threads to use.
 #    Value 0:

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -396,9 +396,9 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("debug_log_level", "action");
 	settings->setDefault("debug_log_size_max", "50");
 	settings->setDefault("chat_log_level", "error");
-	settings->setDefault("emergequeue_limit_total", "512");
-	settings->setDefault("emergequeue_limit_diskonly", "64");
-	settings->setDefault("emergequeue_limit_generate", "64");
+	settings->setDefault("emergequeue_limit_total", "1024");
+	settings->setDefault("emergequeue_limit_diskonly", "128");
+	settings->setDefault("emergequeue_limit_generate", "128");
 	settings->setDefault("num_emerge_threads", "1");
 	settings->setDefault("secure.enable_security", "true");
 	settings->setDefault("secure.trusted_mods", "");

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -426,6 +426,10 @@ bool EmergeManager::pushBlockEmergeData(
 				m_qlimit_generate : m_qlimit_diskonly;
 			if (count_peer >= qlimit_peer)
 				return false;
+		} else {
+			// limit block enqueue requests for active blocks to 1/2 of total
+			if (count_peer * 2 >= m_qlimit_total)
+				return false;
 		}
 	}
 


### PR DESCRIPTION
Partially related to #10597

The visual view cone of a player could be up to 2400 blocks.
The current emerge queue limits are 64 for disk reads, 64 for block generate, and 512 for a server in total.
Thus the queues would full over and over before the blocks have been loaded.

Even before #10597 these were quite low. This PR doubles these values - I would consider even that very conservative (I have certainly set mine much higher, but we have to start somewhere).
Note that these settings only increase the server's ability to *queue* requests, and hence to pace its work better.

I will renew my call to please reduce the "insane" number of config options.
@paramat Do need both a disk and generate queue limit (again this is not a work limit, but a queue limit)? When would I set these differently?

Edit: _In _return__ block requests on behalf of ABMs are limited to _1/2 of the total_ (as is, ABM requests can starve out the loading of visible blocks)