### PR TITLE
Add setting to mirror hands

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -225,6 +225,9 @@ view_bobbing_amount (View bobbing factor) float 1.0 0.0 7.9
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
 fall_bobbing_amount (Fall bobbing factor) float 0.03 0.0 100.0
 
+#    Draw main hand on left side of screen, offhand on right side.
+mirror_hands (Mirror hands) bool false
+
 [**Camera]
 
 #   Camera 'near clipping plane' distance in nodes, between 0 and 0.25

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3261,6 +3261,13 @@ Player Inventory lists
 * `hand`: list containing an override for the empty hand
     * Is not created automatically, use `InvRef:set_size`
     * Is only used to enhance the empty hand's tool capabilities
+* `offhand`: list containing the offhand wielded item.
+    * Will be used for placements and secondary uses if the
+        main hand does not have any node_place_prediction, on_place
+        or on_secondary_use callbacks.
+    * Is passed to on_place and on_secondary_use callbacks; make sure
+        mods are aware of the itemstack not neccessarily being
+        located in the main hand.
 
 Colors
 ======
@@ -4707,13 +4714,13 @@ Privileges
 
 Privileges provide a means for server administrators to give certain players
 access to special abilities in the engine, games or mods.
-For example, game moderators may need to travel instantly to any place in the world, 
+For example, game moderators may need to travel instantly to any place in the world,
 this ability is implemented in `/teleport` command which requires `teleport` privilege.
 
 Registering privileges
 ----------------------
 
-A mod can register a custom privilege using `minetest.register_privilege` function 
+A mod can register a custom privilege using `minetest.register_privilege` function
 to give server administrators fine-grained access control over mod functionality.
 
 For consistency and practical reasons, privileges should strictly increase the abilities of the user.
@@ -4722,7 +4729,7 @@ Do not register custom privileges that e.g. restrict the player from certain in-
 Checking privileges
 -------------------
 
-A mod can call `minetest.check_player_privs` to test whether a player has privileges 
+A mod can call `minetest.check_player_privs` to test whether a player has privileges
 to perform an operation.
 Also, when registering a chat command with `minetest.register_chatcommand` a mod can
 declare privileges that the command requires using the `privs` field of the command
@@ -4786,7 +4793,7 @@ Minetest includes the following settings to control behavior of privileges:
 
    * `default_privs`: defines privileges granted to new players.
    * `basic_privs`: defines privileges that can be granted/revoked by players having
-    the `basic_privs` privilege. This can be used, for example, to give 
+    the `basic_privs` privilege. This can be used, for example, to give
     limited moderation powers to selected users.
 
 'minetest' namespace reference
@@ -7948,8 +7955,10 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         },
 
         on_place = function(itemstack, placer, pointed_thing),
-        -- When the 'place' key was pressed with the item in hand
+        -- When the 'place' key was pressed with the item one of the hands
         -- and a node was pointed at.
+        -- 'itemstack' may be the offhand item iff the main hand has
+        -- no on_place handler and no node_placement_prediction.
         -- Shall place item and return the leftover itemstack
         -- or nil to not modify the inventory.
         -- The placer may be any ObjectRef or nil.
@@ -7957,6 +7966,8 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
 
         on_secondary_use = function(itemstack, user, pointed_thing),
         -- Same as on_place but called when not pointing at a node.
+        -- 'itemstack' may be the offhand item iff the main hand has
+        -- no on_secondary_use handler.
         -- Function must return either nil if inventory shall not be modified,
         -- or an itemstack to replace the original itemstack.
         -- The user may be any ObjectRef or nil.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -212,6 +212,10 @@
 #    type: float min: 0 max: 100
 # fall_bobbing_amount = 0.03
 
+#    Draw main hand on left side of screen, offhand on right side.
+#    type: bool
+# mirror_hands = false
+
 ### Camera
 
 #    Camera 'near clipping plane' distance in nodes, between 0 and 0.25

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -45,7 +45,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define WIELDMESH_AMPLITUDE_X 7.0f
 #define WIELDMESH_AMPLITUDE_Y 10.0f
 
