### PR TITLE
WIP: Do not stat /etc/localtime all the time

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1811,10 +1811,17 @@ void Client::makeScreenshot()
 		return;
 
 	time_t t = time(NULL);
-	struct tm *tm = localtime(&t);
+	struct tm tm;
+
+#ifdef _WIN32
+	// Microsoft has inverted the order of arguments.
+	localtime_s(&tm, &t);
+#else
+	localtime_r(&t, &tm);
+#endif
 
 	char timetstamp_c[64];
-	strftime(timetstamp_c, sizeof(timetstamp_c), "%Y%m%d_%H%M%S", tm);
+	strftime(timetstamp_c, sizeof(timetstamp_c), "%Y%m%d_%H%M%S", &tm);
 
 	std::string screenshot_dir;
 

--- a/src/gettime.h
+++ b/src/gettime.h
@@ -33,10 +33,16 @@ enum TimePrecision
 inline std::string getTimestamp()
 {
 	time_t t = time(NULL);
-	// This is not really thread-safe but it won't break anything
-	// except its own output, so just go with it.
-	struct tm *tm = localtime(&t);
+	struct tm tm;
+
+#ifdef _WIN32
+	// Yes, Microsoft has inverted the order of arguments.
+	localtime_s(&tm, &t);
+#else
+	localtime_r(&t, &tm);
+#endif
+
 	char cs[20]; // YYYY-MM-DD HH:MM:SS + '\0'
-	strftime(cs, 20, "%Y-%m-%d %H:%M:%S", tm);
+	strftime(cs, 20, "%Y-%m-%d %H:%M:%S", &tm);
 	return cs;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,6 +129,7 @@ static OptionList allowed_options;
 int main(int argc, char *argv[])
 {
 	int retval;
+	tzset();
 	debug_set_exception_handler();
 
 	g_logger.registerThread("Main");


### PR DESCRIPTION
tzset(3) initializes the time zone from the $TZ environment variable,
or, if the $TZ variable is not set, from /etc/localtime.  According to
POSIX.1-2001, localtime(3) is required to behave as though tzset(3) was
called, while localtime_r(3) is not. This translated into many syscalls
to check /etc/localtime, … every log line & mapblock needs a timestamp.

- Does it resolve any reported issue?

Yes, this one: https://github.com/minetest/minetest/issues/12079

- Does this relate to a goal in [the roadmap](../doc/direction.md)?

Yes. This PR relates to the goal “2.2 Internal Code refactoring”.
Note that `localtime_r(3)` is threadsafe and `localtime(3)` is not.

- If not a bug fix, why is this PR needed? What usecases does it solve?

This PR reduces the amount of useless busywork done by a small amount.

## To do

- [x] Check that it works on GNU/Linux
- [ ] Check that it works on Android/Linux
- [ ] Check that it works on Windows
- [ ] Check that it works on OS X

## How to test

##### Steps to reproduce
1. Start Minetest from master branch using `strace -e 'trace=%file minetest`.
2. Verify that MInetest is very fond of `/etc/localtime` (stats it on log lines or when a new mapblock is generated).
3. Start Minetest from this branch using `strace -e 'trace=%file' minetest`.
4. Verify that MInetest and `/etc/localtime` are no longer friends (stats it at program startup, then not anymore).
5. Verify that log lines and screenshots and mapblocks have the correct timestamp.