### PR TITLE
Implement core.get_node() in Lua so that it can be optimized by LuaJIT

### DIFF
--- a/builtin/async/game.lua
+++ b/builtin/async/game.lua
@@ -27,11 +27,13 @@ do
 
 	-- reassemble other tables
 	all.registered_nodes = {}
+	all.registered_content_ids = {}
 	all.registered_craftitems = {}
 	all.registered_tools = {}
 	for k, v in pairs(all.registered_items) do
 		if v.type == "node" then
 			all.registered_nodes[k] = v
+			all.registered_content_ids[v.content_id] = v
 		elseif v.type == "craftitem" then
 			all.registered_craftitems[k] = v
 		elseif v.type == "tool" then

--- a/builtin/game/init.lua
+++ b/builtin/game/init.lua
@@ -35,5 +35,6 @@ dofile(gamepath .. "forceloading.lua")
 dofile(gamepath .. "statbars.lua")
 dofile(gamepath .. "knockback.lua")
 dofile(gamepath .. "async.lua")
+dofile(gamepath .. "map.lua")
 
 profiler = nil

--- a/builtin/game/map.lua
+++ b/builtin/game/map.lua
@@ -1,0 +1,18 @@
+-- Minetest: builtin/map.lua
+
+-- Internal interfaces
+local get_node_raw = core.get_node_raw
+core.get_node_raw = nil
+
+function core.get_node(pos)
+	return core.get_node_or_nil(pos) or { name = "ignore", param1 = 0, param2 = 0 }
+end
+
+function core.get_node_or_nil(pos)
+	local param0, param1, param2, pos_ok = get_node_raw(pos.x, pos.y, pos.z)
+	if not pos_ok then
+		return nil
+	end
+	local name = core.get_name_from_content_id(param0)
+	return { name = name, param1 = param1, param2 = param2 }
+end

--- a/builtin/game/misc_s.lua
+++ b/builtin/game/misc_s.lua
@@ -91,3 +91,21 @@ function core.encode_png(width, height, data, compression)
 
 	return o_encode_png(width, height, data, compression or 6)
 end
+
+function core.get_name_from_content_id(content_id)
+	return core.registered_content_ids[content_id].name
+end
+
+function core.get_content_id(name)
+	local alias = core.registered_aliases[name]
+	local k = alias or name
+	local itemdef = core.registered_nodes[k]
+	if itemdef == nil then
+		if alias == nil then
+			error("Unknown node: " .. k)
+		else
+			error("Unknown node: " .. k .. " (from alias " .. name .. ")")
+		end
+	end
+	return itemdef.content_id
+end

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1208,6 +1208,14 @@ void pushnode(lua_State *L, const MapNode &n, const NodeDefManager *ndef)
 	lua_setfield(L, -2, "param2");
 }
 
+int pushnode_flat(lua_State *L, const MapNode &n)
+{
+	lua_pushnumber(L, n.param0);
+	lua_pushnumber(L, n.param1);
+	lua_pushnumber(L, n.param2);
+	return 3;
+}
+
 /******************************************************************************/
 void warn_if_field_exists(lua_State *L, int table,
 		const char *name, const std::string &message)

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -132,7 +132,7 @@ MapNode            readnode                  (lua_State *L, int index,
                                               const NodeDefManager *ndef);
 void               pushnode                  (lua_State *L, const MapNode &n,
                                               const NodeDefManager *ndef);
-
+int                pushnode_flat             (lua_State *L, const MapNode &n);
 
 void               read_groups               (lua_State *L, int index,
                                               ItemGroupList &result);

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -207,6 +207,15 @@ v3d read_v3d(lua_State *L, int index)
 	return pos;
 }
 
