### PR TITLE
make item count background work

### DIFF
--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1164,15 +1164,18 @@ void drawItemStack(
 		v2u32 dim = font->getDimension(utf8_to_wide(text).c_str());
 		v2s32 sdim(dim.X, dim.Y);
 
-		core::rect<s32> rect2(
-			/*rect.UpperLeftCorner,
-			core::dimension2d<u32>(rect.getWidth(), 15)*/
-			rect.LowerRightCorner - sdim,
-			sdim
+		core::rect<s32> background_rect(
+			rect.LowerRightCorner - sdim - core::position2d<s32>(3,0),
+			rect.LowerRightCorner + core::position2d<s32>(3,0)
 		);
 
 		video::SColor bgcolor(128, 0, 0, 0);
-		driver->draw2DRectangle(bgcolor, rect2, clip);
+		driver->draw2DRectangle(bgcolor, background_rect, clip);
+
+		core::rect<s32> rect2(
+			rect.LowerRightCorner - sdim,
+			rect.LowerRightCorner
+		);
 
 		video::SColor color(255, 255, 255, 255);
 		font->draw(text.c_str(), rect2, color, false, false, clip);

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1165,7 +1165,7 @@ void drawItemStack(
 		v2s32 sdim(dim.X, dim.Y);
 
 		const s32 horizontal_padding = 3; //px
-		core::position2d<s32> offset(-2,-2);
+		core::position2d<s32> offset(-4,-2);
 
 		core::rect<s32> background_rect(
 			rect.LowerRightCorner - sdim + core::position2d<s32>(-horizontal_padding,0) + offset,

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1164,17 +1164,20 @@ void drawItemStack(
 		v2u32 dim = font->getDimension(utf8_to_wide(text).c_str());
 		v2s32 sdim(dim.X, dim.Y);
 
+		const s32 horizontal_padding = 3; //px
+		core::position2d<s32> offset(-2,-2);
+
 		core::rect<s32> background_rect(
-			rect.LowerRightCorner - sdim - core::position2d<s32>(3,0),
-			rect.LowerRightCorner + core::position2d<s32>(3,0)
+			rect.LowerRightCorner - sdim + core::position2d<s32>(-horizontal_padding,0) + offset,
+			rect.LowerRightCorner + core::position2d<s32>(horizontal_padding,0) + offset
 		);
 
 		video::SColor bgcolor(128, 0, 0, 0);
 		driver->draw2DRectangle(bgcolor, background_rect, clip);
 
 		core::rect<s32> rect2(
-			rect.LowerRightCorner - sdim,
-			rect.LowerRightCorner
+			rect.LowerRightCorner - sdim + offset,
+			rect.LowerRightCorner + offset
 		);
 
 		video::SColor color(255, 255, 255, 255);

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1165,7 +1165,7 @@ void drawItemStack(
 		v2s32 sdim(dim.X, dim.Y);
 
 		const s32 horizontal_padding = 3; //px
-		core::position2d<s32> offset(-4,-2);
+		core::position2d<s32> offset(-5,-2);
 
 		core::rect<s32> background_rect(
 			rect.LowerRightCorner - sdim + core::position2d<s32>(-horizontal_padding,0) + offset,


### PR DESCRIPTION
The original code was using the wrong overloaded constructor of `rect`, using two points instead of one point and dimension, this patch makes it works like it was originally intended
I added some pixels left and right so it's less tight

before:
![immagine](https://user-images.githubusercontent.com/3357750/120864692-e4d21a80-c58c-11eb-9567-e49f3c7b5ea8.png)

after:
![immagine](https://user-images.githubusercontent.com/3357750/120867332-fec22c00-c591-11eb-8d72-0e9b4e16f217.png)


![immagine](https://user-images.githubusercontent.com/3357750/120867253-d63a3200-c591-11eb-9394-4fadce3b78c3.png)

![immagine](https://user-images.githubusercontent.com/3357750/120867135-9a06d180-c591-11eb-99a8-1f83eb37563a.png)
