### PR TITLE
Depth sorting for node faces

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -857,6 +857,10 @@ autoscale_mode (Autoscaling mode) enum disable disable,enable,force
 #    A restart is required after changing this.
 show_entity_selectionbox (Show entity selection boxes) bool false
 
+#    Distance in nodes at which transparency depth sorting is enabled
+#    Use this to limit the performance impact of transparency depth sorting
+transparency_sorting_distance (Transparency Sorting Distance) int 16 0 128
+
 [*Menus]
 
 #    Use a cloud animation for the main menu background.

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -101,7 +101,7 @@ ClientMap::ClientMap(
 
 }
 
-void ClientMap::updateCamera(const v3f &pos, const v3f &dir, f32 fov, v3s16 offset)
+void ClientMap::updateCamera(v3f pos, v3f dir, f32 fov, v3s16 offset)
 {
 	v3s16 previous_node = floatToInt(m_camera_position, BS) + m_camera_offset;
 	v3s16 previous_block = getContainerPos(previous_node, MAP_BLOCKSIZE);

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -100,7 +100,7 @@ ClientMap::ClientMap(
 
 }
 
-void ClientMap::updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset)
+void ClientMap::updateCamera(const v3f &pos, const v3f &dir, f32 fov, v3s16 offset)
 {
 	v3s16 previous_node = floatToInt(m_camera_position, BS) + m_camera_offset;
 	v3s16 previous_block = getContainerPos(previous_node, MAP_BLOCKSIZE);

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -783,7 +783,7 @@ void ClientMap::renderMapShadows(video::IVideoDriver *driver,
 		}
 	}
 
-	uint buffer_count = 0;
+	u32 buffer_count = 0;
 	for (auto &lists : grouped_buffers.lists)
 		for (MeshBufList &list : lists)
 			buffer_count += list.bufs.size();

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -324,6 +324,11 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	//u32 mesh_animate_count_far = 0;
 
 	/*
+		Update transparent meshes
+	*/
+	this->updateTransparentMeshBuffers();
+
+	/*
 		Draw the selected MapBlocks
 	*/
 
@@ -891,3 +896,16 @@ void ClientMap::updateDrawListShadow(const v3f &shadow_light_pos, const v3f &sha
 	g_profiler->avg("SHADOW MapBlocks drawn [#]", m_drawlist_shadow.size());
 	g_profiler->avg("SHADOW MapBlocks loaded [#]", blocks_loaded);
 }
+
+void ClientMap::updateTransparentMeshBuffers()
+{
+	u16 blocks_queued = 0;
+	// Update block meshes if the blocks are marked dirty by camera movement
+	for (auto it = m_drawlist.rbegin(); it != m_drawlist.rend(); it++) {
+		MapBlock* block = it->second;
+		block->mesh->updateTransparentBuffers(m_camera_position, block->getPos());
+	}
+
+	g_profiler->avg("MapBlocks queued for remesh [#]", blocks_queued);
+}
+

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -349,7 +349,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 		Update transparent meshes
 	*/
 	if (is_transparent_pass)
