### PR TITLE
Add Lua metatable-based class helpers

### DIFF
--- a/builtin/common/class.lua
+++ b/builtin/common/class.lua
@@ -1,0 +1,119 @@
+class = {}
+
+function class.new(name, ...)
+	local cls = {}
+
+	-- Copy inherited classes in reverse order to make the first ones overwrite later ones
+	local bases = {...}
+	for i = #bases, 1, -1 do
+		for k, v in pairs(bases[i]) do
+			cls[class.copy(k)] = class.copy(v)
+		end
+	end
+
+	cls.__name = name
+	cls.__index = cls
+
+	-- Add instance information
+	cls.__is = {[cls] = true}
+	for _, base in ipairs(bases) do
+		for base in pairs(base.__is) do
+			cls.__is[base] = true
+		end
+	end
+
+	-- Create pretty class constructor
+	setmetatable(cls, {
+		__call = function(cls, ...)
+			local args = {...}
+			if #args == 1 and class.is(args[1], cls) then
+				return class.copy(args[1])
+			else
+				return class.init(cls, ...)
+			end
+		end
+	})
+
+	return cls
+end
+
+function class.instantiate(cls)
+	return setmetatable({}, cls)
+end
+
+function class.init(cls, ...)
+	local self = class.instantiate(cls)
+
+	local init = self.__init
+	if init then
+		init(self, ...)
+	end
+
+	return self
+end
+
+local function class_deepcopy(obj, seen, bypass_ctor, into)
+	if type(obj) == "table" then
+		local already_seen = seen[obj]
+		if already_seen then
+			return already_seen
+		end
+
+		local mt = getmetatable(obj)
+		local copier = mt and mt.__copy
+		if copier == "ref" then
+			return obj
+		elseif not bypass_ctor and type(copier) == "function" then
+			local copy = class.instantiate(mt)
+			seen[obj] = copy
+			copier(copy, obj)
+			return copy
+		end
+
+		local copy = into or {}
+		seen[obj] = copy
+
+		for k, v in pairs(obj) do
+			copy[class_deepcopy(k, seen)] = class_deepcopy(v, seen)
+		end
+		if mt and not into then
+			setmetatable(copy, mt)
+		end
+
+		return copy
+	end
+	return obj
+end
+
+function class.copy(obj, bypass_ctor)
+	return class_deepcopy(obj, {}, bypass_ctor)
+end
+
+-- Note: `into` will not be copied if it is inside itself
+function class.copy_into(obj, into, bypass_ctro)
+	class_deepcopy(obj, {}, bypass_ctor, into)
+end
+
+function class.name(cls_or_obj)
+	local prototype = class.prototype(cls_or_obj)
+	return prototype and prototype.__name
+end
+
+function class.prototype(cls_or_obj)
+	local mt = getmetatable(cls_or_obj) or {}
+	if mt.__is then
+		return mt -- An object was passed
+	elseif cls_or_obj.__is then
+		return cls_or_obj -- A prototype was passed
+	end
+	return nil -- Invalid
+end
+
+function class.is(cls_or_obj, cls)
+	local prototype = class.prototype(cls_or_obj)
+	return prototype and prototype.__is and prototype.__is[cls]
+end
+
+function class.cast(obj, cls)
+	setmetatable(obj, cls)
+end

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -33,6 +33,7 @@ local asyncpath = scriptdir .. "async" .. DIR_DELIM
 dofile(commonpath .. "strict.lua")
 dofile(commonpath .. "serialize.lua")
 dofile(commonpath .. "misc_helpers.lua")
+dofile(commonpath .. "class.lua")
 
 if INIT == "game" then
 	dofile(gamepath .. "init.lua")

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2113,7 +2113,7 @@ Examples
     list[current_player;main;0,3.5;8,4;]
     list[current_player;craft;3,0;3,3;]
     list[current_player;craftpreview;7,1;1,1;]
-   
+
 Version History
 ---------------
 
@@ -3259,8 +3259,9 @@ Helper functions
 * `minetest.get_us_time()`
     * returns time with microsecond precision. May not return wall time.
     * This value might overflow on certain 32-bit systems!
-* `table.copy(table)`: returns a table
-    * returns a deep copy of `table`
+* `table.copy(table)`: Returns a deep copy of `table`.
+    * Metatables are ignored. If the tables have metatables that should be
+      preserved or the table contains Lua classes, `class.copy` may be better.
 * `table.indexof(list, val)`: returns the smallest numerical index containing
       the value `val` in the table `list`. Non-numerical indices are ignored.
       If `val` could not be found, `-1` is returned. `list` must not have
