### PR TITLE
Support IrrLicht 1.9 (again)

### DIFF
--- a/src/client/render/interlaced.cpp
+++ b/src/client/render/interlaced.cpp
@@ -35,7 +35,7 @@ void RenderingCoreInterlaced::initMaterial()
 	IShaderSource *s = client->getShaderSource();
 	mat.UseMipMaps = false;
 	mat.ZBuffer = false;
-	mat.ZWriteEnable = false;
+	mat.setFlag(video::EMF_ZWRITE_ENABLE, false); // ZWriteEnable is bool on early 1.9 but E_ZWRITE on later 1.9
 	u32 shader = s->getShader("3d_interlaced_merge", TILE_MATERIAL_BASIC);
 	mat.MaterialType = s->getShaderInfo(shader).material;
 	for (int k = 0; k < 3; ++k) {

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -128,7 +128,7 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	params.Vsync = vsync;
 	params.EventReceiver = receiver;
 	params.HighPrecisionFPU = g_settings->getBool("high_precision_fpu");
-	params.ZBufferBits = 24;
+	params.ZBufferBits = 16;
 #ifdef __ANDROID__
 	params.PrivateData = porting::app_global;
 #endif
@@ -225,6 +225,7 @@ bool RenderingEngine::print_video_modes()
 
 bool RenderingEngine::setupTopLevelWindow(const std::string &name)
 {
+	return true;
 	// FIXME: It would make more sense for there to be a switch of some
 	// sort here that would call the correct toplevel setup methods for
 	// the environment Minetest is running in.

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -44,7 +44,7 @@ static video::SMaterial baseMaterial()
 #else
 	mat.ZBuffer = video::ECFN_NEVER;
 #endif
-	mat.ZWriteEnable = false;
+	mat.setFlag(video::EMF_ZWRITE_ENABLE, false); // ZWriteEnable is bool on early 1.9 but E_ZWRITE on later 1.9
 	mat.AntiAliasing = 0;
 	mat.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
 	mat.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -21,7 +21,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <algorithm>
 #include <ICameraSceneNode.h>
-#include <IrrCompileConfig.h>
 #include "util/string.h"
 #include "util/container.h"
 #include "util/thread.h"

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -17,7 +17,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <IrrCompileConfig.h>
 #include "settings.h"
 #include "porting.h"
 #include "filesys.h"

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -506,6 +506,16 @@ video::SColor GUIButton::getOverrideColor() const
 	return OverrideColor;
 }
 
+video::SColor GUIButton::getActiveColor() const
+{
+	if (OverrideColorEnabled)
+		return OverrideColor;
+	IGUISkin* skin = Environment->getSkin();
+	if (skin)
+		return skin->getColor(isEnabled() ? EGDC_BUTTON_TEXT : EGDC_GRAY_TEXT);
+	return OverrideColor;
+}
+
 void GUIButton::enableOverrideColor(bool enable)
 {
 	OverrideColorEnabled = enable;

--- a/src/gui/guiButton.h
+++ b/src/gui/guiButton.h
@@ -102,6 +102,8 @@ public:
 	//! Gets the override color
 	virtual video::SColor getOverrideColor(void) const;
 
+	video::SColor getActiveColor() const; // IrrLicht 1.9; doesn't hurt in 1.8
+
 	//! Sets if the button text should use the override color or the color in the gui skin.
 	virtual void enableOverrideColor(bool enable);
 

--- a/src/gui/guiButton.h
+++ b/src/gui/guiButton.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "IrrCompileConfig.h"
 
 #include <IGUIStaticText.h>
 #include "irrlicht_changes/static_text.h"

--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -209,28 +209,8 @@ bool GUIEditBox::OnEvent(const SEvent &event)
 			}
 			break;
 		case EET_KEY_INPUT_EVENT: {
-#if (defined(__linux__) || defined(__FreeBSD__)) || defined(__DragonFly__)
-			// ################################################################
-			// ValkaTR:
-			// This part is the difference from the original intlGUIEditBox
-			// It converts UTF-8 character into a UCS-2 (wchar_t)
-			wchar_t wc = L'_';
-			mbtowc(&wc, (char *)&event.KeyInput.Char,
-					sizeof(event.KeyInput.Char));
-
-			// printf( "char: %lc (%u)  \r\n", wc, wc );
-
-			SEvent irrevent(event);
-			irrevent.KeyInput.Char = wc;
-			// ################################################################
-
-			if (processKey(irrevent))
-				return true;
-#else
 			if (processKey(event))
 				return true;
-#endif // defined(linux)
-
 			break;
 		}
 		case EET_MOUSE_INPUT_EVENT:

--- a/src/gui/guiSkin.cpp
+++ b/src/gui/guiSkin.cpp
@@ -5,7 +5,6 @@
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
 #include "guiSkin.h"
-#ifdef _IRR_COMPILE_WITH_GUI_
 
 #include "IGUIFont.h"
 #include "IGUISpriteBank.h"
@@ -1078,7 +1077,4 @@ void GUISkin::getColors(video::SColor* colors)
 
 } // end namespace gui
 } // end namespace irr
