### PR TITLE
Add doc to list breaking changes for the next major release

### DIFF
--- a/doc/breakages.md
+++ b/doc/breakages.md
@@ -1,0 +1,8 @@
+# Minetest Major Breakages List
+
+This document contains a list of breaking changes to be made in the next major version.
+
+* Remove attachment space multiplier (*10)
+* `get_sky()` returns a table (without arg)
+* `game.conf` name/id mess
+* remove depends.txt / description.txt (would simplify ContentDB and Minetest code a little)

--- a/doc/breakages.md
+++ b/doc/breakages.md
@@ -5,4 +5,4 @@ This document contains a list of breaking changes to be made in the next major v
 * Remove attachment space multiplier (*10)
 * `get_sky()` returns a table (without arg)
 * `game.conf` name/id mess
-* remove depends.txt / description.txt (would simplify ContentDB and Minetest code a little)
+* remove `depends.txt` / `description.txt` (would simplify ContentDB and Minetest code a little)


### PR DESCRIPTION
Closes #12028 

I think that a document works better than an issue:
* it removes the risk to go OT, as feared by ruben here https://github.com/minetest/minetest/issues/12028#issuecomment-1026000484, making the list unreadable
* way easier to keep track of it, compared to 1k+ issues
* can be accessed offline
* breakages can be suggested and discussed through PRs adding a line inside the file

## To do

This PR is Ready for Review.

## How to test
read
