### PR TITLE
Player death: Fix item duplication

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1828,7 +1828,7 @@ void GenericCAO::processMessage(const std::string &data)
 		}
 
 		if (m_hp == 0) {
-			// Same as 'Server::DiePlayer'
+			// Same as 'Server::SendPlayerDie'
 			clearParentAttachment();
 			// Same as 'ObjectRef::l_remove'
 			if (!m_is_player)

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -429,13 +429,24 @@ void ScriptApiBase::pushPlayerHPChangeReason(lua_State *L, const PlayerHPChangeR
 	lua_setfield(L, -2, "from");
 
 	if (reason.object) {
-		objectrefGetOrCreate(L, reason.object);
+		objectrefGetOrCreate(L, getServer()->getEnv().getActiveObject(reason.object));
 		lua_setfield(L, -2, "object");
 	}
 	if (!reason.node.empty()) {
 		lua_pushstring(L, reason.node.c_str());
 		lua_setfield(L, -2, "node");
 	}
+}
+
+void ScriptApiBase::popPlayerHPChangeReason(PlayerHPChangeReason &reason)
+{
+	if (!reason.hasLuaReference())
+		return;
+
+	SCRIPTAPI_PRECHECKHEADER
+
+	luaL_unref(L, LUA_REGISTRYINDEX, reason.lua_reference);
+	reason.lua_reference = -1;
 }
 
 Server* ScriptApiBase::getServer()

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -99,6 +99,7 @@ public:
 	/* object */
 	void addObjectReference(ServerActiveObject *cobj);
 	void removeObjectReference(ServerActiveObject *cobj);
+	void popPlayerHPChangeReason(PlayerHPChangeReason &reason);
 
 	IGameDef *getGameDef() { return m_gamedef; }
 	Server* getServer();
@@ -144,7 +145,7 @@ protected:
 
 	void objectrefGetOrCreate(lua_State *L, ServerActiveObject *cobj);
 
-	void pushPlayerHPChangeReason(lua_State *L, const PlayerHPChangeReason& reason);
+	void pushPlayerHPChangeReason(lua_State *L, const PlayerHPChangeReason &reason);
 
 	std::recursive_mutex m_luastackmutex;
 	std::string     m_last_run_mod;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -222,8 +222,7 @@ int ObjectRef::l_set_hp(lua_State *L)
 	}
 
 	sao->setHP(hp, reason);
-	if (reason.hasLuaReference())
-		luaL_unref(L, LUA_REGISTRYINDEX, reason.lua_reference);
+	getScriptApiBase(L)->popPlayerHPChangeReason(reason);
 	return 0;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -341,7 +341,8 @@ public:
 
 	void printToConsoleOnly(const std::string &text);
 
-	void SendPlayerHPOrDie(PlayerSAO *player, const PlayerHPChangeReason &reason);
+	void SendPlayerHP(session_t peer_id);
+	void SendPlayerDie(session_t peer_id, PlayerHPChangeReason &reason);
 	void SendPlayerBreath(PlayerSAO *sao);
 	void SendInventory(PlayerSAO *playerSAO, bool incremental);
 	void SendMovePlayer(session_t peer_id);
@@ -415,7 +416,6 @@ private:
 
 	virtual void SendChatMessage(session_t peer_id, const ChatMessage &message);
 	void SendTimeOfDay(session_t peer_id, u16 time, f32 time_speed);
-	void SendPlayerHP(session_t peer_id);
 
 	void SendLocalPlayerAnimations(session_t peer_id, v2s32 animation_frames[4],
 		f32 animation_speed);
@@ -486,7 +486,6 @@ private:
 		Something random
 	*/
 
