### PR TITLE
Enable dependencies when enabling modpacks

### DIFF
--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -448,9 +448,8 @@ function pkgmgr.enable_mod(this, toset)
 	local toggled_mods = {}
 	local enabled_mods = {}
 	toggle_mod_or_modpack(list, toggled_mods, enabled_mods, toset, mod)
-	toset = mod.enabled -- Update if toggled
 
-	if not toset then
+	if next(enabled_mods) == nil then
 		-- Mod(s) were disabled, so no dependencies need to be enabled
 		table.sort(toggled_mods)
 		core.log("info", "Following mods were disabled: " ..


### PR DESCRIPTION
This PR fixes a bug: When you enable a modpack, external dependencies of the mods in the modpack should be enabled, but they currently are not.

## To do

This PR is Ready for Review.

## How to test

1. Install [automobiles_pck](https://content.minetest.net/packages/apercy/automobiles_pck/).
2. Enable the modpack.
3. The biofuel mod should be enabled as a result.
4. Make sure the other enabling/disabling functionality continues to work too.
