### PR TITLE
Add min_y and max_y checks for Active Block Modifiers (ABM)

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -20,6 +20,7 @@ core.features = {
 	direct_velocity_on_players = true,
 	use_texture_alpha_string_modes = true,
 	degrotate_240_steps = true,
+	abm_min_max_y = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4441,6 +4441,8 @@ Utilities
           -- degrotate param2 rotates in units of 1.5° instead of 2°
           -- thus changing the range of values from 0-179 to 0-240 (5.5.0)
           degrotate_240_steps = true,
+          -- ABM supports min_y and max_y fields in definition (5.5.0)
+          abm_min_max_y = true,
       }
 
 * `minetest.has_feature(arg)`: returns `boolean, missing_features`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7147,8 +7147,8 @@ Used by `minetest.register_abm`.
         -- Chance of triggering `action` per-node per-interval is 1.0 / this
         -- value
         
-        min_y = -31000,
-        max_y = 31000,
+        min_y = -32768,
+        max_y = 32767,
         -- min and max height levels where ABM will be processed
         -- can be used to reduce CPU usage
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7144,6 +7144,11 @@ Used by `minetest.register_abm`.
         chance = 1,
         -- Chance of triggering `action` per-node per-interval is 1.0 / this
         -- value
+        
+        min_y = -31000,
+        max_y = 31000,
+        -- min and max height levels where ABM will be processed
+        -- can be used to reduce CPU usage
 
         catch_up = true,
         -- If true, catch-up behaviour is enabled: The `chance` value is

--- a/src/client/fontengine.cpp
+++ b/src/client/fontengine.cpp
@@ -342,8 +342,9 @@ gui::IGUIFont *FontEngine::initSimpleFont(const FontSpec &spec)
 			(spec.mode == FM_SimpleMono) ? "mono_font_path" : "font_path");
 
 	size_t pos_dot = font_path.find_last_of('.');
-	std::string basename = font_path;
-	std::string ending = lowercase(font_path.substr(pos_dot));
+	std::string basename = font_path, ending;
+	if (pos_dot != std::string::npos)
+		ending = lowercase(font_path.substr(pos_dot));
 
 	if (ending == ".ttf") {
 		errorstream << "FontEngine: Found font \"" << font_path

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -150,13 +150,19 @@ void ScriptApiEnv::initializeEnvironment(ServerEnvironment *env)
 
 		bool simple_catch_up = true;
 		getboolfield(L, current_abm, "catch_up", simple_catch_up);
+		
+		int min_y = -31000;
+		getintfield(L, current_abm, "min_y", min_y);
+		
+		int max_y = 31000;
+		getintfield(L, current_abm, "max_y", max_y);
 
 		lua_getfield(L, current_abm, "action");
 		luaL_checktype(L, current_abm + 1, LUA_TFUNCTION);
 		lua_pop(L, 1);
 
 		LuaABM *abm = new LuaABM(L, id, trigger_contents, required_neighbors,
-			trigger_interval, trigger_chance, simple_catch_up);
+			trigger_interval, trigger_chance, simple_catch_up, min_y, max_y);
 
 		env->addActiveBlockModifier(abm);
 

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -151,10 +151,10 @@ void ScriptApiEnv::initializeEnvironment(ServerEnvironment *env)
 		bool simple_catch_up = true;
 		getboolfield(L, current_abm, "catch_up", simple_catch_up);
 		
-		int min_y = -31000;
+		s16 min_y = INT16_MIN;
 		getintfield(L, current_abm, "min_y", min_y);
 		
-		int max_y = 31000;
+		s16 max_y = INT16_MAX;
 		getintfield(L, current_abm, "max_y", max_y);
 
 		lua_getfield(L, current_abm, "action");

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -223,17 +223,21 @@ private:
 	float m_trigger_interval;
 	u32 m_trigger_chance;
 	bool m_simple_catch_up;
+	int m_min_y;
+	int m_max_y;
 public:
 	LuaABM(lua_State *L, int id,
 			const std::vector<std::string> &trigger_contents,
 			const std::vector<std::string> &required_neighbors,
-			float trigger_interval, u32 trigger_chance, bool simple_catch_up):
+			float trigger_interval, u32 trigger_chance, bool simple_catch_up, int min_y, int max_y):
 		m_id(id),
 		m_trigger_contents(trigger_contents),
 		m_required_neighbors(required_neighbors),
 		m_trigger_interval(trigger_interval),
 		m_trigger_chance(trigger_chance),
-		m_simple_catch_up(simple_catch_up)
+		m_simple_catch_up(simple_catch_up),
+		m_min_y(min_y),
+		m_max_y(max_y)
 	{
 	}
 	virtual const std::vector<std::string> &getTriggerContents() const
