### PR TITLE
Add min_repeat_place_time physics override

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -95,7 +95,7 @@ always_fly_fast (Always fly fast) bool true
 
 #    The time in seconds it takes between repeated node placements when holding
 #    the place button.
-repeat_place_time (Place repetition interval) float 0.25 0.25 2
+repeat_place_time (Place repetition interval) float 0.25 0.001 2
 
 #    Automatically jump up single-node obstacles.
 autojump (Automatic jumping) bool false

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4710,13 +4710,13 @@ Privileges
 
 Privileges provide a means for server administrators to give certain players
 access to special abilities in the engine, games or mods.
-For example, game moderators may need to travel instantly to any place in the world, 
+For example, game moderators may need to travel instantly to any place in the world,
 this ability is implemented in `/teleport` command which requires `teleport` privilege.
 
 Registering privileges
 ----------------------
 
-A mod can register a custom privilege using `minetest.register_privilege` function 
+A mod can register a custom privilege using `minetest.register_privilege` function
 to give server administrators fine-grained access control over mod functionality.
 
 For consistency and practical reasons, privileges should strictly increase the abilities of the user.
@@ -4725,7 +4725,7 @@ Do not register custom privileges that e.g. restrict the player from certain in-
 Checking privileges
 -------------------
 
-A mod can call `minetest.check_player_privs` to test whether a player has privileges 
+A mod can call `minetest.check_player_privs` to test whether a player has privileges
 to perform an operation.
 Also, when registering a chat command with `minetest.register_chatcommand` a mod can
 declare privileges that the command requires using the `privs` field of the command
@@ -4789,7 +4789,7 @@ Minetest includes the following settings to control behavior of privileges:
 
    * `default_privs`: defines privileges granted to new players.
    * `basic_privs`: defines privileges that can be granted/revoked by players having
-    the `basic_privs` privilege. This can be used, for example, to give 
+    the `basic_privs` privilege. This can be used, for example, to give
     limited moderation powers to selected users.
 
 'minetest' namespace reference
@@ -7081,6 +7081,11 @@ child will follow movement and rotation of that bone.
           (default: `false`)
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behaviour (default: `true`)
+        * `min_repeat_place_time`: minimum time in seconds between places when
+          the player holds the place button (default: `0`)
+          The player can set any higher value via the `repeat_place_time` setting.
+          Note: This does not limit node placement speed (neither server-, nor
+          client-side).
 * `get_physics_override()`: returns the table given to `set_physics_override`
 * `hud_add(hud definition)`: add a HUD element described by HUD def, returns ID
    number on success

--- a/games/devtest/mods/util_commands/init.lua
+++ b/games/devtest/mods/util_commands/init.lua
@@ -62,6 +62,28 @@ minetest.register_chatcommand("zoomfov", {
 	end,
 })
 
+minetest.register_chatcommand("min_repeat_place_time", {
+	params = "[<min_repeat_place_time>]",
+	description = "Set or display your min_repeat_place_time physics override",
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+		if not player then
+			return false, "No player."
+		end
+		if param == "" then
+			local mrpt = player:get_physics_override().min_repeat_place_time
+			return true, "min_repeat_place_time = "..tostring(mrpt)
+		end
+		local mrpt = tonumber(param)
+		if not mrpt then
+			return false, "Missing or incorrect min_repeat_place_time parameter!"
+		end
+		player:set_physics_override({min_repeat_place_time = mrpt})
+		mrpt = player:get_physics_override().min_repeat_place_time
+		return true, "min_repeat_place_time = "..tostring(mrpt)
+	end,
+})
+
 local s_infplace = minetest.settings:get("devtest_infplace")
 if s_infplace == "true" then
 	infplace = true

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1766,7 +1766,8 @@ void GenericCAO::processMessage(const std::string &data)
 		bool sneak = !readU8(is);
 		bool sneak_glitch = !readU8(is);
 		bool new_move = !readU8(is);
-
+		readU8(is); // padding, always 0
+		float min_repeat_place_time = readF32(is);
 
 		if (m_is_local_player) {
 			auto &phys = m_env->getLocalPlayer()->physics_override;
@@ -1776,6 +1777,7 @@ void GenericCAO::processMessage(const std::string &data)
 			phys.sneak = sneak;
 			phys.sneak_glitch = sneak_glitch;
 			phys.new_move = new_move;
+			phys.min_repeat_place_time = min_repeat_place_time;
 		}
 	} else if (cmd == AO_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -900,7 +900,7 @@ private:
 	bool m_cache_enable_free_move;
 	f32  m_cache_mouse_sensitivity;
 	f32  m_cache_joystick_frustum_sensitivity;
-	f32  m_repeat_place_time;
+	f32  m_repeat_place_time_setting;
 	f32  m_cache_cam_smoothing;
 	f32  m_cache_fog_start;
 
@@ -3332,8 +3332,11 @@ void Game::handlePointingAtNode(const PointedThing &pointed,
 		}
 	}
 
