### PR TITLE
Fix wield image of plantlike_rooted

### DIFF
--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -411,9 +411,8 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 			break;
 		}
 		case NDT_PLANTLIKE_ROOTED: {
-			v3f wscale = def.wield_scale;
 			setExtruded(tsrc->getTextureName(f.special_tiles[0].layers[0].texture_id),
-				"", wscale, tsrc,
+				"", def.wield_scale, tsrc,
 				f.special_tiles[0].layers[0].animation_frame_count);
 			// Add color
 			const TileLayer &l0 = f.special_tiles[0].layers[0];

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -395,7 +395,6 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		case NDT_TORCHLIKE:
 		case NDT_RAILLIKE:
 		case NDT_PLANTLIKE:
-		case NDT_PLANTLIKE_ROOTED:
 		case NDT_FLOWINGLIQUID: {
 			v3f wscale = def.wield_scale;
 			if (f.drawtype == NDT_FLOWINGLIQUID)
@@ -409,6 +408,16 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 			m_colors.emplace_back(l0.has_color, l0.color);
 			const TileLayer &l1 = f.tiles[0].layers[1];
 			m_colors.emplace_back(l1.has_color, l1.color);
+			break;
+		}
+		case NDT_PLANTLIKE_ROOTED: {
+			v3f wscale = def.wield_scale;
+			setExtruded(tsrc->getTextureName(f.special_tiles[0].layers[0].texture_id),
+				"", wscale, tsrc,
+				f.special_tiles[0].layers[0].animation_frame_count);
+			// Add color
+			const TileLayer &l0 = f.special_tiles[0].layers[0];
+			m_colors.emplace_back(l0.has_color, l0.color);
 			break;
 		}
 		case NDT_NORMAL:


### PR DESCRIPTION
The default wield image of `plantlike_rooted` image is unexpected. It is the texture of the big cube, rather than the plant. This is a regression introduced in 5.4.0.

This PR will fix the wield image of `plantlike_rooted` to use the plant image instead.

This will indirectly fix <https://github.com/minetest/minetest_game/issues/2849>.