### PR TITLE
Improve sky rendering performance

### DIFF
--- a/client/shaders/stars_shader/opengl_fragment.glsl
+++ b/client/shaders/stars_shader/opengl_fragment.glsl
@@ -1,0 +1,6 @@
+uniform vec4 starColor;
+
+void main(void)
+{
+	gl_FragColor = starColor;
+}

--- a/client/shaders/stars_shader/opengl_vertex.glsl
+++ b/client/shaders/stars_shader/opengl_vertex.glsl
@@ -1,0 +1,4 @@
+void main(void)
+{
+	gl_Position = mWorldViewProj * inVertexPosition;
+}

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -170,8 +170,9 @@ void Clouds::render()
 
 	// Read noise
 
-	bool *grid = new bool[m_cloud_radius_i * 2 * m_cloud_radius_i * 2];
-
+	std::vector<char> grid(m_cloud_radius_i * 2 * m_cloud_radius_i * 2); // vector<bool> is broken
+	std::vector<video::S3DVertex> vertices;
+	vertices.reserve(16 * m_cloud_radius_i * m_cloud_radius_i);
 
 	for(s16 zi = -m_cloud_radius_i; zi < m_cloud_radius_i; zi++) {
 		u32 si = (zi + m_cloud_radius_i) * m_cloud_radius_i * 2 + m_cloud_radius_i;
@@ -195,12 +196,7 @@ void Clouds::render()
 	{
 		s16 zi = zi0;
 		s16 xi = xi0;
-		// Draw from front to back (needed for transparency)
-		/*if(zi <= 0)
-			zi = -m_cloud_radius_i - zi;
-		if(xi <= 0)
-			xi = -m_cloud_radius_i - xi;*/
-		// Draw from back to front
+		// Draw from back to front for proper transparency
 		if(zi >= 0)
 			zi = m_cloud_radius_i - zi - 1;
 		if(xi >= 0)
@@ -220,17 +216,10 @@ void Clouds::render()
 			video::S3DVertex(0,0,0, 0,0,0, c_top, 0, 0)
 		};
 
-		/*if(zi <= 0 && xi <= 0){
-			v[0].Color.setBlue(255);
-			v[1].Color.setBlue(255);
-			v[2].Color.setBlue(255);
-			v[3].Color.setBlue(255);
-		}*/
-
-		f32 rx = cloud_size / 2.0f;
+		const f32 rx = cloud_size / 2.0f;
 		// if clouds are flat, the top layer should be at the given height
-		f32 ry = m_enable_3d ? m_params.thickness * BS : 0.0f;
-		f32 rz = cloud_size / 2;
+		const f32 ry = m_enable_3d ? m_params.thickness * BS : 0.0f;
+		const f32 rz = cloud_size / 2;
 
 		for(int i=0; i<num_faces_to_draw; i++)
 		{
@@ -320,15 +309,25 @@ void Clouds::render()
 			v3f pos(p0.X, m_params.height * BS, p0.Y);
 			pos -= intToFloat(m_camera_offset, BS);
 
-			for (video::S3DVertex &vertex : v)
+			for (video::S3DVertex &vertex : v) {
 				vertex.Pos += pos;
-			u16 indices[] = {0,1,2,2,3,0};
-			driver->drawVertexPrimitiveList(v, 4, indices, 2,
-					video::EVT_STANDARD, scene::EPT_TRIANGLES, video::EIT_16BIT);
+				vertices.push_back(vertex);
+			}
 		}
 	}
