### PR TITLE
Fix worldaligned textures

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -373,6 +373,10 @@ void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box, const f32 *txc,
 	f32 dx2 = box.MaxEdge.X;
 	f32 dy2 = box.MaxEdge.Y;
 	f32 dz2 = box.MaxEdge.Z;
+
+	box.MinEdge += origin;
+	box.MaxEdge += origin;
+
 	if (scale) {
 		if (!txc) { // generate texture coords before scaling
 			generateCuboidTextureCoords(box, texture_coord_buf);
@@ -385,8 +389,7 @@ void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box, const f32 *txc,
 		generateCuboidTextureCoords(box, texture_coord_buf);
 		txc = texture_coord_buf;
 	}
-	box.MinEdge += origin;
-	box.MaxEdge += origin;
+
 	if (!tiles) {
 		tiles = &tile;
 		tile_count = 1;


### PR DESCRIPTION
As reported in #12197, b0b9732359d43325c8bd820abeb8417353365a0c
introduces a regression in worldalign textures.

The specific change that seems to be responsible for this issue is the
change in order between the computation of the cuboid texture
coordinates and the box edge correction.

Fix #12197 by moving the box edge correction back to before the cuboid
texture coordinates, as it used to be.
