### PR TITLE
Display Minetest header when menu_last_game value isn't available anymore

### DIFF
--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -105,6 +105,14 @@ local function init_globals()
 	if last_tab and tv_main.current_tab ~= last_tab then
 		tv_main:set_tab(last_tab)
 	end
+
+	if tv_main.current_tab == "local" then
+		local game = pkgmgr.find_by_gameid(core.settings:get("menu_last_game"))
+		if game == nil then
+			mm_texture.reset()
+		end
+	end
+
 	ui.set_default("maintab")
 	tv_main:show()
 

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -106,6 +106,8 @@ local function init_globals()
 		tv_main:set_tab(last_tab)
 	end
 
+	-- In case the folder of the last selected game has been deleted,
+	-- display "Minetest" as a header
 	if tv_main.current_tab == "local" then
 		local game = pkgmgr.find_by_gameid(core.settings:get("menu_last_game"))
 		if game == nil then

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -22,6 +22,9 @@ if enable_gamebar then
 	function current_game()
 		local last_game_id = core.settings:get("menu_last_game")
 		local game = pkgmgr.find_by_gameid(last_game_id)
+		if game == nil then
+			mm_texture.reset()
+		end
 
 		return game
 	end

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -18,13 +18,11 @@
 
 local enable_gamebar = PLATFORM ~= "Android"
 local current_game, singleplayer_refresh_gamebar
+
 if enable_gamebar then
 	function current_game()
 		local last_game_id = core.settings:get("menu_last_game")
 		local game = pkgmgr.find_by_gameid(last_game_id)
-		if game == nil then
-			mm_texture.reset()
-		end
 
 		return game
 	end


### PR DESCRIPTION
Fixes #9962

## To do

This PR is Ready for Review.

## How to test
- Install a game
- Close MT having that game selected in the local tab
- delete that game folder
- reopen MT
- "Minetest" header should appear