### PR TITLE
Ignore mod dirs starts with an tilde (`~`)

### DIFF
--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -176,7 +176,7 @@ std::map<std::string, ModSpec> getModsInPath(
 		// Also ignore all directories beginning with a "_", to allow
 		// special directories which does not contains mods, i.e.
 		// documentations and test files
-		if (modname[0] == '.' || modname[0] == "_")
+		if (modname[0] == '.' || modname[0] == '_')
 			continue;
 
 		modpath.clear();

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -173,7 +173,10 @@ std::map<std::string, ModSpec> getModsInPath(
 		const std::string &modname = dln.name;
 		// Ignore all directories beginning with a ".", especially
 		// VCS directories like ".git" or ".svn"
-		if (modname[0] == '.')
+		// Also ignore all directories beginning with a "_", to allow
+		// special directories which does not contains mods, i.e.
+		// documentations and test files
+		if (modname[0] == '.' || modname[0] == "_")
 			continue;
 
 		modpath.clear();

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -173,10 +173,10 @@ std::map<std::string, ModSpec> getModsInPath(
 		const std::string &modname = dln.name;
 		// Ignore all directories beginning with a ".", especially
 		// VCS directories like ".git" or ".svn"
-		// Also ignore all directories beginning with a "_", to allow
+		// Also ignore all directories beginning with a "~", to allow
 		// special directories which does not contains mods, i.e.
 		// documentations and test files
-		if (modname[0] == '.' || modname[0] == '_')
+		if (modname[0] == '.' || modname[0] == '~')
 			continue;
 
 		modpath.clear();


### PR DESCRIPTION
Close #11240, to ignore mod dirs starts with an <s>underscore (`_`)</s> tilde (`~`)

## To do

This PR is Ready for Review, please help me to test it.
<!-- ^ delete one -->

- [x] Ignore mod dirs starts with an <s>underscore (`_`)</s> tilde (`~`)

## How to test

Create a mod with these dirs:
```
example_mod/
├── ~docs
├── .hidden_file
├── modpack.conf
├── real_mod
│   ├── init.lua
│   ├── mod.conf
│   └── textures
│       └── real_textures.png
└── ~test
```
Note that `~docs`, `~test`, and `.hidden_file` will not show in neither mod menu nor `world.mt`.