### PR TITLE
Cancel emerge callbacks on shutdown

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -724,6 +724,8 @@ void *EmergeThread::run()
 		m_server->setAsyncFatalError(err.str());
 	}
 
+	cancelPendingItems();
+
 	END_DEBUG_EXCEPTION_HANDLER
 	return NULL;
 }


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - When the server shuts down, pending emerge callbacks should be cancelled.
- How does the PR work?
  - There was already a method for this task, but it wasn't used anywhere. I made use of it. It runs after the main loop of each emerge thread.
  - The callbacks are cancelled even after a `VersionMismatchException` or a `SerializationError`.
- Does it resolve any reported issue?
  - No.
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
  - No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  - It's probably a bug fix. I don't see why that method would be unused otherwise.
  - I ran into the cancellation issue when developing a mod. I had the code put some data into an unfinished state then wait for emergence to finish before putting the data into a finished state. The code needed to know when the emergence did not complete in order to not leave the data in an unfinished state. However, the cancellation issue made detection difficult. I ended up using an `on_shutdown` callback, which made the code more complicated.

## To do

This PR is Ready for Review.

## How to test

Create a world with the `dummy` map backend. Put this code in a mod:

```lua
minetest.after(0, function()
	local p1 = vector.new(1000, 1000, 1000)
	local p2 = vector.new(1200, 1200, 1200)
	local n_cancelled = 0
	local n = 0
	minetest.emerge_area(p1, p2, function(_, a, n_left)
		n = math.max(n, n_left + 1)
		if a == minetest.EMERGE_CANCELLED then
			n_cancelled = n_cancelled + 1
		end
		if n_left == 0 then
			minetest.log("action", "Cancelled: " .. n_cancelled .. "/" .. n)
		end
	end)
	error("fooba")
end)
```

When you open the world, you should get an error. You should see a line something like this in the log:

```
ACTION[Emerge-0]: Cancelled: 2729/2744
```