### PR TITLE
Entity definition: Validate max_hp

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -101,6 +101,12 @@ function core.register_entity(name, prototype)
 	end
 	name = check_modname_prefix(tostring(name))
 
+	-- Check prototype (not exhaustive)
+	if prototype.max_hp ~= nil then
+		assert(type(prototype.max_hp) == "number")
+		assert(prototype.max_hp % 1 == 0 and prototype.max_hp > 0, "max_hp must be a positive integer")
+	end
+
 	prototype.name = name
 	prototype.__index = prototype  -- so that it can be used as a metatable
 


### PR DESCRIPTION
Since 5.6.0, a zero max HP leads to entities being deactivated even before on_activate is called (i.e. entities are "gone" immediately even before they are added because they are initialized with 0 HP). This is a massive footgun for modders, which somehow have [awesome ideas like using `max_hp = 0.5`](https://bitbucket.org/minetest_gamers/x_bows/issues/6/doesnt-work-arrow-entities-get-removed). This PR adds basic validation for `max_hp` inside `register_entity` (assignments to `max_hp` later on may however set an invalid value...).