### PR TITLE
New physics overrides

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7688,6 +7688,8 @@ child will follow movement and rotation of that bone.
         * `gravity`: multiplier to default gravity value (default: `1`)
         * `speed_climb`: multiplier to default climb speed value (default: `1`)
             * Note: The actual climb speed is the product of `speed` and `speed_climb`
+        * `speed_crouch`: multiplier to default sneak speed value (default: `1`)
+            * Note: The actual sneak speed is the product of `speed` and `speed_crouch`
         * `liquid_fluidity`: multiplier to liquid movement resistance value;
           the higher this value, the lower the resistance to movement.
           At `math.huge`, the resistance is zero and you can move through any

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7681,12 +7681,13 @@ child will follow movement and rotation of that bone.
         * 9 - zoom
     * Returns `0` (no bits set) if the object is not a player.
 * `set_physics_override(override_table)`
+    * Overrides the physics attributes of the player
     * `override_table` is a table with the following fields:
         * `speed`: multiplier to default walking/climb speed value (default: `1`)
         * `jump`: multiplier to default jump value (default: `1`)
         * `gravity`: multiplier to default gravity value (default: `1`)
         * `speed_climb`: multiplier to default climb speed value (default: `1`)
-            * Note: The actual climb speed is a product of `speed` and `speed_climb`
+            * Note: The actual climb speed is the product of `speed` and `speed_climb`
         * `liquid_fluidity`: multiplier to liquid movement resistance value;
           the higher this value, the lower the resistance to movement.
           At `math.huge`, the resistance is zero and you can move through any
@@ -7696,13 +7697,21 @@ child will follow movement and rotation of that bone.
           controls deceleration when entering liquid at high speed. At higher values
           you come to a halt more quickly (default: `1`)
         * `liquid_sink`: multiplier to default liquid sinking speed value (default: `1`)
