### PR TITLE
Make logging cost free when there is no output target

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1491,7 +1491,7 @@ bool Game::connectToServer(const GameStartData &start_data,
 	client->m_simple_singleplayer_mode = simple_singleplayer_mode;
 
 	infostream << "Connecting to server at ";
-	connect_address.print(&infostream);
+	connect_address.print(infostream);
 	infostream << std::endl;
 
 	client->connect(connect_address,

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -116,7 +116,7 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	}
 
 	SIrrlichtCreationParameters params = SIrrlichtCreationParameters();
-	if (g_logger.getTraceEnabled())
+	if (tracestream)
 		params.LoggingLevel = irr::ELL_DEBUG;
 	params.DriverType = driverType;
 	params.WindowSize = core::dimension2d<u32>(screen_w, screen_h);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -297,6 +297,8 @@ static void set_allowed_options(OptionList *allowed_options)
 			_("Print even more information to console"))));
 	allowed_options->insert(std::make_pair("trace", ValueSpec(VALUETYPE_FLAG,
 			_("Print enormous amounts of information to log and console"))));
+	allowed_options->insert(std::make_pair("socketdebug", ValueSpec(VALUETYPE_FLAG,
+			_("Enable socket debug output"))));
 	allowed_options->insert(std::make_pair("logfile", ValueSpec(VALUETYPE_STRING,
 			_("Set logfile path ('' = no logging)"))));
 	allowed_options->insert(std::make_pair("gameid", ValueSpec(VALUETYPE_STRING,
@@ -453,14 +455,6 @@ static bool setup_log_params(const Settings &cmd_args)
 		}
 	}
 
-	// If trace is enabled, enable logging of certain things
-	if (cmd_args.getFlag("trace")) {
-		dstream << _("Enabling trace level debug output") << std::endl;
-		g_logger.setTraceEnabled(true);
-		dout_con_ptr = &verbosestream; // This is somewhat old
-		socket_enable_debug_output = true; // Sockets doesn't use log.h
-	}
-
 	// In certain cases, output info level on stderr
 	if (cmd_args.getFlag("info") || cmd_args.getFlag("verbose") ||
 			cmd_args.getFlag("trace") || cmd_args.getFlag("speedtests"))
@@ -469,6 +463,16 @@ static bool setup_log_params(const Settings &cmd_args)
 	// In certain cases, output verbose level on stderr
 	if (cmd_args.getFlag("verbose") || cmd_args.getFlag("trace"))
 		g_logger.addOutput(&stderr_output, LL_VERBOSE);
+
+	if (cmd_args.getFlag("trace")) {
+		dstream << _("Enabling trace level debug output") << std::endl;
+		g_logger.addOutput(&stderr_output, LL_TRACE);
+	}
+
+	if (cmd_args.getFlag("socketdebug")) {
+		dstream << _("Enabling socket debug output") << std::endl;
+		socket_enable_debug_output = true;
+	}
 
 	return true;
 }
@@ -599,7 +603,7 @@ static void init_log_streams(const Settings &cmd_args)
 		warningstream << "Deprecated use of debug_log_level with an "
 			"integer value; please update your configuration." << std::endl;
 		static const char *lev_name[] =
-			{"", "error", "action", "info", "verbose"};
+			{"", "error", "action", "info", "verbose", "trace"};
 		int lev_i = atoi(conf_loglev.c_str());
 		if (lev_i < 0 || lev_i >= (int)ARRLEN(lev_name)) {
 			warningstream << "Supplied invalid debug_log_level!"

--- a/src/network/address.cpp
+++ b/src/network/address.cpp
@@ -230,14 +230,14 @@ void Address::setPort(u16 port)
 	m_port = port;
 }
 
