### PR TITLE
Remove `package`, `debug.debug` and `debug.upvalueid` from global env

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -129,15 +129,7 @@ void ScriptApiSecurity::initializeSecurity()
 		"getinfo",
 		"getmetatable",
 		"setmetatable",
-		"upvalueid",
 		"sethook",
-		"debug",
-	};
-	static const char *package_whitelist[] = {
-		"config",
-		"cpath",
-		"path",
-		"searchpath",
 	};
 #if USE_LUAJIT
 	static const char *jit_whitelist[] = {
@@ -229,14 +221,6 @@ void ScriptApiSecurity::initializeSecurity()
 	copy_safe(L, debug_whitelist, sizeof(debug_whitelist));
 	lua_setglobal(L, "debug");
 	lua_pop(L, 1);  // Pop old debug
-
-
-	// Copy safe package fields
-	lua_getfield(L, old_globals, "package");
-	lua_newtable(L);
-	copy_safe(L, package_whitelist, sizeof(package_whitelist));
-	lua_setglobal(L, "package");
-	lua_pop(L, 1);  // Pop old package
 
 #if USE_LUAJIT
 	// Copy safe jit functions, if they exist


### PR DESCRIPTION
- Goal of the PR: Maintenance, and reducing the number things that you have to think about when using the insecure environment.
- How does the PR work: The things are no longer copied to global env.
- Does it resolve any reported issue: Probably not.

They were all useless:

* `package` is useless without `require`.
  (There was no bad security problem through this though, as all whitelisted
  fields were strings.)
* `debug.debug` is pretty useless without the other `debug.*` functions.
  (But it didn't create serious security issues, AFAIK.)
  Modders that want to debug should disable mod security.
* `debug.upvalueid` is an extension in LuaJIT from Lua 5.2, and it's not
  useful at all.
  (But it didn't create security issues either, AFAIK.)


## To do

This PR is a Ready for Review.

## How to test

* Grep in builtin for these things (and find nothing).
* Try to think of valid use-cases (there are none).
* Check that your mods still work.