### PR TITLE
Implement mapblock camera offset correctly

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -56,8 +56,8 @@ void MeshBufListList::add(scene::IMeshBuffer *buf, v3s16 position, u8 layer)
 	}
 	MeshBufList l;
 	l.m = m;
-	l.bufs.push_back({position,buf});
-	list.push_back(l);
+	l.bufs.emplace_back({position, buf});
+	list.emplace_back(l);
 }
 
 // ClientMap
@@ -602,4 +602,3 @@ void ClientMap::PrintInfo(std::ostream &out)
 {
 	out<<"ClientMap: ";
 }
-

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -31,6 +31,37 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <algorithm>
 #include "client/renderingengine.h"
 
+// struct MeshBufListList
+void MeshBufListList::clear()
+{
+	for (auto &list : lists)
+		list.clear();
+}
+
+void MeshBufListList::add(scene::IMeshBuffer *buf, v3s16 position, u8 layer)
+{
+	// Append to the correct layer
+	std::vector<MeshBufList> &list = lists[layer];
+	const video::SMaterial &m = buf->getMaterial();
+	for (MeshBufList &l : list) {
+		// comparing a full material is quite expensive so we don't do it if
+		// not even first texture is equal
+		if (l.m.TextureLayer[0].Texture != m.TextureLayer[0].Texture)
+			continue;
+
+		if (l.m == m) {
+			l.bufs.push_back({position,buf});
+			return;
+		}
+	}
+	MeshBufList l;
+	l.m = m;
+	l.bufs.push_back({position,buf});
+	list.push_back(l);
+}
+
+// ClientMap
+
 ClientMap::ClientMap(
 		Client *client,
 		MapDrawControl &control,
@@ -182,9 +213,7 @@ void ClientMap::updateDrawList()
 				if not seen on display
 			*/
 
-			if (block->mesh) {
-				block->mesh->updateCameraOffset(m_camera_offset);
-			} else {
+			if (!block->mesh) {
 				// Ignore if mesh doesn't exist
 				continue;
 			}
@@ -228,50 +257,6 @@ void ClientMap::updateDrawList()
 	g_profiler->avg("MapBlocks drawn [#]", m_drawlist.size());
 	g_profiler->avg("MapBlocks loaded [#]", blocks_loaded);
 }
-
-struct MeshBufList
-{
-	video::SMaterial m;
-	std::vector<scene::IMeshBuffer*> bufs;
-};
-
-struct MeshBufListList
-{
-	/*!
-	 * Stores the mesh buffers of the world.
-	 * The array index is the material's layer.
-	 * The vector part groups vertices by material.
-	 */
-	std::vector<MeshBufList> lists[MAX_TILE_LAYERS];
-
-	void clear()
-	{
-		for (auto &list : lists)
-			list.clear();
-	}
-
-	void add(scene::IMeshBuffer *buf, u8 layer)
-	{
-		// Append to the correct layer
-		std::vector<MeshBufList> &list = lists[layer];
-		const video::SMaterial &m = buf->getMaterial();
-		for (MeshBufList &l : list) {
-			// comparing a full material is quite expensive so we don't do it if
-			// not even first texture is equal
-			if (l.m.TextureLayer[0].Texture != m.TextureLayer[0].Texture)
-				continue;
-
-			if (l.m == m) {
-				l.bufs.push_back(buf);
-				return;
-			}
-		}
-		MeshBufList l;
-		l.m = m;
-		l.bufs.push_back(buf);
-		list.push_back(l);
-	}
-};
 
 void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 {
@@ -317,6 +302,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	MeshBufListList drawbufs;
 
 	for (auto &i : m_drawlist) {
+		v3s16 block_pos = i.first;
 		MapBlock *block = i.second;
 
 		// If the mesh of the block happened to get deleted, ignore it
@@ -382,7 +368,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 						material.setFlag(video::EMF_WIREFRAME,
 							m_control.show_wireframe);
 
-						drawbufs.add(buf, layer);
+						drawbufs.add(buf, block_pos, layer);
 					}
 				}
 			}
@@ -390,7 +376,10 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	}
 
 	TimeTaker draw("Drawing mesh buffers");
-
+	
+	core::matrix4 m; // Model matrix
+	v3f offset = intToFloat(m_camera_offset, BS);
+	
 	// Render all layers in order
 	for (auto &lists : drawbufs.lists) {
 		for (MeshBufList &list : lists) {
@@ -402,7 +391,13 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			}
 			driver->setMaterial(list.m);
 
-			for (scene::IMeshBuffer *buf : list.bufs) {
+			for (auto &pair : list.bufs) {
+				scene::IMeshBuffer *buf = pair.second;
+				
+				v3f block_wpos = intToFloat(pair.first * MAP_BLOCKSIZE, BS);
+				m.setTranslation(block_wpos - offset);
+				
+				driver->setTransform(video::ETS_WORLD, m);
 				driver->drawMeshBuffer(buf);
 				vertex_count += buf->getVertexCount();
 			}

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -50,13 +50,13 @@ void MeshBufListList::add(scene::IMeshBuffer *buf, v3s16 position, u8 layer)
 			continue;
 
 		if (l.m == m) {
-			l.bufs.emplace_back(std::make_pair(position, buf));
+			l.bufs.emplace_back(position, buf);
 			return;
 		}
 	}
 	MeshBufList l;
 	l.m = m;
-	l.bufs.emplace_back(std::make_pair(position, buf));
+	l.bufs.emplace_back(position, buf);
 	list.emplace_back(l);
 }
 

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -50,13 +50,13 @@ void MeshBufListList::add(scene::IMeshBuffer *buf, v3s16 position, u8 layer)
 			continue;
 
 		if (l.m == m) {
-			l.bufs.emplace_back({position, buf});
+			l.bufs.emplace_back(std::make_pair(position, buf));
 			return;
 		}
 	}
 	MeshBufList l;
 	l.m = m;
