### PR TITLE
[NO SQUASH] Add callback on_mapblocks_changed

### DIFF
--- a/builtin/game/misc_s.lua
+++ b/builtin/game/misc_s.lua
@@ -8,10 +8,9 @@
 -- Misc. API functions
 --
 
+-- This must match the implementation in src/script/common/c_converter.h
 function core.hash_node_position(pos)
-	return (pos.z + 32768) * 65536 * 65536
-		 + (pos.y + 32768) * 65536
-		 +  pos.x + 32768
+	return (pos.z + 0x8000) * 0x100000000 + (pos.y + 0x8000) * 0x10000 + (pos.x + 0x8000)
 end
 
 

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -633,6 +633,17 @@ core.registered_on_player_inventory_actions, core.register_on_player_inventory_a
 core.registered_allow_player_inventory_actions, core.register_allow_player_inventory_action = make_registration()
 core.registered_on_rightclickplayers, core.register_on_rightclickplayer = make_registration()
 core.registered_on_liquid_transformed, core.register_on_liquid_transformed = make_registration()
+core.registered_on_mapblocks_changed, core.register_on_mapblocks_changed = make_registration()
+
+core.register_on_mods_loaded(function()
+	core.after(0, function()
+		setmetatable(core.registered_on_mapblocks_changed, {
+			__newindex = function()
+				error("on_mapblocks_changed callbacks must be registered at load time")
+			end,
+		})
+	end)
+end)
 
 --
 -- Compatibility for on_mapgen_init()

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -43,6 +43,7 @@ local register_functions = {
 	register_on_item_eat = 0,
 	register_on_punchplayer = 0,
 	register_on_player_hpchange = 0,
+	register_on_mapblocks_changed = 0,
 }
 
 ---

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5372,6 +5372,16 @@ Call these functions only at load time!
     * `pos_list` is an array of all modified positions.
     * `node_list` is an array of the old node that was previously at the position
       with the corresponding index in pos_list.
+* `minetest.register_on_mapblocks_changed(function(modified_blocks, modified_block_count))`
+    * Called soon after any nodes or node metadata have been modified. No
+      modifications will be missed, but there may be false positives.
+    * Will never be called more than once per server step.
+    * `modified_blocks` is the set of modified mapblock position hashes. These
+      are in the same format as those produced by `minetest.hash_node_position`,
+      and can be converted to positions with `minetest.get_position_from_hash`.
+      The set is a table where the keys are hashes and the values are `true`.
+    * `modified_block_count` is the number of entries in the set.
+    * Note: callbacks must be registered at mod load time.
 
 Setting-related
 ---------------

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -722,8 +722,15 @@ void *EmergeThread::run()
 		if (block)
 			modified_blocks[pos] = block;
 
