### PR TITLE
Keep mapblocks in memory if they're in range

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -30,7 +30,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/basic_macros.h"
 #include <algorithm>
 #include "client/renderingengine.h"
-#include <cmath>
 
 // struct MeshBufListList
 void MeshBufListList::clear()

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -221,13 +221,20 @@ void ClientMap::updateDrawList()
 			float range = 100000 * BS;
 			if (!m_control.range_all)
 				range = m_control.wanted_range * BS;
-
+			
+			v3s16 block_pos = block->getPos();
+			// First, perform a simple distance check.
+			if (block_pos.getDistanceFrom(camera_position) > range)
+				continue; // Out of range, skip.
+			
+			// This block is in range. Reset usage timer.
+			block->resetUsageTimer();
+			blocks_in_range_with_mesh++;
+			
 			float d = 0.0;
 			if (!isBlockInSight(block->getPos(), camera_position,
 					camera_direction, camera_fov, range, &d))
 				continue;
-
-			blocks_in_range_with_mesh++;
 
 			/*
 				Occlusion culling
@@ -237,9 +244,6 @@ void ClientMap::updateDrawList()
 				blocks_occlusion_culled++;
 				continue;
 			}
-
-			// This block is in range. Reset usage timer.
-			block->resetUsageTimer();
 
 			// Add to set
 			block->refGrab();

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -229,7 +229,8 @@ void ClientMap::updateDrawList()
 			v3s16 block_position = block_coord * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2;
 
 			// First, perform a simple distance check.
-			if (!m_control.range_all && block_position.getDistanceFrom(cam_pos_nodes) > range + UNLOAD_PADDING)
+			if (!m_control.range_all &&
+					block_position.getDistanceFrom(cam_pos_nodes) > range + UNLOAD_PADDING)
 				continue; // Out of range, skip.
 
 			// This block is in range. Reset usage timer.

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -227,7 +227,7 @@ void ClientMap::updateDrawList()
 
 			v3s16 block_coord = block->getPos();
 			v3s16 block_position = block_coord * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2;
-			
+
 			// First, perform a simple distance check.
 			if (!m_control.range_all && block_position.getDistanceFrom(cam_pos_nodes) > range + UNLOAD_PADDING)
 				continue; // Out of range, skip.
@@ -317,10 +317,10 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 		// If the mesh of the block happened to get deleted, ignore it
 		if (!block->mesh)
 			continue;
-		
+
 		v3f block_pos_r = v3f(block_pos.X,block_pos.Y,block_pos.Z) * MAP_BLOCKSIZE;
 		float d = camera_position.getDistanceFrom((block_pos_r + MAP_BLOCKSIZE / 2) * BS);
-		
+
 		// Mesh animation
 		if (pass == scene::ESNRP_SOLID) {
 			//MutexAutoLock lock(block->mesh_mutex);

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -290,8 +290,6 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	const u32 daynight_ratio = m_client->getEnv().getDayNightRatio();
 
 	const v3f camera_position = m_camera_position;
-	const v3f camera_direction = m_camera_direction;
-	const f32 camera_fov = m_camera_fov;
 
 	/*
 		Get all blocks and draw all visible ones

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -143,8 +143,7 @@ void ClientMap::getBlocksInViewRange(v3s16 cam_pos_nodes,
 			p_nodes_max.Z / MAP_BLOCKSIZE + 1);
 }
 
-static const constexpr s16 CULL_PADDING = MAP_BLOCKSIZE * 2;
-static const constexpr s16 UNLOAD_PADDING = MAP_BLOCKSIZE * 4;
+static const constexpr s16 UNLOAD_PADDING = MAP_BLOCKSIZE * 3;
 void ClientMap::updateDrawList()
 {
 	ScopeProfiler sp(g_profiler, "CM::updateDrawList()", SPT_AVG);
@@ -238,7 +237,7 @@ void ClientMap::updateDrawList()
 
 			float d = 0.0;
 			if (!isBlockInSight(block_coord, camera_position,
-					camera_direction, camera_fov, (range + CULL_PADDING) * BS, &d))
+					camera_direction, camera_fov, range * BS, &d))
 				continue;
 
 			/*

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -143,7 +143,6 @@ void ClientMap::getBlocksInViewRange(v3s16 cam_pos_nodes,
 			p_nodes_max.Z / MAP_BLOCKSIZE + 1);
 }
 
-static const constexpr s16 UNLOAD_PADDING = MAP_BLOCKSIZE * 3;
 void ClientMap::updateDrawList()
 {
 	ScopeProfiler sp(g_profiler, "CM::updateDrawList()", SPT_AVG);
@@ -226,23 +225,22 @@ void ClientMap::updateDrawList()
 			v3s16 block_coord = block->getPos();
 			v3s16 block_position = block->getPosRelative() + MAP_BLOCKSIZE / 2;
 
-			// First, perform a simple distance check.
+			// First, perform a simple distance check, with a padding of one extra block.
 			if (!m_control.range_all &&
-					block_position.getDistanceFrom(cam_pos_nodes) > range + UNLOAD_PADDING)
+					block_position.getDistanceFrom(cam_pos_nodes) > range + MAP_BLOCKSIZE)
 				continue; // Out of range, skip.
 
-			// This block is in range. Reset usage timer.
+			// Keep the block alive as long as it is in range.
 			block->resetUsageTimer();
 			blocks_in_range_with_mesh++;
 
+			// Frustum culling
 			float d = 0.0;
 			if (!isBlockInSight(block_coord, camera_position,
 					camera_direction, camera_fov, range * BS, &d))
 				continue;
 
-			/*
-				Occlusion culling
-			*/
+			// Occlusion culling
 			if ((!m_control.range_all && d > m_control.wanted_range * BS) ||
 					(occlusion_culling_enabled && isBlockOccluded(block, cam_pos_nodes))) {
 				blocks_occlusion_culled++;

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -319,7 +319,8 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 
 		v3f block_pos_r = v3f(block_pos.X,block_pos.Y,block_pos.Z) * MAP_BLOCKSIZE;
 		float d = camera_position.getDistanceFrom((block_pos_r + MAP_BLOCKSIZE / 2) * BS);
-
+		d = MYMAX(0,d - BLOCK_MAX_RADIUS);
+		
 		// Mesh animation
 		if (pass == scene::ESNRP_SOLID) {
 			//MutexAutoLock lock(block->mesh_mutex);

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -106,10 +106,6 @@ u64 murmur_hash_64_ua(const void *key, int len, unsigned int seed)
 bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		f32 camera_fov, f32 range, f32 *distance_ptr)
 {
-	// Maximum radius of a block.  The magic number is
-	// sqrt(3.0) / 2.0 in literal form.
-	static constexpr const f32 block_max_radius = 0.866025403784f * MAP_BLOCKSIZE * BS;
-
 	v3s16 blockpos_nodes = blockpos_b * MAP_BLOCKSIZE;
 
 	// Block center position
@@ -123,7 +119,7 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 	v3f blockpos_relative = blockpos - camera_pos;
 
 	// Total distance
-	f32 d = MYMAX(0, blockpos_relative.getLength() - block_max_radius);
+	f32 d = MYMAX(0, blockpos_relative.getLength() - BLOCK_MAX_RADIUS);
 
 	if (distance_ptr)
 		*distance_ptr = d;
@@ -141,7 +137,7 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 	// such that a block that has any portion visible with the
 	// current camera position will have the center visible at the
 	// adjusted postion
-	f32 adjdist = block_max_radius / cos((M_PI - camera_fov) / 2);
+	f32 adjdist = BLOCK_MAX_RADIUS / cos((M_PI - camera_fov) / 2);
 
 	// Block position relative to adjusted camera
 	v3f blockpos_adj = blockpos - (camera_pos - camera_dir * adjdist);

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -36,6 +36,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	y = temp; \
 } while (0)
 
+// Maximum radius of a block.  The magic number is
+// sqrt(3.0) / 2.0 in literal form.
+static constexpr const f32 BLOCK_MAX_RADIUS = 0.866025403784f * MAP_BLOCKSIZE * BS;
 
 inline s16 getContainerPos(s16 p, s16 d)
 {

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "basic_macros.h"
+#include "constants.h"
 #include "irrlichttypes.h"
 #include "irr_v2d.h"
 #include "irr_v3d.h"


### PR DESCRIPTION
Fixes #10567

_Rendering, bugfix_
**Ready for review**

With this PR, the client no longer discards mapblocks based on the result of a camera frustum cull. This should reduce the appearance of holes in a map, and prevent the client from hammering the server for the same blocks over and over.
It also makes frequent client data unloads a viable performance strategy, which may help #10683
The range used for unloading is padded a bit beyond the visual cull range.

Some other minor parts of clientmap.cpp have been cleaned up along the way:
- A couple lines have been hoisted out of a loop that they weren't dependent on
- A duplicate frustum cull that only effectively computed distance for block animation was replaced by an actual distance calculation.