### PR TITLE
[NO SQUASH] Remove unused MapBlock functionality, in particular dummy blocks

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -311,7 +311,7 @@ void RemoteClient::GetNextBlocks (
 				block->resetUsageTimer();
 
 				// Check whether the block exists (with data)
-				if (block->isDummy() || !block->isGenerated())
+				if (!block->isGenerated())
 					block_not_found = true;
 
 				/*

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -596,7 +596,7 @@ EmergeAction EmergeThread::getBlockOrStartGen(
 
 	// 1). Attempt to fetch block from memory
 	*block = m_map->getBlockNoCreateNoEx(pos);
-	if (*block && !(*block)->isDummy()) {
+	if (*block) {
 		if ((*block)->isGenerated())
 			return EMERGE_FROM_MEMORY;
 	} else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1131,14 +1131,16 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 		iss.str(data);
 		iss.clear();
 
-		MapBlock mb(nullptr, v3s16(0,0,0), &server);
-		u8 ver = readU8(iss);
-		mb.deSerialize(iss, ver, true);
+		{
+			MapBlock mb(nullptr, v3s16(0,0,0), &server);
+			u8 ver = readU8(iss);
+			mb.deSerialize(iss, ver, true);
 
-		oss.str("");
-		oss.clear();
-		writeU8(oss, serialize_as_ver);
-		mb.serialize(oss, serialize_as_ver, true, -1);
+			oss.str("");
+			oss.clear();
+			writeU8(oss, serialize_as_ver);
+			mb.serialize(oss, serialize_as_ver, true, -1);
+		}
 
 		db->saveBlock(*it, oss.str());
 

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -66,14 +66,14 @@ static const char *modified_reason_strings[] = {
 	MapBlock
 */
 
-MapBlock::MapBlock(Map *parent, v3s16 pos, IGameDef *gamedef, bool dummy):
+MapBlock::MapBlock(Map *parent, v3s16 pos, IGameDef *gamedef):
 		m_parent(parent),
 		m_pos(pos),
 		m_pos_relative(pos * MAP_BLOCKSIZE),
-		m_gamedef(gamedef)
+		m_gamedef(gamedef),
+		data(new MapNode[nodecount])
 {
-	if (!dummy)
-		reallocate();
+	reallocate();
 }
 
 MapBlock::~MapBlock()
@@ -102,11 +102,6 @@ MapNode MapBlock::getNodeParent(v3s16 p, bool *is_valid_position)
 	if (!isValidPosition(p))
 		return m_parent->getNode(getPosRelative() + p, is_valid_position);
 
-	if (!data) {
-		if (is_valid_position)
-			*is_valid_position = false;
-		return {CONTENT_IGNORE};
-	}
 	if (is_valid_position)
 		*is_valid_position = true;
 	return data[p.Z * zstride + p.Y * ystride + p.X];
@@ -161,11 +156,6 @@ void MapBlock::actuallyUpdateDayNightDiff()
 	// Running this function un-expires m_day_night_differs
 	m_day_night_differs_expired = false;
 
-	if (!data) {
-		m_day_night_differs = false;
-		return;
-	}
-
 	bool differs = false;
 
 	/*
@@ -209,12 +199,6 @@ void MapBlock::actuallyUpdateDayNightDiff()
 
 void MapBlock::expireDayNightDiff()
 {
-	if (!data) {
-		m_day_night_differs = false;
-		m_day_night_differs_expired = false;
-		return;
-	}
-
 	m_day_night_differs_expired = true;
 }
 
@@ -339,9 +323,6 @@ void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int
 	if(!ser_ver_supported(version))
 		throw VersionMismatchException("ERROR: MapBlock format not supported");
 
-	if (!data)
-		throw SerializationError("ERROR: Not writing dummy block.");
-
 	FATAL_ERROR_IF(version < SER_FMT_VER_LOWEST_WRITE, "Serialisation version error");
 
 	std::ostringstream os_raw(std::ios_base::binary);
@@ -446,10 +427,6 @@ void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int
 
 void MapBlock::serializeNetworkSpecific(std::ostream &os)
 {
-	if (!data) {
-		throw SerializationError("ERROR: Not writing dummy block.");
-	}
-
 	writeU8(os, 2); // version
 }
 
@@ -861,52 +838,45 @@ std::string analyze_block(MapBlock *block)
 
 	desc<<"lighting_complete: "<<block->getLightingComplete()<<", ";
 
-	if(block->isDummy())
+	bool full_ignore = true;
+	bool some_ignore = false;
+	bool full_air = true;
+	bool some_air = false;
+	for(s16 z0=0; z0<MAP_BLOCKSIZE; z0++)
+	for(s16 y0=0; y0<MAP_BLOCKSIZE; y0++)
+	for(s16 x0=0; x0<MAP_BLOCKSIZE; x0++)
 	{
-		desc<<"Dummy, ";
+		v3s16 p(x0,y0,z0);
+		MapNode n = block->getNodeNoEx(p);
+		content_t c = n.getContent();
+		if(c == CONTENT_IGNORE)
+			some_ignore = true;
+		else
+			full_ignore = false;
+		if(c == CONTENT_AIR)
+			some_air = true;
+		else
+			full_air = false;
 	}
-	else
-	{
-		bool full_ignore = true;
-		bool some_ignore = false;
-		bool full_air = true;
-		bool some_air = false;
-		for(s16 z0=0; z0<MAP_BLOCKSIZE; z0++)
-		for(s16 y0=0; y0<MAP_BLOCKSIZE; y0++)
-		for(s16 x0=0; x0<MAP_BLOCKSIZE; x0++)
-		{
-			v3s16 p(x0,y0,z0);
-			MapNode n = block->getNodeNoEx(p);
-			content_t c = n.getContent();
-			if(c == CONTENT_IGNORE)
-				some_ignore = true;
-			else
-				full_ignore = false;
-			if(c == CONTENT_AIR)
-				some_air = true;
-			else
-				full_air = false;
-		}
 
-		desc<<"content {";
+	desc<<"content {";
 
-		std::ostringstream ss;
+	std::ostringstream ss;
 
-		if(full_ignore)
-			ss<<"IGNORE (full), ";
-		else if(some_ignore)
-			ss<<"IGNORE, ";
+	if(full_ignore)
+		ss<<"IGNORE (full), ";
+	else if(some_ignore)
+		ss<<"IGNORE, ";
 
-		if(full_air)
-			ss<<"AIR (full), ";
-		else if(some_air)
-			ss<<"AIR, ";
+	if(full_air)
+		ss<<"AIR (full), ";
+	else if(some_air)
+		ss<<"AIR, ";
 
-		if(ss.str().size()>=2)
-			desc<<ss.str().substr(0, ss.str().size()-2);
+	if(ss.str().size()>=2)
+		desc<<ss.str().substr(0, ss.str().size()-2);
 
-		desc<<"}, ";
-	}
+	desc<<"}, ";
 
 	return desc.str().substr(0, desc.str().size()-2);
 }

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -70,8 +70,7 @@ MapBlock::MapBlock(Map *parent, v3s16 pos, IGameDef *gamedef):
 		m_parent(parent),
 		m_pos(pos),
 		m_pos_relative(pos * MAP_BLOCKSIZE),
-		m_gamedef(gamedef),
-		data(new MapNode[nodecount])
+		m_gamedef(gamedef)
 {
 	reallocate();
 }
@@ -84,8 +83,6 @@ MapBlock::~MapBlock()
 		mesh = nullptr;
 	}
 #endif
-
-	delete[] data;
 }
 
 bool MapBlock::isValidPositionParent(v3s16 p)

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -481,8 +481,6 @@ private:
 
 	IGameDef *m_gamedef;
 
-	MapNode *const data;
-
 	/*
 		- On the server, this is used for telling whether the
 		  block has been modified from the one on disk.
@@ -536,6 +534,8 @@ private:
 		the list of blocks to be drawn.
 	*/
 	int m_refcount = 0;
+
+	MapNode data[nodecount];
 };
 
 typedef std::vector<MapBlock*> MapBlockVect;

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -73,7 +73,7 @@ class VoxelManipulator;
 class MapBlock
 {
 public:
-	MapBlock(Map *parent, v3s16 pos, IGameDef *gamedef, bool dummy=false);
+	MapBlock(Map *parent, v3s16 pos, IGameDef *gamedef);
 	~MapBlock();
 
 	/*virtual u16 nodeContainerId() const
@@ -88,11 +88,8 @@ public:
 
 	void reallocate()
 	{
-		delete[] data;
-		data = new MapNode[nodecount];
 		for (u32 i = 0; i < nodecount; i++)
 			data[i] = MapNode(CONTENT_IGNORE);
-
 		raiseModified(MOD_STATE_WRITE_NEEDED, MOD_REASON_REALLOCATE);
 	}
 
@@ -139,17 +136,6 @@ public:
 	////
 	//// Flags
 	////
-
-	inline bool isDummy() const
-	{
-		return !data;
-	}
-
-	inline void unDummify()
-	{
-		assert(isDummy()); // Pre-condition
-		reallocate();
-	}
 
 	// is_underground getter/setter
 	inline bool getIsUnderground()
@@ -242,8 +228,7 @@ public:
 
 	inline bool isValidPosition(s16 x, s16 y, s16 z)
 	{
-		return data
-			&& x >= 0 && x < MAP_BLOCKSIZE
+		return x >= 0 && x < MAP_BLOCKSIZE
 			&& y >= 0 && y < MAP_BLOCKSIZE
 			&& z >= 0 && z < MAP_BLOCKSIZE;
 	}
@@ -274,7 +259,7 @@ public:
 		return getNode(p.X, p.Y, p.Z, &is_valid);
 	}
 
-	inline void setNode(s16 x, s16 y, s16 z, MapNode & n)
+	inline void setNode(s16 x, s16 y, s16 z, MapNode n)
 	{
 		if (!isValidPosition(x, y, z))
 			throw InvalidPositionException();
@@ -283,7 +268,7 @@ public:
 		raiseModified(MOD_STATE_WRITE_NEEDED, MOD_REASON_SET_NODE);
 	}
 
-	inline void setNode(v3s16 p, MapNode & n)
+	inline void setNode(v3s16 p, MapNode n)
 	{
 		setNode(p.X, p.Y, p.Z, n);
 	}
@@ -292,46 +277,23 @@ public:
 	//// Non-checking variants of the above
 	////
 
-	inline MapNode getNodeNoCheck(s16 x, s16 y, s16 z, bool *valid_position)
-	{
-		*valid_position = data != nullptr;
-		if (!*valid_position)
-			return {CONTENT_IGNORE};
-
-		return data[z * zstride + y * ystride + x];
-	}
-
-	inline MapNode getNodeNoCheck(v3s16 p, bool *valid_position)
-	{
-		return getNodeNoCheck(p.X, p.Y, p.Z, valid_position);
-	}
-
-	////
-	//// Non-checking, unsafe variants of the above
-	//// MapBlock must be loaded by another function in the same scope/function
-	//// Caller must ensure that this is not a dummy block (by calling isDummy())
-	////
-
-	inline const MapNode &getNodeUnsafe(s16 x, s16 y, s16 z)
+	inline MapNode getNodeNoCheck(s16 x, s16 y, s16 z)
 	{
 		return data[z * zstride + y * ystride + x];
 	}
 
-	inline const MapNode &getNodeUnsafe(v3s16 &p)
+	inline MapNode getNodeNoCheck(v3s16 p)
 	{
-		return getNodeUnsafe(p.X, p.Y, p.Z);
+		return getNodeNoCheck(p.X, p.Y, p.Z);
 	}
 
-	inline void setNodeNoCheck(s16 x, s16 y, s16 z, MapNode & n)
+	inline void setNodeNoCheck(s16 x, s16 y, s16 z, MapNode n)
 	{
-		if (!data)
-			throw InvalidPositionException();
-
 		data[z * zstride + y * ystride + x] = n;
 		raiseModified(MOD_STATE_WRITE_NEEDED, MOD_REASON_SET_NODE_NO_CHECK);
 	}
 
-	inline void setNodeNoCheck(v3s16 p, MapNode & n)
+	inline void setNodeNoCheck(v3s16 p, MapNode n)
 	{
 		setNodeNoCheck(p.X, p.Y, p.Z, n);
 	}
@@ -432,12 +394,12 @@ public:
 	//// Node Timers
 	////
 
-	inline NodeTimer getNodeTimer(const v3s16 &p)
+	inline NodeTimer getNodeTimer(v3s16 p)
 	{
 		return m_node_timers.get(p);
 	}
 
-	inline void removeNodeTimer(const v3s16 &p)
+	inline void removeNodeTimer(v3s16 p)
 	{
 		m_node_timers.remove(p);
 	}
@@ -472,23 +434,6 @@ private:
 	*/
 
 	void deSerialize_pre22(std::istream &is, u8 version, bool disk);
-
-	/*
-		Used only internally, because changes can't be tracked
-	*/
-
-	inline MapNode &getNodeRef(s16 x, s16 y, s16 z)
-	{
-		if (!isValidPosition(x, y, z))
-			throw InvalidPositionException();
-
-		return data[z * zstride + y * ystride + x];
-	}
-
-	inline MapNode &getNodeRef(v3s16 &p)
-	{
-		return getNodeRef(p.X, p.Y, p.Z);
-	}
 
 public:
 	/*
@@ -536,11 +481,7 @@ private:
 
 	IGameDef *m_gamedef;
 
-	/*
-		If NULL, block is a dummy block.
-		Dummy blocks are used for caching not-found-on-disk blocks.
-	*/
-	MapNode *data = nullptr;
+	MapNode *const data;
 
 	/*
 		- On the server, this is used for telling whether the
@@ -624,12 +565,12 @@ inline bool blockpos_over_max_limit(v3s16 p)
 /*
 	Returns the position of the block where the node is located
 */
-inline v3s16 getNodeBlockPos(const v3s16 &p)
+inline v3s16 getNodeBlockPos(v3s16 p)
 {
 	return getContainerPos(p, MAP_BLOCKSIZE);
 }
 
-inline void getNodeBlockPosWithOffset(const v3s16 &p, v3s16 &block, v3s16 &offset)
+inline void getNodeBlockPosWithOffset(v3s16 p, v3s16 &block, v3s16 &offset)
 {
 	getContainerPosWithOffset(p, MAP_BLOCKSIZE, block, offset);
 }

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -135,7 +135,7 @@ struct ContentFeatures;
 */
 
 
-struct MapNode
+struct alignas(u32) MapNode
 {
 	/*
 		Main content

--- a/src/reflowscan.cpp
+++ b/src/reflowscan.cpp
@@ -85,13 +85,12 @@ inline MapBlock *ReflowScan::lookupBlock(int x, int y, int z)
 inline bool ReflowScan::isLiquidFlowableTo(int x, int y, int z)
 {
 	// Tests whether (x,y,z) is a node to which liquid might flow.
-	bool valid_position;
 	MapBlock *block = lookupBlock(x, y, z);
 	if (block) {
 		int dx = (MAP_BLOCKSIZE + x) % MAP_BLOCKSIZE;
 		int dy = (MAP_BLOCKSIZE + y) % MAP_BLOCKSIZE;
 		int dz = (MAP_BLOCKSIZE + z) % MAP_BLOCKSIZE;
-		MapNode node = block->getNodeNoCheck(dx, dy, dz, &valid_position);
+		MapNode node = block->getNodeNoCheck(dx, dy, dz);
 		if (node.getContent() != CONTENT_IGNORE) {
 			const ContentFeatures &f = m_ndef->get(node);
 			// NOTE: No need to check for flowing nodes with lower liquid level
@@ -115,8 +114,6 @@ inline bool ReflowScan::isLiquidHorizontallyFlowable(int x, int y, int z)
 
 void ReflowScan::scanColumn(int x, int z)
 {
-	bool valid_position;
-
 	// Is the column inside a loaded block?
 	MapBlock *block = lookupBlock(x, 0, z);
 	if (!block)
@@ -129,7 +126,7 @@ void ReflowScan::scanColumn(int x, int z)
 	// Get the state from the node above the scanned block
 	bool was_ignore, was_liquid;
 	if (above) {
-		MapNode node = above->getNodeNoCheck(dx, 0, dz, &valid_position);
+		MapNode node = above->getNodeNoCheck(dx, 0, dz);
 		was_ignore = node.getContent() == CONTENT_IGNORE;
 		was_liquid = m_ndef->get(node).isLiquid();
 	} else {
@@ -141,7 +138,7 @@ void ReflowScan::scanColumn(int x, int z)
 
 	// Scan through the whole block
 	for (s16 y = MAP_BLOCKSIZE - 1; y >= 0; y--) {
-		MapNode node = block->getNodeNoCheck(dx, y, dz, &valid_position);
+		MapNode node = block->getNodeNoCheck(dx, y, dz);
 		const ContentFeatures &f = m_ndef->get(node);
 		bool is_ignore = node.getContent() == CONTENT_IGNORE;
 		bool is_liquid = f.isLiquid();
@@ -179,7 +176,7 @@ void ReflowScan::scanColumn(int x, int z)
 	// Check the node below the current block
 	MapBlock *below = lookupBlock(x, -1, z);
 	if (below) {
-		MapNode node = below->getNodeNoCheck(dx, MAP_BLOCKSIZE - 1, dz, &valid_position);
+		MapNode node = below->getNodeNoCheck(dx, MAP_BLOCKSIZE - 1, dz);
 		const ContentFeatures &f = m_ndef->get(node);
 		bool is_ignore = node.getContent() == CONTENT_IGNORE;
 		bool is_liquid = f.isLiquid();

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -258,7 +258,6 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
 	v3s16 pos;
 	MapNode n;
 	content_t c;
-	bool pos_valid; // dummy, we know it's valid
 	auto it = getLBMsIntroducedAfter(stamp);
 	for (; it != m_lbm_lookup.end(); ++it) {
 		// Cache previous version to speedup lookup which has a very high performance
@@ -269,7 +268,7 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
 		for (pos.X = 0; pos.X < MAP_BLOCKSIZE; pos.X++)
 			for (pos.Y = 0; pos.Y < MAP_BLOCKSIZE; pos.Y++)
 				for (pos.Z = 0; pos.Z < MAP_BLOCKSIZE; pos.Z++) {
-					n = block->getNodeNoCheck(pos, &pos_valid);
+					n = block->getNodeNoCheck(pos);
 					c = n.getContent();
 
 					// If content_t are not matching perform an LBM lookup
@@ -850,7 +849,7 @@ public:
 	}
 	void apply(MapBlock *block, int &blocks_scanned, int &abms_run, int &blocks_cached)
 	{
-		if(m_aabms.empty() || block->isDummy())
+		if(m_aabms.empty())
 			return;
 
 		// Check the content type cache first
@@ -884,7 +883,7 @@ public:
 		for(p0.Y=0; p0.Y<MAP_BLOCKSIZE; p0.Y++)
 		for(p0.Z=0; p0.Z<MAP_BLOCKSIZE; p0.Z++)
 		{
-			const MapNode &n = block->getNodeUnsafe(p0);
+			const MapNode &n = block->getNodeNoCheck(p0);
 			content_t c = n.getContent();
 			// Cache content types as we go
 			if (!block->contents_cached && !block->do_not_cache_contents) {
@@ -920,7 +919,7 @@ public:
 						if (block->isValidPosition(p1)) {
 							// if the neighbor is found on the same map block
 							// get it straight from there
-							const MapNode &n = block->getNodeUnsafe(p1);
+							const MapNode &n = block->getNodeNoCheck(p1);
 							c = n.getContent();
 						} else {
 							// otherwise consult the map
@@ -1589,7 +1588,7 @@ ServerEnvironment::BlockStatus ServerEnvironment::getBlockStatus(v3s16 blockpos)
 		return BS_ACTIVE;
 
 	const MapBlock *block = m_map->getBlockNoCreateNoEx(blockpos);
-	if (block && !block->isDummy())
+	if (block)
 		return BS_LOADED;
 
 	if (m_map->isBlockInQueue(blockpos))


### PR DESCRIPTION
1. Dummy blocks are removed.
2. Functionality related to dummy blocks is removed.
3. Some other miscellaneous unused functionality is removed.
4. Block data is stored directly in the `MapBlock` to reduce pointer indirection. x86 has a fixed offset + array index addressing mode.
5. MapNodes are aligned to a 4 byte boundary to avoid potential unaligned loads and make 4-byte loads possible on some ARM CPUs.
6. `MapBlock mb` in `main.cpp` is put inside a scope to prevent the large amount of block data from taking up stack space for longer than it has to.

## To do

This PR is Ready for Review.

## How to test

Run the unit tests and play the game.
