### PR TITLE
Fixes to android build. Add option to turn LuaJIT on/off for testing purposes

### DIFF
--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -34,10 +34,14 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
+import androidx.annotation.Keep;
 import androidx.appcompat.app.AlertDialog;
 
 import java.util.Objects;
 
+// Native code finds these methods by name (see porting_android.cpp).
+// This annotation prevents the minifier/Proguard from mangling them.
+@Keep
 public class GameActivity extends NativeActivity {
 	static {
 		System.loadLibrary("c++_shared");

--- a/lib/lua/src/lgc.c
+++ b/lib/lua/src/lgc.c
@@ -164,13 +164,8 @@ static int traversetable (global_State *g, Table *h) {
     markobject(g, h->metatable);
   mode = gfasttm(g, h->metatable, TM_MODE);
   if (mode && ttisstring(mode)) {  /* is there a weak mode? */
-    // Android's 'FORTIFY libc' calls __builtin_object_size on the argument of strchr.
-    // This produces an incorrect size for the expression `svalue(mode)`, causing
-    // an assertion. By placing it in a temporary, __builtin_object_size returns
-    // -1 (for unknown size) which functions correctly.
-    const char *tmp = svalue(mode);
-    weakkey = (strchr(tmp, 'k') != NULL);
-    weakvalue = (strchr(tmp, 'v') != NULL);
+    weakkey = (strchr(svalue(mode), 'k') != NULL);
+    weakvalue = (strchr(svalue(mode), 'v') != NULL);
     if (weakkey || weakvalue) {  /* is really weak? */
       h->marked &= ~(KEYWEAK | VALUEWEAK);  /* clear bits */
       h->marked |= cast_byte((weakkey << KEYWEAKBIT) |


### PR DESCRIPTION
Related to https://github.com/minetest/minetest/issues/12062

1) Added an annotation to GameActivity.java that is needed to make the Release build work with the newer Android toolchains that have minification.

2) Added the ability to switch between LuaJIT and PUC Lua. This was helpful for determining where the problem crash was occurring. This includes a fix to lib/lua/src/lgc.c which is needed to prevent a miscompile.