### PR TITLE
Add padding[] element to formspecs

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -117,7 +117,7 @@ Menu music
 -----------
 
 Games can provide custom main menu music. They are put inside a `menu`
-directory inside the game directory. 
+directory inside the game directory.
 
 The music files are named `theme.ogg`.
 If you want to specify multiple music files for one game, add additional
@@ -2311,9 +2311,20 @@ Elements
 * `position` and `anchor` elements need suitable values to avoid a formspec
   extending off the game window due to particular game window sizes.
 
-### `no_prepend[]`
+### `padding[<X>,<Y>]`
 
 * Must be used after the `size`, `position`, and `anchor` elements (if present).
+* Defines how much space is padded around the formspec if the formspec tries to
+  increase past the size of the screen and coordinates have to be shrunk.
+* For X and Y, 0.0 represents no padding (the formspec can touch the edge of the
+  screen), and 0.5 represents half the screen (which forces the coordinate size
+  to 0). If negative, the formspec can extend off the edge of the screen.
+* Defaults to [0.05, 0.05].
+
+### `no_prepend[]`
+
+* Must be used after the `size`, `position`, `anchor`, and `padding` elements
+  (if present).
 * Disables player:set_formspec_prepend() from applying to this formspec.
 
 ### `real_coordinates[<bool>]`
