### PR TITLE
Docs: Remove outdated warning

### DIFF
--- a/doc/StorageRef
+++ b/doc/StorageRef
@@ -7456,9 +7456,6 @@ The settings have the format `key = value`. Example:
 Mod metadata: per mod metadata, saved automatically.
 Can be obtained via `minetest.get_mod_storage()` during load time.
 
-WARNING: This storage backend is incapable of saving raw binary data due
-to restrictions of JSON.
-
 ### Methods
 
 * All methods in MetaDataRef


### PR DESCRIPTION
Noticed by @GoodClover: The backend switch to SQLite makes this warning obsolete. MetaRefs properly take care of string length and on the SQLite side of things BLOBs are used, so binary data should work just fine.