+        * `acceleration_default`: multiplier to horizontal and vertical acceleration
+          on ground or when climbing (default: `1`)
+        * `acceleration_air`: multiplier to acceleration
+          when jumping or falling (default: `1`)
         * `sneak`: whether player can sneak (default: `true`)
         * `sneak_glitch`: whether player can use the new move code replications
           of the old sneak side-effects: sneak ladders and 2 node sneak jump
           (default: `false`)
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behavior (default: `true`)
-        * Note: Most of these settings modify a corresponding `movement_*` setting
+    * Note: All numeric fields above modify a corresponding `movement_*` setting.
+    * For games, we recommend for simpler code to first modify the `movement_*`
+      settings (e.g. via the game's `minetest.conf`) to set a global base value
+      for all players and only use `set_physics_override` when you need to change
+      from the base value on a per-player basis
 
 * `get_physics_override()`: returns the table given to `set_physics_override`
 * `hud_add(hud definition)`: add a HUD element described by HUD def, returns ID

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7683,7 +7683,7 @@ child will follow movement and rotation of that bone.
 * `set_physics_override(override_table)`
     * Overrides the physics attributes of the player
     * `override_table` is a table with the following fields:
-        * `speed`: multiplier to default movement speed value (default: `1`)
+        * `speed`: multiplier to default movement speed and acceleration values (default: `1`)
         * `jump`: multiplier to default jump value (default: `1`)
         * `gravity`: multiplier to default gravity value (default: `1`)
         * `speed_climb`: multiplier to default climb speed value (default: `1`)
@@ -7703,8 +7703,10 @@ child will follow movement and rotation of that bone.
           (for nodes with `liquid_move_physics`) (default: `1`)
         * `acceleration_default`: multiplier to horizontal and vertical acceleration
           on ground or when climbing (default: `1`)
+            * Note: The actual acceleration is the product of `speed` and `acceleration_default`
         * `acceleration_air`: multiplier to acceleration
           when jumping or falling (default: `1`)
+            * Note: The actual acceleration is the product of `speed` and `acceleration_air`
         * `sneak`: whether player can sneak (default: `true`)
         * `sneak_glitch`: whether player can use the new move code replications
           of the old sneak side-effects: sneak ladders and 2 node sneak jump

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7682,15 +7682,28 @@ child will follow movement and rotation of that bone.
     * Returns `0` (no bits set) if the object is not a player.
 * `set_physics_override(override_table)`
     * `override_table` is a table with the following fields:
-        * `speed`: multiplier to default walking speed value (default: `1`)
+        * `speed`: multiplier to default walking/climb speed value (default: `1`)
         * `jump`: multiplier to default jump value (default: `1`)
         * `gravity`: multiplier to default gravity value (default: `1`)
+        * `speed_climb`: multiplier to default climb speed value (default: `1`)
+            * Note: The actual climb speed is a product of `speed` and `speed_climb`
+        * `liquid_fluidity`: multiplier to liquid movement resistance value;
+          the higher this value, the lower the resistance to movement.
+          At `math.huge`, the resistance is zero and you can move through any
+          liquid like air. (default: `1`)
+          Warning: Values below 1 are currently unsupported.
+        * `liquid_fluidity_smooth`: multiplier to default maximum liquid resistance value;
+          controls deceleration when entering liquid at high speed. At higher values
+          you come to a halt more quickly (default: `1`)
+        * `liquid_sink`: multiplier to default liquid sinking speed value (default: `1`)
         * `sneak`: whether player can sneak (default: `true`)
         * `sneak_glitch`: whether player can use the new move code replications
           of the old sneak side-effects: sneak ladders and 2 node sneak jump
           (default: `false`)
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behavior (default: `true`)
+        * Note: Most of these settings modify a corresponding `movement_*` setting
+
 * `get_physics_override()`: returns the table given to `set_physics_override`
 * `hud_add(hud definition)`: add a HUD element described by HUD def, returns ID
    number on success

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7683,7 +7683,7 @@ child will follow movement and rotation of that bone.
 * `set_physics_override(override_table)`
     * Overrides the physics attributes of the player
     * `override_table` is a table with the following fields:
-        * `speed`: multiplier to default walking/climb speed value (default: `1`)
+        * `speed`: multiplier to default movement speed value (default: `1`)
         * `jump`: multiplier to default jump value (default: `1`)
         * `gravity`: multiplier to default gravity value (default: `1`)
         * `speed_climb`: multiplier to default climb speed value (default: `1`)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7694,7 +7694,7 @@ child will follow movement and rotation of that bone.
           (for nodes with `liquid_move_physics`); the higher this value, the lower the
           resistance to movement. At `math.huge`, the resistance is zero and you can
           move through any liquid like air. (default: `1`)
-          Warning: Values below 1 are currently unsupported.
+            * Warning: Values below 1 are currently unsupported.
         * `liquid_fluidity_smooth`: multiplier to default maximum liquid resistance value
           (for nodes with `liquid_move_physics`); controls deceleration when entering
           node at high speed. At higher values you come to a halt more quickly

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7690,15 +7690,17 @@ child will follow movement and rotation of that bone.
             * Note: The actual climb speed is the product of `speed` and `speed_climb`
         * `speed_crouch`: multiplier to default sneak speed value (default: `1`)
             * Note: The actual sneak speed is the product of `speed` and `speed_crouch`
-        * `liquid_fluidity`: multiplier to liquid movement resistance value;
-          the higher this value, the lower the resistance to movement.
-          At `math.huge`, the resistance is zero and you can move through any
-          liquid like air. (default: `1`)
+        * `liquid_fluidity`: multiplier to liquid movement resistance value
+          (for nodes with `liquid_move_physics`); the higher this value, the lower the
+          resistance to movement. At `math.huge`, the resistance is zero and you can
+          move through any liquid like air. (default: `1`)
           Warning: Values below 1 are currently unsupported.
-        * `liquid_fluidity_smooth`: multiplier to default maximum liquid resistance value;
-          controls deceleration when entering liquid at high speed. At higher values
-          you come to a halt more quickly (default: `1`)
-        * `liquid_sink`: multiplier to default liquid sinking speed value (default: `1`)
+        * `liquid_fluidity_smooth`: multiplier to default maximum liquid resistance value
+          (for nodes with `liquid_move_physics`); controls deceleration when entering
+          node at high speed. At higher values you come to a halt more quickly
+          (default: `1`)
+        * `liquid_sink`: multiplier to default liquid sinking speed value;
+          (for nodes with `liquid_move_physics`) (default: `1`)
         * `acceleration_default`: multiplier to horizontal and vertical acceleration
           on ground or when climbing (default: `1`)
         * `acceleration_air`: multiplier to acceleration

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -206,9 +206,13 @@ void ClientEnvironment::step(float dtime)
 			// Liquid floating / sinking
 			if (!is_climbing && lplayer->in_liquid &&
 					!lplayer->swimming_vertical &&
-					!lplayer->swimming_pitch)
+					!lplayer->swimming_pitch) {
 				// HACK the factor 2 for gravity is arbitrary and should be removed eventually
-				lplayer->gravity = 2 * lplayer->movement_liquid_sink;
+				lplayer->gravity = 2 * lplayer->movement_liquid_sink * lplayer->physics_override.liquid_sink;
+
+				speed.Y -= lplayer->movement_liquid_sink *
+					lplayer->physics_override.liquid_sink * dtime_part * 2.0f;
+			}
 
 			// Movement resistance
 			if (lplayer->move_resistance > 0) {
@@ -218,20 +222,20 @@ void ClientEnvironment::step(float dtime)
 				// between 0 and 1. Should match the scale at which liquid_viscosity
 				// increase affects other liquid attributes.
 				static const f32 resistance_factor = 0.3f;
+				float fluidity = lplayer->movement_liquid_fluidity;
+				fluidity *= lplayer->physics_override_liquid_fluidity;
+				float fluidity_smooth = lplayer->movement_liquid_fluidity_smooth;
+				fluidity_smooth *= lplayer->physics_override_liquid_fluidity_smooth;
 
 				v3f d_wanted;
 				bool in_liquid_stable = lplayer->in_liquid_stable || lplayer->in_liquid;
-				if (in_liquid_stable) {
-					d_wanted = -speed / lplayer->movement_liquid_fluidity;
-				} else {
+				if (in_liquid_stable)
+					d_wanted = -speed / fluidity;
+				else
 					d_wanted = -speed / BS;
-				}
 				f32 dl = d_wanted.getLength();
-				if (in_liquid_stable) {
-					if (dl > lplayer->movement_liquid_fluidity_smooth)
-						dl = lplayer->movement_liquid_fluidity_smooth;
-				}
-
+				if (in_liquid_stable && dl > fluidity_smooth)
+					dl = fluidity_smooth;
 				dl *= (lplayer->move_resistance * resistance_factor) +
 					(1 - resistance_factor);
 				v3f d = d_wanted.normalize() * (dl * dtime_part * 100.0f);

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -234,8 +234,8 @@ void ClientEnvironment::step(float dtime)
 				else
 					d_wanted = -speed / BS;
 				f32 dl = d_wanted.getLength();
-				if (in_liquid_stable && dl > fluidity_smooth)
-					dl = fluidity_smooth;
+				if (in_liquid_stable)
+					dl = MYMIN(dl, fluidity_smooth);
 				dl *= (lplayer->move_resistance * resistance_factor) +
 					(1 - resistance_factor);
 				v3f d = d_wanted.normalize() * (dl * dtime_part * 100.0f);

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -223,6 +223,7 @@ void ClientEnvironment::step(float dtime)
 				fluidity = MYMAX(0.001f, fluidity); // prevent division by 0
 				float fluidity_smooth = lplayer->movement_liquid_fluidity_smooth;
 				fluidity_smooth *= lplayer->physics_override.liquid_fluidity_smooth;
+				fluidity_smooth = MYMAX(0.0f, fluidity_smooth);
 
 				v3f d_wanted;
 				bool in_liquid_stable = lplayer->in_liquid_stable || lplayer->in_liquid;

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -219,7 +219,8 @@ void ClientEnvironment::step(float dtime)
 				// increase affects other liquid attributes.
 				static const f32 resistance_factor = 0.3f;
 				float fluidity = lplayer->movement_liquid_fluidity;
-				fluidity *= lplayer->physics_override.liquid_fluidity;
+				fluidity *= MYMAX(1.0f, lplayer->physics_override.liquid_fluidity);
+				fluidity = MYMAX(0.001f, fluidity); // prevent division by 0
 				float fluidity_smooth = lplayer->movement_liquid_fluidity_smooth;
 				fluidity_smooth *= lplayer->physics_override.liquid_fluidity_smooth;
 

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -206,13 +206,9 @@ void ClientEnvironment::step(float dtime)
 			// Liquid floating / sinking
 			if (!is_climbing && lplayer->in_liquid &&
 					!lplayer->swimming_vertical &&
-					!lplayer->swimming_pitch) {
+					!lplayer->swimming_pitch)
 				// HACK the factor 2 for gravity is arbitrary and should be removed eventually
 				lplayer->gravity = 2 * lplayer->movement_liquid_sink * lplayer->physics_override.liquid_sink;
-
-				speed.Y -= lplayer->movement_liquid_sink *
-					lplayer->physics_override.liquid_sink * dtime_part * 2.0f;
-			}
 
 			// Movement resistance
 			if (lplayer->move_resistance > 0) {
@@ -223,9 +219,9 @@ void ClientEnvironment::step(float dtime)
 				// increase affects other liquid attributes.
 				static const f32 resistance_factor = 0.3f;
 				float fluidity = lplayer->movement_liquid_fluidity;
-				fluidity *= lplayer->physics_override_liquid_fluidity;
+				fluidity *= lplayer->physics_override.liquid_fluidity;
 				float fluidity_smooth = lplayer->movement_liquid_fluidity_smooth;
-				fluidity_smooth *= lplayer->physics_override_liquid_fluidity_smooth;
+				fluidity_smooth *= lplayer->physics_override.liquid_fluidity_smooth;
 
 				v3f d_wanted;
 				bool in_liquid_stable = lplayer->in_liquid_stable || lplayer->in_liquid;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1786,6 +1786,8 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_liquid_fluidity = readF32(is);
 		float override_liquid_fluidity_smooth = readF32(is);
 		float override_liquid_sink = readF32(is);
+		float override_acceleration_default = readF32(is);
+		float override_acceleration_air = readF32(is);
 
 		if (m_is_local_player) {
 			auto &phys = m_env->getLocalPlayer()->physics_override;
@@ -1799,6 +1801,8 @@ void GenericCAO::processMessage(const std::string &data)
 			phys.liquid_fluidity = override_liquid_fluidity;
 			phys.liquid_fluidity_smooth = override_liquid_fluidity_smooth;
 			phys.liquid_sink = override_liquid_sink;
+			phys.acceleration_default = override_acceleration_default;
+			phys.acceleration_air = override_acceleration_air;
 		}
 	} else if (cmd == AO_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1789,6 +1789,16 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_liquid_sink = readF32(is);
 		float override_acceleration_default = readF32(is);
 		float override_acceleration_air = readF32(is);
+		// fallback for new overrides (since 5.5.0)
+		if (is.eof()) {
+			override_speed_climb = 1.0f;
+			override_speed_crouch = 1.0f;
+			override_liquid_fluidity = 1.0f;
+			override_liquid_fluidity_smooth = 1.0f;
+			override_liquid_sink = 1.0f;
+			override_acceleration_default = 1.0f;
+			override_acceleration_air = 1.0f;
+		}
 
 		if (m_is_local_player) {
 			auto &phys = m_env->getLocalPlayer()->physics_override;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1789,7 +1789,7 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_liquid_sink = readF32(is);
 		float override_acceleration_default = readF32(is);
 		float override_acceleration_air = readF32(is);
-		// fallback for new overrides (since 5.5.0)
+		// fallback for new overrides (since 5.8.0)
 		if (is.eof()) {
 			override_speed_climb = 1.0f;
 			override_speed_crouch = 1.0f;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1783,6 +1783,7 @@ void GenericCAO::processMessage(const std::string &data)
 		bool new_move = !readU8(is);
 
 		float override_speed_climb = readF32(is);
+		float override_speed_crouch = readF32(is);
 		float override_liquid_fluidity = readF32(is);
 		float override_liquid_fluidity_smooth = readF32(is);
 		float override_liquid_sink = readF32(is);
@@ -1798,6 +1799,7 @@ void GenericCAO::processMessage(const std::string &data)
 			phys.sneak_glitch = sneak_glitch;
 			phys.new_move = new_move;
 			phys.speed_climb = override_speed_climb;
+			phys.speed_crouch = override_speed_crouch;
 			phys.liquid_fluidity = override_liquid_fluidity;
 			phys.liquid_fluidity_smooth = override_liquid_fluidity_smooth;
 			phys.liquid_sink = override_liquid_sink;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1782,6 +1782,10 @@ void GenericCAO::processMessage(const std::string &data)
 		bool sneak_glitch = !readU8(is);
 		bool new_move = !readU8(is);
 
+		float override_speed_climb = readF32(is);
+		float override_liquid_fluidity = readF32(is);
+		float override_liquid_fluidity_smooth = readF32(is);
+		float override_liquid_sink = readF32(is);
 
 		if (m_is_local_player) {
 			auto &phys = m_env->getLocalPlayer()->physics_override;
@@ -1791,6 +1795,10 @@ void GenericCAO::processMessage(const std::string &data)
 			phys.sneak = sneak;
 			phys.sneak_glitch = sneak_glitch;
 			phys.new_move = new_move;
+			phys.speed_climb = override_speed_climb;
+			phys.liquid_fluidity = override_liquid_fluidity;
+			phys.liquid_fluidity_smooth = override_liquid_fluidity_smooth;
+			phys.liquid_sink = override_liquid_sink;
 		}
 	} else if (cmd == AO_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -557,7 +557,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				speedV.Y = -movement_speed_walk;
 				swimming_vertical = true;
 			} else if (is_climbing && !m_disable_descend) {
-				speedV.Y = -movement_speed_climb * physics_override_speed_climb;
+				speedV.Y = -movement_speed_climb * physics_override.speed_climb;
 			} else {
 				// If not free movement but fast is allowed, aux1 is
 				// "Turbo button"
@@ -595,7 +595,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				if (fast_climb)
 					speedV.Y = -movement_speed_fast;
 				else
-					speedV.Y = -movement_speed_climb * physics_override_speed_climb;
+					speedV.Y = -movement_speed_climb * physics_override.speed_climb;
 			}
 		}
 	}
