### PR TITLE
Remove workaround for normals not matching winding order

### DIFF
--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -330,9 +330,6 @@ void recalculateBoundingBox(scene::IMesh *src_mesh)
 
 bool checkMeshNormals(scene::IMesh *mesh)
 {
-	// Assume correct normals if this many first faces get it right.
-	static const u16 MAX_FACES_TO_CHECK = 9;
-
 	u32 buffer_count = mesh->getMeshBufferCount();
 
 	for (u32 i = 0; i < buffer_count; i++) {

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -346,19 +346,6 @@ bool checkMeshNormals(scene::IMesh *mesh)
 
 		if (!std::isfinite(length) || length < 1e-10f)
 			return false;
-
-		const u16 count = MYMIN(MAX_FACES_TO_CHECK * 3, buffer->getIndexCount() - 3);
-		for (u16 i = 0; i < count; i += 3) {
-
-			core::plane3df plane(buffer->getPosition(buffer->getIndices()[i]),
-					buffer->getPosition(buffer->getIndices()[i+1]),
-					buffer->getPosition(buffer->getIndices()[i+2]));
-
-			for (u16 j = 0; j < 3; j++)
-				if (plane.Normal.dotProduct(buffer->getNormal(buffer->getIndices()[i+j])) <= 0)
-					return false;
-		}
-
 	}
 
 	return true;


### PR DESCRIPTION
Fixes #12430.

After this, correct shading of entities requires correct or zero normals in the models. There is a related fix for the B3D exporter for Blender: GreenXenith/io_scene_b3d#7.

## To do

This PR is Ready for Review.

## How to test

Use the test from #12430.

@appgurueu 