-		if (!modified_blocks.empty())
-			m_server->SetBlocksNotSent(modified_blocks);
+		if (!modified_blocks.empty()) {
+			MapEditEvent event;
+			event.type = MEET_OTHER;
+			for (const auto &pair : modified_blocks) {
+				event.modified_blocks.insert(pair.first);
+			}
+			MutexAutoLock envlock(m_server->m_env_mutex);
+			m_map->dispatchEvent(event);
+		}
 		modified_blocks.clear();
 	}
 	} catch (VersionMismatchException &e) {

--- a/src/map.h
+++ b/src/map.h
@@ -79,21 +79,21 @@ struct MapEditEvent
 
 	MapEditEvent() = default;
 
+	// Sets the event's position and marks the block as modified.
+	void setPositionModified(v3s16 pos)
+	{
+		p = pos;
+		modified_blocks.insert(getNodeBlockPos(pos));
+	}
+
 	VoxelArea getArea() const
 	{
 		switch(type){
 		case MEET_ADDNODE:
-			return VoxelArea(p);
 		case MEET_REMOVENODE:
-			return VoxelArea(p);
 		case MEET_SWAPNODE:
-			return VoxelArea(p);
 		case MEET_BLOCK_NODE_METADATA_CHANGED:
-		{
-			v3s16 np1 = p*MAP_BLOCKSIZE;
-			v3s16 np2 = np1 + v3s16(1,1,1)*MAP_BLOCKSIZE - v3s16(1,1,1);
-			return VoxelArea(np1, np2);
-		}
+			return VoxelArea(p);
 		case MEET_OTHER:
 		{
 			VoxelArea a;

--- a/src/rollback_interface.cpp
+++ b/src/rollback_interface.cpp
@@ -175,7 +175,7 @@ bool RollbackAction::applyRevert(Map *map, InventoryManager *imgr, IGameDef *gam
 				// Inform other things that the meta data has changed
 				MapEditEvent event;
 				event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
-				event.p = p;
+				event.setPositionModified(p);
 				map->dispatchEvent(event);
 			} catch (InvalidPositionException &e) {
 				infostream << "RollbackAction::applyRevert(): "

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -121,3 +121,12 @@ void                warn_if_field_exists(lua_State *L, int table,
 
 size_t write_array_slice_float(lua_State *L, int table_index, float *data,
 	v3u16 data_size, v3u16 slice_offset, v3u16 slice_size);
+
+// This must match the implementation in builtin/game/misc_s.lua
+// Note that this returns a floating point result as Lua integers are 32-bit
+inline lua_Number hash_node_position(v3s16 pos)
+{
+	return (((s64)pos.Z + 0x8000L) << 32)
+			| (((s64)pos.Y + 0x8000L) << 16)
+			| ((s64)pos.X + 0x8000L);
+}

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -299,3 +299,36 @@ void ScriptApiEnv::on_liquid_transformed(
 
 	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
 }
+
+void ScriptApiEnv::on_mapblocks_changed(const std::unordered_set<v3s16> &set)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_mapblocks_changed
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_mapblocks_changed");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	lua_remove(L, -2);
+
+	// Convert the set to a set of position hashes
+	lua_createtable(L, 0, set.size());
+	for(const v3s16 &p : set) {
+		lua_pushnumber(L, hash_node_position(p));
+		lua_pushboolean(L, true);
+		lua_rawset(L, -3);
+	}
+	lua_pushinteger(L, set.size());
+
+	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
+}
+
+bool ScriptApiEnv::has_on_mapblocks_changed()
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_mapblocks_changed
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_mapblocks_changed");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	return lua_objlen(L, -1) > 0;
+}

--- a/src/script/cpp_api/s_env.h
+++ b/src/script/cpp_api/s_env.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_base.h"
 #include "irr_v3d.h"
 #include "mapnode.h"
+#include <unordered_set>
 #include <vector>
 
 class ServerEnvironment;
@@ -47,6 +48,12 @@ public:
 
 	// Called after liquid transform changes
 	void on_liquid_transformed(const std::vector<std::pair<v3s16, MapNode>> &list);
+
+	// Called after mapblock changes
+	void on_mapblocks_changed(const std::unordered_set<v3s16> &set);
+
+	// Determines whether there are any on_mapblocks_changed callbacks
+	bool has_on_mapblocks_changed();
 
 	void initializeEnvironment(ServerEnvironment *env);
 };

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -66,7 +66,7 @@ void NodeMetaRef::reportMetadataChange(const std::string *name)
 
 	MapEditEvent event;
 	event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
-	event.p = m_p;
+	event.setPositionModified(m_p);
 	event.is_private_change = name && meta && meta->isPrivate(*name);
 	m_env->getMap().dispatchEvent(event);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -696,11 +696,13 @@ void Server::AsyncRunStep(bool initial_step)
 		std::map<v3s16, MapBlock*> modified_blocks;
 		m_env->getServerMap().transformLiquids(modified_blocks, m_env);
 
-		/*
-			Set the modified blocks unsent for all the clients
-		*/
 		if (!modified_blocks.empty()) {
-			SetBlocksNotSent(modified_blocks);
+			MapEditEvent event;
+			event.type = MEET_OTHER;
+			for (const auto &pair : modified_blocks) {
+				event.modified_blocks.insert(pair.first);
+			}
+			m_env->getMap().dispatchEvent(event);
 		}
 	}
 	m_clients.step(dtime);
@@ -1251,17 +1253,6 @@ void Server::onMapEditEvent(const MapEditEvent &event)
 		return;
 
 	m_unsent_map_edit_queue.push(new MapEditEvent(event));
-}
-
-void Server::SetBlocksNotSent(std::map<v3s16, MapBlock *>& block)
-{
-	std::vector<session_t> clients = m_clients.getClientIDs();
-	ClientInterface::AutoLock clientlock(m_clients);
-	// Set the modified blocks unsent for all the clients
-	for (const session_t client_id : clients) {
-			if (RemoteClient *client = m_clients.lockedGetClientNoEx(client_id))
-				client->SetBlocksNotSent(block);
-	}
 }
 
 void Server::peerAdded(con::Peer *peer)

--- a/src/server.h
+++ b/src/server.h
@@ -439,9 +439,6 @@ private:
 	void SendNodeDef(session_t peer_id, const NodeDefManager *nodedef,
 		u16 protocol_version);
 
-	/* mark blocks not sent for all clients */
-	void SetBlocksNotSent(std::map<v3s16, MapBlock *>& block);
-
 
 	virtual void SendChatMessage(session_t peer_id, const ChatMessage &message);
 	void SendTimeOfDay(session_t peer_id, u16 time, f32 time_speed);

--- a/src/server/serverinventorymgr.cpp
+++ b/src/server/serverinventorymgr.cpp
@@ -95,7 +95,7 @@ void ServerInventoryManager::setInventoryModified(const InventoryLocation &loc)
 	case InventoryLocation::NODEMETA: {
 		MapEditEvent event;
 		event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
-		event.p = loc.p;
+		event.setPositionModified(loc.p);
 		m_env->getMap().dispatchEvent(event);
 	} break;
 	case InventoryLocation::DETACHED: {

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "activeobject.h"
 #include "environment.h"
-#include "mapnode.h"
+#include "map.h"
 #include "settings.h"
 #include "server/activeobjectmgr.h"
 #include "util/numeric.h"
@@ -30,9 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <random>
 
 class IGameDef;
-class ServerMap;
 struct GameParams;
-class MapBlock;
 class RemotePlayer;
 class PlayerDatabase;
 class AuthDatabase;
@@ -191,6 +189,16 @@ public:
 	std::set<v3s16> m_abm_list;
 	// list of blocks that are always active, not modified by this class
 	std::set<v3s16> m_forceloaded_list;
+};
+
+/*
+	ServerEnvironment::m_on_mapblocks_changed_receiver
+*/
+struct OnMapblocksChangedReceiver : public MapEventReceiver {
+	std::unordered_set<v3s16> modified_blocks;
+	bool receiving = false;
+
+	void onMapEditEvent(const MapEditEvent &event) override;
 };
 
 /*
@@ -455,6 +463,8 @@ private:
 	Server *m_server;
 	// Active Object Manager
 	server::ActiveObjectMgr m_ao_manager;
+	// on_mapblocks_changed map event receiver
+	OnMapblocksChangedReceiver m_on_mapblocks_changed_receiver;
 	// World path
 	const std::string m_path_world;
 	// Outgoing network message buffer for active objects


### PR DESCRIPTION
This could close https://github.com/minetest/minetest/issues/12725. It provides a new callback registered with `register_on_mapblocks_changed`. Basically, all the map modifications each server step are collected and passed to Lua as a set. No modifications are missed. You can read more in lua_api.txt.

Unlike other possible solutions to https://github.com/minetest/minetest/issues/12725, this one might raise many false positives, but it is relatively easy to implement and fast.

## To do

This PR is Ready for Review.

## How to test

I added a Lua unit test.

Here is a mod which uses the functionality. It is a more limited version of the Mesecons node detector. The code is crude and unoptimized.
[mesecons_detector2.zip](https://github.com/minetest/minetest/files/9483706/mesecons_detector2.zip)

