### PR TITLE
Add helper functions to make tool usable n times

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3512,6 +3512,12 @@ Helper functions
 * `minetest.pointed_thing_to_face_pos(placer, pointed_thing)`: returns a
   position.
     * returns the exact position on the surface of a pointed node
+* `minetest.get_tool_wear_after_use(uses [, initial_wear])`
+    * Simulates a tool being used once and returns the added wear,
+    * such that, if only this function is used to calculate wear,
+    * the tool will break exactly after `uses` times of uses
+    * `uses`: Number of times the tool can be used
+    * `initial_wear`: The initial wear the tool starts with (default: 0)
 * `minetest.get_dig_params(groups, tool_capabilities [, wear])`:
     Simulates an item that digs a node.
     Returns a table with the following fields:

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6383,11 +6383,11 @@ an itemstring, a table or `nil`.
     * Increases wear by `amount` if the item is a tool, otherwise does nothing
     * Valid `amount` range is [0,65536]
     * `amount`: number, integer
-* `add_wear_by_uses(uses)`
+* `add_wear_by_uses(max_uses)`
     * Increases wear in such a way that, if only this function is called,
-      the item breaks after `uses` times
-    * Valid `uses` range is [0,65536]
-    * Does nothing if item is not a tool or if `uses` is 0
+      the item breaks after `max_uses` times
+    * Valid `max_uses` range is [0,65536]
+    * Does nothing if item is not a tool or if `max_uses` is 0
 * `add_item(item)`: returns leftover `ItemStack`
     * Put some item or stack onto this stack
 * `item_fits(item)`: returns `true` if item or stack can be fully added to

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3514,8 +3514,8 @@ Helper functions
     * returns the exact position on the surface of a pointed node
 * `minetest.get_tool_wear_after_use(uses [, initial_wear])`
     * Simulates a tool being used once and returns the added wear,
-    * such that, if only this function is used to calculate wear,
-    * the tool will break exactly after `uses` times of uses
+      such that, if only this function is used to calculate wear,
+      the tool will break exactly after `uses` times of uses
     * `uses`: Number of times the tool can be used
     * `initial_wear`: The initial wear the tool starts with (default: 0)
 * `minetest.get_dig_params(groups, tool_capabilities [, wear])`:

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6381,12 +6381,13 @@ an itemstring, a table or `nil`.
   or those of the hand if none are defined for this item type
 * `add_wear(amount)`
     * Increases wear by `amount` if the item is a tool, otherwise does nothing
+    * Valid `amount` range is [0,65536]
     * `amount`: number, integer
 * `add_wear_by_uses(uses)`
     * Increases wear in such a way that, if only this function is called,
-      the item breaks after `uses` times.
-    * Valid `uses` range is [0,65536].
-    * Does nothing if item is not a tool or if `uses` is 0.
+      the item breaks after `uses` times
+    * Valid `uses` range is [0,65536]
+    * Does nothing if item is not a tool or if `uses` is 0
 * `add_item(item)`: returns leftover `ItemStack`
     * Put some item or stack onto this stack
 * `item_fits(item)`: returns `true` if item or stack can be fully added to

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6382,6 +6382,11 @@ an itemstring, a table or `nil`.
 * `add_wear(amount)`
     * Increases wear by `amount` if the item is a tool, otherwise does nothing
     * `amount`: number, integer
+* `add_wear_by_uses(uses)`
+    * Increases wear in such a way that, if only this function is called,
+      the item breaks after `uses` times.
+    * Valid `uses` range is [0,65536].
+    * Does nothing if item is not a tool or if `uses` is 0.
 * `add_item(item)`: returns leftover `ItemStack`
     * Put some item or stack onto this stack
 * `item_fits(item)`: returns `true` if item or stack can be fully added to

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -356,6 +356,26 @@ int LuaItemStack::l_add_wear(lua_State *L)
 	return 1;
 }
 
+// add_wear_by_uses(self, uses) -> true/false
+// The range for "uses" is [0,65536].
+// Adds wear to the item in such a way that, if
+// only this function is called to add wear, the item
+// will be destroyed exactly after `uses` times of calling it.
+// No-op if `uses` is 0 or item is not a tool.
+// Returns true if the item is (or was) a tool.
+int LuaItemStack::l_add_wear_by_uses(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	LuaItemStack *o = checkobject(L, 1);
+	ItemStack &item = o->m_stack;
+	u32 uses = readParam<int>(L, 2);
+	u16 initial_wear = item.wear;
+	u32 add_wear = calculateResultWear(uses, initial_wear);
+	bool result = item.addWear(add_wear, getGameDef(L)->idef());
+	lua_pushboolean(L, result);
+	return 1;
+}
+
 // add_item(self, itemstack or itemstring or table or nil) -> itemstack
 // Returns leftover item stack
 int LuaItemStack::l_add_item(lua_State *L)
