### PR TITLE
Add minetest.get_player_window_information()

### DIFF
--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -165,7 +165,7 @@ return {
 		fs = fs .. "style[label_button2;border=false]" ..
 			"button[0.1,6;5.3,1;label_button2;" ..
 			fgettext("Active renderer:") .. "\n" ..
-			core.formspec_escape(core.get_screen_info().render_info) .. "]"
+			core.formspec_escape(core.get_active_renderer()) .. "]"
 
 		if PLATFORM == "Android" then
 			fs = fs .. "button[0.5,5.1;4.5,0.8;share_debug;" .. fgettext("Share debug log") .. "]"

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4972,6 +4972,21 @@ Utilities
           protocol_version = 32,     -- protocol version used by client
           formspec_version = 2,      -- supported formspec version
           lang_code = "fr"           -- Language code used for translation
+
+          -- Will only be present if the client sent this information (requires v5.6+)
+          --
+          -- Note that none of these things are constant, they are likely to change during a client
+          -- connection as the player resizes the window and moves it between monitors
+          display = {
+              screen_size = { -- Current window size, not including any decorations (window bar, etc)
+                  x = 1308,
+                  y = 577,
+              },
+              dpi = 96, -- Dots per inch
+              gui_scaling = 1, -- gui_scaling setting
+              hud_scaling = 1, -- hud_scaling setting
+          },
+
           -- the following keys can be missing if no stats have been collected yet
           min_rtt = 0.01,            -- minimum round trip time
           max_rtt = 0.2,             -- maximum round trip time

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4995,6 +4995,10 @@ Utilities
       --
       -- Note that none of these things are constant, they are likely to change during a client
       -- connection as the player resizes the window and moves it between monitors
+      --
+      -- real_gui_scaling and real_hud_scaling can be used instead of DPI.
+      -- OSes already lie about DPI by allowing the user to configure it.
+      -- real_*_scaling is just OS DPI / 96 but with another level of user configuration.
       {
           -- Current size of the in-game render target.
           --

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5007,11 +5007,11 @@ Utilities
 
           -- GUI Scaling multiplier
           -- Equal to the setting `gui_scaling` multiplied by `dpi / 96`
-          gui_scaling = 1,
+          real_gui_scaling = 1,
 
           -- HUD Scaling multiplier
           -- Equal to the setting `hud_scaling` multiplied by `dpi / 96`
-          hud_scaling = 1,
+          real_hud_scaling = 1,
       }
 
 * `minetest.mkdir(path)`: returns success.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5000,7 +5000,7 @@ Utilities
       -- OSes don't necessarily give the physical DPI, as they may allow user configuration.
       -- real_*_scaling is just OS DPI / 96 but with another level of user configuration.
       {
-          -- Current size of the in-game render target.
+          -- Current size of the in-game render target (pixels).
           --
           -- This is usually the window size, but may be smaller in certain situations,
           -- such as side-by-side mode.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4997,7 +4997,7 @@ Utilities
       -- connection as the player resizes the window and moves it between monitors
       --
       -- real_gui_scaling and real_hud_scaling can be used instead of DPI.
-      -- OSes already lie about DPI by allowing the user to configure it.
+      -- OSes don't necessarily give the physical DPI, as they may allow user configuration.
       -- real_*_scaling is just OS DPI / 96 but with another level of user configuration.
       {
           -- Current size of the in-game render target.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4973,20 +4973,6 @@ Utilities
           formspec_version = 2,      -- supported formspec version
           lang_code = "fr"           -- Language code used for translation
 
-          -- Will only be present if the client sent this information (requires v5.6+)
-          --
-          -- Note that none of these things are constant, they are likely to change during a client
-          -- connection as the player resizes the window and moves it between monitors
-          display = {
-              screen_size = { -- Current window size, not including any decorations (window bar, etc)
-                  x = 1308,
-                  y = 577,
-              },
-              dpi = 96, -- Dots per inch
-              gui_scaling = 1, -- gui_scaling setting
-              hud_scaling = 1, -- hud_scaling setting
-          },
-
           -- the following keys can be missing if no stats have been collected yet
           min_rtt = 0.01,            -- minimum round trip time
           max_rtt = 0.2,             -- maximum round trip time
@@ -5002,6 +4988,30 @@ Utilities
           --patch = 10,                -- patch version number
           --vers_string = "0.4.9-git", -- full version string
           --state = "Active"           -- current client state
+      }
+* `minetest.get_player_window_information(player_name)`:
+
+      -- Will only be present if the client sent this information (requires v5.6+)
+      --
+      -- Note that none of these things are constant, they are likely to change during a client
+      -- connection as the player resizes the window and moves it between monitors
+      {
+          -- Current size of the in-game render target.
+          --
+          -- This is usually the window size, but may be smaller in certain situations,
+          -- such as side-by-side mode.
+          size = {
+              x = 1308,
+              y = 577,
+          },
+
+          -- GUI Scaling multiplier
+          -- Equal to the setting `gui_scaling` multiplied by `dpi / 96`
+          gui_scaling = 1,
+
+          -- HUD Scaling multiplier
+          -- Equal to the setting `hud_scaling` multiplied by `dpi / 96`
+          hud_scaling = 1,
       }
 
 * `minetest.mkdir(path)`: returns success.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4991,7 +4991,7 @@ Utilities
       }
 * `minetest.get_player_window_information(player_name)`:
 
-      -- Will only be present if the client sent this information (requires v5.6+)
+      -- Will only be present if the client sent this information (requires v5.7+)
       --
       -- Note that none of these things are constant, they are likely to change during a client
       -- connection as the player resizes the window and moves it between monitors
@@ -5007,6 +5007,14 @@ Utilities
           size = {
               x = 1308,
               y = 577,
+          },
+
+          -- Estimated maximum formspec size before Minetest will start shrinking the
+          -- formspec to fit. For a fullscreen formspec, use a size 10-20% larger than
+          -- this and `padding[-0.01,-0.01]`.
+          max_formspec_size = {
+              x = 20,
+              y = 11.25
           },
 
           -- GUI Scaling multiplier

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -203,17 +203,42 @@ GUI
         will be added to fieldname value is set to formname itself
   * if `is_file_select` is `true`, a file and not a folder will be selected
   * returns nil or selected file/folder
-* `core.get_screen_info()`
-  * returns
+* `core.get_active_renderer()`: Ex: "OpenGL 4.6".
+* `core.get_window_info()`: Same as server-side `get_player_window_information` API.
 
-        {
-          density         = <screen density 0.75,1.0,2.0,3.0 ... (dpi)>,
-          display_width   = <width of display>,
-          display_height  = <height of display>,
-          window_width    = <current window width>,
-          window_height   = <current window height>,
-          render_info     = <active render information>
-        }
+      -- Note that none of these things are constant, they are likely to change
+      -- as the player resizes the window and moves it between monitors
+      --
+      -- real_gui_scaling and real_hud_scaling can be used instead of DPI.
+      -- OSes don't necessarily give the physical DPI, as they may allow user configuration.
+      -- real_*_scaling is just OS DPI / 96 but with another level of user configuration.
+      {
+          -- Current size of the in-game render target.
+          --
+          -- This is usually the window size, but may be smaller in certain situations,
+          -- such as side-by-side mode.
+          size = {
+              x = 1308,
+              y = 577,
+          },
+
+          -- Estimated maximum formspec size before Minetest will start shrinking the
+          -- formspec to fit. For a fullscreen formspec, use a size 10-20% larger than
+          -- this and `padding[-0.01,-0.01]`.
+          max_formspec_size = {
+              x = 20,
+              y = 11.25
+          },
+
+          -- GUI Scaling multiplier
+          -- Equal to the setting `gui_scaling` multiplied by `dpi / 96`
+          real_gui_scaling = 1,
+
+          -- HUD Scaling multiplier
+          -- Equal to the setting `hud_scaling` multiplied by `dpi / 96`
+          real_hud_scaling = 1,
+      }
+
 
 
 Content and Packages

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -203,7 +203,6 @@ GUI
         will be added to fieldname value is set to formname itself
   * if `is_file_select` is `true`, a file and not a folder will be selected
   * returns nil or selected file/folder
-* `core.get_screen_info()`: DEPRECATED, use below 2 functions instead.
 * `core.get_active_renderer()`: Ex: "OpenGL 4.6".
 * `core.get_window_info()`: Same as server-side `get_player_window_information` API.
 

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -203,6 +203,7 @@ GUI
         will be added to fieldname value is set to formname itself
   * if `is_file_select` is `true`, a file and not a folder will be selected
   * returns nil or selected file/folder
+* `core.get_screen_info()`: DEPRECATED, use below 2 functions instead.
 * `core.get_active_renderer()`: Ex: "OpenGL 4.6".
 * `core.get_window_info()`: Same as server-side `get_player_window_information` API.
 

--- a/games/devtest/mods/testfullscreenfs/init.lua
+++ b/games/devtest/mods/testfullscreenfs/init.lua
@@ -1,7 +1,7 @@
 local function calculate_max_fs_size(window)
 	return {
-		x = window.size.x / (0.5555 * 96 * window.gui_scaling),
-		y = window.size.y / (0.5555 * 96 * window.gui_scaling),
+		x = window.size.x / (0.5555 * 96 * window.real_gui_scaling),
+		y = window.size.y / (0.5555 * 96 * window.real_gui_scaling),
 	}
 end
 

--- a/games/devtest/mods/testfullscreenfs/init.lua
+++ b/games/devtest/mods/testfullscreenfs/init.lua
@@ -14,7 +14,7 @@ local function show_fullscreen_fs(name)
 	local size = calculate_max_fs_size(window)
 	local fs = {
 		"formspec_version[4]",
-		("size[%f,%f]"):format(size.x, size.y),
+		("size[%f,%f;true]"):format(size.x, size.y),
 		"padding[-0.01,-0.01]",
 		("button[%f,%f;1,1;%s;%s]"):format(0, 0, "tl", "TL"),
 		("button[%f,%f;1,1;%s;%s]"):format(size.x - 1, 0, "tr", "TR"),

--- a/games/devtest/mods/testfullscreenfs/init.lua
+++ b/games/devtest/mods/testfullscreenfs/init.lua
@@ -1,0 +1,36 @@
+local function calculate_max_fs_size(window)
+	return {
+		x = window.size.x / (0.5555 * 96 * window.gui_scaling),
+		y = window.size.y / (0.5555 * 96 * window.gui_scaling),
+	}
+end
+
+local function show_fullscreen_fs(name)
+	local window = minetest.get_player_window_information(name)
+	if not window then
+		return false, "Unable to get window info"
+	end
+
+	local size = calculate_max_fs_size(window)
+	local fs = {
+		"formspec_version[4]",
+		("size[%f,%f]"):format(size.x, size.y),
+		"padding[-0.01,-0.01]",
+		("button[%f,%f;1,1;%s;%s]"):format(0, 0, "tl", "TL"),
+		("button[%f,%f;1,1;%s;%s]"):format(size.x - 1, 0, "tr", "TR"),
+		("button[%f,%f;1,1;%s;%s]"):format(size.x - 1, size.y - 1, "br", "BR"),
+		("button[%f,%f;1,1;%s;%s]"):format(0, size.y - 1, "bl", "BL"),
+
+		("label[%f,%f;%s]"):format(size.x / 2, size.y / 2, "Fullscreen")
+	}
+
+	print(table.concat(fs))
+
+	minetest.show_formspec(name, "testfullscreenfs:fs", table.concat(fs))
+	return true, ("Calculated size of %f, %f"):format(size.x, size.y)
+end
+
+
+minetest.register_chatcommand("testfullscreenfs", {
+	func = show_fullscreen_fs,
+})

--- a/games/devtest/mods/testfullscreenfs/init.lua
+++ b/games/devtest/mods/testfullscreenfs/init.lua
@@ -1,20 +1,15 @@
-local function calculate_max_fs_size(window)
-	return {
-		x = window.size.x / (0.5555 * 96 * window.real_gui_scaling),
-		y = window.size.y / (0.5555 * 96 * window.real_gui_scaling),
-	}
-end
-
 local function show_fullscreen_fs(name)
 	local window = minetest.get_player_window_information(name)
 	if not window then
 		return false, "Unable to get window info"
 	end
 
-	local size = calculate_max_fs_size(window)
+	print(dump(window))
+
+	local size = { x = window.max_formspec_size.x * 1.1, y = window.max_formspec_size.y * 1.1 }
 	local fs = {
 		"formspec_version[4]",
-		("size[%f,%f;true]"):format(size.x, size.y),
+		("size[%f,%f]"):format(size.x, size.y),
 		"padding[-0.01,-0.01]",
 		("button[%f,%f;1,1;%s;%s]"):format(0, 0, "tl", "TL"),
 		("button[%f,%f;1,1;%s;%s]"):format(size.x - 1, 0, "tr", "TR"),
@@ -23,8 +18,6 @@ local function show_fullscreen_fs(name)
 
 		("label[%f,%f;%s]"):format(size.x / 2, size.y / 2, "Fullscreen")
 	}
-
-	print(table.concat(fs))
 
 	minetest.show_formspec(name, "testfullscreenfs:fs", table.concat(fs))
 	return true, ("Calculated size of %f, %f"):format(size.x, size.y)

--- a/games/devtest/mods/testfullscreenfs/mod.conf
+++ b/games/devtest/mods/testfullscreenfs/mod.conf
@@ -1,0 +1,2 @@
+name = testfullscreenfs
+description = Test mod to use minetest.get_player_window_information()

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1383,9 +1383,8 @@ void Client::sendHaveMedia(const std::vector<u32> &tokens)
 
 void Client::sendUpdateClientInfo(const ClientDynamicInfo& info)
 {
-	NetworkPacket pkt(TOSERVER_UPDATE_CLIENT_INFO, 4*2 + 2 + 4 + 4);
-	pkt << (u32)info.screen_size.X << (u32)info.screen_size.Y;
-	pkt << info.dpi;
+	NetworkPacket pkt(TOSERVER_UPDATE_CLIENT_INFO, 4*2 + 4 + 4);
+	pkt << (u32)info.render_target_size.X << (u32)info.render_target_size.Y;
 	pkt << info.gui_scaling;
 	pkt << info.hud_scaling;
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1381,6 +1381,17 @@ void Client::sendHaveMedia(const std::vector<u32> &tokens)
 	Send(&pkt);
 }
 
+void Client::sendUpdateClientInfo(const ClientDynamicInfo& info)
+{
+	NetworkPacket pkt(TOSERVER_UPDATE_CLIENT_INFO, 4*2 + 2 + 4 + 4);
+	pkt << (u32)info.screen_size.X << (u32)info.screen_size.Y;
+	pkt << info.dpi;
+	pkt << info.gui_scaling;
+	pkt << info.hud_scaling;
+
+	Send(&pkt);
+}
+
 void Client::removeNode(v3s16 p)
 {
 	std::map<v3s16, MapBlock*> modified_blocks;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1383,7 +1383,7 @@ void Client::sendHaveMedia(const std::vector<u32> &tokens)
 
 void Client::sendUpdateClientInfo(const ClientDynamicInfo& info)
 {
-	NetworkPacket pkt(TOSERVER_UPDATE_CLIENT_INFO, 4*2 + 4 + 4 + 4*4);
+	NetworkPacket pkt(TOSERVER_UPDATE_CLIENT_INFO, 4*2 + 4 + 4 + 4*2);
 	pkt << (u32)info.render_target_size.X << (u32)info.render_target_size.Y;
 	pkt << info.real_gui_scaling;
 	pkt << info.real_hud_scaling;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1383,10 +1383,11 @@ void Client::sendHaveMedia(const std::vector<u32> &tokens)
 
 void Client::sendUpdateClientInfo(const ClientDynamicInfo& info)
 {
-	NetworkPacket pkt(TOSERVER_UPDATE_CLIENT_INFO, 4*2 + 4 + 4);
+	NetworkPacket pkt(TOSERVER_UPDATE_CLIENT_INFO, 4*2 + 4 + 4 + 4*4);
 	pkt << (u32)info.render_target_size.X << (u32)info.render_target_size.Y;
 	pkt << info.real_gui_scaling;
 	pkt << info.real_hud_scaling;
+	pkt << (f32)info.max_fs_size.X << (f32)info.max_fs_size.Y;
 
 	Send(&pkt);
 }

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1385,8 +1385,8 @@ void Client::sendUpdateClientInfo(const ClientDynamicInfo& info)
 {
 	NetworkPacket pkt(TOSERVER_UPDATE_CLIENT_INFO, 4*2 + 4 + 4);
 	pkt << (u32)info.render_target_size.X << (u32)info.render_target_size.Y;
-	pkt << info.gui_scaling;
-	pkt << info.hud_scaling;
+	pkt << info.real_gui_scaling;
+	pkt << info.real_hud_scaling;
 
 	Send(&pkt);
 }

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -38,6 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "network/address.h"
 #include "network/peerhandler.h"
 #include "gameparams.h"
+#include "clientdynamicinfo.h"
 #include <fstream>
 
 #define CLIENT_CHAT_MESSAGE_LIMIT_PER_10S 10.0f
@@ -250,6 +251,7 @@ public:
 	void sendRespawn();
 	void sendReady();
 	void sendHaveMedia(const std::vector<u32> &tokens);
+	void sendUpdateClientInfo(const ClientDynamicInfo &info);
 
 	ClientEnvironment& getEnv() { return m_env; }
 	ITextureSource *tsrc() { return getTextureSource(); }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -918,7 +918,7 @@ private:
 	static const ClientEventHandler clientEventHandler[CLIENTEVENT_MAX];
 
 	f32 getSensitivityScaleFactor() const;
-	ClientDynamicInfo getCurrentDisplayInfo() const;
+	ClientDynamicInfo getCurrentDynamicInfo() const;
 
 	InputHandler *input = nullptr;
 
@@ -1202,13 +1202,13 @@ void Game::run()
 			&& !(*kill || g_gamecallback->shutdown_requested
 			|| (server && server->isShutdownRequested()))) {
 
-		const auto current_display_info = getCurrentDisplayInfo();
+		const auto current_display_info = getCurrentDynamicInfo();
 		if (!current_display_info.equal(client_display_info)) {
 			client_display_info = current_display_info;
 			client->sendUpdateClientInfo(current_display_info);
 		}
 
-		const auto &current_screen_size = current_display_info.screen_size;
+		const auto &current_screen_size = current_display_info.render_target_size;
 
 		// Verify if window size has changed and save it if it's the case
 		// Ensure evaluating settings->getBool after verifying screensize
@@ -2597,14 +2597,14 @@ f32 Game::getSensitivityScaleFactor() const
 	return tan(fov_y / 2.0f) * 1.3763818698f;
 }
 
-ClientDynamicInfo Game::getCurrentDisplayInfo() const
+ClientDynamicInfo Game::getCurrentDynamicInfo() const
 {
 	v2u32 screen_size = RenderingEngine::getWindowSize();
-	f32 dpi = RenderingEngine::getDisplayDensity() * 96.0f;
-	f32 gui_scaling = g_settings->getFloat("gui_scaling");
-	f32 hud_scaling = g_settings->getFloat("hud_scaling");;
+	f32 density = RenderingEngine::getDisplayDensity();
+	f32 gui_scaling = g_settings->getFloat("gui_scaling") * density;
+	f32 hud_scaling = g_settings->getFloat("hud_scaling") * density;
 
-	return { screen_size, dpi, gui_scaling, hud_scaling };
+	return { screen_size, gui_scaling, hud_scaling };
 }
 
 void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2614,7 +2614,7 @@ ClientDynamicInfo Game::getCurrentDynamicInfo() const
 
 	return {
 		screen_size, gui_scaling, hud_scaling,
-		ClientDynamicInfo::calculateMaxFSSize(screen_size, gui_scaling)
+		ClientDynamicInfo::calculateMaxFSSize(screen_size)
 	};
 }
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2612,7 +2612,10 @@ ClientDynamicInfo Game::getCurrentDynamicInfo() const
 	f32 gui_scaling = g_settings->getFloat("gui_scaling") * density;
 	f32 hud_scaling = g_settings->getFloat("hud_scaling") * density;
 
-	return { screen_size, gui_scaling, hud_scaling };
+	return {
+		screen_size, gui_scaling, hud_scaling,
+		ClientDynamicInfo::calculateMaxFSSize(screen_size, gui_scaling)
+	};
 }
 
 void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -67,6 +67,12 @@ public:
 
 	void removeMesh(const scene::IMesh* mesh);
 
+	/**
+	 * This takes 3d_mode into account - side-by-side will return a
+	 * halved horizontal size.
+	 *
+	 * @return "window" size
+	 */
 	static v2u32 getWindowSize()
 	{
 		sanity_check(s_singleton);

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -6,12 +6,12 @@
 struct ClientDynamicInfo
 {
 	v2u32 render_target_size;
-	f32 gui_scaling;
-	f32 hud_scaling;
+	f32 real_gui_scaling;
+	f32 real_hud_scaling;
 
 	bool equal(const ClientDynamicInfo &other) const {
 		return render_target_size == other.render_target_size &&
-				abs(gui_scaling - other.gui_scaling) < 0.001f &&
-				abs(hud_scaling - other.hud_scaling) < 0.001f;
+				abs(real_gui_scaling - other.real_gui_scaling) < 0.001f &&
+				abs(real_hud_scaling - other.real_hud_scaling) < 0.001f;
 	}
 };

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "irrTypes.h"
+
+
+struct ClientDynamicInfo
+{
+	v2u32 screen_size;
+	f32 dpi;
+	f32 gui_scaling;
+	f32 hud_scaling;
+
+	bool equal(const ClientDynamicInfo &other) const {
+		return screen_size == other.screen_size &&
+				abs(dpi - other.dpi) < 0.001f &&
+				abs(gui_scaling - other.gui_scaling) < 0.001f &&
+				abs(hud_scaling - other.hud_scaling) < 0.001f;
+	}
+};

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -5,14 +5,12 @@
 
 struct ClientDynamicInfo
 {
-	v2u32 screen_size;
-	f32 dpi;
+	v2u32 render_target_size;
 	f32 gui_scaling;
 	f32 hud_scaling;
 
 	bool equal(const ClientDynamicInfo &other) const {
-		return screen_size == other.screen_size &&
-				abs(dpi - other.dpi) < 0.001f &&
+		return render_target_size == other.render_target_size &&
 				abs(gui_scaling - other.gui_scaling) < 0.001f &&
 				abs(hud_scaling - other.hud_scaling) < 0.001f;
 	}

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -8,10 +8,16 @@ struct ClientDynamicInfo
 	v2u32 render_target_size;
 	f32 real_gui_scaling;
 	f32 real_hud_scaling;
+	v2f32 max_fs_size;
 
 	bool equal(const ClientDynamicInfo &other) const {
 		return render_target_size == other.render_target_size &&
 				abs(real_gui_scaling - other.real_gui_scaling) < 0.001f &&
 				abs(real_hud_scaling - other.real_hud_scaling) < 0.001f;
+	}
+
+	static v2f32 calculateMaxFSSize(v2u32 render_target_size, f32 real_gui_scaling) {
+		float slot_size = 0.5555f * 96.f * real_gui_scaling;
+		return v2f32(render_target_size.X, render_target_size.Y) / slot_size;
 	}
 };

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -1,3 +1,22 @@
+/*
+Minetest
+Copyright (C) 2022-3 rubenwardy <rw@rubenwardy.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
 #pragma once
 
 #include "irrTypes.h"

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -16,8 +16,17 @@ struct ClientDynamicInfo
 				abs(real_hud_scaling - other.real_hud_scaling) < 0.001f;
 	}
 
-	static v2f32 calculateMaxFSSize(v2u32 render_target_size, f32 real_gui_scaling) {
-		float slot_size = 0.5555f * 96.f * real_gui_scaling;
-		return v2f32(render_target_size.X, render_target_size.Y) / slot_size;
+	static v2f32 calculateMaxFSSize(v2u32 render_target_size) {
+		f32 factor =
+#ifdef HAVE_TOUCHSCREENGUI
+				10;
+#else
+				15;
+#endif
+		f32 ratio = (f32)render_target_size.X / (f32)render_target_size.Y;
+		if (ratio < 1)
+			return { factor, factor / ratio };
+		else
+			return { factor * ratio, factor };
 	}
 };

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "network/address.h"
 #include "porting.h"
 #include "threading/mutex_auto_lock.h"
+#include "clientdynamicinfo.h"
 
 #include <list>
 #include <vector>
@@ -350,6 +351,9 @@ public:
 	void setCachedAddress(const Address &addr) { m_addr = addr; }
 	const Address &getAddress() const { return m_addr; }
 
+	void setDynamicInfo(const ClientDynamicInfo &info) { m_dynamic_info = info; }
+	const ClientDynamicInfo &getDynamicInfo() const { return m_dynamic_info; }
+
 private:
 	// Version is stored in here after INIT before INIT2
 	u8 m_pending_serialization_version = SER_FMT_VER_INVALID;
@@ -360,8 +364,11 @@ private:
 	// Cached here so retrieval doesn't have to go to connection API
 	Address m_addr;
 
-	// Client sent language code
+	// Client-sent language code
 	std::string m_lang_code;
+
+	// Client-sent dynamic info
+	ClientDynamicInfo m_dynamic_info{};
 
 	/*
 		Blocks that have been sent to client.

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -223,4 +223,5 @@ const ServerCommandFactory serverCommandFactoryTable[TOSERVER_NUM_MSG_TYPES] =
 	{ "TOSERVER_FIRST_SRP",          1, true }, // 0x50
 	{ "TOSERVER_SRP_BYTES_A",        1, true }, // 0x51
 	{ "TOSERVER_SRP_BYTES_M",        1, true }, // 0x52
+	{ "TOSERVER_UPDATE_CLIENT_INFO", 1, true }, // 0x53
 };

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -1066,6 +1066,7 @@ enum ToServerCommand
 		v2s16 render_target_size
 		f32 gui_scaling
 		f32 hud_scaling
+		v2f32 max_fs_info
  	*/
 
 	TOSERVER_NUM_MSG_TYPES = 0x54,

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -1061,7 +1061,15 @@ enum ToServerCommand
 		std::string bytes_M
 	*/
 
-	TOSERVER_NUM_MSG_TYPES = 0x53,
+	TOSERVER_UPDATE_CLIENT_INFO = 0x53,
+	/*
+		v2s16 screen_size
+		f32 dpi
+		f32 gui_scaling
+		f32 hud_scaling
+ 	*/
+
+	TOSERVER_NUM_MSG_TYPES = 0x54,
 };
 
 enum AuthMechanism

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -1063,8 +1063,7 @@ enum ToServerCommand
 
 	TOSERVER_UPDATE_CLIENT_INFO = 0x53,
 	/*
-		v2s16 screen_size
-		f32 dpi
+		v2s16 render_target_size
 		f32 gui_scaling
 		f32 hud_scaling
  	*/

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -107,6 +107,7 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	{ "TOSERVER_FIRST_SRP",                TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_FirstSrp }, // 0x50
 	{ "TOSERVER_SRP_BYTES_A",              TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_SrpBytesA }, // 0x51
 	{ "TOSERVER_SRP_BYTES_M",              TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_SrpBytesM }, // 0x52
+	{ "TOSERVER_UPDATE_CLIENT_INFO",       TOSERVER_STATE_INGAME, &Server::handleCommand_UpdateClientInfo }, // 0x53
 };
 
 const static ClientCommandFactory null_command_factory = { "TOCLIENT_NULL", 0, false };

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1848,8 +1848,8 @@ void Server::handleCommand_UpdateClientInfo(NetworkPacket *pkt)
 	ClientDynamicInfo info;
 	*pkt >> info.render_target_size.X;
 	*pkt >> info.render_target_size.Y;
