### PR TITLE
Better enable_damage=false / 'immortal' group fix

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1085,7 +1085,7 @@ default_stack_max (Default stack size) int 99
 #    Enable players getting damage and dying.
 enable_damage (Damage) bool false
 
-#    Enable creative mode for new created maps.
+#    Enable creative mode for all players
 creative_mode (Creative) bool false
 
 #    A chosen map seed for a new map, leave empty for random.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1745,8 +1745,9 @@ to games.
 ### `ObjectRef` groups
 
 * `immortal`: Skips all damage and breath handling for an object. This group
-  will also hide the integrated HUD status bars for players, and is
-  automatically set to all players when damage is disabled on the server.
+  will also hide the integrated HUD status bars for players. It is
+  automatically set to all players when damage is disabled on the server and
+  cannot be reset (subject to change).
 * `punch_operable`: For entities; disables the regular damage mechanism for
   players punching it by hand or a non-tool item, so that it can do something
   else than take damage.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1275,9 +1275,8 @@ void Client::sendPlayerPos()
 	// Save bandwidth by only updating position when
 	// player is not dead and something changed
 
-	// FIXME: This part causes breakages in mods like 3d_armor, and has been commented for now
-	// if (m_activeobjects_received && player->isDead())
-	//	return;
+	if (m_activeobjects_received && player->isDead())
+		return;
 
 	if (
 			player->last_position     == player->getPosition() &&

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -355,6 +355,15 @@ int ObjectRef::l_set_armor_groups(lua_State *L)
 	ItemGroupList groups;
 
 	read_groups(L, 2, groups);
+	if (sao->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
+		if (!g_settings->getBool("enable_damage") && !itemgroup_get(groups, "immortal")) {
+			warningstream << "Mod tried to enable damage for a player, but it's "
+				"disabled globally. Ignoring." << std::endl;
+			infostream << script_get_backtrace(L) << std::endl;
+			groups["immortal"] = 1;
+		}
+	}
+
 	sao->setArmorGroups(groups);
 	return 0;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1358,7 +1358,7 @@ void Server::SendPlayerHPOrDie(PlayerSAO *playersao, const PlayerHPChangeReason 
 		return;
 
 	session_t peer_id = playersao->getPeerID();
-	bool is_alive = playersao->getHP() > 0;
+	bool is_alive = !playersao->isDead();
 
 	if (is_alive)
 		SendPlayerHP(peer_id);


### PR DESCRIPTION
This is essentially the better solution to #9022.

People keep running into(*) subtle issues because they are using an outdated version of 3d_armor.
But, subtle issues are bad because it doesn't provide a obvious indication that something went wrong and people are inclined to blame the engine instead of the <i>n</i>-year old mod they just installed from god knows where.

So instead this PR adds code to preserve the `immortal` group (it throws a warning instead).

(*) References:
- https://forum.minetest.net/viewtopic.php?p=360051#p360051
- https://forum.minetest.net/viewtopic.php?p=388908#p388908
- https://github.com/minetest/minetest/issues/9159
- https://github.com/minetest/minetest/issues/10161
- https://github.com/minetest/minetest/issues/9788#issuecomment-766514513

## To do

This PR is a Ready for Review.

## How to test

* Join a world with damage disabled
* Run `//lua local p=core.get_player_by_name("singleplayer");p:set_hp(0);p:set_armor_groups({})`
* Find that damage is still disabled and that the world still loads
