### PR TITLE
Fix revoke debug privs not reliably turn off stuff

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -676,7 +676,7 @@ protected:
 	bool handleCallbacks();
 	void processQueues();
 	void updateProfilers(const RunStats &stats, const FpsControl &draw_times, f32 dtime);
-	void updateBasicDebugState();
+	void updateDebugState();
 	void updateStats(RunStats *stats, const FpsControl &draw_times, f32 dtime);
 	void updateProfilerGraphs(ProfilerGraph *graph);
 
@@ -1122,7 +1122,7 @@ void Game::run()
 		updatePlayerControl(cam_view);
 		step(&dtime);
 		processClientEvents(&cam_view_target);
-		updateBasicDebugState();
+		updateDebugState();
 		updateCamera(draw_times.busy_time, dtime);
 		updateSound(dtime);
 		processPlayerInteraction(dtime, m_game_ui->m_flags.show_hud,
@@ -1727,18 +1727,24 @@ void Game::processQueues()
 	shader_src->processQueue();
 }
 
-void Game::updateBasicDebugState()
+void Game::updateDebugState()
 {
+	bool has_basic_debug = client->checkPrivilege("basic_debug");
+	bool has_debug = client->checkPrivilege("debug");
+
 	if (m_game_ui->m_flags.show_basic_debug) {
-		if (!client->checkPrivilege("basic_debug")) {
+		if (!has_basic_debug) {
 			m_game_ui->m_flags.show_basic_debug = false;
-			hud->disableBlockBounds();
 		}
 	} else if (m_game_ui->m_flags.show_minimal_debug) {
-		if (client->checkPrivilege("basic_debug")) {
+		if (has_basic_debug) {
 			m_game_ui->m_flags.show_basic_debug = true;
 		}
 	}
+	if (!has_basic_debug)
+		hud->disableBlockBounds();
+	if (!has_debug)
+		draw_control->show_wireframe = false;
 }
 
 void Game::updateProfilers(const RunStats &stats, const FpsControl &draw_times,


### PR DESCRIPTION
I noticed bugs when revoking debug / basic\_debug.

What is expected that you lose debug features instantly: wireframe, block borders, the 2nd line in the debug header. But the wireframe and block borders persist after the revoke. Block borders only persist if you did not have the debug mode activated. Otherwise, they disappear corrctly.

Anyway, this PR fixes that by guaranteeing every relevant debug disappears instantly when you lose the corresponding priv.

## To do

This PR is ready.

## How to test

Start the game and grant yourselves all privs. Then turn block borders on and the debug screen with wireframe. Now revoke everything. All things you got with privs (wireframe, block borders, line 2 in debug header (pos and more)) should disappear.