### PR TITLE
Make some improvements to minetest.after

### DIFF
--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -87,21 +87,20 @@ core.register_globalstep(function(dtime)
 	-- Run the callbacks afterward to prevent infinite loops with core.after(0, ...).
 	for i = 1, #expired do
 		local job = expired[i]
-		local func = job.func
-		if func then
-			core.set_last_run_mod(job.mod_origin)
-			func(unpack(job, 1, job.n_args))
-		end
+		core.set_last_run_mod(job.mod_origin)
+		job.func(unpack(job, 1, job.n_args))
 	end
 end)
 
 local job_metatable = {__index = {}}
 
+local function dummy_func() end
 function job_metatable.__index:cancel()
-	self.func = nil
+	self.func = dummy_func
 	for i = 1, self.n_args do
 		self[i] = nil
 	end
+	self.n_args = 0
 end
 
 function core.after(after, func, ...)

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -1,4 +1,67 @@
+-- The jobs are stored in an array representing a binary min-heap. This heap is
+-- a binary tree where no child node has an expiration time before its parent.
+-- Parent-child relationships are determined by indices. A parent at index i has
+-- children at indices i*2 and i*2+1. Child indices beyond the end of the array
+-- represent nonexistent children.
+-- All this means that, if the first array element exists, there is no other
+-- element in the array which expires sooner.
 local jobs = {}
+
+-- Adds a job to the heap.
+-- The worst-case complexity is O(log n), where n is the heap size.
+local function add_job(job)
+	local expire = job.expire
+	local index = #jobs + 1
+	while index > 1 do
+		local parent_index = math.floor(index / 2)
+		local parent = jobs[parent_index]
+		if expire < parent.expire then
+			jobs[index] = parent
+			index = parent_index
+		else
+			break
+		end
+	end
+	jobs[index] = job
+end
+
+-- Removes the first (soonest to expire) job from the heap.
+-- The worst-case complexity is O(log n), where n is the heap size.
+local function remove_first_job()
+	local length = #jobs
+	local job = jobs[length]
+	jobs[length] = nil
+	length = length - 1
+	if length == 0 then
+		return
+	end
+	local index = 1
+	while true do
+		local old_index = index
+		local expire = job.expire
+		local left_index = index * 2
+		local right_index = index * 2 + 1
+		if left_index <= length then
+			local left_expire = jobs[left_index].expire
+			if left_expire < expire then
+				index = left_index
+				expire = left_expire
+			end
+		end
+		if right_index <= length then
+			if jobs[right_index].expire < expire then
+				index = right_index
+			end
+		end
+		if old_index ~= index then
+			jobs[old_index] = jobs[index]
+		else
+			break
+		end
+	end
+	jobs[index] = job
+end
+
 local time = 0.0
 local time_next = math.huge
 
