### PR TITLE
For trying: Spread sunlight further down into water.

### DIFF
--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -545,6 +545,13 @@ void Mapgen::spreadLight(const v3s16 &nmin, const v3s16 &nmax)
 					// spread to all 6 neighbor nodes
 					for (const auto &dir : g_6dirs)
 						lightSpread(a, queue, p + dir, light);
+
+					// allow sunlight to spread down a bit further
+					if (cf.drawtype == NDT_LIQUID && light & 0x0F) {
+						for (int k=2; k<6; k++) {
+							lightSpread(a, queue, p + v3s16(0,-k,0), light & 0x0F);
+						}
+					}
 				}
 			}
 		}
@@ -552,9 +559,19 @@ void Mapgen::spreadLight(const v3s16 &nmin, const v3s16 &nmax)
 
 	while (!queue.empty()) {
 		const auto &i = queue.front();
+		u32 vi = vm->m_area.index(i.first);
+		const ContentFeatures &cf = ndef->get(vm->m_data[vi]);
+
 		// spread to all 6 neighbor nodes
 		for (const auto &dir : g_6dirs)
 			lightSpread(a, queue, i.first + dir, i.second);
+
+		// allow sunlight to spread down a bit further
+		if (cf.drawtype == NDT_LIQUID && i.second & 0x0F) {
+			for (int k=2; k<6; k++) {
+				lightSpread(a, queue, i.first + v3s16(0,-k,0), i.second & 0x0F);
+			}
+		}
 		queue.pop();
 	}
 


### PR DESCRIPTION
- Goal of the PR
Make underwater scenes brighther

- How does the PR work?
Sunlight is propagated further down (and down only) through water.

- Does it resolve any reported issue?
#11895

- Does this relate to a goal in [the roadmap](../doc/direction.md)?
Nope

- If not a bug fix, why is this PR needed? What usecases does it solve?
Allows using underwater areas much better (they are not black 8 blocks down)

## How to test
Start a new world (this affects MapGen) and dive into the water, see how it is brighter and you can actually see something.

## Note
This is for testing to see if/how people like it.
Are there better way to brighten up blocks "deep" underwater?