### PR TITLE
Deserialization: Restore backwards compat

### DIFF
--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -190,13 +190,13 @@ local nan = (0/0)^1 -- +nan
 function core.deserialize(str, safe)
 	-- Backwards compatibility
 	if str == nil then
-		core.log("warning", "minetest.deserialize called with nil (expected string). This is deprecated.")
+		core.log("warning", debug.traceback("minetest.deserialize called with nil (expected string). This is deprecated."))
 		return nil, "Invalid type: Expected a string, got nil"
 	end
 	local t = type(str)
 	if t ~= "string" then
-		core.log("warning", ("minetest.deserialize called with %s (expected string). "
-				.. "This is deprecated and almost certainly a bug."):format(t))
+		core.log("warning", debug.traceback(("minetest.deserialize called with %s (expected string). "
+				.. "This is deprecated and almost certainly a bug."):format(t)))
 		return nil, "Invalid type: Expected a string, got " .. t
 	end
 

--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -188,6 +188,18 @@ local function dummy_func() end
 local nan = (0/0)^1 -- +nan
 
 function core.deserialize(str, safe)
+	-- Backwards compatibility
+	if str == nil then
+		core.log("warning", "minetest.deserialize called with nil (expected string). This is deprecated.")
+		return nil, "Invalid type: Expected a string, got nil"
+	end
+	local t = type(str)
+	if t ~= "string" then
+		core.log("warning", ("minetest.deserialize called with %s (expected string). "
+				.. "This is deprecated and almost certainly a bug."):format(t))
+		return nil, "Invalid type: Expected a string, got " .. t
+	end
+
 	local func, err = loadstring(str)
 	if not func then return nil, err end
 

--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -190,14 +190,12 @@ local nan = (0/0)^1 -- +nan
 function core.deserialize(str, safe)
 	-- Backwards compatibility
 	if str == nil then
-		core.log("warning", debug.traceback("minetest.deserialize called with nil (expected string). This is deprecated."))
+		core.log("deprecated", "minetest.deserialize called with nil (expected string).")
 		return nil, "Invalid type: Expected a string, got nil"
 	end
 	local t = type(str)
 	if t ~= "string" then
-		core.log("warning", debug.traceback(("minetest.deserialize called with %s (expected string). "
-				.. "This is deprecated and almost certainly a bug."):format(t)))
-		return nil, "Invalid type: Expected a string, got " .. t
+		error(("minetest.deserialize called with %s (expected string)."):format(t))
 	end
 
 	local func, err = loadstring(str)


### PR DESCRIPTION
https://github.com/minetest/minetest/pull/11427 deliberately stopped *not* throwing an error when a non-string is passed to `minetest.deserialize`. Mods however seem to rely on this (unfortunately it's hard to [sem]grep for this since this depends heavily on program logic). The first case of this causing a crash was [with petz](https://github.com/runsy/petz/issues/105), where it lead to an issue in petz code being discovered & fixed, which prompted me to write this patch. The second case was [with technic_plus](https://github.com/mt-mods/technic/pull/277), a rather well-written mod which relied on passing `nil` returning `nil`, which prompted me to open this PR. Both crashes have since been fixed, but widespread adoption of 5.6.0 might cause more crashes to pop up.

This PR now changes the hard error into:

1. A deprecation warning if `nil` is passed, and returns `nil` plus an error message as before
2. A more useful error if any other type is passed.
