### PR TITLE
Mods: Improve mod loading priorities (2nd)

### DIFF
--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -385,11 +385,8 @@ bool PrioritySortedMod::addDependingMod(const std::string &modname,
 			// Step 4: Reached the very same mod again.
 			// Stop the circular dependencies
 
-			// clang-format off
 			warningstream << "Detected circular dependencies in mod '" <<
 					modname << "'" << std::endl;
-			// clang-format on
-
 			return false;
 		}
 		return true; // The dependency trees merge. Nothing unusual
@@ -476,10 +473,8 @@ void ModConfiguration::resolveDependencies()
 
 	for (auto &mod : mods) {
 		m_sorted_mods.push_back(*mod->spec);
-		// clang-format off
 		verbosestream << "Sorted mod: " << mod->spec->name <<
 				"\t depending=" << mod->deps_chain.size() << std::endl;
-		// clang-format on
 	}
 
 	// Step 6: Update the list of unsatisfied mods

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -362,7 +362,7 @@ void ModConfiguration::checkConflictsAndDeps()
 
 struct PrioritySortedMod
 {
-	PrioritySortedMod(ModSpec *mod) : spec(mod) {}
+	PrioritySortedMod(ModSpec *mod = nullptr) : spec(mod) {}
 
 	static bool sorter(const PrioritySortedMod *a, const PrioritySortedMod *b)
 	{
@@ -428,8 +428,7 @@ void ModConfiguration::resolveDependencies()
 	for (ModSpec &mod : m_unsatisfied_mods) {
 		// Reduce memory copy time by passing 'mod' as pointer
 		// 'm_unsatisfied_mods' owns the value!
-		mods_by_name.emplace(std::pair<std::string, PrioritySortedMod>(
-				mod.name, &mod));
+		mods_by_name[mod.name] = PrioritySortedMod(&mod);
 	}
 
 	std::vector<ModSpec> unsatisfied;
@@ -458,7 +457,7 @@ void ModConfiguration::resolveDependencies()
 				// Mod cannot be satisfied: Add to the "error list"
 				// also skip it in the next loop
 				unsatisfied.push_back(mod);
-				mods_by_name.erase(mod_it++);
+				mod_it = mods_by_name.erase(mod_it);
 			}
 		}
 	} while (mods_by_name.size() != old_list_size);

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -94,6 +94,10 @@ public:
 	void printUnsatisfiedModsError() const;
 
 protected:
+#if BUILD_UNITTESTS
+	friend class TestServerModManager;
+#endif
+
 	ModConfiguration(const std::string &worldpath);
 	// adds all mods in the given path. used for games, modpacks
 	// and world-specific mods (worldmods-folders)

--- a/src/unittest/test_servermodmanager.cpp
+++ b/src/unittest/test_servermodmanager.cpp
@@ -217,33 +217,33 @@ void TestServerModManager::testModDependencies()
 			circ_1:    circular reference. circ_2 not met
 	*/
 	std::vector<ModSpec> mods;
-	mods.push_back(ModSpec("default"));
-	mods.push_back(ModSpec("dye"));
+	mods.emplace_back(ModSpec("default"));
+	mods.emplace_back(ModSpec("dye"));
 	mods[mods.size() - 1].depends.insert("default");
 
-	mods.push_back(ModSpec("wool"));
+	mods.emplace_back(ModSpec("wool"));
 	mods[mods.size() - 1].depends.insert("default");
 	mods[mods.size() - 1].depends.insert("dye");
 
-	mods.push_back(ModSpec("mesecons"));
+	mods.emplace_back(ModSpec("mesecons"));
 	mods[mods.size() - 1].depends.insert("default");
 	mods[mods.size() - 1].depends.insert("invalid"); // unknown mod
 
-	mods.push_back(ModSpec("pipeworks"));
+	mods.emplace_back(ModSpec("pipeworks"));
 	mods[mods.size() - 1].depends.insert("default");
 	mods[mods.size() - 1].optdepends.insert("mesecons");
 
-	mods.push_back(ModSpec("technic"));
+	mods.emplace_back(ModSpec("technic"));
 	mods[mods.size() - 1].depends.insert("pipeworks");
 	mods[mods.size() - 1].depends.insert("mesecons");
 
