### PR TITLE
Check for "icon.png" if "screenshot.png" does not exist

### DIFF
--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -71,6 +71,12 @@ local function get_formspec(tabview, name, tabdata)
 		local screenshotfilename = selected_pkg.path .. DIR_DELIM .. "screenshot.png"
 		local screenshotfile, error = io.open(screenshotfilename, "r")
 
+		if error then
+			-- check for icon if screenshot not available
+			screenshotfilename = selected_pkg.path .. DIR_DELIM .. "icon.png"
+			screenshotfile, error = io.open(screenshotfilename, "r")
+		end
+
 		local modscreenshot
 		if error == nil then
 			screenshotfile:close()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -158,6 +158,7 @@ Mod directory structure
     │   ├── mod.conf
     │   ├── screenshot.png
     │   ├── settingtypes.txt
+    │   ├── icon.png
     │   ├── init.lua
     │   ├── models
     │   ├── textures
@@ -203,6 +204,11 @@ Note: to support 0.4.x, please also provide depends.txt.
 
 A screenshot shown in the mod manager within the main menu. It should
 have an aspect ratio of 3:2 and a minimum size of 300×200 pixels.
+
+### `icon.png`
+
+An icon image shown in the mod manager within the main menu if screenshot
+image is not found. Same requirements as screenshot.
 
 ### `depends.txt`
 


### PR DESCRIPTION
Adds a simple check in the mod manager for "icon.png" if "screenshot.png" doesn't exist.

- Does it resolve any reported issue? *no*
- If not a bug fix, why is this PR needed? What usecases does it solve? *none, simply aesthetic for mods that it might be inconvenient to create a screenshot*

This PR is Ready for Review.

## How to test

Delete `screenshot.png` file from a mod in the mod directory. Add `icon.png`. Open the "Content" tab in the client. Select the mod. Icon image should be displayed.

![icon_preview](https://user-images.githubusercontent.com/3631473/120405071-9575bb00-c2fc-11eb-8859-562094e6d279.png)
