### PR TITLE
Disable dynamic shadows for 5.5.0 release

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -218,10 +218,10 @@ local function formspec(tabview, name, tabdata)
 			"checkbox[8.25,1.5;cb_waving_leaves;" .. fgettext("Waving Leaves") .. ";"
 					.. dump(core.settings:get_bool("enable_waving_leaves")) .. "]" ..
 			"checkbox[8.25,2;cb_waving_plants;" .. fgettext("Waving Plants") .. ";"
-					.. dump(core.settings:get_bool("enable_waving_plants")) .. "]"..
-			"label[8.25,3.0;" .. fgettext("Dynamic shadows: ") .. "]" ..
-			"dropdown[8.25,3.5;3.5;dd_shadows;" .. dd_options.shadow_levels[1] .. ";"
-					.. getSettingIndex.ShadowMapping() .. "]"
+					.. dump(core.settings:get_bool("enable_waving_plants")) .. "]"
+			--"label[8.25,3.0;" .. fgettext("Dynamic shadows: ") .. "]" ..
+			--"dropdown[8.25,3.5;3.5;dd_shadows;" .. dd_options.shadow_levels[1] .. ";"
+			--		.. getSettingIndex.ShadowMapping() .. "]"
 	else
 		tab_string = tab_string ..
 			"label[8.38,0.7;" .. core.colorize("#888888",
@@ -231,9 +231,9 @@ local function formspec(tabview, name, tabdata)
 			"label[8.38,1.7;" .. core.colorize("#888888",
 					fgettext("Waving Leaves")) .. "]" ..
 			"label[8.38,2.2;" .. core.colorize("#888888",
-					fgettext("Waving Plants")) .. "]"..
-			"label[8.38,2.7;" .. core.colorize("#888888",
-					fgettext("Dynamic shadows")) .. "]"
+					fgettext("Waving Plants")) .. "]"
+			--"label[8.38,2.7;" .. core.colorize("#888888",
+			--		fgettext("Dynamic shadows")) .. "]"
 	end
 
 	return tab_string

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -586,58 +586,6 @@ enable_waving_leaves (Waving leaves) bool false
 #    Requires shaders to be enabled.
 enable_waving_plants (Waving plants) bool false
 
-[***Dynamic shadows]
-
-#    Set to true to enable Shadow Mapping.
-#    Requires shaders to be enabled.
-enable_dynamic_shadows (Dynamic shadows) bool false
-
-#    Set the shadow strength.
-#    Lower value means lighter shadows, higher value means darker shadows.
-shadow_strength (Shadow strength) float 0.2 0.05 1.0
-
-#    Maximum distance to render shadows.
-shadow_map_max_distance (Shadow map max distance in nodes to render shadows) float 120.0 10.0 1000.0
-
-#    Texture size to render the shadow map on.
-#    This must be a power of two.
-#    Bigger numbers create better shadows but it is also more expensive.
-shadow_map_texture_size (Shadow map texture size) int 1024 128 8192
-
-#    Sets shadow texture quality to 32 bits.
-#    On false, 16 bits texture will be used.
-#    This can cause much more artifacts in the shadow.
-shadow_map_texture_32bit (Shadow map texture in 32 bits) bool true
-
-#    Enable Poisson disk filtering.
-#    On true uses Poisson disk to make "soft shadows". Otherwise uses PCF filtering.
-shadow_poisson_filter (Poisson filtering) bool true
-
-#   Define shadow filtering quality.
-#   This simulates the soft shadows effect by applying a PCF or Poisson disk
-#   but also uses more resources.
-shadow_filters (Shadow filter quality) enum 1 0,1,2
-
-#    Enable colored shadows.
-#    On true translucent nodes cast colored shadows. This is expensive.
-shadow_map_color (Colored shadows) bool false
-
-#    Spread a complete update of shadow map over given amount of frames.
-#    Higher values might make shadows laggy, lower values
-#    will consume more resources.
-#    Minimum value: 1; maximum value: 16
-shadow_update_frames (Map shadows update frames) int 8 1 16
-
-#    Set the soft shadow radius size.
-#    Lower values mean sharper shadows, bigger values mean softer shadows.
-#    Minimum value: 1.0; maximum value: 10.0
-shadow_soft_radius (Soft shadow radius) float 1.0 1.0 10.0
-
-#    Set the tilt of Sun/Moon orbit in degrees.
-#    Value of 0 means no tilt / vertical orbit.
-#    Minimum value: 0.0; maximum value: 60.0
-shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 0.0 60.0
-
 [**Advanced]
 
 #    Arm inertia, gives a more realistic movement of

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -666,69 +666,6 @@
 #    type: bool
 # enable_waving_plants = false
 
