### PR TITLE
For play only: Curved Surface Simulation.

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -197,7 +197,9 @@ local function formspec(tabview, name, tabdata)
 			"checkbox[8.25,1.5;cb_waving_leaves;" .. fgettext("Waving Leaves") .. ";"
 					.. dump(core.settings:get_bool("enable_waving_leaves")) .. "]" ..
 			"checkbox[8.25,2;cb_waving_plants;" .. fgettext("Waving Plants") .. ";"
-					.. dump(core.settings:get_bool("enable_waving_plants")) .. "]"
+					.. dump(core.settings:get_bool("enable_waving_plants")) .. "]" ..
+			"checkbox[8.25,2.5;cb_curved_surface;" .. fgettext("Curved Surface") .. ";"
+					.. dump(core.settings:get_bool("enable_curved_surface")) .. "]"
 	else
 		tab_string = tab_string ..
 			"label[8.38,0.7;" .. core.colorize("#888888",
@@ -207,7 +209,9 @@ local function formspec(tabview, name, tabdata)
 			"label[8.38,1.7;" .. core.colorize("#888888",
 					fgettext("Waving Leaves")) .. "]" ..
 			"label[8.38,2.2;" .. core.colorize("#888888",
-					fgettext("Waving Plants")) .. "]"
+					fgettext("Waving Plants")) .. "]" ..
+			"label[8.38,2.7;" .. core.colorize("#888888",
+					fgettext("Curved Surface")) .. "]"
 	end
 
 	return tab_string
@@ -271,6 +275,10 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 	end
 	if fields["cb_waving_plants"] then
 		core.settings:set("enable_waving_plants", fields["cb_waving_plants"])
+		return true
+	end
+	if fields["cb_curved_surface"] then
+		core.settings:set("enable_curved_surface", fields["cb_curved_surface"])
 		return true
 	end
 	if fields["btn_change_keys"] then

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -576,6 +576,16 @@ enable_waving_leaves (Waving leaves) bool false
 #    Requires shaders to be enabled.
 enable_waving_plants (Waving plants) bool false
 
+[***Curved Surface]
+
+#    Set to true to enable curved terrain.
+#    Requires shaders to be enabled.
+enable_curved_surface (Curved Survace) bool false
+
+#    The perceived horizon (when standing on the ground)
+#    Good values are between 1/4 and 1 times viewing_range
+curved_horizon (Curved Horizon) float 100 20
+
 [**Advanced]
 
 #    Arm inertia, gives a more realistic movement of

--- a/client/shaders/default_shader/opengl_vertex.glsl
+++ b/client/shaders/default_shader/opengl_vertex.glsl
@@ -2,6 +2,6 @@ varying lowp vec4 varColor;
 
 void main(void)
 {
-	gl_Position = mWorldViewProj * inVertexPosition;
+	gl_Position = mProj * mView * mWorld * inVertexPosition;
 	varColor = inVertexColor;
 }

--- a/client/shaders/minimap_shader/opengl_vertex.glsl
+++ b/client/shaders/minimap_shader/opengl_vertex.glsl
@@ -1,11 +1,9 @@
-uniform mat4 mWorld;
-
 varying lowp vec4 varColor;
 varying mediump vec2 varTexCoord;
 
 void main(void)
 {
 	varTexCoord = inTexCoord0.st;
-	gl_Position = mWorldViewProj * inVertexPosition;
+	gl_Position = mProj * mView * mWorld * inVertexPosition;
 	varColor = inVertexColor;
 }

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -1,5 +1,3 @@
-uniform mat4 mWorld;
-
 // Color of the light emitted by the sun.
 uniform vec3 dayLight;
 uniform vec3 eyePosition;
@@ -7,6 +5,7 @@ uniform vec3 eyePosition;
 // The cameraOffset is the current center of the visible world.
 uniform vec3 cameraOffset;
 uniform float animationTimer;
+uniform float horizon;
 
 varying vec3 vPosition;
 // World position in the visible world (i.e. relative to the cameraOffset.)
@@ -97,13 +96,13 @@ void main(void)
 #endif
 
 	worldPosition = (mWorld * inVertexPosition).xyz;
