### PR TITLE
Use vec4 for varTexCoord in interlaced shader

### DIFF
--- a/client/shaders/3d_interlaced_merge/opengl_fragment.glsl
+++ b/client/shaders/3d_interlaced_merge/opengl_fragment.glsl
@@ -6,7 +6,7 @@ uniform sampler2D textureFlags;
 #define rightImage normalTexture
 #define maskImage textureFlags
 
-varying mediump vec2 varTexCoord;
+varying mediump vec4 varTexCoord;
 
 void main(void)
 {

--- a/client/shaders/3d_interlaced_merge/opengl_vertex.glsl
+++ b/client/shaders/3d_interlaced_merge/opengl_vertex.glsl
@@ -1,4 +1,4 @@
-varying mediump vec2 varTexCoord;
+varying mediump vec4 varTexCoord;
 
 void main(void)
 {


### PR DESCRIPTION
Use `vec4` for `varTexCoord` in interlaced shader. Somewhen in the past, `inTexCoord0` was changed from `vec2`.

- Goal of the PR
Interlaced 3D mode is able to work correctly.
- Does it resolve any reported issue?
Yes, this PR tries to fix #10998.

This PR is Ready for Review.

## How to test
1. Use `3d_mode = interlaced` to enable interlaced 3D mode.
2. Try to run play a Minetest world.
3. Check that the shader works without errors.