### PR TITLE
Fix some debug info showing despite being disabled in the UI

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3157,8 +3157,9 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 		handlePointingAtNode(pointed, selected_item, hand_item, dtime);
 	} else if (pointed.type == POINTEDTHING_OBJECT) {
 		v3f player_position  = player->getPosition();
+		bool basic_debug_allowed = client->checkPrivilege("debug") || (player->hud_flags & HUD_FLAG_BASIC_DEBUG);
 		handlePointingAtObject(pointed, tool_item, player_position,
-				client->checkPrivilege("debug") || (player->hud_flags & HUD_FLAG_BASIC_DEBUG));
+				m_game_ui->m_flags.show_basic_debug && basic_debug_allowed);
 	} else if (isKeyDown(KeyType::DIG)) {
 		// When button is held down in air, show continuous animation
 		runData.punching = true;


### PR DESCRIPTION
This fixes a bug reported by @GoodClover and introduced in #12020, namely [here](https://github.com/minetest/minetest/pull/12020/files#r855321367): F5 is now being ignored, only the priv and the flag are used to check whether some debug info (such as GenericCAO hp & armor groups) is shown.