### PR TITLE
Fix liquid drawtype faces sometimes not rendering

### DIFF
--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -651,7 +651,7 @@ static u8 face_contents(content_t m1, content_t m2, bool *equivalent,
 	const ContentFeatures &f2 = ndef->get(m2);
 
 	// Contents don't differ for different forms of same liquid
-	if (f1.sameLiquid(f2))
+	if (f1.sameLiquidRender(f2))
 		return 0;
 
 	u8 c1 = f1.solidness;
@@ -668,9 +668,9 @@ static u8 face_contents(content_t m1, content_t m2, bool *equivalent,
 	if (c1 == c2) {
 		*equivalent = true;
 		// If same solidness, liquid takes precense
-		if (f1.isLiquid())
+		if (f1.isLiquidRender())
 			return 1;
-		if (f2.isLiquid())
+		if (f2.isLiquidRender())
 			return 2;
 	}
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1681,7 +1681,7 @@ static void removeDupes(std::vector<content_t> &list)
 void NodeDefManager::resolveCrossrefs()
 {
 	for (ContentFeatures &f : m_content_features) {
-		if (f.liquid_type != LIQUID_NONE || f.drawtype == NDT_LIQUID || f.drawtype == NDT_FLOWINGLIQUID) {
+		if (f.isLiquidRender()) {
 			f.liquid_alternative_flowing_id = getId(f.liquid_alternative_flowing);
 			f.liquid_alternative_source_id = getId(f.liquid_alternative_source);
 			continue;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1681,7 +1681,7 @@ static void removeDupes(std::vector<content_t> &list)
 void NodeDefManager::resolveCrossrefs()
 {
 	for (ContentFeatures &f : m_content_features) {
-		if (f.isLiquidRender()) {
+		if (f.isLiquid() || f.isLiquidRender()) {
 			f.liquid_alternative_flowing_id = getId(f.liquid_alternative_flowing);
 			f.liquid_alternative_source_id = getId(f.liquid_alternative_source);
 			continue;

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -500,9 +500,7 @@ struct ContentFeatures
 	bool sameLiquidRender(const ContentFeatures &f) const{
 		if (!isLiquidRender() || !f.isLiquidRender())
 			return false;
-		if (name == f.name)
-		       return true;
-		return (liquid_alternative_flowing_id != CONTENT_IGNORE) && (liquid_alternative_flowing_id == f.liquid_alternative_flowing_id);
+		return (liquid_alternative_flowing_id == f.liquid_alternative_flowing_id) && (liquid_alternative_source_id == f.liquid_alternative_source_id);
 	}
 
 	bool lightingEquivalent(const ContentFeatures &other) const {

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -493,9 +493,16 @@ struct ContentFeatures
 	bool isLiquid() const{
 		return (liquid_type != LIQUID_NONE);
 	}
-	bool sameLiquid(const ContentFeatures &f) const{
-		if(!isLiquid() || !f.isLiquid()) return false;
-		return (liquid_alternative_flowing_id == f.liquid_alternative_flowing_id);
+
+	bool isLiquidRender() const{
+		return (drawtype == NDT_LIQUID || drawtype == NDT_FLOWINGLIQUID);
+	}
+	bool sameLiquidRender(const ContentFeatures &f) const{
+		if (!isLiquidRender() || !f.isLiquidRender())
+			return false;
+		if (name == f.name)
+		       return true;
+		return (liquid_alternative_flowing_id != CONTENT_IGNORE) && (liquid_alternative_flowing_id == f.liquid_alternative_flowing_id);
 	}
 
 	bool lightingEquivalent(const ContentFeatures &other) const {

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -494,13 +494,15 @@ struct ContentFeatures
 		return (liquid_type != LIQUID_NONE);
 	}
 
-	bool isLiquidRender() const{
+	bool isLiquidRender() const {
 		return (drawtype == NDT_LIQUID || drawtype == NDT_FLOWINGLIQUID);
 	}
-	bool sameLiquidRender(const ContentFeatures &f) const{
+
+	bool sameLiquidRender(const ContentFeatures &f) const {
 		if (!isLiquidRender() || !f.isLiquidRender())
 			return false;
-		return (liquid_alternative_flowing_id == f.liquid_alternative_flowing_id) && (liquid_alternative_source_id == f.liquid_alternative_source_id);
+		return liquid_alternative_flowing_id == f.liquid_alternative_flowing_id &&
+			liquid_alternative_source_id == f.liquid_alternative_source_id;
 	}
 
 	bool lightingEquivalent(const ContentFeatures &other) const {


### PR DESCRIPTION
Fixes #12718.

## Implementation details

The problem was, as I have suspected, that the rendering code checked `liquidtype` instead of the drawtype via `isLiquid` and `sameLiquid`. This is incorrect because liquid flowing physics are supposed to be completely independent from liquid rendering.

So the bugfix is check for the drawtype only, not liquidtype, because it's about rendering, not liquid flowing.

The `sameLiquid` function was removed because it had only one caller. It has been replaced by `sameLiquidRender`.

## How to test

Use the drawtype test nodes from DevTest (like `testnodes:liquid_3`) and surround them in glass (`testnodes:glasslike`). Viewed from every side, the liquid must look correctly.

Surround the various other liquid test nodes with glass for comparison.

Also you might test liquids in DevTest in general to make sure that other liquid features weren't accidentally broken.
