### PR TITLE
unordered_map instead of map for MapSectors

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -102,7 +102,7 @@ MapSector * Map::getSectorNoGenerateNoLock(v2s16 p)
 		return sector;
 	}
 
-	std::unordered_map<v2s16, MapSector*>::iterator n = m_sectors.find(p);
+	auto n = m_sectors.find(p);
 
 	if (n == m_sectors.end())
 		return NULL;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -102,7 +102,7 @@ MapSector * Map::getSectorNoGenerateNoLock(v2s16 p)
 		return sector;
 	}
 
-	std::map<v2s16, MapSector*>::iterator n = m_sectors.find(p);
+	std::unordered_map<v2s16, MapSector*>::iterator n = m_sectors.find(p);
 
 	if (n == m_sectors.end())
 		return NULL;

--- a/src/map.h
+++ b/src/map.h
@@ -266,7 +266,7 @@ protected:
 
 	std::set<MapEventReceiver*> m_event_receivers;
 
-	std::map<v2s16, MapSector*> m_sectors;
+	std::unordered_map<v2s16, MapSector*> m_sectors;
 
 	// Be sure to set this to NULL when the cached sector is deleted
 	MapSector *m_sector_cache = nullptr;


### PR DESCRIPTION
MapSectors now stored in unordered_map, access is faster.
Can be compiled with IrrlichtMt which has [this](https://github.com/minetest/irrlicht/commit/6928c7eb6f00a00df4efcf1a1ec8f2310609696b) commit.