### PR TITLE
Remove unused error when attempting to enable shaders with Direct3D video driver selected

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -275,13 +275,7 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 		return true
 	end
 	if fields["cb_shaders"] then
-		if (core.settings:get("video_driver") == "direct3d8" or
-				core.settings:get("video_driver") == "direct3d9") then
-			core.settings:set("enable_shaders", "false")
-			gamedata.errormessage = fgettext("To enable shaders the OpenGL driver needs to be used.")
-		else
-			core.settings:set("enable_shaders", fields["cb_shaders"])
-		end
+		core.settings:set("enable_shaders", fields["cb_shaders"])
 		return true
 	end
 	if fields["cb_tonemapping"] then


### PR DESCRIPTION
Rather trivial PR which removes an unused check and error attempting to enable shaders when you are on a Direct3D video driver. This has been unused even before Direct3D was removed from IrrlichtMt as the `Enable shaders` checkbox would be disabled by the same code that disables it on OpenGLES 1. That code still intact and the shaders checkbox is still unable to be enabled on OpenGLES 1 after this PR.