### PR TITLE
Modifying fall damage via armor group

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1726,12 +1726,14 @@ to games.
 * `disable_jump`: Player (and possibly other things) cannot jump from node
   or if their feet are in the node. Note: not supported for `new_move = false`
 * `fall_damage_add_percent`: modifies the fall damage suffered when hitting
-  the top of this node. The damage formula is:
-    node damage speed = `speed * (1 + value/100) * player_damage_speed`
-  Where `node damage speed` is a factor that the fall impact speed will be
-  multiplied by, which in turn determines the actual fall damage.
-  `player_damage_speed` is the calculated damage modifier for players
-  (see `ObjectRef` section below) and is 1.0 by default.
+  the top of this node. There's also an armor group with the same name.
+  The final player damage is determined by the following formula:
+    damage =
+      collision speed
+      * ((node_fall_damage_add_percent   + 100) / 100) -- node group
+      * ((player_fall_damage_add_percent + 100) / 100) -- player armor group
+      - (14)                                           -- constant tolerance
+  Negative damage values are discarded as no damage.
 * `falling_node`: if there is no walkable block under the node it will fall
 * `float`: the node will not fall through liquids
 * `level`: Can be used to give an additional sense of progression in the game.
@@ -1759,7 +1761,7 @@ to games.
   cannot be reset (subject to change).
 * `fall_damage_add_percent`: Modifies the fall damage suffered by players
   when they hit the ground. It is analog to the node group with the same
-  name.
+  name. See the node group above for the exact calculation.
 * `punch_operable`: For entities; disables the regular damage mechanism for
   players punching it by hand or a non-tool item, so that it can do something
   else than take damage.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1725,7 +1725,13 @@ to games.
     * `3`: the node always gets the digging time 0 seconds (torch)
 * `disable_jump`: Player (and possibly other things) cannot jump from node
   or if their feet are in the node. Note: not supported for `new_move = false`
-* `fall_damage_add_percent`: damage speed = `speed * (1 + value/100)`
+* `fall_damage_add_percent`: modifies the fall damage suffered when hitting
+  the top of this node. The damage formula is:
+    node damage speed = `speed * (1 + value/100) * player_damage_speed`
+  Where `node damage speed` is a factor that the fall impact speed will be
+  multiplied by, which in turn determines the actual fall damage.
+  `player_damage_speed` is the calculated damage modifier for players
+  (see `ObjectRef` section below) and is 1.0 by default.
 * `falling_node`: if there is no walkable block under the node it will fall
 * `float`: the node will not fall through liquids
 * `level`: Can be used to give an additional sense of progression in the game.
@@ -1745,12 +1751,15 @@ to games.
   `"toolrepair"` crafting recipe
 
 
-### `ObjectRef` groups
+### `ObjectRef` armor groups
 
 * `immortal`: Skips all damage and breath handling for an object. This group
   will also hide the integrated HUD status bars for players. It is
   automatically set to all players when damage is disabled on the server and
   cannot be reset (subject to change).
+* `fall_damage_add_percent`: Modifies the fall damage suffered by players
+  when they hit the ground. It is analog to the node group with the same
+  name.
 * `punch_operable`: For entities; disables the regular damage mechanism for
   players punching it by hand or a non-tool item, so that it can do something
   else than take damage.

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -237,7 +237,7 @@ void ClientEnvironment::step(float dtime)
 
 	bool player_immortal = false;
 	f32 player_fall_factor = 1.0f;
-	GenericCAO* playercao = lplayer->getCAO();
+	GenericCAO *playercao = lplayer->getCAO();
 	if (playercao) {
 		player_immortal = playercao->isImmortal();
 		int addp_p = itemgroup_get(playercao->getGroups(),

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -235,7 +235,16 @@ void ClientEnvironment::step(float dtime)
 			&player_collisions);
 	}
 
