### PR TITLE
Show message when changing block bounds

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2199,7 +2199,24 @@ void Game::toggleCinematic()
 void Game::toggleBlockBounds()
 {
 	if (client->checkPrivilege("basic_debug")) {
-		hud->toggleBlockBounds();
+		enum Hud::BlockBoundsMode newmode = hud->toggleBlockBounds();
+		switch (newmode) {
+			case Hud::BLOCK_BOUNDS_OFF:
+				m_game_ui->showTranslatedStatusText("Block bounds hidden");
+				break;
+			case Hud::BLOCK_BOUNDS_CURRENT:
+				m_game_ui->showTranslatedStatusText("Block bounds shown for current block");
+				break;
+			case Hud::BLOCK_BOUNDS_NEAR:
+				m_game_ui->showTranslatedStatusText("Block bounds shown for nearby blocks");
+				break;
+			case Hud::BLOCK_BOUNDS_MAX:
+				m_game_ui->showTranslatedStatusText("Block bounds shown for all blocks");
+				break;
+			default:
+				break;
+		}
+
 	} else {
 		m_game_ui->showTranslatedStatusText("Can't show block bounds (need 'basic_debug' privilege)");
 	}

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -857,13 +857,14 @@ void Hud::drawSelectionMesh()
 	}
 }
 
-void Hud::toggleBlockBounds()
+enum Hud::BlockBoundsMode Hud::toggleBlockBounds()
 {
 	m_block_bounds_mode = static_cast<BlockBoundsMode>(m_block_bounds_mode + 1);
 
 	if (m_block_bounds_mode >= BLOCK_BOUNDS_MAX) {
 		m_block_bounds_mode = BLOCK_BOUNDS_OFF;
 	}
+	return m_block_bounds_mode;
 }
 
 void Hud::disableBlockBounds()
@@ -890,7 +891,7 @@ void Hud::drawBlockBounds()
 
 	v3f offset = intToFloat(client->getCamera()->getOffset(), BS);
 
-	s8 radius = m_block_bounds_mode == BLOCK_BOUNDS_ALL ? 2 : 0;
+	s8 radius = m_block_bounds_mode == BLOCK_BOUNDS_NEAR ? 2 : 0;
 
 	v3f halfNode = v3f(BS, BS, BS) / 2.0f;
 

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -35,6 +35,14 @@ struct ItemStack;
 class Hud
 {
 public:
+	enum BlockBoundsMode
+	{
+		BLOCK_BOUNDS_OFF,
+		BLOCK_BOUNDS_CURRENT,
+		BLOCK_BOUNDS_NEAR,
+		BLOCK_BOUNDS_MAX
+	} m_block_bounds_mode = BLOCK_BOUNDS_OFF;
+
 	video::SColor crosshair_argb;
 	video::SColor selectionbox_argb;
 
@@ -51,7 +59,7 @@ public:
 			Inventory *inventory);
 	~Hud();
 
-	void toggleBlockBounds();
+	enum BlockBoundsMode toggleBlockBounds();
 	void disableBlockBounds();
 	void drawBlockBounds();
 
@@ -126,14 +134,6 @@ private:
 	video::SMaterial m_selection_material;
 
 	scene::SMeshBuffer m_rotation_mesh_buffer;
-
-	enum BlockBoundsMode
-	{
-		BLOCK_BOUNDS_OFF,
-		BLOCK_BOUNDS_CURRENT,
-		BLOCK_BOUNDS_ALL,
-		BLOCK_BOUNDS_MAX
-	} m_block_bounds_mode = BLOCK_BOUNDS_OFF;
 
 	enum
 	{


### PR DESCRIPTION
This PR will add a status message which is shown when you change the displayed block bounds.

Also `BLOCK_BOUNDS_ALL` is renamed to `BLOCK_BOUNDS_NEAR` because the old name was too confusing.