### PR TITLE
Add more Prometheus metrics

### DIFF
--- a/src/emerge.h
+++ b/src/emerge.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "network/networkprotocol.h"
 #include "irr_v3d.h"
 #include "util/container.h"
+#include "util/metricsbackend.h"
 #include "mapgen/mapgen.h" // for MapgenParams
 #include "map.h"
 
@@ -67,6 +68,14 @@ enum EmergeAction {
 	EMERGE_FROM_MEMORY,
 	EMERGE_FROM_DISK,
 	EMERGE_GENERATED,
+};
+
+const static std::string emergeActionStrs[] = {
+	"cancelled",
+	"errored",
+	"from_memory",
+	"from_disk",
+	"generated",
 };
 
 // Callback
@@ -138,7 +147,7 @@ public:
 	MapSettingsManager *map_settings_mgr;
 
 	// Methods
-	EmergeManager(Server *server);
+	EmergeManager(Server *server, MetricsBackend *mb);
 	~EmergeManager();
 	DISABLE_CLASS_COPY(EmergeManager);
 
@@ -197,6 +206,9 @@ private:
 	u32 m_qlimit_diskonly;
 	u32 m_qlimit_generate;
 
+	// Emerge metrics
+	MetricCounterPtr m_completed_emerge_counter[5];
+
 	// Managers of various map generation-related components
 	// Note that each Mapgen gets a copy(!) of these to work with
 	BiomeGen *biomegen;
@@ -217,6 +229,8 @@ private:
 		bool *entry_already_exists);
 
 	bool popBlockEmergeData(v3s16 pos, BlockEmergeData *bedata);
+
+	void reportCompletedEmerge(EmergeAction action);
 
 	friend class EmergeThread;
 };

--- a/src/map.h
+++ b/src/map.h
@@ -275,6 +275,9 @@ protected:
 	// This stores the properties of the nodes on the map.
 	const NodeDefManager *m_nodedef;
 
+	// Can be implemented by child class
+	virtual void reportMetrics(u64 save_time_us, u32 saved_blocks, u32 all_blocks) {}
+
 	bool determineAdditionalOcclusionCheck(const v3s16 &pos_camera,
 		const core::aabbox3d<s16> &block_bounds, v3s16 &check);
 	bool isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
@@ -392,6 +395,10 @@ public:
 
 	MapSettingsManager settings_mgr;
 
+protected:
+
+	void reportMetrics(u64 save_time_us, u32 saved_blocks, u32 all_blocks) override;
+
 private:
 	friend class LuaVoxelManip;
 
@@ -420,7 +427,10 @@ private:
 	MapDatabase *dbase = nullptr;
 	MapDatabase *dbase_ro = nullptr;
 
+	// Map metrics
+	MetricGaugePtr m_loaded_blocks_gauge;
 	MetricCounterPtr m_save_time_counter;
+	MetricCounterPtr m_save_count_counter;
 };
 
 

--- a/src/server.h
+++ b/src/server.h
@@ -713,7 +713,7 @@ private:
 	MetricGaugePtr m_player_gauge;
 	MetricGaugePtr m_timeofday_gauge;
 	MetricGaugePtr m_lag_gauge;
-	MetricCounterPtr m_aom_buffer_counter;
+	MetricCounterPtr m_aom_buffer_counter[2]; // [0] = rel, [1] = unrel
 	MetricCounterPtr m_packet_recv_counter;
 	MetricCounterPtr m_packet_recv_processed_counter;
 	MetricCounterPtr m_map_edit_event_counter;

--- a/src/server.h
+++ b/src/server.h
@@ -712,11 +712,11 @@ private:
 	MetricCounterPtr m_uptime_counter;
 	MetricGaugePtr m_player_gauge;
 	MetricGaugePtr m_timeofday_gauge;
-	// current server step lag
 	MetricGaugePtr m_lag_gauge;
 	MetricCounterPtr m_aom_buffer_counter;
 	MetricCounterPtr m_packet_recv_counter;
 	MetricCounterPtr m_packet_recv_processed_counter;
