### PR TITLE
[NO SQUASH] Add basic client-server test to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install deps
         run: |
           source ./util/ci/common.sh
-          install_linux_deps clang-3.9
+          install_linux_deps clang-3.9 gdb
 
       - name: Build
         run: |
@@ -89,9 +89,13 @@ jobs:
           CC: clang-3.9
           CXX: clang++-3.9
 
-      - name: Test
+      - name: Unittest
         run: |
           ./bin/minetest --run-unittests
+
+      - name: Integration test
+        run: |
+          ./util/test_multiplayer.sh
 
   # This is the current clang version
   clang_9:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,11 +102,11 @@ endif()
 option(ENABLE_GLES "Use OpenGL ES instead of OpenGL" FALSE)
 mark_as_advanced(ENABLE_GLES)
 if(BUILD_CLIENT)
-	if(ENABLE_GLES)
-		find_package(OpenGLES2 REQUIRED)
-	else()
-		# transitive dependency from Irrlicht (see longer explanation below)
-		if(NOT WIN32)
+	# transitive dependency from Irrlicht (see longer explanation below)
+	if(NOT WIN32)
+		if(ENABLE_GLES)
+			find_package(OpenGLES2 REQUIRED)
+		else()
 			set(OPENGL_GL_PREFERENCE "LEGACY" CACHE STRING
 				"See CMake Policy CMP0072 for reference. GLVND is broken on some nvidia setups")
 			set(OpenGL_GL_PREFERENCE ${OPENGL_GL_PREFERENCE})
@@ -521,10 +521,6 @@ include_directories(
 	${X11_INCLUDE_DIR}
 	${PROJECT_SOURCE_DIR}/script
 )
-
-if(ENABLE_GLES)
-	include_directories(${OPENGLES2_INCLUDE_DIR} ${EGL_INCLUDE_DIR})
-endif()
 
 if(USE_GETTEXT)
 	include_directories(${GETTEXT_INCLUDE_DIR})

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -23,7 +23,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h"
 #include <cstdio>
 #include "client/renderingengine.h"
-#include "client/tile.h" // hasNPotSupport()
 
 /* Maintain a static cache to store the images that correspond to textures
  * in a format that's manipulable by code.  Some platforms exhibit issues
@@ -117,7 +116,7 @@ video::ITexture *guiScalingResizeCached(video::IVideoDriver *driver,
 #if ENABLE_GLES
 	// Some platforms are picky about textures being powers of 2, so expand
 	// the image dimensions to the next power of 2, if necessary.
-	if (!hasNPotSupport()) {
+	if (!driver->queryFeature(video::EVDF_TEXTURE_NPOT)) {
 		video::IImage *po2img = driver->createImage(src->getColorFormat(),
 				core::dimension2d<u32>(npot2((u32)destrect.getWidth()),
 				npot2((u32)destrect.getHeight())));

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -34,15 +34,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiscalingfilter.h"
 #include "renderingengine.h"
 
-
-#if ENABLE_GLES
-#ifdef _IRR_COMPILE_WITH_OGLES1_
-#include <GLES/gl.h>
-#else
-#include <GLES2/gl2.h>
-#endif
-#endif
-
 /*
 	A cache from texture name to texture path
 */
@@ -1013,42 +1004,19 @@ video::IImage* TextureSource::generateImage(const std::string &name)
 
 #if ENABLE_GLES
 
-
-static inline u16 get_GL_major_version()
-{
-	const GLubyte *gl_version = glGetString(GL_VERSION);
-	return (u16) (gl_version[0] - '0');
-}
-
-/**
- * Check if hardware requires npot2 aligned textures
- * @return true if alignment NOT(!) requires, false otherwise
- */
-
-bool hasNPotSupport()
-{
-	// Only GLES2 is trusted to correctly report npot support
-	// Note: we cache the boolean result, the GL context will never change.
-	static const bool supported = get_GL_major_version() > 1 &&
-		glGetString(GL_EXTENSIONS) &&
-		strstr((char *)glGetString(GL_EXTENSIONS), "GL_OES_texture_npot");
-	return supported;
-}
-
 /**
  * Check and align image to npot2 if required by hardware
  * @param image image to check for npot2 alignment
  * @param driver driver to use for image operations
  * @return image or copy of image aligned to npot2
  */
