### PR TITLE
Fix CAO rubberbanding

### DIFF
--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -167,7 +167,7 @@ public:
 
 	void setPosition(const v3f &pos)
 	{
-		pos_translator.val_current = pos;
+		pos_translator.init(pos);
 	}
 
 	inline const v3f &getRotation() const { return m_rotation; }


### PR DESCRIPTION
Trivial. Fixes #12317.

Explanation: Previously, this would just set the `current` value of the interpolated property, rather than setting both `target` and `current` value by initializing. This presumably led to rubber banding as instead of an instant position update, the interpolation would lead the CAO the move *back towards the previous position*. This trivially fixes this by calling the designated `init` method of the translator.
