### PR TITLE
Fix lua_api typo: animated_images

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2311,7 +2311,7 @@ Version History
 * Formspec version 5 (5.5.0):
   * Added padding[] element
 * Formspec version 6 (5.6.0):
-  * Add nine-slice images, animated_images, and fgimg_middle
+  * Add nine-slice images, animated_image, and fgimg_middle
 
 Elements
 --------


### PR DESCRIPTION
There was a typo in `lua_api.txt`. The formspec element `animated_image` was falsely labelled as `animated_images`.

I verified in the source code that the true formspec element name is `animated_image`.