### PR TITLE
Add mod.conf to preview clientmod

### DIFF
--- a/clientmods/preview/mod.conf
+++ b/clientmods/preview/mod.conf
@@ -1,0 +1,1 @@
+name = preview 


### PR DESCRIPTION
This PR prevents the deprecation warning 
```
2021-03-04 11:59:37: WARNING[Main]: Mods not having a mod.conf file with the name is deprecated. (preview at /home/fleckenstein/minetest/bin/../clientmods/preview)
```

## To do

This PR is a Ready for Review.

## How to test

Enable client modding and the preview CSM. Then start a singeplayer world. With this PR, you will not get the deprecation warning, without the PR you will.
