### PR TITLE
Fix memory leak from SpatialAreaStore

### DIFF
--- a/src/util/areastore.cpp
+++ b/src/util/areastore.cpp
@@ -308,6 +308,7 @@ void SpatialAreaStore::getAreasInArea(std::vector<Area *> *result,
 SpatialAreaStore::~SpatialAreaStore()
 {
 	delete m_tree;
+	delete m_storagemanager;
 }
 
 SpatialAreaStore::SpatialAreaStore()


### PR DESCRIPTION
I noticed a memory leak while running unit tests. This pull request fixes that by `deleting` a member of `SpatialAreaStore` that is `new`ed but not released when the area store is deleted.

[The libspatialindex docs](https://libspatialindex.org/en/latest/doxygen/MemoryStorageManager_8cc_source.html) seem to indicate that it's the caller's responsibility to free the underlying memory storage manager of an `RTree`, [not the RTree itself](https://libspatialindex.org/en/latest/doxygen/RTree_8cc_source.html) (see line 395).

## To do

This PR is Ready for Review.

## How to test

This fix can be verified by using Valgrind to run minetest's unit tests before and afterwards.

---

This is my first contribution to minetest, so please do let me know if I've overlooked anything.