### PR TITLE
Limit dynamic shadows to the viewing range

### DIFF
--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -93,6 +93,8 @@ void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool fo
 
 	float zNear = cam->getCameraNode()->getNearValue();
 	float zFar = getMaxFarValue();
+	if (!client->getEnv().getClientMap().getControl().range_all)
+		zFar = MYMIN(zFar, client->getEnv().getClientMap().getControl().wanted_range * BS);
 
 	///////////////////////////////////
 	// update splits near and fars


### PR DESCRIPTION
This PR adjust the light-space frustum so that shadow map is only produced for geometry that is going to be rendered on the screen. This also gives some control over SM performance by changing viewing range in-game.

## To do

This PR is Ready for Review.

## How to test

1. Set filter quality to 0, enable shadows and start a compatible game
2. Decrease the viewing range. Notice that the shadow quality increases, and FPS goes up
3. Increase the viewing range. Notice that the shadows become more pixelated.
