### PR TITLE
Fix attached-to-object sounds having a higher reference distance

### DIFF
--- a/src/client/sound_openal.cpp
+++ b/src/client/sound_openal.cpp
@@ -671,8 +671,8 @@ public:
 
 		alSourcei(sound->source_id, AL_SOURCE_RELATIVE, false);
 		alSource3f(sound->source_id, AL_POSITION, pos.X, pos.Y, pos.Z);
-		alSource3f(sound->source_id, AL_VELOCITY, 0, 0, 0);
-		alSourcef(sound->source_id, AL_REFERENCE_DISTANCE, 30.0);
+		alSource3f(sound->source_id, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
+		alSourcef(sound->source_id, AL_REFERENCE_DISTANCE, 10.0f);
 	}
 
 	bool updateSoundGain(int id, float gain)


### PR DESCRIPTION
- Goal of the PR: fix a small bug
- How does the PR work? fix numbers
- Does it resolve any reported issue? Probalby not, the difference is hardly audible.
- Bug was probably introduced by #6457.
- This is a trivial bugfix.

## To do

This PR is a Ready for Review.

## How to test

- Test mod:
```lua
minetest.register_craftitem("sound_test:test", {
	description = "sound tset",
	groups = {},
	inventory_image = "default_tool_steelaxe.png",

	on_use = function(itemstack, user, pointed_thing)
		if pointed_thing.type == "node" then
			minetest.sound_play({name = "technic_hv_nuclear_reactor_siren_danger_loop"},
					{pos = pointed_thing.above, loop = true})
		elseif pointed_thing.type == "object" then
			minetest.sound_play({name = "technic_hv_nuclear_reactor_siren_danger_loop"},
					{object = pointed_thing.ref, loop = true})
		end
	end,
})
```
  (Uses technic's nuclear siren, see https://github.com/minetest-mods/technic/blob/master/technic/README.md for licensing details.)
  For you to download whole mod: [sound_test.zip](https://github.com/minetest/minetest/files/6185993/sound_test.zip)
- Use something to measure sound loudness, eg. pavucontrol.
- Use the item on a cart.
- Use the item on the dirt below a flower, far away.
- Compare loudness at a distance of ca. 3 nodes.