### PR TITLE
Allow toggling of texture pack by double clicking

### DIFF
--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -146,10 +146,25 @@ local function get_formspec(tabview, name, tabdata)
 end
 
 --------------------------------------------------------------------------------
+local function handle_doubleclick(pkg)
+	if pkg.type == "txp" then
+		if core.settings:get("texture_path") == pkg.path then
+			core.settings:set("texture_path", "")
+		else
+			core.settings:set("texture_path", pkg.path)
+		end
+		packages = nil
+	end
+end
+
+--------------------------------------------------------------------------------
 local function handle_buttons(tabview, fields, tabname, tabdata)
 	if fields["pkglist"] ~= nil then
 		local event = core.explode_table_event(fields["pkglist"])
 		tabdata.selected_pkg = event.row
+		if event.type == "DCL" then
+			handle_doubleclick(packages:get_list()[tabdata.selected_pkg])
+		end
 		return true
 	end
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR: Allow more intuitive ways to quickly switch the texture packs.
- How does the PR work? I added a handle_doubleclick function.
- Does it resolve any reported issue? None that I could find in the tracker.
- If not a bug fix, why is this PR needed? What usecases does it solve?
If a user double clicks on a texture pack, they probably want to turn it on/off. In the configure world dialog, the same behavior is used to toggle mods.

## To do

This PR is Ready for Review.

## How to test

1. Download some texture packs
2. Double click on a texture pack in the content tab

<!-- Example code or instructions -->
