### PR TITLE
Night vision

### DIFF
--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -7,6 +7,9 @@ uniform vec3 eyePosition;
 uniform vec3 cameraOffset;
 uniform float animationTimer;
 
+uniform float ambientBrightness = 0.0;
+uniform vec4 ambientColorTint = vec4(1.0,1.0,1.0,1.0);
+
 varying vec3 vNormal;
 varying vec3 vPosition;
 // World position in the visible world (i.e. relative to the cameraOffset.)
@@ -191,6 +194,12 @@ void main(void)
 		0.07 * brightness);
 
 	varColor = clamp(color, 0.0, 1.0);
+
+	varColor.rgb = (1 - (1 - varColor.rgb) * (1 - ambientBrightness)) * ambientColorTint.rgb;
+	// adjust nightRatio for the ambient brightness, assuming that
+	// it only contributes to the 'night' part of the lighting.
+	nightRatio = 1 - brightness * (1 - nightRatio) * (1 - ambientBrightness) /
+			(1 - (1 - brightness) * (1 - ambientBrightness));
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	vec3 nNormal = normalize(vNormal);

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -195,11 +195,12 @@ void main(void)
 
 	varColor = clamp(color, 0.0, 1.0);
 
-	varColor.rgb = (1 - (1 - varColor.rgb) * (1 - ambientBrightness)) * ambientColorTint.rgb;
-	// adjust nightRatio for the ambient brightness, assuming that
-	// it only contributes to the 'night' part of the lighting.
-	nightRatio = 1 - brightness * (1 - nightRatio) * (1 - ambientBrightness) /
-			(1 - (1 - brightness) * (1 - ambientBrightness));
+	const float light_factor = 0.9; // this portion of the color is light
+	const float shade_factor = 1.0 - light_factor; // this portion of the color is shading
+
+	vec3 shades = ambientBrightness * (1.0 - clamp(shade_factor - varColor.rgb, 0.0, shade_factor) / shade_factor);
+	vec3 lights = 1.0 -  (1.0 - ambientBrightness) * clamp(1 - varColor.rgb, 0.0, light_factor) / light_factor;
+	varColor.rgb = (shades + lights) * ambientColorTint.rgb;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	vec3 nNormal = normalize(vNormal);

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -114,6 +114,46 @@ float snoise(vec3 p)
 
 #endif
 
+vec3 rgb2hsv(vec3 color)
+{
+	float _max = max(color.r, max(color.g, color.b));
+	float _min = min(color.r, min(color.g, color.b));
+	float delta = _max-_min;
+	float hue = 0;
+	float sat = 0;
+	if (delta != 0)
+	{
+		if (color.r == _max)
+			hue = (color.g - color.b) / delta;
+		else if (color.g == _max)
+			hue = (color.b - color.r) / delta + 2;
+		else
+			hue = (color.r - color.g) / delta + 4;
+		if (hue < 0)
+			hue += 6;
+		hue /= 6.0;
+		sat = delta / _max;
+	}
+	return clamp(vec3(hue, sat, _max), vec3(0.0), vec3(1.0));
+}
+
+vec3 hsv2rgb(vec3 color)
+{
+	float c = color.g * color.b; // s*v
+	float x = c * (1.0 - abs(mod(color.r * 6.0, 2) - 1));
+	float m = color.b - c; // v - c
+	if (color.r < 1.0/6.0)
+		return vec3(c, x, 0) + m;
+	if (color.r < 2.0/6.0)
+		return vec3(x, c, 0) + m;
+	if (color.r < 3.0/6.0)
+		return vec3(0, c, x) + m;
+	if (color.r < 4.0/6.0)
+		return vec3(0, x, c) + m;
+	if (color.r < 5.0/6.0)
+		return vec3(x, 0, c) + m;
+	return vec3(c, 0, x) + m;
+}
 
 
 
@@ -181,26 +221,30 @@ void main(void)
 #else
 	vec4 color = inVertexColor;
 #endif
-	// The alpha gives the ratio of sunlight in the incoming light.
-	nightRatio = 1.0 - color.a;
-	color.rgb = color.rgb * (color.a * dayLight.rgb +
-		nightRatio * artificialLight.rgb) * 2.0;
-	color.a = 1.0;
+	// incoming color is downscaled
+	color.rgb *= 2.0;
 
+	// adjust the brightness, preserving hue and contrast
+
+	// light/shadow balance in the vertex color
+	// this value must match COLOR_LIGHT_FACTOR in mapblock_mesh.cpp
+	const float light_fraction = 0.9;
+	vec3 hsv = rgb2hsv(color.rgb);
+	hsv.b = clamp((pow(hsv.b, log(0.5 * ambientBrightness + 0.5) / log(0.5)) - 1 + light_fraction) / light_fraction, 0.0, 1.0);
+	color.rgb = hsv2rgb(hsv.rgb);
+
+	// The alpha gives the ratio of sunlight in the incoming light.
+	nightRatio = min(1.0, 1.0 - color.a + ambientBrightness);
+	color.rgb = color.rgb * mix(dayLight.rgb, artificialLight.rgb, nightRatio);
+	color.a = 1.0;
 	// Emphase blue a bit in darker places
 	// See C++ implementation in mapblock_mesh.cpp final_color_blend()
 	float brightness = (color.r + color.g + color.b) / 3.0;
 	color.b += max(0.0, 0.021 - abs(0.2 * brightness - 0.021) +
 		0.07 * brightness);
 
