### PR TITLE
Fix media overriding regression

### DIFF
--- a/src/server/mods.cpp
+++ b/src/server/mods.cpp
@@ -94,7 +94,11 @@ void ServerModManager::getModNames(std::vector<std::string> &modlist) const
 
 void ServerModManager::getModsMediaPaths(std::vector<std::string> &paths) const
 {
-	for (const auto &spec : configuration.getMods()) {
+	// Iterate mods in reverse load order: Media loading expects higher priority media files first
+	// and mods loading later should be able to override media of already loaded mods
+	const auto mods = configuration.getMods();
+	for (auto it = mods.crbegin(); it != mods.crend(); it++) {
+		const ModSpec &spec = *it;
 		fs::GetRecursiveDirs(paths, spec.path + DIR_DELIM + "textures");
 		fs::GetRecursiveDirs(paths, spec.path + DIR_DELIM + "sounds");
 		fs::GetRecursiveDirs(paths, spec.path + DIR_DELIM + "media");

--- a/src/unittest/test_servermodmanager.cpp
+++ b/src/unittest/test_servermodmanager.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server/mods.h"
 #include "settings.h"
 #include "test_config.h"
+#include "util/string.h"
 
 class TestServerModManager : public TestBase
 {
@@ -190,4 +191,11 @@ void TestServerModManager::testGetModMediaPaths()
 	std::vector<std::string> result;
 	sm.getModsMediaPaths(result);
 	UASSERTEQ(bool, result.empty(), false);
+
+	// Test media overriding:
+	// unittests depends on basenodes to override default_dirt.png,
+	// thus the unittests texture path must come first in the returned media paths to take priority
+	auto it = std::find(result.begin(), result.end(), sm.getModSpec("unittests")->path + DIR_DELIM + "textures");
+	UASSERT(it != result.end());
+	UASSERT(std::find(++it, result.end(), sm.getModSpec("basenodes")->path + DIR_DELIM + "textures") != result.end());
 }


### PR DESCRIPTION
Fixes #12557. Ruben replaced a [reverse iterator (`crbegin` & `crend`)](https://github.com/minetest/minetest/commit/06de82fd86678e0a1c260c67792c5cd192863edd#diff-24cd186c8d4fc53d29afe3e5c3b0a1c53fe9418edfb702996fc9a0ffdbbfa051L99) with a normal one. Reverted that and added a comment since this is a reregression (the second time mod media overriding was broken) so that this doesn't happen again.