### PR TITLE
Fix minetest.find_nodes_in_area() coord clamping

### DIFF
--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -888,8 +888,9 @@ static void checkArea(v3s16 &minp, v3s16 &maxp)
 		throw LuaError("Area volume exceeds allowed value of 4096000");
 	}
 
-	// Clamp to map range to avoid problems
-#define CLAMP(arg) core::clamp(arg, (s16)-MAX_MAP_GENERATION_LIMIT, (s16)MAX_MAP_GENERATION_LIMIT)
+	// Clamp to almost s16 range to avoid problems
+	// Clamping to exactly s16 range hangs Minetest
+#define CLAMP(arg) core::clamp(arg, (s16)(INT16_MIN+1), (s16)(INT16_MAX-1))
 	minp = v3s16(CLAMP(minp.X), CLAMP(minp.Y), CLAMP(minp.Z));
 	maxp = v3s16(CLAMP(maxp.X), CLAMP(maxp.Y), CLAMP(maxp.Z));
 #undef CLAMP


### PR DESCRIPTION
(The patch and commit message were written by erlehmann, I just made the pull request)
(Related: #11828,  #11770)

Previously, minetest.find_nodes_in_area() was affected by a signed
integer overflow, which was fixed by clamping the area in which the
function works to MAX_MAP_GENERATION_LIMIT & -MAX_MAP_GENERATION_LIMIT.

The problem with that approach is that nodes can exist and even be generated
past MAX_MAP_GENERATION_LIMIT in vanilla Minetest – which, despite the name,
does not specify exactly where the map generator stops working. Therefore,
the bug fix created an unknown amount of other bugs near the map border.

At minimum, those bugs affect the outer mapblocks, where nodes past
MAX_MAP_GENERATION_LIMIT can be generated. Ironically, the first thing
broken by the faulty bug fix was a test case belonging to a workaround that
prevents minetest.find_nodes_in_area() being called with coordinates out of
s16 bounds in the Mineclonia game, thus avoiding signed integer overflow.

Using INT16_MIN+1 & INT16_MAX-1 makes minetest.find_nodes_in_area()
work for all coordinates that worked before the faulty fix, avoiding a
situation where Minetest can place a node in the map, but then not find
it afterwards using minetest_find_nodes_in_area().

## To do

This PR is Ready for Review.

## How to test
(This was copied from https://git.minetest.land/Mineclonia/Mineclonia/raw/branch/master/mods/MISC/mcl_selftests/init.lua and was written by erlehmann as well. Without this Pull Request, game startup will fail if the following code is used)
```lua
local test_minetest_find_nodes_in_area_can_count = function(dtime)
	local pos = { x=30999, y=30999, z=30999 }
	-- You think there is nothing there? Well, here is the thing:
	-- With standard settings you can only see map until x=30927,
	-- although the renderer can actually render up to x=31007 if
	-- you configure it to. Any statements given by minetest core
	-- devs that contradict the above assertion are probably lies.
	--
	-- In any way, this area should be so far out that no one has
	-- built here … yet. Now that you know it is possible, I know
	-- you want to. How though? I suggest to figure the technique
	-- out yourself, then go on and build invisible lag machines.

	local radius = 3
	local minp = vector.subtract(pos, radius)
	local maxp = vector.add(pos, radius)
	local nodename = "air"
	local c_nodename = minetest.get_content_id(nodename)

	-- Why not use minetest.set_node() here? Well, some mods do
	-- trigger on every placement of a node in the entire map …
	-- and we do not want to crash those mods in this test case.
	-- (Voxelmanip does not trigger callbacks – so all is well.)
	--
	-- And now for a funny story: I initially copied the following
	-- code from the Minetest developer wiki. Can you spot a typo?
	-- <https://dev.minetest.net/index.php?title=minetest.get_content_id&action=edit>
	local vm = minetest.get_voxel_manip()
	local emin, emax = vm:read_from_map(
		minp,
		maxp
	)
	local area = VoxelArea:new({
		MinEdge=emin,
		MaxEdge=emax
	})
	local data = vm:get_data()
	for z = minp.z, maxp.z do
		for y = minp.y, maxp.y do
			local vi = area:index(minp.x, y, z)
			for x = minp.x, maxp.y do
				data[vi] = c_nodename
				vi = vi + 1
			end
		end
	end
	vm:set_data(data)
	vm:write_to_map()
	local npos, nnum = minetest.find_nodes_in_area(
		minp,
		maxp,
		{ nodename }
	)
	local nodes_expected = math.pow( 1 + (2 * radius), 3 )
	local nodes_counted = nnum[nodename]
	local nodes_difference = nodes_expected - nodes_counted
	-- Yes, the following line is supposed to crash the game in
	-- the case that Minetest forgot how to count the number of
	-- nodes in a three dimensional volume it just filled. This
	-- function contains an excellent explanation on what not to
	-- do further up. I strongly suggest to pester Minetest core
	-- devs about this issue and not the author of the function,
	-- should this test ever fail.
	assert ( 0 == nodes_difference )
end

minetest.after( 0, test_minetest_find_nodes_in_area_can_count )

local test_minetest_find_nodes_in_area_crash = function(dtime)
	-- And now for our feature presentation, where we call the
	-- function “minetest.find_nodes_in_area()” with a position
	-- out of bounds! Will it crash? Who knows‽ If it does, the
	-- workaround is not working though, so it should be patched.

	local pos = { x=32767, y=32767, z=32767 }
	-- Note that not all out of bounds values actually crash the
	-- function minetest.find_nodes_in_area()“. In fact, the vast
	-- majority of out of bounds values do not crash the function.

	local radius = 3
	local minp = vector.subtract(pos, radius)
	local maxp = vector.add(pos, radius)
	local nodename = "air"
	local npos, nnum = minetest.find_nodes_in_area(
		minp,
		maxp,
		{ nodename }
	)
	-- That's all, folks!
end

minetest.after( 0, test_minetest_find_nodes_in_area_crash )
```