### PR TITLE
Allow getmetatable in CSM

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -292,7 +292,7 @@ void ScriptApiSecurity::initializeSecurityClient()
 		"rawset",
 		"select",
 		"setfenv",
-		// getmetatable can be used to escape the sandbox <- ???
+		"getmetatable",
 		"setmetatable",
 		"tonumber",
 		"tostring",


### PR DESCRIPTION
This is a trivial change. It was claimed that `getmetatable` allowed a sandbox escape. The comment was added in b0baa698a495cc990ce5d9c22763957f1138aed3. This would only be true if userdata metatables were not protected with `__metatable`. If a type of userdata were accidentally not registered, which is what b0baa698a495cc990ce5d9c22763957f1138aed3 fixed, the metatable would not exist in the first place.

This change allows `vector.check` to work in CSM without crashing.

## To do

This PR is Ready for Review.

## How to test

Test that `vector.check` works in a CSM.