+	varColor.rgb *= ambientColorTint.rgb;
 	varColor = clamp(color, 0.0, 1.0);
-
-	const float light_factor = 0.9; // this portion of the color is light
-	const float shade_factor = 1.0 - light_factor; // this portion of the color is shading
-
-	vec3 shades = ambientBrightness * (1.0 - clamp(shade_factor - varColor.rgb, 0.0, shade_factor) / shade_factor);
-	vec3 lights = 1.0 -  (1.0 - ambientBrightness) * clamp(1 - varColor.rgb, 0.0, light_factor) / light_factor;
-	varColor.rgb = (shades + lights) * ambientColorTint.rgb;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	vec3 nNormal = normalize(vNormal);

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -185,7 +185,8 @@ void main(void)
 
 	// light/shadow balance in the vertex color
 	// 0.9 is the value of COLOR_LIGHT_FACTOR in mapblock_mesh.cpp
-	const float base_point = 1 - 0.9;
+	const float light_fraction = 0.9;
+	const float base_point = 1 - light_fraction;
 	// get color value as the largest component
 	float color_value = max(color.r, max(color.g, color.b));
 	// scale color relative to its value (like HSV)
@@ -193,8 +194,8 @@ void main(void)
 	// adjust color value as scaled brightness - scaled shades (e.g. ambient occlusion)
 	color_value = 1 - (1 - color_value) * (1 - ambientBrightness) - 
 			0.3 * ambientBrightness * max(0, base_point - color_value) / base_point;
-	 // stretch back to original color space
-	color_value = (color_value - 1 + light_fraction) / light_fraction;
+	// stretch back to original color space
+	color_value = (color_value - base_point) / light_fraction;
 	// restore the color
 	color.rgb *= color_value;
 

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -16,7 +16,6 @@ centroid varying vec2 varTexCoord;
 #endif
 
 varying vec3 eyeVec;
-varying float vIDiff;
 
 const float e = 2.718281828459;
 const float BS = 10.0;
@@ -343,7 +342,6 @@ void main(void)
 	color = base.rgb;
 	vec4 col = vec4(color.rgb, base.a);
 	col.rgb *= varColor.rgb;
-	col.rgb *= emissiveColor.rgb * vIDiff;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	float shadow_int = 0.0;

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -3,6 +3,11 @@ uniform mat4 mWorld;
 uniform vec3 eyePosition;
 uniform float animationTimer;
 
+uniform vec4 emissiveColor; // emissiveColor holds lighting for objects
+
+uniform float ambientBrightness = 0.0;
+uniform vec4 ambientColorTint = vec4(1.0,1.0,1.0,1.0);
+
 varying vec3 vNormal;
 varying vec3 vPosition;
 varying vec3 worldPosition;
@@ -28,7 +33,6 @@ centroid varying vec2 varTexCoord;
 #endif
 
 varying vec3 eyeVec;
-varying float vIDiff;
 
 const float e = 2.718281828459;
 const float BS = 10.0;
@@ -65,11 +69,11 @@ void main(void)
 	eyeVec = -(mWorldView * inVertexPosition).xyz;
 
 #if (MATERIAL_TYPE == TILE_MATERIAL_PLAIN) || (MATERIAL_TYPE == TILE_MATERIAL_PLAIN_ALPHA)
-	vIDiff = 1.0;
+	float vIDiff = 1.0;
 #else
 	// This is intentional comparison with zero without any margin.
 	// If normal is not equal to zero exactly, then we assume it's a valid, just not normalized vector
-	vIDiff = length(inVertexNormal) == 0.0
+	float vIDiff = length(inVertexNormal) == 0.0
 		? 1.0
 		: directional_ambient(normalize(inVertexNormal));
 #endif
@@ -79,6 +83,9 @@ void main(void)
 #else
 	varColor = inVertexColor;
 #endif
+
+	varColor *= emissiveColor * vIDiff;
+	varColor.rgb = (1 - (1 - varColor.rgb) * (1 - ambientBrightness)) * ambientColorTint.rgb;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6922,7 +6922,9 @@ object you are working with still exists.
     * Resource intensive - use sparsely
     * To get blockpos, integer divide pos by 16
 * `set_lighting(light_definition)`: sets lighting for the player
