### PR TITLE
Restore GCC 5 compatibility

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -548,7 +548,7 @@ private:
 	// Set of media filenames pushed by server at runtime
 	std::unordered_set<std::string> m_media_pushed_files;
 	// Pending downloads of dynamic media (key: token)
-	std::vector<std::pair<u32, std::unique_ptr<SingleMediaDownloader>>> m_pending_media_downloads;
+	std::vector<std::pair<u32, std::shared_ptr<SingleMediaDownloader>>> m_pending_media_downloads;
 
 	// time_of_day speed approximation for old protocol
 	bool m_time_of_day_set = false;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -43,6 +43,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "tileanimation.h"
 #include "gettext.h"
 #include "skyparams.h"
+#include <memory>
+#include <utility>
 
 void Client::handleCommand_Deprecated(NetworkPacket* pkt)
 {
@@ -1559,8 +1561,9 @@ void Client::handleCommand_MediaPush(NetworkPacket *pkt)
 	m_media_pushed_files.insert(filename);
 
 	// create a downloader for this file
-	auto downloader = new SingleMediaDownloader(cached);
-	m_pending_media_downloads.emplace_back(token, downloader);
+	std::unique_ptr<SingleMediaDownloader> downloader{
+		new SingleMediaDownloader(cached) };
+	m_pending_media_downloads.emplace_back(token, std::move(downloader));
 	downloader->addFile(filename, raw_hash);
 	for (const auto &baseurl : m_remote_media_servers)
 		downloader->addRemoteServer(baseurl);

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -44,7 +44,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gettext.h"
 #include "skyparams.h"
 #include <memory>
-#include <utility>
 
 void Client::handleCommand_Deprecated(NetworkPacket* pkt)
 {
@@ -1561,9 +1560,8 @@ void Client::handleCommand_MediaPush(NetworkPacket *pkt)
 	m_media_pushed_files.insert(filename);
 
 	// create a downloader for this file
-	std::unique_ptr<SingleMediaDownloader> downloader{
-		new SingleMediaDownloader(cached) };
-	m_pending_media_downloads.emplace_back(token, std::move(downloader));
+	auto downloader(std::make_shared<SingleMediaDownloader>(cached));
+	m_pending_media_downloads.emplace_back(token, downloader);
 	downloader->addFile(filename, raw_hash);
 	for (const auto &baseurl : m_remote_media_servers)
 		downloader->addRemoteServer(baseurl);

--- a/src/util/png.cpp
+++ b/src/util/png.cpp
@@ -37,11 +37,11 @@ static void writeChunk(std::ostringstream &target, const std::string &chunk_str)
 
 std::string encodePNG(const u8 *data, u32 width, u32 height, s32 compression)
 {
-	std::ostringstream file{ std::ios::binary };
+	std::ostringstream file(std::ios::binary);
 	file << "\x89PNG\r\n\x1a\n";
 
 	{
-		std::ostringstream IHDR{ std::ios::binary };
+		std::ostringstream IHDR(std::ios::binary);
 		IHDR << "IHDR";
 		writeU32(IHDR, width);
 		writeU32(IHDR, height);
@@ -51,9 +51,9 @@ std::string encodePNG(const u8 *data, u32 width, u32 height, s32 compression)
 	}
 
 	{
-		std::ostringstream IDAT{ std::ios::binary };
+		std::ostringstream IDAT(std::ios::binary);
 		IDAT << "IDAT";
-		std::ostringstream scanlines{ std::ios::binary };
+		std::ostringstream scanlines(std::ios::binary);
 		for(u32 i = 0; i < height; i++) {
 			scanlines.write("\x00", 1); // Null predictor
 			scanlines.write((const char*) data + width * 4 * i, width * 4);

--- a/src/util/png.cpp
+++ b/src/util/png.cpp
@@ -37,11 +37,11 @@ static void writeChunk(std::ostringstream &target, const std::string &chunk_str)
 
 std::string encodePNG(const u8 *data, u32 width, u32 height, s32 compression)
 {
-	auto file = std::ostringstream(std::ios::binary);
+	std::ostringstream file{ std::ios::binary };
 	file << "\x89PNG\r\n\x1a\n";
 
 	{
-		auto IHDR = std::ostringstream(std::ios::binary);
+		std::ostringstream IHDR{ std::ios::binary };
 		IHDR << "IHDR";
 		writeU32(IHDR, width);
 		writeU32(IHDR, height);
@@ -51,9 +51,9 @@ std::string encodePNG(const u8 *data, u32 width, u32 height, s32 compression)
 	}
 
 	{
-		auto IDAT = std::ostringstream(std::ios::binary);
+		std::ostringstream IDAT{ std::ios::binary };
 		IDAT << "IDAT";
-		auto scanlines = std::ostringstream(std::ios::binary);
+		std::ostringstream scanlines{ std::ios::binary };
 		for(u32 i = 0; i < height; i++) {
 			scanlines.write("\x00", 1); // Null predictor
 			scanlines.write((const char*) data + width * 4 * i, width * 4);


### PR DESCRIPTION
The README says that GCC 4.9 is the minimum supported compiler version, but this compatibility got accidentally broken over time. This is a small PR to get Minetest compiling on GCC 4.9 once again. The only real compile errors were a pointer type mismatch and use of a deleted copy constructor (modern compiler versions elide it), and both are documented in their respective commits. There is also a spurious compile error issued by Minetest because it does not detect the `__cpp_rtti` and `__cpp_exceptions` macros, although both are enabled - I disabled the check locally for testing purposes and devtest ran perfectly fine.

fixes #11708

Ready for Review

## How to test

Try compiling with GCC 4.9. This is a pain to set up, because many distros don't have GCC 4.9 in their package repositories now. My testing environment was an Alt Linux Starter Kit in a VM, which does package lots of old GCC versions.
