### PR TITLE
Irrlicht support code maintenance

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -178,11 +178,9 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	g_fontengine = new FontEngine(guienv);
 	FATAL_ERROR_IF(g_fontengine == NULL, "Font engine creation failed.");
 
-#if (IRRLICHT_VERSION_MAJOR >= 1 && IRRLICHT_VERSION_MINOR >= 8) || IRRLICHT_VERSION_MAJOR >= 2
 	// Irrlicht 1.8 input colours
 	skin->setColor(gui::EGDC_EDITABLE, video::SColor(255, 128, 128, 128));
 	skin->setColor(gui::EGDC_FOCUSED_EDITABLE, video::SColor(255, 96, 134, 49));
-#endif
 
 	// Create the menu clouds
 	if (!g_menucloudsmgr)

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1473,11 +1473,8 @@ void GenericCAO::updateAnimation()
 	if (m_animated_meshnode->getAnimationSpeed() != m_animation_speed)
 		m_animated_meshnode->setAnimationSpeed(m_animation_speed);
 	m_animated_meshnode->setTransitionTime(m_animation_blend);
-// Requires Irrlicht 1.8 or greater
-#if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR >= 8) || IRRLICHT_VERSION_MAJOR > 1
 	if (m_animated_meshnode->getLoopMode() != m_animation_loop)
 		m_animated_meshnode->setLoopMode(m_animation_loop);
-#endif
 }
 
 void GenericCAO::updateAnimationSpeed()

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -400,12 +400,7 @@ public:
 };
 
 
-// before 1.8 there isn't a "integer interface", only float
-#if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8)
-typedef f32 SamplerLayer_t;
-#else
 typedef s32 SamplerLayer_t;
-#endif
 
 
 class GameGlobalShaderConstantSetter : public IShaderConstantSetter
@@ -513,38 +508,20 @@ public:
 
 		float eye_position_array[3];
 		v3f epos = m_client->getEnv().getLocalPlayer()->getEyePosition();
-#if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8)
-		eye_position_array[0] = epos.X;
-		eye_position_array[1] = epos.Y;
-		eye_position_array[2] = epos.Z;
-#else
 		epos.getAs3Values(eye_position_array);
-#endif
 		m_eye_position_pixel.set(eye_position_array, services);
 		m_eye_position_vertex.set(eye_position_array, services);
 
 		if (m_client->getMinimap()) {
 			float minimap_yaw_array[3];
 			v3f minimap_yaw = m_client->getMinimap()->getYawVec();
-#if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8)
-			minimap_yaw_array[0] = minimap_yaw.X;
-			minimap_yaw_array[1] = minimap_yaw.Y;
-			minimap_yaw_array[2] = minimap_yaw.Z;
-#else
 			minimap_yaw.getAs3Values(minimap_yaw_array);
-#endif
 			m_minimap_yaw.set(minimap_yaw_array, services);
 		}
 
 		float camera_offset_array[3];
 		v3f offset = intToFloat(m_client->getCamera()->getOffset(), BS);
-#if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8)
-		camera_offset_array[0] = offset.X;
-		camera_offset_array[1] = offset.Y;
-		camera_offset_array[2] = offset.Z;
-#else
 		offset.getAs3Values(camera_offset_array);
