### PR TITLE
Look for PostgreSQL library properly and fix CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Compiling
 | Dependency | Version | Commentary |
 |------------|---------|------------|
 | GCC        | 4.9+    | Can be replaced with Clang 3.4+ |
-| CMake      | 2.6+    |            |
+| CMake      | 3.5+    |            |
 | Irrlicht   | -       | Custom version required, see https://github.com/minetest/irrlicht |
 | SQLite3    | 3.0+    |            |
 | LuaJIT     | 2.0+    | Bundled Lua 5.1 is used if not present |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,7 +146,16 @@ option(ENABLE_POSTGRESQL "Enable PostgreSQL backend" TRUE)
 set(USE_POSTGRESQL FALSE)
 
 if(ENABLE_POSTGRESQL)
-	find_package("PostgreSQL")
+	if(CMAKE_VERSION VERSION_LESS "3.20")
+		find_package(PostgreSQL QUIET)
+		# Before CMake 3.20 FindPostgreSQL.cmake always looked for server includes
+		# but we don't need them, so continue anyway if only those are missing.
+		if(PostgreSQL_INCLUDE_DIR AND PostgreSQL_LIBRARY)
+			set(PostgreSQL_FOUND TRUE)
+		endif()
+	else()
+		find_package(PostgreSQL)
+	endif()
 
 	if(PostgreSQL_FOUND)
 		set(USE_POSTGRESQL TRUE)

--- a/util/ci/common.sh
+++ b/util/ci/common.sh
@@ -5,8 +5,7 @@ install_linux_deps() {
 	local pkgs=(cmake libpng-dev \
 		libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev \
 		libhiredis-dev libogg-dev libgmp-dev libvorbis-dev libopenal-dev \
-		gettext libpq-dev postgresql-server-dev-all libleveldb-dev \
-		libcurl4-openssl-dev)
+		gettext libpq-dev libleveldb-dev libcurl4-openssl-dev)
 
 	if [[ "$1" == "--old-irr" ]]; then
 		shift


### PR DESCRIPTION
Problem: `postgresql-server-dev-all` became [uninstallable inside Github Actions](https://github.com/minetest/minetest/runs/2374156689?check_suite_focus=true), which broke almost all of the CI runs.

But we don't actually need that package for postgres integration, yet CMake forcefully searches for it.
This was only fixed by https://github.com/Kitware/CMake/commit/8b066f1a65466ae2dc542b097f877795f386f942 (CMake 3.20), but it's relatively easy to add a workaround for older versions.

## To do

This PR is Ready for Review.

## How to test

Use your eyes on the CI results.
