### PR TITLE
Optimize swapping nodes with equivalent lighting

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -171,8 +171,15 @@ void Map::setNode(v3s16 p, MapNode & n)
 	v3s16 blockpos = getNodeBlockPos(p);
 	MapBlock *block = getBlockNoCreate(blockpos);
 	v3s16 relpos = p - blockpos*MAP_BLOCKSIZE;
+	setNode(block, relpos, n);
+}
+
+void Map::setNode(MapBlock *block, v3s16 relpos, MapNode &n)
+{
 	// Never allow placing CONTENT_IGNORE, it causes problems
 	if(n.getContent() == CONTENT_IGNORE){
+		v3s16 blockpos = block->getPos();
+		v3s16 p = blockpos * MAP_BLOCKSIZE + relpos;
 		bool temp_bool;
 		errorstream<<"Map::setNode(): Not allowing to place CONTENT_IGNORE"
 				<<" while trying to replace \""
@@ -191,7 +198,12 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 	RollbackNode rollback_oldnode(this, p, m_gamedef);
 
 	// This is needed for updating the lighting
-	MapNode oldnode = getNode(p);
+	v3s16 blockpos = getNodeBlockPos(p);
+	MapBlock *block = getBlockNoCreate(blockpos);
+	if (block->isDummy())
+		throw InvalidPositionException();
+	v3s16 relpos = p - blockpos * MAP_BLOCKSIZE;
+	MapNode oldnode = block->getNodeUnsafe(relpos);
 
 	// Remove node metadata
 	if (remove_metadata) {
@@ -199,18 +211,29 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 	}
 
 	// Set the node on the map
-	// Ignore light (because calling voxalgo::update_lighting_nodes)
-	n.setLight(LIGHTBANK_DAY, 0, m_nodedef);
-	n.setLight(LIGHTBANK_NIGHT, 0, m_nodedef);
-	setNode(p, n);
+	const ContentFeatures &cf = m_nodedef->get(n);
+	const ContentFeatures &oldcf = m_nodedef->get(oldnode);
+	if (cf.lightingEquivalent(oldcf)) {
+		// No light update needed, just copy over the old light.
+		n.setLight(LIGHTBANK_DAY, oldnode.getLightRaw(LIGHTBANK_DAY, oldcf), cf);
+		n.setLight(LIGHTBANK_NIGHT, oldnode.getLightRaw(LIGHTBANK_NIGHT, oldcf), cf);
+		setNode(block, relpos, n);
 
-	// Update lighting
-	std::vector<std::pair<v3s16, MapNode> > oldnodes;
-	oldnodes.emplace_back(p, oldnode);
-	voxalgo::update_lighting_nodes(this, oldnodes, modified_blocks);
+		modified_blocks[blockpos] = block;
+	} else {
+		// Ignore light (because calling voxalgo::update_lighting_nodes)
+		n.setLight(LIGHTBANK_DAY, 0, cf);
+		n.setLight(LIGHTBANK_NIGHT, 0, cf);
+		setNode(block, relpos, n);
 
-	for (auto &modified_block : modified_blocks) {
-		modified_block.second->expireDayNightDiff();
+		// Update lighting
+		std::vector<std::pair<v3s16, MapNode> > oldnodes;
+		oldnodes.emplace_back(p, oldnode);
+		voxalgo::update_lighting_nodes(this, oldnodes, modified_blocks);
+
+		for (auto &modified_block : modified_blocks) {
+			modified_block.second->expireDayNightDiff();
+		}
 	}
 
 	// Report for rollback

--- a/src/map.h
+++ b/src/map.h
@@ -295,6 +295,9 @@ protected:
 		float step, float stepfac, float start_offset, float end_offset,
 		u32 needed_count);
 
+	// helper function, throws InvalidPositionException if block is a dummy
+	void setNode(MapBlock *block, v3s16 relpos, MapNode &n);
+
 private:
 	f32 m_transforming_liquid_loop_count_multiplier = 1.0f;
 	u32 m_unprocessed_count = 0;

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -478,6 +478,12 @@ struct ContentFeatures
 		return (liquid_alternative_flowing_id == f.liquid_alternative_flowing_id);
 	}
 
+	bool lightingEquivalent(const ContentFeatures &other) const {
+		return light_propagates == other.light_propagates
+				&& sunlight_propagates == other.sunlight_propagates
+				&& light_source == other.light_source;
+	}
+
 	int getGroup(const std::string &group) const
 	{
 		return itemgroup_get(groups, group);


### PR DESCRIPTION
It is a fairly common occurrence for a node to be swapped with another node that has the exact same lighting characteristics. For example, this is occurs when Mesecons logic gates change state. In these cases, Minetest does an unnecessary light update check which seems to take a significant amount of time. This PR skips unnecessary light checks.

## To do

This PR is Ready for Review.

## How to test

You can use the devtest command `bench_bulk_set_node` to compare performance. The code with the PR is much faster for me, but keep in mind that this will only be so when the nodes being set have the same lighting characteristics as the previous nodes.
