### PR TITLE
Proposal: API to control shadow intensity from the game/mod

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -592,9 +592,10 @@ enable_waving_plants (Waving plants) bool false
 #    Requires shaders to be enabled.
 enable_dynamic_shadows (Dynamic shadows) bool false
 
-#    Set the shadow strength.
+#    Set the shadow strength gamma.
+#    Adjusts the intensity of in-game dynamic shadows.
 #    Lower value means lighter shadows, higher value means darker shadows.
-shadow_strength (Shadow strength) float 0.2 0.05 1.0
+shadow_strength_gamma (Shadow strength gamma) float 1.0 0.1 10.0
 
 #    Maximum distance to render shadows.
 shadow_map_max_distance (Shadow map max distance in nodes to render shadows) float 120.0 10.0 1000.0

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -16,6 +16,7 @@ uniform float animationTimer;
 	uniform float f_textureresolution;
 	uniform mat4 m_ShadowViewProj;
 	uniform float f_shadowfar;
+	uniform float f_shadow_strength;
 	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float cosLight;
@@ -483,55 +484,57 @@ void main(void)
 	vec4 col = vec4(color.rgb * varColor.rgb, 1.0);
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
-	float shadow_int = 0.0;
-	vec3 shadow_color = vec3(0.0, 0.0, 0.0);
-	vec3 posLightSpace = getLightSpacePosition();
+	if (f_shadow_strength > 0.0) {
+		float shadow_int = 0.0;
+		vec3 shadow_color = vec3(0.0, 0.0, 0.0);
+		vec3 posLightSpace = getLightSpacePosition();
 
-	float distance_rate = (1 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 20.0));
-	float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z  ),0.0);
+		float distance_rate = (1 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 20.0));
+		float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z  ),0.0);
 