-
-	delete[] grid;
+	int quad_count = vertices.size() / 4;
+	std::vector<u16> indices;
+	indices.reserve(quad_count * 6);
+	for (int k = 0; k < quad_count; k++) {
+		indices.push_back(4 * k + 0);
+		indices.push_back(4 * k + 1);
+		indices.push_back(4 * k + 2);
+		indices.push_back(4 * k + 2);
+		indices.push_back(4 * k + 3);
+		indices.push_back(4 * k + 0);
+	}
+	driver->drawVertexPrimitiveList(vertices.data(), vertices.size(), indices.data(), 2 * quad_count,
+			video::EVT_STANDARD, scene::EPT_TRIANGLES, video::EIT_16BIT);
 
 	// Restore fog settings
 	driver->setFog(fog_color, fog_type, fog_start, fog_end, fog_density,

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -341,14 +341,13 @@ void Clouds::step(float dtime)
 
 void Clouds::update(const v3f &camera_p, const video::SColorf &color_diffuse)
 {
+	video::SColorf ambient(m_params.color_ambient);
+	video::SColorf bright(m_params.color_bright);
 	m_camera_pos = camera_p;
-	m_color.r = MYMIN(MYMAX(color_diffuse.r * m_params.color_bright.getRed(),
-			m_params.color_ambient.getRed()), 255) / 255.0f;
-	m_color.g = MYMIN(MYMAX(color_diffuse.g * m_params.color_bright.getGreen(),
-			m_params.color_ambient.getGreen()), 255) / 255.0f;
-	m_color.b = MYMIN(MYMAX(color_diffuse.b * m_params.color_bright.getBlue(),
-			m_params.color_ambient.getBlue()), 255) / 255.0f;
-	m_color.a = m_params.color_bright.getAlpha() / 255.0f;
+	m_color.r = core::clamp(color_diffuse.r * bright.r, ambient.r, 1.0f);
+	m_color.g = core::clamp(color_diffuse.g * bright.g, ambient.g, 1.0f);
+	m_color.b = core::clamp(color_diffuse.b * bright.b, ambient.b, 1.0f);
+	m_color.a = bright.a;
 
 	// is the camera inside the cloud mesh?
 	m_camera_inside_cloud = false; // default

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -424,6 +424,7 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedVertexShaderSetting<float> m_animation_timer_vertex;
 	CachedPixelShaderSetting<float> m_animation_timer_pixel;
 	CachedPixelShaderSetting<float, 3> m_day_light;
+	CachedPixelShaderSetting<float, 4> m_star_color;
 	CachedPixelShaderSetting<float, 3> m_eye_position_pixel;
 	CachedVertexShaderSetting<float, 3> m_eye_position_vertex;
 	CachedPixelShaderSetting<float, 3> m_minimap_yaw;
@@ -456,6 +457,7 @@ public:
 		m_animation_timer_vertex("animationTimer"),
 		m_animation_timer_pixel("animationTimer"),
 		m_day_light("dayLight"),
+		m_star_color("starColor"),
 		m_eye_position_pixel("eyePosition"),
 		m_eye_position_vertex("eyePosition"),
 		m_minimap_yaw("yawVec"),
@@ -506,6 +508,10 @@ public:
 			sunlight.g,
 			sunlight.b };
 		m_day_light.set(dnc, services);
+
+		video::SColorf star_color = m_sky->getCurrentStarColor();
+		float clr[4] = {star_color.r, star_color.g, star_color.b, star_color.a};
+		m_star_color.set(clr, services);
 
 		u32 animation_timer = porting::getTimeMs() % 1000000;
 		float animation_timer_f = (float)animation_timer / 100000.f;
@@ -1363,7 +1369,7 @@ bool Game::createClient(const GameStartData &start_data)
 
 	/* Skybox
 	 */
-	sky = new Sky(-1, texture_src);
+	sky = new Sky(-1, texture_src, shader_src);
 	scsf->setSky(sky);
 	skybox = NULL;	// This is used/set later on in the main run loop
 

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -577,7 +577,6 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 	shaderinfo.name = name;
 	shaderinfo.material_type = material_type;
 	shaderinfo.drawtype = drawtype;
-	shaderinfo.material = video::EMT_SOLID;
 	switch (material_type) {
 	case TILE_MATERIAL_OPAQUE:
 	case TILE_MATERIAL_LIQUID_OPAQUE:
@@ -598,6 +597,7 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		shaderinfo.base_material = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
 		break;
 	}
+	shaderinfo.material = shaderinfo.base_material;
 
 	bool enable_shaders = g_settings->getBool("enable_shaders");
 	if (!enable_shaders)

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -849,6 +849,7 @@ void Sky::updateStars() {
 	m_stars->Vertices.reallocate(4 * m_star_params.count);
 	m_stars->Indices.reallocate(6 * m_star_params.count);
 
+	video::SColor fallback_color = m_star_params.starcolor; // used on GLES 2 “without shaders”
 	PcgRandom rgen(m_seed);
 	float d = (0.006 / 2) * m_star_params.scale;
 	for (u16 i = 0; i < m_star_params.count; i++) {
@@ -867,10 +868,10 @@ void Sky::updateStars() {
 		a.rotateVect(p1);
 		a.rotateVect(p2);
 		a.rotateVect(p3);
-		m_stars->Vertices.push_back(video::S3DVertex(p, {}, {}, {}));
-		m_stars->Vertices.push_back(video::S3DVertex(p1, {}, {}, {}));
-		m_stars->Vertices.push_back(video::S3DVertex(p2, {}, {}, {}));
-		m_stars->Vertices.push_back(video::S3DVertex(p3, {}, {}, {}));
+		m_stars->Vertices.push_back(video::S3DVertex(p, {}, fallback_color, {}));
+		m_stars->Vertices.push_back(video::S3DVertex(p1, {}, fallback_color, {}));
+		m_stars->Vertices.push_back(video::S3DVertex(p2, {}, fallback_color, {}));
+		m_stars->Vertices.push_back(video::S3DVertex(p3, {}, fallback_color, {}));
 	}
 	for (u16 i = 0; i < m_star_params.count; i++) {
 		m_stars->Indices.push_back(i * 4 + 0);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -830,6 +830,7 @@ void Sky::setStarCount(u16 star_count, bool force_update)
 	// Allow force updating star count at game init.
 	if (m_star_params.count != star_count || force_update) {
 		m_star_params.count = star_count;
+		m_seed = (u64)myrand() << 32 | myrand();
 		updateStars();
 	}
 }
@@ -847,12 +848,13 @@ void Sky::updateStars() {
 	m_stars->Vertices.reallocate(4 * m_star_params.count);
 	m_stars->Indices.reallocate(6 * m_star_params.count);
 
+	PcgRandom rgen(m_seed);
 	float d = (0.006 / 2) * m_star_params.scale;
 	for (u16 i = 0; i < m_star_params.count; i++) {
 		v3f r = v3f(
-			myrand_range(-10000, 10000),
-			myrand_range(-10000, 10000),
-			myrand_range(-10000, 10000)
+			rgen.range(-10000, 10000),
+			rgen.range(-10000, 10000),
+			rgen.range(-10000, 10000)
 		);
 		core::CMatrix4<f32> a;
 		a.buildRotateFromTo(v3f(0, 1, 0), r);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -35,7 +35,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "config.h"
 using namespace irr::core;
 
-static video::SMaterial baseMaterial() {
+static video::SMaterial baseMaterial()
+{
 	video::SMaterial mat;
 	mat.Lighting = false;
 #if ENABLE_GLES
@@ -836,7 +837,8 @@ void Sky::setStarCount(u16 star_count, bool force_update)
 	}
 }
 
-void Sky::updateStars() {
+void Sky::updateStars()
+{
 	m_stars.reset(new scene::SMeshBuffer());
 	// Stupid IrrLicht doesn’t allow non-indexed rendering, and indexed quad
 	// rendering is slow due to lack of hardware support. So as indices are

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -209,7 +209,7 @@ void Sky::render()
 
 		const f32 t = 1.0f;
 		const f32 o = 0.0f;
-		static const u16 indices[4] = {0, 1, 2, 3};
+		static const u16 indices[6] = {0, 1, 2, 0, 2, 3};
 		video::S3DVertex vertices[4];
 
 		driver->setMaterial(m_materials[1]);
@@ -251,7 +251,7 @@ void Sky::render()
 						vertex.Pos.rotateXZBy(180);
 					}
 				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+				driver->drawIndexedTriangleList(&vertices[0], 4, indices, 2);
 			}
 		}
 
@@ -277,7 +277,7 @@ void Sky::render()
 						// Switch from -Z (south) to +Z (north)
 						vertex.Pos.rotateXZBy(-180);
 				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+				driver->drawIndexedTriangleList(&vertices[0], 4, indices, 2);
 			}
 		}
 
@@ -308,7 +308,7 @@ void Sky::render()
 					// Switch from -Z (south) to -X (west)
 					vertex.Pos.rotateXZBy(-90);
 			}
-			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+			driver->drawIndexedTriangleList(&vertices[0], 4, indices, 2);
 		}
 
 		// Draw sun
