### PR TITLE
Send only relevant ItemStack meta fields to Client

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1062,11 +1062,9 @@ max_packets_per_iteration (Max. packets per iteration) int 1024
 #     (levels 1-3 use Zlib's "fast" method, 4-9 use the normal method)
 map_compression_level_net (Map Compression Level for Network Transfer) int -1 -1 9
 
-#	 When this is enbled, all item metadata will be sent to all clients. This
-# 	 might be useful to allow for local map saving, but it also increases
-# 	 lag, and malicious players could abuse it to crash the server or prevent
-# 	 other players from logging in by making the server crash automatically
-#	 when they log in.
+#    Sends all item metadata fields to clients. Otherwise the server will truncate
+#    irrelevant data per-client to reduce load and network traffic.
+#    Note: Set to "true" to allow local map saving on clients prior to 5.5.0-dev.
 send_all_item_metadata (Send all Item metadata to clients) bool false
 
 [*Game]

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1062,6 +1062,13 @@ max_packets_per_iteration (Max. packets per iteration) int 1024
 #     (levels 1-3 use Zlib's "fast" method, 4-9 use the normal method)
 map_compression_level_net (Map Compression Level for Network Transfer) int -1 -1 9
 
+#	 When this is enbled, all item metadata will be sent to all clients. This
+# 	 might be useful to allow for local map saving, but it also increases
+# 	 lag, and malicious players could abuse it to crash the server or prevent
+# 	 other players from logging in by making the server crash automatically
+#	 when they log in.
+send_all_item_metadata (Send all Item metadata to clients) bool false
+
 [*Game]
 
 #    Default game when creating a new world.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2040,6 +2040,12 @@ Some of the values in the key-value store are handled specially:
 * `palette_index`: If the item has a palette, this is used to get the
   current color from the palette.
 
+Item metadata is usually not fully sent to client (except the client has
+local map saving enabled or it is disabled globaly by the server). Only
+the fields `description`, `short_description`, `color`, `palette_index`
+and `tool_capabilities` are always sent. If there are any other fields,
+they will be hashed into an additional `_hash` field.
+
 Example:
 
     local meta = stack:get_meta()

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1269,11 +1269,9 @@
 #    type: int min: -1 max: 9
 # map_compression_level_net = -1
 
-#	 When this is enbled, all item metadata will be sent to all clients. This
-# 	 might be useful to allow for local map saving, but it also increases
-# 	 lag, and malicious players could abuse it to crash the server or prevent
-# 	 other players from logging in by making the server crash automatically
-#	 when they log in.
+#    Sends all item metadata fields to clients. Otherwise the server will truncate
+#    irrelevant data per-client to reduce load and network traffic.
+#    Note: Set to "true" to allow local map saving on clients prior to 5.5.0-dev.
 # send_all_item_metadata = false
 
 ## Game

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1269,6 +1269,13 @@
 #    type: int min: -1 max: 9
 # map_compression_level_net = -1
 
+#	 When this is enbled, all item metadata will be sent to all clients. This
+# 	 might be useful to allow for local map saving, but it also increases
+# 	 lag, and malicious players could abuse it to crash the server or prevent
+# 	 other players from logging in by making the server crash automatically
+#	 when they log in.
+# send_all_item_metadata = false
+
 ## Game
 
 #    Default game when creating a new world.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1008,7 +1008,7 @@ AuthMechanism Client::choseAuthMech(const u32 mechs)
 
 void Client::sendInit(const std::string &playerName)
 {
-	NetworkPacket pkt(TOSERVER_INIT, 1 + 2 + 2 + (1 + playerName.size()));
+	NetworkPacket pkt(TOSERVER_INIT, 1 + 2 + 2 + (1 + playerName.size()) + 1);
 
 	// we don't support network compression yet
 	u16 supp_comp_modes = NETPROTO_COMPRESSION_NONE;
@@ -1016,6 +1016,7 @@ void Client::sendInit(const std::string &playerName)
 	pkt << (u8) SER_FMT_VER_HIGHEST_READ << (u16) supp_comp_modes;
 	pkt << (u16) CLIENT_PROTOCOL_VERSION_MIN << (u16) CLIENT_PROTOCOL_VERSION_MAX;
 	pkt << playerName;
+	pkt << (u8) (m_localdb ? 1 : 0);
 
 	Send(&pkt);
 }

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -233,6 +233,8 @@ public:
 	//
 	u16 net_proto_version = 0;
 
