### PR TITLE
Fix cooking and fuel crafts with aliases

### DIFF
--- a/games/devtest/mods/unittests/crafting_prepare.lua
+++ b/games/devtest/mods/unittests/crafting_prepare.lua
@@ -31,25 +31,31 @@ minetest.register_craftitem("unittests:steel_ingot", {
 	groups = { dummy = 1 },
 })
 
+-- Use aliases in recipes for more complete testing
+
+minetest.register_alias("unittests:steel_ingot_alias", "unittests:steel_ingot")
+minetest.register_alias("unittests:coal_lump_alias", "unittests:coal_lump")
+minetest.register_alias("unittests:iron_lump_alias", "unittests:iron_lump")
+
 -- Recipes for tests: Normal crafting, cooking and fuel
 
 minetest.register_craft({
 	output = 'unittests:torch 4',
 	recipe = {
-		{'unittests:coal_lump'},
+		{'unittests:coal_lump_alias'},
 		{'unittests:stick'},
 	}
 })
 
 minetest.register_craft({
 	type = "cooking",
-	output = "unittests:steel_ingot",
-	recipe = "unittests:iron_lump",
+	output = "unittests:steel_ingot_alias",
+	recipe = "unittests:iron_lump_alias",
 })
 
 minetest.register_craft({
 	type = "fuel",
-	recipe = "unittests:coal_lump",
+	recipe = "unittests:coal_lump_alias",
 	burntime = 40,
 })
 

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -734,7 +734,8 @@ bool CraftDefinitionCooking::check(const CraftInput &input, IGameDef *gamedef) c
 	}
 
 	// Check the single input item
-	return inputItemMatchesRecipe(input_filtered[0], recipe, gamedef->idef());
+	std::string rec_name = craftGetItemName(recipe, gamedef);
+	return inputItemMatchesRecipe(input_filtered[0], rec_name, gamedef->idef());
 }
 
 CraftOutput CraftDefinitionCooking::getOutput(const CraftInput &input, IGameDef *gamedef) const
@@ -836,7 +837,8 @@ bool CraftDefinitionFuel::check(const CraftInput &input, IGameDef *gamedef) cons
 	}
 
 	// Check the single input item
-	return inputItemMatchesRecipe(input_filtered[0], recipe, gamedef->idef());
+	std::string rec_name = craftGetItemName(recipe, gamedef);
+	return inputItemMatchesRecipe(input_filtered[0], rec_name, gamedef->idef());
 }
 
 CraftOutput CraftDefinitionFuel::getOutput(const CraftInput &input, IGameDef *gamedef) const


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - Make cooking and fuel recipes work when the input is an alias.
- How does the PR work?
  - Uses the input item name rather than the input itemstring for matching.
- Does it resolve any reported issue?
  - https://github.com/minetest-mods/mesecons/issues/611

## To do

This PR is Ready for Review.

## How to test

The unit tests have been modified to test the code.
