### PR TITLE
Preserve attachment velocity on detach

### DIFF
--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -44,22 +44,28 @@ public:
 
 	virtual void updateLight(u32 day_night_ratio) {}
 
-	virtual bool getCollisionBox(aabb3f *toset) const { return false; }
-	virtual bool getSelectionBox(aabb3f *toset) const { return false; }
-	virtual bool collideWithObjects() const { return false; }
-	virtual const v3f getPosition() const { return v3f(0.0f); }
-	virtual scene::ISceneNode *getSceneNode() const
-	{ return NULL; }
+	virtual scene::ISceneNode *getSceneNode() const { return NULL; }
 	virtual scene::IAnimatedMeshSceneNode *getAnimatedMeshSceneNode() const
 	{ return NULL; }
 	virtual bool isLocalPlayer() const { return false; }
 
+	/*
+		Physics-related
+	*/
+	virtual bool getCollisionBox(aabb3f *toset) const { return false; }
+	virtual bool getSelectionBox(aabb3f *toset) const { return false; }
+	virtual bool collideWithObjects() const { return false; }
+	virtual bool doShowSelectionBox() { return true; }
+	virtual v3f getPosition() const { return v3f(0.0f); }
+	virtual v3f getVelocity() const { return v3f(0.0f); }
+
+	/*
+		Attachments
+	*/
 	virtual ClientActiveObject *getParent() const { return nullptr; };
 	virtual const std::unordered_set<int> &getAttachmentChildIds() const
 	{ static std::unordered_set<int> rv; return rv; }
 	virtual void updateAttachments() {};
-
-	virtual bool doShowSelectionBox() { return true; }
 
 	// Step object in time
 	virtual void step(float dtime, ClientEnvironment *env) {}

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -157,18 +157,23 @@ public:
 
 	void processInitData(const std::string &data);
 
+	/*
+		Physics-related
+	*/
 	bool getCollisionBox(aabb3f *toset) const;
 
 	bool collideWithObjects() const;
 
 	virtual bool getSelectionBox(aabb3f *toset) const;
 
-	const v3f getPosition() const;
+	v3f getPosition() const;
 
 	void setPosition(const v3f &pos)
 	{
 		pos_translator.val_current = pos;
 	}
+
+	v3f getVelocity() const;
 
 	inline const v3f &getRotation() const { return m_rotation; }
 
@@ -220,6 +225,9 @@ public:
 		m_is_visible = toset;
 	}
 
+	/*
+		Attachments
+	*/
 	void setChildrenVisible(bool toset);
 	void setAttachment(int parent_id, const std::string &bone, v3f position,
 			v3f rotation, bool force_visible);

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -208,6 +208,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	PROTOCOL VERSION 40:
 		Added 'basic_debug' privilege
 		TOCLIENT_MEDIA_PUSH changed, TOSERVER_HAVE_MEDIA added
+		Preserved velocity on detach
 */
 
 #define LATEST_PROTOCOL_VERSION 40

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -402,29 +402,14 @@ void LuaEntitySAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
 	m_hp = rangelim(hp, 0, U16_MAX);
 }
 
-u16 LuaEntitySAO::getHP() const
-{
-	return m_hp;
-}
-
 void LuaEntitySAO::setVelocity(v3f velocity)
 {
 	m_velocity = velocity;
 }
 
-v3f LuaEntitySAO::getVelocity()
-{
-	return m_velocity;
-}
-
 void LuaEntitySAO::setAcceleration(v3f acceleration)
 {
 	m_acceleration = acceleration;
-}
-
-v3f LuaEntitySAO::getAcceleration()
-{
-	return m_acceleration;
 }
 
 void LuaEntitySAO::setTextureMod(const std::string &mod)

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -402,6 +402,20 @@ void LuaEntitySAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
 	m_hp = rangelim(hp, 0, U16_MAX);
 }
 
+void LuaEntitySAO::setAttachment(int parent_id, const std::string &bone, v3f position,
+			v3f rotation, bool force_visible)
+{
+	auto *old_parent = getParent();
+	UnitSAO::setAttachment(parent_id, bone, position, rotation, force_visible);
+	if (old_parent && !getParent()) {
+		// Detached. Preserve velocity from the moving parent.
+		while (old_parent->getParent())
+			old_parent = old_parent->getParent();
+
+		setVelocity(old_parent->getVelocity());
+	}
+}
+
 void LuaEntitySAO::setVelocity(v3f velocity)
 {
 	m_velocity = velocity;

--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -36,9 +36,13 @@ public:
 	{
 	}
 	~LuaEntitySAO();
+
+	/*
+		Overloaded functions from ServerActiveObject
+	*/
 	ActiveObjectType getType() const { return ACTIVEOBJECT_TYPE_LUAENTITY; }
 	ActiveObjectType getSendType() const { return ACTIVEOBJECT_TYPE_GENERIC; }
-	virtual void addedToEnvironment(u32 dtime_s);
+	void addedToEnvironment(u32 dtime_s);
 	void step(float dtime, bool send_recommended);
 	std::string getClientInitializationData(u16 protocol_version);
 	bool isStaticAllowed() const { return m_prop.static_save; }
@@ -48,19 +52,23 @@ public:
 			ServerActiveObject *puncher = nullptr,
 			float time_from_last_punch = 1000000.0f);
 	void rightClick(ServerActiveObject *clicker);
