### PR TITLE
Automatically use SSE registers for FP operations on i386

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,9 @@ endif()
 # use SSE for floating-point operations to avoid issues with improper fp-rounding and loss of precision
 # when moving fp-data to incompatible or less-precise registers/storage locations
 # see https://gcc.gnu.org/wiki/FloatingPointMath and https://gcc.gnu.org/wiki/x87note
+IF(NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR  CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64") )
 add_compile_options(-mfpmath=sse -msse2)
+ENDIF(NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR  CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64") )
 
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,14 +286,6 @@ endif()
 
 # Subdirectories
 # Be sure to add all relevant definitions above this
-
-# use SSE for floating-point operations to avoid issues with improper fp-rounding and loss of precision
-# when moving fp-data to incompatible or less-precise registers/storage locations
-# see https://gcc.gnu.org/wiki/FloatingPointMath and https://gcc.gnu.org/wiki/x87note
-IF(NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR  CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64") )
-add_compile_options(-mfpmath=sse -msse2)
-ENDIF(NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR  CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64") )
-
 add_subdirectory(src)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,11 @@ endif()
 # Subdirectories
 # Be sure to add all relevant definitions above this
 
+# use SSE for floating-point operations to avoid issues with improper fp-rounding and loss of precision
+# when moving fp-data to incompatible or less-precise registers/storage locations
+# see https://gcc.gnu.org/wiki/FloatingPointMath and https://gcc.gnu.org/wiki/x87note
+add_compile_options(-mfpmath=sse -msse2)
+
 add_subdirectory(src)
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -769,6 +769,16 @@ else()
 	# - we don't deal with Inf/NaN or signed zero
 	set(MATH_FLAGS "-fno-math-errno -fno-trapping-math -ffinite-math-only -fno-signed-zeros")
 
+	# Enable SSE for floating point math on 32-bit x86 by default
+	# reasoning see minetest issue #11810 and https://gcc.gnu.org/wiki/FloatingPointMath
+	if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+		check_c_source_compiles("#ifndef __i686__\n#error\n#endif\nint main(){}" IS_I686)
+		if(IS_I686)
+			message(STATUS "Detected Intel x86: using SSE instead of x87 FPU")
+			set(OTHER_FLAGS "${OTHER_FLAGS} -mfpmath=sse -msse")
+		endif()
+	endif()
+
 	set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG ${RELEASE_WARNING_FLAGS} ${WARNING_FLAGS} ${OTHER_FLAGS} -Wall -pipe -funroll-loops")
 	if(CMAKE_SYSTEM_NAME MATCHES "(Darwin|BSD|DragonFly)")
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Os")
@@ -787,16 +797,6 @@ else()
 
 	if(USE_GPROF)
 		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pg")
-	endif()
-
-	# Enable SSE for floating point math on 32-bit x86 by default
-	# reasoning see minetest issue #11810 and https://gcc.gnu.org/wiki/FloatingPointMath
-	if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-		check_c_source_compiles("#ifndef __i686__\n#error\n#endif\nint main(){}" IS_I686)
-		if(IS_I686)
-			message(STATUS "Detected Intel x86: using SSE instead of x87 FPU")
-			set(OTHER_FLAGS "${OTHER_FLAGS} -mfpmath=sse -msse")
-		endif()
 	endif()
 
 	if(MINGW)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -789,6 +789,16 @@ else()
 		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pg")
 	endif()
 
+	# Enable SSE for floating point math on 32-bit x86 by default
+	# reasoning see minetest issue #11810 and https://gcc.gnu.org/wiki/FloatingPointMath
+	if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+		check_c_source_compiles("#ifndef __i686__\n#error\n#endif\nint main(){}" IS_I686)
+		if(IS_I686)
+			message(STATUS "Detected Intel x86: using SSE instead of x87 FPU")
+			set(OTHER_FLAGS "${OTHER_FLAGS} -mfpmath=sse -msse")
+		endif()
+	endif()
+
 	if(MINGW)
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mwindows")
 	endif()


### PR DESCRIPTION
Related PRs:
https://github.com/minetest/irrlicht/pull/83


This pull request fixes a minetest issue dealting with floating-point operations and it affects both minetest and irrlicht.
See: https://github.com/minetest/minetest/issues/11810

On a x86 system (could affect other platforms that handle floats this way) the x87 fp unit
stores floats with 80-bit precision, but when those floats are moved to other registers they suffer from
loss of precision and double rounding.

see
https://gcc.gnu.org/wiki/FloatingPointMath 
https://gcc.gnu.org/wiki/x87note

The solution to correct those two issues: (1) loss of precision and (2) double rounding, is to have all floating-point operations occur in sse registers.

That solution can be enabled by adding the following cmake options (in CMakeLists.txt):
```
add_compile_options(-mfpmath=sse -msse2)
```

This definately fixes the issue on i386 (the original issue involved Debian 10 Buster) but should affect all i386 and later systems.
On x86_64 (amd64) the issue wasn't present and the implemented solution (above) didn't affect the outcome.

The only potential pitfall (by enabling sse registers by default) would be on systems that don't have sse support.
However, I don't know if that is really an issue today (cpus that don't have sse support).