### PR TITLE
Formspec: Allow to specify frame loop for model[]

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2784,6 +2784,7 @@ Some types may inherit styles from parent types.
 * image_button
 * item_image_button
 * label
+* model
 * pwdfield, inherits from field
 * scrollbar
 * tabheader
@@ -2861,6 +2862,9 @@ Some types may inherit styles from parent types.
     * bgcolor - color, sets background color.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
         * Default to false in formspec_version version 3 or higher
+    * frame_loop - range of the animation frames
+        * Defaults to the full range of all available frames
+        * Syntax: `frame_loop=<start>,<end>`; example: `style[player_preview;frame_loop=0,79]`
 * image
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
         * Default to false in formspec_version version 3 or higher

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2272,7 +2272,7 @@ Elements
 * `frame duration`: Milliseconds between each frame. `0` means the frames don't advance.
 * `frame start` (Optional): The index of the frame to start on. Default `1`.
 
-### `model[<X>,<Y>;<W>,<H>;<name>;<mesh>;<textures>;<rotation X,Y>;<continuous>;<mouse control>]`
+### `model[<X>,<Y>;<W>,<H>;<name>;<mesh>;<textures>;<rotation X,Y>;<continuous>;<mouse control>;<frame loop range>]`
 
 * Show a mesh model.
 * `name`: Element name that can be used for styling
@@ -2283,6 +2283,9 @@ Elements
   The axes are euler angles in degrees.
 * `continuous` (Optional): Whether the rotation is continuous. Default `false`.
 * `mouse control` (Optional): Whether the model can be controlled with the mouse. Default `true`.
+* `frame loop range` (Optional): Range of the animation frames.
+  * Defaults to the full range of all available frames.
+  * Syntax: `<begin>,<end>`; example: `model[0,0;4,6;player_preview;character.b3d;character.png;0,180;false;true;0,79]`
 
 ### `item_image[<X>,<Y>;<W>,<H>;<item name>]`
 
@@ -2862,9 +2865,6 @@ Some types may inherit styles from parent types.
     * bgcolor - color, sets background color.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
         * Default to false in formspec_version version 3 or higher
-    * frame_loop - range of the animation frames
-        * Defaults to the full range of all available frames
-        * Syntax: `frame_loop=<start>,<end>`; example: `style[player_preview;frame_loop=0,79]`
 * image
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
         * Default to false in formspec_version version 3 or higher

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2284,8 +2284,8 @@ Elements
 * `continuous` (Optional): Whether the rotation is continuous. Default `false`.
 * `mouse control` (Optional): Whether the model can be controlled with the mouse. Default `true`.
 * `frame loop range` (Optional): Range of the animation frames.
-  * Defaults to the full range of all available frames.
-  * Syntax: `<begin>,<end>`; example: `model[0,0;4,6;player_preview;character.b3d;character.png;0,180;false;true;0,79]`
+    * Defaults to the full range of all available frames.
+    * Syntax: `<begin>,<end>`
 
 ### `item_image[<X>,<Y>;<W>,<H>;<item name>]`
 

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -55,6 +55,7 @@ public:
 		BORDERCOLORS,
 		BORDERWIDTHS,
 		SOUND,
+		FRAME_LOOP,
 		NUM_PROPERTIES,
 		NONE
 	};
@@ -119,6 +120,8 @@ public:
 			return BORDERWIDTHS;
 		} else if (name == "sound") {
 			return SOUND;
+		} else if (name == "frame_loop") {
+			return FRAME_LOOP;
 		} else {
 			return NONE;
 		}
@@ -232,6 +235,22 @@ public:
 
 		for (size_t i = 0; i <= 3; i++)
 			def[i] = stoi(strs[i]);
+
+		return def;
+	}
+
+	std::array<s32, 2> getIntRange(Property prop, std::array<s32, 2> def) const
+	{
+		const auto &val = properties[prop];
+		if(val.empty())
+			return def;
+
+		std::vector<std::string> strs;
+		if (!parseArray(val, strs))
+			return def;
+
+		def[0] = stoi(strs[0]);
+		def[1] = stoi(strs[1]);
 
 		return def;
 	}

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -55,7 +55,6 @@ public:
 		BORDERCOLORS,
 		BORDERWIDTHS,
 		SOUND,
-		FRAME_LOOP,
 		NUM_PROPERTIES,
 		NONE
 	};
@@ -120,8 +119,6 @@ public:
 			return BORDERWIDTHS;
 		} else if (name == "sound") {
 			return SOUND;
-		} else if (name == "frame_loop") {
-			return FRAME_LOOP;
 		} else {
 			return NONE;
 		}
@@ -235,22 +232,6 @@ public:
 
 		for (size_t i = 0; i <= 3; i++)
 			def[i] = stoi(strs[i]);