@@ -647,7 +647,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			if (fast_climb)
 				speedV.Y = movement_speed_fast;
 			else
-				speedV.Y = movement_speed_climb * physics_override_speed_climb;
+				speedV.Y = movement_speed_climb * physics_override.speed_climb;
 		}
 	}
 
@@ -656,7 +656,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			((in_liquid || in_liquid_stable) && fast_climb))
 		speedH = speedH.normalize() * movement_speed_fast;
 	else if (control.sneak && !free_move && !in_liquid && !in_liquid_stable)
-		speedH = speedH.normalize() * movement_speed_crouch * physics_override_speed_crouch;
+		speedH = speedH.normalize() * movement_speed_crouch * physics_override.speed_crouch;
 	else
 		speedH = speedH.normalize() * movement_speed_walk;
 
@@ -671,13 +671,13 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 		if (superspeed || (fast_move && control.aux1))
 			incH = movement_acceleration_fast * BS * dtime;
 		else
-			incH = movement_acceleration_air * physics_override_acceleration_air * BS * dtime;
+			incH = movement_acceleration_air * physics_override.acceleration_air * BS * dtime;
 		incV = 0.0f; // No vertical acceleration in air
 	} else if (superspeed || (is_climbing && fast_climb) ||
 			((in_liquid || in_liquid_stable) && fast_climb)) {
 		incH = incV = movement_acceleration_fast * BS * dtime;
 	} else {
-		incH = incV = movement_acceleration_default * physics_override_acceleration_default * BS * dtime;
+		incH = incV = movement_acceleration_default * physics_override.acceleration_default * BS * dtime;
 	}
 
 	float slip_factor = 1.0f;

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -656,7 +656,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			((in_liquid || in_liquid_stable) && fast_climb))
 		speedH = speedH.normalize() * movement_speed_fast;
 	else if (control.sneak && !free_move && !in_liquid && !in_liquid_stable)
