### PR TITLE
Consolidate API object code

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1065,7 +1065,7 @@ void read_server_sound_params(lua_State *L, int index,
 		lua_pop(L, 1);
 		lua_getfield(L, index, "object");
 		if(!lua_isnil(L, -1)){
-			ObjectRef *ref = (ObjectRef *)ModApiBase::checkObject(L, -1, ObjectRef::className);
+			ObjectRef *ref = ModApiBase::checkObject<ObjectRef>(L, -1);
 			ServerActiveObject *sao = ObjectRef::getobject(ref);
 			if(sao){
 				params.object = sao->getId();
@@ -1251,7 +1251,7 @@ ItemStack read_item(lua_State* L, int index, IItemDefManager *idef)
 
 	if (lua_isuserdata(L, index)) {
 		// Convert from LuaItemStack
-		LuaItemStack *o = (LuaItemStack *)ModApiBase::checkObject(L, index, LuaItemStack::className);
+		LuaItemStack *o = ModApiBase::checkObject<LuaItemStack>(L, index);
 		return o->getItem();
 	}
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1065,7 +1065,7 @@ void read_server_sound_params(lua_State *L, int index,
 		lua_pop(L, 1);
 		lua_getfield(L, index, "object");
 		if(!lua_isnil(L, -1)){
-			ObjectRef *ref = ObjectRef::checkobject(L, -1);
+			ObjectRef *ref = (ObjectRef *)ModApiBase::checkObject(L, -1, ObjectRef::className);
 			ServerActiveObject *sao = ObjectRef::getobject(ref);
 			if(sao){
 				params.object = sao->getId();
@@ -1251,7 +1251,7 @@ ItemStack read_item(lua_State* L, int index, IItemDefManager *idef)
 
 	if (lua_isuserdata(L, index)) {
 		// Convert from LuaItemStack
-		LuaItemStack *o = LuaItemStack::checkobject(L, index);
+		LuaItemStack *o = (LuaItemStack *)ModApiBase::checkObject(L, index, LuaItemStack::className);
 		return o->getItem();
 	}
 

--- a/src/script/lua_api/l_areastore.cpp
+++ b/src/script/lua_api/l_areastore.cpp
@@ -99,7 +99,7 @@ int LuaAreaStore::l_get_area(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
+	LuaAreaStore *o = checkObject<LuaAreaStore>(L, 1);
 	AreaStore *ast = o->as;
 
 	u32 id = luaL_checknumber(L, 2);
@@ -124,7 +124,7 @@ int LuaAreaStore::l_get_areas_for_pos(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
+	LuaAreaStore *o = checkObject<LuaAreaStore>(L, 1);
 	AreaStore *ast = o->as;
 
 	v3s16 pos = check_v3s16(L, 2);
@@ -146,7 +146,7 @@ int LuaAreaStore::l_get_areas_in_area(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
+	LuaAreaStore *o = checkObject<LuaAreaStore>(L, 1);
 	AreaStore *ast = o->as;
 
 	v3s16 minp = check_v3s16(L, 2);
@@ -173,7 +173,7 @@ int LuaAreaStore::l_insert_area(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
+	LuaAreaStore *o = checkObject<LuaAreaStore>(L, 1);
 	AreaStore *ast = o->as;
 
 	Area a(check_v3s16(L, 2), check_v3s16(L, 3));
@@ -199,7 +199,7 @@ int LuaAreaStore::l_reserve(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
+	LuaAreaStore *o = checkObject<LuaAreaStore>(L, 1);
 	AreaStore *ast = o->as;
 
 	size_t count = luaL_checknumber(L, 2);
@@ -212,7 +212,7 @@ int LuaAreaStore::l_remove_area(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
+	LuaAreaStore *o = checkObject<LuaAreaStore>(L, 1);
 	AreaStore *ast = o->as;
 
 	u32 id = luaL_checknumber(L, 2);
@@ -227,7 +227,7 @@ int LuaAreaStore::l_set_cache_params(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
+	LuaAreaStore *o = checkObject<LuaAreaStore>(L, 1);
 	AreaStore *ast = o->as;
 
 	luaL_checktype(L, 2, LUA_TTABLE);
@@ -246,7 +246,7 @@ int LuaAreaStore::l_to_string(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
+	LuaAreaStore *o = checkObject<LuaAreaStore>(L, 1);
 
 	std::ostringstream os(std::ios_base::binary);
 	o->as->serialize(os);
@@ -261,7 +261,7 @@ int LuaAreaStore::l_to_file(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
+	LuaAreaStore *o = checkObject<LuaAreaStore>(L, 1);
 	AreaStore *ast = o->as;
 
 	const char *filename = luaL_checkstring(L, 2);
@@ -279,7 +279,7 @@ int LuaAreaStore::l_from_string(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
+	LuaAreaStore *o = checkObject<LuaAreaStore>(L, 1);
 
 	size_t len;
 	const char *str = luaL_checklstring(L, 2, &len);
@@ -293,7 +293,7 @@ int LuaAreaStore::l_from_file(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
+	LuaAreaStore *o = checkObject<LuaAreaStore>(L, 1);
 
 	const char *filename = luaL_checkstring(L, 2);
 	CHECK_SECURE_PATH(L, filename, false);

--- a/src/script/lua_api/l_areastore.cpp
+++ b/src/script/lua_api/l_areastore.cpp
@@ -99,7 +99,7 @@ int LuaAreaStore::l_get_area(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = checkobject(L, 1);
+	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
 	AreaStore *ast = o->as;
 
 	u32 id = luaL_checknumber(L, 2);
@@ -124,7 +124,7 @@ int LuaAreaStore::l_get_areas_for_pos(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = checkobject(L, 1);
+	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
 	AreaStore *ast = o->as;
 
 	v3s16 pos = check_v3s16(L, 2);
@@ -146,7 +146,7 @@ int LuaAreaStore::l_get_areas_in_area(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = checkobject(L, 1);
+	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
 	AreaStore *ast = o->as;
 
 	v3s16 minp = check_v3s16(L, 2);
@@ -173,7 +173,7 @@ int LuaAreaStore::l_insert_area(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = checkobject(L, 1);
+	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
 	AreaStore *ast = o->as;
 
 	Area a(check_v3s16(L, 2), check_v3s16(L, 3));
@@ -199,7 +199,7 @@ int LuaAreaStore::l_reserve(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = checkobject(L, 1);
+	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
 	AreaStore *ast = o->as;
 
 	size_t count = luaL_checknumber(L, 2);
@@ -212,7 +212,7 @@ int LuaAreaStore::l_remove_area(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = checkobject(L, 1);
+	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
 	AreaStore *ast = o->as;
 
 	u32 id = luaL_checknumber(L, 2);
@@ -227,7 +227,7 @@ int LuaAreaStore::l_set_cache_params(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = checkobject(L, 1);
+	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
 	AreaStore *ast = o->as;
 
 	luaL_checktype(L, 2, LUA_TTABLE);
@@ -246,7 +246,7 @@ int LuaAreaStore::l_to_string(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = checkobject(L, 1);
+	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
 
 	std::ostringstream os(std::ios_base::binary);
 	o->as->serialize(os);
@@ -261,7 +261,7 @@ int LuaAreaStore::l_to_file(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = checkobject(L, 1);
+	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
 	AreaStore *ast = o->as;
 
 	const char *filename = luaL_checkstring(L, 2);
@@ -279,7 +279,7 @@ int LuaAreaStore::l_from_string(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = checkobject(L, 1);
+	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
 
 	size_t len;
 	const char *str = luaL_checklstring(L, 2, &len);
@@ -293,7 +293,7 @@ int LuaAreaStore::l_from_file(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaAreaStore *o = checkobject(L, 1);
+	LuaAreaStore *o = (LuaAreaStore *)methodCheckObject(L, 1);
 
 	const char *filename = luaL_checkstring(L, 2);
 	CHECK_SECURE_PATH(L, filename, false);
@@ -339,42 +339,13 @@ int LuaAreaStore::create_object(lua_State *L)
 	return 1;
 }
 
-LuaAreaStore *LuaAreaStore::checkobject(lua_State *L, int narg)
-{
-	NO_MAP_LOCK_REQUIRED;
-
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-
-	return *(LuaAreaStore **)ud;  // unbox pointer
-}
-
 void LuaAreaStore::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);  // drop metatable
-
-	luaL_register(L, nullptr, methods);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 
 	// Can be created from Lua (AreaStore())
 	lua_register(L, className, create_object);

--- a/src/script/lua_api/l_areastore.h
+++ b/src/script/lua_api/l_areastore.h
@@ -26,7 +26,6 @@ class AreaStore;
 class LuaAreaStore : public ModApiBase
 {
 private:
-	static const char className[];
 	static const luaL_Reg methods[];
 
 	static int gc_object(lua_State *L);
@@ -58,7 +57,7 @@ public:
 	// Creates a AreaStore and leaves it on top of stack
 	static int create_object(lua_State *L);
 
-	static LuaAreaStore *checkobject(lua_State *L, int narg);
-
 	static void Register(lua_State *L);
+
+	static const char className[];
 };

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -100,6 +100,67 @@ bool ModApiBase::registerFunction(lua_State *L, const char *name,
 	return true;
 }
 
+static void set_methods(lua_State *L, int metatable, int into, const luaL_Reg *methods)
+{
+	if (!methods)
+		return;
+	for (int i = 0; methods[i].name != NULL; i++) {
+		// Remember the metatable as an upvalue for argument checking purposes.
+		lua_pushvalue(L, metatable);
+		lua_pushcclosure(L, methods[i].func, 1);
+		lua_setfield(L, into, methods[i].name);
+	}
+}
+
+void ModApiBase::registerClass(lua_State *L, const char *name,
+		const luaL_Reg *methods,
+		const luaL_Reg *metamethods)
+{
+	luaL_newmetatable(L, name);
+	int metatable = lua_gettop(L);
+
+	lua_newtable(L);
+	int methodtable = lua_gettop(L);
+
+	set_methods(L, metatable, methodtable, methods);
+
+	lua_pushvalue(L, methodtable);
+	lua_setfield(L, metatable, "__index");
+
+	// Protect the real metatable.
+	lua_pushvalue(L, methodtable);
+	lua_setfield(L, metatable, "__metatable");
+
+	// Remember the class name for error messages.
+	lua_pushstring(L, name);
+	lua_setfield(L, metatable, "class_name");
+
+	set_methods(L, metatable, metatable, metamethods);
+
+	// Pop methodtable and metatable.
+	lua_pop(L, 2);
+}
+
+void *ModApiBase::methodCheckObject(lua_State *L, int narg)
+{
+	void *ud = lua_touserdata(L, narg);
+
+	bool ok = ud && lua_getmetatable(L, narg);
+	if (ok) {
+		ok = lua_rawequal(L, -1, lua_upvalueindex(1));
+		lua_pop(L, 1);
+	}
+
+	if (!ok) {
+		lua_getfield(L, lua_upvalueindex(1), "class_name");
+		std::string className = luaL_optstring(L, -1, "<unknown class>");
+		lua_pop(L, 1);
+		luaL_typerror(L, narg, className.c_str());
+	}
+
+	return *(void **)ud; // unbox pointer
+}
+
 int ModApiBase::l_deprecated_function(lua_State *L, const char *good, const char *bad, lua_CFunction func)
 {
 	thread_local std::vector<u64> deprecated_logged;

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -119,10 +119,6 @@ void ModApiBase::registerClass(lua_State *L, const char *name,
 	lua_pushvalue(L, methodtable);
 	lua_setfield(L, metatable, "__metatable");
 
-	// Remember the class name for error messages.
-	lua_pushstring(L, name);
-	lua_setfield(L, metatable, "class_name");
-
 	// Pop methodtable and metatable.
 	lua_pop(L, 2);
 }

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -81,9 +81,10 @@ public:
 	// Only use this in methods (functions with the right metatable as their first upvalue).
 	static void *methodCheckObject(lua_State *L, int narg);
 
-	static inline void *checkObject(lua_State *L, int narg, const char *className)
+	template<typename T>
+	static inline T *checkObject(lua_State *L, int narg)
 	{
-		return *(void **)luaL_checkudata(L, narg, className);
+		return *(T **)luaL_checkudata(L, narg, T::className);
 	}
 
 	/**

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -81,7 +81,7 @@ public:
 	template<typename T>
 	static inline T *checkObject(lua_State *L, int narg)
 	{
-		return *(T **)luaL_checkudata(L, narg, T::className);
+		return *reinterpret_cast<T**>(luaL_checkudata(L, narg, T::className));
 	}
 
 	/**

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -78,9 +78,6 @@ public:
 			const luaL_Reg *methods,
 			const luaL_Reg *metamethods);
 
-	// Only use this in methods (functions with the right metatable as their first upvalue).
-	static void *methodCheckObject(lua_State *L, int narg);
-
 	template<typename T>
 	static inline T *checkObject(lua_State *L, int narg)
 	{

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -74,6 +74,18 @@ public:
 			lua_CFunction func,
 			int top);
 
+	static void registerClass(lua_State *L, const char *name,
+			const luaL_Reg *methods,
+			const luaL_Reg *metamethods);
+
+	// Only use this in methods (functions with the right metatable as their first upvalue).
+	static void *methodCheckObject(lua_State *L, int narg);
+
+	static inline void *checkObject(lua_State *L, int narg, const char *className)
+	{
+		return *(void **)luaL_checkudata(L, narg, className);
+	}
+
 	/**
 	 * A wrapper for deprecated functions.
 	 *

--- a/src/script/lua_api/l_camera.cpp
+++ b/src/script/lua_api/l_camera.cpp
@@ -172,7 +172,7 @@ Camera *LuaCamera::getobject(LuaCamera *ref)
 
 Camera *LuaCamera::getobject(lua_State *L, int narg)
 {
-	LuaCamera *ref = (LuaCamera *)methodCheckObject(L, narg);
+	LuaCamera *ref = checkObject<LuaCamera>(L, narg);
 	assert(ref);
 	return getobject(ref);
 }

--- a/src/script/lua_api/l_camera.cpp
+++ b/src/script/lua_api/l_camera.cpp
@@ -165,17 +165,6 @@ int LuaCamera::l_get_aspect_ratio(lua_State *L)
 	return 1;
 }
 
-LuaCamera *LuaCamera::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-
-	return *(LuaCamera **)ud;
-}
-
 Camera *LuaCamera::getobject(LuaCamera *ref)
 {
 	return ref->m_camera;
@@ -183,12 +172,9 @@ Camera *LuaCamera::getobject(LuaCamera *ref)
 
 Camera *LuaCamera::getobject(lua_State *L, int narg)
 {
-	LuaCamera *ref = checkobject(L, narg);
+	LuaCamera *ref = (LuaCamera *)methodCheckObject(L, narg);
 	assert(ref);
-	Camera *camera = getobject(ref);
-	if (!camera)
-		return NULL;
-	return camera;
+	return getobject(ref);
 }
 
 int LuaCamera::gc_object(lua_State *L)
@@ -200,27 +186,11 @@ int LuaCamera::gc_object(lua_State *L)
 
 void LuaCamera::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);
-
-	luaL_register(L, nullptr, methods);
-	lua_pop(L, 1);
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 }
 
 // clang-format off

--- a/src/script/lua_api/l_camera.h
+++ b/src/script/lua_api/l_camera.h
@@ -26,7 +26,6 @@ class Camera;
 class LuaCamera : public ModApiBase
 {
 private:
-	static const char className[];
 	static const luaL_Reg methods[];
 
 	// garbage collector
@@ -44,6 +43,9 @@ private:
 	static int l_get_look_horizontal(lua_State *L);
 	static int l_get_aspect_ratio(lua_State *L);
 
+	static Camera *getobject(LuaCamera *ref);
+	static Camera *getobject(lua_State *L, int narg);
+
 	Camera *m_camera = nullptr;
 
 public:
@@ -52,9 +54,7 @@ public:
 
 	static void create(lua_State *L, Camera *m);
 
-	static LuaCamera *checkobject(lua_State *L, int narg);
-	static Camera *getobject(LuaCamera *ref);
-	static Camera *getobject(lua_State *L, int narg);
-
 	static void Register(lua_State *L);
+
+	static const char className[];
 };

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -158,7 +158,7 @@ int LuaRaycast::l_next(lua_State *L)
 	csm = getClient(L) != nullptr;
 #endif
 
-	LuaRaycast *o = checkobject(L, 1);
+	LuaRaycast *o = (LuaRaycast *)methodCheckObject(L, 1);
 	PointedThing pointed;
 	env->continueRaycast(&o->state, &pointed);
 	if (pointed.type == POINTEDTHING_NOTHING)
@@ -194,17 +194,6 @@ int LuaRaycast::create_object(lua_State *L)
 	return 1;
 }
 
-LuaRaycast *LuaRaycast::checkobject(lua_State *L, int narg)
-{
-	NO_MAP_LOCK_REQUIRED;
-
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-	return *(LuaRaycast **) ud;
-}
-
 int LuaRaycast::gc_object(lua_State *L)
 {
 	LuaRaycast *o = *(LuaRaycast **) (lua_touserdata(L, 1));
@@ -214,31 +203,12 @@ int LuaRaycast::gc_object(lua_State *L)
 
 void LuaRaycast::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__call");
-	lua_pushcfunction(L, l_next);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);
-
-	luaL_register(L, nullptr, methods);
-	lua_pop(L, 1);
+	static const luaL_Reg metamethods[] = {
+		{"__call", l_next},
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 
 	lua_register(L, className, create_object);
 }

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -158,7 +158,7 @@ int LuaRaycast::l_next(lua_State *L)
 	csm = getClient(L) != nullptr;
 #endif
 
-	LuaRaycast *o = (LuaRaycast *)methodCheckObject(L, 1);
+	LuaRaycast *o = checkObject<LuaRaycast>(L, 1);
 	PointedThing pointed;
 	env->continueRaycast(&o->state, &pointed);
 	if (pointed.type == POINTEDTHING_NOTHING)

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -294,7 +294,6 @@ public:
 class LuaRaycast : public ModApiBase
 {
 private:
-	static const char className[];
 	static const luaL_Reg methods[];
 	//! Inner state
 	RaycastState state;
@@ -321,14 +320,10 @@ public:
 	//! Creates a LuaRaycast and leaves it on top of the stack.
 	static int create_object(lua_State *L);
 
-	/*!
-	 * Returns the Raycast from the stack or throws an error.
-	 * @param narg location of the RaycastState in the stack
-	 */
-	static LuaRaycast *checkobject(lua_State *L, int narg);
-
 	//! Registers Raycast as a Lua userdata type.
 	static void Register(lua_State *L);
+
+	static const char className[];
 };
 
 struct ScriptCallbackState {

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -29,13 +29,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /*
 	InvRef
 */
-InvRef* InvRef::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if(!ud) luaL_typerror(L, narg, className);
-	return *(InvRef**)ud;  // unbox pointer
-}
 
 Inventory* InvRef::getinv(lua_State *L, InvRef *ref)
 {
@@ -71,7 +64,7 @@ int InvRef::gc_object(lua_State *L) {
 int InvRef::l_is_empty(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	InventoryList *list = getlist(L, ref, listname);
 	if(list && list->getUsedSlots() > 0){
@@ -86,7 +79,7 @@ int InvRef::l_is_empty(lua_State *L)
 int InvRef::l_get_size(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	InventoryList *list = getlist(L, ref, listname);
 	if(list){
@@ -101,7 +94,7 @@ int InvRef::l_get_size(lua_State *L)
 int InvRef::l_get_width(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	InventoryList *list = getlist(L, ref, listname);
 	if(list){
@@ -116,7 +109,7 @@ int InvRef::l_get_width(lua_State *L)
 int InvRef::l_set_size(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 
 	int newsize = luaL_checknumber(L, 3);
@@ -156,7 +149,7 @@ int InvRef::l_set_size(lua_State *L)
 int InvRef::l_set_width(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	int newwidth = luaL_checknumber(L, 3);
 	Inventory *inv = getinv(L, ref);
@@ -177,7 +170,7 @@ int InvRef::l_set_width(lua_State *L)
 int InvRef::l_get_stack(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	int i = luaL_checknumber(L, 3) - 1;
 	InventoryList *list = getlist(L, ref, listname);
@@ -192,7 +185,7 @@ int InvRef::l_get_stack(lua_State *L)
 int InvRef::l_set_stack(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	int i = luaL_checknumber(L, 3) - 1;
 	ItemStack newitem = read_item(L, 4, getServer(L)->idef());
@@ -211,7 +204,7 @@ int InvRef::l_set_stack(lua_State *L)
 int InvRef::l_get_list(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	Inventory *inv = getinv(L, ref);
 	if (!inv) {
@@ -231,7 +224,7 @@ int InvRef::l_get_list(lua_State *L)
 int InvRef::l_set_list(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	Inventory *inv = getinv(L, ref);
 	if(inv == NULL){
@@ -251,7 +244,7 @@ int InvRef::l_set_list(lua_State *L)
 int InvRef::l_get_lists(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	Inventory *inv = getinv(L, ref);
 	if (!inv) {
 		return 0;
@@ -264,7 +257,7 @@ int InvRef::l_get_lists(lua_State *L)
 int InvRef::l_set_lists(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	Inventory *inv = getinv(L, ref);
 	if (!inv) {
 		return 0;
@@ -292,7 +285,7 @@ int InvRef::l_set_lists(lua_State *L)
 int InvRef::l_add_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	ItemStack item = read_item(L, 3, getServer(L)->idef());
 	InventoryList *list = getlist(L, ref, listname);
@@ -312,7 +305,7 @@ int InvRef::l_add_item(lua_State *L)
 int InvRef::l_room_for_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	ItemStack item = read_item(L, 3, getServer(L)->idef());
 	InventoryList *list = getlist(L, ref, listname);
@@ -329,7 +322,7 @@ int InvRef::l_room_for_item(lua_State *L)
 int InvRef::l_contains_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	ItemStack item = read_item(L, 3, getServer(L)->idef());
 	InventoryList *list = getlist(L, ref, listname);
@@ -349,7 +342,7 @@ int InvRef::l_contains_item(lua_State *L)
 int InvRef::l_remove_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	ItemStack item = read_item(L, 3, getServer(L)->idef());
 	InventoryList *list = getlist(L, ref, listname);
@@ -368,7 +361,7 @@ int InvRef::l_remove_item(lua_State *L)
 int InvRef::l_get_location(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = checkobject(L, 1);
+	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
 	const InventoryLocation &loc = ref->m_loc;
 	switch(loc.type){
 	case InventoryLocation::PLAYER:
@@ -421,27 +414,11 @@ void InvRef::create(lua_State *L, const InventoryLocation &loc)
 
 void InvRef::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);  // drop metatable
-
-	luaL_register(L, nullptr, methods);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 
 	// Cannot be created from Lua
 	//lua_register(L, className, create_object);

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -64,7 +64,7 @@ int InvRef::gc_object(lua_State *L) {
 int InvRef::l_is_empty(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	InventoryList *list = getlist(L, ref, listname);
 	if(list && list->getUsedSlots() > 0){
@@ -79,7 +79,7 @@ int InvRef::l_is_empty(lua_State *L)
 int InvRef::l_get_size(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	InventoryList *list = getlist(L, ref, listname);
 	if(list){
@@ -94,7 +94,7 @@ int InvRef::l_get_size(lua_State *L)
 int InvRef::l_get_width(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	InventoryList *list = getlist(L, ref, listname);
 	if(list){
@@ -109,7 +109,7 @@ int InvRef::l_get_width(lua_State *L)
 int InvRef::l_set_size(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 
 	int newsize = luaL_checknumber(L, 3);
@@ -149,7 +149,7 @@ int InvRef::l_set_size(lua_State *L)
 int InvRef::l_set_width(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	int newwidth = luaL_checknumber(L, 3);
 	Inventory *inv = getinv(L, ref);
@@ -170,7 +170,7 @@ int InvRef::l_set_width(lua_State *L)
 int InvRef::l_get_stack(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	int i = luaL_checknumber(L, 3) - 1;
 	InventoryList *list = getlist(L, ref, listname);
@@ -185,7 +185,7 @@ int InvRef::l_get_stack(lua_State *L)
 int InvRef::l_set_stack(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	int i = luaL_checknumber(L, 3) - 1;
 	ItemStack newitem = read_item(L, 4, getServer(L)->idef());
@@ -204,7 +204,7 @@ int InvRef::l_set_stack(lua_State *L)
 int InvRef::l_get_list(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	Inventory *inv = getinv(L, ref);
 	if (!inv) {
@@ -224,7 +224,7 @@ int InvRef::l_get_list(lua_State *L)
 int InvRef::l_set_list(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	Inventory *inv = getinv(L, ref);
 	if(inv == NULL){
@@ -244,7 +244,7 @@ int InvRef::l_set_list(lua_State *L)
 int InvRef::l_get_lists(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	Inventory *inv = getinv(L, ref);
 	if (!inv) {
 		return 0;
@@ -257,7 +257,7 @@ int InvRef::l_get_lists(lua_State *L)
 int InvRef::l_set_lists(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	Inventory *inv = getinv(L, ref);
 	if (!inv) {
 		return 0;
@@ -285,7 +285,7 @@ int InvRef::l_set_lists(lua_State *L)
 int InvRef::l_add_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	ItemStack item = read_item(L, 3, getServer(L)->idef());
 	InventoryList *list = getlist(L, ref, listname);
@@ -305,7 +305,7 @@ int InvRef::l_add_item(lua_State *L)
 int InvRef::l_room_for_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	ItemStack item = read_item(L, 3, getServer(L)->idef());
 	InventoryList *list = getlist(L, ref, listname);
@@ -322,7 +322,7 @@ int InvRef::l_room_for_item(lua_State *L)
 int InvRef::l_contains_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	ItemStack item = read_item(L, 3, getServer(L)->idef());
 	InventoryList *list = getlist(L, ref, listname);
@@ -342,7 +342,7 @@ int InvRef::l_contains_item(lua_State *L)
 int InvRef::l_remove_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
 	ItemStack item = read_item(L, 3, getServer(L)->idef());
 	InventoryList *list = getlist(L, ref, listname);
@@ -361,7 +361,7 @@ int InvRef::l_remove_item(lua_State *L)
 int InvRef::l_get_location(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	InvRef *ref = (InvRef *)methodCheckObject(L, 1);
+	InvRef *ref = checkObject<InvRef>(L, 1);
 	const InventoryLocation &loc = ref->m_loc;
 	switch(loc.type){
 	case InventoryLocation::PLAYER:

--- a/src/script/lua_api/l_inventory.h
+++ b/src/script/lua_api/l_inventory.h
@@ -34,10 +34,7 @@ class InvRef : public ModApiBase {
 private:
 	InventoryLocation m_loc;
 
-	static const char className[];
 	static const luaL_Reg methods[];
-
-	static InvRef *checkobject(lua_State *L, int narg);
 
 	static Inventory* getinv(lua_State *L, InvRef *ref);
 
@@ -112,6 +109,8 @@ public:
 	// Not callable from Lua; all references are created on the C side.
 	static void create(lua_State *L, const InventoryLocation &loc);
 	static void Register(lua_State *L);
+
+	static const char className[];
 };
 
 class ModApiInventory : public ModApiBase {

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -466,7 +466,7 @@ int LuaItemStack::create(lua_State *L, const ItemStack &item)
 
 void *LuaItemStack::packIn(lua_State *L, int idx)
 {
-	LuaItemStack *o = (LuaItemStack *)checkObject(L, idx, className);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, idx);
 	return new ItemStack(o->getItem());
 }
 

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -41,7 +41,7 @@ int LuaItemStack::gc_object(lua_State *L)
 // __tostring metamethod
 int LuaItemStack::mt_tostring(lua_State *L)
 {
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	std::string itemstring = o->m_stack.getItemString(false);
 	lua_pushfstring(L, "ItemStack(\"%s\")", itemstring.c_str());
 	return 1;
@@ -51,7 +51,7 @@ int LuaItemStack::mt_tostring(lua_State *L)
 int LuaItemStack::l_is_empty(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	lua_pushboolean(L, item.empty());
 	return 1;
@@ -61,7 +61,7 @@ int LuaItemStack::l_is_empty(lua_State *L)
 int LuaItemStack::l_get_name(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	lua_pushstring(L, item.name.c_str());
 	return 1;
@@ -71,7 +71,7 @@ int LuaItemStack::l_get_name(lua_State *L)
 int LuaItemStack::l_set_name(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 
 	bool status = true;
@@ -89,7 +89,7 @@ int LuaItemStack::l_set_name(lua_State *L)
 int LuaItemStack::l_get_count(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	lua_pushinteger(L, item.count);
 	return 1;
@@ -99,7 +99,7 @@ int LuaItemStack::l_get_count(lua_State *L)
 int LuaItemStack::l_set_count(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 
 	bool status;
@@ -120,7 +120,7 @@ int LuaItemStack::l_set_count(lua_State *L)
 int LuaItemStack::l_get_wear(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	lua_pushinteger(L, item.wear);
 	return 1;
@@ -130,7 +130,7 @@ int LuaItemStack::l_get_wear(lua_State *L)
 int LuaItemStack::l_set_wear(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 
 	bool status;
@@ -151,7 +151,7 @@ int LuaItemStack::l_set_wear(lua_State *L)
 int LuaItemStack::l_get_meta(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStackMetaRef::create(L, o);
 	return 1;
 }
@@ -161,7 +161,7 @@ int LuaItemStack::l_get_meta(lua_State *L)
 int LuaItemStack::l_get_metadata(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	const std::string &value = item.metadata.getString("");
 	lua_pushlstring(L, value.c_str(), value.size());
@@ -173,7 +173,7 @@ int LuaItemStack::l_get_metadata(lua_State *L)
 int LuaItemStack::l_set_metadata(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 
 	size_t len = 0;
@@ -188,7 +188,7 @@ int LuaItemStack::l_set_metadata(lua_State *L)
 int LuaItemStack::l_get_description(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	std::string desc = o->m_stack.getDescription(getGameDef(L)->idef());
 	lua_pushstring(L, desc.c_str());
 	return 1;
@@ -198,7 +198,7 @@ int LuaItemStack::l_get_description(lua_State *L)
 int LuaItemStack::l_get_short_description(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	std::string desc = o->m_stack.getShortDescription(getGameDef(L)->idef());
 	lua_pushstring(L, desc.c_str());
 	return 1;
@@ -208,7 +208,7 @@ int LuaItemStack::l_get_short_description(lua_State *L)
 int LuaItemStack::l_clear(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	o->m_stack.clear();
 	lua_pushboolean(L, true);
 	return 1;
@@ -218,7 +218,7 @@ int LuaItemStack::l_clear(lua_State *L)
 int LuaItemStack::l_replace(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	o->m_stack = read_item(L, 2, getGameDef(L)->idef());
 	lua_pushboolean(L, true);
 	return 1;
@@ -228,7 +228,7 @@ int LuaItemStack::l_replace(lua_State *L)
 int LuaItemStack::l_to_string(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	std::string itemstring = o->m_stack.getItemString();
 	lua_pushstring(L, itemstring.c_str());
 	return 1;
@@ -238,7 +238,7 @@ int LuaItemStack::l_to_string(lua_State *L)
 int LuaItemStack::l_to_table(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	const ItemStack &item = o->m_stack;
 	if(item.empty())
 	{
@@ -278,7 +278,7 @@ int LuaItemStack::l_to_table(lua_State *L)
 int LuaItemStack::l_get_stack_max(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	lua_pushinteger(L, item.getStackMax(getGameDef(L)->idef()));
 	return 1;
@@ -288,7 +288,7 @@ int LuaItemStack::l_get_stack_max(lua_State *L)
 int LuaItemStack::l_get_free_space(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	lua_pushinteger(L, item.freeSpace(getGameDef(L)->idef()));
 	return 1;
@@ -299,7 +299,7 @@ int LuaItemStack::l_get_free_space(lua_State *L)
 int LuaItemStack::l_is_known(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	bool is_known = item.isKnown(getGameDef(L)->idef());
 	lua_pushboolean(L, is_known);
@@ -312,7 +312,7 @@ int LuaItemStack::l_is_known(lua_State *L)
 int LuaItemStack::l_get_definition(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 
 	// Get registered_items[name]
@@ -334,7 +334,7 @@ int LuaItemStack::l_get_definition(lua_State *L)
 int LuaItemStack::l_get_tool_capabilities(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	const ToolCapabilities &prop =
 		item.getToolCapabilities(getGameDef(L)->idef());
@@ -349,7 +349,7 @@ int LuaItemStack::l_get_tool_capabilities(lua_State *L)
 int LuaItemStack::l_add_wear(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	int amount = lua_tointeger(L, 2);
 	bool result = item.addWear(amount, getGameDef(L)->idef());
@@ -367,7 +367,7 @@ int LuaItemStack::l_add_wear(lua_State *L)
 int LuaItemStack::l_add_wear_by_uses(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	u32 max_uses = readParam<int>(L, 2);
 	u32 add_wear = calculateResultWear(max_uses, item.wear);
@@ -381,7 +381,7 @@ int LuaItemStack::l_add_wear_by_uses(lua_State *L)
 int LuaItemStack::l_add_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	ItemStack newitem = read_item(L, -1, getGameDef(L)->idef());
 	ItemStack leftover = item.addItem(newitem, getGameDef(L)->idef());
@@ -395,7 +395,7 @@ int LuaItemStack::l_add_item(lua_State *L)
 int LuaItemStack::l_item_fits(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	ItemStack newitem = read_item(L, 2, getGameDef(L)->idef());
 	ItemStack restitem;
@@ -409,7 +409,7 @@ int LuaItemStack::l_item_fits(lua_State *L)
 int LuaItemStack::l_take_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	u32 takecount = 1;
 	if(!lua_isnone(L, 2))
@@ -423,7 +423,7 @@ int LuaItemStack::l_take_item(lua_State *L)
 int LuaItemStack::l_peek_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = checkobject(L, 1);
+	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
 	ItemStack &item = o->m_stack;
 	u32 peekcount = 1;
 	if(!lua_isnone(L, 2))
@@ -464,14 +464,9 @@ int LuaItemStack::create(lua_State *L, const ItemStack &item)
 	return 1;
 }
 
-LuaItemStack *LuaItemStack::checkobject(lua_State *L, int narg)
-{
-	return *(LuaItemStack **)luaL_checkudata(L, narg, className);
-}
-
 void *LuaItemStack::packIn(lua_State *L, int idx)
 {
-	LuaItemStack *o = checkobject(L, idx);
+	LuaItemStack *o = (LuaItemStack *)checkObject(L, idx, className);
 	return new ItemStack(o->getItem());
 }
 
@@ -485,32 +480,12 @@ void LuaItemStack::packOut(lua_State *L, void *ptr)
 
 void LuaItemStack::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	// hide metatable from Lua getmetatable()
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__tostring");
-	lua_pushcfunction(L, mt_tostring);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);  // drop metatable
-
-	luaL_register(L, nullptr, methods);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
+	static const luaL_Reg metamethods[] = {
+		{"__tostring", mt_tostring},
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 
 	// Can be created from Lua (ItemStack(itemstack or itemstring or table or nil))
 	lua_register(L, className, create_object);

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -41,7 +41,7 @@ int LuaItemStack::gc_object(lua_State *L)
 // __tostring metamethod
 int LuaItemStack::mt_tostring(lua_State *L)
 {
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	std::string itemstring = o->m_stack.getItemString(false);
 	lua_pushfstring(L, "ItemStack(\"%s\")", itemstring.c_str());
 	return 1;
@@ -51,7 +51,7 @@ int LuaItemStack::mt_tostring(lua_State *L)
 int LuaItemStack::l_is_empty(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	lua_pushboolean(L, item.empty());
 	return 1;
@@ -61,7 +61,7 @@ int LuaItemStack::l_is_empty(lua_State *L)
 int LuaItemStack::l_get_name(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	lua_pushstring(L, item.name.c_str());
 	return 1;
@@ -71,7 +71,7 @@ int LuaItemStack::l_get_name(lua_State *L)
 int LuaItemStack::l_set_name(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 
 	bool status = true;
@@ -89,7 +89,7 @@ int LuaItemStack::l_set_name(lua_State *L)
 int LuaItemStack::l_get_count(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	lua_pushinteger(L, item.count);
 	return 1;
@@ -99,7 +99,7 @@ int LuaItemStack::l_get_count(lua_State *L)
 int LuaItemStack::l_set_count(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 
 	bool status;
@@ -120,7 +120,7 @@ int LuaItemStack::l_set_count(lua_State *L)
 int LuaItemStack::l_get_wear(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	lua_pushinteger(L, item.wear);
 	return 1;
@@ -130,7 +130,7 @@ int LuaItemStack::l_get_wear(lua_State *L)
 int LuaItemStack::l_set_wear(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 
 	bool status;
@@ -151,7 +151,7 @@ int LuaItemStack::l_set_wear(lua_State *L)
 int LuaItemStack::l_get_meta(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStackMetaRef::create(L, o);
 	return 1;
 }
@@ -161,7 +161,7 @@ int LuaItemStack::l_get_meta(lua_State *L)
 int LuaItemStack::l_get_metadata(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	const std::string &value = item.metadata.getString("");
 	lua_pushlstring(L, value.c_str(), value.size());
@@ -173,7 +173,7 @@ int LuaItemStack::l_get_metadata(lua_State *L)
 int LuaItemStack::l_set_metadata(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 
 	size_t len = 0;
@@ -188,7 +188,7 @@ int LuaItemStack::l_set_metadata(lua_State *L)
 int LuaItemStack::l_get_description(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	std::string desc = o->m_stack.getDescription(getGameDef(L)->idef());
 	lua_pushstring(L, desc.c_str());
 	return 1;
@@ -198,7 +198,7 @@ int LuaItemStack::l_get_description(lua_State *L)
 int LuaItemStack::l_get_short_description(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	std::string desc = o->m_stack.getShortDescription(getGameDef(L)->idef());
 	lua_pushstring(L, desc.c_str());
 	return 1;
@@ -208,7 +208,7 @@ int LuaItemStack::l_get_short_description(lua_State *L)
 int LuaItemStack::l_clear(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	o->m_stack.clear();
 	lua_pushboolean(L, true);
 	return 1;
@@ -218,7 +218,7 @@ int LuaItemStack::l_clear(lua_State *L)
 int LuaItemStack::l_replace(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	o->m_stack = read_item(L, 2, getGameDef(L)->idef());
 	lua_pushboolean(L, true);
 	return 1;
@@ -228,7 +228,7 @@ int LuaItemStack::l_replace(lua_State *L)
 int LuaItemStack::l_to_string(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	std::string itemstring = o->m_stack.getItemString();
 	lua_pushstring(L, itemstring.c_str());
 	return 1;
@@ -238,7 +238,7 @@ int LuaItemStack::l_to_string(lua_State *L)
 int LuaItemStack::l_to_table(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	const ItemStack &item = o->m_stack;
 	if(item.empty())
 	{
@@ -278,7 +278,7 @@ int LuaItemStack::l_to_table(lua_State *L)
 int LuaItemStack::l_get_stack_max(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	lua_pushinteger(L, item.getStackMax(getGameDef(L)->idef()));
 	return 1;
@@ -288,7 +288,7 @@ int LuaItemStack::l_get_stack_max(lua_State *L)
 int LuaItemStack::l_get_free_space(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	lua_pushinteger(L, item.freeSpace(getGameDef(L)->idef()));
 	return 1;
@@ -299,7 +299,7 @@ int LuaItemStack::l_get_free_space(lua_State *L)
 int LuaItemStack::l_is_known(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	bool is_known = item.isKnown(getGameDef(L)->idef());
 	lua_pushboolean(L, is_known);
@@ -312,7 +312,7 @@ int LuaItemStack::l_is_known(lua_State *L)
 int LuaItemStack::l_get_definition(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 
 	// Get registered_items[name]
@@ -334,7 +334,7 @@ int LuaItemStack::l_get_definition(lua_State *L)
 int LuaItemStack::l_get_tool_capabilities(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	const ToolCapabilities &prop =
 		item.getToolCapabilities(getGameDef(L)->idef());
@@ -349,7 +349,7 @@ int LuaItemStack::l_get_tool_capabilities(lua_State *L)
 int LuaItemStack::l_add_wear(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	int amount = lua_tointeger(L, 2);
 	bool result = item.addWear(amount, getGameDef(L)->idef());
@@ -367,7 +367,7 @@ int LuaItemStack::l_add_wear(lua_State *L)
 int LuaItemStack::l_add_wear_by_uses(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	u32 max_uses = readParam<int>(L, 2);
 	u32 add_wear = calculateResultWear(max_uses, item.wear);
@@ -381,7 +381,7 @@ int LuaItemStack::l_add_wear_by_uses(lua_State *L)
 int LuaItemStack::l_add_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	ItemStack newitem = read_item(L, -1, getGameDef(L)->idef());
 	ItemStack leftover = item.addItem(newitem, getGameDef(L)->idef());
@@ -395,7 +395,7 @@ int LuaItemStack::l_add_item(lua_State *L)
 int LuaItemStack::l_item_fits(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	ItemStack newitem = read_item(L, 2, getGameDef(L)->idef());
 	ItemStack restitem;
@@ -409,7 +409,7 @@ int LuaItemStack::l_item_fits(lua_State *L)
 int LuaItemStack::l_take_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	u32 takecount = 1;
 	if(!lua_isnone(L, 2))
@@ -423,7 +423,7 @@ int LuaItemStack::l_take_item(lua_State *L)
 int LuaItemStack::l_peek_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaItemStack *o = (LuaItemStack *)methodCheckObject(L, 1);
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	u32 peekcount = 1;
 	if(!lua_isnone(L, 2))

--- a/src/script/lua_api/l_item.h
+++ b/src/script/lua_api/l_item.h
@@ -30,7 +30,6 @@ private:
 	LuaItemStack(const ItemStack &item);
 	~LuaItemStack() = default;
 
-	static const char className[];
 	static const luaL_Reg methods[];
 
 	// Exported functions
@@ -152,12 +151,13 @@ public:
 	static int create_object(lua_State *L);
 	// Not callable from Lua
 	static int create(lua_State *L, const ItemStack &item);
-	static LuaItemStack* checkobject(lua_State *L, int narg);
 
 	static void *packIn(lua_State *L, int idx);
 	static void packOut(lua_State *L, void *ptr);
 
 	static void Register(lua_State *L);
+
+	static const char className[];
 };
 
 class ModApiItemMod : public ModApiBase {

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -45,7 +45,7 @@ void ItemStackMetaRef::reportMetadataChange(const std::string *name)
 // Exported functions
 int ItemStackMetaRef::l_set_tool_capabilities(lua_State *L)
 {
-	ItemStackMetaRef *metaref = (ItemStackMetaRef *)methodCheckObject(L, 1);
+	ItemStackMetaRef *metaref = checkObject<ItemStackMetaRef>(L, 1);
 	if (lua_isnoneornil(L, 2)) {
 		metaref->clearToolCapabilities();
 	} else if (lua_istable(L, 2)) {

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -24,17 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_content.h"
 
 /*
-	NodeMetaRef
+	ItemStackMetaRef
 */
-ItemStackMetaRef* ItemStackMetaRef::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-
-	return *(ItemStackMetaRef**)ud;  // unbox pointer
-}
 
 IMetadata* ItemStackMetaRef::getmeta(bool auto_create)
 {
@@ -54,7 +45,7 @@ void ItemStackMetaRef::reportMetadataChange(const std::string *name)
 // Exported functions
 int ItemStackMetaRef::l_set_tool_capabilities(lua_State *L)
 {
-	ItemStackMetaRef *metaref = checkobject(L, 1);
+	ItemStackMetaRef *metaref = (ItemStackMetaRef *)methodCheckObject(L, 1);
 	if (lua_isnoneornil(L, 2)) {
 		metaref->clearToolCapabilities();
 	} else if (lua_istable(L, 2)) {
@@ -77,13 +68,6 @@ ItemStackMetaRef::~ItemStackMetaRef()
 	istack->drop();
 }
 
-// garbage collector
-int ItemStackMetaRef::gc_object(lua_State *L) {
-	ItemStackMetaRef *o = *(ItemStackMetaRef **)(lua_touserdata(L, 1));
-	delete o;
-	return 0;
-}
-
 // Creates an NodeMetaRef and leaves it on top of stack
 // Not callable from Lua; all references are created on the C side.
 void ItemStackMetaRef::create(lua_State *L, LuaItemStack *istack)
@@ -97,35 +81,7 @@ void ItemStackMetaRef::create(lua_State *L, LuaItemStack *istack)
 
 void ItemStackMetaRef::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
-
-	lua_pushliteral(L, "metadata_class");
-	lua_pushlstring(L, className, strlen(className));
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__eq");
-	lua_pushcfunction(L, l_equals);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);  // drop metatable
-
-	luaL_register(L, nullptr, methods);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
+	registerMetadataClass(L, className, methods);
 
 	// Cannot be created from Lua
 	//lua_register(L, className, create_object);

--- a/src/script/lua_api/l_itemstackmeta.h
+++ b/src/script/lua_api/l_itemstackmeta.h
@@ -31,10 +31,7 @@ class ItemStackMetaRef : public MetaDataRef
 private:
 	LuaItemStack *istack;
 
-	static const char className[];
 	static const luaL_Reg methods[];
-
-	static ItemStackMetaRef *checkobject(lua_State *L, int narg);
 
 	virtual IMetadata* getmeta(bool auto_create);
 
@@ -54,9 +51,6 @@ private:
 
 	// Exported functions
 	static int l_set_tool_capabilities(lua_State *L);
-
-	// garbage collector
-	static int gc_object(lua_State *L);
 public:
 	// takes a reference
 	ItemStackMetaRef(LuaItemStack *istack);
@@ -69,4 +63,6 @@ public:
 	static void create(lua_State *L, LuaItemStack *istack);
 
 	static void Register(lua_State *L);
+
+	static const char className[];
 };

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -401,17 +401,6 @@ int LuaLocalPlayer::l_hud_get(lua_State *L)
 	return 1;
 }
 
-LuaLocalPlayer *LuaLocalPlayer::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-
-	return *(LuaLocalPlayer **)ud;
-}
-
 LocalPlayer *LuaLocalPlayer::getobject(LuaLocalPlayer *ref)
 {
 	return ref->m_localplayer;
@@ -419,7 +408,7 @@ LocalPlayer *LuaLocalPlayer::getobject(LuaLocalPlayer *ref)
 
 LocalPlayer *LuaLocalPlayer::getobject(lua_State *L, int narg)
 {
-	LuaLocalPlayer *ref = checkobject(L, narg);
+	LuaLocalPlayer *ref = (LuaLocalPlayer *)methodCheckObject(L, narg);
 	assert(ref);
 	LocalPlayer *player = getobject(ref);
 	assert(player);
@@ -435,27 +424,11 @@ int LuaLocalPlayer::gc_object(lua_State *L)
 
 void LuaLocalPlayer::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable); // hide metatable from lua getmetatable()
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1); // Drop metatable
-
-	luaL_register(L, nullptr, methods); // fill methodtable
-	lua_pop(L, 1);			// Drop methodtable
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 }
 
 const char LuaLocalPlayer::className[] = "LocalPlayer";

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -408,7 +408,7 @@ LocalPlayer *LuaLocalPlayer::getobject(LuaLocalPlayer *ref)
 
 LocalPlayer *LuaLocalPlayer::getobject(lua_State *L, int narg)
 {
-	LuaLocalPlayer *ref = (LuaLocalPlayer *)methodCheckObject(L, narg);
+	LuaLocalPlayer *ref = checkObject<LuaLocalPlayer>(L, narg);
 	assert(ref);
 	LocalPlayer *player = getobject(ref);
 	assert(player);

--- a/src/script/lua_api/l_localplayer.h
+++ b/src/script/lua_api/l_localplayer.h
@@ -26,7 +26,6 @@ class LocalPlayer;
 class LuaLocalPlayer : public ModApiBase
 {
 private:
-	static const char className[];
 	static const luaL_Reg methods[];
 
 	// garbage collector
@@ -97,6 +96,9 @@ private:
 
 	static int l_get_move_resistance(lua_State *L);
 
+	static LocalPlayer *getobject(LuaLocalPlayer *ref);
+	static LocalPlayer *getobject(lua_State *L, int narg);
+
 	LocalPlayer *m_localplayer = nullptr;
 
 public:
@@ -105,9 +107,7 @@ public:
 
 	static void create(lua_State *L, LocalPlayer *m);
 
-	static LuaLocalPlayer *checkobject(lua_State *L, int narg);
-	static LocalPlayer *getobject(LuaLocalPlayer *ref);
-	static LocalPlayer *getobject(lua_State *L, int narg);
-
 	static void Register(lua_State *L);
+
+	static const char className[];
 };

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1429,7 +1429,7 @@ int ModApiMapgen::l_generate_ores(lua_State *L)
 	Mapgen mg;
 	// Intentionally truncates to s32, see Mapgen::Mapgen()
 	mg.seed = (s32)emerge->mgparams->seed;
-	mg.vm   = ((LuaVoxelManip *)checkObject(L, 1, LuaVoxelManip::className))->vm;
+	mg.vm   = checkObject<LuaVoxelManip>(L, 1)->vm;
 	mg.ndef = getServer(L)->getNodeDefManager();
 
 	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
@@ -1458,7 +1458,7 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 	Mapgen mg;
 	// Intentionally truncates to s32, see Mapgen::Mapgen()
 	mg.seed = (s32)emerge->mgparams->seed;
-	mg.vm   = ((LuaVoxelManip *)checkObject(L, 1, LuaVoxelManip::className))->vm;
+	mg.vm   = checkObject<LuaVoxelManip>(L, 1)->vm;
 	mg.ndef = getServer(L)->getNodeDefManager();
 
 	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
@@ -1597,7 +1597,7 @@ int ModApiMapgen::l_place_schematic_on_vmanip(lua_State *L)
 	SchematicManager *schemmgr = getServer(L)->getEmergeManager()->schemmgr;
 
 	//// Read VoxelManip object
-	MMVManip *vm = ((LuaVoxelManip *)checkObject(L, 1, LuaVoxelManip::className))->vm;
+	MMVManip *vm = checkObject<LuaVoxelManip>(L, 1)->vm;
 
 	//// Read position
 	v3s16 p = check_v3s16(L, 2);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1429,7 +1429,7 @@ int ModApiMapgen::l_generate_ores(lua_State *L)
 	Mapgen mg;
 	// Intentionally truncates to s32, see Mapgen::Mapgen()
 	mg.seed = (s32)emerge->mgparams->seed;
-	mg.vm   = LuaVoxelManip::checkobject(L, 1)->vm;
+	mg.vm   = ((LuaVoxelManip *)checkObject(L, 1, LuaVoxelManip::className))->vm;
 	mg.ndef = getServer(L)->getNodeDefManager();
 
 	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
@@ -1458,7 +1458,7 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 	Mapgen mg;
 	// Intentionally truncates to s32, see Mapgen::Mapgen()
 	mg.seed = (s32)emerge->mgparams->seed;
-	mg.vm   = LuaVoxelManip::checkobject(L, 1)->vm;
+	mg.vm   = ((LuaVoxelManip *)checkObject(L, 1, LuaVoxelManip::className))->vm;
 	mg.ndef = getServer(L)->getNodeDefManager();
 
 	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
@@ -1597,7 +1597,7 @@ int ModApiMapgen::l_place_schematic_on_vmanip(lua_State *L)
 	SchematicManager *schemmgr = getServer(L)->getEmergeManager()->schemmgr;
 
 	//// Read VoxelManip object
-	MMVManip *vm = LuaVoxelManip::checkobject(L, 1)->vm;
+	MMVManip *vm = ((LuaVoxelManip *)checkObject(L, 1, LuaVoxelManip::className))->vm;
 
 	//// Read position
 	v3s16 p = check_v3s16(L, 2);

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -25,28 +25,27 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "map.h"
 #include "server.h"
 
-// LUALIB_API
-void *luaL_checkudata_is_metadataref(lua_State *L, int ud) {
-	void *p = lua_touserdata(L, ud);
-	if (p != NULL &&  // value is a userdata?
-			lua_getmetatable(L, ud)) {  // does it have a metatable?
-		lua_getfield(L, -1, "metadata_class");
-		if (lua_type(L, -1) == LUA_TSTRING) { // does it have a metadata_class field?
-			return p;
-		}
-	}
-	luaL_typerror(L, ud, "MetaDataRef");
-	return NULL;
-}
-
-MetaDataRef* MetaDataRef::checkobject(lua_State *L, int narg)
+MetaDataRef *MetaDataRef::checkAnyMetadata(lua_State *L, int narg)
 {
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata_is_metadataref(L, narg);
-	if (!ud)
+	void *ud = lua_touserdata(L, narg);
+
+	bool ok = ud && luaL_getmetafield(L, narg, "metadata_class");
+	if (ok) {
+		ok = lua_isstring(L, -1);
+		lua_pop(L, 1);
+	}
+
+	if (!ok)
 		luaL_typerror(L, narg, "MetaDataRef");
 
-	return *(MetaDataRef**)ud;  // unbox pointer
+	return *(MetaDataRef **)ud; // unbox pointer
+}
+
+int MetaDataRef::gc_object(lua_State *L)
+{
+	MetaDataRef *o = *(MetaDataRef **)lua_touserdata(L, 1);
+	delete o;
+	return 0;
 }
 
 // Exported functions
@@ -56,7 +55,7 @@ int MetaDataRef::l_contains(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = checkobject(L, 1);
+	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 
 	IMetadata *meta = ref->getmeta(false);
@@ -72,7 +71,7 @@ int MetaDataRef::l_get(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = checkobject(L, 1);
+	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 
 	IMetadata *meta = ref->getmeta(false);
@@ -93,7 +92,7 @@ int MetaDataRef::l_get_string(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = checkobject(L, 1);
+	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 
 	IMetadata *meta = ref->getmeta(false);
@@ -113,7 +112,7 @@ int MetaDataRef::l_set_string(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = checkobject(L, 1);
+	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	size_t len = 0;
 	const char *s = lua_tolstring(L, 3, &len);
@@ -130,7 +129,7 @@ int MetaDataRef::l_get_int(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = checkobject(L, 1);
+	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 
 	IMetadata *meta = ref->getmeta(false);
@@ -150,7 +149,7 @@ int MetaDataRef::l_set_int(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = checkobject(L, 1);
+	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	int a = luaL_checkint(L, 3);
 	std::string str = itos(a);
@@ -166,7 +165,7 @@ int MetaDataRef::l_get_float(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = checkobject(L, 1);
+	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 
 	IMetadata *meta = ref->getmeta(false);
@@ -186,7 +185,7 @@ int MetaDataRef::l_set_float(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = checkobject(L, 1);
+	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	float a = readParam<float>(L, 3);
 	std::string str = ftos(a);
@@ -202,7 +201,7 @@ int MetaDataRef::l_to_table(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = checkobject(L, 1);
+	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
 
 	IMetadata *meta = ref->getmeta(true);
 	if (meta == NULL) {
@@ -221,7 +220,7 @@ int MetaDataRef::l_from_table(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = checkobject(L, 1);
+	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
 	int base = 2;
 
 	ref->clearMeta();
@@ -286,13 +285,29 @@ bool MetaDataRef::handleFromTable(lua_State *L, int table, IMetadata *meta)
 // equals(self, other)
 int MetaDataRef::l_equals(lua_State *L)
 {
-	MetaDataRef *ref1 = checkobject(L, 1);
+	MetaDataRef *ref1 = (MetaDataRef *)methodCheckObject(L, 1);
 	IMetadata *data1 = ref1->getmeta(false);
-	MetaDataRef *ref2 = checkobject(L, 2);
+	MetaDataRef *ref2 = checkAnyMetadata(L, 2);
 	IMetadata *data2 = ref2->getmeta(false);
 	if (data1 == NULL || data2 == NULL)
 		lua_pushboolean(L, data1 == data2);
 	else
 		lua_pushboolean(L, *data1 == *data2);
 	return 1;
+}
+
+void MetaDataRef::registerMetadataClass(lua_State *L, const char *name,
+		const luaL_Reg *methods)
+{
+	const luaL_Reg metamethods[] = {
+		{"__eq", l_equals},
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, name, methods, metamethods);
+
+	luaL_getmetatable(L, name);
+	lua_pushstring(L, name);
+	lua_setfield(L, -2, "metadata_class");
+	lua_pop(L, 1);
 }

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -55,7 +55,7 @@ int MetaDataRef::l_contains(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 
 	IMetadata *meta = ref->getmeta(false);
@@ -71,7 +71,7 @@ int MetaDataRef::l_get(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 
 	IMetadata *meta = ref->getmeta(false);
@@ -92,7 +92,7 @@ int MetaDataRef::l_get_string(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 
 	IMetadata *meta = ref->getmeta(false);
@@ -112,7 +112,7 @@ int MetaDataRef::l_set_string(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	size_t len = 0;
 	const char *s = lua_tolstring(L, 3, &len);
@@ -129,7 +129,7 @@ int MetaDataRef::l_get_int(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 
 	IMetadata *meta = ref->getmeta(false);
@@ -149,7 +149,7 @@ int MetaDataRef::l_set_int(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	int a = luaL_checkint(L, 3);
 	std::string str = itos(a);
@@ -165,7 +165,7 @@ int MetaDataRef::l_get_float(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 
 	IMetadata *meta = ref->getmeta(false);
@@ -185,7 +185,7 @@ int MetaDataRef::l_set_float(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	float a = readParam<float>(L, 3);
 	std::string str = ftos(a);
@@ -201,7 +201,7 @@ int MetaDataRef::l_to_table(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
 
 	IMetadata *meta = ref->getmeta(true);
 	if (meta == NULL) {
@@ -220,7 +220,7 @@ int MetaDataRef::l_from_table(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	MetaDataRef *ref = (MetaDataRef *)methodCheckObject(L, 1);
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
 	int base = 2;
 
 	ref->clearMeta();
@@ -285,7 +285,7 @@ bool MetaDataRef::handleFromTable(lua_State *L, int table, IMetadata *meta)
 // equals(self, other)
 int MetaDataRef::l_equals(lua_State *L)
 {
-	MetaDataRef *ref1 = (MetaDataRef *)methodCheckObject(L, 1);
+	MetaDataRef *ref1 = checkAnyMetadata(L, 1);
 	IMetadata *data1 = ref1->getmeta(false);
 	MetaDataRef *ref2 = checkAnyMetadata(L, 2);
 	IMetadata *data2 = ref2->getmeta(false);

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -306,6 +306,7 @@ void MetaDataRef::registerMetadataClass(lua_State *L, const char *name,
 	};
 	registerClass(L, name, methods, metamethods);
 
+	// Set metadata_class in the metatable for MetaDataRef::checkAnyMetadata.
 	luaL_getmetatable(L, name);
 	lua_pushstring(L, name);
 	lua_setfield(L, -2, "metadata_class");

--- a/src/script/lua_api/l_metadata.h
+++ b/src/script/lua_api/l_metadata.h
@@ -34,9 +34,9 @@ class MetaDataRef : public ModApiBase
 public:
 	virtual ~MetaDataRef() = default;
 
-protected:
-	static MetaDataRef *checkobject(lua_State *L, int narg);
+	static MetaDataRef *checkAnyMetadata(lua_State *L, int narg);
 
+protected:
 	virtual void reportMetadataChange(const std::string *name = nullptr) {}
 	virtual IMetadata *getmeta(bool auto_create) = 0;
 	virtual void clearMeta() = 0;
@@ -44,7 +44,11 @@ protected:
 	virtual void handleToTable(lua_State *L, IMetadata *meta);
 	virtual bool handleFromTable(lua_State *L, int table, IMetadata *meta);
 
+	static void registerMetadataClass(lua_State *L, const char *name, const luaL_Reg *methods);
+
 	// Exported functions
+
+	static int gc_object(lua_State *L);
 
 	// contains(self, name)
 	static int l_contains(lua_State *L);

--- a/src/script/lua_api/l_minimap.cpp
+++ b/src/script/lua_api/l_minimap.cpp
@@ -50,7 +50,7 @@ void LuaMinimap::create(lua_State *L, Minimap *m)
 
 int LuaMinimap::l_get_pos(lua_State *L)
 {
-	LuaMinimap *ref = checkobject(L, 1);
+	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
 	Minimap *m = getobject(ref);
 
 	push_v3s16(L, m->getPos());
@@ -59,7 +59,7 @@ int LuaMinimap::l_get_pos(lua_State *L)
 
 int LuaMinimap::l_set_pos(lua_State *L)
 {
-	LuaMinimap *ref = checkobject(L, 1);
+	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
 	Minimap *m = getobject(ref);
 
 	m->setPos(read_v3s16(L, 2));
@@ -68,7 +68,7 @@ int LuaMinimap::l_set_pos(lua_State *L)
 
 int LuaMinimap::l_get_angle(lua_State *L)
 {
-	LuaMinimap *ref = checkobject(L, 1);
+	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
 	Minimap *m = getobject(ref);
 
 	lua_pushinteger(L, m->getAngle());
@@ -77,7 +77,7 @@ int LuaMinimap::l_get_angle(lua_State *L)
 
 int LuaMinimap::l_set_angle(lua_State *L)
 {
-	LuaMinimap *ref = checkobject(L, 1);
+	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
 	Minimap *m = getobject(ref);
 
 	m->setAngle(lua_tointeger(L, 2));
@@ -86,7 +86,7 @@ int LuaMinimap::l_set_angle(lua_State *L)
 
 int LuaMinimap::l_get_mode(lua_State *L)
 {
-	LuaMinimap *ref = checkobject(L, 1);
+	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
 	Minimap *m = getobject(ref);
 
 	lua_pushinteger(L, m->getModeIndex());
@@ -95,7 +95,7 @@ int LuaMinimap::l_get_mode(lua_State *L)
 
 int LuaMinimap::l_set_mode(lua_State *L)
 {
-	LuaMinimap *ref = checkobject(L, 1);
+	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
 	Minimap *m = getobject(ref);
 
 	u32 mode = lua_tointeger(L, 2);
@@ -108,7 +108,7 @@ int LuaMinimap::l_set_mode(lua_State *L)
 
 int LuaMinimap::l_set_shape(lua_State *L)
 {
-	LuaMinimap *ref = checkobject(L, 1);
+	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
 	Minimap *m = getobject(ref);
 	if (!lua_isnumber(L, 2))
 		return 0;
@@ -119,7 +119,7 @@ int LuaMinimap::l_set_shape(lua_State *L)
 
 int LuaMinimap::l_get_shape(lua_State *L)
 {
-	LuaMinimap *ref = checkobject(L, 1);
+	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
 	Minimap *m = getobject(ref);
 
 	lua_pushnumber(L, (int)m->getMinimapShape());
@@ -135,7 +135,7 @@ int LuaMinimap::l_show(lua_State *L)
 	Client *client = getClient(L);
 	assert(client);
 
-	LuaMinimap *ref = checkobject(L, 1);
+	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
 	Minimap *m = getobject(ref);
 
 	// This is not very adapted to new minimap mode management. Btw, tried
@@ -153,7 +153,7 @@ int LuaMinimap::l_hide(lua_State *L)
 	Client *client = getClient(L);
 	assert(client);
 
-	LuaMinimap *ref = checkobject(L, 1);
+	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
 	Minimap *m = getobject(ref);
 
 	// This is not very adapted to new minimap mode management. Btw, tried
@@ -164,19 +164,6 @@ int LuaMinimap::l_hide(lua_State *L)
 
 	client->showMinimap(false);
 	return 1;
-}
-
-LuaMinimap *LuaMinimap::checkobject(lua_State *L, int narg)
-{
-	NO_MAP_LOCK_REQUIRED;
-
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-
-	return *(LuaMinimap **)ud;  // unbox pointer
 }
 
 Minimap* LuaMinimap::getobject(LuaMinimap *ref)
@@ -192,27 +179,11 @@ int LuaMinimap::gc_object(lua_State *L) {
 
 void LuaMinimap::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);  // drop metatable
-
-	luaL_register(L, nullptr, methods);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 }
 
 const char LuaMinimap::className[] = "Minimap";

--- a/src/script/lua_api/l_minimap.cpp
+++ b/src/script/lua_api/l_minimap.cpp
@@ -50,7 +50,7 @@ void LuaMinimap::create(lua_State *L, Minimap *m)
 
 int LuaMinimap::l_get_pos(lua_State *L)
 {
-	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
+	LuaMinimap *ref = checkObject<LuaMinimap>(L, 1);
 	Minimap *m = getobject(ref);
 
 	push_v3s16(L, m->getPos());
@@ -59,7 +59,7 @@ int LuaMinimap::l_get_pos(lua_State *L)
 
 int LuaMinimap::l_set_pos(lua_State *L)
 {
-	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
+	LuaMinimap *ref = checkObject<LuaMinimap>(L, 1);
 	Minimap *m = getobject(ref);
 
 	m->setPos(read_v3s16(L, 2));
@@ -68,7 +68,7 @@ int LuaMinimap::l_set_pos(lua_State *L)
 
 int LuaMinimap::l_get_angle(lua_State *L)
 {
-	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
+	LuaMinimap *ref = checkObject<LuaMinimap>(L, 1);
 	Minimap *m = getobject(ref);
 
 	lua_pushinteger(L, m->getAngle());
@@ -77,7 +77,7 @@ int LuaMinimap::l_get_angle(lua_State *L)
 
 int LuaMinimap::l_set_angle(lua_State *L)
 {
-	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
+	LuaMinimap *ref = checkObject<LuaMinimap>(L, 1);
 	Minimap *m = getobject(ref);
 
 	m->setAngle(lua_tointeger(L, 2));
@@ -86,7 +86,7 @@ int LuaMinimap::l_set_angle(lua_State *L)
 
 int LuaMinimap::l_get_mode(lua_State *L)
 {
-	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
+	LuaMinimap *ref = checkObject<LuaMinimap>(L, 1);
 	Minimap *m = getobject(ref);
 
 	lua_pushinteger(L, m->getModeIndex());
@@ -95,7 +95,7 @@ int LuaMinimap::l_get_mode(lua_State *L)
 
 int LuaMinimap::l_set_mode(lua_State *L)
 {
-	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
+	LuaMinimap *ref = checkObject<LuaMinimap>(L, 1);
 	Minimap *m = getobject(ref);
 
 	u32 mode = lua_tointeger(L, 2);
@@ -108,7 +108,7 @@ int LuaMinimap::l_set_mode(lua_State *L)
 
 int LuaMinimap::l_set_shape(lua_State *L)
 {
-	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
+	LuaMinimap *ref = checkObject<LuaMinimap>(L, 1);
 	Minimap *m = getobject(ref);
 	if (!lua_isnumber(L, 2))
 		return 0;
@@ -119,7 +119,7 @@ int LuaMinimap::l_set_shape(lua_State *L)
 
 int LuaMinimap::l_get_shape(lua_State *L)
 {
-	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
+	LuaMinimap *ref = checkObject<LuaMinimap>(L, 1);
 	Minimap *m = getobject(ref);
 
 	lua_pushnumber(L, (int)m->getMinimapShape());
@@ -135,7 +135,7 @@ int LuaMinimap::l_show(lua_State *L)
 	Client *client = getClient(L);
 	assert(client);
 
-	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
+	LuaMinimap *ref = checkObject<LuaMinimap>(L, 1);
 	Minimap *m = getobject(ref);
 
 	// This is not very adapted to new minimap mode management. Btw, tried
@@ -153,7 +153,7 @@ int LuaMinimap::l_hide(lua_State *L)
 	Client *client = getClient(L);
 	assert(client);
 
-	LuaMinimap *ref = (LuaMinimap *)methodCheckObject(L, 1);
+	LuaMinimap *ref = checkObject<LuaMinimap>(L, 1);
 	Minimap *m = getobject(ref);
 
 	// This is not very adapted to new minimap mode management. Btw, tried

--- a/src/script/lua_api/l_minimap.h
+++ b/src/script/lua_api/l_minimap.h
@@ -26,7 +26,6 @@ class Minimap;
 class LuaMinimap : public ModApiBase
 {
 private:
-	static const char className[];
 	static const luaL_Reg methods[];
 
 	// garbage collector
@@ -55,8 +54,9 @@ public:
 
 	static void create(lua_State *L, Minimap *object);
 
-	static LuaMinimap *checkobject(lua_State *L, int narg);
 	static Minimap *getobject(LuaMinimap *ref);
 
 	static void Register(lua_State *L);
+
+	static const char className[];
 };

--- a/src/script/lua_api/l_modchannels.cpp
+++ b/src/script/lua_api/l_modchannels.cpp
@@ -57,14 +57,14 @@ ModChannelRef::ModChannelRef(const std::string &modchannel) :
 
 int ModChannelRef::l_leave(lua_State *L)
 {
-	ModChannelRef *ref = checkobject(L, 1);
+	ModChannelRef *ref = (ModChannelRef *)methodCheckObject(L, 1);
 	getGameDef(L)->leaveModChannel(ref->m_modchannel_name);
 	return 0;
 }
 
 int ModChannelRef::l_send_all(lua_State *L)
 {
-	ModChannelRef *ref = checkobject(L, 1);
+	ModChannelRef *ref = (ModChannelRef *)methodCheckObject(L, 1);
 	ModChannel *channel = getobject(L, ref);
 	if (!channel || !channel->canWrite())
 		return 0;
@@ -78,7 +78,7 @@ int ModChannelRef::l_send_all(lua_State *L)
 
 int ModChannelRef::l_is_writeable(lua_State *L)
 {
-	ModChannelRef *ref = checkobject(L, 1);
+	ModChannelRef *ref = (ModChannelRef *)methodCheckObject(L, 1);
 	ModChannel *channel = getobject(L, ref);
 	if (!channel)
 		return 0;
@@ -88,27 +88,11 @@ int ModChannelRef::l_is_writeable(lua_State *L)
 }
 void ModChannelRef::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable); // hide metatable from lua getmetatable()
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1); // Drop metatable
-
-	luaL_register(L, nullptr, methods); // fill methodtable
-	lua_pop(L, 1);			// Drop methodtable
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 }
 
 void ModChannelRef::create(lua_State *L, const std::string &channel)
@@ -124,17 +108,6 @@ int ModChannelRef::gc_object(lua_State *L)
 	ModChannelRef *o = *(ModChannelRef **)(lua_touserdata(L, 1));
 	delete o;
 	return 0;
-}
-
-ModChannelRef *ModChannelRef::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-
-	return *(ModChannelRef **)ud; // unbox pointer
 }
 
 ModChannel *ModChannelRef::getobject(lua_State *L, ModChannelRef *ref)

--- a/src/script/lua_api/l_modchannels.cpp
+++ b/src/script/lua_api/l_modchannels.cpp
@@ -57,14 +57,14 @@ ModChannelRef::ModChannelRef(const std::string &modchannel) :
 
 int ModChannelRef::l_leave(lua_State *L)
 {
-	ModChannelRef *ref = (ModChannelRef *)methodCheckObject(L, 1);
+	ModChannelRef *ref = checkObject<ModChannelRef>(L, 1);
 	getGameDef(L)->leaveModChannel(ref->m_modchannel_name);
 	return 0;
 }
 
 int ModChannelRef::l_send_all(lua_State *L)
 {
-	ModChannelRef *ref = (ModChannelRef *)methodCheckObject(L, 1);
+	ModChannelRef *ref = checkObject<ModChannelRef>(L, 1);
 	ModChannel *channel = getobject(L, ref);
 	if (!channel || !channel->canWrite())
 		return 0;
@@ -78,7 +78,7 @@ int ModChannelRef::l_send_all(lua_State *L)
 
 int ModChannelRef::l_is_writeable(lua_State *L)
 {
-	ModChannelRef *ref = (ModChannelRef *)methodCheckObject(L, 1);
+	ModChannelRef *ref = checkObject<ModChannelRef>(L, 1);
 	ModChannel *channel = getobject(L, ref);
 	if (!channel)
 		return 0;

--- a/src/script/lua_api/l_modchannels.h
+++ b/src/script/lua_api/l_modchannels.h
@@ -52,15 +52,15 @@ public:
 	// is_writeable()
 	static int l_is_writeable(lua_State *L);
 
+	static const char className[];
+
 private:
 	// garbage collector
 	static int gc_object(lua_State *L);
 
-	static ModChannelRef *checkobject(lua_State *L, int narg);
 	static ModChannel *getobject(lua_State *L, ModChannelRef *ref);
 
 	std::string m_modchannel_name;
 
-	static const char className[];
 	static const luaL_Reg methods[];
 };

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -29,13 +29,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /*
 	NodeMetaRef
 */
-NodeMetaRef* NodeMetaRef::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if(!ud) luaL_typerror(L, narg, className);
-	return *(NodeMetaRef**)ud;  // unbox pointer
-}
 
 IMetadata* NodeMetaRef::getmeta(bool auto_create)
 {
@@ -80,19 +73,12 @@ void NodeMetaRef::reportMetadataChange(const std::string *name)
 
 // Exported functions
 
-// garbage collector
-int NodeMetaRef::gc_object(lua_State *L) {
-	NodeMetaRef *o = *(NodeMetaRef **)(lua_touserdata(L, 1));
-	delete o;
-	return 0;
-}
-
 // get_inventory(self)
 int NodeMetaRef::l_get_inventory(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	NodeMetaRef *ref = checkobject(L, 1);
+	NodeMetaRef *ref = (NodeMetaRef *)methodCheckObject(L, 1);
 	ref->getmeta(true);  // try to ensure the metadata exists
 
 	InventoryLocation loc;
@@ -106,7 +92,7 @@ int NodeMetaRef::l_mark_as_private(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	NodeMetaRef *ref = checkobject(L, 1);
+	NodeMetaRef *ref = (NodeMetaRef *)methodCheckObject(L, 1);
 	NodeMetadata *meta = dynamic_cast<NodeMetadata*>(ref->getmeta(true));
 	assert(meta);
 
@@ -207,41 +193,10 @@ void NodeMetaRef::createClient(lua_State *L, IMetadata *meta)
 }
 
 const char NodeMetaRef::className[] = "NodeMetaRef";
-void NodeMetaRef::RegisterCommon(lua_State *L)
-{
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
-
-	lua_pushliteral(L, "metadata_class");
-	lua_pushlstring(L, className, strlen(className));
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__eq");
-	lua_pushcfunction(L, l_equals);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);  // drop metatable
-}
 
 void NodeMetaRef::Register(lua_State *L)
 {
-	RegisterCommon(L);
-	luaL_register(L, nullptr, methodsServer);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
+	registerMetadataClass(L, className, methodsServer);
 }
 
 
@@ -265,9 +220,7 @@ const luaL_Reg NodeMetaRef::methodsServer[] = {
 
 void NodeMetaRef::RegisterClient(lua_State *L)
 {
-	RegisterCommon(L);
-	luaL_register(L, nullptr, methodsClient);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
+	registerMetadataClass(L, className, methodsClient);
 }
 
 

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -78,7 +78,7 @@ int NodeMetaRef::l_get_inventory(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	NodeMetaRef *ref = (NodeMetaRef *)methodCheckObject(L, 1);
+	NodeMetaRef *ref = checkObject<NodeMetaRef>(L, 1);
 	ref->getmeta(true);  // try to ensure the metadata exists
 
 	InventoryLocation loc;
@@ -92,7 +92,7 @@ int NodeMetaRef::l_mark_as_private(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	NodeMetaRef *ref = (NodeMetaRef *)methodCheckObject(L, 1);
+	NodeMetaRef *ref = checkObject<NodeMetaRef>(L, 1);
 	NodeMetadata *meta = dynamic_cast<NodeMetadata*>(ref->getmeta(true));
 	assert(meta);
 

--- a/src/script/lua_api/l_nodemeta.h
+++ b/src/script/lua_api/l_nodemeta.h
@@ -40,11 +40,8 @@ private:
 	// Set for client metadata
 	IMetadata *m_local_meta = nullptr;
 
-	static const char className[];
 	static const luaL_Reg methodsServer[];
 	static const luaL_Reg methodsClient[];
-
-	static NodeMetaRef *checkobject(lua_State *L, int narg);
 
 	/**
 	 * Retrieve metadata for a node.
@@ -69,9 +66,6 @@ private:
 
 	// Exported functions
 
-	// garbage collector
-	static int gc_object(lua_State *L);
-
 	// get_inventory(self)
 	static int l_get_inventory(lua_State *L);
 
@@ -91,7 +85,8 @@ public:
 	// Client-sided version of the above
 	static void createClient(lua_State *L, IMetadata *meta);
 
-	static void RegisterCommon(lua_State *L);
 	static void Register(lua_State *L);
 	static void RegisterClient(lua_State *L);
+
+	static const char className[];
 };

--- a/src/script/lua_api/l_nodetimer.cpp
+++ b/src/script/lua_api/l_nodetimer.cpp
@@ -29,18 +29,10 @@ int NodeTimerRef::gc_object(lua_State *L) {
 	return 0;
 }
 
-NodeTimerRef* NodeTimerRef::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if(!ud) luaL_typerror(L, narg, className);
-	return *(NodeTimerRef**)ud;  // unbox pointer
-}
-
 int NodeTimerRef::l_set(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
-	NodeTimerRef *o = checkobject(L, 1);
+	NodeTimerRef *o = (NodeTimerRef *)methodCheckObject(L, 1);
 	f32 t = readParam<float>(L,2);
 	f32 e = readParam<float>(L,3);
 	o->m_map->setNodeTimer(NodeTimer(t, e, o->m_p));
@@ -50,7 +42,7 @@ int NodeTimerRef::l_set(lua_State *L)
 int NodeTimerRef::l_start(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
-	NodeTimerRef *o = checkobject(L, 1);
+	NodeTimerRef *o = (NodeTimerRef *)methodCheckObject(L, 1);
 	f32 t = readParam<float>(L,2);
 	o->m_map->setNodeTimer(NodeTimer(t, 0, o->m_p));
 	return 0;
@@ -59,7 +51,7 @@ int NodeTimerRef::l_start(lua_State *L)
 int NodeTimerRef::l_stop(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
-	NodeTimerRef *o = checkobject(L, 1);
+	NodeTimerRef *o = (NodeTimerRef *)methodCheckObject(L, 1);
 	o->m_map->removeNodeTimer(o->m_p);
 	return 0;
 }
@@ -67,7 +59,7 @@ int NodeTimerRef::l_stop(lua_State *L)
 int NodeTimerRef::l_is_started(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
-	NodeTimerRef *o = checkobject(L, 1);
+	NodeTimerRef *o = (NodeTimerRef *)methodCheckObject(L, 1);
 	NodeTimer t = o->m_map->getNodeTimer(o->m_p);
 	lua_pushboolean(L,(t.timeout != 0));
 	return 1;
@@ -76,7 +68,7 @@ int NodeTimerRef::l_is_started(lua_State *L)
 int NodeTimerRef::l_get_timeout(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
-	NodeTimerRef *o = checkobject(L, 1);
+	NodeTimerRef *o = (NodeTimerRef *)methodCheckObject(L, 1);
 	NodeTimer t = o->m_map->getNodeTimer(o->m_p);
 	lua_pushnumber(L,t.timeout);
 	return 1;
@@ -85,7 +77,7 @@ int NodeTimerRef::l_get_timeout(lua_State *L)
 int NodeTimerRef::l_get_elapsed(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
-	NodeTimerRef *o = checkobject(L, 1);
+	NodeTimerRef *o = (NodeTimerRef *)methodCheckObject(L, 1);
 	NodeTimer t = o->m_map->getNodeTimer(o->m_p);
 	lua_pushnumber(L,t.elapsed);
 	return 1;
@@ -103,27 +95,11 @@ void NodeTimerRef::create(lua_State *L, v3s16 p, ServerMap *map)
 
 void NodeTimerRef::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);  // drop metatable
-
-	luaL_register(L, nullptr, methods);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 
 	// Cannot be created from Lua
 	//lua_register(L, className, create_object);

--- a/src/script/lua_api/l_nodetimer.cpp
+++ b/src/script/lua_api/l_nodetimer.cpp
@@ -32,7 +32,7 @@ int NodeTimerRef::gc_object(lua_State *L) {
 int NodeTimerRef::l_set(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
-	NodeTimerRef *o = (NodeTimerRef *)methodCheckObject(L, 1);
+	NodeTimerRef *o = checkObject<NodeTimerRef>(L, 1);
 	f32 t = readParam<float>(L,2);
 	f32 e = readParam<float>(L,3);
 	o->m_map->setNodeTimer(NodeTimer(t, e, o->m_p));
@@ -42,7 +42,7 @@ int NodeTimerRef::l_set(lua_State *L)
 int NodeTimerRef::l_start(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
-	NodeTimerRef *o = (NodeTimerRef *)methodCheckObject(L, 1);
+	NodeTimerRef *o = checkObject<NodeTimerRef>(L, 1);
 	f32 t = readParam<float>(L,2);
 	o->m_map->setNodeTimer(NodeTimer(t, 0, o->m_p));
 	return 0;
@@ -51,7 +51,7 @@ int NodeTimerRef::l_start(lua_State *L)
 int NodeTimerRef::l_stop(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
-	NodeTimerRef *o = (NodeTimerRef *)methodCheckObject(L, 1);
+	NodeTimerRef *o = checkObject<NodeTimerRef>(L, 1);
 	o->m_map->removeNodeTimer(o->m_p);
 	return 0;
 }
@@ -59,7 +59,7 @@ int NodeTimerRef::l_stop(lua_State *L)
 int NodeTimerRef::l_is_started(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
-	NodeTimerRef *o = (NodeTimerRef *)methodCheckObject(L, 1);
+	NodeTimerRef *o = checkObject<NodeTimerRef>(L, 1);
 	NodeTimer t = o->m_map->getNodeTimer(o->m_p);
 	lua_pushboolean(L,(t.timeout != 0));
 	return 1;
@@ -68,7 +68,7 @@ int NodeTimerRef::l_is_started(lua_State *L)
 int NodeTimerRef::l_get_timeout(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
-	NodeTimerRef *o = (NodeTimerRef *)methodCheckObject(L, 1);
+	NodeTimerRef *o = checkObject<NodeTimerRef>(L, 1);
 	NodeTimer t = o->m_map->getNodeTimer(o->m_p);
 	lua_pushnumber(L,t.timeout);
 	return 1;
@@ -77,7 +77,7 @@ int NodeTimerRef::l_get_timeout(lua_State *L)
 int NodeTimerRef::l_get_elapsed(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
-	NodeTimerRef *o = (NodeTimerRef *)methodCheckObject(L, 1);
+	NodeTimerRef *o = checkObject<NodeTimerRef>(L, 1);
 	NodeTimer t = o->m_map->getNodeTimer(o->m_p);
 	lua_pushnumber(L,t.elapsed);
 	return 1;

--- a/src/script/lua_api/l_nodetimer.h
+++ b/src/script/lua_api/l_nodetimer.h
@@ -30,12 +30,9 @@ private:
 	v3s16 m_p;
 	ServerMap *m_map;
 
-	static const char className[];
 	static const luaL_Reg methods[];
 
 	static int gc_object(lua_State *L);
-
-	static NodeTimerRef *checkobject(lua_State *L, int narg);
 
 	static int l_set(lua_State *L);
 
@@ -58,4 +55,6 @@ public:
 	static void create(lua_State *L, v3s16 p, ServerMap *map);
 
 	static void Register(lua_State *L);
+
+	static const char className[];
 };

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -40,7 +40,7 @@ LuaPerlinNoise::LuaPerlinNoise(const NoiseParams *params) :
 int LuaPerlinNoise::l_get_2d(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaPerlinNoise *o = checkobject(L, 1);
+	LuaPerlinNoise *o = (LuaPerlinNoise *)methodCheckObject(L, 1);
 	v2f p = readParam<v2f>(L, 2);
 	lua_Number val = NoisePerlin2D(&o->np, p.X, p.Y, 0);
 	lua_pushnumber(L, val);
@@ -51,7 +51,7 @@ int LuaPerlinNoise::l_get_2d(lua_State *L)
 int LuaPerlinNoise::l_get_3d(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaPerlinNoise *o = checkobject(L, 1);
+	LuaPerlinNoise *o = (LuaPerlinNoise *)methodCheckObject(L, 1);
 	v3f p = check_v3f(L, 2);
 	lua_Number val = NoisePerlin3D(&o->np, p.X, p.Y, p.Z, 0);
 	lua_pushnumber(L, val);
@@ -91,20 +91,9 @@ int LuaPerlinNoise::gc_object(lua_State *L)
 }
 
 
-LuaPerlinNoise *LuaPerlinNoise::checkobject(lua_State *L, int narg)
-{
-	NO_MAP_LOCK_REQUIRED;
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-	return *(LuaPerlinNoise **)ud;
-}
-
-
 void *LuaPerlinNoise::packIn(lua_State *L, int idx)
 {
-	LuaPerlinNoise *o = checkobject(L, idx);
+	LuaPerlinNoise *o = (LuaPerlinNoise *)checkObject(L, idx, className);
 	return new NoiseParams(o->np);
 }
 
@@ -123,27 +112,11 @@ void LuaPerlinNoise::packOut(lua_State *L, void *ptr)
 
 void LuaPerlinNoise::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);
-
-	luaL_register(L, nullptr, methods);
-	lua_pop(L, 1);
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 
 	lua_register(L, className, create_object);
 
@@ -184,7 +157,7 @@ int LuaPerlinNoiseMap::l_get_2d_map(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	size_t i = 0;
 
-	LuaPerlinNoiseMap *o = checkobject(L, 1);
+	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
 	v2f p = readParam<v2f>(L, 2);
 
 	Noise *n = o->noise;
@@ -207,7 +180,7 @@ int LuaPerlinNoiseMap::l_get_2d_map_flat(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = checkobject(L, 1);
+	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
 	v2f p = readParam<v2f>(L, 2);
 	bool use_buffer = lua_istable(L, 3);
 
@@ -234,7 +207,7 @@ int LuaPerlinNoiseMap::l_get_3d_map(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	size_t i = 0;
 
-	LuaPerlinNoiseMap *o = checkobject(L, 1);
+	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
 	v3f p = check_v3f(L, 2);
 
 	if (!o->is3D())
@@ -264,7 +237,7 @@ int LuaPerlinNoiseMap::l_get_3d_map_flat(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = checkobject(L, 1);
+	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
 	v3f p                = check_v3f(L, 2);
 	bool use_buffer      = lua_istable(L, 3);
 
@@ -293,7 +266,7 @@ int LuaPerlinNoiseMap::l_calc_2d_map(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = checkobject(L, 1);
+	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
 	v2f p = readParam<v2f>(L, 2);
 
 	Noise *n = o->noise;
@@ -306,7 +279,7 @@ int LuaPerlinNoiseMap::l_calc_3d_map(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = checkobject(L, 1);
+	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
 	v3f p                = check_v3f(L, 2);
 
 	if (!o->is3D())
@@ -323,7 +296,7 @@ int LuaPerlinNoiseMap::l_get_map_slice(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = checkobject(L, 1);
+	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
 	v3s16 slice_offset   = read_v3s16(L, 2);
 	v3s16 slice_size     = read_v3s16(L, 3);
 	bool use_buffer      = lua_istable(L, 4);
@@ -367,18 +340,6 @@ int LuaPerlinNoiseMap::gc_object(lua_State *L)
 }
 
 
-LuaPerlinNoiseMap *LuaPerlinNoiseMap::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-
-	return *(LuaPerlinNoiseMap **)ud;
-}
-
-
 struct NoiseMapParams {
 	NoiseParams np;
 	s32 seed;
@@ -387,7 +348,7 @@ struct NoiseMapParams {
 
 void *LuaPerlinNoiseMap::packIn(lua_State *L, int idx)
 {
-	LuaPerlinNoiseMap *o = checkobject(L, idx);
+	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)checkObject(L, idx, className);
 	NoiseMapParams *ret = new NoiseMapParams();
 	ret->np = o->noise->np;
 	ret->seed = o->noise->seed;
@@ -410,27 +371,11 @@ void LuaPerlinNoiseMap::packOut(lua_State *L, void *ptr)
 
 void LuaPerlinNoiseMap::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);
-
-	luaL_register(L, nullptr, methods);
-	lua_pop(L, 1);
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 
 	lua_register(L, className, create_object);
 
@@ -459,7 +404,7 @@ int LuaPseudoRandom::l_next(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPseudoRandom *o = checkobject(L, 1);
+	LuaPseudoRandom *o = (LuaPseudoRandom *)methodCheckObject(L, 1);
 	int min = 0;
 	int max = 32767;
 	lua_settop(L, 3);
@@ -505,39 +450,13 @@ int LuaPseudoRandom::gc_object(lua_State *L)
 }
 
 
-LuaPseudoRandom *LuaPseudoRandom::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-	return *(LuaPseudoRandom **)ud;
-}
-
-
 void LuaPseudoRandom::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);
-
-	luaL_register(L, nullptr, methods);
-	lua_pop(L, 1);
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 
 	lua_register(L, className, create_object);
 }
@@ -558,7 +477,7 @@ int LuaPcgRandom::l_next(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPcgRandom *o = checkobject(L, 1);
+	LuaPcgRandom *o = (LuaPcgRandom *)methodCheckObject(L, 1);
 	u32 min = lua_isnumber(L, 2) ? lua_tointeger(L, 2) : o->m_rnd.RANDOM_MIN;
 	u32 max = lua_isnumber(L, 3) ? lua_tointeger(L, 3) : o->m_rnd.RANDOM_MAX;
 
@@ -571,7 +490,7 @@ int LuaPcgRandom::l_rand_normal_dist(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPcgRandom *o = checkobject(L, 1);
+	LuaPcgRandom *o = (LuaPcgRandom *)methodCheckObject(L, 1);
 	u32 min = lua_isnumber(L, 2) ? lua_tointeger(L, 2) : o->m_rnd.RANDOM_MIN;
 	u32 max = lua_isnumber(L, 3) ? lua_tointeger(L, 3) : o->m_rnd.RANDOM_MAX;
 	int num_trials = lua_isnumber(L, 4) ? lua_tointeger(L, 4) : 6;
@@ -604,39 +523,13 @@ int LuaPcgRandom::gc_object(lua_State *L)
 }
 
 
-LuaPcgRandom *LuaPcgRandom::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-	return *(LuaPcgRandom **)ud;
-}
-
-
 void LuaPcgRandom::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);
-
-	luaL_register(L, nullptr, methods);
-	lua_pop(L, 1);
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 
 	lua_register(L, className, create_object);
 }
@@ -663,7 +556,7 @@ int LuaSecureRandom::l_next_bytes(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaSecureRandom *o = checkobject(L, 1);
+	LuaSecureRandom *o = (LuaSecureRandom *)methodCheckObject(L, 1);
 	u32 count = lua_isnumber(L, 2) ? lua_tointeger(L, 2) : 1;
 
 	// Limit count
@@ -719,39 +612,13 @@ int LuaSecureRandom::gc_object(lua_State *L)
 }
 
 
-LuaSecureRandom *LuaSecureRandom::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-	return *(LuaSecureRandom **)ud;
-}
-
-
 void LuaSecureRandom::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);
-
-	luaL_register(L, nullptr, methods);
-	lua_pop(L, 1);
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 
 	lua_register(L, className, create_object);
 }

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -93,7 +93,7 @@ int LuaPerlinNoise::gc_object(lua_State *L)
 
 void *LuaPerlinNoise::packIn(lua_State *L, int idx)
 {
-	LuaPerlinNoise *o = (LuaPerlinNoise *)checkObject(L, idx, className);
+	LuaPerlinNoise *o = checkObject<LuaPerlinNoise>(L, idx);
 	return new NoiseParams(o->np);
 }
 
@@ -348,7 +348,7 @@ struct NoiseMapParams {
 
 void *LuaPerlinNoiseMap::packIn(lua_State *L, int idx)
 {
-	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)checkObject(L, idx, className);
+	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, idx);
 	NoiseMapParams *ret = new NoiseMapParams();
 	ret->np = o->noise->np;
 	ret->seed = o->noise->seed;

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -40,7 +40,7 @@ LuaPerlinNoise::LuaPerlinNoise(const NoiseParams *params) :
 int LuaPerlinNoise::l_get_2d(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaPerlinNoise *o = (LuaPerlinNoise *)methodCheckObject(L, 1);
+	LuaPerlinNoise *o = checkObject<LuaPerlinNoise>(L, 1);
 	v2f p = readParam<v2f>(L, 2);
 	lua_Number val = NoisePerlin2D(&o->np, p.X, p.Y, 0);
 	lua_pushnumber(L, val);
@@ -51,7 +51,7 @@ int LuaPerlinNoise::l_get_2d(lua_State *L)
 int LuaPerlinNoise::l_get_3d(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaPerlinNoise *o = (LuaPerlinNoise *)methodCheckObject(L, 1);
+	LuaPerlinNoise *o = checkObject<LuaPerlinNoise>(L, 1);
 	v3f p = check_v3f(L, 2);
 	lua_Number val = NoisePerlin3D(&o->np, p.X, p.Y, p.Z, 0);
 	lua_pushnumber(L, val);
@@ -157,7 +157,7 @@ int LuaPerlinNoiseMap::l_get_2d_map(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	size_t i = 0;
 
-	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
+	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
 	v2f p = readParam<v2f>(L, 2);
 
 	Noise *n = o->noise;
@@ -180,7 +180,7 @@ int LuaPerlinNoiseMap::l_get_2d_map_flat(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
+	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
 	v2f p = readParam<v2f>(L, 2);
 	bool use_buffer = lua_istable(L, 3);
 
@@ -207,7 +207,7 @@ int LuaPerlinNoiseMap::l_get_3d_map(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	size_t i = 0;
 
-	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
+	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
 	v3f p = check_v3f(L, 2);
 
 	if (!o->is3D())
@@ -237,7 +237,7 @@ int LuaPerlinNoiseMap::l_get_3d_map_flat(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
+	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
 	v3f p                = check_v3f(L, 2);
 	bool use_buffer      = lua_istable(L, 3);
 
@@ -266,7 +266,7 @@ int LuaPerlinNoiseMap::l_calc_2d_map(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
+	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
 	v2f p = readParam<v2f>(L, 2);
 
 	Noise *n = o->noise;
@@ -279,7 +279,7 @@ int LuaPerlinNoiseMap::l_calc_3d_map(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
+	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
 	v3f p                = check_v3f(L, 2);
 
 	if (!o->is3D())
@@ -296,7 +296,7 @@ int LuaPerlinNoiseMap::l_get_map_slice(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = (LuaPerlinNoiseMap *)methodCheckObject(L, 1);
+	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
 	v3s16 slice_offset   = read_v3s16(L, 2);
 	v3s16 slice_size     = read_v3s16(L, 3);
 	bool use_buffer      = lua_istable(L, 4);
@@ -404,7 +404,7 @@ int LuaPseudoRandom::l_next(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPseudoRandom *o = (LuaPseudoRandom *)methodCheckObject(L, 1);
+	LuaPseudoRandom *o = checkObject<LuaPseudoRandom>(L, 1);
 	int min = 0;
 	int max = 32767;
 	lua_settop(L, 3);
@@ -477,7 +477,7 @@ int LuaPcgRandom::l_next(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPcgRandom *o = (LuaPcgRandom *)methodCheckObject(L, 1);
+	LuaPcgRandom *o = checkObject<LuaPcgRandom>(L, 1);
 	u32 min = lua_isnumber(L, 2) ? lua_tointeger(L, 2) : o->m_rnd.RANDOM_MIN;
 	u32 max = lua_isnumber(L, 3) ? lua_tointeger(L, 3) : o->m_rnd.RANDOM_MAX;
 
@@ -490,7 +490,7 @@ int LuaPcgRandom::l_rand_normal_dist(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPcgRandom *o = (LuaPcgRandom *)methodCheckObject(L, 1);
+	LuaPcgRandom *o = checkObject<LuaPcgRandom>(L, 1);
 	u32 min = lua_isnumber(L, 2) ? lua_tointeger(L, 2) : o->m_rnd.RANDOM_MIN;
 	u32 max = lua_isnumber(L, 3) ? lua_tointeger(L, 3) : o->m_rnd.RANDOM_MAX;
 	int num_trials = lua_isnumber(L, 4) ? lua_tointeger(L, 4) : 6;
@@ -556,7 +556,7 @@ int LuaSecureRandom::l_next_bytes(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaSecureRandom *o = (LuaSecureRandom *)methodCheckObject(L, 1);
+	LuaSecureRandom *o = checkObject<LuaSecureRandom>(L, 1);
 	u32 count = lua_isnumber(L, 2) ? lua_tointeger(L, 2) : 1;
 
 	// Limit count

--- a/src/script/lua_api/l_noise.h
+++ b/src/script/lua_api/l_noise.h
@@ -31,7 +31,6 @@ class LuaPerlinNoise : public ModApiBase
 private:
 	NoiseParams np;
 
-	static const char className[];
 	static luaL_Reg methods[];
 
 	// Exported functions
@@ -50,12 +49,12 @@ public:
 	// Creates an LuaPerlinNoise and leaves it on top of stack
 	static int create_object(lua_State *L);
 
-	static LuaPerlinNoise *checkobject(lua_State *L, int narg);
-
 	static void *packIn(lua_State *L, int idx);
 	static void packOut(lua_State *L, void *ptr);
 
 	static void Register(lua_State *L);
+
+	static const char className[];
 };
 
 /*
@@ -65,7 +64,6 @@ class LuaPerlinNoiseMap : public ModApiBase
 {
 	Noise *noise;
 
-	static const char className[];
 	static luaL_Reg methods[];
 
 	// Exported functions
@@ -92,12 +90,12 @@ public:
 	// Creates an LuaPerlinNoiseMap and leaves it on top of stack
 	static int create_object(lua_State *L);
 
-	static LuaPerlinNoiseMap *checkobject(lua_State *L, int narg);
-
 	static void *packIn(lua_State *L, int idx);
 	static void packOut(lua_State *L, void *ptr);
 
 	static void Register(lua_State *L);
+
+	static const char className[];
 };
 
 /*
@@ -108,7 +106,6 @@ class LuaPseudoRandom : public ModApiBase
 private:
 	PseudoRandom m_pseudo;
 
-	static const char className[];
 	static const luaL_Reg methods[];
 
 	// Exported functions
@@ -126,9 +123,9 @@ public:
 	// Creates an LuaPseudoRandom and leaves it on top of stack
 	static int create_object(lua_State *L);
 
-	static LuaPseudoRandom *checkobject(lua_State *L, int narg);
-
 	static void Register(lua_State *L);
+
+	static const char className[];
 };
 
 /*
@@ -139,7 +136,6 @@ class LuaPcgRandom : public ModApiBase
 private:
 	PcgRandom m_rnd;
 
-	static const char className[];
 	static const luaL_Reg methods[];
 
 	// Exported functions
@@ -162,9 +158,9 @@ public:
 	// Creates an LuaPcgRandom and leaves it on top of stack
 	static int create_object(lua_State *L);
 
-	static LuaPcgRandom *checkobject(lua_State *L, int narg);
-
 	static void Register(lua_State *L);
+
+	static const char className[];
 };
 
 /*
@@ -174,7 +170,6 @@ class LuaSecureRandom : public ModApiBase
 {
 private:
 	static const size_t RAND_BUF_SIZE = 2048;
-	static const char className[];
 	static const luaL_Reg methods[];
 
 	u32 m_rand_idx;
@@ -195,7 +190,7 @@ public:
 	// Creates an LuaSecureRandom and leaves it on top of stack
 	static int create_object(lua_State *L);
 
-	static LuaSecureRandom *checkobject(lua_State *L, int narg);
-
 	static void Register(lua_State *L);
+
+	static const char className[];
 };

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2353,7 +2353,7 @@ void ObjectRef::create(lua_State *L, ServerActiveObject *object)
 
 void ObjectRef::set_null(lua_State *L)
 {
-	ObjectRef *obj = (ObjectRef *)checkObject(L, -1, className);
+	ObjectRef *obj = checkObject<ObjectRef>(L, -1);
 	obj->m_object = nullptr;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -40,15 +40,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 
-ObjectRef* ObjectRef::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (ud == nullptr)
-		luaL_typerror(L, narg, className);
-	return *(ObjectRef**)ud;  // unbox pointer
-}
-
 ServerActiveObject* ObjectRef::getobject(ObjectRef *ref)
 {
 	ServerActiveObject *sao = ref->m_object;
@@ -99,7 +90,7 @@ int ObjectRef::l_remove(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -118,7 +109,7 @@ int ObjectRef::l_remove(lua_State *L)
 int ObjectRef::l_get_pos(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -131,7 +122,7 @@ int ObjectRef::l_get_pos(lua_State *L)
 int ObjectRef::l_set_pos(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -146,7 +137,7 @@ int ObjectRef::l_set_pos(lua_State *L)
 int ObjectRef::l_move_to(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -162,8 +153,8 @@ int ObjectRef::l_move_to(lua_State *L)
 int ObjectRef::l_punch(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
-	ObjectRef *puncher_ref = checkobject(L, 2);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *puncher_ref = (ObjectRef *)methodCheckObject(L, 2);
 	ServerActiveObject *sao = getobject(ref);
 	ServerActiveObject *puncher = getobject(puncher_ref);
 	if (sao == nullptr || puncher == nullptr)
@@ -184,8 +175,8 @@ int ObjectRef::l_punch(lua_State *L)
 int ObjectRef::l_right_click(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
-	ObjectRef *ref2 = checkobject(L, 2);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref2 = (ObjectRef *)methodCheckObject(L, 2);
 	ServerActiveObject *sao = getobject(ref);
 	ServerActiveObject *sao2 = getobject(ref2);
 	if (sao == nullptr || sao2 == nullptr)
@@ -199,7 +190,7 @@ int ObjectRef::l_right_click(lua_State *L)
 int ObjectRef::l_set_hp(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -231,7 +222,7 @@ int ObjectRef::l_set_hp(lua_State *L)
 int ObjectRef::l_get_hp(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr) {
 		// Default hp is 1
@@ -249,7 +240,7 @@ int ObjectRef::l_get_hp(lua_State *L)
 int ObjectRef::l_get_inventory(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -266,7 +257,7 @@ int ObjectRef::l_get_inventory(lua_State *L)
 int ObjectRef::l_get_wield_list(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -279,7 +270,7 @@ int ObjectRef::l_get_wield_list(lua_State *L)
 int ObjectRef::l_get_wield_index(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -292,7 +283,7 @@ int ObjectRef::l_get_wield_index(lua_State *L)
 int ObjectRef::l_get_wielded_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr) {
 		// Empty ItemStack
@@ -310,7 +301,7 @@ int ObjectRef::l_get_wielded_item(lua_State *L)
 int ObjectRef::l_set_wielded_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -329,7 +320,7 @@ int ObjectRef::l_set_wielded_item(lua_State *L)
 int ObjectRef::l_set_armor_groups(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -354,7 +345,7 @@ int ObjectRef::l_set_armor_groups(lua_State *L)
 int ObjectRef::l_get_armor_groups(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -367,7 +358,7 @@ int ObjectRef::l_get_armor_groups(lua_State *L)
 int ObjectRef::l_set_animation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -385,7 +376,7 @@ int ObjectRef::l_set_animation(lua_State *L)
 int ObjectRef::l_get_animation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -407,7 +398,7 @@ int ObjectRef::l_get_animation(lua_State *L)
 int ObjectRef::l_set_local_animation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -427,7 +418,7 @@ int ObjectRef::l_set_local_animation(lua_State *L)
 int ObjectRef::l_get_local_animation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -448,7 +439,7 @@ int ObjectRef::l_get_local_animation(lua_State *L)
 int ObjectRef::l_set_eye_offset(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -470,7 +461,7 @@ int ObjectRef::l_set_eye_offset(lua_State *L)
 int ObjectRef::l_get_eye_offset(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -484,7 +475,7 @@ int ObjectRef::l_get_eye_offset(lua_State *L)
 int ObjectRef::l_send_mapblock(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -502,7 +493,7 @@ int ObjectRef::l_send_mapblock(lua_State *L)
 int ObjectRef::l_set_animation_frame_speed(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -521,7 +512,7 @@ int ObjectRef::l_set_animation_frame_speed(lua_State *L)
 int ObjectRef::l_set_bone_position(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -538,7 +529,7 @@ int ObjectRef::l_set_bone_position(lua_State *L)
 int ObjectRef::l_get_bone_position(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -558,8 +549,8 @@ int ObjectRef::l_get_bone_position(lua_State *L)
 int ObjectRef::l_set_attach(lua_State *L)
 {
 	GET_ENV_PTR;
-	ObjectRef *ref = checkobject(L, 1);
-	ObjectRef *parent_ref = checkobject(L, 2);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *parent_ref = (ObjectRef *)methodCheckObject(L, 2);
 	ServerActiveObject *sao = getobject(ref);
 	ServerActiveObject *parent = getobject(parent_ref);
 	if (sao == nullptr || parent == nullptr)
@@ -593,7 +584,7 @@ int ObjectRef::l_set_attach(lua_State *L)
 int ObjectRef::l_get_attach(lua_State *L)
 {
 	GET_ENV_PTR;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -621,7 +612,7 @@ int ObjectRef::l_get_attach(lua_State *L)
 int ObjectRef::l_get_children(lua_State *L)
 {
 	GET_ENV_PTR;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -642,7 +633,7 @@ int ObjectRef::l_get_children(lua_State *L)
 int ObjectRef::l_set_detach(lua_State *L)
 {
 	GET_ENV_PTR;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -655,7 +646,7 @@ int ObjectRef::l_set_detach(lua_State *L)
 int ObjectRef::l_set_properties(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -674,7 +665,7 @@ int ObjectRef::l_set_properties(lua_State *L)
 int ObjectRef::l_get_properties(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -691,7 +682,7 @@ int ObjectRef::l_get_properties(lua_State *L)
 int ObjectRef::l_is_player(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	lua_pushboolean(L, (player != nullptr));
 	return 1;
@@ -701,7 +692,7 @@ int ObjectRef::l_is_player(lua_State *L)
 int ObjectRef::l_set_nametag_attributes(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -742,7 +733,7 @@ int ObjectRef::l_set_nametag_attributes(lua_State *L)
 int ObjectRef::l_get_nametag_attributes(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -778,7 +769,7 @@ int ObjectRef::l_get_nametag_attributes(lua_State *L)
 int ObjectRef::l_set_velocity(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	LuaEntitySAO *sao = getluaobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -793,7 +784,7 @@ int ObjectRef::l_set_velocity(lua_State *L)
 int ObjectRef::l_add_velocity(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -816,7 +807,7 @@ int ObjectRef::l_add_velocity(lua_State *L)
 int ObjectRef::l_get_velocity(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -840,7 +831,7 @@ int ObjectRef::l_get_velocity(lua_State *L)
 int ObjectRef::l_set_acceleration(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -855,7 +846,7 @@ int ObjectRef::l_set_acceleration(lua_State *L)
 int ObjectRef::l_get_acceleration(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -869,7 +860,7 @@ int ObjectRef::l_get_acceleration(lua_State *L)
 int ObjectRef::l_set_rotation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -884,7 +875,7 @@ int ObjectRef::l_set_rotation(lua_State *L)
 int ObjectRef::l_get_rotation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -900,7 +891,7 @@ int ObjectRef::l_get_rotation(lua_State *L)
 int ObjectRef::l_set_yaw(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -915,7 +906,7 @@ int ObjectRef::l_set_yaw(lua_State *L)
 int ObjectRef::l_get_yaw(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -930,7 +921,7 @@ int ObjectRef::l_get_yaw(lua_State *L)
 int ObjectRef::l_set_texture_mod(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -945,7 +936,7 @@ int ObjectRef::l_set_texture_mod(lua_State *L)
 int ObjectRef::l_get_texture_mod(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -960,7 +951,7 @@ int ObjectRef::l_get_texture_mod(lua_State *L)
 int ObjectRef::l_set_sprite(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -979,7 +970,7 @@ int ObjectRef::l_set_sprite(lua_State *L)
 int ObjectRef::l_get_entity_name(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	log_deprecated(L,"Deprecated call to \"get_entity_name");
 	if (entitysao == nullptr)
@@ -995,7 +986,7 @@ int ObjectRef::l_get_entity_name(lua_State *L)
 int ObjectRef::l_get_luaentity(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -1010,7 +1001,7 @@ int ObjectRef::l_get_luaentity(lua_State *L)
 int ObjectRef::l_get_player_name(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr) {
 		lua_pushlstring(L, "", 0);
@@ -1025,7 +1016,7 @@ int ObjectRef::l_get_player_name(lua_State *L)
 int ObjectRef::l_get_look_dir(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1048,7 +1039,7 @@ int ObjectRef::l_get_look_pitch(lua_State *L)
 	log_deprecated(L,
 		"Deprecated call to get_look_pitch, use get_look_vertical instead");
 
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1066,7 +1057,7 @@ int ObjectRef::l_get_look_yaw(lua_State *L)
 	log_deprecated(L,
 		"Deprecated call to get_look_yaw, use get_look_horizontal instead");
 
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1079,7 +1070,7 @@ int ObjectRef::l_get_look_yaw(lua_State *L)
 int ObjectRef::l_get_look_vertical(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1092,7 +1083,7 @@ int ObjectRef::l_get_look_vertical(lua_State *L)
 int ObjectRef::l_get_look_horizontal(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1105,7 +1096,7 @@ int ObjectRef::l_get_look_horizontal(lua_State *L)
 int ObjectRef::l_set_look_vertical(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1120,7 +1111,7 @@ int ObjectRef::l_set_look_vertical(lua_State *L)
 int ObjectRef::l_set_look_horizontal(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1140,7 +1131,7 @@ int ObjectRef::l_set_look_pitch(lua_State *L)
 	log_deprecated(L,
 		"Deprecated call to set_look_pitch, use set_look_vertical instead.");
 
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1160,7 +1151,7 @@ int ObjectRef::l_set_look_yaw(lua_State *L)
 	log_deprecated(L,
 		"Deprecated call to set_look_yaw, use set_look_horizontal instead.");
 
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1175,7 +1166,7 @@ int ObjectRef::l_set_look_yaw(lua_State *L)
 int ObjectRef::l_set_fov(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1194,7 +1185,7 @@ int ObjectRef::l_set_fov(lua_State *L)
 int ObjectRef::l_get_fov(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1211,7 +1202,7 @@ int ObjectRef::l_get_fov(lua_State *L)
 int ObjectRef::l_set_breath(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1226,7 +1217,7 @@ int ObjectRef::l_set_breath(lua_State *L)
 int ObjectRef::l_get_breath(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1243,7 +1234,7 @@ int ObjectRef::l_set_attribute(lua_State *L)
 	log_deprecated(L,
 		"Deprecated call to set_attribute, use MetaDataRef methods instead.");
 
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1264,7 +1255,7 @@ int ObjectRef::l_get_attribute(lua_State *L)
 	log_deprecated(L,
 		"Deprecated call to get_attribute, use MetaDataRef methods instead.");
 
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1284,7 +1275,7 @@ int ObjectRef::l_get_attribute(lua_State *L)
 // get_meta(self, attribute)
 int ObjectRef::l_get_meta(lua_State *L)
 {
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO *playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1298,7 +1289,7 @@ int ObjectRef::l_get_meta(lua_State *L)
 int ObjectRef::l_set_inventory_formspec(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1314,7 +1305,7 @@ int ObjectRef::l_set_inventory_formspec(lua_State *L)
 int ObjectRef::l_get_inventory_formspec(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1329,7 +1320,7 @@ int ObjectRef::l_get_inventory_formspec(lua_State *L)
 int ObjectRef::l_set_formspec_prepend(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1345,7 +1336,7 @@ int ObjectRef::l_set_formspec_prepend(lua_State *L)
 int ObjectRef::l_get_formspec_prepend(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		 return 0;
@@ -1360,7 +1351,7 @@ int ObjectRef::l_get_formspec_prepend(lua_State *L)
 int ObjectRef::l_get_player_control(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 
 	lua_newtable(L);
@@ -1400,7 +1391,7 @@ int ObjectRef::l_get_player_control(lua_State *L)
 int ObjectRef::l_get_player_control_bits(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr) {
 		lua_pushinteger(L, 0);
@@ -1429,7 +1420,7 @@ int ObjectRef::l_get_player_control_bits(lua_State *L)
 int ObjectRef::l_set_physics_override(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	PlayerSAO *playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1472,7 +1463,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 int ObjectRef::l_get_physics_override(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1498,7 +1489,7 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 int ObjectRef::l_hud_add(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1520,7 +1511,7 @@ int ObjectRef::l_hud_add(lua_State *L)
 int ObjectRef::l_hud_remove(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1538,7 +1529,7 @@ int ObjectRef::l_hud_remove(lua_State *L)
 int ObjectRef::l_hud_change(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1564,7 +1555,7 @@ int ObjectRef::l_hud_change(lua_State *L)
 int ObjectRef::l_hud_get(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1583,7 +1574,7 @@ int ObjectRef::l_hud_get(lua_State *L)
 int ObjectRef::l_hud_set_flags(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1609,7 +1600,7 @@ int ObjectRef::l_hud_set_flags(lua_State *L)
 int ObjectRef::l_hud_get_flags(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1627,7 +1618,7 @@ int ObjectRef::l_hud_get_flags(lua_State *L)
 int ObjectRef::l_hud_set_hotbar_itemcount(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1645,7 +1636,7 @@ int ObjectRef::l_hud_set_hotbar_itemcount(lua_State *L)
 int ObjectRef::l_hud_get_hotbar_itemcount(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1658,7 +1649,7 @@ int ObjectRef::l_hud_get_hotbar_itemcount(lua_State *L)
 int ObjectRef::l_hud_set_hotbar_image(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1673,7 +1664,7 @@ int ObjectRef::l_hud_set_hotbar_image(lua_State *L)
 int ObjectRef::l_hud_get_hotbar_image(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1688,7 +1679,7 @@ int ObjectRef::l_hud_get_hotbar_image(lua_State *L)
 int ObjectRef::l_hud_set_hotbar_selected_image(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1703,7 +1694,7 @@ int ObjectRef::l_hud_set_hotbar_selected_image(lua_State *L)
 int ObjectRef::l_hud_get_hotbar_selected_image(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1718,7 +1709,7 @@ int ObjectRef::l_hud_get_hotbar_selected_image(lua_State *L)
 int ObjectRef::l_set_sky(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1893,7 +1884,7 @@ static void push_sky_color(lua_State *L, const SkyboxParams &params)
 int ObjectRef::l_get_sky(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1946,7 +1937,7 @@ int ObjectRef::l_get_sky_color(lua_State *L)
 
 	log_deprecated(L, "Deprecated call to get_sky_color, use get_sky instead");
 
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1960,7 +1951,7 @@ int ObjectRef::l_get_sky_color(lua_State *L)
 int ObjectRef::l_set_sun(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1988,7 +1979,7 @@ int ObjectRef::l_set_sun(lua_State *L)
 int ObjectRef::l_get_sun(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2015,7 +2006,7 @@ int ObjectRef::l_get_sun(lua_State *L)
 int ObjectRef::l_set_moon(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2041,7 +2032,7 @@ int ObjectRef::l_set_moon(lua_State *L)
 int ObjectRef::l_get_moon(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2064,7 +2055,7 @@ int ObjectRef::l_get_moon(lua_State *L)
 int ObjectRef::l_set_stars(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2098,7 +2089,7 @@ int ObjectRef::l_set_stars(lua_State *L)
 int ObjectRef::l_get_stars(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2123,7 +2114,7 @@ int ObjectRef::l_get_stars(lua_State *L)
 int ObjectRef::l_set_clouds(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2166,7 +2157,7 @@ int ObjectRef::l_set_clouds(lua_State *L)
 int ObjectRef::l_get_clouds(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2198,7 +2189,7 @@ int ObjectRef::l_get_clouds(lua_State *L)
 int ObjectRef::l_override_day_night_ratio(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2221,7 +2212,7 @@ int ObjectRef::l_override_day_night_ratio(lua_State *L)
 int ObjectRef::l_get_day_night_ratio(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2242,7 +2233,7 @@ int ObjectRef::l_get_day_night_ratio(lua_State *L)
 int ObjectRef::l_set_minimap_modes(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2295,7 +2286,7 @@ int ObjectRef::l_set_minimap_modes(lua_State *L)
 int ObjectRef::l_set_lighting(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2316,7 +2307,7 @@ int ObjectRef::l_set_lighting(lua_State *L)
 int ObjectRef::l_get_lighting(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2335,7 +2326,7 @@ int ObjectRef::l_get_lighting(lua_State *L)
 int ObjectRef::l_respawn(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
+	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2362,33 +2353,17 @@ void ObjectRef::create(lua_State *L, ServerActiveObject *object)
 
 void ObjectRef::set_null(lua_State *L)
 {
-	ObjectRef *obj = checkobject(L, -1);
+	ObjectRef *obj = (ObjectRef *)checkObject(L, -1, className);
 	obj->m_object = nullptr;
 }
 
 void ObjectRef::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);  // drop metatable
-
-	luaL_register(L, nullptr, methods);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 }
 
 const char ObjectRef::className[] = "ObjectRef";

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -90,7 +90,7 @@ int ObjectRef::l_remove(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -109,7 +109,7 @@ int ObjectRef::l_remove(lua_State *L)
 int ObjectRef::l_get_pos(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -122,7 +122,7 @@ int ObjectRef::l_get_pos(lua_State *L)
 int ObjectRef::l_set_pos(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -137,7 +137,7 @@ int ObjectRef::l_set_pos(lua_State *L)
 int ObjectRef::l_move_to(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -153,8 +153,8 @@ int ObjectRef::l_move_to(lua_State *L)
 int ObjectRef::l_punch(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
-	ObjectRef *puncher_ref = (ObjectRef *)methodCheckObject(L, 2);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
+	ObjectRef *puncher_ref = checkObject<ObjectRef>(L, 2);
 	ServerActiveObject *sao = getobject(ref);
 	ServerActiveObject *puncher = getobject(puncher_ref);
 	if (sao == nullptr || puncher == nullptr)
@@ -175,8 +175,8 @@ int ObjectRef::l_punch(lua_State *L)
 int ObjectRef::l_right_click(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
-	ObjectRef *ref2 = (ObjectRef *)methodCheckObject(L, 2);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
+	ObjectRef *ref2 = checkObject<ObjectRef>(L, 2);
 	ServerActiveObject *sao = getobject(ref);
 	ServerActiveObject *sao2 = getobject(ref2);
 	if (sao == nullptr || sao2 == nullptr)
@@ -190,7 +190,7 @@ int ObjectRef::l_right_click(lua_State *L)
 int ObjectRef::l_set_hp(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -222,7 +222,7 @@ int ObjectRef::l_set_hp(lua_State *L)
 int ObjectRef::l_get_hp(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr) {
 		// Default hp is 1
@@ -240,7 +240,7 @@ int ObjectRef::l_get_hp(lua_State *L)
 int ObjectRef::l_get_inventory(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -257,7 +257,7 @@ int ObjectRef::l_get_inventory(lua_State *L)
 int ObjectRef::l_get_wield_list(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -270,7 +270,7 @@ int ObjectRef::l_get_wield_list(lua_State *L)
 int ObjectRef::l_get_wield_index(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -283,7 +283,7 @@ int ObjectRef::l_get_wield_index(lua_State *L)
 int ObjectRef::l_get_wielded_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr) {
 		// Empty ItemStack
@@ -301,7 +301,7 @@ int ObjectRef::l_get_wielded_item(lua_State *L)
 int ObjectRef::l_set_wielded_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -320,7 +320,7 @@ int ObjectRef::l_set_wielded_item(lua_State *L)
 int ObjectRef::l_set_armor_groups(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -345,7 +345,7 @@ int ObjectRef::l_set_armor_groups(lua_State *L)
 int ObjectRef::l_get_armor_groups(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -358,7 +358,7 @@ int ObjectRef::l_get_armor_groups(lua_State *L)
 int ObjectRef::l_set_animation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -376,7 +376,7 @@ int ObjectRef::l_set_animation(lua_State *L)
 int ObjectRef::l_get_animation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -398,7 +398,7 @@ int ObjectRef::l_get_animation(lua_State *L)
 int ObjectRef::l_set_local_animation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -418,7 +418,7 @@ int ObjectRef::l_set_local_animation(lua_State *L)
 int ObjectRef::l_get_local_animation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -439,7 +439,7 @@ int ObjectRef::l_get_local_animation(lua_State *L)
 int ObjectRef::l_set_eye_offset(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -461,7 +461,7 @@ int ObjectRef::l_set_eye_offset(lua_State *L)
 int ObjectRef::l_get_eye_offset(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -475,7 +475,7 @@ int ObjectRef::l_get_eye_offset(lua_State *L)
 int ObjectRef::l_send_mapblock(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -493,7 +493,7 @@ int ObjectRef::l_send_mapblock(lua_State *L)
 int ObjectRef::l_set_animation_frame_speed(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -512,7 +512,7 @@ int ObjectRef::l_set_animation_frame_speed(lua_State *L)
 int ObjectRef::l_set_bone_position(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -529,7 +529,7 @@ int ObjectRef::l_set_bone_position(lua_State *L)
 int ObjectRef::l_get_bone_position(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -549,8 +549,8 @@ int ObjectRef::l_get_bone_position(lua_State *L)
 int ObjectRef::l_set_attach(lua_State *L)
 {
 	GET_ENV_PTR;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
-	ObjectRef *parent_ref = (ObjectRef *)methodCheckObject(L, 2);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
+	ObjectRef *parent_ref = checkObject<ObjectRef>(L, 2);
 	ServerActiveObject *sao = getobject(ref);
 	ServerActiveObject *parent = getobject(parent_ref);
 	if (sao == nullptr || parent == nullptr)
@@ -584,7 +584,7 @@ int ObjectRef::l_set_attach(lua_State *L)
 int ObjectRef::l_get_attach(lua_State *L)
 {
 	GET_ENV_PTR;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -612,7 +612,7 @@ int ObjectRef::l_get_attach(lua_State *L)
 int ObjectRef::l_get_children(lua_State *L)
 {
 	GET_ENV_PTR;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -633,7 +633,7 @@ int ObjectRef::l_get_children(lua_State *L)
 int ObjectRef::l_set_detach(lua_State *L)
 {
 	GET_ENV_PTR;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -646,7 +646,7 @@ int ObjectRef::l_set_detach(lua_State *L)
 int ObjectRef::l_set_properties(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -665,7 +665,7 @@ int ObjectRef::l_set_properties(lua_State *L)
 int ObjectRef::l_get_properties(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -682,7 +682,7 @@ int ObjectRef::l_get_properties(lua_State *L)
 int ObjectRef::l_is_player(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	lua_pushboolean(L, (player != nullptr));
 	return 1;
@@ -692,7 +692,7 @@ int ObjectRef::l_is_player(lua_State *L)
 int ObjectRef::l_set_nametag_attributes(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -733,7 +733,7 @@ int ObjectRef::l_set_nametag_attributes(lua_State *L)
 int ObjectRef::l_get_nametag_attributes(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -769,7 +769,7 @@ int ObjectRef::l_get_nametag_attributes(lua_State *L)
 int ObjectRef::l_set_velocity(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	LuaEntitySAO *sao = getluaobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -784,7 +784,7 @@ int ObjectRef::l_set_velocity(lua_State *L)
 int ObjectRef::l_add_velocity(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -807,7 +807,7 @@ int ObjectRef::l_add_velocity(lua_State *L)
 int ObjectRef::l_get_velocity(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
 		return 0;
@@ -831,7 +831,7 @@ int ObjectRef::l_get_velocity(lua_State *L)
 int ObjectRef::l_set_acceleration(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -846,7 +846,7 @@ int ObjectRef::l_set_acceleration(lua_State *L)
 int ObjectRef::l_get_acceleration(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -860,7 +860,7 @@ int ObjectRef::l_get_acceleration(lua_State *L)
 int ObjectRef::l_set_rotation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -875,7 +875,7 @@ int ObjectRef::l_set_rotation(lua_State *L)
 int ObjectRef::l_get_rotation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -891,7 +891,7 @@ int ObjectRef::l_get_rotation(lua_State *L)
 int ObjectRef::l_set_yaw(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -906,7 +906,7 @@ int ObjectRef::l_set_yaw(lua_State *L)
 int ObjectRef::l_get_yaw(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -921,7 +921,7 @@ int ObjectRef::l_get_yaw(lua_State *L)
 int ObjectRef::l_set_texture_mod(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -936,7 +936,7 @@ int ObjectRef::l_set_texture_mod(lua_State *L)
 int ObjectRef::l_get_texture_mod(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -951,7 +951,7 @@ int ObjectRef::l_get_texture_mod(lua_State *L)
 int ObjectRef::l_set_sprite(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -970,7 +970,7 @@ int ObjectRef::l_set_sprite(lua_State *L)
 int ObjectRef::l_get_entity_name(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	log_deprecated(L,"Deprecated call to \"get_entity_name");
 	if (entitysao == nullptr)
@@ -986,7 +986,7 @@ int ObjectRef::l_get_entity_name(lua_State *L)
 int ObjectRef::l_get_luaentity(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	LuaEntitySAO *entitysao = getluaobject(ref);
 	if (entitysao == nullptr)
 		return 0;
@@ -1001,7 +1001,7 @@ int ObjectRef::l_get_luaentity(lua_State *L)
 int ObjectRef::l_get_player_name(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr) {
 		lua_pushlstring(L, "", 0);
@@ -1016,7 +1016,7 @@ int ObjectRef::l_get_player_name(lua_State *L)
 int ObjectRef::l_get_look_dir(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1039,7 +1039,7 @@ int ObjectRef::l_get_look_pitch(lua_State *L)
 	log_deprecated(L,
 		"Deprecated call to get_look_pitch, use get_look_vertical instead");
 
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1057,7 +1057,7 @@ int ObjectRef::l_get_look_yaw(lua_State *L)
 	log_deprecated(L,
 		"Deprecated call to get_look_yaw, use get_look_horizontal instead");
 
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1070,7 +1070,7 @@ int ObjectRef::l_get_look_yaw(lua_State *L)
 int ObjectRef::l_get_look_vertical(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1083,7 +1083,7 @@ int ObjectRef::l_get_look_vertical(lua_State *L)
 int ObjectRef::l_get_look_horizontal(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1096,7 +1096,7 @@ int ObjectRef::l_get_look_horizontal(lua_State *L)
 int ObjectRef::l_set_look_vertical(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1111,7 +1111,7 @@ int ObjectRef::l_set_look_vertical(lua_State *L)
 int ObjectRef::l_set_look_horizontal(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1131,7 +1131,7 @@ int ObjectRef::l_set_look_pitch(lua_State *L)
 	log_deprecated(L,
 		"Deprecated call to set_look_pitch, use set_look_vertical instead.");
 
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1151,7 +1151,7 @@ int ObjectRef::l_set_look_yaw(lua_State *L)
 	log_deprecated(L,
 		"Deprecated call to set_look_yaw, use set_look_horizontal instead.");
 
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1166,7 +1166,7 @@ int ObjectRef::l_set_look_yaw(lua_State *L)
 int ObjectRef::l_set_fov(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1185,7 +1185,7 @@ int ObjectRef::l_set_fov(lua_State *L)
 int ObjectRef::l_get_fov(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1202,7 +1202,7 @@ int ObjectRef::l_get_fov(lua_State *L)
 int ObjectRef::l_set_breath(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1217,7 +1217,7 @@ int ObjectRef::l_set_breath(lua_State *L)
 int ObjectRef::l_get_breath(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1234,7 +1234,7 @@ int ObjectRef::l_set_attribute(lua_State *L)
 	log_deprecated(L,
 		"Deprecated call to set_attribute, use MetaDataRef methods instead.");
 
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1255,7 +1255,7 @@ int ObjectRef::l_get_attribute(lua_State *L)
 	log_deprecated(L,
 		"Deprecated call to get_attribute, use MetaDataRef methods instead.");
 
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO* playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1275,7 +1275,7 @@ int ObjectRef::l_get_attribute(lua_State *L)
 // get_meta(self, attribute)
 int ObjectRef::l_get_meta(lua_State *L)
 {
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO *playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1289,7 +1289,7 @@ int ObjectRef::l_get_meta(lua_State *L)
 int ObjectRef::l_set_inventory_formspec(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1305,7 +1305,7 @@ int ObjectRef::l_set_inventory_formspec(lua_State *L)
 int ObjectRef::l_get_inventory_formspec(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1320,7 +1320,7 @@ int ObjectRef::l_get_inventory_formspec(lua_State *L)
 int ObjectRef::l_set_formspec_prepend(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1336,7 +1336,7 @@ int ObjectRef::l_set_formspec_prepend(lua_State *L)
 int ObjectRef::l_get_formspec_prepend(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		 return 0;
@@ -1351,7 +1351,7 @@ int ObjectRef::l_get_formspec_prepend(lua_State *L)
 int ObjectRef::l_get_player_control(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 
 	lua_newtable(L);
@@ -1391,7 +1391,7 @@ int ObjectRef::l_get_player_control(lua_State *L)
 int ObjectRef::l_get_player_control_bits(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr) {
 		lua_pushinteger(L, 0);
@@ -1420,7 +1420,7 @@ int ObjectRef::l_get_player_control_bits(lua_State *L)
 int ObjectRef::l_set_physics_override(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	PlayerSAO *playersao = getplayersao(ref);
 	if (playersao == nullptr)
 		return 0;
@@ -1463,7 +1463,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 int ObjectRef::l_get_physics_override(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1489,7 +1489,7 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 int ObjectRef::l_hud_add(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1511,7 +1511,7 @@ int ObjectRef::l_hud_add(lua_State *L)
 int ObjectRef::l_hud_remove(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1529,7 +1529,7 @@ int ObjectRef::l_hud_remove(lua_State *L)
 int ObjectRef::l_hud_change(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1555,7 +1555,7 @@ int ObjectRef::l_hud_change(lua_State *L)
 int ObjectRef::l_hud_get(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1574,7 +1574,7 @@ int ObjectRef::l_hud_get(lua_State *L)
 int ObjectRef::l_hud_set_flags(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1600,7 +1600,7 @@ int ObjectRef::l_hud_set_flags(lua_State *L)
 int ObjectRef::l_hud_get_flags(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1618,7 +1618,7 @@ int ObjectRef::l_hud_get_flags(lua_State *L)
 int ObjectRef::l_hud_set_hotbar_itemcount(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1636,7 +1636,7 @@ int ObjectRef::l_hud_set_hotbar_itemcount(lua_State *L)
 int ObjectRef::l_hud_get_hotbar_itemcount(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1649,7 +1649,7 @@ int ObjectRef::l_hud_get_hotbar_itemcount(lua_State *L)
 int ObjectRef::l_hud_set_hotbar_image(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1664,7 +1664,7 @@ int ObjectRef::l_hud_set_hotbar_image(lua_State *L)
 int ObjectRef::l_hud_get_hotbar_image(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1679,7 +1679,7 @@ int ObjectRef::l_hud_get_hotbar_image(lua_State *L)
 int ObjectRef::l_hud_set_hotbar_selected_image(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1694,7 +1694,7 @@ int ObjectRef::l_hud_set_hotbar_selected_image(lua_State *L)
 int ObjectRef::l_hud_get_hotbar_selected_image(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1709,7 +1709,7 @@ int ObjectRef::l_hud_get_hotbar_selected_image(lua_State *L)
 int ObjectRef::l_set_sky(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1884,7 +1884,7 @@ static void push_sky_color(lua_State *L, const SkyboxParams &params)
 int ObjectRef::l_get_sky(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1937,7 +1937,7 @@ int ObjectRef::l_get_sky_color(lua_State *L)
 
 	log_deprecated(L, "Deprecated call to get_sky_color, use get_sky instead");
 
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1951,7 +1951,7 @@ int ObjectRef::l_get_sky_color(lua_State *L)
 int ObjectRef::l_set_sun(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -1979,7 +1979,7 @@ int ObjectRef::l_set_sun(lua_State *L)
 int ObjectRef::l_get_sun(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2006,7 +2006,7 @@ int ObjectRef::l_get_sun(lua_State *L)
 int ObjectRef::l_set_moon(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2032,7 +2032,7 @@ int ObjectRef::l_set_moon(lua_State *L)
 int ObjectRef::l_get_moon(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2055,7 +2055,7 @@ int ObjectRef::l_get_moon(lua_State *L)
 int ObjectRef::l_set_stars(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2089,7 +2089,7 @@ int ObjectRef::l_set_stars(lua_State *L)
 int ObjectRef::l_get_stars(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2114,7 +2114,7 @@ int ObjectRef::l_get_stars(lua_State *L)
 int ObjectRef::l_set_clouds(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2157,7 +2157,7 @@ int ObjectRef::l_set_clouds(lua_State *L)
 int ObjectRef::l_get_clouds(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2189,7 +2189,7 @@ int ObjectRef::l_get_clouds(lua_State *L)
 int ObjectRef::l_override_day_night_ratio(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2212,7 +2212,7 @@ int ObjectRef::l_override_day_night_ratio(lua_State *L)
 int ObjectRef::l_get_day_night_ratio(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2233,7 +2233,7 @@ int ObjectRef::l_get_day_night_ratio(lua_State *L)
 int ObjectRef::l_set_minimap_modes(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2286,7 +2286,7 @@ int ObjectRef::l_set_minimap_modes(lua_State *L)
 int ObjectRef::l_set_lighting(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2307,7 +2307,7 @@ int ObjectRef::l_set_lighting(lua_State *L)
 int ObjectRef::l_get_lighting(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;
@@ -2326,7 +2326,7 @@ int ObjectRef::l_get_lighting(lua_State *L)
 int ObjectRef::l_respawn(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = (ObjectRef *)methodCheckObject(L, 1);
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	RemotePlayer *player = getplayer(ref);
 	if (player == nullptr)
 		return 0;

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -45,12 +45,11 @@ public:
 
 	static void Register(lua_State *L);
 
-	static ObjectRef *checkobject(lua_State *L, int narg);
-
 	static ServerActiveObject* getobject(ObjectRef *ref);
+
+	static const char className[];
 private:
 	ServerActiveObject *m_object = nullptr;
-	static const char className[];
 	static luaL_Reg methods[];
 
 

--- a/src/script/lua_api/l_particleparams.h
+++ b/src/script/lua_api/l_particleparams.h
@@ -270,7 +270,7 @@ namespace LuaParticleParams
 		u16 id = 0;
 		lua_getfield(L, -1, name);
 		if (!lua_isnil(L, -1)) {
-			ObjectRef *ref = (ObjectRef *)ModApiBase::checkObject(L, -1, ObjectRef::className);
+			ObjectRef *ref = ModApiBase::checkObject<ObjectRef>(L, -1);
 			if (auto obj = ObjectRef::getobject(ref))
 				id = obj->getId();
 		}

--- a/src/script/lua_api/l_particleparams.h
+++ b/src/script/lua_api/l_particleparams.h
@@ -270,7 +270,7 @@ namespace LuaParticleParams
 		u16 id = 0;
 		lua_getfield(L, -1, name);
 		if (!lua_isnil(L, -1)) {
-			ObjectRef *ref = ObjectRef::checkobject(L, -1);
+			ObjectRef *ref = (ObjectRef *)ModApiBase::checkObject(L, -1, ObjectRef::className);
 			if (auto obj = ObjectRef::getobject(ref))
 				id = obj->getId();
 		}

--- a/src/script/lua_api/l_particles.cpp
+++ b/src/script/lua_api/l_particles.cpp
@@ -259,7 +259,7 @@ int ModApiParticles::l_add_particlespawner(lua_State *L)
 
 		lua_getfield(L, 1, "attached");
 		if (!lua_isnil(L, -1)) {
-			ObjectRef *ref = ObjectRef::checkobject(L, -1);
+			ObjectRef *ref = (ObjectRef *)checkObject(L, -1, ObjectRef::className);
 			lua_pop(L, 1);
 			attached = ObjectRef::getobject(ref);
 		}

--- a/src/script/lua_api/l_particles.cpp
+++ b/src/script/lua_api/l_particles.cpp
@@ -259,7 +259,7 @@ int ModApiParticles::l_add_particlespawner(lua_State *L)
 
 		lua_getfield(L, 1, "attached");
 		if (!lua_isnil(L, -1)) {
-			ObjectRef *ref = (ObjectRef *)checkObject(L, -1, ObjectRef::className);
+			ObjectRef *ref = checkObject<ObjectRef>(L, -1);
 			lua_pop(L, 1);
 			attached = ObjectRef::getobject(ref);
 		}

--- a/src/script/lua_api/l_playermeta.h
+++ b/src/script/lua_api/l_playermeta.h
@@ -31,19 +31,13 @@ class PlayerMetaRef : public MetaDataRef
 private:
 	IMetadata *metadata = nullptr;
 
-	static const char className[];
 	static const luaL_Reg methods[];
-
-	static PlayerMetaRef *checkobject(lua_State *L, int narg);
 
 	virtual IMetadata *getmeta(bool auto_create);
 
 	virtual void clearMeta();
 
 	virtual void reportMetadataChange(const std::string *name = nullptr);
-
-	// garbage collector
-	static int gc_object(lua_State *L);
 
 public:
 	PlayerMetaRef(IMetadata *metadata) : metadata(metadata) {}
@@ -54,4 +48,6 @@ public:
 	static void create(lua_State *L, IMetadata *metadata);
 
 	static void Register(lua_State *L);
+
+	static const char className[];
 };

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -115,7 +115,7 @@ int LuaSettings::gc_object(lua_State* L)
 int LuaSettings::l_get(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	if (o->m_settings->exists(key)) {
@@ -132,7 +132,7 @@ int LuaSettings::l_get(lua_State* L)
 int LuaSettings::l_get_bool(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	if (o->m_settings->exists(key)) {
@@ -153,7 +153,7 @@ int LuaSettings::l_get_bool(lua_State* L)
 int LuaSettings::l_get_np_group(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings *o = checkobject(L, 1);
+	LuaSettings *o = (LuaSettings *)methodCheckObject(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	if (o->m_settings->exists(key)) {
@@ -171,7 +171,7 @@ int LuaSettings::l_get_np_group(lua_State *L)
 int LuaSettings::l_get_flags(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings *o = checkobject(L, 1);
+	LuaSettings *o = (LuaSettings *)methodCheckObject(L, 1);
 	std::string key = std::string(luaL_checkstring(L, 2));
 
 	u32 flags = 0;
@@ -195,7 +195,7 @@ int LuaSettings::l_get_flags(lua_State *L)
 int LuaSettings::l_set(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	const char* value = luaL_checkstring(L, 3);
@@ -212,7 +212,7 @@ int LuaSettings::l_set(lua_State* L)
 int LuaSettings::l_set_bool(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	bool value = readParam<bool>(L, 3);
@@ -228,7 +228,7 @@ int LuaSettings::l_set_bool(lua_State* L)
 int LuaSettings::l_set_np_group(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings *o = checkobject(L, 1);
+	LuaSettings *o = (LuaSettings *)methodCheckObject(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	NoiseParams value;
@@ -245,7 +245,7 @@ int LuaSettings::l_set_np_group(lua_State *L)
 int LuaSettings::l_remove(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 
@@ -261,7 +261,7 @@ int LuaSettings::l_remove(lua_State* L)
 int LuaSettings::l_get_names(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
 
 	std::vector<std::string> keys = o->m_settings->getNames();
 
@@ -279,7 +279,7 @@ int LuaSettings::l_get_names(lua_State* L)
 int LuaSettings::l_write(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
 
 	if (!o->m_write_allowed) {
 		throw LuaError("Settings: writing " + o->m_filename +
@@ -318,7 +318,7 @@ static void push_settings_table(lua_State *L, const Settings *settings)
 int LuaSettings::l_to_table(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
 
 	MutexAutoLock(o->m_settings->m_mutex);
 	push_settings_table(L, o->m_settings);
@@ -328,27 +328,11 @@ int LuaSettings::l_to_table(lua_State* L)
 
 void LuaSettings::Register(lua_State* L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);  // drop metatable
-
-	luaL_register(L, nullptr, methods);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 
 	// Can be created from Lua (Settings(filename))
 	lua_register(L, className, create_object);
@@ -367,16 +351,6 @@ int LuaSettings::create_object(lua_State* L)
 	luaL_getmetatable(L, className);
 	lua_setmetatable(L, -2);
 	return 1;
-}
-
-LuaSettings* LuaSettings::checkobject(lua_State* L, int narg)
-{
-	NO_MAP_LOCK_REQUIRED;
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-	return *(LuaSettings**) ud;  // unbox pointer
 }
 
 const char LuaSettings::className[] = "Settings";

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -115,7 +115,7 @@ int LuaSettings::gc_object(lua_State* L)
 int LuaSettings::l_get(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
+	LuaSettings* o = checkObject<LuaSettings>(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	if (o->m_settings->exists(key)) {
@@ -132,7 +132,7 @@ int LuaSettings::l_get(lua_State* L)
 int LuaSettings::l_get_bool(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
+	LuaSettings* o = checkObject<LuaSettings>(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	if (o->m_settings->exists(key)) {
@@ -153,7 +153,7 @@ int LuaSettings::l_get_bool(lua_State* L)
 int LuaSettings::l_get_np_group(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings *o = (LuaSettings *)methodCheckObject(L, 1);
+	LuaSettings *o = checkObject<LuaSettings>(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	if (o->m_settings->exists(key)) {
@@ -171,7 +171,7 @@ int LuaSettings::l_get_np_group(lua_State *L)
 int LuaSettings::l_get_flags(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings *o = (LuaSettings *)methodCheckObject(L, 1);
+	LuaSettings *o = checkObject<LuaSettings>(L, 1);
 	std::string key = std::string(luaL_checkstring(L, 2));
 
 	u32 flags = 0;
@@ -195,7 +195,7 @@ int LuaSettings::l_get_flags(lua_State *L)
 int LuaSettings::l_set(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
+	LuaSettings* o = checkObject<LuaSettings>(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	const char* value = luaL_checkstring(L, 3);
@@ -212,7 +212,7 @@ int LuaSettings::l_set(lua_State* L)
 int LuaSettings::l_set_bool(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
+	LuaSettings* o = checkObject<LuaSettings>(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	bool value = readParam<bool>(L, 3);
@@ -228,7 +228,7 @@ int LuaSettings::l_set_bool(lua_State* L)
 int LuaSettings::l_set_np_group(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings *o = (LuaSettings *)methodCheckObject(L, 1);
+	LuaSettings *o = checkObject<LuaSettings>(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	NoiseParams value;
@@ -245,7 +245,7 @@ int LuaSettings::l_set_np_group(lua_State *L)
 int LuaSettings::l_remove(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
+	LuaSettings* o = checkObject<LuaSettings>(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 
@@ -261,7 +261,7 @@ int LuaSettings::l_remove(lua_State* L)
 int LuaSettings::l_get_names(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
+	LuaSettings* o = checkObject<LuaSettings>(L, 1);
 
 	std::vector<std::string> keys = o->m_settings->getNames();
 
@@ -279,7 +279,7 @@ int LuaSettings::l_get_names(lua_State* L)
 int LuaSettings::l_write(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
+	LuaSettings* o = checkObject<LuaSettings>(L, 1);
 
 	if (!o->m_write_allowed) {
 		throw LuaError("Settings: writing " + o->m_filename +
@@ -318,7 +318,7 @@ static void push_settings_table(lua_State *L, const Settings *settings)
 int LuaSettings::l_to_table(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = (LuaSettings *)methodCheckObject(L, 1);
+	LuaSettings* o = checkObject<LuaSettings>(L, 1);
 
 	MutexAutoLock(o->m_settings->m_mutex);
 	push_settings_table(L, o->m_settings);

--- a/src/script/lua_api/l_settings.h
+++ b/src/script/lua_api/l_settings.h
@@ -27,7 +27,6 @@ class Settings;
 class LuaSettings : public ModApiBase
 {
 private:
-	static const char className[];
 	static const luaL_Reg methods[];
 
 	// garbage collector
@@ -82,7 +81,7 @@ public:
 	// Creates a LuaSettings and leaves it on top of the stack
 	static int create_object(lua_State *L);
 
-	static LuaSettings *checkobject(lua_State *L, int narg);
-
 	static void Register(lua_State *L);
+
+	static const char className[];
 };

--- a/src/script/lua_api/l_storage.cpp
+++ b/src/script/lua_api/l_storage.cpp
@@ -49,52 +49,9 @@ void StorageRef::create(lua_State *L, const std::string &mod_name, ModMetadataDa
 	lua_setmetatable(L, -2);
 }
 
-int StorageRef::gc_object(lua_State *L)
-{
-	StorageRef *o = *(StorageRef **)(lua_touserdata(L, 1));
-	delete o;
-	return 0;
-}
-
 void StorageRef::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
-
-	lua_pushliteral(L, "metadata_class");
-	lua_pushlstring(L, className, strlen(className));
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__eq");
-	lua_pushcfunction(L, l_equals);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);  // drop metatable
-
-	luaL_register(L, nullptr, methods);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
-}
-
-StorageRef* StorageRef::checkobject(lua_State *L, int narg)
-{
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud) luaL_typerror(L, narg, className);
-	return *(StorageRef**)ud;  // unbox pointer
+	registerMetadataClass(L, className, methods);
 }
 
 IMetadata* StorageRef::getmeta(bool auto_create)

--- a/src/script/lua_api/l_storage.h
+++ b/src/script/lua_api/l_storage.h
@@ -38,14 +38,10 @@ class StorageRef : public MetaDataRef
 private:
 	ModMetadata m_object;
 
-	static const char className[];
 	static const luaL_Reg methods[];
 
 	virtual IMetadata *getmeta(bool auto_create);
 	virtual void clearMeta();
-
-	// garbage collector
-	static int gc_object(lua_State *L);
 
 public:
 	StorageRef(const std::string &mod_name, ModMetadataDatabase *db): m_object(mod_name, db) {}
@@ -54,5 +50,5 @@ public:
 	static void Register(lua_State *L);
 	static void create(lua_State *L, const std::string &mod_name, ModMetadataDatabase *db);
 
-	static StorageRef *checkobject(lua_State *L, int narg);
+	static const char className[];
 };

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -427,7 +427,7 @@ int LuaVoxelManip::create_object(lua_State *L)
 
 void *LuaVoxelManip::packIn(lua_State *L, int idx)
 {
-	LuaVoxelManip *o = (LuaVoxelManip *)checkObject(L, idx, className);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, idx);
 
 	if (o->is_mapgen_vm)
 		throw LuaError("nope");

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -44,7 +44,7 @@ int LuaVoxelManip::l_read_from_map(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	MMVManip *vm = o->vm;
 	if (vm->isOrphan())
 		return 0;
@@ -65,7 +65,7 @@ int LuaVoxelManip::l_get_data(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	bool use_buffer  = lua_istable(L, 2);
 
 	MMVManip *vm = o->vm;
@@ -90,7 +90,7 @@ int LuaVoxelManip::l_set_data(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	MMVManip *vm = o->vm;
 
 	if (!lua_istable(L, 2))
@@ -113,7 +113,7 @@ int LuaVoxelManip::l_write_to_map(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	bool update_light = !lua_isboolean(L, 2) || readParam<bool>(L, 2);
 
 	GET_ENV_PTR;
@@ -141,7 +141,7 @@ int LuaVoxelManip::l_get_node_at(lua_State *L)
 
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	v3s16 pos        = check_v3s16(L, 2);
 
 	pushnode(L, o->vm->getNodeNoExNoEmerge(pos), ndef);
@@ -154,7 +154,7 @@ int LuaVoxelManip::l_set_node_at(lua_State *L)
 
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	v3s16 pos        = check_v3s16(L, 2);
 	MapNode n        = readnode(L, 3, ndef);
 
@@ -167,7 +167,7 @@ int LuaVoxelManip::l_update_liquids(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 
 	ServerMap *map = &(env->getServerMap());
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
@@ -187,7 +187,7 @@ int LuaVoxelManip::l_calc_lighting(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	if (!o->is_mapgen_vm) {
 		warningstream << "VoxelManip:calc_lighting called for a non-mapgen "
 			"VoxelManip object" << std::endl;
@@ -223,7 +223,7 @@ int LuaVoxelManip::l_set_lighting(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	if (!o->is_mapgen_vm) {
 		warningstream << "VoxelManip:set_lighting called for a non-mapgen "
 			"VoxelManip object" << std::endl;
@@ -259,7 +259,7 @@ int LuaVoxelManip::l_get_light_data(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	bool use_buffer  = lua_istable(L, 2);
 
 	MMVManip *vm = o->vm;
@@ -284,7 +284,7 @@ int LuaVoxelManip::l_set_light_data(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	MMVManip *vm = o->vm;
 
 	if (!lua_istable(L, 2))
@@ -308,7 +308,7 @@ int LuaVoxelManip::l_get_param2_data(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	bool use_buffer  = lua_istable(L, 2);
 
 	MMVManip *vm = o->vm;
@@ -333,7 +333,7 @@ int LuaVoxelManip::l_set_param2_data(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	MMVManip *vm = o->vm;
 
 	if (!lua_istable(L, 2))
@@ -362,7 +362,7 @@ int LuaVoxelManip::l_was_modified(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 	MMVManip *vm = o->vm;
 
 	lua_pushboolean(L, vm->m_is_dirty);
@@ -374,7 +374,7 @@ int LuaVoxelManip::l_get_emerged_area(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = checkobject(L, 1);
+	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
 
 	push_v3s16(L, o->vm->m_area.MinEdge);
 	push_v3s16(L, o->vm->m_area.MaxEdge);
@@ -425,22 +425,9 @@ int LuaVoxelManip::create_object(lua_State *L)
 	return 1;
 }
 
-LuaVoxelManip *LuaVoxelManip::checkobject(lua_State *L, int narg)
-{
-	NO_MAP_LOCK_REQUIRED;
-
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-
-	return *(LuaVoxelManip **)ud;  // unbox pointer
-}
-
 void *LuaVoxelManip::packIn(lua_State *L, int idx)
 {
-	LuaVoxelManip *o = checkobject(L, idx);
+	LuaVoxelManip *o = (LuaVoxelManip *)checkObject(L, idx, className);
 
 	if (o->is_mapgen_vm)
 		throw LuaError("nope");
@@ -468,27 +455,11 @@ void LuaVoxelManip::packOut(lua_State *L, void *ptr)
 
 void LuaVoxelManip::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);  // drop metatable
-
-	luaL_register(L, nullptr, methods);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
+	static const luaL_Reg metamethods[] = {
+		{"__gc", gc_object},
+		{0, 0}
+	};
+	registerClass(L, className, methods, metamethods);
 
 	// Can be created from Lua (VoxelManip())
 	lua_register(L, className, create_object);

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -44,7 +44,7 @@ int LuaVoxelManip::l_read_from_map(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	MMVManip *vm = o->vm;
 	if (vm->isOrphan())
 		return 0;
@@ -65,7 +65,7 @@ int LuaVoxelManip::l_get_data(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	bool use_buffer  = lua_istable(L, 2);
 
 	MMVManip *vm = o->vm;
@@ -90,7 +90,7 @@ int LuaVoxelManip::l_set_data(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	MMVManip *vm = o->vm;
 
 	if (!lua_istable(L, 2))
@@ -113,7 +113,7 @@ int LuaVoxelManip::l_write_to_map(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	bool update_light = !lua_isboolean(L, 2) || readParam<bool>(L, 2);
 
 	GET_ENV_PTR;
@@ -141,7 +141,7 @@ int LuaVoxelManip::l_get_node_at(lua_State *L)
 
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	v3s16 pos        = check_v3s16(L, 2);
 
 	pushnode(L, o->vm->getNodeNoExNoEmerge(pos), ndef);
@@ -154,7 +154,7 @@ int LuaVoxelManip::l_set_node_at(lua_State *L)
 
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	v3s16 pos        = check_v3s16(L, 2);
 	MapNode n        = readnode(L, 3, ndef);
 
@@ -167,7 +167,7 @@ int LuaVoxelManip::l_update_liquids(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 
 	ServerMap *map = &(env->getServerMap());
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
@@ -187,7 +187,7 @@ int LuaVoxelManip::l_calc_lighting(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	if (!o->is_mapgen_vm) {
 		warningstream << "VoxelManip:calc_lighting called for a non-mapgen "
 			"VoxelManip object" << std::endl;
@@ -223,7 +223,7 @@ int LuaVoxelManip::l_set_lighting(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	if (!o->is_mapgen_vm) {
 		warningstream << "VoxelManip:set_lighting called for a non-mapgen "
 			"VoxelManip object" << std::endl;
@@ -259,7 +259,7 @@ int LuaVoxelManip::l_get_light_data(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	bool use_buffer  = lua_istable(L, 2);
 
 	MMVManip *vm = o->vm;
@@ -284,7 +284,7 @@ int LuaVoxelManip::l_set_light_data(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	MMVManip *vm = o->vm;
 
 	if (!lua_istable(L, 2))
@@ -308,7 +308,7 @@ int LuaVoxelManip::l_get_param2_data(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	bool use_buffer  = lua_istable(L, 2);
 
 	MMVManip *vm = o->vm;
@@ -333,7 +333,7 @@ int LuaVoxelManip::l_set_param2_data(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	MMVManip *vm = o->vm;
 
 	if (!lua_istable(L, 2))
@@ -362,7 +362,7 @@ int LuaVoxelManip::l_was_modified(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	MMVManip *vm = o->vm;
 
 	lua_pushboolean(L, vm->m_is_dirty);
@@ -374,7 +374,7 @@ int LuaVoxelManip::l_get_emerged_area(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaVoxelManip *o = (LuaVoxelManip *)methodCheckObject(L, 1);
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 
 	push_v3s16(L, o->vm->m_area.MinEdge);
 	push_v3s16(L, o->vm->m_area.MaxEdge);

--- a/src/script/lua_api/l_vmanip.h
+++ b/src/script/lua_api/l_vmanip.h
@@ -34,7 +34,6 @@ class LuaVoxelManip : public ModApiBase
 private:
 	bool is_mapgen_vm = false;
 
-	static const char className[];
 	static const luaL_Reg methods[];
 
 	static int gc_object(lua_State *L);
@@ -73,10 +72,10 @@ public:
 	// Creates a LuaVoxelManip and leaves it on top of stack
 	static int create_object(lua_State *L);
 
-	static LuaVoxelManip *checkobject(lua_State *L, int narg);
-
 	static void *packIn(lua_State *L, int idx);
 	static void packOut(lua_State *L, void *ptr);
 
 	static void Register(lua_State *L);
+
+	static const char className[];
 };


### PR DESCRIPTION
This PR reduces repetition in the code that implements userdata objects such as `VoxelManip` and `Settings`. Overall, it removes over 600 lines of code. It should also decrease the size of the executable, but I haven't measured that.

## To do

This PR is Ready for Review.

## How to test

There are many changes in the PR, and it's possible that some are erroneous. Someone should look through them to make sure this is not the case.