### PR TITLE
Fix builtin statbar backgrounds

### DIFF
--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -73,7 +73,7 @@ local function update_builtin_statbars(player)
 	local breath     = player:get_breath()
 	local breath_max = player:get_properties().breath_max
 	if show_breathbar and breath <= breath_max then
-		local number = 2 * scaleToHudMax(player, "breath")
+		local number = scaleToHudMax(player, "breath")
 		if not hud.id_breathbar and breath < breath_max then
 			local hud_def = table.copy(bar_definitions.breath)
 			hud_def.number = number

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -1,36 +1,37 @@
 -- cache setting
 local enable_damage = core.settings:get_bool("enable_damage")
 
-local health_bar_definition = {
-	hud_elem_type = "statbar",
-	position = {x = 0.5, y = 1},
-	text = "heart.png",
-	text2 = "heart_gone.png",
-	number = core.PLAYER_MAX_HP_DEFAULT,
-	item = core.PLAYER_MAX_HP_DEFAULT,
-	direction = 0,
-	size = {x = 24, y = 24},
-	offset = {x = (-10 * 24) - 25, y = -(48 + 24 + 16)},
-}
-
-local breath_bar_definition = {
-	hud_elem_type = "statbar",
-	position = {x = 0.5, y = 1},
-	text = "bubble.png",
-	text2 = "bubble_gone.png",
-	number = core.PLAYER_MAX_BREATH_DEFAULT * 2,
-	item = core.PLAYER_MAX_BREATH_DEFAULT * 2,
-	direction = 0,
-	size = {x = 24, y = 24},
-	offset = {x = 25, y= -(48 + 24 + 16)},
+local bar_definitions = {
+	hp = {
+		hud_elem_type = "statbar",
+		position = {x = 0.5, y = 1},
+		text = "heart.png",
+		text2 = "heart_gone.png",
+		number = core.PLAYER_MAX_HP_DEFAULT,
+		item = core.PLAYER_MAX_HP_DEFAULT,
+		direction = 0,
+		size = {x = 24, y = 24},
+		offset = {x = (-10 * 24) - 25, y = -(48 + 24 + 16)},
+	},
+	breath = {
+		hud_elem_type = "statbar",
+		position = {x = 0.5, y = 1},
+		text = "bubble.png",
+		text2 = "bubble_gone.png",
+		number = core.PLAYER_MAX_BREATH_DEFAULT * 2,
+		item = core.PLAYER_MAX_BREATH_DEFAULT * 2,
+		direction = 0,
+		size = {x = 24, y = 24},
+		offset = {x = 25, y= -(48 + 24 + 16)},
+	},
 }
 
 local hud_ids = {}
 
-local function scaleToDefault(player, field)
-	-- Scale "hp" or "breath" to the default dimensions
+local function scaleToHudMax(player, field)
+	-- Scale "hp" or "breath" to the hud maximum dimensions
 	local current = player["get_" .. field](player)
-	local nominal = core["PLAYER_MAX_" .. field:upper() .. "_DEFAULT"]
+	local nominal = bar_definitions[field].item
 	local max_display = math.max(player:get_properties()[field .. "_max"], current)
 	return math.ceil(current / max_display * nominal)
 end
@@ -54,9 +55,9 @@ local function update_builtin_statbars(player)
 	local immortal = player:get_armor_groups().immortal == 1
 
 	if flags.healthbar and enable_damage and not immortal then
-		local number = scaleToDefault(player, "hp")
+		local number = scaleToHudMax(player, "hp")
 		if hud.id_healthbar == nil then
-			local hud_def = table.copy(health_bar_definition)
+			local hud_def = table.copy(bar_definitions.hp)
 			hud_def.number = number
 			hud.id_healthbar = player:hud_add(hud_def)
 		else
@@ -72,9 +73,9 @@ local function update_builtin_statbars(player)
 	local breath     = player:get_breath()
 	local breath_max = player:get_properties().breath_max
 	if show_breathbar and breath <= breath_max then
-		local number = 2 * scaleToDefault(player, "breath")
+		local number = 2 * scaleToHudMax(player, "breath")
 		if not hud.id_breathbar and breath < breath_max then
-			local hud_def = table.copy(breath_bar_definition)
+			local hud_def = table.copy(bar_definitions.breath)
 			hud_def.number = number
 			hud.id_breathbar = player:hud_add(hud_def)
 		elseif hud.id_breathbar then
@@ -144,7 +145,7 @@ function core.hud_replace_builtin(hud_name, definition)
 	end
 
 	if hud_name == "health" then
-		health_bar_definition = definition
+		bar_definitions.hp = definition
 
 		for name, ids in pairs(hud_ids) do
 			local player = core.get_player_by_name(name)
@@ -158,7 +159,7 @@ function core.hud_replace_builtin(hud_name, definition)
 	end
 
 	if hud_name == "breath" then
-		breath_bar_definition = definition
+		bar_definitions.breath = definition
 
 		for name, ids in pairs(hud_ids) do
 			local player = core.get_player_by_name(name)

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -18,7 +18,7 @@ local breath_bar_definition = {
 	position = {x = 0.5, y = 1},
 	text = "bubble.png",
 	text2 = "bubble_gone.png",
-	number = core.PLAYER_MAX_BREATH_DEFAULT,
+	number = core.PLAYER_MAX_BREATH_DEFAULT * 2,
 	item = core.PLAYER_MAX_BREATH_DEFAULT * 2,
 	direction = 0,
 	size = {x = 24, y = 24},
@@ -31,9 +31,8 @@ local function scaleToDefault(player, field)
 	-- Scale "hp" or "breath" to the default dimensions
 	local current = player["get_" .. field](player)
 	local nominal = core["PLAYER_MAX_" .. field:upper() .. "_DEFAULT"]
-	local max_display = math.max(nominal,
-		math.max(player:get_properties()[field .. "_max"], current))
-	return current / max_display * nominal
+	local max_display = math.max(player:get_properties()[field .. "_max"], current)
+	return math.ceil(current / max_display * nominal)
 end
 
 local function update_builtin_statbars(player)

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -676,7 +676,7 @@ void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir,
 	// Rectangles for 1/2 the "off state" texture
 	core::rect<s32> srchalfrect2, dsthalfrect2;
 
-	if (count % 2 == 1) {
+	if (count % 2 == 1 || maxcount % 2 == 1) {
 		// Need to draw halves: Calculate rectangles
 		srchalfrect  = calculate_clipping_rect(srcd, steppos);
 		dsthalfrect  = calculate_clipping_rect(dstd, steppos);
@@ -711,7 +711,7 @@ void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir,
 		}
 	}
 
-	if (stat_texture_bg && maxcount > count / 2) {
+	if (stat_texture_bg && maxcount > count) {
 		// Draw "off state" textures
 		s32 start_offset;
 		if (count % 2 == 1)
@@ -731,8 +731,7 @@ void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir,
 
 		if (maxcount % 2 == 1) {
 			draw2DImageFilterScaled(driver, stat_texture_bg,
-					dsthalfrect + p, srchalfrect,
-					NULL, colors, true);
+				dsthalfrect + p, srchalfrect, NULL, colors, true);
 		}
 	}
 }


### PR DESCRIPTION
Closes #11999. Also closes #10741.

* Half background statbar "off" icons weren't drawn if the HP was even, as the clipping rect zero-defaulted.
* HP & breath were incorrectly scaled: If the max properties were set to something below the default max, the default max was still assumed to be the max. This also `ceil`s the scaled values instead of (implicitly?) `floor`ing them.

## How to test

```lua
local hp = 1
local timer = 0
minetest.register_globalstep(function(dtime)
timer = timer + dtime
	if timer < 1 then return end
	timer = 0
	for _, player in pairs(minetest.get_connected_players()) do
		player:set_properties{hp_max = hp + 3}
		player:set_hp(hp)
	end
	if hp > 30 then
		hp = 1
	else
		hp = hp + 1
	end
end)

minetest.register_on_joinplayer(function(player)
	player:hud_add{
		hud_elem_type = "statbar",
		position = {x = 0.5, y = 0.5},
		text = "heart.png",
		text2 = "heart_gone.png",
		number = 2,
		item = 3,
		direction = 0,
		size = {x = 24, y = 24},
	}
end)
```