### PR TITLE
Raise default max FPS on Android to 60

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -480,7 +480,6 @@ void set_default_settings()
 	settings->setDefault("emergequeue_limit_generate", "16");
 	settings->setDefault("max_block_generate_distance", "5");
 	settings->setDefault("enable_3d_clouds", "false");
-	settings->setDefault("fps_max", "30");
 	settings->setDefault("fps_max_unfocused", "10");
 	settings->setDefault("sqlite_synchronous", "1");
 	settings->setDefault("map_compression_level_disk", "-1");


### PR DESCRIPTION
This PR raises the default max FPS setting on Android to 60, like it is on desktop. Fixes #12009.

## Extremely unscientific personal anecdote
I play Minetest on my phone, which is a Nokia 5.4. It is a rather low-end device but it still manages to maintain a rather stable 60fps with a view range of 90, which makes me confident in saying that most phones *should* be able to hit 60fps at the lower default view range of 50 (if not it will still be better than the capped 30fps, unstable 40fps-50fps > stable 30fps IMO). I find this would also improve the overall feel of the Android version of Minetest, 30fps has always given it some amount of "jank", especially on a device that should definitively be able to handle more.

## To do
This PR is Ready for Review.

## How to test
Change the fps_max setting to 60 on your Android device, and play I guess.