### PR TITLE
Make edit boxes respond to string input (IME)

### DIFF
--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include "IrrCompileConfig.h"
 #include "guiChatConsole.h"
 #include "chat.h"
 #include "client/client.h"
@@ -619,11 +620,13 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			m_chat_backend->scroll(rows);
 		}
 	}
+#if defined(IRRLICHT_VERSION_MT_REVISION) && (IRRLICHT_VERSION_MT_REVISION >= 2)
 	else if(event.EventType == EET_STRING_INPUT_EVENT)
 	{
 		prompt.input(std::wstring(event.StringInput.Str->c_str()));
 		return true;
 	}
+#endif
 
 	return Parent ? Parent->OnEvent(event) : false;
 }

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -619,6 +619,11 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			m_chat_backend->scroll(rows);
 		}
 	}
+	else if(event.EventType == EET_STRING_INPUT_EVENT)
+	{
+		prompt.input(std::wstring(event.StringInput.Str->c_str()));
+		return true;
+	}
 
 	return Parent ? Parent->OnEvent(event) : false;
 }

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -620,7 +620,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			m_chat_backend->scroll(rows);
 		}
 	}
-#if defined(IRRLICHT_VERSION_MT_REVISION) && (IRRLICHT_VERSION_MT_REVISION >= 2)
+#if (IRRLICHT_VERSION_MT_REVISION >= 2)
 	else if(event.EventType == EET_STRING_INPUT_EVENT)
 	{
 		prompt.input(std::wstring(event.StringInput.Str->c_str()));

--- a/src/gui/guiChatConsole.h
+++ b/src/gui/guiChatConsole.h
@@ -72,6 +72,8 @@ public:
 
 	virtual void setVisible(bool visible);
 
+	virtual bool acceptsIME() { return true; }
+
 private:
 	void reformatConsole();
 	void recalculateConsolePosition();

--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -221,7 +221,6 @@ bool GUIEditBox::OnEvent(const SEvent &event)
 		case EET_STRING_INPUT_EVENT:
 			inputString(*event.StringInput.Str);
 			return true;
-			break;
 #endif
 		default:
 			break;

--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -216,6 +216,10 @@ bool GUIEditBox::OnEvent(const SEvent &event)
 			if (processMouse(event))
 				return true;
 			break;
+		case EET_STRING_INPUT_EVENT:
+			inputString(event.StringInput.Str);
+			return true;
+			break;
 		default:
 			break;
 		}
@@ -697,6 +701,46 @@ void GUIEditBox::inputChar(wchar_t c)
 						Text.size() - m_cursor_pos));
 				Text = s;
 				++m_cursor_pos;
