### PR TITLE
Store vector metatable in registry

### DIFF
--- a/builtin/common/tests/misc_helpers_spec.lua
+++ b/builtin/common/tests/misc_helpers_spec.lua
@@ -1,4 +1,5 @@
 _G.core = {}
+_G.vector = {metatable = {}}
 dofile("builtin/common/vector.lua")
 dofile("builtin/common/misc_helpers.lua")
 

--- a/builtin/common/tests/serialize_spec.lua
+++ b/builtin/common/tests/serialize_spec.lua
@@ -1,4 +1,5 @@
 _G.core = {}
+_G.vector = {metatable = {}}
 
 _G.setfenv = require 'busted.compatibility'.setfenv
 

--- a/builtin/common/tests/vector_spec.lua
+++ b/builtin/common/tests/vector_spec.lua
@@ -1,4 +1,4 @@
-_G.vector = {}
+_G.vector = {metatable = {}}
 dofile("builtin/common/vector.lua")
 
 describe("vector", function()

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -6,10 +6,8 @@ Note: The vector.*-functions must be able to accept old vectors that had no meta
 -- localize functions
 local setmetatable = setmetatable
 
-vector = {}
-
-local metatable = {}
-vector.metatable = metatable
+-- vector.metatable is set by C++.
+local metatable = vector.metatable
 
 local xyz = {"x", "y", "z"}
 

--- a/builtin/mainmenu/tests/serverlistmgr_spec.lua
+++ b/builtin/mainmenu/tests/serverlistmgr_spec.lua
@@ -1,4 +1,5 @@
 _G.core = {}
+_G.vector = {metatable = {}}
 _G.unpack = table.unpack
 _G.serverlistmgr = {}
 

--- a/games/devtest/mods/unittests/misc.lua
+++ b/games/devtest/mods/unittests/misc.lua
@@ -36,3 +36,15 @@ local function test_dynamic_media(cb, player)
 	-- if the callback isn't called this test will just hang :shrug:
 end
 unittests.register("test_dynamic_media", test_dynamic_media, {async=true, player=true})
+
+local function test_v3f_metatable(player)
+	assert(vector.check(player:get_pos()))
+end
+unittests.register("test_v3f_metatable", test_v3f_metatable, {player=true})
+
+local function test_v3s16_metatable(player, pos)
+	local node = minetest.get_node(pos)
+	local found_pos = minetest.find_node_near(pos, 0, node.name, true)
+	assert(vector.check(found_pos))
+end
+unittests.register("test_v3s16_metatable", test_v3s16_metatable, {map=true})

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -51,28 +51,6 @@ if (value < F1000_MIN || value > F1000_MAX) { \
 #define CHECK_POS_TAB(index) CHECK_TYPE(index, "position", LUA_TTABLE)
 
 
-/**
- * A helper which sets (if available) the vector metatable from builtin as metatable
- * for the table on top of the stack
- */
-static void set_vector_metatable(lua_State *L)
-{
-	// get vector.metatable
-	lua_getglobal(L, "vector");
-	if (!lua_istable(L, -1)) {
-		// there is no global vector table
-		lua_pop(L, 1);
-		errorstream << "set_vector_metatable in c_converter.cpp: " <<
-				"missing global vector table" << std::endl;
-		return;
-	}
-	lua_getfield(L, -1, "metatable");
-	// set the metatable
-	lua_setmetatable(L, -3);
-	// pop vector global
-	lua_pop(L, 1);
-}
-
 void push_v3f(lua_State *L, v3f p)
 {
 	lua_createtable(L, 0, 3);
@@ -82,7 +60,8 @@ void push_v3f(lua_State *L, v3f p)
 	lua_setfield(L, -2, "y");
 	lua_pushnumber(L, p.Z);
 	lua_setfield(L, -2, "z");
-	set_vector_metatable(L);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_VECTOR_METATABLE);
+	lua_setmetatable(L, -2);
 }
 
 void push_v2f(lua_State *L, v2f p)
@@ -275,7 +254,8 @@ void push_v3s16(lua_State *L, v3s16 p)
 	lua_setfield(L, -2, "y");
 	lua_pushinteger(L, p.Z);
 	lua_setfield(L, -2, "z");
-	set_vector_metatable(L);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_VECTOR_METATABLE);
+	lua_setmetatable(L, -2);
 }
 
 v3s16 read_v3s16(lua_State *L, int index)

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -55,6 +55,7 @@ extern "C" {
 #define CUSTOM_RIDX_CURRENT_MOD_NAME    (CUSTOM_RIDX_BASE + 2)
 #define CUSTOM_RIDX_BACKTRACE           (CUSTOM_RIDX_BASE + 3)
 #define CUSTOM_RIDX_HTTP_API_LUA        (CUSTOM_RIDX_BASE + 4)
+#define CUSTOM_RIDX_VECTOR_METATABLE    (CUSTOM_RIDX_BASE + 5)
 
 
 // Determine if CUSTOM_RIDX_SCRIPTAPI will hold a light or full userdata

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -121,6 +121,14 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 	lua_newtable(m_luastack);
 	lua_setglobal(m_luastack, "core");
 
+	// vector.metatable is stored in the registry for quick access from C++.
+	lua_newtable(m_luastack);
+	lua_rawseti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_VECTOR_METATABLE);
+	lua_newtable(m_luastack);
+	lua_rawgeti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_VECTOR_METATABLE);
+	lua_setfield(m_luastack, -2, "metatable");
+	lua_setglobal(m_luastack, "vector");
+
 	if (m_type == ScriptingType::Client)
 		lua_pushstring(m_luastack, "/");
 	else

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -98,6 +98,7 @@ void ScriptApiSecurity::initializeSecurity()
 		"type",
 		"unpack",
 		"_VERSION",
+		"vector",
 		"xpcall",
 	};
 	static const char *whitelist_tables[] = {
@@ -296,6 +297,7 @@ void ScriptApiSecurity::initializeSecurityClient()
 		"type",
 		"unpack",
 		"_VERSION",
+		"vector",
 		"xpcall",
 		// Completely safe libraries
 		"coroutine",


### PR DESCRIPTION
Vectors are pushed to the Lua stack from C++ very often. For example, every time an ABM action executes, a vector must be pushed. Therefore, it makes sense to optimize the pushing of vectors. Currently, in order to set the pushed vector's metatable, first the global `vector` is queried, after which the code queries its field `metatable`. My change puts the metatable directly into the registry, turning two hash index operations into one array index operation for every push.

## To do

This PR is Ready for Review.

## How to test

I added a unit test to devtest. It should probably be run both with and without mod security.
