### PR TITLE
Bloom

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -470,6 +470,12 @@ bloom_luminance_threshold (Bloom Luminance Threshold) float 1.0 0.0 2.0
 #    Range: from 0.1 to 10.0, default: 1.0
 bloom_intensity (Bloom Intensity) float 1.0 0.1 10.0
 
+#    Set the radius of the bloom filter in pixels.
+#    Larger values render more glow around bright objects
+#    at the cost of higher resource consumption.
+#    Range: from 1 to 64, default: 3
+bloom_radius (Bloom Radius) int 3 1 64
+
 [*Audio]
 
 #    Volume of all sounds.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -473,7 +473,7 @@ enable_bloom_dedicated_texture (Enable Bloom Dedicated Texture) bool false
 
 #    Set the intensity of bloom
 #    Smaller values make bloom more subtle
-#    Range: from 0.01 to 1.0, default: 1.0
+#    Range: from 0.01 to 1.0, default: 0.05
 bloom_intensity (Bloom Intensity) float 0.05 0.01 1.0
 
 #    Set the radius of the bloom filter in pixels.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -458,7 +458,13 @@ exposure_factor	(Exposure Factor) float 1.0 0.1 10.0
 
 #    Set to true to enable bloom effect.
 #    Bright colors will bleed over the neighboring objects.
-enable_bloom (Enable bloom) bool false
+enable_bloom (Enable Bloom) bool false
+
+#    Set to true to render debugging breakdown of the bloom effect.
+#    In debug mode, the screen is split into 4 quadrants: 
+#    top-left - processed base image, top-right - final image
+#    bottom-left - raw base image, bottom-right - bloom texture.
+enable_bloom_debug (Enable Bloom Debug) bool false
 
 #    Set the intensity of bloom
 #    Smaller values make bloom more subtle

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -460,6 +460,17 @@ exposure_factor	(Exposure Factor) float 1.0 0.1 10.0
 #    Bright colors will bleed over the neighboring objects.
 enable_bloom (Enable bloom) bool false
 
+#    Set the luminance threshold for bleeding colors.
+#    Lower values will cause more blurring of the scene.
+#    Range: from 0.0 to 2.0, Default: 1.0
+bloom_luminance_threshold (Bloom Luminance Threshold) float 1.0 0.0 2.0
+
+#    Set the boost of brightness when bleeding light.
+#    Causes bright colors to appear brighter.
+#    Value of 0.0 (default) does not add any boost.
+#    Range: from 0.0 to 2.0
+bloom_boost (Bloom Boost) float 0.0 0.0 2.0
+
 [*Audio]
 
 #    Volume of all sounds.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -445,6 +445,15 @@ shadow_soft_radius (Soft shadow radius) float 5.0 1.0 15.0
 #    Minimum value: 0.0; maximum value: 60.0
 shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 0.0 60.0
 
+[**Post processing]
+
+#    Set the exposure compensation factor.
+#    This factor is applied to linear color value 
+#    before all other post-processing effects.
+#    Value of 1.0 (default) means no exposure compensation.
+#    Range: from 0.1 to 10.0
+exposure_factor	(Exposure Factor) float 1.0 0.1 10.0
+
 [*Audio]
 
 #    Volume of all sounds.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -454,6 +454,12 @@ shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 0.0 60.0
 #    Range: from 0.1 to 10.0
 exposure_factor	(Exposure Factor) float 1.0 0.1 10.0
 
+[**Bloom]
+
+#    Set to true to enable bloom effect.
+#    Bright colors will bleed over the neighboring objects.
+enable_bloom (Enable bloom) bool false
+
 [*Audio]
 
 #    Volume of all sounds.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -462,13 +462,13 @@ enable_bloom (Enable bloom) bool false
 
 #    Set the intensity of bloom
 #    Smaller values make bloom more subtle
-#    Range: from 0.1 to 10.0, default: 1.0
+#    Range: from 0.01 to 1.0, default: 1.0
 bloom_intensity (Bloom Intensity) float 0.05 0.01 1.0
 
 #    Set the radius of the bloom filter in pixels.
 #    Larger values render more glow around bright objects
 #    at the cost of higher resource consumption.
-#    Range: from 1 to 64, default: 3
+#    Range: from 1 to 64, default: 16
 bloom_radius (Bloom Radius) int 16 1 64
 
 [*Audio]

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -465,11 +465,10 @@ enable_bloom (Enable bloom) bool false
 #    Range: from 0.0 to 2.0, Default: 1.0
 bloom_luminance_threshold (Bloom Luminance Threshold) float 1.0 0.0 2.0
 
-#    Set the boost of brightness when bleeding light.
-#    Causes bright colors to appear brighter.
-#    Value of 0.0 (default) does not add any boost.
-#    Range: from 0.0 to 2.0
-bloom_boost (Bloom Boost) float 0.0 0.0 2.0
+#    Set the intensity of bloom
+#    Smaller values make bloom more subtle
+#    Range: from 0.1 to 10.0, default: 1.0
+bloom_intensity (Bloom Intensity) float 1.0 0.1 10.0
 
 [*Audio]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -466,6 +466,11 @@ enable_bloom (Enable Bloom) bool false
 #    bottom-left - raw base image, bottom-right - bloom texture.
 enable_bloom_debug (Enable Bloom Debug) bool false
 
+#    Set to true to use dedicated texture at each step of bloom effect.
+#    This is a compatibility setting to avoid visual artifacts 
+#    on certain GPUs and video drivers.
+enable_bloom_dedicated_texture (Enable Bloom Dedicated Texture) bool false
+
 #    Set the intensity of bloom
 #    Smaller values make bloom more subtle
 #    Range: from 0.01 to 1.0, default: 1.0
@@ -476,6 +481,7 @@ bloom_intensity (Bloom Intensity) float 0.05 0.01 1.0
 #    at the cost of higher resource consumption.
 #    Range: from 1 to 64, default: 16
 bloom_radius (Bloom Radius) int 16 1 64
+
 
 [*Audio]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -460,21 +460,16 @@ exposure_factor	(Exposure Factor) float 1.0 0.1 10.0
 #    Bright colors will bleed over the neighboring objects.
 enable_bloom (Enable bloom) bool false
 
-#    Set the luminance threshold for bleeding colors.
-#    Lower values will cause more blurring of the scene.
-#    Range: from 0.0 to 2.0, Default: 1.0
-bloom_luminance_threshold (Bloom Luminance Threshold) float 1.0 0.0 2.0
-
 #    Set the intensity of bloom
 #    Smaller values make bloom more subtle
 #    Range: from 0.1 to 10.0, default: 1.0
-bloom_intensity (Bloom Intensity) float 1.0 0.1 10.0
+bloom_intensity (Bloom Intensity) float 0.05 0.01 1.0
 
 #    Set the radius of the bloom filter in pixels.
 #    Larger values render more glow around bright objects
 #    at the cost of higher resource consumption.
 #    Range: from 1 to 64, default: 3
-bloom_radius (Bloom Radius) int 3 1 64
+bloom_radius (Bloom Radius) int 16 1 64
 
 [*Audio]
 

