### PR TITLE
Fix src/util/string.cpp on NetBSD

### DIFF
--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -108,7 +108,6 @@ std::wstring utf8_to_wide(const std::string &input)
 	out.resize(outbuf_size / sizeof(wchar_t));
 
 #if defined(__ANDROID__) || defined(__NetBSD__)
-	// Android need manual caring to support the full character set possible with wchar_t
 	SANITY_CHECK(sizeof(wchar_t) == 4);
 #endif
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -39,8 +39,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#include <windows.h>
 #endif
 
-#if defined(_ICONV_H_) && (defined(__FreeBSD__) || defined(__NetBSD__) || \
-	defined(__OpenBSD__) || defined(__DragonFly__))
+#ifdef __NetBSD__
+	#include <sys/param.h>
+	#if __NetBSD_Version__ <= 999001500
+		#define BSD_ICONV_USED
+	#endif
+#elif defined(_ICONV_H_) && (defined(__FreeBSD__) || defined(__OpenBSD__) || \
+	defined(__DragonFly__))
 	#define BSD_ICONV_USED
 #endif
 
@@ -79,6 +84,14 @@ static bool convert(const char *to, const char *from, char *outbuf,
 #ifdef __ANDROID__
 // On Android iconv disagrees how big a wchar_t is for whatever reason
 const char *DEFAULT_ENCODING = "UTF-32LE";
+#elif defined(__NetBSD__)
+	// NetBSD does not allow "WCHAR_T" as a charset input to iconv.
+	#include <sys/endian.h>
+	#if BYTE_ORDER == BIG_ENDIAN
+	const char *DEFAULT_ENCODING = "UTF-32BE";
+	#else
+	const char *DEFAULT_ENCODING = "UTF-32LE";
+	#endif
 #else
 const char *DEFAULT_ENCODING = "WCHAR_T";
 #endif
@@ -94,7 +107,8 @@ std::wstring utf8_to_wide(const std::string &input)
 	std::wstring out;
 	out.resize(outbuf_size / sizeof(wchar_t));
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) || defined(__NetBSD__)
+	// Android need manual caring to support the full character set possible with wchar_t
 	SANITY_CHECK(sizeof(wchar_t) == 4);
 #endif
 


### PR DESCRIPTION
- iconv() prototype changed from traditional Unix definition to POSIX definition in 9.99.x.
- wchar_t is not a valid character set for iconv. Share code with Android for using UTF-32. Fixes text rendering in menus.