### PR TITLE
Use active object id in objrefs instead of pointers 

### DIFF
--- a/src/activeobjectmgr.h
+++ b/src/activeobjectmgr.h
@@ -36,7 +36,7 @@ public:
 	virtual bool registerObject(T *obj) = 0;
 	virtual void removeObject(u16 id) = 0;
 
-	T *getActiveObject(u16 id)
+	T *getActiveObject(u16 id) const
 	{
 		typename std::unordered_map<u16, T *>::const_iterator n =
 				m_active_objects.find(id);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1046,7 +1046,8 @@ void read_server_sound_params(lua_State *L, int index,
 		lua_getfield(L, index, "object");
 		if(!lua_isnil(L, -1)){
 			ObjectRef *ref = ObjectRef::checkobject(L, -1);
-			ServerActiveObject *sao = ObjectRef::getobject(ref);
+			ServerActiveObject *sao = ObjectRef::getobject(ref,
+					ObjectRef::getServer(L)->getEnv());
 			if(sao){
 				params.object = sao->getId();
 				params.type = ServerSoundParams::SSP_OBJECT;

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -348,10 +348,8 @@ void ScriptApiBase::setOriginFromTableRaw(int index, const char *fxn)
  * table instead of creating their own.(*)
  * When an active object is removed, the existing ObjectRef is invalidated
  * using ::set_null() and removed from the core.object_refs table.
- * (*) An exception to this are NULL ObjectRefs and anonymous ObjectRefs
- *     for objects without ID.
- *     It's unclear what the latter are needed for and their use is problematic
- *     since we lose control over the ref and the contained pointer.
+ * (*) An exception to this are invalid ObjectRefs. Anonymous ObjectRefs
+ *     for objects without ID are also counted as invalid.
  */
 
 void ScriptApiBase::addObjectReference(ServerActiveObject *cobj)
@@ -389,7 +387,7 @@ void ScriptApiBase::removeObjectReference(ServerActiveObject *cobj)
 	// Get object_refs[id]
 	lua_pushnumber(L, cobj->getId()); // Push id
 	lua_gettable(L, objectstable);
-	// Set object reference to NULL
+	// Invalidate object reference
 	ObjectRef::set_null(L);
 	lua_pop(L, 1); // pop object
 
@@ -403,7 +401,7 @@ void ScriptApiBase::removeObjectReference(ServerActiveObject *cobj)
 void ScriptApiBase::objectrefGetOrCreate(lua_State *L,
 		ServerActiveObject *cobj)
 {
-	if (cobj == NULL || cobj->getId() == 0) {
+	if (!cobj || cobj->getId() == 0) {
 		ObjectRef::create(L, cobj);
 	} else {
 		push_objectRef(L, cobj->getId());

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -51,7 +51,7 @@ ObjectRef *ObjectRef::checkobject(lua_State *L, int narg)
 
 ServerActiveObject *ObjectRef::getobject(ObjectRef *ref, const ServerEnvironment &senv)
 {
-	ServerActiveObject *sao = senv.getActiveObject(ref->m_obj_id);
+	ServerActiveObject *sao = ref->m_obj_id != 0 ? senv.getActiveObject(ref->m_obj_id) : nullptr;
 	if (sao && sao->isGone())
 		return nullptr;
 	return sao;
@@ -2274,7 +2274,7 @@ int ObjectRef::l_set_minimap_modes(lua_State *L)
 }
 
 ObjectRef::ObjectRef(ServerActiveObject *object):
-	m_obj_id(object->getId())
+	m_obj_id(object ? object->getId() : 0)
 {}
 
 // Creates an ObjectRef and leaves it on top of stack

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -26,6 +26,7 @@ class ServerActiveObject;
 class LuaEntitySAO;
 class PlayerSAO;
 class RemotePlayer;
+class ServerEnvironment;
 
 /*
 	ObjectRef
@@ -41,24 +42,25 @@ public:
 	// Not callable from Lua; all references are created on the C side.
 	static void create(lua_State *L, ServerActiveObject *object);
 
+	// invalidates the objref
 	static void set_null(lua_State *L);
 
 	static void Register(lua_State *L);
 
 	static ObjectRef *checkobject(lua_State *L, int narg);
 
-	static ServerActiveObject* getobject(ObjectRef *ref);
+	static ServerActiveObject *getobject(ObjectRef *ref, const ServerEnvironment &senv);
 private:
-	ServerActiveObject *m_object = nullptr;
+	u16 m_obj_id = 0; // the object's ActiveObject-id
 	static const char className[];
 	static luaL_Reg methods[];
 
 
-	static LuaEntitySAO* getluaobject(ObjectRef *ref);
+	static LuaEntitySAO* getluaobject(ObjectRef *ref, const ServerEnvironment &senv);
 
-	static PlayerSAO* getplayersao(ObjectRef *ref);
+	static PlayerSAO* getplayersao(ObjectRef *ref, const ServerEnvironment &senv);
 
-	static RemotePlayer *getplayer(ObjectRef *ref);
+	static RemotePlayer *getplayer(ObjectRef *ref, const ServerEnvironment &senv);
 
 	// Exported functions
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -51,7 +51,10 @@ public:
 
 	static ServerActiveObject *getobject(ObjectRef *ref, const ServerEnvironment &senv);
 private:
-	u16 m_obj_id = 0; // the object's ActiveObject-id
+	// the object's id
+	// 0 means invalid
+	u16 m_obj_id = 0;
+
 	static const char className[];
 	static luaL_Reg methods[];
 

--- a/src/script/lua_api/l_particles.cpp
+++ b/src/script/lua_api/l_particles.cpp
@@ -231,7 +231,7 @@ int ModApiParticles::l_add_particlespawner(lua_State *L)
 		if (!lua_isnil(L, -1)) {
 			ObjectRef *ref = ObjectRef::checkobject(L, -1);
 			lua_pop(L, 1);
-			attached = ObjectRef::getobject(ref);
+			attached = ObjectRef::getobject(ref, ObjectRef::getServer(L)->getEnv());
 		}
 
 		p.vertical = getboolfield_default(L, 1, "vertical", p.vertical);

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -237,7 +237,7 @@ public:
 		-------------------------------------------
 	*/
 
-	ServerActiveObject* getActiveObject(u16 id)
+	ServerActiveObject *getActiveObject(u16 id) const
 	{
 		return m_ao_manager.getActiveObject(id);
 	}


### PR DESCRIPTION
- objrefs currently carry pointers, which can be problematic
- With this PR, objrefs use active object ids and lookup the ServerActiveObject on each access.
- Invalid objrefs no longer have a nullptr, but the id 0.
- Anonymous active objects also have id 0, hence they are also counted as invalid. This means that you can't interact with them from lua.
  It's like a goblin that died and became a ghost, you can't interact with the ghost, but did you ever interact with a goblin? If so, please tell me about it.
- The pointer to the ServerActiveObject was boxed in the ObjectRef, and a pointer to that was stored in the userdata. I have no idea why this extra boxing happened, and so I've removed it. The ObjectRef is now directly stored in the userdata buffer.

## To do

This PR is a Ready for Review.

## How to test

I don't know.

@rubenwardy 
