### PR TITLE
Replace XOR with complement for bitflip

### DIFF
--- a/src/util/sha1.cpp
+++ b/src/util/sha1.cpp
@@ -103,7 +103,7 @@ void SHA1::process()
 	{
 		if( t < 20 ) {
 			K = 0x5a827999;
-			f = (b & c) | ((b ^ 0xFFFFFFFF) & d);//TODO: try using ~
+			f = (b & c) | ((~b) & d);
 		} else if( t < 40 ) {
 			K = 0x6ed9eba1;
 			f = b ^ c ^ d;


### PR DESCRIPTION
This replaces the XOR in the SHA1 computation code with the complement ~. I have tested that it should work with by running the following with compiler optimisations:
```
#include <stdint.h>
#include <assert.h>
#include <inttypes.h>
#include <stdio.h>
int main() {
	uint32_t x = 0;
	for (x=0; x<UINT32_MAX; x+=1) {
		assert(~x == x^0xFFFFFFFF);
	}
	assert(~UINT32_MAX == UINT32_MAX ^ 0xFFFFFFFF);
}
```
This means that for any uint32_t the two are equivalent and therefore this change makes no difference. More simply, compiling without linking gives the exact same object file sha1.o before and after the change, so this safely improves code quality.