### PR TITLE
Fix crash when crafting callbacks return strings

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -303,14 +303,16 @@ end
 
 function core.on_craft(itemstack, player, old_craft_list, craft_inv)
 	for _, func in ipairs(core.registered_on_crafts) do
-		itemstack = func(itemstack, player, old_craft_list, craft_inv) or itemstack
+		-- cast to ItemStack since func() could return a string
+		itemstack = ItemStack(func(itemstack, player, old_craft_list, craft_inv) or itemstack)
 	end
 	return itemstack
 end
 
 function core.craft_predict(itemstack, player, old_craft_list, craft_inv)
 	for _, func in ipairs(core.registered_craft_predicts) do
-		itemstack = func(itemstack, player, old_craft_list, craft_inv) or itemstack
+		-- cast to ItemStack since func() could return a string
+		itemstack = ItemStack(func(itemstack, player, old_craft_list, craft_inv) or itemstack)
 	end
 	return itemstack
 end


### PR DESCRIPTION
Fixes #4947

## To do

This PR is Ready for Review.

## How to test
* add:
```lua
minetest.register_on_craft(function(itemstack, player, old_craft_grid, craft_inv)
    return "default:wood"
end)

```
* craft whatever. No crash (MTG needed)