### PR TITLE
Fix rotation for falling mesh degrotate nodes

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -209,11 +209,11 @@ core.register_entity(":__builtin:falling_node", {
 				end
 				self.object:set_rotation({x=pitch, y=yaw, z=roll})
 			elseif (def.drawtype == "mesh" and def.paramtype2 == "degrotate") then
-				local p2 = (node.param2 - def.place_param2) % 240
+				local p2 = (node.param2 - (def.place_param2 or 0)) % 240
 				local yaw = (p2 / 240) * (math.pi * 2)
 				self.object:set_yaw(yaw)
 			elseif (def.drawtype == "mesh" and def.paramtype2 == "colordegrotate") then
-				local p2 = (node.param2 % 32 - def.place_param2 % 32) % 24
+				local p2 = (node.param2 % 32 - (def.place_param2 or 0) % 32) % 24
 				local yaw = (p2 / 24) * (math.pi * 2)
 				self.object:set_yaw(yaw)
 			end

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -208,6 +208,14 @@ core.register_entity(":__builtin:falling_node", {
 					end
 				end
 				self.object:set_rotation({x=pitch, y=yaw, z=roll})
+			elseif (def.drawtype == "mesh" and def.paramtype2 == "degrotate") then
+				local p2 = (node.param2 - def.place_param2) % 240
+				local yaw = (p2 / 240) * (math.pi * 2)
+				self.object:set_yaw(yaw)
+			elseif (def.drawtype == "mesh" and def.paramtype2 == "colordegrotate") then
+				local p2 = (node.param2 % 32 - def.place_param2 % 32) % 24
+				local yaw = (p2 / 24) * (math.pi * 2)
+				self.object:set_yaw(yaw)
 			end
 		end
 	end,

--- a/games/devtest/mods/experimental/commands.lua
+++ b/games/devtest/mods/experimental/commands.lua
@@ -131,10 +131,11 @@ local function place_nodes(param)
 				p2_max = 63
 			elseif def.paramtype2 == "leveled" then
 				p2_max = 127
-			elseif def.paramtype2 == "degrotate" and def.drawtype == "plantlike" then
-				p2_max = 179
+			elseif def.paramtype2 == "degrotate" and (def.drawtype == "plantlike" or def.drawtype == "mesh") then
+				p2_max = 239
 			elseif def.paramtype2 == "colorfacedir" or
 				def.paramtype2 == "colorwallmounted" or
+				def.paramtype2 == "colordegrotate" or
 				def.paramtype2 == "color" then
 				p2_max = 255
 			end
@@ -143,7 +144,8 @@ local function place_nodes(param)
 			-- Skip undefined param2 values
 			if not ((def.paramtype2 == "meshoptions" and p2 % 8 > 4) or
 					(def.paramtype2 == "colorwallmounted" and p2 % 8 > 5) or
-					(def.paramtype2 == "colorfacedir" and p2 % 32 > 23)) then
+					((def.paramtype2 == "colorfacedir" or def.paramtype2 == "colordegrotate")
+					and p2 % 32 > 23)) then
 
 				minetest.set_node(pos, { name = itemstring, param2 = p2 })
 				nodes_placed = nodes_placed + 1

--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -266,11 +266,11 @@ minetest.register_node("testnodes:mesh_degrotate", {
 	drawtype = "mesh",
 	paramtype = "light",
 	paramtype2 = "degrotate",
-	mesh = "testnodes_pyramid.obj",
+	mesh = "testnodes_ocorner.obj",
 	tiles = { "testnodes_mesh_stripes2.png" },
 
 	on_rightclick = rotate_on_rightclick,
-	place_param2 = 7,
+	place_param2 = 10, -- 15°
 	sunlight_propagates = true,
 	groups = { dig_immediate = 3 },
 })
@@ -278,14 +278,15 @@ minetest.register_node("testnodes:mesh_degrotate", {
 minetest.register_node("testnodes:mesh_colordegrotate", {
 	description = S("Color Degrotate Mesh Drawtype Test Node"),
 	drawtype = "mesh",
+	paramtype = "light",
 	paramtype2 = "colordegrotate",
 	palette = "testnodes_palette_facedir.png",
-	mesh = "testnodes_pyramid.obj",
-	tiles = { "testnodes_mesh_stripes2.png" },
+	mesh = "testnodes_ocorner.obj",
+	tiles = { "testnodes_mesh_stripes3.png" },
 
 	on_rightclick = rotate_on_rightclick,
-	-- color index 1, 7 steps rotated
-	place_param2 = 1 * 2^5 + 7,
+	-- color index 1, 1 step (=15°) rotated
+	place_param2 = 1 * 2^5 + 1,
 	sunlight_propagates = true,
 	groups = { dig_immediate = 3 },
 })


### PR DESCRIPTION
If a node with `drawtype="mesh"` and `paramtype2="[color]degrotate"` falls, the rotation of that node was wrong.

Also, the drawtype test nodes in DevTest were quite buggy as well and not very useful for testing (pyramid looks the same after 90° rotation).

I fixed both this.

## How to test

Place the degrotate nodes from DevTest on the ground. Use the Param2 Tool to set a rotation and/or color. Use the Falling Node Tool with the Punch key to force a fall. Test all possible variations. The color and rotation of the falling node must be the same as the color and rotation of the node.

## Notifications
@numberZero