### PR TITLE
[nosquash] Use X11 primary selection

### DIFF
--- a/src/gui/guiChatConsole.h
+++ b/src/gui/guiChatConsole.h
@@ -84,8 +84,12 @@ private:
 	void drawText();
 	void drawPrompt();
 
-	// If clicked fragment has a web url, send it to the system default web browser
-	void middleClick(s32 col, s32 row);
+	// If clicked fragment has a web url, send it to the system default web browser.
+	// Returns true if, and only if a web url was pressed.
+	bool weblinkClick(s32 col, s32 row);
+
+	// If the selected text changed, we need to update the (X11) primary selection.
+	void updatePrimarySelection();
 
 private:
 	ChatBackend* m_chat_backend;


### PR DESCRIPTION
* Requires <https://github.com/minetest/irrlicht/pull/132>.
* This PR adds support for primary selection to (1st commit) GUIEditBox (i.e. textarea) and (2nd commit) GUIChatConsole (the chat window).
* (For GUIChatConsole, middle-click doesn't move the cursor. This is on purpose, as the same happens in terminal emulators.)

## To do

This PR is a Ready for Review.
Commits are best reviewed separately.

Don't squash.

## How to test

* Use X11 or wayland (with a compositor that supports primary selection). Compile with X11 or SDL backend.
* Place a luacontroller.
* Mark text.
* Middle click.
* Do the same in other programs.
* Do the same in the chat window.