### PR TITLE
GUIEditBox: Allow selecting and copying read-only texts

### DIFF
--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -232,10 +232,6 @@ bool GUIEditBox::OnEvent(const SEvent &event)
 
 bool GUIEditBox::processKey(const SEvent &event)
 {
-	if (!m_writable) {
-		return false;
-	}
-
 	if (!event.KeyInput.PressedDown)
 		return false;
 
@@ -531,6 +527,9 @@ bool GUIEditBox::onKeyControlX(const SEvent &event, s32 &mark_begin, s32 &mark_e
 	// First copy to clipboard
 	onKeyControlC(event);
 
+	if (!m_writable)
+		return false;
+
 	if (m_passwordbox || !m_operator || m_mark_begin == m_mark_end)
 		return false;
 
@@ -556,7 +555,7 @@ bool GUIEditBox::onKeyControlX(const SEvent &event, s32 &mark_begin, s32 &mark_e
 
 bool GUIEditBox::onKeyControlV(const SEvent &event, s32 &mark_begin, s32 &mark_end)
 {
-	if (!isEnabled())
+	if (!isEnabled() || !m_writable)
 		return false;
 
 	// paste from the clipboard
@@ -602,7 +601,7 @@ bool GUIEditBox::onKeyControlV(const SEvent &event, s32 &mark_begin, s32 &mark_e
 
 bool GUIEditBox::onKeyBack(const SEvent &event, s32 &mark_begin, s32 &mark_end)
 {
-	if (!isEnabled() || Text.empty())
+	if (!isEnabled() || Text.empty() || !m_writable)
 		return false;
 
 	core::stringw s;
@@ -640,7 +639,7 @@ bool GUIEditBox::onKeyBack(const SEvent &event, s32 &mark_begin, s32 &mark_end)
 
 bool GUIEditBox::onKeyDelete(const SEvent &event, s32 &mark_begin, s32 &mark_end)
 {
-	if (!isEnabled() || Text.empty())
+	if (!isEnabled() || Text.empty() || !m_writable)
 		return false;
 
 	core::stringw s;


### PR DESCRIPTION
Fixes #11273

## To do

This PR is Ready for Review.

## How to test

1. devtest `/test_formspec`
2. Try to modify the read-only text area
3. Select, (cut = copy), copy text into other text areas

Copy & paste must work fine within Minetest, but may still suck when copying to/from X11.
