### PR TITLE
Remove call to `pairs` causing trace abort in `table.copy`

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -477,9 +477,12 @@ function table.copy(t, seen)
 	local n = {}
 	seen = seen or {}
 	seen[t] = n
-	for k, v in pairs(t) do
+	-- Avoid pairs() as it makes traces abort here.
+	local k, v = next(t)
+	while k ~= nil do
 		n[(type(k) == "table" and (seen[k] or table.copy(k, seen))) or k] =
 			(type(v) == "table" and (seen[v] or table.copy(v, seen))) or v
+		k, v = next(t, k)
 	end
 	return n
 end

--- a/builtin/common/tests/misc_helpers_spec.lua
+++ b/builtin/common/tests/misc_helpers_spec.lua
@@ -162,6 +162,18 @@ describe("table", function()
 		assert.equal(1, table.indexof({"foo", "bar"}, "foo"))
 		assert.equal(-1, table.indexof({"foo", "bar"}, "baz"))
 	end)
+
+	it("copy()", function()
+		local t1 = {1, {}, foo = "foo"}
+		t1[0] = t1
+		assert.same(t1, table.copy(t1))
+
+		local t2 = {}
+		t2[t2] = t2
+		local t2_copy = table.copy(t2)
+		assert.equal(t2_copy, next(t2_copy))
+		assert.equal(t2_copy, t2_copy[t2_copy])
+	end)
 end)
 
 describe("formspec_escape", function()


### PR DESCRIPTION
This PR fixes a problem with the API (not a bug exactly.)

For some reason, the call to `pairs` in `table.copy` causes LuaJIT (version 2.1.0-beta3) to abort its current trace.  To verify the problem, put the following code in `tablecopytest.lua` (in the project root directory) and run it with `luajit -jdump tablecopytest.lua`:

```lua
core = {}
dofile("builtin/common/misc_helpers.lua")

for i = 1, 10000 do
	table.copy({})
end
```

The issue is fixed by using `next` instead.

## To do

This PR is Ready for Review.

## How to test

I added a unit test. You could also try running Minetest with a mod such as Mesecons.
