### PR TITLE
Fix broken `BiomeGen` abstraction

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -113,19 +113,22 @@ EmergeParams::~EmergeParams()
 {
 	infostream << "EmergeParams: destroying " << this << std::endl;
 	// Delete everything that was cloned on creation of EmergeParams
+	delete biomegen;
 	delete biomemgr;
 	delete oremgr;
 	delete decomgr;
 	delete schemmgr;
 }
 
-EmergeParams::EmergeParams(EmergeManager *parent, const BiomeManager *biomemgr,
+EmergeParams::EmergeParams(EmergeManager *parent, const BiomeGen *biomegen,
+	const BiomeManager *biomemgr,
 	const OreManager *oremgr, const DecorationManager *decomgr,
 	const SchematicManager *schemmgr) :
 	ndef(parent->ndef),
 	enable_mapgen_debug_info(parent->enable_mapgen_debug_info),
 	gen_notify_on(parent->gen_notify_on),
 	gen_notify_on_deco_ids(&parent->gen_notify_on_deco_ids),
+	biomegen(biomegen->clone()),
 	biomemgr(biomemgr->clone()), oremgr(oremgr->clone()),
 	decomgr(decomgr->clone()), schemmgr(schemmgr->clone())
 {
@@ -142,6 +145,8 @@ EmergeManager::EmergeManager(Server *server)
 	this->oremgr    = new OreManager(server);
 	this->decomgr   = new DecorationManager(server);
 	this->schemmgr  = new SchematicManager(server);
+
+	this->biomegen = nullptr; // initialized later
 
 	// Note that accesses to this variable are not synchronized.
 	// This is because the *only* thread ever starting or stopping
@@ -240,9 +245,12 @@ void EmergeManager::initMapgens(MapgenParams *params)
 
 	mgparams = params;
 
+	v3s16 csize = v3s16(1, 1, 1) * (params->chunksize * MAP_BLOCKSIZE);
+	biomegen = biomemgr->createBiomeGen(BIOMEGEN_ORIGINAL, params->bparams, csize);
+
 	for (u32 i = 0; i != m_threads.size(); i++) {
-		EmergeParams *p = new EmergeParams(
-			this, biomemgr, oremgr, decomgr, schemmgr);
+		EmergeParams *p = new EmergeParams(this, biomegen,
+			biomemgr, oremgr, decomgr, schemmgr);
 		infostream << "EmergeManager: Created params " << p
 			<< " for thread " << i << std::endl;
 		m_mapgens.push_back(Mapgen::createMapgen(params->mgtype, params, p));

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -146,7 +146,9 @@ EmergeManager::EmergeManager(Server *server)
 	this->decomgr   = new DecorationManager(server);
 	this->schemmgr  = new SchematicManager(server);
 
-	this->biomegen = nullptr; // initialized later
+	// initialized later
+	this->mgparams = nullptr;
+	this->biomegen = nullptr;
 
 	// Note that accesses to this variable are not synchronized.
 	// This is because the *only* thread ever starting or stopping

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -128,10 +128,10 @@ EmergeParams::EmergeParams(EmergeManager *parent, const BiomeGen *biomegen,
 	enable_mapgen_debug_info(parent->enable_mapgen_debug_info),
 	gen_notify_on(parent->gen_notify_on),
 	gen_notify_on_deco_ids(&parent->gen_notify_on_deco_ids),
-	biomegen(biomegen->clone()),
 	biomemgr(biomemgr->clone()), oremgr(oremgr->clone()),
 	decomgr(decomgr->clone()), schemmgr(schemmgr->clone())
 {
+	this->biomegen = biomegen->clone(this->biomemgr);
 }
 
 ////

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -99,13 +99,15 @@ public:
 	u32 gen_notify_on;
 	const std::set<u32> *gen_notify_on_deco_ids; // shared
 
+	BiomeGen *biomegen;
 	BiomeManager *biomemgr;
 	OreManager *oremgr;
 	DecorationManager *decomgr;
 	SchematicManager *schemmgr;
 
 private:
-	EmergeParams(EmergeManager *parent, const BiomeManager *biomemgr,
+	EmergeParams(EmergeManager *parent, const BiomeGen *biomegen,
+		const BiomeManager *biomemgr,
 		const OreManager *oremgr, const DecorationManager *decomgr,
 		const SchematicManager *schemmgr);
 };
@@ -139,6 +141,8 @@ public:
 	EmergeManager(Server *server);
 	~EmergeManager();
 	DISABLE_CLASS_COPY(EmergeManager);
+
+	const BiomeGen *getBiomeGen() const { return biomegen; }
 
 	// no usage restrictions
 	const BiomeManager *getBiomeManager() const { return biomemgr; }
@@ -196,6 +200,7 @@ private:
 
 	// Managers of various map generation-related components
 	// Note that each Mapgen gets a copy(!) of these to work with
+	BiomeGen *biomegen;
 	BiomeManager *biomemgr;
 	OreManager *oremgr;
 	DecorationManager *decomgr;

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -595,7 +595,8 @@ MapgenBasic::MapgenBasic(int mapgenid, MapgenParams *params, EmergeParams *emerg
 	this->heightmap = new s16[csize.X * csize.Z];
 
 	//// Initialize biome generator
-	biomegen = m_bmgr->createBiomeGen(BIOMEGEN_ORIGINAL, params->bparams, csize);
+	biomegen = emerge->biomegen;
+	biomegen->assertChunkSize(csize);
 	biomemap = biomegen->biomemap;
 
 	//// Look up some commonly used content
@@ -621,7 +622,6 @@ MapgenBasic::MapgenBasic(int mapgenid, MapgenParams *params, EmergeParams *emerg
 
 MapgenBasic::~MapgenBasic()
 {
-	delete biomegen;
 	delete []heightmap;
 
 	delete m_emerge; // destroying EmergeParams is our responsibility

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -57,7 +57,8 @@ FlagDesc flagdesc_mapgen_valleys[] = {
 MapgenValleys::MapgenValleys(MapgenValleysParams *params, EmergeParams *emerge)
 	: MapgenBasic(MAPGEN_VALLEYS, params, emerge)
 {
-	// NOTE: MapgenValleys has a hard dependency on BiomeGenOriginal
+	FATAL_ERROR_IF(biomegen->getType() != BIOMEGEN_ORIGINAL,
+		"MapgenValleys has a hard dependency on BiomeGenOriginal");
 	m_bgen = (BiomeGenOriginal *)biomegen;
 
 	spflags            = params->spflags;

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -101,71 +101,6 @@ BiomeManager *BiomeManager::clone() const
 	return mgr;
 }
 
-
-// For BiomeGen type 'BiomeGenOriginal'
-float BiomeManager::getHeatAtPosOriginal(v3s16 pos, NoiseParams &np_heat,
-	NoiseParams &np_heat_blend, u64 seed) const
-{
-	return
-		NoisePerlin2D(&np_heat,       pos.X, pos.Z, seed) +
-		NoisePerlin2D(&np_heat_blend, pos.X, pos.Z, seed);
-}
-
-
-// For BiomeGen type 'BiomeGenOriginal'
-float BiomeManager::getHumidityAtPosOriginal(v3s16 pos, NoiseParams &np_humidity,
-	NoiseParams &np_humidity_blend, u64 seed) const
-{
-	return
-		NoisePerlin2D(&np_humidity,       pos.X, pos.Z, seed) +
-		NoisePerlin2D(&np_humidity_blend, pos.X, pos.Z, seed);
-}
-
-
-// For BiomeGen type 'BiomeGenOriginal'
-const Biome *BiomeManager::getBiomeFromNoiseOriginal(float heat,
-	float humidity, v3s16 pos) const
-{
-	Biome *biome_closest = nullptr;
-	Biome *biome_closest_blend = nullptr;
-	float dist_min = FLT_MAX;
-	float dist_min_blend = FLT_MAX;
-
-	for (size_t i = 1; i < getNumObjects(); i++) {
-		Biome *b = (Biome *)getRaw(i);
-		if (!b ||
-				pos.Y < b->min_pos.Y || pos.Y > b->max_pos.Y + b->vertical_blend ||
-				pos.X < b->min_pos.X || pos.X > b->max_pos.X ||
-				pos.Z < b->min_pos.Z || pos.Z > b->max_pos.Z)
-			continue;
-
-		float d_heat = heat - b->heat_point;
-		float d_humidity = humidity - b->humidity_point;
-		float dist = (d_heat * d_heat) + (d_humidity * d_humidity);
-
-		if (pos.Y <= b->max_pos.Y) { // Within y limits of biome b
-			if (dist < dist_min) {
-				dist_min = dist;
-				biome_closest = b;
-			}
-		} else if (dist < dist_min_blend) { // Blend area above biome b
-			dist_min_blend = dist;
-			biome_closest_blend = b;
-		}
-	}
-
-	const u64 seed = pos.Y + (heat + humidity) * 0.9f;
-	PcgRandom rng(seed);
-
-	if (biome_closest_blend && dist_min_blend <= dist_min &&
-			rng.range(0, biome_closest_blend->vertical_blend) >=
-			pos.Y - biome_closest_blend->max_pos.Y)
-		return biome_closest_blend;
-
-	return (biome_closest) ? biome_closest : (Biome *)getRaw(BIOME_NONE);
-}
-
-
 ////////////////////////////////////////////////////////////////////////////////
 
 void BiomeParamsOriginal::readParams(const Settings *settings)
@@ -229,17 +164,21 @@ BiomeGen *BiomeGenOriginal::clone() const
 	return new BiomeGenOriginal(m_bmgr, m_params, m_csize);
 }
 
-// Only usable in a mapgen thread
+float BiomeGenOriginal::calcHeatAtPoint(v3s16 pos) const
+{
+	return NoisePerlin2D(&m_params->np_heat, pos.X, pos.Z, m_params->seed) +
+		NoisePerlin2D(&m_params->np_heat_blend, pos.X, pos.Z, m_params->seed);
+}
+
+float BiomeGenOriginal::calcHumidityAtPoint(v3s16 pos) const
+{
+	return NoisePerlin2D(&m_params->np_humidity, pos.X, pos.Z, m_params->seed) +
+		NoisePerlin2D(&m_params->np_humidity_blend, pos.X, pos.Z, m_params->seed);
+}
+
 Biome *BiomeGenOriginal::calcBiomeAtPoint(v3s16 pos) const
 {
-	float heat =
-		NoisePerlin2D(&m_params->np_heat,       pos.X, pos.Z, m_params->seed) +
-		NoisePerlin2D(&m_params->np_heat_blend, pos.X, pos.Z, m_params->seed);
-	float humidity =
-		NoisePerlin2D(&m_params->np_humidity,       pos.X, pos.Z, m_params->seed) +
-		NoisePerlin2D(&m_params->np_humidity_blend, pos.X, pos.Z, m_params->seed);
-
-	return calcBiomeFromNoise(heat, humidity, pos);
+	return calcBiomeFromNoise(calcHeatAtPoint(pos), calcHumidityAtPoint(pos), pos);
 }
 
 

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -224,6 +224,11 @@ BiomeGenOriginal::~BiomeGenOriginal()
 	delete noise_humidity_blend;
 }
 
+BiomeGen *BiomeGenOriginal::clone() const
+{
+	return new BiomeGenOriginal(m_bmgr, m_params, m_csize);
+}
+
 // Only usable in a mapgen thread
 Biome *BiomeGenOriginal::calcBiomeAtPoint(v3s16 pos) const
 {

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -159,9 +159,9 @@ BiomeGenOriginal::~BiomeGenOriginal()
 	delete noise_humidity_blend;
 }
 
-BiomeGen *BiomeGenOriginal::clone() const
+BiomeGen *BiomeGenOriginal::clone(BiomeManager *biomemgr) const
 {
-	return new BiomeGenOriginal(m_bmgr, m_params, m_csize);
+	return new BiomeGenOriginal(biomemgr, m_params, m_csize);
 }
 
 float BiomeGenOriginal::calcHeatAtPoint(v3s16 pos) const

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -189,7 +189,7 @@ void BiomeParamsOriginal::writeParams(Settings *settings) const
 ////////////////////////////////////////////////////////////////////////////////
 
 BiomeGenOriginal::BiomeGenOriginal(BiomeManager *biomemgr,
-	BiomeParamsOriginal *params, v3s16 chunksize)
+	const BiomeParamsOriginal *params, v3s16 chunksize)
 {
 	m_bmgr   = biomemgr;
 	m_params = params;

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -97,7 +97,8 @@ public:
 
 	virtual BiomeGenType getType() const = 0;
 
-	virtual BiomeGen *clone() const = 0;
+	// Clone this BiomeGen and set a the new BiomeManager to be used by the copy
+	virtual BiomeGen *clone(BiomeManager *biomemgr) const = 0;
 
 	// Check that the internal chunk size is what the mapgen expects, just to be sure.
 	inline void assertChunkSize(v3s16 expect) const
@@ -171,7 +172,7 @@ public:
 
 	BiomeGenType getType() const { return BIOMEGEN_ORIGINAL; }
 
-	BiomeGen *clone() const;
+	BiomeGen *clone(BiomeManager *biomemgr) const;
 
 	// Slower, meant for Script API use
 	float calcHeatAtPoint(v3s16 pos) const;

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -158,7 +158,7 @@ struct BiomeParamsOriginal : public BiomeParams {
 class BiomeGenOriginal : public BiomeGen {
 public:
 	BiomeGenOriginal(BiomeManager *biomemgr,
-		BiomeParamsOriginal *params, v3s16 chunksize);
+		const BiomeParamsOriginal *params, v3s16 chunksize);
 	virtual ~BiomeGenOriginal();
 
 	BiomeGenType getType() const { return BIOMEGEN_ORIGINAL; }
@@ -176,7 +176,7 @@ public:
 	float *humidmap;
 
 private:
-	BiomeParamsOriginal *m_params;
+	const BiomeParamsOriginal *m_params;
 
 	Noise *noise_heat;
 	Noise *noise_humidity;

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -173,7 +173,11 @@ public:
 
 	BiomeGen *clone() const;
 
+	// Slower, meant for Script API use
+	float calcHeatAtPoint(v3s16 pos) const;
+	float calcHumidityAtPoint(v3s16 pos) const;
 	Biome *calcBiomeAtPoint(v3s16 pos) const;
+
 	void calcBiomeNoise(v3s16 pmin);
 
 	biome_t *getBiomes(s16 *heightmap, v3s16 pmin);
@@ -238,14 +242,6 @@ public:
 	}
 
 	virtual void clear();
-
-	// For BiomeGen type 'BiomeGenOriginal'
-	float getHeatAtPosOriginal(v3s16 pos, NoiseParams &np_heat,
-		NoiseParams &np_heat_blend, u64 seed) const;
-	float getHumidityAtPosOriginal(v3s16 pos, NoiseParams &np_humidity,
-		NoiseParams &np_humidity_blend, u64 seed) const;
-	const Biome *getBiomeFromNoiseOriginal(float heat, float humidity,
-		v3s16 pos) const;
 
 private:
 	BiomeManager() {};

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -97,6 +97,14 @@ public:
 
 	virtual BiomeGenType getType() const = 0;
 
+	virtual BiomeGen *clone() const = 0;
+
+	// Check that the internal chunk size is what the mapgen expects, just to be sure.
+	inline void assertChunkSize(v3s16 expect) const
+	{
+		FATAL_ERROR_IF(m_csize != expect, "Chunk size mismatches");
+	}
+
 	// Calculates the biome at the exact position provided.  This function can
 	// be called at any time, but may be less efficient than the latter methods,
 	// depending on implementation.
@@ -162,6 +170,8 @@ public:
 	virtual ~BiomeGenOriginal();
 
 	BiomeGenType getType() const { return BIOMEGEN_ORIGINAL; }
+
+	BiomeGen *clone() const;
 
 	Biome *calcBiomeAtPoint(v3s16 pos) const;
 	void calcBiomeNoise(v3s16 pmin);

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -369,7 +369,7 @@ float contour(float v)
 ///////////////////////// [ New noise ] ////////////////////////////
 
 
-float NoisePerlin2D(NoiseParams *np, float x, float y, s32 seed)
+float NoisePerlin2D(const NoiseParams *np, float x, float y, s32 seed)
 {
 	float a = 0;
 	float f = 1.0;
@@ -395,7 +395,7 @@ float NoisePerlin2D(NoiseParams *np, float x, float y, s32 seed)
 }
 
 
-float NoisePerlin3D(NoiseParams *np, float x, float y, float z, s32 seed)
+float NoisePerlin3D(const NoiseParams *np, float x, float y, float z, s32 seed)
 {
 	float a = 0;
 	float f = 1.0;
@@ -422,7 +422,7 @@ float NoisePerlin3D(NoiseParams *np, float x, float y, float z, s32 seed)
 }
 
 
-Noise::Noise(NoiseParams *np_, s32 seed, u32 sx, u32 sy, u32 sz)
+Noise::Noise(const NoiseParams *np_, s32 seed, u32 sx, u32 sy, u32 sz)
 {
 	np = *np_;
 	this->seed = seed;

--- a/src/noise.h
+++ b/src/noise.h
@@ -146,7 +146,7 @@ public:
 	float *persist_buf = nullptr;
 	float *result = nullptr;
 
-	Noise(NoiseParams *np, s32 seed, u32 sx, u32 sy, u32 sz=1);
+	Noise(const NoiseParams *np, s32 seed, u32 sx, u32 sy, u32 sz=1);
 	~Noise();
 
 	void setSize(u32 sx, u32 sy, u32 sz=1);
@@ -192,8 +192,8 @@ private:
 
 };
 
-float NoisePerlin2D(NoiseParams *np, float x, float y, s32 seed);
-float NoisePerlin3D(NoiseParams *np, float x, float y, float z, s32 seed);
+float NoisePerlin2D(const NoiseParams *np, float x, float y, s32 seed);
+float NoisePerlin3D(const NoiseParams *np, float x, float y, float z, s32 seed);
 
 inline float NoisePerlin2D_PO(NoiseParams *np, float x, float xoff,
 	float y, float yoff, s32 seed)

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -482,9 +482,7 @@ int ModApiMapgen::l_get_biome_id(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	const char *biome_str = lua_tostring(L, 1);
-	if (!biome_str)
-		return 0;
+	const char *biome_str = luaL_checkstring(L, 1);
 
 	const BiomeManager *bmgr = getServer(L)->getEmergeManager()->getBiomeManager();
 	if (!bmgr)
@@ -527,30 +525,12 @@ int ModApiMapgen::l_get_heat(lua_State *L)
 
 	v3s16 pos = read_v3s16(L, 1);
 
-	NoiseParams np_heat;
-	NoiseParams np_heat_blend;
+	const BiomeGen *biomegen = getServer(L)->getEmergeManager()->getBiomeGen();
 
-	MapSettingsManager *settingsmgr =
-		getServer(L)->getEmergeManager()->map_settings_mgr;
-
-	if (!settingsmgr->getMapSettingNoiseParams("mg_biome_np_heat",
-			&np_heat) ||
-			!settingsmgr->getMapSettingNoiseParams("mg_biome_np_heat_blend",
-			&np_heat_blend))
+	if (!biomegen || biomegen->getType() != BIOMEGEN_ORIGINAL)
 		return 0;
 
-	std::string value;
-	if (!settingsmgr->getMapSetting("seed", &value))
-		return 0;
-	std::istringstream ss(value);
-	u64 seed;
-	ss >> seed;
-
-	const BiomeManager *bmgr = getServer(L)->getEmergeManager()->getBiomeManager();
-	if (!bmgr)
-		return 0;
-
-	float heat = bmgr->getHeatAtPosOriginal(pos, np_heat, np_heat_blend, seed);
+	float heat = ((BiomeGenOriginal*) biomegen)->calcHeatAtPoint(pos);
 
 	lua_pushnumber(L, heat);
 
@@ -566,31 +546,12 @@ int ModApiMapgen::l_get_humidity(lua_State *L)
 
 	v3s16 pos = read_v3s16(L, 1);
 
-	NoiseParams np_humidity;
-	NoiseParams np_humidity_blend;
+	const BiomeGen *biomegen = getServer(L)->getEmergeManager()->getBiomeGen();
 
-	MapSettingsManager *settingsmgr =
-		getServer(L)->getEmergeManager()->map_settings_mgr;
-
-	if (!settingsmgr->getMapSettingNoiseParams("mg_biome_np_humidity",
-			&np_humidity) ||
-			!settingsmgr->getMapSettingNoiseParams("mg_biome_np_humidity_blend",
-			&np_humidity_blend))
+	if (!biomegen || biomegen->getType() != BIOMEGEN_ORIGINAL)
 		return 0;
 
-	std::string value;
-	if (!settingsmgr->getMapSetting("seed", &value))
-		return 0;
-	std::istringstream ss(value);
-	u64 seed;
-	ss >> seed;
-
-	const BiomeManager *bmgr = getServer(L)->getEmergeManager()->getBiomeManager();
-	if (!bmgr)
-		return 0;
-
-	float humidity = bmgr->getHumidityAtPosOriginal(pos, np_humidity,
-		np_humidity_blend, seed);
+	float humidity = ((BiomeGenOriginal*) biomegen)->calcHumidityAtPoint(pos);
 
 	lua_pushnumber(L, humidity);
 
@@ -606,45 +567,11 @@ int ModApiMapgen::l_get_biome_data(lua_State *L)
 
 	v3s16 pos = read_v3s16(L, 1);
 
-	NoiseParams np_heat;
-	NoiseParams np_heat_blend;
-	NoiseParams np_humidity;
-	NoiseParams np_humidity_blend;
-
-	MapSettingsManager *settingsmgr =
-		getServer(L)->getEmergeManager()->map_settings_mgr;
-
-	if (!settingsmgr->getMapSettingNoiseParams("mg_biome_np_heat",
-			&np_heat) ||
-			!settingsmgr->getMapSettingNoiseParams("mg_biome_np_heat_blend",
-			&np_heat_blend) ||
-			!settingsmgr->getMapSettingNoiseParams("mg_biome_np_humidity",
-			&np_humidity) ||
-			!settingsmgr->getMapSettingNoiseParams("mg_biome_np_humidity_blend",
-			&np_humidity_blend))
+	const BiomeGen *biomegen = getServer(L)->getEmergeManager()->getBiomeGen();
+	if (!biomegen)
 		return 0;
 
-	std::string value;
-	if (!settingsmgr->getMapSetting("seed", &value))
-		return 0;
-	std::istringstream ss(value);
-	u64 seed;
-	ss >> seed;
-
-	const BiomeManager *bmgr = getServer(L)->getEmergeManager()->getBiomeManager();
-	if (!bmgr)
-		return 0;
-
-	float heat = bmgr->getHeatAtPosOriginal(pos, np_heat, np_heat_blend, seed);
-	if (!heat)
-		return 0;
-
-	float humidity = bmgr->getHumidityAtPosOriginal(pos, np_humidity,
-		np_humidity_blend, seed);
-	if (!humidity)
-		return 0;
-
-	const Biome *biome = bmgr->getBiomeFromNoiseOriginal(heat, humidity, pos);
+	const Biome *biome = biomegen->calcBiomeAtPoint(pos);
 	if (!biome || biome->index == OBJDEF_INVALID_INDEX)
 		return 0;
 
@@ -653,11 +580,16 @@ int ModApiMapgen::l_get_biome_data(lua_State *L)
 	lua_pushinteger(L, biome->index);
 	lua_setfield(L, -2, "biome");
 
-	lua_pushnumber(L, heat);
-	lua_setfield(L, -2, "heat");
+	if (biomegen->getType() == BIOMEGEN_ORIGINAL) {
+		float heat = ((BiomeGenOriginal*) biomegen)->calcHeatAtPoint(pos);
+		float humidity = ((BiomeGenOriginal*) biomegen)->calcHumidityAtPoint(pos);
 
-	lua_pushnumber(L, humidity);
-	lua_setfield(L, -2, "humidity");
+		lua_pushnumber(L, heat);
+		lua_setfield(L, -2, "heat");
+
+		lua_pushnumber(L, humidity);
+		lua_setfield(L, -2, "humidity");
+	}
 
 	return 1;
 }
@@ -1495,7 +1427,8 @@ int ModApiMapgen::l_generate_ores(lua_State *L)
 	EmergeManager *emerge = getServer(L)->getEmergeManager();
 
 	Mapgen mg;
-	mg.seed = emerge->mgparams->seed;
+	// Intentionally truncates to s32, see Mapgen::Mapgen()
+	mg.seed = (s32)emerge->mgparams->seed;
 	mg.vm   = LuaVoxelManip::checkobject(L, 1)->vm;
 	mg.ndef = getServer(L)->getNodeDefManager();
 
@@ -1521,7 +1454,8 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 	EmergeManager *emerge = getServer(L)->getEmergeManager();
 
 	Mapgen mg;
-	mg.seed = emerge->mgparams->seed;
+	// Intentionally truncates to s32, see Mapgen::Mapgen()
+	mg.seed = (s32)emerge->mgparams->seed;
 	mg.vm   = LuaVoxelManip::checkobject(L, 1)->vm;
 	mg.ndef = getServer(L)->getNodeDefManager();
 

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1425,6 +1425,8 @@ int ModApiMapgen::l_generate_ores(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 
 	EmergeManager *emerge = getServer(L)->getEmergeManager();
+	if (!emerge || !emerge->mgparams)
+		return 0;
 
 	Mapgen mg;
 	// Intentionally truncates to s32, see Mapgen::Mapgen()
@@ -1452,6 +1454,8 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 
 	EmergeManager *emerge = getServer(L)->getEmergeManager();
+	if (!emerge || !emerge->mgparams)
+		return 0;
 
 	Mapgen mg;
 	// Intentionally truncates to s32, see Mapgen::Mapgen()


### PR DESCRIPTION
We have a `BiomeGen` -> `BiomeGenOriginal` class hierarchy.
Yet `minetest.get_heat()`'s implementation manually grabs mapgen parameters(?!) and directly calls a copy(??!!) of BiomeGenOriginal's algorithm situated inside `BiomeManager`(???!!!).

Fixing this gaping hole in the abstraction actually makes it viable to introduce BiomeGens other than BiomeGenOriginal.
For that purpose this PR moves the responsibility for creating BiomeGen out of `MapgenBasic` into `EmergeManager`.

## To do

This PR is Ready for Review.

