### PR TITLE
Support crafting with drag&drop

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3790,7 +3790,6 @@ void GUIFormSpecMenu::updateSelectedItem()
 			m_selected_item->listname = "craftresult";
 			m_selected_item->i = 0;
 			m_selected_amount = item.count;
-			m_selected_dragging = false;
 			break;
 		}
 	}
@@ -4196,7 +4195,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 		bool identical = m_selected_item && s.isValid() &&
 			(inv_selected == inv_s) &&
-			(m_selected_item->listname == s.listname) &&
+			(m_selected_item->listname == s.listname || (m_selected_item->listname == "craftresult" && s.listname == "craftpreview")) &&
 			(m_selected_item->i == s.i);
 
 		ButtonEventType button = BET_LEFT;
@@ -4502,6 +4501,9 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 				a->count = craft_amount;
 				a->craft_inv = s.inventoryloc;
 				m_invmgr->inventoryAction(a);
+				if (!m_selected_item)
+					m_selected_dragging = button != BET_WHEEL_DOWN && button != BET_WHEEL_UP;
+				updateSelectedItem();
 			}
 		}
 

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -925,6 +925,15 @@ void ICraftAction::clientApply(InventoryManager *mgr, IGameDef *gamedef)
 {
 	// Optional InventoryAction operation that is run on the client
 	// to make lag less apparent.
+
+	Inventory *inv_craft = mgr->getInventory(craft_inv);
+	if (!inv_craft)
+		return;
+	InventoryList *list_craftpreview = inv_craft->getList("craftpreview");
+	InventoryList *list_craftresult = inv_craft->getList("craftresult");
+	if (!list_craftpreview || !list_craftresult || list_craftpreview->getSize() != 1 || list_craftresult->getSize() < 1)
+		return;
+	list_craftresult->addItem(list_craftpreview->getItem(0));
 }
 
 
@@ -963,4 +972,3 @@ bool getCraftingResult(Inventory *inv, ItemStack &result,
 
 	return found;
 }
-


### PR DESCRIPTION
Items can be moved with clicks or dragging. This PR makes crafting work the same.
Fixes #8241 

## To do

This PR is a Work in Progress.

- [ ] Repeated crafting by holding the button/touch

## How to test

Place a recipe into the crafting grid. Drag the result to the inventory.