### PR TITLE
Fix Android blank screen

### DIFF
--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -87,7 +87,7 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	// Resolution selection
 	bool fullscreen = g_settings->getBool("fullscreen");
 #ifdef __ANDROID__
-	u16 screen_w = 0, screen_h = 0
+	u16 screen_w = 0, screen_h = 0;
 #else
 	u16 screen_w = std::max<u16>(g_settings->getU16("screen_w"), 1);
 	u16 screen_h = std::max<u16>(g_settings->getU16("screen_h"), 1);

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -86,8 +86,13 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 
 	// Resolution selection
 	bool fullscreen = g_settings->getBool("fullscreen");
+#ifdef __ANDROID__
+	u16 screen_w = g_settings->getU16("screen_w");
+	u16 screen_h = g_settings->getU16("screen_h");
+#else
 	u16 screen_w = std::max<u16>(g_settings->getU16("screen_w"), 1);
 	u16 screen_h = std::max<u16>(g_settings->getU16("screen_h"), 1);
+#endif
 
 	// bpp, fsaa, vsync
 	bool vsync = g_settings->getBool("vsync");

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -87,8 +87,8 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	// Resolution selection
 	bool fullscreen = g_settings->getBool("fullscreen");
 #ifdef __ANDROID__
-	u16 screen_w = g_settings->getU16("screen_w");
-	u16 screen_h = g_settings->getU16("screen_h");
+	u16 screen_w = 0;
+	u16 screen_h = 0;
 #else
 	u16 screen_w = std::max<u16>(g_settings->getU16("screen_w"), 1);
 	u16 screen_h = std::max<u16>(g_settings->getU16("screen_h"), 1);

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -87,8 +87,7 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	// Resolution selection
 	bool fullscreen = g_settings->getBool("fullscreen");
 #ifdef __ANDROID__
-	u16 screen_w = 0;
-	u16 screen_h = 0;
+	u16 screen_w = 0, screen_h = 0
 #else
 	u16 screen_w = std::max<u16>(g_settings->getU16("screen_w"), 1);
 	u16 screen_h = std::max<u16>(g_settings->getU16("screen_h"), 1);


### PR DESCRIPTION
Fixes #12573, caused by https://github.com/minetest/minetest/commit/051181fa6ee00d8379e8a7dc7442b58342d4352b clamping the screen width and height to at least 1, which breaks on Android where those are set to 0.

## To do
This PR is a Ready for Review.

## How to test
Install the Android version and see so that it actually works again.
