### PR TITLE
New mapblocks-for-sending selection algorithm

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1900,11 +1900,11 @@ emergequeue_limit_total (Absolute limit of queued blocks to emerge) int 1024 1 1
 
 #    Maximum number of blocks to be queued that are to be loaded from file.
 #    This limit is enforced per player.
-emergequeue_limit_diskonly (Per-player limit of queued blocks load from disk) int 128 1 1000000
+emergequeue_limit_diskonly (Per-player limit of queued blocks load from disk) int 50 1 1000000
 
 #    Maximum number of blocks to be queued that are to be generated.
 #    This limit is enforced per player.
-emergequeue_limit_generate (Per-player limit of queued blocks to generate) int 128 1 1000000
+emergequeue_limit_generate (Per-player limit of queued blocks to generate) int 10 1 1000000
 
 #    Number of emerge threads to use.
 #    Value 0:

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -2963,12 +2963,12 @@
 #    Maximum number of blocks to be queued that are to be loaded from file.
 #    This limit is enforced per player.
 #    type: int min: 1 max: 1000000
-# emergequeue_limit_diskonly = 128
+# emergequeue_limit_diskonly = 50
 
 #    Maximum number of blocks to be queued that are to be generated.
 #    This limit is enforced per player.
 #    type: int min: 1 max: 1000000
-# emergequeue_limit_generate = 128
+# emergequeue_limit_generate = 10
 
 #    Number of emerge threads to use.
 #    Value 0:

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -230,6 +230,7 @@ public:
 	void handleCommand_MediaPush(NetworkPacket *pkt);
 	void handleCommand_MinimapModes(NetworkPacket *pkt);
 	void handleCommand_SetLighting(NetworkPacket *pkt);
+	void handleCommand_FarBlocksResult(NetworkPacket* pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 
@@ -366,6 +367,8 @@ public:
 	scene::ISceneManager *getSceneManager();
 
 	bool shouldShowMinimap() const;
+
+	s32 calculateReasonableMapblockLimit();
 
 	// IGameDef interface
 	IItemDefManager* getItemDefManager() override;
@@ -606,4 +609,6 @@ private:
 	u32 m_csm_restriction_noderange = 8;
 
 	std::unique_ptr<ModChannelMgr> m_modchannel_mgr;
+
+	IntervalLimiter m_blocks_request_interval;
 };

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -35,6 +35,17 @@ struct MapDrawControl
 	bool allow_noclip = false;
 	// show a wire frame for debugging
 	bool show_wireframe = false;
+
+	// These are updated by ClientMap::updateDrawList
+	// Number of blocks rendered
+	u32 blocks_drawn = 0;
+	// Distance to the farthest block drawn
+	float farthest_drawn = 0;
+	// The maximum-number-of-blocks value told to the server is increased by
+	// this value so that new areas can be received while keeping the old ones
+	// in memory until they time out (so that if the player moves back and
+	// forth, stuff isn't constantly being dropped and re-downloaded)
+	u32 num_blocks_dont_exist_but_probably_should_be_requested_from_server;
 };
 
 struct MeshBufList
@@ -135,6 +146,11 @@ public:
 	const MapDrawControl & getControl() const { return m_control; }
 	f32 getWantedRange() const { return m_control.wanted_range; }
 	f32 getCameraFov() const { return m_camera_fov; }
+	
+	std::vector<v3s16> suggestMapBlocksToFetch(v3s16 camera_p,
+			size_t wanted_num_results);
+	s16 suggestAutosendMapblocksRadius(); // Result in MapBlocks
+	float suggestAutosendFov();
 
 private:
 
@@ -206,4 +222,8 @@ private:
 	bool m_cache_anistropic_filter;
 	bool m_added_to_shadow_renderer{false};
 	u16 m_cache_transparency_sorting_distance;
+
+	// Fetch suggestion algorithm
+	s16 m_mapblocks_exist_up_to_d;
+	s16 m_mapblocks_exist_up_to_d_reset_counter;
 };

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -104,6 +104,7 @@ public:
 	 */
 	virtual Palette* getPalette(const std::string &name) = 0;
 	virtual bool isKnownSourceImage(const std::string &name)=0;
+	virtual video::IImage* generateImage(const std::string &name)=0;
 	virtual video::ITexture* getNormalTexture(const std::string &name)=0;
 	virtual video::SColor getTextureAverageColor(const std::string &name)=0;
 	virtual video::ITexture *getShaderFlagsTexture(bool normalmap_present)=0;

--- a/src/constants.h
+++ b/src/constants.h
@@ -82,6 +82,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // Player step height in nodes
 #define PLAYER_DEFAULT_STEPHEIGHT 0.6f
 
+// FarBlock size in MapBlocks in every dimension. This is hardcoded too so that
+// caching and networking can be done efficiently as no conversions are needed.
+#define FMP_SCALE 8
+
 /*
     Old stuff that shouldn't be hardcoded
 */

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -412,8 +412,8 @@ void set_default_settings()
 	settings->setDefault("debug_log_size_max", "50");
 	settings->setDefault("chat_log_level", "error");
 	settings->setDefault("emergequeue_limit_total", "1024");
-	settings->setDefault("emergequeue_limit_diskonly", "128");
-	settings->setDefault("emergequeue_limit_generate", "128");
+	settings->setDefault("emergequeue_limit_diskonly", "50");
+	settings->setDefault("emergequeue_limit_generate", "10");
 	settings->setDefault("num_emerge_threads", "1");
 	settings->setDefault("secure.enable_security", "true");
 	settings->setDefault("secure.trusted_mods", "");

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -426,14 +426,20 @@ bool EmergeManager::pushBlockEmergeData(
 			return false;
 
 		if (peer_requested != PEER_ID_INEXISTENT) {
-			u32 qlimit_peer = (flags & BLOCK_EMERGE_ALLOW_GEN) ?
-				m_qlimit_generate : m_qlimit_diskonly;
-			if (count_peer >= qlimit_peer)
+			// If we are over the limit for from-disk loading, we can't do
+			// anything in any case.
+			if (count_peer >= m_qlimit_diskonly)
 				return false;
-		} else {
-			// limit block enqueue requests for active blocks to 1/2 of total
-			if (count_peer * 2 >= m_qlimit_total)
-				return false;
+
+			// Otherwise we might do something.
+			if (count_peer < m_qlimit_generate) {
+				// We are under the queue limit for generation or we will not be
+				// gneerating anything; pass
+			} else {
+				// We want to generate something but we are over queue limit for
+				// that; don't generate but try just loading instead.
+				flags &= ~BLOCK_EMERGE_ALLOW_GEN;
+			}
 		}
 	}
 
