### PR TITLE
Make `minetest.write_json` use "[]" instead of "null" for empty tables

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6041,6 +6041,7 @@ Misc.
         2. You can not mix string and integer keys.
            This is due to the fact that JSON has two distinct array and object
            values.
+    * Note: Empty tables are serialized as `"[]"`, not `"{}"`.
     * Example: `write_json({10, {a = false}})`,
       returns `'[10, {"a": false}]'`
 * `minetest.serialize(table)`: returns a string

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1846,6 +1846,11 @@ void read_json_value(lua_State *L, Json::Value &root, int index, u8 recursion)
 				throw SerializationError("Lua key to convert to JSON is not a string or number");
 			}
 		}
+
+		if (root.type() == Json::nullValue) {
+			// table is empty
+			root = Json::Value(Json::arrayValue);
+		}
 	} else if (type == LUA_TNIL) {
 		root = Json::nullValue;
 	} else {


### PR DESCRIPTION
- Problem:
  `minetest.write_json` writes `null` for empty tables. When parsed back to lua via `minetest.parse_json`, it results in `nil`.
  This can be considered a bug because empty tables are not equivalent to `null`.
- Fix by this PR:
  It writes `[]` instead.
  (`{}` would work too. I've chosen `[]` because empty arrays are probably more common than empty dictionaries.)

## To do

This PR is a Ready for Review.

Should I add a flag to `minetest.features`? Edit: Probably useless as mods can easily test.

## How to test

- `//lua print("'"..assert(minetest.write_json({})).."'")`
  master: `'null'`
  PR: `'[]'`
- `//lua print("'"..assert(minetest.write_json({{}})).."'")`
  master: `'[null]'`
  PR: `'[[]]'`