### PR TITLE
Break up the message queue by category

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -701,6 +701,8 @@ u8 ClientInterface::patchLegacyChannel(u8 channel, u16 proto_version)
 		channel = legacyChannelMap.at(channel);
 		assert(channel < LEGACY_CHANNEL_COUNT);
 		verbosestream << "Patching legacy channel to " << ((int)channel) << "\n";
+	} else {
+		verbosestream << "Protocol version matches, packet won't be patched\n";
 	}
 	return channel;
 }
@@ -710,8 +712,11 @@ void ClientInterface::send(session_t peer_id, u8 channelnum,
 {
 	RemoteClient *rcl = getClientNoEx(peer_id);
 
+	
 	if (rcl) {
 		channelnum = patchLegacyChannel(channelnum, rcl->net_proto_version);
+	} else {
+		verbosestream << "RemoteClient for pid " << peer_id << " not found\n";
 	}
 	verbosestream << "Sending out packet on channel " << ((int)channelnum) << "\n";
 	m_con->Send(peer_id, channelnum, pkt, reliable);

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -698,7 +698,7 @@ u8 ClientInterface::patchLegacyChannel(u8 channel, u16 proto_version)
 {
 	// Funnel packets into the original 3 channels for legacy clients.
 	if (proto_version < 40) {
-		channel = legacyChannelMap.at(channel);
+		channel = legacyChannelMap[channel];
 		// If this is tripped, you probably messed up the legacy lookup.
 		assert(channel < LEGACY_CHANNEL_COUNT);
 	}

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -700,7 +700,7 @@ u8 ClientInterface::patchLegacyChannel(u8 channel, u16 proto_version)
 	if (proto_version < 40) {
 		channel = legacyChannelMap.at(channel);
 		assert(channel < LEGACY_CHANNEL_COUNT);
-		verbosestream << "Patching legacy channel to " << channel << "\n";
+		verbosestream << "Patching legacy channel to " << ((int)channel) << "\n";
 	}
 	return channel;
 }
@@ -713,7 +713,7 @@ void ClientInterface::send(session_t peer_id, u8 channelnum,
 	if (rcl) {
 		channelnum = patchLegacyChannel(channelnum, rcl->net_proto_version);
 	}
-	verbosestream << "Sending out packet on channel " << channelnum << "\n";
+	verbosestream << "Sending out packet on channel " << ((int)channelnum) << "\n";
 	m_con->Send(peer_id, channelnum, pkt, reliable);
 }
 
@@ -725,8 +725,10 @@ void ClientInterface::sendToAll(NetworkPacket *pkt)
 
 		if (client->net_proto_version != 0) {
 			u8 channel = clientCommandFactoryTable[pkt->getCommand()].channel;
+			channel = patchLegacyChannel(channel, client->net_proto_version);
+			verbosestream << "Broadcasting packet on channel " << ((int)channel) << "\n";
 			m_con->Send(client->peer_id,
-					patchLegacyChannel(channel, client->net_proto_version), pkt,
+					channel, pkt,
 					clientCommandFactoryTable[pkt->getCommand()].reliable);
 		}
 	}

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -712,8 +712,8 @@ void ClientInterface::send(session_t peer_id, u8 channelnum,
 
 	if (rcl) {
 		channelnum = patchLegacyChannel(channelnum, rcl->net_proto_version);
-		verbosestream << "Sending out packet on channel " << channelnum << "\n";
 	}
+	verbosestream << "Sending out packet on channel " << channelnum << "\n";
 	m_con->Send(peer_id, channelnum, pkt, reliable);
 }
 

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -697,6 +697,12 @@ void ClientInterface::UpdatePlayerList()
 void ClientInterface::send(session_t peer_id, u8 channelnum,
 		NetworkPacket *pkt, bool reliable)
 {
+	// Funnel packets into the original 3 channels for legacy clients.
+	if (net_proto_version < 40) {
+		channelnum = legacyChannelMap[channelnum];
+		assert( channelnum < LEGACY_CHANNEL_COUNT );
+	}
+
 	m_con->Send(peer_id, channelnum, pkt, reliable);
 }
 

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -700,7 +700,8 @@ u8 ClientInterface::patchLegacyChannel(u8 channel, u16 proto_version)
 	if (proto_version < 40) {
 		channel = legacyChannelMap.at(channel);
 		assert(channel < LEGACY_CHANNEL_COUNT);
-	}	
+		verbosestream << "Patching legacy channel to " << channel << "\n";
+	}
 	return channel;
 }
 
@@ -708,8 +709,11 @@ void ClientInterface::send(session_t peer_id, u8 channelnum,
 		NetworkPacket *pkt, bool reliable)
 {
 	RemoteClient *rcl = getClientNoEx(peer_id);
-	if (rcl)
+
+	if (rcl) {
 		channelnum = patchLegacyChannel(channelnum, rcl->net_proto_version);
+		verbosestream << "Sending out packet on channel " << channelnum << "\n";
+	}
 	m_con->Send(peer_id, channelnum, pkt, reliable);
 }
 
@@ -746,8 +750,9 @@ void ClientInterface::sendToAllCompat(NetworkPacket *pkt, NetworkPacket *legacyp
 			continue;
 		}
 
+		u8 channel = clientCommandFactoryTable[pkt_to_send->getCommand()].channel;
 		m_con->Send(client->peer_id,
-			clientCommandFactoryTable[pkt_to_send->getCommand()].channel,
+			patchLegacyChannel(channel, client->net_proto_version),
 			pkt_to_send,
 			clientCommandFactoryTable[pkt_to_send->getCommand()].reliable);
 	}

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -339,8 +339,9 @@ public:
 	u8 getMajor() const { return m_version_major; }
 	u8 getMinor() const { return m_version_minor; }
 	u8 getPatch() const { return m_version_patch; }
+
 	const std::string &getFullVer() const { return m_full_version; }
