### PR TITLE
Allow Selecting Which GLES Version To Link With

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ General options and their default values:
     ENABLE_FREETYPE=ON         - Build with FreeType2; Allows using TTF fonts
     ENABLE_GETTEXT=ON          - Build with Gettext; Allows using translations
     ENABLE_GLES=OFF            - Build for OpenGL ES instead of OpenGL (requires support by IrrlichtMt)
+    GLES_VERSION=2             - Specify OpenGL ES Version (1, 2, or BOTH) (requires support by IrrlichtMt)
     ENABLE_LEVELDB=ON          - Build with LevelDB; Enables use of LevelDB map backend
     ENABLE_POSTGRESQL=ON       - Build with libpq; Enables use of PostgreSQL map backend (PostgreSQL 9.5 or greater recommended)
     ENABLE_REDIS=ON            - Build with libhiredis; Enables use of Redis map backend
@@ -291,8 +292,10 @@ Library specific options:
     OPENAL_DLL                      - Only if building with sound on Windows; path to OpenAL32.dll
     OPENAL_INCLUDE_DIR              - Only if building with sound; directory where al.h is located
     OPENAL_LIBRARY                  - Only if building with sound; path to libopenal.a/libopenal.so/OpenAL32.lib
-    OPENGLES2_INCLUDE_DIR           - Only if building with GLES; directory that contains gl2.h
-    OPENGLES2_LIBRARY               - Only if building with GLES; path to libGLESv2.a/libGLESv2.so
+    OpenGLES2_INCLUDE_DIR           - Only if building with GLES2; directory that contains gl2.h
+    OpenGLES2_LIBRARY               - Only if building with GLES2; path to libGLESv2.a/libGLESv2.so
+    OpenGLES1_INCLUDE_DIR           - Only if building with GLES1; directory that contains gl.h
+    OpenGLES1_LIBRARY               - Only if building with GLES1; path to libGLESv1_CM.a/libGLESv1_CM.so
     SQLITE3_INCLUDE_DIR             - Directory that contains sqlite3.h
     SQLITE3_LIBRARY                 - Path to libsqlite3.a/libsqlite3.so/sqlite3.lib
     VORBISFILE_LIBRARY              - Only if building with sound; path to libvorbisfile.a/libvorbisfile.so/libvorbisfile.dll.a

--- a/cmake/Modules/FindEGL.cmake
+++ b/cmake/Modules/FindEGL.cmake
@@ -1,0 +1,42 @@
+#-------------------------------------------------------------------
+# The contents of this file are placed in the public domain. Feel
+# free to make use of it in any way you like.
+#-------------------------------------------------------------------
+
+# - Try to find EGL
+# Once done this will define
+#
+#  EGL_FOUND        - system has EGL
+#  EGL_INCLUDE_DIR  - the EGL include directory
+#  EGL_LIBRARIES    - Link these to use EGL
+
+# Win32 and Apple are not tested!
+# Linux tested and works
+
+if(NOT WIN32 AND NOT APPLE)
+	# Unix
+	find_path(EGL_INCLUDE_DIR EGL/egl.h
+		PATHS /usr/openwin/share/include
+			/opt/graphics/OpenGL/include
+			/usr/X11R6/include
+			/usr/include
+	)
+
+	find_library(EGL_LIBRARY
+		NAMES EGL
+		PATHS /opt/graphics/OpenGL/lib
+			/usr/openwin/lib
+			/usr/X11R6/lib
+			/usr/lib
+	)
+
+	include(FindPackageHandleStandardArgs)
+	find_package_handle_standard_args(EGL DEFAULT_MSG EGL_LIBRARY EGL_INCLUDE_DIR)
+endif()
+
+set(EGL_LIBRARIES ${EGL_LIBRARY})
+
+mark_as_advanced(
+	EGL_INCLUDE_DIR
+	EGL_LIBRARY
+)

--- a/cmake/Modules/FindOpenGLES1.cmake
+++ b/cmake/Modules/FindOpenGLES1.cmake
@@ -3,34 +3,34 @@
 # free to make use of it in any way you like.
 #-------------------------------------------------------------------
 
-# - Try to find OpenGLES and EGL
+# - Try to find OpenGL ES 1
 # Once done this will define
 #
-#  OpenGLES2_FOUND        - system has OpenGLES
-#  OpenGLES2_INCLUDE_DIR  - the GL include directory
-#  OpenGLES2_LIBRARIES    - Link these to use OpenGLES
+#  OpenGLES1_FOUND        - system has OpenGL ES
+#  OpenGLES1_INCLUDE_DIR  - the GL include directory
+#  OpenGLES1_LIBRARIES    - Link these to use OpenGL ES
 
 # Win32 and Apple are not tested!
 # Linux tested and works
 
 if(WIN32)