-	if (distance_rate > 1e-7) {
-	
+		if (distance_rate > 1e-7) {
+		
 #ifdef COLORED_SHADOWS
-		vec4 visibility;
-		if (cosLight > 0.0)
-			visibility = getShadowColor(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
-		else
-			visibility = vec4(1.0, 0.0, 0.0, 0.0);
-		shadow_int = visibility.r;
-		shadow_color = visibility.gba;
+			vec4 visibility;
+			if (cosLight > 0.0)
+				visibility = getShadowColor(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
+			else
+				visibility = vec4(1.0, 0.0, 0.0, 0.0);
+			shadow_int = visibility.r;
+			shadow_color = visibility.gba;
 #else
-		if (cosLight > 0.0)
-			shadow_int = getShadow(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
-		else
-			shadow_int = 1.0;
+			if (cosLight > 0.0)
+				shadow_int = getShadow(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
+			else
+				shadow_int = 1.0;
 #endif
-		shadow_int *= distance_rate;
-		shadow_int = clamp(shadow_int, 0.0, 1.0);
+			shadow_int *= distance_rate;
+			shadow_int = clamp(shadow_int, 0.0, 1.0);
 
+		}
+
+		// turns out that nightRatio falls off much faster than
+		// actual brightness of artificial light in relation to natual light.
+		// Power ratio was measured on torches in MTG (brightness = 14).
+		float adjusted_night_ratio = pow(max(0.0, nightRatio), 0.6);
+
+		// Apply self-shadowing when light falls at a narrow angle to the surface
+		// Cosine of the cut-off angle.
+		const float self_shadow_cutoff_cosine = 0.035;
+		if (f_normal_length != 0 && cosLight < self_shadow_cutoff_cosine) {
+			shadow_int = max(shadow_int, 1 - clamp(cosLight, 0.0, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);
+			shadow_color = mix(vec3(0.0), shadow_color, min(cosLight, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);
+		}
+
+		shadow_int *= f_adj_shadow_strength;
+		
+		// calculate fragment color from components:
+		col.rgb =
+				adjusted_night_ratio * col.rgb + // artificial light
+				(1.0 - adjusted_night_ratio) * ( // natural light
+						col.rgb * (1.0 - shadow_int * (1.0 - shadow_color)) +  // filtered texture color
+						dayLight * shadow_color * shadow_int);                 // reflected filtered sunlight/moonlight
 	}
-
-	// turns out that nightRatio falls off much faster than
-	// actual brightness of artificial light in relation to natual light.
-	// Power ratio was measured on torches in MTG (brightness = 14).
-	float adjusted_night_ratio = pow(max(0.0, nightRatio), 0.6);
-
-	// Apply self-shadowing when light falls at a narrow angle to the surface
-	// Cosine of the cut-off angle.
-	const float self_shadow_cutoff_cosine = 0.035;
-	if (f_normal_length != 0 && cosLight < self_shadow_cutoff_cosine) {
-		shadow_int = max(shadow_int, 1 - clamp(cosLight, 0.0, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);
-		shadow_color = mix(vec3(0.0), shadow_color, min(cosLight, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);
-	}
-
-	shadow_int *= f_adj_shadow_strength;
-	
-	// calculate fragment color from components:
-	col.rgb =
-			adjusted_night_ratio * col.rgb + // artificial light
-			(1.0 - adjusted_night_ratio) * ( // natural light
-					col.rgb * (1.0 - shadow_int * (1.0 - shadow_color)) +  // filtered texture color
-					dayLight * shadow_color * shadow_int);                 // reflected filtered sunlight/moonlight
 #endif
 
 #if ENABLE_TONE_MAPPING

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -195,34 +195,35 @@ void main(void)
 	varColor = clamp(color, 0.0, 1.0);
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
-	vec3 nNormal = normalize(vNormal);
-	cosLight = dot(nNormal, -v_LightDirection);
-	
-	// Calculate normal offset scale based on the texel size adjusted for 
-	// curvature of the SM texture. This code must be change together with
-	// getPerspectiveFactor or any light-space transformation.
-	vec3 eyeToVertex = worldPosition - eyePosition + cameraOffset;
-	// Distance from the vertex to the player
-	float distanceToPlayer = length(eyeToVertex - v_LightDirection * dot(eyeToVertex, v_LightDirection)) / f_shadowfar;
-	// perspective factor estimation according to the 
-	float perspectiveFactor = distanceToPlayer * bias0 + bias1;
-	float texelSize = f_shadowfar * perspectiveFactor * perspectiveFactor /
-			(f_textureresolution * bias1  - perspectiveFactor * bias0);
-	float slopeScale = clamp(pow(1.0 - cosLight*cosLight, 0.5), 0.0, 1.0);
-	normalOffsetScale = texelSize * slopeScale;
+	if (f_shadow_strength > 0.0) {
+		vec3 nNormal = normalize(vNormal);
+		cosLight = dot(nNormal, -v_LightDirection);
+		
+		// Calculate normal offset scale based on the texel size adjusted for 
+		// curvature of the SM texture. This code must be change together with
+		// getPerspectiveFactor or any light-space transformation.
+		vec3 eyeToVertex = worldPosition - eyePosition + cameraOffset;
+		// Distance from the vertex to the player
+		float distanceToPlayer = length(eyeToVertex - v_LightDirection * dot(eyeToVertex, v_LightDirection)) / f_shadowfar;
+		// perspective factor estimation according to the 
+		float perspectiveFactor = distanceToPlayer * bias0 + bias1;
+		float texelSize = f_shadowfar * perspectiveFactor * perspectiveFactor /
+				(f_textureresolution * bias1  - perspectiveFactor * bias0);
+		float slopeScale = clamp(pow(1.0 - cosLight*cosLight, 0.5), 0.0, 1.0);
+		normalOffsetScale = texelSize * slopeScale;
 
-	if (f_timeofday < 0.2) {
-		adj_shadow_strength = f_shadow_strength * 0.5 *
-			(1.0 - mtsmoothstep(0.18, 0.2, f_timeofday));
-	} else if (f_timeofday >= 0.8) {
-		adj_shadow_strength = f_shadow_strength * 0.5 *
-			mtsmoothstep(0.8, 0.83, f_timeofday);
-	} else {
-		adj_shadow_strength = f_shadow_strength *
-			mtsmoothstep(0.20, 0.25, f_timeofday) *
-			(1.0 - mtsmoothstep(0.7, 0.8, f_timeofday));
+		if (f_timeofday < 0.2) {
+			adj_shadow_strength = f_shadow_strength * 0.5 *
+				(1.0 - mtsmoothstep(0.18, 0.2, f_timeofday));
+		} else if (f_timeofday >= 0.8) {
+			adj_shadow_strength = f_shadow_strength * 0.5 *
+				mtsmoothstep(0.8, 0.83, f_timeofday);
+		} else {
+			adj_shadow_strength = f_shadow_strength *
+				mtsmoothstep(0.20, 0.25, f_timeofday) *
+				(1.0 - mtsmoothstep(0.7, 0.8, f_timeofday));
+		}
+		f_normal_length = length(vNormal);
 	}
-	f_normal_length = length(vNormal);
 #endif
-
 }

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -105,33 +105,35 @@ void main(void)
 
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
-	vec3 nNormal = normalize(vNormal);
-	cosLight = dot(nNormal, -v_LightDirection);
+	if (f_shadow_strength > 0.0) {
+		vec3 nNormal = normalize(vNormal);
+		cosLight = dot(nNormal, -v_LightDirection);
 
-	// Calculate normal offset scale based on the texel size adjusted for 
-	// curvature of the SM texture. This code must be change together with
-	// getPerspectiveFactor or any light-space transformation.
-	vec3 eyeToVertex = worldPosition - eyePosition + cameraOffset;
-	// Distance from the vertex to the player
-	float distanceToPlayer = length(eyeToVertex - v_LightDirection * dot(eyeToVertex, v_LightDirection)) / f_shadowfar;
-	// perspective factor estimation according to the 
-	float perspectiveFactor = distanceToPlayer * bias0 + bias1;
-	float texelSize = f_shadowfar * perspectiveFactor * perspectiveFactor /
-			(f_textureresolution * bias1  - perspectiveFactor * bias0);
-	float slopeScale = clamp(pow(1.0 - cosLight*cosLight, 0.5), 0.0, 1.0);
-	normalOffsetScale = texelSize * slopeScale;
-	
-	if (f_timeofday < 0.2) {
-		adj_shadow_strength = f_shadow_strength * 0.5 *
-			(1.0 - mtsmoothstep(0.18, 0.2, f_timeofday));
-	} else if (f_timeofday >= 0.8) {
-		adj_shadow_strength = f_shadow_strength * 0.5 *
-			mtsmoothstep(0.8, 0.83, f_timeofday);
-	} else {
-		adj_shadow_strength = f_shadow_strength *
-			mtsmoothstep(0.20, 0.25, f_timeofday) *
-			(1.0 - mtsmoothstep(0.7, 0.8, f_timeofday));
+		// Calculate normal offset scale based on the texel size adjusted for 
+		// curvature of the SM texture. This code must be change together with
+		// getPerspectiveFactor or any light-space transformation.
+		vec3 eyeToVertex = worldPosition - eyePosition + cameraOffset;
+		// Distance from the vertex to the player
+		float distanceToPlayer = length(eyeToVertex - v_LightDirection * dot(eyeToVertex, v_LightDirection)) / f_shadowfar;
+		// perspective factor estimation according to the
+		float perspectiveFactor = distanceToPlayer * bias0 + bias1;
+		float texelSize = f_shadowfar * perspectiveFactor * perspectiveFactor /
+				(f_textureresolution * bias1  - perspectiveFactor * bias0);
+		float slopeScale = clamp(pow(1.0 - cosLight*cosLight, 0.5), 0.0, 1.0);
+		normalOffsetScale = texelSize * slopeScale;
+
+		if (f_timeofday < 0.2) {
+			adj_shadow_strength = f_shadow_strength * 0.5 *
+				(1.0 - mtsmoothstep(0.18, 0.2, f_timeofday));
+		} else if (f_timeofday >= 0.8) {
+			adj_shadow_strength = f_shadow_strength * 0.5 *
+				mtsmoothstep(0.8, 0.83, f_timeofday);
+		} else {
+			adj_shadow_strength = f_shadow_strength *
+				mtsmoothstep(0.20, 0.25, f_timeofday) *
+				(1.0 - mtsmoothstep(0.7, 0.8, f_timeofday));
+		}
+		f_normal_length = length(vNormal);
 	}
-	f_normal_length = length(vNormal);
 #endif
 }

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6961,6 +6961,11 @@ object you are working with still exists.
     * Returns `false` if failed.
     * Resource intensive - use sparsely
     * To get blockpos, integer divide pos by 16
+* `set_lighting(light_definition)`: sets lighting for the player
+    * `light_definition` is a table.
+    * Returns true on success.
+* `get_lighting()`: returns the current state of lighting for the player.
+    * Result is a table with the same fields as `light_definition` in `set_lighting`.
 
 `PcgRandom`
 -----------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6962,7 +6962,9 @@ object you are working with still exists.
     * Resource intensive - use sparsely
     * To get blockpos, integer divide pos by 16
 * `set_lighting(light_definition)`: sets lighting for the player
-    * `light_definition` is a table.
+    * `light_definition` is a table with the following optional fields:
+      * `shadows` is a table that controls ambient shadows
+        * `intensity` sets the intensity of the shadows from 0 (no shadows, default) to 1 (blackness)
     * Returns true on success.
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.

--- a/games/devtest/mods/experimental/init.lua
+++ b/games/devtest/mods/experimental/init.lua
@@ -7,6 +7,7 @@ experimental = {}
 dofile(minetest.get_modpath("experimental").."/detached.lua")
 dofile(minetest.get_modpath("experimental").."/items.lua")
 dofile(minetest.get_modpath("experimental").."/commands.lua")
+dofile(minetest.get_modpath("experimental").."/lighting.lua")
 
 function experimental.print_to_everything(msg)
 	minetest.log("action", msg)

--- a/games/devtest/mods/experimental/lighting.lua
+++ b/games/devtest/mods/experimental/lighting.lua
@@ -1,7 +1,8 @@
 core.register_chatcommand("set_lighting", {
-    params = "",
+    params = "shadow_intensity",
     description = "Set lighting parameters.",
     func = function(player_name, param)
-        minetest.get_player_by_name(player_name):set_lighting({})
+        local shadow_intensity = tonumber(param)
+        minetest.get_player_by_name(player_name):set_lighting({shadow_intensity = shadow_intensity})
     end
 })

--- a/games/devtest/mods/experimental/lighting.lua
+++ b/games/devtest/mods/experimental/lighting.lua
@@ -3,6 +3,6 @@ core.register_chatcommand("set_lighting", {
     description = "Set lighting parameters.",
     func = function(player_name, param)
         local shadow_intensity = tonumber(param)
-        minetest.get_player_by_name(player_name):set_lighting({shadow_intensity = shadow_intensity})
+        minetest.get_player_by_name(player_name):set_lighting({shadows = { intensity = shadow_intensity} })
     end
 })

--- a/games/devtest/mods/experimental/lighting.lua
+++ b/games/devtest/mods/experimental/lighting.lua
@@ -1,0 +1,7 @@
+core.register_chatcommand("set_lighting", {
+    params = "",
+    description = "Set lighting parameters.",
+    func = function(player_name, param)
+        minetest.get_player_by_name(player_name):set_lighting({})
+    end
+})

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -227,6 +227,7 @@ public:
 	void handleCommand_PlayerSpeed(NetworkPacket *pkt);
 	void handleCommand_MediaPush(NetworkPacket *pkt);
 	void handleCommand_MinimapModes(NetworkPacket *pkt);
+	void handleCommand_SetLighting(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4035,11 +4035,14 @@ void Game::updateShadows()
 	if (!shadow)
 		return;
 
-	shadow->setShadowIntensity(client->getEnv().getLocalPlayer()->getLighting().shadow_intensity);
-
 	float in_timeofday = fmod(runData.time_of_day_smooth, 1.0f);
 
-	float timeoftheday = fmod(getWickedTimeOfDay(in_timeofday) + 0.75f, 0.5f) + 0.25f;
+	float timeoftheday = getWickedTimeOfDay(in_timeofday);
+	bool is_day = timeoftheday > 0.25 && timeoftheday < 0.75;
+	bool is_shadow_visible = is_day ? sky->getSunVisible() : sky->getMoonVisible();
+	shadow->setShadowIntensity(is_shadow_visible ? client->getEnv().getLocalPlayer()->getLighting().shadow_intensity : 0.0f);
+
+	timeoftheday = fmod(timeoftheday + 0.75f, 0.5f) + 0.25f;
 	const float offset_constant = 10000.0f;
 
 	v3f light(0.0f, 0.0f, -1.0f);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4035,6 +4035,8 @@ void Game::updateShadows()
 	if (!shadow)
 		return;
 
+	shadow->setShadowIntensity(client->getEnv().getLocalPlayer()->getLighting().shadow_intensity);
+
 	float in_timeofday = fmod(runData.time_of_day_smooth, 1.0f);
 
 	float timeoftheday = fmod(getWickedTimeOfDay(in_timeofday) + 0.75f, 0.5f) + 0.25f;

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "environment.h"
 #include "constants.h"
 #include "settings.h"
+#include "lighting.h"
 #include <list>
 
 class Client;
@@ -158,6 +159,8 @@ public:
 		added_velocity += vel;
 	}
 
+	inline Lighting& getLighting() { return m_lighting; }
+
 private:
 	void accelerate(const v3f &target_speed, const f32 max_increase_H,
 		const f32 max_increase_V, const bool use_pitch);
@@ -209,4 +212,5 @@ private:
 
 	GenericCAO *m_cao = nullptr;
 	Client *m_client;
+	Lighting m_lighting;
 };

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include <cstring>
+#include <cmath>
 #include "client/shadows/dynamicshadowsrender.h"
 #include "client/shadows/shadowsScreenQuad.h"
 #include "client/shadows/shadowsshadercallbacks.h"

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -36,7 +36,10 @@ ShadowRenderer::ShadowRenderer(IrrlichtDevice *device, Client *client) :
 	m_shadows_supported = true; // assume shadows supported. We will check actual support in initialize
 	m_shadows_enabled = true;
 
-	m_shadow_strength = g_settings->getFloat("shadow_strength");
+	m_shadow_strength_gamma = g_settings->getFloat("shadow_strength_gamma");
+	if (std::isnan(m_shadow_strength_gamma))
+		m_shadow_strength_gamma = 1.0f;
+	m_shadow_strength_gamma = core::clamp(m_shadow_strength_gamma, 0.1f, 10.0f);
 
 	m_shadow_map_max_distance = g_settings->getFloat("shadow_map_max_distance");
 
@@ -142,7 +145,7 @@ f32 ShadowRenderer::getMaxShadowFar() const
 
 void ShadowRenderer::setShadowIntensity(float shadow_intensity)
 {
-	m_shadow_strength = shadow_intensity * g_settings->getFloat("shadow_strength");
+	m_shadow_strength = pow(shadow_intensity, 1.0f / m_shadow_strength_gamma);
 	if (m_shadow_strength > 1E-2)
 		enable();
 	else

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -82,11 +82,12 @@ public:
 	}
 
 
-	bool is_active() const { return m_shadows_enabled; }
+	bool is_active() const { return m_shadows_enabled && shadowMapTextureFinal != nullptr; }
 	void setTimeOfDay(float isDay) { m_time_day = isDay; };
+	void setShadowIntensity(float shadow_intensity);
 
 	s32 getShadowSamples() const { return m_shadow_samples; }
-	float getShadowStrength() const { return m_shadow_strength; }
+	float getShadowStrength() const { return m_shadows_enabled ? m_shadow_strength : 0.0f; }
 	float getTimeOfDay() const { return m_time_day; }
 
 private:
@@ -100,6 +101,9 @@ private:
 	void renderShadowObjects(video::ITexture *target, DirectionalLight &light);
 	void mixShadowsQuad();
 	void updateSMTextures();
+
+	void disable();
+	void enable() { m_shadows_enabled = m_shadows_supported; }
 
 	// a bunch of variables
 	IrrlichtDevice *m_device{nullptr};
@@ -122,6 +126,7 @@ private:
 	int m_shadow_samples;
 	bool m_shadow_map_texture_32bit;
 	bool m_shadows_enabled;
+	bool m_shadows_supported;
 	bool m_shadow_map_colored;
 	u8 m_map_shadow_update_frames; /* Use this number of frames to update map shaodw */
 	u8 m_current_frame{0}; /* Current frame */

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -120,6 +120,7 @@ private:
 	std::vector<NodeToApply> m_shadow_node_array;
 
 	float m_shadow_strength;
+	float m_shadow_strength_gamma;
 	float m_shadow_map_max_distance;
 	float m_shadow_map_texture_size;
 	float m_time_day{0.0f};

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -65,6 +65,7 @@ public:
 	}
 
 	void setSunVisible(bool sun_visible) { m_sun_params.visible = sun_visible; }
+	bool getSunVisible() const { return m_sun_params.visible; }
 	void setSunTexture(const std::string &sun_texture,
 		const std::string &sun_tonemap, ITextureSource *tsrc);
 	void setSunScale(f32 sun_scale) { m_sun_params.scale = sun_scale; }
@@ -72,6 +73,7 @@ public:
 	void setSunriseTexture(const std::string &sunglow_texture, ITextureSource* tsrc);
 
 	void setMoonVisible(bool moon_visible) { m_moon_params.visible = moon_visible; }
+	bool getMoonVisible() const { return m_moon_params.visible; }
 	void setMoonTexture(const std::string &moon_texture,
 		const std::string &moon_tonemap, ITextureSource *tsrc);
 	void setMoonScale(f32 moon_scale) { m_moon_params.scale = moon_scale; }

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -266,7 +266,7 @@ void set_default_settings()
 
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");
-	settings->setDefault("shadow_strength", "0.2");
+	settings->setDefault("shadow_strength_gamma", "1.0");
 	settings->setDefault("shadow_map_max_distance", "200.0");
 	settings->setDefault("shadow_map_texture_size", "2048");
 	settings->setDefault("shadow_map_texture_32bit", "true");

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -23,5 +23,5 @@ with this program; if not, write to the Free Software Foundation, Inc.,
  */
 struct Lighting
 {
-    float shadow_intensity {1.0f};
+    float shadow_intensity {0.0f};
 };

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -23,4 +23,5 @@ with this program; if not, write to the Free Software Foundation, Inc.,
  */
 struct Lighting
 {
+    float shadow_intensity {1.0f};
 };

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -1,0 +1,26 @@
+/*
+Minetest
+Copyright (C) 2021 x2048, Dmitry Kostenko <codeforsmile@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+/** Describes ambient light settings for a player
+ */
+struct Lighting
+{
+};

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -123,6 +123,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_SRP_BYTES_S_B",            TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_SrpBytesSandB }, // 0x60
 	{ "TOCLIENT_FORMSPEC_PREPEND",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FormspecPrepend }, // 0x61,
 	{ "TOCLIENT_MINIMAP_MODES",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MinimapModes }, // 0x62,
+	{ "TOCLIENT_SET_LIGHTING",        TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SetLighting }, // 0x63,
 };
 
 const static ServerCommandFactory null_command_factory = { "TOSERVER_NULL", 0, false };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1682,3 +1682,7 @@ void Client::handleCommand_MinimapModes(NetworkPacket *pkt)
 	if (m_minimap)
 		m_minimap->setModeIndex(mode);
 }
+
+void Client::handleCommand_SetLighting(NetworkPacket *pkt)
+{
+}

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1685,4 +1685,8 @@ void Client::handleCommand_MinimapModes(NetworkPacket *pkt)
 
 void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 {
+	Lighting& lighting = m_env.getLocalPlayer()->getLighting();
+
+	if (pkt->getRemainingBytes() >= 4)
+		*pkt >> lighting.shadow_intensity;
 }

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -764,6 +764,7 @@ enum ToClientCommand
 
 	TOCLIENT_SET_LIGHTING = 0x63,
 	/*
+		f32 shadow_intensity
 	*/
 
 	TOCLIENT_NUM_MSG_TYPES = 0x64,

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -762,7 +762,11 @@ enum ToClientCommand
 			std::string extra
 	*/
 
-	TOCLIENT_NUM_MSG_TYPES = 0x63,
+	TOCLIENT_SET_LIGHTING = 0x63,
+	/*
+	*/
+
+	TOCLIENT_NUM_MSG_TYPES = 0x64,
 };
 
 enum ToServerCommand

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "player.h"
 #include "skyparams.h"
+#include "lighting.h"
 
 class PlayerSAO;
 
@@ -125,6 +126,10 @@ public:
 		*frame_speed = local_animation_speed;
 	}
 
+	void setLighting(const Lighting &lighting) { m_lighting = lighting; }
+
+	const Lighting& getLighting() const { return m_lighting; }
+
 	void setDirty(bool dirty) { m_dirty = true; }
 
 	u16 protocol_version = 0;
@@ -159,6 +164,8 @@ private:
 	SunParams m_sun_params;
 	MoonParams m_moon_params;
 	StarParams m_star_params;
+
+	Lighting m_lighting;
 
 	session_t m_peer_id = PEER_ID_INEXISTENT;
 };

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2295,6 +2295,38 @@ int ObjectRef::l_set_minimap_modes(lua_State *L)
 	return 0;
 }
 
