### PR TITLE
Set ENABLE_SYSTEM_JSONCPP to TRUE by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,8 +204,8 @@ find_package(GMP REQUIRED)
 find_package(Json REQUIRED)
 find_package(Lua REQUIRED)
 
-# JsonCPP doesn't compile well on GCC 4.8
-if(NOT ENABLE_SYSTEM_JSONCPP)
+# JsonCpp doesn't compile well on GCC 4.8
+if(NOT USE_SYSTEM_JSONCPP)
 	set(GCC_MINIMUM_VERSION "4.9")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ General options and their default values:
     ENABLE_LUAJIT=ON           - Build with LuaJIT (much faster than non-JIT Lua)
     ENABLE_PROMETHEUS=OFF      - Build with Prometheus metrics exporter (listens on tcp/30000 by default)
     ENABLE_SYSTEM_GMP=ON       - Use GMP from system (much faster than bundled mini-gmp)
-    ENABLE_SYSTEM_JSONCPP=OFF  - Use JsonCPP from system
+    ENABLE_SYSTEM_JSONCPP=ON   - Use JsonCPP from system
     OPENGL_GL_PREFERENCE=LEGACY - Linux client build only; See CMake Policy CMP0072 for reference
     RUN_IN_PLACE=FALSE         - Create a portable install (worlds, settings etc. in current directory)
     USE_GPROF=FALSE            - Enable profiling using GProf
@@ -354,7 +354,7 @@ This is outdated and not recommended. Follow the instructions on https://dev.min
 Run the following script in PowerShell:
 
 ```powershell
-cmake . -G"Visual Studio 15 2017 Win64" -DCMAKE_TOOLCHAIN_FILE=D:/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_GETTEXT=OFF -DENABLE_CURSES=OFF -DENABLE_SYSTEM_JSONCPP=ON
+cmake . -G"Visual Studio 15 2017 Win64" -DCMAKE_TOOLCHAIN_FILE=D:/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_GETTEXT=OFF -DENABLE_CURSES=OFF
 cmake --build . --config Release
 ```
 Make sure that the right compiler is selected and the path to the vcpkg toolchain is correct.

--- a/cmake/Modules/FindGMP.cmake
+++ b/cmake/Modules/FindGMP.cmake
@@ -12,8 +12,6 @@ if(ENABLE_SYSTEM_GMP)
 	else()
 		message (STATUS "Detecting GMP from system failed.")
 	endif()
-else()
-	message (STATUS "Detecting GMP from system disabled! (ENABLE_SYSTEM_GMP=0)")
 endif()
 
 if(NOT USE_SYSTEM_GMP)

--- a/cmake/Modules/FindJson.cmake
+++ b/cmake/Modules/FindJson.cmake
@@ -1,26 +1,25 @@
-# Look for JSONCPP if asked to.
-# We use a bundled version by default because some distros ship versions of
-# JSONCPP that cause segfaults and other memory errors when we link with them.
-# See https://github.com/minetest/minetest/issues/1793
+# Look for JsonCpp, with fallback to bundeled version
 
 mark_as_advanced(JSON_LIBRARY JSON_INCLUDE_DIR)
-option(ENABLE_SYSTEM_JSONCPP "Enable using a system-wide JSONCPP.  May cause segfaults and other memory errors!" FALSE)
+option(ENABLE_SYSTEM_JSONCPP "Enable using a system-wide JsonCpp" TRUE)
+set(USE_SYSTEM_JSONCPP FALSE)
 
 if(ENABLE_SYSTEM_JSONCPP)
 	find_library(JSON_LIBRARY NAMES jsoncpp)
 	find_path(JSON_INCLUDE_DIR json/allocator.h PATH_SUFFIXES jsoncpp)
 
-	include(FindPackageHandleStandardArgs)
-	find_package_handle_standard_args(Json DEFAULT_MSG JSON_LIBRARY JSON_INCLUDE_DIR)
-
-	if(JSON_FOUND)
-		message(STATUS "Using system JSONCPP library.")
+	if(JSON_LIBRARY AND JSON_INCLUDE_DIR)
+		message(STATUS "Using JsonCpp provided by system.")
+		set(USE_SYSTEM_JSONCPP TRUE)
 	endif()
 endif()
 
-if(NOT JSON_FOUND)
-	message(STATUS "Using bundled JSONCPP library.")
+if(NOT USE_SYSTEM_JSONCPP)
+	message(STATUS "Using bundled JsonCpp library.")
 	set(JSON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/jsoncpp)
 	set(JSON_LIBRARY jsoncpp)
 	add_subdirectory(lib/jsoncpp)
 endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Json DEFAULT_MSG JSON_LIBRARY JSON_INCLUDE_DIR)


### PR DESCRIPTION
No reason not to anymore.

(also corrected message to use the official spelling which is "JsonCpp")