### PR TITLE
 Add C++/Lua classes for Unicode text management

### DIFF
--- a/cmake/Modules/FindHarfBuzz.cmake
+++ b/cmake/Modules/FindHarfBuzz.cmake
@@ -1,0 +1,8 @@
+mark_as_advanced(HARFBUZZ_LIBRARY HARFBUZZ_INCLUDE_DIR)
+
+find_path(HARFBUZZ_INCLUDE_DIR harfbuzz/hb.h)
+
+find_library(HARFBUZZ_LIBRARY NAMES harfbuzz)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HarfBuzz DEFAULT_MSG HARFBUZZ_LIBRARY HARFBUZZ_INCLUDE_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,7 +109,9 @@ endif()
 
 if(BUILD_CLIENT)
 	find_package(Freetype REQUIRED)
+	find_package(HarfBuzz REQUIRED)
 endif()
+find_package(ICU REQUIRED COMPONENTS uc dt in)
 
 option(ENABLE_CURSES "Enable ncurses console" TRUE)
 set(USE_CURSES FALSE)
@@ -480,6 +482,7 @@ include_directories(SYSTEM
 	${GMP_INCLUDE_DIR}
 	${JSON_INCLUDE_DIR}
 	${LUA_BIT_INCLUDE_DIR}
+	${ICU_INCLUDE_DIRS}
 )
 
 if(USE_GETTEXT)
@@ -491,6 +494,7 @@ if(BUILD_CLIENT)
 		${FREETYPE_INCLUDE_DIRS}
 		${SOUND_INCLUDE_DIRS}
 		${X11_INCLUDE_DIR}
+		${HARFBUZZ_INCLUDE_DIR}
 	)
 endif()
 
@@ -520,8 +524,10 @@ if(BUILD_CLIENT)
 		${GMP_LIBRARY}
 		${JSON_LIBRARY}
 		${LUA_BIT_LIBRARY}
-		${FREETYPE_LIBRARY}
 		${PLATFORM_LIBS}
+		${FREETYPE_LIBRARY}
+		${HARFBUZZ_LIBRARY}
+		${ICU_LIBRARIES}
 	)
 	if(NOT USE_LUAJIT)
 		set_target_properties(${PROJECT_NAME} PROPERTIES
@@ -547,7 +553,7 @@ if(BUILD_CLIENT)
 		set_target_properties(${PROJECT_NAME}
 			PROPERTIES
 			COMPILE_FLAGS "${FREETYPE_CFLAGS_STR}"
-	)
+		)
 	endif()
 	if (USE_CURSES)
 		target_link_libraries(${PROJECT_NAME} ${CURSES_LIBRARIES})
@@ -588,6 +594,7 @@ if(BUILD_SERVER)
 		${LUA_BIT_LIBRARY}
 		${GMP_LIBRARY}
 		${PLATFORM_LIBS}
+		${ICU_LIBRARIES}
 	)
 	set_target_properties(${PROJECT_NAME}server PROPERTIES
 		COMPILE_DEFINITIONS "SERVER")
@@ -794,17 +801,6 @@ if(WIN32)
 				FILES_MATCHING PATTERN "*.dll")
 	else()
 		# Use the old-style way to install dll's
-		if(BUILD_CLIENT AND USE_SOUND)
-			if(OPENAL_DLL)
-				install(FILES ${OPENAL_DLL} DESTINATION ${BINDIR})
-			endif()
-			if(OGG_DLL)
-				install(FILES ${OGG_DLL} DESTINATION ${BINDIR})
-			endif()
-			if(VORBIS_DLL)
-				install(FILES ${VORBIS_DLL} DESTINATION ${BINDIR})
-			endif()
-		endif()
 		if(CURL_DLL)
 			install(FILES ${CURL_DLL} DESTINATION ${BINDIR})
 		endif()
@@ -813,9 +809,6 @@ if(WIN32)
 		endif()
 		if(ZSTD_DLL)
 			install(FILES ${ZSTD_DLL} DESTINATION ${BINDIR})
-		endif()
-		if(BUILD_CLIENT AND FREETYPE_DLL)
-			install(FILES ${FREETYPE_DLL} DESTINATION ${BINDIR})
 		endif()
 		if(SQLITE3_DLL)
 			install(FILES ${SQLITE3_DLL} DESTINATION ${BINDIR})
@@ -826,11 +819,33 @@ if(WIN32)
 		if(LUA_DLL)
 			install(FILES ${LUA_DLL} DESTINATION ${BINDIR})
 		endif()
-		if(BUILD_CLIENT AND IRRLICHT_DLL)
-			install(FILES ${IRRLICHT_DLL} DESTINATION ${BINDIR})
+		if(ICU_DLL)
+			install(FILES ${ICU_DLL} DESTINATION ${BINDIR})
 		endif()
-		if(BUILD_CLIENT AND USE_GETTEXT AND GETTEXT_DLL)
-			install(FILES ${GETTEXT_DLL} DESTINATION ${BINDIR})
+		if(BUILD_CLIENT)
+			if(USE_SOUND)
+				if(OPENAL_DLL)
+					install(FILES ${OPENAL_DLL} DESTINATION ${BINDIR})
+				endif()
+				if(OGG_DLL)
+					install(FILES ${OGG_DLL} DESTINATION ${BINDIR})
+				endif()
+				if(VORBIS_DLL)
+					install(FILES ${VORBIS_DLL} DESTINATION ${BINDIR})
+				endif()
+			endif()
+			if(IRRLICHT_DLL)
+				install(FILES ${IRRLICHT_DLL} DESTINATION ${BINDIR})
+			endif()
+			if(USE_GETTEXT AND GETTEXT_DLL)
+				install(FILES ${GETTEXT_DLL} DESTINATION ${BINDIR})
+			endif()
+			if(FREETYPE_DLL)
+				install(FILES ${FREETYPE_DLL} DESTINATION ${BINDIR})
+			endif()
+			if(HARFBUZZ_DLL)
+				install(FILES ${HARFBUZZ_DLL} DESTINATION ${BINDIR})
+			endif()
 		endif()
 	endif()
 endif()

--- a/src/script/lua_api/CMakeLists.txt
+++ b/src/script/lua_api/CMakeLists.txt
@@ -21,6 +21,7 @@ set(common_SCRIPT_LUA_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/l_server.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_settings.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_storage.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/l_unistr.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_util.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_vmanip.cpp
 	PARENT_SCOPE)

