### PR TITLE
Add core.compare_block_status function

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5849,6 +5849,19 @@ Misc.
     * If `transient` is `false` or absent, frees a persistent forceload.
       If `true`, frees a transient forceload.
 
+* `minetest.compare_block_status(pos, condition)`
+    * Checks whether the mapblock at positition `pos` is in the wanted condition.
+    * `condition` may be one of the following values:
+        * `"unknown"`: not in memory
+        * `"loaded"`: in memory but inactive (no ABMs are executed)
+        * `"active"`: in memory and active
+        * Other values are reserved for future functionality extensions
+    * Return value, the comparison status:
+        * `-1`: Condition is not met. Mapblock is not ready
+        * `0`: Mapblock is exactly in the wanted condition
+        * `1`: The mapblock surpasses the given condition (i.e. rather ready)
+        * `nil`: Unsupported `condition` value
+
 * `minetest.request_insecure_environment()`: returns an environment containing
   insecure functions if the calling mod has been listed as trusted in the
   `secure.trusted_mods` setting or security is disabled, otherwise returns

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5853,7 +5853,7 @@ Misc.
     * Checks whether the mapblock at positition `pos` is in the wanted condition.
     * `condition` may be one of the following values:
         * `"unknown"`: not in memory
-        * `"emerging"`: in the queue for generating
+        * `"emerging"`: in the queue for loading from disk or generating
         * `"loaded"`: in memory but inactive (no ABMs are executed)
         * `"active"`: in memory and active
         * Other values are reserved for future functionality extensions

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5853,13 +5853,13 @@ Misc.
     * Checks whether the mapblock at positition `pos` is in the wanted condition.
     * `condition` may be one of the following values:
         * `"unknown"`: not in memory
+        * `"emerging"`: in the queue for generating
         * `"loaded"`: in memory but inactive (no ABMs are executed)
         * `"active"`: in memory and active
         * Other values are reserved for future functionality extensions
     * Return value, the comparison status:
-        * `-1`: Condition is not met. Mapblock is not ready
-        * `0`: Mapblock is exactly in the wanted condition
-        * `1`: The mapblock surpasses the given condition (i.e. rather ready)
+        * `false`: Mapblock does not fulfil the wanted condition
+        * `true`: Mapblock meets the requirement
         * `nil`: Unsupported `condition` value
 
 * `minetest.request_insecure_environment()`: returns an environment containing

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -358,6 +358,13 @@ bool EmergeManager::enqueueBlockEmergeEx(
 }
 
 
+bool EmergeManager::isBlockInQueue(v3s16 pos)
+{
+	MutexAutoLock queuelock(m_queue_mutex);
+	return m_blocks_enqueued.find(pos) != m_blocks_enqueued.end();
+}
+
+
 //
 // Mapgen-related helper functions
 //

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -174,6 +174,8 @@ public:
 		EmergeCompletionCallback callback,
 		void *callback_param);
 
+	bool isBlockInQueue(v3s16 pos);
+
 	v3s16 getContainingChunk(v3s16 blockpos);
 
 	Mapgen *getCurrentMapgen();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1549,6 +1549,11 @@ MapBlock *ServerMap::getBlockOrEmerge(v3s16 p3d)
 	return block;
 }
 
+bool ServerMap::isBlockInQueue(v3s16 pos)
+{
+	return m_emerge && m_emerge->isBlockInQueue(pos);
+}
+
 // N.B.  This requires no synchronization, since data will not be modified unless
 // the VoxelManipulator being updated belongs to the same thread.
 void ServerMap::updateVManip(v3s16 pos)

--- a/src/map.h
+++ b/src/map.h
@@ -365,6 +365,8 @@ public:
 	*/
 	MapBlock *getBlockOrEmerge(v3s16 p3d);
 
+	bool isBlockInQueue(v3s16 pos);
+
 	/*
 		Database functions
 	*/

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -140,7 +140,7 @@ public:
 	//// Flags
 	////
 
