### PR TITLE
Speed up Mapgen::spreadLight by computing an upper bound Y for propagation

### DIFF
--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -196,6 +196,7 @@ public:
 	void calcLighting(v3s16 nmin, v3s16 nmax, v3s16 full_nmin, v3s16 full_nmax,
 		bool propagate_shadow = true);
 	void propagateSunlight(v3s16 nmin, v3s16 nmax, bool propagate_shadow);
+	int findPropagationCutoff(const v3s16 &nmin, const v3s16 &nmax);
 	void spreadLight(const v3s16 &nmin, const v3s16 &nmax);
 
 	virtual void makeChunk(BlockMakeData *data) {}


### PR DESCRIPTION
I discovered with profiling that spreadLight spends most of its time here:

https://github.com/minetest/minetest/blob/ba65e0ace76dc39dab15b70725cafc629d165e7f/src/mapgen/mapgen.cpp#L544-L549

Even in cases where `queue` is never used (no actual light propagation was done), it could still spend up to 25ms here for a single chunk! This worst case happens when there are many nodes with sunlight. The existing code requires checking every neighbor of every node with light != 0.

This adds a fast scan to determine where the solid sunlight ends, and skips propagation over that height. This saves a lot of time, since the fast scan only checks every node once. On my machine, this results in a 2.6x speedup of calcLighting (on average).