### PR TITLE
[No squash] Corrections to entity and node light calculation

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -869,6 +869,7 @@ void GenericCAO::updateLight(u32 day_night_ratio)
 		bool this_ok;
 		MapNode n = m_env->getMap().getNode(pos[i], &this_ok);
 		if (this_ok) {
+			// Get light level at the position plus the entity glow
 			u16 this_light = getInteriorLight(n, m_prop.glow, m_client->ndef());
 			u8 this_light_intensity = MYMAX(this_light & 0xFF, this_light >> 8);
 			if (this_light_intensity > light_at_pos_intensity) {
@@ -881,6 +882,8 @@ void GenericCAO::updateLight(u32 day_night_ratio)
 	if (!pos_ok)
 		light_at_pos = LIGHT_SUN;
 
+	// Encode light into color, adding a small boost
+	// based on the entity glow.
 	video::SColor light = encode_light(light_at_pos, m_prop.glow);
 	if (!m_enable_shaders)
 		final_color_blend(&light, light_at_pos, day_night_ratio);

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -869,7 +869,7 @@ void GenericCAO::updateLight(u32 day_night_ratio)
 		bool this_ok;
 		MapNode n = m_env->getMap().getNode(pos[i], &this_ok);
 		if (this_ok) {
-			u16 this_light = getInteriorLight(n, 0, m_client->ndef());
+			u16 this_light = getInteriorLight(n, m_prop.glow, m_client->ndef());
 			u8 this_light_intensity = MYMAX(this_light & 0xFF, this_light >> 8);
 			if (this_light_intensity > light_at_pos_intensity) {
 				light_at_pos = this_light;
@@ -881,7 +881,7 @@ void GenericCAO::updateLight(u32 day_night_ratio)
 	if (!pos_ok)
 		light_at_pos = LIGHT_SUN;
 
-	video::SColor light = encode_light(light_at_pos, decode_light(m_prop.glow));
+	video::SColor light = encode_light(light_at_pos, m_prop.glow);
 	if (!m_enable_shaders)
 		final_color_blend(&light, light_at_pos, day_night_ratio);
 

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1131,7 +1131,7 @@ void MapblockMeshGenerator::drawPlantlikeRootedNode()
 		getSmoothLightFrame();
 	} else {
 		MapNode ntop = data->m_vmanip.getNodeNoEx(blockpos_nodes + p);
-		light = LightPair(getInteriorLight(ntop, 1, nodedef));
+		light = LightPair(getInteriorLight(ntop, 0, nodedef));
 	}
 	drawPlantlike(true);
 	p.Y--;
@@ -1594,7 +1594,7 @@ void MapblockMeshGenerator::drawNode()
 	if (data->m_smooth_lighting)
 		getSmoothLightFrame();
 	else
-		light = LightPair(getInteriorLight(n, 1, nodedef));
+		light = LightPair(getInteriorLight(n, 0, nodedef));
 	switch (f->drawtype) {
 		case NDT_FLOWINGLIQUID:     drawLiquidNode(); break;
 		case NDT_GLASSLIKE:         drawGlasslikeNode(); break;

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -103,8 +103,7 @@ static u8 getInteriorLight(enum LightBank bank, MapNode n, s32 increment,
 	const NodeDefManager *ndef)
 {
 	u8 light = n.getLight(bank, ndef->getLightingFlags(n));
-	if (light > 0)
-		light = rangelim(light + increment, 0, LIGHT_SUN);
+	light = rangelim(light + increment, 0, LIGHT_SUN);
 	return decode_light(light);
 }
 


### PR DESCRIPTION
This PR fixes two things:
1. When smooth light is disabled, makes visible brightness of nodebox and other draw types the same as NDT_SOLID at the same light level:
![image](https://user-images.githubusercontent.com/4933697/188332120-5aa9cd9c-68cf-4592-9545-3845cf8764b1.png)
2. Corrects computation of brightness for entity `glow` property to work on the light levels (0..LIGHT_MAX):
  a. Glow is added to the map light level at the node position, before converting to the color space
  b. Additional brightness is added at the final stage in the same was as for light sources

The reason for a single PR is that light calculation for both scenarios is based on [getInteriorLight](https://github.com/minetest/minetest/blob/a8711158896d993e23d823f41ab086c3915c7d4e/src/client/mapblock_mesh.cpp#L102) function

Fixes #12686 in a formally correct way.

## To do

This PR is Ready for Review.

## How to test

In devtest:
Test 1:
1. Throw various light sources on the ground in a dark place.
2. Brightness of the item entities must reflect the light source level

Note, depending on your hardware, dim light sources (1-3) may not be visible in full darkness.

Test 2:

1. Place arrays of sandstone, sandstone slab and sandstone stairs in sunlight and check that the brightness level is the same
2. Place arrays of sandstone, sandstone slab and sandstone stairs near an array of light sources as show below:
![image](https://user-images.githubusercontent.com/4933697/188333406-8c4a9ce7-4c07-494f-b36b-5b8d253fa407.png)
3. Brightness of stairs and slabs must be exactly one level higher than on solid nodes. This is because solid nodes use light levels of the air nodes above them, which are 1 manhattan unit further away from the light source (as displayed above).
