### PR TITLE
Remove unsupported video drivers

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -715,7 +715,7 @@ texture_path (Texture path) path
 #    Note: On Android, stick with OGLES1 if unsure! App may fail to start otherwise.
 #    On other platforms, OpenGL is recommended.
 #    Shaders are supported by OpenGL (desktop only) and OGLES2 (experimental)
-video_driver (Video driver) enum opengl null,opengl,ogles1,ogles2
+video_driver (Video driver) enum opengl opengl,ogles1,ogles2
 
 #    Radius of cloud area stated in number of 64 node cloud squares.
 #    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -715,7 +715,7 @@ texture_path (Texture path) path
 #    Note: On Android, stick with OGLES1 if unsure! App may fail to start otherwise.
 #    On other platforms, OpenGL is recommended.
 #    Shaders are supported by OpenGL (desktop only) and OGLES2 (experimental)
-video_driver (Video driver) enum opengl null,software,burningsvideo,direct3d8,direct3d9,opengl,ogles1,ogles2
+video_driver (Video driver) enum opengl null,opengl,ogles1,ogles2
 
 #    Radius of cloud area stated in number of 64 node cloud squares.
 #    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -521,14 +521,15 @@ std::vector<irr::video::E_DRIVER_TYPE> RenderingEngine::getSupportedVideoDrivers
 {
 	// Only check these drivers.
 	// We do not support software and D3D in any capacity.
-	static const irr::video::E_DRIVER_TYPE glDrivers[3] = {
+	static const irr::video::E_DRIVER_TYPE glDrivers[4] = {
+		irr::video::EDT_NULL,
 		irr::video::EDT_OPENGL,
 		irr::video::EDT_OGLES1,
 		irr::video::EDT_OGLES2,
 	};
 	std::vector<irr::video::E_DRIVER_TYPE> drivers;
 
-	for (int i = 0; i < 3; i++) {
+	for (int i = 0; i < 4; i++) {
 		if (irr::IrrlichtDevice::isDriverSupported(glDrivers[i]))
 			drivers.push_back(glDrivers[i]);
 	}

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -284,14 +284,6 @@ static bool getWindowHandle(irr::video::IVideoDriver *driver, HWND &hWnd)
 	const video::SExposedVideoData exposedData = driver->getExposedVideoData();
 
 	switch (driver->getDriverType()) {
-#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9
-	case video::EDT_DIRECT3D8:
-		hWnd = reinterpret_cast<HWND>(exposedData.D3D8.HWnd);
-		break;
-#endif
-	case video::EDT_DIRECT3D9:
-		hWnd = reinterpret_cast<HWND>(exposedData.D3D9.HWnd);
-		break;
 #if ENABLE_GLES
 	case video::EDT_OGLES1:
 	case video::EDT_OGLES2:
@@ -527,11 +519,18 @@ void RenderingEngine::draw_menu_scene(gui::IGUIEnvironment *guienv,
 
 std::vector<irr::video::E_DRIVER_TYPE> RenderingEngine::getSupportedVideoDrivers()
 {
+	// Only check these drivers.
+	// We do not support software and D3D in any capacity.
+	static const irr::video::E_DRIVER_TYPE glDrivers[3] = {
+		irr::video::EDT_OPENGL,
+		irr::video::EDT_OGLES1,
+		irr::video::EDT_OGLES2,
+	};
 	std::vector<irr::video::E_DRIVER_TYPE> drivers;
 
-	for (int i = 0; i != irr::video::EDT_COUNT; i++) {
-		if (irr::IrrlichtDevice::isDriverSupported((irr::video::E_DRIVER_TYPE)i))
-			drivers.push_back((irr::video::E_DRIVER_TYPE)i);
+	for (int i = 0; i < 3; i++) {
+		if (irr::IrrlichtDevice::isDriverSupported(glDrivers[i]))
+			drivers.push_back(glDrivers[i]);
 	}
 
 	return drivers;
@@ -557,34 +556,26 @@ void RenderingEngine::draw_scene(video::SColor skycolor, bool show_hud,
 
 const char *RenderingEngine::getVideoDriverName(irr::video::E_DRIVER_TYPE type)
 {
-	static const char *driver_ids[] = {
-			"null",
-			"software",
-			"burningsvideo",
-			"direct3d8",
-			"direct3d9",
-			"opengl",
-			"ogles1",
-			"ogles2",
+	static const std::unordered_map<irr::video::E_DRIVER_TYPE,const std::string> driver_ids = {
+		{irr::video::EDT_NULL, "null"},
+		{irr::video::EDT_OPENGL, "opengl"},
+		{irr::video::EDT_OGLES1, "ogles1"},
+		{irr::video::EDT_OGLES2, "ogles2"},
 	};
 
-	return driver_ids[type];
+	return driver_ids.at(type).c_str();
 }
 
 const char *RenderingEngine::getVideoDriverFriendlyName(irr::video::E_DRIVER_TYPE type)
 {
-	static const char *driver_names[] = {
-			"NULL Driver",
-			"Software Renderer",
-			"Burning's Video",
-			"Direct3D 8",
-			"Direct3D 9",
-			"OpenGL",
-			"OpenGL ES1",
-			"OpenGL ES2",
+	static const std::unordered_map<irr::video::E_DRIVER_TYPE,const std::string> driver_names = {
+		{irr::video::EDT_NULL, "NULL Driver"},
+		{irr::video::EDT_OPENGL, "OpenGL"},
+		{irr::video::EDT_OGLES1, "OpenGL ES1"},
+		{irr::video::EDT_OGLES2, "OpenGL ES2"},
 	};
 
-	return driver_names[type];
+	return driver_names.at(type).c_str();
 }
 
 #ifndef __ANDROID__


### PR DESCRIPTION
This PR completely removes any mention of the software and D3D drivers from MT, preventing the user from accidentally attempting to use them. Users who need a software renderer should be asked to install Mesa drivers which offer superior fidelity and performance over the 'burningsvideo' driver.

Goals:
- Prevents issues like  #11386, #11052
- Allows us to assume that some form of OpenGL is available when designing renderer improvements.
- Allows us to use OpenGL APIs directly.
- Allows us to trim unsupported renderers from the MT fork, reducing various maintenance costs. (build times, file sizes)

This PR is Ready for Review.

