### PR TITLE
Make bloom shaders compatible with GLES2

### DIFF
--- a/client/shaders/blur_h/opengl_fragment.glsl
+++ b/client/shaders/blur_h/opengl_fragment.glsl
@@ -2,7 +2,7 @@
 
 uniform sampler2D rendered;
 uniform vec2 texelSize0;
-uniform mediump float bloomRadius = 3.0;
+uniform mediump float bloomRadius;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;

--- a/client/shaders/blur_v/opengl_fragment.glsl
+++ b/client/shaders/blur_v/opengl_fragment.glsl
@@ -2,7 +2,7 @@
 
 uniform sampler2D rendered;
 uniform vec2 texelSize0;
-uniform mediump float bloomRadius = 3.0;
+uniform mediump float bloomRadius;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;

--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -1,8 +1,8 @@
 #define rendered texture0
 
 uniform sampler2D rendered;
-uniform mediump float exposureFactor = 2.5;
-uniform float bloomLuminanceThreshold = 1.0;
+uniform mediump float exposureFactor;
+uniform float bloomLuminanceThreshold;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -3,8 +3,8 @@
 
 uniform sampler2D rendered;
 uniform sampler2D bloom;
-uniform mediump float exposureFactor = 2.5;
-uniform lowp float bloomIntensity = 1.0;
+uniform mediump float exposureFactor;
+uniform lowp float bloomIntensity;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -12,13 +12,13 @@ varying mediump vec2 varTexCoord;
 centroid varying vec2 varTexCoord;
 #endif
 
-#if ENABLE_BLOOM
+#ifdef ENABLE_BLOOM
 
 vec4 applyBloom(vec4 color, vec2 uv)
 {
 	float bias = bloomIntensity;
 	vec4 bloom = texture2D(bloom, uv);
-#if ENABLE_BLOOM_DEBUG
+#ifdef ENABLE_BLOOM_DEBUG
 	if (uv.x > 0.5 && uv.y < 0.5)
 		return vec4(bloom.rgb, color.a);
 	if (uv.x < 0.5)
@@ -30,7 +30,7 @@ vec4 applyBloom(vec4 color, vec2 uv)
 
 #endif
 
-#if ENABLE_TONE_MAPPING
+#ifdef ENABLE_TONE_MAPPING
 
 /* Hable's UC2 Tone mapping parameters
 	A = 0.22;
@@ -68,7 +68,7 @@ void main(void)
 	// translate to linear colorspace (approximate)
 	color.rgb = pow(color.rgb, vec3(2.2));
 
-#if ENABLE_BLOOM_DEBUG
+#ifdef ENABLE_BLOOM_DEBUG
 	if (uv.x > 0.5 || uv.y > 0.5)
 #endif
 	{
@@ -76,15 +76,15 @@ void main(void)
 	}
 
 
-#if ENABLE_BLOOM
+#ifdef ENABLE_BLOOM
 	color = applyBloom(color, uv);
 #endif
 
-#if ENABLE_BLOOM_DEBUG
+#ifdef ENABLE_BLOOM_DEBUG
 	if (uv.x > 0.5 || uv.y > 0.5)
 #endif
 	{
-#if ENABLE_TONE_MAPPING
+#ifdef ENABLE_TONE_MAPPING
 		color = applyToneMapping(color);
 #else
 		color.rgb /= 2.5; // default exposure factor, see also RenderingEngine::DEFAULT_EXPOSURE_FACTOR;


### PR DESCRIPTION
Fixes #12824 

## To do

This PR is Ready for Review.

## How to test

1. Play Minetest on GLES 2.0
2. The game should render normally, without shader errors.

Co-authored-by: @srifqi 