### PR TITLE
Fix Android input box crash

### DIFF
--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -252,11 +252,6 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 				return retval;
 
 			m_jni_field_name = field_name;
-			std::string label = wide_to_utf8(getLabelByID(hovered->getID()));
-			if (label.empty())
-				label = "text";
-			/*~ Imperative, as in "Type in text" */
-			std::string message = fmtgettext("Enter %s:");
 
 			// single line text input
 			int type = 2;


### PR DESCRIPTION
This PR fixes a crash related to the Android input box introduced in 0c6a02941320cb089a5965857866ff064ba986b6.

Originally I fixed it by adding the missing `label.c_str()` argument to the `fmtgettext` call, but then realised the message variable itself is completely unused (or at least, I can't find anywhere it shows up. remnant of something else that was removed?), so I removed it instead.

## To do
This PR is Ready for Review.

## How to test
Open an input field on Android, witness it not crashing anymore.