### PR TITLE
Prevent the use of : as the name when not defining/overriding the player's hand

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -113,6 +113,8 @@ function core.register_item(name, itemdef)
 	-- Check name
 	if name == nil then
 		error("Unable to register item: Name is nil")
+	elseif name == ":" and itemdef.type ~= "none" then
+		error("Unable to register item: Cannot use \":\" as a name except to override the player's hand")
 	end
 	name = check_modname_prefix(tostring(name))
 	if forbidden_item_names[name] then


### PR DESCRIPTION
Fixes #10769 by preventing registration of `:` as a node name. This can prevent malicious mods from registering the name and causing world breakage.

## To do

This PR is Ready for Review.

- [ ] Testing

## How to test

Create a mod with `minetest.register_node(":", {})` in `init.lua`. Run a game with the mod enabled and ensure it causes an error before the game is loaded. Run the game again without the mod enabled and ensure it loads.