### PR TITLE
Consistently use "health points"

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6221,8 +6221,8 @@ object you are working with still exists.
     * `time_from_last_punch` = time since last punch action of the puncher
     * `direction`: can be `nil`
 * `right_click(clicker)`; `clicker` is another `ObjectRef`
-* `get_hp()`: returns number of hitpoints (2 * number of hearts)
-* `set_hp(hp, reason)`: set number of hitpoints (2 * number of hearts).
+* `get_hp()`: returns number of health points (2 * number of hearts)
+* `set_hp(hp, reason)`: set number of health points (2 * number of hearts).
     * See reason in register_on_player_hpchange
     * Is limited to the range of 0 ... 65535 (2^16 - 1)
     * For players: HP are also limited by `hp_max` specified in the player's

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6221,8 +6221,8 @@ object you are working with still exists.
     * `time_from_last_punch` = time since last punch action of the puncher
     * `direction`: can be `nil`
 * `right_click(clicker)`; `clicker` is another `ObjectRef`
-* `get_hp()`: returns number of health points (2 * number of hearts)
-* `set_hp(hp, reason)`: set number of health points (2 * number of hearts).
+* `get_hp()`: returns number of health points
+* `set_hp(hp, reason)`: set number of health points
     * See reason in register_on_player_hpchange
     * Is limited to the range of 0 ... 65535 (2^16 - 1)
     * For players: HP are also limited by `hp_max` specified in the player's

--- a/src/constants.h
+++ b/src/constants.h
@@ -89,7 +89,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // Size of player's main inventory
 #define PLAYER_INVENTORY_SIZE (8 * 4)
 
-// Default maximum hit points of a player
+// Default maximum health points of a player
 #define PLAYER_MAX_HP_DEFAULT 20
 
 // Default maximal breath of a player

--- a/util/wireshark/minetest.lua
+++ b/util/wireshark/minetest.lua
@@ -873,7 +873,7 @@ end
 -- TOCLIENT_HP
 
 do
-	local f_hp = ProtoField.uint16("minetest.server.hp", "Hitpoints", base.DEC)
+	local f_hp = ProtoField.uint16("minetest.server.hp", "Health points", base.DEC)
 
 	minetest_server_commands[0x33] = {
 		"HP", 4,


### PR DESCRIPTION
Hitpoints and health points were used arbitrarily both in the docs and in the code. I opted for the latter, it's the first thing I think about when I read "HP"

## To do

This PR is Ready for Review.

## How to test

Read
