### PR TITLE
Add minetest.light_equivalent

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -175,6 +175,22 @@ function core.strip_param2_color(param2, paramtype2)
 	return param2
 end
 
+function core.light_equivalent(node1, node2)
+	local nodename1 = type(node1) == "table" and node1.name or node1
+	local nodename2 = type(node2) == "table" and node2.name or node2
+	local def1 = core.registered_nodes[nodename1]
+	if not def1 then
+		error("Invalid first node name " .. tostring(nodename1))
+	end
+	local def2 = core.registered_nodes[nodename2]
+	if not def2 then
+		error("Invalid second node name " .. tostring(nodename2))
+	end
+	return (def1.paramtype == "light") == (def2.paramtype == "light")
+			and def1.sunlight_propagates == def2.sunlight_propagates
+			and def1.light_source == def2.light_source
+end
+
 local function has_all_groups(tbl, required_groups)
 	if type(required_groups) == "string" then
 		return (tbl[required_groups] or 0) ~= 0

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3542,6 +3542,10 @@ Helper functions
     * `tool_capabilities`: Tool capabilities table of the item
     * `time_from_last_punch`: time in seconds since last punch action
     * `wear`: Amount of wear the item starts with (default: 0)
+* `minetest.light_equivalent(node1, node2)`:
+    Returns whether the nodes have the same lighting characteristics, meaning they can be
+    swapped without necessitating a light update.
+    * `node1` and `node2` are node names or tables representing nodes.
 
 
 

--- a/games/devtest/mods/unittests/misc.lua
+++ b/games/devtest/mods/unittests/misc.lua
@@ -6,6 +6,44 @@ local function test_random()
 end
 unittests.register("test_random", test_random)
 
+local function test_light_equivalent()
+	local function assert_equivalence(a, b, equiv)
+		if core.light_equivalent(a, b) ~= equiv then
+			error(("%s %s light-wise equivalent to %s"):format(
+				core.write_json(a),
+				equiv and "is not" or "is",
+				core.write_json(b)
+			))
+		end
+	end
+	local function test_noncommutatively(a, b, equiv)
+		local node_a = {name = a, param1 = 0, param2 = 0}
+		local node_b = {name = b, param1 = 0, param2 = 0}
+		assert_equivalence(a, b, equiv)
+		assert_equivalence(node_a, b, equiv)
+		assert_equivalence(a, node_b, equiv)
+		assert_equivalence(node_a, node_b, equiv)
+	end
+	local function test(a, b, equiv)
+		test_noncommutatively(a, b, equiv)
+		test_noncommutatively(b, a, equiv)
+	end
+
+	test("ignore", "ignore", true)
+	test("basenodes:water_source", "basenodes:water_flowing", true)
+	test("basenodes:water_source", "mapgen_water_source", true)
+	test("basenodes:lava_source", "basenodes:lava_flowing", true)
+	test("basenodes:water_source", "basenodes:lava_flowing", false)
+	test("mapgen_water_source", "mapgen_lava_source", false)
+	test("basenodes:stone", "basenodes:dirt_with_grass", true)
+	test("basenodes:tree", "basenodes:leaves", false)
+	test("basenodes:leaves", "basenodes:jungleleaves", true)
+	test("basenodes:leaves", "basenodes:lava_source", false)
+	test("basenodes:leaves", "basenodes:apple", false)
+	test("basenodes:apple", "air", true)
+end
+unittests.register("test_light_equivalent", test_light_equivalent)
+
 local function test_dynamic_media(cb, player)
 	if core.get_player_information(player:get_player_name()).protocol_version < 40 then
 		core.log("warning", "test_dynamic_media: Client too old, skipping test.")


### PR DESCRIPTION
This PR adds a helper function for determining whether two nodes can be swapped without needing to update lighting afterward. This is useful for avoiding unnecessary light updates when using voxel manipulators. For a practical use, see [Mesecons](https://github.com/minetest-mods/mesecons/blob/399ee9f5b5ded1c423f4aa652c2e2252abbe5312/mesecons/internal.lua#L399).

The function is pretty simple, but I think adding it to the core is warranted; if in the future there are more fields that distinguish nodes light-wise, it would be good to be able to update the code in a central location rather than for every mod that uses the technique.

## To do

This PR is Ready for Review.

## How to test

I have added a unit test to devtest.
