### PR TITLE
Add API function minetest.activate_objects_in_area

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5115,6 +5115,7 @@ Environment access
 * `minetest.get_player_by_name(name)`: Get an `ObjectRef` to a player
 * `minetest.activate_objects_in_area(pos1, pos2)`: Immediately activate static
   objects in the area from `pos1` to `pos2`.
+    * In addition, the mapblocks that contain the area are loaded if they exist.
     * The objects will soon be deactivated again if they are and remain in a
       mapblock that is not active.
     * This function cannot be called during some object activation/deactivation.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5113,6 +5113,14 @@ Environment access
 * `minetest.add_item(pos, item)`: Spawn item
     * Returns `ObjectRef`, or `nil` if failed
 * `minetest.get_player_by_name(name)`: Get an `ObjectRef` to a player
+* `minetest.activate_objects_in_area(pos1, pos2)`: Immediately activate static
+  objects in the area from `pos1` to `pos2`.
+    * The objects will soon be deactivated again if they are and remain in a
+      mapblock that is not active.
+    * This function cannot be called during some object activation/deactivation.
+      If it is called at such a time, it throws an error. Therefore, try not to
+      call it during the execution of `on_activate` and `on_deactivate`
+      callbacks.
 * `minetest.get_objects_inside_radius(pos, radius)`: returns a list of
   ObjectRefs.
     * `radius`: using an euclidean metric

--- a/games/devtest/mods/experimental/commands.lua
+++ b/games/devtest/mods/experimental/commands.lua
@@ -86,6 +86,40 @@ minetest.register_chatcommand("bench_bulk_set_node", {
 	end,
 })
 
+local function objects_to_string(objects)
+	local info_list = {}
+	for i, object in ipairs(objects) do
+		local name = ""
+		if object:is_player() then
+			name = object:get_player_name()
+		elseif object:get_luaentity() then
+			name = object:get_luaentity().name
+		end
+		info_list[i] = name .. minetest.pos_to_string(object:get_pos())
+	end
+	return table.concat(info_list, ", ")
+end
+
+minetest.register_chatcommand("test_activate_objects", {
+	params = "<minp> <maxp>",
+	description = "Test: Activate objects in an area",
+	func = function(name, param)
+		local minp, maxp = minetest.string_to_area(param)
+		if not (minp and maxp) then
+			return false, "Invalid area specified."
+		end
+
+		local objects = minetest.get_objects_in_area(minp, maxp)
+		minetest.chat_send_player(name,
+			"Objects before activation: " .. objects_to_string(objects))
+		minetest.activate_objects_in_area(minp, maxp)
+		objects = minetest.get_objects_in_area(minp, maxp)
+		minetest.chat_send_player(name,
+			"Objects after activation: " .. objects_to_string(objects))
+		return true
+	end,
+})
+
 local function advance_pos(pos, start_pos, advance_z)
 	if advance_z then
 		pos.z = pos.z + 2

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -124,3 +124,15 @@ public:
 		BaseException(s)
 	{}
 };
