### PR TITLE
Fix BSD iconv declaration

### DIFF
--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -39,16 +39,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#include <windows.h>
 #endif
 
-#ifdef __NetBSD__
-	#include <sys/param.h>
-	#if __NetBSD_Version__ <= 999001500
-		#define BSD_ICONV_USED
-	#endif
-#elif defined(_ICONV_H_) && (defined(__FreeBSD__) || defined(__OpenBSD__) || \
-	defined(__DragonFly__))
-	#define BSD_ICONV_USED
-#endif
-
 #ifndef _WIN32
 
 static bool convert(const char *to, const char *from, char *outbuf,
@@ -56,11 +46,7 @@ static bool convert(const char *to, const char *from, char *outbuf,
 {
 	iconv_t cd = iconv_open(to, from);
 
-#ifdef BSD_ICONV_USED
-	const char *inbuf_ptr = inbuf;
-#else
 	char *inbuf_ptr = inbuf;
-#endif
 	char *outbuf_ptr = outbuf;
 
 	size_t *inbuf_left_ptr = &inbuf_size;


### PR DESCRIPTION
Fix #7295

Every modern BSD version uses the declaration without const
https://github.com/freebsd/freebsd-src/commit/1243a98e38a54709f670e748070f4051de2ad10f#diff-77c42797746fe492e237c8caaf4e7a3c5c9b1fd7ae398c607936bf45852188b5L56
https://github.com/DragonFlyBSD/DragonFlyBSD/commit/d960c16f87527f1b3d15a07a26e80ca82e7ae043#diff-77c42797746fe492e237c8caaf4e7a3c5c9b1fd7ae398c607936bf45852188b5
https://github.com/NetBSD/src/commit/822d8d667a3ee74d7b893e2e951f6324c94ace3c#diff-77c42797746fe492e237c8caaf4e7a3c5c9b1fd7ae398c607936bf45852188b5