### PR TITLE
[NoSquash] ContentDB: Fix crash when trying to overwrite a package

### DIFF
--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -608,11 +608,10 @@ function pkgmgr.install_dir(type, path, basename, targetpath)
 		end
 
 		local from = basefolder and basefolder.path or path
-		if targetpath then
-			core.delete_dir(targetpath)
-		else
+		if not targetpath then
 			targetpath = core.get_texturepath() .. DIR_DELIM .. basename
 		end
+		core.delete_dir(targetpath)
 		if not core.copy_dir(from, targetpath, false) then
 			return nil,
 				fgettext("Failed to install $1 to $2", basename, targetpath)
@@ -690,6 +689,7 @@ function pkgmgr.install_dir(type, path, basename, targetpath)
 	end
 
 	-- Copy it
+	core.delete_dir(targetpath)
 	if not core.copy_dir(basefolder.path, targetpath, false) then
 		return nil,
 			fgettext("Failed to install $1 to $2", basename, targetpath)

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -243,7 +243,7 @@ function pkgmgr.get_base_folder(temppath)
 end
 
 --------------------------------------------------------------------------------
-function pkgmgr.isValidModname(modpath)
+function pkgmgr.is_valid_modname(modpath)
 	if modpath:find("-") ~= nil then
 		return false
 	end
@@ -251,91 +251,6 @@ function pkgmgr.isValidModname(modpath)
 	return true
 end
 
---------------------------------------------------------------------------------
-function pkgmgr.parse_register_line(line)
-	local pos1 = line:find("\"")
-	local pos2 = nil
-	if pos1 ~= nil then
-		pos2 = line:find("\"",pos1+1)
-	end
-
-	if pos1 ~= nil and pos2 ~= nil then
-		local item = line:sub(pos1+1,pos2-1)
-
-		if item ~= nil and
-			item ~= "" then
-			local pos3 = item:find(":")
-
-			if pos3 ~= nil then
-				local retval = item:sub(1,pos3-1)
-				if retval ~= nil and
-					retval ~= "" then
-					return retval
-				end
-			end
-		end
-	end
-	return nil
-end
-
---------------------------------------------------------------------------------
-function pkgmgr.parse_dofile_line(modpath,line)
-	local pos1 = line:find("\"")
-	local pos2 = nil
-	if pos1 ~= nil then
-		pos2 = line:find("\"",pos1+1)
-	end
-
-	if pos1 ~= nil and pos2 ~= nil then
-		local filename = line:sub(pos1+1,pos2-1)
-
-		if filename ~= nil and
-			filename ~= "" and
-			filename:find(".lua") then
-			return pkgmgr.identify_modname(modpath,filename)
-		end
-	end
-	return nil
-end
-
---------------------------------------------------------------------------------
-function pkgmgr.identify_modname(modpath,filename)
-	local testfile = io.open(modpath .. DIR_DELIM .. filename,"r")
-	if testfile ~= nil then
-		local line = testfile:read()
-
-		while line~= nil do
-			local modname = nil
-
-			if line:find("minetest.register_tool") then
-				modname = pkgmgr.parse_register_line(line)
-			end
-
-			if line:find("minetest.register_craftitem") then
-				modname = pkgmgr.parse_register_line(line)
-			end
-
-
-			if line:find("minetest.register_node") then
-				modname = pkgmgr.parse_register_line(line)
-			end
-
-			if line:find("dofile") then
-				modname = pkgmgr.parse_dofile_line(modpath,line)
-			end
-
-			if modname ~= nil then
-				testfile:close()
-				return modname
-			end
-
-			line = testfile:read()
-		end
-		testfile:close()
-	end
-
-	return nil
-end
 --------------------------------------------------------------------------------
 function pkgmgr.render_packagelist(render_list, use_technical_names, with_error)
 	if not render_list then
@@ -597,12 +512,17 @@ function pkgmgr.get_worldconfig(worldpath)
 end
 
 --------------------------------------------------------------------------------
-function pkgmgr.install_dir(type, path, basename, targetpath)
+function pkgmgr.install_dir(expected_type, path, basename, targetpath)
+	assert(type(expected_type) == "string")
+	assert(type(path) == "string")
+	assert(basename == nil or type(basename) == "string")
+	assert(targetpath == nil or type(targetpath) == "string")
+
 	local basefolder = pkgmgr.get_base_folder(path)
 
-	-- There's no good way to detect a texture pack, so let's just assume
-	-- it's correct for now.
-	if type == "txp" then
+	if expected_type == "txp" then
+		-- There's no good way to detect a texture pack, so let's just assume
+		-- it's correct for now.
 		if basefolder and basefolder.type ~= "invalid" and basefolder.type ~= "txp" then
 			return nil, fgettext("Unable to install a $1 as a texture pack", basefolder.type)
 		end
