### PR TITLE
Clarify key_value_swap's edge case

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3269,7 +3269,8 @@ Helper functions
     * Appends all values in `other_table` to `table` - uses `#table + 1` to
       find new indices.
 * `table.key_value_swap(t)`: returns a table with keys and values swapped
-    * If multiple keys in `t` map to the same value, the result is undefined.
+    * If multiple keys in `t` map to the same value, it is unspecified which
+      value maps to that key.
 * `table.shuffle(table, [from], [to], [random_func])`:
     * Shuffles elements `from` to `to` in `table` in place
     * `from` defaults to `1`


### PR DESCRIPTION
In compiler design especially, leaving behavior as "undefined" is a _strong_ condition that basically states that all possible integrity is violated; it's the kind of thing that happens when, say, dereferencing a pointer with unknown provenance, and most typically leads to a crash, but can result in all sorts of spectacular errors--thus, "it is undefined" how your program will melt down.

The pure-Lua implementation of `key_value_swap` does not permit UB _per se_ (assuming the implementation of Lua itself is sound), but does deterministically choose the value to which a key is mapped (the last in visitation order wins--since visitation order is arbitrary, _some_ value _will_ be chosen). Most importantly, the program won't do something wildly unexpected.

Ready for Review. (Feel free to squash the explanation out of the commit :)