-		this->updateTransparentMeshBuffers();
+		updateTransparentMeshBuffers();
 
 	/*
 		Draw the selected MapBlocks

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -477,12 +477,12 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			buf = descriptor.m_buffer;
 		}
 
-		// Check and abort if the machine is swapping a lot
-		// if (draw.getTimerTime() > 2000) {
-		// 	infostream << "ClientMap::renderMap(): Rendering took >2s, " <<
-		// 			"returning." << std::endl;
-		// 	return;
-		// }
+		Check and abort if the machine is swapping a lot
+		if (draw.getTimerTime() > 2000) {
+			infostream << "ClientMap::renderMap(): Rendering took >2s, " <<
+					"returning." << std::endl;
+			return;
+		}
 
 		if (!descriptor.m_reuse_material) {
 			auto &material = buf->getMaterial();

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -783,13 +783,19 @@ void ClientMap::renderMapShadows(video::IVideoDriver *driver,
 		}
 	}
 
+	uint buffer_count = 0;
+	for (auto &lists : grouped_buffers.lists)
+		for (MeshBufList &list : lists)
+			buffer_count += list.bufs.size();
+	
+	draw_order.reserve(draw_order.size() + buffer_count);
+	
 	// Capture draw order for all solid meshes
 	for (auto &lists : grouped_buffers.lists) {
 		for (MeshBufList &list : lists) {
 			// iterate in reverse to draw closest blocks first
-			for (auto it = list.bufs.rbegin(); it != list.bufs.rend(); ++it) {
+			for (auto it = list.bufs.rbegin(); it != list.bufs.rend(); ++it)
 				draw_order.emplace_back(it->first, it->second, it != list.bufs.rbegin());
-			}
 		}
 	}
 

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -949,6 +949,9 @@ void ClientMap::updateDrawListShadow(const v3f &shadow_light_pos, const v3f &sha
 void ClientMap::updateTransparentMeshBuffers()
 {
 	ScopeProfiler sp(g_profiler, "CM::updateTransparentMeshBuffers", SPT_AVG);
+	u32 sorted_blocks = 0;
+	u32 unsorted_blocks = 0;
+	const f32 MAX_SORT_DISTANCE = BS * BS * 75 * 75; // 75 nodes, 1.5x animation threshold
 
 	// Update the order of transparent mesh buffers in each mesh
 	for (auto it = m_drawlist.begin(); it != m_drawlist.end(); it++) {
@@ -957,10 +960,24 @@ void ClientMap::updateTransparentMeshBuffers()
 			continue;
 		
 		if (m_needs_update_transparent_meshes || 
-				block->mesh->getTransparentBuffers().size() == 0)
-			block->mesh->updateTransparentBuffers(m_camera_position, block->getPos());
+				block->mesh->getTransparentBuffers().size() == 0) {
+
+			v3s16 block_pos = block->getPos();
+			v3f block_pos_f = intToFloat(block_pos * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2, BS);
+			f32 distance = m_camera_position.getDistanceFromSQ(block_pos_f);
+			if (distance <= MAX_SORT_DISTANCE) {
+				block->mesh->updateTransparentBuffers(m_camera_position, block_pos);
+				++sorted_blocks;
+			}
+			else {
+				block->mesh->consolidateTransparentBuffers();
+				++unsorted_blocks;
+			}
+		}
 	}
 
+	g_profiler->avg("CM::Transparent Buffers - Sorted", sorted_blocks);
+	g_profiler->avg("CM::Transparent Buffers - Unsorted", unsorted_blocks);
 	m_needs_update_transparent_meshes = false;
 }
 

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -414,9 +414,8 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 		if (is_transparent_pass) {
 			// In transparent pass, the mesh will give us
 			// the partial buffers in the correct order
-			for (auto &buffer : block->mesh->getTransparentBuffers()) {
+			for (auto &buffer : block->mesh->getTransparentBuffers())
 				draw_order.emplace_back(block_pos, &buffer);
-			}
 		}
 		else {
 			// otherwise, group buffers across meshes
@@ -434,12 +433,12 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 
 					video::SMaterial& material = buf->getMaterial();
 					video::IMaterialRenderer* rnd =
-						driver->getMaterialRenderer(material.MaterialType);
+							driver->getMaterialRenderer(material.MaterialType);
 					bool transparent = (rnd && rnd->isTransparent());
 					if (!transparent) {
 						if (buf->getVertexCount() == 0)
 							errorstream << "Block [" << analyze_block(block)
-								<< "] contains an empty meshbuf" << std::endl;
+									<< "] contains an empty meshbuf" << std::endl;
 
 						grouped_buffers.add(buf, block_pos, layer);
 					}
@@ -466,6 +465,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 
 	// Render all mesh buffers in order
 	drawcall_count += draw_order.size();
+
 	for (auto &descriptor : draw_order) {
 		scene::IMeshBuffer *buf;
 		
@@ -478,11 +478,11 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 		}
 
 		// Check and abort if the machine is swapping a lot
-		if (draw.getTimerTime() > 2000) {
-			infostream << "ClientMap::renderMap(): Rendering took >2s, " <<
-					"returning." << std::endl;
-			return;
-		}
+		// if (draw.getTimerTime() > 2000) {
+		// 	infostream << "ClientMap::renderMap(): Rendering took >2s, " <<
+		// 			"returning." << std::endl;
+		// 	return;
+		// }
 
 		if (!descriptor.m_reuse_material) {
 			auto &material = buf->getMaterial();
@@ -518,7 +518,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 
 		driver->setTransform(video::ETS_WORLD, m);
 		driver->drawMeshBuffer(buf);
-		vertex_count += buf->getVertexCount();
+		vertex_count += buf->getIndexCount();
 	}
 
 	g_profiler->avg(prefix + "draw meshes [ms]", draw.stop(true));

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -477,7 +477,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			buf = descriptor.m_buffer;
 		}
 
-		Check and abort if the machine is swapping a lot
+		// Check and abort if the machine is swapping a lot
 		if (draw.getTimerTime() > 2000) {
 			infostream << "ClientMap::renderMap(): Rendering took >2s, " <<
 					"returning." << std::endl;

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -97,6 +97,7 @@ ClientMap::ClientMap(
 	m_cache_trilinear_filter  = g_settings->getBool("trilinear_filter");
 	m_cache_bilinear_filter   = g_settings->getBool("bilinear_filter");
 	m_cache_anistropic_filter = g_settings->getBool("anisotropic_filter");
+	m_cache_transparency_sorting_distance = g_settings->getU16("transparency_sorting_distance");
 
 }
 
@@ -957,7 +958,8 @@ void ClientMap::updateTransparentMeshBuffers()
 	ScopeProfiler sp(g_profiler, "CM::updateTransparentMeshBuffers", SPT_AVG);
 	u32 sorted_blocks = 0;
 	u32 unsorted_blocks = 0;
-	const f32 MAX_SORT_DISTANCE = BS * BS * 75 * 75; // 75 nodes, 1.5x animation threshold
+	f32 sorting_distance_sq = pow(m_cache_transparency_sorting_distance * BS, 2.0f);
+
 
 	// Update the order of transparent mesh buffers in each mesh
 	for (auto it = m_drawlist.begin(); it != m_drawlist.end(); it++) {
@@ -971,7 +973,7 @@ void ClientMap::updateTransparentMeshBuffers()
 			v3s16 block_pos = block->getPos();
 			v3f block_pos_f = intToFloat(block_pos * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2, BS);
 			f32 distance = m_camera_position.getDistanceFromSQ(block_pos_f);
-			if (distance <= MAX_SORT_DISTANCE) {
+			if (distance <= sorting_distance_sq) {
 				block->mesh->updateTransparentBuffers(m_camera_position, block_pos);
 				++sorted_blocks;
 			}

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -86,7 +86,7 @@ public:
 		ISceneNode::drop();
 	}
 
-	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, v3s16 offset);
+	void updateCamera(v3f pos, v3f dir, f32 fov, v3s16 offset);
 
 	/*
 		Forcefully get a sector from somewhere
@@ -169,11 +169,11 @@ private:
 		bool m_reuse_material:1;
 		bool m_use_partial_buffer:1;
 
-		DrawDescriptor(const v3s16 &pos, scene::IMeshBuffer *buffer, bool reuse_material) :
+		DrawDescriptor(v3s16 pos, scene::IMeshBuffer *buffer, bool reuse_material) :
 			m_pos(pos), m_buffer(buffer), m_reuse_material(reuse_material), m_use_partial_buffer(false)
 		{}
 
-		DrawDescriptor(const v3s16 &pos, const PartialMeshBuffer *buffer) :
+		DrawDescriptor(v3s16 pos, const PartialMeshBuffer *buffer) :
 			m_pos(pos), m_partial_buffer(buffer), m_reuse_material(false), m_use_partial_buffer(true)
 		{}
 	};

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -150,6 +150,10 @@ public:
 	f32 getCameraFov() const { return m_camera_fov; }
 
 private:
+
+	// update the vertex order in transparent mesh buffers
+	void updateTransparentMeshBuffers();
+
 	// Orders blocks by distance to the camera
 	class MapBlockComparer
 	{

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -85,21 +85,7 @@ public:
 		ISceneNode::drop();
 	}
 
-	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset)
-	{
-		v3s16 previous_block = getContainerPos(floatToInt(m_camera_position, BS) + m_camera_offset, MAP_BLOCKSIZE);
-
-		m_camera_position = pos;
-		m_camera_direction = dir;
-		m_camera_fov = fov;
-		m_camera_offset = offset;
-
-		v3s16 current_block = getContainerPos(floatToInt(m_camera_position, BS) + m_camera_offset, MAP_BLOCKSIZE);
-
-		// reorder the blocks when camera crosses block boundary
-		if (previous_block != current_block)
-			m_needs_update_drawlist = true;
-	}
+	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset);
 
 	/*
 		Forcefully get a sector from somewhere
@@ -183,6 +169,7 @@ private:
 	v3f m_camera_direction = v3f(0,0,1);
 	f32 m_camera_fov = M_PI;
 	v3s16 m_camera_offset;
+	bool m_needs_update_transparent_meshes = true;
 
 	std::map<v3s16, MapBlock*, MapBlockComparer> m_drawlist;
 	std::map<v3s16, MapBlock*> m_drawlist_shadow;

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -86,7 +86,7 @@ public:
 		ISceneNode::drop();
 	}
 
-	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset);
+	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, v3s16 offset);
 
 	/*
 		Forcefully get a sector from somewhere

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -202,4 +202,5 @@ private:
 	bool m_cache_bilinear_filter;
 	bool m_cache_anistropic_filter;
 	bool m_added_to_shadow_renderer{false};
+	u16 m_cache_transparency_sorting_distance;
 };

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -56,6 +56,7 @@ struct MeshBufListList
 
 class Client;
 class ITextureSource;
+class PartialMeshBuffer;
 
 /*
 	ClientMap
@@ -155,6 +156,26 @@ private:
 
 	private:
 		v3s16 m_camera_block;
+	};
+
+
+	// reference to a mesh buffer used when rendering the map.
+	struct DrawDescriptor {
+		v3s16 m_pos;
+		union {
+			scene::IMeshBuffer *m_buffer;
+			PartialMeshBuffer *m_partial_buffer;
+		};
+		bool m_reuse_material:1;
+		bool m_use_partial_buffer:1;
+
+		DrawDescriptor(const v3s16 &pos, scene::IMeshBuffer *buffer, bool reuse_material) :
+			m_pos(pos), m_buffer(buffer), m_reuse_material(reuse_material), m_use_partial_buffer(false)
+		{}
+
+		DrawDescriptor(const v3s16 &pos, PartialMeshBuffer *buffer) :
+			m_pos(pos), m_partial_buffer(buffer), m_reuse_material(false), m_use_partial_buffer(true)
+		{}
 	};
 
 	Client *m_client;

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -164,7 +164,7 @@ private:
 		v3s16 m_pos;
 		union {
 			scene::IMeshBuffer *m_buffer;
-			PartialMeshBuffer *m_partial_buffer;
+			const PartialMeshBuffer *m_partial_buffer;
 		};
 		bool m_reuse_material:1;
 		bool m_use_partial_buffer:1;
@@ -173,7 +173,7 @@ private:
 			m_pos(pos), m_buffer(buffer), m_reuse_material(reuse_material), m_use_partial_buffer(false)
 		{}
 
-		DrawDescriptor(const v3s16 &pos, PartialMeshBuffer *buffer) :
+		DrawDescriptor(const v3s16 &pos, const PartialMeshBuffer *buffer) :
 			m_pos(pos), m_partial_buffer(buffer), m_reuse_material(false), m_use_partial_buffer(true)
 		{}
 	};

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1377,6 +1377,40 @@ void MapblockMeshGenerator::drawNodeboxNode()
 
 	std::vector<aabb3f> boxes;
 	n.getNodeBoxes(nodedef, &boxes, neighbors_set);
+
+	bool isTransparent = false;
+
+	for (const TileSpec &tile : tiles) {
+		if (tile.layers[0].isTransparent()) {
+			isTransparent = true;
+			break;
+		}
+	}
+
+	if (isTransparent) {
+		for (int axis = 0; axis < 3; axis++) {
+			// identify sections
+			std::vector<float> sections;
+			for (size_t i = 0; i < boxes.size(); i++) {
+				sections.push_back(boxes[i].MinEdge[axis]);
+				sections.push_back(boxes[i].MaxEdge[axis]);
+			}
+
+			// split the boxes as necessary
+			for (size_t i = 0; i < boxes.size(); i++) {
+				aabb3f &box = boxes[i];
+				for (float section : sections) {
+					if (box.MinEdge[axis] < section && box.MaxEdge[axis] > section) {
+						aabb3f copy = box;
+						copy.MinEdge[axis] = section;
+						box.MaxEdge[axis] = section;
+						boxes.push_back(copy);
+					}
+				}
+			}
+		}
+	}
+
 	for (auto &box : boxes)
 		drawAutoLightedCuboid(box, nullptr, tiles, 6);
 }

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1388,9 +1388,11 @@ void MapblockMeshGenerator::drawNodeboxNode()
 	}
 
 	if (isTransparent) {
+		std::vector<float> sections;
+		sections.reserve(8 + 2 * boxes.size());
 		for (int axis = 0; axis < 3; axis++) {
 			// identify sections
-			std::vector<float> sections;
+			sections.clear();
 
 			// Default split at node bounds, up to 3 nodes in each direction
 			for (float s = -3.5f * BS; s < 4.0f * BS; s += 1.0f * BS)

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1391,6 +1391,11 @@ void MapblockMeshGenerator::drawNodeboxNode()
 		for (int axis = 0; axis < 3; axis++) {
 			// identify sections
 			std::vector<float> sections;
+
+			// Default split at node bounds, up to 3 nodes in each direction
+			for (float s = -35; s < 40; s += 10)
+				sections.push_back(s);
+
 			for (size_t i = 0; i < boxes.size(); i++) {
 				sections.push_back(boxes[i].MinEdge[axis]);
 				sections.push_back(boxes[i].MaxEdge[axis]);

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1393,23 +1393,25 @@ void MapblockMeshGenerator::drawNodeboxNode()
 			std::vector<float> sections;
 
 			// Default split at node bounds, up to 3 nodes in each direction
-			for (float s = -35; s < 40; s += 10)
+			for (float s = -3.5f * BS; s < 4.0f * BS; s += 1.0f * BS)
 				sections.push_back(s);
 
+			// Add edges of existing node boxes, rounded to 1E-3
 			for (size_t i = 0; i < boxes.size(); i++) {
-				sections.push_back(boxes[i].MinEdge[axis]);
-				sections.push_back(boxes[i].MaxEdge[axis]);
+				sections.push_back(std::floor(boxes[i].MinEdge[axis] * 1E3) * 1E-3);
+				sections.push_back(std::floor(boxes[i].MaxEdge[axis] * 1E3) * 1E-3);
 			}
 
-			// split the boxes as necessary
-			for (size_t i = 0; i < boxes.size(); i++) {
-				aabb3f &box = boxes[i];
+			// split the boxes at recorded sections
+			for (size_t i = 0; i < boxes.size() && i < 100; i++) {
+				aabb3f *box = &boxes[i];
 				for (float section : sections) {
-					if (box.MinEdge[axis] < section && box.MaxEdge[axis] > section) {
-						aabb3f copy = box;
+					if (box->MinEdge[axis] < section && box->MaxEdge[axis] > section) {
+						aabb3f copy(*box);
 						copy.MinEdge[axis] = section;
-						box.MaxEdge[axis] = section;
+						box->MaxEdge[axis] = section;
 						boxes.push_back(copy);
+						box = &boxes[i]; // find new address of the box in case of reallocation
 					}
 				}
 			}

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1389,14 +1389,21 @@ void MapblockMeshGenerator::drawNodeboxNode()
 
 	if (isTransparent) {
 		std::vector<float> sections;
+		// Preallocate 8 default splits + Min&Max for each nodebox
 		sections.reserve(8 + 2 * boxes.size());
+
 		for (int axis = 0; axis < 3; axis++) {
 			// identify sections
-			sections.clear();
 
-			// Default split at node bounds, up to 3 nodes in each direction
-			for (float s = -3.5f * BS; s < 4.0f * BS; s += 1.0f * BS)
-				sections.push_back(s);
+			if (axis == 0) {
+				// Default split at node bounds, up to 3 nodes in each direction
+				for (float s = -3.5f * BS; s < 4.0f * BS; s += 1.0f * BS)
+					sections.push_back(s);
+			}
+			else {
+				// Avoid readding the same 8 default splits for Y and Z
+				sections.resize(8);
+			}
 
 			// Add edges of existing node boxes, rounded to 1E-3
 			for (size_t i = 0; i < boxes.size(); i++) {

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1405,6 +1405,9 @@ void MapblockMeshGenerator::drawNodeboxNode()
 			}
 
 			// split the boxes at recorded sections
+			// limit splits to avoid runaway crash if inner loop adds infinite splits
+			// due to e.g. precision problems.
+			// 100 is just an arbitrary, reasonably high number.
 			for (size_t i = 0; i < boxes.size() && i < 100; i++) {
 				aabb3f *box = &boxes[i];
 				for (float section : sections) {

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -381,12 +381,12 @@ void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box, const f32 *txc,
 		box.MinEdge *= f->visual_scale;
 		box.MaxEdge *= f->visual_scale;
 	}
-	box.MinEdge += origin;
-	box.MaxEdge += origin;
 	if (!txc) {
 		generateCuboidTextureCoords(box, texture_coord_buf);
 		txc = texture_coord_buf;
 	}
+	box.MinEdge += origin;
+	box.MaxEdge += origin;
 	if (!tiles) {
 		tiles = &tile;
 		tile_count = 1;

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1014,9 +1014,11 @@ void MapBlockBspTree::buildTree(const std::vector<MeshTriangle> *triangles)
 
 	nodes.clear();
 
+	// assert that triangle index can fit into s32
+	assert(triangles->size() <= 0x7FFFFFFFL);
 	std::vector<s32> indexes;
 	indexes.reserve(triangles->size());
-	for (u16 i = 0; i < triangles->size(); i++)
+	for (u32 i = 0; i < triangles->size(); i++)
 		indexes.push_back(i);
 
 	root = buildTree(v3f(1, 0, 0), v3f(85, 85, 85), 40, indexes, 0);

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1305,8 +1305,8 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 			scene::SMeshBuffer *buf = new scene::SMeshBuffer();
 			buf->Material = material;
 			switch (p.layer.material_type) {
+			// list of transparent materials taken from tile.h
 			case TILE_MATERIAL_ALPHA:
-			case TILE_MATERIAL_PLAIN_ALPHA:
 			case TILE_MATERIAL_LIQUID_TRANSPARENT:
 			case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
 				{

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1055,14 +1055,7 @@ s32 MapBlockBspTree::buildTree(v3f normal, v3f origin, float delta, const std::v
 
 	// if there is only one triangle, or the delta is insanely small, this is a leaf node
 	if (list.size() == 1 || delta < 0.01) {
-		struct TreeNode node;
-		node.normal = normal;
-		node.origin = origin;
-		node.triangle_refs = list;
-		node.front_ref = -1;
-		node.back_ref = -1;
-		nodes.push_back(node);
-
+		nodes.emplace_back(normal, origin, list, -1, -1);
 		return nodes.size() - 1;
 	}
 
@@ -1124,13 +1117,7 @@ s32 MapBlockBspTree::buildTree(v3f normal, v3f origin, float delta, const std::v
 			return back_index;
 	}
 
-	struct TreeNode node;
-	node.normal = normal;
-	node.origin = origin;
-	node.triangle_refs = node_list;
-	node.front_ref = front_index;
-	node.back_ref = back_index;
-	nodes.push_back(node);
+	nodes.emplace_back(normal, origin, node_list, front_index, back_index);
 
 	return nodes.size() - 1;
 }

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1024,13 +1024,22 @@ void MapBlockBspTree::buildTree(const std::vector<MeshTriangle> *triangles)
 	root = buildTree(v3f(1, 0, 0), v3f(85, 85, 85), 40, indexes, 0);
 }
 
+/**
+ * @brief Find a candidate plane to split a set of triangles in two
+ * 
+ * The candidate plane is represented by one of the triangles from the set.
+ * 
+ * @param list Vector of indexes of the triangles in the set
+ * @param triangles Vector of all triangles in the BSP tree
+ * @return Address of the triangle that represents the proposed split plane
+ */
 static const MeshTriangle *findSplitCandidate(const std::vector<s32> &list, const std::vector<MeshTriangle> &triangles)
 {
-	// find best origin as a center of the cluster.
-	v3f origin(0, 0, 0);
+	// find the center of the cluster.
+	v3f center(0, 0, 0);
 	size_t n = list.size();
 	for (s32 i : list) {
-		origin += triangles[i].centroid / n;
+		center += triangles[i].centroid / n;
 	}
 
 	// find the triangle with the largest area and closest to the center
@@ -1040,7 +1049,7 @@ static const MeshTriangle *findSplitCandidate(const std::vector<s32> &list, cons
 		ith_triangle = &triangles[i];
 		if (ith_triangle->areaSQ > candidate_triangle->areaSQ ||
 				(ith_triangle->areaSQ == candidate_triangle->areaSQ &&
-				ith_triangle->centroid.getDistanceFromSQ(origin) < candidate_triangle->centroid.getDistanceFromSQ(origin))) {
+				ith_triangle->centroid.getDistanceFromSQ(center) < candidate_triangle->centroid.getDistanceFromSQ(center))) {
 			candidate_triangle = ith_triangle;
 		}
 	}

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1172,7 +1172,7 @@ void PartialMeshBuffer::beforeDraw() const
 		for (auto index : m_vertex_indexes)
 			m_buffer->Indices.push_back(index);
 	}
