### PR TITLE
Add vcs-browser and contribute URLs to Appdata

### DIFF
--- a/misc/net.minetest.minetest.appdata.xml
+++ b/misc/net.minetest.minetest.appdata.xml
@@ -68,12 +68,14 @@
 		<keyword>mining</keyword>
 		<keyword>multiplayer</keyword>
 	</keywords>
-	<url type="homepage">http://minetest.net</url>
-	<url type="bugtracker">http://www.minetest.net/development/#reporting-issues</url>
-	<url type="translate">http://dev.minetest.net/Translation</url>
-	<url type="donation">http://www.minetest.net/development/#donate</url>
-	<url type="faq">http://wiki.minetest.net/FAQ</url>
-	<url type="help">http://wiki.minetest.net</url>
+	<url type="homepage">https://minetest.net</url>
+	<url type="bugtracker">https://www.minetest.net/development/#reporting-issues</url>
+	<url type="translate">https://dev.minetest.net/Translation</url>
+	<url type="donation">https://www.minetest.net/development/#donate</url>
+	<url type="faq">https://wiki.minetest.net/FAQ</url>
+	<url type="help">https://wiki.minetest.net</url>
+	<url type="vcs-browser">https://github.com/minetest/minetest</url>
+	<url type="contribute">https://www.minetest.net/get-involved/</url>
 	<provides>
 		<binary>minetest</binary>
 	</provides>

--- a/misc/net.minetest.minetest.appdata.xml
+++ b/misc/net.minetest.minetest.appdata.xml
@@ -68,7 +68,7 @@
 		<keyword>mining</keyword>
 		<keyword>multiplayer</keyword>
 	</keywords>
-	<url type="homepage">https://minetest.net</url>
+	<url type="homepage">https://www.minetest.net</url>
 	<url type="bugtracker">https://www.minetest.net/development/#reporting-issues</url>
 	<url type="translate">https://dev.minetest.net/Translation</url>
 	<url type="donation">https://www.minetest.net/development/#donate</url>


### PR DESCRIPTION
I added the 2 new URL types vcs-browser and contribute. See [here](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url) for a list of all URL types I also updated all existing URLs to https.