### PR TITLE
Fix DLL detection issue for Windows builds

### DIFF
--- a/util/buildbot/buildwin32.sh
+++ b/util/buildbot/buildwin32.sh
@@ -28,12 +28,25 @@ if [ -z "$compiler" ]; then
 	echo "Unable to determine which MinGW compiler to use"
 	exit 1
 fi
+
+# Determine compiler version
+compiler_version=`$compiler --version | head -n1 | cut -f3 -d ' '`
+
 toolchain_file=$dir/toolchain_${compiler/-gcc/}.cmake
 echo "Using $toolchain_file"
 
-tmp=$(dirname "$(command -v $compiler)")/../i686-w64-mingw32/bin
+# Look for runtime DLLs to add
 runtime_dlls=
-[ -d "$tmp" ] && runtime_dlls=$(echo $tmp/lib{gcc_,stdc++-,winpthread-}*.dll | tr ' ' ';')
+extra_dlls_prefix="libgcc_ libstdc++- libwinpthread-"
+dll_search_dirs="/usr/i686-w64-mingw32-mingw32/bin
+/usr/i686-w64-mingw32-mingw32/lib
+/usr/lib/gcc/i686-w64-mingw32-mingw32/$compiler_version"
+for dll in $extra_dlls_prefix; do
+	for dir in $dll_search_dirs; do
+		add_dll=$(find "$dir" -name "$dll*.dll")
+		[ ! -z "$add_dll" ] && runtime_dlls="$add_dll;$runtime_dlls" && break
+	done
+done
 [ -z "$runtime_dlls" ] &&
 	echo "The compiler runtime DLLs could not be found, they might be missing in the final package."
 

--- a/util/buildbot/buildwin32.sh
+++ b/util/buildbot/buildwin32.sh
@@ -38,9 +38,9 @@ echo "Using $toolchain_file"
 # Look for runtime DLLs to add
 runtime_dlls=
 extra_dlls_prefix="libgcc_ libstdc++- libwinpthread-"
-dll_search_dirs="/usr/i686-w64-mingw32-mingw32/bin
-/usr/i686-w64-mingw32-mingw32/lib
-/usr/lib/gcc/i686-w64-mingw32-mingw32/$compiler_version"
+dll_search_dirs="/usr/i686-w64-mingw32/bin
+/usr/i686-w64-mingw32/lib
+/usr/lib/gcc/i686-w64-mingw32/$compiler_version"
 for dll in $extra_dlls_prefix; do
 	for dir in $dll_search_dirs; do
 		add_dll=$(find "$dir" -name "$dll*.dll")


### PR DESCRIPTION
This fixes the issue I stated in the comment of #11729, where the build script for win64 can't find the needed DLLs due to a typo in the build script and a flaw with the DLL detection logic.

Edit 11/10: buildbot scripts now also support building with MinGW packages from Ubuntu repos (instead of the tarball used in CI) on Ubuntu 20.04 and later.

## To do

This PR is Ready for Review.

## How to test

- ~~Install the same MinGW tarball used for GitLab CI on Ubuntu 18.04 or 20.04:~~
<pre><code><del>
  # copied from .gitlab-ci.yml
  # please run as root
  apt-get install wget xz-utils unzip git cmake gettext
  wget -nv http://minetest.kitsunemimi.pw/mingw-w64-${WIN_ARCH}_9.2.0_ubuntu18.04.tar.xz -O mingw.tar.xz
  tar -xaf mingw.tar.xz -C /usr
</del></code></pre>
- ~~Execute `util/buildbot/buildwin64.sh` and run output on Windows. should launch normally.~~
- Follow instruction in updated README in #11760: [Compiling for Windows using MinGW on GNU/Linux](https://github.com/michiganhackers/minetest/tree/win-build-docs#compiling-for-windows-using-mingw-on-gnulinux)
- Build for Windows 32-bit and 64-bit
- Test build output on Windows systems