### PR TITLE
Adjust PSM distortion to use entire SM texture

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -187,7 +187,6 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	float baseLength = getBaseLength(smTexCoord);
 	float perspectiveFactor;
 
-	if (PCFBOUND == 0.0) return 0.0;
 	// Return fast if sharp shadows are requested
 	if (PCFBOUND == 0.0)
 		return 0.0;
@@ -497,7 +496,7 @@ void main(void)
 		float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z),0.0);
 
 		if (distance_rate > 1e-7) {
-		
+
 #ifdef COLORED_SHADOWS
 			vec4 visibility;
 			if (cosLight > 0.0)
@@ -531,7 +530,7 @@ void main(void)
 		}
 
 		shadow_int *= f_adj_shadow_strength;
-		
+
 		// calculate fragment color from components:
 		col.rgb =
 				adjusted_night_ratio * col.rgb + // artificial light

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -17,6 +17,7 @@ uniform float animationTimer;
 	uniform mat4 m_ShadowViewProj;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
+	uniform vec4 v_CameraPos;
 	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float cosLight;

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -51,16 +51,16 @@ const float fogShadingParameter = 1.0 / ( 1.0 - fogStart);
 uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
-float scale;
+uniform float shadowMapScale;
 
 vec4 getPerspectiveFactor(in vec4 shadowPosition)
 {
-	shadowPosition.xy = (shadowPosition.xy - CameraPos.xy) / scale;
+	shadowPosition.xy = (shadowPosition.xy - CameraPos.xy) / shadowMapScale;
 	float pDistance = length(shadowPosition.xy);
 	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
 
 	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPerspectiveBias);
-	shadowPosition.xy = scale * shadowPosition.xy + CameraPos.xy;
+	shadowPosition.xy = shadowMapScale * shadowPosition.xy + CameraPos.xy;
 
 	return shadowPosition;
 }
@@ -174,7 +174,7 @@ float getHardShadowDepth(sampler2D shadowsampler, vec2 smTexCoord, float realDis
 
 float getBaseLength(vec2 smTexCoord)
 {
-	float l = length(2.0 * smTexCoord.xy - 1.0 - CameraPos.xy) / scale;     // length in texture coords
+	float l = length(2.0 * smTexCoord.xy - 1.0 - CameraPos.xy) / shadowMapScale;     // length in texture coords
 	return xyPerspectiveBias1 / (1.0 / l - xyPerspectiveBias0); 				 // return to undistorted coords
 }
 
@@ -467,8 +467,6 @@ vec4 applyToneMapping(vec4 color)
 
 void main(void)
 {
-	scale = 0.8 + pow(length(CameraPos.xy), 2.0);
-
 	vec3 color;
 	vec2 uv = varTexCoord.st;
 
@@ -494,7 +492,7 @@ void main(void)
 		vec3 shadow_color = vec3(0.0, 0.0, 0.0);
 		vec3 posLightSpace = getLightSpacePosition();
 
-		float distance_rate = (1 - pow(clamp(0.5 / scale * length(2.0 * (posLightSpace.xy - 0.5) - CameraPos.xy),0.0,1.0), 50.0));
+		float distance_rate = (1 - pow(clamp(0.5 / shadowMapScale * length(2.0 * (posLightSpace.xy - 0.5) - CameraPos.xy),0.0,1.0), 50.0));
 		if (max(abs(posLightSpace.x - 0.5), abs(posLightSpace.y - 0.5)) > 0.5)
 			distance_rate = 0.0;
 		float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z),0.0);

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -17,7 +17,7 @@ uniform float animationTimer;
 	uniform mat4 m_ShadowViewProj;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
-	uniform vec4 v_CameraPos;
+	uniform vec4 CameraPos;
 	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float cosLight;
@@ -55,12 +55,12 @@ float scale;
 
 vec4 getPerspectiveFactor(in vec4 shadowPosition)
 {
-	shadowPosition.xy = (shadowPosition.xy - v_CameraPos.xy) / scale;
+	shadowPosition.xy = (shadowPosition.xy - CameraPos.xy) / scale;
 	float pDistance = length(shadowPosition.xy);
 	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
 
 	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPerspectiveBias);
-	shadowPosition.xy = scale * shadowPosition.xy + v_CameraPos.xy;
+	shadowPosition.xy = scale * shadowPosition.xy + CameraPos.xy;
 
 	return shadowPosition;
 }
@@ -174,7 +174,7 @@ float getHardShadowDepth(sampler2D shadowsampler, vec2 smTexCoord, float realDis
 
 float getBaseLength(vec2 smTexCoord)
 {
-	float l = length(2.0 * smTexCoord.xy - 1.0 - v_CameraPos.xy) / scale;     // length in texture coords
+	float l = length(2.0 * smTexCoord.xy - 1.0 - CameraPos.xy) / scale;     // length in texture coords
 	return xyPerspectiveBias1 / (1.0 / l - xyPerspectiveBias0); 				 // return to undistorted coords
 }
 
@@ -467,7 +467,7 @@ vec4 applyToneMapping(vec4 color)
 
 void main(void)
 {
-	scale = 0.8 + pow(length(v_CameraPos.xy), 2.0);
+	scale = 0.8 + pow(length(CameraPos.xy), 2.0);
 
 	vec3 color;
 	vec2 uv = varTexCoord.st;
@@ -494,7 +494,7 @@ void main(void)
 		vec3 shadow_color = vec3(0.0, 0.0, 0.0);
 		vec3 posLightSpace = getLightSpacePosition();
 
-		float distance_rate = (1 - pow(clamp(0.5 / scale * length(2.0 * (posLightSpace.xy - 0.5) - v_CameraPos.xy),0.0,1.0), 50.0));
+		float distance_rate = (1 - pow(clamp(0.5 / scale * length(2.0 * (posLightSpace.xy - 0.5) - CameraPos.xy),0.0,1.0), 50.0));
 		if (max(abs(posLightSpace.x - 0.5), abs(posLightSpace.y - 0.5)) > 0.5)
 			distance_rate = 0.0;
 		float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z),0.0);

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -179,7 +179,7 @@ float getBaseLength(vec2 smTexCoord)
 
 float getDeltaPerspectiveFactor(float l)
 {
-	return 0.03 / (xyPerspectiveBias0 * l + xyPerspectiveBias1);                      // original distortion factor, divided by 10
+	return 0.04 * pow(512.0 / f_textureresolution, 0.4) / (xyPerspectiveBias0 * l + xyPerspectiveBias1);                      // original distortion factor, divided by 10
 }
 
 float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDistance, float multiplier)

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -182,7 +182,7 @@ float getBaseLength(vec2 smTexCoord)
 
 float getDeltaPerspectiveFactor(float l)
 {
-	return 0.03 / (xyPerspectiveBias0 * l + xyPerspectiveBias1);                      // original distortion factor, divided by 10
+	return 0.04 * pow(512.0 / f_textureresolution, 0.4) / (xyPerspectiveBias0 * l + xyPerspectiveBias1);                      // original distortion factor, divided by 10
 }
 
 float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDistance, float multiplier)

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -6,26 +6,9 @@ uniform vec4 skyBgColor;
 uniform float fogDistance;
 uniform vec3 eyePosition;
 
