### PR TITLE
Fix memory leak in EmergeManager

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -202,6 +202,7 @@ EmergeManager::~EmergeManager()
 			delete m_mapgens[i];
 	}
 
+	delete biomegen;
 	delete biomemgr;
 	delete oremgr;
 	delete decomgr;


### PR DESCRIPTION
`EmergeManager` keeps a pointer to a `BiomeGen` that it creates and then hands (a copy of) out to each worker thread, but never `delete`s the `BiomeGen`.

## To do

This PR is Ready for Review.

## How to test

This fix can be verified with Valgrind by creating, entering, and then leaving a world.