+
+class IllegalObjectActivationException : public BaseException
+{
+public:
+	IllegalObjectActivationException():
+		BaseException("Someone tried to activate objects when doing so was not permitted.")
+	{}
+
+	IllegalObjectActivationException(const std::string &s):
+		BaseException(s)
+	{}
+};

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -53,7 +53,7 @@ static const char *modified_reason_strings[] = {
 	"addActiveObjectRaw",
 	"removeRemovedObjects/remove",
 	"removeRemovedObjects/deactivate",
-	"Stored list cleared in activateObjects due to overflow",
+	"Stored list cleared in activateStoredObjects due to overflow",
 	"deactivateFarObjects: Static data moved in",
 	"deactivateFarObjects: Static data moved out",
 	"deactivateFarObjects: Static data changed considerably",

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -736,34 +736,28 @@ int ModApiEnvMod::l_activate_objects_in_area(lua_State *L)
 
 	v3f minp = checkFloatPos(L, 1);
 	v3f maxp = checkFloatPos(L, 2);
-	aabb3f box(minp, maxp);
-	box.repair();
 
 	v3s16 bpmin = getNodeBlockPos(check_v3s16(L, 1));
 	v3s16 bpmax = getNodeBlockPos(check_v3s16(L, 2));
+
+	aabb3f box(minp, maxp);
+	box.repair();
+	ServerEnvironment::ObjectActivationCondition condition =
+		[box](const StaticObject &s_obj) -> bool { return box.isPointInside(s_obj.pos); };
+
 	sortBoxVerticies(bpmin, bpmax);
 
-	try {
-		ServerEnvironment::ObjectActivationCondition condition =
-			[box](const StaticObject &s_obj) -> bool { return box.isPointInside(s_obj.pos); };
-
-		Map &map = env->getMap();
-		for (s16 z = bpmin.Z; z <= bpmax.Z; z++)
-		for (s16 y = bpmin.Y; y <= bpmax.Y; y++)
-		for (s16 x = bpmin.X; x <= bpmax.X; x++) {
-			MapBlock *block = map.emergeBlock(v3s16(x, y, z), false);
-			// Only existing blocks are operated upon
-			if (block)
-				env->activateObjects(block, condition);
-		}
-
-		return 0;
-
-	} catch (const IllegalObjectActivationException &e) {
-		lua_pop(L, 1); // Make space on the stack
-		lua_pushstring(L, e.what());
+	Map &map = env->getMap();
+	for (s16 z = bpmin.Z; z <= bpmax.Z; z++)
+	for (s16 y = bpmin.Y; y <= bpmax.Y; y++)
+	for (s16 x = bpmin.X; x <= bpmax.X; x++) {
+		MapBlock *block = map.emergeBlock(v3s16(x, y, z), false);
+		// Only existing blocks are operated upon
+		if (block)
+			env->activateObjects(block, condition);
 	}
-	return lua_error(L); // Rethrow as Lua error
+
+	return 0;
 }
 
 // get_objects_inside_radius(pos, radius)

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -734,18 +734,19 @@ int ModApiEnvMod::l_activate_objects_in_area(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	v3s16 bpmin = getNodeBlockPos(check_v3s16(L, 1));
-	v3s16 bpmax = getNodeBlockPos(check_v3s16(L, 2));
-	sortBoxVerticies(bpmin, bpmax);
-
 	v3f minp = checkFloatPos(L, 1);
 	v3f maxp = checkFloatPos(L, 2);
 	aabb3f box(minp, maxp);
 	box.repair();
-	ServerEnvironment::ObjectActivationCondition condition =
-		[box](const StaticObject &s_obj) -> bool { return box.isPointInside(s_obj.pos); };
+
+	v3s16 bpmin = getNodeBlockPos(check_v3s16(L, 1));
+	v3s16 bpmax = getNodeBlockPos(check_v3s16(L, 2));
+	sortBoxVerticies(bpmin, bpmax);
 
 	try {
+		ServerEnvironment::ObjectActivationCondition condition =
+			[box](const StaticObject &s_obj) -> bool { return box.isPointInside(s_obj.pos); };
+
 		Map &map = env->getMap();
 		for (s16 z = bpmin.Z; z <= bpmax.Z; z++)
 		for (s16 y = bpmin.Y; y <= bpmax.Y; y++)
@@ -759,6 +760,7 @@ int ModApiEnvMod::l_activate_objects_in_area(lua_State *L)
 		return 0;
 
 	} catch (const IllegalObjectActivationException &e) {
+		lua_pop(L, 1); // Make space on the stack
 		lua_pushstring(L, e.what());
 	}
 	return lua_error(L); // Rethrow as Lua error

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -42,6 +42,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server/player_sao.h"
 #include "util/string.h"
 #include "translation.h"
+#include "exceptions.h"
 #ifndef SERVER
 #include "client/client.h"
 #endif
@@ -726,6 +727,41 @@ int ModApiEnvMod::l_get_player_by_name(lua_State *L)
 	// Put player on stack
 	getScriptApiBase(L)->objectrefGetOrCreate(L, sao);
 	return 1;
+}
+
+// activate_objects_in_area(minp, maxp)
+int ModApiEnvMod::l_activate_objects_in_area(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	v3s16 bpmin = getNodeBlockPos(check_v3s16(L, 1));
+	v3s16 bpmax = getNodeBlockPos(check_v3s16(L, 2));
+	sortBoxVerticies(bpmin, bpmax);
+
+	v3f minp = checkFloatPos(L, 1);
+	v3f maxp = checkFloatPos(L, 2);
+	aabb3f box(minp, maxp);
+	box.repair();
+	ServerEnvironment::ObjectActivationCondition condition =
+		[box](const StaticObject &s_obj) -> bool { return box.isPointInside(s_obj.pos); };
+
+	try {
+		Map &map = env->getMap();
+		for (s16 z = bpmin.Z; z <= bpmax.Z; z++)
+		for (s16 y = bpmin.Y; y <= bpmax.Y; y++)
+		for (s16 x = bpmin.X; x <= bpmax.X; x++) {
+			MapBlock *block = map.emergeBlock(v3s16(x, y, z), false);
+			// Only existing blocks are operated upon
+			if (block)
+				env->activateObjects(block, condition);
+		}
+
+		return 0;
+
+	} catch (const IllegalObjectActivationException &e) {
+		lua_pushstring(L, e.what());
+	}
+	return lua_error(L); // Rethrow as Lua error
 }
 
 // get_objects_inside_radius(pos, radius)
@@ -1465,6 +1501,7 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(get_node_timer);
 	API_FCT(get_connected_players);
 	API_FCT(get_player_by_name);
+	API_FCT(activate_objects_in_area);
 	API_FCT(get_objects_in_area);
 	API_FCT(get_objects_inside_radius);
 	API_FCT(set_timeofday);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -112,6 +112,9 @@ private:
 	// get_player_by_name(name)
 	static int l_get_player_by_name(lua_State *L);
 
+	// activate_objects_in_area(minp, maxp)
+	static int l_activate_objects_in_area(lua_State *L);
+
 	// get_objects_inside_radius(pos, radius)
 	static int l_get_objects_inside_radius(lua_State *L);
 	

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -995,8 +995,8 @@ void ServerEnvironment::activateBlock(MapBlock *block, u32 additional_dtime)
 	}
 }
 
