### PR TITLE
Quantize light frustum calculations

### DIFF
--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -27,7 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 using m4f = core::matrix4;
 
-static v3f quantize_direction(v3f direction, float step)
+static v3f quantizeDirection(v3f direction, float step)
 {
 
 	float yaw = std::atan2(direction.Z, direction.X);
@@ -44,7 +44,7 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	const float DISTANCE_STEP = BS * 2.0; // 2 meters
 	v3f newCenter;
 	v3f look = cam->getDirection();
-	look = quantize_direction(look, M_PI / 12.0); // 15 degrees
+	look = quantizeDirection(look, M_PI / 12.0); // 15 degrees
 
 	// camera view tangents
 	float tanFovY = tanf(cam->getFovY() * 0.5f);
@@ -79,7 +79,7 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	v3f boundVec = (cam_pos_scene + farCorner * sfFar) - center_scene;
 	float radius = boundVec.getLength();
 	float length = radius * 3.0f;
-	v3f eye_displacement = quantize_direction(direction, M_PI / 2880 /*15 seconds*/) * length;
+	v3f eye_displacement = quantizeDirection(direction, M_PI / 2880 /*15 seconds*/) * length;
 
 	// we must compute the viewmat with the position - the camera offset
 	// but the future_frustum position must be the actual world position

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -27,10 +27,24 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 using m4f = core::matrix4;
 
+static v3f quantize_direction(v3f direction, float step)
+{
+
+	float yaw = std::atan2(direction.Z, direction.X);
+	float pitch = std::asin(direction.Y); // assume look is normalized
+
+	yaw = std::floor(yaw / step) * step;
+	pitch = std::floor(pitch / step) * step;
+
+	return v3f(std::cos(yaw)*std::cos(pitch), std::sin(pitch), std::sin(yaw)*std::cos(pitch));
+}
+
 void DirectionalLight::createSplitMatrices(const Camera *cam)
 {
+	const float DISTANCE_STEP = BS * 2.0; // 2 meters
 	v3f newCenter;
 	v3f look = cam->getDirection();
+	look = quantize_direction(look, M_PI / 12.0); // 15 degrees
 
 	// camera view tangents
 	float tanFovY = tanf(cam->getFovY() * 0.5f);
@@ -42,6 +56,10 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 
 	// adjusted camera positions
 	v3f cam_pos_world = cam->getPosition();
+	cam_pos_world = v3f(
+			floor(cam_pos_world.X / DISTANCE_STEP) * DISTANCE_STEP,
+			floor(cam_pos_world.Y / DISTANCE_STEP) * DISTANCE_STEP,
+			floor(cam_pos_world.Z / DISTANCE_STEP) * DISTANCE_STEP);
 	v3f cam_pos_scene = v3f(cam_pos_world.X - cam->getOffset().X * BS,
 			cam_pos_world.Y - cam->getOffset().Y * BS,
 			cam_pos_world.Z - cam->getOffset().Z * BS);
@@ -61,7 +79,7 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	v3f boundVec = (cam_pos_scene + farCorner * sfFar) - center_scene;
 	float radius = boundVec.getLength();
 	float length = radius * 3.0f;
-	v3f eye_displacement = direction * length;
+	v3f eye_displacement = quantize_direction(direction, M_PI / 2880 /*15 seconds*/) * length;
 
 	// we must compute the viewmat with the position - the camera offset
 	// but the future_frustum position must be the actual world position


### PR DESCRIPTION
Reduces dancing shadows.

Quantization is applied to three variables:
* Camera/player position is truncated to 2-node increments
* Player camera direction is truncated to increments of 15 degrees in Yaw and Pitch
* Light direction is truncated to increments of 0.0625 degrees (approximate angle that sun travels in 15 seconds)

While reducing dancing of the shadows on the grass and tree leaves, the movement of the shadows becomes chunky.

## To do

This PR is  Ready for Review.

## How to test

1. Enable shadows
2. Disable filters or reduce filters
3. Start game
4. Walk and look around, observe less dancing shadows
5. Pause time (set time speed to 0)
6. Walk and look around, there should be almost no dancing shadows.

@lhofhansl @kilbith You use shadows frequently, you feedback is appreciated
@Andrey2470T It might resolve #11743

