### PR TITLE
Fix client-side performance of chat UI

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -50,6 +50,8 @@ ChatBuffer::ChatBuffer(u32 scrollback):
 
 void ChatBuffer::addLine(const std::wstring &name, const std::wstring &text)
 {
+	m_lines_changed = true;
+
 	ChatLine line(name, text);
 	m_unformatted.push_back(line);
 
@@ -72,6 +74,7 @@ void ChatBuffer::clear()
 	m_unformatted.clear();
 	m_formatted.clear();
 	m_scroll = 0;
+	m_lines_changed = true;
 }
 
 u32 ChatBuffer::getLineCount() const
@@ -99,14 +102,11 @@ void ChatBuffer::deleteOldest(u32 count)
 	u32 del_unformatted = 0;
 	u32 del_formatted = 0;
 
-	while (count > 0 && del_unformatted < m_unformatted.size())
-	{
+	while (count > 0 && del_unformatted < m_unformatted.size()) {
 		++del_unformatted;
 
 		// keep m_formatted in sync
-		if (del_formatted < m_formatted.size())
-		{
-
+		if (del_formatted < m_formatted.size()) {
 			sanity_check(m_formatted[del_formatted].first);
 			++del_formatted;
 			while (del_formatted < m_formatted.size() &&
@@ -119,6 +119,9 @@ void ChatBuffer::deleteOldest(u32 count)
 
 	m_unformatted.erase(m_unformatted.begin(), m_unformatted.begin() + del_unformatted);
 	m_formatted.erase(m_formatted.begin(), m_formatted.begin() + del_formatted);
+
+	if (del_unformatted > 0)
+		m_lines_changed = true;
 
 	if (at_bottom)
 		m_scroll = getBottomScrollPos();

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -50,7 +50,7 @@ ChatBuffer::ChatBuffer(u32 scrollback):
 
 void ChatBuffer::addLine(const std::wstring &name, const std::wstring &text)
 {
-	m_lines_changed = true;
+	m_lines_modified = true;
 
 	ChatLine line(name, text);
 	m_unformatted.push_back(line);
@@ -74,7 +74,7 @@ void ChatBuffer::clear()
 	m_unformatted.clear();
 	m_formatted.clear();
 	m_scroll = 0;
-	m_lines_changed = true;
+	m_lines_modified = true;
 }
 
 u32 ChatBuffer::getLineCount() const
@@ -121,7 +121,7 @@ void ChatBuffer::deleteOldest(u32 count)
 	m_formatted.erase(m_formatted.begin(), m_formatted.begin() + del_formatted);
 
 	if (del_unformatted > 0)
-		m_lines_changed = true;
+		m_lines_modified = true;
 
 	if (at_bottom)
 		m_scroll = getBottomScrollPos();

--- a/src/chat.h
+++ b/src/chat.h
@@ -117,8 +117,8 @@ public:
 	// preceding operations
 	// If they were not changed, getLineCount() and getLine() output the same as
 	// before
-	bool areLinesChanged() const { return m_lines_changed; }
-	void markLinesUnchanged() { m_lines_changed = false; }
+	bool getLinesModified() const { return m_lines_modified; }
+	void resetLinesModified() { m_lines_modified = false; }
 
 	// Format a chat line for the given number of columns.
 	// Appends the formatted lines to the destination array and
@@ -157,7 +157,7 @@ private:
 	// Whether the lines were modified since last markLinesUnchanged()
 	// Is always set to true when m_unformatted is modified, because that's what
 	// determines the output of getLineCount() and getLine()
-	bool m_lines_changed = true;
+	bool m_lines_modified = true;
 };
 
 class ChatPrompt

--- a/src/chat.h
+++ b/src/chat.h
@@ -113,6 +113,13 @@ public:
 	// Scroll to top of buffer (oldest)
 	void scrollTop();
 
+	// Functions for keeping track of whether the lines were modified by any
+	// preceding operations
+	// If they were not changed, getLineCount() and getLine() output the same as
+	// before
+	bool areLinesChanged() { return m_lines_changed; }
+	void markLinesUnchanged() { m_lines_changed = false; }
+
 	// Format a chat line for the given number of columns.
 	// Appends the formatted lines to the destination array and
 	// returns the number of formatted lines.
@@ -146,6 +153,11 @@ private:
 	bool m_cache_clickable_chat_weblinks;
 	// Color of clickable chat weblinks
 	irr::video::SColor m_cache_chat_weblink_color;
+
+	// Whether the lines were modified since last markLinesUnchanged()
+	// Is always set to true when m_unformatted is modified, because that's what
+	// determines the output of getLineCount() and getLine()
+	bool m_lines_changed = true;
 };
 
 class ChatPrompt

--- a/src/chat.h
+++ b/src/chat.h
@@ -117,7 +117,7 @@ public:
 	// preceding operations
 	// If they were not changed, getLineCount() and getLine() output the same as
 	// before
-	bool areLinesChanged() { return m_lines_changed; }
+	bool areLinesChanged() const { return m_lines_changed; }
 	void markLinesUnchanged() { m_lines_changed = false; }
 
 	// Format a chat line for the given number of columns.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2938,8 +2938,14 @@ void Game::updateChat(f32 dtime, const v2u32 &screensize)
 	chat_backend->step(dtime);
 
 	// Display all messages in a static text element
-	m_game_ui->setChatText(chat_backend->getRecentChat(),
-		chat_backend->getRecentBuffer().getLineCount());
+	if (chat_backend->getRecentBuffer().areLinesChanged()) {
+		chat_backend->getRecentBuffer().markLinesUnchanged();
+		m_game_ui->setChatText(chat_backend->getRecentChat(),
+				chat_backend->getRecentBuffer().getLineCount());
+	}
+
+	// Make sure that the size is still correct
+	m_game_ui->updateChatSize();
 }
 
 void Game::updateCamera(u32 busy_time, f32 dtime)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -804,7 +804,7 @@ private:
 		CameraOrientation *cam);
 	void handleClientEvent_CloudParams(ClientEvent *event, CameraOrientation *cam);
 
-	void updateChat(f32 dtime, const v2u32 &screensize);
+	void updateChat(f32 dtime);
 
 	bool nodePlacement(const ItemDefinition &selected_def, const ItemStack &selected_item,
 		const v3s16 &nodepos, const v3s16 &neighbourpos, const PointedThing &pointed,
@@ -2922,7 +2922,7 @@ void Game::processClientEvents(CameraOrientation *cam)
 	}
 }
 
