### PR TITLE
Fix texture string overlay with texture groups of different sizes

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -454,6 +454,20 @@ Example: `cobble.png^(thing1.png^thing2.png)`
 A texture for `thing1.png^thing2.png` is created and the resulting
 texture is overlaid on top of `cobble.png`.
 
+Note: if a texture group in _single_ parentheses is overlaid on another texture,
+automatic scaling does not work.
+This is to support older mods making use of this issue.
+If you can not guarantee that the base texture has the same size as the
+texture group (e. g. because a texture part is provided by another mod),
+you should use _double_ parentheses.
+
+Example: `cobble.png^((external_texture.png))`
+
+If you need to overlay textures without scaling, you should use
+the `[combine` modifier instead.
+
+Example: `[combine:16x16:0,0=cobble.png:0,0=small_overlay.png`
+
 ### Escaping
 
 Modifiers that accept texture names (e.g. `[combine`) accept escaping to allow


### PR DESCRIPTION
```
Fix texture string overlay with texture groups of different sizes

See #12459.

Texture overlays of the form `cobble.png^(external_texture.png)` break
if it is not guaranteed that both texture parts have the same size.
Overlaying a texture group previously did not check for different sizes.

Because older mods might rely on the undocumented behavior,
overlaying a texture group in single parentheses continues to not check sizes,
and only texture groups in double parentheses are resized.

(A texture group is a part of a texture string enclosed in parentheses.)
```

## Summary

Sorry, I just wanted to try to hack my suggested fix together. :D

This is my patch to fix issue #12459.

To break as few mods as possible, which _might_ rely on the old behavior, the fix is only applied if the mod uses double parentheses.
This situation is explained in lua_api.txt.

## To do

This PR is Ready for Review...

- [ ] ...but no one has yet approved my suggestion to distinguish between single and double parentheses.
- [ ] Unit tests? I didn’t find existing tests.

## How to test

Use the formspec_editor game, and put the below test forms into games/formspec_editor/mods/formspec_edit/formspec.spec:

### Existing good behavior
```
formspec_version[2]
size[10,10]
image_button[1,1;8,8;menu_bg.png^logo.png;name;label]
```

![Screenshot_20220620_195826](https://user-images.githubusercontent.com/76133492/174656658-a6f268c3-facf-4056-96e8-79c53ee0e6dc.png)

### Existing bad behavior
```
formspec_version[2]
size[10,10]
image_button[1,1;8,8;menu_bg.png^(logo.png);name;label]
```

![Screenshot_20220620_200117](https://user-images.githubusercontent.com/76133492/174656977-77acf6d4-7b00-4d0e-b502-ee9158a4583b.png)

### New good behavior
```
formspec_version[2]
size[10,10]
image_button[1,1;8,8;menu_bg.png^((logo.png));name;label]
```

![Screenshot_20220620_200205](https://user-images.githubusercontent.com/76133492/174657068-79e875e9-4c5b-442c-800a-3fdaea1bda48.png)

### String indices

Also try some other texture strings, like the below, to test corner cases of string indices.

* (empty string)
* `()`, `(())`
* `^`, `(^)`, `((^))`
* `^()`, `()^`,
* `^^`, `^()^`, `^(())^`
* `logo.png^`, `logo.png^()`, `logo.png^(())`

(I promise I tested them all. ;) )