### PR TITLE
Send chat error when attemping to /set a secure setting

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -621,7 +621,7 @@ core.register_chatcommand("set", {
 
 		setname, setvalue = string.match(param, "([^ ]+) (.+)")
 		if setname and setvalue then
-			if string.match(setname, "^secure.") then
+			if setname:sub(1, 7) == "secure." then
 				return false, S("Failed. Cannot modify secure settings. "
 					.. "Edit the settings file manually.")
 			end

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -621,6 +621,10 @@ core.register_chatcommand("set", {
 
 		setname, setvalue = string.match(param, "([^ ]+) (.+)")
 		if setname and setvalue then
+			if string.match(setname, "^secure.") then
+				return false, S("Failed. Cannot modify secure settings. "
+					.. "Edit the settings file manually.")
+			end
 			if not core.settings:get(setname) then
 				return false, S("Failed. Use '/set -n <name> <value>' "
 					.. "to create a new setting.")


### PR DESCRIPTION
Fixes #11480. Please see my comments there.

This PR:
- Fixes the crash when trying to `/set` a secure setting.

This PR does not:
- Prevent reading secure settings via `/set` (would be an easy change though).
- Prevent mods from causing the crash when attempting to set a secure setting. (No Lua API changes)

## To do

This PR is ready for review.

## How to test

Kablam:
![image](https://user-images.githubusercontent.com/27222523/162941139-3131ec83-8116-4867-bea7-37ffe1d8c824.png)

