### PR TITLE
Builtin: Allow to revoke unknown privileges

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -310,12 +310,7 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 			and revokename == core.settings:get("name")
 			and revokename ~= ""
 	if revokeprivstr == "all" then
-		revokeprivs = privs
-		privs = {}
-	else
-		for priv, _ in pairs(revokeprivs) do
-			privs[priv] = nil
-		end
+		revokeprivs = table.copy(privs)
 	end
 
 	local privs_unknown = ""
@@ -332,7 +327,10 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 		end
 		local def = core.registered_privileges[priv]
 		if not def then
-			privs_unknown = privs_unknown .. S("Unknown privilege: @1", priv) .. "\n"
+			-- Old/removed privileges might still be granted to certain players
+			if not privs[priv] then
+				privs_unknown = privs_unknown .. S("Unknown privilege: @1", priv) .. "\n"
+			end
 		elseif is_singleplayer and def.give_to_singleplayer then
 			irrevokable[priv] = true
 		elseif is_admin and def.give_to_admin then
@@ -344,7 +342,7 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 		has_irrevokable_priv = true
 	end
 	if privs_unknown ~= "" then
-		return false, privs_unknown
+		core.chat_send_player(caller, privs_unknown)
 	end
 	if has_irrevokable_priv then
 		if is_singleplayer then
@@ -359,18 +357,21 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 	end
 
 	local revokecount = 0
+	for priv, _ in pairs(revokeprivs) do
+		privs[priv] = nil
+		revokecount = revokecount + 1
+	end
+
+	if revokecount == 0 then
+		return false, S("No privileges were revoked.")
+	end
 
 	core.set_player_privs(revokename, privs)
 	for priv, _ in pairs(revokeprivs) do
 		-- call the on_revoke callbacks
 		core.run_priv_callbacks(revokename, priv, caller, "revoke")
-		revokecount = revokecount + 1
 	end
 	local new_privs = core.get_player_privs(revokename)
-
-	if revokecount == 0 then
-		return false, S("No privileges were revoked.")
-	end
 
 	core.log("action", caller..' revoked ('
 			..core.privs_to_string(revokeprivs, ', ')

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -342,7 +342,7 @@ local function handle_revoke_command(caller, revokename, revokeprivstr)
 		has_irrevokable_priv = true
 	end
 	if privs_unknown ~= "" then
-		core.chat_send_player(caller, privs_unknown)
+		return false, privs_unknown
 	end
 	if has_irrevokable_priv then
 		if is_singleplayer then


### PR DESCRIPTION
Fixes #12114

This PR also keeps the new `privs` table unmodified until the permission checks are done - to hopefully improve security in case this code is touched again.

## To do

This PR is Ready for Review.

## How to test

Either register privileges using a mod or:

1. Open `auth.sqlite`
2. Add a permission entry and save
3. Join the world and try to revoke