### PR TITLE
Build message information on how to build with in-tree Irrlicht

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,9 @@ else()
 	find_package(IrrlichtMt QUIET)
 	if(NOT TARGET IrrlichtMt::IrrlichtMt)
 		string(CONCAT explanation_msg
-			"The Minetest team has forked Irrlicht to make their own customizations. "
-			"It can be found here: https://github.com/minetest/irrlicht")
+			"The Minetest team has forked Irrlicht to make their own customizations.\n"
+			"It can be found here: https://github.com/minetest/irrlicht\n"
+			"For example: git clone --depth=1 https://github.com/minetest/irrlicht lib/irrlichtmt\n")
 		if(BUILD_CLIENT)
 			message(FATAL_ERROR "IrrlichtMt is required to build the client, but it was not found.\n${explanation_msg}")
 		endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,9 +85,9 @@ else()
 	find_package(IrrlichtMt QUIET)
 	if(NOT TARGET IrrlichtMt::IrrlichtMt)
 		string(CONCAT explanation_msg
-			"The Minetest team has forked Irrlicht to make their own customizations.\n"
+			"The Minetest team has forked Irrlicht to make their own customizations. "
 			"It can be found here: https://github.com/minetest/irrlicht\n"
-			"For example: git clone --depth=1 https://github.com/minetest/irrlicht lib/irrlichtmt\n")
+			"For example use: git clone --depth=1 https://github.com/minetest/irrlicht lib/irrlichtmt\n")
 		if(BUILD_CLIENT)
 			message(FATAL_ERROR "IrrlichtMt is required to build the client, but it was not found.\n${explanation_msg}")
 		endif()


### PR DESCRIPTION
- Helps improve first-build experience without altering project structure.
- Changes the reported message when IrrlichtMt is not found.
- This PR specifically aids in helping people compile Minetest locally without performing a system-wide installation of IrrlichtMt.

## To do

This PR is Ready for Review.

## How to test

+ Confirm that the resulting change is parsable by CMake. (EDIT: To be clear, it works fine for me, but I'm specifically on `cmake version 3.16.3`)
+ Confirm that the wording is sufficiently clear and that formatting is ideal.
+ Confirm that the instructions are the standard that ought to be used for new contributors and/or people who need to make local builds due to system circumstances.
