### PR TITLE
Add semi-transparent background to chat

### DIFF
--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -226,7 +226,9 @@ void GameUI::showTranslatedStatusText(const char *str)
 
 void GameUI::setChatText(const EnrichedString &chat_text, u32 recent_chat_count)
 {
-	setStaticText(m_guitext_chat, chat_text);
+	EnrichedString str(chat_text);
+	str.setBackground(video::SColor(90, 0, 0, 0));
+	setStaticText(m_guitext_chat, str);
 
 	m_recent_chat_count = recent_chat_count;
 }


### PR DESCRIPTION
- Goal of the PR: readability
- Does this relate to a goal in [the roadmap](../doc/direction.md)? 2.1 Rendering/Graphics improvements

I'm making this PR as I've run tired of being unable to use different colours but white in the chat. Right now 99% of colours are penalised and it's in general hard to read.
My idea was to put a tailored background to each message, trimmed right after the last character of the message, but I don't have the right amount of knowledge to do that (I tried for a while, with no luck). I'd be more than happy to see someone improving this PR, which I consider just a first step towards readability - I can't be sure if it's better with different lengths anyway, but it was worth a shot exploring it.

Yes, the best thing would be having the chat as an HUD element to allow customisations, but it's been more than a year since it was suggested (https://github.com/minetest/minetest/issues/10372), with no real attempt to turn it into reality. Furthermore, I'm nowhere able to do that, so I've simply applied a patch for the time being.

Before:
![imagen](https://user-images.githubusercontent.com/63455151/158874031-9315c3a6-98e5-4248-aa4b-8a557ee54463.png)

After (red is punished as it's darker than the rest):
![imagen](https://user-images.githubusercontent.com/63455151/158874092-ae8d276b-9176-43cc-83a3-070aa3a9e9c3.png)

I was talking about tailoring each message because this is what the whole screen looks like:
![imagen](https://user-images.githubusercontent.com/63455151/158874635-c1019b47-3ec9-4f53-b50b-d56bde3acf36.png)

(background colour is lighter than F10)



## To do

This PR is Ready for Review.

## How to test
```
minetest.register_on_joinplayer(function(player)
    minetest.after(3, function()
        minetest.chat_send_all(minetest.colorize("#3cebf6", "This is sky blue") .. " and " .. minetest.colorize("#ff5033", "this is red!"))
        minetest.chat_send_all(minetest.colorize("#c3ee1b", "Even green") .. " doesn't seem so bad")
        minetest.chat_send_all(minetest.colorize("#ffaeb6", "Pink") .. " and " .. minetest.colorize("#ff9033", "orange") .. " are also fine")
        minetest.chat_send_all("You can now read without turning blind!")
    end)
end)
```
