### PR TITLE
[NO SQUASH] Mod storage PostgreSQL backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,9 @@ on:
       - 'Dockerfile'
       - '.dockerignore'
 
+env:
+  MINETEST_POSTGRESQL_CONNECT_STRING: 'host=localhost user=minetest password=minetest dbname=minetest'
+
 jobs:
   # Older gcc version (should be close to our minimum supported version)
   gcc_5:

--- a/games/devtest/mods/unittests/metadata.lua
+++ b/games/devtest/mods/unittests/metadata.lua
@@ -12,7 +12,8 @@ compare_meta:from_table({
 })
 
 local function test_metadata(meta)
-	meta:from_table({fields = {a = 1, b = "2"}})
+	meta:from_table({fields = {a = 2, b = "2"}})
+	meta:set_string("a", 1)
 	meta:set_string("c", "3")
 	meta:set_int("d", 4)
 	meta:set_string("e", "e")

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -276,7 +276,7 @@ void MapDatabasePostgreSQL::loadBlock(const v3s16 &pos, std::string *block)
 		argLen, argFmt, false);
 
 	if (PQntuples(results))
-		block->assign(PQgetvalue(results, 0, 0), PQgetlength(results, 0, 0));
+		*block = pg_to_string(results, 0, 0);
 	else
 		block->clear();
 
@@ -697,8 +697,8 @@ bool AuthDatabasePostgreSQL::getAuth(const std::string &name, AuthEntry &res)
 	}
 
 	res.id = pg_to_uint(result, 0, 0);
-	res.name = std::string(PQgetvalue(result, 0, 1), PQgetlength(result, 0, 1));
-	res.password = std::string(PQgetvalue(result, 0, 2), PQgetlength(result, 0, 2));
+	res.name = pg_to_string(result, 0, 1);
+	res.password = pg_to_string(result, 0, 2);
 	res.last_login = pg_to_int(result, 0, 3);
 
 	PQclear(result);
@@ -878,11 +878,8 @@ bool ModMetadataDatabasePostgreSQL::getModEntries(const std::string &modname, St
 
 	int numrows = PQntuples(results);
 
-	for (int row = 0; row < numrows; ++row) {
-		std::string key(PQgetvalue(results, row, 0), PQgetlength(results, row, 0));
-		std::string value(PQgetvalue(results, row, 1), PQgetlength(results, row, 1));
-		storage->emplace(std::move(key), std::move(value));
-	}
+	for (int row = 0; row < numrows; ++row)
+		(*storage)[pg_to_string(results, row, 0)] = pg_to_string(results, row, 1);
 
 	PQclear(results);
 
@@ -904,7 +901,7 @@ bool ModMetadataDatabasePostgreSQL::getModKeys(const std::string &modname,
 
 	storage->reserve(storage->size() + numrows);
 	for (int row = 0; row < numrows; ++row)
-		storage->emplace_back(PQgetvalue(results, row, 0), PQgetlength(results, row, 0));
+		storage->push_back(pg_to_string(results, row, 0));
 
 	PQclear(results);
 
@@ -925,7 +922,7 @@ bool ModMetadataDatabasePostgreSQL::getModEntry(const std::string &modname,
 	bool found = numrows > 0;
 
 	if (found)
-		value->assign(PQgetvalue(results, 0, 0), PQgetlength(results, 0, 0));
+		*value = pg_to_string(results, 0, 0);
 
 	PQclear(results);
 
@@ -1014,7 +1011,7 @@ void ModMetadataDatabasePostgreSQL::listMods(std::vector<std::string> *res)
 	int numrows = PQntuples(results);
 
 	for (int row = 0; row < numrows; ++row)
-		res->emplace_back(PQgetvalue(results, row, 0), PQgetlength(results, row, 0));
+		res->push_back(pg_to_string(results, row, 0));
 
 	PQclear(results);
 }

--- a/src/database/database-postgresql.h
+++ b/src/database/database-postgresql.h
@@ -169,3 +169,27 @@ protected:
 private:
 	virtual void writePrivileges(const AuthEntry &authEntry);
 };
+
+class ModMetadataDatabasePostgreSQL : private Database_PostgreSQL, public ModMetadataDatabase
+{
+public:
+	ModMetadataDatabasePostgreSQL(const std::string &connect_string);
+	~ModMetadataDatabasePostgreSQL() = default;
+
+	bool getModEntries(const std::string &modname, StringMap *storage);
+	bool getModKeys(const std::string &modname, std::vector<std::string> *storage);
+	bool getModEntry(const std::string &modname, const std::string &key, std::string *value);
+	bool hasModEntry(const std::string &modname, const std::string &key);
+	bool setModEntry(const std::string &modname,
+			const std::string &key, const std::string &value);
+	bool removeModEntry(const std::string &modname, const std::string &key);
+	bool removeModEntries(const std::string &modname);
+	void listMods(std::vector<std::string> *res);
+
+	void beginSave() { Database_PostgreSQL::beginSave(); }
+	void endSave() { Database_PostgreSQL::endSave(); }
+
+protected:
+	virtual void createDatabase();
+	virtual void initStatements();
+};

--- a/src/database/database-postgresql.h
+++ b/src/database/database-postgresql.h
@@ -65,6 +65,11 @@ protected:
 		);
 	}
 
