### PR TITLE
Avert collision static detection rounding error

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -255,7 +255,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	*speed_f += accel_f * dtime;
 
 	// If the object is static, there are no collisions
-	if (dpos_f == v3f(0.0f, 0.0f, 0.0f))
+	if (dpos_f == v3f())
 		return result;
 
 	// Limit speed for avoiding hangs

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -250,11 +250,12 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		time_notification_done = false;
 	}
 
-	v3f newpos_f = *pos_f + (*speed_f + accel_f * 0.5f * dtime) * dtime;
+	v3f dpos_f = (*speed_f + accel_f * 0.5f * dtime) * dtime;
+	v3f newpos_f = *pos_f + dpos_f;
 	*speed_f += accel_f * dtime;
 
 	// If the object is static, there are no collisions
-	if (newpos_f == *pos_f)
+	if (dpos_f == v3f(0.0f, 0.0f, 0.0f))
 		return result;
 
 	// Limit speed for avoiding hangs


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/12817. The check for non-movement is no longer subject to floating-point rounding error at large coordinates.

## To do

This PR is Ready for Review.

## How to test

Test that collision still works. Also test that footstep sounds still work, including the ones that should occur when you touch down on the ground. Test that footstep sounds work at high altitudes specifically. I did this by walking around inside an [area container](https://content.minetest.net/packages/jwmhjwmh/area_containers/).
