### PR TITLE
Fix automatic rotate for attached entities

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1199,7 +1199,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		}
 	}
 
-	if (!getParent() && node && fabs(m_prop.automatic_rotate) > 0.001f) {
+	if (node && fabs(m_prop.automatic_rotate) > 0.001f) {
 		// This is the child node's rotation. It is only used for automatic_rotate.
 		v3f local_rot = node->getRotation();
 		local_rot.Y = modulo360f(local_rot.Y - dtime * core::RADTODEG *


### PR DESCRIPTION
Trivial fix to make automatic rotation work for attached entities.

## How to test

```lua
minetest.register_entity("testentities:spinner", {
	initial_properties = {
		visual = "cube",
		textures = {"a", "a", "a", "a", "a", "a"},
		automatic_rotate = math.pi,
	},
	on_activate = function(self)
		self.object:set_armor_groups({punch_operable = 1})
	end,
	on_punch = function(self, puncher)
		self.object:set_attach(puncher)
	end
})
```
then `/spawnentity testentities:spinner` and punch it to attach
