### PR TITLE
Print stacktrace on segfault

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,6 +126,8 @@ int main(int argc, char *argv[])
 	g_logger.registerThread("Main");
 	g_logger.addOutputMaxLevel(&stderr_output, LL_ACTION);
 
+	porting::install_crash_handler();
+
 	Settings cmd_args;
 	bool cmd_args_ok = get_cmdline_opts(argc, argv, &cmd_args);
 	if (!cmd_args_ok

--- a/src/porting.h
+++ b/src/porting.h
@@ -352,6 +352,8 @@ bool open_url(const std::string &url);
  */
 bool open_directory(const std::string &path);
 
+void install_crash_handler();
+
 } // namespace porting
 
 #ifdef __ANDROID__


### PR DESCRIPTION
- Goal of the PR
To "catch" game crashes.
Sometimes, even the stable version crashes, but since core dump is not always enabled, no trace of segfault remains after termination. This patch makes the stack traces print before the OS terminates the program.
- How does the PR work?
At the beginning of the program, it registers a segfault signal handler, which runs in case of a segfault, before the program termination.

## To do
Works only in gnu/Linux environment, since it uses `backtrace_symbols` which is only in Glibc.
I separated the sighandler installation and stack trace print by platforms, so on other platforms, this needs to be implemented too.

## How to test
There's no obvious way to test, it points to catch "random" crashes.