### PR TITLE
Give the ASCII console splash a facelift

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -512,7 +512,7 @@ void Server::start()
 
 	// ASCII art for the win!
 	std::cerr
-		<< "        .__                __.                 __.  " << std::endl
+		<< "         __.               __.                 __.  " << std::endl
 		<< "  _____ |__| ____   _____ /  |_  _____  _____ /  |_ " << std::endl
 		<< " /     \\|  |/    \\ /  __ \\    _\\/  __ \\/   __>    _\\" << std::endl
 		<< "|  Y Y  \\  |   |  \\   ___/|  | |   ___/\\___  \\|  |  " << std::endl

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -512,12 +512,12 @@ void Server::start()
 
 	// ASCII art for the win!
 	std::cerr
-		<< "        .__               __                   __   " << std::endl
-		<< "  _____ |__| ____   _____/  |_  ____   _______/  |_ " << std::endl
-		<< " /     \\|  |/    \\_/ __ \\   __\\/ __ \\ /  ___/\\   __\\" << std::endl
-		<< "|  Y Y  \\  |   |  \\  ___/|  | \\  ___/ \\___ \\  |  |  " << std::endl
-		<< "|__|_|  /__|___|  /\\___  >__|  \\___  >____  > |__|  " << std::endl
-		<< "      \\/        \\/     \\/          \\/     \\/        " << std::endl;
+		<< "        .__                __.                 __.  " << std::endl
+		<< "  _____ |__| ____   _____ /  |_  _____  _____ /  |_ " << std::endl
+		<< " /     \\|  |/    \\ /  __ \\    _\\/  __ \\/   __>    _\\" << std::endl
+		<< "|  Y Y  \\  |   |  \\   ___/|  | |   ___/\\___  \\|  |  " << std::endl
+		<< "|__|_|  /  |___|  /\\______>  |  \\______>_____/|  |  " << std::endl
+		<< "      \\/ \\/     \\/         \\/                  \\/   " << std::endl;
 	actionstream << "World at [" << m_path_world << "]" << std::endl;
 	actionstream << "Server for gameid=\"" << m_gamespec.id
 			<< "\" listening on ";


### PR DESCRIPTION
The current console splash is super inconsistent and messy.  
Top: Old; Bottom: New
![image](https://user-images.githubusercontent.com/24834740/149426851-5d96af19-6880-4c9b-b754-1910d3f0750b.png)

Changes:
* Make letters consistently thicc
* Give `t`s a corner-dot (right side for balance)
* Add drips (`\/`) to vertical parts (`i` and `t`s)
* Remove drips from not-vertical parts (`e`s and `s`)
* Move the `s` stinger (`>`) to the correct place
* Make the `t`s crosses not cut into them
* Fix `e` shapes (remove side `_` on first, fix middle `\` on second)