-	*pkt >> info.gui_scaling;
-	*pkt >> info.hud_scaling;
+	*pkt >> info.real_gui_scaling;
+	*pkt >> info.real_hud_scaling;
 
 	session_t peer_id = pkt->getPeerId();
 	RemoteClient *client = getClient(peer_id, CS_Invalid);

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1846,9 +1846,8 @@ void Server::handleCommand_HaveMedia(NetworkPacket *pkt)
 void Server::handleCommand_UpdateClientInfo(NetworkPacket *pkt)
 {
 	ClientDynamicInfo info;
-	*pkt >> info.screen_size.X;
-	*pkt >> info.screen_size.Y;
-	*pkt >> info.dpi;
+	*pkt >> info.render_target_size.X;
+	*pkt >> info.render_target_size.Y;
 	*pkt >> info.gui_scaling;
 	*pkt >> info.hud_scaling;
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1850,6 +1850,8 @@ void Server::handleCommand_UpdateClientInfo(NetworkPacket *pkt)
 	*pkt >> info.render_target_size.Y;
 	*pkt >> info.real_gui_scaling;
 	*pkt >> info.real_hud_scaling;
+	*pkt >> info.max_fs_size.X;
+	*pkt >> info.max_fs_size.Y;
 
 	session_t peer_id = pkt->getPeerId();
 	RemoteClient *client = getClient(peer_id, CS_Invalid);

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -40,6 +40,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/pointedthing.h"
 #include "util/serialize.h"
 #include "util/srp.h"
+#include "clientdynamicinfo.h"
 
 void Server::handleCommand_Deprecated(NetworkPacket* pkt)
 {
@@ -1840,4 +1841,18 @@ void Server::handleCommand_HaveMedia(NetworkPacket *pkt)
 				getScriptIface()->on_dynamic_media_added(token, player->getName());
 		}
 	}
