### PR TITLE
Use absolute value for bouncy in collision

### DIFF
--- a/games/devtest/mods/testnodes/properties.lua
+++ b/games/devtest/mods/testnodes/properties.lua
@@ -252,9 +252,9 @@ for i=-100, 100, 25 do
 end
 
 -- Bouncy nodes (various bounce levels)
-for i=20, 180, 20 do
+for i=-140, 180, 20 do
 	local val = math.floor(((i-20)/200)*255)
-	minetest.register_node("testnodes:bouncy"..i, {
+	minetest.register_node(("testnodes:bouncy"..i):gsub("-","NEG"), {
 		description = S("Bouncy Node (@1%)", i),
 		groups = {bouncy=i, dig_immediate=3},
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -303,7 +303,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			if (!f.walkable)
 				continue;
 
-			int n_bouncy_value = itemgroup_get(f.groups, "bouncy");
+			int n_bouncy_value = abs(itemgroup_get(f.groups, "bouncy"));
 
 			int neighbors = 0;
 			if (f.drawtype == NDT_NODEBOX &&
@@ -504,7 +504,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 							d));
 
 			// Get bounce multiplier
-			float bounce = -(float)nearest_info.bouncy / 100.0f;
+			float bounce = -(float)abs(nearest_info.bouncy) / 100.0f;
 
 			// Move to the point of collision and reduce dtime by nearest_dtime
 			if (nearest_dtime < 0) {

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -504,7 +504,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 							d));
 
 			// Get bounce multiplier
-			float bounce = -(float)abs(nearest_info.bouncy) / 100.0f;
+			float bounce = -(float)nearest_info.bouncy / 100.0f;
 
 			// Move to the point of collision and reduce dtime by nearest_dtime
 			if (nearest_dtime < 0) {

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -303,6 +303,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			if (!f.walkable)
 				continue;
 
+			// Negative bouncy may have a meaning, but we need +value here.
 			int n_bouncy_value = abs(itemgroup_get(f.groups, "bouncy"));
 
 			int neighbors = 0;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -452,7 +452,12 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	writeU16(os, groups.size());
 	for (const auto &group : groups) {
 		os << serializeString16(group.first);
-		writeS16(os, group.second);
+		if (protocol_version < 41 && group.first.compare("bouncy") == 0) {
+			// Old clients may choke on negative bouncy value
+			writeS16(os, abs(group.second));
+		} else {
+			writeS16(os, group.second);
+		}
 	}
 	writeU8(os, param_type);
 	writeU8(os, param_type_2);


### PR DESCRIPTION
Currently, a node with negative bouncy does "nothing" except when it doesn't.

Examples:
* colliding with -80 does nothing
* colliding with -100 does "nothing" but fills the terminal with messages about avoiding an infinite loop
* colliding with -120 **freezes the game**

This patch makes collision use the absolute value, and masks all bouncy nodes as positive for old clients (updated to protocol 41 for 5.6.0).

This fixes the problem, does not conflict with any current valid use, and prepares the code to use negative values for a "controllable/uncontrollable" flag later (#11939).

## To do
Ready for Review.

## How to test

Create a world with negative bouncy nodes

* Old server w Old client:
   no bounce, and at -120 or so the game freezes
* New server w Old client:
   client sees all bouncy nodes as positive
* Any server w New client:
   client sees negative nodes but treats them as positive
