### PR TITLE
Supersede motley c_converter.cpp functions with templated LuaHelper functions

### DIFF
--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -24,6 +24,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /*             not being a script/modapi file!!!!!!!!                         */
 /******************************************************************************/
 /******************************************************************************/
+
+// Notice: All functions in this file that have been superseded by LuaHelper
+// functions (e.g. readParam, pushParam, etc.) are now deprecated.
+
 #pragma once
 
 #include <vector>

--- a/src/script/common/helper.cpp
+++ b/src/script/common/helper.cpp
@@ -17,116 +17,345 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#define LUA_HELPER_KEEP_TEMPLATE_MACRO
+
 #include "helper.h"
 #include <cmath>
-#include <sstream>
-#include <irr_v2d.h>
-#include <irr_v3d.h>
 #include "c_types.h"
 #include "c_internal.h"
 
-// imported from c_converter.cpp with pure C++ style
-static inline void check_lua_type(lua_State *L, int index, const char *name, int type)
+void LuaHelper::invalidType(lua_State *L, int index, const std::string &name, int type)
 {
-	int t = lua_type(L, index);
-	if (t != type) {
-		std::string traceback = script_get_backtrace(L);
-		throw LuaError(std::string("Invalid ") + (name) + " (expected " +
-				lua_typename(L, (type)) + " got " + lua_typename(L, t) +
-				").\n" + traceback);
-	}
+	throw LuaError(std::string("Invalid ") + name + " (expected " +
+		lua_typename(L, type) + " got " + lua_typename(L, lua_type(L, index)) +
+		").\n" + script_get_backtrace(L));
 }
 
-// imported from c_converter.cpp
-#define CHECK_POS_COORD(name)                                                            \
-	check_lua_type(L, -1, "position coordinate '" name "'", LUA_TNUMBER)
-#define CHECK_POS_TAB(index) check_lua_type(L, index, "position", LUA_TTABLE)
-
-bool LuaHelper::isNaN(lua_State *L, int idx)
+template <typename T> T LuaHelper::readParamField(
+	lua_State *L, int index, const char *field)
 {
-	return lua_type(L, idx) == LUA_TNUMBER && std::isnan(lua_tonumber(L, idx));
+	lua_getfield(L, index, field);
+	T value = readParam<T>(L, -1);
+	lua_pop(L, 1);
+	return value;
 }
 
-/*
- * Read template functions
- */
+template <typename T> T LuaHelper::readParamField(
+	lua_State *L, int index, const char *field, const T &def)
+{
+	if (lua_isnoneornil(L, index))
+		return def;
+
+	lua_getfield(L, index, field);
+	T value = readParam<T>(L, -1, def);
+	lua_pop(L, 1);
+
+	return value;
+}
+
+template <typename T> T LuaHelper::readParamIndex(lua_State *L, int index, int n)
+{
+	lua_rawgeti(L, index, n);
+	T ret = readParam<T>(L, -1);
+	lua_pop(L, 1);
+	return ret;
+}
+
+template <typename T> T LuaHelper::readParamIndex(
+	lua_State *L, int index, int n, const T &def)
+{
+	if (lua_isnoneornil(L, index))
+		return def;
+
+	lua_rawgeti(L, index, n);
+	T ret = readParam<T>(L, -1, def);
+	lua_pop(L, 1);
+
+	return ret;
+}
+
+/* bool */
+
+template <> std::string LuaHelper::getTypeName<bool>(bool plural)
+{
+	return plural ? "booleans" : "boolean";
+}
+
+template <> bool LuaHelper::paramIsType<bool>(lua_State *L, int index)
+{
+	return lua_isboolean(L, index);
+}
+
+template <> void LuaHelper::checkParamType<bool>(lua_State *L, int index)
+{
+	if (!lua_isboolean(L, index))
+		invalidType(L, index, getTypeName<bool>(), LUA_TBOOLEAN);
+}
+
 template <> bool LuaHelper::readParam(lua_State *L, int index)
 {
-	return lua_toboolean(L, index) != 0;
+	return lua_toboolean(L, index);
 }
 
