### PR TITLE
Add backwards-compatible behaviour if too few CAO textures specified

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7161,6 +7161,7 @@ Player properties need to be saved manually.
         -- "sprite" uses 1 texture.
         -- "upright_sprite" uses 2 textures: {front, back}.
         -- "wielditem" expects 'textures = {itemname}' (see 'visual' above).
+        -- "mesh" requires one texture for each mesh buffer/material (in order)
 
         colors = {},
         -- Number of required colors depends on visual


### PR DESCRIPTION
On 5.4 or below specifying less textures than materials used to (accidentally?) work *if* shaders were enabled.
Of course modders relied and continue to rely on this so they expect compatible behavior.
This PR adds that.

## To do

This PR is Ready for Review.

## How to test

https://github.com/Skandarella/people