-
-		return def;
-	}
-
-	std::array<s32, 2> getIntRange(Property prop, std::array<s32, 2> def) const
-	{
-		const auto &val = properties[prop];
-		if(val.empty())
-			return def;
-
-		std::vector<std::string> strs;
-		if (!parseArray(val, strs))
-			return def;
-
-		def[0] = stoi(strs[0]);
-		def[1] = stoi(strs[1]);
 
 		return def;
 	}

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2795,15 +2795,12 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	e->enableContinuousRotation(inf_rotation);
 	e->enableMouseControl(mousectrl);
 
-	s32 frame_loop_begin;
-	s32 frame_loop_end;
+	s32 frame_loop_begin = 0;
+	s32 frame_loop_end = 0x7FFFFFFF;
 
 	if (frame_loop.size() == 2) {
 	    frame_loop_begin = stoi(frame_loop[0]);
 	    frame_loop_end = stoi(frame_loop[1]);
-	} else {
-	    frame_loop_begin = 0;
-	    frame_loop_end = 0x7FFFFFFF;
 	}
 
 	e->setFrameLoop(frame_loop_begin, frame_loop_end);

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2795,8 +2795,16 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	e->enableContinuousRotation(inf_rotation);
 	e->enableMouseControl(mousectrl);
 
-	const s32 frame_loop_begin = stoi(frame_loop[0]);
-	const s32 frame_loop_end = frame_loop.size() == 1 ? 0x7FFFFFFF : stoi(frame_loop[1]);
+	s32 frame_loop_begin;
+	s32 frame_loop_end;
+
+	if (frame_loop.size() == 2) {
+	    frame_loop_begin = stoi(frame_loop[0]);
+	    frame_loop_end = stoi(frame_loop[1]);
+	} else {
+	    frame_loop_begin = 0;
+	    frame_loop_end = 0x7FFFFFFF;
+	}
 
 	e->setFrameLoop(frame_loop_begin, frame_loop_end);
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -70,7 +70,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define MY_CHECKPOS(a,b)													\
 	if (v_pos.size() != 2) {												\
-		errorstream<< "Invalid pos for element " << a << "specified: \""	\
+		errorstream<< "Invalid pos for element " << a << " specified: \""	\
 			<< parts[b] << "\"" << std::endl;								\
 			return;															\
 	}
@@ -78,7 +78,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MY_CHECKGEOM(a,b)													\
 	if (v_geom.size() != 2) {												\
 		errorstream<< "Invalid geometry for element " << a <<				\
-			"specified: \"" << parts[b] << "\"" << std::endl;				\
+			" specified: \"" << parts[b] << "\"" << std::endl;				\
 			return;															\
 	}
 /*
@@ -2725,7 +2725,7 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element, ';');
 
-	if (parts.size() < 5 || (parts.size() > 8 &&
+	if (parts.size() < 5 || (parts.size() > 9 &&
 			m_formspec_version <= FORMSPEC_API_VERSION)) {
 		errorstream << "Invalid model element (" << parts.size() << "): '" << element
 			<< "'" << std::endl;
@@ -2733,8 +2733,8 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	}
 
 	// Avoid length checks by resizing
-	if (parts.size() < 8)
-		parts.resize(8);
+	if (parts.size() < 9)
+		parts.resize(9);
 
 	std::vector<std::string> v_pos = split(parts[0], ',');
 	std::vector<std::string> v_geom = split(parts[1], ',');
@@ -2744,6 +2744,7 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	std::vector<std::string> vec_rot = split(parts[5], ',');
 	bool inf_rotation = is_yes(parts[6]);
 	bool mousectrl = is_yes(parts[7]) || parts[7].empty(); // default true
+	std::vector<std::string> frame_loop = split(parts[8], ',');
 
 	MY_CHECKPOS("model", 0);
 	MY_CHECKGEOM("model", 1);
@@ -2793,6 +2794,11 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 
 	e->enableContinuousRotation(inf_rotation);
 	e->enableMouseControl(mousectrl);
+
+	const s32 frame_loop_begin = stoi(frame_loop[0]);
+	const s32 frame_loop_end = frame_loop.size() == 1 ? 0x7FFFFFFF : stoi(frame_loop[1]);
+
+	e->setFrameLoop(frame_loop_begin, frame_loop_end);
 
 	auto style = getStyleForElement("model", spec.fname);
 	e->setStyles(style);

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -155,7 +155,7 @@ void GUIScene::setStyles(const std::array<StyleSpec, StyleSpec::NUM_STATES> &sty
 /**
  * Sets the frame loop range for the mesh
  */
