### PR TITLE
Protect mg_name and mg_flags from being set by Lua

### DIFF
--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -26,11 +26,35 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 
 
-#define SET_SECURITY_CHECK(L, name) \
-	if (o->m_settings == g_settings && ScriptApiSecurity::isSecure(L) && \
-			name.compare(0, 7, "secure.") == 0) { \
-		throw LuaError("Attempt to set secure setting."); \
+/* This protects:
+ * 'secure.*' settings from being set
+ * some mapgen settings from being set
+ *   (not security-criticial, just to avoid messing up user configs)
+ */
+#define CHECK_SETTING_SECURITY(L, name) \
+	if (o->m_settings == g_settings) { \
+		if (checkSettingSecurity(L, name) == -1) \
+			return 0; \
 	}
+
+static inline int checkSettingSecurity(lua_State* L, const std::string &name)
+{
+	if (ScriptApiSecurity::isSecure(L) && name.compare(0, 7, "secure.") == 0)
+		throw LuaError("Attempt to set secure setting.");
+
+	bool is_mainmenu = false;
+#ifndef SERVER
+	is_mainmenu = ModApiBase::getGuiEngine(L) != nullptr;
+#endif
+	if (!is_mainmenu && (name == "mg_name" || name == "mg_flags")) {
+		errorstream << "Tried to set global setting " << name << ", ignoring. "
+			"minetest.set_mapgen_setting() should be used instead." << std::endl;
+		infostream << script_get_backtrace(L) << std::endl;
+		return -1;
+	}
+
+	return 0;
+}
 
 LuaSettings::LuaSettings(Settings *settings, const std::string &filename) :
 	m_settings(settings),
@@ -129,6 +153,7 @@ int LuaSettings::l_get_np_group(lua_State *L)
 	return 1;
 }
 
+// get_flags(self, key) -> table or nil
 int LuaSettings::l_get_flags(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -161,7 +186,7 @@ int LuaSettings::l_set(lua_State* L)
 	std::string key = std::string(luaL_checkstring(L, 2));
 	const char* value = luaL_checkstring(L, 3);
 
-	SET_SECURITY_CHECK(L, key);
+	CHECK_SETTING_SECURITY(L, key);
 
 	if (!o->m_settings->set(key, value))
 		throw LuaError("Invalid sequence found in setting parameters");
@@ -178,14 +203,14 @@ int LuaSettings::l_set_bool(lua_State* L)
 	std::string key = std::string(luaL_checkstring(L, 2));
 	bool value = readParam<bool>(L, 3);
 
-	SET_SECURITY_CHECK(L, key);
+	CHECK_SETTING_SECURITY(L, key);
 
 	o->m_settings->setBool(key, value);
 
-	return 1;
+	return 0;
 }
 
-// set(self, key, value)
+// set_np_group(self, key, value)
 int LuaSettings::l_set_np_group(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -195,7 +220,7 @@ int LuaSettings::l_set_np_group(lua_State *L)
 	NoiseParams value;
 	read_noiseparams(L, 3, &value);
 
-	SET_SECURITY_CHECK(L, key);
+	CHECK_SETTING_SECURITY(L, key);
 
 	o->m_settings->setNoiseParams(key, value);
 
@@ -210,7 +235,7 @@ int LuaSettings::l_remove(lua_State* L)
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 
-	SET_SECURITY_CHECK(L, key);
+	CHECK_SETTING_SECURITY(L, key);
 
 	bool success = o->m_settings->remove(key);
 	lua_pushboolean(L, success);


### PR DESCRIPTION
As I suggested months ago https://irc.minetest.net/minetest-dev/2020-11-03#i_5748973
mods or games setting mapgen stuff only ever confuses users when all their newly created worlds are broken.

## To do

This PR is Ready for Review.

## How to test

1. `//lua core.settings:set("mg_name", "foo")` -> should fail
2. Use advanced settings in mainmenu to change mapgen -> should work