-	inline bool isDummy()
+	inline bool isDummy() const
 	{
 		return !data;
 	}

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -56,6 +56,7 @@ const EnumString ModApiEnvMod::es_ClearObjectsMode[] =
 const EnumString ModApiEnvMod::es_BlockStatusType[] =
 {
 	{ServerEnvironment::BS_UNKNOWN, "unknown"},
+	{ServerEnvironment::BS_EMERGING, "emerging"},
 	{ServerEnvironment::BS_LOADED,  "loaded"},
 	{ServerEnvironment::BS_ACTIVE,  "active"},
 	{0, NULL},
@@ -1397,7 +1398,7 @@ int ModApiEnvMod::l_forceload_block(lua_State *L)
 	return 0;
 }
 
-// get_block_status(nodepos)
+// compare_block_status(nodepos)
 int ModApiEnvMod::l_compare_block_status(lua_State *L)
 {
 	GET_ENV_PTR;
@@ -1408,11 +1409,9 @@ int ModApiEnvMod::l_compare_block_status(lua_State *L)
 	
 	int condition_i = -1;
 	if (!string_to_enum(es_BlockStatusType, condition_i, condition_s))
-		return 0;
+		return 0; // Unsupported
 
-	// Convert difference to -1 (diff < 0), 0 and 1 (diff > 0)
-	int diff = (int)status - condition_i;
-	lua_pushnumber(L, (diff > 0) - (diff < 0));
+	lua_pushboolean(L, status >= condition_i);
 	return 1;
 }
 

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -46,10 +46,18 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/client.h"
 #endif
 
-struct EnumString ModApiEnvMod::es_ClearObjectsMode[] =
+const EnumString ModApiEnvMod::es_ClearObjectsMode[] =
 {
 	{CLEAR_OBJECTS_MODE_FULL,  "full"},
 	{CLEAR_OBJECTS_MODE_QUICK, "quick"},
+	{0, NULL},
+};
+
+const EnumString ModApiEnvMod::es_BlockStatusType[] =
+{
+	{ServerEnvironment::BS_UNKNOWN, "unknown"},
+	{ServerEnvironment::BS_LOADED,  "loaded"},
+	{ServerEnvironment::BS_ACTIVE,  "active"},
 	{0, NULL},
 };
 
@@ -1389,6 +1397,26 @@ int ModApiEnvMod::l_forceload_block(lua_State *L)
 	return 0;
 }
 
+// get_block_status(nodepos)
+int ModApiEnvMod::l_compare_block_status(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	v3s16 nodepos = check_v3s16(L, 1);
+	std::string condition_s = luaL_checkstring(L, 2);
+	auto status = env->getBlockStatus(getNodeBlockPos(nodepos));
+	
+	int condition_i = -1;
+	if (!string_to_enum(es_BlockStatusType, condition_i, condition_s))
+		return 0;
+
+	// Convert difference to -1 (diff < 0), 0 and 1 (diff > 0)
+	int diff = (int)status - condition_i;
+	lua_pushnumber(L, (diff > 0) - (diff < 0));
+	return 1;
+}
+
+
 // forceload_free_block(blockpos)
 // blockpos = {x=num, y=num, z=num}
 int ModApiEnvMod::l_forceload_free_block(lua_State *L)
@@ -1462,6 +1490,7 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(transforming_liquid_add);
 	API_FCT(forceload_block);
 	API_FCT(forceload_free_block);
+	API_FCT(compare_block_status);
 	API_FCT(get_translated_string);
 }
 

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -195,6 +195,9 @@ private:
 	// stops forceloading a position
 	static int l_forceload_free_block(lua_State *L);
 
+	// compare_block_status(nodepos)
+	static int l_compare_block_status(lua_State *L);
+
 	// Get a string translated server side
 	static int l_get_translated_string(lua_State * L);
 
