### PR TITLE
Put torchlike/signlike node on floor if paramtype2="none"

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -84,9 +84,6 @@ core.register_entity(":__builtin:falling_node", {
 			local textures
 			if def.tiles and def.tiles[1] then
 				local tile = def.tiles[1]
-				if def.drawtype == "torchlike" and def.paramtype2 ~= "wallmounted" then
-					tile = def.tiles[2] or def.tiles[1]
-				end
 				if type(tile) == "table" then
 					tile = tile.name
 				end
@@ -147,11 +144,7 @@ core.register_entity(":__builtin:falling_node", {
 
 		-- Rotate entity
 		if def.drawtype == "torchlike" then
-			if def.paramtype2 == "wallmounted" then
-				self.object:set_yaw(math.pi*0.25)
-			else
-				self.object:set_yaw(-math.pi*0.25)
-			end
+			self.object:set_yaw(math.pi*0.25)
 		elseif ((node.param2 ~= 0 or def.drawtype == "nodebox" or def.drawtype == "mesh")
 				and (def.wield_image == "" or def.wield_image == nil))
 				or def.drawtype == "signlike"
@@ -165,8 +158,12 @@ core.register_entity(":__builtin:falling_node", {
 				if euler then
 					self.object:set_rotation(euler)
 				end
-			elseif (def.paramtype2 == "wallmounted" or def.paramtype2 == "colorwallmounted") then
+			elseif (def.paramtype2 == "wallmounted" or def.paramtype2 == "colorwallmounted" or def.drawtype == "signlike") then
 				local rot = node.param2 % 8
+				if (def.drawtype == "signlike" and def.paramtype2 ~= "wallmounted" and def.paramtype2 ~= "colorwallmounted") then
+					-- Change rotation to "floor" by default for non-wallmounted paramtype2
+					rot = 1
+				end
 				local pitch, yaw, roll = 0, 0, 0
 				if def.drawtype == "nodebox" or def.drawtype == "mesh" then
 					if rot == 0 then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1135,14 +1135,20 @@ Look for examples in `games/devtest` or `games/minetest_game`.
       used to compensate for how `glasslike` reduces visual thickness.
 * `torchlike`
     * A single vertical texture.
-    * If placed on top of a node, uses the first texture specified in `tiles`.
-    * If placed against the underside of a node, uses the second texture
-      specified in `tiles`.
-    * If placed on the side of a node, uses the third texture specified in
-      `tiles` and is perpendicular to that node.
+    * If `paramtype2="[color]wallmounted":
+        * If placed on top of a node, uses the first texture specified in `tiles`.
+        * If placed against the underside of a node, uses the second texture
+          specified in `tiles`.
+        * If placed on the side of a node, uses the third texture specified in
+          `tiles` and is perpendicular to that node.
+    * If `paramtype2="none"`:
+        * Will be rendered as if placed on top of a node (see
+          above) and only the first texture is used.
 * `signlike`
     * A single texture parallel to, and mounted against, the top, underside or
       side of a node.
+    * If `paramtype2="[color]wallmounted", it rotates according to `param2`
+    * If `paramtype2="none"`, it will always be on the floor.
 * `plantlike`
     * Two vertical and diagonal textures at right-angles to each other.
     * See `paramtype2 = "meshoptions"` above for other options.

--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -145,14 +145,10 @@ minetest.register_node("testnodes:fencelike", {
 })
 
 minetest.register_node("testnodes:torchlike", {
-	description = S("Torchlike Drawtype Test Node"),
+	description = S("Floor Torchlike Drawtype Test Node"),
 	drawtype = "torchlike",
 	paramtype = "light",
-	tiles = {
-		"testnodes_torchlike_floor.png",
-		"testnodes_torchlike_ceiling.png",
-		"testnodes_torchlike_wall.png",
-	},
+	tiles = { "testnodes_torchlike_floor.png^[colorize:#FF0000:64" },
 
 
 	walkable = false,
@@ -179,9 +175,21 @@ minetest.register_node("testnodes:torchlike_wallmounted", {
 	inventory_image = fallback_image("testnodes_torchlike_floor.png"),
 })
 
-
-
 minetest.register_node("testnodes:signlike", {
+	description = S("Floor Signlike Drawtype Test Node"),
+	drawtype = "signlike",
+	paramtype = "light",
+	tiles = { "testnodes_signlike.png^[colorize:#FF0000:64" },
+
+
+	walkable = false,
+	groups = { dig_immediate = 3 },
+	sunlight_propagates = true,
+	inventory_image = fallback_image("testnodes_signlike.png"),
+})
+
+
+minetest.register_node("testnodes:signlike_wallmounted", {
 	description = S("Wallmounted Signlike Drawtype Test Node"),
 	drawtype = "signlike",
 	paramtype = "light",
@@ -549,7 +557,7 @@ scale("plantlike",
 scale("torchlike_wallmounted",
 	S("Double-sized Wallmounted Torchlike Drawtype Test Node"),
 	S("Half-sized Wallmounted Torchlike Drawtype Test Node"))
-scale("signlike",
+scale("signlike_wallmounted",
 	S("Double-sized Wallmounted Signlike Drawtype Test Node"),
 	S("Half-sized Wallmounted Signlike Drawtype Test Node"))
 scale("firelike",

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -315,12 +315,14 @@ static scene::SMesh *createSpecialNodeMesh(Client *client, MapNode n,
 		// keep it
 	} else if (f.param_type_2 == CPT2_WALLMOUNTED ||
 			f.param_type_2 == CPT2_COLORED_WALLMOUNTED) {
-		if (f.drawtype == NDT_TORCHLIKE)
-			n.setParam2(1);
-		else if (f.drawtype == NDT_SIGNLIKE ||
+		if (f.drawtype == NDT_TORCHLIKE ||
+				f.drawtype == NDT_SIGNLIKE ||
 				f.drawtype == NDT_NODEBOX ||
-				f.drawtype == NDT_MESH)
+				f.drawtype == NDT_MESH) {
 			n.setParam2(4);
+		}
+	} else if (f.drawtype == NDT_SIGNLIKE || f.drawtype == NDT_TORCHLIKE) {
+		n.setParam2(1);
 	}
 	gen.renderSingle(n.getContent(), n.getParam2());
 

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -159,8 +159,11 @@ u8 MapNode::getWallMounted(const NodeDefManager *nodemgr) const
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	if (f.param_type_2 == CPT2_WALLMOUNTED ||
-			f.param_type_2 == CPT2_COLORED_WALLMOUNTED)
+			f.param_type_2 == CPT2_COLORED_WALLMOUNTED) {
 		return getParam2() & 0x07;
+	} else if (f.drawtype == NDT_SIGNLIKE || f.drawtype == NDT_TORCHLIKE) {
+		return 1;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Currently, if you use a `torchlike` or `signlike` node with `paramtype2="none"` (or anything other than `[color]wallmounted`), the ceiling rendering of the node will be used. That's a bit weird and also not very useful.

So I have changed this to use the floor rendering of the node for that case, this is as if the node would have `param2=1` as a `wallmounted` node.

IMO using the floor image makes more sense because:
* `attached_node=1` for non-wallmounted nodes checks the node below, not the node above
* It is a more common use case in general