-	m_buffer->setDirty();
+	m_buffer->setDirty(scene::EBT_INDEX);
 }
 
 /*

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1122,7 +1122,7 @@ s32 MapBlockBspTree::buildTree(v3f normal, v3f origin, float delta, const std::v
 	return nodes.size() - 1;
 }
 
-void MapBlockBspTree::traverse(s32 node, const v3f &viewpoint, std::vector<s32> &output) const
+void MapBlockBspTree::traverse(s32 node, v3f viewpoint, std::vector<s32> &output) const
 {
 	if (node < 0) return; // recursion break;
 
@@ -1481,7 +1481,7 @@ bool MapBlockMesh::animate(bool faraway, float time, int crack,
 	return true;
 }
 
-void MapBlockMesh::updateTransparentBuffers(const v3f &camera_pos, const v3s16 &block_pos)
+void MapBlockMesh::updateTransparentBuffers(v3f camera_pos, v3s16 block_pos)
 {
 	// nothing to do if the entire block is opaque
 	if (m_transparent_triangles.empty())

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1015,6 +1015,7 @@ void MapBlockBspTree::buildTree(const std::vector<MeshTriangle> *triangles)
 	nodes.clear();
 
 	std::vector<s32> indexes;
+	indexes.reserve(triangles->size());
 	for (u16 i = 0; i < triangles->size(); i++)
 		indexes.push_back(i);
 
@@ -1513,8 +1514,8 @@ void MapBlockMesh::updateTransparentBuffers(const v3f &camera_pos, const v3s16 &
 	for (auto i : triangle_refs) {
 		const auto &t = m_transparent_triangles[i];
 		if (current_buffer != t.buffer) {
-			if (current_buffer != nullptr) {
-				this->m_transparent_buffers.emplace_back(current_buffer, current_strain);
+			if (current_buffer) {
+				m_transparent_buffers.emplace_back(current_buffer, current_strain);
 				current_strain.clear();
 			}
 			current_buffer = t.buffer;
@@ -1524,9 +1525,8 @@ void MapBlockMesh::updateTransparentBuffers(const v3f &camera_pos, const v3s16 &
 		current_strain.push_back(t.p3);
 	}
 
-	if (current_strain.size() > 0) {
-		this->m_transparent_buffers.emplace_back(current_buffer, current_strain);
-	}
+	if (!current_strain.empty())
+		m_transparent_buffers.emplace_back(current_buffer, current_strain);
 }
 
 void MapBlockMesh::consolidateTransparentBuffers()

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1315,41 +1315,177 @@ bool MapBlockMesh::animate(bool faraway, float time, int crack,
 	return true;
 }
 
+// represents a triangle as indexes into the vertex buffer
+class MeshTriangle
+{
+public:
+	scene::SMeshBuffer *buffer;
+	u16 p1, p2, p3;
+	v3f centroid;
+
+	void fillCentroid()
+	{
+		const v3f &v1 = buffer->getPosition(p1);
+		const v3f &v2 = buffer->getPosition(p2);
+		const v3f &v3 = buffer->getPosition(p3);
+
+		centroid = (v1 + v2 + v3) / 3;
+	}
+};
+
+class MapBlockBspTree
+{
+public:
+	MapBlockBspTree() {}
+
+	MapBlockBspTree(const std::vector<MeshTriangle> *triangles) : triangles(triangles)
+	{
+		nodes.reserve(triangles->size()); // worst case every node holds only one triangle
+
+		std::vector<s32> indexes;
+		for (u16 i = 0; i < triangles->size(); i++)
+			indexes.push_back(i);
+
+		root = build_tree(v3f(1, 0, 0), v3f(85, 85, 85), 40, indexes);
+	}
+
+	void traverse(const v3f &viewpoint, std::vector<s32> &output)
+	{
+		traverse(root, viewpoint, output);
+	}
+
+private:
+	// Tree node definition;
+	struct TreeNode
+	{
+		v3f normal;
+		v3f origin;
+		std::vector<s32> triangle_refs;
+		s32 front_ref;
+		s32 back_ref;
+	};
+
+	s32 build_tree(v3f normal, v3f origin, float delta, const std::vector<s32> &list)
+	{
+		// if the list is empty, don't bother
+		if (list.size() == 0) {
+			return -1;
+		}
+
+		// if there is only one triangle, or the delta is insanely small, this is a leaf node
+		if (list.size() == 1 || delta < 0.01) {
+			struct TreeNode node;
+			node.normal = normal;
+			node.origin = origin;
+			node.triangle_refs = list;
+			node.front_ref = -1;
+			node.back_ref = -1;
+			nodes.push_back(node);
+
+			return nodes.size() - 1;
+		}
+
+		std::vector<s32> front_list;
+		std::vector<s32> back_list;
+		std::vector<s32> node_list;
+
+		// split the list
+		for (s32 i : list) {
+			const MeshTriangle &triangle = (*triangles)[i];
+			float factor = normal.dotProduct(triangle.centroid - origin);
+			if (factor == 0)
+				node_list.push_back(i);
+			else if (factor > 0)
+				front_list.push_back(i);
+			else
+				back_list.push_back(i);
+		}
+
+		// define the new split-plane
+		v3f next_normal(normal.Z, normal.X, normal.Y);
+		float next_delta = delta;
+		if (next_normal.X > 0) {
+			next_delta /= 2;
+		}
+
+		s32 front_index = -1;
+		s32 back_index = -1;
+
+		if (front_list.size() > 0) {
+			front_index = build_tree(next_normal, origin + delta * normal, next_delta, front_list);
+
+			// if there are no other triangles, don't create a new node
+			if (back_list.size() == 0 && node_list.size() == 0)
+				return front_index;
+		}
+
+		if (back_list.size() >= 0) {
+			back_index = build_tree(next_normal, origin - delta * normal, next_delta, back_list);
+
+			// if there are no other triangles, don't create a new node
+			if (front_list.size() == 0 && node_list.size() == 0)
+				return back_index;
+		}
+
+		struct TreeNode node;
+		node.normal = normal;
+		node.origin = origin;
+		node.triangle_refs = node_list;
+		node.front_ref = front_index;
+		node.back_ref = back_index;
+		nodes.push_back(node);
+
+		return nodes.size() - 1;
+	}
+
+	void traverse(s32 node, const v3f &viewpoint, std::vector<s32> &output)
+	{
+		if (node < 0) return; // recursion break;
+
+		const TreeNode &n = nodes[node];
+		float factor = n.normal.dotProduct(viewpoint - n.origin);
+
+		if (factor > 0)
+			traverse(n.back_ref, viewpoint, output);
+		else
+			traverse(n.front_ref, viewpoint, output);
+
+		if (factor != 0)
+			for (s32 i : n.triangle_refs)
+				output.push_back(i);
+
+		if (factor > 0)
+			traverse(n.front_ref, viewpoint, output);
+		else
+			traverse(n.back_ref, viewpoint, output);
+	}
+
+	const std::vector<MeshTriangle> *triangles = nullptr; // this reference is managed externally
+	std::vector<TreeNode> nodes; // list of nodes
+	s32 root = -1; // index of the root node
+};
+
 void MapBlockMesh::updateTransparentBuffers(const v3f &camera_pos, const v3s16 &block_pos)
 {
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
 
-	// represents a triangle as indexes into the vertex buffer
-	struct triangle {
-		u16 p1, p2, p3;
-		f32 centroid_distance;
-		scene::SMeshBuffer *buffer;
-	};
-
-	// compares triangles by distance to centroid, descending
-	struct triangle_comparer {
-		bool operator() (struct triangle l, struct triangle r) const {
-			return l.centroid_distance > r.centroid_distance;
-		}
-	};
-
 	v3f block_posf = intToFloat(block_pos * MAP_BLOCKSIZE, BS);
+	v3f rel_camera_pos = camera_pos - block_posf;
 
-	std::vector<struct triangle> tris;
+	std::vector<MeshTriangle> tris;
 
 	if (this->m_transparent_buffers.size() > 0) {
 		for (const PartialMeshBuffer &partial_buffer : this->m_transparent_buffers) {
 			scene::SMeshBuffer *buffer = partial_buffer.m_buffer;
 			const std::vector<u16> &indices = partial_buffer.getVertexIndexes();
-			struct triangle t;
+			MeshTriangle t;
 			for (u32 i = 0; i < indices.size(); i += 3)
 			{
 				t.p1 = indices[i];
 				t.p2 = indices[i + 1];
 				t.p3 = indices[i + 2];
-				v3f centroid = (buffer->getPosition(t.p1) + buffer->getPosition(t.p2) + buffer->getPosition(t.p3)) / 3;
-				t.centroid_distance = camera_pos.getDistanceFrom(centroid + block_posf);
 				t.buffer = buffer;
+				t.fillCentroid();
 				tris.push_back(t);
 			}
 		}
@@ -1360,22 +1496,23 @@ void MapBlockMesh::updateTransparentBuffers(const v3f &camera_pos, const v3s16 &
 			u32 buffer_count = mesh->getMeshBufferCount();
 			for (u32 buffer_index = 0; buffer_index < buffer_count; ++buffer_index)
 			{
-				scene::IMeshBuffer *buffer = mesh->getMeshBuffer(buffer_index);
-				if (!driver->getMaterialRenderer(buffer->getMaterial().MaterialType)->isTransparent())
+				scene::SMeshBuffer *buffer = static_cast<scene::SMeshBuffer *>(mesh->getMeshBuffer(buffer_index));
+				video::IMaterialRenderer *renderer = driver == nullptr ? nullptr : driver->getMaterialRenderer(buffer->getMaterial().MaterialType);
+
+				if (renderer == nullptr || !renderer->isTransparent())
 					continue;
 
 				u32 index_count = buffer->getIndexCount();
 
 				// copy indices to the triangles
 				u16 *indices = buffer->getIndices();
-				struct triangle t;
+				MeshTriangle t;
 				for (u32 i = 0; i < index_count; i += 3) {
 					t.p1 = indices[i];
 					t.p2 = indices[i + 1];
 					t.p3 = indices[i + 2];
-					v3f centroid = (buffer->getPosition(t.p1) + buffer->getPosition(t.p2) + buffer->getPosition(t.p3)) / 3;
-					t.centroid_distance = camera_pos.getDistanceFrom(centroid + block_posf);
-					t.buffer = static_cast<scene::SMeshBuffer *>(buffer);
+					t.buffer = buffer;
+					t.fillCentroid();
 					tris.push_back(t);
 				}
 			}
@@ -1383,21 +1520,23 @@ void MapBlockMesh::updateTransparentBuffers(const v3f &camera_pos, const v3s16 &
 	}
 
 	// sort the triangles by distance to the camera
-	static struct triangle_comparer comp;
-	std::sort(tris.begin(), tris.end(), comp);
+	struct MapBlockBspTree tree(&tris);
+	std::vector<s32> triangle_refs;
+	tree.traverse(rel_camera_pos, triangle_refs);
 
 	// arrange index sequences into partial buffers
 	this->m_transparent_buffers.clear();
 
-	scene::SMeshBuffer *prev_buffer = nullptr;
+	scene::SMeshBuffer *current_buffer = nullptr;
 	std::vector<u16> current_strain;
-	for (const auto &t : tris) {
-		if (prev_buffer != t.buffer) {
-			if (prev_buffer != nullptr) {
-				this->m_transparent_buffers.emplace_back(prev_buffer, current_strain);
+	for (auto i : triangle_refs) {
+		const auto &t = tris[i];
+		if (current_buffer != t.buffer) {
+			if (current_buffer != nullptr) {
+				this->m_transparent_buffers.emplace_back(current_buffer, current_strain);
 				current_strain.clear();
 			}
-			prev_buffer = t.buffer;
+			current_buffer = t.buffer;
 		}
 		current_strain.push_back(t.p1);
 		current_strain.push_back(t.p2);
@@ -1405,7 +1544,7 @@ void MapBlockMesh::updateTransparentBuffers(const v3f &camera_pos, const v3s16 &
 	}
 
 	if (current_strain.size() > 0) {
-		this->m_transparent_buffers.emplace_back(prev_buffer, current_strain);
+		this->m_transparent_buffers.emplace_back(current_buffer, current_strain);
 	}
 }
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1529,6 +1529,32 @@ void MapBlockMesh::updateTransparentBuffers(const v3f &camera_pos, const v3s16 &
 	}
 }
 
+void MapBlockMesh::consolidateTransparentBuffers()
+{
+	m_transparent_buffers.clear();
+
+	scene::SMeshBuffer *current_buffer = nullptr;
+	std::vector<u16> current_strain;
+
+	// use the fact that m_transparent_triangles is already arranged by buffer
+	for (const auto &t : m_transparent_triangles) {
+		if (current_buffer != t.buffer) {
+			if (current_buffer != nullptr) {
+				this->m_transparent_buffers.emplace_back(current_buffer, current_strain);
+				current_strain.clear();
+			}
+			current_buffer = t.buffer;
+		}
+		current_strain.push_back(t.p1);
+		current_strain.push_back(t.p2);
+		current_strain.push_back(t.p3);
+	}
+
+	if (current_strain.size() > 0) {
+		this->m_transparent_buffers.emplace_back(current_buffer, current_strain);
+	}
+}
+
 video::SColor encode_light(u16 light, u8 emissive_light)
 {
 	// Get components

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1163,7 +1163,7 @@ void MapBlockBspTree::traverse(s32 node, const v3f &viewpoint, std::vector<s32> 
 	PartialMeshBuffer
 */
 