-		speedH = speedH.normalize() * movement_speed_crouch;
+		speedH = speedH.normalize() * movement_speed_crouch * physics_override_speed_crouch;
 	else
 		speedH = speedH.normalize() * movement_speed_walk;
 

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -557,7 +557,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				speedV.Y = -movement_speed_walk;
 				swimming_vertical = true;
 			} else if (is_climbing && !m_disable_descend) {
-				speedV.Y = -movement_speed_climb;
+				speedV.Y = -movement_speed_climb * physics_override_speed_climb;
 			} else {
 				// If not free movement but fast is allowed, aux1 is
 				// "Turbo button"
@@ -595,7 +595,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				if (fast_climb)
 					speedV.Y = -movement_speed_fast;
 				else
-					speedV.Y = -movement_speed_climb;
+					speedV.Y = -movement_speed_climb * physics_override_speed_climb;
 			}
 		}
 	}
@@ -647,7 +647,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			if (fast_climb)
 				speedV.Y = movement_speed_fast;
 			else
-				speedV.Y = movement_speed_climb;
+				speedV.Y = movement_speed_climb * physics_override_speed_climb;
 		}
 	}
 

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -671,13 +671,13 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 		if (superspeed || (fast_move && control.aux1))
 			incH = movement_acceleration_fast * BS * dtime;
 		else
