### PR TITLE
Render shadows on entities.

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -533,8 +533,6 @@ void main(void)
 			(1.0 - adjusted_night_ratio) * ( // natural light
 					col.rgb * (1.0 - shadow_int * (1.0 - shadow_color)) +  // filtered texture color
 					dayLight * shadow_color * shadow_int);                 // reflected filtered sunlight/moonlight
-	// col.r = 0.5 * clamp(getPenumbraRadius(ShadowMapSampler, posLightSpace.xy, posLightSpace.z, 1.0) / SOFTSHADOWRADIUS, 0.0, 1.0) + 0.5 * col.r;
-	// col.r = adjusted_night_ratio; // debug night ratio adjustment
 #endif
 
 #if ENABLE_TONE_MAPPING

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -187,6 +187,9 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 
 	if (PCFBOUND == 0.0) return 0.0;
 	// Return fast if sharp shadows are requested
+	if (PCFBOUND == 0.0)
+		return 0.0;
+
 	if (SOFTSHADOWRADIUS <= 1.0) {
 		perspectiveFactor = getDeltaPerspectiveFactor(baseLength);
 		return max(2 * length(smTexCoord.xy) * 2048 / f_textureresolution / pow(perspectiveFactor, 3), SOFTSHADOWRADIUS);

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -74,8 +74,7 @@ vec3 getLightSpacePosition()
 	#if DRAW_TYPE == NDT_PLANTLIKE
 	pLightSpace = m_ShadowViewProj * vec4(worldPosition, 1.0);
 	#else
-	float offsetScale = (0.0057 * getLinearDepth() + normalOffsetScale);
-	pLightSpace = m_ShadowViewProj * vec4(worldPosition + offsetScale * normalize(vNormal), 1.0);
+	pLightSpace = m_ShadowViewProj * vec4(worldPosition + normalOffsetScale * normalize(vNormal), 1.0);
 	#endif
 	pLightSpace = getPerspectiveFactor(pLightSpace);
 	return pLightSpace.xyz * 0.5 + 0.5;

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -514,8 +514,12 @@ void main(void)
 	// Power ratio was measured on torches in MTG (brightness = 14).
 	float adjusted_night_ratio = pow(max(0.0, nightRatio), 0.6);
 
-	if (f_normal_length != 0 && cosLight < 0.035) {
-		shadow_int = max(shadow_int, 1 - clamp(cosLight, 0.0, 0.035)/0.035);
+	// Apply self-shadowing when light falls at a narrow angle to the surface
+	// Cosine of the cut-off angle.
+	const float self_shadow_cutoff_cosine = 0.035;
+	if (f_normal_length != 0 && cosLight < self_shadow_cutoff_cosine) {
+		shadow_int = max(shadow_int, 1 - clamp(cosLight, 0.0, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);
+		shadow_color = mix(vec3(0.0), shadow_color, min(cosLight, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);
 	}
 
 	shadow_int *= f_adj_shadow_strength;

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -45,6 +45,8 @@ varying float nightRatio;
 const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
 const float e = 2.718281828459;
 const float BS = 10.0;
+const float bias0 = 0.9;
+const float bias1 = 1.0 - bias0;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 // custom smoothstep implementation because it's not defined in glsl1.2
@@ -195,10 +197,20 @@ void main(void)
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	vec3 nNormal = normalize(vNormal);
 	cosLight = dot(nNormal, -v_LightDirection);
-	float texelSize = 767.0 / f_textureresolution;
-	float slopeScale = clamp(1.0 - abs(cosLight), 0.0, 1.0);
-	normalOffsetScale = texelSize * slopeScale;
 	
+	// Calculate normal offset scale based on the texel size adjusted for 
+	// curvature of the SM texture. This code must be change together with
+	// getPerspectiveFactor or any light-space transformation.
+	vec3 eyeToVertex = worldPosition - eyePosition + cameraOffset;
+	// Distance from the vertex to the player
+	float distanceToPlayer = length(eyeToVertex - v_LightDirection * dot(eyeToVertex, v_LightDirection)) / f_shadowfar;
+	// perspective factor estimation according to the 
+	float perspectiveFactor = distanceToPlayer * bias0 + bias1;
+	float texelSize = f_shadowfar * perspectiveFactor * perspectiveFactor /
+			(f_textureresolution * bias1  - perspectiveFactor * bias0);
+	float slopeScale = clamp(pow(1.0 - cosLight*cosLight, 0.5), 0.0, 1.0);
+	normalOffsetScale = texelSize * slopeScale;
+
 	if (f_timeofday < 0.2) {
 		adj_shadow_strength = f_shadow_strength * 0.5 *
 			(1.0 - mtsmoothstep(0.18, 0.2, f_timeofday));

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -508,7 +508,7 @@ void main(void)
 	// turns out that nightRatio falls off much faster than
 	// actual brightness of artificial light in relation to natual light.
 	// Power ratio was measured on torches in MTG (brightness = 14).
-	float adjusted_night_ratio = pow(nightRatio, 0.6);
+	float adjusted_night_ratio = pow(max(0.0, nightRatio), 0.6);
 
 	// cosine of the normal-to-light angle when
 	// we start to apply self-shadowing

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -471,7 +471,7 @@ void main(void)
 	color = base.rgb;
 	vec4 col = vec4(color.rgb, base.a);
 	col.rgb *= varColor.rgb;
-	col.rgb *= emissiveColor.rgb * vIDiff;
+	col.rgb *= vIDiff;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	float shadow_int = 0.0;

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -507,8 +507,12 @@ void main(void)
 	// Power ratio was measured on torches in MTG (brightness = 14).
 	float adjusted_night_ratio = pow(nightRatio, 0.6);
 
-	if (f_normal_length != 0 && cosLight < 0.035) {
-		shadow_int = max(shadow_int, 1 - clamp(cosLight, 0.0, 0.035)/0.035);
+	// cosine of the normal-to-light angle when
+	// we start to apply self-shadowing
+	const float self_shadow_cutoff_cosine = 0.14;
+	if (f_normal_length != 0 && cosLight < self_shadow_cutoff_cosine) {
+		shadow_int = max(shadow_int, 1 - clamp(cosLight, 0.0, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);
+		shadow_color = mix(vec3(0.0), shadow_color, min(cosLight, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);
 	}
 
 	shadow_int *= f_adj_shadow_strength;

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -181,6 +181,9 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	float perspectiveFactor;
 
 	// Return fast if sharp shadows are requested
+	if (PCFBOUND == 0.0)
+		return 0.0;
+		
 	if (SOFTSHADOWRADIUS <= 1.0) {
 		perspectiveFactor = getDeltaPerspectiveFactor(baseLength);
 		return max(2 * length(smTexCoord.xy) * 2048 / f_textureresolution / pow(perspectiveFactor, 3), SOFTSHADOWRADIUS);

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -56,12 +56,6 @@ vec4 getPerspectiveFactor(in vec4 shadowPosition)
 	return shadowPosition;
 }
 
-// assuming near is always 1.0
-float getLinearDepth()
-{
-	return 2.0 * f_shadowfar / (f_shadowfar + 1.0 - (2.0 * gl_FragCoord.z - 1.0) * (f_shadowfar - 1.0));
-}
-
 vec3 getLightSpacePosition()
 {
 	vec4 pLightSpace;
@@ -69,8 +63,7 @@ vec3 getLightSpacePosition()
 	#if DRAW_TYPE == NDT_PLANTLIKE
 	pLightSpace = m_ShadowViewProj * vec4(worldPosition, 1.0);
 	#else
-	float offsetScale = (0.0057 * getLinearDepth() + normalOffsetScale);
-	pLightSpace = m_ShadowViewProj * vec4(worldPosition + offsetScale * normalize(vNormal), 1.0);
+	pLightSpace = m_ShadowViewProj * vec4(worldPosition + normalOffsetScale * normalize(vNormal), 1.0);
 	#endif
 	pLightSpace = getPerspectiveFactor(pLightSpace);
 	return pLightSpace.xyz * 0.5 + 0.5;
@@ -544,6 +537,5 @@ void main(void)
 	float clarity = clamp(fogShadingParameter
 		- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
 	col = mix(skyBgColor, col, clarity);
-
 	gl_FragColor = vec4(col.rgb, base.a);
 }

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -526,8 +526,6 @@ void main(void)
 			(1.0 - adjusted_night_ratio) * ( // natural light
 					col.rgb * (1.0 - shadow_int * (1.0 - shadow_color)) +  // filtered texture color
 					dayLight * shadow_color * shadow_int);                 // reflected filtered sunlight/moonlight
-	// col.r = 0.5 * clamp(getPenumbraRadius(ShadowMapSampler, posLightSpace.xy, posLightSpace.z, 1.0) / SOFTSHADOWRADIUS, 0.0, 1.0) + 0.5 * col.r;
-	// col.r = adjusted_night_ratio; // debug night ratio adjustment
 #endif
 
 #if ENABLE_TONE_MAPPING

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -3,6 +3,7 @@ uniform vec3 dayLight;
 uniform vec3 eyePosition;
 uniform float animationTimer;
 uniform vec4 emissiveColor;
+uniform vec3 cameraOffset;
 
 
 varying vec3 vNormal;
@@ -110,10 +111,13 @@ void main(void)
 	// Calculate normal offset scale based on the texel size adjusted for 
 	// curvature of the SM texture. This code must be change together with
 	// getPerspectiveFactor or any light-space transformation.
-	float distanceToPlayer = length((eyePosition - worldPosition).xyz) / f_shadowfar;
+	vec3 eyeToVertex = worldPosition - eyePosition + cameraOffset;
+	// Distance from the vertex to the player
+	float distanceToPlayer = length(eyeToVertex - v_LightDirection * dot(eyeToVertex, v_LightDirection)) / f_shadowfar;
+	// perspective factor estimation according to the 
 	float perspectiveFactor = distanceToPlayer * bias0 + bias1;
-	float texelSize = 1.0 / f_textureresolution;
-	texelSize *= f_shadowfar * perspectiveFactor / (bias1 / perspectiveFactor - texelSize * bias0) * 0.15;
+	float texelSize = f_shadowfar * perspectiveFactor * perspectiveFactor /
+			(f_textureresolution * bias1  - perspectiveFactor * bias0);
 	float slopeScale = clamp(pow(1.0 - cosLight*cosLight, 0.5), 0.0, 1.0);
 	normalOffsetScale = texelSize * slopeScale;
 	

--- a/client/shaders/shadow_shaders/pass1_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_vertex.glsl
@@ -22,5 +22,5 @@ void main()
 	tPos = getPerspectiveFactor(pos);
 
 	gl_Position = vec4(tPos.xyz, 1.0);
-	gl_TexCoord[0].st = gl_MultiTexCoord0.st;
+	gl_TexCoord[0] = gl_TextureMatrix[0] * gl_MultiTexCoord0;
 }

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1322,6 +1322,12 @@ void GenericCAO::updateTextures(std::string mod)
 	m_current_texture_modifier = mod;
 	m_glow = m_prop.glow;
 
+	video::ITexture *shadow_texture = nullptr;
+	if (auto shadow = RenderingEngine::get_shadow_renderer())
+		shadow_texture = shadow->get_texture();
+
+	const u32 TEXTURE_LAYER_SHADOW = 3;
+
 	if (m_spritenode) {
 		if (m_prop.visual == "sprite") {
 			std::string texturestring = "no_texture.png";
@@ -1332,6 +1338,7 @@ void GenericCAO::updateTextures(std::string mod)
 			m_spritenode->getMaterial(0).MaterialTypeParam = 0.5f;
 			m_spritenode->setMaterialTexture(0,
 					tsrc->getTextureForMesh(texturestring));
+			m_spritenode->setMaterialTexture(TEXTURE_LAYER_SHADOW, shadow_texture);
 
 			// This allows setting per-material colors. However, until a real lighting
 			// system is added, the code below will have no effect. Once MineTest
@@ -1367,6 +1374,7 @@ void GenericCAO::updateTextures(std::string mod)
 				material.MaterialType = m_material_type;
 				material.MaterialTypeParam = 0.5f;
 				material.TextureLayer[0].Texture = texture;
+				material.TextureLayer[TEXTURE_LAYER_SHADOW].Texture = shadow_texture;
 				material.setFlag(video::EMF_LIGHTING, true);
 				material.setFlag(video::EMF_BILINEAR_FILTER, false);
 				material.setFlag(video::EMF_BACK_FACE_CULLING, m_prop.backface_culling);
@@ -1417,6 +1425,7 @@ void GenericCAO::updateTextures(std::string mod)
 				material.setFlag(video::EMF_BILINEAR_FILTER, false);
 				material.setTexture(0,
 						tsrc->getTextureForMesh(texturestring));
+				material.setTexture(TEXTURE_LAYER_SHADOW, shadow_texture);
 				material.getTextureMatrix(0).makeIdentity();
 
 				// This allows setting per-material colors. However, until a real lighting
@@ -1443,6 +1452,7 @@ void GenericCAO::updateTextures(std::string mod)
 				scene::IMeshBuffer *buf = mesh->getMeshBuffer(0);
 				buf->getMaterial().setTexture(0,
 						tsrc->getTextureForMesh(tname));
+				buf->getMaterial().setTexture(TEXTURE_LAYER_SHADOW, shadow_texture);
 
 				// This allows setting per-material colors. However, until a real lighting
 				// system is added, the code below will have no effect. Once MineTest
@@ -1467,6 +1477,7 @@ void GenericCAO::updateTextures(std::string mod)
 				scene::IMeshBuffer *buf = mesh->getMeshBuffer(1);
 				buf->getMaterial().setTexture(0,
 						tsrc->getTextureForMesh(tname));
+				buf->getMaterial().setTexture(TEXTURE_LAYER_SHADOW, shadow_texture);
 
 				// This allows setting per-material colors. However, until a real lighting
 				// system is added, the code below will have no effect. Once MineTest

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -745,9 +745,6 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 		m_meshnode = m_smgr->addMeshSceneNode(mesh, m_matrixnode);
 		m_meshnode->grab();
 		mesh->drop();
-		// Set it to use the materials of the meshbuffers directly.
-		// This is needed for changing the texture in the future
-		m_meshnode->setReadOnlyMaterials(true);
 	} else if (m_prop.visual == "cube") {
 		grabMatrixNode();
 		scene::IMesh *mesh = createCubeMesh(v3f(BS,BS,BS));
@@ -1455,23 +1452,23 @@ void GenericCAO::updateTextures(std::string mod)
 				if (!m_prop.textures.empty())
 					tname = m_prop.textures[0];
 				tname += mod;
-				scene::IMeshBuffer *buf = mesh->getMeshBuffer(0);
-				buf->getMaterial().setTexture(0,
+				auto& material = m_meshnode->getMaterial(0);
+				material.setTexture(0,
 						tsrc->getTextureForMesh(tname));
-				buf->getMaterial().setTexture(TEXTURE_LAYER_SHADOW, shadow_texture);
+				material.setTexture(TEXTURE_LAYER_SHADOW, shadow_texture);
 
 				// This allows setting per-material colors. However, until a real lighting
 				// system is added, the code below will have no effect. Once MineTest
 				// has directional lighting, it should work automatically.
 				if(!m_prop.colors.empty()) {
-					buf->getMaterial().AmbientColor = m_prop.colors[0];
-					buf->getMaterial().DiffuseColor = m_prop.colors[0];
-					buf->getMaterial().SpecularColor = m_prop.colors[0];
+					material.AmbientColor = m_prop.colors[0];
+					material.DiffuseColor = m_prop.colors[0];
+					material.SpecularColor = m_prop.colors[0];
 				}
 
-				buf->getMaterial().setFlag(video::EMF_TRILINEAR_FILTER, use_trilinear_filter);
-				buf->getMaterial().setFlag(video::EMF_BILINEAR_FILTER, use_bilinear_filter);
-				buf->getMaterial().setFlag(video::EMF_ANISOTROPIC_FILTER, use_anisotropic_filter);
+				material.setFlag(video::EMF_TRILINEAR_FILTER, use_trilinear_filter);
+				material.setFlag(video::EMF_BILINEAR_FILTER, use_bilinear_filter);
+				material.setFlag(video::EMF_ANISOTROPIC_FILTER, use_anisotropic_filter);
 			}
 			{
 				std::string tname = "no_texture.png";
@@ -1480,27 +1477,27 @@ void GenericCAO::updateTextures(std::string mod)
 				else if (!m_prop.textures.empty())
 					tname = m_prop.textures[0];
 				tname += mod;
-				scene::IMeshBuffer *buf = mesh->getMeshBuffer(1);
-				buf->getMaterial().setTexture(0,
+				auto& material = m_meshnode->getMaterial(1);
+				material.setTexture(0,
 						tsrc->getTextureForMesh(tname));
-				buf->getMaterial().setTexture(TEXTURE_LAYER_SHADOW, shadow_texture);
+				material.setTexture(TEXTURE_LAYER_SHADOW, shadow_texture);
 
 				// This allows setting per-material colors. However, until a real lighting
 				// system is added, the code below will have no effect. Once MineTest
 				// has directional lighting, it should work automatically.
 				if (m_prop.colors.size() >= 2) {
-					buf->getMaterial().AmbientColor = m_prop.colors[1];
-					buf->getMaterial().DiffuseColor = m_prop.colors[1];
-					buf->getMaterial().SpecularColor = m_prop.colors[1];
+					material.AmbientColor = m_prop.colors[1];
+					material.DiffuseColor = m_prop.colors[1];
+					material.SpecularColor = m_prop.colors[1];
 				} else if (!m_prop.colors.empty()) {
-					buf->getMaterial().AmbientColor = m_prop.colors[0];
-					buf->getMaterial().DiffuseColor = m_prop.colors[0];
-					buf->getMaterial().SpecularColor = m_prop.colors[0];
+					material.AmbientColor = m_prop.colors[0];
+					material.DiffuseColor = m_prop.colors[0];
+					material.SpecularColor = m_prop.colors[0];
 				}
 
-				buf->getMaterial().setFlag(video::EMF_TRILINEAR_FILTER, use_trilinear_filter);
-				buf->getMaterial().setFlag(video::EMF_BILINEAR_FILTER, use_bilinear_filter);
-				buf->getMaterial().setFlag(video::EMF_ANISOTROPIC_FILTER, use_anisotropic_filter);
+				material.setFlag(video::EMF_TRILINEAR_FILTER, use_trilinear_filter);
+				material.setFlag(video::EMF_BILINEAR_FILTER, use_bilinear_filter);
+				material.setFlag(video::EMF_ANISOTROPIC_FILTER, use_anisotropic_filter);
 			}
 			// Set mesh color (only if lighting is disabled)
 			if (!m_prop.colors.empty() && m_glow < 0)

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -125,7 +125,7 @@ private:
 	std::string m_current_texture_modifier = "";
 	bool m_visuals_expired = false;
 	float m_step_distance_counter = 0.0f;
-	u8 m_last_light = 255;
+	video::SColor m_last_light = video::SColor(0xFFFFFFFF);
 	bool m_is_visible = false;
 	s8 m_glow = 0;
 	// Material
@@ -245,7 +245,7 @@ public:
 
 	void updateLight(u32 day_night_ratio);
 
-	void setNodeLight(u8 light);
+	void setNodeLight(const video::SColor &light);
 
 	/* Get light position(s).
 	 * returns number of positions written into pos[], which must have space

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -356,7 +356,7 @@ bool checkMeshNormals(scene::IMesh *mesh)
 					buffer->getPosition(buffer->getIndices()[i+2]));
 
 			for (u16 j = 0; j < 3; j++)
-				if (plane.Normal.dotProduct(buffer->getNormal(buffer->getIndices()[j])) < 0)
+				if (plane.Normal.dotProduct(buffer->getNormal(buffer->getIndices()[i+j])) <= 0)
 					return false;
 		}
 

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -331,6 +331,9 @@ void recalculateBoundingBox(scene::IMesh *src_mesh)
 
 bool checkMeshNormals(scene::IMesh *mesh)
 {
+	// Assume correct normals if this many first faces get it right.
+	static const u16 MAX_FACES_TO_CHECK = 9;
+
 	u32 buffer_count = mesh->getMeshBufferCount();
 
 	for (u32 i = 0; i < buffer_count; i++) {
@@ -344,6 +347,19 @@ bool checkMeshNormals(scene::IMesh *mesh)
 
 		if (!std::isfinite(length) || length < 1e-10f)
 			return false;
+
+		const u16 count = MYMIN(MAX_FACES_TO_CHECK * 3, buffer->getIndexCount());
+		for (u16 i = 0; i < count; i += 3) {
+
+			core::plane3df plane(buffer->getPosition(buffer->getIndices()[i]),
+					buffer->getPosition(buffer->getIndices()[i+1]),
+					buffer->getPosition(buffer->getIndices()[i+2]));
+
+			for (u16 j = 0; j < 3; j++)
+				if (plane.Normal.dotProduct(buffer->getNormal(buffer->getIndices()[j])) < 0)
+					return false;
+		}
+
 	}
 
 	return true;

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -348,7 +348,7 @@ bool checkMeshNormals(scene::IMesh *mesh)
 		if (!std::isfinite(length) || length < 1e-10f)
 			return false;
 
-		const u16 count = MYMIN(MAX_FACES_TO_CHECK * 3, buffer->getIndexCount());
+		const u16 count = MYMIN(MAX_FACES_TO_CHECK * 3, buffer->getIndexCount() - 3);
 		for (u16 i = 0; i < count; i += 3) {
 
 			core::plane3df plane(buffer->getPosition(buffer->getIndices()[i]),

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -58,15 +58,13 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	const v3f &viewUp = cam->getCameraNode()->getUpVector();
 	v3f viewRight = look.crossProduct(viewUp);
 
-	v3f farCorner = look + viewRight * tanFovX + viewUp * tanFovY;
+	v3f farCorner = (look + viewRight * tanFovX + viewUp * tanFovY).normalize();
 	// Compute the frustumBoundingSphere radius
 	v3f boundVec = (camPos + farCorner * sfFar) - newCenter;
-	radius = boundVec.getLength() * 2.0f;
+	radius = boundVec.getLength();
 	// boundVec.getLength();
-	float vvolume = radius * 2.0f;
-
+	float vvolume = radius;
 	v3f frustumCenter = newCenter;
-	// probar radius multipliacdor en funcion del I, a menor I mas multiplicador
 	v3f eye_displacement = direction * vvolume;
 
 	// we must compute the viewmat with the position - the camera offset

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_bloated.h"
 #include <matrix4.h>
 #include "util/basic_macros.h"
+#include "constants.h"
 
 class Camera;
 class Client;
@@ -67,7 +68,7 @@ public:
 	/// Gets the light's far value.
 	f32 getMaxFarValue() const
 	{
-		return farPlane;
+		return farPlane * BS;
 	}
 
 

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -118,12 +118,8 @@ size_t ShadowRenderer::getDirectionalLightCount() const
 f32 ShadowRenderer::getMaxShadowFar() const
 {
 	if (!m_light_list.empty()) {
-		float wanted_range = m_client->getEnv().getClientMap().getWantedRange();
-
-		float zMax = m_light_list[0].getMaxFarValue() > wanted_range
-					     ? wanted_range
-					     : m_light_list[0].getMaxFarValue();
-		return zMax * MAP_BLOCKSIZE;
+		float zMax = m_light_list[0].getMaxFarValue();
+		return zMax;
 	}
 	return 0.0f;
 }

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -541,9 +541,14 @@ void WieldMeshSceneNode::changeToMesh(scene::IMesh *mesh)
 	m_meshnode->setMaterialFlag(video::EMF_NORMALIZE_NORMALS, m_lighting);
 	m_meshnode->setVisible(true);
 
-	// Add mesh to shadow caster
-	if (m_shadow)
+	if (m_shadow) {
+		// Add mesh to shadow caster
 		m_shadow->addNodeToShadowList(m_meshnode);
+
+		// Set shadow texture
+		for (u32 i = 0; i < m_meshnode->getMaterialCount(); i++)
+			m_meshnode->setMaterialTexture(3, m_shadow->get_texture());
+	}
 }
 
 void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -515,8 +515,9 @@ void WieldMeshSceneNode::setNodeLightColor(video::SColor color)
 			material.EmissiveColor = color;
 		}
 	}
-
-	setColor(color);
+	else {
+		setColor(color);
+	}
 }
 
 void WieldMeshSceneNode::render()


### PR DESCRIPTION
Fixes a number of problems with how shadows are applied to entities:
* Bug with mod 'drawers' described in #11326
* Colored shadows not being applied properly to entities
* Different shader logic being used for entities and nodes
* Light and color of entities being calculated and communicated differently from nodes
* Entity surface not being shaded correctly when facing way from directional light

What I've done so far:
* I've added code to assign SM texture to its texture layer when setting texture in content_cao.
* Implemented the same light color contract for entities as for nodes (alpha communicating the balance between natural/artificial). The only difference is that emissiveColor is used as a factor to the vertex color.
* Copied the SM logic from node shader and object shader.
* Fixed the way colored shadows are applied at small falling angle (cos(alpha) < 0.035 for nodes and 0.14 for objects)

What's left
- [x] Fix the way split-normals are loaded, since it causes problems with shading (e.g. MCL2 chests, boats, wolves)
- [x] Calibrate offset bias to remove self-shadowing on dropped node stacks (vanilla Minetest)
- [x] Fix phantom shadows from entities (looks like a broken world transformation)
- [x] (Almost) Fix self-shadowing of banner entities in MCL2 (offsets?)

This PR is Ready for Review

## How to test

* Add 'drawers' mod
* Place three drawers: one in a shadow, one on the edge and one in the sunlight.
* Place node of sand into each of the drawers (right-click)
* Drawers should display sand inventory image, properly shaded together with the drawer node itself.

Another test:
* Place any entity (e.g. animals, chests and boats in MCL2).
* Fly/walk over.
* Observe your shadow rendered on the entity.