### PR TITLE
Light space perspective shadow mapping

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -364,11 +364,11 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 		core.settings:set("enable_dynamic_shadows", "false")
 	else
 		local shadow_presets = {
-			[2] = { 80,  512,  "true", 0, "false" },
-			[3] = { 120, 1024, "true", 1, "false" },
-			[4] = { 350, 2048, "true", 1, "false" },
-			[5] = { 350, 2048, "true", 2,  "true" },
-			[6] = { 450, 4096, "true", 2,  "true" },
+			[2] = { 40,  512,  "true", 0, "false" },
+			[3] = { 60, 1024, "true", 1, "false" },
+			[4] = { 120, 2048, "true", 1, "false" },
+			[5] = { 120, 2048, "true", 2,  "true" },
+			[6] = { 180, 4096, "true", 2,  "true" },
 		}
 		local s = shadow_presets[table.indexof(labels.shadow_levels, fields["dd_shadows"])]
 		if s then

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -626,7 +626,7 @@ shadow_map_color (Colored shadows) bool false
 #    Higher values might make shadows laggy, lower values
 #    will consume more resources.
 #    Minimum value: 1; maximum value: 16
-shadow_update_frames (Map shadows update frames) int 8 1 16
+shadow_update_frames (Shadow map update frames) int 1 1 16
 
 #    Set the soft shadow radius size.
 #    Lower values mean sharper shadows, bigger values mean softer shadows.

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -71,7 +71,7 @@ vec3 getLightSpacePosition()
 	float offsetScale = (0.0057 * getLinearDepth() + normalOffsetScale);
 	pLightSpace = m_ShadowViewProj * vec4(worldPosition + offsetScale * normalize(vNormal), 1.0);
 	#endif
-	pLightSpace = getPerspectiveFactor(pLightSpace);
+	pLightSpace /= pLightSpace.w;
 	return pLightSpace.xyz * 0.5 + 0.5;
 }
 // custom smoothstep implementation because it's not defined in glsl1.2
@@ -479,7 +479,7 @@ void main(void)
 	vec3 shadow_color = vec3(0.0, 0.0, 0.0);
 	vec3 posLightSpace = getLightSpacePosition();
 
-	float distance_rate = (1 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 20.0));
+	float distance_rate = 1; //(1 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 20.0));
 	float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z  ),0.0);
 
 	if (distance_rate > 1e-7) {
@@ -522,6 +522,12 @@ void main(void)
 					dayLight * shadow_color * shadow_int);                 // reflected filtered sunlight/moonlight
 	// col.r = 0.5 * clamp(getPenumbraRadius(ShadowMapSampler, posLightSpace.xy, posLightSpace.z, 1.0) / SOFTSHADOWRADIUS, 0.0, 1.0) + 0.5 * col.r;
 	// col.r = adjusted_night_ratio; // debug night ratio adjustment
