### PR TITLE
Network: Delete copy constructor and use std::move instead

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -877,7 +877,7 @@ void Client::ProcessData(NetworkPacket *pkt)
 	*/
 	if(sender_peer_id != PEER_ID_SERVER) {
 		infostream << "Client::ProcessData(): Discarding data not "
-			"coming from server: peer_id=" << sender_peer_id
+			"coming from server: peer_id=" << sender_peer_id << " command=" << pkt->getCommand()
 			<< std::endl;
 		return;
 	}

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -93,6 +93,15 @@ struct BufferedPacket
 	BufferedPacket(u32 a_size):
 		data(a_size)
 	{}
+	void copyTo(BufferedPacket &p) const
+	{
+		data.copyTo(p.data);
+		p.time = time;
+		p.totaltime = totaltime;
+		p.absolute_send_time = absolute_send_time;
+		p.address = address;
+		p.resend_count = resend_count;
+	}
 	Buffer<u8> data; // Data of the packet, including headers
 	float time = 0.0f; // Seconds from buffering the packet or re-sending
 	float totaltime = 0.0f; // Seconds from buffering the packet
@@ -355,7 +364,7 @@ struct ConnectionCommand
 		type = CONCMD_ACK;
 		peer_id = peer_id_;
 		channelnum = channelnum_;
-		data = data_;
+		data_.copyTo(data);
 		reliable = false;
 	}
 
@@ -363,7 +372,7 @@ struct ConnectionCommand
 	{
 		type = CONCMD_CREATE_PEER;
 		peer_id = peer_id_;
-		data = data_;
+		data_.copyTo(data);
 		channelnum = 0;
 		reliable = true;
 		raw = true;
@@ -718,7 +727,7 @@ struct ConnectionEvent
 	{
 		type = CONNEVENT_DATA_RECEIVED;
 		peer_id = peer_id_;
-		data = data_;
+		data_.copyTo(data);
 	}
 	void peerAdded(session_t peer_id_, Address address_)
 	{
@@ -753,8 +762,7 @@ public:
 
 	/* Interface */
 	ConnectionEvent waitEvent(u32 timeout_ms);
-	// Warning: creates an unnecessary copy, prefer putCommand(T&&) if possible
-	void putCommand(const ConnectionCommand &c);
+
 	void putCommand(ConnectionCommand &&c);
 
 	void SetTimeoutMs(u32 timeout) { m_bc_receive_timeout = timeout; }
@@ -799,8 +807,6 @@ protected:
 
 	bool Receive(NetworkPacket *pkt, u32 timeout);
 
-	// Warning: creates an unnecessary copy, prefer putEvent(T&&) if possible
-	void putEvent(const ConnectionEvent &e);
 	void putEvent(ConnectionEvent &&e);
 
 	void TriggerSend();

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -236,12 +236,12 @@ void ConnectionSendThread::runTimeouts(float dtime)
 					<< "RE-SENDING timed-out RELIABLE to "
 					<< k->address.serializeString()
 					<< "(t/o=" << resend_timeout << "): "
-					<< "count=" << k.resend_count
+					<< "count=" << k->resend_count
 					<< ", channel=" << ((int) channelnum & 0xff)
 					<< ", seqnum=" << seqnum
 					<< std::endl);
 
-				rawSend(k);
+				rawSend(k.get());
 
 				// do not handle rtt here as we can't decide if this packet was
 				// lost or really takes more time to transmit
@@ -274,7 +274,7 @@ void ConnectionSendThread::runTimeouts(float dtime)
 	}
 }
 
-void ConnectionSendThread::rawSend(const BufferedPacketPtr &p)
+void ConnectionSendThread::rawSend(const BufferedPacket *p)
 {
 	try {
 		m_connection->m_udpSocket.Send(p->address, p->data, p->size());
@@ -304,7 +304,7 @@ void ConnectionSendThread::sendAsPacketReliable(BufferedPacketPtr &p, Channel *c
 	}
 
 	// Send the packet
-	rawSend(p);
+	rawSend(p.get());
 }
 
 bool ConnectionSendThread::rawSendAsPacket(session_t peer_id, u8 channelnum,
@@ -361,7 +361,7 @@ bool ConnectionSendThread::rawSendAsPacket(session_t peer_id, u8 channelnum,
 			channelnum);
 
 		// Send the packet
-		rawSend(p);
+		rawSend(p.get());
 		return true;
 	}
 

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -482,7 +482,7 @@ void ConnectionSendThread::serve(Address bind_address)
 		// Create event
 		ConnectionEvent ce;
 		ce.bindFailed();
-		m_connection->putEvent(ce);
+		m_connection->putEvent(std::move(ce));
 	}
 }
 