+
 	void setPos(const v3f &pos);
 	void moveTo(v3f pos, bool continuous);
+	v3f getVelocity() const { return m_velocity; }
+
 	float getMinimumSavedMovement();
 	std::string getDescription();
 	void setHP(s32 hp, const PlayerHPChangeReason &reason);
-	u16 getHP() const;
+	u16 getHP() const { return m_hp; }
 
-	/* LuaEntitySAO-specific */
+	/*
+		LuaEntitySAO-specific functions
+	*/
 	void setVelocity(v3f velocity);
 	void addVelocity(v3f velocity) { m_velocity += velocity; }
-	v3f getVelocity();
 	void setAcceleration(v3f acceleration);
-	v3f getAcceleration();
+	v3f getAcceleration() { return m_acceleration; }
 
 	void setTextureMod(const std::string &mod);
 	std::string getTextureMod() const;

--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -62,6 +62,9 @@ public:
 	void setHP(s32 hp, const PlayerHPChangeReason &reason);
 	u16 getHP() const { return m_hp; }
 
+	void setAttachment(int parent_id, const std::string &bone, v3f position,
+			v3f rotation, bool force_visible);
+
 	/*
 		LuaEntitySAO-specific functions
 	*/

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -87,9 +87,19 @@ public:
 	std::string getClientInitializationData(u16 protocol_version);
 	void getStaticData(std::string *result) const;
 	void step(float dtime, bool send_recommended);
+
+	void setAttachment(int parent_id, const std::string &bone, v3f position,
+			v3f rotation, bool force_visible);
+
+	/*
+		Physics: position, direction, view, etc
+	*/
+
 	void setBasePosition(const v3f &position);
 	void setPos(const v3f &pos);
 	void moveTo(v3f pos, bool continuous);
+	v3f getVelocity() const;
+
 	void setPlayerYaw(const float yaw);
 	// Data should not be sent at player initialization
 	void setPlayerYawAndSend(const float yaw);
@@ -141,7 +151,9 @@ public:
 	RemotePlayer *getPlayer() { return m_player; }
 	session_t getPeerID() const { return m_peer_id; }
 
-	// Cheat prevention
+	/*
+		Cheat prevention
+	*/
 
 	v3f getLastGoodPosition() const { return m_last_good_position; }
 	float resetTimeFromLastPunch()

--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -95,6 +95,7 @@ public:
 	// continuous: if true, object does not stop immediately at pos
 	virtual void moveTo(v3f pos, bool continuous)
 		{ setBasePosition(pos); }
+	virtual v3f getVelocity() const { return v3f(); }
 	// If object has moved less than this and data has not changed,
 	// saving to disk may be omitted
 	virtual float getMinimumSavedMovement();

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -63,9 +63,9 @@ public:
 	// Attachments
 	ServerActiveObject *getParent() const;
 	inline bool isAttached() const { return getParent(); }
-	void setAttachment(int parent_id, const std::string &bone, v3f position,
+	virtual void setAttachment(int parent_id, const std::string &bone, v3f position,
 			v3f rotation, bool force_visible);
-	void getAttachment(int *parent_id, std::string *bone, v3f *position,
+	virtual void getAttachment(int *parent_id, std::string *bone, v3f *position,
 			v3f *rotation, bool *force_visible) const;
 	void clearChildAttachments();
 	void clearParentAttachment();


### PR DESCRIPTION
This is a minor improvement to make the physics a bit more realistic.
After detaching from its parent, the child object will inherit its velocity. The difference is noticeable when detaching mid-air with high velocity, or when riding a fast cart and "jumping off".

## To do

This PR is Ready for Review.

## How to test

1. https://github.com/minetest/minetest_game/blob/5273fcb3ad35502abfb7c9e5b43c0cd74ddc49fb/mods/carts/init.lua#L11-L14 : Change these limits to 100 each
2. Drive real fast
3. Detach
4. Notice the minor difference