### PR TITLE
Add minetest.get_server_max_lag()

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5647,6 +5647,8 @@ Server
       a player joined.
     * This function may be overwritten by mods to customize the status message.
 * `minetest.get_server_uptime()`: returns the server uptime in seconds
+* `minetest.get_server_max_lag()`: returns the current maximum lag
+  of the server in seconds or nil if server is not fully loaded yet
 * `minetest.remove_player(name)`: remove player from database (if they are not
   connected).
     * As auth data is not removed, minetest.player_exists will continue to

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -57,6 +57,17 @@ int ModApiServer::l_get_server_uptime(lua_State *L)
 	return 1;
 }
 
+// get_server_max_lag()
+int ModApiServer::l_get_server_max_lag(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ServerEnvironment *s_env = dynamic_cast<ServerEnvironment *>(getEnv(L));
+	if (!s_env)
+		lua_pushnil(L);
+	else
+		lua_pushnumber(L, s_env->getMaxLagEstimate());
+	return 1;
+}
 
 // print(text)
 int ModApiServer::l_print(lua_State *L)
@@ -512,6 +523,7 @@ void ModApiServer::Initialize(lua_State *L, int top)
 	API_FCT(request_shutdown);
 	API_FCT(get_server_status);
 	API_FCT(get_server_uptime);
+	API_FCT(get_server_max_lag);
 	API_FCT(get_worldpath);
 	API_FCT(is_singleplayer);
 

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -33,6 +33,9 @@ private:
 	// get_server_uptime()
 	static int l_get_server_uptime(lua_State *L);
 
+	// get_server_max_lag()
+	static int l_get_server_max_lag(lua_State *L);
+
 	// get_worldpath()
 	static int l_get_worldpath(lua_State *L);
 


### PR DESCRIPTION
This PR adds the function `minetest.get_server_max_lag()` which is like `minetest.get_server_uptime()` but for `max_lag`.
It returns the current server's `max_lag`, in seconds.
If the server environment is not initialized yet, `nil` is returned instead.

## Rationale
I've heard serveral modders wanted to grab this info but in their desperation they used dirty tricks such as parsing the return value of `minetest.get_server_status()`. This PR means such dirty tricks are no longer neccessary. :D
See also #11077.

## To do

This PR is ready for review.

## How to test

Test 1:
Use `luacmd` and type in chat:

```
/lua print(minetest.get_server_max_lag())`
```

It should output a number.

Test 2:
Try this test mod that immediately tries to get the `max_lag` on startup. Use this code:

```
minetest.log("action", "max_lag="..tostring(minetest.get_server_max_lag()))
```

You should get `max_lag=nil` in the console (since at this early stage the server environment is not fully inited yet).