-void PartialMeshBuffer::beforeDraw()
+void PartialMeshBuffer::beforeDraw() const
 {
 	// Patch the indexes in the mesh buffer before draw
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1048,9 +1048,8 @@ static const MeshTriangle *findSplitCandidate(const std::vector<s32> &list, cons
 s32 MapBlockBspTree::buildTree(v3f normal, v3f origin, float delta, const std::vector<s32> &list, u32 depth)
 {
 	// if the list is empty, don't bother
-	if (list.size() == 0) {
+	if (list.empty())
 		return -1;
-	}
 
 	// if there is only one triangle, or the delta is insanely small, this is a leaf node
 	if (list.size() == 1 || delta < 0.01) {
@@ -1084,14 +1083,13 @@ s32 MapBlockBspTree::buildTree(v3f normal, v3f origin, float delta, const std::v
 	// define the new split-plane
 	v3f candidate_normal(normal.Z, normal.X, normal.Y);
 	float candidate_delta = delta;
-	if (depth % 3 == 2) {
+	if (depth % 3 == 2)
 		candidate_delta /= 2;
-	}
 
 	s32 front_index = -1;
 	s32 back_index = -1;
 
-	if (front_list.size() > 0) {
+	if (!front_list.empty()) {
 		v3f next_normal = candidate_normal;
 		v3f next_origin = origin + delta * normal;
 		float next_delta = candidate_delta;
@@ -1103,11 +1101,11 @@ s32 MapBlockBspTree::buildTree(v3f normal, v3f origin, float delta, const std::v
 		front_index = buildTree(next_normal, next_origin, next_delta, front_list, depth + 1);
 
 		// if there are no other triangles, don't create a new node
-		if (back_list.size() == 0 && node_list.size() == 0)
+		if (back_list.empty() && node_list.empty())
 			return front_index;
 	}
 
-	if (back_list.size() > 0) {
+	if (!back_list.empty()) {
 		v3f next_normal = candidate_normal;
 		v3f next_origin = origin - delta * normal;
 		float next_delta = candidate_delta;
@@ -1120,7 +1118,7 @@ s32 MapBlockBspTree::buildTree(v3f normal, v3f origin, float delta, const std::v
 		back_index = buildTree(next_normal, next_origin, next_delta, back_list, depth + 1);
 
 		// if there are no other triangles, don't create a new node
-		if (front_list.size() == 0 && node_list.size() == 0)
+		if (front_list.empty() && node_list.empty())
 			return back_index;
 	}
 
@@ -1168,7 +1166,7 @@ void PartialMeshBuffer::beforeDraw() const
 	// Patch the indexes in the mesh buffer before draw
 
 	m_buffer->Indices.clear();
-	if (m_vertex_indexes.size() > 0) {
+	if (!m_vertex_indexes.empty()) {
 		for (auto index : m_vertex_indexes)
 			m_buffer->Indices.push_back(index);
 	}
@@ -1497,7 +1495,7 @@ bool MapBlockMesh::animate(bool faraway, float time, int crack,
 void MapBlockMesh::updateTransparentBuffers(const v3f &camera_pos, const v3s16 &block_pos)
 {
 	// nothing to do if the entire block is opaque
-	if (m_transparent_triangles.size() == 0)
+	if (m_transparent_triangles.empty())
 		return;
 
 	v3f block_posf = intToFloat(block_pos * MAP_BLOCKSIZE, BS);
@@ -1550,7 +1548,7 @@ void MapBlockMesh::consolidateTransparentBuffers()
 		current_strain.push_back(t.p3);
 	}
 
-	if (current_strain.size() > 0) {
+	if (!current_strain.empty()) {
 		this->m_transparent_buffers.emplace_back(current_buffer, current_strain);
 	}
 }

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -205,6 +205,7 @@ public:
 
 	/// update transparent buffers to render towards the camera
 	void updateTransparentBuffers(const v3f &camera_pos, const v3s16 &block_pos);
+	void consolidateTransparentBuffers();
 
 	/// get the list of transparent buffers
 	std::vector<PartialMeshBuffer> &getTransparentBuffers()

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -120,6 +120,11 @@ private:
 		std::vector<s32> triangle_refs;
 		s32 front_ref;
 		s32 back_ref;
+
+		TreeNode() = default;
+		TreeNode(const v3f &normal, const v3f &origin, const std::vector<s32> &triangle_refs, s32 front_ref, s32 back_ref) :
+				normal(normal), origin(origin), triangle_refs(triangle_refs), front_ref(front_ref), back_ref(back_ref)
+		{}
 	};
 
 

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -141,12 +141,10 @@ public:
 	scene::IMeshBuffer *getBuffer() const { return m_buffer; }
 	const std::vector<u16> &getVertexIndexes() const { return m_vertex_indexes; }
 
-	void beforeDraw();
+	void beforeDraw() const;
 private:
 	scene::SMeshBuffer *m_buffer;
 	std::vector<u16> m_vertex_indexes;
-
-	friend class MapBlockMesh;
 };
 
 /*
@@ -208,7 +206,7 @@ public:
 	void consolidateTransparentBuffers();
 
 	/// get the list of transparent buffers
-	std::vector<PartialMeshBuffer> &getTransparentBuffers()
+	const std::vector<PartialMeshBuffer> &getTransparentBuffers() const
 	{
 		return this->m_transparent_buffers;
 	}

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -71,6 +71,24 @@ struct MeshMakeData
 	void setSmoothLighting(bool smooth_lighting);
 };
 
+class PartialMeshBuffer
+{
+public:
+	PartialMeshBuffer(scene::SMeshBuffer *buffer, const std::vector<u16> &vertex_indexes) :
+			m_buffer(buffer), m_vertex_indexes(vertex_indexes)
+	{}
+
+	scene::IMeshBuffer *getBuffer() const { return m_buffer; }
+	const std::vector<u16> &getVertexIndexes() const { return m_vertex_indexes; }
+
+	void beforeDraw();
+private:
+	scene::SMeshBuffer *m_buffer;
+	std::vector<u16> m_vertex_indexes;
+
+	friend class MapBlockMesh;
+};
+
 /*
 	Holds a mesh for a mapblock.
 
@@ -125,8 +143,14 @@ public:
 			m_animation_force_timer--;
 	}
 
-	/// attempt to update transparent buffers for camera movement to avoid full mesh regeneration
-	bool updateTransparentBuffers(const v3f &camera_pos, const v3s16 &block_pos);
+	/// update transparent buffers to render towards the camera
+	void updateTransparentBuffers(const v3f &camera_pos, const v3s16 &block_pos);
+
+	/// get the list of transparent buffers
+	std::vector<PartialMeshBuffer> &getTransparentBuffers()
+	{
+		return this->m_transparent_buffers;
+	}
 private:
 	scene::IMesh *m_mesh[MAX_TILE_LAYERS];
 	MinimapMapblock *m_minimap_mapblock;
@@ -160,6 +184,9 @@ private:
 	// of sunlit vertices
 	// Keys are pairs of (mesh index, buffer index in the mesh)
 	std::map<std::pair<u8, u32>, std::map<u32, video::SColor > > m_daynight_diffs;
+
+	// Ordered list of references to parts of transparent buffers to draw
+	std::vector<PartialMeshBuffer> m_transparent_buffers;
 };
 
 /*!

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -82,18 +82,18 @@ public:
 
 	void updateAttributes()
 	{
-		const v3f &v1 = buffer->getPosition(p1);
-		const v3f &v2 = buffer->getPosition(p2);
-		const v3f &v3 = buffer->getPosition(p3);
+		v3f v1 = buffer->getPosition(p1);
+		v3f v2 = buffer->getPosition(p2);
+		v3f v3 = buffer->getPosition(p3);
 
 		centroid = (v1 + v2 + v3) / 3;
 		areaSQ = (v2-v1).crossProduct(v3-v1).getLengthSQ() / 4;
 	}
 
 	v3f getNormal() const {
-		const v3f &v1 = buffer->getPosition(p1);
-		const v3f &v2 = buffer->getPosition(p2);
-		const v3f &v3 = buffer->getPosition(p3);
+		v3f v1 = buffer->getPosition(p1);
+		v3f v2 = buffer->getPosition(p2);
+		v3f v3 = buffer->getPosition(p3);
 
 		return (v2-v1).crossProduct(v3-v1);
 	}
@@ -106,7 +106,7 @@ public:
 
 	void buildTree(const std::vector<MeshTriangle> *triangles);
 
-	void traverse(const v3f &viewpoint, std::vector<s32> &output) const
+	void traverse(v3f viewpoint, std::vector<s32> &output) const
 	{
 		traverse(root, viewpoint, output);
 	}
@@ -122,14 +122,14 @@ private:
 		s32 back_ref;
 
 		TreeNode() = default;
-		TreeNode(const v3f &normal, const v3f &origin, const std::vector<s32> &triangle_refs, s32 front_ref, s32 back_ref) :
+		TreeNode(v3f normal, v3f origin, const std::vector<s32> &triangle_refs, s32 front_ref, s32 back_ref) :
 				normal(normal), origin(origin), triangle_refs(triangle_refs), front_ref(front_ref), back_ref(back_ref)
 		{}
 	};
 
 
 	s32 buildTree(v3f normal, v3f origin, float delta, const std::vector<s32> &list, u32 depth);
-	void traverse(s32 node, const v3f &viewpoint, std::vector<s32> &output) const;
+	void traverse(s32 node, v3f viewpoint, std::vector<s32> &output) const;
 
 	const std::vector<MeshTriangle> *triangles = nullptr; // this reference is managed externally
 	std::vector<TreeNode> nodes; // list of nodes
@@ -207,7 +207,7 @@ public:
 	}
 
 	/// update transparent buffers to render towards the camera
-	void updateTransparentBuffers(const v3f &camera_pos, const v3s16 &block_pos);
+	void updateTransparentBuffers(v3f camera_pos, v3s16 block_pos);
 	void consolidateTransparentBuffers();
 
 	/// get the list of transparent buffers

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -71,6 +71,56 @@ struct MeshMakeData
 	void setSmoothLighting(bool smooth_lighting);
 };
 
+// represents a triangle as indexes into the vertex buffer in SMeshBuffer
+class MeshTriangle
+{
+public:
+	scene::SMeshBuffer *buffer;
+	u16 p1, p2, p3;
+	v3f centroid;
+
+	void fillCentroid()
+	{
+		const v3f &v1 = buffer->getPosition(p1);
+		const v3f &v2 = buffer->getPosition(p2);
+		const v3f &v3 = buffer->getPosition(p3);
+
+		centroid = (v1 + v2 + v3) / 3;
+	}
+};
+
+class MapBlockBspTree
+{
+public:
+	MapBlockBspTree() {}
+
+	void buildTree(const std::vector<MeshTriangle> *triangles);
+
+	void traverse(const v3f &viewpoint, std::vector<s32> &output) const
+	{
+		traverse(root, viewpoint, output);
+	}
+
+private:
+	// Tree node definition;
+	struct TreeNode
+	{
+		v3f normal;
+		v3f origin;
+		std::vector<s32> triangle_refs;
+		s32 front_ref;
+		s32 back_ref;
+	};
+
+
+	s32 buildTree(v3f normal, v3f origin, float delta, const std::vector<s32> &list);
+	void traverse(s32 node, const v3f &viewpoint, std::vector<s32> &output) const;
+
+	const std::vector<MeshTriangle> *triangles = nullptr; // this reference is managed externally
+	std::vector<TreeNode> nodes; // list of nodes
+	s32 root = -1; // index of the root node
+};
+
 class PartialMeshBuffer
 {
 public:
@@ -185,6 +235,10 @@ private:
 	// Keys are pairs of (mesh index, buffer index in the mesh)
 	std::map<std::pair<u8, u32>, std::map<u32, video::SColor > > m_daynight_diffs;
 
+	// list of all semitransparent triangles in the mapblock
+	std::vector<MeshTriangle> m_transparent_triangles;
+	// Binary Space Partitioning tree for the block
+	MapBlockBspTree m_bsp_tree;
 	// Ordered list of references to parts of transparent buffers to draw
 	std::vector<PartialMeshBuffer> m_transparent_buffers;
 };

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -125,6 +125,8 @@ public:
 			m_animation_force_timer--;
 	}
 
+	/// attempt to update transparent buffers for camera movement to avoid full mesh regeneration
+	bool updateTransparentBuffers(const v3f &camera_pos, const v3s16 &block_pos);
 private:
 	scene::IMesh *m_mesh[MAX_TILE_LAYERS];
 	MinimapMapblock *m_minimap_mapblock;

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -78,14 +78,24 @@ public:
 	scene::SMeshBuffer *buffer;
 	u16 p1, p2, p3;
 	v3f centroid;
+	float areaSQ;
 
-	void fillCentroid()
+	void updateAttributes()
 	{
 		const v3f &v1 = buffer->getPosition(p1);
 		const v3f &v2 = buffer->getPosition(p2);
 		const v3f &v3 = buffer->getPosition(p3);
 
 		centroid = (v1 + v2 + v3) / 3;
+		areaSQ = (v2-v1).crossProduct(v3-v1).getLengthSQ() / 4;
+	}
+
+	v3f getNormal() const {
+		const v3f &v1 = buffer->getPosition(p1);
+		const v3f &v2 = buffer->getPosition(p2);
+		const v3f &v3 = buffer->getPosition(p3);
+
+		return (v2-v1).crossProduct(v3-v1);
 	}
 };
 
@@ -113,7 +123,7 @@ private:
 	};
 
 
-	s32 buildTree(v3f normal, v3f origin, float delta, const std::vector<s32> &list);
+	s32 buildTree(v3f normal, v3f origin, float delta, const std::vector<s32> &list, u32 depth);
 	void traverse(s32 node, const v3f &viewpoint, std::vector<s32> &output) const;
 
 	const std::vector<MeshTriangle> *triangles = nullptr; // this reference is managed externally

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -99,6 +99,10 @@ public:
 	}
 };
 
+/**
+ * Implements a binary space partitioning tree 
+ * See also: https://en.wikipedia.org/wiki/Binary_space_partitioning
+ */
 class MapBlockBspTree
 {
 public:

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -278,6 +278,18 @@ struct TileLayer
 		return false;
 	}
 
+	bool isTransparent() const
+	{
+		switch (material_type) {
+		case TILE_MATERIAL_BASIC:
+		case TILE_MATERIAL_ALPHA:
+		case TILE_MATERIAL_LIQUID_TRANSPARENT:
+		case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
+			return true;
+		}
+		return false;
+	}
+
 	// Ordered for size, please do not reorder
 
 	video::ITexture *texture = nullptr;
@@ -333,6 +345,14 @@ struct TileSpec
 			&& rotation == other.rotation
 			&& emissive_light == other.emissive_light;
 	}
+
+	bool isTransparent() const
+	{
+		for (const TileLayer &layer : layers)
+			if (!layer.isTransparent())
+				return false;
+		return true;
+	}	
 
 	//! If true, the tile rotation is ignored.
 	bool world_aligned = false;

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -232,24 +232,30 @@ struct TileLayer
 			break;
 		}
 		material.BackfaceCulling = (material_flags & MATERIAL_FLAG_BACKFACE_CULLING) != 0;
-		if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
-			material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
-		}
-		if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
-			material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
+		if (!isLiquid()) {
+			// Flowing liquid needs texture wrapping to render correctly
+			if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
+				material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
+			}
+			if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
+				material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
+			}
 		}
 	}
 
 	void applyMaterialOptionsWithShaders(video::SMaterial &material) const
 	{
 		material.BackfaceCulling = (material_flags & MATERIAL_FLAG_BACKFACE_CULLING) != 0;
-		if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
-			material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
-			material.TextureLayer[1].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
-		}
-		if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
-			material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
-			material.TextureLayer[1].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
+		if (!isLiquid()) {
+			// Flowing liquid needs texture wrapping to render correctly
+			if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
+				material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
+				material.TextureLayer[1].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
+			}
+			if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
+				material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
+				material.TextureLayer[1].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
+			}
 		}
 	}
 
