### PR TITLE
Expose LuaJIT bit module

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -240,6 +240,14 @@ void ScriptApiSecurity::initializeSecurity()
 	lua_pop(L, 1);  // Pop old package
 
 #if USE_LUAJIT
+	// Copy bit functions, if they exist
+	lua_getfield(L, -1, "bit");
+	if (!lua_isnil(L, -1)) {
+		lua_newtable(L);
+		shallow_copy_table(L);
+		lua_setglobal(L, "bit");
+	}
+	lua_pop(L, 1);  // Pop old bit
 	// Copy safe jit functions, if they exist
 	lua_getfield(L, -1, "jit");
 	if (!lua_isnil(L, -1)) {


### PR DESCRIPTION
Fixes #9843 for builds which have LuaJIT enabled. A better solution might be to make [Lua BitOp](https://bitop.luajit.org/download.html) available to allow both LuaJIT and non-LuaJIT builds to use BitOps.
