### PR TITLE
Disable clang-format, clean up scripts

### DIFF
--- a/.github/workflows/cpp_lint.yml
+++ b/.github/workflows/cpp_lint.yml
@@ -24,20 +24,21 @@ on:
       - '.github/workflows/**.yml'
 
 jobs:
-  clang_format:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install clang-format
-        run: |
-          sudo apt-get install clang-format-9 -qyy
 
-      - name: Run clang-format
-        run: |
-          source ./util/ci/lint.sh
-          perform_lint
-        env:
-          CLANG_FORMAT: clang-format-9
+#  clang_format:
+#    runs-on: ubuntu-18.04
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Install clang-format
+#        run: |
+#          sudo apt-get install clang-format-9 -qyy
+#
+#      - name: Run clang-format
+#        run: |
+#          source ./util/ci/clang-format.sh
+#          check_format
+#        env:
+#          CLANG_FORMAT: clang-format-9
 
   clang_tidy:
     runs-on: ubuntu-18.04

--- a/util/ci/clang-format.sh
+++ b/util/ci/clang-format.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
-function perform_lint() {
-	echo "Performing LINT..."
+
+function setup_for_format() {
 	if [ -z "${CLANG_FORMAT}" ]; then
 		CLANG_FORMAT=clang-format
 	fi
@@ -8,6 +8,12 @@ function perform_lint() {
 	CLANG_FORMAT_WHITELIST="util/ci/clang-format-whitelist.txt"
 
 	files_to_lint="$(find src/ -name '*.cpp' -or -name '*.h')"
+}
+
+function check_format() {
+	echo "Checking format..."
+
+	setup_for_format
 
 	local errorcount=0
 	local fail=0
@@ -41,3 +47,18 @@ function perform_lint() {
 	echo "LINT OK"
 }
 
+
+
+function fix_format() {
+	echo "Fixing format..."
+
+	setup_for_format
+
+	for f in ${files_to_lint}; do
+		whitelisted=$(awk '$1 == "'$f'" { print 1 }' "$CLANG_FORMAT_WHITELIST")
+		if [ -z "${whitelisted}" ]; then
+			echo "$f"
+			$CLANG_FORMAT -i "$f"
+		fi
+	done
+}

--- a/util/fix_format.sh
+++ b/util/fix_format.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+. ./util/ci/clang-format.sh
+
+fix_format


### PR DESCRIPTION
The configuration has been completely broken for a long time.

This PR disables clang-format from the CI
