### PR TITLE
[NO SQUASH] Inventory: Fix order of callbacks when swapping items

### DIFF
--- a/builtin/game/tests/test_moveaction.lua
+++ b/builtin/game/tests/test_moveaction.lua
@@ -1,0 +1,84 @@
+-- Table to keep track of callback executions
+-- [i + 0] = count of expected patterns of index (i + 1)
+-- [i + 1] = pattern to check
+local PATTERN_NORMAL = { 4, "allow_%w", 2, "on_take", 1, "on_put", 1 }
+local PATTERN_SWAP   = { 8, "allow_%w", 4, "on_take", 2, "on_put", 2 }
+local exec_listing = {} -- List of logged callbacks (e.g. "on_take", "allow_put")
+
+-- Checks whether the logged callbacks equal the expected pattern
+core.__helper_check_callbacks = function(expect_swap)
+	local exec_pattern = expect_swap and PATTERN_SWAP or PATTERN_NORMAL
+	local ok = #exec_listing == exec_pattern[1]
+	if ok then
+		local list_index = 1
+		for i = 2, #exec_pattern, 2 do
+			for n = 1, exec_pattern[i + 1] do
+				-- Match the list for "n" occurrences of the wanted callback name pattern
+				ok = exec_listing[list_index]:find(exec_pattern[i])
+				list_index = list_index + 1
+				if not ok then break end
+			end
+			if not ok then break end
+		end
+	end
+
+	if not ok then
+		print("Execution order mismatch!")
+		print("Expected patterns: ", dump(exec_pattern))
+		print("Got list: ", dump(exec_listing))
+	end
+	exec_listing = {}
+	return ok
+end
+
+-- Uncomment the other line for easier callback debugging
+local log = function(...) end
+--local log = print
+
+minetest.register_allow_player_inventory_action(function(_, action, inv, info)
+	log("\tallow " .. action, info.count or info.stack:to_string())
+
+	if action == "move" then
+		-- testMoveFillStack
+		return info.count
+	end
+
+	if action == "take" or action == "put" then
+		assert(not info.stack:is_empty(), "Stack empty in: " .. action)
+
+		-- testMoveUnallowed
+		-- testSwapFromUnallowed
+		-- testSwapToUnallowed
+		if info.stack:get_name() == "default:takeput_deny" then
+			return 0
+		end
+
+		-- testMovePartial
+		if info.stack:get_name() == "default:takeput_max_5" then
+			return 5
+		end
+
+		-- testCallbacks
+		if info.stack:get_name():find("default:takeput_cb_%d") then
+			-- Log callback as executed
+			table.insert(exec_listing, "allow_" .. action)
+			return -- Unlimited
+		end
+	end
+
+	return -- Unlimited
+end)
+
+minetest.register_on_player_inventory_action(function(_, action, inv, info)
+	log("\ton " .. action, info.count or info.stack:to_string())
+
+	if action == "take" or action == "put" then
+		assert(not info.stack:is_empty(), action)
+
+		if info.stack:get_name():find("default:takeput_cb_%d") then
+			-- Log callback as executed
+			table.insert(exec_listing, "on_" .. action)
+			return
+		end
+	end
+end)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3620,6 +3620,19 @@ Player Inventory lists
     * Is not created automatically, use `InvRef:set_size`
     * Is only used to enhance the empty hand's tool capabilities
 
+ItemStack transaction order
+---------------------------
+
+This list describes the situation for non-empty ItemStacks in both slots
+that cannot be stacked at all, hence triggering an ItemStack swap operation.
+Put/take callbacks on empty ItemStack are not executed.
+
+1. The "allow take" and "allow put" callbacks are each run once for the source
+   and destination inventory.
+2. The allowed ItemStacks are exchanged.
+3. The "on take" callbacks are run for the source and destination inventories
+4. The "on put" callbacks are run for the source and destination inventories
+
 Colors
 ======
 

