### PR TITLE
Allow server to use media from texture_path

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -89,9 +89,6 @@ The game directory can contain the following files:
   In the same format as the one in builtin.
   This settingtypes.txt will be parsed by the menu and the settings will be
   displayed in the "Games" category in the advanced settings tab.
-* If the game contains a folder called `textures` the server will load it as a
-  texturepack, overriding mod textures.
-  Any server texturepack will override mod textures and the game texturepack.
 
 Menu images
 -----------
@@ -400,6 +397,21 @@ stripping out the file extension:
 * e.g. `foomod_foothing.png`
 * e.g. `foomod_foothing`
 
+Texture Load Path
+-----------------
+
+Paths are relative to the directories listed in the [Paths] section above. Each
+location overrides those under it.
+
+### On singleplayer or server
+* Path defined in the texture_path setting
+* `textures/server`
+* `games/<gameid>/textures`
+* Mod Textures
+
+### On client
+* Path defined in the texture_path setting
+* Server populated data path
 
 Texture modifiers
 -----------------

--- a/doc/texture_packs.txt
+++ b/doc/texture_packs.txt
@@ -2,7 +2,7 @@ Minetest Texture Pack Reference
 ===============================
 
 Texture packs allow you to replace textures provided by a mod with your own
-textures.
+textures. See lua_api.txt for texture load path.
 
 Texture pack directory structure
 --------------------------------

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2496,6 +2496,7 @@ void Server::fillMediaCache()
 	// Collect all media file paths
 	std::vector<std::string> paths;
 	// The paths are ordered in descending priority
+	fs::GetRecursiveDirs(paths, g_settings->get("texture_path"));
 	fs::GetRecursiveDirs(paths, porting::path_user + DIR_DELIM + "textures" + DIR_DELIM + "server");
 	fs::GetRecursiveDirs(paths, m_gamespec.path + DIR_DELIM + "textures");
 	m_modmgr->getModsMediaPaths(paths);

--- a/textures/texture_packs_here.txt
+++ b/textures/texture_packs_here.txt
@@ -1,1 +1,2 @@
-Put your texture pack folders in this folder. Textures in the "server" pack will be used by the server.
+Put your texture pack folders in this folder. See texture_packs.txt for details.
+Textures in the "server" pack will be used by the server. See [Textures] in lua_api.txt for details.


### PR DESCRIPTION
Closes #6935

I kept the `textures/server` hard-coded path so that servers that use this path are not broken but I can remove it as well.

## To do

This PR is Ready for Review.
<!-- ^ delete one -->

## How to test

Set texture_path and start a server

1. Set texture_path
2. Place other texture packs in various other locations
2. Start a server
3. Connect a client to this server
4. Verify textures are prioritized based on added documentation.
