### PR TITLE
[DONT SQUASH] Switch Irrlicht dependency to our own fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Install deps
         run: |
           source ./util/ci/common.sh
-          install_linux_deps clang-9
+          install_linux_deps --old-irr clang-9
 
       - name: Build prometheus-cpp
         run: |
@@ -212,7 +212,10 @@ jobs:
 
   msvc:
     name: VS 2019 ${{ matrix.config.arch }}-${{ matrix.type }}
-    runs-on: windows-2019 
+    runs-on: windows-2019
+    #### Disabled due to Irrlicht switch
+    if: false
+    #### Disabled due to Irrlicht switch
     env:
       VCPKG_VERSION: 0bf3923f9fab4001c00f0f429682a0853b5749e0
 #                    2020.11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,29 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 # This is done here so that relative search paths are more reasonable
 find_package(Irrlicht)
+if(BUILD_CLIENT AND NOT IRRLICHT_FOUND)
+	message(FATAL_ERROR "Irrlicht is required to build the client, but it was not found.")
+elseif(IRRLICHT_INCLUDE_DIR STREQUAL "")
+	message(FATAL_ERROR "Irrlicht headers are required to build the server, but none found.")
+endif()
+
+include(CheckSymbolExists)
+set(CMAKE_REQUIRED_INCLUDES ${IRRLICHT_INCLUDE_DIR})
+unset(HAS_FORKED_IRRLICHT CACHE)
+check_symbol_exists(IRRLICHT_VERSION_MT "IrrCompileConfig.h" HAS_FORKED_IRRLICHT)
+if(NOT HAS_FORKED_IRRLICHT)
+	string(CONCAT EXPLANATION_MSG
+		"Irrlicht found, but it is not Minetest's Irrlicht fork. "
+		"The Minetest team has forked Irrlicht to make their own customizations. "
+		"It can be found here: https://github.com/minetest/irrlicht")
+	if(BUILD_CLIENT)
+		message(FATAL_ERROR "${EXPLANATION_MSG}\n"
+			"Building the client with upstream Irrlicht is no longer possible.")
+	else()
+		message(WARNING "${EXPLANATION_MSG}\n"
+			"The server can still be built with upstream Irrlicht but this is DISCOURAGED.")
+	endif()
+endif()
 
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Compiling
 |------------|---------|------------|
 | GCC        | 4.9+    | Can be replaced with Clang 3.4+ |
 | CMake      | 2.6+    |            |
-| Irrlicht   | 1.7.3+  |            |
+| Irrlicht   | -       | Custom version required, see https://github.com/minetest/irrlicht |
 | SQLite3    | 3.0+    |            |
 | LuaJIT     | 2.0+    | Bundled Lua 5.1 is used if not present |
 | GMP        | 5.0.0+  | Bundled mini-GMP is used if not present |
@@ -142,19 +142,19 @@ Compiling
 
 For Debian/Ubuntu users:
 
-    sudo apt install g++ make libc6-dev libirrlicht-dev cmake libbz2-dev libpng-dev libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev
+    sudo apt install g++ make libc6-dev cmake libpng-dev libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev
 
 For Fedora users:
 
-    sudo dnf install make automake gcc gcc-c++ kernel-devel cmake libcurl-devel openal-soft-devel libvorbis-devel libXxf86vm-devel libogg-devel freetype-devel mesa-libGL-devel zlib-devel jsoncpp-devel irrlicht-devel bzip2-libs gmp-devel sqlite-devel luajit-devel leveldb-devel ncurses-devel doxygen spatialindex-devel bzip2-devel
+    sudo dnf install make automake gcc gcc-c++ kernel-devel cmake libcurl-devel openal-soft-devel libvorbis-devel libXxf86vm-devel libogg-devel freetype-devel mesa-libGL-devel zlib-devel jsoncpp-devel gmp-devel sqlite-devel luajit-devel leveldb-devel ncurses-devel spatialindex-devel
     
 For Arch users:
 