+v3d read_v3d_flat(lua_State *L, int index)
+{
+	v3d pos;
+	pos.X = lua_tonumber(L, index);
+	pos.Y = lua_tonumber(L, index + 1);
+	pos.Z = lua_tonumber(L, index + 2);
+	return pos;
+}
+
 v3d check_v3d(lua_State *L, int index)
 {
 	v3d pos;
@@ -269,6 +278,13 @@ v3s16 read_v3s16(lua_State *L, int index)
 {
 	// Correct rounding at <0
 	v3d pf = read_v3d(L, index);
+	return doubleToInt(pf, 1.0);
+}
+
+v3s16 read_v3s16_flat(lua_State *L, int index)
+{
+	// Correct rounding at <0
+	v3d pf = read_v3d_flat(L, index);
 	return doubleToInt(pf, 1.0);
 }
 

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -114,6 +114,7 @@ bool                is_color_table      (lua_State *L, int index);
 
 aabb3f              read_aabb3f         (lua_State *L, int index, f32 scale);
 v3s16               read_v3s16          (lua_State *L, int index);
+v3s16               read_v3s16_flat     (lua_State *L, int index);
 std::vector<aabb3f> read_aabb3f_vector  (lua_State *L, int index, f32 scale);
 size_t              read_stringlist     (lua_State *L, int index,
                                          std::vector<std::string> *result);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -355,39 +355,16 @@ int ModApiEnvMod::l_swap_node(lua_State *L)
 	return 1;
 }
 
-// get_node(pos)
-// pos = {x=num, y=num, z=num}
-int ModApiEnvMod::l_get_node(lua_State *L)
+// get_node_raw(x, y, z)
+int ModApiEnvMod::l_get_node_raw(lua_State *L)
 {
 	GET_ENV_PTR;
-
-	// pos
-	v3s16 pos = read_v3s16(L, 1);
-	// Do it
-	MapNode n = env->getMap().getNode(pos);
-	// Return node
-	pushnode(L, n, env->getGameDef()->ndef());
-	return 1;
-}
-
-// get_node_or_nil(pos)
-// pos = {x=num, y=num, z=num}
-int ModApiEnvMod::l_get_node_or_nil(lua_State *L)
-{
-	GET_ENV_PTR;
-
-	// pos
-	v3s16 pos = read_v3s16(L, 1);
-	// Do it
+	v3s16 pos = read_v3s16_flat(L, 1); // consumes 3 args
 	bool pos_ok;
 	MapNode n = env->getMap().getNode(pos, &pos_ok);
-	if (pos_ok) {
-		// Return node
-		pushnode(L, n, env->getGameDef()->ndef());
-	} else {
-		lua_pushnil(L);
-	}
-	return 1;
+	pushnode_flat(L, n);
+	lua_pushboolean(L, pos_ok);
+	return 4;
 }
 
 // get_node_light(pos, timeofday)
@@ -1451,8 +1428,7 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(swap_node);
 	API_FCT(add_item);
 	API_FCT(remove_node);
-	API_FCT(get_node);
-	API_FCT(get_node_or_nil);
+	API_FCT(get_node_raw);
 	API_FCT(get_node_light);
 	API_FCT(get_natural_light);
 	API_FCT(place_node);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -43,13 +43,8 @@ private:
 	// pos = {x=num, y=num, z=num}
 	static int l_swap_node(lua_State *L);
 
-	// get_node(pos)
-	// pos = {x=num, y=num, z=num}
-	static int l_get_node(lua_State *L);
-
-	// get_node_or_nil(pos)
-	// pos = {x=num, y=num, z=num}
-	static int l_get_node_or_nil(lua_State *L);
+	// get_node_raw(x, y, z)
+	static int l_get_node_raw(lua_State *L);
 
 	// get_node_light(pos, timeofday)
 	// pos = {x=num, y=num, z=num}

--- a/src/script/lua_api/l_item.h
+++ b/src/script/lua_api/l_item.h
@@ -162,8 +162,6 @@ private:
 	static int l_register_item_raw(lua_State *L);
 	static int l_unregister_item_raw(lua_State *L);
 	static int l_register_alias_raw(lua_State *L);
-	static int l_get_content_id(lua_State *L);
-	static int l_get_name_from_content_id(lua_State *L);
 
 public:
 	static void Initialize(lua_State *L, int top);


### PR DESCRIPTION
Replaces core.get_node() with a Lua implementation, which then uses two private back-end methods, `get_node_raw` and `get_node_name`, to retrieve data from the script api. Dealing with basic types is much more efficient than constructing tables and strings from C++ using the lua api. Node names are cached in Lua to reduce the passing of strings.

See issue https://github.com/minetest/minetest/issues/12437 for more details

On my particular machine with MCL2, this reduces the time needed to run finishGen() from 78 ms to 68 ms on average. This can be measured using this patch:

https://github.com/minetest/minetest/commit/56db6130001961f8bc57fc4a3f476e4842266c7f.patch