+	// col.r = posLightSpace.x;
+	// col.g = posLightSpace.y;
+	// col.rgb = vec3(worldPosition.x, worldPosition.y, worldPosition.z);
+	// col.rgb = vec3(posLightSpace.x, posLightSpace.y, posLightSpace.z);
+	// col.r = getHardShadow(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
+	// col.g = texture2D(ShadowMapSampler, posLightSpace.xy).r;
 #endif
 
 #if ENABLE_TONE_MAPPING

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -55,7 +55,10 @@ float getLinearDepth()
 vec3 getLightSpacePosition()
 {
 	vec4 pLightSpace;
-	float linear_bias = 0.2; // empirical
+	float linear_bias = f_shadowfar / f_textureresolution; // 1 SM texel in world space
+	if (length(vNormal) > 0.0) {
+		linear_bias /= 4.0; // empirical, 0.25 texel seems enough for most cases
+	}
 	pLightSpace = m_ShadowViewProj * vec4(worldPosition - linear_bias * v_LightDirection, 1.0);
 	pLightSpace /= pLightSpace.w;
 	return pLightSpace.xyz * 0.5 + 0.5;

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -16,7 +16,6 @@ uniform float animationTimer;
 	uniform float f_textureresolution;
 	uniform mat4 m_ShadowViewProj;
 	uniform float f_shadowfar;
-	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float cosLight;
 	varying float f_normal_length;
@@ -56,13 +55,9 @@ float getLinearDepth()
 vec3 getLightSpacePosition()
 {
 	vec4 pLightSpace;
+	float linear_bias = 0.2; // empirical
 	// some drawtypes have zero normals, so we need to handle it :(
-	#if DRAW_TYPE == NDT_PLANTLIKE
-	pLightSpace = m_ShadowViewProj * vec4(worldPosition, 1.0);
-	#else
-	float offsetScale = (0.0057 * getLinearDepth() + normalOffsetScale);
-	pLightSpace = m_ShadowViewProj * vec4(worldPosition + offsetScale * normalize(vNormal), 1.0);
-	#endif
+	pLightSpace = m_ShadowViewProj * vec4(worldPosition - linear_bias * v_LightDirection, 1.0);
 	pLightSpace /= pLightSpace.w;
 	return pLightSpace.xyz * 0.5 + 0.5;
 }

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -118,11 +118,11 @@ float getHardShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance
 #if SHADOW_FILTER == 2
 	#define PCFBOUND 1.5	// 16 samples
 	#define PCFSAMPLES 16.0
-	#define PCFRADIUS 0.7
+	#define PCFRADIUS 1.5
 #elif SHADOW_FILTER == 1
 	#define PCFBOUND 0.5	// 4 samples
 	#define PCFSAMPLES 4.0
-	#define PCFRADIUS 2.0
+	#define PCFRADIUS 1.0
 #else
 	#define PCFBOUND 0.0
 	#define PCFSAMPLES 1.0

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -479,7 +479,7 @@ void main(void)
 	vec3 shadow_color = vec3(0.0, 0.0, 0.0);
 	vec3 posLightSpace = getLightSpacePosition();
 
-	float distance_rate = 1; //(1 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 20.0));
+	float distance_rate = (1 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 20.0));
 	float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z  ),0.0);
 
 	if (distance_rate > 1e-7) {

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -479,7 +479,7 @@ void main(void)
 	vec3 shadow_color = vec3(0.0, 0.0, 0.0);
 	vec3 posLightSpace = getLightSpacePosition();
 
-	float distance_rate = (1 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 20.0));
+	float distance_rate = (1 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 10.0));
 	float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z  ),0.0);
 
 	if (distance_rate > 1e-7) {

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -435,14 +435,14 @@ void main(void)
 	
 #ifdef COLORED_SHADOWS
 		vec4 visibility;
-		if (cosLight > 0.0)
+		if (cosLight > 0.0 || f_normal_length < 0.01)
 			visibility = getShadowColor(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
 		else
 			visibility = vec4(1.0, 0.0, 0.0, 0.0);
 		shadow_int = visibility.r;
 		shadow_color = visibility.gba;
 #else
-		if (cosLight > 0.0)
+		if (cosLight > 0.0 || f_normal_length < 0.01)
 			shadow_int = getShadow(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
 		else
 			shadow_int = 1.0;

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -426,10 +426,9 @@ void main(void)
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	float shadow_int = 0.0;
 	vec3 shadow_color = vec3(0.0, 0.0, 0.0);
-	vec3 posLightSpace = clamp(getLightSpacePosition(), 0.0, 1.0);
+	vec3 posLightSpace = getLightSpacePosition();
 
-	float distance_rate = 1.0 - 
-			pow(pow(2.0 * (posLightSpace.x - 0.5), 4) + pow(2.0 * (posLightSpace.y - 0.5), 4), 2.0);
+	float distance_rate = (1 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 10.0));
 	float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z  ),0.0);
 
 	if (distance_rate > 1e-7) {
@@ -478,7 +477,6 @@ void main(void)
 	// col.rgb = vec3(posLightSpace.x, posLightSpace.y, posLightSpace.z);
 	// col.r = getHardShadow(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
 	// col.g = texture2D(ShadowMapSampler, posLightSpace.xy).r;
-	// col.r = distance_rate; // nice to debug the projection of shadowmap
 #endif
 
 #if ENABLE_TONE_MAPPING

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -426,9 +426,10 @@ void main(void)
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	float shadow_int = 0.0;
 	vec3 shadow_color = vec3(0.0, 0.0, 0.0);
-	vec3 posLightSpace = getLightSpacePosition();
+	vec3 posLightSpace = clamp(getLightSpacePosition(), 0.0, 1.0);
 
-	float distance_rate = (1 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 10.0));
+	float distance_rate = 1.0 - 
+			pow(pow(2.0 * (posLightSpace.x - 0.5), 4) + pow(2.0 * (posLightSpace.y - 0.5), 4), 2.0);
 	float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z  ),0.0);
 
 	if (distance_rate > 1e-7) {
@@ -477,6 +478,7 @@ void main(void)
 	// col.rgb = vec3(posLightSpace.x, posLightSpace.y, posLightSpace.z);
 	// col.r = getHardShadow(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
 	// col.g = texture2D(ShadowMapSampler, posLightSpace.xy).r;
+	// col.r = distance_rate; // nice to debug the projection of shadowmap
 #endif
 
 #if ENABLE_TONE_MAPPING

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -52,12 +52,6 @@ const float bias1 = 1.0 - bias0 + 1e-6;
 
 vec4 getPerspectiveFactor(in vec4 shadowPosition)
 {
-
-	float pDistance = length(shadowPosition.xy);
-	float pFactor = pDistance * bias0 + bias1;
-
-	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPersFactor);
-
 	return shadowPosition;
 }
 

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -195,7 +195,7 @@ void main(void)
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	vec3 nNormal = normalize(vNormal);
 	cosLight = dot(nNormal, -v_LightDirection);