+	u8 mapsaving_enabled = 0;
+
 	/* Authentication information */
 	std::string enc_pwd = "";
 	bool create_player_on_auth_success = false;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -391,6 +391,7 @@ void set_default_settings()
 	settings->setDefault("sqlite_synchronous", "2");
 	settings->setDefault("map_compression_level_disk", "3");
 	settings->setDefault("map_compression_level_net", "-1");
+	settings->setDefault("send_all_item_metadata", "false");
 	settings->setDefault("full_block_send_enable_min_time_from_building", "2.0");
 	settings->setDefault("dedicated_server_step", "0.09");
 	settings->setDefault("active_block_mgmt_interval", "2.0");

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -56,7 +56,7 @@ ItemStack::ItemStack(const std::string &name_, u16 count_,
 		count = 1;
 }
 
-void ItemStack::serialize(std::ostream &os, bool serialize_meta) const
+void ItemStack::serialize(std::ostream &os, bool serialize_meta, bool disk) const
 {
 	if (empty())
 		return;
@@ -78,7 +78,7 @@ void ItemStack::serialize(std::ostream &os, bool serialize_meta) const
 	if (parts >= 4) {
 		os << " ";
 		if (serialize_meta)
-			metadata.serialize(os);
+			metadata.serialize(os, disk);
 		else
 			os << "<metadata size=" << metadata.size() << ">";
 	}
@@ -243,10 +243,10 @@ void ItemStack::deSerialize(const std::string &str, IItemDefManager *itemdef)
 	deSerialize(is, itemdef);
 }
 
-std::string ItemStack::getItemString(bool include_meta) const
+std::string ItemStack::getItemString(bool include_meta, bool disk) const
 {
 	std::ostringstream os(std::ios::binary);
-	serialize(os, include_meta);
+	serialize(os, include_meta, disk);
 	return os.str();
 }
 
@@ -425,7 +425,7 @@ void InventoryList::setName(const std::string &name)
 	setModified();
 }
 
-void InventoryList::serialize(std::ostream &os, bool incremental) const
+void InventoryList::serialize(std::ostream &os, bool incremental, bool disk) const
 {
 	//os.imbue(std::locale("C"));
 
@@ -436,7 +436,7 @@ void InventoryList::serialize(std::ostream &os, bool incremental) const
 			os<<"Empty";
 		} else {
 			os<<"Item ";
-			item.serialize(os);
+			item.serialize(os, true, disk);
 		}
 		// TODO: Implement this:
 		// if (!incremental || item.checkModified())
@@ -847,13 +847,13 @@ bool Inventory::operator == (const Inventory &other) const
 	return true;
 }
 
