### PR TITLE
Reset override material in anaglyph

### DIFF
--- a/src/client/render/anaglyph.cpp
+++ b/src/client/render/anaglyph.cpp
@@ -30,6 +30,7 @@ void RenderingCoreAnaglyph::drawAll()
 void RenderingCoreAnaglyph::setupMaterial(int color_mask)
 {
 	video::SOverrideMaterial &mat = driver->getOverrideMaterial();
+	mat.reset();
 	mat.Material.ColorMask = color_mask;
 	mat.EnableFlags = video::EMF_COLOR_MASK;
 	mat.EnablePasses = scene::ESNRP_SKY_BOX | scene::ESNRP_SOLID |


### PR DESCRIPTION
Fixes #11437 

## To do

This PR is Ready for Review.

## How to test

* Enable 3d mode = anaglyph
* Put your red-blue glasses on
* Start a world
* Enjoy the 3d game - no black (or white) textures
