### PR TITLE
Revert get_player_control() API change

### DIFF
--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1367,8 +1367,10 @@ int ObjectRef::l_get_player_control(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	RemotePlayer *player = getplayer(ref);
-	if (player == nullptr)
-		return 0;
+	if (player == nullptr) {
+		lua_pushlstring(L, "", 0);
+		return 1;
+	}
 
 	const PlayerControl &control = player->getPlayerControl();
 	lua_newtable(L);


### PR DESCRIPTION
Issue: https://github.com/minetest/minetest/issues/11989

In Minetest 5.4.1, calling get_player_control() on a mob returned the
empty string. Since commit 5eb45e1ea03c6104f007efec6dd9c351f310193d,
calling get_player_control() on a mob returns nil.

Several mods contain vessels that can have a human or a mob as a driver.
Code like the following crashes with a changed get_player_control() API:

```
local ctrl = driver:get_player_control()
if ctrl.sneak then
    detach_object(driver, true)
end
```

Furthermore, once a world has crashed, joining it near a mob that is a
driver of a vessel with such control code immediately crashes again.

For this reason, the get_player_control() API change has been reverted.

## How to test

### Verify Bug

1. Start Minetest commit 1b2176a426dd987795f20e9042a8d79f958b7b44 with Mineclonia commit b1b96e3fac6e1fc93356d86132e6b7a65419fd47 in creative mode.
2. Place a boat close to a mob.
3. Enjoy your crash.
4. Try to join the world.
5. Note that the server crashes on joining the world.

### Verify Patch

1. Start Minetest commit 414eb63c381031de4563b5c99bb51cbdcadc63ed with Mineclonia commit b1b96e3fac6e1fc93356d86132e6b7a65419fd47 in creative mode.
2. Place a boat close to a mob.
3. No crash happens.

**Edit:** First time in my life that I proposed a fix to a crash and got only downvotes.