### PR TITLE
Enable strip color codes

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1060,7 +1060,7 @@ serverlist_url (Serverlist URL) string servers.minetest.net
 
 #    Remove color codes from incoming chat messages
 #    Use this to stop players from being able to use color in their messages
-strip_color_codes (Strip color codes) bool false
+strip_color_codes (Strip color codes) bool true
 
 [*Network]
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -344,7 +344,7 @@ void set_default_settings()
 
 	// Server
 	settings->setDefault("disable_escape_sequences", "false");
-	settings->setDefault("strip_color_codes", "false");
+	settings->setDefault("strip_color_codes", "true");
 #if USE_PROMETHEUS
 	settings->setDefault("prometheus_listener_address", "127.0.0.1:30000");
 #endif


### PR DESCRIPTION
It makes no sense to allow players to send color codes by default. If this is a desired feature, then it should be supported as such on the client rather than requiring a CSM

Alternative: this setting could also be removed, fewer settings is better

See #5948

## To do

This PR is a Ready for Review.

## How to test

N/a
