### PR TITLE
Preload meshes at startup

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -378,8 +378,14 @@ public:
 	virtual ParticleManager* getParticleManager();
 	bool checkLocalPrivilege(const std::string &priv)
 	{ return checkPrivilege(priv); }
-	virtual scene::IAnimatedMesh* getMesh(const std::string &filename, bool cache = false);
 	const std::string* getModFile(std::string filename);
+
+	/*
+	 * Get a mesh by filename.
+	 * If cache=true the mesh is shared globally, if not it returns a copy.
+	 * The returned pointer should be dropped.
+	 */
+	scene::IAnimatedMesh* getMesh(const std::string &filename, bool cache = false);
 
 	std::string getModStoragePath() const override;
 	bool registerModStorage(ModMetadata *meta) override;
@@ -574,8 +580,8 @@ private:
 	// key = name
 	std::unordered_map<std::string, Inventory*> m_detached_inventories;
 
-	// Storage for mesh data for creating multiple instances of the same mesh
-	StringMap m_mesh_data;
+	// Storage for loaded meshes
+	std::unordered_map<std::string, scene::IAnimatedMesh*> m_meshes;
 
 	// own state
 	LocalClientState m_state;

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -23,6 +23,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrMap.h"
 #include <cmath>
 #include <iostream>
+#include <IMesh.h>
+#include <SMesh.h>
+#include <IMeshBuffer.h>
+#include <SMeshBuffer.h>
 #include <IAnimatedMesh.h>
 #include <SAnimatedMesh.h>
 #include <IAnimatedMeshSceneNode.h>
@@ -394,8 +398,21 @@ scene::SMesh* cloneMesh(scene::IMesh *src_mesh)
 			src_mesh->getMeshBuffer(j));
 		dst_mesh->addMeshBuffer(temp_buf);
 		temp_buf->drop();
-
 	}
+	dst_mesh->setBoundingBox(src_mesh->getBoundingBox());
+	return dst_mesh;
+}
+
+scene::SAnimatedMesh *cloneMesh(scene::IAnimatedMesh *src_mesh)
+{
+	auto dst_mesh = new scene::SAnimatedMesh();
+	for (u32 i = 0; i < src_mesh->getFrameCount(); i++) {
+		auto *temp_mesh = cloneMesh(src_mesh->getMesh(i));
+		dst_mesh->addMesh(temp_mesh);
+		temp_mesh->drop();
+	}
+	dst_mesh->setAnimationSpeed(src_mesh->getAnimationSpeed());
+	dst_mesh->setBoundingBox(src_mesh->getBoundingBox());
 	return dst_mesh;
 }
 

--- a/src/client/mesh.h
+++ b/src/client/mesh.h
@@ -19,8 +19,17 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes_bloated.h"
 #include "nodedef.h"
+
+namespace irr { namespace scene {
+	class IAnimatedMesh;
+	class IAnimatedMeshSceneNode;
+	class IMesh;
+	class IMeshBuffer;
+	class SAnimatedMesh;
+	class SMesh;
+}};
 
 /*!
  * Applies shading to a color based on the surface's
@@ -104,15 +113,21 @@ void rotateMeshXZby (scene::IMesh *mesh, f64 degrees);
 void rotateMeshYZby (scene::IMesh *mesh, f64 degrees);
 
 /*
- *  Clone the mesh buffer.
+ *  Clone a mesh buffer.
  *  The returned pointer should be dropped.
+ *  Does not copy the material.
  */
 scene::IMeshBuffer* cloneMeshBuffer(scene::IMeshBuffer *mesh_buffer);
 
 /*
-	Clone the mesh.
+	Clone a mesh.
 */
 scene::SMesh* cloneMesh(scene::IMesh *src_mesh);
+
+/*
+	Clone an animated mesh.
+*/
+scene::SAnimatedMesh *cloneMesh(scene::IAnimatedMesh *src_mesh);
 
 /*
 	Convert nodeboxes to mesh. Each tile goes into a different buffer.

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -955,7 +955,6 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 		if (mesh_ptr[0]){
 			v3f scale = v3f(1.0, 1.0, 1.0) * BS * visual_scale;
 			scaleMesh(mesh_ptr[0], scale);
-			recalculateBoundingBox(mesh_ptr[0]);
 			meshmanip->recalculateNormals(mesh_ptr[0], true, false);
 		}
 	}

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -56,7 +56,6 @@ public:
 	IRollbackManager *getRollbackManager() { return m_rollbackmgr; }
 	EmergeManager *getEmergeManager() { return m_emergemgr; }
 
-	scene::IAnimatedMesh *getMesh(const std::string &filename) { return NULL; }
 	bool checkLocalPrivilege(const std::string &priv) { return false; }
 	u16 allocateUnknownNodeId(const std::string &name) { return 0; }
 


### PR DESCRIPTION
It has always seemed weird to me that Minetest parses mesh files *every time* it needs a mesh object to work with (e.g. every time an entity is spawned). So I wrote some code to do it the more obvious way: load meshes once at startup

<b>However I'm entirely unsure whether there is any point in doing this</b>

## To do

This PR is Ready for Review.

## Testing RAM usage

First pick a game/mod set that's *not* just bare MTG.

(Before PR) put this in some `Client` function you can easily trigger:

```cpp
u32 total = 0;
for (auto it : m_mesh_data)
        total += it.second.size();
printf("Size of mesh file data: %.1f KB\n", total / 1024.0f);
```
You should see something like `Size of mesh file data: 4089.3 KB`

(After PR) put this in some `Client` function you can easily trigger:
```cpp
u32 total = 0;
for (auto it : m_meshes) {
        for (u32 i = 0; i < it.second->getFrameCount(); i++) {
                auto mesh = it.second->getMesh(i);
                for (u32 j = 0; j < mesh->getMeshBufferCount(); j++) {
                        auto buf = mesh->getMeshBuffer(j);
                        total += buf->getIndexCount() * sizeof(u16) + buf->getVertexCount() * sizeof(video::S3DVertex);
                }
        }
}
printf("Size of mesh objects: %.1f KB\n", total / 1024.0f);
```
You should see something like `Size of mesh objects: 30336.0 KB`