-			incH = movement_acceleration_air * BS * dtime;
+			incH = movement_acceleration_air * physics_override_acceleration_air * BS * dtime;
 		incV = 0.0f; // No vertical acceleration in air
 	} else if (superspeed || (is_climbing && fast_climb) ||
 			((in_liquid || in_liquid_stable) && fast_climb)) {
 		incH = incV = movement_acceleration_fast * BS * dtime;
 	} else {
-		incH = incV = movement_acceleration_default * BS * dtime;
+		incH = incV = movement_acceleration_default * physics_override_acceleration_default * BS * dtime;
 	}
 
 	float slip_factor = 1.0f;

--- a/src/player.h
+++ b/src/player.h
@@ -106,6 +106,14 @@ struct PlayerPhysicsOverride
 	bool sneak_glitch = false;
 	// "Temporary" option for old move code
 	bool new_move = true;
+
+	float speed_climb = 1.f;
+	float speed_crouch = 1.f;
+	float liquid_fluidity = 1.f;
+	float liquid_fluidity_smooth = 1.f;
+	float liquid_sink = 1.f;
+	float acceleration_default = 1.f;
+	float acceleration_air = 1.f;
 };
 
 struct PlayerSettings

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -180,6 +180,9 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushnumber(L, player->physics_override_speed_climb);
 	lua_setfield(L, -2, "speed_climb");
 
+	lua_pushnumber(L, player->physics_override_speed_crouch);
+	lua_setfield(L, -2, "speed_crouch");
+
 	lua_pushnumber(L, player->physics_override_liquid_fluidity);
 	lua_setfield(L, -2, "liquid_fluidity");
 

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -177,25 +177,25 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushboolean(L, phys.new_move);
 	lua_setfield(L, -2, "new_move");
 
-	lua_pushnumber(L, player->physics_override_speed_climb);
+	lua_pushnumber(L, phys.speed_climb);
 	lua_setfield(L, -2, "speed_climb");
 
-	lua_pushnumber(L, player->physics_override_speed_crouch);
+	lua_pushnumber(L, phys.speed_crouch);
 	lua_setfield(L, -2, "speed_crouch");
 
-	lua_pushnumber(L, player->physics_override_liquid_fluidity);
+	lua_pushnumber(L, phys.liquid_fluidity);
 	lua_setfield(L, -2, "liquid_fluidity");
 
-	lua_pushnumber(L, player->physics_override_liquid_fluidity_smooth);
+	lua_pushnumber(L, phys.liquid_fluidity_smooth);
 	lua_setfield(L, -2, "liquid_fluidity_smooth");
 
-	lua_pushnumber(L, player->physics_override_liquid_sink);
+	lua_pushnumber(L, phys.liquid_sink);
 	lua_setfield(L, -2, "liquid_sink");
 
-	lua_pushnumber(L, player->physics_override_acceleration_default);
+	lua_pushnumber(L, phys.acceleration_default);
 	lua_setfield(L, -2, "acceleration_default");
 
-	lua_pushnumber(L, player->physics_override_acceleration_air);
+	lua_pushnumber(L, phys.acceleration_air);
 	lua_setfield(L, -2, "acceleration_air");
 
 	return 1;

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -189,6 +189,12 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushnumber(L, player->physics_override_liquid_sink);
 	lua_setfield(L, -2, "liquid_sink");
 
+	lua_pushnumber(L, player->physics_override_acceleration_default);
+	lua_setfield(L, -2, "acceleration_default");
+
+	lua_pushnumber(L, player->physics_override_acceleration_air);
+	lua_setfield(L, -2, "acceleration_air");
+
 	return 1;
 }
 

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -177,6 +177,18 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushboolean(L, phys.new_move);
 	lua_setfield(L, -2, "new_move");
 
