### PR TITLE
Fix list spacing and size (again)

### DIFF
--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -35,11 +35,30 @@ local tabheaders_fs = [[
 
 local inv_style_fs = [[
 	style_type[list;noclip=true]
-	list[current_player;main;-1.125,-1.125;2,2]
+	list[current_player;main;-0.75,0.75;2,2]
+
+	real_coordinates[false]
+	list[current_player;main;1.5,0;3,2]
+	real_coordinates[true]
+
+	real_coordinates[false]
+	style_type[list;size=1.1;spacing=0.1]
+	list[current_player;main;5,0;3,2]
+	real_coordinates[true]
+
+	style_type[list;size=.001;spacing=0]
+	list[current_player;main;7,3.5;8,4]
+
+	box[3,3.5;1,1;#000000]
+	box[5,3.5;1,1;#000000]
+	box[4,4.5;1,1;#000000]
+	box[3,5.5;1,1;#000000]
+	box[5,5.5;1,1;#000000]
 	style_type[list;spacing=.25,.125;size=.75,.875]
-	list[current_player;main;3,.5;3,3]
-	style_type[list;spacing=0;size=1]
-	list[current_player;main;.5,4;8,4]
+	list[current_player;main;3,3.5;3,3]
+
+	style_type[list;spacing=0;size=1.1]
+	list[current_player;main;.5,7;8,4]
 ]]
 
 local hypertext_basic = [[
@@ -322,8 +341,7 @@ local pages = {
 		"container[0.5,1.5]" .. tabheaders_fs .. "container_end[]",
 
 		-- Inv
-		"size[12,13]real_coordinates[true]" ..
-		"container[0.5,1.5]" .. inv_style_fs .. "container_end[]",
+		"size[12,13]real_coordinates[true]" .. inv_style_fs,
 
 	-- Animation
 		[[

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 
 #include <cstdlib>
+#include <cmath>
 #include <algorithm>
 #include <iterator>
 #include <limits>
@@ -501,8 +502,8 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 
 		v2f32 slot_scale = style.getVector2f(StyleSpec::SIZE, v2f32(0, 0));
 		v2s32 slot_size(
-			slot_scale.X <= 0 ? imgsize.X : slot_scale.X * imgsize.X,
-			slot_scale.Y <= 0 ? imgsize.Y : slot_scale.Y * imgsize.Y
+			slot_scale.X <= 0 ? imgsize.X : std::max<s32>(round(slot_scale.X * imgsize.X), 1),
+			slot_scale.Y <= 0 ? imgsize.Y : std::max<s32>(round(slot_scale.Y * imgsize.Y), 1)
 		);
 
 		v2f32 slot_spacing = style.getVector2f(StyleSpec::SPACING, v2f32(-1, -1));
@@ -511,22 +512,22 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 					imgsize.X * slot_spacing.X;
 			slot_spacing.Y = slot_spacing.Y < 0 ? imgsize.Y * 0.25f :
 					imgsize.Y * slot_spacing.Y;
-
-			slot_spacing.X += slot_size.X;
-			slot_spacing.Y += slot_size.Y;
 		} else {
-			slot_spacing.X = slot_spacing.X < 0 ? spacing.X :
-					slot_spacing.X * spacing.X;
-			slot_spacing.Y = slot_spacing.Y < 0 ? spacing.Y :
-					slot_spacing.Y * spacing.Y;
+			slot_spacing.X = slot_spacing.X < 0 ? spacing.X - imgsize.X :
+					imgsize.X * slot_spacing.X;
+			slot_spacing.Y = slot_spacing.Y < 0 ? spacing.Y - imgsize.Y :
+					imgsize.Y * slot_spacing.Y;
 		}
+
+		slot_spacing.X = round(slot_spacing.X) + slot_size.X;
+		slot_spacing.Y = round(slot_spacing.Y) + slot_size.Y;
 
 		v2s32 pos = data->real_coordinates ? getRealCoordinateBasePos(v_pos) :
 				getElementBasePos(&v_pos);
 
 		core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y,
-				pos.X + (geom.X - 1) * slot_spacing.X + imgsize.X,
-				pos.Y + (geom.Y - 1) * slot_spacing.Y + imgsize.Y);
+				pos.X + (geom.X - 1) * slot_spacing.X + slot_size.X,
+				pos.Y + (geom.Y - 1) * slot_spacing.Y + slot_size.Y);
 
 		GUIInventoryList *e = new GUIInventoryList(Environment, data->current_parent,
 				spec.fid, rect, m_invmgr, loc, listname, geom, start_i, slot_size,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -501,26 +501,22 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 		auto style = getDefaultStyleForElement("list", spec.fname);
 
 		v2f32 slot_scale = style.getVector2f(StyleSpec::SIZE, v2f32(0, 0));
-		v2s32 slot_size(
-			slot_scale.X <= 0 ? imgsize.X : std::max<s32>(round(slot_scale.X * imgsize.X), 1),
-			slot_scale.Y <= 0 ? imgsize.Y : std::max<s32>(round(slot_scale.Y * imgsize.Y), 1)
+		v2f32 slot_size(
+			slot_scale.X <= 0 ? imgsize.X : std::max<f32>(slot_scale.X * imgsize.X, 1),
+			slot_scale.Y <= 0 ? imgsize.Y : std::max<f32>(slot_scale.Y * imgsize.Y, 1)
 		);
 
 		v2f32 slot_spacing = style.getVector2f(StyleSpec::SPACING, v2f32(-1, -1));
-		if (data->real_coordinates) {
-			slot_spacing.X = slot_spacing.X < 0 ? imgsize.X * 0.25f :
-					imgsize.X * slot_spacing.X;
-			slot_spacing.Y = slot_spacing.Y < 0 ? imgsize.Y * 0.25f :
-					imgsize.Y * slot_spacing.Y;
-		} else {
-			slot_spacing.X = slot_spacing.X < 0 ? spacing.X - imgsize.X :
-					imgsize.X * slot_spacing.X;
-			slot_spacing.Y = slot_spacing.Y < 0 ? spacing.Y - imgsize.Y :
-					imgsize.Y * slot_spacing.Y;
-		}
+		v2f32 default_spacing = data->real_coordinates ?
+				v2f32(imgsize.X * 0.25f, imgsize.Y * 0.25f) :
+				v2f32(spacing.X - imgsize.X, spacing.Y - imgsize.Y);
 
-		slot_spacing.X = round(slot_spacing.X) + slot_size.X;
-		slot_spacing.Y = round(slot_spacing.Y) + slot_size.Y;
+		slot_spacing.X = slot_spacing.X < 0 ? default_spacing.X :
+				imgsize.X * slot_spacing.X;
+		slot_spacing.Y = slot_spacing.Y < 0 ? default_spacing.Y :
+				imgsize.Y * slot_spacing.Y;
+
+		slot_spacing += slot_size;
 
 		v2s32 pos = data->real_coordinates ? getRealCoordinateBasePos(v_pos) :
 				getElementBasePos(&v_pos);
@@ -530,8 +526,9 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 				pos.Y + (geom.Y - 1) * slot_spacing.Y + slot_size.Y);
 
 		GUIInventoryList *e = new GUIInventoryList(Environment, data->current_parent,
-				spec.fid, rect, m_invmgr, loc, listname, geom, start_i, slot_size,
-				slot_spacing, this, data->inventorylist_options, m_font);
+				spec.fid, rect, m_invmgr, loc, listname, geom, start_i,
+				v2s32(slot_size.X, slot_size.Y), slot_spacing, this,
+				data->inventorylist_options, m_font);
 
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -104,8 +104,6 @@ void GUIInventoryList::draw()
 			&& m_invmgr->getInventory(selected_item->inventoryloc) == inv
 			&& selected_item->listname == m_listname
 			&& selected_item->i == item_i;
-		core::rect<s32> clipped_rect(rect);
-		clipped_rect.clipAgainst(AbsoluteClippingRect);
 		bool hovering = m_hovered_i == item_i;
 		ItemRotationKind rotation_kind = selected ? IT_ROT_SELECTED :
 			(hovering ? IT_ROT_HOVERED : IT_ROT_NONE);


### PR DESCRIPTION
Fixes #10866 and fixes #10862 as well as making old coordinate system custom spacing more sane and making rounding behavior more consistent with the rest of formspec elements.

Devtest should look like this:
![image](https://user-images.githubusercontent.com/31123645/106342232-fdd06500-6254-11eb-8c8f-009aed7479d1.png)
