### PR TITLE
Source image tracking in tile generation

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -549,8 +549,6 @@ private:
 	std::vector<std::string> m_remote_media_servers;
 	// Media downloader, only exists during init
 	ClientMediaDownloader *m_media_downloader;
-	// Set of media filenames pushed by server at runtime
-	std::unordered_set<std::string> m_media_pushed_files;
 	// Pending downloads of dynamic media (key: token)
 	std::vector<std::pair<u32, std::shared_ptr<SingleMediaDownloader>>> m_pending_media_downloads;
 

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -171,6 +171,7 @@ struct TextureInfo
 {
 	std::string name;
 	video::ITexture *texture;
+	std::set<std::string> sourceImages;
 
 	TextureInfo(
 			const std::string &name_,
@@ -178,6 +179,17 @@ struct TextureInfo
 		):
 		name(name_),
 		texture(texture_)
+	{
+	}
+
+	TextureInfo(
+			const std::string &name_,
+			video::ITexture *texture_,
+			std::set<std::string> &sourceImages_
+		):
+		name(name_),
+		texture(texture_),
+		sourceImages(sourceImages_)
 	{
 	}
 };
@@ -379,19 +391,26 @@ private:
 	// This should be only accessed from the main thread
 	SourceImageCache m_sourcecache;
 
+	// Rebuild images and textures from the current set of source images
+	// Shall be called from the main thread.
+	// You ARE expected to be holding m_textureinfo_cache_mutex
+	void rebuildTexture(video::IVideoDriver *driver, TextureInfo &ti);
+
 	// Generate a texture
 	u32 generateTexture(const std::string &name);
 
 	// Generate image based on a string like "stone.png" or "[crack:1:0".
 	// if baseimg is NULL, it is created. Otherwise stuff is made on it.
-	bool generateImagePart(std::string part_of_name, video::IImage *& baseimg);
+	// usedSourceImages is important to determine when to flush the image from a cache (dynamic media)
+	bool generateImagePart(std::string part_of_name, video::IImage *& baseimg, std::set<std::string> &usedSourceImages);
 
 	/*! Generates an image from a full string like
 	 * "stone.png^mineral_coal.png^[crack:1:0".
 	 * Shall be called from the main thread.
 	 * The returned Image should be dropped.
+	 * usedSourceImages is important to determine when to flush the image from a cache (dynamic media)
 	 */
-	video::IImage* generateImage(const std::string &name);
+	video::IImage* generateImage(const std::string &name, std::set<std::string> &usedSourceImages);
 
 	// Thread-safe cache of what source images are known (true = known)
 	MutexedMap<std::string, bool> m_source_image_existence;
@@ -592,7 +611,9 @@ u32 TextureSource::generateTexture(const std::string &name)
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
 	sanity_check(driver);
 
-	video::IImage *img = generateImage(name);
+	// passed into texture info for dynamic media tracking
+	std::set<std::string> sourceImageNames;
+	video::IImage *img = generateImage(name, sourceImageNames);
 
 	video::ITexture *tex = NULL;
 
@@ -613,7 +634,7 @@ u32 TextureSource::generateTexture(const std::string &name)
 	MutexAutoLock lock(m_textureinfo_cache_mutex);
 
 	u32 id = m_textureinfo_cache.size();
-	TextureInfo ti(name, tex);
+	TextureInfo ti(name, tex, sourceImageNames);
 	m_textureinfo_cache.push_back(ti);
 	m_name_to_id[name] = id;
 
