### PR TITLE
Fix some outdated stuff about falling node docs

### DIFF
--- a/doc/builtin_entities.txt
+++ b/doc/builtin_entities.txt
@@ -16,9 +16,11 @@ Default behavior:
 * Collides with `walkable` node
 * Collides with all physical objects except players
 * If the node group `float=1` is set, it also collides with liquid nodes
+  (nodes with `liquidtype ~= "none"`)
 * When it hits a solid (=`walkable`) node, it will try to place itself as a
   node, replacing the node above.
-    * If the falling node cannot replace the destination node, it is dropped.
+    * If the falling node cannot replace the destination node, it is dropped
+      as an item.
     * If the destination node is a leveled node (`paramtype2="leveled"`) of the
       same node name, the levels of both are summed.
 
@@ -57,13 +59,18 @@ Supported drawtypes:
 * `airlike` (not pointable)
 
 Other drawtypes still kinda work, but they might look weird.
+If the node uses a world-aligned texture with a `scale` greater
+than 1, the falling node will display the top-most, left-most
+portion of that texture.
 
 Supported `paramtype2` values:
 
 * `wallmounted`
 * `facedir`
+* `4dir`
 * `colorwallmounted`
 * `colorfacedir`
+* `color4dir`
 * `color`
 
 ## Dropped item stack (`__builtin:item`)


### PR DESCRIPTION
I updated the documentation of falling nodes a little.

* `4dir` and `color4dir` paramtype2 is now officially supported (I forgot to add this initially)
* Clarify some other stuff about the behavior of falling nodes