+	f32 repeat_place_time = std::max(m_repeat_place_time_setting,
+			client->getEnv().getLocalPlayer()->physics_override.min_repeat_place_time);
+
 	if ((wasKeyPressed(KeyType::PLACE) ||
-			runData.repeat_place_timer >= m_repeat_place_time) &&
+			runData.repeat_place_timer >= repeat_place_time) &&
 			client->checkPrivilege("interact")) {
 		runData.repeat_place_timer = 0;
 		infostream << "Place button pressed while looking at ground" << std::endl;
@@ -4145,7 +4148,7 @@ void Game::readSettings()
 	m_cache_enable_fog                   = g_settings->getBool("enable_fog");
 	m_cache_mouse_sensitivity            = g_settings->getFloat("mouse_sensitivity", 0.001f, 10.0f);
 	m_cache_joystick_frustum_sensitivity = std::max(g_settings->getFloat("joystick_frustum_sensitivity"), 0.001f);
-	m_repeat_place_time                  = g_settings->getFloat("repeat_place_time", 0.25f, 2.0);
+	m_repeat_place_time_setting          = g_settings->getFloat("repeat_place_time", 0.001f, 2.0);
 
 	m_cache_enable_noclip                = g_settings->getBool("noclip");
 	m_cache_enable_free_move             = g_settings->getBool("free_move");

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -208,7 +208,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	PROTOCOL VERSION 40:
 		TOCLIENT_MEDIA_PUSH changed, TOSERVER_HAVE_MEDIA added
 		Added new particlespawner parameters
-		[scheduled bump for 5.6.0]
+	PROTOCOL VERSION 41:
+		Added physics override: min_repeat_place_time
 */
 
 #define LATEST_PROTOCOL_VERSION 41

--- a/src/player.h
+++ b/src/player.h
@@ -101,6 +101,7 @@ struct PlayerPhysicsOverride
 	float speed = 1.f;
 	float jump = 1.f;
 	float gravity = 1.f;
+	float min_repeat_place_time = 0.0f;
 
 	bool sneak = true;
 	bool sneak_glitch = false;

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -177,6 +177,9 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushboolean(L, phys.new_move);
 	lua_setfield(L, -2, "new_move");
 
+	lua_pushboolean(L, phys.min_repeat_place_time);
+	lua_setfield(L, -2, "min_repeat_place_time");
+
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1445,6 +1445,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		modified |= getboolfield(L, 2, "sneak", phys.sneak);
 		modified |= getboolfield(L, 2, "sneak_glitch", phys.sneak_glitch);
 		modified |= getboolfield(L, 2, "new_move", phys.new_move);
+		modified |= getfloatfield(L, 2, "min_repeat_place_time", phys.min_repeat_place_time);
 		if (modified)
 			playersao->m_physics_override_sent = false;
 	} else {
@@ -1491,6 +1492,8 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "sneak_glitch");
 	lua_pushboolean(L, phys.new_move);
 	lua_setfield(L, -2, "new_move");
+	lua_pushnumber(L, phys.min_repeat_place_time);
+	lua_setfield(L, -2, "min_repeat_place_time");
 	return 1;
 }
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -322,6 +322,8 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeU8(os, !phys.sneak);
 	writeU8(os, !phys.sneak_glitch);
 	writeU8(os, !phys.new_move);
+	writeU8(os, 0); // padding, always 0
+	writeF32(os, phys.min_repeat_place_time);
 	return os.str();
 }
 


### PR DESCRIPTION
- #12450 did more than its title said. It added a new settings limit that disrupted my user experience, and had nothing to do with buggy behaviour. One could also argue that it introduced a breakage.
- This PR fixes that via a new physics override variable, which does exactly what its name says.
- Fixes #12493, but properly. Fixes bug introduced by #12450.
- (I wasn't entirely sure if this should've better been an object property. If so, just request me to change it.)
- There's still no server-side limit. But mods can do that easily, I think.

## To do

This PR is a Ready for Review.

## How to test

* Set you `repeat_place_time` setting very low (i.e. 0.05).
* Start a world in the devtest subgame.
* Use the new chatcommand.
* Hold the place button with a node in your hand, pointing at another node in range.
* (Compatibility with older server version was tested already. (`readU8` reads 0 in that case.))