### PR TITLE
Add handling of environment variables to control terminal/logging colors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1138,38 +1138,23 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 
 static void get_env_opts(Settings &settings)
 {
-	// allows turning on/off colored output via env (see issue #7553)
-	// CLICOLOR is a de-facto standard option for colors in ANSI-capable environments.
-	// CLICOLOR != 0: ANSI colors are supported
+	// CLICOLOR is a de-facto standard option for colors <https://bixense.com/clicolors/>
+	// CLICOLOR != 0: ANSI colors are supported (auto-detection, this is the default)
 	// CLICOLOR == 0: ANSI colors are NOT supported
-	const char *clicolor_raw = std::getenv(ENV_CLICOLOR);
-	if (clicolor_raw) {
-		const std::string color = clicolor_raw;
-		if (color == "0") {
-			settings.set("color", "never");
-		} else {
-			// auto since it still could be not a tty
-			settings.set("color", "auto");
-		}
+	const char *clicolor = std::getenv(ENV_CLICOLOR);
+	if (clicolor && std::string(clicolor) == "0") {
+		settings.set("color", "never");
 	}
-	// NO_COLOR only specifies that NO color is allowed - whether or not
-	// we actually give the user color is up to the "auto" mode.
-	// Implemented according to no-color.org (08-2022)
-	const char *no_color_raw = std::getenv(ENV_NO_COLOR);
-	if (no_color_raw) {
-		const std::string color = no_color_raw;
-		if (!color.empty()) {
-			settings.set("color", "never");
-		}
+	// NO_COLOR only specifies that no color is allowed.
+	// Implemented according to <http://no-color.org/>
+	const char *no_color = std::getenv(ENV_NO_COLOR);
+	if (no_color && no_color[0]) {
+		settings.set("color", "never");
 	}
-	// CLICOLOR_FORCE is another option of the CLICOLOR semi-standard, which
-	// should turn on colors "no matter what".
-	const char *clicolor_force_raw = std::getenv(ENV_CLICOLOR_FORCE);
-	if (clicolor_force_raw) {
-		const std::string color = clicolor_force_raw;
-		if (color != "0") {
-			// should ALWAYS have colors, so we ignore tty (no "auto")
-			settings.set("color", "always");
-		}
+	// CLICOLOR_FORCE is another option, which should turn on colors "no matter what".
+	const char *clicolor_force = std::getenv(ENV_CLICOLOR_FORCE);
+	if (clicolor_force && std::string(clicolor_force) != "0") {
+		// should ALWAYS have colors, so we ignore tty (no "auto")
+		settings.set("color", "always");
 	}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1150,23 +1150,4 @@ static void get_env_opts(Settings &settings)
 			settings.set("color", "always");
 		}
 	}
-	// MINETEST_COLOR may be defined to "always", "never", or "auto" (auto => same as not
-	// defined)
-	const char *minetest_color_raw = std::getenv(ENV_MINETEST_COLOR);
-	if (minetest_color_raw) {
-		const std::string color = minetest_color_raw;
-		if (color == "always") {
-			settings.set("color", "always");
-		} else if (color == "never") {
-			settings.set("color", "never");
-		} else if (color != "auto") {
-			// if anything else but auto, warn that it has no effect (auto is default so
-			// we ignore it)
-			warningstream << "Environment variable " << ENV_MINETEST_COLOR
-						  << " set to invalid value '" << color
-						  << "' (must be one of 'always', 'never', "
-							 "'auto'), so it is ignored."
-						  << std::endl;
-		}
-	}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,7 +77,7 @@ extern "C" {
 #define DEBUGFILE "debug.txt"
 #define DEFAULT_SERVER_PORT 30000
 
-#define ENV_MINETEST_COLOR "MINETEST_COLOR"
+#define ENV_NO_COLOR "NO_COLOR"
 #define ENV_CLICOLOR "CLICOLOR"
 
 typedef std::map<std::string, ValueSpec> OptionList;
@@ -1148,6 +1148,16 @@ static void get_env_opts(Settings &settings)
 			settings.set("color", "never");
 		} else {
 			settings.set("color", "always");
+		}
+	}
+	// NO_COLOR only specifies that NO color is allowed - whether or not
+	// we actually give the user color is up to the "auto" mode.
+	// Implemented according to no-color.org (08-2022)
+	const char* no_color_raw = std::getenv(ENV_NO_COLOR);
+	if (no_color_raw && no_color_raw[0] != '\0') {
+		const std::string color = clicolor_raw;
+		if (color[0] != '\0') {
+			settings.set("color", "never");
 		}
 	}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1155,9 +1155,6 @@ static void get_env_opts(Settings &settings)
 	// Implemented according to no-color.org (08-2022)
 	const char* no_color_raw = std::getenv(ENV_NO_COLOR);
 	if (no_color_raw && no_color_raw[0] != '\0') {
-		const std::string color = clicolor_raw;
-		if (color[0] != '\0') {
-			settings.set("color", "never");
-		}
+		settings.set("color", "never");
 	}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1136,25 +1136,25 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 	return true;
 }
 
-static void get_env_opts(Settings &settings)
+static void get_env_opts(Settings &args)
 {
 	// CLICOLOR is a de-facto standard option for colors <https://bixense.com/clicolors/>
 	// CLICOLOR != 0: ANSI colors are supported (auto-detection, this is the default)
 	// CLICOLOR == 0: ANSI colors are NOT supported
 	const char *clicolor = std::getenv(ENV_CLICOLOR);
 	if (clicolor && std::string(clicolor) == "0") {
-		settings.set("color", "never");
+		args.set("color", "never");
 	}
 	// NO_COLOR only specifies that no color is allowed.
 	// Implemented according to <http://no-color.org/>
 	const char *no_color = std::getenv(ENV_NO_COLOR);
 	if (no_color && no_color[0]) {
-		settings.set("color", "never");
+		args.set("color", "never");
 	}
 	// CLICOLOR_FORCE is another option, which should turn on colors "no matter what".
 	const char *clicolor_force = std::getenv(ENV_CLICOLOR_FORCE);
 	if (clicolor_force && std::string(clicolor_force) != "0") {
 		// should ALWAYS have colors, so we ignore tty (no "auto")
-		settings.set("color", "always");
+		args.set("color", "always");
 	}
 }


### PR DESCRIPTION
Adds handling of terminal-color related environment variables. Fixes #7553.

It supports the `CLICOLOR`, `MINETEST_COLOR` environment variables.

For `CLICOLOR`, see https://bixense.com/clicolors/ (`CLICOLOR_FORCE` not
implemented, it sounds like a source of confusion). In short: `CLICOLOR == 0` is colors OFF, `CLICOLOR != 0` is ON.

For `MINETEST_COLOR`, the same options as `--color` are used, so `always`, `never` and `auto` (the latter of course is the same as not defining it at all, considering the `--color` switch has this default).

They are evaluated in this order (overriding each other):

1. `CLICOLOR`
2. `MINETEST_COLOR`
3. commandline arguments (`--color`)

So in order of increasing specificity.

This PR is **Ready for Review**, unless we'd like other environment variables, like `CLICOLOR_FORCE`.

## How to test

*on a \*nix:*

```sh
# if "auto" is ON, this will turn them off
CLICOLOR=0 ./minetest

# MINETEST_COLOR always overrides CLICOLOR as its more specific
CLICOLOR=0 MINETEST_COLOR=always ./minetest

# commandline arguments override, so the environment is ignored in this case
CLICOLOR=0 MINETEST_COLOR=never ./minetest --color always
```