+// set_lighting(self, lighting)
+int ObjectRef::l_set_lighting(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (player == nullptr)
+		return 0;
+
+	luaL_checktype(L, 2, LUA_TTABLE);
+	Lighting lighting = player->getLighting();
+
+	getServer(L)->setLighting(player, lighting);
+	lua_pushboolean(L, true);
+	return 1;
+}
+
+// get_lighting(self)
+int ObjectRef::l_get_lighting(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (player == nullptr)
+		return 0;
+
+	const Lighting &lighting = player->getLighting();
+
+	lua_newtable(L);
+	return 1;
+}
+
 ObjectRef::ObjectRef(ServerActiveObject *object):
 	m_object(object)
 {}
@@ -2448,5 +2480,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_eye_offset),
 	luamethod(ObjectRef, send_mapblock),
 	luamethod(ObjectRef, set_minimap_modes),
+	luamethod(ObjectRef, set_lighting),
+	luamethod(ObjectRef, get_lighting),
 	{0,0}
 };

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2306,8 +2306,11 @@ int ObjectRef::l_set_lighting(lua_State *L)
 
 	luaL_checktype(L, 2, LUA_TTABLE);
 	Lighting lighting = player->getLighting();
-
-	lighting.shadow_intensity = getfloatfield_default(L, 2, "shadow_intensity",    lighting.shadow_intensity);
+	lua_getfield(L, 2, "shadows");
+	if (lua_istable(L, -1)) {
+		lighting.shadow_intensity = getfloatfield_default(L, -1, "intensity",    lighting.shadow_intensity);
+	}
+	lua_pop(L, -1);
 
 	getServer(L)->setLighting(player, lighting);
 	lua_pushboolean(L, true);
