### PR TITLE
Deprecate game.conf name, use title instead

### DIFF
--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -151,11 +151,9 @@ local function start_install(package, reason)
 
 				if conf_path then
 					local conf = Settings(conf_path)
-					if name_is_title then
-						conf:set("name",   package.title)
-					else
-						conf:set("title",  package.title)
-						conf:set("name",   package.name)
+					conf:set("title", package.title)
+					if not name_is_title then
+						conf:set("name", package.name)
 					end
 					if not conf:get("description") then
 						conf:set("description", package.short_description)
@@ -360,7 +358,7 @@ function install_dialog.get_formspec()
 			selected_game_idx = i
 		end
 
-		games[i] = core.formspec_escape(games[i].name)
+		games[i] = core.formspec_escape(games[i].title)
 	end
 
 	local selected_game = pkgmgr.games[selected_game_idx]
@@ -410,7 +408,7 @@ function install_dialog.get_formspec()
 		"container[0.375,0.70]",
 
 		"label[0,0.25;", fgettext("Base Game:"), "]",
-		"dropdown[2,0;4.25,0.5;gameid;", table.concat(games, ","), ";", selected_game_idx, "]",
+		"dropdown[2,0;4.25,0.5;selected_game;", table.concat(games, ","), ";", selected_game_idx, "]",
 
 		"label[0,0.8;", fgettext("Dependencies:"), "]",
 
@@ -461,9 +459,9 @@ function install_dialog.handle_submit(this, fields)
 		return true
 	end
 
-	if fields.gameid then
+	if fields.selected_game then
 		for _, game in pairs(pkgmgr.games) do
-			if game.name == fields.gameid then
+			if game.title == fields.selected_game then
 				core.settings:set("menu_last_game", game.id)
 				break
 			end

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -646,6 +646,8 @@ function pkgmgr.install_dir(type, path, basename, targetpath)
 		else
 			targetpath = core.get_gamepath() .. DIR_DELIM .. basename
 		end
+	else
+		error("basefolder didn't return a recognised type, this shouldn't happen")
 	end
 
 	-- Copy it
@@ -692,7 +694,7 @@ function pkgmgr.preparemodlist(data)
 		retval[#retval + 1] = {
 			type = "game",
 			is_game_content = true,
-			name = fgettext("$1 mods", gamespec.name),
+			name = fgettext("$1 mods", gamespec.title),
 			path = gamespec.path
 		}
 	end
@@ -873,10 +875,10 @@ end
 function pkgmgr.gamelist()
 	local retval = ""
 	if #pkgmgr.games > 0 then
-		retval = retval .. core.formspec_escape(pkgmgr.games[1].name)
+		retval = retval .. core.formspec_escape(pkgmgr.games[1].title)
 
 		for i=2,#pkgmgr.games,1 do
-			retval = retval .. "," .. core.formspec_escape(pkgmgr.games[i].name)
+			retval = retval .. "," .. core.formspec_escape(pkgmgr.games[i].title)
 		end
 	end
 	return retval

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -88,7 +88,7 @@ if enable_gamebar then
 
 			local image = nil
 			local text = nil
-			local tooltip = core.formspec_escape(game.name)
+			local tooltip = core.formspec_escape(game.title)
 
 			if (game.menuicon_path or "") ~= "" then
 				image = core.formspec_escape(game.menuicon_path)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -62,7 +62,8 @@ Where `<gameid>` is unique to each game.
 The game directory can contain the following files:
 
 * `game.conf`, with the following keys:
-    * `name`: Required, a human readable title to address the game, e.g. `name = Minetest`.
+    * `title`: Required, a human-readable title to address the game, e.g. `title = Minetest Game`.
+    * `name`: (Deprecated) same as title.
     * `description`: Short description to be shown in the content tab
     * `allowed_mapgens = <comma-separated mapgens>`
       e.g. `allowed_mapgens = v5,v6,flat`

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -246,13 +246,14 @@ Package - content which is downloadable from the content db, may or may not be i
 * core.get_texturepath() (possible in async calls)
     * returns path to default textures
 * core.get_game(index)
