### PR TITLE
Offset cuboid origin after scaling the cuboid.

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -385,12 +385,12 @@ void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box, const f32 *txc,
 		box.MinEdge *= f->visual_scale;
 		box.MaxEdge *= f->visual_scale;
 	}
+	box.MinEdge += origin;
+	box.MaxEdge += origin;
 	if (!txc) {
 		generateCuboidTextureCoords(box, texture_coord_buf);
 		txc = texture_coord_buf;
 	}
-	box.MinEdge += origin;
-	box.MaxEdge += origin;
 	if (!tiles) {
 		tiles = &tile;
 		tile_count = 1;

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -377,10 +377,6 @@ void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box, const f32 *txc,
 	f32 dx2 = box.MaxEdge.X;
 	f32 dy2 = box.MaxEdge.Y;
 	f32 dz2 = box.MaxEdge.Z;
-
-	box.MinEdge += origin;
-	box.MaxEdge += origin;
-
 	if (scale) {
 		if (!txc) { // generate texture coords before scaling
 			generateCuboidTextureCoords(box, texture_coord_buf);
@@ -393,7 +389,8 @@ void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box, const f32 *txc,
 		generateCuboidTextureCoords(box, texture_coord_buf);
 		txc = texture_coord_buf;
 	}
-
+	box.MinEdge += origin;
+	box.MaxEdge += origin;
 	if (!tiles) {
 		tiles = &tile;
 		tile_count = 1;


### PR DESCRIPTION
This avoids the problem of offset nodes with visual_scale > 1.

Fixes #12536
## To do

This PR is a Ready for Review.

## How to test

1. Start devtest world
2. Place the following nodes:
  * A row of `stairs:stair_tiled`
  * A few of `testnodes:allfaces_double`
3. Expected:
  * the row of stais shows increasing numbers 1 2 3 4 5 6 7 8 ...
  * scaled allfaces nodes are rendered at their places

![](https://user-images.githubusercontent.com/4933697/179607901-bc4518c7-0bf4-47ff-815c-2b8c4ee62330.png)