### PR TITLE
Fix build for newer versions of GCC

### DIFF
--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -31,6 +31,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <list>
 #include <vector>
 #include <set>
+#include <memory>
 #include <mutex>
 
 class MapBlock;


### PR DESCRIPTION
I just upgraded my distro a few days ago. Now Minetest fails to compile with the below error.

```
In file included from minetest/src/clientiface.cpp:21:
minetest/src/clientiface.h:444:36: error: ‘shared_ptr’ in namespace ‘std’ does not name a template type
444 |         ClientInterface(const std::shared_ptr<con::Connection> &con);
|                                    ^~~~~~~~~~
In file included from minetest/src/clientiface.cpp:21:
minetest/src/clientiface.h:34:1: note: ‘std::shared_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
```

So here I just added an include for `memory`, which can't do any harm - it is included from other files as well.
