### PR TITLE
Inventory: Make addList() consistent

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -938,18 +938,15 @@ void Inventory::deSerialize(std::istream &is)
 InventoryList * Inventory::addList(const std::string &name, u32 size)
 {
 	setModified();
+
+	// Remove existing lists
 	s32 i = getListIndex(name);
-	if(i != -1)
-	{
-		if(m_lists[i]->getSize() != size)
-		{
-			delete m_lists[i];
-			m_lists[i] = new InventoryList(name, size, m_itemdef);
-			m_lists[i]->setModified();
-		}
+	if (i != -1) {
+		delete m_lists[i];
+		m_lists[i] = new InventoryList(name, size, m_itemdef);
+		m_lists[i]->setModified();
 		return m_lists[i];
 	}
-
 
 	//don't create list with invalid name
 	if (name.find(' ') != std::string::npos)

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -298,7 +298,7 @@ public:
 	void serialize(std::ostream &os, bool incremental = false) const;
 	void deSerialize(std::istream &is);
 
-	// Adds a new list or clears and resizes an existing one
+	// Creates a new list if none exists or truncates existing lists
 	InventoryList * addList(const std::string &name, u32 size);
 	InventoryList * getList(const std::string &name);
 	const InventoryList * getList(const std::string &name) const;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1359,9 +1359,9 @@ void read_inventory_list(lua_State *L, int tableindex,
 
 	// Get Lua-specified items to insert into the list
 	std::vector<ItemStack> items = read_items(L, tableindex,srv);
-	size_t listsize = (forcesize > 0) ? forcesize : items.size();
+	size_t listsize = (forcesize >= 0) ? forcesize : items.size();
 
-	// Create or clear list
+	// Create or resize/clear list
 	InventoryList *invlist = inv->addList(name, listsize);
 	if (!invlist) {
 		luaL_error(L, "inventory list: cannot create list named '%s'", name);


### PR DESCRIPTION
Fixes list clearing for inv:set_list() using same size, since 2db6b07.
addList() now clears the list in all cases. Use setSize() to resize without clearing.

This is IMO a proper solution to the weird case where matching list sizes would not clear the list contents.

Fixes #11373

## To do

This PR is Ready for Review.

## How to test

1. Trash slot in the inventory
2. Use `sfinv` (trash slot), `craftguide` (sort inventory), `i3` (sort inventory), `moreblocks` (circular saw) or `unified_inventory` (bags, trash slot) to confirm that `set_list` is still working
3. Rejoin to ensure that `"main"`, `"craft"` etc are saved and loaded properly