### PR TITLE
UnitSAO: Prevent circular attachments

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6314,6 +6314,8 @@ object you are working with still exists.
       Default `{x=0, y=0, z=0}`
     * `forced_visible`: Boolean to control whether the attached entity
        should appear in first person. Default `false`.
+    * This command may fail silently (do nothing) when it would result
+      in circular attachments.
 * `get_attach()`: returns parent, bone, position, rotation, forced_visible,
     or nil if it isn't attached.
 * `get_children()`: returns a list of ObjectRefs that are attached to the

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -129,8 +129,11 @@ void UnitSAO::setAttachment(int parent_id, const std::string &bone, v3f position
 		// Do checks to avoid circular references
 		// The chain of wanted parent must not refer or contain "this"
 		for (obj = obj->getParent(); obj; obj = obj->getParent()) {
-			if (obj == this)
+			if (obj == this) {
+				warningstream << "Mod bug: Attempted to attach object " << m_id << " to parent "
+					<< parent_id << " but former is an (in)direct parent of latter." << std::endl;
 				return;
+			}
 		}
 	}
 

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -124,6 +124,16 @@ void UnitSAO::sendOutdatedData()
 void UnitSAO::setAttachment(int parent_id, const std::string &bone, v3f position,
 		v3f rotation, bool force_visible)
 {
+	auto *obj = parent_id ? m_env->getActiveObject(parent_id) : nullptr;
+	if (obj) {
+		// Do checks to avoid circular references
+		// The chain of wanted parent must not refer or contain "this"
+		for (obj = obj->getParent(); obj; obj = obj->getParent()) {
+			if (obj == this)
+				return;
+		}
+	}
+
 	// Attachments need to be handled on both the server and client.
 	// If we just attach on the server, we can only copy the position of the parent.
 	// Attachments are still sent to clients at an interval so players might see them


### PR DESCRIPTION
Fixes #11079

## To do

This PR is Ready for Review.

## How to test

> 1. Open DevTest
>2. Place a `testentities:cube` and a `testentities:armorball` with the entity spawner
>3. Pick up the object attacher
>4. Attach the cube to the armor ball (first punch the cube, then the armor ball) → the armor ball should now be the parent of the cube
>5. Verify you did it correctly by punching the armor ball with the children getter tool
>6. Now try to attach the armor ball to the cube (first punch the ~~cube with the object attacher, then the~~ armor ball, *then the cube*)

Shameless copy from #11079 with corrections

Step 6 should log "Attachment failed!" to the chat.