### PR TITLE
Fix short_description fallback order

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -665,10 +665,6 @@ function core.itemstring_with_color(item, colorstring)
 	return stack:to_string()
 end
 
-function core.get_short_description(item)
-	return ItemStack(item):get_short_description()
-end
-
 -- This is used to allow mods to redefine core.item_place and so on
 -- NOTE: This is not the preferred way. Preferred way is to provide enough
 --       callbacks to not require redefining global functions. -celeron55

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -665,6 +665,10 @@ function core.itemstring_with_color(item, colorstring)
 	return stack:to_string()
 end
 
+function core.get_short_description(item)
+	return ItemStack(item):get_short_description()
+end
+
 -- This is used to allow mods to redefine core.item_place and so on
 -- NOTE: This is not the preferred way. Preferred way is to provide enough
 --       callbacks to not require redefining global functions. -celeron55

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -118,10 +118,6 @@ function core.register_item(name, itemdef)
 	end
 	itemdef.name = name
 
-	-- default short_description to first line of description
-	itemdef.short_description = itemdef.short_description or
-		(itemdef.description or ""):gsub("\n.*","")
-
 	-- Apply defaults and add to registered_* table
 	if itemdef.type == "node" then
 		-- Use the nodebox as selection box if it's not set manually

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5335,17 +5335,6 @@ Item handling
     * `item`: the item stack which becomes colored. Can be in string,
       table and native form.
     * `colorstring`: the new color of the item stack
-* `minetest.get_short_description(item)`: returns the short description or nil
-    * Unlike the description, this does not include new lines.
-    * This is equivalent to `ItemStack(item):get_short_description()`.
-    * Fields for finding the short description, in order:
-        * `short_description` in item metadata (See [Item Metadata].)
-        * `short_description` in item definition
-        * first line of `description` in item metadata
-        * first line of `description` in item definition
-        * Returns nil if none of the above are set
-    * `item`: the item to get the short description for.
-              Can be an item name, string, table, or stack.
 
 Rollback
 --------
@@ -7183,8 +7172,8 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         short_description = "Steel Axe",
         -- Must not contain new lines.
         -- Defaults to nil.
-        -- See also: `minetest.get_short_description()` and
-        --    `get_short_description` in [`ItemStack`]
+        -- Use an [`ItemStack`] to get the short description, eg:
+        --   ItemStack(itemname):get_short_description()
 
         groups = {},
         -- key = name, value = rating; rating = 1..3.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5335,6 +5335,17 @@ Item handling
     * `item`: the item stack which becomes colored. Can be in string,
       table and native form.
     * `colorstring`: the new color of the item stack
+* `minetest.get_short_description(item)`: returns the short description or nil
+    * Unlike the description, this does not include new lines.
+    * This is equivalent to `ItemStack(item):get_short_description()`.
+    * Fields for finding the short description, in order:
+        * `short_description` in item metadata (See [Item Metadata].)
+        * `short_description` in item definition
+        * first line of `description` in item metadata
+        * first line of `description` in item definition
+        * Returns nil if none of the above are set
+    * `item`: the item to get the short description for.
+              Can be an item name, string, table, or stack.
 
 Rollback
 --------
@@ -6039,18 +6050,18 @@ an itemstring, a table or `nil`.
   stack).
 * `set_metadata(metadata)`: (DEPRECATED) Returns true.
 * `get_description()`: returns the description shown in inventory list tooltips.
-    * The engine uses the same as this function for item descriptions.
+    * The engine uses the same as this function for item descriptions, shown in tooltips.
     * Fields for finding the description, in order:
         * `description` in item metadata (See [Item Metadata].)
         * `description` in item definition
         * item name
-* `get_short_description()`: returns the short description.
+* `get_short_description()`: returns the short description or nil.
     * Unlike the description, this does not include new lines.
-    * The engine uses the same as this function for short item descriptions.
     * Fields for finding the short description, in order:
         * `short_description` in item metadata (See [Item Metadata].)
         * `short_description` in item definition
-        * first line of the description (See `get_description()`.)
+        * first line of the description (From item meta or def, see `get_description()`.)
+        * Returns nil if none of the above are set
 * `clear()`: removes all items from the stack, making it empty.
 * `replace(item)`: replace the contents of this stack.
     * `item` can also be an itemstring or table.
@@ -7171,8 +7182,9 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
 
         short_description = "Steel Axe",
         -- Must not contain new lines.
-        -- Defaults to the first line of description.
-        -- See also: `get_short_description` in [`ItemStack`]
+        -- Defaults to nil.
+        -- See also: `minetest.get_short_description()` and
+        --    `get_short_description` in [`ItemStack`]
 
         groups = {},
         -- key = name, value = rating; rating = 1..3.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6039,7 +6039,7 @@ an itemstring, a table or `nil`.
   stack).
 * `set_metadata(metadata)`: (DEPRECATED) Returns true.
 * `get_description()`: returns the description shown in inventory list tooltips.