-	void DiePlayer(session_t peer_id, const PlayerHPChangeReason &reason);
 	void RespawnPlayer(session_t peer_id);
 	void DeleteClient(session_t peer_id, ClientDeletionReason reason);
 	void UpdateCrafting(RemotePlayer *player);

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -328,8 +328,8 @@ u16 LuaEntitySAO::punch(v3f dir,
 
 	if (!damage_handled) {
 		if (result.did_punch) {
-			setHP((s32)getHP() - result.damage,
-				PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, puncher));
+			PlayerHPChangeReason reason(PlayerHPChangeReason::PLAYER_PUNCH, puncher);
+			setHP((s32)getHP() - result.damage, reason);
 
 			// create message and add to list
 			sendPunchCommand();
@@ -392,7 +392,7 @@ std::string LuaEntitySAO::getDescription()
 	return oss.str();
 }
 
-void LuaEntitySAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
+void LuaEntitySAO::setHP(s32 hp, PlayerHPChangeReason &reason)
 {
 	m_hp = rangelim(hp, 0, U16_MAX);
 }

--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -52,7 +52,7 @@ public:
 	void moveTo(v3f pos, bool continuous);
 	float getMinimumSavedMovement();
 	std::string getDescription();
-	void setHP(s32 hp, const PlayerHPChangeReason &reason);
+	void setHP(s32 hp, PlayerHPChangeReason &reason);
 	u16 getHP() const;
 
 	/* LuaEntitySAO-specific */

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -204,6 +204,7 @@ private:
 	IntervalLimiter m_node_hurt_interval;
 
 	bool m_position_not_sent = false;
+	PlayerHPChangeReason *m_death_reason = nullptr;
 
 	// Cached privileges for enforcement
 	std::set<std::string> m_privs;

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -112,7 +112,7 @@ public:
 	u16 punch(v3f dir, const ToolCapabilities *toolcap, ServerActiveObject *puncher,
 			float time_from_last_punch);
 	void rightClick(ServerActiveObject *clicker);
-	void setHP(s32 hp, const PlayerHPChangeReason &reason);
+	void setHP(s32 hp, PlayerHPChangeReason &reason);
 	void setHPRaw(u16 hp) { m_hp = hp; }
 	u16 getBreath() const { return m_breath; }
 	void setBreath(const u16 breath, bool send = true);
@@ -244,7 +244,7 @@ struct PlayerHPChangeReason
 	int lua_reference = -1;
 
 	// For PLAYER_PUNCH
-	ServerActiveObject *object = nullptr;
+	u16 object = 0;
 	// For NODE_DAMAGE
 	std::string node;
 
@@ -293,7 +293,7 @@ struct PlayerHPChangeReason
 	PlayerHPChangeReason(Type type) : type(type) {}
 
 	PlayerHPChangeReason(Type type, ServerActiveObject *object) :
-			type(type), object(object)
+			type(type), object(object->getId())
 	{
 	}
 

--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -153,7 +153,7 @@ public:
 	{ return 0; }
 	virtual void rightClick(ServerActiveObject *clicker)
 	{}
-	virtual void setHP(s32 hp, const PlayerHPChangeReason &reason)
+	virtual void setHP(s32 hp, PlayerHPChangeReason &reason)
 	{}
 	virtual u16 getHP() const
 	{ return 0; }


### PR DESCRIPTION
Fixes #6546 by delaying the death message to the next server tick. This allows proper callback return value handling. For example, killing a player in `on_use` would cause duplication issues due to interleaved callback handling.

## To do

This PR is Ready for Review.


## How to test

```Lua
minetest.register_on_punchplayer(function(player)
	--player:set_hp(player:get_hp() - 1)
	return false
end)

minetest.register_on_dieplayer(function(player, reason)
	print("on_dieplayer", dump(reason))
end)

minetest.register_on_player_hpchange(function(player, hp_change, reason)
	print("on_player_hpchange", hp_change, dump(reason))
end, false)

minetest.register_craftitem(":danger_noodle", {
	inventory_image = "default_stick.png",
	description = "DANGER NOODLE",
	on_use = function(itemstack, user, pointed_thing)
		if pointed_thing.ref then
			pointed_thing.ref:set_hp(-69, { totally_rigged = false })
		else
			user:set_hp(-69, { totally_rigged = true })
		end
		itemstack:take_item()
		return itemstack
	end
})
```

1. `devtest_unittests_autostart = true`
2. Join devtest. The tests must pass.
3. Ensure the death callback is only run once
4. Ensure the death reason is correct
5. Kill a player, shut down the server before revival. On restart, the player must be greeted with a death screen.
6. ???
7. The danger noodle item stack must decrease after each use; especially when not pointing at any other object
