### PR TITLE
Dynamic_Add_Media v2

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -269,27 +269,8 @@ function core.cancel_shutdown_requests()
 end
 
 
--- Callback handling for dynamic_add_media
-
-local dynamic_add_media_raw = core.dynamic_add_media_raw
-core.dynamic_add_media_raw = nil
-function core.dynamic_add_media(filepath, callback)
-	local ret = dynamic_add_media_raw(filepath)
-	if ret == false then
-		return ret
-	end
-	if callback == nil then
-		core.log("deprecated", "Calling minetest.dynamic_add_media without "..
-			"a callback is deprecated and will stop working in future versions.")
-	else
-		-- At the moment async loading is not actually implemented, so we
-		-- immediately call the callback ourselves
-		for _, name in ipairs(ret) do
-			callback(name)
-		end
-	end
-	return true
-end
+-- Used for callback handling with dynamic_add_media
+core.dynamic_media_callbacks = {}
 
 
 -- PNG encoder safety wrapper

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5647,22 +5647,33 @@ Server
     * Returns a code (0: successful, 1: no such player, 2: player is connected)
 * `minetest.remove_player_auth(name)`: remove player authentication data
     * Returns boolean indicating success (false if player nonexistant)
-* `minetest.dynamic_add_media(filepath, callback)`
-    * `filepath`: path to a media file on the filesystem
-    * `callback`: function with arguments `name`, where name is a player name
-      (previously there was no callback argument; omitting it is deprecated)
-    * Adds the file to the media sent to clients by the server on startup
-      and also pushes this file to already connected clients.
-      The file must be a supported image, sound or model format. It must not be
-      modified, deleted, moved or renamed after calling this function.
-      The list of dynamically added media is not persisted.
+* `minetest.dynamic_add_media(options, callback)`
+    * `options`: table containing the following parameters
+        * `filepath`: path to a media file on the filesystem
+        * `to_player`: name of the player the media should be sent to instead of
+                       all players (optional)
+        * `ephemeral`: boolean that marks the media as ephermal,
+                       it will not be cached on the client (optional, default false)
+    * `callback`: function with arguments `name`, which is a player name
+    * Pushes the specified media file to client(s). (details below)
+      The file must be a supported image, sound or model format.
+      Dynamically added media is not persisted between server restarts.
     * Returns false on error, true if the request was accepted
     * The given callback will be called for every player as soon as the
       media is available on the client.
