### PR TITLE
Add many limits to settingtypes

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -794,7 +794,7 @@ desynchronize_mapblock_texture_animation (Desynchronize block animation) bool tr
 hud_hotbar_max_width (Maximum hotbar width) float 1.0 0.001 1.0
 
 #    Modifies the size of the HUD elements.
-hud_scaling (HUD scale factor) float 1.0 0.1
+hud_scaling (HUD scale factor) float 1.0 0.5 20
 
 #    Enables caching of facedir rotated meshes.
 enable_mesh_cache (Mesh cache) bool false
@@ -867,7 +867,7 @@ menu_clouds (Clouds in menu) bool true
 #    This will smooth over some of the rough edges, and blend
 #    pixels when scaling down, at the cost of blurring some
 #    edge pixels when images are scaled by non-integer sizes.
-gui_scaling (GUI scaling) float 1.0 0.5
+gui_scaling (GUI scaling) float 1.0 0.5 20
 
 #    When gui_scaling_filter is true, all GUI images need to be
 #    filtered in software, but some images are generated directly

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -97,7 +97,7 @@ cinematic_camera_smoothing (Camera smoothing in cinematic mode) float 0.7 0.0 0.
 invert_mouse (Invert mouse) bool false
 
 #    Mouse sensitivity multiplier.
-mouse_sensitivity (Mouse sensitivity) float 0.2
+mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
 
 #    If enabled, "Aux1" key instead of "Sneak" key is used for climbing down and
 #    descending.
@@ -139,11 +139,11 @@ fixed_virtual_joystick (Fixed virtual joystick) bool false
 #    If enabled, virtual joystick will also tap "Aux1" button when out of main circle.
 virtual_joystick_triggers_aux1 (Virtual joystick triggers Aux1 button) bool false
 
-#    Enable joysticks
+#    Enable joysticks. Requires a restart to take effect
 enable_joysticks (Enable joysticks) bool false
 
 #    The identifier of the joystick to use
-joystick_id (Joystick ID) int 0
+joystick_id (Joystick ID) int 0 0 255
 
 #    The type of joystick
 joystick_type (Joystick type) enum auto auto,generic,xbox,dragonrise_gamecube
@@ -153,11 +153,11 @@ joystick_type (Joystick type) enum auto auto,generic,xbox,dragonrise_gamecube
 repeat_joystick_button_time (Joystick button repetition interval) float 0.17 0.001
 
 #    The dead zone of the joystick
-joystick_deadzone (Joystick dead zone) int 2048
+joystick_deadzone (Joystick dead zone) int 2048 0 65535
 
 #    The sensitivity of the joystick axes for moving the
 #    in-game view frustum around.
-joystick_frustum_sensitivity (Joystick frustum sensitivity) float 170
+joystick_frustum_sensitivity (Joystick frustum sensitivity) float 170.0 0.001
 
 #    Key for moving the player forward.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
@@ -521,7 +521,7 @@ texture_clean_transparent (Clean transparent textures) bool false
 #    bilinear/trilinear/anisotropic filtering is enabled.
 #    This is also used as the base node texture size for world-aligned
 #    texture autoscaling.
-texture_min_size (Minimum texture size) int 64
+texture_min_size (Minimum texture size) int 64 1 32768
 
 #    Use multi-sample antialiasing (MSAA) to smooth out block edges.
 #    This algorithm smooths out the 3D viewport while keeping the image sharp,
@@ -646,10 +646,10 @@ arm_inertia (Arm inertia) bool true
 
 #    If FPS would go higher than this, limit it by sleeping
 #    to not waste CPU power for no benefit.
-fps_max (Maximum FPS) int 60 1
+fps_max (Maximum FPS) int 60 1 4294967295
 
 #    Maximum FPS when the window is not focused, or when the game is paused.
-fps_max_unfocused (FPS when unfocused or paused) int 20 1
+fps_max_unfocused (FPS when unfocused or paused) int 20 1 4294967295
 
 #    Open the pause menu when the window's focus is lost. Does not pause if a formspec is
 #    open.
@@ -665,10 +665,10 @@ viewing_range (Viewing range) int 190 20 4000
 near_plane (Near plane) float 0.1 0 0.25
 
 #    Width component of the initial window size. Ignored in fullscreen mode.
-screen_w (Screen width) int 1024 1
+screen_w (Screen width) int 1024 1 65535
 
 #    Height component of the initial window size. Ignored in fullscreen mode.
-screen_h (Screen height) int 600 1
+screen_h (Screen height) int 600 1 65535
 
 #    Save window size automatically when modified.
 autosave_screensize (Autosave screen size) bool true
@@ -723,15 +723,15 @@ video_driver (Video driver) enum opengl opengl,ogles1,ogles2
 
 #    Radius of cloud area stated in number of 64 node cloud squares.
 #    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.
-cloud_radius (Cloud radius) int 12
+cloud_radius (Cloud radius) int 12 1 62
 
 #    Enable view bobbing and amount of view bobbing.
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
-view_bobbing_amount (View bobbing factor) float 1.0
+view_bobbing_amount (View bobbing factor) float 1.0 0.0 7.9
 
 #    Multiplier for fall bobbing.
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
-fall_bobbing_amount (Fall bobbing factor) float 0.03
+fall_bobbing_amount (Fall bobbing factor) float 0.03 0.0
 
 #    3D support.
 #    Currently supported:
