### PR TITLE
Attachments: Avoid data loss caused by set_attach() in callbacks

### DIFF
--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -134,16 +134,21 @@ void UnitSAO::setAttachment(int parent_id, const std::string &bone, v3f position
 
 	int old_parent = m_attachment_parent_id;
 	m_attachment_parent_id = parent_id;
+
+	// The detach callbacks might call to setAttachment() again.
+	// Ensure the attachment params are applied after this callback is run.
+	if (parent_id != old_parent)
+		onDetach(old_parent);
+
+	m_attachment_parent_id = parent_id;
 	m_attachment_bone = bone;
 	m_attachment_position = position;
 	m_attachment_rotation = rotation;
 	m_force_visible = force_visible;
 	m_attachment_sent = false;
 
-	if (parent_id != old_parent) {
-		onDetach(old_parent);
+	if (parent_id != old_parent)
 		onAttach(parent_id);
-	}
 }
 
 void UnitSAO::getAttachment(int *parent_id, std::string *bone, v3f *position,


### PR DESCRIPTION
Counterpart to https://github.com/minetest/minetest_game/pull/2865 to fix https://github.com/minetest/minetest_game/issues/2864

This avoids data being overwritten in `on_detach_child` callbacks after calling to `on_attach` from another entity/mod.

## To do

This PR is Ready for Review.

## How to test

1. Place a MTG cart
2. Place a MTG boat
3. Rightclick one and the other, switch between them and observe the eye and attachment positions
