### PR TITLE
Support CSS Color Module Level 4

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3248,7 +3248,7 @@ Colors
 `#RRGGBBAA` defines a color in hexadecimal format and alpha channel.
 
 Named colors are also supported and are equivalent to
-[CSS Color Module Level 3](https://www.w3.org/TR/css-color-3/).
+[CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#named-color).
 To specify the value of the alpha channel, append `#A` or `#AA` to the end of
 the color name (e.g. `colorname#08`).
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -494,6 +494,7 @@ const static std::unordered_map<std::string, u32> s_named_colors = {
 	{"plum",                 0xdda0dd},
 	{"powderblue",           0xb0e0e6},
 	{"purple",               0x800080},
+	{"rebeccapurple",        0x663399},
 	{"red",                  0xff0000},
 	{"rosybrown",            0xbc8f8f},
 	{"royalblue",            0x4169e1},


### PR DESCRIPTION
Alternative to #12203. Fixes the link to not point to the dev version as well, but makes Minetest compliant with level 4 by adding the named color "rebeccapurple". See [changes from level 3](https://www.w3.org/TR/css-color-4/#changes-from-3).