+	inline std::string pg_to_string(PGresult *res, int row, int col)
+	{
+		return std::string(PQgetvalue(res, row, col), PQgetlength(res, row, col));
+	}
+
 	inline PGresult *execPrepared(const char *stmtName, const int paramsNumber,
 		const void **params,
 		const int *paramsLengths = NULL, const int *paramsFormats = NULL,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -67,6 +67,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server/serverinventorymgr.h"
 #include "translation.h"
 #include "database/database-sqlite3.h"
+#if USE_POSTGRESQL
+#include "database/database-postgresql.h"
+#endif
 #include "database/database-files.h"
 #include "database/database-dummy.h"
 #include "gameparams.h"
@@ -4043,6 +4046,14 @@ ModMetadataDatabase *Server::openModStorageDatabase(const std::string &backend,
 {
 	if (backend == "sqlite3")
 		return new ModMetadataDatabaseSQLite3(world_path);
+
+#if USE_POSTGRESQL
+	if (backend == "postgresql") {
+		std::string connect_string;
+		world_mt.getNoEx("pgsql_mod_storage_connection", connect_string);
+		return new ModMetadataDatabasePostgreSQL(connect_string);
+	}
+#endif // USE_POSTGRESQL
 
 	if (backend == "files")
 		return new ModMetadataDatabaseFiles(world_path);

--- a/src/unittest/test_modmetadatadatabase.cpp
+++ b/src/unittest/test_modmetadatadatabase.cpp
@@ -262,6 +262,7 @@ void TestModMetadataDatabase::testListMods()
 {
 	ModMetadataDatabase *mod_meta_db = mod_meta_provider->getModMetadataDatabase();
 	UASSERT(mod_meta_db->setModEntry("mod2", "key1", "value1"));
+	UASSERT(mod_meta_db->setModEntry("mod2", "key2", "value1"));
 	std::vector<std::string> mod_list;
 	mod_meta_db->listMods(&mod_list);
 	UASSERTCMP(size_t, ==, mod_list.size(), 2);

--- a/util/ci/common.sh
+++ b/util/ci/common.sh
@@ -3,7 +3,7 @@
 # Linux build only
 install_linux_deps() {
 	local pkgs=(
-		cmake gettext
+		cmake gettext postgresql
 		libpng-dev libjpeg-dev libxi-dev libgl1-mesa-dev
 		libsqlite3-dev libhiredis-dev libogg-dev libgmp-dev libvorbis-dev
 		libopenal-dev libpq-dev libleveldb-dev libcurl4-openssl-dev libzstd-dev
@@ -19,6 +19,12 @@ install_linux_deps() {
 
 	sudo apt-get update
 	sudo apt-get install -y --no-install-recommends "${pkgs[@]}" "$@"
+
+	sudo systemctl start postgresql.service
+	sudo -u postgres psql <<<"
+		CREATE USER minetest WITH PASSWORD 'minetest';
+		CREATE DATABASE minetest;
+	"
 }
 
 # macOS build only


### PR DESCRIPTION
Closes https://github.com/minetest/minetest/issues/12873. It seems server owners want a PostgreSQL backend. I have implemented `getModKeys` from https://github.com/minetest/minetest/pull/12841 for compatibility with that PR.

## To do

This PR is Ready for Review.

## How to test

Ideally you should test with Postgres versions before and after 9.5.

1. Run the DevTest unit tests.
2. Run the C++ unit tests with `MINETEST_POSTGRESQL_CONNECT_STRING` set appropriately.