### PR TITLE
Reorder client initialization

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -162,7 +162,10 @@ public:
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(bool initial_step=false);
 	void Receive();
-	PlayerSAO* StageTwoClientInit(session_t peer_id);
+
+	// Full player initialization after they processed all static media
+	// This is a helper function for TOSERVER_CLIENT_READY
+	PlayerSAO *StageTwoClientInit(session_t peer_id);
 
 	/*
 	 * Command Handlers

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -165,11 +165,13 @@ public:
 
 	// Other
 
-	void updatePrivileges(const std::set<std::string> &privs, bool is_singleplayer)
+	void updatePrivileges(const std::set<std::string> &privs)
 	{
 		m_privs = privs;
-		m_is_singleplayer = is_singleplayer;
 	}
+
+	inline void setNewPlayer() { m_is_new_player = true; }
+	inline bool isNewPlayer()  { return m_is_new_player; }
 
 	bool getCollisionBox(aabb3f *toset) const override;
 	bool getSelectionBox(aabb3f *toset) const override;
@@ -211,7 +213,8 @@ private:
 
 	// Cached privileges for enforcement
 	std::set<std::string> m_privs;
-	bool m_is_singleplayer;
+	const bool m_is_singleplayer;
+	bool m_is_new_player = false;
 
 	u16 m_breath = PLAYER_MAX_BREATH_DEFAULT;
 	f32 m_pitch = 0.0f;

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -617,13 +617,13 @@ void ServerEnvironment::savePlayer(RemotePlayer *player)
 	}
 }
 
-PlayerSAO *ServerEnvironment::loadPlayer(RemotePlayer *player, bool *new_player,
-	session_t peer_id, bool is_singleplayer)
+PlayerSAO *ServerEnvironment::loadPlayer(RemotePlayer *player, session_t peer_id)
 {
-	PlayerSAO *playersao = new PlayerSAO(this, player, peer_id, is_singleplayer);
+	PlayerSAO *playersao = new PlayerSAO(this, player, peer_id, m_server->isSingleplayer());
 	// Create player if it doesn't exist
 	if (!m_player_database->loadPlayer(player, playersao)) {
-		*new_player = true;
+		playersao->setNewPlayer();
+
 		// Set player position
 		infostream << "Server: Finding spawn place for player \""
 			<< player->getName() << "\"" << std::endl;
@@ -641,15 +641,6 @@ PlayerSAO *ServerEnvironment::loadPlayer(RemotePlayer *player, bool *new_player,
 			playersao->setBasePosition(m_server->findSpawnPos());
 		}
 	}
-
-	// Add player to environment
-	addPlayer(player);
-
-	/* Clean up old HUD elements from previous sessions */
-	player->clearHud();
-
-	/* Add object to environment */
-	addActiveObject(playersao);
 
 	// Update active blocks quickly for a bit so objects in those blocks appear on the client
 	m_fast_active_block_divider = 10;

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -241,8 +241,7 @@ public:
 	// Save players
 	void saveLoadedPlayers(bool force = false);
 	void savePlayer(RemotePlayer *player);
-	PlayerSAO *loadPlayer(RemotePlayer *player, bool *new_player, session_t peer_id,
-		bool is_singleplayer);
+	PlayerSAO *loadPlayer(RemotePlayer *player, session_t peer_id);
 	void addPlayer(RemotePlayer *player);
 	void removePlayer(RemotePlayer *player);
 	bool removePlayerFromDatabase(const std::string &name);


### PR DESCRIPTION
**Before**

`minetest.get_connected_players` occasionally returns object references of yet-not-joined players, for example in `minetest.register_globalstep` callbacks. This is a problem because `minetest.register_on_joinplayer` was not called yet.
Mods rely on joinplayer to initialize their API entries, which causes unpredictable and unreliable code paths.

**After**

`minetest.get_connected_players` includes the player reference only after (and including) `minetest.register_on_newplayer`, followed by `minetest.register_on_joinplayer`.


Fixes the root issue of https://github.com/minetest-mods/playeranim/issues/3

## To do

This PR is Ready for Review.

## How to test

1. https://github.com/minetest-mods/playeranim commit 9dab03f
2. This code:

```Lua
-- Ensure the callbacks are run
minetest.register_on_newplayer(function(p)
	print("newplayer", p:get_player_name())
end)
minetest.register_on_joinplayer(function(p)
	print("joinplayer", p:get_player_name())
end)
```

3. Any other mod you'd like to test.
4. Host a server and attempt to join with a same-named player