### PR TITLE
Move code style guidelines into repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,8 +33,8 @@ Contributions are welcome! Here's how you can help:
       [Lua API](https://github.com/minetest/minetest/blob/master/doc/lua_api.txt),
       [Developer Wiki](http://dev.minetest.net/Main_Page) and other
       [documentation](https://github.com/minetest/minetest/tree/master/doc).
-    - Follow the [C/C++](http://dev.minetest.net/Code_style_guidelines) and
-      [Lua](http://dev.minetest.net/Lua_code_style_guidelines) code style guidelines.
+    - Follow the [C/C++](https://github.com/minetest/minetest/blob/master/doc/code_style_guidelines.md) and
+      [Lua](https://github.com/minetest/minetest/blob/master/doc/lua_code_style_guidelines.md) code style guidelines.
     - Check your code works as expected and document any changes to the Lua API.
 
 4. Commit & [push](https://help.github.com/articles/pushing-to-a-remote/) your changes to a new branch (not `master`, one change per branch)

--- a/doc/code_style_guidelines.md
+++ b/doc/code_style_guidelines.md
@@ -46,7 +46,7 @@ No more than 7 parameters allowed (except for constructors).
 
 ## Spaces
 
-<span style="color: red">Do **not** use spaces to indent.</span>
+Do **not** use spaces to indent.
 
 Try to stay under 6 levels of indentation.
 
@@ -97,7 +97,7 @@ Align backslashes for multi-line macros with spaces:
 
 This rule has already been explicitly stated in the [Linux kernel code style](https://www.kernel.org/doc/html/latest/process/coding-style.html) from which this code style inherits, but it will be repeated here:
 
-<span style="color: red">**Putting the body of an `if` statement on the same line as the condition is strictly prohibited.**</span>
+**Putting the body of an `if` statement on the same line as the condition is strictly prohibited.**
 
 Example:
 ```cpp
@@ -223,7 +223,7 @@ All files should include the appropriate license header.
 
 ## Miscellaneous
 
-<span style="color: red">Do **not** use `or`, use `||`.</span>
+Do **not** use `or`, use `||`.
 
 Set pointer values to `nullptr` (C++11), not 0.
 

--- a/doc/code_style_guidelines.md
+++ b/doc/code_style_guidelines.md
@@ -84,9 +84,9 @@ for (std::vector<std::string>::iterator it = strings.begin();
 Align backslashes for multi-line macros with spaces:
 
 ```cpp
-#define FOOBAR(x) do {    \
-	int __temp = (x); \
-	foo(__temp);      \
+#define FOOBAR(x) do { \
+	int __temp = (x);  \
+	foo(__temp);       \
 } while (0)
 ```
 
@@ -175,12 +175,12 @@ Add comments to explain a non-trivial but important detail about the code, or ex
 For comments with text, be sure to add a space between the text and the comment tokens:
 
 ```cpp
-DoThingHere();  // This does thing    <--- yes!
-DoThingHere();  /* This does thing */ <--- yes!
+DoThingHere();  // This does thing      /* <--- yes! */
+DoThingHere();  /* This does thing */   /* <--- yes! */
 
-DoThingHere();  //This does thing      <--- no!
-DoThingHere();  /*This does thing*/    <--- no!
-DoThingHere();//This does thing        <--- no!
+DoThingHere();  //This does thing       /* <--- no! */
+DoThingHere();  /*This does thing*/     /* <--- no! */
+DoThingHere();//This does thing         /* <--- no! */
 ```
 
 

--- a/doc/code_style_guidelines.md
+++ b/doc/code_style_guidelines.md
@@ -1,6 +1,4 @@
-
-Code style guidelines
-=====================
+# Code style guidelines
 
 This is the coding style used for C/C++ code. Also see the Lua code style guidelines.
 
@@ -9,12 +7,12 @@ The coding style is based on the <https://www.kernel.org/doc/html/latest/process
 Currently, the code uses C++14. Do not use features that depend on more recent versions.
 
 
-# Spelling
+## Spelling
 
 Use American English, but avoid idioms that may be difficult to understand by non-native speakers.
 
 
-# Function declarations
+## Function declarations
 
 In case your function parameters don't fit within the defined line length, use the following style.
 Indention for continuation lines is **exactly** two tabs.
@@ -46,7 +44,7 @@ void some_function_name(
 No more than 7 parameters allowed (except for constructors).
 
 
-# Spaces
+## Spaces
 
 * <span style="color: red">Do **not** use spaces to indent.</span>
 * Try to stay under 6 levels of indentation.
@@ -88,9 +86,9 @@ for (std::vector<std::string>::iterator it = strings.begin();
 ```
 
 
-# Bracing and indentation
+## Bracing and indentation
 
-## `if` statements
+### `if` statements
 
 This rule has already been explicitly stated in the [Linux kernel code style](https://www.kernel.org/doc/html/latest/process/coding-style.html) from which this code style inherits, but it will be repeated here:
 
@@ -115,7 +113,7 @@ if (foobar < 6) {
 }
 ```
 
-## Nested for loop exception
+### Nested for loop exception
 
 Special exception to the standard bracing/indent rules for nested loops:
 If a nested loop iterates over a set of coordinates, it is permitted to omit the braces for all but the innermost loop and keep the outer loops at the same indentation level, like so:
@@ -128,7 +126,7 @@ for (s16 x = pmin.X; x <= pmax.X; x++) {
 ```
 
 
-# Do not be too C++y
+## Do not be too C++y
 
 * Avoid passing non-`const` references to functions.
 * Don't use initializer lists unless absolutely necessary (initializing an object inside a class, or initializing a reference).
@@ -138,7 +136,7 @@ for (s16 x = pmin.X; x <= pmax.X; x++) {
 * Usage of macros is not discouraged, just don't overdo it [like X.org](http://cgit.freedesktop.org/xorg/xserver/tree/randr/rrscreen.c?id=01e18af17f8dc91451fbd0902049045afd1cea7e#n325). It's better to use inline functions or lambdas instead.
 
 
-# Classes
+## Classes
 
 * **Class names are *PascalCase*, method names are *camelCase*.**
 * Don't put actual code in header files, unless it's a 4-liner, an inline function, or part of a template.
@@ -147,7 +145,7 @@ for (s16 x = pmin.X; x <= pmax.X; x++) {
 * Functions not part of any class should use `lowercase_underscore_style()`.
 
 
-# Comments
+## Comments
 
 * Doxygen comments are acceptable, but **please** put them in the header file.
 * Don't make uninformative comments like this:
@@ -170,20 +168,20 @@ DoThingHere();//This does thing        <--- no!
 ```
 
 
-# Use STL, avoid Irrlicht containers, and no, Boost will not even be considered, so forget it
+## Use STL, avoid Irrlicht containers, and no, Boost will not even be considered, so forget it
 
 * In general, adding new dependencies is considered serious business.
 * We are using C++14; Boost will never be an option.
 
 
-# Don't let things get too large
+## Don't let things get too large
 
 * **Try to keep lines under 95 characters.** It's okay if it goes over by a few, but do not exaggerate. (Note that this column count assumes 4-space indents.)
 * Functions should not have over 200 lines of code – if you are concerned with having to pass too many parameters to child functions, make whatever it is into a class.
 * Don't let files get too large (over 1500 lines of code). Currently, existing huge files (`game.cpp`, `server.cpp`, …) are in the slow process of being cleaned up.
 
 
-# Files
+## Files
 
 * Files should be named using *snake_case* style.
 * Files should have includes for everything that they depend on. Don't depend on, eg, `"util/numeric.h"` including `<string>`!
@@ -202,7 +200,7 @@ class Foo {
 * All files should include the appropriate license header.
 
 
-# Miscellaneous
+## Miscellaneous
 
 * <span style="color: red">Do **not** use `or`, use `||`.</span>
 * Set pointer values to `nullptr` (C++11), not 0.
@@ -215,4 +213,3 @@ class Foo {
 * In `switch-case` statements, add `break` to the last case and to the `default` case.
 * In `if-else` statements, put the code which is more likely to be executed first.
 * For consistency, use American English where spellings differ (e.g. use "color", not "colour").
-

--- a/doc/code_style_guidelines.md
+++ b/doc/code_style_guidelines.md
@@ -2,7 +2,7 @@
 
 This is the coding style used for C/C++ code. Also see the Lua code style guidelines.
 
-The coding style is based on the <https://www.kernel.org/doc/html/latest/process/coding-style.html Linux kernel code style>. Much of the existing code doesn't follow the current code style guidelines, do not try to replicate that. Use your best judgment for C++-specific syntax.
+The coding style is based on the [Linux kernel code style](https://www.kernel.org/doc/html/latest/process/coding-style.html). Much of the existing code doesn't follow the current code style guidelines, do not try to replicate that. Use your best judgment for C++-specific syntax.
 
 Currently, the code uses C++14. Do not use features that depend on more recent versions.
 

--- a/doc/code_style_guidelines.md
+++ b/doc/code_style_guidelines.md
@@ -1,0 +1,218 @@
+
+Code style guidelines
+=====================
+
+This is the coding style used for C/C++ code. Also see the Lua code style guidelines.
+
+The coding style is based on the <https://www.kernel.org/doc/html/latest/process/coding-style.html Linux kernel code style>. Much of the existing code doesn't follow the current code style guidelines, do not try to replicate that. Use your best judgment for C++-specific syntax.
+
+Currently, the code uses C++14. Do not use features that depend on more recent versions.
+
+
+# Spelling
+
+Use American English, but avoid idioms that may be difficult to understand by non-native speakers.
+
+
+# Function declarations
+
+In case your function parameters don't fit within the defined line length, use the following style.
+Indention for continuation lines is **exactly** two tabs.
+
+```cpp
+void some_function_name(type1 param1, type2 param2, type3 param3,
+		type4 param4, type5 param5, type6 param6, type7 param7)
+{
+	...
+}
+```
+
+Sometimes with complex function declarations, it might be messy to define as many parameters as possible on the same line.
+This is acceptable too (and currently used in some places):
+
+```cpp
+void some_function_name(
+		const ReallyBigLongTypeName &param1,
+		ReallyBigLongTypeName *param2,
+		void *param3,
+		size_t param4,
+		const void *param5,
+		size_t param6)
+{
+	...
+}
+```
+
+No more than 7 parameters allowed (except for constructors).
+
+
+# Spaces
+
+* <span style="color: red">Do **not** use spaces to indent.</span>
+* Try to stay under 6 levels of indentation.
+* Add spaces between operators so they line up when appropriate (don't go overboard). For example:
+
+```cpp
+np_terrain_base   = settings->getNoiseParams("mgv6_np_terrain_base");
+np_terrain_higher = settings->getNoiseParams("mgv6_np_terrain_higher");
+np_steepness      = settings->getNoiseParams("mgv6_np_steepness");
+np_height_select  = settings->getNoiseParams("mgv6_np_height_select");
+...
+bool success =
+		np_terrain_base  && np_terrain_higher && np_steepness &&
+		np_height_select && np_trees          && np_mud       &&
+		np_beach         && np_biome          && np_cave;
+```
+  The above code looks really nice.
+
+* Separate different parts of functions with newlines for readability.
+* Separate functions by two newlines (not necessary, but encouraged).
+* Use a space after `if`, `else`, `for`, `do`, `while`, `switch`, `case`, `try`, `catch`, etc.
+* When breaking conditionals, indent following lines of the conditional with two tabs and the statement body with one tab. For example:
+
+```cpp
+for (std::vector<std::string>::iterator it = strings.begin();
+		it != strings.end();
+		++it) {
+	*it = it->substr(1, 1);
+}
+```
+
+* Align backslashes for multi-line macros with spaces:
+
+```cpp
+#define FOOBAR(x) do {    \
+	int __temp = (x); \
+	foo(__temp);      \
+} while (0)
+```
+
+
+# Bracing and indentation
+
+## `if` statements
+
+This rule has already been explicitly stated in the [Linux kernel code style](https://www.kernel.org/doc/html/latest/process/coding-style.html) from which this code style inherits, but it will be repeated here:
+
+<span style="color: red">**Putting the body of an `if` statement on the same line as the condition is strictly prohibited.**</span>
+
+Example:
+```cpp
+if (foobar < 3) foobar = 45;      // Bad
+(foobar < 3 && (foobar = 45));    // Bad
+```
+
+Violating this rule will result in **instant rejection**.
+
+Examples of good if statement wordings:
+```cpp
+if (foobar < 3)
+	foobar = 45;
+
+if (foobar < 6) {
+	foobar = 62;
+	return;
+}
+```
+
+## Nested for loop exception
+
+Special exception to the standard bracing/indent rules for nested loops:
+If a nested loop iterates over a set of coordinates, it is permitted to omit the braces for all but the innermost loop and keep the outer loops at the same indentation level, like so:
+```cpp
+for (s16 z = pmin.Z; z <= pmax.Z, z++)
+for (s16 y = pmin.Y; y <= pmax.Y; y++)
+for (s16 x = pmin.X; x <= pmax.X; x++) {
+	// ... do stuff here ...
+}
+```
+
+
+# Do not be too C++y
+
+* Avoid passing non-`const` references to functions.
+* Don't use initializer lists unless absolutely necessary (initializing an object inside a class, or initializing a reference).
+* Try to minimize the use of exceptions.
+* Avoid operator overloading like the plague.
+* Avoid templates unless they are very convenient.
+* Usage of macros is not discouraged, just don't overdo it [like X.org](http://cgit.freedesktop.org/xorg/xserver/tree/randr/rrscreen.c?id=01e18af17f8dc91451fbd0902049045afd1cea7e#n325). It's better to use inline functions or lambdas instead.
+
+
+# Classes
+
+* **Class names are *PascalCase*, method names are *camelCase*.**
+* Don't put actual code in header files, unless it's a 4-liner, an inline function, or part of a template.
+* Class definitions should go in header files.
+* Substantial methods (over 4 lines) should be defined outside of the class definition.
+* Functions not part of any class should use `lowercase_underscore_style()`.
+
+
+# Comments
+
+* Doxygen comments are acceptable, but **please** put them in the header file.
+* Don't make uninformative comments like this:
+
+```cpp
+// Draw "Loading" screen
+draw_load_screen(L"Loading...", driver, font);
+```
+
+* Add comments to explain a non-trivial but important detail about the code, or explain behavior that is not obvious.
+* For comments with text, be sure to add a space between the text and the comment tokens:
+
+```cpp
+DoThingHere();  // This does thing    <--- yes!
+DoThingHere();  /* This does thing */ <--- yes!
+
+DoThingHere();  //This does thing      <--- no!
+DoThingHere();  /*This does thing*/    <--- no!
+DoThingHere();//This does thing        <--- no!
+```
+
+
+# Use STL, avoid Irrlicht containers, and no, Boost will not even be considered, so forget it
+
+* In general, adding new dependencies is considered serious business.
+* We are using C++14; Boost will never be an option.
+
+
+# Don't let things get too large
+
+* **Try to keep lines under 95 characters.** It's okay if it goes over by a few, but do not exaggerate. (Note that this column count assumes 4-space indents.)
+* Functions should not have over 200 lines of code – if you are concerned with having to pass too many parameters to child functions, make whatever it is into a class.
+* Don't let files get too large (over 1500 lines of code). Currently, existing huge files (`game.cpp`, `server.cpp`, …) are in the slow process of being cleaned up.
+
+
+# Files
+
+* Files should be named using *snake_case* style.
+* Files should have includes for everything that they depend on. Don't depend on, eg, `"util/numeric.h"` including `<string>`!
+* Uniqueness when compiling headers is ensured by using `#pragma once`. ([Accepted by all coredevs](https://github.com/minetest/minetest/issues/6259))
+
+```cpp
+#pragma once
+
+#include <string>
+
+class Foo {
+};
+
+```
+
+* All files should include the appropriate license header.
+
+
+# Miscellaneous
+
+* <span style="color: red">Do **not** use `or`, use `||`.</span>
+* Set pointer values to `nullptr` (C++11), not 0.
+* When using floats, add the `f` suffix, e.g. `float k = 0.0f;` and not `float k = 0.0;`.
+* Avoid non-ASCII characters in source files. Other UTF-8 characters may (only) be used in string literals and comments where ASCII would worsen readability.
+* Use of Hungarian notation is very limited. Scope specifiers such as `g_` for globals, `s_` for statics, or `m_` for members are allowed. The prefix `m_` is discouraged for public members in newer code as it is a part of the class' interface, but sometimes needed for consistency when adding a member to older code.
+* Use *snake_case* for local variables, not *camelCase*.
+* Don't use distracting and unnecessary amounts of object-oriented abstraction. See [Terasology](https://github.com/MovingBlocks/Terasology) as an example of what not to do.
+    * Don't add unnecessary design patterns to your code, such as factories/providers/sources.
+* In `switch-case` statements, add `break` to the last case and to the `default` case.
+* In `if-else` statements, put the code which is more likely to be executed first.
+* For consistency, use American English where spellings differ (e.g. use "color", not "colour").
+

--- a/doc/code_style_guidelines.md
+++ b/doc/code_style_guidelines.md
@@ -15,7 +15,7 @@ Use American English, but avoid idioms that may be difficult to understand by no
 ## Function declarations
 
 In case your function parameters don't fit within the defined line length, use the following style.
-Indention for continuation lines is **exactly** two tabs.
+Indention for continuation lines is **exactly** two tabs:
 
 ```cpp
 void some_function_name(type1 param1, type2 param2, type3 param3,
@@ -46,9 +46,11 @@ No more than 7 parameters allowed (except for constructors).
 
 ## Spaces
 
-* <span style="color: red">Do **not** use spaces to indent.</span>
-* Try to stay under 6 levels of indentation.
-* Add spaces between operators so they line up when appropriate (don't go overboard). For example:
+<span style="color: red">Do **not** use spaces to indent.</span>
+
+Try to stay under 6 levels of indentation.
+
+Add spaces between operators so they line up when appropriate (don't go overboard). For example:
 
 ```cpp
 np_terrain_base   = settings->getNoiseParams("mgv6_np_terrain_base");
@@ -61,12 +63,15 @@ bool success =
 		np_height_select && np_trees          && np_mud       &&
 		np_beach         && np_biome          && np_cave;
 ```
-  The above code looks really nice.
+The above code looks really nice.
 
-* Separate different parts of functions with newlines for readability.
-* Separate functions by two newlines (not necessary, but encouraged).
-* Use a space after `if`, `else`, `for`, `do`, `while`, `switch`, `case`, `try`, `catch`, etc.
-* When breaking conditionals, indent following lines of the conditional with two tabs and the statement body with one tab. For example:
+Separate different parts of functions with newlines for readability.
+
+Separate functions by two newlines (not necessary, but encouraged).
+
+Use a space after `if`, `else`, `for`, `do`, `while`, `switch`, `case`, `try`, `catch`, etc.
+
+When breaking conditionals, indent following lines of the conditional with two tabs and the statement body with one tab. For example:
 
 ```cpp
 for (std::vector<std::string>::iterator it = strings.begin();
@@ -76,7 +81,7 @@ for (std::vector<std::string>::iterator it = strings.begin();
 }
 ```
 
-* Align backslashes for multi-line macros with spaces:
+Align backslashes for multi-line macros with spaces:
 
 ```cpp
 #define FOOBAR(x) do {    \
@@ -128,35 +133,46 @@ for (s16 x = pmin.X; x <= pmax.X; x++) {
 
 ## Do not be too C++y
 
-* Avoid passing non-`const` references to functions.
-* Don't use initializer lists unless absolutely necessary (initializing an object inside a class, or initializing a reference).
-* Try to minimize the use of exceptions.
-* Avoid operator overloading like the plague.
-* Avoid templates unless they are very convenient.
-* Usage of macros is not discouraged, just don't overdo it [like X.org](http://cgit.freedesktop.org/xorg/xserver/tree/randr/rrscreen.c?id=01e18af17f8dc91451fbd0902049045afd1cea7e#n325). It's better to use inline functions or lambdas instead.
+Avoid passing non-`const` references to functions.
+
+Don't use initializer lists unless absolutely necessary (initializing an object inside a class, or initializing a reference).
+
+Try to minimize the use of exceptions.
+
+Avoid operator overloading like the plague.
+
+Avoid templates unless they are very convenient.
+
+Usage of macros is not discouraged, just don't overdo it [like X.org](http://cgit.freedesktop.org/xorg/xserver/tree/randr/rrscreen.c?id=01e18af17f8dc91451fbd0902049045afd1cea7e#n325). It's better to use inline functions or lambdas instead.
 
 
 ## Classes
 
-* **Class names are *PascalCase*, method names are *camelCase*.**
-* Don't put actual code in header files, unless it's a 4-liner, an inline function, or part of a template.
-* Class definitions should go in header files.
-* Substantial methods (over 4 lines) should be defined outside of the class definition.
-* Functions not part of any class should use `lowercase_underscore_style()`.
+**Class names are *PascalCase*, method names are *camelCase*.**
+
+Don't put actual code in header files, unless it's a 4-liner, an inline function, or part of a template.
+
+Class definitions should go in header files.
+
+Substantial methods (over 4 lines) should be defined outside of the class definition.
+
+Functions not part of any class should use `lowercase_underscore_style()`.
 
 
 ## Comments
 
-* Doxygen comments are acceptable, but **please** put them in the header file.
-* Don't make uninformative comments like this:
+Doxygen comments are acceptable, but **please** put them in the header file.
+
+Don't make uninformative comments like this:
 
 ```cpp
 // Draw "Loading" screen
 draw_load_screen(L"Loading...", driver, font);
 ```
 
-* Add comments to explain a non-trivial but important detail about the code, or explain behavior that is not obvious.
-* For comments with text, be sure to add a space between the text and the comment tokens:
+Add comments to explain a non-trivial but important detail about the code, or explain behavior that is not obvious.
+
+For comments with text, be sure to add a space between the text and the comment tokens:
 
 ```cpp
 DoThingHere();  // This does thing    <--- yes!
@@ -170,22 +186,27 @@ DoThingHere();//This does thing        <--- no!
 
 ## Use STL, avoid Irrlicht containers, and no, Boost will not even be considered, so forget it
 
-* In general, adding new dependencies is considered serious business.
-* We are using C++14; Boost will never be an option.
+In general, adding new dependencies is considered serious business.
+
+We are using C++14; Boost will never be an option.
 
 
 ## Don't let things get too large
 
-* **Try to keep lines under 95 characters.** It's okay if it goes over by a few, but do not exaggerate. (Note that this column count assumes 4-space indents.)
-* Functions should not have over 200 lines of code – if you are concerned with having to pass too many parameters to child functions, make whatever it is into a class.
-* Don't let files get too large (over 1500 lines of code). Currently, existing huge files (`game.cpp`, `server.cpp`, …) are in the slow process of being cleaned up.
+**Try to keep lines under 95 characters.** It's okay if it goes over by a few, but do not exaggerate. (Note that this column count assumes 4-space indents.)
+
+Functions should not have over 200 lines of code – if you are concerned with having to pass too many parameters to child functions, make whatever it is into a class.
+
+Don't let files get too large (over 1500 lines of code). Currently, existing huge files (`game.cpp`, `server.cpp`, …) are in the slow process of being cleaned up.
 
 
 ## Files
 
-* Files should be named using *snake_case* style.
-* Files should have includes for everything that they depend on. Don't depend on, eg, `"util/numeric.h"` including `<string>`!
-* Uniqueness when compiling headers is ensured by using `#pragma once`. ([Accepted by all coredevs](https://github.com/minetest/minetest/issues/6259))
+Files should be named using *snake_case* style.
+
+Files should have includes for everything that they depend on. Don't depend on, eg, `"util/numeric.h"` including `<string>`!
+
+Uniqueness when compiling headers is ensured by using `#pragma once`. ([Accepted by all coredevs](https://github.com/minetest/minetest/issues/6259))
 
 ```cpp
 #pragma once
@@ -197,19 +218,29 @@ class Foo {
 
 ```
 
-* All files should include the appropriate license header.
+All files should include the appropriate license header.
 
 
 ## Miscellaneous
 
-* <span style="color: red">Do **not** use `or`, use `||`.</span>
-* Set pointer values to `nullptr` (C++11), not 0.
-* When using floats, add the `f` suffix, e.g. `float k = 0.0f;` and not `float k = 0.0;`.
-* Avoid non-ASCII characters in source files. Other UTF-8 characters may (only) be used in string literals and comments where ASCII would worsen readability.
-* Use of Hungarian notation is very limited. Scope specifiers such as `g_` for globals, `s_` for statics, or `m_` for members are allowed. The prefix `m_` is discouraged for public members in newer code as it is a part of the class' interface, but sometimes needed for consistency when adding a member to older code.
-* Use *snake_case* for local variables, not *camelCase*.
-* Don't use distracting and unnecessary amounts of object-oriented abstraction. See [Terasology](https://github.com/MovingBlocks/Terasology) as an example of what not to do.
-    * Don't add unnecessary design patterns to your code, such as factories/providers/sources.
-* In `switch-case` statements, add `break` to the last case and to the `default` case.
-* In `if-else` statements, put the code which is more likely to be executed first.
-* For consistency, use American English where spellings differ (e.g. use "color", not "colour").
+<span style="color: red">Do **not** use `or`, use `||`.</span>
+
+Set pointer values to `nullptr` (C++11), not 0.
+
+When using floats, add the `f` suffix, e.g. `float k = 0.0f;` and not `float k = 0.0;`.
+
+Avoid non-ASCII characters in source files. Other UTF-8 characters may (only) be used in string literals and comments where ASCII would worsen readability.
+
+Use of Hungarian notation is very limited. Scope specifiers such as `g_` for globals, `s_` for statics, or `m_` for members are allowed. The prefix `m_` is discouraged for public members in newer code as it is a part of the class' interface, but sometimes needed for consistency when adding a member to older code.
+
+Use *snake_case* for local variables, not *camelCase*.
+
+Don't use distracting and unnecessary amounts of object-oriented abstraction. See [Terasology](https://github.com/MovingBlocks/Terasology) as an example of what not to do.
+
+Don't add unnecessary design patterns to your code, such as factories/providers/sources.
+
+In `switch-case` statements, add `break` to the last case and to the `default` case.
+
+In `if-else` statements, put the code which is more likely to be executed first.
+
+For consistency, use American English where spellings differ (e.g. use "color", not "colour").

--- a/doc/lua_code_style_guidelines.md
+++ b/doc/lua_code_style_guidelines.md
@@ -7,11 +7,11 @@ Note that these are only *guidelines* for more readable code.  In some (rare) ca
 
 ## Comments
 
-* Incorrect or outdated comments are worse than no comments.
+Incorrect or outdated comments are worse than no comments.
 
-* Avoid inline comments, unless they're very short.
+Avoid inline comments, unless they're very short.
 
-* Write comments to clarify anything that may be confusing. Don't write comments that describe things that are obvious from the code.
+Write comments to clarify anything that may be confusing. Don't write comments that describe things that are obvious from the code:
 
 <span style="color: #282;">Good:</span>
 ```lua
@@ -23,29 +23,29 @@ width = width - 2  -- Adjust for 1px border on each side
 width = width - 2  -- Decrement width by two
 ```
 
-* Comments should follow English grammar rules, this means **starting with a capital letter**, using commas and apostrophes where appropriate, and **ending with a period**. The period may be omitted in single-sentence comments. If the first word of a comment is an identifier, its casing should not be changed. **Check the spelling.**
+Comments should follow English grammar rules, this means **starting with a capital letter**, using commas and apostrophes where appropriate, and **ending with a period**. The period may be omitted in single-sentence comments. If the first word of a comment is an identifier, its casing should not be changed. **Check the spelling.** Examples:
 ```lua
 -- This is a properly formatted comment.
 -- This isnt.              (missing apostrophe)
 -- neither is this.        (lowercase first letter)
 ```
 
-* Comments should have a space between the comment characters and the first word.
+Comments should have a space between the comment characters and the first word:
 ```lua
 --This is wrong.
 -- This is right.
 ```
 
-* Inline comments should be separated from the code by two spaces.
+Inline comments should be separated from the code by two spaces:
 ```lua
 foo()  -- A proper comment.
 ```
 
-* If you write comments for a documentation generation tool, write the comments in LuaDoc format.
+If you write comments for a documentation generation tool, write the comments in LuaDoc format.
 
-* Short multi-line comments should use the regular single-line comment style.
+Short multi-line comments should use the regular single-line comment style.
 
-* Long multi-line comments should use Lua's multi-line comment format with no leading characters except a `--` before the closer.
+Long multi-line comments should use Lua's multi-line comment format with no leading characters except a `--` before the closer:
 ```lua
 --[[
 Very long
@@ -56,14 +56,14 @@ multi-line comment.
 
 ## Lines, spaces, and indentation
 
-* Indentation is done with one tab per indentation level.
+Indentation is done with one tab per indentation level.
 
-* **Lines are wrapped at 80 characters** where possible, with a hard limit of 90.  If you need more you're probably doing something wrong.
+**Lines are wrapped at 80 characters** where possible, with a hard limit of 90.  If you need more you're probably doing something wrong.
 
 
 ### Continuation lines
 
-* Conditional expressions have continuation lines indented by two tabs.
+Conditional expressions have continuation lines indented by two tabs:
 ```lua
 if long_function_call(with, many, arguments) and
 		another_function_call() then
@@ -71,7 +71,7 @@ if long_function_call(with, many, arguments) and
 end
 ```
 
-* Function arguments are indented by two tabs if multiple arguments are in a line, same for definition continuations.
+Function arguments are indented by two tabs if multiple arguments are in a line, same for definition continuations:
 ```lua
 foo(bar, biz, "This is a long string..."
 		baz, qux, "Lua")
@@ -82,7 +82,7 @@ function foo(a, b, c, d,
 end
 ```
 
-* If the function arguments contain a table, it's indented by one tab and if the arguments get own lines, it's indented like a table.
+If the function arguments contain a table, it's indented by one tab and if the arguments get own lines, it's indented like a table:
 ```lua
 register_node("name", {
 	"This is a long string...",
@@ -98,7 +98,7 @@ list = filterlist.create(
 )
 ```
 
-* When strings don't fit into the line, you should add the string (changes) to the next line(s) indented by one tab.
+When strings don't fit into the line, you should add the string (changes) to the next line(s) indented by one tab:
 ```lua
 longvarname = longvarname ..
 	"Thanks for reading this example!"
@@ -109,7 +109,7 @@ local retval =
 	"label[1.75,0;" .. data.worldspec.name .. "]"
 ```
 
-* When breaking around a binary operator you should break after the operator.
+When breaking around a binary operator you should break after the operator:
 ```lua
 if a or b or c or d or
 		e or f then
@@ -120,11 +120,11 @@ end
 
 ### Empty lines
 
-* Use a single empty line to separate sections of long functions.
+Use a single empty line to separate sections of long functions.
 
-* Use two empty lines to separate top-level functions and large tables.
+Use two empty lines to separate top-level functions and large tables.
 
-* Do not use a empty line after conditional, looping, or function opening statements.
+Do not use a empty line after conditional, looping, or function opening statements:
 
 <span style="color: #282;">Good:</span>
 ```lua
@@ -146,11 +146,11 @@ function foo()
 end
 ```
 
-* Don't leave white-space at the end of lines.
+Don't leave white-space at the end of lines.
 
 ### Spaces
 
-* Spaces are not used around parenthesis, brackets, or curly braces.
+Spaces are not used around parenthesis, brackets, or curly braces:
 
 <span style="color: #282;">Good:</span>
 ```lua
@@ -164,7 +164,7 @@ foo ( { baz=true } )
 bar [ 1 ]
 ```
 
-* Spaces are used after, but not before, commas and semicolons.
+Spaces are used after, but not before, commas and semicolons:
 
 <span style="color: #282;">Good:</span>
 ```lua
@@ -176,11 +176,12 @@ foo(a, b, {c, d})
 foo(a,b,{c , d})
 ```
 
-* Spaces are used around binary operators with following exceptions:
-    * There mustn't be spaces around the member access operator (".")
-    * Spaces around the concatenation operator ("..") are optional.
-    * In short one-line table definitions the spaces around the equals sign can be omitted.
-    * When in-/decrementing a variable by 1, the spaces around the + and - operator can be omitted if you want to "get the neighbour" of something, e.g. when increasing some counter variable.
+Spaces are used around binary operators with following exceptions:
+
+* There mustn't be spaces around the member access operator (".")
+* Spaces around the concatenation operator ("..") are optional.
+* In short one-line table definitions the spaces around the equals sign can be omitted.
+* When in-/decrementing a variable by 1, the spaces around the + and - operator can be omitted if you want to "get the neighbour" of something, e.g. when increasing some counter variable.
 
 <span style="color: #282;">Good:</span>
 ```lua
@@ -205,7 +206,7 @@ local def={
 playerpos.y = playerpos.y+1  -- playerpos.y is not an integer
 ```
 
-* Use spaces to align related things, but don't go overboard:
+Use spaces to align related things, but don't go overboard:
 
 <span style="color: #282;">Good:</span>
 ```lua
@@ -226,7 +227,7 @@ local unrelated = {}
 
 ### Tables
 
-* **Small tables may be placed on one line.**  Large tables have one entry per line, with the opening and closing braces on lines without items; and with a comma after the last item.
+**Small tables may be placed on one line.**  Large tables have one entry per line, with the opening and closing braces on lines without items; and with a comma after the last item:
 
 <span style="color: #282;">Good:</span>
 ```lua
@@ -249,7 +250,7 @@ foo = {
 }
 ```
 
-* In list-style tables where each element is short multiple elements may be placed on each line.
+In list-style tables where each element is short multiple elements may be placed on each line:
 ```lua
 local first_eight_letters = {
 	"a", "b", "c", "d",
@@ -260,18 +261,18 @@ local first_eight_letters = {
 
 ## Naming
 
-* **Functions and variables should be named in `lowercase_underscore_style`**, with the exception of constructor-like functions such as `PseudoRandom()`, which should use UpperCamelCase.
+**Functions and variables should be named in `lowercase_underscore_style`**, with the exception of constructor-like functions such as `PseudoRandom()`, which should use UpperCamelCase.
 
-* Don't invent compound words.  Common words like `filename` are okay, but mashes like `getbox` and `collisiondetection` aren't.
+Don't invent compound words.  Common words like `filename` are okay, but mashes like `getbox` and `collisiondetection` aren't.
 
-* Avoid leading and/or trailing underscores.  They're ugly and can be hard to see.
+Avoid leading and/or trailing underscores.  They're ugly and can be hard to see.
 
 
 ## Misc
 
-* Don't put multiple statements on the same line.
+Don't put multiple statements on the same line.
 
-* You can put conditionals / loops with small conditions and bodies on one line.  This is discouraged for all but the smallest ones though.
+You can put conditionals / loops with small conditions and bodies on one line.  This is discouraged for all but the smallest ones though:
 
 <span style="color: #282;">Good:</span>
 ```lua
@@ -289,7 +290,7 @@ end
 if not f and use_error then error(err) elseif not f then return err end
 ```
 
-* Don't compare values explicitly to `true`, `false`, or `nil`, unless it's really needed.
+Don't compare values explicitly to `true`, `false`, or `nil`, unless it's really needed:
 
 <span style="color: #282;">Good:</span>
 ```lua
@@ -311,14 +312,14 @@ end
 if f == nil then return err end
 ```
 
-* Don't use unnecessary parenthesis unless they improve readability a lot.
+Don't use unnecessary parenthesis unless they improve readability a lot:
 ```lua
 if y then bar() end -- Good
 if (not x) then foo() end -- Bad
 ```
 
-* Write function definitions of the form `function foo()` instead of the lambda form `foo = function()`, except when inserting functions in tables inline, where only the second form will work.
+Write function definitions of the form `function foo()` instead of the lambda form `foo = function()`, except when inserting functions in tables inline, where only the second form will work.
 
-* **Avoid globals like the plague.**  The only globals that you should create are namespace tables&mdash;and even those might eventually be phased out.
+**Avoid globals like the plague.**  The only globals that you should create are namespace tables&mdash;and even those might eventually be phased out.
 
-* Don't let functions get too large.  Maximum length depends on complexity; simple functions can be longer than complex functions.
+Don't let functions get too large.  Maximum length depends on complexity; simple functions can be longer than complex functions.

--- a/doc/lua_code_style_guidelines.md
+++ b/doc/lua_code_style_guidelines.md
@@ -13,12 +13,12 @@ Avoid inline comments, unless they're very short.
 
 Write comments to clarify anything that may be confusing. Don't write comments that describe things that are obvious from the code:
 
-<span style="color: #282;">Good:</span>
+Good:
 ```lua
 width = width - 2  -- Adjust for 1px border on each side
 ```
 
-<span style="color: #b44;">Bad:
+Bad:
 ```lua
 width = width - 2  -- Decrement width by two
 ```
@@ -126,7 +126,7 @@ Use two empty lines to separate top-level functions and large tables.
 
 Do not use a empty line after conditional, looping, or function opening statements:
 
-<span style="color: #282;">Good:</span>
+Good:
 ```lua
 function foo()
 	if x then
@@ -135,7 +135,7 @@ function foo()
 end
 ```
 
-<span style="color: #b44;">Bad:</span>
+Bad:
 ```lua
 function foo()
 
@@ -152,13 +152,13 @@ Don't leave white-space at the end of lines.
 
 Spaces are not used around parenthesis, brackets, or curly braces:
 
-<span style="color: #282;">Good:</span>
+Good:
 ```lua
 foo({baz=true})
 bar[1] = "Hello world"
 ```
 
-<span style="color: #b44;">Bad:</span>
+Bad:
 ```lua
 foo ( { baz=true } )
 bar [ 1 ]
@@ -166,12 +166,12 @@ bar [ 1 ]
 
 Spaces are used after, but not before, commas and semicolons:
 
-<span style="color: #282;">Good:</span>
+Good:
 ```lua
 foo(a, b, {c, d})
 ```
 
-<span style="color: #b44;">Bad:</span>
+Bad:
 ```lua
 foo(a,b,{c , d})
 ```
@@ -183,7 +183,7 @@ Spaces are used around binary operators with following exceptions:
 * In short one-line table definitions the spaces around the equals sign can be omitted.
 * When in-/decrementing a variable by 1, the spaces around the + and - operator can be omitted if you want to "get the neighbour" of something, e.g. when increasing some counter variable.
 
-<span style="color: #282;">Good:</span>
+Good:
 ```lua
 local num = 2 * (3 / 4)
 foo({bar=true})
@@ -196,7 +196,7 @@ i = i+1
 sometable[#sometable+1] = v
 ```
 
-<span style="color: #b44;">Bad:</span>
+Bad:
 ```lua
 local num=2*(3/4)
 local def={
@@ -208,7 +208,7 @@ playerpos.y = playerpos.y+1  -- playerpos.y is not an integer
 
 Use spaces to align related things, but don't go overboard:
 
-<span style="color: #282;">Good:</span>
+Good:
 ```lua
 local node_up   = minetest.get_node(pos_up)
 local node_down = minetest.get_node(pos_down)
@@ -216,7 +216,7 @@ local node_down = minetest.get_node(pos_down)
 local node_up_1_east_2_north_3 = minetest.get_node(pos_up_1_east_2_north_3)
 ```
 
-<span style="color: #b44;">Bad:</span>
+Bad:
 ```lua
 local x                       = true
 local very_long_variable_name = false
@@ -229,7 +229,7 @@ local unrelated = {}
 
 **Small tables may be placed on one line.**  Large tables have one entry per line, with the opening and closing braces on lines without items; and with a comma after the last item:
 
-<span style="color: #282;">Good:</span>
+Good:
 ```lua
 local foo = {bar=true}
 foo = {
@@ -239,7 +239,7 @@ foo = {
 }
 ```
 
-<span style="color: #b44;">Bad:</span>
+Bad:
 ```lua
 foo = {bar = 0,
 	biz = 1,
@@ -274,7 +274,7 @@ Don't put multiple statements on the same line.
 
 You can put conditionals / loops with small conditions and bodies on one line.  This is discouraged for all but the smallest ones though:
 
-<span style="color: #282;">Good:</span>
+Good:
 ```lua
 local f, err = io.open(filename, "r")
 if not f then return err end
@@ -285,14 +285,14 @@ elseif qux then return qux
 end
 ```
 
-<span style="color: #b44;">Bad:</span>
+Bad:
 ```lua
 if not f and use_error then error(err) elseif not f then return err end
 ```
 
 Don't compare values explicitly to `true`, `false`, or `nil`, unless it's really needed:
 
-<span style="color: #282;">Good:</span>
+Good:
 ```lua
 local f, err = io.open(filename, "r")
 if not f then return err end
@@ -307,7 +307,7 @@ for i = 1, 5 do
 end
 ```
 
-<span style="color: #b44;">Bad:</span>
+Bad:
 ```lua
 if f == nil then return err end
 ```

--- a/doc/lua_code_style_guidelines.md
+++ b/doc/lua_code_style_guidelines.md
@@ -1,14 +1,11 @@
-
-Lua code style guidelines
-=========================
+# Lua code style guidelines
 
 This is largely based on [the Python style guide](https://www.python.org/dev/peps/pep-0008) except for some indentation and language syntax differences.  When in doubt, consult that guide.
 
 Note that these are only *guidelines* for more readable code.  In some (rare) cases they may result in *less* readable code.  Use your best judgement.
 
 
-Comments
---------
+## Comments
 
 * Incorrect or outdated comments are worse than no comments.
 
@@ -57,15 +54,14 @@ multi-line comment.
 ```
 
 
-Lines, spaces, and indentation
-------------------------------
+## Lines, spaces, and indentation
 
 * Indentation is done with one tab per indentation level.
 
 * **Lines are wrapped at 80 characters** where possible, with a hard limit of 90.  If you need more you're probably doing something wrong.
 
 
-# Continuation lines
+### Continuation lines
 
 * Conditional expressions have continuation lines indented by two tabs.
 ```lua
@@ -122,7 +118,7 @@ end
 ```
 
 
-# Empty lines
+### Empty lines
 
 * Use a single empty line to separate sections of long functions.
 
@@ -152,7 +148,7 @@ end
 
 * Don't leave white-space at the end of lines.
 
-# Spaces
+### Spaces
 
 * Spaces are not used around parenthesis, brackets, or curly braces.
 
@@ -228,7 +224,7 @@ local foobar    = true
 local unrelated = {}
 ```
 
-# Tables
+### Tables
 
 * **Small tables may be placed on one line.**  Large tables have one entry per line, with the opening and closing braces on lines without items; and with a comma after the last item.
 
@@ -262,8 +258,7 @@ local first_eight_letters = {
 ```
 
 
-Naming
-------
+## Naming
 
 * **Functions and variables should be named in `lowercase_underscore_style`**, with the exception of constructor-like functions such as `PseudoRandom()`, which should use UpperCamelCase.
 
@@ -272,8 +267,7 @@ Naming
 * Avoid leading and/or trailing underscores.  They're ugly and can be hard to see.
 
 
-Misc
-----
+## Misc
 
 * Don't put multiple statements on the same line.
 

--- a/doc/lua_code_style_guidelines.md
+++ b/doc/lua_code_style_guidelines.md
@@ -320,6 +320,6 @@ if (not x) then foo() end -- Bad
 
 Write function definitions of the form `function foo()` instead of the lambda form `foo = function()`, except when inserting functions in tables inline, where only the second form will work.
 
-**Avoid globals like the plague.**  The only globals that you should create are namespace tables&mdash;and even those might eventually be phased out.
+**Avoid globals like the plague.** The only globals that you should create are namespace tables&mdash;and even those might eventually be phased out.
 
-Don't let functions get too large.  Maximum length depends on complexity; simple functions can be longer than complex functions.
+Don't let functions get too large. Maximum length depends on complexity; simple functions can be longer than complex functions.

--- a/doc/lua_code_style_guidelines.md
+++ b/doc/lua_code_style_guidelines.md
@@ -1,0 +1,330 @@
+
+Lua code style guidelines
+=========================
+
+This is largely based on [the Python style guide](https://www.python.org/dev/peps/pep-0008) except for some indentation and language syntax differences.  When in doubt, consult that guide.
+
+Note that these are only *guidelines* for more readable code.  In some (rare) cases they may result in *less* readable code.  Use your best judgement.
+
+
+Comments
+--------
+
+* Incorrect or outdated comments are worse than no comments.
+
+* Avoid inline comments, unless they're very short.
+
+* Write comments to clarify anything that may be confusing. Don't write comments that describe things that are obvious from the code.
+
+<span style="color: #282;">Good:</span>
+```lua
+width = width - 2  -- Adjust for 1px border on each side
+```
+
+<span style="color: #b44;">Bad:
+```lua
+width = width - 2  -- Decrement width by two
+```
+
+* Comments should follow English grammar rules, this means **starting with a capital letter**, using commas and apostrophes where appropriate, and **ending with a period**. The period may be omitted in single-sentence comments. If the first word of a comment is an identifier, its casing should not be changed. **Check the spelling.**
+```lua
+-- This is a properly formatted comment.
+-- This isnt.              (missing apostrophe)
+-- neither is this.        (lowercase first letter)
+```
+
+* Comments should have a space between the comment characters and the first word.
+```lua
+--This is wrong.
+-- This is right.
+```
+
+* Inline comments should be separated from the code by two spaces.
+```lua
+foo()  -- A proper comment.
+```
+
+* If you write comments for a documentation generation tool, write the comments in LuaDoc format.
+
+* Short multi-line comments should use the regular single-line comment style.
+
+* Long multi-line comments should use Lua's multi-line comment format with no leading characters except a `--` before the closer.
+```lua
+--[[
+Very long
+multi-line comment.
+--]]
+```
+
+
+Lines, spaces, and indentation
+------------------------------
+
+* Indentation is done with one tab per indentation level.
+
+* **Lines are wrapped at 80 characters** where possible, with a hard limit of 90.  If you need more you're probably doing something wrong.
+
+
+# Continuation lines
+
+* Conditional expressions have continuation lines indented by two tabs.
+```lua
+if long_function_call(with, many, arguments) and
+		another_function_call() then
+	do_something()
+end
+```
+
+* Function arguments are indented by two tabs if multiple arguments are in a line, same for definition continuations.
+```lua
+foo(bar, biz, "This is a long string..."
+		baz, qux, "Lua")
+
+function foo(a, b, c, d,
+		e, f, g, h)
+	[…]
+end
+```
+
+* If the function arguments contain a table, it's indented by one tab and if the arguments get own lines, it's indented like a table.
+```lua
+register_node("name", {
+	"This is a long string...",
+	0.3,
+})
+
+list = filterlist.create(
+	preparemodlist,
+	comparemod,
+	function()
+		return "no comma at the end"
+	end
+)
+```
+
+* When strings don't fit into the line, you should add the string (changes) to the next line(s) indented by one tab.
+```lua
+longvarname = longvarname ..
+	"Thanks for reading this example!"
+
+local retval =
+	"size[11.5,7.5,true]" ..
+	"label[0.5,0;" .. fgettext("World:") .. "]" ..
+	"label[1.75,0;" .. data.worldspec.name .. "]"
+```
+
+* When breaking around a binary operator you should break after the operator.
+```lua
+if a or b or c or d or
+		e or f then
+	foo()
+end
+```
+
+
+# Empty lines
+
+* Use a single empty line to separate sections of long functions.
+
+* Use two empty lines to separate top-level functions and large tables.
+
+* Do not use a empty line after conditional, looping, or function opening statements.
+
+<span style="color: #282;">Good:</span>
+```lua
+function foo()
+	if x then
+		bar()
+	end
+end
+```
+
+<span style="color: #b44;">Bad:</span>
+```lua
+function foo()
+
+	if x then
+
+		bar()
+	end
+end
+```
+
+* Don't leave white-space at the end of lines.
+
+# Spaces
+
+* Spaces are not used around parenthesis, brackets, or curly braces.
+
+<span style="color: #282;">Good:</span>
+```lua
+foo({baz=true})
+bar[1] = "Hello world"
+```
+
+<span style="color: #b44;">Bad:</span>
+```lua
+foo ( { baz=true } )
+bar [ 1 ]
+```
+
+* Spaces are used after, but not before, commas and semicolons.
+
+<span style="color: #282;">Good:</span>
+```lua
+foo(a, b, {c, d})
+```
+
+<span style="color: #b44;">Bad:</span>
+```lua
+foo(a,b,{c , d})
+```
+
+* Spaces are used around binary operators with following exceptions:
+    * There mustn't be spaces around the member access operator (".")
+    * Spaces around the concatenation operator ("..") are optional.
+    * In short one-line table definitions the spaces around the equals sign can be omitted.
+    * When in-/decrementing a variable by 1, the spaces around the + and - operator can be omitted if you want to "get the neighbour" of something, e.g. when increasing some counter variable.
+
+<span style="color: #282;">Good:</span>
+```lua
+local num = 2 * (3 / 4)
+foo({bar=true})
+foo({bar = true})
+local def = {
+	foo = true,
+	bar = false,
+}
+i = i+1
+sometable[#sometable+1] = v
+```
+
+<span style="color: #b44;">Bad:</span>
+```lua
+local num=2*(3/4)
+local def={
+	foo=true,
+	bar=false,
+}
+playerpos.y = playerpos.y+1  -- playerpos.y is not an integer
+```
+
+* Use spaces to align related things, but don't go overboard:
+
+<span style="color: #282;">Good:</span>
+```lua
+local node_up   = minetest.get_node(pos_up)
+local node_down = minetest.get_node(pos_down)
+-- Too long relative to the other lines, don't align with it
+local node_up_1_east_2_north_3 = minetest.get_node(pos_up_1_east_2_north_3)
+```
+
+<span style="color: #b44;">Bad:</span>
+```lua
+local x                       = true
+local very_long_variable_name = false
+
+local foobar    = true
+local unrelated = {}
+```
+
+# Tables
+
+* **Small tables may be placed on one line.**  Large tables have one entry per line, with the opening and closing braces on lines without items; and with a comma after the last item.
+
+<span style="color: #282;">Good:</span>
+```lua
+local foo = {bar=true}
+foo = {
+	bar = 0,
+	biz = 1,
+	baz = 2,
+}
+```
+
+<span style="color: #b44;">Bad:</span>
+```lua
+foo = {bar = 0,
+	biz = 1,
+	baz = 2}
+foo = {
+	bar = 0, biz = 1,
+	baz = 2
+}
+```
+
+* In list-style tables where each element is short multiple elements may be placed on each line.
+```lua
+local first_eight_letters = {
+	"a", "b", "c", "d",
+	"e", "f", "g", "h",
+}
+```
+
+
+Naming
+------
+
+* **Functions and variables should be named in `lowercase_underscore_style`**, with the exception of constructor-like functions such as `PseudoRandom()`, which should use UpperCamelCase.
+
+* Don't invent compound words.  Common words like `filename` are okay, but mashes like `getbox` and `collisiondetection` aren't.
+
+* Avoid leading and/or trailing underscores.  They're ugly and can be hard to see.
+
+
+Misc
+----
+
+* Don't put multiple statements on the same line.
+
+* You can put conditionals / loops with small conditions and bodies on one line.  This is discouraged for all but the smallest ones though.
+
+<span style="color: #282;">Good:</span>
+```lua
+local f, err = io.open(filename, "r")
+if not f then return err end
+
+if     foo then return foo
+elseif bar then return bar
+elseif qux then return qux
+end
+```
+
+<span style="color: #b44;">Bad:</span>
+```lua
+if not f and use_error then error(err) elseif not f then return err end
+```
+
+* Don't compare values explicitly to `true`, `false`, or `nil`, unless it's really needed.
+
+<span style="color: #282;">Good:</span>
+```lua
+local f, err = io.open(filename, "r")
+if not f then return err end
+
+local t = {"a", true, false}
+for i = 1, 5 do
+	-- Needs an explicit nil check to avoid triggering
+	-- on false, which is a valid value.
+	if t[i] == nil then
+		t[i] = "Default"
+	end
+end
+```
+
+<span style="color: #b44;">Bad:</span>
+```lua
+if f == nil then return err end
+```
+
+* Don't use unnecessary parenthesis unless they improve readability a lot.
+```lua
+if y then bar() end -- Good
+if (not x) then foo() end -- Bad
+```
+
+* Write function definitions of the form `function foo()` instead of the lambda form `foo = function()`, except when inserting functions in tables inline, where only the second form will work.
+
+* **Avoid globals like the plague.**  The only globals that you should create are namespace tables&mdash;and even those might eventually be phased out.
+
+* Don't let functions get too large.  Maximum length depends on complexity; simple functions can be longer than complex functions.


### PR DESCRIPTION
* Moves https://dev.minetest.net/Code_style_guidelines and https://dev.minetest.net/Lua_code_style_guidelines into the repo, formatted as markdown.
* No contents are changed.
* Rationale:
  * ~~The script things on the dev wiki are broken.~~ Language syntax is still broken though.
  * We can make PRs to discuss and edit the guidelines.
* Issues that I don't know how to fix:
  * The red color is not displayed by github. => Color was removed.
  * ~~How to get the code nicely indented relative to the bullet point?~~ Bullet lists are replaced with paragraphs.
  * (I don't know why, but markdown looks ugly imho, compared to the wiki text.)

## To do

This PR is a Ready for Review.

## How to test

* :eye: :lips: :eye:. Other configurations, like :eye: :lips: :black_circle:, are also fine.
* Make sure the content is the same as on the dev wiki.
* Look for style issues.