-varying vec3 vNormal;
-varying vec3 vPosition;
-varying vec3 worldPosition;
-varying lowp vec4 varColor;
-#ifdef GL_ES
-varying mediump vec2 varTexCoord;
-#else
-centroid varying vec2 varTexCoord;
-#endif
-
-varying vec3 eyeVec;
-varying float nightRatio;
-
-varying float vIDiff;
-
-const float e = 2.718281828459;
-const float BS = 10.0;
-const float fogStart = FOG_START;
-const float fogShadingParameter = 1.0 / (1.0 - fogStart);
-
+// The cameraOffset is the current center of the visible world.
+uniform vec3 cameraOffset;
+uniform float animationTimer;
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	// shadow texture
 	uniform sampler2D ShadowMapSampler;
@@ -34,13 +17,38 @@ const float fogShadingParameter = 1.0 / (1.0 - fogStart);
 	uniform float f_textureresolution;
 	uniform mat4 m_ShadowViewProj;
 	uniform float f_shadowfar;
-	uniform float f_timeofday;
 	uniform float f_shadow_strength;
+	uniform vec4 CameraPos;
 	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float cosLight;
 	varying float f_normal_length;
 #endif
+
+
+varying vec3 vNormal;
+varying vec3 vPosition;
+// World position in the visible world (i.e. relative to the cameraOffset.)
+// This can be used for many shader effects without loss of precision.
+// If the absolute position is required it can be calculated with
+// cameraOffset + worldPosition (for large coordinates the limits of float
+// precision must be considered).
+varying vec3 worldPosition;
+varying lowp vec4 varColor;
+#ifdef GL_ES
+varying mediump vec2 varTexCoord;
+#else
+centroid varying vec2 varTexCoord;
+#endif
+varying vec3 eyeVec;
+varying float nightRatio;
+
+varying float vIDiff;
+
+const float fogStart = FOG_START;
+const float fogShadingParameter = 1.0 / (1.0 - fogStart);
+
+
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 uniform float xyPerspectiveBias0;
@@ -49,13 +57,20 @@ uniform float zPerspectiveBias;
 
 vec4 getPerspectiveFactor(in vec4 shadowPosition)
 {
-
-	float pDistance = length(shadowPosition.xy);
+	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
+	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);
+	float pDistance = length(l);
 	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-
-	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPerspectiveBias);
-
+	l /= pFactor;
+	shadowPosition.xy = CameraPos.xy * (1.0 - l) + s * l;
+	shadowPosition.z *= zPerspectiveBias;
 	return shadowPosition;
+}
+
+// assuming near is always 1.0
+float getLinearDepth()
+{
+	return 2.0 * f_shadowfar / (f_shadowfar + 1.0 - (2.0 * gl_FragCoord.z - 1.0) * (f_shadowfar - 1.0));
 }
 
 vec3 getLightSpacePosition()
@@ -161,13 +176,13 @@ float getHardShadowDepth(sampler2D shadowsampler, vec2 smTexCoord, float realDis
 
 float getBaseLength(vec2 smTexCoord)
 {
-	float l = length(2.0 * smTexCoord.xy - 1.0);     // length in texture coords
+	float l = length(2.0 * smTexCoord.xy - 1.0 - CameraPos.xy);     // length in texture coords
 	return xyPerspectiveBias1 / (1.0 / l - xyPerspectiveBias0); 				 // return to undistorted coords
 }
 
 float getDeltaPerspectiveFactor(float l)
 {
-	return 0.1 / (xyPerspectiveBias0 * l + xyPerspectiveBias1);                      // original distortion factor, divided by 10
+	return 0.03 / (xyPerspectiveBias0 * l + xyPerspectiveBias1);                      // original distortion factor, divided by 10
 }
 
 float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDistance, float multiplier)
@@ -178,7 +193,7 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	// Return fast if sharp shadows are requested
 	if (PCFBOUND == 0.0)
 		return 0.0;
