### PR TITLE
Also return the ObjectRef from minetest.spawn_falling_node()

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -407,7 +407,7 @@ local function convert_to_falling_node(pos, node)
 
 	obj:get_luaentity():set_node(node, metatable)
 	core.remove_node(pos)
-	return true
+	return true, obj
 end
 
 function core.spawn_falling_node(pos)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4927,7 +4927,7 @@ Environment access
     * Punch node with the same effects that a player would cause
 * `minetest.spawn_falling_node(pos)`
     * Change node into falling node
-    * Returns `true` if successful, `false` on failure
+    * Returns `true` and the ObjectRef of the spawned entity if successful, `false` on failure
 
 * `minetest.find_nodes_with_meta(pos1, pos2)`
     * Get a table of positions of nodes that have metadata within a region


### PR DESCRIPTION
I'd like to set the velocity of a spawned-in falling node (e.g. for nodes thrown by a mob or blown away by some force) without having to do extra logic to find the newly spawned in node or set-up the meta myself. This is a trivial change that allows that sort of thing to be done while maintaining compatibility with existing calls to the function.

## To do

This PR is a Ready for Review.
<!-- ^ delete one -->

## How to test

```Lua
minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
  local _, obj = minetest.spawn_falling_node(pos)
  obj:set_velocity(vector.new(0, 10, 0))
end)
```
