### PR TITLE
Shader improvements: Saturation Optimization

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -552,6 +552,16 @@ shader_path (Shader path) path
 #    enhanced, highlights and shadows are gradually compressed.
 tone_mapping (Filmic tone mapping) bool false
 
+[***Saturation Optimization]
+
+#    "Saturation Optimization" is an additional feature of tone mapping.
+#    It is necessary to enable tone mapping if you would like to enable it.
+#    The higher the value, the brighter the game screen looks
+#    The smaller the value, the darker the game screen looks
+#    1.0 = Disable saturation optimization
+#    Default is 1.5 
+saturation_param (Saturation Optimization) float 1.5 0.0
+
 [***Waving Nodes]
 
 #    Set to true to enable waving liquids (like water).

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -456,6 +456,15 @@ vec4 applyToneMapping(vec4 color)
 }
 #endif
 
+/*
+ *  @function saturation 
+ *  @param color         
+ *  @param factor        
+ */ 
+vec3 saturation(vec3 color, float factor) {
+    float brightness = dot(color, vec3(0.2125, 0.7154, 0.0721));
+    return mix(vec3(brightness), color, factor);
+}
 
 
 void main(void)
@@ -531,6 +540,7 @@ void main(void)
 
 #if ENABLE_TONE_MAPPING
 	col = applyToneMapping(col);
+	col.rgb = saturation(col.rgb, 1.5);
 #endif
 
 	// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -540,7 +540,7 @@ void main(void)
 
 #if ENABLE_TONE_MAPPING
 	col = applyToneMapping(col);
-	col.rgb = saturation(col.rgb, 1.5);
+	col.rgb = saturation(col.rgb, SATURATION_PARAM);
 #endif
 
 	// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -625,6 +625,15 @@
 #    type: bool
 # tone_mapping = false
 
+#    "Saturation Optimization" is an additional feature of tone mapping.
+#    It is necessary to enable tone mapping if you would like to enable it.
+#    The higher the value, the brighter the game screen looks
+#    The smaller the value, the darker the game screen looks
+#    1.0 = Disable saturation optimization
+#    Default is 1.5 
+#    type: float min:0
+# saturation_param = 1.5
+
 #### Waving Nodes
 
 #    Set to true to enable waving liquids (like water).

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -730,6 +730,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 	shaders_header << "#define ENABLE_WAVING_LEAVES " << g_settings->getBool("enable_waving_leaves") << "\n";
 	shaders_header << "#define ENABLE_WAVING_PLANTS " << g_settings->getBool("enable_waving_plants") << "\n";
 	shaders_header << "#define ENABLE_TONE_MAPPING " << g_settings->getBool("tone_mapping") << "\n";
+	shaders_header << "#define SATURATION_PARAM " << g_settings->getFloat("saturation_param")<< "\n";
 
 	shaders_header << "#define FOG_START " << core::clamp(g_settings->getFloat("fog_start"), 0.0f, 0.99f) << "\n";
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -256,6 +256,7 @@ void set_default_settings()
 	settings->setDefault("bilinear_filter", "false");
 	settings->setDefault("trilinear_filter", "false");
 	settings->setDefault("tone_mapping", "false");
+	settings->setDefault("saturation_param","1.5");
 	settings->setDefault("enable_waving_water", "false");
 	settings->setDefault("water_wave_height", "1.0");
 	settings->setDefault("water_wave_length", "20.0");


### PR DESCRIPTION
## Screenshots

#####

Saturation Optimization OFF:

![原版色调映射](https://user-images.githubusercontent.com/29888010/145710777-1969e0ec-6ad8-4e1f-a438-da8915049377.png)

Saturation Optimization ON:
![饱和度优化](https://user-images.githubusercontent.com/29888010/145710782-6ec14fcb-66f3-4207-8568-6c6ee2c63d85.png)

## What it did?
This PR changes the saturation of the blocks in the rendering.

Make the color of minetest brighter.

It can effectively improve the image quality without any performance loss

Through repeated tests, it is found that the saturation parameter is 1.5, which looks best.

Because it is only a simple change of tone, it is put together with tone mapping.

(when hue mapping is enabled in minetest, it is also enabled)

## How to test

1.Start minetest before merging and take a screenshot after entering the world

2.Then start minetest in this PR and take a screenshot after entering the world

3.Compare these two screenshots
