### PR TITLE
Fix nested modpacks and some other stuff

### DIFF
--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -216,7 +216,7 @@ local function get_formspec(data)
 
 	if mod.name ~= "" and not mod.is_game_content then
 		if mod.is_modpack then
-			if pkgmgr.is_modpack_entirely_enabled(data, mod.name) then
+			if pkgmgr.is_mod_or_modpack_enabled(mod) then
 				retval = retval ..
 					"button[5.5,0.125;3,0.5;btn_mp_disable;" ..
 					fgettext("Disable modpack") .. "]"


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - Make nested modpacks function properly in the mod selection screen.
  - Make multiple modpacks with identical names function properly too.
  - Display nested modpacks with extra indentation and their own expand/collapse buttons.
- How does the PR work?
  - The `modpack` field of mod objects now points to the modpack object instead of holding its name.
  - Modpack objects now hold references to their mods in the field `mods`.
  - The sorting of mods has been changed to support arbitrary nesting.
  - The sorting was also stabilized to support modpacks with identical names.
  - Fixing the indentation of nested modpacks was pretty simple.
- Does it resolve any reported issue?
  - Fixes https://github.com/minetest/minetest/issues/3363

## To do

This PR is Ready for Review.

## How to test

1. Download and unzip this modpack: [test_pack.zip](https://github.com/minetest/minetest/files/9136831/test_pack.zip)
2. Make two symlinks in your mod folder pointing to the modpack.
3. Create a new world.
4. Try enabling and disabling the two different modpacks and their mods in various patterns, ensuring that the interface behaves as one would expect. The mods and modpacks should be highlighted correctly.
5. Make sure the world loads correctly with different mod configurations.
6. To test that modpacks in game mods work, create a new Mineclone world and ensure that you can see the mod "mesecons" inside the "REDSTONE" modpack in the game mods section.