### PR TITLE
Fix scaled world-aligned textures being aligned inconsistently for non-normal drawtypes 

### DIFF
--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -407,20 +407,20 @@ static void getNodeTextureCoords(v3f base, const v3f &scale, const v3s16 &dir, f
 	if (dir.X > 0 || dir.Y != 0 || dir.Z < 0)
 		base -= scale;
 	if (dir == v3s16(0,0,1)) {
-		*u = -base.X - 1;
-		*v = -base.Y - 1;
+		*u = -base.X;
+		*v = -base.Y;
 	} else if (dir == v3s16(0,0,-1)) {
 		*u = base.X + 1;
-		*v = -base.Y - 2;
+		*v = -base.Y - 1;
 	} else if (dir == v3s16(1,0,0)) {
 		*u = base.Z + 1;
-		*v = -base.Y - 2;
-	} else if (dir == v3s16(-1,0,0)) {
-		*u = -base.Z - 1;
 		*v = -base.Y - 1;
+	} else if (dir == v3s16(-1,0,0)) {
+		*u = -base.Z;
+		*v = -base.Y;
 	} else if (dir == v3s16(0,1,0)) {
 		*u = base.X + 1;
-		*v = -base.Z - 2;
+		*v = -base.Z - 1;
 	} else if (dir == v3s16(0,-1,0)) {
 		*u = base.X + 1;
 		*v = base.Z + 1;


### PR DESCRIPTION
Fixes #11401.

## To do

This PR is Ready for Review.

## How to test

StartDev test and place a lot of `tiled` nodes (both normal and stairs) and check if the pattern is always correct, viewed from any direction (up, down, left, right, front, back).