### PR TITLE
Avoid jittering when player is attached

### DIFF
--- a/src/activeobjectmgr.h
+++ b/src/activeobjectmgr.h
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include <unordered_map>
+#include <map>
 #include "irrlichttypes.h"
 
 class TestClientActiveObjectMgr;
@@ -38,7 +38,7 @@ public:
 
 	T *getActiveObject(u16 id)
 	{
-		typename std::unordered_map<u16, T *>::const_iterator n =
+		typename std::map<u16, T *>::const_iterator n =
 				m_active_objects.find(id);
 		return (n != m_active_objects.end() ? n->second : nullptr);
 	}
@@ -62,5 +62,5 @@ protected:
 		return id != 0 && m_active_objects.find(id) == m_active_objects.end();
 	}
 
-	std::unordered_map<u16, T *> m_active_objects;
+	std::map<u16, T *> m_active_objects;
 };

--- a/src/activeobjectmgr.h
+++ b/src/activeobjectmgr.h
@@ -38,8 +38,7 @@ public:
 
 	T *getActiveObject(u16 id)
 	{
-		typename std::map<u16, T *>::const_iterator n =
-				m_active_objects.find(id);
+		auto n = m_active_objects.find(id);
 		return (n != m_active_objects.end() ? n->second : nullptr);
 	}
 
@@ -62,5 +61,5 @@ protected:
 		return id != 0 && m_active_objects.find(id) == m_active_objects.end();
 	}
 
-	std::map<u16, T *> m_active_objects;
+	std::map<u16, T *> m_active_objects; // ordered to fix #10985 
 };


### PR DESCRIPTION
When a player is attached to an entity there sometimes is a lot of jittering - as if player and entity are out of sync.
(Note I am not referring to the jerkiness w.r.t. to the world, but w.r.t. to the 

A possible explanation is that entities are sorted differently on the the client and the server.

*Potentially* fixes #10985

## To do

Testing! You can try any mod that attach a player (hot air balloon, steam punk blimp, etc).
Notice that *sometimes* movement is very jittery. Not w.r.t. to the world but w.r.t. to the attached entity.

(I think different sort orders on client and server might be the problem, but I have not finally convinced myself that this is the case.
By changing the sort order I might also be just lucky in all cases for accidentally have one that does not cause jittering)

## How to test

See above.