### PR TITLE
Increase limit for simultaneous blocks sent per client and the meshgen cache.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -747,7 +747,7 @@ mesh_generation_interval (Mapblock mesh generation delay) int 0 0 50
 #    Size of the MapBlock cache of the mesh generator. Increasing this will
 #    increase the cache hit %, reducing the data being copied from the main
 #    thread, thus reducing jitter.
-meshgen_block_cache_size (Mapblock mesh generator's MapBlock cache size in MB) int 20 0 1000
+meshgen_block_cache_size (Mapblock mesh generator's MapBlock cache size in MB) int 40 0 1000
 
 #    Enables minimap.
 enable_minimap (Minimap) bool true
@@ -1037,7 +1037,7 @@ ipv6_server (IPv6 server) bool false
 #    Maximum number of blocks that are simultaneously sent per client.
 #    The maximum total count is calculated dynamically:
 #    max_total = ceil((#clients + max_users) * per_client / 4)
-max_simultaneous_block_sends_per_client (Maximum simultaneous block sends per client) int 40
+max_simultaneous_block_sends_per_client (Maximum simultaneous block sends per client) int 128
 
 #    To reduce lag, block transfers are slowed down when a player is building something.
 #    This determines how long they are slowed down after placing or removing a node.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -42,7 +42,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("mute_sound", "false");
 	settings->setDefault("enable_mesh_cache", "false");
 	settings->setDefault("mesh_generation_interval", "0");
-	settings->setDefault("meshgen_block_cache_size", "20");
+	settings->setDefault("meshgen_block_cache_size", "40");
 	settings->setDefault("enable_vbo", "true");
 	settings->setDefault("free_move", "false");
 	settings->setDefault("pitch_move", "false");
@@ -343,7 +343,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("port", "30000");
 	settings->setDefault("strict_protocol_version_checking", "false");
 	settings->setDefault("player_transfer_distance", "0");
-	settings->setDefault("max_simultaneous_block_sends_per_client", "40");
+	settings->setDefault("max_simultaneous_block_sends_per_client", "128");
 	settings->setDefault("time_send_interval", "5");
 
 	settings->setDefault("default_game", "minetest");


### PR DESCRIPTION
This goes together with #10616 

We used to limit `max_simultaneous_block_sends_per_client` to a small number in order to reduce client jitter.
The jitter was since addressed with a client side cache. Now this limit is woefully small.

This PR changes is increases from 40 to 128 to roughly match the default emerge-queue settings.

I'd consider this a conservative change still, but it's good enough.
(I have tried with a setting on 10000 and have observed no detriments. Other parts of the system already limit what is being send. Above 100-200 there's no improvement that I could observe. Hence 128.)

Edit: for a scene with a high viewing_range this reduced the load time from about 35s to about 18s.