+			}
+
+			m_blink_start_time = porting::getTimeMs();
+			setTextMarkers(0, 0);
+		}
+	}
+	breakText();
+	sendGuiEvent(EGET_EDITBOX_CHANGED);
+	calculateScrollPos();
+}
+
+void GUIEditBox::inputString(core::stringw *str)
+{
+	if (!isEnabled() || !m_writable)
+		return;
+
+	if (str) {
+		u32 len = str->size();
+		if (Text.size()+len <= m_max || m_max == 0) {
+			core::stringw s;
+			if (m_mark_begin != m_mark_end) {
+				// clang-format off
+				// replace marked test
+				s32 real_begin = m_mark_begin < m_mark_end ? m_mark_begin : m_mark_end;
+				s32 real_end = m_mark_begin < m_mark_end ? m_mark_end : m_mark_begin;
+
+				s = Text.subString(0, real_begin);
+				s.append(*str);
+				s.append(Text.subString(real_end, Text.size() - real_end));
+				Text = s;
+				m_cursor_pos = real_begin + len;
+				// clang-format on
+			} else {
+				// append string
+				s = Text.subString(0, m_cursor_pos);
+				s.append(*str);
+				s.append(Text.subString(m_cursor_pos,
+						Text.size() - m_cursor_pos));
+				Text = s;
+				m_cursor_pos += len;
 			}
 
 			m_blink_start_time = porting::getTimeMs();

--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -217,7 +217,7 @@ bool GUIEditBox::OnEvent(const SEvent &event)
 				return true;
 			break;
 		case EET_STRING_INPUT_EVENT:
-			inputString(event.StringInput.Str);
+			inputString(*event.StringInput.Str);
 			return true;
 			break;
 		default:
@@ -674,79 +674,44 @@ bool GUIEditBox::onKeyDelete(const SEvent &event, s32 &mark_begin, s32 &mark_end
 
 void GUIEditBox::inputChar(wchar_t c)
 {
-	if (!isEnabled() || !m_writable)
-		return;
-
-	if (c != 0) {
-		if (Text.size() < m_max || m_max == 0) {
-			core::stringw s;
-
-			if (m_mark_begin != m_mark_end) {
-				// clang-format off
-				// replace marked text
-				s32 real_begin = m_mark_begin < m_mark_end ? m_mark_begin : m_mark_end;
-				s32 real_end = m_mark_begin < m_mark_end ? m_mark_end : m_mark_begin;
-
-				s = Text.subString(0, real_begin);
-				s.append(c);
-				s.append(Text.subString(real_end, Text.size() - real_end));
-				Text = s;
-				m_cursor_pos = real_begin + 1;
-				// clang-format on
-			} else {
-				// add new character
-				s = Text.subString(0, m_cursor_pos);
-				s.append(c);
-				s.append(Text.subString(m_cursor_pos,
-						Text.size() - m_cursor_pos));
-				Text = s;
-				++m_cursor_pos;
-			}
-
-			m_blink_start_time = porting::getTimeMs();
-			setTextMarkers(0, 0);
-		}
-	}
-	breakText();
-	sendGuiEvent(EGET_EDITBOX_CHANGED);
-	calculateScrollPos();
+	core::stringw s(&c, 1);
+	inputString(s);
 }
 
-void GUIEditBox::inputString(core::stringw *str)
+void GUIEditBox::inputString(const core::stringw &str)
 {
 	if (!isEnabled() || !m_writable)
 		return;
 
-	if (str) {
-		u32 len = str->size();
-		if (Text.size()+len <= m_max || m_max == 0) {
-			core::stringw s;
-			if (m_mark_begin != m_mark_end) {
-				// clang-format off
-				// replace marked test
-				s32 real_begin = m_mark_begin < m_mark_end ? m_mark_begin : m_mark_end;
-				s32 real_end = m_mark_begin < m_mark_end ? m_mark_end : m_mark_begin;
+	u32 len = str.size();
+	if (Text.size()+len <= m_max || m_max == 0) {
+		core::stringw s;
+		if (m_mark_begin != m_mark_end) {
+			// clang-format off
+			// replace marked test
+			s32 real_begin = m_mark_begin < m_mark_end ? m_mark_begin : m_mark_end;
+			s32 real_end = m_mark_begin < m_mark_end ? m_mark_end : m_mark_begin;
 
-				s = Text.subString(0, real_begin);
-				s.append(*str);
-				s.append(Text.subString(real_end, Text.size() - real_end));
-				Text = s;
-				m_cursor_pos = real_begin + len;
-				// clang-format on
-			} else {
-				// append string
-				s = Text.subString(0, m_cursor_pos);
-				s.append(*str);
-				s.append(Text.subString(m_cursor_pos,
-						Text.size() - m_cursor_pos));
-				Text = s;
-				m_cursor_pos += len;
-			}
-
-			m_blink_start_time = porting::getTimeMs();
-			setTextMarkers(0, 0);
+			s = Text.subString(0, real_begin);
+			s.append(str);
+			s.append(Text.subString(real_end, Text.size() - real_end));
+			Text = s;
+			m_cursor_pos = real_begin + len;
+			// clang-format on
+		} else {
+			// append string
+			s = Text.subString(0, m_cursor_pos);
+			s.append(str);
+			s.append(Text.subString(m_cursor_pos,
+					Text.size() - m_cursor_pos));
+			Text = s;
+			m_cursor_pos += len;
 		}
+
+		m_blink_start_time = porting::getTimeMs();
+		setTextMarkers(0, 0);
 	}
+
 	breakText();
 	sendGuiEvent(EGET_EDITBOX_CHANGED);
 	calculateScrollPos();

--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -217,7 +217,7 @@ bool GUIEditBox::OnEvent(const SEvent &event)
 			if (processMouse(event))
 				return true;
 			break;
-#if defined(IRRLICHT_VERSION_MT_REVISION) && (IRRLICHT_VERSION_MT_REVISION >= 2)
+#if (IRRLICHT_VERSION_MT_REVISION >= 2)
 		case EET_STRING_INPUT_EVENT:
 			inputString(*event.StringInput.Str);
 			return true;

--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -674,6 +674,8 @@ bool GUIEditBox::onKeyDelete(const SEvent &event, s32 &mark_begin, s32 &mark_end
 
 void GUIEditBox::inputChar(wchar_t c)
 {
+	if (c == 0)
+		return;
 	core::stringw s(&c, 1);
 	inputString(s);
 }

--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "guiEditBox.h"
 
+#include "IrrCompileConfig.h"
 #include "IGUISkin.h"
 #include "IGUIEnvironment.h"
 #include "IGUIFont.h"
@@ -216,10 +217,12 @@ bool GUIEditBox::OnEvent(const SEvent &event)
 			if (processMouse(event))
 				return true;
 			break;
+#if defined(IRRLICHT_VERSION_MT_REVISION) && (IRRLICHT_VERSION_MT_REVISION >= 2)
 		case EET_STRING_INPUT_EVENT:
 			inputString(*event.StringInput.Str);
 			return true;
 			break;
+#endif
 		default:
 			break;
 		}

--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -691,8 +691,7 @@ void GUIEditBox::inputString(const core::stringw &str)
 	if (Text.size()+len <= m_max || m_max == 0) {
 		core::stringw s;
 		if (m_mark_begin != m_mark_end) {
-			// clang-format off
-			// replace marked test
+			// replace marked text
 			s32 real_begin = m_mark_begin < m_mark_end ? m_mark_begin : m_mark_end;
 			s32 real_end = m_mark_begin < m_mark_end ? m_mark_end : m_mark_begin;
 
@@ -701,7 +700,6 @@ void GUIEditBox::inputString(const core::stringw &str)
 			s.append(Text.subString(real_end, Text.size() - real_end));
 			Text = s;
 			m_cursor_pos = real_begin + len;
-			// clang-format on
 		} else {
 			// append string
 			s = Text.subString(0, m_cursor_pos);

--- a/src/gui/guiEditBox.h
+++ b/src/gui/guiEditBox.h
@@ -156,6 +156,7 @@ protected:
 	virtual s32 getCursorPos(s32 x, s32 y) = 0;
 
 	bool processKey(const SEvent &event);
+	virtual void inputString(core::stringw *str);
 	virtual void inputChar(wchar_t c);
 
 	//! returns the line number that the cursor is on

--- a/src/gui/guiEditBox.h
+++ b/src/gui/guiEditBox.h
@@ -158,7 +158,7 @@ protected:
 	virtual s32 getCursorPos(s32 x, s32 y) = 0;
 
 	bool processKey(const SEvent &event);
-	virtual void inputString(core::stringw *str);
+	virtual void inputString(const core::stringw &str);
 	virtual void inputChar(wchar_t c);
 
 	//! returns the line number that the cursor is on

--- a/src/gui/guiEditBox.h
+++ b/src/gui/guiEditBox.h
@@ -138,6 +138,8 @@ public:
 	virtual void deserializeAttributes(
 			io::IAttributes *in, io::SAttributeReadWriteOptions *options);
 
+	virtual bool acceptsIME() { return isEnabled() && m_writable; };
+
 protected:
 	virtual void breakText() = 0;
 


### PR DESCRIPTION
This PR makes edit boxes respond to string input events (introduced in minetest/irrlicht#23) that are usually triggered by entering text with an IME.

## To do

This PR is ready for review.

## How to test
- Compile with the `master` branch of minetest/irrlicht
- Try to enter text with an IME
