### PR TITLE
Make get_sky return a table

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -22,6 +22,7 @@ core.features = {
 	degrotate_240_steps = true,
 	abm_min_max_y = true,
 	dynamic_add_media_table = true,
+	get_sky_as_table = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6844,7 +6844,13 @@ object you are working with still exists.
         * `"plain"`: Uses 0 textures, `bgcolor` used
     * `clouds`: Boolean for whether clouds appear in front of `"skybox"` or
       `"plain"` custom skyboxes (default: `true`)
-* `get_sky()`: returns base_color, type, table of textures, clouds.
+* `get_sky(as_table):
+    * returns a table containing sky parameters as defined in
+    `set_sky(sky_parameters)`
+    * `as_table`: boolean to avoid calling the deprecated version
+* `get_sky()`:
+    * Deprecated. Use `get_sky(as_table)`
+    * returns base_color, type, table of textures, clouds.
 * `get_sky_color()`:
     * Deprecated: Use `get_sky(as_table)` instead
     * returns a table with the `sky_color` parameters as in `set_sky`.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6844,13 +6844,12 @@ object you are working with still exists.
         * `"plain"`: Uses 0 textures, `bgcolor` used
     * `clouds`: Boolean for whether clouds appear in front of `"skybox"` or
       `"plain"` custom skyboxes (default: `true`)
-* `get_sky(as_table):
-    * returns a table containing sky parameters as defined in
-    `set_sky(sky_parameters)`.
-    * `as_table`: boolean to avoid calling the deprecated version.
-* `get_sky()`:
-    * Deprecated. Use `get_sky(as_table)`.
-    * returns base_color, type, table of textures, clouds.
+* `get_sky(as_table)`:
+    * `as_table`: boolean that determines whether the deprecated version of this
+    function is being used.
+        * `true` returns a table containing sky parameters as defined in `set_sky(sky_parameters)`.
+        * Deprecated: `false` or `nil` returns base_color, type, table of textures,
+        clouds.
 * `get_sky_color()`:
     * Deprecated: Use `get_sky(as_table)` instead.
     * returns a table with the `sky_color` parameters as in `set_sky`.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4623,7 +4623,7 @@ Utilities
           abm_min_max_y = true,
           -- dynamic_add_media supports passing a table with options (5.5.0)
           dynamic_add_media_table = true,
-          -- allows get_sky to return a table instead of separate values (5.5.0)
+          -- allows get_sky to return a table instead of separate values (5.6.0)
           get_sky_as_table = true,
       }
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6845,8 +6845,9 @@ object you are working with still exists.
     * `clouds`: Boolean for whether clouds appear in front of `"skybox"` or
       `"plain"` custom skyboxes (default: `true`)
 * `get_sky()`: returns base_color, type, table of textures, clouds.
-* `get_sky_color()`: returns a table with the `sky_color` parameters as in
-    `set_sky`.
+* `get_sky_color()`:
+    * Deprecated: Use `get_sky(as_table)` instead
+    * returns a table with the `sky_color` parameters as in `set_sky`.
 * `set_sun(sun_parameters)`:
     * `sun_parameters` is a table with the following optional fields:
         * `visible`: Boolean for whether the sun is visible.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4623,6 +4623,8 @@ Utilities
           abm_min_max_y = true,
           -- dynamic_add_media supports passing a table with options (5.5.0)
           dynamic_add_media_table = true,
