### PR TITLE
porting: Slap u64 on everything time-y

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3265,7 +3265,6 @@ Helper functions
     * returns true when the passed number represents NaN.
 * `minetest.get_us_time()`
     * returns time with microsecond precision. May not return wall time.
-    * This value might overflow on certain 32-bit systems!
 * `table.copy(table)`: returns a table
     * returns a deep copy of `table`
 * `table.indexof(list, val)`: returns the smallest numerical index containing

--- a/src/porting.h
+++ b/src/porting.h
@@ -234,21 +234,21 @@ inline u64 getTimeMs()
 {
 	struct timespec ts;
 	os_get_clock(&ts);
-	return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+	return ((u64) ts.tv_sec) * 1000LL + ((u64) ts.tv_nsec) / 1000000LL;
 }
 
 inline u64 getTimeUs()
 {
 	struct timespec ts;
 	os_get_clock(&ts);
-	return ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
+	return ((u64) ts.tv_sec) * 1000000LL + ((u64) ts.tv_nsec) / 1000LL;
 }
 
 inline u64 getTimeNs()
 {
 	struct timespec ts;
 	os_get_clock(&ts);
-	return ts.tv_sec * 1000000000 + ts.tv_nsec;
+	return ((u64) ts.tv_sec) * 1000000000LL + ((u64) ts.tv_nsec);
 }
 
 #endif


### PR DESCRIPTION
Hopefully *actually* (no, documenting it does *not* fix it) fixes #10105. Won't work if `os_get_clock` is flawed.

@hecktest can you test?