### PR TITLE
feat: add text tile modifier

### DIFF
--- a/games/devtest/mods/testnodes/textures.lua
+++ b/games/devtest/mods/testnodes/textures.lua
@@ -171,3 +171,12 @@ minetest.register_node("testnodes:generated_png_dst_emb", {
 
 	groups = { dig_immediate = 2 },
 })
+minetest.register_node("testnodes:glyph_font", {
+	description = S("Combine Test Node"),
+	tiles = {{
+		name = "testnodes_generated_mb.png^[text:helloworld",
+		align_style = "world",
+		scale = 8,
+	}},
+	groups = { dig_immediate = 2 },
+})


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:
Add text modifier for texture file. 

- Goal of the PR
    Current implemention can render only one character like this:
    ![image with one character rendered](https://mister-muffin.de/p/JANH.png)
    Another option is render characters in a string, but this method will render misaligned text because of lacking api.
    ![image with one character rendered](https://mister-muffin.de/p/kuxq.png)
- How does the PR work?
- Does it resolve any reported issue?
    - #9946
    - #1367 partially
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
    not yet
- If not a bug fix, why is this PR needed? What using cases does it solve?
    Improve fps by render text directly instead of overlay dynamicly

## To do

This PR is a Work in Progress.

- [ ] Avoid scatter of glyph
- [ ] Render paragraph of texts properly

## How to test
See games/devtest/mods/testnodes/textures.lua

<!-- Example code or instructions -->
