### PR TITLE
Add persistent unique identifiers for objects

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6204,7 +6204,6 @@ object you are working with still exists.
 
 ### Methods
 
-
 * `get_guid()`: returns a global unique identifier (a string)
     * An object keeps its guid forever, even over server restarts.
     * The same guid will never be reused for a different object.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6204,6 +6204,10 @@ object you are working with still exists.
 
 ### Methods
 
+
+* `get_guid()`: returns a global unique identifier (a string)
+    * An object keeps its guid forever, even over server restarts.
+    * The same guid will never be reused for a different object.
 * `get_pos()`: returns `{x=num, y=num, z=num}`
 * `set_pos(pos)`: `pos`=`{x=num, y=num, z=num}`
 * `get_velocity()`: returns the velocity, a vector.
@@ -6299,9 +6303,6 @@ object you are working with still exists.
     * The object is removed after returning from Lua. However the `ObjectRef`
       itself instantly becomes unusable with all further method calls having
       no effect and returning `nil`.
-* `get_guid()`: returns a global unique identifier (a string)
-    * An object keeps its guid forever, even over server restarts.
-    * The same guid will never be reused for a different object.
 * `set_velocity(vel)`
     * `vel` is a vector, e.g. `{x=0.0, y=2.3, z=1.0}`
 * `set_acceleration(acc)`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6299,6 +6299,9 @@ object you are working with still exists.
     * The object is removed after returning from Lua. However the `ObjectRef`
       itself instantly becomes unusable with all further method calls having
       no effect and returning `nil`.
+* `get_guid()`: returns a global unique identifier (a string)
+    * An object keeps its guid forever, even over server restarts.
+    * The same guid will never be reused for a different object.
 * `set_velocity(vel)`
     * `vel` is a vector, e.g. `{x=0.0, y=2.3, z=1.0}`
 * `set_acceleration(acc)`

--- a/doc/world_format.txt
+++ b/doc/world_format.txt
@@ -507,9 +507,12 @@ Object types:
   s32 velocity.z * 10000
   s32 yaw * 1000
   if PROTOCOL_VERSION >= 37:
-    u8 version2 (=1)
+    u8 version2 (=2)
     s32 pitch * 1000
     s32 roll * 1000
