### PR TITLE
ContentDB: Add overwrite dialog when content is already installed

### DIFF
--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -437,11 +437,52 @@ function install_dialog.create(package, raw_deps)
 	install_dialog.package = package
 	install_dialog.raw_deps = raw_deps
 	install_dialog.will_install_deps = true
-	return dialog_create("package_view",
+	return dialog_create("install_dialog",
 			install_dialog.get_formspec,
 			install_dialog.handle_submit,
 			nil)
 end
+
+
+local confirm_overwrite = {}
+function confirm_overwrite.get_formspec()
+	local package = confirm_overwrite.package
+
+	return "size[11.5,4.5,true]" ..
+			"label[2,2;" ..
+			fgettext("\"$1\" already exists. Would you like to overwrite it?", package.name) .. "]"..
+			"style[install;bgcolor=red]" ..
+			"button[3.25,3.5;2.5,0.5;install;" .. fgettext("Overwrite") .. "]" ..
+			"button[5.75,3.5;2.5,0.5;cancel;" .. fgettext("Cancel") .. "]"
+end
+
+function confirm_overwrite.handle_submit(this, fields)
+	if fields.cancel then
+		this:delete()
+		return true
+	end
+
+	if fields.install then
+		confirm_overwrite.callback()
+		this:delete()
+		return true
+	end
+
+	return false
+end
+
+function confirm_overwrite.create(package, callback)
+	assert(type(package) == "table")
+	assert(type(callback) == "function")
+
+	confirm_overwrite.package = package
+	confirm_overwrite.callback = callback
+	return dialog_create("confirm_overwrite",
+		confirm_overwrite.get_formspec,
+		confirm_overwrite.handle_submit,
+		nil)
+end
+
 
 local function get_file_extension(path)
 	local parts = path:split(".")
@@ -854,14 +895,37 @@ function store.handle_submit(this, fields)
 		assert(package)
 
 		if fields["install_" .. i] then
-			local deps = get_raw_dependencies(package)
-			if deps and has_hard_deps(deps) then
-				local dlg = install_dialog.create(package, deps)
+			local install_parent
+			if package.type == "mod" then
+				install_parent = core.get_modpath()
+			elseif package.type == "game" then
+				install_parent = core.get_gamepath()
+			elseif package.type == "txp" then
+				install_parent = core.get_texturepath()
+			else
+				error("Unknown package type: " .. package.type)
+			end
+
+
+			local function on_confirm()
+				local deps = get_raw_dependencies(package)
+				if deps and has_hard_deps(deps) then
+					local dlg = install_dialog.create(package, deps)
+					dlg:set_parent(this)
+					this:hide()
+					dlg:show()
+				else
+					queue_download(package)
+				end
+			end
+
+			if not package.path and core.is_dir(install_parent .. DIR_DELIM .. package.name) then
+				local dlg = confirm_overwrite.create(package, on_confirm)
 				dlg:set_parent(this)
 				this:hide()
 				dlg:show()
 			else
-				queue_download(package)
+				on_confirm()
 			end
 
 			return true

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -463,8 +463,8 @@ function confirm_overwrite.handle_submit(this, fields)
 	end
 
 	if fields.install then
-		confirm_overwrite.callback()
 		this:delete()
+		confirm_overwrite.callback()
 		return true
 	end
 

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -67,6 +67,8 @@ core.copy_dir(source,destination,keep_soure) (possible in async calls)
 ^ destination folder
 ^ keep_source DEFAULT true --> if set to false source is deleted after copying
 ^ returns true/false
+core.is_dir(path) (possible in async calls)
+^ returns true if path is a valid dir
 core.extract_zip(zipfile,destination) [unzip within path required]
 ^ zipfile to extract
 ^ destination folder to extract to

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -804,6 +804,15 @@ int ModApiMainMenu::l_copy_dir(lua_State *L)
 }
 
 /******************************************************************************/
+int ModApiMainMenu::l_is_dir(lua_State *L)
+{
+	const char *path	= luaL_checkstring(L, 1);
+
+	lua_pushboolean(L, fs::IsDir(path));
+	return 1;
+}
+
+/******************************************************************************/
 int ModApiMainMenu::l_extract_zip(lua_State *L)
 {
 	const char *zipfile	= luaL_checkstring(L, 1);
@@ -1139,6 +1148,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(create_dir);
 	API_FCT(delete_dir);
 	API_FCT(copy_dir);
+	API_FCT(is_dir);
 	API_FCT(extract_zip);
 	API_FCT(may_modify_path);
 	API_FCT(get_mainmenu_path);
@@ -1172,6 +1182,7 @@ void ModApiMainMenu::InitializeAsync(lua_State *L, int top)
 	API_FCT(create_dir);
 	API_FCT(delete_dir);
 	API_FCT(copy_dir);
+	API_FCT(is_dir);
 	//API_FCT(extract_zip); //TODO remove dependency to GuiEngine
 	API_FCT(may_modify_path);
 	API_FCT(download_file);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -806,7 +806,7 @@ int ModApiMainMenu::l_copy_dir(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_is_dir(lua_State *L)
 {
-	const char *path	= luaL_checkstring(L, 1);
+	const char *path = luaL_checkstring(L, 1);
 
 	lua_pushboolean(L, fs::IsDir(path));
 	return 1;

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -132,6 +132,8 @@ private:
 
 	static int l_copy_dir(lua_State *L);
 
+	static int l_is_dir(lua_State *L);
+
 	static int l_extract_zip(lua_State *L);
 
 	static int l_may_modify_path(lua_State *L);


### PR DESCRIPTION
When a user attempts to install a package which is already installed on their system, Minetest will now show a confirmation dialog. This will prevent users from accidentally writing over their git cloned or custom mods

## To do

Ready for Review.

## How to test

Install some mods