### PR TITLE
Improve TTF support for pixel-style fonts

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -896,8 +896,14 @@ font_shadow (Font shadow) int 1
 #    Opaqueness (alpha) of the shadow behind the default font, between 0 and 255.
 font_shadow_alpha (Font shadow alpha) int 127 0 255
 
-#    Font size of the default font in point (pt).
+#    Font size of the default font where 1 unit = 1 pixel at 96 DPI
 font_size (Font size) int 16 1
+
+#    For pixel-style fonts that do not scale well, this ensures that font sizes used
+#    with this font will always be divisible by this value, in pixels. For instance,
+#    a pixel font 16 pixels tall should have this set to 16, so it will only ever be
+#    sized 16, 32, 48, etc., so a mod requesting a size of 25 will get 32.
+font_size_divisible_by (Font size divisible by) int 1 1
 
 #    Path to the default font.
 #    If “freetype” setting is enabled: Must be a TrueType font.
@@ -909,8 +915,14 @@ font_path_bold (Bold font path) filepath fonts/Arimo-Bold.ttf
 font_path_italic (Italic font path) filepath fonts/Arimo-Italic.ttf
 font_path_bold_italic (Bold and italic font path) filepath fonts/Arimo-BoldItalic.ttf
 
-#    Font size of the monospace font in point (pt).
-mono_font_size (Monospace font size) int 15 1
+#    Font size of the monospace font where 1 unit = 1 pixel at 96 DPI
+mono_font_size (Monospace font size) int 16 1
+
+#    For pixel-style fonts that do not scale well, this ensures that font sizes used
+#    with this font will always be divisible by this value, in pixels. For instance,
+#    a pixel font 16 pixels tall should have this set to 16, so it will only ever be
+#    sized 16, 32, 48, etc., so a mod requesting a size of 25 will get 32.
+mono_font_size_divisible_by (Monospace font size divisible by) int 1 1
 
 #    Path to the monospace font.
 #    If “freetype” setting is enabled: Must be a TrueType font.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1055,6 +1055,12 @@
 #    type: int min: 1
 # font_size = 16
 
+#    For pixel-style fonts that do not scale well, this ensures that font sizes used
+#    with this font will always be divisible by this value, in pixels. For instance,
+#    a pixel font 16 pixels tall should have this set to 16, so it will only ever be
+#    sized 16, 32, 48, etc., so a mod requesting a size of 25 will get 32.
+# font_size_divisible_by = 1
+
 #    Path to the default font.
 #    If “freetype” setting is enabled: Must be a TrueType font.
 #    If “freetype” setting is disabled: Must be a bitmap or XML vectors font.
@@ -1073,7 +1079,13 @@
 
 #    Font size of the monospace font in point (pt).
 #    type: int min: 1
-# mono_font_size = 15
+# mono_font_size = 16
+
+#    For pixel-style fonts that do not scale well, this ensures that font sizes used
+#    with this font will always be divisible by this value, in pixels. For instance,
+#    a pixel font 16 pixels tall should have this set to 16, so it will only ever be
+#    sized 16, 32, 48, etc., so a mod requesting a size of 25 will get 32.
+# mono_font_size_divisible_by = 1
 
 #    Path to the monospace font.
 #    If “freetype” setting is enabled: Must be a TrueType font.

--- a/src/client/fontengine.cpp
+++ b/src/client/fontengine.cpp
@@ -258,9 +258,8 @@ gui::IGUIFont *FontEngine::initFont(const FontSpec &spec)
 			g_settings->getFloat("gui_scaling"), 1);
 
 	// Constrain the font size to a certain multiple, if necessary
-	u16 divisible_by = 1;
-	g_settings->getU16NoEx(setting_prefix + "font_size_divisible_by", divisible_by);
-	if (divisible_by != 1) {
+	u16 divisible_by = g_settings->getU16(setting_prefix + "font_size_divisible_by");
+	if (divisible_by > 1) {
 		size = std::max<u32>(
 				std::round((double)size / divisible_by) * divisible_by, divisible_by);
 	}

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -312,10 +312,12 @@ void set_default_settings()
 	settings->setDefault("font_italic", "false");
 	settings->setDefault("font_shadow", "1");
 	settings->setDefault("font_shadow_alpha", "127");
+	settings->setDefault("font_size_divisible_by", "1");
 	settings->setDefault("mono_font_path", porting::getDataPath("fonts" DIR_DELIM "Cousine-Regular.ttf"));
 	settings->setDefault("mono_font_path_italic", porting::getDataPath("fonts" DIR_DELIM "Cousine-Italic.ttf"));
 	settings->setDefault("mono_font_path_bold", porting::getDataPath("fonts" DIR_DELIM "Cousine-Bold.ttf"));
 	settings->setDefault("mono_font_path_bold_italic", porting::getDataPath("fonts" DIR_DELIM "Cousine-BoldItalic.ttf"));
+	settings->setDefault("mono_font_size_divisible_by", "1");
 	settings->setDefault("fallback_font_path", porting::getDataPath("fonts" DIR_DELIM "DroidSansFallbackFull.ttf"));
 
 	std::string font_size_str = std::to_string(TTF_DEFAULT_FONT_SIZE);


### PR DESCRIPTION
This PR improves support for TTF pixel-style fonts, such as Unifont TTF.  It introduces a new setting, `font_size_divisible_by` (and `mono_font_size_divisible_by`) that forces a font into integer scaling.  It takes an integer, which is the number of pixels high the font is (not points, pixels).  It works regardless of DPI or GUI scaling.

Please note that `font_size` is not in pixels but scaled such that 1 unit = 1 pixel at 96 DPI -- hence, higher DPIs will result in higher font sizes.

Alternate to #11767 to supersede bitmap fonts in every regard (see #11611).

![image](https://user-images.githubusercontent.com/31123645/145477488-1100d0d4-df1e-4919-a7ce-0ba840aec30f.png)

## To do

This PR is Ready for Review.

## How to test

Get Unifont.  Set it as the font, set `font_size_divisible_by` to 16 (since that is the height of the font in pixels), and then muck about with `font_size`, `display_density_factor`, and `gui_scaling`.  Make sure that Unifont _never, ever_ appears blurry no matter what settings you use for those, but does, in fact, do integer scaling.