### PR TITLE
Appdata: Fix screenshot resolutions

### DIFF
--- a/misc/net.minetest.minetest.appdata.xml
+++ b/misc/net.minetest.minetest.appdata.xml
@@ -56,10 +56,10 @@
 			<image width="1920" height="1080">http://www.minetest.net/media/gallery/1.jpg</image>
 		</screenshot>
 		<screenshot>
-			<image width="1920" height="1080">http://www.minetest.net/media/gallery/3.jpg</image>
+			<image width="1367" height="832">http://www.minetest.net/media/gallery/3.jpg</image>
 		</screenshot>
 		<screenshot>
-			<image width="1920" height="1080">http://www.minetest.net/media/gallery/5.jpg</image>
+			<image width="1280" height="653">http://www.minetest.net/media/gallery/5.jpg</image>
 		</screenshot>
 	</screenshots>
 	<keywords>


### PR DESCRIPTION
Fixes #12597 partially - alternative to #12652.

```
• attribute-invalid     : <screenshot> width too large [http://www.minetest.net/media/gallery/1.jpg] maximum is 1600px
• attribute-invalid     : <screenshot> height too large [http://www.minetest.net/media/gallery/1.jpg] maximum is 900px
```
is obviously not fixed by this and would require adding a downsized version of the screenshot to the website