### PR TITLE
Rework main menu confirmation dialogs

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -245,8 +245,7 @@ end
 
 function confirmation_formspec(message, confirm_id, confirm_label, cancel_id, cancel_label)
 	return "size[10,2.5,true]" ..
-			"label[0.5,0.5;" ..
-			message .. "]" ..
+			"label[0.5,0.5;" .. message .. "]" ..
 			"style[" .. confirm_id .. ";bgcolor=red]" ..
 			"button[0.5,1.5;2.5,0.5;" .. confirm_id .. ";" .. confirm_label .. "]" ..
 			"button[7.0,1.5;2.5,0.5;" .. cancel_id .. ";" .. cancel_label .. "]"

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -242,3 +242,12 @@ function menu_worldmt_legacy(selected)
 		end
 	end
 end
+
+function confirmation_formspec(message, confirm_id, confirm_label, cancel_id, cancel_label)
+	return "size[10,2.5,true]" ..
+			"label[0.5,0.5;" ..
+			message .. "]" ..
+			"style[" .. confirm_id .. ";bgcolor=red]" ..
+			"button[0.5,1.5;2.5,0.5;" .. confirm_id .. ";" .. confirm_label .. "]" ..
+			"button[7.0,1.5;2.5,0.5;" .. cancel_id .. ";" .. cancel_label .. "]"
+end

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -490,12 +490,10 @@ local confirm_overwrite = {}
 function confirm_overwrite.get_formspec()
 	local package = confirm_overwrite.package
 
-	return "size[11.5,4.5,true]" ..
-			"label[2,2;" ..
-			fgettext("\"$1\" already exists. Would you like to overwrite it?", package.name) .. "]"..
-			"style[install;bgcolor=red]" ..
-			"button[3.25,3.5;2.5,0.5;install;" .. fgettext("Overwrite") .. "]" ..
-			"button[5.75,3.5;2.5,0.5;cancel;" .. fgettext("Cancel") .. "]"
+	return confirmation_formspec(
+		fgettext("\"$1\" already exists. Would you like to overwrite it?", package.name),
+		'install', fgettext("Overwrite"),
+		'cancel', fgettext("Cancel"))
 end
 
 function confirm_overwrite.handle_submit(this, fields)

--- a/builtin/mainmenu/dlg_delete_content.lua
+++ b/builtin/mainmenu/dlg_delete_content.lua
@@ -18,15 +18,10 @@
 --------------------------------------------------------------------------------
 
 local function delete_content_formspec(dialogdata)
-	local retval =
-		"size[11.5,4.5,true]" ..
-		"label[2,2;" ..
-		fgettext("Are you sure you want to delete \"$1\"?", dialogdata.content.name) .. "]"..
-		"style[dlg_delete_content_confirm;bgcolor=red]" ..
-		"button[3.25,3.5;2.5,0.5;dlg_delete_content_confirm;" .. fgettext("Delete") .. "]" ..
-		"button[5.75,3.5;2.5,0.5;dlg_delete_content_cancel;" .. fgettext("Cancel") .. "]"
-
-	return retval
+	return confirmation_formspec(
+		fgettext("Are you sure you want to delete \"$1\"?", dialogdata.content.name),
+		'dlg_delete_content_confirm', fgettext("Delete"),
+		'dlg_delete_content_cancel', fgettext("Cancel"))
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/dlg_delete_world.lua
+++ b/builtin/mainmenu/dlg_delete_world.lua
@@ -17,14 +17,10 @@
 
 
 local function delete_world_formspec(dialogdata)
-	local retval =
-		"size[10,2.5,true]" ..
-		"label[0.5,0.5;" ..
-		fgettext("Delete World \"$1\"?", dialogdata.delete_name) .. "]" ..
-		"style[world_delete_confirm;bgcolor=red]" ..
-		"button[0.5,1.5;2.5,0.5;world_delete_confirm;" .. fgettext("Delete") .. "]" ..
-		"button[7.0,1.5;2.5,0.5;world_delete_cancel;" .. fgettext("Cancel") .. "]"
-	return retval
+	return confirmation_formspec(
+		fgettext("Delete World \"$1\"?", dialogdata.delete_name),
+		'world_delete_confirm', fgettext("Delete"),
+		'world_delete_cancel', fgettext("Cancel"))
 end
 
 local function delete_world_buttonhandler(this, fields)


### PR DESCRIPTION
This PR reworks all three confirmation dialogs that exist in the main menu (deleting a world, deleting content and overwriting already existing content from the content browser).

It reworks the hilariously oversized content deletion and overwriting dialogs to be more similar to the delete world dialog, and merges them all into one reusable function since they ended up using the same formspec code anyways minus different text strings.

![dlg_delete_content_new_2](https://user-images.githubusercontent.com/60856959/169369110-f196b45f-2886-46ea-b22b-49d051e491e2.png)

## To do
This PR is Ready for Review.

## How to test
- Delete a world
- Delete content
- Overwrite content

The dialogs should work like they used to before (i.e. no regressions)