+}
+
+void Server::handleCommand_UpdateClientInfo(NetworkPacket *pkt)
+{
+	ClientDynamicInfo info;
+	*pkt >> info.screen_size.X;
+	*pkt >> info.screen_size.Y;
+	*pkt >> info.dpi;
+	*pkt >> info.gui_scaling;
+	*pkt >> info.hud_scaling;
+
+	session_t peer_id = pkt->getPeerId();
+	RemoteClient *client = getClient(peer_id, CS_Invalid);
+	client->setDynamicInfo(info);
 }

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -128,6 +128,15 @@ void push_v2s32(lua_State *L, v2s32 p)
 	lua_setfield(L, -2, "y");
 }
 
+void push_v2u32(lua_State *L, v2u32 p)
+{
+	lua_createtable(L, 0, 2);
+	lua_pushinteger(L, p.X);
+	lua_setfield(L, -2, "x");
+	lua_pushinteger(L, p.Y);
+	lua_setfield(L, -2, "y");
+}
+
 v2s32 read_v2s32(lua_State *L, int index)
 {
 	v2s32 p;

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -108,6 +108,7 @@ size_t              read_stringlist     (lua_State *L, int index,
 
 void                push_v2s16          (lua_State *L, v2s16 p);
 void                push_v2s32          (lua_State *L, v2s32 p);
+void                push_v2u32          (lua_State *L, v2u32 p);
 void                push_v3s16          (lua_State *L, v3s16 p);
 void                push_aabb3f         (lua_State *L, aabb3f box);
 void                push_ARGB8          (lua_State *L, video::SColor color);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -952,6 +952,31 @@ int ModApiMainMenu::l_get_window_info(lua_State *L)
 	return 1;
 }
 
+/******************************************************************************/
+int ModApiMainMenu::l_get_screen_info(lua_State *L)
+{
+	lua_newtable(L);
+	int top = lua_gettop(L);
+	lua_pushstring(L,"density");
+	lua_pushnumber(L,RenderingEngine::getDisplayDensity());
+	lua_settable(L, top);
+
+	const v2u32 &window_size = RenderingEngine::getWindowSize();
+	lua_pushstring(L,"window_width");
+	lua_pushnumber(L, window_size.X);
+	lua_settable(L, top);
+
+	lua_pushstring(L,"window_height");
+	lua_pushnumber(L, window_size.Y);
+	lua_settable(L, top);
+
+	lua_pushstring(L, "render_info");
+	lua_pushstring(L, wide_to_utf8(RenderingEngine::get_video_driver()->getName()).c_str());
+	lua_settable(L, top);
+	return 1;
+}
+/******************************************************************************/
+
 int ModApiMainMenu::l_get_active_renderer(lua_State *L)
 {
 	lua_pushstring(L, wide_to_utf8(RenderingEngine::get_video_driver()->getName()).c_str());
@@ -1099,6 +1124,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(download_file);
 	API_FCT(gettext);
 	API_FCT(get_video_drivers);
+	API_FCT(get_screen_info);
 	API_FCT(get_window_info);
 	API_FCT(get_active_renderer);
 	API_FCT(get_min_supp_proto);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -40,6 +40,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "network/networkprotocol.h"
 #include "content/mod_configuration.h"
 #include "threading/mutex_auto_lock.h"
+#include "common/c_converter.h"
 
 /******************************************************************************/
 std::string ModApiMainMenu::getTextData(lua_State *L, std::string name)
@@ -922,26 +923,38 @@ int ModApiMainMenu::l_gettext(lua_State *L)
 }
 
 /******************************************************************************/
-int ModApiMainMenu::l_get_screen_info(lua_State *L)
+int ModApiMainMenu::l_get_window_info(lua_State *L)
 {
 	lua_newtable(L);
 	int top = lua_gettop(L);
-	lua_pushstring(L,"density");
-	lua_pushnumber(L,RenderingEngine::getDisplayDensity());
-	lua_settable(L, top);
 
 	const v2u32 &window_size = RenderingEngine::getWindowSize();
-	lua_pushstring(L,"window_width");
-	lua_pushnumber(L, window_size.X);
+	f32 density = RenderingEngine::getDisplayDensity();
+	f32 gui_scaling = g_settings->getFloat("gui_scaling") * density;
+	f32 hud_scaling = g_settings->getFloat("hud_scaling") * density;
+
+	lua_pushstring(L, "size");
+	push_v2u32(L, window_size);
 	lua_settable(L, top);
 
-	lua_pushstring(L,"window_height");
-	lua_pushnumber(L, window_size.Y);
+	lua_pushstring(L, "max_formspec_size");
+	push_v2f(L, ClientDynamicInfo::calculateMaxFSSize(window_size));
 	lua_settable(L, top);
 
-	lua_pushstring(L, "render_info");
+	lua_pushstring(L, "real_gui_scaling");
+	lua_pushnumber(L, gui_scaling);
+	lua_settable(L, top);
+
+	lua_pushstring(L, "real_hud_scaling");
+	lua_pushnumber(L, hud_scaling);
+	lua_settable(L, top);
+
+	return 1;
+}
+
+int ModApiMainMenu::l_get_active_renderer(lua_State *L)
+{
 	lua_pushstring(L, wide_to_utf8(RenderingEngine::get_video_driver()->getName()).c_str());
-	lua_settable(L, top);
 	return 1;
 }
 
@@ -1086,7 +1099,8 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(download_file);
 	API_FCT(gettext);
 	API_FCT(get_video_drivers);
-	API_FCT(get_screen_info);
+	API_FCT(get_window_info);
+	API_FCT(get_active_renderer);
 	API_FCT(get_min_supp_proto);
 	API_FCT(get_max_supp_proto);
 	API_FCT(open_url);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -953,29 +953,6 @@ int ModApiMainMenu::l_get_window_info(lua_State *L)
 }
 
 /******************************************************************************/
