### PR TITLE
Formspec: Unify argument checks

### DIFF
--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -279,6 +279,8 @@ protected:
 	v2s32 getElementBasePos(const std::vector<std::string> *v_pos);
 	v2s32 getRealCoordinateBasePos(const std::vector<std::string> &v_pos);
 	v2s32 getRealCoordinateGeometry(const std::vector<std::string> &v_geom);
+	bool precheckElement(const std::string &name, const std::string &element,
+		size_t args_min, size_t args_max, std::vector<std::string> &parts);
 
 	std::unordered_map<std::string, std::vector<StyleSpec>> theme_by_type;
 	std::unordered_map<std::string, std::vector<StyleSpec>> theme_by_name;


### PR DESCRIPTION
Features:
 * Combined argument range checks to avoid forwards-compatibility mistakes
 * Additional `m_client` checks where necessary (low priority)
 * Error message corrections where it stated wrong element names

Based on the idea of v-rob: https://github.com/minetest/minetest/pull/11821#discussion_r765239200

## To do

This PR is Ready for Review.

## How to test

1. Main menu must render properly
2. devtest `/test_formspecs`
3. Code review: **Ignore space changes**: `git diff -w`  (only few lines were actually modified)
