### PR TITLE
Minor profiler fixes.

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -290,6 +290,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	*/
 
 	u32 vertex_count = 0;
+	u32 drawcall_count = 0;
 
 	// For limiting number of mesh animations per frame
 	u32 mesh_animate_count = 0;
@@ -391,6 +392,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			}
 			driver->setMaterial(list.m);
 
+			drawcall_count += list.bufs.size();
 			for (auto &pair : list.bufs) {
 				scene::IMeshBuffer *buf = pair.second;
 
@@ -411,6 +413,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	}
 
 	g_profiler->avg(prefix + "vertices drawn [#]", vertex_count);
+	g_profiler->avg(prefix + "drawcalls [#]", drawcall_count);
 }
 
 static bool getVisibleBrightness(Map *map, const v3f &p0, v3f dir, float step,

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -38,7 +38,7 @@ ScopeProfiler::~ScopeProfiler()
 		return;
 
 	float duration_ms = m_timer->stop(true);
-	float duration = duration_ms / 1000.0;
+	float duration = duration_ms;
 	if (m_profiler) {
 		switch (m_type) {
 		case SPT_ADD:


### PR DESCRIPTION
Mixes two minor changes:
1. The numbers reported by the ScopeProfiler are now in ms (as advertised). This way the numbers also make more sense. Alternately could change the string to say [s] instead of [ms]
2. On the client report the number of drawcalls since they are very significant to client FPS

Happy to do two PRs. These just seemed minor.