### PR TITLE
Show unknown node in debug screen

### DIFF
--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -151,9 +151,13 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			const NodeDefManager *nodedef = client->getNodeDefManager();
 			MapNode n = map.getNode(pointed_old.node_undersurface);
 
-			if (n.getContent() != CONTENT_IGNORE && nodedef->get(n).name != "unknown") {
-				os << ", pointed: " << nodedef->get(n).name
-					<< ", param2: " << (u64) n.getParam2();
+			if (n.getContent() != CONTENT_IGNORE) {
+				if (nodedef->get(n).name == "unknown") {
+					os << ", pointed: <unknown node>";
+				} else {
+					os << ", pointed: " << nodedef->get(n).name;
+				}
+				os << ", param2: " << (u64) n.getParam2();
 			}
 		}
 


### PR DESCRIPTION
If you point at an unknown node in the F5 debug screen, the "pointed" info is not visible.

This PR fixes this by writing "pointed: \<unknown node\>" in the debug screen.