@@ -255,6 +259,14 @@ public:
 	virtual bool getSimpleCatchUp()
 	{
 		return m_simple_catch_up;
+	}
+	virtual int getMinY()
+	{
+		return m_min_y;
+	}
+	virtual int getMaxY()
+	{
+		return m_max_y;
 	}
 	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n,
 			u32 active_object_count, u32 active_object_count_wider);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -223,13 +223,13 @@ private:
 	float m_trigger_interval;
 	u32 m_trigger_chance;
 	bool m_simple_catch_up;
-	int m_min_y;
-	int m_max_y;
+	s16 m_min_y;
+	s16 m_max_y;
 public:
 	LuaABM(lua_State *L, int id,
 			const std::vector<std::string> &trigger_contents,
 			const std::vector<std::string> &required_neighbors,
-			float trigger_interval, u32 trigger_chance, bool simple_catch_up, int min_y, int max_y):
+			float trigger_interval, u32 trigger_chance, bool simple_catch_up, s16 min_y, s16 max_y):
 		m_id(id),
 		m_trigger_contents(trigger_contents),
 		m_required_neighbors(required_neighbors),
@@ -260,11 +260,11 @@ public:
 	{
 		return m_simple_catch_up;
 	}
-	virtual int getMinY()
+	virtual s16 getMinY()
 	{
 		return m_min_y;
 	}
-	virtual int getMaxY()
+	virtual s16 getMaxY()
 	{
 		return m_max_y;
 	}

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -729,6 +729,8 @@ struct ActiveABM
 	int chance;
 	std::vector<content_t> required_neighbors;
 	bool check_required_neighbors; // false if required_neighbors is known to be empty
+	int min_y;
+	int max_y;
 };
 
 class ABMHandler
@@ -773,6 +775,9 @@ public:
 			} else {
 				aabm.chance = chance;
 			}
+			// y limits
+			aabm.min_y = abm->getMinY();
+			aabm.max_y = abm->getMaxY();
 
 			// Trigger neighbors
 			const std::vector<std::string> &required_neighbors_s =
@@ -885,6 +890,9 @@ public:
 
 			v3s16 p = p0 + block->getPosRelative();
 			for (ActiveABM &aabm : *m_aabms[c]) {
+				if ((p.Y < aabm.min_y) || (p.Y > aabm.max_y))
+					continue;
+				
 				if (myrand() % aabm.chance != 0)
 					continue;
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -729,8 +729,8 @@ struct ActiveABM
 	int chance;
 	std::vector<content_t> required_neighbors;
 	bool check_required_neighbors; // false if required_neighbors is known to be empty
-	int min_y;
-	int max_y;
+	s16 min_y;
+	s16 max_y;
 };
 
 class ABMHandler

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -67,6 +67,10 @@ public:
 	virtual u32 getTriggerChance() = 0;
 	// Whether to modify chance to simulate time lost by an unnattended block
 	virtual bool getSimpleCatchUp() = 0;
+  // get min Y for apply abm
+	virtual int getMinY() = 0;
+  // get max Y for apply abm
+	virtual int getMaxY() = 0;
 	// This is called usually at interval for 1/chance of the nodes
 	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n){};
 	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n,

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -68,9 +68,9 @@ public:
 	// Whether to modify chance to simulate time lost by an unnattended block
 	virtual bool getSimpleCatchUp() = 0;
   // get min Y for apply abm
-	virtual int getMinY() = 0;
+	virtual s16 getMinY() = 0;
   // get max Y for apply abm
-	virtual int getMaxY() = 0;
+	virtual s16 getMaxY() = 0;
 	// This is called usually at interval for 1/chance of the nodes
 	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n){};
 	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n,


### PR DESCRIPTION
Add min_y and max_y checks for Active Block Modifiers (ABM).

This check can be used by ABM to reduce CPU usage.

Example:
  vacuum mod has ABM for all airs nodes with vacuum node in the neighbourhood.
- This causes that for all air nodes neighbourhood has to be check.
- with this min_y, max_y, looking for the neighbourhood nodes is eliminated 

Some of minetest games (Hades Revisited for example) are using similar ABM calls like a vacuum with height limitation check, so it can help developers to better optimize ABM.

I believe this can be useful in multidimensional worlds where developers want to provide different behaviors in different worlds separated by Y limits for reducing server CPU usage.

## To do

This PR is a Ready for Review.

## How to test

Use vacuum mod from branch: [sfence_use_abm_min_max_y](https://github.com/sfence/vacuum/tree/sfence_use_abm_min_max_y) with enabled physics and measure abm time.
On slower CPUs (etc. slower than i7-4771, 3.5 GHz you should see something like: ```
2021-06-11 09:21:34: WARNING[Server]: active block modifiers took 201ms (processed 466 of 485 active blocks)
```
without min_y, max_y check and this message should disappear when minetest is compelled with min_y, max_y check-in ABM.
