### PR TITLE
Define control(bits) as "unset" for entities

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6716,18 +6716,21 @@ object you are working with still exists.
       `aux1`, `sneak`, `dig`, `place`, `LMB`, `RMB`, and `zoom`.
     * The fields `LMB` and `RMB` are equal to `dig` and `place` respectively,
       and exist only to preserve backwards compatibility.
+    * Returns an empty table `{}` if the object is not a player.
 * `get_player_control_bits()`: returns integer with bit packed player pressed
-  keys. Bits:
-    * 0 - up
-    * 1 - down
-    * 2 - left
-    * 3 - right
-    * 4 - jump
-    * 5 - aux1
-    * 6 - sneak
-    * 7 - dig
-    * 8 - place
-    * 9 - zoom
+  keys.
+    * Bits:
+        * 0 - up
+        * 1 - down
+        * 2 - left
+        * 3 - right
+        * 4 - jump
+        * 5 - aux1
+        * 6 - sneak
+        * 7 - dig
+        * 8 - place
+        * 9 - zoom
+    * Returns `0` (no bits set) if the object is not a player.
 * `set_physics_override(override_table)`
     * `override_table` is a table with the following fields:
         * `speed`: multiplier to default walking speed value (default: `1`)

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1367,11 +1367,12 @@ int ObjectRef::l_get_player_control(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	RemotePlayer *player = getplayer(ref);
-	if (player == nullptr)
-		return 0;
 
-	const PlayerControl &control = player->getPlayerControl();
 	lua_newtable(L);
+	if (player == nullptr)
+		return 1;
+	
+	const PlayerControl &control = player->getPlayerControl();
 	lua_pushboolean(L, control.direction_keys & (1 << 0));
 	lua_setfield(L, -2, "up");
 	lua_pushboolean(L, control.direction_keys & (1 << 1));
@@ -1406,8 +1407,10 @@ int ObjectRef::l_get_player_control_bits(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	RemotePlayer *player = getplayer(ref);
-	if (player == nullptr)
-		return 0;
+	if (player == nullptr) {
+		lua_pushinteger(L, 0);
+		return 1;
+	}
 
 	const auto &c = player->getPlayerControl();
 


### PR DESCRIPTION
Closes #11989 by implementing the preferred API.

Alternatives for `get_player_control`:

* Return nothing (not even `nil`) and break existing mods (current state of master). Obviously problematic.
* Return a string in place of a table. This is far from a clean API and relies on the string metatable when indexed - very dirty.
* Return a table with all fields set to `false`. Acceptable as well, but wastes performance. Modders doing `controls.something` usually only check for truthiness (in `if`s for example), which works for `nil` the same as `false`.
* Return a table with a metatable. The metatable could have a metamethod set to constantly return `false`, perhaps even logging deprecation warnings. Proper and modder-friendly solution, but some effort would be needed to ensure that mods aren't spammed (such as caching hashes of already logged warnings etc.).
* Conclusion: Returning the empty table will allow most mods to continue to work even if relying on indexing the empty string as if it were a table of controls. More sophisticated approaches are possible though.

Now for `get_player_control_bits`:

* Returning nothing instead of the empty string technically breaks existing mods, but it's very unlikely that anyone ever relied on this, as it's hard to mistake a string for a number in Lua (especially when indexing and when it can't even be `tonumber`ed)
* Modders hardly use this, as `get_player_control` is way more comfortable to use.
* Conclusion: This can pretty much arbitrarily be changed, but the most sane is to just return `0` - no bits sit - which is the equivalent of the empty table returned by `get_player_control` in terms of control truthiness.
