### PR TITLE
Allow renaming favorited servers in client

### DIFF
--- a/builtin/fstk/dialog.lua
+++ b/builtin/fstk/dialog.lua
@@ -50,13 +50,13 @@ local dialog_metatable = {
 }
 dialog_metatable.__index = dialog_metatable
 
-function dialog_create(name,get_formspec,buttonhandler,eventhandler)
+function dialog_create(name,get_formspec,buttonhandler,eventhandler,data)
 	local self = {}
 
 	self.name = name
 	self.type = "toplevel"
 	self.hidden = true
-	self.data = {}
+	self.data = data or {}
 
 	self.formspec      = get_formspec
 	self.buttonhandler = buttonhandler

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -47,7 +47,9 @@ end
 
 function render_serverlist_row(spec)
 	local text = ""
-	if spec.name then
+	if spec.nick then
+		text = text .. core.formspec_escape(spec.nick:trim())
+	elseif spec.name then
 		text = text .. core.formspec_escape(spec.name:trim())
 	elseif spec.address then
 		text = text .. core.formspec_escape(spec.address:trim())

--- a/builtin/mainmenu/dlg_rename_favorite.lua
+++ b/builtin/mainmenu/dlg_rename_favorite.lua
@@ -1,0 +1,41 @@
+
+local function rename_favorite_formspec(dialogdata)
+	local n_val = ""
+	if dialogdata.nick then n_val = dialogdata.nick:trim() end
+
+	local retval = "size[11.5,4.5,true]"
+		.. "field[2.5,2;7,0.5;te_fav_nick;" .. fgettext("Set server nick:") .. ";" .. n_val .. "]"
+		.. "button[3.25,3;2.5,0.5;btn_accept;" .. fgettext("Accept") .. "]"
+		.. "button[5.75,3;2.5,0.5;btn_cancel;" .. fgettext("Cancel") .. "]"
+
+	return retval
+end
+
+local function rename_favorite_buttonhandler(this, fields)
+	if fields.btn_cancel then
+		this:delete()
+		return true
+	elseif fields.btn_accept and fields.te_fav_nick then
+		local nick = fields.te_fav_nick:trim()
+		if nick ~= "" then
+			this.data.nick = nick
+			serverlistmgr.add_favorite(this.data)
+
+			this:delete()
+			return true
+		end
+	end
+
+	return false
+end
+
+function create_rename_favorite_dlg(data)
+	local retval = dialog_create(
+		"dlg_rename_fav",
+		rename_favorite_formspec,
+		rename_favorite_buttonhandler,
+		nil,
+		data)
+
+	return retval
+end

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -44,6 +44,7 @@ dofile(menupath .. DIR_DELIM .. "dlg_create_world.lua")
 dofile(menupath .. DIR_DELIM .. "dlg_delete_content.lua")
 dofile(menupath .. DIR_DELIM .. "dlg_delete_world.lua")
 dofile(menupath .. DIR_DELIM .. "dlg_rename_modpack.lua")
+dofile(menupath .. DIR_DELIM .. "dlg_rename_favorite.lua")
 
 local tabs = {}
 

--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -236,6 +236,7 @@ function serverlistmgr.add_favorite(new_favorite)
 		address = new_favorite.address,
 		port = new_favorite.port,
 		description = new_favorite.description,
+		nick = new_favorite.nick,
 	}
 
 	local favorites = serverlistmgr.get_favorites()

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -77,7 +77,7 @@ local function get_formspec(tabview, name, tabdata)
 		"container_end[]" ..
 
 		"container[9.75,0]" ..
-		"box[0,0;5.75,7;#666666]" ..
+		"box[0,0;5.75,7.95;#666666]" ..
 
 		-- Address / Port
 		"label[0.25,0.35;" .. fgettext("Address") .. "]" ..
@@ -104,7 +104,8 @@ local function get_formspec(tabview, name, tabdata)
 	if tabdata.selected then
 		if gamedata.fav then
 			retval = retval .. "button[0.25,6;2.5,0.75;btn_delete_favorite;" ..
-				fgettext("Del. Favorite") .. "]"
+				fgettext("Del. Favorite") .. "]button[0.25,6.95;2.5,0.75;btn_rename_favorite;" ..
+				fgettext("Rename") .. "]"
 		end
 		if gamedata.serverdescription then
 			retval = retval .. "textarea[0.25,3;5.25,2.75;;;" ..
@@ -141,7 +142,7 @@ local function get_formspec(tabview, name, tabdata)
 		"align=inline,padding=0.25,width=1.5;" ..
 		"color,align=inline,span=1;" ..
 		"text,align=inline,padding=1]" ..
-		"table[0.25,1;9.25,5.75;servers;"
+		"table[0.25,1;9.25,6.67;servers;"
 
 	local servers = get_sorted_servers()
 
@@ -173,7 +174,7 @@ local function get_formspec(tabview, name, tabdata)
 		retval = retval .. ";0]"
 	end
 
-	return retval, "size[15.5,7,false]real_coordinates[true]"
+	return retval, "size[15.5,7.95,false]real_coordinates[true]"
 end
 
 --------------------------------------------------------------------------------
@@ -314,6 +315,20 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		serverlistmgr.delete_favorite(server)
 		-- the server at [idx+1] will be at idx once list is refreshed
 		set_selected_server(tabdata, idx, tabdata.lookup[idx+1])
+		return true
+	end
+
+	if fields.btn_rename_favorite then
+		local idx = core.get_table_index("servers")
+		if not idx then return end
+		local fav = tabdata.lookup[idx]
+		if not fav then return end
+
+		local dlg_renamefav = create_rename_favorite_dlg(fav)
+		dlg_renamefav:set_parent(tabview)
+		tabview:hide()
+		dlg_renamefav:show()
+
 		return true
 	end
 


### PR DESCRIPTION
As per requested in https://github.com/minetest/minetest/issues/9932, this creates a button & dialog for renaming favorite servers.

## How to test

1. Highlight a favorited server.
2. Press "Rename" button.
3. Type desired nick in text field.
4. Press "Accept".

Closes #9932

Ready for review.