### PR TITLE
Improve touch event handling

### DIFF
--- a/src/gui/modalMenu.h
+++ b/src/gui/modalMenu.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "irrlichttypes_extrabloated.h"
+#include "irr_ptr.h"
 #include "util/string.h"
 
 class GUIModalMenu;
@@ -100,4 +101,12 @@ private:
 	// This might be necessary to expose to the implementation if it
 	// wants to launch other menus
 	bool m_allow_focus_removal = false;
+
+#ifdef __ANDROID__
+	irr_ptr<gui::IGUIElement> m_hovered;
+
+	bool simulateMouseEvent(gui::IGUIElement *target, ETOUCH_INPUT_EVENT touch_event);
+	void enter(gui::IGUIElement *element);
+	void leave();
+#endif
 };


### PR DESCRIPTION
PR contents:
~~1. `irr_ptr` improvements~~ Moved into #10808 (merged)
2. Fix inventory lists misbehavior on touchscreen (requires 1)
~~3. Allows using drag&drop for crafting just like for regular move (#8241; could be in a separate PR)~~ Moved into #10809

Inventory lists were behaving strangely on Android since 1116918. The reason is that that code relies on enter/leave events which weren’t generated on touchscreens. This PR fixes that (with some refactor). 

## To do

This PR is Ready for Review.

## How to test

Play with inventories and crafting both on touchscreen and desktop (drag&drop for item move was and is supported on desktop too; now it should work for crafting as well)

@MoNTE48