### PR TITLE
Cap damage overlay duration to 1 second

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1860,6 +1860,8 @@ void GenericCAO::processMessage(const std::string &data)
 				m_reset_textures_timer = 0.05;
 				if(damage >= 2)
 					m_reset_textures_timer += 0.05 * damage;
+				if (m_reset_textures_timer > 1.0)
+					m_reset_textures_timer = 1.0;
 				updateTextures(m_current_texture_modifier + m_prop.damage_texture_modifier);
 			}
 		}
@@ -1928,6 +1930,8 @@ bool GenericCAO::directReportPunch(v3f dir, const ItemStack *punchitem,
 			m_reset_textures_timer = 0.05;
 			if (result.damage >= 2)
 				m_reset_textures_timer += 0.05 * result.damage;
+			if (m_reset_textures_timer > 1.0)
+				m_reset_textures_timer = 1.0;
 			updateTextures(m_current_texture_modifier + m_prop.damage_texture_modifier);
 		}
 	}

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1860,8 +1860,8 @@ void GenericCAO::processMessage(const std::string &data)
 				m_reset_textures_timer = 0.05;
 				if(damage >= 2)
 					m_reset_textures_timer += 0.05 * damage;
-				if (m_reset_textures_timer > 1.0)
-					m_reset_textures_timer = 1.0;
+				// Cap damage overlay to 1 second
+				m_reset_textures_timer = std::min(m_reset_textures_timer, 1.0f);
 				updateTextures(m_current_texture_modifier + m_prop.damage_texture_modifier);
 			}
 		}

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1930,8 +1930,8 @@ bool GenericCAO::directReportPunch(v3f dir, const ItemStack *punchitem,
 			m_reset_textures_timer = 0.05;
 			if (result.damage >= 2)
 				m_reset_textures_timer += 0.05 * result.damage;
-			if (m_reset_textures_timer > 1.0)
-				m_reset_textures_timer = 1.0;
+			// Cap damage overlay to 1 second
+			m_reset_textures_timer = std::min(m_reset_textures_timer, 1.0f);
 			updateTextures(m_current_texture_modifier + m_prop.damage_texture_modifier);
 		}
 	}


### PR DESCRIPTION
There’s a problem with `damage_texture_overlay` that this PR fixes:

If the entity receives a ton of damage (like, over 1000), the damage texture overlay is shown extremely long (maximum possible is 32767*0.05 = 1638.35 seconds = ca. 27 minutes)

This PR does the following:
Cap the duration of the damage texture overlay to 1 second (this is reached at 20 damage)

## Note

The duration of the damage texture overlay is currently (i.e. before this PR) calculated by `<damage> * 0.05` seconds. This formula is NOT changed, the PR only introduces some basic limit.

It sucks that this overlay duration is hardcoded in the first place, but this PR doesn’t care. Maybe un-hardcoding this feature is a task for a later PR.

## How to test

You need to code yourself some basic test weapons, like a weapon with high damage and use it on a dummy entity with high health.