### PR TITLE
Android: Do not submit text after pressing Enter key for multi-line text

### DIFF
--- a/build/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/build/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -30,7 +30,9 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.Button;
 import android.widget.EditText;
+import android.widget.LinearLayout;
 
 import androidx.appcompat.app.AlertDialog;
 
@@ -85,9 +87,18 @@ public class GameActivity extends NativeActivity {
 
 	private void showDialogUI(String hint, String current, int editType) {
 		final AlertDialog.Builder builder = new AlertDialog.Builder(this);
-		EditText editText = new CustomEditText(this);
-		builder.setView(editText);
+		LinearLayout container = new LinearLayout(this);
+		container.setOrientation(LinearLayout.VERTICAL);
+		builder.setView(container);
 		AlertDialog alertDialog = builder.create();
+		EditText editText;
+		// For multi-line, do not close the dialog after pressing back button
+		if (editType == 1) {
+			editText = new EditText(this);
+		} else {
+			editText = new CustomEditText(this);
+		}
+		container.addView(editText);
 		editText.requestFocus();
 		editText.setHint(hint);
 		editText.setText(current);
@@ -103,8 +114,9 @@ public class GameActivity extends NativeActivity {
 		else
 			editText.setInputType(InputType.TYPE_CLASS_TEXT);
 		editText.setSelection(editText.getText().length());
-		editText.setOnKeyListener((view, KeyCode, event) -> {
-			if (KeyCode == KeyEvent.KEYCODE_ENTER) {
+		editText.setOnKeyListener((view, keyCode, event) -> {
+			// For multi-line, do not submit the text after pressing Enter key
+			if (keyCode == KeyEvent.KEYCODE_ENTER && editType != 1) {
 				imm.hideSoftInputFromWindow(editText.getWindowToken(), 0);
 				messageReturnCode = 0;
 				messageReturnValue = editText.getText().toString();
@@ -113,6 +125,18 @@ public class GameActivity extends NativeActivity {
 			}
 			return false;
 		});
+		// For multi-line, add Done button since Enter key does not submit text
+		if (editType == 1) {
+			Button doneButton = new Button(this);
+			container.addView(doneButton);
+			doneButton.setText(R.string.ime_dialog_done);
+			doneButton.setOnClickListener((view -> {
+				imm.hideSoftInputFromWindow(editText.getWindowToken(), 0);
+				messageReturnCode = 0;
+				messageReturnValue = editText.getText().toString();
+				alertDialog.dismiss();
+			}));
+		}
 		alertDialog.show();
 		alertDialog.setOnCancelListener(dialog -> {
 			getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);

--- a/build/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/build/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -99,6 +99,7 @@ public class GameActivity extends NativeActivity {
 			editText = new CustomEditText(this);
 		}
 		container.addView(editText);
+		editText.setMaxLines(8);
 		editText.requestFocus();
 		editText.setHint(hint);
 		editText.setText(current);

--- a/build/android/app/src/main/res/values/strings.xml
+++ b/build/android/app/src/main/res/values/strings.xml
@@ -6,5 +6,6 @@
 	<string name="not_granted">Required permission wasn\'t granted, Minetest can\'t run without it</string>
 	<string name="notification_title">Loading Minetest</string>
 	<string name="notification_description">Less than 1 minute&#8230;</string>
+	<string name="ime_dialog_done">Done</string>
 
 </resources>


### PR DESCRIPTION
**Goal of the PR**
Make Android version able to write multi-line text.

**How does the PR work?**
The usage of the Enter key for submitting text is limited to single-line text (and password). Regular `EditText` is used (instead of `CustomEditText`) for multi-line text to not close the dialog after pressing the back button. A new button is added for submitting multi-line text.

**Does it resolve any reported issue?**
Yes, this tries to fix #11225.

## To do
This PR is a Ready for Review.

## How to test
There are many ways to test this. This is just one example.
1. Play any Minetest Game world in creative mode.
2. Pick a book from creative inventory.
3. Open the book by selecting it and tap-hold (left click).
4. Try to write the title and the content.
5. When writing the content, make sure that the Enter key is present in the IME and the back button only closes the IME.
