### PR TITLE
Cross-reference the node level manipulation functions

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1014,7 +1014,9 @@ The function of `param2` is determined by `paramtype2` in node definition.
 * `paramtype2 = "flowingliquid"`
     * Used by `drawtype = "flowingliquid"` and `liquidtype = "flowing"`
     * The liquid level and a flag of the liquid are stored in `param2`
-    * Bits 0-2: Liquid level (0-7). The higher, the more liquid is in this node
+    * Bits 0-2: Liquid level (0-7). The higher, the more liquid is in this node;
+      see `minetest.get_node_level`, `minetest.set_node_level` and `minetest.add_node_level`
+      to access/manipulate the content of this field
     * Bit 3: If set, liquid is flowing downwards (no graphical effect)
 * `paramtype2 = "wallmounted"`
     * Supported drawtypes: "torchlike", "signlike", "normal", "nodebox", "mesh"


### PR DESCRIPTION
This can help developers find the correct functions to access and
manipulate the fluid level.

(When I was hacking around with fluids, I didn't find the relevant functions right off the bat, despite finding that param2 was the field to manipulate, so I was trying to come up with fancy ways to do the manipulation in Lua, before people on IRC pointed me to the right functions. By adding a reference to the functions I wish to spare other mod developers from missing them like I did.)