### PR TITLE
Use mod names/titles instead of technical names

### DIFF
--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -163,10 +163,13 @@ local function get_formspec(data)
 			"button[8.95,0.125;2.5,0.5;btn_enable_all_mods;" ..
 			fgettext("Enable all") .. "]"
 	end
+
+	local use_technical_names = core.settings:get_bool("main_menu_technical_settings")
+
 	return retval ..
 		"tablecolumns[color;tree;text]" ..
 		"table[5.5,0.75;5.75,6;world_config_modlist;" ..
-		pkgmgr.render_packagelist(data.list) .. ";" .. data.selected_mod .."]"
+		pkgmgr.render_packagelist(data.list, use_technical_names) .. ";" .. data.selected_mod .."]"
 end
 
 local function handle_buttons(this, fields)

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -164,7 +164,7 @@ local function get_formspec(data)
 			fgettext("Enable all") .. "]"
 	end
 
-	local use_technical_names = core.settings:get_bool("main_menu_technical_settings")
+	local use_technical_names = core.settings:get_bool("show_technical_names")
 
 	return retval ..
 		"tablecolumns[color;tree;text]" ..

--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -957,7 +957,7 @@ local function create_settings_formspec(tabview, _, tabdata)
 	local current_level = 0
 	for _, entry in ipairs(settings) do
 		local name
-		if not core.settings:get_bool("main_menu_technical_settings") and entry.readable_name then
+		if not core.settings:get_bool("show_technical_names") and entry.readable_name then
 			name = fgettext_ne(entry.readable_name)
 		else
 			name = entry.name
@@ -998,7 +998,7 @@ local function create_settings_formspec(tabview, _, tabdata)
 			"button[10,4.9;2,1;btn_edit;" .. fgettext("Edit") .. "]" ..
 			"button[7,4.9;3,1;btn_restore;" .. fgettext("Restore Default") .. "]" ..
 			"checkbox[0,4.3;cb_tech_settings;" .. fgettext("Show technical names") .. ";"
-					.. dump(core.settings:get_bool("main_menu_technical_settings")) .. "]"
+					.. dump(core.settings:get_bool("show_technical_names")) .. "]"
 
 	return formspec
 end
@@ -1081,7 +1081,7 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 	end
 
 	if fields["cb_tech_settings"] then
-		core.settings:set("main_menu_technical_settings", fields["cb_tech_settings"])
+		core.settings:set("show_technical_names", fields["cb_tech_settings"])
 		core.settings:write()
 		core.update_formspec(this:get_formspec())
 		return true

--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -395,6 +395,7 @@ local function parse_config_file(read_all, parse_mods)
 
 				table.insert(settings, {
 					name = mod.name,
+					readable_name = mod.title,
 					level = 1,
 					type = "category",
 				})

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -78,23 +78,24 @@ local function load_texture_packs(txtpath, retval)
 
 	for _, item in ipairs(list) do
 		if item ~= "base" then
-			local name = item
-
 			local path = txtpath .. DIR_DELIM .. item .. DIR_DELIM
-			if path == current_texture_path then
-				name = fgettext("$1 (Enabled)", name)
-			end
-
 			local conf = Settings(path .. "texture_pack.conf")
+			local enabled = conf == current_texture_path
+
+			local name = item
+			local title = conf:get("title")
+			-- list_* is only used if non-nil, else the regular versions are used.
 
 			retval[#retval + 1] = {
-				name = item,
+				name = name,
+				title = title,
+				list_name = enabled and fgettext("$1 (Enabled)", name) or nil,
+				list_title = enabled and fgettext("$1 (Enabled)", title) or nil,
 				author = conf:get("author"),
 				release = tonumber(conf:get("release")) or 0,
-				list_name = name,
 				type = "txp",
 				path = path,
-				enabled = path == current_texture_path,
+				enabled = enabled,
 			}
 		end
 	end
@@ -135,6 +136,7 @@ function get_mods(path, virtual_path, retval, modpack)
 
 			-- Read from config
 			toadd.name = name
