### PR TITLE
Change default key to access inventory to TAB

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -79,7 +79,7 @@ void set_default_settings()
 	settings->setDefault("keymap_place", "KEY_RBUTTON");
 	settings->setDefault("keymap_drop", "KEY_KEY_Q");
 	settings->setDefault("keymap_zoom", "KEY_KEY_Z");
-	settings->setDefault("keymap_inventory", "KEY_KEY_I");
+	settings->setDefault("keymap_inventory", "KEY_TAB");
 	settings->setDefault("keymap_aux1", "KEY_KEY_E");
 	settings->setDefault("keymap_chat", "KEY_KEY_T");
 	settings->setDefault("keymap_cmd", "/");


### PR DESCRIPTION
Why?

- No need to move your left hand when it hovers <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> to press <kbd>TAB</kbd> -- it's important that players access their inventory quickly.
- If <kbd>I</kbd> must bind **I**nventory, the same logic should be applied to <kbd>L</kbd> to move left and <kbd>R</kbd> to move right.
- Skyrim does it by default.