-    * `light_definition` is a table.
+    * `light_definition` is a table with the following optional fields:
+        * `brightness` - amount of added ambient light from 0 (no added light) to 1 (full brightness).
+        * `color_tint` - color that is applied to the rendered image.
     * Returns true on success.
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6921,6 +6921,11 @@ object you are working with still exists.
     * Returns `false` if failed.
     * Resource intensive - use sparsely
     * To get blockpos, integer divide pos by 16
+* `set_lighting(light_definition)`: sets lighting for the player
+    * `light_definition` is a table.
+    * Returns true on success.
+* `get_lighting()`: returns the current state of lighting for the player.
+    * Result is a table with the same fields as `light_definition` in `set_lighting`.
 
 `PcgRandom`
 -----------

--- a/games/devtest/mods/experimental/init.lua
+++ b/games/devtest/mods/experimental/init.lua
@@ -7,6 +7,7 @@ experimental = {}
 dofile(minetest.get_modpath("experimental").."/detached.lua")
 dofile(minetest.get_modpath("experimental").."/items.lua")
 dofile(minetest.get_modpath("experimental").."/commands.lua")
+dofile(minetest.get_modpath("experimental").."/lighting.lua")
 
 function experimental.print_to_everything(msg)
 	minetest.log("action", msg)

--- a/games/devtest/mods/experimental/lighting.lua
+++ b/games/devtest/mods/experimental/lighting.lua
@@ -1,7 +1,13 @@
 core.register_chatcommand("set_lighting", {
-    params = "",
-    description = "Set lighting parameters.",
+    params = "<brightness> [color]",
+    description = "Set lighting parameters. Brightness is a number from 0 to 1, color is an #RRGGBB color",
     func = function(player_name, param)
-        minetest.get_player_by_name(player_name):set_lighting({})
+        local brightness, color_tint = string.match(param, "([^ ]+)(.*)$");
+        if not brightness then
+            return false, "Invalid input, see /help set_lighting"
+        end
+        color_tint = string.gsub(color_tint, " ", "")
+        if color_tint == "" then color_tint = nil end
+        minetest.get_player_by_name(player_name):set_lighting({brightness=tonumber(brightness), color_tint = color_tint})
     end
 })

--- a/games/devtest/mods/experimental/lighting.lua
+++ b/games/devtest/mods/experimental/lighting.lua
@@ -1,0 +1,7 @@
+core.register_chatcommand("set_lighting", {
+    params = "",
+    description = "Set lighting parameters.",
+    func = function(player_name, param)
+        minetest.get_player_by_name(player_name):set_lighting({})
+    end
+})

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -227,6 +227,7 @@ public:
 	void handleCommand_PlayerSpeed(NetworkPacket *pkt);
 	void handleCommand_MediaPush(NetworkPacket *pkt);
 	void handleCommand_MinimapModes(NetworkPacket *pkt);
+	void handleCommand_SetLighting(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -447,6 +447,22 @@ void ClientEnvironment::processActiveObjectMessage(u16 id, const std::string &da
 	}
 }
 
+void ClientEnvironment::applyLighting()
+{
+	if (g_settings->getBool("enable_shaders"))
+		return;
+
+	getClientMap().updateMeshes();
+
+	u32 day_night_ratio = getDayNightRatio();
+	auto cb_state = [day_night_ratio] (ClientActiveObject *cao) {
+		cao->updateLight(day_night_ratio, true);
+	};
+
+	m_ao_manager.step(0, cb_state);
+}
+
+
 /*
 	Callbacks for activeobjects
 */

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -305,7 +305,9 @@ void ClientEnvironment::step(float dtime)
 		node_at_lplayer = m_map->getNode(p);
 
 		u16 light = getInteriorLight(node_at_lplayer, 0, m_client->ndef());
-		final_color_blend(&lplayer->light_color, light, day_night_ratio);
+		light = decode_light(light & 0x0F) |
+				(decode_light(light >> 4) << 8);
+		final_color_blend(&lplayer->light_color, light, day_night_ratio, &lplayer->getLighting());
 	}
 
 	/*

--- a/src/client/clientenvironment.h
+++ b/src/client/clientenvironment.h
@@ -109,6 +109,12 @@ public:
 	void processActiveObjectMessage(u16 id, const std::string &data);
 
 	/*
+	 * Update the lighting of all objects, e.g. when ambient
+	 * light parameters change
+	 */
+	void applyLighting();
+
+	/*
 		Callbacks for activeobjects
 	*/
 

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -364,7 +364,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 					mesh_animate_count < (m_control.range_all ? 200 : 50)) {
 
 				bool animated = mapBlockMesh->animate(faraway, animation_time,
-					crack, daynight_ratio);
+					crack, daynight_ratio, &(m_client->getEnv().getLocalPlayer()->getLighting()));
 				if (animated)
 					mesh_animate_count++;
 			} else {

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -891,3 +891,22 @@ void ClientMap::updateDrawListShadow(const v3f &shadow_light_pos, const v3f &sha
 	g_profiler->avg("SHADOW MapBlocks drawn [#]", m_drawlist_shadow.size());
 	g_profiler->avg("SHADOW MapBlocks loaded [#]", blocks_loaded);
 }
+
+void ClientMap::updateMeshes() const
+{
+	for (auto &sector_it : m_sectors) {
+		MapSector *sector = sector_it.second;
+		if (!sector)
+			continue;
+
+		MapBlockVect sectorblocks;
+		sector->getBlocks(sectorblocks);
+
+		/*
+			Loop through blocks in sector
+		*/
+		for (MapBlock *block : sectorblocks) {
+			m_client->addUpdateMeshTask(block->getPos());
+		}
+	}
+}

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -149,6 +149,7 @@ public:
 	f32 getWantedRange() const { return m_control.wanted_range; }
 	f32 getCameraFov() const { return m_camera_fov; }
 
+	void updateMeshes() const;
 private:
 	// Orders blocks by distance to the camera
 	class MapBlockComparer

--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -42,7 +42,7 @@ public:
 	virtual void addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr) = 0;
 	virtual void removeFromScene(bool permanent) {}
 