+	MetricCounterPtr m_map_edit_event_counter;
 };
 
 /*

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -393,7 +393,7 @@ static std::random_device seed;
 
 ServerEnvironment::ServerEnvironment(ServerMap *map,
 	ServerScripting *scriptIface, Server *server,
-	const std::string &path_world):
+	const std::string &path_world, MetricsBackend *mb):
 	Environment(server),
 	m_map(map),
 	m_script(scriptIface),
@@ -460,6 +460,15 @@ ServerEnvironment::ServerEnvironment(ServerMap *map,
 
 	m_player_database = openPlayerDatabase(player_backend_name, path_world, conf);
 	m_auth_database = openAuthDatabase(auth_backend_name, path_world, conf);
+
+	m_step_time_counter = mb->addCounter(
+		"minetest_env_step_time", "Time spent in environment step (in microseconds)");
+
+	m_active_block_gauge = mb->addGauge(
+		"minetest_env_active_blocks", "Number of active blocks");
+
+	m_active_object_gauge = mb->addGauge(
+		"minetest_env_active_objects", "Number of active objects");
 }
 
 ServerEnvironment::~ServerEnvironment()
@@ -1283,6 +1292,8 @@ void ServerEnvironment::clearObjects(ClearObjectsMode mode)
 void ServerEnvironment::step(float dtime)
 {
 	ScopeProfiler sp2(g_profiler, "ServerEnv::step()", SPT_AVG);
+	const auto start_time = porting::getTimeUs();
+
 	/* Step time of day */
 	stepTimeOfDay(dtime);
 
@@ -1351,6 +1362,8 @@ void ServerEnvironment::step(float dtime)
 		std::set<v3s16> blocks_added;
 		m_active_blocks.update(players, active_block_range, active_object_range,
 			blocks_removed, blocks_added);
+
+		m_active_block_gauge->set(m_active_blocks.size());
 
 		/*
 			Handle removed blocks
@@ -1497,9 +1510,12 @@ void ServerEnvironment::step(float dtime)
 			send_recommended = true;
 		}
 
-		auto cb_state = [this, dtime, send_recommended] (ServerActiveObject *obj) {
+		u32 object_count = 0;
+
+		auto cb_state = [&] (ServerActiveObject *obj) {
 			if (obj->isGone())
 				return;
+			object_count++;
 
 			// Step object
 			obj->step(dtime, send_recommended);
@@ -1507,6 +1523,8 @@ void ServerEnvironment::step(float dtime)
 			obj->dumpAOMessagesToQueue(m_active_object_messages);
 		};
 		m_ao_manager.step(dtime, cb_state);
+
+		m_active_object_gauge->set(object_count);
 	}
 
 	/*
@@ -1548,6 +1566,9 @@ void ServerEnvironment::step(float dtime)
 
 	// Send outdated detached inventories
 	m_server->sendDetachedInventories(PEER_ID_INEXISTENT, true);
+
+	const auto end_time = porting::getTimeUs();
+	m_step_time_counter->increment(end_time - start_time);
 }
 
 ServerEnvironment::BlockStatus ServerEnvironment::getBlockStatus(v3s16 blockpos)

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "server/activeobjectmgr.h"
 #include "util/numeric.h"
+#include "util/metricsbackend.h"
 #include <set>
 #include <random>
 
@@ -167,19 +168,21 @@ public:
 		std::set<v3s16> &blocks_removed,
 		std::set<v3s16> &blocks_added);
 
-	bool contains(v3s16 p){
+	bool contains(v3s16 p) const {
 		return (m_list.find(p) != m_list.end());
 	}
 
-	void clear(){
+	auto size() const {
+		return m_list.size();
+	}
+
+	void clear() {
 		m_list.clear();
 	}
 
 	std::set<v3s16> m_list;
 	std::set<v3s16> m_abm_list;
 	std::set<v3s16> m_forceloaded_list;
-
-private:
 };
 
 /*
@@ -198,7 +201,7 @@ class ServerEnvironment : public Environment
 {
 public:
 	ServerEnvironment(ServerMap *map, ServerScripting *scriptIface,
-		Server *server, const std::string &path_world);
+		Server *server, const std::string &path_world, MetricsBackend *mb);
 	~ServerEnvironment();
 
 	Map & getMap();
@@ -486,6 +489,11 @@ private:
 	IntervalLimiter m_particle_management_interval;
 	std::unordered_map<u32, float> m_particle_spawners;
 	std::unordered_map<u32, u16> m_particle_spawner_attachments;
+
+	// Environment metrics
+	MetricCounterPtr m_step_time_counter;
+	MetricGaugePtr m_active_block_gauge;
+	MetricGaugePtr m_active_object_gauge;
 
 	ServerActiveObject* createSAO(ActiveObjectType type, v3f pos, const std::string &data);
 };

--- a/src/util/metricsbackend.cpp
+++ b/src/util/metricsbackend.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "metricsbackend.h"
+#include "util/thread.h"
 #if USE_PROMETHEUS
 #include <prometheus/exposer.h>
 #include <prometheus/registry.h>
@@ -27,17 +28,77 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #endif
 
-MetricCounterPtr MetricsBackend::addCounter(
-		const std::string &name, const std::string &help_str)
+/* Plain implementation */
+
+class SimpleMetricCounter : public MetricCounter
 {
-	return std::make_shared<SimpleMetricCounter>(name, help_str);
+public:
+	SimpleMetricCounter() : MetricCounter(), m_counter(0.0) {}
+
+	virtual ~SimpleMetricCounter() {}
+
+	void increment(double number) override
+	{
+		MutexAutoLock lock(m_mutex);
+		m_counter += number;
+	}
+	double get() const override
+	{
+		MutexAutoLock lock(m_mutex);
+		return m_counter;
+	}
+
+private:
+	mutable std::mutex m_mutex;
+	double m_counter;
+};
+
+class SimpleMetricGauge : public MetricGauge
+{
+public:
+	SimpleMetricGauge() : MetricGauge(), m_gauge(0.0) {}
+
+	virtual ~SimpleMetricGauge() {}
+
+	void increment(double number) override
+	{
+		MutexAutoLock lock(m_mutex);
+		m_gauge += number;
+	}
+	void decrement(double number) override
+	{
+		MutexAutoLock lock(m_mutex);
+		m_gauge -= number;
+	}
+	void set(double number) override
+	{
+		MutexAutoLock lock(m_mutex);
+		m_gauge = number;
+	}
+	double get() const override
+	{
+		MutexAutoLock lock(m_mutex);
+		return m_gauge;
+	}
+
+private:
+	mutable std::mutex m_mutex;
+	double m_gauge;
+};
+
+MetricCounterPtr MetricsBackend::addCounter(
+		const std::string &name, const std::string &help_str, Labels labels)
+{
+	return std::make_shared<SimpleMetricCounter>();
 }
 
 MetricGaugePtr MetricsBackend::addGauge(
-		const std::string &name, const std::string &help_str)
+		const std::string &name, const std::string &help_str, Labels labels)
 {
-	return std::make_shared<SimpleMetricGauge>(name, help_str);
+	return std::make_shared<SimpleMetricGauge>();
 }
