### PR TITLE
Don't reseed stars when changing star count

### DIFF
--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -57,6 +57,8 @@ Sky::Sky(s32 id, ITextureSource *tsrc, IShaderSource *ssrc) :
 		scene::ISceneNode(RenderingEngine::get_scene_manager()->getRootSceneNode(),
 			RenderingEngine::get_scene_manager(), id)
 {
+	m_seed = (u64)myrand() << 32 | myrand();
+
 	setAutomaticCulling(scene::EAC_OFF);
 	m_box.MaxEdge.set(0, 0, 0);
 	m_box.MinEdge.set(0, 0, 0);
@@ -833,7 +835,6 @@ void Sky::setStarCount(u16 star_count, bool force_update)
 	// Allow force updating star count at game init.
 	if (m_star_params.count != star_count || force_update) {
 		m_star_params.count = star_count;
-		m_seed = (u64)myrand() << 32 | myrand();
 		updateStars();
 	}
 }


### PR DESCRIPTION
When you change the star count with `set_stars`, the star seed is changed as well. This has an annoying downside because if you want to add only like 10 stars, all stars will change their position.
In my personal opinion, this is also just weird behavior, since to my knowledge, no other attribute change (like `scale`) will change the star seed.

With this PR, the seed is only generated once and is kept for the duration of the game session. When you change the star count, the seed is kept and the positions of the existing or remaining stars won't change.

If you restart/rejoin the game, the seed is still regenerated, so that part of the behavior remains unchanged.

## How to test

* Use DevTest
* Activate `luacmd`
* `/time 0`
* `/set time_speed 0`
* `/lua me:set_stars({count=1100})`

Check how the sky changes. Are the existing 1000 (default) stars staying in their spots or are all stars shuffled at random?