### PR TITLE
Added libjpeg-turbo to Fedora dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ For Debian/Ubuntu users:
 
 For Fedora users:
 
-    sudo dnf install make automake gcc gcc-c++ kernel-devel cmake libcurl-devel openal-soft-devel libvorbis-devel libXxf86vm-devel libogg-devel freetype-devel mesa-libGL-devel zlib-devel jsoncpp-devel gmp-devel sqlite-devel luajit-devel leveldb-devel ncurses-devel spatialindex-devel libzstd-devel
+    sudo dnf install make automake gcc gcc-c++ kernel-devel cmake libcurl-devel openal-soft-devel libvorbis-devel libXxf86vm-devel libogg-devel freetype-devel mesa-libGL-devel zlib-devel jsoncpp-devel gmp-devel sqlite-devel luajit-devel leveldb-devel ncurses-devel spatialindex-devel libzstd-devel libjpeg-turbo-devel
 
 For Arch users:
 


### PR DESCRIPTION
On Fedora, libjpeg has been replaced by libjpeg-turbo. It looks like libjpeg is an Irrlicht dependency, but is it fair to put it here?