+			toadd.title = mod_conf.title
 			toadd.author = mod_conf.author
 			toadd.release = tonumber(mod_conf.release) or 0
 			toadd.path = mod_path
@@ -336,7 +338,7 @@ function pkgmgr.identify_modname(modpath,filename)
 	return nil
 end
 --------------------------------------------------------------------------------
-function pkgmgr.render_packagelist(render_list)
+function pkgmgr.render_packagelist(render_list, use_technical_names)
 	if not render_list then
 		if not pkgmgr.global_mods then
 			pkgmgr.refresh_globals()
@@ -372,7 +374,12 @@ function pkgmgr.render_packagelist(render_list)
 		else
 			retval[#retval + 1] = "0"
 		end
-		retval[#retval + 1] = core.formspec_escape(v.list_name or v.name)
+
+		if use_technical_names then
+			retval[#retval + 1] = core.formspec_escape(v.list_name or v.name)
+		else
+			retval[#retval + 1] = core.formspec_escape(v.list_title or v.list_name or v.title or v.name)
+		end
 	end
 
 	return table.concat(retval, ",")

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -82,14 +82,13 @@ local function load_texture_packs(txtpath, retval)
 			local conf = Settings(path .. "texture_pack.conf")
 			local enabled = conf == current_texture_path
 
-			local name = item
 			local title = conf:get("title")
 			-- list_* is only used if non-nil, else the regular versions are used.
 
 			retval[#retval + 1] = {
-				name = name,
+				name = item,
 				title = title,
-				list_name = enabled and fgettext("$1 (Enabled)", name) or nil,
+				list_name = enabled and fgettext("$1 (Enabled)", item) or nil,
 				list_title = enabled and fgettext("$1 (Enabled)", title) or nil,
 				author = conf:get("author"),
 				release = tonumber(conf:get("release")) or 0,

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -89,9 +89,16 @@ local function get_formspec(tabview, name, tabdata)
 			desc = info.description
 		end
 
+		local title_and_name
+		if selected_pkg.type == "game" then
+			title_and_name = selected_pkg.name
+		else
+			title_and_name = (selected_pkg.title or selected_pkg.name) .. core.colorize("#BFBFBF", "\n(" .. selected_pkg.name .. ")")
+		end
+
 		retval = retval ..
 				"image[5.5,0;3,2;" .. core.formspec_escape(modscreenshot) .. "]" ..
-				"label[8.25,0.6;" .. core.formspec_escape(selected_pkg.name) .. "]" ..
+				"label[8.25,0.6;" .. core.formspec_escape(title_and_name) .. "]" ..
 				"box[5.5,2.2;6.15,2.35;#000]"
 
 		if selected_pkg.type == "mod" then

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -93,8 +93,8 @@ local function get_formspec(tabview, name, tabdata)
 		if selected_pkg.type == "game" then
 			title_and_name = selected_pkg.name
 		else
-			title_and_name = (selected_pkg.title or selected_pkg.name) ..
-				core.colorize("#BFBFBF", "\n(" .. selected_pkg.name .. ")")
+			title_and_name = (selected_pkg.title or selected_pkg.name) .. "\n" ..
+				core.colorize("#BFBFBF", "(" .. selected_pkg.name .. ")")
 		end
 
 		retval = retval ..

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -94,7 +94,7 @@ local function get_formspec(tabview, name, tabdata)
 			title_and_name = selected_pkg.name
 		else
 			title_and_name = (selected_pkg.title or selected_pkg.name) .. "\n" ..
-				core.colorize("#BFBFBF", "(" .. selected_pkg.name .. ")")
+				core.colorize("#BFBFBF", selected_pkg.name)
 		end
 
 		retval = retval ..

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -93,7 +93,8 @@ local function get_formspec(tabview, name, tabdata)
 		if selected_pkg.type == "game" then
 			title_and_name = selected_pkg.name
 		else
-			title_and_name = (selected_pkg.title or selected_pkg.name) .. core.colorize("#BFBFBF", "\n(" .. selected_pkg.name .. ")")
+			title_and_name = (selected_pkg.title or selected_pkg.name) ..
+				core.colorize("#BFBFBF", "\n(" .. selected_pkg.name .. ")")
 		end
 
 		retval = retval ..

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -51,12 +51,14 @@ local function get_formspec(tabview, name, tabdata)
 		tabdata.selected_pkg = 1
 	end
 
+	local use_technical_names = core.settings:get_bool("main_menu_technical_settings")
+
 
 	local retval =
 		"label[0.05,-0.25;".. fgettext("Installed Packages:") .. "]" ..
 		"tablecolumns[color;tree;text]" ..
 		"table[0,0.25;5.1,4.3;pkglist;" ..
-		pkgmgr.render_packagelist(packages) ..
+		pkgmgr.render_packagelist(packages, use_technical_names) ..
 		";" .. tabdata.selected_pkg .. "]" ..
 		"button[0,4.85;5.25,0.5;btn_contentdb;".. fgettext("Browse online content") .. "]"
 

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -51,7 +51,7 @@ local function get_formspec(tabview, name, tabdata)
 		tabdata.selected_pkg = 1
 	end
 
-	local use_technical_names = core.settings:get_bool("main_menu_technical_settings")
+	local use_technical_names = core.settings:get_bool("show_technical_names")
 
 
 	local retval =

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1046,7 +1046,9 @@ client_unload_unused_data_timeout (Mapblock unload timeout) int 600
 #    Set to -1 for unlimited amount.
 client_mapblock_limit (Mapblock limit) int 7500
 
-#    Whether to show technical names for mods, texture packs and settings.
+#    Whether to show technical names.
+#    Affects mods and texture packs in the Content and Select Mods menus, as well as
+#    setting names in All Settings.
 #    Controlled by the checkbox in the "All settings" menu.
 main_menu_technical_settings (Show technical names) bool false
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1050,7 +1050,7 @@ client_mapblock_limit (Mapblock limit) int 7500
 #    Affects mods and texture packs in the Content and Select Mods menus, as well as
 #    setting names in All Settings.
 #    Controlled by the checkbox in the "All settings" menu.
-main_menu_technical_settings (Show technical names) bool false
+show_technical_names (Show technical names) bool false
 
 #    Whether to show the client debug info (has the same effect as hitting F5).
 show_debug (Show debug info) bool false

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1046,6 +1046,10 @@ client_unload_unused_data_timeout (Mapblock unload timeout) int 600
 #    Set to -1 for unlimited amount.
 client_mapblock_limit (Mapblock limit) int 7500
 
+#    Whether to show technical names for mods, texture packs and settings.
+#    Controlled by the checkbox in the "All settings" menu.
+main_menu_technical_settings (Show technical names) bool false
+
 #    Whether to show the client debug info (has the same effect as hitting F5).
 show_debug (Show debug info) bool false
 


### PR DESCRIPTION
Closes #12190 (see for details).
This is my first time poking with MT's menu code.

This PR:
- Adds `main_menu_technical_settings` to `settingtypes.txt` (previously only accessible via the checkbox).
- Expands the above setting to also cover mod & texture pack titles vs technical names.

This PR does not:
- Add the checkbox to the "Select mods" dialogue and "Content" tab.
- Enable technical names in "Browse online content".

## To do

This PR is a ready for review.

## How to test

1. Ensure the setting and checkbox are in sync.
![image](https://user-images.githubusercontent.com/27222523/162818611-26cfac01-63a1-4eb6-a72e-9fd36ad63024.png)

2. Ensure the setting works for mods in the settings page.
![image](https://user-images.githubusercontent.com/27222523/162818403-2ee20990-d530-4cbf-a350-bdfb0fc39727.png)

3. Go the the "Content" tab and "Select mods" dialogue with the setting enabled and disabled, ensure it works.
![image](https://user-images.githubusercontent.com/27222523/162818724-fdfabd60-c161-45f6-81f8-31833b7a3841.png)