### PR TITLE
Fix rendering of allfaces nodes with transparent textures

### DIFF
--- a/games/devtest/mods/testnodes/textures.lua
+++ b/games/devtest/mods/testnodes/textures.lua
@@ -160,7 +160,7 @@ minetest.register_node("testnodes:generated_png_ck", {
 minetest.register_node("testnodes:multitile_liquid", {
 	description = S("Multiple Tiles Liquid Test Node"),
 	drawtype = "liquid",
-	paramtype = "light",
+	waving = 3,
 	tiles = {
 		"default_water.png^[colorize:#ff00007f^[opacity:192",
 		"default_water.png^[colorize:#00ffff7f^[opacity:192",
@@ -169,9 +169,8 @@ minetest.register_node("testnodes:multitile_liquid", {
 		"default_water.png^[colorize:#00ff007f^[opacity:192",
 		"default_water.png^[colorize:#ff00ff7f^[opacity:192",
 	},
-	inventory_image = "default_water.png^[colorize:#00ff007f",
-	wield_image = "default_water.png^[colorize:#00ff007f",
 	use_texture_alpha = "blend",
-
-	groups = { dig_immediate = 3 },
+	paramtype = "light",
+	walkable = false,
+	groups = { water = 3, liquid = 3, dig_immediate = 3 },
 })

--- a/games/devtest/mods/testnodes/textures.lua
+++ b/games/devtest/mods/testnodes/textures.lua
@@ -155,3 +155,23 @@ minetest.register_node("testnodes:generated_png_ck", {
 
 	groups = { dig_immediate = 2 },
 })
+
+-- Colored water
+minetest.register_node("testnodes:multitile_liquid", {
+	description = S("Multiple Tiles Liquid Test Node"),
+	drawtype = "liquid",
+	paramtype = "light",
+	tiles = {
+		"default_water.png^[colorize:#ff00007f^[opacity:192",
+		"default_water.png^[colorize:#00ffff7f^[opacity:192",
+		"default_water.png^[colorize:#0000ff7f^[opacity:192",
+		"default_water.png^[colorize:#ffff007f^[opacity:192",
+		"default_water.png^[colorize:#00ff007f^[opacity:192",
+		"default_water.png^[colorize:#ff00ff7f^[opacity:192",
+	},
+	inventory_image = "default_water.png^[colorize:#00ff007f",
+	wield_image = "default_water.png^[colorize:#00ff007f",
+	use_texture_alpha = "blend",
+
+	groups = { dig_immediate = 3 },
+})

--- a/games/devtest/mods/testnodes/textures.lua
+++ b/games/devtest/mods/testnodes/textures.lua
@@ -63,6 +63,21 @@ for a=1,#alphas do
 
 		groups = { dig_immediate = 3 },
 	})
+
+	-- Allfaces nodes with transparency
+	minetest.register_node("testnodes:allfaces_alpha_"..alpha, {
+		description = S("Allfaces alpha Test Node (@1)", alpha),
+		drawtype = "allfaces",
+		paramtype = "light",
+		tiles = {
+			"testnodes_alpha.png^[colorize:#ff00007f^[opacity:" .. alpha,
+		},
+		inventory_image = "testnodes_alpha.png^[colorize:#ff00007f",
+		wield_image = "testnodes_alpha.png^[colorize:#ff00007f",
+		use_texture_alpha = "blend",
+
+		groups = { dig_immediate = 3 },
+	})
 end
 
 -- Generate PNG textures

--- a/games/devtest/mods/testnodes/textures.lua
+++ b/games/devtest/mods/testnodes/textures.lua
@@ -72,8 +72,6 @@ for a=1,#alphas do
 		tiles = {
 			"testnodes_alpha.png^[colorize:#ff00007f^[opacity:" .. alpha,
 		},
-		inventory_image = "testnodes_alpha.png^[colorize:#ff00007f",
-		wield_image = "testnodes_alpha.png^[colorize:#ff00007f",
 		use_texture_alpha = "blend",
 
 		groups = { dig_immediate = 3 },

--- a/games/devtest/mods/testnodes/textures.lua
+++ b/games/devtest/mods/testnodes/textures.lua
@@ -155,20 +155,21 @@ minetest.register_node("testnodes:generated_png_ck", {
 })
 
 -- Colored water
-minetest.register_node("testnodes:multitile_liquid", {
+minetest.register_node("testnodes:6sides_liquid", {
 	description = S("Multiple Tiles Liquid Test Node"),
 	drawtype = "liquid",
 	waving = 3,
 	tiles = {
-		"default_water.png^[colorize:#ff00007f^[opacity:192",
-		"default_water.png^[colorize:#00ffff7f^[opacity:192",
-		"default_water.png^[colorize:#0000ff7f^[opacity:192",
-		"default_water.png^[colorize:#ffff007f^[opacity:192",
-		"default_water.png^[colorize:#00ff007f^[opacity:192",
-		"default_water.png^[colorize:#ff00ff7f^[opacity:192",
+		"testnodes_normal1.png^[opacity:192",
+		"testnodes_normal2.png^[opacity:192",
+		"testnodes_normal3.png^[opacity:192",
+		"testnodes_normal4.png^[opacity:192",
+		"testnodes_normal5.png^[opacity:192",
+		"testnodes_normal6.png^[opacity:192",
 	},
 	use_texture_alpha = "blend",
 	paramtype = "light",
 	walkable = false,
 	groups = { water = 3, liquid = 3, dig_immediate = 3 },
 })
+minetest.register_alias("testnodes:multitile_liquid", "testnodes:6sides_liquid")

--- a/games/devtest/mods/testnodes/textures.lua
+++ b/games/devtest/mods/testnodes/textures.lua
@@ -160,16 +160,15 @@ minetest.register_node("testnodes:6sides_liquid", {
 	drawtype = "liquid",
 	waving = 3,
 	tiles = {
-		"testnodes_normal1.png^[opacity:192",
-		"testnodes_normal2.png^[opacity:192",
-		"testnodes_normal3.png^[opacity:192",
-		"testnodes_normal4.png^[opacity:192",
-		"testnodes_normal5.png^[opacity:192",
-		"testnodes_normal6.png^[opacity:192",
+		"testnodes_normal1.png^[colorize:#4040FF80^[opacity:192",
+		"testnodes_normal2.png^[colorize:#4040FF80^[opacity:192",
+		"testnodes_normal3.png^[colorize:#4040FF80^[opacity:192",
+		"testnodes_normal4.png^[colorize:#4040FF80^[opacity:192",
+		"testnodes_normal5.png^[colorize:#4040FF80^[opacity:192",
+		"testnodes_normal6.png^[colorize:#4040FF80^[opacity:192",
 	},
 	use_texture_alpha = "blend",
 	paramtype = "light",
 	walkable = false,
 	groups = { water = 3, liquid = 3, dig_immediate = 3 },
 })
-minetest.register_alias("testnodes:multitile_liquid", "testnodes:6sides_liquid")

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -223,7 +223,7 @@ void ClientMap::updateDrawList()
 	if (g_settings->getBool("free_move") && g_settings->getBool("noclip")) {
 		MapNode n = getNode(cam_pos_nodes);
 		if (n.getContent() == CONTENT_IGNORE ||
-				m_nodedef->get(n).solidness == 2)
+				m_nodedef->get(n).solidness == SOLIDNESS_SOLID)
 			occlusion_culling_enabled = false;
 	}
 
@@ -686,7 +686,7 @@ void ClientMap::renderPostFx(CameraMode cam_mode)
 	// - Do not if player is in third person mode
 	const ContentFeatures& features = m_nodedef->get(n);
 	video::SColor post_effect_color = features.post_effect_color;
-	if(features.solidness == 2 && !(g_settings->getBool("noclip") &&
+	if(features.solidness == SOLIDNESS_SOLID && !(g_settings->getBool("noclip") &&
 			m_client->checkLocalPrivilege("noclip")) &&
 			cam_mode == CAMERA_MODE_FIRST)
 	{

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -914,8 +914,8 @@ static bool hasTransparency(scene::IMesh *mesh)
 		irr::scene::IMeshBuffer *buffer = mesh->getMeshBuffer(i);
 
 		if (buffer->getVertexCount() > 0 &&
-				(buffer->getMaterial().MaterialType == video::EMT_TRANSPARENT_ALPHA_CHANNEL ||
-				 buffer->getMaterial().MaterialType == video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF)) {
+				buffer->getMaterial().MaterialType != video::EMT_SOLID &&
+				buffer->getMaterial().MaterialType != video::EMT_SOLID_2_LAYER) {
 			return true;
 		}
 	}

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -905,23 +905,6 @@ void ClientMap::updateDrawListShadow(const v3f &shadow_light_pos, const v3f &sha
 	g_profiler->avg("SHADOW MapBlocks loaded [#]", blocks_loaded);
 }
 
-static bool hasTransparency(scene::IMesh *mesh)
-{
-	if (mesh == nullptr)
-		return false;
-
-	for (u32 i = 0; i < mesh->getMeshBufferCount(); i++) {
-		irr::scene::IMeshBuffer *buffer = mesh->getMeshBuffer(i);
-
-		if (buffer->getVertexCount() > 0 &&
-				buffer->getMaterial().MaterialType != video::EMT_SOLID &&
-				buffer->getMaterial().MaterialType != video::EMT_SOLID_2_LAYER) {
-			return true;
-		}
-	}
-	return false;
-}
-
 void ClientMap::markBlocksDirty(v3s16 current_node, v3s16 current_block, v3s16 previous_block)
 {
 	v3s16 p_blocks_min;
@@ -958,9 +941,9 @@ void ClientMap::markBlocksDirty(v3s16 current_node, v3s16 current_block, v3s16 p
 				++blocks_on_axis;
 
 				// if there is known transparency
-				if (block_pos.getDistanceFromSQ(current_block) < 100) {
+				if (abs(block_pos.X - current_block.X) + abs(block_pos.Y - current_block.Y) + abs(block_pos.Z - current_block.Z) < 10) {
 					++blocks_in_distance;
-					if (block->mesh && hasTransparency(block->mesh->getMesh())) {
+					if (block->mesh && block->mesh->hasTransparency()) {
 						if (block->getNeedsRemesh()) {
 							++blocks_skipped;
 						}

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -898,7 +898,7 @@ void ClientMap::queueBlocksForRemesh()
 	// Update block meshes if the blocks are marked dirty by camera movement
 	for (auto it = m_drawlist.rbegin(); it != m_drawlist.rend(); it++) {
 		MapBlock* block = it->second;
-		if (block->getNeedsRemesh()) {
+		if (block->needsRemesh()) {
 			block->setNeedsRemesh(false);
 			m_client->addUpdateMeshTask(block->getPos());
 			++blocks_queued;
@@ -958,7 +958,7 @@ void ClientMap::markBlocksDirty(v3s16 current_node, v3s16 previous_node, v3s16 c
 					if (block_distance < 10) {
 						++blocks_in_distance;
 						if (block->mesh && block->mesh->hasTransparency()) {
-							if (block->getNeedsRemesh()) {
+							if (block->needsRemesh()) {
 								++blocks_skipped;
 							}
 							else {

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -281,22 +281,10 @@ void ClientMap::updateDrawList()
 
 	}
 
-	u16 blocks_queued = 0;
-	// Update block meshes if the blocks are marked dirty by camera movement
-	for (auto it = m_drawlist.rbegin(); it != m_drawlist.rend(); it++) {
-		MapBlock* block = it->second;
-		if (block->getNeedsRemesh()) {
-			block->setNeedsRemesh(false);
-			m_client->addUpdateMeshTask(block->getPos());
-			++blocks_queued;
-		}
-	}
-
 	g_profiler->avg("MapBlock meshes in range [#]", blocks_in_range_with_mesh);
 	g_profiler->avg("MapBlocks occlusion culled [#]", blocks_occlusion_culled);
 	g_profiler->avg("MapBlocks drawn [#]", m_drawlist.size());
 	g_profiler->avg("MapBlocks loaded [#]", blocks_loaded);
-	g_profiler->avg("MapBlocks queued for remesh [#]", blocks_queued);
 }
 
 void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
@@ -902,6 +890,22 @@ void ClientMap::updateDrawListShadow(const v3f &shadow_light_pos, const v3f &sha
 	g_profiler->avg("SHADOW MapBlocks occlusion culled [#]", blocks_occlusion_culled);
 	g_profiler->avg("SHADOW MapBlocks drawn [#]", m_drawlist_shadow.size());
 	g_profiler->avg("SHADOW MapBlocks loaded [#]", blocks_loaded);
+}
+
+void ClientMap::queueBlocksForRemesh()
+{
+	u16 blocks_queued = 0;
+	// Update block meshes if the blocks are marked dirty by camera movement
+	for (auto it = m_drawlist.rbegin(); it != m_drawlist.rend(); it++) {
+		MapBlock* block = it->second;
+		if (block->getNeedsRemesh()) {
+			block->setNeedsRemesh(false);
+			m_client->addUpdateMeshTask(block->getPos());
+			++blocks_queued;
+		}
+	}
+
+	g_profiler->avg("MapBlocks queued for remesh [#]", blocks_queued);
 }
 
 void ClientMap::markBlocksDirty(v3s16 current_node, v3s16 previous_node, v3s16 current_block, v3s16 previous_block)

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -149,6 +149,9 @@ public:
 
 	void renderPostFx(CameraMode cam_mode);
 
+	// queue dirty blocks in the draw list for remesh
+	void queueBlocksForRemesh();
+
 	// For debug printing
 	virtual void PrintInfo(std::ostream &out);
 

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -101,7 +101,7 @@ public:
 
 		// if moved over node boundary
 		if (current_node != previous_node)
-			markBlocksDirty(current_node, current_block, previous_block);
+			markBlocksDirty(current_node, previous_node, current_block, previous_block);
 
 		// reorder the blocks when camera crosses block boundary
 		if (previous_block != current_block)
@@ -198,5 +198,5 @@ private:
 	bool m_cache_anistropic_filter;
 	bool m_added_to_shadow_renderer{false};
 
-	void markBlocksDirty(v3s16 current_node, v3s16 current_block, v3s16 previous_block);
+	void markBlocksDirty(v3s16 current_node, v3s16 previous_node, v3s16 current_block, v3s16 previous_block);
 };

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include "map.h"
 #include "camera.h"
+#include "profiler.h"
 #include <set>
 #include <map>
 
@@ -87,7 +88,7 @@ public:
 
 	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset)
 	{
-		v3s16 previous_node = floatToInt(m_camera_position, BS) + m_camera_offset;
+		v3s16 previous_node = floatToInt(m_camera_position, BS);
 		v3s16 previous_block = getContainerPos(previous_node, MAP_BLOCKSIZE);
 
 		m_camera_position = pos;
@@ -95,7 +96,7 @@ public:
 		m_camera_fov = fov;
 		m_camera_offset = offset;
 
-		v3s16 current_node = floatToInt(m_camera_position, BS) + m_camera_offset;
+		v3s16 current_node = floatToInt(m_camera_position, BS);
 		v3s16 current_block = getContainerPos(current_node, MAP_BLOCKSIZE);
 
 		// if moved over node boundary

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -86,27 +86,7 @@ public:
 		ISceneNode::drop();
 	}
 
-	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset)
-	{
-		v3s16 previous_node = floatToInt(m_camera_position, BS);
-		v3s16 previous_block = getContainerPos(previous_node, MAP_BLOCKSIZE);
-
-		m_camera_position = pos;
-		m_camera_direction = dir;
-		m_camera_fov = fov;
-		m_camera_offset = offset;
-
-		v3s16 current_node = floatToInt(m_camera_position, BS);
-		v3s16 current_block = getContainerPos(current_node, MAP_BLOCKSIZE);
-
-		// if moved over node boundary
-		if (current_node != previous_node)
-			markBlocksDirty(current_node, previous_node, current_block, previous_block);
-
-		// reorder the blocks when camera crosses block boundary
-		if (previous_block != current_block)
-			m_needs_update_drawlist = true;
-	}
+	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset);
 
 	/*
 		Forcefully get a sector from somewhere

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -87,14 +87,20 @@ public:
 
 	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset)
 	{
-		v3s16 previous_block = getContainerPos(floatToInt(m_camera_position, BS) + m_camera_offset, MAP_BLOCKSIZE);
+		v3s16 previous_node = floatToInt(m_camera_position, BS) + m_camera_offset;
+		v3s16 previous_block = getContainerPos(previous_node, MAP_BLOCKSIZE);
 
 		m_camera_position = pos;
 		m_camera_direction = dir;
 		m_camera_fov = fov;
 		m_camera_offset = offset;
 
-		v3s16 current_block = getContainerPos(floatToInt(m_camera_position, BS) + m_camera_offset, MAP_BLOCKSIZE);
+		v3s16 current_node = floatToInt(m_camera_position, BS) + m_camera_offset;
+		v3s16 current_block = getContainerPos(current_node, MAP_BLOCKSIZE);
+
+		// if moved over node boundary
+		if (current_node != previous_node)
+			markBlocksDirty(current_node, current_block, previous_block);
 
 		// reorder the blocks when camera crosses block boundary
 		if (previous_block != current_block)
@@ -190,4 +196,6 @@ private:
 	bool m_cache_bilinear_filter;
 	bool m_cache_anistropic_filter;
 	bool m_added_to_shadow_renderer{false};
+
+	void markBlocksDirty(v3s16 current_node, v3s16 current_block, v3s16 previous_block);
 };

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -415,12 +415,19 @@ void MapblockMeshGenerator::prepareLiquidNodeDrawing()
 	MapNode nbottom = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(p.X, p.Y - 1, p.Z));
 	c_flowing = f->liquid_alternative_flowing_id;
 	c_source = f->liquid_alternative_source_id;
+	top_is_drawable = false;
 	top_is_same_liquid = (ntop.getContent() == c_flowing) || (ntop.getContent() == c_source);
 	draw_liquid_bottom = (nbottom.getContent() != c_flowing) && (nbottom.getContent() != c_source);
 	if (draw_liquid_bottom) {
 		const ContentFeatures &f2 = nodedef->get(nbottom.getContent());
-		if (f2.solidness > 1)
+		if (f2.solidness > 1 || (f2.solidness == 0 && f2.visual_solidness == 1))
 			draw_liquid_bottom = false;
+	}
+	if (!top_is_same_liquid) {
+		const ContentFeatures &f2 = nodedef->get(ntop.getContent());
+		if (f2.solidness > 1 || (f2.solidness == 0 && f2.visual_solidness == 1)) {
+			top_is_drawable = true;
+		}
 	}
 
 	if (data->m_smooth_lighting)
@@ -559,7 +566,8 @@ void MapblockMeshGenerator::drawLiquidSides()
 
 		const ContentFeatures &neighbor_features = nodedef->get(neighbor.content);
 		// Don't draw face if neighbor is blocking the view
-		if (neighbor_features.solidness == 2)
+		if (neighbor_features.solidness == 2 ||
+				(neighbor_features.solidness == 0 && neighbor_features.visual_solidness == 1))
 			continue;
 
 		video::S3DVertex vertices[4];
@@ -606,7 +614,7 @@ void MapblockMeshGenerator::drawLiquidTop()
 	for (int i = 0; i < 4; i++) {
 		int u = corner_resolve[i][0];
 		int w = corner_resolve[i][1];
-		vertices[i].Pos.Y += corner_levels[w][u];
+		vertices[i].Pos.Y += corner_levels[w][u] - 1E-4; // make it slightly lower to avoid Z-buffer fight
 		if (data->m_smooth_lighting)
 			vertices[i].Color = blendLightColor(vertices[i].Pos);
 		vertices[i].Pos += origin;
@@ -662,7 +670,7 @@ void MapblockMeshGenerator::drawLiquidNode()
 	getLiquidNeighborhood();
 	calculateCornerLevels();
 	drawLiquidSides();
-	if (!top_is_same_liquid)
+	if (!top_is_same_liquid && !top_is_drawable)
 		drawLiquidTop();
 	if (draw_liquid_bottom)
 		drawLiquidBottom();
@@ -1462,7 +1470,6 @@ void MapblockMeshGenerator::drawNode()
 	switch (f->drawtype) {
 		case NDT_NORMAL:   // Drawn by MapBlockMesh
 		case NDT_AIRLIKE:  // Not drawn at all
-		case NDT_LIQUID:   // Drawn by MapBlockMesh
 			return;
 		default:
 			break;
@@ -1473,6 +1480,7 @@ void MapblockMeshGenerator::drawNode()
 	else
 		light = LightPair(getInteriorLight(n, 1, nodedef));
 	switch (f->drawtype) {
+		case NDT_LIQUID:
 		case NDT_FLOWINGLIQUID:     drawLiquidNode(); break;
 		case NDT_GLASSLIKE:         drawGlasslikeNode(); break;
 		case NDT_GLASSLIKE_FRAMED:  drawGlasslikeFramedNode(); break;

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -138,7 +138,7 @@ void MapblockMeshGenerator::drawQuad(v3f *coords, const v3s16 &normal,
 			applyFacesShading(vertices[j].Color, normal2);
 		vertices[j].TCoords = tcoords[j];
 	}
-	collector->append(tile, vertices, 4, quad_indices, 6);
+	collector->append(tile, p, vertices, 4, quad_indices, 6);
 }
 
 // Create a cuboid.

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1621,7 +1621,7 @@ void MapblockMeshGenerator::generate()
 	// with each iteration, the bubble around the player will shrink
 
 	// loop over layers
-	for (u16 base_a = 0; base_a <= nlayers; ++base_a) {
+	for (u16 base_a = 0; base_a <= nlayers + 1; ++base_a) {
 		collector->startNewMeshLayer();
 		for (s16 i = 7; i >= 0; --i) {                        // loop over octants
 

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -421,7 +421,7 @@ void MapblockMeshGenerator::prepareLiquidNodeDrawing()
 	draw_liquid_bottom = (nbottom.getContent() != c_flowing) && (nbottom.getContent() != c_source);
 	if (draw_liquid_bottom) {
 		const ContentFeatures &f2 = nodedef->get(nbottom.getContent());
-		if (f2.solidness > 1)
+		if (f2.solidness > SOLIDNESS_LIQUID)
 			draw_liquid_bottom = false;
 	}
 
@@ -561,7 +561,7 @@ void MapblockMeshGenerator::drawLiquidSides()
 
 		const ContentFeatures &neighbor_features = nodedef->get(neighbor.content);
 		// Don't draw face if neighbor is blocking the view
-		if (neighbor_features.solidness == 2)
+		if (neighbor_features.solidness == SOLIDNESS_SOLID)
 			continue;
 
 		video::S3DVertex vertices[4];
@@ -715,7 +715,7 @@ void MapblockMeshGenerator::drawLiquidSourceNode()
 		if (f->solidness <= neighbor_features.solidness)
 			continue;
 
-		bool apply_backface_culling = neighbor_features.solidness == 1 || neighbor_features.visual_solidness == 1;
+		bool apply_backface_culling = neighbor_features.solidness >= SOLIDNESS_TRANSPARENT;
 
 		s16 distance = manhattanDistance(player_pos, neighbor_pos);
 

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1567,6 +1567,9 @@ void MapblockMeshGenerator::generate()
 	}
 
 
+	// detect transparent nodes
+	bool has_transparency = false;
+
 	// draw each octant in layers by constant manhatan distance, starting from the most distant
 	// with each iteration, the bubble around the player will shrink
 
@@ -1602,10 +1605,14 @@ void MapblockMeshGenerator::generate()
 
 				n = data->m_vmanip.getNodeNoEx(blockpos_nodes + p);
 				f = &nodedef->get(n);
+				if (f->alpha == ALPHAMODE_BLEND) {
+					has_transparency = true;
+				}
 				drawNode();
 			}
 		}
 	}
+	data->m_has_transparency = has_transparency;
 }
 
 void MapblockMeshGenerator::renderSingle(content_t node, u8 param2)

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -719,7 +719,15 @@ void MapblockMeshGenerator::drawLiquidSourceNode()
 					vertex.rotateXZBy(-90); break;
 			}
 		}
-		useTile(face, 0, face == 1 || face == 4 ? MATERIAL_FLAG_BACKFACE_CULLING : 0);
+
+		getTile(g_6dirs[face], &tile);
+		if (!data->m_smooth_lighting)
+			color = encode_light(light, f->light_source);
+		if (face == 1 || face == 4) {
+			tile.layers[0].material_flags &= ~MATERIAL_FLAG_BACKFACE_CULLING;
+			tile.layers[1].material_flags &= ~MATERIAL_FLAG_BACKFACE_CULLING;
+		}
+
 		drawQuad(vertices, dir);
 	}
 }

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -670,6 +670,10 @@ void MapblockMeshGenerator::drawLiquidNode()
 
 void MapblockMeshGenerator::drawLiquidSourceNode()
 {
+	// Skip rendering since this node was already rendered by fast faces.
+	if (f->alpha == ALPHAMODE_OPAQUE)
+		return;
+
 	for (int face = 0; face < 6; face++) {
 		// Check this neighbor
 		v3s16 dir = g_6dirs[face];

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -565,8 +565,9 @@ void MapblockMeshGenerator::drawLiquidSides()
 		}
 
 		const ContentFeatures &neighbor_features = nodedef->get(neighbor.content);
-		// Don't draw face if neighbor is blocking the view
+		// Don't draw face if neighbor is drawable or ignore (map block not loaded yet)
 		if (neighbor_features.solidness == 2 ||
+				neighbor.content == CONTENT_IGNORE ||
 				(neighbor_features.solidness == 0 && neighbor_features.visual_solidness == 1))
 			continue;
 

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -421,9 +421,7 @@ void MapblockMeshGenerator::prepareLiquidNodeDrawing()
 	draw_liquid_bottom = (nbottom.getContent() != c_flowing) && (nbottom.getContent() != c_source);
 	if (draw_liquid_bottom) {
 		const ContentFeatures &f2 = nodedef->get(nbottom.getContent());
-
-		// use 1 == solidness of liquid source because own solidness is 0
-		if (f2.solidness > 1 || (f2.solidness == 0 && f2.visual_solidness == 1))
+		if (f2.solidness > 1)
 			draw_liquid_bottom = false;
 	}
 
@@ -563,9 +561,7 @@ void MapblockMeshGenerator::drawLiquidSides()
 
 		const ContentFeatures &neighbor_features = nodedef->get(neighbor.content);
 		// Don't draw face if neighbor is blocking the view
-		// Use 1 == solidness of liquid source, because own solidness is 0
-		if (neighbor_features.solidness > 1 ||
-				(neighbor_features.solidness == 0 && neighbor_features.visual_solidness == 1))
+		if (neighbor_features.solidness == 2)
 			continue;
 
 		video::S3DVertex vertices[4];

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1553,37 +1553,40 @@ void MapblockMeshGenerator::generate()
 	// draw each octant in layers by constant manhatan distance, starting from the most distant
 	// with each iteration, the bubble around the player will shrink
 
-	for (u16 base_a = 0; base_a <= nlayers; ++base_a)     // loop over layers
-	for (s16 i = 7; i >= 0; --i) {                        // loop over octants
+	// loop over layers
+	for (u16 base_a = 0; base_a <= nlayers; ++base_a) {
+		collector->startNewMeshLayer();
+		for (s16 i = 7; i >= 0; --i) {                        // loop over octants
 
-		struct octant *octant = octants + i;
-		struct boundary *boundary = bounds + i;
+			struct octant *octant = octants + i;
+			struct boundary *boundary = bounds + i;
 
-		// offset layer to create bubble around the player
-		s16 a = base_a + octant->distance - nlayers;
-		if (a < 0)
-			continue;
-
-		// b and c are layer's x and y
-		for (u16 b = 0; b <= a; ++b)
-		for (u16 c = 0; c <= (a - b); ++c) {
-
-			// translate into world coordinates and clip
-			p.X = octant->origin.X + (a - b - c) * octant->increment.X;
-			if (p.X < boundary->min.X || p.X > boundary->max.X)
+			// offset layer to create bubble around the player
+			s16 a = base_a + octant->distance - nlayers;
+			if (a < 0)
 				continue;
 
-			p.Z = octant->origin.Z + b * octant->increment.Z;
-			if (p.Z < boundary->min.Z || p.Z > boundary->max.Z)
-				continue;
+			// b and c are layer's x and y
+			for (u16 b = 0; b <= a; ++b)
+			for (u16 c = 0; c <= (a - b); ++c) {
 
-			p.Y = octant->origin.Y + c * octant->increment.Y;
-			if (p.Y < boundary->min.Y || p.Y > boundary->max.Y)
-				continue;
+				// translate into world coordinates and clip
+				p.X = octant->origin.X + (a - b - c) * octant->increment.X;
+				if (p.X < boundary->min.X || p.X > boundary->max.X)
+					continue;
 
-			n = data->m_vmanip.getNodeNoEx(blockpos_nodes + p);
-			f = &nodedef->get(n);
-			drawNode();
+				p.Z = octant->origin.Z + b * octant->increment.Z;
+				if (p.Z < boundary->min.Z || p.Z > boundary->max.Z)
+					continue;
+
+				p.Y = octant->origin.Y + c * octant->increment.Y;
+				if (p.Y < boundary->min.Y || p.Y > boundary->max.Y)
+					continue;
+
+				n = data->m_vmanip.getNodeNoEx(blockpos_nodes + p);
+				f = &nodedef->get(n);
+				drawNode();
+			}
 		}
 	}
 }

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -687,7 +687,7 @@ void MapblockMeshGenerator::drawLiquidSourceNode()
 		facePointer(int index, int distance, bool apply_backface_culling) : 
 				face(index), distance(distance), apply_backface_culling(apply_backface_culling) {}
 
-		bool operator<(const struct facePointer& other) {
+		bool operator<(const struct facePointer& other) const {
 			return distance > other.distance || (distance == other.distance && face > other.face);
 		}
 	};

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -716,7 +716,7 @@ void MapblockMeshGenerator::drawLiquidSourceNode()
 
 		bool apply_backface_culling = neighbor_features.solidness >= SOLIDNESS_TRANSPARENT;
 
-		s16 distance = manhattanDistance(player_pos, neighbor_pos);
+		s16 distance = manhattanDistance(camera_pos, neighbor_pos);
 
 		faces.emplace_back(face, distance, apply_backface_culling);
 	}
@@ -1603,12 +1603,12 @@ void MapblockMeshGenerator::drawNode()
 
 void MapblockMeshGenerator::generate()
 {
-	player_pos = floatToInt(data->m_camera_position, BS);
+	camera_pos = floatToInt(data->m_camera_position, BS);
 
 	v3s16 player = v3s16(
-		core::clamp(player_pos.X - blockpos_nodes.X, -1, MAP_BLOCKSIZE),
-		core::clamp(player_pos.Y - blockpos_nodes.Y, -1, MAP_BLOCKSIZE),
-		core::clamp(player_pos.Z - blockpos_nodes.Z, -1, MAP_BLOCKSIZE));
+		core::clamp(camera_pos.X - blockpos_nodes.X, -1, MAP_BLOCKSIZE),
+		core::clamp(camera_pos.Y - blockpos_nodes.Y, -1, MAP_BLOCKSIZE),
+		core::clamp(camera_pos.Z - blockpos_nodes.Z, -1, MAP_BLOCKSIZE));
 
 	s16 s = MAP_BLOCKSIZE - 1;
 
@@ -1670,8 +1670,8 @@ void MapblockMeshGenerator::generate()
 		collector->startNewMeshLayer();
 		for (s16 i = 7; i >= 0; --i) {                        // loop over octants
 
-			struct octant &octant = octants[i];
-			struct boundary &boundary = bounds[i];
+			const octant &octant = octants[i];
+			const boundary &boundary = bounds[i];
 
 			// offset layer to create bubble around the player
 			s16 a = base_a + octant.distance - nlayers - ((i == 0) & 1);

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1483,6 +1483,9 @@ void MapblockMeshGenerator::drawNodeboxNode()
 		}
 	}
 
+	if (f->alpha == ALPHAMODE_BLEND)
+		collector->startNewMeshLayer(false);
+
 	std::vector<aabb3f> boxes;
 	n.getNodeBoxes(nodedef, &boxes, neighbors_set);
 	for (auto &box : boxes)

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -32,7 +32,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/renderingengine.h"
 #include "client.h"
 #include "noise.h"
-#include "camera.h"
 
 // Distance of light extrapolation (for oversized nodes)
 // After this distance, it gives up and considers light level constant
@@ -1604,7 +1603,7 @@ void MapblockMeshGenerator::drawNode()
 
 void MapblockMeshGenerator::generate()
 {
-	player_pos = floatToInt(data->m_client->getCamera()->getPosition(), BS);
+	player_pos = floatToInt(data->m_camera_position, BS);
 
 	v3s16 player = v3s16(
 		core::clamp(player_pos.X - blockpos_nodes.X, -1, MAP_BLOCKSIZE),

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -408,8 +408,16 @@ void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box, const f32 *txc,
 
 void MapblockMeshGenerator::prepareLiquidNodeDrawing()
 {
-	getSpecialTile(0, &tile_liquid_top);
-	getSpecialTile(1, &tile_liquid);
+	if (f->drawtype == NDT_FLOWINGLIQUID)
+	{
+		getSpecialTile(0, &tile_liquid_top);
+		getSpecialTile(1, &tile_liquid);
+	}
+	else
+	{
+		getTile(0, &tile_liquid_top);
+		getTile(0, &tile_liquid);
+	}
 
 	MapNode ntop = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(p.X, p.Y + 1, p.Z));
 	MapNode nbottom = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(p.X, p.Y - 1, p.Z));
@@ -567,8 +575,8 @@ void MapblockMeshGenerator::drawLiquidSides()
 		const ContentFeatures &neighbor_features = nodedef->get(neighbor.content);
 		// Don't draw face if neighbor is drawable or ignore (map block not loaded yet)
 		if (neighbor_features.solidness == 2 ||
-				neighbor.content == CONTENT_IGNORE ||
-				(neighbor_features.solidness == 0 && neighbor_features.visual_solidness == 1))
+				neighbor.content == CONTENT_IGNORE /* ||
+				(neighbor_features.solidness == 0 && neighbor_features.visual_solidness == 1) */)
 			continue;
 
 		video::S3DVertex vertices[4];
@@ -578,8 +586,8 @@ void MapblockMeshGenerator::drawLiquidSides()
 			float v = vertex.v;
 
 			v3f pos;
-			pos.X = (base.X - 0.5f) * BS;
-			pos.Z = (base.Z - 0.5f) * BS;
+			pos.X = (base.X - 0.5f) * BS - face.dir.X * 1E-3;
+			pos.Z = (base.Z - 0.5f) * BS - face.dir.Z * 1E-3;
 			if (vertex.v) {
 				pos.Y = neighbor.is_same_liquid ? corner_levels[base.Z][base.X] : -0.5f * BS;
 			} else if (top_is_same_liquid) {

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1621,7 +1621,7 @@ void MapblockMeshGenerator::generate()
 			struct boundary *boundary = bounds + i;
 
 			// offset layer to create bubble around the player
-			s16 a = base_a + octant->distance - nlayers;
+			s16 a = base_a + octant->distance - nlayers - ((i == 0) & 1);
 			if (a < 0)
 				continue;
 

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -733,7 +733,7 @@ void MapblockMeshGenerator::drawLiquidSourceNode()
 	for (const struct facePointer &fp : faces) {
 
 		if (has_multiple_tiles)
-			collector->startNewMeshLayer(true);
+			collector->startNewMeshLayer(/* allow_reuse */ false);
 
 		v3s16 dir = g_6dirs[fp.face];
 

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -81,7 +81,7 @@ public:
 	video::SColor color;
 	TileSpec tile;
 	float scale;
-	v3s16 player_pos;           // player's position at the time of mesh generation
+	v3s16 camera_pos;           // camera position at the time of mesh generation
 
 // lighting
 	void getSmoothLightFrame();

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -106,7 +106,6 @@ public:
 		TileSpec *tiles = NULL, int tile_count = 0);
 
 // liquid-specific
-    bool top_is_drawable;
 	bool top_is_same_liquid;
 	bool draw_liquid_bottom;
 	TileSpec tile_liquid;
@@ -155,6 +154,7 @@ public:
 
 // drawtypes
 	void drawLiquidNode();
+	void drawLiquidSourceNode();
 	void drawGlasslikeNode();
 	void drawGlasslikeFramedNode();
 	void drawAllfacesNode();

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -81,6 +81,7 @@ public:
 	video::SColor color;
 	TileSpec tile;
 	float scale;
+	v3s16 player_pos;           // player's position at the time of mesh generation
 
 // lighting
 	void getSmoothLightFrame();

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -106,6 +106,7 @@ public:
 		TileSpec *tiles = NULL, int tile_count = 0);
 
 // liquid-specific
+    bool top_is_drawable;
 	bool top_is_same_liquid;
 	bool draw_liquid_bottom;
 	TileSpec tile_liquid;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3901,6 +3901,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 			|| client->getEnv().getClientMap().needsUpdateDrawList()) {
 		runData.update_draw_list_timer = 0;
 		client->getEnv().getClientMap().updateDrawList();
+		client->getEnv().getClientMap().queueBlocksForRemesh();
 		runData.update_draw_list_last_cam_dir = camera_direction;
 	}
 

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -431,7 +431,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		v3s16 camera_np = floatToInt(getEyePosition(), BS);
 		MapNode n = map->getNode(camera_np);
 		if (n.getContent() != CONTENT_IGNORE) {
-			if (nodemgr->get(n).walkable && nodemgr->get(n).solidness == 2)
+			if (nodemgr->get(n).walkable && nodemgr->get(n).solidness == SOLIDNESS_SOLID)
 				camera_barely_in_ceiling = true;
 		}
 	}
@@ -1028,7 +1028,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		v3s16 camera_np = floatToInt(getEyePosition(), BS);
 		MapNode n = map->getNode(camera_np);
 		if (n.getContent() != CONTENT_IGNORE) {
-			if (nodemgr->get(n).walkable && nodemgr->get(n).solidness == 2)
+			if (nodemgr->get(n).walkable && nodemgr->get(n).solidness == SOLIDNESS_SOLID)
 				camera_barely_in_ceiling = true;
 		}
 	}

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1176,6 +1176,7 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 	}
 
 	//std::cout<<"added "<<fastfaces.getSize()<<" faces."<<std::endl;
+	m_has_transparency = data->m_has_transparency;
 
 	// Check if animation is required for this mesh
 	m_has_animation =

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -659,13 +659,27 @@ static u8 face_contents(content_t m1, content_t m2, bool *equivalent,
 	if (c1 == c2)
 		return 0;
 
-	if (c1 == 2)
-		return 1;
-	if (c2 == 2)
-		return 2;
+	if (c1 == 0)
+		c1 = f1.visual_solidness;
+	else if (c2 == 0)
+		c2 = f2.visual_solidness;
 
-	// All non-solid nodes are depth-sorted and handled by MapblockMeshGenerator.
-	return 0;
+	// In all cases, only render face if it is opaque.
+	// All transparency is handled by MapblockMeshGenerator.
+
+	if (c1 == c2) {
+		*equivalent = true;
+		// If same solidness, liquid takes precense
+		if (f1.isLiquid())
+			return f1.alpha == ALPHAMODE_OPAQUE ? 1 : 0;
+		if (f2.isLiquid())
+			return f2.alpha == ALPHAMODE_OPAQUE ? 2 : 0;
+	}
+
+	if (c1 > c2)
+		return f1.drawtype == NDT_NORMAL || f1.drawtype == NDT_PLANTLIKE_ROOTED || f1.alpha == ALPHAMODE_OPAQUE ? 1 : 0;
+
+	return f2.drawtype == NDT_NORMAL || f2.drawtype == NDT_PLANTLIKE_ROOTED || f2.alpha == ALPHAMODE_OPAQUE ? 2 : 0;
 }
 
 /*

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -90,6 +90,11 @@ void MeshMakeData::setSmoothLighting(bool smooth_lighting)
 	m_smooth_lighting = smooth_lighting;
 }
 
+void MeshMakeData::setCameraPosition(v3f camera_position)
+{
+	m_camera_position = camera_position;
+}
+
 /*
 	Light and vertex color functions
 */

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -677,9 +677,9 @@ static u8 face_contents(content_t m1, content_t m2, bool *equivalent,
 	}
 
 	if (c1 > c2)
-		return c1 == SOLIDNESS_SOLID ? 1 : 0;
+		return c1 >= SOLIDNESS_OPAQUE_LIQUID ? 1 : 0;
 
-	return c2 == SOLIDNESS_SOLID ? 2 : 0;
+	return c2 >= SOLIDNESS_OPAQUE_LIQUID ? 2 : 0;
 }
 
 /*

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -182,7 +182,7 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 		if (f.light_source > light_source_max)
 			light_source_max = f.light_source;
 		// Check f.solidness because fast-style leaves look better this way
-		if (f.param_type == CPT_LIGHT && f.solidness != 2) {
+		if (f.param_type == CPT_LIGHT && f.solidness != SOLIDNESS_SOLID) {
 			u8 light_level_day = n.getLightNoChecks(LIGHTBANK_DAY, &f);
 			u8 light_level_night = n.getLightNoChecks(LIGHTBANK_NIGHT, &f);
 			if (light_level_day == LIGHT_SUN)
@@ -659,11 +659,6 @@ static u8 face_contents(content_t m1, content_t m2, bool *equivalent,
 	if (c1 == c2)
 		return 0;
 
-	if (c1 == 0)
-		c1 = f1.visual_solidness;
-	else if (c2 == 0)
-		c2 = f2.visual_solidness;
-
 	// In all cases, only render face if it is opaque.
 	// All transparency is handled by MapblockMeshGenerator.
 
@@ -677,9 +672,9 @@ static u8 face_contents(content_t m1, content_t m2, bool *equivalent,
 	}
 
 	if (c1 > c2)
-		return f1.drawtype == NDT_NORMAL || f1.drawtype == NDT_PLANTLIKE_ROOTED || f1.alpha == ALPHAMODE_OPAQUE ? 1 : 0;
+		return c1 == SOLIDNESS_SOLID ? 1 : 0;
 
-	return f2.drawtype == NDT_NORMAL || f2.drawtype == NDT_PLANTLIKE_ROOTED || f2.alpha == ALPHAMODE_OPAQUE ? 2 : 0;
+	return c2 == SOLIDNESS_SOLID ? 2 : 0;
 }
 
 /*

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -670,9 +670,9 @@ static u8 face_contents(content_t m1, content_t m2, bool *equivalent,
 	if (c1 == c2) {
 		*equivalent = true;
 		// If same solidness, liquid takes precense
-		if (f1.isLiquid())
+		if (f1.drawtype == NDT_LIQUID)
 			return f1.alpha == ALPHAMODE_OPAQUE ? 1 : 0;
-		if (f2.isLiquid())
+		if (f2.drawtype == NDT_LIQUID)
 			return f2.alpha == ALPHAMODE_OPAQUE ? 2 : 0;
 	}
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -659,24 +659,13 @@ static u8 face_contents(content_t m1, content_t m2, bool *equivalent,
 	if (c1 == c2)
 		return 0;
 
-	if (c1 == 0)
-		c1 = f1.visual_solidness;
-	else if (c2 == 0)
-		c2 = f2.visual_solidness;
-
-	if (c1 == c2) {
-		*equivalent = true;
-		// If same solidness, liquid takes precense
-		if (f1.isLiquid())
-			return 1;
-		if (f2.isLiquid())
-			return 2;
-	}
-
-	if (c1 > c2)
+	if (c1 == 2)
 		return 1;
+	if (c2 == 2)
+		return 2;
 
-	return 2;
+	// All non-solid nodes are depth-sorted and handled by MapblockMeshGenerator.
+	return 0;
 }
 
 /*

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -42,6 +42,7 @@ struct MeshMakeData
 	v3s16 m_blockpos = v3s16(-1337,-1337,-1337);
 	v3s16 m_crack_pos_relative = v3s16(-1337,-1337,-1337);
 	bool m_smooth_lighting = false;
+	bool m_has_transparency = false; // true when MapblocMeshGenerator detects transpareny
 
 	Client *m_client;
 	bool m_use_shaders;
@@ -125,6 +126,11 @@ public:
 			m_animation_force_timer--;
 	}
 
+	inline bool hasTransparency()
+	{
+		return m_has_transparency;
+	}
+
 private:
 	scene::IMesh *m_mesh[MAX_TILE_LAYERS];
 	MinimapMapblock *m_minimap_mapblock;
@@ -133,6 +139,9 @@ private:
 
 	bool m_enable_shaders;
 	bool m_enable_vbo;
+
+	// handling transparency detected by MapblockMeshGenerator
+	bool m_has_transparency;
 
 	// Must animate() be called before rendering?
 	bool m_has_animation;

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -41,6 +41,7 @@ struct MeshMakeData
 	VoxelManipulator m_vmanip;
 	v3s16 m_blockpos = v3s16(-1337,-1337,-1337);
 	v3s16 m_crack_pos_relative = v3s16(-1337,-1337,-1337);
+	v3f m_camera_position = v3f(-1337.0f,-1337.0f,-1337.0f);
 	bool m_smooth_lighting = false;
 	bool m_has_transparency = false; // true when MapblocMeshGenerator detects transpareny
 
@@ -70,6 +71,11 @@ struct MeshMakeData
 		Enable or disable smooth lighting
 	*/
 	void setSmoothLighting(bool smooth_lighting);
+
+	/*
+		Set camera position for depth sortings
+	*/
+	void setCameraPosition(v3f camera_position);
 };
 
 /*

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -132,7 +132,7 @@ public:
 			m_animation_force_timer--;
 	}
 
-	inline bool hasTransparency()
+	inline bool hasTransparency() const
 	{
 		return m_has_transparency;
 	}

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client.h"
 #include "mapblock.h"
 #include "map.h"
+#include "camera.h"
 
 /*
 	CachedMapBlockData
@@ -116,6 +117,7 @@ void MeshUpdateQueue::addBlock(Map *map, v3s16 p, bool ack_block_to_server, bool
 				q->ack_block_to_server = true;
 			q->crack_level = m_client->getCrackLevel();
 			q->crack_pos = m_client->getCrackPos();
+			q->camera_pos = m_client->getCamera()->getPosition();
 			return;
 		}
 	}
@@ -128,6 +130,7 @@ void MeshUpdateQueue::addBlock(Map *map, v3s16 p, bool ack_block_to_server, bool
 	q->ack_block_to_server = ack_block_to_server;
 	q->crack_level = m_client->getCrackLevel();
 	q->crack_pos = m_client->getCrackPos();
+	q->camera_pos = m_client->getCamera()->getPosition();
 	m_queue.push_back(q);
 
 	// This queue entry is a new reference to the cached blocks
@@ -228,6 +231,7 @@ void MeshUpdateQueue::fillDataFromMapBlockCache(QueuedMeshUpdate *q)
 
 	data->setCrack(q->crack_level, q->crack_pos);
 	data->setSmoothLighting(m_cache_smooth_lighting);
+	data->setCameraPosition(q->camera_pos);
 }
 
 void MeshUpdateQueue::cleanupCache()

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -42,6 +42,7 @@ struct QueuedMeshUpdate
 	bool ack_block_to_server = false;
 	int crack_level = -1;
 	v3s16 crack_pos;
+	v3f camera_pos;
 	MeshMakeData *data = nullptr; // This is generated in MeshUpdateQueue::pop()
 
 	QueuedMeshUpdate() = default;

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -98,6 +98,11 @@ PreMeshBuffer &MeshCollector::findBuffer(
 				"Mesh can't contain more than 65536 vertices");
 
 	std::vector<PreMeshBuffer> &buffers = prebuffers[layernum];
+
+	// avoid scanning the entire list of buffers when filling with the same material
+	if (latest_buffers[layernum].size() > 0 && buffers[latest_buffers[layernum].back()].layer == layer)
+		return buffers[latest_buffers[layernum].back()];
+
 	for (PreMeshBuffer &p : buffers)
 		if (!p.closed && p.layer == layer && p.vertices.size() + numVertices <= U16_MAX)
 			return p;
@@ -114,9 +119,16 @@ void MeshCollector::startNewMeshLayer()
 		if (latest_buffers[tile_layer].size() == 1)
 			continue;
 
+		s16 latest_buffer = -1;
+		if (latest_buffers[tile_layer].size() > 0)
+			latest_buffer = latest_buffers[tile_layer].back();
+
 		for (s16 index: latest_buffers[tile_layer])
-			prebuffers[tile_layer][index].closed = true;
+			if (index != latest_buffer)
+				prebuffers[tile_layer][index].closed = true;
 
 		latest_buffers[tile_layer].clear();
+		if (latest_buffer != -1)
+			latest_buffers[tile_layer].push_back(latest_buffer);
 	}
 }

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -114,7 +114,7 @@ PreMeshBuffer &MeshCollector::findBuffer(
 	return buffers.back();
 }
 
-void MeshCollector::startNewMeshLayer(bool forceNoReuse)
+void MeshCollector::startNewMeshLayer(bool allow_reuse)
 {
 	for (s16 tile_layer = 0; tile_layer < MAX_TILE_LAYERS; ++tile_layer) {
 		// do not close mesh buffer if there is only one
@@ -122,7 +122,7 @@ void MeshCollector::startNewMeshLayer(bool forceNoReuse)
 			continue;
 
 		s16 latest_buffer = -1;
-		if (!forceNoReuse && latest_buffers[tile_layer].size() > 0)
+		if (allow_reuse && latest_buffers[tile_layer].size() > 0)
 			latest_buffer = latest_buffers[tile_layer].back();
 
 		for (s16 index: latest_buffers[tile_layer])

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -23,32 +23,36 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/mesh.h"
 #include "profiler.h"
 
-void MeshCollector::append(const TileSpec &tile, const video::S3DVertex *vertices,
+void MeshCollector::append(const TileSpec &tile, const v3s16 &pos, const video::S3DVertex *vertices,
 		u32 numVertices, const u16 *indices, u32 numIndices)
 {
 	for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
 		const TileLayer *layer = &tile.layers[layernum];
 		if (layer->texture_id == 0)
 			continue;
-		append(*layer, vertices, numVertices, indices, numIndices, layernum,
+		append(*layer, pos, vertices, numVertices, indices, numIndices, layernum,
 				tile.world_aligned);
 	}
 }
 
-void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *vertices,
+void MeshCollector::append(const TileLayer &layer, const v3s16 &pos, const video::S3DVertex *vertices,
 		u32 numVertices, const u16 *indices, u32 numIndices, u8 layernum,
 		bool use_scale)
 {
 	PreMeshBuffer &p = findBuffer(layer, layernum, numVertices);
 
 	f32 scale = 1.0f;
-	if (use_scale)
+	v2f offset = v2f();
+
+	if (use_scale) {
 		scale = 1.0f / layer.scale;
+		offset = v2f((pos.X) % layer.scale, (-pos.Z) % layer.scale);
+	}
 
 	u32 vertex_count = p.vertices.size();
 	for (u32 i = 0; i < numVertices; i++)
 		p.vertices.emplace_back(vertices[i].Pos, vertices[i].Normal,
-				vertices[i].Color, scale * vertices[i].TCoords);
+				vertices[i].Color, scale * (offset + vertices[i].TCoords));
 
 	for (u32 i = 0; i < numIndices; i++)
 		p.indices.push_back(indices[i] + vertex_count);

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -124,8 +124,14 @@ void MeshCollector::startNewMeshLayer()
 			latest_buffer = latest_buffers[tile_layer].back();
 
 		for (s16 index: latest_buffers[tile_layer])
-			if (index != latest_buffer)
-				prebuffers[tile_layer][index].closed = true;
+			if (index != latest_buffer) {
+				auto &buffer = prebuffers[tile_layer][index];
+				if (buffer.layer.material_type == TILE_MATERIAL_ALPHA ||
+						buffer.layer.material_type == TILE_MATERIAL_PLAIN_ALPHA ||
+						buffer.layer.material_type == TILE_MATERIAL_LIQUID_TRANSPARENT ||
+						buffer.layer.material_type == TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT)
+					prebuffers[tile_layer][index].closed = true;
+			}
 
 		latest_buffers[tile_layer].clear();
 		if (latest_buffer != -1)

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -100,7 +100,9 @@ PreMeshBuffer &MeshCollector::findBuffer(
 	std::vector<PreMeshBuffer> &buffers = prebuffers[layernum];
 
 	// avoid scanning the entire list of buffers when filling with the same material
-	if (latest_buffers[layernum].size() > 0 && buffers[latest_buffers[layernum].back()].layer == layer)
+	if (latest_buffers[layernum].size() > 0 && 
+			buffers[latest_buffers[layernum].back()].layer == layer && 
+			buffers[latest_buffers[layernum].back()].vertices.size() + numVertices <= U16_MAX)
 		return buffers[latest_buffers[layernum].back()];
 
 	for (PreMeshBuffer &p : buffers)

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -114,7 +114,7 @@ PreMeshBuffer &MeshCollector::findBuffer(
 	return buffers.back();
 }
 
-void MeshCollector::startNewMeshLayer()
+void MeshCollector::startNewMeshLayer(bool forceNoReuse)
 {
 	for (s16 tile_layer = 0; tile_layer < MAX_TILE_LAYERS; ++tile_layer) {
 		// do not close mesh buffer if there is only one
@@ -122,7 +122,7 @@ void MeshCollector::startNewMeshLayer()
 			continue;
 
 		s16 latest_buffer = -1;
-		if (latest_buffers[tile_layer].size() > 0)
+		if (!forceNoReuse && latest_buffers[tile_layer].size() > 0)
 			latest_buffer = latest_buffers[tile_layer].back();
 
 		for (s16 index: latest_buffers[tile_layer])

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -49,7 +49,7 @@ struct MeshCollector
 			v3f pos, video::SColor c, u8 light_source);
 	// clang-format on
 
-	void startNewMeshLayer();
+	void startNewMeshLayer(bool forceNoReuse = false);
 private:
 	// clang-format off
 	void append(const TileLayer &material,

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -49,7 +49,7 @@ struct MeshCollector
 			v3f pos, video::SColor c, u8 light_source);
 	// clang-format on
 
-	void startNewMeshLayer(bool forceNoReuse = false);
+	void startNewMeshLayer(bool allow_reuse = true);
 private:
 	// clang-format off
 	void append(const TileLayer &material,

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -65,5 +65,6 @@ private:
 
 	PreMeshBuffer &findBuffer(const TileLayer &layer, u8 layernum, u32 numVertices);
 
-	std::array<std::vector<s16>, MAX_TILE_LAYERS> latest_buffers;
+	std::array<int, MAX_TILE_LAYERS> closed_buffers{};
+	std::array<int, MAX_TILE_LAYERS> latest_buffers{};
 };

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -29,7 +29,7 @@ struct PreMeshBuffer
 	TileLayer layer;
 	std::vector<u16> indices;
 	std::vector<video::S3DVertex> vertices;
-	bool closed;
+	bool closed = false;
 
 	PreMeshBuffer() = default;
 	explicit PreMeshBuffer(const TileLayer &layer) : layer(layer) {}

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -29,6 +29,7 @@ struct PreMeshBuffer
 	TileLayer layer;
 	std::vector<u16> indices;
 	std::vector<video::S3DVertex> vertices;
+	bool closed;
 
 	PreMeshBuffer() = default;
 	explicit PreMeshBuffer(const TileLayer &layer) : layer(layer) {}
@@ -48,6 +49,7 @@ struct MeshCollector
 			v3f pos, video::SColor c, u8 light_source);
 	// clang-format on
 
+	void startNewMeshLayer();
 private:
 	// clang-format off
 	void append(const TileLayer &material,
@@ -62,4 +64,6 @@ private:
 	// clang-format on
 
 	PreMeshBuffer &findBuffer(const TileLayer &layer, u8 layernum, u32 numVertices);
+
+	std::array<std::vector<s16>, MAX_TILE_LAYERS> latest_buffers;
 };

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -40,7 +40,12 @@ struct MeshCollector
 	std::array<std::vector<PreMeshBuffer>, MAX_TILE_LAYERS> prebuffers;
 
 	// clang-format off
-	void append(const TileSpec &material,
+	inline void append(const TileSpec &material,
+			const video::S3DVertex *vertices, u32 numVertices,
+			const u16 *indices, u32 numIndices) {
+		append(material, v3s16(), vertices, numVertices, indices, numIndices);
+	}
+	void append(const TileSpec &material, const v3s16 &pos,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices);
 	void append(const TileSpec &material,
@@ -52,7 +57,7 @@ struct MeshCollector
 	void startNewMeshLayer(bool allow_reuse = true);
 private:
 	// clang-format off
-	void append(const TileLayer &material,
+	void append(const TileLayer &material, const v3s16& pos,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices,
 			u8 layernum, bool use_scale = false);

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -259,6 +259,19 @@ struct TileLayer
 			&& (material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL);
 	}
 
+	bool hasAlpha() const
+	{
+		// The same values that set MaterialType to video::EMT_TRANSPARENT_ALPHA_CHANNEL
+		switch (material_type) {
+		case TILE_MATERIAL_ALPHA:
+		case TILE_MATERIAL_LIQUID_TRANSPARENT:
+		case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
+			return true;
+		}
+
+		return false;
+	}
+
 	// Ordered for size, please do not reorder
 
 	video::ITexture *texture = nullptr;

--- a/src/irr_v3d.h
+++ b/src/irr_v3d.h
@@ -28,3 +28,11 @@ typedef core::vector3d<double> v3d;
 typedef core::vector3d<s16> v3s16;
 typedef core::vector3d<u16> v3u16;
 typedef core::vector3d<s32> v3s32;
+
+// Calculate Manhattan distance between two vectors.
+// This is used in mesh generation to layer transparent nodes correctly
+template<class T>
+int manhattanDistance(const core::vector3d<T>& a, const core::vector3d<T>& b)
+{
+    return abs(a.X - b.X) + abs(a.Y - b.Y) + abs(a.Z - b.Z);
+}

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -485,11 +485,13 @@ public:
 	//// Dynamic remesh
 	////
 
-	inline void setNeedsRemesh(bool value = true) {
+	inline void setNeedsRemesh(bool value = true)
+	{
 		m_needs_remesh = value;
 	}
 
-	inline bool getNeedsRemesh() {
+	inline bool needsRemesh()
+	{
 		return m_needs_remesh;
 	}
 private:

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -480,6 +480,18 @@ public:
 
 	void serializeNetworkSpecific(std::ostream &os);
 	void deSerializeNetworkSpecific(std::istream &is);
+
+	////
+	//// Dynamic remesh
+	////
+
+	inline void setNeedsRemesh(bool value = true) {
+		m_needs_remesh = value;
+	}
+
+	inline bool getNeedsRemesh() {
+		return m_needs_remesh;
+	}
 private:
 	/*
 		Private methods
@@ -609,6 +621,12 @@ private:
 		the list of blocks to be drawn.
 	*/
 	int m_refcount = 0;
+
+	/*
+		Marks a block for remesh next time it is scheduled for drawing.
+		This is to optimize dynamic mesh updates for blocks carrying transparent materials
+	*/
+	bool m_needs_remesh = false;
 };
 
 typedef std::vector<MapBlock*> MapBlockVect;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -330,8 +330,7 @@ void ContentFeatures::reset()
 		Cached stuff
 	*/
 #ifndef SERVER
-	solidness = 2;
-	visual_solidness = 0;
+	solidness = SOLIDNESS_SOLID;
 	backface_culling = true;
 
 #endif
@@ -822,56 +821,50 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 	switch (drawtype) {
 	default:
 	case NDT_NORMAL:
-		solidness = 2;
+		solidness = SOLIDNESS_SOLID;
 		break;
 	case NDT_AIRLIKE:
-		solidness = 0;
+		solidness = SOLIDNESS_AIR;
 		break;
 	case NDT_LIQUID:
 		if (tsettings.opaque_water)
 			alpha = ALPHAMODE_OPAQUE;
-		solidness = 1;
+		solidness = SOLIDNESS_LIQUID;
 		is_liquid = true;
 		break;
 	case NDT_FLOWINGLIQUID:
-		solidness = 0;
+		solidness = SOLIDNESS_LIQUID;
 		if (tsettings.opaque_water)
 			alpha = ALPHAMODE_OPAQUE;
 		is_liquid = true;
 		break;
 	case NDT_GLASSLIKE:
-		solidness = 0;
-		visual_solidness = 1;
+		solidness = alpha == ALPHAMODE_OPAQUE ? SOLIDNESS_SOLID : SOLIDNESS_TRANSPARENT;
 		break;
 	case NDT_GLASSLIKE_FRAMED:
-		solidness = 0;
-		visual_solidness = 1;
+		solidness = alpha == ALPHAMODE_OPAQUE ? SOLIDNESS_SOLID : SOLIDNESS_TRANSPARENT;
 		break;
 	case NDT_GLASSLIKE_FRAMED_OPTIONAL:
-		solidness = 0;
-		visual_solidness = 1;
+		solidness = alpha == ALPHAMODE_OPAQUE ? SOLIDNESS_SOLID : SOLIDNESS_TRANSPARENT;
 		drawtype = tsettings.connected_glass ? NDT_GLASSLIKE_FRAMED : NDT_GLASSLIKE;
 		break;
 	case NDT_ALLFACES:
-		solidness = 0;
-		visual_solidness = 1;
+		solidness = alpha == ALPHAMODE_OPAQUE ? SOLIDNESS_SOLID : SOLIDNESS_TRANSPARENT;
 		break;
 	case NDT_ALLFACES_OPTIONAL:
 		if (tsettings.leaves_style == LEAVES_FANCY) {
 			drawtype = NDT_ALLFACES;
-			solidness = 0;
-			visual_solidness = 1;
+			solidness = alpha == ALPHAMODE_OPAQUE ? SOLIDNESS_SOLID : SOLIDNESS_TRANSPARENT;
 		} else if (tsettings.leaves_style == LEAVES_SIMPLE) {
 			for (u32 j = 0; j < 6; j++) {
 				if (!tdef_spec[j].name.empty())
 					tdef[j].name = tdef_spec[j].name;
 			}
 			drawtype = NDT_GLASSLIKE;
-			solidness = 0;
-			visual_solidness = 1;
+			solidness = alpha == ALPHAMODE_OPAQUE ? SOLIDNESS_SOLID : SOLIDNESS_TRANSPARENT;
 		} else {
 			drawtype = NDT_NORMAL;
-			solidness = 2;
+			solidness = SOLIDNESS_SOLID;
 			for (TileDef &td : tdef)
 				td.name += std::string("^[noalpha");
 		}
@@ -879,16 +872,16 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 			material_type = TILE_MATERIAL_WAVING_LEAVES;
 		break;
 	case NDT_PLANTLIKE:
-		solidness = 0;
+		solidness = SOLIDNESS_OBJECT;
 		if (waving >= 1)
 			material_type = TILE_MATERIAL_WAVING_PLANTS;
 		break;
 	case NDT_FIRELIKE:
-		solidness = 0;
+		solidness = SOLIDNESS_OBJECT;
 		break;
 	case NDT_MESH:
 	case NDT_NODEBOX:
-		solidness = 0;
+		solidness = SOLIDNESS_OBJECT;
 		if (waving == 1) {
 			material_type = TILE_MATERIAL_WAVING_PLANTS;
 		} else if (waving == 2) {
@@ -903,10 +896,10 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 	case NDT_SIGNLIKE:
 	case NDT_FENCELIKE:
 	case NDT_RAILLIKE:
-		solidness = 0;
+		solidness = SOLIDNESS_OBJECT;
 		break;
 	case NDT_PLANTLIKE_ROOTED:
-		solidness = 2;
+		solidness = SOLIDNESS_SOLID;
 		break;
 	}
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -829,7 +829,7 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 	case NDT_LIQUID:
 		if (tsettings.opaque_water)
 			alpha = ALPHAMODE_OPAQUE;
-		solidness = SOLIDNESS_LIQUID;
+		solidness = alpha == ALPHAMODE_OPAQUE ? SOLIDNESS_OPAQUE_LIQUID : SOLIDNESS_LIQUID;
 		is_liquid = true;
 		break;
 	case NDT_FLOWINGLIQUID:

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -243,6 +243,16 @@ enum AlphaMode : u8 {
 	ALPHAMODE_LEGACY_COMPAT, /* means either opaque or clip */
 };
 
+// Solidness is used to decide which faces are drawn between adjacent nodes.
+// Larger values mean more solid node, new entries can be added in between as needed.
+enum Solidness : u8 {
+	SOLIDNESS_AIR,		// air and irlike nodes
+	SOLIDNESS_OBJECT,   // torchlike, fencelike etc.
+	SOLIDNESS_TRANSPARENT, // glasslike, allfaces
+	SOLIDNESS_LIQUID,  // liquids
+	SOLIDNESS_SOLID,   // normal nodes
+};
+
 
 /*
 	Stand-alone definition of a TileSpec (basically a server-side TileSpec)
@@ -293,7 +303,6 @@ struct ContentFeatures
 	// - Currently used for flowing liquids
 	TileSpec special_tiles[CF_SPECIAL_COUNT];
 	u8 solidness; // Used when choosing which face is drawn
-	u8 visual_solidness; // When solidness=0, this tells how it looks like
 	bool backface_culling;
 #endif
 

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -246,7 +246,7 @@ enum AlphaMode : u8 {
 // Solidness is used to decide which faces are drawn between adjacent nodes.
 // Larger values mean more solid node, new entries can be added in between as needed.
 enum Solidness : u8 {
-	SOLIDNESS_AIR,		// air and irlike nodes
+	SOLIDNESS_AIR,		// air and airlike nodes
 	SOLIDNESS_OBJECT,   // torchlike, fencelike etc.
 	SOLIDNESS_TRANSPARENT, // glasslike, allfaces
 	SOLIDNESS_LIQUID,  // liquids

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -250,6 +250,7 @@ enum Solidness : u8 {
 	SOLIDNESS_OBJECT,   // torchlike, fencelike etc.
 	SOLIDNESS_TRANSPARENT, // glasslike, allfaces
 	SOLIDNESS_LIQUID,  // liquids
+	SOLIDNESS_OPAQUE_LIQUID, // liquids without transparency
 	SOLIDNESS_SOLID,   // normal nodes
 };
 


### PR DESCRIPTION
This PR fixes #11119.

I contains the following changes:

* Mapblock meshes are generated 'towards the player' with dynamic precedence of axes.
* When the player moved, mapblocks are scheduled for mesh regeneration as required.
* Mapblock draw list is sorted by distance to the player.

## To do

This PR is Ready for Review.

What could be done:

- [x] Fix rendering of overlapping different transparent materials
- [x] Improve markBlocksDirty to avoid remeshing solid blocks changed by shaders
- [x] Transparent nodes placed in water are not rendered correctly
- [x] Side-by-side different transparent materials still produce artifacts (see comments)
- [x] Add more test nodes to devtest (allfaces and check if multi-faced liquid is there)

## How to test

1. Register a node with this definition:
```
{
    description = "Test",
    drawtype = "allfaces",
    tiles = {"white.png^[opacity:10"},
    inventory_image = "white.png^[opacity:129",
    use_texture_alpha = "blend",
    sunlight_propagates = true,
    walkable = false,
    pointable = false,
    diggable = false,
    floodable = true,
    paramtype = "light",
    air_equivalent = true
}
```
Where `white.png` is a single white pixel.

2. Create a cloud of these nodes.
3. Walk around and inside the cloud

*Expected behavior:* Cloud looks uniform from all directions, there are no significant visual artifacts when moving inside the cloud.

