### PR TITLE
falling.lua - Fix Meshnodes Being Too Big

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -105,6 +105,19 @@ core.register_entity(":__builtin:falling_node", {
 				textures = textures,
 				glow = def.light_source,
 			})
+		elseif def.drawtype == "mesh" then
+			local itemstring = node.name
+			if core.is_colored_paramtype(def.paramtype2) then
+				itemstring = core.itemstring_with_palette(itemstring, node.param2)
+			end
+			local s = (def.visual_scale or 1) * SCALE * 0.5
+			local vsize = vector.new(s, s, s)
+			self.object:set_properties({
+				is_visible = true,
+				wield_item = itemstring,
+				visual_size = vsize,
+				glow = def.light_source,
+			})
 		elseif def.drawtype ~= "airlike" then
 			local itemstring = node.name
 			if core.is_colored_paramtype(def.paramtype2) then

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -105,34 +105,20 @@ core.register_entity(":__builtin:falling_node", {
 				textures = textures,
 				glow = def.light_source,
 			})
-		elseif def.drawtype == "mesh" then
-			local itemstring = node.name
-			if core.is_colored_paramtype(def.paramtype2) then
-				itemstring = core.itemstring_with_palette(itemstring, node.param2)
-			end
-			local s = (def.visual_scale or 1) * SCALE * 0.5
-			local vsize = vector.new(s, s, s)
-			self.object:set_properties({
-				is_visible = true,
-				wield_item = itemstring,
-				visual_size = vsize,
-				glow = def.light_source,
-			})
 		elseif def.drawtype ~= "airlike" then
 			local itemstring = node.name
 			if core.is_colored_paramtype(def.paramtype2) then
 				itemstring = core.itemstring_with_palette(itemstring, node.param2)
 			end
 			-- FIXME: solution needed for paramtype2 == "leveled"
-			local vsize
-			if def.visual_scale then
-				local s = def.visual_scale * SCALE
-				vsize = vector.new(s, s, s)
+			local s = (def.visual_scale or 1) * SCALE
+			if def.drawtype == "mesh" then
+				s = s * 0.5
 			end
 			self.object:set_properties({
 				is_visible = true,
 				wield_item = itemstring,
-				visual_size = vsize,
+				visual_size = vector.new(s, s, s),
 				glow = def.light_source,
 			})
 		end


### PR DESCRIPTION
I've noticed that falling meshnodes are twice as big as they should be when falling, this PR fixes that by halving their visual scale.

## How to test

Take a meshnode and let it fall.
