### PR TITLE
Allow Enabling The Touch UI In A Desktop Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ General options and their default values:
     RUN_IN_PLACE=FALSE         - Create a portable install (worlds, settings etc. in current directory)
     USE_GPROF=FALSE            - Enable profiling using GProf
     VERSION_EXTRA=             - Text to append to version (e.g. VERSION_EXTRA=foobar -> Minetest 0.4.9-foobar)
+    ENABLE_TOUCH=FALSE         - Enable Touchscreen support (requires support by IrrlichtMt)
 
 Library specific options:
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -949,6 +949,9 @@ screenshot_quality (Screenshot quality) int 0 0 100
 #    Adjust dpi configuration to your screen (non X11/Android only) e.g. for 4k screens.
 screen_dpi (DPI) int 72 1
 
+#    Adjust the detected display density, used for scaling UI elements.
+display_density_factor (Display Density Scaling Factor) float 1
+
 #    Windows systems only: Start Minetest with the command line window in the background.
 #    Contains the same information as the file debug.txt (default name).
 enable_console (Enable console window) bool false

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,6 +101,12 @@ endif()
 
 option(ENABLE_GLES "Use OpenGL ES instead of OpenGL" FALSE)
 mark_as_advanced(ENABLE_GLES)
+
+option(ENABLE_TOUCH "Enable Touchscreen support" FALSE)
+if(ENABLE_TOUCH)
+	add_definitions(-DHAVE_TOUCHSCREENGUI)
+endif()
+
 if(BUILD_CLIENT)
 	# transitive dependency from Irrlicht (see longer explanation below)
 	if(NOT WIN32)

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -38,9 +38,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #if USE_SOUND
 	#include "sound_openal.h"
 #endif
-#ifdef __ANDROID__
-	#include "porting.h"
-#endif
 
 /* mainmenumanager.h
  */
@@ -147,8 +144,8 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	skin->setColor(gui::EGDC_3D_SHADOW, video::SColor(255, 0, 0, 0));
 	skin->setColor(gui::EGDC_HIGH_LIGHT, video::SColor(255, 70, 120, 50));
 	skin->setColor(gui::EGDC_HIGH_LIGHT_TEXT, video::SColor(255, 255, 255, 255));
-#ifdef __ANDROID__
-	float density = porting::getDisplayDensity();
+#ifdef HAVE_TOUCHSCREENGUI
+	float density = RenderingEngine::getDisplayDensity();
 	skin->setSize(gui::EGDS_CHECK_BOX_WIDTH, (s32)(17.0f * density));
 	skin->setSize(gui::EGDS_SCROLLBAR_SIZE, (s32)(14.0f * density));
 	skin->setSize(gui::EGDS_WINDOW_BUTTON_WIDTH, (s32)(15.0f * density));

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -566,7 +566,7 @@ public:
 	}
 };
 
-#ifdef __ANDROID__
+#ifdef HAVE_TOUCHSCREENGUI
 #define SIZE_TAG "size[11,5.5]"
 #else
 #define SIZE_TAG "size[11,5.5,true]" // Fixed size on desktop
@@ -901,8 +901,10 @@ private:
 	bool m_does_lost_focus_pause_game = false;
 
 	int m_reset_HW_buffer_counter = 0;
-#ifdef __ANDROID__
+#ifdef HAVE_TOUCHSCREENGUI
 	bool m_cache_hold_aux1;
+#endif
+#ifdef __ANDROID__
 	bool m_android_chat_open;
 #endif
 };
@@ -940,7 +942,7 @@ Game::Game() :
 
 	readSettings();
 
-#ifdef __ANDROID__
+#ifdef HAVE_TOUCHSCREENGUI
 	m_cache_hold_aux1 = false;	// This is initialised properly later
 #endif
 
@@ -1065,7 +1067,7 @@ void Game::run()
 
 	set_light_table(g_settings->getFloat("display_gamma"));
 
-#ifdef __ANDROID__
+#ifdef HAVE_TOUCHSCREENGUI
 	m_cache_hold_aux1 = g_settings->getBool("fast_move")
 			&& client->checkPrivilege("fast");
 #endif
