### PR TITLE
Add support for MINETEST_USERDATA environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,15 @@ Where each location is on each platform:
 * Windows installed:
     * `bin`   = `C:\Program Files\Minetest\bin (Depends on the install location)`
     * `share` = `C:\Program Files\Minetest (Depends on the install location)`
-    * `user`  = `%APPDATA%\Minetest`
+    * `user`  = `%APPDATA%\Minetest` or `%MINETEST_USER_PATH%`
 * Linux installed:
     * `bin`   = `/usr/bin`
     * `share` = `/usr/share/minetest`
-    * `user`  = `~/.minetest`
+    * `user`  = `~/.minetest` or `$MINETEST_USER_PATH`
 * macOS:
     * `bin`   = `Contents/MacOS`
     * `share` = `Contents/Resources`
-    * `user`  = `Contents/User OR ~/Library/Application Support/minetest`
+    * `user`  = `Contents/User` or `~/Library/Application Support/minetest` or `$MINETEST_USER_PATH`
 
 Worlds can be found as separate folders in: `user/worlds/`
 

--- a/doc/minetest.6
+++ b/doc/minetest.6
@@ -124,6 +124,9 @@ Colon delimited list of directories to search for games.
 .TP
 .B MINETEST_MOD_PATH
 Colon delimited list of directories to search for mods.
+.TP
+.B MINETEST_USER_PATH
+Path to Minetest user data directory.
 
 .SH BUGS
 Please report all bugs at https://github.com/minetest/minetest/issues.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -527,7 +527,7 @@ static bool create_userdata_path()
 	}
 #else
 	// Create user data directory
-	success = fs::CreateDir(porting::path_user);
+	success = fs::CreateAllDirs(porting::path_user);
 #endif
 
 	return success;

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -422,11 +422,18 @@ bool setSystemPaths()
 		path_share += DIR_DELIM "..";
 	}
 
-	// Use "C:\Users\<user>\AppData\Roaming\<PROJECT_NAME_C>"
-	DWORD len = GetEnvironmentVariable("APPDATA", buf, sizeof(buf));
-	FATAL_ERROR_IF(len == 0 || len > sizeof(buf), "Failed to get APPDATA");
+	// Use %MINETEST_USER_PATH%
+	DWORD len = GetEnvironmentVariable("MINETEST_USER_PATH", buf, sizeof(buf));
+	FATAL_ERROR_IF(len > sizeof(buf), "Failed to get MINETEST_USER_PATH (too large for buffer)");
+	if (len == 0) {
+		// Use "C:\Users\<user>\AppData\Roaming\<PROJECT_NAME_C>"
+		len = GetEnvironmentVariable("APPDATA", buf, sizeof(buf));
+		FATAL_ERROR_IF(len == 0 || len > sizeof(buf), "Failed to get APPDATA");
+		path_user = std::string(buf) + DIR_DELIM + PROJECT_NAME_C;
+	} else {
+		path_user = std::string(buf);
+	}
 
-	path_user = std::string(buf) + DIR_DELIM + PROJECT_NAME_C;
 	return true;
 }
 
@@ -486,8 +493,13 @@ bool setSystemPaths()
 	}
 
 #ifndef __ANDROID__
-	path_user = std::string(getHomeOrFail()) + DIR_DELIM "."
-		+ PROJECT_NAME;
+	const char *const minetest_user_path = getenv("MINETEST_USER_PATH");
+	if (minetest_user_path && minetest_user_path[0] != '\0') {
+		path_user = std::string(minetest_user_path);
+	} else {
+		path_user = std::string(getHomeOrFail()) + DIR_DELIM "."
+			+ PROJECT_NAME;
+	}
 #endif
 
 	return true;
@@ -510,9 +522,14 @@ bool setSystemPaths()
 	}
 	CFRelease(resources_url);
 
-	path_user = std::string(getHomeOrFail())
-		+ "/Library/Application Support/"
-		+ PROJECT_NAME;
+	const char *const minetest_user_path = getenv("MINETEST_USER_PATH");
+	if (minetest_user_path && minetest_user_path[0] != '\0') {
+		path_user = std::string(minetest_user_path);
+	} else {
+		path_user = std::string(getHomeOrFail())
+			+ "/Library/Application Support/"
+			+ PROJECT_NAME;
+	}
 	return true;
 }
 
@@ -522,8 +539,13 @@ bool setSystemPaths()
 bool setSystemPaths()
 {
 	path_share = STATIC_SHAREDIR;
-	path_user  = std::string(getHomeOrFail()) + DIR_DELIM "."
-		+ lowercase(PROJECT_NAME);
+	const char *const minetest_user_path = getenv("MINETEST_USER_PATH");
+	if (minetest_user_path && minetest_user_path[0] != '\0') {
+		path_user = std::string(minetest_user_path);
+	} else {
+		path_user  = std::string(getHomeOrFail()) + DIR_DELIM "."
+			+ lowercase(PROJECT_NAME);
+	}
 	return true;
 }
 


### PR DESCRIPTION
The MINETEST_USERDATA environment variable can be used to defined a
custom path for Minetest user data. If MINETEST_USERDATA is empty or
unset, the HOME environment variable is used as the default user data
path; this ensures backwards compatibility with existing user setups.