### PR TITLE
more detailled & corrected lua documentation of sound behavior

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -867,7 +867,8 @@ Table form has the following fields:
 
 `gain` is capped at 1.
 
-`fade` values close to 0 make the sound almost inaudible. Large fade values (20+) give no fade and sound similar to 'fade=0'.
+`fade` values close to 0 make the sound almost inaudible. Large fade values (20+) 
+give no fade and sound similar to 'fade=0'.
 
 Examples:
 
@@ -881,10 +882,13 @@ Examples:
 
 `Sound Parameters`
 ------------------
-Basic sound functionality as used within node definitions for placing, breaking, digging, walking, swimming etc. only uses the SimpleSoundSpec.
-But the minetest.sound_play() function takes an optional second table of parameters in addition to SimpleSoundSpec. 
+Basic sound functionality as used within node definitions for placing, breaking, digging, 
+walking, swimming etc. only uses the SimpleSoundSpec.
+But the minetest.sound_play() function takes an optional second table of parameters in 
+addition to SimpleSoundSpec. 
 
-This table has the following parameters, all of which are optional, same as the table itself (when omitted, default values are used for the values that have them):
+This table has the following parameters, all of which are optional, same as the table itself  
+(when omitted, default values are used for the values that have them):
 
 {
 * `to_player=name`,				--play locationless to one player. 
@@ -894,27 +898,40 @@ This table has the following parameters, all of which are optional, same as the 
 * `pos=<some pos>`,				--play at a spot
 * `object = <an ObjectRef>`,    --play connected to an object
 * `max_hear_distance=32`, 		--default, uses an euclidean metric
-* `loop=false`					--default
+* `loop=false`,					--default
 * `gain=1.0`,	 				--default. gets multiplied with
 								--  the SimpleSoundSpec's 'gain' value
 * `pitch=1.0`, 					--default. the SimpleSoundSpec's
 								--  'pitch' value is ignored, 
 								--  so you have use this one instead.
-* `fade=0.0`, 					--default. the SimpleSoundSpec's
+* `fade=0.0` 					--default. the SimpleSoundSpec's
 								--  'fade' value is ignored, 
 								--  so you have use this one instead.
 }
 
 
-NOTE!: While passing a 'pitch' and 'fade' value in Sound Parameters is optional, the SimpleSoundSpec's 'pitch' and 'fade' are ignored by minetest.sound_play(), so if said SimpleSoundSpec's pitch/fade are not the default '1', you will have to pass the same values again in the Sound Parameters table to have identical results to using the SimpleSoundSpec in a node definition.
+NOTE!: While passing a 'pitch' and 'fade' value in Sound Parameters is optional, the 
+SimpleSoundSpec's 'pitch' and 'fade' are ignored by minetest.sound_play(), so if said 
+SimpleSoundSpec's pitch/fade are not the default '1', you will have to pass the same values 
+again in the Sound Parameters table to have identical results to using the SimpleSoundSpec in 
+a node definition.
 
-Several of the parameters conflict when provided simultaneously. In this case, arguments of higher priority result in lower priority arguments being ignored. The table above is ordered in descending priority of arguments overriding each other: 
+Several of the parameters conflict when provided simultaneously. In this case, arguments of 
+higher priority result in lower priority arguments being ignored. The table above is ordered 
+in descending priority of arguments overriding each other: 
 to_player,exclude_player,pos,object,max_hear_distance.
 exclude_player only overrides behavior for the specified player.
 
-loop has several quirks: It does not override max_hear_distance, which decides whether the initial sound is heard. However, players who heard the initial sound will continue to hear the looped sound at a minimum volume even if they leave beyond the max_hear_distance. When they get closer to the 'center spot' again, the sound gets louder at the correct position as expected, while players not in the initial sound's max_hear_distance will never hear the sound when they come closer later.
+loop has several quirks: It does not override max_hear_distance, which decides whether the 
+initial sound is heard. However, players who heard the initial sound will continue to hear the 
+looped sound at a minimum volume even if they leave beyond the max_hear_distance. When they 
+get closer to the 'center spot' again, the sound gets louder at the correct position as   
+expected, while players not in the initial sound's max_hear_distance will never hear the sound 
+when they come closer later.
 
