### PR TITLE
Restore pass-through of direction keys

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -928,7 +928,7 @@ void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *
 	v3f sf           = myplayer->getSpeed() * 100;
 	s32 pitch        = myplayer->getPitch() * 100;
 	s32 yaw          = myplayer->getYaw() * 100;
-	u32 keyPressed   = myplayer->keyPressed;
+	u32 keyPressed   = myplayer->control.getKeysPressed();
 	// scaled by 80, so that pi can fit into a u8
 	u8 fov           = clientMap->getCameraFov() * 80;
 	u8 wanted_range  = MYMIN(255,
@@ -1284,22 +1284,24 @@ void Client::sendPlayerPos()
 	if (!player)
 		return;
 
-	ClientMap &map = m_env.getClientMap();
-	u8 camera_fov   = map.getCameraFov();
-	u8 wanted_range = map.getControl().wanted_range;
-
 	// Save bandwidth by only updating position when
 	// player is not dead and something changed
 
 	if (m_activeobjects_received && player->isDead())
 		return;
 
+	ClientMap &map = m_env.getClientMap();
+	u8 camera_fov   = map.getCameraFov();
+	u8 wanted_range = map.getControl().wanted_range;
+
+	u32 keyPressed = player->control.getKeysPressed();
+
 	if (
 			player->last_position     == player->getPosition() &&
 			player->last_speed        == player->getSpeed()    &&
 			player->last_pitch        == player->getPitch()    &&
 			player->last_yaw          == player->getYaw()      &&
-			player->last_keyPressed   == player->keyPressed    &&
+			player->last_keyPressed   == keyPressed            &&
 			player->last_camera_fov   == camera_fov            &&
 			player->last_wanted_range == wanted_range)
 		return;
@@ -1308,7 +1310,7 @@ void Client::sendPlayerPos()
 	player->last_speed        = player->getSpeed();
 	player->last_pitch        = player->getPitch();
 	player->last_yaw          = player->getYaw();
-	player->last_keyPressed   = player->keyPressed;
+	player->last_keyPressed   = keyPressed;
 	player->last_camera_fov   = camera_fov;
 	player->last_wanted_range = wanted_range;
 

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -70,9 +70,9 @@ static void dump_start_data(const GameStartData &data)
 
 ClientLauncher::~ClientLauncher()
 {
-	delete receiver;
-
 	delete input;
+
+	delete receiver;
 
 	delete g_fontengine;
 	delete g_gamecallback;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2516,7 +2516,6 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 #endif
 
 	client->setPlayerControl(control);
-	player->keyPressed = control.getKeysPressed();
 
 	//tt.stop();
 }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2481,6 +2481,10 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 	//TimeTaker tt("update player control", NULL, PRECISION_NANO);
 
 	PlayerControl control(
+		isKeyDown(KeyType::FORWARD),
+		isKeyDown(KeyType::BACKWARD),
+		isKeyDown(KeyType::LEFT),
+		isKeyDown(KeyType::RIGHT),
 		isKeyDown(KeyType::JUMP) || player->getAutojump(),
 		isKeyDown(KeyType::AUX1),
 		isKeyDown(KeyType::SNEAK),
@@ -2511,39 +2515,8 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 	}
 #endif
 
-	u32 keypress_bits = (
-			( (u32)(control.jump  & 0x1) << 4) |
-			( (u32)(control.aux1  & 0x1) << 5) |
-			( (u32)(control.sneak & 0x1) << 6) |
-			( (u32)(control.dig   & 0x1) << 7) |
-			( (u32)(control.place & 0x1) << 8) |
-			( (u32)(control.zoom  & 0x1) << 9)
-		);
-
-	// Set direction keys to ensure mod compatibility
-	if (control.movement_speed > 0.001f) {
-		float absolute_direction;
-
-		// Check in original orientation (absolute value indicates forward / backward)
-		absolute_direction = abs(control.movement_direction);
-		if (absolute_direction < (3.0f / 8.0f * M_PI))
-			keypress_bits |= (u32)(0x1 << 0); // Forward
-		if (absolute_direction > (5.0f / 8.0f * M_PI))
-			keypress_bits |= (u32)(0x1 << 1); // Backward
-
-		// Rotate entire coordinate system by 90 degrees (absolute value indicates left / right)
-		absolute_direction = control.movement_direction + M_PI_2;
-		if (absolute_direction >= M_PI)
-			absolute_direction -= 2 * M_PI;
-		absolute_direction = abs(absolute_direction);
-		if (absolute_direction < (3.0f / 8.0f * M_PI))
-			keypress_bits |= (u32)(0x1 << 2); // Left
-		if (absolute_direction > (5.0f / 8.0f * M_PI))
-			keypress_bits |= (u32)(0x1 << 3); // Right
-	}
-
 	client->setPlayerControl(control);
-	player->keyPressed = keypress_bits;
+	player->keyPressed = control.getKeysPressed();
 
 	//tt.stop();
 }

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -152,8 +152,14 @@ public:
 	// in the subsequent iteration of Game::processPlayerInteraction
 	bool WasKeyReleased(const KeyPress &keycode) const { return keyWasReleased[keycode]; }
 
