### PR TITLE
Remove creative/damage info in Esc/Pause menu

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4287,16 +4287,18 @@ void Game::showPauseMenu()
 	if (simple_singleplayer_mode || address.empty()) {
 		static const std::string on = strgettext("On");
 		static const std::string off = strgettext("Off");
-		const std::string &damage = g_settings->getBool("enable_damage") ? on : off;
-		const std::string &creative = g_settings->getBool("creative_mode") ? on : off;
+		// Note: Status of enable_damage and creative_mode settings is intentionally
+		// NOT shown here because the game might roll its own damage system and/or do
+		// a per-player Creative Mode, in which case writing it here would mislead.
+		bool damage = g_settings->getBool("enable_damage");
 		const std::string &announced = g_settings->getBool("server_announce") ? on : off;
-		os << strgettext("- Damage: ") << damage << "\n"
-				<< strgettext("- Creative Mode: ") << creative << "\n";
 		if (!simple_singleplayer_mode) {
-			const std::string &pvp = g_settings->getBool("enable_pvp") ? on : off;
-			//~ PvP = Player versus Player
-			os << strgettext("- PvP: ") << pvp << "\n"
-					<< strgettext("- Public: ") << announced << "\n";
+			if (damage) {
+				const std::string &pvp = g_settings->getBool("enable_pvp") ? on : off;
+				//~ PvP = Player versus Player
+				os << strgettext("- PvP: ") << pvp << "\n";
+			}
+			os << strgettext("- Public: ") << announced << "\n";
 			std::string server_name = g_settings->get("server_name");
 			str_formspec_escape(server_name);
 			if (announced == on && !server_name.empty())


### PR DESCRIPTION
Fixes #11458.

This simple PR removes "Damage: On/Off" and "Creative Mode: On/Off" from the Esc/Pause menu.
The "PvP: On/Off" remains, but is hidden when damage is disabled (since PvP is not possible if damage is disabled).

## Justification

These three things exclusively look at the settings, e.g. `enable_damge`. The lines completely ignore when a game overrides anything. This leads to game bugs that games cannot fix without engine intervention.

Games can and do override/implement both damage handling and Creative Mode handling.
It is common for games to implement a per-player Creative Mode (including MTG) but the Esc menu only shows the value of the `creatve_mode` and `enable_damage` settings. But per-player Creative Mode acts independent from the setting (that's the point). This is therefore a bug that the games cannot fix without giving up on per-player Creative Mode (which is BAD). By hardcoding this line into the Esc menu, Minetest is potentially lying to the player (including in MTG!).

Damage handling is a little bit more esoteric but I can imagine a game in which the developer completely disagrees with the way Minetest does damage and thus ignores all builtin health stuff and somehow rolls their own damage system. To do this, you'd have to disable built-in damage to it doesn't interfere, but then the menu would still say "Damage: Off" which is again misleading.

While there are various solutions to deal with this, I think just removing these two lines entirely is the simplest option. Another solution would be to let games override this field but this is much more work and I decided it's not really worth the effort.

I also think those two lines are not important to begin with. It is relatively obvious to the player whether damage/Creative is enabled for the player. Damage enabled usually means that the hearts appear and Creative Mode enabled means your inventory is different, so I guess nobody would really miss these lines anyway. And even in the rare case the game absolutely needs to display this information explicitly, I think it makes more sense for the game to just do it itselves, rather than trusting MT to do it.

PvP was left in because it's kind of a special case. It's not too obvious an information (unlike damage/creative), especially before you hit any player, and it also doesn't really interfere with other potential game overrides. If a game rolls its own damage system, it will do `enable_damage=false` in which case the "PvP" line disappears, so I think this is OK.

## To do

This PR is ready for review.

## How to test

* Start a game
* Press Esc
* Look what is written in the Esc menu

Repeat this test with all possible combinations of settings (`enable_damage`, `creative_mode` and `enable_pvp`). Check if they match the promises.