### PR TITLE
`formspec_escape`: Restore backwards compat

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -254,7 +254,7 @@ local formspec_escapes = {
 }
 function core.formspec_escape(text)
 	-- Use explicit character set instead of dot here because it doubles the performance
-	return text and text:gsub("[\\%[%];,]", formspec_escapes)
+	return text and string.gsub(text, "[\\%[%];,]", formspec_escapes)
 end
 
 


### PR DESCRIPTION
Support numbers as arguments by using `string.gsub(text, ...)` instead of `text:gsub(...)` which will coerce `text` to a string

`text:gsub` failed on numbers because they don't have the string metatable set (duh)

Trivial fix for #12412