### PR TITLE
Correct gravity calculation

### DIFF
--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1047,6 +1047,7 @@ Methods:
         sneak = boolean,
         sneak_glitch = boolean,
         new_move = boolean,
+        new_acceleration = boolean,
     }
 ```
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6727,6 +6727,8 @@ object you are working with still exists.
           (default: `false`)
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behaviour (default: `true`)
+        * `new_acceleration`: use new, physically correct acceleration/gravity
+          code (default: `false`)
 * `get_physics_override()`: returns the table given to `set_physics_override`
 * `hud_add(hud definition)`: add a HUD element described by HUD def, returns ID
    number on success

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -197,6 +197,8 @@ void ClientEnvironment::step(float dtime)
 		if (!free_move) {
 			// Gravity
 			v3f speed = lplayer->getSpeed();
+			v3f old_speed = speed;
+
 			if (!is_climbing && !lplayer->in_liquid)
 				speed.Y -= lplayer->movement_gravity *
 					lplayer->physics_override_gravity * dtime_part * 2.0f;
@@ -233,7 +235,10 @@ void ClientEnvironment::step(float dtime)
 				speed += d;
 			}
 
-			lplayer->setSpeed(speed);
+			lplayer->setSpeed(lplayer->physics_override_new_gravity
+				? (speed + old_speed) / 2.0f
+				: speed
+			);
 		}
 
 		/*

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -235,7 +235,7 @@ void ClientEnvironment::step(float dtime)
 				speed += d;
 			}
 
-			lplayer->setSpeed(lplayer->physics_override_new_gravity
+			lplayer->setSpeed(lplayer->physics_override_new_acceleration
 				? (speed + old_speed) / 2.0f
 				: speed
 			);

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1772,7 +1772,7 @@ void GenericCAO::processMessage(const std::string &data)
 		bool sneak_glitch = !readU8(is);
 		bool new_move = !readU8(is);
 		// this one is off by default
-		bool new_gravity = readU8(is);
+		bool new_acceleration = readU8(is);
 
 
 		if(m_is_local_player)
@@ -1784,7 +1784,7 @@ void GenericCAO::processMessage(const std::string &data)
 			player->physics_override_sneak = sneak;
 			player->physics_override_sneak_glitch = sneak_glitch;
 			player->physics_override_new_move = new_move;
-			player->physics_override_new_gravity = new_gravity;
+			player->physics_override_new_acceleration = new_acceleration;
 		}
 	} else if (cmd == AO_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1771,6 +1771,8 @@ void GenericCAO::processMessage(const std::string &data)
 		bool sneak = !readU8(is);
 		bool sneak_glitch = !readU8(is);
 		bool new_move = !readU8(is);
+		// this one is off by default
+		bool new_gravity = readU8(is);
 
 
 		if(m_is_local_player)
@@ -1782,6 +1784,7 @@ void GenericCAO::processMessage(const std::string &data)
 			player->physics_override_sneak = sneak;
 			player->physics_override_sneak_glitch = sneak_glitch;
 			player->physics_override_new_move = new_move;
+			player->physics_override_new_gravity = new_gravity;
 		}
 	} else if (cmd == AO_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -68,7 +68,7 @@ public:
 	bool physics_override_sneak_glitch = false;
 	// Temporary option for old move code
 	bool physics_override_new_move = true;
-	bool physics_override_new_gravity = false;
+	bool physics_override_new_acceleration = false;
 
 	void move(f32 dtime, Environment *env, f32 pos_max_d);
 	void move(f32 dtime, Environment *env, f32 pos_max_d,

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -68,6 +68,7 @@ public:
 	bool physics_override_sneak_glitch = false;
 	// Temporary option for old move code
 	bool physics_override_new_move = true;
+	bool physics_override_new_gravity = false;
 
 	void move(f32 dtime, Environment *env, f32 pos_max_d);
 	void move(f32 dtime, Environment *env, f32 pos_max_d,

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -176,6 +176,9 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushboolean(L, player->physics_override_new_move);
 	lua_setfield(L, -2, "new_move");
 
+	lua_pushboolean(L, player->physics_override_new_gravity);
+	lua_setfield(L, -2, "new_gravity");
+
 	return 1;
 }
 

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -176,8 +176,8 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushboolean(L, player->physics_override_new_move);
 	lua_setfield(L, -2, "new_move");
 
-	lua_pushboolean(L, player->physics_override_new_gravity);
-	lua_setfield(L, -2, "new_gravity");
+	lua_pushboolean(L, player->physics_override_new_acceleration);
+	lua_setfield(L, -2, "new_acceleration");
 
 	return 1;
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1434,6 +1434,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		modified |= getboolfield(L, 2, "sneak", playersao->m_physics_override_sneak);
 		modified |= getboolfield(L, 2, "sneak_glitch", playersao->m_physics_override_sneak_glitch);
 		modified |= getboolfield(L, 2, "new_move", playersao->m_physics_override_new_move);
+		modified |= getboolfield(L, 2, "new_gravity", playersao->m_physics_override_new_gravity);
 		if (modified)
 			playersao->m_physics_override_sent = false;
 	} else {
@@ -1479,6 +1480,8 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "sneak_glitch");
 	lua_pushboolean(L, playersao->m_physics_override_new_move);
 	lua_setfield(L, -2, "new_move");
+	lua_pushboolean(L, playersao->m_physics_override_new_gravity);
+	lua_setfield(L, -2, "new_gravity");
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1434,7 +1434,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		modified |= getboolfield(L, 2, "sneak", playersao->m_physics_override_sneak);
 		modified |= getboolfield(L, 2, "sneak_glitch", playersao->m_physics_override_sneak_glitch);
 		modified |= getboolfield(L, 2, "new_move", playersao->m_physics_override_new_move);
-		modified |= getboolfield(L, 2, "new_gravity", playersao->m_physics_override_new_gravity);
+		modified |= getboolfield(L, 2, "new_acceleration", playersao->m_physics_override_new_acceleration);
 		if (modified)
 			playersao->m_physics_override_sent = false;
 	} else {
@@ -1480,8 +1480,8 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "sneak_glitch");
 	lua_pushboolean(L, playersao->m_physics_override_new_move);
 	lua_setfield(L, -2, "new_move");
-	lua_pushboolean(L, playersao->m_physics_override_new_gravity);
-	lua_setfield(L, -2, "new_gravity");
+	lua_pushboolean(L, playersao->m_physics_override_new_acceleration);
+	lua_setfield(L, -2, "new_acceleration");
 	return 1;
 }
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -316,6 +316,8 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeU8(os, !m_physics_override_sneak);
 	writeU8(os, !m_physics_override_sneak_glitch);
 	writeU8(os, !m_physics_override_new_move);
+	// this one is off by default
+	writeU8(os, m_physics_override_new_gravity);
 	return os.str();
 }
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -317,7 +317,7 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeU8(os, !m_physics_override_sneak_glitch);
 	writeU8(os, !m_physics_override_new_move);
 	// this one is off by default
-	writeU8(os, m_physics_override_new_gravity);
+	writeU8(os, m_physics_override_new_acceleration);
 	return os.str();
 }
 

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -227,6 +227,7 @@ public:
 	bool m_physics_override_sneak = true;
 	bool m_physics_override_sneak_glitch = false;
 	bool m_physics_override_new_move = true;
+	bool m_physics_override_new_gravity = false;
 	bool m_physics_override_sent = false;
 };
 

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -227,7 +227,7 @@ public:
 	bool m_physics_override_sneak = true;
 	bool m_physics_override_sneak_glitch = false;
 	bool m_physics_override_new_move = true;
-	bool m_physics_override_new_gravity = false;
+	bool m_physics_override_new_acceleration = false;
 	bool m_physics_override_sent = false;
 };
 


### PR DESCRIPTION
## Problem
The Minetest engine calculates gravity different from the real world. After the new speed is calculated by adding gravity * dtime to it, it is applied to position by adding speed * dtime. However, this is wrong, since the speed is assumed to be the value that it actually just reached at the end of the step over the entire step. Yes, this has a practical impact.

Currently the new position is wrongly calculated by:
![image](https://user-images.githubusercontent.com/54945686/145719133-ecc864d4-b28e-47d1-9a20-4b19548c930c.png)
This approach would be correct if velocity was constant. However, this is an accelerated movement, so
![image](https://user-images.githubusercontent.com/54945686/145721281-882a6b31-517e-4575-a84a-eb2d3d36c444.png)

Generally correct is:
![image](https://user-images.githubusercontent.com/54945686/145719172-f73ea9c7-7c3d-4c85-842d-a975ffb58ad3.png)
Since the velocity is linearly increasing (gravity is constant), this resolves to:
![image](https://user-images.githubusercontent.com/54945686/145719138-00eb2f52-2dd5-4f23-8f37-c95370482ab2.png)

## Solution
This PR adds the `new_acceleration` field to physics_override. This field is opt-in, so that it does not break existing games/mods. If the field is enabled, you will notice that you can jump higher than before unless you also change `movement_jump_speed` or `movement_gravity`. This is to be expected, since gravity has been calculated incorrectly before. Projects that want to use the new formula have to adjust these settings.

If you want the player to be able to jump 1.25 nodes high at a gravity of 9.81, set the jump speed to 4.95 (approximately). The formula is
![image](https://user-images.githubusercontent.com/54945686/145721096-4862ee62-0d8b-43ed-9481-4dc75734b7b5.png)
This formula works IRL. Do the math or just try it out if you don't believe me.

## To do

Currently, the pull request only fixes the physics calculation for players.

- [ ] Fix server-side luaentity acceleration code in case it's wrong like the client side player acceleration code. Find a way to make these correct luaentity physics opt-in. Also apply this to the client side prediction of the server-side luaentitiy accelerations, if there is any.
- [ ] Find a fix for the following scenario: A player with <5.5.0-dev client joins >=5.5.0 server that has new_gravity enabled and a lower jump speed configured, can jump lower than other players
- [ ] Adjust fall damage since the speed at that the player collides with the ground will be lower than before

## How to test
```lua
minetest.register_on_joinplayer(function(player)
	player:set_physics_override({new_acceleration = true})
end)
```

Btw: I used this http://www.sciweavers.org/free-online-latex-equation-editor tool for the equation images, since GitHub markdown does not support inline latex or any other way to embed equations.