### PR TITLE
Avoid draw list and shadow map update in the same frame to reduce dtime jitter

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3894,7 +3894,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	if (ShadowRenderer *shadow = RenderingEngine::get_shadow_renderer()) {
 		update_draw_list_delta = shadow->getUpdateDelta();
 
-		if (runData.update_shadows_timer > update_draw_list_delta * (0.99f + 0.0002 * (rand() % 100)) && // 0.99-1.01
+		if (runData.update_shadows_timer > update_draw_list_delta &&
 				(!draw_list_updated || shadow->getDirectionalLightCount() == 0)) {
 			runData.update_shadows_timer = 0;
 			updateShadows();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -609,6 +609,7 @@ struct GameRunData {
 	float jump_timer;
 	float damage_flash;
 	float update_draw_list_timer;
+	float update_shadows_timer;
 
 	f32 fog_range;
 
@@ -3874,6 +3875,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		changed much
 	*/
 	runData.update_draw_list_timer += dtime;
+	runData.update_shadows_timer += dtime;
 
 	float update_draw_list_delta = 0.2f;
 	if (ShadowRenderer *shadow = RenderingEngine::get_shadow_renderer())
@@ -3887,6 +3889,14 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		runData.update_draw_list_timer = 0;
 		client->getEnv().getClientMap().updateDrawList();
 		runData.update_draw_list_last_cam_dir = camera_direction;
+	}
+
+	if (ShadowRenderer *shadow = RenderingEngine::get_shadow_renderer())
+		update_draw_list_delta = shadow->getUpdateDelta();
+
+	if (runData.update_shadows_timer > update_draw_list_delta)
+	{
+		runData.update_shadows_timer = 0;
 
 		updateShadows();
 	}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3894,8 +3894,8 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	if (ShadowRenderer *shadow = RenderingEngine::get_shadow_renderer()) {
 		update_draw_list_delta = shadow->getUpdateDelta();
 
-		if (runData.update_shadows_timer > update_draw_list_delta &&
-				(!draw_list_updated || shadow->getDirectionalLightCount() == 0)) {
+		if (m_camera_offset_changed ||
+				(runData.update_shadows_timer > update_draw_list_delta && (!draw_list_updated || shadow->getDirectionalLightCount() == 0))) {
 			runData.update_shadows_timer = 0;
 			updateShadows();
 		}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3891,13 +3891,14 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		draw_list_updated = true;
 	}
 
-	if (ShadowRenderer *shadow = RenderingEngine::get_shadow_renderer())
+	if (ShadowRenderer *shadow = RenderingEngine::get_shadow_renderer()) {
 		update_draw_list_delta = shadow->getUpdateDelta();
 
-	if (runData.update_shadows_timer > update_draw_list_delta &&
-			(!draw_list_updated || RenderingEngine::get_shadow_renderer()->getDirectionalLightCount() == 0)) {
-		runData.update_shadows_timer = 0;
-		updateShadows();
+		if (runData.update_shadows_timer > update_draw_list_delta &&
+				(!draw_list_updated || shadow->getDirectionalLightCount() == 0)) {
+			runData.update_shadows_timer = 0;
+			updateShadows();
+		}
 	}
 
 	m_game_ui->update(*stats, client, draw_control, cam, runData.pointed_old, gui_chat_console, dtime);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3894,7 +3894,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	if (ShadowRenderer *shadow = RenderingEngine::get_shadow_renderer()) {
 		update_draw_list_delta = shadow->getUpdateDelta();
 
-		if (runData.update_shadows_timer > update_draw_list_delta &&
+		if (runData.update_shadows_timer > update_draw_list_delta * (0.99f + 0.0002 * (rand() % 100)) && // 0.99-1.01
 				(!draw_list_updated || shadow->getDirectionalLightCount() == 0)) {
 			runData.update_shadows_timer = 0;
 			updateShadows();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3895,7 +3895,8 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		update_draw_list_delta = shadow->getUpdateDelta();
 
 		if (m_camera_offset_changed ||
-				(runData.update_shadows_timer > update_draw_list_delta && (!draw_list_updated || shadow->getDirectionalLightCount() == 0))) {
+				(runData.update_shadows_timer > update_draw_list_delta &&
+				(!draw_list_updated || shadow->getDirectionalLightCount() == 0))) {
 			runData.update_shadows_timer = 0;
 			updateShadows();
 		}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3878,8 +3878,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	runData.update_shadows_timer += dtime;
 
 	float update_draw_list_delta = 0.2f;
-	if (ShadowRenderer *shadow = RenderingEngine::get_shadow_renderer())
-		update_draw_list_delta = shadow->getUpdateDelta();
+	bool draw_list_updated = false;
 
 	v3f camera_direction = camera->getDirection();
 	if (runData.update_draw_list_timer >= update_draw_list_delta
@@ -3889,15 +3888,15 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		runData.update_draw_list_timer = 0;
 		client->getEnv().getClientMap().updateDrawList();
 		runData.update_draw_list_last_cam_dir = camera_direction;
+		draw_list_updated = true;
 	}
 
 	if (ShadowRenderer *shadow = RenderingEngine::get_shadow_renderer())
 		update_draw_list_delta = shadow->getUpdateDelta();
 
-	if (runData.update_shadows_timer > update_draw_list_delta)
-	{
+	if (runData.update_shadows_timer > update_draw_list_delta &&
+			(!draw_list_updated || RenderingEngine::get_shadow_renderer()->getDirectionalLightCount() == 0)) {
 		runData.update_shadows_timer = 0;
-
 		updateShadows();
 	}
 


### PR DESCRIPTION
This patch improves #11357 by forcing draw list update and shadow draw list update in different frames and decoupling draw list update from shadow map update intervals.

This PR is Ready for Review.

## How to test
Enable dynamic shadows, open the game and move around. There should not be rendering stutter in e.g. leaves and liquid shaders, and dtime jitter should most of the time be less than 100% and around 50%.