### PR TITLE
Fix Minetest logo when installed system-wide.

### DIFF
--- a/builtin/mainmenu/game_theme.lua
+++ b/builtin/mainmenu/game_theme.lua
@@ -20,7 +20,7 @@ mm_game_theme = {}
 
 --------------------------------------------------------------------------------
 function mm_game_theme.init()
-	mm_game_theme.defaulttexturedir = core.get_texturepath() .. DIR_DELIM .. "base" ..
+	mm_game_theme.defaulttexturedir = core.get_texturepath_share() .. DIR_DELIM .. "base" ..
 						DIR_DELIM .. "pack" .. DIR_DELIM
 	mm_game_theme.basetexturedir = mm_game_theme.defaulttexturedir
 


### PR DESCRIPTION
This PR makes the Minetest logo show up in the main menu when installed system-wide (RUN_IN_PLACE=0). Before this, it would try to load the logo from `~/.minetest/textures/base/pack/menu_header.png` which is incorrect, it should really be `/usr/share/minetest/textures/base/pack/menu_header.png`.

## To do
This PR is Ready for Review.

## How to test
1. Build Minetest with RUN_IN_PLACE=0, i.e. a system-wide install and install it.
2. Launch the game and go to a main menu tab other than the "Start game" tab and see that the Minetest logo now shows up properly.
3. Install a texture pack that has a custom Minetest logo (i.e. REFI textures). Restart the game and see that the Minetest logo is now the custom one provided by the texture pack.