### PR TITLE
Fix texture pack sorting in content tab

### DIFF
--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -787,6 +787,9 @@ end
 --------------------------------------------------------------------------------
 function pkgmgr.update_gamelist()
 	pkgmgr.games = core.get_games()
+	table.sort(pkgmgr.games, function(a, b)
+		return a.title:lower() < b.title:lower()
+	end)
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -177,7 +177,7 @@ function pkgmgr.get_texture_packs()
 	end
 
 	table.sort(retval, function(a, b)
-		return a.name > b.name
+		return a.name < b.name
 	end)
 
 	return retval

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -177,7 +177,7 @@ function pkgmgr.get_texture_packs()
 	end
 
 	table.sort(retval, function(a, b)
-		return a.name < b.name
+		return a.title:lower() < b.title:lower()
 	end)
 
 	return retval


### PR DESCRIPTION
In the content tab, games and mods are sorted in alphabetical order. However, texture packs are sorted in reverse order. This PR fixes that by reversing the order that texture packs are sorted.

## To do
This PR is Ready for Review.

## How to test
See that texture packs are now sorted properly.