### PR TITLE
GUIScene: Clear depth buffer + replace deprecated clearZBuffer calls

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2299,7 +2299,7 @@ Elements
 * `frame duration`: Milliseconds between each frame. `0` means the frames don't advance.
 * `frame start` (Optional): The index of the frame to start on. Default `1`.
 
-### `model[<X>,<Y>;<W>,<H>;<name>;<mesh>;<textures>;<rotation X,Y>;<continuous>;<mouse control>;<frame loop range>]`
+### `model[<X>,<Y>;<W>,<H>;<name>;<mesh>;<textures>;<rotation X,Y>;<continuous>;<mouse control>;<frame loop range>;<animation speed>]`
 
 * Show a mesh model.
 * `name`: Element name that can be used for styling
@@ -2313,6 +2313,7 @@ Elements
 * `frame loop range` (Optional): Range of the animation frames.
     * Defaults to the full range of all available frames.
     * Syntax: `<begin>,<end>`
+* `animation speed` (Optional): Sets the animation speed. Default 0 FPS.
 
 ### `item_image[<X>,<Y>;<W>,<H>;<item name>]`
 

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -664,7 +664,7 @@ void Camera::wield(const ItemStack &item)
 void Camera::drawWieldedTool(irr::core::matrix4* translation)
 {
 	// Clear Z buffer so that the wielded tool stays in front of world geometry
-	m_wieldmgr->getVideoDriver()->clearZBuffer();
+	m_wieldmgr->getVideoDriver()->clearBuffers(video::ECBF_DEPTH);
 
 	// Draw the wielded node (in a separate scene manager)
 	scene::ICameraSceneNode* cam = m_wieldmgr->getActiveCamera();

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -950,7 +950,7 @@ void drawItemStack(
 
 	if (imesh && imesh->mesh) {
 		scene::IMesh *mesh = imesh->mesh;
-		driver->clearZBuffer();
+		driver->clearBuffers(video::ECBF_DEPTH);
 		s32 delta = 0;
 		if (rotation_kind < IT_ROT_NONE) {
 			MeshTimeInfo &ti = rotation_time_infos[rotation_kind];

--- a/src/client/render/anaglyph.cpp
+++ b/src/client/render/anaglyph.cpp
@@ -40,7 +40,7 @@ void RenderingCoreAnaglyph::setupMaterial(int color_mask)
 void RenderingCoreAnaglyph::useEye(bool right)
 {
 	RenderingCoreStereo::useEye(right);
-	driver->clearZBuffer();
+	driver->clearBuffers(video::ECBF_DEPTH);
 	setupMaterial(right ? video::ECP_GREEN | video::ECP_BLUE : video::ECP_RED);
 }
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2746,7 +2746,7 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element, ';');
 
-	if (parts.size() < 5 || (parts.size() > 9 &&
+	if (parts.size() < 5 || (parts.size() > 10 &&
 			m_formspec_version <= FORMSPEC_API_VERSION)) {
 		errorstream << "Invalid model element (" << parts.size() << "): '" << element
 			<< "'" << std::endl;
@@ -2766,6 +2766,7 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	bool inf_rotation = is_yes(parts[6]);
 	bool mousectrl = is_yes(parts[7]) || parts[7].empty(); // default true
 	std::vector<std::string> frame_loop = split(parts[8], ',');
+	std::string speed = unescape_string(parts[9]);
 
 	MY_CHECKPOS("model", 0);
 	MY_CHECKGEOM("model", 1);
@@ -2825,6 +2826,7 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	}
 
 	e->setFrameLoop(frame_loop_begin, frame_loop_end);
+	e->setAnimationSpeed(stof(speed));
 
 	auto style = getStyleForElement("model", spec.fname);
 	e->setStyles(style);

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -34,9 +34,6 @@ GUIScene::GUIScene(gui::IGUIEnvironment *env, scene::ISceneManager *smgr,
 	m_cam = m_smgr->addCameraSceneNode(0, v3f(0.f, 0.f, -100.f), v3f(0.f));
 	m_cam->setFOV(30.f * core::DEGTORAD);
 
-	scene::ILightSceneNode *light = m_smgr->addLightSceneNode(m_cam);
-	light->setRadius(1000.f);
-
 	m_smgr->getParameters()->setAttribute(scene::ALLOW_ZWRITE_ON_TRANSPARENT, true);
 }
 
@@ -60,6 +57,7 @@ scene::IAnimatedMeshSceneNode *GUIScene::setMesh(scene::IAnimatedMesh *mesh)
 	m_mesh = m_smgr->addAnimatedMeshSceneNode(mesh);
 	m_mesh->setPosition(-m_mesh->getBoundingBox().getCenter());
 	m_mesh->animateJoints();
+
 	return m_mesh;
 }
 
@@ -73,10 +71,13 @@ void GUIScene::setTexture(u32 idx, video::ITexture *texture)
 	material.setFlag(video::EMF_FOG_ENABLE, true);
 	material.setFlag(video::EMF_BILINEAR_FILTER, false);
 	material.setFlag(video::EMF_BACK_FACE_CULLING, false);
+	material.setFlag(video::EMF_ZWRITE_ENABLE, true);
 }
 
 void GUIScene::draw()
 {
+	m_driver->clearBuffers(video::ECBF_DEPTH);
+
 	// Control rotation speed based on time
 	u64 new_time = porting::getTimeMs();
 	u64 dtime_ms = 0;
@@ -159,6 +160,14 @@ void GUIScene::setFrameLoop(s32 begin, s32 end)
 {
 	if (m_mesh->getStartFrame() != begin || m_mesh->getEndFrame() != end)
 		m_mesh->setFrameLoop(begin, end);
+}
+
+/**
+ * Sets the animation speed (FPS) for the mesh
+ */
+void GUIScene::setAnimationSpeed(f32 speed)
+{
+	m_mesh->setAnimationSpeed(speed);
 }
 
 /* Camera control functions */

--- a/src/gui/guiScene.h
+++ b/src/gui/guiScene.h
@@ -37,6 +37,7 @@ public:
 	void setTexture(u32 idx, video::ITexture *texture);
 	void setBackgroundColor(const video::SColor &color) noexcept { m_bgcolor = color; };
 	void setFrameLoop(s32 begin, s32 end);
+	void setAnimationSpeed(f32 speed);
 	void enableMouseControl(bool enable) noexcept { m_mouse_ctrl = enable; };
 	void setRotation(v2f rot) noexcept { m_custom_rot = rot; };
 	void enableContinuousRotation(bool enable) noexcept { m_inf_rot = enable; };


### PR DESCRIPTION
- Attempt to fixing `model[]` glitches. Transparent models (e.g. Beer Mug from homedecor) are still broken (they weren't in 5.4).
- Replace deprecated `clearZBuffer` calls by Irrlicht 1.9.
- ~~Restore previous animation speed (by adding an additional property to `model` for the speed -- Irrlicht 1.9 sets it to 60 FPS by default).~~ Added an extra param to `model[]` for animation speed.

Context: https://irc.minetest.net/minetest-dev/2021-03-10#i_5796225

@luk3yx @v-rob 