### PR TITLE
Fix shadow mapping when PCF is disabled

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -185,6 +185,7 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	float baseLength = getBaseLength(smTexCoord);
 	float perspectiveFactor;
 
+	if (PCFBOUND == 0.0) return 0.0;
 	// Return fast if sharp shadows are requested
 	if (SOFTSHADOWRADIUS <= 1.0) {
 		perspectiveFactor = getDeltaPerspectiveFactor(baseLength);


### PR DESCRIPTION
When PCF filter quality is set to 0, shadows may not be rendered due to division by zero in 
the fragment shader. This PR avoids the division by zero and unnecessary calculations
when filtering is disabled.

## To do

This PR is Ready for Review.

## How to test

* Enable Shadow Mapping at the Very Low level OR
* Set Shadow Filter Quality to 0
* Start the game
* Shadows will be rendered unfiltered (shadows would not be rendered without the fix)
