### PR TITLE
Correct world_format.txt specification

### DIFF
--- a/doc/world_format.txt
+++ b/doc/world_format.txt
@@ -346,6 +346,9 @@ if map format version >= 29:
   - 0xffffffff = invalid/unknown timestamp, nothing should be done with the time
                  difference when loaded
 
+  u8 name_id_mapping_version
+  - Should be zero for map format version 29.
+  
   u16 num_name_id_mappings
   foreach num_name_id_mappings
     u16 id

--- a/doc/world_format.txt
+++ b/doc/world_format.txt
@@ -447,7 +447,7 @@ if map format version < 29:
     u8[name_len] name
 
 - Node timers
-if map format version == 25:
+if map format version >= 25:
   u8 length of the data of a single timer (always 2+4+4=10)
   u16 num_of_timers
   foreach num_of_timers:


### PR DESCRIPTION
I believe that the specification is incorrect, and that the node timers appear at the end of a mapblock for map format version >= 25, not just map format version 25.  This is based on my observations of map block format #28 (from minetest-5.4.x and multicrraft-2.0.x) while developing a stand-alone C++ library for reading and writing minetest mapblock data.

Add compact, short information about your PR for easier understanding:

- Goal of the PR
- How does the PR work?
- Does it resolve any reported issue?
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is a Work in Progress / Ready for Review.
<!-- ^ delete one -->

- [ ] List
- [ ] Things
- [ ] To do

## How to test

<!-- Example code or instructions -->
