### PR TITLE
Move Mapgen V7 river generation into the main generation loop

### DIFF
--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -342,10 +342,6 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 	// Generate base and mountain terrain
 	s16 stone_surface_max_y = generateTerrain();
 
-	// Generate rivers
-	if (spflags & MGV7_RIDGES)
-		generateRidgeTerrain();
-
 	// Create heightmap
 	updateHeightmap(node_min, node_max);
 
@@ -467,6 +463,23 @@ bool MapgenV7::getMountainTerrainFromMap(int idx_xyz, int idx_xz, s16 y)
 }
 
 
+bool MapgenV7::getRiverChannelFromMap(int idx_xyz, int idx_xz, s16 y)
+{
+	// Maximum width of river channel. Creates the vertical canyon walls
+	float width = 0.2f;
+	float absuwatern = std::fabs(noise_ridge_uwater->result[idx_xz]) * 2.0f;
+	if (absuwatern > width)
+		return false;
+
+	float altitude = y - water_level;
+	float height_mod = (altitude + 17.0f) / 2.5f;
+	float width_mod = width - absuwatern;
+	float nridge = noise_ridge->result[idx_xyz] * std::fmax(altitude, 0.0f) / 7.0f;
+
+	return nridge + width_mod * height_mod >= 0.6f;
+}
+
+
 bool MapgenV7::getFloatlandTerrainFromMap(int idx_xyz, float float_offset)
 {
 	return noise_floatland->result[idx_xyz] + floatland_density - float_offset >= 0.0f;
@@ -521,6 +534,15 @@ int MapgenV7::generateTerrain()
 		}
 	}
 
+	// 'Generate rivers in this mapchunk' bool for
+	// simplification of condition checks in y-loop.
+	bool gen_rivers = (spflags & MGV7_RIDGES) && node_max.Y >= water_level - 16 &&
+		!gen_floatlands;
+	if (gen_rivers) {
+		noise_ridge->perlinMap3D(node_min.X, node_min.Y - 1, node_min.Z);
+		noise_ridge_uwater->perlinMap2D(node_min.X, node_min.Z);
+	}
+
 	//// Place nodes
 	const v3s16 &em = vm->m_area.getExtent();
 	s16 stone_surface_max_y = -MAX_MAP_GENERATION_LIMIT;
@@ -544,10 +566,13 @@ int MapgenV7::generateTerrain()
 			if (vm->m_data[vi].getContent() != CONTENT_IGNORE)
 				continue;
 
-			if (y <= surface_y) {
+			bool is_river_channel = gen_rivers &&
+				getRiverChannelFromMap(index3d, index2d, y);
+			if (y <= surface_y && !is_river_channel) {
 				vm->m_data[vi] = n_stone; // Base terrain
 			} else if ((spflags & MGV7_MOUNTAINS) &&
-					getMountainTerrainFromMap(index3d, index2d, y)) {
+					getMountainTerrainFromMap(index3d, index2d, y) &&
+					!is_river_channel) {
 				vm->m_data[vi] = n_stone; // Mountain terrain
 				if (y > stone_surface_max_y)
 					stone_surface_max_y = y;
@@ -568,46 +593,4 @@ int MapgenV7::generateTerrain()
 	}
 
 	return stone_surface_max_y;
-}
-
-
-void MapgenV7::generateRidgeTerrain()
-{
-	if (node_max.Y < water_level - 16 ||
-			(node_max.Y >= floatland_ymin && node_min.Y <= floatland_ymax))
-		return;
-
-	noise_ridge->perlinMap3D(node_min.X, node_min.Y - 1, node_min.Z);
-	noise_ridge_uwater->perlinMap2D(node_min.X, node_min.Z);
-
-	MapNode n_water(c_water_source);
-	MapNode n_air(CONTENT_AIR);
-	u32 index3d = 0;
-	float width = 0.2f;
-
-	for (s16 z = node_min.Z; z <= node_max.Z; z++)
-	for (s16 y = node_min.Y - 1; y <= node_max.Y + 1; y++) {
-		u32 vi = vm->m_area.index(node_min.X, y, z);
-		for (s16 x = node_min.X; x <= node_max.X; x++, index3d++, vi++) {
-			u32 index2d = (z - node_min.Z) * csize.X + (x - node_min.X);
-			float uwatern = noise_ridge_uwater->result[index2d] * 2.0f;
-			if (std::fabs(uwatern) > width)
-				continue;
-			// Optimises, but also avoids removing nodes placed by mods in
-			// 'on-generated', when generating outside mapchunk.
-			content_t c = vm->m_data[vi].getContent();
-			if (c != c_stone)
-				continue;
-
-			float altitude = y - water_level;
-			float height_mod = (altitude + 17.0f) / 2.5f;
-			float width_mod = width - std::fabs(uwatern);
-			float nridge = noise_ridge->result[index3d] *
-				std::fmax(altitude, 0.0f) / 7.0f;
-			if (nridge + width_mod * height_mod < 0.6f)
-				continue;
-
-			vm->m_data[vi] = (y > water_level) ? n_air : n_water;
-		}
-	}
 }

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -94,10 +94,10 @@ public:
 	float baseTerrainLevelFromMap(int index);
 	bool getMountainTerrainAtPoint(s16 x, s16 y, s16 z);
 	bool getMountainTerrainFromMap(int idx_xyz, int idx_xz, s16 y);
