### PR TITLE
upright_sprite: Fix walk animation in first person

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1974,19 +1974,16 @@ void GenericCAO::updateMeshCulling()
 
 	const bool hidden = m_client->getCamera()->getCameraMode() == CAMERA_MODE_FIRST;
 
-	if (m_meshnode && m_prop.visual == "upright_sprite") {
-		u32 buffers = m_meshnode->getMesh()->getMeshBufferCount();
-		for (u32 i = 0; i < buffers; i++) {
-			video::SMaterial &mat = m_meshnode->getMesh()->getMeshBuffer(i)->getMaterial();
-			// upright sprite has no backface culling
-			mat.setFlag(video::EMF_FRONT_FACE_CULLING, hidden);
-		}
-		return;
-	}
-
 	scene::ISceneNode *node = getSceneNode();
+
 	if (!node)
 		return;
+
+	if (m_prop.visual == "upright_sprite") {
+		// upright sprite has no backface culling
+		node->setMaterialFlag(video::EMF_FRONT_FACE_CULLING, hidden);
+		return;
+	}
 
 	if (hidden) {
 		// Hide the mesh by culling both front and


### PR DESCRIPTION
When a player walks in devtest (first person view), their own sprite animation appears in the screen. Example:
![grafik](https://user-images.githubusercontent.com/1497498/163023689-d4f4b715-9864-439e-af51-72caef0bd754.png)

It was caused by 8f652f4e3. This PR fixes it now. The shadows are still weird when walking backwards, but at least the animation no longer appears.

## To do

This PR is Ready for Review.

## How to test

1. devtest world
2. watch your "feet"
3. walk