-void Inventory::serialize(std::ostream &os, bool incremental) const
+void Inventory::serialize(std::ostream &os, bool incremental, bool disk) const
 {
 	//std::cout << "Serialize " << (int)incremental << ", n=" << m_lists.size() << std::endl;
 	for (const InventoryList *list : m_lists) {
 		if (!incremental || list->checkModified()) {
 			os << "List " << list->getName() << " " << list->getSize() << "\n";
-			list->serialize(os, incremental);
+			list->serialize(os, incremental, disk);
 		} else {
 			os << "KeepList " << list->getName() << "\n";
 		}

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "inventoryoptimisation.h"
 #include "itemdef.h"
 #include "irrlichttypes.h"
 #include "itemstackmetadata.h"
@@ -40,13 +41,13 @@ struct ItemStack
 	~ItemStack() = default;
 
 	// Serialization
-	void serialize(std::ostream &os, bool serialize_meta = true, bool disk = true) const;
+	void serialize(std::ostream &os, InventoryOptimizationOption opt = INV_OO_NONE) const;
 	// Deserialization. Pass itemdef unless you don't want aliases resolved.
 	void deSerialize(std::istream &is, IItemDefManager *itemdef = NULL);
 	void deSerialize(const std::string &s, IItemDefManager *itemdef = NULL);
 
 	// Returns the string used for inventory
-	std::string getItemString(bool include_meta = true, bool disk = true) const;
+	std::string getItemString(InventoryOptimizationOption opt = INV_OO_NONE) const;
 	// Returns the tooltip
 	std::string getDescription(IItemDefManager *itemdef) const;
 	std::string getShortDescription(IItemDefManager *itemdef) const;
@@ -195,7 +196,7 @@ public:
 	void setSize(u32 newsize);
 	void setWidth(u32 newWidth);
 	void setName(const std::string &name);
-	void serialize(std::ostream &os, bool incremental, bool disk = true) const;
+	void serialize(std::ostream &os, InventoryOptimizationOption opt = INV_OO_NONE) const;
 	void deSerialize(std::istream &is);
 
 	InventoryList(const InventoryList &other);
@@ -295,7 +296,7 @@ public:
 	}
 
 	// Never ever serialize to disk using "incremental"!
-	void serialize(std::ostream &os, bool incremental = false, bool disk = true) const;
+	void serialize(std::ostream &os, InventoryOptimizationOption opt = INV_OO_NONE) const;
 	void deSerialize(std::istream &is);
 
 	InventoryList * addList(const std::string &name, u32 size);

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -40,13 +40,13 @@ struct ItemStack
 	~ItemStack() = default;
 
 	// Serialization
-	void serialize(std::ostream &os, bool serialize_meta = true) const;
+	void serialize(std::ostream &os, bool serialize_meta = true, bool disk = true) const;
 	// Deserialization. Pass itemdef unless you don't want aliases resolved.
 	void deSerialize(std::istream &is, IItemDefManager *itemdef = NULL);
 	void deSerialize(const std::string &s, IItemDefManager *itemdef = NULL);
 
 	// Returns the string used for inventory
-	std::string getItemString(bool include_meta = true) const;
+	std::string getItemString(bool include_meta = true, bool disk = true) const;
 	// Returns the tooltip
 	std::string getDescription(IItemDefManager *itemdef) const;
 	std::string getShortDescription(IItemDefManager *itemdef) const;
@@ -195,7 +195,7 @@ public:
 	void setSize(u32 newsize);
 	void setWidth(u32 newWidth);
 	void setName(const std::string &name);
-	void serialize(std::ostream &os, bool incremental) const;
+	void serialize(std::ostream &os, bool incremental, bool disk = true) const;
 	void deSerialize(std::istream &is);
 
 	InventoryList(const InventoryList &other);
@@ -295,7 +295,7 @@ public:
 	}
 
 	// Never ever serialize to disk using "incremental"!
-	void serialize(std::ostream &os, bool incremental = false) const;
+	void serialize(std::ostream &os, bool incremental = false, bool disk = true) const;
 	void deSerialize(std::istream &is);
 
 	InventoryList * addList(const std::string &name, u32 size);

