### PR TITLE
Fix missing jsoncpp in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN mkdir build && \
 
 FROM alpine:3.11
 
-RUN apk add --no-cache sqlite-libs curl gmp libstdc++ libgcc libpq luajit && \
+RUN apk add --no-cache sqlite-libs curl gmp libstdc++ libgcc libpq luajit jsoncpp && \
 	adduser -D minetest --uid 30000 -h /var/lib/minetest && \
 	chown -R minetest:minetest /var/lib/minetest
 


### PR DESCRIPTION
#11027 broke the docker image building cause it builds minetest with jsoncpp-dev.
But later it's used without.
So the container fails to start for:
`Error loading shared library libjsoncpp.so.22: No such file or directory (needed by /usr/local/bin/minetestserver)`

This PR just adds jsoncpp to the final docker image

## How to test

Try my docker image with this fix: registry.gitlab.com/lejo1/minetest/server