### PR TITLE
Use a Lua error handler that calls tostring

### DIFF
--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -6,6 +6,9 @@
 --
 
 -- Initialize some very basic things
+function core.error_handler(err)
+	return debug.traceback(tostring(err), 2)
+end
 do
 	local function concat_args(...)
 		local n, t = select("#", ...), {...}

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -6,8 +6,8 @@
 --
 
 -- Initialize some very basic things
-function core.error_handler(err)
-	return debug.traceback(tostring(err), 2)
+function core.error_handler(err, level)
+	return debug.traceback(tostring(err), level)
 end
 do
 	local function concat_args(...)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -9948,11 +9948,12 @@ Error Handling
 --------------
 
 When an error occurs that is not caught, Minetest calls the function
-`minetest.error_handler` with the error object as its argument. The return value
-is the error string that should be printed. By default this is a backtrace from
+`minetest.error_handler` with the error object as its first argument. The second
+argument is the stack level where the error occurred. The return value is the
+error string that should be shown. By default this is a backtrace from
 `debug.traceback`. If the error object is not a string, it is first converted
-with `tostring` before being displayed. This means that you can use tables
-as error objects so long as you give them `__tostring` metamethods.
+with `tostring` before being displayed. This means that you can use tables as
+error objects so long as you give them `__tostring` metamethods.
 
-You can override `minetest.error_handler`, but you _must_ end your function
-with a tail call to the previous error handler.
+You can override `minetest.error_handler`. You should call the previous handler
+with the correct stack level in your implementation.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -9943,3 +9943,10 @@ Bit Library
 Functions: bit.tobit, bit.tohex, bit.bnot, bit.band, bit.bor, bit.bxor, bit.lshift, bit.rshift, bit.arshift, bit.rol, bit.ror, bit.bswap
 
 See http://bitop.luajit.org/ for advanced information.
+
+Error Object Conversion
+-----------------------
+
+If an error object is not caught by a mod, it is converted to a string with
+`tostring` before being displayed. This means that you can use tables as error
+objects so long as you give them `__tostring` metamethods.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -9944,9 +9944,15 @@ Functions: bit.tobit, bit.tohex, bit.bnot, bit.band, bit.bor, bit.bxor, bit.lshi
 
 See http://bitop.luajit.org/ for advanced information.
 
-Error Object Conversion
------------------------
+Error Handling
+--------------
 
-If an error object is not caught by a mod, it is converted to a string with
-`tostring` before being displayed. This means that you can use tables as error
-objects so long as you give them `__tostring` metamethods.
+When an error occurs that is not caught, Minetest calls the function
+`minetest.error_handler` with the error object as its argument. The return value
+is the error string that should be printed. By default this is a backtrace from
+`debug.traceback`. If the error object is not a string, it is first converted
+with `tostring` before being displayed. This means that you can use tables
+as error objects so long as you give them `__tostring` metamethods.
+
+You can override `minetest.error_handler`, but you _must_ end your function
+with a tail call to the previous error handler.

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -53,17 +53,16 @@ int script_error_handler(lua_State *L)
 	lua_getfield(L, -1, "error_handler");
 	if (!lua_isnil(L, -1)) {
 		lua_pushvalue(L, 1);
-		lua_call(L, 1, 1);
 	} else {
-		// No Lua error handler available. Call debug.traceback(tostring(#1), 2)
+		// No Lua error handler available. Call debug.traceback(tostring(#1), level).
 		lua_getglobal(L, "debug");
 		lua_getfield(L, -1, "traceback");
 		lua_getglobal(L, "tostring");
 		lua_pushvalue(L, 1);
 		lua_call(L, 1, 1);
-		lua_pushinteger(L, 2);
-		lua_call(L, 2, 1);
 	}
+	lua_pushinteger(L, 2); // Stack level
+	lua_call(L, 2, 1);
 	return 1;
 }
 

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -27,10 +27,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 std::string script_get_backtrace(lua_State *L)
 {
-	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_BACKTRACE);
+	lua_getglobal(L, "debug");
+	lua_getfield(L, -1, "traceback");
 	lua_call(L, 0, 1);
 	std::string result = luaL_checkstring(L, -1);
-	lua_pop(L, 1);
+	lua_pop(L, 2);
 	return result;
 }
 

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -47,6 +47,19 @@ int script_exception_wrapper(lua_State *L, lua_CFunction f)
 	return lua_error(L);  // Rethrow as a Lua error.
 }
 
