### PR TITLE
Implement shadow offsets for the new SM distortion function

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -18,6 +18,9 @@ uniform float animationTimer;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
 	uniform vec4 CameraPos;
+	uniform float xyPerspectiveBias0;
+	uniform float xyPerspectiveBias1;
+	
 	varying float adj_shadow_strength;
 	varying float cosLight;
 	varying float f_normal_length;
@@ -45,24 +48,7 @@ varying float nightRatio;
 const float fogStart = FOG_START;
 const float fogShadingParameter = 1.0 / ( 1.0 - fogStart);
 
-
-
 #ifdef ENABLE_DYNAMIC_SHADOWS
-uniform float xyPerspectiveBias0;
-uniform float xyPerspectiveBias1;
-uniform float zPerspectiveBias;
-
-vec4 applyPerspectiveDistortion(in vec4 shadowPosition)
-{
-	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
-	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);
-	float pDistance = length(l);
-	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-	l /= pFactor;
-	shadowPosition.xy = CameraPos.xy * (1.0 - l) + s * l;
-	shadowPosition.z *= zPerspectiveBias;
-	return shadowPosition;
-}
 
 // assuming near is always 1.0
 float getLinearDepth()

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -52,7 +52,7 @@ uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
 
-vec4 getPerspectiveFactor(in vec4 shadowPosition)
+vec4 applyPerspectiveDistortion(in vec4 shadowPosition)
 {
 	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
 	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -22,6 +22,7 @@ uniform float animationTimer;
 	varying float adj_shadow_strength;
 	varying float cosLight;
 	varying float f_normal_length;
+	varying vec3 shadow_position;
 #endif
 
 
@@ -72,15 +73,7 @@ float getLinearDepth()
 
 vec3 getLightSpacePosition()
 {
-	vec4 pLightSpace;
-	// some drawtypes have zero normals, so we need to handle it :(
-	#if DRAW_TYPE == NDT_PLANTLIKE
-	pLightSpace = m_ShadowViewProj * vec4(worldPosition, 1.0);
-	#else
-	pLightSpace = m_ShadowViewProj * vec4(worldPosition + normalOffsetScale * normalize(vNormal), 1.0);
-	#endif
-	pLightSpace = getPerspectiveFactor(pLightSpace);
-	return pLightSpace.xyz * 0.5 + 0.5;
+	return shadow_position * 0.5 + 0.5;
 }
 // custom smoothstep implementation because it's not defined in glsl1.2
 // https://docs.gl/sl4/smoothstep
@@ -499,14 +492,14 @@ void main(void)
 
 #ifdef COLORED_SHADOWS
 			vec4 visibility;
-			if (cosLight > 0.0)
+			if (cosLight > 0.0 || f_normal_length < 1e-3)
 				visibility = getShadowColor(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
 			else
 				visibility = vec4(1.0, 0.0, 0.0, 0.0);
 			shadow_int = visibility.r;
 			shadow_color = visibility.gba;
 #else
-			if (cosLight > 0.0)
+			if (cosLight > 0.0 || f_normal_length < 1e-3)
 				shadow_int = getShadow(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
 			else
 				shadow_int = 1.0;

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -18,7 +18,6 @@ uniform float animationTimer;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
 	uniform vec4 CameraPos;
-	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float cosLight;
 	varying float f_normal_length;

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -237,14 +237,16 @@ void main(void)
 		if (f_normal_length > 0.0) {
 			nNormal = normalize(vNormal);
 			cosLight = dot(nNormal, -v_LightDirection);
-			normalOffsetScale = 5.5e2 * pFactor * pFactor * pow(1 - pow(cosLight, 2.0), 0.5) / 
+			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
+			normalOffsetScale = 2.0 * pFactor * pFactor * sinLight * min(f_shadowfar, 500.0) / 
 					xyPerspectiveBias1 / f_textureresolution;
-			z_bias = 1.5e3 / clamp(cosLight, 0.01, 1.0);
+			z_bias = 1.0 * sinLight / cosLight;
 		} else {
 			nNormal = vec3(0.0);
-			cosLight = dot(v_LightDirection, normalize(vec3(v_LightDirection.x, 0.0, v_LightDirection.z)));
+			cosLight = clamp(dot(v_LightDirection, normalize(vec3(v_LightDirection.x, 0.0, v_LightDirection.z))), 1e-2, 1.0);
+			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
 			normalOffsetScale = 0.0;
-			z_bias = 3.6e3 / (1.0 - clamp(dot(v_LightDirection, vec3(0.0, -1.0, 0.0)), 0.0, 0.9));
+			z_bias = 3.6e3 * sinLight / cosLight;
 		}
 		z_bias *= pFactor * pFactor / f_textureresolution / f_shadowfar;
 

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -241,7 +241,8 @@ void main(void)
 			normalOffsetScale = 2.0 * pFactor * pFactor * sinLight * min(f_shadowfar, 500.0) / 
 					xyPerspectiveBias1 / f_textureresolution;
 			z_bias = 1.0 * sinLight / cosLight;
-		} else {
+		}
+		else {
 			nNormal = vec3(0.0);
 			cosLight = clamp(dot(v_LightDirection, normalize(vec3(v_LightDirection.x, 0.0, v_LightDirection.z))), 1e-2, 1.0);
 			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -215,14 +215,12 @@ void main(void)
 	if (f_shadow_strength > 0.0) {
 		vec3 nNormal = normalize(vNormal);
 		cosLight = dot(nNormal, -v_LightDirection);
+		f_normal_length = length(vNormal);
 
-		normalOffsetScale = 0.0;
+		float normalOffsetScale = f_normal_length > 0 ? 5e5 : 0.0;
+		normalOffsetScale *= pow(1 - pow(cosLight, 2.0), 0.5) / f_textureresolution / f_shadowfar;
+		float z_bias_factor = f_normal_length > 0 ? 1e2 : 5e2;
 
-#if DRAW_TYPE == NDT_PLANTLIKE
-		float z_bias_factor = 5e2;
-#else
-		float z_bias_factor = 1e2;
-#endif
 		shadow_position = getPerspectiveFactor(m_ShadowViewProj * mWorld * inVertexPosition).xyz;
 		float z_bias = z_bias_factor / f_textureresolution / f_shadowfar;
 		shadow_position.z -= z_bias;
@@ -238,7 +236,6 @@ void main(void)
 				mtsmoothstep(0.20, 0.25, f_timeofday) *
 				(1.0 - mtsmoothstep(0.7, 0.8, f_timeofday));
 		}
-		f_normal_length = length(vNormal);
 	}
 #endif
 }

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -54,7 +54,7 @@ uniform float zPerspectiveBias;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 
-vec4 getPerspectiveFactor(in vec4 shadowPosition)
+vec4 applyPerspectiveDistortion(in vec4 shadowPosition)
 {
 	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
 	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);
@@ -221,7 +221,7 @@ void main(void)
 		normalOffsetScale *= pow(1 - pow(cosLight, 2.0), 0.5) / f_textureresolution / f_shadowfar;
 		float z_bias_factor = f_normal_length > 0 ? 1e2 : 5e2;
 
-		shadow_position = getPerspectiveFactor(m_ShadowViewProj * mWorld * (inVertexPosition + vec4(normalOffsetScale * nNormal, 0.0))).xyz;
+		shadow_position = applyPerspectiveDistortion(m_ShadowViewProj * mWorld * (inVertexPosition + vec4(normalOffsetScale * nNormal, 0.0))).xyz;
 		float z_bias = z_bias_factor / f_textureresolution / f_shadowfar;
 		shadow_position.z -= z_bias;
 

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -227,8 +227,7 @@ void main(void)
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	if (f_shadow_strength > 0.0) {
-		vec3 nNormal = normalize(vNormal);
-		cosLight = dot(nNormal, -v_LightDirection);
+		vec3 nNormal;
 		f_normal_length = length(vNormal);
 
 		/* normalOffsetScale is in world coordinates (1/10th of a meter)
@@ -236,12 +235,16 @@ void main(void)
 		float normalOffsetScale, z_bias;
 		float pFactor = getPerspectiveFactor(getRelativePosition(m_ShadowViewProj * mWorld * inVertexPosition));
 		if (f_normal_length > 0.0) {
+			nNormal = normalize(vNormal);
+			cosLight = dot(nNormal, -v_LightDirection);
 			normalOffsetScale = 5.5e2 * pFactor * pFactor * pow(1 - pow(cosLight, 2.0), 0.5) / 
 					xyPerspectiveBias1 / f_textureresolution;
-			z_bias = 3.6e3 / clamp(cosLight, 0.01, 1.0);
+			z_bias = 1.5e3 / clamp(cosLight, 0.01, 1.0);
 		} else {
+			nNormal = vec3(0.0);
+			cosLight = dot(v_LightDirection, normalize(vec3(v_LightDirection.x, 0.0, v_LightDirection.z)));
 			normalOffsetScale = 0.0;
-			z_bias = 0.0;
+			z_bias = 3.6e3 / (1.0 - clamp(dot(v_LightDirection, vec3(0.0, -1.0, 0.0)), 0.0, 0.9));
 		}
 		z_bias *= pFactor * pFactor / f_textureresolution / f_shadowfar;
 

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -54,28 +54,28 @@ uniform float zPerspectiveBias;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 
-vec2 getRelativePosition(in vec4 position)
+vec4 getRelativePosition(in vec4 position)
 {
 	vec2 l = position.xy - CameraPos.xy;
 	vec2 s = l / abs(l);
-	l /= (1 - s * CameraPos.xy);
-	return l;
+	s = (1.0 - s * CameraPos.xy);
+	l /= s;
+	return vec4(l, s);
 }
 
-float getPerspectiveFactor(in vec2 relativePosition)
+float getPerspectiveFactor(in vec4 relativePosition)
 {
-	float pDistance = length(relativePosition);
+	float pDistance = length(relativePosition.xy);
 	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
 	return pFactor;
 }
 
 vec4 applyPerspectiveDistortion(in vec4 position)
 {
-	vec2 l = getRelativePosition(position);
+	vec4 l = getRelativePosition(position);
 	float pFactor = getPerspectiveFactor(l);
-	l /= pFactor;
-	vec2 s = l / abs(l);
-	position.xy = l * (1.0 - s * CameraPos.xy) + CameraPos.xy;
+	l.xy /= pFactor;
+	position.xy = l.xy * l.zw + CameraPos.xy;
 	position.z *= zPerspectiveBias;
 	return position;
 }

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -217,11 +217,11 @@ void main(void)
 		cosLight = dot(nNormal, -v_LightDirection);
 		f_normal_length = length(vNormal);
 
-		float normalOffsetScale = f_normal_length > 0 ? 5e5 : 0.0;
+		float normalOffsetScale = f_normal_length > 0 ? 1e5 : 0.0;
 		normalOffsetScale *= pow(1 - pow(cosLight, 2.0), 0.5) / f_textureresolution / f_shadowfar;
 		float z_bias_factor = f_normal_length > 0 ? 1e2 : 5e2;
 
-		shadow_position = getPerspectiveFactor(m_ShadowViewProj * mWorld * inVertexPosition).xyz;
+		shadow_position = getPerspectiveFactor(m_ShadowViewProj * mWorld * (inVertexPosition + vec4(normalOffsetScale * nNormal, 0.0))).xyz;
 		float z_bias = z_bias_factor / f_textureresolution / f_shadowfar;
 		shadow_position.z -= z_bias;
 

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -19,7 +19,6 @@ uniform float animationTimer;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
 	uniform vec4 CameraPos;
-	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float cosLight;
 	varying float f_normal_length;

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -55,7 +55,7 @@ uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
 
-vec4 getPerspectiveFactor(in vec4 shadowPosition)
+vec4 applyPerspectiveDistortion(in vec4 shadowPosition)
 {
 	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
 	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -19,6 +19,9 @@ uniform float animationTimer;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
 	uniform vec4 CameraPos;
+	uniform float xyPerspectiveBias0;
+	uniform float xyPerspectiveBias1;
+	
 	varying float adj_shadow_strength;
 	varying float cosLight;
 	varying float f_normal_length;
@@ -48,24 +51,7 @@ varying float vIDiff;
 const float fogStart = FOG_START;
 const float fogShadingParameter = 1.0 / (1.0 - fogStart);
 
-
-
 #ifdef ENABLE_DYNAMIC_SHADOWS
-uniform float xyPerspectiveBias0;
-uniform float xyPerspectiveBias1;
-uniform float zPerspectiveBias;
-
-vec4 applyPerspectiveDistortion(in vec4 shadowPosition)
-{
-	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
-	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);
-	float pDistance = length(l);
-	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-	l /= pFactor;
-	shadowPosition.xy = CameraPos.xy * (1.0 - l) + s * l;
-	shadowPosition.z *= zPerspectiveBias;
-	return shadowPosition;
-}
 
 // assuming near is always 1.0
 float getLinearDepth()

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -150,7 +150,8 @@ void main(void)
 			normalOffsetScale = 0.1 * pFactor * pFactor * sinLight * min(f_shadowfar, 500.0) / 
 					xyPerspectiveBias1 / f_textureresolution;
 			z_bias = 1e3 * sinLight / cosLight * (0.5 + f_textureresolution / 1024.0);
-		} else {
+		}
+		else {
 			nNormal = vec3(0.0);
 			cosLight = clamp(dot(v_LightDirection, normalize(vec3(v_LightDirection.x, 0.0, v_LightDirection.z))), 1e-2, 1.0);
 			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -24,10 +24,13 @@ centroid varying vec2 varTexCoord;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
 	uniform float f_timeofday;
+	uniform vec4 CameraPos;
+
 	varying float cosLight;
 	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float f_normal_length;
+	varying vec3 shadow_position;
 #endif
 
 varying vec3 eyeVec;
@@ -39,8 +42,22 @@ const float e = 2.718281828459;
 const float BS = 10.0;
 uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
+uniform float zPerspectiveBias;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
+
+vec4 getPerspectiveFactor(in vec4 shadowPosition)
+{
+	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
+	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);
+	float pDistance = length(l);
+	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
+	l /= pFactor;
+	shadowPosition.xy = CameraPos.xy * (1.0 - l) + s * l;
+	shadowPosition.z *= zPerspectiveBias;
+	return shadowPosition;
+}
+
 // custom smoothstep implementation because it's not defined in glsl1.2
 // https://docs.gl/sl4/smoothstep
 float mtsmoothstep(in float edge0, in float edge1, in float x)
@@ -107,20 +124,17 @@ void main(void)
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	if (f_shadow_strength > 0.0) {
 		vec3 nNormal = normalize(vNormal);
+		f_normal_length = length(vNormal);
+
 		cosLight = dot(nNormal, -v_LightDirection);
 
-		// Calculate normal offset scale based on the texel size adjusted for 
-		// curvature of the SM texture. This code must be change together with
-		// getPerspectiveFactor or any light-space transformation.
-		vec3 eyeToVertex = worldPosition - eyePosition + cameraOffset;
-		// Distance from the vertex to the player
-		float distanceToPlayer = length(eyeToVertex - v_LightDirection * dot(eyeToVertex, v_LightDirection)) / f_shadowfar;
-		// perspective factor estimation according to the
-		float perspectiveFactor = distanceToPlayer * xyPerspectiveBias0 + xyPerspectiveBias1;
-		float texelSize = f_shadowfar * perspectiveFactor * perspectiveFactor /
-				(f_textureresolution * xyPerspectiveBias1  - perspectiveFactor * xyPerspectiveBias0);
-		float slopeScale = clamp(pow(1.0 - cosLight*cosLight, 0.5), 0.0, 1.0);
-		normalOffsetScale = texelSize * slopeScale;
+		normalOffsetScale = f_normal_length > 0 ? 2e3 : 0.0;
+		normalOffsetScale *= 1.0 / f_textureresolution / f_shadowfar * pow(1 - pow(cosLight, 2.0), 0.5);
+
+		float z_bias_factor = 2e2;
+		shadow_position = getPerspectiveFactor(m_ShadowViewProj * mWorld * (inVertexPosition + vec4(normalOffsetScale * nNormal, 0.0))).xyz;
+		float z_bias = z_bias_factor / f_textureresolution / f_shadowfar;
+		shadow_position.z -= z_bias;
 
 		if (f_timeofday < 0.2) {
 			adj_shadow_strength = f_shadow_strength * 0.5 *
@@ -133,7 +147,6 @@ void main(void)
 				mtsmoothstep(0.20, 0.25, f_timeofday) *
 				(1.0 - mtsmoothstep(0.7, 0.8, f_timeofday));
 		}
-		f_normal_length = length(vNormal);
 	}
 #endif
 }

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -27,7 +27,6 @@ centroid varying vec2 varTexCoord;
 	uniform vec4 CameraPos;
 
 	varying float cosLight;
-	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float f_normal_length;
 	varying vec3 shadow_position;
@@ -128,10 +127,10 @@ void main(void)
 
 		cosLight = dot(nNormal, -v_LightDirection);
 
-		normalOffsetScale = f_normal_length > 0 ? 2e3 : 0.0;
-		normalOffsetScale *= 1.0 / f_textureresolution / f_shadowfar * pow(1 - pow(cosLight, 2.0), 0.5);
+		float normalOffsetScale = f_normal_length > 0 ? 5e5 : 0.0;
+		normalOffsetScale *= pow(1 - pow(cosLight, 2.0), 0.5) / f_textureresolution / f_shadowfar;
+		float z_bias_factor = f_normal_length > 0 ? 2e2 : 5e2;
 
-		float z_bias_factor = 2e2;
 		shadow_position = getPerspectiveFactor(m_ShadowViewProj * mWorld * (inVertexPosition + vec4(normalOffsetScale * nNormal, 0.0))).xyz;
 		float z_bias = z_bias_factor / f_textureresolution / f_shadowfar;
 		shadow_position.z -= z_bias;

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -45,28 +45,28 @@ uniform float zPerspectiveBias;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 
-vec2 getRelativePosition(in vec4 position)
+vec4 getRelativePosition(in vec4 position)
 {
 	vec2 l = position.xy - CameraPos.xy;
 	vec2 s = l / abs(l);
-	l /= (1 - s * CameraPos.xy);
-	return l;
+	s = (1.0 - s * CameraPos.xy);
+	l /= s;
+	return vec4(l, s);
 }
 
-float getPerspectiveFactor(in vec2 relativePosition)
+float getPerspectiveFactor(in vec4 relativePosition)
 {
-	float pDistance = length(relativePosition);
+	float pDistance = length(relativePosition.xy);
 	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
 	return pFactor;
 }
 
 vec4 applyPerspectiveDistortion(in vec4 position)
 {
-	vec2 l = getRelativePosition(position);
+	vec4 l = getRelativePosition(position);
 	float pFactor = getPerspectiveFactor(l);
-	l /= pFactor;
-	vec2 s = l / abs(l);
-	position.xy = l * (1.0 - s * CameraPos.xy) + CameraPos.xy;
+	l.xy /= pFactor;
+	position.xy = l.xy * l.zw + CameraPos.xy;
 	position.z *= zPerspectiveBias;
 	return position;
 }

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -45,16 +45,30 @@ uniform float zPerspectiveBias;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 
-vec4 applyPerspectiveDistortion(in vec4 shadowPosition)
+vec2 getRelativePosition(in vec4 position)
 {
-	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
-	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);
-	float pDistance = length(l);
+	vec2 l = position.xy - CameraPos.xy;
+	vec2 s = l / abs(l);
+	l /= (1 - s * CameraPos.xy);
+	return l;
+}
+
+float getPerspectiveFactor(in vec2 relativePosition)
+{
+	float pDistance = length(relativePosition);
 	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
+	return pFactor;
+}
+
+vec4 applyPerspectiveDistortion(in vec4 position)
+{
+	vec2 l = getRelativePosition(position);
+	float pFactor = getPerspectiveFactor(l);
 	l /= pFactor;
-	shadowPosition.xy = CameraPos.xy * (1.0 - l) + s * l;
-	shadowPosition.z *= zPerspectiveBias;
-	return shadowPosition;
+	vec2 s = l / abs(l);
+	position.xy = l * (1.0 - s * CameraPos.xy) + CameraPos.xy;
+	position.z *= zPerspectiveBias;
+	return position;
 }
 
 // custom smoothstep implementation because it's not defined in glsl1.2
@@ -127,12 +141,21 @@ void main(void)
 
 		cosLight = dot(nNormal, -v_LightDirection);
 
-		float normalOffsetScale = f_normal_length > 0 ? 5e5 : 0.0;
-		normalOffsetScale *= pow(1 - pow(cosLight, 2.0), 0.5) / f_textureresolution / f_shadowfar;
-		float z_bias_factor = f_normal_length > 0 ? 2e2 : 5e2;
+		/* normalOffsetScale is in world coordinates (1/10th of a meter)
+		   z_bias is in light space coordinates */
+		float normalOffsetScale, z_bias;
+		float pFactor = getPerspectiveFactor(getRelativePosition(m_ShadowViewProj * mWorld * inVertexPosition));
+		if (f_normal_length > 0.0) {
+			normalOffsetScale = 5.5e2 * pFactor * pFactor * pow(1 - pow(cosLight, 2.0), 0.5) / 
+					xyPerspectiveBias1 / f_textureresolution;
+			z_bias = 3.6e3 / clamp(cosLight, 0.01, 1.0);
+		} else {
+			normalOffsetScale = 0.0;
+			z_bias = 5e3;
+		}
+		z_bias *= pFactor * pFactor / f_textureresolution / f_shadowfar;
 
 		shadow_position = applyPerspectiveDistortion(m_ShadowViewProj * mWorld * (inVertexPosition + vec4(normalOffsetScale * nNormal, 0.0))).xyz;
-		float z_bias = z_bias_factor / f_textureresolution / f_shadowfar;
 		shadow_position.z -= z_bias;
 
 		if (f_timeofday < 0.2) {

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -139,19 +139,23 @@ void main(void)
 		vec3 nNormal = normalize(vNormal);
 		f_normal_length = length(vNormal);
 
-		cosLight = dot(nNormal, -v_LightDirection);
-
 		/* normalOffsetScale is in world coordinates (1/10th of a meter)
 		   z_bias is in light space coordinates */
 		float normalOffsetScale, z_bias;
 		float pFactor = getPerspectiveFactor(getRelativePosition(m_ShadowViewProj * mWorld * inVertexPosition));
 		if (f_normal_length > 0.0) {
-			normalOffsetScale = 5.5e2 * pFactor * pFactor * pow(1 - pow(cosLight, 2.0), 0.5) / 
+			nNormal = normalize(vNormal);
+			cosLight = dot(nNormal, -v_LightDirection);
+			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
+			normalOffsetScale = 0.1 * pFactor * pFactor * sinLight * min(f_shadowfar, 500.0) / 
 					xyPerspectiveBias1 / f_textureresolution;
-			z_bias = 3.6e3 / clamp(cosLight, 0.01, 1.0);
+			z_bias = 1e3 * sinLight / cosLight * (0.5 + f_textureresolution / 1024.0);
 		} else {
+			nNormal = vec3(0.0);
+			cosLight = clamp(dot(v_LightDirection, normalize(vec3(v_LightDirection.x, 0.0, v_LightDirection.z))), 1e-2, 1.0);
+			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
 			normalOffsetScale = 0.0;
-			z_bias = 5e3;
+			z_bias = 3.6e3 * sinLight / cosLight;
 		}
 		z_bias *= pFactor * pFactor / f_textureresolution / f_shadowfar;
 

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -45,7 +45,7 @@ uniform float zPerspectiveBias;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 
-vec4 getPerspectiveFactor(in vec4 shadowPosition)
+vec4 applyPerspectiveDistortion(in vec4 shadowPosition)
 {
 	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
 	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);
@@ -131,7 +131,7 @@ void main(void)
 		normalOffsetScale *= pow(1 - pow(cosLight, 2.0), 0.5) / f_textureresolution / f_shadowfar;
 		float z_bias_factor = f_normal_length > 0 ? 2e2 : 5e2;
 
-		shadow_position = getPerspectiveFactor(m_ShadowViewProj * mWorld * (inVertexPosition + vec4(normalOffsetScale * nNormal, 0.0))).xyz;
+		shadow_position = applyPerspectiveDistortion(m_ShadowViewProj * mWorld * (inVertexPosition + vec4(normalOffsetScale * nNormal, 0.0))).xyz;
 		float z_bias = z_bias_factor / f_textureresolution / f_shadowfar;
 		shadow_position.z -= z_bias;
 

--- a/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
@@ -9,18 +9,31 @@ uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
 
-vec4 applyPerspectiveDistortion(in vec4 shadowPosition)
+vec4 getRelativePosition(in vec4 position)
 {
-	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
-	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);
-	float pDistance = length(l);
-	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-	l /= pFactor;
-	shadowPosition.xy = CameraPos.xy * (1.0 - l) + s * l;
-	shadowPosition.z *= zPerspectiveBias;
-	return shadowPosition;
+	vec2 l = position.xy - CameraPos.xy;
+	vec2 s = l / abs(l);
+	s = (1.0 - s * CameraPos.xy);
+	l /= s;
+	return vec4(l, s);
 }
 
+float getPerspectiveFactor(in vec4 relativePosition)
+{
+	float pDistance = length(relativePosition.xy);
+	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
+	return pFactor;
+}
+
+vec4 applyPerspectiveDistortion(in vec4 position)
+{
+	vec4 l = getRelativePosition(position);
+	float pFactor = getPerspectiveFactor(l);
+	l.xy /= pFactor;
+	position.xy = l.xy * l.zw + CameraPos.xy;
+	position.z *= zPerspectiveBias;
+	return position;
+}
 
 void main()
 {

--- a/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
@@ -9,7 +9,7 @@ uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
 
-vec4 getPerspectiveFactor(in vec4 shadowPosition)
+vec4 applyPerspectiveDistortion(in vec4 shadowPosition)
 {
 	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
 	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);
@@ -26,7 +26,7 @@ void main()
 {
 	vec4 pos = LightMVP * gl_Vertex;
 
-	tPos = getPerspectiveFactor(LightMVP * gl_Vertex);
+	tPos = applyPerspectiveDistortion(LightMVP * gl_Vertex);
 
 	gl_Position = vec4(tPos.xyz, 1.0);
 	gl_TexCoord[0].st = gl_MultiTexCoord0.st;

--- a/client/shaders/shadow_shaders/pass1_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_vertex.glsl
@@ -6,7 +6,7 @@ uniform float xyPerspectiveBias0;
 uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
 
-vec4 getPerspectiveFactor(in vec4 shadowPosition)
+vec4 applyPerspectiveDistortion(in vec4 shadowPosition)
 {
 	vec2 s = vec2(shadowPosition.x > CameraPos.x ? 1.0 : -1.0, shadowPosition.y > CameraPos.y ? 1.0 : -1.0);
 	vec2 l = s * (shadowPosition.xy - CameraPos.xy) / (1.0 - s * CameraPos.xy);
@@ -23,7 +23,7 @@ void main()
 {
 	vec4 pos = LightMVP * gl_Vertex;
 
-	tPos = getPerspectiveFactor(pos);
+	tPos = applyPerspectiveDistortion(pos);
 
 	gl_Position = vec4(tPos.xyz, 1.0);
 	gl_TexCoord[0] = gl_TextureMatrix[0] * gl_MultiTexCoord0;

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -76,8 +76,11 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 	draw_wield_tool = _draw_wield_tool;
 	draw_crosshair = _draw_crosshair;
 
-	if (shadow_renderer)
+	if (shadow_renderer) {
+		// This is necessary to render shadows for animations correctly
+		smgr->getRootSceneNode()->OnAnimate(device->getTimer()->getTime());
 		shadow_renderer->update();
+	}
 
 	beforeDraw();
 	drawAll();

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -69,10 +69,16 @@ public:
 	const core::matrix4 &getFutureProjectionMatrix() const;
 	core::matrix4 getViewProjMatrix();
 
-	/// Gets the light's far value.
+	/// Gets the light's maximum far value, i.e. the shadow boundary
 	f32 getMaxFarValue() const
 	{
 		return farPlane * BS;
+	}
+
+	/// Gets the current far value of the light
+	f32 getFarValue() const
+	{
+		return shadow_frustum.zFar;
 	}
 
 

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -431,9 +431,6 @@ void ShadowRenderer::renderShadowMap(video::ITexture *target,
 			material.BlendOperation = video::EBO_MIN;
 		}
 
-		// FIXME: I don't think this is needed here
-		map_node->OnAnimate(m_device->getTimer()->getTime());
-
 		m_driver->setTransform(video::ETS_WORLD,
 				map_node->getAbsoluteTransformation());
 

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -418,10 +418,6 @@ void ShadowRenderer::renderShadowMap(video::ITexture *target,
 
 		material.BackfaceCulling = false;
 		material.FrontfaceCulling = true;
-		material.PolygonOffsetFactor = 4.0f;
-		material.PolygonOffsetDirection = video::EPO_BACK;
-		//material.PolygonOffsetDepthBias = 1.0f/4.0f;
-		//material.PolygonOffsetSlopeScale = -1.f;
 
 		if (m_shadow_map_colored && pass != scene::ESNRP_SOLID) {
 			material.MaterialType = (video::E_MATERIAL_TYPE) depth_shader_trans;
@@ -476,10 +472,6 @@ void ShadowRenderer::renderShadowObjects(
 
 			current_mat.BackfaceCulling = true;
 			current_mat.FrontfaceCulling = false;
-			current_mat.PolygonOffsetFactor = 1.0f/2048.0f;
-			current_mat.PolygonOffsetDirection = video::EPO_BACK;
-			//current_mat.PolygonOffsetDepthBias = 1.0 * 2.8e-6;
-			//current_mat.PolygonOffsetSlopeScale = -1.f;
 		}
 
 		m_driver->setTransform(video::ETS_WORLD,

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -143,7 +143,7 @@ size_t ShadowRenderer::getDirectionalLightCount() const
 f32 ShadowRenderer::getMaxShadowFar() const
 {
 	if (!m_light_list.empty()) {
-		float zMax = m_light_list[0].getMaxFarValue();
+		float zMax = m_light_list[0].getFarValue();
 		return zMax;
 	}
 	return 0.0f;


### PR DESCRIPTION
This PR reworks offsets of shadow mapping to improve remove shadow artifacts.

## What has been improved
* Most of self-shadowing cases, both for nodes, nodeboxes and entities should be resolved now
* Plants and flowing water now render shadows
* Shader performance should now be improved, as there are fewer calculations
* Shadow no longer lags one-two frames behind entities (@Andrey2470T)

## What has been done
* Move light space transformation into the vertex shader. Surprisingly (or not) this makes shadow aliasing linear = simpler correction.
* Enable shadows on surfaces with zero normal (plants, flowing water etc.)
* Use z-bias to remove shadow acne at /time 9000 and normal offset to remove acne at /time 11500. Remove use of other offsets when rendering the shadow map.
* Force animation on entire scene before rendering the shadows
* Lots of tuning

## To do

This PR is Ready for Review.

## How to test

1. Enable shadow mapping, choose a preset and disable filtering (`shadow_filters = 0`)
2. Start a compatible game
3. Check shadows on nodes, plants, water, flowing water, entities
4. Check shadows at different time (6:00, 9:00, 11:30, 11:45 etc.)
5. Check different SM texture sizes and rendering distance

In all presets but Very Low, self-shadowing acne and peter panning (detached shadows) should not be present. At Very Low and certain time values there may be elements of self-shadowing acne.
