### PR TITLE
Fix lighting of the wield mesh

### DIFF
--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -47,7 +47,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 Camera::Camera(MapDrawControl &draw_control, Client *client, RenderingEngine *rendering_engine):
 	m_draw_control(draw_control),
-	m_client(client)
+	m_client(client),
+	m_player_light_color(0xFFFFFFFF)
 {
 	auto smgr = rendering_engine->get_scene_manager();
 	// note: making the camera node a child of the player node
@@ -153,8 +154,10 @@ void Camera::step(f32 dtime)
 	bool was_under_zero = m_wield_change_timer < 0;
 	m_wield_change_timer = MYMIN(m_wield_change_timer + dtime, 0.125);
 
-	if (m_wield_change_timer >= 0 && was_under_zero)
+	if (m_wield_change_timer >= 0 && was_under_zero) {
 		m_wieldnode->setItem(m_wield_item_next, m_client);
+		m_wieldnode->setNodeLightColor(m_player_light_color);
+	}
 
 	if (m_view_bobbing_state != 0)
 	{
@@ -555,7 +558,8 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 tool_reload_ratio)
 	m_wieldnode->setPosition(wield_position);
 	m_wieldnode->setRotation(wield_rotation);
 
-	m_wieldnode->setNodeLightColor(player->light_color);
+	m_player_light_color = player->light_color;
+	m_wieldnode->setNodeLightColor(m_player_light_color);
 
 	// Set render distance
 	updateViewingRange();

--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -264,4 +264,7 @@ private:
 
 	std::list<Nametag *> m_nametags;
 	bool m_show_nametag_backgrounds;
+
+	// Last known light color of the player
+	video::SColor m_player_light_color;
 };

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -305,6 +305,7 @@ void ClientEnvironment::step(float dtime)
 		node_at_lplayer = m_map->getNode(p);
 
 		u16 light = getInteriorLight(node_at_lplayer, 0, m_client->ndef());
+		lplayer->light_color = encode_light(light, 0); // this transfers light.alpha
 		final_color_blend(&lplayer->light_color, light, day_night_ratio);
 	}
 


### PR DESCRIPTION
Fixes #12338 and removes flicker of wield mesh light when changing current item.

## To do

This PR is Ready for Review.

## How to test

###Scenario 1
1. Start any game
2. Switch time to night
3. Place a light
4. Wielded item must be lit near the light and dark far from lights / underground

## Scenario 2
1. Start any game
2. Switch the current item 
3. Notice that wield mesh changes without becoming black