### PR TITLE
Fix Minetest blaming the wrong mod for errors

### DIFF
--- a/builtin/client/register.lua
+++ b/builtin/client/register.lua
@@ -1,6 +1,6 @@
 core.callback_origins = setmetatable({}, {
 	__index = function()
-		return {mod = "", name = ""}
+		return {mod = "??", name = "??"}
 	end
 })
 

--- a/builtin/client/register.lua
+++ b/builtin/client/register.lua
@@ -1,8 +1,4 @@
-core.callback_origins = setmetatable({}, {
-	__index = function()
-		return {mod = "??", name = "??"}
-	end
-})
+core.callback_origins = {}
 
 local getinfo = debug.getinfo
 debug.getinfo = nil

--- a/builtin/client/register.lua
+++ b/builtin/client/register.lua
@@ -1,5 +1,8 @@
-
-core.callback_origins = {}
+core.callback_origins = setmetatable({}, {
+	__index = function()
+		return {mod = "", name = ""}
+	end
+})
 
 local getinfo = debug.getinfo
 debug.getinfo = nil

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -676,7 +676,7 @@ function core.node_dig(pos, node, digger)
 	-- Run script hook
 	for _, callback in ipairs(core.registered_on_dignodes) do
 		local origin = core.callback_origins[callback]
-		core.set_last_run_mod(origin.mod or "??")
+		core.set_last_run_mod(origin.mod or "")
 
 		-- Copy pos and node because callback can modify them
 		local pos_copy = vector.new(pos)

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -676,9 +676,7 @@ function core.node_dig(pos, node, digger)
 	-- Run script hook
 	for _, callback in ipairs(core.registered_on_dignodes) do
 		local origin = core.callback_origins[callback]
-		if origin then
-			core.set_last_run_mod(origin.mod)
-		end
+		core.set_last_run_mod(origin.mod or "??")
 
 		-- Copy pos and node because callback can modify them
 		local pos_copy = vector.new(pos)

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -676,7 +676,7 @@ function core.node_dig(pos, node, digger)
 	-- Run script hook
 	for _, callback in ipairs(core.registered_on_dignodes) do
 		local origin = core.callback_origins[callback]
-		core.set_last_run_mod(origin.mod or "")
+		core.set_last_run_mod(origin.mod)
 
 		-- Copy pos and node because callback can modify them
 		local pos_copy = vector.new(pos)

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -419,9 +419,7 @@ function core.run_callbacks(callbacks, mode, ...)
 	local ret = nil
 	for i = 1, cb_len do
 		local origin = core.callback_origins[callbacks[i]]
-		if origin then
-			core.set_last_run_mod(origin.mod)
-		end
+		core.set_last_run_mod(origin.mod or "??")
 		local cb_ret = callbacks[i](...)
 
 		if mode == 0 and i == 1 then

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -419,7 +419,7 @@ function core.run_callbacks(callbacks, mode, ...)
 	local ret = nil
 	for i = 1, cb_len do
 		local origin = core.callback_origins[callbacks[i]]
-		core.set_last_run_mod(origin.mod or "??")
+		core.set_last_run_mod(origin.mod or "")
 		local cb_ret = callbacks[i](...)
 
 		if mode == 0 and i == 1 then

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -404,7 +404,6 @@ function core.override_item(name, redefinition)
 end
 
 
-
 core.callback_origins = setmetatable({}, {
 	__index = function()
 		return {mod = "", name = ""}

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -403,12 +403,14 @@ function core.override_item(name, redefinition)
 	register_item_raw(item)
 end
 
-
-core.callback_origins = setmetatable({}, {
-	__index = function()
-		return {mod = "??", name = "??"}
-	end
-})
+do
+	local default = {mod = "??", name = "??"}
+	core.callback_origins = setmetatable({}, {
+		__index = function()
+			return default
+		end
+	})
+end
 
 function core.run_callbacks(callbacks, mode, ...)
 	assert(type(callbacks) == "table")

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -404,7 +404,12 @@ function core.override_item(name, redefinition)
 end
 
 
-core.callback_origins = {}
+
+core.callback_origins = setmetatable({}, {
+	__index = function()
+		return {mod = "", name = ""}
+	end
+})
 
 function core.run_callbacks(callbacks, mode, ...)
 	assert(type(callbacks) == "table")
@@ -419,7 +424,7 @@ function core.run_callbacks(callbacks, mode, ...)
 	local ret = nil
 	for i = 1, cb_len do
 		local origin = core.callback_origins[callbacks[i]]
-		core.set_last_run_mod(origin.mod or "")
+		core.set_last_run_mod(origin.mod)
 		local cb_ret = callbacks[i](...)
 
 		if mode == 0 and i == 1 then

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -406,7 +406,7 @@ end
 
 core.callback_origins = setmetatable({}, {
 	__index = function()
-		return {mod = "", name = ""}
+		return {mod = "??", name = "??"}
 	end
 })
 

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -76,10 +76,10 @@ void script_error(lua_State *L, int pcall_result, const char *mod, const char *f
 		err_type = "Unknown";
 	}
 
-	if (!mod)
+	if (!mod || !*mod)
 		mod = "??";
 
-	if (!fxn)
+	if (!fxn || !*fxn)
 		fxn = "??";
 
 	const char *err_descr = lua_tostring(L, -1);

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -76,10 +76,10 @@ void script_error(lua_State *L, int pcall_result, const char *mod, const char *f
 		err_type = "Unknown";
 	}
 
-	if (!mod || !*mod)
+	if (!mod)
 		mod = "??";
 
-	if (!fxn || !*fxn)
+	if (!fxn)
 		fxn = "??";
 
 	const char *err_descr = lua_tostring(L, -1);


### PR DESCRIPTION
Presumably fixes #12236 for the case that mods *insert their callbacks manually into* minetest.registered_\<callbacks\> (often to achieve a particular order of execution). This is the case with mesecons and used to be the case with modlib.