### PR TITLE
Fix misleading chat messages of /clearobjects

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -1075,10 +1075,12 @@ core.register_chatcommand("clearobjects", {
 			return false, S("Invalid usage, see /help clearobjects.")
 		end
 
-		core.log("action", name .. " clears all objects ("
+		core.log("action", name .. " clears objects ("
 				.. options.mode .. " mode).")
-		core.chat_send_all(S("Clearing all objects. This may take a long time. "
-			.. "You may experience a timeout. (by @1)", name))
+		if options.mode == "full" then
+			core.chat_send_all(S("Clearing all objects. This may take a long time. "
+				.. "You may experience a timeout. (by @1)", name))
+		end
 		core.clear_objects(options)
 		core.log("action", "Object clearing done.")
 		core.chat_send_all("*** "..S("Cleared all objects."))


### PR DESCRIPTION
This PR changes the messages that appear when you use `/clearobjects` with different argument.

## Why?

Before, in both modes (quick or full), the messages said that *all* objects are being removed, and that this will take a long time. But the messages were wrong in quick mode, which does a) not remove all objects and b) is not slow.

With this PR, the messages have been adjusted to be more fitting for quick mode (which is the default btw).

## How to test

Use `/clearobjects quick` and `/clearobjects full` and watch the messages.