### PR TITLE
Make MetaDataRef:get() return nil instead of nothing

### DIFF
--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -82,9 +82,10 @@ int MetaDataRef::l_get(lua_State *L)
 	std::string str;
 	if (meta->getStringToRef(name, str)) {
 		lua_pushlstring(L, str.c_str(), str.size());
-		return 1;
+	} else {
+		lua_pushnil(L);
 	}
-	return 0;
+	return 1;
 }
 
 // get_string(self, name)


### PR DESCRIPTION
This is a small bugfix. The documentation says that `MetaDataRef:get()` returns `nil` when it cannot find the key. However, at the moment it returns zero values rather than one nil value when it cannot find the key. That is what this PR fixes. I came upon the issue when I tried to pass the returned value to `tonumber`; `tonumber(nil)` returns `nil`, but `tonumber()` (with no argument) throws an error.

## To do

This PR is Ready for Review.

## How to test

1. Add this code to a mod:
    ```lua
    assert(nil == tonumber(minetest.get_mod_storage():get("lalala")))
    ```
2. Load a world with the mod enabled. With my PR, the world should load. Without my PR, an error should be thrown on startup.
