### PR TITLE
Allow map save to compress blocks asynchronously.

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -385,7 +385,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("chat_message_limit_per_10sec", "8.0");
 	settings->setDefault("chat_message_limit_trigger_kick", "50");
 	settings->setDefault("sqlite_synchronous", "2");
-	settings->setDefault("map_compression_level_disk", "3");
+	settings->setDefault("map_compression_level_disk", "-1");
 	settings->setDefault("map_compression_level_net", "-1");
 	settings->setDefault("full_block_send_enable_min_time_from_building", "2.0");
 	settings->setDefault("dedicated_server_step", "0.09");

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -37,6 +37,7 @@ class NodeMetadataList;
 class IGameDef;
 class MapBlockMesh;
 class VoxelManipulator;
+struct MapBlockDiskSer;
 
 #define BLOCK_TIMESTAMP_UNDEFINED 0xffffffff
 
@@ -483,6 +484,7 @@ public:
 	// Set disk to true for on-disk format, false for over-the-network format
 	// Precondition: version >= SER_FMT_VER_LOWEST_WRITE
 	void serialize(std::ostream &os, u8 version, bool disk, int compression_level);
+	void serializeForDisk(MapBlockDiskSer &dst, u8 version);
 	// If disk == true: In addition to doing other things, will add
 	// unknown blocks from id-name mapping to wndef
 	void deSerialize(std::istream &is, u8 version, bool disk);
@@ -621,6 +623,21 @@ private:
 };
 
 typedef std::vector<MapBlock*> MapBlockVect;
+
+struct MapBlockDiskSer
+{
+	MapBlockDiskSer();
+	u8 flags;
+	u16 lighting_complete;
+	u32 timestamp;
+	MapNode nodes[MapBlock::nodecount];
+	std::ostringstream metadata;
+	NameIdMapping nimap;
+	StaticObjectList static_objects;
+	NodeTimerList node_timers;
+
+	void compress(std::ostream &os, u8 version, int compression_level);
+};
 
 inline bool objectpos_over_limit(v3f p)
 {

--- a/src/server.h
+++ b/src/server.h
@@ -69,6 +69,7 @@ struct SunParams;
 struct MoonParams;
 struct StarParams;
 class ServerThread;
+class MapThread;
 class ServerModManager;
 class ServerInventoryManager;
 
@@ -288,6 +289,7 @@ public:
 	bool showFormspec(const char *name, const std::string &formspec, const std::string &formname);
 	Map & getMap() { return m_env->getMap(); }
 	ServerEnvironment & getEnv() { return *m_env; }
+	BanManager & getBanManager() { return *m_banmanager; }
 	v3f findSpawnPos();
 
 	u32 hudAdd(RemotePlayer *player, HudElement *element);
@@ -533,8 +535,6 @@ private:
 	float m_liquid_transform_every = 1.0f;
 	float m_masterserver_timer = 0.0f;
 	float m_emergethread_trigger_timer = 0.0f;
-	float m_savemap_timer = 0.0f;
-	IntervalLimiter m_map_timer_and_unload_interval;
 
 	// Environment
 	ServerEnvironment *m_env = nullptr;
@@ -582,6 +582,7 @@ private:
 
 	// The server mainly operates in this thread
 	ServerThread *m_thread = nullptr;
+	MapThread *m_map_thread = nullptr;
 
 	/*
 		Time related stuff


### PR DESCRIPTION
This reduces the amount the time that the server is blocked during map save. Map save can take up to 5s, 70-80% of which is spent in compressing the blocks (on a fast machine)

This should significantly improve server side jitter. With large maps the server previously would go away for up to ~~30s~~ 5s, during which time not blocks can be loaded, or generated, no ABM/Objects can be handled, and no blocks would be sent to the client.

This does the following:
1. Move server map saving to a separate thread.
2. Save by (a) collecting and serializing the changed blocks without compression, (b) outside of the global lock, compress these blocks, and (c) with the lock held again, save the compressed blocks.
3. Every 4th time it also saves blocks that are marked to be saved at unload only. This reduces the time spent during unloading (which is still done under the lock)

Right now the server performs these three steps and servermap has new API to allow it to do. **Alternatively this could be a single servermap method with the relevant mutex passed it.**

Please have a look and try it out.

How to test:
1. Just explore a world.
2. Create a new world - or delete map.sqlite for an existing world - fly around, see how world is loading faster.
3. Watch for server stalls - times when the server seems unresponsive, inventory is sluggish, etc.
