### PR TITLE
Disable inventory if player's inventory formspec is blank

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6675,6 +6675,7 @@ object you are working with still exists.
 * `set_inventory_formspec(formspec)`
     * Redefine player's inventory form
     * Should usually be called in `on_joinplayer`
+    * If `formspec` is `""`, the player's inventory is disabled.
 * `get_inventory_formspec()`: returns a formspec string
 * `set_formspec_prepend(formspec)`:
     * the formspec string will be added to every formspec shown to the user,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2060,16 +2060,17 @@ void Game::openInventory()
 	InventoryLocation inventoryloc;
 	inventoryloc.setCurrentPlayer();
 
-	if ((!client->modsLoaded()
-			|| !client->getScript()->on_inventory_open(fs_src->m_client->getInventory(inventoryloc)))
-			&& fs_src->getForm() != "") {
-		TextDest *txt_dst = new TextDestPlayerInventory(client);
-		auto *&formspec = m_game_ui->updateFormspec("");
-		GUIFormSpecMenu::create(formspec, client, m_rendering_engine->get_gui_env(),
-			&input->joystick, fs_src, txt_dst, client->getFormspecPrepend(), sound);
+	if (!client->modsLoaded() || !client->getScript()->on_inventory_open(fs_src->m_client->getInventory(inventoryloc)))
+    	return;
+	if (fs_src->getForm().empty())
+   		return;
 
-		formspec->setFormSpec(fs_src->getForm(), inventoryloc);
-	}
+	TextDest *txt_dst = new TextDestPlayerInventory(client);
+	auto *&formspec = m_game_ui->updateFormspec("");
+	GUIFormSpecMenu::create(formspec, client, m_rendering_engine->get_gui_env(),
+		&input->joystick, fs_src, txt_dst, client->getFormspecPrepend(), sound);
+
+	formspec->setFormSpec(fs_src->getForm(), inventoryloc);
 }
 
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2057,14 +2057,18 @@ void Game::openInventory()
 
 	PlayerInventoryFormSource *fs_src = new PlayerInventoryFormSource(client);
 
+	if (fs_src->getForm().empty()) {
+		delete fs_src;
+		return;
+	}
+
 	InventoryLocation inventoryloc;
 	inventoryloc.setCurrentPlayer();
 
-	if (client->modsLoaded() && client->getScript()->on_inventory_open(fs_src->m_client->getInventory(inventoryloc)))
+	if (client->modsLoaded() && client->getScript()->on_inventory_open(fs_src->m_client->getInventory(inventoryloc))) {
+		delete fs_src;
 		return;
-
-	if (fs_src->getForm().empty())
-		return;
+	}
 
 	TextDest *txt_dst = new TextDestPlayerInventory(client);
 	auto *&formspec = m_game_ui->updateFormspec("");

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2060,8 +2060,9 @@ void Game::openInventory()
 	InventoryLocation inventoryloc;
 	inventoryloc.setCurrentPlayer();
 
-	if (!client->modsLoaded()
-			|| !client->getScript()->on_inventory_open(fs_src->m_client->getInventory(inventoryloc))) {
+	if ((!client->modsLoaded()
+			|| !client->getScript()->on_inventory_open(fs_src->m_client->getInventory(inventoryloc)))
+			&& fs_src->getForm() != "") {
 		TextDest *txt_dst = new TextDestPlayerInventory(client);
 		auto *&formspec = m_game_ui->updateFormspec("");
 		GUIFormSpecMenu::create(formspec, client, m_rendering_engine->get_gui_env(),

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2060,10 +2060,11 @@ void Game::openInventory()
 	InventoryLocation inventoryloc;
 	inventoryloc.setCurrentPlayer();
 
-	if (!client->modsLoaded() || !client->getScript()->on_inventory_open(fs_src->m_client->getInventory(inventoryloc)))
-    	return;
+	if (client->modsLoaded() && client->getScript()->on_inventory_open(fs_src->m_client->getInventory(inventoryloc)))
+		return;
+
 	if (fs_src->getForm().empty())
-   		return;
+		return;
 
 	TextDest *txt_dst = new TextDestPlayerInventory(client);
 	auto *&formspec = m_game_ui->updateFormspec("");

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2057,15 +2057,15 @@ void Game::openInventory()
 
 	PlayerInventoryFormSource *fs_src = new PlayerInventoryFormSource(client);
 
-	if (fs_src->getForm().empty()) {
-		delete fs_src;
-		return;
-	}
-
 	InventoryLocation inventoryloc;
 	inventoryloc.setCurrentPlayer();
 
 	if (client->modsLoaded() && client->getScript()->on_inventory_open(fs_src->m_client->getInventory(inventoryloc))) {
+		delete fs_src;
+		return;
+	}
+
+	if (fs_src->getForm().empty()) {
 		delete fs_src;
 		return;
 	}


### PR DESCRIPTION
This PR intends to make it possible for games/mods to completely disable the inventory by setting the player's inventory to an empty string.

Previously if you set the player's inventory to an empty string the inventory would still exist, and opening it will open an empty default sized formspec. You could set the formspec to an extremely small value (`size[0.01,0.01]`) to effectively hide it, but this is a rather awful hack that will still show it and steal controls to the formspec that is now completely non-existant, and the player will now wonder if their keyboard is broken.

## To do
This PR is Ready for Review.

## How to test
**PR tests:**
* Check that if you set your inventory to an empty string (Lua code for singleplayer: `minetest.get_player_by_name("singleplayer"):set_inventory_formspec("")`), pressing the inventory button will do nothing.

**Test for regressions:**
* Check that you can still open custom non-empty inventories.
* Check that the default inventory still appears.
* Check that client-side modding formspecs don't break by this PR. (!)