### PR TITLE
[no squash] Fix bright sky in caves (without noclip priv)

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -219,13 +219,11 @@ void ClientMap::updateDrawList()
 	// Number of blocks occlusion culled
 	u32 blocks_occlusion_culled = 0;
 
-	// No occlusion culling when free_move is on and camera is
-	// inside ground
+	// No occlusion culling when free_move is on and camera is inside ground
 	bool occlusion_culling_enabled = true;
-	if (g_settings->getBool("free_move") && g_settings->getBool("noclip")) {
+	if (m_control.allow_noclip) {
 		MapNode n = getNode(cam_pos_nodes);
-		if (n.getContent() == CONTENT_IGNORE ||
-				m_nodedef->get(n).solidness == 2)
+		if (n.getContent() == CONTENT_IGNORE || m_nodedef->get(n).solidness == 2)
 			occlusion_culling_enabled = false;
 	}
 
@@ -678,19 +676,17 @@ void ClientMap::renderPostFx(CameraMode cam_mode)
 
 	MapNode n = getNode(floatToInt(m_camera_position, BS));
 
-	// - If the player is in a solid node, make everything black.
-	// - If the player is in liquid, draw a semi-transparent overlay.
-	// - Do not if player is in third person mode
 	const ContentFeatures& features = m_nodedef->get(n);
 	video::SColor post_effect_color = features.post_effect_color;
-	if(features.solidness == 2 && !(g_settings->getBool("noclip") &&
-			m_client->checkLocalPrivilege("noclip")) &&
-			cam_mode == CAMERA_MODE_FIRST)
-	{
+
+	// If the camera is in a solid node, make everything black.
+	// (first person mode only)
+	if (features.solidness == 2 && cam_mode == CAMERA_MODE_FIRST &&
+		!m_control.allow_noclip) {
 		post_effect_color = video::SColor(255, 0, 0, 0);
 	}
-	if (post_effect_color.getAlpha() != 0)
-	{
+
+	if (post_effect_color.getAlpha() != 0) {
 		// Draw a full-screen rectangle
 		video::IVideoDriver* driver = SceneManager->getVideoDriver();
 		v2u32 ss = driver->getScreenSize();

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -27,10 +27,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 struct MapDrawControl
 {
-	// Overrides limits by drawing everything
-	bool range_all = false;
 	// Wanted drawing range
 	float wanted_range = 0.0f;
+	// Overrides limits by drawing everything
+	bool range_all = false;
+	// Allow rendering out of bounds
+	bool allow_noclip = false;
 	// show a wire frame for debugging
 	bool show_wireframe = false;
 };

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1743,6 +1743,8 @@ void Game::processQueues()
 void Game::updateDebugState()
 {
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
+
+	// debug UI and wireframe
 	bool has_debug = client->checkPrivilege("debug");
 	bool has_basic_debug = has_debug || (player->hud_flags & HUD_FLAG_BASIC_DEBUG);
 
@@ -1757,6 +1759,9 @@ void Game::updateDebugState()
 		hud->disableBlockBounds();
 	if (!has_debug)
 		draw_control->show_wireframe = false;
+
+	// noclip
+	draw_control->allow_noclip = m_cache_enable_noclip && client->checkPrivilege("noclip");
 }
 
 void Game::updateProfilers(const RunStats &stats, const FpsControl &draw_times,
@@ -3762,7 +3767,10 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	float direct_brightness;
 	bool sunlight_seen;
 
-	if (m_cache_enable_noclip && m_cache_enable_free_move) {
+	// When in noclip mode force same sky brightness as above ground so you
+	// can see properly
+	if (draw_control->allow_noclip && m_cache_enable_free_move &&
+		client->checkPrivilege("fly")) {
 		direct_brightness = time_brightness;
 		sunlight_seen = true;
 	} else {

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -426,16 +426,6 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		camera_impact = getSpeed().Y * -1;
 	}
 
-	{
-		camera_barely_in_ceiling = false;
-		v3s16 camera_np = floatToInt(getEyePosition(), BS);
-		MapNode n = map->getNode(camera_np);
-		if (n.getContent() != CONTENT_IGNORE) {
-			if (nodemgr->get(n).walkable && nodemgr->get(n).solidness == 2)
-				camera_barely_in_ceiling = true;
-		}
-	}
-
 	/*
 		Check properties of the node on which the player is standing
 	*/
@@ -696,8 +686,7 @@ v3s16 LocalPlayer::getLightPosition() const
 
 v3f LocalPlayer::getEyeOffset() const
 {
-	float eye_height = camera_barely_in_ceiling ? m_eye_height - 0.125f : m_eye_height;
-	return v3f(0.0f, BS * eye_height, 0.0f);
+	return v3f(0.0f, BS * m_eye_height, 0.0f);
 }
 
 ClientActiveObject *LocalPlayer::getParent() const
@@ -1023,16 +1012,6 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_REGAIN_GROUND));
 		// Set camera impact value to be used for view bobbing
 		camera_impact = getSpeed().Y * -1.0f;
-	}
-
-	{
-		camera_barely_in_ceiling = false;
-		v3s16 camera_np = floatToInt(getEyePosition(), BS);
-		MapNode n = map->getNode(camera_np);
-		if (n.getContent() != CONTENT_IGNORE) {
-			if (nodemgr->get(n).walkable && nodemgr->get(n).solidness == 2)
-				camera_barely_in_ceiling = true;
-		}
 	}
 
 	/*

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -199,7 +199,6 @@ private:
 	u16 m_breath = PLAYER_MAX_BREATH_DEFAULT;
 	f32 m_yaw = 0.0f;
 	f32 m_pitch = 0.0f;
-	bool camera_barely_in_ceiling = false;
 	aabb3f m_collisionbox = aabb3f(-BS * 0.30f, 0.0f, -BS * 0.30f, BS * 0.30f,
 		BS * 1.75f, BS * 0.30f);
 	float m_eye_height = 1.625f;


### PR DESCRIPTION
old bug described e.g. here https://forum.minetest.net/viewtopic.php?p=410257#p410257
the first commit is there because I first thought it would be useful but it turned out not

Fixes #5939

## To do

This PR is Ready for Review.

## How to test

1. Stare at unloaded blocks in a cave (easy with `max_block_send_distance=1`) during daytime
2. Do *not* have the `noclip` privilege
3. Enable free_move mode
4. Toggle noclip on and off and verify that the unloaded area does not turn bright