+	vec4 pos = mWorld * inVertexPosition;
 
 // OpenGL < 4.3 does not support continued preprocessor lines
 #if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_OPAQUE || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_BASIC) && ENABLE_WAVING_WATER
 	// Generate waves with Perlin-type noise.
 	// The constants are calibrated such that they roughly
 	// correspond to the old sine waves.
-	vec4 pos = inVertexPosition;
 	vec3 wavePos = worldPosition + cameraOffset;
 	// The waves are slightly compressed along the z-axis to get
 	// wave-fronts along the x-axis.
@@ -111,28 +110,24 @@ void main(void)
 	wavePos.z /= WATER_WAVE_LENGTH * 2.0;
 	wavePos.z += animationTimer * WATER_WAVE_SPEED * 10.0;
 	pos.y += (snoise(wavePos) - 1.0) * WATER_WAVE_HEIGHT * 5.0;
-	gl_Position = mWorldViewProj * pos;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES
-	vec4 pos = inVertexPosition;
 	pos.x += disp_x;
 	pos.y += disp_z * 0.1;
 	pos.z += disp_z;
-	gl_Position = mWorldViewProj * pos;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS
-	vec4 pos = inVertexPosition;
 	if (varTexCoord.y < 0.05) {
 		pos.x += disp_x;
 		pos.z += disp_z;
 	}
-	gl_Position = mWorldViewProj * pos;
-#else
-	gl_Position = mWorldViewProj * inVertexPosition;
 #endif
-
-
+#if ENABLE_CURVED_SURFACE
+	vec2 xz_pos = eyePosition.xz - cameraOffset.xz - worldPosition.xz;
+	pos.y -= dot(xz_pos, xz_pos) / horizon / horizon;
+#endif
+	gl_Position = mProj * mView * pos;
 	vPosition = gl_Position.xyz;
 
-	eyeVec = -(mWorldView * inVertexPosition).xyz;
+	eyeVec = -(mView * pos).xyz;
 
 	// Calculate color.
 	// Red, green and blue components are pre-multiplied with

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -1,7 +1,9 @@
-uniform mat4 mWorld;
-
 uniform vec3 eyePosition;
+
+// The cameraOffset is the current center of the visible world.
+uniform vec3 cameraOffset;
 uniform float animationTimer;
+uniform float horizon;
 
 varying vec3 vNormal;
 varying vec3 vPosition;
