### PR TITLE
Fix item entity Z-fighting

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -58,11 +58,12 @@ core.register_entity(":__builtin:item", {
 		local glow = def and def.light_source and
 			math.floor(def.light_source / 2 + 0.5)
 
+		local size_bias = 1e-3 * math.random() -- small random bias to counter Z-fighting
 		self.object:set_properties({
 			is_visible = true,
 			visual = "wielditem",
 			textures = {itemname},
-			visual_size = {x = size, y = size},
+			visual_size = {x = size + size_bias, y = size + size_bias},
 			collisionbox = {-size, -size, -size, size, size, size},
 			automatic_rotate = math.pi * 0.5 * 0.2 / size,
 			wield_item = self.itemstring,


### PR DESCRIPTION
Currently, item entities of the same size (usually stacks of nodes of the same stacksize) will Z-fight, showing nasty artifacts. This often happens when emptying inventories. This PR fixes noticeable Z-fighting through the addition of a very tiny random bias.

With this PR (after, no Z-fighting):
![Bildschirmfoto von 2022-04-04 15-21-14](https://user-images.githubusercontent.com/34514239/161552994-4f74a113-7ab5-498a-ab9c-67b644c9b1e5.png)

Without it (before):
![Bildschirmfoto von 2022-04-04 15-17-49](https://user-images.githubusercontent.com/34514239/161552876-483ef099-3a84-4475-94d5-298aae92c493.png)