@@ -344,7 +344,7 @@ void Sky::render()
 						// Switch from -Z (south) to +Z (north)
 						vertex.Pos.rotateXZBy(-180);
 				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+				driver->drawIndexedTriangleList(&vertices[0], 4, indices, 2);
 			}
 
 			// Draw bottom far cloudy fog thing in front of sun, moon and stars
@@ -353,7 +353,7 @@ void Sky::render()
 			vertices[1] = video::S3DVertex( 1, -1.0, -1, 0, 1, 0, c, o, t);
 			vertices[2] = video::S3DVertex( 1, -1.0, 1, 0, 1, 0, c, o, o);
 			vertices[3] = video::S3DVertex(-1, -1.0, 1, 0, 1, 0, c, t, o);
-			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+			driver->drawIndexedTriangleList(&vertices[0], 4, indices, 2);
 		}
 	}
 }
@@ -597,7 +597,7 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SCol
 	 * wicked_time_of_day: current time of day, to know where should be the sun in the sky
 	 */
 {
-	static const u16 indices[4] = {0, 1, 2, 3};
+	static const u16 indices[] = {0, 1, 2, 0, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
 	if (!m_sun_texture) {
 		driver->setMaterial(m_materials[1]);
@@ -615,7 +615,7 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SCol
 		for (int i = 0; i < 4; i++) {
 			draw_sky_body(vertices, -sunsizes[i], sunsizes[i], colors[i]);
 			place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
-			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+			driver->drawIndexedTriangleList(&vertices[0], 4, indices, 2);
 		}
 	} else {
 		driver->setMaterial(m_materials[3]);
@@ -627,7 +627,7 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SCol
 			c = video::SColor(255, 255, 255, 255);
 		draw_sky_body(vertices, -d, d, c);
 		place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
-		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+		driver->drawIndexedTriangleList(&vertices[0], 4, indices, 2);
 	}
 }
 
@@ -644,7 +644,7 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SC
 	* the sky
 	*/
 {
-	static const u16 indices[4] = {0, 1, 2, 3};
+	static const u16 indices[] = {0, 1, 2, 0, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
 	if (!m_moon_texture) {
 		driver->setMaterial(m_materials[1]);
@@ -668,7 +668,7 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SC
 		for (int i = 0; i < 4; i++) {
 			draw_sky_body(vertices, moonsizes_1[i], moonsizes_2[i], colors[i]);
 			place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
-			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+			driver->drawIndexedTriangleList(&vertices[0], 4, indices, 2);
 		}
 	} else {
 		driver->setMaterial(m_materials[4]);

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "camera.h"
 #include "irrlichttypes_extrabloated.h"
 #include "irr_ptr.h"
+#include "shader.h"
 #include "skyparams.h"
 
 #pragma once
@@ -35,7 +36,7 @@ class Sky : public scene::ISceneNode
 {
 public:
 	//! constructor
-	Sky(s32 id, ITextureSource *tsrc);
+	Sky(s32 id, ITextureSource *tsrc, IShaderSource *ssrc);
 
 	virtual void OnRegisterSceneNode();
 
@@ -102,6 +103,8 @@ public:
 	void clearSkyboxTextures() { m_sky_params.textures.clear(); }
 	void addTextureToSkybox(std::string texture, int material_id,
 		ITextureSource *tsrc);
+	const video::SColorf &getCurrentStarColor() const { return m_star_color; }
+
 private:
 	aabb3f m_box;
 	video::SMaterial m_materials[SKY_MATERIAL_COUNT];
@@ -155,6 +158,7 @@ private:
 	bool m_clouds_enabled = true; // Initialised to true, reset only by set_sky API
 	bool m_directional_colored_fog;
 	bool m_in_clouds = true; // Prevent duplicating bools to remember old values
+	bool m_enable_shaders = false;
 
 	video::SColorf m_bgcolor_bright_f = video::SColorf(1.0f, 1.0f, 1.0f, 1.0f);
 	video::SColorf m_skycolor_bright_f = video::SColorf(1.0f, 1.0f, 1.0f, 1.0f);
@@ -181,6 +185,7 @@ private:
 
 	u64 m_seed = 0;
 	irr_ptr<scene::SMeshBuffer> m_stars;
+	video::SColorf m_star_color;
 
 	video::ITexture *m_sun_texture;
 	video::ITexture *m_moon_texture;
@@ -188,7 +193,6 @@ private:
 	video::ITexture *m_moon_tonemap;
 
 	void updateStars();
-	void updateStarsColor(video::SColor color);
 
 	void draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor &suncolor,
 		const video::SColor &suncolor2, float wicked_time_of_day);

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <array>
 #include "camera.h"
 #include "irrlichttypes_extrabloated.h"
+#include "irr_ptr.h"
 #include "skyparams.h"
 
 #pragma once
@@ -77,7 +78,7 @@ public:
 	void setStarsVisible(bool stars_visible) { m_star_params.visible = stars_visible; }
 	void setStarCount(u16 star_count, bool force_update);
 	void setStarColor(video::SColor star_color) { m_star_params.starcolor = star_color; }
-	void setStarScale(f32 star_scale) { m_star_params.scale = star_scale; }
+	void setStarScale(f32 star_scale) { m_star_params.scale = star_scale; updateStars(); }
 
 	bool getCloudsVisible() const { return m_clouds_visible && m_clouds_enabled; }
 	const video::SColorf &getCloudColor() const { return m_cloudcolor_f; }
@@ -178,12 +179,15 @@ private:
 
 	bool m_default_tint = true;
 
-	std::vector<v3f> m_stars;
+	irr_ptr<scene::SMeshBuffer> m_stars;
 
 	video::ITexture *m_sun_texture;
 	video::ITexture *m_moon_texture;
 	video::ITexture *m_sun_tonemap;
 	video::ITexture *m_moon_tonemap;
+
+	void updateStars();
+	void updateStarsColor(video::SColor color);
 
 	void draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor &suncolor,
 		const video::SColor &suncolor2, float wicked_time_of_day);

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -179,6 +179,7 @@ private:
 
 	bool m_default_tint = true;
 
+	u64 m_seed = 0;
 	irr_ptr<scene::SMeshBuffer> m_stars;
 
 	video::ITexture *m_sun_texture;


### PR DESCRIPTION
Sky rendering appears to be very resource-intensive for no good reason, namely due to overuse of immediate rendering and CPU-side calculations. This PR attempts to fix that.

As a bonus, stars are now rendered with a custom shader if enabled (important on GLES 2 because IrrLicht own shaders are even more limited than OpenGL fixed-function pipeline).

Tested on desktop Linux/OpenGL with and without shaders, Android/GLES, Android/GLES 2 with shaders.

## How to test

Test with heavy cloudness and 16k stars (the limit was and is 16384).