+    if version2 >= 2:
+      u32 len
+      u8[len] guid
 
 Itemstring format
 ------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -385,6 +385,7 @@ set(common_SRCS
 	face_position_cache.cpp
 	filesys.cpp
 	gettext.cpp
+	guid.cpp
 	httpfetch.cpp
 	hud.cpp
 	inventory.cpp

--- a/src/guid.cpp
+++ b/src/guid.cpp
@@ -1,0 +1,109 @@
+/*
+Minetest
+Copyright (C) 2021, DS
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "guid.h"
+#include <sstream>
+
+#define DIGITS_PER_U64 19
+#define MAX_NUM_IN_U64 9999999999999999999ul
+
+GUIDGenerator::Validity GUIDGenerator::seed(const GUID &first)
+{
+	Validity v = getValidity(first);
+	if (v != Valid)
+		return v;
+
+	m_next_v.clear();
+
+	size_t num_len = first.size() - 6;
+
+	while (num_len > DIGITS_PER_U64) {
+		num_len -= DIGITS_PER_U64;
+		m_next_v.push_back(std::stoull(first.substr(6 + num_len, DIGITS_PER_U64)));
+	}
+
+	m_next_v.push_back(std::stoull(first.substr(6, num_len)));
+
+	return Valid;
+}
+
+GUID GUIDGenerator::generateNext()
+{
+	if (m_next_v.empty())
+		return "";
+
+	GUID ret = peekNext();
+
+	// increment m_next_v
+
+	if (m_next_v[0] < MAX_NUM_IN_U64) {
+		m_next_v[0] += 1ul;
+
+	} else { // very unlikely
+		m_next_v[0] = 0ul;
+		size_t s = m_next_v.size();
+		for (size_t i = 1; true; i++) {
+			if (i == s) {
+				m_next_v.push_back(1ul);
+				break;
+			}
+			if (m_next_v[i] < MAX_NUM_IN_U64) {
+				m_next_v[i] += 1ul;
+				break;
+			}
+			// very unlikely
+			m_next_v[i] = 0ul;
+			continue;
+		}
+	}
+
+	return ret;
+}
+
+GUID GUIDGenerator::peekNext() const
+{
+	if (m_next_v.empty())
+		return "";
+
+	std::ostringstream id_strm;
+
+	id_strm << "v1guid";
+
+	for (auto it = m_next_v.rbegin(); it != m_next_v.rend(); it++)
+		id_strm << *it;
+
+	return id_strm.str();
+}
+
+GUIDGenerator::Validity GUIDGenerator::getValidity(const GUID &id)
+{
+	if (id.empty())
+		return Old;
+
+	size_t s = id.size();
+
+	if (s < 7 || id.substr(0, 6) != "v1guid" || id[6] == '0')
+		return Invalid;
+
+	for (size_t i = 7; i < s; i++)
+		if (!isdigit(id[i]))
+			return Invalid;
+
+	return Valid;
+}

--- a/src/guid.cpp
+++ b/src/guid.cpp
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define DIGITS_PER_U64 19
 #define MAX_NUM_IN_U64 9999999999999999999ul
 
-GUIDGenerator::Validity GUIDGenerator::seed(const GUID &first)
+GUIdGenerator::Validity GUIdGenerator::seed(const GUId &first)
 {
 	Validity v = getValidity(first);
 	if (v != Valid)
@@ -43,12 +43,12 @@ GUIDGenerator::Validity GUIDGenerator::seed(const GUID &first)
 	return Valid;
 }
 
-GUID GUIDGenerator::generateNext()
+GUId GUIdGenerator::generateNext()
 {
 	if (m_next_v.empty())
 		return "";
 
-	GUID ret = peekNext();
+	GUId ret = peekNext();
 
 	// increment m_next_v
 
@@ -76,7 +76,7 @@ GUID GUIDGenerator::generateNext()
 	return ret;
 }
 
-GUID GUIDGenerator::peekNext() const
+GUId GUIdGenerator::peekNext() const
 {
 	if (m_next_v.empty())
 		return "";
@@ -91,7 +91,7 @@ GUID GUIDGenerator::peekNext() const
 	return id_strm.str();
 }
 
-GUIDGenerator::Validity GUIDGenerator::getValidity(const GUID &id)
+GUIdGenerator::Validity GUIdGenerator::getValidity(const GUId &id)
 {
 	if (id.empty())
 		return Old;

--- a/src/guid.h
+++ b/src/guid.h
@@ -1,0 +1,104 @@
+/*
+Minetest
+Copyright (C) 2021, DS
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "irrlichttypes.h"
+#include <vector>
+#include <string>
+
+/**
+ * A global unique identifier.
+ * It is global because it stays valid in a world forever.
+ * It is unique because there are no collisions.
+ *
+ * It is a string of the following form:
+ * "v1guid<deci_num>"
+ * where <deci_num> should be replaced by a number of decimal digits, with the
+ * first digit != 0 ("0" and "" are invalid).
+ * The number after the v is the version number (currently always 1).
+ *
+ * There is a partial order for guids:
+ * guid A is newer than guid B iff
+ * A's version number is higher than B's and B's version number is 1 or
+ * A and B both have version number 1 and A's deci_num is higher
+ */
+typedef std::string GUID;
+
+/**
+ * Generates infinitely many guids.
+ */
+class GUIDGenerator {
+public:
+	/**
+	 * Creates a new uninitialized generator.
+	 */
+	GUIDGenerator() = default;
+
+	~GUIDGenerator() = default;
+
+	/**
+	 * The validity of a guid.
+	 * Old means that it was a valid guid in an older version, this includes
+	 * the empty string.
+	 * Invalid guids are strings that have an invalid form, eg. "v1guid1a23", but
+	 * also guids of newer versions.
+	 * Everything else is valid.
+	 */
+	enum Validity {
+		Valid,
+		Old,
+		Invalid,
+	};
+
+	/**
+	 * Seeds the generator with the first guid to return next.
+	 * Can fail for invalid seeds.
+	 * Do only seed with guids of which you know that itself and newer guids are
+	 * not used yet.
+	 * @param first the first guid that should be returned by generateNext
+	 * @return the validity of the given id; Valid iff the generator is seeded
+	 */
+	Validity seed(const GUID &first);
+
+	/**
+	 * Generates the next guid, which it will never return again.
+	 * @return the new guid, or "" if the generator is not yet initialized
+	 */
+	GUID generateNext();
+
+	/**
+	 * Returns the guid that would be generated next.
+	 * @return the next guid
+	 */
+	GUID peekNext() const;
+
+	/**
+	 * Returns the validity for a guid.
+	 * @param id the guid
+	 * @return the validity of id
+	 */
+	static Validity getValidity(const GUID &id);
+
+private:
+	/**
+	 * Internal representation of the next guid.
+	 * Each u64 stores 19 decimal digits of the next deci_num.
+	 * The u64s are ordered little-endian-wise.
+	 */
+	std::vector<u64> m_next_v;
+};

--- a/src/guid.h
+++ b/src/guid.h
@@ -17,6 +17,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#pragma once
+
 #include "irrlichttypes.h"
 #include <vector>
 #include <string>

--- a/src/guid.h
+++ b/src/guid.h
@@ -39,19 +39,19 @@ with this program; if not, write to the Free Software Foundation, Inc.,
  * A's version number is higher than B's and B's version number is 1 or
  * A and B both have version number 1 and A's deci_num is higher
  */
-typedef std::string GUID;
+typedef std::string GUId;
 
 /**
  * Generates infinitely many guids.
  */
-class GUIDGenerator {
+class GUIdGenerator {
 public:
 	/**
 	 * Creates a new uninitialized generator.
 	 */
-	GUIDGenerator() = default;
+	GUIdGenerator() = default;
 
-	~GUIDGenerator() = default;
+	~GUIdGenerator() = default;
 
 	/**
 	 * The validity of a guid.
@@ -75,26 +75,26 @@ public:
 	 * @param first the first guid that should be returned by generateNext
 	 * @return the validity of the given id; Valid iff the generator is seeded
 	 */
-	Validity seed(const GUID &first);
+	Validity seed(const GUId &first);
 
 	/**
 	 * Generates the next guid, which it will never return again.
 	 * @return the new guid, or "" if the generator is not yet initialized
 	 */
-	GUID generateNext();
+	GUId generateNext();
 
 	/**
 	 * Returns the guid that would be generated next.
 	 * @return the next guid
 	 */
-	GUID peekNext() const;
+	GUId peekNext() const;
 
 	/**
 	 * Returns the validity for a guid.
 	 * @param id the guid
 	 * @return the validity of id
 	 */
-	static Validity getValidity(const GUID &id);
+	static Validity getValidity(const GUId &id);
 
 private:
 	/**

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -114,6 +114,21 @@ int ObjectRef::l_remove(lua_State *L)
 	return 0;
 }
 
+// get_guid()
+int ObjectRef::l_get_guid(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *sao = getobject(ref);
+	if (sao == nullptr)
+		return 0;
+
+	const std::string &guid = sao->getGuid();
+
+	lua_pushstring(L, guid.c_str());
+	return 1;
+}
+
 // get_pos(self)
 int ObjectRef::l_get_pos(lua_State *L)
 {
@@ -792,21 +807,6 @@ int ObjectRef::l_get_nametag_attributes(lua_State *L)
 }
 
 /* LuaEntitySAO-only */
-
-// get_guid()
-int ObjectRef::l_get_guid(lua_State *L)
-{
-	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
-	LuaEntitySAO *sao = getluaobject(ref);
-	if (sao == nullptr)
-		return 0;
-
-	const GUId &guid = sao->getGuid();
-
-	lua_pushstring(L, guid.c_str());
-	return 1;
-}
 
 // set_velocity(self, velocity)
 int ObjectRef::l_set_velocity(lua_State *L)
@@ -2334,6 +2334,7 @@ const char ObjectRef::className[] = "ObjectRef";
 luaL_Reg ObjectRef::methods[] = {
 	// ServerActiveObject
 	luamethod(ObjectRef, remove),
+	luamethod(ObjectRef, get_guid),
 	luamethod_aliased(ObjectRef, get_pos, getpos),
 	luamethod_aliased(ObjectRef, set_pos, setpos),
 	luamethod_aliased(ObjectRef, move_to, moveto),
@@ -2368,7 +2369,6 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod_dep(ObjectRef, get_velocity, get_player_velocity),
 
 	// LuaEntitySAO-only
-	luamethod(ObjectRef, get_guid),
 	luamethod_aliased(ObjectRef, set_acceleration, setacceleration),
 	luamethod_aliased(ObjectRef, get_acceleration, getacceleration),
 	luamethod_aliased(ObjectRef, set_yaw, setyaw),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -802,7 +802,7 @@ int ObjectRef::l_get_guid(lua_State *L)
 	if (sao == nullptr)
 		return 0;
 
-	const GUID &guid = sao->get_guid();
+	const GUId &guid = sao->getGuid();
 
 	lua_pushstring(L, guid.c_str());
 	return 1;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -793,6 +793,21 @@ int ObjectRef::l_get_nametag_attributes(lua_State *L)
 
 /* LuaEntitySAO-only */
 
+// get_guid()
+int ObjectRef::l_get_guid(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *sao = getluaobject(ref);
+	if (sao == nullptr)
+		return 0;
+
+	const GUID &guid = sao->get_guid();
+
+	lua_pushstring(L, guid.c_str());
+	return 1;
+}
+
 // set_velocity(self, velocity)
 int ObjectRef::l_set_velocity(lua_State *L)
 {
@@ -2353,6 +2368,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod_dep(ObjectRef, get_velocity, get_player_velocity),
 
 	// LuaEntitySAO-only
+	luamethod(ObjectRef, get_guid),
 	luamethod_aliased(ObjectRef, set_acceleration, setacceleration),
 	luamethod_aliased(ObjectRef, get_acceleration, getacceleration),
 	luamethod_aliased(ObjectRef, set_yaw, setyaw),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -154,6 +154,9 @@ private:
 
 	/* LuaEntitySAO-only */
 
+	// get_guid()
+	static int l_get_guid(lua_State *L);
+
 	// set_velocity(self, velocity)
 	static int l_set_velocity(lua_State *L);
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -68,6 +68,9 @@ private:
 	// remove(self)
 	static int l_remove(lua_State *L);
 
+	// get_guid()
+	static int l_get_guid(lua_State *L);
+
 	// get_pos(self)
 	static int l_get_pos(lua_State *L);
 
@@ -153,9 +156,6 @@ private:
 	static int l_is_player(lua_State *L);
 
 	/* LuaEntitySAO-only */
-
-	// get_guid()
-	static int l_get_guid(lua_State *L);
 
 	// set_velocity(self, velocity)
 	static int l_set_velocity(lua_State *L);

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -85,7 +85,7 @@ LuaEntitySAO::LuaEntitySAO(ServerEnvironment *env, v3f pos, const std::string &d
 	if (!guid.empty()) {
 		m_guid = guid;
 	} else {
-		m_guid = env->generateNextLuaentGUID();
+		m_guid = env->generateNextLuaentGUId();
 		m_force_write_staticdata = true;
 	}
 }
@@ -95,7 +95,7 @@ LuaEntitySAO::LuaEntitySAO(ServerEnvironment *env, v3f pos, const std::string &n
 		UnitSAO(env, pos),
 		m_init_name(name), m_init_state(state)
 {
-	m_guid = env->generateNextLuaentGUID();
+	m_guid = env->generateNextLuaentGUId();
 }
 
 LuaEntitySAO::~LuaEntitySAO()

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -82,10 +82,12 @@ LuaEntitySAO::LuaEntitySAO(ServerEnvironment *env, v3f pos, const std::string &d
 	m_hp = hp;
 	m_velocity = velocity;
 	m_rotation = rotation;
-	if (!guid.empty())
+	if (!guid.empty()) {
 		m_guid = guid;
-	else
+	} else {
 		m_guid = env->generateNextLuaentGUID();
+		m_force_write_staticdata = true;
+	}
 }
 
 LuaEntitySAO::LuaEntitySAO(ServerEnvironment *env, v3f pos, const std::string &name,

--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -51,9 +51,9 @@ public:
 	std::string getDescription();
 	void setHP(s32 hp, const PlayerHPChangeReason &reason);
 	u16 getHP() const;
+	std::string getGuid() const override { return m_guid; }
 
 	/* LuaEntitySAO-specific */
-	const GUId &getGuid() const { return m_guid; }
 	void setVelocity(v3f velocity);
 	void addVelocity(v3f velocity) { m_velocity += velocity; }
 	v3f getVelocity();

--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -53,7 +53,7 @@ public:
 	u16 getHP() const;
 
 	/* LuaEntitySAO-specific */
-	const GUID &get_guid() const { return m_guid; }
+	const GUId &getGuid() const { return m_guid; }
 	void setVelocity(v3f velocity);
 	void addVelocity(v3f velocity) { m_velocity += velocity; }
 	v3f getVelocity();
@@ -85,7 +85,7 @@ private:
 	std::string m_init_state;
 	bool m_registered = false;
 
-	GUID m_guid;
+	GUId m_guid;
 
 	v3f m_velocity;
 	v3f m_acceleration;

--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "unit_sao.h"
+#include "guid.h"
 
 class LuaEntitySAO : public UnitSAO
 {
@@ -30,11 +31,7 @@ public:
 	LuaEntitySAO(ServerEnvironment *env, v3f pos, const std::string &data);
 	// Used by the Lua API
 	LuaEntitySAO(ServerEnvironment *env, v3f pos, const std::string &name,
-			const std::string &state) :
-			UnitSAO(env, pos),
-			m_init_name(name), m_init_state(state)
-	{
-	}
+			const std::string &state);
 	~LuaEntitySAO();
 	ActiveObjectType getType() const { return ACTIVEOBJECT_TYPE_LUAENTITY; }
 	ActiveObjectType getSendType() const { return ACTIVEOBJECT_TYPE_GENERIC; }
@@ -56,6 +53,7 @@ public:
 	u16 getHP() const;
 
 	/* LuaEntitySAO-specific */
+	const GUID &get_guid() const { return m_guid; }
 	void setVelocity(v3f velocity);
 	void addVelocity(v3f velocity) { m_velocity += velocity; }
 	v3f getVelocity();
@@ -86,6 +84,8 @@ private:
 	std::string m_init_name;
 	std::string m_init_state;
 	bool m_registered = false;
+
+	GUID m_guid;
 
 	v3f m_velocity;
 	v3f m_acceleration;

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -375,6 +375,11 @@ void PlayerSAO::setPlayerYaw(const float yaw)
 	UnitSAO::setRotation(rotation);
 }
 
+std::string PlayerSAO::getGuid() const
+{
+	return std::string("vpguid") + m_player->getName();
+}
+
 void PlayerSAO::setFov(const float fov)
 {
 	if (m_player && fov != m_fov)

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -91,6 +91,7 @@ public:
 	void setPos(const v3f &pos);
 	void moveTo(v3f pos, bool continuous);
 	void setPlayerYaw(const float yaw);
+	std::string getGuid() const override;
 	// Data should not be sent at player initialization
 	void setPlayerYawAndSend(const float yaw);
 	void setLookPitch(const float pitch);

--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -229,6 +229,11 @@ public:
 	*/
 	bool m_static_exists = false;
 	/*
+		Set this to true when the staticdata needs to be saved even though it
+		looks like it did not change.
+	*/
+	bool m_force_write_staticdata = false;
+	/*
 		The block from which the object was loaded from, and in which
 		a copy of the static data resides.
 	*/

--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -158,6 +158,9 @@ public:
 	virtual u16 getHP() const
 	{ return 0; }
 
+	// Returns always the same unique string for the same object.
+	virtual std::string getGuid() const = 0;
+
 	virtual void setArmorGroups(const ItemGroupList &armor_groups)
 	{}
 	virtual const ItemGroupList &getArmorGroups() const

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -2061,7 +2061,9 @@ void ServerEnvironment::deactivateFarObjects(bool _force_delete)
 				While changes are always saved, blocks are only marked as modified
 				if the object has moved or different staticdata. (see above)
 			*/
-			bool shall_be_written = (!stays_in_same_block || data_changed);
+			bool shall_be_written = (!stays_in_same_block || data_changed ||
+					obj->m_force_write_staticdata);
+			obj->m_force_write_staticdata = false;
 			u32 reason = shall_be_written ? MOD_REASON_STATIC_DATA_CHANGED : MOD_REASON_UNKNOWN;
 
 			// Delete old static object

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -640,6 +640,7 @@ void ServerEnvironment::saveMeta()
 	args.set("lbm_introduction_times",
 		m_lbm_mgr.createIntroductionTimesString());
 	args.setU64("day_count", m_day_count);
+	args.set("luaent_guid_next", m_luaent_guid_generator.peekNext());
 	args.writeLines(ss);
 
 	if(!fs::safeWriteToFile(path, ss.str()))
@@ -713,6 +714,10 @@ void ServerEnvironment::loadMeta()
 
 	m_day_count = args.exists("day_count") ?
 		args.getU64("day_count") : 0;
+
+	const std::string &next_luaent_guid = args.exists("luaent_guid_next") ?
+		args.get("luaent_guid_next") : "v1guid1000"; // 1000 is chosen arbitrarily
+	m_luaent_guid_generator.seed(next_luaent_guid);
 }
 
 /**
@@ -721,6 +726,7 @@ void ServerEnvironment::loadMeta()
 void ServerEnvironment::loadDefaultMeta()
 {
 	m_lbm_mgr.loadIntroductionTimes("", m_server, m_game_time);
+	m_luaent_guid_generator.seed("v1guid1000"); // 1000 is chosen arbitrarily
 }
 
 struct ActiveABM

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "activeobject.h"
 #include "environment.h"
+#include "guid.h"
 #include "mapnode.h"
 #include "settings.h"
 #include "server/activeobjectmgr.h"
@@ -296,6 +297,9 @@ public:
 	*/
 	void activateBlock(MapBlock *block, u32 additional_dtime=0);
 
+	GUID generateNextLuaentGUID()
+	{ return m_luaent_guid_generator.generateNext(); }
+
 	/*
 		{Active,Loading}BlockModifiers
 		-------------------------------------------
@@ -429,6 +433,8 @@ private:
 	Server *m_server;
 	// Active Object Manager
 	server::ActiveObjectMgr m_ao_manager;
+	// Generator for luaentity guids
+	GUIDGenerator m_luaent_guid_generator;
 	// World path
 	const std::string m_path_world;
 	// Outgoing network message buffer for active objects

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -297,7 +297,7 @@ public:
 	*/
 	void activateBlock(MapBlock *block, u32 additional_dtime=0);
 
-	GUID generateNextLuaentGUID()
+	GUId generateNextLuaentGUId()
 	{ return m_luaent_guid_generator.generateNext(); }
 
 	/*
@@ -434,7 +434,7 @@ private:
 	// Active Object Manager
 	server::ActiveObjectMgr m_ao_manager;
 	// Generator for luaentity guids
-	GUIDGenerator m_luaent_guid_generator;
+	GUIdGenerator m_luaent_guid_generator;
 	// World path
 	const std::string m_path_world;
 	// Outgoing network message buffer for active objects

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -9,6 +9,7 @@ set (UNITTEST_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/test_compression.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_connection.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_filepath.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/test_guid.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_inventory.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_irrptr.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_map_settings_manager.cpp

--- a/src/unittest/test_guid.cpp
+++ b/src/unittest/test_guid.cpp
@@ -45,7 +45,7 @@ void TestGUID::runTests(IGameDef *gamedef)
 void TestGUID::testGetValidity()
 {
 #define ASSERT_VALIDITY(str, validity) \
-		UASSERT(GUIDGenerator::getValidity(str) == GUIDGenerator::validity)
+		UASSERT(GUIdGenerator::getValidity(str) == GUIdGenerator::validity)
 
 	ASSERT_VALIDITY("v1guid1", Valid);
 	ASSERT_VALIDITY("", Old);
@@ -62,20 +62,20 @@ void TestGUID::testGetValidity()
 
 void TestGUID::testGenerate()
 {
-	GUIDGenerator generator;
+	GUIdGenerator generator;
 	UASSERT(generator.peekNext() == "");
 	UASSERT(generator.generateNext() == "");
 
-	UASSERT(generator.seed("foo") == GUIDGenerator::Invalid);
+	UASSERT(generator.seed("foo") == GUIdGenerator::Invalid);
 	UASSERT(generator.generateNext() == "");
 
-	UASSERT(generator.seed("") == GUIDGenerator::Old);
+	UASSERT(generator.seed("") == GUIdGenerator::Old);
 	UASSERT(generator.generateNext() == "");
 
-	UASSERT(generator.seed("v1guid0") == GUIDGenerator::Invalid);
+	UASSERT(generator.seed("v1guid0") == GUIdGenerator::Invalid);
 	UASSERT(generator.generateNext() == "");
 
-	UASSERT(generator.seed("v1guid1") == GUIDGenerator::Valid);
+	UASSERT(generator.seed("v1guid1") == GUIdGenerator::Valid);
 	UASSERT(generator.peekNext() == "v1guid1");
 	UASSERT(generator.peekNext() == "v1guid1");
 	UASSERT(generator.generateNext() == "v1guid1");
@@ -93,7 +93,7 @@ void TestGUID::testGenerate()
 	UASSERT(generator.generateNext() == "v1guid11");
 	UASSERT(generator.generateNext() == "v1guid12");
 
-	UASSERT(generator.seed("v1guid1000000000000") == GUIDGenerator::Valid);
+	UASSERT(generator.seed("v1guid1000000000000") == GUIdGenerator::Valid);
 	UASSERT(generator.generateNext() == "v1guid1000000000000");
 	UASSERT(generator.generateNext() == "v1guid1000000000001");
 	UASSERT(generator.generateNext() == "v1guid1000000000002");
@@ -101,7 +101,7 @@ void TestGUID::testGenerate()
 
 	UASSERT(generator.seed("v1guid1000000000000000000000000000000000000000"
 			"0000000000000000000000000000000000000000000000000000000000000"
-			"000000000000000000000000000000000000000000000000") == GUIDGenerator::Valid);
+			"000000000000000000000000000000000000000000000000") == GUIdGenerator::Valid);
 	UASSERT(generator.generateNext() == "v1guid1000000000000000000000000000000000000000"
 			"0000000000000000000000000000000000000000000000000000000000000"
 			"000000000000000000000000000000000000000000000000");
@@ -112,7 +112,7 @@ void TestGUID::testGenerate()
 			"0000000000000000000000000000000000000000000000000000000000000"
 			"000000000000000000000000000000000000000000000002");
 
-	UASSERT(generator.seed("v1guid9999999999999999998") == GUIDGenerator::Valid);
+	UASSERT(generator.seed("v1guid9999999999999999998") == GUIdGenerator::Valid);
 	UASSERT(generator.generateNext() == "v1guid9999999999999999998");
 	UASSERT(generator.generateNext() == "v1guid9999999999999999999");
 	UASSERT(generator.generateNext() == "v1guid10000000000000000000");

--- a/src/unittest/test_guid.cpp
+++ b/src/unittest/test_guid.cpp
@@ -1,0 +1,121 @@
+/*
+Minetest
+Copyright (C) 2021, DS
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "test.h"
+
+#include "guid.h"
+
+class TestGUID : public TestBase
+{
+public:
+	TestGUID() { TestManager::registerTestModule(this); }
+	const char *getName() { return "TestGUID"; }
+
+	void runTests(IGameDef *gamedef);
+
+	void testGetValidity();
+	void testGenerate();
+};
+
+static TestGUID g_test_instance;
+
+void TestGUID::runTests(IGameDef *gamedef)
+{
+	TEST(testGetValidity);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TestGUID::testGetValidity()
+{
+#define ASSERT_VALIDITY(str, validity) \
+		UASSERT(GUIDGenerator::getValidity(str) == GUIDGenerator::validity)
+
+	ASSERT_VALIDITY("v1guid1", Valid);
+	ASSERT_VALIDITY("", Old);
+	ASSERT_VALIDITY("v1guid", Invalid);
+	ASSERT_VALIDITY("v1guid3456789987654323456789876543456789834578909870007654", Valid);
+	ASSERT_VALIDITY("v1guid0523", Invalid);
+	ASSERT_VALIDITY("v1guid12340", Valid);
+	ASSERT_VALIDITY("v1gsd12340", Invalid);
+	ASSERT_VALIDITY("v2guid12340", Invalid);
+	ASSERT_VALIDITY("v1guid0", Invalid);
+
+#undef TEST_VALIDITY
+}
+
+void TestGUID::testGenerate()
+{
+	GUIDGenerator generator;
+	UASSERT(generator.peekNext() == "");
+	UASSERT(generator.generateNext() == "");
+
+	UASSERT(generator.seed("foo") == GUIDGenerator::Invalid);
+	UASSERT(generator.generateNext() == "");
+
+	UASSERT(generator.seed("") == GUIDGenerator::Old);
+	UASSERT(generator.generateNext() == "");
+
+	UASSERT(generator.seed("v1guid0") == GUIDGenerator::Invalid);
+	UASSERT(generator.generateNext() == "");
+
+	UASSERT(generator.seed("v1guid1") == GUIDGenerator::Valid);
+	UASSERT(generator.peekNext() == "v1guid1");
+	UASSERT(generator.peekNext() == "v1guid1");
+	UASSERT(generator.generateNext() == "v1guid1");
+	UASSERT(generator.generateNext() == "v1guid2");
+	UASSERT(generator.peekNext() == "v1guid2");
+	UASSERT(generator.peekNext() == "v1guid2");
+	UASSERT(generator.generateNext() == "v1guid3");
+	UASSERT(generator.generateNext() == "v1guid4");
+	UASSERT(generator.generateNext() == "v1guid5");
+	UASSERT(generator.generateNext() == "v1guid6");
+	UASSERT(generator.generateNext() == "v1guid7");
+	UASSERT(generator.generateNext() == "v1guid8");
+	UASSERT(generator.generateNext() == "v1guid9");
+	UASSERT(generator.generateNext() == "v1guid10");
+	UASSERT(generator.generateNext() == "v1guid11");
+	UASSERT(generator.generateNext() == "v1guid12");
+
+	UASSERT(generator.seed("v1guid1000000000000") == GUIDGenerator::Valid);
+	UASSERT(generator.generateNext() == "v1guid1000000000000");
+	UASSERT(generator.generateNext() == "v1guid1000000000001");
+	UASSERT(generator.generateNext() == "v1guid1000000000002");
+	UASSERT(generator.generateNext() == "v1guid1000000000003");
+
+	UASSERT(generator.seed("v1guid1000000000000000000000000000000000000000"
+			"0000000000000000000000000000000000000000000000000000000000000"
+			"000000000000000000000000000000000000000000000000") == GUIDGenerator::Valid);
+	UASSERT(generator.generateNext() == "v1guid1000000000000000000000000000000000000000"
+			"0000000000000000000000000000000000000000000000000000000000000"
+			"000000000000000000000000000000000000000000000000");
+	UASSERT(generator.generateNext() == "v1guid1000000000000000000000000000000000000000"
+			"0000000000000000000000000000000000000000000000000000000000000"
+			"000000000000000000000000000000000000000000000001");
+	UASSERT(generator.generateNext() == "v1guid1000000000000000000000000000000000000000"
+			"0000000000000000000000000000000000000000000000000000000000000"
+			"000000000000000000000000000000000000000000000002");
+
+	UASSERT(generator.seed("v1guid9999999999999999998") == GUIDGenerator::Valid);
+	UASSERT(generator.generateNext() == "v1guid9999999999999999998");
+	UASSERT(generator.generateNext() == "v1guid9999999999999999999");
+	UASSERT(generator.generateNext() == "v1guid10000000000000000000");
+	UASSERT(generator.generateNext() == "v1guid10000000000000000001");
+	UASSERT(generator.generateNext() == "v1guid10000000000000000002");
+}

--- a/src/unittest/test_serveractiveobjectmgr.cpp
+++ b/src/unittest/test_serveractiveobjectmgr.cpp
@@ -33,6 +33,7 @@ public:
 	bool getCollisionBox(aabb3f *toset) const override { return false; }
 	bool getSelectionBox(aabb3f *toset) const override { return false; }
 	bool collideWithObjects() const override { return false; }
+	std::string getGuid() const override { return ""; }
 };
 
 class TestServerActiveObjectMgr : public TestBase


### PR DESCRIPTION
- Goal of the PR: Assign each luaentity object a per-world-unique id that is persistent as long as the world exists, and make this id accessible in lua. Players also have an id, which uses their name.
- How it works:
  - The guid (global unique identifier) (a string) is generated by the GUIDGenerator (or created from the playername for players).
  - This generator has basically an unlimited precision integer, which it increments for each new guid.
  - A guid for luaentities looks like this: `"v1guid1005"` The `1` after `v` is a version num, to allow futuristic changes.
  - For players it looks like this: `"vpguidceleron55"`
  - (There are unittests for the genereator.)
  - The next guid for luaentites is stored over server restarts in `env_meta.txt`.
  - Objects from old worlds get a new id when loaded.
- Does it resolve any reported issue? maybe
- usecases: makes modding easier

## To do

This PR is a Ready for Review.

The one bugfix with the forced staticdata save is maybe a little bit ugly, feel free to suggest improvements.
The reason why it's needed is because the staticobject data doesn't change, because the guid is set in the constructor, and therefore the new guid isn't saved, I think.

## How to test

- Run the unitests.
- Use this small mod to inspect guids of objects:
<details>

```lua
local function printc(msg)
	print(msg)
	minetest.chat_send_all(msg)
end

--~ local branch_is_master = false
local branch_is_master = true

local function get_guid(obj)
	if branch_is_master then
		return "master,eh"
	else
		return obj:get_guid()
	end
end

minetest.register_craftitem("obj_info_staff:staff", {
	description = "Object info staff",
	groups = {},
	inventory_image = "default_tool_steelaxe.png",
	stack_max = 1,

	on_secondary_use = function(itemstack, user, pointed_thing)
		for _, o in ipairs(minetest.get_objects_inside_radius(user:get_pos(), 2)) do
			printc("objref guid: " .. tostring(get_guid(o) or nil))
		end
	end,

	on_use = function(itemstack, user, pointed_thing)
		if not pointed_thing or pointed_thing.type ~= "object" then
			return
		end
		local obj = pointed_thing.ref

		printc("objref guid: " .. get_guid(obj))
	end,
})


minetest.register_entity("obj_info_staff:ent", {
	initial_properties = {
		physical = false,
		collisionbox = {-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
		selectionbox = {-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
		pointable = true,
		visual = "cube",
		visual_size = {x = 1, y = 1, z = 1},
		textures = {},
		static_save = true,
	},

	on_activate = function(self, staticdata, dtime_s)
		printc("on_activate of "..get_guid(self.object))
	end,

	--~ on_step = function(self, dtime, moveresult),

	on_punch = function(self, puncher, time_from_last_punch, tool_capabilities, dir)
		printc("on_punch of "..get_guid(self.object))
	end,

	on_rightclick = function(self, clicker)
		printc("on_rightclick of "..get_guid(self.object))
	end,

	get_staticdata = function(self)
		printc("get_staticdata of "..get_guid(self.object))
	end,
})
```

</details>
