### PR TITLE
Always make everything black if camera is within node

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -669,7 +669,7 @@ int ClientMap::getBackgroundBrightness(float max_d, u32 daylight_factor,
 	return ret;
 }
 
-const v3f cuboid_corners[8] = {
+static const v3f cuboid_corners[8] = {
 	v3f(-1, -1, -1),
 	v3f(-1, -1,  1),
 	v3f(-1,  1, -1),


### PR DESCRIPTION
WIP. Closes https://github.com/minetest/minetest/issues/12429.

Simply checks all nodes within a +/- near clipping plane cuboid for solidness. Technically a sphere should be used, but the cuboid is way easier to implement and is only off by less than the very slim near plane ($\sqrt{3} - 1$ to be precise) at the *literal corner cases* which can safely be ignored.

Furthermore this makes no distinction for 3rd person view, as that would make it trivial to circumvent this fix (in fact I only knew the reported "glitch" from 3rd person, where no black color is applied for solid nodes).

# How to test

Go inside nodes as described in the issue. Now move your camera *just outside* the nodes such that the node face is clipped, allowing you to see through the node ("X-ray"):

![screenshot_20220622_233202](https://user-images.githubusercontent.com/34514239/175144824-d8bfa11b-f20b-42b5-8427-26f8a1801c75.png)

Now apply the patch from this PR however you please and recompile. When you now rejoin, your screen should be all black:

![screenshot_20220622_233443](https://user-images.githubusercontent.com/34514239/175144908-4d608db0-a490-43b4-ba42-d0961b6b0f8a.png)

Switch to 3rd person and it should still be black.

Note: This should not make the screen black if you're outside of a node due to the player collisionbox being significantly larger than the clipping distance of 1 cm (0.01 nodes).