### PR TITLE
Fix missing package in fedora instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ For Debian/Ubuntu users:
 
 For Fedora users:
 
-    sudo dnf install make automake gcc gcc-c++ kernel-devel cmake libcurl-devel openal-soft-devel libvorbis-devel libXxf86vm-devel libogg-devel freetype-devel mesa-libGL-devel zlib-devel jsoncpp-devel gmp-devel sqlite-devel luajit-devel leveldb-devel ncurses-devel spatialindex-devel libzstd-devel
+    sudo dnf install make automake gcc gcc-c++ kernel-devel cmake libcurl-devel openal-soft-devel libvorbis-devel libXxf86vm-devel libogg-devel freetype-devel mesa-libGL-devel zlib-devel jsoncpp-devel gmp-devel sqlite-devel luajit-devel leveldb-devel ncurses-devel spatialindex-devel libzstd-devel libjpeg-devel
 
 For Arch users:
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR

Add missing fedora package to install instructions

- Does it resolve any reported issue?

Unknown

- If not a bug fix, why is this PR needed? What usecases does it solve?

Fixes fedora 35 not being able to compile with current instructions

## How to test

Try in a VM with fedora 35