-		
+
 	if (SOFTSHADOWRADIUS <= 1.0) {
 		perspectiveFactor = getDeltaPerspectiveFactor(baseLength);
 		return max(2 * length(smTexCoord.xy) * 2048 / f_textureresolution / pow(perspectiveFactor, 3), SOFTSHADOWRADIUS);
@@ -418,6 +433,7 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 #endif
 
 #if ENABLE_TONE_MAPPING
+
 /* Hable's UC2 Tone mapping parameters
 	A = 0.22;
 	B = 0.30;
@@ -448,12 +464,14 @@ vec4 applyToneMapping(vec4 color)
 }
 #endif
 
+
+
 void main(void)
 {
 	vec3 color;
 	vec2 uv = varTexCoord.st;
-	vec4 base = texture2D(baseTexture, uv).rgba;
 
+	vec4 base = texture2D(baseTexture, uv).rgba;
 	// If alpha is zero, we can just discard the pixel. This fixes transparency
 	// on GPUs like GC7000L, where GL_ALPHA_TEST is not implemented in mesa,
 	// and also on GLES 2, where GL_ALPHA_TEST is missing entirely.
@@ -467,8 +485,7 @@ void main(void)
 #endif
 
 	color = base.rgb;
-	vec4 col = vec4(color.rgb, base.a);
-	col.rgb *= varColor.rgb;
+	vec4 col = vec4(color.rgb * varColor.rgb, 1.0);
 	col.rgb *= vIDiff;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
@@ -477,11 +494,13 @@ void main(void)
 		vec3 shadow_color = vec3(0.0, 0.0, 0.0);
 		vec3 posLightSpace = getLightSpacePosition();
 
-		float distance_rate = (1 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 50.0));
+		float distance_rate = (1.0 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 10.0));
+		if (max(abs(posLightSpace.x - 0.5), abs(posLightSpace.y - 0.5)) > 0.5)
+			distance_rate = 0.0;
 		float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z),0.0);
 
 		if (distance_rate > 1e-7) {
-	
+
 #ifdef COLORED_SHADOWS
 			vec4 visibility;
 			if (cosLight > 0.0)
@@ -506,8 +525,8 @@ void main(void)
 		// Power ratio was measured on torches in MTG (brightness = 14).
 		float adjusted_night_ratio = pow(max(0.0, nightRatio), 0.6);
 
-		// cosine of the normal-to-light angle when
-		// we start to apply self-shadowing
+		// Apply self-shadowing when light falls at a narrow angle to the surface
+		// Cosine of the cut-off angle.
 		const float self_shadow_cutoff_cosine = 0.14;
 		if (f_normal_length != 0 && cosLight < self_shadow_cutoff_cosine) {
 			shadow_int = max(shadow_int, 1 - clamp(cosLight, 0.0, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);
@@ -541,5 +560,7 @@ void main(void)
 	float clarity = clamp(fogShadingParameter
 		- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
 	col = mix(skyBgColor, col, clarity);
-	gl_FragColor = vec4(col.rgb, base.a);
+	col = vec4(col.rgb, base.a);
+	
+	gl_FragColor = col;
 }

--- a/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
@@ -8,15 +8,15 @@ varying vec3 varColor;
 uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
-float scale;
+uniform float shadowMapScale;
 
 vec4 getPerspectiveFactor(in vec4 shadowPosition)
 {
-	shadowPosition.xy = (shadowPosition.xy - CameraPos.xy) / scale;
+	shadowPosition.xy = (shadowPosition.xy - CameraPos.xy) / shadowMapScale;
 	float pDistance = length(shadowPosition.xy);
 	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
 	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPerspectiveBias);
-	shadowPosition.xy = scale * shadowPosition.xy + CameraPos.xy;	
+	shadowPosition.xy = shadowMapScale * shadowPosition.xy + CameraPos.xy;	
 
 	return shadowPosition;
 }
@@ -25,7 +25,6 @@ vec4 getPerspectiveFactor(in vec4 shadowPosition)
 void main()
 {
 	vec4 pos = LightMVP * gl_Vertex;
-	scale = 0.8 + pow(length(CameraPos.xy), 2.0);
 
 	tPos = getPerspectiveFactor(LightMVP * gl_Vertex);
 

--- a/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
@@ -8,16 +8,16 @@ varying vec3 varColor;
 uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
-uniform float shadowMapScale;
 
 vec4 getPerspectiveFactor(in vec4 shadowPosition)
 {
-	shadowPosition.xy = (shadowPosition.xy - CameraPos.xy) / shadowMapScale;
-	float pDistance = length(shadowPosition.xy);
+	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
+	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);
+	float pDistance = length(l);
 	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPerspectiveBias);
-	shadowPosition.xy = shadowMapScale * shadowPosition.xy + CameraPos.xy;	
-
+	l /= pFactor;
+	shadowPosition.xy = CameraPos.xy * (1.0 - l) + s * l;
+	shadowPosition.z *= zPerspectiveBias;
 	return shadowPosition;
 }
 

--- a/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
@@ -1,4 +1,5 @@
 uniform mat4 LightMVP; // world matrix
+uniform vec4 CameraPos;
 varying vec4 tPos;
 #ifdef COLORED_SHADOWS
 varying vec3 varColor;

--- a/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
@@ -8,12 +8,15 @@ varying vec3 varColor;
 uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
+float scale;
 
 vec4 getPerspectiveFactor(in vec4 shadowPosition)
 {
+	shadowPosition.xy = (shadowPosition.xy - CameraPos.xy) / scale;
 	float pDistance = length(shadowPosition.xy);
 	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
 	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPerspectiveBias);
+	shadowPosition.xy = scale * shadowPosition.xy + CameraPos.xy;	
 
 	return shadowPosition;
 }
@@ -22,6 +25,7 @@ vec4 getPerspectiveFactor(in vec4 shadowPosition)
 void main()
 {
 	vec4 pos = LightMVP * gl_Vertex;
+	scale = 0.8 + pow(length(CameraPos.xy), 2.0);
 
 	tPos = getPerspectiveFactor(LightMVP * gl_Vertex);
 

--- a/client/shaders/shadow_shaders/pass1_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_vertex.glsl
@@ -5,15 +5,15 @@ varying vec4 tPos;
 uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
-float scale;
+uniform float shadowMapScale;
 
 vec4 getPerspectiveFactor(in vec4 shadowPosition)
 {
-	shadowPosition.xy = (shadowPosition.xy - CameraPos.xy) / scale;
+	shadowPosition.xy = (shadowPosition.xy - CameraPos.xy) / shadowMapScale;
 	float pDistance = length(shadowPosition.xy);
 	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
 	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPerspectiveBias);
-	shadowPosition.xy = scale * shadowPosition.xy + CameraPos.xy;	
+	shadowPosition.xy = shadowMapScale * shadowPosition.xy + CameraPos.xy;
 	return shadowPosition;
 }
 
@@ -21,7 +21,6 @@ vec4 getPerspectiveFactor(in vec4 shadowPosition)
 void main()
 {
 	vec4 pos = LightMVP * gl_Vertex;
-	scale = 0.8 + pow(length(CameraPos.xy), 2.0);
 
 	tPos = getPerspectiveFactor(pos);
 

--- a/client/shaders/shadow_shaders/pass1_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_vertex.glsl
@@ -1,4 +1,5 @@
 uniform mat4 LightMVP; // world matrix
+uniform vec4 CameraPos; // camera position
 varying vec4 tPos;
 
 uniform float xyPerspectiveBias0;

--- a/client/shaders/shadow_shaders/pass1_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_vertex.glsl
@@ -5,15 +5,16 @@ varying vec4 tPos;
 uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
-uniform float shadowMapScale;
 
 vec4 getPerspectiveFactor(in vec4 shadowPosition)
 {
-	shadowPosition.xy = (shadowPosition.xy - CameraPos.xy) / shadowMapScale;
-	float pDistance = length(shadowPosition.xy);
+	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
+	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);
+	float pDistance = length(l);
 	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPerspectiveBias);
-	shadowPosition.xy = shadowMapScale * shadowPosition.xy + CameraPos.xy;
+	l /= pFactor;
+	shadowPosition.xy = CameraPos.xy * (1.0 - l) + s * l;
+	shadowPosition.z *= zPerspectiveBias;
 	return shadowPosition;
 }
 

--- a/client/shaders/shadow_shaders/pass1_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_vertex.glsl
@@ -5,13 +5,15 @@ varying vec4 tPos;
 uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
+float scale;
 
 vec4 getPerspectiveFactor(in vec4 shadowPosition)
 {
+	shadowPosition.xy = (shadowPosition.xy - CameraPos.xy) / scale;
 	float pDistance = length(shadowPosition.xy);
 	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
 	shadowPosition.xyz *= vec3(vec2(1.0 / pFactor), zPerspectiveBias);
-
+	shadowPosition.xy = scale * shadowPosition.xy + CameraPos.xy;	
 	return shadowPosition;
 }
 
@@ -19,6 +21,7 @@ vec4 getPerspectiveFactor(in vec4 shadowPosition)
 void main()
 {
 	vec4 pos = LightMVP * gl_Vertex;
+	scale = 0.8 + pow(length(CameraPos.xy), 2.0);
 
 	tPos = getPerspectiveFactor(pos);
 

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -116,7 +116,7 @@ public:
 	void getBlocksInViewRange(v3s16 cam_pos_nodes,
 		v3s16 *p_blocks_min, v3s16 *p_blocks_max, float range=-1.0f);
 	void updateDrawList();
-	void updateDrawListShadow(const v3f &shadow_light_pos, const v3f &shadow_light_dir, float shadow_range);
+	void updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length);
 	// Returns true if draw list needs updating before drawing the next frame.
 	bool needsUpdateDrawList() { return m_needs_update_drawlist; }
 	void renderMap(video::IVideoDriver* driver, s32 pass);

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -324,7 +324,7 @@ public:
 			m_shadowfar.set(&shadowFar, services);
 
 			float camera_pos[4];
-			shadowViewProj.transformVect(camera_pos, shadow->getCameraPos());
+			shadowViewProj.transformVect(camera_pos, shadow->getPlayerPos());
 			m_camera_pos.set(camera_pos, services);
 
 			// I dont like using this hardcoded value. maybe something like

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -253,7 +253,7 @@ public:
 		, m_shadow_strength("f_shadow_strength")
 		, m_time_of_day("f_timeofday")
 		, m_shadowfar("f_shadowfar")
-		, m_camera_pos("v_CameraPos")
+		, m_camera_pos("CameraPos")
 		, m_shadow_texture("ShadowMapSampler")
 		, m_perspective_bias0_vertex("xyPerspectiveBias0")
 		, m_perspective_bias0_pixel("xyPerspectiveBias0")

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -220,6 +220,7 @@ class MainShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<f32> m_shadow_strength;
 	CachedPixelShaderSetting<f32> m_time_of_day;
 	CachedPixelShaderSetting<f32> m_shadowfar;
+	CachedPixelShaderSetting<f32, 4> m_camera_pos;
 	CachedPixelShaderSetting<s32> m_shadow_texture;
 	CachedVertexShaderSetting<f32> m_perspective_bias0_vertex;
 	CachedPixelShaderSetting<f32> m_perspective_bias0_pixel;
@@ -252,6 +253,7 @@ public:
 		, m_shadow_strength("f_shadow_strength")
 		, m_time_of_day("f_timeofday")
 		, m_shadowfar("f_shadowfar")
+		, m_camera_pos("v_CameraPos")
 		, m_shadow_texture("ShadowMapSampler")
 		, m_perspective_bias0_vertex("xyPerspectiveBias0")
 		, m_perspective_bias0_pixel("xyPerspectiveBias0")
@@ -320,6 +322,10 @@ public:
 
 			f32 shadowFar = shadow->getMaxShadowFar();
 			m_shadowfar.set(&shadowFar, services);
+
+			float camera_pos[4];
+			shadowViewProj.transformVect(camera_pos, shadow->getCameraPos());
+			m_camera_pos.set(camera_pos, services);
 
 			// I dont like using this hardcoded value. maybe something like
 			// MAX_TEXTURE - 1 or somthing like that??

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -228,6 +228,8 @@ class MainShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<f32> m_perspective_bias1_pixel;
 	CachedVertexShaderSetting<f32> m_perspective_zbias_vertex;
 	CachedPixelShaderSetting<f32> m_perspective_zbias_pixel;
+	CachedVertexShaderSetting<f32> m_sm_scale_vertex;
+	CachedPixelShaderSetting<f32> m_sm_scale_pixel;
 
 #if ENABLE_GLES
 	// Modelview matrix
@@ -261,6 +263,8 @@ public:
 		, m_perspective_bias1_pixel("xyPerspectiveBias1")
 		, m_perspective_zbias_vertex("zPerspectiveBias")
 		, m_perspective_zbias_pixel("zPerspectiveBias")
+		, m_sm_scale_vertex("shadowMapScale")
+		, m_sm_scale_pixel("shadowMapScale")
 	{}
 	~MainShaderConstantSetter() = default;
 
@@ -323,9 +327,13 @@ public:
 			f32 shadowFar = shadow->getMaxShadowFar();
 			m_shadowfar.set(&shadowFar, services);
 
-			float camera_pos[4];
-			shadowViewProj.transformVect(camera_pos, shadow->getPlayerPos());
-			m_camera_pos.set(camera_pos, services);
+			f32 cam_pos[4];
+			shadowViewProj.transformVect(cam_pos, light.getPlayerPos());
+			m_camera_pos.set(cam_pos, services);
+
+			f32 shadow_map_scale = light.getShadowMapScale();
+			m_sm_scale_vertex.set(&shadow_map_scale, services);
+			m_sm_scale_pixel.set(&shadow_map_scale, services);
 
 			// I dont like using this hardcoded value. maybe something like
 			// MAX_TEXTURE - 1 or somthing like that??

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -228,8 +228,6 @@ class MainShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<f32> m_perspective_bias1_pixel;
 	CachedVertexShaderSetting<f32> m_perspective_zbias_vertex;
 	CachedPixelShaderSetting<f32> m_perspective_zbias_pixel;
-	CachedVertexShaderSetting<f32> m_sm_scale_vertex;
-	CachedPixelShaderSetting<f32> m_sm_scale_pixel;
 
 #if ENABLE_GLES
 	// Modelview matrix
@@ -263,8 +261,6 @@ public:
 		, m_perspective_bias1_pixel("xyPerspectiveBias1")
 		, m_perspective_zbias_vertex("zPerspectiveBias")
 		, m_perspective_zbias_pixel("zPerspectiveBias")
-		, m_sm_scale_vertex("shadowMapScale")
-		, m_sm_scale_pixel("shadowMapScale")
 	{}
 	~MainShaderConstantSetter() = default;
 
@@ -330,10 +326,6 @@ public:
 			f32 cam_pos[4];
 			shadowViewProj.transformVect(cam_pos, light.getPlayerPos());
 			m_camera_pos.set(cam_pos, services);
-
-			f32 shadow_map_scale = light.getShadowMapScale();
-			m_sm_scale_vertex.set(&shadow_map_scale, services);
-			m_sm_scale_pixel.set(&shadow_map_scale, services);
 
 			// I dont like using this hardcoded value. maybe something like
 			// MAX_TEXTURE - 1 or somthing like that??

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -40,6 +40,8 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	// adjusted frustum boundaries
 	float sfNear = future_frustum.zNear;
 	float sfFar = adjustDist(future_frustum.zFar, cam->getFovY());
+	float cosLightAngle = abs(look.dotProduct(direction));
+	float sinLightAngle = sqrt(1.0f - powf(cosLightAngle, 2.0f));
 
 	// adjusted camera positions
 	v3f camPos2 = cam->getPosition();
@@ -50,8 +52,8 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	camPos2 += look * sfNear;
 
 	// center point of light frustum
-	newCenter = camPos + look * 0.35f * (sfFar - sfNear);
-	v3f world_center = camPos2 + look * 0.35f * (sfFar - sfNear);
+	newCenter = camPos + look * (0.05f + 0.3f * sinLightAngle) * (sfFar - sfNear);
+	v3f world_center = camPos2 + look * (0.05f + 0.3f * sinLightAngle) * (sfFar - sfNear);
 
 	// Create a vector to the frustum far corner
 	const v3f &viewUp = cam->getCameraNode()->getUpVector();
@@ -77,6 +79,11 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 			future_frustum.length, -future_frustum.length,
 			future_frustum.length,false);
 	future_frustum.camera_offset = cam->getOffset();
+	f32 cam_pos1[4];
+	future_frustum.ViewMat.transformVect(cam_pos1, camPos);
+	f32 cam_pos2[4];
+	future_frustum.ProjOrthMat.transformVec4(cam_pos2, cam_pos1);
+	future_frustum.scale = 0.8f + MYMAX(abs(cam_pos2[0]), abs(cam_pos2[1]));
 }
 
 DirectionalLight::DirectionalLight(const u32 shadowMapResolution,
@@ -148,6 +155,16 @@ v3f DirectionalLight::getPlayerPos() const
 v3f DirectionalLight::getFuturePlayerPos() const
 {
 	return future_frustum.player;
+}
+
+f32 DirectionalLight::getShadowMapScale() const
+{
+	return shadow_frustum.scale;
+}
+
+f32 DirectionalLight::getFutureShadowMapScale() const
+{
+	return future_frustum.scale;
 }
 
 const m4f &DirectionalLight::getViewMatrix() const

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -40,8 +40,6 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	// adjusted frustum boundaries
 	float sfNear = future_frustum.zNear;
 	float sfFar = adjustDist(future_frustum.zFar, cam->getFovY());
-	float cosLightAngle = abs(look.dotProduct(direction));
-	float sinLightAngle = sqrt(1.0f - powf(cosLightAngle, 2.0f));
 
 	// adjusted camera positions
 	v3f camPos2 = cam->getPosition();
@@ -52,8 +50,8 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	camPos2 += look * sfNear;
 
 	// center point of light frustum
-	newCenter = camPos + look * (0.05f + 0.3f * sinLightAngle) * (sfFar - sfNear);
-	v3f world_center = camPos2 + look * (0.05f + 0.3f * sinLightAngle) * (sfFar - sfNear);
+	newCenter = camPos + look * 0.35 * (sfFar - sfNear);
+	v3f world_center = camPos2 + look * 0.35 * (sfFar - sfNear);
 
 	// Create a vector to the frustum far corner
 	const v3f &viewUp = cam->getCameraNode()->getUpVector();
@@ -79,11 +77,6 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 			future_frustum.length, -future_frustum.length,
 			future_frustum.length,false);
 	future_frustum.camera_offset = cam->getOffset();
-	f32 cam_pos1[4];
-	future_frustum.ViewMat.transformVect(cam_pos1, camPos);
-	f32 cam_pos2[4];
-	future_frustum.ProjOrthMat.transformVec4(cam_pos2, cam_pos1);
-	future_frustum.scale = 0.8f + MYMAX(abs(cam_pos2[0]), abs(cam_pos2[1]));
 }
 
 DirectionalLight::DirectionalLight(const u32 shadowMapResolution,
@@ -155,16 +148,6 @@ v3f DirectionalLight::getPlayerPos() const
 v3f DirectionalLight::getFuturePlayerPos() const
 {
 	return future_frustum.player;
-}
-
-f32 DirectionalLight::getShadowMapScale() const
-{
-	return shadow_frustum.scale;
-}
-
-f32 DirectionalLight::getFutureShadowMapScale() const
-{
-	return future_frustum.scale;
 }
 
 const m4f &DirectionalLight::getViewMatrix() const

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -50,9 +50,8 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	camPos2 += look * sfNear;
 
 	// center point of light frustum
-	float end = sfNear + sfFar;
-	newCenter = camPos + look * (sfNear + 0.05f * end);
-	v3f world_center = camPos2 + look * (sfNear + 0.05f * end);
+	newCenter = camPos + look * 0.35f * (sfFar - sfNear);
+	v3f world_center = camPos2 + look * 0.35f * (sfFar - sfNear);
 
 	// Create a vector to the frustum far corner
 	const v3f &viewUp = cam->getCameraNode()->getUpVector();

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -69,6 +69,7 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	// we must compute the viewmat with the position - the camera offset
 	// but the future_frustum position must be the actual world position
 	v3f eye = frustumCenter - eye_displacement;
+	future_frustum.player = camPos;
 	future_frustum.position = world_center - eye_displacement;
 	future_frustum.length = vvolume;
 	future_frustum.ViewMat.buildCameraLookAtMatrixLH(eye, frustumCenter, v3f(0.0f, 1.0f, 0.0f));
@@ -114,6 +115,7 @@ void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool fo
 		v3f rotated_offset;
 		shadow_frustum.ViewMat.rotateVect(rotated_offset, intToFloat(cam_offset - shadow_frustum.camera_offset, BS));
 		shadow_frustum.ViewMat.setTranslation(shadow_frustum.ViewMat.getTranslation() + rotated_offset);
+		shadow_frustum.player += intToFloat(shadow_frustum.camera_offset - cam->getOffset(), BS);
 		shadow_frustum.camera_offset = cam_offset;
 	}
 }
@@ -136,6 +138,16 @@ void DirectionalLight::setDirection(v3f dir)
 v3f DirectionalLight::getPosition() const
 {
 	return shadow_frustum.position;
+}
+
+v3f DirectionalLight::getPlayerPos() const
+{
+	return shadow_frustum.player;
+}
+
+v3f DirectionalLight::getFuturePlayerPos() const
+{
+	return future_frustum.player;
 }
 
 const m4f &DirectionalLight::getViewMatrix() const

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -94,7 +94,7 @@ void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool fo
 	float zNear = cam->getCameraNode()->getNearValue();
 	float zFar = getMaxFarValue();
 	if (!client->getEnv().getClientMap().getControl().range_all)
-		zFar = MYMIN(zFar, client->getEnv().getClientMap().getControl().wanted_range * BS * 1.5);
+		zFar = MYMIN(zFar, client->getEnv().getClientMap().getControl().wanted_range * BS);
 
 	///////////////////////////////////
 	// update splits near and fars

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -32,6 +32,7 @@ struct shadowFrustum
 	f32 zNear{0.0f};
 	f32 zFar{0.0f};
 	f32 length{0.0f};
+	f32 radius{0.0f};
 	core::matrix4 ProjOrthMat;
 	core::matrix4 ViewMat;
 	v3f position;

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -35,6 +35,7 @@ struct shadowFrustum
 	core::matrix4 ProjOrthMat;
 	core::matrix4 ViewMat;
 	v3f position;
+	v3f player;
 	v3s16 camera_offset;
 };
 
@@ -57,6 +58,8 @@ public:
 		return direction;
 	};
 	v3f getPosition() const;
+	v3f getPlayerPos() const;
+	v3f getFuturePlayerPos() const;	
 
 	/// Gets the light's matrices.
 	const core::matrix4 &getViewMatrix() const;

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -29,14 +29,15 @@ class Client;
 
 struct shadowFrustum
 {
-	float zNear{0.0f};
-	float zFar{0.0f};
-	float length{0.0f};
+	f32 zNear{0.0f};
+	f32 zFar{0.0f};
+	f32 length{0.0f};
 	core::matrix4 ProjOrthMat;
 	core::matrix4 ViewMat;
 	v3f position;
 	v3f player;
 	v3s16 camera_offset;
+	f32 scale{1.0f};
 };
 
 class DirectionalLight
@@ -59,7 +60,10 @@ public:
 	};
 	v3f getPosition() const;
 	v3f getPlayerPos() const;
-	v3f getFuturePlayerPos() const;	
+	v3f getFuturePlayerPos() const;
+
+	f32 getShadowMapScale() const;
+	f32 getFutureShadowMapScale() const;
 
 	/// Gets the light's matrices.
 	const core::matrix4 &getViewMatrix() const;

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -37,7 +37,6 @@ struct shadowFrustum
 	v3f position;
 	v3f player;
 	v3s16 camera_offset;
-	f32 scale{1.0f};
 };
 
 class DirectionalLight
@@ -61,9 +60,6 @@ public:
 	v3f getPosition() const;
 	v3f getPlayerPos() const;
 	v3f getFuturePlayerPos() const;
-
-	f32 getShadowMapScale() const;
-	f32 getFutureShadowMapScale() const;
 
 	/// Gets the light's matrices.
 	const core::matrix4 &getViewMatrix() const;

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -158,24 +158,6 @@ void ShadowRenderer::setShadowIntensity(float shadow_intensity)
 		disable();
 }
 
-v3f ShadowRenderer::getPlayerPos() const
-{
-	if (m_light_list.empty()) {
-		auto cam = m_client->getCamera();
-		return cam->getPosition() - intToFloat(cam->getOffset(), BS);
-	}
-	return m_light_list[0].getPlayerPos();
-}
-
-v3f ShadowRenderer::getFuturePlayerPos() const
-{
-	if (getDirectionalLightCount() == 0) {
-		auto cam = m_client->getCamera();
-		return cam->getPosition() - intToFloat(cam->getOffset(), BS);
-	}
-	return m_light_list[0].getFuturePlayerPos();
-}
-
 void ShadowRenderer::addNodeToShadowList(
 		scene::ISceneNode *node, E_SHADOW_MODE shadowMode)
 {
@@ -279,7 +261,6 @@ void ShadowRenderer::updateSMTextures()
 					cb->PerspectiveBiasXY = getPerspectiveBiasXY();
 					cb->PerspectiveBiasZ = getPerspectiveBiasZ();
 					cb->CameraPos = light.getFuturePlayerPos();
-					cb->ShadowMapScale = light.getFutureShadowMapScale();
 				}
 			
 			// set the Render Target
@@ -345,7 +326,6 @@ void ShadowRenderer::update(video::ITexture *outputTarget)
 			// SM texture for entities is not updated incrementally and 
 			// must by updated using current player position.
 			m_shadow_depth_entity_cb->CameraPos = light.getPlayerPos();
-			m_shadow_depth_entity_cb->ShadowMapScale = light.getShadowMapScale();
 
 			// render shadows for the n0n-map objects.
 			m_driver->setRenderTarget(shadowMapTextureDynamicObjects, true,

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -158,6 +158,11 @@ void ShadowRenderer::setShadowIntensity(float shadow_intensity)
 		disable();
 }
 
+v3f ShadowRenderer::getCameraPos() const
+{
+	auto cam = m_client->getCamera();
+	return cam->getPosition() - intToFloat(cam->getOffset(), BS);
+}
 
 void ShadowRenderer::addNodeToShadowList(
 		scene::ISceneNode *node, E_SHADOW_MODE shadowMode)
@@ -261,6 +266,7 @@ void ShadowRenderer::updateSMTextures()
 					cb->MaxFar = (f32)m_shadow_map_max_distance * BS;
 					cb->PerspectiveBiasXY = getPerspectiveBiasXY();
 					cb->PerspectiveBiasZ = getPerspectiveBiasZ();
+					cb->CameraPos = getCameraPos();
 				}
 
 			// set the Render Target
@@ -322,9 +328,7 @@ void ShadowRenderer::update(video::ITexture *outputTarget)
 	if (!m_shadow_node_array.empty() && !m_light_list.empty()) {
 
 		for (DirectionalLight &light : m_light_list) {
-			// Static shader values.
-			m_shadow_depth_cb->MapRes = (f32)m_shadow_map_texture_size;
-			m_shadow_depth_cb->MaxFar = (f32)m_shadow_map_max_distance * BS;
+			// Static shader values for entities are set in updateSMTextures
 
 			// render shadows for the n0n-map objects.
 			m_driver->setRenderTarget(shadowMapTextureDynamicObjects, true,

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -278,7 +278,8 @@ void ShadowRenderer::updateSMTextures()
 					cb->MaxFar = (f32)m_shadow_map_max_distance * BS;
 					cb->PerspectiveBiasXY = getPerspectiveBiasXY();
 					cb->PerspectiveBiasZ = getPerspectiveBiasZ();
-					cb->CameraPos = getFuturePlayerPos();
+					cb->CameraPos = light.getFuturePlayerPos();
+					cb->ShadowMapScale = light.getFutureShadowMapScale();
 				}
 			
 			// set the Render Target
@@ -343,7 +344,8 @@ void ShadowRenderer::update(video::ITexture *outputTarget)
 			// Static shader values for entities are set in updateSMTextures
 			// SM texture for entities is not updated incrementally and 
 			// must by updated using current player position.
-			m_shadow_depth_entity_cb->CameraPos = getPlayerPos();
+			m_shadow_depth_entity_cb->CameraPos = light.getPlayerPos();
+			m_shadow_depth_entity_cb->ShadowMapScale = light.getShadowMapScale();
 
 			// render shadows for the n0n-map objects.
 			m_driver->setRenderTarget(shadowMapTextureDynamicObjects, true,

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -63,7 +63,8 @@ public:
 	DirectionalLight &getDirectionalLight(u32 index = 0);
 	size_t getDirectionalLightCount() const;
 	f32 getMaxShadowFar() const;
-	v3f getCameraPos() const;
+	v3f getPlayerPos() const;
+	v3f getFuturePlayerPos() const;
 
 	/// Adds a shadow to the scene node.
 	/// The shadow mode can be ESM_BOTH, or ESM_RECEIVE.

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -63,6 +63,7 @@ public:
 	DirectionalLight &getDirectionalLight(u32 index = 0);
 	size_t getDirectionalLightCount() const;
 	f32 getMaxShadowFar() const;
+	v3f getCameraPos() const;
 
 	/// Adds a shadow to the scene node.
 	/// The shadow mode can be ESM_BOTH, or ESM_RECEIVE.

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -63,8 +63,6 @@ public:
 	DirectionalLight &getDirectionalLight(u32 index = 0);
 	size_t getDirectionalLightCount() const;
 	f32 getMaxShadowFar() const;
-	v3f getPlayerPos() const;
-	v3f getFuturePlayerPos() const;
 
 	/// Adds a shadow to the scene node.
 	/// The shadow mode can be ESM_BOTH, or ESM_RECEIVE.

--- a/src/client/shadows/shadowsshadercallbacks.cpp
+++ b/src/client/shadows/shadowsshadercallbacks.cpp
@@ -26,6 +26,10 @@ void ShadowDepthShaderCB::OnSetConstants(
 
 	core::matrix4 lightMVP = driver->getTransform(video::ETS_PROJECTION);
 	lightMVP *= driver->getTransform(video::ETS_VIEW);
+
+	f32 cam_pos[4];
+	lightMVP.transformVect(cam_pos, CameraPos);
+
 	lightMVP *= driver->getTransform(video::ETS_WORLD);
 
 	m_light_mvp_setting.set(lightMVP.pointer(), services);
@@ -39,4 +43,6 @@ void ShadowDepthShaderCB::OnSetConstants(
 	m_perspective_bias1.set(&bias1, services);
 	f32 zbias = PerspectiveBiasZ;
 	m_perspective_zbias.set(&zbias, services);
+
+	m_cam_pos_setting.set(cam_pos, services);
 }

--- a/src/client/shadows/shadowsshadercallbacks.cpp
+++ b/src/client/shadows/shadowsshadercallbacks.cpp
@@ -45,5 +45,4 @@ void ShadowDepthShaderCB::OnSetConstants(
 	m_perspective_zbias.set(&zbias, services);
 
 	m_cam_pos_setting.set(cam_pos, services);
-	m_sm_scale_vertex.set(&ShadowMapScale, services);
 }

--- a/src/client/shadows/shadowsshadercallbacks.cpp
+++ b/src/client/shadows/shadowsshadercallbacks.cpp
@@ -45,4 +45,5 @@ void ShadowDepthShaderCB::OnSetConstants(
 	m_perspective_zbias.set(&zbias, services);
 
 	m_cam_pos_setting.set(cam_pos, services);
+	m_sm_scale_vertex.set(&ShadowMapScale, services);
 }

--- a/src/client/shadows/shadowsshadercallbacks.h
+++ b/src/client/shadows/shadowsshadercallbacks.h
@@ -33,7 +33,8 @@ public:
 			m_color_map_sampler_setting("ColorMapSampler"),
 			m_perspective_bias0("xyPerspectiveBias0"),
 			m_perspective_bias1("xyPerspectiveBias1"),
-			m_perspective_zbias("zPerspectiveBias")
+			m_perspective_zbias("zPerspectiveBias"),
+			m_cam_pos_setting("CameraPos")
 	{}
 
 	void OnSetMaterial(const video::SMaterial &material) override {}
@@ -43,6 +44,7 @@ public:
 
 	f32 MaxFar{2048.0f}, MapRes{1024.0f};
 	f32 PerspectiveBiasXY {0.9f}, PerspectiveBiasZ {0.5f};
+	v3f CameraPos;
 
 private:
 	CachedVertexShaderSetting<f32, 16> m_light_mvp_setting;
@@ -52,4 +54,5 @@ private:
 	CachedVertexShaderSetting<f32> m_perspective_bias0;
 	CachedVertexShaderSetting<f32> m_perspective_bias1;
 	CachedVertexShaderSetting<f32> m_perspective_zbias;
+	CachedVertexShaderSetting<f32, 4> m_cam_pos_setting;
 };

--- a/src/client/shadows/shadowsshadercallbacks.h
+++ b/src/client/shadows/shadowsshadercallbacks.h
@@ -34,7 +34,8 @@ public:
 			m_perspective_bias0("xyPerspectiveBias0"),
 			m_perspective_bias1("xyPerspectiveBias1"),
 			m_perspective_zbias("zPerspectiveBias"),
-			m_cam_pos_setting("CameraPos")
+			m_cam_pos_setting("CameraPos"),
+			m_sm_scale_vertex("shadowMapScale")
 	{}
 
 	void OnSetMaterial(const video::SMaterial &material) override {}
@@ -45,6 +46,7 @@ public:
 	f32 MaxFar{2048.0f}, MapRes{1024.0f};
 	f32 PerspectiveBiasXY {0.9f}, PerspectiveBiasZ {0.5f};
 	v3f CameraPos;
+	f32 ShadowMapScale;
 
 private:
 	CachedVertexShaderSetting<f32, 16> m_light_mvp_setting;
@@ -55,4 +57,5 @@ private:
 	CachedVertexShaderSetting<f32> m_perspective_bias1;
 	CachedVertexShaderSetting<f32> m_perspective_zbias;
 	CachedVertexShaderSetting<f32, 4> m_cam_pos_setting;
+	CachedVertexShaderSetting<f32> m_sm_scale_vertex;
 };

--- a/src/client/shadows/shadowsshadercallbacks.h
+++ b/src/client/shadows/shadowsshadercallbacks.h
@@ -34,8 +34,7 @@ public:
 			m_perspective_bias0("xyPerspectiveBias0"),
 			m_perspective_bias1("xyPerspectiveBias1"),
 			m_perspective_zbias("zPerspectiveBias"),
-			m_cam_pos_setting("CameraPos"),
-			m_sm_scale_vertex("shadowMapScale")
+			m_cam_pos_setting("CameraPos")
 	{}
 
 	void OnSetMaterial(const video::SMaterial &material) override {}
@@ -46,7 +45,6 @@ public:
 	f32 MaxFar{2048.0f}, MapRes{1024.0f};
 	f32 PerspectiveBiasXY {0.9f}, PerspectiveBiasZ {0.5f};
 	v3f CameraPos;
-	f32 ShadowMapScale;
 
 private:
 	CachedVertexShaderSetting<f32, 16> m_light_mvp_setting;
@@ -57,5 +55,4 @@ private:
 	CachedVertexShaderSetting<f32> m_perspective_bias1;
 	CachedVertexShaderSetting<f32> m_perspective_zbias;
 	CachedVertexShaderSetting<f32, 4> m_cam_pos_setting;
-	CachedVertexShaderSetting<f32> m_sm_scale_vertex;
 };


### PR DESCRIPTION
This PR aims to improve quality and visible distance of the dynamic shadows.

What's done:
- [x] Passing camera/player position to all the relevant shaders
- [x] New distortion function that is tied to the position of the player
- [x] Adjusted light frustum to render more area in front of the player
- [x] Adjusted filter radius to get more crisp shadows.

## To do

This PR is Ready for Review.

## How to test

1. Enable dynamic shadows and choose one of the presets
2. Start a game that supports shadows (devtest)
3. Shadows should look better than earlier
4. Performance should be the same or better

For example, Medium preset should have decent shadow quality and support viewing distance up to 200 nodes.