### PR TITLE
fix integer overflow in mapgen

### DIFF
--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -238,8 +238,8 @@ u32 Mapgen::getBlockSeed(v3s16 p, s32 seed)
 
 u32 Mapgen::getBlockSeed2(v3s16 p, s32 seed)
 {
-	// Unsigned magic seed prevents undefined behavior.
-	u32 n = 1619 * p.X + 31337 * p.Y + 52591 * p.Z + 1013U * seed;
+	// Multiply by unsigned number to avoid signed overflow (UB)
+	u32 n = 1619U * p.X + 31337U * p.Y + 52591U * p.Z + 1013U * seed;
 	n = (n >> 13) ^ n;
 	return (n * (n * n * 60493 + 19990303) + 1376312589);
 }

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -238,7 +238,8 @@ u32 Mapgen::getBlockSeed(v3s16 p, s32 seed)
 
 u32 Mapgen::getBlockSeed2(v3s16 p, s32 seed)
 {
-	u32 n = 1619 * p.X + 31337 * p.Y + 52591 * p.Z + 1013 * seed;
+	// Unsigned magic seed prevents undefined behavior.
+	u32 n = 1619 * p.X + 31337 * p.Y + 52591 * p.Z + 1013U * seed;
 	n = (n >> 13) ^ n;
 	return (n * (n * n * 60493 + 19990303) + 1376312589);
 }

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -35,7 +35,8 @@
 #define NOISE_MAGIC_X    1619
 #define NOISE_MAGIC_Y    31337
 #define NOISE_MAGIC_Z    52591
-#define NOISE_MAGIC_SEED 1013
+// Unsigned magic seed prevents undefined behavior.
+#define NOISE_MAGIC_SEED 1013U
 
 typedef float (*Interp2dFxn)(
 		float v00, float v10, float v01, float v11,

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -167,7 +167,6 @@ float noise2d(int x, int y, s32 seed)
 {
 	unsigned int n = (NOISE_MAGIC_X * x + NOISE_MAGIC_Y * y
 			+ NOISE_MAGIC_SEED * seed) & 0x7fffffff;
-	// Right bit shift on an unsigned type zero-fills.
 	n = (n >> 13) ^ n;
 	n = (n * (n * n * 60493 + 19990303) + 1376312589) & 0x7fffffff;
 	return 1.f - (float)(int)n / 0x40000000;

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -167,6 +167,7 @@ float noise2d(int x, int y, s32 seed)
 {
 	unsigned int n = (NOISE_MAGIC_X * x + NOISE_MAGIC_Y * y
 			+ NOISE_MAGIC_SEED * seed) & 0x7fffffff;
+	// Right bit shift on an unsigned type zero-fills.
 	n = (n >> 13) ^ n;
 	n = (n * (n * n * 60493 + 19990303) + 1376312589) & 0x7fffffff;
 	return 1.f - (float)(int)n / 0x40000000;

--- a/src/unittest/test_noise.cpp
+++ b/src/unittest/test_noise.cpp
@@ -30,8 +30,14 @@ public:
 
 	void runTests(IGameDef *gamedef);
 
+	void testNoise2dAtOriginWithZeroSeed();
+	void testNoise2dWithMaxSeed();
+	void testNoise2dWithFunPrimes();
 	void testNoise2dPoint();
 	void testNoise2dBulk();
+	void testNoise3dAtOriginWithZeroSeed();
+	void testNoise3dWithMaxSeed();
+	void testNoise3dWithFunPrimes();
 	void testNoise3dPoint();
 	void testNoise3dBulk();
 	void testNoiseInvalidParams();
@@ -44,14 +50,41 @@ static TestNoise g_test_instance;
 
 void TestNoise::runTests(IGameDef *gamedef)
 {
+	TEST(testNoise2dAtOriginWithZeroSeed);
+	TEST(testNoise2dWithMaxSeed);
+	TEST(testNoise2dWithFunPrimes);
 	TEST(testNoise2dPoint);
 	TEST(testNoise2dBulk);
+	TEST(testNoise3dAtOriginWithZeroSeed);
+	TEST(testNoise3dWithMaxSeed);
+	TEST(testNoise3dWithFunPrimes);
 	TEST(testNoise3dPoint);
 	TEST(testNoise3dBulk);
 	TEST(testNoiseInvalidParams);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void TestNoise::testNoise2dAtOriginWithZeroSeed()
+{
+	float actual{ noise2d(0, 0, 0) };
+	constexpr float expected{ -0.281791f };
+	UASSERT(std::fabs(actual - expected) <= 0.00001);
+}
+
+void TestNoise::testNoise2dWithMaxSeed()
+{
+	float actual{ noise2d(4096, 4096, 2147483647) };
+	constexpr float expected{ 0.950606f };
+	UASSERT(std::fabs(actual - expected) <= 0.00001);
+}
+
+void TestNoise::testNoise2dWithFunPrimes()
+{
+	float actual{ noise2d(-3947, -2333, 7027) };
+	constexpr float expected{ -0.294907f };
+	UASSERT(std::fabs(actual - expected) <= 0.00001);
+}
 
 void TestNoise::testNoise2dPoint()
 {
@@ -77,6 +110,27 @@ void TestNoise::testNoise2dBulk()
 		float expected = expected_2d_results[i];
 		UASSERT(std::fabs(actual - expected) <= 0.00001);
 	}
+}
+
+void TestNoise::testNoise3dAtOriginWithZeroSeed()
+{
+	float actual{ noise2d(0, 0, 0) };
+	constexpr float expected{ -0.281791f };
+	UASSERT(std::fabs(actual - expected) <= 0.00001);
+}
+
+void TestNoise::testNoise3dWithMaxSeed()
+{
+	float actual{ noise3d(4096, 4096, 4096, 2147483647) };
+	constexpr float expected{ -0.775243f };
+	UASSERT(std::fabs(actual - expected) <= 0.00001);
+}
+
+void TestNoise::testNoise3dWithFunPrimes()
+{
+	float actual{ noise2d(3903, -1723, 7411) };
+	constexpr float expected{ 0.989124f };
+	UASSERT(std::fabs(actual - expected) <= 0.00001);
 }
 
 void TestNoise::testNoise3dPoint()


### PR DESCRIPTION
Some calculations involving the magic seed had overflow because the result of an intermediate arithmetic step could not fit in an s32. By making the magic seed unsigned, the other operand in the equation will be cast to unsigned, and possibly other operands or intermediate operands. This will result in unexpected behavior if an operand is negative, which is technically possible, but logically should not happen.

Because this overflow will no longer occur, maps that were generated with this overflow may not be reproducible. The extent of this effect is unknown. Judging from issues #11620 and #11621, this would only be noticed in the valleys mapgen.

- The PR will make the behavior of the affected mapgen equations well-defined and predictable.
- This is done by making the magic seed unsigned, so that the result of an arithmetic operation with the seed will not overflow.
- Fixes #11620; fixes #11621.

## To do

Ready for Review.

## How to test

I do not know how to properly test this. One could generate a map with the valleys mapgen with a given seed, before and after this commit, and compare the result, but that is not a definitive test of whether the maps match exactly or not.