### PR TITLE
Add minetest.generate_biomes

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4365,10 +4365,10 @@ Mapgen objects
 ==============
 
 A mapgen object is a construct used in map generation. Mapgen objects can be
-used by an `on_generate` callback to speed up operations by avoiding
+used by an `on_generated()` callback to speed up operations by avoiding
 unnecessary recalculations, these can be retrieved using the
 `minetest.get_mapgen_object()` function. If the requested Mapgen object is
-unavailable, or `get_mapgen_object()` was called outside of an `on_generate()`
+unavailable, or `get_mapgen_object()` was called outside of an `on_generated()`
 callback, `nil` is returned.
 
 The following Mapgen objects are currently available:
@@ -5323,6 +5323,21 @@ Environment access
     * Generate all registered decorations within the VoxelManip `vm` and in the
       area from `pos1` to `pos2`.
     * `pos1` and `pos2` are optional and default to mapchunk minp and maxp.
+* `minetest.generate_biomes(vm, pos1, pos2[, noise_filler_depth])`
+    * Generate biome nodes according to the registered biomes and
+      temperature/humidity noises within the VoxelManip `vm` and in the area
+      from `pos1` to `pos2`.
+    * `noise_filler_depth` is an optional `PerlinNoiseMap` to add an offset to
+      the `depth_filler` of the biomes (see [Biome definition]). It is
+      recommended as it avoids creating a new `PerlinNoiseMap` internally for
+      every chunk. By default, the default noise for mgv7 is used.
+    * Must be called during mapgen (`on_generated()` callback)
+    * `pos1` and `pos2` should have the same X and Z size than mapgen chunks.
+    * The initial data in `vm` may only contain air, stone, water and
+      river water nodes (see [Essential aliases]). Other nodes are ignored.
+    * Also populates the mapgen objects `heatmap`, `humiditymap` and `biomemap`
+      (see [Mapgen objects]), so that `minetest.generate_decorations` and
+      `minetest.register_ores` will take them into account.
 * `minetest.clear_objects([options])`
     * Clear all objects in the environment
     * Takes an optional table as an argument with the field `mode`.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5328,16 +5328,14 @@ Environment access
       temperature/humidity noises within the VoxelManip `vm` and in the area
       from `pos1` to `pos2`.
     * `noise_filler_depth` is an optional `PerlinNoiseMap` to add an offset to
-      the `depth_filler` of the biomes (see [Biome definition]). It is
-      recommended as it avoids creating a new `PerlinNoiseMap` internally for
-      every chunk. By default, the default noise for mgv7 is used.
+      the `depth_filler` of the biomes (see [Biome definition]).
     * Must be called during mapgen (`on_generated()` callback)
     * `pos1` and `pos2` should have the same X and Z size than mapgen chunks.
     * The initial data in `vm` may only contain air, stone, water and
       river water nodes (see [Essential aliases]). Other nodes are ignored.
     * Also populates the mapgen objects `heatmap`, `humiditymap` and `biomemap`
       (see [Mapgen objects]), so that `minetest.generate_decorations` and
-      `minetest.register_ores` will take them into account.
+      `minetest.generate_ores` will take them into account.
 * `minetest.clear_objects([options])`
     * Clear all objects in the environment
     * Takes an optional table as an argument with the field `mode`.

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -651,7 +651,8 @@ void MapgenBasic::generateBiomes()
 	const v3s16 &em = vm->m_area.getExtent();
 	u32 index = 0;
 
-	noise_filler_depth->perlinMap2D(node_min.X, node_min.Z);
+	if (noise_filler_depth)
+		noise_filler_depth->perlinMap2D(node_min.X, node_min.Z);
 
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, index++) {
@@ -706,8 +707,8 @@ void MapgenBasic::generateBiomes()
 
 				depth_top = biome->depth_top;
 				base_filler = MYMAX(depth_top +
-					biome->depth_filler +
-					noise_filler_depth->result[index], 0.0f);
+					biome->depth_filler + (noise_filler_depth ?
+					noise_filler_depth->result[index] : 0.0f), 0.0f);
 				depth_water_top = biome->depth_water_top;
 				depth_riverbed = biome->depth_riverbed;
 				biome_y_min = biome->min_pos.Y;

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -623,15 +623,6 @@ MapgenBasic::MapgenBasic(int mapgenid, MapgenParams *params, EmergeParams *emerg
 }
 
 
