### PR TITLE
No damage effects on hp_max change

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -493,6 +493,7 @@ void Client::step(float dtime)
 			ClientEvent *event = new ClientEvent();
 			event->type = CE_PLAYER_DAMAGE;
 			event->player_damage.amount = damage;
+			event->player_damage.effect = true;
 			m_client_event_queue.push(event);
 		}
 	}

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -87,6 +87,7 @@ struct ClientEvent
 		struct
 		{
 			u16 amount;
+			bool effect;
 		} player_damage;
 		struct
 		{

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2605,6 +2605,9 @@ void Game::handleClientEvent_PlayerDamage(ClientEvent *event, CameraOrientation 
 	if (client->modsLoaded())
 		client->getScript()->on_damage_taken(event->player_damage.amount);
 
+	if (!event->player_damage.effect)
+		return;
+
 	// Damage flash and hurt tilt are not used at death
 	if (client->getHP() > 0) {
 		LocalPlayer *player = client->getEnv().getLocalPlayer();

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -570,6 +570,10 @@ void Client::handleCommand_HP(NetworkPacket *pkt)
 
 	u16 hp;
 	*pkt >> hp;
+	bool damage_effect = true;
+	try {
+		*pkt >> damage_effect;
+	} catch (PacketError &e) {};
 
 	player->hp = hp;
 
@@ -581,6 +585,7 @@ void Client::handleCommand_HP(NetworkPacket *pkt)
 		ClientEvent *event = new ClientEvent();
 		event->type = CE_PLAYER_DAMAGE;
 		event->player_damage.amount = oldhp - hp;
+		event->player_damage.effect = damage_effect;
 		m_client_event_queue.push(event);
 	}
 }

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -198,7 +198,7 @@ void read_object_properties(lua_State *L, int index,
 		prop->hp_max = (u16)rangelim(hp_max, 0, U16_MAX);
 
 		if (prop->hp_max < sao->getHP()) {
-			PlayerHPChangeReason reason(PlayerHPChangeReason::SET_HP);
+			PlayerHPChangeReason reason(PlayerHPChangeReason::SET_HP_MAX);
 			sao->setHP(prop->hp_max, reason);
 		}
 	}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1107,7 +1107,7 @@ PlayerSAO* Server::StageTwoClientInit(session_t peer_id)
 	SendInventory(playersao, false);
 
 	// Send HP
-	SendPlayerHP(playersao);
+	SendPlayerHP(playersao, false);
 
 	// Send death screen
 	if (playersao->isDead())
@@ -1374,7 +1374,7 @@ void Server::SendMovement(session_t peer_id)
 void Server::HandlePlayerHPChange(PlayerSAO *playersao, const PlayerHPChangeReason &reason)
 {
 	m_script->player_event(playersao, "health_changed");
-	SendPlayerHP(playersao);
+	SendPlayerHP(playersao, reason.type != PlayerHPChangeReason::SET_HP_MAX);
 
 	// Send to other clients
 	playersao->sendPunchCommand();
@@ -1383,15 +1383,15 @@ void Server::HandlePlayerHPChange(PlayerSAO *playersao, const PlayerHPChangeReas
 		HandlePlayerDeath(playersao, reason);
 }
 
-void Server::SendPlayerHP(PlayerSAO *playersao)
+void Server::SendPlayerHP(PlayerSAO *playersao, bool effect)
 {
-	SendHP(playersao->getPeerID(), playersao->getHP());
+	SendHP(playersao->getPeerID(), playersao->getHP(), effect);
 }
 
-void Server::SendHP(session_t peer_id, u16 hp)
+void Server::SendHP(session_t peer_id, u16 hp, bool effect)
 {
-	NetworkPacket pkt(TOCLIENT_HP, 1, peer_id);
-	pkt << hp;
+	NetworkPacket pkt(TOCLIENT_HP, 3, peer_id);
+	pkt << hp << effect;
 	Send(&pkt);
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -353,7 +353,7 @@ public:
 	void printToConsoleOnly(const std::string &text);
 
 	void HandlePlayerHPChange(PlayerSAO *sao, const PlayerHPChangeReason &reason);
-	void SendPlayerHP(PlayerSAO *sao);
+	void SendPlayerHP(PlayerSAO *sao, bool effect);
 	void SendPlayerBreath(PlayerSAO *sao);
 	void SendInventory(PlayerSAO *playerSAO, bool incremental);
 	void SendMovePlayer(session_t peer_id);
@@ -439,7 +439,7 @@ private:
 	void init();
 
 	void SendMovement(session_t peer_id);
-	void SendHP(session_t peer_id, u16 hp);
+	void SendHP(session_t peer_id, u16 hp, bool effect);
 	void SendBreath(session_t peer_id, u16 breath);
 	void SendAccessDenied(session_t peer_id, AccessDeniedCode reason,
 		const std::string &custom_reason, bool reconnect = false);

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -495,7 +495,7 @@ void PlayerSAO::setHP(s32 target_hp, const PlayerHPChangeReason &reason, bool fr
 		m_hp = hp;
 		m_env->getGameDef()->HandlePlayerHPChange(this, reason);
 	} else if (from_client)
-		m_env->getGameDef()->SendPlayerHP(this);
+		m_env->getGameDef()->SendPlayerHP(this, true);
 }
 
 void PlayerSAO::setBreath(const u16 breath, bool send)

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -235,6 +235,7 @@ struct PlayerHPChangeReason
 	enum Type : u8
 	{
 		SET_HP,
+		SET_HP_MAX, // internal type to allow distinguishing hp reset and damage (for effects)
 		PLAYER_PUNCH,
 		FALL,
 		NODE_DAMAGE,
@@ -277,6 +278,7 @@ struct PlayerHPChangeReason
 	{
 		switch (type) {
 		case PlayerHPChangeReason::SET_HP:
+		case PlayerHPChangeReason::SET_HP_MAX:
 			return "set_hp";
 		case PlayerHPChangeReason::PLAYER_PUNCH:
 			return "punch";


### PR DESCRIPTION
#10569 rebased and fixed. Closes #7876 - should this also alter the punch command being sent, to suppress the punch effect?

Test using the following code (**EPILEPSY WARNING**):
```lua
minetest.register_globalstep(function()
    for _, player in pairs(minetest.get_connected_players()) do
        local hp_max = math.random(1, 20)
        player:set_properties{hp_max = hp_max}
        player:set_hp(hp_max)
    end
end)
```