### PR TITLE
Update and improve warnings when no games are found or when only devtest is installed

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -94,14 +94,14 @@ local mgv6_biomes = {
 
 local function create_world_formspec(dialogdata)
 
-	-- Error out when no games found
+	-- Point the player to ContentDB when no games are found
 	if #pkgmgr.games == 0 then
-		return "size[12.25,3,true]" ..
-			"box[0,0;12,2;" .. mt_color_orange .. "]" ..
-			"textarea[0.3,0;11.7,2;;;"..
-			fgettext("You have no games installed.") .. "\n" ..
-			fgettext("Download one from minetest.net") .. "]" ..
-			"button[4.75,2.5;3,0.5;world_create_cancel;" .. fgettext("Cancel") .. "]"
+		return "size[8,2.5,true]" ..
+			"style[label_button;border=false]" ..
+			"button[0.5,0.5;7,0.5;label_button;" ..
+			fgettext("You have no games installed.") .. "]" ..
+			"button[0.5,1.5;2.5,0.5;world_create_open_cdb;" .. fgettext("Install a game") .. "]" ..
+			"button[5.0,1.5;2.5,0.5;world_create_cancel;" .. fgettext("Cancel") .. "]"
 	end
 
 	local current_mg = dialogdata.mg
@@ -301,9 +301,9 @@ local function create_world_formspec(dialogdata)
 	local gamelist_height = 2.3
 	if #pkgmgr.games == 1 and pkgmgr.games[1].id == "devtest" then
 		devtest_only = "box[0,0;5.8,1.7;#ff8800]" ..
-				"textarea[0.3,0;6,1.8;;;"..
-				fgettext("Warning: The Development Test is meant for developers.") .. "\n" ..
-				fgettext("Download a game, such as Minetest Game, from minetest.net") .. "]"
+				"textarea[0.4,0.1;6,1.8;;;"..
+				fgettext("Development Test is meant for developers.") .. "]" ..
+				"button[1,1;4,0.5;world_create_open_cdb;" .. fgettext("Install another game") .. "]"
 		gamelist_height = 0.5
 	end
 
@@ -357,6 +357,14 @@ local function create_world_formspec(dialogdata)
 end
 
 local function create_world_buttonhandler(this, fields)
+
+	if fields["world_create_open_cdb"] then
+		local dlg = create_store_dlg("game")
+		dlg:set_parent(this)
+		this:hide()
+		dlg:show()
+		return true
+	end
 
 	if fields["world_create_confirm"] or
 		fields["key_enter"] then

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -360,8 +360,9 @@ local function create_world_buttonhandler(this, fields)
 
 	if fields["world_create_open_cdb"] then
 		local dlg = create_store_dlg("game")
-		dlg:set_parent(this)
-		this:hide()
+		dlg:set_parent(this.parent)
+		this:delete()
+		this.parent:hide()
 		dlg:show()
 		return true
 	end


### PR DESCRIPTION
This PR updates the warning messages that appear when either no game is installed or when only the Development Test game is found. Previously it would give an unclear message to "download one from minetest.net", but now it contains a button which takes you to ContentDB in-game where you can actually install a new game.

![image](https://user-images.githubusercontent.com/60856959/149571408-eeb6a887-dd06-45fa-8907-0c0e539d0ca9.png)

![image](https://user-images.githubusercontent.com/60856959/149571454-a5ad34dd-e814-4f16-b482-7e70495db1b1.png)

## To do
This PR is a Ready for Review.

## How to test
- Test with only Development Test installed and try to click on the "Install another game" button. It should take you to ContentDB where you can install a game.
- Test with no game installed at all and try to click on the "Install a game" button. It should take you to ContentDB where you can install a game.
- Test that the regular create world dialog still works like it should without any regressions.