### PR TITLE
Replace fallback font nonsense with automatic per-glyph fallback

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -859,7 +859,7 @@ font_path (Regular font path) filepath fonts/Arimo-Regular.ttf
 
 font_path_bold (Bold font path) filepath fonts/Arimo-Bold.ttf
 font_path_italic (Italic font path) filepath fonts/Arimo-Italic.ttf
-font_path_bolditalic (Bold and italic font path) filepath fonts/Arimo-BoldItalic.ttf
+font_path_bold_italic (Bold and italic font path) filepath fonts/Arimo-BoldItalic.ttf
 
 #    Font size of the monospace font in point (pt).
 mono_font_size (Monospace font size) int 15 1
@@ -872,16 +872,7 @@ mono_font_path (Monospace font path) filepath fonts/Cousine-Regular.ttf
 
 mono_font_path_bold (Bold monospace font path) filepath fonts/Cousine-Bold.ttf
 mono_font_path_italic (Italic monospace font path) filepath fonts/Cousine-Italic.ttf
-mono_font_path_bolditalic (Bold and italic monospace font path) filepath fonts/Cousine-BoldItalic.ttf
-
-#    Font size of the fallback font in point (pt).
-fallback_font_size (Fallback font size) int 15 1
-
-#    Shadow offset (in pixels) of the fallback font. If 0, then shadow will not be drawn.
-fallback_font_shadow (Fallback font shadow) int 1
-
-#    Opaqueness (alpha) of the shadow behind the fallback font, between 0 and 255.
-fallback_font_shadow_alpha (Fallback font shadow alpha) int 128 0 255
+mono_font_path_bold_italic (Bold and italic monospace font path) filepath fonts/Cousine-BoldItalic.ttf
 
 #    Path of the fallback font.
 #    If “freetype” setting is enabled: Must be a TrueType font.

--- a/po/minetest.pot
+++ b/po/minetest.pot
@@ -1085,18 +1085,6 @@ msgstr ""
 msgid "Invalid gamespec."
 msgstr ""
 
-#. ~ DO NOT TRANSLATE THIS LITERALLY!
-#. This is a special string. Put either "no" or "yes"
-#. into the translation field (literally).
-#. Choose "yes" if the language requires use of the fallback
-#. font, "no" otherwise.
-#. The fallback font is (normally) required for languages with
-#. non-Latin script, like Chinese.
-#. When in doubt, test your translation.
-#: src/client/fontengine.cpp
-msgid "needs_fallback_font"
-msgstr ""
-
 #: src/client/game.cpp
 msgid "Shutting down..."
 msgstr ""

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -668,7 +668,10 @@ endif(BUILD_SERVER)
 # see issue #4638
 set(GETTEXT_BLACKLISTED_LOCALES
 	ar
+	dv
 	he
+	hi
+	kn
 	ky
 	ms_Arab
 	th

--- a/src/client/fontengine.h
+++ b/src/client/fontengine.h
@@ -132,10 +132,12 @@ public:
 	void readSettings();
 
 private:
+	irr::gui::IGUIFont *getFont(FontSpec spec, bool may_fail);
+
 	/** update content of font cache in case of a setting change made it invalid */
 	void updateFontCache();
 
-	/** initialize a new font */
+	/** initialize a new TTF font */
 	gui::IGUIFont *initFont(const FontSpec &spec);
 
 	/** initialize a font without freetype */

--- a/src/client/fontengine.h
+++ b/src/client/fontengine.h
@@ -33,7 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 enum FontMode : u8 {
 	FM_Standard = 0,
 	FM_Mono,
-	FM_Fallback,
+	_FM_Fallback, // do not use directly
 	FM_Simple,
 	FM_SimpleMono,
 	FM_MaxMode,

--- a/src/client/fontengine.h
+++ b/src/client/fontengine.h
@@ -47,7 +47,7 @@ struct FontSpec {
 		bold(bold),
 		italic(italic) {}
 
-	u16 getHash()
+	u16 getHash() const
 	{
 		return (mode << 2) | (static_cast<u8>(bold) << 1) | static_cast<u8>(italic);
 	}

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -304,12 +304,7 @@ void set_default_settings()
 	settings->setDefault("mono_font_path_bold_italic", porting::getDataPath("fonts" DIR_DELIM "Cousine-BoldItalic.ttf"));
 	settings->setDefault("fallback_font_path", porting::getDataPath("fonts" DIR_DELIM "DroidSansFallbackFull.ttf"));
 
-	settings->setDefault("fallback_font_shadow", "1");
-	settings->setDefault("fallback_font_shadow_alpha", "128");
-
 	std::string font_size_str = std::to_string(TTF_DEFAULT_FONT_SIZE);
-
-	settings->setDefault("fallback_font_size", font_size_str);
 #else
 	settings->setDefault("freetype", "false");
 	settings->setDefault("font_path", porting::getDataPath("fonts" DIR_DELIM "mono_dejavu_sans"));

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -658,7 +658,7 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 
 				u32 current_color = iter.getPos();
 				fallback->draw(core::stringw(l1),
-					core::rect<s32>(offset, position.LowerRightCorner),
+					core::rect<s32>({offset.X-1, offset.Y-1}, position.LowerRightCorner), // ???
 					current_color < colors.size() ? colors[current_color] : video::SColor(255, 255, 255, 255),
 					false, false, clip);
 			}

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -1199,7 +1199,7 @@ core::array<scene::ISceneNode*> CGUITTFont::addTextSceneNode(const wchar_t* text
 				container.push_back(current_node);
 			}
 			offset.X += getWidthFromCharacter(current_char);
-			// TODO: missing fallback font handling here
+			// Note that fallback font handling is missing here (Minetest never uses this)
 
 			previous_char = current_char;
 			++text;

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -571,6 +571,7 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 	// Determine offset positions.
 	if (hcenter || vcenter)
 	{
+		// FIXME: centering doesn't account for fallback, this doesn't seem to cause any issues(?!)
 		textDimension = getDimension(text.c_str());
 
 		if (hcenter)
@@ -660,7 +661,7 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 				fallback->draw(core::stringw(l1),
 					core::rect<s32>(offset, position.LowerRightCorner),
 					current_color < colors.size() ? colors[current_color] : video::SColor(255, 255, 255, 255),
-					hcenter, vcenter, clip);
+					false, false, clip);
 			}
 
 			offset.X += fallback->getDimension(l1).Width;
@@ -1187,7 +1188,7 @@ core::array<scene::ISceneNode*> CGUITTFont::addTextSceneNode(const wchar_t* text
 				container.push_back(current_node);
 			}
 			offset.X += getWidthFromCharacter(current_char);
-			// FIXME: missing fallback font handling here
+			// TODO: missing fallback font handling here
 
 			previous_char = current_char;
 			++text;

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -571,7 +571,6 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 	// Determine offset positions.
 	if (hcenter || vcenter)
 	{
-		// FIXME: centering doesn't account for fallback, this doesn't seem to cause any issues(?!)
 		textDimension = getDimension(text.c_str());
 
 		if (hcenter)
@@ -791,6 +790,12 @@ inline u32 CGUITTFont::getWidthFromCharacter(uchar32_t c) const
 		int w = Glyphs[n-1].advance.x / 64;
 		return w;
 	}
+	if (fallback != 0)
+	{
+		wchar_t s[] = { (wchar_t) c, 0 };
+		return fallback->getDimension(s).Width;
+	}
+
 	if (c >= 0x2000)
 		return (font_metrics.ascender / 64);
 	else return (font_metrics.ascender / 64) / 2;
@@ -814,6 +819,12 @@ inline u32 CGUITTFont::getHeightFromCharacter(uchar32_t c) const
 		s32 height = (font_metrics.ascender / 64) - Glyphs[n-1].offset.Y + Glyphs[n-1].source_rect.getHeight();
 		return height;
 	}