-	virtual void updateLight(u32 day_night_ratio) {}
+	virtual void updateLight(u32 day_night_ratio, bool force=false) {}
 
 	virtual bool getCollisionBox(aabb3f *toset) const { return false; }
 	virtual bool getSelectionBox(aabb3f *toset) const { return false; }

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -204,7 +204,7 @@ public:
 
 	void addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr);
 	void removeFromScene(bool permanent);
-	void updateLight(u32 day_night_ratio);
+	void updateLight(u32 day_night_ratio, bool force=false);
 	void updateNodePos();
 
 	void step(float dtime, ClientEnvironment *env);
@@ -276,7 +276,7 @@ void TestCAO::removeFromScene(bool permanent)
 	m_node = NULL;
 }
 
-void TestCAO::updateLight(u32 day_night_ratio)
+void TestCAO::updateLight(u32 day_night_ratio, bool force)
 {
 }
 
@@ -859,7 +859,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 	}
 }
 
-void GenericCAO::updateLight(u32 day_night_ratio)
+void GenericCAO::updateLight(u32 day_night_ratio, bool force)
 {
 	if (m_glow < 0)
 		return;
@@ -882,7 +882,7 @@ void GenericCAO::updateLight(u32 day_night_ratio)
 		light_at_pos = blend_light(day_night_ratio, LIGHT_SUN, 0);
 
 	u8 light = decode_light(light_at_pos + m_glow);
-	if (light != m_last_light) {
+	if (force || light != m_last_light) {
 		m_last_light = light;
 		setNodeLight(light);
 	}
@@ -890,8 +890,9 @@ void GenericCAO::updateLight(u32 day_night_ratio)
 
 void GenericCAO::setNodeLight(u8 light)
 {
-	video::SColor color(255, light, light, light);
+	video::SColor color;
 
+	final_color_blend(&color, light, 1000, &m_env->getLocalPlayer()->getLighting());
 	if (m_prop.visual == "wielditem" || m_prop.visual == "item") {
 		if (m_wield_meshnode)
 			m_wield_meshnode->setNodeLightColor(color);

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -243,7 +243,7 @@ public:
 		m_visuals_expired = true;
 	}
 
-	void updateLight(u32 day_night_ratio);
+	void updateLight(u32 day_night_ratio, bool force=false);
 
 	void setNodeLight(u8 light);
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3266,7 +3266,7 @@ PointedThing Game::updatePointedThing(
 
 		u32 daynight_ratio = client->getEnv().getDayNightRatio();
 		video::SColor c;
-		final_color_blend(&c, light_level, daynight_ratio);
+		final_color_blend(&c, light_level, daynight_ratio, &client->getEnv().getLocalPlayer()->getLighting());
 
 		// Modify final color a bit with time
 		u32 timer = porting::getTimeMs() % 5000;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -422,6 +422,8 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<float, 3> m_camera_offset_vertex;
 	CachedPixelShaderSetting<SamplerLayer_t> m_base_texture;
 	CachedPixelShaderSetting<SamplerLayer_t> m_normal_texture;
+	CachedPixelShaderSetting<float> m_ambient_brightness;
+	CachedPixelShaderSetting<float, 4> m_ambient_color_tint;
 	Client *m_client;
 
 public:
@@ -456,6 +458,8 @@ public:
 		m_camera_offset_vertex("cameraOffset"),
 		m_base_texture("baseTexture"),
 		m_normal_texture("normalTexture"),
+		m_ambient_brightness("ambientBrightness"),
+		m_ambient_color_tint("ambientColorTint"),
 		m_client(client)
 	{
 		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
@@ -528,6 +532,18 @@ public:
 		SamplerLayer_t base_tex = 0, normal_tex = 1;
 		m_base_texture.set(&base_tex, services);
 		m_normal_texture.set(&normal_tex, services);
+
+		const float ambient_brightness(m_client->getEnv().getLocalPlayer()->getLighting().brightness);
+		m_ambient_brightness.set(&ambient_brightness, services);
+
+		const video::SColorf ambient_color(m_client->getEnv().getLocalPlayer()->getLighting().color_tint);
+		float ambient_color_array[4] {
+			ambient_color.r,
+			ambient_color.g,
+			ambient_color.b,
+			ambient_color.a,
+		};
+		m_ambient_color_tint.set(ambient_color_array, services);
 	}
 };
 

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "environment.h"
 #include "constants.h"
 #include "settings.h"
+#include "lighting.h"
 #include <list>
 
 class Client;
@@ -158,6 +159,8 @@ public:
 		added_velocity += vel;
 	}
 
+	inline Lighting& getLighting() { return m_lighting; }
+
 private:
 	void accelerate(const v3f &target_speed, const f32 max_increase_H,
 		const f32 max_increase_V, const bool use_pitch);
@@ -209,4 +212,5 @@ private:
 
 	GenericCAO *m_cao = nullptr;
 	Client *m_client;
+	Lighting m_lighting;
 };

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1148,7 +1148,7 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 					video::SColor *vc = &p.vertices[j].Color;
 					video::SColor copy = *vc;
 					if (vc->getAlpha() == 0) // No sunlight - no need to animate
-						final_color_blend(vc, copy, sunlight, &(data->m_client->getEnv().getLocalPlayer()->getLighting())); // Finalize color
+						final_color_blend(vc, copy, sunlight, &(data->m_lighting)); // Finalize color
 					else // Record color to animate
 						m_daynight_diffs[std::pair<u8, u32>(layer, i)][j] = copy;
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -32,12 +32,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lighting.h"
 #include <array>
 
-// When converting light levels to color value, compress the 
-// value by 10% to give place to ambient occlusion and face shading 
-// at the lowest brightness values.
-static const float COLOR_LIGHT_FACTOR = 0.9f;
-static const float COLOR_SHADE_FACTOR = 1.0f - COLOR_LIGHT_FACTOR;
-
 /*
 	MeshMakeData
 */
@@ -246,10 +240,6 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 			skip_ambient_occlusion_night = true;
 		}
 	}
