### PR TITLE
Add API for mods to hook liquid transformation events

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -610,6 +610,7 @@ core.registered_on_modchannel_message, core.register_on_modchannel_message = mak
 core.registered_on_player_inventory_actions, core.register_on_player_inventory_action = make_registration()
 core.registered_allow_player_inventory_actions, core.register_allow_player_inventory_action = make_registration()
 core.registered_on_rightclickplayers, core.register_on_rightclickplayer = make_registration()
+core.registered_on_liquid_transformed, core.register_on_liquid_transformed = make_registration()
 
 --
 -- Compatibility for on_mapgen_init()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4859,6 +4859,12 @@ Call these functions only at load time!
     * Called when an incoming mod channel message is received
     * You should have joined some channels to receive events.
     * If message comes from a server mod, `sender` field is an empty string.
+* `minetest.register_on_liquid_transformed(function(list))`
+    * Called after liquid nodes are modified by the engine's liquid transformation
+      process.
+    * `list` is an array of all nodes modified.  Each entry will contain:
+      * `pos`: the position of the modified node.
+      * `oldnode`: the old node that was replaced at that position.
 
 Setting-related
 ---------------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4859,12 +4859,12 @@ Call these functions only at load time!
     * Called when an incoming mod channel message is received
     * You should have joined some channels to receive events.
     * If message comes from a server mod, `sender` field is an empty string.
-* `minetest.register_on_liquid_transformed(function(list))`
+* `minetest.register_on_liquid_transformed(function(post_list, node_list))`
     * Called after liquid nodes are modified by the engine's liquid transformation
       process.
-    * `list` is an array of all nodes modified.  Each entry will contain:
-      * `pos`: the position of the modified node.
-      * `oldnode`: the old node that was replaced at that position.
+    * `pos_list` is an array of all modified positions.
+    * `node_list` is an array of the old node that was previously at the position
+      with the corresponding index in pos_list.
 
 Setting-related
 ---------------

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -829,7 +829,7 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 		m_transforming_liquid.push_back(iter);
 
 	voxalgo::update_lighting_nodes(this, changed_nodes, modified_blocks);
