### PR TITLE
Recalculate normals before adding mesh to the scene.

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -764,10 +764,9 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 		grabMatrixNode();
 		scene::IAnimatedMesh *mesh = m_client->getMesh(m_prop.mesh, true);
 		if (mesh) {
-			m_animated_meshnode = m_smgr->addAnimatedMeshSceneNode(mesh, m_matrixnode);
-			m_animated_meshnode->grab();
-			mesh->drop(); // The scene node took hold of it
-
+			// It is important to recalculate normals before adding the mesh to the scene,
+			// because the latter starts animation process and changes vertex positions,
+			// which are treated as a source of truth when recalculating normals
 			if (!checkMeshNormals(mesh)) {
 				infostream << "GenericCAO: recalculating normals for mesh "
 					<< m_prop.mesh << std::endl;
@@ -775,6 +774,9 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 						recalculateNormals(mesh, true, false);
 			}
 
+			m_animated_meshnode = m_smgr->addAnimatedMeshSceneNode(mesh, m_matrixnode);
+			m_animated_meshnode->grab();
+			mesh->drop(); // The scene node took hold of it
 			m_animated_meshnode->animateJoints(); // Needed for some animations
 			m_animated_meshnode->setScale(m_prop.visual_size);
 

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -764,9 +764,6 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 		grabMatrixNode();
 		scene::IAnimatedMesh *mesh = m_client->getMesh(m_prop.mesh, true);
 		if (mesh) {
-			// It is important to recalculate normals before adding the mesh to the scene,
-			// because the latter starts animation process and changes vertex positions,
-			// which are treated as a source of truth when recalculating normals
 			if (!checkMeshNormals(mesh)) {
 				infostream << "GenericCAO: recalculating normals for mesh "
 					<< m_prop.mesh << std::endl;


### PR DESCRIPTION
Fixes calculation of normals for models where the first animation frame is not the same as static position.

Fixes #11908.

## To do

This PR is Ready for Review.

## How to test

* Install NSSM mod from ContentDB
* Create a new world and enable nssm and mobs mods
* Start the world and spawn an Icelamander
* You should see an animal-like monster, not a set of flying blocks.