### PR TITLE
Reorganise settingtypes.txt

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -351,9 +351,9 @@ local function parse_config_file(read_all, parse_mods)
 			local file = io.open(path, "r")
 			if file then
 				if not games_category_initialized then
-					fgettext_ne("Games") -- not used, but needed for xgettext
+					fgettext_ne("Content: Games") -- not used, but needed for xgettext
 					table.insert(settings, {
-						name = "Games",
+						name = "Content: Games",
 						level = 0,
 						type = "category",
 					})
@@ -384,9 +384,9 @@ local function parse_config_file(read_all, parse_mods)
 			local file = io.open(path, "r")
 			if file then
 				if not mods_category_initialized then
-					fgettext_ne("Mods") -- not used, but needed for xgettext
+					fgettext_ne("Content: Mods") -- not used, but needed for xgettext
 					table.insert(settings, {
-						name = "Mods",
+						name = "Content: Mods",
 						level = 0,
 						type = "category",
 					})

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -63,10 +63,1954 @@
 # There shouldn't be too much settings per category; settings that shouldn't be
 #  modified by the "average user" should be in (sub-)categories called "Advanced".
 
+
 [Controls]
+
+[*General]
+
 #    If enabled, you can place blocks at the position (feet + eye level) where you stand.
 #    This is helpful when working with nodeboxes in small areas.
 enable_build_where_you_stand (Build inside player) bool false
