### PR TITLE
feat(main_menu): add optional parent param to messagebox function

### DIFF
--- a/builtin/fstk/dialog.lua
+++ b/builtin/fstk/dialog.lua
@@ -68,14 +68,14 @@ function dialog_create(name,get_formspec,buttonhandler,eventhandler)
 	return self
 end
 
-function messagebox(name, message)
-	return dialog_create(name,
+function messagebox(name, message, parent)
+	local dlg = dialog_create(name,
 			function()
 				return ([[
 					formspec_version[3]
-					size[8,3]
-					textarea[0.375,0.375;7.25,1.2;;;%s]
-					button[3,1.825;2,0.8;ok;%s]
+					size[8,4]
+					textarea[0.375,0.375;7.25,2.2;;;%s]
+					button[3,2.825;2,0.8;ok;%s]
 				]]):format(message, fgettext("OK"))
 			end,
 			function(this, fields)
@@ -85,4 +85,10 @@ function messagebox(name, message)
 				end
 			end,
 			nil)
+	if parent then
+		dlg:set_parent(parent)
+		parent:hide()
+		dlg:show()
+	end
+	return dlg
 end


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- add optional parent parameter to messagebox function

Now, You can call `messagebox(name, msg, parent)` directly instead of:

```lua
local dlg = messagebox(name, msg)
dlg:set_parent(this)
parent:hide()
dlg:show()
```

## To do

This PR is a Ready for Review.
<!-- ^ delete one -->

- [ ] List
- [ ] Things
- [ ] To do

## How to test

<!-- Example code or instructions -->
```lua
local dlg = messagebox(name, msg, this)
--dlg:set_parent(this)
--parent:hide()
--dlg:show()
```