### PR TITLE
Fix item duplication if player dies during interact callback

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -507,6 +507,8 @@ private:
 	void DeleteClient(session_t peer_id, ClientDeletionReason reason);
 	void UpdateCrafting(RemotePlayer *player);
 	bool checkInteractDistance(RemotePlayer *player, const f32 d, const std::string &what);
+	void updateWieldedItem(PlayerSAO *playersao, const ItemStack &item,
+		const char *from_callback);
 
 	void handleChatInterfaceEvent(ChatEvent *evt);
 


### PR DESCRIPTION
This fixes #6546 with the workaround proposed multiple times (discarding the item). Despite not fixing the underlying problem I think this is reasonable IMO.

There's one issue left unfixed:
The last item you eat before dying will not be subtracted from the stack, ~~MTG~~ `core.do_item_eat` would have to handle this.

## To do

This PR is Ready for Review.

## How to test

Eat MTG `flowers:mushroom_red` until you die, make sure you are not holding a copy of the stack after dying.
