### PR TITLE
Add bold and italic for HUD text elements

### DIFF
--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1309,6 +1309,10 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
     --  ^ See "HUD Element Types"
         size = { x=100, y=100 },  -- default {x=0, y=0}
     --  ^ Size of element in pixels
+        bold = true,              -- default false
+    --  ^ Use bold font (works for hud_elem_type = "text")
+        italic = true,            -- default false
+    --  ^ Use italic font (works for hud_elem_type = "text", compatible with bold = true)
     }
 ```
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -8234,6 +8234,12 @@ Used by `Player:hud_add`. Returned by `Player:hud_get`.
 
         z_index = 0,
         -- Z index : lower z-index HUDs are displayed behind higher z-index HUDs
+
+        bold = false,
+        -- Use bold font (works for hud_elem_type = "text")
+
+        italic = false,
+        -- Use italic font (works for hud_elem_type = "text", compatible with bold = true)
     }
 
 Particle definition

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -64,6 +64,7 @@ struct ClientEventHudAdd
 	v3f world_pos;
 	v2s32 size;
 	s16 z_index;
+	bool bold, italic;
 };
 
 struct ClientEventHudChange
@@ -73,6 +74,7 @@ struct ClientEventHudChange
 	v2f v2fdata;
 	std::string sdata;
 	u32 data;
+	bool booldata;
 	v3f v3fdata;
 	v2s32 v2s32data;
 };

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2666,6 +2666,8 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 	e->size      = event->hudadd->size;
 	e->z_index   = event->hudadd->z_index;
 	e->text2     = event->hudadd->text2;
+	e->bold      = event->hudadd->bold;
+	e->italic    = event->hudadd->italic;
 	m_hud_server_to_client[server_id] = player->addHud(e);
 
 	delete event->hudadd;
@@ -2731,6 +2733,10 @@ void Game::handleClientEvent_HudChange(ClientEvent *event, CameraOrientation *ca
 		CASE_SET(HUD_STAT_Z_INDEX, z_index, data);
 
 		CASE_SET(HUD_STAT_TEXT2, text2, sdata);
+
+		CASE_SET(HUD_STAT_BOLD, bold, booldata);
+
+		CASE_SET(HUD_STAT_ITALIC, italic, booldata);
 	}
 
 #undef CASE_SET

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -358,13 +358,14 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 		switch (e->type) {
 			case HUD_ELEM_TEXT: {
 				irr::gui::IGUIFont *textfont = font;
-				unsigned int font_size = g_fontengine->getDefaultFontSize();
+				unsigned int default_font_size = g_fontengine->getDefaultFontSize();
+				unsigned int font_size = default_font_size;
 
 				if (e->size.X > 0)
 					font_size *= e->size.X;
 
-				if (font_size != g_fontengine->getDefaultFontSize())
-					textfont = g_fontengine->getFont(font_size);
+				if (font_size != default_font_size || e->bold || e->italic)
+					textfont = g_fontengine->getFont(FontSpec(font_size, FM_Standard, e->bold, e->italic));
 
 				video::SColor color(255, (e->number >> 16) & 0xFF,
 										 (e->number >> 8)  & 0xFF,

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -50,6 +50,8 @@ const struct EnumString es_HudElementStat[] =
 	{HUD_STAT_SIZE,    "size"},
 	{HUD_STAT_Z_INDEX, "z_index"},
 	{HUD_STAT_TEXT2,   "text2"},
+	{HUD_STAT_BOLD,    "bold"},
+	{HUD_STAT_ITALIC,  "italic"},
 	{0, NULL},
 };
 

--- a/src/hud.h
+++ b/src/hud.h
@@ -78,6 +78,8 @@ enum HudElementStat {
 	HUD_STAT_SIZE,
 	HUD_STAT_Z_INDEX,
 	HUD_STAT_TEXT2,
+	HUD_STAT_BOLD,
+	HUD_STAT_ITALIC,
 };
 
 enum HudCompassDir {
@@ -102,6 +104,8 @@ struct HudElement {
 	v2s32 size;
 	s16 z_index = 0;
 	std::string text2;
+	bool bold;
+	bool italic;
 };
 
 extern const EnumString es_HudElementType[];

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1056,6 +1056,8 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	v2s32 size;
 	s16 z_index = 0;
 	std::string text2;
+	bool bold = false;
+	bool italic = false;
 
 	*pkt >> server_id >> type >> pos >> name >> scale >> text >> number >> item
 		>> dir >> align >> offset;
@@ -1064,6 +1066,8 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 		*pkt >> size;
 		*pkt >> z_index;
 		*pkt >> text2;
+		*pkt >> bold;
+		*pkt >> italic;
 	} catch(PacketError &e) {};
 
 	ClientEvent *event = new ClientEvent();
@@ -1084,6 +1088,8 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	event->hudadd->size      = size;
 	event->hudadd->z_index   = z_index;
 	event->hudadd->text2     = text2;
+	event->hudadd->bold      = bold;
+	event->hudadd->italic    = italic;
 	m_client_event_queue.push(event);
 }
 
@@ -1105,6 +1111,7 @@ void Client::handleCommand_HudChange(NetworkPacket* pkt)
 	v2f v2fdata;
 	v3f v3fdata;
 	u32 intdata = 0;
+	bool booldata = false;
 	v2s32 v2s32data;
 	u32 server_id;
 	u8 stat;
@@ -1120,6 +1127,8 @@ void Client::handleCommand_HudChange(NetworkPacket* pkt)
 		*pkt >> v3fdata;
 	else if (stat == HUD_STAT_SIZE )
 		*pkt >> v2s32data;
+	else if (stat == HUD_STAT_BOLD || stat == HUD_STAT_ITALIC)
+		*pkt >> booldata;
 	else
 		*pkt >> intdata;
 
@@ -1132,6 +1141,7 @@ void Client::handleCommand_HudChange(NetworkPacket* pkt)
 	event->hudchange->v3fdata   = v3fdata;
 	event->hudchange->sdata     = sdata;
 	event->hudchange->data      = intdata;
+	event->hudchange->booldata  = booldata;
 	event->hudchange->v2s32data = v2s32data;
 	m_client_event_queue.push(event);
 }

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1925,6 +1925,9 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->world_pos = lua_istable(L, -1) ? read_v3f(L, -1) : v3f();
 	lua_pop(L, 1);
 
+	elem->bold = getboolfield_default(L, 2, "bold", false);
+	elem->italic = getboolfield_default(L, 2, "italic", false);
+
 	/* check for known deprecated element usage */
 	if ((elem->type  == HUD_ELEM_STATBAR) && (elem->size == v2s32()))
 		log_deprecated(L,"Deprecated usage of statbar without size!");
@@ -1979,6 +1982,12 @@ void push_hud_element(lua_State *L, HudElement *elem)
 
 	lua_pushstring(L, elem->text2.c_str());
 	lua_setfield(L, -2, "text2");
+
+	lua_pushboolean(L, elem->bold);
+	lua_setfield(L, -2, "bold");
+
+	lua_pushboolean(L, elem->italic);
+	lua_setfield(L, -2, "italic");
 }
 
 HudElementStat read_hud_change(lua_State *L, HudElement *elem, void **value)
@@ -2046,6 +2055,14 @@ HudElementStat read_hud_change(lua_State *L, HudElement *elem, void **value)
 		case HUD_STAT_TEXT2:
 			elem->text2 = luaL_checkstring(L, 4);
 			*value = &elem->text2;
+			break;
+		case HUD_STAT_BOLD:
+			elem->bold = lua_toboolean(L, 4);
+			*value = &elem->bold;
+			break;
+		case HUD_STAT_ITALIC:
+			elem->italic = lua_toboolean(L, 4);
+			*value = &elem->italic;
 			break;
 	}
 	return stat;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1638,7 +1638,7 @@ void Server::SendHUDAdd(session_t peer_id, u32 id, HudElement *form)
 	pkt << id << (u8) form->type << form->pos << form->name << form->scale
 			<< form->text << form->number << form->item << form->dir
 			<< form->align << form->offset << form->world_pos << form->size
-			<< form->z_index << form->text2;
+			<< form->z_index << form->text2 << form->bold << form->italic;
 
 	Send(&pkt);
 }
@@ -1672,6 +1672,10 @@ void Server::SendHUDChange(session_t peer_id, u32 id, HudElementStat stat, void 
 			break;
 		case HUD_STAT_SIZE:
 			pkt << *(v2s32 *) value;
+			break;
+		case HUD_STAT_BOLD:
+		case HUD_STAT_ITALIC:
+			pkt << *(bool *) value;
 			break;
 		case HUD_STAT_NUMBER:
 		case HUD_STAT_ITEM:


### PR DESCRIPTION
This PR makes it possible to use bold or italic font in HUD text elements. There are no compatibility problems; a client with these changes can connect to a server without these changes and a client without these changes can connect to a server with these changes. (The older client does not display the font bold / italic tho ofc)

## To do

This PR is Ready for Review.

- [x] Add documentation

## How to test

I made this snippet to demonstrate both hud_add and hud_change work:
```lua
local player_huds = {}

