### PR TITLE
Document glasslikeliquidlevel merge bits

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -247,7 +247,7 @@ Media files (textures, sounds, whatever) that will be transferred to the
 client and will be available for use by the mod and translation files for
 the clients (see [Translations]).
 
-It is suggested to use the folders for the purpous they are thought for,
+It is suggested to use the folders for the purpose they are thought for,
 eg. put textures into `textures`, translation files into `locale`,
 models for entities or meshnodes into `models` et cetera.
 
@@ -3607,7 +3607,7 @@ A whole number, 1 or more.
 Each additional octave adds finer detail to the noise but also increases the
 noise calculation load.
 3 is a typical minimum for a high quality, complex and natural-looking noise
-variation. 1 octave has a slight 'gridlike' appearence.
+variation. 1 octave has a slight 'gridlike' appearance.
 
 Choose the number of octaves according to the `spread` and `lacunarity`, and the
 size of the finest detail you require. For example:
@@ -7204,7 +7204,7 @@ Used by `minetest.register_abm`.
         chance = 1,
         -- Chance of triggering `action` per-node per-interval is 1.0 / this
         -- value
-        
+
         min_y = -32768,
         max_y = 32767,
         -- min and max height levels where ABM will be processed

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1085,9 +1085,14 @@ The function of `param2` is determined by `paramtype2` in node definition.
       palette. The palette should have 32 pixels.
 * `paramtype2 = "glasslikeliquidlevel"`
     * Only valid for "glasslike_framed" or "glasslike_framed_optional"
-      drawtypes.
-    * `param2` values 0-63 define 64 levels of internal liquid, 0 being empty
-      and 63 being full.
+      drawtypes. "glasslike_framed_optional" nodes are only affected if the
+      "Connected Glass" setting is enabled.
+    * Bits 0-5 define 64 levels of internal liquid, 0 being empty and 63 being
+      full.
+    * Bits 6 and 7 modify the appearance of the frame and node faces. One or
+      both of these values may be added to `param2`:
+        * 64  - Makes the node not connect with neighbors above or below it.
+        * 128 - Makes the node not connect with neighbors to its sides.
     * Liquid texture is defined using `special_tiles = {"modname_tilename.png"}`
 * `paramtype2 = "colordegrotate"`
     * Same as `degrotate`, but with colors.


### PR DESCRIPTION
Fixes Lua API documentation for "glasslikeliquidlevel", which currently does not mention the horizontal/vertical merge bits used by the engine. Also fixes a couple typos in the documentation.

## To do

This PR is Ready for Review.

## How to test

Check the documentation changes and make sure they're sensical. :)
