### PR TITLE
Fix wrong number of items in allow_metadata_inventory_put/take callbacks

### DIFF
--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -340,7 +340,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 	*/
 
 	ItemStack src_item = list_from->getItem(from_i);
-	if (count > 0)
+	if (count > 0 && count < src_item.count)
 		src_item.count = count;
 	if (src_item.empty())
 		return;


### PR DESCRIPTION
Make sure that number of items in callbacks is not more than exists in the source inventory or chest
Fix #10989