### PR TITLE
Apply texture pack main menu textures immediately

### DIFF
--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -154,6 +154,9 @@ local function handle_doubleclick(pkg)
 			core.settings:set("texture_path", pkg.path)
 		end
 		packages = nil
+
+		mm_game_theme.init()
+		mm_game_theme.reset()
 	end
 end
 

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -197,17 +197,17 @@ local function handle_buttons(tabview, fields, tabname, tabdata)
 		return true
 	end
 
-	if fields.btn_mod_mgr_use_txp then
-		local txp = packages:get_list()[tabdata.selected_pkg]
-		core.settings:set("texture_path", txp.path)
-		packages = nil
-		return true
-	end
+	if fields.btn_mod_mgr_use_txp or fields.btn_mod_mgr_disable_txp then
+		local txp_path = ""
+		if fields.btn_mod_mgr_use_txp then
+			txp_path = packages:get_list()[tabdata.selected_pkg].path
+		end
 
-
-	if fields.btn_mod_mgr_disable_txp then
-		core.settings:set("texture_path", "")
+		core.settings:set("texture_path", txp_path)
 		packages = nil
+
+		mm_game_theme.init()
+		mm_game_theme.reset()
 		return true
 	end
 


### PR DESCRIPTION
This PR makes texture pack main menu textures apply immediately after being enabled. Previously it would only take effect after restarting Minetest.

## To do
This PR is Ready for Review.

## How to test
1. Apply the changes in this PR, and install [this](https://github.com/minetest/minetest/files/7966319/menu_texturepack.zip) texture pack for testing.
2. Open Minetest and enable the texture pack. This should make the main menu immediately switch to the texture pack's textures.
3. Disable the texture pack. It should immediately switch back to the default textures and the built-in sky background.