### PR TITLE
Only set quicktune keybinds in debug builds

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -146,11 +146,18 @@ void set_default_settings()
 	settings->setDefault("keymap_slot31", "");
 	settings->setDefault("keymap_slot32", "");
 
-	// Some (temporary) keys for debugging
+#ifndef NDEBUG
+	// Default keybinds for quicktune in debug builds
 	settings->setDefault("keymap_quicktune_prev", "KEY_HOME");
 	settings->setDefault("keymap_quicktune_next", "KEY_END");
 	settings->setDefault("keymap_quicktune_dec", "KEY_NEXT");
 	settings->setDefault("keymap_quicktune_inc", "KEY_PRIOR");
+#else
+	settings->setDefault("keymap_quicktune_prev", "");
+	settings->setDefault("keymap_quicktune_next", "");
+	settings->setDefault("keymap_quicktune_dec", "");
+	settings->setDefault("keymap_quicktune_inc", "");
+#endif
 
 	// Visuals
 #ifdef NDEBUG


### PR DESCRIPTION
This PR disables the default quicktune keybinds in non-debug builds, as the quicktune functionality is only useful for engine development in debug builds anyways and the keybinds interfere with other keybinds mapped onto the numpad. (i.e. I have keybinds on my numpad to start and stop recording with OBS, which also triggers quicktune)

## To do
This PR is a Ready for Review.

## How to test
See that quicktune keybinds exist in debug and not in release...