### PR TITLE
Add helper function to rotate a facedir

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -51,8 +51,8 @@ local rotated_facedir_map = {
 }
 
 function core.rotate_facedir(rotation, vector_name, facedir)
-    if rotation == 0 then return facedir end
-    return core.rotate_facedir(rotation - 1, vector_name, rotated_facedir_map[vector_name][facedir])
+    if rotation == 0 then return facedir or 0 end
+    return core.rotate_facedir(rotation - 1, vector_name, rotated_facedir_map[vector_name][facedir or 0])
 end
 
 -- Define rotations around the four remaining axes

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -76,69 +76,6 @@ for axis, rotate in pairs(rotate_remaining) do
     rotated_facedir_map[axis] = rotated_facedirs
 end
 
-function core.dir_to_wallmounted(dir)
-	if math.abs(dir.y) > math.max(math.abs(dir.x), math.abs(dir.z)) then
-		if dir.y < 0 then
-			return 1
-		else
-			return 0
-		end
-	elseif math.abs(dir.x) > math.abs(dir.z) then
-		if dir.x < 0 then
-			return 3
-		else
-			return 2
-		end
-	else
-		if dir.z < 0 then
-			return 5
-		else
-			return 4
-		end
-	end
-end
-
--- table of dirs in wallmounted order
-local wallmounted_to_dir = {
-	[0] = vector.new( 0,  1,  0),
-	vector.new( 0, -1,  0),
-	vector.new( 1,  0,  0),
-	vector.new(-1,  0,  0),
-	vector.new( 0,  0,  1),
-	vector.new( 0,  0, -1),
-}
-function core.wallmounted_to_dir(wallmounted)
-	return wallmounted_to_dir[wallmounted % 8]
-end
-
-function core.dir_to_yaw(dir)
-	return -math.atan2(dir.x, dir.z)
-end
-
-function core.yaw_to_dir(yaw)
-	return vector.new(-math.sin(yaw), 0, math.cos(yaw))
-end
-
-function core.is_colored_paramtype(ptype)
-	return (ptype == "color") or (ptype == "colorfacedir") or
-		(ptype == "colorwallmounted") or (ptype == "colordegrotate")
-end
-
-function core.strip_param2_color(param2, paramtype2)
-	if not core.is_colored_paramtype(paramtype2) then
-		return nil
-	end
-	if paramtype2 == "colorfacedir" then
-		param2 = math.floor(param2 / 32) * 32
-	elseif paramtype2 == "colorwallmounted" then
-		param2 = math.floor(param2 / 8) * 8
-	elseif paramtype2 == "colordegrotate" then
-		param2 = math.floor(param2 / 32) * 32
-	end
-	-- paramtype2 == "color" requires no modification.
-	return param2
-end
-
 local function has_all_groups(tbl, required_groups)
 	if type(required_groups) == "string" then
 		return (tbl[required_groups] or 0) ~= 0

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -147,7 +147,9 @@ function core.rotate_facedir(rotation, vector_name, facedir)
 		if r == 0 then return x end
 		return lookup_function(r - 1, n, rotated_facedir_map[n][x])
 	end
-	return vector_lambda_map[vector_name](lookup_function, rotation, facedir)
+	local translation_function = vector_lambda_map[vector_name]
+		or function (f, r, x) return nil end
+	return translation_function(lookup_function, rotation % 4, facedir)
 end
 
 function core.dir_to_wallmounted(dir)

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -51,8 +51,8 @@ local rotated_facedir_map = {
 }
 
 function core.rotate_facedir(rotation, vector_name, facedir)
