### PR TITLE
HUD: Update selection mesh every frame

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3093,10 +3093,10 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 			!runData.btn_down_for_dig,
 			camera_offset);
 
-	if (pointed != runData.pointed_old) {
+	if (pointed != runData.pointed_old)
 		infostream << "Pointing at " << pointed.dump() << std::endl;
-		hud->updateSelectionMesh(camera_offset);
-	}
+
+	hud->updateSelectionMesh(camera_offset);
 
 	// Allow digging again if button is not pressed
 	if (runData.digging_blocked && !isKeyDown(KeyType::DIG))

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3096,6 +3096,8 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	if (pointed != runData.pointed_old)
 		infostream << "Pointing at " << pointed.dump() << std::endl;
 
+	// Note that updating the selection mesh every frame is not particularly efficient,
+	// but the halo rendering code is already inefficient so there's no point in optimizing it here
 	hud->updateSelectionMesh(camera_offset);
 
 	// Allow digging again if button is not pressed


### PR DESCRIPTION
Fixes #11904, most likely also fixes #3873

Minetest incorrectly made the assumption that the selectionbox doesn't change when the pointed thing doesn't change, which doesn't hold in the case of entities (which may have their properties changed) and nodes (which may have their neighborhood changed).

This PR fixes this by always updating the selection mesh. The performance impact is presumably negligible; worst-case performance (pointed thing constantly changing) hasn't changed at all. Only updating the selection mesh when it has changed would require way more code complexity and probably be less efficient.