@@ -677,7 +698,8 @@ Palette* TextureSource::getPalette(const std::string &name)
 	auto it = m_palettes.find(name);
 	if (it == m_palettes.end()) {
 		// Create palette
-		video::IImage *img = generateImage(name);
+		std::set<std::string> sourceImageNames; // unused, sadly.
+		video::IImage *img = generateImage(name, sourceImageNames);
 		if (!img) {
 			warningstream << "TextureSource::getPalette(): palette \"" << name
 				<< "\" could not be loaded." << std::endl;
@@ -749,6 +771,26 @@ void TextureSource::insertSourceImage(const std::string &name, video::IImage *im
 
 	m_sourcecache.insert(name, img, true);
 	m_source_image_existence.set(name, true);
+
+	// now we need to check for any textures that need updating
+	MutexAutoLock lock(m_textureinfo_cache_mutex);
+
+	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
+	sanity_check(driver);
+
+	// Recreate affected textures
+	int affected = 0;
+	for (TextureInfo &ti : m_textureinfo_cache) {
+		if (ti.name.empty())
+			continue; // Skip dummy entry
+		// if the source image is used, we need to rebuild this texture
+		if (ti.sourceImages.find(name) != ti.sourceImages.end()) {
+			rebuildTexture(driver, ti);
+			affected++;
+		}
+	}
+	if (affected > 0)
+		verbosestream << "TextureSource: insertSourceImage \"" << name << "\" caused rebuild of " << affected << " textures." << std::endl;
 }
 
 void TextureSource::rebuildImagesAndTextures()
@@ -765,25 +807,36 @@ void TextureSource::rebuildImagesAndTextures()
 	for (TextureInfo &ti : m_textureinfo_cache) {
 		if (ti.name.empty())
 			continue; // Skip dummy entry
-
-		video::IImage *img = generateImage(ti.name);
-#if ENABLE_GLES
-		img = Align2Npot2(img, driver);
-#endif
-		// Create texture from resulting image
-		video::ITexture *t = NULL;
-		if (img) {
-			t = driver->addTexture(ti.name.c_str(), img);
-			guiScalingCache(io::path(ti.name.c_str()), driver, img);
-			img->drop();
-		}
-		video::ITexture *t_old = ti.texture;
-		// Replace texture
-		ti.texture = t;
-
-		if (t_old)
-			m_texture_trash.push_back(t_old);
+		rebuildTexture(driver, ti);
 	}
+}
+
+void TextureSource::rebuildTexture(video::IVideoDriver *driver, TextureInfo & ti)
+{
+	if (ti.name.empty())
+		return; // this shouldn't happen, just a precaution
+
+	// replaces the previous sourceImages
+	// shouldn't really need to be done, but can't hurt
+	std::set<std::string> sourceImageNames;
+	video::IImage *img = generateImage(ti.name, sourceImageNames);
+#if ENABLE_GLES
+	img = Align2Npot2(img, driver);
+#endif
+	// Create texture from resulting image
+	video::ITexture *t = NULL;
+	if (img) {
+		t = driver->addTexture(ti.name.c_str(), img);
+		guiScalingCache(io::path(ti.name.c_str()), driver, img);
+		img->drop();
+	}
+	video::ITexture *t_old = ti.texture;
+	// Replace texture
+	ti.texture = t;
+	ti.sourceImages = sourceImageNames;
+
+	if (t_old)
+		m_texture_trash.push_back(t_old);
 }
 
 inline static void applyShadeFactor(video::SColor &color, u32 factor)
@@ -901,7 +954,7 @@ static video::IImage *createInventoryCubeImage(
 	return result;
 }
 
-video::IImage* TextureSource::generateImage(const std::string &name)
+video::IImage* TextureSource::generateImage(const std::string &name, std::set<std::string> &sourceImageNames)
 {
 	// Get the base image
 
@@ -954,7 +1007,7 @@ video::IImage* TextureSource::generateImage(const std::string &name)
 		using a recursive call.
 	*/
 	if (last_separator_pos != -1) {
-		baseimg = generateImage(name.substr(0, last_separator_pos));
+		baseimg = generateImage(name.substr(0, last_separator_pos), sourceImageNames);
 	}
 
 	/*
@@ -972,7 +1025,7 @@ video::IImage* TextureSource::generateImage(const std::string &name)
 			&& last_part_of_name[last_part_of_name.size() - 1] == paren_close) {
 		std::string name2 = last_part_of_name.substr(1,
 				last_part_of_name.size() - 2);
-		video::IImage *tmp = generateImage(name2);
+		video::IImage *tmp = generateImage(name2, sourceImageNames);
 		if (!tmp) {
 			errorstream << "generateImage(): "
 				"Failed to generate \"" << name2 << "\""
@@ -986,7 +1039,7 @@ video::IImage* TextureSource::generateImage(const std::string &name)
 		} else {
 			baseimg = tmp;
 		}
-	} else if (!generateImagePart(last_part_of_name, baseimg)) {
+	} else if (!generateImagePart(last_part_of_name, baseimg, sourceImageNames)) {
 		// Generate image according to part of name
 		errorstream << "generateImage(): "
 				"Failed to generate \"" << last_part_of_name << "\""
@@ -1100,7 +1153,7 @@ void blitBaseImage(video::IImage* &src, video::IImage* &dst)
 }
 
 bool TextureSource::generateImagePart(std::string part_of_name,
-		video::IImage *& baseimg)
+		video::IImage *& baseimg, std::set<std::string> &sourceImageNames)
 {
 	const char escape = '\\'; // same as in generateImage()
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
@@ -1108,6 +1161,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 
 	// Stuff starting with [ are special commands
 	if (part_of_name.empty() || part_of_name[0] != '[') {
+		sourceImageNames.insert(part_of_name);
 		video::IImage *image = m_sourcecache.getOrLoad(part_of_name);
 		if (image == NULL) {
 			if (!part_of_name.empty()) {
@@ -1245,7 +1299,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 				infostream<<"Adding \""<<filename
 						<<"\" to combined ("<<x<<","<<y<<")"
 						<<std::endl;
-				video::IImage *img = generateImage(filename);
+				video::IImage *img = generateImage(filename, sourceImageNames);
 				if (img) {
 					core::dimension2d<u32> dim = img->getDimension();
 					core::position2d<s32> pos_base(x, y);
@@ -1409,15 +1463,15 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			std::string imagename_right = sf.next("{");
 
 			// Generate images for the faces of the cube
-			video::IImage *img_top = generateImage(imagename_top);
-			video::IImage *img_left = generateImage(imagename_left);
-			video::IImage *img_right = generateImage(imagename_right);
+			video::IImage *img_top = generateImage(imagename_top, sourceImageNames);
+			video::IImage *img_left = generateImage(imagename_left, sourceImageNames);
+			video::IImage *img_right = generateImage(imagename_right, sourceImageNames);
 
 			if (img_top == NULL || img_left == NULL || img_right == NULL) {
 				errorstream << "generateImagePart(): Failed to create textures"
 						<< " for inventorycube \"" << part_of_name << "\""
 						<< std::endl;
-				baseimg = generateImage(imagename_top);
+				baseimg = generateImage(imagename_top, sourceImageNames);
 				return true;
 			}
 
@@ -1443,7 +1497,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 
 			if (baseimg == NULL)
 				baseimg = driver->createImage(video::ECF_A8R8G8B8, v2u32(16,16));
-			video::IImage *img = generateImage(filename);
+			video::IImage *img = generateImage(filename, sourceImageNames);
 			if (img)
 			{
 				core::dimension2d<u32> dim = img->getDimension();
@@ -1525,7 +1579,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			sf.next(":");
 			std::string filename = unescape_string(sf.next_esc(":", escape), escape);
 
-			video::IImage *img = generateImage(filename);
+			video::IImage *img = generateImage(filename, sourceImageNames);
 			if (img) {
 				apply_mask(img, baseimg, v2s32(0, 0), v2s32(0, 0),
 						img->getDimension());

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -779,18 +779,18 @@ void TextureSource::insertSourceImage(const std::string &name, video::IImage *im
 	sanity_check(driver);
 
 	// Recreate affected textures
-	int affected = 0;
+	u32 affected = 0;
 	for (TextureInfo &ti : m_textureinfo_cache) {
 		if (ti.name.empty())
 			continue; // Skip dummy entry
-		// if the source image is used, we need to rebuild this texture
+		// If the source image was used, we need to rebuild this texture
 		if (ti.sourceImages.find(name) != ti.sourceImages.end()) {
 			rebuildTexture(driver, ti);
 			affected++;
 		}
 	}
 	if (affected > 0)
-		verbosestream << "TextureSource: insertSourceImage \"" << name << "\" caused rebuild of " << affected << " textures." << std::endl;
+		verbosestream << "TextureSource: inserting \"" << name << "\" caused rebuild of " << affected << " textures." << std::endl;
 }
 
 void TextureSource::rebuildImagesAndTextures()
@@ -811,7 +811,7 @@ void TextureSource::rebuildImagesAndTextures()
 	}
 }
 
-void TextureSource::rebuildTexture(video::IVideoDriver *driver, TextureInfo & ti)
+void TextureSource::rebuildTexture(video::IVideoDriver *driver, TextureInfo &ti)
 {
 	if (ti.name.empty())
 		return; // this shouldn't happen, just a precaution

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1530,14 +1530,6 @@ void Client::handleCommand_MediaPush(NetworkPacket *pkt)
 		verbosestream << "with " << filedata.size() << " bytes ";
 	verbosestream << "(cached=" << cached << ")" << std::endl;
 
-	if (m_media_pushed_files.count(filename) != 0) {
-		// Ignore (but acknowledge). Previously this was for sync purposes,
-		// but even in new versions media cannot be replaced at runtime.
-		if (m_proto_ver >= 40)
-			sendHaveMedia({ token });
-		return;
-	}
-
 	if (!filedata.empty()) {
 		// LEGACY CODEPATH
 		// Compute and check checksum of data

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1548,15 +1548,12 @@ void Client::handleCommand_MediaPush(NetworkPacket *pkt)
 
 		// Actually load media
 		loadMedia(filedata, filename, true);
-		m_media_pushed_files.insert(filename);
 
 		// Cache file for the next time when this client joins the same server
 		if (cached)
 			clientMediaUpdateCache(raw_hash, filedata);
 		return;
 	}
-
-	m_media_pushed_files.insert(filename);
 
 	// create a downloader for this file
 	auto downloader(std::make_shared<SingleMediaDownloader>(cached));

--- a/src/server.h
+++ b/src/server.h
@@ -505,10 +505,6 @@ private:
 	void sendRequestedMedia(session_t peer_id,
 			const std::vector<std::string> &tosend);
 	void stepPendingDynMediaCallbacks(float dtime);
-	// This assumes you hold m_env_mutex.
-	// And that you'll remove the callback from the table yourself.
-	// Used by stepPendingDynMediaCallbacks & dynamicAddMedia.
-	void closePendingDynMediaCallback(u32 token, PendingDynamicMediaCallback &callback);
 
 	// Adds a ParticleSpawner on peer with peer_id (PEER_ID_INEXISTENT == all)
 	void SendAddParticleSpawner(session_t peer_id, u16 protocol_version,

--- a/src/server.h
+++ b/src/server.h
@@ -505,6 +505,10 @@ private:
 	void sendRequestedMedia(session_t peer_id,
 			const std::vector<std::string> &tosend);
 	void stepPendingDynMediaCallbacks(float dtime);
+	// This assumes you hold m_env_mutex.
+	// And that you'll remove the callback from the table yourself.
+	// Used by stepPendingDynMediaCallbacks & dynamicAddMedia.
+	void closePendingDynMediaCallback(u32 token, PendingDynamicMediaCallback &callback);
 
 	// Adds a ParticleSpawner on peer with peer_id (PEER_ID_INEXISTENT == all)
 	void SendAddParticleSpawner(session_t peer_id, u16 protocol_version,


### PR DESCRIPTION
This PR adds tracking to `tile.cpp` for if a source image is replaced at runtime.
If a source image is replaced, the generated images are replaced in turn.

This PR is Ready for Review.

# The below is inaccurate and is kept only for historical reasons.

This is in no way an absolute and complete solution, but I think it's a useful start and it reduces the likelihood of a memory leak caused by repeated uploads.

The problem this PR is intended to solve is that repeated uploads with differing paths are simultaneously necessary for large dynamically updating images and also cause a memory leak on receiving clients.

Note that this PR does *not* fully solve the existing issues with replacing textures at runtime. It does however begin that work by updating generated textures when one of their source images is replaced.

This leads to a number of situations where some form of "poke" is required to get a given target to update properly, but the results are usable.

This PR is Ready for Review.

Rationale on this:

There are various weird behaviours that will be seen here.
However to actually fix all of them would create a massive PR.

In practice I believe being able to safely runtime-replace textures with minor caveats is "good enough" for realistic usecases like player skins and so forth.

Still, I've kind of lost faith in the PR since beginning writing it, since there's a lot of edge cases that I don't think can be handled without changing stuff all over the place to the point where the PR ends up with a rather large scope.

I would not submit it at all, but I already made the fork and so forth, so I'm submitting it on the basis that engine developers will either agree with it despite it being incomplete or won't.

## How to test

1. Open up the devtest subgame.
2. Place down a `dynamic_media:node` node.
3. This is one of those "would be nice if this could change dynamically but won't happen" situations, it's not within scope for it to change in the following steps.
4. Use the entity spawner to create an `dynamic_media:entity` instance.
5. Right now this entity will update appearance to the current setting when it's reloaded.
6. Run commands: `/dynmedia 1` `/dynmedia 2`, `/dynmedia 1e`, `/dynmedia 2e`
7. Expected result is a HUD element on your screen appearing and changing image.
8. Create a second `dynamic_media:entity` instance
9. This will show the current state of the dynamic media image at when it's placed.
10. Run command `/dynmedia_ui`.
11. Expected result is a form - press the buttons to change the image sent to the client, press `reload` to send the client a slightly different formspec that causes it to reload the formspec and therefore update the image.