-      Old clients that lack support for this feature will not see the media
-      unless they reconnect to the server. (callback won't be called)
-    * Since media transferred this way currently does not use client caching
-       or HTTP transfers, dynamic media should not be used with big files.
+    * Details/Notes:
+    * If `ephemeral`=false and `to_player` is unset the file is added to the media
+      sent to clients on startup, this means the media will appear even on
+      old clients if they rejoin the server.
+    * If `ephemeral`=false the file must not be modified, deleted, moved or
+      renamed after calling this function.
+    * Regardless of any use of `ephemeral`, adding media files with the same
+      name twice is not possible/guaranteed to work. An exception to this is the
+      use of `to_player` to send the same, already existent file to multiple
+      chosen players.
+    * Clients will attempt to fetch files added this way via remote media,
+      this can make transfer of bigger files painless (if set up). Nevertheless
+      it is advised not to use remote media for big media files.
 
 Bans
 ----

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5662,18 +5662,18 @@ Server
     * The given callback will be called for every player as soon as the
       media is available on the client.
     * Details/Notes:
-    * If `ephemeral`=false and `to_player` is unset the file is added to the media
-      sent to clients on startup, this means the media will appear even on
-      old clients if they rejoin the server.
-    * If `ephemeral`=false the file must not be modified, deleted, moved or
-      renamed after calling this function.
-    * Regardless of any use of `ephemeral`, adding media files with the same
-      name twice is not possible/guaranteed to work. An exception to this is the
-      use of `to_player` to send the same, already existent file to multiple
-      chosen players.
+      * If `ephemeral`=false and `to_player` is unset the file is added to the media
+        sent to clients on startup, this means the media will appear even on
+        old clients if they rejoin the server.
+      * If `ephemeral`=false the file must not be modified, deleted, moved or
+        renamed after calling this function.
+      * Regardless of any use of `ephemeral`, adding media files with the same
+        name twice is not possible/guaranteed to work. An exception to this is the
+        use of `to_player` to send the same, already existent file to multiple
+        chosen players.
     * Clients will attempt to fetch files added this way via remote media,
       this can make transfer of bigger files painless (if set up). Nevertheless
-      it is advised not to use remote media for big media files.
+      it is advised not to use dynamic media for big media files.
 
 Bans
 ----

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5652,7 +5652,7 @@ Server
         * `filepath`: path to a media file on the filesystem
         * `to_player`: name of the player the media should be sent to instead of
                        all players (optional)
-        * `ephemeral`: boolean that marks the media as ephermal,
+        * `ephemeral`: boolean that marks the media as ephemeral,
                        it will not be cached on the client (optional, default false)
     * `callback`: function with arguments `name`, which is a player name
     * Pushes the specified media file to client(s). (details below)

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -558,12 +558,11 @@ void Client::step(float dtime)
 	{
 		std::vector<u32> done;
 		for (auto it = m_pending_media_downloads.begin();
-			it != m_pending_media_downloads.end();) {
+				it != m_pending_media_downloads.end();) {
 			assert(it->second->isStarted());
 			it->second->step(this);
 			if (it->second->isDone()) {
 				done.emplace_back(it->first);
-				delete it->second;
 
 				it = m_pending_media_downloads.erase(it);
 			} else {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -558,8 +558,7 @@ void Client::step(float dtime)
 	{
 		std::vector<u32> done;
 		for (auto it = m_pending_media_downloads.begin();
-			it != m_pending_media_downloads.end();)
-		{
+			it != m_pending_media_downloads.end();) {
 			assert(it->second->isStarted());
 			it->second->step(this);
 			if (it->second->isDone()) {
@@ -571,7 +570,7 @@ void Client::step(float dtime)
 				it++;
 			}
 
-			if (done.size() == 255) {
+			if (done.size() == 255) { // maximum in one packet
 				sendHaveMedia(done);
 				done.clear();
 			}

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -556,6 +556,7 @@ void Client::step(float dtime)
 		}
 	}
 	{
+		// Acknowledge dynamic media downloads to server
 		std::vector<u32> done;
 		for (auto it = m_pending_media_downloads.begin();
 				it != m_pending_media_downloads.end();) {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -555,6 +555,30 @@ void Client::step(float dtime)
 			m_media_downloader = NULL;
 		}
 	}
+	{
+		std::vector<u32> done;
+		for (auto it = m_pending_media_downloads.begin();
+			it != m_pending_media_downloads.end();)
+		{
+			assert(it->second->isStarted());
+			it->second->step(this);
+			if (it->second->isDone()) {
+				done.emplace_back(it->first);
+				delete it->second;
+
+				it = m_pending_media_downloads.erase(it);
+			} else {
+				it++;
+			}
+
+			if (done.size() == 255) {
+				sendHaveMedia(done);
+				done.clear();
+			}
+		}
+		if (!done.empty())
+			sendHaveMedia(done);
+	}
 
 	/*
 		If the server didn't update the inventory in a while, revert
@@ -770,7 +794,8 @@ void Client::request_media(const std::vector<std::string> &file_requests)
 	Send(&pkt);
 
 	infostream << "Client: Sending media request list to server ("
-			<< file_requests.size() << " files. packet size)" << std::endl;
+			<< file_requests.size() << " files, packet size "
+			<< pkt.getSize() << ")" << std::endl;
 }
 
 void Client::initLocalMapSaving(const Address &address,
@@ -1291,6 +1316,19 @@ void Client::sendPlayerPos()
 	NetworkPacket pkt(TOSERVER_PLAYERPOS, 12 + 12 + 4 + 4 + 4 + 1 + 1);
 
 	writePlayerPos(player, &map, &pkt);
+
+	Send(&pkt);
+}
+
+void Client::sendHaveMedia(const std::vector<u32> &tokens)
+{
+	NetworkPacket pkt(TOSERVER_HAVE_MEDIA, 1 + tokens.size() * 4);
+
+	sanity_check(tokens.size() < 256);
+
+	pkt << static_cast<u8>(tokens.size());
+	for (u32 token : tokens)
+		pkt << token;
 
 	Send(&pkt);
 }

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -544,7 +544,7 @@ private:
 	// Set of media filenames pushed by server at runtime
 	std::unordered_set<std::string> m_media_pushed_files;
 	// Pending downloads of dynamic media (key: token)
-	std::unordered_map<u32, SingleMediaDownloader*> m_pending_media_downloads;
+	std::vector<std::pair<u32, std::unique_ptr<SingleMediaDownloader>>> m_pending_media_downloads;
 
 	// time_of_day speed approximation for old protocol
 	bool m_time_of_day_set = false;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -53,6 +53,7 @@ class ISoundManager;
 class NodeDefManager;
 //class IWritableCraftDefManager;
 class ClientMediaDownloader;
+class SingleMediaDownloader;
 struct MapDrawControl;
 class ModChannelMgr;
 class MtEventManager;
@@ -245,6 +246,7 @@ public:
 	void sendDamage(u16 damage);
 	void sendRespawn();
 	void sendReady();
+	void sendHaveMedia(const std::vector<u32> &tokens);
 
 	ClientEnvironment& getEnv() { return m_env; }
 	ITextureSource *tsrc() { return getTextureSource(); }
@@ -536,9 +538,13 @@ private:
 	bool m_activeobjects_received = false;
 	bool m_mods_loaded = false;
 
+	std::vector<std::string> m_remote_media_servers;
+	// Media downloader, only exists during init
 	ClientMediaDownloader *m_media_downloader;
 	// Set of media filenames pushed by server at runtime
 	std::unordered_set<std::string> m_media_pushed_files;
+	// Pending downloads of dynamic media (key: token)
+	std::unordered_map<u32, SingleMediaDownloader*> m_pending_media_downloads;
 
 	// time_of_day speed approximation for old protocol
 	bool m_time_of_day_set = false;

--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -301,8 +301,7 @@ void ClientMediaDownloader::remoteHashSetReceived(
 			// available on this server, add this server
 			// to the available_remotes array
 
-			for(std::map<std::string, FileStatus*>::iterator
-					it = m_files.upper_bound(m_name_bound);
+			for(auto it = m_files.upper_bound(m_name_bound);
 					it != m_files.end(); ++it) {
 				FileStatus *f = it->second;
 				if (!f->received && sha1_set.count(f->sha1))
@@ -328,8 +327,7 @@ void ClientMediaDownloader::remoteMediaReceived(
 
 	std::string name;
 	{
-		std::unordered_map<unsigned long, std::string>::iterator it =
-			m_remote_file_transfers.find(fetch_result.request_id);
+		auto it = m_remote_file_transfers.find(fetch_result.request_id);
 		assert(it != m_remote_file_transfers.end());
 		name = it->second;
 		m_remote_file_transfers.erase(it);
@@ -398,8 +396,7 @@ void ClientMediaDownloader::startRemoteMediaTransfers()
 {
 	bool changing_name_bound = true;
 
-	for (std::map<std::string, FileStatus*>::iterator
-			files_iter = m_files.upper_bound(m_name_bound);
+	for (auto files_iter = m_files.upper_bound(m_name_bound);
 			files_iter != m_files.end(); ++files_iter) {
 
 		// Abort if active fetch limit is exceeded
@@ -483,8 +480,7 @@ void ClientMediaDownloader::conventionalTransferDone(
 		Client *client)
 {
 	// Check that file was announced
-	std::map<std::string, FileStatus*>::iterator
-		file_iter = m_files.find(name);
+	auto file_iter = m_files.find(name);
 	if (file_iter == m_files.end()) {
 		errorstream << "Client: server sent media file that was"
 			<< "not announced, ignoring it: \"" << name << "\""
@@ -587,12 +583,10 @@ std::string ClientMediaDownloader::serializeRequiredHashSet()
 
 	// Write list of hashes of files that have not been
 	// received (found in cache) yet
-	for (std::map<std::string, FileStatus*>::iterator
-			it = m_files.begin();
-			it != m_files.end(); ++it) {
-		if (!it->second->received) {
-			FATAL_ERROR_IF(it->second->sha1.size() != 20, "Invalid SHA1 size");
-			os << it->second->sha1;
+	for (const auto &it : m_files) {
+		if (!it.second->received) {
+			FATAL_ERROR_IF(it.second->sha1.size() != 20, "Invalid SHA1 size");
+			os << it.second->sha1;
 		}
 	}
 

--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -758,7 +758,7 @@ void SingleMediaDownloader::remoteMediaReceived(
 
 	// Otherwise try the next remote server or fall back to conventional transfer
 	m_current_remote++;
-	if (m_current_remote >= m_remotes.size()) {
+	if (m_current_remote >= (int)m_remotes.size()) {
 		infostream << "Client: Failed to remote-fetch \"" << m_file_name
 				<< "\". Requesting it the usual way." << std::endl;
 		m_current_remote = -1;

--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -673,7 +673,7 @@ bool SingleMediaDownloader::loadMedia(Client *client, const std::string &data,
 
 void SingleMediaDownloader::addFile(const std::string &name, const std::string &sha1)
 {
-	assert(m_stage == 0); // pre-condition
+	assert(m_stage == STAGE_INIT); // pre-condition
 
 	assert(!name.empty());
 	assert(sha1.size() == 20);
@@ -685,7 +685,7 @@ void SingleMediaDownloader::addFile(const std::string &name, const std::string &
 
 void SingleMediaDownloader::addRemoteServer(const std::string &baseurl)
 {
-	assert(m_stage == 0); // pre-condition
+	assert(m_stage == STAGE_INIT); // pre-condition
 
 	if (g_settings->getBool("enable_remote_media_server"))
 		m_remotes.emplace_back(baseurl);
@@ -693,8 +693,8 @@ void SingleMediaDownloader::addRemoteServer(const std::string &baseurl)
 
 void SingleMediaDownloader::step(Client *client)
 {
-	if (m_stage == 0) {
-		m_stage = 1;
+	if (m_stage == STAGE_INIT) {
+		m_stage = STAGE_CACHE_CHECKED;
 		initialStep(client);
 	}
 
@@ -714,7 +714,7 @@ bool SingleMediaDownloader::conventionalTransferDone(const std::string &name,
 		return false;
 
 	// Mark file as received unconditionally and try to load it
-	m_stage = 2;
+	m_stage = STAGE_DONE;
 	checkAndLoad(name, m_file_sha1, data, false, client);
 	return true;
 }
@@ -722,7 +722,7 @@ bool SingleMediaDownloader::conventionalTransferDone(const std::string &name,
 void SingleMediaDownloader::initialStep(Client *client)
 {
 	if (tryLoadFromCache(m_file_name, m_file_sha1, client))
-		m_stage = 2;
+		m_stage = STAGE_DONE;
 	if (isDone())
 		return;
 
@@ -751,7 +751,7 @@ void SingleMediaDownloader::remoteMediaReceived(
 		bool success = checkAndLoad(m_file_name, m_file_sha1,
 				fetch_result.data, false, client);
 		if (success) {
-			m_stage = 2;
+			m_stage = STAGE_DONE;
 			return;
 		}
 	}

--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -673,7 +673,7 @@ bool SingleMediaDownloader::loadMedia(Client *client, const std::string &data,
 
 void SingleMediaDownloader::addFile(const std::string &name, const std::string &sha1)
 {
-	assert(stage == 0); // pre-condition
+	assert(m_stage == 0); // pre-condition
 
 	assert(!name.empty());
 	assert(sha1.size() == 20);
@@ -685,7 +685,7 @@ void SingleMediaDownloader::addFile(const std::string &name, const std::string &
 
 void SingleMediaDownloader::addRemoteServer(const std::string &baseurl)
 {
-	assert(stage == 0); // pre-condition
+	assert(m_stage == 0); // pre-condition
 
 	if (g_settings->getBool("enable_remote_media_server"))
 		m_remotes.emplace_back(baseurl);

--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -44,11 +44,6 @@ bool clientMediaUpdateCache(const std::string &raw_hash, const std::string &file
 	return true;
 }
 
-IClientMediaDownloader::IClientMediaDownloader():
-	m_media_cache(getMediaCacheDir())
-{
-}
-
 /*
 	ClientMediaDownloader
 */
@@ -68,6 +63,12 @@ ClientMediaDownloader::~ClientMediaDownloader()
 
 	for (auto &remote : m_remotes)
 		delete remote;
+}
+
+bool ClientMediaDownloader::loadMedia(Client *client, const std::string &data,
+		const std::string &name)
+{
+	return client->loadMedia(data, name);
 }
 
 void ClientMediaDownloader::addFile(const std::string &name, const std::string &sha1)
@@ -176,36 +177,21 @@ void ClientMediaDownloader::initialStep(Client *client)
 	// Check media cache
 	m_uncached_count = m_files.size();
 	for (auto &file_it : m_files) {
-		std::string name = file_it.first;
+		const std::string &name = file_it.first;
 		FileStatus *filestatus = file_it.second;
 		const std::string &sha1 = filestatus->sha1;
 
-		std::ostringstream tmp_os(std::ios_base::binary);
-		bool found_in_cache = m_media_cache.load(hex_encode(sha1), tmp_os);
-
-		// If found in cache, try to load it from there
-		if (found_in_cache) {
-			bool success = checkAndLoad(name, sha1,
-					tmp_os.str(), true, client);
-			if (success) {
-				filestatus->received = true;
-				m_uncached_count--;
-			}
+		if (tryLoadFromCache(name, sha1, client)) {
+			filestatus->received = true;
+			m_uncached_count--;
 		}
 	}
 
 	assert(m_uncached_received_count == 0);
 
 	// Create the media cache dir if we are likely to write to it
-	if (m_uncached_count != 0) {
-		bool did = fs::CreateAllDirs(getMediaCacheDir());
-		if (!did) {
-			errorstream << "Client: "
-				<< "Could not create media cache directory: "
-				<< getMediaCacheDir()
-				<< std::endl;
-		}
-	}
+	if (m_uncached_count != 0)
+		createCacheDirs();
 
 	// If we found all files in the cache, report this fact to the server.
 	// If the server reported no remote servers, immediately start
@@ -516,6 +502,40 @@ bool ClientMediaDownloader::conventionalTransferDone(
 	return true;
 }
 
+/*
+	IClientMediaDownloader
+*/
+
+IClientMediaDownloader::IClientMediaDownloader():
+	m_media_cache(getMediaCacheDir()), m_write_to_cache(true)
+{
+}
+
+void IClientMediaDownloader::createCacheDirs()
+{
+	if (!m_write_to_cache)
+		return;
+
+	std::string path = getMediaCacheDir();
+	if (!fs::CreateAllDirs(path)) {
+		errorstream << "Client: Could not create media cache directory: "
+			<< path << std::endl;
+	}
+}
+
+bool IClientMediaDownloader::tryLoadFromCache(const std::string &name,
+	const std::string &sha1, Client *client)
+{
+	std::ostringstream tmp_os(std::ios_base::binary);
+	bool found_in_cache = m_media_cache.load(hex_encode(sha1), tmp_os);
+
+	// If found in cache, try to load it from there
+	if (found_in_cache)
+		return checkAndLoad(name, sha1, tmp_os.str(), true, client);
+
+	return false;
+}
+
 bool IClientMediaDownloader::checkAndLoad(
 		const std::string &name, const std::string &sha1,
 		const std::string &data, bool is_from_cache, Client *client)
@@ -546,7 +566,7 @@ bool IClientMediaDownloader::checkAndLoad(
 	}
 
 	// Checksum is ok, try loading the file
-	bool success = client->loadMedia(data, name);
+	bool success = loadMedia(client, data, name);
 	if (!success) {
 		infostream << "Client: "
 			<< "Failed to load " << cached_or_received << " media: "
@@ -561,7 +581,7 @@ bool IClientMediaDownloader::checkAndLoad(
 		<< std::endl;
 
 	// Update cache (unless we just loaded the file from the cache)
-	if (!is_from_cache)
+	if (!is_from_cache && m_write_to_cache)
 		m_media_cache.update(sha1_hex, data);
 
 	return true;
@@ -627,4 +647,146 @@ void ClientMediaDownloader::deSerializeHashSet(const std::string &data,
 	for (u32 pos = 6; pos < data.size(); pos += 20) {
 		result.insert(data.substr(pos, 20));
 	}
+}
+
+/*
+	SingleMediaDownloader
+*/
+
+SingleMediaDownloader::SingleMediaDownloader(bool write_to_cache):
+	m_httpfetch_caller(HTTPFETCH_DISCARD)
+{
+	m_write_to_cache = write_to_cache;
+}
+
+SingleMediaDownloader::~SingleMediaDownloader()
+{
+	if (m_httpfetch_caller != HTTPFETCH_DISCARD)
+		httpfetch_caller_free(m_httpfetch_caller);
+}
+
+bool SingleMediaDownloader::loadMedia(Client *client, const std::string &data,
+		const std::string &name)
+{
+	return client->loadMedia(data, name, true);
+}
+
+void SingleMediaDownloader::addFile(const std::string &name, const std::string &sha1)
+{
+	assert(stage == 0); // pre-condition
+
+	assert(!name.empty());
+	assert(sha1.size() == 20);
+
+	FATAL_ERROR_IF(!m_file_name.empty(), "Cannot add a second file");
+	m_file_name = name;
+	m_file_sha1 = sha1;
+}
+
+void SingleMediaDownloader::addRemoteServer(const std::string &baseurl)
+{
+	assert(stage == 0); // pre-condition
+
+	if (g_settings->getBool("enable_remote_media_server"))
+		m_remotes.emplace_back(baseurl);
+}
+
+void SingleMediaDownloader::step(Client *client)
+{
+	if (m_stage == 0) {
+		m_stage = 1;
+		initialStep(client);
+	}
+
+	// Remote media: check for completion of fetches
+	if (m_httpfetch_caller != HTTPFETCH_DISCARD) {
+		HTTPFetchResult fetch_result;
+		while (httpfetch_async_get(m_httpfetch_caller, fetch_result)) {
+			remoteMediaReceived(fetch_result, client);
+		}
+	}
+}
+
+bool SingleMediaDownloader::conventionalTransferDone(const std::string &name,
+		const std::string &data, Client *client)
+{
+	if (name != m_file_name)
+		return false;
+
+	// Mark file as received unconditionally and try to load it
+	m_stage = 2;
+	checkAndLoad(name, m_file_sha1, data, false, client);
+	return true;
+}
+
+void SingleMediaDownloader::initialStep(Client *client)
+{
+	if (tryLoadFromCache(m_file_name, m_file_sha1, client))
+		m_stage = 2;
+	if (isDone())
+		return;
+
+	createCacheDirs();
+
+	// If the server reported no remote servers, immediately fall back to
+	// conventional transfer.
+	if (!USE_CURL || m_remotes.empty()) {
+		startConventionalTransfer(client);
+	} else {
+		// Otherwise start by requesting the file from the first remote media server
+		m_httpfetch_caller = httpfetch_caller_alloc();
+		m_current_remote = 0;
+		startRemoteMediaTransfer();
+	}
+}
+
+void SingleMediaDownloader::remoteMediaReceived(
+		const HTTPFetchResult &fetch_result, Client *client)
+{
+	sanity_check(!isDone());
+	sanity_check(m_current_remote >= 0);
+
+	// If fetch succeeded, try to load it
+	if (fetch_result.succeeded) {
+		bool success = checkAndLoad(m_file_name, m_file_sha1,
+				fetch_result.data, false, client);
+		if (success) {
+			m_stage = 2;
+			return;
+		}
+	}
+
+	// Otherwise try the next remote server or fall back to conventional transfer
+	m_current_remote++;
+	if (m_current_remote >= m_remotes.size()) {
+		infostream << "Client: Failed to remote-fetch \"" << m_file_name
+				<< "\". Requesting it the usual way." << std::endl;
+		m_current_remote = -1;
+		startConventionalTransfer(client);
+	} else {
+		startRemoteMediaTransfer();
+	}
+}
+
+void SingleMediaDownloader::startRemoteMediaTransfer()
+{
+	std::string url = m_remotes.at(m_current_remote) + hex_encode(m_file_sha1);
+	verbosestream << "Client: Requesting remote media file "
+		<< "\"" << m_file_name << "\" " << "\"" << url << "\"" << std::endl;
+
+	HTTPFetchRequest fetch_request;
+	fetch_request.url = url;
+	fetch_request.caller = m_httpfetch_caller;
+	fetch_request.request_id = m_httpfetch_next_id;
+	fetch_request.timeout = g_settings->getS32("curl_file_download_timeout");
+	httpfetch_async(fetch_request);
+
+	m_httpfetch_next_id++;
+}
+
+void SingleMediaDownloader::startConventionalTransfer(Client *client)
+{
+	std::vector<std::string> requests;
+	requests.emplace_back(m_file_name);
+	client->request_media(requests);
 }

--- a/src/client/clientmedia.h
+++ b/src/client/clientmedia.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "irrlichttypes.h"
 #include "filecache.h"
+#include "util/basic_macros.h"
 #include <ostream>
 #include <map>
 #include <set>
@@ -42,6 +43,8 @@ bool clientMediaUpdateCache(const std::string &raw_hash,
 class IClientMediaDownloader
 {
 public:
+	DISABLE_CLASS_COPY(IClientMediaDownloader)
+
 	virtual bool isStarted() const = 0;
 
 	// If this returns true, the downloader is done and can be deleted
@@ -72,7 +75,7 @@ public:
 
 protected:
 	IClientMediaDownloader();
-	virtual ~IClientMediaDownloader() {};
+	virtual ~IClientMediaDownloader() = default;
 
 	// Forwards the call to the appropriate Client method
 	virtual bool loadMedia(Client *client, const std::string &data,

--- a/src/client/clientmedia.h
+++ b/src/client/clientmedia.h
@@ -201,11 +201,11 @@ public:
 	~SingleMediaDownloader();
 
 	bool isStarted() const override {
-		return m_stage > 0;
+		return m_stage > STAGE_INIT;
 	}
 
 	bool isDone() const override {
-		return m_stage > 1;
+		return m_stage >= STAGE_DONE;
 	}
 
 	void addFile(const std::string &name, const std::string &sha1) override;
@@ -227,6 +227,12 @@ private:
 	void startRemoteMediaTransfer();
 	void startConventionalTransfer(Client *client);
 
+	enum Stage {
+		STAGE_INIT,
+		STAGE_CACHE_CHECKED, // we have tried to load the file from cache
+		STAGE_DONE
+	};
+
 	// Information about the one file we want to fetch
 	std::string m_file_name;
 	std::string m_file_sha1;
@@ -235,10 +241,7 @@ private:
 	// Array of remote media servers
 	std::vector<std::string> m_remotes;
 
-	// 0 = init
-	// 1 = attempt to load the media file from the file cache has been made
-	// 2 = file received, we're done
-	int m_stage = 0;
+	enum Stage m_stage = STAGE_INIT;
 
 	// Status of remote transfers
 	unsigned long m_httpfetch_caller;

--- a/src/client/clientmedia.h
+++ b/src/client/clientmedia.h
@@ -72,6 +72,7 @@ public:
 
 protected:
 	IClientMediaDownloader();
+	virtual ~IClientMediaDownloader() {};
 
 	// Forwards the call to the appropriate Client method
 	virtual bool loadMedia(Client *client, const std::string &data,

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
+#include <unistd.h>
 #include <fstream>
 #include "log.h"
 #include "config.h"

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -813,7 +813,7 @@ bool Rename(const std::string &from, const std::string &to)
 	return rename(from.c_str(), to.c_str()) == 0;
 }
 
-std::string TempFile()
+std::string CreateTempFile()
 {
 	std::string path = TempPath() + DIR_DELIM "/MT_XXXXXX";
 	int fd = mkstemp(&path[0]); // modifies path

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -815,7 +815,7 @@ bool Rename(const std::string &from, const std::string &to)
 
 std::string CreateTempFile()
 {
-	std::string path = TempPath() + DIR_DELIM "/MT_XXXXXX";
+	std::string path = TempPath() + DIR_DELIM "MT_XXXXXX";
 	int fd = mkstemp(&path[0]); // modifies path
 	if (fd == -1)
 		return "";

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h"
 #include <iostream>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <cerrno>
 #include <fstream>
@@ -809,6 +810,16 @@ bool ReadFile(const std::string &path, std::string &out)
 bool Rename(const std::string &from, const std::string &to)
 {
 	return rename(from.c_str(), to.c_str()) == 0;
+}
+
+std::string TempFile()
+{
+	std::string path = TempPath() + DIR_DELIM "/MT_XXXXXX";
+	int fd = mkstemp(&path[0]); // modifies path
+	if (fd == -1)
+		return "";
+	close(fd);
+	return path;
 }
 
 } // namespace fs

--- a/src/filesys.h
+++ b/src/filesys.h
@@ -73,7 +73,7 @@ std::string TempPath();
 
 // Returns path to securely-created temporary file (will already exist when this function returns)
 // can return "" on error
-std::string TempFile();
+std::string CreateTempFile();
 
 /* Returns a list of subdirectories, including the path itself, but excluding
        hidden directories (whose names start with . or _)

--- a/src/filesys.h
+++ b/src/filesys.h
@@ -71,6 +71,10 @@ bool DeleteSingleFileOrEmptyDirectory(const std::string &path);
 // Returns path to temp directory, can return "" on error
 std::string TempPath();
 
+// Returns path to securely-created temporary file (will already exist when this function returns)
+// can return "" on error
+std::string TempFile();
+
 /* Returns a list of subdirectories, including the path itself, but excluding
        hidden directories (whose names start with . or _)
 */

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -204,7 +204,7 @@ const ServerCommandFactory serverCommandFactoryTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_factory, // 0x3e
 	null_command_factory, // 0x3f
 	{ "TOSERVER_REQUEST_MEDIA",      1, true }, // 0x40
-	null_command_factory, // 0x41
+	{ "TOSERVER_HAVE_MEDIA",         2, true }, // 0x41
 	null_command_factory, // 0x42
 	{ "TOSERVER_CLIENT_READY",       1, true }, // 0x43
 	null_command_factory, // 0x44

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -728,16 +728,16 @@ void Client::handleCommand_Media(NetworkPacket* pkt)
 		*pkt >> name;
 		data = pkt->readLongString();
 
-		if (init_phase) {
-			m_media_downloader->conventionalTransferDone(name, data, this);
-			continue;
-		}
-		// Check pending dynamic transfers, one of them must be it
 		bool ok = false;
-		for (const auto &it : m_pending_media_downloads) {
-			if (it.second->conventionalTransferDone(name, data, this)) {
-				ok = true;
-				break;
+		if (init_phase) {
+			ok = m_media_downloader->conventionalTransferDone(name, data, this);
+		} else {
+			// Check pending dynamic transfers, one of them must be it
+			for (const auto &it : m_pending_media_downloads) {
+				if (it.second->conventionalTransferDone(name, data, this)) {
+					ok = true;
+					break;
+				}
 			}
 		}
 		if (!ok) {

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1549,7 +1549,7 @@ void Client::handleCommand_MediaPush(NetworkPacket *pkt)
 
 	// create a downloader for this file
 	auto downloader = new SingleMediaDownloader(cached);
-	m_pending_media_downloads[token] = downloader;
+	m_pending_media_downloads.emplace_back(token, downloader);
 	downloader->addFile(filename, raw_hash);
 	for (const auto &baseurl : m_remote_media_servers)
 		downloader->addRemoteServer(baseurl);

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1493,12 +1493,11 @@ void Client::handleCommand_MediaPush(NetworkPacket *pkt)
 	u32 token;
 	bool cached;
 
-	if (m_proto_ver >= 40) {
-		*pkt >> raw_hash >> filename >> token >> cached;
-	} else {
-		*pkt >> raw_hash >> filename >> cached;
+	*pkt >> raw_hash >> filename >> cached;
+	if (m_proto_ver >= 40)
+		*pkt >> token;
+	else
 		filedata = pkt->readLongString();
-	}
 
 	if (raw_hash.size() != 20 || filename.empty() ||
 			(m_proto_ver < 40 && filedata.empty()) ||

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1513,8 +1513,10 @@ void Client::handleCommand_MediaPush(NetworkPacket *pkt)
 	verbosestream << "(cached=" << cached << ")" << std::endl;
 
 	if (m_media_pushed_files.count(filename) != 0) {
-		// Silently ignore. Previously this was for sync purposes, but even in
-		// new versions media cannot be replaced at runtime.
+		// Ignore (but acknowledge). Previously this was for sync purposes,
+		// but even in new versions media cannot be replaced at runtime.
+		if (m_proto_ver >= 40)
+			sendHaveMedia({ token });
 		return;
 	}
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1545,6 +1545,8 @@ void Client::handleCommand_MediaPush(NetworkPacket *pkt)
 		return;
 	}
 
+	m_media_pushed_files.insert(filename);
+
 	// create a downloader for this file
 	auto downloader = new SingleMediaDownloader(cached);
 	m_pending_media_downloads[token] = downloader;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1500,8 +1500,8 @@ void Client::handleCommand_MediaPush(NetworkPacket *pkt)
 		filedata = pkt->readLongString();
 	}
 
-	bool data_empty = m_proto_ver < 40 && filedata.empty();
-	if (raw_hash.size() != 20 || data_empty || filename.empty() ||
+	if (raw_hash.size() != 20 || filename.empty() ||
+			(m_proto_ver < 40 && filedata.empty()) ||
 			!string_allowed(filename, TEXTURENAME_ALLOWED_CHARS)) {
 		throw PacketError("Illegal filename, data or hash");
 	}

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -207,6 +207,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Minimap modes
 	PROTOCOL VERSION 40:
 		Added 'basic_debug' privilege
+		TOCLIENT_MEDIA_PUSH changed, TOSERVER_HAVE_MEDIA added
 */
 
 #define LATEST_PROTOCOL_VERSION 40
@@ -317,9 +318,8 @@ enum ToClientCommand
 	/*
 		std::string raw_hash
 		std::string filename
+		u32 callback_token
 		bool should_be_cached
-		u32 len
-		char filedata[len]
 	*/
 
 	// (oops, there is some gap here)
@@ -940,7 +940,7 @@ enum ToServerCommand
 
 	TOSERVER_HAVE_MEDIA = 0x41,
 	/*
-		u8 number of media tokens
+		u8 number of callback tokens
 		for each:
 			u32 token
 	*/

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -938,7 +938,13 @@ enum ToServerCommand
 		}
 	*/
 
-	TOSERVER_RECEIVED_MEDIA = 0x41, // Obsolete
+	TOSERVER_HAVE_MEDIA = 0x41,
+	/*
+		u8 number of media tokens
+		for each:
+			u32 token
+	*/
+
 	TOSERVER_BREATH = 0x42, // Obsolete
 
 	TOSERVER_CLIENT_READY = 0x43,

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -89,7 +89,7 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_handler, // 0x3e
 	null_command_handler, // 0x3f
 	{ "TOSERVER_REQUEST_MEDIA",            TOSERVER_STATE_STARTUP, &Server::handleCommand_RequestMedia }, // 0x40
-	{ "TOSERVER_HAVE_MEDIA",               TOSERVER_STATE_STARTUP, &Server::handleCommand_HaveMedia }, // 0x41
+	{ "TOSERVER_HAVE_MEDIA",               TOSERVER_STATE_INGAME, &Server::handleCommand_HaveMedia }, // 0x41
 	null_command_handler, // 0x42
 	{ "TOSERVER_CLIENT_READY",             TOSERVER_STATE_STARTUP, &Server::handleCommand_ClientReady }, // 0x43
 	null_command_handler, // 0x44

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -89,7 +89,7 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_handler, // 0x3e
 	null_command_handler, // 0x3f
 	{ "TOSERVER_REQUEST_MEDIA",            TOSERVER_STATE_STARTUP, &Server::handleCommand_RequestMedia }, // 0x40
-	null_command_handler, // 0x41
+	{ "TOSERVER_HAVE_MEDIA",               TOSERVER_STATE_STARTUP, &Server::handleCommand_HaveMedia }, // 0x41
 	null_command_handler, // 0x42
 	{ "TOSERVER_CLIENT_READY",             TOSERVER_STATE_STARTUP, &Server::handleCommand_ClientReady }, // 0x43
 	null_command_handler, // 0x44
@@ -167,7 +167,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_TIME_OF_DAY",              0, true }, // 0x29
 	{ "TOCLIENT_CSM_RESTRICTION_FLAGS",    0, true }, // 0x2A
 	{ "TOCLIENT_PLAYER_SPEED",             0, true }, // 0x2B
-	{ "TOCLIENT_MEDIA_PUSH",               0, true }, // 0x2C (sent over channel 1 too)
+	{ "TOCLIENT_MEDIA_PUSH",               0, true }, // 0x2C (sent over channel 1 too if legacy)
 	null_command_factory, // 0x2D
 	null_command_factory, // 0x2E
 	{ "TOCLIENT_CHAT_MESSAGE",             0, true }, // 0x2F

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1821,7 +1821,7 @@ void Server::handleCommand_ModChannelMsg(NetworkPacket *pkt)
 	broadcastModChannelMessage(channel_name, channel_msg, peer_id);
 }
 
-void Server::handleCommand_HaveMedia(NetworkPacket* pkt)
+void Server::handleCommand_HaveMedia(NetworkPacket *pkt)
 {
 	std::vector<u32> tokens;
 	u8 numtokens;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -362,16 +362,15 @@ void Server::handleCommand_RequestMedia(NetworkPacket* pkt)
 	session_t peer_id = pkt->getPeerId();
 	infostream << "Sending " << numfiles << " files to " <<
 		getPlayerName(peer_id) << std::endl;
-	verbosestream << "TOSERVER_REQUEST_MEDIA: " << std::endl;
+	verbosestream << "TOSERVER_REQUEST_MEDIA: requested file(s)" << std::endl;
 
 	for (u16 i = 0; i < numfiles; i++) {
 		std::string name;
 
 		*pkt >> name;
 
-		tosend.push_back(name);
-		verbosestream << "TOSERVER_REQUEST_MEDIA: requested file "
-				<< name << std::endl;
+		tosend.emplace_back(name);
+		verbosestream << "  " << name << std::endl;
 	}
 
 	sendRequestedMedia(peer_id, tosend);

--- a/src/script/cpp_api/s_server.cpp
+++ b/src/script/cpp_api/s_server.cpp
@@ -215,9 +215,9 @@ u32 ScriptApiServer::allocateDynamicMediaCallback(int f_idx)
 	while (1) {
 		token = myrand();
 		lua_rawgeti(L, -2, token);
-		bool exit = lua_isnil(L, -1);
+		bool is_free = lua_isnil(L, -1);
 		lua_pop(L, 1);
-		if (exit)
+		if (is_free)
 			break;
 		if (--tries < 0)
 			FATAL_ERROR("Ran out of callbacks IDs?!");

--- a/src/script/cpp_api/s_server.cpp
+++ b/src/script/cpp_api/s_server.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_server.h"
 #include "cpp_api/s_internal.h"
 #include "common/c_converter.h"
+#include "util/numeric.h" // myrand
 
 bool ScriptApiServer::getAuth(const std::string &playername,
 		std::string *dst_password,
@@ -195,4 +196,72 @@ std::string ScriptApiServer::formatChatMessage(const std::string &name,
 	lua_pop(L, 1);
 
 	return ret;
+}
+
+u32 ScriptApiServer::allocateDynamicMediaCallback(int f_idx)
+{
+	lua_State *L = getStack();
+
+	if (f_idx < 0)
+		f_idx = lua_gettop(L) + f_idx + 1;
+
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "dynamic_media_callbacks");
+	luaL_checktype(L, -1, LUA_TTABLE);
+
+	// Find a randomly generated token that doesn't exist yet
+	int tries = 100;
+	u32 token;
+	while (1) {
+		token = myrand();
+		lua_rawgeti(L, -2, token);
+		bool exit = lua_isnil(L, -1);
+		lua_pop(L, 1);
+		if (exit)
+			break;
+		if (--tries < 0)
+			FATAL_ERROR("Ran out of callbacks IDs?!");
+	}
+
+	// core.dynamic_media_callbacks[token] = callback_func
+	lua_pushvalue(L, f_idx);
+	lua_rawseti(L, -2, token);
+
+	lua_pop(L, 2);
+
+	verbosestream << "allocateDynamicMediaCallback() = " << token << std::endl;
+	return token;
+}
+
+void ScriptApiServer::freeDynamicMediaCallback(u32 token)
+{
+	lua_State *L = getStack();
+
+	verbosestream << "freeDynamicMediaCallback(" << token << ")" << std::endl;
+
+	// core.dynamic_media_callbacks[token] = nil
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "dynamic_media_callbacks");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	lua_pushnil(L);
+	lua_rawseti(L, -2, token);
+	lua_pop(L, 2);
+}
+
+void ScriptApiServer::on_dynamic_media_added(u32 token, const char *playername)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	verbosestream << "on_dynamic_media_added(" << token << ", " << playername
+		<< ")" << std::endl;
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "dynamic_media_callbacks");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	lua_rawgeti(L, -2, token);
+	luaL_checktype(L, -1, LUA_TFUNCTION);
+
+	lua_pushstring(L, playername);
+	PCALL_RES(lua_pcall(L, 1, 0, error_handler));
 }

--- a/src/script/cpp_api/s_server.cpp
+++ b/src/script/cpp_api/s_server.cpp
@@ -252,14 +252,11 @@ void ScriptApiServer::on_dynamic_media_added(u32 token, const char *playername)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
-	verbosestream << "on_dynamic_media_added(" << token << ", " << playername
-		<< ")" << std::endl;
-
 	int error_handler = PUSH_ERROR_HANDLER(L);
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "dynamic_media_callbacks");
 	luaL_checktype(L, -1, LUA_TTABLE);
-	lua_rawgeti(L, -2, token);
+	lua_rawgeti(L, -1, token);
 	luaL_checktype(L, -1, LUA_TFUNCTION);
 
 	lua_pushstring(L, playername);

--- a/src/script/cpp_api/s_server.h
+++ b/src/script/cpp_api/s_server.h
@@ -49,6 +49,12 @@ public:
 		const std::string &password);
 	bool setPassword(const std::string &playername,
 		const std::string &password);
+
+	/* dynamic media handling */
+	u32 allocateDynamicMediaCallback(int f_idx);
+	void freeDynamicMediaCallback(u32 token);
+	void on_dynamic_media_added(u32 token, const char *playername);
+
 private:
 	void getAuthHandler();
 	void readPrivileges(int index, std::set<std::string> &result);

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_content.h"
 #include "cpp_api/s_base.h"
 #include "cpp_api/s_security.h"
+#include "scripting_server.h"
 #include "server.h"
 #include "environment.h"
 #include "remoteplayer.h"
@@ -452,29 +453,25 @@ int ModApiServer::l_sound_fade(lua_State *L)
 }
 
 // dynamic_add_media(filepath)
-int ModApiServer::l_dynamic_add_media_raw(lua_State *L)
+int ModApiServer::l_dynamic_add_media(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
 	if (!getEnv(L))
 		throw LuaError("Dynamic media cannot be added before server has started up");
+	Server *server = getServer(L);
 
 	std::string filepath = readParam<std::string>(L, 1);
 	CHECK_SECURE_PATH(L, filepath.c_str(), false);
 
-	std::vector<RemotePlayer*> sent_to;
-	bool ok = getServer(L)->dynamicAddMedia(filepath, sent_to);
-	if (ok) {
-		// (see wrapper code in builtin)
-		lua_createtable(L, sent_to.size(), 0);
-		int i = 0;
-		for (RemotePlayer *player : sent_to) {
-			lua_pushstring(L, player->getName());
-			lua_rawseti(L, -2, ++i);
-		}
-	} else {
-		lua_pushboolean(L, false);
-	}
+	luaL_checktype(L, 2, LUA_TFUNCTION);
+
+	u32 token = server->getScriptIface()->allocateDynamicMediaCallback(2);
+
+	bool ok = server->dynamicAddMedia(filepath, token);
+	if (!ok)
+		server->getScriptIface()->freeDynamicMediaCallback(token);
+	lua_pushboolean(L, ok);
 
 	return 1;
 }
@@ -543,7 +540,7 @@ void ModApiServer::Initialize(lua_State *L, int top)
 	API_FCT(sound_play);
 	API_FCT(sound_stop);
 	API_FCT(sound_fade);
-	API_FCT(dynamic_add_media_raw);
+	API_FCT(dynamic_add_media);
 
 	API_FCT(get_player_information);
 	API_FCT(get_player_privs);

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -463,10 +463,12 @@ int ModApiServer::l_dynamic_add_media(lua_State *L)
 
 	std::string filepath;
 	std::string to_player;
+	bool ephemeral = false;
 
 	if (lua_istable(L, 1)) {
 		getstringfield(L, 1, "filepath", filepath);
 		getstringfield(L, 1, "to_player", to_player);
+		getboolfield(L, 1, "ephemeral", ephemeral);
 	} else {
 		filepath = readParam<std::string>(L, 1);
 	}
@@ -476,7 +478,7 @@ int ModApiServer::l_dynamic_add_media(lua_State *L)
 
 	u32 token = server->getScriptIface()->allocateDynamicMediaCallback(2);
 
-	bool ok = server->dynamicAddMedia(filepath, token, to_player);
+	bool ok = server->dynamicAddMedia(filepath, token, to_player, false);
 	if (!ok)
 		server->getScriptIface()->freeDynamicMediaCallback(token);
 	lua_pushboolean(L, ok);

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -472,6 +472,8 @@ int ModApiServer::l_dynamic_add_media(lua_State *L)
 	} else {
 		filepath = readParam<std::string>(L, 1);
 	}
+	if (filepath.empty())
+		luaL_typerror(L, 1, "non-empty string");
 	luaL_checktype(L, 2, LUA_TFUNCTION);
 
 	CHECK_SECURE_PATH(L, filepath.c_str(), false);

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -461,14 +461,22 @@ int ModApiServer::l_dynamic_add_media(lua_State *L)
 		throw LuaError("Dynamic media cannot be added before server has started up");
 	Server *server = getServer(L);
 
-	std::string filepath = readParam<std::string>(L, 1);
-	CHECK_SECURE_PATH(L, filepath.c_str(), false);
+	std::string filepath;
+	std::string to_player;
 
+	if (lua_istable(L, 1)) {
+		getstringfield(L, 1, "filepath", filepath);
+		getstringfield(L, 1, "to_player", to_player);
+	} else {
+		filepath = readParam<std::string>(L, 1);
+	}
 	luaL_checktype(L, 2, LUA_TFUNCTION);
+
+	CHECK_SECURE_PATH(L, filepath.c_str(), false);
 
 	u32 token = server->getScriptIface()->allocateDynamicMediaCallback(2);
 
-	bool ok = server->dynamicAddMedia(filepath, token);
+	bool ok = server->dynamicAddMedia(filepath, token, to_player);
 	if (!ok)
 		server->getScriptIface()->freeDynamicMediaCallback(token);
 	lua_pushboolean(L, ok);

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -480,7 +480,7 @@ int ModApiServer::l_dynamic_add_media(lua_State *L)
 
 	u32 token = server->getScriptIface()->allocateDynamicMediaCallback(2);
 
-	bool ok = server->dynamicAddMedia(filepath, token, to_player, false);
+	bool ok = server->dynamicAddMedia(filepath, token, to_player, ephemeral);
 	if (!ok)
 		server->getScriptIface()->freeDynamicMediaCallback(token);
 	lua_pushboolean(L, ok);

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -71,7 +71,7 @@ private:
 	static int l_sound_fade(lua_State *L);
 
 	// dynamic_add_media(filepath)
-	static int l_dynamic_add_media_raw(lua_State *L);
+	static int l_dynamic_add_media(lua_State *L);
 
 	// get_player_privs(name, text)
 	static int l_get_player_privs(lua_State *L);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3499,7 +3499,7 @@ bool Server::dynamicAddMedia(std::string filepath,
 	if (ephemeral) {
 		// Create a copy of the file and swap out the path, this removes the
 		// requirement that mods keep the file accessible at the original path.
-		filepath = fs::TempFile();
+		filepath = fs::CreateTempFile();
 		bool ok = ([&] () -> bool {
 			if (filepath.empty())
 				return false;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2571,7 +2571,7 @@ struct SendableMedia
 
 	SendableMedia(const std::string &name, const std::string &path,
 			std::string &&data):
-		name(name), path(path), data(data)
+		name(name), path(path), data(std::move(data))
 	{}
 };
 
@@ -3560,7 +3560,7 @@ bool Server::dynamicAddMedia(std::string filepath,
 			m_clients.send(peer_id, 0, &legacy_pkt, true);
 		} else {
 			waiting.emplace(peer_id);
-			m_clients.send(peer_id, 1, &pkt, true);
+			Send(peer_id, &pkt);
 		}
 	}
 	m_clients.unlock();

--- a/src/server.h
+++ b/src/server.h
@@ -83,7 +83,7 @@ struct MediaInfo
 {
 	std::string path;
 	std::string sha1_digest; // base64-encoded
-	bool no_announce;
+	bool no_announce; // true: not announced in TOCLIENT_ANNOUNCE_MEDIA (at player join)
 
 	MediaInfo(const std::string &path_="",
 	          const std::string &sha1_digest_=""):

--- a/src/server.h
+++ b/src/server.h
@@ -261,8 +261,8 @@ public:
 
 	void deleteParticleSpawner(const std::string &playername, u32 id);
 
-	bool dynamicAddMedia(const std::string &filepath, u32 token,
-		const std::string &to_player);
+	bool dynamicAddMedia(std::string filepath, u32 token,
+		const std::string &to_player, bool ephemeral);
 
 	ServerInventoryManager *getInventoryMgr() const { return m_inventory_mgr.get(); }
 	void sendDetachedInventory(Inventory *inventory, const std::string &name, session_t peer_id);
@@ -401,6 +401,7 @@ private:
 	};
 
 	struct PendingDynamicMediaCallback {
+		std::string filename; // only set if media entry and file is to be deleted
 		float expiry_timer;
 		std::unordered_set<session_t> waiting_players;
 	};

--- a/src/server.h
+++ b/src/server.h
@@ -82,12 +82,14 @@ enum ClientDeletionReason {
 struct MediaInfo
 {
 	std::string path;
-	std::string sha1_digest;
+	std::string sha1_digest; // base64-encoded
+	bool no_announce;
 
 	MediaInfo(const std::string &path_="",
 	          const std::string &sha1_digest_=""):
 		path(path_),
-		sha1_digest(sha1_digest_)
+		sha1_digest(sha1_digest_),
+		no_announce(false)
 	{
 	}
 };
@@ -259,7 +261,8 @@ public:
 
 	void deleteParticleSpawner(const std::string &playername, u32 id);
 
-	bool dynamicAddMedia(const std::string &filepath, u32 token);
+	bool dynamicAddMedia(const std::string &filepath, u32 token,
+		const std::string &to_player);
 
 	ServerInventoryManager *getInventoryMgr() const { return m_inventory_mgr.get(); }
 	void sendDetachedInventory(Inventory *inventory, const std::string &name, session_t peer_id);

--- a/src/server.h
+++ b/src/server.h
@@ -43,6 +43,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <list>
 #include <map>
 #include <vector>
+#include <unordered_set>
 
 class ChatEvent;
 struct ChatEventChat;
@@ -197,6 +198,7 @@ public:
 	void handleCommand_FirstSrp(NetworkPacket* pkt);
 	void handleCommand_SrpBytesA(NetworkPacket* pkt);
 	void handleCommand_SrpBytesM(NetworkPacket* pkt);
+	void handleCommand_HaveMedia(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 
@@ -257,7 +259,7 @@ public:
 
 	void deleteParticleSpawner(const std::string &playername, u32 id);
 
-	bool dynamicAddMedia(const std::string &filepath, std::vector<RemotePlayer*> &sent_to);
+	bool dynamicAddMedia(const std::string &filepath, u32 token);
 
 	ServerInventoryManager *getInventoryMgr() const { return m_inventory_mgr.get(); }
 	void sendDetachedInventory(Inventory *inventory, const std::string &name, session_t peer_id);
@@ -395,6 +397,11 @@ private:
 			float m_timer = 0.0f;
 	};
 
+	struct PendingDynamicMediaCallback {
+		float expiry_timer;
+		std::unordered_set<session_t> waiting_players;
+	};
+
 	void init();
 
 	void SendMovement(session_t peer_id);
@@ -466,6 +473,7 @@ private:
 	void sendMediaAnnouncement(session_t peer_id, const std::string &lang_code);
 	void sendRequestedMedia(session_t peer_id,
 			const std::vector<std::string> &tosend);
+	void stepPendingDynMediaCallbacks(float dtime);
 
 	// Adds a ParticleSpawner on peer with peer_id (PEER_ID_INEXISTENT == all)
 	void SendAddParticleSpawner(session_t peer_id, u16 protocol_version,
@@ -649,6 +657,10 @@ private:
 
 	// media files known to server
 	std::unordered_map<std::string, MediaInfo> m_media;
+
+	// pending dynamic media callbacks, clients inform the server when they have a file fetched
+	std::unordered_map<u32, PendingDynamicMediaCallback> m_pending_dyn_media;
+	float m_step_pending_dyn_media_timer = 0.0f;
 
 	/*
 		Sounds


### PR DESCRIPTION
What's new:
* Awful hack gone (file contents no longer sent twice), instead works asynchonously
* Remote media support
* Send to chosen player
* Ephemeral mode: Client won't save data in cache, file doesn't need to be kept on disk

Note that the last two features will work even with a 5.5 server and 5.3/5.4 client.

Important: To avoid bumping the protocol version this "reuses" proto ver 40 and introduces a subtle incompatibility between dev versions (only if dynamic media used!), there will of course be <b>no issues between release versions</b>.

## To do

This PR is Ready for Review.

## How to test

Use this mod:
```lua
local function show_to(name, param)
	local basename = table.remove(string.split(param, "/"))
	local e = table.remove(string.split(basename, "."))
	basename = basename:gsub("%." .. e .. "$", "")

	if e == "ogg" then
		core.sound_play({name = basename}, {to_player = name})
	elseif e == "jpg" or e == "png" then
		core.get_player_by_name(name):hud_add({
			hud_elem_type = "image",
			position = {x = math.random(0.2, 0.8), y = math.random(0.2, 0.8)},
			scale = {x = 1, y = 1},
			text = basename .. "." .. e
		})
	end
end
core.register_chatcommand("show", {
	func = function(name, param)
		if param:sub(1, 1) ~= "/" then
			param = core.get_worldpath() .. "/" .. param
		end
		local cb = function(name2)
			print("callback(" .. name2 .. ")")
			if name == name2 then show_to(name, param) end
		end
		if not core.dynamic_add_media({
			filepath = param,
			to_player = name,
			--ephemeral = true,
		}, cb) then
			return false, "couldn't add media"
		end
		return true
	end
})
```

* play around with the parameters to `dynamic_add_media`
* observe verbose log messages (they're useful)
* don't forget that remote media exists ([darkhttpd](https://github.com/emikulic/darkhttpd) works to set up a http server on a whim)