+	bool getRiverChannelFromMap(int idx_xyz, int idx_xz, s16 y);
 	bool getFloatlandTerrainFromMap(int idx_xyz, float float_offset);
 
 	int generateTerrain();
-	void generateRidgeTerrain();
 
 private:
 	s16 mount_zero_level;


### PR DESCRIPTION
All terrain generation now occurs in one loop, instead of rivers
being carved afterwards in a separate loop. This fixes the removal
of nodes added by mods in 'register on generated'.

Also fixes a bug where rivergen is disabled at floatland altitudes
even when floatlands are disabled.
/////////////////////////////////////////////////

Closes #7878 and closes #10638 
Having all terrain generation in one loop makes a mapgen simpler, more robust and reduces the chances of bugs. I also expect a slight performance improvement due to not needing a second generation loop.

Identical terrain test
-
I mapgen-aliased water to air in MTG and compared a map of master branch to a map of this PR.
Area was chosen to have a river channel cutting through mountains for the most thorough testing.
Config:
```
fixed_map_seed = 0
static_spawnpoint = 525, 4.5, -445
mg_flags = nodecorations,nocaves,nobiomes,nodungeons,light,noores
```
In game: `/emergeblocks (0, -32, -1000) (1000, 127, 0)`
MT mapper: `--min-y -32 --max-y 127 --geometry 100:-900+800+800`
Resulting maps are below, save and open both, switch rapidly between to check they are identical.

![rivtestair_master_100_-900_800_800](https://user-images.githubusercontent.com/3686677/99569128-28d24900-29c8-11eb-977d-25d3146bda4f.png)

^ Master branch

![rivtestair_PR](https://user-images.githubusercontent.com/3686677/99569175-35ef3800-29c8-11eb-97c6-7ecaf5a5eb78.png)

^ PR

Test bug is fixed
-
I confirmed #10638 is fixed.
Config that creates extreme height and solid mountain terrain:
```
fixed_map_seed = 0
static_spawnpoint = 525, 4.5, -445
mgv7_np_mount_height = {
	flags = eased
	lacunarity = 2
	offset = 10000
	scale = 0
	spread = (1000,1000,1000)
	seed = 72449
	octaves = 3
	persistence = 0.6
}
mgv7_np_mountain = {
	flags = 
	lacunarity = 2
	offset = 1
	scale = 0.1
	spread = (250,350,250)
	seed = 5333
	octaves = 5
	persistence = 0.63
}
```

Chunk generation time test
-
I used the commented-out timing lines in code to compare chunk generation times of PR and master. Spawning the player near a river as before.
Config:
```
max_block_generate_distance = 1
fixed_map_seed = 0
static_spawnpoint = 525, 4.5, -445
mg_flags = nodecorations,nocaves,nobiomes,nodungeons,light,noores
```
Results:
```
Master

makeChunk: 62ms
makeChunk: 51ms
makeChunk: 70ms
makeChunk: 64ms

PR

makeChunk: 60ms
makeChunk: 50ms
makeChunk: 67ms
makeChunk: 63ms
```
Surprisingly noticeable improvement of 1-3ms less.

No river channel in floatland test
-
Floatland density was increased to be almost solid. Floatlands were confirmed to not have river canyons cut into them.
Config:
```
mgv7_spflags = mountains,ridges,floatlands,caverns
fixed_map_seed = 0
static_spawnpoint = 525, 4.5, -445
mgv7_floatland_density = 1
```