### PR TITLE
GLES fixes

### DIFF
--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -335,6 +335,10 @@ static bool getWindowHandle(irr::video::IVideoDriver *driver, HWND &hWnd)
 	case video::EDT_DIRECT3D9:
 		hWnd = reinterpret_cast<HWND>(exposedData.D3D9.HWnd);
 		break;
+#if ENABLE_GLES
+	case video::EDT_OGLES1:
+	case video::EDT_OGLES2:
+#endif
 	case video::EDT_OPENGL:
 		hWnd = reinterpret_cast<HWND>(exposedData.OpenGLWin32.HWnd);
 		break;

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -579,8 +579,10 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 	if (use_gles) {
 		shaders_header << R"(
 			#version 100
-			)";
+		)";
 		vertex_header = R"(
+			precision mediump float;
+
 			uniform highp mat4 mWorldView;
 			uniform highp mat4 mWorldViewProj;
 			uniform mediump mat4 mTexture;
@@ -592,17 +594,17 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 			attribute mediump vec3 inVertexNormal;
 			attribute mediump vec4 inVertexTangent;
 			attribute mediump vec4 inVertexBinormal;
-			)";
+		)";
 		fragment_header = R"(
 			precision mediump float;
-			)";
+		)";
 	} else {
 		shaders_header << R"(
 			#version 120
 			#define lowp
 			#define mediump
 			#define highp
-			)";
+		)";
 		vertex_header = R"(
 			#define mWorldView gl_ModelViewMatrix
 			#define mWorldViewProj gl_ModelViewProjectionMatrix
@@ -615,7 +617,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 			#define inVertexNormal gl_Normal
 			#define inVertexTangent gl_MultiTexCoord1
 			#define inVertexBinormal gl_MultiTexCoord2
-			)";
+		)";
 	}
 
 	bool use_discard = use_gles;


### PR DESCRIPTION
The first commit fixes the following error I encountered on GLES with an Intel GPU:
<pre>
2021-04-17 16:27:58: ERROR[Main]: Irrlicht: GLSL shader program failed to link
2021-04-17 16:27:58: ERROR[Main]: Irrlicht: Uniform "animationTimer" has different precision qualifier across different shaders.

