### PR TITLE
Fix broken translation on formspec labels with multi line text

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1743,7 +1743,7 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 	std::vector<std::wstring> lines = split(text, L'\n');
 
 	for (unsigned int i = 0; i != lines.size(); i++) {
-		std::wstring wlabel_colors = lines[i];
+		const std::wstring &wlabel_colors = lines[i];
 		// Without color escapes to get the font dimensions
 		std::wstring wlabel_plain = unescape_enriched(wlabel_colors);
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -52,7 +52,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/sound.h"
 #include "util/hex.h"
 #include "util/numeric.h"
-#include "util/string.h" // for parseColorString()
+#include "util/string.h"
 #include "irrlicht_changes/static_text.h"
 #include "client/guiscalingfilter.h"
 #include "guiAnimatedImage.h"
@@ -1727,23 +1727,23 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 		return;
 
 	std::vector<std::string> v_pos = split(parts[0],',');
-	std::string text = parts[1];
 
 	MY_CHECKPOS("label",0);
 
 	if(!data->explicit_size)
 		warningstream<<"invalid use of label without a size[] element"<<std::endl;
 
-	std::vector<std::string> lines = split(text, '\n');
-
 	auto style = getDefaultStyleForElement("label", "");
 	gui::IGUIFont *font = style.getFont();
 	if (!font)
 		font = m_font;
 
+	std::wstring text = unescape_translate(
+		unescape_string(utf8_to_wide(parts[1])));
+	std::vector<std::wstring> lines = split(text, L'\n');
+
 	for (unsigned int i = 0; i != lines.size(); i++) {
-		std::wstring wlabel_colors = translate_string(
-			utf8_to_wide(unescape_string(lines[i])));
+		std::wstring wlabel_colors = lines[i];
 		// Without color escapes to get the font dimensions
 		std::wstring wlabel_plain = unescape_enriched(wlabel_colors);
 


### PR DESCRIPTION
Fixes #7450.

## To do

This PR is Ready for Review.

- [ ] Someone who understands various types of escaping in formspec has to review the change.

## How to test

Test this formspec code with the `formspec_editor` game:

```
formspec_version[2]
size[8,8]
label[0.5,2;(T@abc)AB:
F1E CDE]
button[0.5,2;4,2;abcd;(T@abc)AB:
F1E CDE]
tooltip[abcd;(T@abc)AB:
F1E CDE]
```

This code contains all the escape sequences introduced by `minetest.get_translator("abc")("AB:\n@1 CD", 1)`.

I promise you that Github will now break the text. ;)
I also tried to attach it as file, but that was broken too. :(
So here is Base64: 

```.bash
echo 'Zm9ybXNwZWNfdmVyc2lvblsyXQpzaXplWzgsNF0KbGFiZWxbMC41LDI7GyhUQGFiYylBQjoKG0Yx
G0UgQ0QbRV0KYnV0dG9uWzMsMTs0LDI7YWJjZDsbKFRAYWJjKUFCOgobRjEbRSBDRBtFXQp0b29s
dGlwW2FiY2Q7GyhUQGFiYylBQjoKG0YxG0UgQ0QbRV0K' | base64 -d >~/.minetest/games/formspec_editor/mods/formspec_edit/formspec.spec
```

Screenshot with the fix:
![Screenshot_20220623_215501](https://user-images.githubusercontent.com/76133492/175386445-f382f8d3-1e5d-49d2-ba9d-64e80c8fe255.png)

Without the fix, the label (and only the label) misses the text “CD”.
The bug is easily visible in this case, because the text contains a parameter.
After the parameter, the broken apart translatable string “ends”, and the translation function returns before seeing “CD”.

