### PR TITLE
Free player model rotation in 3rd person

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -989,8 +989,14 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		LocalPlayer *player = m_env->getLocalPlayer();
 		m_position = player->getPosition();
 		pos_translator.val_current = m_position;
-		m_rotation.Y = wrapDegrees_0_360(player->getYaw());
-		rot_translator.val_current = m_rotation;
+
+		// Rotate the player model based on movement direction.
+		v3f speed = player->getSpeed();
+		speed.Y = 0;
+		if (speed.getLengthSQ() > 0.001f) {
+			m_rotation.Y = core::RADTODEG * -atan2f(speed.X, speed.Z);
+			rot_translator.val_current = m_rotation;
+		}
 
 		if (m_is_visible) {
 			int old_anim = player->last_animation;


### PR DESCRIPTION
As seen in other games, the player model rotation is now no longer locked to the view direction, but to the movement direction. This only adds an eye candy for cinematic recordings, and has yet no practical use because all actions still depend on the camera view direction.

## To do

This PR is a Work in Progress. .. to see what people think about it in general. Feedback is welcome.

## How to test

1. F7
2. Walk