### PR TITLE
Fix falling node rotation of wallmounted nodebox/mesh

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -152,8 +152,8 @@ core.register_entity(":__builtin:falling_node", {
 			else
 				self.object:set_yaw(-math.pi*0.25)
 			end
-		elseif (node.param2 ~= 0 and (def.wield_image == ""
-				or def.wield_image == nil))
+		elseif ((node.param2 ~= 0 or def.drawtype == "nodebox" or def.drawtype == "mesh")
+				and (def.wield_image == "" or def.wield_image == nil))
 				or def.drawtype == "signlike"
 				or def.drawtype == "mesh"
 				or def.drawtype == "normal"
@@ -168,16 +168,30 @@ core.register_entity(":__builtin:falling_node", {
 			elseif (def.paramtype2 == "wallmounted" or def.paramtype2 == "colorwallmounted") then
 				local rot = node.param2 % 8
 				local pitch, yaw, roll = 0, 0, 0
-				if rot == 1 then
-					pitch, yaw = math.pi, math.pi
-				elseif rot == 2 then
-					pitch, yaw = math.pi/2, math.pi/2
-				elseif rot == 3 then
-					pitch, yaw = math.pi/2, -math.pi/2
-				elseif rot == 4 then
-					pitch, yaw = math.pi/2, math.pi
-				elseif rot == 5 then
-					pitch, yaw = math.pi/2, 0
+				if def.drawtype == "nodebox" or def.drawtype == "mesh" then
+					if rot == 0 then
+						pitch, yaw = math.pi/2, 0
+					elseif rot == 1 then
+						pitch, yaw = -math.pi/2, math.pi
+					elseif rot == 2 then
+						pitch, yaw = 0, math.pi/2
+					elseif rot == 3 then
+						pitch, yaw = 0, -math.pi/2
+					elseif rot == 4 then
+						pitch, yaw = 0, math.pi
+					end
+				else
+					if rot == 1 then
+						pitch, yaw = math.pi, math.pi
+					elseif rot == 2 then
+						pitch, yaw = math.pi/2, math.pi/2
+					elseif rot == 3 then
+						pitch, yaw = math.pi/2, -math.pi/2
+					elseif rot == 4 then
+						pitch, yaw = math.pi/2, math.pi
+					elseif rot == 5 then
+						pitch, yaw = math.pi/2, 0
+					end
 				end
 				if def.drawtype == "signlike" then
 					pitch = pitch - math.pi/2
@@ -186,7 +200,7 @@ core.register_entity(":__builtin:falling_node", {
 					elseif rot == 1 then
 						yaw = yaw - math.pi/2
 					end
-				elseif def.drawtype == "mesh" or def.drawtype == "normal" then
+				elseif def.drawtype == "mesh" or def.drawtype == "normal" or def.drawtype == "nodebox" then
 					if rot >= 0 and rot <= 1 then
 						roll = roll + math.pi
 					else


### PR DESCRIPTION
## Context

This fixes a bug I have introduced in #9299 (whoops!).

In #9299 have changed the rotation of the inventory image of wallmounted nodeboxes and meshes in that PR so in the inventory image they look like they "attach" to an invisible wall (this is done by the engine pretending these nodes have `param2=1`). I thought this looks nice.

This, however, broke the rotation of the falling node version of these nodes.

## The bugfix

This PR will fix the rotation of falling nodes that have drawtype `nodebox` or `mesh`, and paramtype2 of `wallmounted`.

## How to test

I already tested this myself, but feel free to test yourself. Here's how:

Generate a flat world in DevTest, enter `/test_place_nodes`. Wait for the nodes to appear.
Look for these nodes (the nodes are sorted alphabetically by itemstring):

* `testnodes:colorwallmounted`
* `testnodes:colorwallmounted_nodebox`
* `testnodes:mesh_wallmounted`
* `testnodes:mesh_colorwallmounted`
* `testnodes:wallmounted`
* `testnodes:wallmounted_nodebox`

These nodes are placed in all eliglble `param2` variants.

Use the Falling Node Tool and rightclick all those nodes. Check if the rotation of the falling node is correct (i.e. the falling node entity must have the same rotation as the actual node).

If you want, you can also test other nodes.

If you spot any mistake, please tell me itemstring + param2 value. Thank you for reading.