### PR TITLE
Make std::pair hashable

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -425,15 +425,7 @@ private:
 		std::unordered_set<session_t> waiting_players;
 	};
 
-	// the standard library does not implement std::hash for pairs so we have this:
-	struct SBCHash {
-		size_t operator() (const std::pair<v3s16, u16> &p) const {
-			return (((size_t) p.first.X) << 48) | (((size_t) p.first.Y) << 32) |
-				(((size_t) p.first.Z) << 16) | ((size_t) p.second);
-		}
-	};
-
-	typedef std::unordered_map<std::pair<v3s16, u16>, std::string, SBCHash> SerializedBlockCache;
+	typedef std::unordered_map<std::pair<v3s16, u16>, std::string> SerializedBlockCache;
 
 	void init();
 

--- a/src/util/container.h
+++ b/src/util/container.h
@@ -305,3 +305,23 @@ private:
 	// we can't use std::deque here, because its iterators get invalidated
 	std::list<K> m_queue;
 };
+
+inline size_t scrambleBits(size_t h, size_t randPrime1, size_t randPrime2) {
+	// Multiplication is very good at scrambling upper bits, less so lower bits.
+	// So move one set of upper bits lower.
+	size_t halfSizeT = sizeof(size_t) * 4;
+	size_t s1 = h * randPrime1;
+	size_t s2 = h * randPrime2;
+	return s1 ^ (s2 >> halfSizeT);
+}
+
+// Make std::pair hashable
+template<typename T, typename S>
+struct std::hash<std::pair<T, S> > {
+	size_t operator()(const std::pair<T, S> &pair) const
+	{
+		size_t h1 = std::hash<T>()(pair.first);
+		size_t h2 = std::hash<S>()(pair.second);
+		return h1 ^ scrambleBits(h2, 879788123, 1546275799);
+        }
+};


### PR DESCRIPTION
Suggested replacement for SBCHash.

Hashable std::pair should be safe in general as long as pairs are not modified while the key in a the container.