### PR TITLE
Make `debug.g/setmetatable` respect the `"__metatable_debug"` metatable field

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -56,6 +56,10 @@ files["builtin/game/init.lua"] = {
 	globals = { "profiler" },
 }
 
+files["builtin/game/secure_sandbox.lua"] = {
+	globals = { debug = { "getmetatable", "setmetatable" }},
+}
+
 files["builtin/common/filterlist.lua"] = {
 	globals = {
 		"filterlist",

--- a/builtin/game/init.lua
+++ b/builtin/game/init.lua
@@ -7,6 +7,8 @@ local gamepath   = scriptpath .. "game".. DIR_DELIM
 -- not exposed to outer context
 local builtin_shared = {}
 
+dofile(gamepath .. "secure_sandbox.lua")
+
 dofile(gamepath .. "constants.lua")
 assert(loadfile(gamepath .. "item.lua"))(builtin_shared)
 dofile(gamepath .. "register.lua")

--- a/builtin/game/secure_sandbox.lua
+++ b/builtin/game/secure_sandbox.lua
@@ -7,7 +7,8 @@ done in C++.
 -- Overwrite debug.getmetatable and debug.setmetatable, so that they have the same
 -- semantics with the metatable field "__metatable_debug" as getmetatable and
 -- setmetatable have with the "__metatable" field.
-do
+-- If mod security is off, they are not restricted.
+if minetest.settings:get_bool("secure.enable_security", true) then
 	local debug_getmetatable_orig = debug.getmetatable
 	local debug_setmetatable_orig = debug.setmetatable
 	-- store error in local variable, so that mods can't overwrite it later

--- a/builtin/game/secure_sandbox.lua
+++ b/builtin/game/secure_sandbox.lua
@@ -1,0 +1,33 @@
+
+--[[
+This file contains things for making the global env sandbox secure that weren't
+done in C++.
+]]
+
+-- Overwrite debug.getmetatable and debug.setmetatable, so that they have the same
+-- semantics with the metatable field "__metatable_debug" as getmetatable and
+-- setmetatable have with the "__metatable" field.
+do
+	local debug_getmetatable_orig = debug.getmetatable
+	local debug_setmetatable_orig = debug.setmetatable
+	-- store error in local variable, so that mods can't overwrite it later
+	local error = error
+
+	debug.getmetatable = function(obj)
+		local mt = debug_getmetatable_orig(obj)
+		if mt.__metatable_debug ~= nil then
+			return mt.__metatable_debug
+		else
+			return mt
+		end
+	end
+
+	debug.setmetatable = function(obj, mt)
+		local current_mt = debug_getmetatable_orig(obj)
+		if current_mt.__metatable_debug ~= nil then
+			error("Overwriting a metatable with __metatable_debug is not allowed for debug.setmetatable.")
+		else
+			return debug_setmetatable_orig(obj, mt)
+		end
+	end
+end

--- a/builtin/game/secure_sandbox.lua
+++ b/builtin/game/secure_sandbox.lua
@@ -16,19 +16,17 @@ if minetest.settings:get_bool("secure.enable_security", true) then
 
 	debug.getmetatable = function(obj)
 		local mt = debug_getmetatable_orig(obj)
-		if mt.__metatable_debug ~= nil then
-			return mt.__metatable_debug
-		else
+		if mt.__metatable_debug == nil then
 			return mt
 		end
+		return mt.__metatable_debug
 	end
 
 	debug.setmetatable = function(obj, mt)
 		local current_mt = debug_getmetatable_orig(obj)
-		if current_mt.__metatable_debug ~= nil then
-			error("Overwriting a metatable with __metatable_debug is not allowed for debug.setmetatable.")
-		else
+		if current_mt.__metatable_debug == nil then
 			return debug_setmetatable_orig(obj, mt)
 		end
+		error("Overwriting a metatable with __metatable_debug is not allowed for debug.setmetatable.")
 	end
 end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -36,7 +36,8 @@ Due to security reasons, mods are executed in a sandboxed environment (see also
 `minetest.request_insecure_environment()`). Mods therefore do not have access to
 all functions in the std library. To see what is available, iterate over `_G`.
 
-There are also functions that are available, but were changed in their functionality:
+There are also functions that are available, but were changed in their functionality
+(list is non-exhaustive):
 
 * `debug.getmetatable`: The metatable's `"__metatable_debug"` field is returned
   instead of the metatable, if it is not `nil`.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -23,8 +23,25 @@ functionality in the engine and API, and to document it here.
 Programming in Lua
 ------------------
 
-If you have any difficulty in understanding this, please read
-[Programming in Lua](http://www.lua.org/pil/).
+Lua version 5.1 is used. LuaJIT and PUC Lua are supported.
+
+If you have any difficulty in understanding this document, please read
+[Programming in Lua](https://www.lua.org/pil/).
+Also look at the [Lua 5.1 Reference Manual](https://www.lua.org/manual/5.1/).
+
+Changes to the Lua std library
+------------------------------
+
+Due to security reasons, mods are executed in a sandboxed environment (see also
+`minetest.request_insecure_environment()`). Mods therefore do not have access to
+all functions in the std library. To see what is available, iterate over `_G`.
+
+There are also functions that are available, but were changed in their functionality:
+
+* `debug.getmetatable`: The metatable's `"__metatable_debug"` field is returned
+  instead of the metatable, if it is not `nil`.
+* `debug.setmetatable`: Raises an error if the original metatable has a non-`nil`
+  `"__metatable_debug"` field.
 
 Startup
 -------

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -127,8 +127,8 @@ void ScriptApiSecurity::initializeSecurity()
 		"gethook",
 		"traceback",
 		"getinfo",
-		"getmetatable",
-		"setmetatable",
+		"getmetatable", // overwritten in builtin to respect "__metatable_debug"
+		"setmetatable", // same as above
 		"upvalueid",
 		"sethook",
 		"debug",

--- a/src/script/lua_api/l_areastore.cpp
+++ b/src/script/lua_api/l_areastore.cpp
@@ -363,6 +363,10 @@ void LuaAreaStore::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua debug.getmetatable()
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_camera.cpp
+++ b/src/script/lua_api/l_camera.cpp
@@ -209,6 +209,9 @@ void LuaCamera::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);
 
+	// (no need to set "__metatable_debug" because client-side API has no
+	// debug.getmetatable() or debug.setmetatable())
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -223,6 +223,10 @@ void LuaRaycast::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);
@@ -757,7 +761,7 @@ int ModApiEnvMod::l_get_objects_in_area(lua_State *L)
 {
 	GET_ENV_PTR;
 	ScriptApiBase *script = getScriptApiBase(L);
-	
+
 	v3f minp = read_v3f(L, 1) * BS;
 	v3f maxp = read_v3f(L, 2) * BS;
 	aabb3f box(minp, maxp);
@@ -1409,7 +1413,7 @@ int ModApiEnvMod::l_compare_block_status(lua_State *L)
 	v3s16 nodepos = check_v3s16(L, 1);
 	std::string condition_s = luaL_checkstring(L, 2);
 	auto status = env->getBlockStatus(getNodeBlockPos(nodepos));
-	
+
 	int condition_i = -1;
 	if (!string_to_enum(es_BlockStatusType, condition_i, condition_s))
 		return 0; // Unsupported

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -433,6 +433,10 @@ void InvRef::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua debug.getmetatable()
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -469,6 +469,11 @@ void LuaItemStack::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);
 
+	// hide metatable from Lua debug.getmetatable()
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -96,6 +96,10 @@ void ItemStackMetaRef::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua debug.getmetatable()
+
 	lua_pushliteral(L, "metadata_class");
 	lua_pushlstring(L, className, strlen(className));
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -443,6 +443,9 @@ void LuaLocalPlayer::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable); // hide metatable from lua getmetatable()
 
+	// (no need to set "__metatable_debug" because client-side API has no
+	// debug.getmetatable() or debug.setmetatable())
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_minimap.cpp
+++ b/src/script/lua_api/l_minimap.cpp
@@ -201,6 +201,9 @@ void LuaMinimap::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
 
+	// (no need to set "__metatable_debug" because client-side API has no
+	// debug.getmetatable() or debug.setmetatable())
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_modchannels.cpp
+++ b/src/script/lua_api/l_modchannels.cpp
@@ -97,6 +97,10 @@ void ModChannelRef::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable); // hide metatable from lua getmetatable()
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua debug.getmetatable()
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -215,6 +215,10 @@ void NodeMetaRef::RegisterCommon(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua debug.getmetatable()
+
 	lua_pushliteral(L, "metadata_class");
 	lua_pushlstring(L, className, strlen(className));
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_nodetimer.cpp
+++ b/src/script/lua_api/l_nodetimer.cpp
@@ -112,6 +112,10 @@ void NodeTimerRef::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua debug.getmetatable()
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -112,6 +112,10 @@ void LuaPerlinNoise::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);
@@ -370,6 +374,10 @@ void LuaPerlinNoiseMap::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);
@@ -475,6 +483,10 @@ void LuaPseudoRandom::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);
@@ -571,6 +583,10 @@ void LuaPcgRandom::Register(lua_State *L)
 	int metatable = lua_gettop(L);
 
 	lua_pushliteral(L, "__metatable");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__metatable_debug");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);
 