-	void listenForKey(const KeyPress &keyCode) { keysListenedFor.set(keyCode); }
-	void dontListenForKeys() { keysListenedFor.clear(); }
+	void listenForKey(const KeyPress &keyCode)
+	{
+		keysListenedFor.set(keyCode);
+	}
+	void dontListenForKeys()
+	{
+		keysListenedFor.clear();
+	}
 
 	s32 getMouseWheel()
 	{
@@ -189,8 +195,6 @@ public:
 #endif
 	}
 
-	s32 mouse_wheel = 0;
-
 	JoystickController *joystick = nullptr;
 
 #ifdef HAVE_TOUCHSCREENGUI
@@ -198,6 +202,8 @@ public:
 #endif
 
 private:
+	s32 mouse_wheel = 0;
+
 	// The current state of keys
 	KeyList keyIsDown;
 
@@ -272,6 +278,12 @@ public:
 	{
 		m_receiver->joystick = &joystick;
 	}
+
+	virtual ~RealInputHandler()
+	{
+		m_receiver->joystick = nullptr;
+	}
+
 	virtual bool isKeyDown(GameKeyType k)
 	{
 		return m_receiver->IsKeyDown(keycache.key[k]) || joystick.isKeyDown(k);
@@ -288,6 +300,7 @@ public:
 	{
 		return m_receiver->WasKeyReleased(keycache.key[k]) || joystick.wasKeyReleased(k);
 	}
+
 	virtual float getMovementSpeed()
 	{
 		bool f = m_receiver->IsKeyDown(keycache.key[KeyType::FORWARD]),
@@ -307,6 +320,7 @@ public:
 		}
 		return joystick.getMovementSpeed();
 	}
+
 	virtual float getMovementDirection()
 	{
 		float x = 0, z = 0;
@@ -326,10 +340,12 @@ public:
 		else
 			return joystick.getMovementDirection();
 	}
+
 	virtual bool cancelPressed()
 	{
 		return wasKeyDown(KeyType::ESC) || m_receiver->WasKeyDown(CancelKey);
 	}
