### PR TITLE
Put server sound handles into userdata

### DIFF
--- a/builtin/game/finish_core_api.lua
+++ b/builtin/game/finish_core_api.lua
@@ -1,0 +1,10 @@
+
+-- old non-method sound functions
+
+function core.sound_stop(handle, ...)
+	return handle:stop(...)
+end
+
+function core.sound_fade(handle, ...)
+	return handle:fade(...)
+end

--- a/builtin/game/init.lua
+++ b/builtin/game/init.lua
@@ -7,6 +7,7 @@ local gamepath   = scriptpath .. "game".. DIR_DELIM
 -- not exposed to outer context
 local builtin_shared = {}
 
+dofile(gamepath .. "finish_core_api.lua")
 dofile(gamepath .. "constants.lua")
 assert(loadfile(commonpath .. "item_s.lua"))(builtin_shared)
 assert(loadfile(gamepath .. "item.lua"))(builtin_shared)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6399,9 +6399,9 @@ Sounds
       Ephemeral sounds will not return a handle and can't be stopped or faded.
       It is recommend to use this for short sounds that happen in response to
       player actions (e.g. door closing).
-* `minetest.sound_stop(handle)`
+* `handle:stop()` or `minetest.sound_stop(handle)`
     * `handle` is a handle returned by `minetest.sound_play`
-* `minetest.sound_fade(handle, step, gain)`
+* `handle:fade(step, gain)` or `minetest.sound_fade(handle, step, gain)`
     * `handle` is a handle returned by `minetest.sound_play`
     * `step` determines how fast a sound will fade.
       The gain will change by this much per second,

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1335,15 +1335,14 @@ void Server::handleCommand_RemovedSounds(NetworkPacket* pkt)
 
 		*pkt >> id;
 
-		std::unordered_map<s32, ServerPlayingSound>::iterator i =
-			m_playing_sounds.find(id);
-		if (i == m_playing_sounds.end())
+		auto it = m_playing_sounds.find(id);
+		if (it == m_playing_sounds.end())
 			continue;
 
-		ServerPlayingSound &psound = i->second;
+		ServerPlayingSound &psound = it->second;
 		psound.clients.erase(pkt->getPeerId());
-		if (psound.clients.empty())
-			m_playing_sounds.erase(i++);
+		if (!psound.grabbed && psound.clients.empty())
+			m_playing_sounds.erase(it);
 	}
 }
 

--- a/src/script/lua_api/CMakeLists.txt
+++ b/src/script/lua_api/CMakeLists.txt
@@ -19,6 +19,7 @@ set(common_SCRIPT_LUA_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/l_playermeta.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_rollback.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_server.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/l_server_sound.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_settings.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_storage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_util.cpp

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -498,43 +498,6 @@ int ModApiServer::l_get_worldpath(lua_State *L)
 	return 1;
 }
 