@@ -686,6 +702,10 @@ void LuaSecureRandom::Register(lua_State *L)
 	int metatable = lua_gettop(L);
 
 	lua_pushliteral(L, "__metatable");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__metatable_debug");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1371,7 +1371,7 @@ int ObjectRef::l_get_player_control(lua_State *L)
 	lua_newtable(L);
 	if (player == nullptr)
 		return 1;
-	
+
 	const PlayerControl &control = player->getPlayerControl();
 	lua_pushboolean(L, control.direction_keys & (1 << 0));
 	lua_setfield(L, -2, "up");
@@ -2325,6 +2325,10 @@ void ObjectRef::Register(lua_State *L)
 	lua_pushliteral(L, "__metatable");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
+
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua debug.getmetatable()
 
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);

--- a/src/script/lua_api/l_playermeta.cpp
+++ b/src/script/lua_api/l_playermeta.cpp
@@ -79,6 +79,10 @@ void PlayerMetaRef::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable); // hide metatable from Lua getmetatable()
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua debug.getmetatable()
+
 	lua_pushliteral(L, "metadata_class");
 	lua_pushlstring(L, className, strlen(className));
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -324,6 +324,10 @@ void LuaSettings::Register(lua_State* L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua debug.getmetatable()
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_storage.cpp
+++ b/src/script/lua_api/l_storage.cpp
@@ -96,6 +96,10 @@ void StorageRef::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua debug.getmetatable()
+
 	lua_pushliteral(L, "metadata_class");
 	lua_pushlstring(L, className, strlen(className));
 	lua_settable(L, metatable);

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -440,6 +440,10 @@ void LuaVoxelManip::Register(lua_State *L)
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
 
+	lua_pushliteral(L, "__metatable_debug");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua debug.getmetatable()
+
 	lua_pushliteral(L, "__index");
 	lua_pushvalue(L, methodtable);
 	lua_settable(L, metatable);


### PR DESCRIPTION
- Goal of the PR: Improvement of the SSM sandbox security.
- How does the PR work:
  * `debug.getmetatable` and `debug.setmetatable` are overwritten in builtin to use the `"__metatable_debug"` field like `getmetatable` and `setmetatable` use the `"__metatable"` field.
  * Userdata metatables have now the same value for `"__metatable_debug"` as for `"__metatable"`. This prevents mods from doing nasty stuff like overwriting or replacing `"__gc"` metatable fields.
    (The `"__metatable"` fields had basically no effect.)
  * (We still have to leave `debug.g/setmetatable` in the sandbox because we want to allow to overwrite the string metatable.)
- Does it resolve any reported issue: Idk.
- If not a bug fix, why is this PR needed? What usecases does it solve? It can be considered a (security-related) bugfix.

## To do

This PR is a Ready for Review.

## How to test

* Check that your mods still work.
* Read the code.
* Read the doc changes.