--- a/games/devtest/mods/chest/chest.lua
+++ b/games/devtest/mods/chest/chest.lua
@@ -29,17 +29,24 @@ minetest.register_node("chest:chest", {
 		return inv:is_empty("main")
 	end,
 	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
-		print_to_everything("Chest: ".. player:get_player_name() .. " triggered 'allow put' event for " .. stack:to_string())
-		return stack:get_count()
+		print_to_everything("Chest: ".. player:get_player_name() .. " triggered 'allow put' (10) event for " .. stack:to_string())
+		return 10
 	end,
 	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
-		print_to_everything("Chest: ".. player:get_player_name() .. " triggered 'allow take' event for " .. stack:to_string())
-		return stack:get_count()
+		print_to_everything("Chest: ".. player:get_player_name() .. " triggered 'allow take' (20) event for " .. stack:to_string())
+		return 20
+	end,
+	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
+		print_to_everything("Chest: ".. player:get_player_name() .. " triggered 'allow move' (30) event")
+		return 30
 	end,
 	on_metadata_inventory_put = function(pos, listname, index, stack, player)
 		print_to_everything("Chest: ".. player:get_player_name() .. " put " .. stack:to_string())
 	end,
 	on_metadata_inventory_take = function(pos, listname, index, stack, player)
 		print_to_everything("Chest: ".. player:get_player_name() .. " took " .. stack:to_string())
+	end,
+	on_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
+		print_to_everything("Chest: ".. player:get_player_name() .. " moved " .. count)
 	end,
 })

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -756,54 +756,53 @@ void InventoryList::moveItemSomewhere(u32 i, InventoryList *dest, u32 count)
 
 	if (!leftover.empty()) {
 		// Add the remaining part back to the source item
-		addItem(i, leftover);
+		ItemStack &source = getItem(i);
+		source.add(leftover.count); // do NOT use addItem to allow oversized stacks!
 	}
 }
 
