### PR TITLE
Fix possible unreliable behavior due to uninitialized variables

### DIFF
--- a/src/rollback.cpp
+++ b/src/rollback.cpp
@@ -483,6 +483,7 @@ const std::list<ActionRow> RollbackManager::actionRowsFromSelect(sqlite3_stmt* s
 		row.actor     = sqlite3_column_int  (stmt, 0);
 		row.timestamp = sqlite3_column_int64(stmt, 1);
 		row.type      = sqlite3_column_int  (stmt, 2);
+		row.nodeMeta  = 0;
 
 		if (row.type == RollbackAction::TYPE_MODIFY_INVENTORY_STACK) {
 			text = sqlite3_column_text (stmt, 3);


### PR DESCRIPTION
This PR fixes a possible unreliable behavior due to the uninitialized variable row.nodeMeta, and improves code-clarity.
