### PR TITLE
Add warning when writing to mod directory

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -573,6 +573,13 @@ bool ScriptApiSecurity::checkPath(lua_State *L, const char *path,
 			if (mod) {
 				str = fs::AbsolutePath(mod->path);
 				if (!str.empty() && fs::PathStartsWith(abs_path, str)) {
+					if (write_required) {
+						const char *message =
+								"Writing to mod directories is deprecated, as any changes"
+								" will be overwritten when updating content.";
+						log_deprecated(L, message, 1);
+					}
+
 					if (write_allowed) *write_allowed = true;
 					return true;
 				}


### PR DESCRIPTION
Minetest will overwrite any changes to mod directories when updating content. Modders should be dissuaded from storing data in the mod directory.

## To do

This PR is a Ready for Review.

## How to test

```lua
local function save()
	local file = io.open(minetest.get_modpath("testsec") .. "/file.txt", "w")
end

save()
```

