### PR TITLE
Temporary fix for Android inventory list hovering bug

### DIFF
--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -106,7 +106,11 @@ void GUIInventoryList::draw()
 			&& selected_item->i == item_i;
 		core::rect<s32> clipped_rect(rect);
 		clipped_rect.clipAgainst(AbsoluteClippingRect);
+#ifdef __ANDROID__
+		bool hovering = false;
+#else
 		bool hovering = m_hovered_i == item_i;
+#endif
 		ItemRotationKind rotation_kind = selected ? IT_ROT_SELECTED :
 			(hovering ? IT_ROT_HOVERED : IT_ROT_NONE);
 


### PR DESCRIPTION
On Android, when an inventory list slot is tapped, it stays in the hovered state even when the finger leaves the slot and/or the list entirely which looks bad, especially on multiple inventory lists.  This PR disables slot highlighting completely on Android as a temporary fix, mainly because the inventory list code is such a huge mess.

I am unfortunately unable to test this out because a) I am terrible at compiling Minetest on Windows, and I have no luck with Android either and b) the artifacts made with GitHub Actions won't run on my Android device even when security for downloaded apps is disabled (so me compiling it myself probably wouldn't help anyway).  I still made this PR because it's rather trivial and should work and because someone requested it, and I like to keep my commitments.

## To do

This PR is Ready for Review.

## How to test

Tap on slots and ensure that they aren't hovered or anything funky happens with them.