### PR TITLE
Fix two memleak reports from Coverity

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1911,11 +1911,8 @@ void Game::processKeyInput()
 	} else if (wasKeyDown(KeyType::CMD_LOCAL)) {
 		if (client->modsLoaded())
 			openConsole(0.2, L".");
-		else {
-			const wchar_t *text = wgettext("Client side scripting is disabled");
-			m_game_ui->showStatusText(text);
-			delete[] text;
-		}
+		else
+			m_game_ui->showTranslatedStatusText(("Client side scripting is disabled");
 	} else if (wasKeyDown(KeyType::CONSOLE)) {
 		openConsole(core::clamp(g_settings->getFloat("console_height"), 0.1f, 1.0f));
 	} else if (wasKeyDown(KeyType::FREEMOVE)) {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1912,7 +1912,7 @@ void Game::processKeyInput()
 		if (client->modsLoaded())
 			openConsole(0.2, L".");
 		else
-			m_game_ui->showTranslatedStatusText(("Client side scripting is disabled");
+			m_game_ui->showTranslatedStatusText("Client side scripting is disabled");
 	} else if (wasKeyDown(KeyType::CONSOLE)) {
 		openConsole(core::clamp(g_settings->getFloat("console_height"), 0.1f, 1.0f));
 	} else if (wasKeyDown(KeyType::FREEMOVE)) {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1911,8 +1911,11 @@ void Game::processKeyInput()
 	} else if (wasKeyDown(KeyType::CMD_LOCAL)) {
 		if (client->modsLoaded())
 			openConsole(0.2, L".");
-		else
-			m_game_ui->showStatusText(wgettext("Client side scripting is disabled"));
+		else {
+			const wchar_t *text = wgettext("Client side scripting is disabled");
+			m_game_ui->showStatusText(text);
+			delete[] text;
+		}
 	} else if (wasKeyDown(KeyType::CONSOLE)) {
 		openConsole(core::clamp(g_settings->getFloat("console_height"), 0.1f, 1.0f));
 	} else if (wasKeyDown(KeyType::FREEMOVE)) {

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1219,7 +1219,8 @@ int ModApiEnvMod::l_emerge_area(lua_State *L)
 	sortBoxVerticies(bpmin, bpmax);
 
 	size_t num_blocks = VoxelArea(bpmin, bpmax).getVolume();
-	assert(num_blocks != 0);
+	if (num_blocks == 0)
+		return 0;
 
 	if (lua_isfunction(L, 3)) {
 		callback = LuaEmergeAreaCallback;


### PR DESCRIPTION
Fixes two memleaks reported by Coverity in the Minetest engine.

- Fixes leaking string allocated by gettext by using appropriate high level functions.
- Fixes possible (unlikely in practice) memleak in Lua API when emerging area with no mapblocks. Was previously guarded by assert.

## To do

Ready for Review.

## How to test

I couldn't figure out how to get the particular string ("Client side scripting is disabled") to show up in-game, so I don't know how to test it.
