### PR TITLE
Improve shadow rendering with non-default camera FOV

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -187,7 +187,7 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	// Return fast if sharp shadows are requested
 	if (SOFTSHADOWRADIUS <= 1.0) {
 		perspectiveFactor = getDeltaPerspectiveFactor(baseLength);
-		return max(1 / perspectiveFactor / perspectiveFactor, SOFTSHADOWRADIUS);
+		return max(length(smTexCoord.xy) * 2 / pow(perspectiveFactor, 3), SOFTSHADOWRADIUS);
 	}
 
 	vec2 clampedpos;
@@ -217,7 +217,7 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	depth = pow(clamp(depth, 0.0, 1000.0), 1.6) / 0.001;
 
 	perspectiveFactor = getDeltaPerspectiveFactor(baseLength);
-	return max(1 / perspectiveFactor / perspectiveFactor, depth * maxRadius);
+	return max(length(smTexCoord.xy) * 2 / pow(perspectiveFactor, 3), depth * maxRadius);
 }
 
 #ifdef POISSON_FILTER

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -187,7 +187,7 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	// Return fast if sharp shadows are requested
 	if (SOFTSHADOWRADIUS <= 1.0) {
 		perspectiveFactor = getDeltaPerspectiveFactor(baseLength);
-		return max(length(smTexCoord.xy) * 2 / pow(perspectiveFactor, 3), SOFTSHADOWRADIUS);
+		return max(2 * length(smTexCoord.xy) * 2048 / f_textureresolution / pow(perspectiveFactor, 3), SOFTSHADOWRADIUS);
 	}
 
 	vec2 clampedpos;
@@ -217,7 +217,7 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	depth = pow(clamp(depth, 0.0, 1000.0), 1.6) / 0.001;
 
 	perspectiveFactor = getDeltaPerspectiveFactor(baseLength);
-	return max(length(smTexCoord.xy) * 2 / pow(perspectiveFactor, 3), depth * maxRadius);
+	return max(length(smTexCoord.xy) * 2 * 2048 / f_textureresolution / pow(perspectiveFactor, 3), depth * maxRadius);
 }
 
 #ifdef POISSON_FILTER

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -740,7 +740,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		s32 shadow_filter = g_settings->getS32("shadow_filters");
 		shaders_header << "#define SHADOW_FILTER " << shadow_filter << "\n";
 