@@ -2325,9 +2328,11 @@ int ObjectRef::l_get_lighting(lua_State *L)
 
 	const Lighting &lighting = player->getLighting();
 
-	lua_newtable(L);
+	lua_newtable(L); // result
+	lua_newtable(L); // "shadows"
 	lua_pushnumber(L, lighting.shadow_intensity);
-	lua_setfield(L, -2, "shadow_intensity");
+	lua_setfield(L, -2, "intensity");
+	lua_setfield(L, -2, "shadows");
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2307,6 +2307,8 @@ int ObjectRef::l_set_lighting(lua_State *L)
 	luaL_checktype(L, 2, LUA_TTABLE);
 	Lighting lighting = player->getLighting();
 
+	lighting.shadow_intensity = getfloatfield_default(L, 2, "shadow_intensity",    lighting.shadow_intensity);
+
 	getServer(L)->setLighting(player, lighting);
 	lua_pushboolean(L, true);
 	return 1;
@@ -2324,6 +2326,8 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	const Lighting &lighting = player->getLighting();
 
 	lua_newtable(L);
+	lua_pushnumber(L, lighting.shadow_intensity);
+	lua_setfield(L, -2, "shadow_intensity");
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -376,4 +376,10 @@ private:
 
 	// set_minimap_modes(self, modes, wanted_mode)
 	static int l_set_minimap_modes(lua_State *L);
