### PR TITLE
Use the player's overridden hand as the default for digging instead of always the default ("") hand.

### DIFF
--- a/games/devtest/mods/hand/init.lua
+++ b/games/devtest/mods/hand/init.lua
@@ -1,0 +1,19 @@
+minetest.register_chatcommand("sethand", {
+	params = "<itemstring>",
+	description = "Set hand item",
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+		if not player then
+			return false, "No player."
+		end
+
+		local itemstack = ItemStack(param)
+		if not itemstack:is_known() then
+			return false, "Item type does not exist."
+		end
+
+		player:get_inventory():set_size("hand", 1)
+		player:get_inventory():set_list("hand", {itemstack})
+		return true
+	end,
+})

--- a/games/devtest/mods/hand/mod.conf
+++ b/games/devtest/mods/hand/mod.conf
@@ -1,0 +1,2 @@
+name = hand
+description = Command to set the player's hand

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3556,15 +3556,19 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 
 	// NOTE: Similar piece of code exists on the server side for
 	// cheat detection.
-	// Get digging parameters
-	DigParams params = getDigParams(nodedef_manager->get(n).groups,
-			&selected_item.getToolCapabilities(itemdef_manager));
 
-	// If can't dig, try hand
-	if (!params.diggable) {
-		params = getDigParams(nodedef_manager->get(n).groups,
-				&hand_item.getToolCapabilities(itemdef_manager));
+	// Get digging parameters for the selected item.
+	ToolCapabilities dig_tool_caps;
+	if(selected_item.name == "") {
+		// Empty slot means go straight to the hand,
+		// otherwise the empty ("") item might still override it with its own capabilities
+		dig_tool_caps = hand_item.getToolCapabilities(itemdef_manager);
 	}
+	else {
+		// Otherwise just get the selected item's capabilities, defaulting to the hand.
+		dig_tool_caps = selected_item.getToolCapabilities(itemdef_manager, &hand_item.getToolCapabilities(itemdef_manager));
+	}
+	DigParams params = getDigParams(nodedef_manager->get(n).groups, &dig_tool_caps);
 
 	if (!params.diggable) {
 		// I guess nobody will wait for this long

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3558,17 +3558,20 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 	// cheat detection.
 
 	// Get digging parameters for the selected item.
-	ToolCapabilities dig_tool_caps;
-	if(selected_item.name == "") {
-		// Empty slot means go straight to the hand,
-		// otherwise the empty ("") item might still override it with its own capabilities
-		dig_tool_caps = hand_item.getToolCapabilities(itemdef_manager);
+	ToolCapabilities tool_caps = selected_item.getToolCapabilities(itemdef_manager,
+			&hand_item.getToolCapabilities(itemdef_manager));
+	DigParams params = getDigParams(nodedef_manager->get(n).groups, &tool_caps);
+
+	// And for the hand.
+	ToolCapabilities hand_caps = hand_item.getToolCapabilities(itemdef_manager);
+	DigParams hand_params = getDigParams(nodedef_manager->get(n).groups, &hand_caps);
+
+	// If the tool can't dig, use the hand instead.
+	// Empty slot also means go straight to the hand,
+	// otherwise the empty ("") item might still override it with its own capabilities
+	if(!params.diggable || selected_item.name == "") {
+		params = hand_params;
 	}
-	else {
-		// Otherwise just get the selected item's capabilities, defaulting to the hand.
-		dig_tool_caps = selected_item.getToolCapabilities(itemdef_manager, &hand_item.getToolCapabilities(itemdef_manager));
-	}
-	DigParams params = getDigParams(nodedef_manager->get(n).groups, &dig_tool_caps);
 
 	if (!params.diggable) {
 		// I guess nobody will wait for this long

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -110,18 +110,26 @@ struct ItemStack
 		return itemdef->get(name);
 	}
 
-	// Get tool digging properties, or those of the hand if not a tool
+	// Get tool digging properties, or the default caps if not a tool.
+	// If the defaults are not specified (nullptr),
+	// use the hand's (item "").
 	const ToolCapabilities& getToolCapabilities(
-			IItemDefManager *itemdef) const
+			IItemDefManager *itemdef, const ToolCapabilities *default_caps = nullptr) const
 	{
 		const ToolCapabilities *item_cap =
 			itemdef->get(name).tool_capabilities;
 
-		if (item_cap == NULL)
-			// Fall back to the hand's tool capabilities
+		if (item_cap == nullptr)
+		{
+			// Fall back to the specified default.
+			item_cap = default_caps;
+		}
+
+		if (item_cap == nullptr)
+			// Fall back to the default hand's tool capabilities
 			item_cap = itemdef->get("").tool_capabilities;
 
-		assert(item_cap != NULL);
+		assert(item_cap != nullptr);
 		return metadata.getToolCapabilities(*item_cap); // Check for override
 	}
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1185,13 +1185,18 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 			playersao->getPlayer()->getWieldedItem(&selected_item, &hand_item);
 
 			// Get diggability and expected digging time
-			DigParams params = getDigParams(m_nodedef->get(n).groups,
-					&selected_item.getToolCapabilities(m_itemdef));
-			// If can't dig, try hand
-			if (!params.diggable) {
-				params = getDigParams(m_nodedef->get(n).groups,
-					&hand_item.getToolCapabilities(m_itemdef));
+			ToolCapabilities dig_tool_caps;
+			if(selected_item.name == "") {
+				// Empty slot means go straight to the hand,
+				// otherwise the empty ("") item might still override it with its own capabilities
+				dig_tool_caps = hand_item.getToolCapabilities(m_itemdef);
 			}
+			else {
+				// Otherwise just get the selected item's capabilities, defaulting to the hand.
+				dig_tool_caps = selected_item.getToolCapabilities(m_itemdef, &hand_item.getToolCapabilities(m_itemdef));
+			}
+			DigParams params = getDigParams(m_nodedef->get(n).groups, &dig_tool_caps);
+
 			// If can't dig, ignore dig
 			if (!params.diggable) {
 				infostream << "Server: " << player->getName()


### PR DESCRIPTION
Currently, even if the player's hand item is faster at digging than the empty item (default hand, `""`), the empty item will be used to determine digging parameters for the empty slot and non-tool items unless it cannot dig a node, in which case the actual hand is used.

This doesn't come up much in minetest game or similar games, where there is only one default hand, the `""` item, as wielded items will simply inherit that item's capabilities if they don't have their own and it is identical to the empty slot. However, this can be a problem if the hand is set to a more powerful tool, as the `""` item will still be used to determine dig parameters if it is possible to dig with it, even if the parameters are slower than the new hand.

This PR fixes that by using the player's actual hand as the default for digging parameters.

This PR also adds a `sethand` test command to devtest, so that hands can easily be tested.

## How to test

With this PR, load up a devtest game.
Dig some dirt with your hand, observe the speed.
Use `/sethand basetools:shovel_stone` to set your new hand.
Dig some dirt with your new shovel-hand or with a non-tool item, observe the speed increase as if you were actually wielding a shovel.

To see the bug, reset away from this PR (your hand will remain set, this PR only adds a helper command to set it) and try digging dirt with your new shovel-hand or a non-tool item. The speed will be as slow as if you had not set your hand in the first place.

