### PR TITLE
Real-time per-thread Profiler charts

### DIFF
--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -38,7 +38,7 @@ void ActiveObjectMgr::clear()
 void ActiveObjectMgr::step(
 		float dtime, const std::function<void(ClientActiveObject *)> &f)
 {
-	g_profiler->avg("ActiveObjectMgr: CAO count [#]", m_active_objects.size());
+	g_profiler.avg("ActiveObjectMgr: CAO count [#]", m_active_objects.size());
 	for (auto &ao_it : m_active_objects) {
 		f(ao_it.second);
 	}

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -583,7 +583,7 @@ void Client::step(float dtime)
 		}
 
 		if (num_processed_meshes > 0)
-			g_profiler->graphAdd("num_processed_meshes", num_processed_meshes);
+			g_profiler.graphAdd("num_processed_meshes", num_processed_meshes);
 
 		auto shadow_renderer = RenderingEngine::get_shadow_renderer();
 		if (shadow_renderer && force_update_shadows)
@@ -909,7 +909,7 @@ void Client::ProcessData(NetworkPacket *pkt)
 
 	//infostream<<"Client: received command="<<command<<std::endl;
 	m_packetcounter.add((u16)command);
-	g_profiler->graphAdd("client_received_packets", 1);
+	g_profiler.graphAdd("client_received_packets", 1);
 
 	/*
 		If this check is removed, be sure to change the queue

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -327,7 +327,7 @@ void ClientEnvironment::step(float dtime)
 	/*
 		Step and handle simple objects
 	*/
-	g_profiler->avg("ClientEnv: CSO count [#]", m_simple_objects.size());
+	g_profiler.avg("ClientEnv: CSO count [#]", m_simple_objects.size());
 	for (auto i = m_simple_objects.begin(); i != m_simple_objects.end();) {
 		ClientSimpleObject *simple = *i;
 

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -186,7 +186,7 @@ void ClientMap::getBlocksInViewRange(v3s16 cam_pos_nodes,
 
 void ClientMap::updateDrawList()
 {
-	ScopeProfiler sp(g_profiler, "CM::updateDrawList()", SPT_AVG);
+	ScopeProfiler sp("CM::updateDrawList()");
 
 	m_needs_update_drawlist = false;
 
@@ -302,10 +302,10 @@ void ClientMap::updateDrawList()
 			m_last_drawn_sectors.insert(sp);
 	}
 
-	g_profiler->avg("MapBlock meshes in range [#]", blocks_in_range_with_mesh);
-	g_profiler->avg("MapBlocks occlusion culled [#]", blocks_occlusion_culled);
-	g_profiler->avg("MapBlocks drawn [#]", m_drawlist.size());
-	g_profiler->avg("MapBlocks loaded [#]", blocks_loaded);
+	g_profiler.avg("MapBlock meshes in range [#]", blocks_in_range_with_mesh);
+	g_profiler.avg("MapBlocks occlusion culled [#]", blocks_occlusion_culled);
+	g_profiler.avg("MapBlocks drawn [#]", m_drawlist.size());
+	g_profiler.avg("MapBlocks loaded [#]", blocks_loaded);
 }
 
 void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
@@ -495,20 +495,20 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 		vertex_count += buf->getIndexCount();
 	}
 
-	g_profiler->avg(prefix + "draw meshes [ms]", draw.stop(true));
+	g_profiler.avg(prefix + "draw meshes [ms]", draw.stop(true));
 
 	// Log only on solid pass because values are the same
 	if (pass == scene::ESNRP_SOLID) {
-		g_profiler->avg("renderMap(): animated meshes [#]", mesh_animate_count);
+		g_profiler.avg("renderMap(): animated meshes [#]", mesh_animate_count);
 	}
 
 	if (pass == scene::ESNRP_TRANSPARENT) {
-		g_profiler->avg("renderMap(): transparent buffers [#]", draw_order.size());
+		g_profiler.avg("renderMap(): transparent buffers [#]", draw_order.size());
 	}
 
-	g_profiler->avg(prefix + "vertices drawn [#]", vertex_count);
-	g_profiler->avg(prefix + "drawcalls [#]", drawcall_count);
-	g_profiler->avg(prefix + "material swaps [#]", material_swaps);
+	g_profiler.avg(prefix + "vertices drawn [#]", vertex_count);
+	g_profiler.avg(prefix + "drawcalls [#]", drawcall_count);
+	g_profiler.avg(prefix + "material swaps [#]", material_swaps);
 }
 
 static bool getVisibleBrightness(Map *map, const v3f &p0, v3f dir, float step,
@@ -587,7 +587,7 @@ static bool getVisibleBrightness(Map *map, const v3f &p0, v3f dir, float step,
 int ClientMap::getBackgroundBrightness(float max_d, u32 daylight_factor,
 		int oldvalue, bool *sunlight_seen_result)
 {
-	ScopeProfiler sp(g_profiler, "CM::getBackgroundBrightness", SPT_AVG);
+	ScopeProfiler sp("CM::getBackgroundBrightness");
 	static v3f z_directions[50] = {
 		v3f(-100, 0, 0)
 	};
@@ -835,10 +835,10 @@ void ClientMap::renderMapShadows(video::IVideoDriver *driver,
 	driver->setMaterial(clean); // reset material to defaults
 	driver->draw3DLine(v3f(), v3f(), video::SColor(0));
 
-	g_profiler->avg(prefix + "draw meshes [ms]", draw.stop(true));
-	g_profiler->avg(prefix + "vertices drawn [#]", vertex_count);
-	g_profiler->avg(prefix + "drawcalls [#]", drawcall_count);
-	g_profiler->avg(prefix + "material swaps [#]", material_swaps);
+	g_profiler.avg(prefix + "draw meshes [ms]", draw.stop(true));
+	g_profiler.avg(prefix + "vertices drawn [#]", vertex_count);
+	g_profiler.avg(prefix + "drawcalls [#]", drawcall_count);
+	g_profiler.avg(prefix + "material swaps [#]", material_swaps);
 }
 
 /*
@@ -846,7 +846,7 @@ void ClientMap::renderMapShadows(video::IVideoDriver *driver,
 */
 void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length)
 {
-	ScopeProfiler sp(g_profiler, "CM::updateDrawListShadow()", SPT_AVG);
+	ScopeProfiler sp("CM::updateDrawListShadow()");
 
 	v3s16 cam_pos_nodes = floatToInt(shadow_light_pos, BS);
 	v3s16 p_blocks_min;
@@ -904,15 +904,15 @@ void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir,
 		}
 	}
 
-	g_profiler->avg("SHADOW MapBlock meshes in range [#]", blocks_in_range_with_mesh);
-	g_profiler->avg("SHADOW MapBlocks occlusion culled [#]", blocks_occlusion_culled);
-	g_profiler->avg("SHADOW MapBlocks drawn [#]", m_drawlist_shadow.size());
-	g_profiler->avg("SHADOW MapBlocks loaded [#]", blocks_loaded);
+	g_profiler.avg("SHADOW MapBlock meshes in range [#]", blocks_in_range_with_mesh);
+	g_profiler.avg("SHADOW MapBlocks occlusion culled [#]", blocks_occlusion_culled);
+	g_profiler.avg("SHADOW MapBlocks drawn [#]", m_drawlist_shadow.size());
+	g_profiler.avg("SHADOW MapBlocks loaded [#]", blocks_loaded);
 }
 
 void ClientMap::updateTransparentMeshBuffers()
 {
-	ScopeProfiler sp(g_profiler, "CM::updateTransparentMeshBuffers", SPT_AVG);
+	ScopeProfiler sp("CM::updateTransparentMeshBuffers");
 	u32 sorted_blocks = 0;
 	u32 unsorted_blocks = 0;
 	f32 sorting_distance_sq = pow(m_cache_transparency_sorting_distance * BS, 2.0f);
@@ -941,8 +941,8 @@ void ClientMap::updateTransparentMeshBuffers()
 		}
 	}
 
