### PR TITLE
Proposal: Limit availability of dynamic shadows in 5.5.0

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -219,8 +219,9 @@ local function formspec(tabview, name, tabdata)
 					.. dump(core.settings:get_bool("enable_waving_leaves")) .. "]" ..
 			"checkbox[8.25,2;cb_waving_plants;" .. fgettext("Waving Plants") .. ";"
 					.. dump(core.settings:get_bool("enable_waving_plants")) .. "]"..
-			"label[8.25,3.0;" .. fgettext("Dynamic shadows: ") .. "]" ..
-			"dropdown[8.25,3.5;3.5;dd_shadows;" .. dd_options.shadow_levels[1] .. ";"
+			"label[8.25,2.7;" .. fgettext("Dynamic shadows:") .. "]" ..
+			"label[8.25,3;" .. fgettext("(when supported by the game)") .. "]" ..
+					"dropdown[8.25,3.5;3.5;dd_shadows;" .. dd_options.shadow_levels[1] .. ";"
 					.. getSettingIndex.ShadowMapping() .. "]"
 	else
 		tab_string = tab_string ..

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -588,7 +588,7 @@ enable_waving_plants (Waving plants) bool false
 
 [***Dynamic shadows]
 
-#    Set to true to enable Shadow Mapping.
+#    Set to true to enable dynamic shadows for local games that declare support.
 #    Requires shaders to be enabled.
 enable_dynamic_shadows (Dynamic shadows) bool false
 

--- a/games/devtest/game.conf
+++ b/games/devtest/game.conf
@@ -1,2 +1,3 @@
 name = Development Test
 description = Testing environment to help with testing the engine features of Minetest. It can also be helpful in mod development.
+supports_dynamic_shadows = true

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1046,6 +1046,9 @@ bool Game::startup(bool *kill,
 
 	m_rendering_engine->initialize(client, hud);
 
+	if (start_data.game_spec.supports_dynamic_shadows)
+		m_rendering_engine->initializeShadows();
+
 	return true;
 }
 

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -35,10 +35,6 @@ RenderingCore::RenderingCore(IrrlichtDevice *_device, Client *_client, Hud *_hud
 	screensize = driver->getScreenSize();
 	virtual_size = screensize;
 
-	if (g_settings->getBool("enable_shaders") &&
-			g_settings->getBool("enable_dynamic_shadows")) {
-		shadow_renderer = new ShadowRenderer(device, client);
-	}
 }
 
 RenderingCore::~RenderingCore()
@@ -51,8 +47,16 @@ void RenderingCore::initialize()
 {
 	// have to be called late as the VMT is not ready in the constructor:
 	initTextures();
-	if (shadow_renderer)
+}
+
+void RenderingCore::initializeShadows()
+{
+	if (shadow_renderer == nullptr &&
+			g_settings->getBool("enable_shaders") &&
+			g_settings->getBool("enable_dynamic_shadows")) {
+		shadow_renderer = new ShadowRenderer(device, client);
 		shadow_renderer->initialize();
+	}
 }
 
 void RenderingCore::updateScreenSize()

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -71,6 +71,7 @@ public:
 	RenderingCore &operator=(RenderingCore &&) = delete;
 
 	void initialize();
+	void initializeShadows();
 	void draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
 			bool _draw_wield_tool, bool _draw_crosshair);
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -543,6 +543,12 @@ void RenderingEngine::initialize(Client *client, Hud *hud)
 	core->initialize();
 }
 
+void RenderingEngine::initializeShadows()
+{
+	if (core)
+		core->initializeShadows();
+}
+
 void RenderingEngine::finalize()
 {
 	core.reset();

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -113,6 +113,7 @@ public:
 			bool show_minimap, bool draw_wield_tool, bool draw_crosshair);
 
 	void initialize(Client *client, Hud *hud);
+	void initializeShadows();
 	void finalize();
 
 	bool run()

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -141,8 +141,12 @@ SubgameSpec findSubgame(const std::string &id)
 	menuicon_path = getImagePath(
 			game_path + DIR_DELIM + "menu" + DIR_DELIM + "icon.png");
 #endif
+	bool supports_dynamic_shadows = false;
+	if (conf.exists("supports_dynamic_shadows"))
+		supports_dynamic_shadows = conf.getBool("supports_dynamic_shadows");
+
 	return SubgameSpec(id, game_path, gamemod_path, mods_paths, game_name,
-			menuicon_path, game_author, game_release);
+			menuicon_path, game_author, game_release, supports_dynamic_shadows);
 }
 
 SubgameSpec findWorldSubgame(const std::string &world_path)

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -35,6 +35,7 @@ struct SubgameSpec
 	std::string gamemods_path;
 	std::set<std::string> addon_mods_paths;
 	std::string menuicon_path;
+	bool supports_dynamic_shadows;
 
 	SubgameSpec(const std::string &id = "", const std::string &path = "",
 			const std::string &gamemods_path = "",
@@ -42,11 +43,11 @@ struct SubgameSpec
 					std::set<std::string>(),
 			const std::string &name = "",
 			const std::string &menuicon_path = "",
-			const std::string &author = "", int release = 0) :
+			const std::string &author = "", int release = 0, bool supports_dynamic_shadows = false) :
 			id(id),
 			name(name), author(author), release(release), path(path),
 			gamemods_path(gamemods_path), addon_mods_paths(addon_mods_paths),
-			menuicon_path(menuicon_path)
+			menuicon_path(menuicon_path), supports_dynamic_shadows(supports_dynamic_shadows)
 	{
 	}
 


### PR DESCRIPTION
Fixes #11365 for 5.5.0 by allowing dynamic shadows only for local games where game.conf contains the following setting:
```
supports_dynamic_shadows = true
```

Dynamic shadows for remote server connections are always disabled. Work on server-side API to control dynamic shadows is in #11944. When it is merged, the games/servers will be able to opt-in using Lua API, and game.conf option will be deprecated.

## To do

This PR is Ready for Review.

## How to test

* Enable dynamic shadows in your client
* Start devtest game - dynamic shadows are rendered
* Start NodeCore game - dynamic shadows are not rendered, and FPS is higher
* Connect to a server - dynamic shadows are not rendered.