-
-	// compress brightness to give place to ambient occlusion
-	light_day = (255 - (255 - light_day) * COLOR_LIGHT_FACTOR);
-	light_night = (255 - (255 - light_night) * COLOR_LIGHT_FACTOR);
 
 	if (ambient_occlusion > 4) {
 		static thread_local const float ao_gamma = rangelim(

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -333,14 +333,14 @@ void final_color_blend(video::SColor *result,
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	};
 
-	b += emphase_blue_when_dark[irr::core::clamp((s32) ((r + g + b) / 3 * 255),
-		0, 255) / 8] / 255.0f;
-
 	if (lighting != nullptr) {
 		r = (1 - (1 - r) * (1 - lighting->brightness)) * lighting->color_tint.getRed() * ONE_BY_255;
 		g = (1 - (1 - g) * (1 - lighting->brightness)) * lighting->color_tint.getGreen() * ONE_BY_255;
 		b = (1 - (1 - b) * (1 - lighting->brightness)) * lighting->color_tint.getBlue() * ONE_BY_255;
 	}
+
+	b += emphase_blue_when_dark[irr::core::clamp((s32) ((r + g + b) / 3 * 255),
+		0, 255) / 8] / 255.0f;
 
 	result->setRed(core::clamp((s32) (r * 255.0f), 0, 255));
 	result->setGreen(core::clamp((s32) (g * 255.0f), 0, 255));
@@ -1218,7 +1218,7 @@ MapBlockMesh::~MapBlockMesh()
 }
 
 bool MapBlockMesh::animate(bool faraway, float time, int crack,
-	u32 daynight_ratio)
+	u32 daynight_ratio, const Lighting *lighting)
 {
 	if (!m_has_animation) {
 		m_animation_force_timer = 100000;
@@ -1298,7 +1298,7 @@ bool MapBlockMesh::animate(bool faraway, float time, int crack,
 			video::S3DVertex *vertices = (video::S3DVertex *)buf->getVertices();
 			for (const auto &j : daynight_diff.second)
 				final_color_blend(&(vertices[j.first].Color), j.second,
-						day_color);
+						day_color, lighting);
 		}
 		m_last_daynight_ratio = daynight_ratio;
 	}

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -24,10 +24,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "voxel.h"
 #include <array>
 #include <map>
+#include "lighting.h"
 
 class Client;
 class IShaderSource;
