### PR TITLE
Use consistent temp folder path

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -151,6 +151,13 @@ os.tempfolder = function()
 end
 
 --------------------------------------------------------------------------------
+os.tmpname = function()
+	local path = os.tempfolder()
+	io.open(path, "w"):close()
+	return path
+end
+
+--------------------------------------------------------------------------------
 function menu_render_worldlist()
 	local retval = ""
 	local current_worldlist = menudata.worldlist:get_list()

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -146,35 +146,8 @@ end
 
 --------------------------------------------------------------------------------
 os.tempfolder = function()
-	if core.settings:get("TMPFolder") then
-		return core.settings:get("TMPFolder") .. DIR_DELIM .. "MT_" .. math.random(0,10000)
-	end
-
-	local filetocheck = os.tmpname()
-	os.remove(filetocheck)
-
-	-- luacheck: ignore
-	-- https://blogs.msdn.microsoft.com/vcblog/2014/06/18/c-runtime-crt-features-fixes-and-breaking-changes-in-visual-studio-14-ctp1/
-	--   The C runtime (CRT) function called by os.tmpname is tmpnam.
-	--   Microsofts tmpnam implementation in older CRT / MSVC releases is defective.
-	--   tmpnam return values starting with a backslash characterize this behavior.
-	-- https://sourceforge.net/p/mingw-w64/bugs/555/
-	--   MinGW tmpnam implementation is forwarded to the CRT directly.
-	-- https://sourceforge.net/p/mingw-w64/discussion/723797/thread/55520785/
-	--   MinGW links to an older CRT release (msvcrt.dll).
-	--   Due to legal concerns MinGW will never use a newer CRT.
-	--
-	--   Make use of TEMP to compose the temporary filename if an old
-	--   style tmpnam return value is detected.
-	if filetocheck:sub(1, 1) == "\\" then
-		local tempfolder = os.getenv("TEMP")
-		return tempfolder .. filetocheck
-	end
-
-	local randname = "MTTempModFolder_" .. math.random(0,10000)
-	local backstring = filetocheck:reverse()
-	return filetocheck:sub(0, filetocheck:len() - backstring:find(DIR_DELIM) + 1) ..
-		randname
+	local temp = core.get_temp_path()
+	return temp .. DIR_DELIM .. "MT_" .. math.random(0, 10000)
 end
 
 --------------------------------------------------------------------------------

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -85,6 +85,7 @@ core.get_video_drivers()
 core.get_mapgen_names([include_hidden=false]) -> table of map generator algorithms
     registered in the core (possible in async calls)
 core.get_cache_path() -> path of cache
+core.get_temp_path() -> path of temp folder
 
 
 HTTP Requests

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -461,7 +461,6 @@ void set_default_settings()
 	settings->setDefault("screen_h", "0");
 	settings->setDefault("fullscreen", "true");
 	settings->setDefault("touchtarget", "true");
-	settings->setDefault("TMPFolder", porting::path_cache);
 	settings->setDefault("touchscreen_threshold","20");
 	settings->setDefault("fixed_virtual_joystick", "false");
 	settings->setDefault("virtual_joystick_triggers_aux", "false");

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -27,9 +27,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "config.h"
 #include "porting.h"
-#ifdef __ANDROID__
-#include "settings.h" // For g_settings
-#endif
 
 namespace fs
 {
@@ -359,8 +356,9 @@ std::string TempPath()
 		compatible with lua's os.tmpname which under the default
 		configuration hardcodes mkstemp("/tmp/lua_XXXXXX").
 	*/
+
 #ifdef __ANDROID__
-	return g_settings->get("TMPFolder");
+	return porting::path_cache;
 #else
 	return DIR_DELIM "tmp";
 #endif

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -529,6 +529,7 @@ int ModApiMainMenu::l_get_texturepath(lua_State *L)
 	return 1;
 }
 
+/******************************************************************************/
 int ModApiMainMenu::l_get_texturepath_share(lua_State *L)
 {
 	std::string gamepath = fs::RemoveRelativePathComponents(
@@ -537,9 +538,17 @@ int ModApiMainMenu::l_get_texturepath_share(lua_State *L)
 	return 1;
 }
 
+/******************************************************************************/
 int ModApiMainMenu::l_get_cache_path(lua_State *L)
 {
 	lua_pushstring(L, fs::RemoveRelativePathComponents(porting::path_cache).c_str());
+	return 1;
+}
+
+/******************************************************************************/
+int ModApiMainMenu::l_get_temp_path(lua_State *L)
+{
+	lua_pushstring(L, fs::TempPath().c_str());
 	return 1;
 }
 
@@ -942,6 +951,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(get_texturepath);
 	API_FCT(get_texturepath_share);
 	API_FCT(get_cache_path);
+	API_FCT(get_temp_path);
 	API_FCT(create_dir);
 	API_FCT(delete_dir);
 	API_FCT(copy_dir);
@@ -975,6 +985,7 @@ void ModApiMainMenu::InitializeAsync(lua_State *L, int top)
 	API_FCT(get_texturepath);
 	API_FCT(get_texturepath_share);
 	API_FCT(get_cache_path);
+	API_FCT(get_temp_path);
 	API_FCT(create_dir);
 	API_FCT(delete_dir);
 	API_FCT(copy_dir);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -122,6 +122,8 @@ private:
 
 	static int l_get_cache_path(lua_State *L);
 
+	static int l_get_temp_path(lua_State *L);
+
 	static int l_create_dir(lua_State *L);
 
 	static int l_delete_dir(lua_State *L);


### PR DESCRIPTION
This should fix #10657, but **I'm unable to test on Windows**

## To do

- [x] Does `os.tmpname()` need to be replaced too?
- [ ] Test that this does fix #10657

## How to test

* Try installing from ContentDB