### PR TITLE
Fix consistency of sky sun/moon texture behaviour

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6856,7 +6856,7 @@ object you are working with still exists.
         * `visible`: Boolean for whether the sun is visible.
             (default: `true`)
         * `texture`: A regular texture for the sun. Setting to `""`
-            will re-enable the mesh sun. (default: `"sun.png"`)
+            will re-enable the mesh sun. (default: "sun.png", if it exists)
         * `tonemap`: A 512x1 texture containing the tonemap for the sun
             (default: `"sun_tonemap.png"`)
         * `sunrise`: A regular texture for the sunrise texture.
@@ -6872,7 +6872,7 @@ object you are working with still exists.
         * `visible`: Boolean for whether the moon is visible.
             (default: `true`)
         * `texture`: A regular texture for the moon. Setting to `""`
-            will re-enable the mesh moon. (default: `"moon.png"`)
+            will re-enable the mesh moon. (default: "moon.png", if it exists)
         * `tonemap`: A 512x1 texture containing the tonemap for the moon
             (default: `"moon_tonemap.png"`)
         * `scale`: Float controlling the overall size of the moon (default: `1`)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2862,7 +2862,7 @@ void Game::handleClientEvent_SetMoon(ClientEvent *event, CameraOrientation *cam)
 void Game::handleClientEvent_SetStars(ClientEvent *event, CameraOrientation *cam)
 {
 	sky->setStarsVisible(event->star_params->visible);
-	sky->setStarCount(event->star_params->count, false);
+	sky->setStarCount(event->star_params->count);
 	sky->setStarColor(event->star_params->starcolor);
 	sky->setStarScale(event->star_params->scale);
 	delete event->star_params;

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -17,6 +17,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#pragma once
+
 #include "irrlichttypes_extrabloated.h"
 #include <ISceneNode.h>
 #include <array>
@@ -24,8 +26,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irr_ptr.h"
 #include "shader.h"
 #include "skyparams.h"
-
-#pragma once
 
 #define SKY_MATERIAL_COUNT 12
 
@@ -77,7 +77,7 @@ public:
 	void setMoonScale(f32 moon_scale) { m_moon_params.scale = moon_scale; }
 
 	void setStarsVisible(bool stars_visible) { m_star_params.visible = stars_visible; }
-	void setStarCount(u16 star_count, bool force_update);
+	void setStarCount(u16 star_count);
 	void setStarColor(video::SColor star_color) { m_star_params.starcolor = star_color; }
 	void setStarScale(f32 star_scale) { m_star_params.scale = star_scale; updateStars(); }
 
@@ -150,7 +150,7 @@ private:
 	bool m_visible = true;
 	// Used when m_visible=false
 	video::SColor m_fallback_bg_color = video::SColor(255, 255, 255, 255);
-	bool m_first_update = true;
+	bool m_first_update = true; // Set before the sky is updated for the first time
 	float m_time_of_day;
 	float m_time_brightness;
 	bool m_sunlight_seen;
@@ -206,7 +206,6 @@ private:
 	void draw_stars(video::IVideoDriver *driver, float wicked_time_of_day);
 	void place_sky_body(std::array<video::S3DVertex, 4> &vertices,
 		float horizon_position,	float day_position);
-	void setSkyDefaults();
 };
 
 // calculates value for sky body positions for the given observed time of day

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1242,19 +1242,17 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 		} catch (...) {}
 
 		// Use default skybox settings:
-		SkyboxDefaults sky_defaults;
-		SunParams sun = sky_defaults.getSunDefaults();
-		MoonParams moon = sky_defaults.getMoonDefaults();
-		StarParams stars = sky_defaults.getStarDefaults();
+		SunParams sun = SkyboxDefaults::getSunDefaults();
+		MoonParams moon = SkyboxDefaults::getMoonDefaults();
+		StarParams stars = SkyboxDefaults::getStarDefaults();
 
 		// Fix for "regular" skies, as color isn't kept:
 		if (skybox.type == "regular") {
-			skybox.sky_color = sky_defaults.getSkyColorDefaults();
+			skybox.sky_color = SkyboxDefaults::getSkyColorDefaults();
 			skybox.fog_tint_type = "default";
 			skybox.fog_moon_tint = video::SColor(255, 255, 255, 255);
 			skybox.fog_sun_tint = video::SColor(255, 255, 255, 255);
-		}
-		else {
+		} else {
 			sun.visible = false;
 			sun.sunrise_visible = false;
 			moon.visible = false;

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -31,6 +31,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /*
 	RemotePlayer
 */
+
 // static config cache for remoteplayer
 bool RemotePlayer::m_setting_cache_loaded = false;
 float RemotePlayer::m_setting_chat_message_limit_per_10sec = 0.0f;
@@ -46,6 +47,7 @@ RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
 			g_settings->getU16("chat_message_limit_trigger_kick");
 		RemotePlayer::m_setting_cache_loaded = true;
 	}
+
 	movement_acceleration_default   = g_settings->getFloat("movement_acceleration_default")   * BS;
 	movement_acceleration_air       = g_settings->getFloat("movement_acceleration_air")       * BS;
 	movement_acceleration_fast      = g_settings->getFloat("movement_acceleration_fast")      * BS;
@@ -59,19 +61,12 @@ RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
 	movement_liquid_sink            = g_settings->getFloat("movement_liquid_sink")            * BS;
 	movement_gravity                = g_settings->getFloat("movement_gravity")                * BS;
 
-	// copy defaults
-	m_cloud_params.density = 0.4f;
-	m_cloud_params.color_bright = video::SColor(229, 240, 240, 255);
-	m_cloud_params.color_ambient = video::SColor(255, 0, 0, 0);
-	m_cloud_params.height = 120.0f;
-	m_cloud_params.thickness = 16.0f;
-	m_cloud_params.speed = v2f(0.0f, -2.0f);
-
 	// Skybox defaults:
+	m_cloud_params  = SkyboxDefaults::getCloudDefaults();
 	m_skybox_params = SkyboxDefaults::getSkyDefaults();
-	m_sun_params = SkyboxDefaults::getSunDefaults();
-	m_moon_params = SkyboxDefaults::getMoonDefaults();
-	m_star_params = SkyboxDefaults::getStarDefaults();
+	m_sun_params    = SkyboxDefaults::getSunDefaults();
+	m_moon_params   = SkyboxDefaults::getMoonDefaults();
+	m_star_params   = SkyboxDefaults::getStarDefaults();
 }
 
 

--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -82,6 +82,8 @@ struct CloudParams
 class SkyboxDefaults
 {
 public:
+	SkyboxDefaults() = delete;
+
 	static const SkyboxParams getSkyDefaults()
 	{
 		SkyboxParams sky;


### PR DESCRIPTION
fixes #11930

The reason for this behaviour was that at startup the sky picks "sun.png" *if* it exists and else uses the mesh sun. The code for runtime texture changes did not do this.
This meant if you ever changed the texture it was impossible to return to the default state.