-	find_path(OpenGLES2_INCLUDE_DIR GLES2/gl2.h)
-	find_library(OpenGLES2_LIBRARY libGLESv2)
+	find_path(OpenGLES1_INCLUDE_DIR GLES/gl.h)
+	find_library(OpenGLES1_LIBRARY libGLESv1_CM)
 elseif(APPLE)
 	create_search_paths(/Developer/Platforms)
-	findpkg_framework(OpenGLES2)
-	set(OpenGLES2_LIBRARY "-framework OpenGLES")
+	findpkg_framework(OpenGLES)
+	set(OpenGLES1_LIBRARY "-framework OpenGLES")
 else()
 	# Unix
-	find_path(OpenGLES2_INCLUDE_DIR GLES2/gl2.h
+	find_path(OpenGLES1_INCLUDE_DIR GLES/gl.h
 		PATHS /usr/openwin/share/include
 			/opt/graphics/OpenGL/include
 			/usr/X11R6/include
 			/usr/include
 	)
 
-	find_library(OpenGLES2_LIBRARY
-		NAMES GLESv2
+	find_library(OpenGLES1_LIBRARY
+		NAMES GLESv1_CM
 		PATHS /opt/graphics/OpenGL/lib
 			/usr/openwin/lib
 			/usr/X11R6/lib
@@ -38,12 +38,12 @@ else()
 	)
 
 	include(FindPackageHandleStandardArgs)
-	find_package_handle_standard_args(OpenGLES2 DEFAULT_MSG OpenGLES2_LIBRARY OpenGLES2_INCLUDE_DIR)
+	find_package_handle_standard_args(OpenGLES1 DEFAULT_MSG OpenGLES1_LIBRARY OpenGLES1_INCLUDE_DIR)
 endif()
 
-set(OpenGLES2_LIBRARIES ${OpenGLES2_LIBRARY})
+set(OpenGLES1_LIBRARIES ${OpenGLES1_LIBRARY})
 
 mark_as_advanced(
-	OpenGLES2_INCLUDE_DIR
-	OpenGLES2_LIBRARY
+	OpenGLES1_INCLUDE_DIR
+	OpenGLES1_LIBRARY
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,12 +100,27 @@ endif()
 
 
 option(ENABLE_GLES "Use OpenGL ES instead of OpenGL" FALSE)
-mark_as_advanced(ENABLE_GLES)
+set(GLES_VERSION "2" CACHE STRING "Specify OpenGL ES Version (1, 2, or BOTH)")
+mark_as_advanced(ENABLE_GLES GLES_VERSION)
+
 if(BUILD_CLIENT)
 	# transitive dependency from Irrlicht (see longer explanation below)
 	if(NOT WIN32)
 		if(ENABLE_GLES)
-			find_package(OpenGLES2 REQUIRED)
+			find_package(EGL REQUIRED)
+
+			set(VALID_GLES FALSE)
+			if("${GLES_VERSION}" STREQUAL "2" OR "${GLES_VERSION}" STREQUAL "BOTH")
+				find_package(OpenGLES2 REQUIRED)
+				set(VALID_GLES TRUE)
+			endif()
+			if("${GLES_VERSION}" STREQUAL "1" OR "${GLES_VERSION}" STREQUAL "BOTH")
+				find_package(OpenGLES1 REQUIRED)
+				set(VALID_GLES TRUE)
+			endif()
+			if(NOT VALID_GLES)
+				message(FATAL_ERROR "Invalid OpenGL ES Version: ${GLES_VERSION}")
+			endif()
 		else()
 			set(OPENGL_GL_PREFERENCE "LEGACY" CACHE STRING
 				"See CMake Policy CMP0072 for reference. GLVND is broken on some nvidia setups")
@@ -572,9 +587,20 @@ if(BUILD_CLIENT)
 	if(ENABLE_GLES)
 		target_link_libraries(
 			${PROJECT_NAME}
-			${OPENGLES2_LIBRARIES}
 			${EGL_LIBRARIES}
 		)
+		if("${GLES_VERSION}" STREQUAL "2" OR "${GLES_VERSION}" STREQUAL "BOTH")
+			target_link_libraries(
+				${PROJECT_NAME}
+				${OpenGLES2_LIBRARIES}
+			)
+		endif()
+		if("${GLES_VERSION}" STREQUAL "1" OR "${GLES_VERSION}" STREQUAL "BOTH")
+			target_link_libraries(
+				${PROJECT_NAME}
+				${OpenGLES1_LIBRARIES}
+			)
+		endif()
 	else()
 		target_link_libraries(
 			${PROJECT_NAME}


### PR DESCRIPTION
This PR allows you to select which version of OpenGL ES you want to link with when building. Previously, it would always force GLESv2.

## To do

This PR is a Ready for Review.

## How to test
```
cmake \
    -DENABLE_GLES=ON \
    -DGLES_VERSION=<1, 2, BOTH> \
    .
make -j$(nproc)
./bin/minetest
```