### PR TITLE
Add keybind to swap items between hands

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2167,6 +2167,10 @@ keymap_screenshot (Screenshot) key KEY_F12
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_drop (Drop item key) key KEY_KEY_Q
 
+#    Key for swapping items between main hand and offhand.
+#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
+keymap_swap_offhand (Swap hand items) key KEY_KEY_F
+
 #    Key to use view zoom when possible.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_zoom (View zoom key) key KEY_KEY_Z

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3261,6 +3261,13 @@ Player Inventory lists
 * `hand`: list containing an override for the empty hand
     * Is not created automatically, use `InvRef:set_size`
     * Is only used to enhance the empty hand's tool capabilities
+* `offhand`: list containing the offhand wielded item.
+    * Will be used for placements and secondary uses if the
+        main hand does not have any node_place_prediction, on_place
+        or on_secondary_use callbacks.
+    * Is passed to on_place and on_secondary_use callbacks; make sure
+        mods are aware of the itemstack not neccessarily being
+        located in the main hand.
 
 Colors
 ======
@@ -4707,13 +4714,13 @@ Privileges
 
 Privileges provide a means for server administrators to give certain players
 access to special abilities in the engine, games or mods.
-For example, game moderators may need to travel instantly to any place in the world, 
+For example, game moderators may need to travel instantly to any place in the world,
 this ability is implemented in `/teleport` command which requires `teleport` privilege.
 
 Registering privileges
 ----------------------
 
-A mod can register a custom privilege using `minetest.register_privilege` function 
+A mod can register a custom privilege using `minetest.register_privilege` function
 to give server administrators fine-grained access control over mod functionality.
 
 For consistency and practical reasons, privileges should strictly increase the abilities of the user.
@@ -4722,7 +4729,7 @@ Do not register custom privileges that e.g. restrict the player from certain in-
 Checking privileges
 -------------------
 
-A mod can call `minetest.check_player_privs` to test whether a player has privileges 
+A mod can call `minetest.check_player_privs` to test whether a player has privileges
 to perform an operation.
 Also, when registering a chat command with `minetest.register_chatcommand` a mod can
 declare privileges that the command requires using the `privs` field of the command
@@ -4786,7 +4793,7 @@ Minetest includes the following settings to control behavior of privileges:
 
    * `default_privs`: defines privileges granted to new players.
    * `basic_privs`: defines privileges that can be granted/revoked by players having
-    the `basic_privs` privilege. This can be used, for example, to give 
+    the `basic_privs` privilege. This can be used, for example, to give
     limited moderation powers to selected users.
 
 'minetest' namespace reference
@@ -7948,8 +7955,10 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         },
 
         on_place = function(itemstack, placer, pointed_thing),
-        -- When the 'place' key was pressed with the item in hand
+        -- When the 'place' key was pressed with the item one of the hands
         -- and a node was pointed at.
+        -- 'itemstack' may be the offhand item iff the main hand has
+        -- no on_place handler and no node_placement_prediction.
         -- Shall place item and return the leftover itemstack
         -- or nil to not modify the inventory.
         -- The placer may be any ObjectRef or nil.
@@ -7957,6 +7966,8 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
 
         on_secondary_use = function(itemstack, user, pointed_thing),
         -- Same as on_place but called when not pointing at a node.
+        -- 'itemstack' may be the offhand item iff the main hand has
+        -- no on_secondary_use handler.
         -- Function must return either nil if inventory shall not be modified,
         -- or an itemstack to replace the original itemstack.
         -- The user may be any ObjectRef or nil.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -3307,6 +3307,11 @@
 #    type: key
 # keymap_drop = KEY_KEY_Q
 
+#    Key for swapping items between main hand and offhand.
+#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
+#    type: key
+# keymap_swap_offhand = KEY_KEY_F
+
 #    Key to use view zoom when possible.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 #    type: key

--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -146,11 +146,12 @@ public:
 	void updateViewingRange();
 
 	// Start digging animation
