### PR TITLE
Enforce a map save time budget per server step.

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -201,7 +201,10 @@ public:
 	virtual void beginSave() {}
 	virtual void endSave() {}
 
-	virtual void save(ModifiedState save_level) { FATAL_ERROR("FIXME"); }
+	virtual bool save(ModifiedState save_level, u32 time_limit_ms = 0)
+	{
+		FATAL_ERROR("FIXME");
+	}
 
 	// Server implements these.
 	// Client leaves them as no-op.
@@ -212,8 +215,8 @@ public:
 		Updates usage timers and unloads unused blocks and sectors.
 		Saves modified blocks before unloading on MAPTYPE_SERVER.
 	*/
-	void timerUpdate(float dtime, float unload_timeout, u32 max_loaded_blocks,
-			std::vector<v3s16> *unloaded_blocks=NULL);
+	bool timerUpdate(float dtime, float unload_timeout, u32 max_loaded_blocks,
+			std::vector<v3s16> *unloaded_blocks=NULL, u32 time_limit_ms = 0);
 
 	/*
 		Unloads all blocks with a zero refCount().
@@ -374,7 +377,7 @@ public:
 	void beginSave();
 	void endSave();
 
-	void save(ModifiedState save_level);
+	bool save(ModifiedState save_level, u32 time_limit_ms = 0);
 	void listAllLoadableBlocks(std::vector<v3s16> &dst);
 	void listAllLoadedBlocks(std::vector<v3s16> &dst);
 


### PR DESCRIPTION
Saving blocks marked with `MOD_STATE_WRITE_NEEDED` (save) or any non-clean state (timerUpdate on unload) can take multiple seconds.

This simple PR breaks the save up in 100ms chunks of work. This allow the server to schedule some other work (such as generating blocks or sending blocks to the a client) while the map is being saved.

Note that there's no special logic for starting where the last save ended, it simply tries again in the next AsyncRunStep, until the map is saved. I do not believe anything more complicated is needed.

This only changes the in-game logic. The shutdown logic is unchanged and forces all unclean blocks to be saved.

(This can be seen as a simpler, slightly inferior alternative to #10709).

To test: Start a new world (or delete map.sqlite), increase `max_block_send_distance`, `max_block_generate_distance`, and `viewing_range` and fly around to get blocks loaded and unloaded. Place a door (or something) and keep opening and closing the door. Notice that there is less lag opening and closing.