@@ -257,6 +263,19 @@ struct TileLayer
 	{
 		return (material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)
 			&& (material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL);
+	}
+
+	bool isLiquid() const
+	{
+		switch (material_type) {
+		case TILE_MATERIAL_LIQUID_OPAQUE:
+		case TILE_MATERIAL_LIQUID_TRANSPARENT:
+		case TILE_MATERIAL_WAVING_LIQUID_BASIC:
+		case TILE_MATERIAL_WAVING_LIQUID_OPAQUE:
+		case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
+			return true;
+		}
+		return false;
 	}
 
 	// Ordered for size, please do not reorder

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -259,19 +259,6 @@ struct TileLayer
 			&& (material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL);
 	}
 
-	bool isLiquid() const
-	{
-		switch (material_type) {
-		case TILE_MATERIAL_LIQUID_OPAQUE:
-		case TILE_MATERIAL_LIQUID_TRANSPARENT:
-		case TILE_MATERIAL_WAVING_LIQUID_BASIC:
-		case TILE_MATERIAL_WAVING_LIQUID_OPAQUE:
-		case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
-			return true;
-		}
-		return false;
-	}
-
 	bool isTransparent() const
 	{
 		switch (material_type) {

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -232,30 +232,24 @@ struct TileLayer
 			break;
 		}
 		material.BackfaceCulling = (material_flags & MATERIAL_FLAG_BACKFACE_CULLING) != 0;
-		if (!isLiquid()) {
-			// Flowing liquid needs texture wrapping to render correctly
-			if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
-				material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
-			}
-			if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
-				material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
-			}
+		if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
+			material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
+		}
+		if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
+			material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
 		}
 	}
 
 	void applyMaterialOptionsWithShaders(video::SMaterial &material) const
 	{
 		material.BackfaceCulling = (material_flags & MATERIAL_FLAG_BACKFACE_CULLING) != 0;
-		if (!isLiquid()) {
-			// Flowing liquid needs texture wrapping to render correctly
-			if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
-				material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
-				material.TextureLayer[1].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
-			}
-			if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
-				material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
-				material.TextureLayer[1].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
-			}
+		if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
+			material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
+			material.TextureLayer[1].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
+		}
+		if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
+			material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
+			material.TextureLayer[1].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
 		}
 	}
 
