### PR TITLE
fix: lua http api overwrite the default timeout wrongly

### DIFF
--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -47,7 +47,9 @@ void ModApiHttp::read_http_fetch_request(lua_State *L, HTTPFetchRequest &req)
 		req.useragent = getstringfield_default(L, 1, "user_agent", "");
 	lua_pop(L, 1);
 	req.multipart = getboolfield_default(L, 1, "multipart", false);
-	req.timeout = getintfield_default(L, 1, "timeout", 3) * 1000;
+	lua_getfield(L, 1, "timeout");
+	if (lua_isnumber(L, -1))
+  	req.timeout = getintfield_default(L, 1, "timeout", 3) * 1000;
 
 	lua_getfield(L, 1, "method");
 	if (lua_isstring(L, -1)) {

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -50,6 +50,7 @@ void ModApiHttp::read_http_fetch_request(lua_State *L, HTTPFetchRequest &req)
 	lua_getfield(L, 1, "timeout");
 	if (lua_isnumber(L, -1))
   	req.timeout = getintfield_default(L, 1, "timeout", 3) * 1000;
+	lua_pop(L, 1);
 
 	lua_getfield(L, 1, "method");
 	if (lua_isstring(L, -1)) {


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- bug fixed
- Do not overwrite the default timeout if no timeout passed
- fixed #11269

## How to test

<!-- Example code or instructions -->