@@ -1845,6 +1847,7 @@ void Game::processUserInput(f32 dtime)
 	else if (g_touchscreengui) {
 		/* on touchscreengui step may generate own input events which ain't
 		 * what we want in case we just did clear them */
+		g_touchscreengui->show();
 		g_touchscreengui->step(dtime);
 	}
 #endif
@@ -2157,7 +2160,7 @@ void Game::toggleFast()
 		m_game_ui->showTranslatedStatusText("Fast mode disabled");
 	}
 
-#ifdef __ANDROID__
+#ifdef HAVE_TOUCHSCREENGUI
 	m_cache_hold_aux1 = fast_move && has_fast_privs;
 #endif
 }
@@ -2507,10 +2510,10 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 			( (u32)(isKeyDown(KeyType::ZOOM)                          & 0x1) << 9)
 		);
 
-#ifdef ANDROID
-	/* For Android, simulate holding down AUX1 (fast move) if the user has
+#ifdef HAVE_TOUCHSCREENGUI
+	/* For touch, simulate holding down AUX1 (fast move) if the user has
 	 * the fast_move setting toggled on. If there is an aux1 key defined for
-	 * Android then its meaning is inverted (i.e. holding aux1 means walk and
+	 * touch then its meaning is inverted (i.e. holding aux1 means walk and
 	 * not fast)
 	 */
 	if (m_cache_hold_aux1) {
@@ -4175,7 +4178,7 @@ void Game::showDeathFormspec()
 #define GET_KEY_NAME(KEY) gettext(getKeySetting(#KEY).name())
 void Game::showPauseMenu()
 {
-#ifdef __ANDROID__
+#ifdef HAVE_TOUCHSCREENGUI
 	static const std::string control_text = strgettext("Default Controls:\n"
 		"No menu visible:\n"
 		"- single tap: button activate\n"

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -598,7 +598,7 @@ static float calcDisplayDensity()
 float RenderingEngine::getDisplayDensity()
 {
 	static float cached_display_density = calcDisplayDensity();
-	return cached_display_density;
+	return cached_display_density * g_settings->getFloat("display_density_factor");
 }
 
 #elif defined(_WIN32)
@@ -626,14 +626,14 @@ float RenderingEngine::getDisplayDensity()
 		display_density = calcDisplayDensity(get_video_driver());
 		cached = true;
 	}
-	return display_density;
+	return display_density * g_settings->getFloat("display_density_factor");
 }
 
 #else
 
 float RenderingEngine::getDisplayDensity()
 {
-	return g_settings->getFloat("screen_dpi") / 96.0;
+	return (g_settings->getFloat("screen_dpi") / 96.0) * g_settings->getFloat("display_density_factor");
 }
 
 #endif

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -285,7 +285,7 @@ void set_default_settings()
 	settings->setDefault("aux1_descends", "false");
 	settings->setDefault("doubletap_jump", "false");
 	settings->setDefault("always_fly_fast", "true");
-#ifdef __ANDROID__
+#ifdef HAVE_TOUCHSCREENGUI
 	settings->setDefault("autojump", "true");
 #else
 	settings->setDefault("autojump", "false");
@@ -457,6 +457,7 @@ void set_default_settings()
 
 	settings->setDefault("enable_console", "false");
 	settings->setDefault("screen_dpi", "72");
+	settings->setDefault("display_density_factor", "1");
 
 	// Altered settings for macOS
 #if defined(__MACH__) && defined(__APPLE__)
@@ -464,15 +465,17 @@ void set_default_settings()
 	settings->setDefault("fps_max", "0");
 #endif
 
+#ifdef HAVE_TOUCHSCREENGUI
+	settings->setDefault("touchtarget", "true");
+	settings->setDefault("touchscreen_threshold","20");
+	settings->setDefault("fixed_virtual_joystick", "false");
+	settings->setDefault("virtual_joystick_triggers_aux1", "false");
+#endif
 	// Altered settings for Android
 #ifdef __ANDROID__
 	settings->setDefault("screen_w", "0");
 	settings->setDefault("screen_h", "0");
 	settings->setDefault("fullscreen", "true");
-	settings->setDefault("touchtarget", "true");
-	settings->setDefault("touchscreen_threshold","20");
-	settings->setDefault("fixed_virtual_joystick", "false");
-	settings->setDefault("virtual_joystick_triggers_aux1", "false");
 	settings->setDefault("smooth_lighting", "false");
 	settings->setDefault("max_simultaneous_block_sends_per_client", "10");
 	settings->setDefault("emergequeue_limit_diskonly", "16");

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(extra_gui_SRCS "")
+if(ENABLE_TOUCH)
+	set(extra_gui_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/touchscreengui.cpp)
+endif()
+
 set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiAnimatedImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiBackgroundImage.cpp
@@ -25,5 +30,6 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiVolumeChange.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/modalMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/profilergraph.cpp
+	${extra_gui_SRCS}
 	PARENT_SCOPE
 )

