### PR TITLE
Check for duplicate login in TOSERVER_INIT handler

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -174,6 +174,16 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 		return;
 	}
 
+	RemotePlayer *player = m_env->getPlayer(playername);
+
+	// If player is already connected, cancel
+	if (player && player->getPeerId() != PEER_ID_INEXISTENT) {
+		actionstream << "Server: Player with name \"" << playername <<
+			"\" tried to connect, but player with same name is already connected" << std::endl;
+			DenyAccess(peer_id, SERVER_ACCESSDENIED_ALREADY_CONNECTED);
+		return;
+	}
+
 	m_clients.setPlayerName(peer_id, playername);
 	//TODO (later) case insensitivity
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -180,7 +180,7 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 	if (player && player->getPeerId() != PEER_ID_INEXISTENT) {
 		actionstream << "Server: Player with name \"" << playername <<
 			"\" tried to connect, but player with same name is already connected" << std::endl;
-			DenyAccess(peer_id, SERVER_ACCESSDENIED_ALREADY_CONNECTED);
+		DenyAccess(peer_id, SERVER_ACCESSDENIED_ALREADY_CONNECTED);
 		return;
 	}
 


### PR DESCRIPTION
This PR resolves issue #10957 by checking for a player already connected to the server with the same name in the TOSERVER_INIT handler. You might notice that I did not remove the old code; this is intended, because when to players connect with the same name at the same time the old handler in StageTwoClientInit will kick the one that comes second. This fix does not cause any problems with older clients (tested).

## To do

This PR is Ready for Review.

## How to test

Host a local server and wait until you are connected. Then, try to connect to it with the same name - it will fail before loading media etc.