### PR TITLE
Remove default keybind for range select

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2109,7 +2109,7 @@ keymap_cmd_local (Command key) key .
 
 #    Key for toggling unlimited view range.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
-keymap_rangeselect (Range select key) key KEY_KEY_R
+keymap_rangeselect (Range select key) key
 
 #    Key for toggling flying.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -87,7 +87,7 @@ void set_default_settings()
 	settings->setDefault("keymap_cmd_local", ".");
 	settings->setDefault("keymap_minimap", "KEY_KEY_V");
 	settings->setDefault("keymap_console", "KEY_F10");
-	settings->setDefault("keymap_rangeselect", "KEY_KEY_R");
+	settings->setDefault("keymap_rangeselect", "");
 	settings->setDefault("keymap_freemove", "KEY_KEY_K");
 	settings->setDefault("keymap_pitchmove", "KEY_KEY_P");
 	settings->setDefault("keymap_fastmove", "KEY_KEY_J");


### PR DESCRIPTION
This was going to just be a proposal issue, except the change is trivial, so why not save someone a couple minutes work in the case this is accepted.

Currently, neophyte players very often accidentally trigger "infinite view range" and then get upset about the "lag" they experience. As someone who actually uses the feature semi-often, I find I personally trigger it accidentally around as much as I do intentionally. I've had to talk scores of players through the process of disabling it, and I would guess that most players only discover the feature after accidentally triggering. 

I propose to just remove the default key binding. 