local states = {
	{false, false, "Normal font"},
	{false, true, "Italic font"},
	{true, false, "Bold font"},
	{true, true, "Bold and italic font"},
}


local default_def = {
	hud_elem_type = "text",
	position = {x = 0.5, y = 0.5},
	scale = {x = 2, y = 2},
	alignment = { x = 0, y = 0 },
}

local function add_hud(player, state)
	local def = table.copy(default_def)
	local statetbl = states[state]
	def.offset = {x = 0, y = 32 * state}
	def.bold = statetbl[1]
	def.italic = statetbl[2]
	def.text = statetbl[3]
	return player:hud_add(def)
end

minetest.register_on_joinplayer(function(player)
	player_huds[player:get_player_name()] = {
		add_hud(player, 1),
		add_hud(player, 2),
		add_hud(player, 3),
		add_hud(player, 4),
	}
end)

minetest.register_on_leaveplayer(function(player)
	player_huds[player:get_player_name()] = nil
end)

local etime = 0
local state = 0

minetest.register_globalstep(function(dtime)
	etime = etime + dtime
	if etime > 1 then
		etime = 0
		for _, player in ipairs(minetest.get_connected_players()) do
			local huds = player_huds[player:get_player_name()]
			for i = 0, 3 do
				local statetbl = states[(state + i) % 4 + 1]
				local hud_id = huds[i + 1]
				player:hud_change(hud_id, "bold", statetbl[1])
				player:hud_change(hud_id, "italic", statetbl[2])
				player:hud_change(hud_id, "text", statetbl[3])
			end
		end
		state = state + 1
	end
end)
```