### PR TITLE
Fix access violation in create_schematic()

### DIFF
--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -598,8 +598,8 @@ void Schematic::applyProbabilities(v3s16 p0,
 	}
 
 	for (size_t i = 0; i != splist->size(); i++) {
-		s16 y = (*splist)[i].first - p0.Y;
-		slice_probs[y] = (*splist)[i].second;
+		s16 slice = (*splist)[i].first;
+		slice_probs[slice] = (*splist)[i].second;
 	}
 }
 

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -599,7 +599,8 @@ void Schematic::applyProbabilities(v3s16 p0,
 
 	for (size_t i = 0; i != splist->size(); i++) {
 		s16 slice = (*splist)[i].first;
-		slice_probs[slice] = (*splist)[i].second;
+		if (slice < size.Y)
+			slice_probs[slice] = (*splist)[i].second;
 	}
 }
 


### PR DESCRIPTION
Fixes #11533, schematics saved from y locations higher than 0 would cause an access violation if layer probabilities were specified

See #11533 for more details

## To do

This PR is Ready for Review.

## How to test

* [Attached is a mod](https://github.com/minetest/minetest/files/6983134/crashy.zip) that reproduces the error, run `/nocrashy` chat command for the mod to save a schematic without crashing, and `/crashy` for it to cause an access violation.
* Operations performed before create_schematic() is called can affect whether Minetest will crash, so different lua code doesn't always reproduce it, and this may also be the case across different machines.
* Testing that layer probabilities are now correctly applied (in addition to not crashing) requires serializing the output of create_schematic() into lua and inspecting the yslice_prob table. The one i tried looked good to me.
* I've not checked whether `l_create_schematic()` sanitizes the `ypos` it receives from lua before using it as an index. (I didn't notice any, but also don't know what the policy is)