+	lua_pushnumber(L, player->physics_override_speed_climb);
+	lua_setfield(L, -2, "speed_climb");
+
+	lua_pushnumber(L, player->physics_override_liquid_fluidity);
+	lua_setfield(L, -2, "liquid_fluidity");
+
+	lua_pushnumber(L, player->physics_override_liquid_fluidity_smooth);
+	lua_setfield(L, -2, "liquid_fluidity_smooth");
+
+	lua_pushnumber(L, player->physics_override_liquid_sink);
+	lua_setfield(L, -2, "liquid_sink");
+
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1439,6 +1439,8 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		modified |= getboolfield(L, 2, "liquid_fluidity", phys.liquid_fluidity);
 		modified |= getboolfield(L, 2, "liquid_fluidity_smooth", phys.liquid_fluidity_smooth);
 		modified |= getboolfield(L, 2, "liquid_sink", phys.liquid_sink);
+		modified |= getboolfield(L, 2, "acceleration_default", phys.acceleration_default);
+		modified |= getboolfield(L, 2, "acceleration_air", phys.acceleration_air);
 		if (modified)
 			playersao->m_physics_override_sent = false;
 	} else {
@@ -1493,6 +1495,10 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "liquid_fluidity_smooth");
 	lua_pushnumber(L, phys.liquid_sink);
 	lua_setfield(L, -2, "liquid_sink");
+	lua_pushnumber(L, phys.acceleration_default);
+	lua_setfield(L, -2, "acceleration_default");
+	lua_pushnumber(L, phys.acceleration_air);
+	lua_setfield(L, -2, "acceleration_air");
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1435,13 +1435,13 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		modified |= getboolfield(L, 2, "sneak", phys.sneak);
 		modified |= getboolfield(L, 2, "sneak_glitch", phys.sneak_glitch);
 		modified |= getboolfield(L, 2, "new_move", phys.new_move);
-		modified |= getboolfield(L, 2, "speed_climb", phys.speed_climb);
-		modified |= getboolfield(L, 2, "speed_crouch", phys.speed_crouch);
-		modified |= getboolfield(L, 2, "liquid_fluidity", phys.liquid_fluidity);
-		modified |= getboolfield(L, 2, "liquid_fluidity_smooth", phys.liquid_fluidity_smooth);
-		modified |= getboolfield(L, 2, "liquid_sink", phys.liquid_sink);
-		modified |= getboolfield(L, 2, "acceleration_default", phys.acceleration_default);
-		modified |= getboolfield(L, 2, "acceleration_air", phys.acceleration_air);
+		modified |= getfloatfield(L, 2, "speed_climb", phys.speed_climb);
+		modified |= getfloatfield(L, 2, "speed_crouch", phys.speed_crouch);
+		modified |= getfloatfield(L, 2, "liquid_fluidity", phys.liquid_fluidity);
+		modified |= getfloatfield(L, 2, "liquid_fluidity_smooth", phys.liquid_fluidity_smooth);
+		modified |= getfloatfield(L, 2, "liquid_sink", phys.liquid_sink);
+		modified |= getfloatfield(L, 2, "acceleration_default", phys.acceleration_default);
+		modified |= getfloatfield(L, 2, "acceleration_air", phys.acceleration_air);
 		if (modified)
 			playersao->m_physics_override_sent = false;
 	} else {

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1436,6 +1436,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		modified |= getboolfield(L, 2, "sneak_glitch", phys.sneak_glitch);
 		modified |= getboolfield(L, 2, "new_move", phys.new_move);
 		modified |= getboolfield(L, 2, "speed_climb", phys.speed_climb);
+		modified |= getboolfield(L, 2, "speed_crouch", phys.speed_crouch);
 		modified |= getboolfield(L, 2, "liquid_fluidity", phys.liquid_fluidity);
 		modified |= getboolfield(L, 2, "liquid_fluidity_smooth", phys.liquid_fluidity_smooth);
 		modified |= getboolfield(L, 2, "liquid_sink", phys.liquid_sink);
@@ -1489,6 +1490,8 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "new_move");
 	lua_pushnumber(L, phys.speed_climb);
 	lua_setfield(L, -2, "speed_climb");
+	lua_pushnumber(L, phys.speed_crouch);
+	lua_setfield(L, -2, "speed_crouch");
 	lua_pushnumber(L, phys.liquid_fluidity);
 	lua_setfield(L, -2, "liquid_fluidity");
 	lua_pushnumber(L, phys.liquid_fluidity_smooth);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1435,6 +1435,10 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		modified |= getboolfield(L, 2, "sneak", phys.sneak);
 		modified |= getboolfield(L, 2, "sneak_glitch", phys.sneak_glitch);
 		modified |= getboolfield(L, 2, "new_move", phys.new_move);
+		modified |= getboolfield(L, 2, "speed_climb", phys.speed_climb);
+		modified |= getboolfield(L, 2, "liquid_fluidity", phys.liquid_fluidity);
+		modified |= getboolfield(L, 2, "liquid_fluidity_smooth", phys.liquid_fluidity_smooth);
+		modified |= getboolfield(L, 2, "liquid_sink", phys.liquid_sink);
 		if (modified)
 			playersao->m_physics_override_sent = false;
 	} else {
@@ -1481,6 +1485,14 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "sneak_glitch");
 	lua_pushboolean(L, phys.new_move);
 	lua_setfield(L, -2, "new_move");
