### PR TITLE
Make overrideDefaults override defaults with other defaults also

### DIFF
--- a/src/defaultsettings.h
+++ b/src/defaultsettings.h
@@ -26,10 +26,3 @@ class Settings;
  * @param settings pointer to settings
  */
 void set_default_settings(Settings *settings);
-
-/**
- * override a default settings by settings from another settings element
- * @param settings target settings pointer
- * @param from source settings pointer
- */
-void override_default_settings(Settings *settings, Settings *from);

--- a/src/settings.h
+++ b/src/settings.h
@@ -232,6 +232,12 @@ private:
 	const SettingsEntry &getEntry(const std::string &name) const;
 	const SettingsEntry &getEntryDefault(const std::string &name) const;
 
+	/**************
+	 * Miscellany *
+	 **************/
+
+	void overrideDefault(const std::string &key, const SettingsEntry &entry);
+
 	// Allow TestSettings to run sanity checks using private functions.
 	friend class TestSettings;
 


### PR DESCRIPTION

Makes `Settings::overrideDefaults` override defaults with other settings and defaults instead of only other settings only.

Fixes #10555

Also removed pointless `override_default_settings` declaration in `defaultsettings.h`.

## To do

This PR is a Ready for Review.

## How to test

#10555 has a good test case.

Here is another one:

Add to **game's** minetest.conf following line:
```
mg_flags = nocaves, nodungeons, light
```
Add to **main** minetest.conf following line:
```
mg_flags = dungeons, nolight
```
Create a new map and check that map_meta.txt file contains following line:
```
mg_flags = nocaves, dungeons, nolight, decorations, biomes, ores
```
This is the result of main minetest.conf overriding game's minetest.conf overriding default settings.


Effect can only be seen on map settings. There is one other use of `overrideDefaults` but the overriding settings have no defaults, so behavior is not changed.