@@ -461,6 +467,9 @@ bool EmergeManager::pushBlockEmergeData(
 
 bool EmergeManager::popBlockEmergeData(v3s16 pos, BlockEmergeData *bedata)
 {
+	g_profiler->avg("Emerge: Queue avg size", m_blocks_enqueued.size());
+	//dstream<<"emerge queue size: "<<m_blocks_enqueued.size()<<std::endl;
+
 	auto it = m_blocks_enqueued.find(pos);
 	if (it == m_blocks_enqueued.end())
 		return false;
@@ -596,15 +605,14 @@ EmergeAction EmergeThread::getBlockOrStartGen(
 
 	// 1). Attempt to fetch block from memory
 	*block = m_map->getBlockNoCreateNoEx(pos);
-	if (*block && !(*block)->isDummy()) {
-		if ((*block)->isGenerated())
-			return EMERGE_FROM_MEMORY;
-	} else {
-		// 2). Attempt to load block from disk if it was not in the memory
-		*block = m_map->loadBlock(pos);
-		if (*block && (*block)->isGenerated())
-			return EMERGE_FROM_DISK;
-	}
+	if (*block && !(*block)->isDummy() && (*block)->isGenerated())
+		return EMERGE_FROM_MEMORY;
+
+	// 2). Attempt to load block from disk
+	g_profiler->add("Emerge: Attempted MapBlock loads", 1);
+	*block = m_map->loadBlock(pos);
+	if (*block && (*block)->isGenerated())
+		return EMERGE_FROM_DISK;
 
 	// 3). Attempt to start generation
 	if (allow_gen && m_map->initBlockMake(pos, bmdata))
@@ -657,6 +665,8 @@ MapBlock *EmergeThread::finishGen(v3s16 pos, BlockMakeData *bmdata,
 
 	EMERGE_DBG_OUT("ended up with: " << analyze_block(block));
 
+	g_profiler->add("Emerge: Chunks generated", 1);
+
 	/*
 		Clear mapgen state
 	*/
@@ -671,7 +681,6 @@ MapBlock *EmergeThread::finishGen(v3s16 pos, BlockMakeData *bmdata,
 
 	return block;
 }
-
 
 void *EmergeThread::run()
 {
@@ -693,6 +702,8 @@ void *EmergeThread::run()
 		MapBlock *block = nullptr;
 
 		if (!popBlockEmerge(&pos, &bedata)) {
+			ScopeProfiler sp(g_profiler,
+					"Emerge: Queue empty time", SPT_ADD);
 			m_queue_event.wait();
 			continue;
 		}
@@ -722,8 +733,11 @@ void *EmergeThread::run()
 		if (block)
 			modified_blocks[pos] = block;
 
+		// This is kind of a vague number but it still tells something
+		g_profiler->add("Emerge: Blocks modified", modified_blocks.size());
+
 		if (!modified_blocks.empty())
-			m_server->SetBlocksNotSent(modified_blocks);
+			m_server->SetMapBlocksUpdated(modified_blocks);
 		modified_blocks.clear();
 	}
 	} catch (VersionMismatchException &e) {

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -170,12 +170,14 @@ public:
 	void stopThreads();
 	bool isRunning();
 
+	// Returns false if queue is full
 	bool enqueueBlockEmerge(
 		session_t peer_id,
 		v3s16 blockpos,
 		bool allow_generate,
 		bool ignore_queue_limits=false);
 
+	// Returns false if queue is full
 	bool enqueueBlockEmergeEx(
 		v3s16 blockpos,
 		session_t peer_id,
@@ -219,7 +221,7 @@ private:
 
 	// Requires m_queue_mutex held
 	EmergeThread *getOptimalThread();
-
+	// Returns false if queue is full
 	bool pushBlockEmergeData(
 		v3s16 pos,
 		u16 peer_requested,

--- a/src/map.h
+++ b/src/map.h
@@ -204,8 +204,12 @@ public:
 	/*
 		Updates usage timers and unloads unused blocks and sectors.
 		Saves modified blocks before unloading if possible.
+
+		Does not unload blocks inside the sphere centered at retain_sphere_p,
+		radius retain_sphere_r (nodes). (Check disabled if r<=1.0f)
 	*/
 	void timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
+			const v3f &retain_sphere_p, float retain_sphere_r,
 			std::vector<v3s16> *unloaded_blocks=NULL);
 
 	/*

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -117,7 +117,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_SET_SUN",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetSun }, // 0x5a
 	{ "TOCLIENT_SET_MOON",                 TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetMoon }, // 0x5b
 	{ "TOCLIENT_SET_STARS",                TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetStars }, // 0x5c
-	null_command_handler,
+	{ "TOCLIENT_FAR_BLOCKS_RESULT",        TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FarBlocksResult }, // 0x5d
 	null_command_handler,
 	null_command_handler,
 	{ "TOCLIENT_SRP_BYTES_S_B",            TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_SrpBytesSandB }, // 0x60
@@ -223,4 +223,6 @@ const ServerCommandFactory serverCommandFactoryTable[TOSERVER_NUM_MSG_TYPES] =
 	{ "TOSERVER_FIRST_SRP",          1, true }, // 0x50
 	{ "TOSERVER_SRP_BYTES_A",        1, true }, // 0x51
 	{ "TOSERVER_SRP_BYTES_M",        1, true }, // 0x52
+	null_command_factory, // 0x53
+	{ "TOSERVER_SET_WANTED_MAP_SEND_QUEUE", 2, true }, // 0x54
 };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -36,6 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/sound.h"
 #include "network/clientopcodes.h"
 #include "network/connection.h"
+#include "profiler.h"
 #include "script/scripting_client.h"
 #include "util/serialize.h"
 #include "util/srp.h"
@@ -1765,3 +1766,23 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.shadow_intensity;
 }
+
+void Client::handleCommand_FarBlocksResult(NetworkPacket* pkt_in)
+{
+	infostream << "Client: Received FAR_BLOCKS_RESULT" << std::endl;
+
+	/*
+		v3s16 p (position in farblocks)
+		u8 status
+		u8 flags
+		v3s16 divs_per_mb (amount of divisions per mapblock)
+		u32 data_len
+		Zlib-compressed:
+			for each FarNode (indexed by VoxelArea):
+				u16 node_id
+				u8 light (both lightbanks; raw value)
+	*/
+
+	// Not supported, but packet reserved for future versions.
+}
+

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -114,6 +114,22 @@ public:
 	NetworkPacket &operator>>(video::SColor &dst);
 	NetworkPacket &operator<<(video::SColor src);
 
+	// With this function you can control the format you are reading from
+	// vs. the type you are putting your result into. Use for enums and
+	// stuff. Also allows nicer-looking code when you don't have to split
+	// reads into two statements.
+	template<typename T> T read() {
+		T buf;
+		*this >> buf;
+		return buf;
+	}
+
+	// Same thing for writing. Create a copy of the parameter just so that
+	// it can be implicitly or non-implicitly cast.
+	template<typename T> void write(T v) {
+		*this << v;
+	}
+
 	// Temp, we remove SharedBuffer when migration finished
 	// ^ this comment has been here for 4 years
 	Buffer<u8> oldForgePacket();

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -107,6 +107,8 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	{ "TOSERVER_FIRST_SRP",                TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_FirstSrp }, // 0x50
 	{ "TOSERVER_SRP_BYTES_A",              TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_SrpBytesA }, // 0x51
 	{ "TOSERVER_SRP_BYTES_M",              TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_SrpBytesM }, // 0x52
+	null_command_handler, // 0x53
+	{ "TOSERVER_SET_WANTED_MAP_SEND_QUEUE", TOSERVER_STATE_INGAME, &Server::handleCommand_SetWantedMapSendQueue }, // 0x54
 };
 
 const static ClientCommandFactory null_command_factory = { "TOCLIENT_NULL", 0, false };
@@ -216,7 +218,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_SET_SUN",                  0, true }, // 0x5a
 	{ "TOCLIENT_SET_MOON",                 0, true }, // 0x5b
 	{ "TOCLIENT_SET_STARS",                0, true }, // 0x5c
-	null_command_factory, // 0x5d
+	{ "TOCLIENT_FAR_BLOCKS_RESULT",        2, true }, // 0x5d
 	null_command_factory, // 0x5e
 	null_command_factory, // 0x5f
 	{ "TOSERVER_SRP_BYTES_S_B",            0, true }, // 0x60

--- a/src/network/wms_priority.h
+++ b/src/network/wms_priority.h
@@ -1,0 +1,81 @@
+/*
+Minetest
+Copyright (C) 2015 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef WMS_PRIORITY_HEADER
+#define WMS_PRIORITY_HEADER
+#include "constants.h"
+#include "networkprotocol.h"
+
+struct WMSPriority
+{
+	v3s16 player_p;
+	float far_weight;
+
+	WMSPriority(v3s16 player_p, float far_weight):
+		player_p(player_p),
+		far_weight(far_weight)
+	{}
+
+	// Lower is more important
+	float getPriority(const WantedMapSend &wms) {
+		float priority;
+		switch (wms.type) {
+		case WMST_INVALID:
+			assert("WMST_INVALID");
+			priority = 1000000;
+			break;
+		case WMST_MAPBLOCK:
+			{
+				v3s16 center_p = wms.p * MAP_BLOCKSIZE +
+						v3s16(1,1,1) * (MAP_BLOCKSIZE/2);
+				priority = (player_p - center_p).getLength();
+			}
+			break;
+		case WMST_FARBLOCK:
+			{
+				v3s16 center_p = wms.p * MAP_BLOCKSIZE * FMP_SCALE +
+						v3s16(1,1,1) * (MAP_BLOCKSIZE*FMP_SCALE/2);
+				priority = (player_p - center_p).getLength();
+
+				// Lessen priority by a static amount so that close-by MapBlocks
+				// are always transferred first
+				priority += MAP_BLOCKSIZE * FMP_SCALE;
+
+				if (far_weight <= 0.0f)
+					priority /= 0.1f; // Just get some proportional large value
+					                  // so that FarBlocks are in correct order
+					                  // to each other
+				else
+					priority /= far_weight;
+			}
+			break;
+		default:
+			priority = 1000000;
+			break;
+		}
+		return priority;
+	}
+
+	// Sorts WantedMapSends in descending order of priority
+	bool operator() (const WantedMapSend& wms1, const WantedMapSend& wms2) {
+		return (getPriority(wms1) < getPriority(wms2));
+	}
+};
+
+#endif

--- a/src/server.h
+++ b/src/server.h
@@ -195,6 +195,7 @@ public:
 	void handleCommand_SrpBytesA(NetworkPacket* pkt);
 	void handleCommand_SrpBytesM(NetworkPacket* pkt);
 	void handleCommand_HaveMedia(NetworkPacket *pkt);
+	void handleCommand_SetWantedMapSendQueue(NetworkPacket* pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 
@@ -442,7 +443,7 @@ private:
 		u16 protocol_version);
 
 	/* mark blocks not sent for all clients */
-	void SetBlocksNotSent(std::map<v3s16, MapBlock *>& block);
+	void SetMapBlocksUpdated(std::map<v3s16, MapBlock *>& blocks);
 
 
 	virtual void SendChatMessage(session_t peer_id, const ChatMessage &message);

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -6,4 +6,5 @@ set(server_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/serveractiveobject.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/serverinventorymgr.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/unit_sao.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/autosend.cpp
 	PARENT_SCOPE)

--- a/src/server/autosend.cpp
+++ b/src/server/autosend.cpp
@@ -1,0 +1,952 @@
+/*
+Minetest
+Copyright (C) 2010-2022 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "autosend.h"
+#include "clientiface.h" // RemoteClient
+#include "mapblock.h"
+#include "serverenvironment.h"
+#include "network/wms_priority.h"
+#include "server/player_sao.h"
+#include "server/luaentity_sao.h"
+#include "remoteplayer.h"
+#include "face_position_cache.h"
+#include "util/basic_macros.h"
+
+struct WMSSPriority: WMSPriority
+{
+	WMSSPriority(v3s16 player_p, float far_weight):
+		WMSPriority(player_p, far_weight)
+	{}
+
+	// Lower is more important
+	float getPriority(const WMSSuggestion &wmss) {
+		return WMSPriority::getPriority(wmss.wms);
+	}
+
+	// Sorts WMSSuggestions in descending order of priority
+	bool operator() (const WMSSuggestion& wms1, const WMSSuggestion& wms2) {
+		return (getPriority(wms1) < getPriority(wms2));
+	}
+};
+
+/*
+	AutosendAlgorithm
+*/
+
+u16 figure_out_max_simultaneous_block_sends(u16 base_setting,
+		float time_from_building, float time_from_building_limit_setting,
+		s16 block_distance_in_blocks)
+{
+	// If block is very close, always send the configured amount
+	if (block_distance_in_blocks <= BLOCK_SEND_DISABLE_LIMITS_MAX_D)
+		return base_setting;
+
+	// If the time from last addNode/removeNode is small, don't send as much
+	// stuff in order to reduce lag
+	if (time_from_building < time_from_building_limit_setting)
+		return LIMITED_MAX_SIMULTANEOUS_BLOCK_SENDS;
+
+	// Send the configured amount if nothing special is happening
+	return base_setting;
+}
+
+RemoteClient::RemoteClient(ServerEnvironment *env):
+	m_env(env),
+	m_autosend(this)
+{
+}
+
+struct AutosendCycle
+{
+	bool disabled = false;
+	AutosendAlgorithm *alg = nullptr;
+	RemoteClient *client = nullptr;
+	ServerEnvironment *env = nullptr;
+
+	v3f camera_p;
+	v3f camera_dir;
+	v3s16 focus_point_nodepos;
+	v3s16 focus_point;
+	float fov = 1.72f; // Modified FOV based on client's FOV
+
+	u16 max_simul_sends_setting = 0;
+	float time_from_building_limit_s = 0;
+	s16 max_mapblock_send_distance_setting = 0; // Setting as-is
+	s16 max_mapblock_generate_distance_setting = 0; // Setting as-is
+	s16 max_mapblock_send_distance = 0; // Modified value during cycle
+	s16 max_mapblock_generate_distance = 0; // Modified value during cycle
+	bool far_map_allow_generate = false;
+	bool server_side_occlusion_culling_setting = true;
+	s16 block_send_optimize_distance_setting = 0; // TODO: Remove?
+	float max_send_distance_bs = 0;
+
+	std::list<v3s16> finished_mapblock_emerges;
+
+	struct Search {
+		s32 log_id; // Id used for logging and debugging (peer id)
+		const char *log_name = "?"; // Name used for logging and debugging (mapblock/farblock)
+
+		// All of these are reset by start()
+		s16 max_send_distance = 0;
+		s16 fov_limit_activation_distance = 0;
+		s16 d_start = 0;
+		s16 d_max = 0;
+		s16 d = 0;
+		size_t i = 0;
+		s32 nearest_emergequeued_d = 0;
+		s32 nearest_emergefull_d = 0;
+		s32 nearest_sendqueued_d = 0;
+
+		// All of these are persistent
+		s16 nearest_unsent_d = 0;
+		bool fov_limit_enabled = true; // Automatically turned off to transfer the rest
+		float nothing_to_send_timer = 0; // // Counts up from 0
+		float nothing_to_send_pause_timer = 0; // CPU usage optimization. Pause if >=0; decrements
+
+		Search(){}
+
+		void runTimers(float dtime);
+
+		void start(s16 max_send_distance_, s16 fov_limit_activation_distance_);
+
+		void finish(bool enable_fov_toggle);
+	};
+
+	Search mapblock;
+	Search farblock;
+
+	AutosendCycle():
+		disabled(true)
+	{
+		mapblock.log_name = "map";
+		farblock.log_name = "far";
+	}
+
+	void start(AutosendAlgorithm *alg_,
+			RemoteClient *client_, ServerEnvironment *env_);
+
+	//WMSSuggestion getNextBlock(EmergeManager *emerge, ServerFarMap *far_map);
+	WMSSuggestion getNextBlock(EmergeManager *emerge);
+
+	void finish();
+
+private:
+	enum class MapBlockAnalysis {
+		IN_VIEW_AND_LOADED,
+		IN_VIEW_BUT_NOT_LOADED, // Disk not checked
+		IN_VIEW_BUT_NOT_GENERATED, // Disk checked
+		NOT_IN_VIEW,
+		ALREADY_SENT,
+	};
+	MapBlockAnalysis checkMapBlock(const v3s16 &p);
+	WMSSuggestion suggestNextMapBlock(EmergeManager *emerge);
+	//WMSSuggestion suggestNextFarBlock(EmergeManager *emerge, ServerFarMap *far_map);
+};
+
+LuaEntitySAO *getAttachedObject(PlayerSAO *sao, ServerEnvironment *env)
+{
+	if (!sao->isAttached())
+		return nullptr;
+
+	int id;
+	std::string bone;
+	v3f dummy;
+	bool force_visible;
+	sao->getAttachment(&id, &bone, &dummy, &dummy, &force_visible);
+	ServerActiveObject *ao = env->getActiveObject(id);
+	while (id && ao) {
+		ao->getAttachment(&id, &bone, &dummy, &dummy, &force_visible);
+		if (id)
+			ao = env->getActiveObject(id);
+	}
+	return dynamic_cast<LuaEntitySAO *>(ao);
+}
+
+void AutosendCycle::start(AutosendAlgorithm *alg_,
+		RemoteClient *client_, ServerEnvironment *env_)
+{
+	alg = alg_;
+	client = client_;
+	env = env_;
+
+	mapblock.log_id = client->peer_id;
+	farblock.log_id = client->peer_id;
+
+	disabled = false;
+
+	if (alg->m_radius_map == 0 && alg->m_radius_far == 0) {
+		tracestream<<"AutosendCycle::start(): peer_id="<<client->peer_id
+				<<": radius=0"<<std::endl;
+		disabled = true;
+		return;
+	}
+
+	// Disable if MapBlock and FarBlock pauses are active
+	if (mapblock.nothing_to_send_pause_timer >= 0 &&
+			farblock.nothing_to_send_pause_timer >= 0) {
+		tracestream<<"AutosendCycle::start(): peer_id="<<client->peer_id
+				<<": nothing to send pause (map+far)"<<std::endl;
+		disabled = true;
+		return;
+	}
+
+	RemotePlayer *player = env->getPlayer(client->peer_id);
+	if (player == NULL) {
+		tracestream<<"AutosendCycle::start(): peer_id="<<client->peer_id
+				<<": player==NULL"<<std::endl;
+		// This can happen sometimes; clients and players are not in perfect sync.
+		disabled = true;
+		return;
+	}
+
+	PlayerSAO *sao = player->getPlayerSAO();
+	if (sao == NULL) {
+		tracestream<<"AutosendCycle::start(): peer_id="<<client->peer_id
+				<<": sao==NULL"<<std::endl;
+		disabled = true;
+		return;
+	}
+
+	// Get some settings. We need the first one for the next check so get them
+	// all.
+	max_simul_sends_setting =
+			g_settings->getU16("max_simultaneous_block_sends_per_client");
+	time_from_building_limit_s =
+			g_settings->getFloat("full_block_send_enable_min_time_from_building");
+	max_mapblock_send_distance_setting =
+			g_settings->getS16("max_block_send_distance");
+	max_mapblock_generate_distance_setting =
+			g_settings->getS16("max_block_generate_distance");
+	server_side_occlusion_culling_setting =
+			g_settings->getBool("server_side_occlusion_culling");
+	block_send_optimize_distance_setting =
+			g_settings->getS16("block_send_optimize_distance");
+	far_map_allow_generate = false;
+
+	// Won't send anything if already sending enough
+	if (client->m_blocks_sending.size() >= max_simul_sends_setting) {
+		tracestream<<"AutosendCycle::start(): peer_id="<<client->peer_id
+				<<": client->m_blocks_sending.size()="<<client->m_blocks_sending.size()
+				<<" > max_simul_sends_setting="<<max_simul_sends_setting<<std::endl;
+		disabled = true;
+		return;
+	}
+
+	tracestream<<"AutosendCycle::start(): peer_id="<<client_->peer_id
+			<<": Starting normally"<<std::endl;
+
+	// Use camera position as the center for searching blocks
+	// Camera position and direction
+	camera_p = sao->getEyePosition();
+	camera_dir = v3f(0,0,1);
+	camera_dir.rotateYZBy(sao->getLookPitch());
+	camera_dir.rotateXZBy(sao->getRotation().Y);
+
+	// Get the player's speed
+	// If the player is attached, get the velocity from the attached object
+	// (In practice the player walks at around BS*4/second and fast speed is at
+	// around BS*16/second, but these of course depend on the game and mods.)
+	LuaEntitySAO *lsao = getAttachedObject(sao, env);
+	const v3f &player_velocity = lsao? lsao->getVelocity() : player->getSpeed();
+
+	// Get player position and figure out a good focus point for block selection
+	v3f player_velocity_dir(0,0,0);
+	if(player_velocity.getLength() > 1.0f * BS)
+		player_velocity_dir = player_velocity / player_velocity.getLength();
+
+	// Predict one block into player's movement direction
+	v3f camera_p_predicted = camera_p + player_velocity_dir * MAP_BLOCKSIZE * BS;
+
+	// Focus point is at predicted camera position
+	focus_point_nodepos = floatToInt(camera_p_predicted, BS);
+	focus_point = getNodeBlockPos(focus_point_nodepos);
+
+	// If focus point has changed to a different MapBlock, reset radius value
+	// for iterating from zero again
+	if (alg->m_last_focus_point != focus_point) {
+		alg->m_cycle->mapblock.nearest_unsent_d = 0;
+		alg->m_cycle->farblock.nearest_unsent_d = 0;
+		alg->m_last_focus_point = focus_point;
+	}
+	// If camera has turned considerably, reset radius value for iterating from
+	// zero again (has to be done because of FOV dependence of some things)
+	if (alg->m_last_camera_dir.dotProduct(camera_dir) < 0.8f) {
+		alg->m_cycle->mapblock.nearest_unsent_d = 0;
+		alg->m_cycle->farblock.nearest_unsent_d = 0;
+		alg->m_last_camera_dir = camera_dir;
+	}
+
+	// Derived settings
+	max_mapblock_send_distance = std::min(adjustDist(
+			max_mapblock_send_distance_setting, alg->m_fov), alg->m_radius_map);
+	max_mapblock_generate_distance = std::min(adjustDist(
+			max_mapblock_generate_distance_setting, alg->m_fov), alg->m_radius_map);
+	max_send_distance_bs = (float)alg->m_radius_map * BS * MAP_BLOCKSIZE;
+
+	// FOV
+	fov = alg->m_fov; // Begin with client's reported FOV
+
+	// If the player not using the zoom function and is moving fast, replace
+	// camera direction with the player's movement direction to make sure the
+	// right stuff is being sent. Also replace the FOV value with a static one.
+	// When moving fast, the real camera direction and FOV are worthless.
+	if(sao->getZoomFOV() < 0.001f && player_velocity.getLength() > 10.0f * BS){
+		fov = 1.72f;
+		camera_dir = player_velocity;
+	}
+
+	// Reduce the field of view when a player moves and looks forward.
+	// limit max fov effect to 50%, 60% at 20n/s fly speed
+
+	// cos(angle between velocity and camera) * |velocity|
+	// Limit to 0.0f in case player moves backwards.
+	f32 dot = rangelim(camera_dir.dotProduct(player_velocity), 0.0f, 300.0f);
+
+	fov = fov / (1 + dot / 300.0f);
+
+	// Reset periodically to workaround possible glitches due to whatever
+	// reasons (this is somewhat guided by just heuristics, after all)
+	if (alg->m_nearest_unsent_reset_timer > 20.0) {
+		alg->m_nearest_unsent_reset_timer = 0;
+		alg->m_cycle->mapblock.nearest_unsent_d = 0;
+		alg->m_cycle->farblock.nearest_unsent_d = 0;
+	}
+
+	// MapBlock search iteration
+	// Out-of-FOV distance limit is decreased when limit is enabled
+	//s16 mb_fov_limit_activation_distance = 1; // This is the classic behavior
+	s16 mb_fov_limit_activation_distance = mapblock.fov_limit_enabled ?
+			max_mapblock_send_distance / 5 : max_mapblock_send_distance;
+	mapblock.start(max_mapblock_send_distance, mb_fov_limit_activation_distance);
+
+	// FarBlock search iteration
+	// Out-of-FOV distance limit is always disabled
+	// TODO: Enable later
+	//s16 fb_fov_limit_activation_distance = alg->m_radius_far;
+	//farblock.start(alg->m_radius_far, fb_fov_limit_activation_distance);
+	// TODO: Remove once farblocks are enabled. This allows the system to sleep
+	// when no mapblocks were found.
+	farblock.nothing_to_send_pause_timer = 5.0;
+}
+
+static void AutosendCycleEmergeCallback(v3s16 bp, EmergeAction action, void *param)
+{
+	AutosendCycle *cycle = (AutosendCycle*)param;
+	tracestream<<"AutosendCycleEmergeCallback(): peer_id="
+				<<cycle->client->peer_id<<": bp="<<PP(bp)
+				<<", action="<<(int)action<<std::endl;
+
+	if(action == EMERGE_FROM_MEMORY || action == EMERGE_FROM_DISK ||
+			action == EMERGE_GENERATED){
+		// Add to shortcut queue
+		cycle->finished_mapblock_emerges.push_back(bp);
+	}
+}
+
+AutosendCycle::MapBlockAnalysis AutosendCycle::checkMapBlock(const v3s16 &p)
+{
+	// Don't go over hard map limits
+	if (blockpos_over_max_limit(p)) {
+		/*dstream<<"AutosendMap: "<<wms.describe()
+				<<": continue: over limit"<<std::endl;*/
+		return AutosendCycle::MapBlockAnalysis::NOT_IN_VIEW;
+	}
+
+	WantedMapSend wms(WMST_MAPBLOCK, p);
+
+	// Don't send blocks that are currently being transferred
+	if (client->m_blocks_sending.count(wms)) {
+		/*dstream<<"AutosendMap: "<<wms.describe()
+				<<": continue: num sending"<<std::endl;*/
+		return AutosendCycle::MapBlockAnalysis::ALREADY_SENT;
+	}
+
+	// TODO: Remove
+	/*// Limit the generating area vertically to 2/3
+	if(abs(p.Y - focus_point.Y) >
+			max_mapblock_generate_distance - max_mapblock_generate_distance / 3)
+		allow_generate = false;*/
+
+	// TODO: Remove
+	/*// Limit the send area vertically to 1/2
+	if (abs(p.Y - focus_point.Y) > max_block_send_distance / 2)
+		continue;*/
+
+	f32 distance_bs;
+	if (mapblock.d >= mapblock.fov_limit_activation_distance) {
+		// Don't generate or send if not in sight
+		if(isBlockInSight(p, camera_p, camera_dir, fov,
+				max_send_distance_bs, &distance_bs) == false)
+		{
+			/*dstream<<"AutosendMap: "<<wms.describe()
+					<<": continue: not in sight"<<std::endl;*/
+			return AutosendCycle::MapBlockAnalysis::NOT_IN_VIEW;
+		}
+	} else {
+		// Calculate block distance without FOV check
+		v3s16 blockpos_nodes = p * MAP_BLOCKSIZE;
+		v3f blockpos_center(
+				blockpos_nodes.X * BS + MAP_BLOCKSIZE/2 * BS,
+				blockpos_nodes.Y * BS + MAP_BLOCKSIZE/2 * BS,
+				blockpos_nodes.Z * BS + MAP_BLOCKSIZE/2 * BS
+		);
+		v3f blockpos_relative = blockpos_center - camera_p;
+		distance_bs = blockpos_relative.getLength();
+		// Don't generate or send if not in sight
+		if (distance_bs > max_send_distance_bs) {
+			/*dstream<<"AutosendMap: "<<wms.describe()
+					<<": continue: distance_bs: "<<distance_bs<<std::endl;*/
+			return AutosendCycle::MapBlockAnalysis::NOT_IN_VIEW;
+		}
+	}
+
+	// Don't send blocks that have already been sent
+	std::map<v3s16, time_t>::const_iterator
+			blocks_sent_i = client->m_mapblocks_sent.find(wms.p);
+	if (blocks_sent_i != client->m_mapblocks_sent.end()){
+		if (client->m_blocks_updated_since_last_send.count(wms) == 0) {
+			/*dstream<<"AutosendMap: "<<wms.describe()
+					<<": Already sent and not updated"<<std::endl;*/
+			return AutosendCycle::MapBlockAnalysis::ALREADY_SENT;
+		}
+		// NOTE: Don't do rate limiting for MapBlocks
+		//time_t sent_time = blocks_sent_i->second;
+		/*dstream<<"AutosendMap: "<<wms.describe()
+				<<": Already sent but updated"<<std::endl;*/
+	}
+
+	/*
+		Check if map has this block
+	*/
+	MapBlock *block = env->getMap().getBlockNoCreateNoEx(p);
+
+	bool surely_not_found_on_disk = false;
+	bool surely_not_generated = false;
+	if(block != NULL)
+	{
+		// Reset usage timer, this block will be of use in the future.
+		block->resetUsageTimer();
+
+		// Block is dummy if data doesn't exist. A dummy block has been
+		// confirmed to be not found on disk and to not having been
+		// generated.
+		if(block->isDummy())
+			surely_not_found_on_disk = true;
+
+		if(!block->isGenerated())
+			surely_not_generated = true;
+
+		/*
+			If block is not close, don't send it unless it is near
+			ground level.
+
+			Block is near ground level if night-time mesh
+			differs from day-time mesh.
+		*/
+		if (mapblock.d >= block_send_optimize_distance_setting) {
+			if (!block->getIsUnderground() && !block->getDayNightDiff())
+				return AutosendCycle::MapBlockAnalysis::NOT_IN_VIEW;
+		}
+	}
+
+	// If doing occlusion culling on the server:
+	// If a block isn't found on disk, don't proceed to generate or load
+	// it if it's occluded
+	if (server_side_occlusion_culling_setting
+			&& mapblock.d >= block_send_optimize_distance_setting) {
+		// Make a dummy block detached from the Map so that we can check
+		// occlusion of any block regardless of whether it exists or not
+		// TODO: Make version of Map::isBlockOccluded that doesn't need
+		//       an actual MapBlock
+		MapBlock dummyblock(NULL, p, NULL, true);
+		bool occ = env->getMap().isBlockOccluded(&dummyblock, focus_point_nodepos);
+		tracestream<<"AutosendCycle::suggestNextMapBlock(): peer_id="
+				<<client->peer_id<<": "<<PP(p)
+				<<": isBlockOccluded() = "<<occ<<std::endl;
+		if (occ)
+			return AutosendCycle::MapBlockAnalysis::NOT_IN_VIEW;
+	}
+
+	if(surely_not_generated)
+		return AutosendCycle::MapBlockAnalysis::IN_VIEW_BUT_NOT_GENERATED;
+
+	if(!block || surely_not_found_on_disk || surely_not_generated)
+		return AutosendCycle::MapBlockAnalysis::IN_VIEW_BUT_NOT_LOADED;
+
+	return AutosendCycle::MapBlockAnalysis::IN_VIEW_AND_LOADED;
+}
+
+WMSSuggestion AutosendCycle::suggestNextMapBlock(EmergeManager *emerge)
+{
+	// Use shortcut queue first
+	// TODO: Somehow keep track and check that client's position hasn't changed
+	//       by a huge amount between making the queue and now reading from it
+	//       (generally it should be a short time). Maybe just drop queue
+	//       elements based on their age, eg. by a 3 second timeout or so.
+	while(!finished_mapblock_emerges.empty()){
+		// Pop position from queue
+		v3s16 p = finished_mapblock_emerges.front();
+		finished_mapblock_emerges.pop_front();
+
+		// Check if this MapBlock is relevant for sending to the client and
+		// return it if so. Otherwise just ignore it.
+		AutosendCycle::MapBlockAnalysis a = checkMapBlock(p);
+		if(a == AutosendCycle::MapBlockAnalysis::IN_VIEW_AND_LOADED){
+			tracestream<<"AutosendCycle::suggestNextMapBlock(): peer_id="
+					<<client->peer_id<<": Suggesting finished emerge: "
+					<<PP(p)<<std::endl;
+			WantedMapSend wms(WMST_MAPBLOCK, p);
+			return WMSSuggestion(wms);
+		}
+	}
+
+	// Then do actual algorithm
+	for (; mapblock.d <= mapblock.d_max; mapblock.d++) {
+		tracestream<<"AutosendCycle::suggestNextMapBlock(): peer_id="
+				<<client->peer_id<<": mapblock.d="<<mapblock.d<<std::endl;
+
+		// Get the border/face dot coordinates of a mapblock.d-"radiused" box
+		std::vector<v3s16> face_ps = FacePositionCache::getFacePositions(mapblock.d);
+		// Continue from the last mapblock.i unless it was reset by something
+		for (; mapblock.i < face_ps.size(); mapblock.i++) {
+
+			// Calculate this thing
+			u16 max_simultaneous_block_sends =
+					figure_out_max_simultaneous_block_sends(
+							max_simul_sends_setting,
+							client->m_time_from_building,
+							time_from_building_limit_s,
+							mapblock.d);
+
+			// Don't select too many blocks for sending
+			if (client->getSendingCount() >= max_simultaneous_block_sends) {
+				tracestream<<"AutosendCycle::suggestNextMapBlock(): peer_id="
+						<<client->peer_id<<": "
+						<<"(client->getSendingCount()="<<client->getSendingCount()
+						<<" >= max_simultaneous_block_sends="<<max_simultaneous_block_sends
+						<<") (client->m_time_from_building="<<client->m_time_from_building
+						<<")-> Returning nothing"<<std::endl;
+				// Shouldn't suggest anything (why is the server even asking us?)
+				return WMSSuggestion();
+			}
+
+			v3s16 p = face_ps[mapblock.i] + focus_point;
+
+			// Analyze block
+
+			AutosendCycle::MapBlockAnalysis analysis = checkMapBlock(p);
+
+			// Return this block if it's good for sending
+			if(analysis == AutosendCycle::MapBlockAnalysis::IN_VIEW_AND_LOADED){
+				tracestream<<"AutosendCycle::suggestNextMapBlock(): peer_id="
+						<<client->peer_id<<": Suggesting: "
+						<<PP(p)<<std::endl;
+				WantedMapSend wms(WMST_MAPBLOCK, p);
+				return WMSSuggestion(wms);
+			}
+
+			// If this block shouldn't be sent, continue searching
+			if(analysis == AutosendCycle::MapBlockAnalysis::ALREADY_SENT ||
+					analysis == AutosendCycle::MapBlockAnalysis::NOT_IN_VIEW){
+				continue;
+			}
+
+			// If block has been marked to not exist on disk (dummy) or is
+			// not generated and generating new ones is not wanted, skip block.
+			bool allow_generate = mapblock.d <= max_mapblock_generate_distance;
+			if(analysis == AutosendCycle::MapBlockAnalysis::IN_VIEW_BUT_NOT_GENERATED &&
+					!allow_generate){
+				//dstream<<"continue: not on disk, no generate"<<std::endl;
+				// get next one.
+				continue;
+			}
+
+			// Generating is wanted. Generate or load it if it's not loaded
+			if(analysis == AutosendCycle::MapBlockAnalysis::IN_VIEW_BUT_NOT_LOADED)
+			{
+				// Queue the block for loading or generating
+				u16 flags = 0;
+				if (allow_generate)
+					flags |= BLOCK_EMERGE_ALLOW_GEN;
+				bool queue_full = !emerge->enqueueBlockEmergeEx(
+						p, client->peer_id, flags, AutosendCycleEmergeCallback, this);
+				if (!queue_full) {
+					if (mapblock.nearest_emergequeued_d == INT32_MAX)
+						mapblock.nearest_emergequeued_d = mapblock.d;
+					// Queue is not full; continue searching
+					continue;
+				} else {
+					if (mapblock.nearest_emergefull_d == INT32_MAX)
+						mapblock.nearest_emergefull_d = mapblock.d;
+					// Queue is full; don't bother searching futher
+					return WMSSuggestion();
+				}
+			}
+
+			// Continue searching
+		}
+
+		// Now reset i as we go to next d
+		mapblock.i = 0;
+	}
+
+	tracestream<<"AutosendCycle::suggestNextMapBlock(): peer_id="
+			<<client->peer_id<<": Nothing to suggest"<<std::endl;
+
+	// Nothing to suggest
+	return WMSSuggestion();
+}
+
+/*WMSSuggestion AutosendCycle::getNextBlock(
+		EmergeManager *emerge, ServerFarMap *far_map)*/
+WMSSuggestion AutosendCycle::getNextBlock(EmergeManager *emerge)
+{
+	//dstream<<"AutosendCycle::getNextBlock()"<<std::endl;
+
+	if (disabled)
+		return WMSSuggestion();
+
+	// Get MapBlock and FarBlock suggestions
+
+	WMSSuggestion suggested_mb;
+	if (alg->m_client->m_mapblocks_sent.size() < alg->m_max_total_mapblocks) {
+		suggested_mb = suggestNextMapBlock(emerge);
+	}
+
+	WMSSuggestion suggested_fb;
+	// Not suggesting FarBlocks (not supported by this version)
+
+	//dstream<<"suggested_mb = "<<suggested_mb.describe()<<std::endl;
+	//dstream<<"suggested_fb = "<<suggested_fb.describe()<<std::endl;
+
+	// Prioritize suggestions
+
+	std::vector<WMSSuggestion> suggestions;
+	if (suggested_mb.wms.type != WMST_INVALID)
+		suggestions.push_back(suggested_mb);
+	if (suggested_fb.wms.type != WMST_INVALID)
+		suggestions.push_back(suggested_fb);
+
+	if (suggestions.empty()) {
+		// Nothing to send or prioritize
+		return WMSSuggestion();
+	}
+
+	// Prioritize if there is more than one option
+	if (suggestions.size() > 1) {
+		v3s16 camera_np = floatToInt(camera_p, BS);
+		std::sort(suggestions.begin(), suggestions.end(),
+				WMSSPriority(camera_np, alg->m_far_weight));
+	}
+
+	// Take the most important one
+	WMSSuggestion wmss = suggestions[0];
+
+	//dstream<<"wmss = "<<wmss.describe()<<std::endl;
+
+	// Keep track of the distance of the closest block being sent (separetely
+	// for MapBlocks and FarBlocks)
+
+	if (wmss.wms.type == WMST_MAPBLOCK) {
+		if(mapblock.nearest_sendqueued_d == INT32_MAX)
+			mapblock.nearest_sendqueued_d = mapblock.d;
+		mapblock.nothing_to_send_timer = 0.0f;
+	}
+
+	if (wmss.wms.type == WMST_FARBLOCK) {
+		if(farblock.nearest_sendqueued_d == INT32_MAX)
+			farblock.nearest_sendqueued_d = farblock.d;
+		farblock.nothing_to_send_timer = 0.0f;
+	}
+
+	return wmss;
+}
+
+void AutosendCycle::Search::runTimers(float dtime)
+{
+	nothing_to_send_timer += dtime;
+	nothing_to_send_pause_timer -= dtime;
+}
+
+void AutosendCycle::Search::start(s16 max_send_distance_,
+		s16 fov_limit_activation_distance_)
+{
+	max_send_distance = max_send_distance_; // Needed by finish()
+	fov_limit_activation_distance = fov_limit_activation_distance_;
+	i = 0;
+
+	// We will start from a radius that still has unsent MapBlocks
+	d_start = nearest_unsent_d >= 0 ? nearest_unsent_d : 0;
+	d = d_start;
+
+	// Don't loop very much at a time. This function is called each server tick
+	// so just a few steps will work fine (+2 is 3 steps per call).
+	d_max = 0;
+	if (d_start < 5)
+		d_max = d_start + 3;
+	else if (d_max < 8)
+		d_max = d_start + 2;
+	else
+		d_max = d_start + 1; // These iterations start to be rather heavy
+
+	if (d_max > max_send_distance)
+		d_max = max_send_distance;
+
+	tracestream<<"AutosendCycle::Search::start(): "
+			<<"id="<<log_id<<"/"<<log_name<<": "
+			<<"d_start="<<d_start
+			<<", d_max="<<d_max
+			<<", max_send_distance="<<max_send_distance
+			<<", fov_limit_activation_distance="<<fov_limit_activation_distance
+			<<std::endl;
+
+	// Keep track of... things. We need these in order to figure out where to
+	// continue iterating on the next call to this function.
+	// TODO: Put these in the class
+	nearest_emergequeued_d = INT32_MAX;
+	nearest_emergefull_d = INT32_MAX;
+	nearest_sendqueued_d = INT32_MAX;
+}
+
+void AutosendCycle::Search::finish(bool enable_fov_toggle)
+{
+	if(nearest_emergequeued_d == INT32_MAX &&
+			nearest_emergefull_d == INT32_MAX &&
+			nearest_sendqueued_d == INT32_MAX){
+		tracestream << "AutosendCycle::Search::finish(): "
+				<<"id="<<log_id<<"/"<<log_name<<":"
+				<<" Nothing queued"<<tracestream<<std::endl;
+	} else {
+		tracestream << "AutosendCycle::Search::finish(): "
+				<<"id="<<log_id<<"/"<<log_name<<":";
+		tracestream<<" Stuff queued:";
+		if(nearest_emergequeued_d != INT32_MAX)
+			tracestream<<" nearest_emergequeued_d="<<nearest_emergequeued_d;
+		if(nearest_emergefull_d != INT32_MAX)
+			tracestream<<" nearest_emergefull_d="<<nearest_emergefull_d;
+		if(nearest_sendqueued_d != INT32_MAX)
+			tracestream<<" nearest_sendqueued_d="<<nearest_sendqueued_d;
+		tracestream<<std::endl;
+	}
+
+	// Because none of the things we queue for sending or emerging or anything
+	// will necessarily be sent or anything, next time we need to continue
+	// iterating from the closest radius of any of that happening so that we can
+	// check whether they were sent or emerged or otherwise handled.
+	s32 closest_required_re_check = INT32_MAX;
+	if (nearest_emergequeued_d < closest_required_re_check)
+		closest_required_re_check = nearest_emergequeued_d;
+	if (nearest_emergefull_d < closest_required_re_check)
+		closest_required_re_check = nearest_emergefull_d;
+	if (nearest_sendqueued_d < closest_required_re_check)
+		closest_required_re_check = nearest_sendqueued_d;
+
+	bool searched_full_range = false;
+	bool result_may_be_available_later_at_this_d = false;
+
+	if (closest_required_re_check != INT32_MAX) {
+		// We did something that requires a result to be checked later. Continue
+		// from that on the next time.
+		nearest_unsent_d = closest_required_re_check;
+		// If nothing has been sent in a moment, indicating that the emerge
+		// thread is not finding anything on disk anymore, caller should start a
+		// fresh pass without the FOV limit.
+		result_may_be_available_later_at_this_d = true;
+	} else if (d > max_send_distance) {
+		// We iterated all the way through to the end of the send radius, if you
+		// can believe that.
+		nearest_unsent_d = 0;
+		// Caller should do a second pass with FOV limiting disabled or start
+		// from the beginning after a short idle delay. (with FOV limiting
+		// enabled because nobody knows what the future holds.)
+		searched_full_range = true;
+	} else {
+		// Absolutely nothing interesting happened. Next time we will continue
+		// iterating from the next radius.
+		nearest_unsent_d = d;
+	}
+
+	// Trigger FOV limit removal in certain situations
+	if (result_may_be_available_later_at_this_d) {
+		tracestream << "AutosendCycle::Search::finish(): "
+				<<"id="<<log_id<<"/"<<log_name<<": "
+				<<"-> Processed result may be found later at d="<<nearest_unsent_d
+				<<std::endl;
+
+		// If nothing has been sent in a moment, indicating that the emerge
+		// thread is not finding anything on disk anymore, start a fresh
+		// pass without the FOV limit.
+		if (enable_fov_toggle && nothing_to_send_timer >= 3.0f) {
+			if(fov_limit_enabled){
+				verbosestream << "AutosendCycle::Search::finish(): "
+						<<"id="<<log_id<<"/"<<log_name<<": "
+						<<"-> Nothing to send; Disabling FOV limit"<<std::endl;
+
+				fov_limit_enabled = false;
+			} else {
+				verbosestream << "AutosendCycle::Search::finish(): "
+						<<"id="<<log_id<<"/"<<log_name<<": "
+						<<"-> Nothing to send (no FOV limit); starting short sleep"
+						<<std::endl;
+
+				// Start from the beginning after a very short idle delay.
+				// During this delay, some map data may be loaded or generated.
+				// Start is done with FOV limiting enabled again.
+				fov_limit_enabled = true;
+				nothing_to_send_pause_timer = 0.2;
+			}
+			// Have to be reset in order to not trigger this immediately again
+			nothing_to_send_timer = 0.0f;
+		}
+	} else if(searched_full_range) {
+		// We iterated all the way through to the end of the send radius, if you
+		// can believe that.
+		if (enable_fov_toggle && fov_limit_enabled) {
+			tracestream << "AutosendCycle::Search::finish(): "
+					<<"id="<<log_id<<"/"<<log_name<<": "
+					<<"-> Iterated all the way through"
+					<<"; Disabling FOV limit"<<std::endl;
+
+			// Do a second pass with FOV limiting disabled
+			fov_limit_enabled = false;
+		} else {
+			tracestream << "AutosendCycle::Search::finish(): "
+					<<"id="<<log_id<<"/"<<log_name<<": "
+					<<"-> Initiating idle sleep"<<std::endl;
+
+			// Start from the beginning after a short idle delay. During
+			// this delay, some map data may be loaded or generated.
+			// Start is done with FOV limiting enabled again.
+			// TODO: The pause timer should be reset also when the emergethread
+			// has generated or loaded something within the area the client is
+			// looking for. This hasn't been implemented yet, so the pause will
+			// always be fully waited before anything is checked again. For this
+			// reason the pause is relatively short.
+			fov_limit_enabled = true;
+			nothing_to_send_pause_timer = 1.0;
+		}
+	} else {
+		tracestream << "AutosendCycle::Search::finish(): "
+				<<"id="<<log_id<<"/"<<log_name<<": "
+				<<"-> Continuing at d="<<nearest_unsent_d<<std::endl;
+	}
+}
+
+void AutosendCycle::finish()
+{
+	//dstream<<"AutosendCycle::finish()"<<std::endl;
+
+	if (disabled) {
+		// If disabled, none of our variables are even initialized
+		return;
+	}
+
+	bool enable_fov_toggle = (alg->m_fov != 0.0f);
+	mapblock.finish(enable_fov_toggle);
+	//farblock.finish(enable_fov_toggle); // TODO: Enable later
+}
+
+AutosendAlgorithm::AutosendAlgorithm(RemoteClient *client):
+	m_client(client),
+	m_cycle(new AutosendCycle()),
+	m_radius_map(0),
+	m_radius_far(0),
+	m_far_weight(3.0f),
+	m_fov(1.72f), // In radians
+	m_nearest_unsent_reset_timer(0.0)
+{}
+
+AutosendAlgorithm::~AutosendAlgorithm()
+{
+	delete m_cycle;
+}
+
+void AutosendAlgorithm::cycle(float dtime, ServerEnvironment *env)
+{
+	m_cycle->finish();
+
+	// Increment timers
+	m_cycle->mapblock.runTimers(dtime);
+	m_cycle->farblock.runTimers(dtime);
+	m_nearest_unsent_reset_timer += dtime;
+
+	m_cycle->start(this, m_client, env);
+}
+
+/*WMSSuggestion AutosendAlgorithm::getNextBlock(
+		EmergeManager *emerge, ServerFarMap *far_map)*/
+WMSSuggestion AutosendAlgorithm::getNextBlock(EmergeManager *emerge)
+{
+	return m_cycle->getNextBlock(emerge);
+}
+
+void AutosendAlgorithm::resetMapblockSearchRadius(const v3s16 &mb_p)
+{
+	s16 reset_to_d = 0; // Radius value in MapBlocks to reset the search to
+
+	// Get distance to player and use it as the reset value in order to not scan
+	// unnecessarily close
+	RemotePlayer *player = m_client->m_env->getPlayer(m_client->peer_id);
+	PlayerSAO *sao = player ? player->getPlayerSAO() : NULL;
+	if (sao) {
+		v3f camera_pf_nodes = sao->getEyePosition() / BS;
+		v3s16 mb_nodes = mb_p * MAP_BLOCKSIZE;
+		v3f mb_pf_nodes(mb_nodes.X, mb_nodes.Y, mb_nodes.Z);
+		float distance_nodes = (mb_pf_nodes - camera_pf_nodes).getLength();
+		reset_to_d = distance_nodes / MAP_BLOCKSIZE;
+	}
+
+	/*dstream<<"AutosendAlgorithm::resetMapblockSearchRadius(): peer_id="
+			<<m_client->peer_id<<", reset_to_d="<<reset_to_d<<std::endl;*/
+
+	if (m_cycle->mapblock.d == reset_to_d){
+		m_cycle->mapblock.i = 0;
+	}
+
+	if (m_cycle->mapblock.d > reset_to_d){
+		m_cycle->mapblock.d = reset_to_d;
+		m_cycle->mapblock.fov_limit_enabled = true;
+	}
+
+	if (m_cycle->mapblock.nearest_unsent_d > reset_to_d){
+		m_cycle->mapblock.nearest_unsent_d = reset_to_d;
+	}
+
+	// Apparently all of these have to be reset in order to have the search
+	// start at 0 because of what finish() does (it's maybe a bug, but as long
+	// as this works, we really don't need to care)
+	if (m_cycle->mapblock.nearest_emergequeued_d > reset_to_d)
+		m_cycle->mapblock.nearest_emergequeued_d = reset_to_d;
+	if (m_cycle->mapblock.nearest_emergefull_d > reset_to_d)
+		m_cycle->mapblock.nearest_emergefull_d = reset_to_d;
+	if (m_cycle->mapblock.nearest_sendqueued_d > reset_to_d)
+		m_cycle->mapblock.nearest_sendqueued_d = reset_to_d;
+
+	// Start searching for MapBlocks to be sent soon enough (don't set this to
+	// zero because it would cause unnecessary CPU usage)
+	if (m_cycle->mapblock.nothing_to_send_pause_timer > 0.1f)
+		m_cycle->mapblock.nothing_to_send_pause_timer = 0.1f;
+}
+
+std::string AutosendAlgorithm::describeStatus()
+{
+	return "(mapblock.nearest_unsent_d="+itos(m_cycle->mapblock.nearest_unsent_d)+", "
+			"farblock.nearest_unsent_d="+itos(m_cycle->farblock.nearest_unsent_d)+")";
+}
+

--- a/src/server/autosend.h
+++ b/src/server/autosend.h
@@ -1,0 +1,99 @@
+/*
+Minetest
+Copyright (C) 2010-2022 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+#include "irr_v3d.h"                   // for irrlicht datatypes
+#include "serverenvironment.h"
+#include "emerge.h"
+
+class RemoteClient;
+struct AutosendCycle;
+
+struct WMSSuggestion {
+	WantedMapSend wms;
+	bool is_fully_loaded; // Can be false for FarBlocks
+	//bool is_fully_generated; // TODO
+	// TODO: Using enum ServerFarBlock::LoadState would be more suitable
+
+	WMSSuggestion():
+		is_fully_loaded(true)
+	{}
+	WMSSuggestion(WantedMapSend wms):
+		wms(wms),
+		is_fully_loaded(true)
+	{}
+	std::string describe() const {
+		if (wms.type == WMST_FARBLOCK) {
+			return wms.describe()+
+					": is_fully_loaded="+(is_fully_loaded?"1":"0");
+		} else {
+			return wms.describe();
+		}
+	}
+};
+
+class AutosendAlgorithm
+{
+public:
+	AutosendAlgorithm(RemoteClient *client);
+	~AutosendAlgorithm();
+
+	// Shall be called every time before starting to ask a bunch of blocks by
+	// calling getNextBlock()
+	void cycle(float dtime, ServerEnvironment *env);
+
+	// Finds a block that should be sent next to the client.
+	// Environment should be locked when this is called.
+	//WMSSuggestion getNextBlock(EmergeManager *emerge, ServerFarMap *far_map);
+	WMSSuggestion getNextBlock(EmergeManager *emerge);
+
+	void setParameters(s16 radius_map, s16 radius_far, float far_weight,
+			float fov, u32 max_total_mapblocks, u32 max_total_farblocks) {
+		m_radius_map = radius_map;
+		m_radius_far = radius_far;
+		m_far_weight = far_weight;
+		m_fov = fov;
+		m_max_total_mapblocks = max_total_mapblocks;
+		m_max_total_farblocks = max_total_farblocks;
+	}
+
+	// If something is modified near a player, this should probably be called so
+	// that it gets sent as quickly as possible while being prioritized
+	// correctly
+	void resetMapblockSearchRadius(const v3s16 &mb_p);
+
+	std::string describeStatus();
+
+private:
+	RemoteClient *m_client;
+	AutosendCycle *m_cycle;
+	s16 m_radius_map; // Updated by the client; 0 disables autosend.
+	s16 m_radius_far; // Updated by the client; 0 disables autosend.
+	float m_far_weight; // Updated by the client.
+	float m_fov; // Updated by the client; 0 disables FOV limit.
+	u32 m_max_total_mapblocks;
+	u32 m_max_total_farblocks;
+	v3s16 m_last_focus_point;
+	v3f m_last_camera_dir;
+	float m_nearest_unsent_reset_timer;
+
+	friend struct AutosendCycle;
+};
+
+

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -407,6 +407,12 @@ inline u32 npot2(u32 orig) {
 	return orig + 1;
 }
 
+// NOTE: Irrlicht only provides something like this for v3s32
+inline v3s16 v3s16_div(const v3s16 &a, s16 b)
+{
+	return v3s16(a.X/b, a.Y/b, a.Z/b);
+}
+
 // Gradual steps towards the target value in a wrapped (circular) system
 // using the shorter of both ways
 template<typename T>

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -80,6 +80,20 @@ inline v3s16 getContainerPos(v3s16 p, v3s16 d)
 	);
 }
 
+inline s32 getContainerPos32(s32 p, s32 d)
+{
+	return (p>=0 ? p : p-d+1) / d;
+}
+
+inline v3s16 getContainerPos32to16(v3s32 p, s32 d)
+{
+	return v3s16(
+		getContainerPos32(p.X, d),
+		getContainerPos32(p.Y, d),
+		getContainerPos32(p.Z, d)
+	);
+}
+
 inline void getContainerPosWithOffset(s16 p, s16 d, s16 &container, s16 &offset)
 {
 	container = (p >= 0 ? p : p - d + 1) / d;

--- a/src/voxel.h
+++ b/src/voxel.h
@@ -155,6 +155,18 @@ public:
 			a.MinEdge.Z >= MinEdge.Z && a.MaxEdge.Z <= MaxEdge.Z
 		);
 	}
+	bool touches(const VoxelArea &a) const
+	{
+		// No area touches an empty area
+		if(a.hasEmptyExtent())
+			return false;
+
+		return(
+			a.MaxEdge.X >= MinEdge.X && a.MinEdge.X <= MaxEdge.X &&
+			a.MaxEdge.Y >= MinEdge.Y && a.MinEdge.Y <= MaxEdge.Y &&
+			a.MaxEdge.Z >= MinEdge.Z && a.MinEdge.Z <= MaxEdge.Z
+		);
+	}
 	bool contains(v3s16 p) const
 	{
 		return(
@@ -307,6 +319,27 @@ public:
 	static void add_p(const v3s16 &extent, u32 &i, v3s16 a)
 	{
 		i += a.Z * extent.X * extent.Y + a.Y * extent.X + a.X;
+	}
+
+	// Translate index in the X coordinate
+	u32 added_x(const v3s16 &extent, u32 i, s16 a) const
+	{
+		return i + a;
+	}
+	// Translate index in the Y coordinate
+	u32 added_y(const v3s16 &extent, u32 i, s16 a) const
+	{
+		return i + a * extent.X;
+	}
+	// Translate index in the Z coordinate
+	u32 added_z(const v3s16 &extent, u32 i, s16 a) const
+	{
+		return i + a * extent.X*extent.Y;
+	}
+	// Translate index in space
+	u32 added_p(const v3s16 &extent, u32 i, v3s16 a) const
+	{
+		return i + a.Z*extent.X*extent.Y + a.Y*extent.X + a.X;
 	}
 
 	/*
@@ -505,4 +538,39 @@ public:
 	u8 *m_flags = nullptr;
 
 	static const MapNode ContentIgnoreNode;
+};
+
+template<typename T>
+struct BlockAreaBitmap
+{
+	VoxelArea blocks_area;
+	std::vector<T> blocks;
+
+	void reset(const VoxelArea &new_blocks_area,
+			T initial_value=T()) {
+		blocks_area = new_blocks_area;
+		blocks.clear();
+		blocks.resize(new_blocks_area.getVolume(), initial_value);
+	}
+	void set(v3s16 bp, T v) {
+		if(!blocks_area.contains(bp))
+			return;
+		blocks[blocks_area.index(bp)] = v;
+	}
+	T get(v3s16 bp) const {
+		if(!blocks_area.contains(bp))
+			return T();
+		return blocks[blocks_area.index(bp)];
+	}
+	size_t size() const {
+		return blocks.size();
+	}
+	size_t count(T v) const {
+		size_t n = 0;
+		for (size_t i=0; i<blocks.size(); i++) {
+			if (blocks[i] == v)
+				n++;
+		}
+		return n;
+	}
 };


### PR DESCRIPTION
This is a rebase of the mapblock transfer implementation I made in 2015 alongside the farmap branch which never got merged: 
https://github.com/minetest/minetest/pull/3502#issuecomment-322311668

This does not contain the farmap implementation.

The point of this is to set up mapblock transfers in such a way that
- Clients manage their memory by requesting a certain amount of map data to be present from the server
- Clients request a certain weighing of MapBlocks and FarBlocks, allowing them to decide how much of each level of detail they want to get from the server (by player preference)
- The server can optimize the send order of a priority queue of mixed level-of-detail map content
- If you stand still, the world will load and then all MapBlock transfers will stop, if there are no changes happening in the world. The client will not delete anything, and the server will not send anything, as they are able to agree on what part of the map the client wants to have in memory.

The client informs the server about its view range and other mapblock transfer related parameters using the added TOSERVER_SET_WANTED_MAP_SEND_QUEUE = 0x54 network packet.

It also allows easily extending to a farblock system allowing radically less level of detail in larger blocks to be sent in far away areas. For any level-of-detail system the server needs to be able to generate queues of blocks of mixed LoD sorted by a weighed priority according to the client's request. The client can, if it wants to, request only plain mapblocks, or only farblocks (i.e. reduced level of detail), or any ratio of those. This has been ripped out of the system that already generated, sent and rendered farblocks succesfully so the concept works.

To-do:
- [x] Clean up: It's pretty well cleaned up now
- [x] Tweaking for cross version network compatibility (looks like it already was set up for it, both ways)
- [x] Testing for stability and performance (IMO it works fine)
- [x] Testing for cross-version network compatibility (could use some testing by others, but in my tests it works both ways)

Requests:
- Please test for performance and stability.

Side note:
The original [block_transfer_v2](https://github.com/celeron55/minetest/compare/block_transfer_v2) branch also contains a system for splitting mapblock drawlist calculation into multiple frames on the client. I left it out from this for now, but that's a very useful piece of code also. In that branch that code uses `struct DrawListUpdate` in clientmap.cpp.