### PR TITLE
Add Lua API for Prometheus Metrics

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5181,11 +5181,16 @@ Metrics
 The following function is only available when Minetest was built with
 [Prometheus](https://wiki.minetest.net/Server_Metrics_using_Prometheus).
 
-* `minetest.create_metric(type, name, help)`
+* `minetest.create_metric(type, name [, help, labels])`
     * Returns `MetricRef`.
-    * `type`: `counter` or `gauge`, see [MetricRef].
-    * `name`: name of the metric.
-    * `help`: help description about the metric.
+    * `type`: strinrg, `counter` or `gauge`, see [MetricRef].
+    * `name`: string, name of the metric.
+    * `help`: string or nil, a help description about the metric.
+    * `labels`: table or nil, a map from label keys to values.
+
+You can call this multiple times for the same metric name to create dimensional/labelled data.
+All metrics with the same name must have the same type, and `help` will only be read the first
+time the metric name is created.
 
 Metric names can only contain letters, numbers, and underscores. You should
 start the name with your mod name plus an underscore, eg: `mymod_some_statistic`.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5178,19 +5178,21 @@ You can find mod channels communication scheme in `doc/mod_channels.png`.
 Metrics
 -------
 
-The following function is only available when Minetest was built with
+The following function will only be defined when Minetest was built with
 [Prometheus](https://wiki.minetest.net/Server_Metrics_using_Prometheus).
 
 * `minetest.create_metric(type, name [, help, labels])`
-    * Returns `MetricRef`.
-    * `type`: strinrg, `counter` or `gauge`, see [MetricRef].
+    * Returns [`MetricRef`].
+    * `type`: string, `counter` or `gauge`, see [`MetricRef`].
     * `name`: string, name of the metric.
     * `help`: string or nil, a help description about the metric.
     * `labels`: table or nil, a map from label keys to values.
-
-You can call this multiple times for the same metric name to create dimensional/labelled data.
-All metrics with the same name must have the same type, and `help` will only be read the first
-time the metric name is created.
+    * You can call this multiple times with the same metric name and
+      different labels to create dimensional/labelled data.
+    * All metrics with the same name must have the same type, and
+      `help` will only be read the first time the metric name is created.
+    * It's fine to call this multiple times with the same arguments,
+      but it is recommended to store the MetricRef for ease of use.
 
 Metric names can only contain letters, numbers, and underscores. You should
 start the name with your mod name plus an underscore, eg: `mymod_some_statistic`.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5174,6 +5174,25 @@ You can find mod channels communication scheme in `doc/mod_channels.png`.
       should listen for incoming messages with
       `minetest.register_on_modchannel_message`
 
+
+Metrics
+-------
+
+The following function is only available when Minetest was built with
+[Prometheus](https://wiki.minetest.net/Server_Metrics_using_Prometheus).
+
+* `minetest.create_metric(type, name, help)`
+    * Returns `MetricRef`.
+    * `type`: `counter` or `gauge`, see [MetricRef].
+    * `name`: name of the metric.
+    * `help`: help description about the metric.
+
+Metric names can only contain letters, numbers, and underscores. You should
+start the name with your mod name plus an underscore, eg: `mymod_some_statistic`.
+When Prometheus queries for metrics, Minetest will prepend your name with
+`minetest_`, eg: `minetest_mymod_some_statistic`.
+
+
 Inventory
 ---------
 
@@ -6136,6 +6155,31 @@ An interface to use mod channels on client and server
 * `send_all(message)`: Send `message` though the mod channel.
     * If mod channel is not writeable or invalid, message will be dropped.
     * Message size is limited to 65535 characters by protocol.
+
+`MetricRef`
+-----------
+
+Represents a value to be used in metric gathering software, such as
+Prometheus.
+
+Created by [`minetest.create_metric`](#Metrics)
+
+A metric is either a gauge or a counter.
+A gauge may go up and down as needed, but a counter may only increase.
+See [Prometheus Metric Types](https://prometheus.io/docs/concepts/metric_types/).
+
+## Methods
+
+* increment([value]):
+    * Increment by `value`.
+    * `value` defaults to 1 if not present.
+* decrement([value]):
+    * Decrement by `value`. Gauges only.
+    * `value` defaults to 1 if not present.
+* set(value):
+    * Set `value`. Gauges only.
+* get(): returns current value.
+
 
 `NodeMetaRef`
 -------------

--- a/src/map.h
+++ b/src/map.h
@@ -428,7 +428,7 @@ private:
 	MapDatabase *dbase = nullptr;
 	MapDatabase *dbase_ro = nullptr;
 
-	MetricCounterPtr m_save_time_counter;
+	MetricPtr m_save_time_counter;
 };
 
 

--- a/src/script/common/helper.cpp
+++ b/src/script/common/helper.cpp
@@ -78,6 +78,15 @@ float LuaHelper::readParam(lua_State *L, int index)
 }
 
 template <>
+double LuaHelper::readParam(lua_State *L, int index)
+{
+	if (isNaN(L, index))
+		throw LuaError("NaN value is not allowed.");
+
+	return (double)luaL_checknumber(L, index);
+}
+
+template <>
 v2s16 LuaHelper::readParam(lua_State *L, int index)
 {
 	v2s16 p;

--- a/src/script/lua_api/CMakeLists.txt
+++ b/src/script/lua_api/CMakeLists.txt
@@ -10,6 +10,7 @@ set(common_SCRIPT_LUA_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/l_itemstackmeta.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_mapgen.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_metadata.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/l_metrics.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_modchannels.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_nodemeta.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_nodetimer.cpp

--- a/src/script/lua_api/l_metrics.cpp
+++ b/src/script/lua_api/l_metrics.cpp
@@ -1,0 +1,182 @@
+/*
+Minetest
+Copyright (C) 2021  rubenwardy
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "lua_api/l_internal.h"
+#include "common/c_content.h"
+#include "lua_api/l_metrics.h"
+#include "server.h"
+
+#if USE_PROMETHEUS
+
+class MetricRef : public ModApiBase
+{
+	MetricPtr metric;
+
+	explicit MetricRef(MetricPtr metric) : metric(metric) {}
+
+	// increment(v)
+	static int l_increment(lua_State *L)
+	{
+		auto metric = checkMetric(L, 1);
+
+		double number = readParam<double>(L, 2, 1.0);
+		metric->increment(number);
+		return 0;
+	}
+
+	// decrement(v)
+	static int l_decrement(lua_State *L)
+	{
+		auto metric = checkMetricGauge(L, 1);
+
+		double number = readParam<double>(L, 2, 1.0);
+		metric->decrement(number);
+		return 0;
+	}
+
+	// set(v)
+	static int l_set(lua_State *L)
+	{
+		auto metric = checkMetricGauge(L, 1);
+
+		double number = luaL_checknumber(L, 2);
+		metric->set(number);
+		return 0;
+	}
+
+	// get()
+	static int l_get(lua_State *L)
+	{
+		auto metric = checkMetric(L, 1);
+
+		lua_pushnumber(L, metric->get());
+		return 1;
+	}
+
+	// garbage collector
+	static int gc_object(lua_State *L)
+	{
+		MetricRef *o = *(MetricRef **)(lua_touserdata(L, 1));
+		delete o;
+		return 0;
+	}
+
+	static MetricRef *checkobject(lua_State *L, int narg)
+	{
+		luaL_checktype(L, narg, LUA_TUSERDATA);
+
+		void *ud = luaL_checkudata(L, narg, className);
+		if (!ud)
+			luaL_typerror(L, narg, className);
+
+		return *(MetricRef **)ud; // unbox pointer
+	}
+
+	static MetricPtr checkMetric(lua_State *L, int narg)
+	{
+		auto ref = checkobject(L, narg);
+		return ref->metric;
+	}
+
+	static MetricGauge *checkMetricGauge(lua_State *L, int narg)
+	{
+		auto ref = checkobject(L, narg);
+		auto ret = dynamic_cast<MetricGauge *>(ref->metric.get());
+		if (!ret)
+			throw LuaError("Expected gauge metric");
+		return ret;
+	}
+
+	static const char className[];
+	static const luaL_Reg methods[];
+
+public:
+	static void create(lua_State *L, MetricPtr metric)
+	{
+		MetricRef *o = new MetricRef(metric);
+		*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
+		luaL_getmetatable(L, className);
+		lua_setmetatable(L, -2);
+	}
+
+	static void Register(lua_State *L)
+	{
+		lua_newtable(L);
+		int methodtable = lua_gettop(L);
+		luaL_newmetatable(L, className);
+		int metatable = lua_gettop(L);
+
+		lua_pushliteral(L, "__metatable");
+		lua_pushvalue(L, methodtable);
+		lua_settable(L, metatable); // hide metatable from lua getmetatable()
+
+		lua_pushliteral(L, "__index");
+		lua_pushvalue(L, methodtable);
+		lua_settable(L, metatable);
+
+		lua_pushliteral(L, "__gc");
+		lua_pushcfunction(L, gc_object);
+		lua_settable(L, metatable);
+
+		lua_pop(L, 1); // Drop metatable
+
+		luaL_openlib(L, 0, methods, 0); // fill methodtable
+		lua_pop(L, 1);			// Drop methodtable
+	}
+};
+
+const char MetricRef::className[] = "MetricsGaugeRef";
+const luaL_Reg MetricRef::methods[] = {
+		luamethod(MetricRef, increment),
+		luamethod(MetricRef, decrement),
+		luamethod(MetricRef, set),
+		luamethod(MetricRef, get),
+		{0, 0},
+};
+
+// create_metric(type, name, help)
+int ModApiMetrics::l_create_metric(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	std::string type = luaL_checkstring(L, 1);
+	std::string name = luaL_checkstring(L, 2);
+	std::string help = luaL_checkstring(L, 3);
+
+	name.insert(0, "minetest_");
+
+	auto metrics = getServer(L)->getMetrics();
+	if (type == "counter") {
+		MetricRef::create(L, metrics->addCounter(name, help));
+	} else if (type == "gauge") {
+		MetricRef::create(L, metrics->addGauge(name, help));
+	} else {
+		throw LuaError(std::string("Unknown metric type ") + type);
+	}
+	return 1;
+}
+
+void ModApiMetrics::Initialize(lua_State *L, int top)
+{
+	MetricRef::Register(L);
+
+	API_FCT(create_metric);
+}
+
+#endif

--- a/src/script/lua_api/l_metrics.h
+++ b/src/script/lua_api/l_metrics.h
@@ -1,0 +1,44 @@
+/*
+Minetest
+Copyright (C) 2021  rubenwardy
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "lua_api/l_base.h"
+#include "config.h"
+
+#if USE_PROMETHEUS
+
+class ModApiMetrics : public ModApiBase
+{
+	// create_metric(type, name, help)
+	static int l_create_metric(lua_State *L);
+
+public:
+	static void Initialize(lua_State *L, int top);
+};
+
+#else
+
+class ModApiMetrics : public ModApiBase
+{
+public:
+	static void Initialize(lua_State *L, int top) {}
+};
+
+#endif

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -45,6 +45,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_settings.h"
 #include "lua_api/l_http.h"
 #include "lua_api/l_storage.h"
+#include "lua_api/l_metrics.h"
 
 extern "C" {
 #include "lualib.h"
@@ -124,4 +125,5 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	ModApiHttp::Initialize(L, top);
 	ModApiStorage::Initialize(L, top);
 	ModApiChannels::Initialize(L, top);
+	ModApiMetrics::Initialize(L, top);
 }

--- a/src/server.h
+++ b/src/server.h
@@ -368,6 +368,10 @@ public:
 	// Get or load translations for a language
 	Translations *getTranslationLanguage(const std::string &lang_code);
 
+	inline MetricsBackend *getMetrics() const {
+		return m_metrics_backend.get();
+	}
+
 	// Bind address
 	Address m_bind_addr;
 
@@ -674,14 +678,14 @@ private:
 	std::unique_ptr<MetricsBackend> m_metrics_backend;
 
 	// Server metrics
-	MetricCounterPtr m_uptime_counter;
+	MetricPtr m_uptime_counter;
 	MetricGaugePtr m_player_gauge;
 	MetricGaugePtr m_timeofday_gauge;
 	// current server step lag
 	MetricGaugePtr m_lag_gauge;
-	MetricCounterPtr m_aom_buffer_counter;
-	MetricCounterPtr m_packet_recv_counter;
-	MetricCounterPtr m_packet_recv_processed_counter;
+	MetricPtr m_aom_buffer_counter;
+	MetricPtr m_packet_recv_counter;
+	MetricPtr m_packet_recv_processed_counter;
 };
 
 /*

--- a/src/util/metricsbackend.h
+++ b/src/util/metricsbackend.h
@@ -131,10 +131,10 @@ public:
 
 	virtual ~MetricsBackend() {}
 
-	virtual MetricPtr addCounter(
-			const std::string &name, const std::string &help_str, const MetricLabels &labels = {});
-	virtual MetricGaugePtr addGauge(
-			const std::string &name, const std::string &help_str, const MetricLabels &labels = {});
+	virtual MetricPtr addCounter(const std::string &name, const std::string &help_str,
+			const MetricLabels &labels = {});
+	virtual MetricGaugePtr addGauge(const std::string &name,
+			const std::string &help_str, const MetricLabels &labels = {});
 };
 
 #if USE_PROMETHEUS

--- a/src/util/metricsbackend.h
+++ b/src/util/metricsbackend.h
@@ -122,6 +122,8 @@ private:
 	double m_gauge;
 };
 
+using MetricLabels = std::map<std::string, std::string>;
+
 class MetricsBackend
 {
 public:
@@ -130,9 +132,9 @@ public:
 	virtual ~MetricsBackend() {}
 
 	virtual MetricPtr addCounter(
-			const std::string &name, const std::string &help_str);
+			const std::string &name, const std::string &help_str, const MetricLabels &labels = {});
 	virtual MetricGaugePtr addGauge(
-			const std::string &name, const std::string &help_str);
+			const std::string &name, const std::string &help_str, const MetricLabels &labels = {});
 };
 
 #if USE_PROMETHEUS


### PR DESCRIPTION
A while back, nerzhul [added support for prometheus](https://github.com/minetest/minetest/pull/9719).

This PR adds an API to allow mods to add their own Prometheus metrics. They can create multi-dimensional counter or gauge metrics.

Here's what I'm using it for: https://monitor.rubenwardy.com/d/9TgIegyGk/ctf

## To do

This PR is a Work in Progress.

- [x] Support for labels
- [ ] Clean up Metric type hierarchy/API
- [ ] Clean up how dimensional data is created (no point in passing in type and help again)
- [ ] Testing

## How to test

```lua
if not minetest.create_metric then
	error("No metrics!")
	return
end

local chat_counter = minetest.create_metric("counter", "chat_messages", "Total chat messages")
minetest.register_on_chat_message(function()
	chat_counter:increment()
end)
```