+
+	// set_lighting(self, lighting)
+	static int l_set_lighting(lua_State *L);
+	
+	// get_lighting(self)
+	static int l_get_lighting(lua_State *L);
 };

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1798,7 +1798,9 @@ void Server::SendOverrideDayNightRatio(session_t peer_id, bool do_override,
 void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 {
 	NetworkPacket pkt(TOCLIENT_SET_LIGHTING,
-			0, peer_id);
+			4, peer_id);
+	
+	pkt << lighting.shadow_intensity;
 
 	Send(&pkt);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1795,6 +1795,14 @@ void Server::SendOverrideDayNightRatio(session_t peer_id, bool do_override,
 	Send(&pkt);
 }
 
+void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
+{
+	NetworkPacket pkt(TOCLIENT_SET_LIGHTING,
+			0, peer_id);
+
+	Send(&pkt);
+}
+
 void Server::SendTimeOfDay(session_t peer_id, u16 time, f32 time_speed)
 {
 	NetworkPacket pkt(TOCLIENT_TIME_OF_DAY, 0, peer_id);
@@ -3384,6 +3392,13 @@ void Server::overrideDayNightRatio(RemotePlayer *player, bool do_override,
 	sanity_check(player);
 	player->overrideDayNightRatio(do_override, ratio);
 	SendOverrideDayNightRatio(player->getPeerId(), do_override, ratio);
+}
+
+void Server::setLighting(RemotePlayer *player, const Lighting &lighting)
+{
+	sanity_check(player);
+	player->setLighting(lighting);
+	SendSetLighting(player->getPeerId(), lighting);
 }
 
 void Server::notifyPlayers(const std::wstring &msg)

--- a/src/server.h
+++ b/src/server.h
@@ -69,6 +69,7 @@ struct SkyboxParams;
 struct SunParams;
 struct MoonParams;
 struct StarParams;
+struct Lighting;
 class ServerThread;
 class ServerModManager;
 class ServerInventoryManager;
@@ -333,6 +334,8 @@ public:
 
 	void overrideDayNightRatio(RemotePlayer *player, bool do_override, float brightness);
 
+	void setLighting(RemotePlayer *player, const Lighting &lighting);
+
 	/* con::PeerHandler implementation. */
 	void peerAdded(con::Peer *peer);
 	void deletingPeer(con::Peer *peer, bool timeout);
@@ -459,6 +462,7 @@ private:
 	void SendSetStars(session_t peer_id, const StarParams &params);
 	void SendCloudParams(session_t peer_id, const CloudParams &params);
 	void SendOverrideDayNightRatio(session_t peer_id, bool do_override, float ratio);
+	void SendSetLighting(session_t peer_id, const Lighting &lighting);
 	void broadcastModChannelMessage(const std::string &channel,
 			const std::string &message, session_t from_peer);
 


### PR DESCRIPTION
This is a proposal to fix #11365 and #11972.

## Specification

*Lua API*

A game should be able to control intensity of ambient shadows as part of a new set_lighting() API call
```
   local player = core.get_player_by_name("singleplayer")
   player:set_lighting( { shadows = { intensity = 0.5 } } )
```

set_lighting() API call will also be used for ambient brightness (#11499) and saturation (#11854). A matching get_lighting() API call will be used to retrieve the current values of the lighting and shadows parameters.

*Network*
set_lighting call translates into a new TOCLIENT_SET_LIGHTING network packet containing parameters packed one after another.

*Client*

Introduce new setting `shadow_intensity_gamma` to control the visual darkness of shadow intensity values to accommodate for differences between computer screens.

The formula is: actual_intensity = (input_intensity) * (1 / shadow_intensity_gamma).

When actual_intensity is zero:
* Stop generating shadow mapping textures
* Disable shadow mapping code in the shaders.

## To do

This PR is Ready for Review.

Follow-up tasks:
- [x] Slight change to the Lua API, [this](https://irc.minetest.net/minetest-dev/2022-01-22#i_5926013)

## How to test

* Enable dynamic shadows
* Tune `shadow_strength_gamma` parameter
* Launch a devtest world
* `/set_lighting 0` - shadows disappear, and FPS goes up
* `/set_lighting 0.5` - shadows appear at half intensity
* `/set_lighting 1` - shadows appear at full intensity (black)

Check `games/devtest/mods/experimental/lighting.lua` for the example code.

## Note

Deleting and recreating the SM textures at runtime causes irrlicht errors and an eventual crash, won't fix in this PR.

Edit: spelling, add a todo