### PR TITLE
Fix server favorites not saving when client/serverlist/ doesn't exist already

### DIFF
--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -90,8 +90,11 @@ function serverlistmgr.sync()
 end
 
 --------------------------------------------------------------------------------
-local function get_favorites_path()
+local function get_favorites_path(folder)
 	local base = core.get_user_path() .. DIR_DELIM .. "client" .. DIR_DELIM .. "serverlist" .. DIR_DELIM
+	if folder then
+		return base
+	end
 	return base .. core.settings:get("serverlist_file")
 end
 
@@ -103,9 +106,8 @@ local function save_favorites(favorites)
 		core.settings:set("serverlist_file", filename:sub(1, #filename - 4) .. ".json")
 	end
 
-	local path = get_favorites_path()
-	core.create_dir(path)
-	core.safe_file_write(path, core.write_json(favorites))
+	assert(core.create_dir(get_favorites_path(true)))
+	core.safe_file_write(get_favorites_path(), core.write_json(favorites))
 end
 
 --------------------------------------------------------------------------------

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -716,21 +716,24 @@ int ModApiMainMenu::l_get_mainmenu_path(lua_State *L)
 }
 
 /******************************************************************************/
-bool ModApiMainMenu::mayModifyPath(const std::string &path)
+bool ModApiMainMenu::mayModifyPath(std::string path)
 {
+	path = fs::RemoveRelativePathComponents(path);
+
 	if (fs::PathStartsWith(path, fs::TempPath()))
 		return true;
 
-	if (fs::PathStartsWith(path, fs::RemoveRelativePathComponents(porting::path_user + DIR_DELIM "games")))
-		return true;
+	std::string path_user = fs::RemoveRelativePathComponents(porting::path_user);
 
-	if (fs::PathStartsWith(path, fs::RemoveRelativePathComponents(porting::path_user + DIR_DELIM "mods")))
+	if (fs::PathStartsWith(path, path_user + DIR_DELIM "client"))
 		return true;
-
-	if (fs::PathStartsWith(path, fs::RemoveRelativePathComponents(porting::path_user + DIR_DELIM "textures")))
+	if (fs::PathStartsWith(path, path_user + DIR_DELIM "games"))
 		return true;
-
-	if (fs::PathStartsWith(path, fs::RemoveRelativePathComponents(porting::path_user + DIR_DELIM "worlds")))
+	if (fs::PathStartsWith(path, path_user + DIR_DELIM "mods"))
+		return true;
+	if (fs::PathStartsWith(path, path_user + DIR_DELIM "textures"))
+		return true;
+	if (fs::PathStartsWith(path, path_user + DIR_DELIM "worlds"))
 		return true;
 
 	if (fs::PathStartsWith(path, fs::RemoveRelativePathComponents(porting::path_cache)))

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -58,7 +58,7 @@ private:
 	 * @param path path to check
 	 * @return true if the path may be modified
 	 */
-	static bool mayModifyPath(const std::string &path);
+	static bool mayModifyPath(std::string path);
 
 	//api calls
 


### PR DESCRIPTION
reported by @VanessaE here: https://irc.minetest.net/minetest/2021-04-02#i_5806729
this affects all `RUN_IN_PLACE=0` new installations since 5.4.0

There's ~~two~~three bugs here:
* sanity checks prevent the mainmenu from touching `~/.minetest/client/*`
* The `create_dir` call is wrong and it would create a <b>folder</b> named `~/.minetest/client/serverlist/favoriteservers.json`
* (zero error checking so this went unnoticed)

## To do

This PR is Ready for Review.

## How to test

Delete `client/serverlist/`, try to connect to a server in the mainmenu and see if saves.