-int ModApiMainMenu::l_get_screen_info(lua_State *L)
-{
-	lua_newtable(L);
-	int top = lua_gettop(L);
-	lua_pushstring(L,"density");
-	lua_pushnumber(L,RenderingEngine::getDisplayDensity());
-	lua_settable(L, top);
-
-	const v2u32 &window_size = RenderingEngine::getWindowSize();
-	lua_pushstring(L,"window_width");
-	lua_pushnumber(L, window_size.X);
-	lua_settable(L, top);
-
-	lua_pushstring(L,"window_height");
-	lua_pushnumber(L, window_size.Y);
-	lua_settable(L, top);
-
-	lua_pushstring(L, "render_info");
-	lua_pushstring(L, wide_to_utf8(RenderingEngine::get_video_driver()->getName()).c_str());
-	lua_settable(L, top);
-	return 1;
-}
-/******************************************************************************/
 
 int ModApiMainMenu::l_get_active_renderer(lua_State *L)
 {
@@ -1124,7 +1101,6 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(download_file);
 	API_FCT(gettext);
 	API_FCT(get_video_drivers);
-	API_FCT(get_screen_info);
 	API_FCT(get_window_info);
 	API_FCT(get_active_renderer);
 	API_FCT(get_min_supp_proto);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -104,7 +104,9 @@ private:
 
 	static int l_set_formspec_prepend(lua_State *L);
 
-	static int l_get_screen_info(lua_State *L);
+	static int l_get_window_info(lua_State *L);
+
+	static int l_get_active_renderer(lua_State *L);
 
 	//filesystem
 

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -104,8 +104,6 @@ private:
 
 	static int l_set_formspec_prepend(lua_State *L);
 
-	static int l_get_screen_info(lua_State *L);
-
 	static int l_get_window_info(lua_State *L);
 
 	static int l_get_active_renderer(lua_State *L);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -104,6 +104,8 @@ private:
 
 	static int l_set_formspec_prepend(lua_State *L);
 
+	static int l_get_screen_info(lua_State *L);
+
 	static int l_get_window_info(lua_State *L);
 
 	static int l_get_active_renderer(lua_State *L);

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -291,12 +291,12 @@ int ModApiServer::l_get_player_window_information(lua_State *L)
 		push_v2u32(L, dynamic->render_target_size);
 		lua_settable(L, dyn_table);
 
-		lua_pushstring(L, "gui_scaling");
-		lua_pushnumber(L, dynamic->gui_scaling);
+		lua_pushstring(L, "real_gui_scaling");
+		lua_pushnumber(L, dynamic->real_gui_scaling);
 		lua_settable(L, dyn_table);
 
-		lua_pushstring(L, "hud_scaling");
-		lua_pushnumber(L, dynamic->hud_scaling);
+		lua_pushstring(L, "real_hud_scaling");
+		lua_pushnumber(L, dynamic->real_hud_scaling);
 		lua_settable(L, dyn_table);
 	}
 

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -240,6 +240,30 @@ int ModApiServer::l_get_player_information(lua_State *L)
 	lua_pushstring(L, info.lang_code.c_str());
 	lua_settable(L, table);
 
