### PR TITLE
Fix player hp desync between client and server

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -826,7 +826,8 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 				<< std::endl;
 
 		PlayerHPChangeReason reason(PlayerHPChangeReason::FALL);
-		playersao->setHP((s32)playersao->getHP() - (s32)damage, reason);
+		playersao->setHP((s32)playersao->getHP() - (s32)damage, reason, false);
+		SendPlayerHPOrDie(playersao, reason); // correct client side prediction
 	}
 }
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -462,7 +462,7 @@ void PlayerSAO::rightClick(ServerActiveObject *clicker)
 	m_env->getScriptIface()->on_rightclickplayer(this, clicker);
 }
 
-void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
+void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason, bool send)
 {
 	if (hp == (s32)m_hp)
 		return; // Nothing to do
@@ -490,7 +490,8 @@ void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
 	if ((hp == 0) != (oldhp == 0))
 		m_properties_sent = false;
 
-	m_env->getGameDef()->SendPlayerHPOrDie(this, reason);
+	if (send)
+		m_env->getGameDef()->SendPlayerHPOrDie(this, reason);
 }
 
 void PlayerSAO::setBreath(const u16 breath, bool send)

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -112,7 +112,11 @@ public:
 	u16 punch(v3f dir, const ToolCapabilities *toolcap, ServerActiveObject *puncher,
 			float time_from_last_punch);
 	void rightClick(ServerActiveObject *clicker);
-	void setHP(s32 hp, const PlayerHPChangeReason &reason);
+	void setHP(s32 hp, const PlayerHPChangeReason &reason) override
+	{
+		return setHP(hp, reason, true);
+	}
+	void setHP(s32 hp, const PlayerHPChangeReason &reason, bool send);
 	void setHPRaw(u16 hp) { m_hp = hp; }
 	u16 getBreath() const { return m_breath; }
 	void setBreath(const u16 breath, bool send = true);


### PR DESCRIPTION
After #11411 setHP doesn't send hp change if a lua callback rejected it. https://github.com/minetest/minetest/blob/3f1adb49ae8da5bb02bea52609524d3645b6a665/src/server/player_sao.cpp#L474-L476
But it's not always the correct behavior.

When a client sends `TOSERVER_DAMAGE` packet it already has changed client side hp according to damage. If a server rejected the damage it must send old hp to the client to correct client expectations.

That desync causes problems for example there https://github.com/minetest/minetest/blob/6de8d77e17017cd5cc7b065d42566b6b1cd076cc/src/client/client.cpp#L1294-L1295
The client assumes the player is dead and doesn't send movements.

My fix is to always send player hp in `TOSERVER_DAMAGE` handler.

## To do
This PR is Ready for Review.

## How to test
* Create a mod with this code:
```lua
minetest.register_on_player_hpchange(function()
    return 0
end, true)
```
* Join the server and fall from high ground
* Make sure that the client sends movements to the server