+int script_error_handler(lua_State *L)
+{
+	// Executes debug.traceback(tostring(#1), 2)
+	lua_getglobal(L, "debug");
+	lua_getfield(L, -1, "traceback");
+	lua_getglobal(L, "tostring");
+	lua_pushvalue(L, 1);
+	lua_call(L, 1, 1);
+	lua_pushinteger(L, 2);
+	lua_call(L, 2, 1);
+	return 1;
+}
+
 /*
  * Note that we can't get tracebacks for LUA_ERRMEM or LUA_ERRERR (without
  * hacking Lua internals).  For LUA_ERRMEM, this is because memory errors will

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -49,14 +49,21 @@ int script_exception_wrapper(lua_State *L, lua_CFunction f)
 
 int script_error_handler(lua_State *L)
 {
-	// Executes debug.traceback(tostring(#1), 2)
-	lua_getglobal(L, "debug");
-	lua_getfield(L, -1, "traceback");
-	lua_getglobal(L, "tostring");
-	lua_pushvalue(L, 1);
-	lua_call(L, 1, 1);
-	lua_pushinteger(L, 2);
-	lua_call(L, 2, 1);
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "error_handler");
+	if (!lua_isnil(L, -1)) {
+		lua_pushvalue(L, 1);
+		lua_call(L, 1, 1);
+	} else {
+		// No Lua error handler available. Call debug.traceback(tostring(#1), 2)
+		lua_getglobal(L, "debug");
+		lua_getfield(L, -1, "traceback");
+		lua_getglobal(L, "tostring");
+		lua_pushvalue(L, 1);
+		lua_call(L, 1, 1);
+		lua_pushinteger(L, 2);
+		lua_call(L, 2, 1);
+	}
 	return 1;
 }
 

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -77,8 +77,7 @@ enum {
 #endif
 
 // Pushes the error handler onto the stack and returns its index
-#define PUSH_ERROR_HANDLER(L) \
-	(lua_rawgeti((L), LUA_REGISTRYINDEX, CUSTOM_RIDX_BACKTRACE), lua_gettop((L)))
+#define PUSH_ERROR_HANDLER(L) (lua_pushcfunction((L), script_error_handler), lua_gettop((L)))
 
 #define PCALL_RESL(L, RES) {                            \
 	int result_ = (RES);                                \
@@ -121,6 +120,8 @@ enum RunCallbacksMode
 std::string script_get_backtrace(lua_State *L);
 // Wrapper for CFunction calls that converts C++ exceptions to Lua errors
 int script_exception_wrapper(lua_State *L, lua_CFunction f);
+// Acts as the error handler for lua_pcall
+int script_error_handler(lua_State *L);
 // Takes an error from lua_pcall and throws it as a LuaError
 void script_error(lua_State *L, int pcall_result, const char *mod, const char *fxn);
 

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -54,7 +54,7 @@ enum {
 	CUSTOM_RIDX_SCRIPTAPI,
 	CUSTOM_RIDX_GLOBALS_BACKUP,
 	CUSTOM_RIDX_CURRENT_MOD_NAME,
-	CUSTOM_RIDX_BACKTRACE,
+	CUSTOM_RIDX_ERROR_HANDLER,
 	CUSTOM_RIDX_HTTP_API_LUA,
 	CUSTOM_RIDX_METATABLE_MAP,
 
@@ -77,7 +77,8 @@ enum {
 #endif
 
 // Pushes the error handler onto the stack and returns its index
-#define PUSH_ERROR_HANDLER(L) (lua_pushcfunction((L), script_error_handler), lua_gettop((L)))
+#define PUSH_ERROR_HANDLER(L) \
+	(lua_rawgeti((L), LUA_REGISTRYINDEX, CUSTOM_RIDX_ERROR_HANDLER), lua_gettop((L)))
 
 #define PCALL_RESL(L, RES) {                            \
 	int result_ = (RES);                                \

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -103,9 +103,6 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 #endif
 	lua_rawseti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
 
-	lua_pushcfunction(m_luastack, luaHandleError);
-	lua_rawseti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_BACKTRACE);
-
 	// Add a C++ wrapper function to catch exceptions thrown in Lua -> C++ calls
 #if USE_LUAJIT
 	lua_pushlightuserdata(m_luastack, (void*) script_exception_wrapper);
@@ -160,19 +157,6 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 ScriptApiBase::~ScriptApiBase()
 {
 	lua_close(m_luastack);
-}
-
-int ScriptApiBase::luaHandleError(lua_State *L)
-{
-	// Executes debug.traceback(tostring(#1), 2)
-	lua_getglobal(L, "debug");
-	lua_getfield(L, -1, "traceback");
-	lua_getglobal(L, "tostring");
-	lua_pushvalue(L, 1);
-	lua_call(L, 1, 1);
-	lua_pushinteger(L, 2);
-	lua_call(L, 2, 1);
-	return 1;
 }
 
 int ScriptApiBase::luaPanic(lua_State *L)

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -103,11 +103,8 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 #endif
 	lua_rawseti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
 
-	// Add and save an error handler
-	lua_getglobal(m_luastack, "debug");
-	lua_getfield(m_luastack, -1, "traceback");
+	lua_pushcfunction(m_luastack, luaHandleError);
 	lua_rawseti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_BACKTRACE);
-	lua_pop(m_luastack, 1); // pop debug
 
 	// Add a C++ wrapper function to catch exceptions thrown in Lua -> C++ calls
 #if USE_LUAJIT
@@ -163,6 +160,19 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 ScriptApiBase::~ScriptApiBase()
 {
 	lua_close(m_luastack);
+}
+
+int ScriptApiBase::luaHandleError(lua_State *L)
+{
+	// Executes debug.traceback(tostring(#1), 2)
+	lua_getglobal(L, "debug");
+	lua_getfield(L, -1, "traceback");
+	lua_getglobal(L, "tostring");
+	lua_pushvalue(L, 1);
+	lua_call(L, 1, 1);
+	lua_pushinteger(L, 2);
+	lua_call(L, 2, 1);
+	return 1;
 }
 
 int ScriptApiBase::luaPanic(lua_State *L)

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -103,6 +103,9 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 #endif
 	lua_rawseti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
 
+	lua_pushcfunction(m_luastack, script_error_handler);
+	lua_rawseti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_ERROR_HANDLER);
+
 	// Add a C++ wrapper function to catch exceptions thrown in Lua -> C++ calls
 #if USE_LUAJIT
 	lua_pushlightuserdata(m_luastack, (void*) script_exception_wrapper);

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -170,8 +170,6 @@ protected:
 #endif
 
 private:
-	static int luaHandleError(lua_State *L);
-
 	static int luaPanic(lua_State *L);
 
 	lua_State      *m_luastack = nullptr;

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -170,6 +170,8 @@ protected:
 #endif
 
 private:
+	static int luaHandleError(lua_State *L);
+
 	static int luaPanic(lua_State *L);
 
 	lua_State      *m_luastack = nullptr;


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - The body of the error handler is now in `core.error_handler` and can be overridden by mods.
  - Since `tostring` handles the `__tostring` metamethod, calling `tostring` in the error handler allows for tables that implement the metamethod to be thrown without problems.
- How does the PR work?
  - The error handler in C++ queries and calls `core.error_handler`, which is implemented in Lua.
  - The error handler calls `debug.traceback` after calling `tostring` on the argument.
- Does it resolve any reported issue?
  - It resolves https://github.com/minetest/minetest/issues/11634. Now that `debug.traceback` is queried every time the handler is called, you can also override `debug.traceback` to apply source maps and stuff to the output.
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
  - It relates to feedback from a modder.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  - Custom error handlers are now possible.
  - Previously, tables could not be thrown as errors if you wanted to provide a useful error message. Now table errors can automatically be converted into message strings using the `__tostring` metamethod.

## To do

This PR is Ready for Review.

## How to test

1. Add this code to a mod's `init.lua`:
   ```lua
   error("foo")
   ```
2. You should get the correct error message and backtrace when trying to load a world with the mod.
3. Remove the code.
4. Add this code to a mod's `init.lua`:
   ```lua
   error(setmetatable({}, {__tostring = function() return "foo" end}))
   ```
5. You should get the correct error message and backtrace. It will not be quite the same as before; `error` adds extra information to thrown strings, but not tables. However, this information seems to be present in the backtrace anyway.
6. Override the error handler with some trivial addition and try the process again. Make sure you pass the correct stack level to the previous handler.