### PR TITLE
Strip carriage returns from lines in settingtypes.txt

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -33,7 +33,7 @@ end
 local function parse_setting_line(settings, line, read_all, base_level, allow_secure)
 
 	-- strip carriage returns (CR, /r)
-	line = line:gsub("\r","")
+	line = line:gsub("\r", "")
 
 	-- comment
 	local comment = line:match("^#" .. CHAR_CLASSES.SPACE .. "*(.*)$")

--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -31,6 +31,10 @@ end
 
 -- returns error message, or nil
 local function parse_setting_line(settings, line, read_all, base_level, allow_secure)
+
+	-- strip carriage returns (CR, /r)
+	line = line:gsub("\r","")
+
 	-- comment
 	local comment = line:match("^#" .. CHAR_CLASSES.SPACE .. "*(.*)$")
 	if comment then


### PR DESCRIPTION
Fixes issue #11327 
Carriage returns should be stripped when reading lines from settingstypes.txt.

**Example of Biofuel's settingtypes.txt file cause the problem:**
https://github.com/Lokrates/Biofuel/blob/master/settingtypes.txt
```
2021-06-09 08:18:04: ERROR[Main]: Invalid integer setting in /home/sfence/.minetest/mods/biofuel/settingtypes.txt "fuel_production_time (fuel production time) i"t 10 5 360
2021-06-09 08:18:04: ERROR[Main]: Invalid integer setting in /home/sfence/.minet"st/mods/biofuel/settingtypes.txt "biomass_input (required input) int 4 1 99
2021-06-09 08:18:04: ERROR[Main]: Invalid boolean setting in /home/sfence/.minet"st/mods/biofuel/settingtypes.txt "refinery_output (bottle output) bool false
2021-06-09 08:18:04: ERROR[Main]: Invalid boolean setting in /home/sfence/.minet"st/mods/biofuel/settingtypes.txt "food_fuel (food waste) bool false
```

Linux uses LF (0x0A, /n) for line endings, but windows uses CRLF (0x0D0A, /r/n).
Lua strips the LF (which is fine on linux, if only using LF), but when the file uses CRLF, the CR gets left behind.

I suspect that when this happens on a windows system -- lua will strip the CRLF completely.

The best solution (cross-platform) is just to remove any stray carriage returns.