### PR TITLE
Speed up find_nodes_in_area

### DIFF
--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -902,11 +902,8 @@ int ModApiEnvMod::l_find_nodes_in_area(lua_State *L)
 		for (u32 i = 0; i < filter.size(); i++)
 			lua_newtable(L);
 
-		v3s16 p;
-		for (p.X = minp.X; p.X <= maxp.X; p.X++)
-		for (p.Y = minp.Y; p.Y <= maxp.Y; p.Y++)
-		for (p.Z = minp.Z; p.Z <= maxp.Z; p.Z++) {
-			content_t c = map.getNode(p).getContent();
+		map.forEachNodeInArea(minp, maxp, [&](v3s16 p, MapNode n) -> bool {
+			content_t c = n.getContent();
 
 			auto it = std::find(filter.begin(), filter.end(), c);
 			if (it != filter.end()) {
@@ -915,7 +912,9 @@ int ModApiEnvMod::l_find_nodes_in_area(lua_State *L)
 				push_v3s16(L, p);
 				lua_rawseti(L, base + 1 + filt_index, ++idx[filt_index]);
 			}
-		}
+
+			return true;
+		});
 
 		// last filter table is at top of stack
 		u32 i = filter.size() - 1;
@@ -937,11 +936,8 @@ int ModApiEnvMod::l_find_nodes_in_area(lua_State *L)
 
 		lua_newtable(L);
 		u32 i = 0;
-		v3s16 p;
-		for (p.X = minp.X; p.X <= maxp.X; p.X++)
-		for (p.Y = minp.Y; p.Y <= maxp.Y; p.Y++)
-		for (p.Z = minp.Z; p.Z <= maxp.Z; p.Z++) {
-			content_t c = env->getMap().getNode(p).getContent();
+		map.forEachNodeInArea(minp, maxp, [&](v3s16 p, MapNode n) -> bool {
+			content_t c = n.getContent();
 
 			auto it = std::find(filter.begin(), filter.end(), c);
 			if (it != filter.end()) {
@@ -951,7 +947,9 @@ int ModApiEnvMod::l_find_nodes_in_area(lua_State *L)
 				u32 filt_index = it - filter.begin();
 				individual_count[filt_index]++;
 			}
-		}
+
+			return true;
+		});
 
 		lua_createtable(L, 0, filter.size());
 		for (u32 i = 0; i < filter.size(); i++) {

--- a/src/unittest/test_map.cpp
+++ b/src/unittest/test_map.cpp
@@ -35,6 +35,7 @@ public:
 	void testMaxMapgenLimit();
 	void testForEachNodeInArea(IGameDef *gamedef);
 	void testForEachNodeInAreaBlank(IGameDef *gamedef);
+	void testForEachNodeInAreaEmpty(IGameDef *gamedef);
 };
 
 static TestMap g_test_instance;
@@ -44,6 +45,7 @@ void TestMap::runTests(IGameDef *gamedef)
 	TEST(testMaxMapgenLimit);
 	TEST(testForEachNodeInArea, gamedef);
 	TEST(testForEachNodeInAreaBlank, gamedef);
+	TEST(testForEachNodeInAreaEmpty, gamedef);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -147,10 +149,23 @@ void TestMap::testForEachNodeInAreaBlank(IGameDef *gamedef)
 	DummyMap map(gamedef, v3s16(0, 0, 0), v3s16(-1, -1, -1));
 
 	v3s16 invalid_p(0, 0, 0);
+	bool visited = false;
 	map.forEachNodeInArea(invalid_p, invalid_p, [&](v3s16 p, MapNode n) -> bool {
 		bool is_valid_position = true;
 		UASSERT(n == map.getNode(p, &is_valid_position));
 		UASSERT(!is_valid_position);
+		UASSERT(!visited);
+		visited = true;
+		return true;
+	});
+	UASSERT(visited);
+}
+
+void TestMap::testForEachNodeInAreaEmpty(IGameDef *gamedef)
+{
+	DummyMap map(gamedef, v3s16(), v3s16());
+	map.forEachNodeInArea(v3s16(0, 0, 0), v3s16(-1, -1, -1), [&](v3s16 p, MapNode n) -> bool {
+		UASSERT(false); // Should be unreachable
 		return true;
 	});
 }

--- a/src/unittest/test_map.cpp
+++ b/src/unittest/test_map.cpp
@@ -19,7 +19,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "test.h"
 
 #include <cstdio>
+#include <unordered_set>
+#include <unordered_map>
 #include "mapblock.h"
+#include "dummymap.h"
 
 class TestMap : public TestBase
 {
@@ -30,6 +33,8 @@ public:
 	void runTests(IGameDef *gamedef);
 
 	void testMaxMapgenLimit();
+	void testForEachNodeInArea(IGameDef *gamedef);
+	void testForEachNodeInAreaBlank(IGameDef *gamedef);
 };
 
 static TestMap g_test_instance;
