### PR TITLE
DevTest: Reject buggy "/hp inf" command

### DIFF
--- a/games/devtest/mods/util_commands/init.lua
+++ b/games/devtest/mods/util_commands/init.lua
@@ -28,7 +28,7 @@ minetest.register_chatcommand("hp", {
 			return false, "No player."
 		end
 		local hp = tonumber(param)
-		if not hp then
+		if not hp or minetest.is_nan(hp) or hp < 0 or hp > 65535 then
 			return false, "Missing or incorrect hp parameter!"
 		end
 		player:set_hp(hp)


### PR DESCRIPTION
Fixes #11817.

This will reject invalid arguments for the `hp` command like `inf` or numbers out of range.