### PR TITLE
Use std::map instead of core::map

### DIFF
--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -20,7 +20,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mesh.h"
 #include "debug.h"
 #include "log.h"
-#include "irrMap.h"
 #include <cmath>
 #include <iostream>
 #include <IAnimatedMesh.h>

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -59,7 +59,7 @@ struct SGUITTFace : public virtual irr::IReferenceCounted
 
 // Static variables.
 FT_Library CGUITTFont::c_library;
-core::map<io::path, SGUITTFace*> CGUITTFont::c_faces;
+std::map<io::path, SGUITTFace*> CGUITTFont::c_faces;
 bool CGUITTFont::c_libraryLoaded = false;
 scene::IMesh* CGUITTFont::shared_plane_ptr_ = 0;
 scene::SMesh CGUITTFont::shared_plane_;
@@ -320,11 +320,11 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 
 	// Grab the face.
 	SGUITTFace* face = 0;
-	core::map<io::path, SGUITTFace*>::Node* node = c_faces.find(filename);
-	if (node == 0)
+	auto node = c_faces.find(filename);
+	if (node == c_faces.end())
 	{
 		face = new SGUITTFace();
-		c_faces.set(filename, face);
+		c_faces.emplace(filename, face);
 
 		if (filesystem)
 		{
@@ -334,7 +334,7 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 			{
 				if (logger) logger->log(L"CGUITTFont", L"Failed to open the file.", irr::ELL_INFORMATION);
 
-				c_faces.remove(filename);
+				c_faces.erase(filename);
 				delete face;
 				face = 0;
 				return false;
@@ -349,7 +349,7 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 			{
 				if (logger) logger->log(L"CGUITTFont", L"FT_New_Memory_Face failed.", irr::ELL_INFORMATION);
 
-				c_faces.remove(filename);
+				c_faces.erase(filename);
 				delete face;
 				face = 0;
 				return false;
@@ -362,7 +362,7 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 			{
 				if (logger) logger->log(L"CGUITTFont", L"FT_New_Face failed.", irr::ELL_INFORMATION);
 
-				c_faces.remove(filename);
+				c_faces.erase(filename);
 				delete face;
 				face = 0;
 				return false;
@@ -372,7 +372,7 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 	else
 	{
 		// Using another instance of this face.
-		face = node->getValue();
+		face = node->second;
 		face->grab();
 	}
 
@@ -415,17 +415,17 @@ CGUITTFont::~CGUITTFont()
 	//Glyphs.clear();
 
 	// We aren't using this face anymore.
-	core::map<io::path, SGUITTFace*>::Node* n = c_faces.find(filename);
-	if (n)
+	auto n = c_faces.find(filename);
+	if (n != c_faces.end())
 	{
-		SGUITTFace* f = n->getValue();
+		SGUITTFace* f = n->second;
 
 		// Drop our face.  If this was the last face, the destructor will clean up.
 		if (f->drop())
-			c_faces.remove(filename);
+			c_faces.erase(filename);
 
 		// If there are no more faces referenced by FreeType, clean up.
-		if (c_faces.size() == 0)
+		if (c_faces.empty())
 		{
 			FT_Done_FreeType(c_library);
 			c_libraryLoaded = false;
@@ -585,7 +585,7 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 	core::ustring utext = text.getString();
 
 	// Set up our render map.
-	core::map<u32, CGUITTGlyphPage*> Render_Map;
+	std::map<u32, CGUITTGlyphPage*> Render_Map;
 
 	// Start parsing characters.
 	u32 n;
@@ -640,7 +640,7 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 				page->render_colors.push_back(colors[iter.getPos()]);
 			else
 				page->render_colors.push_back(video::SColor(255,255,255,255));
-			Render_Map.set(glyph.glyph_page, page);
+			Render_Map[glyph.glyph_page] = page;
 		}
 		if (n > 0)
 		{
@@ -673,14 +673,12 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 
 	// Draw now.
 	update_glyph_pages();
-	core::map<u32, CGUITTGlyphPage*>::Iterator j = Render_Map.getIterator();
-	while (!j.atEnd())
+	auto it = Render_Map.begin();
+	auto ie = Render_Map.end();
+	while (it != ie)
 	{
-		core::map<u32, CGUITTGlyphPage*>::Node* n = j.getNode();
-		j++;
-		if (n == 0) continue;
-
-		CGUITTGlyphPage* page = n->getValue();
+		CGUITTGlyphPage* page = it->second;
+		++it;
 
 		if (shadow_offset) {
 			for (size_t i = 0; i < page->render_positions.size(); ++i)

--- a/src/irrlicht_changes/CGUITTFont.h
+++ b/src/irrlicht_changes/CGUITTFont.h
@@ -34,6 +34,7 @@
 #include <irrlicht.h>
 #include <ft2build.h>
 #include <vector>
+#include <map>
 #include <irrUString.h>
 #include "util/enriched_string.h"
 #include FT_FREETYPE_H
@@ -345,7 +346,7 @@ namespace gui
 		private:
 			// Manages the FreeType library.
 			static FT_Library c_library;
-			static core::map<io::path, SGUITTFace*> c_faces;
+			static std::map<io::path, SGUITTFace*> c_faces;
 			static bool c_libraryLoaded;
 			static scene::IMesh* shared_plane_ptr_;
 			static scene::SMesh  shared_plane_;

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -533,7 +533,7 @@ struct TestMapBlock: public TestBase
 			parent.node.setContent(CONTENT_AIR);
 			parent.node.setLight(LIGHTBANK_DAY, LIGHT_SUN);
 			parent.node.setLight(LIGHTBANK_NIGHT, 0);
-			core::map<v3s16, bool> light_sources;
+			std::map<v3s16, bool> light_sources;
 			// The bottom block is invalid, because we have a shadowing node
 			UASSERT(b.propagateSunlight(light_sources) == false);
 			UASSERT(b.getNode(v3s16(1,4,0)).getLight(LIGHTBANK_DAY) == LIGHT_SUN);
@@ -560,7 +560,7 @@ struct TestMapBlock: public TestBase
 			parent.position_valid = true;
 			b.setIsUnderground(true);
 			parent.node.setLight(LIGHTBANK_DAY, LIGHT_MAX/2);
-			core::map<v3s16, bool> light_sources;
+			std::map<v3s16, bool> light_sources;
 			// The block below should be valid because there shouldn't be
 			// sunlight in there either
 			UASSERT(b.propagateSunlight(light_sources, true) == true);
@@ -601,7 +601,7 @@ struct TestMapBlock: public TestBase
 			}
 			// Lighting value for the valid nodes
 			parent.node.setLight(LIGHTBANK_DAY, LIGHT_MAX/2);
-			core::map<v3s16, bool> light_sources;
+			std::map<v3s16, bool> light_sources;
 			// Bottom block is not valid
 			UASSERT(b.propagateSunlight(light_sources) == false);
 		}


### PR DESCRIPTION
Replaces all uses of core::map in the minetest repo with std::map.

Part of https://github.com/minetest/minetest/issues/12300