-void Game::updateChat(f32 dtime, const v2u32 &screensize)
+void Game::updateChat(f32 dtime)
 {
 	// Get new messages from error log buffer
 	while (!m_chat_log_buf.empty())
@@ -2938,10 +2938,10 @@ void Game::updateChat(f32 dtime, const v2u32 &screensize)
 	chat_backend->step(dtime);
 
 	// Display all messages in a static text element
-	if (chat_backend->getRecentBuffer().areLinesChanged()) {
-		chat_backend->getRecentBuffer().markLinesUnchanged();
-		m_game_ui->setChatText(chat_backend->getRecentChat(),
-				chat_backend->getRecentBuffer().getLineCount());
+	auto &buf = chat_backend->getRecentBuffer();
+	if (buf.areLinesChanged()) {
+		buf.markLinesUnchanged();
+		m_game_ui->setChatText(chat_backend->getRecentChat(), buf.getLineCount());
 	}
 
 	// Make sure that the size is still correct
@@ -3867,9 +3867,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		Get chat messages from client
 	*/
 
-	v2u32 screensize = driver->getScreenSize();
-
-	updateChat(dtime, screensize);
+	updateChat(dtime);
 
 	/*
 		Inventory
@@ -3963,6 +3961,8 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	/*
 		Profiler graph
 	*/
+	v2u32 screensize = driver->getScreenSize();
+
 	if (m_game_ui->m_flags.show_profiler_graph)
 		graph->draw(10, screensize.Y - 10, driver, g_fontengine->getFont());
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2939,8 +2939,8 @@ void Game::updateChat(f32 dtime)
 
 	// Display all messages in a static text element
 	auto &buf = chat_backend->getRecentBuffer();
-	if (buf.areLinesChanged()) {
-		buf.markLinesUnchanged();
+	if (buf.getLinesModified()) {
+		buf.resetLinesModified();
 		m_game_ui->setChatText(chat_backend->getRecentChat(), buf.getLineCount());
 	}
 

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -227,7 +227,13 @@ void GameUI::showTranslatedStatusText(const char *str)
 
 void GameUI::setChatText(const EnrichedString &chat_text, u32 recent_chat_count)
 {
+	setStaticText(m_guitext_chat, chat_text);
 
+	m_recent_chat_count = recent_chat_count;
+}
+
+void GameUI::updateChatSize()
+{
 	// Update gui element size and position
 	s32 chat_y = 5;
 
@@ -238,21 +244,15 @@ void GameUI::setChatText(const EnrichedString &chat_text, u32 recent_chat_count)
 
 	const v2u32 &window_size = RenderingEngine::getWindowSize();
 
-	core::rect<s32> chat_size(10, chat_y,
-		window_size.X - 20, 0);
+	core::rect<s32> chat_size(10, chat_y, window_size.X - 20, 0);
 	chat_size.LowerRightCorner.Y = std::min((s32)window_size.Y,
-		m_guitext_chat->getTextHeight() + chat_y);
+			m_guitext_chat->getTextHeight() + chat_y);
 
-	if (chat_size != m_cached_chat_size) {
-		m_guitext_chat->setRelativePosition(chat_size);
-		m_cached_chat_size = chat_size;
-	}
-	if (chat_text != m_cached_chat_text) {
-		setStaticText(m_guitext_chat, chat_text);
-		m_cached_chat_text = chat_text;
-	}
+	if (chat_size == m_current_chat_size)
+		return;
+	m_current_chat_size = chat_size;
 
-	m_recent_chat_count = recent_chat_count;
+	m_guitext_chat->setRelativePosition(chat_size);
 }
 
 void GameUI::updateProfiler()

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -243,8 +243,14 @@ void GameUI::setChatText(const EnrichedString &chat_text, u32 recent_chat_count)
 	chat_size.LowerRightCorner.Y = std::min((s32)window_size.Y,
 		m_guitext_chat->getTextHeight() + chat_y);
 
-	m_guitext_chat->setRelativePosition(chat_size);
-	setStaticText(m_guitext_chat, chat_text);
+	if (chat_size != m_cached_chat_size) {
+		m_guitext_chat->setRelativePosition(chat_size);
+		m_cached_chat_size = chat_size;
+	}
+	if (chat_text != m_cached_chat_text) {
+		setStaticText(m_guitext_chat, chat_text);
+		m_cached_chat_text = chat_text;
+	}
 
 	m_recent_chat_count = recent_chat_count;
 }

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -89,6 +89,7 @@ public:
 		return m_flags.show_chat && m_recent_chat_count != 0 && m_profiler_current_page == 0;
 	}
 	void setChatText(const EnrichedString &chat_text, u32 recent_chat_count);
