### PR TITLE
Textures: introduce world-align overrides

### DIFF
--- a/doc/texture_packs.txt
+++ b/doc/texture_packs.txt
@@ -204,9 +204,12 @@ Here are targets you can choose from:
 | special6      | The sixth entry in the special_tiles list         |
 | inventory     | The inventory texture                             |
 | wield         | The texture used when held by the player          |
+| align_world=N | Overrides the "world align" behaviour of tiles ¹  |
 
 Nodes support all targets, but other items only support 'inventory'
 and 'wield'.
+
+¹ : `N` stands for any number in [0,255]. See lua_api.txt "align_style" for details.
 
 ### Using the special targets
 

--- a/doc/texture_packs.txt
+++ b/doc/texture_packs.txt
@@ -209,7 +209,7 @@ Here are targets you can choose from:
 Nodes support all targets, but other items only support 'inventory'
 and 'wield'.
 
-¹ : `N` stands for any number in [0,255]. See lua_api.txt "align_style" for details.
+¹ : `N` is an integer [0,255]. Sets align_style = "world" and scale = N on the tile, refer to lua_api.txt for details.
 
 ### Using the special targets
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1445,44 +1445,52 @@ void NodeDefManager::applyTextureOverrides(const std::vector<TextureOverride> &o
 
 		ContentFeatures &nodedef = m_content_features[id];
 
+		auto apply = [&] (TileDef &tile) {
+			tile.name = texture_override.texture;
+			if (texture_override.world_scale > 0) {
+				tile.align_style = ALIGN_STYLE_WORLD;
+				tile.scale = texture_override.world_scale;
+			}
+		};
+
 		// Override tiles
 		if (texture_override.hasTarget(OverrideTarget::TOP))
-			nodedef.tiledef[0].name = texture_override.texture;
+			apply(nodedef.tiledef[0]);
 
 		if (texture_override.hasTarget(OverrideTarget::BOTTOM))
-			nodedef.tiledef[1].name = texture_override.texture;
+			apply(nodedef.tiledef[1]);
 
 		if (texture_override.hasTarget(OverrideTarget::RIGHT))
-			nodedef.tiledef[2].name = texture_override.texture;
+			apply(nodedef.tiledef[2]);
 
 		if (texture_override.hasTarget(OverrideTarget::LEFT))
-			nodedef.tiledef[3].name = texture_override.texture;
+			apply(nodedef.tiledef[3]);
 
 		if (texture_override.hasTarget(OverrideTarget::BACK))
-			nodedef.tiledef[4].name = texture_override.texture;
+			apply(nodedef.tiledef[4]);
 
 		if (texture_override.hasTarget(OverrideTarget::FRONT))
-			nodedef.tiledef[5].name = texture_override.texture;
+			apply(nodedef.tiledef[5]);
 
 
 		// Override special tiles, if applicable
 		if (texture_override.hasTarget(OverrideTarget::SPECIAL_1))
-			nodedef.tiledef_special[0].name = texture_override.texture;
+			apply(nodedef.tiledef_special[0]);
 
 		if (texture_override.hasTarget(OverrideTarget::SPECIAL_2))
-			nodedef.tiledef_special[1].name = texture_override.texture;
+			apply(nodedef.tiledef_special[1]);
 
 		if (texture_override.hasTarget(OverrideTarget::SPECIAL_3))
-			nodedef.tiledef_special[2].name = texture_override.texture;
+			apply(nodedef.tiledef_special[2]);
 
 		if (texture_override.hasTarget(OverrideTarget::SPECIAL_4))
-			nodedef.tiledef_special[3].name = texture_override.texture;
+			apply(nodedef.tiledef_special[3]);
 
 		if (texture_override.hasTarget(OverrideTarget::SPECIAL_5))
-			nodedef.tiledef_special[4].name = texture_override.texture;
+			apply(nodedef.tiledef_special[4]);
 
 		if (texture_override.hasTarget(OverrideTarget::SPECIAL_6))
-			nodedef.tiledef_special[5].name = texture_override.texture;
+			apply(nodedef.tiledef_special[5]);
 	}
 }
 

--- a/src/texture_override.h
+++ b/src/texture_override.h
@@ -57,7 +57,8 @@ struct TextureOverride
 {
 	std::string id;
 	std::string texture;
-	override_t target;
+	override_t target = 0;
+	u8 world_scale = 0;
 
 	// Helper function for checking if an OverrideTarget is found in
 	// a TextureOverride without casting


### PR DESCRIPTION
Many games do not care about world align textures, however texture packs should have the capabilities to change that if they have suitable textures. This PR now introduces a node property override for world-align in particular to force a certain scale on the selected override tiles.

Example using an ugly texture:

![screenshot](https://user-images.githubusercontent.com/1497498/178986754-1e974955-526a-48cb-90c9-2165045dd6e2.jpg)

## To do

This PR is Ready for Review.

## How to test

1. Example override.txt plus textures to drop into any texture pack: [example_overrides_dirt_stone.zip](https://github.com/minetest/minetest/files/9111871/example_overrides_dirt_stone.zip)
2. Notice the difference
3. Judge