### PR TITLE
Rotate custom moon texture the right way

### DIFF
--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -675,13 +675,13 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SC
 		}
 	} else {
 		driver->setMaterial(m_materials[4]);
-		float d = (moonsize * 1.9) * m_moon_params.scale;
+		float d = (moonsize * 1.3) * m_moon_params.scale;
 		video::SColor c;
 		if (m_moon_tonemap)
 			c = video::SColor(0, 0, 0, 0);
 		else
 			c = video::SColor(255, 255, 255, 255);
-		draw_sky_body(vertices, -d, d, c);
+		draw_sky_body(vertices, d, -d, c);
 		place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleList(&vertices[0], 4, indices, 2);
 	}

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -675,7 +675,7 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SC
 		}
 	} else {
 		driver->setMaterial(m_materials[4]);
-		float d = (moonsize * 1.3) * m_moon_params.scale;
+		float d = (moonsize * 1.9) * m_moon_params.scale;
 		video::SColor c;
 		if (m_moon_tonemap)
 			c = video::SColor(0, 0, 0, 0);


### PR DESCRIPTION
Fixes #11901 
~~I've also scaled it down a bit, because when changed into a custom texture, the texture was almost twice as the original moon (halo of the original one included)~~ Never mind, scaling is correct, the PR only modifies the rotation

Before
![imagen](https://user-images.githubusercontent.com/63455151/147672408-d084b679-a9b5-4a72-a157-11e6895a1b99.png)

After
![imagen](https://user-images.githubusercontent.com/63455151/147672240-43a156e6-e689-4d61-b2d0-d207f1c3e8da.png)


## To do

This PR is Ready for Review.

## How to test
Put a custom texture on your moon
<!-- Example code or instructions -->
