### PR TITLE
Set UTF-8 codepage in Windows manifest

### DIFF
--- a/misc/minetest.exe.manifest
+++ b/misc/minetest.exe.manifest
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <assemblyIdentity type="win32" name="minetest" version="0.0.0.0" />
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
         <security>
             <requestedPrivileges>
@@ -10,6 +11,7 @@
     <application xmlns="urn:schemas-microsoft-com:asm.v3">
         <windowsSettings>
             <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+            <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
         </windowsSettings>
     </application>
 </assembly>


### PR DESCRIPTION
as documented here: https://docs.microsoft.com/en-us/windows/uwp/design/globalizing/use-utf8-code-page

What this does is make it so that standard library functions (e.g. `fopen`) suddenly start accepting UTF-8 strings like on every other sane platform.

This fixes the long-standing issue where MT wouldn't work at all when you extracted it to a path with non-ASCII characters
fixes #10500, fixes #3588

## To do

This PR is a Ready for Review.

## How to test

* Use Windows 10 1903 or newer
* Run Minetest
* Move Minetest to `C:\Users\<your name>\Desktop\ääääääääää`
* Create a world named "üüüüüüüüü"
* Join world and find that it works
