### PR TITLE
Add configurable saturation

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -366,6 +366,15 @@ enable_shaders (Shaders) bool true
 #    enhanced, highlights and shadows are gradually compressed.
 tone_mapping (Filmic tone mapping) bool false
 
+#    Adjust the saturation (or vividness) of the scene
+#    Values
+#    < 1.0 decrease saturation
+#    > 1.0 increase saturation
+#    1.0 = unchanged saturation
+#    0.0 = black and white
+#    (Tone mapping needs to be enabled.)
+saturation (Saturation) float 1.0 0.0 5.0
+
 [**Waving Nodes]
 
 #    Set to true to enable waving leaves.

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -5,6 +5,7 @@ uniform sampler2D rendered;
 uniform sampler2D bloom;
 uniform mediump float exposureFactor;
 uniform lowp float bloomIntensity;
+uniform lowp float saturation;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -57,6 +58,14 @@ vec4 applyToneMapping(vec4 color)
 	color.rgb *= whiteScale;
 	return color;
 }
+
+vec3 applySaturation(vec3 color, float factor)
+{
+	// Calculate the perceived luminosity from the RGB color.
+	// See also: https://www.w3.org/WAI/GL/wiki/Relative_luminance
+	float brightness = dot(color, vec3(0.2125, 0.7154, 0.0721));
+       	return mix(vec3(brightness), color, factor);
+}
 #endif
 
 void main(void)
@@ -85,6 +94,7 @@ void main(void)
 	{
 #if ENABLE_TONE_MAPPING
 		color = applyToneMapping(color);
+		color.rgb = applySaturation(color.rgb, saturation);
 #endif
 	}
 

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -64,7 +64,7 @@ vec3 applySaturation(vec3 color, float factor)
 	// Calculate the perceived luminosity from the RGB color.
 	// See also: https://www.w3.org/WAI/GL/wiki/Relative_luminance
 	float brightness = dot(color, vec3(0.2125, 0.7154, 0.0721));
-       	return mix(vec3(brightness), color, factor);
+	return mix(vec3(brightness), color, factor);
 }
 #endif
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -436,6 +436,8 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	float m_bloom_strength;
 	CachedPixelShaderSetting<float> m_bloom_radius_pixel;
 	float m_bloom_radius;
+	float m_saturation;
+	CachedPixelShaderSetting<float> m_saturation_pixel;
 
 public:
 	void onSettingsChange(const std::string &name)
@@ -450,6 +452,8 @@ public:
 			m_bloom_strength = RenderingEngine::BASE_BLOOM_STRENGTH * g_settings->getFloat("bloom_strength_factor", 0.1f, 10.0f);
 		if (name == "bloom_radius")
 			m_bloom_radius = g_settings->getFloat("bloom_radius", 0.1f, 8.0f);
+		if (name == "saturation")
+			m_saturation = g_settings->getFloat("saturation", 0.0f, 5.0f);
 	}
 
 	static void settingsCallback(const std::string &name, void *userdata)
@@ -484,19 +488,22 @@ public:
 		m_exposure_factor_pixel("exposureFactor"),
 		m_bloom_intensity_pixel("bloomIntensity"),
 		m_bloom_strength_pixel("bloomStrength"),
-		m_bloom_radius_pixel("bloomRadius")
+		m_bloom_radius_pixel("bloomRadius"),
+		m_saturation_pixel("saturation")
 	{
 		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
 		g_settings->registerChangedCallback("exposure_factor", settingsCallback, this);
 		g_settings->registerChangedCallback("bloom_intensity", settingsCallback, this);
 		g_settings->registerChangedCallback("bloom_strength_factor", settingsCallback, this);
 		g_settings->registerChangedCallback("bloom_radius", settingsCallback, this);
+		g_settings->registerChangedCallback("saturation", settingsCallback, this);
 		m_fog_enabled = g_settings->getBool("enable_fog");
 		m_user_exposure_factor = g_settings->getFloat("exposure_factor", 0.1f, 10.0f);
 		m_bloom_enabled = g_settings->getBool("enable_bloom");
 		m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.01f, 1.0f);
 		m_bloom_strength = RenderingEngine::BASE_BLOOM_STRENGTH * g_settings->getFloat("bloom_strength_factor", 0.1f, 10.0f);
 		m_bloom_radius = g_settings->getFloat("bloom_radius", 0.1f, 8.0f);
+		m_saturation = g_settings->getFloat("saturation", 0.0f, 5.0f);
 	}
 
 	~GameGlobalShaderConstantSetter()
@@ -584,6 +591,7 @@ public:
 			m_bloom_radius_pixel.set(&m_bloom_radius, services);
 			m_bloom_strength_pixel.set(&m_bloom_strength, services);
 		}
+		m_saturation_pixel.set(&m_saturation, services);
 	}
 
 	void onSetMaterial(const video::SMaterial &material)

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -276,6 +276,7 @@ void set_default_settings()
 	settings->setDefault("bloom_strength_factor", "1.0");
 	settings->setDefault("bloom_intensity", "0.05");
 	settings->setDefault("bloom_radius", "1");
+	settings->setDefault("saturation", "1.0");
 
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");


### PR DESCRIPTION
Co-authored-by: Pevernow <3450354617@qq.com>

Continues: #11854

This adds saturation as post-processing. (The same place where bloom is applied)
To test, start a world and change the saturation with `/set saturation ...`

### TODO
When bloom is server controlled we should make this server controlled in the same way.
Right this is to play around with it.