@@ -619,73 +539,34 @@ function pkgmgr.install_dir(type, path, basename, targetpath)
 		return targetpath, nil
 
 	elseif not basefolder then
-		return nil, fgettext("Unable to find a valid mod or modpack")
+		return nil, fgettext("Unable to find a valid mod, modpack, or game")
 	end
 
-	--
-	-- Get destination
-	--
-	if basefolder.type == "modpack" then
-		if type ~= "mod" then
-			return nil, fgettext("Unable to install a modpack as a $1", type)
-		end
+	-- Check type
+	if basefolder.type ~= expected_type and (basefolder.type ~= "modpack" or expected_type ~= "mod") then
+		return nil, fgettext("Unable to install a $1 as a $1", basefolder.type, expected_type)
+	end
 
-		-- Get destination name for modpack
-		if targetpath then
-			core.delete_dir(targetpath)
+	-- Set targetpath if not predetermined
+	if not targetpath then
+		local content_path
+		if basefolder.type == "modpack" or basefolder.type == "mod" then
+			if not basename then
+				basename = get_last_folder(cleanup_path(basefolder.path))
+			end
+			content_path = core.get_modpath()
+		elseif basefolder.type == "game" then
+			content_path = core.get_gamepath()
 		else
-			local clean_path = nil
-			if basename ~= nil then
-				clean_path = basename
-			end
-			if not clean_path then
-				clean_path = get_last_folder(cleanup_path(basefolder.path))
-			end
-			if clean_path then
-				targetpath = core.get_modpath() .. DIR_DELIM .. clean_path
-			else
-				return nil,
-					fgettext("Install Mod: Unable to find suitable folder name for modpack $1",
-					path)
-			end
-		end
-	elseif basefolder.type == "mod" then
-		if type ~= "mod" then
-			return nil, fgettext("Unable to install a mod as a $1", type)
+			error("Unknown content type")
 		end
 
-		if targetpath then
-			core.delete_dir(targetpath)
+		if basename and (basefolder.type ~= "mod" or pkgmgr.is_valid_modname(basename)) then
+			targetpath = content_path .. DIR_DELIM .. basename
 		else
-			local targetfolder = basename
-			if targetfolder == nil then
-				targetfolder = pkgmgr.identify_modname(basefolder.path, "init.lua")
-			end
-
-			-- If heuristic failed try to use current foldername
-			if targetfolder == nil then
-				targetfolder = get_last_folder(basefolder.path)
-			end
-
-			if targetfolder ~= nil and pkgmgr.isValidModname(targetfolder) then
-				targetpath = core.get_modpath() .. DIR_DELIM .. targetfolder
-			else
-				return nil, fgettext("Install Mod: Unable to find real mod name for: $1", path)
-			end
+			return nil,
+				fgettext("Install: Unable to find suitable folder name for $1", path)
 		end
-
-	elseif basefolder.type == "game" then
-		if type ~= "game" then
-			return nil, fgettext("Unable to install a game as a $1", type)
-		end
-
-		if targetpath then
-			core.delete_dir(targetpath)
-		else
-			targetpath = core.get_gamepath() .. DIR_DELIM .. basename
-		end
-	else
-		error("basefolder didn't return a recognised type, this shouldn't happen")
 	end
 
 	-- Copy it

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -244,11 +244,7 @@ end
 
 --------------------------------------------------------------------------------
 function pkgmgr.is_valid_modname(modpath)
-	if modpath:find("-") ~= nil then
-		return false
-	end
-
-	return true
+	return modpath:match("[^a-z0-9_]") == nil
 end
 
 --------------------------------------------------------------------------------
@@ -521,6 +517,8 @@ function pkgmgr.install_dir(expected_type, path, basename, targetpath)
 	local basefolder = pkgmgr.get_base_folder(path)
 
 	if expected_type == "txp" then
+		assert(basename)
+
 		-- There's no good way to detect a texture pack, so let's just assume
 		-- it's correct for now.
 		if basefolder and basefolder.type ~= "invalid" and basefolder.type ~= "txp" then
@@ -544,7 +542,7 @@ function pkgmgr.install_dir(expected_type, path, basename, targetpath)
 
 	-- Check type
 	if basefolder.type ~= expected_type and (basefolder.type ~= "modpack" or expected_type ~= "mod") then
-		return nil, fgettext("Unable to install a $1 as a $1", basefolder.type, expected_type)
+		return nil, fgettext("Unable to install a $1 as a $2", basefolder.type, expected_type)
 	end
 
 	-- Set targetpath if not predetermined