+	if (info.dynamic && info.dynamic->screen_size != v2u32()) {
+		lua_pushstring(L, "display");
+		lua_newtable(L);
+		int dyn_table = lua_gettop(L);
+
+		lua_pushstring(L, "screen_size");
+		push_v2u32(L, info.dynamic->screen_size);
+		lua_settable(L, dyn_table);
+
+		lua_pushstring(L, "dpi");
+		lua_pushnumber(L, info.dynamic->dpi);
+		lua_settable(L, dyn_table);
+
+		lua_pushstring(L, "gui_scaling");
+		lua_pushnumber(L, info.dynamic->gui_scaling);
+		lua_settable(L, dyn_table);
+
+		lua_pushstring(L, "hud_scaling");
+		lua_pushnumber(L, info.dynamic->hud_scaling);
+		lua_settable(L, dyn_table);
+
+		lua_settable(L, table);
+	}
+
 #ifndef NDEBUG
 	lua_pushstring(L,"serialization_version");
 	lua_pushnumber(L, info.ser_vers);

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -240,30 +240,6 @@ int ModApiServer::l_get_player_information(lua_State *L)
 	lua_pushstring(L, info.lang_code.c_str());
 	lua_settable(L, table);
 
-	if (info.dynamic && info.dynamic->screen_size != v2u32()) {
-		lua_pushstring(L, "display");
-		lua_newtable(L);
-		int dyn_table = lua_gettop(L);
-
-		lua_pushstring(L, "screen_size");
-		push_v2u32(L, info.dynamic->screen_size);
-		lua_settable(L, dyn_table);
-
-		lua_pushstring(L, "dpi");
-		lua_pushnumber(L, info.dynamic->dpi);
-		lua_settable(L, dyn_table);
-
-		lua_pushstring(L, "gui_scaling");
-		lua_pushnumber(L, info.dynamic->gui_scaling);
-		lua_settable(L, dyn_table);
-
-		lua_pushstring(L, "hud_scaling");
-		lua_pushnumber(L, info.dynamic->hud_scaling);
-		lua_settable(L, dyn_table);
-
-		lua_settable(L, table);
-	}
-
 #ifndef NDEBUG
 	lua_pushstring(L,"serialization_version");
 	lua_pushnumber(L, info.ser_vers);
