### PR TITLE
Fix swapped vertex colors on GLES2

### DIFF
--- a/client/shaders/default_shader/opengl_vertex.glsl
+++ b/client/shaders/default_shader/opengl_vertex.glsl
@@ -3,5 +3,9 @@ varying lowp vec4 varColor;
 void main(void)
 {
 	gl_Position = mWorldViewProj * inVertexPosition;
+#ifdef GL_ES
+	varColor = inVertexColor.bgra;
+#else
 	varColor = inVertexColor;
+#endif
 }

--- a/client/shaders/minimap_shader/opengl_vertex.glsl
+++ b/client/shaders/minimap_shader/opengl_vertex.glsl
@@ -7,5 +7,9 @@ void main(void)
 {
 	varTexCoord = inTexCoord0.st;
 	gl_Position = mWorldViewProj * inVertexPosition;
+#ifdef GL_ES
+	varColor = inVertexColor.bgra;
+#else
 	varColor = inVertexColor;
+#endif
 }

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -146,10 +146,14 @@ void main(void)
 	// the brightness, so now we have to multiply these
 	// colors with the color of the incoming light.
 	// The pre-baked colors are halved to prevent overflow.
-	vec4 color;
+#ifdef GL_ES
+	vec4 color = inVertexColor.bgra;
+#else
+	vec4 color = inVertexColor;
+#endif
 	// The alpha gives the ratio of sunlight in the incoming light.
-	float nightRatio = 1.0 - inVertexColor.a;
-	color.rgb = inVertexColor.rgb * (inVertexColor.a * dayLight.rgb +
+	float nightRatio = 1.0 - color.a;
+	color.rgb = color.rgb * (color.a * dayLight.rgb +
 		nightRatio * artificialLight.rgb) * 2.0;
 	color.a = 1.0;
 

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -49,5 +49,9 @@ void main(void)
 		: directional_ambient(normalize(inVertexNormal));
 #endif
 
+#ifdef GL_ES
+	varColor = inVertexColor.bgra;
+#else
 	varColor = inVertexColor;
+#endif
 }

--- a/client/shaders/selection_shader/opengl_vertex.glsl
+++ b/client/shaders/selection_shader/opengl_vertex.glsl
@@ -6,5 +6,9 @@ void main(void)
 	varTexCoord = inTexCoord0.st;
 	gl_Position = mWorldViewProj * inVertexPosition;
 
+#ifdef GL_ES
+	varColor = inVertexColor.bgra;
+#else
 	varColor = inVertexColor;
+#endif
 }


### PR DESCRIPTION
fixes https://github.com/minetest/minetest/issues/11248#issuecomment-833884497

#### Why is this needed?

Irrlicht's `SColor` stores colors as an `0xAARRGGBB` `u32`.
On a little endian system this stored as `BB GG RR AA` in memory.
`gl_FragColor` however is an RGBA vector.

Consequently the shaders need to reorder the components. 

#### Why isn't this a problem on OpenGL?

With the legacy OpenGL pipeline the colors are ["directly"](http://docs.gl/gl2/glColorPointer) given to OpenGL.
Irrlicht will either reorder them internally or make sure the driver understands the BGRA order (this is an extension).

## To do

This PR is Ready for Review.

## How to test

<pre>
minetest.register_craftitem("test2:color_test", {
	description = "Test Color Bug",
	inventory_image = "default_cobble.png",
	color = "#0000aa"
})
</pre>

When dropped as item it should be blue, **not** red.
