### PR TITLE
Change light banks meaning

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -569,7 +569,7 @@ static bool getVisibleBrightness(Map *map, const v3f &p0, v3f dir, float step,
 		}
 
 		if (distance >= sunlight_min_d && !*sunlight_seen && !nonlight_seen)
-			if (n.getLight(LIGHTBANK_DAY, ndef) == LIGHT_SUN)
+			if (n.getLight(LightBank::Sun, ndef) == LIGHT_SUN)
 				*sunlight_seen = true;
 		noncount = 0;
 		brightness_sum += decode_light(n.getLightBlend(daylight_factor, ndef));

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -99,7 +99,7 @@ void MeshMakeData::setSmoothLighting(bool smooth_lighting)
 	Calculate non-smooth lighting at interior of node.
 	Single light bank.
 */
-static u8 getInteriorLight(enum LightBank bank, MapNode n, s32 increment,
+static u8 getInteriorLight(LegacyLightBank bank, MapNode n, s32 increment,
 	const NodeDefManager *ndef)
 {
 	u8 light = n.getLight(bank, ndef);
@@ -123,7 +123,7 @@ u16 getInteriorLight(MapNode n, s32 increment, const NodeDefManager *ndef)
 	Calculate non-smooth lighting at face of node.
 	Single light bank.
 */
-static u8 getFaceLight(enum LightBank bank, MapNode n, MapNode n2,
+static u8 getFaceLight(LegacyLightBank bank, MapNode n, MapNode n2,
 	v3s16 face_dir, const NodeDefManager *ndef)
 {
 	u8 light;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -217,15 +217,15 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 	const ContentFeatures &oldcf = m_nodedef->get(oldnode);
 	if (cf.lightingEquivalent(oldcf)) {
 		// No light update needed, just copy over the old light.
-		n.setLight(LIGHTBANK_DAY, oldnode.getLightRaw(LIGHTBANK_DAY, oldcf), cf);
-		n.setLight(LIGHTBANK_NIGHT, oldnode.getLightRaw(LIGHTBANK_NIGHT, oldcf), cf);
+		n.setLight(LightBank::Sun, oldnode.getLightRaw(LightBank::Sun, oldcf), cf);
+		n.setLight(LightBank::Art, oldnode.getLightRaw(LightBank::Art, oldcf), cf);
 		set_node_in_block(block, relpos, n);
 
 		modified_blocks[blockpos] = block;
 	} else {
 		// Ignore light (because calling voxalgo::update_lighting_nodes)
-		n.setLight(LIGHTBANK_DAY, 0, cf);
-		n.setLight(LIGHTBANK_NIGHT, 0, cf);
+		n.setLight(LightBank::Sun, 0, cf);
+		n.setLight(LightBank::Art, 0, cf);
 		set_node_in_block(block, relpos, n);
 
 		// Update lighting
@@ -780,8 +780,8 @@ void ServerMap::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 		}
 
 		// Ignore light (because calling voxalgo::update_lighting_nodes)
-		n0.setLight(LIGHTBANK_DAY, 0, m_nodedef);
-		n0.setLight(LIGHTBANK_NIGHT, 0, m_nodedef);
+		n0.setLight(LightBank::Sun, 0, m_nodedef);
+		n0.setLight(LightBank::Art, 0, m_nodedef);
 
 		// Find out whether there is a suspect for this action
 		std::string suspect;

--- a/src/map.h
+++ b/src/map.h
@@ -365,7 +365,7 @@ public:
 	static bool saveBlock(MapBlock *block, MapDatabase *db, int compression_level = -1);
 	MapBlock* loadBlock(v3s16 p);
 	// Database version
-	void loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool save_after_load=false);
+	MapBlock* loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool save_after_load=false);
 
 	bool deleteBlock(v3s16 blockpos) override;
 

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -180,7 +180,7 @@ public:
 		bool is_complete)
 	{
 		assert(direction >= 0 && direction <= 5);
-		if (bank == LIGHTBANK_NIGHT) {
+		if (bank == LightBank::Art) {
 			direction += 6;
 		}
 		u16 newflags = m_lighting_complete;
@@ -195,7 +195,7 @@ public:
 	inline bool isLightingComplete(LightBank bank, u8 direction)
 	{
 		assert(direction >= 0 && direction <= 5);
-		if (bank == LIGHTBANK_NIGHT) {
+		if (bank == LightBank::Art) {
 			direction += 6;
 		}
 		return (m_lighting_complete & (1 << direction)) != 0;

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -770,8 +770,16 @@ SharedBuffer<u8> MapNode::serializeBulk(int version,
 
 	// Serialize content
 	for (u32 i = 0; i < nodecount; i++) {
+		u8 param1 = nodes[i].param1;
+		if (version < 29) {
+			// pre-29 versions use "day" and "night" light banks instead of "sun" and "artificial"
+			u8 sun = param1 & 0x0f;
+			u8 art = param1 >> 4;
+			param1 &= 0xf0;
+			param1 |= std::max(sun, art);
+		}
 		writeU16(&databuf[i * 2], nodes[i].param0);
-		writeU8(&databuf[start1 + i], nodes[i].param1);
+		writeU8(&databuf[start1 + i], param1);
 		writeU8(&databuf[start2 + i], nodes[i].param2);
 	}
 	return databuf;

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -71,10 +71,16 @@ typedef u16 content_t;
 */
 #define CONTENT_IGNORE 127
 
-enum LightBank
+enum LegacyLightBank
 {
 	LIGHTBANK_DAY,
 	LIGHTBANK_NIGHT
+};
+
+enum class LightBank
+{
+	Sun,
+	Art,
 };
 
 /*
@@ -224,8 +230,8 @@ struct MapNode
 	 */
 	u8 getLightNoChecks(LightBank bank, const ContentFeatures *f) const noexcept;
 
-	bool getLightBanks(u8 &lightday, u8 &lightnight,
-		const NodeDefManager *nodemgr) const;
+	u8 getLight(LegacyLightBank bank, const NodeDefManager *nodemgr) const;
+	u8 getLightNoChecks(LegacyLightBank bank, const ContentFeatures *f) const noexcept;
 
 	// 0 <= daylight_factor <= 1000
 	// 0 <= return value <= LIGHT_SUN
@@ -302,6 +308,10 @@ struct MapNode
 			u8 content_width, u8 params_width);
 
 private:
+	u8 getLightBank(LightBank bank) const noexcept;
+	bool getLightBanks(u8 &lightday, u8 &lightnight,
+		const NodeDefManager *nodemgr) const;
+
 	// Deprecated serialization methods
 	void deSerialize_pre22(const u8 *source, u8 version);
 };

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -431,9 +431,10 @@ int ModApiEnvMod::l_get_natural_light(lua_State *L)
 	if (!is_position_ok)
 		return 0;
 
-	// If the daylight is 0, nothing needs to be calculated
-	u8 daylight = n.param1 & 0x0f;
-	if (daylight == 0) {
+	u8 sunlight = n.getLight(LightBank::Sun, env->getGameDef()->getNodeDefManager());
+
+	// If the sunlight is 0, nothing needs to be calculated
+	if (sunlight == 0) {
 		lua_pushinteger(L, 0);
 		return 1;
 	}
@@ -447,12 +448,7 @@ int ModApiEnvMod::l_get_natural_light(lua_State *L)
 	}
 	u32 dnr = time_to_daynight_ratio(time_of_day, true);
 
-	// If it's the same as the artificial light, the sunlight needs to be
-	// searched for because the value may not emanate from the sun
-	if (daylight == n.param1 >> 4)
-		daylight = env->findSunlight(pos);
-
-	lua_pushinteger(L, dnr * daylight / 1000);
+	lua_pushinteger(L, dnr * sunlight / 1000);
 	return 1;
 }
 

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -64,13 +64,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	27: Added light spreading flags to blocks
 	28: Added "private" flag to NodeMetadata
 	29: Switched compression to zstd, a bit of reorganization
+	30: split sunlight/node light
 */
 // This represents an uninitialized or invalid format
 #define SER_FMT_VER_INVALID 255
 // Highest supported serialization version
-#define SER_FMT_VER_HIGHEST_READ 29
+#define SER_FMT_VER_HIGHEST_READ 30
 // Saved on disk version
-#define SER_FMT_VER_HIGHEST_WRITE 29
+#define SER_FMT_VER_HIGHEST_WRITE 30
 // Lowest supported serialization version
 #define SER_FMT_VER_LOWEST_READ 0
 // Lowest serialization version for writing

--- a/src/voxelalgorithms.h
+++ b/src/voxelalgorithms.h
@@ -60,6 +60,9 @@ void update_lighting_nodes(
 void update_block_border_lighting(Map *map, MapBlock *block,
 	std::map<v3s16, MapBlock*> &modified_blocks);
 
+void convert_legacy_light_banks(MapBlock *block, const NodeDefManager *nodemgr,
+	std::map<v3s16, MapBlock*> &modified_blocks);
+
 /*!
  * Copies back nodes from a voxel manipulator
  * to the map and updates lighting.


### PR DESCRIPTION
Fix #5155. Seems to work.
All the meshgen uses old-style light values (as they can always be reconstructed).

**WARNING:** converts the map to a new version. You will not be able to load the map in other Minetest versions. Making backup before testing is strongly recommended. (the conversion should always be reversible but MT can’t handle it. I wrote [a tool](https://github.com/numberZero/minetest-toolset) for that but it is barely tested and supports sqlite only).

## To do

This PR is Ready for Review. Let me know if I forgot anything.

## How to test

Play with various sunlight&artificial light combinations. Try using client from this PR with server from master or vice versa. If it looks right it is probably right but light testing tool (devtest) may also be helpful (pay attention to `param1`, first digit is artificial light, second digit is sunlight).