### PR TITLE
Improve double tap for jump detection

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -619,7 +619,10 @@ struct GameRunData {
 	float time_from_last_punch;
 	ClientActiveObject *selected_object;
 
-	float jump_timer;
+	float jump_timer_up;          // from key up until key down
+	float jump_timer_down;        // since last key down
+	float jump_timer_down_before; // from key down until key down again
+
 	float damage_flash;
 	float update_draw_list_timer;
 
@@ -1875,8 +1878,10 @@ void Game::processUserInput(f32 dtime)
 #endif
 
 	// Increase timer for double tap of "keymap_jump"
-	if (m_cache_doubletap_jump && runData.jump_timer <= 0.2f)
-		runData.jump_timer += dtime;
+	if (m_cache_doubletap_jump && runData.jump_timer_up <= 0.2f)
+		runData.jump_timer_up += dtime;
+	if (m_cache_doubletap_jump && runData.jump_timer_down <= 0.4f)
+		runData.jump_timer_down += dtime;
 
 	processKeyInput();
 	processItemSelection(&runData.new_playeritem);
@@ -1997,7 +2002,7 @@ void Game::processKeyInput()
 
 	if (!isKeyDown(KeyType::JUMP) && runData.reset_jump_timer) {
 		runData.reset_jump_timer = false;
-		runData.jump_timer = 0.0f;
+		runData.jump_timer_up = 0.0f;
 	}
 
 	if (quicktune->hasMessage()) {
@@ -2138,7 +2143,14 @@ void Game::toggleFreeMove()
 
 void Game::toggleFreeMoveAlt()
 {
-	if (m_cache_doubletap_jump && runData.jump_timer < 0.2f)
+	if (!runData.reset_jump_timer) {
+		runData.jump_timer_down_before = runData.jump_timer_down;
+		runData.jump_timer_down = 0.0f;
+	}
+
+	// key down (0.2 s max.), then key up (0.2 s max.), then key down
+	if (m_cache_doubletap_jump && runData.jump_timer_up < 0.2f &&
+			runData.jump_timer_down_before < 0.4f) // 0.2 + 0.2
 		toggleFreeMove();
 
 	runData.reset_jump_timer = true;


### PR DESCRIPTION
**Goal of the PR**
Improve the double jump toggling by not toggling fly if the first key press is too long.

**How does the PR work?**
This PR adds another timer for the jump key. There are now two timers: (1) between the start of key downs and (2) from key up to key down.

```
key down           key up           key down             now
    |                 |                 |                 |
    |                 +-----------------+                 |
    |                    jump_timer_up  +-----------------+
    |                                   | jump_timer_down
    +-----------------------------------+
           jump_timer_down_before
```

**Does it resolve any reported issue?**
Yes, this PR tries to fix #12738.

**Does this relate to a goal in the roadmap?**
Probably, this PR tries to fix gameplay/control-related bug.

## To do
This PR is Ready for Review.

## How to test
1. Play any Minetest world.
2. Press the jump key quickly (200 ms max.).
3. Release the jump key for a short time (200 ms max.).
4. Press the jump key again.
5. The last key press should toggle the fly mode.
6. Press the jump key for a long time (200 ms min.).
7. Release the jump key for a short time (200 ms max.).
8. Press the jump key again.
9. The last key press should **not** toggle the fly mode.