### PR TITLE
fix macos build permissions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,6 +60,16 @@ jobs:
         run: |
           ./build/macos/minetest.app/Contents/MacOS/minetest --run-unittests
 
+      - name: CPack
+        run: |
+          cd build
+          cpack -G ZIP -B macos
+
+      - name: Package Clean
+        run: |
+          rm -r build/macos/_CPack_Packages
+          rm -rf build/macos/minetest.app
+
       - uses: actions/upload-artifact@v3
         with:
           name: minetest-macos


### PR DESCRIPTION
I was hoping to get a Homebrew cask going so the macOS installation instructions could be more up-to-date and not use the no-longer-supported `brew linkapps` command. I saw there was a workflow to build the macOS version, but it was just doing an upload of the raw .app bundle, which removes the necessary executable permissions. 

By zipping the .app directory beforehand (using CPack to try and match the existing builds), those permissions are retained. 

## To do

This PR is Ready for Review.

## How to test

1. Push a new set of changes, and download the macOS artifact afterwards.
2. Note that you can now run the .app file normally. 
