### PR TITLE
GUIScrollbar: Add styling

### DIFF
--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -57,6 +57,9 @@ public:
 		SOUND,
 		SPACING,
 		SIZE,
+		UP_ARROW_BGIMG,
+		DOWN_ARROW_BGIMG,
+		THUMB_BGIMG,
 		NUM_PROPERTIES,
 		NONE
 	};
@@ -125,6 +128,12 @@ public:
 			return SPACING;
 		} else if (name == "size") {
 			return SIZE;
+		} else if (name == "up_arrow_bgimg") {
+			return UP_ARROW_BGIMG;
+		} else if (name == "down_arrow_bgimg") {
+			return DOWN_ARROW_BGIMG;
+		} else if (name == "thumb_bgimg") {
+			return THUMB_BGIMG;
 		} else {
 			return NONE;
 		}

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -698,11 +698,12 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 		spec.ftype = f_ScrollBar;
 		spec.send  = true;
 		GUIScrollBar *e = new GUIScrollBar(Environment, data->current_parent,
-				spec.fid, rect, is_horizontal, true);
+				spec.fid, rect, is_horizontal, true, m_tsrc);
 
-		auto style = getDefaultStyleForElement("scrollbar", name);
-		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 		e->setArrowsVisible(data->scrollbar_options.arrow_visiblity);
+
+		auto style = getStyleForElement("scrollbar", name);
+		e->setStyles(style);
 
 		s32 max = data->scrollbar_options.max;
 		s32 min = data->scrollbar_options.min;

--- a/src/gui/guiScrollBar.h
+++ b/src/gui/guiScrollBar.h
@@ -13,6 +13,7 @@ the arrow buttons where there is insufficient space.
 #pragma once
 
 #include "irrlichttypes_extrabloated.h"
+#include "StyleSpec.h"
 
 using namespace irr;
 using namespace gui;
@@ -21,7 +22,8 @@ class GUIScrollBar : public IGUIElement
 {
 public:
 	GUIScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s32 id,
-			core::rect<s32> rectangle, bool horizontal, bool auto_scale);
+			core::rect<s32> rectangle, bool horizontal, bool auto_scale,
+			ISimpleTextureSource *tsrc = nullptr);
 
 	enum ArrowVisibility
 	{
@@ -47,18 +49,28 @@ public:
 	void setPos(const s32 &pos);
 	void setPageSize(const s32 &size);
 	void setArrowsVisible(ArrowVisibility visible);
+	void setStyles(const std::array<StyleSpec, StyleSpec::NUM_STATES> &styles);
 
 private:
+	ISimpleTextureSource *getTextureSource() const noexcept { return m_tsrc; }
 	void refreshControls();
 	s32 getPosFromMousePos(const core::position2di &p) const;
-	f32 range() const { return f32(max_pos - min_pos); }
+	inline f32 range() const { return f32(max_pos - min_pos); }
 
-	IGUIButton *up_button;
-	IGUIButton *down_button;
+	IGUIButton *up_button = nullptr;
+	IGUIButton *down_button = nullptr;
+
+	video::ITexture *m_up_arrow_texture = nullptr;
+	video::ITexture *m_down_arrow_texture = nullptr;
+	video::ITexture *m_thumb_texture = nullptr;
+	gui::IGUIImage  *m_thumb = nullptr;
+	video::ITexture *m_bg_texture = nullptr;
+	
 	ArrowVisibility arrow_visibility = DEFAULT;
 	bool is_dragging;
 	bool is_horizontal;
 	bool is_auto_scaling;
+	ISimpleTextureSource *m_tsrc = nullptr;
 	bool dragged_by_slider;
 	bool tray_clicked;
 	s32 scroll_pos;


### PR DESCRIPTION
This PR adds different styling to the `scrollbar` element.

This is still WIP, lots of styling properties are missing.

![Capture d’écran du 2021-06-14 06-00-11](https://user-images.githubusercontent.com/7883281/121838680-ad741400-ccd8-11eb-90d2-4ed59f2ebfd0.png)

```Ruby
style[scrbar_inv;bgimg=scrbar_bg.png;up_arrow_bgimg=default_mese_crystal.png;down_arrow_bgimg=default_diamond.png;thumb_bgimg=trump.png]
```

@v-rob Thoughts?