-void GUIScene::setFrameLoop(const s32 begin, const s32 end)
+void GUIScene::setFrameLoop(s32 begin, s32 end)
 {
 	if (m_mesh->getStartFrame() != begin || m_mesh->getEndFrame() != end)
 		m_mesh->setFrameLoop(begin, end);

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -150,6 +150,16 @@ void GUIScene::setStyles(const std::array<StyleSpec, StyleSpec::NUM_STATES> &sty
 
 	setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 	setBackgroundColor(style.getColor(StyleSpec::BGCOLOR, m_bgcolor));
+	setFrameLoop(style.getIntRange(StyleSpec::FRAME_LOOP, {0, 0x7FFFFFFF}));
+}
+
+/**
+ * Sets the frame loop range for the mesh
+ */
+void GUIScene::setFrameLoop(const std::array<s32, 2> range)
+{
+	if (m_mesh->getStartFrame() != range[0] || m_mesh->getEndFrame() != range[1])
+		m_mesh->setFrameLoop(range[0], range[1]);
 }
 
 /* Camera control functions */

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -150,16 +150,15 @@ void GUIScene::setStyles(const std::array<StyleSpec, StyleSpec::NUM_STATES> &sty
 
 	setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 	setBackgroundColor(style.getColor(StyleSpec::BGCOLOR, m_bgcolor));
-	setFrameLoop(style.getIntRange(StyleSpec::FRAME_LOOP, {0, 0x7FFFFFFF}));
 }
 
 /**
  * Sets the frame loop range for the mesh
  */
-void GUIScene::setFrameLoop(const std::array<s32, 2> range)
+void GUIScene::setFrameLoop(const s32 begin, const s32 end)
 {
-	if (m_mesh->getStartFrame() != range[0] || m_mesh->getEndFrame() != range[1])
-		m_mesh->setFrameLoop(range[0], range[1]);
+	if (m_mesh->getStartFrame() != begin || m_mesh->getEndFrame() != end)
+		m_mesh->setFrameLoop(begin, end);
 }
 
 /* Camera control functions */

--- a/src/gui/guiScene.h
+++ b/src/gui/guiScene.h
@@ -36,7 +36,7 @@ public:
 	scene::IAnimatedMeshSceneNode *setMesh(scene::IAnimatedMesh *mesh = nullptr);
 	void setTexture(u32 idx, video::ITexture *texture);
 	void setBackgroundColor(const video::SColor &color) noexcept { m_bgcolor = color; };
-	void setFrameLoop(const std::array<s32, 2> range);
+	void setFrameLoop(const s32 begin, const s32 end);
 	void enableMouseControl(bool enable) noexcept { m_mouse_ctrl = enable; };
 	void setRotation(v2f rot) noexcept { m_custom_rot = rot; };
 	void enableContinuousRotation(bool enable) noexcept { m_inf_rot = enable; };

--- a/src/gui/guiScene.h
+++ b/src/gui/guiScene.h
@@ -36,6 +36,7 @@ public:
 	scene::IAnimatedMeshSceneNode *setMesh(scene::IAnimatedMesh *mesh = nullptr);
 	void setTexture(u32 idx, video::ITexture *texture);
 	void setBackgroundColor(const video::SColor &color) noexcept { m_bgcolor = color; };
+	void setFrameLoop(const std::array<s32, 2> range);
 	void enableMouseControl(bool enable) noexcept { m_mouse_ctrl = enable; };
 	void setRotation(v2f rot) noexcept { m_custom_rot = rot; };
 	void enableContinuousRotation(bool enable) noexcept { m_inf_rot = enable; };

--- a/src/gui/guiScene.h
+++ b/src/gui/guiScene.h
@@ -36,7 +36,7 @@ public:
 	scene::IAnimatedMeshSceneNode *setMesh(scene::IAnimatedMesh *mesh = nullptr);
 	void setTexture(u32 idx, video::ITexture *texture);
 	void setBackgroundColor(const video::SColor &color) noexcept { m_bgcolor = color; };
-	void setFrameLoop(const s32 begin, const s32 end);
+	void setFrameLoop(s32 begin, s32 end);
 	void enableMouseControl(bool enable) noexcept { m_mouse_ctrl = enable; };
 	void setRotation(v2f rot) noexcept { m_custom_rot = rot; };
 	void enableContinuousRotation(bool enable) noexcept { m_inf_rot = enable; };


### PR DESCRIPTION
- Goal of the PR: Add the ability to specify an animation frame loop range for the `model[]` formspec element.
- How does the PR work? A new option is added to the `model[]`element.
- Does it resolve any reported issue? Yes, it closes #10615 
- If not a bug fix, why is this PR needed? What usecases does it solve? A possible use case is to display the player model only in a certain pose in a formspec, e.g. for the preview of a wardrobe/skin mod.

## How to test

The following formspec element should display the player model in a standing position only.

```
model[0,0;4,6;player_preview;character.b3d;character.png;0,180;false;true;0,79]
```

<!-- Example code or instructions -->
