### PR TITLE
Fix media download speed status

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1629,9 +1629,11 @@ bool Game::getServerContent(bool *aborted)
 				message << " " << receive << "%";
 			message.precision(2);
 
-			if ((USE_CURL == 0) ||
-					(!g_settings->getBool("enable_remote_media_server"))) {
-				float cur = client->getCurRate();
+			// The media downloading speed status only works on multiplayer
+			// servers without a remote media server. If this is not the case
+			// then 'cur' will be 0, so don't show it on the progress bar.
+			float cur = client->getCurRate();
+			if (cur > 0) {
 				std::string cur_unit = gettext("KiB/s");
 
 				if (cur > 900) {


### PR DESCRIPTION
This PR fixes the media download speed status. Previously it would only show up when Minetest was compiled without cURL or if the `enable_remote_media_server` setting was disabled, as the status does not work when downloading media from a remote media server. However this also means that it would only rarely show up in rare circumstances as opposed to every time you connect to a server that uses the regular media transfer method (and in addition a bullshit "0.00KiB/s" status when joining singleplayer with `enable_remote_media_server` disabled or without cURL compiled in).

As such, I removed the checks for `USE_CURL` and `enable_remote_media_server` and replaced it to instead show the status only whenever the current download rate is higher than 0. It is always 0 when downloading from a remote media server and in singleplayer which means that:
- When starting a singleplayer world it will not show up, no matter what.
- When joining a server using the regular media transfer method it will display the download speed of the media you're downloading from the server, no matter what.
- When joining a server that uses a remote media server it will not show up.

(heh, these points work as test instructions too)

## To do
This PR is Ready for Review.

## How to test
Check that it behaves as the three points above state.
