### PR TITLE
Add smooth light-shadow transition at noon

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -494,8 +494,8 @@ void main(void)
 
 	}
 
-	if (f_normal_length != 0 && cosLight < 0.09) {
-		shadow_int = max(shadow_int, min(clamp(1.0-nightRatio, 0.0, 1.0), 1 - clamp(cosLight, 0.0, 0.09)/0.09));
+	if (f_normal_length != 0 && cosLight < 0.035) {
+		shadow_int = max(shadow_int, min(clamp(1.0-nightRatio, 0.0, 1.0), 1 - clamp(cosLight, 0.0, 0.035)/0.035));
 	}
 
 	shadow_int = 1.0 - (shadow_int * f_adj_shadow_strength);

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -494,8 +494,8 @@ void main(void)
 
 	}
 
-	if (f_normal_length != 0 && cosLight < 0.0) {
-		shadow_int = clamp(1.0-nightRatio, 0.0, 1.0);
+	if (f_normal_length != 0 && cosLight < 0.09) {
+		shadow_int = max(shadow_int, min(clamp(1.0-nightRatio, 0.0, 1.0), 1 - clamp(cosLight, 0.0, 0.09)/0.09));
 	}
 
 	shadow_int = 1.0 - (shadow_int * f_adj_shadow_strength);


### PR DESCRIPTION
Node faces with normals pointing East/West (+X/-X) will transition between light
and shadow at noon. This code makes the transition smooth.

This PR is Ready for Review.

## How to test

Enable shadows, launch the game and set /time 11:50, watch the node faces transition from lit to shadowed or vice versa.