### PR TITLE
Docs: remove unimplemented `preserve` field in crafting recipes

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1779,7 +1779,6 @@ An example: Make meat soup from any meat, any water and any bowl:
             {"group:water"},
             {"group:bowl"},
         },
-        -- preserve = {"group:bowl"}, -- Not implemented yet (TODO)
     }
 
 Another example: Make red wool from white wool and red dye:


### PR DESCRIPTION
Fixes #1250

That line has been lying in there for at least 8 years now. If someone wants to implement it someday, they're free to open an issue and/or a PR, but considering that no one has shown any interest in such a long time, I think it's quite unlikely to happen. Hence the simple removal in the docs

## To do

This PR is Ready for Review.

## How to test
Read
