### PR TITLE
Remove unused header includes

### DIFF
--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -19,7 +19,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include <IrrlichtDevice.h>
-#include <irrlicht.h>
 #include "fontengine.h"
 #include "client.h"
 #include "clouds.h"

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -21,7 +21,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <SViewFrustum.h>
 #include <IAnimatedMeshSceneNode.h>
-#include <ILightSceneNode.h>
 #include "porting.h"
 
 GUIScene::GUIScene(gui::IGUIEnvironment *env, scene::ISceneManager *smgr,

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -32,8 +32,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <iostream>
 #include <algorithm>
 
-#include <ISceneCollisionManager.h>
-
 using namespace irr::core;
 
 const char **button_imagenames = (const char *[]) {


### PR DESCRIPTION
Remove unnecessary header includes.
We do not actually use light scene nodes or the collision manager, and inclusion of irrlicht.h anywhere is a blunder.

Ready for review.