### PR TITLE
Restore and enhance bouncy behavior

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1832,7 +1832,9 @@ to games.
 * `attached_node`: if the node under it is not a walkable block the node will be
   dropped as an item. If the node is wallmounted the wallmounted direction is
   checked.
-* `bouncy`: value is bounce speed in percent
+* `bouncy`: value is bounce speed in percent.
+  If positive, jump/sneak on floor impact will increase/decrease bounce height.
+  Negative value is the same bounciness, but non-controllable.
 * `connect_to_raillike`: makes nodes of raillike drawtype with same group value
   connect to each other
 * `dig_immediate`: Player can always pick up node without reducing tool wear

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -465,7 +465,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		} else {
 			// jump pressed
 			// Reduce boost when speed already is high
-			jumpspeed = jumpspeed / (1.0f + (m_speed.Y / 24.0f));
+			jumpspeed = jumpspeed / (1.0f + (m_speed.Y * 2.8f / jumpspeed));
 		}
 		m_speed.Y += jumpspeed;
 		setSpeed(m_speed);
@@ -1080,7 +1080,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		} else {
 			// jump pressed
 			// Reduce boost when speed already is high
-			jumpspeed = jumpspeed / (1.0f + (m_speed.Y / 24.0f));
+			jumpspeed = jumpspeed / (1.0f + (m_speed.Y * 2.8f / jumpspeed));
 		}
 		m_speed.Y += jumpspeed;
 		setSpeed(m_speed);

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -331,8 +331,8 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	}
 
 	/*
-		If the player's feet touch the topside of any node, this is
-		set to true.
+		If the player's feet touch the topside of any node
+		at the END of clientstep, then this is set to true.
 
 		Player is allowed to jump when this is true.
 	*/
@@ -432,22 +432,46 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	const ContentFeatures &f = nodemgr->get(map->getNode(m_standing_node));
 	const ContentFeatures &f1 = nodemgr->get(map->getNode(m_standing_node + v3s16(0, 1, 0)));
 
+	// We can jump from a bouncy node we collided with this clientstep,
+	// even if we are not "touching" it at the end of clientstep.
+	bool bouncy_can_jump = false;
+	if (result.collides && m_speed.Y > 0.0f) {
+		// must use result.collisions here because sometimes collision_info
+		// is passed in prepopulated with a problematic floor.
+		for (const auto &colinfo : result.collisions) {
+			if (colinfo.node_p == m_standing_node
+					&& itemgroup_get(f.groups, "bouncy") != 0) {
+				bouncy_can_jump = true;
+				break;
+			}
+		}
+	}
+
 	// Determine if jumping is possible
 	m_disable_jump = itemgroup_get(f.groups, "disable_jump") ||
 		itemgroup_get(f1.groups, "disable_jump");
-	m_can_jump = ((touching_ground && !is_climbing) || sneak_can_jump) && !m_disable_jump;
+	m_can_jump = ((touching_ground && !is_climbing) || sneak_can_jump || bouncy_can_jump)
+			&& !m_disable_jump;
 
