### PR TITLE
Lua API: Add function to check if a block is active

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5794,16 +5794,20 @@ Misc.
       change knockback behaviour.
 
 * `minetest.forceload_block(pos[, transient])`
-    * forceloads the position `pos`.
+    * forceloads the block that contains node position `pos`.
     * returns `true` if area could be forceloaded
     * If `transient` is `false` or absent, the forceload will be persistent
       (saved between server runs). If `true`, the forceload will be transient
       (not saved between server runs).
 
 * `minetest.forceload_free_block(pos[, transient])`
-    * stops forceloading the position `pos`
+    * stops forceloading the block that contains node position `pos`
     * If `transient` is `false` or absent, frees a persistent forceload.
       If `true`, frees a transient forceload.
+
+* `minetest.is_block_active(pos)`
+    * Returns true if the block containing the node pos is currently "active",
+      that is, ABMs are running and ActiveObjects are loaded.
 
 * `minetest.request_insecure_environment()`: returns an environment containing
   insecure functions if the calling mod has been listed as trusted in the

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1400,6 +1400,20 @@ int ModApiEnvMod::l_forceload_free_block(lua_State *L)
 	return 0;
 }
 
+// is_block_active(nodepos)
+// blockpos = {x=num, y=num, z=num}
+int ModApiEnvMod::l_is_block_active(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	v3s16 nodepos = read_v3s16(L, 1);
+	v3s16 blockpos = getNodeBlockPos(nodepos);
+	bool active = env->isBlockActive(blockpos);
+
+	lua_pushboolean(L, active);
+	return 1;
+}
+
 // get_translated_string(lang_code, string)
 int ModApiEnvMod::l_get_translated_string(lua_State * L)
 {
@@ -1462,6 +1476,7 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(transforming_liquid_add);
 	API_FCT(forceload_block);
 	API_FCT(forceload_free_block);
+	API_FCT(is_block_active);
 	API_FCT(get_translated_string);
 }
 

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -195,6 +195,10 @@ private:
 	// stops forceloading a position
 	static int l_forceload_free_block(lua_State *L);
 
+	// is_block_active(nodepos)
+	// nodepos = {x=num, y=num, z=num}
+	static int l_is_block_active(lua_State *L);
+
 	// Get a string translated server side
 	static int l_get_translated_string(lua_State * L);
 

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -344,6 +344,8 @@ public:
 
 	std::set<v3s16>* getForceloadedBlocks() { return &m_active_blocks.m_forceloaded_list; };
 
+	bool isBlockActive(v3s16 blockpos) { return m_active_blocks.contains(blockpos); };
+
 	// Sets the static object status all the active objects in the specified block
 	// This is only really needed for deleting blocks from the map
 	void setStaticForActiveObjectsInBlock(v3s16 blockpos,


### PR DESCRIPTION
This PR extends the Lua API by a reliable way to check whether a map block is currently "active" in engine sense.
It adds a new API function "is_block_active(pos)" which returns true if the block containing pos is in the list of active blocks.

This is particularily useful in conjunction with LBMs. As LBMs are run right at the transition of a block from inactive to active state, it can clearly be told whether the LBM has already run for a block.

Example use cases:
- advtrains: only change nodes in the map if the block is active, changes in inactive mapblocks are done in bulk using an LBM
- signs/other node-bound entities: decide when to delete the entity, and respawn it using an LBM.

This PR is Ready for Review.

## How to test

Test mod init.lua: prints the state of block 0,0,0 every second, and includes a test node to try out LBM and ABM (place this test node somewhere in block 0,0,0)
```
local nodepos = vector.new(0,0,0)

local function print_active_status()
	local active = minetest.is_block_active(nodepos)
	local loaded = minetest.get_node_or_nil(nodepos) ~= nil
	
	minetest.chat_send_all("Block at "..minetest.pos_to_string(nodepos)
		..": "..(active and "active" or "inactive").." "..(loaded and "loaded" or "unloaded"))

	minetest.after(1, print_active_status)
end

minetest.after(1, print_active_status)

minetest.register_node(":test:test", {
	description = "Test Node",
	tiles = {"asdf.png"},
	is_ground_content = false,
	groups = {cracky = 3, stone = 2},
})

minetest.register_abm({
        name = ":test:test_abm",
        nodenames = {"test:test"},
        action = function(pos)
			minetest.chat_send_all("ABM running for node at "..minetest.pos_to_string(pos))
        end,
        interval=1,
        chance=1,
    })
minetest.register_lbm({
        name = ":test:test_lbm",
        nodenames = {"test:test"},
        run_at_every_load = true,
        run_on_every_load = true,
        action = function(pos)
			minetest.chat_send_all("LBM running for node at "..minetest.pos_to_string(pos))
        end,
    })
```