### PR TITLE
Use legacy image implementation when not using 9-slice image

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -825,12 +825,23 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 	core::rect<s32> middle;
 	if (parts.size() >= 4)
 		parseMiddleRect(parts[3], &middle);
+	
+	gui::IGUIElement *e;
+	if (middle.getArea() > 0) {
+		GUIAnimatedImage *image = new GUIAnimatedImage(Environment, data->current_parent,
+			spec.fid, rect);
 
-	GUIAnimatedImage *e = new GUIAnimatedImage(Environment, data->current_parent,
-		spec.fid, rect);
-
-	e->setTexture(texture);
-	e->setMiddleRect(middle);
+		image->setTexture(texture);
+		image->setMiddleRect(middle);
+		e = image;
+	}
+	else {
+		gui::IGUIImage *image = Environment->addImage(rect, data->current_parent, spec.fid, nullptr, true);
+		image->setImage(texture);
+		image->setScaleImage(true);
+		image->grab(); // compensate for drop in addImage
+		e = image;
+	}
 
 	auto style = getDefaultStyleForElement("image", spec.fname);
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, m_formspec_version < 3));

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -826,6 +826,10 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 	if (parts.size() >= 4)
 		parseMiddleRect(parts[3], &middle);
 	
+	// Temporary fix for issue #12581 in 5.6.0.
+	// Use legacy image when not rendering 9-slice image because GUIAnimatedImage 
+	// uses NNAA filter which causes visual artifacts when image uses alpha blending.
+
 	gui::IGUIElement *e;
 	if (middle.getArea() > 0) {
 		GUIAnimatedImage *image = new GUIAnimatedImage(Environment, data->current_parent,


### PR DESCRIPTION
Fixes #12581

## To do

This PR is Ready for Review.

## How to test

1. Set `gui_scaling_filter = true`
2. Start Repixture game
3. Open inventory
4. Notice that inventory slots do not have dark border (see #12581).