+    * `name` in return value is deprecated, use `title` instead.
     * returns:
 
         {
             id               = <id>,
             path             = <full path to game>,
             gamemods_path    = <path>,
-            name             = <name of game>,
+            title            = <title of game>,
             menuicon_path    = <full path to menuicon>,
             author           = "author",
             DEPRECATED:
@@ -266,6 +267,7 @@ Package - content which is downloadable from the content db, may or may not be i
         {
             name             = "name of content",
             type             = "mod" or "modpack" or "game" or "txp",
+            title            = "Human readable title",
             description      = "description",
             author           = "author",
             path             = "path/to/content",

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -265,7 +265,7 @@ Package - content which is downloadable from the content db, may or may not be i
     * returns
 
         {
-            name             = "name of content",
+            name             = "technical_id",
             type             = "mod" or "modpack" or "game" or "txp",
             title            = "Human readable title",
             description      = "description",

--- a/games/devtest/game.conf
+++ b/games/devtest/game.conf
@@ -1,2 +1,2 @@
-name = Development Test
+title = Development Test
 description = Testing environment to help with testing the engine features of Minetest. It can also be helpful in mod development.

--- a/src/content/content.cpp
+++ b/src/content/content.cpp
@@ -96,7 +96,12 @@ void parseContentInfo(ContentSpec &spec)
 
 	Settings conf;
 	if (!conf_path.empty() && conf.readConfigFile(conf_path.c_str())) {
-		if (conf.exists("name"))
+		if (conf.exists("title"))
+			spec.title = conf.get("title");
+		else if (spec.type == "game" && conf.exists("name"))
+			spec.title = conf.get("name");
+
+		if (spec.type != "game" && conf.exists("name"))
 			spec.name = conf.get("name");
 
 		if (conf.exists("description"))

--- a/src/content/content.h
+++ b/src/content/content.h
@@ -27,7 +27,14 @@ struct ContentSpec
 	std::string type;
 	std::string author;
 	u32 release = 0;
+
+	/// Technical name / Id
 	std::string name;
+
+	/// Human-readable title
+	std::string title;
+
+	/// Short description
 	std::string desc;
 	std::string path;
 };

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include <common/c_internal.h>
 #include "content/subgames.h"
 #include "porting.h"
 #include "filesys.h"
@@ -44,6 +45,25 @@ bool getGameMinetestConfig(const std::string &game_path, Settings &conf)
 }
 
 }
+
+
+void SubgameSpec::checkAndLog() const
+{
+	// Log deprecation messages
+	auto handling_mode = get_deprecated_handling_mode();
+	if (!deprecation_msgs.empty() && handling_mode != DeprecatedHandlingMode::Ignore) {
+		std::ostringstream os;
+		os << "Game " << title << " at " << path << ":" << std::endl;
+		for (auto msg : deprecation_msgs)
+			os << "\t" << msg << std::endl;
+
+		if (handling_mode == DeprecatedHandlingMode::Error)
+			throw ModError(os.str());
+		else
+			warningstream << os.str();
+	}
+}
+
 
 struct GameFindPath
 {
@@ -121,11 +141,13 @@ SubgameSpec findSubgame(const std::string &id)
 	Settings conf;
 	conf.readConfigFile(conf_path.c_str());
 
-	std::string game_name;
-	if (conf.exists("name"))
-		game_name = conf.get("name");
+	std::string game_title;
+	if (conf.exists("title"))
+		game_title = conf.get("title");
+	else if (conf.exists("name"))
+		game_title = conf.get("name");
 	else
-		game_name = id;
+		game_title = id;
 
 	std::string game_author;
 	if (conf.exists("author"))
@@ -140,8 +162,14 @@ SubgameSpec findSubgame(const std::string &id)
 	menuicon_path = getImagePath(
 			game_path + DIR_DELIM + "menu" + DIR_DELIM + "icon.png");
 #endif
-	return SubgameSpec(id, game_path, gamemod_path, mods_paths, game_name,
+
+	SubgameSpec spec(id, game_path, gamemod_path, mods_paths, game_title,
 			menuicon_path, game_author, game_release);
+
+	if (conf.exists("name") && !conf.exists("title"))
+		spec.deprecation_msgs.push_back("name in game.conf is deprecated, please use title instead");
+
+	return spec;
 }
 
 SubgameSpec findWorldSubgame(const std::string &world_path)
@@ -159,10 +187,12 @@ SubgameSpec findWorldSubgame(const std::string &world_path)
 		std::string conf_path = world_gamepath + DIR_DELIM + "game.conf";
 		conf.readConfigFile(conf_path.c_str());
 
-		if (conf.exists("name"))
-			gamespec.name = conf.get("name");
+		if (conf.exists("title"))
+			gamespec.title = conf.get("title");
+		else if (conf.exists("name"))
+			gamespec.title = conf.get("name");
 		else
-			gamespec.name = world_gameid;
+			gamespec.title = world_gameid;
 
 		return gamespec;
 	}

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -167,7 +167,7 @@ SubgameSpec findSubgame(const std::string &id)
 			menuicon_path, game_author, game_release);
 
 	if (conf.exists("name") && !conf.exists("title"))