--- a/src/inventoryoptimisation.h
+++ b/src/inventoryoptimisation.h
@@ -1,0 +1,28 @@
+/*
+Minetest
+Copyright (C) 2021 Elias Fleckenstein <eliasfleckenstein@web.de>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+enum InventoryOptimizationOption {
+	INV_OO_NONE = 0,
+	INV_OO_INCREMENTAL = 0x0001,
+	INV_OO_META_SPARSE = 0x0002,
+	INV_OO_INCREMENTAL_META_SPARSE = 0x0003,
+	INV_OO_NO_META  = 0x0004,
+};

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -63,7 +63,12 @@ void ItemStackMetadata::serialize(std::ostream &os, bool disk) const
 	std::ostringstream os2;
 	os2 << DESERIALIZE_START;
 	for (const auto &stringvar : m_stringvars) {
-		if (! disk && stringvar.first != TOOLCAP_KEY && stringvar.first != "description" && stringvar.first != "color")
+		if (! disk
+				&& stringvar.first != TOOLCAP_KEY
+				&& stringvar.first != "description"
+				&& stringvar.first != "color"
+				&& stringvar.first != "short_description"
+				&& stringvar.first != "palette_index")
 			continue;
 		if (!stringvar.first.empty() || !stringvar.second.empty())
 			os2 << stringvar.first << DESERIALIZE_KV_DELIM

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -58,11 +58,13 @@ bool ItemStackMetadata::setString(const std::string &name, const std::string &va
 	return result;
 }
 
-void ItemStackMetadata::serialize(std::ostream &os) const
+void ItemStackMetadata::serialize(std::ostream &os, bool disk) const
 {
 	std::ostringstream os2;
 	os2 << DESERIALIZE_START;
 	for (const auto &stringvar : m_stringvars) {
+		if (! disk && stringvar.first != TOOLCAP_KEY && stringvar.first != "name" && stringvar.first != "description" && stringvar.first != "color")
+			continue;
 		if (!stringvar.first.empty() || !stringvar.second.empty())
 			os2 << stringvar.first << DESERIALIZE_KV_DELIM
 				<< stringvar.second << DESERIALIZE_PAIR_DELIM;

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -78,7 +78,7 @@ void ItemStackMetadata::serialize(std::ostream &os, InventoryOptimizationOption 
 	}
 	std::string hash_str = os_hash.str();
 	if (! hash_str.empty()) {
-		os2 << "hash" << DESERIALIZE_KV_DELIM
+		os2 << "_hash" << DESERIALIZE_KV_DELIM
 			<< murmur_hash_64_ua(hash_str.data(), hash_str.length(), 0xdeadbeef) << DESERIALIZE_PAIR_DELIM;
 	}
 	os << serializeJsonStringIfNeeded(os2.str());

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -59,13 +59,14 @@ bool ItemStackMetadata::setString(const std::string &name, const std::string &va
 	return result;
 }
 
-void ItemStackMetadata::serialize(std::ostream &os, bool disk) const
+void ItemStackMetadata::serialize(std::ostream &os, InventoryOptimizationOption opt) const
 {
 	std::ostringstream os2;
 	os2 << DESERIALIZE_START;
 	std::string unsent_fields;
+	bool sparse_meta = opt & INV_OO_META_SPARSE;
 	for (const auto &stringvar : m_stringvars) {
-		if (! disk
+		if (sparse_meta
 				&& stringvar.first != TOOLCAP_KEY
 				&& stringvar.first != "description"
 				&& stringvar.first != "color"

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -63,7 +63,7 @@ void ItemStackMetadata::serialize(std::ostream &os, bool disk) const
 	std::ostringstream os2;
 	os2 << DESERIALIZE_START;
 	for (const auto &stringvar : m_stringvars) {
-		if (! disk && stringvar.first != TOOLCAP_KEY && stringvar.first != "name" && stringvar.first != "description" && stringvar.first != "color")
+		if (! disk && stringvar.first != TOOLCAP_KEY && stringvar.first != "description" && stringvar.first != "color")
 			continue;
 		if (!stringvar.first.empty() || !stringvar.second.empty())
 			os2 << stringvar.first << DESERIALIZE_KV_DELIM

--- a/src/itemstackmetadata.h
+++ b/src/itemstackmetadata.h
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "inventoryoptimisation.h"
 #include "metadata.h"
 #include "tool.h"
 
@@ -34,7 +35,7 @@ public:
 	void clear() override;
 	bool setString(const std::string &name, const std::string &var) override;
 
-	void serialize(std::ostream &os, bool disk = true) const;
+	void serialize(std::ostream &os, InventoryOptimizationOption opt = INV_OO_NONE) const;
 	void deSerialize(std::istream &is);
 
 	const ToolCapabilities &getToolCapabilities(

--- a/src/itemstackmetadata.h
+++ b/src/itemstackmetadata.h
@@ -34,7 +34,7 @@ public:
 	void clear() override;
 	bool setString(const std::string &name, const std::string &var) override;
 
-	void serialize(std::ostream &os) const;
+	void serialize(std::ostream &os, bool disk = true) const;
 	void deSerialize(std::istream &is);
 
 	const ToolCapabilities &getToolCapabilities(

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -355,7 +355,7 @@ static void correctBlockNodeIds(const NameIdMapping *nimap, MapNode *nodes,
 	}
 }
 
-void MapBlock::serialize(std::ostream &os, u8 version, bool disk, int compression_level)
+void MapBlock::serialize(std::ostream &os, u8 version, bool disk, int compression_level, bool disk_inv)
 {
 	if(!ser_ver_supported(version))
 		throw VersionMismatchException("ERROR: MapBlock format not supported");
@@ -411,7 +411,7 @@ void MapBlock::serialize(std::ostream &os, u8 version, bool disk, int compressio
 		Node metadata
 	*/
 	std::ostringstream oss(std::ios_base::binary);
-	m_node_metadata.serialize(oss, version, disk);
+	m_node_metadata.serialize(oss, version, disk, false, disk_inv);
 	compressZlib(oss.str(), os, compression_level);
 
 	/*

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -355,7 +355,7 @@ static void correctBlockNodeIds(const NameIdMapping *nimap, MapNode *nodes,
 	}
 }
 
-void MapBlock::serialize(std::ostream &os, u8 version, bool disk, int compression_level, bool disk_inv)
+void MapBlock::serialize(std::ostream &os, u8 version, bool disk, int compression_level, InventoryOptimizationOption opt)
 {
 	if(!ser_ver_supported(version))
 		throw VersionMismatchException("ERROR: MapBlock format not supported");
@@ -411,7 +411,7 @@ void MapBlock::serialize(std::ostream &os, u8 version, bool disk, int compressio
 		Node metadata
 	*/
 	std::ostringstream oss(std::ios_base::binary);
