### PR TITLE
Deprecate loading a world with unresolved dependencies

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -431,8 +431,8 @@ void Server::init()
 		m_modmgr->printUnsatisfiedModsError();
 
 		warningstream
-			<< "Attempting to loading worlds with unsatisfied dependencies is deprecated. "
-			<< "In the future, Minetest will prevent loading." << std::endl;
+			<< "You have unsatisfied dependencies, loading your world anyway. "
+			<< "This will become a fatal error in the future." << std::endl;
 	}
 
 	//lock environment

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -425,9 +425,14 @@ void Server::init()
 
 	m_modmgr = std::make_unique<ServerModManager>(m_path_world);
 	std::vector<ModSpec> unsatisfied_mods = m_modmgr->getUnsatisfiedMods();
+
 	// complain about mods with unsatisfied dependencies
 	if (!m_modmgr->isConsistent()) {
 		m_modmgr->printUnsatisfiedModsError();
+
+		warningstream
+			<< "Attempting to loading worlds with unsatisfied dependencies is deprecated. "
+			<< "In the future, Minetest will prevent loading." << std::endl;
 	}
 
 	//lock environment


### PR DESCRIPTION
In preparation for #12217 (issue) and #12542 (PR)

## To do

This PR is a Ready for Review.

## How to test

<!-- Example code or instructions -->
