### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+end_of_line = lf
+
+[*.{cpp,h,lua,txt}]
+indent_size = 4
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,9 @@
 [*]
 end_of_line = lf
 
-[*.{cpp,h,lua,txt,glsl}]
+[*.{cpp,h,lua,txt,glsl,md,c,cmake,java,gradle}]
+charset = utf8
 indent_size = 4
 indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 [*]
 end_of_line = lf
 
-[*.{cpp,h,lua,txt}]
+[*.{cpp,h,lua,txt,glsl}]
 indent_size = 4
 indent_style = tab


### PR DESCRIPTION
Adding an .editorconfig in the repo root allows us to tell github that we:
- Use LF as line endings
- Use tab indentation
- Use 4-space tabs, **which makes github display them appropriately**

The last point is important as it makes the code fit better in a browser window, especially in compares.

Before:
![before](https://user-images.githubusercontent.com/42101236/124354143-ce11f880-dc0a-11eb-9dde-701ffb494886.png)

After:
![after](https://user-images.githubusercontent.com/42101236/124354148-d4a07000-dc0a-11eb-887b-4628b28d6870.png)

This PR is ready for review.
