### PR TITLE
Add modslist formspec for /mods command.

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -763,15 +763,22 @@ core.register_chatcommand("fixlight", {
 })
 
 core.register_chatcommand("mods", {
-	params = "",
-	description = S("List mods installed on the server"),
+	params = S("[-t]"),
+	description = S("List mods installed on the server (-t: output in chat)"),
 	privs = {},
 	func = function(name, param)
-		local mods = core.get_modnames()
-		if #mods == 0 then
-			return true, S("No mods installed.")
+		local player = core.get_player_by_name(name)
+
+		if param == "" and player then
+			core.show_formspec(name, "__builtin:mods", build_mods_formspec())
+			return true
 		else
-			return true, table.concat(core.get_modnames(), ", ")
+			local mods = core.get_modnames()
+			if #mods == 0 then
+				return true, S("No mods installed.")
+			else
+				return true, table.concat(mods, ", ")
+			end
 		end
 	end,
 })


### PR DESCRIPTION
Previous failed attempts: #11946 #10924 #10450

Releavant issues: #10367 #9563

This is my fourth (and I hope last) attempt to add formspec display for `/mods` command. With this PR it outputs a formspec with a table listing all enabled mods and modpacks if no parameters are passed. In case of `/mods -t` call, it will output the info in string form as before. Also note, currently there's no a color difference between mods being a part of a game/world and  global as in the mainmenu mods conf dialogue. 

![Снимок экрана от 2022-10-09 19-21-19](https://user-images.githubusercontent.com/25750346/194767982-0552ec57-7ed4-488b-adb8-a9ce288b78c9.png)


## To do

This PR is Ready for Review.

## How to test
Try to call `/mods -t` and just `/mods`.
