### PR TITLE
Avoid marking map blocks dirty upon deserialization.

### DIFF
--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -533,7 +533,7 @@ void MapBlock::deSerialize(std::istream &is, u8 version, bool disk)
 		// Timestamp
 		TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())
 				<<": Timestamp"<<std::endl);
-		setTimestamp(readU32(is));
+		setTimestampNoChangedFlag(readU32(is));
 		m_disk_timestamp = m_timestamp;
 
 		// Dynamically re-set ids based on node names
@@ -716,10 +716,10 @@ void MapBlock::deSerialize_pre22(std::istream &is, u8 version, bool disk)
 
 		// Timestamp
 		if (version >= 17) {
-			setTimestamp(readU32(is));
+			setTimestampNoChangedFlag(readU32(is));
 			m_disk_timestamp = m_timestamp;
 		} else {
-			setTimestamp(BLOCK_TIMESTAMP_UNDEFINED);
+			setTimestampNoChangedFlag(BLOCK_TIMESTAMP_UNDEFINED);
 		}
 
 		// Dynamically re-set ids based on node names


### PR DESCRIPTION
Improves #10566 (but does not fix it completely)
@hecktest 

As is just de-serializing a block from disk marks it dirty, which makes no sense.
That looks like an unintended side-effect of setting the blocks timestamp.

Note that active blocks are still marked dirty every 60s, but is a subset of all blocks.