+
+/* Prometheus backend */
 
 #if USE_PROMETHEUS
 
@@ -47,13 +108,14 @@ public:
 	PrometheusMetricCounter() = delete;
 
 	PrometheusMetricCounter(const std::string &name, const std::string &help_str,
+			MetricsBackend::Labels labels,
 			std::shared_ptr<prometheus::Registry> registry) :
 			MetricCounter(),
 			m_family(prometheus::BuildCounter()
 							.Name(name)
 							.Help(help_str)
 							.Register(*registry)),
-			m_counter(m_family.Add({}))
+			m_counter(m_family.Add(labels))
 	{
 	}
 
@@ -73,13 +135,14 @@ public:
 	PrometheusMetricGauge() = delete;
 
 	PrometheusMetricGauge(const std::string &name, const std::string &help_str,
+			MetricsBackend::Labels labels,
 			std::shared_ptr<prometheus::Registry> registry) :
 			MetricGauge(),
 			m_family(prometheus::BuildGauge()
 							.Name(name)
 							.Help(help_str)
 							.Register(*registry)),
-			m_gauge(m_family.Add({}))
+			m_gauge(m_family.Add(labels))
 	{
 	}
 
@@ -107,10 +170,12 @@ public:
 
 	virtual ~PrometheusMetricsBackend() {}
 
-	virtual MetricCounterPtr addCounter(
-			const std::string &name, const std::string &help_str);
-	virtual MetricGaugePtr addGauge(
-			const std::string &name, const std::string &help_str);
+	MetricCounterPtr addCounter(
+			const std::string &name, const std::string &help_str,
+			Labels labels = {}) override;
+	MetricGaugePtr addGauge(
+			const std::string &name, const std::string &help_str,
+			Labels labels = {}) override;
 
 private:
 	std::unique_ptr<prometheus::Exposer> m_exposer;
