### PR TITLE
Lua workflow: Bump Ubuntu version to 22.04

### DIFF
--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -17,7 +17,7 @@ jobs:
   # Note that the integration tests are also run build.yml, but only when C++ code is changed.
   integration_tests:
     name: "Compile and run multiplayer tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install deps
@@ -39,7 +39,7 @@ jobs:
 
   luacheck:
     name: "Builtin Luacheck and Unit Tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Install luarocks


### PR DESCRIPTION
in turn bumps the luarocks version to 3.8.0 fixing a 2.4.3 bug which leads to the workflow failing

See [the failed workflow here](https://github.com/minetest/minetest/runs/6628264075?check_suite_focus=true). This happens due to a Luarocks bug [fixed in 2.4.4](https://github.com/luarocks/luarocks/issues/713#issuecomment-372668216).