--- a/builtin/mainmenu/tests/pkgmgr_spec.lua
+++ b/builtin/mainmenu/tests/pkgmgr_spec.lua
@@ -1,0 +1,243 @@
+--Minetest
+--Copyright (C) 2022 rubenwardy
+--
+--This program is free software; you can redistribute it and/or modify
+--it under the terms of the GNU Lesser General Public License as published by
+--the Free Software Foundation; either version 2.1 of the License, or
+--(at your option) any later version.
+--
+--This program is distributed in the hope that it will be useful,
+--but WITHOUT ANY WARRANTY; without even the implied warranty of
+--MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--GNU Lesser General Public License for more details.
+--
+--You should have received a copy of the GNU Lesser General Public License along
+--with this program; if not, write to the Free Software Foundation, Inc.,
+--51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+local mods_dir = "/tmp/.minetest/mods"
+local games_dir = "/tmp/.minetest/games"
+local txp_dir = "/tmp/.minetest/textures"
+
+local function reset()
+	local env = {
+		core = {},
+		unpack = table.unpack or unpack,
+		pkgmgr = {},
+		DIR_DELIM = "/",
+	}
+	env._G = env
+	setmetatable(env, { __index = _G })
+
+	local core = env.core
+
+	local calls = {}
+	function core.get_games()
+		return {}
+	end
+	function core.delete_dir(...)
+		table.insert(calls, { "delete_dir", ... })
+		return true
+	end
+	function core.copy_dir(...)
+		table.insert(calls, { "copy_dir", ... })
+		return true
+	end
+	function core.get_texturepath()
+		return txp_dir
+	end
+	function core.get_modpath()
+		return mods_dir
+	end
+	function core.get_gamepath()
+		return games_dir
+	end
+	function env.fgettext(fmt, ...)
+		return fmt
+	end
+
+	setfenv(loadfile("builtin/common/misc_helpers.lua"), env)()
+	setfenv(loadfile("builtin/mainmenu/pkgmgr.lua"), env)()
+
+	function env.pkgmgr.update_gamelist()
+		table.insert(calls, { "update_gamelist" })
+	end
+	function env.pkgmgr.refresh_globals()
+		table.insert(calls, { "refresh_globals" })
+	end
+
+	function env.assert_calls(list)
+		assert.are.same(list, calls)
+	end
+
+	return env
+end
+
+
+describe("install_dir", function()
+	it("installs texture pack", function()
+		local env = reset()
+		env.pkgmgr.get_base_folder = function()
+			return { type = "invalid", path = "/tmp/123" }
+		end
+
+		local path, message = env.pkgmgr.install_dir("txp", "/tmp/123", "mytxp", nil)
+		assert.is.equal(txp_dir .. "/mytxp", path)
+		assert.is._nil(message)
+		env.assert_calls({
+			{ "delete_dir", txp_dir .. "/mytxp" },
+			{ "copy_dir", "/tmp/123", txp_dir .. "/mytxp", false },
+		})
+	end)
+
+	it("prevents installing other as texture pack", function()
+		local env = reset()
+		env.pkgmgr.get_base_folder = function()
+			return { type = "mod", path = "/tmp/123" }
+		end
+
+		local path, message = env.pkgmgr.install_dir("txp", "/tmp/123", "mytxp", nil)
+		assert.is._nil(path)
+		assert.is.equal("Unable to install a $1 as a texture pack", message)
+	end)
+
+	it("installs mod", function()
+		local env = reset()
+		env.pkgmgr.get_base_folder = function()
+			return { type = "mod", path = "/tmp/123" }
+		end
+
+		local path, message = env.pkgmgr.install_dir("mod", "/tmp/123", "mymod", nil)
+		assert.is.equal(mods_dir .. "/mymod", path)
+		assert.is._nil(message)
+		env.assert_calls({
+			{ "delete_dir", mods_dir .. "/mymod" },
+			{ "copy_dir", "/tmp/123", mods_dir .. "/mymod", false },
+			{ "refresh_globals" },
+		})
+	end)
+
+	it("installs modpack", function()
+		local env = reset()
+		env.pkgmgr.get_base_folder = function()
+			return { type = "modpack", path = "/tmp/123" }
+		end
+
+		local path, message = env.pkgmgr.install_dir("mod", "/tmp/123", "mymod", nil)
+		assert.is.equal(mods_dir .. "/mymod", path)
+		assert.is._nil(message)
+		env.assert_calls({
+			{ "delete_dir", mods_dir .. "/mymod" },
+			{ "copy_dir", "/tmp/123", mods_dir .. "/mymod", false },
+			{ "refresh_globals" },
+		})
+	end)
+
+	it("installs game", function()
+		local env = reset()
+		env.pkgmgr.get_base_folder = function()
+			return { type = "game", path = "/tmp/123" }
+		end
+
+		local path, message = env.pkgmgr.install_dir("game", "/tmp/123", "mygame", nil)
+		assert.is.equal(games_dir .. "/mygame", path)
+		assert.is._nil(message)
+		env.assert_calls({
+			{ "delete_dir", games_dir .. "/mygame" },
+			{ "copy_dir", "/tmp/123", games_dir .. "/mygame", false },
+			{ "update_gamelist" },
+		})
+	end)
+
+	it("installs mod detects name", function()
+		local env = reset()
+		env.pkgmgr.get_base_folder = function()
+			return { type = "mod", path = "/tmp/123" }
+		end
+
+		local path, message = env.pkgmgr.install_dir("mod", "/tmp/123", nil, nil)
+		assert.is.equal(mods_dir .. "/123", path)
+		assert.is._nil(message)
+		env.assert_calls({
+			{ "delete_dir", mods_dir .. "/123" },
+			{ "copy_dir", "/tmp/123", mods_dir .. "/123", false },
+			{ "refresh_globals" },
+		})
+	end)
+
+	it("installs mod detects invalid name", function()
+		local env = reset()
+		env.pkgmgr.get_base_folder = function()
+			return { type = "mod", path = "/tmp/hi!" }
+		end
+
+		local path, message = env.pkgmgr.install_dir("mod", "/tmp/hi!", nil, nil)
+		assert.is._nil(path)
+		assert.is.equal("Install: Unable to find suitable folder name for $1", message)
+	end)
+
+	it("installs mod to target (update)", function()
+		local env = reset()
+		env.pkgmgr.get_base_folder = function()
+			return { type = "mod", path = "/tmp/123" }
+		end
+
+		local path, message = env.pkgmgr.install_dir("mod", "/tmp/123", "mymod", "/tmp/alt-target")
+		assert.is.equal("/tmp/alt-target", path)
+		assert.is._nil(message)
+		env.assert_calls({
+			{ "delete_dir", "/tmp/alt-target" },
+			{ "copy_dir", "/tmp/123", "/tmp/alt-target", false },
+			{ "refresh_globals" },
+		})
+	end)
+
+	it("checks expected types", function()
+		local actual_type = "modpack"
+		local env = reset()
+		env.pkgmgr.get_base_folder = function()
+			return { type = actual_type, path = "/tmp/123" }
+		end
+
+		local path, message = env.pkgmgr.install_dir("mod", "/tmp/123", "name", nil)
+		assert.is._not._nil(path)
+		assert.is._nil(message)
+
+		path, message = env.pkgmgr.install_dir("game", "/tmp/123", "name", nil)
+		assert.is._nil(path)
+		assert.is.equal("Unable to install a $1 as a $2", message)
+
+		path, message = env.pkgmgr.install_dir("txp", "/tmp/123", "name", nil)
+		assert.is._nil(path)
+		assert.is.equal("Unable to install a $1 as a texture pack", message)
+
+		actual_type = "game"
+
+		path, message = env.pkgmgr.install_dir("mod", "/tmp/123", "name", nil)
+		assert.is._nil(path)
+		assert.is.equal("Unable to install a $1 as a $2", message)
+
+		path, message = env.pkgmgr.install_dir("game", "/tmp/123", "name", nil)
+		assert.is._not._nil(path)
+		assert.is._nil(message)
+
+		path, message = env.pkgmgr.install_dir("txp", "/tmp/123", "name", nil)
+		assert.is._nil(path)
+		assert.is.equal("Unable to install a $1 as a texture pack", message)
+
+		actual_type = "txp"
+
+		path, message = env.pkgmgr.install_dir("mod", "/tmp/123", "name", nil)
+		assert.is._nil(path)
+		assert.is.equal("Unable to install a $1 as a $2", message)
+
+		path, message = env.pkgmgr.install_dir("game", "/tmp/123", "name", nil)
+		assert.is._nil(path)
+		assert.is.equal("Unable to install a $1 as a $2", message)
+
+		path, message = env.pkgmgr.install_dir("txp", "/tmp/123", "name", nil)
+		assert.is._not._nil(path)
+		assert.is._nil(message)
+
+	end)
+end)


### PR DESCRIPTION
Before #11646, core.copy_dir would overwrite the target if it exists. Adding core.delete_dir restores the exact same behaviour

Also adds unit tests to install_dir and removes unused support for modname detection

Fixes #12303

## Alternatives

1. The ContentDB dialog could be responsible for deleting the mod dir
2. ContentDB dialog could pass targetpath to signal that overwrites are allowed
3. Allow installing the same modname multiple times by generating unique folder names (`mymod`, `mymod2`, etc)
## To do

This PR is a Ready for Review.

## How to test

To reproduce the bug:

* mkdir mods/basic_materials && touch mods/basic_materials/init.lua
* Attempt to install basic_materials, there will be a dialog select overwrite, it will crash on master

Other things to test (this is also done by unit tests)

* For games, mods, modpacks, and texture packs:
	  * Test new installs
	  * Test updates
	  * Test overwrites
