### PR TITLE
Fix some more joystick issues

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -152,6 +152,9 @@ joystick_type (Joystick type) enum auto auto,generic,xbox
 #    when holding down a joystick button combination.
 repeat_joystick_button_time (Joystick button repetition interval) float 0.17 0.001
 
+#    The deadzone of the joystick
+joystick_deadzone (Joystick deadzone) int 2048
+
 #    The sensitivity of the joystick axes for moving the
 #    ingame view frustum around.
 joystick_frustum_sensitivity (Joystick frustum sensitivity) float 170

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -129,6 +129,9 @@
 #    type: float min: 0.001
 # repeat_joystick_button_time = 0.17
 
+#    The deadzone of the joystick
+# joystick_deadzone = 2048
+
 #    The sensitivity of the joystick axes for moving the
 #    ingame view frustum around.
 #    type: float

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3134,8 +3134,8 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 	input->clearWasKeyPressed();
 	input->clearWasKeyReleased();
 
-	input->joystick.clearWasKeyDown(KeyType::DIG);
-	input->joystick.clearWasKeyDown(KeyType::PLACE);
+	input->joystick.clearWasKeyPressed(KeyType::DIG);
+	input->joystick.clearWasKeyPressed(KeyType::PLACE);
 
 	input->joystick.clearWasKeyReleased(KeyType::DIG);
 	input->joystick.clearWasKeyReleased(KeyType::PLACE);

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -209,7 +209,7 @@ public:
 	}
 	virtual bool wasKeyPressed(GameKeyType k)
 	{
-		return m_receiver->WasKeyPressed(keycache.key[k]) || joystick.wasKeyReleased(k);
+		return m_receiver->WasKeyPressed(keycache.key[k]) || joystick.wasKeyPressed(k);
 	}
 	virtual bool wasKeyReleased(GameKeyType k)
 	{

--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -251,8 +251,7 @@ void JoystickController::clear()
 s16 JoystickController::getAxisWithoutDead(JoystickAxis axis)
 {
 	s16 v = m_axes_vals[axis];
-	if (((v > 0) && (v < m_layout.axes_dead_border)) ||
-			((v < 0) && (v > -m_layout.axes_dead_border)))
+	if (abs(v) < m_layout.axes_dead_border)
 		return 0;
 	return v;
 }

--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -37,7 +37,7 @@ bool JoystickAxisCmb::isTriggered(const irr::SEvent::SJoystickEvent &ev) const
 {
 	s16 ax_val = ev.Axis[axis_to_compare];
 
-	return (ax_val * direction < 0) && (thresh * direction > ax_val * direction);
+	return (ax_val * direction < -thresh);
 }
 
 // spares many characters

--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -48,7 +48,7 @@ JoystickLayout create_default_layout()
 {
 	JoystickLayout jlo;
 
-	jlo.axes_dead_border = 1024;
+	jlo.axes_dead_border = g_settings->getU16("joystick_deadzone");
 
 	const JoystickAxisLayout axes[JA_COUNT] = {
 		{0, 1}, // JA_SIDEWARD_MOVE

--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -219,16 +219,19 @@ bool JoystickController::handleEvent(const irr::SEvent::SJoystickEvent &ev)
 
 	for (size_t i = 0; i < KeyType::INTERNAL_ENUM_COUNT; i++) {
 		if (keys_pressed[i]) {
-			if (!m_past_pressed_keys[i] &&
+			if (!m_past_keys_pressed[i] &&
 					m_past_pressed_time[i] < m_internal_time - doubling_dtime) {
-				m_past_pressed_keys[i] = true;
+				m_past_keys_pressed[i] = true;
 				m_past_pressed_time[i] = m_internal_time;
 			}
-		} else if (m_pressed_keys[i]) {
-			m_past_released_keys[i] = true;
+		} else if (m_keys_down[i]) {
+			m_keys_released[i] = true;
 		}
 
-		m_pressed_keys[i] = keys_pressed[i];
+		if (keys_pressed[i] && !(m_keys_down[i]))
+			m_keys_pressed[i] = true;
+
+		m_keys_down[i] = keys_pressed[i];
 	}
 
 	for (size_t i = 0; i < JA_COUNT; i++) {
@@ -236,15 +239,15 @@ bool JoystickController::handleEvent(const irr::SEvent::SJoystickEvent &ev)
 		m_axes_vals[i] = ax_la.invert * ev.Axis[ax_la.axis_id];
 	}
 
-
 	return true;
 }
 
 void JoystickController::clear()
 {
-	m_pressed_keys.reset();
-	m_past_pressed_keys.reset();
-	m_past_released_keys.reset();
+	m_keys_pressed.reset();
+	m_keys_down.reset();
+	m_past_keys_pressed.reset();
+	m_keys_released.reset();
 	memset(m_axes_vals, 0, sizeof(m_axes_vals));
 }
 

--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -93,14 +93,14 @@ JoystickLayout create_default_layout()
 	// Now about the buttons simulated by the axes
 
 	// Movement buttons, important for vessels
-	JLO_A_PB(KeyType::FORWARD,  1,  1, 1024);
-	JLO_A_PB(KeyType::BACKWARD, 1, -1, 1024);
-	JLO_A_PB(KeyType::LEFT,     0,  1, 1024);
-	JLO_A_PB(KeyType::RIGHT,    0, -1, 1024);
+	JLO_A_PB(KeyType::FORWARD,  1,  1, jlo.axes_dead_border);
+	JLO_A_PB(KeyType::BACKWARD, 1, -1, jlo.axes_dead_border);
+	JLO_A_PB(KeyType::LEFT,     0,  1, jlo.axes_dead_border);
+	JLO_A_PB(KeyType::RIGHT,    0, -1, jlo.axes_dead_border);
 
 	// Scroll buttons
-	JLO_A_PB(KeyType::HOTBAR_PREV, 2, -1, 1024);
-	JLO_A_PB(KeyType::HOTBAR_NEXT, 5, -1, 1024);
+	JLO_A_PB(KeyType::HOTBAR_PREV, 2, -1, jlo.axes_dead_border);
+	JLO_A_PB(KeyType::HOTBAR_NEXT, 5, -1, jlo.axes_dead_border);
 
 	return jlo;
 }
@@ -146,10 +146,10 @@ JoystickLayout create_xbox_layout()
 	JLO_B_PB(KeyType::FREEMOVE,    1 << 16, 1 << 16); // down
 
 	// Movement buttons, important for vessels
-	JLO_A_PB(KeyType::FORWARD,  1,  1, 1024);
-	JLO_A_PB(KeyType::BACKWARD, 1, -1, 1024);
-	JLO_A_PB(KeyType::LEFT,     0,  1, 1024);
-	JLO_A_PB(KeyType::RIGHT,    0, -1, 1024);
+	JLO_A_PB(KeyType::FORWARD,  1,  1, jlo.axes_dead_border);
+	JLO_A_PB(KeyType::BACKWARD, 1, -1, jlo.axes_dead_border);
+	JLO_A_PB(KeyType::LEFT,     0,  1, jlo.axes_dead_border);
+	JLO_A_PB(KeyType::RIGHT,    0, -1, jlo.axes_dead_border);
 
 	return jlo;
 }

--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -48,7 +48,7 @@ JoystickLayout create_default_layout()
 {
 	JoystickLayout jlo;
 
-	jlo.axes_dead_border = g_settings->getU16("joystick_deadzone");
+	jlo.axes_deadzone = g_settings->getU16("joystick_deadzone");
 
 	const JoystickAxisLayout axes[JA_COUNT] = {
 		{0, 1}, // JA_SIDEWARD_MOVE
@@ -93,14 +93,14 @@ JoystickLayout create_default_layout()
 	// Now about the buttons simulated by the axes
 
 	// Movement buttons, important for vessels
-	JLO_A_PB(KeyType::FORWARD,  1,  1, jlo.axes_dead_border);
-	JLO_A_PB(KeyType::BACKWARD, 1, -1, jlo.axes_dead_border);
-	JLO_A_PB(KeyType::LEFT,     0,  1, jlo.axes_dead_border);
-	JLO_A_PB(KeyType::RIGHT,    0, -1, jlo.axes_dead_border);
+	JLO_A_PB(KeyType::FORWARD,  1,  1, jlo.axes_deadzone);
+	JLO_A_PB(KeyType::BACKWARD, 1, -1, jlo.axes_deadzone);
+	JLO_A_PB(KeyType::LEFT,     0,  1, jlo.axes_deadzone);
+	JLO_A_PB(KeyType::RIGHT,    0, -1, jlo.axes_deadzone);
 
 	// Scroll buttons
-	JLO_A_PB(KeyType::HOTBAR_PREV, 2, -1, jlo.axes_dead_border);
-	JLO_A_PB(KeyType::HOTBAR_NEXT, 5, -1, jlo.axes_dead_border);
+	JLO_A_PB(KeyType::HOTBAR_PREV, 2, -1, jlo.axes_deadzone);
+	JLO_A_PB(KeyType::HOTBAR_NEXT, 5, -1, jlo.axes_deadzone);
 
 	return jlo;
 }
@@ -109,7 +109,7 @@ JoystickLayout create_xbox_layout()
 {
 	JoystickLayout jlo;
 
-	jlo.axes_dead_border = 7000;
+	jlo.axes_deadzone = 7000;
 
 	const JoystickAxisLayout axes[JA_COUNT] = {
 		{0, 1}, // JA_SIDEWARD_MOVE
@@ -146,10 +146,10 @@ JoystickLayout create_xbox_layout()
 	JLO_B_PB(KeyType::FREEMOVE,    1 << 16, 1 << 16); // down
 
 	// Movement buttons, important for vessels
-	JLO_A_PB(KeyType::FORWARD,  1,  1, jlo.axes_dead_border);
-	JLO_A_PB(KeyType::BACKWARD, 1, -1, jlo.axes_dead_border);
-	JLO_A_PB(KeyType::LEFT,     0,  1, jlo.axes_dead_border);
-	JLO_A_PB(KeyType::RIGHT,    0, -1, jlo.axes_dead_border);
+	JLO_A_PB(KeyType::FORWARD,  1,  1, jlo.axes_deadzone);
+	JLO_A_PB(KeyType::BACKWARD, 1, -1, jlo.axes_deadzone);
+	JLO_A_PB(KeyType::LEFT,     0,  1, jlo.axes_deadzone);
+	JLO_A_PB(KeyType::RIGHT,    0, -1, jlo.axes_deadzone);
 
 	return jlo;
 }
@@ -254,7 +254,7 @@ void JoystickController::clear()
 s16 JoystickController::getAxisWithoutDead(JoystickAxis axis)
 {
 	s16 v = m_axes_vals[axis];
-	if (abs(v) < m_layout.axes_dead_border)
+	if (abs(v) < m_layout.axes_deadzone)
 		return 0;
 	return v;
 }

--- a/src/client/joystick_controller.h
+++ b/src/client/joystick_controller.h
@@ -111,37 +111,32 @@ public:
 
 	bool wasKeyDown(GameKeyType b)
 	{
-		bool r = m_past_pressed_keys[b];
-		m_past_pressed_keys[b] = false;
+		bool r = m_past_keys_pressed[b];
+		m_past_keys_pressed[b] = false;
 		return r;
-	}
-	bool getWasKeyDown(GameKeyType b)
-	{
-		return m_past_pressed_keys[b];
-	}
-	void clearWasKeyDown(GameKeyType b)
-	{
-		m_past_pressed_keys[b] = false;
 	}
 
 	bool wasKeyReleased(GameKeyType b)
 	{
-		bool r = m_past_released_keys[b];
-		m_past_released_keys[b] = false;
-		return r;
-	}
-	bool getWasKeyReleased(GameKeyType b)
-	{
-		return m_past_pressed_keys[b];
+		return m_keys_released[b];
 	}
 	void clearWasKeyReleased(GameKeyType b)
 	{
-		m_past_pressed_keys[b] = false;
+		m_keys_released[b] = false;
+	}
+
+	bool wasKeyPressed(GameKeyType b)
+	{
+		return m_keys_pressed[b];
+	}
+	void clearWasKeyPressed(GameKeyType b)
+	{
+		m_keys_pressed[b] = false;
 	}
 
 	bool isKeyDown(GameKeyType b)
 	{
-		return m_pressed_keys[b];
+		return m_keys_down[b];
 	}
 
 	s16 getAxis(JoystickAxis axis)
@@ -162,12 +157,13 @@ private:
 
 	u8 m_joystick_id = 0;
 
-	std::bitset<KeyType::INTERNAL_ENUM_COUNT> m_pressed_keys;
+	std::bitset<KeyType::INTERNAL_ENUM_COUNT> m_keys_down;
+	std::bitset<KeyType::INTERNAL_ENUM_COUNT> m_keys_pressed;
 
 	f32 m_internal_time;
 
 	f32 m_past_pressed_time[KeyType::INTERNAL_ENUM_COUNT];
 
-	std::bitset<KeyType::INTERNAL_ENUM_COUNT> m_past_pressed_keys;
-	std::bitset<KeyType::INTERNAL_ENUM_COUNT> m_past_released_keys;
+	std::bitset<KeyType::INTERNAL_ENUM_COUNT> m_past_keys_pressed;
+	std::bitset<KeyType::INTERNAL_ENUM_COUNT> m_keys_released;
 };

--- a/src/client/joystick_controller.h
+++ b/src/client/joystick_controller.h
@@ -96,7 +96,7 @@ struct JoystickLayout {
 	std::vector<JoystickButtonCmb> button_keys;
 	std::vector<JoystickAxisCmb> axis_keys;
 	JoystickAxisLayout axes[JA_COUNT];
-	s16 axes_dead_border;
+	s16 axes_deadzone;
 };
 
 class JoystickController {

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -279,6 +279,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("joystick_type", "");
 	settings->setDefault("repeat_joystick_button_time", "0.17");
 	settings->setDefault("joystick_frustum_sensitivity", "170");
+	settings->setDefault("joystick_deadzone", "2048");
 
 	// Main menu
 	settings->setDefault("main_menu_path", "");


### PR DESCRIPTION
This PR fixes some issues with Joystick input:

* Don't use hard-coded 1024 as axis-to-key translation threshold, use the "configured" dead zone.
* Refactor getAxisWithoutDead to use abs() instead of doing manual comparisons.
* Fix handling of wasKeyPressed(), which caused joystick users to be unable to interact with objects (e.g. eating).
* Add dead zone as configurable parameter

## To do

This PR is a Ready for Review.

## How to test

* Set a high dead zone and check when the character starts walking
* Try to eat with a joystick

Other things shouldn't really have any effect apart from clear code. Also, no subsystem other than joystick input should be affected by this.

