### PR TITLE
Docs: Recommend `entity.name`

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6717,7 +6717,7 @@ object you are working with still exists.
         * Fourth column: subject looking to the right
         * Fifth column:  subject viewed from above
         * Sixth column:  subject viewed from below
-* `get_entity_name()` (**Deprecated**: Will be removed in a future version)
+* `get_entity_name()` (**Deprecated**: Will be removed in a future version, use the field `entity.name` instead)
 * `get_luaentity()`
 
 #### Player only (no-op for other objects)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6717,7 +6717,7 @@ object you are working with still exists.
         * Fourth column: subject looking to the right
         * Fifth column:  subject viewed from above
         * Sixth column:  subject viewed from below
-* `get_entity_name()` (**Deprecated**: Will be removed in a future version, use the field `entity.name` instead)
+* `get_entity_name()` (**Deprecated**: Will be removed in a future version, use the field `self.name` instead)
 * `get_luaentity()`
 
 #### Player only (no-op for other objects)


### PR DESCRIPTION
"What should I use instead of `get_entity_name()`" has come up a couple times now and currently isn't answered by the docs.
