### PR TITLE
Add physics modifier API

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,7 @@
 BasedOnStyle: LLVM
-IndentWidth: 8
+IndentWidth: 4
 UseTab: Always
+TabWidth: 4
 BreakBeforeBraces: Custom
 Standard: Cpp11
 BraceWrapping:
@@ -16,7 +17,7 @@ BraceWrapping:
 FixNamespaceComments: false
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false
-AccessModifierOffset: -8
+AccessModifierOffset: -4
 ColumnLimit: 90
 AllowShortFunctionsOnASingleLine: InlineOnly
 SortIncludes: false
@@ -26,7 +27,7 @@ IncludeCategories:
   - Regex:           '^<.*'
     Priority:        1
 AlignAfterOpenBracket: DontAlign
-ContinuationIndentWidth: 16
-ConstructorInitializerIndentWidth: 16
+ContinuationIndentWidth: 8
+ConstructorInitializerIndentWidth: 8
 BreakConstructorInitializers: AfterColon
 AlwaysBreakTemplateDeclarations: Yes

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6548,21 +6548,33 @@ object you are working with still exists.
     * 7 - dig
     * 8 - place
     * 9 - zoom
-* `get_effective_physics()`: Returns a table representing the current player movement physics parameters.
-    * If physics modifiers are enabled, this will be the resolved values after the modifiers are applied.
-    * Otherwise, this will return same values as `get_physics_override()`, but without the flags.
-    * fields:
+* `get_effective_physics()`:
+    * Returns a table of the physics factors after applying all overrides.
+    * Table fields:
         * `speed`: multiplier to default walking speed value (default: `1`)
         * `jump`: multiplier to default jump value (default: `1`)
         * `gravity`: multiplier to default gravity value (default: `1`)
-* `set_physics_modifier(key_string, modifier_table)`: Adds a physics modifier to
-   the player under the given key.
+* `set_physics_modifier(id, modifiers)`:
+   * Adds a physics modifier to the player under the given id.
    * Modifiers are resolved by first adding all `add` modifiers, and then multiplying all `multiply` modifiers.
-   * `key_string`: A string key identifying this modifier. Should take the format
-     "modname:modifier_name".
-   * `modifier_table`: a table with the same fields as `get_effective_physics`. Plus:
-       * `type` - `multiply` or `add`. Default: `multiply`.
-* `remove_physics_modifier(key_string)`: Removes the physics modifier with the key `key_string`.
+   * `id`: A string to identify this modifier in the format "modname:modifier_name".
+   * `modifiers`: either `nil` to delete the modifier, or a table with the same fields as `get_effective_physics` plus:
+       * `type`: `multiply` or `add`. Default: `multiply`.
+   * Examples:
+
+     ```lua
+     player:set_physics_modifier("mymod:moon", {
+          gravity = 0.16,
+     })
+
+     player:set_physics_modifier("phystest:potion", {
+         type = "add",
+         speed = 0.5,
+     })
+
+     player:set_physics_modifier("phystest:potion", nil)
+     ```
+* `remove_physics_modifier(id)`: Same as `set_physics_modifier(id, nil)`.
 * `set_physics_flags(flags)`:
     * `sneak`: whether player can sneak (default: `true`)
     * `sneak_glitch`: whether player can use the new move code replications
@@ -7222,7 +7234,7 @@ Used by `minetest.register_abm`.
         chance = 1,
         -- Chance of triggering `action` per-node per-interval is 1.0 / this
         -- value
-        
+
         min_y = -32768,
         max_y = 32767,
         -- min and max height levels where ABM will be processed

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6562,7 +6562,7 @@ object you are working with still exists.
      "modname:modifier_name".
    * `modifier_table`: a table with the same fields as `get_effective_physics`. Plus:
        * `type` - `multiply` or `add`. Default: `multiply`.
-* `delete_physics_modifier(key_string)`: Removes the physics modifier with the key `key_string`.
+* `remove_physics_modifier(key_string)`: Removes the physics modifier with the key `key_string`.
 * `set_physics_flags(flags)`:
     * `sneak`: whether player can sneak (default: `true`)
     * `sneak_glitch`: whether player can use the new move code replications

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6564,15 +6564,15 @@ object you are working with still exists.
 
      ```lua
      player:set_physics_modifier("mymod:moon", {
-          gravity = 0.16,
+         gravity = 0.16,
      })
 
-     player:set_physics_modifier("phystest:potion", {
+     player:set_physics_modifier("mymod:potion", {
          type = "add",
          speed = 0.5,
      })
 
-     player:set_physics_modifier("phystest:potion", nil)
+     player:set_physics_modifier("mymod:potion", nil)
      ```
 
 * `get_physics_modifiers()`: returns table of modifier id to modifier table, see above.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6548,8 +6548,14 @@ object you are working with still exists.
     * 7 - dig
     * 8 - place
     * 9 - zoom
-* `set_physics_override(override_table)`
-    * `override_table` is a table with the following fields:
+* `set_physics_modifier(key_string, modifier_table)`: Adds a physics modifier to
+   the player under the given key. For multipliers, the product of the
+   multipliers from each physics modifier applies. For boolean values, players
+   start with the default value, but get the non-default value if any physics
+   modifier sets it to the non-default value.
+   * `key_string`: A string key identifying this modifier. Should take the format
+     "modname:modifier_name".
+   * `modifier_table`: a table with the following fields:
         * `speed`: multiplier to default walking speed value (default: `1`)
         * `jump`: multiplier to default jump value (default: `1`)
         * `gravity`: multiplier to default gravity value (default: `1`)
@@ -6557,6 +6563,13 @@ object you are working with still exists.
         * `sneak_glitch`: whether player can use the new move code replications
           of the old sneak side-effects: sneak ladders and 2 node sneak jump
           (default: `false`)
+* `delete_physics_modifier(key_string)`: Removes the physics modifier set with
+  `set_physics_modifier` using key `key_string`.
+* `set_physics_override(override_table)`: Overrides the player's movement physics
+  parameters and disables physics modifiers. After calling this function on a
+  player, only this function will be able to change that player's physics
+  parameters.
+    * `override_table` is a table with the fields from `modifier_table` in `set_physics_modifier` plus the following:
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behaviour (default: `true`)
 * `get_physics_override()`: returns the table given to `set_physics_override`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6557,7 +6557,7 @@ object you are working with still exists.
         * `gravity`: multiplier to default gravity value (default: `1`)
 * `set_physics_modifier(key_string, modifier_table)`: Adds a physics modifier to
    the player under the given key.
