### PR TITLE
run on_grant and on_revoke callbacks after privs change

### DIFF
--- a/builtin/game/auth.lua
+++ b/builtin/game/auth.lua
@@ -87,6 +87,10 @@ core.builtin_auth_handler = {
 					core.settings:get("default_password")))
 		end
 
+		auth_entry.privileges = privileges
+
+		core_auth.save(auth_entry)
+
 		-- Run grant callbacks
 		for priv, _ in pairs(privileges) do
 			if not auth_entry.privileges[priv] then
@@ -100,9 +104,6 @@ core.builtin_auth_handler = {
 				core.run_priv_callbacks(name, priv, nil, "revoke")
 			end
 		end
-
-		auth_entry.privileges = privileges
-		core_auth.save(auth_entry)
 		core.notify_authentication_modified(name)
 	end,
 	reload = function()

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -255,11 +255,11 @@ local function handle_grant_command(caller, grantname, grantprivstr)
 	if privs_unknown ~= "" then
 		return false, privs_unknown
 	end
+	core.set_player_privs(grantname, privs)
 	for priv, _ in pairs(grantprivs) do
 		-- call the on_grant callbacks
 		core.run_priv_callbacks(grantname, priv, caller, "grant")
 	end
-	core.set_player_privs(grantname, privs)
 	core.log("action", caller..' granted ('..core.privs_to_string(grantprivs, ', ')..') privileges to '..grantname)
 	if grantname ~= caller then
 		core.chat_send_player(grantname,
@@ -359,13 +359,13 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 	end
 
 	local revokecount = 0
+
+	core.set_player_privs(revokename, privs)
 	for priv, _ in pairs(revokeprivs) do
 		-- call the on_revoke callbacks
 		core.run_priv_callbacks(revokename, priv, caller, "revoke")
 		revokecount = revokecount + 1
 	end
-
-	core.set_player_privs(revokename, privs)
 	local new_privs = core.get_player_privs(revokename)
 
 	if revokecount == 0 then


### PR DESCRIPTION
Fix #11372
Run `on_grant` and `on_revoke` callbacks after privs change

## To do

This PR is Ready for Review.

## How to test

https://github.com/minetest/minetest/issues/11372#issuecomment-865274439

**(DEPRECATED: both calls now return right values)**
**Before:**
```
grant "singleplayer" "singleplayer" "fast" | get_player_privs = {	fly = true}
grant "singleplayer" nil "fast" | get_player_privs = {	fly = true}
2021-06-25 14:45:10: ACTION[Server]: singleplayer granted (fast) privileges to singleplayer

revoke "singleplayer" "singleplayer" "fast" | get_player_privs = {	fast = true,	fly = true}
revoke "singleplayer" nil "fast" | get_player_privs = {	fast = true,	fly = true}
2021-06-25 14:45:16: ACTION[Server]: singleplayer revoked (fast) privileges from singleplayer
```
**After:**
```
grant "singleplayer" nil "fast" | get_player_privs = {	fly = true}
grant "singleplayer" "singleplayer" "fast" | get_player_privs = {	fast = true,	fly = true}
2021-06-25 14:46:20: ACTION[Server]: singleplayer granted (fast) privileges to singleplayer

revoke "singleplayer" nil "fast" | get_player_privs = {	fast = true,	fly = true}
revoke "singleplayer" "singleplayer" "fast" | get_player_privs = {	fly = true}
2021-06-25 14:46:25: ACTION[Server]: singleplayer revoked (fast) privileges from singleplayer
```
