### PR TITLE
Use `persistence` instead of `persist` in NoiseParams examples.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3676,7 +3676,7 @@ For 2D or 3D perlin noise or perlin noise maps:
         spread = {x = 500, y = 500, z = 500},
         seed = 571347,
         octaves = 5,
-        persist = 0.63,
+        persistence = 0.63,
         lacunarity = 2.0,
         flags = "defaults, absvalue",
     }
@@ -3766,7 +3766,7 @@ The following is a decent set of parameters to work from:
         spread  = {x=200, y=200, z=200},
         seed    = 5390,
         octaves = 4,
-        persist = 0.5,
+        persistence = 0.5,
         lacunarity = 2.0,
         flags = "eased",
     },
@@ -7937,7 +7937,7 @@ See [Ores] section above for essential information.
             spread = {x = 100, y = 100, z = 100},
             seed = 23,
             octaves = 3,
-            persist = 0.7
+            persistence = 0.7
         },
         -- NoiseParams structure describing one of the perlin noises used for
         -- ore distribution.
@@ -7966,7 +7966,7 @@ See [Ores] section above for essential information.
             spread = {x = 100, y = 100, z = 100},
             seed = 47,
             octaves = 3,
-            persist = 0.7
+            persistence = 0.7
         },
         np_puff_bottom = {
             offset = 4,
@@ -7974,7 +7974,7 @@ See [Ores] section above for essential information.
             spread = {x = 100, y = 100, z = 100},
             seed = 11,
             octaves = 3,
-            persist = 0.7
+            persistence = 0.7
         },
 
         -- vein
@@ -7987,7 +7987,7 @@ See [Ores] section above for essential information.
             spread = {x = 100, y = 100, z = 100},
             seed = 17,
             octaves = 3,
-            persist = 0.7
+            persistence = 0.7
         },
         stratum_thickness = 8,
     }
@@ -8114,7 +8114,7 @@ See [Decoration types]. Used by `minetest.register_decoration`.
             spread = {x = 100, y = 100, z = 100},
             seed = 354,
             octaves = 3,
-            persist = 0.7,
+            persistence = 0.7,
             lacunarity = 2.0,
             flags = "absvalue"
         },


### PR DESCRIPTION
lua_api.txt is unclear whether the Noise parameter is called `persist` or `persistence`. In examples, it's `persist`. In the property description, it's `persistence`.

The code actually accepts both when reading noiseparams:

https://github.com/minetest/minetest/blob/062fd2190e0ac617499b19c51db609d3a923347e/src/script/common/c_content.cpp#L1659-L1660

However, when it comes to writing noiseparams, it prefers `persistence`:

https://github.com/minetest/minetest/blob/062fd2190e0ac617499b19c51db609d3a923347e/src/script/common/c_content.cpp#L1685

There's also settings, which does not accept `persist`, only `persistence`:

https://github.com/minetest/minetest/blob/062fd2190e0ac617499b19c51db609d3a923347e/minetest.conf.example#L2084

These lead me to believe that `persistence` is the recommended name to pass in persistence parameters, and `persist` is a legacy name.

This PR changes lua_api.txt examples that use `persist` to use the "new" `persistence`.