### PR TITLE
Use sky API to obtain directional light source position

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4059,10 +4059,7 @@ void Game::updateShadows()
 	timeoftheday = fmod(timeoftheday + 0.75f, 0.5f) + 0.25f;
 	const float offset_constant = 10000.0f;
 
-	v3f light(0.0f, 0.0f, -1.0f);
-	light.rotateXZBy(90);
-	light.rotateXYBy(timeoftheday * 360 - 90);
-	light.rotateYZBy(sky->getSkyBodyOrbitTilt());
+	v3f light = is_day ? sky->getSunDirection() : sky->getMoonDirection();
 
 	v3f sun_pos = light * offset_constant;
 

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -554,6 +554,25 @@ void Sky::update(float time_of_day, float time_brightness,
 	}
 }
 
+static v3f getSkyBodyPosition(float horizon_position, float day_position, float orbit_tilt)
+{
+	v3f result = v3f(0, 0, -1);
+	result.rotateXZBy(horizon_position);
+	result.rotateXYBy(day_position);
+	result.rotateYZBy(orbit_tilt);
+	return result;
+}
+
+v3f Sky::getSunDirection()
+{
+	return getSkyBodyPosition(90, getWickedTimeOfDay(m_time_of_day) * 360 - 90, m_sky_body_orbit_tilt);
+}
+
+v3f Sky::getMoonDirection()
+{
+	return getSkyBodyPosition(270, getWickedTimeOfDay(m_time_of_day) * 360 - 90, m_sky_body_orbit_tilt);
+}
+
 void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor &suncolor,
 	const video::SColor &suncolor2, float wicked_time_of_day)
 	/* Draw sun in the sky.
@@ -703,15 +722,13 @@ void Sky::place_sky_body(
 	* day_position: turn the body around the Z axis, to place it depending of the time of the day
 	*/
 {
-	v3f centrum(0, 0, -1);
-	centrum.rotateXZBy(horizon_position);
-	centrum.rotateXYBy(day_position);
-	centrum.rotateYZBy(m_sky_body_orbit_tilt);
+	v3f centrum = getSkyBodyPosition(horizon_position, day_position, m_sky_body_orbit_tilt);
+	v3f untilted_centrum = getSkyBodyPosition(horizon_position, day_position, 0.f);
 	for (video::S3DVertex &vertex : vertices) {
 		// Body is directed to -Z (south) by default
 		vertex.Pos.rotateXZBy(horizon_position);
 		vertex.Pos.rotateXYBy(day_position);
-		vertex.Pos.Z += centrum.Z;
+		vertex.Pos += centrum - untilted_centrum;
 	}
 }
 

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -110,8 +110,6 @@ public:
 		ITextureSource *tsrc);
 	const video::SColorf &getCurrentStarColor() const { return m_star_color; }
 
-	float getSkyBodyOrbitTilt() const { return m_sky_body_orbit_tilt; }
-
 private:
 	aabb3f m_box;
 	video::SMaterial m_materials[SKY_MATERIAL_COUNT];

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -71,12 +71,14 @@ public:
 	void setSunScale(f32 sun_scale) { m_sun_params.scale = sun_scale; }
 	void setSunriseVisible(bool glow_visible) { m_sun_params.sunrise_visible = glow_visible; }
 	void setSunriseTexture(const std::string &sunglow_texture, ITextureSource* tsrc);
+	v3f getSunDirection();
 
 	void setMoonVisible(bool moon_visible) { m_moon_params.visible = moon_visible; }
 	bool getMoonVisible() const { return m_moon_params.visible; }
 	void setMoonTexture(const std::string &moon_texture,
 		const std::string &moon_tonemap, ITextureSource *tsrc);
 	void setMoonScale(f32 moon_scale) { m_moon_params.scale = moon_scale; }
+	v3f getMoonDirection();
 
 	void setStarsVisible(bool stars_visible) { m_star_params.visible = stars_visible; }
 	void setStarCount(u16 star_count);


### PR DESCRIPTION
Refactor calculation of sun/moon position to be in the Sky class, so that it is easy to use in e.g. shaders.
Fixes a bug where sun position on the sky and shadow direction are not aligned with high values of `sky_body_orbit_tilt`

## To do

This PR is Ready for Review.

## How to test

### Test1

1. Set `sky_body_orbit_tilt = 30`
2. Enable dynamic shadows
3. Start a game
4. Set time to 10:00
5. Align player's shadow with an object in the world (e.g. tree trunk or a stack a nodes).
6. Look at the sun and check that the light source is behind the object.
7. Perform the same test with moon at 22:00

### Test2

1. Set `sky_body_orbit_tilt = 30`
2. Start a game (MTG)
3. Set time to 6:00
4. Look at the sun, the texture must not be rotated