### PR TITLE
Fix docs to reference CSS Color Module Level 3

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3248,7 +3248,7 @@ Colors
 `#RRGGBBAA` defines a color in hexadecimal format and alpha channel.
 
 Named colors are also supported and are equivalent to
-[CSS Color Module Level 4](http://dev.w3.org/csswg/css-color/#named-colors).
+[CSS Color Module Level 3](https://www.w3.org/TR/css-color-3/).
 To specify the value of the alpha channel, append `#A` or `#AA` to the end of
 the color name (e.g. `colorname#08`).
 


### PR DESCRIPTION
as the named color "rebeccapurple" is unavailable, Level 4 clearly isn't supported; the link should not point to a dev version of the spec either. This has been discussed on IRC a while ago. Alternative to https://github.com/minetest/minetest/pull/12204.