-	
+
 	void setLangCode(const std::string &code) { m_lang_code = code; }
 	const std::string &getLangCode() const { return m_lang_code; }
 
@@ -513,6 +514,9 @@ protected:
 private:
 	/* update internal player list */
 	void UpdatePlayerList();
+	
+	/* Funnel the channel ID into the three legacy channels. */
+	u8 patchLegacyChannel(u8 channel, u16 proto_version);
 
 	// Connection
 	std::shared_ptr<con::Connection> m_con;

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1143,20 +1143,17 @@ void UDPPeer::RunCommandQueues(
 
 u16 UDPPeer::getNextSplitSequenceNumber(u8 channel)
 {
-	assert(channel < CHANNEL_COUNT); // Pre-condition
 	return channels[channel].readNextSplitSeqNum();
 }
 
 void UDPPeer::setNextSplitSequenceNumber(u8 channel, u16 seqnum)
 {
-	assert(channel < CHANNEL_COUNT); // Pre-condition
 	channels[channel].setNextSplitSeqNum(seqnum);
 }
 
 SharedBuffer<u8> UDPPeer::addSplitPacket(u8 channel, const BufferedPacket &toadd,
 	bool reliable)
 {
-	assert(channel < CHANNEL_COUNT); // Pre-condition
 	return channels[channel].incoming_splits.insert(toadd, reliable);
 }
 
@@ -1403,7 +1400,6 @@ bool Connection::TryReceive(NetworkPacket *pkt)
 void Connection::Send(session_t peer_id, u8 channelnum,
 		NetworkPacket *pkt, bool reliable)
 {
-	assert(channelnum < CHANNEL_COUNT); // Pre-condition
 
 	ConnectionCommand c;
 
@@ -1546,7 +1542,6 @@ void Connection::DisconnectPeer(session_t peer_id)
 
 void Connection::sendAck(session_t peer_id, u8 channelnum, u16 seqnum)
 {
-	assert(channelnum < CHANNEL_COUNT); // Pre-condition
 
 	LOG(dout_con<<getDesc()
 			<<" Queuing ACK command to peer_id: " << peer_id <<

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -151,10 +151,11 @@ sender_peer_id:
 	value 1 (PEER_ID_SERVER) is reserved for server
 	these constants are defined in constants.h
 channel:
-	Channel numbers have no intrinsic meaning. Currently only 0, 1, 2 exist.
+	Network messages are transferred over a number of parallel channels.
+	See serveropcodes.h for details on how the channels are being used.
 */
 #define BASE_HEADER_SIZE 7
-#define CHANNEL_COUNT 3
+#define CHANNEL_COUNT 17
 /*
 Packet types:
 

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -153,9 +153,13 @@ sender_peer_id:
 channel:
 	Network messages are transferred over a number of parallel channels.
 	See serveropcodes.h for details on how the channels are being used.
+	Historically, 3 static channels were being used for communication.
+	Channels are now allocated dynamically based on the server's 
 */
 #define BASE_HEADER_SIZE 7
-#define CHANNEL_COUNT 17
+#define LEGACY_CHANNEL_COUNT 3
+#define CHANNEL_COUNT 256
+
 /*
 Packet types:
 
@@ -810,8 +814,8 @@ protected:
 	void putEvent(ConnectionEvent &e);
 
 	void TriggerSend();
-	
-	bool ConnectedToServer() 
+
+	bool ConnectedToServer()
 	{
 		return getPeerNoEx(PEER_ID_SERVER) != nullptr;
 	}

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -154,7 +154,7 @@ channel:
 	Network messages are transferred over a number of parallel channels.
 	See serveropcodes.h for details on how the channels are being used.
 	Historically, 3 static channels were being used for communication.
-	Channels are now allocated dynamically based on the server's 
+	Now the whole 256 channel range is available.
 */
 #define BASE_HEADER_SIZE 7
 #define LEGACY_CHANNEL_COUNT 3

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -580,8 +580,6 @@ void ConnectionSendThread::disconnect_peer(session_t peer_id)
 void ConnectionSendThread::send(session_t peer_id, u8 channelnum,
 	const SharedBuffer<u8> &data)
 {
-	assert(channelnum < CHANNEL_COUNT); // Pre-condition
-
 	PeerHelper peer = m_connection->getPeerNoEx(peer_id);
 	if (!peer) {
 		LOG(dout_con << m_connection->getDesc() << " peer: peer_id=" << peer_id
@@ -684,7 +682,7 @@ void ConnectionSendThread::sendPackets(float dtime)
 			<< " packet quota: " << peer->m_increment_packets_remaining << std::endl);
 
 		// first send queued reliable packets for all peers (if possible)
-		for (unsigned int i = 0; i < CHANNEL_COUNT; i++) {
+		for (unsigned int i = 0; i < LEGACY_CHANNEL_COUNT; i++) {
 			Channel &channel = udpPeer->channels[i];
 			u16 next_to_ack = 0;
 
@@ -856,7 +854,7 @@ void *ConnectionReceiveThread::run()
 				float avg_rate = 0.0;
 				float avg_loss = 0.0;
 
-				for(u16 j=0; j<CHANNEL_COUNT; j++)
+				for(u16 j=0; j<LEGACY_CHANNEL_COUNT; j++)
 				{
 					peer_current +=peer->channels[j].getCurrentDownloadRateKB();
 					peer_loss += peer->channels[j].getCurrentLossRateKB();
@@ -870,7 +868,7 @@ void *ConnectionReceiveThread::run()
 				output << "\tcurrent (sum): " << peer_current << "kb/s "<< peer_loss << "kb/s" << std::endl;
 				output << "\taverage (sum): " << avg_rate << "kb/s "<< avg_loss << "kb/s" << std::endl;
 				output << std::setfill(' ');
-				for(u16 j=0; j<CHANNEL_COUNT; j++)
+				for(u16 j=0; j<LEGACY_CHANNEL_COUNT; j++)
 				{
 					output << "\tcha " << j << ":"
 						<< " CUR: " << std::setw(6) << peer->channels[j].getCurrentDownloadRateKB() <<"kb/s"
@@ -942,7 +940,7 @@ void ConnectionReceiveThread::receive(SharedBuffer<u8> &packetdata,
 		session_t peer_id = readPeerId(*packetdata);
 		u8 channelnum = readChannel(*packetdata);
 
-		if (channelnum > CHANNEL_COUNT - 1) {
+		if (channelnum > LEGACY_CHANNEL_COUNT - 1) {
 			LOG(derr_con << m_connection->getDesc()
 				<< "Receive(): Invalid channel " << (u32)channelnum << std::endl);
 			return;

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -682,7 +682,7 @@ void ConnectionSendThread::sendPackets(float dtime)
 			<< " packet quota: " << peer->m_increment_packets_remaining << std::endl);
 
 		// first send queued reliable packets for all peers (if possible)
-		for (unsigned int i = 0; i < LEGACY_CHANNEL_COUNT; i++) {
+		for (unsigned int i = 0; i < CHANNEL_COUNT; i++) {
 			Channel &channel = udpPeer->channels[i];
 			u16 next_to_ack = 0;
 
@@ -854,7 +854,7 @@ void *ConnectionReceiveThread::run()
 				float avg_rate = 0.0;
 				float avg_loss = 0.0;
 
-				for(u16 j=0; j<LEGACY_CHANNEL_COUNT; j++)
+				for(u16 j=0; j<CHANNEL_COUNT; j++)
 				{
 					peer_current +=peer->channels[j].getCurrentDownloadRateKB();
 					peer_loss += peer->channels[j].getCurrentLossRateKB();
@@ -868,7 +868,7 @@ void *ConnectionReceiveThread::run()
 				output << "\tcurrent (sum): " << peer_current << "kb/s "<< peer_loss << "kb/s" << std::endl;
 				output << "\taverage (sum): " << avg_rate << "kb/s "<< avg_loss << "kb/s" << std::endl;
 				output << std::setfill(' ');
-				for(u16 j=0; j<LEGACY_CHANNEL_COUNT; j++)
+				for(u16 j=0; j<CHANNEL_COUNT; j++)
 				{
 					output << "\tcha " << j << ":"
 						<< " CUR: " << std::setw(6) << peer->channels[j].getCurrentDownloadRateKB() <<"kb/s"
@@ -939,12 +939,6 @@ void ConnectionReceiveThread::receive(SharedBuffer<u8> &packetdata,
 
 		session_t peer_id = readPeerId(*packetdata);
 		u8 channelnum = readChannel(*packetdata);
-
-		if (channelnum > LEGACY_CHANNEL_COUNT - 1) {
-			LOG(derr_con << m_connection->getDesc()
-				<< "Receive(): Invalid channel " << (u32)channelnum << std::endl);
-			return;
-		}
 
 		/* Try to identify peer by sender address (may happen on join) */
 		if (peer_id == PEER_ID_INEXISTENT) {

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -209,7 +209,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Added 'basic_debug' privilege
 	PROTOCOL VERSION 41:
 		Break up the monolithic packet channels.
-		Make the channels dynamic.
+		Expand the channel count to 256.
 		Emulate the legacy 3-channel protocol.
 */
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -207,9 +207,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Minimap modes
 	PROTOCOL VERSION 40:
 		Added 'basic_debug' privilege
+	PROTOCOL VERSION 41:
+		Break up the monolithic packet channels.
+		Make the channels dynamic.
+		Emulate the legacy 3-channel protocol.
 */
 
-#define LATEST_PROTOCOL_VERSION 40
+#define LATEST_PROTOCOL_VERSION 41
 #define LATEST_PROTOCOL_VERSION_STRING TOSTRING(LATEST_PROTOCOL_VERSION)
 
 // Server's supported network protocol range

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -225,18 +225,18 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 //	The mapping is different (and more balanced) than the original,
 //	but clients shouldn't care.
 //	Guideline: 2 for high bandwidth, 0 for high frequency, 1 for the rest
-const std::map<int,int> legacyChannelMap = {
+const std::map<u8,u8> legacyChannelMap = {
 	{ MTSCMC_DEFAULT, 0 },
 	{ MTSCMC_HUD, 1 },
 	{ MTSCMC_AUTH, 0 },
 	{ MTSCMC_INIT, 0 },
 	{ MTSCMC_MEDIA, 2 },
 	{ MTSCMC_MAP, 2 },
-	{ MTSCMC_INVENTORY, 2 }, // makes sense to sync it with forms and map meta
+	{ MTSCMC_INVENTORY, 1 },
 	{ MTSCMC_ENTITY, 0 },
 	{ MTSCMC_CHAT, 1 },
 	{ MTSCMC_CAMERA, 1 },
-	{ MTSCMC_FORMSPEC, 2 }, // forms are big and rarely updated
+	{ MTSCMC_FORMSPEC, 1 },
 	{ MTSCMC_PARTICLE, 1 },
 	{ MTSCMC_PHYSICS, 0 },
 	{ MTSCMC_ENVIRONMENT, 1 },

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -125,21 +125,21 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 {
 	null_command_factory, // 0x00
 	null_command_factory, // 0x01
-	{ "TOCLIENT_HELLO",                    0, true }, // 0x02
-	{ "TOCLIENT_AUTH_ACCEPT",              0, true }, // 0x03
-	{ "TOCLIENT_ACCEPT_SUDO_MODE",         0, true }, // 0x04
-	{ "TOCLIENT_DENY_SUDO_MODE",           0, true }, // 0x05
+	{ "TOCLIENT_HELLO",                    MTSCMC_AUTH, true }, // 0x02
+	{ "TOCLIENT_AUTH_ACCEPT",              MTSCMC_AUTH, true }, // 0x03
+	{ "TOCLIENT_ACCEPT_SUDO_MODE",         MTSCMC_AUTH, true }, // 0x04
+	{ "TOCLIENT_DENY_SUDO_MODE",           MTSCMC_AUTH, true }, // 0x05
 	null_command_factory, // 0x06
 	null_command_factory, // 0x07
 	null_command_factory, // 0x08
 	null_command_factory, // 0x09
-	{ "TOCLIENT_ACCESS_DENIED",            0, true }, // 0x0A
+	{ "TOCLIENT_ACCESS_DENIED",            MTSCMC_AUTH, true }, // 0x0A
 	null_command_factory, // 0x0B
 	null_command_factory, // 0x0C
 	null_command_factory, // 0x0D
 	null_command_factory, // 0x0E
 	null_command_factory, // 0x0F
-	{ "TOCLIENT_INIT",                     0, true }, // 0x10
+	{ "TOCLIENT_INIT",                     MTSCMC_INIT, true }, // 0x10
 	null_command_factory, // 0x11
 	null_command_factory, // 0x12
 	null_command_factory, // 0x13
@@ -155,71 +155,71 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_factory, // 0x1D
 	null_command_factory, // 0x1E
 	null_command_factory, // 0x1F
-	{ "TOCLIENT_BLOCKDATA",                2, true }, // 0x20
-	{ "TOCLIENT_ADDNODE",                  0, true }, // 0x21
-	{ "TOCLIENT_REMOVENODE",               0, true }, // 0x22
+	{ "TOCLIENT_BLOCKDATA",                MTSCMC_MAP, true }, // 0x20
+	{ "TOCLIENT_ADDNODE",                  MTSCMC_MAP, true }, // 0x21
+	{ "TOCLIENT_REMOVENODE",               MTSCMC_MAP, true }, // 0x22
 	null_command_factory, // 0x23
 	null_command_factory, // 0x24
 	null_command_factory, // 0x25
 	null_command_factory, // 0x26
-	{ "TOCLIENT_INVENTORY",                0, true }, // 0x27
+	{ "TOCLIENT_INVENTORY",                MTSCMC_INVENTORY, true }, // 0x27
 	null_command_factory, // 0x28
-	{ "TOCLIENT_TIME_OF_DAY",              0, true }, // 0x29
-	{ "TOCLIENT_CSM_RESTRICTION_FLAGS",    0, true }, // 0x2A
-	{ "TOCLIENT_PLAYER_SPEED",             0, true }, // 0x2B
-	{ "TOCLIENT_MEDIA_PUSH",               0, true }, // 0x2C (sent over channel 1 too)
+	{ "TOCLIENT_TIME_OF_DAY",              MTSCMC_ENVIRONMENT, true }, // 0x29
+	{ "TOCLIENT_CSM_RESTRICTION_FLAGS",    MTSCMC_AUTH, true }, // 0x2A
+	{ "TOCLIENT_PLAYER_SPEED",             MTSCMC_PHYSICS, true }, // 0x2B
+	{ "TOCLIENT_MEDIA_PUSH",               MTSCMC_MEDIA, true }, // 0x2C (sent over channel 1 too)
 	null_command_factory, // 0x2D
 	null_command_factory, // 0x2E
-	{ "TOCLIENT_CHAT_MESSAGE",             0, true }, // 0x2F
+	{ "TOCLIENT_CHAT_MESSAGE",             MTSCMC_CHAT, true }, // 0x2F
 	null_command_factory, // 0x30
-	{ "TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD", 0, true }, // 0x31
-	{ "TOCLIENT_ACTIVE_OBJECT_MESSAGES",   0, true }, // 0x32 (may be sent as unrel over channel 1 too)
-	{ "TOCLIENT_HP",                       0, true }, // 0x33
-	{ "TOCLIENT_MOVE_PLAYER",              0, true }, // 0x34
-	{ "TOCLIENT_ACCESS_DENIED_LEGACY",     0, true }, // 0x35
-	{ "TOCLIENT_FOV",                      0, true }, // 0x36
-	{ "TOCLIENT_DEATHSCREEN",              0, true }, // 0x37
-	{ "TOCLIENT_MEDIA",                    2, true }, // 0x38
+	{ "TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD", MTSCMC_ENTITY, true }, // 0x31
+	{ "TOCLIENT_ACTIVE_OBJECT_MESSAGES",   MTSCMC_ENTITY, true }, // 0x32 (may be sent as unrel over channel 1 too)
+	{ "TOCLIENT_HP",                       MTSCMC_PLAYERSTAT, true }, // 0x33
+	{ "TOCLIENT_MOVE_PLAYER",              MTSCMC_PHYSICS, true }, // 0x34
+	{ "TOCLIENT_ACCESS_DENIED_LEGACY",     MTSCMC_AUTH, true }, // 0x35
+	{ "TOCLIENT_FOV",                      MTSCMC_CAMERA, true }, // 0x36
+	{ "TOCLIENT_DEATHSCREEN",              MTSCMC_FORMSPEC, true }, // 0x37
+	{ "TOCLIENT_MEDIA",                    MTSCMC_MEDIA, true }, // 0x38
 	null_command_factory, // 0x39
-	{ "TOCLIENT_NODEDEF",                  0, true }, // 0x3A
+	{ "TOCLIENT_NODEDEF",                  MTSCMC_INIT, true }, // 0x3A
 	null_command_factory, // 0x3B
-	{ "TOCLIENT_ANNOUNCE_MEDIA",           0, true }, // 0x3C
-	{ "TOCLIENT_ITEMDEF",                  0, true }, // 0x3D
+	{ "TOCLIENT_ANNOUNCE_MEDIA",           MTSCMC_MEDIA, true }, // 0x3C
+	{ "TOCLIENT_ITEMDEF",                  MTSCMC_INIT, true }, // 0x3D
 	null_command_factory, // 0x3E
-	{ "TOCLIENT_PLAY_SOUND",               0, true }, // 0x3f (may be sent as unrel too)
-	{ "TOCLIENT_STOP_SOUND",               0, true }, // 0x40
-	{ "TOCLIENT_PRIVILEGES",               0, true }, // 0x41
-	{ "TOCLIENT_INVENTORY_FORMSPEC",       0, true }, // 0x42
-	{ "TOCLIENT_DETACHED_INVENTORY",       0, true }, // 0x43
-	{ "TOCLIENT_SHOW_FORMSPEC",            0, true }, // 0x44
-	{ "TOCLIENT_MOVEMENT",                 0, true }, // 0x45
-	{ "TOCLIENT_SPAWN_PARTICLE",           0, true }, // 0x46
-	{ "TOCLIENT_ADD_PARTICLESPAWNER",      0, true }, // 0x47
+	{ "TOCLIENT_PLAY_SOUND",               MTSCMC_AUDIO, true }, // 0x3f (may be sent as unrel too)
+	{ "TOCLIENT_STOP_SOUND",               MTSCMC_AUDIO, true }, // 0x40
+	{ "TOCLIENT_PRIVILEGES",               MTSCMC_AUTH, true }, // 0x41
+	{ "TOCLIENT_INVENTORY_FORMSPEC",       MTSCMC_FORMSPEC, true }, // 0x42
+	{ "TOCLIENT_DETACHED_INVENTORY",       MTSCMC_INVENTORY, true }, // 0x43
+	{ "TOCLIENT_SHOW_FORMSPEC",            MTSCMC_FORMSPEC, true }, // 0x44
+	{ "TOCLIENT_MOVEMENT",                 MTSCMC_PHYSICS, true }, // 0x45
+	{ "TOCLIENT_SPAWN_PARTICLE",           MTSCMC_PARTICLE, true }, // 0x46
+	{ "TOCLIENT_ADD_PARTICLESPAWNER",      MTSCMC_PARTICLE, true }, // 0x47
 	null_command_factory, // 0x48
-	{ "TOCLIENT_HUDADD",                   1, true }, // 0x49
-	{ "TOCLIENT_HUDRM",                    1, true }, // 0x4a
-	{ "TOCLIENT_HUDCHANGE",                1, true }, // 0x4b
-	{ "TOCLIENT_HUD_SET_FLAGS",            1, true }, // 0x4c
-	{ "TOCLIENT_HUD_SET_PARAM",            1, true }, // 0x4d
-	{ "TOCLIENT_BREATH",                   0, true }, // 0x4e
-	{ "TOCLIENT_SET_SKY",                  0, true }, // 0x4f
-	{ "TOCLIENT_OVERRIDE_DAY_NIGHT_RATIO", 0, true }, // 0x50
-	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  0, true }, // 0x51
-	{ "TOCLIENT_EYE_OFFSET",               0, true }, // 0x52
-	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   0, true }, // 0x53
-	{ "TOCLIENT_CLOUD_PARAMS",             0, true }, // 0x54
-	{ "TOCLIENT_FADE_SOUND",               0, true }, // 0x55
-	{ "TOCLIENT_UPDATE_PLAYER_LIST",       0, true }, // 0x56
-	{ "TOCLIENT_MODCHANNEL_MSG",           0, true }, // 0x57
-	{ "TOCLIENT_MODCHANNEL_SIGNAL",        0, true }, // 0x58
-	{ "TOCLIENT_NODEMETA_CHANGED",         0, true }, // 0x59
-	{ "TOCLIENT_SET_SUN",                  0, true }, // 0x5a
-	{ "TOCLIENT_SET_MOON",                 0, true }, // 0x5b
-	{ "TOCLIENT_SET_STARS",                0, true }, // 0x5c
+	{ "TOCLIENT_HUDADD",                   MTSCMC_HUD, true }, // 0x49
+	{ "TOCLIENT_HUDRM",                    MTSCMC_HUD, true }, // 0x4a
+	{ "TOCLIENT_HUDCHANGE",                MTSCMC_HUD, true }, // 0x4b
+	{ "TOCLIENT_HUD_SET_FLAGS",            MTSCMC_HUD, true }, // 0x4c
+	{ "TOCLIENT_HUD_SET_PARAM",            MTSCMC_HUD, true }, // 0x4d
+	{ "TOCLIENT_BREATH",                   MTSCMC_PLAYERSTAT, true }, // 0x4e
+	{ "TOCLIENT_SET_SKY",                  MTSCMC_ENVIRONMENT, true }, // 0x4f
+	{ "TOCLIENT_OVERRIDE_DAY_NIGHT_RATIO", MTSCMC_ENVIRONMENT, true }, // 0x50
+	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  MTSCMC_ENTITY, true }, // 0x51
+	{ "TOCLIENT_EYE_OFFSET",               MTSCMC_CAMERA, true }, // 0x52
+	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   MTSCMC_PARTICLE, true }, // 0x53
+	{ "TOCLIENT_CLOUD_PARAMS",             MTSCMC_ENVIRONMENT, true }, // 0x54
+	{ "TOCLIENT_FADE_SOUND",               MTSCMC_AUDIO, true }, // 0x55
+	{ "TOCLIENT_UPDATE_PLAYER_LIST",       MTSCMC_AUTH, true }, // 0x56
+	{ "TOCLIENT_MODCHANNEL_MSG",           MTSCMC_MODCHANNEL, true }, // 0x57
+	{ "TOCLIENT_MODCHANNEL_SIGNAL",        MTSCMC_MODCHANNEL, true }, // 0x58
+	{ "TOCLIENT_NODEMETA_CHANGED",         MTSCMC_MAP, true }, // 0x59
+	{ "TOCLIENT_SET_SUN",                  MTSCMC_ENVIRONMENT, true }, // 0x5a
+	{ "TOCLIENT_SET_MOON",                 MTSCMC_ENVIRONMENT, true }, // 0x5b
+	{ "TOCLIENT_SET_STARS",                MTSCMC_ENVIRONMENT, true }, // 0x5c
 	null_command_factory, // 0x5d
 	null_command_factory, // 0x5e
 	null_command_factory, // 0x5f
-	{ "TOSERVER_SRP_BYTES_S_B",            0, true }, // 0x60
-	{ "TOCLIENT_FORMSPEC_PREPEND",         0, true }, // 0x61
-	{ "TOCLIENT_MINIMAP_MODES",            0, true }, // 0x62
+	{ "TOSERVER_SRP_BYTES_S_B",            MTSCMC_AUTH, true }, // 0x60
+	{ "TOCLIENT_FORMSPEC_PREPEND",         MTSCMC_FORMSPEC, true }, // 0x61
+	{ "TOCLIENT_MINIMAP_MODES",            MTSCMC_HUD, true }, // 0x62
 };

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -153,8 +153,8 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_factory, // 0x1E
 	null_command_factory, // 0x1F
 	{ "TOCLIENT_BLOCKDATA",                MTSCMC_MAP, true }, // 0x20
-	{ "TOCLIENT_ADDNODE",                  MTSCMC_MAP, true }, // 0x21
-	{ "TOCLIENT_REMOVENODE",               MTSCMC_MAP, true }, // 0x22
+	{ "TOCLIENT_ADDNODE",                  MTSCMC_NODE, true }, // 0x21
+	{ "TOCLIENT_REMOVENODE",               MTSCMC_NODE, true }, // 0x22
 	null_command_factory, // 0x23
 	null_command_factory, // 0x24
 	null_command_factory, // 0x25
@@ -209,7 +209,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_UPDATE_PLAYER_LIST",       MTSCMC_AUTH, true }, // 0x56
 	{ "TOCLIENT_MODCHANNEL_MSG",           MTSCMC_MODCHANNEL, true }, // 0x57
 	{ "TOCLIENT_MODCHANNEL_SIGNAL",        MTSCMC_MODCHANNEL, true }, // 0x58
-	{ "TOCLIENT_NODEMETA_CHANGED",         MTSCMC_MAP, true }, // 0x59
+	{ "TOCLIENT_NODEMETA_CHANGED",         MTSCMC_NODE, true }, // 0x59
 	{ "TOCLIENT_SET_SUN",                  MTSCMC_ENVIRONMENT, true }, // 0x5a
 	{ "TOCLIENT_SET_MOON",                 MTSCMC_ENVIRONMENT, true }, // 0x5b
 	{ "TOCLIENT_SET_STARS",                MTSCMC_ENVIRONMENT, true }, // 0x5c
@@ -243,4 +243,5 @@ const u8 legacyChannelMap[256] = {
 	1, // MTSCMC_AUDIO
 	0, // MTSCMC_PLAYERSTAT
 	0, // MTSCMC_MODCHANNEL
+	0, // MTSCMC_NODE
 };

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -225,22 +225,22 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 //	The mapping is different (and more balanced) than the original,
 //	but clients shouldn't care.
 //	Guideline: 2 for high bandwidth, 0 for high frequency, 1 for the rest
-const std::map<u8,u8> legacyChannelMap = {
-	{ MTSCMC_DEFAULT, 0 },
-	{ MTSCMC_HUD, 1 },
-	{ MTSCMC_AUTH, 0 },
-	{ MTSCMC_INIT, 0 },
-	{ MTSCMC_MEDIA, 2 },
-	{ MTSCMC_MAP, 2 },
-	{ MTSCMC_INVENTORY, 1 },
-	{ MTSCMC_ENTITY, 0 },
-	{ MTSCMC_CHAT, 1 },
-	{ MTSCMC_CAMERA, 1 },
-	{ MTSCMC_FORMSPEC, 1 },
-	{ MTSCMC_PARTICLE, 1 },
-	{ MTSCMC_PHYSICS, 0 },
-	{ MTSCMC_ENVIRONMENT, 1 },
-	{ MTSCMC_AUDIO, 1 },
-	{ MTSCMC_PLAYERSTAT, 0 },
-	{ MTSCMC_MODCHANNEL, 0 },
+const u8 legacyChannelMap[256] = {
+	0, // MTSCMC_DEFAULT
+	1, // MTSCMC_HUD
+	0, // MTSCMC_AUTH
+	0, // MTSCMC_INIT
+	2, // MTSCMC_MEDIA
+	2, // MTSCMC_MAP
+	1, // MTSCMC_INVENTORY
+	0, // MTSCMC_ENTITY
+	1, // MTSCMC_CHAT
+	1, // MTSCMC_CAMERA
+	1, // MTSCMC_FORMSPEC
+	1, // MTSCMC_PARTICLE
+	0, // MTSCMC_PHYSICS
+	1, // MTSCMC_ENVIRONMENT
+	1, // MTSCMC_AUDIO
+	0, // MTSCMC_PLAYERSTAT
+	0, // MTSCMC_MODCHANNEL
 };

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -113,9 +113,6 @@ const static ClientCommandFactory null_command_factory = { "TOCLIENT_NULL", 0, f
 
 /*
 	Channels used for Server -> Client communication
-	2: Bulk data (mapblocks, media, ...)
-	1: HUD packets
-	0: everything else
 
 	Packet order is only guaranteed inside a channel, so packets that operate on
 	the same objects are *required* to be in the same channel.
@@ -222,4 +219,28 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOSERVER_SRP_BYTES_S_B",            MTSCMC_AUTH, true }, // 0x60
 	{ "TOCLIENT_FORMSPEC_PREPEND",         MTSCMC_FORMSPEC, true }, // 0x61
 	{ "TOCLIENT_MINIMAP_MODES",            MTSCMC_HUD, true }, // 0x62
+};
+
+//	Legacy channels for 5.3 and earlier.
+//	The mapping is different (and more balanced) than the original,
+//	but clients shouldn't care.
+//	Guideline: 2 for high bandwidth, 0 for high frequency, 1 for the rest
+const std::map<int,int> legacyChannelMap = {
+	{ MTSCMC_DEFAULT, 0 },
+	{ MTSCMC_HUD, 1 },
+	{ MTSCMC_AUTH, 0 },
+	{ MTSCMC_INIT, 0 },
+	{ MTSCMC_MEDIA, 2 },
+	{ MTSCMC_MAP, 2 },
+	{ MTSCMC_INVENTORY, 2 }, // makes sense to sync it with forms and map meta
+	{ MTSCMC_ENTITY, 0 },
+	{ MTSCMC_CHAT, 1 },
+	{ MTSCMC_CAMERA, 1 },
+	{ MTSCMC_FORMSPEC, 2 }, // forms are big and rarely updated
+	{ MTSCMC_PARTICLE, 1 },
+	{ MTSCMC_PHYSICS, 0 },
+	{ MTSCMC_ENVIRONMENT, 1 },
+	{ MTSCMC_AUDIO, 1 },
+	{ MTSCMC_PLAYERSTAT, 0 },
+	{ MTSCMC_MODCHANNEL, 0 },
 };

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -31,6 +31,44 @@ enum ToServerConnectionState {
 	TOSERVER_STATE_INGAME,
 	TOSERVER_STATE_ALL,
 };
+
+enum ServerToClientMessageChannel {
+	// Default message channel if none has been specified.
+	MTSCMC_DEFAULT,
+	// HUD add, remove and change operations.
+	MTSCMC_HUD,
+	// Authentication and privileges.
+	MTSCMC_AUTH,
+	// Client state initialization, node and other init-time definitions.
+	MTSCMC_INIT,
+	// Game asset transfer, including dynamic updates.
+	MTSCMC_MEDIA,
+	// Map data.
+	MTSCMC_MAP,
+	// Inventory updates.
+	MTSCMC_INVENTORY,
+	// Entity messages.
+	MTSCMC_ENTITY,
+	// Chat messages.
+	MTSCMC_CHAT,
+	// Camera parameters such as FOV or local position.
+	MTSCMC_CAMERA,
+	// Forms.
+	MTSCMC_FORMSPEC,
+	// Particle FX.
+	MTSCMC_PARTICLE,
+	// Everything physics and motion related.
+	MTSCMC_PHYSICS,
+	// Visual environment settings such as skybox, time of day, sunlight ratio.
+	MTSCMC_ENVIRONMENT,
+	// Audio play, stop and volume control.
+	MTSCMC_AUDIO,
+	// Built in legacy player stats like health and breath.
+	MTSCMC_PLAYERSTAT,
+	// Modchannel messages.
+	MTSCMC_MODCHANNEL,
+};
+
 struct ToServerCommandHandler
 {
     const std::string name;

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -73,6 +73,8 @@ enum ServerToClientMessageChannel : u8 {
 	MTSCMC_PLAYERSTAT,
 	// Modchannel messages.
 	MTSCMC_MODCHANNEL,
+	// Per-node data.
+	MTSCMC_NODE,
 };
 
 struct ToServerCommandHandler

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -33,12 +33,12 @@ enum ToServerConnectionState {
 };
 
 /*
-	When adding new channels, ensure that CHANNEL_COUNT in connection.h 
+	When adding new channels, ensure that CHANNEL_COUNT in connection.h
 	is big enough to accomodate all the channels in this enum.
-	
+
 	If it turns out that different message types need to wait on one another,
 	assign the same number to them instead of merging them into one.
-	
+
 	Always assign numbers explicitly to allow easy rearrangement.
 */
 enum ServerToClientMessageChannel {

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -32,41 +32,50 @@ enum ToServerConnectionState {
 	TOSERVER_STATE_ALL,
 };
 
+/*
+	When adding new channels, ensure that CHANNEL_COUNT in connection.h 
+	is big enough to accomodate all the channels in this enum.
+	
+	If it turns out that different message types need to wait on one another,
+	assign the same number to them instead of merging them into one.
+	
+	Always assign numbers explicitly to allow easy rearrangement.
+*/
 enum ServerToClientMessageChannel {
 	// Default message channel if none has been specified.
-	MTSCMC_DEFAULT,
+	MTSCMC_DEFAULT = 0,
 	// HUD add, remove and change operations.
-	MTSCMC_HUD,
+	MTSCMC_HUD = 1,
 	// Authentication and privileges.
-	MTSCMC_AUTH,
+	MTSCMC_AUTH = 2,
 	// Client state initialization, node and other init-time definitions.
-	MTSCMC_INIT,
+	MTSCMC_INIT = 3,
 	// Game asset transfer, including dynamic updates.
-	MTSCMC_MEDIA,
+	MTSCMC_MEDIA = 4,
 	// Map data.
-	MTSCMC_MAP,
+	MTSCMC_MAP = 5,
 	// Inventory updates.
-	MTSCMC_INVENTORY,
+	MTSCMC_INVENTORY = 6,
 	// Entity messages.
-	MTSCMC_ENTITY,
+	MTSCMC_ENTITY = 7,
 	// Chat messages.
-	MTSCMC_CHAT,
+	MTSCMC_CHAT = 8,
 	// Camera parameters such as FOV or local position.
-	MTSCMC_CAMERA,
+	MTSCMC_CAMERA = 9,
 	// Forms.
-	MTSCMC_FORMSPEC,
+	MTSCMC_FORMSPEC = 10,
 	// Particle FX.
-	MTSCMC_PARTICLE,
+	MTSCMC_PARTICLE = 11,
 	// Everything physics and motion related.
-	MTSCMC_PHYSICS,
+	MTSCMC_PHYSICS = 12,
 	// Visual environment settings such as skybox, time of day, sunlight ratio.
-	MTSCMC_ENVIRONMENT,
+	MTSCMC_ENVIRONMENT = 16,
 	// Audio play, stop and volume control.
-	MTSCMC_AUDIO,
+	MTSCMC_AUDIO = 14,
 	// Built in legacy player stats like health and breath.
-	MTSCMC_PLAYERSTAT,
+	MTSCMC_PLAYERSTAT = 15,
 	// Modchannel messages.
-	MTSCMC_MODCHANNEL,
+	MTSCMC_MODCHANNEL = 16,
 };
 
 struct ToServerCommandHandler

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -39,7 +39,7 @@ enum ToServerConnectionState {
 	
 	If you add a new message type to this enum, please also add it to legacyChannelMap.
 */
-enum ServerToClientMessageChannel {
+enum ServerToClientMessageChannel : u8 {
 	// Default message channel if none has been specified.
 	MTSCMC_DEFAULT,
 	// HUD add, remove and change operations.
@@ -93,4 +93,4 @@ struct ClientCommandFactory
 extern const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES];
 
 extern const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES];
-extern const std::map<int,int> legacyChannelMap;
+extern const std::map<u8,u8> legacyChannelMap;

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -22,7 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "server.h"
 #include "networkprotocol.h"
-#include <map>
 
 class NetworkPacket;
 

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "server.h"
 #include "networkprotocol.h"
+#include <map>
 
 class NetworkPacket;
 
@@ -33,49 +34,46 @@ enum ToServerConnectionState {
 };
 
 /*
-	When adding new channels, ensure that CHANNEL_COUNT in connection.h
-	is big enough to accomodate all the channels in this enum.
-
 	If it turns out that different message types need to wait on one another,
 	assign the same number to them instead of merging them into one.
-
-	Always assign numbers explicitly to allow easy rearrangement.
+	
+	If you add a new message type to this enum, please also add it to legacyChannelMap.
 */
 enum ServerToClientMessageChannel {
 	// Default message channel if none has been specified.
-	MTSCMC_DEFAULT = 0,
+	MTSCMC_DEFAULT,
 	// HUD add, remove and change operations.
-	MTSCMC_HUD = 1,
+	MTSCMC_HUD,
 	// Authentication and privileges.
-	MTSCMC_AUTH = 2,
+	MTSCMC_AUTH,
 	// Client state initialization, node and other init-time definitions.
-	MTSCMC_INIT = 3,
+	MTSCMC_INIT,
 	// Game asset transfer, including dynamic updates.
-	MTSCMC_MEDIA = 4,
+	MTSCMC_MEDIA,
 	// Map data.
-	MTSCMC_MAP = 5,
+	MTSCMC_MAP,
 	// Inventory updates.
-	MTSCMC_INVENTORY = 6,
+	MTSCMC_INVENTORY,
 	// Entity messages.
-	MTSCMC_ENTITY = 7,
+	MTSCMC_ENTITY,
 	// Chat messages.
-	MTSCMC_CHAT = 8,
+	MTSCMC_CHAT,
 	// Camera parameters such as FOV or local position.
-	MTSCMC_CAMERA = 9,
+	MTSCMC_CAMERA,
 	// Forms.
-	MTSCMC_FORMSPEC = 10,
+	MTSCMC_FORMSPEC,
 	// Particle FX.
-	MTSCMC_PARTICLE = 11,
+	MTSCMC_PARTICLE,
 	// Everything physics and motion related.
-	MTSCMC_PHYSICS = 12,
+	MTSCMC_PHYSICS,
 	// Visual environment settings such as skybox, time of day, sunlight ratio.
-	MTSCMC_ENVIRONMENT = 16,
+	MTSCMC_ENVIRONMENT,
 	// Audio play, stop and volume control.
-	MTSCMC_AUDIO = 14,
+	MTSCMC_AUDIO,
 	// Built in legacy player stats like health and breath.
-	MTSCMC_PLAYERSTAT = 15,
+	MTSCMC_PLAYERSTAT,
 	// Modchannel messages.
-	MTSCMC_MODCHANNEL = 16,
+	MTSCMC_MODCHANNEL,
 };
 
 struct ToServerCommandHandler
@@ -95,3 +93,4 @@ struct ClientCommandFactory
 extern const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES];
 
 extern const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES];
+extern const std::map<int,int> legacyChannelMap;

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -93,4 +93,4 @@ struct ClientCommandFactory
 extern const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES];
 
 extern const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES];
-extern const std::map<u8,u8> legacyChannelMap;
+extern const u8 legacyChannelMap[256];


### PR DESCRIPTION
Partial fix for #10694, **protocol bump**.

The network channels have been expanded and reorganized into ~~16~~ more categories. Unrelated messages will no longer block one another, hopefully preventing a brief zap of lag from escalating into an unrecoverable lag storm.
A compatibility filter has been added to support protocols 37-39, by mapping the new channels to the three original ones. The legacy mapping is not an exact 1:1 copy of the old one, but instead attempts to balance the load on all three available queues.
In order to avoid having to write more compatibility code later, all 256 possible channel slots have been allocated. I doubt that this will make much difference.

**This PR is Ready for Review** but it needs a lot of testing to make sure nothing blows up.
You might want to squash when merging, there's some silly debugging commits in this branch.

## Further work
Some places in the code still use hardcoded channel IDs. It's not a big deal right now but it would be a good idea to round them up one day and make them use the new enum.

## How to test
Connect to a server running this PR using various supported clients (from protocol 37 to 40).
Check for any instability and edge cases that might arise from the new channel arrangement. Some subtle changes in behavior are expected, but nothing should outright break.
Compare the network performance to a server without this PR, especially in low bandwidth conditions.

