### PR TITLE
Make hypertext and textarea have proper scroll event propagation

### DIFF
--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -220,6 +220,8 @@ local scroll_fs =
 		"tooltip[0,11;3,2;Buz;#f00;#000]"..
 		"box[0,11;3,2;#00ff00]"..
 		"hypertext[3,13;3,3;;" .. hypertext_basic .. "]" ..
+		"hypertext[3,17;3,3;;Hypertext with no scrollbar\\; the scroll container should scroll.]" ..
+		"textarea[3,21;3,1;textarea;;More scroll within scroll]" ..
 		"container[0,18]"..
 			"box[1,2;3,2;#0a0a]"..
 			"scroll_container[1,2;3,2;scrbar2;horizontal;0.06]"..

--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -787,6 +787,7 @@ bool GUIEditBox::processMouse(const SEvent &event)
 			s32 pos = m_vscrollbar->getPos();
 			s32 step = m_vscrollbar->getSmallStep();
 			m_vscrollbar->setPos(pos - event.MouseInput.Wheel * step);
+			return true;
 		}
 		break;
 	default:

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -1088,7 +1088,7 @@ bool GUIHyperText::OnEvent(const SEvent &event)
 		if (event.MouseInput.Event == EMIE_MOUSE_MOVED)
 			checkHover(event.MouseInput.X, event.MouseInput.Y);
 
-		if (event.MouseInput.Event == EMIE_MOUSE_WHEEL) {
+		if (event.MouseInput.Event == EMIE_MOUSE_WHEEL && m_vscrollbar->isVisible()) {
 			m_vscrollbar->setPos(m_vscrollbar->getPos() -
 					event.MouseInput.Wheel * m_vscrollbar->getSmallStep());
 			m_text_scrollpos.Y = -m_vscrollbar->getPos();


### PR DESCRIPTION
Formspec hypertext elements always block scroll wheel events.  So, if a hypertext without a scrollbar is inside a scroll container, the hypertext eats the scroll event, meaning the scroll container doesn't scroll.  Also, textarea always propagates scroll events, so the scroll container and textarea both scroll.  This fixes those.