### PR TITLE
Make /status message easier to read

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3097,15 +3097,16 @@ std::string Server::getStatusString()
 	std::ostringstream os(std::ios_base::binary);
 	os << "# Server: ";
 	// Version
-	os << "version=" << g_version_string;
+	os << "version: " << g_version_string;
 	// Uptime
-	os << ", uptime=" << m_uptime_counter->get();
+	os << " | uptime: " << duration_to_string((int) m_uptime_counter->get());
 	// Max lag estimate
-	os << ", max_lag=" << (m_env ? m_env->getMaxLagEstimate() : 0);
+	os << " | max lag: " << std::setprecision(3);
+	os << (m_env ? m_env->getMaxLagEstimate() : 0) << "s";
 
 	// Information about clients
 	bool first = true;
-	os << ", clients={";
+	os << " | clients: ";
 	if (m_env) {
 		std::vector<session_t> clients = m_clients.getClientIDs();
 		for (session_t client_id : clients) {
@@ -3122,7 +3123,6 @@ std::string Server::getStatusString()
 			os << name;
 		}
 	}
-	os << "}";
 
 	if (m_env && !((ServerMap*)(&m_env->getMap()))->isSavingEnabled())
 		os << std::endl << "# Server: " << " WARNING: Map saving is disabled.";

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -661,14 +661,33 @@ inline const char *bool_to_cstr(bool val)
 	return val ? "true" : "false";
 }
 
+/**
+ * Converts a duration in seconds to a pretty-printed duration in
+ * days, hours, minutes and seconds.
+ *
+ * @param sec duration in seconds (must not be negative)
+ * @return pretty-printed duration
+ */
 inline const std::string duration_to_string(int sec)
 {
+	int total_sec = sec;
+	if (total_sec < 0) {
+		return "<unknown>";
+	}
 	int min = sec / 60;
 	sec %= 60;
 	int hour = min / 60;
 	min %= 60;
+	int day = hour / 24;
+	hour %= 24;
 
 	std::stringstream ss;
+	if (day > 0) {
+		ss << day << "d";
+		if (hour > 0 || min > 0 || sec > 0)
+			ss << " ";
+	}
+
 	if (hour > 0) {
 		ss << hour << "h";
 		if (min > 0 || sec > 0)
@@ -681,7 +700,7 @@ inline const std::string duration_to_string(int sec)
 			ss << " ";
 	}
 
-	if (sec > 0) {
+	if (sec > 0 || total_sec == 0) {
 		ss << sec << "s";
 	}
 


### PR DESCRIPTION
I made the `/status` message a little bit more readable. Features:

* Use a style similar to the debug screen (with colons and pipe symbols)
* Add the missing units of time
* Print uptime in days, hours, minutes and seconds
* Crop superflous number precision

Preview

> # Server: version: 5.5.0-dev | uptime: 6min 1s | max. lag: 0.219s | clients: player1, player2, player3