### PR TITLE
Use utf-8 for the irrlicht clipboard

### DIFF
--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -338,7 +338,7 @@ void GUIChatConsole::drawText()
 					false,
 					false,
 					&AbsoluteClippingRect);
-			} else 
+			} else
 #endif
 			{
 				// Otherwise use standard text
@@ -580,8 +580,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			const c8 *text = os_operator->getTextFromClipboard();
 			if (!text)
 				return true;
-			std::basic_string<unsigned char> str((const unsigned char*)text);
-			prompt.input(std::wstring(str.begin(), str.end()));
+			prompt.input(utf8_to_wide(text));
 			return true;
 		}
 		else if(event.KeyInput.Key == KEY_KEY_X && event.KeyInput.Control)

--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "IGUIFont.h"
 
 #include "porting.h"
+#include "util/string.h"
 
 GUIEditBox::~GUIEditBox()
 {
@@ -517,8 +518,7 @@ void GUIEditBox::onKeyControlC(const SEvent &event)
 	const s32 realmbgn = m_mark_begin < m_mark_end ? m_mark_begin : m_mark_end;
 	const s32 realmend = m_mark_begin < m_mark_end ? m_mark_end : m_mark_begin;
 
-	core::stringc s;
-	s = Text.subString(realmbgn, realmend - realmbgn).c_str();
+	std::string s = stringw_to_utf8(Text.subString(realmbgn, realmend - realmbgn));
 	m_operator->copyToClipboard(s.c_str());
 }
 
@@ -567,29 +567,28 @@ bool GUIEditBox::onKeyControlV(const SEvent &event, s32 &mark_begin, s32 &mark_e
 
 	// add new character
 	if (const c8 *p = m_operator->getTextFromClipboard()) {
+		core::stringw inserted_text = utf8_to_stringw(p);
 		if (m_mark_begin == m_mark_end) {
 			// insert text
 			core::stringw s = Text.subString(0, m_cursor_pos);
-			s.append(p);
+			s.append(inserted_text);
 			s.append(Text.subString(
 					m_cursor_pos, Text.size() - m_cursor_pos));
 
 			if (!m_max || s.size() <= m_max) {
 				Text = s;
-				s = p;
-				m_cursor_pos += s.size();
+				m_cursor_pos += inserted_text.size();
 			}
 		} else {
 			// replace text
 
 			core::stringw s = Text.subString(0, realmbgn);
-			s.append(p);
+			s.append(inserted_text);
 			s.append(Text.subString(realmend, Text.size() - realmend));
 
 			if (!m_max || s.size() <= m_max) {
 				Text = s;
-				s = p;
-				m_cursor_pos = realmbgn + s.size();
+				m_cursor_pos = realmbgn + inserted_text.size();
 			}
 		}
 	}


### PR DESCRIPTION
- Minetest inconsistently uses the clipboard with wide and utf-8 strings. This PR changes that to utf-8 only. 
- Use together with https://github.com/minetest/irrlicht/pull/55 if you're on X11.

## To do

This PR is Ready for Review.

(Though it probably makes sense to merge this together with the irrlicht PR.)

## How to test

* Use https://github.com/minetest/irrlicht/pull/55.
* Copy any text from and to minetest, ie. `¯\_(ツ)_/¯`. Note that there are characters that minetest doesn't render, due to font stuff or so.
* grep for occurrences of `copyToClipboard` and `getTextFromClipboard`.
