### PR TITLE
Rename “Irrlicht” to “IrrlichtMt” in documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 # This is done here so that relative search paths are more reasonable
 find_package(Irrlicht)
 if(BUILD_CLIENT AND NOT IRRLICHT_FOUND)
-	message(FATAL_ERROR "Irrlicht is required to build the client, but it was not found.")
+	message(FATAL_ERROR "IrrlichtMt is required to build the client, but it was not found.")
 elseif(NOT IRRLICHT_INCLUDE_DIR)
-	message(FATAL_ERROR "Irrlicht headers are required to build the server, but none found.")
+	message(FATAL_ERROR "Irrlicht or IrrlichtMt headers are required to build the server, but none found.")
 endif()
 
 include(CheckSymbolExists)
@@ -71,7 +71,7 @@ unset(HAS_FORKED_IRRLICHT CACHE)
 check_symbol_exists(IRRLICHT_VERSION_MT "IrrCompileConfig.h" HAS_FORKED_IRRLICHT)
 if(NOT HAS_FORKED_IRRLICHT)
 	string(CONCAT EXPLANATION_MSG
-		"Irrlicht found, but it is not Minetest's Irrlicht fork. "
+		"Irrlicht found, but it is not IrrlichtMt (Minetest's Irrlicht fork). "
 		"The Minetest team has forked Irrlicht to make their own customizations. "
 		"It can be found here: https://github.com/minetest/irrlicht")
 	if(BUILD_CLIENT)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -87,7 +87,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 Irrlicht
 ---------------
 
-This program uses the Irrlicht Engine. http://irrlicht.sourceforge.net/
+This program uses IrrlichtMt, Minetest's fork of
+the Irrlicht Engine. http://irrlicht.sourceforge.net/
 
  The Irrlicht Engine License
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Compiling
 |------------|---------|------------|
 | GCC        | 4.9+    | Can be replaced with Clang 3.4+ |
 | CMake      | 3.5+    |            |
-| Irrlicht   | -       | Custom version required, see https://github.com/minetest/irrlicht |
+| IrrlichtMt | -       | Custom version of Irrlicht, see https://github.com/minetest/irrlicht |
 | SQLite3    | 3.0+    |            |
 | LuaJIT     | 2.0+    | Bundled Lua 5.1 is used if not present |
 | GMP        | 5.0.0+  | Bundled mini-GMP is used if not present |
@@ -209,7 +209,7 @@ Run it:
 - You can disable the client build by specifying `-DBUILD_CLIENT=FALSE`.
 - You can select between Release and Debug build by `-DCMAKE_BUILD_TYPE=<Debug or Release>`.
   - Debug build is slower, but gives much more useful output in a debugger.
-- If you build a bare server you don't need to have the Irrlicht library installed.
+- If you build a bare server you don't need to have the Irrlicht or IrrlichtMt library installed.
   - In that case use `-DIRRLICHT_INCLUDE_DIR=/some/where/irrlicht/include`.
 
 ### CMake options
@@ -229,7 +229,7 @@ General options and their default values:
     ENABLE_CURSES=ON           - Build with (n)curses; Enables a server side terminal (command line option: --terminal)
     ENABLE_FREETYPE=ON         - Build with FreeType2; Allows using TTF fonts
     ENABLE_GETTEXT=ON          - Build with Gettext; Allows using translations
-    ENABLE_GLES=OFF            - Build for OpenGL ES instead of OpenGL (requires support by Irrlicht)
+    ENABLE_GLES=OFF            - Build for OpenGL ES instead of OpenGL (requires support by IrrlichtMt)
     ENABLE_LEVELDB=ON          - Build with LevelDB; Enables use of LevelDB map backend
     ENABLE_POSTGRESQL=ON       - Build with libpq; Enables use of PostgreSQL map backend (PostgreSQL 9.5 or greater recommended)
     ENABLE_REDIS=ON            - Build with libhiredis; Enables use of Redis map backend

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -661,7 +661,7 @@ lighting_boost_spread (Light curve boost spread) float 0.2 0.0 0.4
 #    Path to texture directory. All textures are first searched from here.
 texture_path (Texture path) path
 
-#    The rendering back-end for Irrlicht.
+#    The rendering back-end.
 #    A restart is required after changing this.
 #    Note: On Android, stick with OGLES1 if unsure! App may fail to start otherwise.
 #    On other platforms, OpenGL is recommended.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -761,7 +761,7 @@
 #    type: path
 # texture_path =
 
-#    The rendering back-end for Irrlicht.
+#    The rendering back-end.
 #    A restart is required after changing this.
 #    Note: On Android, stick with OGLES1 if unsure! App may fail to start otherwise.
 #    On other platforms, OpenGL is recommended.


### PR DESCRIPTION
Since Minetest's Irrlicht fork was recently officially renamed to “IrrlichtMt”, this PR will reflect that change.