### PR TITLE
Refactor local time retrieval

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1810,11 +1810,10 @@ void Client::makeScreenshot()
 	if (!raw_image)
 		return;
 
-	time_t t = time(NULL);
-	struct tm *tm = localtime(&t);
+	const struct tm tm = mt_localtime();
 
 	char timetstamp_c[64];
-	strftime(timetstamp_c, sizeof(timetstamp_c), "%Y%m%d_%H%M%S", tm);
+	strftime(timetstamp_c, sizeof(timetstamp_c), "%Y%m%d_%H%M%S", &tm);
 
 	std::string screenshot_dir;
 


### PR DESCRIPTION
Based on the work by Nils Dagsson Moskopp (@erlehmann),
this commit introduces get_local_time() in src/gettime.h, a wrapper
around the OS-specific thread-safe versions of localtime()
(resp. localtime_s on Windows and localtime_r in other systems).

Per the Open Group recommendation,
«portable applications should call tzset() explicitly before using
ctime_r() or localtime_r() because setting timezone information is
optional for those functions», so we also do a one-shot
call of tzset() (_tzset() on Windows to avoid warning C4996).

The function is used to replace the localtime() calls in
getTimestamp() and makeScreenshot().

(The only reminaing call to localtime() in the tree now is the one in
the local copy of the Lua source code.)

This is an alternative to PR #12080