+	lua_pushnumber(L, phys.speed_climb);
+	lua_setfield(L, -2, "speed_climb");
+	lua_pushnumber(L, phys.liquid_fluidity);
+	lua_setfield(L, -2, "liquid_fluidity");
+	lua_pushnumber(L, phys.liquid_fluidity_smooth);
+	lua_setfield(L, -2, "liquid_fluidity_smooth");
+	lua_pushnumber(L, phys.liquid_sink);
+	lua_setfield(L, -2, "liquid_sink");
 	return 1;
 }
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -638,7 +638,6 @@ bool PlayerSAO::checkMovementCheat()
 	player_max_walk = MYMAX(player_max_walk, override_max_H);
 
 	player_max_jump = m_player->movement_speed_jump * m_player->physics_override.jump;
-	player_max_jump = MYMAX(player_max_jump, m_player->movement_speed_climb * m_player->physics_override.speed_climb);
 	// FIXME: Bouncy nodes cause practically unbound increase in Y speed,
 	//        until this can be verified correctly, tolerate higher jumping speeds
 	player_max_jump *= 2.0;

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -325,7 +325,7 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeU8(os, !phys.sneak);
 	writeU8(os, !phys.sneak_glitch);
 	writeU8(os, !phys.new_move);
-	// new physics overrids since 5.8.0
+	// new physics overrides since 5.8.0
 	writeF32(os, phys.speed_climb);
 	writeF32(os, phys.speed_crouch);
 	writeF32(os, phys.liquid_fluidity);

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -629,6 +629,7 @@ bool PlayerSAO::checkMovementCheat()
 	// FIXME: Bouncy nodes cause practically unbound increase in Y speed,
 	//        until this can be verified correctly, tolerate higher jumping speeds
 	player_max_jump *= 2.0;
+	player_max_jump = MYMAX(player_max_jump, m_player->movement_speed_climb * m_physics_override_speed_climb);
 	player_max_jump = MYMAX(player_max_jump, override_max_V);
 
 	// Don't divide by zero!

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -325,7 +325,7 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeU8(os, !phys.sneak);
 	writeU8(os, !phys.sneak_glitch);
 	writeU8(os, !phys.new_move);
-	// new physics overrids since 5.7.0-dev
+	// new physics overrids since 5.8.0
 	writeF32(os, phys.speed_climb);
 	writeF32(os, phys.speed_crouch);
 	writeF32(os, phys.liquid_fluidity);

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -330,6 +330,8 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeF32(os, phys.liquid_fluidity);
 	writeF32(os, phys.liquid_fluidity_smooth);
 	writeF32(os, phys.liquid_sink);
+	writeF32(os, phys.acceleration_default);
+	writeF32(os, phys.acceleration_air);
 	return os.str();
 }
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -325,6 +325,11 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeU8(os, !phys.sneak);
 	writeU8(os, !phys.sneak_glitch);
 	writeU8(os, !phys.new_move);
+	// new physics overrids since 5.7.0-dev
+	writeF32(os, phys.speed_climb);
+	writeF32(os, phys.liquid_fluidity);
+	writeF32(os, phys.liquid_fluidity_smooth);
+	writeF32(os, phys.liquid_sink);
 	return os.str();
 }
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -617,9 +617,9 @@ bool PlayerSAO::checkMovementCheat()
 	float player_max_walk = 0; // horizontal movement
 	float player_max_jump = 0; // vertical upwards movement
 
-	float speed_walk = m_player->movement_speed_walk *= m_player->physics_override.speed;
+	float speed_walk = m_player->movement_speed_walk * m_player->physics_override.speed;
 	float speed_fast = m_player->movement_speed_fast;
