### PR TITLE
Fix missing footstep sound when walking at edge

### DIFF
--- a/games/devtest/mods/soundstuff/init.lua
+++ b/games/devtest/mods/soundstuff/init.lua
@@ -88,6 +88,28 @@ minetest.register_node("soundstuff:footstep_liquid", {
 	}
 })
 
+
+minetest.register_node("soundstuff:footstep_16", {
+	description = "1/16 Footstep Sound Node",
+	drawtype = "nodebox",
+	node_box = {
+		type = "fixed",
+		fixed = { -0.5, -0.5, -0.5, 0.5, -7/16, 0.5 },
+	},
+	tiles = {
+		"soundstuff_node_sound.png",
+		"soundstuff_node_sound.png",
+		"soundstuff_node_footstep.png",
+	},
+	paramtype = "light",
+	is_ground_content = false,
+	sounds = {
+		footstep = { name = "soundstuff_mono", gain = 1.0 },
+	},
+	groups = { dig_immediate = 2 },
+})
+
+
 minetest.register_node("soundstuff:footstep_climbable", {
 	description = "Climbable Footstep Sound Node",
 	drawtype = "allfaces",

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -253,6 +253,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	node = map->getNode(pp, &is_valid_position);
 	if (is_valid_position) {
 		in_liquid_stable = nodemgr->get(node.getContent()).isLiquid();
+		m_liquid_stable_node = pp;
 	} else {
 		in_liquid_stable = false;
 	}
@@ -686,17 +687,18 @@ v3s16 LocalPlayer::getFootstepNodePos()
 {
 	// Emit swimming sound if the player is in liquid
 	if (in_liquid_stable)
-		return floatToInt(getPosition(), BS);
+		return m_liquid_stable_node;
 
+	v3s16 base_pos = getStandingNodePos();
 	// BS * 0.05 below the player's feet ensures a 1/16th height
 	// nodebox is detected instead of the node below it.
 	if (touching_ground)
-		return floatToInt(getPosition() - v3f(0.0f, BS * 0.05f, 0.0f), BS);
+		return base_pos - floatToInt(v3f(0.0f, BS * 0.05f, 0.0f), BS);
 
 	// A larger distance below is necessary for a footstep sound
 	// when landing after a jump or fall. BS * 0.5 ensures water
 	// sounds when swimming in 1 node deep water.
-	return floatToInt(getPosition() - v3f(0.0f, BS * 0.5f, 0.0f), BS);
+	return base_pos - floatToInt(v3f(0.0f, BS * 0.5f, 0.0f), BS);
 }
 
 v3s16 LocalPlayer::getLightPosition() const

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -170,6 +170,7 @@ private:
 
 	v3f m_position;
 	v3s16 m_standing_node;
+	v3s16 m_liquid_stable_node = v3s16(32767, 32767, 32767);
 
 	v3s16 m_sneak_node = v3s16(32767, 32767, 32767);
 	// Stores the top bounding box of m_sneak_node


### PR DESCRIPTION
An attempt to fix #6810.

## How to test
Try DevTest and use the various footstep test nodes.

Try walking along the edge in MTG.

Try the carpet mod:
```
minetest.register_node("test_carpet:carpet", {
	description = "Carpet",
	tiles = {"wool_red.png"},
	drawtype = "nodebox",
	node_box = {
		type = "fixed",
		fixed = { -0.5, -0.5, -0.5, 0.5, -7/16, 0.5 },
	},
	paramtype = "light",
	sunlight_propagates = true,
	sounds = default.node_sound_stone_defaults(),
	groups = { dig_immediate = 3 },
})
```

### Known bugs
* When you fall on a carpet (1/16 height block) or slab (1/2 height), you hear the sound of the node below the carpet, and nod the carpet. (not a regression)
* When you fall on the edge of a block, it is silent. Walking on the edge is fine tho (not a regression)

This code needs more testing.