-	mods.push_back(ModSpec("circ_1"));
+	mods.emplace_back(ModSpec("circ_1"));
 	mods[mods.size() - 1].depends.insert("default");
 	mods[mods.size() - 1].optdepends.insert("circ_2");
 
-	mods.push_back(ModSpec("circ_2"));
+	mods.emplace_back(ModSpec("circ_2"));
 	mods[mods.size() - 1].depends.insert("circ_3");
-	mods.push_back(ModSpec("circ_3"));
+	mods.emplace_back(ModSpec("circ_3"));
 	mods[mods.size() - 1].depends.insert("circ_1");
 
 	mc.addMods(mods);

--- a/src/unittest/test_servermodmanager.cpp
+++ b/src/unittest/test_servermodmanager.cpp
@@ -219,32 +219,32 @@ void TestServerModManager::testModDependencies()
 	std::vector<ModSpec> mods;
 	mods.emplace_back(ModSpec("default"));
 	mods.emplace_back(ModSpec("dye"));
-	mods[mods.size() - 1].depends.insert("default");
+	mods.back().depends.insert("default");
 
 	mods.emplace_back(ModSpec("wool"));
-	mods[mods.size() - 1].depends.insert("default");
-	mods[mods.size() - 1].depends.insert("dye");
+	mods.back().depends.insert("default");
+	mods.back().depends.insert("dye");
 
 	mods.emplace_back(ModSpec("mesecons"));
-	mods[mods.size() - 1].depends.insert("default");
-	mods[mods.size() - 1].depends.insert("invalid"); // unknown mod
+	mods.back().depends.insert("default");
+	mods.back().depends.insert("invalid"); // unknown mod
 
 	mods.emplace_back(ModSpec("pipeworks"));
-	mods[mods.size() - 1].depends.insert("default");
-	mods[mods.size() - 1].optdepends.insert("mesecons");
+	mods.back().depends.insert("default");
+	mods.back().optdepends.insert("mesecons");
 
 	mods.emplace_back(ModSpec("technic"));
-	mods[mods.size() - 1].depends.insert("pipeworks");
-	mods[mods.size() - 1].depends.insert("mesecons");
+	mods.back().depends.insert("pipeworks");
+	mods.back().depends.insert("mesecons");
 
 	mods.emplace_back(ModSpec("circ_1"));
-	mods[mods.size() - 1].depends.insert("default");
-	mods[mods.size() - 1].optdepends.insert("circ_2");
+	mods.back().depends.insert("default");
+	mods.back().optdepends.insert("circ_2");
 
 	mods.emplace_back(ModSpec("circ_2"));
-	mods[mods.size() - 1].depends.insert("circ_3");
+	mods.back().depends.insert("circ_3");
 	mods.emplace_back(ModSpec("circ_3"));
-	mods[mods.size() - 1].depends.insert("circ_1");
+	mods.back().depends.insert("circ_1");
 
 	mc.addMods(mods);
 	mc.resolveDependencies();


### PR DESCRIPTION
Revival of #8603 because GitHub does not want to track branches that were `git reset --hard`'d.

Fixes #8601 and #9977 **but** breaks mods that rely on the current, undefined mod loading order. Please confirm that resulting mod errors are not caused by the different loading order.

## How it works
_Documentation in the code™_
There is now a new list to determinate how many mods depend on the mod:
   * deps_chain: Contains all mod names which either need or may need the mod

1) Dependencies are read from the mod's config
2) Each mod adds its own name recursively to the dependency list of each dependent mod
3) If a hard-dependency cannot be matched, the mod is not loaded (same as before)
4) If a recursion is detected, all affected mods will be loaded as long it's logically possible (i.e. enough optional dependencies)
5) Sort the final list: Sort the `ModSpec`s according to the amount of mods depending on this mod
6) Load the mods

## To do

Ready for review.

## How to test

1) Download [`mod_sorting_pack.zip`](https://github.com/minetest/minetest/files/3293490/mod_sorting_pack.zip)
2) Enable all mods inside the "Mod sorting modpack"
3) `debug_log_level = verbose`
4) Join a world
5) Confirm `Sorted mod: ` and `Loading and running script from` outputs (`grep` is your friend)
6) Test with your own complicated dependency issues, such as MineClone2 + unified_inventory
7) Run the unittests, because why not.