--- a/src/script/lua_api/l_unistr.cpp
+++ b/src/script/lua_api/l_unistr.cpp
@@ -1,0 +1,610 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "l_unistr.h"
+
+#include "l_internal.h"
+
+const char LuaUniLocale::class_name[] = "uni.Locale";
+const luaL_Reg LuaUniLocale::methods[] =
+{
+	luamethod(LuaUniLocale, equals),
+	luamethod(LuaUniLocale, to_string),
+	luamethod(LuaUniLocale, get_language),
+	luamethod(LuaUniLocale, get_script),
+	luamethod(LuaUniLocale, get_country),
+	{0, 0}
+};
+
+LuaUniLocale *LuaUniLocale::read_object(lua_State *L, int index)
+{
+	LuaUniLocale *l = *(LuaUniLocale **)luaL_checkudata(L, index, class_name);
+	return l;
+}
+
+uni::Locale LuaUniLocale::read_locale(lua_State *L, int index)
+{
+	if (lua_isstring(L, index))
+		return uni::Locale(readParam<std::string>(L, index).c_str());
+
+	return read_object(L, index)->locale;
+}
+
+void LuaUniLocale::push_object(lua_State *L, const uni::Locale &locale)
+{
+	*(void **)lua_newuserdata(L, sizeof(void *)) = new LuaUniLocale(locale);
+	luaL_getmetatable(L, class_name);
+	lua_setmetatable(L, -2);
+}
+
+void LuaUniLocale::Register(lua_State *L)
+{
+	lua_newtable(L);
+	int method_table = lua_gettop(L);
+
+	luaL_newmetatable(L, class_name);
+	int metatable = lua_gettop(L);
+
+	lua_pushvalue(L, method_table);
+	lua_setfield(L, metatable, "__metatable");
+
+	lua_pushvalue(L, method_table);
+	lua_setfield(L, metatable, "__index");
+
+	lua_pushcfunction(L, gc_object);
+	lua_setfield(L, metatable, "__gc");
+
+	lua_pushcfunction(L, l_equals);
+	lua_setfield(L, metatable, "__eq");
+
+	lua_pushcfunction(L, l_to_string);
+	lua_setfield(L, metatable, "__tostring");
+
+	lua_pop(L, 1);
+
+	luaL_openlib(L, 0, methods, 0);
+	lua_pop(L, 1);
+
+	lua_pushcfunction(L, create);
+	lua_setfield(L, -1, class_name);
+}
+
+int LuaUniLocale::gc_object(lua_State *L)
+{
+	LuaUniLocale *l = *(LuaUniLocale **)lua_touserdata(L, 1);
+	delete l;
+	return 0;
+}
+
+// uni.Locale([locale]) -> locale
+int LuaUniLocale::create(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	push_object(L, read_locale(L, 1));
+	return 1;
+}
+
+// equals(other) -> bool
+int LuaUniLocale::l_equals(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushboolean(L, read_object(L, 1)->locale == read_locale(L, 2));
+	return 1;
+}
+
+// to_string() -> string
+int LuaUniLocale::l_to_string(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushstring(L, read_object(L, 1)->locale.toString());
+	return 1;
+}
+
+// get_langauge() -> string
+int LuaUniLocale::l_get_language(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushstring(L, read_object(L, 1)->locale.getLanguage());
+	return 1;
+}
+
+// get_script() -> string
+int LuaUniLocale::l_get_script(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushstring(L, read_object(L, 1)->locale.getScript());
+	return 1;
+}
+
+// get_country() -> string
+int LuaUniLocale::l_get_country(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushstring(L, read_object(L, 1)->locale.getCountry());
+	return 1;
+}
+
+const char LuaUniStrIt::class_name[] = "uni.StrIt";
+const luaL_Reg LuaUniStrIt::methods[] =
+{
+	luamethod(LuaUniStrIt, get_code),
+	luamethod(LuaUniStrIt, next_code),
+	luamethod(LuaUniStrIt, prev_code),
+	luamethod(LuaUniStrIt, next_char),
+	luamethod(LuaUniStrIt, prev_char),
+	luamethod(LuaUniStrIt, next_word),
+	luamethod(LuaUniStrIt, prev_word),
+	luamethod(LuaUniStrIt, next_break),
+	luamethod(LuaUniStrIt, prev_break),
+	luamethod(LuaUniStrIt, next_line),
+	luamethod(LuaUniStrIt, prev_line),
+	luamethod(LuaUniStrIt, is_at_start),
+	luamethod(LuaUniStrIt, is_at_end),
+	luamethod(LuaUniStrIt, to_start),
+	luamethod(LuaUniStrIt, to_end),
+	{0, 0}
+};
+
+LuaUniStrIt *LuaUniStrIt::read_object(lua_State *L, int index)
+{
+	return *(LuaUniStrIt **)luaL_checkudata(L, index, class_name);
+}
+
+const uni::StrIt &LuaUniStrIt::read_it(lua_State *L, int index)
+{
+	return read_object(L, index)->it;
+}
+
+void LuaUniStrIt::push_object(lua_State *L, const uni::StrIt &it)
+{
+	*(void **)lua_newuserdata(L, sizeof(void *)) = new LuaUniStrIt(it);
+	luaL_getmetatable(L, class_name);
+	lua_setmetatable(L, -2);
+}
+
+void LuaUniStrIt::Register(lua_State *L)
+{
+	lua_newtable(L);
+	int method_table = lua_gettop(L);
+
+	luaL_newmetatable(L, class_name);
+	int metatable = lua_gettop(L);
+
+	lua_pushvalue(L, method_table);
+	lua_setfield(L, metatable, "__metatable");
+
+	lua_pushvalue(L, method_table);
+	lua_setfield(L, metatable, "__index");
+
+	lua_pushcfunction(L, gc_object);
+	lua_setfield(L, metatable, "__gc");
+
+	lua_pushcfunction(L, eq);
+	lua_setfield(L, metatable, "__eq");
+
+	lua_pushcfunction(L, lt);
+	lua_setfield(L, metatable, "__lt");
+
+	lua_pushcfunction(L, le);
+	lua_setfield(L, metatable, "__le");
+
+	lua_pop(L, 1);
+
+	luaL_openlib(L, 0, methods, 0);
+	lua_pop(L, 1);
+}
+
+int LuaUniStrIt::gc_object(lua_State *L)
+{
+	LuaUniStrIt *i = *(LuaUniStrIt **)lua_touserdata(L, 1);
+	delete i;
+	return 0;
+}
+
+int LuaUniStrIt::eq(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushboolean(L, read_object(L, 1)->it == read_object(L, 2)->it);
+	return 1;
+}
+
+int LuaUniStrIt::lt(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushboolean(L, read_object(L, 1)->it < read_object(L, 2)->it);
+	return 1;
+}
+
+int LuaUniStrIt::le(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushboolean(L, read_object(L, 1)->it <= read_object(L, 2)->it);
+	return 1;
+}
+
+// get_code() -> code
+int LuaUniStrIt::l_get_code(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushinteger(L, read_object(L, 1)->it.getCode());
+	return 1;
+}
+
+// next_code() -> code
+int LuaUniStrIt::l_next_code(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushinteger(L, read_object(L, 1)->it.nextCode());
+	return 1;
+}
+
+// prev_code() -> code
+int LuaUniStrIt::l_prev_code(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushinteger(L, read_object(L, 1)->it.prevCode());
+	return 1;
+}
+
+// next_char()
+int LuaUniStrIt::l_next_char(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->it.nextChar();
+	return 0;
+}
+
+// prev_char()
+int LuaUniStrIt::l_prev_char(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->it.prevChar();
+	return 0;
+}
+
+// next_word()
+int LuaUniStrIt::l_next_word(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->it.nextWord();
+	return 0;
+}
+
+// prev_word()
+int LuaUniStrIt::l_prev_word(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->it.prevWord();
+	return 0;
+}
+
+// next_break() -> is_hard
+int LuaUniStrIt::l_next_break(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushboolean(L, read_object(L, 1)->it.nextBreak());
+	return 1;
+}
+
+// prev_break() -> is_hard
+int LuaUniStrIt::l_prev_break(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushboolean(L, read_object(L, 1)->it.prevBreak());
+	return 1;
+}
+
+// next_line()
+int LuaUniStrIt::l_next_line(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->it.nextLine();
+	return 0;
+}
+
+// prev_line()
+int LuaUniStrIt::l_prev_line(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->it.prevLine();
+	return 0;
+}
+
+// is_at_start() -> at_start
+int LuaUniStrIt::l_is_at_start(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushboolean(L, read_object(L, 1)->it.isAtStart());
+	return 1;
+}
+
+// is_at_end() -> at_end
+int LuaUniStrIt::l_is_at_end(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushboolean(L, read_object(L, 1)->it.isAtEnd());
+	return 1;
+}
+
+// to_start()
+int LuaUniStrIt::l_to_start(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->it.toStart();
+	return 0;
+}
+
+// to_end()
+int LuaUniStrIt::l_to_end(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->it.toEnd();
+	return 0;
+}
+
+const char LuaUniStr::class_name[] = "uni.Str";
+const luaL_Reg LuaUniStr::methods[] =
+{
+	luamethod(LuaUniStr, equals),
+	luamethod(LuaUniStr, to_string),
+	luamethod(LuaUniStr, is_empty),
+	luamethod(LuaUniStr, it_start),
+	luamethod(LuaUniStr, it_end),
+	luamethod(LuaUniStr, sub),
+	luamethod(LuaUniStr, append),
+	luamethod(LuaUniStr, insert),
+	luamethod(LuaUniStr, replace),
+	luamethod(LuaUniStr, remove),
+	luamethod(LuaUniStr, clear),
+	luamethod(LuaUniStr, trim),
+	luamethod(LuaUniStr, to_lower),
+	luamethod(LuaUniStr, to_upper),
+	luamethod(LuaUniStr, to_title),
+	luamethod(LuaUniStr, normalize),
+	luamethod(LuaUniStr, get_locale),
+	luamethod(LuaUniStr, set_locale),
+	{0, 0}
+};
+
+LuaUniStr *LuaUniStr::read_object(lua_State *L, int index)
+{
+	LuaUniStr *s = *(LuaUniStr **)luaL_checkudata(L, index, class_name);
+	return s;
+}
+
+std::shared_ptr<uni::Str> LuaUniStr::read_str(lua_State *L, int index)
+{
+	if (lua_isstring(L, index))
+		return uni::Str::create(readParam<std::string>(L, index));
+
+	return read_object(L, index)->str;
+}
+
+void LuaUniStr::push_object(lua_State *L, std::shared_ptr<uni::Str> str)
+{
+	*(void **)lua_newuserdata(L, sizeof(void *)) = new LuaUniStr(str);
+	luaL_getmetatable(L, class_name);
+	lua_setmetatable(L, -2);
+}
+
+void LuaUniStr::Register(lua_State *L)
+{
+	lua_newtable(L);
+	int method_table = lua_gettop(L);
+
+	luaL_newmetatable(L, class_name);
+	int metatable = lua_gettop(L);
+
+	lua_pushvalue(L, method_table);
+	lua_setfield(L, metatable, "__metatable");
+
+	lua_pushvalue(L, method_table);
+	lua_setfield(L, metatable, "__index");
+
+	lua_pushcfunction(L, gc_object);
+	lua_setfield(L, metatable, "__gc");
+
+	lua_pushcfunction(L, l_equals);
+	lua_setfield(L, metatable, "__eq");
+
+	lua_pushcfunction(L, l_to_string);
+	lua_setfield(L, metatable, "__tostring");
+
+	lua_pop(L, 1);
+
+	luaL_openlib(L, 0, methods, 0);
+	lua_pop(L, 1);
+
+	lua_pushcfunction(L, create);
+	lua_setfield(L, -1, class_name);
+}
+
+int LuaUniStr::gc_object(lua_State *L)
+{
+	LuaUniStr *s = *(LuaUniStr **)lua_touserdata(L, 1);
+	delete s;
+	return 0;
+}
+
+// uni.Str([str, [locale]]) -> str
+int LuaUniStr::create(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	std::shared_ptr<uni::Str> str;
+
+	if (!lua_isnoneornil(L, 1))
+		str = read_str(L, 1);
+	else
+		str = uni::Str::create();
+
+	if (!lua_isnoneornil(L, 2))
+		str->setLocale(LuaUniLocale::read_locale(L, 2));
+
+	push_object(L, str);
+
+	return 1;
+}
+
+// equals(other) -> bool
+int LuaUniStr::l_equals(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushboolean(L, *read_str(L, 1) == *read_str(L, 2));
+	return 1;
+}
+
+// to_string() -> string
+int LuaUniStr::l_to_string(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	std::string str = read_object(L, 1)->str->toString();
+	lua_pushlstring(L, str.c_str(), str.size());
+	return 1;
+}
+
+// is_empty() -> bool
+int LuaUniStr::l_is_empty(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	lua_pushboolean(L, read_object(L, 1)->str->isEmpty());
+	return 1;
+}
+
+// it_start() -> it
+int LuaUniStr::l_it_start(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	LuaUniStrIt::push_object(L, read_object(L, 1)->str->itStart());
+	return 1;
+}
+
+// it_end() -> it
+int LuaUniStr::l_it_end(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	LuaUniStrIt::push_object(L, read_object(L, 1)->str->itEnd());
+	return 1;
+}
+
+// sub(begin, end) -> substr
+int LuaUniStr::l_sub(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	push_object(L, read_object(L, 1)->str->sub(
+			LuaUniStrIt::read_it(L, 2), LuaUniStrIt::read_it(L, 3)));
+	return 1;
+}
+
+// append(str)
+int LuaUniStr::l_append(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->str->append(read_str(L, 2));
+	return 0;
+}
+
+// insert(pos, str)
+int LuaUniStr::l_insert(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->str->insert(LuaUniStrIt::read_it(L, 2), read_str(L, 3));
+	return 0;
+}
+
+// replace(begin, end, str)
+int LuaUniStr::l_replace(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->str->replace(
+			LuaUniStrIt::read_it(L, 2), LuaUniStrIt::read_it(L, 3), read_str(L, 4));
+	return 0;
+}
+
+// remove(begin, end)
+int LuaUniStr::l_remove(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->str->remove(
+			LuaUniStrIt::read_it(L, 2), LuaUniStrIt::read_it(L, 3));
+	return 0;
+}
+
+// clear()
+int LuaUniStr::l_clear(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->str->clear();
+	return 0;
+}
+
+// trim()
+int LuaUniStr::l_trim(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->str->trim();
+	return 0;
+}
+
+// to_lower()
+int LuaUniStr::l_to_lower(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->str->toLower();
+	return 0;
+}
+
+// to_upper()
+int LuaUniStr::l_to_upper(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->str->toUpper();
+	return 0;
+}
+
+// to_title([first_only])
+int LuaUniStr::l_to_title(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->str->toTitle(lua_toboolean(L, 2));
+	return 0;
+}
+
+// normalize([compose])
+int LuaUniStr::l_normalize(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->str->normalize(lua_toboolean(L, 2));
+	return 0;
+}
+
+// get_locale()
+int LuaUniStr::l_get_locale(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	LuaUniLocale::push_object(L, read_object(L, 1)->str->getLocale());
+	return 1;
+}
+
+// set_locale(locale)
+int LuaUniStr::l_set_locale(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	read_object(L, 1)->str->setLocale(LuaUniLocale::read_locale(L, 2));
+	return 0;
+}

