### PR TITLE
Implement on_rightclickplayer callback

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -617,6 +617,7 @@ core.registered_can_bypass_userlimit, core.register_can_bypass_userlimit = make_
 core.registered_on_modchannel_message, core.register_on_modchannel_message = make_registration()
 core.registered_on_player_inventory_actions, core.register_on_player_inventory_action = make_registration()
 core.registered_allow_player_inventory_actions, core.register_allow_player_inventory_action = make_registration()
+core.registered_on_rightclickplayers, core.register_on_rightclickplayer = make_registration()
 
 --
 -- Compatibility for on_mapgen_init()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2113,7 +2113,7 @@ Examples
     list[current_player;main;0,3.5;8,4;]
     list[current_player;craft;3,0;3,3;]
     list[current_player;craftpreview;7,1;1,1;]
-   
+
 Version History
 ---------------
 
@@ -4586,11 +4586,11 @@ Call these functions only at load time!
     * `dir`: Unit vector of direction of punch. Always defined. Points from
       the puncher to the punched.
     * `damage`: Number that represents the damage calculated by the engine
+    * should return `true` to prevent the default damage mechanism
 * `minetest.register_on_rightclickplayer(function(player, clicker))`
     * Called when a player is right-clicked
     * `player`: ObjectRef - Player that was right-clicked
     * `clicker`: ObjectRef - Player that right-click
-    * should return `true` to prevent the default damage mechanism
 * `minetest.register_on_player_hpchange(function(player, hp_change, reason), modifier)`
     * Called when the player gets damaged or healed
     * `player`: ObjectRef of the player
@@ -7645,12 +7645,12 @@ Used by `minetest.register_node`.
         -- intensity: 1.0 = mid range of regular TNT.
         -- If defined, called when an explosion touches the node, instead of
         -- removing the node.
-        
+
         mod_origin = "modname",
         -- stores which mod actually registered a node
         -- if it can not find a source, returns "??"
         -- useful for getting what mod truly registered something
-        -- example: if a node is registered as ":othermodname:nodename", 
+        -- example: if a node is registered as ":othermodname:nodename",
         -- nodename will show "othermodname", but mod_orgin will say "modname"
     }
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4590,7 +4590,7 @@ Call these functions only at load time!
 * `minetest.register_on_rightclickplayer(function(player, clicker))`
     * Called when a player is right-clicked
     * `player`: ObjectRef - Player that was right-clicked
-    * `clicker`: ObjectRef - Player that right-click
+    * `clicker`: ObjectRef - Object that right-clicked, may or may not be a player
 * `minetest.register_on_player_hpchange(function(player, hp_change, reason), modifier)`
     * Called when the player gets damaged or healed
     * `player`: ObjectRef of the player

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4586,6 +4586,10 @@ Call these functions only at load time!
     * `dir`: Unit vector of direction of punch. Always defined. Points from
       the puncher to the punched.
     * `damage`: Number that represents the damage calculated by the engine
+* `minetest.register_on_rightclickplayer(function(player, clicker))`
+    * Called when a player is right-clicked
+    * `player`: ObjectRef - Player that was right-clicked
+    * `clicker`: ObjectRef - Player that right-click
     * should return `true` to prevent the default damage mechanism
 * `minetest.register_on_player_hpchange(function(player, hp_change, reason), modifier)`
     * Called when the player gets damaged or healed

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -77,6 +77,19 @@ bool ScriptApiPlayer::on_punchplayer(ServerActiveObject *player,
 	return readParam<bool>(L, -1);
 }
 
+void ScriptApiPlayer::on_rightclickplayer(ServerActiveObject *player,
+                ServerActiveObject *clicker)
+{
+	SCRIPTAPI_PRECHECKHEADER
+	// Get core.registered_on_rightclickplayers
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_rightclickplayers");
+	// Call callbacks
+	objectrefGetOrCreate(L, player);
+	objectrefGetOrCreate(L, clicker);
+	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
+}
+
 s32 ScriptApiPlayer::on_player_hpchange(ServerActiveObject *player,
 	s32 hp_change, const PlayerHPChangeReason &reason)
 {

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -47,6 +47,7 @@ public:
 	bool on_punchplayer(ServerActiveObject *player, ServerActiveObject *hitter,
 			float time_from_last_punch, const ToolCapabilities *toolcap,
 			v3f dir, s16 damage);
+	void on_rightclickplayer(ServerActiveObject *player, ServerActiveObject *clicker);
 	s32 on_player_hpchange(ServerActiveObject *player, s32 hp_change,
 			const PlayerHPChangeReason &reason);
 	void on_playerReceiveFields(ServerActiveObject *player,

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -456,6 +456,11 @@ u16 PlayerSAO::punch(v3f dir,
 	return hitparams.wear;
 }
 
+void PlayerSAO::rightClick(ServerActiveObject *clicker)
+{
+	m_env->getScriptIface()->on_rightclickplayer(this, clicker);
+}
+
 void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
 {
 	if (hp == (s32)m_hp)

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -111,7 +111,7 @@ public:
 
 	u16 punch(v3f dir, const ToolCapabilities *toolcap, ServerActiveObject *puncher,
 			float time_from_last_punch);
-	void rightClick(ServerActiveObject *clicker) {}
+	void rightClick(ServerActiveObject *clicker);
 	void setHP(s32 hp, const PlayerHPChangeReason &reason);
 	void setHPRaw(u16 hp) { m_hp = hp; }
 	s16 readDamage();


### PR DESCRIPTION
The on_rightclickplayer callback makes exacty that, notifies when a player right-click on another.

Cool PR for multiplayer interactions between players: share inventory for example.

A fork (slighty modification) of this:
[https://github.com/minetest/minetest/pull/9569](https://github.com/minetest/minetest/pull/9569)

**To do**
This PR is Ready for Review.

**How to test**

Join a multiplayer game. Join as a second player and right-click one another to be notified of the action.

```
minetest.register_on_rightclickplayer( function ( target, source )
        minetest.chat_send_all( string.format( "Player %s right-clicked player %s",
                source:get_player_name( ), target:get_player_name( )
        ) )
end )
```
