### PR TITLE
Fix incorrect bit positions in paramtype documentation

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1026,7 +1026,7 @@ The function of `param1` is determined by `paramtype` in node definition.
 `param1` is reserved for the engine when `paramtype != "none"`.
 
 * `paramtype = "light"`
-    * The value stores light with and without sun in its upper and lower 4 bits
+    * The value stores light with and without sun in its lower and upper 4 bits
       respectively.
     * Required by a light source node to enable spreading its light.
     * Required by the following drawtypes as they determine their visual


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

So, in the documentation for light paramtype, there is the following line:

> The value stores light with and without sun in its lower and upper 4 bits respectively.

This seems to be incorrect, as a value of 15 causes nodes to be luminous during the day and dark at night, while a value of 240 seems to give the opposite result.

This PR simply swaps those two words in the description.

## To do
This PR is Ready for Review.

## How to test
Please make sure that the reason the above assertion doesn't hold is indeed that the 'upper' and 'lower' positions are swapped, and not some more obscure reason.
