### PR TITLE
Fix documented default colors for set_sky

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6621,9 +6621,9 @@ object you are working with still exists.
         * `clouds`: Boolean for whether clouds appear. (default: `true`)
         * `sky_color`: A table containing the following values, alpha is ignored:
             * `day_sky`: ColorSpec, for the top half of the `"regular"`
-              sky during the day. (default: `#8cbafa`)
+              sky during the day. (default: `#61b5f5`)
             * `day_horizon`: ColorSpec, for the bottom half of the
-              `"regular"` sky during the day. (default: `#9bc1f0`)
+              `"regular"` sky during the day. (default: `#90d3f6`)
             * `dawn_sky`: ColorSpec, for the top half of the `"regular"`
               sky during dawn/sunset. (default: `#b4bafa`)
               The resulting sky color will be a darkened version of the ColorSpec.
@@ -6633,7 +6633,7 @@ object you are working with still exists.
               The resulting sky color will be a darkened version of the ColorSpec.
               Warning: The darkening of the ColorSpec is subject to change.
             * `night_sky`: ColorSpec, for the top half of the `"regular"`
-              sky during the night. (default: `#006aff`)
+              sky during the night. (default: `#006bff`)
               The resulting sky color will be a dark version of the ColorSpec.
               Warning: The darkening of the ColorSpec is subject to change.
             * `night_horizon`: ColorSpec, for the bottom half of the `"regular"`


### PR DESCRIPTION
The default sky colors were modified in #9502, but the corresponding documentation was not updated.  Additionally, `night_sky` was never correctly documented. Judging by the error, it was probably a typo. This rather trivial documentation fix updates the values to be correct. The new values have been verified in-game using `get_sky_colors`.

Alternatively, we _could_ remove the defaults and let modders find them via `get_sky_colors` but since they're already here and unlikely to change regularly I see no harm in letting them remain (as long as they're correct).