### PR TITLE
Move updating shadows outside of RenderingCore::drawAll.

### DIFF
--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -76,19 +76,18 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 	draw_wield_tool = _draw_wield_tool;
 	draw_crosshair = _draw_crosshair;
 
+	if (shadow_renderer)
+		shadow_renderer->update();
+
 	beforeDraw();
 	drawAll();
 }
 
 void RenderingCore::draw3D()
 {
-	if (shadow_renderer) {
-		// Shadow renderer will handle the draw stage
-		shadow_renderer->setClearColor(skycolor);
-		shadow_renderer->update();
-	} else {
-		smgr->drawAll();
-	}
+	smgr->drawAll();
+	if (shadow_renderer)
+		shadow_renderer->drawDebug();
 
 	driver->setTransform(video::ETS_WORLD, core::IdentityMatrix);
 	if (!show_hud)

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -146,11 +146,6 @@ void ShadowRenderer::removeNodeFromShadowList(scene::ISceneNode *node)
 	}
 }
 
-void ShadowRenderer::setClearColor(video::SColor ClearColor)
-{
-	m_clear_color = ClearColor;
-}
-
 void ShadowRenderer::updateSMTextures()
 {
 	if (!m_shadows_enabled || m_smgr->getActiveCamera() == nullptr) {

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -242,6 +242,7 @@ void ShadowRenderer::updateSMTextures()
 				// This is also handled in ClientMap.
 				if (m_current_frame == m_map_shadow_update_frames - 1) {
 					if (m_shadow_map_colored) {
+						m_driver->setRenderTarget(0, false, false);
 						m_driver->setRenderTarget(shadowMapTextureColors,
 								true, false, video::SColor(255, 255, 255, 255));
 					}
@@ -273,7 +274,6 @@ void ShadowRenderer::updateSMTextures()
 void ShadowRenderer::update(video::ITexture *outputTarget)
 {
 	if (!m_shadows_enabled || m_smgr->getActiveCamera() == nullptr) {
-		m_smgr->drawAll();
 		return;
 	}
 
@@ -308,36 +308,34 @@ void ShadowRenderer::update(video::ITexture *outputTarget)
 			m_driver->setRenderTarget(0, false, false);
 
 		} // end for lights
-
-		// now render the actual MT render pass
-		m_driver->setRenderTarget(outputTarget, true, true, m_clear_color);
-		m_smgr->drawAll();
-
-		/* this code just shows shadows textures in screen and in ONLY for debugging*/
-		#if 0
-		// this is debug, ignore for now.
-		m_driver->draw2DImage(shadowMapTextureFinal,
-				core::rect<s32>(0, 50, 128, 128 + 50),
-				core::rect<s32>({0, 0}, shadowMapTextureFinal->getSize()));
-
-		m_driver->draw2DImage(shadowMapClientMap,
-				core::rect<s32>(0, 50 + 128, 128, 128 + 50 + 128),
-				core::rect<s32>({0, 0}, shadowMapTextureFinal->getSize()));
-		m_driver->draw2DImage(shadowMapTextureDynamicObjects,
-				core::rect<s32>(0, 128 + 50 + 128, 128,
-						128 + 50 + 128 + 128),
-				core::rect<s32>({0, 0}, shadowMapTextureDynamicObjects->getSize()));
-
-		if (m_shadow_map_colored) {
-
-			m_driver->draw2DImage(shadowMapTextureColors,
-					core::rect<s32>(128,128 + 50 + 128 + 128,
-							128 + 128, 128 + 50 + 128 + 128 + 128),
-					core::rect<s32>({0, 0}, shadowMapTextureColors->getSize()));
-		}
-		#endif
-		m_driver->setRenderTarget(0, false, false);
 	}
+}
+
+void ShadowRenderer::drawDebug()
+{
+	/* this code just shows shadows textures in screen and in ONLY for debugging*/
+	#if 0
+	// this is debug, ignore for now.
+	m_driver->draw2DImage(shadowMapTextureFinal,
+			core::rect<s32>(0, 50, 128, 128 + 50),
+			core::rect<s32>({0, 0}, shadowMapTextureFinal->getSize()));
+
+	m_driver->draw2DImage(shadowMapClientMap,
+			core::rect<s32>(0, 50 + 128, 128, 128 + 50 + 128),
+			core::rect<s32>({0, 0}, shadowMapTextureFinal->getSize()));
+	m_driver->draw2DImage(shadowMapTextureDynamicObjects,
+			core::rect<s32>(0, 128 + 50 + 128, 128,
+					128 + 50 + 128 + 128),
+			core::rect<s32>({0, 0}, shadowMapTextureDynamicObjects->getSize()));
+
+	if (m_shadow_map_colored) {
+
+		m_driver->draw2DImage(shadowMapTextureColors,
+				core::rect<s32>(128,128 + 50 + 128 + 128,
+						128 + 128, 128 + 50 + 128 + 128 + 128),
+				core::rect<s32>({0, 0}, shadowMapTextureColors->getSize()));
+	}
+	#endif
 }
 
 

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -76,6 +76,7 @@ public:
 	void setClearColor(video::SColor ClearColor);
 
 	void update(video::ITexture *outputTarget = nullptr);
+	void drawDebug();
 
 	video::ITexture *get_texture()
 	{

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -73,8 +73,6 @@ public:
 			E_SHADOW_MODE shadowMode = ESM_BOTH);
 	void removeNodeFromShadowList(scene::ISceneNode *node);
 
-	void setClearColor(video::SColor ClearColor);
-
 	void update(video::ITexture *outputTarget = nullptr);
 	void drawDebug();
 
@@ -113,7 +111,6 @@ private:
 	video::ITexture *shadowMapTextureFinal{nullptr};
 	video::ITexture *shadowMapTextureDynamicObjects{nullptr};
 	video::ITexture *shadowMapTextureColors{nullptr};
-	video::SColor m_clear_color{0x0};
 
 	std::vector<DirectionalLight> m_light_list;
 	std::vector<NodeToApply> m_shadow_node_array;

--- a/src/client/shadows/shadowsScreenQuad.cpp
+++ b/src/client/shadows/shadowsScreenQuad.cpp
@@ -51,17 +51,11 @@ void shadowScreenQuadCB::OnSetConstants(
 		video::IMaterialRendererServices *services, s32 userData)
 {
 	s32 TextureId = 0;
-	services->setPixelShaderConstant(
-		services->getPixelShaderConstantID("ShadowMapClientMap"),
-		&TextureId, 1);
+	m_sm_client_map_setting.set(&TextureId, services);
 
 	TextureId = 1;
-	services->setPixelShaderConstant(
-		services->getPixelShaderConstantID("ShadowMapClientMapTraslucent"),
-		&TextureId, 1);
+	m_sm_client_map_trans_setting.set(&TextureId, services);
 
 	TextureId = 2;
-	services->setPixelShaderConstant(
-		services->getPixelShaderConstantID("ShadowMapSamplerdynamic"),
-		&TextureId, 1);
+	m_sm_dynamic_sampler_setting.set(&TextureId, services);
 }

--- a/src/client/shadows/shadowsScreenQuad.h
+++ b/src/client/shadows/shadowsScreenQuad.h
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include <IMaterialRendererServices.h>
 #include <IShaderConstantSetCallBack.h>
-#include "../shader.h"
+#include "client/shader.h"
 
 class shadowScreenQuad
 {

--- a/src/client/shadows/shadowsScreenQuad.h
+++ b/src/client/shadows/shadowsScreenQuad.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include <IMaterialRendererServices.h>
 #include <IShaderConstantSetCallBack.h>
+#include "../shader.h"
 
 class shadowScreenQuad
 {
@@ -38,8 +39,16 @@ private:
 class shadowScreenQuadCB : public video::IShaderConstantSetCallBack
 {
 public:
-	shadowScreenQuadCB(){};
+	shadowScreenQuadCB() :
+			m_sm_client_map_setting("ShadowMapClientMap"),
+			m_sm_client_map_trans_setting("ShadowMapClientMapTraslucent"),
+			m_sm_dynamic_sampler_setting("ShadowMapSamplerdynamic")
+	{}
 
 	virtual void OnSetConstants(video::IMaterialRendererServices *services,
 			s32 userData);
+private:
+	CachedPixelShaderSetting<s32> m_sm_client_map_setting;
+	CachedPixelShaderSetting<s32> m_sm_client_map_trans_setting;
+	CachedPixelShaderSetting<s32> m_sm_dynamic_sampler_setting;
 };

--- a/src/client/shadows/shadowsshadercallbacks.cpp
+++ b/src/client/shadows/shadowsshadercallbacks.cpp
@@ -28,17 +28,9 @@ void ShadowDepthShaderCB::OnSetConstants(
 	lightMVP *= driver->getTransform(video::ETS_VIEW);
 	lightMVP *= driver->getTransform(video::ETS_WORLD);
 
-	services->setVertexShaderConstant(
-		services->getPixelShaderConstantID("LightMVP"),
-		lightMVP.pointer(), 16);
-
-	services->setVertexShaderConstant(
-		services->getPixelShaderConstantID("MapResolution"), &MapRes, 1);
-	services->setVertexShaderConstant(
-		services->getPixelShaderConstantID("MaxFar"), &MaxFar, 1);
-
+	m_light_mvp_setting.set(lightMVP.pointer(), services);
+	m_map_resolution_setting.set(&MapRes, services);
+	m_max_far_setting.set(&MaxFar, services);
 	s32 TextureId = 0;
-	services->setPixelShaderConstant(
-		services->getPixelShaderConstantID("ColorMapSampler"), &TextureId,
-		1);
+	m_color_map_sampler_setting.set(&TextureId, services);
 }

--- a/src/client/shadows/shadowsshadercallbacks.h
+++ b/src/client/shadows/shadowsshadercallbacks.h
@@ -21,14 +21,28 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include <IMaterialRendererServices.h>
 #include <IShaderConstantSetCallBack.h>
+#include "../shader.h"
 
 class ShadowDepthShaderCB : public video::IShaderConstantSetCallBack
 {
 public:
+	ShadowDepthShaderCB() :
+			m_light_mvp_setting("LightMVP"),
+			m_map_resolution_setting("MapResolution"),
+			m_max_far_setting("MaxFar"),
+			m_color_map_sampler_setting("ColorMapSampler")
+	{}
+
 	void OnSetMaterial(const video::SMaterial &material) override {}
 
 	void OnSetConstants(video::IMaterialRendererServices *services,
 			s32 userData) override;
 
 	f32 MaxFar{2048.0f}, MapRes{1024.0f};
+
+private:
+	CachedVertexShaderSetting<f32, 16> m_light_mvp_setting;
+	CachedVertexShaderSetting<f32> m_map_resolution_setting;
+	CachedVertexShaderSetting<f32> m_max_far_setting;
+	CachedPixelShaderSetting<s32> m_color_map_sampler_setting;
 };

--- a/src/client/shadows/shadowsshadercallbacks.h
+++ b/src/client/shadows/shadowsshadercallbacks.h
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include <IMaterialRendererServices.h>
 #include <IShaderConstantSetCallBack.h>
-#include "../shader.h"
+#include "client/shader.h"
 
 class ShadowDepthShaderCB : public video::IShaderConstantSetCallBack
 {


### PR DESCRIPTION
Fixes indirect rendering modes such as some 3D modes mentioned in #11437 and undersampled rendering.
Does not fully fix anaglyph 3d mode.

This PR is Ready for Review.

## How to test

1. Start Minetest, choose one of the following:
  * 3D Mode (anaglyph, side by side etc.)
  * Undersampling > 1

2. Launch any game.
3. You should be able to see the world, HUD, wield etc.