-    if r == 0 then return x end
-    return lookup_function(r - 1, n, rotated_facedir_map[n][x])
+    if rotation == 0 then return facedir end
+    return lookup_function(rotation - 1, vector_name, rotated_facedir_map[vector_name][facedir])
 end
 
 -- Define rotations around the four remaining axes

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -52,7 +52,7 @@ local rotated_facedir_map = {
 
 function core.rotate_facedir(rotation, vector_name, facedir)
     if rotation == 0 then return facedir end
-    return lookup_function(rotation - 1, vector_name, rotated_facedir_map[vector_name][facedir])
+    return core.rotate_facedir(rotation - 1, vector_name, rotated_facedir_map[vector_name][facedir])
 end
 
 -- Define rotations around the four remaining axes

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -70,7 +70,7 @@ local rotate_remaining = {
 -- Precompute remaining axes
 for axis, rotate in pairs(rotate_remaining) do
     local rotated_facedirs = {}
-    for x in 0..23 do
+    for x=0,23 do
         rotated_facedirs[x] = rotate(1, x)
     end
     rotated_facedir_map[axis] = rotated_facedirs

--- a/builtin/game/tests/item_spec.lua
+++ b/builtin/game/tests/item_spec.lua
@@ -1,0 +1,59 @@
+_G.core = {}
+
+dofile("builtin/common/vector.lua")
+
+core.settings = {
+    get = function(self, arg) return 0 end
+}
+
+dofile("builtin/game/item.lua")
+
+describe("rotate_facedir()", function()
+    it("can reverse rotations", function()
+        local in_value = 7
+        local out_value = core.rotate_facedir(3, "y+", in_value)
+        out_value = core.rotate_facedir(3, "y-", out_value)
+        assert.are.equal(in_value, out_value)
+    end)
+
+    it("can do quarter rotations", function()
+        local in_value = 13
+        local out_value = core.rotate_facedir(1, "z+", in_value)
+        out_value = core.rotate_facedir(1, "z+", out_value)
+        out_value = core.rotate_facedir(1, "z+", out_value)
+        out_value = core.rotate_facedir(1, "z+", out_value)
+        assert.are.equal(in_value, out_value)
+    end)
+
+    it("can do half rotations", function()
+        local in_value = 2
+        local out_value = core.rotate_facedir(2, "x+", in_value)
+        out_value = core.rotate_facedir(2, "x+", out_value)
+        assert.are.equal(in_value, out_value)
+    end)
+
+    it("can compose rotations well", function()
+        local in_value = 6
+        local out_value = core.rotate_facedir(1, "x+", in_value)
+        out_value = core.rotate_facedir(1, "y+", out_value)
+        out_value = core.rotate_facedir(1, "z+", out_value)
+        out_value = core.rotate_facedir(1, "y-", out_value)
+        out_value = core.rotate_facedir(2, "x-", out_value)
+        assert.are.equal(in_value, out_value)
+    end)
+
+    it("can construct facedirs", function()
+        for in_value = 0, 23 do
+            local axis = math.floor(in_value / 4)
+            local rotation = in_value % 4
+            local out_value = core.rotate_facedir(rotation, "y-")
+            if axis == 1 then out_value = core.rotate_facedir(1, "x-", out_value)
+            elseif axis == 2 then out_value = core.rotate_facedir(1, "x+", out_value)
+            elseif axis == 3 then out_value = core.rotate_facedir(1, "z+", out_value)
+            elseif axis == 4 then out_value = core.rotate_facedir(1, "z-", out_value)
+            elseif axis == 5 then out_value = core.rotate_facedir(2, "z+", out_value)
+            end
+            assert.are.equal(in_value, out_value)
+        end
+    end)
+end)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6050,8 +6050,8 @@ Item handling
       rotation is performed around this vector.
     * `rotation` is in quarter-turns, always right-handed around the chosen vector
       (see https://en.wikipedia.org/wiki/Right-hand_rule#Rotations). Basically,
-      if ones places the right hand so that its thumb points outwards from the
-      specified face, the curled fingers then describe this rotation.
+      if ones places the right hand so that its thumb is pointing in the direction
+      of the specified vector, the curled fingers then describe this rotation.
 * `minetest.dir_to_wallmounted(dir)`
     * Convert a vector to a wallmounted value, used for
       `paramtype2="wallmounted"`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6046,9 +6046,9 @@ Item handling
       node.
 * `minetest.rotate_facedir(rotation, vector_name, facedir)`
     * Returns the facedir value that results from rotating `facedir` around an axis.
-    * `face_name` is one of `"x+"`, `"x-"`, `"y+"`, `"y-"`, `"z+"` or `"z-"`;
-      rotation is performed around the axis perpendicular to it.
-    * `rotation` is in quarter-turns, always right-handed around the normal vector
+    * `vector_name` is one of `"x+"`, `"x-"`, `"y+"`, `"y-"`, `"z+"` or `"z-"`;
+      rotation is performed around this vector.
+    * `rotation` is in quarter-turns, always right-handed around the chosen vector
       (see https://en.wikipedia.org/wiki/Right-hand_rule#Rotations). Basically,
       if ones places the right hand so that its thumb points outwards from the
       specified face, the curled fingers then describe this rotation.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6043,6 +6043,12 @@ Item handling
 * `minetest.fourdir_to_dir(fourdir)`
     * Convert a 4dir back into a vector aimed directly out the "back" of a
       node.
+* `minetest.rotate_facedir(rotation, vector_name, facedir)`
+    * Returns the facedir value that results from rotating `facedir` around an axis.
+    * `vector_name` is one of `"x+"`, `"x-"`, `"y+"`, `"y-"`, `"z+"` or `"z-"`,
+      indicating an orthogonal vector around which to perform rotation.
+    * `rotation` is in quarter-turns, always right-handed around the vector
+      (see https://en.wikipedia.org/wiki/Right-hand_rule#Rotations).
 * `minetest.dir_to_wallmounted(dir)`
     * Convert a vector to a wallmounted value, used for
       `paramtype2="wallmounted"`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1097,6 +1097,7 @@ The function of `param2` is determined by `paramtype2` in node definition.
     * The rotation of the node is stored in `param2`.
     * Node is rotated around face and axis; 24 rotations in total.
     * Can be made by using `minetest.dir_to_facedir()`.
+    * Can also be created or transformed via `minetest.rotate_facedir()`.
     * Chests and furnaces can be rotated that way, and also 'flipped'
     * Values range 0 - 23
     * facedir / 4 = axis direction:

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6046,10 +6046,12 @@ Item handling
       node.
 * `minetest.rotate_facedir(rotation, vector_name, facedir)`
     * Returns the facedir value that results from rotating `facedir` around an axis.
-    * `vector_name` is one of `"x+"`, `"x-"`, `"y+"`, `"y-"`, `"z+"` or `"z-"`,
-      indicating an orthogonal vector around which to perform rotation.
-    * `rotation` is in quarter-turns, always right-handed around the vector
-      (see https://en.wikipedia.org/wiki/Right-hand_rule#Rotations).
+    * `face_name` is one of `"x+"`, `"x-"`, `"y+"`, `"y-"`, `"z+"` or `"z-"`;
+      rotation is performed around the axis perpendicular to it.
+    * `rotation` is in quarter-turns, always right-handed around the normal vector
+      (see https://en.wikipedia.org/wiki/Right-hand_rule#Rotations). Basically,
+      if ones places the right hand so that its thumb points outwards from the
+      specified face, the curled fingers then describe this rotation.
 * `minetest.dir_to_wallmounted(dir)`
     * Convert a vector to a wallmounted value, used for
       `paramtype2="wallmounted"`.


### PR DESCRIPTION
This PR adds a helper function as proposed in #11918, with one of the possible implementations presented by myself.

It adds a function `minetest.rotate_facedir(rotation, vector_name, facedir)` that is meant to be used like this:
``` Lua
-- Rotate existing node counter-clockwise
new_value = minetest.rotate_facedir(rotation, "y+", current_value)
-- Rotate it to its back
new_value = minetest.rotate_facedir(1, "x-", current_value)
-- Construct a facedir from its components (I used this for test code)
facedir = minetest.rotate_facedir(rotation, "y-") -- default value is 0
if axis == 1 then facedir = minetest.rotate_facedir(1, "x-", facedir)
elseif axis == 2 then facedir = minetest.rotate_facedir(1, "x+", facedir)
elseif axis == 3 then facedir = minetest.rotate_facedir(1, "z+", facedir)
elseif axis == 4 then facedir = minetest.rotate_facedir(1, "z-", facedir)
elseif axis == 5 then facedir = minetest.rotate_facedir(2, "z+", facedir)
end
-- Compose rotations
minetest.rotate_facedir(1, "x+", minetest.rotate_facedir(2, "y+", facedir))
```

## To do

This PR is Ready for Review.

## How to test

I've tested many classes of example values, including invalid ones. Not every possible combination though. Should I also add explicit test code?
