### PR TITLE
Allow `table.copy` to copy metatables

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2113,7 +2113,7 @@ Examples
     list[current_player;main;0,3.5;8,4;]
     list[current_player;craft;3,0;3,3;]
     list[current_player;craftpreview;7,1;1,1;]
-   
+
 Version History
 ---------------
 
@@ -3259,8 +3259,11 @@ Helper functions
 * `minetest.get_us_time()`
     * returns time with microsecond precision. May not return wall time.
     * This value might overflow on certain 32-bit systems!
-* `table.copy(table)`: returns a table
-    * returns a deep copy of `table`
+* `table.copy(table[, copy_meta])`: Returns a deep copy of a table.
+    * `table`: The table to copy. Functions, userdata, and coroutines will not
+      be copied and will stay as references.
+    * `copy_meta` (optional): If true, makes deep copies of metatables as well.
+      Default false.
 * `table.indexof(list, val)`: returns the smallest numerical index containing
       the value `val` in the table `list`. Non-numerical indices are ignored.
       If `val` could not be found, `-1` is returned. `list` must not have
@@ -7641,12 +7644,12 @@ Used by `minetest.register_node`.
         -- intensity: 1.0 = mid range of regular TNT.
         -- If defined, called when an explosion touches the node, instead of
         -- removing the node.
-        
+
         mod_origin = "modname",
         -- stores which mod actually registered a node
         -- if it can not find a source, returns "??"
         -- useful for getting what mod truly registered something
-        -- example: if a node is registered as ":othermodname:nodename", 
+        -- example: if a node is registered as ":othermodname:nodename",
         -- nodename will show "othermodname", but mod_orgin will say "modname"
     }
 


### PR DESCRIPTION
This PR allows `table.copy` to additionally copy metatables via a new parameter `copy_meta` (default false) as well as being implemented in a less redundant way.

## To do

This PR is a Ready for Review.

## How to test

Ensure the same thing is printed twice:
```lua
local x = {
	foo = "x",
	bar = {
		baz = {
			joe = 6,
		},
		[{table_as_key = "works"}] = true,
		[9] = function()
			return 3
		end,
	},
	[function() end] = {},
	array = {1, 2, 5},
}

local meta = {
	func = function(self)
		print("This is X calling...")
	end
}
meta.__index = meta
setmetatable(x, meta)

x:func()
print(dump(x))
local y = table.copy(x, true)
y:func()
print(dump(y))
```