### PR TITLE
Fix wrong reported item counts for inventory actions caused by move somewhere

### DIFF
--- a/games/devtest/mods/chest/init.lua
+++ b/games/devtest/mods/chest/init.lua
@@ -23,6 +23,18 @@ minetest.register_node("chest:chest", {
 		local inv = meta:get_inventory()
 		return inv:is_empty("main")
 	end,
+	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
+		minetest.chat_send_player(player:get_player_name(), "Allow put: " .. stack:to_string())
+		return stack:get_count()
+	end,
+	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
+		minetest.chat_send_player(player:get_player_name(), "Allow take: " .. stack:to_string())
+		return stack:get_count()
+	end,
+	on_metadata_inventory_put = function(pos, listname, index, stack, player)
+		minetest.chat_send_player(player:get_player_name(), "On put: " .. stack:to_string())
+	end,
+	on_metadata_inventory_take = function(pos, listname, index, stack, player)
+		minetest.chat_send_player(player:get_player_name(), "On take: " .. stack:to_string())
+	end,
 })
-
-

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -421,12 +421,10 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 
 	/* Modify count according to collected data */
 	count = src_item.count;
-	if (!caused_by_move_somewhere) {
-		if (src_can_take_count != -1 && count > src_can_take_count)
-			count = std::min((int)count, src_can_take_count);
-		if (dst_can_put_count != -1 && count > dst_can_put_count)
-			count = std::min((int)count, dst_can_put_count);
-	}
+	if (src_can_take_count != -1 && count > src_can_take_count)
+		count = std::min((int)count, src_can_take_count);
+	if (dst_can_put_count != -1 && count > dst_can_put_count)
+		count = std::min((int)count, dst_can_put_count);
 
 	/* Limit according to source item count */
 	if (count > list_from->getItem(from_i).count)
@@ -467,6 +465,8 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 	bool did_swap = false;
 	move_count = list_from->moveItem(from_i,
 		list_to, to_i, count, allow_swap, &did_swap);
+	if (caused_by_move_somewhere)
+		count = old_count;
 	assert(allow_swap == did_swap);
 	assert(move_count == expected_move_count);
 

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -574,7 +574,8 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		if (caused_by_move_somewhere)
 			src_item.count = move_count;
 		onPutAndOnTake(src_item, player);
-		src_item.count = src_item_count;
+		if (caused_by_move_somewhere)
+			src_item.count = src_item_count;
 		if (did_swap) {
 			// Item is now placed in source list
 			src_item = list_from->getItem(from_i);


### PR DESCRIPTION
Partially closes #10805

## To do

- [x] Fix underflow
- [x] Thorough testing

## How to test

The devtest chest has been modified to output counts in chat.
