### PR TITLE
refacto(Server): more intelligent packet handler

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -744,18 +744,6 @@ RemoteClient* ClientInterface::lockedGetClientNoEx(session_t peer_id, ClientStat
 	return NULL;
 }
 
-ClientState ClientInterface::getClientState(session_t peer_id)
-{
-	RecursiveMutexAutoLock clientslock(m_clients_mutex);
-	RemoteClientMap::const_iterator n = m_clients.find(peer_id);
-	// The client may not exist; clients are immediately removed if their
-	// access is denied, and this event occurs later then.
-	if (n == m_clients.end())
-		return CS_Invalid;
-
-	return n->second->getState();
-}
-
 void ClientInterface::setPlayerName(session_t peer_id, const std::string &name)
 {
 	RecursiveMutexAutoLock clientslock(m_clients_mutex);

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -481,9 +481,6 @@ public:
 	/* get client by peer_id (make sure you have list lock before!*/
 	RemoteClient *lockedGetClientNoEx(session_t peer_id,  ClientState state_min = CS_Active);
 
-	/* get state of client by id*/
-	ClientState getClientState(session_t peer_id);
-
 	/* set client playername */
 	void setPlayerName(session_t peer_id, const std::string &name);
 

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -20,13 +20,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "serveropcodes.h"
 
-const static ToServerCommandHandler null_command_handler = { "TOSERVER_NULL", TOSERVER_STATE_ALL, &Server::handleCommand_Null };
+const static ToServerCommandHandler null_command_handler = { "TOSERVER_NULL", TOSERVER_STATE_ALL, &Server::handleCommand_Null, CS_Invalid };
 
 const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 {
 	null_command_handler, // 0x00 (never use this)
 	null_command_handler, // 0x01
-	{ "TOSERVER_INIT",                     TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_Init }, // 0x02
+	{ "TOSERVER_INIT",                     TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_Init, CS_Created }, // 0x02
 	null_command_handler, // 0x03
 	null_command_handler, // 0x04
 	null_command_handler, // 0x05
@@ -41,15 +41,15 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_handler, // 0x0e
 	null_command_handler, // 0x0f
 	null_command_handler, // 0x10
-	{ "TOSERVER_INIT2",                    TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_Init2 }, // 0x11
+	{ "TOSERVER_INIT2",                    TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_Init2, CS_Created }, // 0x11
 	null_command_handler, // 0x12
 	null_command_handler, // 0x13
 	null_command_handler, // 0x14
 	null_command_handler, // 0x15
 	null_command_handler, // 0x16
-	{ "TOSERVER_MODCHANNEL_JOIN",          TOSERVER_STATE_INGAME, &Server::handleCommand_ModChannelJoin }, // 0x17
-	{ "TOSERVER_MODCHANNEL_LEAVE",         TOSERVER_STATE_INGAME, &Server::handleCommand_ModChannelLeave }, // 0x18
-	{ "TOSERVER_MODCHANNEL_MSG",           TOSERVER_STATE_INGAME, &Server::handleCommand_ModChannelMsg }, // 0x19
+	{ "TOSERVER_MODCHANNEL_JOIN",          TOSERVER_STATE_INGAME, &Server::handleCommand_ModChannelJoin, CS_Active }, // 0x17
+	{ "TOSERVER_MODCHANNEL_LEAVE",         TOSERVER_STATE_INGAME, &Server::handleCommand_ModChannelLeave, CS_Active }, // 0x18
+	{ "TOSERVER_MODCHANNEL_MSG",           TOSERVER_STATE_INGAME, &Server::handleCommand_ModChannelMsg, CS_Active }, // 0x19
 	null_command_handler, // 0x1a
 	null_command_handler, // 0x1b
 	null_command_handler, // 0x1c
@@ -59,9 +59,9 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_handler, // 0x20
 	null_command_handler, // 0x21
 	null_command_handler, // 0x22
-	{ "TOSERVER_PLAYERPOS",                TOSERVER_STATE_INGAME, &Server::handleCommand_PlayerPos }, // 0x23
-	{ "TOSERVER_GOTBLOCKS",                TOSERVER_STATE_STARTUP, &Server::handleCommand_GotBlocks }, // 0x24
-	{ "TOSERVER_DELETEDBLOCKS",            TOSERVER_STATE_INGAME, &Server::handleCommand_DeletedBlocks }, // 0x25
+	{ "TOSERVER_PLAYERPOS",                TOSERVER_STATE_INGAME, &Server::handleCommand_PlayerPos, CS_Active }, // 0x23
+	{ "TOSERVER_GOTBLOCKS",                TOSERVER_STATE_STARTUP, &Server::handleCommand_GotBlocks, CS_Active }, // 0x24
+	{ "TOSERVER_DELETEDBLOCKS",            TOSERVER_STATE_INGAME, &Server::handleCommand_DeletedBlocks, CS_Active }, // 0x25
 	null_command_handler, // 0x26
 	null_command_handler, // 0x27
 	null_command_handler, // 0x28
@@ -73,25 +73,25 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_handler, // 0x2e
 	null_command_handler, // 0x2f
 	null_command_handler, // 0x30
-	{ "TOSERVER_INVENTORY_ACTION",         TOSERVER_STATE_INGAME, &Server::handleCommand_InventoryAction }, // 0x31
-	{ "TOSERVER_CHAT_MESSAGE",             TOSERVER_STATE_INGAME, &Server::handleCommand_ChatMessage }, // 0x32
+	{ "TOSERVER_INVENTORY_ACTION",         TOSERVER_STATE_INGAME, &Server::handleCommand_InventoryAction, CS_Active }, // 0x31
+	{ "TOSERVER_CHAT_MESSAGE",             TOSERVER_STATE_INGAME, &Server::handleCommand_ChatMessage, CS_Active }, // 0x32
 	null_command_handler, // 0x33
 	null_command_handler, // 0x34
-	{ "TOSERVER_DAMAGE",                   TOSERVER_STATE_INGAME, &Server::handleCommand_Damage }, // 0x35
+	{ "TOSERVER_DAMAGE",                   TOSERVER_STATE_INGAME, &Server::handleCommand_Damage, CS_Active }, // 0x35
 	null_command_handler, // 0x36
-	{ "TOSERVER_PLAYERITEM",               TOSERVER_STATE_INGAME, &Server::handleCommand_PlayerItem }, // 0x37
-	{ "TOSERVER_RESPAWN",                  TOSERVER_STATE_INGAME, &Server::handleCommand_Respawn }, // 0x38
-	{ "TOSERVER_INTERACT",                 TOSERVER_STATE_INGAME, &Server::handleCommand_Interact }, // 0x39
-	{ "TOSERVER_REMOVED_SOUNDS",           TOSERVER_STATE_INGAME, &Server::handleCommand_RemovedSounds }, // 0x3a
-	{ "TOSERVER_NODEMETA_FIELDS",          TOSERVER_STATE_INGAME, &Server::handleCommand_NodeMetaFields }, // 0x3b
-	{ "TOSERVER_INVENTORY_FIELDS",         TOSERVER_STATE_INGAME, &Server::handleCommand_InventoryFields }, // 0x3c
+	{ "TOSERVER_PLAYERITEM",               TOSERVER_STATE_INGAME, &Server::handleCommand_PlayerItem, CS_Active }, // 0x37
+	{ "TOSERVER_RESPAWN",                  TOSERVER_STATE_INGAME, &Server::handleCommand_Respawn, CS_Active }, // 0x38
+	{ "TOSERVER_INTERACT",                 TOSERVER_STATE_INGAME, &Server::handleCommand_Interact, CS_Active }, // 0x39
+	{ "TOSERVER_REMOVED_SOUNDS",           TOSERVER_STATE_INGAME, &Server::handleCommand_RemovedSounds, CS_Active }, // 0x3a
+	{ "TOSERVER_NODEMETA_FIELDS",          TOSERVER_STATE_INGAME, &Server::handleCommand_NodeMetaFields, CS_Active }, // 0x3b
+	{ "TOSERVER_INVENTORY_FIELDS",         TOSERVER_STATE_INGAME, &Server::handleCommand_InventoryFields, CS_Active }, // 0x3c
 	null_command_handler, // 0x3d
 	null_command_handler, // 0x3e
 	null_command_handler, // 0x3f
-	{ "TOSERVER_REQUEST_MEDIA",            TOSERVER_STATE_STARTUP, &Server::handleCommand_RequestMedia }, // 0x40
-	{ "TOSERVER_HAVE_MEDIA",               TOSERVER_STATE_INGAME, &Server::handleCommand_HaveMedia }, // 0x41
+	{ "TOSERVER_REQUEST_MEDIA",            TOSERVER_STATE_STARTUP, &Server::handleCommand_RequestMedia, CS_Created }, // 0x40
+	{ "TOSERVER_HAVE_MEDIA",               TOSERVER_STATE_INGAME, &Server::handleCommand_HaveMedia, CS_Active }, // 0x41
 	null_command_handler, // 0x42
-	{ "TOSERVER_CLIENT_READY",             TOSERVER_STATE_STARTUP, &Server::handleCommand_ClientReady }, // 0x43
+	{ "TOSERVER_CLIENT_READY",             TOSERVER_STATE_STARTUP, &Server::handleCommand_ClientReady, CS_DefinitionsSent }, // 0x43
 	null_command_handler, // 0x44
 	null_command_handler, // 0x45
 	null_command_handler, // 0x46
@@ -104,9 +104,9 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_handler, // 0x4d
 	null_command_handler, // 0x4e
 	null_command_handler, // 0x4f
-	{ "TOSERVER_FIRST_SRP",                TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_FirstSrp }, // 0x50
-	{ "TOSERVER_SRP_BYTES_A",              TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_SrpBytesA }, // 0x51
-	{ "TOSERVER_SRP_BYTES_M",              TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_SrpBytesM }, // 0x52
+	{ "TOSERVER_FIRST_SRP",                TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_FirstSrp, CS_HelloSent }, // 0x50
+	{ "TOSERVER_SRP_BYTES_A",              TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_SrpBytesA, CS_HelloSent }, // 0x51
+	{ "TOSERVER_SRP_BYTES_M",              TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_SrpBytesM, CS_HelloSent }, // 0x52
 };
 
 const static ClientCommandFactory null_command_factory = { "TOCLIENT_NULL", 0, false };

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -35,7 +35,8 @@ struct ToServerCommandHandler
 {
     const std::string name;
     ToServerConnectionState state;
-    void (Server::*handler)(NetworkPacket* pkt);
+    void (Server::*handler)(NetworkPacket* pkt, RemoteClient *client);
+	ClientState min_client_state = CS_Invalid;
 };
 
 struct ClientCommandFactory

--- a/src/server.h
+++ b/src/server.h
@@ -168,33 +168,33 @@ public:
 	 * Command Handlers
 	 */
 
-	void handleCommand(NetworkPacket* pkt);
+	void handleCommand(NetworkPacket* pkt, RemoteClient *client);
 
-	void handleCommand_Null(NetworkPacket* pkt) {};
-	void handleCommand_Deprecated(NetworkPacket* pkt);
-	void handleCommand_Init(NetworkPacket* pkt);
-	void handleCommand_Init2(NetworkPacket* pkt);
-	void handleCommand_ModChannelJoin(NetworkPacket *pkt);
-	void handleCommand_ModChannelLeave(NetworkPacket *pkt);
-	void handleCommand_ModChannelMsg(NetworkPacket *pkt);
-	void handleCommand_RequestMedia(NetworkPacket* pkt);
-	void handleCommand_ClientReady(NetworkPacket* pkt);
-	void handleCommand_GotBlocks(NetworkPacket* pkt);
-	void handleCommand_PlayerPos(NetworkPacket* pkt);
-	void handleCommand_DeletedBlocks(NetworkPacket* pkt);
-	void handleCommand_InventoryAction(NetworkPacket* pkt);
-	void handleCommand_ChatMessage(NetworkPacket* pkt);
-	void handleCommand_Damage(NetworkPacket* pkt);
-	void handleCommand_PlayerItem(NetworkPacket* pkt);
-	void handleCommand_Respawn(NetworkPacket* pkt);
-	void handleCommand_Interact(NetworkPacket* pkt);
-	void handleCommand_RemovedSounds(NetworkPacket* pkt);
-	void handleCommand_NodeMetaFields(NetworkPacket* pkt);
-	void handleCommand_InventoryFields(NetworkPacket* pkt);
-	void handleCommand_FirstSrp(NetworkPacket* pkt);
-	void handleCommand_SrpBytesA(NetworkPacket* pkt);
-	void handleCommand_SrpBytesM(NetworkPacket* pkt);
-	void handleCommand_HaveMedia(NetworkPacket *pkt);
+	void handleCommand_Null(NetworkPacket* pkt, RemoteClient *client) {};
+	void handleCommand_Deprecated(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_Init(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_Init2(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_ModChannelJoin(NetworkPacket *pkt, RemoteClient *client);
+	void handleCommand_ModChannelLeave(NetworkPacket *pkt, RemoteClient *client);
+	void handleCommand_ModChannelMsg(NetworkPacket *pkt, RemoteClient *client);
+	void handleCommand_RequestMedia(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_ClientReady(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_GotBlocks(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_PlayerPos(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_DeletedBlocks(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_InventoryAction(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_ChatMessage(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_Damage(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_PlayerItem(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_Respawn(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_Interact(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_RemovedSounds(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_NodeMetaFields(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_InventoryFields(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_FirstSrp(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_SrpBytesA(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_SrpBytesM(NetworkPacket* pkt, RemoteClient *client);
+	void handleCommand_HaveMedia(NetworkPacket *pkt, RemoteClient *client);
 
 	void ProcessData(NetworkPacket *pkt);
 


### PR DESCRIPTION
Server packet handler now have the RemoteClient as a parameter and handlers have a minimum session state prerequisite.

Why this change ? Nearly all packets are re-lookuping the RemoteClient (based on session state, we keep that), then just send the parameter to all handlers and use it. It also prevent a lock on the session to perform the lookup, which is now unnecessary as we have the session to handle.

Also we don't check the session state in majority of cases, or it's implicit because of the getClient call, but getClient returns nullptr is session is not in right state whereas an existing peer_id may be valid. It's a pretty illogical way to handle the getter as it can lead to coding errors (rare, we do in majority things in CS_Active state) and it hides wrong things sent by clients (maybe rogues), or catch them up very late in the code path.

Drop ClientInterface::getClientState, it's not needed anymore, it was a very low used helper, now we have the client we can directly check it

For the performance optimization it should be a bit low, except when you have hundreds of client sending thousands of commands (that reduce the locking to zero), then a very rare case. For the code usage security it's clearly higher than before as now you need to set the required state for packets.

drop single used getClientNoEx and properly catch & log ClientNotFoundException

## To do

This PR is  Ready for Review.

## How to test

<!-- Example code or instructions -->
Build and test with multiple clients
