### PR TITLE
Allow printf-style exception messages

### DIFF
--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -82,8 +82,7 @@ video::ITexture *guiScalingResizeCached(video::IVideoDriver *driver,
 		return src;
 
 	// Calculate scaled texture name.
-	char rectstr[200];
-	porting::mt_snprintf(rectstr, sizeof(rectstr), "%d:%d:%d:%d:%d:%d",
+	std::string rectstr = StringPrintf("%d:%d:%d:%d:%d:%d",
 		srcrect.UpperLeftCorner.X,
 		srcrect.UpperLeftCorner.Y,
 		srcrect.getWidth(),
@@ -91,7 +90,7 @@ video::ITexture *guiScalingResizeCached(video::IVideoDriver *driver,
 		destrect.getWidth(),
 		destrect.getHeight());
 	io::path origname = src->getName().getPath();
-	io::path scalename = origname + "@guiScalingFilter:" + rectstr;
+	io::path scalename = origname + "@guiScalingFilter:" + rectstr.c_str();
 
 	// Search for existing scaled texture.
 	auto it_txr = g_txrCache.find(scalename);

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -26,12 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h"
 #include "util/basic_macros.h"
 
-class UnknownKeycode : public BaseException
-{
-public:
-	UnknownKeycode(const char *s) :
-		BaseException(s) {};
-};
+DEFINE_EXCEPTION(UnknownKeycode);
 
 struct table_key {
 	const char *Name;
@@ -252,7 +247,7 @@ struct table_key lookup_keyname(const char *name)
 			return table_key;
 	}
 
-	throw UnknownKeycode(name);
+	throw UnknownKeycode("%s", name);
 }
 
 struct table_key lookup_keykey(irr::EKEY_CODE key)
@@ -262,9 +257,7 @@ struct table_key lookup_keykey(irr::EKEY_CODE key)
 			return table_key;
 	}
 
-	std::ostringstream os;
-	os << "<Keycode " << (int) key << ">";
-	throw UnknownKeycode(os.str().c_str());
+	throw UnknownKeycode("<Keycode %d>", key);
 }
 
 struct table_key lookup_keychar(wchar_t Char)
@@ -274,9 +267,8 @@ struct table_key lookup_keychar(wchar_t Char)
 			return table_key;
 	}
 
-	std::ostringstream os;
-	os << "<Char " << hex_encode((char*) &Char, sizeof(wchar_t)) << ">";
-	throw UnknownKeycode(os.str().c_str());
+	throw UnknownKeycode("<Char %s>",
+		hex_encode((char*) &Char, sizeof(wchar_t)).c_str());
 }
 
 KeyPress::KeyPress(const char *name)

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -33,7 +33,7 @@ public:
 	// Supports printf-like exception creation, example:
 	//   throw MyException("Invalid value: %d", value);
 	PRINTF_ATTR(2, 3)