-	// Pass 0 for left click, 1 for right click
-	void setDigging(s32 button);
+	// button: Pass 0 for left click, 1 for right click
+	// hand: 0 for main hand, 1 for offhand
+	void setDigging(s32 button, int hand);
 
 	// Replace the wielded item mesh
-	void wield(const ItemStack &item);
+	void wield(const ItemStack &item, int hand);
 
 	// Draw the wielded tool.
 	// This has to happen *after* the main scene is drawn.
@@ -196,7 +197,7 @@ private:
 	scene::ICameraSceneNode *m_cameranode = nullptr;
 
 	scene::ISceneManager *m_wieldmgr = nullptr;
-	WieldMeshSceneNode *m_wieldnode = nullptr;
+	WieldMeshSceneNode *m_wieldnode[2] = {nullptr, nullptr};
 
 	// draw control
 	MapDrawControl& m_draw_control;
@@ -246,15 +247,17 @@ private:
 	f32 m_view_bobbing_fall = 0.0f;
 
 	// Digging animation frame (0 <= m_digging_anim < 1)
-	f32 m_digging_anim = 0.0f;
+	f32 m_digging_anim[2] = {0.0f, 0.0f};
+
 	// If -1, no digging animation
 	// If 0, left-click digging animation
 	// If 1, right-click digging animation
-	s32 m_digging_button = -1;
+	s32 m_digging_button[2] = {-1, -1};
 
 	// Animation when changing wielded item
-	f32 m_wield_change_timer = 0.125f;
-	ItemStack m_wield_item_next;
+	f32 m_wield_change_timer[2] = {0.125f, 0.125f};
+	ItemStack m_wield_item_next[2];
+	bool m_offhand_wield_item_old;
 
 	CameraMode m_camera_mode = CAMERA_MODE_FIRST;
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1487,6 +1487,8 @@ bool Client::updateWieldedItem()
 		list->setModified(false);
 	if (auto *list = player->inventory.getList("hand"))
 		list->setModified(false);
+	if (auto *list = player->inventory.getList("offhand"))
+		list->setModified(false);
 
 	return true;
 }

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -275,6 +275,7 @@ public:
 	// Returns true if the inventory of the local player has been
 	// updated from the server. If it is true, it is set to false.
 	bool updateWieldedItem();
+	bool updateOffhandWieldedItem();
 
 	/* InventoryManager interface */
 	Inventory* getInventory(const InventoryLocation &loc) override;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -699,6 +699,7 @@ protected:
 	void processItemSelection(u16 *new_playeritem);
 
 	void dropSelectedItem(bool single_item = false);
+	void swapOffhand();
 	void openInventory();
 	void openConsole(float scale, const wchar_t *line=NULL);
 	void toggleFreeMove();
