### PR TITLE
Add support for static boxes in 'leveled' type; add node box types 'leveled_plantlike[_rooted]'

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1325,6 +1325,7 @@ The function of `param2` is determined by `paramtype2` in node definition.
               nodeboxes.
             * The nodebox height is (`param2` / 64) nodes.
             * The maximum accepted value of `param2` is 127.
+            * Boxes in '`leveled_fixed = {}`' will never change.
         * Rooted plantlike:
             * The height of the 'plantlike' section is stored in `param2`.
             * The height is (`param2` / 16) nodes.
@@ -1526,8 +1527,29 @@ A nodebox is defined as any of:
     -- by the node parameter 'leveled = ', or if 'paramtype2 == "leveled"'
     -- by param2.
     -- Other faces are defined by 'fixed = {}' as with 'type = "fixed"'.
+    -- Optionally add 'leveled_fixed = {}' for static boxes.
     type = "leveled",
-    fixed = box OR {box1, box2, ...}
+    fixed = box OR {box1, box2, ...} -- top face is variable
+    leveled_fixed = box OR {box1, box2, ...} -- never changes
+}
+{
+    -- Same as leveled, but the box height is in sync with the 'plant'
+    -- of 'plantlike' nodes (steps of 1/16).
+    -- Recommended use for this is as selection box.
+    -- Be careful when using this as a collision box -- do not exceed the
+    -- max. permissible heights of collision boxes (see collision box
+    -- definition).
+    type = "leveled_plantlike",
+    fixed, leveled_fixed = -- see above
+}
+{
+    -- Same as leveled, but the box height is in sync with the graphical
+    -- representation of of 'plantlike_rooted' nodes (steps of 1/16).
+    -- The upper box bound begins at the top side of the base cube (0.5).
+    -- Recommended use for this is as selection box.
+    -- Be careful when using this as a collision box (see above).
+    type = "leveled_plantlike_rooted",
+    fixed, leveled_fixed = -- see above
 }
 {
     -- A box like the selection box for torches
@@ -9520,6 +9542,9 @@ Used by `minetest.register_node`.
     -- Custom collision box definition. Multiple boxes can be defined.
     -- If "nodebox" drawtype is used and collision_box is nil, then node_box
     -- definition is used for the collision box.
+    -- Collision boxes that are larger than the node itself are allowed, but
+    -- only up to an absolute value of -0.5 + 127/64 on each axis. If you
+    -- exceed this limit, there's no guarantee that collisions still work.
 
     -- Support maps made in and before January 2012
     legacy_facedir_simple = false,

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1600,10 +1600,11 @@ A box of a regular node would look like:
 {-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
 ```
 
-To avoid collision issues, keep each value within the range of +/- 1.45.
-This also applies to leveled nodeboxes, where the final height shall not
-exceed this soft limit.
-
+To avoid collision issues, keep each value within the range of +/- 1.45
+for collision boxes. This also applies to leveled collision boxes, where
+the final height shall not exceed this soft limit.
+The same restrictions apply to selection boxes, with one exception:
+Their maximum allowed height is +16.5.
 
 
 Map terminology and coordinates

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1318,17 +1318,20 @@ The function of `param2` is determined by `paramtype2` in node definition.
     * 4dir modulo 4 = rotation
     * Otherwise, behavior is identical to facedir
 * `paramtype2 = "leveled"`
-    * Only valid for "nodebox" with 'type = "leveled"', and "plantlike_rooted".
-        * Leveled nodebox:
+    * Only valid for the drawtypes `nodebox`, `plantlike` and `plantlike_rooted`
+        * Nodebox:
+            * Nodebox `type` must be set to `"leveled"`
             * The level of the top face of the nodebox is stored in `param2`.
             * The other faces are defined by 'fixed = {}' like 'type = "fixed"'
               nodeboxes.
             * The nodebox height is (`param2` / 64) nodes.
             * The maximum accepted value of `param2` is 127.
             * Boxes in '`leveled_fixed = {}`' will never change.
-        * Rooted plantlike:
+        * Plantlike:
             * The height of the 'plantlike' section is stored in `param2`.
             * The height is (`param2` / 16) nodes.
+        * Rooted plantlike:
+            * Same as plantlike
 * `paramtype2 = "degrotate"`
     * Valid for `plantlike` and `mesh` drawtypes. The rotation of the node is
       stored in `param2`.

--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -450,7 +450,9 @@ minetest.register_node("testnodes:plantlike_rooted_leveled", {
 	-- also test the 'leveled_plantlike_rooted' nodebox
 	selection_box = {
 		type = "leveled_plantlike_rooted",
+		-- variable box for plant
 		fixed = { -0.4, 0.5, -0.4, 0.4, 0.5, 0.4 },
+		-- fixed box for the base cube
 		leveled_fixed = { -0.5, -0.5, -0.5, 0.5, 0.5, 0.5 },
 	},
 

--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -366,7 +366,7 @@ minetest.register_node("testnodes:plantlike_leveled", {
 	-- also test the 'leveled_plantlike' nodebox
 	selection_box = {
 		type = "leveled_plantlike",
-		fixed = { -0.5, -0.5, -0.5, 0.5, 0.5, 0.5 },
+		fixed = { -0.4, -0.5, -0.4, 0.4, 0.4, 0.4 },
 	},
 
 
@@ -446,6 +446,12 @@ minetest.register_node("testnodes:plantlike_rooted_leveled", {
 	},
 	special_tiles = {
 		{ name = "testnodes_plantlike_rooted_leveled.png", tileable_vertical = true },
+	},
+	-- also test the 'leveled_plantlike_rooted' nodebox
+	selection_box = {
+		type = "leveled_plantlike_rooted",
+		fixed = { -0.4, 0.5, -0.4, 0.4, 0.5, 0.4 },
+		leveled_fixed = { -0.5, -0.5, -0.5, 0.5, 0.5, 0.5 },
 	},
 
 

--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -363,6 +363,11 @@ minetest.register_node("testnodes:plantlike_leveled", {
 	tiles = {
 		{ name = "testnodes_plantlike_leveled.png", tileable_vertical = true },
 	},
+	-- also test the 'leveled_plantlike' nodebox
+	selection_box = {
+		type = "leveled_plantlike",
+		fixed = { -0.5, -0.5, -0.5, 0.5, 0.5, 0.5 },
+	},
 
 
 	-- We set a default param2 here only for convenience, to make the "plant" visible after placement

--- a/games/devtest/mods/testnodes/nodeboxes.lua
+++ b/games/devtest/mods/testnodes/nodeboxes.lua
@@ -61,6 +61,28 @@ minetest.register_node("testnodes:nodebox_leveled", {
 
 	groups = {dig_immediate=3},
 })
+-- Leveled nodebox that also contains a static nodebox
+minetest.register_node("testnodes:nodebox_leveled_fixed", {
+	description = S("Combined Leveled Nodebox Test Node"),
+	tiles = {"testnodes_nodebox.png"},
+	drawtype = "nodebox",
+	paramtype = "light",
+	paramtype2 = "leveled",
+	node_box = {
+		type = "leveled",
+		fixed = {-0.25, 0.0, -0.25, 0.25, -0.499, 0.25},
+		leveled_fixed = {
+			{-0.5, -0.5, -0.5, -0.25, 0.0, -0.25},
+			{0.25, -0.5, 0.25, 0.5, 0.0, 0.5},
+			{-0.5, -0.5, 0.25, -0.25, 0.0, 0.5},
+			{0.25, -0.5, -0.5, 0.5, 0.0, -0.25},
+		},
+	},
+
+	groups = {dig_immediate=3},
+})
+
+
 
 
 local nodebox_wall = {

--- a/games/devtest/mods/testnodes/nodeboxes.lua
+++ b/games/devtest/mods/testnodes/nodeboxes.lua
@@ -63,7 +63,9 @@ minetest.register_node("testnodes:nodebox_leveled", {
 })
 -- Leveled nodebox that also contains a static nodebox
 minetest.register_node("testnodes:nodebox_leveled_fixed", {
-	description = S("Combined Leveled Nodebox Test Node"),
+	description = S("Combined Leveled Nodebox Test Node").."\n"..
+		S("param2 = height of center box (0..127)").."\n"..
+		S("Other boxes are unaffected by param2"),
 	tiles = {"testnodes_nodebox.png"},
 	drawtype = "nodebox",
 	paramtype = "light",

--- a/src/constants.h
+++ b/src/constants.h
@@ -76,10 +76,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define BS 10.0f
 
 // This number defines the safe max absolute X/Y/Z coordinate in which
-// collisions are still work safely. Beyond that limit, collisions might
-// break.
-// -0.5 + 127/64
-#define SAFE_NODE_COLLISION_LIMIT (1.484375f)
+// selection boxes still work safely. Beyond that limit, selection boxes
+// might break.
+#define SAFE_SELECTION_BOX_LIMIT (3.5f)
 
 // Dimension of a MapBlock
 #define MAP_BLOCKSIZE 16

--- a/src/constants.h
+++ b/src/constants.h
@@ -78,7 +78,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // This number defines the safe max absolute X/Y/Z coordinate in which
 // selection boxes still work safely. Beyond that limit, selection boxes
 // might break.
-#define SAFE_SELECTION_BOX_LIMIT (3.5f)
+#define SAFE_SELECTION_BOX_LIMIT (16.5f)
 
 // Dimension of a MapBlock
 #define MAP_BLOCKSIZE 16

--- a/src/constants.h
+++ b/src/constants.h
@@ -75,6 +75,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // Use floatToInt(p, BS) and intToFloat(p, BS).
 #define BS 10.0f
 
+// This number defines the safe max absolute X/Y/Z coordinate in which
+// collisions are still work safely. Beyond that limit, collisions might
+// break.
+// -0.5 + 127/64
+#define SAFE_NODE_COLLISION_LIMIT (1.484375f)
+
 // Dimension of a MapBlock
 #define MAP_BLOCKSIZE 16
 // This makes mesh updates too slow, as many meshes are updated during

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -205,9 +205,7 @@ void buildFixedNodeBox(const MapNode &n, const NodeBox &nodebox, const NodeDefMa
 			} else {
 				box.MaxEdge.Y = (-0.5f + height / 16.0f) * BS;
 			}
-			if (box.MaxEdge.Y > SAFE_SELECTION_BOX_LIMIT * BS) {
-				box.MaxEdge.Y = SAFE_SELECTION_BOX_LIMIT * BS;
-			}
+			box.MaxEdge.Y = std::min(box.MaxEdge.Y, SAFE_SELECTION_BOX_LIMIT * BS);
 			break;
 		}
 		default: {

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -185,6 +185,137 @@ void MapNode::rotateAlongYAxis(const NodeDefManager *nodemgr, Rotation rot)
 	}
 }
 
+void buildFixedNodeBox(const MapNode &n, const NodeBox &nodebox, const NodeDefManager *nodemgr,
+		std::vector<aabb3f> &boxes, std::vector<aabb3f> input_boxes,
+		bool is_leveled) {
+	u8 facedir = n.getFaceDir(nodemgr, true);
+	facedir &= 0x03;
+	u8 axisdir = facedir>>2;
+	for (aabb3f box : input_boxes) {
+		if (is_leveled)
+			box.MaxEdge.Y = (-0.5f + n.getLevel(nodemgr) / 64.0f) * BS;
+
+		switch (axisdir) {
+		case 0:
+			if(facedir == 1)
+			{
+				box.MinEdge.rotateXZBy(-90);
+				box.MaxEdge.rotateXZBy(-90);
+			}
+			else if(facedir == 2)
+			{
+				box.MinEdge.rotateXZBy(180);
+				box.MaxEdge.rotateXZBy(180);
+			}
+			else if(facedir == 3)
+			{
+				box.MinEdge.rotateXZBy(90);
+				box.MaxEdge.rotateXZBy(90);
+			}
+			break;
+		case 1: // z+
+			box.MinEdge.rotateYZBy(90);
+			box.MaxEdge.rotateYZBy(90);
+			if(facedir == 1)
+			{
+				box.MinEdge.rotateXYBy(90);
+				box.MaxEdge.rotateXYBy(90);
+			}
+			else if(facedir == 2)
+			{
+				box.MinEdge.rotateXYBy(180);
+				box.MaxEdge.rotateXYBy(180);
+			}
+			else if(facedir == 3)
+			{
+				box.MinEdge.rotateXYBy(-90);
+				box.MaxEdge.rotateXYBy(-90);
+			}
+			break;
+		case 2: //z-
+			box.MinEdge.rotateYZBy(-90);
+			box.MaxEdge.rotateYZBy(-90);
+			if(facedir == 1)
+			{
+				box.MinEdge.rotateXYBy(-90);
+				box.MaxEdge.rotateXYBy(-90);
+			}
+			else if(facedir == 2)
+			{
+				box.MinEdge.rotateXYBy(180);
+				box.MaxEdge.rotateXYBy(180);
+			}
+			else if(facedir == 3)
+			{
+				box.MinEdge.rotateXYBy(90);
+				box.MaxEdge.rotateXYBy(90);
+			}
+			break;
+		case 3:  //x+
+			box.MinEdge.rotateXYBy(-90);
+			box.MaxEdge.rotateXYBy(-90);
+			if(facedir == 1)
+			{
+				box.MinEdge.rotateYZBy(90);
+				box.MaxEdge.rotateYZBy(90);
+			}
+			else if(facedir == 2)
+			{
+				box.MinEdge.rotateYZBy(180);
+				box.MaxEdge.rotateYZBy(180);
+			}
+			else if(facedir == 3)
+			{
+				box.MinEdge.rotateYZBy(-90);
+				box.MaxEdge.rotateYZBy(-90);
+			}
+			break;
+		case 4:  //x-
+			box.MinEdge.rotateXYBy(90);
+			box.MaxEdge.rotateXYBy(90);
+			if(facedir == 1)
+			{
+				box.MinEdge.rotateYZBy(-90);
+				box.MaxEdge.rotateYZBy(-90);
+			}
+			else if(facedir == 2)
+			{
+				box.MinEdge.rotateYZBy(180);
+				box.MaxEdge.rotateYZBy(180);
+			}
+			else if(facedir == 3)
+			{
+				box.MinEdge.rotateYZBy(90);
+				box.MaxEdge.rotateYZBy(90);
+			}
+			break;
+		case 5:
+			box.MinEdge.rotateXYBy(-180);
+			box.MaxEdge.rotateXYBy(-180);
+			if(facedir == 1)
+			{
+				box.MinEdge.rotateXZBy(90);
+				box.MaxEdge.rotateXZBy(90);
+			}
+			else if(facedir == 2)
+			{
+				box.MinEdge.rotateXZBy(180);
+				box.MaxEdge.rotateXZBy(180);
+			}
+			else if(facedir == 3)
+			{
+				box.MinEdge.rotateXZBy(-90);
+				box.MaxEdge.rotateXZBy(-90);
+			}
+			break;
+		default:
+			break;
+		}
+		box.repair();
+		boxes.push_back(box);
+	}
+}
+
 void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 	const NodeDefManager *nodemgr, std::vector<aabb3f> *p_boxes,
 	u8 neighbors = 0)
@@ -192,135 +323,13 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 	std::vector<aabb3f> &boxes = *p_boxes;
 
 	if (nodebox.type == NODEBOX_FIXED || nodebox.type == NODEBOX_LEVELED) {
-		const auto &fixed = nodebox.fixed;
-		int facedir = n.getFaceDir(nodemgr, true);
-		u8 axisdir = facedir>>2;
-		facedir&=0x03;
-
-		boxes.reserve(boxes.size() + fixed.size());
-		for (aabb3f box : fixed) {
-			if (nodebox.type == NODEBOX_LEVELED)
-				box.MaxEdge.Y = (-0.5f + n.getLevel(nodemgr) / 64.0f) * BS;
-
-			switch (axisdir) {
-			case 0:
-				if(facedir == 1)
-				{
-					box.MinEdge.rotateXZBy(-90);
-					box.MaxEdge.rotateXZBy(-90);
-				}
-				else if(facedir == 2)
-				{
-					box.MinEdge.rotateXZBy(180);
-					box.MaxEdge.rotateXZBy(180);
-				}
-				else if(facedir == 3)
-				{
-					box.MinEdge.rotateXZBy(90);
-					box.MaxEdge.rotateXZBy(90);
-				}
-				break;
-			case 1: // z+
-				box.MinEdge.rotateYZBy(90);
-				box.MaxEdge.rotateYZBy(90);
-				if(facedir == 1)
-				{
-					box.MinEdge.rotateXYBy(90);
-					box.MaxEdge.rotateXYBy(90);
-				}
-				else if(facedir == 2)
-				{
-					box.MinEdge.rotateXYBy(180);
-					box.MaxEdge.rotateXYBy(180);
-				}
-				else if(facedir == 3)
-				{
-					box.MinEdge.rotateXYBy(-90);
-					box.MaxEdge.rotateXYBy(-90);
-				}
-				break;
-			case 2: //z-
-				box.MinEdge.rotateYZBy(-90);
-				box.MaxEdge.rotateYZBy(-90);
-				if(facedir == 1)
-				{
-					box.MinEdge.rotateXYBy(-90);
-					box.MaxEdge.rotateXYBy(-90);
-				}
-				else if(facedir == 2)
-				{
-					box.MinEdge.rotateXYBy(180);
-					box.MaxEdge.rotateXYBy(180);
-				}
-				else if(facedir == 3)
-				{
-					box.MinEdge.rotateXYBy(90);
-					box.MaxEdge.rotateXYBy(90);
-				}
-				break;
-			case 3:  //x+
-				box.MinEdge.rotateXYBy(-90);
-				box.MaxEdge.rotateXYBy(-90);
-				if(facedir == 1)
-				{
-					box.MinEdge.rotateYZBy(90);
-					box.MaxEdge.rotateYZBy(90);
-				}
-				else if(facedir == 2)
-				{
-					box.MinEdge.rotateYZBy(180);
-					box.MaxEdge.rotateYZBy(180);
-				}
-				else if(facedir == 3)
-				{
-					box.MinEdge.rotateYZBy(-90);
-					box.MaxEdge.rotateYZBy(-90);
-				}
-				break;
-			case 4:  //x-
-				box.MinEdge.rotateXYBy(90);
-				box.MaxEdge.rotateXYBy(90);
-				if(facedir == 1)
-				{
-					box.MinEdge.rotateYZBy(-90);
-					box.MaxEdge.rotateYZBy(-90);
-				}
-				else if(facedir == 2)
-				{
-					box.MinEdge.rotateYZBy(180);
-					box.MaxEdge.rotateYZBy(180);
-				}
-				else if(facedir == 3)
-				{
-					box.MinEdge.rotateYZBy(90);
-					box.MaxEdge.rotateYZBy(90);
-				}
-				break;
-			case 5:
-				box.MinEdge.rotateXYBy(-180);
-				box.MaxEdge.rotateXYBy(-180);
-				if(facedir == 1)
-				{
-					box.MinEdge.rotateXZBy(90);
-					box.MaxEdge.rotateXZBy(90);
-				}
-				else if(facedir == 2)
-				{
-					box.MinEdge.rotateXZBy(180);
-					box.MaxEdge.rotateXZBy(180);
-				}
-				else if(facedir == 3)
-				{
-					box.MinEdge.rotateXZBy(-90);
-					box.MaxEdge.rotateXZBy(-90);
-				}
-				break;
-			default:
-				break;
-			}
-			box.repair();
-			boxes.push_back(box);
+		const std::vector<aabb3f> &fixed = nodebox.fixed;
+		const std::vector<aabb3f> &leveled_fixed = nodebox.leveled_fixed;
+		bool is_leveled = nodebox.type == NODEBOX_LEVELED;
+		if (is_leveled) {
+			buildFixedNodeBox(n, nodebox, nodemgr, boxes, leveled_fixed, false);
 		}
+		buildFixedNodeBox(n, nodebox, nodemgr, boxes, fixed, is_leveled);
 	}
 	else if(nodebox.type == NODEBOX_WALLMOUNTED)
 	{

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -189,8 +189,8 @@ void buildFixedNodeBox(const MapNode &n, const NodeBox &nodebox, const NodeDefMa
 		std::vector<aabb3f> &boxes, std::vector<aabb3f> input_boxes,
 		enum NodeBoxType nbt) {
 	u8 facedir = n.getFaceDir(nodemgr, true);
-	facedir &= 0x03;
 	u8 axisdir = facedir>>2;
+	facedir &= 0x03;
 	for (aabb3f box : input_boxes) {
 		switch (nbt) {
 		case NODEBOX_LEVELED: {
@@ -205,8 +205,8 @@ void buildFixedNodeBox(const MapNode &n, const NodeBox &nodebox, const NodeDefMa
 			} else {
 				box.MaxEdge.Y = (-0.5f + height / 16.0f) * BS;
 			}
-                        if (box.MaxEdge.Y > SAFE_NODE_COLLISION_LIMIT * BS) {
-				box.MaxEdge.Y = SAFE_NODE_COLLISION_LIMIT * BS;
+                        if (box.MaxEdge.Y > SAFE_SELECTION_BOX_LIMIT * BS) {
+				box.MaxEdge.Y = SAFE_SELECTION_BOX_LIMIT * BS;
 			}
 			break;
 		}

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -205,7 +205,7 @@ void buildFixedNodeBox(const MapNode &n, const NodeBox &nodebox, const NodeDefMa
 			} else {
 				box.MaxEdge.Y = (-0.5f + height / 16.0f) * BS;
 			}
-                        if (box.MaxEdge.Y > SAFE_SELECTION_BOX_LIMIT * BS) {
+			if (box.MaxEdge.Y > SAFE_SELECTION_BOX_LIMIT * BS) {
 				box.MaxEdge.Y = SAFE_SELECTION_BOX_LIMIT * BS;
 			}
 			break;

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -197,9 +197,14 @@ void buildFixedNodeBox(const MapNode &n, const NodeBox &nodebox, const NodeDefMa
 			box.MaxEdge.Y = (-0.5f + n.getLevel(nodemgr) / 64.0f) * BS;
 			break;
 		}
-		case NODEBOX_LEVELED_PLANTLIKE: {
+		case NODEBOX_LEVELED_PLANTLIKE:
+		case NODEBOX_LEVELED_PLANTLIKE_ROOTED: {
 			u8 height = n.getParam2();
-			box.MaxEdge.Y = (-0.5f + height / 16.0f) * BS;
+			if (nbt == NODEBOX_LEVELED_PLANTLIKE_ROOTED) {
+				box.MaxEdge.Y = (0.5f + height / 16.0f) * BS;
+			} else {
+				box.MaxEdge.Y = (-0.5f + height / 16.0f) * BS;
+			}
                         if (box.MaxEdge.Y > SAFE_NODE_COLLISION_LIMIT * BS) {
 				box.MaxEdge.Y = SAFE_NODE_COLLISION_LIMIT * BS;
 			}
@@ -338,11 +343,13 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 	std::vector<aabb3f> &boxes = *p_boxes;
 
 	if (nodebox.type == NODEBOX_FIXED || nodebox.type == NODEBOX_LEVELED ||
-			nodebox.type == NODEBOX_LEVELED_PLANTLIKE) {
+			nodebox.type == NODEBOX_LEVELED_PLANTLIKE ||
+			nodebox.type == NODEBOX_LEVELED_PLANTLIKE_ROOTED) {
 		const std::vector<aabb3f> &fixed = nodebox.fixed;
 		const std::vector<aabb3f> &leveled_fixed = nodebox.leveled_fixed;
 		enum NodeBoxType nbt = nodebox.type;
-		if (nbt == NODEBOX_LEVELED || nbt == NODEBOX_LEVELED_PLANTLIKE) {
+		if (nbt == NODEBOX_LEVELED || nbt == NODEBOX_LEVELED_PLANTLIKE ||
+				nbt == NODEBOX_LEVELED_PLANTLIKE_ROOTED) {
 			buildFixedNodeBox(n, nodebox, nodemgr, boxes, leveled_fixed, NODEBOX_FIXED);
 		}
 		buildFixedNodeBox(n, nodebox, nodemgr, boxes, fixed, nbt);

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -158,6 +158,9 @@ void NodeBox::deSerialize(std::istream &is)
 					type == NODEBOX_LEVELED_PLANTLIKE ||
 					type == NODEBOX_LEVELED_PLANTLIKE_ROOTED) {
 				u16 leveled_fixed_count = readU16(is);
+				if (is.eof()) {
+					leveled_fixed_count = 0;
+				}
 				while(leveled_fixed_count--)
 				{
 					aabb3f box;
@@ -1251,8 +1254,7 @@ void rawUnionFixed(const ContentFeatures &features,
 	boxVectorUnion(to_add, &half_processed);
 	// Set leveled boxes to maximal
 	if (nbt == NODEBOX_LEVELED) {
-		// -0.5 + 127/64
-		half_processed.MaxEdge.Y = 1.484375f * BS;
+		half_processed.MaxEdge.Y = (-0.5 + 127/64) * BS;
 	} else if (nbt == NODEBOX_LEVELED_PLANTLIKE ||
 			nbt == NODEBOX_LEVELED_PLANTLIKE_ROOTED) {
 		half_processed.MaxEdge.Y = SAFE_SELECTION_BOX_LIMIT * BS;
@@ -1260,19 +1262,14 @@ void rawUnionFixed(const ContentFeatures &features,
 	if (features.param_type_2 == CPT2_FACEDIR ||
 			features.param_type_2 == CPT2_COLORED_FACEDIR) {
 		// Get maximal coordinate
-		f32 coords[] = {
+		f32 max = std::max({
 			fabsf(half_processed.MinEdge.X),
 			fabsf(half_processed.MinEdge.Y),
 			fabsf(half_processed.MinEdge.Z),
 			fabsf(half_processed.MaxEdge.X),
 			fabsf(half_processed.MaxEdge.Y),
-			fabsf(half_processed.MaxEdge.Z) };
-		f32 max = 0;
-		for (float coord : coords) {
-			if (max < coord) {
-				max = coord;
-			}
-		}
+			fabsf(half_processed.MaxEdge.Z)
+		});
 		// Add the union of all possible rotated boxes
 		box_union->addInternalPoint(-max, -max, -max);
 		box_union->addInternalPoint(+max, +max, +max);

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1254,7 +1254,7 @@ void rawUnionFixed(const ContentFeatures &features,
 	boxVectorUnion(to_add, &half_processed);
 	// Set leveled boxes to maximal
 	if (nbt == NODEBOX_LEVELED) {
-		half_processed.MaxEdge.Y = (-0.5 + 127/64) * BS;
+		half_processed.MaxEdge.Y = (-0.5f + 127.0f/64.0f) * BS;
 	} else if (nbt == NODEBOX_LEVELED_PLANTLIKE ||
 			nbt == NODEBOX_LEVELED_PLANTLIKE_ROOTED) {
 		half_processed.MaxEdge.Y = SAFE_SELECTION_BOX_LIMIT * BS;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -144,8 +144,8 @@ void NodeBox::deSerialize(std::istream &is)
 			break;
 		case NODEBOX_FIXED:
 		case NODEBOX_LEVELED:
-		case NODEBOX_LEVELED_PLANTLIIKE:
-		case NODEBOX_LEVELED_PLANTLIIKE_ROOTED:
+		case NODEBOX_LEVELED_PLANTLIKE:
+		case NODEBOX_LEVELED_PLANTLIKE_ROOTED:
 		{
 			u16 fixed_count = readU16(is);
 			while(fixed_count--) {
@@ -1298,9 +1298,8 @@ void getNodeBoxUnion(const NodeBox &nodebox, const ContentFeatures &features,
 			// Raw union
 			aabb3f half_processed(0, 0, 0, 0, 0, 0);
 			boxVectorUnion(nodebox.fixed, &half_processed);
-			bool is_leveled = nodebox.type == NODEBOX_LEVELED;
 			// Set leveled boxes to maximal
-			if (is_leveled) {
+			if (nodebox.type == NODEBOX_LEVELED) {
 				half_processed.MaxEdge.Y = +BS / 2;
 			}
 			if (features.param_type_2 == CPT2_FACEDIR ||
@@ -1327,11 +1326,7 @@ void getNodeBoxUnion(const NodeBox &nodebox, const ContentFeatures &features,
 			} else {
 				box_union->addInternalBox(half_processed);
 			}
-			if (is_leveled) {
-				rawUnionFixed(features, box_union, nodebox.leveled_fixed, false);
-			}
 		}
-		case NODEBOX_LEVELED:
 		case NODEBOX_LEVELED_PLANTLIKE:
 		case NODEBOX_LEVELED_PLANTLIKE_ROOTED: {
 			NodeBoxType nbt = nodebox.type;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -66,6 +66,7 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 
 	switch (type) {
 	case NODEBOX_LEVELED:
+	case NODEBOX_LEVELED_PLANTLIKE:
 	case NODEBOX_FIXED:
 		writeU8(os, type);
 
@@ -74,7 +75,7 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 			writeV3F32(os, nodebox.MinEdge);
 			writeV3F32(os, nodebox.MaxEdge);
 		}
-		if (type == NODEBOX_LEVELED) {
+		if (type == NODEBOX_LEVELED || type == NODEBOX_LEVELED_PLANTLIKE) {
 			writeU16(os, leveled_fixed.size());
 			for (const aabb3f &nodebox : leveled_fixed) {
 				writeV3F32(os, nodebox.MinEdge);
@@ -140,13 +141,15 @@ void NodeBox::deSerialize(std::istream &is)
 		case NODEBOX_REGULAR:
 			break;
 		case NODEBOX_FIXED:
-		case NODEBOX_LEVELED: {
-			u16 leveled_fixed_count = readU16(is);
-			while(leveled_fixed_count--) {
+		case NODEBOX_LEVELED:
+		case NODEBOX_LEVELED_PLANTLIIKE:
+		{
+			u16 fixed_count = readU16(is);
+			while(fixed_count--) {
 				aabb3f box;
 				box.MinEdge = readV3F32(is);
 				box.MaxEdge = readV3F32(is);
-				leveled_fixed.push_back(box);
+				fixed.push_back(box);
 			}
 			break;
 		}

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1240,7 +1240,7 @@ void boxVectorUnion(const std::vector<aabb3f> &boxes, aabb3f *box_union)
  *                            can be rotated
  * @param[in, out] box_union  the union of the arguments
  * @param          to_add     nodebox to add to union
- * @param          is_leveled true if leveled nodebox
+ * @param          nbt        node box type
  */
 void rawUnionFixed(const ContentFeatures &features,
 		aabb3f *box_union,

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1323,6 +1323,7 @@ void getNodeBoxUnion(const NodeBox &nodebox, const ContentFeatures &features,
 			} else {
 				box_union->addInternalBox(half_processed);
 			}
+			break;
 		}
 		case NODEBOX_LEVELED_PLANTLIKE:
 		case NODEBOX_LEVELED_PLANTLIKE_ROOTED: {

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -67,6 +67,7 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 	switch (type) {
 	case NODEBOX_LEVELED:
 	case NODEBOX_LEVELED_PLANTLIKE:
+	case NODEBOX_LEVELED_PLANTLIKE_ROOTED:
 	case NODEBOX_FIXED:
 		writeU8(os, type);
 
@@ -75,7 +76,8 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 			writeV3F32(os, nodebox.MinEdge);
 			writeV3F32(os, nodebox.MaxEdge);
 		}
-		if (type == NODEBOX_LEVELED || type == NODEBOX_LEVELED_PLANTLIKE) {
+		if (type == NODEBOX_LEVELED || type == NODEBOX_LEVELED_PLANTLIKE ||
+				type == NODEBOX_LEVELED_PLANTLIKE_ROOTED) {
 			writeU16(os, leveled_fixed.size());
 			for (const aabb3f &nodebox : leveled_fixed) {
 				writeV3F32(os, nodebox.MinEdge);
@@ -143,6 +145,7 @@ void NodeBox::deSerialize(std::istream &is)
 		case NODEBOX_FIXED:
 		case NODEBOX_LEVELED:
 		case NODEBOX_LEVELED_PLANTLIIKE:
+		case NODEBOX_LEVELED_PLANTLIIKE_ROOTED:
 		{
 			u16 fixed_count = readU16(is);
 			while(fixed_count--) {
@@ -150,6 +153,18 @@ void NodeBox::deSerialize(std::istream &is)
 				box.MinEdge = readV3F32(is);
 				box.MaxEdge = readV3F32(is);
 				fixed.push_back(box);
+			}
+			if(type == NODEBOX_LEVELED ||
+					type == NODEBOX_LEVELED_PLANTLIKE ||
+					type == NODEBOX_LEVELED_PLANTLIKE_ROOTED) {
+				u16 leveled_fixed_count = readU16(is);
+				while(leveled_fixed_count--)
+				{
+					aabb3f box;
+					box.MinEdge = readV3F32(is);
+					box.MaxEdge = readV3F32(is);
+					leveled_fixed.push_back(box);
+				}
 			}
 			break;
 		}

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -104,6 +104,7 @@ enum NodeBoxType : u8
 	NODEBOX_LEVELED, // Same as fixed, but with dynamic height from param2. for snow, ...
 	NODEBOX_CONNECTED, // optionally draws nodeboxes if a neighbor node attaches
 	NODEBOX_LEVELED_PLANTLIKE, // Same as leveled, but in sync with plantlike height
+	NODEBOX_LEVELED_PLANTLIKE_ROOTED, // Same as leveled, but in sync with plantlike_rooted height
 };
 
 struct NodeBoxConnected

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -103,6 +103,7 @@ enum NodeBoxType : u8
 	NODEBOX_WALLMOUNTED, // Box for wall mounted nodes; (top, bottom, side)
 	NODEBOX_LEVELED, // Same as fixed, but with dynamic height from param2. for snow, ...
 	NODEBOX_CONNECTED, // optionally draws nodeboxes if a neighbor node attaches
+	NODEBOX_LEVELED_PLANTLIKE, // Same as leveled, but in sync with plantlike height
 };
 
 struct NodeBoxConnected

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -136,6 +136,8 @@ struct NodeBox
 	// NODEBOX_CONNECTED
 	// (kept externally to not bloat the structure)
 	std::shared_ptr<NodeBoxConnected> connected;
+	// NODEBOX_LEVELED
+	std::vector<aabb3f> leveled_fixed;
 
 	NodeBox()
 	{ reset(); }

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1127,9 +1127,9 @@ void push_nodebox(lua_State *L, const NodeBox &box)
 			else if (box.type == NODEBOX_LEVELED_PLANTLIKE_ROOTED)
 				lua_pushstring(L, "leveled_plantlike_rooted");
 			lua_setfield(L, -2, "type");
-			push_box(L, box.fixed);
+			push_aabb3f_vector(L, box.fixed);
 			lua_setfield(L, -2, "fixed");
-			push_box(L, box.leveled_fixed);
+			push_aabb3f_vector(L, box.leveled_fixed);
 			lua_setfield(L, -2, "leveled_fixed");
 			break;
 		case NODEBOX_WALLMOUNTED:

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1120,7 +1120,12 @@ void push_nodebox(lua_State *L, const NodeBox &box)
 		case NODEBOX_LEVELED:
 		case NODEBOX_LEVELED_PLANTLIKE:
 		case NODEBOX_LEVELED_PLANTLIKE_ROOTED:
-			lua_pushstring(L, "leveled");
+			if (box.type == NODEBOX_LEVELED)
+				lua_pushstring(L, "leveled");
+			else if (box.type == NODEBOX_LEVELED_PLANTLIKE)
+				lua_pushstring(L, "leveled_plantlike");
+			else if (box.type == NODEBOX_LEVELED_PLANTLIKE_ROOTED)
+				lua_pushstring(L, "leveled_plantlike_rooted");
 			lua_setfield(L, -2, "type");
 			push_box(L, box.fixed);
 			lua_setfield(L, -2, "fixed");

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1111,12 +1111,19 @@ void push_nodebox(lua_State *L, const NodeBox &box)
 			lua_pushstring(L, "regular");
 			lua_setfield(L, -2, "type");
 			break;
-		case NODEBOX_LEVELED:
 		case NODEBOX_FIXED:
 			lua_pushstring(L, "fixed");
 			lua_setfield(L, -2, "type");
 			push_aabb3f_vector(L, box.fixed);
 			lua_setfield(L, -2, "fixed");
+			break;
+		case NODEBOX_LEVELED:
+			lua_pushstring(L, "leveled");
+			lua_setfield(L, -2, "type");
+			push_box(L, box.fixed);
+			lua_setfield(L, -2, "fixed");
+			push_box(L, box.leveled_fixed);
+			lua_setfield(L, -2, "leveled_fixed");
 			break;
 		case NODEBOX_WALLMOUNTED:
 			lua_pushstring(L, "wallmounted");
@@ -1286,6 +1293,7 @@ NodeBox read_nodebox(lua_State *L, int index)
 		NODEBOXREADVEC(c.disconnected, "disconnected");
 		NODEBOXREADVEC(c.disconnected_sides, "disconnected_sides");
 	}
+	NODEBOXREADVEC(nodebox.leveled_fixed, "leveled_fixed");
 
 	return nodebox;
 }

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1118,6 +1118,7 @@ void push_nodebox(lua_State *L, const NodeBox &box)
 			lua_setfield(L, -2, "fixed");
 			break;
 		case NODEBOX_LEVELED:
+		case NODEBOX_LEVELED_PLANTLIKE:
 			lua_pushstring(L, "leveled");
 			lua_setfield(L, -2, "type");
 			push_box(L, box.fixed);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1119,6 +1119,7 @@ void push_nodebox(lua_State *L, const NodeBox &box)
 			break;
 		case NODEBOX_LEVELED:
 		case NODEBOX_LEVELED_PLANTLIKE:
+		case NODEBOX_LEVELED_PLANTLIKE_ROOTED:
 			lua_pushstring(L, "leveled");
 			lua_setfield(L, -2, "type");
 			push_box(L, box.fixed);

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -93,6 +93,7 @@ struct EnumString ScriptApiNode::es_NodeBoxType[] =
 		{NODEBOX_WALLMOUNTED, "wallmounted"},
 		{NODEBOX_LEVELED, "leveled"},
 		{NODEBOX_CONNECTED, "connected"},
+		{NODEBOX_LEVELED_PLANTLIKE, "leveled_plantlike"},
 		{0, NULL},
 	};
 

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -94,6 +94,7 @@ struct EnumString ScriptApiNode::es_NodeBoxType[] =
 		{NODEBOX_LEVELED, "leveled"},
 		{NODEBOX_CONNECTED, "connected"},
 		{NODEBOX_LEVELED_PLANTLIKE, "leveled_plantlike"},
+		{NODEBOX_LEVELED_PLANTLIKE_ROOTED, "leveled_plantlike_rooted"},
 		{0, NULL},
 	};
 


### PR DESCRIPTION
## The problems

Currently, 'leveled' boxes will allways have their upper face change with param2. So this only allows you to do fairly simple things. If you need a fully static box as part of a leveled nodebox, you are out of luck.

Also, you can't get selection boxes to be in sync with leveled plantlike nodes. No matter what you do, they are always off.

## The PR

This PR adds a new field '`leveled_fixed`' for the nodebox type 'leveled'. This is an optional box (or boxes) for leveled-type nodeboxes, but it will be fully static.

This screenshot shows an example (it's always the same node, but with different param2): https://satoshiupload.com/images/q5VZ1MoO8I.png

Moreover, it adds two new nodebox types `leveled_plantlike` and `leveled_plantlike_rooted`. These work like `leveled` except they are in sync with the height of the leveled 'plant' for the drawtypes `plantlike` and `plantlike_rooted`, respectively. This allows you to make pixel-perfect selection boxes for such nodes.

The height, however, is capped at one point because leveled plantlike nodes can get very high and I'm not sure how reliable selection boxes are when they're really high.

Fixes #8202.

## Use cases
* Cauldron with water of variable height (`leveled_fixed` is the cauldron (which is static), `fixed` is the water box (which varies in height))
* Trash can with something inside
* Some kind of simple ice spike
* Kelp plant with varying height with pixel-perfect selection box that respects height

## Please note

Unfortunately, the naming is a little bit weird for `leveled` nodeboxes. For some reason, the `fixed` box is actually NOT fixed, since it varies in height. The new nodebox field `leveled_fixed` is the box (or boxes) that is ACTUALLY fixed.

It has been like that before, I cannot change that trivially w/o breaking compability. I think it is best to just keep the naming for the sake of compability, which is MUCH more important.

The nodebox types `leveled_plantlike` and `leveled_plantlike_rooted` are intended to be used as selection boxes so you can capture the plant pixel-perfectly. New nodebox types were neccessary because `leveled` has a step of 1/64 while leveled plantlike nodes have a step of 1/16. The new nodebox types use a step of 1/16 so it matches. `leveled_plantlike_rooted` is basically the same as `leveled_plantlike` but a height offset is applied (because of the base cube).
Also, unlike `leveled`, the new nodebox types do NOT restart at param2=128.

For collision boxes, they are only safe to use if you keep the upper end of the "plant" below a height of -0.5+127/64 (roughly 1.5), otherwise, collision bugs will start to occur. There is nothing in the code that enforces this limit so it's the responsibilty of the game author to make sure the "plant" doesn't become too tall. However, using these nodebox types as collision boxes is a rather esoteric use case anyway, so it should not be that big of a deal. I documented that anyway, just in case.

## How to test

Use the following test nodes in DevTest. Try them together with the Param2 Tool.

* `testnodes:nodebox_leveled_fixed` (new node)
* `testnodes:plantlike_leveled` (old node, new dynamic selection box)
* `testnodes:plantlike_rooted_leveled` (old node, new dynamic selection box)