@@ -338,21 +332,14 @@ struct TileSpec
 		for (int layer = 0; layer < MAX_TILE_LAYERS; layer++) {
 			if (layers[layer] != other.layers[layer])
 				return false;
-			if (!layers[layer].isTileable())
+			// Only non-transparent tiles can be merged into fast faces
+			if (layers[layer].isTransparent() || !layers[layer].isTileable())
 				return false;
 		}
 		return rotation == 0
 			&& rotation == other.rotation
 			&& emissive_light == other.emissive_light;
 	}
-
-	bool isTransparent() const
-	{
-		for (const TileLayer &layer : layers)
-			if (!layer.isTransparent())
-				return false;
-		return true;
-	}	
 
 	//! If true, the tile rotation is ignored.
 	bool world_aligned = false;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -244,6 +244,7 @@ void set_default_settings()
 	settings->setDefault("enable_particles", "true");
 	settings->setDefault("arm_inertia", "true");
 	settings->setDefault("show_nametag_backgrounds", "true");
+	settings->setDefault("transparency_sorting_distance", "16");
 
 	settings->setDefault("enable_minimap", "true");
 	settings->setDefault("minimap_shape_round", "true");

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -666,7 +666,7 @@ void ContentFeatures::deSerialize(std::istream &is)
 static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 		const TileSpec &tile, const TileDef &tiledef, video::SColor color,
 		u8 material_type, u32 shader_id, bool backface_culling,