@@ -3299,6 +3300,176 @@ Helper functions
     * `groups`: Damage groups of the object
     * `tool_capabilities`: Tool capabilities table of the item
     * `time_from_last_punch`: time in seconds since last punch action
+
+
+
+
+Metatable Classes
+=================
+
+Lua doesn't have a built-in OOP class implementation, but it is possible to create such an
+implementation through the usage of metatables, such as <http://www.lua.org/pil/16.html>.
+The following functions make a consistent interface for metatable-based classes. Basic
+knowledge of metatable-based classes and OOP is assumed.
+
+To make a class, use `class.new`. The first argument is a string name, while the next
+arguments (if present) are the classes to inherit from. It returns the metatable of the
+classes, called the "prototype":
+
+    local MyClass = class.new("MyClass")
+
+Methods, operator overloads, constructors, and predefined values can be added directly to the
+prototype, like so (detailed more later on):
+
+    -- Constructor
+    function MyClass:__init(val)
+        self.value = val
+    end
+
+    -- Plain method
+    function MyClass:set_value(val)
+        self.value = val
+    end
+
+    -- Metamethod for operator `+`
+    function MyClass:__add(other)
+        return MyClass(self.value + other.value)
+    end
+
+    -- Default value
+    MyClass.value = 0
+
+Classes can be instantiated by calling the prototype like a function, or less commonly,
+by using `class.init` or `class.copy`. Here, `obj` is a table with `MyClass` as its
+metatable, i.e. an "instance" or "object" of `MyClass`.
+
+    local obj = MyClass(5)
+    assert(obj.value == 5)
+
+    obj:set_value(7)
+    assert(obj.value == 7)
+    assert((obj + MyClass(10)).value == 17)
+
+    obj:set_value(nil) -- `obj.value` is actually nil...
+    assert(obj.value == 0) -- ... but uses the class's default value of 0.
+
+When a class is instantiated, it calls the class's constructor. For `class.init` or most
+calls to the prototype, this calls the metamethod `__init`, which should set up the class.
+
+Alternatively, when using `class.copy`, `class.copy_into`, or calling the prototype with one
+parameter of the same type as the class being instantiated, the instance is being copied from
+another. Normally, it suffices to let this class library do the copying automatically, but
+sometimes more advanced behavior is necessary.
+
+The behavior of copying an instance changes depending on the value of the `__copy` metafield.
+If `__copy` is not present, the object is simply deep copied with `class.copy`. If it is set
+to the string "ref", the object will not be copied and will return a reference to the original
+table. If it is a function, that function is called, which should copy the table by itself.
+
+    local copy = MyClass(obj)
+    assert(copy.value == obj.value)
+
+    -- If `__copy = "ref`:
+    print(copy == obj) -- Outputs `true`
+    -- Otherwise:
+    print(copy == obj) -- Outputs `false`
+
+    -- Example of `__copy` function.
+    -- This has essentially the same behavior as the defaultly provided deep copy behavior
+    function MyClass:__copy(other)
+        self.value = class.copy(other.value)
+    end
+
+Some Lua metamethods (like the previously seen `__add`) may be set on the prototype. Others
+are restricted because they would mess up class usage. The allowed metamethods are arithmetic
+and comparison operators, `__tostring`, `__call`, and `__newindex`. `__index` may be used if
+it is a function and returns the class prototype after the special cases:
+
+    function MyClass:__index(k)
+        if k == "value" then
+            return "None of your business!"
+        end
+        return MyClass -- Without this, method calls and default values will not work
+    end
+
+Finally, (multiple) inheritance is also possible. Constructors of base classes will not be
+called automatically, so they must be called manually in the derived class's constructor.
+
+    local DerivedClass = class.new("DerivedClass", MyClass)
+    function DerivedClass:__init(val, special_val)
+        MyClass.__init(self, val)
+        self.special_value = special_val
+    end
+
+    function DerivedClass:set_special_value(val)
+        self.special_value = val
+    end
+
+    local d = DerivedClass(10, 5)
+
+    assert(d.value == 10)
+    assert(d.special_value == 5)
+
+    d:set_special_value(3)
+    assert(d.special_value == 3)
+
+Functions:
+
+The argument `cls` denotes a class prototype returned by `class.new`. The argument `obj` means
+an instantiation of a class. `cls_or_obj` means either can be provided.
+
+* `class.new(name[, ...])`: Returns a new class prototype ready for population with methods.
+    * `name`: The name of the class. This should usually match the return variable name.
+      For instance, if the class `Class` is in the global table `mymod` (i.e. `mymod.Class`),
+      then the name should be "mymod.Class".
+    * `...` (optional): Class prototype(s) to inherit from. Methods and default values will be
+      copied into the new class. If there are conflicting methods or default values, the ones
+      in the classes put earlier in the list will overwrite the ones put later in the list.
+    * The resulting table has a `__call` metamethod for class instantiation. If one argument
+      is provided of the same type as or is derived from this class, `class.copy` will be used
+      to instantiate the class. Otherwise, `class.init` will be used.
+* `class.init(cls[, ...])`: Instantiates and returns an object, calling the normal constructor.
+    * `cls`: The class to construct an instance of.
+    * `...` (optional)`: Arguments to provide to the class's `__init` constructor.
+    * It is usually preferred to use the class's `__call` metamethod to instantiate the class,
+      but this can be used if the copy constructor should not be called.
+* `class.copy(obj[, bypass_ctor])`: Returns a deep copy of the provided class or value.
+    * `obj`: The object or value to make a deep copy of.
+        * While this is usually used on a class instance, it can be any value, like a plain
+          table, string, or number.
+        * All values are deep copied with a few exceptions that are left as references:
+          functions, coroutines, and userdata (which can't be copied), metatables, and tables
+          with the metafield `__copy` set to "ref".
+        * If a class has the metafield `__copy` set to a function, that copy constructor is
+          called instead of making a deep copy.
+    * `bypass_ctor` (optional): If true and `obj` has the `__copy` metafield set to a function,
+      it will not be called. This should be used if `table.copy` is called on an object from
+      inside it's own copy constructor to prevent infinite recursion.
+* `class.copy_into(obj, into[, bypass_ctor])`: Makes a deep copy of `obj`, placing all copied
+  keys into `into` instead of returning a new table.
+    * The same stipulations as `class.copy` apply, although `obj` and `into` must be tables
+      or objects since other types do not have keys.
+    * `obj`: The table or object to copy from.
+    * `into`: The table or object to copy into.
+* `class.instantiate(cls)`: Instantiates and returns a class without calling any constructors.
+    * This function should rarely be used. Calling with constructors is almost always better.
+    * `cls`: The class to construct an instance of.
+* `class.name(cls_or_obj)`: Returns the name of the class set with `class.new`.
+    * `cls_or_obj`: The class or object to get the name of.
+* `class.prototype(cls_or_obj)`: Returns the class prototype of an instance.
+    * `cls_or_obj`: The object or class to get the prototype of. If a prototype is passed, it
+      returns itself. `nil` is returned if it is neither.
+    * To check if an object is an instantiation of a specific class, use `class.is` to
+      properly account for inheritance.
+* `class.is(cls_or_obj, cls)`: Returns whether a class or object is an instance of or
+  inherited from another class.
+    * `cls_or_obj`: The class or object to check instantiation or inheritance of.
+    * `cls`: The class to compare against.
+* `class.cast(obj, cls)`: Casts an object in place from one prototype to another.
+    * No constructors are called, and members are left untouched. This function is best for
+      casting an object up or down the inheritance tree when methods differ.
+    * `obj`: The object to cast.
+    * `cls`: The prototype to cast the object to.
 
 
 
@@ -7641,12 +7812,12 @@ Used by `minetest.register_node`.
         -- intensity: 1.0 = mid range of regular TNT.
         -- If defined, called when an explosion touches the node, instead of
         -- removing the node.
-        
+
         mod_origin = "modname",
         -- stores which mod actually registered a node
         -- if it can not find a source, returns "??"
         -- useful for getting what mod truly registered something
-        -- example: if a node is registered as ":othermodname:nodename", 
+        -- example: if a node is registered as ":othermodname:nodename",
         -- nodename will show "othermodname", but mod_orgin will say "modname"
     }
 

--- a/games/devtest/mods/unittests/classes.lua
+++ b/games/devtest/mods/unittests/classes.lua
@@ -1,0 +1,291 @@
+local function test_basic()
+	local Vector = class.new("Vector")
+	-- Constructor
+	function Vector:__init(x, y, z)
+		self.x = x
+		self.y = y
+		self.z = z
+	end
+
+	-- Copy constructor
+	function Vector:__copy(other)
+		self.x = other.x
+		self.y = other.y
+		self.z = other.z
+		self.copied = true
+	end
+
+	-- Operator overloading
+	function Vector:__add(other)
+		return Vector(
+			self.x + other.x,
+			self.y + other.y,
+			self.z + other.z
+		)
+	end
+
+	-- Mutating in-place function
+	function Vector:floor()
+		self.x = math.floor(self.x)
+		self.y = math.floor(self.y)
+		self.z = math.floor(self.z)
+	end
+
+	-- Returning function
+	function Vector:__tostring()
+		local copied = ""
+		if self.copied then
+			copied = "c"
+		end
+		return copied .. "(" .. self.x .. ", " .. self.y .. ", " .. self.z .. ")"
+	end
+
+	-- Default value
+	Vector.z = 0
+
+	local v1 = Vector(1, 2, 3)
+	local v2 = Vector(5.5, 6.8, 7.1)
+
+	assert(tostring(v1 + v2) == "(6.5, 8.8, 10.1)")
+
+	v2:floor()
+	assert(v2.x == 5 and v2.y == 6 and v2.z == 7)
+
+	assert(tostring(Vector(v1)) == "c(1, 2, 3)")
+
+	assert(Vector(1, 2).z == 0)
+end
+
+local function test_inheritance()
+	-- Base class
+	local A = class.new("A")
+	function A:a()
+		return "A:a"
+	end
+
+	function A:ab()
+		return "A:ab"
+	end
+
+	function A:ax()
+		return "A:ax"
+	end
+
+	function A:abx()
+		return "A:abx"
+	end
+
+	-- Since inheritance
+	local AX = class.new("AX", A)
+	function AX:x()
+		return "AX:x"
+	end
+
+	function AX:ax()
+		return "AX:ax"
+	end
+
+	-- Base class
+	local B = class.new("B")
+	function B:b()
+		return "B:b"
+	end
+
+	function B:ab()
+		return "B:ab"
+	end
+
+	function B:abx()
+		return "B:abx"
+	end
+
+	-- Multiple inheritance
+	local ABX = class.new("ABX", B, A)
+	function ABX:x()
+		return "ABX:x"
+	end
+
+	function ABX:abx()
+		return "ABX:abx"
+	end
+
+	-- Test them
+	local a = A()
+	assert(a:a() == "A:a")
+	assert(a:ab() == "A:ab")
+	assert(a:ax() == "A:ax")
+	assert(a:abx() == "A:abx")
+	assert(class.name(a) == "A" and class.name(A) == "A")
+	assert(class.prototype(a) == A and class.prototype(A) == A)
+	assert(class.is(a, A) and class.is(A, A))
+
+	class.cast(a, AX)
+	assert(a:ax() == "AX:ax")
+
+	local ax = AX()
+	assert(ax:a() == "A:a")
+	assert(ax:x() == "AX:x")
+	assert(ax:ax() == "AX:ax") -- Overwritten
+	assert(class.name(ax) == "AX" and class.name(AX) == "AX")
+	assert(class.prototype(ax) == AX and class.prototype(AX) == AX)
+	assert(class.is(ax, AX) and class.is(AX, AX) and
+			class.is(ax, A) and class.is(AX, A))
+
+	class.cast(ax, A)
+	assert(class.prototype(ax) == A)
+	assert(ax:ax() == "A:ax")
+
+	local b = B()
+	assert(b:b() == "B:b")
+	assert(b:ab() == "B:ab")
+	assert(b:abx() == "B:abx")
+	assert(class.name(b) == "B" and class.name(B) == "B")
+	assert(class.prototype(b) == B and class.prototype(B) == B)
+	assert(class.is(b, B) and class.is(B, B))
+
+	local abx = ABX()
+	assert(abx:a() == "A:a")
+	assert(abx:b() == "B:b")
+	assert(abx:ab() == "B:ab") -- Overwritten
+	assert(abx:x() == "ABX:x")
+	assert(abx:abx() == "ABX:abx") -- Overwritten
+	assert(class.name(abx) == "ABX" and class.name(ABX) == "ABX")
+	assert(class.prototype(abx) == ABX and class.prototype(ABX) == ABX)
+	assert(class.is(abx, ABX) and class.is(ABX, ABX) and
+			class.is(abx, A) and class.is(ABX, A) and
+			class.is(abx, B) and class.is(ABX, B))
+
+	class.cast(abx, A)
+	assert(class.prototype(abx) == A)
+	assert(abx:ab() == "A:ab")
+	assert(abx:abx() == "A:abx")
+
+	class.cast(abx, B)
+	assert(class.prototype(abx) == B)
+	assert(abx:ab() == "B:ab")
+	assert(abx:abx() == "B:abx")
+
+	assert(class.prototype({}) == nil)
+end
+
+local function test_copying()
+	-- Copies with the default deep copy
+	local DeepCopy = class.new("DeepCopy")
+	function DeepCopy:__init()
+		self.param = {1, {2, {3}}}
+	end
+
+	-- Copies with a custom copy constructor which does a shallow copy only of itself
+	local ShallowCopy = class.new("ShallowCopy")
+	function ShallowCopy:__init()
+		self.param = {1, {2, {3}}}
+	end
+
+	function ShallowCopy:__copy(other)
+		self.param = other.param
+	end
+
+	-- Does not copy at all
+	local Ref = class.new("Ref")
+	function Ref:__init()
+		self.param = {1, {2, {3}}}
+	end
+	Ref.__copy = "ref"
+
+	-- Has all sorts of copiable and non-copiable types, copied via the default deep copy
+	local Copy = class.new("Copy")
+	function Copy:__init(some_value)
+		-- Note: For all these tables, values on the same level must be unique.
+		self.some_value = some_value
+
+		local reref = {"a", "b", "c"}
+
+		-- A large testing table
+		self.some_table = {
+			-- Test normal values
+			boolean = true,
+			number = 7,
+			string = "x",
+
+			-- Test nested tables
+			table = {
+				nest = {
+					value = 6,
+				},
+				array = {1, 2, 5}
+			},
+
+			-- Repeated references
+			once = reref,
+			twice = reref,
+			thrice = reref,
+
+			-- Test classes
+			deep = DeepCopy(),
+			shallow = ShallowCopy(),
+			ref = Ref(),
+
+			-- Test non-copiables
+			userdata = PseudoRandom(123),
+			func = function() end
+		}
+
+		-- Another table with cross references
+		self.other_table = {
+			ref = self.some_table,
+			whatever = {
+				true,
+				3.14159,
+				"pi",
+			},
+		}
+
+		-- Add cross references to the original table to make a circular reference
+		self.some_table.ref = self.other_table
+	end
+
+	local a1 = Copy()
+	local a2 = Copy(a1)
+
+	local function equal(val1, val2, seen)
+		if type(val1) == "table" then
+			if seen[val1] then
+				return true
+			end
+			seen[val1] = true
+
+			local mt1 = getmetatable(val1)
+			assert(mt1 == getmetatable(val2))
+
+			if mt1 then
+				if mt1.__copy == "ref" then -- Plain reference
+					assert(val1 == val2)
+				elseif type(mt1.__copy) == "function" then -- Shallow copy
+					for k, v in pairs(val1) do
+						assert(v == val2[k])
+					end
+
+					return true
+				end
+			else
+				assert(val1 ~= val2)
+			end
+
+			for k, v in pairs(val1) do
+				assert(equal(v, val2[k], seen))
+			end
+
+			return true
+		else
+			return val1 == val2
+		end
+	end
+
+	assert(equal(a1, a2, {}))
+end
+
+function unittests.test_classes()
+	test_basic()
+	test_inheritance()
+	test_copying()
+end

--- a/games/devtest/mods/unittests/init.lua
+++ b/games/devtest/mods/unittests/init.lua
@@ -6,11 +6,13 @@ dofile(modpath .. "/player.lua")
 dofile(modpath .. "/crafting_prepare.lua")
 dofile(modpath .. "/crafting.lua")
 dofile(modpath .. "/itemdescription.lua")
+dofile(modpath .. "/classes.lua")
 
 if minetest.settings:get_bool("devtest_unittests_autostart", false) then
 	unittests.test_random()
 	unittests.test_crafting()
 	unittests.test_short_desc()
+	unittests.test_classes()
 	minetest.register_on_joinplayer(function(player)
 		unittests.test_player(player)
 	end)


### PR DESCRIPTION
Lua has no consistent way to use OOP, leading to many home-baked solutions in mods, all of which are more or less incompatible.  Seeing as metatable-based classes are common enough, this PR adds helper functions to create metatable-based classes including support for inheritance and automatic deep copying of classes.

If this PR needs more justification, the engine likely will have some Lua metatable-based classes with the formspec replacement, and custom elements will require inheritance and deep copying.  So, either this PR (or a similar one) goes through, or the GUI will have to bake its own solution anyway.  So, we might as well make a standard solution beforehand.

Documentation can be seen in the changes to `lua_api.txt`.

## To do

This PR is Ready for Review.

## How to test

A unit test has been added to devtest.  Enable unit testing, and ensure it doesn't fail.
