### PR TITLE
New move code: Only snap to collision box only on fall

### DIFF
--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -360,7 +360,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		m_standing_node = m_sneak_node;
 
 		// (BS * 0.6f) is the basic stepheight while standing on ground
-		if (y_diff < BS * 0.6f) {
+		if (y_diff < BS * 0.6f && m_speed.Y <= 0.0f) {
 			// Only center player when they're on the node
 			position.X = rangelim(position.X,
 				bmin.X - sneak_max.X, bmax.X + sneak_max.X);


### PR DESCRIPTION
Fixes #11261

I did not mark this as trivial because there might (as always) someone depend on this snapping behaviour already when jumping up.

## To do

This PR is Ready for Review.

## How to test

1. Testing mod:

```Lua
minetest.register_on_joinplayer(function(player)
	player:set_physics_override({
		sneak_glitch = true,
		sneak = true,
		new_move = true,
		jump = 2,
	})
end)
```

2. Stack a few slabs (like below) and rotate them accordingly to make the effect more apparent:

   * https://github.com/minetest/minetest/issues/11261#issuecomment-840746330