-u32 InventoryList::moveItem(u32 i, InventoryList *dest, u32 dest_i,
+ItemStack InventoryList::moveItem(u32 i, InventoryList *dest, u32 dest_i,
 		u32 count, bool swap_if_needed, bool *did_swap)
 {
+	ItemStack moved;
 	if (this == dest && i == dest_i)
-		return count;
+		return moved;
 
 	// Take item from source list
-	ItemStack item1;
 	if (count == 0)
-		item1 = changeItem(i, ItemStack());
+		moved = changeItem(i, ItemStack());
 	else
-		item1 = takeItem(i, count);
-
-	if (item1.empty())
-		return 0;
+		moved = takeItem(i, count);
 
 	// Try to add the item to destination list
-	count = item1.count;
-	item1 = dest->addItem(dest_i, item1);
+	ItemStack leftover = dest->addItem(dest_i, moved);
 
 	// If something is returned, the item was not fully added
-	if (!item1.empty()) {
-		bool nothing_added = (item1.count == count);
+	if (!leftover.empty()) {
+		// Keep track of how many we actually moved
+		moved.remove(leftover.count);
 
 		// Add any leftover stack back to the source stack.
-		item1.add(getItem(i).count); // leftover + source count
-		changeItem(i, item1); // do NOT use addItem to allow oversized stacks!
+		leftover.add(getItem(i).count); // leftover + source count
+		changeItem(i, leftover); // do NOT use addItem to allow oversized stacks!
+		leftover.clear();
 
 		// Swap if no items could be moved
-		if (nothing_added && swap_if_needed) {
+		if (moved.empty() && swap_if_needed) {
 			// Tell that we swapped
 			if (did_swap != NULL) {
 				*did_swap = true;
 			}
 			// Take item from source list
-			item1 = changeItem(i, ItemStack());
+			moved = changeItem(i, ItemStack());
 			// Adding was not possible, swap the items.
-			ItemStack item2 = dest->changeItem(dest_i, item1);
+			ItemStack item2 = dest->changeItem(dest_i, moved);
 			// Put item from destination list to the source list
 			changeItem(i, item2);
-			item1.clear(); // no leftover
 		}
 	}
-	return (count - item1.count);
+
+	return moved;
 }
 
 void InventoryList::checkResizeLock()

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -286,8 +286,8 @@ public:
 
 	// Move an item to a different list (or a different stack in the same list)
 	// count is the maximum number of items to move (0 for everything)
-	// returns number of moved items
-	u32 moveItem(u32 i, InventoryList *dest, u32 dest_i,
+	// returns the moved stack
+	ItemStack moveItem(u32 i, InventoryList *dest, u32 dest_i,
 		u32 count = 0, bool swap_if_needed = true, bool *did_swap = NULL);
 
 	// like moveItem, but without a fixed destination index

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -162,7 +162,20 @@ void IMoveAction::swapDirections()
 	std::swap(from_i, to_i);
 }
 
-void IMoveAction::onPutAndOnTake(const ItemStack &src_item, ServerActiveObject *player) const
+void IMoveAction::onTake(const ItemStack &src_item, ServerActiveObject *player) const
+{
+	ServerScripting *sa = PLAYER_TO_SA(player);
+	if (from_inv.type == InventoryLocation::DETACHED)
+		sa->detached_inventory_OnTake(*this, src_item, player);
+	else if (from_inv.type == InventoryLocation::NODEMETA)
+		sa->nodemeta_inventory_OnTake(*this, src_item, player);
+	else if (from_inv.type == InventoryLocation::PLAYER)
+		sa->player_inventory_OnTake(*this, src_item, player);
+	else
+		assert(false);
+}
+
+void IMoveAction::onPut(const ItemStack &src_item, ServerActiveObject *player) const
 {
 	ServerScripting *sa = PLAYER_TO_SA(player);
 	if (to_inv.type == InventoryLocation::DETACHED)
@@ -171,15 +184,6 @@ void IMoveAction::onPutAndOnTake(const ItemStack &src_item, ServerActiveObject *
 		sa->nodemeta_inventory_OnPut(*this, src_item, player);
 	else if (to_inv.type == InventoryLocation::PLAYER)
 		sa->player_inventory_OnPut(*this, src_item, player);
-	else
-		assert(false);
-
-	if (from_inv.type == InventoryLocation::DETACHED)
-		sa->detached_inventory_OnTake(*this, src_item, player);
-	else if (from_inv.type == InventoryLocation::NODEMETA)
-		sa->nodemeta_inventory_OnTake(*this, src_item, player);
-	else if (from_inv.type == InventoryLocation::PLAYER)
-		sa->player_inventory_OnTake(*this, src_item, player);
 	else
 		assert(false);
 }
@@ -244,6 +248,8 @@ int IMoveAction::allowMove(int try_take_count, ServerActiveObject *player) const
 
 void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGameDef *gamedef)
 {
+	/// Necessary for executing Lua callbacks which may manipulate the inventory,
+	/// hence invalidate pointers needed by IMoveAction::apply
 	auto get_borrow_checked_invlist = [mgr](const InventoryLocation &invloc,
 			const std::string &listname) -> InventoryList::ResizeLocked
 	{
@@ -375,6 +381,8 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 	bool allow_swap = !list_to->itemFits(to_i, src_item, &restitem)
 		&& restitem.count == src_item.count
 		&& !caused_by_move_somewhere;
+	// move_count : How many items that were moved at the end
+	// count      : Total items "in the queue" of being moved. Do not touch.
 	move_count = src_item.count - restitem.count;
 
 	// Shift-click: Cannot fill this stack, proceed with next slot
@@ -383,10 +391,11 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 	}
 
 	if (allow_swap) {
-		// Swap will affect the entire stack if it can performed.
+		// Swap will affect the entire stack (= count) if it can performed.
 		src_item = list_from->getItem(from_i);
-		count = src_item.count;
+		move_count = src_item.count;
 	}
+	src_item.count = move_count; // Temporary movement stack
 
 	if (from_inv == to_inv) {
 		// Move action within the same inventory
@@ -409,16 +418,9 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			src_can_take_count = dst_can_put_count = 0;
 	} else {
 		// Take from one inventory, put into another
-		int src_item_count = src_item.count;
-		if (caused_by_move_somewhere)
-			// When moving somewhere: temporarily use the actual movable stack
-			// size to ensure correct callback execution.
-			src_item.count = move_count;
 		dst_can_put_count = allowPut(src_item, player);
 		src_can_take_count = allowTake(src_item, player);
-		if (caused_by_move_somewhere)
-			// Reset source item count
-			src_item.count = src_item_count;
+
 		bool swap_expected = allow_swap;
 		allow_swap = allow_swap
 			&& (src_can_take_count == -1 || src_can_take_count >= src_item.count)
@@ -440,25 +442,20 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			src_can_take_count = dst_can_put_count = 0;
 	}
 
-	int old_count = count;
+	int old_move_count = move_count;
 
-	/* Modify count according to collected data */
-	count = src_item.count;
-	if (src_can_take_count != -1 && count > src_can_take_count)
-		count = src_can_take_count;
-	if (dst_can_put_count != -1 && count > dst_can_put_count)
-		count = dst_can_put_count;
+	// Apply limits given by allow_* callbacks
+	if (src_can_take_count != -1)
+		move_count = (u32)std::min<s32>(src_can_take_count, move_count);
+	if (dst_can_put_count != -1)
+		move_count = (u32)std::min<s32>(dst_can_put_count, move_count);
 
-	/* Limit according to source item count */
-	if (count > list_from->getItem(from_i).count)
-		count = list_from->getItem(from_i).count;
+	// allow_* callbacks should not modify the stack - but if they do - handle that.
+	if (move_count > list_from->getItem(from_i).count)
+		move_count = list_from->getItem(from_i).count;
 
 	/* If no items will be moved, don't go further */
-	if (count == 0) {
-		if (caused_by_move_somewhere)
-			// Set move count to zero, as no items have been moved
-			move_count = 0;
-
+	if (move_count == 0) {
 		// Undo client prediction. See 'clientApply'
 		if (from_inv.type == InventoryLocation::PLAYER)
 			list_from->setModified();
@@ -467,7 +464,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			list_to->setModified();
 
 		infostream<<"IMoveAction::apply(): move was completely disallowed:"
-				<<" count="<<old_count
+				<<" move_count="<<old_move_count
 				<<" from inv=\""<<from_inv.dump()<<"\""
 				<<" list=\""<<from_list<<"\""
 				<<" i="<<from_i
@@ -479,8 +476,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		return;
 	}
 
-	src_item = list_from->getItem(from_i);
-	src_item.count = count;
+	// Backups stacks for infinite sources
 	ItemStack from_stack_was = list_from->getItem(from_i);
 	ItemStack to_stack_was = list_to->getItem(to_i);
 
@@ -491,13 +487,13 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		same as source), nothing happens
 	*/
 	bool did_swap = false;
-	move_count = list_from->moveItem(from_i,
-		list_to.get(), to_i, count, allow_swap, &did_swap);
-	if (caused_by_move_somewhere)
-		count = old_count;
+	src_item = list_from->moveItem(from_i,
+		list_to.get(), to_i, move_count, allow_swap, &did_swap);
+	move_count = src_item.count;
+
 	assert(allow_swap == did_swap);
 
-	// If source is infinite, reset it's stack
+	// If source is infinite, reset its stack
 	if (src_can_take_count == -1) {
 		// For the caused_by_move_somewhere == true case we didn't force-put the item,
 		// which guarantees there is no leftover, and code below would duplicate the
@@ -517,23 +513,23 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			}
 		}
 		if (move_count > 0 || did_swap) {
-			list_from->deleteItem(from_i);
-			list_from->addItem(from_i, from_stack_was);
+			list_from->changeItem(from_i, from_stack_was);
 		}
 	}
-	// If destination is infinite, reset it's stack and take count from source
+	// If destination is infinite, reset its stack and take count from source
 	if (dst_can_put_count == -1) {
-		list_to->deleteItem(to_i);
-		list_to->addItem(to_i, to_stack_was);
-		list_from->deleteItem(from_i);
-		list_from->addItem(from_i, from_stack_was);
-		list_from->takeItem(from_i, count);
+		list_to->changeItem(to_i, to_stack_was);
+		if (did_swap) {
+			// Undo swap result: set the expected stack + size
+			list_from->changeItem(from_i, from_stack_was);
+			list_from->takeItem(from_i, move_count);
+		}
 	}
 
 	infostream << "IMoveAction::apply(): moved"
 			<< " msom=" << move_somewhere
 			<< " caused=" << caused_by_move_somewhere
-			<< " count=" << count
+			<< " move_count=" << move_count
 			<< " from inv=\"" << from_inv.dump() << "\""
 			<< " list=\"" << from_list << "\""
 			<< " i=" << from_i
@@ -589,9 +585,9 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 
 	// Source = destination => move
 	if (from_inv == to_inv) {
-		onMove(count, player);
+		onMove(move_count, player);
 		if (did_swap) {
-			// Item is now placed in source list
+			// Already swapped. The other stack is now placed in "from" list
 			list_from = get_borrow_checked_invlist(from_inv, from_list);
 			if (list_from) {
 				src_item = list_from->getItem(from_i);
@@ -603,26 +599,34 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		}
 		mgr->setInventoryModified(from_inv);
 	} else {
-		int src_item_count = src_item.count;
-		if (caused_by_move_somewhere)
-			// When moving somewhere: temporarily use the actual movable stack
-			// size to ensure correct callback execution.
-			src_item.count = move_count;
-		onPutAndOnTake(src_item, player);
-		if (caused_by_move_somewhere)
-			// Reset source item count
-			src_item.count = src_item_count;
+		ItemStack swap_item;
 		if (did_swap) {
-			// Item is now placed in source list
+			// Already swapped. The other stack is now placed in "from" list
 			list_from = get_borrow_checked_invlist(from_inv, from_list);
 			if (list_from) {
-				src_item = list_from->getItem(from_i);
+				swap_item = list_from->getItem(from_i);
 				list_from.reset();
-				swapDirections();
-				onPutAndOnTake(src_item, player);
-				swapDirections();
 			}
 		}
+
+		// 1. Take the ItemStack (visually: freely detached)
+		onTake(src_item, player);
+		if (!swap_item.empty() && get_borrow_checked_invlist(to_inv, to_list)) {
+			swapDirections();
+			onTake(swap_item, player);
+			swapDirections();
+		}
+
+		// 2. Put the ItemStack
+		if (get_borrow_checked_invlist(to_inv, to_list))
+			onPut(src_item, player);
+
+		if (!swap_item.empty() && get_borrow_checked_invlist(to_inv, to_list)) {
+			swapDirections();
+			onPut(swap_item, player);
+			swapDirections();
+		}
+
 		mgr->setInventoryModified(to_inv);
 		mgr->setInventoryModified(from_inv);
 	}

--- a/src/inventorymanager.h
+++ b/src/inventorymanager.h
@@ -191,7 +191,8 @@ struct IMoveAction : public InventoryAction, public MoveAction
 
 	void swapDirections();
 
-	void onPutAndOnTake(const ItemStack &src_item, ServerActiveObject *player) const;
+	void onTake(const ItemStack &src_item, ServerActiveObject *player) const;
+	void onPut(const ItemStack &src_item, ServerActiveObject *player) const;
 
 	void onMove(int count, ServerActiveObject *player) const;
 

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -130,6 +130,7 @@ protected:
 	friend class ModApiBase;
 	friend class ModApiEnv;
 	friend class LuaVoxelManip;
+	friend class TestMoveAction; // needs getStack()
 
 	/*
 		Subtle edge case with coroutines: If for whatever reason you have a

--- a/src/server.h
+++ b/src/server.h
@@ -433,7 +433,10 @@ public:
 private:
 	friend class EmergeThread;
 	friend class RemoteClient;
+
+	// unittest classes
 	friend class TestServerShutdownState;
+	friend class TestMoveAction;
 
 	struct ShutdownState {
 		friend class TestServerShutdownState;

--- a/src/server/serverinventorymgr.h
+++ b/src/server/serverinventorymgr.h
@@ -40,8 +40,9 @@ public:
 		m_env = env;
 	}
 
-	Inventory *getInventory(const InventoryLocation &loc);
-	void setInventoryModified(const InventoryLocation &loc);
+	// virtual: Overwritten by MockInventoryManager for the unittests
+	virtual Inventory *getInventory(const InventoryLocation &loc);
+	virtual void setInventoryModified(const InventoryLocation &loc);
 
 	// Creates or resets inventory
 	Inventory *createDetachedInventory(const std::string &name, IItemDefManager *idef,
@@ -52,7 +53,7 @@ public:
 	void sendDetachedInventories(const std::string &peer_name, bool incremental,
 			std::function<void(const std::string &, Inventory *)> apply_cb);
 
-private:
+protected:
 	struct DetachedInventory
 	{
 		std::unique_ptr<Inventory> inventory;

--- a/src/unittest/mock_inventorymanager.h
+++ b/src/unittest/mock_inventorymanager.h
@@ -17,11 +17,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <gamedef.h>
-#include <inventory.h>
-#include <inventorymanager.h>
+#pragma once
 
-class MockInventoryManager : public InventoryManager
+#include "gamedef.h"
+#include "inventory.h"
+#include "server/serverinventorymgr.h"
+
+class ServerEnvironment;
+
+class MockInventoryManager : public ServerInventoryManager
 {
 public:
 	MockInventoryManager(IGameDef *gamedef) :
@@ -29,14 +33,17 @@ public:
 		p2(gamedef->getItemDefManager())
 	{};
 
-	virtual Inventory* getInventory(const InventoryLocation &loc){
+	Inventory *getInventory(const InventoryLocation &loc) override
+	{
 		if (loc.type == InventoryLocation::PLAYER && loc.name == "p1")
 			return &p1;
 		if (loc.type == InventoryLocation::PLAYER && loc.name == "p2")
 			return &p2;
 		return nullptr;
 	}
+	void setInventoryModified(const InventoryLocation &loc) override {}
 
 	Inventory p1;
 	Inventory p2;
+
 };

--- a/src/unittest/mock_server.h
+++ b/src/unittest/mock_server.h
@@ -17,6 +17,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#pragma once
+
 #include <server.h>
 
 class MockServer : public Server

--- a/src/unittest/test_moveaction.cpp
+++ b/src/unittest/test_moveaction.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mock_serveractiveobject.h"
 
 #include "scripting_server.h"
+#include "server/mods.h"
 
 
 class TestMoveAction : public TestBase
@@ -39,49 +40,39 @@ public:
 	void testMoveSomewhere(ServerActiveObject *obj, IGameDef *gamedef);
 	void testMoveUnallowed(ServerActiveObject *obj, IGameDef *gamedef);
 	void testMovePartial(ServerActiveObject *obj, IGameDef *gamedef);
+
 	void testSwap(ServerActiveObject *obj, IGameDef *gamedef);
 	void testSwapFromUnallowed(ServerActiveObject *obj, IGameDef *gamedef);
 	void testSwapToUnallowed(ServerActiveObject *obj, IGameDef *gamedef);
+
+	void testCallbacks(ServerActiveObject *obj, Server *server);
+	void testCallbacksSwap(ServerActiveObject *obj, Server *server);
 };
 
 static TestMoveAction g_test_instance;
-
-const static char *helper_lua_src = R"(
-core.register_allow_player_inventory_action(function(player, action, inventory, info)
-	if action == "move" then
-		return info.count
-	end
-
-	if info.stack:get_name() == "default:water" then
-		return 0
-	end
-	if info.stack:get_name() == "default:lava" then
-		return 5
-	end
-
-	return info.stack:get_count()
-end)
-)";
 
 void TestMoveAction::runTests(IGameDef *gamedef)
 {
 	MockServer server(getTestTempDirectory());
 
-	const auto helper_lua = getTestTempFile();
-	std::ofstream ofs(helper_lua, std::ios::out | std::ios::binary);
-	ofs << helper_lua_src;
-	ofs.close();
-
 	ServerScripting server_scripting(&server);
 	try {
-		server_scripting.loadMod(Server::getBuiltinLuaPath() + DIR_DELIM "init.lua", BUILTIN_MOD_NAME);
-		server_scripting.loadMod(helper_lua, BUILTIN_MOD_NAME);
+		// FIXME: When removing the line below, the unittest does NOT crash
+		// (but it should) when running all unittests in order or registration.
+		// Some Lua API functions used in builtin require the Mgr to be present.
+		server.m_modmgr = std::make_unique<ServerModManager>(server.m_path_world);
+
+		std::string builtin = Server::getBuiltinLuaPath() + DIR_DELIM;
+		server_scripting.loadMod(builtin + "init.lua", BUILTIN_MOD_NAME);
+		server_scripting.loadMod(builtin + "game" DIR_DELIM "tests" DIR_DELIM "test_moveaction.lua", BUILTIN_MOD_NAME);
 	} catch (ModError &e) {
 		// Print backtrace in case of syntax errors
 		rawstream << e.what() << std::endl;
 		num_tests_failed = 1;
 		return;
 	}
+
+	server.m_script = &server_scripting;
 
 	MetricsBackend mb;
 	ServerEnvironment server_env(nullptr, &server_scripting, &server, "", &mb);
@@ -92,9 +83,15 @@ void TestMoveAction::runTests(IGameDef *gamedef)
 	TEST(testMoveSomewhere, &obj, gamedef);
 	TEST(testMoveUnallowed, &obj, gamedef);
 	TEST(testMovePartial, &obj, gamedef);
+
 	TEST(testSwap, &obj, gamedef);
 	TEST(testSwapFromUnallowed, &obj, gamedef);
 	TEST(testSwapToUnallowed, &obj, gamedef);
+
+	TEST(testCallbacks, &obj, &server);
+	TEST(testCallbacksSwap, &obj, &server);
+
+	server.m_script = nullptr; // Do not free stack memory
 }
 
 static ItemStack parse_itemstack(const char *s)
@@ -165,12 +162,12 @@ void TestMoveAction::testMoveUnallowed(ServerActiveObject *obj, IGameDef *gamede
 {
 	MockInventoryManager inv(gamedef);
 
-	inv.p1.addList("main", 10)->addItem(0, parse_itemstack("default:water 50"));
+	inv.p1.addList("main", 10)->addItem(0, parse_itemstack("default:takeput_deny 50"));
 	inv.p2.addList("main", 10);
 
 	apply_action("Move 20 player:p1 main 0 player:p2 main 0", &inv, obj, gamedef);
 
-	UASSERT(inv.p1.getList("main")->getItem(0).getItemString() == "default:water 50");
+	UASSERT(inv.p1.getList("main")->getItem(0).getItemString() == "default:takeput_deny 50");
 	UASSERT(inv.p2.getList("main")->getItem(0).empty())
 }
 
@@ -178,13 +175,14 @@ void TestMoveAction::testMovePartial(ServerActiveObject *obj, IGameDef *gamedef)
 {
 	MockInventoryManager inv(gamedef);
 
-	inv.p1.addList("main", 10)->addItem(0, parse_itemstack("default:lava 50"));
+	inv.p1.addList("main", 10)->addItem(0, parse_itemstack("default:takeput_max_5 50"));
 	inv.p2.addList("main", 10);
 
+	// Lua: limited to 5 per transaction
 	apply_action("Move 20 player:p1 main 0 player:p2 main 0", &inv, obj, gamedef);
 
-	UASSERT(inv.p1.getList("main")->getItem(0).getItemString() == "default:lava 45");
-	UASSERT(inv.p2.getList("main")->getItem(0).getItemString() == "default:lava 5");
+	UASSERT(inv.p1.getList("main")->getItem(0).getItemString() == "default:takeput_max_5 45");
+	UASSERT(inv.p2.getList("main")->getItem(0).getItemString() == "default:takeput_max_5 5");
 }
 
 void TestMoveAction::testSwap(ServerActiveObject *obj, IGameDef *gamedef)
@@ -204,12 +202,12 @@ void TestMoveAction::testSwapFromUnallowed(ServerActiveObject *obj, IGameDef *ga
 {
 	MockInventoryManager inv(gamedef);
 
-	inv.p1.addList("main", 10)->addItem(0, parse_itemstack("default:water 50"));
+	inv.p1.addList("main", 10)->addItem(0, parse_itemstack("default:takeput_deny 50"));
 	inv.p2.addList("main", 10)->addItem(0, parse_itemstack("default:brick 60"));
 
 	apply_action("Move 50 player:p1 main 0 player:p2 main 0", &inv, obj, gamedef);
 
-	UASSERT(inv.p1.getList("main")->getItem(0).getItemString() == "default:water 50");
+	UASSERT(inv.p1.getList("main")->getItem(0).getItemString() == "default:takeput_deny 50");
 	UASSERT(inv.p2.getList("main")->getItem(0).getItemString() == "default:brick 60");
 }
 
@@ -218,10 +216,60 @@ void TestMoveAction::testSwapToUnallowed(ServerActiveObject *obj, IGameDef *game
 	MockInventoryManager inv(gamedef);
 
 	inv.p1.addList("main", 10)->addItem(0, parse_itemstack("default:stone 50"));
-	inv.p2.addList("main", 10)->addItem(0, parse_itemstack("default:water 60"));
+	inv.p2.addList("main", 10)->addItem(0, parse_itemstack("default:takeput_deny 60"));
 
 	apply_action("Move 50 player:p1 main 0 player:p2 main 0", &inv, obj, gamedef);
 
 	UASSERT(inv.p1.getList("main")->getItem(0).getItemString() == "default:stone 50");
-	UASSERT(inv.p2.getList("main")->getItem(0).getItemString() == "default:water 60");
+	UASSERT(inv.p2.getList("main")->getItem(0).getItemString() == "default:takeput_deny 60");
+}
+
+static bool check_function(lua_State *L, bool expect_swap)
+{
+	bool ok = false;
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "__helper_check_callbacks");
+	lua_pushboolean(L, expect_swap);
+	int result = lua_pcall(L, 1, 1, error_handler);
+	if (result == 0)
+		ok = lua_toboolean(L, -1);
+	else
+		errorstream << lua_tostring(L, -1) << std::endl; // Error msg
+
+	lua_settop(L, 0);
+	return ok;
+}
+
+void TestMoveAction::testCallbacks(ServerActiveObject *obj, Server *server)
+{
+	server->m_inventory_mgr = std::make_unique<MockInventoryManager>(server);
+	MockInventoryManager &inv = *(MockInventoryManager *)server->getInventoryMgr();
+
+	inv.p1.addList("main", 10)->addItem(0, parse_itemstack("default:takeput_cb_1 10"));
+	inv.p2.addList("main", 10);
+
+	apply_action("Move 10 player:p1 main 0 player:p2 main 1", &inv, obj, server);
+
+	// Expecting no swap. 4 callback executions in total. See Lua file for details.
+	UASSERT(check_function(server->getScriptIface()->getStack(), false));
+
+	server->m_inventory_mgr.reset();
+}
+
+void TestMoveAction::testCallbacksSwap(ServerActiveObject *obj, Server *server)
+{
+	server->m_inventory_mgr = std::make_unique<MockInventoryManager>(server);
+	MockInventoryManager &inv = *(MockInventoryManager *)server->getInventoryMgr();
+
+	inv.p1.addList("main", 10)->addItem(0, parse_itemstack("default:takeput_cb_2 50"));
+	inv.p2.addList("main", 10)->addItem(1, parse_itemstack("default:takeput_cb_1 10"));
+
+	apply_action("Move 10 player:p1 main 0 player:p2 main 1", &inv, obj, server);
+
+	// Expecting swap. 8 callback executions in total. See Lua file for details.
+	UASSERT(check_function(server->getScriptIface()->getStack(), true));
+
+	server->m_inventory_mgr.reset();
 }


### PR DESCRIPTION
This PR yet again touches the item movement code to fix the wrong order of put/take callbacks when swapping items.

Current swap callback order:
 * destination inventory put
 * source inventory take
 * source inventory put
 * destination inventory take

Corrected/expected callback order:
 * destination + source inventory take
 * source + destination inventory put

Revealed/discovered by @fluxionary in https://github.com/minetest-mods/unified_inventory/issues/208

Fixes #13486, fixes #14210


## To do

This PR is Ready for Review.

## How to test

1. MTG creative inventory: must work as expected
2. devtest chest: put and take any number of items, shift-click them. ensure the reported counts are correct.
    * Namely, bug #10805 must not re-appear.
3. unified_inventory : tab "Bags" -> put a bag in, replace with another. Open the bag and there must be no warning about a missing inventory list.
4. Modify `helper_moveaction.lua` L2/L3: change `on_take` to `on_whatever` and check for correctly failing unittests

**How to test (variant 2)**

1. Testing script: https://github.com/SmallJoker/minetest_lab/blob/master/init_76_inv_callbacks.lua
2. MTG creative mode enabled (no additional inventory mod)
3. Place `default:chest_locked` nearby
4. `/fs` and move items

Expected order: "allow take"+"allow put", then "on take" and finally "on put". Example:
```
	2                              | action=take (singleplayer) | [main,2] default:glass 4
	on_metadata_inventory_take     | [main,3] butterflies:butterfly_red 2 (singleplayer)
2023-06-12 21:06:01: ACTION[Server]: singleplayer takes butterflies:butterfly_red from chest at (-9,2,1)
	on_metadata_inventory_put      | [main,3] default:glass 4 (singleplayer)
2023-06-12 21:06:01: ACTION[Server]: singleplayer moves default:glass to chest at (-9,2,1)
	2                              | action=put (singleplayer) | [main,2] butterflies:butterfly_red 2
```