### PR TITLE
Fix format of src/content/mods.cpp

### DIFF
--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -50,7 +50,8 @@ static void log_mod_deprecation(const ModSpec &spec, const std::string &warning)
 	auto handling_mode = get_deprecated_handling_mode();
 	if (handling_mode != DeprecatedHandlingMode::Ignore) {
 		std::ostringstream os;
-		os << warning << " (" << spec.name << " at " << spec.path << ")" << std::endl;
+		os << warning << " (" << spec.name << " at " << spec.path << ")"
+		   << std::endl;
 
 		if (handling_mode == DeprecatedHandlingMode::Error) {
 			throw ModError(os.str());
@@ -89,7 +90,8 @@ void parseModContents(ModSpec &spec)
 		if (info.exists("name"))
 			spec.name = info.get("name");
 		else
-			log_mod_deprecation(spec, "Mods not having a mod.conf file with the name is deprecated.");
+			log_mod_deprecation(spec, "Mods not having a mod.conf file with "
+						  "the name is deprecated.");
 
 		if (info.exists("author"))
 			spec.author = info.get("author");
@@ -130,7 +132,8 @@ void parseModContents(ModSpec &spec)
 			std::ifstream is((spec.path + DIR_DELIM + "depends.txt").c_str());
 
 			if (is.good())
-				log_mod_deprecation(spec, "depends.txt is deprecated, please use mod.conf instead.");
+				log_mod_deprecation(spec, "depends.txt is deprecated, "
+							  "please use mod.conf instead.");
 
 			while (is.good()) {
 				std::string dep;
@@ -152,8 +155,10 @@ void parseModContents(ModSpec &spec)
 
 		if (info.exists("description"))
 			spec.desc = info.get("description");
-		else if (fs::ReadFile(spec.path + DIR_DELIM + "description.txt", spec.desc))
-			log_mod_deprecation(spec, "description.txt is deprecated, please use mod.conf instead.");
+		else if (fs::ReadFile(spec.path + DIR_DELIM + "description.txt",
+					 spec.desc))
+			log_mod_deprecation(spec, "description.txt is deprecated, please "
+						  "use mod.conf instead.");
 	}
 }
 


### PR DESCRIPTION
Fixes the code style of src/content/mods.cpp (Using the clang-format script)

This PR is ready for review.