@@ -746,7 +746,7 @@ fall_bobbing_amount (Fall bobbing factor) float 0.03
 3d_mode (3D mode) enum none none,anaglyph,interlaced,topbottom,sidebyside,crossview,pageflip
 
 #    Strength of 3D mode parallax.
-3d_paralax_strength (3D mode parallax strength) float 0.025
+3d_paralax_strength (3D mode parallax strength) float 0.025 -0.087 0.087
 
 #    In-game chat console height, between 0.1 (10%) and 1.0 (100%).
 console_height (Console height) float 0.6 0.1 1.0
@@ -791,10 +791,10 @@ desynchronize_mapblock_texture_animation (Desynchronize block animation) bool tr
 
 #    Maximum proportion of current window to be used for hotbar.
 #    Useful if there's something to be displayed right or left of hotbar.
-hud_hotbar_max_width (Maximum hotbar width) float 1.0
+hud_hotbar_max_width (Maximum hotbar width) float 1.0 0.001 1.0
 
 #    Modifies the size of the HUD elements.
-hud_scaling (HUD scale factor) float 1.0
+hud_scaling (HUD scale factor) float 1.0 0.1
 
 #    Enables caching of facedir rotated meshes.
 enable_mesh_cache (Mesh cache) bool false
@@ -867,7 +867,7 @@ menu_clouds (Clouds in menu) bool true
 #    This will smooth over some of the rough edges, and blend
 #    pixels when scaling down, at the cost of blurring some
 #    edge pixels when images are scaled by non-integer sizes.
-gui_scaling (GUI scaling) float 1.0 0.001
+gui_scaling (GUI scaling) float 1.0 0.5
 
 #    When gui_scaling_filter is true, all GUI images need to be
 #    filtered in software, but some images are generated directly
@@ -881,7 +881,7 @@ gui_scaling_filter (GUI scaling filter) bool false
 gui_scaling_filter_txr2img (GUI scaling filter txr2img) bool true
 
 #    Delay showing tooltips, stated in milliseconds.
-tooltip_show_delay (Tooltip delay) int 400
+tooltip_show_delay (Tooltip delay) int 400 0 18446744073709551615
 
 #    Append item name to tooltip.
 tooltip_append_itemname (Append item name) bool false
@@ -891,13 +891,13 @@ font_bold (Font bold by default) bool false
 font_italic (Font italic by default) bool false
 
 #    Shadow offset (in pixels) of the default font. If 0, then shadow will not be drawn.
-font_shadow (Font shadow) int 1
+font_shadow (Font shadow) int 1 0 65535
 
 #    Opaqueness (alpha) of the shadow behind the default font, between 0 and 255.
 font_shadow_alpha (Font shadow alpha) int 127 0 255
 
 #    Font size of the default font where 1 unit = 1 pixel at 96 DPI
-font_size (Font size) int 16 1
+font_size (Font size) int 16 5 72
 
 #    For pixel-style fonts that do not scale well, this ensures that font sizes used
 #    with this font will always be divisible by this value, in pixels. For instance,
@@ -914,7 +914,7 @@ font_path_italic (Italic font path) filepath fonts/Arimo-Italic.ttf
 font_path_bold_italic (Bold and italic font path) filepath fonts/Arimo-BoldItalic.ttf
 
 #    Font size of the monospace font where 1 unit = 1 pixel at 96 DPI
-mono_font_size (Monospace font size) int 16 1
+mono_font_size (Monospace font size) int 16 5 72
 
 #    For pixel-style fonts that do not scale well, this ensures that font sizes used
 #    with this font will always be divisible by this value, in pixels. For instance,
@@ -936,7 +936,7 @@ fallback_font_path (Fallback font path) filepath fonts/DroidSansFallbackFull.ttf
 
 #    Font size of the recent chat text and chat prompt in point (pt).
 #    Value 0 will use the default font size.
-chat_font_size (Chat font size) int 0
+chat_font_size (Chat font size) int 0 0 72
 
 #    Path to save screenshots at. Can be an absolute or relative path.
 #    The folder will be created if it doesn't already exist.
@@ -1026,7 +1026,7 @@ serverlist_file (Serverlist file) string favoriteservers.json
 
 #    Maximum size of the out chat queue.
 #    0 to disable queueing and -1 to make the queue size unlimited.
-max_out_chat_queue_size (Maximum size of the out chat queue) int 20
+max_out_chat_queue_size (Maximum size of the out chat queue) int 20 -1 32767
 
 #    Enable register confirmation when connecting to server.
 #    If disabled, new account will be registered automatically.
@@ -1034,12 +1034,12 @@ enable_register_confirmation (Enable register confirmation) bool true
 
 [*Advanced]
 
