### PR TITLE
Shave off buffer copies in networking code

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -971,14 +971,14 @@ void UDPPeer::PutReliableSendCommand(ConnectionCommand &c,
 				<<" processing reliable command for peer id: " << c.peer_id
 				<<" data size: " << c.data.getSize() << std::endl);
 		if (!processReliableSendCommand(c,max_packet_size)) {
-			chan.queued_commands.push_back(c);
+			chan.queued_commands.emplace_back(c);
 		}
 	}
 	else {
 		LOG(dout_con<<m_connection->getDesc()
 				<<" Queueing reliable command for peer id: " << c.peer_id
 				<<" data size: " << c.data.getSize() <<std::endl);
-		chan.queued_commands.push_back(c);
+		chan.queued_commands.emplace_back(c);
 		if (chan.queued_commands.size() >= chan.getWindowSize() / 2) {
 			LOG(derr_con << m_connection->getDesc()
 					<< "Possible packet stall to peer id: " << c.peer_id

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -282,7 +282,7 @@ void ReliablePacketBuffer::insert(const BufferedPacket &p, u16 next_expected)
 	// If list is empty, just add it
 	if (m_list.empty())
 	{
-		m_list.emplace_back(p);
+		m_list.push_back(p);
 		m_oldest_non_answered_ack = seqnum;
 		// Done.
 		return;
@@ -336,9 +336,9 @@ void ReliablePacketBuffer::insert(const BufferedPacket &p, u16 next_expected)
 	}
 	/* insert or push back */
 	else if (i != m_list.end()) {
-		m_list.emplace(i, p);
+		m_list.insert(i, p);
 	} else {
-		m_list.emplace_back(p);
+		m_list.push_back(p);
 	}
 
 	/* update last packet number */
@@ -361,7 +361,7 @@ std::list<BufferedPacket> ReliablePacketBuffer::getTimedOuts(float timeout,
 	std::list<BufferedPacket> timed_outs;
 	for (BufferedPacket &bufferedPacket : m_list) {
 		if (bufferedPacket.time >= timeout) {
-			timed_outs.emplace_back(bufferedPacket);
+			timed_outs.push_back(bufferedPacket);
 
 			//this packet will be sent right afterwards reset timeout here
 			bufferedPacket.time = 0.0f;
@@ -971,14 +971,14 @@ void UDPPeer::PutReliableSendCommand(ConnectionCommand &c,
 				<<" processing reliable command for peer id: " << c.peer_id
 				<<" data size: " << c.data.getSize() << std::endl);
 		if (!processReliableSendCommand(c,max_packet_size)) {
-			chan.queued_commands.emplace_back(c);
+			chan.queued_commands.push_back(c);
 		}
 	}
 	else {
 		LOG(dout_con<<m_connection->getDesc()
 				<<" Queueing reliable command for peer id: " << c.peer_id
 				<<" data size: " << c.data.getSize() <<std::endl);
-		chan.queued_commands.emplace_back(c);
+		chan.queued_commands.push_back(c);
 		if (chan.queued_commands.size() >= chan.getWindowSize() / 2) {
 			LOG(derr_con << m_connection->getDesc()
 					<< "Possible packet stall to peer id: " << c.peer_id
@@ -1038,7 +1038,7 @@ bool UDPPeer::processReliableSendCommand(
 				m_connection->GetProtocolID(), m_connection->GetPeerID(),
 				c.channelnum);
 
-		toadd.emplace(std::move(p));
+		toadd.push(std::move(p));
 	}
 
 	if (have_sequence_number) {
@@ -1051,7 +1051,7 @@ bool UDPPeer::processReliableSendCommand(
 //					<< " channel: " << (c.channelnum&0xFF)
 //					<< " seqnum: " << readU16(&p.data[BASE_HEADER_SIZE+1])
 //					<< std::endl)
-			chan.queued_reliables.emplace(std::move(p));
+			chan.queued_reliables.push(std::move(p));
 			pcount++;
 		}
 		sanity_check(chan.queued_reliables.size() < 0xFFFF);
@@ -1205,7 +1205,7 @@ void Connection::putEvent(const ConnectionEvent &e)
 void Connection::putEvent(ConnectionEvent &&e)
 {
 	assert(e.type != CONNEVENT_NONE); // Pre-condition
-	m_event_queue.emplace_back(std::move(e));
+	m_event_queue.push_back(std::move(e));
 }
 
 void Connection::TriggerSend()
@@ -1304,7 +1304,7 @@ void Connection::putCommand(const ConnectionCommand &c)
 void Connection::putCommand(ConnectionCommand &&c)
 {
 	if (!m_shutting_down) {
-		m_command_queue.emplace_back(std::move(c));
+		m_command_queue.push_back(std::move(c));
 		m_sendThread->Trigger();
 	}
 }

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -354,14 +354,14 @@ void ReliablePacketBuffer::incrementTimeouts(float dtime)
 	}
 }
 
-std::list<BufferedPacket> ReliablePacketBuffer::getTimedOuts(float timeout,
-													unsigned int max_packets)
+std::vector<std::reference_wrapper<BufferedPacket>>
+	ReliablePacketBuffer::getTimedOuts(float timeout, u32 max_packets)
 {
 	MutexAutoLock listlock(m_list_mutex);
-	std::list<BufferedPacket> timed_outs;
+	std::vector<std::reference_wrapper<BufferedPacket>> timed_outs;
 	for (BufferedPacket &bufferedPacket : m_list) {
 		if (bufferedPacket.time >= timeout) {
-			timed_outs.push_back(bufferedPacket);
+			timed_outs.push_back(std::ref(bufferedPacket));
 
 			//this packet will be sent right afterwards reset timeout here
 			bufferedPacket.time = 0.0f;

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -242,7 +242,7 @@ public:
 
 	BufferedPacket popFirst();
 	BufferedPacket popSeqnum(u16 seqnum);
-	void insert(BufferedPacket &p, u16 next_expected);
+	void insert(const BufferedPacket &p, u16 next_expected);
 
 	void incrementTimeouts(float dtime);
 	std::list<BufferedPacket> getTimedOuts(float timeout,
@@ -250,12 +250,12 @@ public:
 
 	void print();
 	bool empty();
-	RPBSearchResult notFound();
 	u32 size();
 
 
 private:
 	RPBSearchResult findPacket(u16 seqnum); // does not perform locking
+	inline RPBSearchResult notFound() { return m_list.end(); }
 
 	std::list<BufferedPacket> m_list;
 

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -29,7 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h"
 #include "networkprotocol.h"
 #include <iostream>
-#include <fstream>
+#include <functional>
 #include <vector>
 #include <map>
 
@@ -245,8 +245,8 @@ public:
 	void insert(const BufferedPacket &p, u16 next_expected);
 
 	void incrementTimeouts(float dtime);
-	std::list<BufferedPacket> getTimedOuts(float timeout,
-			unsigned int max_packets);
+	std::vector<std::reference_wrapper<BufferedPacket>>
+		getTimedOuts(float timeout, u32 max_packets);
 
 	void print();
 	bool empty();

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -751,7 +751,7 @@ public:
 
 	/* Interface */
 	ConnectionEvent waitEvent(u32 timeout_ms);
-	// Warning: creates an uncecessary copy, prefer putCommand(T&&) if possible
+	// Warning: creates an unnecessary copy, prefer putCommand(T&&) if possible
 	void putCommand(const ConnectionCommand &c);
 	void putCommand(ConnectionCommand &&c);
 
@@ -797,7 +797,7 @@ protected:
 
 	bool Receive(NetworkPacket *pkt, u32 timeout);
 
-	// Warning: creates an uncecessary copy, prefer putEvent(T&&) if possible
+	// Warning: creates an unnecessary copy, prefer putEvent(T&&) if possible
 	void putEvent(const ConnectionEvent &e);
 	void putEvent(ConnectionEvent &&e);
 

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_bloated.h"
+#include "irrlichttypes.h"
 #include "peerhandler.h"
 #include "socket.h"
 #include "constants.h"
@@ -29,7 +29,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h"
 #include "networkprotocol.h"
 #include <iostream>
-#include <functional>
 #include <vector>
 #include <map>
 
@@ -245,8 +244,7 @@ public:
 	void insert(const BufferedPacket &p, u16 next_expected);
 
 	void incrementTimeouts(float dtime);
-	std::vector<std::reference_wrapper<BufferedPacket>>
-		getTimedOuts(float timeout, u32 max_packets);
+	std::list<BufferedPacket> getTimedOuts(float timeout, u32 max_packets);
 
 	void print();
 	bool empty();

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -375,7 +375,7 @@ bool ConnectionSendThread::rawSendAsPacket(session_t peer_id, u8 channelnum,
 			<< " INFO: queueing reliable packet for peer_id: " << peer_id
 			<< " channel: " << (u32)channelnum
 			<< " seqnum: " << seqnum << std::endl);
-		channel->queued_reliables.push(p);
+		channel->queued_reliables.emplace(std::move(p));
 		return false;
 	}
 
@@ -717,13 +717,15 @@ void ConnectionSendThread::sendPackets(float dtime)
 					channel.outgoing_reliables_sent.size()
 					< channel.getWindowSize() &&
 					peer->m_increment_packets_remaining > 0) {
-				BufferedPacket p = channel.queued_reliables.front();
+				BufferedPacket p = std::move(channel.queued_reliables.front());
 				channel.queued_reliables.pop();
+
 				LOG(dout_con << m_connection->getDesc()
 					<< " INFO: sending a queued reliable packet "
 					<< " channel: " << i
 					<< ", seqnum: " << readU16(&p.data[BASE_HEADER_SIZE + 1])
 					<< std::endl);
+
 				sendAsPacketReliable(p, &channel);
 				peer->m_increment_packets_remaining--;
 			}

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -375,7 +375,7 @@ bool ConnectionSendThread::rawSendAsPacket(session_t peer_id, u8 channelnum,
 			<< " INFO: queueing reliable packet for peer_id: " << peer_id
 			<< " channel: " << (u32)channelnum
 			<< " seqnum: " << seqnum << std::endl);
-		channel->queued_reliables.emplace(std::move(p));
+		channel->queued_reliables.push(std::move(p));
 		return false;
 	}
 

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -174,6 +174,11 @@ void ConnectionSendThread::runTimeouts(float dtime)
 	std::vector<session_t> timeouted_peers;
 	std::vector<session_t> peerIds = m_connection->getPeerIDs();
 
+	const u32 numpeers = m_connection->m_peers.size();
+
+	if (numpeers == 0)
+		return;
+
 	for (session_t &peerId : peerIds) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerId);
 
@@ -209,7 +214,6 @@ void ConnectionSendThread::runTimeouts(float dtime)
 		float resend_timeout = udpPeer->getResendTimeout();
 		bool retry_count_exceeded = false;
 		for (Channel &channel : udpPeer->channels) {
-			std::list<BufferedPacket> timed_outs;
 
 			// Remove timed out incomplete unreliable split packets
 			channel.incoming_splits.removeUnreliableTimedOuts(dtime, m_timeout);
@@ -217,13 +221,8 @@ void ConnectionSendThread::runTimeouts(float dtime)
 			// Increment reliable packet times
 			channel.outgoing_reliables_sent.incrementTimeouts(dtime);
 
-			unsigned int numpeers = m_connection->m_peers.size();
-
-			if (numpeers == 0)
-				return;
-
 			// Re-send timed out outgoing reliables
-			timed_outs = channel.outgoing_reliables_sent.getTimedOuts(resend_timeout,
+			auto timed_outs = channel.outgoing_reliables_sent.getTimedOuts(resend_timeout,
 				(m_max_data_packets_per_iteration / numpeers));
 
 			channel.UpdatePacketLossCounter(timed_outs.size());
@@ -231,16 +230,16 @@ void ConnectionSendThread::runTimeouts(float dtime)
 
 			m_iteration_packets_avaialble -= timed_outs.size();
 
-			for (std::list<BufferedPacket>::iterator k = timed_outs.begin();
-				k != timed_outs.end(); ++k) {
-				session_t peer_id = readPeerId(*(k->data));
-				u8 channelnum = readChannel(*(k->data));
-				u16 seqnum = readU16(&(k->data[BASE_HEADER_SIZE + 1]));
+			for (auto it : timed_outs) {
+				BufferedPacket &k = it.get();
+				session_t peer_id = readPeerId(*k.data);
+				u8 channelnum = readChannel(*k.data);
+				u16 seqnum = readU16(&(k.data[BASE_HEADER_SIZE + 1]));
 
-				channel.UpdateBytesLost(k->data.getSize());
-				k->resend_count++;
+				channel.UpdateBytesLost(k.data.getSize());
+				k.resend_count++;
 
-				if (k->resend_count > MAX_RELIABLE_RETRY) {
+				if (k.resend_count > MAX_RELIABLE_RETRY) {
 					retry_count_exceeded = true;
 					timeouted_peers.push_back(peer->id);
 					/* no need to check additional packets if a single one did timeout*/
@@ -249,14 +248,14 @@ void ConnectionSendThread::runTimeouts(float dtime)
 
 				LOG(derr_con << m_connection->getDesc()
 					<< "RE-SENDING timed-out RELIABLE to "
-					<< k->address.serializeString()
+					<< k.address.serializeString()
 					<< "(t/o=" << resend_timeout << "): "
 					<< "from_peer_id=" << peer_id
 					<< ", channel=" << ((int) channelnum & 0xff)
 					<< ", seqnum=" << seqnum
 					<< std::endl);
 
-				rawSend(*k);
+				rawSend(k);
 
 				// do not handle rtt here as we can't decide if this packet was
 				// lost or really takes more time to transmit

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -230,14 +230,12 @@ void ConnectionSendThread::runTimeouts(float dtime)
 
 			m_iteration_packets_avaialble -= timed_outs.size();
 
-			for (auto it : timed_outs) {
-				BufferedPacket &k = it.get();
+			for (const auto &k : timed_outs) {
 				session_t peer_id = readPeerId(*k.data);
 				u8 channelnum = readChannel(*k.data);
 				u16 seqnum = readU16(&(k.data[BASE_HEADER_SIZE + 1]));
 
 				channel.UpdateBytesLost(k.data.getSize());
-				k.resend_count++;
 
 				if (k.resend_count > MAX_RELIABLE_RETRY) {
 					retry_count_exceeded = true;

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -911,7 +911,7 @@ void ConnectionReceiveThread::receive(SharedBuffer<u8> &packetdata,
 					if (data_left) {
 						ConnectionEvent e;
 						e.dataReceived(peer_id, resultdata);
-						m_connection->putEvent(e);
+						m_connection->putEvent(std::move(e));
 					}
 				}
 				catch (ProcessedSilentlyException &e) {
@@ -1022,7 +1022,7 @@ void ConnectionReceiveThread::receive(SharedBuffer<u8> &packetdata,
 
 			ConnectionEvent e;
 			e.dataReceived(peer_id, resultdata);
-			m_connection->putEvent(e);
+			m_connection->putEvent(std::move(e));
 		}
 		catch (ProcessedSilentlyException &e) {
 		}

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -549,14 +549,11 @@ NetworkPacket& NetworkPacket::operator<<(video::SColor src)
 	return *this;
 }
 
-SharedBuffer<u8> NetworkPacket::oldForgePacket()
+Buffer<u8> NetworkPacket::oldForgePacket()
 {
-	SharedBuffer<u8> sb(m_datasize + 2);
+	Buffer<u8> sb(m_datasize + 2);
 	writeU16(&sb[0], m_command);
+	memcpy(&sb[2], m_data.data(), m_datasize);
 
-	u8* datas = getU8Ptr(0);
-
-	if (datas != NULL)
-		memcpy(&sb[2], datas, m_datasize);
 	return sb;
 }

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -115,7 +115,8 @@ public:
 	NetworkPacket &operator<<(video::SColor src);
 
 	// Temp, we remove SharedBuffer when migration finished
-	SharedBuffer<u8> oldForgePacket();
+	// ^ this comment has been here for 4 years
+	Buffer<u8> oldForgePacket();
 
 private:
 	void checkReadOffset(u32 from_offset, u32 field_size);

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -88,7 +88,7 @@ void TestConnection::testNetworkPacketSerialize()
 	};
 
 	if (sizeof(wchar_t) == 2)
-		warningstream << __func__ << " may fail on this platform." << std::endl;
+		warningstream << __FUNCTION__ << " may fail on this platform." << std::endl;
 
 	{
 		NetworkPacket pkt(123, 0);
@@ -96,7 +96,7 @@ void TestConnection::testNetworkPacketSerialize()
 		// serializing wide strings should do surrogate encoding, we test that here
 		pkt << std::wstring(L"\U00020b9a");
 
-		SharedBuffer<u8> buf = pkt.oldForgePacket();
+		auto buf = pkt.oldForgePacket();
 		UASSERTEQ(int, buf.getSize(), sizeof(expected));
 		UASSERT(!memcmp(expected, &buf[0], buf.getSize()));
 	}
@@ -280,7 +280,7 @@ void TestConnection::testConnectSendReceive()
 		NetworkPacket pkt;
 		pkt.putRawPacket((u8*) "Hello World !", 14, 0);
 
-		SharedBuffer<u8> sentdata = pkt.oldForgePacket();
+		auto sentdata = pkt.oldForgePacket();
 
 		infostream<<"** running client.Send()"<<std::endl;
 		client.Send(PEER_ID_SERVER, 0, &pkt, true);
@@ -295,7 +295,7 @@ void TestConnection::testConnectSendReceive()
 				<< ", data=" << (const char*)pkt.getU8Ptr(0)
 				<< std::endl;
 
-		SharedBuffer<u8> recvdata = pkt.oldForgePacket();
+		auto recvdata = pkt.oldForgePacket();
 
 		UASSERT(memcmp(*sentdata, *recvdata, recvdata.getSize()) == 0);
 	}
@@ -324,13 +324,13 @@ void TestConnection::testConnectSendReceive()
 			infostream << "...";
 		infostream << std::endl;
 
-		SharedBuffer<u8> sentdata = pkt.oldForgePacket();
+		auto sentdata = pkt.oldForgePacket();
 
 		server.Send(peer_id_client, 0, &pkt, true);
 
 		//sleep_ms(3000);
 
-		SharedBuffer<u8> recvdata;
+		Buffer<u8> recvdata;
 		infostream << "** running client.Receive()" << std::endl;
 		session_t peer_id = 132;
 		u16 size = 0;

--- a/src/util/container.h
+++ b/src/util/container.h
@@ -140,6 +140,13 @@ public:
 		m_signal.post();
 	}
 
+	void emplace_back(T &&t)
+	{
+		MutexAutoLock lock(m_mutex);
+		m_queue.emplace_back(std::move(t));
+		m_signal.post();
+	}
+
 	/* this version of pop_front returns a empty element of T on timeout.
 	* Make sure default constructor of T creates a recognizable "empty" element
 	*/

--- a/src/util/container.h
+++ b/src/util/container.h
@@ -140,10 +140,10 @@ public:
 		m_signal.post();
 	}
 
-	void emplace_back(T &&t)
+	void push_back(T &&t)
 	{
 		MutexAutoLock lock(m_mutex);
-		m_queue.emplace_back(std::move(t));
+		m_queue.push_back(std::move(t));
 		m_signal.post();
 	}
 

--- a/src/util/pointer.h
+++ b/src/util/pointer.h
@@ -51,6 +51,19 @@ public:
 		else
 			data = NULL;
 	}
+	Buffer(Buffer &&buffer)
+	{
+		m_size = buffer.m_size;
+		if(m_size != 0)
+		{
+			data = buffer.data;
+			buffer.data = nullptr;
+			buffer.m_size = 0;
+		}
+		else
+			data = nullptr;
+	}
+	// Copies whole buffer
 	Buffer(const T *t, unsigned int size)
 	{
 		m_size = size;
@@ -62,10 +75,12 @@ public:
 		else
 			data = NULL;
 	}
+
 	~Buffer()
 	{
 		drop();
 	}
+
 	Buffer& operator=(const Buffer &buffer)
 	{
 		if(this == &buffer)
@@ -81,6 +96,23 @@ public:
 			data = NULL;
 		return *this;
 	}
+	Buffer& operator=(Buffer &&buffer)
+	{
+		if(this == &buffer)
+			return *this;
+		drop();
+		m_size = buffer.m_size;
+		if(m_size != 0)
+		{
+			data = buffer.data;
+			buffer.data = nullptr;
+			buffer.m_size = 0;
+		}
+		else
+			data = nullptr;
+		return *this;
+	}
+
 	T & operator[](unsigned int i) const
 	{
 		return data[i];
@@ -89,10 +121,12 @@ public:
 	{
 		return data;
 	}
+
 	unsigned int getSize() const
 	{
 		return m_size;
 	}
+
 private:
 	void drop()
 	{


### PR DESCRIPTION
There's still lots (though less critical) left but those require bigger changes to fix.

Apart from performance this might also help with the "timed out reliables issue in SP" issue because less time is spent doing unnecessary work while locks are held.

## To do

This PR is Ready for Review.

## How to test

(especially for the first commit)
apply this diff:
```diff
diff --git a/src/network/connection.cpp b/src/network/connection.cpp
index 648452e3e..c9ca044a9 100644
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1205,7 +1205,9 @@ void Connection::putEvent(const ConnectionEvent &e)
 void Connection::putEvent(ConnectionEvent &&e)
 {
 	assert(e.type != CONNEVENT_NONE); // Pre-condition
+	printf("%d emplacing event\n", gettid());
 	m_event_queue.push_back(std::move(e));
+	printf("%d --\n", gettid());
 }
 
 void Connection::TriggerSend()
@@ -1304,7 +1306,9 @@ void Connection::putCommand(const ConnectionCommand &c)
 void Connection::putCommand(ConnectionCommand &&c)
 {
 	if (!m_shutting_down) {
+		printf("%d emplacing command\n", gettid());
 		m_command_queue.push_back(std::move(c));
+		printf("%d --\n", gettid());
 		m_sendThread->Trigger();
 	}
 }
@@ -1355,7 +1359,9 @@ bool Connection::Receive(NetworkPacket *pkt, u32 timeout)
 		This is not considered to be a problem (is it?)
 	*/
 	for(;;) {
+		printf("%d waiting event\n", gettid());
 		ConnectionEvent e = waitEvent(timeout);
+		printf("%d -- %s\n", gettid(), e.type == CONNEVENT_DATA_RECEIVED ? "had data!" : "");
 		if (e.type != CONNEVENT_NONE)
 			LOG(dout_con << getDesc() << ": Receive: got event: "
 					<< e.describe() << std::endl);
diff --git a/src/util/pointer.h b/src/util/pointer.h
index 7fc5de551..5498b308c 100644
--- a/src/util/pointer.h
+++ b/src/util/pointer.h
@@ -47,6 +47,7 @@ class Buffer
 		{
 			data = new T[buffer.m_size];
 			memcpy(data, buffer.data, buffer.m_size);
+			printf("%d Buffer<T> copy-constructed\n", gettid());
 		}
 		else
 			data = NULL;
@@ -59,6 +60,7 @@ class Buffer
 			data = buffer.data;
 			buffer.data = nullptr;
 			buffer.m_size = 0;
+			printf("%d Buffer<T> move-constructed\n", gettid());
 		}
 		else
 			data = nullptr;
@@ -91,6 +93,7 @@ class Buffer
 		{
 			data = new T[buffer.m_size];
 			memcpy(data, buffer.data, buffer.m_size);
+			printf("%d Buffer<T> copied\n", gettid());
 		}
 		else
 			data = NULL;
@@ -107,6 +110,7 @@ class Buffer
 			data = buffer.data;
 			buffer.data = nullptr;
 			buffer.m_size = 0;
+			printf("%d Buffer<T> moved\n", gettid());
 		}
 		else
 			data = nullptr;
```

You will see when buffers are copied and on which threads, note that only lines with matching numbers are logically ordered together.
In combination with the other printfs you can use this to verify that emplacing events/commands or waiting for an event does *not* copy:
<pre>
241432 waiting event
241432 Buffer&lt;T> move-constructed
241432 Buffer&lt;T> move-constructed
241432 -- had data!
[...]
241432 emplacing command
241432 Buffer&lt;T> move-constructed
241432 --
[...]
241446 emplacing event
241446 Buffer&lt;T> move-constructed
241446 --
</pre>