-   * Modifiers are resolved by first multiplying all `multiply` modifiers, and then adding all `add` modifiers.
+   * Modifiers are resolved by first adding all `add` modifiers, and then multiplying all `multiply` modifiers.
    * `key_string`: A string key identifying this modifier. Should take the format
      "modname:modifier_name".
    * `modifier_table`: a table with the same fields as `get_effective_physics`. Plus:

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6575,6 +6575,7 @@ object you are working with still exists.
      player:set_physics_modifier("phystest:potion", nil)
      ```
 * `remove_physics_modifier(id)`: Same as `set_physics_modifier(id, nil)`.
+* `get_physics_modifiers()`: returns table of modifier id to modifier table, see above.
 * `set_physics_flags(flags)`:
     * `sneak`: whether player can sneak (default: `true`)
     * `sneak_glitch`: whether player can use the new move code replications

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6548,31 +6548,36 @@ object you are working with still exists.
     * 7 - dig
     * 8 - place
     * 9 - zoom
-* `set_physics_modifier(key_string, modifier_table)`: Adds a physics modifier to
-   the player under the given key. For multipliers, the product of the
-   multipliers from each physics modifier applies. For boolean values, players
-   start with the default value, but get the non-default value if any physics
-   modifier sets it to the non-default value.
-   * `key_string`: A string key identifying this modifier. Should take the format
-     "modname:modifier_name".
-   * `modifier_table`: a table with the following fields:
+* `get_effective_physics()`: Returns a table representing the current player movement physics parameters.
+    * If physics modifiers are enabled, this will be the resolved values after the modifiers are applied.
+    * Otherwise, this will return same values as `get_physics_override()`, but without the flags.
+    * fields:
         * `speed`: multiplier to default walking speed value (default: `1`)
         * `jump`: multiplier to default jump value (default: `1`)
         * `gravity`: multiplier to default gravity value (default: `1`)
-        * `sneak`: whether player can sneak (default: `true`)
-        * `sneak_glitch`: whether player can use the new move code replications
-          of the old sneak side-effects: sneak ladders and 2 node sneak jump
-          (default: `false`)
-* `delete_physics_modifier(key_string)`: Removes the physics modifier set with
-  `set_physics_modifier` using key `key_string`.
-* `set_physics_override(override_table)`: Overrides the player's movement physics
-  parameters and disables physics modifiers. After calling this function on a
-  player, only this function will be able to change that player's physics
-  parameters.
-    * `override_table` is a table with the fields from `modifier_table` in `set_physics_modifier` plus the following:
-        * `new_move`: use new move/sneak code. When `false` the exact old code
-          is used for the specific old sneak behaviour (default: `true`)
-* `get_physics_override()`: returns the table given to `set_physics_override`
+* `set_physics_modifier(key_string, modifier_table)`: Adds a physics modifier to
+   the player under the given key.
+   * Modifiers are resolved by first multiplying all `multiply` modifiers, and then adding all `add` modifiers.
+   * `key_string`: A string key identifying this modifier. Should take the format
+     "modname:modifier_name".
+   * `modifier_table`: a table with the same fields as `get_effective_physics`. Plus:
+       * `type` - `multiply` or `add`. Default: `multiply`.
+* `delete_physics_modifier(key_string)`: Removes the physics modifier with the key `key_string`.
+* `set_physics_flags(flags)`:
+    * `sneak`: whether player can sneak (default: `true`)
+    * `sneak_glitch`: whether player can use the new move code replications
+      of the old sneak side-effects: sneak ladders and 2 node sneak jump
+      (default: `false`)
+    * `new_move`: use new move/sneak code. When `false` the exact old code
+      is used for the specific old sneak behaviour (default: `true`)
+* `get_physics_flags()`: returns the table given to `set_physics_flags`.
+* `set_physics_override(override_table)`:
+    * If `override_table` is a table:
+        * Overrides the player's movement physics parameters and disables physics modifiers.
+        * Can contain the same fields as `get_effective_physics` and `set_physics_flags`.
+        * Setting physics flags here is DEPRECATED.
+    * if `override_table` is nil, the use of physics modifiers will be re-enabled.
+* `get_physics_override()`: returns the table given to `set_physics_override`.
 * `hud_add(hud definition)`: add a HUD element described by HUD def, returns ID
    number on success
 * `hud_remove(id)`: remove the HUD element of the specified id

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6574,7 +6574,7 @@ object you are working with still exists.
 
      player:set_physics_modifier("phystest:potion", nil)
      ```
-* `remove_physics_modifier(id)`: Same as `set_physics_modifier(id, nil)`.
+
 * `get_physics_modifiers()`: returns table of modifier id to modifier table, see above.
 * `set_physics_flags(flags)`:
     * `sneak`: whether player can sneak (default: `true`)

--- a/games/devtest/mods/phystest/init.lua
+++ b/games/devtest/mods/phystest/init.lua
@@ -7,7 +7,7 @@ function cmds.moon(player)
 end
 
 function cmds.nomoon(player)
-	player:remove_physics_modifier("phystest:moon")
+	player:set_physics_modifier("phystest:moon", nil)
 end
 
 function cmds.speed(player)
@@ -17,7 +17,7 @@ function cmds.speed(player)
 end
 
 function cmds.nospeed(player)
-	player:remove_physics_modifier("phystest:speed")
+	player:set_physics_modifier("phystest:speed", nil)
 end
 
 function cmds.potion(player)
@@ -28,7 +28,7 @@ function cmds.potion(player)
 end
 
 function cmds.nopotion(player)
-	player:remove_physics_modifier("phystest:potion")
+	player:set_physics_modifier("phystest:potion", nil)
 end
 
 function cmds.jupiter(player)
@@ -38,7 +38,7 @@ function cmds.jupiter(player)
 end
 
 function cmds.nojupiter(player)
-	player:remove_physics_modifier("phystest:jupiter")
+	player:set_physics_modifier("phystest:jupiter", nil)
 end
 
 function cmds.override(player)

--- a/games/devtest/mods/phystest/init.lua
+++ b/games/devtest/mods/phystest/init.lua
@@ -23,7 +23,7 @@ function cmds.moon(player)
 end
 
 function cmds.nomoon(player)
-	player:delete_physics_modifier("phystest:moon")
+	player:remove_physics_modifier("phystest:moon")
 end
 
 function cmds.speed(player)
@@ -33,7 +33,7 @@ function cmds.speed(player)
 end
 
 function cmds.nospeed(player)
