### PR TITLE
Remove hardcoded matrices from OpenGL shaders.

### DIFF
--- a/client/shaders/default_shader/opengl_vertex.glsl
+++ b/client/shaders/default_shader/opengl_vertex.glsl
@@ -2,6 +2,6 @@ varying lowp vec4 varColor;
 
 void main(void)
 {
-	gl_Position = mWorldViewProj * inVertexPosition;
+	gl_Position = mProj * mView * mWorld * inVertexPosition;
 	varColor = inVertexColor;
 }

--- a/client/shaders/minimap_shader/opengl_vertex.glsl
+++ b/client/shaders/minimap_shader/opengl_vertex.glsl
@@ -1,11 +1,9 @@
-uniform mat4 mWorld;
-
 varying lowp vec4 varColor;
 varying mediump vec2 varTexCoord;
 
 void main(void)
 {
 	varTexCoord = inTexCoord0.st;
-	gl_Position = mWorldViewProj * inVertexPosition;
+	gl_Position = mProj * mView * mWorld * inVertexPosition;
 	varColor = inVertexColor;
 }

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -1,5 +1,3 @@
-uniform mat4 mWorld;
-
 // Color of the light emitted by the sun.
 uniform vec3 dayLight;
 uniform vec3 eyePosition;
@@ -96,14 +94,14 @@ void main(void)
 		smoothTriangleWave(animationTimer * 13.0 + tOffset)) * 0.5;
 #endif
 
-	worldPosition = (mWorld * inVertexPosition).xyz;
+	vec4 pos = mWorld * inVertexPosition;
+	worldPosition = pos.xyz;
 
 // OpenGL < 4.3 does not support continued preprocessor lines
 #if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_OPAQUE || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_BASIC) && ENABLE_WAVING_WATER
 	// Generate waves with Perlin-type noise.
 	// The constants are calibrated such that they roughly
 	// correspond to the old sine waves.
-	vec4 pos = inVertexPosition;
 	vec3 wavePos = worldPosition + cameraOffset;
 	// The waves are slightly compressed along the z-axis to get
 	// wave-fronts along the x-axis.
@@ -111,28 +109,20 @@ void main(void)
 	wavePos.z /= WATER_WAVE_LENGTH * 2.0;
 	wavePos.z += animationTimer * WATER_WAVE_SPEED * 10.0;
 	pos.y += (snoise(wavePos) - 1.0) * WATER_WAVE_HEIGHT * 5.0;
-	gl_Position = mWorldViewProj * pos;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES
-	vec4 pos = inVertexPosition;
 	pos.x += disp_x;
 	pos.y += disp_z * 0.1;
 	pos.z += disp_z;
-	gl_Position = mWorldViewProj * pos;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS
-	vec4 pos = inVertexPosition;
 	if (varTexCoord.y < 0.05) {
 		pos.x += disp_x;
 		pos.z += disp_z;
 	}
-	gl_Position = mWorldViewProj * pos;
-#else
-	gl_Position = mWorldViewProj * inVertexPosition;
 #endif
-
-
+	gl_Position = mProj * mView * pos;
 	vPosition = gl_Position.xyz;
 
-	eyeVec = -(mWorldView * inVertexPosition).xyz;
+	eyeVec = -(mView * pos).xyz;
 
 	// Calculate color.
 	// Red, green and blue components are pre-multiplied with

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -1,6 +1,7 @@
-uniform mat4 mWorld;
-
 uniform vec3 eyePosition;
+
+// The cameraOffset is the current center of the visible world.
+uniform vec3 cameraOffset;
 uniform float animationTimer;
 
 varying vec3 vNormal;
