### PR TITLE
Reduce ore noise_parms error to deprecation warning

### DIFF
--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1337,7 +1337,7 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 		ore->flags |= OREFLAG_USE_NOISE;
 	} else if (ore->needs_noise) {
 		log_deprecated(L,
-				"register_ore: ore type requires 'noise_params' but it is not specified");
+			"register_ore: ore type requires 'noise_params' but it is not specified, falling back to defaults");
 	}
 	lua_pop(L, 1);
 

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1336,10 +1336,8 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 	if (read_noiseparams(L, -1, &ore->np)) {
 		ore->flags |= OREFLAG_USE_NOISE;
 	} else if (ore->needs_noise) {
-		errorstream << "register_ore: specified ore type requires valid "
-			"'noise_params' parameter" << std::endl;
-		delete ore;
-		return 0;
+		log_deprecated(L,
+				"register_ore: ore type requires 'noise_params' but it is not specified");
 	}
 	lua_pop(L, 1);
 


### PR DESCRIPTION
Fixes #10914

In Minetest 5.3.0, the check for `noise_params` for the ores that require it is completely broken. Instead of showing an error, it would use the following default values:

```lua
noise_params = {
    offset  = 0,
    scale   = 1,
    spread  = {x=250, y=250, z=250},
    seed    = 12345,
    octaves = 3,
    persist = 0.6,
    lacunarity = 2,
    flags = "defaults",
}
```

This changes the error to a deprecation warning, and lets the ore still be used with these default values.

## To do

This PR is Ready for Review.

## How to test

Try out Mineclone2