-class Lighting;
 
 /*
 	Mesh making stuff
@@ -45,6 +45,7 @@ struct MeshMakeData
 	bool m_smooth_lighting = false;
 
 	Client *m_client;
+	Lighting m_lighting;
 	bool m_use_shaders;
 
 	MeshMakeData(Client *client, bool use_shaders);

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -96,7 +96,7 @@ public:
 	//   daynight_ratio: 0 .. 1000
 	//   crack: -1 .. CRACK_ANIMATION_LENGTH-1 (-1 for off)
 	// Returns true if anything has been changed.
-	bool animate(bool faraway, float time, int crack, u32 daynight_ratio);
+	bool animate(bool faraway, float time, int crack, u32 daynight_ratio, const Lighting *lighting = nullptr);
 
 	scene::IMesh *getMesh()
 	{

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class Client;
 class IShaderSource;
+class Lighting;
 
 /*
 	Mesh making stuff
@@ -195,7 +196,7 @@ void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio);
  * night light
  */
 void final_color_blend(video::SColor *result,
-		u16 light, u32 daynight_ratio);
+		u16 light, u32 daynight_ratio, const Lighting *lighting = nullptr);
 
 /*!
  * Gives the final  SColor shown on screen.
@@ -205,7 +206,7 @@ void final_color_blend(video::SColor *result,
  * \param dayLight color of the sunlight
  */
 void final_color_blend(video::SColor *result,
-		const video::SColor &data, const video::SColorf &dayLight);
+		const video::SColor &data, const video::SColorf &dayLight, const Lighting *lighting = nullptr);
 
 // Retrieves the TileSpec of a face of a node
 // Adds MATERIAL_FLAG_CRACK if the node is cracked

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -29,9 +29,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 inline static void applyShadeFactor(video::SColor& color, float factor)
 {
-	color.setRed(core::clamp(core::round32(color.getRed()*factor), 0, 255));
-	color.setGreen(core::clamp(core::round32(color.getGreen()*factor), 0, 255));
-	color.setBlue(core::clamp(core::round32(color.getBlue()*factor), 0, 255));
+	f32 alpha = color.getAlpha() / 255.0f;
+	factor = core::clamp(factor, 0.0f, 1.0f);
+	f32 correction_factor = (1.0f - alpha) + alpha * factor; // correct only the sunlight part of the color;
+	color.setRed(core::clamp(core::round32(color.getRed() * correction_factor), 0, 255));
+	color.setGreen(core::clamp(core::round32(color.getGreen() * correction_factor), 0, 255));
+	color.setBlue(core::clamp(core::round32(color.getBlue() * correction_factor), 0, 255));
 }
 
 void applyFacesShading(video::SColor &color, const v3f &normal)

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -202,6 +202,7 @@ CachedMapBlockData* MeshUpdateQueue::getCachedBlock(const v3s16 &p)
 void MeshUpdateQueue::fillDataFromMapBlockCache(QueuedMeshUpdate *q)
 {
 	MeshMakeData *data = new MeshMakeData(m_client, m_cache_enable_shaders);
+	data->m_lighting = m_client->getEnv().getLocalPlayer()->getLighting();
 	q->data = data;
 
 	data->fillBlockDataBegin(q->p);

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -74,14 +74,14 @@ void set_light_table(float gamma)
 	params.gamma = rangelim(gamma, 0.33f, 3.0f);
 
 // Boundary values should be fixed
-	light_LUT[0] = 0;
+	light_LUT[0] = 255 * COLOR_SHADE_FACTOR;
 	light_LUT[LIGHT_SUN] = 255;
 
 	for (size_t i = 1; i < LIGHT_SUN; i++) {
 		float brightness = decode_light_f((float)i / LIGHT_SUN);
 		// Strictly speaking, rangelim is not necessary here—if the implementation
 		// is conforming. But we don’t want problems in any case.
-		light_LUT[i] = rangelim((s32)(255.0f * brightness), 0, 255);
+		light_LUT[i] = rangelim((s32)(255.0f * (COLOR_SHADE_FACTOR + COLOR_LIGHT_FACTOR * brightness)), 255 * COLOR_SHADE_FACTOR, 255);
 
 		// Ensure light brightens with each level
 		if (i > 0 && light_LUT[i] <= light_LUT[i - 1]) {

--- a/src/light.h
+++ b/src/light.h
@@ -37,6 +37,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #ifndef SERVER
 
+// When converting light levels to color value, compress the 
+// value by 10% to give place to ambient occlusion and face shading 
+// at the lowest brightness values. COLOR_LIGHT_FACTOR + COLOR_SHADE_FACTOR must always be 1.0
+#define COLOR_LIGHT_FACTOR 0.9f
+#define COLOR_SHADE_FACTOR 0.1f
+
 /**
  * \internal
  *

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -23,4 +23,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
  */
 struct Lighting
 {
+	float brightness;
+	video::SColor color_tint;
+
+	/* Default ambient light adds zero brightness and no tint */
+	Lighting() : brightness(0.0f), color_tint(0xFFFFFFFF) {}
+
 };

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -1,0 +1,26 @@
+/*
+Minetest
+Copyright (C) 2021 x2048, Dmitry Kostenko <codeforsmile@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+/** Describes ambient light settings for a player
+ */
+struct Lighting
+{
+};

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -123,6 +123,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_SRP_BYTES_S_B",            TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_SrpBytesSandB }, // 0x60
 	{ "TOCLIENT_FORMSPEC_PREPEND",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FormspecPrepend }, // 0x61,
 	{ "TOCLIENT_MINIMAP_MODES",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MinimapModes }, // 0x62,
+	{ "TOCLIENT_SET_LIGHTING",        TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SetLighting }, // 0x63,
 };
 
 const static ServerCommandFactory null_command_factory = { "TOSERVER_NULL", 0, false };

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -123,7 +123,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_SRP_BYTES_S_B",            TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_SrpBytesSandB }, // 0x60
 	{ "TOCLIENT_FORMSPEC_PREPEND",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FormspecPrepend }, // 0x61,
 	{ "TOCLIENT_MINIMAP_MODES",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MinimapModes }, // 0x62,
-	{ "TOCLIENT_SET_LIGHTING",        TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SetLighting }, // 0x63,
+	{ "TOCLIENT_SET_LIGHTING",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SetLighting }, // 0x63,
 };
 
 const static ServerCommandFactory null_command_factory = { "TOSERVER_NULL", 0, false };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1701,6 +1701,6 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 	lighting.color_tint = color_tint;
 
 	if (!g_settings->getBool("enable_shaders")) {
-		m_env.getClientMap().updateMeshes();
+		m_env.applyLighting();
 	}
 }

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1690,4 +1690,12 @@ void Client::handleCommand_MinimapModes(NetworkPacket *pkt)
 
 void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 {
+	f32 brightness;
+	video::SColor color_tint;
+
+	*pkt >> brightness >> color_tint;
+
+	Lighting& lighting = m_env.getLocalPlayer()->getLighting();
+	lighting.brightness = brightness;
+	lighting.color_tint = color_tint;
 }

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1687,3 +1687,7 @@ void Client::handleCommand_MinimapModes(NetworkPacket *pkt)
 	if (m_minimap)
 		m_minimap->setModeIndex(mode);
 }
