### PR TITLE
Add nick colors to chat

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -15,11 +15,30 @@ end
 -- Chat message formatter
 --
 
+function core.get_name_color(name)
+	-- Written by SmallJoker/Krock, license: MIT
+	local hash = core.sha1(name, true)
+	local r = hash:byte( 1) % 0x10
+	local g = hash:byte(10) % 0x10
+	local b = hash:byte(20) % 0x10
+	if r + g + b < 24 then
+		r = 15 - r
+		g = 15 - g
+		b = 15 - b
+	end
+	return ("#%X%X%X"):format(r, g, b)
+end
+
 -- Implemented in Lua to allow redefinition
 function core.format_chat_message(name, message)
 	local error_str = "Invalid chat message format - missing %s"
 	local str = core.settings:get("chat_message_format")
 	local replaced
+
+	-- Colors
+	local user_color = core.get_name_color(name)
+	str = safe_gsub(str, "@color", core.get_color_escape_sequence(user_color))
+	str = safe_gsub(str, "@clear", core.get_color_escape_sequence("#ffffff"))
 
 	-- Name
 	str, replaced = safe_gsub(str, "@name", name)
@@ -128,7 +147,8 @@ core.register_chatcommand("me", {
 			.. " '<player name> orders a pizza')",
 	privs = {shout=true},
 	func = function(name, param)
-		core.chat_send_all("* " .. name .. " " .. param)
+		local color = core.get_name_color(name)
+		core.chat_send_all("* " .. core.colorize(color, name) .. " " .. param)
 		return true
 	end,
 })

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -42,13 +42,15 @@ end
 
 function core.send_join_message(player_name)
 	if not core.is_singleplayer() then
-		core.chat_send_all("*** " .. player_name .. " joined the game.")
+		local color = core.get_name_color(player_name)
+		core.chat_send_all("*** " .. core.colorize(color, player_name) .. " joined the game.")
 	end
 end
 
 
 function core.send_leave_message(player_name, timed_out)
-	local announcement = "*** " ..  player_name .. " left the game."
+	local color = core.get_name_color(player_name)
+	local announcement = "*** " .. core.colorize(color, player_name) .. " left the game."
 	if timed_out then
 		announcement = announcement .. " (timed out)"
 	end

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1130,7 +1130,7 @@ enable_rollback_recording (Rollback recording) bool false
 
 #    Format of player chat messages. The following strings are valid placeholders:
 #    @name, @message, @timestamp (optional)
-chat_message_format (Chat message format) string <@name> @message
+chat_message_format (Chat message format) string @color<@name>@clear @message
 
 #    A message to be displayed to all clients when the server shuts down.
 kick_msg_shutdown (Shutdown message) string Server shutting down.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4813,11 +4813,14 @@ Chat
 
 * `minetest.chat_send_all(text)`
 * `minetest.chat_send_player(name, text)`
+* `minetest.get_name_color(name)`
+    * Returns a `colorstring` based on the given username.
+    * Can be redefined by mods if required.
 * `minetest.format_chat_message(name, message)`
     * Used by the server to format a chat message, based on the setting `chat_message_format`.
       Refer to the documentation of the setting for a list of valid placeholders.
     * Takes player name and message, and returns the formatted string to be sent to players.
-    * Can be redefined by mods if required, for things like colored names or messages.
+    * Can be redefined by mods if required.
     * **Only** the first occurrence of each placeholder will be replaced.
 
 Environment access

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -365,7 +365,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("kick_msg_crash", "This server has experienced an internal error. You will now be disconnected.");
 	settings->setDefault("ask_reconnect_on_crash", "false");
 
-	settings->setDefault("chat_message_format", "<@name> @message");
+	settings->setDefault("chat_message_format", "@color<@name>@clear @message");
 	settings->setDefault("profiler_print_interval", "0");
 	settings->setDefault("active_object_send_range_blocks", "8");
 	settings->setDefault("active_block_range", "4");


### PR DESCRIPTION
Based on @SmallJoker's [colored_names](https://github.com/SmallJoker/colored_names/blob/master/init.lua) mod.

This greatly improves chat readability imo.

![image](https://user-images.githubusercontent.com/2122943/105635992-d72dbb00-5e5d-11eb-9fff-90f375d6a486.png)


## To do

This PR is Ready for Review.

## How to test

<!-- Example code or instructions -->
