### PR TITLE
Enable cleanTransparent filter for mipmapping and improve its' algorithm

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -504,18 +504,17 @@ bilinear_filter (Bilinear filtering) bool false
 trilinear_filter (Trilinear filtering) bool false
 
 #    Filtered textures can blend RGB values with fully-transparent neighbors,
-#    which PNG optimizers usually discard, sometimes resulting in a dark or
-#    light edge to transparent textures. Apply this filter to clean that up
-#    at texture load time.
+#    which PNG optimizers usually discard, often resulting in dark or
+#    light edges to transparent textures. Apply a filter to clean that up
+#    at texture load time. This is automatically enabled if mipmapping is enabled.
 texture_clean_transparent (Clean transparent textures) bool false
 
 #    When using bilinear/trilinear/anisotropic filters, low-resolution textures
 #    can be blurred, so automatically upscale them with nearest-neighbor
 #    interpolation to preserve crisp pixels. This sets the minimum texture size
 #    for the upscaled textures; higher values look sharper, but require more
-#    memory.  Powers of 2 are recommended. Setting this higher than 1 may not
-#    have a visible effect unless bilinear/trilinear/anisotropic filtering is
-#    enabled.
+#    memory.  Powers of 2 are recommended. This setting is ONLY applies if
+#    bilinear/trilinear/anisotropic filtering is enabled.
 #    This is also used as the base node texture size for world-aligned
 #    texture autoscaling.
 texture_min_size (Minimum texture size) int 64

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -102,7 +102,7 @@ video::ITexture *guiScalingResizeCached(video::IVideoDriver *driver,
 		if (!g_settings->getBool("gui_scaling_filter_txr2img"))
 			return src;
 		srcimg = driver->createImageFromData(src->getColorFormat(),
-			src->getSize(), src->lock(), false);
+			src->getSize(), src->lock(video::ETLM_READ_ONLY), false);
 		src->unlock();
 		g_imgCache[origname] = srcimg;
 	}

--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -81,7 +81,7 @@ void imageCleanTransparent(video::IImage *src, u32 threshold)
 
 	Bitmap bitmap(dim.Width, dim.Height);
 
-	// First pass: Mark all opaque pixels.
+	// First pass: Mark all opaque pixels
 	// Note: loop y around x for better cache locality.
 	for (u32 ctry = 0; ctry < dim.Height; ctry++)
 	for (u32 ctrx = 0; ctrx < dim.Width; ctrx++) {
@@ -89,19 +89,19 @@ void imageCleanTransparent(video::IImage *src, u32 threshold)
 			bitmap.set(ctrx, ctry);
 	}
 
-	// All pixels opaque, exit early.
+	// Exit early if all pixels opaque
 	if (bitmap.all())
 		return;
 
 	Bitmap newmap = bitmap;
 
 	// Then repeatedly look for transparent pixels, filling them in until
-	// we're finished (capped to 50 iterations).
+	// we're finished (capped at 50 iterations).
 	for (u32 iter = 0; iter < 50; iter++) {
 
 	for (u32 ctry = 0; ctry < dim.Height; ctry++)
 	for (u32 ctrx = 0; ctrx < dim.Width; ctrx++) {
-		// Skip pixels we have already processed.
+		// Skip pixels we have already processed
 		if (bitmap.get(ctrx, ctry))
 			continue;
 
@@ -110,12 +110,12 @@ void imageCleanTransparent(video::IImage *src, u32 threshold)
 		// Sample size and total weighted r, g, b values
 		u32 ss = 0, sr = 0, sg = 0, sb = 0;
 
-		// Walk each neighbor pixel (clipped to image bounds).
+		// Walk each neighbor pixel (clipped to image bounds)
 		for (u32 sy = (ctry < 1) ? 0 : (ctry - 1);
 				sy <= (ctry + 1) && sy < dim.Height; sy++)
 		for (u32 sx = (ctrx < 1) ? 0 : (ctrx - 1);
 				sx <= (ctrx + 1) && sx < dim.Width; sx++) {
-			// Ignore pixels we haven't processed.
+			// Ignore pixels we haven't processed
 			if (!bitmap.get(sx, sy))
 				continue;
 	
@@ -129,7 +129,7 @@ void imageCleanTransparent(video::IImage *src, u32 threshold)
 			sb += a * d.getBlue();
 		}
 
-		// Set pixel to average weighted by alpha.
+		// Set pixel to average weighted by alpha
 		if (ss > 0) {
 			c.setRed(sr / ss);
 			c.setGreen(sg / ss);
@@ -139,7 +139,6 @@ void imageCleanTransparent(video::IImage *src, u32 threshold)
 		}
 	}
 
-	printf("%p processed %d\n", src, (int)iter);
 	if (newmap.all())
 		return;
 
@@ -148,7 +147,6 @@ void imageCleanTransparent(video::IImage *src, u32 threshold)
 	newmap.copy(bitmap);
 
 	}
