### PR TITLE
Buildbot: Use posix on Win64 builds while running from Ubuntu based distributions

### DIFF
--- a/util/buildbot/buildwin64.sh
+++ b/util/buildbot/buildwin64.sh
@@ -18,7 +18,18 @@ mkdir -p $builddir
 builddir="$( cd "$builddir" && pwd )"
 libdir=$builddir/libs
 
-toolchain_file=$dir/toolchain_x86_64-w64-mingw32.cmake
+# Test which win64 compiler is present
+which x86_64-w64-mingw32-gcc &>/dev/null &&
+	toolchain_file=$dir/toolchain_x86_64-w64-mingw32.cmake
+which x86_64-w64-mingw32-gcc-posix &>/dev/null &&
+	toolchain_file=$dir/toolchain_x86_64-w64-mingw32-posix.cmake
+
+if [ -z "$toolchain_file" ]; then
+	echo "Unable to determine which mingw32 compiler to use"
+	exit 1
+fi
+echo "Using $toolchain_file"
+
 irrlicht_version=1.9.0mt1
 ogg_version=1.3.4
 vorbis_version=1.3.7

--- a/util/buildbot/toolchain_x86_64-w64-mingw32-posix.cmake
+++ b/util/buildbot/toolchain_x86_64-w64-mingw32-posix.cmake
@@ -1,0 +1,19 @@
+# name of the target operating system
+SET(CMAKE_SYSTEM_NAME Windows)
+
+# which compilers to use for C and C++
+# *-posix is Ubuntu's naming for the MinGW variant that comes with support
+# for pthreads / std::thread (required by MT)
+SET(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc-posix)
+SET(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++-posix)
+SET(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
+
+# here is the target environment located
+SET(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32)
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
- This PR allows buildbot to detect and use mingw posix toolchain while cross-compiling Win64 builds on Ubuntu based distributions thus avoiding many issues regarding to threading features required by minetest not available while using default toolchain.
- To achieve this, `util/buildbot/buildwin64.sh` changed in similar way compared to `util/buildbot/buildwin32.sh` where it detects posix toolchain and uses the correct toolchain file pointing to correct utilities. The new toolchain file was copied from 32 bit posix toolchain file and changed where needed to reflect to the correct architecture.
- I din't find any open reported issues, though it would solve anything like #11354 in the future.
- [The roadmap](../doc/direction.md) does not mention this, though some users might have had this problem at least once.

## To do

This PR is Ready for Review.

## How to test

1. Install mingw on Ubuntu if not already installed
2. Run 64 bit buildbot script on Ubuntu or Ubuntu based distribution (e.g. run `EXISTING_MINETEST_DIR=$PWD ./util/buildbot/buildwin32.sh winbuild` from command line)
3. Confirm that compilation works on this pr while it does not work on master or release branches.