-	g_profiler->avg("CM::Transparent Buffers - Sorted", sorted_blocks);
-	g_profiler->avg("CM::Transparent Buffers - Unsorted", unsorted_blocks);
+	g_profiler.avg("CM::Transparent Buffers - Sorted", sorted_blocks);
+	g_profiler.avg("CM::Transparent Buffers - Unsorted", unsorted_blocks);
 	m_needs_update_transparent_meshes = false;
 }
 

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -99,7 +99,7 @@ void Clouds::render()
 	//if(SceneManager->getSceneNodeRenderPass() != scene::ESNRP_SOLID)
 		return;
 
-	ScopeProfiler sp(g_profiler, "Clouds::render()", SPT_AVG);
+	ScopeProfiler sp("Clouds::render()");
 
 	int num_faces_to_draw = m_enable_3d ? 6 : 1;
 

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes.h"
 #include <IGUIEnvironment.h>
 #include "gui/guiFormSpecMenu.h"
+#include "gui/stackedareachart.h"
 #include "util/enriched_string.h"
 #include "util/pointedthing.h"
 #include "game.h"
@@ -91,6 +92,12 @@ public:
 	void setChatText(const EnrichedString &chat_text, u32 recent_chat_count);
 	void updateChatSize();
 
+	bool usingProfiler();
+
+	// called every frame (to draw thread charts)
+	void drawProfiler(video::IVideoDriver *driver, gui::IGUIFont *font);
+
+	// called every ~3 seconds
 	void updateProfiler();
 
 	void toggleChat();
@@ -129,7 +136,11 @@ private:
 
 	gui::IGUIStaticText *m_guitext_profiler = nullptr; // Profiler text
 	u8 m_profiler_current_page = 0;
