### PR TITLE
Fix incorrectly placed label in tab_online

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -94,7 +94,7 @@ local function get_formspec(tabview, name, tabdata)
 		-- Name / Password
 		"container[0,4.8]" ..
 		"label[0.25,0;" .. fgettext("Name") .. "]" ..
-		"label[3,0;" .. fgettext("Password") .. "]" ..
+		"label[2.875,0;" .. fgettext("Password") .. "]" ..
 		"field[0.25,0.2;2.625,0.75;te_name;;" .. core.formspec_escape(core.settings:get("name")) .. "]" ..
 		"pwdfield[2.875,0.2;2.625,0.75;te_pwd;]" ..
 		"container_end[]" ..


### PR DESCRIPTION
The "Password" input field is displayed a bit too far to right

## To do

This PR is Ready for Review.

## How to test
See that the "Password" label is now a little further to the left.

before
![grafik](https://user-images.githubusercontent.com/89982526/187437646-3217d1d8-285d-4f0a-8dd3-7f7c23d15910.png)

after
![grafik](https://user-images.githubusercontent.com/89982526/187437382-2c988091-6220-480f-a1bd-34de0fb8d9b9.png)

