### PR TITLE
Remove dead code

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -216,12 +216,6 @@ void Client::loadMods()
 		m_script->on_minimap_ready(m_minimap);
 }
 
-bool Client::checkBuiltinIntegrity()
-{
-	// TODO
-	return true;
-}
-
 void Client::scanModSubfolder(const std::string &mod_name, const std::string &mod_path,
 			std::string mod_subpath)
 {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -159,20 +159,6 @@ void Client::loadMods()
 	scanModIntoMemory(BUILTIN_MOD_NAME, getBuiltinLuaPath());
 	m_script->loadModFromMemory(BUILTIN_MOD_NAME);
 
-	// TODO Uncomment when server-sent CSM and verifying of builtin are complete
-	/*
-	// Don't load client-provided mods if disabled by server
-	if (checkCSMRestrictionFlag(CSMRestrictionFlags::CSM_RF_LOAD_CLIENT_MODS)) {
-		warningstream << "Client-provided mod loading is disabled by server." <<
-			std::endl;
-		// If builtin integrity is wrong, disconnect user
-		if (!checkBuiltinIntegrity()) {
-			// TODO disconnect user
-		}
-		return;
-	}
-	*/
-
 	ClientModConfiguration modconf(getClientModsLuaPath());
 	m_mods = modconf.getMods();
 	// complain about mods with unsatisfied dependencies

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -415,11 +415,6 @@ public:
 		return m_csm_restriction_flags & flag;
 	}
 
-	u32 getCSMNodeRangeLimit() const
-	{
-		return m_csm_restriction_noderange;
-	}
-
 	inline std::unordered_map<u32, u32> &getHUDTranslationMap()
 	{
 		return m_hud_server_to_client;
@@ -437,7 +432,6 @@ public:
 	}
 private:
 	void loadMods();
-	bool checkBuiltinIntegrity();
 
 	// Virtual methods from con::PeerHandler
 	void peerAdded(con::Peer *peer) override;
@@ -587,7 +581,6 @@ private:
 
 	// Client modding
 	ClientScripting *m_script = nullptr;
-	bool m_modding_enabled;
 	std::unordered_map<std::string, ModMetadata *> m_mod_storages;
 	float m_mod_storage_save_timer = 10.0f;
 	std::vector<ModSpec> m_mods;

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -334,13 +334,6 @@ GenericCAO* ClientEnvironment::getGenericCAO(u16 id)
 	return NULL;
 }
 
