### PR TITLE
Fix falling mesh nodes being half size

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -112,9 +112,6 @@ core.register_entity(":__builtin:falling_node", {
 			end
 			-- FIXME: solution needed for paramtype2 == "leveled"
 			local s = (def.visual_scale or 1) * SCALE
-			if def.drawtype == "mesh" then
-				s = s * 0.5
-			end
 			self.object:set_properties({
 				is_visible = true,
 				wield_item = itemstring,


### PR DESCRIPTION
A falling mesh node converted to the half size during the fall. This PR will fix it and falling mesh nodes will look correctly again, with their full size.

How to test: Place mesh nodes in DevTest and use the falling node tool on them.