2021-04-17 16:27:58: ERROR[Main]: generate_shader(): failed to generate "nodes_shader", addHighLevelShaderMaterial failed.
2021-04-17 16:27:58: WARNING[Main]: Vertex shader program:
2021-04-17 16:27:58: WARNING[Main]: ----------------------------------
2021-04-17 16:27:58: WARNING[Main]: 1: 
2021-04-17 16:27:58: WARNING[Main]: 2: 			#version 100
[...]
2021-04-17 16:27:58: WARNING[Main]: 39: 
2021-04-17 16:27:58: WARNING[Main]: 40: 			uniform highp mat4 mWorldView;
2021-04-17 16:27:58: WARNING[Main]: 41: 			uniform highp mat4 mWorldViewProj;
2021-04-17 16:27:58: WARNING[Main]: 42: 			uniform mediump mat4 mTexture;
2021-04-17 16:27:58: WARNING[Main]: 43: 			uniform mediump mat3 mNormal;
2021-04-17 16:27:58: WARNING[Main]: 44: 
2021-04-17 16:27:58: WARNING[Main]: 45: 			attribute highp vec4 inVertexPosition;
2021-04-17 16:27:58: WARNING[Main]: 46: 			attribute lowp vec4 inVertexColor;
2021-04-17 16:27:58: WARNING[Main]: 47: 			attribute mediump vec4 inTexCoord0;
2021-04-17 16:27:58: WARNING[Main]: 48: 			attribute mediump vec3 inVertexNormal;
2021-04-17 16:27:58: WARNING[Main]: 49: 			attribute mediump vec4 inVertexTangent;
2021-04-17 16:27:58: WARNING[Main]: 50: 			attribute mediump vec4 inVertexBinormal;
2021-04-17 16:27:58: WARNING[Main]: 51: 			uniform mat4 mWorld;
2021-04-17 16:27:58: WARNING[Main]: 52: 
2021-04-17 16:27:58: WARNING[Main]: 53: // Color of the light emitted by the sun.
2021-04-17 16:27:58: WARNING[Main]: 54: uniform vec3 dayLight;
2021-04-17 16:27:58: WARNING[Main]: 55: uniform vec3 eyePosition;
2021-04-17 16:27:58: WARNING[Main]: 56: 
2021-04-17 16:27:58: WARNING[Main]: 57: // The cameraOffset is the current center of the visible world.
2021-04-17 16:27:58: WARNING[Main]: 58: uniform vec3 cameraOffset;
2021-04-17 16:27:58: WARNING[Main]: 59: uniform float animationTimer;
2021-04-17 16:27:58: WARNING[Main]: 60: 
2021-04-17 16:27:58: WARNING[Main]: 61: varying vec3 vPosition;
2021-04-17 16:27:58: WARNING[Main]: 62: // World position in the visible world (i.e. relative to the cameraOffset.)
2021-04-17 16:27:58: WARNING[Main]: 63: // This can be used for many shader effects without loss of precision.
2021-04-17 16:27:58: WARNING[Main]: 64: // If the absolute position is required it can be calculated with
2021-04-17 16:27:58: WARNING[Main]: 65: // cameraOffset + worldPosition (for large coordinates the limits of float
2021-04-17 16:27:58: WARNING[Main]: 66: // precision must be considered).
2021-04-17 16:27:58: WARNING[Main]: 67: varying vec3 worldPosition;
2021-04-17 16:27:58: WARNING[Main]: 68: varying lowp vec4 varColor;
2021-04-17 16:27:58: WARNING[Main]: 69: // The centroid keyword ensures that after interpolation the texture coordinates
2021-04-17 16:27:58: WARNING[Main]: 70: // lie within the same bounds when MSAA is en- and disabled.
2021-04-17 16:27:58: WARNING[Main]: 71: // This fixes the stripes problem with nearest-neighbour textures and MSAA.
2021-04-17 16:27:58: WARNING[Main]: 72: #ifdef GL_ES
2021-04-17 16:27:58: WARNING[Main]: 73: varying mediump vec2 varTexCoord;
2021-04-17 16:27:58: WARNING[Main]: 74: #else
2021-04-17 16:27:58: WARNING[Main]: 75: centroid varying vec2 varTexCoord;
2021-04-17 16:27:58: WARNING[Main]: 76: #endif
2021-04-17 16:27:58: WARNING[Main]: 77: varying vec3 eyeVec;
2021-04-17 16:27:58: WARNING[Main]: 78: 
[...]
2021-04-17 16:27:58: WARNING[Main]: End of Vertex shader program.
2021-04-17 16:27:58: WARNING[Main]:  
2021-04-17 16:27:58: WARNING[Main]: Fragment shader program:
2021-04-17 16:27:58: WARNING[Main]: ----------------------------------
2021-04-17 16:27:58: WARNING[Main]: 1: 
2021-04-17 16:27:58: WARNING[Main]: 2: 			#version 100
[...]
2021-04-17 16:27:58: WARNING[Main]: 39: 
2021-04-17 16:27:58: WARNING[Main]: 40: 			precision mediump float;
2021-04-17 16:27:58: WARNING[Main]: 41: 			uniform sampler2D baseTexture;
2021-04-17 16:27:58: WARNING[Main]: 42: 
2021-04-17 16:27:58: WARNING[Main]: 43: uniform vec4 skyBgColor;
2021-04-17 16:27:58: WARNING[Main]: 44: uniform float fogDistance;
2021-04-17 16:27:58: WARNING[Main]: 45: uniform vec3 eyePosition;
2021-04-17 16:27:58: WARNING[Main]: 46: 
2021-04-17 16:27:58: WARNING[Main]: 47: // The cameraOffset is the current center of the visible world.
2021-04-17 16:27:58: WARNING[Main]: 48: uniform vec3 cameraOffset;
2021-04-17 16:27:58: WARNING[Main]: 49: uniform float animationTimer;
2021-04-17 16:27:58: WARNING[Main]: 50: 
2021-04-17 16:27:58: WARNING[Main]: 51: varying vec3 vPosition;
2021-04-17 16:27:58: WARNING[Main]: 52: // World position in the visible world (i.e. relative to the cameraOffset.)
2021-04-17 16:27:58: WARNING[Main]: 53: // This can be used for many shader effects without loss of precision.
2021-04-17 16:27:58: WARNING[Main]: 54: // If the absolute position is required it can be calculated with
2021-04-17 16:27:58: WARNING[Main]: 55: // cameraOffset + worldPosition (for large coordinates the limits of float
2021-04-17 16:27:58: WARNING[Main]: 56: // precision must be considered).
2021-04-17 16:27:58: WARNING[Main]: 57: varying vec3 worldPosition;
2021-04-17 16:27:58: WARNING[Main]: 58: varying lowp vec4 varColor;
2021-04-17 16:27:58: WARNING[Main]: 59: #ifdef GL_ES
2021-04-17 16:27:58: WARNING[Main]: 60: varying mediump vec2 varTexCoord;
2021-04-17 16:27:58: WARNING[Main]: 61: #else
2021-04-17 16:27:58: WARNING[Main]: 62: centroid varying vec2 varTexCoord;
2021-04-17 16:27:58: WARNING[Main]: 63: #endif
2021-04-17 16:27:58: WARNING[Main]: 64: varying vec3 eyeVec;
2021-04-17 16:27:58: WARNING[Main]: 65: 
[...]
2021-04-17 16:27:59: WARNING[Main]: End of Fragment shader program.
2021-04-17 16:27:59: WARNING[Main]:  
2021-04-17 16:27:59: WARNING[Main]: Geometry shader program:
2021-04-17 16:27:59: WARNING[Main]: ----------------------------------
2021-04-17 16:27:59: WARNING[Main]: 1: 
2021-04-17 16:27:59: WARNING[Main]: End of Geometry shader program.
2021-04-17 16:27:59: WARNING[Main]:  
</pre>

## To do

This PR is a Ready for Review.

