### PR TITLE
Fix vector.from_string returning a table without vector metatable

### DIFF
--- a/builtin/common/tests/vector_spec.lua
+++ b/builtin/common/tests/vector_spec.lua
@@ -300,6 +300,7 @@ describe("vector", function()
 
 	it("from_string()", function()
 		local v = vector.new(1, 2, 3.14)
+		assert.is_true(vector.check(vector.from_string("(1, 2, 3.14)")))
 		assert.same({v, 13}, {vector.from_string("(1, 2, 3.14)")})
 		assert.same({v, 12}, {vector.from_string("(1,2 ,3.14)")})
 		assert.same({v, 12}, {vector.from_string("(1,2,3.14,)")})

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -61,7 +61,7 @@ function vector.from_string(s, init)
 	if not (x and y and z) then
 		return nil
 	end
-	return {x = x, y = y, z = z}, np
+	return fast_new(x, y, z), np
 end
 
 function vector.to_string(v)


### PR DESCRIPTION
- This is a bugfix.
- In a rebase of #11039 I probably forgot to swap the table constructor with a call to the vector constructor.
- Thanks to https://github.com/minetest/minetest_docs/pull/11 for finding this out.

## To do

This PR is a Ready for Review.
Please merge before release.

## How to test

Run unittests:
`$ busted builtin/`