--- a/src/script/lua_api/l_unistr.h
+++ b/src/script/lua_api/l_unistr.h
@@ -1,0 +1,168 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <memory>
+
+#include "lua_api/l_base.h"
+#include "util/unistr.h"
+
+class LuaUniLocale : public ModApiBase
+{
+private:
+	static const char class_name[];
+	static const luaL_Reg methods[];
+
+	uni::Locale locale;
+
+public:
+	static LuaUniLocale *read_object(lua_State *L, int index);
+	static uni::Locale read_locale(lua_State *L, int index);
+
+	static void push_object(lua_State *L, const uni::Locale &locale);
+
+	const uni::Locale &get() const
+	{
+		return locale;
+	}
+
+	static void Register(lua_State *L);
+
+private:
+	LuaUniLocale(const uni::Locale &locale) :
+		locale(locale)
+	{}
+
+	static int gc_object(lua_State *L);
+
+	static int create(lua_State *L);
+
+	static int l_equals(lua_State *L);
+	static int l_to_string(lua_State *L);
+
+	static int l_get_language(lua_State *L);
+	static int l_get_script(lua_State *L);
+	static int l_get_country(lua_State *L);
+};
+
+class LuaUniStrIt : public ModApiBase
+{
+private:
+	static const char class_name[];
+	static const luaL_Reg methods[];
+
+	uni::StrIt it;
+
+public:
+	static LuaUniStrIt *read_object(lua_State *L, int index);
+	static const uni::StrIt &read_it(lua_State *L, int index);
+
+	static void push_object(lua_State *L, const uni::StrIt &it);
+
+	const uni::StrIt &get() const
+	{
+		return it;
+	}
+
+	static void Register(lua_State *L);
+
+private:
+	LuaUniStrIt(const uni::StrIt &it) :
+		it(it)
+	{}
+
+	static int gc_object(lua_State *L);
+
+	static int eq(lua_State *L);
+	static int lt(lua_State *L);
+	static int le(lua_State *L);
+
+	static int l_get_code(lua_State *L);
+	static int l_next_code(lua_State *L);
+	static int l_prev_code(lua_State *L);
+	static int l_next_char(lua_State *L);
+	static int l_prev_char(lua_State *L);
+	static int l_next_word(lua_State *L);
+	static int l_prev_word(lua_State *L);
+	static int l_next_break(lua_State *L);
+	static int l_prev_break(lua_State *L);
+	static int l_next_line(lua_State *L);
+	static int l_prev_line(lua_State *L);
+
+	static int l_is_at_start(lua_State *L);
+	static int l_is_at_end(lua_State *L);
+	static int l_to_start(lua_State *L);
+	static int l_to_end(lua_State *L);
+};
+
+class LuaUniStr : public ModApiBase
+{
+private:
+	static const char class_name[];
+	static const luaL_Reg methods[];
+
+	std::shared_ptr<uni::Str> str;
+
+public:
+	static LuaUniStr *read_object(lua_State *L, int index);
+	static std::shared_ptr<uni::Str> read_str(lua_State *L, int index);
+
+	static void push_object(lua_State *L, std::shared_ptr<uni::Str> str);
+
+	std::shared_ptr<uni::Str> get() const
+	{
+		return str;
+	}
+
+	static void Register(lua_State *L);
+
+private:
+	LuaUniStr(std::shared_ptr<uni::Str> str) :
+		str(str)
+	{}
+
+	static int gc_object(lua_State *L);
+
+	static int create(lua_State *L);
+
+	static int l_equals(lua_State *L);
+	static int l_to_string(lua_State *L);
+	static int l_is_empty(lua_State *L);
+
+	static int l_it_start(lua_State *L);
+	static int l_it_end(lua_State *L);
+
+	static int l_sub(lua_State *L);
+	static int l_append(lua_State *L);
+	static int l_insert(lua_State *L);
+	static int l_replace(lua_State *L);
+	static int l_remove(lua_State *L);
+	static int l_clear(lua_State *L);
+
+	static int l_trim(lua_State *L);
+	static int l_to_lower(lua_State *L);
+	static int l_to_upper(lua_State *L);
+	static int l_to_title(lua_State *L);
+
+	static int l_normalize(lua_State *L);
+
+	static int l_get_locale(lua_State *L);
+	static int l_set_locale(lua_State *L);
+};

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_base.h"
 #include "lua_api/l_craft.h"
 #include "lua_api/l_env.h"
+#include "lua_api/l_http.h"
 #include "lua_api/l_inventory.h"
 #include "lua_api/l_item.h"
 #include "lua_api/l_itemstackmeta.h"
@@ -40,11 +41,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_particles.h"
 #include "lua_api/l_rollback.h"
 #include "lua_api/l_server.h"
+#include "lua_api/l_settings.h"
+#include "lua_api/l_storage.h"
+#include "lua_api/l_unistr.h"
 #include "lua_api/l_util.h"
 #include "lua_api/l_vmanip.h"
