### PR TITLE
Optimize strict.lua

### DIFF
--- a/builtin/common/strict.lua
+++ b/builtin/common/strict.lua
@@ -32,7 +32,7 @@ end
 
 function meta:__index(name)
 	if declared[name] then
-		return nil
+		return
 	end
 	local info = getinfo(2, "Sl")
 	local warn_key = ("%s\0%d\0%s"):format(info.source, info.currentline, name)

--- a/builtin/common/strict.lua
+++ b/builtin/common/strict.lua
@@ -1,4 +1,4 @@
-local getinfo = debug.getinfo
+local getinfo, rawget, rawset = debug.getinfo, rawget, rawset
 
 function core.global_exists(name)
 	if type(name) ~= "string" then
@@ -14,33 +14,34 @@ local declared = {}
 local warned = {}
 
 function meta:__newindex(name, value)
+	if declared[name] then
+		return
+	end
 	local info = getinfo(2, "Sl")
 	local desc = ("%s:%d"):format(info.short_src, info.currentline)
-	if not declared[name] then
-		local warn_key = ("%s\0%d\0%s"):format(info.source,
-				info.currentline, name)
-		if not warned[warn_key] and info.what ~= "main" and
-				info.what ~= "C" then
-			core.log("warning", ("Assignment to undeclared "..
-					"global %q inside a function at %s.")
+	local warn_key = ("%s\0%d\0%s"):format(info.source, info.currentline, name)
+	if not warned[warn_key] and info.what ~= "main" and info.what ~= "C" then
+		core.log("warning", ("Assignment to undeclared global %q inside a function at %s.")
 				:format(name, desc))
-			warned[warn_key] = true
-		end
-		declared[name] = true
+		warned[warn_key] = true
 	end
 	rawset(self, name, value)
+	declared[name] = true
 end
 
 
 function meta:__index(name)
+	if declared[name] then
+		return nil
+	end
 	local info = getinfo(2, "Sl")
 	local warn_key = ("%s\0%d\0%s"):format(info.source, info.currentline, name)
-	if not declared[name] and not warned[warn_key] and info.what ~= "C" then
+	if not warned[warn_key] and info.what ~= "C" then
 		core.log("warning", ("Undeclared global variable %q accessed at %s:%s")
 				:format(name, info.short_src, info.currentline))
 		warned[warn_key] = true
 	end
-	return rawget(self, name)
+	return nil
 end
 
 setmetatable(_G, meta)


### PR DESCRIPTION
Just some basic optimizations.

# How to test
```lua
declared = 1
(function() for _ = 1, 1e3 do undeclared1 = undeclared2 end end)()
```
Expected: One warning for `undeclared1` and one for `undeclared2`.