-#    Timeout for client to remove unused map data from memory.
-client_unload_unused_data_timeout (Mapblock unload timeout) int 600
+#    Timeout for client to remove unused map data from memory, in seconds.
+client_unload_unused_data_timeout (Mapblock unload timeout) float 600.0 0.0
 
 #    Maximum number of mapblocks for client to be kept in memory.
 #    Set to -1 for unlimited amount.
-client_mapblock_limit (Mapblock limit) int 7500
+client_mapblock_limit (Mapblock limit) int 7500 -1 2147483647
 
 #    Whether to show the client debug info (has the same effect as hitting F5).
 show_debug (Show debug info) bool false
@@ -1072,7 +1072,7 @@ strip_color_codes (Strip color codes) bool false
 
 #    Network port to listen (UDP).
 #    This value will be overridden when starting from the main menu.
-port (Server port) int 30000
+port (Server port) int 30000 1 65535
 
 #    The network interface that the server listens on.
 bind_address (Bind address) string
@@ -1098,16 +1098,16 @@ ipv6_server (IPv6 server) bool false
 #    Maximum number of blocks that are simultaneously sent per client.
 #    The maximum total count is calculated dynamically:
 #    max_total = ceil((#clients + max_users) * per_client / 4)
-max_simultaneous_block_sends_per_client (Maximum simultaneous block sends per client) int 40
+max_simultaneous_block_sends_per_client (Maximum simultaneous block sends per client) int 40 1 4294967295
 
 #    To reduce lag, block transfers are slowed down when a player is building something.
 #    This determines how long they are slowed down after placing or removing a node.
-full_block_send_enable_min_time_from_building (Delay in sending blocks after building) float 2.0
+full_block_send_enable_min_time_from_building (Delay in sending blocks after building) float 2.0 0.0
 
 #    Maximum number of packets sent per send step, if you have a slow connection
 #    try reducing it, but don't reduce it to a number below double of targeted
 #    client number.
-max_packets_per_iteration (Max. packets per iteration) int 1024
+max_packets_per_iteration (Max. packets per iteration) int 1024 1 65535
 
 #    Compression level to use when sending mapblocks to the client.
 #    -1 - use default compression level
@@ -1125,7 +1125,7 @@ default_game (Default game) string minetest
 motd (Message of the day) string
 
 #    Maximum number of players that can be connected simultaneously.
-max_users (Maximum users) int 15
+max_users (Maximum users) int 15 0 65535
 
 #    World directory (everything in the world is stored here).
 #    Not needed if starting from the main menu.
@@ -1133,11 +1133,11 @@ map-dir (Map directory) path
 
 #    Time in seconds for item entity (dropped items) to live.
 #    Setting it to -1 disables the feature.
-item_entity_ttl (Item entity TTL) int 900
+item_entity_ttl (Item entity TTL) int 900 -1
 
 #    Specifies the default stack size of nodes, items and tools.
 #    Note that mods or games may explicitly set a stack for certain (or all) items.
-default_stack_max (Default stack size) int 99
+default_stack_max (Default stack size) int 99 1 65535
 
 #    Enable players getting damage and dying.
 enable_damage (Damage) bool false
@@ -1164,7 +1164,7 @@ basic_privs (Basic privileges) string interact, shout
 unlimited_player_transfer_distance (Unlimited player transfer distance) bool true
 
 #    Defines the maximal player transfer distance in blocks (0 = unlimited).
-player_transfer_distance (Player transfer distance) int 0
+player_transfer_distance (Player transfer distance) int 0 0 65535
 
 #    Whether to allow players to damage and kill each other.
 enable_pvp (Player versus player) bool true
@@ -1191,7 +1191,7 @@ chat_message_format (Chat message format) string <@name> @message
 
 #    If the execution of a chat command takes longer than this specified time in
 #    seconds, add the time information to the chat command message
-chatcommand_msg_time_threshold (Chat command time message threshold) float 0.1
+chatcommand_msg_time_threshold (Chat command time message threshold) float 0.1 0.0
 
 #    A message to be displayed to all clients when the server shuts down.
 kick_msg_shutdown (Shutdown message) string Server shutting down.
@@ -1208,82 +1208,84 @@ ask_reconnect_on_crash (Ask to reconnect after crash) bool false
 #    Setting this larger than active_block_range will also cause the server
 #    to maintain active objects up to this distance in the direction the
 #    player is looking. (This can avoid mobs suddenly disappearing from view)
-active_object_send_range_blocks (Active object send range) int 8
+active_object_send_range_blocks (Active object send range) int 8 1 65535
 
 #    The radius of the volume of blocks around every player that is subject to the
 #    active block stuff, stated in mapblocks (16 nodes).
 #    In active blocks objects are loaded and ABMs run.
 #    This is also the minimum range in which active objects (mobs) are maintained.
 #    This should be configured together with active_object_send_range_blocks.
-active_block_range (Active block range) int 4
+active_block_range (Active block range) int 4 1 65535
 
 #    From how far blocks are sent to clients, stated in mapblocks (16 nodes).
-max_block_send_distance (Max block send distance) int 12
+max_block_send_distance (Max block send distance) int 12 1 65535
 
 #    Maximum number of forceloaded mapblocks.
