### PR TITLE
Schematic: Properly deal with before/after node resolving and document

### DIFF
--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -313,7 +313,8 @@ bool Schematic::deserializeFromMts(std::istream *is)
 		slice_probs[y] = (version >= 3) ? readU8(ss) : MTSCHEM_PROB_ALWAYS_OLD;
 
 	//// Read node names
-	m_nodenames.clear();
+	NodeResolver::reset();
+
 	u16 nidmapcount = readU16(ss);
 	for (int i = 0; i != nidmapcount; i++) {
 		std::string name = deSerializeString16(ss);
@@ -328,7 +329,9 @@ bool Schematic::deserializeFromMts(std::istream *is)
 
 		m_nodenames.push_back(name);
 	}
-	m_nodenames_idx = m_nodenames.size(); // All nodes are translated
+
+	// Prepare for node resolver
+	m_nnlistsizes.push_back(m_nodenames.size());
 
 	//// Read node data
 	size_t nodecount = size.X * size.Y * size.Z;
@@ -357,8 +360,6 @@ bool Schematic::deserializeFromMts(std::istream *is)
 			schemdata[i].param1 >>= 1;
 	}
 
-	// Prepare for node resolver
-	m_nnlistsizes.push_back(m_nodenames.size());
 	return true;
 }
 

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -440,12 +440,12 @@ bool Schematic::serializeToLua(std::ostream *os,
 
 				ss << indent << indent << "{" << "name=\"";
 
-				if (c < m_nodenames.size()) {
+				if (c < names.size()) {
 					// Get node name from cache
-					ss << m_nodenames[c];
+					ss << names[c];
 				} else {
-					// If cache is unavailable (biome decoration), use NodeDefManager
-					sanity_check(m_ndef != nullptr);
+					// If cache is unavailable (biome decoration)
+					FATAL_ERROR_IF(m_ndef == nullptr, "Invalid node list and missing NodeDefManager");
 					ss << m_ndef->get(c).name;
 				}
 

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -529,9 +529,7 @@ bool Schematic::saveSchematicToFile(const std::string &filename,
 			return false;
 
 		schem = (Schematic *)this->clone();
-
-		u32 volume = size.X * size.Y * size.Z;
-		schem->condenseContentIds(volume);
+		schem->condenseContentIds();
 	}
 
 	std::ostringstream os(std::ios_base::binary);
@@ -606,7 +604,7 @@ void Schematic::applyProbabilities(v3s16 p0,
 }
 
 
-void Schematic::condenseContentIds(size_t nodecount)
+void Schematic::condenseContentIds()
 {
 	std::unordered_map<content_t, content_t> nodeidmap;
 	content_t numids = 0;
@@ -614,17 +612,18 @@ void Schematic::condenseContentIds(size_t nodecount)
 	// Reset node resolve fields
 	NodeResolver::reset();
 
+	size_t nodecount = size.X * size.Y * size.Z;
 	for (size_t i = 0; i != nodecount; i++) {
 		content_t id;
 		content_t c = schemdata[i].getContent();
 
-		std::unordered_map<content_t, content_t>::const_iterator it = nodeidmap.find(c);
+		auto it = nodeidmap.find(c);
 		if (it == nodeidmap.end()) {
 			id = numids;
 			numids++;
 
 			m_nodenames.push_back(m_ndef->get(c).name);
-			nodeidmap.insert(std::make_pair(c, id));
+			nodeidmap.emplace(std::make_pair(c, id));
 		} else {
 			id = it->second;
 		}

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -436,9 +436,20 @@ bool Schematic::serializeToLua(std::ostream *os,
 				u8 probability   = schemdata[i].param1 & MTSCHEM_PROB_MASK;
 				bool force_place = schemdata[i].param1 & MTSCHEM_FORCE_PLACE;
 
-				ss << indent << indent << "{"
-					<< "name=\"" << names[schemdata[i].getContent()]
-					<< "\", prob=" << (u16)probability * 2
+				content_t c = schemdata[i].getContent();
+
+				ss << indent << indent << "{" << "name=\"";
+
+				if (c < m_nodenames.size()) {
+					// Get node name from cache
+					ss << m_nodenames[c];
+				} else {
+					// If cache is unavailable (biome decoration), use NodeDefManager
+					sanity_check(m_ndef != nullptr);
+					ss << m_ndef->get(c).name;
+				}
+
+				ss << "\", prob=" << (u16)probability * 2
 					<< ", param2=" << (u16)schemdata[i].param2;
 
 				if (force_place)

--- a/src/mapgen/mg_schematic.h
+++ b/src/mapgen/mg_schematic.h
@@ -92,7 +92,7 @@ enum SchematicFormatType {
 
 class Schematic : public ObjDef, public NodeResolver {
 public:
-	Schematic();
+	Schematic() = default;
 	virtual ~Schematic();
 
 	ObjDef *clone() const;

--- a/src/mapgen/mg_schematic.h
+++ b/src/mapgen/mg_schematic.h
@@ -105,11 +105,9 @@ public:
 		const NodeDefManager *ndef);
 	bool getSchematicFromMap(Map *map, v3s16 p1, v3s16 p2);
 
-	bool deserializeFromMts(std::istream *is, std::vector<std::string> *names);
-	bool serializeToMts(std::ostream *os,
-		const std::vector<std::string> &names) const;
-	bool serializeToLua(std::ostream *os, const std::vector<std::string> &names,
-		bool use_comments, u32 indent_spaces) const;
+	bool deserializeFromMts(std::istream *is);
+	bool serializeToMts(std::ostream *os) const;
+	bool serializeToLua(std::ostream *os, bool use_comments, u32 indent_spaces) const;
 
 	void blitToVManip(MMVManip *vm, v3s16 p, Rotation rot, bool force_place);
 	bool placeOnVManip(MMVManip *vm, v3s16 p, u32 flags, Rotation rot, bool force_place);
@@ -124,6 +122,10 @@ public:
 	v3s16 size;
 	MapNode *schemdata = nullptr;
 	u8 *slice_probs = nullptr;
+
+private:
+	// Counterpart to the node resolver: Condense content_t to a sequential "m_nodenames" list
+	void condenseContentIds(size_t nodecount);
 };
 
 class SchematicManager : public ObjDefManager {
@@ -151,5 +153,3 @@ private:
 	Server *m_server;
 };
 
-void generate_nodelist_and_update_ids(MapNode *nodes, size_t nodecount,
-	std::vector<std::string> *usednodes, const NodeDefManager *ndef);

--- a/src/mapgen/mg_schematic.h
+++ b/src/mapgen/mg_schematic.h
@@ -125,7 +125,7 @@ public:
 
 private:
 	// Counterpart to the node resolver: Condense content_t to a sequential "m_nodenames" list
-	void condenseContentIds(size_t nodecount);
+	void condenseContentIds();
 };
 
 class SchematicManager : public ObjDefManager {

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1675,8 +1675,7 @@ bool NodeDefManager::nodeboxConnects(MapNode from, MapNode to,
 
 NodeResolver::NodeResolver()
 {
-	m_nodenames.reserve(16);
-	m_nnlistsizes.reserve(4);
+	reset();
 }
 
 
@@ -1778,4 +1777,17 @@ bool NodeResolver::getIdsFromNrBacklog(std::vector<content_t> *result_out,
 	}
 
 	return success;
+}
+
+void NodeResolver::reset()
+{
+	m_nodenames.clear();
+	m_nodenames_idx = 0;
+	m_nnlistsizes.clear();
+	m_nnlistsizes_idx = 0;
+
+	m_resolve_done = false;
+
+	m_nodenames.reserve(16);
+	m_nnlistsizes.reserve(4);
 }

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1779,14 +1779,14 @@ bool NodeResolver::getIdsFromNrBacklog(std::vector<content_t> *result_out,
 	return success;
 }
 
-void NodeResolver::reset()
+void NodeResolver::reset(bool resolve_done)
 {
 	m_nodenames.clear();
 	m_nodenames_idx = 0;
 	m_nnlistsizes.clear();
 	m_nnlistsizes_idx = 0;
 
-	m_resolve_done = false;
+	m_resolve_done = resolve_done;
 
 	m_nodenames.reserve(16);
 	m_nnlistsizes.reserve(4);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -811,7 +811,7 @@ public:
 		bool all_required = false, content_t c_fallback = CONTENT_IGNORE);
 
 	inline bool isResolveDone() const { return m_resolve_done; }
-	void reset();
+	void reset(bool resolve_done = false);
 
 	// Vector containing all node names in the resolve "queue"
 	std::vector<std::string> m_nodenames;

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -44,6 +44,9 @@ class ITextureSource;
 class IShaderSource;
 class IGameDef;
 class NodeResolver;
+#if BUILD_UNITTESTS
+class TestSchematic;
+#endif
 
 enum ContentParamType
 {
@@ -789,10 +792,13 @@ private:
 
 NodeDefManager *createNodeDefManager();
 
+// NodeResolver: Queue for node names which are then translated
+// to content_t after the NodeDefManager was initialized
 class NodeResolver {
 public:
 	NodeResolver();
 	virtual ~NodeResolver();
+	// Callback which is run as soon NodeDefManager is ready
 	virtual void resolveNodeNames() = 0;
 
 	// required because this class is used as mixin for ObjDef
@@ -804,12 +810,31 @@ public:
 	bool getIdsFromNrBacklog(std::vector<content_t> *result_out,
 		bool all_required = false, content_t c_fallback = CONTENT_IGNORE);
 
+	inline bool isResolveDone() const { return m_resolve_done; }
+	void reset();
+
+	// Vector containing all node names in the resolve "queue"
+	std::vector<std::string> m_nodenames;
+	// Specifies the "set size" of node names which are to be processed
+	// this is used for getIdsFromNrBacklog
+	// TODO: replace or remove
+	std::vector<size_t> m_nnlistsizes;
+
+protected:
+	friend class NodeDefManager; // m_ndef
+
+	const NodeDefManager *m_ndef = nullptr;
+	// Index of the next "m_nodenames" entry to resolve
+	u32 m_nodenames_idx = 0;
+
+private:
+#if BUILD_UNITTESTS
+	// Unittest requires access to m_resolve_done
+	friend class TestSchematic;
+#endif
 	void nodeResolveInternal();
 
-	u32 m_nodenames_idx = 0;
+	// Index of the next "m_nnlistsizes" entry to process
 	u32 m_nnlistsizes_idx = 0;
-	std::vector<std::string> m_nodenames;
-	std::vector<size_t> m_nnlistsizes;
-	const NodeDefManager *m_ndef = nullptr;
 	bool m_resolve_done = false;
 };

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1734,11 +1734,10 @@ int ModApiMapgen::l_serialize_schematic(lua_State *L)
 	std::ostringstream os(std::ios_base::binary);
 	switch (schem_format) {
 	case SCHEM_FMT_MTS:
-		schem->serializeToMts(&os, schem->m_nodenames);
+		schem->serializeToMts(&os);
 		break;
 	case SCHEM_FMT_LUA:
-		schem->serializeToLua(&os, schem->m_nodenames,
-			use_comments, indent_spaces);
+		schem->serializeToLua(&os, use_comments, indent_spaces);
 		break;
 	default:
 		return 0;

--- a/src/unittest/test_noderesolver.cpp
+++ b/src/unittest/test_noderesolver.cpp
@@ -56,6 +56,8 @@ void TestNodeResolver::runTests(IGameDef *gamedef)
 
 class Foobar : public NodeResolver {
 public:
+	friend class TestNodeResolver; // m_ndef
+
 	void resolveNodeNames();
 
 	content_t test_nr_node1;


### PR DESCRIPTION
Fixes #10995

This fixes an out-of-bounds access crash when a biome-specific decoration is serialized to Lua manually afterwards.

1. The node names are resolved on load (`loadSchematicFromFile`. `ndef` is non-NULL) to content IDs
2. Node names are no longer required [by mapgen] and are dropped in `NodeResolver::nodeResolveInternal`
3. The mod loads the cached schematic (same path) which does not have any node name mapping
4. Serialize to Lua fails because the vector is accessed out-of-range

Alternatives:
 * Keep the content_t/node name vector after node resolving -> slightly higher RAM usage depending on the content ID value
 * Re-write this somehow so that the node names are kept more efficiently (map?)
 * Drop use of `m_nodenames` within serialization and rely on NodeDefManager


## To do

This PR is Ready for Review.

## How to test

1. MineClone 2 world, repository commit roughly 9f66238aa (Feb 27) or earlier
2. This testing mod, depends on `mcl_structures`:
   * https://github.com/minetest/minetest/issues/10995#issuecomment-787438358
3. Execute `/s`
4. Worldedit + `//mtschemecreate filename`
5. Change `//pos1` location
6. `//mtschemplace filename`