### PR TITLE
Inventory: show error on invalid list names

### DIFF
--- a/src/inventory.h
+++ b/src/inventory.h
@@ -298,6 +298,7 @@ public:
 	void serialize(std::ostream &os, bool incremental = false) const;
 	void deSerialize(std::istream &is);
 
+	// Adds a new list or clears and resizes an existing one
 	InventoryList * addList(const std::string &name, u32 size);
 	InventoryList * getList(const std::string &name);
 	const InventoryList * getList(const std::string &name) const;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1350,26 +1350,28 @@ void read_inventory_list(lua_State *L, int tableindex,
 {
 	if(tableindex < 0)
 		tableindex = lua_gettop(L) + 1 + tableindex;
+
 	// If nil, delete list
 	if(lua_isnil(L, tableindex)){
 		inv->deleteList(name);
 		return;
 	}
-	// Otherwise set list
+
+	// Get Lua-specified items to insert into the list
 	std::vector<ItemStack> items = read_items(L, tableindex,srv);
-	int listsize = (forcesize != -1) ? forcesize : items.size();
+	size_t listsize = (forcesize > 0) ? forcesize : items.size();
+
+	// Create or clear list
 	InventoryList *invlist = inv->addList(name, listsize);
-	int index = 0;
-	for(std::vector<ItemStack>::const_iterator
-			i = items.begin(); i != items.end(); ++i){
-		if(forcesize != -1 && index == forcesize)
-			break;
-		invlist->changeItem(index, *i);
-		index++;
+	if (!invlist) {
+		luaL_error(L, "inventory list: cannot create list named '%s'", name);
+		return;
 	}
-	while(forcesize != -1 && index < forcesize){
-		invlist->deleteItem(index);
-		index++;
+
+	for (size_t i = 0; i < items.size(); ++i) {
+		if (i == listsize)
+			break; // Truncate provided list of items
+		invlist->changeItem(i, items[i]);
 	}
 }
 


### PR DESCRIPTION
Fixes #11294 and restructures the code a bit. `deleteItem()` calls are superfluous because `Inventory::addList` clears its newly generated list.


## To do

This PR is Ready for Review.


## How to test

1. Testing mod

```Lua
minetest.register_on_joinplayer(function(player)
	local meta = minetest.get_meta(player:get_pos())
	meta:get_inventory():set_lists({
		[" "] = {""}
	})
	meta:from_table({
		inventory = {[" "] = {""}}
	})
	minetest.get_inventory({
		type="player",
		name=player:get_player_name()
	}):set_list(" ", {""})
end)
```

2. Comment out from top to bottom. All cases should throw an error
3. (optional) Check whether `set_list` is still working properly (unified_inventory, 3d_armor, ...?)