-	m_node_metadata.serialize(oss, version, disk, false, disk_inv);
+	m_node_metadata.serialize(oss, version, disk, false, opt);
 	compressZlib(oss.str(), os, compression_level);
 
 	/*

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -473,7 +473,7 @@ public:
 	// These don't write or read version by itself
 	// Set disk to true for on-disk format, false for over-the-network format
 	// Precondition: version >= SER_FMT_VER_LOWEST_WRITE
-	void serialize(std::ostream &os, u8 version, bool disk, int compression_level);
+	void serialize(std::ostream &os, u8 version, bool disk, int compression_level, bool disk_inv = true);
 	// If disk == true: In addition to doing other things, will add
 	// unknown blocks from id-name mapping to wndef
 	void deSerialize(std::istream &is, u8 version, bool disk);

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <set>
 #include "irr_v3d.h"
+#include "inventoryoptimisation.h"
 #include "mapnode.h"
 #include "exceptions.h"
 #include "constants.h"
@@ -473,7 +474,7 @@ public:
 	// These don't write or read version by itself
 	// Set disk to true for on-disk format, false for over-the-network format
 	// Precondition: version >= SER_FMT_VER_LOWEST_WRITE
-	void serialize(std::ostream &os, u8 version, bool disk, int compression_level, bool disk_inv = true);
+	void serialize(std::ostream &os, u8 version, bool disk, int compression_level, InventoryOptimizationOption opt = INV_OO_NONE);
 	// If disk == true: In addition to doing other things, will add
 	// unknown blocks from id-name mapping to wndef
 	void deSerialize(std::istream &is, u8 version, bool disk);

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -100,9 +100,16 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 	u16 min_net_proto_version = 0;
 	u16 max_net_proto_version;
 	std::string playerName;
+	u8 mapsaving_enabled = 0;
 
 	*pkt >> client_max >> supp_compr_modes >> min_net_proto_version
 			>> max_net_proto_version >> playerName;
+
+	try {
+		*pkt >> mapsaving_enabled;
+	} catch (PacketError &e) {};
+
+	client->mapsaving_enabled = mapsaving_enabled;
 
 	u8 our_max = SER_FMT_VER_HIGHEST_READ;
 	// Use the highest version supported by both

--- a/src/nodemetadata.cpp
+++ b/src/nodemetadata.cpp
@@ -40,7 +40,7 @@ NodeMetadata::~NodeMetadata()
 	delete m_inventory;
 }
 
-void NodeMetadata::serialize(std::ostream &os, u8 version, bool disk, bool disk_inv) const
+void NodeMetadata::serialize(std::ostream &os, u8 version, bool disk, InventoryOptimizationOption opt) const
 {
 	int num_vars = disk ? m_stringvars.size() : countNonPrivate();
 	writeU32(os, num_vars);
@@ -55,7 +55,7 @@ void NodeMetadata::serialize(std::ostream &os, u8 version, bool disk, bool disk_
 			writeU8(os, (priv) ? 1 : 0);
 	}
 
-	m_inventory->serialize(os, false, disk || disk_inv);
+	m_inventory->serialize(os, opt);
 }
 
 void NodeMetadata::deSerialize(std::istream &is, u8 version)
@@ -113,7 +113,7 @@ int NodeMetadata::countNonPrivate() const
 */
 
 void NodeMetadataList::serialize(std::ostream &os, u8 blockver, bool disk,
-	bool absolute_pos, bool disk_inv) const
+	bool absolute_pos, InventoryOptimizationOption opt) const
 {
 	/*
 		Version 0 is a placeholder for "nothing to see here; go away."
@@ -146,7 +146,7 @@ void NodeMetadataList::serialize(std::ostream &os, u8 blockver, bool disk,
 			u16 p16 = (p.Z * MAP_BLOCKSIZE + p.Y) * MAP_BLOCKSIZE + p.X;
 			writeU16(os, p16);
 		}
-		data->serialize(os, version, disk, disk_inv);
+		data->serialize(os, version, disk, opt);
 	}
 }
 

--- a/src/nodemetadata.cpp
+++ b/src/nodemetadata.cpp
@@ -40,7 +40,7 @@ NodeMetadata::~NodeMetadata()
 	delete m_inventory;
 }
 
-void NodeMetadata::serialize(std::ostream &os, u8 version, bool disk) const
+void NodeMetadata::serialize(std::ostream &os, u8 version, bool disk, bool disk_inv) const
 {
 	int num_vars = disk ? m_stringvars.size() : countNonPrivate();
 	writeU32(os, num_vars);
@@ -55,7 +55,7 @@ void NodeMetadata::serialize(std::ostream &os, u8 version, bool disk) const
 			writeU8(os, (priv) ? 1 : 0);
 	}
 
-	m_inventory->serialize(os);
+	m_inventory->serialize(os, false, disk || disk_inv);
 }
 
 void NodeMetadata::deSerialize(std::istream &is, u8 version)
@@ -113,7 +113,7 @@ int NodeMetadata::countNonPrivate() const
 */
 
 void NodeMetadataList::serialize(std::ostream &os, u8 blockver, bool disk,
-	bool absolute_pos) const
+	bool absolute_pos, bool disk_inv) const
 {
 	/*
 		Version 0 is a placeholder for "nothing to see here; go away."
@@ -146,7 +146,7 @@ void NodeMetadataList::serialize(std::ostream &os, u8 blockver, bool disk,
 			u16 p16 = (p.Z * MAP_BLOCKSIZE + p.Y) * MAP_BLOCKSIZE + p.X;
 			writeU16(os, p16);
 		}
-		data->serialize(os, version, disk);
+		data->serialize(os, version, disk, disk_inv);
 	}
 }
 

--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -40,7 +40,7 @@ public:
 	NodeMetadata(IItemDefManager *item_def_mgr);
 	~NodeMetadata();
 
-	void serialize(std::ostream &os, u8 version, bool disk=true) const;
+	void serialize(std::ostream &os, u8 version, bool disk = true, bool disk_inv = true) const;
 	void deSerialize(std::istream &is, u8 version);
 
 	void clear();
@@ -82,7 +82,7 @@ public:
 	~NodeMetadataList();
 
 	void serialize(std::ostream &os, u8 blockver, bool disk = true,
-		bool absolute_pos = false) const;
+		bool absolute_pos = false, bool disk_inv = true) const;
 	void deSerialize(std::istream &is, IItemDefManager *item_def_mgr,
 		bool absolute_pos = false);
 

--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include <unordered_set>
+#include "inventoryoptimisation.h"
 #include "metadata.h"
 
 /*
@@ -40,7 +41,7 @@ public:
 	NodeMetadata(IItemDefManager *item_def_mgr);
 	~NodeMetadata();
 
-	void serialize(std::ostream &os, u8 version, bool disk = true, bool disk_inv = true) const;
+	void serialize(std::ostream &os, u8 version, bool disk = true, InventoryOptimizationOption opt = INV_OO_NONE) const;
 	void deSerialize(std::istream &is, u8 version);
 
 	void clear();
@@ -82,7 +83,7 @@ public:
 	~NodeMetadataList();
 
 	void serialize(std::ostream &os, u8 blockver, bool disk = true,
-		bool absolute_pos = false, bool disk_inv = true) const;
+		bool absolute_pos = false, InventoryOptimizationOption opt = INV_OO_NONE) const;
 	void deSerialize(std::istream &is, IItemDefManager *item_def_mgr,
 		bool absolute_pos = false);
 

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -41,7 +41,7 @@ int LuaItemStack::gc_object(lua_State *L)
 int LuaItemStack::mt_tostring(lua_State *L)
 {
 	LuaItemStack *o = checkobject(L, 1);
-	std::string itemstring = o->m_stack.getItemString(false);
+	std::string itemstring = o->m_stack.getItemString(INV_OO_NO_META);
 	lua_pushfstring(L, "ItemStack(\"%s\")", itemstring.c_str());
 	return 1;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1471,7 +1471,7 @@ void Server::SendInventory(PlayerSAO *sao, bool incremental)
 	NetworkPacket pkt(TOCLIENT_INVENTORY, 0, sao->getPeerID());
 
 	std::ostringstream os(std::ios::binary);
-	sao->getInventory()->serialize(os, incremental, false);
+	sao->getInventory()->serialize(os, incremental, g_settings->getBool("send_all_item_metadata"));
 	sao->getInventory()->setModified(false);
 	player->setModified(true);
 
@@ -2335,7 +2335,7 @@ void Server::SendBlockNoLock(session_t peer_id, MapBlock *block, u8 ver,
 	*/
 	thread_local const int net_compression_level = rangelim(g_settings->getS16("map_compression_level_net"), -1, 9);
 	std::ostringstream os(std::ios_base::binary);
-	block->serialize(os, ver, false, net_compression_level, false);
+	block->serialize(os, ver, false, net_compression_level, g_settings->getBool("send_all_item_metadata"));
 	block->serializeNetworkSpecific(os);
 	std::string s = os.str();
 
@@ -2692,7 +2692,7 @@ void Server::sendDetachedInventory(Inventory *inventory, const std::string &name
 
 		// Serialization & NetworkPacket isn't a love story
 		std::ostringstream os(std::ios_base::binary);
-		inventory->serialize(os, false, false);
+		inventory->serialize(os, false, g_settings->getBool("send_all_item_metadata"));
 		inventory->setModified(false);
 
 		const std::string &os_str = os.str();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1471,7 +1471,8 @@ void Server::SendInventory(PlayerSAO *sao, bool incremental)
 	NetworkPacket pkt(TOCLIENT_INVENTORY, 0, sao->getPeerID());
 
 	std::ostringstream os(std::ios::binary);
-	sao->getInventory()->serialize(os, incremental, g_settings->getBool("send_all_item_metadata") || getClient(sao->getPeerID(), CS_InitDone)->mapsaving_enabled);
+	RemoteClient *client = getClientNoEx(sao->getPeerID(), CS_InitDone);
+	sao->getInventory()->serialize(os, incremental, g_settings->getBool("send_all_item_metadata") || (client && client->mapsaving_enabled));
 	sao->getInventory()->setModified(false);
 	player->setModified(true);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1471,7 +1471,7 @@ void Server::SendInventory(PlayerSAO *sao, bool incremental)
 	NetworkPacket pkt(TOCLIENT_INVENTORY, 0, sao->getPeerID());
 
 	std::ostringstream os(std::ios::binary);
-	sao->getInventory()->serialize(os, incremental, g_settings->getBool("send_all_item_metadata"));
+	sao->getInventory()->serialize(os, incremental, g_settings->getBool("send_all_item_metadata") || getClient(sao->getPeerID(), CS_InitDone)->mapsaving_enabled);
 	sao->getInventory()->setModified(false);
 	player->setModified(true);
 
@@ -2335,7 +2335,7 @@ void Server::SendBlockNoLock(session_t peer_id, MapBlock *block, u8 ver,
 	*/
 	thread_local const int net_compression_level = rangelim(g_settings->getS16("map_compression_level_net"), -1, 9);
 	std::ostringstream os(std::ios_base::binary);
-	block->serialize(os, ver, false, net_compression_level, g_settings->getBool("send_all_item_metadata"));
+	block->serialize(os, ver, false, net_compression_level, g_settings->getBool("send_all_item_metadata") || getClient(peer_id)->mapsaving_enabled);
 	block->serializeNetworkSpecific(os);
 	std::string s = os.str();
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1471,7 +1471,7 @@ void Server::SendInventory(PlayerSAO *sao, bool incremental)
 	NetworkPacket pkt(TOCLIENT_INVENTORY, 0, sao->getPeerID());
 
 	std::ostringstream os(std::ios::binary);
-	sao->getInventory()->serialize(os, incremental);
+	sao->getInventory()->serialize(os, incremental, false);
 	sao->getInventory()->setModified(false);
 	player->setModified(true);
 
@@ -2313,7 +2313,7 @@ void Server::sendMetadataChanged(const std::list<v3s16> &meta_updates, float far
 
 		// Send the meta changes
 		std::ostringstream os(std::ios::binary);
-		meta_updates_list.serialize(os, client->net_proto_version, false, true);
+		meta_updates_list.serialize(os, client->net_proto_version, false, true, false);
 		std::ostringstream oss(std::ios::binary);
 		compressZlib(os.str(), oss);
 
@@ -2335,7 +2335,7 @@ void Server::SendBlockNoLock(session_t peer_id, MapBlock *block, u8 ver,
 	*/
 	thread_local const int net_compression_level = rangelim(g_settings->getS16("map_compression_level_net"), -1, 9);
 	std::ostringstream os(std::ios_base::binary);
-	block->serialize(os, ver, false, net_compression_level);
+	block->serialize(os, ver, false, net_compression_level, false);
 	block->serializeNetworkSpecific(os);
 	std::string s = os.str();
 
@@ -2692,7 +2692,7 @@ void Server::sendDetachedInventory(Inventory *inventory, const std::string &name
 
 		// Serialization & NetworkPacket isn't a love story
 		std::ostringstream os(std::ios_base::binary);
-		inventory->serialize(os);
+		inventory->serialize(os, false, false);
 		inventory->setModified(false);
 
 		const std::string &os_str = os.str();

--- a/src/server.h
+++ b/src/server.h
@@ -491,6 +491,7 @@ private:
 	void DeleteClient(session_t peer_id, ClientDeletionReason reason);
 	void UpdateCrafting(RemotePlayer *player);
 	bool checkInteractDistance(RemotePlayer *player, const f32 d, const std::string &what);
+	InventoryOptimizationOption getOptimisationOption(session_t peer_id, bool incremental = false);
 
 	void handleChatInterfaceEvent(ChatEvent *evt);
 

--- a/src/unittest/test_inventory.cpp
+++ b/src/unittest/test_inventory.cpp
@@ -63,13 +63,13 @@ void TestInventory::testSerializeDeserialize(IItemDefManager *idef)
 
 	inv.getList("main")->setWidth(5);
 	std::ostringstream inv_os(std::ios::binary);
-	inv.serialize(inv_os, false);
+	inv.serialize(inv_os, INV_OO_NONE);
 	UASSERTEQ(std::string, inv_os.str(), serialized_inventory_out);
 
 	inv.setModified(false);
 	inv_os.str("");
 	inv_os.clear();
-	inv.serialize(inv_os, true);
+	inv.serialize(inv_os, INV_OO_INCREMENTAL);
 	UASSERTEQ(std::string, inv_os.str(), serialized_inventory_inc);
 
 	ItemStack leftover = inv.getList("main")->takeItem(7, 99 - 12);


### PR DESCRIPTION
The goal of this PR is to avoid massive network traffic and "bookbanning". This PR prevents sending any ItemStack metadata to the client, except the `description`, `color` and `tool_capabilities`. It was originally created for the Clamity server to prevent "bookbanning" and lag, but then I realized that other servers might also profit from this patch so I might as well contribute it to upstream. Bookbanning works by putting items that contain a lot of data into shulkerboxes (in case you don't know, shulkerboxes are basically portable chests, when they are dug, the items inside get stored in the metadata of the itemstack). When several of these boxes, filled with items with lots of data, are dropped into the the inventory of a player, the inventory gets so large it is too big to send and the server crashes with this message:
```
2021-03-01 04:58:54: ERROR[ConnectionSend]: /home/clamity/minetest-5.4.0/src/network/connection.cpp:3f9: bool con::UDPPeer::processReliableSendCommand(con::ConnectionCommand&, unsigned int): An engine assumption 'c.data.getSize() < 0x8000*512' failed.
```
Every time the affected player tries logging in the server will crash again, with this message.
A similar exploit exists in Minecraft, except that it does not crash the server, but rather kicks the client so it is effectively banned. In Minecraft books are used to ban players using this method; in MineClone2 books have a limit of 5kB, so even if they were filled with random characters (to avoid zlib compression), they would contain less data then e.g. an enchanted pickaxe (21kB).

This PR does not significantly reduce the network traffic that comes from having enchanted tools themselves in the inventory, since the data of enchanted tools is the tool_capabilities, but for shulkerboxes with enchanted stuff, it reduces the data **from 0.5 MB to a few byte**. This does not only help against bookbanning, but also removes lag.

This affects player inventories, detached inventories and inventories in node metadata.

## To do

This PR is a Work in Progress.

- [x] Remove the `name` field from the whitelist, since it is not needed by the client
- [x] Add a possibility to disable this patch globally (to make local map saving possible)
- [x] Add short_description and palette_index to the whitelist 
- [x] Add a possibility to disable this patch for certain players
- [x] Find a solution to fix the problem that the client will sometimes incorrectly predict whether 2 stacks can combine
- [ ] Possibility to mark fields as public

## How to test

Add a clientmod like this:
```lua
minetest.register_chatcommand("wielded", {
	func = function()
		return true, minetest.localplayer:get_wielded_item():to_string()
	end
}) 
```
and a server-side mod like this:
```lua
minetest.register_chatcommand("wielded", {
	func = function(name)
		return true, minetest.get_player_by_name(name):get_wielded_item():to_string()
	end
})
```
Next, you need to obtain an item with metadata. This can be done using the MineClone2 subgame, by putting a few items into a shulkerbox. Then wield the item, and run both the .wielded and /wielded command. You'll notice that the client command will print significantly less data. You can also try it with a named shulkerbox (name it using an anvil) - the colored description, will still work and also show up in the .wielded command, but the serialized inventory data of the shulkerbox does not.