-    sudo pacman -S base-devel libcurl-gnutls cmake libxxf86vm irrlicht libpng sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses
+    sudo pacman -S base-devel libcurl-gnutls cmake libxxf86vm libpng sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses
 
 For Alpine users:
 
-    sudo apk add build-base irrlicht-dev cmake bzip2-dev libpng-dev jpeg-dev libxxf86vm-dev mesa-dev sqlite-dev libogg-dev libvorbis-dev openal-soft-dev curl-dev freetype-dev zlib-dev gmp-dev jsoncpp-dev luajit-dev
+    sudo apk add build-base cmake libpng-dev jpeg-dev libxxf86vm-dev mesa-dev sqlite-dev libogg-dev libvorbis-dev openal-soft-dev curl-dev freetype-dev zlib-dev gmp-dev jsoncpp-dev luajit-dev
 
 #### Download
 
@@ -209,8 +209,8 @@ Run it:
 - You can disable the client build by specifying `-DBUILD_CLIENT=FALSE`.
 - You can select between Release and Debug build by `-DCMAKE_BUILD_TYPE=<Debug or Release>`.
   - Debug build is slower, but gives much more useful output in a debugger.
-- If you build a bare server you don't need to have Irrlicht installed.
-  - In that case use `-DIRRLICHT_SOURCE_DIR=/the/irrlicht/source`.
+- If you build a bare server you don't need to have the Irrlicht library installed.
+  - In that case use `-DIRRLICHT_INCLUDE_DIR=/some/where/irrlicht/include`.
 
 ### CMake options
 
@@ -246,8 +246,6 @@ General options and their default values:
 
 Library specific options:
 
-    BZIP2_INCLUDE_DIR               - Linux only; directory where bzlib.h is located
-    BZIP2_LIBRARY                   - Linux only; path to libbz2.a/libbz2.so
     CURL_DLL                        - Only if building with cURL on Windows; path to libcurl.dll
     CURL_INCLUDE_DIR                - Only if building with cURL; directory where curl.h is located
     CURL_LIBRARY                    - Only if building with cURL; path to libcurl.a/libcurl.so/libcurl.lib
@@ -276,7 +274,6 @@ Library specific options:
     SPATIAL_LIBRARY                 - Only when building with LibSpatial; path to libspatialindex_c.so/spatialindex-32.lib
     LUA_INCLUDE_DIR                 - Only if you want to use LuaJIT; directory where luajit.h is located
     LUA_LIBRARY                     - Only if you want to use LuaJIT; path to libluajit.a/libluajit.so
-    MINGWM10_DLL                    - Only if compiling with MinGW; path to mingwm10.dll
     OGG_DLL                         - Only if building with sound on Windows; path to libogg.dll
     OGG_INCLUDE_DIR                 - Only if building with sound; directory that contains an ogg directory which contains ogg.h
     OGG_LIBRARY                     - Only if building with sound; path to libogg.a/libogg.so/libogg.dll.a
@@ -314,9 +311,10 @@ It is highly recommended to use vcpkg as package manager.
 
 After you successfully built vcpkg you can easily install the required libraries:
 ```powershell
-vcpkg install irrlicht zlib curl[winssl] openal-soft libvorbis libogg sqlite3 freetype luajit gmp jsoncpp --triplet x64-windows
+vcpkg install zlib curl[winssl] openal-soft libvorbis libogg sqlite3 freetype luajit gmp jsoncpp --triplet x64-windows
 ```
 
+- **Note that you currently need to build irrlicht on your own**
 - `curl` is optional, but required to read the serverlist, `curl[winssl]` is required to use the content store.
 - `openal-soft`, `libvorbis` and `libogg` are optional, but required to use sound.
 - `freetype` is optional, it allows true-type font rendering.

