### PR TITLE
Add documentation of sun/moon orientation/scale differences

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7208,6 +7208,7 @@ child will follow movement and rotation of that bone.
             (default: `true`)
         * `texture`: A regular texture for the sun. Setting to `""`
             will re-enable the mesh sun. (default: "sun.png", if it exists)
+            At sunrise, the texture appears non-rotated in the east (+X).
         * `tonemap`: A 512x1 texture containing the tonemap for the sun
             (default: `"sun_tonemap.png"`)
         * `sunrise`: A regular texture for the sunrise texture.
@@ -7215,6 +7216,8 @@ child will follow movement and rotation of that bone.
         * `sunrise_visible`: Boolean for whether the sunrise texture is visible.
             (default: `true`)
         * `scale`: Float controlling the overall size of the sun. (default: `1`)
+            Note: For equal `scale` values, the sun is bigger than the moon by a
+            factor of `0.119/0.076`.
 * `get_sun()`: returns a table with the current sun parameters as in
     `set_sun`.
 * `set_moon(moon_parameters)`:
@@ -7224,11 +7227,14 @@ child will follow movement and rotation of that bone.
             (default: `true`)
         * `texture`: A regular texture for the moon. Setting to `""`
             will re-enable the mesh moon. (default: `"moon.png"`, if it exists)
-            Note: Relative to the sun, the moon texture is rotated by 180°.
+            At sunrise, the texture appears non-rotated in the west (-X).
+            Note: Relative to the sun, the moon texture is hence rotated by 180°.
             You can use the `^[transformR180` texture modifier to achieve the same orientation.
         * `tonemap`: A 512x1 texture containing the tonemap for the moon
             (default: `"moon_tonemap.png"`)
         * `scale`: Float controlling the overall size of the moon (default: `1`)
+            Note: For equal `scale` values, the sun is bigger than the moon by a
+            factor of `0.119/0.076`.
 * `get_moon()`: returns a table with the current moon parameters as in
     `set_moon`.
 * `set_stars(star_parameters)`:

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7208,7 +7208,8 @@ child will follow movement and rotation of that bone.
             (default: `true`)
         * `texture`: A regular texture for the sun. Setting to `""`
             will re-enable the mesh sun. (default: "sun.png", if it exists)
-            At sunrise, the texture appears non-rotated.
+            At sunrise, the texture appears non-rotated on the screen if one
+            looks at it.
         * `tonemap`: A 512x1 texture containing the tonemap for the sun
             (default: `"sun_tonemap.png"`)
         * `sunrise`: A regular texture for the sunrise texture.
@@ -7216,8 +7217,8 @@ child will follow movement and rotation of that bone.
         * `sunrise_visible`: Boolean for whether the sunrise texture is visible.
             (default: `true`)
         * `scale`: Float controlling the overall size of the sun. (default: `1`)
-            Note: For equal `scale` values, the sun is bigger than the moon by a
-            factor of `0.119/0.076`.
+            Note: For legacy reasons, the sun is bigger than the moon by a factor
+            of `0.119/0.076` for equal `scale` values.
 * `get_sun()`: returns a table with the current sun parameters as in
     `set_sun`.
 * `set_moon(moon_parameters)`:
@@ -7227,14 +7228,15 @@ child will follow movement and rotation of that bone.
             (default: `true`)
         * `texture`: A regular texture for the moon. Setting to `""`
             will re-enable the mesh moon. (default: `"moon.png"`, if it exists)
-            At sunrise, the texture appears non-rotated.
+            At sunrise, the texture appears non-rotated on the screen if one
+            looks at it.
             Note: Relative to the sun, the moon texture is hence rotated by 180°.
             You can use the `^[transformR180` texture modifier to achieve the same orientation.
         * `tonemap`: A 512x1 texture containing the tonemap for the moon
             (default: `"moon_tonemap.png"`)
         * `scale`: Float controlling the overall size of the moon (default: `1`)
-            Note: For equal `scale` values, the sun is bigger than the moon by a
-            factor of `0.119/0.076`.
+            Note: For legacy reasons, the sun is bigger than the moon by a factor
+            of `0.119/0.076` for equal `scale` values.
 * `get_moon()`: returns a table with the current moon parameters as in
     `set_moon`.
 * `set_stars(star_parameters)`:

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7208,7 +7208,7 @@ child will follow movement and rotation of that bone.
             (default: `true`)
         * `texture`: A regular texture for the sun. Setting to `""`
             will re-enable the mesh sun. (default: "sun.png", if it exists)
-            At sunrise, the texture appears non-rotated in the east (+X).
+            At sunrise, the texture appears non-rotated.
         * `tonemap`: A 512x1 texture containing the tonemap for the sun
             (default: `"sun_tonemap.png"`)
         * `sunrise`: A regular texture for the sunrise texture.
