### PR TITLE
Fix inconsistent craft replacements (#9250)

### DIFF
--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -229,6 +229,7 @@ static void craftDecrementOrReplaceInput(CraftInput &input,
 				rep.deSerialize(j->second, gamedef->idef());
 				item.remove(1);
 				found_replacement = true;
+				pairs.erase(j);
 				output_replacements.push_back(rep);
 				break;
 


### PR DESCRIPTION
Fixes #9250.

How to test:

Use this recipe in MTG:
```
minetest.register_craft({
	type = "shaped",
	recipe = {
		{"group:leaves", "default:apple"},
		{"default:apple", "group:leaves"},
	},
	output = "default:dirt",
	replacements = {
		{"group:leaves", "default:sapling"},
	},
})
```

Craft this recipe.
One time craft it with exactly 1 of each of the 4 recipe input slots in the grid.
The other time, craft it with exactly 2 of each recipe input slots in the grid.

Both times, you should get 1 dirt as regular output plus 1 sapling.
In the first time, the sapling appears in the crafting grid.
In the second time, the sapling appears in your inventory instead.

(The bug was that in the second time, you might end up with 2 instead of 1 sapling, depending on the stack sizes of your input items.)

Shoutout to @p-ouellette!