### PR TITLE
Store whether window is maximized

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -145,11 +145,11 @@ screen_h (Screen height) int 600 1 65535
 #    Whether the window is maximized.
 window_maximized (Window maximized) bool false
 
-#    Save window size and co. automatically when modified.
+#    Save window size automatically when modified.
 #    If true, screen size is saved in screen_w and screen_h, and whether the window
 #    is maximized is stored in window_maximized.
 #    (Autosaving window_maximized only works if compiled with SDL.)
-autosave_screensize (Autosave screen size and co.) bool true
+autosave_screensize (Autosave screen size) bool true
 
 #    Fullscreen mode.
 fullscreen (Full screen) bool false

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -136,14 +136,20 @@ virtual_joystick_triggers_aux1 (Virtual joystick triggers Aux1 button) bool fals
 
 [**Screen]
 
-#    Width component of the initial window size. Ignored in fullscreen mode.
+#    Width component of the initial window size.
 screen_w (Screen width) int 1024 1 65535
 
-#    Height component of the initial window size. Ignored in fullscreen mode.
+#    Height component of the initial window size.
 screen_h (Screen height) int 600 1 65535
 
-#    Save window size automatically when modified.
-autosave_screensize (Autosave screen size) bool true
+#    Whether the window is maximized.
+window_maximized (Window maximized) bool false
+
+#    Save window size and co. automatically when modified.
+#    If true, screen size is saved in screen_w and screen_h, and whether the window
+#    is maximized is stored in window_maximized.
+#    (Autosaving window_maximized only works if compiled with SDL.)
+autosave_screensize (Autosave screen size and co.) bool true
 
 #    Fullscreen mode.
 fullscreen (Full screen) bool false

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1193,8 +1193,11 @@ void Game::run()
 			&& client->checkPrivilege("fast");
 #endif
 
-	core::dimension2du previous_screen_size(g_settings->getU16("screen_w"),
-			g_settings->getU16("screen_h"));
+	const irr::core::dimension2du initial_screen_size(
+			g_settings->getU16("screen_w"),
+			g_settings->getU16("screen_h")
+		);
+	const bool initial_window_maximized = g_settings->getBool("window_maximized");
 
 	while (m_rendering_engine->run()
 			&& !(*kill || g_gamecallback->shutdown_requested
@@ -1211,25 +1214,11 @@ void Game::run()
 			dynamic_info_send_timer = 0.2f;
 		}
 
-		if (dynamic_info_send_timer > 0) {
+		if (dynamic_info_send_timer > 0.0f) {
 			dynamic_info_send_timer -= dtime;
-			if (dynamic_info_send_timer <= 0) {
+			if (dynamic_info_send_timer <= 0.0f) {
 				client->sendUpdateClientInfo(current_dynamic_info);
 			}
-		}
-
-		const core::dimension2du &current_screen_size =
-				RenderingEngine::get_video_driver()->getScreenSize();
-
-		// Verify if window size has changed and save it if it's the case
-		// Ensure evaluating settings->getBool after verifying screensize
-		// First condition is cheaper
-		if (previous_screen_size != current_screen_size &&
-				current_screen_size != core::dimension2du(0, 0) &&
-				g_settings->getBool("autosave_screensize")) {
-			g_settings->setU16("screen_w", current_screen_size.Width);
-			g_settings->setU16("screen_h", current_screen_size.Height);
-			previous_screen_size = current_screen_size;
 		}
 
 		// Prepare render data for next iteration
@@ -1285,6 +1274,8 @@ void Game::run()
 			showPauseMenu();
 		}
 	}
+
+	RenderingEngine::autosaveScreensizeAndCo(initial_screen_size, initial_window_maximized);
 }
 
 

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -136,6 +136,10 @@ public:
 	}
 	static std::vector<irr::video::E_DRIVER_TYPE> getSupportedVideoDrivers();
 
+	static void autosaveScreensizeAndCo(
+			const irr::core::dimension2d<u32> initial_screen_size,
+			const bool initial_window_maximized);
+
 private:
 	v2u32 _getWindowSize() const;
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -188,6 +188,7 @@ void set_default_settings()
 	settings->setDefault("client_mesh_chunk", "1");
 	settings->setDefault("screen_w", "1024");
 	settings->setDefault("screen_h", "600");
+	settings->setDefault("window_maximized", "false");
 	settings->setDefault("autosave_screensize", "true");
 	settings->setDefault("fullscreen", "false");
 	settings->setDefault("vsync", "false");

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -249,9 +249,6 @@ void GUIEngine::run()
 
 	unsigned int text_height = g_fontengine->getTextHeight();
 
-	irr::core::dimension2d<u32> previous_screen_size(g_settings->getU16("screen_w"),
-		g_settings->getU16("screen_h"));
-
 	// Reset fog color
 	{
 		video::SColor fog_color;
@@ -268,20 +265,13 @@ void GUIEngine::run()
 				fog_end, fog_density, fog_pixelfog, fog_rangefog);
 	}
 
-	while (m_rendering_engine->run() && (!m_startgame) && (!m_kill)) {
+	const irr::core::dimension2d<u32> initial_screen_size(
+			g_settings->getU16("screen_w"),
+			g_settings->getU16("screen_h")
+		);
+	const bool initial_window_maximized = g_settings->getBool("window_maximized");
 
-		const irr::core::dimension2d<u32> &current_screen_size =
-			m_rendering_engine->get_video_driver()->getScreenSize();
-		// Verify if window size has changed and save it if it's the case
-		// Ensure evaluating settings->getBool after verifying screensize
-		// First condition is cheaper
-		if (previous_screen_size != current_screen_size &&
-				current_screen_size != irr::core::dimension2d<u32>(0,0) &&
-				g_settings->getBool("autosave_screensize")) {
-			g_settings->setU16("screen_w", current_screen_size.Width);
-			g_settings->setU16("screen_h", current_screen_size.Height);
-			previous_screen_size = current_screen_size;
-		}
+	while (m_rendering_engine->run() && (!m_startgame) && (!m_kill)) {
 
 		//check if we need to update the "upper left corner"-text
 		if (text_height != g_fontengine->getTextHeight()) {
@@ -321,6 +311,8 @@ void GUIEngine::run()
 		m_menu->getAndroidUIInput();
 #endif
 	}
+
+	RenderingEngine::autosaveScreensizeAndCo(initial_screen_size, initial_window_maximized);
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Bugfix for SDL, because big centered windows don't work well.

Pure feature for other backends.

~~Requires irrlicht PR: https://github.com/minetest/irrlicht/pull/142~~ Edit: Was merged.

## To do

This PR is a WIP.

## How to test

* Start minetest.
* Maximize window. Or if not SDL, set the setting.
* Restart minetest.
* => It's still maximized.