@@ -7227,7 +7227,7 @@ child will follow movement and rotation of that bone.
             (default: `true`)
         * `texture`: A regular texture for the moon. Setting to `""`
             will re-enable the mesh moon. (default: `"moon.png"`, if it exists)
-            At sunrise, the texture appears non-rotated in the west (-X).
+            At sunrise, the texture appears non-rotated.
             Note: Relative to the sun, the moon texture is hence rotated by 180°.
             You can use the `^[transformR180` texture modifier to achieve the same orientation.
         * `tonemap`: A 512x1 texture containing the tonemap for the moon

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4710,13 +4710,13 @@ Privileges
 
 Privileges provide a means for server administrators to give certain players
 access to special abilities in the engine, games or mods.
-For example, game moderators may need to travel instantly to any place in the world, 
+For example, game moderators may need to travel instantly to any place in the world,
 this ability is implemented in `/teleport` command which requires `teleport` privilege.
 
 Registering privileges
 ----------------------
 
-A mod can register a custom privilege using `minetest.register_privilege` function 
+A mod can register a custom privilege using `minetest.register_privilege` function
 to give server administrators fine-grained access control over mod functionality.
 
 For consistency and practical reasons, privileges should strictly increase the abilities of the user.
@@ -4725,7 +4725,7 @@ Do not register custom privileges that e.g. restrict the player from certain in-
 Checking privileges
 -------------------
 
-A mod can call `minetest.check_player_privs` to test whether a player has privileges 
+A mod can call `minetest.check_player_privs` to test whether a player has privileges
 to perform an operation.
 Also, when registering a chat command with `minetest.register_chatcommand` a mod can
 declare privileges that the command requires using the `privs` field of the command
@@ -4789,7 +4789,7 @@ Minetest includes the following settings to control behavior of privileges:
 
    * `default_privs`: defines privileges granted to new players.
    * `basic_privs`: defines privileges that can be granted/revoked by players having
-    the `basic_privs` privilege. This can be used, for example, to give 
+    the `basic_privs` privilege. This can be used, for example, to give
     limited moderation powers to selected users.
 
 'minetest' namespace reference
@@ -7208,8 +7208,8 @@ child will follow movement and rotation of that bone.
             (default: `true`)
         * `texture`: A regular texture for the sun. Setting to `""`
             will re-enable the mesh sun. (default: "sun.png", if it exists)
-            At sunrise, the texture appears non-rotated on the screen if one
-            looks at it.
+            The texture appears non-rotated at sunrise and rotated 180 degrees
+            (upside down) at sunset.
         * `tonemap`: A 512x1 texture containing the tonemap for the sun
             (default: `"sun_tonemap.png"`)
         * `sunrise`: A regular texture for the sunrise texture.
@@ -7218,7 +7218,7 @@ child will follow movement and rotation of that bone.
             (default: `true`)
         * `scale`: Float controlling the overall size of the sun. (default: `1`)
             Note: For legacy reasons, the sun is bigger than the moon by a factor
-            of `0.119/0.076` for equal `scale` values.
+            of about `1.57` for equal `scale` values.
 * `get_sun()`: returns a table with the current sun parameters as in
     `set_sun`.
 * `set_moon(moon_parameters)`:
@@ -7228,15 +7228,15 @@ child will follow movement and rotation of that bone.
             (default: `true`)
         * `texture`: A regular texture for the moon. Setting to `""`
             will re-enable the mesh moon. (default: `"moon.png"`, if it exists)
-            At sunrise, the texture appears non-rotated on the screen if one
-            looks at it.
+            The texture appears non-rotated at sunrise / moonset and rotated 180
+            degrees (upside down) at sunset / moonrise.
             Note: Relative to the sun, the moon texture is hence rotated by 180°.
             You can use the `^[transformR180` texture modifier to achieve the same orientation.
         * `tonemap`: A 512x1 texture containing the tonemap for the moon
             (default: `"moon_tonemap.png"`)
         * `scale`: Float controlling the overall size of the moon (default: `1`)
             Note: For legacy reasons, the sun is bigger than the moon by a factor
