### PR TITLE
Serialization spec: Fix number fuzzing

### DIFF
--- a/builtin/common/tests/serialize_spec.lua
+++ b/builtin/common/tests/serialize_spec.lua
@@ -154,7 +154,7 @@ describe("serialize", function()
 			local root = {}
 			local tables = {root}
 			local function random_table()
-				return  tables[#tables == 1 and 1 or math.random(1, #tables)] -- luacheck: ignore
+				return tables[math.random(1, #tables)]
 			end
 			for _ = 1, math.random(1, max_actions) do
 				local tab = random_table()

--- a/builtin/common/tests/serialize_spec.lua
+++ b/builtin/common/tests/serialize_spec.lua
@@ -133,7 +133,9 @@ describe("serialize", function()
 		end
 		local function num()
 			local sign = math.random() < 0.5 and -1 or 1
-			local val = math.random(0, 2^52)
+			-- HACK math.random(a, b) requires a, b & b - a to fit within a 32-bit int
+			-- Use two random calls to generate a random number from 0 - 2^50 as lower & upper 25 bits
+			local val = math.random(0, 2^25) * 2^25 + math.random(0, 2^25 - 1)
 			local exp = math.random() < 0.5 and 1 or 2^(math.random(-120, 120))
 			return sign * val * exp
 		end


### PR DESCRIPTION
Trivial. I found this when I ran my own tests - which contained the same mistake - with [strictest](https://github.com/appgurueu/strictest) enabled. Since PUC Lua uses ints under the hood, care must be taken to have the boundaries fit within int bounds.