### PR TITLE
Fix use of unassigned global "check"

### DIFF
--- a/games/devtest/mods/unittests/init.lua
+++ b/games/devtest/mods/unittests/init.lua
@@ -109,7 +109,7 @@ local function wait_for_player(callback)
 end
 
 local function wait_for_map(player, callback)
-	local check = function()
+	local function check()
 		if core.get_node_or_nil(player:get_pos()) ~= nil then
 			callback()
 		else


### PR DESCRIPTION
This fixes a recursive function reference which before incorrectly referenced a global variable.

## To do

This PR is Ready for Review.

## How to test

Run the unit tests.