@@ -289,6 +265,40 @@ int ModApiServer::l_get_player_information(lua_State *L)
 	lua_pushstring(L, ClientInterface::state2Name(info.state).c_str());
 	lua_settable(L, table);
 #endif
+
+	return 1;
+}
+
+// get_player_window_information(name)
+int ModApiServer::l_get_player_window_information(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	Server *server = getServer(L);
+
+	const char *name = luaL_checkstring(L, 1);
+	RemotePlayer *player = server->getEnv().getPlayer(name);
+	if (!player)
+		return 0;
+
+	auto dynamic = server->getClientDynamicInfo(player->getPeerId());
+
+	if (dynamic && dynamic->render_target_size != v2u32()) {
+		lua_newtable(L);
+		int dyn_table = lua_gettop(L);
+
+		lua_pushstring(L, "size");
+		push_v2u32(L, dynamic->render_target_size);
+		lua_settable(L, dyn_table);
+
+		lua_pushstring(L, "gui_scaling");
+		lua_pushnumber(L, dynamic->gui_scaling);
+		lua_settable(L, dyn_table);
+
+		lua_pushstring(L, "hud_scaling");
+		lua_pushnumber(L, dynamic->hud_scaling);
+		lua_settable(L, dyn_table);
+	}
 
 	return 1;
 }