@@ -28,12 +29,13 @@ float directional_ambient(vec3 normal)
 void main(void)
 {
 	varTexCoord = (mTexture * inTexCoord0).st;
-	gl_Position = mWorldViewProj * inVertexPosition;
+	vec4 pos = mWorld * inVertexPosition;
 
+	gl_Position = mProj * mView * pos;
 	vPosition = gl_Position.xyz;
 	vNormal = inVertexNormal;
-	worldPosition = (mWorld * inVertexPosition).xyz;
-	eyeVec = -(mWorldView * inVertexPosition).xyz;
+	worldPosition = pos.xyz;
+	eyeVec = -(mView * pos).xyz;
 
 #if (MATERIAL_TYPE == TILE_MATERIAL_PLAIN) || (MATERIAL_TYPE == TILE_MATERIAL_PLAIN_ALPHA)
 	vIDiff = 1.0;

--- a/client/shaders/selection_shader/opengl_vertex.glsl
+++ b/client/shaders/selection_shader/opengl_vertex.glsl
@@ -4,7 +4,7 @@ varying mediump vec2 varTexCoord;
 void main(void)
 {
 	varTexCoord = inTexCoord0.st;
-	gl_Position = mWorldViewProj * inVertexPosition;
+	gl_Position = mProj * mView * mWorld * inVertexPosition;
 
 	varColor = inVertexColor;
 }

--- a/client/shaders/stars_shader/opengl_vertex.glsl
+++ b/client/shaders/stars_shader/opengl_vertex.glsl
@@ -1,4 +1,4 @@
 void main(void)
 {
-	gl_Position = mWorldViewProj * inVertexPosition;
+	gl_Position = mProj * mView * mWorld * inVertexPosition;
 }

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -229,11 +229,11 @@ public:
 
 class MainShaderConstantSetter : public IShaderConstantSetter
 {
-	CachedVertexShaderSetting<float, 16> m_world_view_proj;
+	CachedVertexShaderSetting<float, 16> m_proj;
 	CachedVertexShaderSetting<float, 16> m_world;
-#if ENABLE_GLES
 	// Modelview matrix
-	CachedVertexShaderSetting<float, 16> m_world_view;
+	CachedVertexShaderSetting<float, 16> m_view;
+#if ENABLE_GLES
 	// Texture matrix
 	CachedVertexShaderSetting<float, 16> m_texture;
 	// Normal matrix
@@ -242,10 +242,10 @@ class MainShaderConstantSetter : public IShaderConstantSetter
 
 public:
 	MainShaderConstantSetter() :
-		  m_world_view_proj("mWorldViewProj")
+		  m_proj("mProj")
 		, m_world("mWorld")
+		, m_view("mView")
 #if ENABLE_GLES
-		, m_world_view("mWorldView")
 		, m_texture("mTexture")
 		, m_normal("mNormal")
 #endif
@@ -265,26 +265,24 @@ public:
 		else
 			services->setVertexShaderConstant(world.pointer(), 4, 4);
 
-		// Set clip matrix
-		core::matrix4 worldView;
-		worldView = driver->getTransform(video::ETS_VIEW);
-		worldView *= world;
-		core::matrix4 worldViewProj;
-		worldViewProj = driver->getTransform(video::ETS_PROJECTION);
-		worldViewProj *= worldView;
+		core::matrix4 view = driver->getTransform(video::ETS_VIEW);
 		if (is_highlevel)
-			m_world_view_proj.set(*reinterpret_cast<float(*)[16]>(worldViewProj.pointer()), services);
+			m_view.set(*reinterpret_cast<float(*)[16]>(view.pointer()), services);
 		else
-			services->setVertexShaderConstant(worldViewProj.pointer(), 0, 4);
+			services->setVertexShaderConstant(view.pointer(), 0, 4);
 
+		core::matrix4 proj = driver->getTransform(video::ETS_PROJECTION);
+		if (is_highlevel)
+			m_proj.set(*reinterpret_cast<float(*)[16]>(proj.pointer()), services);
+		else
+			services->setVertexShaderConstant(proj.pointer(), 0, 4);
 #if ENABLE_GLES
 		if (is_highlevel) {
 			core::matrix4 texture = driver->getTransform(video::ETS_TEXTURE_0);
-			m_world_view.set(*reinterpret_cast<float(*)[16]>(worldView.pointer()), services);
 			m_texture.set(*reinterpret_cast<float(*)[16]>(texture.pointer()), services);
 
 			core::matrix4 normal;
-			worldView.getTransposed(normal);
+			(view * world).getTransposed(normal);
 			sanity_check(normal.makeInverse());
 			float m[9] = {
 				normal[0], normal[1], normal[2],
@@ -663,8 +661,9 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 			"#version 100\n"
 			;
 		vertex_header = R"(
-			uniform highp mat4 mWorldView;
-			uniform highp mat4 mWorldViewProj;
+			uniform highp mat4 mWorld;
+			uniform highp mat4 mView;
+			uniform highp mat4 mProj;
 			uniform mediump mat4 mTexture;
 			uniform mediump mat3 mNormal;
 
@@ -686,8 +685,9 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 			#define highp
 			)";
 		vertex_header = R"(
-			#define mWorldView gl_ModelViewMatrix
-			#define mWorldViewProj gl_ModelViewProjectionMatrix
+			uniform mat4 mWorld;
+			uniform mat4 mView;
+			uniform mat4 mProj;
 			#define mTexture (gl_TextureMatrix[0])
 			#define mNormal gl_NormalMatrix
 


### PR DESCRIPTION
This removes some more references to the matrices of the hardcoded OpenGL pipeline and passes them into the shaders instead.
For shader programs this also gives access to the work, view, and projection matrices separately.

See also #10686
