### PR TITLE
Fix error when `item` isn't provided to core.hud_replace_builtin

### DIFF
--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -145,6 +145,7 @@ function core.hud_replace_builtin(hud_name, definition)
 	end
 
 	if hud_name == "health" then
+		definition.item = definition.item or core.PLAYER_MAX_HP_DEFAULT
 		bar_definitions.hp = definition
 
 		for name, ids in pairs(hud_ids) do
@@ -159,6 +160,7 @@ function core.hud_replace_builtin(hud_name, definition)
 	end
 
 	if hud_name == "breath" then
+		definition.item = definition.item or core.PLAYER_MAX_BREATH_DEFAULT
 		bar_definitions.breath = definition
 
 		for name, ids in pairs(hud_ids) do

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -146,7 +146,7 @@ function core.hud_replace_builtin(hud_name, definition)
 	definition = table.copy(definition)
 
 	if hud_name == "health" then
-		definition.item = definition.item or core.PLAYER_MAX_HP_DEFAULT
+		definition.item = definition.item or definition.number or core.PLAYER_MAX_HP_DEFAULT
 		bar_definitions.hp = definition
 
 		for name, ids in pairs(hud_ids) do
@@ -161,7 +161,7 @@ function core.hud_replace_builtin(hud_name, definition)
 	end
 
 	if hud_name == "breath" then
-		definition.item = definition.item or core.PLAYER_MAX_BREATH_DEFAULT
+		definition.item = definition.item or definition.number or core.PLAYER_MAX_BREATH_DEFAULT
 		bar_definitions.breath = definition
 
 		for name, ids in pairs(hud_ids) do

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -138,11 +138,12 @@ local function player_event_handler(player,eventname)
 end
 
 function core.hud_replace_builtin(hud_name, definition)
-
 	if type(definition) ~= "table" or
 			definition.hud_elem_type ~= "statbar" then
 		return false
 	end
+
+	definition = table.copy(definition)
 
 	if hud_name == "health" then
 		definition.item = definition.item or core.PLAYER_MAX_HP_DEFAULT


### PR DESCRIPTION
Context: https://forum.minetest.net/viewtopic.php?f=18&t=28131

In the wild: https://github.com/CasimirKaPazi/Voxelgarden/blob/b0893e89b08cc8702f21805c7316599f2dc98983/mods/default/gui.lua#L2

## To do

This PR is Ready for Review.

## How to test

```lua
local health_bar_definition =
{
	hud_elem_type = "statbar",
	position = { x=0.5, y=1 },
	text = "heart.png",
	number = 20,
	direction = 0,
	size = {x=16, y=16},
	offset = {x=(-9*24)-12, y=-(48+24+8)},
}

minetest.hud_replace_builtin("health", health_bar_definition)
```