-max_forceloaded_blocks (Maximum forceloaded blocks) int 16
+max_forceloaded_blocks (Maximum forceloaded blocks) int 16 0
 
-#    Interval of sending time of day to clients.
-time_send_interval (Time send interval) int 5
+#    Interval of sending time of day to clients, stated in seconds.
+time_send_interval (Time send interval) float 5.0 0.001
 
 #    Controls length of day/night cycle.
 #    Examples:
 #    72 = 20min, 360 = 4min, 1 = 24hour, 0 = day/night/whatever stays unchanged.
-time_speed (Time speed) int 72
+time_speed (Time speed) int 72 0
 
 #    Time of day when a new world is started, in millihours (0-23999).
 world_start_time (World start time) int 6125 0 23999
 
 #    Interval of saving important changes in the world, stated in seconds.
-server_map_save_interval (Map save interval) float 5.3
+server_map_save_interval (Map save interval) float 5.3 0.001
 
-#    Set the maximum character length of a chat message sent by clients.
-chat_message_max_size (Chat message max length) int 500
+#    Set the maximum length of a chat message (in characters) sent by clients.
+chat_message_max_size (Chat message max length) int 500 10 65535
 
 #    Amount of messages a player may send per 10 seconds.
-chat_message_limit_per_10sec (Chat message count limit) float 10.0
+chat_message_limit_per_10sec (Chat message count limit) float 10.0 1.0
 
 #    Kick players who sent more than X messages per 10 seconds.
-chat_message_limit_trigger_kick (Chat message kick threshold) int 50
+chat_message_limit_trigger_kick (Chat message kick threshold) int 50 1 65535
 
 [**Physics]
 
 #    Horizontal and vertical acceleration on ground or when climbing,
 #    in nodes per second per second.
-movement_acceleration_default (Default acceleration) float 3
+movement_acceleration_default (Default acceleration) float 3.0 0.0
 
 #    Horizontal acceleration in air when jumping or falling,
 #    in nodes per second per second.
-movement_acceleration_air (Acceleration in air) float 2
+movement_acceleration_air (Acceleration in air) float 2.0 0.0
 
 #    Horizontal and vertical acceleration in fast mode,
 #    in nodes per second per second.
-movement_acceleration_fast (Fast mode acceleration) float 10
+movement_acceleration_fast (Fast mode acceleration) float 10.0 0.0
 
 #    Walking and flying speed, in nodes per second.
-movement_speed_walk (Walking speed) float 4
+movement_speed_walk (Walking speed) float 4.0 0.0
 
 #    Sneaking speed, in nodes per second.
-movement_speed_crouch (Sneaking speed) float 1.35
+movement_speed_crouch (Sneaking speed) float 1.35 0.0
 
 #    Walking, flying and climbing speed in fast mode, in nodes per second.
-movement_speed_fast (Fast mode speed) float 20
+movement_speed_fast (Fast mode speed) float 20.0 0.0
 
 #    Vertical climbing speed, in nodes per second.
-movement_speed_climb (Climbing speed) float 3
+movement_speed_climb (Climbing speed) float 3.0 0.0
 
 #    Initial vertical speed when jumping, in nodes per second.
-movement_speed_jump (Jumping speed) float 6.5
+movement_speed_jump (Jumping speed) float 6.5 0.0
 
+#    How much you are slowed down when moving inside a liquid.
 #    Decrease this to increase liquid resistance to movement.
-movement_liquid_fluidity (Liquid fluidity) float 1
+movement_liquid_fluidity (Liquid fluidity) float 1.0 0.001
 
 #    Maximum liquid resistance. Controls deceleration when entering liquid at
 #    high speed.
 movement_liquid_fluidity_smooth (Liquid fluidity smoothing) float 0.5
 
-#    Controls sinking speed in liquid.
-movement_liquid_sink (Liquid sinking) float 10
+#    Controls sinking speed in liquid when idling. Negative values will cause
+#    you to rise instead.
+movement_liquid_sink (Liquid sinking) float 10.0
 
 #    Acceleration of gravity, in nodes per second per second.
 movement_gravity (Gravity) float 9.81
@@ -1299,14 +1301,14 @@ deprecated_lua_api_handling (Deprecated Lua API handling) enum log none,log,erro
 #    Number of extra blocks that can be loaded by /clearobjects at once.
 #    This is a trade-off between SQLite transaction overhead and
 #    memory consumption (4096=100MB, as a rule of thumb).
-max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096
+max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096 0 4294967295
 
-#    How much the server will wait before unloading unused mapblocks.
+#    How long the server will wait before unloading unused mapblocks, stated in seconds.
 #    Higher value is smoother, but will use more RAM.
-server_unload_unused_data_timeout (Unload unused server data) int 29
+server_unload_unused_data_timeout (Unload unused server data) int 29 0 4294967295
 
 #    Maximum number of statically stored objects in a block.
-max_objects_per_block (Maximum objects per block) int 256
+max_objects_per_block (Maximum objects per block) int 256 1 65535
 
 #    See https://www.sqlite.org/pragma.html#pragma_synchronous
 sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2
