### PR TITLE
Better document sky_color scope

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -117,7 +117,7 @@ Menu music
 -----------
 
 Games can provide custom main menu music. They are put inside a `menu`
-directory inside the game directory. 
+directory inside the game directory.
 
 The music files are named `theme.ogg`.
 If you want to specify multiple music files for one game, add additional
@@ -6792,29 +6792,29 @@ object you are working with still exists.
         * `textures`: A table containing up to six textures in the following
             order: Y+ (top), Y- (bottom), X- (west), X+ (east), Z+ (north), Z- (south).
         * `clouds`: Boolean for whether clouds appear. (default: `true`)
-        * `sky_color`: A table containing the following values, alpha is ignored:
-            * `day_sky`: ColorSpec, for the top half of the `"regular"`
-              sky during the day. (default: `#61b5f5`)
-            * `day_horizon`: ColorSpec, for the bottom half of the
-              `"regular"` sky during the day. (default: `#90d3f6`)
-            * `dawn_sky`: ColorSpec, for the top half of the `"regular"`
-              sky during dawn/sunset. (default: `#b4bafa`)
+        * `sky_color`: A table used in `"regular"` type only, containing the
+          following values (alpha is ignored):
+            * `day_sky`: ColorSpec, for the top half of the sky during the day.
+              (default: `#61b5f5`)
+            * `day_horizon`: ColorSpec, for the bottom half of the sky during the day.
+              (default: `#90d3f6`)
+            * `dawn_sky`: ColorSpec, for the top half of the sky during dawn/sunset.
+              (default: `#b4bafa`)
               The resulting sky color will be a darkened version of the ColorSpec.
               Warning: The darkening of the ColorSpec is subject to change.
-            * `dawn_horizon`: ColorSpec, for the bottom half of the `"regular"`
-              sky during dawn/sunset. (default: `#bac1f0`)
+            * `dawn_horizon`: ColorSpec, for the bottom half of the sky during dawn/sunset.
+              (default: `#bac1f0`)
               The resulting sky color will be a darkened version of the ColorSpec.
               Warning: The darkening of the ColorSpec is subject to change.
-            * `night_sky`: ColorSpec, for the top half of the `"regular"`
-              sky during the night. (default: `#006bff`)
+            * `night_sky`: ColorSpec, for the top half of the sky during the night.
+              (default: `#006bff`)
               The resulting sky color will be a dark version of the ColorSpec.
               Warning: The darkening of the ColorSpec is subject to change.
-            * `night_horizon`: ColorSpec, for the bottom half of the `"regular"`
-              sky during the night. (default: `#4090ff`)
+            * `night_horizon`: ColorSpec, for the bottom half of the sky during the night.
+              (default: `#4090ff`)
               The resulting sky color will be a dark version of the ColorSpec.
               Warning: The darkening of the ColorSpec is subject to change.
-            * `indoors`: ColorSpec, for when you're either indoors or
-              underground. Only applies to the `"regular"` sky.
+            * `indoors`: ColorSpec, for when you're either indoors or underground.
               (default: `#646464`)
             * `fog_sun_tint`: ColorSpec, changes the fog tinting for the sun
               at sunrise and sunset.
@@ -7915,7 +7915,7 @@ Used by `minetest.register_node`.
                     items = {"default:sand", "default:desert_sand"},
                 },
                 {
-                    -- Only drop if using an item in the "magicwand" group, or 
+                    -- Only drop if using an item in the "magicwand" group, or
                     -- an item that is in both the "pickaxe" and the "lucky"
                     -- groups.
                     tool_groups = {


### PR DESCRIPTION
PR makes `sky_color` scope clearer, moving the redundancy from each one of its parameters (actually the custom fog tint one wasn't mentioning it, even if it applies in there too) to the definition of `sky_color` itself.  
I say "redundancy" because it's already mentioned in `type`, but it definitely helps to repeat it inside the very parameter.

## To do

This PR is Ready for Review.