-template <> s16 LuaHelper::readParam(lua_State *L, int index)
+template <> void LuaHelper::pushParam(lua_State *L, const bool &value)
+{
+	lua_pushboolean(L, value);
+}
+
+/* integer types */
+
+SPECIAL_TEMPLATE(LuaHelper::is_integer) std::string LuaHelper::getTypeName(
+	bool plural)
+{
+	return plural ? "integers" : "integer";
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_integer) bool LuaHelper::paramIsType(
+	lua_State *L, int index)
+{
+	return lua_isnumber(L, index);
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_integer) void LuaHelper::checkParamType(
+	lua_State *L, int index)
+{
+	if (!lua_isnumber(L, index))
+		invalidType(L, index, getTypeName<T>(), LUA_TNUMBER);
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_integer) T LuaHelper::readParam(lua_State *L, int index)
 {
 	return lua_tonumber(L, index);
 }
 
-template <> int LuaHelper::readParam(lua_State *L, int index)
+SPECIAL_TEMPLATE(LuaHelper::is_integer) void LuaHelper::pushParam(
+	lua_State *L, const T &value)
 {
-	return luaL_checkint(L, index);
+	lua_pushnumber(L, value);
+}
+
+/* float */
+
+template <> std::string LuaHelper::getTypeName<float>(bool plural)
+{
+	return plural ? "numbers" : "number";
+}
+
+template <> bool LuaHelper::paramIsType<float>(lua_State *L, int index)
+{
+	return lua_isnumber(L, index);
+}
+
+template <> void LuaHelper::checkParamType<float>(lua_State *L, int index)
+{
+	if (!lua_isnumber(L, index))
+		invalidType(L, index, getTypeName<float>(), LUA_TNUMBER);
 }
 
 template <> float LuaHelper::readParam(lua_State *L, int index)
 {
-	if (isNaN(L, index))
+	float num = lua_tonumber(L, index);
+	if (std::isnan(num))
 		throw LuaError("NaN value is not allowed.");
-
-	return (float)luaL_checknumber(L, index);
+	return num;
 }
 
-template <> v2s16 LuaHelper::readParam(lua_State *L, int index)
+template <> void LuaHelper::pushParam(lua_State *L, const float &value)
 {
-	v2s16 p;
-	CHECK_POS_TAB(index);
-	lua_getfield(L, index, "x");
-	CHECK_POS_COORD("x");
-	p.X = readParam<s16>(L, -1);
-	lua_pop(L, 1);
-	lua_getfield(L, index, "y");
-	CHECK_POS_COORD("y");
-	p.Y = readParam<s16>(L, -1);
-	lua_pop(L, 1);
-	return p;
+	lua_pushnumber(L, value);
 }
 
-template <> v2f LuaHelper::readParam(lua_State *L, int index)
+/* double */
+
+template <> std::string LuaHelper::getTypeName<double>(bool plural)
 {
-	v2f p;
-	CHECK_POS_TAB(index);
-	lua_getfield(L, index, "x");
-	CHECK_POS_COORD("x");
-	p.X = readParam<float>(L, -1);
-	lua_pop(L, 1);
-	lua_getfield(L, index, "y");
-	CHECK_POS_COORD("y");
-	p.Y = readParam<float>(L, -1);
-	lua_pop(L, 1);
-	return p;
+	return plural ? "numbers" : "number";
 }
 
