### PR TITLE
Fix NodeDef backwards compatibility to 5.3.0

### DIFF
--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -213,7 +213,10 @@ void TileDef::serialize(std::ostream &os, u16 protocol_version) const
 		// Before f018737, TextureSource::getTextureAverageColor did not handle
 		// missing textures. "[png" can be used as base texture, but is not known
 		// on older clients. Hence use "blank.png" to avoid this problem.
-		os << serializeString16("blank.png^" + name);
+		if (!name.empty() && name[0] == '[')
+			os << serializeString16("blank.png^" + name);
+		else
+			os << serializeString16(name);
 	}
 	animation.serialize(os, version);
 	bool has_scale = scale > 0;
@@ -502,15 +505,10 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	if (protocol_version <= 39) {
 		// Since commit 7f25823, liquid drawtypes can be used even with LIQUID_NONE
 		// solution: force liquid type accordingly to accepted values
-		switch (drawtype) {
-			case NDT_LIQUID:
-				liquid_type_bc = LIQUID_SOURCE;
-				break;
-			case NDT_FLOWINGLIQUID:
-				liquid_type_bc = LIQUID_FLOWING;
-				break;
-			default: break;
-		}
+		if (drawtype == NDT_LIQUID)
+			liquid_type_bc = LIQUID_SOURCE;
+		else if (drawtype == NDT_FLOWINGLIQUID)
+			liquid_type_bc = LIQUID_FLOWING;
 	}
 	writeU8(os, liquid_type_bc);
 	os << serializeString16(liquid_alternative_flowing);


### PR DESCRIPTION
1. Fixes crashes on older clients when `[png` is used as base image
2. Fixes liquid type assertion fails on debug builds

Both reported in https://github.com/minetest/minetest/pull/10737#issuecomment-1008003614, whereas (1) is the original crash cause.

## To do

This PR is Ready for Review.

## How to test

1. Compile Minetest 5.3.0 with nodedef.cpp changes if you don't want a Debug build:
   * Old: `assert(liquid_type == LIQUID_SOURCE);`
   * New: `FATAL_ERROR_IF(liquid_type != LIQUID_SOURCE,"a");`
   * Old: `assert(liquid_type == LIQUID_FLOWING);`
   * New `FATAL_ERROR_IF(liquid_type != LIQUID_FLOWING,"b");`
2. Host a 5.4.0 devtest game
3. Join with 5.3.0 and enjoy SIGSEGV and assertion fails
4. Test again with this PR