### PR TITLE
Allow to set maximum star opacity at daytime

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6907,6 +6907,9 @@ object you are working with still exists.
     * `star_parameters` is a table with the following optional fields:
         * `visible`: Boolean for whether the stars are visible.
             (default: `true`)
+        * `day_opacity`: Float for maximum opacity of stars at day.
+            No effect if `visible` is false.
+            (default: 0.0; maximum: 1.0; minimum: 0.0)
         * `count`: Integer number to set the number of stars in
             the skybox. Only applies to `"skybox"` and `"regular"` sky types.
             (default: `1000`)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2877,6 +2877,7 @@ void Game::handleClientEvent_SetStars(ClientEvent *event, CameraOrientation *cam
 	sky->setStarCount(event->star_params->count);
 	sky->setStarColor(event->star_params->starcolor);
 	sky->setStarScale(event->star_params->scale);
+	sky->setStarDayOpacity(event->star_params->day_opacity);
 	delete event->star_params;
 }
 

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -660,9 +660,12 @@ void Sky::draw_stars(video::IVideoDriver * driver, float wicked_time_of_day)
 	// to time 4000.
 
 	float tod = wicked_time_of_day < 0.5f ? wicked_time_of_day : (1.0f - wicked_time_of_day);
-	float starbrightness = (0.25f - fabsf(tod)) * 20.0f;
+	float day_opacity = clamp(m_star_params.day_opacity, 0.0f, 1.0f);
+	float starbrightness = (0.25f - fabs(tod)) * 20.0f;
+	float alpha = clamp(starbrightness, day_opacity, 1.0f);
+
 	m_star_color = m_star_params.starcolor;
-	m_star_color.a *= clamp(starbrightness, 0.0f, 1.0f);
+	m_star_color.a *= alpha;
 	if (m_star_color.a <= 0.0f) // Stars are only drawn when not fully transparent
 		return;
 	m_materials[0].DiffuseColor = m_materials[0].EmissiveColor = m_star_color.toSColor();

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -80,6 +80,7 @@ public:
 	void setStarCount(u16 star_count);
 	void setStarColor(video::SColor star_color) { m_star_params.starcolor = star_color; }
 	void setStarScale(f32 star_scale) { m_star_params.scale = star_scale; updateStars(); }
+	void setStarDayOpacity(f32 day_opacity) { m_star_params.day_opacity = day_opacity; }
 
 	bool getCloudsVisible() const { return m_clouds_visible && m_clouds_enabled; }
 	const video::SColorf &getCloudColor() const { return m_cloudcolor_f; }

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1331,10 +1331,13 @@ void Client::handleCommand_HudSetMoon(NetworkPacket *pkt)
 
 void Client::handleCommand_HudSetStars(NetworkPacket *pkt)
 {
-	StarParams stars;
+	StarParams stars = SkyboxDefaults::getStarDefaults();
 
 	*pkt >> stars.visible >> stars.count
 		>> stars.starcolor >> stars.scale;
+	try {
+		*pkt >> stars.day_opacity;
+	} catch (PacketError &e) {};
 
 	ClientEvent *event = new ClientEvent();
 	event->type        = CE_SET_STARS;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -735,6 +735,7 @@ enum ToClientCommand
 		u32 count
 		u8[4] starcolor (ARGB)
 		f32 scale
+		f32 day_opacity
 	*/
 
 	TOCLIENT_SRP_BYTES_S_B = 0x60,

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2069,6 +2069,9 @@ int ObjectRef::l_set_stars(lua_State *L)
 			"scale", star_params.scale);
 	}
 
+	star_params.day_opacity = getfloatfield_default(L, 2,
+		"day_opacity", star_params.day_opacity);
+
 	getServer(L)->setStars(player, star_params);
 	lua_pushboolean(L, true);
 	return 1;
@@ -2094,6 +2097,8 @@ int ObjectRef::l_get_stars(lua_State *L)
 	lua_setfield(L, -2, "star_color");
 	lua_pushnumber(L, star_params.scale);
 	lua_setfield(L, -2, "scale");
+	lua_pushnumber(L, star_params.day_opacity);
+	lua_setfield(L, -2, "day_opacity");
 	return 1;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1771,7 +1771,8 @@ void Server::SendSetStars(session_t peer_id, const StarParams &params)
 	NetworkPacket pkt(TOCLIENT_SET_STARS, 0, peer_id);
 
 	pkt << params.visible << params.count
-		<< params.starcolor << params.scale;
+		<< params.starcolor << params.scale
+		<< params.day_opacity;
 
 	Send(&pkt);
 }

--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -66,6 +66,7 @@ struct StarParams
 	u32 count;
 	video::SColor starcolor;
 	f32 scale;
+	f32 day_opacity;
 };
 
 struct CloudParams
@@ -141,6 +142,7 @@ public:
 		stars.count = 1000;
 		stars.starcolor = video::SColor(105, 235, 235, 255);
 		stars.scale = 1;
+		stars.day_opacity = 0;
 		return stars;
 	}
 


### PR DESCRIPTION
Fixes #9887. Successor of #10541.

This PR adds a new Lua API feature to `player:set_stars`: `day_opacity`. This is a floating point number between 0.0 and 1.0. It sets the maximum opacity of stars at daytime, with 1.0 meaning fullbright stars (same as night) and 0.0 being fully invisible.

Technically, the mechanism to do this is very simple: A value of X just means the star opacity is capped at X at daytime, meaning it cannot get more opaque during the day.

The default value is 0.0 and this feature is backwards-compatible. I've tested a 5.5.0-dev client on a 5.4.0 server and it worked.

Note: The word "opacity" here means the opacity of the stars BEFORE `star_color` is applied. This means "full opacity" here means that the full effect color of `star_color` is applied, it does not neccessarily mean that the stars are actually fully opaque. Stars never get more opaque than the alpha value of the `star_color`, like before. This is NOT new behavior, I just pointed that out for clarity.

## To do

Ready for review.

## How to test

Function test in 5.5.0-dev:

* Activate the `luacmd` mod
* Start DevTest
* `/lua me:set_stars({star_color="#FF0000FF"})` (this is optional, but red stars are better for testing; also note the default `star_color` is not fully opaque, so don't be surprised if `day_opacity=1` doesn't make the stars fully opaque when using the default `star_color`)
* `/time 12000`
* Check sky (expected: no stars)
* `/lua me:set_stars({day_opacity=1})`
* Check sky (expected: visible stars)
* `/lua me:set_stars({day_opacity=0})`
* Check sky again (expected: no stars)
* `/time 0`
* Check sky again (expected: visible stars)
* `/lua me:set_stars({day_opacity=1})`
* Check sky again (expected: visible stars)
* `/time 12000`
* `/lua me:set_stars({day_opacity=0.75})`
* Check sky again (expected: reduced opacity stars)

Feel free to try out other opacity values.
Also try to let a full day/night circle complete (under various conditions) to check whether the transition is still smooth in all cases. You could do `/set time_speed 300` to speed things up.

Compability test:

* Launch a 5.4.1 server
* Connect with your compiled -dev client to it
* Watch the sky at night and at day; for compability reasons, the stars should behave in the default way (visible at night, not visible at day)
