### PR TITLE
Fix documentation of formspec sound style

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2872,14 +2872,14 @@ Some types may inherit styles from parent types.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
     * padding - rect, adds space between the edges of the button and the content. This value is
                 relative to bgimg_middle.
-    * sound - a sound to be played when clicked.
+    * sound - a sound to be played when triggered.
     * textcolor - color, default white.
 * checkbox
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
-    * sound - a sound to be played when clicked.
+    * sound - a sound to be played when triggered.
 * dropdown
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
-    * sound - a sound to be played when clicked.
+    * sound - a sound to be played when the entry is changed.
 * field, pwdfield, textarea
     * border - set to false to hide the textbox background and border. Default true.
     * font - Sets font type. See button `font` property for more information.
@@ -2910,12 +2910,12 @@ Some types may inherit styles from parent types.
     * fgimg_pressed - image when pressed. Defaults to fgimg when not provided.
         * This is deprecated, use states instead.
     * NOTE: The parameters of any given image_button will take precedence over fgimg/fgimg_pressed
-    * sound - a sound to be played when clicked.
+    * sound - a sound to be played when triggered.
 * scrollbar
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 * tabheader
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
-    * sound - a sound to be played when clicked.
+    * sound - a sound to be played when a different tab is selected.
     * textcolor - color. Default white.
 * table, textlist
     * font - Sets font type. See button `font` property for more information.


### PR DESCRIPTION
The documentation of the `sound` "style" for formspec is slightly off. It always says the sound is played when the thing is "clicked" but this is not completely accurate.

You also get the sound with e.g. space bar. The `dropdown` and `tabheader` formspec elements also behave differently, sound-wise. `dropdown` does not play sound when it is opened, only when the entry was changed. `tabheader` only plays sound when a tab is changed, not when the current tab was chosen.

This PR repairs this.