### PR TITLE
Pass CFLAGS and CPPFLAGS to build process

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
 	FORCE
 )
 
+set(CMAKE_C_FLAGS "${CMAKE_CFLAGS}  $ENV{CFLAGS} $ENV{CPPFLAGS}")
 
 # Set some random things default to not being visible in the GUI
 mark_as_advanced(EXECUTABLE_OUTPUT_PATH LIBRARY_OUTPUT_PATH)
@@ -756,7 +757,7 @@ else()
 		endif()
 	endif()
 
-	set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG ${RELEASE_WARNING_FLAGS} ${OTHER_FLAGS} -pipe -funroll-loops")
+	set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG ${RELEASE_WARNING_FLAGS} ${OTHER_FLAGS} -pipe -funroll-loops $ENV{CPPFLAGS}")
 	if(CMAKE_SYSTEM_NAME MATCHES "(Darwin|BSD|DragonFly)")
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Os")
 	else()


### PR DESCRIPTION
When overriding compiler options in CMake, it does not by default honor environment set compiler options, this has to be manually considered. In Debian, CFLAGS and CPPFLAGS are injected by the enviornmnent to set some archive-wide defaults, for example enabling hardening features.

(If the environment variables are not set, this patch has no effect.)

Patch origin:
https://salsa.debian.org/games-team/minetest/-/blob/master/debian/patches/enable_hardening.patch (minus some extra blank lines, which I missed when creating the patch for Debian))