+	if (fallback != 0)
+	{
+		wchar_t s[] = { (wchar_t) c, 0 };
+		return fallback->getDimension(s).Height;
+	}
+
 	if (c >= 0x2000)
 		return (font_metrics.ascender / 64);
 	else return (font_metrics.ascender / 64) / 2;

--- a/src/irrlicht_changes/CGUITTFont.h
+++ b/src/irrlicht_changes/CGUITTFont.h
@@ -269,7 +269,7 @@ namespace gui
 				video::SColor color, bool hcenter=false, bool vcenter=false,
 				const core::rect<s32>* clip=0);
 
-			virtual void draw(const EnrichedString& text, const core::rect<s32>& position,
+			void draw(const EnrichedString& text, const core::rect<s32>& position,
 				video::SColor color, bool hcenter=false, bool vcenter=false,
 				const core::rect<s32>* clip=0);
 
@@ -312,6 +312,9 @@ namespace gui
 
 			//! Get the last glyph page's index.
 			u32 getLastGlyphPageIndex() const { return Glyph_Pages.size() - 1; }
+
+			//! Set font that should be used for glyphs not present in ours
+			void setFallback(gui::IGUIFont* font) { fallback = font; }
 
 			//! Create corresponding character's software image copy from the font,
 			//! so you can use this data just like any ordinary video::IImage.
@@ -387,6 +390,8 @@ namespace gui
 			core::ustring Invisible;
 			u32 shadow_offset;
 			u32 shadow_alpha;
+
+			gui::IGUIFont* fallback;
 	};
 
 } // end namespace gui


### PR DESCRIPTION
Switching the font depending on the users language is fundamentally flawed, you do obviously want to be able to display Chinese text for Russian users and vice-versa.
Hence this PR implements what any sane font engine should do: it transparently falls back to other font(s) when it encounters a glyph that wasn't found.

fixes #10634, fixes #9198

## To do

This PR is a Ready for Review.

## How to test

1. Test various locales that used to have fallback font disabled (`de`, `ru`, ...) and ones that used to have it enabled (`zh_CN`, `ja`, `ko`, `kk`, ...).
Text should still show up everywhere as usual.
2. Use this test mod and verify that 1) rendering is correct in chat console & "normal" chat and 2) coloring is correct
```lua
core.register_chatcommand("foo", {
	func = function()
		local function u8iter(s, f)
			local i, i2 = 1, 1
			while i <= #s do
				local c = s:sub(i,i); i = i + 1
				while (s:byte(i) or 0) >= 128 and s:byte(i) < 192 do
					c = c .. s:sub(i,i); i = i + 1
				end
				f(i2, c); i2 = i2 + 1
			end
		end

		local colors = {"#f55", "#5f5", "#55f"}
		local s = "foo_bar a我b都c我d都e我f都g我h都i我0都9我_都-我 我都我 foo_bar"
		local r = ""
		u8iter(s, function(n, char)
			r = r .. core.colorize(colors[(n-1) % #colors + 1], char)
		end)
		return true, r
	end
})
```
3. When there is text with mixed fonts (use chinese or japanese to test this), ensure that alignment and kerning is correct and consistent.