-template <> v3f LuaHelper::readParam(lua_State *L, int index)
+template <> bool LuaHelper::paramIsType<double>(lua_State *L, int index)
 {
-	v3f p;
-	CHECK_POS_TAB(index);
-	lua_getfield(L, index, "x");
-	CHECK_POS_COORD("x");
-	p.X = readParam<float>(L, -1);
-	lua_pop(L, 1);
-	lua_getfield(L, index, "y");
-	CHECK_POS_COORD("y");
-	p.Y = readParam<float>(L, -1);
-	lua_pop(L, 1);
-	lua_getfield(L, index, "z");
-	CHECK_POS_COORD("z");
-	p.Z = readParam<float>(L, -1);
-	lua_pop(L, 1);
-	return p;
+	return lua_isnumber(L, index);
+}
+
+template <> void LuaHelper::checkParamType<double>(lua_State *L, int index)
+{
+	if (!lua_isnumber(L, index))
+		invalidType(L, index, getTypeName<double>(), LUA_TNUMBER);
+}
+
+template <> double LuaHelper::readParam(lua_State *L, int index)
+{
+	return lua_tonumber(L, index);
+}
+
+template <> void LuaHelper::pushParam(lua_State *L, const double &value)
+{
+	lua_pushnumber(L, value);
+}
+
+/* std::string */
+
+template <> std::string LuaHelper::getTypeName<std::string>(bool plural)
+{
+	return plural ? "strings" : "string";
+}
+
+template <> bool LuaHelper::paramIsType<std::string>(lua_State *L, int index)
+{
+	return lua_isstring(L, index);
+}
+
+template <> void LuaHelper::checkParamType<std::string>(lua_State *L, int index)
+{
+	if (!lua_isstring(L, index))
+		invalidType(L, index, getTypeName<std::string>(), LUA_TSTRING);
 }
 
 template <> std::string LuaHelper::readParam(lua_State *L, int index)
 {
+	checkParamType<std::string>(L, index);
+
 	size_t length;
 	std::string result;
-	const char *str = luaL_checklstring(L, index, &length);
+
+	const char *str = lua_tolstring(L, index, &length);
+
 	result.assign(str, length);
 	return result;
+}
+
+template <> void LuaHelper::pushParam(lua_State *L, const std::string &value)
+{
+	lua_pushlstring(L, value.c_str(), value.size());
+}
+
+/* core::vector2d */
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector2d) std::string LuaHelper::getTypeName(
+	bool plural)
+{
+	return plural ? "2D positions/vectors" : "2D position/vector";
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector2d) bool LuaHelper::paramIsType(
+	lua_State *L, int index)
+{
+	return lua_istable(L, index);
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector2d) void LuaHelper::checkParamType(
+	lua_State *L, int index)
+{
+	if (!lua_istable(L, index))
+		invalidType(L, index, getTypeName<T>(), LUA_TTABLE);
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector2d) T LuaHelper::readParam(lua_State *L, int index)
+{
+	checkParamType<T>(L, index);
+	return {
+		readParamField<is_vector2d<T>::value_type>(L, -1, "x"),
+		readParamField<is_vector2d<T>::value_type>(L, -1, "y")
+	};
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector2d) void LuaHelper::pushParam(
+	lua_State *L, const T &value)
+{
+	lua_createtable(L, 0, 2);
+
+	pushParam<is_vector2d<T>::value_type>(L, value.X);
+	lua_setfield(L, -2, "x");
+
+	pushParam<is_vector2d<T>::value_type>(L, value.Y);
+	lua_setfield(L, -2, "y");
+}
+
+/* core::vector3d */
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector3d) std::string LuaHelper::getTypeName(
+bool plural)
+{
+	return plural ? "3D positions/vectors" : "3D position/vector";
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector3d) bool LuaHelper::paramIsType(
+	lua_State *L, int index)
+{
+	return lua_istable(L, index);
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector3d) void LuaHelper::checkParamType(
+	lua_State *L, int index)
+{
+	if (!lua_istable(L, index))
+		invalidType(L, index, getTypeName<T>(), LUA_TTABLE);
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector3d) T LuaHelper::readParam(lua_State *L, int index)
+{
+	checkParamType<T>(L, index);
+	return {
+		readParamField<is_vector2d<T>::value_type>(L, -1, "x"),
+		readParamField<is_vector2d<T>::value_type>(L, -1, "y"),
+		readParamField<is_vector2d<T>::value_type>(L, -1, "z")
+	};
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector3d) void LuaHelper::pushParam(
+	lua_State *L, const T &value)
+{
+	lua_createtable(L, 0, 3);
+
+	pushParam<is_vector2d<T>::value_type>(L, value.X);
+	lua_setfield(L, -2, "x");
+
+	pushParam<is_vector2d<T>::value_type>(L, value.Y);
+	lua_setfield(L, -2, "y");
+
+	pushParam<is_vector2d<T>::value_type>(L, value.Z);
+	lua_setfield(L, -2, "z");
+}
+
+/* std::vector */
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector) std::string LuaHelper::getTypeName(
+	bool plural)
+{
+	std::string start;
+	if (plural)
+		start = "arrays of ";
+	else
+		start = "array of ";
+	return start + getTypeName<typename T::value_type>(true);
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector) bool LuaHelper::paramIsType(
+	lua_State *L, int index)
+{
+	return lua_istable(L, index);
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector) void LuaHelper::checkParamType(
+	lua_State *L, int index)
+{
+	if (!lua_istable(L, index))
+		invalidType(L, index, getTypeName<T>(), LUA_TTABLE);
+}
+
+SPECIAL_TEMPLATE(LuaHelper::is_vector) T LuaHelper::readParam(lua_State *L, int index)
+{
+	checkParamType<T>(L, index, getTypeName<T>(), LUA_TTABLE);
+
+	size_t len = lua_objlen(L, index);
+	T vector;
+	vector.reserve(len);
+
+	for (size_t i = 1; i <= len; i++) {
+		lua_rawgeti(L, index, i);
+		vector.push_back(readParam<typename T::value_type>(L, -1));
+		lua_pop(L, 1);
+	}
+
+	return vector;
 }

