### PR TITLE
Fix broken fixed_virtual_joystick

### DIFF
--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -769,7 +769,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 			m_rarecontrolsbar.deactivate();
 
 			s32 dxj = event.TouchInput.X - button_size * 5.0f / 2.0f;
-			s32 dyj = event.TouchInput.Y - m_screensize.Y + button_size * 5.0f / 2.0f;
+			s32 dyj = event.TouchInput.Y - (s32)m_screensize.Y + button_size * 5.0f / 2.0f;
 
 			/* Select joystick when left 1/3 of screen dragged or
 			 * when joystick tapped (fixed joystick position)
@@ -818,8 +818,9 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 	} else {
 		assert(event.TouchInput.Event == ETIE_MOVED);
 
-		if (m_pointerpos[event.TouchInput.ID] ==
-				v2s32(event.TouchInput.X, event.TouchInput.Y))
+		if (!(m_has_joystick_id && m_fixed_joystick) &&
+				m_pointerpos[event.TouchInput.ID] ==
+						v2s32(event.TouchInput.X, event.TouchInput.Y))
 			return;
 
 		if (m_has_move_id) {
@@ -872,14 +873,14 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 			s32 dx = X - m_pointerpos[event.TouchInput.ID].X;
 			s32 dy = Y - m_pointerpos[event.TouchInput.ID].Y;
 			if (m_fixed_joystick) {
-				dx = X - button_size * 5 / 2;
-				dy = Y - m_screensize.Y + button_size * 5 / 2;
+				dx = X - button_size * 5.0f / 2.0f;
+				dy = Y - (s32)m_screensize.Y + button_size * 5.0f / 2.0f;
 			}
 
 			double distance_sq = dx * dx + dy * dy;
 
 			s32 dxj = event.TouchInput.X - button_size * 5.0f / 2.0f;
-			s32 dyj = event.TouchInput.Y - m_screensize.Y + button_size * 5.0f / 2.0f;
+			s32 dyj = event.TouchInput.Y - (s32)m_screensize.Y + button_size * 5.0f / 2.0f;
 			bool inside_joystick = (dxj * dxj + dyj * dyj <= button_size * button_size * 1.5 * 1.5);
 
 			if (m_joystick_has_really_moved || inside_joystick ||
@@ -930,8 +931,8 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 					s32 ndy = button_size * dy / distance - button_size / 2.0f;
 					if (m_fixed_joystick) {
 						m_joystick_btn_center->guibutton->setRelativePosition(v2s32(
-							button_size * 5 / 2 + ndx,
-							m_screensize.Y - button_size * 5 / 2 + ndy));
+							button_size * 5.0f / 2.0f + ndx,
+							m_screensize.Y - button_size * 5.0f / 2.0f + ndy));
 					} else {
 						m_joystick_btn_center->guibutton->setRelativePosition(v2s32(
 							m_pointerpos[event.TouchInput.ID].X + ndx,


### PR DESCRIPTION
**Goal of the PR**
Restore the behaviour of fixed virtual joystick as originally implemented.

**How does the PR work?**
This PR fixes some C++ implementation issues of the behaviour:
- The usage of `m_screensize` as `u32` produced underflow when it is used as a subtrahend.
- Virtual joystick's movement control calculation did not run when the position of the tap does not change.

**Does it resolve any reported issue?**
Yes, this PR tries to fixes #12002.

**Does this relate to a goal in the roadmap?**
Probably, this PR tries to fix gameplay/control-related bug.

## To do
This PR is Ready for Review.

## How to test
1. Use a device that uses touch screen.
2. Enable `fixed_virtual_joystick`.
3. Play any Minetest world.
4. Tap outside (especially above/below) the virtual joystick.
5. That tap should control the camera and should **not** control the movement (the middle "button" should **not** moved to the tap's location).
6. Tap inside the virtual joystick.
7. That tap should control the movement immediately (**no** need to move finger).