-MapgenBasic::MapgenBasic(const NodeDefManager *ndef_p) : Mapgen() {
-	ndef = ndef_p;
-
-	c_stone              = ndef_p->getId("mapgen_stone");
-	c_water_source       = ndef_p->getId("mapgen_water_source");
-	c_river_water_source = ndef_p->getId("mapgen_river_water_source");
-}
-
-
 MapgenBasic::~MapgenBasic()
 {
 	if (heightmap)
@@ -777,15 +768,6 @@ void MapgenBasic::generateBiomes()
  		if (biomemap[index] == BIOME_NONE && water_biome_index != 0)
 			biomemap[index] = water_biome_index;
 	}
-}
-
-
-void MapgenBasic::generateBiomes(v3s16 pmin, v3s16 pmax)
-{
-	node_min = pmin;
-	node_max = pmax;
-
-	generateBiomes();
 }
 
 

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -252,7 +252,7 @@ public:
 	virtual bool generateCavernsNoise(s16 max_stone_y);
 	virtual void generateDungeons(s16 max_stone_y);
 
-	Noise *noise_filler_depth;
+	Noise *noise_filler_depth = nullptr;
 
 protected:
 	EmergeParams *m_emerge = nullptr;

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -239,24 +239,24 @@ private:
 	inheriting MapgenBasic.
 */
 class MapgenBasic : public Mapgen {
+	friend class ModApiMapgen;
 public:
-	MapgenBasic(const NodeDefManager *ndef_p);
+	MapgenBasic() = default;
 	MapgenBasic(int mapgenid, MapgenParams *params, EmergeParams *emerge);
 	virtual ~MapgenBasic();
 
 	virtual void generateBiomes();
-	virtual void generateBiomes(v3s16 pmin, v3s16 pmax);
 	virtual void dustTopNodes();
 	virtual void generateCavesNoiseIntersection(s16 max_stone_y);
 	virtual void generateCavesRandomWalk(s16 max_stone_y, s16 large_cave_ymax);
 	virtual bool generateCavernsNoise(s16 max_stone_y);
 	virtual void generateDungeons(s16 max_stone_y);
 
-	Noise *noise_filler_depth = nullptr;
-
 protected:
 	EmergeParams *m_emerge = nullptr;
 	BiomeManager *m_bmgr;
+
+	Noise *noise_filler_depth = nullptr;
 
 	v3s16 node_min;
 	v3s16 node_max;

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -240,21 +240,23 @@ private:
 */
 class MapgenBasic : public Mapgen {
 public:
+	MapgenBasic(const NodeDefManager *ndef_p);
 	MapgenBasic(int mapgenid, MapgenParams *params, EmergeParams *emerge);
 	virtual ~MapgenBasic();
 
 	virtual void generateBiomes();
+	virtual void generateBiomes(v3s16 pmin, v3s16 pmax);
 	virtual void dustTopNodes();
 	virtual void generateCavesNoiseIntersection(s16 max_stone_y);
 	virtual void generateCavesRandomWalk(s16 max_stone_y, s16 large_cave_ymax);
 	virtual bool generateCavernsNoise(s16 max_stone_y);
 	virtual void generateDungeons(s16 max_stone_y);
 
-protected:
-	EmergeParams *m_emerge;
-	BiomeManager *m_bmgr;
-
 	Noise *noise_filler_depth;
+
+protected:
+	EmergeParams *m_emerge = nullptr;
+	BiomeManager *m_bmgr;
 
 	v3s16 node_min;
 	v3s16 node_max;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_mapgen.h"
 #include "lua_api/l_internal.h"
 #include "lua_api/l_vmanip.h"
+#include "lua_api/l_noise.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include "cpp_api/s_security.h"
@@ -27,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server.h"
 #include "environment.h"
 #include "emerge.h"
+#include "noise.h"
 #include "mapgen/mg_biome.h"
 #include "mapgen/mg_ore.h"
 #include "mapgen/mg_decoration.h"
@@ -1432,6 +1434,10 @@ int ModApiMapgen::l_generate_ores(lua_State *L)
 	mg.vm   = LuaVoxelManip::checkobject(L, 1)->vm;
 	mg.ndef = getServer(L)->getNodeDefManager();
 
+	Mapgen *mg_current = emerge->getCurrentMapgen();
+	if (mg_current)
+		mg.biomemap = mg_current->biomegen->biomemap;
+
 	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
 			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
 	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
@@ -1461,6 +1467,10 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 	mg.vm   = LuaVoxelManip::checkobject(L, 1)->vm;
 	mg.ndef = getServer(L)->getNodeDefManager();
 
+	Mapgen *mg_current = emerge->getCurrentMapgen();
+	if (mg_current)
+		mg.biomemap = mg_current->biomegen->biomemap;
+
 	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
 			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
 	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
@@ -1470,6 +1480,65 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 	u32 blockseed = Mapgen::getBlockSeed(pmin, mg.seed);
 
 	emerge->decomgr->placeAllDecos(&mg, blockseed, pmin, pmax);
+
+	return 0;
+}
+
+
+// calc_biome_noise(p1)
+int ModApiMapgen::l_calc_biome_noise(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	EmergeManager *emerge = getServer(L)->getEmergeManager();
+	Mapgen *mg = emerge->getCurrentMapgen();
+	if (!mg)
+		return 0;
+
+	BiomeGen *biomegen = mg->biomegen;
+
+	if (!biomegen || biomegen->getType() != BIOMEGEN_ORIGINAL)
+		return 0;
+
+	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
+			mg->vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
+
+	biomegen->calcBiomeNoise(pmin);
+
+	return 0;
+}
+
+
+// generate_biomes(vm, p1, p2, [noise_filler_depth])
+int ModApiMapgen::l_generate_biomes(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	EmergeManager *emerge = getServer(L)->getEmergeManager();
+	if (!emerge)
+		return 0;
+
+	Mapgen *mg = emerge->getCurrentMapgen();
+
+	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
+
+	MapgenBasic mg_temp(ndef);
+
+	mg_temp.vm   = LuaVoxelManip::checkobject(L, 1)->vm;
+	mg_temp.ndef = getServer(L)->getNodeDefManager();
+	mg_temp.biomegen = mg->biomegen;
+	mg_temp.biomemap = mg->biomegen->biomemap;
+	mg_temp.water_level = 1;
+
+	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
+			mg->vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
+	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
+			mg->vm->m_area.MaxEdge - v3s16(1,1,1) * MAP_BLOCKSIZE;
+
+	LuaPerlinNoiseMap *nmap = LuaPerlinNoiseMap::checkobject(L, 4);
+	mg_temp.noise_filler_depth = nmap->noise;
+
+	mg_temp.generateBiomes(pmin, pmax);
 
 	return 0;
 }
@@ -1800,6 +1869,8 @@ void ModApiMapgen::Initialize(lua_State *L, int top)
 
 	API_FCT(generate_ores);
 	API_FCT(generate_decorations);
+	API_FCT(calc_biome_noise);
+	API_FCT(generate_biomes);
 	API_FCT(create_schematic);
 	API_FCT(place_schematic);
 	API_FCT(place_schematic_on_vmanip);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1510,7 +1510,7 @@ int ModApiMapgen::l_generate_biomes(lua_State *L)
 	mg.c_river_water_source = ndef->getId("mapgen_river_water_source");
 
 	mg.vm   = LuaVoxelManip::checkobject(L, 1)->vm;
-	mg.ndef = getServer(L)->getNodeDefManager();
+	mg.ndef = ndef;
 	mg.biomegen = mg_current->biomegen;
 	mg.biomemap = mg_current->biomegen->biomemap;
 	mg.water_level = mg_current->water_level;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1532,24 +1532,13 @@ int ModApiMapgen::l_generate_biomes(lua_State *L)
 		if ((s16)noise->sx == psize.X &&
 				(s16)noise->sz >= psize.Z) {
 			mg_temp.noise_filler_depth = noise;
-			mg_temp.generateBiomes(pmin, pmax);
 		} else {
 			warningstream << "generate_biomes: size of noisemap is inconsistent with chunk size,"
-					" a copy will be used" << std::endl;
-			Noise noise_temp(&noise->np, noise->seed,
-					psize.X, psize.Z);
-			mg_temp.noise_filler_depth = &noise_temp;
-			mg_temp.generateBiomes(pmin, pmax);
+					" noise will not be used" << std::endl;
 		}
-	} else {
-		warningstream << "generate_biomes: passing a PerlinNoiseMap is recommended" << std::endl;
-		const NoiseParams np_filler_depth(0.0, 1.2, v3f(150, 150, 150),
-				261, 3, 0.7, 2.0); // Copy from mgv7 default
-		Noise noise_temp(&np_filler_depth, mg->seed,
-				psize.X, psize.Z);
-		mg_temp.noise_filler_depth = &noise_temp;
-		mg_temp.generateBiomes(pmin, pmax);
 	}