-void ServerEnvironment::activateObjects(MapBlock *block, ObjectActivationCondition condition,
-	u32 additional_dtime)
+void ServerEnvironment::activateObjects(MapBlock *block,
+	const ObjectActivationCondition &condition, u32 additional_dtime)
 {
 	if (m_object_activation_locked)
 		throw IllegalObjectActivationException();
@@ -1938,7 +1938,7 @@ ServerActiveObject* ServerEnvironment::createSAO(ActiveObjectType type, v3f pos,
 	Convert stored objects from blocks near the players to active.
 */
 void ServerEnvironment::activateStoredObjects(MapBlock *block, u32 dtime_s,
-	ObjectActivationCondition condition)
+	const ObjectActivationCondition &condition)
 {
 	if(block == NULL)
 		return;

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -311,7 +311,7 @@ public:
 		Throws an IllegalObjectActivationException and changes nothing
 		if called at a time when object activation is not allowed.
 	*/
-	void activateObjects(MapBlock *block, ObjectActivationCondition condition=nullptr,
+	void activateObjects(MapBlock *block, const ObjectActivationCondition &condition=nullptr,
 		u32 additional_dtime=0);
 
 	/*
@@ -425,7 +425,7 @@ private:
 		If given, the predicate is a precondition to activation
 	*/
 	void activateStoredObjects(MapBlock *block, u32 dtime_s,
-		ObjectActivationCondition condition = nullptr);
+		const ObjectActivationCondition &condition = nullptr);
 
 	/*
 		Convert objects that are not in active blocks to static.

--- a/src/util/set_in_scope.h
+++ b/src/util/set_in_scope.h
@@ -19,6 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <utility>
+
 /**
  * A scoped setting of a reference. The reference is set to the new value when
  * the SetInScope is constructed. On destruction the reference is reset to the
@@ -30,9 +32,17 @@ template<typename T>
 class SetInScope
 {
 public:
-	SetInScope(T &ref, const T &&val): m_ref(ref), m_old_val(ref) { ref = val; }
+	SetInScope(T &ref, const T &&val):
+		m_ref(ref),
+		m_old_val(std::move(m_ref))
+	{
+		m_ref = val;
+	}
 
-	~SetInScope() { m_ref = m_old_val; }
+	~SetInScope()
+	{
+		m_ref = std::move(m_old_val);
+	}
 
 private:
 	T &m_ref;

--- a/src/util/set_in_scope.h
+++ b/src/util/set_in_scope.h
@@ -1,0 +1,40 @@
+/*
+Minetest
+Copyright (C) 2021 Jude Melton-Houghton
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+/**
+ * A scoped setting of a reference. The reference is set to the new value when
+ * the SetInScope is constructed. On destruction the reference is reset to the
+ * value it had before construction.
+ *
+ * @tparam T The referenced type
+ */
+template<typename T>
+class SetInScope
+{
+public:
+	SetInScope(T &ref, const T &&val): m_ref(ref), m_old_val(ref) { ref = val; }
+
+	~SetInScope() { m_ref = m_old_val; }
+
+private:
+	T &m_ref;
+	T m_old_val;
+};

--- a/src/util/set_in_scope.h
+++ b/src/util/set_in_scope.h
@@ -32,7 +32,7 @@ template<typename T>
 class SetInScope
 {
 public:
-	SetInScope(T &ref, const T &&val):
+	SetInScope(T &ref, const T &val):
 		m_ref(ref),
 		m_old_val(std::move(m_ref))
 	{


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - The goal is to add a way to synchronously find the objects in any area.
- How does the PR work?
  - The API function finds the mapblocks containing the given area. Then it goes through each of them and activates the objects using a new method of `ServerEnvironment`. The objects are activated like during regular mapblock activation, except that only those within the given area are activated.
  - The function cannot be called when activation or deactivation is going on. I don't think this restriction is very significant, although I could be wrong. Basically it just means you can't call the function in `on_activate` or `on_deactivate`. I had to change several places in the code to get this to work. It wouldn't be safe to let mods call the function in these places, since the activation and deactivation procedures are not written to be re-entrant.
- Does it resolve any reported issue?
  - Fixes #11599
  - The predecessor of this PR is #11609
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
  - It broadens the interface for objects/entities.
  - It counts as taking feedback from a modder.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  - I mentioned my usecase in the issue and the previous PR. It's for my mod area_containers.
  - @ElCeejo mentioned that my previous PR would be very useful to them in their work with objects, and this PR does basically the same thing in that regard.

## To do

This PR is Ready for Review.

## How to test

1. Load a devtest world with this mod installed: [test_activate_objects.tar.gz](https://github.com/minetest/minetest/files/7165874/test_activate_objects.tar.gz)
2. Run the command `/grantme all`.
3. Start flying.
4. Execute these commands:
  a. `/teleport 0 6001 0`
  b. `/make_platform (0,6000,0)`
  c. `/teleport 0 10 0`
5. After the objects are deactivated, run `/check_platform (0,6000,0)`. It should tell you that it activated the area and detected two objects.
6. If you want to test that `minetest.activate_objects_in_area` throws an error in the right places, you can uncomment one or both of the latter two calls to the function in the mod's `init.lua`. These two calls are at the bottom of the file where the `on_activate` and `on_deactivate` methods of `__builtin:item` are overridden.

I've also now added a devtest command `test_activate_objects` for activating an arbitrary area.
