### PR TITLE
Fix GUIEditBoxWithScrollBar using a smaller small-/largeStep than intlGUIEditBox

### DIFF
--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -620,6 +620,17 @@ void GUIEditBoxWithScrollBar::createVScrollBar()
 	if (Environment)
 		skin = Environment->getSkin();
 
+	s32 fontHeight = 1;
+
+	if (m_override_font) {
+		fontHeight = m_override_font->getDimension(L"").Height;
+	} else {
+		IGUIFont *font;
+		if (skin && (font = skin->getFont())) {
+			fontHeight = font->getDimension(L"").Height;
+		}
+	}
+
 	m_scrollbar_width = skin ? skin->getSize(gui::EGDS_SCROLLBAR_SIZE) : 16;
 
 	irr::core::rect<s32> scrollbarrect = m_frame_rect;
@@ -628,8 +639,8 @@ void GUIEditBoxWithScrollBar::createVScrollBar()
 			scrollbarrect, false, true);
 
 	m_vscrollbar->setVisible(false);
-	m_vscrollbar->setSmallStep(1);
-	m_vscrollbar->setLargeStep(1);
+	m_vscrollbar->setSmallStep(3 * fontHeight);
+	m_vscrollbar->setLargeStep(10 * fontHeight);
 }
 
 

--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -623,11 +623,11 @@ void GUIEditBoxWithScrollBar::createVScrollBar()
 	s32 fontHeight = 1;
 
 	if (m_override_font) {
-		fontHeight = m_override_font->getDimension(L"").Height;
+		fontHeight = m_override_font->getDimension(L"Ay").Height;
 	} else {
 		IGUIFont *font;
 		if (skin && (font = skin->getFont())) {
-			fontHeight = font->getDimension(L"").Height;
+			fontHeight = font->getDimension(L"Ay").Height;
 		}
 	}
 

--- a/util/ci/clang-format-whitelist.txt
+++ b/util/ci/clang-format-whitelist.txt
@@ -192,8 +192,6 @@ src/gui/guiTable.cpp
 src/gui/guiTable.h
 src/gui/guiVolumeChange.cpp
 src/gui/guiVolumeChange.h
-src/gui/intlGUIEditBox.cpp
-src/gui/intlGUIEditBox.h
 src/gui/mainmenumanager.h
 src/gui/modalMenu.h
 src/guiscalingfilter.cpp


### PR DESCRIPTION
- It just set small- and large_step of its scrollbar to 1.
- This caused `textarea[]` formspec elements to scroll horribly slow with the mouse wheel.
- The code is taken from `intlGUIEditBox.cpp`, to make it consistent.
- This is a bugfix.
- This bug is really annoying and not new. Everyone is experiencing it at least since we switched to minetest's own irrlicht fork, but the bug is older (5 years, github says).

## To do

This PR is a Ready for Review.

## How to test

* Open a formspec with a textarea, eg. the one of a mesecons luacontroller.
* Make sure it has a scrollbar (ie. write multiple lines of text to make it appear).
* Use your mouse wheel to scroll. It should no longer be horribly slow.
