### PR TITLE
Fix eat sound not playing if eating last of stack

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -499,9 +499,6 @@ function core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed
 			return result
 		end
 	end
-	if itemstack:take_item():is_empty() then
-		return itemstack
-	end
 
 	local def = itemstack:get_definition()
 	if def and def.sound and def.sound.eat then
@@ -510,6 +507,8 @@ function core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed
 			max_hear_distance = 16
 		}, true)
 	end
+
+	itemstack:take_item()
 
 	-- Changing hp might kill the player causing mods to do who-knows-what to the
 	-- inventory, so do this before set_hp().


### PR DESCRIPTION
This fixes a bug in that the eat sound is not played if you "eat" the final item of an item stack.

How to test: Try the Eat Sound Item in DevTest and use the "punch" key to "eat" it.

Bug was introduced at 660e63dbae.

@sfan5 @erlehmann