### PR TITLE
Remove redundant register_on_dieplayer calls

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -832,7 +832,6 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 
 		PlayerHPChangeReason reason(PlayerHPChangeReason::FALL);
 		playersao->setHP((s32)playersao->getHP() - (s32)damage, reason);
-		SendPlayerHPOrDie(playersao, reason);
 	}
 }
 
@@ -1117,9 +1116,6 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 		float time_from_last_punch =
 			playersao->resetTimeFromLastPunch();
 
-		u16 src_original_hp = pointed_object->getHP();
-		u16 dst_origin_hp = playersao->getHP();
-
 		u16 wear = pointed_object->punch(dir, &toolcap, playersao,
 				time_from_last_punch);
 
@@ -1128,18 +1124,6 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 		bool changed = selected_item.addWear(wear, m_itemdef);
 		if (changed)
 			playersao->setWieldedItem(selected_item);
-
-		// If the object is a player and its HP changed
-		if (src_original_hp != pointed_object->getHP() &&
-				pointed_object->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
-			SendPlayerHPOrDie((PlayerSAO *)pointed_object,
-					PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, playersao));
-		}
-
-		// If the puncher is a player and its HP changed
-		if (dst_origin_hp != playersao->getHP())
-			SendPlayerHPOrDie(playersao,
-					PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, pointed_object));
 
 		return;
 	} // action == INTERACT_START_DIGGING

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -200,8 +200,6 @@ void read_object_properties(lua_State *L, int index,
 		if (prop->hp_max < sao->getHP()) {
 			PlayerHPChangeReason reason(PlayerHPChangeReason::SET_HP);
 			sao->setHP(prop->hp_max, reason);
-			if (sao->getType() == ACTIVEOBJECT_TYPE_PLAYER)
-				sao->getEnv()->getGameDef()->SendPlayerHPOrDie((PlayerSAO *)sao, reason);
 		}
 	}
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -172,27 +172,11 @@ int ObjectRef::l_punch(lua_State *L)
 	float time_from_last_punch = readParam<float>(L, 3, 1000000.0f);
 	ToolCapabilities toolcap = read_tool_capabilities(L, 4);
 	v3f dir = readParam<v3f>(L, 5, sao->getBasePosition() - puncher->getBasePosition());
-
 	dir.normalize();
-	u16 src_original_hp = sao->getHP();
-	u16 dst_origin_hp = puncher->getHP();
 
 	u16 wear = sao->punch(dir, &toolcap, puncher, time_from_last_punch);
 	lua_pushnumber(L, wear);
 
-	// If the punched is a player, and its HP changed
-	if (src_original_hp != sao->getHP() &&
-			sao->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
-		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)sao,
-				PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, puncher));
-	}
-
-	// If the puncher is a player, and its HP changed
-	if (dst_origin_hp != puncher->getHP() &&
-			puncher->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
-		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)puncher,
-				PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, sao));
-	}
 	return 1;
 }
 
@@ -238,8 +222,6 @@ int ObjectRef::l_set_hp(lua_State *L)
 	}
 
 	sao->setHP(hp, reason);
-	if (sao->getType() == ACTIVEOBJECT_TYPE_PLAYER)
-		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)sao, reason);
 	if (reason.hasLuaReference())
 		luaL_unref(L, LUA_REGISTRYINDEX, reason.lua_reference);
 	return 0;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1079,8 +1079,7 @@ PlayerSAO* Server::StageTwoClientInit(session_t peer_id)
 	if (playersao->isDead())
 		SendDeathscreen(peer_id, false, v3f(0,0,0));
 	else
-		SendPlayerHPOrDie(playersao,
-				PlayerHPChangeReason(PlayerHPChangeReason::SET_HP));
+		SendPlayerHP(peer_id);
 
 	// Send Breath
 	SendPlayerBreath(playersao);

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -167,7 +167,6 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 			if (m_breath == 0) {
 				PlayerHPChangeReason reason(PlayerHPChangeReason::DROWNING);
 				setHP(m_hp - c.drowning, reason);
-				m_env->getGameDef()->SendPlayerHPOrDie(this, reason);
 			}
 		}
 	}
@@ -216,7 +215,6 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 			s32 newhp = (s32)m_hp - (s32)damage_per_second;
 			PlayerHPChangeReason reason(PlayerHPChangeReason::NODE_DAMAGE, nodename);
 			setHP(newhp, reason);
-			m_env->getGameDef()->SendPlayerHPOrDie(this, reason);
 		}
 	}
 
@@ -491,6 +489,8 @@ void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
 	// Update properties on death
 	if ((hp == 0) != (oldhp == 0))
 		m_properties_sent = false;
+
+	m_env->getGameDef()->SendPlayerHPOrDie(this, reason);
 }
 
 void PlayerSAO::setBreath(const u16 breath, bool send)


### PR DESCRIPTION
- Don't call SendPlayerHPOrDie() from punch if punch damage is handled by Lua
- Don't call SendPlayerHPOrDie() from set_hp if player is already dead

Fix #11266