### PR TITLE
Pause shader animation timer in singleplayer pause menu

### DIFF
--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -515,7 +515,12 @@ void ClientEnvironment::getSelectedActiveObjects(
 	}
 }
 
-void ClientEnvironment::updateFrameTime()
+void ClientEnvironment::updateFrameTime(bool is_paused)
 {
-	m_frame_time = porting::getTimeMs();
+	// if paused, m_frame_time_pause_accumulator increases by dtime,
+	// otherwise, m_frame_time increases by dtime
+	if (is_paused)
+		m_frame_time_pause_accumulator = porting::getTimeMs() - m_frame_time;
+	else
+		m_frame_time = porting::getTimeMs() - m_frame_time_pause_accumulator;
 }

--- a/src/client/clientenvironment.h
+++ b/src/client/clientenvironment.h
@@ -142,7 +142,7 @@ public:
 	{ m_camera_offset = camera_offset; }
 	v3s16 getCameraOffset() const { return m_camera_offset; }
 
-	void updateFrameTime();
+	void updateFrameTime(bool is_paused);
 	u64 getFrameTime() const { return m_frame_time; }
 
 private:
@@ -157,5 +157,6 @@ private:
 	IntervalLimiter m_active_object_light_update_interval;
 	std::list<std::string> m_player_names;
 	v3s16 m_camera_offset;
-	u64 m_frame_time;
+	u64 m_frame_time = 0;
+	u64 m_frame_time_pause_accumulator = 0;
 };

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1140,16 +1140,16 @@ void Game::run()
 				cam_view.camera_pitch) * m_cache_cam_smoothing;
 		updatePlayerControl(cam_view);
 
-		bool was_paused = m_is_paused;
-		m_is_paused = simple_singleplayer_mode && g_menumgr.pausesGame();
+		{
+			bool was_paused = m_is_paused;
+			m_is_paused = simple_singleplayer_mode && g_menumgr.pausesGame();
+			if (m_is_paused)
+				dtime = 0.0f;
 
-		if (m_is_paused)
-			dtime = 0.0f;
-
-		if (!was_paused && m_is_paused) {
-			pauseAnimation();
-		} else if (was_paused && !m_is_paused) {
-			resumeAnimation();
+			if (!was_paused && m_is_paused)
+				pauseAnimation();
+			else if (was_paused && !m_is_paused)
+				resumeAnimation();
 		}
 
 		if (!m_is_paused)


### PR DESCRIPTION
Other animations (i.e. clouds, object animations, node animations, ...) were already paused.

This is a bugfix.

The calls to `pauseAnimation()` and `resumeAnimation()` are also less hidden in spaghetti. => internal refactor

## To do

This PR is a Ready for Review.

## How to test

* Start a world in singleplayer. Press esc. See how everything (including waving water, leaves and plants) pauses. Press esc again, and see how it resumes at the old frame time.
* Start the game with Host Server ticked. See how it's not paused.