-#endif
 		m_camera_offset_pixel.set(camera_offset_array, services);
 		m_camera_offset_vertex.set(camera_offset_array, services);
 

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -197,7 +197,6 @@ static const struct table_key table[] = {
 	DEFINEKEY1(KEY_MODECHANGE, N_("IME Mode Change"))
 	DEFINEKEY1(KEY_APPS, N_("Apps"))
 	DEFINEKEY1(KEY_SLEEP, N_("Sleep"))
-#if !(IRRLICHT_VERSION_MAJOR <= 1 && IRRLICHT_VERSION_MINOR <= 7 && IRRLICHT_VERSION_REVISION < 3)
 	DEFINEKEY1(KEY_OEM_1, "OEM 1") // KEY_OEM_[0-9] and KEY_OEM_102 are assigned to multiple
 	DEFINEKEY1(KEY_OEM_2, "OEM 2") // different chars (on different platforms too) and thus w/o char
 	DEFINEKEY1(KEY_OEM_3, "OEM 3")
@@ -208,7 +207,6 @@ static const struct table_key table[] = {
 	DEFINEKEY1(KEY_OEM_8, "OEM 8")
 	DEFINEKEY1(KEY_OEM_AX, "OEM AX")
 	DEFINEKEY1(KEY_OEM_102, "OEM 102")
-#endif
 	DEFINEKEY1(KEY_ATTN, "Attn")
 	DEFINEKEY1(KEY_CRSEL, "CrSel")
 	DEFINEKEY1(KEY_EXSEL, "ExSel")

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -27,14 +27,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <SAnimatedMesh.h>
 #include <IAnimatedMeshSceneNode.h>
 
-// In Irrlicht 1.8 the signature of ITexture::lock was changed from
-// (bool, u32) to (E_TEXTURE_LOCK_MODE, u32).
-#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 7
-#define MY_ETLM_READ_ONLY true
-#else
-#define MY_ETLM_READ_ONLY video::ETLM_READ_ONLY
-#endif
-
 inline static void applyShadeFactor(video::SColor& color, float factor)
 {
 	color.setRed(core::clamp(core::round32(color.getRed()*factor), 0, 255));

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -294,9 +294,7 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 		}
 		material.setFlag(video::EMF_ANISOTROPIC_FILTER, m_anisotropic_filter);
 		// mipmaps cause "thin black line" artifacts
-#if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR >= 8) || IRRLICHT_VERSION_MAJOR >= 2
 		material.setFlag(video::EMF_USE_MIP_MAPS, false);
-#endif
 		if (m_enable_shaders) {
 			material.setTexture(2, tsrc->getShaderFlagsTexture(false));
 		}

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -1021,11 +1021,7 @@ video::IImage* CGUITTFont::createTextureFromChar(const uchar32_t& ch)
 	video::ITexture* tex = page->texture;
 
 	// Acquire a read-only lock of the corresponding page texture.
-	#if IRRLICHT_VERSION_MAJOR==1 && IRRLICHT_VERSION_MINOR>=8
 	void* ptr = tex->lock(video::ETLM_READ_ONLY);
-	#else
-	void* ptr = tex->lock(true);
-	#endif
 
 	video::ECOLOR_FORMAT format = tex->getColorFormat();
 	core::dimension2du tex_size = tex->getOriginalSize();
@@ -1182,11 +1178,7 @@ core::array<scene::ISceneNode*> CGUITTFont::addTextSceneNode(const wchar_t* text
 				// Now we copy planes corresponding to the letter size.
 				IMeshManipulator* mani = smgr->getMeshManipulator();
 				IMesh* meshcopy = mani->createMeshCopy(shared_plane_ptr_);
-				#if IRRLICHT_VERSION_MAJOR==1 && IRRLICHT_VERSION_MINOR>=8
 				mani->scale(meshcopy, vector3df((f32)letter_size.Width, (f32)letter_size.Height, 1));
-				#else
-				mani->scaleMesh(meshcopy, vector3df((f32)letter_size.Width, (f32)letter_size.Height, 1));
-				#endif
 
 				ISceneNode* current_node = smgr->addMeshSceneNode(meshcopy, parent, -1, current_pos);
 				meshcopy->drop();

--- a/src/irrlicht_changes/CGUITTFont.h
+++ b/src/irrlicht_changes/CGUITTFont.h
@@ -34,7 +34,7 @@
 #include <irrlicht.h>
 #include <ft2build.h>
 #include <vector>
-#include "irrUString.h"
+#include <irrUString.h>
 #include "util/enriched_string.h"
 #include FT_FREETYPE_H
 

--- a/src/irrlicht_changes/static_text.cpp
+++ b/src/irrlicht_changes/static_text.cpp
@@ -246,11 +246,7 @@ void StaticText::setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vert
 }
 
 
-#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 7
-const video::SColor& StaticText::getOverrideColor() const
-#else
 video::SColor StaticText::getOverrideColor() const
-#endif
 {
 	return ColoredText.getDefaultColor();
 }

--- a/src/irrlicht_changes/static_text.h
+++ b/src/irrlicht_changes/static_text.h
@@ -134,11 +134,7 @@ namespace gui
 		virtual void setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical);
 
 		//! Gets the override color
-		#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 7
-		virtual const video::SColor& getOverrideColor() const;
-		#else
 		virtual video::SColor getOverrideColor() const;
-		#endif
 
 		#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR > 8
 		//! Gets the currently used text color

--- a/src/irrlichttypes.h
+++ b/src/irrlichttypes.h
@@ -19,16 +19,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-/* Ensure that <stdint.h> is included before <irrTypes.h>, unless building on
- * MSVC, to address an irrlicht issue: https://sourceforge.net/p/irrlicht/bugs/433/
- *
- * TODO: Decide whether or not we support non-compliant C++ compilers like old
- *       versions of MSCV.  If we do not then <stdint.h> can always be included
- *       regardless of the compiler.
+/*
+ * IrrlichtMt already includes stdint.h in irrTypes.h. This works everywhere
+ * we need it to (including recent MSVC), so should be fine here too.
  */
-#ifndef _MSC_VER
-#	include <cstdint>
-#endif
+#include <cstdint>
 
 #include <irrTypes.h>
 
@@ -38,15 +33,8 @@ namespace irr {
 
 // Irrlicht 1.8+ defines 64bit unsigned symbol in irrTypes.h
 #if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8)
-#ifdef _MSC_VER
-	// Windows
-	typedef long long s64;
-	typedef unsigned long long u64;
-#else
-	// Posix
-	typedef int64_t s64;
-	typedef uint64_t u64;
-#endif
+typedef int64_t s64;
+typedef uint64_t u64;
 #endif
 
 #if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR >= 9)

--- a/src/irrlichttypes.h
+++ b/src/irrlichttypes.h
@@ -31,12 +31,6 @@ using namespace irr;
 
 namespace irr {
 
-// Irrlicht 1.8+ defines 64bit unsigned symbol in irrTypes.h
-#if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8)
-typedef int64_t s64;
-typedef uint64_t u64;
-#endif
-
 #if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR >= 9)
 namespace core {
 	template <typename T>


### PR DESCRIPTION
* fix incorrect (yet still working) `irrUString.h` include
* always include cstdint
* drop any irrlicht 1.7.x `#if`'d code

We may want to drop any 1.8.x support code at a later point before 5.5.0 release.

## To do

This PR is Ready for Review.

## How to test

1. Observe CI results (ignore Android failing)
