### PR TITLE
Fix mapblock geometry optimisation not working

### DIFF
--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -263,7 +263,6 @@ struct TileLayer
 	bool isTransparent() const
 	{
 		switch (material_type) {
-		case TILE_MATERIAL_BASIC:
 		case TILE_MATERIAL_ALPHA:
 		case TILE_MATERIAL_LIQUID_TRANSPARENT:
 		case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:


### PR DESCRIPTION
This is a bug caused by #11696, effectively breaking the mapblock geometry optimisation which combines the geometry of multiple full nodes of the same type. This appears to be due to it adding a check for specific material types, `TILE_MATERIAL_{ALPHA,LIQUID_TRANSPARENT,WAVING_LIQUID_TRANSPARENT}` all look alright but it also includes `TILE_MATERIAL_BASIC` which from what I can tell all opaque nodes use and completely removes any potential for geometry optimisations.

This PR removes the check for `TILE_MATERIAL_BASIC` in `isTransparent()` which appears to fix the issue.

Currently:
![image](https://user-images.githubusercontent.com/60856959/167265749-fb598b97-d32a-4375-a08c-1f2701e7835b.png)

With the PR applied:
![image](https://user-images.githubusercontent.com/60856959/167265817-2e3b03b9-19a2-41eb-a8ed-10ae83de595b.png)

## To do
This PR is Ready for Review.

## How to test
- Test with the PR applied on reasonably flat terrain in wireframe mode, checking to see that geometry is in fact being optimised again.
- In addition, also check to see if any regressions in terms of depth sorting reappear. I couldn't notice any myself when testing with the translucent nodes in devtest but additional testing would be helpful.