--- a/client/shaders/blur_h/opengl_fragment.glsl
+++ b/client/shaders/blur_h/opengl_fragment.glsl
@@ -17,10 +17,14 @@ void main(void)
 
 	vec2 uv = varTexCoord.st - vec2(bloomRadius * texelSize0.x, 0.);
 	vec4 color = vec4(0.);
+	lowp float sum = 0.;
 	for (lowp float i = 0.; i < n; i++) {
-		color += texture2D(rendered, uv).rgba * ((bloomRadius + 1.) - abs(i - bloomRadius));
+		lowp float weight = 1. + 1. / bloomRadius - (abs(i / bloomRadius - 1.));
+		weight *= weight;
+		color += texture2D(rendered, uv).rgba * weight;
+		sum += weight;
 		uv += vec2(texelSize0.x, 0.);
 	}
-	color /= (bloomRadius + 1.) * (bloomRadius + 1.);
+	color /= sum;
 	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/blur_h/opengl_fragment.glsl
+++ b/client/shaders/blur_h/opengl_fragment.glsl
@@ -19,8 +19,7 @@ void main(void)
 	vec4 color = vec4(0.);
 	lowp float sum = 0.;
 	for (lowp float i = 0.; i < n; i++) {
-		lowp float weight = 1. + 1. / bloomRadius - (abs(i / bloomRadius - 1.));
-		weight *= weight;
+		lowp float weight = pow(1. - (abs(i / bloomRadius - 1.)), 1.3);
 		color += texture2D(rendered, uv).rgba * weight;
 		sum += weight;
 		uv += vec2(texelSize0.x, 0.);

--- a/client/shaders/blur_h/opengl_fragment.glsl
+++ b/client/shaders/blur_h/opengl_fragment.glsl
@@ -2,6 +2,7 @@
 
 uniform sampler2D rendered;
 uniform vec2 texelSize0;
+uniform lowp float bloomRadius = 3.0;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -12,15 +13,14 @@ centroid varying vec2 varTexCoord;
 void main(void)
 {
 	// kernel distance and linear size
-	const lowp float d = 3.;
-	const lowp float n = 2. * d + 1.;
+	lowp float n = 2. * bloomRadius + 1.;
 
-	vec2 uv = varTexCoord.st - vec2(d * texelSize0.x, 0.);
+	vec2 uv = varTexCoord.st - vec2(bloomRadius * texelSize0.x, 0.);
 	vec4 color = vec4(0.);
 	for (lowp float i = 0.; i < n; i++) {
-		color += texture2D(rendered, uv).rgba * ((d + 1.) - abs(i - d));
+		color += texture2D(rendered, uv).rgba * ((bloomRadius + 1.) - abs(i - bloomRadius));
 		uv += vec2(texelSize0.x, 0.);
 	}
-	color /= (d + 1.) * (d + 1.);
+	color /= (bloomRadius + 1.) * (bloomRadius + 1.);
 	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/blur_h/opengl_fragment.glsl
+++ b/client/shaders/blur_h/opengl_fragment.glsl
@@ -1,0 +1,26 @@
+#define rendered texture0
+
+uniform sampler2D rendered;
+uniform vec2 texelSize0;
+
+#ifdef GL_ES
+varying mediump vec2 varTexCoord;
+#else
+centroid varying vec2 varTexCoord;
+#endif
+
+void main(void)
+{
+	// kernel distance and linear size
+	const lowp float d = 3.;
+	const lowp float n = 2. * d + 1.;
+
+	vec2 uv = varTexCoord.st - vec2(d * texelSize0.x, 0.);
+	vec4 color = vec4(0.);
+	for (lowp float i = 0.; i < n; i++) {
+		color += texture2D(rendered, uv).rgba * ((d + 1.) - abs(i - d));
+		uv += vec2(texelSize0.x, 0.);
+	}
+	color /= (d + 1.) * (d + 1.);
+	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.
+}

--- a/client/shaders/blur_h/opengl_fragment.glsl
+++ b/client/shaders/blur_h/opengl_fragment.glsl
@@ -2,7 +2,7 @@
 
 uniform sampler2D rendered;
 uniform vec2 texelSize0;
-uniform lowp float bloomRadius = 3.0;
+uniform mediump float bloomRadius = 3.0;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -13,13 +13,13 @@ centroid varying vec2 varTexCoord;
 void main(void)
 {
 	// kernel distance and linear size
-	lowp float n = 2. * bloomRadius + 1.;
+	mediump float n = 2. * bloomRadius + 1.;
 
 	vec2 uv = varTexCoord.st - vec2(bloomRadius * texelSize0.x, 0.);
 	vec4 color = vec4(0.);
-	lowp float sum = 0.;
-	for (lowp float i = 0.; i < n; i++) {
-		lowp float weight = pow(1. - (abs(i / bloomRadius - 1.)), 1.3);
+	mediump float sum = 0.;
+	for (mediump float i = 0.; i < n; i++) {
+		mediump float weight = pow(1. - (abs(i / bloomRadius - 1.)), 1.3);
 		color += texture2D(rendered, uv).rgba * weight;
 		sum += weight;
 		uv += vec2(texelSize0.x, 0.);

--- a/client/shaders/blur_h/opengl_vertex.glsl
+++ b/client/shaders/blur_h/opengl_vertex.glsl
@@ -1,0 +1,11 @@
+#ifdef GL_ES
+varying mediump vec2 varTexCoord;
+#else
+centroid varying vec2 varTexCoord;
+#endif
+
+void main(void)
+{
+	varTexCoord.st = inTexCoord0.st;
+	gl_Position = inVertexPosition;
+}

--- a/client/shaders/blur_v/opengl_fragment.glsl
+++ b/client/shaders/blur_v/opengl_fragment.glsl
@@ -2,6 +2,7 @@
 
 uniform sampler2D rendered;
 uniform vec2 texelSize0;
+uniform lowp float bloomRadius = 3.0;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -12,15 +13,14 @@ centroid varying vec2 varTexCoord;
 void main(void)
 {
 	// kernel distance and linear size
-	const lowp float d = 3.;
-	const lowp float n = 2. * d + 1.;
+	lowp float n = 2. * bloomRadius + 1.;
 
-	vec2 uv = varTexCoord.st - vec2(0., d * texelSize0.y);
+	vec2 uv = varTexCoord.st - vec2(0., bloomRadius * texelSize0.y);
 	vec4 color = vec4(0.);
 	for (lowp float i = 0.; i < n; i++) {
-		color += texture2D(rendered, uv).rgba * ((d + 1.) - abs(i - d));
+		color += texture2D(rendered, uv).rgba * ((bloomRadius + 1.) - abs(i - bloomRadius));
 		uv += vec2(0., texelSize0.y);
 	}
-	color /= (d + 1.) * (d + 1.);
+	color /= (bloomRadius + 1.) * (bloomRadius + 1.);
 	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/blur_v/opengl_fragment.glsl
+++ b/client/shaders/blur_v/opengl_fragment.glsl
@@ -17,10 +17,14 @@ void main(void)
 
 	vec2 uv = varTexCoord.st - vec2(0., bloomRadius * texelSize0.y);
 	vec4 color = vec4(0.);
+	lowp float sum = 0.;
 	for (lowp float i = 0.; i < n; i++) {
-		color += texture2D(rendered, uv).rgba * ((bloomRadius + 1.) - abs(i - bloomRadius));
+		lowp float weight = 1. + 1. / bloomRadius - (abs(i / bloomRadius - 1.));
+		weight *= weight;
+		color += texture2D(rendered, uv).rgba * weight;
+		sum += weight;
 		uv += vec2(0., texelSize0.y);
 	}
-	color /= (bloomRadius + 1.) * (bloomRadius + 1.);
+	color /= sum;
 	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/blur_v/opengl_fragment.glsl
+++ b/client/shaders/blur_v/opengl_fragment.glsl
@@ -2,7 +2,7 @@
 
 uniform sampler2D rendered;
 uniform vec2 texelSize0;
-uniform lowp float bloomRadius = 3.0;
+uniform mediump float bloomRadius = 3.0;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -13,13 +13,13 @@ centroid varying vec2 varTexCoord;
 void main(void)
 {
 	// kernel distance and linear size
-	lowp float n = 2. * bloomRadius + 1.;
+	mediump float n = 2. * bloomRadius + 1.;
 
 	vec2 uv = varTexCoord.st - vec2(0., bloomRadius * texelSize0.y);
 	vec4 color = vec4(0.);
-	lowp float sum = 0.;
-	for (lowp float i = 0.; i < n; i++) {
-		lowp float weight = pow(1. - (abs(i / bloomRadius - 1.)), 1.3);
+	mediump float sum = 0.;
+	for (mediump float i = 0.; i < n; i++) {
+		mediump float weight = pow(1. - (abs(i / bloomRadius - 1.)), 1.3);
 		color += texture2D(rendered, uv).rgba * weight;
 		sum += weight;
 		uv += vec2(0., texelSize0.y);

--- a/client/shaders/blur_v/opengl_fragment.glsl
+++ b/client/shaders/blur_v/opengl_fragment.glsl
@@ -19,8 +19,7 @@ void main(void)
 	vec4 color = vec4(0.);
 	lowp float sum = 0.;
 	for (lowp float i = 0.; i < n; i++) {
-		lowp float weight = 1. + 1. / bloomRadius - (abs(i / bloomRadius - 1.));
-		weight *= weight;
+		lowp float weight = pow(1. - (abs(i / bloomRadius - 1.)), 1.3);
 		color += texture2D(rendered, uv).rgba * weight;
 		sum += weight;
 		uv += vec2(0., texelSize0.y);

--- a/client/shaders/blur_v/opengl_fragment.glsl
+++ b/client/shaders/blur_v/opengl_fragment.glsl
@@ -1,0 +1,26 @@
+#define rendered texture0
+
+uniform sampler2D rendered;
+uniform vec2 texelSize0;
+
+#ifdef GL_ES
+varying mediump vec2 varTexCoord;
+#else
+centroid varying vec2 varTexCoord;
+#endif
+
+void main(void)
+{
+	// kernel distance and linear size
+	const lowp float d = 3.;
+	const lowp float n = 2. * d + 1.;
+
+	vec2 uv = varTexCoord.st - vec2(0., d * texelSize0.y);
+	vec4 color = vec4(0.);
+	for (lowp float i = 0.; i < n; i++) {
+		color += texture2D(rendered, uv).rgba * ((d + 1.) - abs(i - d));
+		uv += vec2(0., texelSize0.y);
+	}
+	color /= (d + 1.) * (d + 1.);
+	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.
+}

--- a/client/shaders/blur_v/opengl_vertex.glsl
+++ b/client/shaders/blur_v/opengl_vertex.glsl
@@ -1,0 +1,11 @@
+#ifdef GL_ES
+varying mediump vec2 varTexCoord;
+#else
+centroid varying vec2 varTexCoord;
+#endif
+
+void main(void)
+{
+	varTexCoord.st = inTexCoord0.st;
+	gl_Position = inVertexPosition;
+}

--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -1,0 +1,20 @@
+#define rendered texture0
+
+uniform sampler2D rendered;
+
+#ifdef GL_ES
+varying mediump vec2 varTexCoord;
+#else
+centroid varying vec2 varTexCoord;
+#endif
+
+const float bloomLuminanceThreshold = 0.7;
+
+void main(void)
+{
+	vec2 uv = varTexCoord.st;
+	vec4 color = texture2D(rendered, uv).rgba;
+	float luminance = dot(color.rgb, vec3(0.213, 0.715, 0.072)) + 1e-4;
+	color.rgb *= max(0., 1. - bloomLuminanceThreshold / luminance);
+	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.
+}

--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -2,6 +2,8 @@
 
 uniform sampler2D rendered;
 uniform mediump float exposureFactor = 2.5;
+uniform float bloomLuminanceThreshold = 1.0;
+uniform lowp float bloomBoost = 0.0;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -9,7 +11,6 @@ varying mediump vec2 varTexCoord;
 centroid varying vec2 varTexCoord;
 #endif
 
-const float bloomLuminanceThreshold = 0.7;
 
 void main(void)
 {
@@ -19,6 +20,6 @@ void main(void)
 	color = vec4(pow(color.rgb, vec3(2.2)), color.a);
 	color.rgb = color.rgb * exposureFactor;
 	float luminance = dot(color.rgb, vec3(0.213, 0.715, 0.072)) + 1e-4;
-	color.rgb *= max(0., 1. - bloomLuminanceThreshold / luminance);
+	color.rgb *= (1. + bloomBoost) * max(0., 1. - bloomLuminanceThreshold / luminance);
 	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -1,6 +1,7 @@
 #define rendered texture0
 
 uniform sampler2D rendered;
+uniform mediump float exposureFactor = 2.5;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -8,7 +9,6 @@ varying mediump vec2 varTexCoord;
 centroid varying vec2 varTexCoord;
 #endif
 
-const float exposureFactor = 2.5;
 const float bloomLuminanceThreshold = 0.7;
 
 void main(void)

--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -8,6 +8,7 @@ varying mediump vec2 varTexCoord;
 centroid varying vec2 varTexCoord;
 #endif
 
+const float exposureFactor = 2.5;
 const float bloomLuminanceThreshold = 0.7;
 
 void main(void)
@@ -16,6 +17,7 @@ void main(void)
 	vec4 color = texture2D(rendered, uv).rgba;
 	// translate to linear colorspace (approximate)
 	color = vec4(pow(color.rgb, vec3(2.2)), color.a);
+	color.rgb = color.rgb * exposureFactor;
 	float luminance = dot(color.rgb, vec3(0.213, 0.715, 0.072)) + 1e-4;
 	color.rgb *= max(0., 1. - bloomLuminanceThreshold / luminance);
 	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.

--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -3,7 +3,6 @@
 uniform sampler2D rendered;
 uniform mediump float exposureFactor = 2.5;
 uniform float bloomLuminanceThreshold = 1.0;
-uniform lowp float bloomIntensity = 1.0;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -17,9 +16,6 @@ void main(void)
 	vec2 uv = varTexCoord.st;
 	vec4 color = texture2D(rendered, uv).rgba;
 	// translate to linear colorspace (approximate)
-	color = vec4(pow(color.rgb, vec3(2.2)), color.a);
-	color.rgb = color.rgb * exposureFactor;
-	float luminance = dot(color.rgb, vec3(0.213, 0.715, 0.072)) + 1e-4;
-	color.rgb *= bloomIntensity * max(0., 1. - bloomLuminanceThreshold / luminance);
+	color.rgb = pow(color.rgb, vec3(2.2)) * exposureFactor;
 	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -14,6 +14,8 @@ void main(void)
 {
 	vec2 uv = varTexCoord.st;
 	vec4 color = texture2D(rendered, uv).rgba;
+	// translate to linear colorspace (approximate)
+	color = vec4(pow(color.rgb, vec3(2.2)), color.a);
 	float luminance = dot(color.rgb, vec3(0.213, 0.715, 0.072)) + 1e-4;
 	color.rgb *= max(0., 1. - bloomLuminanceThreshold / luminance);
 	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.

--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -3,7 +3,7 @@
 uniform sampler2D rendered;
 uniform mediump float exposureFactor = 2.5;
 uniform float bloomLuminanceThreshold = 1.0;
-uniform lowp float bloomBoost = 0.0;
+uniform lowp float bloomIntensity = 1.0;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -20,6 +20,6 @@ void main(void)
 	color = vec4(pow(color.rgb, vec3(2.2)), color.a);
 	color.rgb = color.rgb * exposureFactor;
 	float luminance = dot(color.rgb, vec3(0.213, 0.715, 0.072)) + 1e-4;
-	color.rgb *= (1. + bloomBoost) * max(0., 1. - bloomLuminanceThreshold / luminance);
+	color.rgb *= bloomIntensity * max(0., 1. - bloomLuminanceThreshold / luminance);
 	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/extract_bloom/opengl_vertex.glsl
+++ b/client/shaders/extract_bloom/opengl_vertex.glsl
@@ -1,0 +1,11 @@
+#ifdef GL_ES
+varying mediump vec2 varTexCoord;
+#else
+centroid varying vec2 varTexCoord;
+#endif
+
+void main(void)
+{
+	varTexCoord.st = inTexCoord0.st;
+	gl_Position = inVertexPosition;
+}

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -4,6 +4,7 @@
 uniform sampler2D rendered;
 uniform sampler2D bloom;
 uniform mediump float exposureFactor = 2.5;
+uniform lowp float bloomIntensity = 1.0;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -13,13 +14,9 @@ centroid varying vec2 varTexCoord;
 
 #if ENABLE_BLOOM
 
-uniform float bloomLuminanceThreshold = 1.0;
-
 vec4 applyBloom(vec4 color, vec2 uv)
 {
-	float luminance = dot(color.rgb, vec3(0.213, 0.715, 0.072)) + 1e-4;
-	color.rgb *= min(1., bloomLuminanceThreshold / luminance);
-	color.rgb += texture2D(bloom, uv).rgb;
+	color.rgb = mix(color.rgb, texture2D(bloom, uv).rgb, bloomIntensity);
 	return color;
 }
 
@@ -60,7 +57,7 @@ void main(void)
 	vec2 uv = varTexCoord.st;
 	vec4 color = texture2D(rendered, uv).rgba;
 	// translate to linear colorspace (approximate) and apply exposure
-	color = vec4(pow(color.rgb, vec3(2.2)) * exposureFactor, color.a);
+	color.rgb = pow(color.rgb, vec3(2.2)) * exposureFactor;
 
 #if ENABLE_BLOOM
 	color = applyBloom(color, uv);

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -13,7 +13,7 @@ centroid varying vec2 varTexCoord;
 
 #if ENABLE_BLOOM
 
-const float bloomLuminanceThreshold = 0.7;
+uniform float bloomLuminanceThreshold = 1.0;
 
 vec4 applyBloom(vec4 color, vec2 uv)
 {

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -65,6 +65,8 @@ void main(void)
 
 #if ENABLE_TONE_MAPPING
 	color = applyToneMapping(color);
+#else
+	color.rgb /= exposureFactor;
 #endif
 
 	// return to sRGB colorspace (approximate)

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -69,8 +69,10 @@ void main(void)
 	color.rgb /= 2.5; // default exposure factor, see also RenderingEngine::DEFAULT_EXPOSURE_FACTOR;
 #endif
 
+	color.rgb = clamp(color.rgb, vec3(0.), vec3(1.));
+
 	// return to sRGB colorspace (approximate)
-	color = vec4(pow(color.rgb, vec3(1.0 / 2.2)), color.a);
+	color.rgb = pow(color.rgb, vec3(1.0 / 2.2));
 
 	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -3,7 +3,7 @@
 
 uniform sampler2D rendered;
 uniform sampler2D bloom;
-
+uniform mediump float exposureFactor = 2.5;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -11,7 +11,6 @@ varying mediump vec2 varTexCoord;
 centroid varying vec2 varTexCoord;
 #endif
 
-const float exposureFactor = 2.5;
 const float bloomLuminanceThreshold = 0.7;
 
 #if ENABLE_TONE_MAPPING

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -1,12 +1,17 @@
-uniform sampler2D baseTexture;
+#define rendered texture0
+#define bloom texture1
 
-#define rendered baseTexture
+uniform sampler2D rendered;
+uniform sampler2D bloom;
+
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
 #else
 centroid varying vec2 varTexCoord;
 #endif
+
+const float bloomLuminanceThreshold = 0.7;
 
 #if ENABLE_TONE_MAPPING
 
@@ -44,6 +49,9 @@ void main(void)
 {
 	vec2 uv = varTexCoord.st;
 	vec4 color = texture2D(rendered, uv).rgba;
+	float luminance = dot(color.rgb, vec3(0.213, 0.715, 0.072)) + 1e-4;
+	color.rgb *= min(1., bloomLuminanceThreshold / luminance);
+	color.rgb += texture2D(bloom, uv).rgb;
 
 #if ENABLE_TONE_MAPPING
 	color = applyToneMapping(color);

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -11,6 +11,7 @@ varying mediump vec2 varTexCoord;
 centroid varying vec2 varTexCoord;
 #endif
 
+const float exposureFactor = 2.5;
 const float bloomLuminanceThreshold = 0.7;
 
 #if ENABLE_TONE_MAPPING
@@ -33,7 +34,7 @@ vec3 uncharted2Tonemap(vec3 x)
 
 vec4 applyToneMapping(vec4 color)
 {
-	const float exposureBias = 5.5;
+	const float exposureBias = 2.0;
 	color.rgb = uncharted2Tonemap(exposureBias * color.rgb);
 	// Precalculated white_scale from
 	//vec3 whiteScale = 1.0 / uncharted2Tonemap(vec3(W));
@@ -49,6 +50,7 @@ void main(void)
 	vec4 color = texture2D(rendered, uv).rgba;
 	// translate to linear colorspace (approximate)
 	color = vec4(pow(color.rgb, vec3(2.2)), color.a);
+	color.rgb = color.rgb * exposureFactor;
 	float luminance = dot(color.rgb, vec3(0.213, 0.715, 0.072)) + 1e-4;
 	color.rgb *= min(1., bloomLuminanceThreshold / luminance);
 	color.rgb += texture2D(bloom, uv).rgb;

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -66,7 +66,7 @@ void main(void)
 #if ENABLE_TONE_MAPPING
 	color = applyToneMapping(color);
 #else
-	color.rgb /= exposureFactor;
+	color.rgb /= 2.5; // default exposure factor, see also RenderingEngine::DEFAULT_EXPOSURE_FACTOR;
 #endif
 
 	// return to sRGB colorspace (approximate)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -431,8 +431,8 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	bool m_bloom_enabled;
 	CachedPixelShaderSetting<float> m_bloom_luminance_threshold_pixel;
 	float m_bloom_luminance_threshold;
-	CachedPixelShaderSetting<float> m_bloom_boost_pixel;
-	float m_bloom_boost;
+	CachedPixelShaderSetting<float> m_bloom_intensity_pixel;
+	float m_bloom_intensity;
 
 public:
 	void onSettingsChange(const std::string &name)
@@ -443,8 +443,8 @@ public:
 			m_user_exposure_factor = g_settings->getFloat("exposure_factor", 0.1f, 10.0f);
 		if (name == "bloom_luminance_threshold")
 			m_bloom_luminance_threshold = g_settings->getFloat("bloom_luminance_threshold", 0.0f, 2.0f);
-		if (name == "bloom_boost")
-			m_bloom_boost = g_settings->getFloat("bloom_boost", 0.0f, 2.0f);
+		if (name == "bloom_intensity")
+			m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.1f, 10.0f);
 	}
 
 	static void settingsCallback(const std::string &name, void *userdata)
@@ -478,17 +478,17 @@ public:
 		m_texel_size0("texelSize0"),
 		m_exposure_factor_pixel("exposureFactor"),
 		m_bloom_luminance_threshold_pixel("bloomLuminanceThreshold"),
-		m_bloom_boost_pixel("bloomBoost")
+		m_bloom_intensity_pixel("bloomIntensity")
 	{
 		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
 		g_settings->registerChangedCallback("exposure_factor", settingsCallback, this);
 		g_settings->registerChangedCallback("bloom_luminance_threshold", settingsCallback, this);
-		g_settings->registerChangedCallback("bloom_boost", settingsCallback, this);
+		g_settings->registerChangedCallback("bloom_intensity", settingsCallback, this);
 		m_fog_enabled = g_settings->getBool("enable_fog");
 		m_user_exposure_factor = g_settings->getFloat("exposure_factor", 0.1f, 10.0f);
 		m_bloom_enabled = g_settings->getBool("enable_bloom");
 		m_bloom_luminance_threshold = g_settings->getFloat("bloom_luminance_threshold", 0.0f, 2.0f);
-		m_bloom_boost = g_settings->getFloat("bloom_boost", 0.0f, 2.0f);
+		m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.1f, 10.0f);
 	}
 
 	~GameGlobalShaderConstantSetter()
@@ -573,7 +573,7 @@ public:
 
 		if (m_bloom_enabled) {
 			m_bloom_luminance_threshold_pixel.set(&m_bloom_luminance_threshold, services);
-			m_bloom_boost_pixel.set(&m_bloom_boost, services);
+			m_bloom_intensity_pixel.set(&m_bloom_intensity, services);
 		}
 	}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -424,6 +424,8 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<SamplerLayer_t> m_texture1;
 	CachedPixelShaderSetting<SamplerLayer_t> m_texture2;
 	CachedPixelShaderSetting<SamplerLayer_t> m_texture3;
+	CachedPixelShaderSetting<float, 2> m_texel_size0;
+	std::array<float, 2> m_texel_size0_values;
 
 public:
 	void onSettingsChange(const std::string &name)
@@ -459,7 +461,8 @@ public:
 		m_texture0("texture0"),
 		m_texture1("texture1"),
 		m_texture2("texture2"),
-		m_texture3("texture3")
+		m_texture3("texture3"),
+		m_texel_size0("texelSize0")
 	{
 		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
 		m_fog_enabled = g_settings->getBool("enable_fog");
@@ -537,6 +540,22 @@ public:
 		m_texture2.set(&tex_id, services);
 		tex_id = 3;
 		m_texture3.set(&tex_id, services);
+
+		m_texel_size0.set(m_texel_size0_values.data(), services);
+	}
+
+	void onSetMaterial(const video::SMaterial &material)
+	{
+		video::ITexture *texture = material.getTexture(0);
+		if (texture) {
+			core::dimension2du size = texture->getSize();
+			m_texel_size0_values[0] = 1.f / size.Width;
+			m_texel_size0_values[1] = 1.f / size.Height;
+		}
+		else {
+			m_texel_size0_values[0] = 0.f;
+			m_texel_size0_values[1] = 0.f;
+		}
 	}
 };
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -429,8 +429,6 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<float> m_exposure_factor_pixel;
 	float m_user_exposure_factor;
 	bool m_bloom_enabled;
-	CachedPixelShaderSetting<float> m_bloom_luminance_threshold_pixel;
-	float m_bloom_luminance_threshold;
 	CachedPixelShaderSetting<float> m_bloom_intensity_pixel;
 	float m_bloom_intensity;
 	CachedPixelShaderSetting<float> m_bloom_radius_pixel;
@@ -443,10 +441,8 @@ public:
 			m_fog_enabled = g_settings->getBool("enable_fog");
 		if (name == "exposure_factor")
 			m_user_exposure_factor = g_settings->getFloat("exposure_factor", 0.1f, 10.0f);
-		if (name == "bloom_luminance_threshold")
-			m_bloom_luminance_threshold = g_settings->getFloat("bloom_luminance_threshold", 0.0f, 2.0f);
 		if (name == "bloom_intensity")
-			m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.1f, 10.0f);
+			m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.01f, 1.0f);
 		if (name == "bloom_radius")
 			m_bloom_radius = g_settings->getFloat("bloom_radius", 1.0f, 64.0f);
 	}
@@ -481,20 +477,17 @@ public:
 		m_texture3("texture3"),
 		m_texel_size0("texelSize0"),
 		m_exposure_factor_pixel("exposureFactor"),
-		m_bloom_luminance_threshold_pixel("bloomLuminanceThreshold"),
 		m_bloom_intensity_pixel("bloomIntensity"),
 		m_bloom_radius_pixel("bloomRadius")
 	{
 		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
 		g_settings->registerChangedCallback("exposure_factor", settingsCallback, this);
-		g_settings->registerChangedCallback("bloom_luminance_threshold", settingsCallback, this);
 		g_settings->registerChangedCallback("bloom_intensity", settingsCallback, this);
 		g_settings->registerChangedCallback("bloom_radius", settingsCallback, this);
 		m_fog_enabled = g_settings->getBool("enable_fog");
 		m_user_exposure_factor = g_settings->getFloat("exposure_factor", 0.1f, 10.0f);
 		m_bloom_enabled = g_settings->getBool("enable_bloom");
-		m_bloom_luminance_threshold = g_settings->getFloat("bloom_luminance_threshold", 0.0f, 2.0f);
-		m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.1f, 10.0f);
+		m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.01f, 1.0f);
 		m_bloom_radius = g_settings->getFloat("bloom_radius", 1.0f, 64.0f);
 	}
 
@@ -579,7 +572,6 @@ public:
 		m_exposure_factor_pixel.set(&exposure_factor, services);
 
 		if (m_bloom_enabled) {
-			m_bloom_luminance_threshold_pixel.set(&m_bloom_luminance_threshold, services);
 			m_bloom_intensity_pixel.set(&m_bloom_intensity, services);
 			m_bloom_radius_pixel.set(&m_bloom_radius, services);
 		}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -433,6 +433,8 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	float m_bloom_luminance_threshold;
 	CachedPixelShaderSetting<float> m_bloom_intensity_pixel;
 	float m_bloom_intensity;
+	CachedPixelShaderSetting<float> m_bloom_radius_pixel;
+	float m_bloom_radius;
 
 public:
 	void onSettingsChange(const std::string &name)
@@ -445,6 +447,8 @@ public:
 			m_bloom_luminance_threshold = g_settings->getFloat("bloom_luminance_threshold", 0.0f, 2.0f);
 		if (name == "bloom_intensity")
 			m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.1f, 10.0f);
+		if (name == "bloom_radius")
+			m_bloom_radius = g_settings->getFloat("bloom_radius", 1.0f, 64.0f);
 	}
 
 	static void settingsCallback(const std::string &name, void *userdata)
@@ -478,17 +482,20 @@ public:
 		m_texel_size0("texelSize0"),
 		m_exposure_factor_pixel("exposureFactor"),
 		m_bloom_luminance_threshold_pixel("bloomLuminanceThreshold"),
-		m_bloom_intensity_pixel("bloomIntensity")
+		m_bloom_intensity_pixel("bloomIntensity"),
+		m_bloom_radius_pixel("bloomRadius")
 	{
 		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
 		g_settings->registerChangedCallback("exposure_factor", settingsCallback, this);
 		g_settings->registerChangedCallback("bloom_luminance_threshold", settingsCallback, this);
 		g_settings->registerChangedCallback("bloom_intensity", settingsCallback, this);
+		g_settings->registerChangedCallback("bloom_radius", settingsCallback, this);
 		m_fog_enabled = g_settings->getBool("enable_fog");
 		m_user_exposure_factor = g_settings->getFloat("exposure_factor", 0.1f, 10.0f);
 		m_bloom_enabled = g_settings->getBool("enable_bloom");
 		m_bloom_luminance_threshold = g_settings->getFloat("bloom_luminance_threshold", 0.0f, 2.0f);
 		m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.1f, 10.0f);
+		m_bloom_radius = g_settings->getFloat("bloom_radius", 1.0f, 64.0f);
 	}
 
 	~GameGlobalShaderConstantSetter()
@@ -574,6 +581,7 @@ public:
 		if (m_bloom_enabled) {
 			m_bloom_luminance_threshold_pixel.set(&m_bloom_luminance_threshold, services);
 			m_bloom_intensity_pixel.set(&m_bloom_intensity, services);
+			m_bloom_radius_pixel.set(&m_bloom_radius, services);
 		}
 	}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -405,6 +405,7 @@ typedef s32 SamplerLayer_t;
 class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 {
 	Sky *m_sky;
+	Client *m_client;
 	bool *m_force_fog_off;
 	f32 *m_fog_range;
 	bool m_fog_enabled;
@@ -419,10 +420,10 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<float, 3> m_minimap_yaw;
 	CachedPixelShaderSetting<float, 3> m_camera_offset_pixel;
 	CachedPixelShaderSetting<float, 3> m_camera_offset_vertex;
-	CachedPixelShaderSetting<SamplerLayer_t> m_base_texture;
-	CachedPixelShaderSetting<SamplerLayer_t> m_normal_texture;
-	CachedPixelShaderSetting<SamplerLayer_t> m_texture_flags;
-	Client *m_client;
+	CachedPixelShaderSetting<SamplerLayer_t> m_texture0;
+	CachedPixelShaderSetting<SamplerLayer_t> m_texture1;
+	CachedPixelShaderSetting<SamplerLayer_t> m_texture2;
+	CachedPixelShaderSetting<SamplerLayer_t> m_texture3;
 
 public:
 	void onSettingsChange(const std::string &name)
@@ -441,6 +442,7 @@ public:
 	GameGlobalShaderConstantSetter(Sky *sky, bool *force_fog_off,
 			f32 *fog_range, Client *client) :
 		m_sky(sky),
+		m_client(client),
 		m_force_fog_off(force_fog_off),
 		m_fog_range(fog_range),
 		m_sky_bg_color("skyBgColor"),
@@ -454,10 +456,10 @@ public:
 		m_minimap_yaw("yawVec"),
 		m_camera_offset_pixel("cameraOffset"),
 		m_camera_offset_vertex("cameraOffset"),
-		m_base_texture("baseTexture"),
-		m_normal_texture("normalTexture"),
-		m_texture_flags("textureFlags"),
-		m_client(client)
+		m_texture0("texture0"),
+		m_texture1("texture1"),
+		m_texture2("texture2"),
+		m_texture3("texture3")
 	{
 		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
 		m_fog_enabled = g_settings->getBool("enable_fog");
@@ -526,12 +528,15 @@ public:
 		m_camera_offset_pixel.set(camera_offset_array, services);
 		m_camera_offset_vertex.set(camera_offset_array, services);
 
-		SamplerLayer_t base_tex = 0,
-				normal_tex = 1,
-				flags_tex = 2;
-		m_base_texture.set(&base_tex, services);
-		m_normal_texture.set(&normal_tex, services);
-		m_texture_flags.set(&flags_tex, services);
+		SamplerLayer_t tex_id;
+		tex_id = 0;
+		m_texture0.set(&tex_id, services);
+		tex_id = 1;
+		m_texture1.set(&tex_id, services);
+		tex_id = 2;
+		m_texture2.set(&tex_id, services);
+		tex_id = 3;
+		m_texture3.set(&tex_id, services);
 	}
 };
 

--- a/src/client/render/pipeline.cpp
+++ b/src/client/render/pipeline.cpp
@@ -27,9 +27,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 TextureBuffer::~TextureBuffer()
 {
-	if (m_render_target)
-		m_driver->removeRenderTarget(m_render_target);
-	m_render_target = nullptr;
 	for (u32 index = 0; index < m_textures.size(); index++)
 		m_driver->removeTexture(m_textures[index]);
 	m_textures.clear();
@@ -37,8 +34,6 @@ TextureBuffer::~TextureBuffer()
 
 video::ITexture *TextureBuffer::getTexture(u8 index)
 {
-	if (index == m_depth_texture_index)
-		return m_depth_texture;
 	if (index >= m_textures.size())
 		return nullptr;
 	return m_textures[index];
@@ -52,9 +47,6 @@ void TextureBuffer::setTexture(u8 index, core::dimension2du size, const std::str
 	if (m_definitions.size() <= index)
 		m_definitions.resize(index + 1);
 
-	if (m_depth_texture_index == index)
-		m_depth_texture_index = NO_DEPTH_TEXTURE;
-	
 	auto &definition = m_definitions[index];
 	definition.valid = true;
 	definition.dirty = true;
@@ -71,9 +63,6 @@ void TextureBuffer::setTexture(u8 index, v2f scale_factor, const std::string &na
 	if (m_definitions.size() <= index)
 		m_definitions.resize(index + 1);
 	
-	if (m_depth_texture_index == index)
-		m_depth_texture_index = NO_DEPTH_TEXTURE;
-
 	auto &definition = m_definitions[index];
 	definition.valid = true;
 	definition.dirty = true;
@@ -81,20 +70,6 @@ void TextureBuffer::setTexture(u8 index, v2f scale_factor, const std::string &na
 	definition.scale_factor = scale_factor;
 	definition.name = name;
 	definition.format = format;
-}
-
-void TextureBuffer::setDepthTexture(u8 index, core::dimension2du size, const std::string &name, video::ECOLOR_FORMAT format)
-{
-	assert(index != NO_DEPTH_TEXTURE);
-	setTexture(index, size, name, format);
-	m_depth_texture_index = index;
-}
-
-void TextureBuffer::setDepthTexture(u8 index, v2f scale_factor, const std::string &name, video::ECOLOR_FORMAT format)
-{
-	assert(index != NO_DEPTH_TEXTURE);
-	setTexture(index, scale_factor, name, format);
-	m_depth_texture_index = index;
 }
 
 void TextureBuffer::reset(PipelineContext &context)
@@ -116,41 +91,14 @@ void TextureBuffer::reset(PipelineContext &context)
 		m_textures.push_back(nullptr);
 
 	// change textures to match definitions
-	bool modified = false;
 	for (u32 i = 0; i < m_definitions.size(); i++) {
 		video::ITexture **ptr = &m_textures[i];
-		if (i == m_depth_texture_index) {
-			if (*ptr) {
-				m_driver->removeTexture(*ptr);
-				*ptr = nullptr;
-			}
-			ptr = &m_depth_texture;
-		}
 
-		if (ensureTexture(ptr, m_definitions[i], context))
-			modified = true;
+		ensureTexture(ptr, m_definitions[i], context);
 		m_definitions[i].dirty = false;
 	}
 	
-	// make sude depth texture is removed and reset
-	if (m_depth_texture_index == NO_DEPTH_TEXTURE && m_depth_texture) {
-		m_driver->removeTexture(m_depth_texture);
-		m_depth_texture = nullptr;
-	}
-
-	if (!m_render_target)
-		m_render_target = m_driver->addRenderTarget();
-
-	if (modified)
-		m_render_target->setTexture(m_textures, m_depth_texture);
-
-	RenderTarget::reset(context);
-}
-
-void TextureBuffer::activate(PipelineContext &context)
-{
-	m_driver->setRenderTargetEx(m_render_target, m_clear ? video::ECBF_DEPTH | video::ECBF_COLOR : 0, context.clear_color);
-	RenderTarget::activate(context);
+	RenderSource::reset(context);
 }
 
 bool TextureBuffer::ensureTexture(video::ITexture **texture, const TextureDefinition& definition, PipelineContext &context)

--- a/src/client/render/pipeline.h
+++ b/src/client/render/pipeline.h
@@ -112,7 +112,7 @@ protected:
  *
  * @note Use of TextureBuffer requires use of gl_FragData[] in the shader
  */
-class TextureBuffer : public RenderSource, public RenderTarget
+class TextureBuffer : public RenderSource
 {
 public:
 	virtual ~TextureBuffer() override;
@@ -138,29 +138,8 @@ public:
 	 */
 	void setTexture(u8 index, v2f scale_factor, const std::string& name, video::ECOLOR_FORMAT format);
 
-	/**
-	 * @Configure depth texture and assign index
-	 * 
-	 * @param index index to use for the depth texture
-	 * @param size width and height of the texture in pixels
-	 * @param name unique name for the texture
-	 * @param format color format
-	 */
-	void setDepthTexture(u8 index, core::dimension2du size, const std::string& name, video::ECOLOR_FORMAT format);
-
-	/**
-	 * @Configure depth texture and assign index
-	 * 
-	 * @param index index to use for the depth texture
-	 * @param scale_factor relation of the texture dimensions to the screen dimensions
-	 * @param name unique name for the texture
-	 * @param format color format
-	 */
-	void setDepthTexture(u8 index, v2f scale_factor, const std::string& name, video::ECOLOR_FORMAT format);
-
 	virtual u8 getTextureCount() override { return m_textures.size(); }
 	virtual video::ITexture *getTexture(u8 index) override;
-	virtual void activate(PipelineContext &context) override;
 	virtual void reset(PipelineContext &context) override;
 private:
 	static const u8 NO_DEPTH_TEXTURE = 255;
@@ -189,9 +168,6 @@ private:
 	video::IVideoDriver *m_driver { nullptr };
 	std::vector<TextureDefinition> m_definitions;
 	core::array<video::ITexture *> m_textures;
-	video::ITexture *m_depth_texture { nullptr };
-	u8 m_depth_texture_index { NO_DEPTH_TEXTURE };
-	video::IRenderTarget *m_render_target { nullptr };
 };
 
 /**

--- a/src/client/render/pipeline.h
+++ b/src/client/render/pipeline.h
@@ -201,10 +201,18 @@ class TextureBufferOutput : public RenderTarget
 {
 public:
 	TextureBufferOutput(TextureBuffer *buffer, u8 texture_index);
+	TextureBufferOutput(TextureBuffer *buffer, const std::vector<u8> &texture_map);
+	TextureBufferOutput(TextureBuffer *buffer, const std::vector<u8> &texture_map, u8 depth_stencil);
+	virtual ~TextureBufferOutput() override;
 	void activate(PipelineContext &context) override;
 private:
+	static const u8 NO_DEPTH_TEXTURE = 255;
+
 	TextureBuffer *buffer;
-	u8 texture_index;
+	std::vector<u8> texture_map;
+	u8 depth_stencil { NO_DEPTH_TEXTURE };
+	video::IRenderTarget* render_target { nullptr };
+	video::IVideoDriver* driver { nullptr };
 };
 
 /**

--- a/src/client/render/secondstage.cpp
+++ b/src/client/render/secondstage.cpp
@@ -125,6 +125,7 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 
 	// post-processing stage
 	// set up bloom
+	if (g_settings->getBool("enable_bloom"))
 	{
 		buffer->setTexture(TEXTURE_BLUR, scale * 0.5, "blur", color_format);
 		buffer->setTexture(TEXTURE_BLOOM, scale * 0.5, "bloom", color_format);

--- a/src/client/render/secondstage.h
+++ b/src/client/render/secondstage.h
@@ -22,7 +22,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "stereo.h"
 #include "pipeline.h"
 
-/// Step to apply post-processing filter to the rendered image
+/**
+ *  Step to apply post-processing filter to the rendered image
+ */
 class PostProcessingStep : public RenderStep
 {
 public:

--- a/src/client/render/secondstage.h
+++ b/src/client/render/secondstage.h
@@ -22,17 +22,31 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "stereo.h"
 #include "pipeline.h"
 
+/// Step to apply post-processing filter to the rendered image
 class PostProcessingStep : public RenderStep
 {
 public:
+	/**
+	 * Construct a new PostProcessingStep object
+	 * 
+	 * @param shader_id ID of the shader in IShaderSource
+	 * @param texture_map Map of textures to be chosen from the render source
+	 */
 	PostProcessingStep(u32 shader_id, const std::vector<u8> &texture_map);
 
-	
+
 	void setRenderSource(RenderSource *source) override;
 	void setRenderTarget(RenderTarget *target) override;
 	void reset(PipelineContext &context) override;
 	void run(PipelineContext &context) override;
 
+	/**
+	 * Configure bilinear filtering for a specific texture layer
+	 * 
+	 * @param index Index of the texture layer
+	 * @param value true to enable the bilinear filter, false to disable
+	 */
+	void setBilinearFilter(u8 index, bool value);
 private:
 	u32 shader_id;
 	std::vector<u8> texture_map;

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -46,6 +46,10 @@ class RenderingCore;
 class RenderingEngine
 {
 public:
+	/// Default color factor before applying effects like bloom or tomemapping
+	/// this is derived from tonemapping code and tuned empirically
+	static constexpr float DEFAULT_EXPOSURE_FACTOR = 2.5f;
+
 	RenderingEngine(IEventReceiver *eventReceiver);
 	~RenderingEngine();
 

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -778,6 +778,9 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		shaders_header << "#define SOFTSHADOWRADIUS " << shadow_soft_radius << "\n";
 	}
 
+	if (g_settings->getBool("enable_bloom"))
+		shaders_header << "#define ENABLE_BLOOM 1\n";
+
 	shaders_header << "#line 0\n"; // reset the line counter for meaningful diagnostics
 
 	std::string common_header = shaders_header.str();

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -682,6 +682,13 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		)";
 	}
 
+	// map legacy semantic texture names to texture identifiers
+	fragment_header += R"(
+		#define baseTexture texture0
+		#define normalTexture texture1
+		#define textureFlags texture2
+	)";
+
 	// Since this is the first time we're using the GL bindings be extra careful.
 	// This should be removed before 5.6.0 or similar.
 	if (!GL.GetString) {

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -778,8 +778,11 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		shaders_header << "#define SOFTSHADOWRADIUS " << shadow_soft_radius << "\n";
 	}
 
-	if (g_settings->getBool("enable_bloom"))
+	if (g_settings->getBool("enable_bloom")) {
 		shaders_header << "#define ENABLE_BLOOM 1\n";
+		if (g_settings->getBool("enable_bloom_debug"))
+			shaders_header << "#define ENABLE_BLOOM_DEBUG 1\n";
+	}
 
 	shaders_header << "#line 0\n"; // reset the line counter for meaningful diagnostics
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -263,6 +263,7 @@ void set_default_settings()
 	settings->setDefault("water_wave_speed", "5.0");
 	settings->setDefault("enable_waving_leaves", "false");
 	settings->setDefault("enable_waving_plants", "false");
+	settings->setDefault("exposure_factor", "1.0");
 
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -265,9 +265,8 @@ void set_default_settings()
 	settings->setDefault("enable_waving_plants", "false");
 	settings->setDefault("exposure_factor", "1.0");
 	settings->setDefault("enable_bloom", "false");
-	settings->setDefault("bloom_luminance_threshold", "1.0");
-	settings->setDefault("bloom_intensity", "1.0");
-	settings->setDefault("bloom_radius", "3");
+	settings->setDefault("bloom_intensity", "0.05");
+	settings->setDefault("bloom_radius", "16");
 
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -265,6 +265,7 @@ void set_default_settings()
 	settings->setDefault("enable_waving_plants", "false");
 	settings->setDefault("exposure_factor", "1.0");
 	settings->setDefault("enable_bloom", "false");
+	settings->setDefault("enable_bloom_debug", "false");
 	settings->setDefault("bloom_intensity", "0.05");
 	settings->setDefault("bloom_radius", "16");
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -266,7 +266,7 @@ void set_default_settings()
 	settings->setDefault("exposure_factor", "1.0");
 	settings->setDefault("enable_bloom", "false");
 	settings->setDefault("bloom_luminance_threshold", "1.0");
-	settings->setDefault("bloom_boost", "0.0");
+	settings->setDefault("bloom_intensity", "1.0");
 
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -266,6 +266,7 @@ void set_default_settings()
 	settings->setDefault("exposure_factor", "1.0");
 	settings->setDefault("enable_bloom", "false");
 	settings->setDefault("enable_bloom_debug", "false");
+	settings->setDefault("enable_bloom_dedicated_texture", "false");
 	settings->setDefault("bloom_intensity", "0.05");
 	settings->setDefault("bloom_radius", "16");
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -267,6 +267,7 @@ void set_default_settings()
 	settings->setDefault("enable_bloom", "false");
 	settings->setDefault("bloom_luminance_threshold", "1.0");
 	settings->setDefault("bloom_intensity", "1.0");
+	settings->setDefault("bloom_radius", "3");
 
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -265,6 +265,8 @@ void set_default_settings()
 	settings->setDefault("enable_waving_plants", "false");
 	settings->setDefault("exposure_factor", "1.0");
 	settings->setDefault("enable_bloom", "false");
+	settings->setDefault("bloom_luminance_threshold", "1.0");
+	settings->setDefault("bloom_boost", "0.0");
 
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -264,6 +264,7 @@ void set_default_settings()
 	settings->setDefault("enable_waving_leaves", "false");
 	settings->setDefault("enable_waving_plants", "false");
 	settings->setDefault("exposure_factor", "1.0");
+	settings->setDefault("enable_bloom", "false");
 
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");


### PR DESCRIPTION
This PR adds exposure control and bloom effect to the game.

The following settings are introduced:
* `exposure_factor` emulates the amount of light that is captured on screen. Default: 1.0, min: 0.1, max: 10.0
* `enable_bloom` turns bloom effect on and off
* `bloom_intensity` controls the amount of bloom on screen. Default: 0.05, min: 0.01 max: 1.0
* `bloom_radius` controls the size of the blur convolution kernel. Default: 16, min: 1, max: 64

## To do

This PR is Ready for Review.

## How to test

1. Turn bloom on
2. Start any game
3. Find scene where source of light overlaps a dark object. Examples:
  * Looking at the sky/sun from a dark cave
  * Looking at lava from around a corner
  * Lava in front of obsidian
  * Forest skyline
4. Notice that the light bleeds from the light source to the dark area

Experiments:
* Type `/set exposure_factor 2` - entire scene becomes lighter
* Type `/set bloom_radius 32` - light bleeds further into the dark areas
* Type `/set bloom_intensity 0.15` - the intensity of bloom effect is higher.