-void Address::print(std::ostream *s) const
+void Address::print(std::ostream& s) const
 {
 	if (m_addr_family == AF_INET6)
-		*s << "[" << serializeString() << "]:" << m_port;
+		s << "[" << serializeString() << "]:" << m_port;
 	else if (m_addr_family == AF_INET)
-		*s << serializeString() << ":" << m_port;
+		s << serializeString() << ":" << m_port;
 	else
-		*s << "(undefined)";
+		s << "(undefined)";
 }
 
 bool Address::isLocalhost() const

--- a/src/network/address.h
+++ b/src/network/address.h
@@ -59,7 +59,7 @@ public:
 	int getFamily() const { return m_addr_family; }
 	bool isIPv6() const { return m_addr_family == AF_INET6; }
 	bool isZero() const;
-	void print(std::ostream *s) const;
+	void print(std::ostream &s) const;
 	std::string serializeString() const;
 	bool isLocalhost() const;
 

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -41,24 +41,13 @@ namespace con
 /* defines used for debugging and profiling                                   */
 /******************************************************************************/
 #ifdef NDEBUG
-	#define LOG(a) a
 	#define PROFILE(a)
 #else
-	#if 0
-	/* this mutex is used to achieve log message consistency */
-	std::mutex log_message_mutex;
-	#define LOG(a)                                                                 \
-		{                                                                          \
-		MutexAutoLock loglock(log_message_mutex);                                 \
-		a;                                                                         \
-		}
-	#else
-	// Prevent deadlocks until a solution is found after 5.2.0 (TODO)
-	#define LOG(a) a
-	#endif
-
 	#define PROFILE(a) a
 #endif
+
+// TODO: Clean this up.
+#define LOG(a) a
 
 #define PING_TIMEOUT 5.0
 

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -32,21 +32,17 @@ namespace con
 /* defines used for debugging and profiling                                   */
 /******************************************************************************/
 #ifdef NDEBUG
-#define LOG(a) a
 #define PROFILE(a)
 #undef DEBUG_CONNECTION_KBPS
 #else
 /* this mutex is used to achieve log message consistency */
-std::mutex log_conthread_mutex;
-#define LOG(a)                                                                \
-	{                                                                         \
-	MutexAutoLock loglock(log_conthread_mutex);                                 \
-	a;                                                                        \
-	}
 #define PROFILE(a) a
 //#define DEBUG_CONNECTION_KBPS
 #undef DEBUG_CONNECTION_KBPS
 #endif
+
+// TODO: Clean this up.
+#define LOG(a) a
 
 #define WINDOW_SIZE 5
 

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -198,7 +198,7 @@ void UDPSocket::Send(const Address &destination, const void *data, int size)
 	if (socket_enable_debug_output) {
 		// Print packet destination and size
 		dstream << (int)m_handle << " -> ";
-		destination.print(&dstream);
+		destination.print(dstream);
 		dstream << ", size=" << size;
 
 		// Print packet contents
@@ -295,7 +295,7 @@ int UDPSocket::Receive(Address &sender, void *data, int size)
 	if (socket_enable_debug_output) {
 		// Print packet sender and size
 		dstream << (int)m_handle << " <- ";
-		sender.print(&dstream);
+		sender.print(dstream);
 		dstream << ", size=" << received;
 
 		// Print packet contents

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -521,7 +521,7 @@ void Server::start()
 	actionstream << "World at [" << m_path_world << "]" << std::endl;
 	actionstream << "Server for gameid=\"" << m_gamespec.id
 			<< "\" listening on ";
-	m_bind_addr.print(&actionstream);
+	m_bind_addr.print(actionstream);
 	actionstream << "." << std::endl;
 }
 


### PR DESCRIPTION
Resolves issue #12242

The logging streams now do almost no work when there is no output target for them.

For example, if LL_VERBOSE has no output targets, then `verbosestream << x` will return a StreamProxy with a null target. Any further `<<` operations applied to it will do nothing.

One can also now test the stream to check if there is an output, before doing any expensive calculations:
```
if (verbosestream) {
    verbosestream << "All the data: " << SomethingExpensive(data) << std::endl;
}
```