### PR TITLE
Improve support for mixed touch/mouse input

### DIFF
--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -179,7 +179,9 @@ public:
 		return res;
 	}
 
-	double getPitch() { return m_camera_pitch; }
+	double getPitch() const { return m_camera_pitch; }
+
+	void setPitch(double camera_pitch, v2s32 screen_XY);
 
 	/*
 	 * Returns a line which describes what the player is pointing at.
@@ -198,6 +200,9 @@ public:
 
 	void hide();
 	void show();
+
+	bool is_visible() const { return m_visible; }
+
 
 private:
 	IrrlichtDevice *m_device;


### PR DESCRIPTION
Do not ignore mouse input when the touchscreen GUI is enabled.
Instead, use mouse motion to control pitch and yaw as expected.
Additionally, if the mouse is used to control movement, disable the
touch UI until a touch event is detected again.

This is a partial contribution to try to fix #11275. I consider it work-in-progress because I was only able to test it on Linux with the touch UI enabled (I don't have an Android build environment, sorry).