@@ -514,6 +534,7 @@ const luaL_Reg LuaItemStack::methods[] = {
 	luamethod(LuaItemStack, get_definition),
 	luamethod(LuaItemStack, get_tool_capabilities),
 	luamethod(LuaItemStack, add_wear),
+	luamethod(LuaItemStack, add_wear_by_uses),
 	luamethod(LuaItemStack, add_item),
 	luamethod(LuaItemStack, item_fits),
 	luamethod(LuaItemStack, take_item),

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -342,7 +342,7 @@ int LuaItemStack::l_get_tool_capabilities(lua_State *L)
 }
 
 // add_wear(self, amount) -> true/false
-// The range for "amount" is [0,65535]. Wear is only added if the item
+// The range for "amount" is [0,65536]. Wear is only added if the item
 // is a tool. Adding wear might destroy the item.
 // Returns true if the item is (or was) a tool.
 int LuaItemStack::l_add_wear(lua_State *L)

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -369,8 +369,7 @@ int LuaItemStack::l_add_wear_by_uses(lua_State *L)
 	LuaItemStack *o = checkobject(L, 1);
 	ItemStack &item = o->m_stack;
 	u32 uses = readParam<int>(L, 2);
-	u16 initial_wear = item.wear;
-	u32 add_wear = calculateResultWear(uses, initial_wear);
+	u32 add_wear = calculateResultWear(uses, item.wear);
 	bool result = item.addWear(add_wear, getGameDef(L)->idef());
 	lua_pushboolean(L, result);
 	return 1;

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -356,20 +356,20 @@ int LuaItemStack::l_add_wear(lua_State *L)
 	return 1;
 }
 
-// add_wear_by_uses(self, uses) -> true/false
-// The range for "uses" is [0,65536].
+// add_wear_by_uses(self, max_uses) -> true/false
+// The range for "max_uses" is [0,65536].
 // Adds wear to the item in such a way that, if
 // only this function is called to add wear, the item
-// will be destroyed exactly after `uses` times of calling it.
-// No-op if `uses` is 0 or item is not a tool.
+// will be destroyed exactly after `max_uses` times of calling it.
+// No-op if `max_uses` is 0 or item is not a tool.
 // Returns true if the item is (or was) a tool.
 int LuaItemStack::l_add_wear_by_uses(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	LuaItemStack *o = checkobject(L, 1);
 	ItemStack &item = o->m_stack;
-	u32 uses = readParam<int>(L, 2);
-	u32 add_wear = calculateResultWear(uses, item.wear);
+	u32 max_uses = readParam<int>(L, 2);
+	u32 add_wear = calculateResultWear(max_uses, item.wear);
 	bool result = item.addWear(add_wear, getGameDef(L)->idef());
 	lua_pushboolean(L, result);
 	return 1;

--- a/src/script/lua_api/l_item.h
+++ b/src/script/lua_api/l_item.h
@@ -113,6 +113,15 @@ private:
 	// Returns true if the item is (or was) a tool.
 	static int l_add_wear(lua_State *L);
 
+	// add_wear_by_uses(self, uses) -> true/false
+	// The range for "uses" is [0,65536].
+	// Adds wear to the item in such a way that, if
+	// only this function is called to add wear, the item
+	// will be destroyed exactly after `uses` times of calling it.
+	// No-op if `uses` is 0 or item is not a tool.
+	// Returns true if the item is (or was) a tool.
+	static int l_add_wear_by_uses(lua_State *L);
+
 	// add_item(self, itemstack or itemstring or table or nil) -> itemstack
 	// Returns leftover item stack
 	static int l_add_item(lua_State *L);

--- a/src/script/lua_api/l_item.h
+++ b/src/script/lua_api/l_item.h
@@ -108,7 +108,7 @@ private:
 	static int l_get_tool_capabilities(lua_State *L);
 
 	// add_wear(self, amount) -> true/false
-	// The range for "amount" is [0,65535]. Wear is only added if the item
+	// The range for "amount" is [0,65536]. Wear is only added if the item
 	// is a tool. Adding wear might destroy the item.
 	// Returns true if the item is (or was) a tool.
 	static int l_add_wear(lua_State *L);

--- a/src/script/lua_api/l_item.h
+++ b/src/script/lua_api/l_item.h
@@ -113,12 +113,12 @@ private:
 	// Returns true if the item is (or was) a tool.
 	static int l_add_wear(lua_State *L);
 
-	// add_wear_by_uses(self, uses) -> true/false
-	// The range for "uses" is [0,65536].
+	// add_wear_by_uses(self, max_uses) -> true/false
+	// The range for "max_uses" is [0,65536].
 	// Adds wear to the item in such a way that, if
 	// only this function is called to add wear, the item
-	// will be destroyed exactly after `uses` times of calling it.
-	// No-op if `uses` is 0 or item is not a tool.
+	// will be destroyed exactly after `max_uses` times of calling it.
+	// No-op if `max_uses` is 0 or item is not a tool.
 	// Returns true if the item is (or was) a tool.
 	static int l_add_wear_by_uses(lua_State *L);
 

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -164,9 +164,7 @@ int ModApiUtil::l_get_tool_wear_after_use(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	u32 uses = readParam<int>(L, 1);
-	u16 initial_wear = 0;
-	if (!lua_isnoneornil(L, 2))
-		initial_wear = readParam<int>(L, 2);
+	u16 initial_wear = readParam<int>(L, 2, 0);
 	u16 wear = calculateResultWear(uses, initial_wear);
 	lua_pushnumber(L, wear);
 	return 1;

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -159,6 +159,19 @@ int ModApiUtil::l_write_json(lua_State *L)
 	return 1;
 }
 
+// get_tool_wear_after_use(uses[, initial_wear])
+int ModApiUtil::l_get_tool_wear_after_use(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	u32 uses = readParam<int>(L, 1);
+	u16 initial_wear = 0;
+	if (!lua_isnoneornil(L, 2))
+		initial_wear = readParam<int>(L, 2);
+	u16 wear = calculateResultWear(uses, initial_wear);
+	lua_pushnumber(L, wear);
+	return 1;
+}
+
 // get_dig_params(groups, tool_capabilities[, wear])
 int ModApiUtil::l_get_dig_params(lua_State *L)
 {
@@ -586,6 +599,7 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 	API_FCT(parse_json);
 	API_FCT(write_json);
 
+	API_FCT(get_tool_wear_after_use);
 	API_FCT(get_dig_params);
 	API_FCT(get_hit_params);
 

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -50,6 +50,9 @@ private:
 	// write_json(data[, styled])
 	static int l_write_json(lua_State *L);
 
+	// get_tool_wear_after_use(uses[, initial_wear])
+	static int l_get_tool_wear_after_use(lua_State *L);
+
 	// get_dig_params(groups, tool_capabilities[, wear])
 	static int l_get_dig_params(lua_State *L);
 

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -183,7 +183,7 @@ void ToolCapabilities::deserializeJson(std::istream &is)
 	}
 }
 
