### PR TITLE
Make devtest the fallback default game

### DIFF
--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -83,7 +83,7 @@ local function init_globals()
 	menudata.worldlist:set_sortmode("alphabetic")
 
 	if not core.settings:get("menu_last_game") then
-		local default_game = core.settings:get("default_game") or "minetest"
+		local default_game = core.settings:get("default_game") or "devtest"
 		core.settings:set("menu_last_game", default_game)
 	end
 


### PR DESCRIPTION
Without a default game, Minetest compiled from source will not even
start. Since devtest is included in Minetest, it is the only option.

Add compact, short information about your PR for easier understanding:

##### Goal of the PR

Make devtest the default game if no other game is configured.

##### How does the PR work?

It falls back to devtest as a default game if no other game is configured.

##### Does it resolve any reported issue?

Yes: https://github.com/minetest/minetest/issues/12096

##### Does this relate to a goal in [the roadmap](../doc/direction.md)?

Yes, it relates to “2.3 UI Improvements”:

> First impressions matter

> A new main menu should promote games to users, allowing Minetest Game to no
longer be bundled by default.

##### If not a bug fix, why is this PR needed? What usecases does it solve?

This is a bugfix. Minetest does not start at all without this bugfix.

##### How to test

1. Compile Minetest on commit 633e23bd6523d4ff14329e8429c2eaf795e6e128 and start it. Verify that it exits immedately.
2. Compile Minetest on commit eebf129b884f8e893e5b1961c0642e11d7bfb9e6 and start it. Verify that you see the main menu.