+
 	virtual void clearWasKeyPressed()
 	{
 		m_receiver->clearWasKeyPressed();
@@ -338,17 +354,21 @@ public:
 	{
 		m_receiver->clearWasKeyReleased();
 	}
+
 	virtual void listenForKey(const KeyPress &keyCode)
 	{
 		m_receiver->listenForKey(keyCode);
 	}
-	virtual void dontListenForKeys() { m_receiver->dontListenForKeys(); }
+	virtual void dontListenForKeys()
+	{
+		m_receiver->dontListenForKeys();
+	}
+
 	virtual v2s32 getMousePos()
 	{
-		if (RenderingEngine::get_raw_device()->getCursorControl()) {
-			return RenderingEngine::get_raw_device()
-					->getCursorControl()
-					->getPosition();
+		auto control = RenderingEngine::get_raw_device()->getCursorControl();
+		if (control) {
+			return control->getPosition();
 		}
 
 		return m_mousepos;
@@ -356,16 +376,18 @@ public:
 
 	virtual void setMousePos(s32 x, s32 y)
 	{
-		if (RenderingEngine::get_raw_device()->getCursorControl()) {
-			RenderingEngine::get_raw_device()
-					->getCursorControl()
-					->setPosition(x, y);
+		auto control = RenderingEngine::get_raw_device()->getCursorControl();
+		if (control) {
+			control->setPosition(x, y);
 		} else {
 			m_mousepos = v2s32(x, y);
 		}
 	}
 
-	virtual s32 getMouseWheel() { return m_receiver->getMouseWheel(); }
+	virtual s32 getMouseWheel()
+	{
+		return m_receiver->getMouseWheel();
+	}
 
 	void clear()
 	{

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1096,10 +1096,8 @@ void LocalPlayer::handleAutojump(f32 dtime, Environment *env,
 	if (m_autojump)
 		return;
 
-	bool control_forward = keyPressed & (1 << 0);
-
 	bool could_autojump =
-		m_can_jump && !control.jump && !control.sneak && control_forward;
+		m_can_jump && !control.jump && !control.sneak && control.isMoving();
 
 	if (!could_autojump)
 		return;

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -86,7 +86,7 @@ public:
 	v3f last_speed;
 	float last_pitch = 0.0f;
 	float last_yaw = 0.0f;
-	unsigned int last_keyPressed = 0;
+	u32 last_keyPressed = 0;
 	u8 last_camera_fov = 0;
 	u8 last_wanted_range = 0;
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -482,7 +482,6 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	f32 yaw = (f32)f32yaw / 100.0f;
 	u32 keyPressed = 0;
 
-	// default behavior (in case an old client doesn't send these)
 	f32 fov = 0;
 	u8 wanted_range = 0;
 
@@ -509,12 +508,7 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	playersao->setWantedRange(wanted_range);
 
 	player->keyPressed = keyPressed;
-	player->control.jump  = (keyPressed & (0x1 << 4));
-	player->control.aux1  = (keyPressed & (0x1 << 5));
-	player->control.sneak = (keyPressed & (0x1 << 6));
-	player->control.dig   = (keyPressed & (0x1 << 7));
-	player->control.place = (keyPressed & (0x1 << 8));
-	player->control.zoom  = (keyPressed & (0x1 << 9));
+	player->control.unpackKeysPressed(keyPressed);
 
 	if (playersao->checkMovementCheat()) {
 		// Call callbacks

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -507,7 +507,6 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	playersao->setFov(fov);
 	playersao->setWantedRange(wanted_range);
 
-	player->keyPressed = keyPressed;
 	player->control.unpackKeysPressed(keyPressed);
 
 	if (playersao->checkMovementCheat()) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "player.h"
 
+#include <cmath>
 #include "threading/mutex_auto_lock.h"
 #include "util/numeric.h"
 #include "hud.h"
@@ -157,6 +158,59 @@ void Player::clearHud()
 		delete hud.back();
 		hud.pop_back();
 	}
+}
+
+u32 PlayerControl::getKeysPressed() const
+{
+	u32 keypress_bits =
+		( (u32)(jump  & 1) << 4) |
+		( (u32)(aux1  & 1) << 5) |
+		( (u32)(sneak & 1) << 6) |
+		( (u32)(dig   & 1) << 7) |
+		( (u32)(place & 1) << 8) |
+		( (u32)(zoom  & 1) << 9)
+	;
+
+	// If any direction keys are pressed pass those through
+	if (direction_keys != 0)
+	{
+		keypress_bits |= direction_keys;
+	}
+	// Otherwise set direction keys based on joystick movement (for mod compatibility)
+	else if (movement_speed > 0.001f)
+	{
+		float abs_d = abs(movement_direction);
+
+		// (absolute value indicates forward / backward)
+		if (abs_d < 3.0f / 8.0f * M_PI)
+			keypress_bits |= (u32)1; // Forward
+		if (abs_d > 5.0f / 8.0f * M_PI)
+			keypress_bits |= (u32)1 << 1; // Backward
+
+		// rotate entire coordinate system by 90 degree
+		abs_d = abs_d + M_PI_2;
+		if (abs_d >= M_PI)
+			abs_d = abs(abs_d - 2 * M_PI);
+		// (value now indicates left / right)
+		if (abs_d < 3.0f / 8.0f * M_PI)
+			keypress_bits |= (u32)1 << 2; // Left
+		if (abs_d > 5.0f / 8.0f * M_PI)
+			keypress_bits |= (u32)1 << 3; // Right
+	}
+
+	return keypress_bits;
+}
+
+void PlayerControl::unpackKeysPressed(u32 keypress_bits)
+{
+	// It would be possible to unpack the direction keys from the bits
+	// but this is handeled differently.
+	jump  = keypress_bits & (1 << 4);
+	aux1  = keypress_bits & (1 << 5);
+	sneak = keypress_bits & (1 << 6);
+	dig   = keypress_bits & (1 << 7);
+	place = keypress_bits & (1 << 8);
+	zoom  = keypress_bits & (1 << 9);
 }
 
 void PlayerSettings::readGlobalSettings()

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -179,18 +179,20 @@ u32 PlayerControl::getKeysPressed() const
 	// Otherwise set direction keys based on joystick movement (for mod compatibility)
 	else if (movement_speed > 0.001f)
 	{
-		float abs_d = abs(movement_direction);
+		float abs_d;
 
 		// (absolute value indicates forward / backward)
+		abs_d = abs(movement_direction);
 		if (abs_d < 3.0f / 8.0f * M_PI)
 			keypress_bits |= (u32)1; // Forward
 		if (abs_d > 5.0f / 8.0f * M_PI)
 			keypress_bits |= (u32)1 << 1; // Backward
 
 		// rotate entire coordinate system by 90 degree
-		abs_d = abs_d + M_PI_2;
+		abs_d = movement_direction + M_PI_2;
 		if (abs_d >= M_PI)
-			abs_d = abs(abs_d - 2 * M_PI);
+			abs_d -= 2 * M_PI;
+		abs_d = abs(abs_d);
 		// (value now indicates left / right)
 		if (abs_d < 3.0f / 8.0f * M_PI)
 			keypress_bits |= (u32)1 << 2; // Left

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -160,6 +160,8 @@ void Player::clearHud()
 	}
 }
 
+#ifndef SERVER
+
 u32 PlayerControl::getKeysPressed() const
 {
 	u32 keypress_bits =
@@ -177,7 +179,7 @@ u32 PlayerControl::getKeysPressed() const
 		keypress_bits |= direction_keys;
 	}
 	// Otherwise set direction keys based on joystick movement (for mod compatibility)
-	else if (movement_speed > 0.001f)
+	else if (isMoving())
 	{
 		float abs_d;
 
@@ -203,10 +205,11 @@ u32 PlayerControl::getKeysPressed() const
 	return keypress_bits;
 }
 
+#endif
+
 void PlayerControl::unpackKeysPressed(u32 keypress_bits)
 {
-	// It would be possible to unpack the direction keys from the bits
-	// but this is handeled differently.
+	direction_keys = keypress_bits & 0xf;
 	jump  = keypress_bits & (1 << 4);
 	aux1  = keypress_bits & (1 << 5);
 	sneak = keypress_bits & (1 << 6);

--- a/src/player.h
+++ b/src/player.h
@@ -49,18 +49,18 @@ struct PlayerControl
 	PlayerControl() = default;
 
 	PlayerControl(
-		bool a_jump,
-		bool a_aux1,
-		bool a_sneak,
+		bool a_up, bool a_down, bool a_left, bool a_right,
+		bool a_jump, bool a_aux1, bool a_sneak,
 		bool a_zoom,
-		bool a_dig,
-		bool a_place,
-		float a_pitch,
-		float a_yaw,
-		float a_movement_speed,
-		float a_movement_direction
+		bool a_dig, bool a_place,
+		float a_pitch, float a_yaw,
+		float a_movement_speed, float a_movement_direction
 	)
 	{
+		// Encode direction keys into a single value so nobody uses it accidentally
+		// as movement_{speed,direction} is supposed to be the source of truth.
+		direction_keys = (a_up&1) | ((a_down&1) << 1) |
+			((a_left&1) << 2) | ((a_right&1) << 3);
 		jump = a_jump;
 		aux1 = a_aux1;
 		sneak = a_sneak;
@@ -72,6 +72,13 @@ struct PlayerControl
 		movement_speed = a_movement_speed;
 		movement_direction = a_movement_direction;
 	}
+
+	// For client use
+	u32 getKeysPressed() const;
+
+	// For server use
+	void unpackKeysPressed(u32 keypress_bits);
+
 	bool jump = false;
 	bool aux1 = false;
 	bool sneak = false;
@@ -80,7 +87,8 @@ struct PlayerControl
 	bool place = false;
 	float pitch = 0.0f;
 	float yaw = 0.0f;
-	// Note: These two are NOT available on the server
+	// Note: These three are NOT available on the server
+	u8 direction_keys = 0;
 	float movement_speed = 0.0f;
 	float movement_direction = 0.0f;
 };

--- a/src/player.h
+++ b/src/player.h
@@ -73,22 +73,25 @@ struct PlayerControl
 		movement_direction = a_movement_direction;
 	}
 
+#ifndef SERVER
 	// For client use
 	u32 getKeysPressed() const;
+	inline bool isMoving() const { return movement_speed > 0.001f; }
+#endif
 
 	// For server use
 	void unpackKeysPressed(u32 keypress_bits);
 
+	u8 direction_keys = 0;
 	bool jump = false;
 	bool aux1 = false;
 	bool sneak = false;
 	bool zoom = false;
 	bool dig = false;
 	bool place = false;
+	// Note: These four are NOT available on the server
 	float pitch = 0.0f;
 	float yaw = 0.0f;
-	// Note: These three are NOT available on the server
-	u8 direction_keys = 0;
 	float movement_speed = 0.0f;
 	float movement_direction = 0.0f;
 };
@@ -196,8 +199,6 @@ public:
 	{
 		return m_fov_override_spec;
 	}
-
-	u32 keyPressed = 0;
 
 	HudElement* getHud(u32 id);
 	u32         addHud(HudElement* hud);

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -230,13 +230,15 @@ int LuaLocalPlayer::l_get_control(lua_State *L)
 	set("dig",   c.dig);
 	set("place", c.place);
 	// Player movement in polar coordinates and non-binary speed
-	set("movement_speed",     c.movement_speed);
-	set("movement_direction", c.movement_direction);
+	lua_pushnumber(L, c.movement_speed);
+	lua_setfield(L, -2, "movement_speed");
+	lua_pushnumber(L, c.movement_direction);
+	lua_setfield(L, -2, "movement_direction");
 	// Provide direction keys to ensure compatibility
-	set("up",    player->keyPressed & (1 << 0)); // Up, down, left, and right were removed in favor of
-	set("down",  player->keyPressed & (1 << 1)); // analog  direction indicators and are therefore not
-	set("left",  player->keyPressed & (1 << 2)); // available as booleans anymore. The corresponding values
-	set("right", player->keyPressed & (1 << 3)); // can still be read from the keyPressed bits though.
+	set("up",    c.direction_keys & (1 << 0));
+	set("down",  c.direction_keys & (1 << 1));
+	set("left",  c.direction_keys & (1 << 2));
+	set("right", c.direction_keys & (1 << 3));
 
 	return 1;
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1423,7 +1423,7 @@ int ObjectRef::l_get_player_control_bits(lua_State *L)
 		( (u32)(c.zoom  & 1) << 9)
 	;
 
-
+	lua_pushinteger(L, keypress_bits);
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1367,20 +1367,18 @@ int ObjectRef::l_get_player_control(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	RemotePlayer *player = getplayer(ref);
-	if (player == nullptr) {
-		lua_pushlstring(L, "", 0);
-		return 1;
-	}
+	if (player == nullptr)
+		return 0;
 
 	const PlayerControl &control = player->getPlayerControl();
 	lua_newtable(L);
-	lua_pushboolean(L, player->keyPressed & (1 << 0));
+	lua_pushboolean(L, control.direction_keys & (1 << 0));
 	lua_setfield(L, -2, "up");
-	lua_pushboolean(L, player->keyPressed & (1 << 1));
+	lua_pushboolean(L, control.direction_keys & (1 << 1));
 	lua_setfield(L, -2, "down");
-	lua_pushboolean(L, player->keyPressed & (1 << 2));
+	lua_pushboolean(L, control.direction_keys & (1 << 2));
 	lua_setfield(L, -2, "left");
-	lua_pushboolean(L, player->keyPressed & (1 << 3));
+	lua_pushboolean(L, control.direction_keys & (1 << 3));
 	lua_setfield(L, -2, "right");
 	lua_pushboolean(L, control.jump);
 	lua_setfield(L, -2, "jump");
@@ -1408,12 +1406,24 @@ int ObjectRef::l_get_player_control_bits(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	RemotePlayer *player = getplayer(ref);
-	if (player == nullptr) {
-		lua_pushlstring(L, "", 0);
-		return 1;
-	}
+	if (player == nullptr)
+		return 0;
 
-	lua_pushnumber(L, player->keyPressed);
+	const auto &c = player->getPlayerControl();
+
+	// This is very close to PlayerControl::getKeysPressed() but duplicated
+	// here so the encoding in the API is not inadvertedly changed.
+	u32 keypress_bits =
+		c.direction_keys |
+		( (u32)(c.jump  & 1) << 4) |
+		( (u32)(c.aux1  & 1) << 5) |
+		( (u32)(c.sneak & 1) << 6) |
+		( (u32)(c.dig   & 1) << 7) |
+		( (u32)(c.place & 1) << 8) |
+		( (u32)(c.zoom  & 1) << 9)
+	;
+
+
 	return 1;
 }
 


### PR DESCRIPTION
fixes #11775

also moves relevant code into the `PlayerControl` class and gets rid of separate storage of `keyPressed`.

## To do

This PR is Ready for Review.

## How to test

1.
```lua
local h = {}; local t = {}
minetest.register_on_joinplayer(function(p)
	local n = p:get_player_name(); h[n] = p:hud_add({
		hud_elem_type = "text",
		position = {x = 0.22, y = 0.22},
		scale = {x = 2, y = 2},
		number = 0xFFFFFF,
		style = 4,
	}); t[n] = ""
end)
minetest.register_on_leaveplayer(function(p)
	local n = p:get_player_name(); h[n] = nil; t[n] = nil
end)
local function z(c)
	local function k(s) return c[s] and s:upper() or s end
	return ("      "..k("up").."          "..k("dig").." "..k("place").."\n"..
	k("left").." "..k("down").." "..k("right").."  "..k("jump").." "..k("sneak").."\n"..
	"                 "..k("aux1").."  "..k("zoom"))
end
minetest.register_globalstep(function(_)
	for _, p in ipairs(minetest.get_connected_players()) do
		local n = p:get_player_name(); local i = h[n]
		if i then
			local s = z(p:get_player_control())
			if s ~= t[n] then p:hud_change(i, "text", s); t[n] = s end
		end
	end
end)
```
2. Press left+right keys at the same time, or up+down
3. Confirm that it shows up in the HUD
