### PR TITLE
Add a worlds_here.txt file in the worlds folder and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,8 @@ build/.cmake/
 !/mods/minetest/
 /mods/minetest/*
 !/mods/minetest/mods_here.txt
-/worlds
+/worlds/*
+!/worlds/worlds_here.txt
 /world/
 /clientmods/*
 !/clientmods/preview/

--- a/.gitignore
+++ b/.gitignore
@@ -47,12 +47,9 @@ build/.cmake/
 /screenshots
 /sounds
 /mods/*
-!/mods/minetest/
-/mods/minetest/*
-!/mods/minetest/mods_here.txt
+!/mods/mods_here.txt
 /worlds/*
 !/worlds/worlds_here.txt
-/world/
 /clientmods/*
 !/clientmods/preview/
 /client/mod_storage/

--- a/worlds/worlds_here.txt
+++ b/worlds/worlds_here.txt
@@ -1,0 +1,3 @@
+If you have downloaded a world somewhere, you can put it in here.
+A world is a folder that contains the world.mt, map_meta.txt and similar files.
+If you are facing problems, try creating a world in-game first.

--- a/worlds/worlds_here.txt
+++ b/worlds/worlds_here.txt
@@ -1,3 +1,4 @@
-If you have downloaded a world somewhere, you can put it in here.
-A world is a folder that contains the world.mt, map_meta.txt and similar files.
-If you are facing problems, try creating a world in-game first.
+World directories are placed into this location. Each world should contain at least following files:
+
+ * map_meta.txt
+ * world.mt


### PR DESCRIPTION
Goal: Make it more straight-forward to install downloaded worlds, see for example: https://youtu.be/nI8Q1bqT8QU?t=54

Also removes some old entries in the .gitignore file.

Note: The user probably won't see the file if they installed minetest system-wide. But `mods_here.txt` suffers the same problem, AFAIK.

## To do

This PR is a Ready for Review.

~~(No squash on merge needed.)~~

## How to test

* :eyes: 
* Also read the `.gitignore`.