-
-video::IImage * Align2Npot2(video::IImage * image,
-		video::IVideoDriver* driver)
+video::IImage *Align2Npot2(video::IImage *image,
+		video::IVideoDriver *driver)
 {
 	if (image == NULL)
 		return image;
 
-	if (hasNPotSupport())
+	if (driver->queryFeature(video::EVDF_TEXTURE_NPOT))
 		return image;
 
 	core::dimension2d<u32> dim = image->getDimension();

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -134,8 +134,7 @@ public:
 IWritableTextureSource *createTextureSource();
 
 #if ENABLE_GLES
-bool hasNPotSupport();
-video::IImage * Align2Npot2(video::IImage * image, irr::video::IVideoDriver* driver);
+video::IImage *Align2Npot2(video::IImage *image, video::IVideoDriver *driver);
 #endif
 
 enum MaterialType{

--- a/util/ci/common.sh
+++ b/util/ci/common.sh
@@ -11,7 +11,9 @@ install_linux_deps() {
 		shift
 		pkgs+=(libirrlicht-dev)
 	else
-		wget "https://github.com/minetest/irrlicht/releases/download/1.9.0mt1/ubuntu-bionic.tar.gz"
+		# TODO: return old URL when IrrlichtMt 1.9.0mt2 is tagged
+		#wget "https://github.com/minetest/irrlicht/releases/download/1.9.0mt1/ubuntu-bionic.tar.gz"
+		wget "http://minetest.kitsunemimi.pw/irrlichtmt-patched-temporary.tgz" -O ubuntu-bionic.tar.gz
 		sudo tar -xaf ubuntu-bionic.tar.gz -C /usr/local
 	fi
 

--- a/util/test_multiplayer.sh
+++ b/util/test_multiplayer.sh
@@ -3,41 +3,58 @@ dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 gameid=devtest
 minetest=$dir/../bin/minetest
 testspath=$dir/../tests
-worldpath=$testspath/testworld_$gameid
-configpath=$testspath/configs
-logpath=$testspath/log
-conf_server=$configpath/minetest.conf.multi.server
-conf_client1=$configpath/minetest.conf.multi.client1
-conf_client2=$configpath/minetest.conf.multi.client2
-log_server=$logpath/server.log
-log_client1=$logpath/client1.log
-log_client2=$logpath/client2.log
+conf_client1=$testspath/client1.conf
+conf_server=$testspath/server.conf
+worldpath=$testspath/world
 
-mkdir -p $worldpath
-mkdir -p $configpath
-mkdir -p $logpath
+waitfor () {
+	n=30
+	while [ $n -gt 0 ]; do
+		[ -f "$1" ] && return 0
+		sleep 0.5
+		((n-=1))
+	done
+	echo "Waiting for ${1##*/} timed out"
+	pkill -P $$
+	exit 1
+}
 
-echo -ne 'client1::shout,interact,settime,teleport,give
-client2::shout,interact,settime,teleport,give
-' > $worldpath/auth.txt
+gdbrun () {
+	gdb -q -ex 'set confirm off' -ex 'r' -ex 'bt' -ex 'quit' --args "$@"
+}
 
-echo -ne '' > $conf_server
+[ -e $minetest ] || { echo "executable $minetest missing"; exit 1; }
 
-echo -ne '# client 1 config
-screenW=500
-screenH=380
-name=client1
-viewing_range_nodes_min=10
-' > $conf_client1
+rm -rf $worldpath
+mkdir -p $worldpath/worldmods/test
 
-echo -ne '# client 2 config
-screenW=500
-screenH=380
-name=client2
-viewing_range_nodes_min=10
-' > $conf_client2
+printf '%s\n' >$testspath/client1.conf \
+	video_driver=null name=client1 viewing_range=10 \
+	enable_{sound,minimap,shaders}=false
 
-echo $(sleep 1; $minetest --disable-unittests --logfile $log_client1 --config $conf_client1 --go --address localhost) &
-echo $(sleep 2; $minetest --disable-unittests --logfile $log_client2 --config $conf_client2 --go --address localhost) &
-$minetest --disable-unittests --server --logfile $log_server --config $conf_server --world $worldpath --gameid $gameid
+printf '%s\n' >$testspath/server.conf \
+	max_block_send_distance=1
 
+cat >$worldpath/worldmods/test/init.lua <<"LUA"
+core.after(0, function()
+	io.close(io.open(core.get_worldpath() .. "/startup", "w"))
+end)
+core.register_on_joinplayer(function(player)
+	io.close(io.open(core.get_worldpath() .. "/player_joined", "w"))
+	core.request_shutdown("", false, 2)
+end)
+LUA
+
+echo "Starting server"
+gdbrun $minetest --server --config $conf_server --world $worldpath --gameid $gameid 2>&1 | sed -u 's/^/(server) /' &
+waitfor $worldpath/startup
+
+echo "Starting client"
+gdbrun $minetest --config $conf_client1 --go --address 127.0.0.1 2>&1 | sed -u 's/^/(client) /' &
+waitfor $worldpath/player_joined
+
+echo "Waiting for client and server to exit"
+wait
+
+echo "Success"
+exit 0


### PR DESCRIPTION
This tests starting up a server, starting up a client (without video driver), joining and shutting down the server again.

#### Why the GLES commit?

I stumbled upon by accident, when you have Minetest compiled with `ENABLE_GLES=1` it is completely unable to start up under the Null video driver since it assumes it can call `glGetString` and consequently indexes a NULL pointer.
Irrlicht provides a way to query the thing needed so I changed it to do just that.

#### Why the weird `irrlichtmt-patched-temporary.tgz` ?

Running under the Null driver only works with fresh commits I made to IrrlichtMt.
`1.9.0mt2` isn't ready to tag for <i>reasons</i>, so there's this thing so that the CI can successfully run until then.

## To do

This PR is Ready for Review.

## How to test

Look here: https://github.com/sfan5/minetest/runs/2403291242?check_suite_focus=true (runs in the clang-3.9 build)

You can also run `./util/test_multiplayer.sh` locally
