### PR TITLE
CGUITTFont optimizations

### DIFF
--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -326,7 +326,6 @@ void GUIChatConsole::drawText()
 				tmp->draw(
 					fragment.text,
 					destrect,
-					video::SColor(255, 255, 255, 255),
 					false,
 					false,
 					&AbsoluteClippingRect);

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -588,12 +588,13 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 	core::map<u32, CGUITTGlyphPage*> Render_Map;
 
 	// Start parsing characters.
+	u32 n;
 	uchar32_t previousChar = 0;
 	core::ustring::const_iterator iter(utext);
 	while (!iter.atEnd())
 	{
 		uchar32_t currentChar = *iter;
-		u32 n = getGlyphIndexByChar(currentChar);
+		n = getGlyphIndexByChar(currentChar);
 		bool visible = (Invisible.findFirst(currentChar) == -1);
 		bool lineBreak=false;
 		if (currentChar == L'\r') // Mac or Windows breaks

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -690,11 +690,24 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 			for (size_t i = 0; i < page->render_positions.size(); ++i)
 				page->render_positions[i] -= core::vector2di(shadow_offset, shadow_offset);
 		}
+		// render runs of matching color in batch
+		size_t ibegin;
+		video::SColor colprev;
 		for (size_t i = 0; i < page->render_positions.size(); ++i) {
-			video::SColor col = applied_colors[i];
+			ibegin = i;
+			colprev = applied_colors[i];
+			do
+				++i;
+			while (i < page->render_positions.size() && applied_colors[i] == colprev);
+			core::array<core::vector2di> tmp_positions;
+			core::array<core::recti> tmp_source_rects;
+			tmp_positions.set_pointer(&page->render_positions[ibegin], i - ibegin, false, false); // no copy
+			tmp_source_rects.set_pointer(&page->render_source_rects[ibegin], i - ibegin, false, false);
+			--i;
+
 			if (!use_transparency)
-				col.color |= 0xff000000;
-			Driver->draw2DImage(page->texture, page->render_positions[i], page->render_source_rects[i], clip, col, true);
+				colprev.color |= 0xff000000;
+			Driver->draw2DImageBatch(page->texture, tmp_positions, tmp_source_rects, clip, colprev, true);
 		}
 	}
 }

--- a/src/irrlicht_changes/CGUITTFont.h
+++ b/src/irrlicht_changes/CGUITTFont.h
@@ -199,6 +199,7 @@ namespace gui
 
 			core::array<core::vector2di> render_positions;
 			core::array<core::recti> render_source_rects;
+			core::array<video::SColor> render_colors;
 
 		private:
 			core::array<const SGUITTGlyph*> glyph_to_be_paged;

--- a/src/irrlicht_changes/CGUITTFont.h
+++ b/src/irrlicht_changes/CGUITTFont.h
@@ -270,7 +270,7 @@ namespace gui
 				const core::rect<s32>* clip=0);
 
 			void draw(const EnrichedString& text, const core::rect<s32>& position,
-				video::SColor color, bool hcenter=false, bool vcenter=false,
+				bool hcenter=false, bool vcenter=false,
 				const core::rect<s32>* clip=0);
 
 			//! Returns the dimension of a character produced by this font.

--- a/src/irrlicht_changes/static_text.cpp
+++ b/src/irrlicht_changes/static_text.cpp
@@ -108,16 +108,11 @@ void StaticText::draw()
 					font->getDimension(str.c_str()).Width;
 			}
 
-			//str = colorizeText(BrokenText[i].c_str(), colors, previous_color);
-			//if (!colors.empty())
-			//	previous_color = colors[colors.size() - 1];
-
 #if USE_FREETYPE
 			if (font->getType() == irr::gui::EGFT_CUSTOM) {
 				irr::gui::CGUITTFont *tmp = static_cast<irr::gui::CGUITTFont*>(font);
 				tmp->draw(str,
-					r, previous_color, // FIXME
-					HAlign == EGUIA_CENTER, VAlign == EGUIA_CENTER,
+					r, HAlign == EGUIA_CENTER, VAlign == EGUIA_CENTER,
 					(RestrainTextInside ? &AbsoluteClippingRect : NULL));
 			} else
 #endif


### PR DESCRIPTION
uses batch drawing instead of each glyph individually (as permitted by coloring)

also fixed coloring being messed up if multiple glyph pages are used, since this is a rare case nobody has noticed this for years

## To do

This PR is Ready for Review.