+          -- allows get_sky to return a table instead of separate values (5.5.0)
+          get_sky_as_table = true,
       }
 
 * `minetest.has_feature(arg)`: returns `boolean, missing_features`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6846,13 +6846,13 @@ object you are working with still exists.
       `"plain"` custom skyboxes (default: `true`)
 * `get_sky(as_table):
     * returns a table containing sky parameters as defined in
-    `set_sky(sky_parameters)`
-    * `as_table`: boolean to avoid calling the deprecated version
+    `set_sky(sky_parameters)`.
+    * `as_table`: boolean to avoid calling the deprecated version.
 * `get_sky()`:
-    * Deprecated. Use `get_sky(as_table)`
+    * Deprecated. Use `get_sky(as_table)`.
     * returns base_color, type, table of textures, clouds.
 * `get_sky_color()`:
-    * Deprecated: Use `get_sky(as_table)` instead
+    * Deprecated: Use `get_sky(as_table)` instead.
     * returns a table with the `sky_color` parameters as in `set_sky`.
 * `set_sun(sun_parameters)`:
     * `sun_parameters` is a table with the following optional fields:

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1886,53 +1886,10 @@ int ObjectRef::l_get_sky(lua_State *L)
 	if (player == nullptr)
 		return 0;
 
-	SkyboxParams skybox_params = player->getSkyParams();
+	const SkyboxParams &skybox_params = player->getSkyParams();
 
-	if (lua_isboolean(L, 2) && readParam<bool>(L, 2) == true) {
-		lua_newtable(L);
-		push_ARGB8(L, skybox_params.bgcolor);
-		lua_setfield(L, -2, "base_color");
-		lua_pushlstring(L, skybox_params.type.c_str(), skybox_params.type.size());
-		lua_setfield(L, -2, "type");
-
-		lua_newtable(L);
-		s16 i = 1;
-		for (const std::string &texture : skybox_params.textures) {
-			lua_pushlstring(L, texture.c_str(), texture.size());
-			lua_rawseti(L, -2, i++);
-		}
-		lua_setfield(L, -2, "textures");
-		lua_pushboolean(L, skybox_params.clouds);
-		lua_setfield(L, -2, "clouds");
-
-		lua_newtable(L);
-		if (skybox_params.type == "regular") {
-			push_ARGB8(L, skybox_params.sky_color.day_sky);
-			lua_setfield(L, -2, "day_sky");
-			push_ARGB8(L, skybox_params.sky_color.day_horizon);
-			lua_setfield(L, -2, "day_horizon");
-			push_ARGB8(L, skybox_params.sky_color.dawn_sky);
-			lua_setfield(L, -2, "dawn_sky");
-			push_ARGB8(L, skybox_params.sky_color.dawn_horizon);
-			lua_setfield(L, -2, "dawn_horizon");
-			push_ARGB8(L, skybox_params.sky_color.night_sky);
-			lua_setfield(L, -2, "night_sky");
-			push_ARGB8(L, skybox_params.sky_color.night_horizon);
-			lua_setfield(L, -2, "night_horizon");
-			push_ARGB8(L, skybox_params.sky_color.indoors);
-			lua_setfield(L, -2, "indoors");
-		}
-		push_ARGB8(L, skybox_params.fog_sun_tint);
-		lua_setfield(L, -2, "fog_sun_tint");
-		push_ARGB8(L, skybox_params.fog_moon_tint);
-		lua_setfield(L, -2, "fog_moon_tint");
-		lua_pushstring(L, skybox_params.fog_tint_type.c_str());
-		lua_setfield(L, -2, "fog_tint_type");
-		lua_setfield(L, -2, "sky_color");
-		return 1;
-
-	// deprecated version
-	} else {
+	// handle the deprecated version
+	if (!readParam<bool>(L, 2, false)) {
 		log_deprecated(L, "Deprecated call to get_sky, please check lua_api.txt");
 
 		push_ARGB8(L, skybox_params.bgcolor);
@@ -1947,6 +1904,48 @@ int ObjectRef::l_get_sky(lua_State *L)
 		lua_pushboolean(L, skybox_params.clouds);
 		return 4;
 	}
+
+	lua_newtable(L);
+	push_ARGB8(L, skybox_params.bgcolor);
+	lua_setfield(L, -2, "base_color");
+	lua_pushlstring(L, skybox_params.type.c_str(), skybox_params.type.size());
+	lua_setfield(L, -2, "type");
+
+	lua_newtable(L);
+	s16 i = 1;
+	for (const std::string &texture : skybox_params.textures) {
+		lua_pushlstring(L, texture.c_str(), texture.size());
+		lua_rawseti(L, -2, i++);
+	}
+	lua_setfield(L, -2, "textures");
+	lua_pushboolean(L, skybox_params.clouds);
+	lua_setfield(L, -2, "clouds");
+
+	lua_newtable(L);
+	if (skybox_params.type == "regular") {
+		push_ARGB8(L, skybox_params.sky_color.day_sky);
+		lua_setfield(L, -2, "day_sky");
+		push_ARGB8(L, skybox_params.sky_color.day_horizon);
+		lua_setfield(L, -2, "day_horizon");
+		push_ARGB8(L, skybox_params.sky_color.dawn_sky);
+		lua_setfield(L, -2, "dawn_sky");
+		push_ARGB8(L, skybox_params.sky_color.dawn_horizon);
+		lua_setfield(L, -2, "dawn_horizon");
+		push_ARGB8(L, skybox_params.sky_color.night_sky);
+		lua_setfield(L, -2, "night_sky");
+		push_ARGB8(L, skybox_params.sky_color.night_horizon);
+		lua_setfield(L, -2, "night_horizon");
+		push_ARGB8(L, skybox_params.sky_color.indoors);
+		lua_setfield(L, -2, "indoors");
+	}
+	push_ARGB8(L, skybox_params.fog_sun_tint);
+	lua_setfield(L, -2, "fog_sun_tint");
+	push_ARGB8(L, skybox_params.fog_moon_tint);
+	lua_setfield(L, -2, "fog_moon_tint");
+	lua_pushstring(L, skybox_params.fog_tint_type.c_str());
+	lua_setfield(L, -2, "fog_tint_type");
+	lua_setfield(L, -2, "sky_color");
+	return 1;
 }
 
 // DEPRECATED

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1949,12 +1949,14 @@ int ObjectRef::l_get_sky(lua_State *L)
 	}
 }
 
+// DEPRECATED
 // get_sky_color(self)
 int ObjectRef::l_get_sky_color(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	RemotePlayer *player = getplayer(ref);
+	log_deprecated(L, "Deprecated call to get_sky_color, use get_sky instead");
 	if (player == nullptr)
 		return 0;
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1877,6 +1877,33 @@ int ObjectRef::l_set_sky(lua_State *L)
 	return 1;
 }
 
+static void push_sky_color(lua_State *L, const SkyboxParams &params)
+{
+	lua_newtable(L);
+	if (params.type == "regular") {
+		push_ARGB8(L, params.sky_color.day_sky);
+		lua_setfield(L, -2, "day_sky");
+		push_ARGB8(L, params.sky_color.day_horizon);
+		lua_setfield(L, -2, "day_horizon");
+		push_ARGB8(L, params.sky_color.dawn_sky);
+		lua_setfield(L, -2, "dawn_sky");
+		push_ARGB8(L, params.sky_color.dawn_horizon);
+		lua_setfield(L, -2, "dawn_horizon");
+		push_ARGB8(L, params.sky_color.night_sky);
+		lua_setfield(L, -2, "night_sky");
+		push_ARGB8(L, params.sky_color.night_horizon);
+		lua_setfield(L, -2, "night_horizon");
+		push_ARGB8(L, params.sky_color.indoors);
+		lua_setfield(L, -2, "indoors");
+	}
+	push_ARGB8(L, params.fog_sun_tint);
+	lua_setfield(L, -2, "fog_sun_tint");
+	push_ARGB8(L, params.fog_moon_tint);
+	lua_setfield(L, -2, "fog_moon_tint");
+	lua_pushstring(L, params.fog_tint_type.c_str());
+	lua_setfield(L, -2, "fog_tint_type");
+}
+
 // get_sky(self, as_table)
 int ObjectRef::l_get_sky(lua_State *L)
 {
@@ -1921,29 +1948,7 @@ int ObjectRef::l_get_sky(lua_State *L)
 	lua_pushboolean(L, skybox_params.clouds);
 	lua_setfield(L, -2, "clouds");
 
-	lua_newtable(L);
-	if (skybox_params.type == "regular") {
-		push_ARGB8(L, skybox_params.sky_color.day_sky);
-		lua_setfield(L, -2, "day_sky");
-		push_ARGB8(L, skybox_params.sky_color.day_horizon);
-		lua_setfield(L, -2, "day_horizon");
-		push_ARGB8(L, skybox_params.sky_color.dawn_sky);
-		lua_setfield(L, -2, "dawn_sky");
-		push_ARGB8(L, skybox_params.sky_color.dawn_horizon);
-		lua_setfield(L, -2, "dawn_horizon");
-		push_ARGB8(L, skybox_params.sky_color.night_sky);
-		lua_setfield(L, -2, "night_sky");
-		push_ARGB8(L, skybox_params.sky_color.night_horizon);
-		lua_setfield(L, -2, "night_horizon");
-		push_ARGB8(L, skybox_params.sky_color.indoors);
-		lua_setfield(L, -2, "indoors");
-	}
-	push_ARGB8(L, skybox_params.fog_sun_tint);
-	lua_setfield(L, -2, "fog_sun_tint");
-	push_ARGB8(L, skybox_params.fog_moon_tint);
-	lua_setfield(L, -2, "fog_moon_tint");
-	lua_pushstring(L, skybox_params.fog_tint_type.c_str());
-	lua_setfield(L, -2, "fog_tint_type");
+	push_sky_color(L, skybox_params);
 	lua_setfield(L, -2, "sky_color");
 	return 1;
 }
@@ -1962,30 +1967,7 @@ int ObjectRef::l_get_sky_color(lua_State *L)
 		return 0;
 
 	const SkyboxParams &skybox_params = player->getSkyParams();
-
-	lua_newtable(L);
-	if (skybox_params.type == "regular") {
-		push_ARGB8(L, skybox_params.sky_color.day_sky);
-		lua_setfield(L, -2, "day_sky");
-		push_ARGB8(L, skybox_params.sky_color.day_horizon);
-		lua_setfield(L, -2, "day_horizon");
-		push_ARGB8(L, skybox_params.sky_color.dawn_sky);
-		lua_setfield(L, -2, "dawn_sky");
-		push_ARGB8(L, skybox_params.sky_color.dawn_horizon);
-		lua_setfield(L, -2, "dawn_horizon");
-		push_ARGB8(L, skybox_params.sky_color.night_sky);
-		lua_setfield(L, -2, "night_sky");
-		push_ARGB8(L, skybox_params.sky_color.night_horizon);
-		lua_setfield(L, -2, "night_horizon");
-		push_ARGB8(L, skybox_params.sky_color.indoors);
-		lua_setfield(L, -2, "indoors");
-	}
-	push_ARGB8(L, skybox_params.fog_sun_tint);
-	lua_setfield(L, -2, "fog_sun_tint");
-	push_ARGB8(L, skybox_params.fog_moon_tint);
-	lua_setfield(L, -2, "fog_moon_tint");
-	lua_pushstring(L, skybox_params.fog_tint_type.c_str());
-	lua_setfield(L, -2, "fog_tint_type");
+	push_sky_color(L, skybox_params);
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1888,17 +1888,65 @@ int ObjectRef::l_get_sky(lua_State *L)
 
 	SkyboxParams skybox_params = player->getSkyParams();
 
-	push_ARGB8(L, skybox_params.bgcolor);
-	lua_pushlstring(L, skybox_params.type.c_str(), skybox_params.type.size());
+	if (!lua_isboolean(L, 1)) {
+		lua_newtable(L);
+		push_ARGB8(L, skybox_params.bgcolor);
+		lua_setfield(L, -2, "base_color");
+		lua_pushlstring(L, skybox_params.type.c_str(), skybox_params.type.size());
+		lua_setfield(L, -2, "type");
 
-	lua_newtable(L);
-	s16 i = 1;
-	for (const std::string &texture : skybox_params.textures) {
-		lua_pushlstring(L, texture.c_str(), texture.size());
-		lua_rawseti(L, -2, i++);
+		lua_newtable(L);
+		s16 i = 1;
+		for (const std::string &texture : skybox_params.textures) {
+			lua_pushlstring(L, texture.c_str(), texture.size());
+			lua_rawseti(L, -2, i++);
+		}
+		lua_setfield(L, -2, "textures");
+		lua_pushboolean(L, skybox_params.clouds);
+		lua_setfield(L, -2, "clouds");
+
+		lua_newtable(L);
+		if (skybox_params.type == "regular") {
+			push_ARGB8(L, skybox_params.sky_color.day_sky);
+			lua_setfield(L, -2, "day_sky");
+			push_ARGB8(L, skybox_params.sky_color.day_horizon);
+			lua_setfield(L, -2, "day_horizon");
+			push_ARGB8(L, skybox_params.sky_color.dawn_sky);
+			lua_setfield(L, -2, "dawn_sky");
+			push_ARGB8(L, skybox_params.sky_color.dawn_horizon);
+			lua_setfield(L, -2, "dawn_horizon");
+			push_ARGB8(L, skybox_params.sky_color.night_sky);
+			lua_setfield(L, -2, "night_sky");
+			push_ARGB8(L, skybox_params.sky_color.night_horizon);
+			lua_setfield(L, -2, "night_horizon");
+			push_ARGB8(L, skybox_params.sky_color.indoors);
+			lua_setfield(L, -2, "indoors");
+		}
+		push_ARGB8(L, skybox_params.fog_sun_tint);
+		lua_setfield(L, -2, "fog_sun_tint");
+		push_ARGB8(L, skybox_params.fog_moon_tint);
+		lua_setfield(L, -2, "fog_moon_tint");
+		lua_pushstring(L, skybox_params.fog_tint_type.c_str());
+		lua_setfield(L, -2, "fog_tint_type");
+		lua_setfield(L, -2, "sky_color");
+		return 1;
+
+	// deprecated
+	} else {
+		log_deprecated(L, "Deprecated call to get_sky, please check lua_api.txt");
+
+		push_ARGB8(L, skybox_params.bgcolor);
+		lua_pushlstring(L, skybox_params.type.c_str(), skybox_params.type.size());
+
+		lua_newtable(L);
+		s16 i = 1;
+		for (const std::string &texture : skybox_params.textures) {
+			lua_pushlstring(L, texture.c_str(), texture.size());
+			lua_rawseti(L, -2, i++);
+		}
+		lua_pushboolean(L, skybox_params.clouds);
+		return 4;
 	}
-	lua_pushboolean(L, skybox_params.clouds);
-	return 4;
 }
 
 // get_sky_color(self)

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1953,9 +1953,11 @@ int ObjectRef::l_get_sky(lua_State *L)
 int ObjectRef::l_get_sky_color(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
+
+	log_deprecated(L, "Deprecated call to get_sky_color, use get_sky instead");
+
 	ObjectRef *ref = checkobject(L, 1);
 	RemotePlayer *player = getplayer(ref);
-	log_deprecated(L, "Deprecated call to get_sky_color, use get_sky instead");
 	if (player == nullptr)
 		return 0;
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1877,7 +1877,7 @@ int ObjectRef::l_set_sky(lua_State *L)
 	return 1;
 }
 
-// get_sky(self)
+// get_sky(self, as_table)
 int ObjectRef::l_get_sky(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -1931,7 +1931,7 @@ int ObjectRef::l_get_sky(lua_State *L)
 		lua_setfield(L, -2, "sky_color");
 		return 1;
 
-	// deprecated
+	// deprecated version
 	} else {
 		log_deprecated(L, "Deprecated call to get_sky, please check lua_api.txt");
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1888,7 +1888,7 @@ int ObjectRef::l_get_sky(lua_State *L)
 
 	SkyboxParams skybox_params = player->getSkyParams();
 
-	if (!lua_isboolean(L, 1)) {
+	if (lua_isboolean(L, 2) && readParam<bool>(L, 2) == true) {
 		lua_newtable(L);
 		push_ARGB8(L, skybox_params.bgcolor);
 		lua_setfield(L, -2, "base_color");

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -316,7 +316,7 @@ private:
 	// set_sky(self, sky_parameters)
 	static int l_set_sky(lua_State *L);
 
-	// get_sky(self)
+	// get_sky(self, as_table)
 	static int l_get_sky(lua_State *L);
 
 	// DEPRECATED

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -319,6 +319,7 @@ private:
 	// get_sky(self)
 	static int l_get_sky(lua_State *L);
 
+	// DEPRECATED
 	// get_sky_color(self)
 	static int l_get_sky_color(lua_State* L);
 


### PR DESCRIPTION
- Goal of the PR: closes #11890 
- Does this relate to a goal in [the roadmap](../doc/direction.md)? 2.4, API convenience

PR also deprecates `get_sky_color`

## To do

This PR is Ready for Review.

## How to test

```lua
minetest.register_on_joinplayer(function(player)
    minetest.chat_send_all(dump(player:get_sky(true))) -- works because it's a table
 -- minetest.chat_send_all(dump(player:get_sky())) -- crashes because it's not
end)
```
