### PR TITLE
Add a function to coordinate buffer sharing

### DIFF
--- a/builtin/common/common_buffers.lua
+++ b/builtin/common/common_buffers.lua
@@ -1,0 +1,17 @@
+-- Reusable common buffers for use with e.g. VoxelManip:get_data(<buffer>)
+
+local common_buffers = {}
+function core.get_common_buffer(index)
+	if index == nil then
+		index = 1
+	elseif type(index) ~= "number" then
+		error("Invalid buffer index; expected number, got " .. type(index))
+	end
+
+	local buffer = common_buffers[index]
+	if not buffer then
+		buffer = {}
+		common_buffers[index] = buffer
+	end
+	return buffer
+end

--- a/builtin/common/tests/common_buffers_spec.lua
+++ b/builtin/common/tests/common_buffers_spec.lua
@@ -1,0 +1,19 @@
+_G.core = {}
+dofile("builtin/common/common_buffers.lua")
+
+describe("common buffer", function()
+	it("default index is 1", function()
+		assert.equals(core.get_common_buffer(), core.get_common_buffer(1))
+	end)
+
+	it("indices are distinct", function()
+		assert.is_not.equals(core.get_common_buffer(1), core.get_common_buffer(2))
+	end)
+
+	it("indices must be numeric", function()
+		assert.has_error(function() core.get_common_buffer(false) end)
+		assert.has_error(function() core.get_common_buffer("1") end)
+		assert.has_error(function() core.get_common_buffer(0/0) end)
+		assert.has_no.error(function() core.get_common_buffer(1.1) end)
+	end)
+end)

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -33,6 +33,7 @@ local asyncpath = scriptdir .. "async" .. DIR_DELIM
 dofile(commonpath .. "vector.lua")
 dofile(commonpath .. "strict.lua")
 dofile(commonpath .. "serialize.lua")
+dofile(commonpath .. "common_buffers.lua")
 dofile(commonpath .. "misc_helpers.lua")
 
 if INIT == "game" then

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -659,6 +659,18 @@ Minetest namespace reference
    * If a flag in this table is set to true, the feature is RESTRICTED.
    * Possible flags: `load_client_mods`, `chat_messages`, `read_itemdefs`,
                    `read_nodedefs`, `lookup_nodes`, `read_playerinfo`
+* `minetest.get_common_buffer([index])`: Gets a shared temporary buffer table.
+    * `index`: The numeric identifier of a buffer such that the returned buffer
+      is distinct from buffers with different indices. The index should be a
+      small integer in order to promote sharing. Default: 1
+  This function provides a way to temporarily store large amounts of
+  information while avoiding many large allocations. Functions can share
+  buffers as temporary storage rather than making their own, increasing memory
+  efficiency.
+  **Sections of code that use a buffer of a given index must not overlap**,
+  as this will lead to data being overwritten while it is still in use.
+  Do not rely on the length of a buffer, as it may be padded by junk left over
+  from its previous uses.
 
 ### Logging
 * `minetest.debug(...)`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4172,7 +4172,8 @@ inside the VoxelManip.
   this reason, it is strongly encouraged to complete the usage of a particular
   VoxelManip object in the same callback it had been created.
 * If a VoxelManip object will be used often, such as in an `on_generated()`
-  callback, consider passing a file-scoped table as the optional parameter to
+  callback, consider passing a file-scoped table or a table from
+  `minetest.get_common_buffer()` as the optional parameter to
   `VoxelManip:get_data()`, which serves as a static buffer the function can use
   to write map data to instead of returning a new table each call. This greatly
   enhances performance by avoiding unnecessary memory allocations.
@@ -4643,6 +4644,18 @@ Utilities
   use `colorspec_to_bytes` to generate raw RGBA values in a predictable way.
   The resulting PNG image is always 32-bit. Palettes are not supported at the moment.
   You may use this to procedurally generate textures during server init.
+* `minetest.get_common_buffer([index])`: Gets a shared temporary buffer table.
+    * `index`: The numeric identifier of a buffer such that the returned buffer
+      is distinct from buffers with different indices. The index should be a
+      small integer in order to promote sharing. Default: 1
+  This function provides a way to temporarily store large amounts of
+  information while avoiding many large allocations. Functions can share
+  buffers as temporary storage rather than making their own, increasing memory
+  efficiency.
+  **Sections of code that use a buffer of a given index must not overlap**,
+  as this will lead to data being overwritten while it is still in use.
+  Do not rely on the length of a buffer, as it may be padded by junk left over
+  from its previous uses.
 
 Logging
 -------


### PR DESCRIPTION
This an unimportant change that isn't part of the roadmap or anything. It just reduces memory usage in some instances. The memory savings might be significant when Minetest is using LuaJIT without GC64 enabled.

In the documentation, `on_generated` callbacks are encouraged to `get_data` into a file-scoped buffer. Sometimes multiple callbacks are registered by multiple mods (e.g. `islands` and `cloudlands`,) and they use separate buffers. They could use the same buffer to get the same results while using much less memory.

That is what this PR allows. It adds a function `minetest.get_common_buffer()`. This function always returns the same buffer for a given value of the optional parameter `index` (default value 1.) Buffers are just plain tables that can be used as arguments to functions like `VoxelManip:get_data()`. The `index` parameter allows an `on_generated` callback to use multiple distinct buffers at once, e.g. for content IDs and param2 values.

To make use of this change in a backwards-compatible way, a mapgen mod could just change this:

```lua
local data_buf = {}
local param2_buf = {}
```

Into this:

```lua
local data_buf = minetest.get_common_buffer and minetest.get_common_buffer(1) or {}
local param2_buf = minetest.get_common_buffer and minetest.get_common_buffer(2) or {}
```

This change would have approximately zero performance penalties and potentially some performance gains. I haven't run a benchmark, but generally, having fewer gigantic buffers is better.

The common buffers would also be available to other VoxelManip users. Where before using a file-scoped buffer was an extra cost in terms of memory, now all these users would have access to a pre-allocated buffer for no additional cost.

That said, if you don't merge this PR, the game will still work fine. Again, this PR isn't very important.

## To do

This PR is ready for review. (I'm not sure of some of the specifics of the changes, such as where the new Lua code should go.)

## How to test

I added some basic tests into the directory `builtin/common/tests`. What follows is an in-game testing procedure.

Install the mods `islands` and `cloudlands`.

Create a world with these mods and see some of the generated terrain.

Now in `islands/init.lua`, change this line:

```lua
local data = {}
```

To this:

```lua
local data = minetest.get_common_buffer()
```

And in `cloudlands/cloudlands.lua`, change this line:

```lua
local data          = {} -- reuse the massive VoxelManip memory buffers instead of creating on every on_generate()
```

To this:

```lua
local data = minetest.get_common_buffer()
```

Now delete the world's `map.sqlite`.

Re-enter the world and make sure the terrain still looks right.