-bool isFreeClientActiveObjectId(const u16 id,
-	ClientActiveObjectMap &objects)
-{
-	return id != 0 && objects.find(id) == objects.end();
-
-}
-
 u16 ClientEnvironment::addActiveObject(ClientActiveObject *object)
 {
 	// Register object. If failed return zero id

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -571,8 +571,6 @@ void Hud::drawCompassTranslate(HudElement *e, video::ITexture *texture,
 void Hud::drawCompassRotate(HudElement *e, video::ITexture *texture,
 		const core::rect<s32> &rect, int angle)
 {
-	core::dimension2di imgsize(texture->getOriginalSize());
-
 	core::rect<s32> oldViewPort = driver->getViewPort();
 	core::matrix4 oldProjMat = driver->getTransform(video::ETS_PROJECTION);
 	core::matrix4 oldViewMat = driver->getTransform(video::ETS_VIEW);

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1176,13 +1176,6 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 		}
 
 		if (m_mesh[layer]) {
-#if 0
-			// Usually 1-700 faces and 1-7 materials
-			std::cout << "Updated MapBlock has " << fastfaces_new.size()
-					<< " faces and uses " << m_mesh[layer]->getMeshBufferCount()
-					<< " materials (meshbuffers)" << std::endl;
-#endif
-
 			// Use VBO for mesh (this just would set this for ever buffer)
 			if (m_enable_vbo)
 				m_mesh[layer]->setHardwareMappingHint(scene::EHM_STATIC);

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -125,8 +125,6 @@ public:
 			m_animation_force_timer--;
 	}
 
-	void updateCameraOffset(v3s16 camera_offset);
-
 private:
 	scene::IMesh *m_mesh[MAX_TILE_LAYERS];
 	MinimapMapblock *m_minimap_mapblock;

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -40,7 +40,6 @@ struct QueuedMeshUpdate
 {
 	v3s16 p = v3s16(-1337, -1337, -1337);
 	bool ack_block_to_server = false;
-	bool urgent = false;
 	int crack_level = -1;
 	v3s16 crack_pos;
 	MeshMakeData *data = nullptr; // This is generated in MeshUpdateQueue::pop()

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -138,7 +138,6 @@ public:
 	size_t getMaxModeIndex() const { return m_modes.size() - 1; };
 	void nextMode();
 
-	void setModesFromString(std::string modes_string);
 	MinimapModeDef getModeDef() const { return data->mode; }
 
 	video::ITexture *getMinimapTexture();

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -449,7 +449,6 @@ TextureSource::TextureSource()
 	// for these settings to take effect
 	m_setting_trilinear_filter = g_settings->getBool("trilinear_filter");
 	m_setting_bilinear_filter = g_settings->getBool("bilinear_filter");
-	g_settings->getBool("anisotropic_filter");
 }
 
 TextureSource::~TextureSource()

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -429,7 +429,6 @@ private:
 	// Cached settings needed for making textures from meshes
 	bool m_setting_trilinear_filter;
 	bool m_setting_bilinear_filter;
-	bool m_setting_anisotropic_filter;
 };
 
 IWritableTextureSource *createTextureSource()
@@ -450,7 +449,7 @@ TextureSource::TextureSource()
 	// for these settings to take effect
 	m_setting_trilinear_filter = g_settings->getBool("trilinear_filter");
 	m_setting_bilinear_filter = g_settings->getBool("bilinear_filter");
-	m_setting_anisotropic_filter = g_settings->getBool("anisotropic_filter");
+	g_settings->getBool("anisotropic_filter");
 }
 
 TextureSource::~TextureSource()

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -396,7 +396,7 @@ int EmergeManager::getGroundLevelAtPoint(v2s16 p)
 // TODO(hmmmm): Move this to ServerMap
 bool EmergeManager::isBlockUnderground(v3s16 blockpos)
 {
-	// Use a simple heuristic; the above method is wildly inaccurate anyway.
+	// Use a simple heuristic
 	return blockpos.Y * (MAP_BLOCKSIZE + 1) <= mgparams->water_level;
 }
 

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -396,13 +396,6 @@ int EmergeManager::getGroundLevelAtPoint(v2s16 p)
 // TODO(hmmmm): Move this to ServerMap
 bool EmergeManager::isBlockUnderground(v3s16 blockpos)
 {
-#if 0
-	v2s16 p = v2s16((blockpos.X * MAP_BLOCKSIZE) + MAP_BLOCKSIZE / 2,
-					(blockpos.Y * MAP_BLOCKSIZE) + MAP_BLOCKSIZE / 2);
-	int ground_level = getGroundLevelAtPoint(p);
-	return blockpos.Y * (MAP_BLOCKSIZE + 1) <= min(water_level, ground_level);
-#endif
-
 	// Use a simple heuristic; the above method is wildly inaccurate anyway.
 	return blockpos.Y * (MAP_BLOCKSIZE + 1) <= mgparams->water_level;
 }

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -72,11 +72,6 @@ public:
 	SettingNotFoundException(const std::string &s): BaseException(s) {}
 };
 
-class InvalidFilenameException : public BaseException {
-public:
-	InvalidFilenameException(const std::string &s): BaseException(s) {}
-};
-
 class ItemNotFoundException : public BaseException {
 public:
 	ItemNotFoundException(const std::string &s): BaseException(s) {}

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -401,21 +401,6 @@ void GetRecursiveSubPaths(const std::string &path,
 	}
 }
 
-bool DeletePaths(const std::vector<std::string> &paths)
-{
-	bool success = true;
-	// Go backwards to succesfully delete the output of GetRecursiveSubPaths
-	for(int i=paths.size()-1; i>=0; i--){
-		const std::string &path = paths[i];
-		bool did = DeleteSingleFileOrEmptyDirectory(path);
-		if(!did){
-			errorstream<<"Failed to delete "<<path<<std::endl;
-			success = false;
-		}
-	}
-	return success;
-}
-
 bool RecursiveDeleteContent(const std::string &path)
 {
 	infostream<<"Removing content of \""<<path<<"\""<<std::endl;

--- a/src/filesys.h
+++ b/src/filesys.h
@@ -85,9 +85,6 @@ void GetRecursiveSubPaths(const std::string &path,
 		  bool list_files,
 		  const std::set<char> &ignore = {});
 
-// Tries to delete all, returns false if any failed
-bool DeletePaths(const std::vector<std::string> &paths);
-
 // Only pass full paths to this one. True on success.
 bool RecursiveDeleteContent(const std::string &path);
 

--- a/src/gui/guiButtonItemImage.cpp
+++ b/src/gui/guiButtonItemImage.cpp
@@ -39,7 +39,6 @@ GUIButtonItemImage::GUIButtonItemImage(gui::IGUIEnvironment *environment,
 			item, getActiveFont(), client);
 	sendToBack(m_image);
 
-	m_item_name = item;
 	m_client = client;
 }
 

