### PR TITLE
Release shadow mapping resources when not needed

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -474,7 +474,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			// pass the shadow map texture to the buffer texture
 			ShadowRenderer *shadow = m_rendering_engine->get_shadow_renderer();
 			if (shadow && shadow->is_active()) {
-				auto &layer = material.TextureLayer[3];
+				auto &layer = material.TextureLayer[ShadowRenderer::TEXTURE_LAYER_SHADOW];
 				layer.Texture = shadow->get_texture();
 				layer.TextureWrapU = video::E_TEXTURE_CLAMP::ETC_CLAMP_TO_EDGE;
 				layer.TextureWrapV = video::E_TEXTURE_CLAMP::ETC_CLAMP_TO_EDGE;
@@ -487,6 +487,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			}
 			driver->setMaterial(material);
 			++material_swaps;
+			material.TextureLayer[ShadowRenderer::TEXTURE_LAYER_SHADOW].Texture = nullptr;
 		}
 
 		v3f block_wpos = intToFloat(descriptor.m_pos * MAP_BLOCKSIZE, BS);

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1321,12 +1321,6 @@ void GenericCAO::updateTextures(std::string mod)
 	m_current_texture_modifier = mod;
 	m_glow = m_prop.glow;
 
-	video::ITexture *shadow_texture = nullptr;
-	if (auto shadow = RenderingEngine::get_shadow_renderer())
-		shadow_texture = shadow->get_texture();
-
-	const u32 TEXTURE_LAYER_SHADOW = 3;
-
 	if (m_spritenode) {
 		if (m_prop.visual == "sprite") {
 			std::string texturestring = "no_texture.png";
@@ -1337,7 +1331,6 @@ void GenericCAO::updateTextures(std::string mod)
 			m_spritenode->getMaterial(0).MaterialTypeParam = 0.5f;
 			m_spritenode->setMaterialTexture(0,
 					tsrc->getTextureForMesh(texturestring));
-			m_spritenode->setMaterialTexture(TEXTURE_LAYER_SHADOW, shadow_texture);
 
 			// This allows setting per-material colors. However, until a real lighting
 			// system is added, the code below will have no effect. Once MineTest
@@ -1373,7 +1366,6 @@ void GenericCAO::updateTextures(std::string mod)
 				material.MaterialType = m_material_type;
 				material.MaterialTypeParam = 0.5f;
 				material.TextureLayer[0].Texture = texture;
-				material.TextureLayer[TEXTURE_LAYER_SHADOW].Texture = shadow_texture;
 				material.setFlag(video::EMF_LIGHTING, true);
 				material.setFlag(video::EMF_BILINEAR_FILTER, false);
 				material.setFlag(video::EMF_BACK_FACE_CULLING, m_prop.backface_culling);
@@ -1424,7 +1416,6 @@ void GenericCAO::updateTextures(std::string mod)
 				material.setFlag(video::EMF_BILINEAR_FILTER, false);
 				material.setTexture(0,
 						tsrc->getTextureForMesh(texturestring));
-				material.setTexture(TEXTURE_LAYER_SHADOW, shadow_texture);
 				material.getTextureMatrix(0).makeIdentity();
 
 				// This allows setting per-material colors. However, until a real lighting
@@ -1451,7 +1442,6 @@ void GenericCAO::updateTextures(std::string mod)
 				auto& material = m_meshnode->getMaterial(0);
 				material.setTexture(0,
 						tsrc->getTextureForMesh(tname));
-				material.setTexture(TEXTURE_LAYER_SHADOW, shadow_texture);
 
 				// This allows setting per-material colors. However, until a real lighting
 				// system is added, the code below will have no effect. Once MineTest
@@ -1476,7 +1466,6 @@ void GenericCAO::updateTextures(std::string mod)
 				auto& material = m_meshnode->getMaterial(1);
 				material.setTexture(0,
 						tsrc->getTextureForMesh(tname));
-				material.setTexture(TEXTURE_LAYER_SHADOW, shadow_texture);
 
 				// This allows setting per-material colors. However, until a real lighting
 				// system is added, the code below will have no effect. Once MineTest

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -179,7 +179,9 @@ void ShadowRenderer::addNodeToShadowList(
 {
 	if (!node)
 		return;
-	m_shadow_node_array.emplace_back(NodeToApply(node, shadowMode));
+	m_shadow_node_array.emplace_back(node, shadowMode);
+	if (shadowMode == ESM_RECEIVE || shadowMode == ESM_BOTH)
+		node->setMaterialTexture(TEXTURE_LAYER_SHADOW, shadowMapTextureFinal);
 }
 
 void ShadowRenderer::removeNodeFromShadowList(scene::ISceneNode *node)
@@ -254,6 +256,10 @@ void ShadowRenderer::updateSMTextures()
 			std::string("shadowmap_final_") + itos(m_shadow_map_texture_size),
 			frt, true);
 		assert(shadowMapTextureFinal != nullptr);
+
+		for (auto &node : m_shadow_node_array)
+			if (node.shadowMode == ESM_RECEIVE || node.shadowMode == ESM_BOTH)
+				node.node->setMaterialTexture(TEXTURE_LAYER_SHADOW, shadowMapTextureFinal);
 	}
 
 	if (!m_shadow_node_array.empty() && !m_light_list.empty()) {
@@ -341,9 +347,6 @@ void ShadowRenderer::update(video::ITexture *outputTarget)
 		return;
 	}
 
-	for (auto &node : m_shadow_node_array)
-		if (node.shadowMode & ESM_RECEIVE)
-			node.node->setMaterialTexture(TEXTURE_LAYER_SHADOW, shadowMapTextureFinal);
 
 	if (!m_shadow_node_array.empty() && !m_light_list.empty()) {
 

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -51,6 +51,8 @@ struct NodeToApply
 class ShadowRenderer
 {
 public:
+	static const int TEXTURE_LAYER_SHADOW = 3;
+
 	ShadowRenderer(IrrlichtDevice *device, Client *client);
 
 	~ShadowRenderer();

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -556,10 +556,6 @@ void WieldMeshSceneNode::changeToMesh(scene::IMesh *mesh)
 	if (m_shadow) {
 		// Add mesh to shadow caster
 		m_shadow->addNodeToShadowList(m_meshnode);
-
-		// Set shadow texture
-		for (u32 i = 0; i < m_meshnode->getMaterialCount(); i++)
-			m_meshnode->setMaterialTexture(3, m_shadow->get_texture());
 	}
 }
 


### PR DESCRIPTION
This PR removes the shadow mapping textures to release GPU memory when shadow intensity is changed to 0. It also cleans up code where shadow texture is assigned to map and entities.

## To do

This PR is Ready for Review.

## How to test

1. Enable the following mod:
```
core.register_chatcommand("s", {
	params = "intensity",
	func = function(name, param)
		local player = core.get_player_by_name(name)
		player:set_lighting({ shadows = { intensity = tonumber(param) } })
	end
})
```
2. Enable the shadows and enter the game
3. Toggle shadows with `/s 0` and `/s 1` commands
4. Shadows must disappear and reappear without error messages or crashing the game
