### PR TITLE
Don't call on_dieplayer callbacks two times

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -826,8 +826,7 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 				<< std::endl;
 
 		PlayerHPChangeReason reason(PlayerHPChangeReason::FALL);
-		playersao->setHP((s32)playersao->getHP() - (s32)damage, reason, false);
-		SendPlayerHPOrDie(playersao, reason); // correct client side prediction
+		playersao->setHP((s32)playersao->getHP() - (s32)damage, reason, true);
 	}
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1372,7 +1372,8 @@ void Server::HandlePlayerHPChange(PlayerSAO *playersao, const PlayerHPChangeReas
 		HandlePlayerDeath(playersao, reason);
 }
 
-void Server::SendPlayerHP(PlayerSAO *playersao) {
+void Server::SendPlayerHP(PlayerSAO *playersao)
+{
 	SendHP(playersao->getPeerID(), playersao->getHP());
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -350,7 +350,8 @@ public:
 
 	void printToConsoleOnly(const std::string &text);
 
-	void SendPlayerHPOrDie(PlayerSAO *player, const PlayerHPChangeReason &reason);
+	void HandlePlayerHPChange(PlayerSAO *sao, const PlayerHPChangeReason &reason);
+	void SendPlayerHP(PlayerSAO *sao);
 	void SendPlayerBreath(PlayerSAO *sao);
 	void SendInventory(PlayerSAO *playerSAO, bool incremental);
 	void SendMovePlayer(session_t peer_id);
@@ -430,7 +431,6 @@ private:
 
 	virtual void SendChatMessage(session_t peer_id, const ChatMessage &message);
 	void SendTimeOfDay(session_t peer_id, u16 time, f32 time_speed);
-	void SendPlayerHP(session_t peer_id);
 
 	void SendLocalPlayerAnimations(session_t peer_id, v2s32 animation_frames[4],
 		f32 animation_speed);
@@ -502,7 +502,7 @@ private:
 		Something random
 	*/
 
-	void DiePlayer(session_t peer_id, const PlayerHPChangeReason &reason);
+	void HandlePlayerDeath(PlayerSAO* sao, const PlayerHPChangeReason &reason);
 	void RespawnPlayer(session_t peer_id);
 	void DeleteClient(session_t peer_id, ClientDeletionReason reason);
 	void UpdateCrafting(RemotePlayer *player);

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -463,14 +463,14 @@ void PlayerSAO::rightClick(ServerActiveObject *clicker)
 	m_env->getScriptIface()->on_rightclickplayer(this, clicker);
 }
 
-void PlayerSAO::setHP(s32 orig_hp, const PlayerHPChangeReason &reason, bool from_client)
+void PlayerSAO::setHP(s32 target_hp, const PlayerHPChangeReason &reason, bool from_client)
 {
-	orig_hp = rangelim(orig_hp, 0, U16_MAX);
+	target_hp = rangelim(target_hp, 0, U16_MAX);
 
-	if (orig_hp == m_hp)
+	if (target_hp == m_hp)
 		return; // Nothing to do
 
-	s32 hp_change = m_env->getScriptIface()->on_player_hpchange(this, orig_hp - (s32)m_hp, reason);
+	s32 hp_change = m_env->getScriptIface()->on_player_hpchange(this, target_hp - (s32)m_hp, reason);
 
 	s32 hp = (s32)m_hp + std::min(hp_change, U16_MAX); // Protection against s32 overflow
 	hp = rangelim(hp, 0, U16_MAX);

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -465,8 +465,7 @@ void PlayerSAO::rightClick(ServerActiveObject *clicker)
 
 void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason, bool from_client)
 {
-	if (hp < 0)
-		hp = 0; // Cannot take more damage
+	hp = rangelim(hp, 0, U16_MAX);
 
 	if (hp == m_hp)
 		return; // Nothing to do

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -470,7 +470,11 @@ void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason, bool from_clie
 	if (hp == m_hp)
 		return; // Nothing to do
 
-	hp = m_hp + m_env->getScriptIface()->on_player_hpchange(this, hp - m_hp, reason);
+	s32 hp_change = m_env->getScriptIface()->on_player_hpchange(this, hp - (s32)m_hp, reason);
+	hp_change = rangelim(hp_change, -U16_MAX, U16_MAX);
+
+	hp += hp_change;
+	hp = rangelim(hp, 0, U16_MAX);
 
 	if (hp > m_prop.hp_max)
 		hp = m_prop.hp_max;

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -463,17 +463,16 @@ void PlayerSAO::rightClick(ServerActiveObject *clicker)
 	m_env->getScriptIface()->on_rightclickplayer(this, clicker);
 }
 
-void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason, bool from_client)
+void PlayerSAO::setHP(s32 orig_hp, const PlayerHPChangeReason &reason, bool from_client)
 {
-	hp = rangelim(hp, 0, U16_MAX);
+	orig_hp = rangelim(orig_hp, 0, U16_MAX);
 
-	if (hp == m_hp)
+	if (orig_hp == m_hp)
 		return; // Nothing to do
 
-	s32 hp_change = m_env->getScriptIface()->on_player_hpchange(this, hp - (s32)m_hp, reason);
-	hp_change = rangelim(hp_change, -U16_MAX, U16_MAX);
+	s32 hp_change = m_env->getScriptIface()->on_player_hpchange(this, orig_hp - (s32)m_hp, reason);
 
-	hp += hp_change;
+	s32 hp = (s32)m_hp + std::min(hp_change, U16_MAX); // Protection against s32 overflow
 	hp = rangelim(hp, 0, U16_MAX);
 
 	if (hp > m_prop.hp_max)

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -114,9 +114,9 @@ public:
 	void rightClick(ServerActiveObject *clicker);
 	void setHP(s32 hp, const PlayerHPChangeReason &reason) override
 	{
-		return setHP(hp, reason, true);
+		return setHP(hp, reason, false);
 	}
-	void setHP(s32 hp, const PlayerHPChangeReason &reason, bool send);
+	void setHP(s32 hp, const PlayerHPChangeReason &reason, bool from_client);
 	void setHPRaw(u16 hp) { m_hp = hp; }
 	u16 getBreath() const { return m_breath; }
 	void setBreath(const u16 breath, bool send = true);


### PR DESCRIPTION
"When you fix one bug you make two" - savilli 2021 

After #11680 on_dieplayer callbacks may be called two times, which was fixed in #11411.
A player dies, on_dieplayer callbacks are called, but the player's client isn't aware of it yet and sends fail damage.
on_dieplayer callbacks are called second time here https://github.com/minetest/minetest/blob/0c4929f0252811d9715b96379973929053d32ef0/src/network/serverpackethandler.cpp#L830

We need better checks.

## To do
This PR is Ready for Review.

## How to test
It's hard to reproduce this naturally, just follow the code.
