### PR TITLE
Fix memory leak detected by address sanitizer

### DIFF
--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -153,7 +153,7 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 RenderingEngine::~RenderingEngine()
 {
 	core.reset();
-	m_device->drop();
+	m_device->closeDevice();
 	s_singleton = nullptr;
 }
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -75,8 +75,6 @@ video::ITexture *MenuTextureSource::getTexture(const std::string &name, u32 *id)
 	if (name.empty())
 		return NULL;
 
-	m_to_delete.insert(name);
-
 #if ENABLE_GLES
 	video::ITexture *retval = m_driver->findTexture(name.c_str());
 	if (retval)
@@ -88,6 +86,7 @@ video::ITexture *MenuTextureSource::getTexture(const std::string &name, u32 *id)
 
 	image = Align2Npot2(image, m_driver);
 	retval = m_driver->addTexture(name.c_str(), image);
+	m_to_delete.insert(name);
 	image->drop();
 	return retval;
 #else

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -378,6 +378,7 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 	}
 
 	// Store our face.
+	sguitt_face = face;
 	tt_face = face->face;
 
 	// Store font metrics.
@@ -436,6 +437,9 @@ CGUITTFont::~CGUITTFont()
 	// Drop our driver now.
 	if (Driver)
 		Driver->drop();
+
+	// Destroy sguitt_face after clearing c_faces
+	delete sguitt_face;
 }
 
 void CGUITTFont::reset_images()

--- a/src/irrlicht_changes/CGUITTFont.h
+++ b/src/irrlicht_changes/CGUITTFont.h
@@ -375,7 +375,7 @@ namespace gui
 			gui::IGUIEnvironment* Environment;
 			video::IVideoDriver* Driver;
 			io::path filename;
-			SGUITTFace* sguitt_face;
+			SGUITTFace* sguitt_face = nullptr;
 			FT_Face tt_face;
 			FT_Size_Metrics font_metrics;
 			FT_Int32 load_flags;

--- a/src/irrlicht_changes/CGUITTFont.h
+++ b/src/irrlicht_changes/CGUITTFont.h
@@ -375,6 +375,7 @@ namespace gui
 			gui::IGUIEnvironment* Environment;
 			video::IVideoDriver* Driver;
 			io::path filename;
+			SGUITTFace* sguitt_face;
 			FT_Face tt_face;
 			FT_Size_Metrics font_metrics;
 			FT_Int32 load_flags;


### PR DESCRIPTION
When I was trying to solve the crash in https://github.com/minetest/minetest/issues/10895, I tried to build minetest with `-fsanitize=address` to see if it was caused by some sort of memory leak. Though there are leaks, they are not related to the issue.

The leaks are reported after I close minetest, so their effects are minor and shouldn't affect the game, but I think it is good to fix any leak if possible. 

I have tested that minetest runs fine on my machine with this PR. It is still possible that it affects some sorts of resource destruction so reviews are needed.