@@ -1318,36 +1320,36 @@ sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2
 map_compression_level_disk (Map Compression Level for Disk Storage) int -1 -1 9
 
 #    Length of a server tick and the interval at which objects are generally updated over
-#    network.
-dedicated_server_step (Dedicated server step) float 0.09
+#    network, stated in seconds.
+dedicated_server_step (Dedicated server step) float 0.09 0.0
 
-#    Length of time between active block management cycles
-active_block_mgmt_interval (Active block management interval) float 2.0
+#    Length of time between active block management cycles, stated in seconds
+active_block_mgmt_interval (Active block management interval) float 2.0 0.0
 
-#    Length of time between Active Block Modifier (ABM) execution cycles
-abm_interval (ABM interval) float 1.0
+#    Length of time between Active Block Modifier (ABM) execution cycles, stated in seconds
+abm_interval (ABM interval) float 1.0 0.0
 
 #    The time budget allowed for ABMs to execute on each step
 #    (as a fraction of the ABM Interval)
 abm_time_budget (ABM time budget) float 0.2 0.1 0.9
 
-#    Length of time between NodeTimer execution cycles
-nodetimer_interval (NodeTimer interval) float 0.2
+#    Length of time between NodeTimer execution cycles, stated in seconds
+nodetimer_interval (NodeTimer interval) float 0.2 0.0
 
 #    If enabled, invalid world data won't cause the server to shut down.
 #    Only enable this if you know what you are doing.
 ignore_world_load_errors (Ignore world errors) bool false
 
 #    Max liquids processed per step.
-liquid_loop_max (Liquid loop max) int 100000
+liquid_loop_max (Liquid loop max) int 100000 1 4294967295
 
 #    The time (in seconds) that the liquids queue may grow beyond processing
 #    capacity until an attempt is made to decrease its size by dumping old queue
 #    items.  A value of 0 disables the functionality.
-liquid_queue_purge_time (Liquid queue purge time) int 0
+liquid_queue_purge_time (Liquid queue purge time) int 0 0 65535
 
 #    Liquid update interval in seconds.
-liquid_update (Liquid update tick) float 1.0
+liquid_update (Liquid update tick) float 1.0 0.001
 
 #    At this distance the server will aggressively optimize which blocks are sent to
 #    clients.
@@ -1357,7 +1359,7 @@ liquid_update (Liquid update tick) float 1.0
 #    Setting this to a value greater than max_block_send_distance disables this
 #    optimization.
 #    Stated in mapblocks (16 nodes).
-block_send_optimize_distance (Block send optimize distance) int 4 2
+block_send_optimize_distance (Block send optimize distance) int 4 2 32767
 
 #    If enabled the server will perform map block occlusion culling based on
 #    on the eye position of the player. This can reduce the number of blocks
@@ -1375,11 +1377,11 @@ server_side_occlusion_culling (Server side occlusion culling) bool true
 #    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to
 #    csm_restriction_noderange)
 #    READ_PLAYERINFO: 32 (disable get_player_names call client-side)
-csm_restriction_flags (Client side modding restrictions) int 62
+csm_restriction_flags (Client side modding restrictions) int 62 0 63
 
 #   If the CSM restriction for node range is enabled, get_node calls are limited
 #   to this distance from the player to the node.
-csm_restriction_noderange (Client side node lookup range restriction) int 0
+csm_restriction_noderange (Client side node lookup range restriction) int 0 0 4294967295
 
 [*Security]
 
@@ -1463,7 +1465,7 @@ debug_log_level (Debug log level) enum action ,none,error,warning,action,info,ve
 #    this setting when it is opened, the file is moved to debug.txt.1,
 #    deleting an older debug.txt.1 if it exists.
 #    debug.txt is only moved if this setting is positive.
-debug_log_size_max (Debug log file size threshold) int 50
+debug_log_size_max (Debug log file size threshold) int 50 1
 
 #    Minimal level of logging to be written to chat.
 chat_log_level (Chat log level) enum error ,none,error,warning,action,info,verbose
@@ -1475,24 +1477,24 @@ enable_ipv6 (IPv6) bool true
 [*Advanced]
 
 #    Maximum time an interactive request (e.g. server list fetch) may take, stated in milliseconds.
-curl_timeout (cURL interactive timeout) int 20000
+curl_timeout (cURL interactive timeout) int 20000 100 2147483647
 
 #    Limits number of parallel HTTP requests. Affects:
 #    -    Media fetch if server uses remote_media setting.
 #    -    Serverlist download and server announcement.
 #    -    Downloads performed by main menu (e.g. mod manager).
 #    Only has an effect if compiled with cURL.
-curl_parallel_limit (cURL parallel limit) int 8
+curl_parallel_limit (cURL parallel limit) int 8 1 2147483647
 
 #    Maximum time a file download (e.g. a mod download) may take, stated in milliseconds.
-curl_file_download_timeout (cURL file download timeout) int 300000
+curl_file_download_timeout (cURL file download timeout) int 300000 100 2147483647
 
 #    Replaces the default main menu with a custom one.
 main_menu_script (Main menu script) string
 
 #    Print the engine's profiling data in regular intervals (in seconds).
 #    0 = disable. Useful for developers.
