### PR TITLE
Add variable to use existing IrrlichtMt build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,6 @@ set(BUILD_CLIENT TRUE CACHE BOOL "Build client")
 set(BUILD_SERVER FALSE CACHE BOOL "Build server")
 set(BUILD_UNITTESTS TRUE CACHE BOOL "Build unittests")
 
-
 set(WARN_ALL TRUE CACHE BOOL "Enable -Wall for Release build")
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -64,8 +63,18 @@ endif()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 
+set(IRRLICHTMT_BUILD_DIR "" CACHE PATH "Path to IrrlichtMt build directory.")
+if(NOT "${IRRLICHTMT_BUILD_DIR}" STREQUAL "")
+	find_package(IrrlichtMt QUIET PATHS "${IRRLICHTMT_BUILD_DIR}")
+
+	if(NOT TARGET IrrlichtMt::IrrlichtMt)
+		# find_package() searches certain subdirectories. ${PATH}/cmake is not
+		# the only one, but it is the one where IrrlichtMt is supposed to export
+		# IrrlichtMtConfig.cmake
+		message(FATAL_ERROR "Could not find IrrlichtMtConfig.cmake in ${IRRLICHTMT_BUILD_DIR}/cmake.")
+	endif()
 # This is done here so that relative search paths are more reasonable
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lib/irrlichtmt")
+elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lib/irrlichtmt")
 	message(STATUS "Using user-provided IrrlichtMt at subdirectory 'lib/irrlichtmt'")
 	if(BUILD_CLIENT)
 		# tell IrrlichtMt to create a static library
@@ -101,9 +110,11 @@ else()
 		# Note that we can't use target_include_directories() since that doesn't work for IMPORTED targets before CMake 3.11
 		set_target_properties(IrrlichtMt::IrrlichtMt PROPERTIES
 			INTERFACE_INCLUDE_DIRECTORIES "${IRRLICHT_INCLUDE_DIR}")
-	else()
-		message(STATUS "Found IrrlichtMt ${IrrlichtMt_VERSION}")
 	endif()
+endif()
+
+if(TARGET IrrlichtMt::IrrlichtMt)
+	message(STATUS "Found IrrlichtMt ${IrrlichtMt_VERSION}")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 set(IRRLICHTMT_BUILD_DIR "" CACHE PATH "Path to IrrlichtMt build directory.")
 if(NOT "${IRRLICHTMT_BUILD_DIR}" STREQUAL "")
-	find_package(IrrlichtMt QUIET PATHS "${IRRLICHTMT_BUILD_DIR}")
+	find_package(IrrlichtMt QUIET
+		PATHS "${IRRLICHTMT_BUILD_DIR}"
+		NO_DEFAULT_PATH
+)
 
 	if(NOT TARGET IrrlichtMt::IrrlichtMt)
 		# find_package() searches certain subdirectories. ${PATH}/cmake is not

--- a/README.md
+++ b/README.md
@@ -224,10 +224,13 @@ Run it:
   - Debug build is slower, but gives much more useful output in a debugger.
 - If you build a bare server you don't need to have the Irrlicht or IrrlichtMt library installed.
   - In that case use `-DIRRLICHT_INCLUDE_DIR=/some/where/irrlicht/include`.
-- IrrlichtMt can also be installed somewhere that is not a standard install path.
-  - In that case use `-DCMAKE_PREFIX_PATH=/path/to/install_prefix`
-  - The path must be set so that `$(CMAKE_PREFIX_PATH)/lib/cmake/IrrlichtMt` exists
-    or that `$(CMAKE_PREFIX_PATH)` is the path of an IrrlichtMt build folder.
+
+- Minetest will look for IrrlichtMt in four steps.
+  1. If the `IRRLICHTMT_BUILD_DIR` variable is set, it takes precedence above all else.
+  2. If no build directory is selected, CMake will use `${PROJECT_SOURCE_DIR}/lib/irrlichtmt` if it exists.
+  3. If the first two steps fail, CMake will look for an IrrlichtMt install in standard root paths.
+  4. If all else fails, `IRRLICHT_INCLUDE_DIR` is set and `BUILD_CLIENT` is turned off, the headers from the include dir will be used.
+  - NOTE: Changing the IrrlichtMt build dir (includes system installs) will require regenerating CMakeCache.txt or clearing the `IrrlichtMt_DIR` variable.
 
 ### CMake options
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Run it:
   2. `${PROJECT_SOURCE_DIR}/lib/irrlichtmt` (if existent)
   3. Installation of IrrlichtMt in the system-specific library paths
   4. For server builds with disabled `BUILD_CLIENT` variable, the headers from `IRRLICHT_INCLUDE_DIR` will be used.
-  - NOTE: Changing the IrrlichtMt build directory (includes system installs) requires regenerating `CMakeCache.txt` or clearing the `IrrlichtMt_DIR` variable.
+  - NOTE: Changing the IrrlichtMt build directory (includes system installs) requires regenerating the CMake cache (`rm CMakeCache.txt`)
 
 ### CMake options
 

--- a/README.md
+++ b/README.md
@@ -225,12 +225,12 @@ Run it:
 - If you build a bare server you don't need to have the Irrlicht or IrrlichtMt library installed.
   - In that case use `-DIRRLICHT_INCLUDE_DIR=/some/where/irrlicht/include`.
 
-- Minetest will look for IrrlichtMt in four steps.
-  1. If the `IRRLICHTMT_BUILD_DIR` variable is set, it takes precedence above all else.
-  2. If no build directory is selected, CMake will use `${PROJECT_SOURCE_DIR}/lib/irrlichtmt` if it exists.
-  3. If the first two steps fail, CMake will look for an IrrlichtMt install in standard root paths.
-  4. If all else fails, `IRRLICHT_INCLUDE_DIR` is set and `BUILD_CLIENT` is turned off, the headers from the include dir will be used.
-  - NOTE: Changing the IrrlichtMt build dir (includes system installs) will require regenerating CMakeCache.txt or clearing the `IrrlichtMt_DIR` variable.
+- Minetest will use the IrrlichtMt package that is found first, given by the following order:
+  1. Specified `IRRLICHTMT_BUILD_DIR` CMake variable
+  2. `${PROJECT_SOURCE_DIR}/lib/irrlichtmt` (if existent)
+  3. Installation of IrrlichtMt in the system-specific library paths
+  4. For server builds with disabled `BUILD_CLIENT` variable, the headers from `IRRLICHT_INCLUDE_DIR` will be used.
+  - NOTE: Changing the IrrlichtMt build directory (includes system installs) requires regenerating `CMakeCache.txt` or clearing the `IrrlichtMt_DIR` variable.
 
 ### CMake options
 


### PR DESCRIPTION
This adds a variable IRRLICHTMT_BUILD_DIR to specify an existing IrrlichtMt build to use in the configuration. The order in which CMake will search for IrrlichtMt in various locations has been fully documented in README.md.

- The documentation is probably the most important part of this PR, because it finally explains how the whole IrrlichtMt thing is supposed to work.
- This could be useful if you use multiple IrrlichtMt branches and want to choose a specific one for each build.

## To do

Ready for Review

## How to test

Testing is pretty self-explanatory. If I needed to explain how here, it would mean the documentation is insufficient.