@@ -659,6 +669,7 @@ void ModApiServer::Initialize(lua_State *L, int top)
 	API_FCT(dynamic_add_media);
 
 	API_FCT(get_player_information);
+	API_FCT(get_player_window_information);
 	API_FCT(get_player_privs);
 	API_FCT(get_player_ip);
 	API_FCT(get_ban_list);

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -283,23 +283,23 @@ int ModApiServer::l_get_player_window_information(lua_State *L)
 
 	auto dynamic = server->getClientDynamicInfo(player->getPeerId());
 
-	if (dynamic && dynamic->render_target_size != v2u32()) {
-		lua_newtable(L);
-		int dyn_table = lua_gettop(L);
+	if (!dynamic || dynamic->render_target_size == v2u32())
+		return 0;
 
-		lua_pushstring(L, "size");
-		push_v2u32(L, dynamic->render_target_size);
-		lua_settable(L, dyn_table);
+	lua_newtable(L);
+	int dyn_table = lua_gettop(L);
 
-		lua_pushstring(L, "real_gui_scaling");
-		lua_pushnumber(L, dynamic->real_gui_scaling);
-		lua_settable(L, dyn_table);
+	lua_pushstring(L, "size");
+	push_v2u32(L, dynamic->render_target_size);
+	lua_settable(L, dyn_table);
 
-		lua_pushstring(L, "real_hud_scaling");
-		lua_pushnumber(L, dynamic->real_hud_scaling);
-		lua_settable(L, dyn_table);
-	}
+	lua_pushstring(L, "real_gui_scaling");
+	lua_pushnumber(L, dynamic->real_gui_scaling);
+	lua_settable(L, dyn_table);
 
