### PR TITLE
Raise default windowed resolution to 1280x720 (720p)

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -666,10 +666,10 @@ viewing_range (Viewing range) int 190 20 4000
 near_plane (Near plane) float 0.1 0 0.25
 
 #    Width component of the initial window size. Ignored in fullscreen mode.
-screen_w (Screen width) int 1024 1
+screen_w (Screen width) int 1280 1
 
 #    Height component of the initial window size. Ignored in fullscreen mode.
-screen_h (Screen height) int 600 1
+screen_h (Screen height) int 720 1
 
 #    Save window size automatically when modified.
 autosave_screensize (Autosave screen size) bool true

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -764,11 +764,11 @@
 
 #    Width component of the initial window size. Ignored in fullscreen mode.
 #    type: int min: 1
-# screen_w = 1024
+# screen_w = 1280
 
 #    Height component of the initial window size. Ignored in fullscreen mode.
 #    type: int min: 1
-# screen_h = 600
+# screen_h = 720
 
 #    Save window size automatically when modified.
 #    type: bool

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -174,8 +174,8 @@ void set_default_settings()
 #if ENABLE_GLES
 	settings->setDefault("near_plane", "0.1");
 #endif
-	settings->setDefault("screen_w", "1024");
-	settings->setDefault("screen_h", "600");
+	settings->setDefault("screen_w", "1280");
+	settings->setDefault("screen_h", "720");
 	settings->setDefault("autosave_screensize", "true");
 	settings->setDefault("fullscreen", "false");
 	settings->setDefault("vsync", "false");


### PR DESCRIPTION
This PR increases the default window resolution from the current 1024x600 to 1280x720 (720p). This is a rather minor increase in size but I feel it significantly improves the margins in the UI and general sizing for people like me who like playing games in windows as compared to maximised or fullscreen (1024x600 looks way too cramped imo, 1280x720 gives it more room to breathe).

It should also be large enough for any screen nowadays. As in, low-end laptops with 1366x768 screens should still be able to comfortably fit the entire game window inside the monitor even when taking into account window handles and taskbars.

![720p_1](https://user-images.githubusercontent.com/60856959/169364829-6a1df94c-55f5-482b-97df-58a32631ffbd.png)
![720p_2](https://user-images.githubusercontent.com/60856959/169364837-56b1b9b2-c81f-4cd9-94b5-776dcbc085ef.png)

## To do
This PR is Ready for Review.

## How to test
:computer: :eyes: 