-
+	env->getScriptIface()->on_liquid_transformed(changed_nodes);
 
 	/* ----------------------------------------------------------------------
 	 * Manage the queue so that it does not grow indefinately

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -285,21 +285,19 @@ void ScriptApiEnv::on_liquid_transformed(
 	// no registered callbacks.
 	if(lua_objlen(L, -1) < 1) return;
 
-	// Convert the list of pos/node pairs into lua format
+	// Convert the list to a pos array and a node array for lua
 	int index = 1;
 	const NodeDefManager *ndef = getEnv()->getGameDef()->ndef();
 	lua_createtable(L, list.size(), 0);
+	lua_createtable(L, list.size(), 0);
 	for(std::pair<v3s16, MapNode> p : list) {
-		lua_pushnumber(L, index++);
-		lua_createtable(L, 2, 0);
-		lua_pushstring(L, "pos");
+		lua_pushnumber(L, index);
 		push_v3s16(L, p.first);
-		lua_rawset(L, -3);
-		lua_pushstring(L, "oldnode");
+		lua_rawset(L, -4);
+		lua_pushnumber(L, index++);
 		pushnode(L, p.second, ndef);
-		lua_rawset(L, -3);
 		lua_rawset(L, -3);
 	}
 
-	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
+	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
 }

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -271,7 +271,7 @@ void ScriptApiEnv::on_emerge_area_completion(
 }
 
 void ScriptApiEnv::on_liquid_transformed(
-	const std::vector<std::pair<v3s16, MapNode> > &list)
+	const std::vector<std::pair<v3s16, MapNode>> &list)
 {
 	SCRIPTAPI_PRECHECKHEADER
 

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -25,6 +25,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapgen/mapgen.h"
 #include "lua_api/l_env.h"
 #include "server.h"
+#include "script/common/c_content.h"
+
 
 void ScriptApiEnv::environment_OnGenerated(v3s16 minp, v3s16 maxp,
 	u32 blockseed)
@@ -269,7 +271,7 @@ void ScriptApiEnv::on_emerge_area_completion(
 }
 
 void ScriptApiEnv::on_liquid_transformed(
-	std::vector<std::pair<v3s16, MapNode> > &list)
+	const std::vector<std::pair<v3s16, MapNode> > &list)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
@@ -294,13 +296,7 @@ void ScriptApiEnv::on_liquid_transformed(
 		push_v3s16(L, p.first);
 		lua_rawset(L, -3);
 		lua_pushstring(L, "oldnode");
-		lua_createtable(L, 0, 3);
-		lua_pushstring(L, ndef->get(p.second).name.c_str());
-		lua_setfield(L, -2, "name");
-		lua_pushinteger(L, p.second.getParam1());
-		lua_setfield(L, -2, "param1");
-		lua_pushinteger(L, p.second.getParam2());
-		lua_setfield(L, -2, "param2");
+		pushnode(L, p.second, ndef);
 		lua_rawset(L, -3);
 		lua_rawset(L, -3);
 	}

--- a/src/script/cpp_api/s_env.h
+++ b/src/script/cpp_api/s_env.h
@@ -44,7 +44,7 @@ public:
 		ScriptCallbackState *state);
 
 	// Called after liquid transform changes
-	void on_liquid_transformed(std::vector<std::pair<v3s16, MapNode> > &list);
+	void on_liquid_transformed(const std::vector<std::pair<v3s16, MapNode> > &list);
 
 	void initializeEnvironment(ServerEnvironment *env);
 };

--- a/src/script/cpp_api/s_env.h
+++ b/src/script/cpp_api/s_env.h
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_base.h"
 #include "irr_v3d.h"
 #include "mapnode.h"
-#include "util/container.h"
+#include <vector>
 
 class ServerEnvironment;
 struct ScriptCallbackState;

--- a/src/script/cpp_api/s_env.h
+++ b/src/script/cpp_api/s_env.h
@@ -21,6 +21,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_base.h"
 #include "irr_v3d.h"
+#include "mapnode.h"
+#include "util/container.h"
 
 class ServerEnvironment;
 struct ScriptCallbackState;
@@ -40,6 +42,9 @@ public:
 	// Called after emerge of a block queued from core.emerge_area()
 	void on_emerge_area_completion(v3s16 blockpos, int action,
 		ScriptCallbackState *state);
+
+	// Called after liquid transform changes
+	void on_liquid_transformed(std::vector<std::pair<v3s16, MapNode> > &list);
 
 	void initializeEnvironment(ServerEnvironment *env);
 };

--- a/src/script/cpp_api/s_env.h
+++ b/src/script/cpp_api/s_env.h
@@ -44,7 +44,7 @@ public:
 		ScriptCallbackState *state);
 
 	// Called after liquid transform changes
-	void on_liquid_transformed(const std::vector<std::pair<v3s16, MapNode> > &list);
+	void on_liquid_transformed(const std::vector<std::pair<v3s16, MapNode>> &list);
 
 	void initializeEnvironment(ServerEnvironment *env);
 };


### PR DESCRIPTION
Make it possible for mods to detect liquid transformation changes to the map without resorting to polling.

Add a register_on_liquid_transformed() hook to the server-side modding API.  If at least one function is registered, call it, passing a list of all nodes that were transformed by the liquid transform process.  This list was already generated by the liquid transform system, so converting it to a lua table was all that was necessary (conversion skipped if no hooks).

Resolves #11399

## Use-Cases

NodeCore: sensing fluid flow movement by blocking/unblocking optics beams for automation.  Possibly other recipes involving liquids (e.g. quenching heated metals).

Minetest Game: Possibly lava quenching (depending on performance trade-offs)

## To do

This PR is Ready for Review.

## How to test

### Use case:

- Install the `fluidhook` branch of **NodeCore** (https://gitlab.com/sztest/nodecore/-/tree/fluidhook)
- Download this test world and load it: [ncfluidtest.tar.gz](https://github.com/minetest/minetest/files/6737039/ncfluidtest.tar.gz)
- Watch the timing between the two circled nodes: 
![fluidwatch](https://user-images.githubusercontent.com/324806/123880210-2a75cf00-d910-11eb-82a5-ed3d1bd5b2ae.png)

**Without** this PR merged, you will notice a delay of a second or two between the molten glass (blue circle) flowing in and the prism (red circle) switching off, and between the molten glass flowing out and the prism switching on.  This delay may vary based on lag; creating artificial lag on the server, especially using ABMs, can expand this time gap significantly.

**With** this PR merged, the delay should always be less than half a second.

### Non-use case:

Load up any other world with any other game that is NOT using the functionality in this PR.  Place lots of liquid nodes high up, e.g. at the top of mountains, such that they will flow out over long distances.  You should not notice any difference in behavior regardless of whether this PR is merged or not.