-		spec.deprecation_msgs.push_back("name in game.conf is deprecated, please use title instead");
+		spec.deprecation_msgs.push_back("\"name\" setting in game.conf is deprecated, please use \"title\" instead");
 
 	return spec;
 }

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -29,7 +29,7 @@ class Settings;
 struct SubgameSpec
 {
 	std::string id;
-	std::string name;
+	std::string title;
 	std::string author;
 	int release;
 	std::string path;
@@ -41,20 +41,24 @@ struct SubgameSpec
 	std::unordered_map<std::string, std::string> addon_mods_paths;
 	std::string menuicon_path;
 
+	// For logging purposes
+	std::vector<const char *> deprecation_msgs;
+
 	SubgameSpec(const std::string &id = "", const std::string &path = "",
 			const std::string &gamemods_path = "",
 			const std::unordered_map<std::string, std::string> &addon_mods_paths = {},
-			const std::string &name = "",
+			const std::string &title = "",
 			const std::string &menuicon_path = "",
 			const std::string &author = "", int release = 0) :
 			id(id),
-			name(name), author(author), release(release), path(path),
+			title(title), author(author), release(release), path(path),
 			gamemods_path(gamemods_path), addon_mods_paths(addon_mods_paths),
 			menuicon_path(menuicon_path)
 	{
 	}
 
 	bool isValid() const { return (!id.empty() && !path.empty()); }
+	void checkAndLog() const;
 };
 
 SubgameSpec findSubgame(const std::string &id);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -304,7 +304,11 @@ int ModApiMainMenu::l_get_games(lua_State *L)
 		lua_settable(L,    top_lvl2);
 
 		lua_pushstring(L,  "name");
-		lua_pushstring(L,  game.name.c_str());
+		lua_pushstring(L,  game.title.c_str());
+		lua_settable(L,    top_lvl2);
+
+		lua_pushstring(L,  "title");
+		lua_pushstring(L,  game.title.c_str());
 		lua_settable(L,    top_lvl2);
 
 		lua_pushstring(L,  "author");
@@ -355,6 +359,11 @@ int ModApiMainMenu::l_get_content_info(lua_State *L)
 
 	lua_pushstring(L, spec.author.c_str());
 	lua_setfield(L, -2, "author");
+
+	if (!spec.title.empty()) {
+		lua_pushstring(L, spec.title.c_str());
+		lua_setfield(L, -2, "title");
+	}
 
 	lua_pushinteger(L, spec.release);
 	lua_setfield(L, -2, "release");

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -440,6 +440,7 @@ void Server::init()
 
 	m_script->loadMod(getBuiltinLuaPath() + DIR_DELIM "init.lua", BUILTIN_MOD_NAME);
 
+	m_gamespec.checkAndLog();
 	m_modmgr->loadMods(m_script);
 
 	// Read Textures and calculate sha1 sums
@@ -3109,7 +3110,7 @@ std::string Server::getStatusString()
 	// Version
 	os << "version: " << g_version_string;
 	// Game
-	os << " | game: " << (m_gamespec.name.empty() ? m_gamespec.id : m_gamespec.name);
+	os << " | game: " << (m_gamespec.title.empty() ? m_gamespec.id : m_gamespec.title);
 	// Uptime
 	os << " | uptime: " << duration_to_string((int) m_uptime_counter->get());
 	// Max lag estimate


### PR DESCRIPTION
This makes it more consistent with mod.conf, modpack.conf, and texture_pack.conf

Currently: 

* Technical name / id
    * the folder name for games
    * `name` for mods/texture packs
* Human-readable title
    * `name` for games
    * `title` for mods/texture packs

This is very likely to lead to confusion, as `name` is an id for mods but a title for games.

This PR deprecates `name` for games and uses `title` instead - making it consistent with mods.

## To do

This PR is ready for review

## How to test

Download various games, check gameid and titles in the UI still work
