### PR TITLE
Fuzz the upper and lower edge of clouds

### DIFF
--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -353,8 +353,8 @@ void Clouds::update(const v3f &camera_p, const video::SColorf &color_diffuse)
 	m_camera_inside_cloud = false; // default
 	if (m_enable_3d) {
 		float camera_height = camera_p.Y - BS * m_camera_offset.Y;
-		if (camera_height >= m_box.MinEdge.Y &&
-				camera_height <= m_box.MaxEdge.Y) {
+		if (camera_height >= m_box.MinEdge.Y - 50 &&
+				camera_height <= m_box.MaxEdge.Y + 50 )  {
 			v2f camera_in_noise;
 			camera_in_noise.X = floor((camera_p.X - m_origin.X) / cloud_size + 0.5);
 			camera_in_noise.Y = floor((camera_p.Z - m_origin.Y) / cloud_size + 0.5);


### PR DESCRIPTION
This trivial fix addresses the problems of #12501 in a simple but functional way. It solves the gameplay issues related there, but is not a perfect fix.

 It extends the range of m_camera_inside_cloud past the edges of the mesh, so that the opaque cloud layer disappears when the player is about 5 nodes from entering it. This ensures that the player's path into the cloud is not obscured.

## To do

This PR is Ready for Review.

## How to test
Load up a world, find a tall mountain that extends into the clouds, and descend. As you get close, the clouds disappear so you can avoid stepping off a cliff.
 Alternately, load up Exile, "/set_weather fog" and find a cave below 0 or a mountain over ~450 nodes high.