@@ -28,12 +30,17 @@ float directional_ambient(vec3 normal)
 void main(void)
 {
 	varTexCoord = (mTexture * inTexCoord0).st;
-	gl_Position = mWorldViewProj * inVertexPosition;
+	worldPosition = (mWorld * inVertexPosition).xyz;
+	vec4 pos = mWorld * inVertexPosition;
 
+#if ENABLE_CURVED_SURFACE
+	vec2 xz_pos = eyePosition.xz - cameraOffset.xz - worldPosition.xz;
+	pos.y -= dot(xz_pos, xz_pos) / horizon / horizon;
+#endif
+	gl_Position = mProj * mView * pos;
 	vPosition = gl_Position.xyz;
 	vNormal = inVertexNormal;
-	worldPosition = (mWorld * inVertexPosition).xyz;
-	eyeVec = -(mWorldView * inVertexPosition).xyz;
+	eyeVec = -(mView * pos).xyz;
 
 #if (MATERIAL_TYPE == TILE_MATERIAL_PLAIN) || (MATERIAL_TYPE == TILE_MATERIAL_PLAIN_ALPHA)
 	vIDiff = 1.0;

--- a/client/shaders/selection_shader/opengl_vertex.glsl
+++ b/client/shaders/selection_shader/opengl_vertex.glsl
@@ -4,7 +4,7 @@ varying mediump vec2 varTexCoord;
 void main(void)
 {
 	varTexCoord = inTexCoord0.st;
-	gl_Position = mWorldViewProj * inVertexPosition;
+	gl_Position = mProj * mView * mWorld * inVertexPosition;
 
 	varColor = inVertexColor;
 }

--- a/client/shaders/stars_shader/opengl_vertex.glsl
+++ b/client/shaders/stars_shader/opengl_vertex.glsl
@@ -1,4 +1,4 @@
 void main(void)
 {
-	gl_Position = mWorldViewProj * inVertexPosition;
+	gl_Position = mProj * mView * mWorld * inVertexPosition;
 }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -418,9 +418,11 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	Sky *m_sky;
 	bool *m_force_fog_off;
 	f32 *m_fog_range;
+	f32 m_horizon;
 	bool m_fog_enabled;
 	CachedPixelShaderSetting<float, 4> m_sky_bg_color;
 	CachedPixelShaderSetting<float> m_fog_distance;
+	CachedVertexShaderSetting<float> m_horizon_vertex;
 	CachedVertexShaderSetting<float> m_animation_timer_vertex;
 	CachedPixelShaderSetting<float> m_animation_timer_pixel;
 	CachedPixelShaderSetting<float, 3> m_day_light;
@@ -454,6 +456,7 @@ public:
 		m_fog_range(fog_range),
 		m_sky_bg_color("skyBgColor"),
 		m_fog_distance("fogDistance"),
+		m_horizon_vertex("horizon"),
 		m_animation_timer_vertex("animationTimer"),
 		m_animation_timer_pixel("animationTimer"),
 		m_day_light("dayLight"),
@@ -468,6 +471,7 @@ public:
 	{
 		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
 		m_fog_enabled = g_settings->getBool("enable_fog");
+		m_horizon = g_settings->getFloat("curved_horizon");
 	}
 
 	~GameGlobalShaderConstantSetter()
@@ -499,6 +503,7 @@ public:
 			fog_distance = *m_fog_range;
 
 		m_fog_distance.set(&fog_distance, services);
+		m_horizon_vertex.set(&m_horizon, services);
 
 		u32 daynight_ratio = (float)m_client->getEnv().getDayNightRatio();
 		video::SColorf sunlight;

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -860,6 +860,10 @@ static void updateFastFaceRow(
 		g_settings->getBool("enable_shaders") &&
 		g_settings->getBool("enable_waving_water");
 
+	static thread_local const bool curved_surface =
+		g_settings->getBool("enable_shaders") &&
+		g_settings->getBool("enable_curved_surface");
+
 	v3s16 p = startpos;
 
 	u16 continuous_tiles_count = 1;
@@ -899,6 +903,7 @@ static void updateFastFaceRow(
 					next_tile);
 
 			if (next_makes_face == makes_face
+					&& !curved_surface
 					&& next_p_corrected == p_corrected + translate_dir
 					&& next_face_dir_corrected == face_dir_corrected
 					&& memcmp(next_lights, lights, sizeof(lights)) == 0

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -251,6 +251,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("bilinear_filter", "false");
 	settings->setDefault("trilinear_filter", "false");
 	settings->setDefault("tone_mapping", "false");
+	settings->setDefault("enable_curved_surface", "false");
+	settings->setDefault("curved_horizon", "100");
 	settings->setDefault("enable_waving_water", "false");
 	settings->setDefault("water_wave_height", "1.0");
 	settings->setDefault("water_wave_length", "20.0");


### PR DESCRIPTION
Decided to make a PR anyway. See video linked from #10672 

- It supports the geometry and entities.
- The "horizon" is configurable - roughly where you would see the horizon standing on the ground.
- In order to avoid artifacts this turns off tiling when the curved surface is enabled.
(Not sure how useful tiling is these days. I see more vertices rendered, but the FPS are the same.)

Current Limitations:
- Clouds are not curved (briefly looked into, it's doable, need to adjust the bounding box, etc.)
- Particles are not supported (no idea what that would entail)
- The wield hand is (somehow) affected by the object shader, and the coordinates are "wrong". I think that's a bug anyway. The result is that now wield hand bobs slowly.
- The effect does not do sphere mapping. Rather it relies on the fact a parabola for low x matches a circle pretty well. With extreme curves and a large viewing_range you can see that's it's actually a parabola. Thus in order to have a good effect the "horizon" should not be less than 1/4 or 1/3 of the viewing distance; within that range is matches a circle very well.

This is just so folks can play around with this.