@@ -1889,6 +1890,8 @@ void Game::processKeyInput()
 {
 	if (wasKeyDown(KeyType::DROP)) {
 		dropSelectedItem(isKeyDown(KeyType::SNEAK));
+	} else if (wasKeyDown(KeyType::SWAP_OFFHAND)) {
+		swapOffhand();
 	} else if (wasKeyDown(KeyType::AUTOFORWARD)) {
 		toggleAutoforward();
 	} else if (wasKeyDown(KeyType::BACKWARD)) {
@@ -1996,7 +1999,6 @@ void Game::processKeyInput()
 	} else if (wasKeyDown(KeyType::QUICKTUNE_DEC)) {
 		quicktune->dec();
 	}
-
 	if (!isKeyDown(KeyType::JUMP) && runData.reset_jump_timer) {
 		runData.reset_jump_timer = false;
 		runData.jump_timer = 0.0f;
@@ -2051,6 +2053,34 @@ void Game::dropSelectedItem(bool single_item)
 	a->from_inv.setCurrentPlayer();
 	a->from_list = "main";
 	a->from_i = client->getEnv().getLocalPlayer()->getWieldIndex();
+	client->inventoryAction(a);
+}
+
+
+void Game::swapOffhand()
+{
+
+	IMoveAction *a = new IMoveAction();
+	a->count = 0;
+	a->from_inv.setCurrentPlayer();
+	a->from_list = "main";
+	a->from_i = client->getEnv().getLocalPlayer()->getWieldIndex();
+	a->to_inv.setCurrentPlayer();
+	a->to_list = "offhand";
+	a->to_i = 0;
+
+	ItemStack selected;
+	client->getEnv().getLocalPlayer()->getWieldedItem(&selected, nullptr);
+
+	if (selected.name == "") {
+		auto tmp_list = a->from_list;
+		auto tmp_i = a->from_i;
+		a->from_list = a->to_list;
+		a->from_i = a->to_i;
+		a->to_list = tmp_list;
+		a->to_i = tmp_i;
+	}
+
 	client->inventoryAction(a);
 }
 
@@ -4226,6 +4256,7 @@ void Game::showPauseMenu()
 		"- %s: place/use\n"
 		"- %s: sneak/climb down\n"
 		"- %s: drop item\n"
+		"- %s: swap hand items\n"
 		"- %s: inventory\n"
 		"- Mouse: turn/look\n"
 		"- Mouse wheel: select item\n"
@@ -4244,6 +4275,7 @@ void Game::showPauseMenu()
 		GET_KEY_NAME(keymap_place),
 		GET_KEY_NAME(keymap_sneak),
 		GET_KEY_NAME(keymap_drop),
+		GET_KEY_NAME(keymap_swap_offhand),
 		GET_KEY_NAME(keymap_inventory),
 		GET_KEY_NAME(keymap_chat)
 	);

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -43,6 +43,7 @@ void KeyCache::populate()
 	key[KeyType::AUTOFORWARD] = getKeySetting("keymap_autoforward");
 
 	key[KeyType::DROP] = getKeySetting("keymap_drop");
+	key[KeyType::SWAP_OFFHAND] = getKeySetting("keymap_swap_offhand");
 	key[KeyType::INVENTORY] = getKeySetting("keymap_inventory");
 	key[KeyType::CHAT] = getKeySetting("keymap_chat");
 	key[KeyType::CMD] = getKeySetting("keymap_cmd");

--- a/src/client/keys.h
+++ b/src/client/keys.h
@@ -42,6 +42,7 @@ public:
 
 		// Other
 		DROP,
+		SWAP_OFFHAND,
 		INVENTORY,
 		CHAT,
 		CMD,

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -79,6 +79,7 @@ void set_default_settings()
 	settings->setDefault("keymap_dig", "KEY_LBUTTON");
 	settings->setDefault("keymap_place", "KEY_RBUTTON");
 	settings->setDefault("keymap_drop", "KEY_KEY_Q");
+	settings->setDefault("keymap_swap_offhand", "KEY_KEY_F");
 	settings->setDefault("keymap_zoom", "KEY_KEY_Z");
 	settings->setDefault("keymap_inventory", "KEY_KEY_I");
 	settings->setDefault("keymap_aux1", "KEY_KEY_E");

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -58,6 +58,7 @@ enum
 	GUI_ID_KEY_CONSOLE_BUTTON,
 	GUI_ID_KEY_SNEAK_BUTTON,
 	GUI_ID_KEY_DROP_BUTTON,
+	GUI_ID_KEY_SWAP_OFFHAND_BUTTON,
 	GUI_ID_KEY_INVENTORY_BUTTON,
 	GUI_ID_KEY_HOTBAR_PREV_BUTTON,
 	GUI_ID_KEY_HOTBAR_NEXT_BUTTON,
@@ -409,6 +410,7 @@ void GUIKeyChangeMenu::init_keys()
 	this->add_key(GUI_ID_KEY_JUMP_BUTTON,         wgettext("Jump"),             "keymap_jump");
 	this->add_key(GUI_ID_KEY_SNEAK_BUTTON,        wgettext("Sneak"),            "keymap_sneak");
 	this->add_key(GUI_ID_KEY_DROP_BUTTON,         wgettext("Drop"),             "keymap_drop");
