### PR TITLE
Fix rotation of falling facedir nodes in some cases

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -158,12 +158,10 @@ core.register_entity(":__builtin:falling_node", {
 				or def.drawtype == "normal"
 				or def.drawtype == "nodebox" then
 			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then
-				local fdir = node.param2 % 32
+				local fdir = node.param2 % 32 % 24
 				-- Get rotation from a precalculated lookup table
 				local euler = facedir_to_euler[fdir + 1]
-				if euler then
-					self.object:set_rotation(euler)
-				end
+				self.object:set_rotation(euler)
 			elseif (def.drawtype ~= "plantlike" and def.drawtype ~= "plantlike_rooted" and
 					(def.paramtype2 == "wallmounted" or def.paramtype2 == "colorwallmounted" or def.drawtype == "signlike")) then
 				local rot = node.param2 % 8

--- a/games/devtest/mods/testnodes/properties.lua
+++ b/games/devtest/mods/testnodes/properties.lua
@@ -13,6 +13,20 @@ minetest.register_node("testnodes:falling", {
 	groups = { falling_node = 1, dig_immediate = 3 },
 })
 
+minetest.register_node("testnodes:falling_facedir", {
+	description = S("Falling Facedir Node"),
+	tiles = {
+		"testnodes_1.png",
+		"testnodes_2.png",
+		"testnodes_3.png",
+		"testnodes_4.png",
+		"testnodes_5.png",
+		"testnodes_6.png",
+	},
+	paramtype2 = "facedir",
+	groups = { falling_node = 1, dig_immediate = 3 },
+})
+
 -- Same as falling node, but will stop falling on top of liquids
 minetest.register_node("testnodes:falling_float", {
 	description = S("Falling+Floating Node"),


### PR DESCRIPTION
The rotation of falling facedir nodes with `param2` values of e.g. 255 and 24-31 is incorrect.

The engine calculates the facedir value by doing `param2 % 32 % 24`. The falling node code that calculates the facedir value only does `param2 % 32` and doesn't rotate nodes where `param2 % 32 > 23` at all.

The relevant code in `MapNode::getFaceDir`:

https://github.com/minetest/minetest/blob/2351c9561265d4136f78ce3dd73c0c77acfed711/src/mapnode.cpp#L151

and in `falling.lua`:

https://github.com/minetest/minetest/blob/2351c9561265d4136f78ce3dd73c0c77acfed711/builtin/game/falling.lua#L161-L166

This PR changes `falling.lua` to calculate the facedir value in the same way as the engine. It also adds a test node to Devtest, `testnodes:falling_facedir`.

## To do

This PR is Ready for Review.

## How to test

In Devtest, place a `testnodes:falling_facedir` node and set its `param2` to 255. See that it is rotated incorrectly while falling without the changes to `falling.lua` and correctly with them.