### PR TITLE
Android: Update Gradle, NDK, Build Tools, and SQLite version

### DIFF
--- a/build/android/app/build.gradle
+++ b/build/android/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 android {
 	compileSdkVersion 29
-	buildToolsVersion '30.0.2'
-	ndkVersion '21.3.6528147'
+	buildToolsVersion '30.0.3'
+	ndkVersion '22.0.7026061'
 	defaultConfig {
 		applicationId 'net.minetest.minetest'
 		minSdkVersion 16

--- a/build/android/build.gradle
+++ b/build/android/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:4.0.1'
+		classpath 'com.android.tools.build:gradle:4.1.1'
 		classpath 'de.undercouch:gradle-download-task:4.1.1'
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/build/android/gradle/wrapper/gradle-wrapper.properties
+++ b/build/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 07 22:11:10 CEST 2020
+#Fri Jan 08 17:52:00 UTC 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip

--- a/build/android/native/build.gradle
+++ b/build/android/native/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'de.undercouch.download'
 
 android {
 	compileSdkVersion 29
-	buildToolsVersion '30.0.2'
-	ndkVersion '21.3.6528147'
+	buildToolsVersion '30.0.3'
+	ndkVersion '22.0.7026061'
 	defaultConfig {
 		minSdkVersion 16
 		targetSdkVersion 29
@@ -71,7 +71,7 @@ task getDeps(dependsOn: downloadDeps, type: Copy) {
 }
 
 // get sqlite
-def sqlite_ver = '3320200'
+def sqlite_ver = '3340000'
 task downloadSqlite(dependsOn: getDeps, type: Download) {
 	src 'https://www.sqlite.org/2020/sqlite-amalgamation-' + sqlite_ver + '.zip'
 	dest new File(buildDir, 'sqlite.zip')


### PR DESCRIPTION
This PR updates Gradle, NDK, Build Tools, and SQLite version for Android build.

- Android Build Tools: 30.0.2 -> 30.0.3
- Android NDK: 21.3.6528147 -> 22.0.7026061
- Gradle: 6.6.1 -> 6.8
- Android Gradle plugin (for Build Tools): 4.0.1 -> 4.1.1
- SQLite: 3.32.2 -> 3.34.0

GitHub Actions needs NDK to be updated.

This PR is a Ready for Review.

## How to test
- Make sure that this can compile successfully.
- Nothing breaks.