### PR TITLE
Allow buffer argument to VoxelManip:get_light_data

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -24,6 +24,7 @@ core.features = {
 	particlespawner_tweenable = true,
 	dynamic_add_media_table = true,
 	get_sky_as_table = true,
+	get_light_data_buffer = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4386,12 +4386,15 @@ Methods
       `minetest.get_mapgen_object`.
     * (`p1`, `p2`) is the area in which lighting is set, defaults to the whole
       area if left out.
-* `get_light_data()`: Gets the light data read into the `VoxelManip` object
+* `get_light_data([buffer])`: Gets the light data read into the
+  `VoxelManip` object
     * Returns an array (indices 1 to volume) of integers ranging from `0` to
       `255`.
     * Each value is the bitwise combination of day and night light values
       (`0` to `15` each).
     * `light = day + (night * 16)`
+    * If the param `buffer` is present, this table will be used to store the
+      result instead.
 * `set_light_data(light_data)`: Sets the `param1` (light) contents of each node
   in the `VoxelManip`.
     * expects lighting data in the same format that `get_light_data()` returns
@@ -4863,6 +4866,8 @@ Utilities
           particlespawner_tweenable = true,
           -- allows get_sky to return a table instead of separate values (5.6.0)
           get_sky_as_table = true,
+          -- VoxelManip:get_light_data accepts an optional buffer argument (5.7.0)
+          get_light_data_buffer = true,
       }
 
 * `minetest.has_feature(arg)`: returns `boolean, missing_features`

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -260,11 +260,17 @@ int LuaVoxelManip::l_get_light_data(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 
 	LuaVoxelManip *o = checkobject(L, 1);
+	bool use_buffer  = lua_istable(L, 2);
+
 	MMVManip *vm = o->vm;
 
 	u32 volume = vm->m_area.getVolume();
 
-	lua_createtable(L, volume, 0);
+	if (use_buffer)
+		lua_pushvalue(L, 2);
+	else
+		lua_createtable(L, volume, 0);
+
 	for (u32 i = 0; i != volume; i++) {
 		lua_Integer light = vm->m_data[i].param1;
 		lua_pushinteger(L, light);


### PR DESCRIPTION
This is just a trivial addition. It brings `get_light_data` in line with `get_data` and `get_param2_data`.

## To do

This PR is Ready for Review.

## How to test

The code changes are minimal. You can just run some code that provides a buffer to `get_light_data`, I guess.
