### PR TITLE
Fix types of get_mapgen_setting_noiseparams

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -517,24 +517,20 @@ end
 
 local function get_current_np_group_as_string(setting)
 	local value = core.settings:get_np_group(setting.name)
-	local t
 	if value == nil then
-		t = setting.default
-	else
-		t = value.offset .. ", " ..
-			value.scale .. ", (" ..
-			value.spread.x .. ", " ..
-			value.spread.y .. ", " ..
-			value.spread.z .. "), " ..
-			value.seed .. ", " ..
-			value.octaves .. ", " ..
-			value.persistence .. ", " ..
-			value.lacunarity
-		if value.flags ~= "" then
-			t = t .. ", " .. value.flags
-		end
+		return setting.default
 	end
-	return t
+	return ("%g, %g, (%g, %g, %g), %g, %g, %g, %g"):format(
+		value.offset,
+		value.scale,
+		value.spread.x,
+		value.spread.y,
+		value.spread.z,
+		value.seed,
+		value.octaves,
+		value.persistence,
+		value.lacunarity
+	) .. (value.flags ~= "" and (", " .. value.flags) or "")
 end
 
 local checkboxes = {} -- handle checkboxes events
@@ -667,7 +663,7 @@ local function create_change_setting_formspec(dialogdata)
 	elseif setting.type == "v3f" then
 		local val = get_current_value(setting)
 		local v3f = {}
-		for line in val:gmatch("[+-]?[%d.-e]+") do -- All numeric characters
+		for line in val:gmatch("[+-]?[%d.+-eE]+") do -- All numeric characters
 			table.insert(v3f, line)
 		end
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1697,24 +1697,19 @@ bool read_noiseparams(lua_State *L, int index, NoiseParams *np)
 void push_noiseparams(lua_State *L, NoiseParams *np)
 {
 	lua_newtable(L);
-	push_float_string(L, np->offset);
-	lua_setfield(L, -2, "offset");
-	push_float_string(L, np->scale);
-	lua_setfield(L, -2, "scale");
-	push_float_string(L, np->persist);
-	lua_setfield(L, -2, "persistence");
-	push_float_string(L, np->lacunarity);
-	lua_setfield(L, -2, "lacunarity");
-	lua_pushnumber(L, np->seed);
-	lua_setfield(L, -2, "seed");
-	lua_pushnumber(L, np->octaves);
-	lua_setfield(L, -2, "octaves");
+	setfloatfield(L, -1, "offset",      np->offset);
+	setfloatfield(L, -1, "scale",       np->scale);
+	setfloatfield(L, -1, "persist",     np->persist);
+	setfloatfield(L, -1, "persistence", np->persist);
+	setfloatfield(L, -1, "lacunarity",  np->lacunarity);
+	setintfield(  L, -1, "seed",        np->seed);
+	setintfield(  L, -1, "octaves",     np->octaves);
 
 	push_flags_string(L, flagdesc_noiseparams, np->flags,
 		np->flags);
 	lua_setfield(L, -2, "flags");
 
-	push_v3_float_string(L, np->spread);
+	push_v3f(L, np->spread);
 	lua_setfield(L, -2, "spread");
 }
 

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -73,13 +73,6 @@ static void set_vector_metatable(lua_State *L)
 	lua_pop(L, 1);
 }
 
-
-void push_float_string(lua_State *L, float value)
-{
-	auto str = ftos(value);
-	lua_pushstring(L, str.c_str());
-}
-
 void push_v3f(lua_State *L, v3f p)
 {
 	lua_createtable(L, 0, 3);
@@ -98,26 +91,6 @@ void push_v2f(lua_State *L, v2f p)
 	lua_pushnumber(L, p.X);
 	lua_setfield(L, -2, "x");
 	lua_pushnumber(L, p.Y);
-	lua_setfield(L, -2, "y");
-}
-
-void push_v3_float_string(lua_State *L, v3f p)
-{
-	lua_createtable(L, 0, 3);
-	push_float_string(L, p.X);
-	lua_setfield(L, -2, "x");
-	push_float_string(L, p.Y);
-	lua_setfield(L, -2, "y");
-	push_float_string(L, p.Z);
-	lua_setfield(L, -2, "z");
-}
-
-void push_v2_float_string(lua_State *L, v2f p)
-{
-	lua_createtable(L, 0, 2);
-	push_float_string(L, p.X);
-	lua_setfield(L, -2, "x");
-	push_float_string(L, p.Y);
 	lua_setfield(L, -2, "y");
 }
 

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -118,9 +118,6 @@ std::vector<aabb3f> read_aabb3f_vector  (lua_State *L, int index, f32 scale);
 size_t              read_stringlist     (lua_State *L, int index,
                                          std::vector<std::string> *result);
 
-void                push_float_string   (lua_State *L, float value);
-void                push_v3_float_string(lua_State *L, v3f p);
-void                push_v2_float_string(lua_State *L, v2f p);
 void                push_v2s16          (lua_State *L, v2s16 p);
 void                push_v2s32          (lua_State *L, v2s32 p);
 void                push_v3s16          (lua_State *L, v3s16 p);


### PR DESCRIPTION
Bugfix. Closes #11962, ready for review. Mainmenu noiseparam setting editing still works. @srifqi

Regarding possible breakage:

* The **documentation** mentions numbers and not strings, so the old behavior was clearly a **bug** nobody should have relied on;
* When passing params to **setters both numbers and strings were, are and continue to be supported** (by means of `tonumber`);
* If somebody **`tonumber`ed the strings, that is a no-op for numbers and works as expected** there;
* If somebody performed **arithmetic** or called **math funcs** on the strings, relying on the implicit conversion Lua does, that will obviously work with numbers too;
* And **even most (all?) string operations will, due to the same implicit string-number conversion, just stringify the number**;

The only thing this would break would be actual typechecks for a buggy type or trying to index the number (something like `noiseparams.something:sub(...)`, but I suppose that hardly matters. Should it be found in the wild, it's *definitely* utter swinecode and on the mod authors, who should be urged to upgrade.

Also note that prior to 5.0, said getter would return numbers.