### PR TITLE
DevTest: Explain purpose of most items in tooltips

### DIFF
--- a/games/devtest/mods/basenodes/init.lua
+++ b/games/devtest/mods/basenodes/init.lua
@@ -125,6 +125,7 @@ minetest.register_node("basenodes:pine_needles", {
 
 minetest.register_node("basenodes:water_source", {
 	description = "Water Source".."\n"..
+		"Swimmable, spreading, renewable liquid".."\n"..
 		"Drowning damage: 1",
 	drawtype = "liquid",
 	waving = 3,
@@ -151,6 +152,7 @@ minetest.register_node("basenodes:water_source", {
 
 minetest.register_node("basenodes:water_flowing", {
 	description = "Flowing Water".."\n"..
+		"Swimmable, spreading, renewable liquid".."\n"..
 		"Drowning damage: 1",
 	drawtype = "flowingliquid",
 	waving = 3,
@@ -180,6 +182,7 @@ minetest.register_node("basenodes:water_flowing", {
 
 minetest.register_node("basenodes:river_water_source", {
 	description = "River Water Source".."\n"..
+		"Swimmable, spreading, non-renewable liquid".."\n"..
 		"Drowning damage: 1",
 	drawtype = "liquid",
 	waving = 3,
@@ -208,6 +211,7 @@ minetest.register_node("basenodes:river_water_source", {
 
 minetest.register_node("basenodes:river_water_flowing", {
 	description = "Flowing River Water".."\n"..
+		"Swimmable, spreading, non-renewable liquid".."\n"..
 		"Drowning damage: 1",
 	drawtype = "flowingliquid",
 	waving = 3,
@@ -239,6 +243,7 @@ minetest.register_node("basenodes:river_water_flowing", {
 
 minetest.register_node("basenodes:lava_flowing", {
 	description = "Flowing Lava".."\n"..
+		"Swimmable, spreading, renewable liquid".."\n"..
 		"4 damage per second".."\n"..
 		"Drowning damage: 1",
 	drawtype = "flowingliquid",
@@ -266,6 +271,7 @@ minetest.register_node("basenodes:lava_flowing", {
 
 minetest.register_node("basenodes:lava_source", {
 	description = "Lava Source".."\n"..
+		"Swimmable, spreading, renewable liquid".."\n"..
 		"4 damage per second".."\n"..
 		"Drowning damage: 1",
 	drawtype = "liquid",
@@ -307,7 +313,7 @@ minetest.register_node("basenodes:mossycobble", {
 
 minetest.register_node("basenodes:apple", {
 	description = "Apple".."\n"..
-		"Food (+2)",
+		"Punch: Eat (+2)",
 	drawtype = "plantlike",
 	tiles ={"default_apple.png"},
 	inventory_image = "default_apple.png",

--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -424,9 +424,15 @@ minetest.register_tool("basetools:dagger_steel", {
 local uses = { 1, 2, 3, 5, 10, 50, 100, 1000, 10000, 65535 }
 for i=1, #uses do
 	local u = uses[i]
+	local ustring
+	if i == 1 then
+		ustring = u.."-Use"
+	else
+		ustring = u.."-Uses"
+	end
 	local color = string.format("#FF00%02X", math.floor(((i-1)/#uses) * 255))
 	minetest.register_tool("basetools:pick_uses_"..string.format("%05d", u), {
-		description = u.."-Uses Pickaxe".."\n"..
+		description = ustring.." Pickaxe".."\n"..
 			"Digs cracky=3",
 		inventory_image = "basetools_usespick.png^[colorize:"..color..":127",
 		tool_capabilities = {
@@ -438,7 +444,7 @@ for i=1, #uses do
 	})
 
 	minetest.register_tool("basetools:sword_uses_"..string.format("%05d", u), {
-		description = u.."-Uses Sword".."\n"..
+		description = ustring.." Sword".."\n"..
 			"Damage: fleshy=1",
 		inventory_image = "basetools_usessword.png^[colorize:"..color..":127",
 		tool_capabilities = {

--- a/games/devtest/mods/chest_of_everything/init.lua
+++ b/games/devtest/mods/chest_of_everything/init.lua
@@ -91,6 +91,7 @@ minetest.register_on_mods_loaded(function()
 	* Other tools
 	* Craftitems
 	* Other items
+	* Items from the 'broken' mod
 	* Dummy items ]]
 	local function compare(item1, item2)
 		local def1 = minetest.registered_items[item1]
@@ -101,6 +102,8 @@ minetest.register_on_mods_loaded(function()
 		local testtool2 = minetest.get_item_group(item2, "testtool") == 1
 		local dummy1 = minetest.get_item_group(item1, "dummy") == 1
 		local dummy2 = minetest.get_item_group(item2, "dummy") == 1
+		local broken1 = def1.mod_origin == "broken"
+		local broken2 = def2.mod_origin == "broken"
 		local craftitem1 = def1.type == "craft"
 		local craftitem2 = def2.type == "craft"
 		if item1 == "chest_of_everything:chest" then
@@ -110,6 +113,10 @@ minetest.register_on_mods_loaded(function()
 		elseif dummy1 and not dummy2 then
 			return false
 		elseif not dummy1 and dummy2 then
+			return true
+		elseif broken1 and not broken2 then
+			return false
+		elseif not broken1 and broken2 then
 			return true
 		elseif testtool1 and not testtool2 then
 			return true

--- a/games/devtest/mods/dignodes/init.lua
+++ b/games/devtest/mods/dignodes/init.lua
@@ -32,6 +32,8 @@ end
 
 -- Node without any digging groups
 minetest.register_node("dignodes:none", {
-	description = "Dig Test Node: groupless",
+	description = "Dig Test Node: groupless".."\n"..
+		"Can't be dug by normal digging tools".."\n"..
+		"(use the Remover tool to remove)",
 	tiles = {"dignodes_none.png"},
 })

--- a/games/devtest/mods/experimental/items.lua
+++ b/games/devtest/mods/experimental/items.lua
@@ -1,5 +1,6 @@
 minetest.register_node("experimental:callback_node", {
-	description = "Callback Test Node (construct/destruct/timer)",
+	description = "Callback Test Node".."\n"..
+		"Tests callbacks: on_construct, after_place_node, on_destruct, after_destruct, after_dig_node, on_timer",
 	tiles = {"experimental_callback_node.png"},
 	groups = {dig_immediate=3},
 	-- This was known to cause a bug in minetest.item_place_node() when used

--- a/games/devtest/mods/soundstuff/init.lua
+++ b/games/devtest/mods/soundstuff/init.lua
@@ -1,14 +1,14 @@
 local simple_nodes = {
-	footstep = { "Footstep Sound Node", "soundstuff_node_footstep.png" },
-	dig = { "Dig Sound Node", "soundstuff_node_dig.png" },
-	dug = { "Dug Sound Node", "soundstuff_node_dug.png" },
-	place = { "Place Sound Node", "soundstuff_node_place.png" },
-	place_failed = { "Place Failed Sound Node", "soundstuff_node_place_failed.png" },
+	footstep = { "Footstep Sound Node", "soundstuff_node_footstep.png", "Plays sound when you step on it" },
+	dig = { "Dig Sound Node", "soundstuff_node_dig.png", "Plays sound when you dig it" },
+	dug = { "Dug Sound Node", "soundstuff_node_dug.png", "Plays sound when you've dug it" },
+	place = { "Place Sound Node", "soundstuff_node_place.png", "Plays sound when you place it" },
+	place_failed = { "Place Failed Sound Node", "soundstuff_node_place_failed.png", "Plays sound when you try to place it but failed" },
 }
 
 for k,v in pairs(simple_nodes) do
 	minetest.register_node("soundstuff:"..k, {
-		description = v[1],
+		description = v[1].."\n"..v[3],
 		tiles = {"soundstuff_node_sound.png","soundstuff_node_sound.png",v[2]},
 		groups = {dig_immediate=2},
 		sounds = {
@@ -18,7 +18,8 @@ for k,v in pairs(simple_nodes) do
 end
 
 minetest.register_node("soundstuff:place_failed_attached", {
-	description = "Attached Place Failed Sound Node",
+	description = "Attached Place Failed Sound Node".."\n"..
+		"Attached to the floor; plays a sound when you try to place it but failed",
 	tiles = {"soundstuff_node_sound.png", "soundstuff_node_sound.png", "soundstuff_node_place_failed.png"},
 	groups = {dig_immediate=2, attached_node=1},
 	drawtype = "nodebox",
@@ -33,7 +34,8 @@ minetest.register_node("soundstuff:place_failed_attached", {
 })
 
 minetest.register_node("soundstuff:fall", {
-	description = "Fall Sound Node",
+	description = "Fall Sound Node".."\n"..
+		"Falls and plays sound if node below is gone",
 	tiles = {"soundstuff_node_sound.png", "soundstuff_node_sound.png", "soundstuff_node_fall.png"},
 	groups = {dig_immediate=2, falling_node=1},
 	sounds = {
@@ -42,7 +44,8 @@ minetest.register_node("soundstuff:fall", {
 })
 
 minetest.register_node("soundstuff:fall_attached", {
-	description = "Attached Fall Sound Node",
+	description = "Attached Fall Sound Node".."\n"..
+		"Drops as item and plays sound if node below is gone",
 	tiles = {"soundstuff_node_sound.png", "soundstuff_node_sound.png", "soundstuff_node_fall.png"},
 	groups = {dig_immediate=2, attached_node=1},
 	drawtype = "nodebox",
@@ -57,7 +60,8 @@ minetest.register_node("soundstuff:fall_attached", {
 })
 
 minetest.register_node("soundstuff:footstep_liquid", {
-	description = "Liquid Footstep Sound Node",
+	description = "Liquid Footstep Sound Node".."\n"..
+		"Plays sound when moving inside it; swimmable",
 	drawtype = "liquid",
 	tiles = {
 		"soundstuff_node_sound.png^[colorize:#0000FF:127^[opacity:190",
@@ -89,7 +93,8 @@ minetest.register_node("soundstuff:footstep_liquid", {
 })
 
 minetest.register_node("soundstuff:footstep_climbable", {
-	description = "Climbable Footstep Sound Node",
+	description = "Climbable Footstep Sound Node".."\n"..
+		"Plays sound when moving inside it; can climb up and down here",
 	drawtype = "allfaces",
 	tiles = {
 		"soundstuff_node_climbable.png",
@@ -167,7 +172,8 @@ minetest.register_tool("soundstuff:punch_use_air", {
 
 -- Plays sound repeatedly
 minetest.register_node("soundstuff:positional", {
-	description = "Positional Sound Node",
+	description = "Positional Sound Node".."\n"..
+		"Repeatedly plays a sound at the node location",
 	on_construct = function(pos)
 		local timer = minetest.get_node_timer(pos)
 		timer:start(0)

--- a/games/devtest/mods/stairs/init.lua
+++ b/games/devtest/mods/stairs/init.lua
@@ -3,7 +3,8 @@ stairs = {}
 -- Node will be called stairs:stair_<subname>
 function stairs.register_stair(subname, recipeitem, groups, images, description)
 	minetest.register_node(":stairs:stair_" .. subname, {
-		description = description,
+		description = description.."\n"..
+			"param2 = facedir rotation (0..23)",
 		drawtype = "nodebox",
 		tiles = images,
 		paramtype = "light",

--- a/games/devtest/mods/testfood/init.lua
+++ b/games/devtest/mods/testfood/init.lua
@@ -1,30 +1,34 @@
 local S = minetest.get_translator("testfood")
 
 minetest.register_craftitem("testfood:good1", {
-	description = S("Good Food (+1)"),
+	description = S("Good Food (+1)").."\n"..
+		S("Punch: Eat"),
 	inventory_image = "testfood_good.png",
 	on_use = minetest.item_eat(1),
 })
 minetest.register_craftitem("testfood:good5", {
-	description = S("Good Food (+5)"),
+	description = S("Good Food (+5)").."\n"..
+		S("Punch: Eat"),
 	inventory_image = "testfood_good2.png",
 	on_use = minetest.item_eat(5),
 })
 
 minetest.register_craftitem("testfood:bad1", {
-	description = S("Bad Food (-1)"),
+	description = S("Bad Food (-1)").."\n"..
+		S("Punch: Eat"),
 	inventory_image = "testfood_bad.png",
 	on_use = minetest.item_eat(-1),
 })
 minetest.register_craftitem("testfood:bad5", {
-	description = S("Bad Food (-5)"),
+	description = S("Bad Food (-5)").."\n"..
+		S("Punch: Eat"),
 	inventory_image = "testfood_bad2.png",
 	on_use = minetest.item_eat(-5),
 })
 
 minetest.register_craftitem("testfood:replace1", {
 	description = S("Replacing Food (+1)").."\n"..
-			S("Replaced with 'Good Food (+1)' when eaten"),
+		S("Punch: Eat and replace with 'Good Food (+1)'"),
 	inventory_image = "testfood_replace.png",
 	on_use = minetest.item_eat(1, "testfood:good1"),
 })

--- a/games/devtest/mods/testitems/init.lua
+++ b/games/devtest/mods/testitems/init.lua
@@ -58,7 +58,10 @@ minetest.register_craftitem("testitems:overlay_global", {
 --
 
 minetest.register_craftitem("testitems:callback_1", {
-	description = "Callback test item 1\n(Use/Drop + Sneak to switch to item 2)",
+	description = "Callback Test Item 1".."\n"..
+		"Tests callbacks: on_secondary_use, on_drop, on_pickup, on_use, after_use".."\n"..
+		"Punch/Drop + Sneak: Switch to Callback Test Item 2",
+		"Aux1 + pickup item: Print additional on_pickup arguments",
 	inventory_image = "testitems_callback_1.png",
 	wield_image = "testitems_callback_1.png",
 
@@ -133,7 +136,8 @@ minetest.register_craftitem("testitems:callback_1", {
 })
 
 minetest.register_craftitem("testitems:callback_2", {
-	description = "Callback test item 2\n(Use to switch to item 1)",
+	description = "Callback Test Item 2".."\n"..
+		"Punch to switch to Callback Test Item 1",
 	inventory_image = "testitems_callback_2.png",
 	wield_image = "testitems_callback_2.png",
 

--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -17,7 +17,8 @@ local S = minetest.get_translator("testnodes")
 
 -- A regular cube
 minetest.register_node("testnodes:normal", {
-	description = S("Normal Drawtype Test Node"),
+	description = S("\"normal\" Drawtype Test Node").."\n"..
+		S("Opaque texture"),
 	drawtype = "normal",
 	tiles = { "testnodes_normal.png" },
 
@@ -26,7 +27,8 @@ minetest.register_node("testnodes:normal", {
 
 -- Standard glasslike node
 minetest.register_node("testnodes:glasslike", {
-	description = S("Glasslike Drawtype Test Node"),
+	description = S("\"glasslike\" Drawtype Test Node").."\n"..
+		S("Transparent node with hidden backfaces"),
 	drawtype = "glasslike",
 	paramtype = "light",
 	tiles = { "testnodes_glasslike.png" },
@@ -36,7 +38,9 @@ minetest.register_node("testnodes:glasslike", {
 
 -- Glasslike framed with the two textures (normal and "detail")
 minetest.register_node("testnodes:glasslike_framed", {
-	description = S("Glasslike Framed Drawtype Test Node"),
+	description = S("\"glasslike_framed\" Drawtype Test Node").."\n"..
+		S("Transparent node with hidden backfaces").."\n"..
+		S("Frame connects to neighbors"),
 	drawtype = "glasslike_framed",
 	paramtype = "light",
 	tiles = {
@@ -53,7 +57,9 @@ minetest.register_node("testnodes:glasslike_framed", {
 -- This node was added to see how the engine behaves when the "detail" texture
 -- is missing.
 minetest.register_node("testnodes:glasslike_framed_no_detail", {
-	description = S("Glasslike Framed without Detail Drawtype Test Node"),
+	description = S("\"glasslike_framed\" Drawtype without Detail Test Node").."\n"..
+		S("Transparent node with hidden backfaces").."\n"..
+		S("Frame connects to neighbors, but the 'detail' tile is not used"),
 	drawtype = "glasslike_framed",
 	paramtype = "light",
 	tiles = { "testnodes_glasslike_framed2.png" },
@@ -65,7 +71,9 @@ minetest.register_node("testnodes:glasslike_framed_no_detail", {
 
 
 minetest.register_node("testnodes:glasslike_framed_optional", {
-	description = S("Glasslike Framed Optional Drawtype Test Node"),
+	description = S("\"glasslike_framed_optional\" Drawtype Test Node").."\n"..
+		S("Transparent node with hidden backfaces").."\n"..
+		S("Frame connects if 'connected_glass' setting is true"),
 	drawtype = "glasslike_framed_optional",
 	paramtype = "light",
 	tiles = {
@@ -81,7 +89,8 @@ minetest.register_node("testnodes:glasslike_framed_optional", {
 
 
 minetest.register_node("testnodes:allfaces", {
-	description = S("Allfaces Drawtype Test Node"),
+	description = S("\"allfaces\" Drawtype Test Node").."\n"..
+		S("Transparent node with visible internal backfaces"),
 	drawtype = "allfaces",
 	paramtype = "light",
 	tiles = { "testnodes_allfaces.png" },
@@ -89,8 +98,15 @@ minetest.register_node("testnodes:allfaces", {
 	groups = { dig_immediate = 3 },
 })
 
+local allfaces_optional_tooltip = ""..
+	S("Rendering depends on 'leaves_style' setting:").."\n"..
+	S("* 'fancy': transparent with visible internal backfaces").."\n"..
+	S("* 'simple': transparent with hidden backfaces").."\n"..
+	S("* 'opaque': opaque")
+
 minetest.register_node("testnodes:allfaces_optional", {
-	description = S("Allfaces Optional Drawtype Test Node"),
+	description = S("\"allfaces_optional\" Drawtype Test Node").."\n"..
+		allfaces_optional_tooltip,
 	drawtype = "allfaces_optional",
 	paramtype = "light",
 	tiles = { "testnodes_allfaces_optional.png" },
@@ -99,7 +115,9 @@ minetest.register_node("testnodes:allfaces_optional", {
 })
 
 minetest.register_node("testnodes:allfaces_optional_waving", {
-	description = S("Waving Allfaces Optional Drawtype Test Node"),
+	description = S("Waving \"allfaces_optional\" Drawtype Test Node").."\n"..
+		allfaces_optional_tooltip.."\n"..
+		S("Waves if waving leaves are enabled by client"),
 	drawtype = "allfaces_optional",
 	paramtype = "light",
 	tiles = { "testnodes_allfaces_optional.png^[brighten" },
@@ -109,7 +127,8 @@ minetest.register_node("testnodes:allfaces_optional_waving", {
 })
 
 minetest.register_node("testnodes:firelike", {
-	description = S("Firelike Drawtype Test Node"),
+	description = S("\"firelike\" Drawtype Test Node").."\n"..
+		S("Changes shape based on neighbors"),
 	drawtype = "firelike",
 	paramtype = "light",
 	tiles = { "testnodes_firelike.png" },
@@ -120,7 +139,8 @@ minetest.register_node("testnodes:firelike", {
 })
 
 minetest.register_node("testnodes:fencelike", {
-	description = S("Fencelike Drawtype Test Node"),
+	description = S("\"fencelike\" Drawtype Test Node").."\n"..
+		S("Connects to neighbors"),
 	drawtype = "fencelike",
 	paramtype = "light",
 	tiles = { "testnodes_fencelike.png" },
@@ -129,7 +149,8 @@ minetest.register_node("testnodes:fencelike", {
 })
 
 minetest.register_node("testnodes:torchlike", {
-	description = S("Floor Torchlike Drawtype Test Node"),
+	description = S("Floor \"torchlike\" Drawtype Test Node").."\n"..
+		S("Always on floor"),
 	drawtype = "torchlike",
 	paramtype = "light",
 	tiles = { "testnodes_torchlike_floor.png^[colorize:#FF0000:64" },
@@ -141,7 +162,8 @@ minetest.register_node("testnodes:torchlike", {
 })
 
 minetest.register_node("testnodes:torchlike_wallmounted", {
-	description = S("Wallmounted Torchlike Drawtype Test Node"),
+	description = S("Wallmounted \"torchlike\" Drawtype Test Node").."\n"..
+		S("param2 = wallmounted rotation (0..5)"),
 	drawtype = "torchlike",
 	paramtype = "light",
 	paramtype2 = "wallmounted",
@@ -158,7 +180,8 @@ minetest.register_node("testnodes:torchlike_wallmounted", {
 })
 
 minetest.register_node("testnodes:signlike", {
-	description = S("Floor Signlike Drawtype Test Node"),
+	description = S("Floor \"signlike\" Drawtype Test Node").."\n"..
+		S("Always on floor"),
 	drawtype = "signlike",
 	paramtype = "light",
 	tiles = { "testnodes_signlike.png^[colorize:#FF0000:64" },
@@ -171,7 +194,8 @@ minetest.register_node("testnodes:signlike", {
 
 
 minetest.register_node("testnodes:signlike_wallmounted", {
-	description = S("Wallmounted Signlike Drawtype Test Node"),
+	description = S("Wallmounted \"signlike\" Drawtype Test Node").."\n"..
+		S("param2 = wallmounted rotation (0..5)"),
 	drawtype = "signlike",
 	paramtype = "light",
 	paramtype2 = "wallmounted",
@@ -184,7 +208,7 @@ minetest.register_node("testnodes:signlike_wallmounted", {
 })
 
 minetest.register_node("testnodes:plantlike", {
-	description = S("Plantlike Drawtype Test Node"),
+	description = S("\"plantlike\" Drawtype Test Node"),
 	drawtype = "plantlike",
 	paramtype = "light",
 	tiles = { "testnodes_plantlike.png" },
@@ -196,7 +220,8 @@ minetest.register_node("testnodes:plantlike", {
 })
 
 minetest.register_node("testnodes:plantlike_waving", {
-	description = S("Waving Plantlike Drawtype Test Node"),
+	description = S("Waving \"plantlike\" Drawtype Test Node").."\n"..
+		S("Waves if waving plants are enabled by client"),
 	drawtype = "plantlike",
 	paramtype = "light",
 	tiles = { "testnodes_plantlike_waving.png" },
@@ -209,7 +234,8 @@ minetest.register_node("testnodes:plantlike_waving", {
 })
 
 minetest.register_node("testnodes:plantlike_wallmounted", {
-	description = S("Wallmounted Plantlike Drawtype Test Node"),
+	description = S("Wallmounted \"plantlike\" Drawtype Test Node").."\n"..
+		S("param2 = wallmounted rotation (0..5)"),
 	drawtype = "plantlike",
 	paramtype = "light",
 	paramtype2 = "wallmounted",
@@ -249,7 +275,8 @@ local function rotate_on_rightclick(pos, node, clicker)
 end
 
 minetest.register_node("testnodes:plantlike_degrotate", {
-	description = S("Degrotate Plantlike Drawtype Test Node"),
+	description = S("Degrotate \"plantlike\" Drawtype Test Node").."\n"..
+		S("param2 = horizontal rotation (0..239)"),
 	drawtype = "plantlike",
 	paramtype = "light",
 	paramtype2 = "degrotate",
@@ -263,7 +290,8 @@ minetest.register_node("testnodes:plantlike_degrotate", {
 })
 
 minetest.register_node("testnodes:mesh_degrotate", {
-	description = S("Degrotate Mesh Drawtype Test Node"),
+	description = S("Degrotate \"mesh\" Drawtype Test Node").."\n"..
+		S("param2 = horizontal rotation (0..239)"),
 	drawtype = "mesh",
 	paramtype = "light",
 	paramtype2 = "degrotate",
@@ -277,7 +305,8 @@ minetest.register_node("testnodes:mesh_degrotate", {
 })
 
 minetest.register_node("testnodes:mesh_colordegrotate", {
-	description = S("Color Degrotate Mesh Drawtype Test Node"),
+	description = S("Colordegrotate \"mesh\" Drawtype Test Node").."\n"..
+		S("param2 = color + horizontal rotation (0..23, 32..55, ...)"),
 	drawtype = "mesh",
 	paramtype = "light",
 	paramtype2 = "colordegrotate",
@@ -294,7 +323,8 @@ minetest.register_node("testnodes:mesh_colordegrotate", {
 
 -- param2 will change height
 minetest.register_node("testnodes:plantlike_leveled", {
-	description = S("Leveled Plantlike Drawtype Test Node"),
+	description = S("Leveled \"plantlike\" Drawtype Test Node").."\n"..
+		S("param2 = height (0..255)"),
 	drawtype = "plantlike",
 	paramtype = "light",
 	paramtype2 = "leveled",
@@ -312,7 +342,8 @@ minetest.register_node("testnodes:plantlike_leveled", {
 
 -- param2 changes shape
 minetest.register_node("testnodes:plantlike_meshoptions", {
-	description = S("Meshoptions Plantlike Drawtype Test Node"),
+	description = S("Meshoptions \"plantlike\" Drawtype Test Node").."\n"..
+		S("param2 = plant shape"),
 	drawtype = "plantlike",
 	paramtype = "light",
 	paramtype2 = "meshoptions",
@@ -324,7 +355,7 @@ minetest.register_node("testnodes:plantlike_meshoptions", {
 })
 
 minetest.register_node("testnodes:plantlike_rooted", {
-	description = S("Rooted Plantlike Drawtype Test Node"),
+	description = S("\"rooted_plantlike\" Drawtype Test Node"),
 	drawtype = "plantlike_rooted",
 	paramtype = "light",
 	tiles = { "testnodes_plantlike_rooted_base.png" },
@@ -334,7 +365,8 @@ minetest.register_node("testnodes:plantlike_rooted", {
 })
 
 minetest.register_node("testnodes:plantlike_rooted_wallmounted", {
-	description = S("Wallmounted Rooted Plantlike Drawtype Test Node"),
+	description = S("Wallmounted \"rooted_plantlike\" Drawtype Test Node").."\n"..
+		S("param2 = wallmounted rotation (0..5)"),
 	drawtype = "plantlike_rooted",
 	paramtype = "light",
 	paramtype2 = "wallmounted",
@@ -348,7 +380,8 @@ minetest.register_node("testnodes:plantlike_rooted_wallmounted", {
 })
 
 minetest.register_node("testnodes:plantlike_rooted_waving", {
-	description = S("Waving Rooted Plantlike Drawtype Test Node"),
+	description = S("Waving \"rooted_plantlike\" Drawtype Test Node").."\n"..
+		S("Waves if waving plants are enabled by client"),
 	drawtype = "plantlike_rooted",
 	paramtype = "light",
 	tiles = {
@@ -364,7 +397,8 @@ minetest.register_node("testnodes:plantlike_rooted_waving", {
 
 -- param2 changes height
 minetest.register_node("testnodes:plantlike_rooted_leveled", {
-	description = S("Leveled Rooted Plantlike Drawtype Test Node"),
+	description = S("Leveled \"rooted_plantlike\" Drawtype Test Node").."\n"..
+		S("param2 = height (0..255)"),
 	drawtype = "plantlike_rooted",
 	paramtype = "light",
 	paramtype2 = "leveled",
@@ -385,7 +419,8 @@ minetest.register_node("testnodes:plantlike_rooted_leveled", {
 
 -- param2 changes shape
 minetest.register_node("testnodes:plantlike_rooted_meshoptions", {
-	description = S("Meshoptions Rooted Plantlike Drawtype Test Node"),
+	description = S("Meshoptions \"rooted_plantlike\" Drawtype Test Node").."\n"..
+		S("param2 = plant shape"),
 	drawtype = "plantlike_rooted",
 	paramtype = "light",
 	paramtype2 = "meshoptions",
@@ -403,7 +438,8 @@ minetest.register_node("testnodes:plantlike_rooted_meshoptions", {
 
 -- param2 changes rotation
 minetest.register_node("testnodes:plantlike_rooted_degrotate", {
-	description = S("Degrotate Rooted Plantlike Drawtype Test Node"),
+	description = S("Degrotate \"rooted_plantlike\" Drawtype Test Node").."\n"..
+		S("param2 = horizontal rotation (0..239)"),
 	drawtype = "plantlike_rooted",
 	paramtype = "light",
 	paramtype2 = "degrotate",
@@ -424,7 +460,8 @@ minetest.register_node("testnodes:plantlike_rooted_degrotate", {
 -- Liquid ranges 0 to 8
 for r = 0, 8 do
 	minetest.register_node("testnodes:liquid_"..r, {
-		description = S("Source Liquid Drawtype Test Node, Range @1", r),
+		description = S("\"liquid\" Drawtype Test Node, Range @1", r).."\n"..
+			S("Drawtype only; all liquid physics are disabled"),
 		drawtype = "liquid",
 		paramtype = "light",
 		tiles = {
@@ -445,7 +482,9 @@ for r = 0, 8 do
 		groups = { dig_immediate = 3 },
 	})
 	minetest.register_node("testnodes:liquid_flowing_"..r, {
-		description = S("Flowing Liquid Drawtype Test Node, Range @1", r),
+		description = S("\"flowingliquid\" Drawtype Test Node, Range @1", r).."\n"..
+			S("Drawtype only; all liquid physics are disabled").."\n"..
+			S("param2 = flowing liquid level"),
 		drawtype = "flowingliquid",
 		paramtype = "light",
 		paramtype2 = "flowingliquid",
@@ -471,7 +510,9 @@ end
 
 -- Waving liquid test (drawtype only)
 minetest.register_node("testnodes:liquid_waving", {
-	description = S("Waving Source Liquid Drawtype Test Node"),
+	description = S("Waving \"liquid\" Drawtype Test Node").."\n"..
+		S("Drawtype only; all liquid physics are disabled").."\n"..
+		S("Waves if waving liquids are enabled by client"),
 	drawtype = "liquid",
 	paramtype = "light",
 	tiles = {
@@ -493,7 +534,10 @@ minetest.register_node("testnodes:liquid_waving", {
 	groups = { dig_immediate = 3 },
 })
 minetest.register_node("testnodes:liquid_flowing_waving", {
-	description = S("Waving Flowing Liquid Drawtype Test Node"),
+	description = S("Waving \"flowingliquid\" Drawtype Test Node").."\n"..
+		S("Drawtype only; all liquid physics are disabled").."\n"..
+		S("param2 = flowing liquid level").."\n"..
+		S("Waves if waving liquids are enabled by client"),
 	drawtype = "flowingliquid",
 	paramtype = "light",
 	paramtype2 = "flowingliquid",
@@ -518,9 +562,13 @@ minetest.register_node("testnodes:liquid_flowing_waving", {
 
 -- Invisible node
 minetest.register_node("testnodes:airlike", {
-	description = S("Airlike Drawtype Test Node"),
+	description = S("\"airlike\" Drawtype Test Node").."\n"..
+		S("Invisible node").."\n"..
+		S("Inventory/wield image = no_texture_airlike.png"),
 	drawtype = "airlike",
 	paramtype = "light",
+	-- inventory/wield images are left empty to make sure the 'no texture'
+	-- fallback for airlike nodes is working properly.
 
 
 	walkable = false,
@@ -530,7 +578,8 @@ minetest.register_node("testnodes:airlike", {
 
 -- param2 changes liquid height
 minetest.register_node("testnodes:glassliquid", {
-	description = S("Glasslike Liquid Level Drawtype Test Node"),
+	description = S("\"glasslike_framed\" Drawtype with Liquid Test Node").."\n"..
+		S("param2 = liquid level (0..63)"),
 	drawtype = "glasslike_framed",
 	paramtype = "light",
 	paramtype2 = "glasslikeliquidlevel",
@@ -549,17 +598,18 @@ minetest.register_node("testnodes:glassliquid", {
 -- should connect to nodes of the same "rail type" (=same shape, different
 -- color) only.
 local rails = {
-	{ "rail", {"testnodes_rail_straight.png", "testnodes_rail_curved.png", "testnodes_rail_t_junction.png", "testnodes_rail_crossing.png"} },
-	{ "line", {"testnodes_line_straight.png", "testnodes_line_curved.png", "testnodes_line_t_junction.png", "testnodes_line_crossing.png"}, },
-	{ "street", {"testnodes_street_straight.png", "testnodes_street_curved.png", "testnodes_street_t_junction.png", "testnodes_street_crossing.png"}, },
+	{ "rail", {"testnodes_rail_straight.png", "testnodes_rail_curved.png", "testnodes_rail_t_junction.png", "testnodes_rail_crossing.png"}, S("Connects to rails")},
+	{ "line", {"testnodes_line_straight.png", "testnodes_line_curved.png", "testnodes_line_t_junction.png", "testnodes_line_crossing.png"}, S("Connects to lines")},
+	{ "street", {"testnodes_street_straight.png", "testnodes_street_curved.png", "testnodes_street_t_junction.png", "testnodes_street_crossing.png"}, S("Connects to streets")},
 	-- the "groupless" nodes are nodes in which the "connect_to_raillike" group is not set
-	{ "groupless", {"testnodes_rail2_straight.png", "testnodes_rail2_curved.png", "testnodes_rail2_t_junction.png", "testnodes_rail2_crossing.png"} },
+	{ "groupless", {"testnodes_rail2_straight.png", "testnodes_rail2_curved.png", "testnodes_rail2_t_junction.png", "testnodes_rail2_crossing.png"}, S("Connects to 'groupless' rails") },
 }
 local colors = { "", "cyan", "red" }
 
 for r=1, #rails do
 	local id = rails[r][1]
 	local tiles = rails[r][2]
+	local tt = rails[r][3]
 	local raillike_group
 	if id ~= "groupless" then
 		raillike_group = minetest.raillike_group(id)
@@ -570,7 +620,8 @@ for r=1, #rails do
 			color = colors[c]
 		end
 		minetest.register_node("testnodes:raillike_"..id..c, {
-			description = S("Raillike Drawtype Test Node: @1 @2", id, c),
+			description = S("\"raillike\" Drawtype Test Node: @1 @2", id, c).."\n"..
+				tt,
 			drawtype = "raillike",
 			paramtype = "light",
 			tiles = tiles,
@@ -591,39 +642,37 @@ end
 
 
 -- Add visual_scale variants of previous nodes for half and double size
-local scale = function(subname, desc_double, desc_half)
+local scale = function(subname, append)
 	local original = "testnodes:"..subname
 	local def = table.copy(minetest.registered_items[original])
+	local orig_desc
+	if append and type(append) == "string" then
+		orig_desc = ItemStack(original):get_short_description()
+		orig_desc = orig_desc .. "\n" .. append
+	elseif append ~= false then
+		orig_desc = ItemStack(original):get_description()
+	else
+		orig_desc = ItemStack(original):get_short_description()
+	end
 	def.visual_scale = 2.0
-	def.description = desc_double
+	def.description = S("Double-sized @1", orig_desc)
 	minetest.register_node("testnodes:"..subname.."_double", def)
 	def = table.copy(minetest.registered_items[original])
 	def.visual_scale = 0.5
-	def.description = desc_half
+	def.description = S("Half-sized @1", orig_desc)
 	minetest.register_node("testnodes:"..subname.."_half", def)
 end
 
-scale("allfaces",
-	S("Double-sized Allfaces Drawtype Test Node"),
-	S("Half-sized Allfaces Drawtype Test Node"))
-scale("allfaces_optional",
-	S("Double-sized Allfaces Optional Drawtype Test Node"),
-	S("Half-sized Allfaces Optional Drawtype Test Node"))
-scale("allfaces_optional_waving",
-	S("Double-sized Waving Allfaces Optional Drawtype Test Node"),
-	S("Half-sized Waving Allfaces Optional Drawtype Test Node"))
-scale("plantlike",
-	S("Double-sized Plantlike Drawtype Test Node"),
-	S("Half-sized Plantlike Drawtype Test Node"))
-scale("plantlike_wallmounted",
-	S("Double-sized Wallmounted Plantlike Drawtype Test Node"),
-	S("Half-sized Wallmounted Plantlike Drawtype Test Node"))
-scale("torchlike_wallmounted",
-	S("Double-sized Wallmounted Torchlike Drawtype Test Node"),
-	S("Half-sized Wallmounted Torchlike Drawtype Test Node"))
-scale("signlike_wallmounted",
-	S("Double-sized Wallmounted Signlike Drawtype Test Node"),
-	S("Half-sized Wallmounted Signlike Drawtype Test Node"))
-scale("firelike",
-	S("Double-sized Firelike Drawtype Test Node"),
-	S("Half-sized Firelike Drawtype Test Node"))
+local allfaces_newsize_tt = ""..
+	S("Rendering depends on 'leaves_style' setting:").."\n"..
+	S("* 'fancy'/'simple': transparent").."\n"..
+	S("* 'opaque': opaque")
+
+scale("allfaces", S("Transparent node"))
+scale("allfaces_optional", allfaces_newsize_tt)
+scale("allfaces_optional_waving", allfaces_newsize_tt .. "\n" .. S("Waving if waving leaves are enabled by client"))
+scale("plantlike")
+scale("plantlike_wallmounted")
+scale("torchlike_wallmounted")
+scale("signlike_wallmounted")
+scale("firelike")

--- a/games/devtest/mods/testnodes/light.lua
+++ b/games/devtest/mods/testnodes/light.lua
@@ -4,7 +4,7 @@ local S = minetest.get_translator("testnodes")
 
 -- All possible light levels
 for i=1, minetest.LIGHT_MAX do
-	minetest.register_node("testnodes:light"..i, {
+	minetest.register_node("testnodes:light"..string.format("%02d", i), {
 		description = S("Light Source (@1)", i),
 		paramtype = "light",
 		light_source = i,

--- a/games/devtest/mods/testnodes/liquids.lua
+++ b/games/devtest/mods/testnodes/liquids.lua
@@ -1,8 +1,15 @@
 -- Add liquids for ranges and viscosity levels 0-8
 
 for d=0, 8 do
+	local tt_normal
+	if d == 0 then
+		tt_normal = "\n".."Swimmable, renewable liquid"
+	else
+		tt_normal = "\n".."Swimmable, spreading, renewable liquid"
+	end
 	minetest.register_node("testnodes:rliquid_"..d, {
-		description = "Test Liquid Source, Range "..d,
+		description = "Test Liquid Source, Range "..d..
+			tt_normal,
 		drawtype = "liquid",
 		tiles = {"testnodes_liquidsource_r"..d..".png"},
 		special_tiles = {
@@ -21,7 +28,8 @@ for d=0, 8 do
 	})
 
 	minetest.register_node("testnodes:rliquid_flowing_"..d, {
-		description = "Flowing Test Liquid, Range "..d,
+		description = "Flowing Test Liquid, Range "..d..
+			tt_normal,
 		drawtype = "flowingliquid",
 		tiles = {"testnodes_liquidflowing_r"..d..".png"},
 		special_tiles = {
@@ -42,9 +50,16 @@ for d=0, 8 do
 
 	if d <= 7 then
 
+	local tt_reduced = ""
+	if d > 0 then
+		tt_reduced = "\n".."Reduced swimming/spreading speed"
+	end
+
 	local mod = "^[colorize:#000000:127"
 	minetest.register_node("testnodes:vliquid_"..d, {
-		description = "Test Liquid Source, Viscosity/Resistance "..d,
+		description = "Test Liquid Source, Viscosity/Resistance "..d.."\n"..
+			"Swimmable, spreading, renewable liquid"..
+			tt_reduced,
 		drawtype = "liquid",
 		tiles = {"testnodes_liquidsource_r"..d..".png"..mod},
 		special_tiles = {
@@ -63,7 +78,9 @@ for d=0, 8 do
 	})
 
 	minetest.register_node("testnodes:vliquid_flowing_"..d, {
-		description = "Flowing Test Liquid, Viscosity/Resistance "..d,
+		description = "Flowing Test Liquid, Viscosity/Resistance "..d.."\n"..
+			"Swimmable, spreading, renewable liquid"..
+			tt_reduced,
 		drawtype = "flowingliquid",
 		tiles = {"testnodes_liquidflowing_r"..d..".png"..mod},
 		special_tiles = {
@@ -85,7 +102,9 @@ for d=0, 8 do
 	mod = "^[colorize:#000000:192"
 	local v = 4
 	minetest.register_node("testnodes:vrliquid_"..d, {
-		description = "Test Liquid Source, Viscosity "..v..", Resistance "..d,
+		description = "Test Liquid Source, Viscosity "..v..", Resistance "..d.."\n"..
+			"Swimmable, spreading, renewable liquid"..
+			tt_reduced,
 		drawtype = "liquid",
 		tiles = {"testnodes_liquidsource_r"..d..".png"..mod},
 		special_tiles = {
@@ -107,7 +126,9 @@ for d=0, 8 do
 	})
 
 	minetest.register_node("testnodes:vrliquid_flowing_"..d, {
-		description = "Flowing Test Liquid, Viscosity "..v..", Resistance "..d,
+		description = "Flowing Test Liquid, Viscosity "..v..", Resistance "..d.."\n"..
+			"Swimmable, spreading, renewable liquid"..
+			tt_reduced,
 		drawtype = "flowingliquid",
 		tiles = {"testnodes_liquidflowing_r"..d..".png"..mod},
 		special_tiles = {

--- a/games/devtest/mods/testnodes/meshes.lua
+++ b/games/devtest/mods/testnodes/meshes.lua
@@ -36,7 +36,8 @@ minetest.register_node("testnodes:mesh", {
 
 -- Facedir mesh: outer corner slope
 minetest.register_node("testnodes:mesh_facedir", {
-	description = S("Facedir Mesh Test Node"),
+	description = S("Facedir Mesh Test Node").."\n"..
+		S("param2 = facedir rotation (0..23)"),
 	drawtype = "mesh",
 	mesh = "testnodes_ocorner.obj",
 	tiles = {"testnodes_mesh_stripes.png"},
@@ -48,7 +49,8 @@ minetest.register_node("testnodes:mesh_facedir", {
 })
 
 minetest.register_node("testnodes:mesh_colorfacedir", {
-	description = S("Color Facedir Mesh Test Node"),
+	description = S("Color Facedir Mesh Test Node").."\n"..
+		S("param2 = color + facedir rotation (0..23, 32..55, ...)"),
 	drawtype = "mesh",
 	mesh = "testnodes_ocorner.obj",
 	tiles = {"testnodes_mesh_stripes3.png"},
@@ -61,7 +63,8 @@ minetest.register_node("testnodes:mesh_colorfacedir", {
 })
 
 minetest.register_node("testnodes:mesh_4dir", {
-	description = S("4dir Mesh Test Node"),
+	description = S("4dir Mesh Test Node").."\n"..
+		S("param2 = 4dir rotation (0..3)"),
 	drawtype = "mesh",
 	mesh = "testnodes_ocorner.obj",
 	tiles = {"testnodes_mesh_stripes.png"},
@@ -73,7 +76,8 @@ minetest.register_node("testnodes:mesh_4dir", {
 })
 
 minetest.register_node("testnodes:mesh_color4dir", {
-	description = S("Color 4dir Mesh Test Node"),
+	description = S("Color 4dir Mesh Test Node").."\n"..
+		S("param2 = color + 4dir rotation (0..255)"),
 	drawtype = "mesh",
 	mesh = "testnodes_ocorner.obj",
 	tiles = {"testnodes_mesh_stripes3.png"},
@@ -87,7 +91,8 @@ minetest.register_node("testnodes:mesh_color4dir", {
 
 -- Wallmounted mesh: pyramid
 minetest.register_node("testnodes:mesh_wallmounted", {
-	description = S("Wallmounted Mesh Test Node"),
+	description = S("Wallmounted Mesh Test Node").."\n"..
+		S("param2 = wallmounted rotation (0..5)"),
 	drawtype = "mesh",
 	mesh = "testnodes_pyramid.obj",
 	tiles = {"testnodes_mesh_stripes2.png"},
@@ -99,7 +104,8 @@ minetest.register_node("testnodes:mesh_wallmounted", {
 })
 
 minetest.register_node("testnodes:mesh_colorwallmounted", {
-	description = S("Color Wallmounted Mesh Test Node"),
+	description = S("Color Wallmounted Mesh Test Node").."\n"..
+		S("param2 = color + wallmounted rotation (0..5, 8..13, ...)"),
 	drawtype = "mesh",
 	mesh = "testnodes_pyramid.obj",
 	tiles = {"testnodes_mesh_stripes3.png"},
@@ -136,7 +142,8 @@ minetest.register_node("testnodes:mesh_half", {
 })
 
 minetest.register_node("testnodes:mesh_waving1", {
-	description = S("Plantlike-waving Mesh Test Node"),
+	description = S("Plantlike-waving Mesh Test Node").."\n"..
+		S("Waves if waving plants are enabled by client"),
 	drawtype = "mesh",
 	mesh = "testnodes_pyramid.obj",
 	tiles = {"testnodes_mesh_stripes4.png^[multiply:#B0FFB0"},
@@ -147,7 +154,8 @@ minetest.register_node("testnodes:mesh_waving1", {
 	groups = {dig_immediate=3},
 })
 minetest.register_node("testnodes:mesh_waving2", {
-	description = S("Leaflike-waving Mesh Test Node"),
+	description = S("Leaflike-waving Mesh Test Node").."\n"..
+		S("Waves if waving leaves are enabled by client"),
 	drawtype = "mesh",
 	mesh = "testnodes_pyramid.obj",
 	tiles = {"testnodes_mesh_stripes4.png^[multiply:#FFFFB0"},
@@ -158,7 +166,8 @@ minetest.register_node("testnodes:mesh_waving2", {
 	groups = {dig_immediate=3},
 })
 minetest.register_node("testnodes:mesh_waving3", {
-	description = S("Liquidlike-waving Mesh Test Node"),
+	description = S("Liquidlike-waving Mesh Test Node").."\n"..
+		S("Waves if waving liquids are enabled by client"),
 	drawtype = "mesh",
 	mesh = "testnodes_pyramid.obj",
 	tiles = {"testnodes_mesh_stripes4.png^[multiply:#B0B0FF"},

--- a/games/devtest/mods/testnodes/nodeboxes.lua
+++ b/games/devtest/mods/testnodes/nodeboxes.lua
@@ -4,7 +4,8 @@ local S = minetest.get_translator("testnodes")
 
 -- An simple example nodebox with one centered box
 minetest.register_node("testnodes:nodebox_fixed", {
-	description = S("Fixed Nodebox Test Node"),
+	description = S("Fixed Nodebox Test Node").."\n"..
+		S("Nodebox is always the same"),
 	tiles = {"testnodes_nodebox.png"},
 	drawtype = "nodebox",
 	paramtype = "light",
@@ -47,7 +48,8 @@ minetest.register_node("testnodes:nodebox_overhigh2", {
 
 -- Height of nodebox changes with its param2 value
 minetest.register_node("testnodes:nodebox_leveled", {
-	description = S("Leveled Nodebox Test Node"),
+	description = S("Leveled Nodebox Test Node").."\n"..
+		S("param2 = height (0..127)"),
 	tiles = {"testnodes_nodebox.png"},
 	drawtype = "nodebox",
 	paramtype = "light",
@@ -81,7 +83,8 @@ local nodebox_wall_thick = {
 
 -- Wall-like nodebox that connects to neighbors
 minetest.register_node("testnodes:nodebox_connected", {
-	description = S("Connected Nodebox Test Node"),
+	description = S("Connected Nodebox Test Node").."\n"..
+		S("Connects to neighbors"),
 	tiles = {"testnodes_nodebox.png"},
 	groups = {connected_nodebox=1, dig_immediate=3},
 	drawtype = "nodebox",
@@ -92,7 +95,9 @@ minetest.register_node("testnodes:nodebox_connected", {
 })
 
 minetest.register_node("testnodes:nodebox_connected_facedir", {
-	description = S("Facedir Connected Nodebox Test Node"),
+	description = S("Facedir Connected Nodebox Test Node").."\n"..
+		S("Connects to neighbors").."\n"..
+		S("param2 = facedir rotation of textures (not of the nodebox!)"),
 	tiles = {
 		"testnodes_1.png",
 		"testnodes_2.png",
@@ -111,7 +116,9 @@ minetest.register_node("testnodes:nodebox_connected_facedir", {
 })
 
 minetest.register_node("testnodes:nodebox_connected_4dir", {
-	description = S("4Dir Connected Nodebox Test Node"),
+	description = S("4Dir Connected Nodebox Test Node").."\n"..
+		S("Connects to neighbors").."\n"..
+		S("param2 = 4dir rotation of textures (not of the nodebox!)"),
 	tiles = {
 		"testnodes_1.png^[colorize:#FFFF00:127",
 		"testnodes_2.png^[colorize:#FFFF00:127",

--- a/games/devtest/mods/testnodes/param2.lua
+++ b/games/devtest/mods/testnodes/param2.lua
@@ -3,7 +3,8 @@
 local S = minetest.get_translator("testnodes")
 
 minetest.register_node("testnodes:facedir", {
-	description = S("Facedir Test Node"),
+	description = S("Facedir Test Node").."\n"..
+		S("param2 = facedir rotation (0..23)"),
 	paramtype2 = "facedir",
 	tiles = {
 		"testnodes_1.png",
@@ -18,7 +19,8 @@ minetest.register_node("testnodes:facedir", {
 })
 
 minetest.register_node("testnodes:4dir", {
-	description = S("4dir Test Node"),
+	description = S("4dir Test Node").."\n"..
+		S("param2 = 4dir rotation (0..3)"),
 	paramtype2 = "4dir",
 	tiles = {
 		"testnodes_1.png^[colorize:#FFFF00:127",
@@ -33,7 +35,8 @@ minetest.register_node("testnodes:4dir", {
 })
 
 minetest.register_node("testnodes:facedir_nodebox", {
-	description = S("Facedir Nodebox Test Node"),
+	description = S("Facedir Nodebox Test Node").."\n"..
+		S("param2 = facedir rotation (0..23)"),
 	tiles = {
 		"testnodes_1.png",
 		"testnodes_2.png",
@@ -54,7 +57,8 @@ minetest.register_node("testnodes:facedir_nodebox", {
 })
 
 minetest.register_node("testnodes:4dir_nodebox", {
-	description = S("4dir Nodebox Test Node"),
+	description = S("4dir Nodebox Test Node").."\n"..
+		S("param2 = 4dir rotation (0..3)"),
 	tiles = {
 		"testnodes_1.png^[colorize:#ffff00:127",
 		"testnodes_2.png^[colorize:#ffff00:127",
@@ -75,7 +79,8 @@ minetest.register_node("testnodes:4dir_nodebox", {
 })
 
 minetest.register_node("testnodes:wallmounted", {
-	description = S("Wallmounted Test Node"),
+	description = S("Wallmounted Test Node").."\n"..
+		S("param2 = wallmounted rotation (0..5)"),
 	paramtype2 = "wallmounted",
 	tiles = {
 		"testnodes_1w.png",
@@ -90,7 +95,8 @@ minetest.register_node("testnodes:wallmounted", {
 })
 
 minetest.register_node("testnodes:wallmounted_nodebox", {
-	description = S("Wallmounted Nodebox Test Node"),
+	description = S("Wallmounted Nodebox Test Node").."\n"..
+		S("param2 = wallmounted rotation (0..5)"),
 	paramtype2 = "wallmounted",
 	paramtype = "light",
 	tiles = {
@@ -113,7 +119,8 @@ minetest.register_node("testnodes:wallmounted_nodebox", {
 })
 
 minetest.register_node("testnodes:color", {
-	description = S("Color Test Node"),
+	description = S("Color Test Node").."\n"..
+		S("param2 = color (0..255)"),
 	paramtype2 = "color",
 	palette = "testnodes_palette_full.png",
 	tiles = {
@@ -124,7 +131,8 @@ minetest.register_node("testnodes:color", {
 })
 
 minetest.register_node("testnodes:colorfacedir", {
-	description = S("Color Facedir Test Node"),
+	description = S("Color Facedir Test Node").."\n"..
+		S("param2 = color + facedir rotation (0..23, 32..55, ...)"),
 	paramtype2 = "colorfacedir",
 	palette = "testnodes_palette_facedir.png",
 	tiles = {
@@ -140,7 +148,8 @@ minetest.register_node("testnodes:colorfacedir", {
 })
 
 minetest.register_node("testnodes:colorfacedir_nodebox", {
-	description = S("Color Facedir Nodebox Test Node"),
+	description = S("Color Facedir Nodebox Test Node").."\n"..
+		S("param2 = color + facedir rotation (0..23, 32..55, ...)"),
 	tiles = {
 		"testnodes_1g.png",
 		"testnodes_2g.png",
@@ -162,7 +171,8 @@ minetest.register_node("testnodes:colorfacedir_nodebox", {
 })
 
 minetest.register_node("testnodes:color4dir", {
-	description = S("Color 4dir Test Node"),
+	description = S("Color 4dir Test Node").."\n"..
+		S("param2 = color + 4dir rotation (0..255)"),
 	paramtype2 = "color4dir",
 	palette = "testnodes_palette_4dir.png",
 	tiles = {
@@ -178,7 +188,8 @@ minetest.register_node("testnodes:color4dir", {
 })
 
 minetest.register_node("testnodes:color4dir_nodebox", {
-	description = S("Color 4dir Nodebox Test Node"),
+	description = S("Color 4dir Nodebox Test Node").."\n"..
+		S("param2 = color + 4dir rotation (0..255)"),
 	tiles = {
 		"testnodes_1g.png",
 		"testnodes_2g.png",
@@ -200,7 +211,8 @@ minetest.register_node("testnodes:color4dir_nodebox", {
 })
 
 minetest.register_node("testnodes:colorwallmounted", {
-	description = S("Color Wallmounted Test Node"),
+	description = S("Color Wallmounted Test Node").."\n"..
+		S("param2 = color + wallmounted rotation (0..5, 8..13, ...)"),
 	paramtype2 = "colorwallmounted",
 	paramtype = "light",
 	palette = "testnodes_palette_wallmounted.png",
@@ -217,7 +229,8 @@ minetest.register_node("testnodes:colorwallmounted", {
 })
 
 minetest.register_node("testnodes:colorwallmounted_nodebox", {
-	description = S("Color Wallmounted Nodebox Test Node"),
+	description = S("Color Wallmounted Nodebox Test Node").."\n"..
+		S("param2 = color + wallmounted rotation (0..5, 8..13, ...)"),
 	paramtype2 = "colorwallmounted",
 	paramtype = "light",
 	palette = "testnodes_palette_wallmounted.png",

--- a/games/devtest/mods/testnodes/properties.lua
+++ b/games/devtest/mods/testnodes/properties.lua
@@ -4,7 +4,8 @@ local S = minetest.get_translator("testnodes")
 
 -- Is supposed to fall when it doesn't rest on solid ground
 minetest.register_node("testnodes:falling", {
-	description = S("Falling Node"),
+	description = S("Falling Node").."\n"..
+		S("Falls down if no node below"),
 	tiles = {
 		"testnodes_node.png",
 		"testnodes_node.png",
@@ -14,14 +15,16 @@ minetest.register_node("testnodes:falling", {
 })
 
 minetest.register_node("testnodes:falling_facedir", {
-	description = S("Falling Facedir Node"),
+	description = S("Falling Facedir Node").."\n"..
+		S("Falls down if no node below").."\n"..
+		S("param2 = facedir rotation"),
 	tiles = {
-		"testnodes_1.png",
-		"testnodes_2.png",
-		"testnodes_3.png",
-		"testnodes_4.png",
-		"testnodes_5.png",
-		"testnodes_6.png",
+		"testnodes_1.png^[brighten",
+		"testnodes_2.png^[brighten",
+		"testnodes_3.png^[brighten",
+		"testnodes_4.png^[brighten",
+		"testnodes_5.png^[brighten",
+		"testnodes_6.png^[brighten",
 	},
 	paramtype2 = "facedir",
 	groups = { falling_node = 1, dig_immediate = 3 },
@@ -29,7 +32,8 @@ minetest.register_node("testnodes:falling_facedir", {
 
 -- Same as falling node, but will stop falling on top of liquids
 minetest.register_node("testnodes:falling_float", {
-	description = S("Falling+Floating Node"),
+	description = S("Falling+Floating Node").."\n"..
+		S("Falls down if no node below, floats on liquids (liquidtype ~= \"none\")"),
 	groups = { falling_node = 1, float = 1, dig_immediate = 3 },
 
 
@@ -44,7 +48,8 @@ minetest.register_node("testnodes:falling_float", {
 -- This node attaches to the floor and drops as item
 -- when the floor is gone.
 minetest.register_node("testnodes:attached", {
-	description = S("Floor-Attached Node"),
+	description = S("Floor-Attached Node").."\n"..
+		S("Drops as item if no solid node below"),
 	tiles = {
 		"testnodes_attached_top.png",
 		"testnodes_attached_bottom.png",
@@ -56,7 +61,9 @@ minetest.register_node("testnodes:attached", {
 -- This node attaches to the side of a node and drops as item
 -- when the node it attaches to is gone.
 minetest.register_node("testnodes:attached_wallmounted", {
-	description = S("Wallmounted Attached Node"),
+	description = S("Wallmounted Attached Node").."\n"..
+		S("Attaches to wall; drops as item if neighbor node is gone").."\n"..
+		S("param2 = wallmounted rotation (0..5)"),
 	paramtype2 = "wallmounted",
 	tiles = {
 		"testnodes_attachedw_top.png",
@@ -68,14 +75,16 @@ minetest.register_node("testnodes:attached_wallmounted", {
 
 -- Jump disabled
 minetest.register_node("testnodes:nojump", {
-	description = S("Non-jumping Node"),
+	description = S("Non-jumping Node").."\n"..
+		S("You can't jump on it"),
 	groups = {disable_jump=1, dig_immediate=3},
 	tiles = {"testnodes_nojump_top.png", "testnodes_nojump_side.png"},
 })
 
 -- Jump disabled plant
 minetest.register_node("testnodes:nojump_walkable", {
-	description = S("Non-jumping Plant Node"),
+	description = S("Non-jumping Plant Node").."\n"..
+		S("You can't jump while your feet are in it"),
 	drawtype = "plantlike",
 	groups = {disable_jump=1, dig_immediate=3},
 	walkable = false,
@@ -84,7 +93,8 @@ minetest.register_node("testnodes:nojump_walkable", {
 
 -- Climbable up and down with jump and sneak keys
 minetest.register_node("testnodes:climbable", {
-	description = S("Climbable Node"),
+	description = S("Climbable Node").."\n"..
+		S("You can climb up and down"),
 	climbable = true,
 	walkable = false,
 
@@ -99,7 +109,8 @@ minetest.register_node("testnodes:climbable", {
 
 -- Climbable only downwards with sneak key
 minetest.register_node("testnodes:climbable_nojump", {
-	description = S("Downwards-climbable Node"),
+	description = S("Downwards-climbable Node").."\n"..
+		S("You can climb only downwards"),
 	climbable = true,
 	walkable = false,
 
@@ -112,7 +123,8 @@ minetest.register_node("testnodes:climbable_nojump", {
 
 -- A liquid in which you can't rise
 minetest.register_node("testnodes:liquid_nojump", {
-	description = S("Non-jumping Liquid Source Node"),
+	description = S("Non-jumping Liquid Source Node").."\n"..
+		S("Swimmable liquid, but you can't swim upwards"),
 	liquidtype = "source",
 	liquid_range = 1,
 	liquid_viscosity = 0,
@@ -139,7 +151,8 @@ minetest.register_node("testnodes:liquid_nojump", {
 
 -- A liquid in which you can't rise (flowing variant)
 minetest.register_node("testnodes:liquidflowing_nojump", {
-	description = S("Non-jumping Flowing Liquid Node"),
+	description = S("Non-jumping Flowing Liquid Node").."\n"..
+		S("Swimmable liquid, but you can't swim upwards"),
 	liquidtype = "flowing",
 	liquid_range = 1,
 	liquid_viscosity = 0,
@@ -168,7 +181,8 @@ minetest.register_node("testnodes:liquidflowing_nojump", {
 
 -- A liquid which doesn't have liquid movement physics (source variant)
 minetest.register_node("testnodes:liquid_noswim", {
-	description = S("No-swim Liquid Source Node"),
+	description = S("No-swim Liquid Source Node").."\n"..
+		S("Liquid node, but swimming is disabled"),
 	liquidtype = "source",
 	liquid_range = 1,
 	liquid_viscosity = 0,
@@ -196,7 +210,8 @@ minetest.register_node("testnodes:liquid_noswim", {
 
 -- A liquid which doen't have liquid movement physics (flowing variant)
 minetest.register_node("testnodes:liquidflowing_noswim", {
-	description = S("No-swim Flowing Liquid Node"),
+	description = S("No-swim Flowing Liquid Node").."\n"..
+		S("Liquid node, but swimming is disabled"),
 	liquidtype = "flowing",
 	liquid_range = 1,
 	liquid_viscosity = 0,
@@ -231,10 +246,10 @@ for i=-100, 100, 25 do
 	if i ~= 0 then
 		local subname, descnum
 		if i < 0 then
-			subname = "m"..math.abs(i)
+			subname = "NEG"..string.format("%03d", math.abs(i))
 			descnum = tostring(i)
 		else
-			subname = tostring(i)
+			subname = string.format("%03d", i)
 			descnum = S("+@1", i)
 		end
 		local tex, color, desc
@@ -266,17 +281,34 @@ for i=-100, 100, 25 do
 end
 
 -- Bouncy nodes (various bounce levels)
-for i=-140, 180, 20 do
-	local val = math.floor(((i-20)/200)*255)
-	minetest.register_node(("testnodes:bouncy"..i):gsub("-","NEG"), {
-		description = S("Bouncy Node (@1%)", i),
-		groups = {bouncy=i, dig_immediate=3},
+local MAX_BOUNCE_JUMPY = 180
+local MAX_BOUNCE_NONJUMPY = 140
+for i=-MAX_BOUNCE_NONJUMPY, MAX_BOUNCE_JUMPY, 20 do
+	if i ~= 0 then
+		local desc
+		local val = math.floor(((i-20)/200)*255)
+		local val2 = math.max(0, 200 - val)
+		local num = string.format("%03d", math.abs(i))
+		if i > 0 then
+			desc = S("Bouncy Node (@1%), jumpy", i).."\n"..
+				S("Sneaking/jumping affects bounce")
+			color = { r=255-val, g=255-val, b=255, a=255 }
+		else
+			desc = S("Bouncy Node (@1%), non-jumpy", math.abs(i)).."\n"..
+				S("Sneaking/jumping does not affect bounce")
+			color = { r=val, g=255, b=val, a=255 }
+			num = "NEG"..num
+		end
+		minetest.register_node("testnodes:bouncy"..num, {
+			description = desc,
+			groups = {bouncy=i, dig_immediate=3},
 
 
-		tiles ={"testnodes_bouncy.png"},
-		is_ground_content = false,
-		color = { r=255, g=255-val, b=val, a=255 },
-	})
+			color = color,
+			tiles ={"testnodes_bouncy.png"},
+			is_ground_content = false,
+		})
+	end
 end
 
 -- Slippery nodes (various slippery levels)
@@ -294,7 +326,8 @@ end
 for r=0, 7 do
 	if r > 0 then
 		minetest.register_node("testnodes:move_resistance"..r, {
-			description = S("Move-resistant Node (@1)", r),
+			description = S("Move-resistant Node (@1)", r).."\n"..
+				S("Reduces movement speed"),
 			walkable = false,
 			move_resistance = r,
 
@@ -308,8 +341,20 @@ for r=0, 7 do
 		})
 	end
 
+	local mdesc, mcolor
+	if r == 0 then
+		mdesc = S("Liquidlike Movement Node").."\n"..
+			S("Swimmable (no move resistance)")
+		mcolor = { b = 255, g = 255, r = 128 }
+	else
+		mdesc = S("Move-resistant Node (@1), liquidlike", r).."\n"..
+			S("Reduces movement speed; swimmable")
+		mcolor = { b = 255, g = 0, r = math.floor((r/7)*255), a = 255 }
+	end
+
+
 	minetest.register_node("testnodes:move_resistance_liquidlike"..r, {
-		description = S("Move-resistant Node, liquidlike (@1)", r),
+		description = mdesc,
 		walkable = false,
 		move_resistance = r,
 		liquid_move_physics = true,
@@ -320,12 +365,13 @@ for r=0, 7 do
 		tiles = { "testnodes_move_resistance.png" },
 		is_ground_content = false,
 		groups = { dig_immediate = 3 },
-		color = { b = 255, g = 0, r = math.floor((r/7)*255), a = 255 },
+		color = mcolor,
 	})
 end
 
 minetest.register_node("testnodes:climbable_move_resistance_4", {
-	description = S("Climbable Move-resistant Node (4)"),
+	description = S("Climbable Move-resistant Node (4)").."\n"..
+		S("You can climb up and down; reduced movement speed"),
 	walkable = false,
 	climbable = true,
 	move_resistance = 4,
@@ -340,7 +386,8 @@ minetest.register_node("testnodes:climbable_move_resistance_4", {
 
 -- By placing something on the node, the node itself will be replaced
 minetest.register_node("testnodes:buildable_to", {
-	description = S("Replacable Node"),
+	description = S("\"buildable_to\" Node").."\n"..
+		S("Placing a node on it will replace it"),
 	buildable_to = true,
 	tiles = {"testnodes_buildable_to.png"},
 	is_ground_content = false,
@@ -351,13 +398,15 @@ minetest.register_node("testnodes:buildable_to", {
 -- Negative damage nodes should heal.
 for d=-3,3 do
 	if d ~= 0 then
-		local sub, tile
+		local sub, tile, desc
 		if d > 0 then
 			sub = tostring(d)
 			tile = "testnodes_damage.png"
+			desc = S("Damage Node (@1 damage per second)", d)
 		else
 			sub = "m" .. tostring(math.abs(d))
 			tile = "testnodes_damage_neg.png"
+			desc = S("Healing Node (@1 HP per second)", math.abs(d))
 		end
 		if math.abs(d) == 2 then
 			tile = tile .. "^[colorize:#000000:70"
@@ -365,7 +414,7 @@ for d=-3,3 do
 			tile = tile .. "^[colorize:#000000:140"
 		end
 		minetest.register_node("testnodes:damage_"..sub, {
-			description = S("Damage Node (@1 damage per second)", d),
+			description = desc,
 			damage_per_second = d,
 
 
@@ -382,7 +431,8 @@ end
 
 -- Causes drowning damage
 minetest.register_node("testnodes:drowning_1", {
-	description = S("Drowning Node (@1 damage)", 1),
+	description = S("Drowning Node (@1 damage)", 1).."\n"..
+		S("You'll drown inside it"),
 	drowning = 1,
 
 

--- a/games/devtest/mods/testnodes/textures.lua
+++ b/games/devtest/mods/testnodes/textures.lua
@@ -3,7 +3,8 @@
 local S = minetest.get_translator("testnodes")
 
 minetest.register_node("testnodes:6sides", {
-	description = S("Six Textures Test Node"),
+	description = S("Six Textures Test Node").."\n"..
+		S("Has 1 texture per face"),
 	tiles = {
 		"testnodes_normal1.png",
 		"testnodes_normal2.png",
@@ -17,7 +18,8 @@ minetest.register_node("testnodes:6sides", {
 })
 
 minetest.register_node("testnodes:anim", {
-	description = S("Animated Test Node"),
+	description = S("Animated Test Node").."\n"..
+		S("Tiles animate from A to D in 4s cycle"),
 	tiles = {
 		{ name = "testnodes_anim.png",
 		animation = {
@@ -40,7 +42,8 @@ for a=1,#alphas do
 
 	-- Transparency taken from texture
 	minetest.register_node("testnodes:alpha_texture_"..alpha, {
-		description = S("Texture Alpha Test Node (@1)", alpha),
+		description = S("Texture Alpha Test Node (@1)", alpha).."\n"..
+			S("Semi-transparent"),
 		drawtype = "glasslike",
 		paramtype = "light",
 		tiles = {
@@ -53,7 +56,8 @@ for a=1,#alphas do
 
 	-- Transparency set via texture modifier
 	minetest.register_node("testnodes:alpha_"..alpha, {
-		description = S("Alpha Test Node (@1)", alpha),
+		description = S("Alpha Test Node (@1)", alpha).."\n"..
+			S("Semi-transparent"),
 		drawtype = "glasslike",
 		paramtype = "light",
 		tiles = {

--- a/games/devtest/mods/tiled/init.lua
+++ b/games/devtest/mods/tiled/init.lua
@@ -1,5 +1,8 @@
+local align_help = "Texture spans over a space of 8×8 nodes"
+local align_help_n = "Tiles looks the same for every node"
+
 minetest.register_node("tiled:tiled", {
-        description = "Tiled Node (world-aligned)",
+        description = "Tiled Node (world-aligned)".."\n"..align_help,
         tiles = {{
                 name = "tiled_tiled.png",
                 align_style = "world",
@@ -9,7 +12,7 @@ minetest.register_node("tiled:tiled", {
 })
 
 minetest.register_node("tiled:tiled_n", {
-        description = "Tiled Node (node-aligned)",
+        description = "Tiled Node (node-aligned)".."\n"..align_help_n,
         tiles = {{
                 name = "tiled_tiled_node.png",
                 align_style = "node",
@@ -20,13 +23,13 @@ minetest.register_node("tiled:tiled_n", {
 stairs.register_stair_and_slab("tiled_n", "tiled:tiled_n",
 		{cracky=3},
 		{{name="tiled_tiled_node.png", align_style="node"}},
-		"Tiled Stair (node-aligned)",
-		"Tiled Slab (node-aligned)")
+		"Tiled Stair (node-aligned)".."\n"..align_help_n,
+		"Tiled Slab (node-aligned)".."\n"..align_help_n)
 
 stairs.register_stair_and_slab("tiled", "tiled:tiled",
 		{cracky=3},
 		{{name="tiled_tiled.png", align_style="world", scale=8}},
-		"Tiled Stair (world-aligned)",
-		"Tiled Slab (world-aligned)")
+		"Tiled Stair (world-aligned)".."\n"..align_help,
+		"Tiled Slab (world-aligned)".."\n"..align_help)
 
 

--- a/games/devtest/mods/unittests/itemdescription.lua
+++ b/games/devtest/mods/unittests/itemdescription.lua
@@ -2,6 +2,7 @@ local full_description = "Description Test Item\nFor testing item decription"
 minetest.register_tool("unittests:description_test", {
 	description = full_description,
 	inventory_image = "unittests_description_test.png",
+	groups = { dummy = 1 },
 })
 
 minetest.register_chatcommand("item_description", {


### PR DESCRIPTION
This PR extends the tooltips of most items in DevTest to roughly explain what they are supposed to do and how to use them, by using newlines and stuff.

When a node supports param2 and it is relevant, this is also mentioned in the tooltip. This is helpful so you know where the Param2 Tool is useful.

The reason is that there are now so many different items in DevTest it is easy to get lost in. Another reason is that the tooltips serve as a reminder how the node is supposed to work when it is not broken; so you can notice when a node does not behave as intende.

Additionally, I have tweaked the sorting of a few items in the Chest of Everything (mostly to make sure that numbers are in order).

I added tooltip extensions to almost everything. One notable exteption are the TGA nodes and the generated texture nodes, because a few of them seem broken atm, and I don't know what they *should* look like. (Help would be appreciated.)