### PR TITLE
Add per-node climb speed modifier

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7658,6 +7658,13 @@ Used by `minetest.register_node`.
         -- (see `liquid_move_physics`), the movement speed will also be
         -- affected by the `movement_liquid_*` settings.
 
+        climb_factor = 1.0,
+        -- The speed at which a climbable node can be climbed is multiplied
+        -- with this number. Must not be negative. No effect if node isn't
+        -- climbable.
+        -- Note: To set the base climbing speed in your game,
+        -- change the setting "movement_speed_climb".
+
         buildable_to = false,  -- If true, placed nodes can replace this node
 
         floodable = false,

--- a/games/devtest/mods/testnodes/properties.lua
+++ b/games/devtest/mods/testnodes/properties.lua
@@ -82,6 +82,35 @@ minetest.register_node("testnodes:climbable", {
 	drawtype = "glasslike",
 	groups = {dig_immediate=3},
 })
+minetest.register_node("testnodes:climbable_fast", {
+	description = S("Climbable Node (fast)"),
+	climbable = true,
+	climb_factor = 2.0,
+	walkable = false,
+
+
+	paramtype = "light",
+	sunlight_propagates = true,
+	is_ground_content = false,
+	tiles = {"testnodes_climbable_side.png^[colorize:#FFFFFF:140"},
+	drawtype = "glasslike",
+	groups = {dig_immediate=3},
+})
+minetest.register_node("testnodes:climbable_slow", {
+	description = S("Climbable Node (slow)"),
+	climbable = true,
+	climb_factor = 0.5,
+	walkable = false,
+
+
+	paramtype = "light",
+	sunlight_propagates = true,
+	is_ground_content = false,
+	tiles = {"testnodes_climbable_side.png^[colorize:#000000:140"},
+	drawtype = "glasslike",
+	groups = {dig_immediate=3},
+})
+
 
 -- Climbable only downwards with sneak key
 minetest.register_node("testnodes:climbable_nojump", {

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -274,6 +274,9 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	} else {
 		is_climbing = (nodemgr->get(node.getContent()).climbable ||
 			nodemgr->get(node2.getContent()).climbable) && !free_move;
+		if (is_climbing) {
+			climb_factor = nodemgr->get(node.getContent()).climb_factor;
+		}
 	}
 
 	/*
@@ -526,7 +529,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				speedV.Y = -movement_speed_walk;
 				swimming_vertical = true;
 			} else if (is_climbing) {
-				speedV.Y = -movement_speed_climb;
+				speedV.Y = -movement_speed_climb * climb_factor;
 			} else {
 				// If not free movement but fast is allowed, aux1 is
 				// "Turbo button"
@@ -561,9 +564,9 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				swimming_vertical = true;
 			} else if (is_climbing) {
 				if (fast_climb)
-					speedV.Y = -movement_speed_fast;
+					speedV.Y = -movement_speed_fast * climb_factor;
 				else
-					speedV.Y = -movement_speed_climb;
+					speedV.Y = -movement_speed_climb * climb_factor;
 			}
 		}
 	}
@@ -610,9 +613,9 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			swimming_vertical = true;
 		} else if (is_climbing && !m_disable_jump) {
 			if (fast_climb)
-				speedV.Y = movement_speed_fast;
+				speedV.Y = movement_speed_fast * climb_factor;
 			else
-				speedV.Y = movement_speed_climb;
+				speedV.Y = movement_speed_climb * climb_factor;
 		}
 	}
 

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -58,6 +58,7 @@ public:
 	// Slows down the player when moving through
 	u8 move_resistance = 0;
 	bool is_climbing = false;
+	f32 climb_factor = 1.0f;
 	bool swimming_vertical = false;
 	bool swimming_pitch = false;
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -405,6 +405,7 @@ void ContentFeatures::reset()
 	node_dig_prediction = "air";
 	move_resistance = 0;
 	liquid_move_physics = false;
+	climb_factor = 1.0;
 }
 
 void ContentFeatures::setAlphaFromLegacy(u8 legacy_alpha)
@@ -520,6 +521,7 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	writeU8(os, alpha);
 	writeU8(os, move_resistance);
 	writeU8(os, liquid_move_physics);
+	writeF32(os, climb_factor);
 }
 
 void ContentFeatures::deSerialize(std::istream &is)
@@ -635,6 +637,11 @@ void ContentFeatures::deSerialize(std::istream &is)
 		if (is.eof())
 			throw SerializationError("");
 		liquid_move_physics = tmp;
+
+		f32 ftmp = readF32(is);
+		if (is.eof())
+			throw SerializationError("");
+		climb_factor = ftmp;
 	} catch(SerializationError &e) {};
 }
 

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -369,6 +369,8 @@ struct ContentFeatures
 	bool diggable;
 	// Player can climb these
 	bool climbable;
+	// Climb speed factor
+	f32 climb_factor;
 	// Player can build on these
 	bool buildable_to;
 	// Player cannot build to these (placement prediction disabled)

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -840,6 +840,8 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 		errorstream << "Field \"liquid_move_physics\": Invalid type!" << std::endl;
 	}
 	lua_pop(L, 1);
+
+	getfloatfield(L, index, "climb_factor", f.climb_factor);
 }
 
 void push_content_features(lua_State *L, const ContentFeatures &c)
@@ -971,6 +973,8 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 	lua_setfield(L, -2, "move_resistance");
 	lua_pushboolean(L, c.liquid_move_physics);
 	lua_setfield(L, -2, "liquid_move_physics");
+	lua_pushnumber(L, c.climb_factor);
+	lua_setfield(L, -2, "climb_factor");
 }
 
 /******************************************************************************/


### PR DESCRIPTION
This fixes #1935.

This adds `climb_factor` property to nodes. It's a float that modifies the climbing speed on climbable nodes.


## How to test

Use the climbable nodes in DevTest. There's a fast, slow and normal one. Compare the speeds.