### PR TITLE
Initialize wield mesh colors when changing item.

### DIFF
--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -457,6 +457,10 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 			material.setFlag(video::EMF_BILINEAR_FILTER, m_bilinear_filter);
 			material.setFlag(video::EMF_TRILINEAR_FILTER, m_trilinear_filter);
 		}
+
+		// initialize the color
+		if (!m_lighting)
+			setColor(video::SColor(0xFFFFFFFF));
 		return;
 	} else {
 		if (!def.inventory_image.empty()) {
@@ -469,6 +473,10 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		m_colors.emplace_back();
 		// overlay is white, if present
 		m_colors.emplace_back(true, video::SColor(0xFFFFFFFF));
+
+		// initialize the color
+		if (!m_lighting)
+			setColor(video::SColor(0xFFFFFFFF));
 		return;
 	}
 


### PR DESCRIPTION
Fixes #12245

## To do

This PR is Ready for Review.

## How to test

1. Install terraform
2. Activate shaders
3. Activate any colored terraform brush
4. Wield mesh must be colored