@@ -497,7 +497,7 @@ void ConnectionSendThread::connect(Address address)
 	// Create event
 	ConnectionEvent e;
 	e.peerAdded(peer->id, peer->address);
-	m_connection->putEvent(e);
+	m_connection->putEvent(std::move(e));
 
 	Address bind_addr;
 
@@ -1330,7 +1330,7 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Reliable(Channel *cha
 		} catch (IncomingDataCorruption &e) {
 			ConnectionCommand discon;
 			discon.disconnect_peer(peer->id);
-			m_connection->putCommand(discon);
+			m_connection->putCommand(std::move(discon));
 
 			LOG(derr_con << m_connection->getDesc()
 				<< "INVALID, TYPE_RELIABLE peer_id: " << peer->id

--- a/src/network/connectionthreads.h
+++ b/src/network/connectionthreads.h
@@ -74,16 +74,16 @@ private:
 	bool rawSendAsPacket(session_t peer_id, u8 channelnum,
 			const SharedBuffer<u8> &data, bool reliable);
 
-	void processReliableCommand(ConnectionCommand &c);
-	void processNonReliableCommand(ConnectionCommand &c);
+	void processReliableCommand(ConnectionCommandPtr &c);
+	void processNonReliableCommand(ConnectionCommandPtr &c);
 	void serve(Address bind_address);
 	void connect(Address address);
 	void disconnect();
 	void disconnect_peer(session_t peer_id);
 	void send(session_t peer_id, u8 channelnum, const SharedBuffer<u8> &data);
-	void sendReliable(ConnectionCommand &c);
+	void sendReliable(ConnectionCommandPtr &c);
 	void sendToAll(u8 channelnum, const SharedBuffer<u8> &data);
-	void sendToAllReliable(ConnectionCommand &c);
+	void sendToAllReliable(ConnectionCommandPtr &c);
 
 	void sendPackets(float dtime);
 

--- a/src/network/connectionthreads.h
+++ b/src/network/connectionthreads.h
@@ -29,6 +29,25 @@ namespace con
 
 class Connection;
 
+struct OutgoingPacket
+{
+	session_t peer_id;
+	u8 channelnum;
+	SharedBuffer<u8> data;
+	bool reliable;
+	bool ack;
+
+	OutgoingPacket(session_t peer_id_, u8 channelnum_, const SharedBuffer<u8> &data_,
+			bool reliable_,bool ack_=false):
+		peer_id(peer_id_),
+		channelnum(channelnum_),
+		data(data_),
+		reliable(reliable_),
+		ack(ack_)
+	{
+	}
+};
+
 class ConnectionSendThread : public Thread
 {
 
@@ -51,7 +70,7 @@ public:
 
 private:
 	void runTimeouts(float dtime);
-	void rawSend(const BufferedPacket &packet);
+	void rawSend(const BufferedPacketPtr &p);
 	bool rawSendAsPacket(session_t peer_id, u8 channelnum,
 			const SharedBuffer<u8> &data, bool reliable);
 
@@ -71,7 +90,7 @@ private:
 	void sendAsPacket(session_t peer_id, u8 channelnum, const SharedBuffer<u8> &data,
 			bool ack = false);
 
-	void sendAsPacketReliable(BufferedPacket &p, Channel *channel);
+	void sendAsPacketReliable(BufferedPacketPtr &p, Channel *channel);
 
 	bool packetsQueued();
 

--- a/src/network/connectionthreads.h
+++ b/src/network/connectionthreads.h
@@ -70,7 +70,7 @@ public:
 
 private:
 	void runTimeouts(float dtime);
-	void rawSend(const BufferedPacketPtr &p);
+	void rawSend(const BufferedPacket *p);
 	bool rawSendAsPacket(session_t peer_id, u8 channelnum,
 			const SharedBuffer<u8> &data, bool reliable);
 

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -124,7 +124,7 @@ void TestConnection::testHelpers()
 	Address a(127,0,0,1, 10);
 	const u16 seqnum = 34352;
 
-	con::BufferedPacket p1 = con::makePacket(a, data1,
+	con::BufferedPacketPtr p1 = con::makePacket(a, data1,
 			proto_id, peer_id, channel);
 	/*
 		We should now have a packet with this data:
@@ -135,10 +135,10 @@ void TestConnection::testHelpers()
 		Data:
 			[7] u8 data1[0]
 	*/
-	UASSERT(readU32(&p1.data[0]) == proto_id);
-	UASSERT(readU16(&p1.data[4]) == peer_id);
-	UASSERT(readU8(&p1.data[6]) == channel);
-	UASSERT(readU8(&p1.data[7]) == data1[0]);
+	UASSERT(readU32(&p1->data[0]) == proto_id);
+	UASSERT(readU16(&p1->data[4]) == peer_id);
+	UASSERT(readU8(&p1->data[6]) == channel);
+	UASSERT(readU8(&p1->data[7]) == data1[0]);
 
 	//infostream<<"initial data1[0]="<<((u32)data1[0]&0xff)<<std::endl;
 

--- a/src/util/pointer.h
+++ b/src/util/pointer.h
@@ -40,17 +40,11 @@ public:
 		else
 			data = NULL;
 	}
-	Buffer(const Buffer &buffer)
-	{
-		m_size = buffer.m_size;
-		if(m_size != 0)
-		{
-			data = new T[buffer.m_size];
-			memcpy(data, buffer.data, buffer.m_size);
-		}
-		else
-			data = NULL;
-	}
+
+	// Disable class copy
+	Buffer(const Buffer &) = delete;
+	Buffer &operator=(const Buffer &) = delete;
+
 	Buffer(Buffer &&buffer)
 	{
 		m_size = buffer.m_size;
@@ -81,21 +75,6 @@ public:
 		drop();
 	}
 
-	Buffer& operator=(const Buffer &buffer)
-	{
-		if(this == &buffer)
-			return *this;
-		drop();
-		m_size = buffer.m_size;
-		if(m_size != 0)
-		{
-			data = new T[buffer.m_size];
-			memcpy(data, buffer.data, buffer.m_size);
-		}
-		else
-			data = NULL;
-		return *this;
-	}
 	Buffer& operator=(Buffer &&buffer)
 	{
 		if(this == &buffer)
@@ -111,6 +90,18 @@ public:
 		else
 			data = nullptr;
 		return *this;
+	}
+
+	void copyTo(Buffer &buffer) const
+	{
+		buffer.drop();
+		buffer.m_size = m_size;
+		if (m_size != 0) {
+			buffer.data = new T[m_size];
+			memcpy(buffer.data, data, m_size);
+		} else {
+			buffer.data = nullptr;
+		}
 	}
 
 	T & operator[](unsigned int i) const

--- a/src/util/pointer.h
+++ b/src/util/pointer.h
@@ -22,6 +22,21 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes.h"
 #include "debug.h" // For assert()
 #include <cstring>
+#include <memory> // std::shared_ptr
+
+
+template<typename T> class ConstSharedPtr {
+public:
+	ConstSharedPtr(T *ptr) : ptr(ptr) {}
+	ConstSharedPtr(const std::shared_ptr<T> &ptr) : ptr(ptr) {}
+
+	const T* get() const noexcept { return ptr.get(); }
+	const T& operator*() const noexcept { return *ptr.get(); }
+	const T* operator->() const noexcept { return ptr.get(); }
+
+private:
+	std::shared_ptr<T> ptr;
+};
 
 template <typename T>
 class Buffer


### PR DESCRIPTION
Follow-up on #11607

This PR takes it a step further by disabling class copies to avoid unnecessary memory movements. ~~However, I did yet not solve all copyTo() calls, which might be a task for a Connection refactor PR to use `std::shared_ptr` rather than deep copies.~~

## To do

This PR is Ready for Review.

## How to test

1. Check whether server hosting & playing still works -> i.e. singleplayer
2. Read the code changes and judge them
3. ????
4. Profit