-This is also true for a looped sound played at an object's position. The 'center spot' of the sound will move with the object's position, and remain at the object's last position after it was removed. The looped sound will continue to play at this position afterwards.
+This is also true for a looped sound played at an object's position. The 'center spot' of the 
+sound will move with the object's position, and remain at the object's last position after it 
+was removed. The looped sound will continue to play at this position afterwards.
 
 A positional sound will only be heard by players that are within
 `max_hear_distance` of the sound position, at the start of the sound.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -882,7 +882,7 @@ Examples:
 `Sound Parameters`
 ------------------
 Basic sound functionality as used within node definitions for placing, breaking, digging, walking, swimming etc. only uses the SimpleSoundSpec.
-But the minetest.play_sound() function takes an optional second table of parameters in addition to SimpleSoundSpec. 
+But the minetest.sound_play() function takes an optional second table of parameters in addition to SimpleSoundSpec. 
 
 This table has the following parameters, all of which are optional, same as the table itself (when omitted, default values are used for the values that have them):
 
@@ -906,7 +906,7 @@ This table has the following parameters, all of which are optional, same as the 
 }
 
 
-NOTE!: While passing a 'pitch' and 'fade' value in Sound Parameters is optional, the SimpleSoundSpec's 'pitch' and 'fade' are ignored by minetest.play_sound(), so if said SimpleSoundSpec's pitch/fade are not the default '1', you will have to pass the same values again in the Sound Parameters table to have identical results to using the SimpleSoundSpec in a node definition.
+NOTE!: While passing a 'pitch' and 'fade' value in Sound Parameters is optional, the SimpleSoundSpec's 'pitch' and 'fade' are ignored by minetest.sound_play(), so if said SimpleSoundSpec's pitch/fade are not the default '1', you will have to pass the same values again in the Sound Parameters table to have identical results to using the SimpleSoundSpec in a node definition.
 
 Several of the parameters conflict when provided simultaneously. In this case, arguments of higher priority result in lower priority arguments being ignored. The table above is ordered in descending priority of arguments overriding each other: 
 to_player,exclude_player,pos,object,max_hear_distance.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -845,6 +845,80 @@ from the available ones of the following files:
 * (...)
 * `foomod_foosound.9.ogg`
 
+
+`SimpleSoundSpec`
+-----------------
+
+Specifies a sound name, gain (=volume), pitch and fade.
+This is either a string or a table.
+
+In string form, you just specify the sound name or
+the empty string for no sound.
+
+Table form has the following fields:
+
+* `name`: Sound name
+* `gain`: Volume (`1.0` = 100%)
+* `pitch`: Pitch (`1.0` = 100%)
+* `fade`: Fade (`0.0` = no fade) 
+
+`gain` and `pitch` are optional and default to `1.0`.
+`fade` is optional and defaults to `0.0`, which means no fade is applied.
+
+`gain` is capped at 1.
+
+`fade` values close to 0 make the sound almost inaudible. Large fade values (20+) give no fade and sound similar to 'fade=0'.
+
+Examples:
+
+* `""`: No sound
+* `{}`: No sound
+* `"default_place_node"`: Play e.g. `default_place_node.ogg`
+* `{name = "default_place_node"}`: Same as above
+* `{name = "default_place_node", gain = 0.5}`: 50% volume
+* `{name = "default_place_node", gain = 0.9, pitch = 1.1}`: 90% volume, 110% pitch
+
+
+`Sound Parameters`
+------------------
+Basic sound functionality as used within node definitions for placing, breaking, digging, walking, swimming etc. only uses the SimpleSoundSpec.
+But the minetest.play_sound() function takes an optional second table of parameters in addition to SimpleSoundSpec. 
+
+This table has the following parameters, all of which are optional, same as the table itself (when omitted, default values are used for the values that have them):
+
+{
+* `to_player=name`,				--play locationless to one player. 
+								--  only 1 player can be specified
+* `exclude_player=name`,		--heard by anyone *but* the given player
+								--  only 1 player can be specified
+* `pos=<some pos>`,				--play at a spot
+* `object = <an ObjectRef>`,    --play connected to an object
+* `max_hear_distance=32`, 		--default, uses an euclidean metric
+* `loop=false`					--default
+* `gain=1.0`,	 				--default. gets multiplied with
+								--  the SimpleSoundSpec's 'gain' value
+* `pitch=1.0`, 					--default. the SimpleSoundSpec's
+								--  'pitch' value is ignored, 
+								--  so you have use this one instead.
+* `fade=0.0`, 					--default. the SimpleSoundSpec's
+								--  'fade' value is ignored, 
+								--  so you have use this one instead.
+}
+
+
+NOTE!: While passing a 'pitch' and 'fade' value in Sound Parameters is optional, the SimpleSoundSpec's 'pitch' and 'fade' are ignored by minetest.play_sound(), so if said SimpleSoundSpec's pitch/fade are not the default '1', you will have to pass the same values again in the Sound Parameters table to have identical results to using the SimpleSoundSpec in a node definition.
+
+Several of the parameters conflict when provided simultaneously. In this case, arguments of higher priority result in lower priority arguments being ignored. The table above is ordered in descending priority of arguments overriding each other: 
+to_player,exclude_player,pos,object,max_hear_distance.
+exclude_player only overrides behavior for the specified player.
+
+loop has several quirks: It does not override max_hear_distance, which decides whether the initial sound is heard. However, players who heard the initial sound will continue to hear the looped sound at a minimum volume even if they leave beyond the max_hear_distance. When they get closer to the 'center spot' again, the sound gets louder at the correct position as expected, while players not in the initial sound's max_hear_distance will never hear the sound when they come closer later.
+
+This is also true for a looped sound played at an object's position. The 'center spot' of the sound will move with the object's position, and remain at the object's last position after it was removed. The looped sound will continue to play at this position afterwards.
+
+A positional sound will only be heard by players that are within
+`max_hear_distance` of the sound position, at the start of the sound.
+
 Examples of sound parameter tables:
 
     -- Play locationless on all clients