-#undef BIT
 }
 
 /* Scale a region of an image into another image, using nearest-neighbor with

--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -24,15 +24,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 // Simple 2D bitmap class with just the functionality needed here
 class Bitmap {
-	std::vector<u8> data;
 	u32 linesize, lines;
+	std::vector<u8> data;
 
 	static inline u32 bytepos(u32 index) { return index >> 3; }
 	static inline u8 bitpos(u32 index) { return index & 7; }
 
 public:
-	Bitmap(u32 width, u32 height) : data(bytepos(width * height) + 1),
-		linesize(width), lines(height) {}
+	Bitmap(u32 width, u32 height) :  linesize(width), lines(height),
+		data(bytepos(width * height) + 1) {}
 
 	inline bool get(u32 x, u32 y) const {
 		u32 index = y * linesize + x;
@@ -51,7 +51,7 @@ public:
 		}
 		// last byte not entirely filled
 		for (u8 i = 0; i < bitpos(linesize * lines); i++) {
-			bool value_of_bit = data[data.size() - 1] & (1 << i);
+			bool value_of_bit = data.back() & (1 << i);
 			if (!value_of_bit)
 				return false;
 		}

--- a/src/client/imagefilters.h
+++ b/src/client/imagefilters.h
@@ -23,13 +23,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /* Fill in RGB values for transparent pixels, to correct for odd colors
  * appearing at borders when blending.  This is because many PNG optimizers
  * like to discard RGB values of transparent pixels, but when blending then
- * with non-transparent neighbors, their RGB values will shpw up nonetheless.
+ * with non-transparent neighbors, their RGB values will show up nonetheless.
  *
  * This function modifies the original image in-place.
  *
  * Parameter "threshold" is the alpha level below which pixels are considered
- * transparent.  Should be 127 for 3d where alpha is threshold, but 0 for
- * 2d where alpha is blended.
+ * transparent. Should be 127 when the texture is used with ALPHA_CHANNEL_REF,
+ * 0 when alpha blending is used.
  */
 void imageCleanTransparent(video::IImage *src, u32 threshold);
 

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -491,7 +491,8 @@ video::ITexture *Minimap::getMinimapTexture()
 		// Want to use texture source, to : 1 find texture, 2 cache it
 		video::ITexture* texture = m_tsrc->getTexture(data->mode.texture);
 		video::IImage* image = driver->createImageFromData(
-			 texture->getColorFormat(), texture->getSize(), texture->lock(), true, false);
+			 texture->getColorFormat(), texture->getSize(),
+			 texture->lock(video::ETLM_READ_ONLY), true, false);
 		texture->unlock();
 
 		auto dim = image->getDimension();

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -33,6 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "imagefilters.h"
 #include "guiscalingfilter.h"
 #include "renderingengine.h"
+#include "util/timetaker.h"
 
 
 #if ENABLE_GLES
@@ -1639,8 +1640,10 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			}
 
 			// Apply the "clean transparent" filter, if needed
-			if (m_setting_mipmap || g_settings->getBool("texture_clean_transparent"))
+			if (m_setting_mipmap || g_settings->getBool("texture_clean_transparent")) {
+				TimeTaker tt("clean_transparent");
 				imageCleanTransparent(baseimg, 127);
+			}
 
 			/* Upscale textures to user's requested minimum size.  This is a trick to make
 			 * filters look as good on low-res textures as on high-res ones, by making
@@ -1648,7 +1651,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			 * mix high- and low-res textures, or for mods with least-common-denominator
 			 * textures that don't have the resources to offer high-res alternatives.
 			 */
-			const bool filter = m_setting_mipmap ||
+			const bool filter = //m_setting_mipmap ||
 				m_setting_trilinear_filter || m_setting_bilinear_filter;
 			const s32 scaleto = filter ? g_settings->getS32("texture_min_size") : 1;
 			if (scaleto > 1) {

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -33,7 +33,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "imagefilters.h"
 #include "guiscalingfilter.h"
 #include "renderingengine.h"
-#include "util/timetaker.h"
 
 
 #if ENABLE_GLES
@@ -1640,10 +1639,8 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			}
 
 			// Apply the "clean transparent" filter, if needed
