### PR TITLE
Serverlist enhancements

### DIFF
--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -354,6 +354,7 @@ void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 		Settings conf;
 
 		conf.set("world_name", name);
+		conf.set("world_uuid", generate_uuid4());
 		conf.set("gameid", gamespec.id);
 		conf.set("backend", "sqlite3");
 		conf.set("player_backend", "sqlite3");

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -354,13 +354,16 @@ void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 		Settings conf;
 
 		conf.set("world_name", name);
-		conf.set("world_uuid", generate_uuid4());
 		conf.set("gameid", gamespec.id);
 		conf.set("backend", "sqlite3");
 		conf.set("player_backend", "sqlite3");
 		conf.set("auth_backend", "sqlite3");
 		conf.setBool("creative_mode", g_settings->getBool("creative_mode"));
 		conf.setBool("enable_damage", g_settings->getBool("enable_damage"));
+
+		if (g_settings->getBool("server_announce")) {
+			conf.set("world_uuid", generate_uuid4());
+		}
 
 		if (!conf.updateConfigFile(worldmt_path.c_str())) {
 			throw BaseException("Failed to update the config file");

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -688,6 +688,7 @@ void Server::AsyncRunStep(bool initial_step)
 				g_settings->getBool("server_announce")) {
 			ServerList::sendAnnounce(counter ? ServerList::AA_UPDATE :
 						ServerList::AA_START,
+					m_env->getWorldUuid(),
 					m_bind_addr.getPort(),
 					m_clients.getPlayerNames(),
 					m_uptime_counter->get(),
@@ -3906,6 +3907,7 @@ void dedicated_server_loop(Server &server, bool &kill)
 #if USE_CURL
 	if (g_settings->getBool("server_announce"))
 		ServerList::sendAnnounce(ServerList::AA_DELETE,
+			server.getEnv().getWorldUuid(),
 			server.m_bind_addr.getPort());
 #endif
 }

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -437,12 +437,12 @@ ServerEnvironment::ServerEnvironment(ServerMap *map,
 			auth_backend_name = conf.get("auth_backend");
 		}
 
-		if (!uuid_exists) {
+		if (uuid_exists) {
+			m_world_uuid = conf.get("world_uuid");
+		} else if (g_settings->getBool("server_announce")) {
 			m_world_uuid = generate_uuid4();
 			conf.set("world_uuid", m_world_uuid);
 			dirty = true;
-		} else {
-			m_world_uuid = conf.get("world_uuid");
 		}
 
 		if (dirty && !conf.updateConfigFile(conf_path.c_str())) {

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -415,32 +415,39 @@ ServerEnvironment::ServerEnvironment(ServerMap *map,
 		// Read those values before setting defaults
 		bool player_backend_exists = conf.exists("player_backend");
 		bool auth_backend_exists = conf.exists("auth_backend");
+		bool uuid_exists = conf.exists("world_uuid");
+		bool dirty = false;
 
 		// player backend is not set, assume it's legacy file backend.
 		if (!player_backend_exists) {
 			// fall back to files
 			conf.set("player_backend", "files");
 			player_backend_name = "files";
-
-			if (!conf.updateConfigFile(conf_path.c_str())) {
-				errorstream << "ServerEnvironment::ServerEnvironment(): "
-						<< "Failed to update world.mt!" << std::endl;
-			}
+			dirty = true;
 		} else {
-			conf.getNoEx("player_backend", player_backend_name);
+			player_backend_name = conf.get("player_backend");
 		}
 
 		// auth backend is not set, assume it's legacy file backend.
 		if (!auth_backend_exists) {
 			conf.set("auth_backend", "files");
 			auth_backend_name = "files";
+			dirty = true;
+		} else {
+			auth_backend_name = conf.get("auth_backend");
+		}
 
-			if (!conf.updateConfigFile(conf_path.c_str())) {
+		if (!uuid_exists) {
+			m_world_uuid = generate_uuid4();
+			conf.set("world_uuid", m_world_uuid);
+			dirty = true;
+		} else {
+			m_world_uuid = conf.get("world_uuid");
+		}
+
+		if (dirty && !conf.updateConfigFile(conf_path.c_str())) {
 				errorstream << "ServerEnvironment::ServerEnvironment(): "
 						<< "Failed to update world.mt!" << std::endl;
-			}
-		} else {
-			conf.getNoEx("auth_backend", auth_backend_name);
 		}
 	}
 

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -343,6 +343,8 @@ public:
 
 	u32 getGameTime() const { return m_game_time; }
 
+	std::string getWorldUuid() const { return m_world_uuid; }
+
 	void reportMaxLagEstimate(float f) { m_max_lag_estimate = f; }
 	float getMaxLagEstimate() { return m_max_lag_estimate; }
 
@@ -459,6 +461,8 @@ private:
 	// Time from the beginning of the game in seconds.
 	// Incremented in step().
 	u32 m_game_time = 0;
+	// Unique ID for the world
+	std::string m_world_uuid;
 	// A helper variable for incrementing the latter
 	float m_game_time_fraction_counter = 0.0f;
 	// Time of last clearObjects call (game time).

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -32,6 +32,7 @@ namespace ServerList
 {
 #if USE_CURL
 void sendAnnounce(AnnounceAction action,
+		const std::string &world_uuid,
 		const u16 port,
 		const std::vector<std::string> &clients_names,
 		const double uptime,
@@ -44,6 +45,7 @@ void sendAnnounce(AnnounceAction action,
 {
 	static const char *aa_names[] = {"start", "update", "delete"};
 	Json::Value server;
+	server["world_uuid"] = world_uuid;
 	server["action"] = aa_names[action];
 	server["port"] = port;
 	if (g_settings->exists("server_address")) {

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -28,7 +28,7 @@ namespace ServerList
 {
 #if USE_CURL
 enum AnnounceAction {AA_START, AA_UPDATE, AA_DELETE};
-void sendAnnounce(AnnounceAction, u16 port,
+void sendAnnounce(AnnounceAction, const std::string &world_uuid, u16 port,
 		const std::vector<std::string> &clients_names = std::vector<std::string>(),
 		double uptime = 0, u32 game_time = 0, float lag = 0,
 		const std::string &gameid = "", const std::string &mg_name = "",

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -903,3 +903,22 @@ void safe_print_string(std::ostream &os, const std::string &str)
 	}
 	os.setf(flags);
 }
+
+
+std::string generate_uuid4()
+{
+	char uuid[16];
+	porting::secure_rand_fill_buf(uuid, sizeof(uuid));
+
+	// Version 4: Random
+	uuid[6] = (uuid[6] & ~0xf0) | 4 << 4;
+	// Variant 1: RFC4122
+	uuid[8] = (uuid[8] & ~0xc0) | 0x80;
+
+	return
+		hex_encode(uuid, 4) + '-' +
+		hex_encode(uuid + 4, 2) + '-' +
+		hex_encode(uuid + 6, 2) + '-' +
+		hex_encode(uuid + 8, 2) + '-' +
+		hex_encode(uuid + 10, 6);
+}

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -761,3 +761,8 @@ std::string sanitizeDirName(const std::string &str, const std::string &optional_
  * brackets (e.g. "a\x1eb" -> "a<1e>b").
  */
 void safe_print_string(std::ostream &os, const std::string &str);
+
+/**
+ * Generate a version 4 (random) UUID based on RFC4122
+ */
+std::string generate_uuid4();


### PR DESCRIPTION
This makes two enhancements for the server list:

- Print HTTP response bodies on error responses.  This is useful because the server list returns information on why the request failed in the body.  Without this you only get the response code, which could mean several different things.
- Add a world UUID and send it to the server list.  This allows the server list to keep better track of worlds and is a companion to minetest/serverlist#45 .  This should not be merged until that PR is in production so that the server list doesn't publish UUIDs, which could be used to spoof servers.

## How to test

Change `src/serverlist.cpp` so that it sends invalid JSON, enable announce, and start a server.