### PR TITLE
Fix a segfault caused by wrong textdomain lines in translation files

### DIFF
--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -64,7 +64,13 @@ void Translations::loadTranslation(const std::string &data)
 			line.resize(line.length() - 1);
 
 		if (str_starts_with(line, "# textdomain:")) {
-			textdomain = utf8_to_wide(trim(str_split(line, ':')[1]));
+			auto parts = str_split(line, ':');
+			if (parts.size() < 2) {
+				errorstream << "Invalid textdomain translation line \"" << line
+						<< "\"" << std::endl;
+				continue;
+			}
+			textdomain = utf8_to_wide(trim(parts[1]));
 		}
 		if (line.empty() || line[0] == '#')
 			continue;


### PR DESCRIPTION
* The problem were lines like these:
  "# textdomain:"
* str_split does not add an empty last part if there is a delimiter
  at the end, but this was probably assumed here.
* This is just a little bugfix.

## To do

This PR is a Ready for Review.

## How to test

* Create a mod with a translation file with these contents:
  ```
  # textdomain:
  foo
  ```
  (One might think that this sets the textdomain to `foo`, but the correct syntax is `# textdomain:foo`, in one line.)
* Start a game with the mod loaded.
* => segfault in master; error message in this PR