-	const u8 m_profiler_max_page = 3;
+	const u8 m_profiler_print_pages = 3;
+
+	u64 m_profiler_thread_update_time = 0;
+	std::vector<std::string> m_profiler_thread_names;
+	StackedAreaChart m_profiler_thread_chart;
 
 	// Default: "". If other than "": Empty show_formspec packets will only
 	// close the formspec when the formname matches

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -935,7 +935,7 @@ static void updateFastFaceRow(
 
 				makeFastFace(tile, lights[0], lights[1], lights[2], lights[3],
 						pf, sp, face_dir_corrected, scale, dest);
-				g_profiler->avg("Meshgen: Tiles per face [#]", continuous_tiles_count);
+				g_profiler.avg("Meshgen: Tiles per face [#]", continuous_tiles_count);
 			}
 
 			continuous_tiles_count = 1;

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -91,7 +91,7 @@ bool MeshUpdateQueue::addBlock(Map *map, v3s16 p, bool ack_block_to_server, bool
 		cached_blocks.push_back(cacheBlock(map, p + dp,
 				SKIP_UPDATE_IF_ALREADY_CACHED,
 				&cache_hit_counter));
-	g_profiler->avg("MeshUpdateQueue: MapBlocks from cache [%]",
+	g_profiler.avg("MeshUpdateQueue: MapBlocks from cache [%]",
 			100.0f * cache_hit_counter / cached_blocks.size());
 
 	/*
@@ -228,7 +228,7 @@ void MeshUpdateQueue::cleanupCache()
 {
 	const int mapblock_kB = MAP_BLOCKSIZE * MAP_BLOCKSIZE * MAP_BLOCKSIZE *
 			sizeof(MapNode) / 1000;
-	g_profiler->avg("MeshUpdateQueue MapBlock cache size kB",
+	g_profiler.avg("MeshUpdateQueue MapBlock cache size kB",
 			mapblock_kB * m_cache.size());
 
 	// The cache size is kept roughly below cache_soft_max_size, not letting
@@ -294,7 +294,7 @@ void MeshUpdateThread::doUpdate()
 	while ((q = m_queue_in.pop())) {
 		if (m_generation_interval)
 			sleep_ms(m_generation_interval);
-		ScopeProfiler sp(g_profiler, "Client: Mesh making (sum)");
+		ScopeProfiler sp("Client: Mesh making (sum)");
 
 		MapBlockMesh *mesh_new = new MapBlockMesh(q->data, m_camera_offset);
 

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -127,7 +127,7 @@ void Sky::render()
 	if (!camera || !driver)
 		return;
 
-	ScopeProfiler sp(g_profiler, "Sky::render()", SPT_AVG);
+	ScopeProfiler sp("Sky::render()");
 
 	// Draw perspective skybox
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -232,7 +232,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	static bool time_notification_done = false;
 	Map *map = &env->getMap();
 
-	ScopeProfiler sp(g_profiler, "collisionMoveSimple()", SPT_AVG);
+	ScopeProfiler sp("collisionMoveSimple()");
 
 	collisionMoveResult result;
 
@@ -268,7 +268,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	std::vector<NearbyCollisionInfo> cinfo;
 	{
 	//TimeTaker tt2("collisionMoveSimple collect boxes");
-	ScopeProfiler sp2(g_profiler, "collisionMoveSimple(): collect boxes", SPT_AVG);
+	ScopeProfiler sp2("collisionMoveSimple(): collect boxes");
 
 	v3f newpos_f = *pos_f + *speed_f * dtime;
 	v3f minpos_f(

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -619,8 +619,7 @@ MapBlock *EmergeThread::finishGen(v3s16 pos, BlockMakeData *bmdata,
 	std::map<v3s16, MapBlock *> *modified_blocks)
 {
 	MutexAutoLock envlock(m_server->m_env_mutex);
-	ScopeProfiler sp(g_profiler,
-		"EmergeThread: after Mapgen::makeChunk", SPT_AVG);
+	ScopeProfiler sp("EmergeThread: after Mapgen::makeChunk");
 
 	/*
 		Perform post-processing on blocks (invalidate lighting, queue liquid
@@ -706,8 +705,7 @@ void *EmergeThread::run()
 		action = getBlockOrStartGen(pos, allow_gen, &block, &bmdata);
 		if (action == EMERGE_GENERATED) {
 			{
-				ScopeProfiler sp(g_profiler,
-					"EmergeThread: Mapgen::makeChunk", SPT_AVG);
+				ScopeProfiler sp("EmergeThread: Mapgen::makeChunk");
 
 				m_mapgen->makeChunk(&bmdata);
 			}

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -29,6 +29,7 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiVolumeChange.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/modalMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/profilergraph.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/stackedareachart.cpp
 	${extra_gui_SRCS}
 	PARENT_SCOPE
 )

--- a/src/gui/profilergraph.cpp
+++ b/src/gui/profilergraph.cpp
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "profilergraph.h"
 #include "util/string.h"
 
-void ProfilerGraph::put(const Profiler::GraphValues &values)
+void ProfilerGraph::put(const StatsCollector::GraphValuesMap &values)
 {
 	m_log.emplace_back(values);
 
@@ -126,7 +126,7 @@ void ProfilerGraph::draw(s32 x_left, s32 y_bottom, video::IVideoDriver *driver,
 		for (const Piece &piece : m_log) {
 			float value = 0;
 			bool value_exists = false;
-			Profiler::GraphValues::const_iterator k = piece.values.find(id);
+			StatsCollector::GraphValuesMap::const_iterator k = piece.values.find(id);
 
 			if (k != piece.values.end()) {
 				value = k->second;

--- a/src/gui/profilergraph.h
+++ b/src/gui/profilergraph.h
@@ -32,8 +32,8 @@ class ProfilerGraph
 private:
 	struct Piece
 	{
-		Piece(Profiler::GraphValues v) : values(std::move(v)) {}
-		Profiler::GraphValues values;
+		Piece(StatsCollector::GraphValuesMap v) : values(std::move(v)) {}
+		StatsCollector::GraphValuesMap values;
 	};
 	struct Meta
 	{
@@ -54,7 +54,7 @@ public:
 
 	ProfilerGraph() = default;
 
-	void put(const Profiler::GraphValues &values);
+	void put(const StatsCollector::GraphValuesMap &values);
 
 	void draw(s32 x_left, s32 y_bottom, video::IVideoDriver *driver,
 			gui::IGUIFont *font) const;

--- a/src/gui/stackedareachart.cpp
+++ b/src/gui/stackedareachart.cpp
@@ -1,0 +1,291 @@
+/*
+Minetest
+Copyright (C) 2022 The Minetest Authors
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <set>
+#include "porting.h"
+#include "stackedareachart.h"
+#include "util/string.h"
+
+// Don't divide by a scale smaller than this
+#define MIN_DIVISOR 0.0001
+
+void StackedAreaChart::clear()
+{
+	m_smooth.clear();
+	m_log.clear();
+	m_log_dirty = true;
+	m_colors.clear();
+	m_used_colors.clear();
+}
+
+void StackedAreaChart::setTitle(const std::string &title)
+{
+	m_title = title;
+}
+
+void StackedAreaChart::updateSmoothData(const StackedAreaData &values)
+{
+	// Smooth the data. This is similiar to a sliding window,
+	// but uses exponential decay.
+	std::set<std::string> names;
+	for (const auto &kv : values) {
+		names.insert(kv.first);
+	}
+	for (const auto &kv : m_smooth) {
+		names.insert(kv.first);
+	}
+	for (const auto &name : names) {
+		auto &val = m_smooth[name];
+		auto it = values.find(name);
+		auto newval = (it != values.end()) ? it->second : (float)0;
+		// Weighted average
+		val = (0.99 * val + 1.0 * newval) / (0.99 + 1.0);
+	}
+}
+
+void StackedAreaChart::put(const StackedAreaData &values)
+
+{
+	updateSmoothData(values);
+	putLog(m_smooth);
+}
+
+void StackedAreaChart::putLog(const StackedAreaData &data)
+{
+	// Before inserting into the log, scale the time values
+	// so that they sum to 1.0
+	StackedAreaData final;
+	float scale = 0;
+	for (const auto &kv : data) {
+		scale += kv.second;
+	}
+	if (scale > MIN_DIVISOR) {
+		for (const auto &kv : data) {
+			final[kv.first] = kv.second / scale;
+		}
+	}
+	if (final.empty()) {
+		final["No data"] = 1.0;
+	}
+	m_log.emplace_back(std::move(final));
+	m_log_dirty = true;
+
+	while (m_log.size() > m_log_max_size)
+		m_log.pop_front();
+}
+
+// Visually distinct colors
+// When these run-out, colors are chosen at random
+static u32 colorMap[] = {
+	0x800080, // purple
+	0xff0000, // red
+	0xffa500, // orange
+	0xffff00, // yellow
+	0x7cfc00, // lawngreen
+	0x00ff7f, // springgreen
+	0x00ffff, // aqua
+	0x00bfff, // deepskyblue
+	0xf4a460, // sandybrown
+	0x0000ff, // blue
+	0xff6347, // tomato
+	0xb0c4de, // lightsteelblue
+	0xff00ff, // fuchsia
+	0x1e90ff, // dodgerblue
+	0xf0e68c, // khaki
+	0x90ee90, // lightgreen
+	0xff1493, // deeppink
+	0x7b68ee, // mediumslateblue
+	0xee82ee, // violet
+	0xffffe0, // lightyellow
+	0xffc0cb, // pink
+	0x696969, // dimgray
+	0x800000, // maroon
+	0x808000, // olive
+	0x008000, // green
+	0x000080, // navy
+	0x9acd32, // yellowgreen
+	0xb03060, // maroon3
+};
+
+video::SColor StackedAreaChart::findFreeColor()
+{
+	for (size_t i = 0; i < ARRLEN(colorMap); i++) {
+		uint32_t val = colorMap[i];
+		u32 r = (val >> 16) & 0xFF;
+		u32 g = (val >> 8 ) & 0xFF;
+		u32 b = (val >> 0 ) & 0xFF;
+		auto color = video::SColor(255, r, g, b);
+		if (!m_used_colors.count(color)) {
+			return color;
+		}
+	}
+	// Out of colors. Pick one at random.
+	u32 val = myrand();
+	u32 r = ((val >> 16) & 0xFF) | 0x80; // 128 to 255
+	u32 g = ((val >> 8)  & 0xFF) | 0x80;
+	u32 b = ((val >> 0)  & 0xFF) | 0x80;
+	return video::SColor(255, r, g, b);
+}
+
+void StackedAreaChart::updateColorMap()
+{
+	std::set<std::string> alive_names;
+	for (const auto & entry : m_log) {
+		for (const auto &kv : entry) {
+			alive_names.insert(kv.first);
+		}
+	}
+
+	std::set<std::string> dead_names;
+	for (const auto &kv : m_colors) {
+		if (alive_names.count(kv.first) == 0) {
+			dead_names.insert(kv.first);
+		}
+	}
+
+	// Remove dead names / colors
+	for (const auto &name : dead_names) {
+		auto color = m_colors[name];
+		m_colors.erase(name);
+		m_used_colors.erase(color);
+	}
+
+	// Assign colors to new names
+	for (const auto &name : alive_names) {
+		if (m_colors.count(name) == 0) {
+			auto color = findFreeColor();
+			m_colors[name] = color;
+			m_used_colors.insert(color);
+		}
+	}
+}
+
+void StackedAreaChart::updateTexture(video::IVideoDriver *driver)
+{
+	if (m_texture) {
+		driver->removeTexture(m_texture);
+		m_texture = nullptr;
+	}
+
+	m_pixels.clear();
+	m_pixels_total = 0;
+
+	u32 width = m_log_max_size;
+	u32 height = m_log_max_size;
+	core::dimension2d<u32> size(width, height);
+
+	video::IImage *img = driver->createImage(video::ECF_A8R8G8B8, size);
+	img->fill(video::SColor(0, 0, 0, 0));
+	u32 x = width - m_log.size();
+	for (const auto & entry : m_log) {
+		float acc = 0;
+		u32 y_start = 0;
+		for (const auto & kv : entry) {
+			auto color = m_colors[kv.first];
+			acc += kv.second;
+			u32 y_end = std::min((u32)(acc * height), height);
+			for (u32 y = y_start; y < y_end; y++) {
+				img->setPixel(x, y, color);
+			}
+			m_pixels[kv.first] += y_end - y_start;
+			m_pixels_total += y_end - y_start;
+			y_start = y_end;
+		}
+		++x;
+	}
+	m_texture = driver->addTexture("stackedarea", img);
+	img->drop();
+}
+
+
+void StackedAreaChart::draw(
+		const core::rect<s32> &dest,
+		video::IVideoDriver *driver,
+		gui::IGUIFont *font)
+{
+	if (!m_texture || m_log_dirty) {
+		updateColorMap();
+		updateTexture(driver);
+		m_log_dirty = false;
+	}
+
+	s32 title_height = 25;
+
+	s32 midX = (dest.UpperLeftCorner.X + dest.LowerRightCorner.X) / 2;
+
+	core::rect<s32> title_rect = core::rect<s32>(
+		dest.UpperLeftCorner.X,
+		dest.UpperLeftCorner.Y,
+		dest.LowerRightCorner.X,
+		dest.UpperLeftCorner.Y + title_height);
+
+	core::rect<s32> chart_rect = core::rect<s32>(
+		dest.UpperLeftCorner.X,
+		dest.UpperLeftCorner.Y + title_height,
+		midX,
+		dest.LowerRightCorner.Y);
+
+	core::rect<s32> labels_rect = core::rect<s32>(
+		midX + 2,
+		dest.UpperLeftCorner.Y + title_height,
+		dest.LowerRightCorner.X,
+		dest.LowerRightCorner.Y);
+
+	auto wh = m_texture->getOriginalSize();
+	driver->draw2DImage(
+		m_texture,
+		chart_rect, // destRect
+		core::rect<s32>(0, 0, wh.Width - 1, wh.Height - 1), // sourceRect
+		nullptr, // clipRect
+		nullptr, // colors
+		true); // useAlphaChannelOfTexture
+
+	auto white = video::SColor(255, 255, 255, 255);
+	char buf[256];
+
+	// Above the image print the title
+	if (!m_title.empty()) {
+		font->draw(utf8_to_wide(m_title).c_str(), title_rect, white,
+			/* hcenter= */ true, /* vcenter= */ true);
+	}
+
+	// On the right half, print labels in alphabetic order
+	s32 label_height = m_colors.size() ? labels_rect.getHeight() / m_colors.size() : 15;
+	if (label_height < 15)
+		label_height = 15;
+
+	size_t label_index = 0;
+	for (const auto &nc : m_colors) {
+		s32 label_y_start = labels_rect.UpperLeftCorner.Y + label_index * label_height;
+		s32 label_y_end = label_y_start + label_height;
+		core::rect<s32> text_area(
+			labels_rect.UpperLeftCorner.X,
+			label_y_start,
+			labels_rect.LowerRightCorner.X,
+			label_y_end);
+
+		// draw the label and percentage
+		u32 pixcount = m_pixels[nc.first];
+		porting::mt_snprintf(buf, sizeof(buf), "%s (%d %%)",
+			nc.first.c_str(), (int)(100.0 * pixcount / m_pixels_total));
+		font->draw(utf8_to_wide(buf).c_str(), text_area, nc.second);
+
+		label_index++;
+	}
+}

