### PR TITLE
Fix damage wraparound if very high damage

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3513,7 +3513,7 @@ Helper functions
 * `minetest.get_hit_params(groups, tool_capabilities [, time_from_last_punch [, wear]])`:
     Simulates an item that punches an object.
     Returns a table with the following fields:
-    * `hp`: How much damage the punch would cause.
+    * `hp`: How much damage the punch would cause (between -65535 and 65535).
     * `wear`: How much wear would be added to the tool (ignored for non-tools).
     Parameters:
     * `groups`: Damage groups of the object

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -240,7 +240,7 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime,
 //                       tool_capabilities, direction, damage)
 bool ScriptApiEntity::luaentity_Punch(u16 id,
 		ServerActiveObject *puncher, float time_from_last_punch,
-		const ToolCapabilities *toolcap, v3f dir, s16 damage)
+		const ToolCapabilities *toolcap, v3f dir, s32 damage)
 {
 	SCRIPTAPI_PRECHECKHEADER
 

--- a/src/script/cpp_api/s_entity.h
+++ b/src/script/cpp_api/s_entity.h
@@ -42,7 +42,7 @@ public:
 		const collisionMoveResult *moveresult);
 	bool luaentity_Punch(u16 id,
 			ServerActiveObject *puncher, float time_from_last_punch,
-			const ToolCapabilities *toolcap, v3f dir, s16 damage);
+			const ToolCapabilities *toolcap, v3f dir, s32 damage);
 	bool luaentity_on_death(u16 id, ServerActiveObject *killer);
 	void luaentity_Rightclick(u16 id, ServerActiveObject *clicker);
 	void luaentity_on_attach_child(u16 id, ServerActiveObject *child);

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -60,7 +60,7 @@ bool ScriptApiPlayer::on_punchplayer(ServerActiveObject *player,
 		float time_from_last_punch,
 		const ToolCapabilities *toolcap,
 		v3f dir,
-		s16 damage)
+		s32 damage)
 {
 	SCRIPTAPI_PRECHECKHEADER
 	// Get core.registered_on_punchplayers

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -46,7 +46,7 @@ public:
 	void on_cheat(ServerActiveObject *player, const std::string &cheat_type);
 	bool on_punchplayer(ServerActiveObject *player, ServerActiveObject *hitter,
 			float time_from_last_punch, const ToolCapabilities *toolcap,
-			v3f dir, s16 damage);
+			v3f dir, s32 damage);
 	void on_rightclickplayer(ServerActiveObject *player, ServerActiveObject *clicker);
 	s32 on_player_hpchange(ServerActiveObject *player, s32 hp_change,
 			const PlayerHPChangeReason &reason);

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -306,7 +306,7 @@ HitParams getHitParams(const ItemGroupList &armor_groups,
 		const ToolCapabilities *tp, float time_from_last_punch,
 		u16 initial_wear)
 {
-	s16 damage = 0;
+	s32 damage = 0;
 	float result_wear = 0.0f;
 	float punch_interval_multiplier =
 			rangelim(time_from_last_punch / tp->full_punch_interval, 0.0f, 1.0f);
@@ -320,6 +320,8 @@ HitParams getHitParams(const ItemGroupList &armor_groups,
 		result_wear = calculateResultWear(tp->punch_attack_uses, initial_wear);
 		result_wear *= punch_interval_multiplier;
 	}
+	// Keep damage in sane bounds for simplicity
+	damage = rangelim(damage, -U16_MAX, U16_MAX);
 
 	u32 wear_i = (u32) result_wear;
 	return {damage, wear_i};

--- a/src/tool.h
+++ b/src/tool.h
@@ -106,11 +106,11 @@ DigParams getDigParams(const ItemGroupList &groups,
 
 struct HitParams
 {
-	s16 hp;
+	s32 hp;
 	// Caused wear
 	u32 wear; // u32 because wear could be 65536 (single-use weapon)
 
-	HitParams(s16 hp_ = 0, u32 wear_ = 0):
+	HitParams(s32 hp_ = 0, u32 wear_ = 0):
 		hp(hp_),
 		wear(wear_)
 	{}


### PR DESCRIPTION
If a weapon deals so much damage that the damage would exceed S16 bounds, the damage might wraparound and become negative, healing the target.

There are several scenarios in which this can happen:

* Weapon has multiple damage groups (e.g. `fleshy=30000, fiery=30000`) and deals multiple hits to the target with matching armor groups, which in sum exceeds s16 bounds
* Target has a very high armor group rating (like `fleshy = 30000`), multiplying the damage to a high value, thus exceeding s16 bounds

This PR makes sure that the wraparound no longer occurs by switching to s32. While in theory that boundary can be exceeded as well, this scenario is too theoretical.
But the damage of a single punch (returned by `getHitParams`) will be capped at [-65535, 65535] for consistency with HP limits for consistency’s sake.

I also documented the possible range of damage of `minetest.get_hit_params`.

## To do

Ready for review.

## How to test

Recommended PR: #11870 (which makes testing MUCH easier).

In DevTest, grant yourself all privs.
Spawn an armorball entity and heal it to 65535 hp with the Super Healing Sword.
Press the debug key F5 and rightclick the armor ball until it has the `icy=100, fiery=100` armor groups.
Then attack it with the mese sword. There should be 1 hp left (65534 damage) because it deals two times 32767 damage (one for icy, one for fiery).

If you try these steps in stable Minetest, the damage dealt would be -2 because of wraparound.