-static u32 calculateResultWear(const u32 uses, const u16 initial_wear)
+u32 calculateResultWear(const u32 uses, const u16 initial_wear)
 {
 	if (uses == 0) {
 		// Trivial case: Infinite uses

--- a/src/tool.h
+++ b/src/tool.h
@@ -142,4 +142,5 @@ PunchDamageResult getPunchDamage(
 		u16 initial_wear = 0
 );
 
+u32 calculateResultWear(const u32 uses, const u16 initial_wear);
 f32 getToolRange(const ItemDefinition &def_selected, const ItemDefinition &def_hand);


### PR DESCRIPTION
This adds two functions:

* `item:add_wear_by_uses`
* `minetest.get_tool_wear_after_use`

These are two helper functions for tools that have a specified number of uses before breaking. Two examples for such tools are MTG's Screwdriver and Flint and Steel. This makes sure the tool will break after the exact specified number of uses.

The first function actually adds the wear to the tool and (if neccessary) breaks it.
The second function only "simulates" it, analog to `get_dig_params` and `get_hit_params`.

It also fixes a minor mistake in the function comments. `add_wear` claims to support only a range of [0,65535] but this is false, it also supports 65536 (which leads to insta-break). I checked this.

## Context
The common (and naive) way that mods usually implement "tool break after *n* uses` is by adding wear with `tool:add_wear(some_fixed_value)` in which `some_fixed_value` is chosen in a way that the tool breaks after exactly `n` times. This works for small numbers of `n` (<273) but as `n` increases you might actually not be able to hit `n` exactly due to rounding. As an extreme example, with this method you can't have a tool with exactly 50000 uses, but must decide 32768 or 65536 uses (adding 2 or 1 wear at every use, respectively).
That's where the helper function comes into play.

This PR builds on the work done in #11110 and is basically an extension of the logic used there for mods. It uses `calculateResultWear` for the calcuation. Read this PR for more context.

Note the actual math is NOT altered by this PR in any way. It basically just exposes the "tool uses before it breaks" calculation the engine already uses to Lua.

## To do

This PR is ready for review.

## How to test

* Activate `luacmd`
* Give yourself any tool with 0 wear and wield it
* `/lua n=60000; p=0; x=me:get_wielded_item(); for i=1,65536 do x:add_wear_by_uses(n); p=p+1; if x:get_count()==0 then break end end print(p); me:set_wielded_item(x)`
* This is a loop that calls `add_wear_by_uses(n)` `n` times, so the tool must break after exactly `n` uses. At the end, it prints out how many iterations this look actually had
* Since `n` is 60000 in this case, it should print out 60000
* Replace the value of `n` with different values, including 0 (=infinite uses), 65535 or 65536
* The other function can be tested in a similar fashion
* Also try manually calling these functions without a loop to see how the wear bar reacts