-    * The engine uses the same as this function for item descriptions, shown in tooltips.
+    * The engine uses this when showing item descriptions in tooltips.
     * Fields for finding the description, in order:
         * `description` in item metadata (See [Item Metadata].)
         * `description` in item definition

--- a/games/devtest/mods/unittests/itemdescription.lua
+++ b/games/devtest/mods/unittests/itemdescription.lua
@@ -33,7 +33,7 @@ function unittests.test_short_desc()
 	local stack = ItemStack("unittests:colorful_pick")
 	assert(stack:get_short_description() == "Colorful Pickaxe")
 	assert(get_short_description("unittests:colorful_pick") == "Colorful Pickaxe")
-	assert(registered_items["unittests:colorful_pick"].short_description == nil)
+	assert(minetest.registered_items["unittests:colorful_pick"].short_description == nil)
 	assert(stack:get_description() == full_description)
 	assert(stack:get_description() == minetest.registered_items["unittests:colorful_pick"].description)
 

--- a/games/devtest/mods/unittests/itemdescription.lua
+++ b/games/devtest/mods/unittests/itemdescription.lua
@@ -28,13 +28,16 @@ minetest.register_chatcommand("item_description", {
 function unittests.test_short_desc()
 	local stack = ItemStack("unittests:colorful_pick")
 	assert(stack:get_short_description() == "Colorful Pickaxe")
-	assert(stack:get_short_description() == minetest.registered_items["unittests:colorful_pick"].short_description)
+	assert(minetest.get_short_description("unittests:colorful_pick") == "Colorful Pickaxe")
+	assert(minetest.registered_items["unittests:colorful_pick"].short_description == nil)
 	assert(stack:get_description() == full_description)
 	assert(stack:get_description() == minetest.registered_items["unittests:colorful_pick"].description)
 
 	stack:get_meta():set_string("description", "Hello World")
-	assert(stack:get_short_description() == "Colorful Pickaxe")
+	assert(stack:get_short_description() == "Hello World")
 	assert(stack:get_description() == "Hello World")
+	assert(minetest.get_short_description(stack) == "Hello World")
+	assert(minetest.get_short_description("unittests:colorful_pick") == "Colorful Pickaxe")
 
 	stack:get_meta():set_string("short_description", "Foo Bar")
 	assert(stack:get_short_description() == "Foo Bar")

--- a/games/devtest/mods/unittests/itemdescription.lua
+++ b/games/devtest/mods/unittests/itemdescription.lua
@@ -26,18 +26,22 @@ minetest.register_chatcommand("item_description", {
 })
 
 function unittests.test_short_desc()
+	local function get_short_description(item)
+		return ItemStack(item):get_short_description()
+	end
+
 	local stack = ItemStack("unittests:colorful_pick")
 	assert(stack:get_short_description() == "Colorful Pickaxe")
-	assert(minetest.get_short_description("unittests:colorful_pick") == "Colorful Pickaxe")
-	assert(minetest.registered_items["unittests:colorful_pick"].short_description == nil)
+	assert(get_short_description("unittests:colorful_pick") == "Colorful Pickaxe")
+	assert(registered_items["unittests:colorful_pick"].short_description == nil)
 	assert(stack:get_description() == full_description)
 	assert(stack:get_description() == minetest.registered_items["unittests:colorful_pick"].description)
 
 	stack:get_meta():set_string("description", "Hello World")
 	assert(stack:get_short_description() == "Hello World")
 	assert(stack:get_description() == "Hello World")
-	assert(minetest.get_short_description(stack) == "Hello World")
-	assert(minetest.get_short_description("unittests:colorful_pick") == "Colorful Pickaxe")
+	assert(get_short_description(stack) == "Hello World")
+	assert(get_short_description("unittests:colorful_pick") == "Colorful Pickaxe")
 
 	stack:get_meta():set_string("short_description", "Foo Bar")
 	assert(stack:get_short_description() == "Foo Bar")

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -140,8 +140,10 @@ void push_item_definition_full(lua_State *L, const ItemDefinition &i)
 	lua_setfield(L, -2, "name");
 	lua_pushstring(L, i.description.c_str());
 	lua_setfield(L, -2, "description");
-	lua_pushstring(L, i.short_description.c_str());
-	lua_setfield(L, -2, "short_description");
+	if (!i.short_description.empty()) {
+		lua_pushstring(L, i.short_description.c_str());
+		lua_setfield(L, -2, "short_description");
+	}
 	lua_pushstring(L, type.c_str());
 	lua_setfield(L, -2, "type");
 	lua_pushstring(L, i.inventory_image.c_str());


### PR DESCRIPTION
`short_description` was always set on the item definition,
meaning that `description` in the metadata was never used.

Fixes #10911

## To do

This PR is  Ready for Review.

## How to test

See that the devtest unit tests pass

(setting: `devtest_unittests_autostart = true`)
