### PR TITLE
Apply DPI Scaling to GUIModalMenu

### DIFF
--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -43,10 +43,11 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
 	m_gui_scale = std::max(g_settings->getFloat("gui_scaling"), 0.5f);
 	const float screen_dpi_scale = RenderingEngine::getDisplayDensity();
 #ifdef HAVE_TOUCHSCREENGUI
-	m_gui_scale *= 1.1 - 0.3 * screen_dpi_scale + 0.2 * screen_dpi_scale * screen_dpi_scale;
+	m_gui_scale *= 1.1f - 0.3f * screen_dpi_scale + 0.2f * screen_dpi_scale * screen_dpi_scale;
 #else
 	m_gui_scale *= screen_dpi_scale;
 #endif
+
 	setVisible(true);
 	Environment->setFocus(this);
 	m_menumgr->createdMenu(this);

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include <cstdlib>
+#include "client/renderingengine.h"
 #include "modalMenu.h"
 #include "gettext.h"
 #include "porting.h"
@@ -40,7 +41,8 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
 		m_menumgr(menumgr),
 		m_remap_dbl_click(remap_dbl_click)
 {
-	m_gui_scale = std::max(g_settings->getFloat("gui_scaling"), 0.5f);
+	const double screen_dpi_scale = RenderingEngine::getDisplayDensity();
+	m_gui_scale = std::max(g_settings->getFloat("gui_scaling"), 0.5f) * screen_dpi_scale;
 #ifdef HAVE_TOUCHSCREENGUI
 	float d = RenderingEngine::getDisplayDensity();
 	m_gui_scale *= 1.1 - 0.3 * d + 0.2 * d * d;

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -40,11 +40,12 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
 		m_menumgr(menumgr),
 		m_remap_dbl_click(remap_dbl_click)
 {
+	m_gui_scale = std::max(g_settings->getFloat("gui_scaling"), 0.5f);
 	const float screen_dpi_scale = RenderingEngine::getDisplayDensity();
 #ifdef HAVE_TOUCHSCREENGUI
 	m_gui_scale *= 1.1 - 0.3 * screen_dpi_scale + 0.2 * screen_dpi_scale * screen_dpi_scale;
 #else
-	m_gui_scale = std::max(g_settings->getFloat("gui_scaling"), 0.5f) * screen_dpi_scale;
+	m_gui_scale *= screen_dpi_scale;
 #endif
 	setVisible(true);
 	Environment->setFocus(this);

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -27,7 +27,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #ifdef HAVE_TOUCHSCREENGUI
 #include "touchscreengui.h"
-#include "client/renderingengine.h"
 #endif
 
 // clang-format off
@@ -41,11 +40,11 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
 		m_menumgr(menumgr),
 		m_remap_dbl_click(remap_dbl_click)
 {
-	const double screen_dpi_scale = RenderingEngine::getDisplayDensity();
-	m_gui_scale = std::max(g_settings->getFloat("gui_scaling"), 0.5f) * screen_dpi_scale;
+	const float screen_dpi_scale = RenderingEngine::getDisplayDensity();
 #ifdef HAVE_TOUCHSCREENGUI
-	float d = RenderingEngine::getDisplayDensity();
-	m_gui_scale *= 1.1 - 0.3 * d + 0.2 * d * d;
+	m_gui_scale *= 1.1 - 0.3 * screen_dpi_scale + 0.2 * screen_dpi_scale * screen_dpi_scale;
+#else
+	m_gui_scale = std::max(g_settings->getFloat("gui_scaling"), 0.5f) * screen_dpi_scale;
 #endif
 	setVisible(true);
 	Environment->setFocus(this);


### PR DESCRIPTION
GUIModalMenu doesn't scale with the system reported DPI.

Issue:
The Change key menu is unreadable on Hi-Dpi due to the controls overlapping on linux.

Fix:
Update GUIModalMenu to include RenderingEngine::getDisplayDensity() in m_gui_scale for all inherited controls
GUIFileSelectMenu, GUIPasswordChange, GUIKeyChangeMenu 

Notes:
I'm not sure how to access GUIFileSelectMenu or GUIPasswordChange to test them I have only verified GUIKeyChangeMenu.
