### PR TITLE
Restore flags texture to fix interlaced stereo mode

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -421,6 +421,7 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<float, 3> m_camera_offset_vertex;
 	CachedPixelShaderSetting<SamplerLayer_t> m_base_texture;
 	CachedPixelShaderSetting<SamplerLayer_t> m_normal_texture;
+	CachedPixelShaderSetting<SamplerLayer_t> m_texture_flags;
 	Client *m_client;
 
 public:
@@ -455,6 +456,7 @@ public:
 		m_camera_offset_vertex("cameraOffset"),
 		m_base_texture("baseTexture"),
 		m_normal_texture("normalTexture"),
+		m_texture_flags("textureFlags"),
 		m_client(client)
 	{
 		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
@@ -524,9 +526,12 @@ public:
 		m_camera_offset_pixel.set(camera_offset_array, services);
 		m_camera_offset_vertex.set(camera_offset_array, services);
 
-		SamplerLayer_t base_tex = 0, normal_tex = 1;
+		SamplerLayer_t base_tex = 0,
+				normal_tex = 1,
+				flags_tex = 2;
 		m_base_texture.set(&base_tex, services);
 		m_normal_texture.set(&normal_tex, services);
+		m_texture_flags.set(&flags_tex, services);
 	}
 };
 


### PR DESCRIPTION
Fix interlaced stereo mode (#12552) by reenabling flags texture in the shaders.

## To do

This PR is Ready for Review.

## How to test

1. Set 3d_mode = interlaced
2. Start any game
3. Notice that there is no interlacing, sometimes there are duplicate pixels in the image.

The reason is that the mask texture ID uniform is not set, and a wrong texture is used as  the mask for merging.

Here is an example of how broken 3d mode looks:
![image](https://user-images.githubusercontent.com/4933697/179709516-b8a41add-5700-430a-b547-36b3ca8b8fef.png)

Example of correct rendering:
![image](https://user-images.githubusercontent.com/4933697/179711440-1ab630af-4c73-49a8-9896-0ea5d0a9ff59.png)