+	lua_pushstring(L, "real_hud_scaling");
+	lua_pushnumber(L, dynamic->real_hud_scaling);
+	lua_settable(L, dyn_table);
 	return 1;
 }
 

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -293,6 +293,10 @@ int ModApiServer::l_get_player_window_information(lua_State *L)
 	push_v2u32(L, dynamic->render_target_size);
 	lua_settable(L, dyn_table);
 
+	lua_pushstring(L, "max_formspec_size");
+	push_v2f(L, dynamic->max_fs_size);
+	lua_settable(L, dyn_table);
+
 	lua_pushstring(L, "real_gui_scaling");
 	lua_pushnumber(L, dynamic->real_gui_scaling);
 	lua_settable(L, dyn_table);

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -88,6 +88,9 @@ private:
 	// get_player_information(name)
 	static int l_get_player_information(lua_State *L);
 
+	// get_player_window_information(name)
+	static int l_get_player_window_information(lua_State *L);
+
 	// get_ban_list()
 	static int l_get_ban_list(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1297,6 +1297,8 @@ bool Server::getClientInfo(session_t peer_id, ClientInfo &ret)
 
 	ret.lang_code = client->getLangCode();
 
+	ret.dynamic = &client->getDynamicInfo();
+
 	return true;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1297,9 +1297,18 @@ bool Server::getClientInfo(session_t peer_id, ClientInfo &ret)
 
 	ret.lang_code = client->getLangCode();
 
-	ret.dynamic = &client->getDynamicInfo();
-
 	return true;
+}
+
+const ClientDynamicInfo *Server::getClientDynamicInfo(session_t peer_id)
+{
+	ClientInterface::AutoLock clientlock(m_clients);
+	RemoteClient *client = m_clients.lockedGetClientNoEx(peer_id, CS_Invalid);
+
+	if (!client)
+		return nullptr;
+
+	return &client->getDynamicInfo();
 }
 
 void Server::handlePeerChanges()

--- a/src/server.h
+++ b/src/server.h
@@ -132,8 +132,6 @@ struct ClientInfo {
 	u16 prot_vers;
 	u8 major, minor, patch;
 	std::string vers_string, lang_code;
-
-	const ClientDynamicInfo *dynamic = nullptr;
 };
 
 class Server : public con::PeerHandler, public MapEventReceiver,
@@ -344,6 +342,7 @@ public:
 	void DisconnectPeer(session_t peer_id);
 	bool getClientConInfo(session_t peer_id, con::rtt_stat_type type, float *retval);
 	bool getClientInfo(session_t peer_id, ClientInfo &ret);
+	const ClientDynamicInfo *getClientDynamicInfo(session_t peer_id);
 
 	void printToConsoleOnly(const std::string &text);
 

--- a/src/server.h
+++ b/src/server.h
@@ -132,6 +132,8 @@ struct ClientInfo {
 	u16 prot_vers;
 	u8 major, minor, patch;
 	std::string vers_string, lang_code;
+
+	const ClientDynamicInfo *dynamic = nullptr;
 };
 
 class Server : public con::PeerHandler, public MapEventReceiver,
@@ -195,6 +197,7 @@ public:
 	void handleCommand_SrpBytesA(NetworkPacket* pkt);
 	void handleCommand_SrpBytesM(NetworkPacket* pkt);
 	void handleCommand_HaveMedia(NetworkPacket *pkt);
+	void handleCommand_UpdateClientInfo(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 


### PR DESCRIPTION
\Adds a new packet to send dynamic client info to the server, and `minetest.get_player_window_information()`

Fixes #10632

```lua
* `minetest.get_player_window_information(player_name)`:

      -- Will only be present if the client sent this information (requires v5.7+)
      --
      -- Note that none of these things are constant, they are likely to change during a client
      -- connection as the player resizes the window and moves it between monitors
      --
      -- real_gui_scaling and real_hud_scaling can be used instead of DPI.
      -- OSes don't necessarily give the physical DPI, as they may allow user configuration.
      -- real_*_scaling is just OS DPI / 96 but with another level of user configuration.
      {
          -- Current size of the in-game render target.
          --
          -- This is usually the window size, but may be smaller in certain situations,
          -- such as side-by-side mode.
          size = {
              x = 1308,
              y = 577,
          },

          -- Estimated maximum formspec size before Minetest will start shrinking the
          -- formspec to fit. For a fullscreen formspec, use a size 10-20% larger than
          -- this and `padding[-0.01,-0.01]`.
          max_formspec_size = {
              x = 20,
              y = 11.25
          },

          -- GUI Scaling multiplier
          -- Equal to the setting `gui_scaling` multiplied by `dpi / 96`
          real_gui_scaling = 1,

          -- HUD Scaling multiplier
          -- Equal to the setting `hud_scaling` multiplied by `dpi / 96`
          real_hud_scaling = 1,
      }
```

## To do

This PR is ready for review

- [x] documentation
- [x] Testing
- [x] Return display = nil when the client doesn't send info
- [x] DPI is always an integer on Windows. Is it always an integer on other platforms?
- [x] should this be a new API function?
- [x] debounce sending
- [x] What other display information is needed?
- [x] ~~Resist fingerprinting~~
- [x] Move to player ObjectRef?
- [x] Add note that real_gui_scaling/real_hud_scaling can be used instead of DPI

## How to test

* See `/testfullscreenfs`
* Test in `sidebyside` 3d mode