### PR TITLE
Set policies through CMake 3.9 to allow enabling IPO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 
 # Set policies up to 3.9 since we want to enable the IPO option
 if(${CMAKE_VERSION} VERSION_LESS 3.9)
-	cmake_policy(VERSION ${CMAKE_MAJOR_VERSION.${CMAKE_MINOR_VERSION})
+	cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 else()
 	cmake_policy(VERSION 3.9)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 
 # Set policies up to 3.9 since we want to enable the IPO option
 if(${CMAKE_VERSION} VERSION_LESS 3.9)
-	cmake_policy(VERSION ${CMAKE_VERSION_MAJOR}.${CMAKE_VERSION_MINOR})
+	cmake_policy(VERSION ${CMAKE_MAJOR_VERSION.${CMAKE_MINOR_VERSION})
 else()
 	cmake_policy(VERSION 3.9)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,14 @@
 cmake_minimum_required(VERSION 3.5)
 
+# Policies should be set to NEW behavior whenever possible. This only sets
+# policies up to version 3.9 (for the IPO policies we want) as a way to
+# introduce the feature more gradually and see how it works.
+if(${CMAKE_VERSION} VERSION_LESS 3.9)
+	cmake_policy(VERSION ${CMAKE_VERSION_MAJOR}.${CMAKE_VERSION_MINOR})
+else()
+	cmake_policy(VERSION 3.9)
+endif()
+
 # This can be read from ${PROJECT_NAME} after project() is called
 project(minetest)
 set(PROJECT_NAME_CAPITALIZED "Minetest")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-# Policies should be set to NEW behavior whenever possible. This only sets
-# policies up to version 3.9 (for the IPO policies we want) as a way to
-# introduce the feature more gradually and see how it works.
+# Set policies up to 3.9 since we want to enable the IPO option
 if(${CMAKE_VERSION} VERSION_LESS 3.9)
 	cmake_policy(VERSION ${CMAKE_VERSION_MAJOR}.${CMAKE_VERSION_MINOR})
 else()


### PR DESCRIPTION
The OLD version of policies are deprecated by definition. This sets all policies to NEW through version 3.9. Newer versions will have policies set as for version 3.9. Version 3.9 was chosen because the CMP0069 policy it introduced allows signficantly improved IPO (Interprocedural Optimization, aka. LTO) support, and this way the policy settings can be introduced somewhat gradually.

Add compact, short information about your PR for easier understanding:

- Goal of the PR is to allow IPO to work when desired on supporting CMake versions (3.9+).
- The PR works by setting policies to NEW when possible.
- This resolves requesting IPO being ignored even on supporting versions due to OLD policy.
- Does this relate to a goal in [the roadmap](../doc/direction.md)? No idea.
- If not a bug fix, why is this PR needed? What usecases does it solve? N/A.

## To do

Ready for Review.

## How to test
Try building with IPO support enabled on any CMake version 3.9 or newer.
