### PR TITLE
Server-side authority for attached players

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -49,6 +49,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gettext.h"
 #include "clientmap.h"
 #include "clientmedia.h"
+#include "content_cao.h" // for getParent()
 #include "version.h"
 #include "database/database-sqlite3.h"
 #include "serialization.h"
@@ -1266,6 +1267,10 @@ void Client::sendPlayerPos()
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
 	if (!player)
+		return;
+
+	// Position defined by parent and attachment information
+	if (player->getCAO() && player->getCAO()->getParent())
 		return;
 
 	ClientMap &map = m_env.getClientMap();

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -49,7 +49,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gettext.h"
 #include "clientmap.h"
 #include "clientmedia.h"
-#include "content_cao.h" // for getParent()
 #include "version.h"
 #include "database/database-sqlite3.h"
 #include "serialization.h"
@@ -1267,10 +1266,6 @@ void Client::sendPlayerPos()
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
 	if (!player)
-		return;
-
-	// Position defined by parent and attachment information
-	if (player->getCAO() && player->getCAO()->getParent())
 		return;
 
 	ClientMap &map = m_env.getClientMap();

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -488,8 +488,12 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	pitch = modulo360f(pitch);
 	yaw = wrapDegrees_0_360(yaw);
 
-	playersao->setBasePosition(position);
-	player->setSpeed(speed);
+	if (!playersao->isAttached()) {
+		// Only update player positions when moving freely
+		// to not interfere with attachment handling
+		playersao->setBasePosition(position);
+		player->setSpeed(speed);
+	}
 	playersao->setLookPitch(pitch);
 	playersao->setPlayerYaw(yaw);
 	playersao->setFov(fov);

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -460,6 +460,10 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	if (pkt->getRemainingBytes() < 12 + 12 + 4 + 4 + 4 + 1 + 1)
 		return;
 
+	// Player position is defined by parent
+	if (playersao->isAttached())
+		return;
+
 	v3s32 ps, ss;
 	s32 f32pitch, f32yaw;
 	u8 f32fov;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -460,10 +460,6 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	if (pkt->getRemainingBytes() < 12 + 12 + 4 + 4 + 4 + 1 + 1)
 		return;
 
-	// Player position is defined by parent
-	if (playersao->isAttached())
-		return;
-
 	v3s32 ps, ss;
 	s32 f32pitch, f32yaw;
 	u8 f32fov;

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -146,15 +146,11 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 
 	// Each frame, parent position is copied if the object is attached, otherwise it's calculated normally
 	// If the object gets detached this comes into effect automatically from the last known origin
-	if(isAttached())
-	{
-		v3f pos = m_env->getActiveObject(m_attachment_parent_id)->getBasePosition();
-		m_base_position = pos;
+	if (auto *parent = getParent()) {
+		m_base_position = parent->getBasePosition();
 		m_velocity = v3f(0,0,0);
 		m_acceleration = v3f(0,0,0);
-	}
-	else
-	{
+	} else {
 		if(m_prop.physical){
 			aabb3f box = m_prop.collisionbox;
 			box.MinEdge *= BS;

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -570,13 +570,9 @@ void PlayerSAO::setMaxSpeedOverride(const v3f &vel)
 bool PlayerSAO::checkMovementCheat()
 {
 	if (m_is_singleplayer ||
+			isAttached() ||
 			g_settings->getBool("disable_anticheat")) {
 		m_last_good_position = m_base_position;
-		return false;
-	}
-
-	if (getParent()) {
-		// Player movement is locked by parent. Position updates are ignored.
 		return false;
 	}
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -260,8 +260,8 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 	// otherwise it's calculated normally.
 	// If the object gets detached this comes into effect automatically from
 	// the last known origin.
-	if (isAttached()) {
-		v3f pos = m_env->getActiveObject(m_attachment_parent_id)->getBasePosition();
+	if (auto *parent = getParent()) {
+		v3f pos = parent->getBasePosition();
 		m_last_good_position = pos;
 		setBasePosition(pos);
 	}
@@ -574,28 +574,9 @@ bool PlayerSAO::checkMovementCheat()
 		m_last_good_position = m_base_position;
 		return false;
 	}
-	if (UnitSAO *parent = dynamic_cast<UnitSAO *>(getParent())) {
-		v3f attachment_pos;
-		{
-			int parent_id;
-			std::string bone;
-			v3f attachment_rot;
-			bool force_visible;
-			getAttachment(&parent_id, &bone, &attachment_pos, &attachment_rot, &force_visible);
-		}
 
-		v3f parent_pos = parent->getBasePosition();
-		f32 diff = m_base_position.getDistanceFromSQ(parent_pos) - attachment_pos.getLengthSQ();
-		const f32 maxdiff = 4.0f * BS; // fair trade-off value for various latencies
-
-		if (diff > maxdiff * maxdiff) {
-			setBasePosition(parent_pos);
-			actionstream << "Server: " << m_player->getName()
-					<< " moved away from parent; diff=" << sqrtf(diff) / BS
-					<< " resetting position." << std::endl;
-			return true;
-		}
-		// Player movement is locked to the entity. Skip further checks
+	if (getParent()) {
+		// Player movement is locked by parent. Position updates are ignored.
 		return false;
 	}
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -264,6 +264,9 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		v3f pos = parent->getBasePosition();
 		m_last_good_position = pos;
 		setBasePosition(pos);
+
+		if (m_player)
+			m_player->setSpeed(v3f());
 	}
 
 	if (!send_recommended)


### PR DESCRIPTION
Supersedes #10928: simpler variant, without the interpolator class.
Fixes #10908

The server must have authority about attachments (see https://github.com/minetest/minetest/pull/10928#issuecomment-778676120). This PR ignores any player movement packets as long they're attached, and the client will no longer send them either (superfluous).

## To do

This PR is Ready for Review.

## How to test

1. Create a server
2. Check whether you can see other players moving
3. Place cart onto rail, attach
4. [this script](https://github.com/minetest/minetest/issues/10908#issuecomment-774481432)

The entity must still move normally without any interpolation/position reset glitches.