### PR TITLE
Physics overrides: Move values to a common struct

### DIFF
--- a/doc/breakages.md
+++ b/doc/breakages.md
@@ -6,3 +6,4 @@ This document contains a list of breaking changes to be made in the next major v
 * `get_sky()` returns a table (without arg)
 * `game.conf` name/id mess
 * remove `depends.txt` / `description.txt` (would simplify ContentDB and Minetest code a little)
+* remove undocumented `set_physics_override(num, num, num)`

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -199,7 +199,7 @@ void ClientEnvironment::step(float dtime)
 			v3f speed = lplayer->getSpeed();
 			if (!is_climbing && !lplayer->in_liquid)
 				speed.Y -= lplayer->movement_gravity *
-					lplayer->physics_override_gravity * dtime_part * 2.0f;
+					lplayer->physics_override.gravity * dtime_part * 2.0f;
 
 			// Liquid floating / sinking
 			if (!is_climbing && lplayer->in_liquid &&

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1762,21 +1762,20 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_speed = readF32(is);
 		float override_jump = readF32(is);
 		float override_gravity = readF32(is);
-		// these are sent inverted so we get true when the server sends nothing
+		// MT 0.4.10 legacy: send inverted for detault `true` if the server sends nothing
 		bool sneak = !readU8(is);
 		bool sneak_glitch = !readU8(is);
 		bool new_move = !readU8(is);
 
 
-		if(m_is_local_player)
-		{
-			LocalPlayer *player = m_env->getLocalPlayer();
-			player->physics_override_speed = override_speed;
-			player->physics_override_jump = override_jump;
-			player->physics_override_gravity = override_gravity;
-			player->physics_override_sneak = sneak;
-			player->physics_override_sneak_glitch = sneak_glitch;
-			player->physics_override_new_move = new_move;
+		if (m_is_local_player) {
+			auto &phys = m_env->getLocalPlayer()->physics_override;
+			phys.speed = override_speed;
+			phys.jump = override_jump;
+			phys.gravity = override_gravity;
+			phys.sneak = sneak;
+			phys.sneak_glitch = sneak_glitch;
+			phys.new_move = new_move;
 		}
 	} else if (cmd == AO_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -117,7 +117,7 @@ bool LocalPlayer::updateSneakNode(Map *map, const v3f &position,
 			continue;
 		// And the node(s) above have to be nonwalkable
 		bool ok = true;
-		if (!physics_override_sneak_glitch) {
+		if (!physics_override.sneak_glitch) {
 			u16 height =
 				ceilf((m_collisionbox.MaxEdge.Y - m_collisionbox.MinEdge.Y) / BS);
 			for (u16 y = 1; y <= height; y++) {
@@ -149,7 +149,7 @@ bool LocalPlayer::updateSneakNode(Map *map, const v3f &position,
 	node.getCollisionBoxes(nodemgr, &nodeboxes);
 	m_sneak_node_bb_top = getNodeBoundingBox(nodeboxes);
 
-	if (physics_override_sneak_glitch) {
+	if (physics_override.sneak_glitch) {
 		// Detect sneak ladder:
 		// Node two meters above sneak node must be solid
 		node = map->getNode(m_sneak_node + v3s16(0, 2, 0),
@@ -173,7 +173,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		m_standing_node = floatToInt(m_position, BS);
 
 	// Temporary option for old move code
-	if (!physics_override_new_move) {
+	if (!physics_override.new_move) {
 		old_move(dtime, env, pos_max_d, collision_info);
 		return;
 	}
@@ -301,7 +301,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		&position, &m_speed, accel_f);
 
 	bool could_sneak = control.sneak && !free_move && !in_liquid &&
-		!is_climbing && physics_override_sneak;
+		!is_climbing && physics_override.sneak;
 
 	// Add new collisions to the vector
 	if (collision_info && !free_move) {
@@ -376,7 +376,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		}
 
 		if (y_diff > 0 && m_speed.Y <= 0.0f &&
-				(physics_override_sneak_glitch || y_diff < BS * 0.6f)) {
+				(physics_override.sneak_glitch || y_diff < BS * 0.6f)) {
 			// Move player to the maximal height when falling or when
 			// the ledge is climbed on the next step.
 
@@ -440,7 +440,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	// Jump key pressed while jumping off from a bouncy block
 	if (m_can_jump && control.jump && itemgroup_get(f.groups, "bouncy") &&
 		m_speed.Y >= -0.5f * BS) {
-		float jumpspeed = movement_speed_jump * physics_override_jump;
+		float jumpspeed = movement_speed_jump * physics_override.jump;
 		if (m_speed.Y > 1.0f) {
 			// Reduce boost when speed already is high
 			m_speed.Y += jumpspeed / (1.0f + (m_speed.Y / 16.0f));
@@ -588,7 +588,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			*/
 			v3f speedJ = getSpeed();
 			if (speedJ.Y >= -0.5f * BS) {
-				speedJ.Y = movement_speed_jump * physics_override_jump;
+				speedJ.Y = movement_speed_jump * physics_override.jump;
 				setSpeed(speedJ);
 				m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_JUMP));
 			}
@@ -647,8 +647,8 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	}
 
 	// Accelerate to target speed with maximum increment
-	accelerate((speedH + speedV) * physics_override_speed,
-		incH * physics_override_speed * slip_factor, incV * physics_override_speed,
+	accelerate((speedH + speedV) * physics_override.speed,
+		incH * physics_override.speed * slip_factor, incV * physics_override.speed,
 		pitch_move);
 }
 
@@ -855,7 +855,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	*/
 	if (control.sneak && m_sneak_node_exists &&
 			!(fly_allowed && player_settings.free_move) && !in_liquid &&
-			physics_override_sneak) {
+			physics_override.sneak) {
 		f32 maxd = 0.5f * BS + sneak_max;
 		v3f lwn_f = intToFloat(m_sneak_node, BS);
 		position.X = rangelim(position.X, lwn_f.X - maxd, lwn_f.X + maxd);
@@ -926,7 +926,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		m_need_to_get_new_sneak_node = true;
 	}
 
-	if (m_need_to_get_new_sneak_node && physics_override_sneak) {
+	if (m_need_to_get_new_sneak_node && physics_override.sneak) {
 		m_sneak_node_bb_ymax = 0.0f;
 		v3s16 pos_i_bottom = floatToInt(position - v3f(0.0f, position_y_mod, 0.0f), BS);
 		v2f player_p2df(position.X, position.Z);
@@ -956,7 +956,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 			if (!is_valid_position || nodemgr->get(node).walkable)
 				continue;
 			// If not 'sneak_glitch' the node 2 nodes above it has to be nonwalkable
-			if (!physics_override_sneak_glitch) {
+			if (!physics_override.sneak_glitch) {
 				node = map->getNode(p + v3s16(0, 2, 0), &is_valid_position);
 				if (!is_valid_position || nodemgr->get(node).walkable)
 					continue;
@@ -1032,7 +1032,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	// Jump key pressed while jumping off from a bouncy block
 	if (m_can_jump && control.jump && itemgroup_get(f.groups, "bouncy") &&
 			m_speed.Y >= -0.5f * BS) {
-		float jumpspeed = movement_speed_jump * physics_override_jump;
+		float jumpspeed = movement_speed_jump * physics_override.jump;
 		if (m_speed.Y > 1.0f) {
 			// Reduce boost when speed already is high
 			m_speed.Y += jumpspeed / (1.0f + (m_speed.Y / 16.0f));

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -62,14 +62,6 @@ public:
 	bool swimming_vertical = false;
 	bool swimming_pitch = false;
 
-	float physics_override_speed = 1.0f;
-	float physics_override_jump = 1.0f;
-	float physics_override_gravity = 1.0f;
-	bool physics_override_sneak = true;
-	bool physics_override_sneak_glitch = false;
-	// Temporary option for old move code
-	bool physics_override_new_move = true;
-
 	void move(f32 dtime, Environment *env, f32 pos_max_d);
 	void move(f32 dtime, Environment *env, f32 pos_max_d,
 			std::vector<CollisionInfo> *collision_info);

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -875,7 +875,7 @@ void ParticleManager::addNodeParticle(IGameDef *gamedef,
 	);
 	p.acc = v3f(
 		0.0f,
-		-player->movement_gravity * player->physics_override_gravity / BS,
+		-player->movement_gravity * player->physics_override.gravity / BS,
 		0.0f
 	);
 	p.pos = v3f(

--- a/src/player.h
+++ b/src/player.h
@@ -104,6 +104,7 @@ struct PlayerPhysicsOverride
 
 	bool sneak = true;
 	bool sneak_glitch = false;
+	// "Temporary" option for old move code
 	bool new_move = true;
 };
 

--- a/src/player.h
+++ b/src/player.h
@@ -96,6 +96,17 @@ struct PlayerControl
 	float movement_direction = 0.0f;
 };
 
+struct PlayerPhysicsOverride
+{
+	float speed = 1.f;
+	float jump = 1.f;
+	float gravity = 1.f;
+
+	bool sneak = true;
+	bool sneak_glitch = false;
+	bool new_move = true;
+};
+
 struct PlayerSettings
 {
 	bool free_move = false;
@@ -182,6 +193,7 @@ public:
 
 	PlayerControl control;
 	const PlayerControl& getPlayerControl() { return control; }
+	PlayerPhysicsOverride physics_override;
 	PlayerSettings &getPlayerSettings() { return m_player_settings; }
 	static void settingsChangedCallback(const std::string &name, void *data);
 

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -157,23 +157,24 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 {
 	LocalPlayer *player = getobject(L, 1);
 
+	const auto &phys = player->physics_override;
 	lua_newtable(L);
-	lua_pushnumber(L, player->physics_override_speed);
+	lua_pushnumber(L, phys.speed);
 	lua_setfield(L, -2, "speed");
 
-	lua_pushnumber(L, player->physics_override_jump);
+	lua_pushnumber(L, phys.jump);
 	lua_setfield(L, -2, "jump");
 
-	lua_pushnumber(L, player->physics_override_gravity);
+	lua_pushnumber(L, phys.gravity);
 	lua_setfield(L, -2, "gravity");
 
-	lua_pushboolean(L, player->physics_override_sneak);
+	lua_pushboolean(L, phys.sneak);
 	lua_setfield(L, -2, "sneak");
 
-	lua_pushboolean(L, player->physics_override_sneak_glitch);
+	lua_pushboolean(L, phys.sneak_glitch);
 	lua_setfield(L, -2, "sneak_glitch");
 
-	lua_pushboolean(L, player->physics_override_new_move);
+	lua_pushboolean(L, phys.new_move);
 	lua_setfield(L, -2, "new_move");
 
 	return 1;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1434,14 +1434,17 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 	if (playersao == nullptr)
 		return 0;
 
+	RemotePlayer *player = playersao->getPlayer();
+	auto &phys = player->physics_override;
+
 	if (lua_istable(L, 2)) {
 		bool modified = false;
-		modified |= getfloatfield(L, 2, "speed", playersao->m_physics_override_speed);
-		modified |= getfloatfield(L, 2, "jump", playersao->m_physics_override_jump);
-		modified |= getfloatfield(L, 2, "gravity", playersao->m_physics_override_gravity);
-		modified |= getboolfield(L, 2, "sneak", playersao->m_physics_override_sneak);
-		modified |= getboolfield(L, 2, "sneak_glitch", playersao->m_physics_override_sneak_glitch);
-		modified |= getboolfield(L, 2, "new_move", playersao->m_physics_override_new_move);
+		modified |= getfloatfield(L, 2, "speed", phys.speed);
+		modified |= getfloatfield(L, 2, "jump", phys.jump);
+		modified |= getfloatfield(L, 2, "gravity", phys.gravity);
+		modified |= getboolfield(L, 2, "sneak", phys.sneak);
+		modified |= getboolfield(L, 2, "sneak_glitch", phys.sneak_glitch);
+		modified |= getboolfield(L, 2, "new_move", phys.new_move);
 		if (modified)
 			playersao->m_physics_override_sent = false;
 	} else {
@@ -1450,15 +1453,15 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		log_deprecated(L, "Deprecated use of set_physics_override(num, num, num)");
 
 		if (!lua_isnil(L, 2)) {
-			playersao->m_physics_override_speed = lua_tonumber(L, 2);
+			phys.speed = lua_tonumber(L, 2);
 			playersao->m_physics_override_sent = false;
 		}
 		if (!lua_isnil(L, 3)) {
-			playersao->m_physics_override_jump = lua_tonumber(L, 3);
+			phys.jump = lua_tonumber(L, 3);
 			playersao->m_physics_override_sent = false;
 		}
 		if (!lua_isnil(L, 4)) {
-			playersao->m_physics_override_gravity = lua_tonumber(L, 4);
+			phys.gravity = lua_tonumber(L, 4);
 			playersao->m_physics_override_sent = false;
 		}
 	}
@@ -1470,22 +1473,23 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO *playersao = getplayersao(ref);
-	if (playersao == nullptr)
+	RemotePlayer *player = getplayer(ref);
+	if (player == nullptr)
 		return 0;
 
+	const auto &phys = player->physics_override;
 	lua_newtable(L);
-	lua_pushnumber(L, playersao->m_physics_override_speed);
+	lua_pushnumber(L, phys.speed);
 	lua_setfield(L, -2, "speed");
-	lua_pushnumber(L, playersao->m_physics_override_jump);
+	lua_pushnumber(L, phys.jump);
 	lua_setfield(L, -2, "jump");
-	lua_pushnumber(L, playersao->m_physics_override_gravity);
+	lua_pushnumber(L, phys.gravity);
 	lua_setfield(L, -2, "gravity");
-	lua_pushboolean(L, playersao->m_physics_override_sneak);
+	lua_pushboolean(L, phys.sneak);
 	lua_setfield(L, -2, "sneak");
-	lua_pushboolean(L, playersao->m_physics_override_sneak_glitch);
+	lua_pushboolean(L, phys.sneak_glitch);
 	lua_setfield(L, -2, "sneak_glitch");
-	lua_pushboolean(L, playersao->m_physics_override_new_move);
+	lua_pushboolean(L, phys.new_move);
 	lua_setfield(L, -2, "new_move");
 	return 1;
 }

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -305,17 +305,23 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 
 std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 {
+	if (!m_player) {
+		// Will output a format warning client-side
+		return "";
+	}
+
+	const auto &phys = m_player->physics_override;
 	std::ostringstream os(std::ios::binary);
 	// command
 	writeU8(os, AO_CMD_SET_PHYSICS_OVERRIDE);
 	// parameters
-	writeF32(os, m_physics_override_speed);
-	writeF32(os, m_physics_override_jump);
-	writeF32(os, m_physics_override_gravity);
-	// these are sent inverted so we get true when the server sends nothing
-	writeU8(os, !m_physics_override_sneak);
-	writeU8(os, !m_physics_override_sneak_glitch);
-	writeU8(os, !m_physics_override_new_move);
+	writeF32(os, phys.speed);
+	writeF32(os, phys.jump);
+	writeF32(os, phys.gravity);
+	// MT 0.4.10 legacy: send inverted for detault `true` if the server sends nothing
+	writeU8(os, !phys.sneak);
+	writeU8(os, !phys.sneak_glitch);
+	writeU8(os, !phys.new_move);
 	return os.str();
 }
 
@@ -604,10 +610,10 @@ bool PlayerSAO::checkMovementCheat()
 		player_max_walk = m_player->movement_speed_fast; // Fast speed
 	else
 		player_max_walk = m_player->movement_speed_walk; // Normal speed
-	player_max_walk *= m_physics_override_speed;
+	player_max_walk *= m_player->physics_override.speed;
 	player_max_walk = MYMAX(player_max_walk, override_max_H);
 
-	player_max_jump = m_player->movement_speed_jump * m_physics_override_jump;
+	player_max_jump = m_player->movement_speed_jump * m_player->physics_override.jump;
 	// FIXME: Bouncy nodes cause practically unbound increase in Y speed,
 	//        until this can be verified correctly, tolerate higher jumping speeds
 	player_max_jump *= 2.0;

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -221,12 +221,6 @@ private:
 	Metadata m_meta;
 
 public:
-	float m_physics_override_speed = 1.0f;
-	float m_physics_override_jump = 1.0f;
-	float m_physics_override_gravity = 1.0f;
-	bool m_physics_override_sneak = true;
-	bool m_physics_override_sneak_glitch = false;
-	bool m_physics_override_new_move = true;
 	bool m_physics_override_sent = false;
 };
 


### PR DESCRIPTION
Code tidy. This moves all physics overrides to a dedicated struct.

This is to avoid further chaos before #11465 gets merged. A server-sided physics modifier API (#10731) could still be built on top of these changes by recycling this struct.

## To do

This PR is Ready for Review.

## How to test

1. It must compile
2. The changes look OK
