### PR TITLE
Fix undefined behavior in TileLayer

### DIFF
--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -196,7 +196,7 @@ struct TileLayer
 			material_type == other.material_type &&
 			material_flags == other.material_flags &&
 			has_color == other.has_color &&
-			(!has_color || color == other.color) &&
+			color == other.color &&
 			scale == other.scale;
 	}
 
@@ -289,7 +289,7 @@ struct TileLayer
 	 * The color of the tile, or if the tile does not own
 	 * a color then the color of the node owning this tile.
 	 */
-	video::SColor color;
+	video::SColor color = video::SColor(0, 0, 0, 0);
 
 	u8 scale = 1;
 };

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -195,7 +195,8 @@ struct TileLayer
 			texture_id == other.texture_id &&
 			material_type == other.material_type &&
 			material_flags == other.material_flags &&
-			color == other.color &&
+			has_color == other.has_color &&
+			(!has_color || color == other.color) &&
 			scale == other.scale;
 	}
 
@@ -290,7 +291,7 @@ struct TileLayer
 	 */
 	video::SColor color;
 
-	u8 scale;
+	u8 scale = 1;
 };
 
 /*!


### PR DESCRIPTION
`TileLayer::operator==` can trigger undefined behavior, because `TileLayer::color` and `TileLayer::scale` are uninitialized. 

`scale` can simply be initialized to a reasonable default value (I chose 1, which I believe should mean 1:1 scale, i.e. no scaling). `color` should only be accessed when `has_color` is true.

This is a pretty simple fix. I'm not sure if it's related to any existing reported bugs, but it could contribute to TileSpecs not getting shared within a block when they ought to be, which is a potential performance problem.

## To do

This PR is Ready for Review.

## How to test

You can test this by using Valgrind, opening a world, and waiting until blocks start to render. Valgrind should give an error about use of an uninitialized value in a conditional jump. If you build with debug information, it will point you at the line in question. Note that on my Radeon card, Irrlichtmt also had some use of uninitialized values, which you should patch out or ignore in order to see this issue.