### PR TITLE
Fix compiler detection in buildbot

### DIFF
--- a/util/buildbot/buildwin32.sh
+++ b/util/buildbot/buildwin32.sh
@@ -25,10 +25,10 @@ command -v i686-w64-mingw32-gcc-posix >/dev/null &&
 	compiler=i686-w64-mingw32-gcc-posix
 
 if [ -z "$compiler" ]; then
-	echo "Unable to determine which mingw32 compiler to use"
+	echo "Unable to determine which MinGW compiler to use"
 	exit 1
 fi
-toolchain_file=$dir/toolchain_${compiler%-gcc}.cmake
+toolchain_file=$dir/toolchain_${compiler/-gcc/}.cmake
 echo "Using $toolchain_file"
 
 tmp=$(dirname "$(command -v $compiler)")/../i686-w64-mingw32/bin

--- a/util/buildbot/buildwin64.sh
+++ b/util/buildbot/buildwin64.sh
@@ -20,15 +20,15 @@ libdir=$builddir/libs
 
 # Test which win64 compiler is present
 command -v x86_64-w64-mingw32-gcc >/dev/null &&
-	compiler=x86_64-w64-mingw32
+	compiler=x86_64-w64-mingw32-gcc
 command -v x86_64-w64-mingw32-gcc-posix >/dev/null &&
-	compiler=x86_64-w64-mingw32-posix
+	compiler=x86_64-w64-mingw32-gcc-posix
 
 if [ -z "$compiler" ]; then
-	echo "Unable to determine which mingw32 compiler to use"
+	echo "Unable to determine which MinGW compiler to use"
 	exit 1
 fi
-toolchain_file=$dir/toolchain_${compiler%-gcc}.cmake
+toolchain_file=$dir/toolchain_${compiler/-gcc/}.cmake
 echo "Using $toolchain_file"
 
 tmp=$(dirname "$(command -v $compiler)")/../x86_64-w64-mingw32/bin


### PR DESCRIPTION
~~supersedes #11759~~

## To do

This PR is Ready for Review.

## How to test

Run this in bash and verify that it actually picks the right files:
```bash
for compiler in i686-w64-mingw32-gcc i686-w64-mingw32-gcc-posix x86_64-w64-mingw32-gcc x86_64-w64-mingw32-gcc-posix; do
	echo "compiler=$compiler"
	toolchain_file=util/buildbot/toolchain_${compiler/-gcc/}.cmake
	echo "Using $(ls -l "$toolchain_file")"
done
```