--- a/src/gui/stackedareachart.h
+++ b/src/gui/stackedareachart.h
@@ -1,0 +1,72 @@
+/*
+Minetest
+Copyright (C) 2022 The Minetest Authors
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <deque>
+#include <utility>
+#include <SColor.h>
+#include <IVideoDriver.h>
+#include <IGUIFont.h>
+#include "profiler.h"
+
+class StackedAreaChart
+{
+public:
+	using StackedAreaData = std::map<std::string, float>;
+
+	u32 m_log_max_size = 256;
+
+	StackedAreaChart() = default;
+
+	void clear();
+
+	void setTitle(const std::string &title);
+
+	void put(const StackedAreaData &values);
+
+	void draw(
+		const core::rect<s32> &dest,
+		video::IVideoDriver *driver,
+		gui::IGUIFont *font);
+private:
+	std::deque<StackedAreaData> m_log;
+	bool m_log_dirty = false;
+
+	// Used to smooth the data
+	StackedAreaData m_smooth;
+
+	// Color assignments
+	std::map<std::string, video::SColor> m_colors;
+	std::set<video::SColor> m_used_colors;
+
+	// Pixels per label
+	std::map<std::string, u32> m_pixels;
+	size_t m_pixels_total;
+
+	std::string m_title;
+
+	video::ITexture *m_texture = nullptr;
+
+	video::SColor findFreeColor();
+	void updateColorMap();
+	void updateTexture(video::IVideoDriver *driver);
+	void updateSmoothData(const StackedAreaData &values);
+	void putLog(const StackedAreaData &data);
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "defaultsettings.h"
 #include "gettext.h"
 #include "log.h"
+#include "profiler.h"
 #include "util/quicktune.h"
 #include "httpfetch.h"
 #include "gameparams.h"
@@ -134,6 +135,7 @@ int main(int argc, char *argv[])
 
 	g_logger.registerThread("Main");
 	g_logger.addOutputMaxLevel(&stderr_output, LL_ACTION);
+	g_profiler.setThreadName("Main");
 
 	Settings cmd_args;
 	bool cmd_args_ok = get_cmdline_opts(argc, argv, &cmd_args);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -329,7 +329,7 @@ void Map::timerUpdate(float dtime, float unload_timeout, u32 max_loaded_blocks,
 	bool save_before_unloading = maySaveBlocks();
 
 	// Profile modified reasons
-	Profiler modprofiler;
+	std::map<std::string, u64> modprofiler;
 
 	std::vector<v2s16> sector_deletion_queue;
 	u32 deleted_blocks_count = 0;
@@ -359,7 +359,7 @@ void Map::timerUpdate(float dtime, float unload_timeout, u32 max_loaded_blocks,
 					// Save if modified
 					if (block->getModified() != MOD_STATE_CLEAN
 							&& save_before_unloading) {
-						modprofiler.add(block->getModifiedReasonString(), 1);
+						modprofiler[block->getModifiedReasonString()] += 1;
 						if (!saveBlock(block))
 							continue;
 						saved_blocks_count++;
@@ -413,7 +413,7 @@ void Map::timerUpdate(float dtime, float unload_timeout, u32 max_loaded_blocks,
 
 			// Save if modified
 			if (block->getModified() != MOD_STATE_CLEAN && save_before_unloading) {
-				modprofiler.add(block->getModifiedReasonString(), 1);
+				modprofiler[block->getModifiedReasonString()] += 1;
 				if (!saveBlock(block))
 					continue;
 				saved_blocks_count++;
@@ -457,7 +457,9 @@ void Map::timerUpdate(float dtime, float unload_timeout, u32 max_loaded_blocks,
 		if(saved_blocks_count != 0){
 			PrintInfo(infostream); // ServerMap/ClientMap:
 			infostream<<"Blocks modified by: "<<std::endl;
-			modprofiler.print(infostream);
+			for (const auto &kv : modprofiler) {
+				infostream << "  " << kv.first << " " << kv.second << std::endl;
+			}
 		}
 	}
 }
@@ -1633,7 +1635,7 @@ void ServerMap::save(ModifiedState save_level)
 	}
 
 	// Profile modified reasons
-	Profiler modprofiler;
+	std::map<std::string, u64> modprofiler;
 
 	u32 block_count = 0;
 	u32 block_count_all = 0; // Number of blocks in memory
@@ -1657,7 +1659,7 @@ void ServerMap::save(ModifiedState save_level)
 					save_started = true;
 				}
 
-				modprofiler.add(block->getModifiedReasonString(), 1);
+				modprofiler[block->getModifiedReasonString()] += 1;
 
 				saveBlock(block);
 				block_count++;
@@ -1679,7 +1681,9 @@ void ServerMap::save(ModifiedState save_level)
 				<< std::endl;
 		PrintInfo(infostream); // ServerMap/ClientMap:
 		infostream<<"Blocks modified by: "<<std::endl;
-		modprofiler.print(infostream);
+		for (const auto &kv : modprofiler) {
+			infostream << "  " << kv.first << " " << kv.second << std::endl;
+		}
 	}
 
 	const auto end_time = porting::getTimeUs();

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -415,7 +415,7 @@ void Mapgen::updateLiquid(UniqueQueue<v3s16> *trans_liquid, v3s16 nmin, v3s16 nm
 
 void Mapgen::setLighting(u8 light, v3s16 nmin, v3s16 nmax)
 {
-	ScopeProfiler sp(g_profiler, "EmergeThread: update lighting", SPT_AVG);
+	ScopeProfiler sp("EmergeThread: update lighting");
 	VoxelArea a(nmin, nmax);
 
 	for (int z = a.MinEdge.Z; z <= a.MaxEdge.Z; z++) {
@@ -469,7 +469,7 @@ void Mapgen::lightSpread(VoxelArea &a, std::queue<std::pair<v3s16, u8>> &queue,
 void Mapgen::calcLighting(v3s16 nmin, v3s16 nmax, v3s16 full_nmin, v3s16 full_nmax,
 	bool propagate_shadow)
 {
-	ScopeProfiler sp(g_profiler, "EmergeThread: update lighting", SPT_AVG);
+	ScopeProfiler sp("EmergeThread: update lighting");
 	//TimeTaker t("updateLighting");
 
 	propagateSunlight(nmin, nmax, propagate_shadow);

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -40,12 +40,6 @@ namespace con
 /******************************************************************************/
 /* defines used for debugging and profiling                                   */
 /******************************************************************************/
