### PR TITLE
Check hp_max > 0 for entities

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -196,6 +196,9 @@ void read_object_properties(lua_State *L, int index,
 	int hp_max = 0;
 	if (getintfield(L, -1, "hp_max", hp_max)) {
 		prop->hp_max = (u16)rangelim(hp_max, 0, U16_MAX);
+		// hp_max = 0 is sometimes used as a hack to keep players dead, only validate for entities
+		if (prop->hp_max == 0 && sao->getType() != ACTIVEOBJECT_TYPE_PLAYER)
+			throw LuaError("The hp_max property may not be 0 for entities!");
 
 		if (prop->hp_max < sao->getHP()) {
 			PlayerHPChangeReason reason(PlayerHPChangeReason::SET_HP_MAX);


### PR DESCRIPTION
Since 5.6.0, a zero max HP leads to entities being deactivated even before on_activate is called (i.e. entities are "gone" immediately even before they are added because they are initialized with 0 HP). This is a massive footgun for modders, which somehow have [awesome ideas like using `hp_max = 0.5`](https://bitbucket.org/minetest_gamers/x_bows/issues/6/doesnt-work-arrow-entities-get-removed). This PR adds basic validation for `hp_max > 0` whenever properties are set.