+
+	mg_temp.generateBiomes(pmin, pmax);
 
 	return 0;
 }

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1503,7 +1503,11 @@ int ModApiMapgen::l_generate_biomes(lua_State *L)
 
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 
-	MapgenBasic mg(ndef);
+	MapgenBasic mg;
+
+	mg.c_stone              = ndef->getId("mapgen_stone");
+	mg.c_water_source       = ndef->getId("mapgen_water_source");
+	mg.c_river_water_source = ndef->getId("mapgen_river_water_source");
 
 	mg.vm   = LuaVoxelManip::checkobject(L, 1)->vm;
 	mg.ndef = getServer(L)->getNodeDefManager();
@@ -1530,16 +1534,16 @@ int ModApiMapgen::l_generate_biomes(lua_State *L)
 	if (lua_isuserdata(L, 4)) {
 		LuaPerlinNoiseMap *nmap = LuaPerlinNoiseMap::checkobject(L, 4);
 		Noise *noise = nmap->noise;
-		if ((s16)noise->sx == psize.X &&
-				(s16)noise->sz >= psize.Z) {
+		if ((s16)noise->sx == psize.X && (s16)noise->sz >= psize.Z)
 			mg.noise_filler_depth = noise;
-		} else {
+		else
 			warningstream << "generate_biomes: size of noisemap is inconsistent with chunk size,"
 					" noise will not be used" << std::endl;
-		}
 	}
 
