### PR TITLE
Add `VoxelArea()` constructor

### DIFF
--- a/builtin/game/voxelarea.lua
+++ b/builtin/game/voxelarea.lua
@@ -8,7 +8,10 @@ VoxelArea = {
 	zstride = 0,
 }
 
-function VoxelArea:new(o)
+local class_metatable = {}
+setmetatable(VoxelArea, class_metatable)
+
+local function new(self, o)
 	o = o or {}
 	setmetatable(o, self)
 	self.__index = self
@@ -19,6 +22,12 @@ function VoxelArea:new(o)
 
 	return o
 end
+
+function class_metatable:__call(MinEdge, MaxEdge)
+	return new(self, {MinEdge = MinEdge, MaxEdge = MaxEdge})
+end
+
+VoxelArea.new = new
 
 function VoxelArea:getExtent()
 	local MaxEdge, MinEdge = self.MaxEdge, self.MinEdge

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4485,7 +4485,8 @@ Methods
 -----------
 
 A helper class for voxel areas.
-It can be created via `VoxelArea:new({MinEdge = pmin, MaxEdge = pmax})`.
+It can be created via `VoxelArea(pmin, pmax)` or
+`VoxelArea:new({MinEdge = pmin, MaxEdge = pmax})`.
 The coordinates are *inclusive*, like most other things in Minetest.
 
 ### Methods
@@ -4533,7 +4534,7 @@ the axes in a voxel area:
 
 If, for example:
 
-    local area = VoxelArea:new({MinEdge = emin, MaxEdge = emax})
+    local area = VoxelArea(emin, emax)
 
 The values of `ystride` and `zstride` can be obtained using `area.ystride` and
 `area.zstride`.


### PR DESCRIPTION
VoxelArea objects can now be created with `VoxelArea(MinEdge, MaxEdge)`. This VoxelArea constructor format is more consistent with VoxelManip. It also lets you create an area like so:

```lua
local area = VoxelArea(vm:get_emerged_area())
```

## To do

This PR is Ready for Review.

## How to test

You can use this command:

```lua
minetest.register_chatcommand("voxelarea_constructor", {
	func = function(name, param)
		local player = minetest.get_player_by_name(name)
		local pos = player and player:get_pos()
		if not pos then return false, "No player" end
		local vm = VoxelManip(pos, pos)
		local va = VoxelArea(vm:get_emerged_area())
		return true, tostring(va.MinEdge) .. "\t" .. tostring(va.MaxEdge) .. "\t" .. va:getVolume()
	end,
})
```

You can also test mods that use the old constructor to make sure they still work.