-#define HANDS (int i = 0, s = +1; i <= 1; i++, s *= -1) // i is index, s is sign
+#define HANDS (int i = 0, s = +1; i <= +1; i++, s = -1, (void) s) // i is index, s is sign
 
 Camera::Camera(MapDrawControl &draw_control, Client *client, RenderingEngine *rendering_engine):
 	m_draw_control(draw_control),
@@ -529,6 +529,9 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 tool_reload_ratio)
 	m_player_light_color = player->light_color;
 
 	for HANDS {
+		if (g_settings->getBool("mirror_hands"))
+			s *= -1;
+
 		// Position the wielded item
 		//v3f wield_position = v3f(45, -35, 65);
 		v3f wield_position = v3f(m_wieldmesh_offset.X, m_wieldmesh_offset.Y, 65);

--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -146,11 +146,12 @@ public:
 	void updateViewingRange();
 
 	// Start digging animation
-	// Pass 0 for left click, 1 for right click
-	void setDigging(s32 button);
+	// button: Pass 0 for left click, 1 for right click
+	// hand: 0 for main hand, 1 for offhand
+	void setDigging(s32 button, int hand);
 
 	// Replace the wielded item mesh
-	void wield(const ItemStack &item);
+	void wield(const ItemStack &item, int hand);
 
 	// Draw the wielded tool.
 	// This has to happen *after* the main scene is drawn.
@@ -196,7 +197,7 @@ private:
 	scene::ICameraSceneNode *m_cameranode = nullptr;
 
 	scene::ISceneManager *m_wieldmgr = nullptr;
-	WieldMeshSceneNode *m_wieldnode = nullptr;
+	WieldMeshSceneNode *m_wieldnode[2] = {nullptr, nullptr};
 
 	// draw control
 	MapDrawControl& m_draw_control;
@@ -246,15 +247,17 @@ private:
 	f32 m_view_bobbing_fall = 0.0f;
 
 	// Digging animation frame (0 <= m_digging_anim < 1)
-	f32 m_digging_anim = 0.0f;
+	f32 m_digging_anim[2] = {0.0f, 0.0f};
+
 	// If -1, no digging animation
 	// If 0, left-click digging animation
 	// If 1, right-click digging animation
-	s32 m_digging_button = -1;
+	s32 m_digging_button[2] = {-1, -1};
 
 	// Animation when changing wielded item
-	f32 m_wield_change_timer = 0.125f;
-	ItemStack m_wield_item_next;
+	f32 m_wield_change_timer[2] = {0.125f, 0.125f};
+	ItemStack m_wield_item_next[2];
+	bool m_offhand_wield_item_old;
 
 	CameraMode m_camera_mode = CAMERA_MODE_FIRST;
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1487,6 +1487,8 @@ bool Client::updateWieldedItem()
 		list->setModified(false);
 	if (auto *list = player->inventory.getList("hand"))
 		list->setModified(false);
+	if (auto *list = player->inventory.getList("offhand"))
+		list->setModified(false);
 
 	return true;
 }

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -275,6 +275,7 @@ public:
 	// Returns true if the inventory of the local player has been
 	// updated from the server. If it is true, it is set to false.
 	bool updateWieldedItem();
+	bool updateOffhandWieldedItem();
 
 	/* InventoryManager interface */
 	Inventory* getInventory(const InventoryLocation &loc) override;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -207,6 +207,7 @@ void set_default_settings()
 	settings->setDefault("enable_clouds", "true");
 	settings->setDefault("view_bobbing_amount", "1.0");
 	settings->setDefault("fall_bobbing_amount", "0.03");
