### PR TITLE
Automatically migrate client mod storage

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -385,6 +385,9 @@ public:
 	bool registerModStorage(ModMetadata *meta) override;
 	void unregisterModStorage(const std::string &name) override;
 
+	// Migrates away old files-based mod storage if necessary
+	void migrateModStorage();
+
 	// The following set of functions is used by ClientMediaDownloader
 	// Insert a media file appropriately into the appropriate manager
 	bool loadMedia(const std::string &data, const std::string &filename,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1466,11 +1466,18 @@ bool Game::connectToServer(const GameStartData &start_data,
 		return false;
 	}
 
-	client = new Client(start_data.name.c_str(),
-			start_data.password, start_data.address,
-			*draw_control, texture_src, shader_src,
-			itemdef_manager, nodedef_manager, sound, eventmgr,
-			m_rendering_engine, connect_address.isIPv6(), m_game_ui.get());
+	try {
+		client = new Client(start_data.name.c_str(),
+				start_data.password, start_data.address,
+				*draw_control, texture_src, shader_src,
+				itemdef_manager, nodedef_manager, sound, eventmgr,
+				m_rendering_engine, connect_address.isIPv6(), m_game_ui.get());
+		client->migrateModStorage();
+	} catch (const BaseException &e) {
+		*error_message = fmtgettext("Error creating client: %s", e.what());
+		errorstream << *error_message << std::endl;
+		return false;
+	}
 
 	client->m_simple_singleplayer_mode = simple_singleplayer_mode;
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - This adds automatic migration from JSON-based client mod storage to SQLite3-based mod storage.
- How does the PR work?
  - In the `Client` constructor, the code checks if a `mod_storage` directory is present in the `client` directory. If so, the data is migrated to the new database. The old directory is then renamed to `mod_storage.bak`. If part of this procedure fails, an exception is thrown. This way, the procedure can be retried when the user next initiates it. Rerunning the procedure should not cause any other problems, even if its last failure occurred during renaming.
- Does it resolve any reported issue?
  - Fixes #11959

## To do

This PR is Ready for Review.

## How to test

First you need a client-side `mod_storage` directory with some contents. Enter a world then exit it again. Now inspect the contents of the new client-side `mod_storage.sqlite` database. The data previously stored in JSON files should be present in the database. The `mod_storage` directory should be renamed to `mod_storage.bak`.
