### PR TITLE
Mods: Combine mod loading checks and deprection logging

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -177,11 +177,7 @@ void Client::loadMods()
 
 	// Load "mod" scripts
 	for (const ModSpec &mod : m_mods) {
-		if (!string_allowed(mod.name, MODNAME_ALLOWED_CHARS)) {
-			throw ModError("Error loading mod \"" + mod.name +
-				"\": Mod name does not follow naming conventions: "
-					"Only characters [a-z0-9_] are allowed.");
-		}
+		mod.checkAndLog();
 		scanModIntoMemory(mod.name, mod.path);
 	}
 

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -49,6 +49,9 @@ struct ModSpec
 	bool part_of_modpack = false;
 	bool is_modpack = false;
 
+	// For logging purposes
+	std::vector<const char *> deprecation_msgs;
+
 	// if modpack:
 	std::map<std::string, ModSpec> modpack_content;
 	ModSpec(const std::string &name = "", const std::string &path = "") :
@@ -59,6 +62,8 @@ struct ModSpec
 			name(name), path(path), part_of_modpack(part_of_modpack)
 	{
 	}
+
+	void checkAndLog() const;
 };
 
 // Retrieves depends, optdepends, is_modpack and modpack_content

--- a/src/server/mods.cpp
+++ b/src/server/mods.cpp
@@ -61,12 +61,8 @@ void ServerModManager::loadMods(ServerScripting *script)
 	infostream << std::endl;
 	// Load and run "mod" scripts
 	for (const ModSpec &mod : m_sorted_mods) {
-		if (!string_allowed(mod.name, MODNAME_ALLOWED_CHARS)) {
-			throw ModError("Error loading mod \"" + mod.name +
-					"\": Mod name does not follow naming "
-					"conventions: "
-					"Only characters [a-z0-9_] are allowed.");
-		}
+		mod.checkAndLog();
+
 		std::string script_path = mod.path + DIR_DELIM + "init.lua";
 		auto t = porting::getTimeMs();
 		script->loadMod(script_path, mod.name);


### PR DESCRIPTION
This limits the logged deprecation messages to the mods that are loaded
Unifies the mod naming convention check for CSM & SSM

Fixes #11444

## To do

This PR is Ready for Review.

## How to test

1. Enable logging of deprecated API
2. Get less log spam