-// sound_play(spec, parameters, [ephemeral])
-int ModApiServer::l_sound_play(lua_State *L)
-{
-	NO_MAP_LOCK_REQUIRED;
-	ServerPlayingSound params;
-	read_simplesoundspec(L, 1, params.spec);
-	read_server_sound_params(L, 2, params);
-	bool ephemeral = lua_gettop(L) > 2 && readParam<bool>(L, 3);
-	if (ephemeral) {
-		getServer(L)->playSound(params, true);
-		lua_pushnil(L);
-	} else {
-		s32 handle = getServer(L)->playSound(params);
-		lua_pushinteger(L, handle);
-	}
-	return 1;
-}
-
-// sound_stop(handle)
-int ModApiServer::l_sound_stop(lua_State *L)
-{
-	NO_MAP_LOCK_REQUIRED;
-	s32 handle = luaL_checkinteger(L, 1);
-	getServer(L)->stopSound(handle);
-	return 0;
-}
-
-int ModApiServer::l_sound_fade(lua_State *L)
-{
-	NO_MAP_LOCK_REQUIRED;
-	s32 handle = luaL_checkinteger(L, 1);
-	float step = readParam<float>(L, 2);
-	float gain = readParam<float>(L, 3);
-	getServer(L)->fadeSound(handle, step, gain);
-	return 0;
-}
-
 // dynamic_add_media(filepath)
 int ModApiServer::l_dynamic_add_media(lua_State *L)
 {
@@ -680,9 +643,6 @@ void ModApiServer::Initialize(lua_State *L, int top)
 	API_FCT(chat_send_all);
 	API_FCT(chat_send_player);
 	API_FCT(show_formspec);
-	API_FCT(sound_play);
-	API_FCT(sound_stop);
-	API_FCT(sound_fade);
 	API_FCT(dynamic_add_media);
 
 	API_FCT(get_player_information);

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -67,15 +67,6 @@ private:
 	// show_formspec(playername,formname,formspec)
 	static int l_show_formspec(lua_State *L);
 
-	// sound_play(spec, parameters)
-	static int l_sound_play(lua_State *L);
-
-	// sound_stop(handle)
-	static int l_sound_stop(lua_State *L);
-
-	// sound_fade(handle, step, gain)
-	static int l_sound_fade(lua_State *L);
-
 	// dynamic_add_media(filepath)
 	static int l_dynamic_add_media(lua_State *L);
 

--- a/src/script/lua_api/l_server_sound.cpp
+++ b/src/script/lua_api/l_server_sound.cpp
@@ -1,0 +1,129 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "l_server_sound.h"
+#include "l_internal.h"
+#include "common/c_content.h"
+#include "server.h"
+
+/* ModApiServerSound */
+
+// sound_play(spec, parameters, [ephemeral])
+int ModApiServerSound::l_sound_play(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ServerPlayingSound params;
+	read_simplesoundspec(L, 1, params.spec);
+	read_server_sound_params(L, 2, params);
+	bool ephemeral = lua_gettop(L) > 2 && readParam<bool>(L, 3);
+	if (ephemeral) {
+		getServer(L)->playSound(std::move(params), true);
+		lua_pushnil(L);
+	} else {
+		params.grabbed = true;
+		s32 handle = getServer(L)->playSound(std::move(params));
+		ServerSoundHandle::create(L, handle);
+	}
+	return 1;
+}
+
+void ModApiServerSound::Initialize(lua_State *L, int top)
+{
+	API_FCT(sound_play);
+}
+
+/* ServerSoundHandle */
+
+ServerSoundHandle *ServerSoundHandle::checkobject(lua_State *L, int narg)
+{
+	luaL_checktype(L, narg, LUA_TUSERDATA);
+	void *ud = luaL_checkudata(L, narg, className);
+	if (!ud)
+		luaL_typerror(L, narg, className);
+	return *(ServerSoundHandle **)ud; // unbox pointer
+}
+
+int ServerSoundHandle::gc_object(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	std::unique_ptr<ServerSoundHandle> o(*(ServerSoundHandle **)(lua_touserdata(L, 1)));
+	if (getServer(L))
+		getServer(L)->dropSound(o->m_handle);
+	return 0;
+}
+
+// :stop()
+int ServerSoundHandle::l_stop(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ServerSoundHandle *o = checkobject(L, 1);
+	getServer(L)->stopSound(o->m_handle);
+	return 0;
+}
+
+// :fade(step, gain)
+int ServerSoundHandle::l_fade(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ServerSoundHandle *o = checkobject(L, 1);
+	float step = readParam<float>(L, 2);
+	float gain = readParam<float>(L, 3);
+	getServer(L)->fadeSound(o->m_handle, step, gain);
+	return 0;
+}
+
+void ServerSoundHandle::create(lua_State *L, s32 handle)
+{
+	ServerSoundHandle *o = new ServerSoundHandle(handle);
+	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
+	luaL_getmetatable(L, className);
+	lua_setmetatable(L, -2);
+}
+
+void ServerSoundHandle::Register(lua_State *L)
+{
+	lua_newtable(L);
+	int methodtable = lua_gettop(L);
+	luaL_newmetatable(L, className);
+	int metatable = lua_gettop(L);
+
+	lua_pushliteral(L, "__metatable");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
+
+	lua_pushliteral(L, "__index");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__gc");
+	lua_pushcfunction(L, gc_object);
+	lua_settable(L, metatable);
+
+	lua_pop(L, 1);  // drop metatable
+
+	luaL_register(L, nullptr, methods);  // fill methodtable
+	lua_pop(L, 1);  // drop methodtable
+}
+
+const char ServerSoundHandle::className[] = "ServerSoundHandle";
+const luaL_Reg ServerSoundHandle::methods[] = {
+	luamethod(ServerSoundHandle, stop),
+	luamethod(ServerSoundHandle, fade),
+	{0,0}
+};

--- a/src/script/lua_api/l_server_sound.h
+++ b/src/script/lua_api/l_server_sound.h
@@ -1,0 +1,69 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "lua_api/l_base.h"
+#include "util/basic_macros.h"
+
+class ModApiServerSound : public ModApiBase
+{
+private:
+	// sound_play(spec, parameters)
+	static int l_sound_play(lua_State *L);
+
+	// sound_stop(handle)
+	static int l_sound_stop(lua_State *L);
+
+	// sound_fade(handle, step, gain)
+	static int l_sound_fade(lua_State *L);
+
+public:
+	static void Initialize(lua_State *L, int top);
+};
+
+class ServerSoundHandle final : public ModApiBase
+{
+private:
+	s32 m_handle;
+
+	static const char className[];
+	static const luaL_Reg methods[];
+
+	ServerSoundHandle(s32 handle) : m_handle(handle) {}
+
+	DISABLE_CLASS_COPY(ServerSoundHandle)
+
+	static ServerSoundHandle *checkobject(lua_State *L, int narg);
+
+	static int gc_object(lua_State *L);
+
+	// :stop()
+	static int l_stop(lua_State *L);
+
+	// :fade(step, gain)
+	static int l_fade(lua_State *L);
+
+public:
+	~ServerSoundHandle() = default;
+
+	// takes ownership of handle
+	static void create(lua_State *L, s32 handle);
+	static void Register(lua_State *L);
+};

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -45,6 +45,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_settings.h"
 #include "lua_api/l_http.h"
 #include "lua_api/l_storage.h"
+#include "lua_api/l_server_sound.h"
 
 extern "C" {
 #include <lualib.h>
@@ -154,6 +155,7 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	LuaSettings::Register(L);
 	StorageRef::Register(L);
 	ModChannelRef::Register(L);
+	ServerSoundHandle::Register(L);
 
 	// Initialize mod api modules
 	ModApiAuth::Initialize(L, top);
@@ -169,6 +171,7 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	ModApiHttp::Initialize(L, top);
 	ModApiStorage::Initialize(L, top);
 	ModApiChannels::Initialize(L, top);
+	ModApiServerSound::Initialize(L, top);
 }
 
 void ServerScripting::InitializeAsync(lua_State *L, int top)


### PR DESCRIPTION
* Handles now own the s32 handle. It can not be re-used while still used by  another handle in lua.
* Allows method syntax for sound_stop and sound_fade: `handle:fade(...)`, `handle:stop()`
* Most of the logic in `l_server_sound.cpp` comes from `l_server.cpp`. The rest is just boilerplate, and the gc function, which drops the handle.
* In practice the ids won't collide in master either, under normal circumstances, because there are about 0x1p31 possible ids. But: A player could theoretically abuse a mod to play many handles, and eventually influence some other sound. Also, it is somewhat cleaner to check if an id is already used before re-using it.
* I doubt any mod will break because the handle no longer is a number. Why would anyone do arithmetic on it or make it to a string? The worst thing that could happen is that a mod compares it with `-1` (invalid handle, sound play failed), but this won't cause crashes, as the fade and stop functions work with invalid handles.
* I'd construct the sound-handle into the userdata with placement-new, but we don't do that for other types either, for whatever reason.

## To do

~~This PR is a Ready for Review.~~ Edit: It's a draft for now.

## How to test

Use the devtest jukebox, from this branch: https://github.com/Desour/minetest/tree/server_sound_handle_test
