### PR TITLE
Predict failing placement of ignore nodes

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -368,6 +368,7 @@ core.register_node(":ignore", {
 	air_equivalent = true,
 	drop = "",
 	groups = {not_in_creative_inventory=1},
+	node_placement_prediction = "",
 	on_place = function(itemstack, placer, pointed_thing)
 		core.chat_send_player(
 				placer:get_player_name(),


### PR DESCRIPTION
If you tried to place an `ignore` node, you will still get a red ERROR message saying that air cannot be replaced by `CONTENT_IGNORE` (in addition to “You can't place 'ignore' nodes!”).

This was because the client predicted that `ignore` will be placed (resulting in failure), although the `on_place` function prevents it on the server-side.

This PR adds the missing node placement prediction, thus removing the redundant error message. (only “You can't place 'ignore' nodes!” will remain)