### PR TITLE
Update to Android target SDK 30

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 android {
-	compileSdkVersion 29
+	compileSdkVersion 30
 	buildToolsVersion '30.0.3'
 	ndkVersion "$ndk_version"
 	defaultConfig {
 		applicationId 'net.minetest.minetest'
 		minSdkVersion 16
-		targetSdkVersion 29
+		targetSdkVersion 30
 		versionName "${versionMajor}.${versionMinor}.${versionPatch}"
 		versionCode project.versionCode
 	}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,7 +30,8 @@
 			android:configChanges="orientation|keyboardHidden|navigation|screenSize"
 			android:maxAspectRatio="3.0"
 			android:screenOrientation="sensorLandscape"
-			android:theme="@style/AppTheme">
+			android:theme="@style/AppTheme"
+			android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
@@ -44,7 +45,8 @@
 			android:launchMode="singleTask"
 			android:maxAspectRatio="3.0"
 			android:screenOrientation="sensorLandscape"
-			android:theme="@style/AppTheme">
+			android:theme="@style/AppTheme"
+			android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 			</intent-filter>

--- a/android/app/src/main/java/net/minetest/minetest/MainActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/MainActivity.java
@@ -101,7 +101,8 @@ public class MainActivity extends AppCompatActivity {
 		mTextView = findViewById(R.id.textView);
 		sharedPreferences = getSharedPreferences(SETTINGS, Context.MODE_PRIVATE);
 
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+				Build.VERSION.SDK_INT < Build.VERSION_CODES.R)
 			checkPermission();
 		else
 			checkAppVersion();

--- a/android/app/src/main/java/net/minetest/minetest/UnzipService.java
+++ b/android/app/src/main/java/net/minetest/minetest/UnzipService.java
@@ -32,6 +32,7 @@ import android.os.Environment;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.StringRes;
 
 import java.io.File;
@@ -200,6 +201,10 @@ public class UnzipService extends IntentService {
 	 * Migrates user data from deprecated external storage to app scoped storage
 	 */
 	private void migrate(Notification.Builder notificationBuilder, File newLocation) throws IOException {
+		if (Build.VERSION.SDK_INT >=  Build.VERSION_CODES.R) {
+			return;
+		}
+
 		File oldLocation = new File(Environment.getExternalStorageDirectory(), "Minetest");
 		if (!oldLocation.isDirectory())
 			return;

--- a/android/native/build.gradle
+++ b/android/native/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'de.undercouch.download'
 
 android {
-	compileSdkVersion 29
+	compileSdkVersion 30
 	buildToolsVersion '30.0.3'
 	ndkVersion "$ndk_version"
 	defaultConfig {
 		minSdkVersion 16
-		targetSdkVersion 29
+		targetSdkVersion 30
 		externalNativeBuild {
 			ndkBuild {
 				arguments '-j' + Runtime.getRuntime().availableProcessors(),


### PR DESCRIPTION
Google Play now requires target API 30

## To do
Testing

## How to test

Warning: Uninstalling the app may delete any worlds

Builds: https://github.com/rubenwardy/minetest/releases/tag/android-30

Perform the following on Android 11, 10, and 4/5:

* Check migration
  * Create worlds on the old version of the app
  * Upgrade
  * Run Minetest again, check that the worlds still appear
* Check new install
  * With no Minetest data, check that you can install the PR version and it works