### PR TITLE
Prevent loading a world with unresolved dependencies

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -213,9 +213,10 @@ void Client::loadMods()
 	}
 
 	m_mods = modconf.getMods();
+
 	// complain about mods with unsatisfied dependencies
 	if (!modconf.isConsistent()) {
-		modconf.printUnsatisfiedModsError();
+		errorstream << modconf.getUnsatisfiedModsError() << std::endl;
 		return;
 	}
 

--- a/src/content/mod_configuration.cpp
+++ b/src/content/mod_configuration.cpp
@@ -21,16 +21,27 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "settings.h"
 #include "filesys.h"
+#include "gettext.h"
 
-void ModConfiguration::printUnsatisfiedModsError() const
+
+std::string ModConfiguration::getUnsatisfiedModsError() const
 {
+	std::ostringstream error;
+	error << gettext("Some mods have unsatisfied dependencies:") << std::endl;
+
 	for (const ModSpec &mod : m_unsatisfied_mods) {
-		errorstream << "mod \"" << mod.name
-					<< "\" has unsatisfied dependencies: ";
+		//~ Error when a mod is missing dependencies. Ex: "Mod Title is missing: mod1, mod2, mod3"
+		error << " - " << fmtgettext("%s is missing:", mod.name.c_str());
 		for (const std::string &unsatisfied_depend : mod.unsatisfied_depends)
-			errorstream << " \"" << unsatisfied_depend << "\"";
-		errorstream << std::endl;
+			error << " " << unsatisfied_depend;
+		error << "\n";
 	}
+
+	error << "\n"
+		<< gettext("Install and enable the required mods, or disable the mods causing errors.") << "\n"
+		<< gettext("Note: this may be caused by a dependency cycle, in which case try updating the mods.");
+
+	return error.str();
 }
 
 void ModConfiguration::addModsInPath(const std::string &path, const std::string &virtual_path)

--- a/src/content/mod_configuration.h
+++ b/src/content/mod_configuration.h
@@ -51,7 +51,7 @@ public:
 	 */
 	const std::vector<ModSpec> &getMods() const { return m_sorted_mods; }
 
-	void printUnsatisfiedModsError() const;
+	std::string getUnsatisfiedModsError() const;
 
 	/**
 	 * Adds all mods in the given path. used for games, modpacks

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -425,14 +425,10 @@ void Server::init()
 
 	m_modmgr = std::make_unique<ServerModManager>(m_path_world);
 	std::vector<ModSpec> unsatisfied_mods = m_modmgr->getUnsatisfiedMods();
-
 	// complain about mods with unsatisfied dependencies
 	if (!m_modmgr->isConsistent()) {
-		m_modmgr->printUnsatisfiedModsError();
-
-		warningstream
-			<< "You have unsatisfied dependencies, loading your world anyway. "
-			<< "This will become a fatal error in the future." << std::endl;
+		std::string error = m_modmgr->getUnsatisfiedModsError();
+		throw ServerError(error);
 	}
 
 	//lock environment

--- a/src/server/mods.h
+++ b/src/server/mods.h
@@ -57,8 +57,8 @@ public:
 		return configuration.isConsistent();
 	}
 
-	inline void printUnsatisfiedModsError() const {
-		return configuration.printUnsatisfiedModsError();
+	inline std::string getUnsatisfiedModsError() const {
+		return configuration.getUnsatisfiedModsError();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #12217

## To do

This PR is a Ready for Review.

## How to test

1. Enable some mods but not their dependencies
2. Attempt to load the world
