### PR TITLE
Limit stepheight smoothing to the stepheight and stop smoothing during jumps

### DIFF
--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -218,6 +218,8 @@ private:
 	// Camera offset
 	v3s16 m_camera_offset;
 
+	bool m_stepheight_smooth_active = false;
+
 	// Server-sent FOV variables
 	bool m_server_sent_fov = false;
 	f32 m_curr_fov_degrees, m_old_fov_degrees, m_target_fov_degrees;


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - Player step height camera smoothing should not be applied with very large upward position changes. For example, if you teleport 1000 nodes upward, you should not experience your point of view moving over time. Instead, your point of view should simply appear in the new location.
  - I have also tried to remove smoothing when jumping.
- How does the PR work?
  - Before applying the smoothing, it checks that the upward movement is less than or equal to the stepheight of the player.
  - Instead of checking `!player->is_climbing && !flying`, the code checks `player->touching_ground`. This prevents smoothing when the player is jumping.
- Does it resolve any reported issue?
  - No.
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
  - No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  - This is a bug fix.

## To do

This PR is Ready for Review.

## How to test

1. Add this code to some mod:
   ```lua
   minetest.register_on_joinplayer(function(p)
     p:set_properties({stepheight = 2})
   end)
   ```
2. With this code, load a flat devtest world.
3. Place solid blocks at (0, 9, 0) and (0, 10, 0)
3. Execute `/teleport 0 8.5 0`.
4. Execute `/teleport 0 10.5 0`. Your point of view should smoothly move upward.
3. Execute `/teleport 0 8.5 0`.
5. Execute `/teleport 0 11.5 0`. Your point of view should abruptly teleport upward.
6. Try to make sure you see the smoothing when walking up stairs and stuff.
7. Making sure jumping, flying, and climbing still look right.