-			if (m_setting_mipmap || g_settings->getBool("texture_clean_transparent")) {
-				TimeTaker tt("clean_transparent");
+			if (m_setting_mipmap || g_settings->getBool("texture_clean_transparent"))
 				imageCleanTransparent(baseimg, 127);
-			}
 
 			/* Upscale textures to user's requested minimum size.  This is a trick to make
 			 * filters look as good on low-res textures as on high-res ones, by making
@@ -1651,8 +1648,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			 * mix high- and low-res textures, or for mods with least-common-denominator
 			 * textures that don't have the resources to offer high-res alternatives.
 			 */
-			const bool filter = //m_setting_mipmap ||
-				m_setting_trilinear_filter || m_setting_bilinear_filter;
+			const bool filter = m_setting_trilinear_filter || m_setting_bilinear_filter;
 			const s32 scaleto = filter ? g_settings->getS32("texture_min_size") : 1;
 			if (scaleto > 1) {
 				const core::dimension2d<u32> dim = baseimg->getDimension();

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -427,6 +427,7 @@ private:
 	std::unordered_map<std::string, Palette> m_palettes;
 
 	// Cached settings needed for making textures from meshes
+	bool m_setting_mipmap;
 	bool m_setting_trilinear_filter;
 	bool m_setting_bilinear_filter;
 };
@@ -447,6 +448,7 @@ TextureSource::TextureSource()
 	// Cache some settings
 	// Note: Since this is only done once, the game must be restarted
 	// for these settings to take effect
+	m_setting_mipmap = g_settings->getBool("mip_map");
 	m_setting_trilinear_filter = g_settings->getBool("trilinear_filter");
 	m_setting_bilinear_filter = g_settings->getBool("bilinear_filter");
 }
@@ -667,7 +669,7 @@ video::ITexture* TextureSource::getTexture(const std::string &name, u32 *id)
 video::ITexture* TextureSource::getTextureForMesh(const std::string &name, u32 *id)
 {
 	static thread_local bool filter_needed =
-		g_settings->getBool("texture_clean_transparent") ||
+		g_settings->getBool("texture_clean_transparent") || m_setting_mipmap ||
 		((m_setting_trilinear_filter || m_setting_bilinear_filter) &&
 		g_settings->getS32("texture_min_size") > 1);
 	// Avoid duplicating texture if it won't actually change
@@ -1636,8 +1638,8 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 				return false;
 			}
 
-			// Apply the "clean transparent" filter, if configured.
-			if (g_settings->getBool("texture_clean_transparent"))
+			// Apply the "clean transparent" filter, if needed
+			if (m_setting_mipmap || g_settings->getBool("texture_clean_transparent"))
 				imageCleanTransparent(baseimg, 127);
 
 			/* Upscale textures to user's requested minimum size.  This is a trick to make
@@ -1646,7 +1648,8 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			 * mix high- and low-res textures, or for mods with least-common-denominator
 			 * textures that don't have the resources to offer high-res alternatives.
 			 */
-			const bool filter = m_setting_trilinear_filter || m_setting_bilinear_filter;
+			const bool filter = m_setting_mipmap ||
+				m_setting_trilinear_filter || m_setting_bilinear_filter;
 			const s32 scaleto = filter ? g_settings->getS32("texture_min_size") : 1;
 			if (scaleto > 1) {
 				const core::dimension2d<u32> dim = baseimg->getDimension();


### PR DESCRIPTION
fixes #6846

This doesn't really do _that_ much: It enables `texture_clean_transparent` if mipmapping is enabled and makes the filter fill *all* transparent pixels not just neighboring ones.

Before | After | 　
--- | --- | ---
![mip1](https://user-images.githubusercontent.com/1042418/113355566-44b80500-9341-11eb-9b55-30096dbc6494.png) | ![mip2](https://user-images.githubusercontent.com/1042418/113355574-471a5f00-9341-11eb-9779-03e5f365e149.png) | original texture for comparison ↓
![tex1](https://user-images.githubusercontent.com/1042418/113355709-76c96700-9341-11eb-972e-73242da4f149.png) | ![tex2](https://user-images.githubusercontent.com/1042418/113355690-70d38600-9341-11eb-944d-ebb4faf8749f.png) | ![orig](https://user-images.githubusercontent.com/1042418/113355842-aaa48c80-9341-11eb-8873-16473259d94c.png)
(^ the pixels that are light green here are already present that way in the texture) | |

For a better demonstration of the new algorithm here's the MTG apple texture fully filled in:
![-byW.png](https://0x0.st/-byW.png)

## To do

This PR is a Ready for Review.

## How to test

* Compare how mipmapping looks ingame with any transparent nodes
