### PR TITLE
Builtin: Make join/leave messages, and /profiler messages translatable

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -1,5 +1,7 @@
 -- Minetest: builtin/misc.lua
 
+local S = core.get_translator("__builtin")
+
 --
 -- Misc. API functions
 --
@@ -42,15 +44,15 @@ end
 
 function core.send_join_message(player_name)
 	if not core.is_singleplayer() then
-		core.chat_send_all("*** " .. player_name .. " joined the game.")
+		core.chat_send_all("*** " .. S("@1 joined the game.", player_name))
 	end
 end
 
 
 function core.send_leave_message(player_name, timed_out)
-	local announcement = "*** " ..  player_name .. " left the game."
+	local announcement = "*** " .. S("@1 left the game.", player_name)
 	if timed_out then
-		announcement = announcement .. " (timed out)"
+		announcement = "*** " .. S("@1 left the game (timed out).", player_name)
 	end
 	core.chat_send_all(announcement)
 end

--- a/builtin/profiler/reporter.lua
+++ b/builtin/profiler/reporter.lua
@@ -15,6 +15,10 @@
 --with this program; if not, write to the Free Software Foundation, Inc.,
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+local S = core.get_translator("__builtin")
+-- Note: In this file, only messages are translated
+-- but not the table itself, to keep it simple.
+
 local DIR_DELIM, LINE_DELIM = DIR_DELIM, "\n"
 local table, unpack, string, pairs, io, os = table, unpack, string, pairs, io, os
 local rep, sprintf, tonumber = string.rep, string.format, tonumber
@@ -104,11 +108,11 @@ local TxtFormatter = Formatter:new {
 	end,
 	format = function(self, filter)
 		local profile = self.profile
-		self:print("Values below show absolute/relative times spend per server step by the instrumented function.")
-		self:print("A total of %d samples were taken", profile.stats_total.samples)
+		self:print(S("Values below show absolute/relative times spend per server step by the instrumented function."))
+		self:print(S("A total of @1 sample(s) were taken.", profile.stats_total.samples))
 
 		if filter then
-			self:print("The output is limited to '%s'", filter)
+			self:print(S("The output is limited to '@1'.", filter))
 		end
 
 		self:print()
@@ -259,19 +263,18 @@ function reporter.save(profile, format, filter)
 
 	local output, io_err = io.open(path, "w")
 	if not output then
-		return false, "Saving of profile failed with: " .. io_err
+		return false, S("Saving of profile failed: @1", io_err)
 	end
 	local content, err = serialize_profile(profile, format, filter)
 	if not content then
 		output:close()
-		return false, "Saving of profile failed with: " .. err
+		return false, S("Saving of profile failed: @1", err)
 	end
 	output:write(content)
 	output:close()
 
-	local logmessage = "Profile saved to " .. path
-	core.log("action", logmessage)
-	return true, logmessage
+	core.log("action", "Profile saved to " .. path)
+	return true, S("Profile saved to @1", path)
 end
 
 return reporter


### PR DESCRIPTION
I noticed a few remaining untranslatable strings in builtin, so I fixed it. This PR will make the following translatable:

* Join and leave messages (“*** PlayerX joined the game.”)
* Help/info/error messages when using the `/profiler` command. Don't worry, the profiler output data/table itself is NOT touched by this, to keep it simple