--- a/src/script/common/helper.h
+++ b/src/script/common/helper.h
@@ -24,34 +24,231 @@ extern "C" {
 #include <lauxlib.h>
 }
 
+#include <vector>
+#include <string>
+#include "irrlichttypes_extrabloated.h"
+
 class LuaHelper
 {
+private:
+#define MAKE_SINGLE_ARG(name, type)									\
+	template <typename T> struct name : public std::false_type {	\
+		typedef T value_type;										\
+	};																\
+	template <typename T>											\
+	struct name<type<T>> : public std::true_type {					\
+		typedef T value_type;										\
+	};
+
+#define MAKE_MULTI_ARG(name, type)									\
+	template <typename T> struct name : public std::false_type {	\
+		typedef T value_type;										\
+	};																\
+	template <typename T, typename... Args>							\
+	struct name<type<T, Args...>> : public std::true_type {			\
+		typedef T value_type;										\
+	};
+
+	MAKE_SINGLE_ARG(is_vector2d, core::vector2d)
+	MAKE_SINGLE_ARG(is_vector3d, core::vector3d)
+
+	MAKE_MULTI_ARG(is_vector, std::vector)
+
+#undef MAKE_SINGLE_ARG
+#undef MAKE_MULTI_ARG
+
+	// Specializations are outside of the class
+	template <typename T> struct is_integer : public std::false_type {
+		typedef T value_type;
+	};
+
+#define SPECIAL_TEMPLATE(name) template <typename T, \
+	typename std::enable_if<name<T>::value>::type* = nullptr>
+#define DISABLE_TEMPLATE template <typename T, typename std::enable_if< \
+		!is_integer<T>::value &&	\
+		!is_vector<T>::value &&		\
+		!is_vector2d<T>::value &&	\
+		!is_vector3d<T>::value		\
+	>::type* = nullptr>
+
+#define TEMPLATES(function)					\
+	DISABLE_TEMPLATE function;				\
+	SPECIAL_TEMPLATE(is_integer) function;	\
+	SPECIAL_TEMPLATE(is_vector2d) function;	\
+	SPECIAL_TEMPLATE(is_vector3d) function;	\
+	SPECIAL_TEMPLATE(is_vector) function
+
 protected:
-	static bool isNaN(lua_State *L, int idx);
+	/**
+	 * Displays an error message appropriate for invalid or unexpected types
+	 *
+	 * @param L Lua state
+	 * @param index Index on the Lua stack that was erroneous
+	 * @param name Name of the expected type
+	 * @param type Expected Lua type
+	 */
+	static void invalidType(lua_State *L, int index, const std::string &name, int type);
 
 	/**
-	 * Read a value using a template type T from Lua State L and index
-	 *
-	 *
-	 * @tparam T type to read from Lua
-	 * @param L Lua state
-	 * @param index Lua Index to read
-	 * @return read value from Lua
+	 * Returns a human-readable description string of the type T.
 	 */
-	template <typename T> static T readParam(lua_State *L, int index);
+	TEMPLATES(static std::string getTypeName(bool plural = false));
 
 	/**
-	 * Read a value using a template type T from Lua State L and index
+	 * Returns whether the given value on the Lua stack is of type T.
 	 *
-	 * @tparam T type to read from Lua
+	 * @tparam T Type to check
 	 * @param L Lua state
-	 * @param index Lua Index to read
-	 * @param default_value default value to apply if nil
-	 * @return read value from Lua or default value if nil
+	 * @param index Index on the Lua stack to check
 	 */
-	template <typename T>
-	static inline T readParam(lua_State *L, int index, const T &default_value)
+	TEMPLATES(static bool paramIsType(lua_State *L, int index));
+
+	/**
+	 * Throws an error if the given value on the Lua stack is not of type T.
+	 *
+	 * @tparam T Type to check
+	 * @param L Lua state
+	 * @param index Index on the Lua stack to check
+	 */
+	TEMPLATES(static void checkParamType(lua_State *L, int index));
+
+	/**
+	 * Read a value of type T from the Lua stack.
+	 *
+	 * @tparam T Type to read from Lua
+	 * @param L Lua state
+	 * @param index Index on the Lua stack to read from
+	 * @return Value read from the stack
+	 */
+	TEMPLATES(static T readParam(lua_State *L, int index));
+
+	/**
+	 * Read a value of type T from the Lua stack, returning a default value if the
+	 * index is nil or none.
+	 *
+	 * @tparam T Type to read from Lua
+	 * @param L Lua state
+	 * @param index Index on the Lua stack to read from
+	 * @param def Default value to return if nil
+	 * @return Value read from the stack or `def` if nil
+	 */
+	template <typename T> static T readParam(
+		lua_State *L, int index, const T &def)
 	{
-		return lua_isnoneornil(L, index) ? default_value : readParam<T>(L, index);
+		return paramIsType<T>(L, index) ? readParam<T>(L, index) : def;
+	}
+
+	/**
+	 * Read a value of type T from a table field on the Lua stack.
+	 *
+	 * @tparam T Type to read from Lua
+	 * @param L Lua state
+	 * @param index Index on the Lua stack of the table to read from
+	 * @param field Name of the field in the table to read from
+	 * @return Value read from the table
+	 */
+	template <typename T> static T readParamField(
+		lua_State *L, int index, const char *field);
+
+	/**
+	 * Read a value of type T from a table field on the Lua stack, returning a default
+	 * value if the index is nil or none or the table field is nonexistent.
+	 *
+	 * @tparam T Type to read from Lua
+	 * @param L Lua state
+	 * @param index Index on the Lua stack of the table to read from
+	 * @param field Name of the field in the table to read from
+	 * @param def Default value to return if the field is nonexistent
+	 * @return Value read from the table or `def` if nil or nonexistent
+	 */
+	template <typename T> static T readParamField(
+		lua_State *L, int index, const char *field, const T &def);
+
+	/**
+	 * Read a value of type T from a table index on the Lua stack.
+	 *
+	 * @tparam T Type to read from Lua
+	 * @param L Lua state
+	 * @param index Index on the Lua stack of the table to read from
+	 * @param n Index in the table to read from
+	 * @return Value read from the table
+	 */
+	template <typename T> static T readParamIndex(lua_State *L, int index, int n);
+
+	/**
+	 * Read a value of type T from a table index on the Lua stack, returning a default
+	 * value if the index is nil or none or the table field is nonexistent.
+	 *
+	 * @tparam T Type to read from Lua
+	 * @param L Lua state
+	 * @param index Index on the Lua stack of the table to read from
+	 * @param n Index in the table to read from
+	 * @param def Default value to return if the field is nonexistent
+	 * @return Value read from the table or `def` if nil or nonexistent
+	 */
+	template <typename T> static T readParamIndex(
+		lua_State *L, int index, int n, const T &def);
+
+	/**
+	 * Pushes a value of type T to the top of the Lua stack.
+	 *
+	 * @tparam T Type to push to Lua
+	 * @param L Lua state
+	 * @param value Value to push to the stack
+	 */
+	TEMPLATES(static void pushParam(lua_State *L, const T &value));
+
+	/**
+	 * Sets a specified field in a Lua table to a value of type T.
+	 *
+	 * @tparam T Type to push to Lua
+	 * @param L Lua state
+	 * @param index Index on the Lua stack of the table to write to
+	 * @param field Name of the field in the table to write to
+	 * @param value Value to push to the stack
+	 */
+	template <typename T> static void setParamField(
+		lua_State *L, int index, const char *field, const T &value)
+	{
+		pushParam<T>(L, value);
+		lua_setfield(L, index, field);
+	}
+
+	/**
+	 * Sets a specified index in a Lua table to a value of type T.
+	 *
+	 * @tparam T Type to push to Lua
+	 * @param L Lua state
+	 * @param index Index on the Lua stack of the table to write to
+	 * @param n Index in the table to write to
+	 * @param value Value to push to the stack
+	 */
+	template <typename T> static void setParamIndex(
+		lua_State *L, int index, int n, const T &value)
+	{
+		pushParam<T>(L, value);
+		lua_rawseti(L, index, n);
 	}
 };