+	this->add_key(GUI_ID_KEY_SWAP_OFFHAND_BUTTON, wgettext("Swap hand items"),  "keymap_swap_offhand");
 	this->add_key(GUI_ID_KEY_INVENTORY_BUTTON,    wgettext("Inventory"),        "keymap_inventory");
 	this->add_key(GUI_ID_KEY_HOTBAR_PREV_BUTTON,  wgettext("Prev. item"),       "keymap_hotbar_previous");
 	this->add_key(GUI_ID_KEY_HOTBAR_NEXT_BUTTON,  wgettext("Next item"),        "keymap_hotbar_next");

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -76,6 +76,8 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	groups = def.groups;
 	node_placement_prediction = def.node_placement_prediction;
 	place_param2 = def.place_param2;
+	has_on_place = def.has_on_place;
+	has_on_secondary_use = def.has_on_secondary_use;
 	sound_place = def.sound_place;
 	sound_place_failed = def.sound_place_failed;
 	range = def.range;
@@ -120,6 +122,8 @@ void ItemDefinition::reset()
 	range = -1;
 	node_placement_prediction = "";
 	place_param2 = 0;
+	has_on_place = false;
+	has_on_secondary_use = false;
 }
 
 void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
@@ -166,6 +170,8 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	os << serializeString16(short_description);
 
 	os << place_param2;
+	writeU8(os, has_on_place);
+	writeU8(os, has_on_secondary_use);
 }
 
 void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
@@ -220,6 +226,8 @@ void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
 		short_description = deSerializeString16(is);
 
 		place_param2 = readU8(is); // 0 if missing
+		has_on_place = readU8(is);
+		has_on_secondary_use = readU8(is);
 	} catch(SerializationError &e) {};
 }
 

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -87,6 +87,8 @@ struct ItemDefinition
 	// "" = no prediction
 	std::string node_placement_prediction;
 	u8 place_param2;