--- a/cmake/Modules/FindIrrlicht.cmake
+++ b/cmake/Modules/FindIrrlicht.cmake
@@ -1,44 +1,11 @@
 
 mark_as_advanced(IRRLICHT_LIBRARY IRRLICHT_INCLUDE_DIR IRRLICHT_DLL)
-set(IRRLICHT_SOURCE_DIR "" CACHE PATH "Path to irrlicht source directory (optional)")
 
+# Find include directory and libraries
 
-# Find include directory
-
-if(NOT IRRLICHT_SOURCE_DIR STREQUAL "")
-	set(IRRLICHT_SOURCE_DIR_INCLUDE
-		"${IRRLICHT_SOURCE_DIR}/include"
-	)
-
-	set(IRRLICHT_LIBRARY_NAMES libIrrlicht.a Irrlicht Irrlicht.lib)
-
-	if(WIN32)
-		if(MSVC)
-			set(IRRLICHT_SOURCE_DIR_LIBS "${IRRLICHT_SOURCE_DIR}/lib/Win32-visualstudio")
-			set(IRRLICHT_LIBRARY_NAMES Irrlicht.lib)
-		else()
-			set(IRRLICHT_SOURCE_DIR_LIBS "${IRRLICHT_SOURCE_DIR}/lib/Win32-gcc")
-			set(IRRLICHT_LIBRARY_NAMES libIrrlicht.a libIrrlicht.dll.a)
-		endif()
-	else()
-		set(IRRLICHT_SOURCE_DIR_LIBS "${IRRLICHT_SOURCE_DIR}/lib/Linux")
-		set(IRRLICHT_LIBRARY_NAMES libIrrlicht.a)
-	endif()
-
+if(TRUE)
 	find_path(IRRLICHT_INCLUDE_DIR NAMES irrlicht.h
-		PATHS
-		${IRRLICHT_SOURCE_DIR_INCLUDE}
-		NO_DEFAULT_PATH
-	)
-
-	find_library(IRRLICHT_LIBRARY NAMES ${IRRLICHT_LIBRARY_NAMES}
-		PATHS
-		${IRRLICHT_SOURCE_DIR_LIBS}
-		NO_DEFAULT_PATH
-	)
-
-else()
-	find_path(IRRLICHT_INCLUDE_DIR NAMES irrlicht.h
+		DOC "Path to the directory with Irrlicht includes"
 		PATHS
 		/usr/local/include/irrlicht
 		/usr/include/irrlicht
@@ -46,7 +13,8 @@ else()
 		PATH_SUFFIXES "include/irrlicht"
 	)
 