+
+// C++11 has a defect where explicit specializations must be outside of the class scope
+#define MAKE_INT(type)															\
+	template <> struct LuaHelper::is_integer<type> : public std::true_type {	\
+		typedef type value_type;												\
+	};
+MAKE_INT(s8)
+MAKE_INT(s16)
+MAKE_INT(s32)
+MAKE_INT(s64)
+MAKE_INT(u8)
+MAKE_INT(u16)
+MAKE_INT(u32)
+MAKE_INT(u64)
+#undef MAKE_INT
+
+#ifndef LUA_HELPER_KEEP_TEMPLATE_MACRO
+#undef SPECIAL_TEMPLATE
+#endif
+
+#undef DISABLE_TEMPLATE
+#undef TEMPLATES

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -892,9 +892,6 @@ int ObjectRef::l_set_yaw(lua_State *L)
 	if (entitysao == nullptr)
 		return 0;
 
-	if (isNaN(L, 2))
-		throw LuaError("ObjectRef::set_yaw: NaN value is not allowed.");
-
 	float yaw = readParam<float>(L, 2) * core::RADTODEG;
 
 	entitysao->setRotation(v3f(0, yaw, 0));

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -40,6 +40,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/hex.h"
 #include "util/sha1.h"
 #include <algorithm>
