### PR TITLE
Fix movement in random_input mode

### DIFF
--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -138,11 +138,8 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 #endif
 
 	} else if (event.EventType == irr::EET_JOYSTICK_INPUT_EVENT) {
-		/* TODO add a check like:
-		if (event.JoystickEvent != joystick_we_listen_for)
-			return false;
-		*/
-		return joystick->handleEvent(event.JoystickEvent);
+		// joystick may be nullptr if game is launched with '--random-input' parameter
+		return joystick && joystick->handleEvent(event.JoystickEvent);
 	} else if (event.EventType == irr::EET_MOUSE_INPUT_EVENT) {
 		// Handle mouse events
 		KeyPress key;

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -240,4 +240,39 @@ void RandomInputHandler::step(float dtime)
 		}
 	}
 	mousepos += mousespeed;
+	static bool useJoystick = false;
+	{
+		static float counterUseJoystick = 0;
+		counterUseJoystick -= dtime;
+		if (counterUseJoystick < 0.0) {
+			counterUseJoystick = 5.0; // switch between joystick and keyboard direction input
+			useJoystick = !useJoystick;
+		}
+	}
+	if (useJoystick) {
+		static float counterMovement = 0;
+		counterMovement -= dtime;
+		if (counterMovement < 0.0) {
+			counterMovement = 0.1 * Rand(1, 40);
+			movementSpeed = Rand(0,100)*0.01;
+			movementDirection = Rand(-100, 100)*0.01 * M_PI;
+		}
+	} else {
+		bool f = keydown[keycache.key[KeyType::FORWARD]],
+			l = keydown[keycache.key[KeyType::LEFT]];
+		if (f || l) {
+			movementSpeed = 1.0f;
+			if (f && !l)
+				movementDirection = 0.0;
+			else if (!f && l)
+				movementDirection = -M_PI_2;
+			else if (f && l)
+				movementDirection = -M_PI_4;
+			else
+				movementDirection = 0.0;
+		} else {
+			movementSpeed = 0.0;
+			movementDirection = 0.0;
+		}
+	}
 }

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -393,8 +393,8 @@ public:
 	virtual bool wasKeyPressed(GameKeyType k) { return false; }
 	virtual bool wasKeyReleased(GameKeyType k) { return false; }
 	virtual bool cancelPressed() { return false; }
-	virtual float getMovementSpeed() {return 0.0f;}
-	virtual float getMovementDirection() {return 0.0f;}
+	virtual float getMovementSpeed() { return movementSpeed; }
+	virtual float getMovementDirection() { return movementDirection; }
 	virtual v2s32 getMousePos() { return mousepos; }
 	virtual void setMousePos(s32 x, s32 y) { mousepos = v2s32(x, y); }
 
@@ -408,4 +408,6 @@ private:
 	KeyList keydown;
 	v2s32 mousepos;
 	v2s32 mousespeed;
+	float movementSpeed;
+	float movementDirection;
 };


### PR DESCRIPTION
When the game is started with `--random-input` flag, then instead of
using `RealInputHandler` a `RandomInputHandler` is created.

The `RealInputHandler` sets the `joystick` member variable of
`MyEventReceiver` in the constructor. The random one does not.

Handle this possibility in `MyEventReceiver`.

Fixes: https://github.com/minetest/minetest/issues/11591

## How to test

- plug in joystick (xbox 360 controller in my case)
- start `minetest --random-input`
- don't get segfault

