### PR TITLE
Use user provided lib/irrlichtmt if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ CMakeDoxy*
 compile_commands.json
 *.apk
 *.zip
+
+# Optional user provided library folder
+lib/irrlichtmt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,18 +59,18 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 # This is done here so that relative search paths are more reasonable
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lib/irrlichtmt")
-	message(STATUS "Using user provided IrrlichtMt at subdirectory 'lib/irrlichtmt'")
+	message(STATUS "Using user-provided IrrlichtMt at subdirectory 'lib/irrlichtmt'")
 	# tell IrrlichtMt to create a static library
 	set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared library" FORCE)
 	add_subdirectory(lib/irrlichtmt EXCLUDE_FROM_ALL)
 	unset(BUILD_SHARED_LIBS CACHE)
-	#message(FATAL_ERROR "lib/irrlichtmt added")
+
 	if(NOT TARGET IrrlichtMt)
-		message(FATAL_ERROR "IrrlichtMt project at subdirectory 'lib/irrlichtmt' must provide a 'IrrlichtMt' cmake target.")
+		message(FATAL_ERROR "IrrlichtMt project is missing a CMake target?!")
 	endif()
-	# set include dir for 'HAS_FORKED_IRRLICHT' check
+
+	# set include dir the way it would normally be
 	set(IRRLICHT_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/irrlichtmt/include")
-	# set target to link against
 	set(IRRLICHT_LIBRARY IrrlichtMt)
 else()
 	find_package(Irrlicht)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,11 +58,27 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 
 # This is done here so that relative search paths are more reasonable
-find_package(Irrlicht)
-if(BUILD_CLIENT AND NOT IRRLICHT_FOUND)
-	message(FATAL_ERROR "IrrlichtMt is required to build the client, but it was not found.")
-elseif(NOT IRRLICHT_INCLUDE_DIR)
-	message(FATAL_ERROR "Irrlicht or IrrlichtMt headers are required to build the server, but none found.")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lib/irrlichtmt")
+	message(STATUS "Using user provided IrrlichtMt at subdirectory 'lib/irrlichtmt'")
+	# tell IrrlichtMt to create a static library
+	set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared library" FORCE)
+	add_subdirectory(lib/irrlichtmt EXCLUDE_FROM_ALL)
+	unset(BUILD_SHARED_LIBS CACHE)
+	#message(FATAL_ERROR "lib/irrlichtmt added")
+	if(NOT TARGET IrrlichtMt)
+		message(FATAL_ERROR "IrrlichtMt project at subdirectory 'lib/irrlichtmt' must provide a 'IrrlichtMt' cmake target.")
+	endif()
+	# set include dir for 'HAS_FORKED_IRRLICHT' check
+	set(IRRLICHT_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/irrlichtmt/include")
+	# set target to link against
+	set(IRRLICHT_LIBRARY IrrlichtMt)
+else()
+	find_package(Irrlicht)
+	if(BUILD_CLIENT AND NOT IRRLICHT_FOUND)
+		message(FATAL_ERROR "IrrlichtMt is required to build the client, but it was not found.")
+	elseif(NOT IRRLICHT_INCLUDE_DIR)
+		message(FATAL_ERROR "Irrlicht or IrrlichtMt headers are required to build the server, but none found.")
+	endif()
 endif()
 
 include(CheckSymbolExists)

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ Download minetest_game (otherwise only the "Development Test" game is available)
 
     git clone --depth 1 https://github.com/minetest/minetest_game.git games/minetest_game
 
+Download Minetest specific Irrlicht fork named IrrlichtMt. If the folder is available it will be used to satisfy the IrrlichtMt dependency:
+
+    git clone --depth 1 https://github.com/minetest/irrlicht.git lib/irrlichtmt
+
 Download source, without using Git:
 
     wget https://github.com/minetest/minetest/archive/master.tar.gz
@@ -189,6 +193,14 @@ Download minetest_game, without using Git:
     wget https://github.com/minetest/minetest_game/archive/master.tar.gz
     tar xf master.tar.gz
     mv minetest_game-master minetest_game
+    cd ..
+
+Download IrrlichtMt, without using Git:
+
+    cd lib/
+    wget https://github.com/minetest/irrlicht/archive/master.tar.gz
+    tar xf master.tar.gz
+    mv irrlicht-master irrlichtmt
     cd ..
 
 #### Build

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Download minetest_game (otherwise only the "Development Test" game is available)
 
     git clone --depth 1 https://github.com/minetest/minetest_game.git games/minetest_game
 
-Download Minetest specific Irrlicht fork named IrrlichtMt. If the folder is available it will be used to satisfy the IrrlichtMt dependency:
+Download IrrlichtMt to `lib/irrlichtmt`, it will be used to satisfy the IrrlichtMt dependency that way:
 
     git clone --depth 1 https://github.com/minetest/irrlicht.git lib/irrlichtmt
 


### PR DESCRIPTION
~~Add a CMake option `USE_BUILTIN_IRRLICHTMT` with default `OFF` to~~ make
it possible for a user to provide the IrrlichtMt dependency as subdirectory.

This enables the user to do the following to satisfy the IrrlichtMt
dependency:

```sh
git clone --depth 1 https://github.com/minetest/irrlicht.git lib/irrlichtmt
cmake . -DRUN_IN_PLACE=TRUE
```

Fixes https://github.com/minetest/minetest/issues/11264

## To do

Ready for Review.

- [x] Update Readme.md with new option

## How to test

~~Currently my fork is needed because of a fix needed in IrrlichtMt to work as subdirectory~~

```sh
git clone --depth 1 --branch subdirectory_fixes https://github.com/NeroBurner/irrlicht.git lib/irrlichtmt
cmake . -DRUN_IN_PLACE=TRUE
make
```


~~After the following PR is merged https://github.com/minetest/irrlicht/pull/36 it would be as simple as~~
With https://github.com/minetest/irrlicht/pull/31 was merged it is as simple as:

```sh
git clone --depth 1 https://github.com/minetest/irrlicht.git lib/irrlichtmt
cmake . -DRUN_IN_PLACE=TRUE
make
```

edit: remove the variable `USE_BUILTIN_IRRLICHTMT`, the subfolder is used automatically if available

edit2: https://github.com/minetest/irrlicht/pull/31 was merged, now minetest/irrlicht master branch works with this PR
