### PR TITLE
Force-update shadows when the world is changed

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -530,7 +530,7 @@ void Client::step(float dtime)
 	{
 		int num_processed_meshes = 0;
 		std::vector<v3s16> blocks_to_ack;
-		auto shadow_renderer = RenderingEngine::get_shadow_renderer();
+		bool force_update_shadows = false;
 		while (!m_mesh_update_thread.m_queue_out.empty())
 		{
 			num_processed_meshes++;
@@ -560,8 +560,7 @@ void Client::step(float dtime)
 					else {
 						// Replace with the new mesh
 						block->mesh = r.mesh;
-						if (shadow_renderer)
-							shadow_renderer->setForceUpdateShadowMap();
+						force_update_shadows = true;
 					}
 				}
 			} else {
@@ -587,6 +586,10 @@ void Client::step(float dtime)
 
 		if (num_processed_meshes > 0)
 			g_profiler->graphAdd("num_processed_meshes", num_processed_meshes);
+
+		auto shadow_renderer = RenderingEngine::get_shadow_renderer();
+		if (shadow_renderer && force_update_shadows)
+			shadow_renderer->setForceUpdateShadowMap();
 	}
 
 	/*

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -530,7 +530,7 @@ void Client::step(float dtime)
 	{
 		int num_processed_meshes = 0;
 		std::vector<v3s16> blocks_to_ack;
-		bool force_update_shadow_map = false;
+		auto shadow_renderer = RenderingEngine::get_shadow_renderer();
 		while (!m_mesh_update_thread.m_queue_out.empty())
 		{
 			num_processed_meshes++;
@@ -560,15 +560,13 @@ void Client::step(float dtime)
 					else {
 						// Replace with the new mesh
 						block->mesh = r.mesh;
-						force_update_shadow_map = true;
+						if (shadow_renderer)
+							shadow_renderer->setForceUpdateShadowMap();
 					}
 				}
 			} else {
 				delete r.mesh;
 			}
-
-			if (force_update_shadow_map)
-				RenderingEngine::get_shadow_renderer()->forceUpdateShadowMap();
 
 			if (m_minimap && do_mapper_update)
 				m_minimap->addBlock(r.p, minimap_mapblock);

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -530,6 +530,7 @@ void Client::step(float dtime)
 	{
 		int num_processed_meshes = 0;
 		std::vector<v3s16> blocks_to_ack;
+		bool force_update_shadow_map = false;
 		while (!m_mesh_update_thread.m_queue_out.empty())
 		{
 			num_processed_meshes++;
@@ -556,13 +557,18 @@ void Client::step(float dtime)
 
 					if (is_empty)
 						delete r.mesh;
-					else
+					else {
 						// Replace with the new mesh
 						block->mesh = r.mesh;
+						force_update_shadow_map = true;
+					}
 				}
 			} else {
 				delete r.mesh;
 			}
+
+			if (force_update_shadow_map)
+				RenderingEngine::get_shadow_renderer()->forceUpdateShadowMap();
 
 			if (m_minimap && do_mapper_update)
 				m_minimap->addBlock(r.p, minimap_mapblock);

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -74,6 +74,7 @@ public:
 	void removeNodeFromShadowList(scene::ISceneNode *node);
 
 	void update(video::ITexture *outputTarget = nullptr);
+	void forceUpdateShadowMap() { m_force_update_shadow_map = true; }
 	void drawDebug();
 
 	video::ITexture *get_texture()
@@ -131,6 +132,7 @@ private:
 	bool m_shadows_enabled;
 	bool m_shadows_supported;
 	bool m_shadow_map_colored;
+	bool m_force_update_shadow_map;
 	u8 m_map_shadow_update_frames; /* Use this number of frames to update map shaodw */
 	u8 m_current_frame{0}; /* Current frame */
 	f32 m_perspective_bias_xy;

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -74,7 +74,7 @@ public:
 	void removeNodeFromShadowList(scene::ISceneNode *node);
 
 	void update(video::ITexture *outputTarget = nullptr);
-	void forceUpdateShadowMap() { m_force_update_shadow_map = true; }
+	void setForceUpdateShadowMap() { m_force_update_shadow_map = true; }
 	void drawDebug();
 
 	video::ITexture *get_texture()


### PR DESCRIPTION
This PR attempts to fix the "lagging shadows" problem when `shadow_update_frames` setting is greater than 1.

`shadow_update_frames` setting was introduced to mitigate the performance degradation caused by shadow mapping and spreads rendering of the 'map' shadow over the given number of frames. This delays change in the shadow when the map changes (mining or building) and causes artifacts such as nodes not casting shadows on building or shadows cast by air on mining.

This PR forces a full SM render on the frame where a map change occurs, removing the lag completely.

The downside is that shadow update frequency is not even, which may be noticeable with fast-moving shadows (e.g. shadows of high cliffs).

## To do

This PR is a Ready for Review.

## How to test

1. Set shadow_update_frames to 16
2. Start a world and start digging/building/pour water etc.
3. Notice that shadows are updated immediately