### PR TITLE
Fix enabling of dependencies with identical names

### DIFF
--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -466,11 +466,16 @@ function pkgmgr.enable_mod(this, toset)
 
 	-- Enable mods' depends after activation
 
-	-- Make a list of mod ids indexed by their names
+	-- Make a list of mod ids indexed by their names. Among mods with the
+	-- same name, enabled mods take precedence, after which game mods take
+	-- precedence, being last in the mod list.
 	local mod_ids = {}
 	for id, mod2 in pairs(list) do
 		if mod2.type == "mod" and not mod2.is_modpack then
-			mod_ids[mod2.name] = id
+			local prev_id = mod_ids[mod2.name]
+			if not prev_id or not list[prev_id].enabled then
+				mod_ids[mod2.name] = id
+			end
 		end
 	end
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - Fix the following situation: Mod A depends on mod B. There are two mods named B. The B mod earlier in the list is already enabled. When the A mod is enabled, the second B mod is enabled due to the dependency, leading to both B mods being enabled at once. This is incorrect. Since the first B mod is already enabled, it should be used to fulfill the dependency.
- How does the PR work?
  - When mod names are being mapped to indices, the indices of already enabled mods take precedence over others.
- Does it resolve any reported issue?
  - Not that I can find.

## To do

This PR is Ready for Review.

## How to test

1. Download and unzip mods [boofarf.zip](https://github.com/minetest/minetest/files/8596987/boofarf.zip) and [foobarf.zip](https://github.com/minetest/minetest/files/8596990/foobarf.zip). boofarf depends on foobarf.
2. Put the mods into your mod directory. Put foobarf in twice using a symlink.
3. Try enabling boofarf with neither foobarf enabled. The one later in the list should become enabled.
4. Disable boofarf and both foobarfs.
5. Enable the first foobarf listed.
6. Try enabling boofarf. The first foobarf should remain the only one enabled.