-profiler_print_interval (Engine profiling data print interval) int 0
+profiler_print_interval (Engine profiling data print interval) int 0 0
 
 [Mapgen]
 
@@ -1503,10 +1505,10 @@ profiler_print_interval (Engine profiling data print interval) int 0
 mg_name (Mapgen name) enum v7 v7,valleys,carpathian,v5,flat,fractal,singlenode,v6
 
 #    Water surface level of the world.
-water_level (Water level) int 1
+water_level (Water level) int 1 -31000 31000
 
 #    From how far blocks are generated for clients, stated in mapblocks (16 nodes).
-max_block_generate_distance (Max block generate distance) int 10
+max_block_generate_distance (Max block generate distance) int 10 1 32767
 
 #    Limit of map generation, in nodes, in all 6 directions from (0, 0, 0).
 #    Only mapchunks completely within the mapgen limit are generated.
@@ -1543,7 +1545,7 @@ mgv5_spflags (Mapgen V5 specific flags) flags caverns caverns,nocaverns
 mgv5_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
-mgv5_large_cave_depth (Large cave depth) int -256
+mgv5_large_cave_depth (Large cave depth) int -256 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgv5_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -1561,19 +1563,19 @@ mgv5_large_cave_num_max (Large cave maximum number) int 2 0 64
 mgv5_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Y-level of cavern upper limit.