-            of `0.119/0.076` for equal `scale` values.
+            of about `1.57` for equal `scale` values.
 * `get_moon()`: returns a table with the current moon parameters as in
     `set_moon`.
 * `set_stars(star_parameters)`:

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -142,7 +142,6 @@ void Sky::render()
 	driver->setTransform(video::ETS_WORLD, translate * scale);
 
 	if (m_sunlight_seen) {
-		float sunsize = 0.07;
 		video::SColorf suncolor_f(1, 1, 0, 1);
 		//suncolor_f.r = 1;
 		//suncolor_f.g = MYMAX(0.3, MYMIN(1.0, 0.7 + m_time_brightness * 0.5));
@@ -156,7 +155,6 @@ void Sky::render()
 		suncolor_f.g = MYMAX(0.3, MYMIN(1.0, 0.85 + m_time_brightness * 0.5));
 		suncolor_f.b = MYMAX(0.0, m_brightness);
 
-		float moonsize = 0.04;
 		video::SColorf mooncolor_f(0.50, 0.57, 0.65, 1);
 		video::SColorf mooncolor2_f(0.85, 0.875, 0.9, 1);
 
@@ -294,11 +292,11 @@ void Sky::render()
 
 		// Draw sun
 		if (m_sun_params.visible)
-			draw_sun(driver, sunsize, suncolor, suncolor2, wicked_time_of_day);
+			draw_sun(driver, suncolor, suncolor2, wicked_time_of_day);
 
 		// Draw moon
 		if (m_moon_params.visible)
-			draw_moon(driver, moonsize, mooncolor, mooncolor2, wicked_time_of_day);
+			draw_moon(driver, mooncolor, mooncolor2, wicked_time_of_day);
 
 		// Draw far cloudy fog thing below all horizons in front of sun, moon
 		// and stars.
@@ -573,16 +571,18 @@ v3f Sky::getMoonDirection()
 	return getSkyBodyPosition(270, getWickedTimeOfDay(m_time_of_day) * 360 - 90, m_sky_body_orbit_tilt);
 }
 
-void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor &suncolor,
+void Sky::draw_sun(video::IVideoDriver *driver, const video::SColor &suncolor,
 	const video::SColor &suncolor2, float wicked_time_of_day)
 	/* Draw sun in the sky.
 	 * driver: Video driver object used to draw
-	 * sunsize: the default size of the sun
 	 * suncolor: main sun color
 	 * suncolor2: second sun color
 	 * wicked_time_of_day: current time of day, to know where should be the sun in the sky
 	 */
 {
+	// A magic number that contributes to the ratio 1.57 sun/moon size difference.
+	constexpr float sunsize = 0.07;
+
 	static const u16 indices[] = {0, 1, 2, 0, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
 	if (!m_sun_texture) {
@@ -605,6 +605,8 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SCol
 		}
 	} else {
 		driver->setMaterial(m_materials[3]);
+		// Another magic number that contributes to the ratio 1.57 sun/moon size
+		// difference.
 		float d = (sunsize * 1.7) * m_sun_params.scale;
 		video::SColor c;
 		if (m_sun_tonemap)
@@ -618,18 +620,20 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SCol
 }
 
 
-void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor &mooncolor,
+void Sky::draw_moon(video::IVideoDriver *driver, const video::SColor &mooncolor,
 	const video::SColor &mooncolor2, float wicked_time_of_day)
 /*
 	* Draw moon in the sky.
 	* driver: Video driver object used to draw
-	* moonsize: the default size of the moon
 	* mooncolor: main moon color
 	* mooncolor2: second moon color
 	* wicked_time_of_day: current time of day, to know where should be the moon in
 	* the sky
 	*/
 {
+	// A magic number that contributes to the ratio 1.57 sun/moon size difference.
+	constexpr float moonsize = 0.04;
+
 	static const u16 indices[] = {0, 1, 2, 0, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
 	if (!m_moon_texture) {
@@ -658,6 +662,8 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SC
 		}
 	} else {
 		driver->setMaterial(m_materials[4]);
+		// Another magic number that contributes to the ratio 1.57 sun/moon size
+		// difference.
 		float d = (moonsize * 1.9) * m_moon_params.scale;
 		video::SColor c;
 		if (m_moon_tonemap)

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -200,9 +200,9 @@ private:
 
 	void updateStars();
 
-	void draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor &suncolor,
+	void draw_sun(video::IVideoDriver *driver, const video::SColor &suncolor,
 		const video::SColor &suncolor2, float wicked_time_of_day);
-	void draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor &mooncolor,
+	void draw_moon(video::IVideoDriver *driver, const video::SColor &mooncolor,
 		const video::SColor &mooncolor2, float wicked_time_of_day);
 	void draw_sky_body(std::array<video::S3DVertex, 4> &vertices,
 		float pos_1, float pos_2, const video::SColor &c);


### PR DESCRIPTION
- Absolute orientation, as requested in #11940.
- Scale thing found by looking around.
  The exact values were found in the code:
  https://github.com/minetest/minetest/blob/163d3547e65a6cea8a3e555557407e88d8e09183/src/client/sky.cpp#L145
  https://github.com/minetest/minetest/blob/163d3547e65a6cea8a3e555557407e88d8e09183/src/client/sky.cpp#L589
  `0.07*1.7 = 0.119`
  Similar for moon.
  Mesh sun and moon also seem to be the same if you interpret the other shine as size.

## To do

This PR is a Ready for Review.

## How to test

- Use non-symmetric moon and sun textures (ie. ruben ;-) ).
  Use `/time` to compare orientations.
- Use worldedit's `//lua` to adjust the moon's scale: `//lua minetest.get_player_by_name("singleplayer"):set_moon({scale = 0.119/0.076})`
  Look straight up and do `/time 0` and `/time 12000` to compare sizes.