### PR TITLE
C exception safety

### DIFF
--- a/lib/bitop/CMakeLists.txt
+++ b/lib/bitop/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(bitop STATIC bit.c)
+add_library(bitop STATIC bit.cpp)
 target_link_libraries(bitop)
 
 include_directories(${LUA_INCLUDE_DIR})

--- a/lib/bitop/bit.cpp
+++ b/lib/bitop/bit.cpp
@@ -26,12 +26,16 @@
 ** [ MIT license: http://www.opensource.org/licenses/mit-license.php ]
 */
 
+extern "C" {
 #include "bit.h"
+}
 
 #define LUA_BITOP_VERSION	"1.0.2"
 
 #define LUA_LIB
+extern "C" {
 #include "lauxlib.h"
+}
 
 #ifdef _MSC_VER
 /* MSVC is stuck in the last century and doesn't have C99's stdint.h. */

--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -857,8 +857,12 @@ void ModMetadataDatabaseSQLite3::listMods(std::vector<std::string> *res)
 	char *errmsg;
 	int status = sqlite3_exec(m_database,
 		"SELECT `modname` FROM `entries` GROUP BY `modname`;",
-		[](void *res_vp, int n_col, char **cols, char **col_names) -> int {
-			((decltype(res)) res_vp)->emplace_back(cols[0]);
+		[](void *res_vp, int n_col, char **cols, char **col_names) noexcept -> int {
+			try {
+				((decltype(res)) res_vp)->emplace_back(cols[0]);
+			} catch (...) {
+				return 1;
+			}
 			return 0;
 		}, (void *) res, &errmsg);
 	if (status != SQLITE_OK) {


### PR DESCRIPTION
This fixes some potential issues with throwing C++ exceptions through C frames:
1. A callback passed to SQLite3 no longer throws exceptions, since SQLite3 may not handle them well.
2. The bitop library is compiled as C++. In most cases this will have no effect, but in rare cases it will fix the issue described here: https://github.com/minetest/minetest/pull/11683#issuecomment-943863581. I have read in some places that throwing exceptions from `extern "C"` functions is technically undefined behavior, but I don't think this will ever actually come up, and `testLuaDestructors` tests for this anyway.

## To do

This PR is Ready for Review.

## How to test

Compile using the bundled Lua then run the tests.