--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -28,6 +28,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiEditBoxWithScrollbar.h"
 #include "porting.h"
 
+#ifdef HAVE_TOUCHSCREENGUI
+	#include "client/renderingengine.h"
+#endif
+
 #include "gettext.h"
 
 // Continuing from guiPasswordChange.cpp
@@ -45,7 +49,7 @@ GUIConfirmRegistration::GUIConfirmRegistration(gui::IGUIEnvironment *env,
 		m_client(client), m_playername(playername), m_password(password),
 		m_aborted(aborted), m_tsrc(tsrc)
 {
-#ifdef __ANDROID__
+#ifdef HAVE_TOUCHSCREENGUI
 	m_touchscreen_visible = false;
 #endif
 }
@@ -73,8 +77,8 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-#ifdef __ANDROID__
-	const float s = m_gui_scale * porting::getDisplayDensity() / 2;
+#ifdef HAVE_TOUCHSCREENGUI
+	const float s = m_gui_scale * RenderingEngine::getDisplayDensity() / 2;
 #else
 	const float s = m_gui_scale;
 #endif

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -308,7 +308,7 @@ void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 		data->invsize.Y = MYMAX(0, stof(parts[1]));
 
 		lockSize(false);
-#ifndef __ANDROID__
+#ifndef HAVE_TOUCHSCREENGUI
 		if (parts.size() == 3) {
 			if (parts[2] == "true") {
 				lockSize(true,v2u32(800,600));
@@ -3278,7 +3278,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 						((15.0 / 13.0) * (0.85 + mydata.invsize.Y));
 			}
 
-#ifdef __ANDROID__
+#ifdef HAVE_TOUCHSCREENGUI
 			// In Android, the preferred imgsize should be larger to accommodate the
 			// smaller screensize.
 			double prefer_imgsize = padded_screensize.Y / 10 * gui_scaling;
@@ -3741,7 +3741,7 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 	v2u32 screenSize = Environment->getVideoDriver()->getScreenSize();
 	int tooltip_offset_x = m_btn_height;
 	int tooltip_offset_y = m_btn_height;
-#ifdef __ANDROID__
+#ifdef HAVE_TOUCHSCREENGUI
 	tooltip_offset_x *= 3;
 	tooltip_offset_y  = 0;
 	if (m_pointer.X > (s32)screenSize.X / 2)

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -25,6 +25,10 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <IGUIStaticText.h>
 #include <IGUIFont.h>
 
+#ifdef HAVE_TOUCHSCREENGUI
+	#include "client/renderingengine.h"
+#endif
+
 #include "porting.h"
 #include "gettext.h"
 
@@ -79,8 +83,8 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-#ifdef __ANDROID__
-	const float s = m_gui_scale * porting::getDisplayDensity() / 2;
+#ifdef HAVE_TOUCHSCREENGUI
+	const float s = m_gui_scale * RenderingEngine::getDisplayDensity() / 2;
 #else
 	const float s = m_gui_scale;
 #endif

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -77,9 +77,10 @@ GUITable::GUITable(gui::IGUIEnvironment *env,
 	setTabStop(true);
 	setTabOrder(-1);
 	updateAbsolutePosition();
+#ifdef HAVE_TOUCHSCREENGUI
+	float density = 1; // dp scaling is applied by the skin
+#else
 	float density = RenderingEngine::getDisplayDensity();
-#ifdef __ANDROID__
-	density = 1; // dp scaling is applied by the skin
 #endif
 	core::rect<s32> relative_rect = m_scrollbar->getRelativePosition();
 	s32 width = (relative_rect.getWidth() / (2.0 / 3.0)) * density *

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #ifdef HAVE_TOUCHSCREENGUI
 #include "touchscreengui.h"
+#include "client/renderingengine.h"
 #endif
 
 // clang-format off
@@ -40,8 +41,8 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
 		m_remap_dbl_click(remap_dbl_click)
 {
 	m_gui_scale = g_settings->getFloat("gui_scaling");
-#ifdef __ANDROID__
-	float d = porting::getDisplayDensity();
+#ifdef HAVE_TOUCHSCREENGUI
+	float d = RenderingEngine::getDisplayDensity();
 	m_gui_scale *= 1.1 - 0.3 * d + 0.2 * d * d;
 #endif
 	setVisible(true);
@@ -183,7 +184,7 @@ static bool isChild(gui::IGUIElement *tocheck, gui::IGUIElement *parent)
 	return false;
 }
 
-#ifdef __ANDROID__
+#ifdef HAVE_TOUCHSCREENGUI
 
 bool GUIModalMenu::simulateMouseEvent(
 		gui::IGUIElement *target, ETOUCH_INPUT_EVENT touch_event)
@@ -217,6 +218,8 @@ bool GUIModalMenu::simulateMouseEvent(
 
 void GUIModalMenu::enter(gui::IGUIElement *hovered)
 {
+	if (!hovered)
+		return;
 	sanity_check(!m_hovered);
 	m_hovered.grab(hovered);
 	SEvent gui_event{};
@@ -286,7 +289,9 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 			return retval;
 		}
 	}
+#endif
 
+#ifdef HAVE_TOUCHSCREENGUI
 	if (event.EventType == EET_TOUCH_INPUT_EVENT) {
 		irr_ptr<GUIModalMenu> holder;
 		holder.grab(this); // keep this alive until return (it might be dropped downstream [?])

--- a/src/gui/modalMenu.h
+++ b/src/gui/modalMenu.h
@@ -75,10 +75,10 @@ protected:
 	v2u32 m_screensize_old;
 	float m_gui_scale;
 #ifdef __ANDROID__
-	v2s32 m_down_pos;
 	std::string m_jni_field_name;
 #endif
 #ifdef HAVE_TOUCHSCREENGUI
+	v2s32 m_down_pos;
 	bool m_touchscreen_visible = true;
 #endif
 
@@ -102,7 +102,7 @@ private:
 	// wants to launch other menus
 	bool m_allow_focus_removal = false;
 
-#ifdef __ANDROID__
+#ifdef HAVE_TOUCHSCREENGUI
 	irr_ptr<gui::IGUIElement> m_hovered;
 
 	bool simulateMouseEvent(gui::IGUIElement *target, ETOUCH_INPUT_EVENT touch_event);

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h"
 #include "porting.h"
 #include "client/guiscalingfilter.h"
+#include "client/renderingengine.h"
 
 #include <iostream>
 #include <algorithm>
@@ -426,7 +427,7 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, IEventReceiver *receiver)
 	m_joystick_triggers_aux1 = g_settings->getBool("virtual_joystick_triggers_aux1");
 	m_screensize = m_device->getVideoDriver()->getScreenSize();
 	button_size = MYMIN(m_screensize.Y / 4.5f,
-			porting::getDisplayDensity() *
+			RenderingEngine::getDisplayDensity() *
 			g_settings->getFloat("hud_scaling") * 65.0f);
 }
 

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -669,9 +669,9 @@ void TouchScreenGUI::handleReleaseEvent(size_t evt_id)
 	if (button != after_last_element_id) {
 		// handle button events
 		handleButtonEvent(button, evt_id, false);
-	} else if (evt_id == m_move_id) {
+	} else if (m_has_move_id && evt_id == m_move_id) {
 		// handle the point used for moving view
-		m_move_id = -1;
+		m_has_move_id = false;
 
 		// if this pointer issued a mouse event issue symmetric release here
 		if (m_move_sent_as_mouse_event) {
@@ -693,8 +693,8 @@ void TouchScreenGUI::handleReleaseEvent(size_t evt_id)
 	}
 
 	// handle joystick
-	else if (evt_id == m_joystick_id) {
-		m_joystick_id = -1;
+	else if (m_has_joystick_id && evt_id == m_joystick_id) {
+		m_has_joystick_id = false;
 
 		// reset joystick
 		for (unsigned int i = 0; i < 4; i++)
@@ -777,7 +777,8 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 			if ((m_fixed_joystick && dxj * dxj + dyj * dyj <= button_size * button_size * 1.5 * 1.5) ||
 					(!m_fixed_joystick && event.TouchInput.X < m_screensize.X / 3.0f)) {
 				// If we don't already have a starting point for joystick make this the one.
-				if (m_joystick_id == -1) {
+				if (!m_has_joystick_id) {
+					m_has_joystick_id           = true;
 					m_joystick_id               = event.TouchInput.ID;
 					m_joystick_has_really_moved = false;
 
@@ -797,7 +798,8 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 				}
 			} else {
 				// If we don't already have a moving point make this the moving one.
-				if (m_move_id == -1) {
+				if (!m_has_move_id) {
+					m_has_move_id              = true;
 					m_move_id                  = event.TouchInput.ID;
 					m_move_has_really_moved    = false;
 					m_move_downtime            = porting::getTimeMs();
@@ -820,7 +822,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 				v2s32(event.TouchInput.X, event.TouchInput.Y))
 			return;
 
-		if (m_move_id != -1) {
+		if (m_has_move_id) {
 			if ((event.TouchInput.ID == m_move_id) &&
 				(!m_move_sent_as_mouse_event)) {
 
@@ -863,7 +865,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 			}
 		}
 
-		if (m_joystick_id != -1 && event.TouchInput.ID == m_joystick_id) {
+		if (m_has_joystick_id && event.TouchInput.ID == m_joystick_id) {
 			s32 X = event.TouchInput.X;
 			s32 Y = event.TouchInput.Y;
 
@@ -942,7 +944,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 			}
 		}
 
-		if (m_move_id == -1 && m_joystick_id == -1)
+		if (!m_has_move_id && !m_has_joystick_id)
 			handleChangedButton(event);
 	}
 }
@@ -1087,7 +1089,7 @@ void TouchScreenGUI::step(float dtime)
 			button.repeatcounter += dtime;
 
 			// in case we're moving around digging does not happen
-			if (m_move_id != -1)
+			if (m_has_move_id)
 				m_move_has_really_moved = true;
 
 			if (button.repeatcounter < button.repeatdelay)
@@ -1115,7 +1117,7 @@ void TouchScreenGUI::step(float dtime)
 	}
 
 	// if a new placed pointer isn't moved for some time start digging
-	if ((m_move_id != -1) &&
+	if (m_has_move_id &&
 			(!m_move_has_really_moved) &&
 			(!m_move_sent_as_mouse_event)) {
 

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -228,13 +228,15 @@ private:
 	 */
 	line3d<f32> m_shootline;
 
-	int m_move_id = -1;
+	bool m_has_move_id = false;
+	size_t m_move_id;
 	bool m_move_has_really_moved = false;
 	u64 m_move_downtime = 0;
 	bool m_move_sent_as_mouse_event = false;
 	v2s32 m_move_downlocation = v2s32(-10000, -10000);
 
-	int m_joystick_id = -1;
+	bool m_has_joystick_id = false;
+	size_t m_joystick_id;
 	bool m_joystick_has_really_moved = false;
 	bool m_fixed_joystick = false;
 	bool m_joystick_triggers_aux1 = false;


### PR DESCRIPTION
This PR allows you to build Minetest with the touch UI on non-Android builds. Why? Because I want to run Minetest on the PinePhone.

## To do

This PR is a Ready for Review.

## How to test
**Build Script:** https://gist.github.com/TheBrokenRail/d1ef86d115fa8012cff13af350c5fdfd

## Notes
Requires minetest/irrlicht#60