### PR TITLE
Correct on_metadata_inventory_* callbacks in default node definition

### DIFF
--- a/builtin/game/deprecated.lua
+++ b/builtin/game/deprecated.lua
@@ -19,6 +19,14 @@ function core.node_metadata_inventory_move_allow_all()
 	core.log("deprecated", "core.node_metadata_inventory_move_allow_all is obsolete and does nothing.")
 end
 
+function core.node_metadata_inventory_offer_allow_all()
+	core.log("deprecated", "core.node_metadata_inventory_offer_allow_all is obsolete and does nothing.")
+end
+
+function core.node_metadata_inventory_take_allow_all()
+	core.log("deprecated", "core.node_metadata_inventory_take_allow_all is obsolete and does nothing.")
+end
+
 function core.add_to_creative_inventory(itemstring)
 	core.log("deprecated", "core.add_to_creative_inventory is obsolete and does nothing.")
 end

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -705,9 +705,13 @@ core.nodedef_default = {
 
 	on_receive_fields = nil,
 
-	on_metadata_inventory_move = core.node_metadata_inventory_move_allow_all,
-	on_metadata_inventory_offer = core.node_metadata_inventory_offer_allow_all,
-	on_metadata_inventory_take = core.node_metadata_inventory_take_allow_all,
+	allow_metadata_inventory_move = nil,
+	allow_metadata_inventory_put = nil,
+	allow_metadata_inventory_take = nil,
+
+	on_metadata_inventory_move = nil,
+	on_metadata_inventory_put = nil,
+	on_metadata_inventory_take = nil,
 
 	-- Node properties
 	drawtype = "normal",


### PR DESCRIPTION
Fixes things that were not changed when metadata callbacks changed in https://github.com/minetest/minetest/commit/9eaf93d41d6745b877f8f52cf54b21050abefda1.
* Corrects the `on_metadata_inventory_*` callbacks in the default node definition.
* Adds the `allow_metadata_inventory_*` callbacks to the default node definition.
* Adds the depreciated `core.node_metadata_inventory_offer_allow_all` and `core.node_metadata_inventory_take_allow_all` functions.

Functionally, nothing is changed, as the callbacks were already set to nil.

## To do

This PR is Ready for Review.