### PR TITLE
[MANUAL MERGE] Add an option `-t` to force text output in /help

### DIFF
--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -125,30 +125,12 @@ core.register_on_player_receive_fields(function(player, formname, fields)
 	end
 end)
 
-
-local help_command = core.registered_chatcommands["help"]
-local old_help_func = help_command.func
-
-help_command.func = function(name, param)
-	local admin = core.settings:get("name")
-
-	-- If the admin ran help, put the output in the chat buffer as well to
-	-- work with the server terminal
-	if param == "privs" then
-		core.show_formspec(name, "__builtin:help_privs",
-			build_privs_formspec(name))
-		if name ~= admin then
-			return true
-		end
-	end
-	if param == "" or param == "all" then
-		core.show_formspec(name, "__builtin:help_cmds",
-			build_chatcommands_formspec(name))
-		if name ~= admin then
-			return true
-		end
-	end
-
-	return old_help_func(name, param)
+function core.show_general_help_formspec(name)
+	core.show_formspec(name, "__builtin:help_cmds",
+		build_chatcommands_formspec(name))
 end
 
+function core.show_privs_help_formspec(name)
+	core.show_formspec(name, "__builtin:help_privs",
+		build_privs_formspec(name))
+end


### PR DESCRIPTION
<b>adopted PR from https://codeberg.org/pgimeno/minetest/pulls/1, don't squash when merging to preserve authorship</b>

When the /help, /help all and /help privs commands were turned into forms, regular users did not have a means of getting text output, even after https://github.com/minetest/minetest/pull/8869 . This PR adds an option -t

## To do

Ready for Review.
## How to test

    Issue /help; check that it shows a form with command help.
    Issue /help -t; check that it shows a few lines of text output.
    Issue /help all; check that it shows the same form as /help.
    Issue /help -t all; check that it shows a LOT of text output.
    Issue /help all -t; check that it does the same as the previous one.
    Issue /help privs; check that it shows a form with privileges.
    Issue /help -t privs; check that it shows the list of privileges in text mode.
    Issue /help privs -t; check that the output is the same as the previous one.
    Issue /help help; check that it works as expected.
    Issue /help -t help; check that it does the same as the previous one.
    Issue /help help -t; check that it works the same too.
    Issue /help help set; check that it gives an error (new feature).
    Issue /help --stuff; check that it gives an error saying that double dashes are reserved.
    Launch a server with --terminal and issue the first 7 commands from the list above but in the terminal console. Check that every command performs the output in text mode, and that the ones with all give different output than the ones without.