--- a/src/gui/guiButtonItemImage.h
+++ b/src/gui/guiButtonItemImage.h
@@ -42,7 +42,6 @@ public:
 			Client *client);
 
 private:
-	std::string m_item_name;
 	Client *m_client;
 	GUIItemImage *m_image;
 };

--- a/src/gui/guiChatConsole.h
+++ b/src/gui/guiChatConsole.h
@@ -68,8 +68,6 @@ public:
 	// Irrlicht draw method
 	virtual void draw();
 
-	bool canTakeFocus(gui::IGUIElement* element) { return false; }
-
 	virtual bool OnEvent(const SEvent& event);
 
 	virtual void setVisible(bool visible);

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -486,8 +486,6 @@ void GUIEngine::drawHeader(video::IVideoDriver *driver)
 		splashrect += v2s32((screensize.Width/2)-(splashsize.X/2),
 				((free_space/2)-splashsize.Y/2)+10);
 
-	video::SColor bgcolor(255,50,50,50);
-
 	draw2DImageFilterScaled(driver, texture, splashrect,
 		core::rect<s32>(core::position2d<s32>(0,0),
 		core::dimension2di(texture->getOriginalSize())),

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3505,8 +3505,6 @@ bool GUIFormSpecMenu::getAndroidUIInput()
 
 GUIInventoryList::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 {
-	core::rect<s32> imgrect(0, 0, imgsize.X, imgsize.Y);
-
 	for (const GUIInventoryList *e : m_inventorylists) {
 		s32 item_index = e->getItemIndexAtPos(p);
 		if (item_index != -1)
@@ -3837,7 +3835,7 @@ ItemStack GUIFormSpecMenu::verifySelectedItem()
 	return ItemStack();
 }
 
-void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode=quit_mode_no)
+void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 {
 	if(m_text_dst)
 	{

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -253,7 +253,7 @@ public:
 	void updateSelectedItem();
 	ItemStack verifySelectedItem();
 
-	void acceptInput(FormspecQuitMode quitmode);
+	void acceptInput(FormspecQuitMode quitmode=quit_mode_no);
 	bool preprocessEvent(const SEvent& event);
 	bool OnEvent(const SEvent& event);
 	bool doPause;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1383,8 +1383,6 @@ void ServerMap::finishBlockMake(BlockMakeData *data,
 	v3s16 bpmin = data->blockpos_min;
 	v3s16 bpmax = data->blockpos_max;
 
-	v3s16 extra_borders(1, 1, 1);
-
 	bool enable_mapgen_debug_info = m_emerge->enable_mapgen_debug_info;
 	EMERGE_DBG_OUT("finishBlockMake(): " PP(bpmin) " - " PP(bpmax));
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -530,23 +530,6 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 	u32 liquid_loop_max = g_settings->getS32("liquid_loop_max");
 	u32 loop_max = liquid_loop_max;
 
-#if 0
-
-	/* If liquid_loop_max is not keeping up with the queue size increase
-	 * loop_max up to a maximum of liquid_loop_max * dedicated_server_step.
-	 */
-	if (m_transforming_liquid.size() > loop_max * 2) {
-		// "Burst" mode
-		float server_step = g_settings->getFloat("dedicated_server_step");
-		if (m_transforming_liquid_loop_count_multiplier - 1.0 < server_step)
-			m_transforming_liquid_loop_count_multiplier *= 1.0 + server_step / 10;
-	} else {
-		m_transforming_liquid_loop_count_multiplier = 1.0;
-	}
-
-	loop_max *= m_transforming_liquid_loop_count_multiplier;
-#endif
-
 	while (m_transforming_liquid.size() != 0)
 	{
 		// This should be done here so that it is done when continue is used
@@ -1302,18 +1285,6 @@ ServerMap::~ServerMap()
 	*/
 	delete dbase;
 	delete dbase_ro;
-
-#if 0
-	/*
-		Free all MapChunks
-	*/
-	core::map<v2s16, MapChunk*>::Iterator i = m_chunks.getIterator();
-	for(; i.atEnd() == false; i++)
-	{
-		MapChunk *chunk = i.getNode()->getValue();
-		delete chunk;
-	}
-#endif
 }
 
 MapgenParams *ServerMap::getMapgenParams()
@@ -1401,25 +1372,6 @@ bool ServerMap::initBlockMake(v3s16 blockpos, BlockMakeData *data)
 
 	data->vmanip = new MMVManip(this);
 	data->vmanip->initialEmerge(full_bpmin, full_bpmax);
-
-	// Note: we may need this again at some point.
-#if 0
-	// Ensure none of the blocks to be generated were marked as
-	// containing CONTENT_IGNORE
-	for (s16 z = blockpos_min.Z; z <= blockpos_max.Z; z++) {
-		for (s16 y = blockpos_min.Y; y <= blockpos_max.Y; y++) {
-			for (s16 x = blockpos_min.X; x <= blockpos_max.X; x++) {
-				core::map<v3s16, u8>::Node *n;
-				n = data->vmanip->m_loaded_blocks.find(v3s16(x, y, z));
-				if (n == NULL)
-					continue;
-				u8 flags = n->getValue();
-				flags &= ~VMANIP_BLOCK_CONTAINS_CIGNORE;
-				n->setValue(flags);
-			}
-		}
-	}
-#endif
 
 	// Data is ready now.
 	return true;
@@ -1524,116 +1476,6 @@ MapSector *ServerMap::createSector(v2s16 p2d)
 
 	return sector;
 }
-
-#if 0
-/*
-	This is a quick-hand function for calling makeBlock().
-*/
-MapBlock * ServerMap::generateBlock(
-		v3s16 p,
-		std::map<v3s16, MapBlock*> &modified_blocks
-)
-{
-	bool enable_mapgen_debug_info = g_settings->getBool("enable_mapgen_debug_info");
-
-	TimeTaker timer("generateBlock");
-
-	//MapBlock *block = original_dummy;
-
-	v2s16 p2d(p.X, p.Z);
-	v2s16 p2d_nodes = p2d * MAP_BLOCKSIZE;
-
-	/*
-		Do not generate over-limit
-	*/
-	if(blockpos_over_limit(p))
-	{
-		infostream<<FUNCTION_NAME<<": Block position over limit"<<std::endl;
-		throw InvalidPositionException("generateBlock(): pos. over limit");
-	}
-
-	/*
-		Create block make data
-	*/
-	BlockMakeData data;
-	initBlockMake(&data, p);
-
-	/*
-		Generate block
-	*/
-	{
-		TimeTaker t("mapgen::make_block()");
-		mapgen->makeChunk(&data);
-		//mapgen::make_block(&data);
-
-		if(enable_mapgen_debug_info == false)
-			t.stop(true); // Hide output
-	}
-
-	/*
-		Blit data back on map, update lighting, add mobs and whatever this does
-	*/
-	finishBlockMake(&data, modified_blocks);
-
-	/*
-		Get central block
-	*/
-	MapBlock *block = getBlockNoCreateNoEx(p);
-
-#if 0
-	/*
-		Check result
-	*/
-	if(block)
-	{
-		bool erroneus_content = false;
-		for(s16 z0=0; z0<MAP_BLOCKSIZE; z0++)
-		for(s16 y0=0; y0<MAP_BLOCKSIZE; y0++)
-		for(s16 x0=0; x0<MAP_BLOCKSIZE; x0++)
-		{
-			v3s16 p(x0,y0,z0);
-			MapNode n = block->getNode(p);
-			if(n.getContent() == CONTENT_IGNORE)
-			{
-				infostream<<"CONTENT_IGNORE at "
-						<<"("<<p.X<<","<<p.Y<<","<<p.Z<<")"
-						<<std::endl;
-				erroneus_content = true;
-				assert(0);
-			}
-		}
-		if(erroneus_content)
-		{
-			assert(0);
-		}
-	}
-#endif
-
-#if 0
-	/*
-		Generate a completely empty block
-	*/
-	if(block)
-	{
-		for(s16 z0=0; z0<MAP_BLOCKSIZE; z0++)
-		for(s16 x0=0; x0<MAP_BLOCKSIZE; x0++)
-		{
-			for(s16 y0=0; y0<MAP_BLOCKSIZE; y0++)
-			{
-				MapNode n;
-				n.setContent(CONTENT_AIR);
-				block->setNode(v3s16(x0,y0,z0), n);
-			}
-		}
-	}
-#endif
-
-	if(enable_mapgen_debug_info == false)
-		timer.stop(true); // Hide output
-
-	return block;
-}
-#endif
 
 MapBlock * ServerMap::createBlock(v3s16 p)
 {

--- a/src/map.h
+++ b/src/map.h
@@ -417,13 +417,7 @@ private:
 	bool m_map_saving_enabled;
 
 	int m_map_compression_level;
-#if 0
-	// Chunk size in MapSectors
-	// If 0, chunks are disabled.
-	s16 m_chunksize;
-	// Chunks
-	core::map<v2s16, MapChunk*> m_chunks;
-#endif
+
 	std::set<v3s16> m_chunks_in_progress;
 
 	/*

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -340,15 +340,6 @@ public:
 	// is not valid on this MapBlock.
 	bool isValidPositionParent(v3s16 p);
 	MapNode getNodeParent(v3s16 p, bool *is_valid_position = NULL);
-	void setNodeParent(v3s16 p, MapNode & n);
-
-	inline void drawbox(s16 x0, s16 y0, s16 z0, s16 w, s16 h, s16 d, MapNode node)
-	{
-		for (u16 z = 0; z < d; z++)
-		for (u16 y = 0; y < h; y++)
-		for (u16 x = 0; x < w; x++)
-			setNode(x0 + x, y0 + y, z0 + z, node);
-	}
 
 	// Copies data to VoxelManipulator to getPosRelative()
 	void copyTo(VoxelManipulator &dst);

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -792,7 +792,7 @@ void MapgenV6::flowMud(s16 &mudflow_minpos, s16 &mudflow_maxpos)
 		v3s16(0, 0, -1), // Front
 		v3s16(-1, 0, 0), // Left
 	};
-	
+
 	// Iterate twice
 	for (s16 k = 0; k < 2; k++) {
 		for (s16 z = mudflow_minpos; z <= mudflow_maxpos; z++)
@@ -1055,7 +1055,6 @@ void MapgenV6::growGrass() // Add surface nodes
 	MapNode n_dirt_with_grass(c_dirt_with_grass);
 	MapNode n_dirt_with_snow(c_dirt_with_snow);
 	MapNode n_snowblock(c_snowblock);
-	MapNode n_snow(c_snow);
 	const v3s16 &em = vm->m_area.getExtent();
 
 	u32 index = 0;

--- a/src/network/networkexceptions.h
+++ b/src/network/networkexceptions.h
@@ -56,12 +56,6 @@ public:
 	InvalidIncomingDataException(const char *s) : BaseException(s) {}
 };
 
-class InvalidOutgoingDataException : public BaseException
-{
-public:
-	InvalidOutgoingDataException(const char *s) : BaseException(s) {}
-};
-
 class NoIncomingDataException : public BaseException
 {
 public:

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -157,9 +157,8 @@ public:
 
 	ArrayGridNodeContainer(Pathfinder *pathf, v3s16 dimensions);
 	virtual PathGridnode &access(v3s16 p);
-private:
-	v3s16 m_dimensions;
 
+private:
 	int m_x_stride;
 	int m_y_stride;
 	std::vector<PathGridnode> m_nodes_array;
@@ -306,8 +305,6 @@ private:
 	int m_max_index_y = 0;            /**< max index of search area in y direction  */
 	int m_max_index_z = 0;            /**< max index of search area in z direction  */
 
-
-	int m_searchdistance = 0;         /**< max distance to search in each direction */
 	int m_maxdrop = 0;                /**< maximum number of blocks a path may drop */
 	int m_maxjump = 0;                /**< maximum number of blocks a path may jump */
 	int m_min_target_distance = 0;    /**< current smalest path to target           */
@@ -619,7 +616,6 @@ std::vector<v3s16> Pathfinder::getPath(v3s16 source,
 	std::vector<v3s16> retval;
 
 	//initialization
-	m_searchdistance = searchdistance;
 	m_maxjump = max_jump;
 	m_maxdrop = max_drop;
 	m_start       = source;

--- a/src/script/cpp_api/s_async.cpp
+++ b/src/script/cpp_api/s_async.cpp
@@ -158,35 +158,6 @@ void AsyncEngine::step(lua_State *L)
 }
 
 /******************************************************************************/
-void AsyncEngine::pushFinishedJobs(lua_State* L) {
-	// Result Table
-	MutexAutoLock l(resultQueueMutex);
-
-	unsigned int index = 1;
-	lua_createtable(L, resultQueue.size(), 0);
-	int top = lua_gettop(L);
-
-	while (!resultQueue.empty()) {
-		LuaJobInfo jobDone = resultQueue.front();
-		resultQueue.pop_front();
-
-		lua_createtable(L, 0, 2);  // Pre-allocate space for two map fields
-		int top_lvl2 = lua_gettop(L);
-
-		lua_pushstring(L, "jobid");
-		lua_pushnumber(L, jobDone.id);
-		lua_settable(L, top_lvl2);
-
-		lua_pushstring(L, "retval");
-		lua_pushlstring(L, jobDone.serializedResult.data(),
-			jobDone.serializedResult.size());
-		lua_settable(L, top_lvl2);
-
-		lua_rawseti(L, top, index++);
-	}
-}
-
-/******************************************************************************/
 void AsyncEngine::prepareEnvironment(lua_State* L, int top)
 {
 	for (StateInitializer &stateInitializer : stateInitializers) {

--- a/src/script/cpp_api/s_async.h
+++ b/src/script/cpp_api/s_async.h
@@ -98,12 +98,6 @@ public:
 	 */
 	void step(lua_State *L);
 
-	/**
-	 * Push a list of finished jobs onto the stack
-	 * @param L The Lua stack
-	 */
-	void pushFinishedJobs(lua_State *L);
-
 protected:
 	/**
 	 * Get a Job from queue to be processed

--- a/src/server.h
+++ b/src/server.h
@@ -564,9 +564,6 @@ private:
 	// Craft definition manager
 	IWritableCraftDefManager *m_craftdef;
 
-	// Event manager
-	EventManager *m_event;
-
 	// Mods
 	std::unique_ptr<ServerModManager> m_modmgr;
 

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -114,7 +114,6 @@ public:
 	void rightClick(ServerActiveObject *clicker);
 	void setHP(s32 hp, const PlayerHPChangeReason &reason);
 	void setHPRaw(u16 hp) { m_hp = hp; }
-	s16 readDamage();
 	u16 getBreath() const { return m_breath; }
 	void setBreath(const u16 breath, bool send = true);
 

--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -162,8 +162,6 @@ public:
 	{}
 	virtual const ItemGroupList &getArmorGroups() const
 	{ static ItemGroupList rv; return rv; }
-	virtual void setPhysicsOverride(float physics_override_speed, float physics_override_jump, float physics_override_gravity)
-	{}
 	virtual void setAnimation(v2f frames, float frame_speed, float frame_blend, bool frame_loop)
 	{}
 	virtual void getAnimation(v2f *frames, float *frame_speed, float *frame_blend, bool *frame_loop)
@@ -206,7 +204,6 @@ public:
 	}
 
 	std::string generateUpdateInfantCommand(u16 infant_id, u16 protocol_version);
-	std::string generateUpdateNametagAttributesCommand(const video::SColor &color) const;
 
 	void dumpAOMessagesToQueue(std::queue<ActiveObjectMessage> &queue);
 

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -190,14 +190,6 @@ enum ClearObjectsMode {
 		CLEAR_OBJECTS_MODE_QUICK,
 };
 
-/*
-	The server-side environment.
-
-	This is not thread-safe. Server uses an environment mutex.
-*/
-
-typedef std::unordered_map<u16, ServerActiveObject *> ServerActiveObjectMap;
-
 class ServerEnvironment : public Environment
 {
 public:
@@ -331,7 +323,7 @@ public:
 	{
 		return m_ao_manager.getObjectsInsideRadius(pos, radius, objects, include_obj_cb);
 	}
-	
+
 	// Find all active objects inside a box
 	void getObjectsInArea(std::vector<ServerActiveObject *> &objects, const aabb3f &box,
 			std::function<bool(ServerActiveObject *obj)> include_obj_cb)


### PR DESCRIPTION
There's a lot of unused code in Minetest - whether that be disabled using `#ifdef 0`, not called, or not defined at all.

This PR removes dead code whilst leaving unused code which may be useful in the future. Keeping dead code around is bad for code quality and can be a maintenance burden.

Let's not continue to hoard code from 2012

## To do

Ready for review

## How to test

See if build completes