-	// Jump key pressed while jumping off from a bouncy block
-	if (m_can_jump && control.jump && itemgroup_get(f.groups, "bouncy") &&
-		m_speed.Y >= -0.5f * BS) {
-		float jumpspeed = movement_speed_jump * physics_override.jump;
-		if (m_speed.Y > 1.0f) {
-			// Reduce boost when speed already is high
-			m_speed.Y += jumpspeed / (1.0f + (m_speed.Y / 16.0f));
+	// Jump/Sneak key pressed while bouncing from a bouncy block
+	float jumpspeed = movement_speed_jump * physics_override.jump;
+	if (bouncy_can_jump && m_can_jump && (control.jump || control.sneak)
+			&& itemgroup_get(f.groups, "bouncy") > 0) {
+		// controllable (>0) bouncy block
+		if (!control.jump) {
+			// sneak pressed, but not jump
+			// Subjective testing indicates 1/3 bounce decrease works well.
+			jumpspeed = -m_speed.Y / 3.0f;
 		} else {
-			m_speed.Y += jumpspeed;
+			// jump pressed
+			// Reduce boost when speed already is high
+			jumpspeed = jumpspeed / (1.0f + (m_speed.Y / 24.0f));
 		}
+		m_speed.Y += jumpspeed;
 		setSpeed(m_speed);
+		m_can_jump = false;
+	} else if(m_speed.Y > jumpspeed && itemgroup_get(f.groups, "bouncy") < 0) {
+		// uncontrollable bouncy is limited to normal jump height.
 		m_can_jump = false;
 	}
 
@@ -1025,21 +1049,45 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	*/
 	const ContentFeatures &f = nodemgr->get(map->getNode(getStandingNodePos()));
 
+	// We can jump from a bouncy node we collided with this clientstep,
+	// even if we are not "touching" it at the end of clientstep.
+	bool bouncy_can_jump = false;
+	if (result.collides && m_speed.Y > 0.0f) {
+		// must use result.collisions here because sometimes collision_info
+		// is passed in prepopulated with a problematic floor.
+		for (const auto &colinfo : result.collisions) {
+			// COLLISION_AXIS_Y here is a hack for old_move
+			if (colinfo.axis == COLLISION_AXIS_Y
+					&& itemgroup_get(f.groups, "bouncy") != 0) {
+				bouncy_can_jump = true;
+				break;
+			}
+		}
+	}
+
 	// Determine if jumping is possible
 	m_disable_jump = itemgroup_get(f.groups, "disable_jump");
-	m_can_jump = touching_ground && !m_disable_jump;
+	m_can_jump = (touching_ground || bouncy_can_jump) && !m_disable_jump;
 
-	// Jump key pressed while jumping off from a bouncy block
-	if (m_can_jump && control.jump && itemgroup_get(f.groups, "bouncy") &&
-			m_speed.Y >= -0.5f * BS) {
-		float jumpspeed = movement_speed_jump * physics_override.jump;
-		if (m_speed.Y > 1.0f) {
-			// Reduce boost when speed already is high
-			m_speed.Y += jumpspeed / (1.0f + (m_speed.Y / 16.0f));
+	// Jump/Sneak key pressed while bouncing from a bouncy block
+	float jumpspeed = movement_speed_jump * physics_override.jump;
+	if (bouncy_can_jump && m_can_jump && (control.jump || control.sneak)
+			&& itemgroup_get(f.groups, "bouncy") > 0) {
+		// controllable (>0) bouncy block
+		if (!control.jump) {
+			// sneak pressed, but not jump
+			// Subjective testing indicates 1/3 bounce decrease works well.
+			jumpspeed = -m_speed.Y / 3.0f;
 		} else {
-			m_speed.Y += jumpspeed;
+			// jump pressed
+			// Reduce boost when speed already is high
+			jumpspeed = jumpspeed / (1.0f + (m_speed.Y / 24.0f));
 		}
+		m_speed.Y += jumpspeed;
 		setSpeed(m_speed);
+		m_can_jump = false;
+	} else if(m_speed.Y > jumpspeed && itemgroup_get(f.groups, "bouncy") < 0) {
+		// uncontrollable bouncy is limited to normal jump height.
 		m_can_jump = false;
 	}
 

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -434,19 +434,16 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 
 	// We can jump from a bouncy node we collided with this clientstep,
 	// even if we are not "touching" it at the end of clientstep.
-	bool bouncy_can_jump = false;
-	int actual_bouncy = 0;
+	int standing_node_bouncy = 0;
 	if (result.collides && m_speed.Y > 0.0f) {
 		// must use result.collisions here because sometimes collision_info
 		// is passed in prepopulated with a problematic floor.
 		for (const auto &colinfo : result.collisions) {
 			if (colinfo.axis == COLLISION_AXIS_Y) {
 				// we cannot rely on m_standing_node because "sneak stuff"
-				actual_bouncy = itemgroup_get(nodemgr->get(map->getNode(colinfo.node_p)).groups, "bouncy");
-				if (actual_bouncy != 0) {
-					bouncy_can_jump = true;
+				standing_node_bouncy = itemgroup_get(nodemgr->get(map->getNode(colinfo.node_p)).groups, "bouncy");
+				if (standing_node_bouncy != 0)
 					break;
-				}
 			}
 		}
 	}
@@ -454,13 +451,12 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	// Determine if jumping is possible
 	m_disable_jump = itemgroup_get(f.groups, "disable_jump") ||
 		itemgroup_get(f1.groups, "disable_jump");
-	m_can_jump = ((touching_ground && !is_climbing) || sneak_can_jump || bouncy_can_jump)
+	m_can_jump = ((touching_ground && !is_climbing) || sneak_can_jump || standing_node_bouncy != 0)
 			&& !m_disable_jump;
 
 	// Jump/Sneak key pressed while bouncing from a bouncy block
 	float jumpspeed = movement_speed_jump * physics_override.jump;
-	if (bouncy_can_jump && m_can_jump && (control.jump || control.sneak)
-			&& actual_bouncy > 0) {
+	if (m_can_jump && (control.jump || control.sneak) && standing_node_bouncy > 0) {
 		// controllable (>0) bouncy block
 		if (!control.jump) {
 			// sneak pressed, but not jump
@@ -474,7 +470,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		m_speed.Y += jumpspeed;
 		setSpeed(m_speed);
 		m_can_jump = false;
-	} else if(m_speed.Y > jumpspeed && actual_bouncy < 0) {
+	} else if(m_speed.Y > jumpspeed && standing_node_bouncy < 0) {
 		// uncontrollable bouncy is limited to normal jump height.
 		m_can_jump = false;
 	}
@@ -1055,31 +1051,27 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 
 	// We can jump from a bouncy node we collided with this clientstep,
 	// even if we are not "touching" it at the end of clientstep.
-	bool bouncy_can_jump = false;
-	int actual_bouncy = 0;
+	int standing_node_bouncy = 0;
 	if (result.collides && m_speed.Y > 0.0f) {
 		// must use result.collisions here because sometimes collision_info
 		// is passed in prepopulated with a problematic floor.
 		for (const auto &colinfo : result.collisions) {
 			if (colinfo.axis == COLLISION_AXIS_Y) {
 				// we cannot rely on m_standing_node because "sneak stuff"
-				actual_bouncy = itemgroup_get(nodemgr->get(map->getNode(colinfo.node_p)).groups, "bouncy");
-				if (actual_bouncy != 0) {
-					bouncy_can_jump = true;
+				standing_node_bouncy = itemgroup_get(nodemgr->get(map->getNode(colinfo.node_p)).groups, "bouncy");
+				if (standing_node_bouncy != 0)
 					break;
-				}
 			}
 		}
 	}
 
 	// Determine if jumping is possible
 	m_disable_jump = itemgroup_get(f.groups, "disable_jump");
-	m_can_jump = (touching_ground || bouncy_can_jump) && !m_disable_jump;
+	m_can_jump = (touching_ground || standing_node_bouncy != 0) && !m_disable_jump;
 
 	// Jump/Sneak key pressed while bouncing from a bouncy block
 	float jumpspeed = movement_speed_jump * physics_override.jump;
-	if (bouncy_can_jump && m_can_jump && (control.jump || control.sneak)
-			&& actual_bouncy > 0) {
+	if (m_can_jump && (control.jump || control.sneak) && standing_node_bouncy > 0) {
 		// controllable (>0) bouncy block
 		if (!control.jump) {
 			// sneak pressed, but not jump
@@ -1093,7 +1085,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		m_speed.Y += jumpspeed;
 		setSpeed(m_speed);
 		m_can_jump = false;
-	} else if(m_speed.Y > jumpspeed && actual_bouncy < 0) {
+	} else if(m_speed.Y > jumpspeed && standing_node_bouncy < 0) {
 		// uncontrollable bouncy is limited to normal jump height.
 		m_can_jump = false;
 	}


### PR DESCRIPTION
This patch attempts to restore and enhance pre-5.3 bouncy behavior.

## The issues

* Previously, it was possible to accumulate height by holding jump on a trampoline, though height naturally decayed even at 100% bouncy.  This decay was probably accidental behavior.
* After collision fixes in 5.3, 100% bouncy means it "never" decays (minus air resistance/friction?) but is NOT possible to accumulate height because touching_ground is inconsistent when falling onto a surface.
* Also, some of the numbers seem to be relics that relied on the old broken collision (fuzzy touching_ground resulting in multiple "jumps" per jump) which currently would result in more subdued initial accumulation compared to pre-5.3

## The treatment

* ~~A small fix for ground collision on bouncy floors~~  A new check in `localplayer` to allow jumping if we actually collided with a bouncy floor during this clientstep.
* New ability to manually decrease bounce height by holding the sneak key.
* Numeric tweaks to retain the 'feel' of the old bouncy without relying on glitches.
* Negative bouncy values will be interpreted as "uncontrollable" so trampolines can be made which behave the same as post-5.3 (though consistent)

## To do

Ready for review.  Could probably use some optimization.

I've fixed sneak behavior while straddling the boundary between bouncy/nonbouncy nodes, but `old_move` behavior is still weird (sneaking when landing on a trampoline stops you immediately)  Kill old_move when?

## How to test

Get on a trampoline. At 100% bouncy, height should remain mostly stable though decay very slowly.
* Holding jump at moment of impact should increase height each jump (a bit more for initial jumps, much less if already jumping very high).
* Holding sneak at moment of impact should decrease bounce height.
* Trampolines with negative bouncy will ignore jump/sneak but otherwise act like +bouncy
* Hopefully nothing weird happens if bouncing while rubbing against a wall.

If you really want, you can also apply https://github.com/minetest/minetest/commit/878cfc22caa6b05cc49a191ceaa82708d4bb61e3 and set a 100% trampoline at y=-0.5 to measure peak heights after X number of bounces.

Here are my (old - using the previous `collision.cpp` hack and before re-normalizing the bounce attenuation. current formula gives a denominator of about 23.2) measured heights from testing on a 100% half-node trampoline ("jumping" mod) using MT5.2 and this PR with various formula denominators.  Yours may vary for MT5.2 as it seems more succeptible to client stepsize.

|MT|5 peaks|10 peaks|20 peaks|
|---|---|---|---|
|5.2 singleplayer|3.7-4.8|6.5-7.8|11.0-13.8|
|5.2 online|2.2-3.8|3.9-6.0|8.6-10.6|
|PR/16 (5.2 formula)|2.3-2.5|4.0-4.4|7.1-7.8|
|PR/22|2.9-3.1|5.3-5.6|9.9-10.2|
|PR/24|3.1-3.3|5.8-6.1|11.0-11.4|
