### PR TITLE
Add an API function for synchronously activating areas

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5266,6 +5266,12 @@ Environment access
     * Load the mapblocks containing the area from `pos1` to `pos2`.
       `pos2` defaults to `pos1` if not specified.
     * This function does not trigger map generation.
+* `minetest.activate_area(pos1, pos2)`
+    * Activate the mapblocks containing the area from `pos1` to `pos2`.
+    * The area will remain active at least until control passes from the Lua
+      code back to the Minetest engine.
+    * Mapblocks are not activated if they do not exist or are already active.
+    * This function does not trigger map generation.
 * `minetest.emerge_area(pos1, pos2, [callback], [param])`
     * Queue all blocks in the area from `pos1` to `pos2`, inclusive, to be
       asynchronously fetched from memory, loaded from disk, or if inexistent,

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1181,7 +1181,6 @@ int ModApiEnvMod::l_raycast(lua_State *L)
 int ModApiEnvMod::l_load_area(lua_State *L)
 {
 	GET_ENV_PTR;
-	MAP_LOCK_REQUIRED;
 
 	Map *map = &(env->getMap());
 	v3s16 bp1 = getNodeBlockPos(check_v3s16(L, 1));
@@ -1205,7 +1204,6 @@ int ModApiEnvMod::l_load_area(lua_State *L)
 int ModApiEnvMod::l_activate_area(lua_State *L)
 {
 	GET_ENV_PTR;
-	MAP_LOCK_REQUIRED;
 
 	Map &map = env->getMap();
 	v3s16 bpmin = getNodeBlockPos(check_v3s16(L, 1));

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -149,6 +149,9 @@ private:
 	// load_area(p1)
 	static int l_load_area(lua_State *L);
 
+	// activate_area(p1, p2)
+	static int l_activate_area(lua_State *L);
+
 	// emerge_area(p1, p2)
 	static int l_emerge_area(lua_State *L);
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - The goal is to add a way to synchronously check for objects in any area, mostly. The function could probably be used more generally as well.
- How does the PR work?
  - I wrote some documentation for the function in lua_api.txt.
  - Internally it uses the method `ServerEnvironment::activateBlock`. This is used to activate the area for a short time, during which the API user can check for active objects and stuff.
  - The function does not create blocks that do not already exist. Hopefully this way the function can avoid triggering one-time LBMs before blocks are generated, for the most part.
- Does it resolve any reported issue?
  - Fixes #11599
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
  - I'm a modder, so this could count as taking feedback from a modder.
  - It might also count as an improvement to objects/entities.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  - I mentioned my usecase in the linked issue.
  - It's for the mod [area_containers](https://github.com/TurkeyMcMac/area_containers). I would like to be able to activate an area to detect objects there. The activation has to be synchronous (unlike with `minetest.forceload_block`) because I need to detect the objects immediately before the end of the `can_dig` callback.

## To do

This PR is Ready for Review.

## How to test

1. Load a devtest world with this mod installed: [test_activate_area.tar.gz](https://github.com/minetest/minetest/files/7148399/test_activate_area.tar.gz)
2. Run the command `make_platform (1000,1000,1000)`. This should make a platform at that position and put two objects on it.
3. Now you can run the command `check_platform (1000,1000,1000)`. This should find the two objects. It will tell you whether it had to activate the area to find the objects. If the area was not active before, it was activated using `minetest.activate_area`.
