### PR TITLE
[NO SQUASH] Fix some fallback font issues

### DIFF
--- a/fonts/DroidSansFallbackFull-LICENSE.txt
+++ b/fonts/DroidSansFallbackFull-LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2008 The Android Open Source Project
+Copyright (C) 2012 The Android Open Source Project
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -677,9 +677,7 @@ endif(BUILD_SERVER)
 # Blacklisted locales that don't work.
 # see issue #4638
 set(GETTEXT_BLACKLISTED_LOCALES
-	be
 	he
-	ko
 	ky
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -677,8 +677,11 @@ endif(BUILD_SERVER)
 # Blacklisted locales that don't work.
 # see issue #4638
 set(GETTEXT_BLACKLISTED_LOCALES
+	ar
 	he
 	ky
+	ms_Arab
+	th
 )
 
 option(APPLY_LOCALE_BLACKLIST "Use a blacklist to avoid broken locales" TRUE)


### PR DESCRIPTION
This makes Belarusian (`be`) and Korean (`ko`) work.
Arabic (`ar`), Malay (Arabic?) (`ms_Arab`) and Thai (`th`) are added to the blacklist since they don't work.

The new font file was taken from Arch's ttf-droid package version 20121017-8.

## To do

This PR is Ready for Review.

## How to test

Run
* `./bin/minetest --config <(echo language=ko)`
* `./bin/minetest --config <(echo language=be)`
and find that the menu displays correctly in both cases
