### PR TITLE
Fix local digging animation

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -996,12 +996,14 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 			m_velocity = v3f(0,0,0);
 			m_acceleration = v3f(0,0,0);
 			const PlayerControl &controls = player->getPlayerControl();
+			f32 new_speed = player->local_animation_speed;
 
 			bool walking = false;
-			if (controls.movement_speed > 0.001f)
+			if (controls.movement_speed > 0.001f) {
+				new_speed *= controls.movement_speed;
 				walking = true;
+			}
 
-			f32 new_speed = player->local_animation_speed;
 			v2s32 new_anim = v2s32(0,0);
 			bool allow_update = false;
 
@@ -1016,7 +1018,6 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 			// slowdown speed if sneaking
 			if (controls.sneak && walking)
 				new_speed /= 2;
-			new_speed *= controls.movement_speed;
 
 			if (walking && (controls.dig || controls.place)) {
 				new_anim = player->local_animations[3];


### PR DESCRIPTION
There is a bug in https://github.com/minetest/minetest/blob/c510037e9a334b3327a6d6b066203618051e4a09/src/client/content_cao.cpp#L1019
`controls.movement_speed` can be zero if a player is standing and digging and digging animation won't play. Let's not multiply to `controls.movement_speed` if a player isn't walking.

## To do

This PR is Ready for Review.

## How to test

* Join the server with set_local_animation enabled
* Switch to third-person mode
* Start to dig
* Check that digging animation is working 
