### PR TITLE
guiScalingFilter: Fix most memory leaks

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -334,6 +334,8 @@ Client::~Client()
 	// cleanup 3d model meshes on client shutdown
 	m_rendering_engine->cleanupMeshCache();
 
+	guiScalingCacheClear();
+
 	delete m_minimap;
 	m_minimap = nullptr;
 

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -43,6 +43,10 @@ void guiScalingCache(const io::path &key, video::IVideoDriver *driver, video::II
 {
 	if (!g_settings->getBool("gui_scaling_filter"))
 		return;
+
+	if (g_imgCache.find(key) != g_imgCache.end())
+		return; // Already cached.
+
 	video::IImage *copied = driver->createImage(value->getColorFormat(),
 			value->getDimension());
 	value->copyTo(copied);
@@ -90,14 +94,16 @@ video::ITexture *guiScalingResizeCached(video::IVideoDriver *driver,
 	io::path scalename = origname + "@guiScalingFilter:" + rectstr;
 
 	// Search for existing scaled texture.
-	video::ITexture *scaled = g_txrCache[scalename];
+	auto it_txr = g_txrCache.find(scalename);
+	video::ITexture *scaled = (it_txr != g_txrCache.end()) ? it_txr->second : nullptr;
 	if (scaled)
 		return scaled;
 
 	// Try to find the texture converted to an image in the cache.
 	// If the image was not found, try to extract it from the texture.
-	video::IImage* srcimg = g_imgCache[origname];
-	if (srcimg == NULL) {
+	auto it_img = g_imgCache.find(origname);
+	video::IImage *srcimg = (it_img != g_imgCache.end()) ? it_img->second : nullptr;
+	if (!srcimg) {
 		if (!g_settings->getBool("gui_scaling_filter_txr2img"))
 			return src;
 		srcimg = driver->createImageFromData(src->getColorFormat(),


### PR DESCRIPTION
Calls to the cache function ended up creating a new texture regardless whether the texture is already cached.

This PR fixes that leak. However, I could not figure out the source of the following memory leak. It is not caused by multithreading - mutex makes no different. If anyone has an idea, I will gladly include the fix in this PR, otherwise the current content must suffice.
```
==21388== 11,200 bytes in 100 blocks are possibly lost in loss record 8,954 of 9,088
==21388==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
<GPU driver>
==21388==    by 0x49F827E: irr::video::COpenGLCoreTexture<irr::video::COpenGLDriver>::COpenGLCoreTexture(irr::core::string<char, irr::core::irrAllocator<char> > const&, irr::core::array<irr::video::IImage*, irr::core::irrAllocator<irr::video::IImage*> > const&, irr::video::E_TEXTURE_TYPE, irr::video::COpenGLDriver*) (in XXX/lib/libIrrlichtMt.so.1.9.0)
==21388==    by 0x49E6960: irr::video::COpenGLDriver::createDeviceDependentTexture(irr::core::string<char, irr::core::irrAllocator<char> > const&, irr::video::IImage*) (in XXX/lib/libIrrlichtMt.so.1.9.0)
==21388==    by 0x49D2217: irr::video::CNullDriver::addTexture(irr::core::string<char, irr::core::irrAllocator<char> > const&, irr::video::IImage*) (in XXX/lib/libIrrlichtMt.so.1.9.0)
==21388==    by 0x29B819: guiScalingResizeCached(irr::video::IVideoDriver*, irr::video::ITexture*, irr::core::rect<int> const&, irr::core::rect<int> const&) (in XXX/minetest)
==21388==    by 0x29C12B: guiScalingImageButton(irr::video::IVideoDriver*, irr::video::ITexture*, int, int) (in XXX/minetest)
==21388==    by 0x389699: GUIButtonImage::setFromStyle(StyleSpec const&) (in XXX/minetest)
==21388==    by 0x3828E4: GUIButton::setFromState() (in XXX/minetest)
```
https://github.com/minetest/minetest/blob/c7bcebb62856ae5fdb23a13e6fa1052eae700ddf/src/client/guiscalingfilter.cpp#L130-L133

## To do

This PR is Ready for Review.

## How to test

1. `gui_scaling_filter = true` in minetest.conf
2. Join and leave the world either with or without `valgrind`
3. It must still work.
