### PR TITLE
Fix the documentation of InvRef:get_lists() and clean up code

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6355,9 +6355,9 @@ An `InvRef` is a reference to an inventory.
 * `set_width(listname, width)`: set width of list; currently used for crafting
 * `get_stack(listname, i)`: get a copy of stack index `i` in list
 * `set_stack(listname, i, stack)`: copy `stack` to index `i` in list
-* `get_list(listname)`: return full list
+* `get_list(listname)`: return full list (list-table of `ItemStack`s)
 * `set_list(listname, list)`: set full list (size will not change)
-* `get_lists()`: returns list of inventory lists
+* `get_lists()`: returns table that maps listnames to inventory lists
 * `set_lists(lists)`: sets inventory lists (size will not change)
 * `add_item(listname, stack)`: add item somewhere in list, returns leftover
   `ItemStack`.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6355,7 +6355,7 @@ An `InvRef` is a reference to an inventory.
 * `set_width(listname, width)`: set width of list; currently used for crafting
 * `get_stack(listname, i)`: get a copy of stack index `i` in list
 * `set_stack(listname, i, stack)`: copy `stack` to index `i` in list
-* `get_list(listname)`: return full list (list-table of `ItemStack`s)
+* `get_list(listname)`: return full list (list of `ItemStack`s)
 * `set_list(listname, list)`: set full list (size will not change)
 * `get_lists()`: returns table that maps listnames to inventory lists
 * `set_lists(lists)`: sets inventory lists (size will not change)

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -495,7 +495,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 	execPrepared("remove_player_inventories", 1, rmvalues);
 	execPrepared("remove_player_inventory_items", 1, rmvalues);
 
-	std::vector<const InventoryList*> inventory_lists = sao->getInventory()->getLists();
+	const std::vector<InventoryList *> &inventory_lists = sao->getInventory()->getLists();
 	std::ostringstream oss;
 	for (u16 i = 0; i < inventory_lists.size(); i++) {
 		const InventoryList* list = inventory_lists[i];

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -495,7 +495,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 	execPrepared("remove_player_inventories", 1, rmvalues);
 	execPrepared("remove_player_inventory_items", 1, rmvalues);
 
-	const std::vector<InventoryList *> &inventory_lists = sao->getInventory()->getLists();
+	const auto &inventory_lists = sao->getInventory()->getLists();
 	std::ostringstream oss;
 	for (u16 i = 0; i < inventory_lists.size(); i++) {
 		const InventoryList* list = inventory_lists[i];

--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -476,7 +476,7 @@ void PlayerDatabaseSQLite3::savePlayer(RemotePlayer *player)
 	sqlite3_vrfy(sqlite3_step(m_stmt_player_remove_inventory_items), SQLITE_DONE);
 	sqlite3_reset(m_stmt_player_remove_inventory_items);
 
-	const std::vector<InventoryList *> &inventory_lists = sao->getInventory()->getLists();
+	const auto &inventory_lists = sao->getInventory()->getLists();
 	std::ostringstream oss;
 	for (u16 i = 0; i < inventory_lists.size(); i++) {
 		const InventoryList *list = inventory_lists[i];

--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -476,10 +476,10 @@ void PlayerDatabaseSQLite3::savePlayer(RemotePlayer *player)
 	sqlite3_vrfy(sqlite3_step(m_stmt_player_remove_inventory_items), SQLITE_DONE);
 	sqlite3_reset(m_stmt_player_remove_inventory_items);
 
-	std::vector<const InventoryList*> inventory_lists = sao->getInventory()->getLists();
+	const std::vector<InventoryList *> &inventory_lists = sao->getInventory()->getLists();
 	std::ostringstream oss;
 	for (u16 i = 0; i < inventory_lists.size(); i++) {
-		const InventoryList* list = inventory_lists[i];
+		const InventoryList *list = inventory_lists[i];
 
 		str_to_sqlite(m_stmt_player_add_inventory, 1, player->getName());
 		int_to_sqlite(m_stmt_player_add_inventory, 2, i);

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -503,11 +503,6 @@ void InventoryList::deSerialize(std::istream &is)
 	throw SerializationError(ss.str());
 }
 
-InventoryList::InventoryList(const InventoryList &other)
-{
-	*this = other;
-}
-
 InventoryList & InventoryList::operator = (const InventoryList &other)
 {
 	m_items = other.m_items;
@@ -535,21 +530,6 @@ bool InventoryList::operator == (const InventoryList &other) const
 	return true;
 }
 
-const std::string &InventoryList::getName() const
-{
-	return m_name;
-}
-
-u32 InventoryList::getSize() const
-{
-	return m_items.size();
-}
-
-u32 InventoryList::getWidth() const
-{
-	return m_width;
-}
-
 u32 InventoryList::getUsedSlots() const
 {
 	u32 num = 0;
@@ -558,18 +538,6 @@ u32 InventoryList::getUsedSlots() const
 			num++;
 	}
 	return num;
-}
-
-const ItemStack& InventoryList::getItem(u32 i) const
-{
-	assert(i < m_size); // Pre-condition
-	return m_items[i];
-}
-
-ItemStack& InventoryList::getItem(u32 i)
-{
-	assert(i < m_size); // Pre-condition
-	return m_items[i];
 }
 
 ItemStack InventoryList::changeItem(u32 i, const ItemStack &newitem)
@@ -958,16 +926,6 @@ InventoryList * Inventory::getList(const std::string &name)
 	if(i == -1)
 		return nullptr;
 	return m_lists[i];
-}
-
-std::vector<const InventoryList*> Inventory::getLists()
-{
-	std::vector<const InventoryList*> lists;
-	lists.reserve(m_lists.size());
-	for (auto list : m_lists) {
-		lists.push_back(list);
-	}
-	return lists;
 }
 
 bool Inventory::deleteList(const std::string &name)

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -198,7 +198,7 @@ public:
 	void serialize(std::ostream &os, bool incremental) const;
 	void deSerialize(std::istream &is);
 
-	InventoryList(const InventoryList &other);
+	InventoryList(const InventoryList &other) { *this = other; }
 	InventoryList & operator = (const InventoryList &other);
 	bool operator == (const InventoryList &other) const;
 	bool operator != (const InventoryList &other) const
@@ -206,15 +206,25 @@ public:
 		return !(*this == other);
 	}
 
