### PR TITLE
Order drawlist by distance to the camera when rendering

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -415,8 +415,9 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 							if (new_material)
 								previous_material = material;
 						}
-						else
+						else {
 							grouped_buffers.add(buf, block_pos, layer);
+						}
 					}
 				}
 			}

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -165,7 +165,7 @@ void ClientMap::updateDrawList()
 {
 	ScopeProfiler sp(g_profiler, "CM::updateDrawList()", SPT_AVG);
 
-	m_needsUpdateDrawList = false;
+	m_needs_update_drawlist = false;
 
 	for (auto &i : m_drawlist) {
 		MapBlock *block = i.second;

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -73,7 +73,8 @@ ClientMap::ClientMap(
 		rendering_engine->get_scene_manager(), id),
 	m_client(client),
 	m_rendering_engine(rendering_engine),
-	m_control(control)
+	m_control(control),
+	m_drawlist(MapBlockComparer(v3s16(0,0,0)))
 {
 
 	/*
@@ -178,6 +179,7 @@ void ClientMap::updateDrawList()
 	const f32 camera_fov = m_camera_fov * 1.1f;
 
 	v3s16 cam_pos_nodes = floatToInt(camera_position, BS);
+
 	v3s16 p_blocks_min;
 	v3s16 p_blocks_max;
 	getBlocksInViewRange(cam_pos_nodes, &p_blocks_min, &p_blocks_max);
@@ -202,6 +204,8 @@ void ClientMap::updateDrawList()
 			occlusion_culling_enabled = false;
 	}
 
+	v3s16 camera_block = getContainerPos(floatToInt(camera_position, BS), MAP_BLOCKSIZE);
+	m_drawlist = std::map<v3s16, MapBlock*, MapBlockComparer>(MapBlockComparer(camera_block));
 
 	// Uncomment to debug occluded blocks in the wireframe mode
 	// TODO: Include this as a flag for an extended debugging setting

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -406,7 +406,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	core::matrix4 m; // Model matrix
 	v3f offset = intToFloat(m_camera_offset, BS);
 
-	// Render all layers in order
+	// Render all solid layers in order
 	for (auto &lists : drawbufs.lists) {
 		for (MeshBufList &list : lists) {
 			// Check and abort if the machine is swapping a lot
@@ -429,7 +429,8 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			driver->setMaterial(list.m);
 
 			drawcall_count += list.bufs.size();
-			for (auto &pair : list.bufs) {
+			for (auto it = list.bufs.rbegin(); it != list.bufs.rend(); ++it) {
+				auto &pair = *it;
 				scene::IMeshBuffer *buf = pair.second;
 
 				v3f block_wpos = intToFloat(pair.first * MAP_BLOCKSIZE, BS);

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -206,7 +206,7 @@ void ClientMap::updateDrawList()
 			occlusion_culling_enabled = false;
 	}
 
-	v3s16 camera_block = getContainerPos(floatToInt(camera_position, BS), MAP_BLOCKSIZE);
+	v3s16 camera_block = getContainerPos(cam_pos_nodes, MAP_BLOCKSIZE);
 	m_drawlist = std::map<v3s16, MapBlock*, MapBlockComparer>(MapBlockComparer(camera_block));
 
 	// Uncomment to debug occluded blocks in the wireframe mode
@@ -431,6 +431,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			driver->setMaterial(list.m);
 
 			drawcall_count += list.bufs.size();
+			// iterate in reverse to draw closest blocks first
 			for (auto it = list.bufs.rbegin(); it != list.bufs.rend(); ++it) {
 				auto &pair = *it;
 				scene::IMeshBuffer *buf = pair.second;

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -165,6 +165,8 @@ void ClientMap::updateDrawList()
 {
 	ScopeProfiler sp(g_profiler, "CM::updateDrawList()", SPT_AVG);
 
+	m_needsUpdateDrawList = false;
+
 	for (auto &i : m_drawlist) {
 		MapBlock *block = i.second;
 		block->refDrop();

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -87,7 +87,7 @@ public:
 
 	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset)
 	{
-		v3s16 previous_block = getContainerPos(floatToInt(m_camera_position + intToFloat(m_camera_offset, BS), BS), MAP_BLOCKSIZE);
+		v3s16 previous_block = getContainerPos(floatToInt(m_camera_position, BS) + m_camera_offset, MAP_BLOCKSIZE);
 
 		m_camera_position = pos;
 		m_camera_direction = dir;

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -16,6 +16,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
+
 #pragma once
 
 #include "irrlichttypes_extrabloated.h"
@@ -97,7 +98,7 @@ public:
 
 		// reorder the blocks when camera crosses block boundary
 		if (previous_block != current_block)
-			updateDrawList();
+			m_needsUpdateDrawList = true;
 	}
 
 	/*
@@ -129,6 +130,8 @@ public:
 		v3s16 *p_blocks_min, v3s16 *p_blocks_max, float range=-1.0f);
 	void updateDrawList();
 	void updateDrawListShadow(const v3f &shadow_light_pos, const v3f &shadow_light_dir, float shadow_range);
+	// Returns true if draw list needs updating before drawing the next frame.
+	bool needsUpdateDrawList() { return m_needsUpdateDrawList; }
 	void renderMap(video::IVideoDriver* driver, s32 pass);
 
 	void renderMapShadows(video::IVideoDriver *driver,
@@ -181,6 +184,7 @@ private:
 
 	std::map<v3s16, MapBlock*, MapBlockComparer> m_drawlist;
 	std::map<v3s16, MapBlock*> m_drawlist_shadow;
+	bool m_needsUpdateDrawList;
 
 	std::set<v2s16> m_last_drawn_sectors;
 

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -94,7 +94,7 @@ public:
 		m_camera_fov = fov;
 		m_camera_offset = offset;
 
-		v3s16 current_block = getContainerPos(floatToInt(m_camera_position + intToFloat(m_camera_offset, BS), BS), MAP_BLOCKSIZE);
+		v3s16 current_block = getContainerPos(floatToInt(m_camera_position, BS) + m_camera_offset, MAP_BLOCKSIZE);
 
 		// reorder the blocks when camera crosses block boundary
 		if (previous_block != current_block)

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -156,8 +156,6 @@ private:
 	public:
 		MapBlockComparer(const v3s16 &camera_block) : m_camera_block(camera_block) {}
 
-		MapBlockComparer(const MapBlockComparer& origin) : m_camera_block(origin.m_camera_block) {}
-
 		bool operator() (const v3s16 &left, const v3s16 &right) const
 		{
 			auto distance_left = left.getDistanceFromSQ(m_camera_block);

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -98,7 +98,7 @@ public:
 
 		// reorder the blocks when camera crosses block boundary
 		if (previous_block != current_block)
-			m_needsUpdateDrawList = true;
+			m_needs_update_drawlist = true;
 	}
 
 	/*
@@ -131,7 +131,7 @@ public:
 	void updateDrawList();
 	void updateDrawListShadow(const v3f &shadow_light_pos, const v3f &shadow_light_dir, float shadow_range);
 	// Returns true if draw list needs updating before drawing the next frame.
-	bool needsUpdateDrawList() { return m_needsUpdateDrawList; }
+	bool needsUpdateDrawList() { return m_needs_update_drawlist; }
 	void renderMap(video::IVideoDriver* driver, s32 pass);
 
 	void renderMapShadows(video::IVideoDriver *driver,
@@ -182,7 +182,7 @@ private:
 
 	std::map<v3s16, MapBlock*, MapBlockComparer> m_drawlist;
 	std::map<v3s16, MapBlock*> m_drawlist_shadow;
-	bool m_needsUpdateDrawList;
+	bool m_needs_update_drawlist;
 
 	std::set<v2s16> m_last_drawn_sectors;
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3894,8 +3894,8 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	v3f camera_direction = camera->getDirection();
 	if (runData.update_draw_list_timer >= update_draw_list_delta
 			|| runData.update_draw_list_last_cam_dir.getDistanceFrom(camera_direction) > 0.2
-			|| m_camera_offset_changed) {
-
+			|| m_camera_offset_changed
+			|| client->getEnv().getClientMap().needsUpdateDrawList()) {
 		runData.update_draw_list_timer = 0;
 		client->getEnv().getClientMap().updateDrawList();
 		runData.update_draw_list_last_cam_dir = camera_direction;


### PR DESCRIPTION
This PR is extracted from #11130 and implements rendering order for mapblocks, providing two benefits:

* Early-Z by rendering solid meshes from closest to farthest.
* Rendering translucent meshes from farthest to closest to solve some of transparency artifacts.

This PR is Ready for Review.

## How to test

Place two transparent objects (columns, walls, cubes) etc. 20 nodes away from each other and walk around them. The objects will always be rendered correctly when overlapping each other.