### PR TITLE
Auth API: Error when accessed prior to ServerEnv init

### DIFF
--- a/src/script/lua_api/l_auth.cpp
+++ b/src/script/lua_api/l_auth.cpp
@@ -32,8 +32,11 @@ AuthDatabase *ModApiAuth::getAuthDb(lua_State *L)
 {
 	ServerEnvironment *server_environment =
 			dynamic_cast<ServerEnvironment *>(getEnv(L));
-	if (!server_environment)
+	if (!server_environment) {
+		luaL_error(L, "Attempt to access an auth function but the auth"
+			" system is yet not initialized. This causes bugs.");
 		return nullptr;
+	}
 	return server_environment->getAuthDatabase();
 }
 


### PR DESCRIPTION
This PR adds a warning message when auth API functions are accessed too early. i.e. when mods are loaded, but ServerEnv is not initialized yet. It would also be possible to move the entire auth to `Server`, but I don't know whether that would bring much.

## To do

This PR is Ready for Review.

## How to test

1. https://github.com/SmallJoker/names_per_ip @ commit d17ecc54
2. Host a server, join with a few dummy accounts
3. Restart the server and observe this warning for each recorded player entry