### PR TITLE
Add MetaDataRef:get_keys

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6863,6 +6863,7 @@ and [`PlayerMetaRef`].
 * `get_int(key)`: Returns `0` if key not present.
 * `set_float(key, value)`
 * `get_float(key)`: Returns `0` if key not present.
+* `get_keys()`: returns a list of all keys in the metadata.
 * `to_table()`: returns `nil` or a table with keys:
     * `fields`: key-value storage
     * `inventory`: `{list1 = {}, ...}}` (NodeMetaRef only)

--- a/games/devtest/mods/unittests/metadata.lua
+++ b/games/devtest/mods/unittests/metadata.lua
@@ -30,6 +30,14 @@ local function test_metadata(meta)
 	assert(tab.fields.d == "4")
 	assert(tab.fields.e == "e")
 
+	local keys = meta:get_keys()
+	assert(table.indexof(keys, "a") > 0)
+	assert(table.indexof(keys, "b") > 0)
+	assert(table.indexof(keys, "c") > 0)
+	assert(table.indexof(keys, "d") > 0)
+	assert(table.indexof(keys, "e") > 0)
+	assert(#keys == 5)
+
 	assert(not meta:contains(""))
 	assert(meta:contains("a"))
 	assert(meta:contains("b"))
@@ -57,6 +65,7 @@ local function test_metadata(meta)
 
 	meta:from_table()
 	assert(next(meta:to_table().fields) == nil)
+	assert(#meta:get_keys() == 0)
 
 	assert(not meta:equals(compare_meta))
 end

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -247,6 +247,13 @@ const StringMap &ModMetadata::getStrings(StringMap *place) const
 	return *place;
 }
 
+const std::vector<std::string> &ModMetadata::getKeys(std::vector<std::string> *place) const
+{
+	place->clear();
+	m_database->getModKeys(m_mod_name, place);
+	return *place;
+}
+
 const std::string *ModMetadata::getStringRaw(const std::string &name, std::string *place) const
 {
 	return m_database->getModEntry(m_mod_name, name, place) ? place : nullptr;

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -127,6 +127,8 @@ public:
 
 	const StringMap &getStrings(StringMap *place) const override;
 
+	const std::vector<std::string> &getKeys(std::vector<std::string> *place) const override;
+
 protected:
 	const std::string *getStringRaw(const std::string &name,
 			std::string *place) const override;

--- a/src/database/database-dummy.cpp
+++ b/src/database/database-dummy.cpp
@@ -92,6 +92,17 @@ bool Database_Dummy::getModEntries(const std::string &modname, StringMap *storag
 	return true;
 }
 
+bool Database_Dummy::getModKeys(const std::string &modname, std::vector<std::string> *storage)
+{
+	const auto mod_pair = m_mod_meta_database.find(modname);
+	if (mod_pair != m_mod_meta_database.cend()) {
+		for (const auto &pair : mod_pair->second) {
+			storage->push_back(pair.first);
+		}
+	}
+	return true;
+}
+
 bool Database_Dummy::getModEntry(const std::string &modname,
 	const std::string &key, std::string *value)
 {

--- a/src/database/database-dummy.cpp
+++ b/src/database/database-dummy.cpp
@@ -96,9 +96,9 @@ bool Database_Dummy::getModKeys(const std::string &modname, std::vector<std::str
 {
 	const auto mod_pair = m_mod_meta_database.find(modname);
 	if (mod_pair != m_mod_meta_database.cend()) {
-		for (const auto &pair : mod_pair->second) {
+		storage->reserve(storage->size() + mod_pair->second.size());
+		for (const auto &pair : mod_pair->second)
 			storage->push_back(pair.first);
-		}
 	}
 	return true;
 }

--- a/src/database/database-dummy.h
+++ b/src/database/database-dummy.h
@@ -38,6 +38,7 @@ public:
 	void listPlayers(std::vector<std::string> &res);
 
 	bool getModEntries(const std::string &modname, StringMap *storage);
+	bool getModKeys(const std::string &modname, std::vector<std::string> *storage);
 	bool getModEntry(const std::string &modname,
 			const std::string &key, std::string *value);
 	bool hasModEntry(const std::string &modname, const std::string &key);

--- a/src/database/database-files.cpp
+++ b/src/database/database-files.cpp
@@ -404,9 +404,9 @@ bool ModMetadataDatabaseFiles::getModKeys(const std::string &modname,
 		return false;
 
 	std::vector<std::string> keys = meta->getMemberNames();
-	for (std::string &key : keys) {
-		storage->emplace_back(std::move(key));
-	}
+	storage->reserve(storage->size() + keys.size());
+	for (std::string &key : keys)
+		storage->push_back(std::move(key));
 
 	return true;
 }

--- a/src/database/database-files.cpp
+++ b/src/database/database-files.cpp
@@ -396,6 +396,21 @@ bool ModMetadataDatabaseFiles::getModEntries(const std::string &modname, StringM
 	return true;
 }
 
+bool ModMetadataDatabaseFiles::getModKeys(const std::string &modname,
+		std::vector<std::string> *storage)
+{
+	Json::Value *meta = getOrCreateJson(modname);
+	if (!meta)
+		return false;
+
+	std::vector<std::string> keys = meta->getMemberNames();
+	for (std::string &key : keys) {
+		storage->emplace_back(std::move(key));
+	}
+
+	return true;
+}
+
 bool ModMetadataDatabaseFiles::getModEntry(const std::string &modname,
 	const std::string &key, std::string *value)
 {

--- a/src/database/database-files.h
+++ b/src/database/database-files.h
@@ -79,6 +79,7 @@ public:
 	virtual ~ModMetadataDatabaseFiles() = default;
 
 	virtual bool getModEntries(const std::string &modname, StringMap *storage);
+	virtual bool getModKeys(const std::string &modname, std::vector<std::string> *storage);
 	virtual bool getModEntry(const std::string &modname,
 		const std::string &key, std::string *value);
 	virtual bool hasModEntry(const std::string &modname, const std::string &key);

--- a/src/database/database-sqlite3.h
+++ b/src/database/database-sqlite3.h
@@ -240,6 +240,7 @@ public:
 	virtual ~ModMetadataDatabaseSQLite3();
 
 	virtual bool getModEntries(const std::string &modname, StringMap *storage);
+	virtual bool getModKeys(const std::string &modname, std::vector<std::string> *storage);
 	virtual bool getModEntry(const std::string &modname,
 		const std::string &key, std::string *value);
 	virtual bool hasModEntry(const std::string &modname, const std::string &key);
@@ -258,6 +259,7 @@ protected:
 
 private:
 	sqlite3_stmt *m_stmt_get_all = nullptr;
+	sqlite3_stmt *m_stmt_get_keys = nullptr;
 	sqlite3_stmt *m_stmt_get = nullptr;
 	sqlite3_stmt *m_stmt_has = nullptr;
 	sqlite3_stmt *m_stmt_set = nullptr;

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -92,6 +92,7 @@ public:
 	virtual ~ModMetadataDatabase() = default;
 
 	virtual bool getModEntries(const std::string &modname, StringMap *storage) = 0;
+	virtual bool getModKeys(const std::string &modname, std::vector<std::string> *storage) = 0;
 	virtual bool hasModEntry(const std::string &modname, const std::string &key) = 0;
 	virtual bool getModEntry(const std::string &modname,
 		const std::string &key, std::string *value) = 0;

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -111,9 +111,9 @@ const StringMap &SimpleMetadata::getStrings(StringMap *) const
 const std::vector<std::string> &SimpleMetadata::getKeys(std::vector<std::string> *place) const
 {
 	place->clear();
-	for (const auto &pair : m_stringvars) {
+	place->reserve(m_stringvars.size());
+	for (const auto &pair : m_stringvars)
 		place->push_back(pair.first);
-	}
 	return *place;
 }
 

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -108,6 +108,15 @@ const StringMap &SimpleMetadata::getStrings(StringMap *) const
 	return m_stringvars;
 }
 
+const std::vector<std::string> &SimpleMetadata::getKeys(std::vector<std::string> *place) const
+{
+	place->clear();
+	for (const auto &pair : m_stringvars) {
+		place->push_back(pair.first);
+	}
+	return *place;
+}
+
 const std::string *SimpleMetadata::getStringRaw(const std::string &name, std::string *) const
 {
 	const auto found = m_stringvars.find(name);

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -60,6 +60,9 @@ public:
 	// May (not must!) put strings in `place` and return a reference to these strings.
 	virtual const StringMap &getStrings(StringMap *place) const = 0;
 
+	// May (not must!) put keys in `place` and return a reference to these keys.
+	virtual const std::vector<std::string> &getKeys(std::vector<std::string> *place) const = 0;
+
 	// Add support for variable names in values. Uses place like getString.
 	const std::string &resolveString(const std::string &str, std::string *place,
 			u16 recursion = 0) const;
@@ -88,6 +91,8 @@ public:
 	bool contains(const std::string &name) const override;
 	virtual bool setString(const std::string &name, const std::string &var) override;
 	const StringMap &getStrings(StringMap *) const override final;
+	const std::vector<std::string> &getKeys(
+			std::vector<std::string> *place) const override final;
 
 	// Simple version of getters, possible due to in-memory storage:
 

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -91,8 +91,8 @@ public:
 	bool contains(const std::string &name) const override;
 	virtual bool setString(const std::string &name, const std::string &var) override;
 	const StringMap &getStrings(StringMap *) const override final;
-	const std::vector<std::string> &getKeys(
-			std::vector<std::string> *place) const override final;
+	const std::vector<std::string> &getKeys(std::vector<std::string> *place)
+		const override final;
 
 	// Simple version of getters, possible due to in-memory storage:
 

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -97,6 +97,7 @@ const luaL_Reg ItemStackMetaRef::methods[] = {
 	luamethod(MetaDataRef, set_int),
 	luamethod(MetaDataRef, get_float),
 	luamethod(MetaDataRef, set_float),
+	luamethod(MetaDataRef, get_keys),
 	luamethod(MetaDataRef, to_table),
 	luamethod(MetaDataRef, from_table),
 	luamethod(MetaDataRef, equals),

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -213,10 +213,10 @@ int MetaDataRef::l_get_keys(lua_State *L)
 	std::vector<std::string> keys_;
 	const std::vector<std::string> &keys = meta->getKeys(&keys_);
 
-	lua_Integer i = 0;
+	lua_Number i = 0;
 	lua_createtable(L, (int)MYMIN(keys.size(), INT_MAX), 0);
 	for (const std::string &key : keys) {
-		lua_pushinteger(L, ++i);
+		lua_pushnumber(L, ++i);
 		lua_pushlstring(L, key.c_str(), key.size());
 		lua_rawset(L, -3);
 	}

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -196,6 +196,31 @@ int MetaDataRef::l_set_float(lua_State *L)
 	return 0;
 }
 
+// get_keys(self)
+int MetaDataRef::l_get_keys(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
+
+	IMetadata *meta = ref->getmeta(false);
+	if (meta == NULL) {
+		lua_newtable(L);
+		return 1;
+	}
+
+	std::vector<std::string> keys_;
+	const std::vector<std::string> &keys = meta->getKeys(&keys_);
+
+	int i = 0;
+	lua_createtable(L, (int)keys.size(), 0);
+	for (const std::string &key : keys) {
+		lua_pushlstring(L, key.c_str(), key.size());
+		lua_rawseti(L, -2, ++i);
+	}
+	return 1;
+}
+
 // to_table(self)
 int MetaDataRef::l_to_table(lua_State *L)
 {

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "serverenvironment.h"
 #include "map.h"
 #include "server.h"
+#include "util/basic_macros.h"
 
 MetaDataRef *MetaDataRef::checkAnyMetadata(lua_State *L, int narg)
 {
@@ -212,11 +213,12 @@ int MetaDataRef::l_get_keys(lua_State *L)
 	std::vector<std::string> keys_;
 	const std::vector<std::string> &keys = meta->getKeys(&keys_);
 
-	int i = 0;
-	lua_createtable(L, (int)keys.size(), 0);
+	lua_Integer i = 0;
+	lua_createtable(L, (int)MYMIN(keys.size(), INT_MAX), 0);
 	for (const std::string &key : keys) {
+		lua_pushinteger(L, ++i);
 		lua_pushlstring(L, key.c_str(), key.size());
-		lua_rawseti(L, -2, ++i);
+		lua_rawset(L, -3);
 	}
 	return 1;
 }

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -213,12 +213,11 @@ int MetaDataRef::l_get_keys(lua_State *L)
 	std::vector<std::string> keys_;
 	const std::vector<std::string> &keys = meta->getKeys(&keys_);
 
-	lua_Number i = 0;
-	lua_createtable(L, (int)MYMIN(keys.size(), INT_MAX), 0);
+	int i = 0;
+	lua_createtable(L, keys.size(), 0);
 	for (const std::string &key : keys) {
-		lua_pushnumber(L, ++i);
 		lua_pushlstring(L, key.c_str(), key.size());
-		lua_rawset(L, -3);
+		lua_rawseti(L, -2, ++i);
 	}
 	return 1;
 }

--- a/src/script/lua_api/l_metadata.h
+++ b/src/script/lua_api/l_metadata.h
@@ -74,6 +74,9 @@ protected:
 	// set_float(self, name, var)
 	static int l_set_float(lua_State *L);
 
+	// get_keys(self)
+	static int l_get_keys(lua_State *L);
+
 	// to_table(self)
 	static int l_to_table(lua_State *L);
 

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -209,6 +209,7 @@ const luaL_Reg NodeMetaRef::methodsServer[] = {
 	luamethod(MetaDataRef, set_int),
 	luamethod(MetaDataRef, get_float),
 	luamethod(MetaDataRef, set_float),
+	luamethod(MetaDataRef, get_keys),
 	luamethod(MetaDataRef, to_table),
 	luamethod(MetaDataRef, from_table),
 	luamethod(NodeMetaRef, get_inventory),
@@ -230,6 +231,7 @@ const luaL_Reg NodeMetaRef::methodsClient[] = {
 	luamethod(MetaDataRef, get_string),
 	luamethod(MetaDataRef, get_int),
 	luamethod(MetaDataRef, get_float),
+	luamethod(MetaDataRef, get_keys),
 	luamethod(MetaDataRef, to_table),
 	{0,0}
 };

--- a/src/script/lua_api/l_playermeta.cpp
+++ b/src/script/lua_api/l_playermeta.cpp
@@ -70,6 +70,7 @@ const luaL_Reg PlayerMetaRef::methods[] = {
 	luamethod(MetaDataRef, set_int),
 	luamethod(MetaDataRef, get_float),
 	luamethod(MetaDataRef, set_float),
+	luamethod(MetaDataRef, get_keys),
 	luamethod(MetaDataRef, to_table),
 	luamethod(MetaDataRef, from_table),
 	luamethod(MetaDataRef, equals),

--- a/src/script/lua_api/l_storage.cpp
+++ b/src/script/lua_api/l_storage.cpp
@@ -74,6 +74,7 @@ const luaL_Reg StorageRef::methods[] = {
 	luamethod(MetaDataRef, set_int),
 	luamethod(MetaDataRef, get_float),
 	luamethod(MetaDataRef, set_float),
+	luamethod(MetaDataRef, get_keys),
 	luamethod(MetaDataRef, to_table),
 	luamethod(MetaDataRef, from_table),
 	luamethod(MetaDataRef, equals),

--- a/src/unittest/test_modmetadatadatabase.cpp
+++ b/src/unittest/test_modmetadatadatabase.cpp
@@ -286,8 +286,11 @@ void TestModMetadataDatabase::testRecallFail()
 {
 	ModMetadataDatabase *mod_meta_db = mod_meta_provider->getModMetadataDatabase();
 	StringMap recalled;
+	std::vector<std::string> recalled_keys;
 	mod_meta_db->getModEntries("mod1", &recalled);
+	mod_meta_db->getModKeys("mod1", &recalled_keys);
 	UASSERT(recalled.empty());
+	UASSERT(recalled_keys.empty());
 	std::string key1_value;
 	UASSERT(!mod_meta_db->getModEntry("mod1", "key1", &key1_value));
 	UASSERT(!mod_meta_db->hasModEntry("mod1", "key1"));
@@ -303,9 +306,13 @@ void TestModMetadataDatabase::testRecall()
 {
 	ModMetadataDatabase *mod_meta_db = mod_meta_provider->getModMetadataDatabase();
 	StringMap recalled;
+	std::vector<std::string> recalled_keys;
 	mod_meta_db->getModEntries("mod1", &recalled);
+	mod_meta_db->getModKeys("mod1", &recalled_keys);
 	UASSERTCMP(std::size_t, ==, recalled.size(), 1);
+	UASSERTCMP(std::size_t, ==, recalled_keys.size(), 1);
 	UASSERTCMP(std::string, ==, recalled["key1"], "value1");
+	UASSERTCMP(std::string, ==, recalled_keys[0], "key1");
 	std::string key1_value;
 	UASSERT(mod_meta_db->getModEntry("mod1", "key1", &key1_value));
 	UASSERTCMP(std::string, ==, key1_value, "value1");


### PR DESCRIPTION
This PR adds a `get_keys` method to metadata objects. It's like `to_table` but it only returns a list of keys. This was suggested by @Warr1024 as a way to save memory when iterating through keys of mod storage, short of adding a fully-fledged iterator API, which would be difficult, what with iterator invalidation and all.

I decided to make the function return a list instead of a set, since its primary application is iteration.

I'd like to get this in before the next Minetest release, so that it can come out in the same release as https://github.com/minetest/minetest/pull/12562.

## To do

This PR is Ready for Review.

## How to test

Run the unit tests.