@@ -886,40 +960,6 @@ Examples of sound parameter tables:
         exclude_player = name,
     }
 
-Looped sounds must either be connected to an object or played locationless to
-one player using `to_player = name`.
-
-A positional sound will only be heard by players that are within
-`max_hear_distance` of the sound position, at the start of the sound.
-
-`exclude_player = name` can be applied to locationless, positional and object-
-bound sounds to exclude a single player from hearing them.
-
-`SimpleSoundSpec`
------------------
-
-Specifies a sound name, gain (=volume) and pitch.
-This is either a string or a table.
-
-In string form, you just specify the sound name or
-the empty string for no sound.
-
-Table form has the following fields:
-
-* `name`: Sound name
-* `gain`: Volume (`1.0` = 100%)
-* `pitch`: Pitch (`1.0` = 100%)
-
-`gain` and `pitch` are optional and default to `1.0`.
-
-Examples:
-
-* `""`: No sound
-* `{}`: No sound
-* `"default_place_node"`: Play e.g. `default_place_node.ogg`
-* `{name = "default_place_node"}`: Same as above
-* `{name = "default_place_node", gain = 0.5}`: 50% volume
-* `{name = "default_place_node", gain = 0.9, pitch = 1.1}`: 90% volume, 110% pitch
 
 Special sound files
 -------------------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -857,10 +857,12 @@ the empty string for no sound.
 
 Table form has the following fields:
 
+{
 * `name`: Sound name
 * `gain`: Volume (`1.0` = 100%)
 * `pitch`: Pitch (`1.0` = 100%)
 * `fade`: Fade (`0.0` = no fade) 
+}
 
 `gain` and `pitch` are optional and default to `1.0`.
 `fade` is optional and defaults to `0.0`, which means no fade is applied.


### PR DESCRIPTION
- Goal of the PR
Improve the clarity of how the various parameters handed to minetest.sound_play() are affecting the end result.

This has come from my own need/curiosity to find answers, and realizing the documentation was very imcomplete, partially wrong*, and partially misleading. I spent the weekend running lots of tests (a LOT of parameters could potentially affect each other...) and collecting the pieces of code that are responsible for various behaviors, and created a lot of chat commands to directly test & verify the behavior in minetest 5.4.1, in minetestgame and devtest. This is the result, in the hope that it will help the next person reading the lua docs.

*Details on what is wrong and misleading will be commented in this pull request thread. 
 Most changes can be directly seen from the source code if you combine looking in 3-5 places, but most of it was a combination of reading the code and confirming the suspected behaviors by doing ingame verification tests, with a lot of result tables.

- Does it resolve any reported issue?
    Should resolve issue #11414 

- Does it relate to a topic on the roadmap?
   I assume accurate documentation is a soft goal anyway, even if not explicitly in the roadmap.

## To do
Formatting, choice of words. I'm quite certain of the results and doublechecked the cases where the old docs tells the opposite of what happens, but the style of the sentences may be improved. Also, if someone does the work of doublechecking my results on another system to rule out funky openAL behavior, or in case they don't believe me, that would be ideal. I will provide the mods (lists of chat commands) I used to test the parameters, to save them some time.

This PR is Ready for Review.

## How to test
I will list the most important places in the code that confirm this behavior, and upload a package of mods (a list of chat commands) which I used to note, organize and verify the behaviors, in a comment once I figure out how to load them onto github.
