### PR TITLE
Make sure nightRatio is always greater than zero.

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -512,7 +512,7 @@ void main(void)
 	// turns out that nightRatio falls off much faster than
 	// actual brightness of artificial light in relation to natual light.
 	// Power ratio was measured on torches in MTG (brightness = 14).
-	float adjusted_night_ratio = pow(nightRatio, 0.6);
+	float adjusted_night_ratio = pow(max(0.0, nightRatio), 0.6);
 
 	if (f_normal_length != 0 && cosLight < 0.035) {
 		shadow_int = max(shadow_int, 1 - clamp(cosLight, 0.0, 0.035)/0.035);


### PR DESCRIPTION
This avoids underfined behaior of GLSL pow() and fixes #11977.

## To do

This PR is Ready for Review.

## How to test

* You need NVidia or AMD card
* Enable shadows
* Find a snowy biome
* Place a torch
* ~~Observe a nice black border where artificial light meets netural light~~