### PR TITLE
Tweak duration_to_string formatting

### DIFF
--- a/src/util/string.h
+++ b/src/util/string.h
@@ -670,15 +670,19 @@ inline const std::string duration_to_string(int sec)
 
 	std::stringstream ss;
 	if (hour > 0) {
-		ss << hour << "h ";
+		ss << hour << "h";
+		if (min > 0 || sec > 0)
+			ss << " ";
 	}
 
 	if (min > 0) {
-		ss << min << "m ";
+		ss << min << "min";
+		if (sec > 0)
+			ss << " ";
 	}
 
 	if (sec > 0) {
-		ss << sec << "s ";
+		ss << sec << "s";
 	}
 
 	return ss.str();


### PR DESCRIPTION
The function `duration_to_string` is used by the `/shutdown` command had a few minor issues:
* The message that shows the remaining time had a trailing space like so: “Server shutting down in 10s .”
* “m” used for “minute” (non-standard)

This PR does the following:
* Fix the trailing space
* Change “m” to “min” (SI standard)

## How to test
Try the `/shutdown` command with different times. Check if there is a trailing space.