-	mg.generateBiomes(pmin, pmax);
+	mg.node_min = pmin;
+	mg.node_max = pmax;
+	mg.generateBiomes();
 
 	return 0;
 }

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -116,9 +116,6 @@ private:
 	// generate_decorations(vm, p1, p2)
 	static int l_generate_decorations(lua_State *L);
 
-	// calc_biome_noise(p1)
-	static int l_calc_biome_noise(lua_State *L);
-
 	// generate_biomes(vm, p1, p2, [noise_filler_depth])
 	static int l_generate_biomes(lua_State *L);
 

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -116,6 +116,12 @@ private:
 	// generate_decorations(vm, p1, p2)
 	static int l_generate_decorations(lua_State *L);
 
+	// calc_biome_noise(p1)
+	static int l_calc_biome_noise(lua_State *L);
+
+	// generate_biomes(vm, p1, p2, [noise_filler_depth])
+	static int l_generate_biomes(lua_State *L);
+
 	// clear_registered_ores
 	static int l_clear_registered_ores(lua_State *L);
 

--- a/src/script/lua_api/l_noise.h
+++ b/src/script/lua_api/l_noise.h
@@ -59,6 +59,7 @@ public:
 */
 class LuaPerlinNoiseMap : public ModApiBase
 {
+	friend class ModApiMapgen;
 	NoiseParams np;
 	Noise *noise;
 	bool m_is3d;


### PR DESCRIPTION
## What it does

Implements #8329. Add function `minetest.generate_biomes(vm, pos1, pos2[, noise_filler_depth])` to generate biome nodes in the `VoxelManip` from Lua mapgen mods.

Also updates `heatmap`, `humiditymap` and `biomemap`, so that they can be reused by `minetest.generate_decorations`, `minetest.generate_ores` and `minetest.get_mapgen_object`.

My approach creates a temporary `MapgenBasic` object and calls `MapgenBasic::generateBiomes()`. The class definition is modified to allow such a usecase.

`minetest.generate_biomes` must be called during mapgen (`register_on_generated` callback), and the X/Z extent of `pos1`-`pos2` must match mapgen chunk size, for the buffers to work correctly. I have not found a way to overcome these limitations that would not lead to a much more complex code.

## Why is it interesting/needed?
- Easier to add biomes to Lua mapgens, a single line will replace a long and complex code to re-implement in Lua what already exists in the core (this latter has been done by several modders including me).
- Improves compatibility between Lua mapgens and mods that use the biome system (including biome-dependant decorations/ores). This is critical for a Lua mapgen mod to be interesting for players and server owners. Otherwise it stays an experimental thing that is rarely going to be really used.
- EDIT: Speeds up biome generation compared to Lua-reimplemented biomes (gain is in the range of 50-100 ms). This is also critical for Lua mapgens.

## To do

I consider this PR as Ready for Review.

I initially planned to include a function to generate dust nodes but this may come in a separate PR, this one is already interesting in itself.

## How to test

I have made a [modified version of Paramat's `lvm_example`](https://github.com/Gael-de-Sailly/lvm_example/tree/use_core_biomegen) for testing. It generates very simple terrain, with biomes, ores and decorations. You can append other biome mods like Ethereal to see how it reacts.

![screenshot_20220114_130702](https://user-images.githubusercontent.com/6905002/149513210-e27969c9-2e75-422f-a081-571bcc315204.png)
^ This PR + lvm_example + Ethereal NG