@@ -118,15 +183,15 @@ private:
 };
 
 MetricCounterPtr PrometheusMetricsBackend::addCounter(
-		const std::string &name, const std::string &help_str)
+		const std::string &name, const std::string &help_str, Labels labels)
 {
-	return std::make_shared<PrometheusMetricCounter>(name, help_str, m_registry);
+	return std::make_shared<PrometheusMetricCounter>(name, help_str, labels, m_registry);
 }
 
 MetricGaugePtr PrometheusMetricsBackend::addGauge(
-		const std::string &name, const std::string &help_str)
+		const std::string &name, const std::string &help_str, Labels labels)
 {
-	return std::make_shared<PrometheusMetricGauge>(name, help_str, m_registry);
+	return std::make_shared<PrometheusMetricGauge>(name, help_str, labels, m_registry);
 }
 
 MetricsBackend *createPrometheusMetricsBackend()

--- a/src/util/metricsbackend.h
+++ b/src/util/metricsbackend.h
@@ -19,8 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 #include <memory>
+#include <utility>
 #include "config.h"
-#include "util/thread.h"
 
 class MetricCounter
 {
@@ -34,38 +34,6 @@ public:
 };
 
 typedef std::shared_ptr<MetricCounter> MetricCounterPtr;
-
-class SimpleMetricCounter : public MetricCounter
-{
-public:
-	SimpleMetricCounter() = delete;
-
-	virtual ~SimpleMetricCounter() {}
-
-	SimpleMetricCounter(const std::string &name, const std::string &help_str) :
-			MetricCounter(), m_name(name), m_help_str(help_str),
-			m_counter(0.0)
-	{
-	}
-
-	virtual void increment(double number)
-	{
-		MutexAutoLock lock(m_mutex);
-		m_counter += number;
-	}
-	virtual double get() const
-	{
-		MutexAutoLock lock(m_mutex);
-		return m_counter;
-	}
-
-private:
-	std::string m_name;
-	std::string m_help_str;
-
-	mutable std::mutex m_mutex;
-	double m_counter;
-};
 
 class MetricGauge
 {
@@ -81,47 +49,6 @@ public:
 
 typedef std::shared_ptr<MetricGauge> MetricGaugePtr;
 
-class SimpleMetricGauge : public MetricGauge
-{
-public:
-	SimpleMetricGauge() = delete;
-
-	SimpleMetricGauge(const std::string &name, const std::string &help_str) :
-			MetricGauge(), m_name(name), m_help_str(help_str), m_gauge(0.0)
-	{
-	}
-
-	virtual ~SimpleMetricGauge() {}
-
-	virtual void increment(double number)
-	{
-		MutexAutoLock lock(m_mutex);
-		m_gauge += number;
-	}
-	virtual void decrement(double number)
-	{
-		MutexAutoLock lock(m_mutex);
-		m_gauge -= number;
-	}
-	virtual void set(double number)
-	{
-		MutexAutoLock lock(m_mutex);
-		m_gauge = number;
-	}
-	virtual double get() const
-	{
-		MutexAutoLock lock(m_mutex);
-		return m_gauge;
-	}
-
-private:
-	std::string m_name;
-	std::string m_help_str;
-
-	mutable std::mutex m_mutex;
-	double m_gauge;
-};
-
 class MetricsBackend
 {
 public:
@@ -129,10 +56,14 @@ public:
 
 	virtual ~MetricsBackend() {}
 
+	typedef std::initializer_list<std::pair<const std::string, std::string>> Labels;
+
 	virtual MetricCounterPtr addCounter(
-			const std::string &name, const std::string &help_str);
+			const std::string &name, const std::string &help_str,
+			Labels labels = {});
 	virtual MetricGaugePtr addGauge(
-			const std::string &name, const std::string &help_str);
+			const std::string &name, const std::string &help_str,
+			Labels labels = {});
 };
 
 #if USE_PROMETHEUS

--- a/src/util/metricsbackend.h
+++ b/src/util/metricsbackend.h
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 #include <memory>
+#include <string>
 #include <utility>
 #include "config.h"
 


### PR DESCRIPTION
Inspired by the [patches](https://github.com/pandorabox-io/minetest_docker/tree/master/patches) pandorabox uses I decided to make the existing [prometheus](https://prometheus.io/) support more useful by adding some metrics that actually matter.

Note: This renames `minetest_core_map_save_time` to `minetest_map_save_time` and changes the unit to microseconds.

## To do

This PR is a Ready for Review.

## How to test

Build Minetest with prometheus-cpp and hook it up to a prometheus instance or use `curl http://localhost:30000/metrics`