### PR TITLE
Fix lighting of upright_sprite entities

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -905,12 +905,8 @@ void GenericCAO::setNodeLight(const video::SColor &light_color)
 		if (m_prop.visual == "upright_sprite") {
 			if (!m_meshnode)
 				return;
-
-			scene::IMesh *mesh = m_meshnode->getMesh();
-			for (u32 i = 0; i < mesh->getMeshBufferCount(); ++i) {
-				scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
-				buf->getMaterial().EmissiveColor = light_color;
-			}
+			for (u32 i = 0; i < m_meshnode->getMaterialCount(); ++i)
+				m_meshnode->getMaterial(i).EmissiveColor = light_color;
 		} else {
 			scene::ISceneNode *node = getSceneNode();
 			if (!node)


### PR DESCRIPTION
The goal is to fix lighting of upright_sprite entities broken in cef252b755277cf5b9eb0605629f294087ebb344. Upright sprite entities (icons on [drawers](https://content.minetest.net/packages/LNJ/drawers/) or player entity in devtest game) would not take light of the current node into account when shaders are enabled and always be drawn in full brightness.

Example devtest player in a dark cave;
![image](https://user-images.githubusercontent.com/4933697/169604125-e6ac84f5-f259-4d31-bdad-242a6b4a1b40.png)



cef252b755277cf5b9eb0605629f294087ebb344 removed a call to IMeshSceneNode::setReadOnlyMaterials(true), meaning that materials in IMeshSceneNode would take precedence over the materials of its mesh buffers. GenericCAO::setNodeLight() was still using mesh buffer materials directly.

This PR changes GenericCAO::setNodeLight() to work with IMeshSceneNode materials via getMaterial() call.

## To do

This PR is a Ready for Review.

## How to test

1. Start devtest
2. Go underground
3. Switch camera to 3rd person mode
4. Player entity must be black due to no light nearby.
