### PR TITLE
Clean up various misleading and/or confusing messages and texts related to priv changes

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -167,6 +167,18 @@ core.register_chatcommand("admin", {
 	end,
 })
 
+local function privileges_of(name, privs)
+	if not privs then
+		privs = core.get_player_privs(name)
+	end
+	local privstr = core.privs_to_string(privs, ", ")
+	if privstr == "" then
+		return S("@1 doesn\'t have any privileges.", name)
+	else
+		return S("Privileges of @1: @2", name, privstr)
+	end
+end
+
 core.register_chatcommand("privs", {
 	params = S("[<name>]"),
 	description = S("Show privileges of yourself or another player"),
@@ -176,9 +188,7 @@ core.register_chatcommand("privs", {
 		if not core.player_exists(name) then
 			return false, S("Player @1 does not exist.", name)
 		end
-		return true, S("Privileges of @1: @2", name,
-				core.privs_to_string(
-				core.get_player_privs(name), ", "))
+		return true, privileges_of(name)
 	end,
 })
 
@@ -250,9 +260,7 @@ local function handle_grant_command(caller, grantname, grantprivstr)
 				S("@1 granted you privileges: @2", caller,
 				core.privs_to_string(grantprivs, ', ')))
 	end
-	return true, S("Privileges of @1: @2", grantname,
-			core.privs_to_string(
-			core.get_player_privs(grantname), ', '))
+	return true, privileges_of(grantname)
 end
 
 core.register_chatcommand("grant", {
@@ -366,8 +374,7 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 			S("@1 revoked privileges from you: @2", caller,
 			core.privs_to_string(revokeprivs, ', ')))
 	end
-	return true, S("Privileges of @1: @2", revokename,
-			core.privs_to_string(new_privs, ', '))
+	return true, privileges_of(revokename, new_privs)
 end
 
 core.register_chatcommand("revoke", {

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -265,7 +265,7 @@ local function handle_grant_command(caller, grantname, grantprivstr)
 end
 
 core.register_chatcommand("grant", {
-	params = S("<name> (<privilege> | all)"),
+	params = S("<name> (<privilege> [, <privilege2> [<...>]] | all)"),
 	description = S("Give privileges to player"),
 	func = function(name, param)
 		local grantname, grantprivstr = string.match(param, "([^ ]+) (.+)")
@@ -277,7 +277,7 @@ core.register_chatcommand("grant", {
 })
 
 core.register_chatcommand("grantme", {
-	params = S("<privilege> | all"),
+	params = S("<privilege> [, <privilege2> [<...>]] | all"),
 	description = S("Grant privileges to yourself"),
 	func = function(name, param)
 		if param == "" then
@@ -380,7 +380,7 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 end
 
 core.register_chatcommand("revoke", {
-	params = S("<name> (<privilege> | all)"),
+	params = S("<name> (<privilege> [, <privilege2> [<...>]] | all)"),
 	description = S("Remove privileges from player"),
 	privs = {},
 	func = function(name, param)
@@ -393,7 +393,7 @@ core.register_chatcommand("revoke", {
 })
 
 core.register_chatcommand("revokeme", {
-	params = S("<privilege> | all"),
+	params = S("<privilege> [, <privilege2> [<...>]] | all"),
 	description = S("Revoke privileges from yourself"),
 	privs = {},
 	func = function(name, param)

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -246,11 +246,11 @@ local function handle_grant_command(caller, grantname, grantprivstr)
 	if grantname ~= caller then
 		core.chat_send_player(grantname,
 				S("@1 granted you privileges: @2", caller,
-				core.privs_to_string(grantprivs, ' ')))
+				core.privs_to_string(grantprivs, ', ')))
 	end
 	return true, S("Privileges of @1: @2", grantname,
 			core.privs_to_string(
-			core.get_player_privs(grantname), ' '))
+			core.get_player_privs(grantname), ', '))
 end
 
 core.register_chatcommand("grant", {
@@ -332,11 +332,11 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 		if is_singleplayer then
 			core.chat_send_player(caller,
 					S("Note: Cannot revoke in singleplayer: @1",
-					core.privs_to_string(irrevokable, ' ')))
+					core.privs_to_string(irrevokable, ', ')))
 		elseif is_admin then
 			core.chat_send_player(caller,
 					S("Note: Cannot revoke from admin: @1",
-					core.privs_to_string(irrevokable, ' ')))
+					core.privs_to_string(irrevokable, ', ')))
 		end
 	end
 
@@ -360,10 +360,10 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 	if revokename ~= caller then
 		core.chat_send_player(revokename,
 			S("@1 revoked privileges from you: @2", caller,
-			core.privs_to_string(revokeprivs, ' ')))
+			core.privs_to_string(revokeprivs, ', ')))
 	end
 	return true, S("Privileges of @1: @2", revokename,
-			core.privs_to_string(new_privs, ' '))
+			core.privs_to_string(new_privs, ', '))
 end
 
 core.register_chatcommand("revoke", {

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -173,7 +173,7 @@ local function privileges_of(name, privs)
 	end
 	local privstr = core.privs_to_string(privs, ", ")
 	if privstr == "" then
-		return S("@1 doesn\'t have any privileges.", name)
+		return S("@1 does not have any privileges.", name)
 	else
 		return S("Privileges of @1: @2", name, privstr)
 	end
@@ -237,8 +237,9 @@ local function handle_grant_command(caller, grantname, grantprivstr)
 		core.string_to_privs(core.settings:get("basic_privs") or "interact,shout")
 	for priv, _ in pairs(grantprivs) do
 		if not basic_privs[priv] and not caller_privs.privs then
-			return false, S("Your privileges are insufficient "..
-					"(basic_privs only allows you to grant: @1).",
+			return false, S("Your privileges are insufficient. "..
+					"'@1' only allows you to grant: @2.",
+					"basic_privs",
 					core.privs_to_string(basic_privs, ', '))
 		end
 		if not core.registered_privileges[priv] then
@@ -319,8 +320,9 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 	local has_irrevokable_priv = false
 	for priv, _ in pairs(revokeprivs) do
 		if not basic_privs[priv] and not caller_privs.privs then
-			return false, S("Your privileges are insufficient "..
-					"(basic_privs only allows you to revoke: @1).",
+			return false, S("Your privileges are insufficient. "..
+					"'@1' only allows you to revoke: @2.",
+					"basic_privs",
 					core.privs_to_string(basic_privs, ', '))
 		end
 		local def = core.registered_privileges[priv]

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -227,7 +227,9 @@ local function handle_grant_command(caller, grantname, grantprivstr)
 		core.string_to_privs(core.settings:get("basic_privs") or "interact,shout")
 	for priv, _ in pairs(grantprivs) do
 		if not basic_privs[priv] and not caller_privs.privs then
-			return false, S("Your privileges are insufficient.")
+			return false, S("Your privileges are insufficient "..
+					"(basic_privs only allows you to grant: @1).",
+					core.privs_to_string(basic_privs, ', '))
 		end
 		if not core.registered_privileges[priv] then
 			privs_unknown = privs_unknown .. S("Unknown privilege: @1", priv) .. "\n"
@@ -309,7 +311,9 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 	local has_irrevokable_priv = false
 	for priv, _ in pairs(revokeprivs) do
 		if not basic_privs[priv] and not caller_privs.privs then
-			return false, S("Your privileges are insufficient.")
+			return false, S("Your privileges are insufficient "..
+					"(basic_privs only allows you to revoke: @1).",
+					core.privs_to_string(basic_privs, ', '))
 		end
 		local def = core.registered_privileges[priv]
 		if not def then

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -238,7 +238,7 @@ local function handle_grant_command(caller, grantname, grantprivstr)
 	for priv, _ in pairs(grantprivs) do
 		if not basic_privs[priv] and not caller_privs.privs then
 			return false, S("Your privileges are insufficient. "..
-					"'@1' only allows you to grant: @2.",
+					"'@1' only allows you to grant: @2",
 					"basic_privs",
 					core.privs_to_string(basic_privs, ', '))
 		end
@@ -321,7 +321,7 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 	for priv, _ in pairs(revokeprivs) do
 		if not basic_privs[priv] and not caller_privs.privs then
 			return false, S("Your privileges are insufficient. "..
-					"'@1' only allows you to revoke: @2.",
+					"'@1' only allows you to revoke: @2",
 					"basic_privs",
 					core.privs_to_string(basic_privs, ', '))
 		end
@@ -330,14 +330,13 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 			privs_unknown = privs_unknown .. S("Unknown privilege: @1", priv) .. "\n"
 		elseif is_singleplayer and def.give_to_singleplayer then
 			irrevokable[priv] = true
-			has_irrevokable_priv = true
 		elseif is_admin and def.give_to_admin then
 			irrevokable[priv] = true
-			has_irrevokable_priv = true
 		end
 	end
 	for priv, _ in pairs(irrevokable) do
 		revokeprivs[priv] = nil
+		has_irrevokable_priv = true
 	end
 	if privs_unknown ~= "" then
 		return false, privs_unknown

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -32,7 +32,11 @@ end
 
 core.register_privilege("interact", S("Can interact with things and modify the world"))
 core.register_privilege("shout", S("Can speak in chat"))
-core.register_privilege("basic_privs", S("Can modify 'shout' and 'interact' privileges"))
+
+local basic_privs = core.string_to_privs((core.settings:get("basic_privs") or "shout,interact"))
+basic_privs_desc = S("Can modify basic privileges (@1)", core.privs_to_string(basic_privs, ', '))
+core.register_privilege("basic_privs", basic_privs_desc)
+
 core.register_privilege("privs", S("Can modify privileges"))
 
 core.register_privilege("teleport", {

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -33,8 +33,10 @@ end
 core.register_privilege("interact", S("Can interact with things and modify the world"))
 core.register_privilege("shout", S("Can speak in chat"))
 
-local basic_privs = core.string_to_privs((core.settings:get("basic_privs") or "shout,interact"))
-basic_privs_desc = S("Can modify basic privileges (@1)", core.privs_to_string(basic_privs, ', '))
+local basic_privs =
+	core.string_to_privs((core.settings:get("basic_privs") or "shout,interact"))
+local basic_privs_desc = S("Can modify basic privileges (@1)",
+	core.privs_to_string(basic_privs, ', '))
 core.register_privilege("basic_privs", basic_privs_desc)
 
 core.register_privilege("privs", S("Can modify privileges"))


### PR DESCRIPTION
This PR does the following:

* Fixes #3632 (No error message when trying to revoke privilege from admin or singleplayer)
* Fixes the description of the `basic_privs` privilege assuming the `basic_privs` setting was unmodified, now it shows the actual list of privileges this will allow to be changed. Note that the list of basic privileges can be cahnged with a setting, they are not guaranteed to be always `interact` and `shout`
* Adds a comma between the privilege names in `/grant[me]` and `/revoke[me]` commands (stolen from #11013)
* Friendlier chat message in `/grant[me], `/revoke[me] and `/privs` command if player has no privs (current message is just “Privileges of player:” with nothing after that, which is slightly confusing)

## Rationale
Some of these are outright bugs that are fixed here, that should be obvious.
Some of these are basically just small usability/messaging tweaks to fix some misleading or irritating messages.
Note the fact that the full priv list is already shown afterwards is no excuse to not improve this. Why? Because it is easy to overlook that the privileges you requested to change did, in fact, not change. Therefore, adding a note that explicitly mentions it makes sense to me.

As all of these things are kind of related, I decided to put everything in a single PR, I also stole trivial PR #11013 to make it easier for you.

## Limitation
The `basic_privs` priv description assumes the `basic_privs` setting will not be modified at runtime (e.g. with `/set`). If that happened, the description will be wrong again. A restart is required for the description to update. It's still better than before, when it assumed that the `basic_privs` setting is always the default.

However, I think this is not fixable for now since there is no callback for setting changes (yet). Besides, I think it's very rare that someone wants to change that obscure settings at runtime anyway.