+	void updateChatSize();
 
 	void updateProfiler();
 
@@ -122,9 +123,7 @@ private:
 
 	gui::IGUIStaticText *m_guitext_chat = nullptr; // Chat text
 	u32 m_recent_chat_count = 0;
-	// cached stuff for m_guitext_chat, because updating each frame is too slow
-	EnrichedString m_cached_chat_text{L""};
-	core::rect<s32> m_cached_chat_size{0, 0, 0, 0};
+	core::rect<s32> m_current_chat_size{0, 0, 0, 0};
 
 	gui::IGUIStaticText *m_guitext_profiler = nullptr; // Profiler text
 	u8 m_profiler_current_page = 0;

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -122,6 +122,9 @@ private:
 
 	gui::IGUIStaticText *m_guitext_chat = nullptr; // Chat text
 	u32 m_recent_chat_count = 0;
+	// cached stuff for m_guitext_chat, because updating each frame is too slow
+	EnrichedString m_cached_chat_text{L""};
+	core::rect<s32> m_cached_chat_size{0, 0, 0, 0};
 
 	gui::IGUIStaticText *m_guitext_profiler = nullptr; // Profiler text
 	u8 m_profiler_current_page = 0;


### PR DESCRIPTION
- Goal: Finally fix the really bad chat performance.
- How does the PR work?:
  Don't update the guistatictext every frame.
  The functions for updating the text and updating the size were split (it was both in one function), because the one just uses its parameters and the other just the environment.
  The function to update the text is only called if the text changed.
  The function to update the size checks if the size is actually not the same before resizing.
- (Related: Other PRs that improved chat rendering a bit: #11136)

## To do

This PR is a Ready for Review.

## How to test

For performance:
- Start a game with many mods.
- Use the chatcommand `/mods` multiple times.
- Look into debug info (f5) how your fps change when you enable/disable chat (f2).
- => master: around 40 fps for me; this PR: fps stay at 60

To test if everything still works:
- Use the chat.
- Resize your window, press F5 for debug info, ....
- Wait some long time to see old messages still disappearing.