### PR TITLE
Add support for 'seed' in disallow_mapgen_settings

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -315,12 +315,17 @@ local function create_world_formspec(dialogdata)
 		"field[0.3,0.6;6,0.5;te_world_name;" ..
 		fgettext("World name") ..
 		";" .. core.formspec_escape(dialogdata.worldname) .. "]" ..
-		"set_focus[te_world_name;false]" ..
+		"set_focus[te_world_name;false]"
 
-		"field[0.3,1.7;6,0.5;te_seed;" ..
-		fgettext("Seed") ..
-		";".. core.formspec_escape(dialogdata.seed) .. "]" ..
+	if not disallowed_mapgen_settings["seed"] then
 
+		retval = retval .. "field[0.3,1.7;6,0.5;te_seed;" ..
+				fgettext("Seed") ..
+				";".. core.formspec_escape(dialogdata.seed) .. "]"
+
+	end
+
+	retval = retval ..
 		"label[0,2;" .. fgettext("Mapgen") .. "]"..
 		"dropdown[0,2.5;6.3;dd_mapgen;" .. mglist .. ";" .. selindex .. "]"
 
@@ -391,7 +396,7 @@ local function create_world_buttonhandler(this, fields)
 		end
 
 		if message == nil then
-			this.data.seed = fields["te_seed"]
+			this.data.seed = fields["te_seed"] or ""
 			this.data.mg = fields["dd_mapgen"]
 
 			-- actual names as used by engine
@@ -426,7 +431,7 @@ local function create_world_buttonhandler(this, fields)
 	end
 
 	this.data.worldname = fields["te_world_name"]
-	this.data.seed = fields["te_seed"]
+	this.data.seed = fields["te_seed"] or ""
 
 	if fields["games"] then
 		local gameindex = core.get_textlist_index("games")

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -78,7 +78,7 @@ The game directory can contain the following files:
     * `disallowed_mapgen_settings= <comma-separated mapgen settings>`
       e.g. `disallowed_mapgen_settings = mgv5_spflags`
       These mapgen settings are hidden for this game in the world creation
-      dialog and game start menu.
+      dialog and game start menu. Add `seed` to hide the seed input field.
     * `disabled_settings = <comma-separated settings>`
       e.g. `disabled_settings = enable_damage, creative_mode`
       These settings are hidden for this game in the "Start game" tab


### PR DESCRIPTION
This is a feature PR. This extends the `game.conf` variable `disallow_mapgen_settings`.

With `disallow_mapgen_settings = seed` you can remove the seed from the Create World dialog.

Use case: Useful for games with static maps in which the map seed is irrelevant.