### PR TITLE
Fix tooltips for dropdown, scrollbar and more

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -825,9 +825,9 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 	core::rect<s32> middle;
 	if (parts.size() >= 4)
 		parseMiddleRect(parts[3], &middle);
-	
+
 	// Temporary fix for issue #12581 in 5.6.0.
-	// Use legacy image when not rendering 9-slice image because GUIAnimatedImage 
+	// Use legacy image when not rendering 9-slice image because GUIAnimatedImage
 	// uses NNAA filter which causes visual artifacts when image uses alpha blending.
 
 	gui::IGUIElement *e;
@@ -3642,13 +3642,21 @@ void GUIFormSpecMenu::drawMenu()
 #endif
 	bool hovered_element_found = false;
 
-	if (hovered != NULL) {
+	if (hovered) {
 		if (m_show_debug) {
 			core::rect<s32> rect = hovered->getAbsoluteClippingRect();
 			driver->draw2DRectangle(0x22FFFF00, rect, &rect);
 		}
 
-		s32 id = hovered->getID();
+		// find the formspec-element of the hovered IGUIElement (a parent)
+		s32 id;
+		for (gui::IGUIElement *hovered_fselem = hovered; hovered_fselem;
+				hovered_fselem = hovered_fselem->getParent()) {
+			id = hovered_fselem->getID();
+			if (id != -1)
+				break;
+		}
+
 		u64 delta = 0;
 		if (id == -1) {
 			m_old_tooltip_id = id;


### PR DESCRIPTION
If we hover a child of the formspec element, search for the first parent that has an id != -1.

Fixes #1577.

## To do

This PR is a Ready for Review.

## How to test

In devtest, use the node meta editor tool, to set this formspec to a node:
```
formspec_version[6]
size[10,10]
dropdown[1,1;2,1;drpdwn;item1,item2;1]
tooltip[drpdwn;foo1]
scrollbar[4,1;0.25,3;vertical;scrbr;0]
tooltip[scrbr;foo2]
```
Then hover and look for tooltips.
You might also want to press F5 to see which IGUIElement is hovered.
