### PR TITLE
Send to clients node metadata that changed to become empty

### DIFF
--- a/src/nodemetadata.cpp
+++ b/src/nodemetadata.cpp
@@ -113,13 +113,13 @@ int NodeMetadata::countNonPrivate() const
 */
 
 void NodeMetadataList::serialize(std::ostream &os, u8 blockver, bool disk,
-	bool absolute_pos) const
+	bool absolute_pos, bool include_empty) const
 {
 	/*
 		Version 0 is a placeholder for "nothing to see here; go away."
 	*/
 
-	u16 count = countNonEmpty();
+	u16 count = include_empty ? m_data.size() : countNonEmpty();
 	if (count == 0) {
 		writeU8(os, 0); // version
 		return;
@@ -134,7 +134,7 @@ void NodeMetadataList::serialize(std::ostream &os, u8 blockver, bool disk,
 			i != m_data.end(); ++i) {
 		v3s16 p = i->first;
 		NodeMetadata *data = i->second;
-		if (data->empty())
+		if (!include_empty && data->empty())
 			continue;
 
 		if (absolute_pos) {

--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -82,7 +82,7 @@ public:
 	~NodeMetadataList();
 
 	void serialize(std::ostream &os, u8 blockver, bool disk = true,
-		bool absolute_pos = false) const;
+		bool absolute_pos = false, bool include_empty = false) const;
 	void deSerialize(std::istream &is, IItemDefManager *item_def_mgr,
 		bool absolute_pos = false);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2309,7 +2309,7 @@ void Server::sendMetadataChanged(const std::list<v3s16> &meta_updates, float far
 
 		// Send the meta changes
 		std::ostringstream os(std::ios::binary);
-		meta_updates_list.serialize(os, client->client->serialization_version, false, true, true);
+		meta_updates_list.serialize(os, client->serialization_version, false, true, true);
 		std::ostringstream oss(std::ios::binary);
 		compressZlib(os.str(), oss);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2309,7 +2309,7 @@ void Server::sendMetadataChanged(const std::list<v3s16> &meta_updates, float far
 
 		// Send the meta changes
 		std::ostringstream os(std::ios::binary);
-		meta_updates_list.serialize(os, client->net_proto_version, false, true);
+		meta_updates_list.serialize(os, client->net_proto_version, false, true, true);
 		std::ostringstream oss(std::ios::binary);
 		compressZlib(os.str(), oss);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2309,7 +2309,7 @@ void Server::sendMetadataChanged(const std::list<v3s16> &meta_updates, float far
 
 		// Send the meta changes
 		std::ostringstream os(std::ios::binary);
-		meta_updates_list.serialize(os, client->net_proto_version, false, true, true);
+		meta_updates_list.serialize(os, client->client->serialization_version, false, true, true);
 		std::ostringstream oss(std::ios::binary);
 		compressZlib(os.str(), oss);
 


### PR DESCRIPTION
This is a bug fix. Without this patch, clients are not sent all node metadata changes. When some node metadata changes on the server, it might become empty. This changed metadata must be sent to the clients, but this is not done in the current state of things. With this patch, `NodeMetadataList::serialize` is given a new parameter to switch on the inclusion of empty metadata. This new option is only used when serializing metadata change lists to send to clients. No changes to the client code are needed.

## To do

This PR is Ready for Review.

## How to test

Create a world with the `devtest` game. Use the Node Meta Editor on a ground node (or any node with no metadata.) Give this node some infotext. Make sure you can see the infotext when pointing at the node. Now use the editor to remove the infotext. Make sure you no longer see any infotext when pointing at the node.

Without this patch, you would still be able to see the infotext after removing it. The infotext would persist on the client until the client was sent the mapblock again, e.g. when it disconnected and reconnected.
