### PR TITLE
Fix view bobbing not resetting when resting 

### DIFF
--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -186,9 +186,7 @@ void Camera::step(f32 dtime)
 				m_view_bobbing_anim -= offset;
 			} else if (m_view_bobbing_anim > 0.75) {
 				m_view_bobbing_anim += offset;
-			}
-
-			if (m_view_bobbing_anim < 0.5) {
+			} else if (m_view_bobbing_anim < 0.5) {
 				m_view_bobbing_anim += offset;
 				if (m_view_bobbing_anim > 0.5)
 					m_view_bobbing_anim = 0.5;


### PR DESCRIPTION
A pretty trivial PR that partially fixes #11694: View bobbing now resets to 0 when the player rests. This also fixes #11692 in the resting case. Some dead code was removed along the way. Ready for review.