-	float speed_crouch = m_player->movement_speed_crouch *= m_player->physics_override.speed_crouch;
+	float speed_crouch = m_player->movement_speed_crouch * m_player->physics_override.speed_crouch;
 
 	// Get permissible max. speed
 	if (m_privs.count("fast") != 0) {
@@ -642,7 +642,7 @@ bool PlayerSAO::checkMovementCheat()
 	// FIXME: Bouncy nodes cause practically unbound increase in Y speed,
 	//        until this can be verified correctly, tolerate higher jumping speeds
 	player_max_jump *= 2.0;
-	player_max_jump = MYMAX(player_max_jump, m_player->movement_speed_climb * m_physics_override_speed_climb);
+	player_max_jump = MYMAX(player_max_jump, m_player->movement_speed_climb * m_player->physics_override.speed_climb);
 	player_max_jump = MYMAX(player_max_jump, override_max_V);
 
 	// Don't divide by zero!

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -625,6 +625,7 @@ bool PlayerSAO::checkMovementCheat()
 	player_max_walk = MYMAX(player_max_walk, override_max_H);
 
 	player_max_jump = m_player->movement_speed_jump * m_player->physics_override.jump;
+	player_max_jump = MYMAX(player_max_jump, m_player->movement_speed_climb * m_player->physics_override.speed_climb);
 	// FIXME: Bouncy nodes cause practically unbound increase in Y speed,
 	//        until this can be verified correctly, tolerate higher jumping speeds
 	player_max_jump *= 2.0;

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -617,11 +617,24 @@ bool PlayerSAO::checkMovementCheat()
 	float player_max_walk = 0; // horizontal movement
 	float player_max_jump = 0; // vertical upwards movement
 
-	if (m_privs.count("fast") != 0)
-		player_max_walk = m_player->movement_speed_fast; // Fast speed
-	else
-		player_max_walk = m_player->movement_speed_walk; // Normal speed
-	player_max_walk *= m_player->physics_override.speed;
+	float speed_walk = m_player->movement_speed_walk *= m_player->physics_override.speed;
+	float speed_fast = m_player->movement_speed_fast;
+	float speed_crouch = m_player->movement_speed_crouch *= m_player->physics_override.speed_crouch;
+
+	// Get permissible max. speed
+	if (m_privs.count("fast") != 0) {
+		// Fast priv: Get the highest speed of fast, walk or crouch
+		// (it is not forbidden the 'fast' speed is
+		// not actually the fastest)
+		player_max_walk = MYMAX(speed_crouch, speed_fast);
+		player_max_walk = MYMAX(player_max_walk, speed_walk);
+	} else {
+		// Get the highest speed of walk or crouch
+		// (it is not forbidden the 'walk' speed is
+		// lower than the crouch speed)
+		player_max_walk = MYMAX(speed_crouch, speed_walk);
+	}
+
 	player_max_walk = MYMAX(player_max_walk, override_max_H);
 
 	player_max_jump = m_player->movement_speed_jump * m_player->physics_override.jump;

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -327,6 +327,7 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeU8(os, !phys.new_move);
 	// new physics overrids since 5.7.0-dev
 	writeF32(os, phys.speed_climb);
+	writeF32(os, phys.speed_crouch);
 	writeF32(os, phys.liquid_fluidity);
 	writeF32(os, phys.liquid_fluidity_smooth);
 	writeF32(os, phys.liquid_sink);


### PR DESCRIPTION
Fixes #11460 which is supported by core dev.

This PR adds the following new fields to `set_physics_override`:

* `speed_climb`: Climbing speed multiplier (based on `movement_speed_climb` setting)
* `speed_crouch`: Sneak speed multiplier (based on `movement_speed_crouch` setting)
* `liquid_fluidity`: Liquid fluidity multiplier (based on `movement_liquid_fluidity` setting)
* `liquid_fluidity_smooth`: Multiplier for `movement_liquid_fluidity_smooth` setting
* `liquid_sink`: Liquid sinking speed multiplier (based on `movement_liquid_sink`)
* `acceleration_default`: Multiplier for `movement_acceleration_default`
* `acceleration_air`: Multiplier for `movement_acceleration_air`

Those work like the existing `gravity`, `jump` and `speed`. With this update you will be able to modify certain parts of the player movement physics on a per-player basis.

To learn how it works, see the documentation updates in this PR.

## Special notes
Note about all `liquid_*` modifiers: Only nodes with `liquid_move_physics=true` are considered to be liquids for these modifiers. Don't worry, this field is true by default for nodes with `liquidtype~="none"`, i.e. most "traditional" liquid nodes.

Note about `liquid_fluidity`: This is based on `movement_liquid_fluidity` setting. But this setting currently behaves a bit buggy for very small values and is completely broke for value 0. Thus, the documentation states that `liquid_fluidity` values <1 are taboo. The reason for this is #11464. Note that most values for `liquid_fluidity` that are <1 are probably still fine and only those close to 0 are problematic, but I'm not taking any chances here, since speed in liquids depends on various other factors. As long you stay at 1 or larger for `liquid_fluidity`, this attribute is safe, according to my tests. Even `math.huge` works.

Note about `speed_climb`: As stated in the documentation, the actual climb speed is `speed` times `speed_climb`, not `speed_climb` alone. This is unfortunate, and obviously it would be better if those two were completely separate, but I can't change that. Note that `speed` is of course much older than `speed_climb` and yes, its current behavior (before the PR) also modifies the climbing speed, so that behavior has to stay for compability. Also, with some simple math, modders should be able to deal with this. 

## To do

Ready for Review.

## How to test

* In DevTest with `luacmd` mod, call `me:set_physics_override(table_of_physics_you_want_to_test)`
* Check if it does what you expect to / what the documentation promises
* For liquid, use the "move resistance" nodes in DevTest (those with the letter R on it). The `liquid_*` modifiers should affect the "liquidlike" move resistance nodes (as well as "classic" liquids like water and lava). The other move resistance nodes (non-liquidlike) should NOT be affected by the `liquid_*` modifiers.

## What I did NOT do

* Test if anti-cheat doesn't have any false-positives. Probably only relevant for `climb_speed` as it's the only one that can make you faster than the base speed. And I am guessing `climb_speed` might actually already be covered by the lax Y speed check due to bouncy nodes (`PlayerSAO::checkMovementCheat`)
* Compability with old clients/servers (I think 5.5.0 will already be incompatible with 5.4.0 anyway, so I didn't bother)
* Change the core player physics logic in any way. All I did is expose some modifiers for `movement_*` settings. If you don't ever all `set_physics_override`, everything should be the same as before

## Use cases, justification, rationale, etc.

See #11460.
