### PR TITLE
[NO SQUASH] Database-related changes

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1311,6 +1311,9 @@ max_objects_per_block (Maximum objects per block) int 64
 #    See https://www.sqlite.org/pragma.html#pragma_synchronous
 sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2
 
+#    See https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT
+postgres_synchronous_commit (Synchronous Commit PostgreSQL) bool true
+
 #    Compression level to use when saving mapblocks to disk.
 #    -1 - use default compression level
 #     0 - least compression, fastest

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -90,6 +90,10 @@ void Database_PostgreSQL::connectToDatabase()
 	infostream << "PostgreSQL Database: Version " << m_pgversion
 			<< " Connection made." << std::endl;
 
+	std::string query_str = "SET synchronous_commit = ";
+	query_str += g_settings->getBool("postgres_synchronous_commit") ? "on" : "off";
+	checkResults(PQexec(m_conn, query_str.c_str()));
+
 	createDatabase();
 	initStatements();
 }

--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -228,11 +228,7 @@ void MapDatabaseSQLite3::createDatabase()
 void MapDatabaseSQLite3::initStatements()
 {
 	PREPARE_STATEMENT(read, "SELECT `data` FROM `blocks` WHERE `pos` = ? LIMIT 1");
-#ifdef __ANDROID__
-	PREPARE_STATEMENT(write,  "INSERT INTO `blocks` (`pos`, `data`) VALUES (?, ?)");
-#else
 	PREPARE_STATEMENT(write, "REPLACE INTO `blocks` (`pos`, `data`) VALUES (?, ?)");
-#endif
 	PREPARE_STATEMENT(delete, "DELETE FROM `blocks` WHERE `pos` = ?");
 	PREPARE_STATEMENT(list, "SELECT `pos` FROM `blocks`");
 
@@ -264,19 +260,6 @@ bool MapDatabaseSQLite3::deleteBlock(const v3s16 &pos)
 bool MapDatabaseSQLite3::saveBlock(const v3s16 &pos, const std::string &data)
 {
 	verifyDatabase();
-
-#ifdef __ANDROID__
-	/**
-	 * Note: For some unknown reason SQLite3 fails to REPLACE blocks on Android,
-	 * deleting them and then inserting works.
-	 */
-	bindPos(m_stmt_read, pos);
-
-	if (sqlite3_step(m_stmt_read) == SQLITE_ROW) {
-		deleteBlock(pos);
-	}
-	sqlite3_reset(m_stmt_read);
-#endif
 
 	bindPos(m_stmt_write, pos);
 	SQLOK(sqlite3_bind_blob(m_stmt_write, 2, data.data(), data.size(), NULL),

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -392,6 +392,7 @@ void set_default_settings()
 	settings->setDefault("chat_message_limit_per_10sec", "8.0");
 	settings->setDefault("chat_message_limit_trigger_kick", "50");
 	settings->setDefault("sqlite_synchronous", "2");
+	settings->setDefault("postgres_synchronous_commit", "true");
 	settings->setDefault("map_compression_level_disk", "-1");
 	settings->setDefault("map_compression_level_net", "-1");
 	settings->setDefault("full_block_send_enable_min_time_from_building", "2.0");


### PR DESCRIPTION
* <b>Add postgres_synchronous_commit setting</b>
  allows server owners to fix performance problems akin to the `sqlite_synchronous` setting
* <b>Get rid of legacy workaround in SQLite backend</b>
  fixes #11937

## How to test

* Join a singleplayer world on Android and see if it breaks