+#include <cmath>
 
 
 // log([level,] text)
@@ -244,7 +245,7 @@ int ModApiUtil::l_is_nan(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	lua_pushboolean(L, isNaN(L, 1));
+	lua_pushboolean(L, std::isnan(lua_tonumber(L, 1)));
 	return 1;
 }
 


### PR DESCRIPTION
Interacting with the Lua stack is a bit of a pain and is prone to confusion and accidents (such as the recent l_object.cpp cleanup).  In addition, there are tons of functions in c_converter.cpp that contain much code duplication such as `read_v2f`, `read_v2s32`, `read_v2s16`, etc, and `LuaHelper::readParam` is just a copy of those issues mostly.  Therefore, this PR aims to clean things up by extending `LuaHelper` with stack reading, writing, type checking, etc and remove code duplication through the usage of templates.

Here's a rough overview:
`LuaHelper` now has these functions (`readParam` already existed, but is improved):
| Function | Description |
|---|---|
| `T readParam(lua_State *L, int index)` | Reads from the Lua stack (supported types will come later) |
| `T readParam(lua_State *L, int index, const T &def)` | Reads from the Lua stack or returns `def` if the given index is nil or none |
| `T readParamField(lua_State *L, int index, const char *field)` | Reads from a table field. Also has default variant |
| `T readParamIndex(lua_State *L, int index, int n)` | Reads from a table index. Also has default variant |
| `std::string getTypeName(bool plural = false)` | Gets a human-readable string of the type name. Useful for error messages. |
| `bool paramIsType<T>(lua_State *L, int index)` | Returns true if the value on the stack is of type T. |
| `void checkParamType<T>(lua_State *L, int index)` | Throws an error if the value on the stack is not of type T. |
| `void pushParam(lua_State *L, const T &value)` | Pushes a value to the Lua stack. |
| `void setParamField(lua_State *L, int index, const char *field, const T &value)` | Sets a field in a table to the specified value. |
| `void setParamIndex(lua_State *L, int index, int n, const T &value)` | Sets an index in a table to the specified value. |

The following values for reading/writing are currently supported (more can definitely be added):
* `bool`
* All integer types
* `float` and `double`
* `std::string`
* `core::vector2d<T>` and `core::vector3d<T>` where `T` is any other supported type
* `std::vector<T>`

So, for instance, it is possible to do `readParam<std::vector<core::vector3d<u32>>>(L, index);` and similarly with pushing with no extra code added to `LuaHelper`.

The pros seem obvious now, but the main con is that it uses complex templates and macros to simplify those templates to achieve this goal.  If all the pros of this outweigh the cons of complicated templates in `LuaHelper`, then I will continue work and add some more functionality and types.

## To do

This PR is a Work in Progress.  More types need adding and testing is necessary (I haven't done much testing).  I want opinions to know if the benefits outweigh the extra complexity before continuing work.

## How to test

I'll probably replace a few files containing c_converter stuff to the new things.  If possible, also unit testing (although that may be hard with Lua).