+	settings->setDefault("mirror_hands", "false");
 	settings->setDefault("enable_3d_clouds", "true");
 	settings->setDefault("cloud_radius", "12");
 	settings->setDefault("menu_clouds", "true");

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -76,6 +76,8 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	groups = def.groups;
 	node_placement_prediction = def.node_placement_prediction;
 	place_param2 = def.place_param2;
+	has_on_place = def.has_on_place;
+	has_on_secondary_use = def.has_on_secondary_use;
 	sound_place = def.sound_place;
 	sound_place_failed = def.sound_place_failed;
 	range = def.range;
@@ -120,6 +122,8 @@ void ItemDefinition::reset()
 	range = -1;
 	node_placement_prediction = "";
 	place_param2 = 0;
+	has_on_place = false;
+	has_on_secondary_use = false;
 }
 
 void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
@@ -166,6 +170,8 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	os << serializeString16(short_description);
 
 	os << place_param2;
+	writeU8(os, has_on_place);
+	writeU8(os, has_on_secondary_use);
 }
 
 void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
@@ -220,6 +226,8 @@ void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
 		short_description = deSerializeString16(is);
 
 		place_param2 = readU8(is); // 0 if missing
+		has_on_place = readU8(is);
+		has_on_secondary_use = readU8(is);
 	} catch(SerializationError &e) {};
 }
 

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -87,6 +87,8 @@ struct ItemDefinition
 	// "" = no prediction
 	std::string node_placement_prediction;
 	u8 place_param2;
