### PR TITLE
Apply NetBSD string conversion workaround to OpenBSD as well

### DIFF
--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -70,7 +70,7 @@ static bool convert(const char *to, const char *from, char *outbuf,
 #ifdef __ANDROID__
 // On Android iconv disagrees how big a wchar_t is for whatever reason
 const char *DEFAULT_ENCODING = "UTF-32LE";
-#elif defined(__NetBSD__)
+#elif defined(__NetBSD__) || defined(__OpenBSD__)
 	// NetBSD does not allow "WCHAR_T" as a charset input to iconv.
 	#include <sys/endian.h>
 	#if BYTE_ORDER == BIG_ENDIAN
@@ -93,7 +93,7 @@ std::wstring utf8_to_wide(const std::string &input)
 	std::wstring out;
 	out.resize(outbuf_size / sizeof(wchar_t));
 
-#if defined(__ANDROID__) || defined(__NetBSD__)
+#if defined(__ANDROID__) || defined(__NetBSD__) || defined(__OpenBSD__)
 	SANITY_CHECK(sizeof(wchar_t) == 4);
 #endif
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -94,7 +94,7 @@ std::wstring utf8_to_wide(const std::string &input)
 	out.resize(outbuf_size / sizeof(wchar_t));
 
 #if defined(__ANDROID__) || defined(__NetBSD__) || defined(__OpenBSD__)
-	SANITY_CHECK(sizeof(wchar_t) == 4);
+	static_assert(sizeof(wchar_t) == 4, "Unexpected wide char size");
 #endif
 
 	char *outbuf = reinterpret_cast<char*>(&out[0]);


### PR DESCRIPTION
This trivial patch applies the pre-existing NetBSD workaround for wide character conversion to OpenBSD as well. Without this, all UTF/wide characters cause an "invalid string" error to be spit out by Minetest, when compiled and run on OpenBSD.
This patch has been tested and is currently running on the Land of Catastrophe server.
