### PR TITLE
Raise minimum compiler versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,49 +30,49 @@ on:
       - '.dockerignore'
 
 jobs:
-  # This is our minor gcc compiler
-  gcc_6:
+  # Older gcc version (should be close to our minimum supported version)
+  gcc_5:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Install deps
         run: |
           source ./util/ci/common.sh
-          install_linux_deps g++-6
+          install_linux_deps g++-5
 
       - name: Build
         run: |
           ./util/ci/build.sh
         env:
-          CC: gcc-6
-          CXX: g++-6
+          CC: gcc-5
+          CXX: g++-5
 
       - name: Test
         run: |
           ./bin/minetest --run-unittests
 
-  # This is the current gcc compiler (available in bionic)
-  gcc_8:
-    runs-on: ubuntu-18.04
+  # Current gcc version
+  gcc_10:
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install deps
         run: |
           source ./util/ci/common.sh
-          install_linux_deps g++-8
+          install_linux_deps g++-10
 
       - name: Build
         run: |
           ./util/ci/build.sh
         env:
-          CC: gcc-8
-          CXX: g++-8
+          CC: gcc-10
+          CXX: g++-10
 
       - name: Test
         run: |
           ./bin/minetest --run-unittests
 
-  # This is our minor clang compiler
+  # Older clang version (should be close to our minimum supported version)
   clang_3_9:
     runs-on: ubuntu-18.04
     steps:
@@ -97,22 +97,22 @@ jobs:
         run: |
           ./util/test_multiplayer.sh
 
-  # This is the current clang version
-  clang_9:
-    runs-on: ubuntu-18.04
+  # Current clang version
+  clang_10:
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install deps
         run: |
           source ./util/ci/common.sh
-          install_linux_deps clang-9 valgrind libluajit-5.1-dev
+          install_linux_deps clang-10 valgrind libluajit-5.1-dev
 
       - name: Build
         run: |
           ./util/ci/build.sh
         env:
-          CC: clang-9
-          CXX: clang++-9
+          CC: clang-10
+          CXX: clang++-10
           CMAKE_FLAGS: "-DREQUIRE_LUAJIT=1"
 
       - name: Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ project(minetest)
 set(PROJECT_NAME_CAPITALIZED "Minetest")
 
 set(CMAKE_CXX_STANDARD 11)
-set(GCC_MINIMUM_VERSION "4.8")
-set(CLANG_MINIMUM_VERSION "3.4")
+set(GCC_MINIMUM_VERSION "5.1")
+set(CLANG_MINIMUM_VERSION "3.5")
 
 # Also remember to set PROTOCOL_VERSION in network/networkprotocol.h when releasing
 set(VERSION_MAJOR 5)
@@ -265,11 +265,6 @@ if(NOT USE_LUAJIT)
 	set(LUA_BIT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/bitop)
 	set(LUA_BIT_LIBRARY bitop)
 	add_subdirectory(lib/bitop)
-endif()
-
-# JsonCpp doesn't compile well on GCC 4.8
-if(NOT USE_SYSTEM_JSONCPP)
-	set(GCC_MINIMUM_VERSION "4.9")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Compiling
 
 | Dependency | Version | Commentary |
 |------------|---------|------------|
-| GCC        | 4.9+    | Can be replaced with Clang 3.4+ |
+| GCC        | 5.1+    | or Clang 3.5+ |
 | CMake      | 3.5+    |            |
 | IrrlichtMt | -       | Custom version of Irrlicht, see https://github.com/minetest/irrlicht |
 | SQLite3    | 3.0+    |            |


### PR DESCRIPTION
super old versions were broken anyway (not only because of MT but also system libs not working etc.) and barely tested by anyone

I verified on Ubuntu 16.04 that **gcc 5.4 and clang 3.5** can successfully build Minetest.

## To do

This PR is a Ready for Review.