-#include "lua_api/l_settings.h"
-#include "lua_api/l_http.h"
-#include "lua_api/l_storage.h"
 
 extern "C" {
 #include "lualib.h"
@@ -109,6 +110,11 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	LuaSettings::Register(L);
 	StorageRef::Register(L);
 	ModChannelRef::Register(L);
+
+	lua_newtable(L);
+	LuaUniLocale::Register(L);
+	LuaUniStr::Register(L);
+	lua_setglobal(L, "uni");
 
 	// Initialize mod api modules
 	ModApiAuth::Initialize(L, top);

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -7,6 +7,7 @@ set(UTIL_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/ieee_float.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/metricsbackend.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/numeric.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/png.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/pointedthing.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/quicktune.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/serialize.cpp
@@ -15,5 +16,5 @@ set(UTIL_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/string.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/srp.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/timetaker.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/png.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/unistr.cpp
 	PARENT_SCOPE)

--- a/src/util/unistr.cpp
+++ b/src/util/unistr.cpp
@@ -1,0 +1,819 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "unistr.h"
+
+#include <unicode/brkiter.h>
+#include <unicode/coll.h>
+#include <unicode/localebuilder.h>
+#include <unicode/normalizer2.h>
+#include <unicode/stringoptions.h>
+#include <unicode/stsearch.h>
+#include <unicode/uchar.h>
+#include <unicode/ucol.h>
+#include <unicode/usearch.h>
+#include <unicode/utext.h>
+#include <unicode/utypes.h>
+
+#include <cstring>
+
+/** Checks an ICU status code for failure, throwing a UnicodeException with the
+  * specified error message if so.
+  *
+  * \param status  The ICU status to check.
+  * \param message The message to pass to the UnicodeException on failure.
+  */
+void check_status(UErrorCode status, const char *message)
+{
+	if (U_FAILURE(status))
+		throw uni::UnicodeException(message);
+}
+
+template<typename T>
+void check_bogus(const T &object, const char *message)
+{
+	if (object.isBogus())
+		throw uni::UnicodeException(message);
+}
+
+namespace uni
+{
+	template<typename T>
+	void ICUDeleter<T>::operator()(T *to_delete)
+	{
+		delete to_delete;
+	}
+
+	template<>
+	void ICUDeleter<UText>::operator()(UText *to_delete)
+	{
+		utext_close(to_delete);
+	}
+
+	std::string get_code_name(Code code)
+	{
+		UErrorCode status = U_ZERO_ERROR;
+
+		// We have to call the u_charName() function twice: once to get the
+		// length of the string, and a second time to actually store the string.
+
+		// Add one to the size to include space for the null terminator.
+		size_t size = 1 + u_charName(code, U_UNICODE_CHAR_NAME, nullptr, 0, &status);
+
+		// Get the codepoint name itself. The null terminator is already set
+		// because new will initialize to zero.
+		char *buffer = new char[size];
+		u_charName(code, U_UNICODE_CHAR_NAME, buffer, size, &status);
+
+		std::string ret = buffer;
+		delete[] buffer;
+
+		if (U_FAILURE(status) || ret.empty())
+			return "UNKNOWN";
+
+		return ret;
+	}
+
+	const char *get_char_type(Code code)
+	{
+		UCharCategory type = (UCharCategory)u_charType(code);
+
+		switch (type) {
+		case U_UPPERCASE_LETTER:
+			return "Lu";
+		case U_LOWERCASE_LETTER:
+			return "Ll";
+		case U_TITLECASE_LETTER:
+			return "Lt";
+		case U_MODIFIER_LETTER:
+			return "Lm";
+		case U_OTHER_LETTER:
+			return "Lo";
+		case U_NON_SPACING_MARK:
+			return "Mn";
+		case U_ENCLOSING_MARK:
+			return "Me";
+		case U_COMBINING_SPACING_MARK:
+			return "Mc";
+		case U_DECIMAL_DIGIT_NUMBER:
+			return "Nd";
+		case U_LETTER_NUMBER:
+			return "Nl";
+		case U_OTHER_NUMBER:
+			return "No";
+		case U_SPACE_SEPARATOR:
+			return "Zs";
+		case U_LINE_SEPARATOR:
+			return "Zl";
+		case U_PARAGRAPH_SEPARATOR:
+			return "Zp";
+		case U_CONTROL_CHAR:
+			return "Cc";
+		case U_FORMAT_CHAR:
+			return "Cf";
+		case U_PRIVATE_USE_CHAR:
+			return "Co";
+		case U_SURROGATE:
+			return "Cs";
+		case U_DASH_PUNCTUATION:
+			return "Pd";
+		case U_START_PUNCTUATION:
+			return "Ps";
+		case U_END_PUNCTUATION:
+			return "Pe";
+		case U_CONNECTOR_PUNCTUATION:
+			return "Pc";
+		case U_OTHER_PUNCTUATION:
+			return "Po";
+		case U_MATH_SYMBOL:
+			return "Sm";
+		case U_CURRENCY_SYMBOL:
+			return "Sc";
+		case U_MODIFIER_SYMBOL:
+			return "Sk";
+		case U_OTHER_SYMBOL:
+			return "So";
+		case U_INITIAL_PUNCTUATION:
+			return "Pi";
+		case U_FINAL_PUNCTUATION:
+			return "Pf";
+		}
+
+		// Anything else is the unknown General Category.
+		return "Cn";
+	}
+
+	UTF8It::UTF8It(const char *str) :
+		m_index(0)
+	{
+		UErrorCode status = U_ZERO_ERROR;
+		m_iterator.reset(utext_openUTF8(nullptr, str, -1, &status));
+		check_status(status, "Could not create UTF-8 codepoint iterator");
+	}
+
+	UTF8It::UTF8It(const char *str, size_t size) :
+		m_index(0)
+	{
+		UErrorCode status = U_ZERO_ERROR;
+		m_iterator.reset(utext_openUTF8(nullptr, str, size, &status));
+		check_status(status, "Could not create UTF-8 codepoint iterator");
+	}
+
+	UTF8It::UTF8It(const UTF8It &other) :
+		m_index(other.m_index)
+	{
+		UErrorCode status = U_ZERO_ERROR;
+		m_iterator.reset(utext_clone(
+				nullptr, other.m_iterator.get(), false, false, &status));
+		check_status(status, "Could not copy UTF-8 codepoint iterator");
+	}
+
+	Code UTF8It::getCode()
+	{
+		Code result = utext_char32At(m_iterator.get(), m_index);
+		m_index = utext_getNativeIndex(m_iterator.get());
+
+		return result;
+	}
+
+	Code UTF8It::nextCode()
+	{
+		Code result = utext_next32From(m_iterator.get(), m_index);
+		m_index = utext_getNativeIndex(m_iterator.get());
+
+		return result;
+	}
+
+	Code UTF8It::prevCode()
+	{
+		Code result = utext_previous32From(m_iterator.get(), m_index);
+		m_index = utext_getNativeIndex(m_iterator.get());
+
+		return result;
+	}
+
+	size_t UTF8It::getEndIndex() const
+	{
+		utext_nativeLength(m_iterator.get());
+	}
+
+	bool operator==(const UTF8It &left, const UTF8It &right)
+	{
+		/* We don't use UText's native string position for reasons described in
+		 * the documentation for m_index. Hence, to make utext_equals() not take
+		 * the iterator position into account, set both to zero.
+		 */
+		utext_setNativeIndex(left.m_iterator.get(), 0);
+		utext_setNativeIndex(right.m_iterator.get(), 0);
+
+		return utext_equals(left.m_iterator.get(), right.m_iterator.get()) &&
+				left.m_index == right.m_index;
+	}
+
+	bool code_to_utf8(Code code, char str[5])
+	{
+		memset(str, '\0', 5);
+
+		// U8_APPEND() is _very_ particular about its arguments; they must be
+		// the exact type that is expects, and some are required to be lvalues.
+		uint8_t *ustr = (uint8_t *)str;
+		UBool error = false;
+		int32_t i = 0;
+
+		U8_APPEND(ustr, i, 5, code, error);
+
+		return error;
+	}
+
+	void Locale::setNormalized(const icu::Locale &locale)
+	{
+		check_bogus(locale, "Invalid locale");
+
+		// We can normalize the locale by extracting just the parts we want
+		// and then passing them back in again.
+		UErrorCode status = U_ZERO_ERROR;
+
+		std::string locale_str = std::string(locale.getLanguage()) + "_" +
+				locale.getScript() + "_" + locale.getCountry();
+		m_locale = icu::Locale::createFromName(locale_str.c_str());
+
+		check_status(status, "Unable to build locale");
+		check_bogus(locale, "Invalid locale");
+	}
+
+	StrPositioner::StrPositioner(std::shared_ptr<const Str> str) :
+		m_str(str)
+	{
+		m_str->registerPositioner(this);
+	}
+
+	StrPositioner::StrPositioner(const StrPositioner &other) :
+		m_str(other.m_str)
+	{
+		m_str->registerPositioner(this);
+	}
+
+	StrPositioner &StrPositioner::operator=(const StrPositioner &other)
+	{
+		if (this != &other) {
+			m_str = other.m_str;
+			m_str->registerPositioner(this);
+		}
+		return *this;
+	}
+
+	StrPositioner::~StrPositioner()
+	{
+		m_str->unregisterPositioner(this);
+	}
+
+	Code StrIt::getCode()
+	{
+		UText *breaker = m_str->getCodeBreaker();
+
+		Code result = utext_char32At(breaker, m_index);
+		m_index = utext_getNativeIndex(breaker);
+
+		return result;
+	}
+
+	Code StrIt::nextCode()
+	{
+		UText *breaker = m_str->getCodeBreaker();
+
+		Code result = utext_next32From(breaker, m_index);
+		m_index = utext_getNativeIndex(breaker);
+
+		return result;
+	}
+
+	Code StrIt::prevCode()
+	{
+		UText *breaker = m_str->getCodeBreaker();
+
+		Code result = utext_previous32From(breaker, m_index);
+		m_index = utext_getNativeIndex(breaker);
+
+		return result;
+	}
+
+	void StrIt::nextChar()
+	{
+		m_index = m_str->getCharBreaker()->following(m_index);
+		correctNext();
+	}
+
+	void StrIt::prevChar()
+	{
+		m_index = m_str->getCharBreaker()->preceding(m_index);
+		correctPrev();
+	}
+
+	void StrIt::nextWord()
+	{
+		m_index = m_str->getWordBreaker()->following(m_index);
+		correctNext();
+	}
+
+	void StrIt::prevWord()
+	{
+		m_index = m_str->getWordBreaker()->preceding(m_index);
+		correctPrev();
+	}
+
+	bool StrIt::nextBreak()
+	{
+		icu::BreakIterator *breaker = m_str->getLineBreaker();
+		m_index = breaker->following(m_index);
+		correctNext();
+		return getLineBreakType(breaker);
+	}
+
+	bool StrIt::prevBreak()
+	{
+		icu::BreakIterator *breaker = m_str->getLineBreaker();
+		breaker->preceding(m_index);
+		correctPrev();
+		return getLineBreakType(breaker);
+	}
+
+	void StrIt::nextLine()
+	{
+		// Simply loop until we find a hard break or hit the end.
+		while (!isAtEnd() && !nextBreak());
+	}
+
+	void StrIt::prevLine()
+	{
+		// Simply loop until we find a hard break or hit the start.
+		while (!isAtStart() && !prevBreak());
+	}
+
+	bool StrIt::isAtStart() const
+	{
+		return m_index == 0;
+	}
+
+	bool StrIt::isAtEnd() const
+	{
+		return m_index == m_str->size();
+	}
+
+	void StrIt::toStart()
+	{
+		m_index = 0;
+	}
+
+	void StrIt::toEnd()
+	{
+		m_index = m_str->size();
+	}
+
+	void StrIt::correctNext()
+	{
+		if (m_index == (size_t)icu::BreakIterator::DONE)
+			toEnd();
+	}
+
+	void StrIt::correctPrev()
+	{
+		if (m_index == (size_t)icu::BreakIterator::DONE)
+			toStart();
+	}
+
+	bool StrIt::getLineBreakType(icu::BreakIterator *breaker) const
+	{
+		Code type = breaker->getRuleStatus();
+		if (type >= UBRK_LINE_HARD && type < UBRK_LINE_HARD_LIMIT)
+			return true;
+		return false;
+	}
+
+	Str::Str(const Locale &locale) :
+		m_locale(locale)
+	{
+		check_bogus(m_string, "Unable to create string");
+		regenerate();
+	}
+
+	Str::Str(const char *str, const Locale &locale) :
+		m_string(icu::UnicodeString::fromUTF8(str)),
+		m_locale(locale)
+	{
+		check_bogus(m_string, "Unable to create string");
+		regenerate();
+	}
+
+	Str::Str(const std::string &str, const Locale &locale) :
+		m_string(icu::UnicodeString::fromUTF8(str)),
+		m_locale(locale)
+	{
+		check_bogus(m_string, "Unable to create string");
+		regenerate();
+	}
+
+	Str &Str::operator=(const Str &other)
+	{
+		if (this != &other) {
+			m_string = other.m_string;
+			m_locale = other.m_locale;
+
+			regenerate();
+		}
+		return *this;
+	}
+
+	std::shared_ptr<Str> Str::sub(const StrIt &begin, const StrIt &end) const
+	{
+		size_t begin_i = begin.getIndex();
+		size_t end_i = end.getIndex();
+
+		std::shared_ptr<Str> str = Str::create();
+		m_string.extract(begin_i, end_i - begin_i, str->m_string);
+
+		return str;
+	}
+
+	void Str::append(std::shared_ptr<Str> str)
+	{
+		size_t pos_i = str->size();
+		m_string.append(str->m_string);
+		updateArea(pos_i, pos_i, size());
+	}
+
+	void Str::insert(const StrIt &pos, std::shared_ptr<Str> str)
+	{
+		size_t pos_i = pos.getIndex();
+
+		m_string.insert(pos_i, str->m_string);
+		updateArea(pos_i, pos_i, pos_i + str->size());
+	}
+
+	void Str::replace(const StrIt &begin, const StrIt &end, std::shared_ptr<Str> str)
+	{
+		size_t begin_i = begin.getIndex();
+		size_t end_i = end.getIndex();
+
+		m_string.replace(begin_i, end_i - begin_i, str->m_string);
+		updateArea(begin_i, end_i, begin_i + str->size());
+	}
+
+	void Str::remove(const StrIt &begin, const StrIt &end)
+	{
+		size_t begin_i = begin.getIndex();
+		size_t end_i = end.getIndex();
+
+		m_string.remove(begin_i, end_i);
+		updateArea(begin_i, end_i, begin_i);
+	}
+
+	void Str::clear()
+	{
+		m_string.remove();
+		updateEntire();
+	}
+
+	void Str::trim()
+	{
+		m_string.trim();
+		updateEntire();
+	}
+
+	void Str::toLower()
+	{
+		m_string.toLower(m_locale.getInternal());
+		updateEntire();
+	}
+
+	void Str::toUpper()
+	{
+		m_string.toUpper(m_locale.getInternal());
+		updateEntire();
+	}
+
+	void Str::toTitle(bool first_only)
+	{
+		m_string.toTitle(getWordBreaker(), m_locale.getInternal(),
+				first_only ? U_TITLECASE_NO_LOWERCASE : 0);
+		updateEntire();
+	}
+
+	void Str::normalize(bool compose)
+	{
+		UErrorCode status = U_ZERO_ERROR;
+
+		const icu::Normalizer2 *normalizer;
+		if (compose) {
+			normalizer = icu::Normalizer2::getNFCInstance(status);
+		} else {
+			normalizer = icu::Normalizer2::getNFDInstance(status);
+		}
+		m_string = normalizer->normalize(m_string, status);
+
+		check_status(status, "Could not normalize string");
+
+		updateEntire();
+	}
+
+	void Str::setLocale(const Locale &locale)
+	{
+		m_locale = locale;
+
+		// Since everything is dependent on locale, update everything.
+		regenerate();
+		updateEntire();
+	}
+
+	void Str::regenerate()
+	{
+		m_code_breaker = nullptr;
+		m_char_breaker = nullptr;
+		m_word_breaker = nullptr;
+		m_line_breaker = nullptr;
+	}
+
+	void Str::updateBreakers()
+	{
+		UErrorCode status = U_ZERO_ERROR;
+
+		m_code_breaker.reset(utext_openUnicodeString(
+				m_code_breaker.get(), &m_string, &status));
+
+		check_status(status, "Could not create codepoint iterator");
+
+		if (m_char_breaker != nullptr)
+			m_char_breaker->setText(m_string);
+		if (m_word_breaker != nullptr)
+			m_word_breaker->setText(m_string);
+		if (m_line_breaker != nullptr)
+			m_line_breaker->setText(m_string);
+	}
+
+	void Str::updatePositioners()
+	{
+		for (StrPositioner *poser : m_positioners)
+			poser->updatePositioner();
+	}
+
+	void Str::updateArea(size_t start, size_t old_end, size_t new_end)
+	{
+		// Rebuild or change break iterators since the string has changed.
+		updateBreakers();
+
+		// Move all StrIts affected by the change so they still point to the
+		// proper positions.
+		for (StrPositioner *poser : m_positioners) {
+			StrIt *it = dynamic_cast<StrIt *>(poser);
+
+			// If this isn't a StrIt, do nothing.
+			if (it == nullptr)
+				continue;
+
+			size_t index = it->getIndex();
+
+			if (index > old_end) {
+				// If we're past the changed area, hold our position.
+				it->setIndex(index - old_end + new_end);
+			} else if (index > start) {
+				// If we're inside the changed area, move to the end of the new area.
+				it->setIndex(new_end);
+			}
+		}
+
+		// Then, now that the StrIts are updated, update all the positioners.
+		updatePositioners();
+	}
+
+	void Str::updateEntire()
+	{
+		updateBreakers();
+
+		for (StrPositioner *poser : m_positioners) {
+			StrIt *it = dynamic_cast<StrIt *>(poser);
+
+			// If this is a StrIt, set its position to the end of the string.
+			if (it != nullptr)
+				it->setIndex(size());
+		}
+
+		updatePositioners();
+	}
+
+	icu::BreakIterator *Str::getBreaker(ICUUniquePtr<icu::BreakIterator> &breaker,
+			BreakerCreator creator) const
+	{
+		if (breaker.get() == nullptr) {
+			UErrorCode status = U_ZERO_ERROR;
+			breaker.reset(creator(m_locale.getInternal(), status));
+			check_status(status, "Could not create break iterator");
+
+			breaker->setText(m_string);
+		}
+
+		return breaker.get();
+	}
+
+	icu::BreakIterator *Str::getCharBreaker() const
+	{
+		return getBreaker(m_char_breaker, &icu::BreakIterator::createCharacterInstance);
+	}
+
+	icu::BreakIterator *Str::getWordBreaker() const
+	{
+		return getBreaker(m_char_breaker, &icu::BreakIterator::createWordInstance);
+	}
+
+	icu::BreakIterator *Str::getLineBreaker() const
+	{
+		return getBreaker(m_char_breaker, &icu::BreakIterator::createLineInstance);
+	}
+
+	/** Configures the level of collation for a normal or string searching
+	  * collator, taking into account IGNORE_CASE and IGNORE_DIACRITICS.
+	  *
+	  * \param collator The collator to configure the strength for.
+	  * \param options  The set of options, either a Collator::Options or a
+	  *                 Searcher::Options. Only IGNORE_CASE and
+	  *                 IGNORE_DIACRITICS are considered.
+	  * \param status   The ICU status code reported by called ICU functions.
+	  */
+	void configure_basic_collator(icu::Collator *collator, Collator::Options options,
+			UErrorCode &status)
+	{
+		UColAttributeValue strength;
+		UColAttributeValue case_level = UCOL_OFF;
+
+		// Since ICU's comparison levels are mutually exclusive, to ignore
+		// diacritics while keeping casing distinct, we have to choose the
+		// primary level and turn on the extra case level.
+		if (options & Collator::IGNORE_DIACRITICS) {
+			strength = UCOL_PRIMARY;
+			if (!(options & Collator::IGNORE_CASE))
+				case_level = UCOL_ON;
+		} else {
+			strength = (options & Collator::IGNORE_CASE) ? UCOL_SECONDARY : UCOL_TERTIARY;
+		}
+
+		collator->setAttribute(UCOL_STRENGTH, strength, status);
+		collator->setAttribute(UCOL_CASE_LEVEL, case_level, status);
+	}
+
+	Collator::Collator(const Locale &locale, Options options) :
+		m_locale(locale),
+		m_options(options)
+	{
+		regenerate();
+	}
+
+	int Collator::collate(std::shared_ptr<Str> left, std::shared_ptr<Str> right) const
+	{
+		UErrorCode status = U_ZERO_ERROR;
+
+		UCollationResult result = m_collator->compare(left->getInternal(),
+				right->getInternal(), status);
+
+		check_status(status, "Unable to perform collation");
+
+		if (result == UCOL_LESS) {
+			return -1;
+		} else if (result == UCOL_EQUAL) {
+			return 0;
+		} else {
+			return 1;
+		}
+	}
+
+	void Collator::regenerate()
+	{
+		UErrorCode status = U_ZERO_ERROR;
+		m_collator.reset(icu::Collator::createInstance(m_locale.getInternal(), status));
+		check_status(status, "Could not configure collator");
+
+		configure();
+	}
+
+	void Collator::configure()
+	{
+		UErrorCode status = U_ZERO_ERROR;
+
+		configure_basic_collator(m_collator.get(), m_options, status);
+
+		// Set which casing should take precedence or whether the default for
+		// this locale should be used.
+		UColAttributeValue case_first = UCOL_OFF;
+		if (m_options & Collator::UPPERCASE_FIRST)
+			case_first = UCOL_UPPER_FIRST;
+		else if (m_options & Collator::LOWERCASE_FIRST)
+			case_first = UCOL_LOWER_FIRST;
+		m_collator->setAttribute(UCOL_CASE_FIRST, case_first, status);
+
+		check_status(status, "Could not configure collator");
+	}
+
+	Searcher::Searcher(std::shared_ptr<const Str> str, std::shared_ptr<Str> pattern,
+			Options options) :
+		StrPositioner(str),
+		m_pattern(uni::Str::create(pattern)),
+		m_options(options),
+		m_start(m_str->itStart()),
+		m_end(m_str->itStart()),
+		m_needs_regen(true)
+	{}
+
+	bool Searcher::next()
+	{
+		checkRegenerate();
+
+		// If there's no searcher (meaning either the parent string or the
+		// pattern is empty), there is no match. Set both iterators to the end.
+		if (m_searcher == nullptr) {
+			toEnd();
+			return false;
+		}
+
+		UErrorCode status = U_ZERO_ERROR;
+		size_t index = m_searcher->following(m_start.getIndex(), status);
+		check_status(status, "Unable to perform string search");
+
+		// If we haven't hit the end, a match was found; return true.
+		if (index != (size_t)USEARCH_DONE)
+			return true;
+
+		if (m_options & WRAP_AROUND && m_start != m_str->itStart()) {
+			// If we should wrap around, try the search again from the beginning.
+			// However, if we're already at the start, it means there is no match
+			// anywhere, so don't go into an infinite loop of searching.
+			return following(m_str->itStart());
+		} else {
+			// Otherwise, there's no match: set both iterators to the end.
+			toEnd();
+			return false;
+		}
+	}
+
+	bool Searcher::prev()
+	{
+		// Same as next(), but everything in the opposite direction. Trying to
+		// generalize it leads to a disgusting mess of pointer-to-member functions.
+		checkRegenerate();
+
+		if (m_searcher == nullptr) {
+			toStart();
+			return false;
+		}
+
+		UErrorCode status = U_ZERO_ERROR;
+		size_t index = m_searcher->preceding(m_start.getIndex(), status);
+		check_status(status, "Unable to perform string search");
+
+		if (index != (size_t)USEARCH_DONE)
+			return true;
+
+		if (m_options & WRAP_AROUND && m_start != m_str->itEnd()) {
+			return preceding(m_str->itEnd());
+		} else {
+			toStart();
+			return false;
+		}
+	}
+
+	void Searcher::regenerate()
+	{
+		if (m_str->isEmpty() || m_pattern->isEmpty())
+			m_searcher = nullptr;
+
+		UErrorCode status = U_ZERO_ERROR;
+
+		icu::BreakIterator *breaker = nullptr;
+		if (m_options & WHOLE_WORDS_ONLY)
+			breaker = m_str->getWordBreaker();
+
+		m_searcher.reset(new icu::StringSearch(m_pattern->getInternal(),
+				m_str->getInternal(), m_str->getLocale().getInternal(),
+				breaker, status));
+
+		configure_basic_collator(m_searcher->getCollator(),
+				(Collator::Options)m_options, status);
+
+		m_searcher->setAttribute(USEARCH_OVERLAP,
+				(m_options & OVERLAP) ? USEARCH_ON : USEARCH_OFF, status);
+
+		check_status(status, "Could not configure string searcher");
+	}
+}

--- a/src/util/unistr.h
+++ b/src/util/unistr.h
@@ -1,0 +1,1053 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <unicode/locid.h>
+#include <unicode/unistr.h>
+
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <string>
+#include <unordered_set>
+
+// Required method for ICU namespace forward declarations due to versioned namespaces
+U_NAMESPACE_BEGIN
+	class BreakIterator;
+	class Collator;
+	class StringSearch;
+U_NAMESPACE_END
+
+struct UText;
+
+namespace uni
+{
+	/** An exception indicating that a Unicode error occurred. It indicates one
+	  * of two things: either the user used a method improperly, such as mixing
+	  * different locales in the same operation, or ICU encountered an
+	  * unrecoverable error that we can't handle.
+	  *
+	  * Generally, this exception should not be handled except to rethrow it as
+	  * a more appropriate exception (such as a LuaError if it occurred in some
+	  * Lua bindings).
+	  */
+	class UnicodeException : public std::exception
+	{
+	private:
+		const char *m_message;
+
+	public:
+		UnicodeException(const char *message)
+		{
+			m_message = message;
+		}
+
+		virtual const char *what() const noexcept override
+		{
+			return m_message;
+		}
+	};
+
+	template<typename T>
+	struct ICUDeleter
+	{
+		void operator()(T *to_delete);
+	};
+
+	template<typename T>
+	using ICUUniquePtr = std::unique_ptr<T, ICUDeleter<T>>;
+
+	/** Represents a single Unicode codepoint. It is defined as a signed 32-bit
+	  * integer as opposed to unsigned or `char32_t` so that `-1` can act as a
+	  * sentinel value when a codepoint is invalid for some reason or another.
+	  */
+	typedef int32_t Code;
+
+	/** Returned by functions to indicate that a Unicode codepoint is invalid.
+	  * It is NOT a valid codepoint itself and should not appear in actual
+	  * strings. It is distinct from the Unicode replacement codepoint
+	  * (`uni::REPLACE_CODE`) so that actual replacement codepoints and invalid
+	  * codepoints can be differentiated.
+	  */
+	const Code INVALID_CODE = -1;
+
+	/** The Unicode replacement codepoint, which is meant to be used to replace
+	  * any invalid sequences of codepoints. All Unicode functions that
+	  * encounter actual invalid sequences of codepoints will return
+	  * `uni::INVALID_CODE`, whereas this codepoint is for user code that needs
+	  * to handle invalid codepoints.
+	  */
+	const Code REPLACE_CODE = 0xFFFD;
+
+	/** Gets the full name of a Unicode codepoint as a string. The name is
+	  * written in uppercase.
+	  *
+	  * \param code The codepoint to get the name of.
+	  * \return The name of the codepoint, or "UNKNOWN" if the codepoint is
+	  *         unknown or invalid.
+	  */
+	std::string get_code_name(Code code);
+
+	/** Gets the general category of a Unicode codepoint as the two-character
+	  * literal. If the codepoint is unknown or invalid, returns the unknown
+	  * category "Cn".
+	  *
+	  * \param code The codepoint to get the general category of.
+	  * \return A two character literal representing the general category, which
+	  *         is one of the values specified in
+	  *         <https://www.unicode.org/reports/tr44/#General_Category_Values>.
+	  */
+	const char *get_char_type(Code code);
+
+	/** An iterator for iterating over codepoints in raw UTF-8 text. It only
+	  * stores a pointer to the text, so the iterator is only valid as long as
+	  * the underlying text is not changed or freed.
+	  *
+	  * Since this iterator only allows iterating over codepoints, it is meant
+	  * to be a lightweight alternative to Str for things that only need the
+	  * most rudimentary of Unicode operations. Anything more complex should use
+	  * Str and StrIt.
+	  *
+	  * The iterator is similar to most standard C++ iterators in that the
+	  * starting position is at the start of the string and the ending position
+	  * is one past the end of the string, or the size of the string.
+	  *
+	  * The public interface of UTF8It is almost a subset of StrIt, but also
+	  * includes functions for moving the iterator directly: getIndex(),
+	  * setIndex(), and getEndIndex().
+	  */
+	class UTF8It
+	{
+	private:
+		/** The UText for iterating over the codepoints. This is preferable to
+		  * using the `U8_` macros to move around because it does more extensive
+		  * bounds and error checking and properly handles cases of the iterator
+		  * being in the middle of a codepoint.
+		  */
+		ICUUniquePtr<UText> m_iterator;
+
+		/** The current position of the iterator. UText stores the iteration
+		  * position itself, but storing it separately here allows setIndex() to
+		  * place iterators in the middle of a codepoint without UText
+		  * automatically rewinding iteration to the start of the codepoint.
+		  */
+		size_t m_index;
+
+	public:
+		/** Create a new UTF-8 iterator pointing to a null-terminated string.
+		  * The size will be found by the iterator. The iterator will start at
+		  * the beginning of the string.
+		  *
+		  * \param str The string to iterate over.
+		  */
+		UTF8It(const char *str);
+
+		/** Create a new UTF-8 iterator pointing to a string with a specified
+		  * size given. The iterator will start at the beginning of the string.
+		  *
+		  * \param str  The string to iterate over.
+		  * \param size The size of the string or substring to iterate over.
+		  */
+		UTF8It(const char *str, size_t size);
+
+		/** Create a new UTF-8 iterator pointing to the contents of the string
+		  * provided. The iterator will start at the beginning of the string.
+		  *
+		  * \param str The string to iterate over.
+		  */
+		UTF8It(const std::string &str) :
+			UTF8It(str.c_str(), str.size())
+		{}
+
+		/** Creates a copy of another UTF-8 iterator.
+		  *
+		  * \param other The iterator to make a copy of.
+		  */
+		UTF8It(const UTF8It &other);
+
+		/** Gets the code at the current position. If the iterator started out
+		  * in the middle of a codepoint (generally by moving with setIndex()), it
+		  * will be moved back to the start of the codepoint.
+		  *
+		  * Generally, nextCode() and prevCode() are more useful when iterating
+		  * over a string in order.
+		  *
+		  * \return The codepoint at that position, or INVALID_CODE if the
+		  *         codepoint is invalid.
+		  */
+		Code getCode();
+
+		/** Advances the iterator to the next codepoint and returns the
+		  * codepoint it was just at. It does not matter whether the iterator is
+		  * at the start or in the middle of a codepoint initially.
+		  *
+		  * \return The codepoint at the position just moved over, or
+		  *         INVALID_CODE if the codepoint is invalid or the iterator is
+		  *         at the end of the string.
+		  */
+		Code nextCode();
+
+		/** If the iterator is at the start of a codepoint, moves the iterator
+		  * to the start of the prev codepoint. If the iterator is in the middle
+		  * of a codepoint, it behaves the same as getCode().
+		  *
+		  * \return The first codepoint at a position before the current
+		  *         iteration position, or INVALID_CODE if that codepoint is
+		  *         invalid or the iterator is at the start of the string.
+		  */
+		Code prevCode();
+
+		/** Queries whether the iterator is at the start of the string.
+		  *
+		  * \return True if the iterator is at the start of the string, and
+		  *         false otherwise.
+		  */
+		bool isAtStart() const
+		{
+			return m_index == 0;
+		}
+
+		/** Queries whether the iterator is at the end of the string.
+		  *
+		  * \return True if the iterator is at the end of the string, and false
+		  *         otherwise.
+		  */
+		bool isAtEnd() const
+		{
+			return m_index == getEndIndex();
+		}
+
+		/** Moves the iterator directly to the start of the string. Equivalent
+		  * to setIndex(0).
+		  */
+		void toStart()
+		{
+			m_index = 0;
+		}
+
+		/** Moves the iterator directly to the end of the string. Equivalent to
+		  * setIndex(getEndIndex());
+		  */
+		void toEnd()
+		{
+			m_index = getEndIndex();
+		}
+
+		/** Gets the current position of the iterator as an index into the
+		  * string. It does not count codepoints, but bytes.
+		  *
+		  * \return The current string index of the iterator.
+		  */
+		size_t getIndex() const
+		{
+			return m_index;
+		}
+
+		/** Sets the current position of the iterator. It may set the iterator
+		  * to the middle of a codepoint.
+		  *
+		  * \param index The string index to move the iterator to.
+		  */
+		void setIndex(size_t index)
+		{
+			m_index = index;
+		}
+
+		/** Queries the position of an iterator to the end of the string (i.e.
+		  * an iterator moved to the end with toEnd()), which is equivalent to
+		  * the string size.
+		  *
+		  * \return The string index of the end iterator position.
+		  */
+		size_t getEndIndex() const;
+
+		/** Queries whether two iterators are equal, which is true if the
+		  * underlying string is equal and both iterators point to the same
+		  * position.
+		  */
+		friend bool operator==(const UTF8It &left, const UTF8It &right);
+
+		/** Same as operator==, but for inequality. */
+		friend bool operator!=(const UTF8It &left, const UTF8It &right)
+		{
+			return !(left == right);
+		}
+
+		/** Compares whether one iterator is at an earlier position than
+		  * another, which is equivalent to just comparing the positions of the
+		  * iterators. If the iterators point to different strings, the value
+		  * will not be meaningful.
+		  */
+		friend bool operator<(const UTF8It &left, const UTF8It &right)
+		{
+			return left.m_index < right.m_index;
+		}
+
+		/** Same as operator<, but for checking if the first iterator is at a
+		  * later position than the first.
+		  */
+		friend bool operator>(const UTF8It &left, const UTF8It &right)
+		{
+			return left.m_index > right.m_index;
+		}
+
+		/** Same as operator<, but for checking if the first iterator is at an
+		  * earlier or equal position to the first.
+		  */
+		friend bool operator<=(const UTF8It &left, const UTF8It &right)
+		{
+			return left.m_index <= right.m_index;
+		}
+
+		/** Same as operator<, but for checking if the first iterator is at a
+		  * later or equal position to the first.
+		  */
+		friend bool operator>=(const UTF8It &left, const UTF8It &right)
+		{
+			return left.m_index >= right.m_index;
+		}
+	};
+
+	/** Converts a codepoint to a UTF-8 string containing that codepoint, which
+	  * is 2-5 bytes (including the null terminator). The function returns a
+	  * value indicating whether or not the operation succeeded.
+	  *
+	  * \param code The codepoint to convert to a UTF-8 string.
+	  * \param str  The buffer where the codepoint will be stored. It is cleared
+	  *             to '\0' before writing the codepoint. The value is
+	  *             unspecified if the function encounters an error.
+	  * \return True if the function encountered an error, false on success.
+	  */
+	bool code_to_utf8(Code code, char str[5]);
+
+	/** Represents a locale somewhere in the world, consisting of three
+	  * components: language, script, and country. Each component can be left
+	  * out, in which case it falls back to an unspecified default value.
+	  *
+	  * Locales can be specified as strings, which have a syntax of the
+	  * following:
+	  *
+	  *     [language][_[script]][_[country]]
+	  *
+	  * All three components are case-insensitive, and dashes can optionally be
+	  * used instead of underscores.
+	  *
+	  * Some examples of valid locale strings:
+	  * - en_US
+	  * - es__ES
+	  * - fr-ca
+	  * - sy_Cyrl_YU
+	  * - SR-LATN
+	  * - US
+	  * - __US
+	  *
+	  * Locales have a normalized form, which means that proper capitalization
+	  * is applied, underscores are used instead of dashes, and all optional
+	  * leading underscores are included.
+	  */
+	class Locale
+	{
+	private:
+		/** The internal ICU locale doing the actual work, which is also passed
+		  * to all ICU services using this Locale object.
+		  */
+		icu::Locale m_locale;
+
+	public:
+		/** Creates a new locale that uses the user's default locale.
+		  */
+		Locale()
+		{
+			setNormalized(icu::Locale());
+		};
+
+		/** Creates a new locale based on a locale string described in the main
+		  * documentation for Locale. Using a locale string with a different
+		  * format will result in an unspecified locale.
+		  *
+		  * \param The locale string to create the locale from.
+		  */
+		Locale(const char *locale)
+		{
+			setNormalized(icu::Locale::createFromName(locale));
+		}
+
+		/** Converts this locale to normalized string form.
+		  *
+		  * \return The normalized locale string.
+		  */
+		const char *toString() const
+		{
+			return m_locale.getName();
+		}
+
+		/** Gets the language component of this locale, or an empty string if
+		  * none was specified.
+		  *
+		  * \return The language component of this locale.
+		  */
+		const char *getLanguage() const
+		{
+			return m_locale.getLanguage();
+		}
+
+		/** Gets the script component of this locale, or an empty string if none
+		  * was specified.
+		  *
+		  * \return The script component of this locale.
+		  */
+		const char *getScript() const
+		{
+			return m_locale.getScript();
+		}
+
+		/** Gets the country component of this locale, or an empty string if
+		  * none was specified.
+		  *
+		  * \return The country component of this locale.
+		  */
+		const char *getCountry() const
+		{
+			return m_locale.getCountry();
+		}
+
+		/** Checks if two locales are equal, which is true if they have the same
+		  * components.
+		  */
+		friend bool operator==(const Locale &left, const Locale &right)
+		{
+			return left.m_locale == right.m_locale;
+		}
+
+		/** Checks if two locales are not equal, which is true if at least one
+		  * component differs.
+		  */
+		friend bool operator!=(const Locale &left, const Locale &right)
+		{
+			return !(left == right);
+		}
+
+	private:
+		/** Given an ICU locale, strips all information such as variant codes
+		  * or attributes. This makes sure that none of those can creep in from
+		  * the user's default locale or user input that includes them.
+		  *
+		  * The reason that this is necessary is that many Str operations take
+		  * other Strs, and those operations require that the locales of those
+		  * strings are identical. If the default locale had a variant, it would
+		  * automatically be different from every other locale even if it had
+		  * the same language, script, and country, which would be extremely
+		  * confusing and lead to subtle bugs.
+		  *
+		  * \param locale The locale to normalize and set to m_locale.
+		  */
+		void setNormalized(const icu::Locale &locale);
+
+		// Start friend interface
+		friend class Collator;
+		friend class Searcher;
+		friend class Str;
+
+		Locale(const icu::Locale &locale) :
+			m_locale(locale)
+		{}
+
+		/** Returns the interal ICU locale contained in this Locale wrapper.
+		  *
+		  * \return The internal ICU locale.
+		  */
+		const icu::Locale &getInternal() const
+		{
+			return m_locale;
+		}
+		// End friend interface
+	};
+
+	class Str;
+
+	class StrPositioner
+	{
+	protected:
+		std::shared_ptr<const Str> m_str;
+
+	public:
+		StrPositioner(std::shared_ptr<const Str> str);
+
+		StrPositioner(const StrPositioner &other);
+
+		StrPositioner &operator=(const StrPositioner &other);
+
+		virtual ~StrPositioner();
+
+	protected:
+		// Start friend interface
+		friend class Str;
+
+		virtual void updatePositioner()
+		{
+			// Do nothing by default; subclasses may override if they need to do
+			// something when their iterators change.
+		};
+		// End friend interface
+	};
+
+	/** An iterator for iterating over a Str. Besides iterating over plain
+	  * codepoints, StrIt can iterate over characters, words, and line breaks.
+	  * Like Str, StrIt hides the encoding of the string, so there is no way to
+	  * extract individual code units, only codepoints or bigger.
+	  *
+	  * The iterator is similar to most standard C++ iterators in that the
+	  * starting position is at the start of the string and the ending position
+	  * is one past the end of the string.
+	  *
+	  * The public interface of StrIt is a near superset of UTF8It, but since
+	  * it hides the encoding, there are no public functions getIndex(),
+	  * setIndex(), and getEndIndex() in the public interface as they are very
+	  * much tied to the encoding used and encourage bad Unicode practice.
+	  *
+	  * StrIt stores a pointer to the parent Str and calls methods on it,
+	  * including at destruction. Therefore, StrIts **must not** outlive their
+	  * parent Strs.
+	  *
+	  * Unlike most iterators, StrIts are highly stable. When the underlying
+	  * Str is changed, the StrIts pointing to it move so that they stay valid
+	  * and point to the same position in the surrounding text as much as
+	  * possible. For example, assume there is the following text where |
+	  * indicates an iterator position rather than a character:
+	  *
+	  *     chee|se is |ve|ry| tas|ty
+	  *         1      2  3  4    5
+	  *
+	  * Assume "very" is replaced with "extremely" with Str::replace() via the
+	  * second and fourth iterators:
+	  *
+	  *     chee|se is |extremely|| tas|ty
+	  *         1      2         34    5
+	  *
+	  * Notice how iterators 1, 2, 4, and 5 stay in the same position relative
+	  * to the surrounding text. Iterator 3, since it is inside the changed text
+	  * area, moves to the end of the replacement text. Most Str methods behave
+	  * in a similar way, and document exactly how iterators move.
+	  *
+	  * Some Str methods that modify the string cannot move iterators in a
+	  * proper way because they modify the string's internal representation
+	  * beyond recognition, such as toUpper() or normalize(). These functions
+	  * always move all iterators to the end of the text.
+	  */
+	class StrIt : public StrPositioner
+	{
+	private:
+		size_t m_index;
+
+	public:
+		StrIt(const StrIt &other) :
+			StrPositioner(other),
+			m_index(other.m_index)
+		{}
+
+		Code getCode();
+
+		Code nextCode();
+
+		Code prevCode();
+
+		void nextChar();
+
+		void prevChar();
+
+		void nextWord();
+
+		void prevWord();
+
+		bool nextBreak();
+
+		bool prevBreak();
+
+		void nextLine();
+
+		void prevLine();
+
+		bool isAtStart() const;
+
+		bool isAtEnd() const;
+
+		void toStart();
+
+		void toEnd();
+
+		friend bool operator==(const StrIt &left, const StrIt &right)
+		{
+			return left.m_str == right.m_str && left.m_index == right.m_index;
+		}
+
+		friend bool operator!=(const StrIt &left, const StrIt &right)
+		{
+			return !(left == right);
+		}
+
+		friend bool operator<(const StrIt &left, const StrIt &right)
+		{
+			return left.m_index < right.m_index;
+		}
+
+		friend bool operator>(const StrIt &left, const StrIt &right)
+		{
+			return left.m_index > right.m_index;
+		}
+
+		friend bool operator<=(const StrIt &left, const StrIt &right)
+		{
+			return left.m_index <= right.m_index;
+		}
+
+		friend bool operator>=(const StrIt &left, const StrIt &right)
+		{
+			return left.m_index >= right.m_index;
+		}
+
+	private:
+		// Start friend interface
+		friend class Searcher;
+		friend class Str;
+
+		size_t getIndex() const
+		{
+			return m_index;
+		}
+
+		void setIndex(size_t index)
+		{
+			m_index = index;
+		}
+		// End Searcher friend interface
+
+		StrIt(std::shared_ptr<const Str> str, size_t index) :
+			StrPositioner(str),
+			m_index(index)
+		{}
+		// End Str friend interface
+
+		void correctNext();
+
+		void correctPrev();
+
+		bool getLineBreakType(icu::BreakIterator *breaker) const;
+	};
+
+	/** Str is the locus of Unicode operations save that of layout and
+	  * rendering. It stores a string of text and the locale that the text is
+	  * in.
+	  *
+	  * Unlike most string types, which have direct indexing, Str only has
+	  * iteration with StrIt. The reason is that, in Unicode, direct indexing
+	  * is mostly worthless since it only addresses either code units (which are
+	  * almost always worthless) or codepoints (which have few uses as well;
+	  * codepoints are often mistaken for characters). Additionally, Str is
+	  * meant to be encoding-independent in its external interface: it could be
+	  * UTF-8, UTF-16, or UTF-32 without the user code being able to tell.
+	  * Therefore, direct indexing is left out as because it has few uses and
+	  * encourages misuse of Unicode.
+	  *
+	  * Str caches all data structures that perform complex Unicode analysis,
+	  * namely break iterators for StrIt, because they can be expensive to
+	  * create and they take memory, so they are created on an as-needed basis
+	  * and cached for as long as possible, only regenerating or changing when
+	  * the text or locale has changed.
+	  */
+	class Str : public std::enable_shared_from_this<Str>
+	{
+	private:
+		icu::UnicodeString m_string;
+
+		Locale m_locale;
+
+		mutable std::unordered_set<StrPositioner *> m_positioners;
+
+		mutable ICUUniquePtr<UText> m_code_breaker;
+		mutable ICUUniquePtr<icu::BreakIterator> m_char_breaker;
+		mutable ICUUniquePtr<icu::BreakIterator> m_word_breaker;
+		mutable ICUUniquePtr<icu::BreakIterator> m_line_breaker;
+
+	public:
+		template<typename ...Args>
+		static std::shared_ptr<Str> create(Args &&...args)
+		{
+			return std::make_shared<Str>(std::forward<Args>(args)...);
+		}
+
+		static std::shared_ptr<Str> create(std::shared_ptr<Str> other)
+		{
+			return std::make_shared<Str>(*other);
+		}
+
+		Str(const Locale &locale = Locale());
+
+		Str(const char *str, const Locale &locale = Locale());
+
+		Str(const std::string &str, const Locale &locale = Locale());
+
+		Str(Code code, const Locale &locale = Locale()) :
+			m_string(code == INVALID_CODE ? REPLACE_CODE : code),
+			m_locale(locale)
+		{
+			regenerate();
+		}
+
+		Str(const Str &other) :
+			m_string(other.m_string),
+			m_locale(other.m_locale)
+		{
+			regenerate();
+		}
+
+		Str &operator=(const Str &other);
+
+		std::string toString() const
+		{
+			std::string out;
+			return m_string.toUTF8String(out);
+		}
+
+		bool isEmpty() const
+		{
+			return m_string.isEmpty();
+		}
+
+		friend bool operator==(const Str &left, const Str &right)
+		{
+			return left.m_string == right.m_string && left.m_locale == right.m_locale;
+		}
+
+		friend bool operator!=(const Str &left, const Str &right)
+		{
+			return !(left == right);
+		}
+
+		StrIt itStart() const
+		{
+			return StrIt(shared_from_this(), 0);
+		}
+
+		StrIt itEnd() const
+		{
+			return StrIt(shared_from_this(), size());
+		}
+
+		std::shared_ptr<Str> sub(const StrIt &begin, const StrIt &end) const;
+
+		void append(std::shared_ptr<Str> str);
+
+		void insert(const StrIt &pos, std::shared_ptr<Str> str);
+
+		void replace(const StrIt &begin, const StrIt &end, std::shared_ptr<Str> str);
+
+		void remove(const StrIt &begin, const StrIt &end);
+
+		void clear();
+
+		void trim();
+
+		void toLower();
+
+		void toUpper();
+
+		void toTitle(bool first_only = false);
+
+		void normalize(bool compose = false);
+
+		const Locale &getLocale() const
+		{
+			return m_locale;
+		}
+
+		void setLocale(const Locale &locale);
+
+	private:
+		void regenerate();
+
+		void updateBreakers();
+
+		void updatePositioners();
+
+		void updateArea(size_t start, size_t old_end, size_t new_end);
+
+		void updateEntire();
+
+		// Start friend interface
+		friend class StrPositioner;
+
+		void registerPositioner(StrPositioner *it) const
+		{
+			m_positioners.insert(it);
+		}
+
+		void unregisterPositioner(StrPositioner *it) const
+		{
+			m_positioners.erase(it);
+		}
+
+		size_t size() const
+		{
+			return m_string.length();
+		}
+		// End friend interface
+
+		typedef icu::BreakIterator *(*BreakerCreator)(const icu::Locale &, UErrorCode &);
+
+		icu::BreakIterator *getBreaker(ICUUniquePtr<icu::BreakIterator> &breaker,
+				BreakerCreator creator) const;
+
+		// Start friend interface
+		friend class Searcher;
+		friend class StrIt;
+
+		UText *getCodeBreaker() const
+		{
+			return m_code_breaker.get();
+		}
+
+		icu::BreakIterator *getCharBreaker() const;
+
+		icu::BreakIterator *getWordBreaker() const;
+
+		icu::BreakIterator *getLineBreaker() const;
+		// End StrIt friend interface
+
+		friend class Collator;
+
+		const icu::UnicodeString &getInternal() const
+		{
+			return m_string;
+		}
+		// End Collator/Searcher friend interface
+	};
+
+	class Collator
+	{
+	public:
+		/** Bitmask options that control the collation behaviour. */
+		enum Options
+		{
+			NORMAL = 0,
+
+			/** Indicates that case should be ignored. For example, with this
+			  * set, a and A are compared as equal. By default, they are
+			  * compared as different.
+			  */
+			IGNORE_CASE = 0x1,
+
+			/** Indicates that diacritics that are insignificant according to
+			  * the given locale should be ignored. For example, in English, A
+			  * and Å are compared equal with this set, but they are different
+			  * when it is not set. However, in a language like Danish where the
+			  * letter Å is treated as a distinct letter, A will not compare
+			  * equal to Å no matter what.
+			  */
+			IGNORE_DIACRITICS = 0x2,
+
+			/** Increases the importance of uppercase letters such that, when
+			  * there are no more important differences in the text, uppercase
+			  * letters are sorted before lowercase.
+			  *
+			  * If neither this nor LOWERCASE_FIRST is set, the convention for
+			  * the current locale is used. If both are set, UPPERCASE_FIRST
+			  * takes precedence.
+			  */
+			UPPERCASE_FIRST = 0x4,
+
+			/** Increases the importance of lowercase letters such that, when
+			  * there are no more important differences in the text, lowercase
+			  * letters are sorted before uppercase. See UPPERCASE_FIRST for
+			  * more information.
+			  */
+			LOWERCASE_FIRST = 0x8,
+		};
+
+	private:
+		ICUUniquePtr<icu::Collator> m_collator;
+
+		Locale m_locale;
+		Options m_options;
+
+	public:
+		Collator(const Locale &locale, Options options);
+
+		const Locale &getLocale()
+		{
+			return m_locale;
+		}
+
+		void setLocale(const Locale &locale)
+		{
+			m_locale = locale;
+			regenerate();
+		}
+
+		Options getOptions()
+		{
+			return m_options;
+		}
+
+		void setOptions(Options options)
+		{
+			m_options = options;
+			configure();
+		}
+
+		int collate(std::shared_ptr<Str> left, std::shared_ptr<Str> right) const;
+
+	private:
+		void regenerate();
+
+		void configure();
+	};
+
+	class Searcher : public StrPositioner
+	{
+	public:
+		/** Bitmask options that control the searching behaviour. Additionally,
+		  * Collator::IGNORE_CASE and Collator::IGNORE_DIACRITICS are also valid
+		  * bitmasks for anything taking a Searcher::Options.
+		  */
+		enum Options
+		{
+			NORMAL = 0,
+
+			/** Specifies whether matches in the searched text may overlap or
+			  * not. For instance, with this set, "aa" will match "aaa" twice,
+			  * whereas it would only match once without this.
+			  */
+			OVERLAP = 0x4,
+
+			/** Indicates that the search should start searching again from the
+			  * other side when hitting the start or end of the string, rather
+			  * than just stopping.
+			  */
+			WRAP_AROUND = 0x8,
+
+			/** Specifies that the search should only match whole words. Words
+			  * are the same as words found by StrIt::nextWord().
+			  */
+			WHOLE_WORDS_ONLY = 0x10,
+		};
+
+	private:
+		ICUUniquePtr<icu::StringSearch> m_searcher;
+
+		std::shared_ptr<Str> m_pattern;
+
+		Options m_options;
+
+		StrIt m_start;
+		StrIt m_end;
+
+		bool m_needs_regen;
+
+	public:
+		Searcher(std::shared_ptr<const Str> str, std::shared_ptr<Str> pattern,
+				Options options);
+
+		std::shared_ptr<Str> getPattern() const
+		{
+			return m_pattern;
+		}
+
+		void setPattern(std::shared_ptr<Str> pattern)
+		{
+			m_pattern = uni::Str::create(pattern);
+			updatePositioner();
+		}
+
+		Options getOptions()
+		{
+			return m_options;
+		}
+
+		void setOptions(Options options)
+		{
+			m_options = options;
+			updatePositioner();
+		}
+
+		bool hasMatch()
+		{
+			// Regenerating isn't necessary since two indentical iterators will
+			// still be identical even if the string changes.
+			return m_start != m_end;
+		}
+
+		StrIt getMatchStart()
+		{
+			return m_start;
+		}
+
+		StrIt getMatchEnd()
+		{
+			return m_end;
+		}
+
+		void setPos(const StrIt &it)
+		{
+			m_start = it;
+			m_end = it;
+		}
+
+		void toStart()
+		{
+			setPos(m_str->itStart());
+		}
+
+		void toEnd()
+		{
+			setPos(m_str->itEnd());
+		}
+
+		bool next();
+		bool prev();
+
+		bool following(const StrIt &it)
+		{
+			setPos(it);
+			return next();
+		}
+
+		bool preceding(const StrIt &it)
+		{
+			setPos(it);
+			return prev();
+		}
+
+	protected:
+		virtual void updatePositioner() override
+		{
+			m_searcher = nullptr;
+			m_needs_regen = true;
+		}
+
+	private:
+		void regenerate();
+
+		void checkRegenerate()
+		{
+			if (m_needs_regen)
+				regenerate();
+		}
+	};
+}


### PR DESCRIPTION
As requested, here's the Unicode code I've been working on for the GUI, specifically the parts that are essentially complete.  I've redesigned this API any number of times (it's hard to put everything in Unicode together!), but I've settled on a design that I think is quite good.  It's entirely untested (although it compiles) for now because I need to get it hooked up with HarfBuzz and Freetype to display it to the screen before I can see whether it's working correctly.

Building with CMake works for me on Visual Studio, but I don't know how other people will fare.  I'll almost certainly need help with the build stuff on other platforms after I finish the code.  You'll need ICU and HarfBuzz to build.

This will close #10939 and will be used to close many, many other issues as it is further integrated into the engine.

## To do

This PR is a Work in Progress.

#### Unicode Manipulation

This is all the stuff that allows you to muck around without Unicode data.  It's not concerned with displaying anything to the screen, and thus could be available to server-side Lua.  I think this is a good idea because it would allow modders to support proper Unicode instead of using Lua's ASCII-only string functions.

- [X] `uni::Str` class for all nearly all Unicode handling
- [X] UTF-8 iteration
- [X] Locale (language, script, country) support
- [X] Character, word, and line iteration
- [X] Stable iterators: insertion, deletion, etc. don't invalidate iterators; the iterators move to compensate.  This is very useful for e.g. cursor movement.
- [x] Case mapping, trimming
- [x] Normalization, collation, searching
- [x] Codepoint traits; constants for useful control codepoints
- [x] Move string searching and collation to separate classes (better design; allows users to cache as needed instead of recreating ICU object potentially many times)
- [ ] Comment and Doxygen comment heavily, including links to webpages that explain it better than I can.

#### Lua API

- [ ] Server-side Lua API
- [ ] Unit tests (which tests the Lua API and everything in Unicode Manipulation simultaneously)

Things that could be added that could be useful, but I'm purposefully leaving out:
* Number/date/time formatting.  This is primarily localization and not pure Unicode, and therefore not part of the primary purpose of this PR.
* Unicode regex.  Perhaps useful, but a lot.

For reference, here are links to the main ICU and HarfBuzz documentation, which may be useful for reviewing:
* https://unicode-org.github.io/icu/
* https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/
* https://harfbuzz.github.io/

<details><summary><b>Will be in a later PR, but here for notes:</b></summary>

#### Unicode Display

This is the stuff that only pertains to rendering Unicode, and hence will be in a different file with different classes and only available to the client.  It may be moved to a different PR, depending on how large this one gets.

- [ ] Class for holding shaped and "bidirectionalized" text that can compensate for multiple fonts, locales, and formatting in the same text.
- [ ] Bidirectionality
- [ ] Text shaping with HarfBuzz
- [ ] New `Font` and `FontEngine`, i.e. so long, Irrlicht `IGUIFont`!
- [ ] `unicode[]` formspec element that allows testing of all Unicode Display features.  It will only be for testing, and that will be enforced somehow (maybe only allowing the formspec element when the current game is `devtest`?  I'll figure something out.)

<details><summary><b>Random notes to self:</b></summary>

* Useful: https://gankra.github.io/blah/text-hates-you/
* Vertical text (you never know, I might just do it if I care enough):
	* How CSS does it:
		* https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode
		* https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation
		* https://developer.mozilla.org/en-US/docs/Web/CSS/text-combine-upright
		* https://www.w3.org/International/articles/vertical-text/
	* Relevant ICU API:
		* https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/uchar_8h.html#a6e4156bf47733677249ea9c272e84a7b
	* Unicode:
		* https://www.unicode.org/reports/tr50/
</details>
</details>