-#ifdef NDEBUG
-	#define PROFILE(a)
-#else
-	#define PROFILE(a) a
-#endif
-
 // TODO: Clean this up.
 #define LOG(a) a
 
@@ -904,8 +898,8 @@ void Peer::RTTStatistics(float rtt, const std::string &profiler_id,
 								jitter * (1/num_samples);
 
 		if (!profiler_id.empty()) {
-			g_profiler->graphAdd(profiler_id + " RTT [ms]", rtt * 1000.f);
-			g_profiler->graphAdd(profiler_id + " jitter [ms]", jitter * 1000.f);
+			g_profiler.graphAdd(profiler_id + " RTT [ms]", rtt * 1000.f);
+			g_profiler.graphAdd(profiler_id + " jitter [ms]", jitter * 1000.f);
 		}
 	}
 	/* save values required for next loop */
@@ -925,6 +919,21 @@ bool Peer::isTimedOut(float timeout)
 	return m_timeout_counter > timeout;
 }
 
+void Peer::initProfileIds()
+{
+	std::string connDesc = m_connection->getDesc();
+	{
+		std::stringstream ss;
+		ss << "runTimeouts[" << connDesc << ";" << id << ";RELIABLE]";
+		runTimeoutsIdentifier = ss.str();
+	}
+	{
+		std::stringstream ss;
+		ss << "sendPackets[" << connDesc << ";" << id << ";RELIABLE]";
+		sendPacketsIdentifier = ss.str();
+	}
+}
+
 void Peer::Drop()
 {
 	{
@@ -934,15 +943,8 @@ void Peer::Drop()
 			return;
 	}
 
-	PROFILE(std::stringstream peerIdentifier1);
-	PROFILE(peerIdentifier1 << "runTimeouts[" << m_connection->getDesc()
-			<< ";" << id << ";RELIABLE]");
-	PROFILE(g_profiler->remove(peerIdentifier1.str()));
-	PROFILE(std::stringstream peerIdentifier2);
-	PROFILE(peerIdentifier2 << "sendPackets[" << m_connection->getDesc()
-			<< ";" << id << ";RELIABLE]");
-	PROFILE(ScopeProfiler peerprofiler(g_profiler, peerIdentifier2.str(), SPT_AVG));
-
+	g_profiler.remove(runTimeoutsIdentifier);
+	g_profiler.remove(sendPacketsIdentifier);
 	delete this;
 }
 

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -497,7 +497,8 @@ class Peer {
 			address(address_),
 			m_last_timeout_check(porting::getTimeMs())
 		{
-		};
+			initProfileIds();
+		}
 
 		virtual ~Peer() {
 			MutexAutoLock usage_lock(m_exclusive_access_mutex);
@@ -506,6 +507,10 @@ class Peer {
 
 		// Unique id of the peer
 		const session_t id;
+
+		// Profiling ids
+		std::string runTimeoutsIdentifier;
+		std::string sendPacketsIdentifier;
 
 		void Drop();
 
@@ -575,6 +580,7 @@ class Peer {
 		// Ping timer
 		float m_ping_timer = 0.0f;
 	private:
+		void initProfileIds();
 
 		struct rttstats {
 			float jitter_min = FLT_MAX;

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -24,14 +24,140 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <map>
 #include <ostream>
+#include <set>
 
 #include "threading/mutex_auto_lock.h"
+#include "config.h"
+#include "debug.h"
+#include "porting.h"
 #include "util/timetaker.h"
 #include "util/numeric.h"      // paging()
 
-// Global profiler
+//
+// g_collector
+//
+//   Global stats collector. Use this for retrieving profiler data.
+//   Must be declared before g_profiler so it is constructed first.
+class StatsCollector;
+extern StatsCollector g_collector;
+
+//
+// g_profiler
+//
+//   Thread-specific global profiler. Use this for recording data.
 class Profiler;
-extern Profiler *g_profiler;
+extern thread_local Profiler g_profiler;
+
+enum ProfileDataKind {
+	PD_NONE,
+	PD_STAT,
+	PD_TIME,
+};
+
+struct ProfileData {
+	ProfileDataKind kind;
+	float total;
+	float self;
+	u64 count;
+
+	ProfileData() :
+		kind(PD_NONE),
+		total(0),
+		self(0),
+		count(0)
+	{ }
+
+	void merge(const ProfileData &other)
+	{
+		if (kind == PD_NONE)
+			kind = other.kind;
+		sanity_check(kind == other.kind);
+		total += other.total;
+		self += other.self;
+		count += other.count;
+	}
+};
+
+class ScopeProfiler;
+
+class StatsCollector {
+public:
+	// id -> {total time, self time, count}
+	using ProfileDataMap = std::map<std::string, ProfileData>;
+	// id -> total
+	using GraphValuesMap = std::map<std::string, float>;
+	// thread name -> data
+	using ThreadDataMap = std::map<std::string, ProfileDataMap>;
+
+	void clear();
+
+	u64 getElapsedMs() const
+	{
+		return porting::getTimeMs() - m_start_time;
+	}
+
+	// Return and clear graph values.
+	GraphValuesMap graphGet()
+	{
+		MutexAutoLock lock(m_mutex);
+		aggregateThreads();
+		GraphValuesMap result = std::move(m_combined_graphvalues);
+		m_combined_graphvalues.clear();
+		return result;
+	}
+
+	// Returns the line count
+	int print(std::ostream &o, u32 page = 1, u32 pagecount = 1);
+	int print(std::ostream &o, const ProfileDataMap &values);
+	void getPage(ProfileDataMap &o, u32 page, u32 pagecount);
+
+	// Return and clear per-thread data
+	ThreadDataMap getThreadMap()
+	{
+		MutexAutoLock lock(m_mutex);
+		aggregateThreads();
+		ThreadDataMap result = std::move(m_thread_data);
+		m_thread_data.clear();
+		return result;
+	}
+
+	std::vector<std::string> listThreadNames();
+
+#if BUILD_UNITTESTS
+	// Used by unit tests to inspect the stats
+	float getValue(const std::string &name)
+	{
+		MutexAutoLock lock(m_mutex);
+		aggregateThreads();
+		auto& entry = m_combined_data[name];
+		return entry.total / entry.count;
+	}
+#endif
+protected:
+	friend class Profiler;
+
+	void registerThread(Profiler *p)
+	{
+		MutexAutoLock lock(m_mutex);
+		m_threads.insert(p);
+	}
+
+	void deregisterThread(Profiler *p)
+	{
+		MutexAutoLock lock(m_mutex);
+		m_threads.erase(p);
+	}
+private:
+	std::mutex m_mutex;
+	std::set<Profiler*> m_threads;
+	u64 m_start_time{0};
+	ProfileDataMap m_combined_data;
+	GraphValuesMap m_combined_graphvalues;
+	// Thread Name -> aggregate data for that thread
+	ThreadDataMap m_thread_data;
+	// Must hold m_mutex when calling this.
+	void aggregateThreads();
+};
 
 /*
 	Time profiler
@@ -40,70 +166,173 @@ extern Profiler *g_profiler;
 class Profiler
 {
 public:
-	Profiler();
 
-	void add(const std::string &name, float value);
-	void avg(const std::string &name, float value);
-	void clear();
+	Profiler()
+	{
+		g_collector.registerThread(this);
+	}
 
-	float getValue(const std::string &name) const;
-	int getAvgCount(const std::string &name) const;
-	u64 getElapsedMs() const;
+	~Profiler()
+	{
+		g_collector.deregisterThread(this);
+	}
 
-	typedef std::map<std::string, float> GraphValues;
+	// Enable profiling
+	static void enable()
+	{
+		m_profiling_enabled.store(true, std::memory_order_relaxed);
+	}
 
-	// Returns the line count
-	int print(std::ostream &o, u32 page = 1, u32 pagecount = 1);
-	void getPage(GraphValues &o, u32 page, u32 pagecount);
+	// Disable profiling
+	static void disable()
+	{
+		m_profiling_enabled.store(false, std::memory_order_relaxed);
+	}
 
+	// Check if profiling is enabled
+	static bool isEnabled()
+	{
+		return m_profiling_enabled.load(std::memory_order_relaxed);
+	}
 
+	void add(const std::string &name, float total_time, float self_time)
+	{
+		if (!isEnabled())
+			return;
+		MutexAutoLock lock(m_local_mutex);
+		auto& entry = m_data[name];
+		if (entry.kind == PD_NONE)
+			entry.kind = PD_TIME;
+		sanity_check(entry.kind == PD_TIME);
+
+		entry.total += total_time;
+		entry.self += self_time;
+		entry.count += 1;
+	}
+
+	// 'avg' is used as a general stats collection endpoint (not profiling data)
+	// This complicates the internal representation a little bit.
+	// Normally a profiler feeds into a stats collector, not vice versa.
+	void avg(const std::string &name, float value)
+	{
+		if (!isEnabled())
+			return;
+		MutexAutoLock lock(m_local_mutex);
+		auto& entry = m_data[name];
+
+		if (entry.kind == PD_NONE)
+			entry.kind = PD_STAT;
+		sanity_check(entry.kind == PD_STAT);
+
+		entry.total += value;
+		entry.count += 1;
+	}
+
+	// For generating real time event graphs.
 	void graphAdd(const std::string &id, float value)
 	{
-		MutexAutoLock lock(m_mutex);
-		std::map<std::string, float>::iterator i =
-				m_graphvalues.find(id);
-		if(i == m_graphvalues.end())
-			m_graphvalues[id] = value;
-		else
-			i->second += value;
-	}
-	void graphGet(GraphValues &result)
-	{
-		MutexAutoLock lock(m_mutex);
-		result = m_graphvalues;
-		m_graphvalues.clear();
+		if (!isEnabled())
+			return;
+		MutexAutoLock lock(m_local_mutex);
+		m_graphvalues[id] += value;
 	}
 
 	void remove(const std::string& name)
 	{
-		MutexAutoLock lock(m_mutex);
-		m_avgcounts.erase(name);
+		if (!isEnabled())
+			return;
+		MutexAutoLock lock(m_local_mutex);
 		m_data.erase(name);
 	}
 
-private:
-	std::mutex m_mutex;
-	std::map<std::string, float> m_data;
-	std::map<std::string, int> m_avgcounts;
-	std::map<std::string, float> m_graphvalues;
-	u64 m_start_time;
-};
+	void setThreadName(const std::string &name)
+	{
+		MutexAutoLock lock(m_local_mutex);
+		m_thread_name = name;
+	}
 
-enum ScopeProfilerType{
-	SPT_ADD,
-	SPT_AVG,
-	SPT_GRAPH_ADD
+protected:
+	friend class StatsCollector;
+
+	void clear()
+	{
+		MutexAutoLock lock(m_local_mutex);
+		m_data.clear();
+		m_graphvalues.clear();
+	}
+
+	std::string getThreadName() const
+	{
+		MutexAutoLock lock(m_local_mutex);
+		return m_thread_name;
+	}
+
+	StatsCollector::ProfileDataMap takeData()
+	{
+		MutexAutoLock lock(m_local_mutex);
+		StatsCollector::ProfileDataMap tmp = std::move(m_data);
+		m_data.clear();
+		return tmp;
+	}
+
+	StatsCollector::GraphValuesMap takeGraphValues()
+	{
+		MutexAutoLock lock(m_local_mutex);
+		StatsCollector::GraphValuesMap tmp = std::move(m_graphvalues);
+		m_graphvalues.clear();
+		return tmp;
+	}
+
+private:
+	static std::atomic<bool> m_profiling_enabled;
+
+	std::string m_thread_name;
+
+	mutable std::mutex m_local_mutex;
+
+	// Local mutex protects these
+	StatsCollector::ProfileDataMap m_data;
+	StatsCollector::GraphValuesMap m_graphvalues;
 };
 
 class ScopeProfiler
 {
 public:
-	ScopeProfiler(Profiler *profiler, const std::string &name,
-			ScopeProfilerType type = SPT_ADD);
-	~ScopeProfiler();
+	ScopeProfiler(const std::string &name) :
+		ScopeProfiler(name.c_str())
+	{ }
+
+	ScopeProfiler(const char *name) :
+		m_enabled(Profiler::isEnabled())
+	{
+		if (!m_enabled)
+			return;
+		m_name = std::string(name) + " [ms]";
+		m_start_time = porting::getTimeMs();
+		m_exclude_time = 0;
+		m_stack.push_back(this);
+	}
+
+	~ScopeProfiler()
+	{
+		if (!m_enabled)
+			return;
+		sanity_check(!m_stack.empty() && m_stack.back() == this);
+		m_stack.pop_back();
+
+		u64 duration = porting::getTimeMs() - m_start_time;
+		if (!m_stack.empty()) {
+			// Exclude from the 'self' time of the scope above it
+			m_stack.back()->m_exclude_time += duration;
+		}
+		g_profiler.add(m_name, duration, duration - m_exclude_time);
+	}
 private:
-	Profiler *m_profiler = nullptr;
+	bool m_enabled;
+	static thread_local std::vector<ScopeProfiler*> m_stack;
+protected:
+	friend class Profiler;
 	std::string m_name;
-	TimeTaker *m_timer = nullptr;
-	enum ScopeProfilerType m_type;
+	u64 m_start_time;
+	u64 m_exclude_time;
 };

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -132,7 +132,7 @@ int ModApiBase::l_deprecated_function(lua_State *L, const char *good, const char
 	}
 
 	u64 end_time = porting::getTimeUs();
-	g_profiler->avg("l_deprecated_function", end_time - start_time);
+	g_profiler.avg("l_deprecated_function", end_time - start_time);
 
 	return func(L);
 }

--- a/src/server/activeobjectmgr.cpp
+++ b/src/server/activeobjectmgr.cpp
@@ -44,7 +44,7 @@ void ActiveObjectMgr::clear(const std::function<bool(ServerActiveObject *, u16)>
 void ActiveObjectMgr::step(
 		float dtime, const std::function<void(ServerActiveObject *)> &f)
 {
-	g_profiler->avg("ActiveObjectMgr: SAO count [#]", m_active_objects.size());
+	g_profiler.avg("ActiveObjectMgr: SAO count [#]", m_active_objects.size());
 	for (auto &ao_it : m_active_objects) {
 		f(ao_it.second);
 	}

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1291,7 +1291,7 @@ void ServerEnvironment::clearObjects(ClearObjectsMode mode)
 
 void ServerEnvironment::step(float dtime)
 {
-	ScopeProfiler sp2(g_profiler, "ServerEnv::step()", SPT_AVG);
+	ScopeProfiler sp2("ServerEnv::step()");
 	const auto start_time = porting::getTimeUs();
 
 	/* Step time of day */
@@ -1318,7 +1318,7 @@ void ServerEnvironment::step(float dtime)
 		Handle players
 	*/
 	{
-		ScopeProfiler sp(g_profiler, "ServerEnv: move players", SPT_AVG);
+		ScopeProfiler sp("ServerEnv: move players");
 		for (RemotePlayer *player : m_players) {
 			// Ignore disconnected players
 			if (player->getPeerId() == PEER_ID_INEXISTENT)
@@ -1334,7 +1334,7 @@ void ServerEnvironment::step(float dtime)
 	*/
 	if (m_active_blocks_mgmt_interval.step(dtime, m_cache_active_block_mgmt_interval) ||
 		m_force_update_active_blocks) {
-		ScopeProfiler sp(g_profiler, "ServerEnv: update active blocks", SPT_AVG);
+		ScopeProfiler sp("ServerEnv: update active blocks");
 
 		/*
 			Get player block positions
@@ -1409,7 +1409,7 @@ void ServerEnvironment::step(float dtime)
 		Mess around in active blocks
 	*/
 	if (m_active_blocks_nodemetadata_interval.step(dtime, m_cache_nodetimer_interval)) {
-		ScopeProfiler sp(g_profiler, "ServerEnv: Run node timers", SPT_AVG);
+		ScopeProfiler sp("ServerEnv: Run node timers");
 
 		float dtime = m_cache_nodetimer_interval;
 
@@ -1447,7 +1447,7 @@ void ServerEnvironment::step(float dtime)
 	}
 
 	if (m_active_block_modifier_interval.step(dtime, m_cache_abm_interval)) {
-		ScopeProfiler sp(g_profiler, "SEnv: modify in blocks avg per interval", SPT_AVG);
+		ScopeProfiler sp("SEnv: modify in blocks avg per interval");
 		TimeTaker timer("modify in active blocks per interval");
 
 		// Initialize handling of ActiveBlockModifiers
@@ -1489,10 +1489,10 @@ void ServerEnvironment::step(float dtime)
 				break;
 			}
 		}
-		g_profiler->avg("ServerEnv: active blocks", m_active_blocks.m_abm_list.size());
-		g_profiler->avg("ServerEnv: active blocks cached", blocks_cached);
-		g_profiler->avg("ServerEnv: active blocks scanned for ABMs", blocks_scanned);
-		g_profiler->avg("ServerEnv: ABMs run", abms_run);
+		g_profiler.avg("ServerEnv: active blocks", m_active_blocks.m_abm_list.size());
+		g_profiler.avg("ServerEnv: active blocks cached", blocks_cached);
+		g_profiler.avg("ServerEnv: active blocks scanned for ABMs", blocks_scanned);
+		g_profiler.avg("ServerEnv: ABMs run", abms_run);
 
 		timer.stop(true);
 	}
@@ -1508,7 +1508,7 @@ void ServerEnvironment::step(float dtime)
 		Step active objects
 	*/
 	{
-		ScopeProfiler sp(g_profiler, "ServerEnv: Run SAO::step()", SPT_AVG);
+		ScopeProfiler sp("ServerEnv: Run SAO::step()");
 
 		// This helps the objects to send data at the same time
 		bool send_recommended = false;
@@ -1824,7 +1824,7 @@ u16 ServerEnvironment::addActiveObjectRaw(ServerActiveObject *object,
 */
 void ServerEnvironment::removeRemovedObjects()
 {
-	ScopeProfiler sp(g_profiler, "ServerEnvironment::removeRemovedObjects()", SPT_AVG);
+	ScopeProfiler sp("ServerEnvironment::removeRemovedObjects()");
 
 	auto clear_cb = [this] (ServerActiveObject *obj, u16 id) {
 		// This shouldn't happen but check it

--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.
 
 #include "threading/thread.h"
 #include "threading/mutex_auto_lock.h"
+#include "profiler.h"
 #include "log.h"
 #include "porting.h"
 
@@ -177,8 +178,8 @@ void Thread::threadProc(Thread *thr)
 #endif
 
 	thr->setName(thr->m_name);
-
 	g_logger.registerThread(thr->m_name);
+	g_profiler.setThreadName(thr->m_name);
 	thr->m_running = true;
 
 	// Wait for the thread that started this one to finish initializing the

--- a/src/unittest/test_profiler.cpp
+++ b/src/unittest/test_profiler.cpp
@@ -43,31 +43,36 @@ void TestProfiler::runTests(IGameDef *gamedef)
 
 void TestProfiler::testProfilerAverage()
 {
-	Profiler p;
+	auto &p = g_profiler;
+	auto &c = g_collector;
+
+	Profiler::enable();
 
 	p.avg("Test1", 1.f);
-	UASSERT(p.getValue("Test1") == 1.f);
+	UASSERT(c.getValue("Test1") == 1.f);
 
 	p.avg("Test1", 2.f);
-	UASSERT(p.getValue("Test1") == 1.5f);
+	UASSERT(c.getValue("Test1") == 1.5f);
 
 	p.avg("Test1", 3.f);
-	UASSERT(p.getValue("Test1") == 2.f);
+	UASSERT(c.getValue("Test1") == 2.f);
 
 	p.avg("Test1", 486.f);
-	UASSERT(p.getValue("Test1") == 123.f);
+	UASSERT(c.getValue("Test1") == 123.f);
 
 	p.avg("Test1", 8);
-	UASSERT(p.getValue("Test1") == 100.f);
+	UASSERT(c.getValue("Test1") == 100.f);
 
 	p.avg("Test1", 700);
-	UASSERT(p.getValue("Test1") == 200.f);
+	UASSERT(c.getValue("Test1") == 200.f);
 
 	p.avg("Test1", 10000);
-	UASSERT(p.getValue("Test1") == 1600.f);
+	UASSERT(c.getValue("Test1") == 1600.f);
 
 	p.avg("Test2", 123.56);
 	p.avg("Test2", 123.58);
 
-	UASSERT(p.getValue("Test2") == 123.57f);
+	UASSERT(c.getValue("Test2") == 123.57f);
+
+	Profiler::disable();
 }


### PR DESCRIPTION
- Make `ScopeProfiler` cost-free when the profiler is disabled. (it only needs to check an atomic flag)
- Make the Profiler thread-local to collect data on a per-thread basis.
- Add a StatsCollector class that aggregates profiling data for all threads.
- Add a stacked-area chart to the profiler display (activated with F6) that iterates through the threads.

This is what it looks like:

![Screenshot from 2022-05-21 08-35-25](https://user-images.githubusercontent.com/102263465/169659335-e604b01e-ef72-4ef1-966b-a138c23affd9.png)

The chart scrolls left, showing the ratio of time spent in each scope, in real time.

After this is merged, I will go through and determine which scopes need to be added/removed in order to improve the quality of the charts. Many of the scopes are too small (always <  1% of total time). There may be also time missing, if sections of the code are not contained in any ScopeProfiler.