### PR TITLE
Increase max objects per block defaults

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1306,7 +1306,7 @@ max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096
 server_unload_unused_data_timeout (Unload unused server data) int 29
 
 #    Maximum number of statically stored objects in a block.
-max_objects_per_block (Maximum objects per block) int 64
+max_objects_per_block (Maximum objects per block) int 256
 
 #    See https://www.sqlite.org/pragma.html#pragma_synchronous
 sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1514,7 +1514,7 @@
 
 #    Maximum number of statically stored objects in a block.
 #    type: int
-# max_objects_per_block = 64
+# max_objects_per_block = 256
 
 #    See https://www.sqlite.org/pragma.html#pragma_synchronous
 #    type: enum values: 0, 1, 2

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -386,7 +386,7 @@ void set_default_settings()
 	settings->setDefault("time_speed", "72");
 	settings->setDefault("world_start_time", "6125");
 	settings->setDefault("server_unload_unused_data_timeout", "29");
-	settings->setDefault("max_objects_per_block", "64");
+	settings->setDefault("max_objects_per_block", "256");
 	settings->setDefault("server_map_save_interval", "5.3");
 	settings->setDefault("chat_message_max_size", "500");
 	settings->setDefault("chat_message_limit_per_10sec", "8.0");
@@ -479,7 +479,6 @@ void set_default_settings()
 	settings->setDefault("enable_3d_clouds", "false");
 	settings->setDefault("fps_max", "30");
 	settings->setDefault("fps_max_unfocused", "10");
-	settings->setDefault("max_objects_per_block", "20");
 	settings->setDefault("sqlite_synchronous", "1");
 	settings->setDefault("map_compression_level_disk", "-1");
 	settings->setDefault("map_compression_level_net", "-1");


### PR DESCRIPTION
Minetest will currently delete all items in a mapblock if this max value is exceeded. This means it should only deal with the most pathological cases where the game & user otherwise could hardly recover from instead of happily deleting clusters of user-dropped items (and even those should probably be dealt with manually using clearobjects). The previous defaults of 64 on desktop and 20 on mobile were definitely way too low. I increased both to 256=16x16 (a full 16² plane filled with dropped items) and removed the distinction so that playtesting on desktop with default settings yields similar results to playing on mobile.