### PR TITLE
Abort raycasts that go out-of-bounds

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -169,6 +169,12 @@ void Environment::continueRaycast(RaycastState *state, PointedThing *result)
 			new_nodes.MaxEdge.Z = new_nodes.MinEdge.Z;
 		}
 
+		if (new_nodes.MaxEdge.X == S16_MAX ||
+			new_nodes.MaxEdge.Y == S16_MAX ||
+			new_nodes.MaxEdge.Z == S16_MAX) {
+			break; // About to go out of bounds
+		}
+
 		// For each untested node
 		for (s16 x = new_nodes.MinEdge.X; x <= new_nodes.MaxEdge.X; x++)
 		for (s16 y = new_nodes.MinEdge.Y; y <= new_nodes.MaxEdge.Y; y++)


### PR DESCRIPTION
fixes #11830 

## How to test

1. Run this:
```lua
minetest.register_chatcommand("raycast", {
	func = function()
		for _, sign in ipairs({-1, 1}) do
			for x = 32760, 32770 do
			for y = 32760, 32770 do
			for z = 32760, 32770 do
				local pos1 = vector.new(sign*x, sign*y, sign*z)
				local pos2 = vector.add(pos1, vector.new(sign*5, 0, sign*10))
				core.raycast(pos1, pos2, true, true):next()
			end
			end
			end
		end
		core.chat_send_all("You should see this message.")
	end
})
```
2. Point at some nodes to confirm raycasting still works