-	float texelSize = 767.0 / f_textureresolution;
+	float texelSize = 0.0 / f_textureresolution;
 	float slopeScale = clamp(1.0 - abs(cosLight), 0.0, 1.0);
 	normalOffsetScale = texelSize * slopeScale;
 	

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -33,7 +33,6 @@ centroid varying vec2 varTexCoord;
 	uniform float f_shadow_strength;
 	uniform float f_timeofday;
 	varying float cosLight;
-	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float f_normal_length;
 #endif
@@ -195,9 +194,7 @@ void main(void)
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	vec3 nNormal = normalize(vNormal);
 	cosLight = dot(nNormal, -v_LightDirection);
-	float texelSize = 0.0 / f_textureresolution;
-	float slopeScale = clamp(1.0 - abs(cosLight), 0.0, 1.0);
-	normalOffsetScale = texelSize * slopeScale;
+	f_normal_length = length(vNormal);
 	
 	if (f_timeofday < 0.2) {
 		adj_shadow_strength = f_shadow_strength * 0.5 *
@@ -210,7 +207,6 @@ void main(void)
 			mtsmoothstep(0.20, 0.25, f_timeofday) *
 			(1.0 - mtsmoothstep(0.7, 0.8, f_timeofday));
 	}
-	f_normal_length = length(vNormal);
 #endif
 
 }

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -76,10 +76,6 @@ const float bias1 = 1.0 - bias0;
 
 vec4 getPerspectiveFactor(in vec4 shadowPosition)
 {
-	float pDistance = length(shadowPosition.xy);
-	float pFactor = pDistance * bias0 + bias1;
-	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPersFactor);
-
 	return shadowPosition;
 }
 

--- a/client/shaders/shadow_shaders/pass1_fragment.glsl
+++ b/client/shaders/shadow_shaders/pass1_fragment.glsl
@@ -8,6 +8,6 @@ void main()
 	if (col.a < 0.70)
 		discard;
 
-	float depth = 0.5 + tPos.z * 0.5;
+	float depth = 0.5 + (tPos.z/tPos.w) * 0.5;
 	gl_FragColor = vec4(depth, 0.0, 0.0, 1.0);
 }

--- a/client/shaders/shadow_shaders/pass1_trans_fragment.glsl
+++ b/client/shaders/shadow_shaders/pass1_trans_fragment.glsl
@@ -26,7 +26,7 @@ void main()
 		discard;
 #endif
 
-	float depth = 0.5 + tPos.z * 0.5;
+	float depth = 0.5 + (tPos.z / tPos.w) * 0.5;
 	// ToDo: Liso: Apply movement on waving plants
 	// depth in [0, 1] for texture
 

--- a/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
@@ -4,25 +4,10 @@ varying vec4 tPos;
 varying vec3 varColor;
 #endif
 
