### PR TITLE
Fail gracefully if main_menu_script has bad value

### DIFF
--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -43,8 +43,8 @@ elseif INIT == "mainmenu" then
 	if mm_script and mm_script ~= "" then
 		local testfile = io.open(mm_script, "r")
 		if testfile then
-			dofile(mm_script)
 			testfile:close()
+			dofile(mm_script)
 			custom_loaded = true
 			core.log("info", "Loaded custom main menu script: "..mm_script)
 		else

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -39,9 +39,20 @@ if INIT == "game" then
 	assert(not core.get_http_api)
 elseif INIT == "mainmenu" then
 	local mm_script = core.settings:get("main_menu_script")
+	local custom_loaded = false
 	if mm_script and mm_script ~= "" then
-		dofile(mm_script)
-	else
+		local testfile = io.open(mm_script, "r")
+		if testfile then
+			dofile(mm_script)
+			testfile:close()
+			custom_loaded = true
+			core.log("info", "Loaded custom main menu script: "..mm_script)
+		else
+			core.log("error", "Failed to load custom main menu script: "..mm_script)
+			core.log("info", "Falling back to default main menu script")
+		end
+	end
+	if not custom_loaded then
 		dofile(core.get_mainmenu_path() .. DIR_DELIM .. "init.lua")
 	end
 elseif INIT == "async" then


### PR DESCRIPTION
Partial fix of #9003. If `main_menu_script` has an invalid value, Minetest will no longer crash, but instead fall back to the default main menu script and prints a warning in log.

## To do

This PR is ready for review.

## How to test

1. Set `main_menu_script` to an invalid value
2. Start Minetest
3. Check log