-	l.bufs.emplace_back({position, buf});
+	l.bufs.emplace_back(std::make_pair(position, buf));
 	list.emplace_back(l);
 }
 
@@ -376,10 +376,10 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	}
 
 	TimeTaker draw("Drawing mesh buffers");
-	
+
 	core::matrix4 m; // Model matrix
 	v3f offset = intToFloat(m_camera_offset, BS);
-	
+
 	// Render all layers in order
 	for (auto &lists : drawbufs.lists) {
 		for (MeshBufList &list : lists) {
@@ -393,10 +393,10 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 
 			for (auto &pair : list.bufs) {
 				scene::IMeshBuffer *buf = pair.second;
-				
+
 				v3f block_wpos = intToFloat(pair.first * MAP_BLOCKSIZE, BS);
 				m.setTranslation(block_wpos - offset);
-				
+
 				driver->setTransform(video::ETS_WORLD, m);
 				driver->drawMeshBuffer(buf);
 				vertex_count += buf->getVertexCount();

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -50,7 +50,7 @@ void MeshBufListList::add(scene::IMeshBuffer *buf, v3s16 position, u8 layer)
 			continue;
 
 		if (l.m == m) {
-			l.bufs.push_back({position,buf});
+			l.bufs.emplace_back({position, buf});
 			return;
 		}
 	}
@@ -602,5 +602,4 @@ void ClientMap::PrintInfo(std::ostream &out)
 {
 	out<<"ClientMap: ";
 }
-
 

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -35,6 +35,25 @@ struct MapDrawControl
 	bool show_wireframe = false;
 };
 
+struct MeshBufList
+{
+	video::SMaterial m;
+	std::vector<std::pair<v3s16,scene::IMeshBuffer*>> bufs;
+};
+
+struct MeshBufListList
+{
+	/*!
+	 * Stores the mesh buffers of the world.
+	 * The array index is the material's layer.
+	 * The vector part groups vertices by material.
+	 */
+	std::vector<MeshBufList> lists[MAX_TILE_LAYERS];
+
+	void clear();
+	void add(scene::IMeshBuffer *buf, v3s16 position, u8 layer);
+};
+
 class Client;
 class ITextureSource;
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1175,13 +1175,6 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 			buf->drop();
 		}
 
-		/*
-			Do some stuff to the mesh
-		*/
-		m_camera_offset = camera_offset;
-		translateMesh(m_mesh[layer],
-			intToFloat(data->m_blockpos * MAP_BLOCKSIZE - camera_offset, BS));
-
 		if (m_mesh[layer]) {
 #if 0
 			// Usually 1-700 faces and 1-7 materials
@@ -1306,19 +1299,6 @@ bool MapBlockMesh::animate(bool faraway, float time, int crack,
 	}
 
 	return true;
-}
-
-void MapBlockMesh::updateCameraOffset(v3s16 camera_offset)
-{
-	if (camera_offset != m_camera_offset) {
-		for (scene::IMesh *layer : m_mesh) {
-			translateMesh(layer,
-				intToFloat(m_camera_offset - camera_offset, BS));
-			if (m_enable_vbo)
-				layer->setDirty();
-		}
-		m_camera_offset = camera_offset;
-	}
 }
 
 video::SColor encode_light(u16 light, u8 emissive_light)

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -160,9 +160,6 @@ private:
 	// of sunlit vertices
 	// Keys are pairs of (mesh index, buffer index in the mesh)
 	std::map<std::pair<u8, u32>, std::map<u32, video::SColor > > m_daynight_diffs;
-
-	// Camera offset info -> do we have to translate the mesh?
-	v3s16 m_camera_offset;
 };
 
 /*!


### PR DESCRIPTION
_bugfix, rendering, performance, maintenance, trivial_
The camera offset for mapblocks was originally implemented in a really stupid way, see https://github.com/minetest/minetest/issues/10683#issuecomment-739334752

This PR reimplements it as a matrix transformation instead of translating every damn vertex in software.
I also moved a couple struct types to the header where they belong.

**How to test**
Zip around the map with fly/fast to trigger the camera offset repeatedly. Enjoy reduced mesher stutter.
Teleport to the map's edge to verify that nothing is jittery.