### PR TITLE
Limit force shadow update to urgent blocks

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -574,7 +574,8 @@ void Client::step(float dtime)
 					else {
 						// Replace with the new mesh
 						block->mesh = r.mesh;
-						force_update_shadows = true;
+						if (r.urgent)
+							force_update_shadows = true;
 					}
 				}
 			} else {

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -149,6 +149,7 @@ QueuedMeshUpdate *MeshUpdateQueue::pop()
 		m_queue.erase(i);
 		m_urgents.erase(q->p);
 		fillDataFromMapBlockCache(q);
+		q->urgent = must_be_urgent;
 		return q;
 	}
 	return NULL;
@@ -310,6 +311,7 @@ void MeshUpdateThread::doUpdate()
 		r.p = q->p;
 		r.mesh = mesh_new;
 		r.ack_block_to_server = q->ack_block_to_server;
+		r.urgent = q->urgent;
 
 		m_queue_out.push_back(r);
 

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -113,6 +113,7 @@ bool MeshUpdateQueue::addBlock(Map *map, v3s16 p, bool ack_block_to_server, bool
 				q->ack_block_to_server = true;
 			q->crack_level = m_client->getCrackLevel();
 			q->crack_pos = m_client->getCrackPos();
+			q->urgent |= urgent;
 			return true;
 		}
 	}
@@ -125,6 +126,7 @@ bool MeshUpdateQueue::addBlock(Map *map, v3s16 p, bool ack_block_to_server, bool
 	q->ack_block_to_server = ack_block_to_server;
 	q->crack_level = m_client->getCrackLevel();
 	q->crack_pos = m_client->getCrackPos();
+	q->urgent = urgent;
 	m_queue.push_back(q);
 
 	// This queue entry is a new reference to the cached blocks
@@ -149,7 +151,6 @@ QueuedMeshUpdate *MeshUpdateQueue::pop()
 		m_queue.erase(i);
 		m_urgents.erase(q->p);
 		fillDataFromMapBlockCache(q);
-		q->urgent = must_be_urgent;
 		return q;
 	}
 	return NULL;

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -45,6 +45,7 @@ struct QueuedMeshUpdate
 	int crack_level = -1;
 	v3s16 crack_pos;
 	MeshMakeData *data = nullptr; // This is generated in MeshUpdateQueue::pop()
+	bool urgent = false;
 
 	QueuedMeshUpdate() = default;
 	~QueuedMeshUpdate();
@@ -105,6 +106,7 @@ struct MeshUpdateResult
 	v3s16 p = v3s16(-1338, -1338, -1338);
 	MapBlockMesh *mesh = nullptr;
 	bool ack_block_to_server = false;
+	bool urgent = false;
 
 	MeshUpdateResult() = default;
 };


### PR DESCRIPTION
Significantly improves performance when:
* shadows are enabled
* shadow_update_frames > 1
* mesh generation is active (world is loading, camera changes etc.)

## To do

This PR is Ready for Review.

## How to test

1. Enable shadows
2. Set shadow_update_frames to a value > 1 (default: 8)
3. Enter the world
4. Observe the graphs: mesh generation should not have significant impact on FPS
5. Place a block / dig a block - shadow is updated without lag.