+	bool has_on_place;
+	bool has_on_secondary_use;
 
 	/*
 		Some helpful methods

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -114,6 +114,46 @@ ItemStack &Player::getWieldedItem(ItemStack *selected, ItemStack *hand) const
 	return (hand && selected->name.empty()) ? *hand : *selected;
 }
 
+bool Player::getOffhandWieldedItem(ItemStack *offhand, ItemStack *place, IItemDefManager *idef, const PointedThing &pointed) const
+{
+	assert(offhand);
+
+	ItemStack main;
+
+	const InventoryList *mlist = inventory.getList("main");
+	const InventoryList *olist = inventory.getList("offhand");
+
+	if (olist)
+		*offhand = olist->getItem(0);
+
+	if (mlist && m_wield_index < mlist->getSize())
+		main = mlist->getItem(m_wield_index);
+
+	const ItemDefinition &main_def = main.getDefinition(idef);
+	const ItemDefinition &offhand_def = offhand->getDefinition(idef);
+	bool main_usable, offhand_usable;
+
+	// figure out which item to use for placements
+
+	if (pointed.type == POINTEDTHING_NODE) {
+		// an item can be used on nodes if it has a place handler or prediction
+		main_usable = main_def.has_on_place || main_def.node_placement_prediction != "";
+		offhand_usable = offhand_def.has_on_place || offhand_def.node_placement_prediction != "";
+	} else {
+		// an item can be used on anything else if it has a secondary use handler
+		main_usable = main_def.has_on_secondary_use;
+		offhand_usable = offhand_def.has_on_secondary_use;
+	}
+
+	// main hand has priority
+	bool use_offhand = offhand_usable && !main_usable;
+
+	if (place)
+		*place = use_offhand ? *offhand : main;
+
+	return use_offhand;
+}
+
 u32 Player::addHud(HudElement *toadd)
 {
 	MutexAutoLock lock(m_mutex);

--- a/src/player.h
+++ b/src/player.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "constants.h"
 #include "network/networkprotocol.h"
 #include "util/basic_macros.h"
+#include "util/pointedthing.h"
 #include <list>
 #include <mutex>
 
@@ -187,6 +188,10 @@ public:
 
 	// Returns non-empty `selected` ItemStack. `hand` is a fallback, if specified
 	ItemStack &getWieldedItem(ItemStack *selected, ItemStack *hand) const;
+
+	// item currently in secondary hand is returned in `offhand`
+	// item to use for place / secondary_use (either main or offhand) is (optionally) returned in `place`
+	bool getOffhandWieldedItem(ItemStack *offhand, ItemStack *place, IItemDefManager *idef, const PointedThing &pointed) const;
 	void setWieldIndex(u16 index);
 	u16 getWieldIndex() const { return m_wield_index; }
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -81,6 +81,16 @@ void read_item_definition(lua_State* L, int index,
 	def.usable = lua_isfunction(L, -1);
 	lua_pop(L, 1);
 
+	lua_pushstring(L, "on_place");
+	lua_rawget(L, index);
+	def.has_on_place = lua_isfunction(L, -1);
+	lua_pop(L, 1);
+
+	lua_pushstring(L, "on_secondary_use");
+	lua_rawget(L, index);
+	def.has_on_secondary_use = lua_isfunction(L, -1);
+	lua_pop(L, 1);
+
 	getboolfield(L, index, "liquids_pointable", def.liquids_pointable);
 
 	lua_getfield(L, index, "tool_capabilities");

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -525,11 +525,26 @@ ItemStack PlayerSAO::getWieldedItem(ItemStack *selected, ItemStack *hand) const
 	return m_player->getWieldedItem(selected, hand);
 }
 
+bool PlayerSAO::getOffhandWieldedItem(ItemStack *offhand, ItemStack *place, IItemDefManager *itemdef_manager, PointedThing pointed) const
+{
+	return m_player->getOffhandWieldedItem(offhand, place, itemdef_manager, pointed);
+}
+
 bool PlayerSAO::setWieldedItem(const ItemStack &item)
 {
 	InventoryList *mlist = m_player->inventory.getList(getWieldList());
 	if (mlist) {
 		mlist->changeItem(m_player->getWieldIndex(), item);
+		return true;
+	}
+	return false;
+}
+
+bool PlayerSAO::setOffhandWieldedItem(const ItemStack &item)
+{
+	InventoryList *olist = m_player->inventory.getList("offhand");
+	if (olist) {
+		olist->changeItem(0, item);
 		return true;
 	}
 	return false;

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "network/networkprotocol.h"
 #include "unit_sao.h"
 #include "util/numeric.h"
+#include "util/pointedthing.h"
 
 /*
 	PlayerSAO needs some internals exposed.
@@ -130,7 +131,9 @@ public:
 	std::string getWieldList() const override { return "main"; }
 	u16 getWieldIndex() const override;
 	ItemStack getWieldedItem(ItemStack *selected, ItemStack *hand = nullptr) const override;
+	bool getOffhandWieldedItem(ItemStack *offhand, ItemStack *place, IItemDefManager *itemdef_manager, PointedThing pointed) const;
 	bool setWieldedItem(const ItemStack &item) override;
+	bool setOffhandWieldedItem(const ItemStack &item);
 
 	/*
 		PlayerSAO-specific

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -86,6 +86,8 @@ fake_function() {
 	gettext("Enable view bobbing and amount of view bobbing.\nFor example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.");
 	gettext("Fall bobbing factor");
 	gettext("Multiplier for fall bobbing.\nFor example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.");
+	gettext("Mirror hands");
+	gettext("Draw main hand on left side of screen, offhand on right side.");
 	gettext("Camera");
 	gettext("Near plane");
 	gettext("Camera 'near clipping plane' distance in nodes, between 0 and 0.25\nOnly works on GLES platforms. Most users will not need to change this.\nIncreasing can reduce artifacting on weaker GPUs.\n0.1 = Default, 0.25 = Good value for weaker tablets.");


### PR DESCRIPTION
This PR adds the mirror_hands setting.
When enabled, the main hand is drawn on the left side of the screen, while the offhand is drawn on the right side.

Fixes: #11207

## To do

**Depends on #11016 to be merged first.**
Otherwise ready for review.

## How to test

1. Follow testing instructions for #11016
2. Verify main hand is right, offhand is left
3. Enable mirror_hands setting
4. Verify main hand is left, offhand is right