### PR TITLE
Fix footsteps for players whose collision box min y != 0

### DIFF
--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -672,19 +672,21 @@ v3s16 LocalPlayer::getStandingNodePos()
 
 v3s16 LocalPlayer::getFootstepNodePos()
 {
+	v3f feet_pos = getPosition() + v3f(0.0f, m_collisionbox.MinEdge.Y, 0.0f);
+
 	// Emit swimming sound if the player is in liquid
 	if (in_liquid_stable)
-		return floatToInt(getPosition() + m_collisionbox.MinEdge, BS);
+		return floatToInt(feet_pos, BS);
 
 	// BS * 0.05 below the player's feet ensures a 1/16th height
 	// nodebox is detected instead of the node below it.
 	if (touching_ground)
-		return floatToInt(getPosition() + m_collisionbox.MinEdge - v3f(0.0f, BS * 0.05f, 0.0f), BS);
+		return floatToInt(feet_pos - v3f(0.0f, BS * 0.05f, 0.0f), BS);
 
 	// A larger distance below is necessary for a footstep sound
 	// when landing after a jump or fall. BS * 0.5 ensures water
 	// sounds when swimming in 1 node deep water.
-	return floatToInt(getPosition() + m_collisionbox.MinEdge - v3f(0.0f, BS * 0.5f, 0.0f), BS);
+	return floatToInt(feet_pos - v3f(0.0f, BS * 0.5f, 0.0f), BS);
 }
 
 v3s16 LocalPlayer::getLightPosition() const


### PR DESCRIPTION
The footstep code assumes that the player's feet are at the player's origin, which is true for Minetest Game, but may not be the case for other games. This PR tries to fix it in a naive way.

If it's needed, I can also open an issue for it.

## To do

This PR is done I think.

## How to test

Try this:

``` Lua
minetest.register_on_joinplayer(function(player)
    minetest.after(0, function() -- To ensure it overrides everything else.
        player:set_properties({
            collisionbox = {
                -0.4375, -0.4375, -0.4375,
                0.4375, 0.4375, 0.4375,
            },

            visual = "cube", -- Just so you can also see it.
            visual_size = vector.new(0.875, 0.875, 0.875),
            textures = {
                "default_gold_block.png", "default_gold_block.png",
                "default_gold_block.png", "default_gold_block.png",
                "default_gold_block.png", "default_gold_block.png",
            },
        })
    end)
end)
```

Footsteps should be broken on master, but work with this PR. As far as I know, it doesn't break anything else.