### PR TITLE
Add openmp for speed boost for old hardware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 # This is done here so that relative search paths are more reasonable
 find_package(Irrlicht)
 
+find_package(OpenMP)
+if (OPENMP_FOUND)
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+endif()
 
 # Installation
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -284,6 +284,7 @@ Client::~Client()
 
 	m_mesh_update_thread.stop();
 	m_mesh_update_thread.wait();
+	
 	while (!m_mesh_update_thread.m_queue_out.empty()) {
 		MeshUpdateResult r = m_mesh_update_thread.m_queue_out.pop_frontNoEx();
 		delete r.mesh;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1082,7 +1082,7 @@ void Game::run()
 
 	irr::core::dimension2d<u32> previous_screen_size(g_settings->getU16("screen_w"),
 		g_settings->getU16("screen_h"));
-
+	
 	while (RenderingEngine::run()
 			&& !(*kill || g_gamecallback->shutdown_requested
 			|| (server && server->isShutdownRequested()))) {

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -131,6 +131,7 @@ void MeshUpdateQueue::addBlock(Map *map, v3s16 p, bool ack_block_to_server, bool
 	m_queue.push_back(q);
 
 	// This queue entry is a new reference to the cached blocks
+#	pragma omp parallel
 	for (CachedMapBlockData *cached_block : cached_blocks) {
 		cached_block->refcount_from_queue++;
 	}

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -96,9 +96,13 @@ PreMeshBuffer &MeshCollector::findBuffer(
 		throw std::invalid_argument(
 				"Mesh can't contain more than 65536 vertices");
 	std::vector<PreMeshBuffer> &buffers = prebuffers[layernum];
-	for (PreMeshBuffer &p : buffers)
-		if (p.layer == layer && p.vertices.size() + numVertices <= U16_MAX)
+	
+	for (PreMeshBuffer &p : buffers) {
+		if (p.layer == layer && p.vertices.size() + numVertices <= U16_MAX) {
 			return p;
+		}
+	}
+	
 	buffers.emplace_back(layer);
 	return buffers.back();
 }

--- a/src/client/render/interlaced.cpp
+++ b/src/client/render/interlaced.cpp
@@ -38,6 +38,8 @@ void RenderingCoreInterlaced::initMaterial()
 	mat.ZWriteEnable = false;
 	u32 shader = s->getShader("3d_interlaced_merge", TILE_MATERIAL_BASIC);
 	mat.MaterialType = s->getShaderInfo(shader).material;
+	
+#	pragma omp for
 	for (int k = 0; k < 3; ++k) {
 		mat.TextureLayer[k].AnisotropicFilter = false;
 		mat.TextureLayer[k].BilinearFilter = false;

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -427,6 +427,7 @@ bool RenderingEngine::setXorgWindowIconFromPath(const std::string &icon_file)
 	icon_buffer[0] = width;
 	icon_buffer[1] = height;
 
+#	pragma omp for
 	for (u32 x = 0; x < width; x++) {
 		for (u32 y = 0; y < height; y++) {
 			video::SColor col = img->getPixel(x, y);

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -464,6 +464,7 @@ TextureSource::~TextureSource()
 	}
 	m_textureinfo_cache.clear();
 
+#	pragma omp for
 	for (auto t : m_texture_trash) {
 		//cleanup trashed texture
 		driver->removeTexture(t);


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

Add openmp on heaviest operations so they run faster. especially on my third world potato intel computer.

- Goal of the PR
Speed boost potato pcs like mine

- How does the PR work?
Just add some pragmas around the most heavy operations

- Does it resolve any reported issue?
No

- If not a bug fix, why is this PR needed? What usecases does it solve?
Some dual core (pentium processors, like mine) run slow with minetest, even on low graphics (30< fps). this just makes a slight speed boost. Sometimes the speed boost is far better than expected.

## To do

Ready for Review.
<!-- ^ delete one -->

- [ ] List
- [ ] Things
- [ ] To do

## How to test

<!-- Example code or instructions -->

build minetest with mp
build another minetest with no mp
run both on a multi-core computer
compare