### PR TITLE
Fix list of libraries included in AppImage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -275,7 +275,7 @@ package:appimage-client:
     - build:ubuntu-18.04
   before_script:
     - apt-get update -y
-    - apt-get install -y git wget
+    - apt-get install -y git
     # Collect files
     - mkdir AppDir
     - cp -a artifact/minetest/usr/ AppDir/usr/

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -24,18 +24,21 @@ AppDir:
       - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-security main universe
 
     include:
-      - libirrlicht1.8
-      - libxxf86vm1
-      - libgl1-mesa-glx
-      - libsqlite3-0
-      - libogg0
-      - libvorbis0a
-      - libopenal1
+      - libc6
       - libcurl3-gnutls
       - libfreetype6
-      - zlib1g
-      - libgmp10
+      - libgl1
+      - libjpeg-turbo8
       - libjsoncpp1
+      - libleveldb1v5
+      - libopenal1
+      - libpng16-16
+      - libsqlite3-0
+      - libstdc++6
+      - libvorbisfile3
+      - libx11-6
+      - libxxf86vm1
+      - zlib1g
 
   files:
     exclude:


### PR DESCRIPTION
Removes the old irrlicht build and uses now the exact library from [here](https://github.com/minetest/minetest/blob/a106bfd456509b676ccba0ac9bef75c214819028/misc/debpkg-control#L6)
## To do

Maybe test again on multiple distributions.

## How to test

Try [this](https://gitlab.com/lejo1/minetest/-/jobs/1264584294/artifacts/download) image of the newes dev version.