### PR TITLE
Start sprite animation at the beginning.

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1722,6 +1722,7 @@ void GenericCAO::processMessage(const std::string &data)
 
 		m_tx_basepos = p;
 		m_anim_num_frames = num_frames;
+		m_anim_frame = 0;
 		m_anim_framelength = framelength;
 		m_tx_select_horiz_by_yawpitch = select_horiz_by_yawpitch;
 


### PR DESCRIPTION
## Bug

When setting a sprite animation, the previous animation's frame number is kept. This results in animations starting in the middle.

## Fix

When setting a sprite animation, do not keep the last animation's frame number. Setting a new animation should start the animation at the start of the new animation.

## Example of bug

### Spritesheet

![FBM7XOy_7x](https://user-images.githubusercontent.com/3705081/128059934-de9f753e-fb95-4236-88c7-a1b062d2d681.png)

Animations are set up as
* Animation 1 (Red): Wind up
* Animation 2 (Yellow): Hold
* Animation 3 (Green): Release

The animation sequences are separate so that I can control the timings programmatically and adjust it on the fly for game balance.

### In-game
![Kapture 2021-08-04 at 01 04 48](https://user-images.githubusercontent.com/3705081/128059457-d0963959-66f0-4f49-9f90-b107acf4bb20.gif)
I synced the nametag to the animation number for debugging purposes.

### Workaround

There is a Lua workaround, which is to set a zero-length animation before setting the next animation. This will make the frame number reset due to the frame number exceeding the framelength.

```lua
function setSpriteAnimation(self, animation)
  -- Hack: Minetest does not reset the animation frame from the prev animation
  -- This hopefully will reset the frame so we can start the next animation properly
  self.objRef:set_sprite(animation.startFrame, 0, 0)

  minetest.after(
    0.025, -- delay must match server tick
    function()
      self.objRef:set_sprite(
        animation.startFrame, 
        animation.numFrames, 
        animation.frameDuration, 
        animation.perDirection) 
      end
  )
end
```

### Workaround in-game
![Kapture 2021-08-04 at 01 03 36](https://user-images.githubusercontent.com/3705081/128059866-80265f01-d7b4-4080-90b2-469eb37e16af.gif)
I'm hoping this would be fixed in-engine so we don't have to rely on this fragile workaround.

Fixes #11510  😄 