### PR TITLE
Align health and bubble bars with default slot edges

### DIFF
--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -9,8 +9,8 @@ local health_bar_definition = {
 	number = core.PLAYER_MAX_HP_DEFAULT,
 	item = core.PLAYER_MAX_HP_DEFAULT,
 	direction = 0,
-	size = {x = 24, y = 24},
-	offset = {x = (-10 * 24) - 25, y = -(48 + 24 + 16)},
+	size = {x = 22, y = 22},
+	offset = {x = (-4 * 56), y = -(48 + 24 + 16)},
 }
 
 local breath_bar_definition = {
@@ -21,8 +21,11 @@ local breath_bar_definition = {
 	number = core.PLAYER_MAX_BREATH_DEFAULT,
 	item = core.PLAYER_MAX_BREATH_DEFAULT * 2,
 	direction = 0,
-	size = {x = 24, y = 24},
-	offset = {x = 25, y= -(48 + 24 + 16)},
+	size = {x = 22, y = 22},
+	offset = {
+		x = (4 * 56) - core.PLAYER_MAX_BREATH_DEFAULT * 22,
+		y = -(48 + 24 + 16),
+	},
 }
 
 local hud_ids = {}


### PR DESCRIPTION
This PR resolves issue #6793. It adjusts the positions of the default health bar and breath bar to align with the default 8 slots. It also shrinks their size slightly to prevent overlapping when displaying 10 hearts and 10 breath bubbles.

![Demo with Minetest game](https://broadwell.sirv.com/Minetest/minetest-game.png)

![Demo with Devtest](https://broadwell.sirv.com/Minetest/devtest.png)

<details><summary>Alignment details</summary>The leftmost edge of the health bar aligns with the leftmost edge of the leftmost item among the 8 slots. The rightmost edge of the breath bar aligns with the rightmost edge of the rightmost item among the 8 slots. In Devtest, the apparent overhang results from invisible padding around each slot item. In Minetest Game, the apparent underhang results from the width of the solid frame around each slot item.<br><div style="display:flex"><img src="https://broadwell.sirv.com/Minetest/Screenshot_20211104_201247.png" alt="Overhang in Devtest" width="200"><img src="https://broadwell.sirv.com/Minetest/Screenshot_20211104_201457.png" alt="Underhang in Minetest Game" width="200"></div></details>

## To do

This PR is Ready for Review.

- [ ] Check alignment for very large screen sizes

## How to test

- Enter a world with damage enabled
- Find a body of water and fully submerge yourself long enough to exhaust your breath while observing the health and breath bars
