### PR TITLE
Use defined evaluation order in profiler

### DIFF
--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -102,8 +102,9 @@ local function instrument(def)
 		-- also called https://en.wikipedia.org/wiki/Continuation_passing_style
 		-- Compared to table creation and unpacking it won't lose `nil` returns
 		-- and is expected to be faster
-		-- `measure` will be executed after time() and func(...)
-		return measure(modname, instrument_name, time(), func(...))
+		-- `measure` will be executed after func(...)
+		local start = time()
+		return measure(modname, instrument_name, start, func(...))
 	end
 end
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - Fix theoretical bug in profiler code. See https://github.com/LuaJIT/LuaJIT/issues/238.
- How does the PR work?
  - It changes the order of evaluation from being undefined to being defined.
- Does it resolve any reported issue?
  - No.
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
  - No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  - This is a bug fix.

## To do

This PR is Ready for Review.

## How to test

1. Turn on profiling, including for the profiler itself.
2. Make sure the profiling overhead is about the same as before.
3. Make sure profiling of mods still works.