-	find_library(IRRLICHT_LIBRARY NAMES libIrrlicht.so libIrrlicht.a Irrlicht
+	find_library(IRRLICHT_LIBRARY NAMES libIrrlicht Irrlicht
+		DOC "Path to the Irrlicht library file"
 		PATHS
 		/usr/local/lib
 		/usr/lib
@@ -54,19 +22,14 @@ else()
 	)
 endif()
 
+# Users will likely need to edit these
+mark_as_advanced(CLEAR IRRLICHT_LIBRARY IRRLICHT_INCLUDE_DIR)
 
 # On Windows, find the DLL for installation
 if(WIN32)
 	# If VCPKG_APPLOCAL_DEPS is ON, dll's are automatically handled by VCPKG
 	if(NOT VCPKG_APPLOCAL_DEPS)
-		if(MSVC)
-			set(IRRLICHT_COMPILER "VisualStudio")
-		else()
-			set(IRRLICHT_COMPILER "gcc")
-		endif()
 		find_file(IRRLICHT_DLL NAMES Irrlicht.dll
-			PATHS
-			"${IRRLICHT_SOURCE_DIR}/bin/Win32-${IRRLICHT_COMPILER}"
 			DOC "Path of the Irrlicht dll (for installation)"
 		)
 	endif()

--- a/misc/Info.plist
+++ b/misc/Info.plist
@@ -8,7 +8,13 @@
 	<string>minetest</string>
 	<key>CFBundleIconFile</key>
 	<string>minetest-icon.icns</string>
+	<key>CFBundleName</key>
+	<string>Minetest</string>
+	<key>CFBundleDisplayName</key>
+	<string>Minetest</string>
 	<key>CFBundleIdentifier</key>
 	<string>net.minetest.minetest</string>
+	<key>NSHighResolutionCapable</key>
+	<false/>
 </dict>
 </plist>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -295,7 +295,6 @@ else()
 		endif(NOT HAIKU AND NOT APPLE)
 
 		find_package(JPEG REQUIRED)
-		find_package(BZip2 REQUIRED)
 		find_package(PNG REQUIRED)
 		if(APPLE)
 			find_library(CARBON_LIB Carbon REQUIRED)

--- a/src/client/render/interlaced.cpp
+++ b/src/client/render/interlaced.cpp
@@ -35,7 +35,11 @@ void RenderingCoreInterlaced::initMaterial()
 	IShaderSource *s = client->getShaderSource();
 	mat.UseMipMaps = false;
 	mat.ZBuffer = false;
+#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR > 8
+	mat.ZWriteEnable = video::EZW_OFF;
+#else
 	mat.ZWriteEnable = false;
+#endif
 	u32 shader = s->getShader("3d_interlaced_merge", TILE_MATERIAL_BASIC);
 	mat.MaterialType = s->getShaderInfo(shader).material;
 	for (int k = 0; k < 3; ++k) {

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -325,9 +325,11 @@ static bool getWindowHandle(irr::video::IVideoDriver *driver, HWND &hWnd)
 	const video::SExposedVideoData exposedData = driver->getExposedVideoData();
 
 	switch (driver->getDriverType()) {
+#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9
 	case video::EDT_DIRECT3D8:
 		hWnd = reinterpret_cast<HWND>(exposedData.D3D8.HWnd);
 		break;
+#endif
 	case video::EDT_DIRECT3D9:
 		hWnd = reinterpret_cast<HWND>(exposedData.D3D9.HWnd);
 		break;

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -39,12 +39,13 @@ static video::SMaterial baseMaterial()
 {
 	video::SMaterial mat;
 	mat.Lighting = false;
-#if ENABLE_GLES
+#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR > 8
 	mat.ZBuffer = video::ECFN_DISABLED;
+	mat.ZWriteEnable = video::EZW_OFF;
 #else
+	mat.ZWriteEnable = false;
 	mat.ZBuffer = video::ECFN_NEVER;
 #endif
-	mat.ZWriteEnable = false;
 	mat.AntiAliasing = 0;
 	mat.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
 	mat.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -506,6 +506,13 @@ video::SColor GUIButton::getOverrideColor() const
 	return OverrideColor;
 }
 
+#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR > 8
+video::SColor GUIButton::getActiveColor() const
+{
+	return video::SColor(0,0,0,0); // unused?
+}
+#endif
+
 void GUIButton::enableOverrideColor(bool enable)
 {
 	OverrideColorEnabled = enable;

--- a/src/gui/guiButton.h
+++ b/src/gui/guiButton.h
@@ -69,6 +69,12 @@ using namespace irr;
 
 class ISimpleTextureSource;
 
+#if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 8)
+#define OVERRIDE_19
+#else
+#define OVERRIDE_19 override
+#endif
+
 class GUIButton : public gui::IGUIButton
 {
 public:
@@ -97,22 +103,27 @@ public:
 	virtual gui::IGUIFont* getActiveFont() const override;
 
 	//! Sets another color for the button text.
-	virtual void setOverrideColor(video::SColor color);
+	virtual void setOverrideColor(video::SColor color) OVERRIDE_19;
 
 	//! Gets the override color
-	virtual video::SColor getOverrideColor(void) const;
+	virtual video::SColor getOverrideColor(void) const OVERRIDE_19;
+
+	#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR > 8
+	//! Gets the currently used text color
+	virtual video::SColor getActiveColor() const override;
+	#endif
 
 	//! Sets if the button text should use the override color or the color in the gui skin.
-	virtual void enableOverrideColor(bool enable);
+	virtual void enableOverrideColor(bool enable) OVERRIDE_19;
 
 	//! Checks if an override color is enabled
-	virtual bool isOverrideColorEnabled(void) const;
+	virtual bool isOverrideColorEnabled(void) const OVERRIDE_19;
 
 	// PATCH
 	//! Sets an image which should be displayed on the button when it is in the given state.
 	virtual void setImage(gui::EGUI_BUTTON_IMAGE_STATE state,
 			video::ITexture* image=nullptr,
-			const core::rect<s32>& sourceRect=core::rect<s32>(0,0,0,0));
+			const core::rect<s32>& sourceRect=core::rect<s32>(0,0,0,0)) OVERRIDE_19;
 
 	//! Sets an image which should be displayed on the button when it is in normal state.
 	virtual void setImage(video::ITexture* image=nullptr) override;
@@ -141,7 +152,7 @@ public:
 	*/
 	virtual void setSprite(gui::EGUI_BUTTON_STATE state, s32 index,
 						   video::SColor color=video::SColor(255,255,255,255),
-						   bool loop=false, bool scale=false);
+						   bool loop=false, bool scale=false) OVERRIDE_19;
 
 #if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 8)
 	void setSprite(gui::EGUI_BUTTON_STATE state, s32 index, video::SColor color, bool loop) override {
@@ -150,16 +161,16 @@ public:
 #endif
 
 	//! Get the sprite-index for the given state or -1 when no sprite is set
-	virtual s32 getSpriteIndex(gui::EGUI_BUTTON_STATE state) const;
+	virtual s32 getSpriteIndex(gui::EGUI_BUTTON_STATE state) const OVERRIDE_19;
 
 	//! Get the sprite color for the given state. Color is only used when a sprite is set.
-	virtual video::SColor getSpriteColor(gui::EGUI_BUTTON_STATE state) const;
+	virtual video::SColor getSpriteColor(gui::EGUI_BUTTON_STATE state) const OVERRIDE_19;
 
 	//! Returns if the sprite in the given state does loop
-	virtual bool getSpriteLoop(gui::EGUI_BUTTON_STATE state) const;
+	virtual bool getSpriteLoop(gui::EGUI_BUTTON_STATE state) const OVERRIDE_19;
 
 	//! Returns if the sprite in the given state is scaled
-	virtual bool getSpriteScale(gui::EGUI_BUTTON_STATE state) const;
+	virtual bool getSpriteScale(gui::EGUI_BUTTON_STATE state) const OVERRIDE_19;
 
 	//! Sets if the button should behave like a push button. Which means it
 	//! can be in two states: Normal or Pressed. With a click on the button,
@@ -199,13 +210,13 @@ public:
 	virtual bool isScalingImage() const override;
 
 	//! Get if the shift key was pressed in last EGET_BUTTON_CLICKED event
-	virtual bool getClickShiftState() const
+	virtual bool getClickShiftState() const OVERRIDE_19
 	{
 		return ClickShiftState;
 	}
 
 	//! Get if the control key was pressed in last EGET_BUTTON_CLICKED event
-	virtual bool getClickControlState() const
+	virtual bool getClickControlState() const OVERRIDE_19
 	{
 		return ClickControlState;
 	}

--- a/src/irrlicht_changes/static_text.cpp
+++ b/src/irrlicht_changes/static_text.cpp
@@ -255,6 +255,12 @@ video::SColor StaticText::getOverrideColor() const
 	return ColoredText.getDefaultColor();
 }
 
+#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR > 8
+video::SColor StaticText::getActiveColor() const
+{
+	return getOverrideColor();
+}
+#endif
 
 //! Sets if the static text should use the overide color or the
 //! color in the gui skin.

--- a/src/irrlicht_changes/static_text.h
+++ b/src/irrlicht_changes/static_text.h
@@ -140,6 +140,11 @@ namespace gui
 		virtual video::SColor getOverrideColor() const;
 		#endif
 
+		#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR > 8
+		//! Gets the currently used text color
+		virtual video::SColor getActiveColor() const;
+		#endif
+
 		//! Sets if the static text should use the overide color or the
 		//! color in the gui skin.
 		virtual void enableOverrideColor(bool enable);

--- a/util/buildbot/buildwin32.sh
+++ b/util/buildbot/buildwin32.sh
@@ -31,7 +31,7 @@ if [ -z "$toolchain_file" ]; then
 fi
 echo "Using $toolchain_file"
 
-irrlicht_version=1.8.4
+irrlicht_version=1.9.0mt0
 ogg_version=1.3.2
 vorbis_version=1.3.5
 curl_version=7.65.3
@@ -48,7 +48,7 @@ mkdir -p $libdir
 cd $builddir
 
 # Get stuff
-[ -e $packagedir/irrlicht-$irrlicht_version.zip ] || wget http://minetest.kitsunemimi.pw/irrlicht-$irrlicht_version-win32.zip \
+[ -e $packagedir/irrlicht-$irrlicht_version.zip ] || wget https://github.com/minetest/irrlicht/releases/download/$irrlicht_version/win32.zip \
 	-c -O $packagedir/irrlicht-$irrlicht_version.zip
 [ -e $packagedir/zlib-$zlib_version.zip ] || wget http://minetest.kitsunemimi.pw/zlib-$zlib_version-win32.zip \
 	-c -O $packagedir/zlib-$zlib_version.zip
@@ -102,6 +102,8 @@ if [ "x$NO_MINETEST_GAME" = "x" ]; then
 	cd ..
 fi
 
+irr_dlls=$(echo $libdir/irrlicht/bin/*.dll | tr ' ' ';')
+
 # Build the thing
 [ -d _build ] && rm -Rf _build/
 mkdir _build
@@ -118,9 +120,9 @@ cmake .. \
 	-DENABLE_FREETYPE=1 \
 	-DENABLE_LEVELDB=1 \
 	\
-	-DIRRLICHT_INCLUDE_DIR=$libdir/irrlicht/include \
-	-DIRRLICHT_LIBRARY=$libdir/irrlicht/lib/Win32-gcc/libIrrlicht.dll.a \
-	-DIRRLICHT_DLL=$libdir/irrlicht/bin/Win32-gcc/Irrlicht.dll \
+	-DIRRLICHT_INCLUDE_DIR=$libdir/irrlicht/include/irrlicht \
+	-DIRRLICHT_LIBRARY=$libdir/irrlicht/lib/libIrrlicht.dll.a \
+	-DIRRLICHT_DLL="$irr_dlls" \
 	\
 	-DZLIB_INCLUDE_DIR=$libdir/zlib/include \
 	-DZLIB_LIBRARIES=$libdir/zlib/lib/libz.dll.a \

--- a/util/buildbot/buildwin64.sh
+++ b/util/buildbot/buildwin64.sh
@@ -20,7 +20,7 @@ packagedir=$builddir/packages
 libdir=$builddir/libs
 
 toolchain_file=$dir/toolchain_x86_64-w64-mingw32.cmake
-irrlicht_version=1.8.4
+irrlicht_version=1.9.0mt0
 ogg_version=1.3.2
 vorbis_version=1.3.5
 curl_version=7.65.3
@@ -37,7 +37,7 @@ mkdir -p $libdir
 cd $builddir
 
 # Get stuff
-[ -e $packagedir/irrlicht-$irrlicht_version.zip ] || wget http://minetest.kitsunemimi.pw/irrlicht-$irrlicht_version-win64.zip \
+[ -e $packagedir/irrlicht-$irrlicht_version.zip ] || wget https://github.com/minetest/irrlicht/releases/download/$irrlicht_version/win64.zip \
 	-c -O $packagedir/irrlicht-$irrlicht_version.zip
 [ -e $packagedir/zlib-$zlib_version.zip ] || wget http://minetest.kitsunemimi.pw/zlib-$zlib_version-win64.zip \
 	-c -O $packagedir/zlib-$zlib_version.zip
@@ -92,6 +92,8 @@ if [ "x$NO_MINETEST_GAME" = "x" ]; then
 	cd ..
 fi
 
+irr_dlls=$(echo $libdir/irrlicht/bin/*.dll | tr ' ' ';')
+
 # Build the thing
 [ -d _build ] && rm -Rf _build/
 mkdir _build
@@ -108,9 +110,9 @@ cmake .. \
 	-DENABLE_FREETYPE=1 \
 	-DENABLE_LEVELDB=1 \
 	\
-	-DIRRLICHT_INCLUDE_DIR=$libdir/irrlicht/include \
-	-DIRRLICHT_LIBRARY=$libdir/irrlicht/lib/Win64-gcc/libIrrlicht.dll.a \
-	-DIRRLICHT_DLL=$libdir/irrlicht/bin/Win64-gcc/Irrlicht.dll \
+	-DIRRLICHT_INCLUDE_DIR=$libdir/irrlicht/include/irrlicht \
+	-DIRRLICHT_LIBRARY=$libdir/irrlicht/lib/libIrrlicht.dll.a \
+	-DIRRLICHT_DLL="$irr_dlls" \
 	\
 	-DZLIB_INCLUDE_DIR=$libdir/zlib/include \
 	-DZLIB_LIBRARIES=$libdir/zlib/lib/libz.dll.a \

--- a/util/ci/common.sh
+++ b/util/ci/common.sh
@@ -2,11 +2,19 @@
 
 # Linux build only
 install_linux_deps() {
-	local pkgs=(libirrlicht-dev cmake libbz2-dev libpng-dev \
+	local pkgs=(cmake libpng-dev \
 		libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev \
 		libhiredis-dev libogg-dev libgmp-dev libvorbis-dev libopenal-dev \
 		gettext libpq-dev postgresql-server-dev-all libleveldb-dev \
 		libcurl4-openssl-dev)
+
+	if [[ "$1" == "--old-irr" ]]; then
+		shift
+		pkgs+=(libirrlicht-dev)
+	else
+		wget "https://github.com/minetest/irrlicht/releases/download/1.9.0mt0/ubuntu-bionic.tar.gz"
+		sudo tar -xaf ubuntu-bionic.tar.gz -C /usr/local
+	fi
 
 	sudo apt-get update
 	sudo apt-get install -y --no-install-recommends ${pkgs[@]} "$@"


### PR DESCRIPTION
~~counterpart: https://github.com/minetest/irrlicht/pull/12~~

<b>How does CI work?</b>

For both Ubuntu 18.04 and Windows we publish precompiled builds on [the release page](https://github.com/minetest/irrlicht/releases).
(One release can be tagged when a revision is declared stable, see below.)

<b>What's that revision number in `IrrCompileConfig.h` for?</b>

It allows us to keep compatibility with multiple versions of our forked Irrlicht (rev++ on every breaking change).
There is no requirement to support this in releases but it can still be useful for development.


I don't know if distros will want to package mt-irrlicht separately, but this would also help in that case.

<b>What else does this PR do?</b>

* it fixes #10654
* it makes building MT on M1 macs relatively easy (tested by @Jordach, thanks!)
* probably fixes other open bugs which I will not attempt to find

## To do

This PR is Ready for Review.

- [x] Fix CI
- [x] Decide if building the server with upstream Irrlicht should be allowed
-> **yes**, we can always revise this stance when problems occurr or before 5.5.0

## How to test

Build it and see if it still works.
