### PR TITLE
Reduce the use of porting::getTimeMs() when rendering frames

### DIFF
--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -34,6 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "shader.h"
 #include "content_cao.h"
+#include "porting.h"
 #include <algorithm>
 #include "client/renderingengine.h"
 
@@ -512,4 +513,9 @@ void ClientEnvironment::getSelectedActiveObjects(
 				(current_intersection - shootline_on_map.start).getLengthSQ());
 		}
 	}
+}
+
+void ClientEnvironment::updateFrameTime()
+{
+	m_frame_time = porting::getTimeMs();
 }

--- a/src/client/clientenvironment.h
+++ b/src/client/clientenvironment.h
@@ -141,6 +141,9 @@ public:
 	void updateCameraOffset(const v3s16 &camera_offset)
 	{ m_camera_offset = camera_offset; }
 	v3s16 getCameraOffset() const { return m_camera_offset; }
+
+	void updateFrameTime();
+	irr::u64 getFrameTime() { return m_frame_time; }
 private:
 	ClientMap *m_map;
 	LocalPlayer *m_local_player = nullptr;
@@ -153,4 +156,5 @@ private:
 	IntervalLimiter m_active_object_light_update_interval;
 	std::list<std::string> m_player_names;
 	v3s16 m_camera_offset;
+	irr::u64 m_frame_time;
 };

--- a/src/client/clientenvironment.h
+++ b/src/client/clientenvironment.h
@@ -143,7 +143,8 @@ public:
 	v3s16 getCameraOffset() const { return m_camera_offset; }
 
 	void updateFrameTime();
-	u64 getFrameTime() { return m_frame_time; }
+	u64 getFrameTime() const { return m_frame_time; }
+
 private:
 	ClientMap *m_map;
 	LocalPlayer *m_local_player = nullptr;

--- a/src/client/clientenvironment.h
+++ b/src/client/clientenvironment.h
@@ -143,7 +143,7 @@ public:
 	v3s16 getCameraOffset() const { return m_camera_offset; }
 
 	void updateFrameTime();
-	irr::u64 getFrameTime() { return m_frame_time; }
+	u64 getFrameTime() { return m_frame_time; }
 private:
 	ClientMap *m_map;
 	LocalPlayer *m_local_player = nullptr;
@@ -156,5 +156,5 @@ private:
 	IntervalLimiter m_active_object_light_update_interval;
 	std::list<std::string> m_player_names;
 	v3s16 m_camera_offset;
-	irr::u64 m_frame_time;
+	u64 m_frame_time;
 };

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -445,12 +445,14 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 
 	// Render all mesh buffers in order
 	drawcall_count += draw_order.size();
+	u16 i = 0;
 
 	for (auto &descriptor : draw_order) {
 		scene::IMeshBuffer *buf = descriptor.getBuffer();
 
 		// Check and abort if the machine is swapping a lot
-		if (draw.getTimerTime() > 2000) {
+		// Avoid checking too frequently because getTimerTime() is expensive
+		if (++i % 128 == 0 && draw.getTimerTime() > 2000) {
 			infostream << "ClientMap::renderMap(): Rendering took >2s, " <<
 					"returning." << std::endl;
 			return;
@@ -799,12 +801,14 @@ void ClientMap::renderMapShadows(video::IVideoDriver *driver,
 
 	// Render all mesh buffers in order
 	drawcall_count += draw_order.size();
+	u16 i = 0;
 
 	for (auto &descriptor : draw_order) {
 		scene::IMeshBuffer *buf = descriptor.getBuffer();
 
 		// Check and abort if the machine is swapping a lot
-		if (draw.getTimerTime() > 1000) {
+		// Avoid checking too frequently because getTimerTime() is expensive
+		if (++i % 128 == 0 && draw.getTimerTime() > 1000) {
 			infostream << "ClientMap::renderMapShadows(): Rendering "
 					"took >1s, returning." << std::endl;
 			break;

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -445,18 +445,9 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 
 	// Render all mesh buffers in order
 	drawcall_count += draw_order.size();
-	u16 i = 0;
 
 	for (auto &descriptor : draw_order) {
 		scene::IMeshBuffer *buf = descriptor.getBuffer();
-
-		// Check and abort if the machine is swapping a lot
-		// Avoid checking too frequently because getTimerTime() is expensive
-		if (++i % 128 == 0 && draw.getTimerTime() > 2000) {
-			infostream << "ClientMap::renderMap(): Rendering took >2s, " <<
-					"returning." << std::endl;
-			return;
-		}
 
 		if (!descriptor.m_reuse_material) {
 			auto &material = buf->getMaterial();
@@ -801,18 +792,9 @@ void ClientMap::renderMapShadows(video::IVideoDriver *driver,
 
 	// Render all mesh buffers in order
 	drawcall_count += draw_order.size();
-	u16 i = 0;
 
 	for (auto &descriptor : draw_order) {
 		scene::IMeshBuffer *buf = descriptor.getBuffer();
-
-		// Check and abort if the machine is swapping a lot
-		// Avoid checking too frequently because getTimerTime() is expensive
-		if (++i % 128 == 0 && draw.getTimerTime() > 1000) {
-			infostream << "ClientMap::renderMapShadows(): Rendering "
-					"took >1s, returning." << std::endl;
-			break;
-		}
 
 		if (!descriptor.m_reuse_material) {
 			// override some material properties

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -502,7 +502,7 @@ public:
 		float clr[4] = {star_color.r, star_color.g, star_color.b, star_color.a};
 		m_star_color.set(clr, services);
 
-		u32 animation_timer = porting::getTimeMs() % 1000000;
+		u32 animation_timer = m_client->getEnv().getFrameTime() % 1000000;
 		float animation_timer_f = (float)animation_timer / 100000.f;
 		m_animation_timer_vertex.set(&animation_timer_f, services);
 		m_animation_timer_pixel.set(&animation_timer_f, services);
@@ -3275,7 +3275,7 @@ PointedThing Game::updatePointedThing(
 		final_color_blend(&c, light_level, daynight_ratio);
 
 		// Modify final color a bit with time
-		u32 timer = porting::getTimeMs() % 5000;
+		u32 timer = client->getEnv().getFrameTime() % 5000;
 		float timerf = (float) (irr::core::PI * ((timer / 2500.0) - 0.5));
 		float sin_r = 0.08f * std::sin(timerf);
 		float sin_g = 0.08f * std::sin(timerf + irr::core::PI * 0.5f);
@@ -3746,6 +3746,12 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 {
 	TimeTaker tt_update("Game::updateFrame()");
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
+
+	/*
+		Frame time
+	*/
+
+	client->getEnv().updateFrameTime();
 
 	/*
 		Fog range


### PR DESCRIPTION
Optimization is based on this graph from hotspot:
![image](https://user-images.githubusercontent.com/4933697/183767134-5558a631-5464-4a0c-a4d2-33fc08f522ae.png)

1. Remove excessive calls to TimeTaker in renderMap() and renderMapShadow()
2. Centralize clock time per frame in ClientEnvironment and avoid calling porting::getTimeMs() from shader constant setters.

## To do

This PR is Ready for Review.

## How to test

1. Start any game
2. FPS should be higher, and rendering should be correct.