-	player:delete_physics_modifier("phystest:speed")
+	player:remove_physics_modifier("phystest:speed")
 end
 
 function cmds.potion(player)
@@ -44,7 +44,7 @@ function cmds.potion(player)
 end
 
 function cmds.nopotion(player)
-	player:delete_physics_modifier("phystest:potion")
+	player:remove_physics_modifier("phystest:potion")
 end
 
 function cmds.jupiter(player)
@@ -54,7 +54,7 @@ function cmds.jupiter(player)
 end
 
 function cmds.nojupiter(player)
-	player:delete_physics_modifier("phystest:jupiter")
+	player:remove_physics_modifier("phystest:jupiter")
 end
 
 function cmds.override(player)

--- a/games/devtest/mods/phystest/init.lua
+++ b/games/devtest/mods/phystest/init.lua
@@ -106,5 +106,6 @@ minetest.register_chatcommand("physics", {
 		end
 
 		minetest.chat_send_player(name, dump(player:get_effective_physics()))
+		minetest.chat_send_player(name, dump(player:get_physics_modifiers()))
 	end
 })

--- a/games/devtest/mods/phystest/init.lua
+++ b/games/devtest/mods/phystest/init.lua
@@ -1,21 +1,5 @@
 local cmds = {}
 
-minetest.register_chatcommand("physics", {
-	func = function(name, param)
-		local player = minetest.get_player_by_name(name)
-		if not player then
-			return
-		end
-
-		local cmd = cmds[param:trim()]
-		if cmd then
-			cmd(player)
-		end
-
-		minetest.chat_send_player(name, dump(player:get_effective_physics()))
-	end
-})
-
 function cmds.moon(player)
 	player:set_physics_modifier("phystest:moon", {
 		gravity = 0.16,
@@ -99,3 +83,28 @@ end
 function cmds.dep2(player)
 	player:set_physics_override(2, 3, 0.16)
 end
+
+
+local params = ""
+for name in pairs(cmds) do
+	params = params .. name .. " | "
+end
+params = params:sub(1, #params - 3)
+
+minetest.register_chatcommand("physics", {
+	params = params,
+	description = "Change physics modifiers",
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+		if not player then
+			return
+		end
+
+		local cmd = cmds[param:trim()]
+		if cmd then
+			cmd(player)
+		end
+
+		minetest.chat_send_player(name, dump(player:get_effective_physics()))
+	end
+})

--- a/games/devtest/mods/phystest/init.lua
+++ b/games/devtest/mods/phystest/init.lua
@@ -1,0 +1,101 @@
+local cmds = {}
+
+minetest.register_chatcommand("physics", {
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+		if not player then
+			return
+		end
+
+		local cmd = cmds[param:trim()]
+		if cmd then
+			cmd(player)
+		end
+
+		minetest.chat_send_player(name, dump(player:get_effective_physics()))
+	end
+})
+
+function cmds.moon(player)
+	player:set_physics_modifier("phystest:moon", {
+		gravity = 0.16,
+	})
+end
+
+function cmds.nomoon(player)
+	player:delete_physics_modifier("phystest:moon")
+end
+
+function cmds.speed(player)
+	player:set_physics_modifier("phystest:speed", {
+		speed = 1.5,
+	})
+end
+
+function cmds.nospeed(player)
+	player:delete_physics_modifier("phystest:speed")
+end
+
+function cmds.potion(player)
+	player:set_physics_modifier("phystest:potion", {
+		type = "add",
+		speed = 0.5,
+	})
+end
+
+function cmds.nopotion(player)
+	player:delete_physics_modifier("phystest:potion")
+end
+
+function cmds.jupiter(player)
+	player:set_physics_modifier("phystest:jupiter", {
+		gravity = 2.5,
+	})
+end
+
+function cmds.nojupiter(player)
+	player:delete_physics_modifier("phystest:jupiter")
+end
+
+function cmds.override(player)
+	player:set_physics_override({
+		speed = 2,
+	})
+end
+
+function cmds.reset(player)
+	player:set_physics_override(nil)
+end
+
+function cmds.flags(player)
+	minetest.chat_send_player(player:get_player_name(), dump(player:get_physics_flags()))
+end
+
+function cmds.glitch(player)
+	player:set_physics_flags({
+		sneak_glitch = true
+	})
+end
+
+function cmds.noglitch(player)
+	player:set_physics_flags({
+		sneak_glitch = false
+	})
+end
+
+function cmds.invalid(player)
+	player:set_physics_modifier("phystest:invalid", {
+		type = "BLARGH",
+		speed = 1.5,
+	})
+end
+
+function cmds.dep(player)
+	player:set_physics_override({
+		sneak_glitch = true
+	})
+end
+
+function cmds.dep2(player)
+	player:set_physics_override(2, 3, 0.16)
+end

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -524,6 +524,15 @@ bool check_field_or_nil(lua_State *L, int index, int type, const char *fieldname
 	return false;
 }
 
+bool has_field(lua_State *L, int table, const char *fieldname)
+{
+	lua_getfield(L, table, fieldname);
+
+	bool ret = !lua_isnil(L, -1);
+	lua_pop(L, 1);
+	return ret;
+}
+
 bool getstringfield(lua_State *L, int table,
 		const char *fieldname, std::string &result)
 {

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -36,16 +36,18 @@ extern "C" {
 #include <lua.h>
 }
 
-std::string        getstringfield_default(lua_State *L, int table,
-                             const char *fieldname, const std::string &default_);
-bool               getboolfield_default(lua_State *L, int table,
-                             const char *fieldname, bool default_);
-float              getfloatfield_default(lua_State *L, int table,
-                             const char *fieldname, float default_);
-int                getintfield_default(lua_State *L, int table,
-                             const char *fieldname, int default_);
+std::string getstringfield_default(lua_State *L, int table,
+		const char *fieldname, const std::string &default_);
+
+bool getboolfield_default(lua_State *L, int table, const char *fieldname, bool default_);
+
+float getfloatfield_default(lua_State *L, int table, const char *fieldname, float default_);
+
+int getintfield_default(lua_State *L, int table, const char *fieldname, int default_);
 
 bool check_field_or_nil(lua_State *L, int index, int type, const char *fieldname);
+
+bool has_field(lua_State *L, int table, const char *fieldname);
 
 template<typename T>
 bool getintfield(lua_State *L, int table,

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -135,18 +135,22 @@ void script_run_callbacks_f(lua_State *L, int nargs,
 	lua_remove(L, error_handler);
 }
 
-static void script_log(lua_State *L, const std::string &message,
-	std::ostream &log_to, bool do_error, int stack_depth)
+void script_log_short_src(lua_State *L, std::ostream &log_to, int stack_depth)
 {
 	lua_Debug ar;
-
-	log_to << message << " ";
 	if (lua_getstack(L, stack_depth, &ar)) {
 		FATAL_ERROR_IF(!lua_getinfo(L, "Sl", &ar), "lua_getinfo() failed");
 		log_to << "(at " << ar.short_src << ":" << ar.currentline << ")";
 	} else {
 		log_to << "(at ?:?)";
 	}
+}
+
+static void script_log(lua_State *L, const std::string &message,
+	std::ostream &log_to, bool do_error, int stack_depth)
+{
+	log_to << message << " ";
+	script_log_short_src(L, log_to, stack_depth);
 	log_to << std::endl;
 
 	if (do_error)

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -146,7 +146,7 @@ void script_log_short_src(lua_State *L, std::ostream &log_to, int stack_depth)
 	}
 }
 
-static void script_log(lua_State *L, const std::string &message,
+void script_log(lua_State *L, const std::string &message,
 	std::ostream &log_to, bool do_error, int stack_depth)
 {
 	log_to << message << " ";

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -109,6 +109,18 @@ enum RunCallbacksMode
 };
 
 std::string script_get_backtrace(lua_State *L);
+
+/**
+ * Prints short source string to stream
+ *
+ * For example (at path/to/file:123)
+ *
+ * @param L Lua state
+ * @param log_to Target stream
+ * @param stack_depth Lua stack depth
+ */
+void script_log_short_src(lua_State *L, std::ostream &log_to, int stack_depth=1);
+
 int script_exception_wrapper(lua_State *L, lua_CFunction f);
 void script_error(lua_State *L, int pcall_result, const char *mod, const char *fxn);
 void script_run_callbacks_f(lua_State *L, int nargs,

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -31,6 +31,7 @@ extern "C" {
 #include <lauxlib.h>
 }
 
+#include <log.h>
 #include "config.h"
 #include "common/c_types.h"
 
@@ -120,6 +121,13 @@ std::string script_get_backtrace(lua_State *L);
  * @param stack_depth Lua stack depth
  */
 void script_log_short_src(lua_State *L, std::ostream &log_to, int stack_depth=1);
+
+void script_log(lua_State *L, const std::string &message,
+				std::ostream &log_to, bool do_error, int stack_depth=1);
+
+inline void script_warning(lua_State *L, const std::string &message, int stack_depth=1) {
+	script_log(L, message, warningstream, false, stack_depth);
+}
 
 int script_exception_wrapper(lua_State *L, lua_CFunction f);
 void script_error(lua_State *L, int pcall_result, const char *mod, const char *fxn);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1505,8 +1505,8 @@ int ObjectRef::l_set_physics_modifier(lua_State *L)
 	return 0;
 }
 
-// delete_physics_modifier(self, key)
-int ObjectRef::l_delete_physics_modifier(lua_State *L)
+// remove_physics_modifier(self, key)
+int ObjectRef::l_remove_physics_modifier(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
@@ -1519,7 +1519,7 @@ int ObjectRef::l_delete_physics_modifier(lua_State *L)
 	playersao->deletePhysicsModifier(key);
 
 	if (playersao->m_physics_override_set) {
-		warningstream << "delete_physics_modifier will have no effect because ";
+		warningstream << "remove_physics_modifier will have no effect because ";
 		warningstream << "set_physics_override was previously called" << std::endl;
 		warningstream << script_get_backtrace(L);
 	}
@@ -2549,7 +2549,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_player_control_bits),
 	luamethod(ObjectRef, get_effective_physics),
 	luamethod(ObjectRef, set_physics_modifier),
-	luamethod(ObjectRef, delete_physics_modifier),
+	luamethod(ObjectRef, remove_physics_modifier),
 	luamethod(ObjectRef, set_physics_flags),
 	luamethod(ObjectRef, get_physics_flags),
 	luamethod(ObjectRef, set_physics_override),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1520,6 +1520,36 @@ int ObjectRef::l_remove_physics_modifier(lua_State *L)
 	return 0;
 }
 
+int ObjectRef::l_get_physics_modifiers(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO *playersao = getplayersao(ref);
+	if (playersao == nullptr)
+		return 0;
+
+	lua_newtable(L);
+
+	const auto &modifiers = playersao->getPhysicsModifiers();
+	for (auto modifier : modifiers) {
+		lua_newtable(L);
+
+		lua_pushstring(L, modifier.second.is_add ? "add" : "multiply");
+		lua_setfield(L, -2, "type");
+
+		lua_pushnumber(L, modifier.second.speed);
+		lua_setfield(L, -2, "speed");
+		lua_pushnumber(L, modifier.second.jump);
+		lua_setfield(L, -2, "jump");
+		lua_pushnumber(L, modifier.second.gravity);
+		lua_setfield(L, -2, "gravity");
+
+		lua_setfield(L, -2, modifier.first.c_str());
+	}
+
+	return 1;
+}
+
 // set_physics_flags(self, override_table)
 int ObjectRef::l_set_physics_flags(lua_State *L)
 {
@@ -2546,6 +2576,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_effective_physics),
 	luamethod(ObjectRef, set_physics_modifier),
 	luamethod(ObjectRef, remove_physics_modifier),
+	luamethod(ObjectRef, get_physics_modifiers),
 	luamethod(ObjectRef, set_physics_flags),
 	luamethod(ObjectRef, get_physics_flags),
 	luamethod(ObjectRef, set_physics_override),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1496,13 +1496,6 @@ int ObjectRef::l_set_physics_modifier(lua_State *L)
 
 	playersao->setPhysicsModifier(key, modifier);
 
-	if (playersao->m_physics_override_set) {
-		warningstream << "set_physics_modifier will have no effect because ";
-		warningstream << "set_physics_override was previously called ";
-		script_log_short_src(L, warningstream);
-		warningstream << std::endl;
-	}
-
 	return 0;
 }
 
@@ -1622,7 +1615,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		// No overrides were set, revert to modifier mode
 		playersao->m_physics_override_sent = false;
 		return 0;
-	} else if (!playersao->getPhysicsModifiers().empty()) {
+	} else if (playersao->hasPhysicsModifiers()) {
 		warningstream << "Use of set_physics_override will disable active ";
 		warningstream << "physics modifiers ";
 		script_log_short_src(L, warningstream);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1617,33 +1617,13 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 
 		playersao->m_physics_override_sent = false;
 		playersao->m_physics_override_set = true;
-	} else if (lua_gettop(L) > 2 || !lua_isnil(L, 2)) {
-		// old, non-table format
-		// TODO: Remove this code after version 5.4.0 is released
-		log_deprecated(L, "Deprecated use of set_physics_override(num, num, num)");
-
-		if (!lua_isnoneornil(L, 2)) {
-			playersao->m_physics_override.speed = lua_tonumber(L, 2);
-			playersao->m_physics_override_sent = false;
-			playersao->m_physics_override_set = true;
-		}
-		if (!lua_isnoneornil(L, 3)) {
-			playersao->m_physics_override.jump = lua_tonumber(L, 3);
-			playersao->m_physics_override_sent = false;
-			playersao->m_physics_override_set = true;
-		}
-		if (!lua_isnoneornil(L, 4)) {
-			playersao->m_physics_override.gravity = lua_tonumber(L, 4);
-			playersao->m_physics_override_sent = false;
-			playersao->m_physics_override_set = true;
-		}
 	}
 
 	if (!playersao->m_physics_override_set) {
 		// No overrides were set, revert to modifier mode
 		playersao->m_physics_override_sent = false;
 		return 0;
-	} else if (playersao->hasPhysicsModifiers()) {
+	} else {
 		warningstream << "Use of set_physics_override will disable active ";
 		warningstream << "physics modifiers ";
 		script_log_short_src(L, warningstream);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1445,8 +1445,10 @@ static bool read_physics_modifier(lua_State *L, int index,
 	if (type == "add") {
 		modifier.is_add = true;
 	} else if (type != "multiply") {
-		warningstream << "Unknown modifier type " << type << ", defaulting to multiply." << std::endl;
-		warningstream << script_get_backtrace(L);
+		warningstream << "Unknown modifier type " << type << ", defaulting to multiply. ";
+		script_log_short_src(L, warningstream);
+		warningstream << std::endl;
+		infostream << script_get_backtrace(L) << std::endl;
 	}
 
 	float def = modifier.is_add ? 0.f : 1.f;
@@ -1511,13 +1513,6 @@ int ObjectRef::l_remove_physics_modifier(lua_State *L)
 	const std::string key = readParam<std::string>(L, 2);
 
 	playersao->deletePhysicsModifier(key);
-
-	if (playersao->m_physics_override_set) {
-		warningstream << "remove_physics_modifier will have no effect because ";
-		warningstream << "set_physics_override was previously called ";
-		script_log_short_src(L, warningstream);
-		warningstream << std::endl;
-	}
 
 	return 0;
 }
@@ -1620,6 +1615,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		warningstream << "physics modifiers ";
 		script_log_short_src(L, warningstream);
 		warningstream << std::endl;
+		infostream << script_get_backtrace(L) << std::endl;
 	}
 
 	return 0;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1504,22 +1504,7 @@ int ObjectRef::l_set_physics_modifier(lua_State *L)
 	return 0;
 }
 
-// remove_physics_modifier(self, key)
-int ObjectRef::l_remove_physics_modifier(lua_State *L)
-{
-	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO *playersao = getplayersao(ref);
-	if (playersao == nullptr)
-		return 0;
-
-	const std::string key = readParam<std::string>(L, 2);
-
-	playersao->deletePhysicsModifier(key);
-
-	return 0;
-}
-
+// get_physics_modifiers(self)
 int ObjectRef::l_get_physics_modifiers(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -1599,6 +1584,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 	if (playersao == nullptr)
 		return 0;
 
+	bool had_physics_override_set = playersao->m_physics_override_set;
 	playersao->m_physics_override_set = false;
 
 	if (read_physics_modifier(L, 2, playersao->m_physics_override)) {
@@ -1623,12 +1609,8 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		// No overrides were set, revert to modifier mode
 		playersao->m_physics_override_sent = false;
 		return 0;
-	} else {
-		warningstream << "Use of set_physics_override will disable active ";
-		warningstream << "physics modifiers ";
-		script_log_short_src(L, warningstream);
-		warningstream << std::endl;
-		infostream << script_get_backtrace(L) << std::endl;
+	} else if (!had_physics_override_set) {
+		script_warning(L,"Use of set_physics_override will disable active physics modifiers");
 	}
 
 	return 0;
@@ -2555,7 +2537,6 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_player_control_bits),
 	luamethod(ObjectRef, get_effective_physics),
 	luamethod(ObjectRef, set_physics_modifier),
-	luamethod(ObjectRef, remove_physics_modifier),
 	luamethod(ObjectRef, get_physics_modifiers),
 	luamethod(ObjectRef, set_physics_flags),
 	luamethod(ObjectRef, get_physics_flags),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1449,7 +1449,7 @@ static bool read_physics_modifier(lua_State *L, int index,
 		warningstream << script_get_backtrace(L);
 	}
 
-	int def =  modifier.is_add ? 0 : 1;
+	float def = modifier.is_add ? 0.f : 1.f;
 
 	modifier.speed = getfloatfield_default(L, index, "speed", def);
 	modifier.jump = getfloatfield_default(L, index, "jump", def);
@@ -1498,8 +1498,9 @@ int ObjectRef::l_set_physics_modifier(lua_State *L)
 
 	if (playersao->m_physics_override_set) {
 		warningstream << "set_physics_modifier will have no effect because ";
-		warningstream << "set_physics_override was previously called" << std::endl;
-		warningstream << script_get_backtrace(L);
+		warningstream << "set_physics_override was previously called ";
+		script_log_short_src(L, warningstream);
+		warningstream << std::endl;
 	}
 
 	return 0;
@@ -1520,8 +1521,9 @@ int ObjectRef::l_remove_physics_modifier(lua_State *L)
 
 	if (playersao->m_physics_override_set) {
 		warningstream << "remove_physics_modifier will have no effect because ";
-		warningstream << "set_physics_override was previously called" << std::endl;
-		warningstream << script_get_backtrace(L);
+		warningstream << "set_physics_override was previously called ";
+		script_log_short_src(L, warningstream);
+		warningstream << std::endl;
 	}
 
 	return 0;
@@ -1596,7 +1598,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		playersao->m_physics_override_set = true;
 	} else if (lua_gettop(L) > 2 || !lua_isnil(L, 2)) {
 		// old, non-table format
-		// TODO: Remove this code after version 5.4.0
+		// TODO: Remove this code after version 5.4.0 is released
 		log_deprecated(L, "Deprecated use of set_physics_override(num, num, num)");
 
 		if (!lua_isnoneornil(L, 2)) {
@@ -1617,12 +1619,14 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 	}
 
 	if (!playersao->m_physics_override_set) {
+		// No overrides were set, revert to modifier mode
 		playersao->m_physics_override_sent = false;
 		return 0;
 	} else if (!playersao->getPhysicsModifiers().empty()) {
 		warningstream << "Use of set_physics_override will disable active ";
-		warningstream << "physics modifiers" << std::endl;
-		warningstream << script_get_backtrace(L);
+		warningstream << "physics modifiers ";
+		script_log_short_src(L, warningstream);
+		warningstream << std::endl;
 	}
 
 	return 0;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1441,14 +1441,13 @@ static bool read_physics_modifier(lua_State *L, int index,
 	if (!lua_istable(L, index))
 		return false;
 
-	auto type = getstringfield_default(L, index, "type", "multiply");
+	std::string type = getstringfield_default(L, index, "type", "multiply");
 	if (type == "add") {
 		modifier.is_add = true;
 	} else if (type != "multiply") {
-		warningstream << "Unknown modifier type " << type << ", defaulting to multiply. ";
-		script_log_short_src(L, warningstream);
-		warningstream << std::endl;
-		infostream << script_get_backtrace(L) << std::endl;
+		std::ostringstream os;
+		os << "Unknown modifier type " << type << ", defaulting to multiply.";
+		script_warning(L, os.str());
 	}
 
 	float def = modifier.is_add ? 0.f : 1.f;
@@ -1465,7 +1464,7 @@ int ObjectRef::l_get_effective_physics(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO *playersao = (PlayerSAO *)getobject(ref);
+	PlayerSAO *playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
 
@@ -1486,17 +1485,21 @@ int ObjectRef::l_set_physics_modifier(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO *playersao = (PlayerSAO *) getobject(ref);
+	PlayerSAO *playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
 
 	const std::string key = readParam<std::string>(L, 2);
 
-	PlayerSAO::PhysicsModifier modifier;
-	if (!read_physics_modifier(L, 3, modifier))
-		throw LuaError("set_physics_modifier expects (string, table)");
+	if (lua_isnoneornil(L, 3)) {
+		playersao->deletePhysicsModifier(key);
+	} else {
+		PlayerSAO::PhysicsModifier modifier;
+		if (!read_physics_modifier(L, 3, modifier))
+			throw LuaError("set_physics_modifier expects (string, table)");
 
-	playersao->setPhysicsModifier(key, modifier);
+		playersao->setPhysicsModifier(key, modifier);
+	}
 
 	return 0;
 }
@@ -1506,7 +1509,7 @@ int ObjectRef::l_remove_physics_modifier(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO *playersao = (PlayerSAO *) getobject(ref);
+	PlayerSAO *playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
 
@@ -1522,7 +1525,7 @@ int ObjectRef::l_set_physics_flags(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO *playersao = (PlayerSAO *) getobject(ref);
+	PlayerSAO *playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
 
@@ -1543,7 +1546,7 @@ int ObjectRef::l_get_physics_flags(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO *playersao = (PlayerSAO *)getobject(ref);
+	PlayerSAO *playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -119,6 +119,9 @@ private:
 	// remove_physics_modifier(self, key)
 	static int l_remove_physics_modifier(lua_State *L);
 
+	// get_physics_modifiers(self)
+	static int l_get_physics_modifiers(lua_State *L);
+
 	// set_physics_flags(self, override_table)
 	static int l_set_physics_flags(lua_State *L);
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -110,17 +110,26 @@ private:
 	// get_armor_groups(self)
 	static int l_get_armor_groups(lua_State *L);
 
-	// set_physics_override(self, override_table)
-	static int l_set_physics_override(lua_State *L);
-
-	// get_physics_override(self)
-	static int l_get_physics_override(lua_State *L);
+	// get_effective_physics(self)
+	static int l_get_effective_physics(lua_State *L);
 
 	// set_physics_modifier(self, key, modifier_table)
 	static int l_set_physics_modifier(lua_State *L);
 
 	// delete_physics_modifier(self, key)
 	static int l_delete_physics_modifier(lua_State *L);
+
+	// set_physics_flags(self, override_table)
+	static int l_set_physics_flags(lua_State *L);
+
+	// get_physics_flags(self)
+	static int l_get_physics_flags(lua_State *L);
+
+	// set_physics_override(self, override_table)
+	static int l_set_physics_override(lua_State *L);
+
+	// get_physics_override(self)
+	static int l_get_physics_override(lua_State *L);
 
 	// set_animation(self, frame_range, frame_speed, frame_blend, frame_loop)
 	static int l_set_animation(lua_State *L);

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -116,8 +116,8 @@ private:
 	// set_physics_modifier(self, key, modifier_table)
 	static int l_set_physics_modifier(lua_State *L);
 
-	// delete_physics_modifier(self, key)
-	static int l_delete_physics_modifier(lua_State *L);
+	// remove_physics_modifier(self, key)
+	static int l_remove_physics_modifier(lua_State *L);
 
 	// set_physics_flags(self, override_table)
 	static int l_set_physics_flags(lua_State *L);

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -116,6 +116,12 @@ private:
 	// get_physics_override(self)
 	static int l_get_physics_override(lua_State *L);
 
+	// set_physics_modifier(self, key, modifier_table)
+	static int l_set_physics_modifier(lua_State *L);
+
+	// delete_physics_modifier(self, key)
+	static int l_delete_physics_modifier(lua_State *L);
+
 	// set_animation(self, frame_range, frame_speed, frame_blend, frame_loop)
 	static int l_set_animation(lua_State *L);
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -116,9 +116,6 @@ private:
 	// set_physics_modifier(self, key, modifier_table)
 	static int l_set_physics_modifier(lua_State *L);
 
-	// remove_physics_modifier(self, key)
-	static int l_remove_physics_modifier(lua_State *L);
-
 	// get_physics_modifiers(self)
 	static int l_get_physics_modifiers(lua_State *L);
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -707,8 +707,7 @@ void PlayerSAO::setPhysicsModifier(
 	updatePhysicsModifiersTotal();
 }
 
-void PlayerSAO::deletePhysicsModifier(
-		const std::string &key)
+void PlayerSAO::deletePhysicsModifier(const std::string &key)
 {
 	m_physics_modifiers.erase(key);
 	updatePhysicsModifiersTotal();

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -199,11 +199,7 @@ public:
 	v3f getEyeOffset() const;
 	float getZoomFOV() const;
 
-	const std::unordered_map<std::string, PhysicsModifier> &getPhysicsModifiers()
-	{
-		return m_physics_modifiers;
-	}
-
+	bool hasPhysicsModifiers() const { return !m_physics_modifiers.empty(); }
 	void setPhysicsModifier(const std::string &key, const PhysicsModifier &modifier);
 	void deletePhysicsModifier(const std::string &key);
 
@@ -255,11 +251,13 @@ private:
 public:
 	PhysicsModifier m_physics_override;
 
-	// Flag, when set to true, disables physics modifiers so that only the override
-	// matters. It is set when a mod calls set_physics_override and is irreversible
-	// until the player leaves and logs back in.
+	// Whether overrides are used instead of modifiers.
 	bool m_physics_override_set = false;
+
+	// Whether overrides or modifiers have been sent
 	bool m_physics_override_sent = false;
+
+	// Physics flags:
 	bool m_physics_override_sneak = true;
 	bool m_physics_override_sneak_glitch = false;
 	bool m_physics_override_new_move = true;

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -200,6 +200,11 @@ public:
 	float getZoomFOV() const;
 
 	bool hasPhysicsModifiers() const { return !m_physics_modifiers.empty(); }
+	const std::unordered_map<std::string, PhysicsModifier> &getPhysicsModifiers() const
+	{
+		return m_physics_modifiers;
+	}
+
 	void setPhysicsModifier(const std::string &key, const PhysicsModifier &modifier);
 	void deletePhysicsModifier(const std::string &key);
 

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -69,46 +69,26 @@ class RemotePlayer;
 class PlayerSAO : public UnitSAO
 {
 public:
-
-
 	struct PhysicsModifier
 	{
-		PhysicsModifier():
-				PhysicsModifier(1.0f, 1.0f, 1.0f, true, false)
-		{
-		}
+		float speed = 1.f;
+		float jump = 1.f;
+		float gravity = 1.f;
 
-		PhysicsModifier(
-				float speed, float jump, float gravity, bool sneak, bool sneak_glitch):
-				speed(speed),
-				jump(jump),
-				gravity(gravity),
-				sneak(sneak),
-				sneak_glitch(sneak_glitch)
-		{
-		}
+		bool is_add = false;
 
-		PhysicsModifier operator*(const PhysicsModifier &other) const
+		void apply(PhysicsModifier &target) const
 		{
-			PhysicsModifier ret = *this;
-			ret *= other;
-			return ret;
+			if (is_add) {
+				target.speed += speed;
+				target.jump += jump;
+				target.gravity += gravity;
+			} else {
+				target.speed *= speed;
+				target.jump *= jump;
+				target.gravity *= gravity;
+			}
 		}
-
-		void operator*=(const PhysicsModifier &other)
-		{
-			speed *= other.speed;
-			jump *= other.jump;
-			gravity *= other.gravity;
-			sneak = sneak && other.sneak;
-			sneak_glitch = sneak || other.sneak_glitch;
-		}
-
-		float speed;
-		float jump;
-		float gravity;
-		bool sneak;
-		bool sneak_glitch;
 	};
 
 	PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t peer_id_,
@@ -240,7 +220,11 @@ private:
 	// Not const since it may cached
 	PhysicsModifier calculatePhysicsModifier();
 	const PhysicsModifier &getTotalPhysicsModifier();
-	void dirtyPhysicsModifier();
+	void setPhysicsModifiersDirty()
+	{
+		m_physics_modifier_dirty = true;
+		m_physics_override_sent = false;
+	}
 
 	RemotePlayer *m_player = nullptr;
 	session_t m_peer_id = 0;
@@ -286,6 +270,8 @@ public:
 	// until the player leaves and logs back in.
 	bool m_physics_override_set = false;
 	bool m_physics_override_sent = false;
+	bool m_physics_override_sneak = true;
+	bool m_physics_override_sneak_glitch = false;
 	bool m_physics_override_new_move = true;
 };
 

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -69,6 +69,48 @@ class RemotePlayer;
 class PlayerSAO : public UnitSAO
 {
 public:
+
+
+	struct PhysicsModifier
+	{
+		PhysicsModifier():
+				PhysicsModifier(1.0f, 1.0f, 1.0f, true, false)
+		{
+		}
+
+		PhysicsModifier(
+				float speed, float jump, float gravity, bool sneak, bool sneak_glitch):
+				speed(speed),
+				jump(jump),
+				gravity(gravity),
+				sneak(sneak),
+				sneak_glitch(sneak_glitch)
+		{
+		}
+
+		PhysicsModifier operator*(const PhysicsModifier &other) const
+		{
+			PhysicsModifier ret = *this;
+			ret *= other;
+			return ret;
+		}
+
+		void operator*=(const PhysicsModifier &other)
+		{
+			speed *= other.speed;
+			jump *= other.jump;
+			gravity *= other.gravity;
+			sneak = sneak && other.sneak;
+			sneak_glitch = sneak || other.sneak_glitch;
+		}
+
+		float speed;
+		float jump;
+		float gravity;
+		bool sneak;
+		bool sneak_glitch;
+	};
+
 	PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t peer_id_,
 			bool is_singleplayer);
 
@@ -177,12 +219,28 @@ public:
 	v3f getEyeOffset() const;
 	float getZoomFOV() const;
 
+	const std::unordered_map<std::string, PhysicsModifier> &getPhysicsModifiers()
+	{
+		return m_physics_modifiers;
+	}
+
+	void setPhysicsModifier(const std::string &key, const PhysicsModifier &modifier);
+	void deletePhysicsModifier(const std::string &key);
+
+	// Not const - physics modifier is cached
+	const PhysicsModifier &getEffectivePhysics();
+
 	inline Metadata &getMeta() { return m_meta; }
 
 private:
 	std::string getPropertyPacket();
 	void unlinkPlayerSessionAndSave();
-	std::string generateUpdatePhysicsOverrideCommand() const;
+	std::string generateUpdatePhysicsOverrideCommand();
+
+	// Not const since it may cached
+	PhysicsModifier calculatePhysicsModifier();
+	const PhysicsModifier &getTotalPhysicsModifier();
+	void dirtyPhysicsModifier();
 
 	RemotePlayer *m_player = nullptr;
 	session_t m_peer_id = 0;
@@ -214,16 +272,21 @@ private:
 	f32 m_fov = 0.0f;
 	s16 m_wanted_range = 0.0f;
 
+	std::unordered_map<std::string, PhysicsModifier> m_physics_modifiers;
+	PhysicsModifier m_physics_modifier; // Cache for calculatePhysicsModifier
+	bool m_physics_modifier_dirty = true;
+
 	Metadata m_meta;
 
 public:
-	float m_physics_override_speed = 1.0f;
-	float m_physics_override_jump = 1.0f;
-	float m_physics_override_gravity = 1.0f;
-	bool m_physics_override_sneak = true;
-	bool m_physics_override_sneak_glitch = false;
-	bool m_physics_override_new_move = true;
+	PhysicsModifier m_physics_override;
+
+	// Flag, when set to true, disables physics modifiers so that only the override
+	// matters. It is set when a mod calls set_physics_override and is irreversible
+	// until the player leaves and logs back in.
+	bool m_physics_override_set = false;
 	bool m_physics_override_sent = false;
+	bool m_physics_override_new_move = true;
 };
 
 struct PlayerHPChangeReason

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -207,24 +207,15 @@ public:
 	void setPhysicsModifier(const std::string &key, const PhysicsModifier &modifier);
 	void deletePhysicsModifier(const std::string &key);
 
-	// Not const - physics modifier is cached
-	const PhysicsModifier &getEffectivePhysics();
+	const PhysicsModifier &getEffectivePhysics() const;
 
 	inline Metadata &getMeta() { return m_meta; }
 
 private:
 	std::string getPropertyPacket();
 	void unlinkPlayerSessionAndSave();
-	std::string generateUpdatePhysicsOverrideCommand();
-
-	// Not const since it may cached
-	PhysicsModifier calculatePhysicsModifier();
-	const PhysicsModifier &getTotalPhysicsModifier();
-	void setPhysicsModifiersDirty()
-	{
-		m_physics_modifier_dirty = true;
-		m_physics_override_sent = false;
-	}
+	std::string generateUpdatePhysicsOverrideCommand() const;
+	void updatePhysicsModifiersTotal();
 
 	RemotePlayer *m_player = nullptr;
 	session_t m_peer_id = 0;
@@ -257,8 +248,7 @@ private:
 	s16 m_wanted_range = 0.0f;
 
 	std::unordered_map<std::string, PhysicsModifier> m_physics_modifiers;
-	PhysicsModifier m_physics_modifier; // Cache for calculatePhysicsModifier
-	bool m_physics_modifier_dirty = true;
+	PhysicsModifier m_physics_modifiers_total;
 
 	Metadata m_meta;
 


### PR DESCRIPTION
This prevents mods from conflicting by adding relative physics modifiers.

Modifiers can either be additive or multiplicative. Additions are done before multiplications.

Mods can still use the set physics override API, which will disable all modifiers.

Based on @raymoo's PR (#7269), but with the following changes:

* Rebased and improved code structure
* Allow unsetting set_physics_override
* Support for additive modifiers
* `get_effective_physics()`
* Move flags out of modifiers, into `set_physics_flags`
* devtest test mod

## Examples

```lua
-- Add multiplier for gravity
player:set_physics_modifier("planets:moon", {
	gravity = 0.16,
})

-- Add add modifier for speed
player:set_physics_modifier("potions:speed", {
	type = "add",

	speed = 0.5,
})

-- Remove modifier
player:set_physics_modifier("planets:moon", nil)

-- Different method is needed to set flags
player:set_physics_flags({
    sneak_glitch = false
})
```

## Documentation

* `get_effective_physics()`:
    * Returns a table of the physics factors after applying all overrides.
    * Table fields:
        * `speed`: multiplier to default walking speed value (default: `1`)
        * `jump`: multiplier to default jump value (default: `1`)
        * `gravity`: multiplier to default gravity value (default: `1`)
* `set_physics_modifier(id, modifiers)`:
   * Adds a physics modifier to the player under the given id.
   * Modifiers are resolved by first adding all `add` modifiers, and then multiplying all `multiply` modifiers.
   * `id`: A string to identify this modifier in the format "modname:modifier_name".
   * `modifiers`: either `nil` to delete the modifier, or a table with the same fields as `get_effective_physics` plus:
       * `type`: `multiply` or `add`. Default: `multiply`.
   * Examples:

     ```lua
     player:set_physics_modifier("mymod:moon", {
          gravity = 0.16,
     })

     player:set_physics_modifier("phystest:potion", {
         type = "add",
         speed = 0.5,
     })

     player:set_physics_modifier("phystest:potion", nil)
     ```

* `get_physics_modifiers()`: returns table of modifier id to modifier table, see above.
* `set_physics_flags(flags)`:
    * `sneak`: whether player can sneak (default: `true`)
    * `sneak_glitch`: whether player can use the new move code replications
      of the old sneak side-effects: sneak ladders and 2 node sneak jump
      (default: `false`)
    * `new_move`: use new move/sneak code. When `false` the exact old code
      is used for the specific old sneak behaviour (default: `true`)
* `get_physics_flags()`: returns the table given to `set_physics_flags`.
* `set_physics_override(override_table)`:
    * If `override_table` is a table:
        * Overrides the player's movement physics parameters and disables physics modifiers.
        * Can contain the same fields as `get_effective_physics` and `set_physics_flags`.
        * Setting physics flags here is DEPRECATED.
    * if `override_table` is nil, the use of physics modifiers will be re-enabled.
* `get_physics_override()`: returns the table given to `set_physics_override`.

## To do

- [x] Fix bug on overrides reset.
- [x] Add support for additive modifiers - these will be applied either before or after multipliers (TBD).
- [x] Consider flag behaviour.
- [x] Add`set_physics_flags()`.
- [x] Add deprecation log with flags in overrides

## How to test

See the /physics command in DevTest:

* `/physics` - list effective physics 
* `/physics override` - set physics overrides (will disable mods)
* `/physics reset` - reset physics overrides (will reenable mods)
* Modifiers:
    * `/physics moon` - add moon physics modifier
    * `/physics nomoon`
    * `/physics speed` - add speed physics modifier
    * `/physics nospeed`
    * `/physics potion` - adds speed physics modifier which is additive
    * `/physics nopotion`
    * `/physics jupiter` - add jupiter physics modifier
    * `/physics nojupiter`
    * `/physics invalid` - tests invalid type
* Flags:
	* `/physics glitch` - enable sneak glitch
	* `/physics noglitch` - disable sneak glitch
