### PR TITLE
Add support for LuaJIT 2.1

### DIFF
--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -387,7 +387,7 @@ std::vector<aabb3f> read_aabb3f_vector(lua_State *L, int index, f32 scale)
 {
 	std::vector<aabb3f> boxes;
 	if(lua_istable(L, index)){
-		int n = lua_objlen(L, index);
+		int n = lua_rawlen(L, index);
 		// Check if it's a single box or a list of boxes
 		bool possibly_single_box = (n == 6);
 		for(int i = 1; i <= n && possibly_single_box; i++){

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -34,6 +34,16 @@ extern "C" {
 #include "config.h"
 #include "common/c_types.h"
 
+/*
+	Newer versions of Lua rename lua_objlen to lua_rawlen.
+*/
+#if USE_LUAJIT
+	#if LUAJIT_VERSION_NUMBER < 20100
+		#define lua_rawlen(L, idx) lua_objlen(L, idx)
+	#endif
+#elif LUA_VERSION_NUM < 502
+	#define lua_rawlen(L, idx) lua_objlen(L, idx)
+#endif
 
 /*
 	Define our custom indices into the Lua registry table.

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -270,7 +270,7 @@ void ScriptApiEnv::on_liquid_transformed(
 
 	// Skip converting list and calling hook if there are
 	// no registered callbacks.
-	if(lua_objlen(L, -1) < 1) return;
+	if(lua_rawlen(L, -1) < 1) return;
 
 	// Convert the list to a pos array and a node array for lua
 	int index = 1;


### PR DESCRIPTION
Arch Linux (and possibly other distros) has moved it's [official LuaJIT package](https://archlinux.org/packages/community/x86_64/luajit/) to the latest unreleased version of 2.1 since the last release is quite old and [that's what the author seems to recommend](https://github.com/LuaJIT/LuaJIT/issues/665#issuecomment-784452583).

LuaJIT 2.1 renames `lua_objlen` to `lua_rawlen` (same as Lua 5.2).

## How to test

Build against the latest version of LuaJIT 2.1.