-mgv5_cavern_limit (Cavern limit) int -256
+mgv5_cavern_limit (Cavern limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
-mgv5_cavern_taper (Cavern taper) int 256
+mgv5_cavern_taper (Cavern taper) int 256 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
 mgv5_cavern_threshold (Cavern threshold) float 0.7
 
 #    Lower Y limit of dungeons.
-mgv5_dungeon_ymin (Dungeon minimum Y) int -31000
+mgv5_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgv5_dungeon_ymax (Dungeon maximum Y) int 31000
+mgv5_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
@@ -1618,10 +1620,10 @@ mgv6_freq_desert (Desert noise threshold) float 0.45
 mgv6_freq_beach (Beach noise threshold) float 0.15
 
 #    Lower Y limit of dungeons.
-mgv6_dungeon_ymin (Dungeon minimum Y) int -31000
+mgv6_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgv6_dungeon_ymax (Dungeon maximum Y) int 31000
+mgv6_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
@@ -1667,19 +1669,19 @@ mgv6_np_apple_trees (Apple trees noise) noise_params_2d 0, 1, (100, 100, 100), 3
 mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,caverns mountains,ridges,floatlands,caverns,nomountains,noridges,nofloatlands,nocaverns
 
 #    Y of mountain density gradient zero level. Used to shift mountains vertically.
-mgv7_mount_zero_level (Mountain zero level) int 0
+mgv7_mount_zero_level (Mountain zero level) int 0 -31000 31000
 
 #    Lower Y limit of floatlands.
-mgv7_floatland_ymin (Floatland minimum Y) int 1024
+mgv7_floatland_ymin (Floatland minimum Y) int 1024 -31000 31000
 
 #    Upper Y limit of floatlands.
-mgv7_floatland_ymax (Floatland maximum Y) int 4096
+mgv7_floatland_ymax (Floatland maximum Y) int 4096 -31000 31000
 
 #    Y-distance over which floatlands taper from full density to nothing.
 #    Tapering starts at this distance from the Y limit.
 #    For a solid floatland layer, this controls the height of hills/mountains.
 #    Must be less than or equal to half the distance between the Y limits.
-mgv7_floatland_taper (Floatland tapering distance) int 256
+mgv7_floatland_taper (Floatland tapering distance) int 256 0 32767
 
 #    Exponent of the floatland tapering. Alters the tapering behaviour.
 #    Value = 1.0 creates a uniform, linear tapering.
@@ -1706,7 +1708,7 @@ mgv7_floatland_density (Floatland density) float -0.6
 #    required value depending on 'mgv7_np_floatland'), to avoid
 #    server-intensive extreme water flow and to avoid vast flooding of the
 #    world surface below.
-mgv7_floatland_ywater (Floatland water level) int -31000
+mgv7_floatland_ywater (Floatland water level) int -31000 -31000 31000
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
@@ -1714,7 +1716,7 @@ mgv7_floatland_ywater (Floatland water level) int -31000
 mgv7_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
-mgv7_large_cave_depth (Large cave depth) int -33
+mgv7_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgv7_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -1732,19 +1734,19 @@ mgv7_large_cave_num_max (Large cave maximum number) int 2 0 64
 mgv7_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Y-level of cavern upper limit.
-mgv7_cavern_limit (Cavern limit) int -256
+mgv7_cavern_limit (Cavern limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
-mgv7_cavern_taper (Cavern taper) int 256
+mgv7_cavern_taper (Cavern taper) int 256 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
 mgv7_cavern_threshold (Cavern threshold) float 0.7
 
 #    Lower Y limit of dungeons.
-mgv7_dungeon_ymin (Dungeon minimum Y) int -31000
+mgv7_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgv7_dungeon_ymax (Dungeon maximum Y) int 31000
+mgv7_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
@@ -1818,7 +1820,7 @@ mgcarpathian_valley_width (River valley width) float 0.25
 mgcarpathian_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
-mgcarpathian_large_cave_depth (Large cave depth) int -33
+mgcarpathian_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgcarpathian_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -1836,19 +1838,19 @@ mgcarpathian_large_cave_num_max (Large cave maximum number) int 2 0 64
 mgcarpathian_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Y-level of cavern upper limit.
-mgcarpathian_cavern_limit (Cavern limit) int -256
+mgcarpathian_cavern_limit (Cavern limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
-mgcarpathian_cavern_taper (Cavern taper) int 256
+mgcarpathian_cavern_taper (Cavern taper) int 256 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
 mgcarpathian_cavern_threshold (Cavern threshold) float 0.7
 
 #    Lower Y limit of dungeons.
-mgcarpathian_dungeon_ymin (Dungeon minimum Y) int -31000
+mgcarpathian_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgcarpathian_dungeon_ymax (Dungeon maximum Y) int 31000
+mgcarpathian_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
@@ -1910,10 +1912,10 @@ mgcarpathian_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 50
 mgflat_spflags (Mapgen Flat specific flags) flags nolakes,nohills,nocaverns lakes,hills,caverns,nolakes,nohills,nocaverns
 
 #    Y of flat ground.
-mgflat_ground_level (Ground level) int 8
+mgflat_ground_level (Ground level) int 8 -31000 31000
 
 #    Y of upper limit of large caves.
-mgflat_large_cave_depth (Large cave depth) int -33
+mgflat_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgflat_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -1952,19 +1954,19 @@ mgflat_hill_threshold (Hill threshold) float 0.45
 mgflat_hill_steepness (Hill steepness) float 64.0
 
 #    Y-level of cavern upper limit.
-mgflat_cavern_limit (Cavern limit) int -256
+mgflat_cavern_limit (Cavern limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
-mgflat_cavern_taper (Cavern taper) int 256
+mgflat_cavern_taper (Cavern taper) int 256 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
 mgflat_cavern_threshold (Cavern threshold) float 0.7
 
 #    Lower Y limit of dungeons.
-mgflat_dungeon_ymin (Dungeon minimum Y) int -31000
+mgflat_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgflat_dungeon_ymax (Dungeon maximum Y) int 31000
+mgflat_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
@@ -1999,7 +2001,7 @@ mgfractal_spflags (Mapgen Fractal specific flags) flags terrain terrain,noterrai
 mgfractal_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
-mgfractal_large_cave_depth (Large cave depth) int -33
+mgfractal_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgfractal_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -2017,10 +2019,10 @@ mgfractal_large_cave_num_max (Large cave maximum number) int 2 0 64
 mgfractal_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Lower Y limit of dungeons.
-mgfractal_dungeon_ymin (Dungeon minimum Y) int -31000
+mgfractal_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgfractal_dungeon_ymax (Dungeon maximum Y) int 31000
+mgfractal_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 #    Selects one of 18 fractal types.
 #    1 = 4D "Roundy" Mandelbrot set.
@@ -2047,7 +2049,7 @@ mgfractal_fractal (Fractal type) int 1 1 18
 #    Increasing this increases the amount of fine detail, but also
 #    increases processing load.
 #    At iterations = 20 this mapgen has a similar load to mapgen V7.
-mgfractal_iterations (Iterations) int 11
+mgfractal_iterations (Iterations) int 11 1 65535
 
 #    (X,Y,Z) scale of fractal in nodes.
 #    Actual fractal size will be 2 to 3 times larger.
@@ -2130,10 +2132,10 @@ mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_riv
 #    The vertical distance over which heat drops by 20 if 'altitude_chill' is
 #    enabled. Also the vertical distance over which humidity drops by 10 if
 #    'altitude_dry' is enabled.
-mgvalleys_altitude_chill (Altitude chill) int 90
+mgvalleys_altitude_chill (Altitude chill) int 90 0 65535
 
 #    Depth below which you'll find large caves.
-mgvalleys_large_cave_depth (Large cave depth) int -33
+mgvalleys_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgvalleys_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -2151,19 +2153,19 @@ mgvalleys_large_cave_num_max (Large cave maximum number) int 2 0 64
 mgvalleys_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Depth below which you'll find giant caverns.
-mgvalleys_cavern_limit (Cavern upper limit) int -256
+mgvalleys_cavern_limit (Cavern upper limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
-mgvalleys_cavern_taper (Cavern taper) int 192
+mgvalleys_cavern_taper (Cavern taper) int 192 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
 mgvalleys_cavern_threshold (Cavern threshold) float 0.6
 
 #    How deep to make rivers.
-mgvalleys_river_depth (River depth) int 4
+mgvalleys_river_depth (River depth) int 4 0 65535
 
 #    How wide to make rivers.
-mgvalleys_river_size (River size) int 5
+mgvalleys_river_size (River size) int 5 0 65535
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
@@ -2171,10 +2173,10 @@ mgvalleys_river_size (River size) int 5
 mgvalleys_cave_width (Cave width) float 0.09
 
 #    Lower Y limit of dungeons.
-mgvalleys_dungeon_ymin (Dungeon minimum Y) int -31000
+mgvalleys_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgvalleys_dungeon_ymax (Dungeon maximum Y) int 63
+mgvalleys_dungeon_ymax (Dungeon maximum Y) int 63 -31000 31000
 
 [**Noises]
 
@@ -2219,7 +2221,7 @@ mgvalleys_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500),
 #    Reducing this value increases cave and dungeon density.
 #    Altering this value is for special usage, leaving it unchanged is
 #    recommended.
-chunksize (Chunk size) int 5
+chunksize (Chunk size) int 5 1 5
 
 #    Dump the mapgen debug information.
 enable_mapgen_debug_info (Mapgen debug) bool false
@@ -2245,7 +2247,7 @@ emergequeue_limit_generate (Per-player limit of queued blocks to generate) int 1
 #    speed, but this may harm game performance by interfering with other
 #    processes, especially in singleplayer and/or when running Lua code in
 #    'on_generated'. For many users the optimum setting may be '1'.
-num_emerge_threads (Number of emerge threads) int 1
+num_emerge_threads (Number of emerge threads) int 1 0 32767
 
 [Online Content Repository]
 
@@ -2262,4 +2264,4 @@ contentdb_flag_blacklist (ContentDB Flag Blacklist) string nonfree, desktop_defa
 
 #    Maximum number of concurrent downloads. Downloads exceeding this limit will be queued.
 #    This should be lower than curl_parallel_limit.
-contentdb_max_concurrent_downloads (ContentDB Max Concurrent Downloads) int 3
+contentdb_max_concurrent_downloads (ContentDB Max Concurrent Downloads) int 3 1


### PR DESCRIPTION
This PR adds the missing upper and lower limits to many settings (int and float) in `settingtypes.txt`. Now I will describe how I came up with those limits:

* Limits found by testing: I used a manual binary search for control/rendering-related settings to find the point at which problems start to occur, then I reduced the value a little above that point (as a "buffer") and used that as a limit. There are the settings for which I did it:
   * `mouse_sensitivity`: Above 10 it's very fast and hard to control, it is close to being unplayable. At 100 (current limit in source code) it's completely unplayable.
   * `cloud_radius`: Serious render bugs start to occur above ca. 65. Clouds disappear completely, error message in console: "Too many vertices for 16bit index type, render artifacts may occur.". Note this is not the same as the "sharp cutoff" as stated in the description
   * `3d_paralax_strength`: Beyond -0.087 or 0.087, the camera goes wild at certain or all view angles, making it unplayable
   * `hud_scale`: HUD is de facto unusable below 0.1
   * `gui_scale`: Below 0.5 it becomes too hard to use (tested at multiple resolutions, big and small)
   * `font_size` (and similar): 5pt is the smallest size in the default font at which I still can make out letters, barely. At 4pt, it's just a pixel mush. At 1000pt or above, Minetest crashes. At 72pt, the interface starts to break down (Minetest clearly isn't made for large fonts)
   * `view_bobbing_amount`: Above 56 the effect is so strong, the camera moves below the ground. Above 16, the camera often moves into the left or right wall when you walk on the center of the node
   * `movement_liquid_fluidity`: Can't be safely 0 like the other `movement_` settings because of a division by 0 and you'd get teleported to (-nan, -nan, -nan) if you touch any liquid.
* Limits set for other reasons:
   * `chunk_size`: The description says there is no reason or benefit for this to be above 5, so 5 is the upper limit then.
* Mapgen Y limits: For all mapgen settings that ask for a Y height, it's always (-31000, 31000). In the code, those are s16 anyway.
* Mapgen taper height: 32767 because those always use s16
* Technical limits: 255, 32767, 65535, 2147483647, 4294967295 and 18446744073709551615 were used as upper limit when there was no other reasonable upper bound, in order to match the C++ data type limits (u8, s16, u16, s32, u32, u64).
* Logical limits: I often used 0 or 1 as lower bound for logical reasons, e.g. minimum waiting time, distances can't be lower than 0
* Special lower bound: Sometimes, the number 0 or -1 has a special meaning, so I used that sometimes as a lower bound
* No upper limit: Rarely, usually when it's based on Lua code (builtin), I placed no upper limit. Many floats also have no upper limit. For some settings, I had no idea what to do, so I also placed no upper bound

The overal idea here is, when a (previously permitted) value causes crashes, render bugs, or similar, it must be moved out of the allowed range. And then apply somewhat of a buffer as a "safe zone", just in case.

As for performance, I generally used the maximum value of the C++ data type because those values might work *in theory* if you have strong enough hardware.

I also made minor changes to the setting descriptions, usually for mentioning the missing unit (milliseconds or seconds).

## To do

This PR is ready for review.

## How to test

First, just read the changeset and my justifications above and think whether the new number makes sense.
Especially complain if you think a range is too small and there are reasonable values beyond the range I chose.
Also complain if you think that any in-range value might lead to errors, crashes, etc.


Then, check if the All Settings menu still behaves properly.
