### PR TITLE
Inline triLinearInterpolationNoEase and triLinearInterpolation

### DIFF
--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -192,6 +192,7 @@ inline float biLinearInterpolation(
 	float x, float y,
 	bool eased)
 {
+	// Inlining will optimize this branch out when possible
 	if (eased) {
 		x = easeCurve(x);
 		y = easeCurve(y);
@@ -208,6 +209,7 @@ inline float triLinearInterpolation(
 	float x, float y, float z,
 	bool eased)
 {
+	// Inlining will optimize this branch out when possible
 	if (eased) {
 		x = easeCurve(x);
 		y = easeCurve(y);

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -189,21 +189,13 @@ inline float linearInterpolation(float v0, float v1, float t)
 inline float biLinearInterpolation(
 	float v00, float v10,
 	float v01, float v11,
-	float x, float y)
+	float x, float y,
+	bool eased)
 {
-	float tx = easeCurve(x);
-	float ty = easeCurve(y);
-	float u = linearInterpolation(v00, v10, tx);
-	float v = linearInterpolation(v01, v11, tx);
-	return linearInterpolation(u, v, ty);
-}
-
-
-inline float biLinearInterpolationNoEase(
-	float v00, float v10,
-	float v01, float v11,
-	float x, float y)
-{
+	if (eased) {
+		x = easeCurve(x);
+		y = easeCurve(y);
+	}
 	float u = linearInterpolation(v00, v10, x);
 	float v = linearInterpolation(v01, v11, x);
 	return linearInterpolation(u, v, y);
@@ -213,23 +205,16 @@ inline float biLinearInterpolationNoEase(
 inline float triLinearInterpolation(
 	float v000, float v100, float v010, float v110,
 	float v001, float v101, float v011, float v111,
-	float x, float y, float z)
+	float x, float y, float z,
+	bool eased)
 {
-	float tx = easeCurve(x);
-	float ty = easeCurve(y);
-	float tz = easeCurve(z);
-	float u = biLinearInterpolationNoEase(v000, v100, v010, v110, tx, ty);
-	float v = biLinearInterpolationNoEase(v001, v101, v011, v111, tx, ty);
-	return linearInterpolation(u, v, tz);
-}
-
-inline float triLinearInterpolationNoEase(
-	float v000, float v100, float v010, float v110,
-	float v001, float v101, float v011, float v111,
-	float x, float y, float z)
-{
-	float u = biLinearInterpolationNoEase(v000, v100, v010, v110, x, y);
-	float v = biLinearInterpolationNoEase(v001, v101, v011, v111, x, y);
+	if (eased) {
+		x = easeCurve(x);
+		y = easeCurve(y);
+		z = easeCurve(z);
+	}
+	float u = biLinearInterpolation(v000, v100, v010, v110, x, y, false);
+	float v = biLinearInterpolation(v001, v101, v011, v111, x, y, false);
 	return linearInterpolation(u, v, z);
 }
 
@@ -247,10 +232,7 @@ float noise2d_gradient(float x, float y, s32 seed, bool eased)
 	float v01 = noise2d(x0, y0+1, seed);
 	float v11 = noise2d(x0+1, y0+1, seed);
 	// Interpolate
-	if (eased)
-		return biLinearInterpolation(v00, v10, v01, v11, xl, yl);
-
-	return biLinearInterpolationNoEase(v00, v10, v01, v11, xl, yl);
+	return biLinearInterpolation(v00, v10, v01, v11, xl, yl, eased);
 }
 
 
@@ -274,17 +256,11 @@ float noise3d_gradient(float x, float y, float z, s32 seed, bool eased)
 	float v011 = noise3d(x0,     y0 + 1, z0 + 1, seed);
 	float v111 = noise3d(x0 + 1, y0 + 1, z0 + 1, seed);
 	// Interpolate
-	if (eased) {
-		return triLinearInterpolation(
-			v000, v100, v010, v110,
-			v001, v101, v011, v111,
-			xl, yl, zl);
-	}
-
-	return triLinearInterpolationNoEase(
+	return triLinearInterpolation(
 		v000, v100, v010, v110,
 		v001, v101, v011, v111,
-		xl, yl, zl);
+		xl, yl, zl,
+		eased);
 }
 
 
@@ -536,9 +512,7 @@ void Noise::gradientMap2D(
 		noisex = 0;
 		for (i = 0; i != sx; i++) {
 			gradient_buf[index++] =
-				eased ?
-				biLinearInterpolation(v00, v10, v01, v11, u, v) :
-				biLinearInterpolationNoEase(v00, v10, v01, v11, u, v);
+				biLinearInterpolation(v00, v10, v01, v11, u, v, eased);
 
 			u += step_x;
 			if (u >= 1.0) {
@@ -615,16 +589,11 @@ void Noise::gradientMap3D(
 			u = orig_u;
 			noisex = 0;
 			for (i = 0; i != sx; i++) {
-				gradient_buf[index++] = eased ?
-					triLinearInterpolation(
-						v000, v100, v010, v110,
-						v001, v101, v011, v111,
-						u, v, w)
-					:
-					triLinearInterpolationNoEase(
-						v000, v100, v010, v110,
-						v001, v101, v011, v111,
-						u, v, w);
+				gradient_buf[index++] = triLinearInterpolation(
+					v000, v100, v010, v110,
+					v001, v101, v011, v111,
+					u, v, w,
+					eased);
 
 				u += step_x;
 				if (u >= 1.0) {


### PR DESCRIPTION
Performance profiling on Linux AMD64 showed this to be a significant bottleneck. The non-inlined functions are expensive due to XMM registers spilling onto the stack.

MapgenV7::generateTerrain measurements on my machine:

Average before: 24 ms per call
Average after: 13 ms per call

~80% speedup