-	const std::string &getName() const;
-	u32 getSize() const;
-	u32 getWidth() const;
+	const std::string &getName() const { return m_name; }
+	u32 getSize() const { return static_cast<u32>(m_items.size()); }
+	u32 getWidth() const { return m_width; }
 	// Count used slots
 	u32 getUsedSlots() const;
 
 	// Get reference to item
-	const ItemStack& getItem(u32 i) const;
-	ItemStack& getItem(u32 i);
+	const ItemStack &getItem(u32 i) const
+	{
+		assert(i < m_size); // Pre-condition
+		return m_items[i];
+	}
+	ItemStack &getItem(u32 i)
+	{
+		assert(i < m_size); // Pre-condition
+		return m_items[i];
+	}
+	// Get reference to all items
+	const std::vector<ItemStack> &getItems() const { return m_items; }
 	// Returns old item. Parameter can be an empty item.
 	ItemStack changeItem(u32 i, const ItemStack &newitem);
 	// Delete item
@@ -271,7 +281,7 @@ public:
 private:
 	std::vector<ItemStack> m_items;
 	std::string m_name;
-	u32 m_size;
+	u32 m_size; // always the same as m_items.size()
 	u32 m_width = 0;
 	IItemDefManager *m_itemdef;
 	bool m_dirty = true;
@@ -301,7 +311,7 @@ public:
 	InventoryList * addList(const std::string &name, u32 size);
 	InventoryList * getList(const std::string &name);
 	const InventoryList * getList(const std::string &name) const;