@@ -9,35 +72,50 @@ core.register_globalstep(function(dtime)
 		return
 	end
 
-	time_next = math.huge
+	-- List of jobs that have to expired; to be built.
+	local expired = {}
 
-	-- Iterate backwards so that we miss any new timers added by
-	-- a timer callback.
-	for i = #jobs, 1, -1 do
-		local job = jobs[i]
-		if time >= job.expire then
+	-- Remove and collect expired jobs.
+	local first_job = jobs[1]
+	repeat
+		remove_first_job()
+		expired[#expired + 1] = first_job
+		first_job = jobs[1]
+	until not first_job or first_job.expire > time
+	time_next = first_job and first_job.expire or math.huge
+
+	-- Run the callbacks afterward to prevent infinite loops with core.after(0, ...).
+	for i = 1, #expired do
+		local job = expired[i]
+		local func = job.func
+		if func then
 			core.set_last_run_mod(job.mod_origin)
-			job.func(unpack(job.arg))
-			local jobs_l = #jobs
-			jobs[i] = jobs[jobs_l]
-			jobs[jobs_l] = nil
-		elseif job.expire < time_next then
-			time_next = job.expire
+			func(unpack(job, 1, job.n_args))
 		end
 	end
 end)
 
+local job_metatable = {__index = {}}
+
+function job_metatable.__index:cancel()
+	self.func = nil
+	for i = 1, self.n_args do
+		self[i] = nil
+	end
+end
+
 function core.after(after, func, ...)
-	assert(tonumber(after) and type(func) == "function",
+	assert(tonumber(after) and not core.is_nan(after) and type(func) == "function",
 		"Invalid minetest.after invocation")
 	local expire = time + after
 	local new_job = {
-		func = func,
 		expire = expire,
-		arg = {...},
 		mod_origin = core.get_last_run_mod(),
+		func = func,
+		n_args = select("#", ...),
+		...
 	}
-	jobs[#jobs + 1] = new_job
+	add_job(new_job)
 	time_next = math.min(time_next, expire)
-	return { cancel = function() new_job.func = function() end end }
+	return setmetatable(new_job, job_metatable)
 end

--- a/builtin/common/tests/after_spec.lua
+++ b/builtin/common/tests/after_spec.lua
@@ -1,0 +1,79 @@
+_G.core = {}
+
+dofile("builtin/common/vector.lua")
+dofile("builtin/common/misc_helpers.lua")
+
+function core.get_last_run_mod() return "*test*" end
+function core.set_last_run_mod() end
+
+local do_step
+function core.register_globalstep(func)
+	do_step = func
+end
+
+dofile("builtin/common/after.lua")
+
+describe("after", function()
+	it("executes callbacks when expected", function()
+		local result = ""
+		core.after(0, function()
+			result = result .. "a"
+		end)
+		core.after(1, function()
+			result = result .. "b"
+		end)
+		core.after(1, function()
+			result = result .. "b"
+		end)
+		core.after(2, function()
+			result = result .. "c"
+		end)
+		local cancel = core.after(2, function()
+			result = result .. "d"
+		end)
+		do_step(0)
+		assert.same(result, "a")
+
+		do_step(1)
+		assert.same(result, "abb")
+
+		core.after(-1, function()
+			result = result .. "e"
+		end)
+		core.after(1, function()
+			result = result .. "c"
+		end)
+		core.after(2, function()
+			result = result .. "f"
+		end)
+		cancel:cancel()
+		do_step(1)
+		assert.same(result, "abbecc")
+
+		do_step(1)
+		assert.same(result, "abbeccf")
+	end)
+
+	it("passes arguments", function()
+		core.after(0, function(...)
+			assert.same(select("#", ...), 0)
+		end)
+		core.after(0, function(...)
+			assert.same(select("#", ...), 4)
+			assert.same((select(1, ...)), 1)
+			assert.same((select(2, ...)), nil)
+			assert.same((select(3, ...)), "a")
+			assert.same((select(4, ...)), nil)
+		end, 1, nil, "a", nil)
+		do_step(0)
+	end)
+
+	it("rejects invalid arguments", function()
+		assert.has.errors(function() core.after() end)
+		assert.has.errors(function() core.after(nil, nil) end)
+		assert.has.errors(function() core.after(0) end)
+		assert.has.errors(function() core.after(0, nil) end)
+		assert.has.errors(function() core.after(nil, function() end) end)
+		assert.has.errors(function() core.after(0 / 0, function() end) end)
+	end)
+end)

--- a/builtin/common/tests/after_spec.lua
+++ b/builtin/common/tests/after_spec.lua
@@ -54,6 +54,20 @@ describe("after", function()
 		assert.same(result, "abbeccf")
 	end)
 
+	it("defers jobs with delay 0", function()
+		local result = ""
+		core.after(0, function()
+			core.after(0, function()
+				result = result .. "b"
+			end)
+			result = result .. "a"
+		end)
+		do_step(1)
+		assert.same(result, "a")
+		do_step(1)
+		assert.same(result, "ab")
+	end)
+
 	it("passes arguments", function()
 		core.after(0, function(...)
 			assert.same(select("#", ...), 0)


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - I wanted to try addressing some problems with `minetest.after`.
- How does the PR work?
  - Jobs are now stored in a heap data structure. I saw this suggested on one of the IRC channels, I think by @appgurueu. Without this change, inserting a job is `O(1)` complexity and removing an expired job is `O(n)` complexity (worst case; `n` is the number of jobs.) With the change, both insertion and deletion are `O(log n)` complexity (worst case.) I haven't found the new way to be faster when used with actual mods. In fact, it may be a microsecond or two slower. It should be noted that, as the number of jobs expiring at once approaches the total number of jobs, the complexity of the old way of removing expired jobs approaches `O(1)`. However, it seems like the number of jobs expiring at once is usually pretty small. The new heap-based method is preferable because it has a better complexity per-job on average and is thus more scalable. I have found it to be faster when a situation is induced such that there are many pending jobs only a few of which expire per globalstep.
  - The number of allocations per call to `minetest.after` has been reduced from 3 to 1. Firstly, the `cancel` method is now dispatched using a shared metatable, and the job table itself is returned. Secondly, the callback arguments are stored directly in the job table. I saw this technique used in @appgurueu's modlib.
  - Arguments are now reliably passed to the callback. Before, if one of the arguments was `nil`, no arguments after it would be passed. This was a bug.
  - There are now unit tests for `minetest.after`.
  - `minetest.after` now throws an error when given NaN.
  - Jobs should now expire in chronological order, even when they expire in the same globalstep. This is just due to the structure of the heap.
- Does it resolve any reported issue?
  - Not that I know of.
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
  - It makes the Lua API more flexible (removing one of its potential performance limitations,) which might relate to something on the road map.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  - It's partially a bug fix. Again, it also makes the API more flexible.

## To do

This PR is ready for review, although maybe it could use more testing.

## How to test

There are unit tests for the API now.

It's important to test this with actual mods. I haven't seen any issues, but they might be hard to spot. It would be nice to test it with mods that made very heavy use of the API in order to test performance accurately.

To test performance, first apply this patch:

```patch
diff --git a/builtin/common/after.lua b/builtin/common/after.lua
index 85169cb70..126c0ed3e 100644
--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -65,6 +65,8 @@ end
 local time = 0.0
 local time_next = math.huge
 
+local n, avg = 0, 0
+
 core.register_globalstep(function(dtime)
 	time = time + dtime
 
@@ -72,6 +74,8 @@ core.register_globalstep(function(dtime)
 		return
 	end
 
+	local before = core.get_us_time()
+
 	-- List of jobs that have to expired; to be built.
 	local expired = {}
 
@@ -93,6 +97,13 @@ core.register_globalstep(function(dtime)
 			func(unpack(job, 1, job.n_args))
 		end
 	end
+
+	local after = core.get_us_time()
+
+	local cost = (after - before) / #expired
+	n = n + 1
+	avg = (avg * (n - 1) + cost) / n
+	core.chat_send_all("Avg. cost per expired job: " .. avg)
 end)
 
 local job_metatable = {__index = {}}
```

You can use this mod to continuously create a bunch of jobs that do nothing:  [test_after.tar.gz](https://github.com/minetest/minetest/files/7893528/test_after.tar.gz)