-const float bias0 = 0.9;
-const float zPersFactor = 0.5;
-const float bias1 = 1.0 - bias0 + 1e-6;
-
-vec4 getPerspectiveFactor(in vec4 shadowPosition)
-{
-	float pDistance = length(shadowPosition.xy);
-	float pFactor = pDistance * bias0 + bias1;
-	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPersFactor);
-
-	return shadowPosition;
-}
-
 
 void main()
 {
-	vec4 pos = LightMVP * gl_Vertex;
-
-	tPos = getPerspectiveFactor(LightMVP * gl_Vertex);
+	tPos = LightMVP * gl_Vertex;
 
 	gl_Position = vec4(tPos.xyz, 1.0);
 	gl_TexCoord[0].st = gl_MultiTexCoord0.st;

--- a/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
@@ -8,8 +8,7 @@ varying vec3 varColor;
 void main()
 {
 	tPos = LightMVP * gl_Vertex;
-
-	gl_Position = vec4(tPos.xyz, 1.0);
+	gl_Position = tPos;
 	gl_TexCoord[0].st = gl_MultiTexCoord0.st;
 
 #ifdef COLORED_SHADOWS

--- a/client/shaders/shadow_shaders/pass1_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_vertex.glsl
@@ -1,26 +1,9 @@
 uniform mat4 LightMVP; // world matrix
 varying vec4 tPos;
 
-const float bias0 = 0.9;
-const float zPersFactor = 0.5;
-const float bias1 = 1.0 - bias0 + 1e-6;
-
-vec4 getPerspectiveFactor(in vec4 shadowPosition)
-{
-	float pDistance = length(shadowPosition.xy);
-	float pFactor = pDistance * bias0 + bias1;
-	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPersFactor);
-
-	return shadowPosition;
-}
-
-
 void main()
 {
-	vec4 pos = LightMVP * gl_Vertex;
-
-	tPos = getPerspectiveFactor(pos);
-
-	gl_Position = vec4(tPos.xyz, 1.0);
+	tPos = LightMVP * gl_Vertex;
+	gl_Position = tPos;
 	gl_TexCoord[0].st = gl_MultiTexCoord0.st;
 }

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -809,7 +809,7 @@ void ClientMap::updateDrawListShadow(const v3f &shadow_light_pos, const v3f &sha
 	const v3f camera_direction = shadow_light_dir;
 	// I "fake" fov just to avoid creating a new function to handle orthographic
 	// projection.
-	const f32 camera_fov = m_camera_fov * 1.9f;
+	const f32 camera_fov = asin(shadow_range / (m_camera_position - shadow_light_pos).getLength());
 
 	v3s16 cam_pos_nodes = floatToInt(camera_position, BS);
 	v3s16 p_blocks_min;

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -867,14 +867,6 @@ void ClientMap::updateDrawListShadow(const v3f &shadow_light_pos, const v3f &sha
 
 			blocks_in_range_with_mesh++;
 
-			/*
-				Occlusion culling
-			*/
-			if (isBlockOccluded(block, cam_pos_nodes)) {
-				blocks_occlusion_culled++;
-				continue;
-			}
-
 			// This block is in range. Reset usage timer.
 			block->resetUsageTimer();
 

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -807,9 +807,10 @@ void ClientMap::updateDrawListShadow(const v3f &shadow_light_pos, const v3f &sha
 
 	const v3f camera_position = shadow_light_pos;
 	const v3f camera_direction = shadow_light_dir;
+	const float camera_distance = (m_camera_position - shadow_light_pos).getLength();
 	// I "fake" fov just to avoid creating a new function to handle orthographic
 	// projection.
-	const f32 camera_fov = asin(shadow_range / (m_camera_position - shadow_light_pos).getLength());
+	const f32 camera_fov = asin(shadow_range * 1.1 / camera_distance);
 
 	v3s16 cam_pos_nodes = floatToInt(camera_position, BS);
 	v3s16 p_blocks_min;
@@ -823,15 +824,6 @@ void ClientMap::updateDrawListShadow(const v3f &shadow_light_pos, const v3f &sha
 		block->refDrop();
 	}
 	m_drawlist_shadow.clear();
-
-	// We need to append the blocks from the camera POV because sometimes
-	// they are not inside the light frustum and it creates glitches.
-	// FIXME: This could be removed if we figure out why they are missing
-	// from the light frustum.
-	for (auto &i : m_drawlist) {
-		i.second->refGrab();
-		m_drawlist_shadow[i.first] = i.second;
-	}
 
 	// Number of blocks currently loaded by the client
 	u32 blocks_loaded = 0;
@@ -858,7 +850,7 @@ void ClientMap::updateDrawListShadow(const v3f &shadow_light_pos, const v3f &sha
 				continue;
 			}
 
-			float range = shadow_range;
+			float range = shadow_range + camera_distance;
 
 			float d = 0.0;
 			if (!isBlockInSight(block->getPos(), camera_position,

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -96,8 +96,6 @@ void GameUI::init()
 	m_guitext_profiler->setVisible(false);
 }
 
-std::string current_debug_message;
-
 void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_control,
 	const CameraOrientation &cam, const PointedThing &pointed_old,
 	const GUIChatConsole *chat_console, float dtime)
@@ -146,8 +144,7 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			<< ") | yaw: " << (wrapDegrees_0_360(cam.camera_yaw)) << "° "
 			<< yawToDirectionString(cam.camera_yaw)
 			<< " | pitch: " << (-wrapDegrees_180(cam.camera_pitch)) << "°"
-			<< " | seed: " << ((u64)client->getMapSeed())
-			<< " | " << current_debug_message;
+			<< " | seed: " << ((u64)client->getMapSeed());
 
 		if (pointed_old.type == POINTEDTHING_NODE) {
 			ClientMap &map = client->getEnv().getClientMap();

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -96,6 +96,8 @@ void GameUI::init()
 	m_guitext_profiler->setVisible(false);
 }
 
+std::string current_debug_message;
+
 void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_control,
 	const CameraOrientation &cam, const PointedThing &pointed_old,
 	const GUIChatConsole *chat_console, float dtime)
@@ -144,7 +146,8 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			<< ") | yaw: " << (wrapDegrees_0_360(cam.camera_yaw)) << "° "
 			<< yawToDirectionString(cam.camera_yaw)
 			<< " | pitch: " << (-wrapDegrees_180(cam.camera_pitch)) << "°"
-			<< " | seed: " << ((u64)client->getMapSeed());
+			<< " | seed: " << ((u64)client->getMapSeed())
+			<< " | " << current_debug_message;
 
 		if (pointed_old.type == POINTEDTHING_NODE) {
 			ClientMap &map = client->getEnv().getClientMap();

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -90,7 +90,7 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	float light_near = n + MYMIN(radius * (1.0 - sin_light), radius * (1.0 - cos_light));
 	float light_far = n + 2 * MYMAX(radius * sin_light, radius * cos_light);
 	// float fov_dy = (0.55 + 0.45 * sin_light) * radius / (n + radius);  // balance between aliasing and size of the shadowed area
-	float fov_dy = MYMAX(radius * sin_light, radius * cos_light) / (n + radius);
+	float fov_dy = MYMAX(radius * sin_light, radius * 0.71) / (n + radius);
 	float fov_dx = fov_dy;
 	float aspect = fov_dy / fov_dx;
 

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -31,6 +31,9 @@ extern std::string current_debug_message;
 
 void DirectionalLight::createSplitMatrices(const Camera *cam)
 {
+	// Light-space perspective implementation for PSM
+	// taken from https://www.cg.tuwien.ac.at/research/vr/lispsm/shadows_egsr2004_revised.pdf
+
 	// camera properties
 	scene::ICameraSceneNode *cam_node = cam->getCameraNode();
 	v3f cam_pos = cam_node->getAbsolutePosition();
@@ -63,7 +66,9 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	v3f center = cam_pos + cam_dir * (0.9 * cam_near + 0.1 * cam_far);
 	float radius = (center - top_right_corner).getLength();
 
-	float n = (cam_near + sqrt(cam_near * cam_far)) / MYMAX(0.0001, pow(1 - r, 3.0));
+	float n = cam_near + sqrt(cam_near * cam_far);
+	// scale n when light and camera vectors are aligned
+	n /= MYMAX(0.0001, pow(1 - r, 4.0));
 	v3f p = center - (n + radius) * light_dir;
 
 	m4f viewmatrix;

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -113,8 +113,8 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	projmatrix = f;
 
 	// update the frustum settings
-	future_frustum.position = cam->getPosition() - 1600.0f * direction;
-	future_frustum.length = 1600.0f;
+	future_frustum.position = cam->getPosition() - 20000.0f * direction;
+	future_frustum.length = 20000.0f;
 	future_frustum.ViewMat = viewmatrix;
 	future_frustum.ProjOrthMat = projmatrix;
 	future_frustum.camera_offset = cam->getOffset();

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -31,17 +31,6 @@ extern std::string current_debug_message;
 
 void DirectionalLight::createSplitMatrices(const Camera *cam)
 {
-	v3f corners[] = {
-		v3f(-1.0f, -1.0f, 0.0f),
-		v3f(-1.0f, 1.0f, 0.0f),
-		v3f(1.0f, -1.0f, 0.0f),
-		v3f(1.0f, 1.0f, 0.0f),
-		v3f(-1.0f, -1.0f, 1.0f),
-		v3f(-1.0f, 1.0f, 1.0f),
-		v3f(1.0f, -1.0f, 1.0f),
-		v3f(1.0f, 1.0f, 1.0f),
-	};
-
 	// camera properties
 	scene::ICameraSceneNode *cam_node = cam->getCameraNode();
 	v3f cam_pos = cam_node->getAbsolutePosition();
@@ -51,15 +40,10 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	float cam_near = cam_node->getNearValue();
 	float cam_far = MYMIN(farPlane * BS, cam_node->getFarValue());
 
-	// find corners of the camera frustum in world coordinates
-	for (u16 i = 0; i < 8; i++) {
-		float depth = cam_near + 
-				corners[i].Z * (cam_far - cam_near);
-		corners[i] = cam_pos + 
-				depth * cam_dir + 
-				corners[i].X * depth * tan(0.5 * cam_node->getAspectRatio() * cam_node->getFOV()) * cam_right + 
-				corners[i].Y * depth * tan(0.5 * cam_node->getFOV()) * cam_up;
-	}
+	v3f top_right_corner = cam_pos + 
+				cam_near * cam_dir + 
+				cam_near * tan(0.5 * cam_node->getAspectRatio() * cam_node->getFOV()) * cam_right + 
+				cam_near * tan(0.5 * cam_node->getFOV()) * cam_up;
  
 	// constructing light space
 	// Y (up) axis points towards the light.
@@ -75,7 +59,7 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 
 	// Define camera position and focus point in the view frustum
 	v3f center = cam_pos + cam_dir * (0.9 * cam_near + 0.1 * cam_far);
-	float radius = (center - corners[0]).getLength();
+	float radius = (center - top_right_corner).getLength();
 
 	float n = (cam_near + sqrt(cam_near * cam_far)) / MYMAX(0.0001, pow(1 - r, 3.0));
 	v3f p = center - (n + radius) * light_dir;

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -39,7 +39,7 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	v3f cam_up = v3f(cam->getCameraNode()->getUpVector()).normalize();
 	v3f cam_right = cam_up.crossProduct(cam_dir).normalize();
 	float cam_near = cam_node->getNearValue();
-	float cam_far = MYMIN(farPlane * BS, cam_node->getFarValue());
+	float cam_far = BS * MYMIN(farPlane, g_settings->getFloat("viewing_range"));
 
 	v3f top_right_corner = cam_pos + 
 				cam_near * cam_dir + 

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -62,20 +62,10 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 
 	v3f lcam_up = -direction;
 	v3f lcam_right = lcam_up.crossProduct(cam_dir).normalize();
-
-	// When looking towards or away from the light, align the virtual camera with
-	// world axes to reduce shadow dancing.
-	float lcam_right_max = MYMAX(MYMAX(abs(lcam_right.X), abs(lcam_right.Y)), abs(lcam_right.Z));
-	v3f lcam_right_rounded = abs(lcam_right.X) == lcam_right_max ? v3f(lcam_right.X >= 0 ? 1.0 : -1.0, 0, 0) : 
-			abs(lcam_right.Y) == lcam_right_max ? v3f(0, lcam_right.Y >= 0 ? 1.0 : -1.0, 0) : 
-			v3f(0, 0, lcam_right.Z >= 0 ? 1.0 : -1.0);
-	float blend = MYMIN(0.05, MYMAX(0, cos_light - 0.90)) / 0.05;
-	lcam_right =  blend * lcam_right_rounded + (1 - blend) * lcam_right;
-
 	v3f lcam_dir = lcam_right.crossProduct(lcam_up).normalize();
 
 	// Define camera position and focus point in the view frustum
-	float center_distance = cam_near + 0.5 * (cam_far - cam_near);
+	float center_distance = cam_near + (0.2 + 0.3 * sin_light) * (cam_far - cam_near);
 	v3f center = cam_pos + cam_dir * center_distance;
 	float radius = (center - top_right_corner).getLength();
 

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -55,6 +55,8 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 
 	v3f light_up = -direction;
 	v3f light_right = (1 - r) * light_up.crossProduct(cam_dir).normalize() + r * cam_right;
+	if (light_right.dotProduct(cam_right) < 0)
+		light_right = -light_right;
 	v3f light_dir = light_right.crossProduct(light_up).normalize();
 
 	// Define camera position and focus point in the view frustum

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -89,7 +89,6 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	// a sphere with center 'center' and radius 'radius'.
 	float light_near = n + MYMIN(radius * (1.0 - sin_light), radius * (1.0 - cos_light));
 	float light_far = n + 2 * MYMAX(radius * sin_light, radius * cos_light);
-	// float fov_dy = (0.55 + 0.45 * sin_light) * radius / (n + radius);  // balance between aliasing and size of the shadowed area
 	float fov_dy = MYMAX(radius * sin_light, radius * 0.71) / (n + radius);
 	float fov_dx = fov_dy;
 	float aspect = fov_dy / fov_dx;

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -51,7 +51,6 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	// Z (dir) axis is in the same plane as Y and camera_dir and orthogonal to Y
 	// X (right) axis complements the Y and Z
 
-	// When looking towards or away from the light, use player's X axis as light space X
 	float cos_light = abs(cam_dir.dotProduct(direction));
 	float sin_light = sqrt(1 - sqr(cos_light));
 
@@ -63,12 +62,16 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 
 	v3f lcam_up = -direction;
 	v3f lcam_right = lcam_up.crossProduct(cam_dir).normalize();
+
+	// When looking towards or away from the light, align the virtual camera with
+	// world axes to reduce shadow dancing.
 	float lcam_right_max = MYMAX(MYMAX(abs(lcam_right.X), abs(lcam_right.Y)), abs(lcam_right.Z));
 	v3f lcam_right_rounded = abs(lcam_right.X) == lcam_right_max ? v3f(lcam_right.X >= 0 ? 1.0 : -1.0, 0, 0) : 
 			abs(lcam_right.Y) == lcam_right_max ? v3f(0, lcam_right.Y >= 0 ? 1.0 : -1.0, 0) : 
 			v3f(0, 0, lcam_right.Z >= 0 ? 1.0 : -1.0);
 	float blend = MYMIN(0.05, MYMAX(0, cos_light - 0.90)) / 0.05;
 	lcam_right =  blend * lcam_right_rounded + (1 - blend) * lcam_right;
+
 	v3f lcam_dir = lcam_right.crossProduct(lcam_up).normalize();
 
 	// Define camera position and focus point in the view frustum

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -27,8 +27,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 using m4f = core::matrix4;
 
-extern std::string current_debug_message;
-
 void DirectionalLight::createSplitMatrices(const Camera *cam)
 {
 	// Light-space perspective implementation for PSM
@@ -102,20 +100,6 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	future_frustum.ViewMat = viewmatrix;
 	future_frustum.ProjOrthMat = projmatrix;
 	future_frustum.camera_offset = cam->getOffset();
-
-	std::stringstream debug;
-	debug << std::fixed
-			// << "direction: " << direction.X << "," << direction.Y << "," << direction.Z << " | "
-			// << "look: " << cam_dir.X << "," << cam_dir.Y << "," << cam_dir.Z << " | "
-			// << "cos: " << direction.dotProduct(cam_dir) << " | "
-			// << "right: " << cam_right.X << "," << cam_right.Y << "," << cam_right.Z << " | "
-			// << "light_dir: " << light_dir.X << "," << light_dir.Y << "," << light_dir.Z << " | "
-			// << "light_right: " << light_right.X << "," << light_right.Y << "," << light_right.Z << " | "
-			<< "r: " << r << " | n: " << n << " | "
-			<< "Fov X: " << max_dx << " | Fov Y: " << max_dy << " | Aspect: " << aspect << " | "
-			<< "Near: " << light_near << " | Far: " << light_far << " | " << (light_far - light_near) << " | ";
-			;
-	current_debug_message = debug.str();
 }
 
 DirectionalLight::DirectionalLight(const u32 shadowMapResolution,

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -388,9 +388,6 @@ void ShadowRenderer::renderShadowMap(video::ITexture *target,
 		// FIXME: I don't think this is needed here
 		map_node->OnAnimate(m_device->getTimer()->getTime());
 
-		m_driver->setTransform(video::ETS_WORLD,
-				map_node->getAbsoluteTransformation());
-
 		map_node->renderMapShadows(m_driver, material, pass, m_current_frame, m_map_shadow_update_frames);
 		break;
 	}
@@ -439,8 +436,6 @@ void ShadowRenderer::renderShadowObjects(
 			//current_mat.PolygonOffsetSlopeScale = -1.f;
 		}
 
-		m_driver->setTransform(video::ETS_WORLD,
-				shadow_node.node->getAbsoluteTransformation());
 		shadow_node.node->render();
 
 		// restore the material.

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -297,7 +297,7 @@ void ShadowRenderer::update(video::ITexture *outputTarget)
 				m_screen_quad->getMaterial().setTexture(1, shadowMapTextureColors);
 			m_screen_quad->getMaterial().setTexture(2, shadowMapTextureDynamicObjects);
 
-			m_driver->setRenderTarget(shadowMapTextureFinal, false, false,
+			m_driver->setRenderTarget(shadowMapTextureFinal, true, true,
 					video::SColor(255, 255, 255, 255));
 			m_screen_quad->render(m_driver);
 			m_driver->setRenderTarget(0, false, false);

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -309,25 +309,29 @@ void ShadowRenderer::update(video::ITexture *outputTarget)
 void ShadowRenderer::drawDebug()
 {
 	/* this code just shows shadows textures in screen and in ONLY for debugging*/
-	#if 0
+	#if 1
+	u16 offset = 50;
+	u16 size = 250;
 	// this is debug, ignore for now.
-	m_driver->draw2DImage(shadowMapTextureFinal,
-			core::rect<s32>(0, 50, 128, 128 + 50),
-			core::rect<s32>({0, 0}, shadowMapTextureFinal->getSize()));
-
 	m_driver->draw2DImage(shadowMapClientMap,
-			core::rect<s32>(0, 50 + 128, 128, 128 + 50 + 128),
+			core::rect<s32>(0, offset, size, offset + size),
 			core::rect<s32>({0, 0}, shadowMapTextureFinal->getSize()));
+	offset += size;
+
 	m_driver->draw2DImage(shadowMapTextureDynamicObjects,
-			core::rect<s32>(0, 128 + 50 + 128, 128,
-					128 + 50 + 128 + 128),
+			core::rect<s32>(0, offset, size, offset + size),
 			core::rect<s32>({0, 0}, shadowMapTextureDynamicObjects->getSize()));
+	offset += size;
+
+	m_driver->draw2DImage(shadowMapTextureFinal,
+			core::rect<s32>(0, offset, size, offset + size),
+			core::rect<s32>({0, 0}, shadowMapTextureFinal->getSize()));
+	offset += size;
 
 	if (m_shadow_map_colored) {
 
 		m_driver->draw2DImage(shadowMapTextureColors,
-				core::rect<s32>(128,128 + 50 + 128 + 128,
-						128 + 128, 128 + 50 + 128 + 128 + 128),
+				core::rect<s32>(size, offset, size + size, offset + size),
 				core::rect<s32>({0, 0}, shadowMapTextureColors->getSize()));
 	}
 	#endif

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -309,7 +309,7 @@ void ShadowRenderer::update(video::ITexture *outputTarget)
 void ShadowRenderer::drawDebug()
 {
 	/* this code just shows shadows textures in screen and in ONLY for debugging*/
-	#if 1
+	#if 0
 	u16 offset = 50;
 	u16 size = 250;
 	// this is debug, ignore for now.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -273,7 +273,7 @@ void set_default_settings()
 	settings->setDefault("shadow_map_color", "false");
 	settings->setDefault("shadow_filters", "1");
 	settings->setDefault("shadow_poisson_filter", "true");
-	settings->setDefault("shadow_update_frames", "8");
+	settings->setDefault("shadow_update_frames", "1");
 	settings->setDefault("shadow_soft_radius", "1.0");
 	settings->setDefault("shadow_sky_body_orbit_tilt", "0.0");
 


### PR DESCRIPTION
This PR adds Light Space Perspective Shadow Mapping based on [work of Michael Wimmer et al.](https://www.cg.tuwien.ac.at/research/vr/lispsm/shadows_egsr2004_revised.pdf).

The goal is to improve the quality of shadow maps by using more of the texture surface while keeping single-pass shadow generation process. The approach also removes the distortion causing 'curved' SM texels.

The intent of the PR is to improve the quality of shadows specifically at Very Low and Low presets that use low-resolution SM texture and, combined with #11747, resolve or improve #11762. It also resolves #11358 at Very Low preset and improves  #11743 for more quality presets.

## LiSPSM

LiSPSM combines Uniform and Perspective Shadow Maps by manipulating the light frustum to match the perspective of player's camera as close as possible in order to increase the density of SM texels close to the player.

Strength of perspective transformation is controlled by parameter n, which is calculated from the player's camera parameters and then blended with 'infinity' (1/1E5) based on angle between player's view and light direction.

## To do

This PR is Ready for Review.

items in the PR:
* [x] Implement light frustum calculation
* [x] Remove perspective distortion from SM shaders and shadow sampling
* [x] Remove perspective distortion from PCF and Poisson filters
* [ ] Tune the light frustum for constant pixel density

## How to test

* Turn on shadow mapping and set soft shadow radius to 1.0 (minimum and default)
* Start a game and observe the shadows.
* Shadow edges should appear uniformly sharp, also for distant shadows.
* While jagged at some presets, edges do not have Fresnel lens pattern (see #11358)