### PR TITLE
Fix keyWasDown in input handler

### DIFF
--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -113,17 +113,12 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 	if (event.EventType == irr::EET_KEY_INPUT_EVENT) {
 		const KeyPress &keyCode = event.KeyInput;
 		if (keysListenedFor[keyCode]) {
-				// If the key is being held down then the OS may
-				// send a continuous stream of keydown events.
-				// In this case, we don't want to let this
-				// stream reach the application as it will cause
-				// certain actions to repeat constantly.
 			if (event.KeyInput.PressedDown) {
-				if (!IsKeyDown(keyCode)) {
-					keyWasDown.set(keyCode);
+				if (!IsKeyDown(keyCode))
 					keyWasPressed.set(keyCode);
-				}
+
 				keyIsDown.set(keyCode);
+				keyWasDown.set(keyCode);
 			} else {
 				if (IsKeyDown(keyCode))
 					keyWasReleased.set(keyCode);

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -201,7 +201,7 @@ private:
 	// The current state of keys
 	KeyList keyIsDown;
 
-	// Whether a key was down
+	// Like keyIsDown but only reset when that key is read
 	KeyList keyWasDown;
 
 	// Whether a key has just been pressed


### PR DESCRIPTION
fixes `<LoneWolfHT> My issue is the fact that you could hold down the keys and it would repeatedly change, now you have to spam it to get it to change more than once`

might fix #10969 

## To do

This PR is Ready for Review.