### PR TITLE
Revert "GUIFormSpecMenu: Shift+Click listring workaround for MacOS"

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4075,9 +4075,6 @@ enum ButtonEventType : u8
 
 bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 {
-	// WORKAROUND: event.MouseInput.Shift is not implemented for MacOS
-	static thread_local bool is_shift_down = false;
-
 	if (event.EventType==EET_KEY_INPUT_EVENT) {
 		KeyPress kp(event.KeyInput);
 		if (event.KeyInput.PressedDown && (
@@ -4086,8 +4083,6 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			tryClose();
 			return true;
 		}
-
-		is_shift_down = event.KeyInput.Shift;
 
 		if (m_client != NULL && event.KeyInput.PressedDown &&
 				(kp == getKeySetting("keymap_screenshot"))) {
@@ -4137,9 +4132,6 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			 (event.MouseInput.Event == EMIE_MOUSE_MOVED &&
 			  event.MouseInput.isRightPressed() &&
 			  getItemAtPos(m_pointer).i != getItemAtPos(m_old_pointer).i))) {
-
-		// WORKAROUND: In case shift was pressed prior showing the formspec
-		is_shift_down |= event.MouseInput.Shift;
 
 		// Get selected item and hovered/clicked item (s)
 
@@ -4271,7 +4263,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 					else  // left
 						count = s_count;
 
-					if (!is_shift_down) {
+					if (!event.MouseInput.Shift) {
 						// no shift: select item
 						m_selected_amount = count;
 						m_selected_dragging = button != BET_WHEEL_DOWN;


### PR DESCRIPTION
The commit caused Shift-Clicking issues on Linux due to another Irrlicht bug where
KeyInput.Shift released keys do not trigger OnEvent()

MacOS users should build using a recent Irrlicht 1.8 development version.
See also: https://sourceforge.net/p/irrlicht/patches/321/

----

The Linux userbase is significantly higher than MacOS, hence I consider this trade-off to be a better solution. It would be possible to fix it by checking against preprocessor macros, but that's not a sane solution.

IMO #9308 does not need reopening because MacOS users can build Minetest using a more recent Irrlicht version.

Q: Should this be documented somewhere?

## To do

This PR is Ready for Review.

## How to test

Using current master:

1) Linux: broken
2) Wine: works
3) Windows: works probably too
4) MacOS: works

This PR:

Test N° 4 fails when using an old Irrlicht version