@@ -7901,7 +7912,7 @@ Used by `minetest.register_node`.
                     items = {"default:sand", "default:desert_sand"},
                 },
                 {
-                    -- Only drop if using an item in the "magicwand" group, or 
+                    -- Only drop if using an item in the "magicwand" group, or
                     -- an item that is in both the "pickaxe" and the "lucky"
                     -- groups.
                     tool_groups = {

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2530,12 +2530,16 @@ bool GUIFormSpecMenu::parsePositionDirect(parserData *data, const std::string &e
 
 void GUIFormSpecMenu::parsePosition(parserData *data, const std::string &element)
 {
-	std::vector<std::string> parts = split(element, ',');
+	std::vector<std::string> parts = split(element, ';');
 
-	if (parts.size() == 2 &&
-			(parts.size() > 2 && m_formspec_version > FORMSPEC_API_VERSION)) {
-		data->offset.X = stof(parts[0]);
-		data->offset.Y = stof(parts[1]);
+	if (parts.size() == 1 ||
+			(parts.size() > 1 && m_formspec_version > FORMSPEC_API_VERSION)) {
+		std::vector<std::string> v_geom = split(parts[0], ',');
+
+		MY_CHECKGEOM("position", 0);
+
+		data->offset.X = stof(v_geom[0]);
+		data->offset.Y = stof(v_geom[1]);
 		return;
 	}
 
@@ -2565,12 +2569,16 @@ bool GUIFormSpecMenu::parseAnchorDirect(parserData *data, const std::string &ele
 
 void GUIFormSpecMenu::parseAnchor(parserData *data, const std::string &element)
 {
-	std::vector<std::string> parts = split(element, ',');
+	std::vector<std::string> parts = split(element, ';');
 
-	if (parts.size() == 2 &&
-			(parts.size() > 2 && m_formspec_version > FORMSPEC_API_VERSION)) {
-		data->anchor.X = stof(parts[0]);
-		data->anchor.Y = stof(parts[1]);
+	if (parts.size() == 1 ||
+			(parts.size() > 1 && m_formspec_version > FORMSPEC_API_VERSION)) {
+		std::vector<std::string> v_geom = split(parts[0], ',');
+
+		MY_CHECKGEOM("anchor", 0);
+
+		data->anchor.X = stof(v_geom[0]);
+		data->anchor.Y = stof(v_geom[1]);
 		return;
 	}
 
@@ -2601,12 +2609,16 @@ bool GUIFormSpecMenu::parsePaddingDirect(parserData *data, const std::string &el
 
 void GUIFormSpecMenu::parsePadding(parserData *data, const std::string &element)
 {
-	std::vector<std::string> parts = split(element, ',');
+	std::vector<std::string> parts = split(element, ';');
 
-	if (parts.size() == 2 &&
-			(parts.size() > 2 && m_formspec_version > FORMSPEC_API_VERSION)) {
-		data->padding.X = stof(parts[0]);
-		data->padding.Y = stof(parts[1]);
+	if (parts.size() == 1 ||
+			(parts.size() > 1 && m_formspec_version > FORMSPEC_API_VERSION)) {
+		std::vector<std::string> v_geom = split(parts[0], ',');
+
+		MY_CHECKGEOM("padding", 0);
+
+		data->padding.X = stof(v_geom[0]);
+		data->padding.Y = stof(v_geom[1]);
 		return;
 	}
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2532,7 +2532,8 @@ void GUIFormSpecMenu::parsePosition(parserData *data, const std::string &element
 {
 	std::vector<std::string> parts = split(element, ',');
 
-	if (parts.size() == 2) {
+	if (parts.size() == 2 &&
+			(parts.size() > 2 && m_formspec_version > FORMSPEC_API_VERSION)) {
 		data->offset.X = stof(parts[0]);
 		data->offset.Y = stof(parts[1]);
 		return;
@@ -2566,13 +2567,50 @@ void GUIFormSpecMenu::parseAnchor(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element, ',');
 
-	if (parts.size() == 2) {
+	if (parts.size() == 2 &&
+			(parts.size() > 2 && m_formspec_version > FORMSPEC_API_VERSION)) {
 		data->anchor.X = stof(parts[0]);
 		data->anchor.Y = stof(parts[1]);
 		return;
 	}
 
 	errorstream << "Invalid anchor element (" << parts.size() << "): '" << element
+			<< "'" << std::endl;
+}
+
+bool GUIFormSpecMenu::parsePaddingDirect(parserData *data, const std::string &element)
+{
+	if (element.empty())
+		return false;
+
+	std::vector<std::string> parts = split(element, '[');
+
+	if (parts.size() != 2)
+		return false;
+
+	std::string type = trim(parts[0]);
+	std::string description = trim(parts[1]);
+
+	if (type != "padding")
+		return false;
+
+	parsePadding(data, description);
+
+	return true;
+}
+
+void GUIFormSpecMenu::parsePadding(parserData *data, const std::string &element)
+{
+	std::vector<std::string> parts = split(element, ',');
+
+	if (parts.size() == 2 &&
+			(parts.size() > 2 && m_formspec_version > FORMSPEC_API_VERSION)) {
+		data->padding.X = stof(parts[0]);
+		data->padding.Y = stof(parts[1]);
+		return;
+	}
+
+	errorstream << "Invalid padding element (" << parts.size() << "): '" << element
 			<< "'" << std::endl;
 }
 
@@ -3092,6 +3130,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	mydata.screensize = screensize;
 	mydata.offset = v2f32(0.5f, 0.5f);
 	mydata.anchor = v2f32(0.5f, 0.5f);
+	mydata.padding = v2f32(0.05f, 0.05f);
 	mydata.simple_field_count = 0;
 
 	// Base position of contents of form
@@ -3194,7 +3233,14 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		}
 	}
 
-	/* "no_prepend" element is always after "position" (or  "size" element) if it used */
+	/* "padding" element is always after "anchor" and previous if it is used */
+	for (; i < elements.size(); i++) {
+		if (!parsePaddingDirect(&mydata, elements[i])) {
+			break;
+		}
+	}
+
+	/* "no_prepend" element is always after "padding" and previous if it used */
 	bool enable_prepends = true;
 	for (; i < elements.size(); i++) {
 		if (elements[i].empty())
@@ -3259,11 +3305,9 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			double fitx_imgsize;
 			double fity_imgsize;
 
-			// Pad the screensize with 5% of the screensize on all sides to ensure
-			// that even the largest formspecs don't touch the screen borders.
 			v2f padded_screensize(
-				mydata.screensize.X * 0.9f,
-				mydata.screensize.Y * 0.9f
+				mydata.screensize.X * (1.0f - mydata.padding.X * 2.0f),
+				mydata.screensize.Y * (1.0f - mydata.padding.Y * 2.0f)
 			);
 
 			if (mydata.real_coordinates) {
@@ -3279,13 +3323,15 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 						((15.0 / 13.0) * (0.85 + mydata.invsize.Y));
 			}
 
+			s32 min_screen_dim = std::min(mydata.screensize.X, mydata.screensize.Y);
+
 #ifdef HAVE_TOUCHSCREENGUI
 			// In Android, the preferred imgsize should be larger to accommodate the
 			// smaller screensize.
-			double prefer_imgsize = padded_screensize.Y / 10 * gui_scaling;
+			double prefer_imgsize = min_screen_dim / 10 * gui_scaling;
 #else
 			// Desktop computers have more space, so try to fit 15 coordinates.
-			double prefer_imgsize = padded_screensize.Y / 15 * gui_scaling;
+			double prefer_imgsize = min_screen_dim / 15 * gui_scaling;
 #endif
 			// Try to use the preferred imgsize, but if that's bigger than the maximum
 			// size, use the maximum size.

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -366,6 +366,7 @@ private:
 		v2s32 size;
 		v2f32 offset;
 		v2f32 anchor;
+		v2f32 padding;
 		core::rect<s32> rect;
 		v2s32 basepos;
 		v2u32 screensize;
@@ -447,6 +448,8 @@ private:
 	void parsePosition(parserData *data, const std::string &element);
 	bool parseAnchorDirect(parserData *data, const std::string &element);
 	void parseAnchor(parserData *data, const std::string &element);
+	bool parsePaddingDirect(parserData *data, const std::string &element);
+	void parsePadding(parserData *data, const std::string &element);
 	bool parseStyle(parserData *data, const std::string &element, bool style_type);
 	void parseSetFocus(const std::string &element);
 	void parseModel(parserData *data, const std::string &element);


### PR DESCRIPTION
OK, I lied -- I didn't get it tested yesterday  But still, here it is.  This adds a `padding[]` element which allows formspecs to decide how much padding will be around the formspec if it's too big.  Closes #11669.

## To do

This PR is Ready for Review.

## How to test

Devtest has a handy new thing in `test_formspec` that allows you to change the size, position, anchor, and padding of the formspec, so play around with that.  You may need to exit the game and re-enter if you input weird (but valid) values.