@@ -207,7 +210,8 @@ public:
 	static void Initialize(lua_State *L, int top);
 	static void InitializeClient(lua_State *L, int top);
 
-	static struct EnumString es_ClearObjectsMode[];
+	static const EnumString es_ClearObjectsMode[];
+	static const EnumString es_BlockStatusType[];
 };
 
 class LuaABM : public ActiveBlockModifier {

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1542,6 +1542,18 @@ void ServerEnvironment::step(float dtime)
 	m_server->sendDetachedInventories(PEER_ID_INEXISTENT, true);
 }
 
+ServerEnvironment::BlockStatus ServerEnvironment::getBlockStatus(v3s16 blockpos)
+{
+	if (m_active_blocks.contains(blockpos))
+		return BS_ACTIVE;
+
+	const MapBlock *block = getMap().getBlockNoCreateNoEx(blockpos);
+	if (block && !block->isDummy())
+		return BS_LOADED;
+
+	return BS_UNKNOWN;
+}
+
 u32 ServerEnvironment::addParticleSpawner(float exptime)
 {
 	// Timers with lifetime 0 do not expire

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1547,9 +1547,12 @@ ServerEnvironment::BlockStatus ServerEnvironment::getBlockStatus(v3s16 blockpos)
 	if (m_active_blocks.contains(blockpos))
 		return BS_ACTIVE;
 
-	const MapBlock *block = getMap().getBlockNoCreateNoEx(blockpos);
+	const MapBlock *block = m_map->getBlockNoCreateNoEx(blockpos);
 	if (block && !block->isDummy())
 		return BS_LOADED;
+
+	if (m_map->isBlockInQueue(blockpos))
+		return BS_EMERGING;
 
 	return BS_UNKNOWN;
 }

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -342,7 +342,15 @@ public:
 	void reportMaxLagEstimate(float f) { m_max_lag_estimate = f; }
 	float getMaxLagEstimate() { return m_max_lag_estimate; }
 
-	std::set<v3s16>* getForceloadedBlocks() { return &m_active_blocks.m_forceloaded_list; };
+	std::set<v3s16>* getForceloadedBlocks() { return &m_active_blocks.m_forceloaded_list; }
+
+	// Sorted by how ready a mapblock is
+	enum BlockStatus {
+		BS_UNKNOWN,
+		BS_LOADED,
+		BS_ACTIVE // always highest value
+	};
+	BlockStatus getBlockStatus(v3s16 blockpos);
 
 	// Sets the static object status all the active objects in the specified block
 	// This is only really needed for deleting blocks from the map

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -347,6 +347,7 @@ public:
 	// Sorted by how ready a mapblock is
 	enum BlockStatus {
 		BS_UNKNOWN,
+		BS_EMERGING,
 		BS_LOADED,
 		BS_ACTIVE // always highest value
 	};


### PR DESCRIPTION
Counter-proposal to #10897.

Intention:
 * Extensible API (for emerge or database checks later on?)
 * API support checking (`nil` return value)
 * Easy mapblock condition requirement checks in mods

The goal is not to return the direct mapblock status, but to provide a simple way to check whether a mapblock meets the required condition.

Intended use in mods
```Lua
if minetest.compare_block_status(pos, "active") == true then
	-- Supplementary action which does not depend on ABMs
else
	-- skip until block is loaded
end
```

## To do

This PR is Ready for Review.

## How to test

```Lua
core.register_chatcommand("bs", {
	func = function(name, param)
		local pos = core.string_to_pos(param)
		if not pos then
			return false, "Cannot parse pos"
		end
		return true, "Status of block " .. core.pos_to_string(pos) .. ": "
			.. tostring(core.compare_block_status(pos, "loaded"))
	end,
})

minetest.register_on_generated(function(minp, maxp, blockseed)
	print("Block inside pos " .. core.pos_to_string(minp) .. ": "
		.. tostring(core.compare_block_status(minp, "emerging")))
end)
```

Run away from the original position, check different map positions.
