### PR TITLE
Add disable_settings to game.conf to get rid of "Enable Damage"/"Creative Mode"/"Host Server" checkbox

### DIFF
--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -151,17 +151,24 @@ local function get_formspec(tabview, name, tabdata)
 
 	local creative, damage, host = "", "", ""
 
+	-- Y offsets for game settings checkboxes
+	local y = -0.2
+	local yo = 0.45
+
 	if disabled_settings["creative_mode"] == nil then
-		creative = "checkbox[0,-0.20;cb_creative_mode;".. fgettext("Creative Mode") .. ";" ..
+		creative = "checkbox[0,"..y..";cb_creative_mode;".. fgettext("Creative Mode") .. ";" ..
 			dump(core.settings:get_bool("creative_mode")) .. "]"
+		y = y + yo
 	end
 	if disabled_settings["enable_damage"] == nil then
-		damage = "checkbox[0,0.25;cb_enable_damage;".. fgettext("Enable Damage") .. ";" ..
+		damage = "checkbox[0,"..y..";cb_enable_damage;".. fgettext("Enable Damage") .. ";" ..
 			dump(core.settings:get_bool("enable_damage")) .. "]"
+		y = y + yo
 	end
 	if disabled_settings["enable_server"] == nil then
-		host = "checkbox[0,0.7;cb_server;".. fgettext("Host Server") ..";" ..
+		host = "checkbox[0,"..y..";cb_server;".. fgettext("Host Server") ..";" ..
 			dump(core.settings:get_bool("enable_server")) .. "]"
+		y = y + yo
 	end
 
 	retval = retval ..
@@ -179,7 +186,7 @@ local function get_formspec(tabview, name, tabdata)
 	if core.settings:get_bool("enable_server") and disabled_settings["enable_server"] == nil then
 		retval = retval ..
 				"button[7.9,4.75;4.1,1;play;".. fgettext("Host Game") .. "]" ..
-				"checkbox[0,1.15;cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
+				"checkbox[0,"..y..";cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
 				dump(core.settings:get_bool("server_announce")) .. "]" ..
 				"field[0.3,2.85;3.8,0.5;te_playername;" .. fgettext("Name") .. ";" ..
 				core.formspec_escape(core.settings:get("name")) .. "]" ..

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -77,8 +77,16 @@ The game directory can contain the following files:
       `disallowed_mapgens`.
     * `disallowed_mapgen_settings= <comma-separated mapgen settings>`
       e.g. `disallowed_mapgen_settings = mgv5_spflags`
-      These settings are hidden for this game in the world creation
+      These mapgen settings are hidden for this game in the world creation
       dialog and game start menu.
+    * `disabled_settings = <comma-separated settings>`
+      e.g. `disabled_settings = enable_damage, creative_mode`
+      These settings are hidden for this game in the "Start game" tab
+      and will be initialized as `false` when the game is started.
+      Prepend a setting name with an exclamation mark to initialize it to `true`
+      (this does not work for `enable_server`).
+      Only these settings are supported:
+          `enable_damage`, `creative_mode`, `enable_server`.
     * `author`: The author of the game. It only appears when downloaded from
                 ContentDB.
     * `release`: Ignore this: Should only ever be set by ContentDB, as it is


### PR DESCRIPTION
Fixes #8927.

This adds support for `disable_settings` to `game.conf`. In this you can specify a list of settings that should not be visible in the "local game" (or however it is called nowadays) tab. Enable Damage, Creative Mode and Host Server are supported.

The settings are initialized with `false` by default but by prepending an explamation mark you can also initialize them to `true` (but not for Host Server, as Minetest cannot guess the address to connect to ;-) ).

## Use cases

* Tutorial in which you need to force-enable damage
* Games without Creative Mode
* Singleplayer games (need to get rid of the "Host Server" checkbox)

## How to test

Add `disable_settings` in `game.conf` of an example game. Check if it initialized to the correct settings after launch (Use the `/set` command). See `lua_api.txt` for details.
