### PR TITLE
Increase the default FPS cap to 200, including on Android

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -594,7 +594,7 @@ arm_inertia (Arm inertia) bool true
 
 #    If FPS would go higher than this, limit it by sleeping
 #    to not waste CPU power for no benefit.
-fps_max (Maximum FPS) int 60 1
+fps_max (Maximum FPS) int 200 1
 
 #    Maximum FPS when the window is not focused, or when the game is paused.
 fps_max_unfocused (FPS when unfocused or paused) int 20 1

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -676,7 +676,7 @@
 #    If FPS would go higher than this, limit it by sleeping
 #    to not waste CPU power for no benefit.
 #    type: int min: 1
-# fps_max = 60
+# fps_max = 200
 
 #    Maximum FPS when the window is not focused, or when the game is paused.
 #    type: int min: 1
@@ -3400,4 +3400,3 @@
 #    This should be lower than curl_parallel_limit.
 #    type: int
 # contentdb_max_concurrent_downloads = 3
-

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -169,7 +169,7 @@ void set_default_settings()
 	settings->setDefault("3d_paralax_strength", "0.025");
 	settings->setDefault("tooltip_show_delay", "400");
 	settings->setDefault("tooltip_append_itemname", "false");
-	settings->setDefault("fps_max", "60");
+	settings->setDefault("fps_max", "200");
 	settings->setDefault("fps_max_unfocused", "20");
 	settings->setDefault("viewing_range", "190");
 #if ENABLE_GLES
@@ -477,7 +477,6 @@ void set_default_settings()
 	settings->setDefault("emergequeue_limit_generate", "16");
 	settings->setDefault("max_block_generate_distance", "5");
 	settings->setDefault("enable_3d_clouds", "false");
-	settings->setDefault("fps_max", "30");
 	settings->setDefault("fps_max_unfocused", "10");
 	settings->setDefault("max_objects_per_block", "20");
 	settings->setDefault("sqlite_synchronous", "1");


### PR DESCRIPTION
This effectively uncaps the framerate on all platforms, making the game run as fast as possible for smoother and lower-latency gameplay. On platforms that force V-Sync such as Android, the framerate will not exceed the display refresh rate. (`vsync` can be set to `true` in `minetest.conf` on other platforms.)

On desktop platforms, this allows making use of high refresh rate monitors without requiring any configuration from the user. 120 Hz and higher monitors are becoming common, even on some non-gaming laptops as of late.

On fast Android devices, this provides a much better out of the box experience by allowing the game to run at 60 FPS instead of 30 FPS.

The value 200 was chosen because it's enough for most monitors on the market, while also reducing audible coil whine on high-end GPUs and [avoiding physics glitches due to high FPS](https://github.com/minetest/minetest/issues/10962).

This closes https://github.com/minetest/minetest/issues/12009.

## To do

This PR is Ready for Review.

We may want to consider enabling V-Sync by default on all platforms to improve smoothness (and reduce power consumption) at the cost of higher input lag. I'm neutral on whether this is a good idea, as 60 Hz monitor users may find the added latency unpleasant.

## How to test

Set `fps_max` to 400 in `minetest.conf` and run the game on your device.