### PR TITLE
Pause animations while game is paused 

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -68,6 +68,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/pointedthing.h"
 #include "util/quicktune_shortcutter.h"
 #include "irrlicht_changes/static_text.h"
+#include "irr_ptr.h"
 #include "version.h"
 #include "script/scripting_client.h"
 #include "hud.h"
@@ -802,6 +803,9 @@ private:
 	void showDeathFormspec();
 	void showPauseMenu();
 
+	void pauseAnimation();
+	void resumeAnimation();
+
 	// ClientEvent handlers
 	void handleClientEvent_None(ClientEvent *event, CameraOrientation *cam);
 	void handleClientEvent_PlayerDamage(ClientEvent *event, CameraOrientation *cam);
@@ -876,6 +880,7 @@ private:
 	std::string *error_message;
 	bool *reconnect_requested;
 	scene::ISceneNode *skybox;
+	std::vector<std::pair<irr_ptr<scene::IAnimatedMeshSceneNode>, float>> paused_animated_nodes;
 
 	bool simple_singleplayer_mode;
 	/* End 'cache' */
@@ -2487,11 +2492,41 @@ inline void Game::step(f32 *dtime)
 	if (can_be_and_is_paused) { // This is for a singleplayer server
 		*dtime = 0;             // No time passes
 	} else {
+		if (simple_singleplayer_mode && !paused_animated_nodes.empty())
+			resumeAnimation();
+
 		if (server)
 			server->step(*dtime);
 
 		client->step(*dtime);
 	}
+}
+
+static void pauseNodeAnimation(std::vector<std::pair<irr_ptr<scene::IAnimatedMeshSceneNode>, float>> &paused, scene::ISceneNode *node) {
+	if (!node)
+		return;
+	for (auto &&child: node->getChildren())
+		pauseNodeAnimation(paused, child);
+	if (node->getType() != scene::ESNT_ANIMATED_MESH)
+		return;
+	auto animated_node = static_cast<scene::IAnimatedMeshSceneNode *>(node);
+	float speed = animated_node->getAnimationSpeed();
+	if (!speed)
+		return;
+	paused.push_back({grab(animated_node), speed});
+	animated_node->setAnimationSpeed(0.0f);
+}
+
+void Game::pauseAnimation()
+{
+	pauseNodeAnimation(paused_animated_nodes, smgr->getRootSceneNode());
+}
+
+void Game::resumeAnimation()
+{
+	for (auto &&pair: paused_animated_nodes)
+		pair.first->setAnimationSpeed(pair.second);
+	paused_animated_nodes.clear();
 }
 
 const ClientEventHandler Game::clientEventHandler[CLIENTEVENT_MAX] = {
@@ -4224,6 +4259,9 @@ void Game::showPauseMenu()
 			fs_src, txt_dst, client->getFormspecPrepend(), sound);
 	formspec->setFocus("btn_continue");
 	formspec->doPause = true;
+
+	if (simple_singleplayer_mode)
+		pauseAnimation();
 }
 
 /****************************************************************************/

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -654,6 +654,8 @@ struct ClientEventHandler
  THE GAME
  ****************************************************************************/
 
+using PausedNodesList = std::vector<std::pair<irr_ptr<scene::IAnimatedMeshSceneNode>, float>>;
+
 /* This is not intended to be a public class. If a public class becomes
  * desirable then it may be better to create another 'wrapper' class that
  * hides most of the stuff in this class (nothing in this class is required
@@ -880,7 +882,7 @@ private:
 	std::string *error_message;
 	bool *reconnect_requested;
 	scene::ISceneNode *skybox;
-	std::vector<std::pair<irr_ptr<scene::IAnimatedMeshSceneNode>, float>> paused_animated_nodes;
+	PausedNodesList paused_animated_nodes;
 
 	bool simple_singleplayer_mode;
 	/* End 'cache' */
@@ -2502,7 +2504,7 @@ inline void Game::step(f32 *dtime)
 	}
 }
 
-static void pauseNodeAnimation(std::vector<std::pair<irr_ptr<scene::IAnimatedMeshSceneNode>, float>> &paused, scene::ISceneNode *node) {
+static void pauseNodeAnimation(PausedNodesList &paused, scene::ISceneNode *node) {
 	if (!node)
 		return;
 	for (auto &&child: node->getChildren())


### PR DESCRIPTION
Pause all mesh animations while game is paused.

## To do

This PR is Ready for Review.

## How to test

Open a singleplayer world, look at a walikng mob, pause game. Walking animation should supsend.