### PR TITLE
Fix formspec focus

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3046,7 +3046,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		}
 	} else {
 		// Don't keep old focus value
-		m_focused_element.clear();
+		m_focused_element = nullopt;
 	}
 
 	// Remove children

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -32,6 +32,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiTable.h"
 #include "network/networkprotocol.h"
 #include "client/joystick_controller.h"
+#include "util/Optional.h"
 #include "util/string.h"
 #include "util/enriched_string.h"
 #include "StyleSpec.h"
@@ -352,13 +353,13 @@ protected:
 	video::SColor m_default_tooltip_color;
 
 private:
-	IFormSource        *m_form_src;
-	TextDest           *m_text_dst;
-	std::string         m_last_formname;
-	u16                 m_formspec_version = 1;
-	std::string         m_focused_element = "";
-	JoystickController *m_joystick;
-	bool m_show_debug = false;
+	IFormSource          *m_form_src;
+	TextDest             *m_text_dst;
+	std::string           m_last_formname;
+	u16                   m_formspec_version = 1;
+	Optional<std::string> m_focused_element = nullopt;
+	JoystickController   *m_joystick;
+	bool                  m_show_debug = false;
 
 	struct parserData {
 		bool explicit_size;

--- a/src/util/Optional.h
+++ b/src/util/Optional.h
@@ -103,3 +103,57 @@ public:
 
 	explicit operator bool() const { return m_has_value; }
 };
+
+template <typename T>
+constexpr bool operator==(const Optional<T> &opt, nullopt_t)
+{
+	return !opt.has_value();
+}
+template <typename T>
+constexpr bool operator==(nullopt_t, const Optional<T> &opt)
+{
+	return !opt.has_value();
+}
+template <typename T>
+constexpr bool operator!=(const Optional<T> &opt, nullopt_t)
+{
+	return opt.has_value();
+}
+template <typename T>
+constexpr bool operator!=(nullopt_t, const Optional<T> &opt)
+{
+	return opt.has_value();
+}
+
+template <typename T, typename U>
+constexpr bool operator==(const Optional<T> &opt, const U &value)
+{
+	return opt.has_value() && *opt == value;
+}
+template <typename T, typename U>
+constexpr bool operator==(const T &value, const Optional<U> &opt)
+{
+	return opt.has_value() && value == *opt;
+}
+template <typename T, typename U>
+constexpr bool operator!=(const Optional<T> &opt, const U &value)
+{
+	return !opt.has_value() || *opt != value;
+}
+template <typename T, typename U>
+constexpr bool operator!=(const T &value, const Optional<U> &opt)
+{
+	return !opt.has_value() || value != *opt;
+}
+
+
+template <typename T, typename U>
+constexpr bool operator==(const Optional<T> &lhs, const Optional<U> &rhs)
+{
+	return lhs.has_value() ? *lhs == rhs : nullopt == rhs;
+}
+template <typename T, typename U>
+constexpr bool operator!=(const Optional<T> &lhs, const Optional<U> &rhs)
+{
+	return lhs.has_value() ? *lhs != rhs : nullopt != rhs;
+}


### PR DESCRIPTION
- Fixes #12784.
- The comparison operators for `Optional` should match those of C++17 `std::optional`.

## To do

This PR is a Ready for Review.

Don't squash.

## How to test

Try to reproduce #12784.
