### PR TITLE
Add joystick layout for DragonRise GameCube controller

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -146,7 +146,7 @@ enable_joysticks (Enable joysticks) bool false
 joystick_id (Joystick ID) int 0
 
 #    The type of joystick
-joystick_type (Joystick type) enum auto auto,generic,xbox
+joystick_type (Joystick type) enum auto auto,generic,xbox,dragonrise_gamecube
 
 #    The time in seconds it takes between repeated events
 #    when holding down a joystick button combination.

--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -154,6 +154,54 @@ JoystickLayout create_xbox_layout()
 	return jlo;
 }
 
+JoystickLayout create_dragonrise_gamecube_layout()
+{
+	JoystickLayout jlo;
+
+	jlo.axes_deadzone = 7000;
+
+	const JoystickAxisLayout axes[JA_COUNT] = {
+		// Control Stick
+		{0, 1}, // JA_SIDEWARD_MOVE
+		{1, 1}, // JA_FORWARD_MOVE
+
+		// C-Stick
+		{3, 1}, // JA_FRUSTUM_HORIZONTAL
+		{4, 1}, // JA_FRUSTUM_VERTICAL
+	};
+	memcpy(jlo.axes, axes, sizeof(jlo.axes));
+
+	// The center button
+	JLO_B_PB(KeyType::ESC, 1 << 9, 1 << 9); // Start/Pause Button
+
+	// Front right buttons
+	JLO_B_PB(KeyType::JUMP,  1 << 2, 1 << 2); // A Button
+	JLO_B_PB(KeyType::AUX1,  1 << 3, 1 << 3); // B Button
+	JLO_B_PB(KeyType::DROP,  1 << 0, 1 << 0); // Y Button
+	JLO_B_PB(KeyType::SNEAK, 1 << 0, 1 << 0); // X Button
+
+	// Triggers
+	JLO_B_PB(KeyType::DIG,       1 << 4, 1 << 4); // L Trigger
+	JLO_B_PB(KeyType::PLACE,     1 << 5, 1 << 5); // R Trigger
+	JLO_B_PB(KeyType::INVENTORY, 1 << 6, 1 << 6); // Z Button
+
+	// D-Pad
+	JLO_A_PB(KeyType::HOTBAR_PREV, 5,  1, jlo.axes_deadzone); // left
+	JLO_A_PB(KeyType::HOTBAR_NEXT, 5, -1, jlo.axes_deadzone); // right
+	// Axis are hard to actuate independantly, best to leave up and down unused.
+	//JLO_A_PB(0, 6,  1, jlo.axes_deadzone); // up
+	//JLO_A_PB(0, 6, -1, jlo.axes_deadzone); // down
+
+	// Movements tied to Control Stick, important for vessels
+	JLO_A_PB(KeyType::LEFT,     0,  1, jlo.axes_deadzone);
+	JLO_A_PB(KeyType::RIGHT,    0, -1, jlo.axes_deadzone);
+	JLO_A_PB(KeyType::FORWARD,  1,  1, jlo.axes_deadzone);
+	JLO_A_PB(KeyType::BACKWARD, 1, -1, jlo.axes_deadzone);
+
+	return jlo;
+}
+
+
 JoystickController::JoystickController() :
 		doubling_dtime(g_settings->getFloat("repeat_joystick_button_time"))
 {
@@ -187,6 +235,8 @@ void JoystickController::setLayoutFromControllerName(const std::string &name)
 {
 	if (lowercase(name).find("xbox") != std::string::npos) {
 		m_layout = create_xbox_layout();
+	} else if (lowercase(name).find("dragonrise_gamecube") != std::string::npos) {
+		m_layout = create_dragonrise_gamecube_layout();
 	} else {
 		m_layout = create_default_layout();
 	}

--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -176,9 +176,9 @@ JoystickLayout create_dragonrise_gamecube_layout()
 
 	// Front right buttons
 	JLO_B_PB(KeyType::JUMP,  1 << 2, 1 << 2); // A Button
-	JLO_B_PB(KeyType::AUX1,  1 << 3, 1 << 3); // B Button
+	JLO_B_PB(KeyType::SNEAK, 1 << 3, 1 << 3); // B Button
 	JLO_B_PB(KeyType::DROP,  1 << 0, 1 << 0); // Y Button
-	JLO_B_PB(KeyType::SNEAK, 1 << 0, 1 << 0); // X Button
+	JLO_B_PB(KeyType::AUX1,  1 << 1, 1 << 1); // X Button
 
 	// Triggers
 	JLO_B_PB(KeyType::DIG,       1 << 4, 1 << 4); // L Trigger


### PR DESCRIPTION
Adds controller layout profile for the DragonRise GameCube controller. Followed the xbox controller introduction as a template https://github.com/minetest/minetest/pull/5506.

Relates to https://github.com/minetest/minetest/issues/4153 and should help anyone with the same controller.

Since it appears DragonRise uses the same vendor/product ID for all their handsets and just wires the controller differently, the product name for my handset is `DragonRise Inc.   Generic   USB  Joystick`. Since they make other controllers which I do not own and cannot test, I don't think using this to autodetect the profile is wise. I've set the layout name (`joystick_type`) to `dragonrise_gamecube` which will not match automatically this controller, but shouldn't erroneously match any other controllers. Users with this controller will have to manually set the `joystick_type`. Obviously this could get out of hand quickly with everyone adding their own joysticks in the code, but considering this is only the second I think it's probably OK for now (of course, I'm new here).

## To do

**Ready for Review.**

## How to test

Buy yourself a DragonRise GameCube controller or find a way to emulate one :wink:, manually enable the profile and try playing the game.
