### PR TITLE
Hide "Autosave Screen Size" on Android

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -200,7 +200,7 @@ local function formspec(tabview, name, tabdata)
 
 	if core.settings:get("touchscreen_threshold") ~= nil then
 		tab_string = tab_string ..
-			"label[4.25,3.5;" .. fgettext("Touch threshold: (px)") .. "]" ..
+			"label[4.25,3.5;" .. fgettext("Touch threshold (px):") .. "]" ..
 			"dropdown[4.25,3.95;3.5;dd_touchthreshold;0,10,20,30,40,50;" ..
 			((tonumber(core.settings:get("touchscreen_threshold")) / 10) + 1) ..
 			"]"

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -200,7 +200,7 @@ local function formspec(tabview, name, tabdata)
 
 	if core.settings:get("touchscreen_threshold") ~= nil then
 		tab_string = tab_string ..
-			"label[4.25,3.5;" .. fgettext("Touchthreshold: (px)") .. "]" ..
+			"label[4.25,3.5;" .. fgettext("Touch threshold: (px)") .. "]" ..
 			"dropdown[4.25,3.95;3.5;dd_touchthreshold;0,10,20,30,40,50;" ..
 			((tonumber(core.settings:get("touchscreen_threshold")) / 10) + 1) ..
 			"]"

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -160,7 +160,7 @@ local function formspec(tabview, name, tabdata)
 				.. getSettingIndex.NodeHighlighting() .. "]" ..
 		"dropdown[0.25,3.6;3.5;dd_leaves_style;" .. dd_options.leaves[1] .. ";"
 				.. getSettingIndex.Leaves() .. "]" ..
-		"box[4,0;3.75,4.5;#999999]" ..
+		"box[4,0;3.75,4.9;#999999]" ..
 		"label[4.25,0.1;" .. fgettext("Texturing:") .. "]" ..
 		"dropdown[4.25,0.55;3.5;dd_filters;" .. dd_options.filters[1] .. ";"
 				.. getSettingIndex.Filter() .. "]" ..
@@ -169,9 +169,6 @@ local function formspec(tabview, name, tabdata)
 		"label[4.25,2.15;" .. fgettext("Antialiasing:") .. "]" ..
 		"dropdown[4.25,2.6;3.5;dd_antialiasing;" .. dd_options.antialiasing[1] .. ";"
 				.. getSettingIndex.Antialiasing() .. "]" ..
-		"label[4.25,3.45;" .. fgettext("Screen:") .. "]" ..
-		"checkbox[4.25,3.6;cb_autosave_screensize;" .. fgettext("Autosave Screen Size") .. ";"
-				.. dump(core.settings:get_bool("autosave_screensize")) .. "]" ..
 		"box[8,0;3.75,4.5;#999999]"
 
 	local video_driver = core.settings:get("video_driver")
@@ -203,10 +200,15 @@ local function formspec(tabview, name, tabdata)
 
 	if core.settings:get("touchscreen_threshold") ~= nil then
 		tab_string = tab_string ..
-			"label[4.3,4.2;" .. fgettext("Touchthreshold: (px)") .. "]" ..
-			"dropdown[4.25,4.65;3.5;dd_touchthreshold;0,10,20,30,40,50;" ..
+			"label[4.25,3.5;" .. fgettext("Touchthreshold: (px)") .. "]" ..
+			"dropdown[4.25,3.95;3.5;dd_touchthreshold;0,10,20,30,40,50;" ..
 			((tonumber(core.settings:get("touchscreen_threshold")) / 10) + 1) ..
-			"]box[4.0,4.5;3.75,1.0;#999999]"
+			"]"
+	else
+		tab_string = tab_string ..
+			"label[4.25,3.65;" .. fgettext("Screen:") .. "]" ..
+			"checkbox[4.25,3.9;cb_autosave_screensize;" .. fgettext("Autosave Screen Size") .. ";"
+					.. dump(core.settings:get_bool("autosave_screensize")) .. "]"
 	end
 
 	if shaders_enabled then


### PR DESCRIPTION
This PR hides the "Autosave Screen Size" checkbox in the settings tab if you're on Android, since it is rather useless there. I also took the liberty of raising the "Touchscreen threshold" dropdown and giving the "Autosave Screen Size" checkbox a bit more room to breathe so that the center background box is the same size both on Android and desktop.

![Screenshot_20220524_214214](https://user-images.githubusercontent.com/60856959/170120081-20f301f5-ecbe-42d3-bc21-036a168458b4.png)
![Screenshot_20220524_214527](https://user-images.githubusercontent.com/60856959/170120097-2960ed4f-5313-4613-93d6-8266ab92622b.png)

## To do
This PR is Ready for Review.

## How to test
See that the chechbox is gone on Android.