### PR TITLE
Fix error message appearing if crafting replacements drop on the floor

### DIFF
--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -939,7 +939,7 @@ void ICraftAction::apply(InventoryManager *mgr,
 		do {
 			PLAYER_TO_SA(player)->item_OnDrop(output_replacement, player,
 				player->getBasePosition());
-			if (count >= output_replacement.count) {
+			if (count <= output_replacement.count) {
 				errorstream << "Couldn't drop replacement stack " <<
 					output_replacement.getItemString() << " because drop loop didn't "
 					"decrease count." << std::endl;


### PR DESCRIPTION
This PR fixes a faulty error message.

There was a rare log error message which appeared if you crafted something that had replacements and your inventory and crafting grid are too full so the items are dropped on the floor instead.

The error message was:

> Couldn't drop replacement stack  because drop loop didn't decrease count.

Relevant code snippet:

```
		u16 count = output_replacement.count;
		do {
			PLAYER_TO_SA(player)->item_OnDrop(output_replacement, player,
				player->getBasePosition());
			if (count >= output_replacement.count) {
				errorstream << "Couldn't drop replacement stack " <<
					output_replacement.getItemString() << " because drop loop didn't "
					"decrease count." << std::endl;

				break;
			}
		} while (!output_replacement.empty());
```

The mistake was in the `if` statement. The `>=` was the wrong way and should be `<=`.
The check is there to see if the stack count of the new stack is smaller than the original stack after dropping it on the floor with `item_OnDrop`. Another indicator that something was wrong that the itemstring in the actual error message was the empty string.

The original count is `count` and the new count is `output_replacement.count`. So, the expected case is that `count` is larger, and the error case should trigger if it is smaller or equal.
As you can see, the check is `count >= output_replacement.count`, so it got it wrong.
The fix is to change it to `count <= output_replacement.count`.

## How to test

Use this code for MTG:

```
minetest.register_craft({
	type = "shaped",
	recipe = {
		{"default:gold_ingot","default:gold_ingot","default:gold_ingot"},
		{"","default:apple",""},
	},
	output = "default:goldblock",
	replacements = {
		{"default:gold_ingot", "default:gold_lump"},
		{"default:gold_ingot", "default:iron_lump"},
		{"default:gold_ingot", "default:coal_lump"},
	},
})
```

Fill your inventory completely with dirt and put in the recipe, but with multiple gold ingots in the input slots. Then craft.
Expected: You get a gold block in your cursor, and a gold lump, iron lump and coal lump drop on the floor. NO error message.
