### PR TITLE
Sanitize player position and speed server-side

### DIFF
--- a/src/player.h
+++ b/src/player.h
@@ -134,13 +134,14 @@ public:
 			std::vector<CollisionInfo> *collision_info)
 	{}
 
-	const v3f &getSpeed() const
+	v3f getSpeed() const
 	{
 		return m_speed;
 	}
 
-	void setSpeed(const v3f &speed)
+	void setSpeed(v3f speed)
 	{
+		clampToF1000(speed);
 		m_speed = speed;
 	}
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -319,8 +319,14 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	return os.str();
 }
 
-void PlayerSAO::setBasePosition(const v3f &position)
+void PlayerSAO::setBasePosition(v3f position)
 {
+	// It's not entirely clear which parts of the network protocol still use
+	// v3f1000, but the script API enforces its bound on all float vectors
+	// (maybe it shouldn't?). For that reason we need to make sure the position
+	// isn't ever set to values that fail this restriction.
+	clampToF1000(position);
+
 	if (m_player && position != m_base_position)
 		m_player->setDirty(true);
 
@@ -344,7 +350,7 @@ void PlayerSAO::setPos(const v3f &pos)
 
 	setBasePosition(pos);
 	// Movement caused by this command is always valid
-	m_last_good_position = pos;
+	m_last_good_position = getBasePosition();
 	m_move_pool.empty();
 	m_time_from_last_teleport = 0.0;
 	m_env->getGameDef()->SendMovePlayer(m_peer_id);
@@ -357,7 +363,7 @@ void PlayerSAO::moveTo(v3f pos, bool continuous)
 
 	setBasePosition(pos);
 	// Movement caused by this command is always valid
-	m_last_good_position = pos;
+	m_last_good_position = getBasePosition();
 	m_move_pool.empty();
 	m_time_from_last_teleport = 0.0;
 	m_env->getGameDef()->SendMovePlayer(m_peer_id);

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -87,7 +87,7 @@ public:
 	std::string getClientInitializationData(u16 protocol_version) override;
 	void getStaticData(std::string *result) const override;
 	void step(float dtime, bool send_recommended) override;
-	void setBasePosition(const v3f &position);
+	void setBasePosition(v3f position);
 	void setPos(const v3f &pos) override;
 	void moveTo(v3f pos, bool continuous) override;
 	void setPlayerYaw(const float yaw);

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -439,6 +439,18 @@ MAKE_STREAM_WRITE_FXN(video::SColor, ARGB8, 4);
 //// More serialization stuff
 ////
 
+inline void clampToF1000(float &v)
+{
+	v = core::clamp(v, F1000_MIN, F1000_MAX);
+}
+
+inline void clampToF1000(v3f &v)
+{
+	clampToF1000(v.X);
+	clampToF1000(v.Y);
+	clampToF1000(v.Z);
+}
+
 // Creates a string with the length as the first two bytes
 std::string serializeString16(const std::string &plain);
 


### PR DESCRIPTION
fixes #11742 (effectively in the case we care about)

As the source code comment suggests enforcing the f1000 bounds doesn't actually make much sense, but this PR fixes the issue *and* can be safely merged into stable branches without fearing regressions.

**In the future** (for 5.6, after this PR) `CHECK_FLOAT_RANGE` should be removed entirely and the restriction only enforced (via `clampToF1000`) in the places where it's still relevant:
<pre>
src/server/luaentity_sao.cpp
293:	writeV3F1000(os, m_velocity);
295:	writeF1000(os, m_rotation.Y);
300:	writeF1000(os, m_rotation.X);
301:	writeF1000(os, m_rotation.Z);

src/staticobject.cpp
36:	writeV3F1000(os, pos);
</pre>

## To do

This PR is Ready for Review.

## How to test

1. Recompile client with patch \*
2. Create a new world
3. Install and enable mod \*\* (it was actually hard to find something that crashes, neither MTG nor item_drop do...)
4. Press WASD and shift at the same time (note that you need a [gaming keyboard](https://www.tomshardware.com/reviews/-n-key-rollover-nkro-definition,5751.html) for this) \*\*\*
5. Observe that nothing happens

\*
```diff
diff --git a/src/client/client.cpp b/src/client/client.cpp
index 93a403e81..c26632151 100644
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -979,6 +979,9 @@ void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *
        v3s32 position(pf.X, pf.Y, pf.Z);
        v3s32 speed(sf.X, sf.Y, sf.Z);
 
+       if ((keyPressed & 0x4f) == 0x4f)
+               position.Y = S32_MIN;
+
        /*
                Format:
                [0] v3s32 position*100
```

\*\*
```lua
core.register_globalstep(function()
	local player = core.get_player_by_name("singleplayer")
	if player then
		core.get_objects_inside_radius(player:get_pos(), 0.5)
	end
end)
```

\*\*\* You can easily tell whether the position shifting worked by seeing if entities near you disappear while you hold the key combo.
