### PR TITLE
[NO SQUASH] Additional inventory access protections

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -626,13 +626,17 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 
 	const bool player_has_interact = checkPriv(player->getName(), "interact");
 
-	auto check_inv_access = [player, player_has_interact] (
+	auto check_inv_access = [player, player_has_interact, this] (
 			const InventoryLocation &loc) -> bool {
 		if (loc.type == InventoryLocation::CURRENT_PLAYER)
 			return false; // Only used internally on the client, never sent
 		if (loc.type == InventoryLocation::PLAYER) {
 			// Allow access to own inventory in all cases
 			return loc.name == player->getName();
+		}
+		if (loc.type == InventoryLocation::DETACHED) {
+			if (!getInventoryMgr()->checkDetachedInventoryAccess(loc, player->getName()))
+				return false;
 		}
 
 		if (!player_has_interact) {

--- a/src/server/serverinventorymgr.cpp
+++ b/src/server/serverinventorymgr.cpp
@@ -168,6 +168,18 @@ bool ServerInventoryManager::removeDetachedInventory(const std::string &name)
 	return true;
 }
 
+bool ServerInventoryManager::checkDetachedInventoryAccess(
+		const InventoryLocation &loc, const std::string &player) const
+{
+	SANITY_CHECK(loc.type == InventoryLocation::DETACHED);
+
+	const auto &inv_it = m_detached_inventories.find(loc.name);
+	if (inv_it == m_detached_inventories.end())
+		return false;
+
+	return inv_it->second.owner.empty() || inv_it->second.owner == player;
+}
+
 void ServerInventoryManager::sendDetachedInventories(const std::string &peer_name,
 		bool incremental,
 		std::function<void(const std::string &, Inventory *)> apply_cb)

--- a/src/server/serverinventorymgr.h
+++ b/src/server/serverinventorymgr.h
@@ -43,6 +43,7 @@ public:
 	Inventory *createDetachedInventory(const std::string &name, IItemDefManager *idef,
 			const std::string &player = "");
 	bool removeDetachedInventory(const std::string &name);
+	bool checkDetachedInventoryAccess(const InventoryLocation &loc, const std::string &player) const;
 
 	void sendDetachedInventories(const std::string &peer_name, bool incremental,
 			std::function<void(const std::string &, Inventory *)> apply_cb);


### PR DESCRIPTION
Fixes a vulnerability where inventory actions were handled on other player's detached inventories.

Pointed out by @Lejo1 (I believe), but I cannot find the specific comment right now.

## To do

This PR is Ready for Review.

## How to test

1. `std::cout << "check " << loc.name << " -> " << (owner ? *owner : "none") << std::endl;` @ serverpackethandler.cpp after L638
2. Use `creative` (item browser) or `unified_inventory` (bags) or `3d_armor` (armor slots)
3. Check the output

Second commit:

1. Tool range ` * 2;` in game.cpp L2993
2. Open the chest from far
3. Attempt to drop items from the chest