### PR TITLE
object ids are u16, not s16

### DIFF
--- a/src/util/pointedthing.cpp
+++ b/src/util/pointedthing.cpp
@@ -36,7 +36,7 @@ PointedThing::PointedThing(const v3s16 &under, const v3s16 &above,
 	distanceSq(distSq)
 {}
 
-PointedThing::PointedThing(s16 id, const v3f &point, const v3s16 &normal,
+PointedThing::PointedThing(u16 id, const v3f &point, const v3s16 &normal,
 	f32 distSq) :
 	type(POINTEDTHING_OBJECT),
 	object_id(id),
@@ -81,7 +81,7 @@ void PointedThing::serialize(std::ostream &os) const
 		writeV3S16(os, node_abovesurface);
 		break;
 	case POINTEDTHING_OBJECT:
-		writeS16(os, object_id);
+		writeU16(os, object_id);
 		break;
 	}
 }
@@ -100,7 +100,7 @@ void PointedThing::deSerialize(std::istream &is)
 		node_abovesurface = readV3S16(is);
 		break;
 	case POINTEDTHING_OBJECT:
-		object_id = readS16(is);
+		object_id = readU16(is);
 		break;
 	default:
 		throw SerializationError("unsupported PointedThingType");

--- a/src/util/pointedthing.h
+++ b/src/util/pointedthing.h
@@ -61,7 +61,7 @@ struct PointedThing
 	 * Only valid if type is POINTEDTHING_OBJECT.
 	 * The ID of the object the ray hit.
 	 */
-	s16 object_id = -1;
+	u16 object_id = 0;
 	/*!
 	 * Only valid if type isn't POINTEDTHING_NONE.
 	 * First intersection point of the ray and the nodebox in irrlicht
@@ -93,7 +93,7 @@ struct PointedThing
 		const v3s16 &real_under, const v3f &point, const v3s16 &normal,
 		u16 box_id, f32 distSq);
 	//! Constructor for POINTEDTHING_OBJECT
-	PointedThing(s16 id, const v3f &point, const v3s16 &normal, f32 distSq);
+	PointedThing(u16 id, const v3f &point, const v3s16 &normal, f32 distSq);
 	std::string dump() const;
 	void serialize(std::ostream &os) const;
 	void deSerialize(std::istream &is);


### PR DESCRIPTION
- Goal of the PR
change the type of the object_id in PointedThing, so that "negative" object IDs don't show up in some log messages e.g. 
```
ACTION[Server]: Parrish right-clicks object -25835: LuaEntitySAO "petz:hamster" at (-10902,10,-13670)
```

- How does the PR work?
changes the type from s16 to u16

- Does it resolve any reported issue?
not that i'm aware of

- Does this relate to a goal in [the roadmap](../doc/direction.md)?
probably not, but it's technically a bug-fix.

## How to test
create more than 32767 objects and then right-click on the last one and check the logs.
