### PR TITLE
Include irrlichttypes.h first to work around Irrlicht#433

### DIFF
--- a/src/client/fontengine.h
+++ b/src/client/fontengine.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <map>
 #include <vector>
 #include "util/basic_macros.h"
+#include "irrlichttypes.h"
 #include <IGUIFont.h>
 #include <IGUISkin.h>
 #include <IGUIEnvironment.h>

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "irrlichttypes.h"
 #include <IGUIEnvironment.h>
 #include "gui/guiFormSpecMenu.h"
 #include "util/enriched_string.h"

--- a/src/client/shader.h
+++ b/src/client/shader.h
@@ -20,8 +20,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include <IMaterialRendererServices.h>
 #include "irrlichttypes_bloated.h"
+#include <IMaterialRendererServices.h>
 #include <string>
 #include "tile.h"
 #include "nodedef.h"

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -17,10 +17,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include "irrlichttypes_extrabloated.h"
 #include <ISceneNode.h>
 #include <array>
 #include "camera.h"
-#include "irrlichttypes_extrabloated.h"
 #include "irr_ptr.h"
 #include "shader.h"
 #include "skyparams.h"

--- a/src/gui/guiEditBox.h
+++ b/src/gui/guiEditBox.h
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "irrlichttypes.h"
 #include "IGUIEditBox.h"
 #include "IOSOperator.h"
 #include "guiScrollBar.h"

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "irrlichttypes.h"
 #include <IEventReceiver.h>
 #include <IGUIButton.h>
 #include <IGUIEnvironment.h>


### PR DESCRIPTION
Added `irrlichttypes.h` before Irrlicht own includes. I might miss some places but should be enough already to fix #10858.

The problem is that Irrlicht guys refuse to `#include <cstdint>`, using own knowledge of the target platform instead. That bugs each time a platform appears to be newer than that knowledge (which doesn’t seem to be updated regularly).