-	bool player_immortal = lplayer->getCAO() && lplayer->getCAO()->isImmortal();
+	bool player_immortal = false;
+	f32 player_fall_factor = 1.0f;
+	GenericCAO* playercao = lplayer->getCAO();
+	if (playercao) {
+		player_immortal = playercao->isImmortal();
+		int addp_p = itemgroup_get(playercao->getGroups(),
+			"fall_damage_add_percent");
+		// convert armor group into an usable fall damage factor
+		player_fall_factor = 1.0f + (float)addp_p / 100.0f;
+	}
 
 	for (const CollisionInfo &info : player_collisions) {
 		v3f speed_diff = info.new_speed - info.old_speed;;
@@ -248,17 +257,20 @@ void ClientEnvironment::step(float dtime)
 		speed_diff.Z = 0;
 		f32 pre_factor = 1; // 1 hp per node/s
 		f32 tolerance = BS*14; // 5 without damage
-		f32 post_factor = 1; // 1 hp per node/s
 		if (info.type == COLLISION_NODE) {
 			const ContentFeatures &f = m_client->ndef()->
 				get(m_map->getNode(info.node_p));
-			// Determine fall damage multiplier
-			int addp = itemgroup_get(f.groups, "fall_damage_add_percent");
-			pre_factor = 1.0f + (float)addp / 100.0f;
+			// Determine fall damage modifier
+			int addp_n = itemgroup_get(f.groups, "fall_damage_add_percent");
+			// convert node group to an usable fall damage factor
+			f32 node_fall_factor = 1.0f + (float)addp_n / 100.0f;
+			// combine both player fall damage modifiers
+			pre_factor = node_fall_factor * player_fall_factor;
 		}
 		float speed = pre_factor * speed_diff.getLength();
-		if (speed > tolerance && !player_immortal) {
-			f32 damage_f = (speed - tolerance) / BS * post_factor;
+
+		if (speed > tolerance && !player_immortal && pre_factor > 0.0f) {
+			f32 damage_f = (speed - tolerance) / BS;
 			u16 damage = (u16)MYMIN(damage_f + 0.5, U16_MAX);
 			if (damage != 0) {
 				damageLocalPlayer(damage, true);


### PR DESCRIPTION
Fixes this issue partially: #10348

I have added a new armor group for players, called `fall_damage_add_percent`. It is completely analog to the node group `fall_damage_add_percent` and modifies the fall damage in the same was as the node group would, except that is applies to one specific player. By setting it to -100, the player does not experience fall damage.

Now what happens when a player with modified fall damage falls on a node with modified fall damage? To answer this, let's look what is done internally: The raw group value is converted to a fall damage factor via the formula `1+1*(value/100)`. So the group value 0 gives the factor 1.0, the value 100 gives a factor of 2, and the value -50 gives a factor of 0.5, etc.

This is done both for the node and the player, and the final step is simply multiplying both fall damage factors.

For example, if you have a player with `fall_damage_add_percent=123` falling on a node with `fall_damage_add_percent=-45`, this results in the factors 1.23 and 0.55. Multiply both together, and you get a fall damage factor of 0.67, or 67%.

This also implies that if either factor is 0, fall damage is guaranteed to be 0.

## Backwards compability

I think this has perfect backwards-compability. There are no surprising changes for existing games. Since all groups are 0 by default, this means that `fall_damage_add_percent` is 0 by default, which stands for 100% fall damage, i.e. no change.

## Note about the fall damage system

I know it is bad that damage is client-side. However, this is sadly unlikely to change anything soon since moving fall damage to the server would be a major undertaking. See #11025. In the meanwhile, I think it makes sense to at least add a simple fall damage modifier, this is a much needed and wanted feature for many games to be able to disable fall damage on a per-player basis.

I also think using the generc `fall_damage_add_percent` approach is future-proof as this concept can be continued to be used even if the underlying fall damage system is completely changed.

## Use cases
* Boots of titanium, reduce fall damage by 20%
* Turn the player into a tiny dwarf, falling more than 3 nodes will kill you
* Disable fall damage completely while keeping damage

## How to test

* Start DevTest and get `luacmd` ready
* Built several towers of different heights and fall down to test the default fall damage
* In chat, do: `/lua me:set_armor_groups({fall_damage_add_percent = NUMBER})` with a number of your choice
* Test fall damage again and see if anything changes
* Use the fall damage test nodes and
* Fall on the -100% fall damage node. You must never get fall damage on it
* Test with a player fall damage add percent of -100. You must never get fall damage
* Set player fall damage to +100 and fall on a -50% fall damage node. Those two should cancel out (200% * 50%) and result in the default fall damage