-
-
-#endif // _IRR_COMPILE_WITH_GUI_
 

--- a/src/gui/guiSkin.h
+++ b/src/gui/guiSkin.h
@@ -5,9 +5,6 @@
 #ifndef __GUI_SKIN_H_INCLUDED__
 #define __GUI_SKIN_H_INCLUDED__
 
-#include "IrrCompileConfig.h"
-#ifdef _IRR_COMPILE_WITH_GUI_
-
 #include "IGUISkin.h"
 #include "irrString.h"
 #include <string>
@@ -369,8 +366,5 @@ inline void setShading(video::SColor &color,f32 s) // :PATCH:
 	}
 }
 } // end namespace irr
-
-
-#endif // _IRR_COMPILE_WITH_GUI_
 
 #endif

--- a/src/gui/intlGUIEditBox.h
+++ b/src/gui/intlGUIEditBox.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "IrrCompileConfig.h"
 //#ifdef _IRR_COMPILE_WITH_GUI_
 
 #include "guiEditBox.h"

--- a/src/irrlicht_changes/static_text.cpp
+++ b/src/irrlicht_changes/static_text.cpp
@@ -255,6 +255,10 @@ video::SColor StaticText::getOverrideColor() const
 	return ColoredText.getDefaultColor();
 }
 
+video::SColor StaticText::getActiveColor() const
+{
+	return ColoredText.getDefaultColor();
+}
 
 //! Sets if the static text should use the overide color or the
 //! color in the gui skin.

--- a/src/irrlicht_changes/static_text.cpp
+++ b/src/irrlicht_changes/static_text.cpp
@@ -5,7 +5,6 @@
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
 #include "static_text.h"
-#ifdef _IRR_COMPILE_WITH_GUI_
 
 #include <IGUIFont.h>
 #include <IVideoDriver.h>
@@ -645,5 +644,3 @@ void StaticText::deserializeAttributes(io::IAttributes* in, io::SAttributeReadWr
 
 } // end namespace irr
 
-
-#endif // _IRR_COMPILE_WITH_GUI_

--- a/src/irrlicht_changes/static_text.h
+++ b/src/irrlicht_changes/static_text.h
@@ -140,6 +140,8 @@ namespace gui
 		virtual video::SColor getOverrideColor() const;
 		#endif
 
+		video::SColor getActiveColor() const; // IrrLicht 1.9; doesn't hurt in 1.8
+
 		//! Sets if the static text should use the overide color or the
 		//! color in the gui skin.
 		virtual void enableOverrideColor(bool enable);

--- a/src/irrlicht_changes/static_text.h
+++ b/src/irrlicht_changes/static_text.h
@@ -6,9 +6,6 @@
 
 #pragma once
 
-#include "IrrCompileConfig.h"
-#ifdef _IRR_COMPILE_WITH_GUI_
-
 #include "IGUIStaticText.h"
 #include "irrArray.h"
 
@@ -276,5 +273,3 @@ inline void setStaticText(irr::gui::IGUIStaticText *static_text, const wchar_t *
 {
 	setStaticText(static_text, EnrichedString(text, static_text->getOverrideColor()));
 }
-
-#endif // _IRR_COMPILE_WITH_GUI_


### PR DESCRIPTION
There are some more changes in IrrLicht 1.9/ogl-es, as of https://github.com/MoNTE48/irrlicht. The one with `ZWriteEnable` is tricky: field type was changed without version change; fortunately `setFlag` still works.