-	explicit BaseException(const char *format, ...) noexcept
+	explicit BaseException(PRINTF_FORMAT_PREFIX const char *format, ...) noexcept
 	{
 		va_list ap;
 		va_start(ap, format);
@@ -59,7 +59,7 @@ protected:
 		ClassName(const std::string &s) noexcept : BaseException(s) { } \
 		ClassName(std::string &&s) noexcept : BaseException(std::move(s)) { } \
 		PRINTF_ATTR(2, 3) \
-		explicit ClassName(const char *format, ...) noexcept : \
+		explicit ClassName(PRINTF_FORMAT_PREFIX const char *format, ...) noexcept : \
 			BaseException(std::string()) \
 		{ \
 			va_list ap; \

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -19,17 +19,29 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <cstdarg>
 #include <exception>
 #include <string>
-
+#include <util/string.h>
 
 class BaseException : public std::exception
 {
 public:
-	BaseException(const std::string &s) throw(): m_s(s) {}
-	~BaseException() throw() = default;
+	BaseException(const std::string &s) noexcept : m_s(s) {}
+	BaseException(std::string &&s) noexcept : m_s(std::move(s)) {}
 
-	virtual const char * what() const throw()
+	// Supports printf-like exception creation, example:
+	//   throw MyException("Invalid value: %d", value);
+	PRINTF_ATTR(2, 3)
+	explicit BaseException(const char *format, ...) noexcept
+	{
+		va_list ap;
+		va_start(ap, format);
+		m_s = VStringPrintf(format, ap);
+		va_end(ap);
+	}
+
+	virtual const char * what() const noexcept
 	{
 		return m_s.c_str();
 	}
@@ -37,90 +49,54 @@ protected:
 	std::string m_s;
 };
 
-class AlreadyExistsException : public BaseException {
-public:
-	AlreadyExistsException(const std::string &s): BaseException(s) {}
-};
-
-class VersionMismatchException : public BaseException {
-public:
-	VersionMismatchException(const std::string &s): BaseException(s) {}
-};
-
-class FileNotGoodException : public BaseException {
-public:
-	FileNotGoodException(const std::string &s): BaseException(s) {}
-};
-
-class DatabaseException : public BaseException {
-public:
-	DatabaseException(const std::string &s): BaseException(s) {}
-};
-
-class SerializationError : public BaseException {
-public:
-	SerializationError(const std::string &s): BaseException(s) {}
-};
-
-class PacketError : public BaseException {
-public:
-	PacketError(const std::string &s): BaseException(s) {}
-};
-
-class SettingNotFoundException : public BaseException {
-public:
-	SettingNotFoundException(const std::string &s): BaseException(s) {}
-};
-
-class ItemNotFoundException : public BaseException {
-public:
-	ItemNotFoundException(const std::string &s): BaseException(s) {}
-};
-
-class ServerError : public BaseException {
-public:
-	ServerError(const std::string &s): BaseException(s) {}
-};
-
-class ClientStateError : public BaseException {
-public:
-	ClientStateError(const std::string &s): BaseException(s) {}
-};
-
-class PrngException : public BaseException {
-public:
-	PrngException(const std::string &s): BaseException(s) {}
-};
-
-class ModError : public BaseException {
-public:
-	ModError(const std::string &s): BaseException(s) {}
-};
-
-
 /*
-	Some "old-style" interrupts:
-*/
+ * Clang supports C++11 Constructor Delegation with printf-style constructors,
+ * but GCC doesn't. So this macro is required for now.
+ */
+#define DEFINE_EXCEPTION_BASE(ClassName, EXTRA_CONSTRUCTORS) \
+	class ClassName : public BaseException { \
+	public: \
+		ClassName(const std::string &s) noexcept : BaseException(s) { } \
+		ClassName(std::string &&s) noexcept : BaseException(std::move(s)) { } \
+		PRINTF_ATTR(2, 3) \
+		explicit ClassName(const char *format, ...) noexcept : \
+			BaseException(std::string()) \
+		{ \
+			va_list ap; \
+			va_start(ap, format); \
+			m_s = VStringPrintf(format, ap); \
+			va_end(ap); \
+		} \
+		EXTRA_CONSTRUCTORS \
+	};
 
-class InvalidNoiseParamsException : public BaseException {
-public:
-	InvalidNoiseParamsException():
-		BaseException("One or more noise parameters were invalid or require "
-			"too much memory")
-	{}
+#define DEFINE_EXCEPTION(ClassName) \
+	DEFINE_EXCEPTION_BASE(ClassName,)
 
-	InvalidNoiseParamsException(const std::string &s):
-		BaseException(s)
-	{}
-};
+// Includes a default constructor with predefined text.
+#define DEFINE_EXCEPTION_DEFTEXT(ClassName, DefaultText) \
+	DEFINE_EXCEPTION_BASE(ClassName, \
+		ClassName() : BaseException(std::string(DefaultText)) { } \
+	)
 
-class InvalidPositionException : public BaseException
-{
-public:
-	InvalidPositionException():
-		BaseException("Somebody tried to get/set something in a nonexistent position.")
-	{}
-	InvalidPositionException(const std::string &s):
-		BaseException(s)
-	{}
-};
+
+DEFINE_EXCEPTION(AlreadyExistsException)
+DEFINE_EXCEPTION(VersionMismatchException)
+DEFINE_EXCEPTION(FileNotGoodException)
+DEFINE_EXCEPTION(DatabaseException)
+DEFINE_EXCEPTION(SerializationError)
+DEFINE_EXCEPTION(PacketError)
+DEFINE_EXCEPTION(SettingNotFoundException)
+DEFINE_EXCEPTION(ItemNotFoundException)
+DEFINE_EXCEPTION(ServerError)
+DEFINE_EXCEPTION(ClientStateError)
+DEFINE_EXCEPTION(PrngException)
+DEFINE_EXCEPTION(ModError)
+
+DEFINE_EXCEPTION_DEFTEXT(
+	InvalidNoiseParamsException,
+	"One or more noise parameters were invalid or require too much memory")
+
+DEFINE_EXCEPTION_DEFTEXT(
+	InvalidPositionException,
+	"Somebody tried to get/set something in a nonexistent position.")

--- a/src/gui/profilergraph.cpp
+++ b/src/gui/profilergraph.cpp
@@ -95,20 +95,20 @@ void ProfilerGraph::draw(s32 x_left, s32 y_bottom, video::IVideoDriver *driver,
 		}
 
 		const s32 texth = 15;
-		char buf[10];
+		std::string buf;
 		if (floorf(show_max) == show_max)
-			porting::mt_snprintf(buf, sizeof(buf), "%.5g", show_max);
+			buf = StringPrintf("%.5g", show_max);
 		else
-			porting::mt_snprintf(buf, sizeof(buf), "%.3g", show_max);
+			buf = StringPrintf("%.3g", show_max);
 		font->draw(utf8_to_wide(buf).c_str(),
 				core::rect<s32>(textx, y - graphh, textx2,
 						y - graphh + texth),
 				meta.color);
 
 		if (floorf(show_min) == show_min)
-			porting::mt_snprintf(buf, sizeof(buf), "%.5g", show_min);
+			buf = StringPrintf("%.5g", show_min);
 		else
-			porting::mt_snprintf(buf, sizeof(buf), "%.3g", show_min);
+			buf = StringPrintf("%.3g", show_min);
 		font->draw(utf8_to_wide(buf).c_str(),
 				core::rect<s32>(textx, y - texth, textx2, y), meta.color);
 

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -826,9 +826,7 @@ std::string analyze_block(MapBlock *block)
 	std::ostringstream desc;
 
 	v3s16 p = block->getPos();
-	char spos[25];
-	porting::mt_snprintf(spos, sizeof(spos), "(%2d,%2d,%2d), ", p.X, p.Y, p.Z);
-	desc<<spos;
+	desc << StringPrintf("(%2d,%2d,%2d), ", p.X, p.Y, p.Z);
 
 	switch(block->getModified())
 	{

--- a/src/network/address.cpp
+++ b/src/network/address.cpp
@@ -129,7 +129,7 @@ void Address::Resolve(const char *name)
 	// Do getaddrinfo()
 	int e = getaddrinfo(name, NULL, &hints, &resolved);
 	if (e != 0)
-		throw ResolveError(gai_strerror(e));
+		throw ResolveError("%s", gai_strerror(e));
 
 	// Copy data
 	if (resolved->ai_family == AF_INET) {

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -1080,7 +1080,7 @@ SharedBuffer<u8> ConnectionReceiveThread::processPacket(Channel *channel,
 	if (MAX_UDP_PEERS <= 65535 && peer_id >= MAX_UDP_PEERS) {
 		std::string errmsg = "Invalid peer_id=" + itos(peer_id);
 		errorstream << errmsg << std::endl;
-		throw InvalidIncomingDataException(errmsg.c_str());
+		throw InvalidIncomingDataException(errmsg);
 	}
 
 	if (type >= PACKET_TYPE_MAX) {

--- a/src/network/networkexceptions.h
+++ b/src/network/networkexceptions.h
@@ -26,75 +26,17 @@ namespace con
 /*
 	Exceptions
 */
-class NotFoundException : public BaseException
-{
-public:
-	NotFoundException(const char *s) : BaseException(s) {}
-};
+DEFINE_EXCEPTION(NotFoundException);
+DEFINE_EXCEPTION(PeerNotFoundException);
+DEFINE_EXCEPTION(ConnectionException);
+DEFINE_EXCEPTION(ConnectionBindFailed);
+DEFINE_EXCEPTION(InvalidIncomingDataException);
+DEFINE_EXCEPTION(NoIncomingDataException);
+DEFINE_EXCEPTION(ProcessedSilentlyException);
+DEFINE_EXCEPTION(ProcessedQueued);
+DEFINE_EXCEPTION(IncomingDataCorruption);
+} // namespace con
 
-class PeerNotFoundException : public BaseException
-{
-public:
-	PeerNotFoundException(const char *s) : BaseException(s) {}
-};
-
-class ConnectionException : public BaseException
-{
-public:
-	ConnectionException(const char *s) : BaseException(s) {}
-};
-
-class ConnectionBindFailed : public BaseException
-{
-public:
-	ConnectionBindFailed(const char *s) : BaseException(s) {}
-};
-
-class InvalidIncomingDataException : public BaseException
-{
-public:
-	InvalidIncomingDataException(const char *s) : BaseException(s) {}
-};
-
-class NoIncomingDataException : public BaseException
-{
-public:
-	NoIncomingDataException(const char *s) : BaseException(s) {}
-};
-
-class ProcessedSilentlyException : public BaseException
-{
-public:
-	ProcessedSilentlyException(const char *s) : BaseException(s) {}
-};
-
-class ProcessedQueued : public BaseException
-{
-public:
-	ProcessedQueued(const char *s) : BaseException(s) {}
-};
-
-class IncomingDataCorruption : public BaseException
-{
-public:
-	IncomingDataCorruption(const char *s) : BaseException(s) {}
-};
-}
-
-class SocketException : public BaseException
-{
-public:
-	SocketException(const std::string &s) : BaseException(s) {}
-};
-
-class ResolveError : public BaseException
-{
-public:
-	ResolveError(const std::string &s) : BaseException(s) {}
-};
-
-class SendFailedException : public BaseException
-{
-public:
-	SendFailedException(const std::string &s) : BaseException(s) {}
-};
+DEFINE_EXCEPTION(SocketException);
+DEFINE_EXCEPTION(ResolveError);
+DEFINE_EXCEPTION(SendFailedException);

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -154,7 +154,7 @@ void UDPSocket::Bind(Address addr)
 		const char *errmsg =
 				"Socket and bind address families do not match";
 		errorstream << "Bind failed: " << errmsg << std::endl;
-		throw SocketException(errmsg);
+		throw SocketException("%s", errmsg);
 	}
 
 	int ret = 0;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -654,22 +654,22 @@ void ContentFeatures::deSerialize(std::istream &is)
 
 		u8 tmp = readU8(is);
 		if (is.eof()) /* readU8 doesn't throw exceptions so we have to do this */
-			throw SerializationError("");
+			throw SerializationError("EOF");
 		leveled_max = tmp;
 
 		tmp = readU8(is);
 		if (is.eof())
-			throw SerializationError("");
+			throw SerializationError("EOF");
 		alpha = static_cast<enum AlphaMode>(tmp);
 
 		tmp = readU8(is);
 		if (is.eof())
-			throw SerializationError("");
+			throw SerializationError("EOF");
 		move_resistance = tmp;
 
 		tmp = readU8(is);
 		if (is.eof())
-			throw SerializationError("");
+			throw SerializationError("EOF");
 		liquid_move_physics = tmp;
 	} catch(SerializationError &e) {};
 }

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "profiler.h"
+#include "util/string.h"
 #include "porting.h"
 
 static Profiler main_profiler;
@@ -137,7 +138,6 @@ int Profiler::print(std::ostream &o, u32 page, u32 pagecount)
 {
 	GraphValues values;
 	getPage(values, page, pagecount);
-	char num_buf[50];
 
 	for (const auto &i : values) {
 		o << "  " << i.first << " ";
@@ -153,9 +153,7 @@ int Profiler::print(std::ostream &o, u32 page, u32 pagecount)
 			else
 				o << " ";
 		}
-		porting::mt_snprintf(num_buf, sizeof(num_buf), "% 4ix % 3g",
-				getAvgCount(i.first), i.second);
-		o << num_buf << std::endl;
+		o << StringPrintf("% 4ix % 3g", getAvgCount(i.first), i.second) << std::endl;
 	}
 	return values.size();
 }

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -86,12 +86,9 @@ void script_error(lua_State *L, int pcall_result, const char *mod, const char *f
 	if (!err_descr)
 		err_descr = "<no description>";
 
-	char buf[256];
-	porting::mt_snprintf(buf, sizeof(buf), "%s error from mod '%s' in callback %s(): ",
-		err_type, mod, fxn);
-
-	std::string err_msg(buf);
-	err_msg += err_descr;
+	std::string err_msg = StringPrintf(
+		"%s error from mod '%s' in callback %s(): %s",
+		err_type, mod, fxn, err_descr);
 
 	if (pcall_result == LUA_ERRMEM) {
 		err_msg += "\nCurrent Lua memory usage: "

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -325,9 +325,7 @@ void ScriptApiBase::stackDump(std::ostream &o)
 				o << (readParam<bool>(m_luastack, i) ? "true" : "false");
 				break;
 			case LUA_TNUMBER:  /* numbers */ {
-				char buf[10];
-				porting::mt_snprintf(buf, sizeof(buf), "%lf", lua_tonumber(m_luastack, i));
-				o << buf;
+				o << StringPrintf("%lf", lua_tonumber(m_luastack, i));
 				break;
 			}
 			default:  /* other values */

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -71,13 +71,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "database/database-dummy.h"
 #include "gameparams.h"
 
-class ClientNotFoundException : public BaseException
-{
-public:
-	ClientNotFoundException(const char *s):
-		BaseException(s)
-	{}
-};
+DEFINE_EXCEPTION(ClientNotFoundException);
 
 class ServerThread : public Thread
 {

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1895,12 +1895,10 @@ static void print_hexdump(std::ostream &o, const std::string &data)
 		}
 		for(int di=0; di<linelength; di++){
 			int i = i0 + di;
-			char buf[4];
 			if(di<thislinelength)
-				porting::mt_snprintf(buf, sizeof(buf), "%.2x ", data[i]);
+				o << StringPrintf("%.2x ", data[i]);
 			else
-				porting::mt_snprintf(buf, sizeof(buf), "   ");
-			o<<buf;
+				o << "   ";
 		}
 		o<<" ";
 		for(int di=0; di<thislinelength; di++){

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -8,6 +8,7 @@ set (UNITTEST_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/test_collision.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_compression.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_connection.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/test_exceptions.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_filepath.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_inventory.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_irrptr.cpp

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -327,10 +327,7 @@ std::string TestBase::getTestTempDirectory()
 	if (!m_test_dir.empty())
 		return m_test_dir;
 
-	char buf[32];
-	porting::mt_snprintf(buf, sizeof(buf), "%08X", myrand());
-
-	m_test_dir = fs::TempPath() + DIR_DELIM "mttest_" + buf;
+	m_test_dir = fs::TempPath() + DIR_DELIM "mttest_" + StringPrintf("%08X", myrand());
 	if (!fs::CreateDir(m_test_dir))
 		throw TestFailedException();
 
@@ -339,10 +336,7 @@ std::string TestBase::getTestTempDirectory()
 
 std::string TestBase::getTestTempFile()
 {
-	char buf[32];
-	porting::mt_snprintf(buf, sizeof(buf), "%08X", myrand());
-
-	return getTestTempDirectory() + DIR_DELIM + buf + ".tmp";
+	return getTestTempDirectory() + DIR_DELIM + StringPrintf("%08X", myrand()) + ".tmp";
 }
 
 

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -315,10 +315,8 @@ void TestConnection::testConnectSendReceive()
 		for (int i = 0; i < datasize && i < 20; i++) {
 			if (i % 2 == 0)
 				infostream << " ";
-			char buf[10];
-			porting::mt_snprintf(buf, sizeof(buf), "%.2X",
+			infostream << StringPrintf("%.2X",
 				((int)((const char *)pkt.getU8Ptr(0))[i]) & 0xff);
-			infostream<<buf;
 		}
 		if (datasize > 20)
 			infostream << "...";
@@ -358,9 +356,7 @@ void TestConnection::testConnectSendReceive()
 		for (int i = 0; i < size && i < 20; i++) {
 			if (i % 2 == 0)
 				infostream << " ";
-			char buf[10];
-			porting::mt_snprintf(buf, sizeof(buf), "%.2X", ((int)(recvdata[i])) & 0xff);
-			infostream << buf;
+			infostream << StringPrintf("%.2X", ((int)(recvdata[i])) & 0xff);
 		}
 		if (size > 20)
 			infostream << "...";

--- a/src/unittest/test_exceptions.cpp
+++ b/src/unittest/test_exceptions.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "test.h"
 #include "util/string.h"
+#include "gettext.h"
 #include "exceptions.h"
 
 class TestExceptions : public TestBase
@@ -30,6 +31,7 @@ public:
 	void runTests(IGameDef *gamedef);
 
 	void testConstructors();
+	void testStringPrintf();
 };
 
 static TestExceptions g_test_instance;
@@ -37,6 +39,7 @@ static TestExceptions g_test_instance;
 void TestExceptions::runTests(IGameDef *gamedef)
 {
 	TEST(testConstructors);
+	TEST(testStringPrintf);
 }
 
 DEFINE_EXCEPTION(CustomException1)
@@ -79,4 +82,11 @@ void TestExceptions::testConstructors()
 	} catch (const CustomException2 &e) {
 		UASSERTEQ(std::string, e.what(), "The Default Message");
 	}
+}
+
+void TestExceptions::testStringPrintf()
+{
+	std::string bigstr(10000, 'x');
+	std::string s = fmtgettext("%s", bigstr.c_str());
+	UASSERTEQ(size_t, s.size(), bigstr.size());
 }

--- a/src/unittest/test_exceptions.cpp
+++ b/src/unittest/test_exceptions.cpp
@@ -1,0 +1,82 @@
+/*
+Minetest
+Copyright (C) 2021 The Minetest Authors
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "test.h"
+#include "util/string.h"
+#include "exceptions.h"
+
+class TestExceptions : public TestBase
+{
+public:
+	TestExceptions() { TestManager::registerTestModule(this); }
+	const char *getName() { return "TestExceptions"; }
+
+	void runTests(IGameDef *gamedef);
+
+	void testConstructors();
+};
+
+static TestExceptions g_test_instance;
+
+void TestExceptions::runTests(IGameDef *gamedef)
+{
+	TEST(testConstructors);
+}
+
+DEFINE_EXCEPTION(CustomException1)
+DEFINE_EXCEPTION_DEFTEXT(CustomException2, "The Default Message")
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TestExceptions::testConstructors()
+{
+	// Test printf-style constructor
+	size_t a = 123;
+	std::string msg = "!!!";
+	try {
+		throw BaseException("Size=%zu and msg=%s", a, msg.c_str());
+		UASSERT(false);
+	} catch (const BaseException &e) {
+		UASSERTEQ(std::string, e.what(), "Size=123 and msg=!!!");
+	}
+
+	// Test std::string constructor
+	try {
+		throw BaseException(std::string("Test std::string"));
+		UASSERT(false);
+	} catch (const BaseException &e) {
+		UASSERTEQ(std::string, e.what(), "Test std::string");
+	}
+
+	// Test custom exception
+	try {
+		throw CustomException1("Test 1");
+		UASSERT(false);
+	} catch (const CustomException1 &e) {
+		UASSERTEQ(std::string, e.what(), "Test 1");
+	}
+
+	// Test exception with default message
+	try {
+		throw CustomException2();
+		UASSERT(false);
+	} catch (const CustomException2 &e) {
+		UASSERTEQ(std::string, e.what(), "The Default Message");
+	}
+}

--- a/src/util/ieee_float.cpp
+++ b/src/util/ieee_float.cpp
@@ -24,7 +24,7 @@
  */
 #include "ieee_float.h"
 #include "log.h"
-#include "porting.h"
+#include "util/string.h"
 #include <limits>
 #include <cmath>
 
@@ -107,17 +107,16 @@ FloatType getFloatSerializationType()
 	warningstream << "floatSerialization: f32 and u32 endianness are "
 		"not equal or machine is not IEEE-754 compliant" << std::endl;
 	u32 i;
-	char buf[128];
 
 	// NaN checks aren't included in the main loop
 	if (!std::isnan(u32Tof32Slow(0x7FC00000UL))) {
-		porting::mt_snprintf(buf, sizeof(buf),
+		auto buf = StringPrintf(
 			"u32Tof32Slow(0x7FC00000) failed to produce a NaN, actual: %.9g",
 			u32Tof32Slow(0x7FC00000UL));
 		infostream << buf << std::endl;
 	}
 	if (!std::isnan(u32Tof32Slow(0xFFC00000UL))) {
-		porting::mt_snprintf(buf, sizeof(buf),
+		auto buf = StringPrintf(
 			"u32Tof32Slow(0xFFC00000) failed to produce a NaN, actual: %.9g",
 			u32Tof32Slow(0xFFC00000UL));
 		infostream << buf << std::endl;
@@ -126,7 +125,7 @@ FloatType getFloatSerializationType()
 	i = f32Tou32Slow(std::numeric_limits<f32>::quiet_NaN());
 	// check that it corresponds to a NaN encoding
 	if ((i & 0x7F800000UL) != 0x7F800000UL || (i & 0x7FFFFFUL) == 0) {
-		porting::mt_snprintf(buf, sizeof(buf),
+		auto buf = StringPrintf(
 			"f32Tou32Slow(NaN) failed to encode NaN, actual: 0x%X", i);
 		infostream << buf << std::endl;
 	}

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -922,7 +922,8 @@ void safe_print_string(std::ostream &os, const std::string &str)
 	os.setf(flags);
 }
 
-std::string StringPrintf(const char *format, ...)  {
+std::string StringPrintf(const char *format, ...)
+{
 	va_list ap;
 	va_start(ap, format);
 	std::string tmp = VStringPrintf(format, ap);
@@ -930,7 +931,8 @@ std::string StringPrintf(const char *format, ...)  {
 	return tmp;
 }
 
-std::string VStringPrintf(const char *format, va_list args) {
+std::string VStringPrintf(const char *format, va_list args)
+{
 	// Need to iterate through the arguments twice.
 	va_list args1;
 	va_list args2;

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -761,3 +761,16 @@ std::string sanitizeDirName(const std::string &str, const std::string &optional_
  * brackets (e.g. "a\x1eb" -> "a<1e>b").
  */
 void safe_print_string(std::ostream &os, const std::string &str);
+
+/**
+ *
+ * StringPrintf
+ *
+ * Create a std::string using a format string like printf.
+ *
+ */
+#define PRINTF_ATTR(index_of_format, index_of_first_vararg) \
+	__attribute__ ((format (printf, index_of_format, index_of_first_vararg)))
+
+std::string StringPrintf(const char *format, ...) PRINTF_ATTR(1, 2);
+std::string VStringPrintf(const char *format, va_list args);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -762,6 +762,18 @@ std::string sanitizeDirName(const std::string &str, const std::string &optional_
  */
 void safe_print_string(std::ostream &os, const std::string &str);
 
+
+// Tell the compiler that a function has printf-style arguments,
+// so that it can catch safety errors at compile-time.
+#ifdef _MSC_VER
+#define PRINTF_ATTR(index_of_format, index_of_first_vararg)
+#define PRINTF_FORMAT_PREFIX _Printf_format_string_
+#else
+#define PRINTF_ATTR(index_of_format, index_of_first_vararg) \
+	__attribute__ ((format (printf, index_of_format, index_of_first_vararg)))
+#define PRINTF_FORMAT_PREFIX
+#endif
+
 /**
  *
  * StringPrintf
@@ -769,8 +781,6 @@ void safe_print_string(std::ostream &os, const std::string &str);
  * Create a std::string using a format string like printf.
  *
  */
-#define PRINTF_ATTR(index_of_format, index_of_first_vararg) \
-	__attribute__ ((format (printf, index_of_format, index_of_first_vararg)))
 
-std::string StringPrintf(const char *format, ...) PRINTF_ATTR(1, 2);
+std::string StringPrintf(PRINTF_FORMAT_PREFIX const char *format, ...) PRINTF_ATTR(1, 2);
 std::string VStringPrintf(const char *format, va_list args);


### PR DESCRIPTION
Add a constructor to BaseException to allow printf-style exceptions. For example:

```
if (size != expectedSize)
     throw MyException("Got size = %zu, expected %zu", size, expectedSize);
```
While technically not required, since one can always use a stringstream to construct a temporary string, I have an upcoming PR that benefits greater from being able to succinctly construct exception messages like this.