-		const TextureSettings &tsettings, AlphaMode alpha)
+		const TextureSettings &tsettings)
 {
 	layer->shader_id     = shader_id;
 	layer->texture       = tsrc->getTextureForMesh(tiledef.name, &layer->texture_id);
@@ -964,11 +964,11 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 				tsettings.world_aligned_mode, drawtype);
 		fillTileAttribs(tsrc, &tiles[j].layers[0], tiles[j], tdef[j],
 				color, material_type, tile_shader,
-				tdef[j].backface_culling, tsettings, alpha);
+				tdef[j].backface_culling, tsettings);
 		if (!tdef_overlay[j].name.empty())
 			fillTileAttribs(tsrc, &tiles[j].layers[1], tiles[j], tdef_overlay[j],
 					color, overlay_material, overlay_shader,
-					tdef[j].backface_culling, tsettings, alpha);
+					tdef[j].backface_culling, tsettings);
 	}
 
 	MaterialType special_material = material_type;
@@ -984,7 +984,7 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 	for (u16 j = 0; j < CF_SPECIAL_COUNT; j++)
 		fillTileAttribs(tsrc, &special_tiles[j].layers[0], special_tiles[j], tdef_spec[j],
 				color, special_material, special_shader,
-				tdef_spec[j].backface_culling, tsettings, alpha);
+				tdef_spec[j].backface_culling, tsettings);
 
 	if (param_type_2 == CPT2_COLOR ||
 			param_type_2 == CPT2_COLORED_FACEDIR ||

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -701,10 +701,6 @@ static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 	if (tiledef.tileable_vertical)
 		layer->material_flags |= MATERIAL_FLAG_TILEABLE_VERTICAL;
 
-	// Semi-transparent materials can never be tiled
-	if (alpha == ALPHAMODE_BLEND)
-		layer->material_flags &= ~(MATERIAL_FLAG_TILEABLE_HORIZONTAL | MATERIAL_FLAG_TILEABLE_VERTICAL);
-
 	// Color
 	layer->has_color = tiledef.has_color;
 	if (tiledef.has_color)

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -666,7 +666,7 @@ void ContentFeatures::deSerialize(std::istream &is)
 static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 		const TileSpec &tile, const TileDef &tiledef, video::SColor color,
 		u8 material_type, u32 shader_id, bool backface_culling,
-		const TextureSettings &tsettings)
+		const TextureSettings &tsettings, AlphaMode alpha)
 {
 	layer->shader_id     = shader_id;
 	layer->texture       = tsrc->getTextureForMesh(tiledef.name, &layer->texture_id);
@@ -700,6 +700,10 @@ static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 		layer->material_flags |= MATERIAL_FLAG_TILEABLE_HORIZONTAL;
 	if (tiledef.tileable_vertical)
 		layer->material_flags |= MATERIAL_FLAG_TILEABLE_VERTICAL;
+
+	// Semi-transparent materials can never be tiled
+	if (alpha == ALPHAMODE_BLEND)
+		layer->material_flags &= ~(MATERIAL_FLAG_TILEABLE_HORIZONTAL | MATERIAL_FLAG_TILEABLE_VERTICAL);
 
 	// Color
 	layer->has_color = tiledef.has_color;
@@ -964,11 +968,11 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 				tsettings.world_aligned_mode, drawtype);
 		fillTileAttribs(tsrc, &tiles[j].layers[0], tiles[j], tdef[j],
 				color, material_type, tile_shader,
-				tdef[j].backface_culling, tsettings);
+				tdef[j].backface_culling, tsettings, alpha);
 		if (!tdef_overlay[j].name.empty())
 			fillTileAttribs(tsrc, &tiles[j].layers[1], tiles[j], tdef_overlay[j],
 					color, overlay_material, overlay_shader,
-					tdef[j].backface_culling, tsettings);
+					tdef[j].backface_culling, tsettings, alpha);
 	}
 
 	MaterialType special_material = material_type;
