### PR TITLE
Add macOS workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ on:
       - '.github/workflows/macos.yml'
 
 env:
-  IRRLICHT_TAG: 1.9.0mt1
+  IRRLICHT_TAG: 1.9.0mt2
   MINETEST_GAME_REPO: https://github.com/minetest/minetest_game.git
   MINETEST_GAME_BRANCH: master
   MINETEST_GAME_NAME: minetest_game
@@ -44,11 +44,7 @@ jobs:
         run: |
           git clone -b $MINETEST_GAME_BRANCH $MINETEST_GAME_REPO games/$MINETEST_GAME_NAME
           rm -rvf games/$MINETEST_GAME_NAME/.git
-          git clone -b $IRRLICHT_TAG https://github.com/minetest/irrlicht
-          cd irrlicht
-          cmake . -DBUILD_SHARED_LIBS=OFF -DCMAKE_FIND_FRAMEWORK=LAST
-          make -j2
-          cd ..
+          git clone https://github.com/minetest/irrlicht -b $IRRLICHT_TAG lib/irrlichtmt
           mkdir cmakebuild
           cd cmakebuild
           cmake \
@@ -61,8 +57,6 @@ jobs:
             -DENABLE_GETTEXT=TRUE \
             -DBUILD_CLIENT=TRUE \
             -DBUILD_SERVER=FALSE \
-            -DIRRLICHT_LIBRARY=$PWD/../irrlicht/lib/OSX/libIrrlichtMt.a \
-            -DIRRLICHT_INCLUDE_DIR=$PWD/../irrlicht/include \
             ..
           make -j2
           make install

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -47,17 +47,12 @@ jobs:
           git clone https://github.com/minetest/irrlicht -b $IRRLICHT_TAG lib/irrlichtmt
           mkdir cmakebuild
           cd cmakebuild
-          cmake \
+          cmake .. \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
             -DCMAKE_FIND_FRAMEWORK=LAST \
             -DCMAKE_INSTALL_PREFIX=../build/macos/ \
-            -DCMAKE_BUILD_TYPE=Release \
             -DRUN_IN_PLACE=FALSE \
-            -DENABLE_FREETYPE=TRUE \
-            -DENABLE_GETTEXT=TRUE \
-            -DBUILD_CLIENT=TRUE \
-            -DBUILD_SERVER=FALSE \
-            ..
+            -DENABLE_FREETYPE=TRUE -DENABLE_GETTEXT=TRUE
           make -j2
           make install
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -67,6 +67,10 @@ jobs:
           make -j2
           make install
 
+      - name: Test
+        run: |
+          ./build/macos/minetest.app/Contents/MacOS/minetest --run-unittests
+
       - uses: actions/upload-artifact@v2
         with:
           name: minetest-macos

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,73 @@
+name: macos
+
+# build on c/cpp changes or workflow changes
+on:
+  push:
+    paths:
+      - 'lib/**.[ch]'
+      - 'lib/**.cpp'
+      - 'src/**.[ch]'
+      - 'src/**.cpp'
+      - '**/CMakeLists.txt'
+      - 'cmake/Modules/**'
+      - '.github/workflows/macos.yml'
+  pull_request:
+    paths:
+      - 'lib/**.[ch]'
+      - 'lib/**.cpp'
+      - 'src/**.[ch]'
+      - 'src/**.cpp'
+      - '**/CMakeLists.txt'
+      - 'cmake/Modules/**'
+      - '.github/workflows/macos.yml'
+
+env:
+  IRRLICHT_TAG: 1.9.0mt1
+  MINETEST_GAME_REPO: https://github.com/minetest/minetest_game.git
+  MINETEST_GAME_BRANCH: master
+  MINETEST_GAME_NAME: minetest_game
+
+jobs:
+  build:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install deps
+        run: |
+          pkgs=(cmake freetype gettext gmp hiredis jpeg jsoncpp leveldb libogg libpng libvorbis luajit)
+          brew update
+          brew install ${pkgs[@]}
+          brew unlink $(brew ls --formula)
+          brew link ${pkgs[@]}
+
+      - name: Build
+        run: |
+          git clone -b $MINETEST_GAME_BRANCH $MINETEST_GAME_REPO games/$MINETEST_GAME_NAME
+          rm -rvf games/$MINETEST_GAME_NAME/.git
+          git clone -b $IRRLICHT_TAG https://github.com/minetest/irrlicht
+          cd irrlicht
+          cmake . -DBUILD_SHARED_LIBS=OFF -DCMAKE_FIND_FRAMEWORK=LAST
+          make -j2
+          cd ..
+          mkdir cmakebuild
+          cd cmakebuild
+          cmake \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
+            -DCMAKE_FIND_FRAMEWORK=LAST \
+            -DCMAKE_INSTALL_PREFIX=../build/macos/ \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DRUN_IN_PLACE=FALSE \
+            -DENABLE_FREETYPE=TRUE \
+            -DENABLE_GETTEXT=TRUE \
+            -DBUILD_CLIENT=TRUE \
+            -DBUILD_SERVER=FALSE \
+            -DIRRLICHT_LIBRARY=$PWD/../irrlicht/lib/OSX/libIrrlichtMt.a \
+            -DIRRLICHT_INCLUDE_DIR=$PWD/../irrlicht/include \
+            ..
+          make -j2
+          make install
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: minetest-macos
+          path: ./build/macos/


### PR DESCRIPTION
## Goal of the PR

This PR adds a GitHub Actions workflow that builds a macOS app which is uploaded as a workflow artifact. This, in turn, can be used to provide macOS downloads at https://github.com/minetest/minetest/releases.

## How does the PR work?

The `macos.yml` workflow is similar to `build.yml` and `android.yml`, but for macOS, and it runs on a `macos-10.15` runner provided by GitHub.

The environment variable `IRRLICHT_TAG` allows for easy updates of IrrlichtMt. The variable `MINETEST_GAME_BRANCH` ideally would be edited in the `stable-5` branch to be the latest stable version of minetest_game.

## Does it resolve any reported issue?

This is somewhat related to #11233.

The `minetest` formula in Homebrew builds a `.app`, but [the Homebrew documentation specifically states that a formula should _not_ build a `.app`](https://docs.brew.sh/Acceptable-Formulae#stuff-that-builds-an-app). Instead, the Minetest project should build a `.app` using e.g. GitHub Actions and distribute it through homebrew/cask.

This will have the added benefit of installing `Minetest.app` directly into `/Applications` when doing <code>brew&nbsp;install&nbsp;minetest</code>. In contrast, the current `minetest` formula installs `minetest.app` in `/usr/local/Cellar/minetest/<version>`, which isn't ideal.

## Does this relate to a goal in [the roadmap](../doc/direction.md)?

No

## If not a bug fix, why is this PR needed? What usecases does it solve?

As stated above, macOS apps should be installed in `/Applications`. This PR would be the first of several steps to migrate the `minetest` formula from homebrew/core to homebrew/cask.

## To do

This PR is Ready for Review.

## How to test

An example artifact (named `minetest-macos`) can be found here: https://github.com/FnControlOption/minetest/actions/runs/1031732133#artifacts
