### PR TITLE
Multipass shadow mapping

### DIFF
--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -122,6 +122,9 @@ public:
 		v3s16 *p_blocks_min, v3s16 *p_blocks_max, float range=-1.0f);
 	void updateDrawList();
 	void updateDrawListShadow(const v3f &shadow_light_pos, const v3f &shadow_light_dir, float shadow_range);
+	// Update m_pointlight_list vector according to the current m_drawlist_shadow from ClientMap.
+	// It will loop through each MapNode of each MapBlock contained in that list and check if that is a light node, then add it.
+	void updatePointLightList();
 	void renderMap(video::IVideoDriver* driver, s32 pass);
 
 	void renderMapShadows(video::IVideoDriver *driver,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4063,6 +4063,8 @@ void Game::updateShadows()
 	shadow->setTimeOfDay(in_timeofday);
 
 	shadow->getDirectionalLight().update_frustum(camera, client);
+
+	m_client->getEnv().getClientMap().updatePointLightList();
 }
 
 /****************************************************************************

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -22,17 +22,21 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_bloated.h"
 #include <matrix4.h>
 #include "util/basic_macros.h"
+#include <array>
+#include "mapnode.h"
 
 class Camera;
 class Client;
 
+typedef core::matrix4 m4f
+
 struct shadowFrustum
 {
-	float zNear{0.0f};
-	float zFar{0.0f};
-	float length{0.0f};
-	core::matrix4 ProjOrthMat;
-	core::matrix4 ViewMat;
+	f32 zNear{0.0f};
+	f32 zFar{0.0f};
+	f32 length{0.0f};
+	m4f ProjOrthMat;
+	m4f ViewMat;
 	v3f position;
 };
 
@@ -57,9 +61,9 @@ public:
 	v3f getPosition() const;
 
 	/// Gets the light's matrices.
-	const core::matrix4 &getViewMatrix() const;
-	const core::matrix4 &getProjectionMatrix() const;
-	core::matrix4 getViewProjMatrix();
+	const m4f &getViewMatrix() const;
+	const m4f &getProjectionMatrix() const;
+	m4f getViewProjMatrix();
 
 	/// Gets the light's far value.
 	f32 getMaxFarValue() const
@@ -99,4 +103,112 @@ private:
 	v3f pos;
 	v3f direction{0};
 	shadowFrustum shadow_frustum;
+};
+
+
+
+// Shadow frustum for point light
+
+struct pLShadowFrustum
+{
+	v3f direction{0.0f};
+
+	f32 nearPlane{0.0f};
+	f32 farPlane{0.0f};
+
+	f32 fov{90.0f};
+
+	m4f ProjPerspectiveMat;
+	m4f ViewMat;
+};
+
+// Enum class of directions
+
+enum class Direction : u16
+{
+	POS_X = 0,
+	NEG_X,
+	POS_Y,
+	NEG_Y,
+	POS_Z,
+	NEG_Z,
+	COUNT
+};
+
+// Point light class
+
+class PointLight
+{
+public:
+	// Constructor
+	PointLight(u32 mapResolution, f32 farPlane, v3f position = v3f(0.0f), video::SColorf diffuseColor = video::SColorf(0xffffffff), MapNode* lightNode = nullptr);
+
+	// Getters
+
+	// Returns list of shadow frustums
+	std::array<pLShadowFrustum, 6> getShadowFrustums() const
+	{
+		return m_shadow_frustums;
+	}
+
+	// Returns certain shadow frustum
+	pLShadowFrustum getShadowFrustum(Direction dir) const
+	{
+		return m_shadow_frustums[dir];
+	}
+
+	// Return light color
+	video::SColorf getLightColor() const
+	{
+		return m_diffuse_color;
+	}
+
+	// Returns frustum position in world coordinates
+	v3f getFrustumPosition() const
+	{
+		return m_position;
+	}
+
+	// Returns depth map resolution
+	u32 getMapResolution() const
+	{
+		return m_map_res;
+	}
+
+	f32 getMaxFarPlane() const
+	{
+		return m_far_plane;
+	}
+
+	// Returns bound light node
+	MapNode* getBoundLightNode() const
+	{
+		return m_light_node;
+	}
+
+	// Sets light color
+	void setLightColor(video::SColorf new_color)
+	{
+		m_diffuse_color = new_color;
+	}
+
+	//void updateShadowDrawList(Client *client) const;
+private:
+	// Color of light
+	video::SColorf m_diffuse_color;
+
+	// Shadow frustums for all 6 directions (+X, -X, +Y, -Y, +Z, -Z)
+	std::array<pLShadowFrustum, 6> m_shadow_frustums;
+
+	// Position of light source
+	v3f m_position;
+
+	// Map resolution
+	u32 m_map_res;
+
+	// Far plane
+	f32 m_far_plane;
+
+	// Point light should be bound to the node that is emitting it
+	MapNode* m_light_node;
 };

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -48,6 +48,46 @@ struct NodeToApply
 	bool dirty{false};
 };
 
+// Enum class of cube map faces
+
+enum class CubeMapFace : u16
+{
+	POSITIVE_X = 0,
+	NEGATIVE_X,
+	POSITIVE_Y,
+	NEGATIVE_Y,
+	POSITIVE_Z,
+	NEGATIVE_Z,
+	COUNT
+};
+
+// Cube map texture
+
+/*class CubeMapTexture
+{
+public:
+	// Default constructor
+	CubeMapTexture() = default;
+
+	// Constructor of 6 2d textures (+X, -X, +Y, -Y, +Z, -Z) with the same data (name, size and format)
+	CubeMapTexture(std::string name, f32 size, video::E_COLOR_FORMAT format);
+
+	~CubeMapTexture();
+
+	// Getters
+
+	std::array<video::ITexture*, 6> getAllData() const;
+
+	video::ITexture* getTexture(CubeMapFace face) const;
+
+private:
+	std::array<video::ITexture*, 6> m_data;
+
+	std::string m_name;
+	core::dimension2du m_size;
+	video::ECOLOR_FORMAT m_format;
+};*/
+
 class ShadowRenderer
 {
 public:
@@ -64,6 +104,18 @@ public:
 	size_t getDirectionalLightCount() const;
 	f32 getMaxShadowFar() const;
 
+	// Add a point light
+	bool addPointLight(v3s16 light_node_pos, MapNode* light_node=nullptr);
+
+	// Gets a point light with index 'index'
+	PointLight &getPointLight(u32 index) const;
+
+	// Gets a total count of point lights
+	size_t getPointLightCount() const;
+
+	// Clears m_pointlight_list
+	void clearPointLightList();
+
 	float getUpdateDelta() const;
 	/// Adds a shadow to the scene node.
 	/// The shadow mode can be ESM_BOTH, or ESM_RECEIVE.
@@ -76,7 +128,7 @@ public:
 
 	void setClearColor(video::SColor ClearColor);
 
-	void update(video::ITexture *outputTarget = nullptr);
+	void update();
 
 	video::ITexture *get_texture()
 	{
@@ -96,10 +148,12 @@ private:
 			video::ECOLOR_FORMAT texture_format,
 			bool force_creation = false);
 
-	void renderShadowMap(video::ITexture *target, DirectionalLight &light,
+	void genShadowMaps(std::string clientmap_name, std::string dynamic_objects_name, std::string colormap_name, std::string final_name
+			video::ITexture* clientmap, video::ITexture* dynamic_objects_map, video::ITexture* colormap, video::ITexture* finalmap);
+	void renderShadowMap(video::ITexture *target, m4f view_mat, m4f proj_mat
 			scene::E_SCENE_NODE_RENDER_PASS pass =
 					scene::ESNRP_SOLID);
-	void renderShadowObjects(video::ITexture *target, DirectionalLight &light);
+	void renderShadowObjects(video::ITexture *target, m4f view_mat, m4f_proj_mat);
 	void mixShadowsQuad();
 
 	// a bunch of variables
@@ -112,9 +166,16 @@ private:
 	video::ITexture *shadowMapTextureDynamicObjects{nullptr};
 	video::ITexture *shadowMapTextureColors{nullptr};
 	video::SColor m_clear_color{0x0};
+	std::array<video::ITexture*, 6> shadowCubeMapClientMap;
+	std::array<video::ITexture*, 6> shadowCubeMapDynamicObjects;
+	std::array<video::ITexture*, 6> shadowCubeMapColors;
+	std::array<video::ITexture*, 6> shadowCubeMapFinal;
 
 	std::vector<DirectionalLight> m_light_list;
 	std::vector<NodeToApply> m_shadow_node_array;
+
+	// List of all point lights within a viewing range
+	std::vector<PointLight> m_pointlight_list;
 
 	float m_shadow_strength;
 	float m_shadow_map_max_distance;


### PR DESCRIPTION
This PR is an extension for #11244 and adds a support for multipass (all-directional) shadow rendering. This means the shadows now are casted not only from the directional light, but also from point light sources as torches, mese post lights, various glow blocks, furniture lamps, street lanterns and etc. Also, there will be a support for casting shadows from glow entities.

**At the moment, this PR is very raw and it is even impossible to compile it for testing, so this is a draft.**

How it works:

The principles of the work are the same, but with some addings (depending on circumstances, they may be much changed):

1. Render client map, dynamic objects and colored map textures for each directional light (currently, the only one).
2. Render client map, dynamic objects and colored map textures for each point light.
  2.1. Loop through each frustum directed from the corresponding face to the outside of point light.
  2.2. Render map blocks from a POV of that frustum to the correponding depth map.
3. Mix all those three textures into one.
4. Call drawAll() with the attached shadow texture.

## To do

This PR is a Work in Progress 

* [x] Concept
* [x] Separate class for point light representation.
* [x] Render to depth maps from each point light.
* [x] Some a bit refactoring in the current ShadowRenderer and DirectionalLight code.
* [x] Add cube map texture class container saving all 6 video::ITexture`s. 
* [ ] Write separate depth shaders for point lights or use the current ones (?).
* [ ] Limit shadow casting from point light based on its maximum light extension range (currently I don`t know how to).
* [ ] Add higher-level rendering calls (in Game::update()).
* [ ] Some still additional code (?).
* [ ] Test the resulted code.

## How to test
Currently testing is impossible.