+
+void Client::handleCommand_SetLighting(NetworkPacket *pkt)
+{
+}

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -43,6 +43,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "tileanimation.h"
 #include "gettext.h"
 #include "skyparams.h"
+#include "client/clientmap.h"
 #include <memory>
 
 void Client::handleCommand_Deprecated(NetworkPacket* pkt)
@@ -1698,4 +1699,8 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 	Lighting& lighting = m_env.getLocalPlayer()->getLighting();
 	lighting.brightness = brightness;
 	lighting.color_tint = color_tint;
+
+	if (!g_settings->getBool("enable_shaders")) {
+		m_env.getClientMap().updateMeshes();
+	}
 }

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -765,6 +765,8 @@ enum ToClientCommand
 
 	TOCLIENT_SET_LIGHTING = 0x63,
 	/*
+		f32 brightness
+		u8[4] color (ARGB)
 	*/
 
 	TOCLIENT_NUM_MSG_TYPES = 0x64,

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -763,7 +763,11 @@ enum ToClientCommand
 			std::string extra
 	*/
 
-	TOCLIENT_NUM_MSG_TYPES = 0x63,
+	TOCLIENT_SET_LIGHTING = 0x63,
+	/*
+	*/
+
+	TOCLIENT_NUM_MSG_TYPES = 0x64,
 };
 
 enum ToServerCommand

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "player.h"
 #include "cloudparams.h"
 #include "skyparams.h"
+#include "lighting.h"
 
 class PlayerSAO;
 
@@ -126,6 +127,10 @@ public:
 		*frame_speed = local_animation_speed;
 	}
 
+	void setLighting(const Lighting &lighting) { m_lighting = lighting; }
+
+	const Lighting& getLighting() const { return m_lighting; }
+
 	void setDirty(bool dirty) { m_dirty = true; }
 
 	u16 protocol_version = 0;
@@ -162,6 +167,8 @@ private:
 	SunParams m_sun_params;
 	MoonParams m_moon_params;
 	StarParams m_star_params;
+
+	Lighting m_lighting;
 
 	session_t m_peer_id = PEER_ID_INEXISTENT;
 };

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2266,6 +2266,38 @@ int ObjectRef::l_set_minimap_modes(lua_State *L)
 	return 0;
 }
 
+// set_lighting(self, lighting)
+int ObjectRef::l_set_lighting(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (player == nullptr)
+		return 0;
+
+	luaL_checktype(L, 2, LUA_TTABLE);
+	Lighting lighting = player->getLighting();
+
+	getServer(L)->setLighting(player, lighting);
+	lua_pushboolean(L, true);
+	return 1;
+}
+
+// get_lighting(self)
+int ObjectRef::l_get_lighting(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (player == nullptr)
+		return 0;
+
+	const Lighting &lighting = player->getLighting();
+
+	lua_newtable(L);
+	return 1;
+}
+
 ObjectRef::ObjectRef(ServerActiveObject *object):
 	m_object(object)
 {}
@@ -2419,5 +2451,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_eye_offset),
 	luamethod(ObjectRef, send_mapblock),
 	luamethod(ObjectRef, set_minimap_modes),