-	std::vector<const InventoryList*> getLists();
+	const std::vector<InventoryList *> &getLists() const { return m_lists; }
 	bool deleteList(const std::string &name);
 	// A shorthand for adding items. Returns leftover item (possibly empty).
 	ItemStack addItem(const std::string &listname, const ItemStack &newitem)

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1359,7 +1359,7 @@ void push_inventory_list(lua_State *L, const InventoryList &invlist)
 /******************************************************************************/
 void push_inventory_lists(lua_State *L, const Inventory &inv)
 {
-	const std::vector<InventoryList *> &lists = inv.getLists();
+	const auto &lists = inv.getLists();
 	lua_createtable(L, 0, lists.size());
 	for(const InventoryList *list : lists) {
 		const std::string &name = list->getName();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1351,17 +1351,22 @@ void push_tool_capabilities(lua_State *L,
 }
 
 /******************************************************************************/
-void push_inventory_list(lua_State *L, Inventory *inv, const char *name)
+void push_inventory_list(lua_State *L, const InventoryList &invlist)
 {
-	InventoryList *invlist = inv->getList(name);
-	if(invlist == NULL){
-		lua_pushnil(L);
-		return;
+	push_items(L, invlist.getItems());
+}
+
+/******************************************************************************/
+void push_inventory_lists(lua_State *L, const Inventory &inv)
+{
+	const std::vector<InventoryList *> &lists = inv.getLists();
+	lua_createtable(L, 0, lists.size());
+	for(const InventoryList *list : lists) {
+		const std::string &name = list->getName();
+		lua_pushlstring(L, name.c_str(), name.size());
+		push_inventory_list(L, *list);
+		lua_rawset(L, -3);
 	}
-	std::vector<ItemStack> items;
-	for(u32 i=0; i<invlist->getSize(); i++)
-		items.push_back(invlist->getItem(i));
-	push_items(L, items);
 }
 
 /******************************************************************************/

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -55,6 +55,7 @@ struct ObjectProperties;
 struct SimpleSoundSpec;
 struct ServerSoundParams;
 class Inventory;
+class InventoryList;
 struct NodeBox;
 struct ContentFeatures;
 struct TileDef;
@@ -120,8 +121,9 @@ void               push_object_properties    (lua_State *L,
                                               ObjectProperties *prop);
 
 void               push_inventory_list       (lua_State *L,
-                                              Inventory *inv,
-                                              const char *name);
+                                              const InventoryList &invlist);
+void               push_inventory_lists      (lua_State *L,
+                                              const Inventory &inv);
 void               read_inventory_list       (lua_State *L, int tableindex,
                                               Inventory *inv, const char *name,
                                               Server *srv, int forcesize=-1);

--- a/src/script/cpp_api/s_client.cpp
+++ b/src/script/cpp_api/s_client.cpp
@@ -281,15 +281,7 @@ bool ScriptApiClient::on_inventory_open(Inventory *inventory)
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "registered_on_inventory_open");
 
-	std::vector<const InventoryList*> lists = inventory->getLists();
-	std::vector<const InventoryList*>::iterator iter = lists.begin();
-	lua_createtable(L, 0, lists.size());
-	for (; iter != lists.end(); iter++) {
-		const char* name = (*iter)->getName().c_str();
-		lua_pushstring(L, name);
-		push_inventory_list(L, inventory, name);
-		lua_rawset(L, -3);
-	}
+	push_inventory_lists(L, *inventory);
 
 	try {
 		runCallbacks(1, RUN_CALLBACKS_MODE_OR);

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -127,18 +127,14 @@ void NodeMetaRef::handleToTable(lua_State *L, Metadata *_meta)
 	// fields
 	MetaDataRef::handleToTable(L, _meta);
 
-	NodeMetadata *meta = (NodeMetadata*) _meta;
+	NodeMetadata *meta = (NodeMetadata *) _meta;
 
 	// inventory
-	lua_newtable(L);
 	Inventory *inv = meta->getInventory();
 	if (inv) {
-		std::vector<const InventoryList *> lists = inv->getLists();
-		for(std::vector<const InventoryList *>::const_iterator
-				i = lists.begin(); i != lists.end(); ++i) {
-			push_inventory_list(L, inv, (*i)->getName().c_str());
-			lua_setfield(L, -2, (*i)->getName().c_str());
-		}
+		push_inventory_lists(L, *inv);
+	} else {
+		lua_newtable(L);
 	}
 	lua_setfield(L, -2, "inventory");
 }


### PR DESCRIPTION
* It returns not a list but a table that maps listnames to inv lists.
* Code looked horrible so I've done some reduction of copying and code duplication.
* Does it resolve any reported issue? Probably not...
- Does this relate to a goal in [the roadmap](../doc/direction.md)? Yes: 2.2 Internal code refactoring. And it's a doc bugfix.
* (Note that `Inventory::getLists()` now returns a const ref to a vector of owning raw pointers, before the PR it returned a new vector of const raw ptr references to each of its owned lists.)

## To do

This PR is a Ready for Review.

## How to test

* `//lua print(dump(minetest.get_player_by_name("singleplayer"):get_inventory():get_lists()))`
* Read changes.