@@ -37,6 +42,8 @@ static TestMap g_test_instance;
 void TestMap::runTests(IGameDef *gamedef)
 {
 	TEST(testMaxMapgenLimit);
+	TEST(testForEachNodeInArea, gamedef);
+	TEST(testForEachNodeInAreaBlank, gamedef);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -65,4 +72,85 @@ void TestMap::testMaxMapgenLimit()
 	UASSERT(blockpos_over_max_limit(v3s16(limit_block+1)) == true);
 	UASSERT(blockpos_over_max_limit(v3s16(-limit_block)) == false);
 	UASSERT(blockpos_over_max_limit(v3s16(-limit_block-1)) == true);
+}
+
+void TestMap::testForEachNodeInArea(IGameDef *gamedef)
+{
+	v3s16 minp_visit(-10, -10, -10);
+	v3s16 maxp_visit(20, 20, 10);
+	v3s16 dims_visit = maxp_visit - minp_visit + v3s16(1, 1, 1);
+	s32 volume_visit = (s32)dims_visit.X * (s32)dims_visit.Y * (s32)dims_visit.Z;
+
+	v3s16 minp = minp_visit - v3s16(1, 1, 1);
+	v3s16 maxp = maxp_visit + v3s16(1, 1, 1);
+	DummyMap map(gamedef, getNodeBlockPos(minp), getNodeBlockPos(maxp));
+
+	v3s16 p1(0, 10, 5);
+	MapNode n1(t_CONTENT_STONE);
+	map.setNode(p1, n1);
+
+	v3s16 p2(-1, 15, 5);
+	MapNode n2(t_CONTENT_TORCH);
+	map.setNode(p2, n2);
+
+	v3s16 p3 = minp_visit;
+	MapNode n3(CONTENT_AIR);
+	map.setNode(p3, n3);
+
+	v3s16 p4 = maxp_visit;
+	MapNode n4(t_CONTENT_LAVA);
+	map.setNode(p4, n4);
+
+	// These positions should not be visited.
+	map.setNode(minp, MapNode(t_CONTENT_WATER));
+	map.setNode(maxp, MapNode(t_CONTENT_WATER));
+
+	s32 n_visited = 0;
+	std::unordered_set<v3s16> visited;
+	v3s16 minp_visited(0, 0, 0);
+	v3s16 maxp_visited(0, 0, 0);
+	std::unordered_map<v3s16, MapNode> found;
+	map.forEachNodeInArea(minp_visit, maxp_visit, [&](v3s16 p, MapNode n) -> bool {
+		n_visited++;
+		visited.insert(p);
+		minp_visited.X = std::min(minp_visited.X, p.X);
+		minp_visited.Y = std::min(minp_visited.Y, p.Y);
+		minp_visited.Z = std::min(minp_visited.Z, p.Z);
+		maxp_visited.X = std::max(maxp_visited.X, p.X);
+		maxp_visited.Y = std::max(maxp_visited.Y, p.Y);
+		maxp_visited.Z = std::max(maxp_visited.Z, p.Z);
+
+		if (n.getContent() != CONTENT_IGNORE)
+			found[p] = n;
+
+		return true;
+	});
+
+	UASSERTEQ(s32, n_visited, volume_visit);
+	UASSERTEQ(s32, (s32)visited.size(), volume_visit);
+	UASSERT(minp_visited == minp_visit);
+	UASSERT(maxp_visited == maxp_visit);
+
+	UASSERTEQ(size_t, found.size(), 4);
+	UASSERT(found.find(p1) != found.end());
+	UASSERTEQ(content_t, found[p1].getContent(), n1.getContent());
+	UASSERT(found.find(p2) != found.end());
+	UASSERTEQ(content_t, found[p2].getContent(), n2.getContent());
+	UASSERT(found.find(p3) != found.end());
+	UASSERTEQ(content_t, found[p3].getContent(), n3.getContent());
+	UASSERT(found.find(p4) != found.end());
+	UASSERTEQ(content_t, found[p4].getContent(), n4.getContent());
+}
+
+void TestMap::testForEachNodeInAreaBlank(IGameDef *gamedef)
+{
+	DummyMap map(gamedef, v3s16(0, 0, 0), v3s16(-1, -1, -1));
+
+	v3s16 invalid_p(0, 0, 0);
+	map.forEachNodeInArea(invalid_p, invalid_p, [&](v3s16 p, MapNode n) -> bool {
+		bool is_valid_position = true;
+		UASSERT(n == map.getNode(p, &is_valid_position));
+		UASSERT(!is_valid_position);
+		return true;
+	});
 }


### PR DESCRIPTION
Nodes are now searched by mapblock and by sector, instead of the "naive" way. Here is a benchmark:

```lua
local N = 15
minetest.after(0, function()
	local p1 = vector.new(10, 10, 10)
	local p2 = vector.new(N, N, N)
	minetest.load_area(p1, p2)
	local before = core.get_us_time()
	for i = 1, 400 do
		assert(#minetest.find_nodes_in_area(p1, p2, "unknown") == 0)
	end
	local after = core.get_us_time()
	minetest.debug("Benchmark:", after - before)
end)
```

Here are my results:

<table>
<tr><th/><th>Before patch</th><th>After patch</th></tr>
<tr><th><code>N = 15</code></th><td>~3000</td><td>~2000</td></tr>
<tr><th><code>N = 30</code></th><td>~95000</td><td>~35000</td></tr>
</table>

## To do

This PR is Ready for Review.

## How to test

Run the new C++ unit test and try mods that use `find_nodes_in_area`.
