### PR TITLE
Avoid rendering invisible faces of simple nodeboxes

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -437,10 +437,12 @@ u8 MapblockMeshGenerator::getNodeBoxMask(aabb3f box, u8 solid_neighbors, u8 same
 
 	// Faces on opposite sides can cancel each other out if there is 
 	// a matching neighbor of the same type
-	u8 sametype_mask =
-			((solid_mask & 3) == 3 ? 3 : 0) |
+	// Only cancel out faces in opaque nodeboxes.
+	u8 sametype_mask = (f->alpha == AlphaMode::ALPHAMODE_OPAQUE) ?
+			(((solid_mask & 3) == 3 ? 3 : 0) |
 			((solid_mask & 12) == 12 ? 12 : 0) |
-			((solid_mask & 48) == 48 ? 48 : 0);
+			((solid_mask & 48) == 48 ? 48 : 0)) :
+			0;
 
 	// Combine masks with actual neighbors to get the faces to be skipped
 	return (solid_mask & solid_neighbors) | (sametype_mask & sametype_neighbors);

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1408,13 +1408,13 @@ void MapblockMeshGenerator::drawNodeboxNode()
 	}
 
 	bool param2_is_rotation =
-			f->param_type_2 == ContentParamType2::CPT2_COLORED_FACEDIR ||
-			f->param_type_2 == ContentParamType2::CPT2_COLORED_WALLMOUNTED ||
-			f->param_type_2 == ContentParamType2::CPT2_FACEDIR ||
-			f->param_type_2 == ContentParamType2::CPT2_WALLMOUNTED;
+			f->param_type_2 == CPT2_COLORED_FACEDIR ||
+			f->param_type_2 == CPT2_COLORED_WALLMOUNTED ||
+			f->param_type_2 == CPT2_FACEDIR ||
+			f->param_type_2 == CPT2_WALLMOUNTED;
 
 	bool param2_is_level =
-			f->param_type_2 == ContentParamType2::CPT2_LEVELED;
+			f->param_type_2 == CPT2_LEVELED;
 
 	// locate possible neighboring nodes to connect to
 	u8 neighbors_set = 0;

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -100,10 +100,12 @@ public:
 
 // cuboid drawing!
 	void drawCuboid(const aabb3f &box, TileSpec *tiles, int tilecount,
-		const LightInfo *lights , const f32 *txc);
+		const LightInfo *lights , const f32 *txc, u8 mask = 0);
 	void generateCuboidTextureCoords(aabb3f const &box, f32 *coords);
 	void drawAutoLightedCuboid(aabb3f box, const f32 *txc = NULL,
-		TileSpec *tiles = NULL, int tile_count = 0);
+		TileSpec *tiles = NULL, int tile_count = 0, u8 mask = 0);
+	u8 getNodeBoxMask(const aabb3f &box, const std::vector<aabb3f> &boxes,
+		u8 solid_set, u8 sametype_set) const;
 
 // liquid-specific
 	bool top_is_same_liquid;

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -104,8 +104,7 @@ public:
 	void generateCuboidTextureCoords(aabb3f const &box, f32 *coords);
 	void drawAutoLightedCuboid(aabb3f box, const f32 *txc = NULL,
 		TileSpec *tiles = NULL, int tile_count = 0, u8 mask = 0);
-	u8 getNodeBoxMask(const aabb3f &box, const std::vector<aabb3f> &boxes,
-		u8 solid_set, u8 sametype_set) const;
+	u8 getNodeBoxMask(aabb3f box, u8 solid_neighbors, u8 sametype_neighbors) const;
 
 // liquid-specific
 	bool top_is_same_liquid;


### PR DESCRIPTION
This PR adds basic infrastructure to render partial cuboids and adds optimizations for simple adjacent nodeboxes of the same type (snow, slabs, stairs etc.)

Fixes #6409.

## To do

This PR is Ready for Review.

## How to test

### Scenario 1
* Create a V7 world in MTG or an MCL2 world
* Start the game and find a snowy biome with 'slab' snow
* Use noclip or wireframe to see through the blocks
* Notice that occluded snow faces are not rendered

### Scenario 2
* Place slabs in MTG in various configurations and combined with solid blocks
* Use noclip or wireframe mode to see through the blocks
* Observe that faces touching solid blocks or adjacent slabs are not rendered.