### PR TITLE
Settings: Push groups in to_table as well

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -590,6 +590,8 @@ bool Settings::exists(const std::string &name) const
 
 std::vector<std::string> Settings::getNames() const
 {
+	MutexAutoLock lock(m_mutex);
+
 	std::vector<std::string> names;
 	for (const auto &settings_it : m_settings) {
 		names.push_back(settings_it.first);

--- a/src/settings.h
+++ b/src/settings.h
@@ -234,6 +234,8 @@ private:
 
 	// Allow TestSettings to run sanity checks using private functions.
 	friend class TestSettings;
+	// For sane mutex locking when iterating
+	friend class LuaSettings;
 
 	void updateNoLock(const Settings &other);
 	void clearNoLock();


### PR DESCRIPTION
Fixes #10831

## To do

This PR is Ready for Review.


## How to test

minetest.conf:
```
test = {
	group = true
	value = 123
	nested = {
		yes = it is nested
		420 = numeric key
	}
}
```
Mod:
```
-- Delay until after alpha texture warnings
minetest.after(1, function()
	local val = minetest.settings:to_table()
	
	print(dump(val["test"]))
end)
```
Wanted output:
```
{
        nested = {
                ["420"] = "numeric key",
                yes = "it is nested"
        },
        group = "true",
        value = "123"
}
```
\+ `minetest --run-unittests` must pass
