### PR TITLE
Lua API: Refer to the update_translations tool

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3653,7 +3653,7 @@ Translations
 Texts can be translated client-side with the help of `minetest.translate` and
 translation files.
 
-Use the tool [update_translations](https://github.com/minetest-tools/update_translations)
+Consider using the tool [update_translations](https://github.com/minetest-tools/update_translations)
 to generate and update translation files automatically from the Lua source.
 
 Translating a string

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3653,6 +3653,9 @@ Translations
 Texts can be translated client-side with the help of `minetest.translate` and
 translation files.
 
+Use the tool [update_translations](https://github.com/minetest-tools/update_translations)
+to generate and update translation files automatically from the Lua source.
+
 Translating a string
 --------------------
 


### PR DESCRIPTION
This is at least the third time I asked for the translation tool. Writing translation files manually is insane, hence the motivation for a well-established script to automatize the process. `minetest-tools` is not well known, hence a link in the relevant Lua API section makes totally sense.

I opened this PR to discuss whether to refer to the repository or to import the script into `utils` directly.

## To do

This PR is ready for discussion/review.
