### PR TITLE
Devtest: Remove testnodes_show_fallback_image

### DIFF
--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -15,22 +15,6 @@ testing this node easier and more convenient.
 
 local S = minetest.get_translator("testnodes")
 
--- If set to true, will show an inventory image for nodes that have no inventory image as of Minetest 5.1.0.
--- This is due to <https://github.com/minetest/minetest/issues/9209>.
--- This is only added to make the items more visible to avoid confusion, but you will no longer see
--- the default inventory images for these items. When you want to test the default inventory image of drawtypes,
--- this should be turned off.
--- TODO: Remove support for fallback inventory image as soon #9209 is fixed.
-local SHOW_FALLBACK_IMAGE = minetest.settings:get_bool("testnodes_show_fallback_image", false)
-
-local fallback_image = function(img)
-	if SHOW_FALLBACK_IMAGE then
-		return img
-	else
-		return nil
-	end
-end
-
 -- A regular cube
 minetest.register_node("testnodes:normal", {
 	description = S("Normal Drawtype Test Node"),
@@ -158,7 +142,6 @@ minetest.register_node("testnodes:torchlike", {
 	walkable = false,
 	sunlight_propagates = true,
 	groups = { dig_immediate = 3 },
-	inventory_image = fallback_image("testnodes_torchlike_floor.png"),
 })
 
 minetest.register_node("testnodes:torchlike_wallmounted", {
@@ -176,7 +159,6 @@ minetest.register_node("testnodes:torchlike_wallmounted", {
 	walkable = false,
 	sunlight_propagates = true,
 	groups = { dig_immediate = 3 },
-	inventory_image = fallback_image("testnodes_torchlike_floor.png"),
 })
 
 
@@ -192,7 +174,6 @@ minetest.register_node("testnodes:signlike", {
 	walkable = false,
 	groups = { dig_immediate = 3 },
 	sunlight_propagates = true,
-	inventory_image = fallback_image("testnodes_signlike.png"),
 })
 
 minetest.register_node("testnodes:plantlike", {
@@ -510,7 +491,6 @@ minetest.register_node("testnodes:airlike", {
 	walkable = false,
 	groups = { dig_immediate = 3 },
 	sunlight_propagates = true,
-	inventory_image = fallback_image("testnodes_airlike.png"),
 })
 
 -- param2 changes liquid height

--- a/games/devtest/mods/testnodes/settingtypes.txt
+++ b/games/devtest/mods/testnodes/settingtypes.txt
@@ -1,4 +1,0 @@
-# If set to true, will show an inventory image for nodes that have no inventory image as of Minetest 5.1.0.
-# This is due to <https://github.com/minetest/minetest/issues/9209>.
-# This is only added to make the items more visible to avoid confusion, but you will no longer see the default inventory images for these items. When you want to test the default inventory image of drawtypes, this should be turned off.
-testnodes_show_fallback_image (Use fallback inventory images) bool false

--- a/games/devtest/settingtypes.txt
+++ b/games/devtest/settingtypes.txt
@@ -30,8 +30,3 @@ devtest_dungeon_mossycobble (Generate mossy cobblestone) bool false
 
 # If enabled, some very basic biomes will be registered.
 devtest_register_biomes (Register biomes) bool true
-
-# If set to true, will show an inventory image for nodes that have no inventory image as of Minetest 5.1.0.
-# This is due to <https://github.com/minetest/minetest/issues/9209>.
-# This is only added to make the items more visible to avoid confusion, but you will no longer see the default inventory images for these items. When you want to test the default inventory image of drawtypes, this should be turned off.
-testnodes_show_fallback_image (Use fallback inventory images) bool false


### PR DESCRIPTION
This is a simple DevTest cleanup PR.
This removes an old setting that I have introduced a while ago: `testnodes_show_fallback_image`. It was used by me during my big work on DevTest, done in the time in which many nodes had a bad default appearance. The point was to make these nodes visible in the inventory despite the bug.
But the reason for this setting no longer exists. This setting was meant to be temporary anyway. This PR will thus remove this setting.