### PR TITLE
Handle too big connection commands gracefully

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -786,16 +786,18 @@ void Client::peerAdded(con::Peer *peer)
 	infostream << "Client::peerAdded(): peer->id="
 			<< peer->id << std::endl;
 }
+
 void Client::deletingPeer(con::Peer *peer, bool timeout)
 {
 	infostream << "Client::deletingPeer(): "
 			"Server Peer is getting deleted "
 			<< "(timeout=" << timeout << ")" << std::endl;
 
-	if (timeout) {
-		m_access_denied = true;
+	m_access_denied = true;
+	if (timeout)
 		m_access_denied_reason = gettext("Connection timed out.");
-	}
+	else
+		m_access_denied_reason = gettext("Connection aborted (protocol error?).");
 }
 
 /*

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1040,7 +1040,15 @@ bool UDPPeer::processReliableSendCommand(
 							- BASE_HEADER_SIZE
 							- RELIABLE_HEADER_SIZE;
 
-	sanity_check(c.data.getSize() < MAX_RELIABLE_WINDOW_SIZE*512);
+	if (c.data.getSize() >= MAX_RELIABLE_WINDOW_SIZE*512) {
+		// This should never happen, complain loudly
+		LOG(errorstream << m_connection->getDesc()
+				<< " Cannot deliver reliable sized "
+				<< c.data.getSize() << " bytes for peer_id="
+				<< c.peer_id << std::endl;)
+		m_connection->DisconnectPeer(c.peer_id);
+		return false;
+	}
 
 	std::list<SharedBuffer<u8>> originals;
 	u16 split_sequence_number = chan.readNextSplitSeqNum();


### PR DESCRIPTION
fixes #11214

I liked the suggestion with giving a straight error message to clients too but terminating conversation at the protocol level is simpler and safer.  

## To do

This PR is Ready for Review.

## How to test

see issue
