### PR TITLE
Add missing zstd-libs to final Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build docker image
         run: |
-          docker build .
+          docker build . -t minetest:latest
+          docker run --rm minetest:latest /usr/local/bin/minetestserver --version
 
   win32:
     name: "MinGW cross-compiler (32-bit)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir build && \
 ARG DOCKER_IMAGE=alpine:3.14
 FROM $DOCKER_IMAGE AS runtime
 
-RUN apk add --no-cache sqlite-libs curl gmp libstdc++ libgcc libpq luajit jsoncpp && \
+RUN apk add --no-cache sqlite-libs curl gmp libstdc++ libgcc libpq luajit jsoncpp zstd-libs && \
 	adduser -D minetest --uid 30000 -h /var/lib/minetest && \
 	chown -R minetest:minetest /var/lib/minetest
 


### PR DESCRIPTION
The generated docker image does not currently work because of a missing `zstd` dependency in the final layer.
It fails since #10788 

Error message:
```
Error loading shared library libzstd.so.1: No such file or directory (needed by /usr/local/bin/minetestserver)
Error relocating /usr/local/bin/minetestserver: ZSTD_initCStream: symbol not found
Error relocating /usr/local/bin/minetestserver: ZSTD_compressStream: symbol not found
Error relocating /usr/local/bin/minetestserver: ZSTD_freeCStream: symbol not found
Error relocating /usr/local/bin/minetestserver: ZSTD_createDStream: symbol not found
Error relocating /usr/local/bin/minetestserver: ZSTD_decompressStream: symbol not found
Error relocating /usr/local/bin/minetestserver: ZSTD_initDStream: symbol not found
Error relocating /usr/local/bin/minetestserver: ZSTD_createCStream: symbol not found
Error relocating /usr/local/bin/minetestserver: ZSTD_isError: symbol not found
Error relocating /usr/local/bin/minetestserver: ZSTD_freeDStream: symbol not found
Error relocating /usr/local/bin/minetestserver: ZSTD_getErrorName: symbol not found
Error relocating /usr/local/bin/minetestserver: ZSTD_endStream: symbol not found
```

This PR adds:
* the `zstd-libs` to the final layer
* the `minetestserver --version` command after the docker build to verify it

## How to test

```bash
docker build . -t minetest
docker run --rm -it minetest
```

The usual minetest banner should pop up afterwards