+
+#    Smooths camera when looking around. Also called look or mouse smoothing.
+#    Useful for recording videos.
+cinematic (Cinematic mode) bool false
+
+#    Smooths rotation of camera. 0 to disable.
+camera_smoothing (Camera smoothing) float 0.0 0.0 0.99
+
+#    Smooths rotation of camera in cinematic mode. 0 to disable.
+cinematic_camera_smoothing (Camera smoothing in cinematic mode) float 0.7 0.0 0.99
+
+#    If enabled, "Aux1" key instead of "Sneak" key is used for climbing down and
+#    descending.
+aux1_descends (Aux1 key for climbing/descending) bool false
+
+#    Double-tapping the jump key toggles fly mode.
+doubletap_jump (Double tap jump for fly) bool false
+
+#    If disabled, "Aux1" key is used to fly fast if both fly and fast mode are
+#    enabled.
+always_fly_fast (Always fly fast) bool true
+
+#    The time in seconds it takes between repeated node placements when holding
+#    the place button.
+repeat_place_time (Place repetition interval) float 0.25 0.001
+
+#    Automatically jump up single-node obstacles.
+autojump (Automatic jumping) bool false
+
+#    Prevent digging and placing from repeating when holding the mouse buttons.
+#    Enable this when you dig or place too often by accident.
+safe_dig_and_place (Safe digging and placing) bool false
+
+[*Keyboard and Mouse]
+
+#    Invert vertical mouse movement.
+invert_mouse (Invert mouse) bool false
+
+#    Mouse sensitivity multiplier.
+mouse_sensitivity (Mouse sensitivity) float 0.2
+
+[*Touchscreen]
+
+#    The length in pixels it takes for touch screen interaction to start.
+touchscreen_threshold (Touch screen threshold) int 20 0 100
+
+#    (Android) Fixes the position of virtual joystick.
+#    If disabled, virtual joystick will center to first-touch's position.
+fixed_virtual_joystick (Fixed virtual joystick) bool false
+
+#    (Android) Use virtual joystick to trigger "Aux1" button.
+#    If enabled, virtual joystick will also tap "Aux1" button when out of main circle.
+virtual_joystick_triggers_aux1 (Virtual joystick triggers Aux1 button) bool false
+
+
+[Graphics and Audio]
+
+[*Graphics]
+
+[**Screen]
+
+#    Width component of the initial window size. Ignored in fullscreen mode.
+screen_w (Screen width) int 1024 1
+
+#    Height component of the initial window size. Ignored in fullscreen mode.
+screen_h (Screen height) int 600 1
+
+#    Save window size automatically when modified.
+autosave_screensize (Autosave screen size) bool true
+
+#    Fullscreen mode.
+fullscreen (Full screen) bool false
+
+#    Open the pause menu when the window's focus is lost. Does not pause if a formspec is
+#    open.
+pause_on_lost_focus (Pause on lost window focus) bool false
+
+[**FPS]
+
+#    If FPS would go higher than this, limit it by sleeping
+#    to not waste CPU power for no benefit.
+fps_max (Maximum FPS) int 60 1
+
+#    Vertical screen synchronization.
+vsync (VSync) bool false
+
+#    Maximum FPS when the window is not focused, or when the game is paused.
+fps_max_unfocused (FPS when unfocused or paused) int 20 1
+
+#    View distance in nodes.
+viewing_range (Viewing range) int 190 20 4000
+
+#    Undersampling is similar to using a lower screen resolution, but it applies
+#    to the game world only, keeping the GUI intact.
+#    It should give a significant performance boost at the cost of less detailed image.
+#    Higher values result in a less detailed image.
+undersampling (Undersampling) int 1 1 8
+
+[**Graphics Effects]
+
+#    Makes all liquids opaque
+opaque_water (Opaque liquids) bool false
+
+#    Leaves style:
+#    -   Fancy:  all faces visible
+#    -   Simple: only outer faces, if defined special_tiles are used
+#    -   Opaque: disable transparency
+leaves_style (Leaves style) enum fancy fancy,simple,opaque
+
+#    Connects glass if supported by node.
+connected_glass (Connect glass) bool false
+
+#    Enable smooth lighting with simple ambient occlusion.
+#    Disable for speed or for different looks.
+smooth_lighting (Smooth lighting) bool true
+
+#    Enables tradeoffs that reduce CPU load or increase rendering performance
+#    at the expense of minor visual glitches that do not impact game playability.
+performance_tradeoffs (Tradeoffs for performance) bool false
+
+#    Adds particles when digging a node.
+enable_particles (Digging particles) bool true
+
+[**3d]
+
+#    3D support.
+#    Currently supported:
+#    -    none: no 3d output.
+#    -    anaglyph: cyan/magenta color 3d.
+#    -    interlaced: odd/even line based polarisation screen support.
+#    -    topbottom: split screen top/bottom.
+#    -    sidebyside: split screen side by side.
+#    -    crossview: Cross-eyed 3d
+#    -    pageflip: quadbuffer based 3d.
+#    Note that the interlaced mode requires shaders to be enabled.
+3d_mode (3D mode) enum none none,anaglyph,interlaced,topbottom,sidebyside,crossview,pageflip
+
+#    Strength of 3D mode parallax.
+3d_paralax_strength (3D mode parallax strength) float 0.025
+
+[**Bobbing]
+
+#    Arm inertia, gives a more realistic movement of
+#    the arm when the camera moves.
+arm_inertia (Arm inertia) bool true
+
+#    Enable view bobbing and amount of view bobbing.
+#    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
+view_bobbing_amount (View bobbing factor) float 1.0
+
+#    Multiplier for fall bobbing.
+#    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
+fall_bobbing_amount (Fall bobbing factor) float 0.03
+
+[**Camera]
+
+#   Camera 'near clipping plane' distance in nodes, between 0 and 0.25
+#   Only works on GLES platforms. Most users will not need to change this.
+#   Increasing can reduce artifacting on weaker GPUs.
+#   0.1 = Default, 0.25 = Good value for weaker tablets.
+near_plane (Near plane) float 0.1 0 0.25
+
+#    Field of view in degrees.
+fov (Field of view) int 72 45 160
+
+#    Alters the light curve by applying 'gamma correction' to it.
+#    Higher values make middle and lower light levels brighter.
+#    Value '1.0' leaves the light curve unaltered.
+#    This only has significant effect on daylight and artificial
+#    light, it has very little effect on natural night light.
+display_gamma (Light curve gamma) float 1.0 0.33 3.0
+
+#    The strength (darkness) of node ambient-occlusion shading.
+#    Lower is darker, Higher is lighter. The valid range of values for this
+#    setting is 0.25 to 4.0 inclusive. If the value is out of range it will be
+#    set to the nearest valid value.
+ambient_occlusion_gamma (Ambient occlusion gamma) float 2.2 0.25 4.0
+
+[**Screenshots]
+
+#    Path to save screenshots at. Can be an absolute or relative path.
+#    The folder will be created if it doesn't already exist.
+screenshot_path (Screenshot folder) path screenshots
+
+#    Format of screenshots.
+screenshot_format (Screenshot format) enum png png,jpg
+
+#    Screenshot quality. Only used for JPEG format.
+#    1 means worst quality; 100 means best quality.
+#    Use 0 for default quality.
+screenshot_quality (Screenshot quality) int 0 0 100
+
+[**Node and Entity Highlighting]
+
+#    Method used to highlight selected object.
+node_highlighting (Node highlighting) enum box box,halo,none
+
+#    Show entity selection boxes
+#    A restart is required after changing this.
+show_entity_selectionbox (Show entity selection boxes) bool false
+
+#    Selection box border color (R,G,B).
+selectionbox_color (Selection box color) string (0,0,0)
+
+#    Width of the selection box lines around nodes.
+selectionbox_width (Selection box width) int 2 1 5
+
+#    Crosshair color (R,G,B).
+#    Also controls the object crosshair color
+crosshair_color (Crosshair color) string (255,255,255)
+
+#    Crosshair alpha (opaqueness, between 0 and 255).
+#    This also applies to the object crosshair.
+crosshair_alpha (Crosshair alpha) int 255 0 255
+
+[**Fog]
+
+#    Whether to fog out the end of the visible area.
+enable_fog (Fog) bool true
+
+#    Make fog and sky colors depend on daytime (dawn/sunset) and view direction.
+directional_colored_fog (Colored fog) bool true
+
+#    Fraction of the visible distance at which fog starts to be rendered
+fog_start (Fog start) float 0.4 0.0 0.99
+
+[**Clouds]
+
+#    Clouds are a client side effect.
+enable_clouds (Clouds) bool true
+
+#    Use 3D cloud look instead of flat.
+enable_3d_clouds (3D clouds) bool true
+
+[**Filtering and Antialiasing]
+
+#    Use mipmapping to scale textures. May slightly increase performance,
+#    especially when using a high resolution texture pack.
+#    Gamma correct downscaling is not supported.
+mip_map (Mipmapping) bool false
+
+#    Use anisotropic filtering when viewing at textures from an angle.
+anisotropic_filter (Anisotropic filtering) bool false
+
+#    Use bilinear filtering when scaling textures.
+bilinear_filter (Bilinear filtering) bool false
+
+#    Use trilinear filtering when scaling textures.
+trilinear_filter (Trilinear filtering) bool false
+
+#    Filtered textures can blend RGB values with fully-transparent neighbors,
+#    which PNG optimizers usually discard, often resulting in dark or
+#    light edges to transparent textures. Apply a filter to clean that up
+#    at texture load time. This is automatically enabled if mipmapping is enabled.
+texture_clean_transparent (Clean transparent textures) bool false
+
+#    When using bilinear/trilinear/anisotropic filters, low-resolution textures
+#    can be blurred, so automatically upscale them with nearest-neighbor
+#    interpolation to preserve crisp pixels. This sets the minimum texture size
+#    for the upscaled textures; higher values look sharper, but require more
+#    memory. Powers of 2 are recommended. This setting is ONLY applied if
+#    bilinear/trilinear/anisotropic filtering is enabled.
+#    This is also used as the base node texture size for world-aligned
+#    texture autoscaling.
+texture_min_size (Minimum texture size) int 64
+
+#    Use multi-sample antialiasing (MSAA) to smooth out block edges.
+#    This algorithm smooths out the 3D viewport while keeping the image sharp,
+#    but it doesn't affect the insides of textures
+#    (which is especially noticeable with transparent textures).
+#    Visible spaces appear between nodes when shaders are disabled.
+#    If set to 0, MSAA is disabled.
+#    A restart is required after changing this option.
+fsaa (FSAA) enum 0 0,1,2,4,8,16
+
+
+[*Shaders]
+
+#    Shaders allow advanced visual effects and may increase performance on some video
+#    cards.
+#    This only works with the OpenGL video backend.
+enable_shaders (Shaders) bool true
+
+[**Tone Mapping]
+
+#    Enables Hable's 'Uncharted 2' filmic tone mapping.
+#    Simulates the tone curve of photographic film and how this approximates the
+#    appearance of high dynamic range images. Mid-range contrast is slightly
+#    enhanced, highlights and shadows are gradually compressed.
+tone_mapping (Filmic tone mapping) bool false
+
+[**Waving Nodes]
+
+#    Set to true to enable waving leaves.
+#    Requires shaders to be enabled.
+enable_waving_leaves (Waving leaves) bool false
+
+#    Set to true to enable waving plants.
+#    Requires shaders to be enabled.
+enable_waving_plants (Waving plants) bool false
+
+#    Set to true to enable waving liquids (like water).
+#    Requires shaders to be enabled.
+enable_waving_water (Waving liquids) bool false
+
+#    The maximum height of the surface of waving liquids.
+#    4.0 = Wave height is two nodes.
+#    0.0 = Wave doesn't move at all.
+#    Default is 1.0 (1/2 node).
+#    Requires waving liquids to be enabled.
+water_wave_height (Waving liquids wave height) float 1.0 0.0 4.0
+
+#    Length of liquid waves.
+#    Requires waving liquids to be enabled.
+water_wave_length (Waving liquids wavelength) float 20.0 0.1
+
+#    How fast liquid waves will move. Higher = faster.
+#    If negative, liquid waves will move backwards.
+#    Requires waving liquids to be enabled.
+water_wave_speed (Waving liquids wave speed) float 5.0
+
+[**Dynamic shadows]
+
+#    Set to true to enable Shadow Mapping.
+#    Requires shaders to be enabled.
+enable_dynamic_shadows (Dynamic shadows) bool false
+
+#    Set the shadow strength gamma.
+#    Adjusts the intensity of in-game dynamic shadows.
+#    Lower value means lighter shadows, higher value means darker shadows.
+shadow_strength_gamma (Shadow strength gamma) float 1.0 0.1 10.0
+
+#    Maximum distance to render shadows.
+shadow_map_max_distance (Shadow map max distance in nodes to render shadows) float 120.0 10.0 1000.0
+
+#    Texture size to render the shadow map on.
+#    This must be a power of two.
+#    Bigger numbers create better shadows but it is also more expensive.
+shadow_map_texture_size (Shadow map texture size) int 1024 128 8192
+
+#    Sets shadow texture quality to 32 bits.
+#    On false, 16 bits texture will be used.
+#    This can cause much more artifacts in the shadow.
+shadow_map_texture_32bit (Shadow map texture in 32 bits) bool true
+
+#    Enable Poisson disk filtering.
+#    On true uses Poisson disk to make "soft shadows". Otherwise uses PCF filtering.
+shadow_poisson_filter (Poisson filtering) bool true
+
+#   Define shadow filtering quality.
+#   This simulates the soft shadows effect by applying a PCF or Poisson disk
+#   but also uses more resources.
+shadow_filters (Shadow filter quality) enum 1 0,1,2
+
+#    Enable colored shadows.
+#    On true translucent nodes cast colored shadows. This is expensive.
+shadow_map_color (Colored shadows) bool false
+
+#    Spread a complete update of shadow map over given amount of frames.
+#    Higher values might make shadows laggy, lower values
+#    will consume more resources.
+#    Minimum value: 1; maximum value: 16
+shadow_update_frames (Map shadows update frames) int 8 1 16
+
+#    Set the soft shadow radius size.
+#    Lower values mean sharper shadows, bigger values mean softer shadows.
+#    Minimum value: 1.0; maximum value: 15.0
+shadow_soft_radius (Soft shadow radius) float 5.0 1.0 15.0
+
+#    Set the tilt of Sun/Moon orbit in degrees.
+#    Value of 0 means no tilt / vertical orbit.
+#    Minimum value: 0.0; maximum value: 60.0
+shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 0.0 60.0
+
+[*Audio]
+
+#    Volume of all sounds.
+#    Requires the sound system to be enabled.
+sound_volume (Volume) float 0.7 0.0 1.0
+
+#    Whether to mute sounds. You can unmute sounds at any time, unless the
+#    sound system is disabled (enable_sound=false).
+#    In-game, you can toggle the mute state with the mute key or by using the
+#    pause menu.
+mute_sound (Mute sound) bool false
+
+[*User Interfaces]
+
+#    Set the language. Leave empty to use the system language.
+#    A restart is required after changing this.
+language (Language) enum   ,be,bg,ca,cs,da,de,el,en,eo,es,et,eu,fi,fr,gd,gl,hu,id,it,ja,jbo,kk,ko,lt,lv,ms,nb,nl,nn,pl,pt,pt_BR,ro,ru,sk,sl,sr_Cyrl,sr_Latn,sv,sw,tr,uk,vi,zh_CN,zh_TW
+
+[**GUIs]
+
+#    Scale GUI by a user specified value.
+#    Use a nearest-neighbor-anti-alias filter to scale the GUI.
+#    This will smooth over some of the rough edges, and blend
+#    pixels when scaling down, at the cost of blurring some
+#    edge pixels when images are scaled by non-integer sizes.
+gui_scaling (GUI scaling) float 1.0 0.001
+
+#    Enables animation of inventory items.
+inventory_items_animations (Inventory items animations) bool false
+
+#    Formspec full-screen background opacity (between 0 and 255).
+formspec_fullscreen_bg_opacity (Formspec Full-Screen Background Opacity) int 140 0 255
+
+#    Formspec full-screen background color (R,G,B).
+formspec_fullscreen_bg_color (Formspec Full-Screen Background Color) string (0,0,0)
+
+#    When gui_scaling_filter is true, all GUI images need to be
+#    filtered in software, but some images are generated directly
+#    to hardware (e.g. render-to-texture for nodes in inventory).
+gui_scaling_filter (GUI scaling filter) bool false
+
+#    When gui_scaling_filter_txr2img is true, copy those images
+#    from hardware to software for scaling.  When false, fall back
+#    to the old scaling method, for video drivers that don't
+#    properly support downloading textures back from hardware.
+gui_scaling_filter_txr2img (GUI scaling filter txr2img) bool true
+
+#    Delay showing tooltips, stated in milliseconds.
+tooltip_show_delay (Tooltip delay) int 400
+
+#    Append item name to tooltip.
+tooltip_append_itemname (Append item name) bool false
+
+#    Use a cloud animation for the main menu background.
+menu_clouds (Clouds in menu) bool true
+
+[**HUD]
+
+#    Modifies the size of the HUD elements.
+hud_scaling (HUD scaling) float 1.0
+
+#    Whether name tag backgrounds should be shown by default.
+#    Mods may still set a background.
+show_nametag_backgrounds (Show name tag backgrounds by default) bool true
+
+[**Chat]
+
+#    Maximum number of recent chat messages to show
+recent_chat_messages (Recent Chat Messages) int 6 2 20
+
+#    In-game chat console height, between 0.1 (10%) and 1.0 (100%).
+console_height (Console height) float 0.6 0.1 1.0
+
+#    In-game chat console background color (R,G,B).
+console_color (Console color) string (0,0,0)
+
+#    In-game chat console background alpha (opaqueness, between 0 and 255).
+console_alpha (Console alpha) int 200 0 255
+
+#    Maximum proportion of current window to be used for hotbar.
+#    Useful if there's something to be displayed right or left of hotbar.
+hud_hotbar_max_width (Maximum hotbar width) float 1.0
+
+#    Clickable weblinks (middle-click or Ctrl+left-click) enabled in chat console output.
+clickable_chat_weblinks (Chat weblinks) bool true
+
+#    Optional override for chat weblink color.
+chat_weblink_color (Weblink color) string
+
+#    Font size of the recent chat text and chat prompt in point (pt).
+#    Value 0 will use the default font size.
+chat_font_size (Chat font size) int 0
+
+
+[**Content Repository]
+
+#    The URL for the content repository
+contentdb_url (ContentDB URL) string https://content.minetest.net
+
+#    Comma-separated list of flags to hide in the content repository.
+#    "nonfree" can be used to hide packages which do not qualify as 'free software',
+#    as defined by the Free Software Foundation.
+#    You can also specify content ratings.
+#    These flags are independent from Minetest versions,
+#    so see a full list at https://content.minetest.net/help/content_flags/
+contentdb_flag_blacklist (ContentDB Flag Blacklist) string nonfree, desktop_default
+
+#    Maximum number of concurrent downloads. Downloads exceeding this limit will be queued.
+#    This should be lower than curl_parallel_limit.
+contentdb_max_concurrent_downloads (ContentDB Max Concurrent Downloads) int 3
+
+
+[Client and Server]
+
+[*Client]
+
+#    Save the map received by the client on disk.
+enable_local_map_saving (Saving map received from server) bool false
+
+#    URL to the server list displayed in the Multiplayer Tab.
+serverlist_url (Serverlist URL) string servers.minetest.net
+
+#    If enabled, account registration is separate from login in the UI.
+#    If disabled, new accounts will be registered automatically when logging in.
+enable_split_login_register (Enable split login/register) bool true
+
+[*Server]
+
+#    Name of the player.
+#    When running a server, clients connecting with this name are admins.
+#    When starting from the main menu, this is overridden.
+name (Admin name) string
+
+[**Serverlist and MOTD]
+
+#    Name of the server, to be displayed when players join and in the serverlist.
+server_name (Server name) string Minetest server
+
+#    Description of server, to be displayed when players join and in the serverlist.
+server_description (Server description) string mine here
+
+#    Domain name of server, to be displayed in the serverlist.
+server_address (Server address) string game.minetest.net
+
+#    Homepage of server, to be displayed in the serverlist.
+server_url (Server URL) string https://minetest.net
+
+#    Automatically report to the serverlist.
+server_announce (Announce server) bool false
+
+#    Announce to this serverlist.
+serverlist_url (Serverlist URL) string servers.minetest.net
+
+#    Message of the day displayed to players connecting.
+motd (Message of the day) string
+
+#    Maximum number of players that can be connected simultaneously.
+max_users (Maximum users) int 15
+
+#    If this is set, players will always (re)spawn at the given position.
+static_spawnpoint (Static spawnpoint) string
+
+[**Networking]
+
+#    Network port to listen (UDP).
+#    This value will be overridden when starting from the main menu.
+port (Server port) int 30000
+
+#    The network interface that the server listens on.
+bind_address (Bind address) string
+
+#    Enable to disallow old clients from connecting.
+#    Older clients are compatible in the sense that they will not crash when connecting
+#    to new servers, but they may not support all new features that you are expecting.
+strict_protocol_version_checking (Strict protocol checking) bool false
+
+#    Specifies URL from which client fetches media instead of using UDP.
+#    $filename should be accessible from $remote_media$filename via cURL
+#    (obviously, remote_media should end with a slash).
+#    Files that are not present will be fetched the usual way.
+remote_media (Remote media) string
+
+#    Enable/disable running an IPv6 server.
+#    Ignored if bind_address is set.
+#    Needs enable_ipv6 to be enabled.
+ipv6_server (IPv6 server) bool false
+
+[*Server Security]
+
+#    New users need to input this password.
+default_password (Default password) string
+
+#    If enabled, players cannot join without a password or change theirs to an empty password.
+disallow_empty_password (Disallow empty passwords) bool false
+
+#    The privileges that new users automatically get.
+#    See /privs in game for a full list on your server and mod configuration.
+default_privs (Default privileges) string interact, shout
+
+#    Privileges that players with basic_privs can grant
+basic_privs (Basic privileges) string interact, shout
+
+#    If enabled, disable cheat prevention in multiplayer.
+disable_anticheat (Disable anticheat) bool false
+
+#    If enabled, actions are recorded for rollback.
+#    This option is only read when server starts.
+enable_rollback_recording (Rollback recording) bool false
+
+[**Client-side Modding]
+
+#    Restricts the access of certain client-side functions on servers.
+#    Combine the byteflags below to restrict client-side features, or set to 0
+#    for no restrictions:
+#    LOAD_CLIENT_MODS: 1 (disable loading client-provided mods)
+#    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
+#    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
+#    READ_NODEDEFS: 8 (disable get_node_def call client-side)
+#    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to
+#    csm_restriction_noderange)
+#    READ_PLAYERINFO: 32 (disable get_player_names call client-side)
+csm_restriction_flags (Client side modding restrictions) int 62
+
+#   If the CSM restriction for node range is enabled, get_node calls are limited
+#   to this distance from the player to the node.
+csm_restriction_noderange (Client side node lookup range restriction) int 0
+
+[**Chat]
+
+#    Remove color codes from incoming chat messages
+#    Use this to stop players from being able to use color in their messages
+strip_color_codes (Strip color codes) bool false
+
+#    Set the maximum character length of a chat message sent by clients.
+chat_message_max_size (Chat message max length) int 500
+
+#    Amount of messages a player may send per 10 seconds.
+chat_message_limit_per_10sec (Chat message count limit) float 10.0
+
+#    Kick players who sent more than X messages per 10 seconds.
+chat_message_limit_trigger_kick (Chat message kick threshold) int 50
+
+[*Server Gameplay]
+
+#    Controls length of day/night cycle.
+#    Examples:
+#    72 = 20min, 360 = 4min, 1 = 24hour, 0 = day/night/whatever stays unchanged.
+time_speed (Time speed) int 72
+
+#    Time of day when a new world is started, in millihours (0-23999).
+world_start_time (World start time) int 6125 0 23999
+
+#    Time in seconds for item entity (dropped items) to live.
+#    Setting it to -1 disables the feature.
+item_entity_ttl (Item entity TTL) int 900
+
+#    Specifies the default stack size of nodes, items and tools.
+#    Note that mods or games may explicitly set a stack for certain (or all) items.
+default_stack_max (Default stack size) int 99
+
+[**Physics]
+
+#    Horizontal and vertical acceleration on ground or when climbing,
+#    in nodes per second per second.
+movement_acceleration_default (Default acceleration) float 3
+
+#    Horizontal acceleration in air when jumping or falling,
+#    in nodes per second per second.
+movement_acceleration_air (Acceleration in air) float 2
+
+#    Horizontal and vertical acceleration in fast mode,
+#    in nodes per second per second.
+movement_acceleration_fast (Fast mode acceleration) float 10
+
+#    Walking and flying speed, in nodes per second.
+movement_speed_walk (Walking speed) float 4
+
+#    Sneaking speed, in nodes per second.
+movement_speed_crouch (Sneaking speed) float 1.35
+
+#    Walking, flying and climbing speed in fast mode, in nodes per second.
+movement_speed_fast (Fast mode speed) float 20
+
+#    Vertical climbing speed, in nodes per second.
+movement_speed_climb (Climbing speed) float 3
+
+#    Initial vertical speed when jumping, in nodes per second.
+movement_speed_jump (Jumping speed) float 6.5
+
+#    Decrease this to increase liquid resistance to movement.
+movement_liquid_fluidity (Liquid fluidity) float 1
+
+#    Maximum liquid resistance. Controls deceleration when entering liquid at
+#    high speed.
+movement_liquid_fluidity_smooth (Liquid fluidity smoothing) float 0.5
+
+#    Controls sinking speed in liquid.
+movement_liquid_sink (Liquid sinking) float 10
+
+#    Acceleration of gravity, in nodes per second per second.
+movement_gravity (Gravity) float 9.81
+
+
+[Mapgen]
+
+#    A chosen map seed for a new map, leave empty for random.
+#    Will be overridden when creating a new world in the main menu.
+fixed_map_seed (Fixed map seed) string
+
+#    Name of map generator to be used when creating a new world.
+#    Creating a world in the main menu will override this.
+#    Current mapgens in a highly unstable state:
+#    -    The optional floatlands of v7 (disabled by default).
+mg_name (Mapgen name) enum v7 v7,valleys,carpathian,v5,flat,fractal,singlenode,v6
+
+#    Water surface level of the world.
+water_level (Water level) int 1
+
+#    From how far blocks are generated for clients, stated in mapblocks (16 nodes).
+max_block_generate_distance (Max block generate distance) int 10
+
+#    Limit of map generation, in nodes, in all 6 directions from (0, 0, 0).
+#    Only mapchunks completely within the mapgen limit are generated.
+#    Value is stored per-world.
+mapgen_limit (Map generation limit) int 31007 0 31007
+
+#    Global map generation attributes.
+#    In Mapgen v6 the 'decorations' flag controls all decorations except trees
+#    and jungle grass, in all other mapgens this flag controls all decorations.
+mg_flags (Mapgen flags) flags caves,dungeons,light,decorations,biomes,ores caves,dungeons,light,decorations,biomes,ores,nocaves,nodungeons,nolight,nodecorations,nobiomes,noores
+
+[*Biome API noise parameters]
+
+#    Temperature variation for biomes.
+mg_biome_np_heat (Heat noise) noise_params_2d 50, 50, (1000, 1000, 1000), 5349, 3, 0.5, 2.0, eased
+
+#    Small-scale temperature variation for blending biomes on borders.
+mg_biome_np_heat_blend (Heat blend noise) noise_params_2d 0, 1.5, (8, 8, 8), 13, 2, 1.0, 2.0, eased
+
+#    Humidity variation for biomes.
+mg_biome_np_humidity (Humidity noise) noise_params_2d 50, 50, (1000, 1000, 1000), 842, 3, 0.5, 2.0, eased
+
+#    Small-scale humidity variation for blending biomes on borders.
+mg_biome_np_humidity_blend (Humidity blend noise) noise_params_2d 0, 1.5, (8, 8, 8), 90003, 2, 1.0, 2.0, eased
+
+[*Mapgen V5]
+
+#    Map generation attributes specific to Mapgen v5.
+mgv5_spflags (Mapgen V5 specific flags) flags caverns caverns,nocaverns
+
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+#    Value >= 10.0 completely disables generation of tunnels and avoids the
+#    intensive noise calculations.
+mgv5_cave_width (Cave width) float 0.09
+
+#    Y of upper limit of large caves.
+mgv5_large_cave_depth (Large cave depth) int -256
+
+#    Minimum limit of random number of small caves per mapchunk.
+mgv5_small_cave_num_min (Small cave minimum number) int 0 0 256
+
+#    Maximum limit of random number of small caves per mapchunk.
+mgv5_small_cave_num_max (Small cave maximum number) int 0 0 256
+
+#    Minimum limit of random number of large caves per mapchunk.
+mgv5_large_cave_num_min (Large cave minimum number) int 0 0 64
+
+#    Maximum limit of random number of large caves per mapchunk.
+mgv5_large_cave_num_max (Large cave maximum number) int 2 0 64
+
+#    Proportion of large caves that contain liquid.
+mgv5_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
+
+#    Y-level of cavern upper limit.
+mgv5_cavern_limit (Cavern limit) int -256
+
+#    Y-distance over which caverns expand to full size.
+mgv5_cavern_taper (Cavern taper) int 256
+
+#    Defines full size of caverns, smaller values create larger caverns.
+mgv5_cavern_threshold (Cavern threshold) float 0.7
+
+#    Lower Y limit of dungeons.
+mgv5_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgv5_dungeon_ymax (Dungeon maximum Y) int 31000
+
+[**Noises]
+
+#    Variation of biome filler depth.
+mgv5_np_filler_depth (Filler depth noise) noise_params_2d 0, 1, (150, 150, 150), 261, 4, 0.7, 2.0, eased
+
+#    Variation of terrain vertical scale.
+#    When noise is < -0.55 terrain is near-flat.
+mgv5_np_factor (Factor noise) noise_params_2d 0, 1, (250, 250, 250), 920381, 3, 0.45, 2.0, eased
+
+#    Y-level of average terrain surface.
+mgv5_np_height (Height noise) noise_params_2d 0, 10, (250, 250, 250), 84174, 4, 0.5, 2.0, eased
+
+#    First of two 3D noises that together define tunnels.
+mgv5_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
+
+#    Second of two 3D noises that together define tunnels.
+mgv5_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
+
+#    3D noise defining giant caverns.
+mgv5_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
+
+#    3D noise defining terrain.
+mgv5_np_ground (Ground noise) noise_params_3d 0, 40, (80, 80, 80), 983240, 4, 0.55, 2.0, eased
+
+#    3D noise that determines number of dungeons per mapchunk.
+mgv5_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
+
+[*Mapgen V6]
+
+#    Map generation attributes specific to Mapgen v6.
+#    The 'snowbiomes' flag enables the new 5 biome system.
+#    When the 'snowbiomes' flag is enabled jungles are automatically enabled and
+#    the 'jungles' flag is ignored.
+mgv6_spflags (Mapgen V6 specific flags) flags jungles,biomeblend,mudflow,snowbiomes,noflat,trees jungles,biomeblend,mudflow,snowbiomes,flat,trees,nojungles,nobiomeblend,nomudflow,nosnowbiomes,noflat,notrees
+
+#    Deserts occur when np_biome exceeds this value.
+#    When the 'snowbiomes' flag is enabled, this is ignored.
+mgv6_freq_desert (Desert noise threshold) float 0.45
+
+#    Sandy beaches occur when np_beach exceeds this value.
+mgv6_freq_beach (Beach noise threshold) float 0.15
+
+#    Lower Y limit of dungeons.
+mgv6_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgv6_dungeon_ymax (Dungeon maximum Y) int 31000
+
+[**Noises]
+
+#    Y-level of lower terrain and seabed.
+mgv6_np_terrain_base (Terrain base noise) noise_params_2d -4, 20, (250, 250, 250), 82341, 5, 0.6, 2.0, eased
+
+#    Y-level of higher terrain that creates cliffs.
+mgv6_np_terrain_higher (Terrain higher noise) noise_params_2d 20, 16, (500, 500, 500), 85039, 5, 0.6, 2.0, eased
+
+#    Varies steepness of cliffs.
+mgv6_np_steepness (Steepness noise) noise_params_2d 0.85, 0.5, (125, 125, 125), -932, 5, 0.7, 2.0, eased
+
+#    Defines distribution of higher terrain.
+mgv6_np_height_select (Height select noise) noise_params_2d 0.5, 1, (250, 250, 250), 4213, 5, 0.69, 2.0, eased
+
+#    Varies depth of biome surface nodes.
+mgv6_np_mud (Mud noise) noise_params_2d 4, 2, (200, 200, 200), 91013, 3, 0.55, 2.0, eased
+
+#    Defines areas with sandy beaches.
+mgv6_np_beach (Beach noise) noise_params_2d 0, 1, (250, 250, 250), 59420, 3, 0.50, 2.0, eased
+
+#    Temperature variation for biomes.
+mgv6_np_biome (Biome noise) noise_params_2d 0, 1, (500, 500, 500), 9130, 3, 0.50, 2.0, eased
+
+#    Variation of number of caves.
+mgv6_np_cave (Cave noise) noise_params_2d 6, 6, (250, 250, 250), 34329, 3, 0.50, 2.0, eased
+
+#    Humidity variation for biomes.
+mgv6_np_humidity (Humidity noise) noise_params_2d 0.5, 0.5, (500, 500, 500), 72384, 3, 0.50, 2.0, eased
+
+#    Defines tree areas and tree density.
+mgv6_np_trees (Trees noise) noise_params_2d 0, 1, (125, 125, 125), 2, 4, 0.66, 2.0, eased
+
+#    Defines areas where trees have apples.
+mgv6_np_apple_trees (Apple trees noise) noise_params_2d 0, 1, (100, 100, 100), 342902, 3, 0.45, 2.0, eased
+
+[*Mapgen V7]
+
+#    Map generation attributes specific to Mapgen v7.
+#    'ridges': Rivers.
+#    'floatlands': Floating land masses in the atmosphere.
+#    'caverns': Giant caves deep underground.
+mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,caverns mountains,ridges,floatlands,caverns,nomountains,noridges,nofloatlands,nocaverns
+
+#    Y of mountain density gradient zero level. Used to shift mountains vertically.
+mgv7_mount_zero_level (Mountain zero level) int 0
+
+#    Lower Y limit of floatlands.
+mgv7_floatland_ymin (Floatland minimum Y) int 1024
+
+#    Upper Y limit of floatlands.
+mgv7_floatland_ymax (Floatland maximum Y) int 4096
+
+#    Y-distance over which floatlands taper from full density to nothing.
+#    Tapering starts at this distance from the Y limit.
+#    For a solid floatland layer, this controls the height of hills/mountains.
+#    Must be less than or equal to half the distance between the Y limits.
+mgv7_floatland_taper (Floatland tapering distance) int 256
+
+#    Exponent of the floatland tapering. Alters the tapering behaviour.
+#    Value = 1.0 creates a uniform, linear tapering.
+#    Values > 1.0 create a smooth tapering suitable for the default separated
+#    floatlands.
+#    Values < 1.0 (for example 0.25) create a more defined surface level with
+#    flatter lowlands, suitable for a solid floatland layer.
+mgv7_float_taper_exp (Floatland taper exponent) float 2.0
+
+#    Adjusts the density of the floatland layer.
+#    Increase value to increase density. Can be positive or negative.
+#    Value = 0.0: 50% of volume is floatland.
+#    Value = 2.0 (can be higher depending on 'mgv7_np_floatland', always test
+#    to be sure) creates a solid floatland layer.
+mgv7_floatland_density (Floatland density) float -0.6
+
+#    Surface level of optional water placed on a solid floatland layer.
+#    Water is disabled by default and will only be placed if this value is set
+#    to above 'mgv7_floatland_ymax' - 'mgv7_floatland_taper' (the start of the
+#    upper tapering).
+#    ***WARNING, POTENTIAL DANGER TO WORLDS AND SERVER PERFORMANCE***:
+#    When enabling water placement the floatlands must be configured and tested
+#    to be a solid layer by setting 'mgv7_floatland_density' to 2.0 (or other
+#    required value depending on 'mgv7_np_floatland'), to avoid
+#    server-intensive extreme water flow and to avoid vast flooding of the
+#    world surface below.
+mgv7_floatland_ywater (Floatland water level) int -31000
+
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+#    Value >= 10.0 completely disables generation of tunnels and avoids the
+#    intensive noise calculations.
+mgv7_cave_width (Cave width) float 0.09
+
+#    Y of upper limit of large caves.
+mgv7_large_cave_depth (Large cave depth) int -33
+
+#    Minimum limit of random number of small caves per mapchunk.
+mgv7_small_cave_num_min (Small cave minimum number) int 0 0 256
+
+#    Maximum limit of random number of small caves per mapchunk.
+mgv7_small_cave_num_max (Small cave maximum number) int 0 0 256
+
+#    Minimum limit of random number of large caves per mapchunk.
+mgv7_large_cave_num_min (Large cave minimum number) int 0 0 64
+
+#    Maximum limit of random number of large caves per mapchunk.
+mgv7_large_cave_num_max (Large cave maximum number) int 2 0 64
+
+#    Proportion of large caves that contain liquid.
+mgv7_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
+
+#    Y-level of cavern upper limit.
+mgv7_cavern_limit (Cavern limit) int -256
+
+#    Y-distance over which caverns expand to full size.
+mgv7_cavern_taper (Cavern taper) int 256
+
+#    Defines full size of caverns, smaller values create larger caverns.
+mgv7_cavern_threshold (Cavern threshold) float 0.7
+
+#    Lower Y limit of dungeons.
+mgv7_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgv7_dungeon_ymax (Dungeon maximum Y) int 31000
+
+[**Noises]
+
+#    Y-level of higher terrain that creates cliffs.
+mgv7_np_terrain_base (Terrain base noise) noise_params_2d 4, 70, (600, 600, 600), 82341, 5, 0.6, 2.0, eased
+
+#    Y-level of lower terrain and seabed.
+mgv7_np_terrain_alt (Terrain alternative noise) noise_params_2d 4, 25, (600, 600, 600), 5934, 5, 0.6, 2.0, eased
+
+#    Varies roughness of terrain.
+#    Defines the 'persistence' value for terrain_base and terrain_alt noises.
+mgv7_np_terrain_persist (Terrain persistence noise) noise_params_2d 0.6, 0.1, (2000, 2000, 2000), 539, 3, 0.6, 2.0, eased
+
+#    Defines distribution of higher terrain and steepness of cliffs.
+mgv7_np_height_select (Height select noise) noise_params_2d -8, 16, (500, 500, 500), 4213, 6, 0.7, 2.0, eased
+
+#    Variation of biome filler depth.
+mgv7_np_filler_depth (Filler depth noise) noise_params_2d 0, 1.2, (150, 150, 150), 261, 3, 0.7, 2.0, eased
+
+#    Variation of maximum mountain height (in nodes).
+mgv7_np_mount_height (Mountain height noise) noise_params_2d 256, 112, (1000, 1000, 1000), 72449, 3, 0.6, 2.0, eased
+
+#    Defines large-scale river channel structure.
+mgv7_np_ridge_uwater (Ridge underwater noise) noise_params_2d 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0, eased
+
+#    3D noise defining mountain structure and height.
+#    Also defines structure of floatland mountain terrain.
+mgv7_np_mountain (Mountain noise) noise_params_3d -0.6, 1, (250, 350, 250), 5333, 5, 0.63, 2.0
+
+#    3D noise defining structure of river canyon walls.
+mgv7_np_ridge (Ridge noise) noise_params_3d 0, 1, (100, 100, 100), 6467, 4, 0.75, 2.0
+
+#    3D noise defining structure of floatlands.
+#    If altered from the default, the noise 'scale' (0.7 by default) may need
+#    to be adjusted, as floatland tapering functions best when this noise has
+#    a value range of approximately -2.0 to 2.0.
+mgv7_np_floatland (Floatland noise) noise_params_3d 0, 0.7, (384, 96, 384), 1009, 4, 0.75, 1.618
+
+#    3D noise defining giant caverns.
+mgv7_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
+
+#    First of two 3D noises that together define tunnels.
+mgv7_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
+
+#    Second of two 3D noises that together define tunnels.
+mgv7_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
+
+#    3D noise that determines number of dungeons per mapchunk.
+mgv7_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
+
+[*Mapgen Carpathian]
+
+#    Map generation attributes specific to Mapgen Carpathian.
+mgcarpathian_spflags (Mapgen Carpathian specific flags) flags caverns,norivers caverns,rivers,nocaverns,norivers
+
+#    Defines the base ground level.
+mgcarpathian_base_level (Base ground level) float 12.0
+
+#    Defines the width of the river channel.
+mgcarpathian_river_width (River channel width) float 0.05
+
+#    Defines the depth of the river channel.
+mgcarpathian_river_depth (River channel depth) float 24.0
+
+#    Defines the width of the river valley.
+mgcarpathian_valley_width (River valley width) float 0.25
+
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+#    Value >= 10.0 completely disables generation of tunnels and avoids the
+#    intensive noise calculations.
+mgcarpathian_cave_width (Cave width) float 0.09
+
+#    Y of upper limit of large caves.
+mgcarpathian_large_cave_depth (Large cave depth) int -33
+
+#    Minimum limit of random number of small caves per mapchunk.
+mgcarpathian_small_cave_num_min (Small cave minimum number) int 0 0 256
+
+#    Maximum limit of random number of small caves per mapchunk.
+mgcarpathian_small_cave_num_max (Small cave maximum number) int 0 0 256
+
+#    Minimum limit of random number of large caves per mapchunk.
+mgcarpathian_large_cave_num_min (Large cave minimum number) int 0 0 64
+
+#    Maximum limit of random number of large caves per mapchunk.
+mgcarpathian_large_cave_num_max (Large cave maximum number) int 2 0 64
+
+#    Proportion of large caves that contain liquid.
+mgcarpathian_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
+
+#    Y-level of cavern upper limit.
+mgcarpathian_cavern_limit (Cavern limit) int -256
+
+#    Y-distance over which caverns expand to full size.
+mgcarpathian_cavern_taper (Cavern taper) int 256
+
+#    Defines full size of caverns, smaller values create larger caverns.
+mgcarpathian_cavern_threshold (Cavern threshold) float 0.7
+
+#    Lower Y limit of dungeons.
+mgcarpathian_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgcarpathian_dungeon_ymax (Dungeon maximum Y) int 31000
+
+[**Noises]
+
+#    Variation of biome filler depth.
+mgcarpathian_np_filler_depth (Filler depth noise) noise_params_2d 0, 1, (128, 128, 128), 261, 3, 0.7, 2.0, eased
+
+#    First of 4 2D noises that together define hill/mountain range height.
+mgcarpathian_np_height1 (Hilliness1 noise) noise_params_2d 0, 5, (251, 251, 251), 9613, 5, 0.5, 2.0, eased
+
+#    Second of 4 2D noises that together define hill/mountain range height.
+mgcarpathian_np_height2 (Hilliness2 noise) noise_params_2d 0, 5, (383, 383, 383), 1949, 5, 0.5, 2.0, eased
+
+#    Third of 4 2D noises that together define hill/mountain range height.
+mgcarpathian_np_height3 (Hilliness3 noise) noise_params_2d 0, 5, (509, 509, 509), 3211, 5, 0.5, 2.0, eased
+
+#    Fourth of 4 2D noises that together define hill/mountain range height.
+mgcarpathian_np_height4 (Hilliness4 noise) noise_params_2d 0, 5, (631, 631, 631), 1583, 5, 0.5, 2.0, eased
+
+#    2D noise that controls the size/occurrence of rolling hills.
+mgcarpathian_np_hills_terrain (Rolling hills spread noise) noise_params_2d 1, 1, (1301, 1301, 1301), 1692, 3, 0.5, 2.0, eased
+
+#    2D noise that controls the size/occurrence of ridged mountain ranges.
+mgcarpathian_np_ridge_terrain (Ridge mountain spread noise) noise_params_2d 1, 1, (1889, 1889, 1889), 3568, 3, 0.5, 2.0, eased
+
+#    2D noise that controls the size/occurrence of step mountain ranges.
+mgcarpathian_np_step_terrain (Step mountain spread noise) noise_params_2d 1, 1, (1889, 1889, 1889), 4157, 3, 0.5, 2.0, eased
+
+#    2D noise that controls the shape/size of rolling hills.
+mgcarpathian_np_hills (Rolling hill size noise) noise_params_2d 0, 3, (257, 257, 257), 6604, 6, 0.5, 2.0, eased
+
+#    2D noise that controls the shape/size of ridged mountains.
+mgcarpathian_np_ridge_mnt (Ridged mountain size noise) noise_params_2d 0, 12, (743, 743, 743), 5520, 6, 0.7, 2.0, eased
+
+#    2D noise that controls the shape/size of step mountains.
+mgcarpathian_np_step_mnt (Step mountain size noise) noise_params_2d 0, 8, (509, 509, 509), 2590, 6, 0.6, 2.0, eased
+
+#    2D noise that locates the river valleys and channels.
+mgcarpathian_np_rivers (River noise) noise_params_2d 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0, eased
+
+#    3D noise for mountain overhangs, cliffs, etc. Usually small variations.
+mgcarpathian_np_mnt_var (Mountain variation noise) noise_params_3d 0, 1, (499, 499, 499), 2490, 5, 0.55, 2.0
+
+#    First of two 3D noises that together define tunnels.
+mgcarpathian_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
+
+#    Second of two 3D noises that together define tunnels.
+mgcarpathian_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
+
+#    3D noise defining giant caverns.
+mgcarpathian_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
+
+#    3D noise that determines number of dungeons per mapchunk.
+mgcarpathian_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
+
+[*Mapgen Flat]
+
+#    Map generation attributes specific to Mapgen Flat.
+#    Occasional lakes and hills can be added to the flat world.
+mgflat_spflags (Mapgen Flat specific flags) flags nolakes,nohills,nocaverns lakes,hills,caverns,nolakes,nohills,nocaverns
+
+#    Y of flat ground.
+mgflat_ground_level (Ground level) int 8
+
+#    Y of upper limit of large caves.
+mgflat_large_cave_depth (Large cave depth) int -33
+
+#    Minimum limit of random number of small caves per mapchunk.
+mgflat_small_cave_num_min (Small cave minimum number) int 0 0 256
+
+#    Maximum limit of random number of small caves per mapchunk.
+mgflat_small_cave_num_max (Small cave maximum number) int 0 0 256
+
+#    Minimum limit of random number of large caves per mapchunk.
+mgflat_large_cave_num_min (Large cave minimum number) int 0 0 64
+
+#    Maximum limit of random number of large caves per mapchunk.
+mgflat_large_cave_num_max (Large cave maximum number) int 2 0 64
+
+#    Proportion of large caves that contain liquid.
+mgflat_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
+
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+#    Value >= 10.0 completely disables generation of tunnels and avoids the
+#    intensive noise calculations.
+mgflat_cave_width (Cave width) float 0.09
+
+#    Terrain noise threshold for lakes.
+#    Controls proportion of world area covered by lakes.
+#    Adjust towards 0.0 for a larger proportion.
+mgflat_lake_threshold (Lake threshold) float -0.45
+
+#    Controls steepness/depth of lake depressions.
+mgflat_lake_steepness (Lake steepness) float 48.0
+
+#    Terrain noise threshold for hills.
+#    Controls proportion of world area covered by hills.
+#    Adjust towards 0.0 for a larger proportion.
+mgflat_hill_threshold (Hill threshold) float 0.45
+
+#    Controls steepness/height of hills.
+mgflat_hill_steepness (Hill steepness) float 64.0
+
+#    Y-level of cavern upper limit.
+mgflat_cavern_limit (Cavern limit) int -256
+
+#    Y-distance over which caverns expand to full size.
+mgflat_cavern_taper (Cavern taper) int 256
+
+#    Defines full size of caverns, smaller values create larger caverns.
+mgflat_cavern_threshold (Cavern threshold) float 0.7
+
+#    Lower Y limit of dungeons.
+mgflat_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgflat_dungeon_ymax (Dungeon maximum Y) int 31000
+
+[**Noises]
+
+#    Defines location and terrain of optional hills and lakes.
+mgflat_np_terrain (Terrain noise) noise_params_2d 0, 1, (600, 600, 600), 7244, 5, 0.6, 2.0, eased
+
+#    Variation of biome filler depth.
+mgflat_np_filler_depth (Filler depth noise) noise_params_2d 0, 1.2, (150, 150, 150), 261, 3, 0.7, 2.0, eased
+
+#    First of two 3D noises that together define tunnels.
+mgflat_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
+
+#    Second of two 3D noises that together define tunnels.
+mgflat_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
+
+#    3D noise defining giant caverns.
+mgflat_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
+
+#    3D noise that determines number of dungeons per mapchunk.
+mgflat_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
+
+[*Mapgen Fractal]
+
+#    Map generation attributes specific to Mapgen Fractal.
+#    'terrain' enables the generation of non-fractal terrain:
+#    ocean, islands and underground.
+mgfractal_spflags (Mapgen Fractal specific flags) flags terrain terrain,noterrain
+
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+#    Value >= 10.0 completely disables generation of tunnels and avoids the
+#    intensive noise calculations.
+mgfractal_cave_width (Cave width) float 0.09
+
+#    Y of upper limit of large caves.
+mgfractal_large_cave_depth (Large cave depth) int -33
+
+#    Minimum limit of random number of small caves per mapchunk.
+mgfractal_small_cave_num_min (Small cave minimum number) int 0 0 256
+
+#    Maximum limit of random number of small caves per mapchunk.
+mgfractal_small_cave_num_max (Small cave maximum number) int 0 0 256
+
+#    Minimum limit of random number of large caves per mapchunk.
+mgfractal_large_cave_num_min (Large cave minimum number) int 0 0 64
+
+#    Maximum limit of random number of large caves per mapchunk.
+mgfractal_large_cave_num_max (Large cave maximum number) int 2 0 64
+
+#    Proportion of large caves that contain liquid.
+mgfractal_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
+
+#    Lower Y limit of dungeons.
+mgfractal_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgfractal_dungeon_ymax (Dungeon maximum Y) int 31000
+
+#    Selects one of 18 fractal types.
+#    1 = 4D "Roundy" Mandelbrot set.
+#    2 = 4D "Roundy" Julia set.
+#    3 = 4D "Squarry" Mandelbrot set.
+#    4 = 4D "Squarry" Julia set.
+#    5 = 4D "Mandy Cousin" Mandelbrot set.
+#    6 = 4D "Mandy Cousin" Julia set.
+#    7 = 4D "Variation" Mandelbrot set.
+#    8 = 4D "Variation" Julia set.
+#    9 = 3D "Mandelbrot/Mandelbar" Mandelbrot set.
+#    10 = 3D "Mandelbrot/Mandelbar" Julia set.
+#    11 = 3D "Christmas Tree" Mandelbrot set.
+#    12 = 3D "Christmas Tree" Julia set.
+#    13 = 3D "Mandelbulb" Mandelbrot set.
+#    14 = 3D "Mandelbulb" Julia set.
+#    15 = 3D "Cosine Mandelbulb" Mandelbrot set.
+#    16 = 3D "Cosine Mandelbulb" Julia set.
+#    17 = 4D "Mandelbulb" Mandelbrot set.
+#    18 = 4D "Mandelbulb" Julia set.
+mgfractal_fractal (Fractal type) int 1 1 18
+
+#    Iterations of the recursive function.
+#    Increasing this increases the amount of fine detail, but also
+#    increases processing load.
+#    At iterations = 20 this mapgen has a similar load to mapgen V7.
+mgfractal_iterations (Iterations) int 11
+
+#    (X,Y,Z) scale of fractal in nodes.
+#    Actual fractal size will be 2 to 3 times larger.
+#    These numbers can be made very large, the fractal does
+#    not have to fit inside the world.
+#    Increase these to 'zoom' into the detail of the fractal.
+#    Default is for a vertically-squashed shape suitable for
+#    an island, set all 3 numbers equal for the raw shape.
+mgfractal_scale (Scale) v3f (4096.0, 1024.0, 4096.0)
+
+#    (X,Y,Z) offset of fractal from world center in units of 'scale'.
+#    Can be used to move a desired point to (0, 0) to create a
+#    suitable spawn point, or to allow 'zooming in' on a desired
+#    point by increasing 'scale'.
+#    The default is tuned for a suitable spawn point for Mandelbrot
+#    sets with default parameters, it may need altering in other
+#    situations.
+#    Range roughly -2 to 2. Multiply by 'scale' for offset in nodes.
+mgfractal_offset (Offset) v3f (1.79, 0.0, 0.0)
+
+#    W coordinate of the generated 3D slice of a 4D fractal.
+#    Determines which 3D slice of the 4D shape is generated.
+#    Alters the shape of the fractal.
+#    Has no effect on 3D fractals.
+#    Range roughly -2 to 2.
+mgfractal_slice_w (Slice w) float 0.0
+
+#    Julia set only.
+#    X component of hypercomplex constant.
+#    Alters the shape of the fractal.
+#    Range roughly -2 to 2.
+mgfractal_julia_x (Julia x) float 0.33
+
+#    Julia set only.
+#    Y component of hypercomplex constant.
+#    Alters the shape of the fractal.
+#    Range roughly -2 to 2.
+mgfractal_julia_y (Julia y) float 0.33
+
+#    Julia set only.
+#    Z component of hypercomplex constant.
+#    Alters the shape of the fractal.
+#    Range roughly -2 to 2.
+mgfractal_julia_z (Julia z) float 0.33
+
+#    Julia set only.
+#    W component of hypercomplex constant.
+#    Alters the shape of the fractal.
+#    Has no effect on 3D fractals.
+#    Range roughly -2 to 2.
+mgfractal_julia_w (Julia w) float 0.33
+
+[**Noises]
+
+#    Y-level of seabed.
+mgfractal_np_seabed (Seabed noise) noise_params_2d -14, 9, (600, 600, 600), 41900, 5, 0.6, 2.0, eased
+
+#    Variation of biome filler depth.
+mgfractal_np_filler_depth (Filler depth noise) noise_params_2d 0, 1.2, (150, 150, 150), 261, 3, 0.7, 2.0, eased
+
+#    First of two 3D noises that together define tunnels.
+mgfractal_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
+
+#    Second of two 3D noises that together define tunnels.
+mgfractal_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
+
+#    3D noise that determines number of dungeons per mapchunk.
+mgfractal_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
+
+[*Mapgen Valleys]
+
+#    Map generation attributes specific to Mapgen Valleys.
+#    'altitude_chill': Reduces heat with altitude.
+#    'humid_rivers': Increases humidity around rivers.
+#    'vary_river_depth': If enabled, low humidity and high heat causes rivers
+#    to become shallower and occasionally dry.
+#    'altitude_dry': Reduces humidity with altitude.
+mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_rivers,vary_river_depth,altitude_dry altitude_chill,humid_rivers,vary_river_depth,altitude_dry,noaltitude_chill,nohumid_rivers,novary_river_depth,noaltitude_dry
+
+#    The vertical distance over which heat drops by 20 if 'altitude_chill' is
+#    enabled. Also the vertical distance over which humidity drops by 10 if
+#    'altitude_dry' is enabled.
+mgvalleys_altitude_chill (Altitude chill) int 90
+
+#    Depth below which you'll find large caves.
+mgvalleys_large_cave_depth (Large cave depth) int -33
+
+#    Minimum limit of random number of small caves per mapchunk.
+mgvalleys_small_cave_num_min (Small cave minimum number) int 0 0 256
+
+#    Maximum limit of random number of small caves per mapchunk.
+mgvalleys_small_cave_num_max (Small cave maximum number) int 0 0 256
+
+#    Minimum limit of random number of large caves per mapchunk.
+mgvalleys_large_cave_num_min (Large cave minimum number) int 0 0 64
+
+#    Maximum limit of random number of large caves per mapchunk.
+mgvalleys_large_cave_num_max (Large cave maximum number) int 2 0 64
+
+#    Proportion of large caves that contain liquid.
+mgvalleys_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
+
+#    Depth below which you'll find giant caverns.
+mgvalleys_cavern_limit (Cavern upper limit) int -256
+
+#    Y-distance over which caverns expand to full size.
+mgvalleys_cavern_taper (Cavern taper) int 192
+
+#    Defines full size of caverns, smaller values create larger caverns.
+mgvalleys_cavern_threshold (Cavern threshold) float 0.6
+
+#    How deep to make rivers.
+mgvalleys_river_depth (River depth) int 4
+
+#    How wide to make rivers.
+mgvalleys_river_size (River size) int 5
+
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+#    Value >= 10.0 completely disables generation of tunnels and avoids the
+#    intensive noise calculations.
+mgvalleys_cave_width (Cave width) float 0.09
+
+#    Lower Y limit of dungeons.
+mgvalleys_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgvalleys_dungeon_ymax (Dungeon maximum Y) int 63
+
+[**Noises]
+
+#    First of two 3D noises that together define tunnels.
+mgvalleys_np_cave1 (Cave noise #1) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
+
+#    Second of two 3D noises that together define tunnels.
+mgvalleys_np_cave2 (Cave noise #2) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
+
+#    The depth of dirt or other biome filler node.
+mgvalleys_np_filler_depth (Filler depth) noise_params_2d 0, 1.2, (256, 256, 256), 1605, 3, 0.5, 2.0, eased
+
+#    3D noise defining giant caverns.
+mgvalleys_np_cavern (Cavern noise) noise_params_3d 0, 1, (768, 256, 768), 59033, 6, 0.63, 2.0
+
+#    Defines large-scale river channel structure.
+mgvalleys_np_rivers (River noise) noise_params_2d 0, 1, (256, 256, 256), -6050, 5, 0.6, 2.0, eased
+
+#    Base terrain height.
+mgvalleys_np_terrain_height (Terrain height) noise_params_2d -10, 50, (1024, 1024, 1024), 5202, 6, 0.4, 2.0, eased
+
+#    Raises terrain to make valleys around the rivers.
+mgvalleys_np_valley_depth (Valley depth) noise_params_2d 5, 4, (512, 512, 512), -1914, 1, 1.0, 2.0, eased
+
+#    Slope and fill work together to modify the heights.
+mgvalleys_np_inter_valley_fill (Valley fill) noise_params_3d 0, 1, (256, 512, 256), 1993, 6, 0.8, 2.0
+
+#    Amplifies the valleys.
+mgvalleys_np_valley_profile (Valley profile) noise_params_2d 0.6, 0.5, (512, 512, 512), 777, 1, 1.0, 2.0, eased
+
+#    Slope and fill work together to modify the heights.
+mgvalleys_np_inter_valley_slope (Valley slope) noise_params_2d 0.5, 0.5, (128, 128, 128), 746, 1, 1.0, 2.0, eased
+
+#    3D noise that determines number of dungeons per mapchunk.
+mgvalleys_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
+
+
+[Advanced]
+
+[*Developer Options]
+
+#    Enable Lua modding support on client.
+#    This support is experimental and API can change.
+enable_client_modding (Client modding) bool false
+
+#    Replaces the default main menu with a custom one.
+main_menu_script (Main menu script) string
+
+[**Mod Security]
+
+#    Prevent mods from doing insecure things like running shell commands.
+secure.enable_security (Enable mod security) bool true
+
+#    Comma-separated list of trusted mods that are allowed to access insecure
+#    functions even when mod security is on (via request_insecure_environment()).
+secure.trusted_mods (Trusted mods) string
+
+#    Comma-separated list of mods that are allowed to access HTTP APIs, which
+#    allow them to upload and download data to/from the internet.
+secure.http_mods (HTTP mods) string
+
+[**Debugging]
+
+#    Level of logging to be written to debug.txt:
+#    -    <nothing> (no logging)
+#    -    none (messages with no level)
+#    -    error
+#    -    warning
+#    -    action
+#    -    info
+#    -    verbose
+#    -    trace
+debug_log_level (Debug log level) enum action ,none,error,warning,action,info,verbose,trace
+
+#    If the file size of debug.txt exceeds the number of megabytes specified in
+#    this setting when it is opened, the file is moved to debug.txt.1,
+#    deleting an older debug.txt.1 if it exists.
+#    debug.txt is only moved if this setting is positive.
+debug_log_size_max (Debug log file size threshold) int 50
+
+#    Minimal level of logging to be written to chat.
+chat_log_level (Chat log level) enum error ,none,error,warning,action,info,verbose,trace
+
+#    Handling for deprecated Lua API calls:
+#    -    none: Do not log deprecated calls
+#    -    log: mimic and log backtrace of deprecated call (default).
+#    -    error: abort on usage of deprecated call (suggested for mod developers).
+deprecated_lua_api_handling (Deprecated Lua API handling) enum log none,log,error
+
+#    Enable random user input (only used for testing).
+random_input (Random input) bool false
+
+#    Enable mod channels support.
+enable_mod_channels (Mod channels) bool false
+
+[**Mod Profiler]
+
+#    Load the game profiler to collect game profiling data.
+#    Provides a /profiler command to access the compiled profile.
+#    Useful for mod developers and server operators.
+profiler.load (Load the game profiler) bool false
+
+#    The default format in which profiles are being saved,
+#    when calling `/profiler save [format]` without format.
+profiler.default_report_format (Default report format) enum txt txt,csv,lua,json,json_pretty
+
+#    The file path relative to your worldpath in which profiles will be saved to.
+profiler.report_path (Report path) string ""
+
+#    Instrument the methods of entities on registration.
+instrument.entity (Entity methods) bool true
+
+#    Instrument the action function of Active Block Modifiers on registration.
+instrument.abm (Active Block Modifiers) bool true
+
+#    Instrument the action function of Loading Block Modifiers on registration.
+instrument.lbm (Loading Block Modifiers) bool true
+
+#    Instrument chat commands on registration.
+instrument.chatcommand (Chat commands) bool true
+
+#    Instrument global callback functions on registration.
+#    (anything you pass to a minetest.register_*() function)
+instrument.global_callback (Global callbacks) bool true
+
+#    Instrument builtin.
+#    This is usually only needed by core/builtin contributors
+instrument.builtin (Builtin) bool false
+
+#    Have the profiler instrument itself:
+#     * Instrument an empty function.
+#       This estimates the overhead, that instrumentation is adding (+1 function call).
+#     * Instrument the sampler being used to update the statistics.
+instrument.profiler (Profiler) bool false
+
+[**Engine profiler]
+
+#    Print the engine's profiling data in regular intervals (in seconds).
+#    0 = disable. Useful for developers.
+profiler_print_interval (Engine profiling data print interval) int 0
+
+
+[*Advanced]
+
+#    Enable IPv6 support (for both client and server).
+#    Required for IPv6 connections to work at all.
+enable_ipv6 (IPv6) bool true
+
+#    If enabled, invalid world data won't cause the server to shut down.
+#    Only enable this if you know what you are doing.
+ignore_world_load_errors (Ignore world errors) bool false
+
+[**Graphics]
+
+#    Path to shader directory. If no path is defined, default location will be used.
+shader_path (Shader path) path
+
+#    The rendering back-end.
+#    A restart is required after changing this.
+#    Note: On Android, stick with OGLES1 if unsure! App may fail to start otherwise.
+#    On other platforms, OpenGL is recommended.
+#    Shaders are supported by OpenGL (desktop only) and OGLES2 (experimental)
+video_driver (Video driver) enum opengl opengl,ogles1,ogles2
+
+#    Distance in nodes at which transparency depth sorting is enabled
+#    Use this to limit the performance impact of transparency depth sorting
+transparency_sorting_distance (Transparency Sorting Distance) int 16 0 128
+
+#    Enable vertex buffer objects.
+#    This should greatly improve graphics performance.
+enable_vbo (VBO) bool true
+
+#    Radius of cloud area stated in number of 64 node cloud squares.
+#    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.
+cloud_radius (Cloud radius) int 12
+
+#    Whether node texture animations should be desynchronized per mapblock.
+desynchronize_mapblock_texture_animation (Desynchronize block animation) bool true
+
+#    Enables caching of facedir rotated meshes.
+enable_mesh_cache (Mesh cache) bool false
+
+#    Delay between mesh updates on the client in ms. Increasing this will slow
+#    down the rate of mesh updates, thus reducing jitter on slower clients.
+mesh_generation_interval (Mapblock mesh generation delay) int 0 0 50
+
+#    Size of the MapBlock cache of the mesh generator. Increasing this will
+#    increase the cache hit %, reducing the data being copied from the main
+#    thread, thus reducing jitter.
+meshgen_block_cache_size (Mapblock mesh generator's MapBlock cache size in MB) int 20 0 1000
+
+#    True = 256
+#    False = 128
+#    Usable to make minimap smoother on slower machines.
+minimap_double_scan_height (Minimap scan height) bool true
+
+#    Textures on a node may be aligned either to the node or to the world.
+#    The former mode suits better things like machines, furniture, etc., while
+#    the latter makes stairs and microblocks fit surroundings better.
+#    However, as this possibility is new, thus may not be used by older servers,
+#    this option allows enforcing it for certain node types. Note though that
+#    that is considered EXPERIMENTAL and may not work properly.
+world_aligned_mode (World-aligned textures mode) enum enable disable,enable,force_solid,force_nodebox
+
+#    World-aligned textures may be scaled to span several nodes. However,
+#    the server may not send the scale you want, especially if you use
+#    a specially-designed texture pack; with this option, the client tries
+#    to determine the scale automatically basing on the texture size.
+#    See also texture_min_size.
+#    Warning: This option is EXPERIMENTAL!
+autoscale_mode (Autoscaling mode) enum disable disable,enable,force
+
+[**Font]
+
+font_bold (Font bold by default) bool false
+
+font_italic (Font italic by default) bool false
+
+#    Shadow offset (in pixels) of the default font. If 0, then shadow will not be drawn.
+font_shadow (Font shadow) int 1
+
+#    Opaqueness (alpha) of the shadow behind the default font, between 0 and 255.
+font_shadow_alpha (Font shadow alpha) int 127 0 255
+
+#    Font size of the default font where 1 unit = 1 pixel at 96 DPI
+font_size (Font size) int 16 1
+
+#    For pixel-style fonts that do not scale well, this ensures that font sizes used
+#    with this font will always be divisible by this value, in pixels. For instance,
+#    a pixel font 16 pixels tall should have this set to 16, so it will only ever be
+#    sized 16, 32, 48, etc., so a mod requesting a size of 25 will get 32.
+font_size_divisible_by (Font size divisible by) int 1 1
+
+#    Path to the default font. Must be a TrueType font.
+#    The fallback font will be used if the font cannot be loaded.
+font_path (Regular font path) filepath fonts/Arimo-Regular.ttf
+
+font_path_bold (Bold font path) filepath fonts/Arimo-Bold.ttf
+font_path_italic (Italic font path) filepath fonts/Arimo-Italic.ttf
+font_path_bold_italic (Bold and italic font path) filepath fonts/Arimo-BoldItalic.ttf
+
+#    Font size of the monospace font where 1 unit = 1 pixel at 96 DPI
+mono_font_size (Monospace font size) int 16 1
+
+#    For pixel-style fonts that do not scale well, this ensures that font sizes used
+#    with this font will always be divisible by this value, in pixels. For instance,
+#    a pixel font 16 pixels tall should have this set to 16, so it will only ever be
+#    sized 16, 32, 48, etc., so a mod requesting a size of 25 will get 32.
+mono_font_size_divisible_by (Monospace font size divisible by) int 1 1
+
+#    Path to the monospace font. Must be a TrueType font.
+#    This font is used for e.g. the console and profiler screen.
+mono_font_path (Monospace font path) filepath fonts/Cousine-Regular.ttf
+
+mono_font_path_bold (Bold monospace font path) filepath fonts/Cousine-Bold.ttf
+mono_font_path_italic (Italic monospace font path) filepath fonts/Cousine-Italic.ttf
+mono_font_path_bold_italic (Bold and italic monospace font path) filepath fonts/Cousine-BoldItalic.ttf
+
+#    Path of the fallback font. Must be a TrueType font.
+#    This font will be used for certain languages or if the default font is unavailable.
+fallback_font_path (Fallback font path) filepath fonts/DroidSansFallbackFull.ttf
+
+[**Lighting]
+
+#    Gradient of light curve at minimum light level.
+#    Controls the contrast of the lowest light levels.
+lighting_alpha (Light curve low gradient) float 0.0 0.0 3.0
+
+#    Gradient of light curve at maximum light level.
+#    Controls the contrast of the highest light levels.
+lighting_beta (Light curve high gradient) float 1.5 0.0 3.0
+
+#    Strength of light curve boost.
+#    The 3 'boost' parameters define a range of the light
+#    curve that is boosted in brightness.
+lighting_boost (Light curve boost) float 0.2 0.0 0.4
+
+#    Center of light curve boost range.
+#    Where 0.0 is minimum light level, 1.0 is maximum light level.
+lighting_boost_center (Light curve boost center) float 0.5 0.0 1.0
+
+#    Spread of light curve boost range.
+#    Controls the width of the range to be boosted.
+#    Standard deviation of the light curve boost Gaussian.
+lighting_boost_spread (Light curve boost spread) float 0.2 0.0 0.4
+
+[**Networking]
+
+#    Prometheus listener address.
+#    If Minetest is compiled with ENABLE_PROMETHEUS option enabled,
+#    enable metrics listener for Prometheus on that address.
+#    Metrics can be fetched on http://127.0.0.1:30000/metrics
+prometheus_listener_address (Prometheus listener address) string 127.0.0.1:30000
+
+#    Maximum size of the out chat queue.
+#    0 to disable queueing and -1 to make the queue size unlimited.
+max_out_chat_queue_size (Maximum size of the out chat queue) int 20
+
+#    Timeout for client to remove unused map data from memory.
+client_unload_unused_data_timeout (Mapblock unload timeout) int 600
+
+#    Maximum number of mapblocks for client to be kept in memory.
+#    Set to -1 for unlimited amount.
+client_mapblock_limit (Mapblock limit) int 7500
+
+#    Whether to show the client debug info (has the same effect as hitting F5).
+show_debug (Show debug info) bool false
+
+#    Maximum number of blocks that are simultaneously sent per client.
+#    The maximum total count is calculated dynamically:
+#    max_total = ceil((#clients + max_users) * per_client / 4)
+max_simultaneous_block_sends_per_client (Maximum simultaneous block sends per client) int 40
+
+#    To reduce lag, block transfers are slowed down when a player is building something.
+#    This determines how long they are slowed down after placing or removing a node.
+full_block_send_enable_min_time_from_building (Delay in sending blocks after building) float 2.0
+
+#    Maximum number of packets sent per send step, if you have a slow connection
+#    try reducing it, but don't reduce it to a number below double of targeted
+#    client number.
+max_packets_per_iteration (Max. packets per iteration) int 1024
+
+#    Compression level to use when sending mapblocks to the client.
+#    -1 - use default compression level
+#     0 - least compression, fastest
+#     9 - best compression, slowest
+map_compression_level_net (Map Compression Level for Network Transfer) int -1 -1 9
+
+[**Server]
+
+#    Format of player chat messages. The following strings are valid placeholders:
+#    @name, @message, @timestamp (optional)
+chat_message_format (Chat message format) string <@name> @message
+
+#    If the execution of a chat command takes longer than this specified time in
+#    seconds, add the time information to the chat command message
+chatcommand_msg_time_threshold (Chat command time message threshold) float 0.1
+
+#    A message to be displayed to all clients when the server shuts down.
+kick_msg_shutdown (Shutdown message) string Server shutting down.
+
+#    A message to be displayed to all clients when the server crashes.
+kick_msg_crash (Crash message) string This server has experienced an internal error. You will now be disconnected.
+
+#    Whether to ask clients to reconnect after a (Lua) crash.
+#    Set this to true if your server is set up to restart automatically.
+ask_reconnect_on_crash (Ask to reconnect after crash) bool false
+
+[**Server/Env Performance]
+
+#    Length of a server tick and the interval at which objects are generally updated over
+#    network.
+dedicated_server_step (Dedicated server step) float 0.09
+
+#    Whether players are shown to clients without any range limit.
+#    Deprecated, use the setting player_transfer_distance instead.
+unlimited_player_transfer_distance (Unlimited player transfer distance) bool true
+
+#    Defines the maximal player transfer distance in blocks (0 = unlimited).
+player_transfer_distance (Player transfer distance) int 0
+
+#    From how far clients know about objects, stated in mapblocks (16 nodes).
+#
+#    Setting this larger than active_block_range will also cause the server
+#    to maintain active objects up to this distance in the direction the
+#    player is looking. (This can avoid mobs suddenly disappearing from view)
+active_object_send_range_blocks (Active object send range) int 8
+
+#    The radius of the volume of blocks around every player that is subject to the
+#    active block stuff, stated in mapblocks (16 nodes).
+#    In active blocks objects are loaded and ABMs run.
+#    This is also the minimum range in which active objects (mobs) are maintained.
+#    This should be configured together with active_object_send_range_blocks.
+active_block_range (Active block range) int 4
+
+#    From how far blocks are sent to clients, stated in mapblocks (16 nodes).
+max_block_send_distance (Max block send distance) int 12
+
+#    Maximum number of forceloaded mapblocks.
+max_forceloaded_blocks (Maximum forceloaded blocks) int 16
+
+#    Interval of sending time of day to clients.
+time_send_interval (Time send interval) int 5
+
+#    Interval of saving important changes in the world, stated in seconds.
+server_map_save_interval (Map save interval) float 5.3
+
+#    How much the server will wait before unloading unused mapblocks.
+#    Higher value is smoother, but will use more RAM.
+server_unload_unused_data_timeout (Unload unused server data) int 29
+
+#    Maximum number of statically stored objects in a block.
+max_objects_per_block (Maximum objects per block) int 256
+
+#    Length of time between active block management cycles
+active_block_mgmt_interval (Active block management interval) float 2.0
+
+#    Length of time between Active Block Modifier (ABM) execution cycles
+abm_interval (ABM interval) float 1.0
+
+#    The time budget allowed for ABMs to execute on each step
+#    (as a fraction of the ABM Interval)
+abm_time_budget (ABM time budget) float 0.2 0.1 0.9
+
+#    Length of time between NodeTimer execution cycles
+nodetimer_interval (NodeTimer interval) float 0.2
+
+#    Max liquids processed per step.
+liquid_loop_max (Liquid loop max) int 100000
+
+#    The time (in seconds) that the liquids queue may grow beyond processing
+#    capacity until an attempt is made to decrease its size by dumping old queue
+#    items.  A value of 0 disables the functionality.
+liquid_queue_purge_time (Liquid queue purge time) int 0
+
+#    Liquid update interval in seconds.
+liquid_update (Liquid update tick) float 1.0
+
+#    At this distance the server will aggressively optimize which blocks are sent to
+#    clients.
+#    Small values potentially improve performance a lot, at the expense of visible
+#    rendering glitches (some blocks will not be rendered under water and in caves,
+#    as well as sometimes on land).
+#    Setting this to a value greater than max_block_send_distance disables this
+#    optimization.
+#    Stated in mapblocks (16 nodes).
+block_send_optimize_distance (Block send optimize distance) int 4 2
+
+#    If enabled the server will perform map block occlusion culling based on
+#    on the eye position of the player. This can reduce the number of blocks
+#    sent to the client 50-80%. The client will not longer receive most invisible
+#    so that the utility of noclip mode is reduced.
+server_side_occlusion_culling (Server side occlusion culling) bool true
+
+[**Mapgen]
+
+#    Size of mapchunks generated by mapgen, stated in mapblocks (16 nodes).
+#    WARNING!: There is no benefit, and there are several dangers, in
+#    increasing this value above 5.
+#    Reducing this value increases cave and dungeon density.
+#    Altering this value is for special usage, leaving it unchanged is
+#    recommended.
+chunksize (Chunk size) int 5
+
+#    Dump the mapgen debug information.
+enable_mapgen_debug_info (Mapgen debug) bool false
+
+#    Maximum number of blocks that can be queued for loading.
+emergequeue_limit_total (Absolute limit of queued blocks to emerge) int 1024 1 1000000
+
+#    Maximum number of blocks to be queued that are to be loaded from file.
+#    This limit is enforced per player.
+emergequeue_limit_diskonly (Per-player limit of queued blocks load from disk) int 128 1 1000000
+
+#    Maximum number of blocks to be queued that are to be generated.
+#    This limit is enforced per player.
+emergequeue_limit_generate (Per-player limit of queued blocks to generate) int 128 1 1000000
+
+#    Number of emerge threads to use.
+#    Value 0:
+#    -    Automatic selection. The number of emerge threads will be
+#    -    'number of processors - 2', with a lower limit of 1.
+#    Any other value:
+#    -    Specifies the number of emerge threads, with a lower limit of 1.
+#    WARNING: Increasing the number of emerge threads increases engine mapgen
+#    speed, but this may harm game performance by interfering with other
+#    processes, especially in singleplayer and/or when running Lua code in
+#    'on_generated'. For many users the optimum setting may be '1'.
+num_emerge_threads (Number of emerge threads) int 1
+
+[**Misc]
+
+#    Adjust dpi configuration to your screen (non X11/Android only) e.g. for 4k screens.
+screen_dpi (DPI) int 72 1
+
+#    Adjust the detected display density, used for scaling UI elements.
+display_density_factor (Display Density Scaling Factor) float 1
+
+#    Windows systems only: Start Minetest with the command line window in the background.
+#    Contains the same information as the file debug.txt (default name).
+enable_console (Enable console window) bool false
+
+#    Number of extra blocks that can be loaded by /clearobjects at once.
+#    This is a trade-off between SQLite transaction overhead and
+#    memory consumption (4096=100MB, as a rule of thumb).
+max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096
+
+#    Maximum time an interactive request (e.g. server list fetch) may take, stated in milliseconds.
+curl_timeout (cURL interactive timeout) int 20000
+
+#    Limits number of parallel HTTP requests. Affects:
+#    -    Media fetch if server uses remote_media setting.
+#    -    Serverlist download and server announcement.
+#    -    Downloads performed by main menu (e.g. mod manager).
+#    Only has an effect if compiled with cURL.
+curl_parallel_limit (cURL parallel limit) int 8
+
+#    Maximum time a file download (e.g. a mod download) may take, stated in milliseconds.
+curl_file_download_timeout (cURL file download timeout) int 300000
+
+#    World directory (everything in the world is stored here).
+#    Not needed if starting from the main menu.
+map-dir (Map directory) path
+
+#    See https://www.sqlite.org/pragma.html#pragma_synchronous
+sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2
+
+#    Compression level to use when saving mapblocks to disk.
+#    -1 - use default compression level
+#     0 - least compression, fastest
+#     9 - best compression, slowest
+map_compression_level_disk (Map Compression Level for Disk Storage) int -1 -1 9
+
+#    Enable usage of remote media server (if provided by server).
+#    Remote servers offer a significantly faster way to download media (e.g. textures)
+#    when connecting to the server.
+enable_remote_media_server (Connect to external media server) bool true
+
+#    File in client/serverlist/ that contains your favorite servers displayed in the
+#    Multiplayer Tab.
+serverlist_file (Serverlist file) string favoriteservers.json
+
+
+[*Gamepads]
+
+#    Enable joysticks
+enable_joysticks (Enable joysticks) bool false
+
+#    The identifier of the joystick to use
+joystick_id (Joystick ID) int 0
+
+#    The type of joystick
+joystick_type (Joystick type) enum auto auto,generic,xbox,dragonrise_gamecube
+
+#    The time in seconds it takes between repeated events
+#    when holding down a joystick button combination.
+repeat_joystick_button_time (Joystick button repetition interval) float 0.17 0.001
+
+#    The dead zone of the joystick
+joystick_deadzone (Joystick dead zone) int 2048
+
+#    The sensitivity of the joystick axes for moving the
+#    in-game view frustum around.
+joystick_frustum_sensitivity (Joystick frustum sensitivity) float 170
+
+
+[*Temporary Settings]
+
+#    Path to texture directory. All textures are first searched from here.
+texture_path (Texture path) path
+
+#    Enables minimap.
+enable_minimap (Minimap) bool true
+
+#    Shape of the minimap. Enabled = round, disabled = square.
+minimap_shape_round (Round minimap) bool true
+
+#    Address to connect to.
+#    Leave this blank to start a local server.
+#    Note that the address field in the main menu overrides this setting.
+address (Server address) string
+
+#    Port to connect to (UDP).
+#    Note that the port field in the main menu overrides this setting.
+remote_port (Remote port) int 30000 1 65535
+
+#    Default game when creating a new world.
+#    This will be overridden when creating a world from the main menu.
+default_game (Default game) string minetest
+
+#    Enable players getting damage and dying.
+enable_damage (Damage) bool false
+
+#    Enable creative mode for all players
+creative_mode (Creative) bool false
+
+#    Whether to allow players to damage and kill each other.
+enable_pvp (Player versus player) bool true
 
 #    Player is able to fly without being affected by gravity.
 #    This requires the "fly" privilege on the server.
@@ -83,81 +2027,27 @@ fast_move (Fast movement) bool false
 #    This requires the "noclip" privilege on the server.
 noclip (Noclip) bool false
 
-#    Smooths camera when looking around. Also called look or mouse smoothing.
-#    Useful for recording videos.
-cinematic (Cinematic mode) bool false
-
-#    Smooths rotation of camera. 0 to disable.
-camera_smoothing (Camera smoothing) float 0.0 0.0 0.99
-
-#    Smooths rotation of camera in cinematic mode. 0 to disable.
-cinematic_camera_smoothing (Camera smoothing in cinematic mode) float 0.7 0.0 0.99
-
-#    Invert vertical mouse movement.
-invert_mouse (Invert mouse) bool false
-
-#    Mouse sensitivity multiplier.
-mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
-
-#    If enabled, "Aux1" key instead of "Sneak" key is used for climbing down and
-#    descending.
-aux1_descends (Aux1 key for climbing/descending) bool false
-
-#    Double-tapping the jump key toggles fly mode.
-doubletap_jump (Double tap jump for fly) bool false
-
-#    If disabled, "Aux1" key is used to fly fast if both fly and fast mode are
-#    enabled.
-always_fly_fast (Always fly and fast) bool true
-
-#    The time in seconds it takes between repeated node placements when holding
-#    the place button.
-repeat_place_time (Place repetition interval) float 0.25 0.001
-
-#    Automatically jump up single-node obstacles.
-autojump (Automatic jumping) bool false
-
-#    Prevent digging and placing from repeating when holding the mouse buttons.
-#    Enable this when you dig or place too often by accident.
-safe_dig_and_place (Safe digging and placing) bool false
-
-#    Enable random user input (only used for testing).
-random_input (Random input) bool false
-
 #    Continuous forward movement, toggled by autoforward key.
 #    Press the autoforward key again or the backwards movement to disable.
 continuous_forward (Continuous forward) bool false
 
-#    The length in pixels it takes for touch screen interaction to start.
-touchscreen_threshold (Touch screen threshold) int 20 0 100
+#    Formspec default background opacity (between 0 and 255).
+formspec_default_bg_opacity (Formspec Default Background Opacity) int 140 0 255
 
-#    (Android) Fixes the position of virtual joystick.
-#    If disabled, virtual joystick will center to first-touch's position.
-fixed_virtual_joystick (Fixed virtual joystick) bool false
+#    Formspec default background color (R,G,B).
+formspec_default_bg_color (Formspec Default Background Color) string (0,0,0)
 
-#    (Android) Use virtual joystick to trigger "Aux1" button.
-#    If enabled, virtual joystick will also tap "Aux1" button when out of main circle.
-virtual_joystick_triggers_aux1 (Virtual joystick triggers Aux1 button) bool false
+#    Whether to show technical names.
+#    Affects mods and texture packs in the Content and Select Mods menus, as well as
+#    setting names in All Settings.
+#    Controlled by the checkbox in the "All settings" menu.
+show_technical_names (Show technical names) bool false
 
-#    Enable joysticks. Requires a restart to take effect
-enable_joysticks (Enable joysticks) bool false
-
-#    The identifier of the joystick to use
-joystick_id (Joystick ID) int 0 0 255
-
-#    The type of joystick
-joystick_type (Joystick type) enum auto auto,generic,xbox,dragonrise_gamecube
-
-#    The time in seconds it takes between repeated events
-#    when holding down a joystick button combination.
-repeat_joystick_button_time (Joystick button repetition interval) float 0.17 0.001
-
-#    The dead zone of the joystick
-joystick_deadzone (Joystick dead zone) int 2048 0 65535
-
-#    The sensitivity of the joystick axes for moving the
-#    in-game view frustum around.
-joystick_frustum_sensitivity (Joystick frustum sensitivity) float 170.0 0.001
+#    Enables the sound system.
+#    If disabled, this completely disables all sounds everywhere and the in-game
+#    sound controls will be non-functional.
+#    Changing this setting requires a restart.
+enable_sound (Sound) bool true
 
 #    Key for moving the player forward.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
@@ -444,1836 +2334,3 @@ keymap_increase_viewing_range_min (View range increase key) key +
 #    Key for decreasing the viewing range.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_decrease_viewing_range_min (View range decrease key) key -
-
-[Graphics]
-
-[*In-Game]
-
-[**Basic]
-
-#    Whether name tag backgrounds should be shown by default.
-#    Mods may still set a background.
-show_nametag_backgrounds (Show name tag backgrounds by default) bool true
-
-#    Enable vertex buffer objects.
-#    This should greatly improve graphics performance.
-enable_vbo (VBO) bool true
-
-#    Whether to fog out the end of the visible area.
-enable_fog (Fog) bool true
-
-#    Leaves style:
-#    -   Fancy:  all faces visible
-#    -   Simple: only outer faces, if defined special_tiles are used
-#    -   Opaque: disable transparency
-leaves_style (Leaves style) enum fancy fancy,simple,opaque
-
-#    Connects glass if supported by node.
-connected_glass (Connect glass) bool false
-
-#    Enable smooth lighting with simple ambient occlusion.
-#    Disable for speed or for different looks.
-smooth_lighting (Smooth lighting) bool true
-
-#    Enables tradeoffs that reduce CPU load or increase rendering performance
-#    at the expense of minor visual glitches that do not impact game playability.
-performance_tradeoffs (Tradeoffs for performance) bool false
-
-#    Clouds are a client side effect.
-enable_clouds (Clouds) bool true
-
-#    Use 3D cloud look instead of flat.
-enable_3d_clouds (3D clouds) bool true
-
-#    Method used to highlight selected object.
-node_highlighting (Node highlighting) enum box box,halo,none
-
-#    Adds particles when digging a node.
-enable_particles (Digging particles) bool true
-
-[**Filtering]
-
-#    Use mipmapping to scale textures. May slightly increase performance,
-#    especially when using a high resolution texture pack.
-#    Gamma correct downscaling is not supported.
-mip_map (Mipmapping) bool false
-
-#    Use anisotropic filtering when viewing at textures from an angle.
-anisotropic_filter (Anisotropic filtering) bool false
-
-#    Use bilinear filtering when scaling textures.
-bilinear_filter (Bilinear filtering) bool false
-
-#    Use trilinear filtering when scaling textures.
-trilinear_filter (Trilinear filtering) bool false
-
-#    Filtered textures can blend RGB values with fully-transparent neighbors,
-#    which PNG optimizers usually discard, often resulting in dark or
-#    light edges to transparent textures. Apply a filter to clean that up
-#    at texture load time. This is automatically enabled if mipmapping is enabled.
-texture_clean_transparent (Clean transparent textures) bool false
-
-#    When using bilinear/trilinear/anisotropic filters, low-resolution textures
-#    can be blurred, so automatically upscale them with nearest-neighbor
-#    interpolation to preserve crisp pixels. This sets the minimum texture size
-#    for the upscaled textures; higher values look sharper, but require more
-#    memory. Powers of 2 are recommended. This setting is ONLY applied if
-#    bilinear/trilinear/anisotropic filtering is enabled.
-#    This is also used as the base node texture size for world-aligned
-#    texture autoscaling.
-texture_min_size (Minimum texture size) int 64 1 32768
-
-#    Use multi-sample antialiasing (MSAA) to smooth out block edges.
-#    This algorithm smooths out the 3D viewport while keeping the image sharp,
-#    but it doesn't affect the insides of textures
-#    (which is especially noticeable with transparent textures).
-#    Visible spaces appear between nodes when shaders are disabled.
-#    If set to 0, MSAA is disabled.
-#    A restart is required after changing this option.
-fsaa (FSAA) enum 0 0,1,2,4,8,16
-
-#    Undersampling is similar to using a lower screen resolution, but it applies
-#    to the game world only, keeping the GUI intact.
-#    It should give a significant performance boost at the cost of less detailed image.
-#    Higher values result in a less detailed image.
-undersampling (Undersampling) int 1 1 8
-
-[**Shaders]
-
-#    Shaders allow advanced visual effects and may increase performance on some video
-#    cards.
-#    This only works with the OpenGL video backend.
-enable_shaders (Shaders) bool true
-
-#    Path to shader directory. If no path is defined, default location will be used.
-shader_path (Shader path) path
-
-[***Tone Mapping]
-
-#    Enables Hable's 'Uncharted 2' filmic tone mapping.
-#    Simulates the tone curve of photographic film and how this approximates the
-#    appearance of high dynamic range images. Mid-range contrast is slightly
-#    enhanced, highlights and shadows are gradually compressed.
-tone_mapping (Filmic tone mapping) bool false
-
-[***Waving Nodes]
-
-#    Set to true to enable waving liquids (like water).
-#    Requires shaders to be enabled.
-enable_waving_water (Waving liquids) bool false
-
-#    The maximum height of the surface of waving liquids.
-#    4.0 = Wave height is two nodes.
-#    0.0 = Wave doesn't move at all.
-#    Default is 1.0 (1/2 node).
-#    Requires waving liquids to be enabled.
-water_wave_height (Waving liquids wave height) float 1.0 0.0 4.0
-
-#    Length of liquid waves.
-#    Requires waving liquids to be enabled.
-water_wave_length (Waving liquids wavelength) float 20.0 0.1
-
-#    How fast liquid waves will move. Higher = faster.
-#    If negative, liquid waves will move backwards.
-#    Requires waving liquids to be enabled.
-water_wave_speed (Waving liquids wave speed) float 5.0
-
-#    Set to true to enable waving leaves.
-#    Requires shaders to be enabled.
-enable_waving_leaves (Waving leaves) bool false
-
-#    Set to true to enable waving plants.
-#    Requires shaders to be enabled.
-enable_waving_plants (Waving plants) bool false
-
-[***Dynamic shadows]
-
-#    Set to true to enable Shadow Mapping.
-#    Requires shaders to be enabled.
-enable_dynamic_shadows (Dynamic shadows) bool false
-
-#    Set the shadow strength gamma.
-#    Adjusts the intensity of in-game dynamic shadows.
-#    Lower value means lighter shadows, higher value means darker shadows.
-shadow_strength_gamma (Shadow strength gamma) float 1.0 0.1 10.0
-
-#    Maximum distance to render shadows.
-shadow_map_max_distance (Shadow map max distance in nodes to render shadows) float 120.0 10.0 1000.0
-
-#    Texture size to render the shadow map on.
-#    This must be a power of two.
-#    Bigger numbers create better shadows but it is also more expensive.
-shadow_map_texture_size (Shadow map texture size) int 1024 128 8192
-
-#    Sets shadow texture quality to 32 bits.
-#    On false, 16 bits texture will be used.
-#    This can cause much more artifacts in the shadow.
-shadow_map_texture_32bit (Shadow map texture in 32 bits) bool true
-
-#    Enable Poisson disk filtering.
-#    On true uses Poisson disk to make "soft shadows". Otherwise uses PCF filtering.
-shadow_poisson_filter (Poisson filtering) bool true
-
-#   Define shadow filtering quality.
-#   This simulates the soft shadows effect by applying a PCF or Poisson disk
-#   but also uses more resources.
-shadow_filters (Shadow filter quality) enum 1 0,1,2
-
-#    Enable colored shadows.
-#    On true translucent nodes cast colored shadows. This is expensive.
-shadow_map_color (Colored shadows) bool false
-
-#    Spread a complete update of shadow map over given amount of frames.
-#    Higher values might make shadows laggy, lower values
-#    will consume more resources.
-#    Minimum value: 1; maximum value: 16
-shadow_update_frames (Map shadows update frames) int 8 1 16
-
-#    Set the soft shadow radius size.
-#    Lower values mean sharper shadows, bigger values mean softer shadows.
-#    Minimum value: 1.0; maximum value: 15.0
-shadow_soft_radius (Soft shadow radius) float 5.0 1.0 15.0
-
-#    Set the tilt of Sun/Moon orbit in degrees.
-#    Value of 0 means no tilt / vertical orbit.
-#    Minimum value: 0.0; maximum value: 60.0
-shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 0.0 60.0
-
-[**Advanced]
-
-#    Arm inertia, gives a more realistic movement of
-#    the arm when the camera moves.
-arm_inertia (Arm inertia) bool true
-
-#    If FPS would go higher than this, limit it by sleeping
-#    to not waste CPU power for no benefit.
-fps_max (Maximum FPS) int 60 1 4294967295
-
-#    Maximum FPS when the window is not focused, or when the game is paused.
-fps_max_unfocused (FPS when unfocused or paused) int 20 1 4294967295
-
-#    Open the pause menu when the window's focus is lost. Does not pause if a formspec is
-#    open.
-pause_on_lost_focus (Pause on lost window focus) bool false
-
-#    View distance in nodes.
-viewing_range (Viewing range) int 190 20 4000
-
-#   Camera 'near clipping plane' distance in nodes, between 0 and 0.25
-#   Only works on GLES platforms. Most users will not need to change this.
-#   Increasing can reduce artifacting on weaker GPUs.
-#   0.1 = Default, 0.25 = Good value for weaker tablets.
-near_plane (Near plane) float 0.1 0 0.25
-
-#    Width component of the initial window size. Ignored in fullscreen mode.
-screen_w (Screen width) int 1024 1 65535
-
-#    Height component of the initial window size. Ignored in fullscreen mode.
-screen_h (Screen height) int 600 1 65535
-
-#    Save window size automatically when modified.
-autosave_screensize (Autosave screen size) bool true
-
-#    Fullscreen mode.
-fullscreen (Full screen) bool false
-
-#    Vertical screen synchronization.
-vsync (VSync) bool false
-
-#    Field of view in degrees.
-fov (Field of view) int 72 45 160
-
-#    Alters the light curve by applying 'gamma correction' to it.
-#    Higher values make middle and lower light levels brighter.
-#    Value '1.0' leaves the light curve unaltered.
-#    This only has significant effect on daylight and artificial
-#    light, it has very little effect on natural night light.
-display_gamma (Light curve gamma) float 1.0 0.33 3.0
-
-#    Gradient of light curve at minimum light level.
-#    Controls the contrast of the lowest light levels.
-lighting_alpha (Light curve low gradient) float 0.0 0.0 3.0
-
-#    Gradient of light curve at maximum light level.
-#    Controls the contrast of the highest light levels.
-lighting_beta (Light curve high gradient) float 1.5 0.0 3.0
-
-#    Strength of light curve boost.
-#    The 3 'boost' parameters define a range of the light
-#    curve that is boosted in brightness.
-lighting_boost (Light curve boost) float 0.2 0.0 0.4
-
-#    Center of light curve boost range.
-#    Where 0.0 is minimum light level, 1.0 is maximum light level.
-lighting_boost_center (Light curve boost center) float 0.5 0.0 1.0
-
-#    Spread of light curve boost range.
-#    Controls the width of the range to be boosted.
-#    Standard deviation of the light curve boost Gaussian.
-lighting_boost_spread (Light curve boost spread) float 0.2 0.0 0.4
-
-#    Path to texture directory. All textures are first searched from here.
-texture_path (Texture path) path
-
-#    The rendering back-end.
-#    A restart is required after changing this.
-#    Note: On Android, stick with OGLES1 if unsure! App may fail to start otherwise.
-#    On other platforms, OpenGL is recommended.
-#    Shaders are supported by OpenGL (desktop only) and OGLES2 (experimental)
-video_driver (Video driver) enum opengl opengl,ogles1,ogles2
-
-#    Radius of cloud area stated in number of 64 node cloud squares.
-#    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.
-cloud_radius (Cloud radius) int 12 1 62
-
-#    Enable view bobbing and amount of view bobbing.
-#    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
-view_bobbing_amount (View bobbing factor) float 1.0 0.0 7.9
-
-#    Multiplier for fall bobbing.
-#    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
-fall_bobbing_amount (Fall bobbing factor) float 0.03 0.0
-
-#    3D support.
-#    Currently supported:
-#    -    none: no 3d output.
-#    -    anaglyph: cyan/magenta color 3d.
-#    -    interlaced: odd/even line based polarisation screen support.
-#    -    topbottom: split screen top/bottom.
-#    -    sidebyside: split screen side by side.
-#    -    crossview: Cross-eyed 3d
-#    -    pageflip: quadbuffer based 3d.
-#    Note that the interlaced mode requires shaders to be enabled.
-3d_mode (3D mode) enum none none,anaglyph,interlaced,topbottom,sidebyside,crossview,pageflip
-
-#    Strength of 3D mode parallax.
-3d_paralax_strength (3D mode parallax strength) float 0.025 -0.087 0.087
-
-#    In-game chat console height, between 0.1 (10%) and 1.0 (100%).
-console_height (Console height) float 0.6 0.1 1.0
-
-#    In-game chat console background color (R,G,B).
-console_color (Console color) string (0,0,0)
-
-#    In-game chat console background alpha (opaqueness, between 0 and 255).
-console_alpha (Console alpha) int 200 0 255
-
-#    Formspec full-screen background opacity (between 0 and 255).
-formspec_fullscreen_bg_opacity (Formspec Full-Screen Background Opacity) int 140 0 255
-
-#    Formspec full-screen background color (R,G,B).
-formspec_fullscreen_bg_color (Formspec Full-Screen Background Color) string (0,0,0)
-
-#    Formspec default background opacity (between 0 and 255).
-formspec_default_bg_opacity (Formspec Default Background Opacity) int 140 0 255
-
-#    Formspec default background color (R,G,B).
-formspec_default_bg_color (Formspec Default Background Color) string (0,0,0)
-
-#    Selection box border color (R,G,B).
-selectionbox_color (Selection box color) string (0,0,0)
-
-#    Width of the selection box lines around nodes.
-selectionbox_width (Selection box width) int 2 1 5
-
-#    Crosshair color (R,G,B).
-#    Also controls the object crosshair color
-crosshair_color (Crosshair color) string (255,255,255)
-
-#    Crosshair alpha (opaqueness, between 0 and 255).
-#    This also applies to the object crosshair.
-crosshair_alpha (Crosshair alpha) int 255 0 255
-
-#    Maximum number of recent chat messages to show
-recent_chat_messages (Recent Chat Messages) int 6 2 20
-
-#    Whether node texture animations should be desynchronized per mapblock.
-desynchronize_mapblock_texture_animation (Desynchronize block animation) bool true
-
-#    Maximum proportion of current window to be used for hotbar.
-#    Useful if there's something to be displayed right or left of hotbar.
-hud_hotbar_max_width (Maximum hotbar width) float 1.0 0.001 1.0
-
-#    Modifies the size of the HUD elements.
-hud_scaling (HUD scale factor) float 1.0 0.5 20
-
-#    Enables caching of facedir rotated meshes.
-enable_mesh_cache (Mesh cache) bool false
-
-#    Delay between mesh updates on the client in ms. Increasing this will slow
-#    down the rate of mesh updates, thus reducing jitter on slower clients.
-mesh_generation_interval (Mapblock mesh generation delay) int 0 0 50
-
-#    Size of the MapBlock cache of the mesh generator. Increasing this will
-#    increase the cache hit %, reducing the data being copied from the main
-#    thread, thus reducing jitter.
-meshgen_block_cache_size (Mapblock mesh generator's MapBlock cache size in MB) int 20 0 1000
-
-#    Enables minimap.
-enable_minimap (Minimap) bool true
-
-#    Shape of the minimap. Enabled = round, disabled = square.
-minimap_shape_round (Round minimap) bool true
-
-#    True = 256
-#    False = 128
-#    Usable to make minimap smoother on slower machines.
-minimap_double_scan_height (Minimap scan height) bool true
-
-#    Make fog and sky colors depend on daytime (dawn/sunset) and view direction.
-directional_colored_fog (Colored fog) bool true
-
-#    The strength (darkness) of node ambient-occlusion shading.
-#    Lower is darker, Higher is lighter. The valid range of values for this
-#    setting is 0.25 to 4.0 inclusive. If the value is out of range it will be
-#    set to the nearest valid value.
-ambient_occlusion_gamma (Ambient occlusion gamma) float 2.2 0.25 4.0
-
-#    Enables animation of inventory items.
-inventory_items_animations (Inventory items animations) bool false
-
-#    Fraction of the visible distance at which fog starts to be rendered
-fog_start (Fog start) float 0.4 0.0 0.99
-
-#    Makes all liquids opaque
-opaque_water (Opaque liquids) bool false
-
-#    Textures on a node may be aligned either to the node or to the world.
-#    The former mode suits better things like machines, furniture, etc., while
-#    the latter makes stairs and microblocks fit surroundings better.
-#    However, as this possibility is new, thus may not be used by older servers,
-#    this option allows enforcing it for certain node types. Note though that
-#    that is considered EXPERIMENTAL and may not work properly.
-world_aligned_mode (World-aligned textures mode) enum enable disable,enable,force_solid,force_nodebox
-
-#    World-aligned textures may be scaled to span several nodes. However,
-#    the server may not send the scale you want, especially if you use
-#    a specially-designed texture pack; with this option, the client tries
-#    to determine the scale automatically basing on the texture size.
-#    See also texture_min_size.
-#    Warning: This option is EXPERIMENTAL!
-autoscale_mode (Autoscaling mode) enum disable disable,enable,force
-
-#    Show entity selection boxes
-#    A restart is required after changing this.
-show_entity_selectionbox (Show entity selection boxes) bool false
-
-#    Distance in nodes at which transparency depth sorting is enabled
-#    Use this to limit the performance impact of transparency depth sorting
-transparency_sorting_distance (Transparency Sorting Distance) int 16 0 128
-
-[*Menus]
-
-#    Use a cloud animation for the main menu background.
-menu_clouds (Clouds in menu) bool true
-
-#    Scale GUI by a user specified value.
-#    Use a nearest-neighbor-anti-alias filter to scale the GUI.
-#    This will smooth over some of the rough edges, and blend
-#    pixels when scaling down, at the cost of blurring some
-#    edge pixels when images are scaled by non-integer sizes.
-gui_scaling (GUI scaling) float 1.0 0.5 20
-
-#    When gui_scaling_filter is true, all GUI images need to be
-#    filtered in software, but some images are generated directly
-#    to hardware (e.g. render-to-texture for nodes in inventory).
-gui_scaling_filter (GUI scaling filter) bool false
-
-#    When gui_scaling_filter_txr2img is true, copy those images
-#    from hardware to software for scaling.  When false, fall back
-#    to the old scaling method, for video drivers that don't
-#    properly support downloading textures back from hardware.
-gui_scaling_filter_txr2img (GUI scaling filter txr2img) bool true
-
-#    Delay showing tooltips, stated in milliseconds.
-tooltip_show_delay (Tooltip delay) int 400 0 18446744073709551615
-
-#    Append item name to tooltip.
-tooltip_append_itemname (Append item name) bool false
-
-font_bold (Font bold by default) bool false
-
-font_italic (Font italic by default) bool false
-
-#    Shadow offset (in pixels) of the default font. If 0, then shadow will not be drawn.
-font_shadow (Font shadow) int 1 0 65535
-
-#    Opaqueness (alpha) of the shadow behind the default font, between 0 and 255.
-font_shadow_alpha (Font shadow alpha) int 127 0 255
-
-#    Font size of the default font where 1 unit = 1 pixel at 96 DPI
-font_size (Font size) int 16 5 72
-
-#    For pixel-style fonts that do not scale well, this ensures that font sizes used
-#    with this font will always be divisible by this value, in pixels. For instance,
-#    a pixel font 16 pixels tall should have this set to 16, so it will only ever be
-#    sized 16, 32, 48, etc., so a mod requesting a size of 25 will get 32.
-font_size_divisible_by (Font size divisible by) int 1 1
-
-#    Path to the default font. Must be a TrueType font.
-#    The fallback font will be used if the font cannot be loaded.
-font_path (Regular font path) filepath fonts/Arimo-Regular.ttf
-
-font_path_bold (Bold font path) filepath fonts/Arimo-Bold.ttf
-font_path_italic (Italic font path) filepath fonts/Arimo-Italic.ttf
-font_path_bold_italic (Bold and italic font path) filepath fonts/Arimo-BoldItalic.ttf
-
-#    Font size of the monospace font where 1 unit = 1 pixel at 96 DPI
-mono_font_size (Monospace font size) int 16 5 72
-
-#    For pixel-style fonts that do not scale well, this ensures that font sizes used
-#    with this font will always be divisible by this value, in pixels. For instance,
-#    a pixel font 16 pixels tall should have this set to 16, so it will only ever be
-#    sized 16, 32, 48, etc., so a mod requesting a size of 25 will get 32.
-mono_font_size_divisible_by (Monospace font size divisible by) int 1 1
-
-#    Path to the monospace font. Must be a TrueType font.
-#    This font is used for e.g. the console and profiler screen.
-mono_font_path (Monospace font path) filepath fonts/Cousine-Regular.ttf
-
-mono_font_path_bold (Bold monospace font path) filepath fonts/Cousine-Bold.ttf
-mono_font_path_italic (Italic monospace font path) filepath fonts/Cousine-Italic.ttf
-mono_font_path_bold_italic (Bold and italic monospace font path) filepath fonts/Cousine-BoldItalic.ttf
-
-#    Path of the fallback font. Must be a TrueType font.
-#    This font will be used for certain languages or if the default font is unavailable.
-fallback_font_path (Fallback font path) filepath fonts/DroidSansFallbackFull.ttf
-
-#    Font size of the recent chat text and chat prompt in point (pt).
-#    Value 0 will use the default font size.
-chat_font_size (Chat font size) int 0 0 72
-
-#    Path to save screenshots at. Can be an absolute or relative path.
-#    The folder will be created if it doesn't already exist.
-screenshot_path (Screenshot folder) path screenshots
-
-#    Format of screenshots.
-screenshot_format (Screenshot format) enum png png,jpg
-
-#    Screenshot quality. Only used for JPEG format.
-#    1 means worst quality; 100 means best quality.
-#    Use 0 for default quality.
-screenshot_quality (Screenshot quality) int 0 0 100
-
-[*Advanced]
-
-#    Adjust dpi configuration to your screen (non X11/Android only) e.g. for 4k screens.
-screen_dpi (DPI) int 72 1
-
-#    Adjust the detected display density, used for scaling UI elements.
-display_density_factor (Display Density Scaling Factor) float 1
-
-#    Windows systems only: Start Minetest with the command line window in the background.
-#    Contains the same information as the file debug.txt (default name).
-enable_console (Enable console window) bool false
-
-[Sound]
-
-#    Enables the sound system.
-#    If disabled, this completely disables all sounds everywhere and the in-game
-#    sound controls will be non-functional.
-#    Changing this setting requires a restart.
-enable_sound (Sound) bool true
-
-#    Volume of all sounds.
-#    Requires the sound system to be enabled.
-sound_volume (Volume) float 0.7 0.0 1.0
-
-#    Whether to mute sounds. You can unmute sounds at any time, unless the
-#    sound system is disabled (enable_sound=false).
-#    In-game, you can toggle the mute state with the mute key or by using the
-#    pause menu.
-mute_sound (Mute sound) bool false
-
-[Client]
-
-#    Clickable weblinks (middle-click or Ctrl+left-click) enabled in chat console output.
-clickable_chat_weblinks (Chat weblinks) bool true
-
-#    Optional override for chat weblink color.
-chat_weblink_color (Weblink color) string
-
-[*Network]
-
-#    Address to connect to.
-#    Leave this blank to start a local server.
-#    Note that the address field in the main menu overrides this setting.
-address (Server address) string
-
-#    Port to connect to (UDP).
-#    Note that the port field in the main menu overrides this setting.
-remote_port (Remote port) int 30000 1 65535
-
-#    Prometheus listener address.
-#    If Minetest is compiled with ENABLE_PROMETHEUS option enabled,
-#    enable metrics listener for Prometheus on that address.
-#    Metrics can be fetched on http://127.0.0.1:30000/metrics
-prometheus_listener_address (Prometheus listener address) string 127.0.0.1:30000
-
-#    Save the map received by the client on disk.
-enable_local_map_saving (Saving map received from server) bool false
-
-#    Enable usage of remote media server (if provided by server).
-#    Remote servers offer a significantly faster way to download media (e.g. textures)
-#    when connecting to the server.
-enable_remote_media_server (Connect to external media server) bool true
-
-#    Enable Lua modding support on client.
-#    This support is experimental and API can change.
-enable_client_modding (Client modding) bool false
-
-#    URL to the server list displayed in the Multiplayer Tab.
-serverlist_url (Serverlist URL) string servers.minetest.net
-
-#    File in client/serverlist/ that contains your favorite servers displayed in the
-#    Multiplayer Tab.
-serverlist_file (Serverlist file) string favoriteservers.json
-
-#    Maximum size of the out chat queue.
-#    0 to disable queueing and -1 to make the queue size unlimited.
-max_out_chat_queue_size (Maximum size of the out chat queue) int 20 -1 32767
-
-#    If enabled, account registration is separate from login in the UI.
-#    If disabled, new accounts will be registered automatically when logging in.
-enable_split_login_register (Enable split login/register) bool true
-
-[*Advanced]
-
-#    Timeout for client to remove unused map data from memory, in seconds.
-client_unload_unused_data_timeout (Mapblock unload timeout) float 600.0 0.0
-
-#    Maximum number of mapblocks for client to be kept in memory.
-#    Set to -1 for unlimited amount.
-client_mapblock_limit (Mapblock limit) int 7500 -1 2147483647
-
-#    Whether to show technical names.
-#    Affects mods and texture packs in the Content and Select Mods menus, as well as
-#    setting names in All Settings.
-#    Controlled by the checkbox in the "All settings" menu.
-show_technical_names (Show technical names) bool false
-
-#    Whether to show the client debug info (has the same effect as hitting F5).
-show_debug (Show debug info) bool false
-
-[Server / Singleplayer]
-
-#    Name of the server, to be displayed when players join and in the serverlist.
-server_name (Server name) string Minetest server
-
-#    Description of server, to be displayed when players join and in the serverlist.
-server_description (Server description) string mine here
-
-#    Domain name of server, to be displayed in the serverlist.
-server_address (Server address) string game.minetest.net
-
-#    Homepage of server, to be displayed in the serverlist.
-server_url (Server URL) string https://minetest.net
-
-#    Automatically report to the serverlist.
-server_announce (Announce server) bool false
-
-#    Announce to this serverlist.
-serverlist_url (Serverlist URL) string servers.minetest.net
-
-#    Remove color codes from incoming chat messages
-#    Use this to stop players from being able to use color in their messages
-strip_color_codes (Strip color codes) bool false
-
-[*Network]
-
-#    Network port to listen (UDP).
-#    This value will be overridden when starting from the main menu.
-port (Server port) int 30000 1 65535
-
-#    The network interface that the server listens on.
-bind_address (Bind address) string
-
-#    Enable to disallow old clients from connecting.
-#    Older clients are compatible in the sense that they will not crash when connecting
-#    to new servers, but they may not support all new features that you are expecting.
-strict_protocol_version_checking (Strict protocol checking) bool false
-
-#    Specifies URL from which client fetches media instead of using UDP.
-#    $filename should be accessible from $remote_media$filename via cURL
-#    (obviously, remote_media should end with a slash).
-#    Files that are not present will be fetched the usual way.
-remote_media (Remote media) string
-
-#    Enable/disable running an IPv6 server.
-#    Ignored if bind_address is set.
-#    Needs enable_ipv6 to be enabled.
-ipv6_server (IPv6 server) bool false
-
-[**Advanced]
-
-#    Maximum number of blocks that are simultaneously sent per client.
-#    The maximum total count is calculated dynamically:
-#    max_total = ceil((#clients + max_users) * per_client / 4)
-max_simultaneous_block_sends_per_client (Maximum simultaneous block sends per client) int 40 1 4294967295
-
-#    To reduce lag, block transfers are slowed down when a player is building something.
-#    This determines how long they are slowed down after placing or removing a node.
-full_block_send_enable_min_time_from_building (Delay in sending blocks after building) float 2.0 0.0
-
-#    Maximum number of packets sent per send step, if you have a slow connection
-#    try reducing it, but don't reduce it to a number below double of targeted
-#    client number.
-max_packets_per_iteration (Max. packets per iteration) int 1024 1 65535
-
-#    Compression level to use when sending mapblocks to the client.
-#    -1 - use default compression level
-#     0 - least compression, fastest
-#     9 - best compression, slowest
-map_compression_level_net (Map Compression Level for Network Transfer) int -1 -1 9
-
-[*Game]
-
-#    Default game when creating a new world.
-#    This will be overridden when creating a world from the main menu.
-default_game (Default game) string minetest
-
-#    Message of the day displayed to players connecting.
-motd (Message of the day) string
-
-#    Maximum number of players that can be connected simultaneously.
-max_users (Maximum users) int 15 0 65535
-
-#    World directory (everything in the world is stored here).
-#    Not needed if starting from the main menu.
-map-dir (Map directory) path
-
-#    Time in seconds for item entity (dropped items) to live.
-#    Setting it to -1 disables the feature.
-item_entity_ttl (Item entity TTL) int 900 -1
-
-#    Specifies the default stack size of nodes, items and tools.
-#    Note that mods or games may explicitly set a stack for certain (or all) items.
-default_stack_max (Default stack size) int 99 1 65535
-
-#    Enable players getting damage and dying.
-enable_damage (Damage) bool false
-
-#    Enable creative mode for all players
-creative_mode (Creative) bool false
-
-#    A chosen map seed for a new map, leave empty for random.
-#    Will be overridden when creating a new world in the main menu.
-fixed_map_seed (Fixed map seed) string
-
-#    New users need to input this password.
-default_password (Default password) string
-
-#    The privileges that new users automatically get.
-#    See /privs in game for a full list on your server and mod configuration.
-default_privs (Default privileges) string interact, shout
-
-#    Privileges that players with basic_privs can grant
-basic_privs (Basic privileges) string interact, shout
-
-#    Whether players are shown to clients without any range limit.
-#    Deprecated, use the setting player_transfer_distance instead.
-unlimited_player_transfer_distance (Unlimited player transfer distance) bool true
-
-#    Defines the maximal player transfer distance in blocks (0 = unlimited).
-player_transfer_distance (Player transfer distance) int 0 0 65535
-
-#    Whether to allow players to damage and kill each other.
-enable_pvp (Player versus player) bool true
-
-#    Enable mod channels support.
-enable_mod_channels (Mod channels) bool false
-
-#    If this is set, players will always (re)spawn at the given position.
-static_spawnpoint (Static spawnpoint) string
-
-#    If enabled, players cannot join without a password or change theirs to an empty password.
-disallow_empty_password (Disallow empty passwords) bool false
-
-#    If enabled, disable cheat prevention in multiplayer.
-disable_anticheat (Disable anticheat) bool false
-
-#    If enabled, actions are recorded for rollback.
-#    This option is only read when server starts.
-enable_rollback_recording (Rollback recording) bool false
-
-#    Format of player chat messages. The following strings are valid placeholders:
-#    @name, @message, @timestamp (optional)
-chat_message_format (Chat message format) string <@name> @message
-
-#    If the execution of a chat command takes longer than this specified time in
-#    seconds, add the time information to the chat command message
-chatcommand_msg_time_threshold (Chat command time message threshold) float 0.1 0.0
-
-#    A message to be displayed to all clients when the server shuts down.
-kick_msg_shutdown (Shutdown message) string Server shutting down.
-
-#    A message to be displayed to all clients when the server crashes.
-kick_msg_crash (Crash message) string This server has experienced an internal error. You will now be disconnected.
-
-#    Whether to ask clients to reconnect after a (Lua) crash.
-#    Set this to true if your server is set up to restart automatically.
-ask_reconnect_on_crash (Ask to reconnect after crash) bool false
-
-#    From how far clients know about objects, stated in mapblocks (16 nodes).
-#
-#    Setting this larger than active_block_range will also cause the server
-#    to maintain active objects up to this distance in the direction the
-#    player is looking. (This can avoid mobs suddenly disappearing from view)
-active_object_send_range_blocks (Active object send range) int 8 1 65535
-
-#    The radius of the volume of blocks around every player that is subject to the
-#    active block stuff, stated in mapblocks (16 nodes).
-#    In active blocks objects are loaded and ABMs run.
-#    This is also the minimum range in which active objects (mobs) are maintained.
-#    This should be configured together with active_object_send_range_blocks.
-active_block_range (Active block range) int 4 1 65535
-
-#    From how far blocks are sent to clients, stated in mapblocks (16 nodes).
-max_block_send_distance (Max block send distance) int 12 1 65535
-
-#    Maximum number of forceloaded mapblocks.
-max_forceloaded_blocks (Maximum forceloaded blocks) int 16 0
-
-#    Interval of sending time of day to clients, stated in seconds.
-time_send_interval (Time send interval) float 5.0 0.001
-
-#    Controls length of day/night cycle.
-#    Examples:
-#    72 = 20min, 360 = 4min, 1 = 24hour, 0 = day/night/whatever stays unchanged.
-time_speed (Time speed) int 72 0
-
-#    Time of day when a new world is started, in millihours (0-23999).
-world_start_time (World start time) int 6125 0 23999
-
-#    Interval of saving important changes in the world, stated in seconds.
-server_map_save_interval (Map save interval) float 5.3 0.001
-
-#    Set the maximum length of a chat message (in characters) sent by clients.
-chat_message_max_size (Chat message max length) int 500 10 65535
-
-#    Amount of messages a player may send per 10 seconds.
-chat_message_limit_per_10sec (Chat message count limit) float 10.0 1.0
-
-#    Kick players who sent more than X messages per 10 seconds.
-chat_message_limit_trigger_kick (Chat message kick threshold) int 50 1 65535
-
-[**Physics]
-
-#    Horizontal and vertical acceleration on ground or when climbing,
-#    in nodes per second per second.
-movement_acceleration_default (Default acceleration) float 3.0 0.0
-
-#    Horizontal acceleration in air when jumping or falling,
-#    in nodes per second per second.
-movement_acceleration_air (Acceleration in air) float 2.0 0.0
-
-#    Horizontal and vertical acceleration in fast mode,
-#    in nodes per second per second.
-movement_acceleration_fast (Fast mode acceleration) float 10.0 0.0
-
-#    Walking and flying speed, in nodes per second.
-movement_speed_walk (Walking speed) float 4.0 0.0
-
-#    Sneaking speed, in nodes per second.
-movement_speed_crouch (Sneaking speed) float 1.35 0.0
-
-#    Walking, flying and climbing speed in fast mode, in nodes per second.
-movement_speed_fast (Fast mode speed) float 20.0 0.0
-
-#    Vertical climbing speed, in nodes per second.
-movement_speed_climb (Climbing speed) float 3.0 0.0
-
-#    Initial vertical speed when jumping, in nodes per second.
-movement_speed_jump (Jumping speed) float 6.5 0.0
-
-#    How much you are slowed down when moving inside a liquid.
-#    Decrease this to increase liquid resistance to movement.
-movement_liquid_fluidity (Liquid fluidity) float 1.0 0.001
-
-#    Maximum liquid resistance. Controls deceleration when entering liquid at
-#    high speed.
-movement_liquid_fluidity_smooth (Liquid fluidity smoothing) float 0.5
-
-#    Controls sinking speed in liquid when idling. Negative values will cause
-#    you to rise instead.
-movement_liquid_sink (Liquid sinking) float 10.0
-
-#    Acceleration of gravity, in nodes per second per second.
-movement_gravity (Gravity) float 9.81
-
-[**Advanced]
-
-#    Handling for deprecated Lua API calls:
-#    -    none: Do not log deprecated calls
-#    -    log: mimic and log backtrace of deprecated call (default).
-#    -    error: abort on usage of deprecated call (suggested for mod developers).
-deprecated_lua_api_handling (Deprecated Lua API handling) enum log none,log,error
-
-#    Number of extra blocks that can be loaded by /clearobjects at once.
-#    This is a trade-off between SQLite transaction overhead and
-#    memory consumption (4096=100MB, as a rule of thumb).
-max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096 0 4294967295
-
-#    How long the server will wait before unloading unused mapblocks, stated in seconds.
-#    Higher value is smoother, but will use more RAM.
-server_unload_unused_data_timeout (Unload unused server data) int 29 0 4294967295
-
-#    Maximum number of statically stored objects in a block.
-max_objects_per_block (Maximum objects per block) int 256 1 65535
-
-#    See https://www.sqlite.org/pragma.html#pragma_synchronous
-sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2
-
-#    Compression level to use when saving mapblocks to disk.
-#    -1 - use default compression level
-#     0 - least compression, fastest
-#     9 - best compression, slowest
-map_compression_level_disk (Map Compression Level for Disk Storage) int -1 -1 9
-
-#    Length of a server tick and the interval at which objects are generally updated over
-#    network, stated in seconds.
-dedicated_server_step (Dedicated server step) float 0.09 0.0
-
-#    Length of time between active block management cycles, stated in seconds
-active_block_mgmt_interval (Active block management interval) float 2.0 0.0
-
-#    Length of time between Active Block Modifier (ABM) execution cycles, stated in seconds
-abm_interval (ABM interval) float 1.0 0.0
-
-#    The time budget allowed for ABMs to execute on each step
-#    (as a fraction of the ABM Interval)
-abm_time_budget (ABM time budget) float 0.2 0.1 0.9
-
-#    Length of time between NodeTimer execution cycles, stated in seconds
-nodetimer_interval (NodeTimer interval) float 0.2 0.0
-
-#    If enabled, invalid world data won't cause the server to shut down.
-#    Only enable this if you know what you are doing.
-ignore_world_load_errors (Ignore world errors) bool false
-
-#    Max liquids processed per step.
-liquid_loop_max (Liquid loop max) int 100000 1 4294967295
-
-#    The time (in seconds) that the liquids queue may grow beyond processing
-#    capacity until an attempt is made to decrease its size by dumping old queue
-#    items.  A value of 0 disables the functionality.
-liquid_queue_purge_time (Liquid queue purge time) int 0 0 65535
-
-#    Liquid update interval in seconds.
-liquid_update (Liquid update tick) float 1.0 0.001
-
-#    At this distance the server will aggressively optimize which blocks are sent to
-#    clients.
-#    Small values potentially improve performance a lot, at the expense of visible
-#    rendering glitches (some blocks will not be rendered under water and in caves,
-#    as well as sometimes on land).
-#    Setting this to a value greater than max_block_send_distance disables this
-#    optimization.
-#    Stated in mapblocks (16 nodes).
-block_send_optimize_distance (Block send optimize distance) int 4 2 32767
-
-#    If enabled the server will perform map block occlusion culling based on
-#    on the eye position of the player. This can reduce the number of blocks
-#    sent to the client 50-80%. The client will not longer receive most invisible
-#    so that the utility of noclip mode is reduced.
-server_side_occlusion_culling (Server side occlusion culling) bool true
-
-#    Restricts the access of certain client-side functions on servers.
-#    Combine the byteflags below to restrict client-side features, or set to 0
-#    for no restrictions:
-#    LOAD_CLIENT_MODS: 1 (disable loading client-provided mods)
-#    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
-#    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
-#    READ_NODEDEFS: 8 (disable get_node_def call client-side)
-#    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to
-#    csm_restriction_noderange)
-#    READ_PLAYERINFO: 32 (disable get_player_names call client-side)
-csm_restriction_flags (Client side modding restrictions) int 62 0 63
-
-#   If the CSM restriction for node range is enabled, get_node calls are limited
-#   to this distance from the player to the node.
-csm_restriction_noderange (Client side node lookup range restriction) int 0 0 4294967295
-
-[*Security]
-
-#    Prevent mods from doing insecure things like running shell commands.
-secure.enable_security (Enable mod security) bool true
-
-#    Comma-separated list of trusted mods that are allowed to access insecure
-#    functions even when mod security is on (via request_insecure_environment()).
-secure.trusted_mods (Trusted mods) string
-
-#    Comma-separated list of mods that are allowed to access HTTP APIs, which
-#    allow them to upload and download data to/from the internet.
-secure.http_mods (HTTP mods) string
-
-[*Advanced]
-
-[**Profiling]
-#    Load the game profiler to collect game profiling data.
-#    Provides a /profiler command to access the compiled profile.
-#    Useful for mod developers and server operators.
-profiler.load (Load the game profiler) bool false
-
-#    The default format in which profiles are being saved,
-#    when calling `/profiler save [format]` without format.
-profiler.default_report_format (Default report format) enum txt txt,csv,lua,json,json_pretty
-
-#    The file path relative to your worldpath in which profiles will be saved to.
-profiler.report_path (Report path) string ""
-
-[***Instrumentation]
-
-#    Instrument the methods of entities on registration.
-instrument.entity (Entity methods) bool true
-
-#    Instrument the action function of Active Block Modifiers on registration.
-instrument.abm (Active Block Modifiers) bool true
-
-#    Instrument the action function of Loading Block Modifiers on registration.
-instrument.lbm (Loading Block Modifiers) bool true
-
-#    Instrument chat commands on registration.
-instrument.chatcommand (Chat commands) bool true
-
-#    Instrument global callback functions on registration.
-#    (anything you pass to a minetest.register_*() function)
-instrument.global_callback (Global callbacks) bool true
-
-[****Advanced]
-#    Instrument builtin.
-#    This is usually only needed by core/builtin contributors
-instrument.builtin (Builtin) bool false
-
-#    Have the profiler instrument itself:
-#     * Instrument an empty function.
-#       This estimates the overhead, that instrumentation is adding (+1 function call).
-#     * Instrument the sampler being used to update the statistics.
-instrument.profiler (Profiler) bool false
-
-[Client and Server]
-
-#    Name of the player.
-#    When running a server, clients connecting with this name are admins.
-#    When starting from the main menu, this is overridden.
-name (Player name) string
-
-#    Set the language. Leave empty to use the system language.
-#    A restart is required after changing this.
-language (Language) enum   ,be,bg,ca,cs,da,de,el,en,eo,es,et,eu,fi,fr,gd,gl,hu,id,it,ja,jbo,kk,ko,lt,lv,ms,nb,nl,nn,pl,pt,pt_BR,ro,ru,sk,sl,sr_Cyrl,sr_Latn,sv,sw,tr,uk,vi,zh_CN,zh_TW
-
-#    Level of logging to be written to debug.txt:
-#    -    <nothing> (no logging)
-#    -    none (messages with no level)
-#    -    error
-#    -    warning
-#    -    action
-#    -    info
-#    -    verbose
-#    -    trace
-debug_log_level (Debug log level) enum action ,none,error,warning,action,info,verbose,trace
-
-#    If the file size of debug.txt exceeds the number of megabytes specified in
-#    this setting when it is opened, the file is moved to debug.txt.1,
-#    deleting an older debug.txt.1 if it exists.
-#    debug.txt is only moved if this setting is positive.
-debug_log_size_max (Debug log file size threshold) int 50 1
-
-#    Minimal level of logging to be written to chat.
-chat_log_level (Chat log level) enum error ,none,error,warning,action,info,verbose,trace
-
-#    Enable IPv6 support (for both client and server).
-#    Required for IPv6 connections to work at all.
-enable_ipv6 (IPv6) bool true
-
-[*Advanced]
-
-#    Maximum time an interactive request (e.g. server list fetch) may take, stated in milliseconds.
-curl_timeout (cURL interactive timeout) int 20000 100 2147483647
-
-#    Limits number of parallel HTTP requests. Affects:
-#    -    Media fetch if server uses remote_media setting.
-#    -    Serverlist download and server announcement.
-#    -    Downloads performed by main menu (e.g. mod manager).
-#    Only has an effect if compiled with cURL.
-curl_parallel_limit (cURL parallel limit) int 8 1 2147483647
-
-#    Maximum time a file download (e.g. a mod download) may take, stated in milliseconds.
-curl_file_download_timeout (cURL file download timeout) int 300000 100 2147483647
-
-#    Replaces the default main menu with a custom one.
-main_menu_script (Main menu script) string
-
-#    Print the engine's profiling data in regular intervals (in seconds).
-#    0 = disable. Useful for developers.
-profiler_print_interval (Engine profiling data print interval) int 0 0
-
-[Mapgen]
-
-#    Name of map generator to be used when creating a new world.
-#    Creating a world in the main menu will override this.
-#    Current mapgens in a highly unstable state:
-#    -    The optional floatlands of v7 (disabled by default).
-mg_name (Mapgen name) enum v7 v7,valleys,carpathian,v5,flat,fractal,singlenode,v6
-
-#    Water surface level of the world.
-water_level (Water level) int 1 -31000 31000
-
-#    From how far blocks are generated for clients, stated in mapblocks (16 nodes).
-max_block_generate_distance (Max block generate distance) int 10 1 32767
-
-#    Limit of map generation, in nodes, in all 6 directions from (0, 0, 0).
-#    Only mapchunks completely within the mapgen limit are generated.
-#    Value is stored per-world.
-mapgen_limit (Map generation limit) int 31007 0 31007
-
-#    Global map generation attributes.
-#    In Mapgen v6 the 'decorations' flag controls all decorations except trees
-#    and jungle grass, in all other mapgens this flag controls all decorations.
-mg_flags (Mapgen flags) flags caves,dungeons,light,decorations,biomes,ores caves,dungeons,light,decorations,biomes,ores,nocaves,nodungeons,nolight,nodecorations,nobiomes,noores
-
-[*Biome API temperature and humidity noise parameters]
-
-#    Temperature variation for biomes.
-mg_biome_np_heat (Heat noise) noise_params_2d 50, 50, (1000, 1000, 1000), 5349, 3, 0.5, 2.0, eased
-
-#    Small-scale temperature variation for blending biomes on borders.
-mg_biome_np_heat_blend (Heat blend noise) noise_params_2d 0, 1.5, (8, 8, 8), 13, 2, 1.0, 2.0, eased
-
-#    Humidity variation for biomes.
-mg_biome_np_humidity (Humidity noise) noise_params_2d 50, 50, (1000, 1000, 1000), 842, 3, 0.5, 2.0, eased
-
-#    Small-scale humidity variation for blending biomes on borders.
-mg_biome_np_humidity_blend (Humidity blend noise) noise_params_2d 0, 1.5, (8, 8, 8), 90003, 2, 1.0, 2.0, eased
-
-[*Mapgen V5]
-
-#    Map generation attributes specific to Mapgen v5.
-mgv5_spflags (Mapgen V5 specific flags) flags caverns caverns,nocaverns
-
-#    Controls width of tunnels, a smaller value creates wider tunnels.
-#    Value >= 10.0 completely disables generation of tunnels and avoids the
-#    intensive noise calculations.
-mgv5_cave_width (Cave width) float 0.09
-
-#    Y of upper limit of large caves.
-mgv5_large_cave_depth (Large cave depth) int -256 -31000 31000
-
-#    Minimum limit of random number of small caves per mapchunk.
-mgv5_small_cave_num_min (Small cave minimum number) int 0 0 256
-
-#    Maximum limit of random number of small caves per mapchunk.
-mgv5_small_cave_num_max (Small cave maximum number) int 0 0 256
-
-#    Minimum limit of random number of large caves per mapchunk.
-mgv5_large_cave_num_min (Large cave minimum number) int 0 0 64
-
-#    Maximum limit of random number of large caves per mapchunk.
-mgv5_large_cave_num_max (Large cave maximum number) int 2 0 64
-
-#    Proportion of large caves that contain liquid.
-mgv5_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
-
-#    Y-level of cavern upper limit.
-mgv5_cavern_limit (Cavern limit) int -256 -31000 31000
-
-#    Y-distance over which caverns expand to full size.
-mgv5_cavern_taper (Cavern taper) int 256 0 32767
-
-#    Defines full size of caverns, smaller values create larger caverns.
-mgv5_cavern_threshold (Cavern threshold) float 0.7
-
-#    Lower Y limit of dungeons.
-mgv5_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
-
-#    Upper Y limit of dungeons.
-mgv5_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
-
-[**Noises]
-
-#    Variation of biome filler depth.
-mgv5_np_filler_depth (Filler depth noise) noise_params_2d 0, 1, (150, 150, 150), 261, 4, 0.7, 2.0, eased
-
-#    Variation of terrain vertical scale.
-#    When noise is < -0.55 terrain is near-flat.
-mgv5_np_factor (Factor noise) noise_params_2d 0, 1, (250, 250, 250), 920381, 3, 0.45, 2.0, eased
-
-#    Y-level of average terrain surface.
-mgv5_np_height (Height noise) noise_params_2d 0, 10, (250, 250, 250), 84174, 4, 0.5, 2.0, eased
-
-#    First of two 3D noises that together define tunnels.
-mgv5_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
-
-#    Second of two 3D noises that together define tunnels.
-mgv5_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
-
-#    3D noise defining giant caverns.
-mgv5_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
-
-#    3D noise defining terrain.
-mgv5_np_ground (Ground noise) noise_params_3d 0, 40, (80, 80, 80), 983240, 4, 0.55, 2.0, eased
-
-#    3D noise that determines number of dungeons per mapchunk.
-mgv5_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
-
-[*Mapgen V6]
-
-#    Map generation attributes specific to Mapgen v6.
-#    The 'snowbiomes' flag enables the new 5 biome system.
-#    When the 'snowbiomes' flag is enabled jungles are automatically enabled and
-#    the 'jungles' flag is ignored.
-mgv6_spflags (Mapgen V6 specific flags) flags jungles,biomeblend,mudflow,snowbiomes,noflat,trees jungles,biomeblend,mudflow,snowbiomes,flat,trees,nojungles,nobiomeblend,nomudflow,nosnowbiomes,noflat,notrees
-
-#    Deserts occur when np_biome exceeds this value.
-#    When the 'snowbiomes' flag is enabled, this is ignored.
-mgv6_freq_desert (Desert noise threshold) float 0.45
-
-#    Sandy beaches occur when np_beach exceeds this value.
-mgv6_freq_beach (Beach noise threshold) float 0.15
-
-#    Lower Y limit of dungeons.
-mgv6_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
-
-#    Upper Y limit of dungeons.
-mgv6_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
-
-[**Noises]
-
-#    Y-level of lower terrain and seabed.
-mgv6_np_terrain_base (Terrain base noise) noise_params_2d -4, 20, (250, 250, 250), 82341, 5, 0.6, 2.0, eased
-
-#    Y-level of higher terrain that creates cliffs.
-mgv6_np_terrain_higher (Terrain higher noise) noise_params_2d 20, 16, (500, 500, 500), 85039, 5, 0.6, 2.0, eased
-
-#    Varies steepness of cliffs.
-mgv6_np_steepness (Steepness noise) noise_params_2d 0.85, 0.5, (125, 125, 125), -932, 5, 0.7, 2.0, eased
-
-#    Defines distribution of higher terrain.
-mgv6_np_height_select (Height select noise) noise_params_2d 0.5, 1, (250, 250, 250), 4213, 5, 0.69, 2.0, eased
-
-#    Varies depth of biome surface nodes.
-mgv6_np_mud (Mud noise) noise_params_2d 4, 2, (200, 200, 200), 91013, 3, 0.55, 2.0, eased
-
-#    Defines areas with sandy beaches.
-mgv6_np_beach (Beach noise) noise_params_2d 0, 1, (250, 250, 250), 59420, 3, 0.50, 2.0, eased
-
-#    Temperature variation for biomes.
-mgv6_np_biome (Biome noise) noise_params_2d 0, 1, (500, 500, 500), 9130, 3, 0.50, 2.0, eased
-
-#    Variation of number of caves.
-mgv6_np_cave (Cave noise) noise_params_2d 6, 6, (250, 250, 250), 34329, 3, 0.50, 2.0, eased
-
-#    Humidity variation for biomes.
-mgv6_np_humidity (Humidity noise) noise_params_2d 0.5, 0.5, (500, 500, 500), 72384, 3, 0.50, 2.0, eased
-
-#    Defines tree areas and tree density.
-mgv6_np_trees (Trees noise) noise_params_2d 0, 1, (125, 125, 125), 2, 4, 0.66, 2.0, eased
-
-#    Defines areas where trees have apples.
-mgv6_np_apple_trees (Apple trees noise) noise_params_2d 0, 1, (100, 100, 100), 342902, 3, 0.45, 2.0, eased
-
-[*Mapgen V7]
-
-#    Map generation attributes specific to Mapgen v7.
-#    'ridges': Rivers.
-#    'floatlands': Floating land masses in the atmosphere.
-#    'caverns': Giant caves deep underground.
-mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,caverns mountains,ridges,floatlands,caverns,nomountains,noridges,nofloatlands,nocaverns
-
-#    Y of mountain density gradient zero level. Used to shift mountains vertically.
-mgv7_mount_zero_level (Mountain zero level) int 0 -31000 31000
-
-#    Lower Y limit of floatlands.
-mgv7_floatland_ymin (Floatland minimum Y) int 1024 -31000 31000
-
-#    Upper Y limit of floatlands.
-mgv7_floatland_ymax (Floatland maximum Y) int 4096 -31000 31000
-
-#    Y-distance over which floatlands taper from full density to nothing.
-#    Tapering starts at this distance from the Y limit.
-#    For a solid floatland layer, this controls the height of hills/mountains.
-#    Must be less than or equal to half the distance between the Y limits.
-mgv7_floatland_taper (Floatland tapering distance) int 256 0 32767
-
-#    Exponent of the floatland tapering. Alters the tapering behaviour.
-#    Value = 1.0 creates a uniform, linear tapering.
-#    Values > 1.0 create a smooth tapering suitable for the default separated
-#    floatlands.
-#    Values < 1.0 (for example 0.25) create a more defined surface level with
-#    flatter lowlands, suitable for a solid floatland layer.
-mgv7_float_taper_exp (Floatland taper exponent) float 2.0
-
-#    Adjusts the density of the floatland layer.
-#    Increase value to increase density. Can be positive or negative.
-#    Value = 0.0: 50% of volume is floatland.
-#    Value = 2.0 (can be higher depending on 'mgv7_np_floatland', always test
-#    to be sure) creates a solid floatland layer.
-mgv7_floatland_density (Floatland density) float -0.6
-
-#    Surface level of optional water placed on a solid floatland layer.
-#    Water is disabled by default and will only be placed if this value is set
-#    to above 'mgv7_floatland_ymax' - 'mgv7_floatland_taper' (the start of the
-#    upper tapering).
-#    ***WARNING, POTENTIAL DANGER TO WORLDS AND SERVER PERFORMANCE***:
-#    When enabling water placement the floatlands must be configured and tested
-#    to be a solid layer by setting 'mgv7_floatland_density' to 2.0 (or other
-#    required value depending on 'mgv7_np_floatland'), to avoid
-#    server-intensive extreme water flow and to avoid vast flooding of the
-#    world surface below.
-mgv7_floatland_ywater (Floatland water level) int -31000 -31000 31000
-
-#    Controls width of tunnels, a smaller value creates wider tunnels.
-#    Value >= 10.0 completely disables generation of tunnels and avoids the
-#    intensive noise calculations.
-mgv7_cave_width (Cave width) float 0.09
-
-#    Y of upper limit of large caves.
-mgv7_large_cave_depth (Large cave depth) int -33 -31000 31000
-
-#    Minimum limit of random number of small caves per mapchunk.
-mgv7_small_cave_num_min (Small cave minimum number) int 0 0 256
-
-#    Maximum limit of random number of small caves per mapchunk.
-mgv7_small_cave_num_max (Small cave maximum number) int 0 0 256
-
-#    Minimum limit of random number of large caves per mapchunk.
-mgv7_large_cave_num_min (Large cave minimum number) int 0 0 64
-
-#    Maximum limit of random number of large caves per mapchunk.
-mgv7_large_cave_num_max (Large cave maximum number) int 2 0 64
-
-#    Proportion of large caves that contain liquid.
-mgv7_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
-
-#    Y-level of cavern upper limit.
-mgv7_cavern_limit (Cavern limit) int -256 -31000 31000
-
-#    Y-distance over which caverns expand to full size.
-mgv7_cavern_taper (Cavern taper) int 256 0 32767
-
-#    Defines full size of caverns, smaller values create larger caverns.
-mgv7_cavern_threshold (Cavern threshold) float 0.7
-
-#    Lower Y limit of dungeons.
-mgv7_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
-
-#    Upper Y limit of dungeons.
-mgv7_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
-
-[**Noises]
-
-#    Y-level of higher terrain that creates cliffs.
-mgv7_np_terrain_base (Terrain base noise) noise_params_2d 4, 70, (600, 600, 600), 82341, 5, 0.6, 2.0, eased
-
-#    Y-level of lower terrain and seabed.
-mgv7_np_terrain_alt (Terrain alternative noise) noise_params_2d 4, 25, (600, 600, 600), 5934, 5, 0.6, 2.0, eased
-
-#    Varies roughness of terrain.
-#    Defines the 'persistence' value for terrain_base and terrain_alt noises.
-mgv7_np_terrain_persist (Terrain persistence noise) noise_params_2d 0.6, 0.1, (2000, 2000, 2000), 539, 3, 0.6, 2.0, eased
-
-#    Defines distribution of higher terrain and steepness of cliffs.
-mgv7_np_height_select (Height select noise) noise_params_2d -8, 16, (500, 500, 500), 4213, 6, 0.7, 2.0, eased
-
-#    Variation of biome filler depth.
-mgv7_np_filler_depth (Filler depth noise) noise_params_2d 0, 1.2, (150, 150, 150), 261, 3, 0.7, 2.0, eased
-
-#    Variation of maximum mountain height (in nodes).
-mgv7_np_mount_height (Mountain height noise) noise_params_2d 256, 112, (1000, 1000, 1000), 72449, 3, 0.6, 2.0, eased
-
-#    Defines large-scale river channel structure.
-mgv7_np_ridge_uwater (Ridge underwater noise) noise_params_2d 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0, eased
-
-#    3D noise defining mountain structure and height.
-#    Also defines structure of floatland mountain terrain.
-mgv7_np_mountain (Mountain noise) noise_params_3d -0.6, 1, (250, 350, 250), 5333, 5, 0.63, 2.0
-
-#    3D noise defining structure of river canyon walls.
-mgv7_np_ridge (Ridge noise) noise_params_3d 0, 1, (100, 100, 100), 6467, 4, 0.75, 2.0
-
-#    3D noise defining structure of floatlands.
-#    If altered from the default, the noise 'scale' (0.7 by default) may need
-#    to be adjusted, as floatland tapering functions best when this noise has
-#    a value range of approximately -2.0 to 2.0.
-mgv7_np_floatland (Floatland noise) noise_params_3d 0, 0.7, (384, 96, 384), 1009, 4, 0.75, 1.618
-
-#    3D noise defining giant caverns.
-mgv7_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
-
-#    First of two 3D noises that together define tunnels.
-mgv7_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
-
-#    Second of two 3D noises that together define tunnels.
-mgv7_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
-
-#    3D noise that determines number of dungeons per mapchunk.
-mgv7_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
-
-[*Mapgen Carpathian]
-
-#    Map generation attributes specific to Mapgen Carpathian.
-mgcarpathian_spflags (Mapgen Carpathian specific flags) flags caverns,norivers caverns,rivers,nocaverns,norivers
-
-#    Defines the base ground level.
-mgcarpathian_base_level (Base ground level) float 12.0
-
-#    Defines the width of the river channel.
-mgcarpathian_river_width (River channel width) float 0.05
-
-#    Defines the depth of the river channel.
-mgcarpathian_river_depth (River channel depth) float 24.0
-
-#    Defines the width of the river valley.
-mgcarpathian_valley_width (River valley width) float 0.25
-
-#    Controls width of tunnels, a smaller value creates wider tunnels.
-#    Value >= 10.0 completely disables generation of tunnels and avoids the
-#    intensive noise calculations.
-mgcarpathian_cave_width (Cave width) float 0.09
-
-#    Y of upper limit of large caves.
-mgcarpathian_large_cave_depth (Large cave depth) int -33 -31000 31000
-
-#    Minimum limit of random number of small caves per mapchunk.
-mgcarpathian_small_cave_num_min (Small cave minimum number) int 0 0 256
-
-#    Maximum limit of random number of small caves per mapchunk.
-mgcarpathian_small_cave_num_max (Small cave maximum number) int 0 0 256
-
-#    Minimum limit of random number of large caves per mapchunk.
-mgcarpathian_large_cave_num_min (Large cave minimum number) int 0 0 64
-
-#    Maximum limit of random number of large caves per mapchunk.
-mgcarpathian_large_cave_num_max (Large cave maximum number) int 2 0 64
-
-#    Proportion of large caves that contain liquid.
-mgcarpathian_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
-
-#    Y-level of cavern upper limit.
-mgcarpathian_cavern_limit (Cavern limit) int -256 -31000 31000
-
-#    Y-distance over which caverns expand to full size.
-mgcarpathian_cavern_taper (Cavern taper) int 256 0 32767
-
-#    Defines full size of caverns, smaller values create larger caverns.
-mgcarpathian_cavern_threshold (Cavern threshold) float 0.7
-
-#    Lower Y limit of dungeons.
-mgcarpathian_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
-
-#    Upper Y limit of dungeons.
-mgcarpathian_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
-
-[**Noises]
-
-#    Variation of biome filler depth.
-mgcarpathian_np_filler_depth (Filler depth noise) noise_params_2d 0, 1, (128, 128, 128), 261, 3, 0.7, 2.0, eased
-
-#    First of 4 2D noises that together define hill/mountain range height.
-mgcarpathian_np_height1 (Hilliness1 noise) noise_params_2d 0, 5, (251, 251, 251), 9613, 5, 0.5, 2.0, eased
-
-#    Second of 4 2D noises that together define hill/mountain range height.
-mgcarpathian_np_height2 (Hilliness2 noise) noise_params_2d 0, 5, (383, 383, 383), 1949, 5, 0.5, 2.0, eased
-
-#    Third of 4 2D noises that together define hill/mountain range height.
-mgcarpathian_np_height3 (Hilliness3 noise) noise_params_2d 0, 5, (509, 509, 509), 3211, 5, 0.5, 2.0, eased
-
-#    Fourth of 4 2D noises that together define hill/mountain range height.
-mgcarpathian_np_height4 (Hilliness4 noise) noise_params_2d 0, 5, (631, 631, 631), 1583, 5, 0.5, 2.0, eased
-
-#    2D noise that controls the size/occurrence of rolling hills.
-mgcarpathian_np_hills_terrain (Rolling hills spread noise) noise_params_2d 1, 1, (1301, 1301, 1301), 1692, 3, 0.5, 2.0, eased
-
-#    2D noise that controls the size/occurrence of ridged mountain ranges.
-mgcarpathian_np_ridge_terrain (Ridge mountain spread noise) noise_params_2d 1, 1, (1889, 1889, 1889), 3568, 3, 0.5, 2.0, eased
-
-#    2D noise that controls the size/occurrence of step mountain ranges.
-mgcarpathian_np_step_terrain (Step mountain spread noise) noise_params_2d 1, 1, (1889, 1889, 1889), 4157, 3, 0.5, 2.0, eased
-
-#    2D noise that controls the shape/size of rolling hills.
-mgcarpathian_np_hills (Rolling hill size noise) noise_params_2d 0, 3, (257, 257, 257), 6604, 6, 0.5, 2.0, eased
-
-#    2D noise that controls the shape/size of ridged mountains.
-mgcarpathian_np_ridge_mnt (Ridged mountain size noise) noise_params_2d 0, 12, (743, 743, 743), 5520, 6, 0.7, 2.0, eased
-
-#    2D noise that controls the shape/size of step mountains.
-mgcarpathian_np_step_mnt (Step mountain size noise) noise_params_2d 0, 8, (509, 509, 509), 2590, 6, 0.6, 2.0, eased
-
-#    2D noise that locates the river valleys and channels.
-mgcarpathian_np_rivers (River noise) noise_params_2d 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0, eased
-
-#    3D noise for mountain overhangs, cliffs, etc. Usually small variations.
-mgcarpathian_np_mnt_var (Mountain variation noise) noise_params_3d 0, 1, (499, 499, 499), 2490, 5, 0.55, 2.0
-
-#    First of two 3D noises that together define tunnels.
-mgcarpathian_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
-
-#    Second of two 3D noises that together define tunnels.
-mgcarpathian_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
-
-#    3D noise defining giant caverns.
-mgcarpathian_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
-
-#    3D noise that determines number of dungeons per mapchunk.
-mgcarpathian_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
-
-[*Mapgen Flat]
-
-#    Map generation attributes specific to Mapgen Flat.
-#    Occasional lakes and hills can be added to the flat world.
-mgflat_spflags (Mapgen Flat specific flags) flags nolakes,nohills,nocaverns lakes,hills,caverns,nolakes,nohills,nocaverns
-
-#    Y of flat ground.
-mgflat_ground_level (Ground level) int 8 -31000 31000
-
-#    Y of upper limit of large caves.
-mgflat_large_cave_depth (Large cave depth) int -33 -31000 31000
-
-#    Minimum limit of random number of small caves per mapchunk.
-mgflat_small_cave_num_min (Small cave minimum number) int 0 0 256
-
-#    Maximum limit of random number of small caves per mapchunk.
-mgflat_small_cave_num_max (Small cave maximum number) int 0 0 256
-
-#    Minimum limit of random number of large caves per mapchunk.
-mgflat_large_cave_num_min (Large cave minimum number) int 0 0 64
-
-#    Maximum limit of random number of large caves per mapchunk.
-mgflat_large_cave_num_max (Large cave maximum number) int 2 0 64
-
-#    Proportion of large caves that contain liquid.
-mgflat_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
-
-#    Controls width of tunnels, a smaller value creates wider tunnels.
-#    Value >= 10.0 completely disables generation of tunnels and avoids the
-#    intensive noise calculations.
-mgflat_cave_width (Cave width) float 0.09
-
-#    Terrain noise threshold for lakes.
-#    Controls proportion of world area covered by lakes.
-#    Adjust towards 0.0 for a larger proportion.
-mgflat_lake_threshold (Lake threshold) float -0.45
-
-#    Controls steepness/depth of lake depressions.
-mgflat_lake_steepness (Lake steepness) float 48.0
-
-#    Terrain noise threshold for hills.
-#    Controls proportion of world area covered by hills.
-#    Adjust towards 0.0 for a larger proportion.
-mgflat_hill_threshold (Hill threshold) float 0.45
-
-#    Controls steepness/height of hills.
-mgflat_hill_steepness (Hill steepness) float 64.0
-
-#    Y-level of cavern upper limit.
-mgflat_cavern_limit (Cavern limit) int -256 -31000 31000
-
-#    Y-distance over which caverns expand to full size.
-mgflat_cavern_taper (Cavern taper) int 256 0 32767
-
-#    Defines full size of caverns, smaller values create larger caverns.
-mgflat_cavern_threshold (Cavern threshold) float 0.7
-
-#    Lower Y limit of dungeons.
-mgflat_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
-
-#    Upper Y limit of dungeons.
-mgflat_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
-
-[**Noises]
-
-#    Defines location and terrain of optional hills and lakes.
-mgflat_np_terrain (Terrain noise) noise_params_2d 0, 1, (600, 600, 600), 7244, 5, 0.6, 2.0, eased
-
-#    Variation of biome filler depth.
-mgflat_np_filler_depth (Filler depth noise) noise_params_2d 0, 1.2, (150, 150, 150), 261, 3, 0.7, 2.0, eased
-
-#    First of two 3D noises that together define tunnels.
-mgflat_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
-
-#    Second of two 3D noises that together define tunnels.
-mgflat_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
-
-#    3D noise defining giant caverns.
-mgflat_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
-
-#    3D noise that determines number of dungeons per mapchunk.
-mgflat_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
-
-[*Mapgen Fractal]
-
-#    Map generation attributes specific to Mapgen Fractal.
-#    'terrain' enables the generation of non-fractal terrain:
-#    ocean, islands and underground.
-mgfractal_spflags (Mapgen Fractal specific flags) flags terrain terrain,noterrain
-
-#    Controls width of tunnels, a smaller value creates wider tunnels.
-#    Value >= 10.0 completely disables generation of tunnels and avoids the
-#    intensive noise calculations.
-mgfractal_cave_width (Cave width) float 0.09
-
-#    Y of upper limit of large caves.
-mgfractal_large_cave_depth (Large cave depth) int -33 -31000 31000
-
-#    Minimum limit of random number of small caves per mapchunk.
-mgfractal_small_cave_num_min (Small cave minimum number) int 0 0 256
-
-#    Maximum limit of random number of small caves per mapchunk.
-mgfractal_small_cave_num_max (Small cave maximum number) int 0 0 256
-
-#    Minimum limit of random number of large caves per mapchunk.
-mgfractal_large_cave_num_min (Large cave minimum number) int 0 0 64
-
-#    Maximum limit of random number of large caves per mapchunk.
-mgfractal_large_cave_num_max (Large cave maximum number) int 2 0 64
-
-#    Proportion of large caves that contain liquid.
-mgfractal_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
-
-#    Lower Y limit of dungeons.
-mgfractal_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
-
-#    Upper Y limit of dungeons.
-mgfractal_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
-
-#    Selects one of 18 fractal types.
-#    1 = 4D "Roundy" Mandelbrot set.
-#    2 = 4D "Roundy" Julia set.
-#    3 = 4D "Squarry" Mandelbrot set.
-#    4 = 4D "Squarry" Julia set.
-#    5 = 4D "Mandy Cousin" Mandelbrot set.
-#    6 = 4D "Mandy Cousin" Julia set.
-#    7 = 4D "Variation" Mandelbrot set.
-#    8 = 4D "Variation" Julia set.
-#    9 = 3D "Mandelbrot/Mandelbar" Mandelbrot set.
-#    10 = 3D "Mandelbrot/Mandelbar" Julia set.
-#    11 = 3D "Christmas Tree" Mandelbrot set.
-#    12 = 3D "Christmas Tree" Julia set.
-#    13 = 3D "Mandelbulb" Mandelbrot set.
-#    14 = 3D "Mandelbulb" Julia set.
-#    15 = 3D "Cosine Mandelbulb" Mandelbrot set.
-#    16 = 3D "Cosine Mandelbulb" Julia set.
-#    17 = 4D "Mandelbulb" Mandelbrot set.
-#    18 = 4D "Mandelbulb" Julia set.
-mgfractal_fractal (Fractal type) int 1 1 18
-
-#    Iterations of the recursive function.
-#    Increasing this increases the amount of fine detail, but also
-#    increases processing load.
-#    At iterations = 20 this mapgen has a similar load to mapgen V7.
-mgfractal_iterations (Iterations) int 11 1 65535
-
-#    (X,Y,Z) scale of fractal in nodes.
-#    Actual fractal size will be 2 to 3 times larger.
-#    These numbers can be made very large, the fractal does
-#    not have to fit inside the world.
-#    Increase these to 'zoom' into the detail of the fractal.
-#    Default is for a vertically-squashed shape suitable for
-#    an island, set all 3 numbers equal for the raw shape.
-mgfractal_scale (Scale) v3f (4096.0, 1024.0, 4096.0)
-
-#    (X,Y,Z) offset of fractal from world center in units of 'scale'.
-#    Can be used to move a desired point to (0, 0) to create a
-#    suitable spawn point, or to allow 'zooming in' on a desired
-#    point by increasing 'scale'.
-#    The default is tuned for a suitable spawn point for Mandelbrot
-#    sets with default parameters, it may need altering in other
-#    situations.
-#    Range roughly -2 to 2. Multiply by 'scale' for offset in nodes.
-mgfractal_offset (Offset) v3f (1.79, 0.0, 0.0)
-
-#    W coordinate of the generated 3D slice of a 4D fractal.
-#    Determines which 3D slice of the 4D shape is generated.
-#    Alters the shape of the fractal.
-#    Has no effect on 3D fractals.
-#    Range roughly -2 to 2.
-mgfractal_slice_w (Slice w) float 0.0
-
-#    Julia set only.
-#    X component of hypercomplex constant.
-#    Alters the shape of the fractal.
-#    Range roughly -2 to 2.
-mgfractal_julia_x (Julia x) float 0.33
-
-#    Julia set only.
-#    Y component of hypercomplex constant.
-#    Alters the shape of the fractal.
-#    Range roughly -2 to 2.
-mgfractal_julia_y (Julia y) float 0.33
-
-#    Julia set only.
-#    Z component of hypercomplex constant.
-#    Alters the shape of the fractal.
-#    Range roughly -2 to 2.
-mgfractal_julia_z (Julia z) float 0.33
-
-#    Julia set only.
-#    W component of hypercomplex constant.
-#    Alters the shape of the fractal.
-#    Has no effect on 3D fractals.
-#    Range roughly -2 to 2.
-mgfractal_julia_w (Julia w) float 0.33
-
-[**Noises]
-
-#    Y-level of seabed.
-mgfractal_np_seabed (Seabed noise) noise_params_2d -14, 9, (600, 600, 600), 41900, 5, 0.6, 2.0, eased
-
-#    Variation of biome filler depth.
-mgfractal_np_filler_depth (Filler depth noise) noise_params_2d 0, 1.2, (150, 150, 150), 261, 3, 0.7, 2.0, eased
-
-#    First of two 3D noises that together define tunnels.
-mgfractal_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
-
-#    Second of two 3D noises that together define tunnels.
-mgfractal_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
-
-#    3D noise that determines number of dungeons per mapchunk.
-mgfractal_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
-
-[*Mapgen Valleys]
-
-#    Map generation attributes specific to Mapgen Valleys.
-#    'altitude_chill': Reduces heat with altitude.
-#    'humid_rivers': Increases humidity around rivers.
-#    'vary_river_depth': If enabled, low humidity and high heat causes rivers
-#    to become shallower and occasionally dry.
-#    'altitude_dry': Reduces humidity with altitude.
-mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_rivers,vary_river_depth,altitude_dry altitude_chill,humid_rivers,vary_river_depth,altitude_dry,noaltitude_chill,nohumid_rivers,novary_river_depth,noaltitude_dry
-
-#    The vertical distance over which heat drops by 20 if 'altitude_chill' is
-#    enabled. Also the vertical distance over which humidity drops by 10 if
-#    'altitude_dry' is enabled.
-mgvalleys_altitude_chill (Altitude chill) int 90 0 65535
-
-#    Depth below which you'll find large caves.
-mgvalleys_large_cave_depth (Large cave depth) int -33 -31000 31000
-
-#    Minimum limit of random number of small caves per mapchunk.
-mgvalleys_small_cave_num_min (Small cave minimum number) int 0 0 256
-
-#    Maximum limit of random number of small caves per mapchunk.
-mgvalleys_small_cave_num_max (Small cave maximum number) int 0 0 256
-
-#    Minimum limit of random number of large caves per mapchunk.
-mgvalleys_large_cave_num_min (Large cave minimum number) int 0 0 64
-
-#    Maximum limit of random number of large caves per mapchunk.
-mgvalleys_large_cave_num_max (Large cave maximum number) int 2 0 64
-
-#    Proportion of large caves that contain liquid.
-mgvalleys_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
-
-#    Depth below which you'll find giant caverns.
-mgvalleys_cavern_limit (Cavern upper limit) int -256 -31000 31000
-
-#    Y-distance over which caverns expand to full size.
-mgvalleys_cavern_taper (Cavern taper) int 192 0 32767
-
-#    Defines full size of caverns, smaller values create larger caverns.
-mgvalleys_cavern_threshold (Cavern threshold) float 0.6
-
-#    How deep to make rivers.
-mgvalleys_river_depth (River depth) int 4 0 65535
-
-#    How wide to make rivers.
-mgvalleys_river_size (River size) int 5 0 65535
-
-#    Controls width of tunnels, a smaller value creates wider tunnels.
-#    Value >= 10.0 completely disables generation of tunnels and avoids the
-#    intensive noise calculations.
-mgvalleys_cave_width (Cave width) float 0.09
-
-#    Lower Y limit of dungeons.
-mgvalleys_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
-
-#    Upper Y limit of dungeons.
-mgvalleys_dungeon_ymax (Dungeon maximum Y) int 63 -31000 31000
-
-[**Noises]
-
-#    First of two 3D noises that together define tunnels.
-mgvalleys_np_cave1 (Cave noise #1) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
-
-#    Second of two 3D noises that together define tunnels.
-mgvalleys_np_cave2 (Cave noise #2) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
-
-#    The depth of dirt or other biome filler node.
-mgvalleys_np_filler_depth (Filler depth) noise_params_2d 0, 1.2, (256, 256, 256), 1605, 3, 0.5, 2.0, eased
-
-#    3D noise defining giant caverns.
-mgvalleys_np_cavern (Cavern noise) noise_params_3d 0, 1, (768, 256, 768), 59033, 6, 0.63, 2.0
-
-#    Defines large-scale river channel structure.
-mgvalleys_np_rivers (River noise) noise_params_2d 0, 1, (256, 256, 256), -6050, 5, 0.6, 2.0, eased
-
-#    Base terrain height.
-mgvalleys_np_terrain_height (Terrain height) noise_params_2d -10, 50, (1024, 1024, 1024), 5202, 6, 0.4, 2.0, eased
-
-#    Raises terrain to make valleys around the rivers.
-mgvalleys_np_valley_depth (Valley depth) noise_params_2d 5, 4, (512, 512, 512), -1914, 1, 1.0, 2.0, eased
-
-#    Slope and fill work together to modify the heights.
-mgvalleys_np_inter_valley_fill (Valley fill) noise_params_3d 0, 1, (256, 512, 256), 1993, 6, 0.8, 2.0
-
-#    Amplifies the valleys.
-mgvalleys_np_valley_profile (Valley profile) noise_params_2d 0.6, 0.5, (512, 512, 512), 777, 1, 1.0, 2.0, eased
-
-#    Slope and fill work together to modify the heights.
-mgvalleys_np_inter_valley_slope (Valley slope) noise_params_2d 0.5, 0.5, (128, 128, 128), 746, 1, 1.0, 2.0, eased
-
-#    3D noise that determines number of dungeons per mapchunk.
-mgvalleys_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
-
-[*Advanced]
-
-#    Size of mapchunks generated by mapgen, stated in mapblocks (16 nodes).
-#    WARNING!: There is no benefit, and there are several dangers, in
-#    increasing this value above 5.
-#    Reducing this value increases cave and dungeon density.
-#    Altering this value is for special usage, leaving it unchanged is
-#    recommended.
-chunksize (Chunk size) int 5 1 5
-
-#    Dump the mapgen debug information.
-enable_mapgen_debug_info (Mapgen debug) bool false
-
-#    Maximum number of blocks that can be queued for loading.
-emergequeue_limit_total (Absolute limit of queued blocks to emerge) int 1024 1 1000000
-
-#    Maximum number of blocks to be queued that are to be loaded from file.
-#    This limit is enforced per player.
-emergequeue_limit_diskonly (Per-player limit of queued blocks load from disk) int 128 1 1000000
-
-#    Maximum number of blocks to be queued that are to be generated.
-#    This limit is enforced per player.
-emergequeue_limit_generate (Per-player limit of queued blocks to generate) int 128 1 1000000
-
-#    Number of emerge threads to use.
-#    Value 0:
-#    -    Automatic selection. The number of emerge threads will be
-#    -    'number of processors - 2', with a lower limit of 1.
-#    Any other value:
-#    -    Specifies the number of emerge threads, with a lower limit of 1.
-#    WARNING: Increasing the number of emerge threads increases engine mapgen
-#    speed, but this may harm game performance by interfering with other
-#    processes, especially in singleplayer and/or when running Lua code in
-#    'on_generated'. For many users the optimum setting may be '1'.
-num_emerge_threads (Number of emerge threads) int 1 0 32767
-
-[Online Content Repository]
-
-#    The URL for the content repository
-contentdb_url (ContentDB URL) string https://content.minetest.net
-
-#    Comma-separated list of flags to hide in the content repository.
-#    "nonfree" can be used to hide packages which do not qualify as 'free software',
-#    as defined by the Free Software Foundation.
-#    You can also specify content ratings.
-#    These flags are independent from Minetest versions,
-#    so see a full list at https://content.minetest.net/help/content_flags/
-contentdb_flag_blacklist (ContentDB Flag Blacklist) string nonfree, desktop_default
-
-#    Maximum number of concurrent downloads. Downloads exceeding this limit will be queued.
-#    This should be lower than curl_parallel_limit.
-contentdb_max_concurrent_downloads (ContentDB Max Concurrent Downloads) int 3 1

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -110,7 +110,7 @@ safe_dig_and_place (Safe digging and placing) bool false
 invert_mouse (Invert mouse) bool false
 
 #    Mouse sensitivity multiplier.
-mouse_sensitivity (Mouse sensitivity) float 0.2
+mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
 
 [*Touchscreen]
 
@@ -133,10 +133,10 @@ virtual_joystick_triggers_aux1 (Virtual joystick triggers Aux1 button) bool fals
 [**Screen]
 
 #    Width component of the initial window size. Ignored in fullscreen mode.
-screen_w (Screen width) int 1024 1
+screen_w (Screen width) int 1024 1 65535
 
 #    Height component of the initial window size. Ignored in fullscreen mode.
-screen_h (Screen height) int 600 1
+screen_h (Screen height) int 600 1 65535
 
 #    Save window size automatically when modified.
 autosave_screensize (Autosave screen size) bool true
@@ -152,13 +152,13 @@ pause_on_lost_focus (Pause on lost window focus) bool false
 
 #    If FPS would go higher than this, limit it by sleeping
 #    to not waste CPU power for no benefit.
-fps_max (Maximum FPS) int 60 1
+fps_max (Maximum FPS) int 60 1 4294967295
 
 #    Vertical screen synchronization.
 vsync (VSync) bool false
 
 #    Maximum FPS when the window is not focused, or when the game is paused.
-fps_max_unfocused (FPS when unfocused or paused) int 20 1
+fps_max_unfocused (FPS when unfocused or paused) int 20 1 4294967295
 
 #    View distance in nodes.
 viewing_range (Viewing range) int 190 20 4000
@@ -209,7 +209,7 @@ enable_particles (Digging particles) bool true
 3d_mode (3D mode) enum none none,anaglyph,interlaced,topbottom,sidebyside,crossview,pageflip
 
 #    Strength of 3D mode parallax.
-3d_paralax_strength (3D mode parallax strength) float 0.025
+3d_paralax_strength (3D mode parallax strength) float 0.025 -0.087 0.087
 
 [**Bobbing]
 
@@ -219,11 +219,11 @@ arm_inertia (Arm inertia) bool true
 
 #    Enable view bobbing and amount of view bobbing.
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
-view_bobbing_amount (View bobbing factor) float 1.0
+view_bobbing_amount (View bobbing factor) float 1.0 0.0 7.9
 
 #    Multiplier for fall bobbing.
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
-fall_bobbing_amount (Fall bobbing factor) float 0.03
+fall_bobbing_amount (Fall bobbing factor) float 0.03 0.0
 
 [**Camera]
 
@@ -335,7 +335,7 @@ texture_clean_transparent (Clean transparent textures) bool false
 #    bilinear/trilinear/anisotropic filtering is enabled.
 #    This is also used as the base node texture size for world-aligned
 #    texture autoscaling.
-texture_min_size (Minimum texture size) int 64
+texture_min_size (Minimum texture size) int 64 1 32768
 
 #    Use multi-sample antialiasing (MSAA) to smooth out block edges.
 #    This algorithm smooths out the 3D viewport while keeping the image sharp,
@@ -470,7 +470,7 @@ language (Language) enum   ,be,bg,ca,cs,da,de,el,en,eo,es,et,eu,fi,fr,gd,gl,hu,i
 #    This will smooth over some of the rough edges, and blend
 #    pixels when scaling down, at the cost of blurring some
 #    edge pixels when images are scaled by non-integer sizes.
-gui_scaling (GUI scaling) float 1.0 0.001
+gui_scaling (GUI scaling) float 1.0 0.5 20
 
 #    Enables animation of inventory items.
 inventory_items_animations (Inventory items animations) bool false
@@ -493,7 +493,7 @@ gui_scaling_filter (GUI scaling filter) bool false
 gui_scaling_filter_txr2img (GUI scaling filter txr2img) bool true
 
 #    Delay showing tooltips, stated in milliseconds.
-tooltip_show_delay (Tooltip delay) int 400
+tooltip_show_delay (Tooltip delay) int 400 0 18446744073709551615
 
 #    Append item name to tooltip.
 tooltip_append_itemname (Append item name) bool false
@@ -504,7 +504,7 @@ menu_clouds (Clouds in menu) bool true
 [**HUD]
 
 #    Modifies the size of the HUD elements.
-hud_scaling (HUD scaling) float 1.0
+hud_scaling (HUD scaling) float 1.0 0.5 20
 
 #    Whether name tag backgrounds should be shown by default.
 #    Mods may still set a background.
@@ -526,7 +526,7 @@ console_alpha (Console alpha) int 200 0 255
 
 #    Maximum proportion of current window to be used for hotbar.
 #    Useful if there's something to be displayed right or left of hotbar.
-hud_hotbar_max_width (Maximum hotbar width) float 1.0
+hud_hotbar_max_width (Maximum hotbar width) float 1.0 0.001 1.0
 
 #    Clickable weblinks (middle-click or Ctrl+left-click) enabled in chat console output.
 clickable_chat_weblinks (Chat weblinks) bool true
@@ -536,7 +536,7 @@ chat_weblink_color (Weblink color) string
 
 #    Font size of the recent chat text and chat prompt in point (pt).
 #    Value 0 will use the default font size.
-chat_font_size (Chat font size) int 0
+chat_font_size (Chat font size) int 0 0 72
 
 
 [**Content Repository]
@@ -554,7 +554,7 @@ contentdb_flag_blacklist (ContentDB Flag Blacklist) string nonfree, desktop_defa
 
 #    Maximum number of concurrent downloads. Downloads exceeding this limit will be queued.
 #    This should be lower than curl_parallel_limit.
-contentdb_max_concurrent_downloads (ContentDB Max Concurrent Downloads) int 3
+contentdb_max_concurrent_downloads (ContentDB Max Concurrent Downloads) int 3 1
 
 
 [Client and Server]
@@ -602,7 +602,7 @@ serverlist_url (Serverlist URL) string servers.minetest.net
 motd (Message of the day) string
 
 #    Maximum number of players that can be connected simultaneously.
-max_users (Maximum users) int 15
+max_users (Maximum users) int 15 0 65535
 
 #    If this is set, players will always (re)spawn at the given position.
 static_spawnpoint (Static spawnpoint) string
@@ -611,7 +611,7 @@ static_spawnpoint (Static spawnpoint) string
 
 #    Network port to listen (UDP).
 #    This value will be overridden when starting from the main menu.
-port (Server port) int 30000
+port (Server port) int 30000 1 65535
 
 #    The network interface that the server listens on.
 bind_address (Bind address) string
@@ -666,11 +666,11 @@ enable_rollback_recording (Rollback recording) bool false
 #    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to
 #    csm_restriction_noderange)
 #    READ_PLAYERINFO: 32 (disable get_player_names call client-side)
-csm_restriction_flags (Client side modding restrictions) int 62
+csm_restriction_flags (Client side modding restrictions) int 62 0 63
 
 #   If the CSM restriction for node range is enabled, get_node calls are limited
 #   to this distance from the player to the node.
-csm_restriction_noderange (Client side node lookup range restriction) int 0
+csm_restriction_noderange (Client side node lookup range restriction) int 0 0 4294967295
 
 [**Chat]
 
@@ -678,71 +678,73 @@ csm_restriction_noderange (Client side node lookup range restriction) int 0
 #    Use this to stop players from being able to use color in their messages
 strip_color_codes (Strip color codes) bool false
 
-#    Set the maximum character length of a chat message sent by clients.
-chat_message_max_size (Chat message max length) int 500
+#    Set the maximum length of a chat message (in characters) sent by clients.
+chat_message_max_size (Chat message max length) int 500 10 65535
 
 #    Amount of messages a player may send per 10 seconds.
-chat_message_limit_per_10sec (Chat message count limit) float 10.0
+chat_message_limit_per_10sec (Chat message count limit) float 10.0 1.0
 
 #    Kick players who sent more than X messages per 10 seconds.
-chat_message_limit_trigger_kick (Chat message kick threshold) int 50
+chat_message_limit_trigger_kick (Chat message kick threshold) int 50 1 65535
 
 [*Server Gameplay]
 
 #    Controls length of day/night cycle.
 #    Examples:
 #    72 = 20min, 360 = 4min, 1 = 24hour, 0 = day/night/whatever stays unchanged.
-time_speed (Time speed) int 72
+time_speed (Time speed) int 72 0
 
 #    Time of day when a new world is started, in millihours (0-23999).
 world_start_time (World start time) int 6125 0 23999
 
 #    Time in seconds for item entity (dropped items) to live.
 #    Setting it to -1 disables the feature.
-item_entity_ttl (Item entity TTL) int 900
+item_entity_ttl (Item entity TTL) int 900 -1
 
 #    Specifies the default stack size of nodes, items and tools.
 #    Note that mods or games may explicitly set a stack for certain (or all) items.
-default_stack_max (Default stack size) int 99
+default_stack_max (Default stack size) int 99 1 65535
 
 [**Physics]
 
 #    Horizontal and vertical acceleration on ground or when climbing,
 #    in nodes per second per second.
-movement_acceleration_default (Default acceleration) float 3
+movement_acceleration_default (Default acceleration) float 3.0 0.0
 
 #    Horizontal acceleration in air when jumping or falling,
 #    in nodes per second per second.
-movement_acceleration_air (Acceleration in air) float 2
+movement_acceleration_air (Acceleration in air) float 2.0 0.0
 
 #    Horizontal and vertical acceleration in fast mode,
 #    in nodes per second per second.
-movement_acceleration_fast (Fast mode acceleration) float 10
+movement_acceleration_fast (Fast mode acceleration) float 10.0 0.0
 
 #    Walking and flying speed, in nodes per second.
-movement_speed_walk (Walking speed) float 4
+movement_speed_walk (Walking speed) float 4.0 0.0
 
 #    Sneaking speed, in nodes per second.
-movement_speed_crouch (Sneaking speed) float 1.35
+movement_speed_crouch (Sneaking speed) float 1.35 0.0
 
 #    Walking, flying and climbing speed in fast mode, in nodes per second.
-movement_speed_fast (Fast mode speed) float 20
+movement_speed_fast (Fast mode speed) float 20.0 0.0
 
 #    Vertical climbing speed, in nodes per second.
-movement_speed_climb (Climbing speed) float 3
+movement_speed_climb (Climbing speed) float 3.0 0.0
 
 #    Initial vertical speed when jumping, in nodes per second.
-movement_speed_jump (Jumping speed) float 6.5
+movement_speed_jump (Jumping speed) float 6.5 0.0
 
+#    How much you are slowed down when moving inside a liquid.
 #    Decrease this to increase liquid resistance to movement.
-movement_liquid_fluidity (Liquid fluidity) float 1
+movement_liquid_fluidity (Liquid fluidity) float 1.0 0.001
 
 #    Maximum liquid resistance. Controls deceleration when entering liquid at
 #    high speed.
 movement_liquid_fluidity_smooth (Liquid fluidity smoothing) float 0.5
 
-#    Controls sinking speed in liquid.
-movement_liquid_sink (Liquid sinking) float 10
+#    Controls sinking speed in liquid when idling. Negative values will cause
+#    you to rise instead.
+movement_liquid_sink (Liquid sinking) float 10.0
 
 #    Acceleration of gravity, in nodes per second per second.
 movement_gravity (Gravity) float 9.81
@@ -761,10 +763,10 @@ fixed_map_seed (Fixed map seed) string
 mg_name (Mapgen name) enum v7 v7,valleys,carpathian,v5,flat,fractal,singlenode,v6
 
 #    Water surface level of the world.
-water_level (Water level) int 1
+water_level (Water level) int 1 -31000 31000
 
 #    From how far blocks are generated for clients, stated in mapblocks (16 nodes).
-max_block_generate_distance (Max block generate distance) int 10
+max_block_generate_distance (Max block generate distance) int 10 1 32767
 
 #    Limit of map generation, in nodes, in all 6 directions from (0, 0, 0).
 #    Only mapchunks completely within the mapgen limit are generated.
@@ -801,7 +803,7 @@ mgv5_spflags (Mapgen V5 specific flags) flags caverns caverns,nocaverns
 mgv5_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
-mgv5_large_cave_depth (Large cave depth) int -256
+mgv5_large_cave_depth (Large cave depth) int -256 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgv5_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -819,19 +821,19 @@ mgv5_large_cave_num_max (Large cave maximum number) int 2 0 64
 mgv5_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Y-level of cavern upper limit.
-mgv5_cavern_limit (Cavern limit) int -256
+mgv5_cavern_limit (Cavern limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
-mgv5_cavern_taper (Cavern taper) int 256
+mgv5_cavern_taper (Cavern taper) int 256 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
 mgv5_cavern_threshold (Cavern threshold) float 0.7
 
 #    Lower Y limit of dungeons.
-mgv5_dungeon_ymin (Dungeon minimum Y) int -31000
+mgv5_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgv5_dungeon_ymax (Dungeon maximum Y) int 31000
+mgv5_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
@@ -876,10 +878,10 @@ mgv6_freq_desert (Desert noise threshold) float 0.45
 mgv6_freq_beach (Beach noise threshold) float 0.15
 
 #    Lower Y limit of dungeons.
-mgv6_dungeon_ymin (Dungeon minimum Y) int -31000
+mgv6_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgv6_dungeon_ymax (Dungeon maximum Y) int 31000
+mgv6_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
@@ -925,19 +927,19 @@ mgv6_np_apple_trees (Apple trees noise) noise_params_2d 0, 1, (100, 100, 100), 3
 mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,caverns mountains,ridges,floatlands,caverns,nomountains,noridges,nofloatlands,nocaverns
 
 #    Y of mountain density gradient zero level. Used to shift mountains vertically.
-mgv7_mount_zero_level (Mountain zero level) int 0
+mgv7_mount_zero_level (Mountain zero level) int 0 -31000 31000
 
 #    Lower Y limit of floatlands.
-mgv7_floatland_ymin (Floatland minimum Y) int 1024
+mgv7_floatland_ymin (Floatland minimum Y) int 1024 -31000 31000
 
 #    Upper Y limit of floatlands.
-mgv7_floatland_ymax (Floatland maximum Y) int 4096
+mgv7_floatland_ymax (Floatland maximum Y) int 4096 -31000 31000
 
 #    Y-distance over which floatlands taper from full density to nothing.
 #    Tapering starts at this distance from the Y limit.
 #    For a solid floatland layer, this controls the height of hills/mountains.
 #    Must be less than or equal to half the distance between the Y limits.
-mgv7_floatland_taper (Floatland tapering distance) int 256
+mgv7_floatland_taper (Floatland tapering distance) int 256 0 32767
 
 #    Exponent of the floatland tapering. Alters the tapering behaviour.
 #    Value = 1.0 creates a uniform, linear tapering.
@@ -964,7 +966,7 @@ mgv7_floatland_density (Floatland density) float -0.6
 #    required value depending on 'mgv7_np_floatland'), to avoid
 #    server-intensive extreme water flow and to avoid vast flooding of the
 #    world surface below.
-mgv7_floatland_ywater (Floatland water level) int -31000
+mgv7_floatland_ywater (Floatland water level) int -31000 -31000 31000
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
@@ -972,7 +974,7 @@ mgv7_floatland_ywater (Floatland water level) int -31000
 mgv7_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
-mgv7_large_cave_depth (Large cave depth) int -33
+mgv7_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgv7_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -990,19 +992,19 @@ mgv7_large_cave_num_max (Large cave maximum number) int 2 0 64
 mgv7_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Y-level of cavern upper limit.
-mgv7_cavern_limit (Cavern limit) int -256
+mgv7_cavern_limit (Cavern limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
-mgv7_cavern_taper (Cavern taper) int 256
+mgv7_cavern_taper (Cavern taper) int 256 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
 mgv7_cavern_threshold (Cavern threshold) float 0.7
 
 #    Lower Y limit of dungeons.
-mgv7_dungeon_ymin (Dungeon minimum Y) int -31000
+mgv7_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgv7_dungeon_ymax (Dungeon maximum Y) int 31000
+mgv7_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
@@ -1076,7 +1078,7 @@ mgcarpathian_valley_width (River valley width) float 0.25
 mgcarpathian_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
-mgcarpathian_large_cave_depth (Large cave depth) int -33
+mgcarpathian_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgcarpathian_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -1094,19 +1096,19 @@ mgcarpathian_large_cave_num_max (Large cave maximum number) int 2 0 64
 mgcarpathian_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Y-level of cavern upper limit.
-mgcarpathian_cavern_limit (Cavern limit) int -256
+mgcarpathian_cavern_limit (Cavern limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
-mgcarpathian_cavern_taper (Cavern taper) int 256
+mgcarpathian_cavern_taper (Cavern taper) int 256 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
 mgcarpathian_cavern_threshold (Cavern threshold) float 0.7
 
 #    Lower Y limit of dungeons.
-mgcarpathian_dungeon_ymin (Dungeon minimum Y) int -31000
+mgcarpathian_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgcarpathian_dungeon_ymax (Dungeon maximum Y) int 31000
+mgcarpathian_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
@@ -1168,10 +1170,10 @@ mgcarpathian_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 50
 mgflat_spflags (Mapgen Flat specific flags) flags nolakes,nohills,nocaverns lakes,hills,caverns,nolakes,nohills,nocaverns
 
 #    Y of flat ground.
-mgflat_ground_level (Ground level) int 8
+mgflat_ground_level (Ground level) int 8 -31000 31000
 
 #    Y of upper limit of large caves.
-mgflat_large_cave_depth (Large cave depth) int -33
+mgflat_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgflat_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -1210,19 +1212,19 @@ mgflat_hill_threshold (Hill threshold) float 0.45
 mgflat_hill_steepness (Hill steepness) float 64.0
 
 #    Y-level of cavern upper limit.
-mgflat_cavern_limit (Cavern limit) int -256
+mgflat_cavern_limit (Cavern limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
-mgflat_cavern_taper (Cavern taper) int 256
+mgflat_cavern_taper (Cavern taper) int 256 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
 mgflat_cavern_threshold (Cavern threshold) float 0.7
 
 #    Lower Y limit of dungeons.
-mgflat_dungeon_ymin (Dungeon minimum Y) int -31000
+mgflat_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgflat_dungeon_ymax (Dungeon maximum Y) int 31000
+mgflat_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
@@ -1257,7 +1259,7 @@ mgfractal_spflags (Mapgen Fractal specific flags) flags terrain terrain,noterrai
 mgfractal_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
-mgfractal_large_cave_depth (Large cave depth) int -33
+mgfractal_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgfractal_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -1275,10 +1277,10 @@ mgfractal_large_cave_num_max (Large cave maximum number) int 2 0 64
 mgfractal_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Lower Y limit of dungeons.
-mgfractal_dungeon_ymin (Dungeon minimum Y) int -31000
+mgfractal_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgfractal_dungeon_ymax (Dungeon maximum Y) int 31000
+mgfractal_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 #    Selects one of 18 fractal types.
 #    1 = 4D "Roundy" Mandelbrot set.
@@ -1305,7 +1307,7 @@ mgfractal_fractal (Fractal type) int 1 1 18
 #    Increasing this increases the amount of fine detail, but also
 #    increases processing load.
 #    At iterations = 20 this mapgen has a similar load to mapgen V7.
-mgfractal_iterations (Iterations) int 11
+mgfractal_iterations (Iterations) int 11 1 65535
 
 #    (X,Y,Z) scale of fractal in nodes.
 #    Actual fractal size will be 2 to 3 times larger.
@@ -1388,10 +1390,10 @@ mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_riv
 #    The vertical distance over which heat drops by 20 if 'altitude_chill' is
 #    enabled. Also the vertical distance over which humidity drops by 10 if
 #    'altitude_dry' is enabled.
-mgvalleys_altitude_chill (Altitude chill) int 90
+mgvalleys_altitude_chill (Altitude chill) int 90 0 65535
 
 #    Depth below which you'll find large caves.
-mgvalleys_large_cave_depth (Large cave depth) int -33
+mgvalleys_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgvalleys_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -1409,19 +1411,19 @@ mgvalleys_large_cave_num_max (Large cave maximum number) int 2 0 64
 mgvalleys_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Depth below which you'll find giant caverns.
-mgvalleys_cavern_limit (Cavern upper limit) int -256
+mgvalleys_cavern_limit (Cavern upper limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
-mgvalleys_cavern_taper (Cavern taper) int 192
+mgvalleys_cavern_taper (Cavern taper) int 192 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
 mgvalleys_cavern_threshold (Cavern threshold) float 0.6
 
 #    How deep to make rivers.
-mgvalleys_river_depth (River depth) int 4
+mgvalleys_river_depth (River depth) int 4 0 65535
 
 #    How wide to make rivers.
-mgvalleys_river_size (River size) int 5
+mgvalleys_river_size (River size) int 5 0 65535
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
@@ -1429,10 +1431,10 @@ mgvalleys_river_size (River size) int 5
 mgvalleys_cave_width (Cave width) float 0.09
 
 #    Lower Y limit of dungeons.
-mgvalleys_dungeon_ymin (Dungeon minimum Y) int -31000
+mgvalleys_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
-mgvalleys_dungeon_ymax (Dungeon maximum Y) int 63
+mgvalleys_dungeon_ymax (Dungeon maximum Y) int 63 -31000 31000
 
 [**Noises]
 
@@ -1511,7 +1513,7 @@ debug_log_level (Debug log level) enum action ,none,error,warning,action,info,ve
 #    this setting when it is opened, the file is moved to debug.txt.1,
 #    deleting an older debug.txt.1 if it exists.
 #    debug.txt is only moved if this setting is positive.
-debug_log_size_max (Debug log file size threshold) int 50
+debug_log_size_max (Debug log file size threshold) int 50 1
 
 #    Minimal level of logging to be written to chat.
 chat_log_level (Chat log level) enum error ,none,error,warning,action,info,verbose,trace
@@ -1572,7 +1574,7 @@ instrument.profiler (Profiler) bool false
 
 #    Print the engine's profiling data in regular intervals (in seconds).
 #    0 = disable. Useful for developers.
-profiler_print_interval (Engine profiling data print interval) int 0
+profiler_print_interval (Engine profiling data print interval) int 0 0
 
 
 [*Advanced]
@@ -1607,7 +1609,7 @@ enable_vbo (VBO) bool true
 
 #    Radius of cloud area stated in number of 64 node cloud squares.
 #    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.
-cloud_radius (Cloud radius) int 12
+cloud_radius (Cloud radius) int 12 1 62
 
 #    Whether node texture animations should be desynchronized per mapblock.
 desynchronize_mapblock_texture_animation (Desynchronize block animation) bool true
@@ -1652,13 +1654,13 @@ font_bold (Font bold by default) bool false
 font_italic (Font italic by default) bool false
 
 #    Shadow offset (in pixels) of the default font. If 0, then shadow will not be drawn.
-font_shadow (Font shadow) int 1
+font_shadow (Font shadow) int 1 0 65535
 
 #    Opaqueness (alpha) of the shadow behind the default font, between 0 and 255.
 font_shadow_alpha (Font shadow alpha) int 127 0 255
 
 #    Font size of the default font where 1 unit = 1 pixel at 96 DPI
-font_size (Font size) int 16 1
+font_size (Font size) int 16 5 72
 
 #    For pixel-style fonts that do not scale well, this ensures that font sizes used
 #    with this font will always be divisible by this value, in pixels. For instance,
@@ -1675,7 +1677,7 @@ font_path_italic (Italic font path) filepath fonts/Arimo-Italic.ttf
 font_path_bold_italic (Bold and italic font path) filepath fonts/Arimo-BoldItalic.ttf
 
 #    Font size of the monospace font where 1 unit = 1 pixel at 96 DPI
-mono_font_size (Monospace font size) int 16 1
+mono_font_size (Monospace font size) int 16 5 72
 
 #    For pixel-style fonts that do not scale well, this ensures that font sizes used
 #    with this font will always be divisible by this value, in pixels. For instance,
@@ -1729,14 +1731,14 @@ prometheus_listener_address (Prometheus listener address) string 127.0.0.1:30000
 
 #    Maximum size of the out chat queue.
 #    0 to disable queueing and -1 to make the queue size unlimited.
-max_out_chat_queue_size (Maximum size of the out chat queue) int 20
+max_out_chat_queue_size (Maximum size of the out chat queue) int 20 -1 32767
 
-#    Timeout for client to remove unused map data from memory.
-client_unload_unused_data_timeout (Mapblock unload timeout) int 600
+#    Timeout for client to remove unused map data from memory, in seconds.
+client_unload_unused_data_timeout (Mapblock unload timeout) float 600.0 0.0
 
 #    Maximum number of mapblocks for client to be kept in memory.
 #    Set to -1 for unlimited amount.
-client_mapblock_limit (Mapblock limit) int 7500
+client_mapblock_limit (Mapblock limit) int 7500 -1 2147483647
 
 #    Whether to show the client debug info (has the same effect as hitting F5).
 show_debug (Show debug info) bool false
@@ -1744,16 +1746,16 @@ show_debug (Show debug info) bool false
 #    Maximum number of blocks that are simultaneously sent per client.
 #    The maximum total count is calculated dynamically:
 #    max_total = ceil((#clients + max_users) * per_client / 4)
-max_simultaneous_block_sends_per_client (Maximum simultaneous block sends per client) int 40
+max_simultaneous_block_sends_per_client (Maximum simultaneous block sends per client) int 40 1 4294967295
 
 #    To reduce lag, block transfers are slowed down when a player is building something.
 #    This determines how long they are slowed down after placing or removing a node.
-full_block_send_enable_min_time_from_building (Delay in sending blocks after building) float 2.0
+full_block_send_enable_min_time_from_building (Delay in sending blocks after building) float 2.0 0.0
 
 #    Maximum number of packets sent per send step, if you have a slow connection
 #    try reducing it, but don't reduce it to a number below double of targeted
 #    client number.
-max_packets_per_iteration (Max. packets per iteration) int 1024
+max_packets_per_iteration (Max. packets per iteration) int 1024 1 65535
 
 #    Compression level to use when sending mapblocks to the client.
 #    -1 - use default compression level
@@ -1769,7 +1771,7 @@ chat_message_format (Chat message format) string <@name> @message
 
 #    If the execution of a chat command takes longer than this specified time in
 #    seconds, add the time information to the chat command message
-chatcommand_msg_time_threshold (Chat command time message threshold) float 0.1
+chatcommand_msg_time_threshold (Chat command time message threshold) float 0.1 0.0
 
 #    A message to be displayed to all clients when the server shuts down.
 kick_msg_shutdown (Shutdown message) string Server shutting down.
@@ -1784,72 +1786,72 @@ ask_reconnect_on_crash (Ask to reconnect after crash) bool false
 [**Server/Env Performance]
 
 #    Length of a server tick and the interval at which objects are generally updated over
-#    network.
-dedicated_server_step (Dedicated server step) float 0.09
+#    network, stated in seconds.
+dedicated_server_step (Dedicated server step) float 0.09 0.0
 
 #    Whether players are shown to clients without any range limit.
 #    Deprecated, use the setting player_transfer_distance instead.
 unlimited_player_transfer_distance (Unlimited player transfer distance) bool true
 
 #    Defines the maximal player transfer distance in blocks (0 = unlimited).
-player_transfer_distance (Player transfer distance) int 0
+player_transfer_distance (Player transfer distance) int 0 0 65535
 
 #    From how far clients know about objects, stated in mapblocks (16 nodes).
 #
 #    Setting this larger than active_block_range will also cause the server
 #    to maintain active objects up to this distance in the direction the
 #    player is looking. (This can avoid mobs suddenly disappearing from view)
-active_object_send_range_blocks (Active object send range) int 8
+active_object_send_range_blocks (Active object send range) int 8 1 65535
 
 #    The radius of the volume of blocks around every player that is subject to the
 #    active block stuff, stated in mapblocks (16 nodes).
 #    In active blocks objects are loaded and ABMs run.
 #    This is also the minimum range in which active objects (mobs) are maintained.
 #    This should be configured together with active_object_send_range_blocks.
-active_block_range (Active block range) int 4
+active_block_range (Active block range) int 4 1 65535
 
 #    From how far blocks are sent to clients, stated in mapblocks (16 nodes).
-max_block_send_distance (Max block send distance) int 12
+max_block_send_distance (Max block send distance) int 12 1 65535
 
 #    Maximum number of forceloaded mapblocks.
-max_forceloaded_blocks (Maximum forceloaded blocks) int 16
+max_forceloaded_blocks (Maximum forceloaded blocks) int 16 0
 
-#    Interval of sending time of day to clients.
-time_send_interval (Time send interval) int 5
+#    Interval of sending time of day to clients, stated in seconds.
+time_send_interval (Time send interval) float 5.0 0.001
 
 #    Interval of saving important changes in the world, stated in seconds.
-server_map_save_interval (Map save interval) float 5.3
+server_map_save_interval (Map save interval) float 5.3 0.001
 
-#    How much the server will wait before unloading unused mapblocks.
+#    How long the server will wait before unloading unused mapblocks, stated in seconds.
 #    Higher value is smoother, but will use more RAM.
-server_unload_unused_data_timeout (Unload unused server data) int 29
+server_unload_unused_data_timeout (Unload unused server data) int 29 0 4294967295
 
 #    Maximum number of statically stored objects in a block.
-max_objects_per_block (Maximum objects per block) int 256
+max_objects_per_block (Maximum objects per block) int 256 1 65535
 
-#    Length of time between active block management cycles
-active_block_mgmt_interval (Active block management interval) float 2.0
+#    Length of time between active block management cycles, stated in seconds.
+active_block_mgmt_interval (Active block management interval) float 2.0 0.0
 
-#    Length of time between Active Block Modifier (ABM) execution cycles
-abm_interval (ABM interval) float 1.0
+#    Length of time between Active Block Modifier (ABM) execution cycles, stated in seconds.
+abm_interval (ABM interval) float 1.0 0.0
 
 #    The time budget allowed for ABMs to execute on each step
 #    (as a fraction of the ABM Interval)
 abm_time_budget (ABM time budget) float 0.2 0.1 0.9
 
-#    Length of time between NodeTimer execution cycles
-nodetimer_interval (NodeTimer interval) float 0.2
+#    Length of time between NodeTimer execution cycles, stated in seconds.
+nodetimer_interval (NodeTimer interval) float 0.2 0.0
 
 #    Max liquids processed per step.
-liquid_loop_max (Liquid loop max) int 100000
+liquid_loop_max (Liquid loop max) int 100000 1 4294967295
 
 #    The time (in seconds) that the liquids queue may grow beyond processing
 #    capacity until an attempt is made to decrease its size by dumping old queue
 #    items.  A value of 0 disables the functionality.
-liquid_queue_purge_time (Liquid queue purge time) int 0
+liquid_queue_purge_time (Liquid queue purge time) int 0 0 65535
 
 #    Liquid update interval in seconds.
-liquid_update (Liquid update tick) float 1.0
+liquid_update (Liquid update tick) float 1.0 0.001
 
 #    At this distance the server will aggressively optimize which blocks are sent to
 #    clients.
@@ -1859,7 +1861,7 @@ liquid_update (Liquid update tick) float 1.0
 #    Setting this to a value greater than max_block_send_distance disables this
 #    optimization.
 #    Stated in mapblocks (16 nodes).
-block_send_optimize_distance (Block send optimize distance) int 4 2
+block_send_optimize_distance (Block send optimize distance) int 4 2 32767
 
 #    If enabled the server will perform map block occlusion culling based on
 #    on the eye position of the player. This can reduce the number of blocks
@@ -1875,7 +1877,7 @@ server_side_occlusion_culling (Server side occlusion culling) bool true
 #    Reducing this value increases cave and dungeon density.
 #    Altering this value is for special usage, leaving it unchanged is
 #    recommended.
-chunksize (Chunk size) int 5
+chunksize (Chunk size) int 5 1 5
 
 #    Dump the mapgen debug information.
 enable_mapgen_debug_info (Mapgen debug) bool false
@@ -1901,7 +1903,7 @@ emergequeue_limit_generate (Per-player limit of queued blocks to generate) int 1
 #    speed, but this may harm game performance by interfering with other
 #    processes, especially in singleplayer and/or when running Lua code in
 #    'on_generated'. For many users the optimum setting may be '1'.
-num_emerge_threads (Number of emerge threads) int 1
+num_emerge_threads (Number of emerge threads) int 1 0 32767
 
 [**Misc]
 
@@ -1918,20 +1920,20 @@ enable_console (Enable console window) bool false
 #    Number of extra blocks that can be loaded by /clearobjects at once.
 #    This is a trade-off between SQLite transaction overhead and
 #    memory consumption (4096=100MB, as a rule of thumb).
-max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096
+max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096 0 4294967295
 
 #    Maximum time an interactive request (e.g. server list fetch) may take, stated in milliseconds.
-curl_timeout (cURL interactive timeout) int 20000
+curl_timeout (cURL interactive timeout) int 20000 100 2147483647
 
 #    Limits number of parallel HTTP requests. Affects:
 #    -    Media fetch if server uses remote_media setting.
 #    -    Serverlist download and server announcement.
 #    -    Downloads performed by main menu (e.g. mod manager).
 #    Only has an effect if compiled with cURL.
-curl_parallel_limit (cURL parallel limit) int 8
+curl_parallel_limit (cURL parallel limit) int 8 1 2147483647
 
 #    Maximum time a file download (e.g. a mod download) may take, stated in milliseconds.
-curl_file_download_timeout (cURL file download timeout) int 300000
+curl_file_download_timeout (cURL file download timeout) int 300000 100 2147483647
 
 #    World directory (everything in the world is stored here).
 #    Not needed if starting from the main menu.
@@ -1958,11 +1960,11 @@ serverlist_file (Serverlist file) string favoriteservers.json
 
 [*Gamepads]
 
-#    Enable joysticks
+#    Enable joysticks. Requires a restart to take effect
 enable_joysticks (Enable joysticks) bool false
 
 #    The identifier of the joystick to use
-joystick_id (Joystick ID) int 0
+joystick_id (Joystick ID) int 0 0 255
 
 #    The type of joystick
 joystick_type (Joystick type) enum auto auto,generic,xbox,dragonrise_gamecube
@@ -1972,11 +1974,11 @@ joystick_type (Joystick type) enum auto auto,generic,xbox,dragonrise_gamecube
 repeat_joystick_button_time (Joystick button repetition interval) float 0.17 0.001
 
 #    The dead zone of the joystick
-joystick_deadzone (Joystick dead zone) int 2048
+joystick_deadzone (Joystick dead zone) int 2048 0 65535
 
 #    The sensitivity of the joystick axes for moving the
 #    in-game view frustum around.
-joystick_frustum_sensitivity (Joystick frustum sensitivity) float 170
+joystick_frustum_sensitivity (Joystick frustum sensitivity) float 170.0 0.001
 
 
 [*Temporary Settings]

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1905,6 +1905,21 @@ emergequeue_limit_generate (Per-player limit of queued blocks to generate) int 1
 #    'on_generated'. For many users the optimum setting may be '1'.
 num_emerge_threads (Number of emerge threads) int 1 0 32767
 
+[**cURL]
+
+#    Maximum time an interactive request (e.g. server list fetch) may take, stated in milliseconds.
+curl_timeout (cURL interactive timeout) int 20000 100 2147483647
+
+#    Limits number of parallel HTTP requests. Affects:
+#    -    Media fetch if server uses remote_media setting.
+#    -    Serverlist download and server announcement.
+#    -    Downloads performed by main menu (e.g. mod manager).
+#    Only has an effect if compiled with cURL.
+curl_parallel_limit (cURL parallel limit) int 8 1 2147483647
+
+#    Maximum time a file download (e.g. a mod download) may take, stated in milliseconds.
+curl_file_download_timeout (cURL file download timeout) int 300000 100 2147483647
+
 [**Misc]
 
 #    Adjust dpi configuration to your screen (non X11/Android only) e.g. for 4k screens.
@@ -1921,19 +1936,6 @@ enable_console (Enable console window) bool false
 #    This is a trade-off between SQLite transaction overhead and
 #    memory consumption (4096=100MB, as a rule of thumb).
 max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096 0 4294967295
-
-#    Maximum time an interactive request (e.g. server list fetch) may take, stated in milliseconds.
-curl_timeout (cURL interactive timeout) int 20000 100 2147483647
-
-#    Limits number of parallel HTTP requests. Affects:
-#    -    Media fetch if server uses remote_media setting.
-#    -    Serverlist download and server announcement.
-#    -    Downloads performed by main menu (e.g. mod manager).
-#    Only has an effect if compiled with cURL.
-curl_parallel_limit (cURL parallel limit) int 8 1 2147483647
-
-#    Maximum time a file download (e.g. a mod download) may take, stated in milliseconds.
-curl_file_download_timeout (cURL file download timeout) int 300000 100 2147483647
 
 #    World directory (everything in the world is stored here).
 #    Not needed if starting from the main menu.


### PR DESCRIPTION
Split out from #12480, in order to avoid merge conflicts.

This organises the settingstype.txt file to use a logical/user-friendly structure. Advanced settings are also demoted to an advanced section at the end.

At most 3 levels of hierarchy are used, as that's the most allowed by the settings redesign

See #12140 for the context/reasoning behind these changes

## To do

This PR is a Ready for Review

## How to test

Use the All Settings dialog to check
