### PR TITLE
[no squash] Implement tool use sound

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7959,6 +7959,12 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
 
             eat = <SimpleSoundSpec>,
             -- When item is eaten with `minetest.do_item_eat`
+
+            punch_use = <SimpleSoundSpec>,
+            -- When item is used with the 'punch/mine' key pointing at a node or entity
+
+            punch_use_air = <SimpleSoundSpec>,
+            -- When item is used with the 'punch/mine' key pointing at nothing (air)
         },
 
         on_place = function(itemstack, placer, pointed_thing),

--- a/games/devtest/mods/soundstuff/init.lua
+++ b/games/devtest/mods/soundstuff/init.lua
@@ -136,6 +136,35 @@ minetest.register_tool("soundstuff:breaks", {
 	},
 })
 
+
+minetest.register_tool("soundstuff:punch_use", {
+	description = "Punch Use Sound Tool\n"..
+		"Digs cracky=3 and more\n"..
+		"Makes a sound when used on node or entity",
+	inventory_image = "soundstuff_node_dig.png",
+	sound = {
+		punch_use = { name = "soundstuff_mono", gain = 1.0 },
+	},
+	tool_capabilities = {
+		max_drop_level=0,
+		groupcaps={
+			cracky={times={[2]=2.00, [3]=1.20}, uses=0, maxlevel=0},
+			choppy={times={[2]=2.00, [3]=1.20}, uses=0, maxlevel=0},
+			snappy={times={[2]=2.00, [3]=1.20}, uses=0, maxlevel=0},
+			crumbly={times={[2]=2.00, [3]=1.20}, uses=0, maxlevel=0},
+		},
+	},
+})
+
+minetest.register_tool("soundstuff:punch_use_air", {
+	description = "Punch Use (Air) Sound Tool\n"..
+		"Makes a sound when used pointing at nothing",
+	inventory_image = "soundstuff_node_dig.png",
+	sound = {
+		punch_use_air = { name = "soundstuff_mono", gain = 1.0 },
+	},
+})
+
 -- Plays sound repeatedly
 minetest.register_node("soundstuff:positional", {
 	description = "Positional Sound Node",

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -239,7 +239,7 @@ public:
 	Client *m_client;
 };
 
-class NodeDugEvent: public MtEvent
+class NodeDugEvent : public MtEvent
 {
 public:
 	v3s16 p;
@@ -249,16 +249,14 @@ public:
 		p(p),
 		n(n)
 	{}
-	MtEvent::Type getType() const
-	{
-		return MtEvent::NODE_DUG;
-	}
+	Type getType() const { return NODE_DUG; }
 };
 
 class SoundMaker
 {
 	ISoundManager *m_sound;
 	const NodeDefManager *m_ndef;
+
 public:
 	bool makes_footstep_sound;
 	float m_player_step_timer;
@@ -3610,18 +3608,19 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 	// See also: serverpackethandle.cpp, action == 2
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
 	ClientMap &map = client->getEnv().getClientMap();
-	MapNode n = client->getEnv().getClientMap().getNode(nodepos);
+	MapNode n = map.getNode(nodepos);
+	const auto &features = nodedef_manager->get(n);
 
 	// NOTE: Similar piece of code exists on the server side for
 	// cheat detection.
 	// Get digging parameters
-	DigParams params = getDigParams(nodedef_manager->get(n).groups,
+	DigParams params = getDigParams(features.groups,
 			&selected_item.getToolCapabilities(itemdef_manager),
 			selected_item.wear);
 
 	// If can't dig, try hand
 	if (!params.diggable) {
-		params = getDigParams(nodedef_manager->get(n).groups,
+		params = getDigParams(features.groups,
 				&hand_item.getToolCapabilities(itemdef_manager));
 	}
 
@@ -3632,7 +3631,6 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 		runData.dig_time_complete = params.time;
 
 		if (m_cache_enable_particles) {
-			const ContentFeatures &features = client->getNodeDefManager()->get(n);
 			client->getParticleManager()->addNodeParticle(client,
 					player, nodepos, n, features);
 		}
@@ -3643,6 +3641,7 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 		runData.dig_instantly = runData.dig_time_complete == 0;
 		if (client->modsLoaded() && client->getScript()->on_punchnode(nodepos, n))
 			return;
+
 		client->interact(INTERACT_START_DIGGING, pointed);
 		runData.digging = true;
 		runData.btn_down_for_dig = true;
@@ -3657,7 +3656,7 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 		runData.dig_index = crack_animation_length;
 	}
 
-	SimpleSoundSpec sound_dig = nodedef_manager->get(n).sound_dig;
+	const auto &sound_dig = features.sound_dig;
 
 	if (sound_dig.exists() && params.diggable) {
 		if (sound_dig.name == "__group") {
@@ -3675,8 +3674,6 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 	// Don't show cracks if not diggable
 	if (runData.dig_time_complete >= 100000.0) {
 	} else if (runData.dig_index < crack_animation_length) {
-		//TimeTaker timer("client.setTempMod");
-		//infostream<<"dig_index="<<dig_index<<std::endl;
 		client->setCrack(runData.dig_index, nodepos);
 	} else {
 		infostream << "Digging completed" << std::endl;
@@ -3698,38 +3695,31 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 		else if (runData.dig_instantly)
 			runData.nodig_delay_timer = 0.15;
 
-		bool is_valid_position;
-		MapNode wasnode = map.getNode(nodepos, &is_valid_position);
-		if (is_valid_position) {
-			if (client->modsLoaded() &&
-					client->getScript()->on_dignode(nodepos, wasnode)) {
-				return;
-			}
-
-			const ContentFeatures &f = client->ndef()->get(wasnode);
-			if (f.node_dig_prediction == "air") {
-				client->removeNode(nodepos);
-			} else if (!f.node_dig_prediction.empty()) {
-				content_t id;
-				bool found = client->ndef()->getId(f.node_dig_prediction, id);
-				if (found)
-					client->addNode(nodepos, id, true);
-			}
-			// implicit else: no prediction
+		if (client->modsLoaded() &&
+				client->getScript()->on_dignode(nodepos, n)) {
+			return;
 		}
+
+		if (features.node_dig_prediction == "air") {
+			client->removeNode(nodepos);
+		} else if (!features.node_dig_prediction.empty()) {
+			content_t id;
+			bool found = nodedef_manager->getId(features.node_dig_prediction, id);
+			if (found)
+				client->addNode(nodepos, id, true);
+		}
+		// implicit else: no prediction
 
 		client->interact(INTERACT_DIGGING_COMPLETED, pointed);
 
 		if (m_cache_enable_particles) {
-			const ContentFeatures &features =
-				client->getNodeDefManager()->get(wasnode);
 			client->getParticleManager()->addDiggingParticles(client,
-				player, nodepos, wasnode, features);
+				player, nodepos, n, features);
 		}
 
 
 		// Send event to trigger sound
-		client->getEventManager()->put(new NodeDugEvent(nodepos, wasnode));
+		client->getEventManager()->put(new NodeDugEvent(nodepos, n));
 	}
 
 	if (runData.dig_time_complete < 100000.0) {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -264,6 +264,8 @@ public:
 
 	SimpleSoundSpec m_player_step_sound;
 	SimpleSoundSpec m_player_leftpunch_sound;
+	// Second sound made on left punch, currently used for item 'use' sound
+	SimpleSoundSpec m_player_leftpunch_sound2;
 	SimpleSoundSpec m_player_rightpunch_sound;
 
 	SoundMaker(ISoundManager *sound, const NodeDefManager *ndef):
@@ -314,6 +316,7 @@ public:
 	{
 		SoundMaker *sm = (SoundMaker *)data;
 		sm->m_sound->playSound(sm->m_player_leftpunch_sound);
+		sm->m_sound->playSound(sm->m_player_leftpunch_sound2);
 	}
 
 	static void cameraPunchRight(MtEvent *e, void *data)
@@ -3148,7 +3151,9 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 
 	runData.punching = false;
 
-	soundmaker->m_player_leftpunch_sound.name.clear();
+	soundmaker->m_player_leftpunch_sound = SimpleSoundSpec();
+	soundmaker->m_player_leftpunch_sound2 = pointed.type != POINTEDTHING_NOTHING ?
+		selected_def.sound_use : selected_def.sound_use_air;
 
 	// Prepare for repeating, unless we're not supposed to
 	if (isKeyDown(KeyType::PLACE) && !g_settings->getBool("safe_dig_and_place"))

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -250,7 +250,7 @@ std::string ItemStack::getItemString(bool include_meta) const
 	return os.str();
 }
 
-std::string ItemStack::getDescription(IItemDefManager *itemdef) const
+std::string ItemStack::getDescription(const IItemDefManager *itemdef) const
 {
 	std::string desc = metadata.getString("description");
 	if (desc.empty())
@@ -258,7 +258,7 @@ std::string ItemStack::getDescription(IItemDefManager *itemdef) const
 	return desc.empty() ? name : desc;
 }
 
-std::string ItemStack::getShortDescription(IItemDefManager *itemdef) const
+std::string ItemStack::getShortDescription(const IItemDefManager *itemdef) const
 {
 	std::string desc = metadata.getString("short_description");
 	if (desc.empty())

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -48,8 +48,8 @@ struct ItemStack
 	// Returns the string used for inventory
 	std::string getItemString(bool include_meta = true) const;
 	// Returns the tooltip
-	std::string getDescription(IItemDefManager *itemdef) const;
-	std::string getShortDescription(IItemDefManager *itemdef) const;
+	std::string getDescription(const IItemDefManager *itemdef) const;
+	std::string getShortDescription(const IItemDefManager *itemdef) const;
 
 	/*
 		Quantity methods
@@ -82,13 +82,13 @@ struct ItemStack
 	}
 
 	// Maximum size of a stack
-	u16 getStackMax(IItemDefManager *itemdef) const
+	u16 getStackMax(const IItemDefManager *itemdef) const
 	{
 		return itemdef->get(name).stack_max;
 	}
 
 	// Number of items that can be added to this stack
-	u16 freeSpace(IItemDefManager *itemdef) const
+	u16 freeSpace(const IItemDefManager *itemdef) const
 	{
 		u16 max = getStackMax(itemdef);
 		if (count >= max)
@@ -97,7 +97,7 @@ struct ItemStack
 	}
 
 	// Returns false if item is not known and cannot be used
-	bool isKnown(IItemDefManager *itemdef) const
+	bool isKnown(const IItemDefManager *itemdef) const
 	{
 		return itemdef->isKnown(name);
 	}
@@ -105,14 +105,14 @@ struct ItemStack
 	// Returns a pointer to the item definition struct,
 	// or a fallback one (name="unknown") if the item is unknown.
 	const ItemDefinition& getDefinition(
-			IItemDefManager *itemdef) const
+			const IItemDefManager *itemdef) const
 	{
 		return itemdef->get(name);
 	}
 
 	// Get tool digging properties, or those of the hand if not a tool
 	const ToolCapabilities& getToolCapabilities(
-			IItemDefManager *itemdef) const
+			const IItemDefManager *itemdef) const
 	{
 		const ToolCapabilities *item_cap =
 			itemdef->get(name).tool_capabilities;
@@ -127,7 +127,7 @@ struct ItemStack
 
 	// Wear out (only tools)
 	// Returns true if the item is (was) a tool
-	bool addWear(s32 amount, IItemDefManager *itemdef)
+	bool addWear(s32 amount, const IItemDefManager *itemdef)
 	{
 		if(getDefinition(itemdef).type == ITEM_TOOL)
 		{

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -78,6 +78,8 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	place_param2 = def.place_param2;
 	sound_place = def.sound_place;
 	sound_place_failed = def.sound_place_failed;
+	sound_use = def.sound_use;
+	sound_use_air = def.sound_use_air;
 	range = def.range;
 	palette_image = def.palette_image;
 	color = def.color;
@@ -117,6 +119,8 @@ void ItemDefinition::reset()
 	groups.clear();
 	sound_place = SimpleSoundSpec();
 	sound_place_failed = SimpleSoundSpec();
+	sound_use = SimpleSoundSpec();
+	sound_use_air = SimpleSoundSpec();
 	range = -1;
 	node_placement_prediction.clear();
 	place_param2 = 0;
@@ -166,6 +170,9 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	os << serializeString16(short_description);
 
 	os << place_param2;
+
+	sound_use.serialize(os, protocol_version);
+	sound_use_air.serialize(os, protocol_version);
 }
 
 void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
@@ -214,12 +221,15 @@ void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
 	inventory_overlay = deSerializeString16(is);
 	wield_overlay = deSerializeString16(is);
 
-	// If you add anything here, insert it primarily inside the try-catch
+	// If you add anything here, insert it inside the try-catch
 	// block to not need to increase the version.
 	try {
 		short_description = deSerializeString16(is);
 
 		place_param2 = readU8(is); // 0 if missing
+
+		sound_use.deSerialize(is, protocol_version);
+		sound_use_air.deSerialize(is, protocol_version);
 	} catch(SerializationError &e) {};
 }
 

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -80,6 +80,7 @@ struct ItemDefinition
 	ItemGroupList groups;
 	SimpleSoundSpec sound_place;
 	SimpleSoundSpec sound_place_failed;
+	SimpleSoundSpec sound_use, sound_use_air;
 	f32 range;
 
 	// Client shall immediately place this node when player places the item.

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -112,6 +112,19 @@ void read_item_definition(lua_State* L, int index,
 	}
 	lua_pop(L, 1);
 
+	// No, this is not a mistake. Item sounds are in "sound", node sounds in "sounds".
+	lua_getfield(L, index, "sound");
+	if (!lua_isnil(L, -1)) {
+		luaL_checktype(L, -1, LUA_TTABLE);
+		lua_getfield(L, -1, "punch_use");
+		read_soundspec(L, -1, def.sound_use);
+		lua_pop(L, 1);
+		lua_getfield(L, -1, "punch_use_air");
+		read_soundspec(L, -1, def.sound_use_air);
+		lua_pop(L, 1);
+	}
+	lua_pop(L, 1);
+
 	def.range = getfloatfield_default(L, index, "range", def.range);
 
 	// Client shall immediately place this node when player places the item.


### PR DESCRIPTION
fixes #11586

~~<b>Open question</b>:  When digging using a tool with a sound, should the sound play for each swing or on the first one?
I initially thought only the first, but each swing is easier to get right and probably makes more sense anyway.~~

## To do

This PR is Ready for Review.

## How to test

devtest `soundstuff:punch_use` and `soundstuff:punch_use_air`
try to punch:
* a node (digging)
* an entity
* nothing
