### PR TITLE
Add missing comma in example in lua_api.txt

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2011,7 +2011,7 @@ Example definition of the capabilities of an item
         max_drop_level=1,
         groupcaps={
             crumbly={maxlevel=2, uses=20, times={[1]=1.60, [2]=1.20, [3]=0.80}}
-        }
+        },
         damage_groups = {fleshy=2},
     }
 


### PR DESCRIPTION
Fixes #3864.

I looked at this issue and searched for any errors in the documentation regarding the `tool_capabilities` documentation. The only mistake I could find was a missing comma in the code example. Everything else, including the numbers presented in this example, seems correct; I have verified it by testing.