### PR TITLE
Add transfer_player function to request client move to new server

### DIFF
--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -61,7 +61,17 @@ function ui.update()
 	local formspec = {}
 
 	-- handle errors
-	if gamedata ~= nil and gamedata.reconnect_requested then
+	if gamedata ~= nil and gamedata.reconnect_requested and #gamedata.transfer_address > 0 then
+		gamedata.reconnect_requested = false
+		gamedata.errormessage = nil
+		-- This is technically -not- a reconnect at this point
+		gamedata.do_reconnect = false
+		gamedata.address = gamedata.transfer_address
+		gamedata.port = gamedata.transfer_port
+		gamedata.playername = gamedata.transfer_playername
+		gamedata.password = gamedata.transfer_password
+		core.start()
+	elseif gamedata ~= nil and gamedata.reconnect_requested then
 		local error_message = core.formspec_escape(
 				gamedata.errormessage or "<none available>")
 		formspec = {

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5501,6 +5501,9 @@ Bans
 * `minetest.kick_player(name, [reason])`: disconnect a player with an optional
   reason.
     * Returns boolean indicating success (false if player nonexistant)
+* `minetest.transfer_player(name, address, port)`: Disconnect a player and
+  request the client re-connect at a new address and port. The connection
+  to the new server will occur using the same player name and password.
 
 Particles
 ---------

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -316,6 +316,9 @@ public:
 
 	bool reconnectRequested() const { return m_access_denied_reconnect; }
 
+	std::string getReconnectAddress() const { return m_access_denied_reconnect_address; }
+	std::string getReconnectPort() const { return m_access_denied_reconnect_port; }
+
 	void setFatalError(const std::string &reason)
 	{
 		m_access_denied = true;
@@ -523,6 +526,8 @@ private:
 
 	bool m_access_denied = false;
 	bool m_access_denied_reconnect = false;
+	std::string m_access_denied_reconnect_address = "";
+	std::string m_access_denied_reconnect_port = "";
 	std::string m_access_denied_reason = "";
 	std::queue<ClientEvent *> m_client_event_queue;
 	bool m_itemdef_received = false;

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -204,6 +204,9 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	std::string error_message;
 	bool reconnect_requested = false;
 
+	std::string reconnect_address;
+	std::string reconnect_port;
+
 	bool first_loop = true;
 
 	/*
@@ -235,10 +238,13 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 				core::rect<s32>(0, 0, 10000, 10000));
 
 			bool game_has_run = launch_game(error_message, reconnect_requested,
-				start_data, cmd_args);
+				reconnect_address, reconnect_port, start_data, cmd_args);
 
 			// Reset the reconnect_requested flag
 			reconnect_requested = false;
+
+			reconnect_address = "";
+			reconnect_port = "";
 
 			// If skip_main_menu, we only want to startup once
 			if (skip_main_menu && !first_loop)
@@ -274,7 +280,9 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 				start_data,
 				error_message,
 				chat_backend,
-				&reconnect_requested
+				&reconnect_requested,
+				reconnect_address,
+				reconnect_port
 			);
 			RenderingEngine::get_scene_manager()->clear();
 
@@ -376,7 +384,8 @@ void ClientLauncher::init_input()
 }
 
 bool ClientLauncher::launch_game(std::string &error_message,
-		bool reconnect_requested, GameStartData &start_data,
+		bool reconnect_requested, std::string reconnect_address,
+		std::string reconnect_port, GameStartData &start_data,
 		const Settings &cmd_args)
 {
 	// Prepare and check the start data to launch a game
@@ -427,6 +436,10 @@ bool ClientLauncher::launch_game(std::string &error_message,
 		menudata.port                            = itos(start_data.socket_port);
 		menudata.script_data.errormessage        = error_message_lua;
 		menudata.script_data.reconnect_requested = reconnect_requested;
+		menudata.script_data.transfer_address    = reconnect_address;
+		menudata.script_data.transfer_port       = reconnect_port;
+		menudata.script_data.transfer_playername = start_data.name;
+		menudata.script_data.transfer_password   = start_data.password;
 
 		main_menu(&menudata);
 

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -40,6 +40,7 @@ private:
 	void init_input();
 
 	bool launch_game(std::string &error_message, bool reconnect_requested,
+		std::string reconnect_address, std::string reconnect_port,
 		GameStartData &start_data, const Settings &cmd_args);
 
 	void main_menu(MainMenuData *menudata);

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -48,4 +48,6 @@ void the_game(bool *kill,
 		const GameStartData &start_data,
 		std::string &error_message,
 		ChatBackend &chat_backend,
-		bool *reconnect_requested);
+		bool *reconnect_requested,
+		std::string &reconnect_address,
+		std::string &reconnect_port);

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1169,3 +1169,4 @@ void LocalPlayer::handleAutojump(f32 dtime, Environment *env,
 		m_autojump_time = 0.1f;
 	}
 }
+

--- a/src/gui/guiMainMenu.h
+++ b/src/gui/guiMainMenu.h
@@ -30,6 +30,11 @@ struct MainMenuDataForScript {
 	// Whether the server has requested a reconnect
 	bool reconnect_requested = false;
 	std::string errormessage = "";
+
+	std::string transfer_address;
+	std::string transfer_port;
+	std::string transfer_playername;
+	std::string transfer_password;
 };
 
 struct MainMenuData {

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -206,6 +206,16 @@ void Client::handleCommand_AccessDenied(NetworkPacket* pkt)
 		u8 reconnect;
 		*pkt >> reconnect;
 		m_access_denied_reconnect = reconnect & 1;
+	} else if (denyCode == SERVER_ACCESSDENIED_TRANSFER) {
+		std::string addressPack;
+		*pkt >> addressPack;
+
+		m_access_denied_reason = accessDeniedStrings[denyCode];
+		m_access_denied_reconnect = true;
+
+		size_t splitAt = addressPack.find(';');
+		m_access_denied_reconnect_address = addressPack.substr(0, splitAt);
+		m_access_denied_reconnect_port = addressPack.substr(splitAt + 1);
 	} else if (denyCode == SERVER_ACCESSDENIED_CUSTOM_STRING) {
 		*pkt >> m_access_denied_reason;
 	} else if (denyCode == SERVER_ACCESSDENIED_TOO_MANY_USERS) {

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -1008,6 +1008,7 @@ enum AccessDeniedCode {
 	SERVER_ACCESSDENIED_CUSTOM_STRING,
 	SERVER_ACCESSDENIED_SHUTDOWN,
 	SERVER_ACCESSDENIED_CRASH,
+	SERVER_ACCESSDENIED_TRANSFER,
 	SERVER_ACCESSDENIED_MAX,
 };
 
@@ -1028,7 +1029,8 @@ const static std::string accessDeniedStrings[SERVER_ACCESSDENIED_MAX] = {
 	"Server authentication failed.  This is likely a server error.",
 	"",
 	"Server shutting down.",
-	"This server has experienced an internal error. You will now be disconnected."
+	"This server has experienced an internal error. You will now be disconnected.",
+	"Server is requesting a transfer"
 };
 
 enum PlayerListModifer : u8

--- a/src/script/cpp_api/s_mainmenu.cpp
+++ b/src/script/cpp_api/s_mainmenu.cpp
@@ -35,6 +35,12 @@ void ScriptApiMainMenu::setMainMenuData(MainMenuDataForScript *data)
 	}
 	lua_settable(L, gamedata_idx);
 	setboolfield(L, gamedata_idx, "reconnect_requested", data->reconnect_requested);
+
+	setstringfield(L, gamedata_idx, "transfer_address", data->transfer_address);
+	setstringfield(L, gamedata_idx, "transfer_port", data->transfer_port);
+	setstringfield(L, gamedata_idx, "transfer_playername", data->transfer_playername);
+	setstringfield(L, gamedata_idx, "transfer_password", data->transfer_password);
+
 	lua_pop(L, 1);
 }
 

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -40,6 +40,18 @@ int ModApiServer::l_request_shutdown(lua_State *L)
 	return 0;
 }
 
+int ModApiServer::l_transfer_player(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	const char *playerName = lua_tolstring(L, 1, NULL);
+	const char *address = lua_tolstring(L, 2, NULL);
+	const char *port = lua_tolstring(L, 3, NULL);
+
+	getServer(L)->getEnv().transferPlayer(playerName, address, port);
+	return 0;
+}
+
 // get_server_status()
 int ModApiServer::l_get_server_status(lua_State *L)
 {
@@ -526,6 +538,7 @@ int ModApiServer::l_set_last_run_mod(lua_State *L)
 void ModApiServer::Initialize(lua_State *L, int top)
 {
 	API_FCT(request_shutdown);
+	API_FCT(transfer_player);
 	API_FCT(get_server_status);
 	API_FCT(get_server_uptime);
 	API_FCT(get_worldpath);

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -27,6 +27,8 @@ private:
 	// request_shutdown([message], [reconnect])
 	static int l_request_shutdown(lua_State *L);
 
+	static int l_transfer_player(lua_State *L);
+
 	// get_server_status()
 	static int l_get_server_status(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1381,7 +1381,8 @@ void Server::SendAccessDenied(session_t peer_id, AccessDeniedCode reason,
 
 	NetworkPacket pkt(TOCLIENT_ACCESS_DENIED, 1, peer_id);
 	pkt << (u8)reason;
-	if (reason == SERVER_ACCESSDENIED_CUSTOM_STRING)
+	if (reason == SERVER_ACCESSDENIED_CUSTOM_STRING ||
+			reason == SERVER_ACCESSDENIED_TRANSFER)
 		pkt << custom_reason;
 	else if (reason == SERVER_ACCESSDENIED_SHUTDOWN ||
 			reason == SERVER_ACCESSDENIED_CRASH)

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -558,6 +558,18 @@ void ServerEnvironment::kickAllPlayers(AccessDeniedCode reason,
 	}
 }
 
+void ServerEnvironment::transferPlayer(const std::string &name, const std::string &address, const std::string &port)
+{
+	auto addressPack = address + ";" + port;
+
+	for (RemotePlayer *player : m_players) {
+		if (name.compare(player->getName()) == 0) {
+			m_server->DenyAccessVerCompliant(player->getPeerId(),
+				player->protocol_version, SERVER_ACCESSDENIED_TRANSFER, addressPack);
+		}
+	}
+}
+
 void ServerEnvironment::saveLoadedPlayers(bool force)
 {
 	for (RemotePlayer *player : m_players) {

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -213,6 +213,7 @@ public:
 
 	void kickAllPlayers(AccessDeniedCode reason,
 		const std::string &str_reason, bool reconnect);
+	void transferPlayer(const std::string &name, const std::string &address, const std::string &port);
 	// Save players
 	void saveLoadedPlayers(bool force = false);
 	void savePlayer(RemotePlayer *player);


### PR DESCRIPTION
This is my crack at an implementation for the following issues:
https://github.com/minetest/minetest/issues/10041
https://github.com/minetest/minetest/issues/5813
And, to a lesser extent:
https://github.com/minetest/minetest/issues/4428

On calling `minetest.transfer_player(name, address, port)`, the server sends a disconnect message of type `SERVER_ACCESSDENIED_TRANSFER` with the IP and port packed into customMessage.

Clients that support this new message type will disconnect and reconnect to the new address:port, using the same username and password as was used to connect to the current server.

Clients that do not support this new message will fall back gracefully. They disconnect and display the destination server address in the disconnection message box (in reality, this is the content of customMessage, which has the packed format address;port).

Eagerly open to suggestions for how this can be improved, with the end goal of finally getting this much-needed feature into the game. 😁

Edit: I should add that it is my view that synchronization be left for server owners to sort out. There's so many ways to coordinate between servers (HTTP, IRC, shared databases, and so on) I don't think it's necessary to introduce an engine feature for it. This sorts out the key obstacle: moving players from one server to another, without taking any stance on how synchronization (if any) should be performed.