### PR TITLE
Fix no_texture.png being shown (instead of unknown_node.png) for unknown nodes w/ content ID < 125

### DIFF
--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -539,7 +539,7 @@ public:
 	 */
 	inline const ContentFeatures& get(content_t c) const {
 		return
-			c < m_content_features.size() ?
+			(c < m_content_features.size() && !m_content_features[c].name.empty()) ?
 				m_content_features[c] : m_content_features[CONTENT_UNKNOWN];
 	}
 


### PR DESCRIPTION
Fixes #12248.
The issue description is wrong, the bug can also happen in singleplayer under the right conditions (see the issue discussion).

If the content ID of an unknown node happens to be below 125, it incorrectly showed the `no_texture.png` texture instead of `unknown_node.png`. Moreover, the F5 debug showed "pointed: , param2: 0" (i.e. the empty string). The reason was `ContentFeatures& get(content_t c)` only returning the ContentFeatures from the Unknown Node if the content ID iff the content ID was < 125, due to the positioning of the Air, Ignore and Unknown Node's Content Features. Otherwise, it reads from ID/nodename map, from an entry in which everything, including `name` is unassigned. `no_texture.png` is the fallback for empty texture field, and the empty string is also the default of `name` which explains the F5 oddity.

Since the content ID can change after every load, this also explains why this bug happens sporadically. Singleplayer vs multiplayer does NOT cause the bug.

The check in array bounds in this function was correct, but incomplete. Therefore, my fix is to also check if `.name` in the ContentFeatures is empty. Because if it is empty, that means it was not assigned before and must therefore be an unknown node.

Thanks to @sfan5's important analysis on this.

## How to test

Create a dummy game with a mod `minimod` with this code in the `init.lua`:

```
local NODES_COUNT = 256

for i=0,NODES_COUNT-1 do
	minetest.register_node("minimod:badnode"..string.format("%03d", i), {
		tiles = { "logo.png" },
		groups = { dig_immediate = 3 },
	})
end

minetest.register_on_mods_loaded(function()
	-- Print list of content IDs
	local nodelist = {}
	for node, _ in pairs(minetest.registered_nodes) do
		table.insert(nodelist, node)
	end
	table.sort(nodelist)
	for i=1, #nodelist do
		local node = nodelist[i]
		local id = minetest.get_content_id(node)
		minetest.log("error", id..": "..node)
	end
end)


minetest.register_chatcommand("place_nodes", {
	privs = {server=true},
	func = function(name, param)
		local pos = vector.zero()
		local row = 0
		for i=0,NODES_COUNT-1 do
			minetest.set_node(pos, {name="minimod:badnode"..string.format("%03d", i)})
			pos.x = pos.x + 2
			row = row + 1
			if row >= 16 then
				row = 0
				pos.x = 0
				pos.z = pos.z + 2
			end
		end
		return true
	end,
})
```

* Start the world, enable fly, teleport to 0,0,0
* `/place_nodes`. This creates a 16×16 node grid with 256 nodes total. The Minetest logo (`logo.png`) should be visible.
* Leave the world
* In the code, set `NODES_COUNT = 0`.
* Start the world again

EXPECTED BUG-FREE BEHAVIOR: Every node of the 256 nodes shows the `unknown_node.png` texture
CURRENT BUGGY BEHAVIOR: 125 nodes of the 256 nodes show the `no_texture.png` texture, the rest shows `unknown_node.png`. The affected nodes can differ per-launch.

Feel free to repeat this test with other values for `NODES_COUNT`.