+	luamethod(ObjectRef, set_lighting),
+	luamethod(ObjectRef, get_lighting),
 	{0,0}
 };

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2278,6 +2278,13 @@ int ObjectRef::l_set_lighting(lua_State *L)
 	luaL_checktype(L, 2, LUA_TTABLE);
 	Lighting lighting = player->getLighting();
 
+	lighting.brightness = rangelim(getfloatfield_default(L, 2, "brightness", lighting.brightness), 0.0f, 1.0f);
+
+	lua_getfield(L, 2, "color_tint");
+	if (!lua_isnil(L, -1))
+		read_color(L, -1, &lighting.color_tint);
+	lua_pop(L, 1);
+
 	getServer(L)->setLighting(player, lighting);
 	lua_pushboolean(L, true);
 	return 1;
@@ -2295,6 +2302,12 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	const Lighting &lighting = player->getLighting();
 
 	lua_newtable(L);
+
+	lua_pushnumber(L, lighting.brightness);
+	lua_setfield(L, -2, "brightness");
+	push_ARGB8(L, lighting.color_tint);
+	lua_setfield(L, -2, "color_tint");
+
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -375,4 +375,10 @@ private:
 
 	// set_minimap_modes(self, modes, wanted_mode)
 	static int l_set_minimap_modes(lua_State *L);
+
+	// set_lighting(self, lighting)
+	static int l_set_lighting(lua_State *L);
+	
+	// get_lighting(self)
+	static int l_get_lighting(lua_State *L);
 };

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1800,7 +1800,9 @@ void Server::SendOverrideDayNightRatio(session_t peer_id, bool do_override,
 void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 {
 	NetworkPacket pkt(TOCLIENT_SET_LIGHTING,
-			0, peer_id);
+			4 + 4, peer_id);
+
+	pkt << lighting.brightness << lighting.color_tint;
 
 	Send(&pkt);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1797,6 +1797,14 @@ void Server::SendOverrideDayNightRatio(session_t peer_id, bool do_override,
 	Send(&pkt);
 }
 
+void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
+{
+	NetworkPacket pkt(TOCLIENT_SET_LIGHTING,
+			0, peer_id);
+
+	Send(&pkt);
+}
+
 void Server::SendTimeOfDay(session_t peer_id, u16 time, f32 time_speed)
 {
 	NetworkPacket pkt(TOCLIENT_TIME_OF_DAY, 0, peer_id);
@@ -3411,6 +3419,13 @@ void Server::overrideDayNightRatio(RemotePlayer *player, bool do_override,
 	sanity_check(player);
 	player->overrideDayNightRatio(do_override, ratio);
 	SendOverrideDayNightRatio(player->getPeerId(), do_override, ratio);
+}
+
+void Server::setLighting(RemotePlayer *player, const Lighting &lighting)
+{
+	sanity_check(player);
+	player->setLighting(lighting);
+	SendSetLighting(player->getPeerId(), lighting);
 }
 
 void Server::notifyPlayers(const std::wstring &msg)

--- a/src/server.h
+++ b/src/server.h
@@ -69,6 +69,7 @@ struct SkyboxParams;
 struct SunParams;
 struct MoonParams;
 struct StarParams;
+struct Lighting;
 class ServerThread;
 class ServerModManager;
 class ServerInventoryManager;
@@ -333,6 +334,8 @@ public:
 
 	void overrideDayNightRatio(RemotePlayer *player, bool do_override, float brightness);
 
+	void setLighting(RemotePlayer *player, const Lighting &lighting);
+
 	/* con::PeerHandler implementation. */
 	void peerAdded(con::Peer *peer);
 	void deletingPeer(con::Peer *peer, bool timeout);
@@ -459,6 +462,7 @@ private:
 	void SendSetStars(session_t peer_id, const StarParams &params);
 	void SendCloudParams(session_t peer_id, const CloudParams &params);
 	void SendOverrideDayNightRatio(session_t peer_id, bool do_override, float ratio);
+	void SendSetLighting(session_t peer_id, const Lighting &lighting);
 	void broadcastModChannelMessage(const std::string &channel,
 			const std::string &message, session_t from_peer);
 


### PR DESCRIPTION
This is early work to enable ambient light in caves and features like night vision in the games. Fixes #6509 and fixes #8890.

This is shader-specific implementation, but it should be possible to add similar code for fixed rendering pipeline.

## Plan
  - [x] Collect feedback
  - [x] Add server-side API to control the ambient brightness
  - [x] Add ambient color, see #8890
  - [ ] Integrate with set_lighting
  - [ ] Rebase
  - [ ] Add support for particles

This PR is Work in Progress

## How to test

* Install WorldEdit mod
* Start any game in single player get all privileges and go underground (fly + noclip).
* Type `//lua minetest.get_player_by_name('singleplayer'):set_ambient_light({brightness=0.5, color_tint="#ffd480"})`.
* You should now see all the caves with an orange tint.