### PR TITLE
Fall back to default when rendering mode (3d_mode) is set invalid

### DIFF
--- a/src/client/render/factory.cpp
+++ b/src/client/render/factory.cpp
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "factory.h"
-#include <stdexcept>
+#include "log.h"
 #include "plain.h"
 #include "anaglyph.h"
 #include "interlaced.h"
@@ -45,5 +45,8 @@ RenderingCore *createRenderingCore(const std::string &stereo_mode, IrrlichtDevic
 		return new RenderingCoreSideBySide(device, client, hud, true);
 	if (stereo_mode == "crossview")
 		return new RenderingCoreSideBySide(device, client, hud, false, true);
-	throw std::invalid_argument("Invalid rendering mode: " + stereo_mode);
+
+	// fallback to plain renderer
+	errorstream << "Invalid rendering mode: " << stereo_mode << std::endl;
+	return new RenderingCorePlain(device, client, hud);
 }


### PR DESCRIPTION
Use plain renderer (`3d_mode = none`) as fallback when the value is invalid.

- Goal of the PR
Minetest does not crash when `3d_mode` setting is invalid.
- How does the PR work?
This changes the way Minetest handling invalid `3d_mode`, from throwing exception to log the error and use plain renderer (`3d_mode = none`).
- Does it resolve any reported issue?
I reported the issue in Unofficial Minetest Discord. I was using invalid value for `3d_mode` (a leftover from another PR).

This PR is a Ready for Review.

## How to test
1. Use invalid value for `3d_mode`, e.g. `myniceunavailablerenderer`.
2. Try to run Minetest (play a world).
3. Check that Minetest does not crash, uses plain renderer, and log the error (error-level log).