+	bool has_on_place;
+	bool has_on_secondary_use;
 
 	/*
 		Some helpful methods

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -114,6 +114,46 @@ ItemStack &Player::getWieldedItem(ItemStack *selected, ItemStack *hand) const
 	return (hand && selected->name.empty()) ? *hand : *selected;
 }
 
+bool Player::getOffhandWieldedItem(ItemStack *offhand, ItemStack *place, IItemDefManager *idef, const PointedThing &pointed) const
+{
+	assert(offhand);
+
+	ItemStack main;
+
+	const InventoryList *mlist = inventory.getList("main");
+	const InventoryList *olist = inventory.getList("offhand");
+
+	if (olist)
+		*offhand = olist->getItem(0);
+
+	if (mlist && m_wield_index < mlist->getSize())
+		main = mlist->getItem(m_wield_index);
+
+	const ItemDefinition &main_def = main.getDefinition(idef);
+	const ItemDefinition &offhand_def = offhand->getDefinition(idef);
+	bool main_usable, offhand_usable;
+
+	// figure out which item to use for placements
+
+	if (pointed.type == POINTEDTHING_NODE) {
+		// an item can be used on nodes if it has a place handler or prediction
+		main_usable = main_def.has_on_place || main_def.node_placement_prediction != "";
+		offhand_usable = offhand_def.has_on_place || offhand_def.node_placement_prediction != "";
+	} else {
+		// an item can be used on anything else if it has a secondary use handler
+		main_usable = main_def.has_on_secondary_use;
+		offhand_usable = offhand_def.has_on_secondary_use;
+	}
+
+	// main hand has priority
+	bool use_offhand = offhand_usable && !main_usable;
+
+	if (place)
+		*place = use_offhand ? *offhand : main;
+
+	return use_offhand;
+}
+
 u32 Player::addHud(HudElement *toadd)
 {
 	MutexAutoLock lock(m_mutex);

--- a/src/player.h
+++ b/src/player.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "constants.h"
 #include "network/networkprotocol.h"
 #include "util/basic_macros.h"
+#include "util/pointedthing.h"
 #include <list>
 #include <mutex>
 
@@ -187,6 +188,10 @@ public:
 
 	// Returns non-empty `selected` ItemStack. `hand` is a fallback, if specified
 	ItemStack &getWieldedItem(ItemStack *selected, ItemStack *hand) const;
+
+	// item currently in secondary hand is returned in `offhand`
+	// item to use for place / secondary_use (either main or offhand) is (optionally) returned in `place`
+	bool getOffhandWieldedItem(ItemStack *offhand, ItemStack *place, IItemDefManager *idef, const PointedThing &pointed) const;
 	void setWieldIndex(u16 index);
 	u16 getWieldIndex() const { return m_wield_index; }
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -81,6 +81,16 @@ void read_item_definition(lua_State* L, int index,
 	def.usable = lua_isfunction(L, -1);
 	lua_pop(L, 1);
 
+	lua_pushstring(L, "on_place");
+	lua_rawget(L, index);
+	def.has_on_place = lua_isfunction(L, -1);
+	lua_pop(L, 1);
+
+	lua_pushstring(L, "on_secondary_use");
+	lua_rawget(L, index);
+	def.has_on_secondary_use = lua_isfunction(L, -1);
+	lua_pop(L, 1);
+
 	getboolfield(L, index, "liquids_pointable", def.liquids_pointable);
 
 	lua_getfield(L, index, "tool_capabilities");

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -525,11 +525,26 @@ ItemStack PlayerSAO::getWieldedItem(ItemStack *selected, ItemStack *hand) const
 	return m_player->getWieldedItem(selected, hand);
 }
 
+bool PlayerSAO::getOffhandWieldedItem(ItemStack *offhand, ItemStack *place, IItemDefManager *itemdef_manager, PointedThing pointed) const
+{
+	return m_player->getOffhandWieldedItem(offhand, place, itemdef_manager, pointed);
+}
+
 bool PlayerSAO::setWieldedItem(const ItemStack &item)
 {
 	InventoryList *mlist = m_player->inventory.getList(getWieldList());
 	if (mlist) {
 		mlist->changeItem(m_player->getWieldIndex(), item);
+		return true;
+	}
+	return false;
+}
+
+bool PlayerSAO::setOffhandWieldedItem(const ItemStack &item)
+{
+	InventoryList *olist = m_player->inventory.getList("offhand");
+	if (olist) {
+		olist->changeItem(0, item);
 		return true;
 	}
 	return false;

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "network/networkprotocol.h"
 #include "unit_sao.h"
 #include "util/numeric.h"
+#include "util/pointedthing.h"
 
 /*
 	PlayerSAO needs some internals exposed.
@@ -130,7 +131,9 @@ public:
 	std::string getWieldList() const override { return "main"; }
 	u16 getWieldIndex() const override;
 	ItemStack getWieldedItem(ItemStack *selected, ItemStack *hand = nullptr) const override;
+	bool getOffhandWieldedItem(ItemStack *offhand, ItemStack *place, IItemDefManager *itemdef_manager, PointedThing pointed) const;
 	bool setWieldedItem(const ItemStack &item) override;
+	bool setOffhandWieldedItem(const ItemStack &item);
 
 	/*
 		PlayerSAO-specific

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -1072,6 +1072,8 @@ fake_function() {
 	gettext("Key for taking screenshots.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");
 	gettext("Drop item key");
 	gettext("Key for dropping the currently selected item.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");
+	gettext("Swap hand items");
+	gettext("Key for swapping items between main hand and offhand.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");
 	gettext("View zoom key");
 	gettext("Key to use view zoom when possible.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");
 	gettext("Hotbar slot 1 key");


### PR DESCRIPTION
Adds a key binding ('F' by default) that swaps the item currently in your main hand with the one currently in your offhand,

## To do

**Depends on #11016 to be merged first.**
Otherwise ready for review.

In the future, this should be added to android UI as well.

## How to test

1. Follow testing instructions for #11016
2. Press F while there is an item in main hand an offhand is empty, verify it works
3. Press F while there is an item in offhand an main hand is empty, verify it works
4. Press F while there is an item each hand, verify it works