@@ -984,7 +988,7 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 	for (u16 j = 0; j < CF_SPECIAL_COUNT; j++)
 		fillTileAttribs(tsrc, &special_tiles[j].layers[0], special_tiles[j], tdef_spec[j],
 				color, special_material, special_shader,
-				tdef_spec[j].backface_culling, tsettings);
+				tdef_spec[j].backface_culling, tsettings, alpha);
 
 	if (param_type_2 == CPT2_COLOR ||
 			param_type_2 == CPT2_COLORED_FACEDIR ||


### PR DESCRIPTION
This PR aims to implement correct painter's algorithm for transparent nodes on the map.

* Vertex indexes for all transparent faces are captured during mesh generation.
* [BSP Tree](https://en.wikipedia.org/wiki/Binary_space_partitioning) is generated for transparent triangles.
* When rendering the map, BSP tree is traversed to generate correct (in most cases) rendering order, which is applied by replacing indexes in the mesh buffers as suggested by @hecktest.

This PR supersedes parts of #11130 and fixes most of cases of transparency problems (including transparent nodebox nodes at the cost of performance).

## Handling Transparent Nodeboxes

In order to render overlapping nodeboxes correctly, this PR splits each nodebox at the edges of other nodeboxes along the same axis. This process produces a significantly larger number of 'atomic' nodeboxes that are guaranteed not to overlap, and may impact overall rendering performance. The total number of nodeboxes (defined + produced) is currently limited to 100.

## To do

This PR is Ready for Review and testing

## How to test

Use a combination of semi-transparent nodes such as:
* Alpha testing nodes in devtest
* Water
* Colored glass in Mineclone 2
* Stained glass 

Transparent nodes should be rendered correctly with minimal temporary artifacts from all angles.