-#### Dynamic shadows
-
-#    Set to true to enable Shadow Mapping.
-#    Requires shaders to be enabled.
-#    type: bool
-# enable_dynamic_shadows = false
-
-#    Set the shadow strength.
-#    Lower value means lighter shadows, higher value means darker shadows.
-#    type: float min: 0.05 max: 1
-# shadow_strength = 0.2
-
-#    Maximum distance to render shadows.
-#    type: float min: 10 max: 1000
-# shadow_map_max_distance = 120.0
-
-#    Texture size to render the shadow map on.
-#    This must be a power of two.
-#    Bigger numbers create better shadows but it is also more expensive.
-#    type: int min: 128 max: 8192
-# shadow_map_texture_size = 1024
-
-#    Sets shadow texture quality to 32 bits.
-#    On false, 16 bits texture will be used.
-#    This can cause much more artifacts in the shadow.
-#    type: bool
-# shadow_map_texture_32bit = true
-
-#    Enable Poisson disk filtering.
-#    On true uses Poisson disk to make "soft shadows". Otherwise uses PCF filtering.
-#    type: bool
-# shadow_poisson_filter = true
-
-#    Define shadow filtering quality.
-#    This simulates the soft shadows effect by applying a PCF or Poisson disk
-#    but also uses more resources.
-#    type: enum values: 0, 1, 2
-# shadow_filters = 1
-
-#    Enable colored shadows.
-#    On true translucent nodes cast colored shadows. This is expensive.
-#    type: bool
-# shadow_map_color = false
-
-#    Spread a complete update of shadow map over given amount of frames.
-#    Higher values might make shadows laggy, lower values
-#    will consume more resources.
-#    Minimum value: 1; maximum value: 16
-#    type: int min: 1 max: 16
-# shadow_update_frames = 8
-
-#    Set the soft shadow radius size.
-#    Lower values mean sharper shadows, bigger values mean softer shadows.
-#    Minimum value: 1.0; maximum value: 10.0
-#    type: float min: 1 max: 10
-# shadow_soft_radius = 1.0
-
-#    Set the tilt of Sun/Moon orbit in degrees.
-#    Value of 0 means no tilt / vertical orbit.
-#    Minimum value: 0.0; maximum value: 60.0
-#    type: float min: 0 max: 60
-# shadow_sky_body_orbit_tilt = 0.0
-
 ### Advanced
 
 #    Arm inertia, gives a more realistic movement of

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -861,7 +861,7 @@ static void updateFastFaceRow(
 		g_settings->getBool("enable_waving_water");
 
 	static thread_local const bool force_not_tiling =
-			g_settings->getBool("enable_dynamic_shadows");
+			false && g_settings->getBool("enable_dynamic_shadows");
 
 	v3s16 p = startpos;
 

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -36,7 +36,7 @@ RenderingCore::RenderingCore(IrrlichtDevice *_device, Client *_client, Hud *_hud
 	virtual_size = screensize;
 
 	if (g_settings->getBool("enable_shaders") &&
-			g_settings->getBool("enable_dynamic_shadows")) {
+			false && g_settings->getBool("enable_dynamic_shadows")) {
 		shadow_renderer = new ShadowRenderer(device, client);
 	}
 }

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -123,8 +123,8 @@ public:
 	// FIXME: this is still global when it shouldn't be
 	static ShadowRenderer *get_shadow_renderer()
 	{
-		if (s_singleton && s_singleton->core)
-			return s_singleton->core->get_shadow_renderer();
+		//if (s_singleton && s_singleton->core)
+		//	return s_singleton->core->get_shadow_renderer();
 		return nullptr;
 	}
 	static std::vector<irr::video::E_DRIVER_TYPE> getSupportedVideoDrivers();

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -733,7 +733,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 
 	shaders_header << "#define FOG_START " << core::clamp(g_settings->getFloat("fog_start"), 0.0f, 0.99f) << "\n";
 
-	if (g_settings->getBool("enable_dynamic_shadows")) {
+	if (false && g_settings->getBool("enable_dynamic_shadows")) {
 		shaders_header << "#define ENABLE_DYNAMIC_SHADOWS 1\n";
 		if (g_settings->getBool("shadow_map_color"))
 			shaders_header << "#define COLORED_SHADOWS 1\n";

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -103,7 +103,7 @@ Sky::Sky(s32 id, RenderingEngine *rendering_engine, ITextureSource *tsrc, IShade
 
 	m_directional_colored_fog = g_settings->getBool("directional_colored_fog");
 
-	if (g_settings->getBool("enable_dynamic_shadows")) {
+	if (false && g_settings->getBool("enable_dynamic_shadows")) {
 		float val = g_settings->getFloat("shadow_sky_body_orbit_tilt");
 		m_sky_body_orbit_tilt = rangelim(val, 0.0f, 60.0f);
 	}


### PR DESCRIPTION
This is the minimal set of changes required to disable the dynamic shadows for the 5.5.0 release. I did not remove `dynamicshadowsrender.cpp` entirely due to references across the code which would need `#if 0` everywhere, resulting in cluttered code.

Supersedes PR #11677.

List of issues related to the dynamic shadows feature:
 * #11365
 * ~~#11437~~

## To do

This PR is Ready for Review.

## How to test

1. Check whether the 3D modes work again
2. No settings must be documented