-		float shadow_soft_radius = g_settings->getS32("shadow_soft_radius");
+		float shadow_soft_radius = g_settings->getFloat("shadow_soft_radius");
 		if (shadow_soft_radius < 1.0f)
 			shadow_soft_radius = 1.0f;
 		shaders_header << "#define SOFTSHADOWRADIUS " << shadow_soft_radius << "\n";

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -29,7 +29,6 @@ using m4f = core::matrix4;
 
 void DirectionalLight::createSplitMatrices(const Camera *cam)
 {
-	const float TAN_36_DEG = 0.726542528006F; // Half of default FOV
 	float radius;
 	v3f newCenter;
 	v3f look = cam->getDirection();
@@ -40,7 +39,7 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 
 	// adjusted frustum boundaries
 	float sfNear = shadow_frustum.zNear;
-	float sfFar = shadow_frustum.zFar * TAN_36_DEG / tanFovY;
+	float sfFar = adjustDist(shadow_frustum.zFar, cam->getFovY());
 
 	// adjusted camera positions
 	v3f camPos2 = cam->getPosition();

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -29,33 +29,39 @@ using m4f = core::matrix4;
 
 void DirectionalLight::createSplitMatrices(const Camera *cam)
 {
+	const float TAN_36_DEG = 0.726542528006F; // Half of default FOV
 	float radius;
 	v3f newCenter;
 	v3f look = cam->getDirection();
 
+	// camera view tangents
+	float tanFovY = tanf(cam->getFovY() * 0.5f);
+	float tanFovX = tanf(cam->getFovX() * 0.5f);
+
+	// adjusted frustum boundaries
+	float sfNear = shadow_frustum.zNear;
+	float sfFar = shadow_frustum.zFar * TAN_36_DEG / tanFovY;
+
+	// adjusted camera positions
 	v3f camPos2 = cam->getPosition();
 	v3f camPos = v3f(camPos2.X - cam->getOffset().X * BS,
 			camPos2.Y - cam->getOffset().Y * BS,
 			camPos2.Z - cam->getOffset().Z * BS);
-	camPos += look * shadow_frustum.zNear;
-	camPos2 += look * shadow_frustum.zNear;
-	float end = shadow_frustum.zNear + shadow_frustum.zFar;
-	newCenter = camPos + look * (shadow_frustum.zNear + 0.05f * end);
-	v3f world_center = camPos2 + look * (shadow_frustum.zNear + 0.05f * end);
+	camPos += look * sfNear;
+	camPos2 += look * sfNear;
+
+	// center point of light frustum
+	float end = sfNear + sfFar;
+	newCenter = camPos + look * (sfNear + 0.05f * end);
+	v3f world_center = camPos2 + look * (sfNear + 0.05f * end);
+
 	// Create a vector to the frustum far corner
-	// @Liso: move all vars we can outside the loop.
-	float tanFovY = tanf(cam->getFovY() * 0.5f);
-	float tanFovX = tanf(cam->getFovX() * 0.5f);
-
 	const v3f &viewUp = cam->getCameraNode()->getUpVector();
-	// viewUp.normalize();
-
 	v3f viewRight = look.crossProduct(viewUp);
-	// viewRight.normalize();
 
 	v3f farCorner = look + viewRight * tanFovX + viewUp * tanFovY;
 	// Compute the frustumBoundingSphere radius
-	v3f boundVec = (camPos + farCorner * shadow_frustum.zFar) - newCenter;
+	v3f boundVec = (camPos + farCorner * sfFar) - newCenter;
 	radius = boundVec.getLength() * 2.0f;
 	// boundVec.getLength();
 	float vvolume = radius * 2.0f;

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -159,7 +159,7 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 	return true;
 }
 
-s16 adjustDist(s16 dist, float zoom_fov)
+inline float adjustDist(float dist, float zoom_fov)
 {
 	// 1.775 ~= 72 * PI / 180 * 1.4, the default FOV on the client.
 	// The heuristic threshold for zooming is half of that.
@@ -167,8 +167,13 @@ s16 adjustDist(s16 dist, float zoom_fov)
 	if (zoom_fov < 0.001f || zoom_fov > threshold_fov)
 		return dist;
 
-	return std::round(dist * std::cbrt((1.0f - std::cos(threshold_fov)) /
-		(1.0f - std::cos(zoom_fov / 2.0f))));
+	return dist * std::cbrt((1.0f - std::cos(threshold_fov)) /
+		(1.0f - std::cos(zoom_fov / 2.0f)));
+}
+
+s16 adjustDist(s16 dist, float zoom_fov)
+{
+	return std::round(adjustDist((float)dist, zoom_fov));
 }
 
 void setPitchYawRollRad(core::matrix4 &m, const v3f &rot)


### PR DESCRIPTION
Improve filtering of distant shadows, see #11341. 

This PR corrects two things:
* shadow frustum calculation when camera FOV is not default, e.g. when using Zoom.
* getPenumbraRadius() in the node fragment shader to adjust the minimum filter radius for perspective, which improves most of the cases of distant shadow filtering.

This PR is Ready for Review.

## How to test

Enable dynamic shadows, choose one of the following parameter sets:
* shadow_filters=1, shadow_soft_radius=1
* shadow_filters=2, shadow_soft_radius=1
* shadow_filters=1, shadow_soft_radius=2
* shadow_filters=2, shadow_soft_radius=4

Look at distant shadows and move around, notice that the overall shape of the shadow does not change significantly and gets less sharp with distance.

Use Zoom to look at distant objects.
