### PR TITLE
Add meta:get_bool and :set_bool

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6861,6 +6861,8 @@ and [`PlayerMetaRef`].
 * `get_int(key)`: Returns `0` if key not present.
 * `set_float(key, value)`
 * `get_float(key)`: Returns `0` if key not present.
+* `set_bool(key, value)`
+* `get_bool(key)`: Returns `false` if key not present.
 * `to_table()`: returns `nil` or a table with keys:
     * `fields`: key-value storage
     * `inventory`: `{list1 = {}, ...}}` (NodeMetaRef only)

--- a/games/devtest/mods/unittests/metadata.lua
+++ b/games/devtest/mods/unittests/metadata.lua
@@ -54,6 +54,16 @@ local function test_metadata(meta)
 	assert(meta:get_float("h") > 1)
 	assert(meta:get_string("i") == "${f}")
 
+	assert(meta:get_bool("") == false)
+	meta:set_bool("j", true)
+	assert(meta:get_bool("j") == true)
+	meta:set_bool("j", false)
+	assert(meta:get_bool("j") == false)
+	meta:set_string("j", "yes")
+	assert(meta:get_bool("j") == true)
+	meta:set_string("j", "no")
+	assert(meta:get_bool("j") == false)
+
 	meta:from_table()
 	assert(next(meta:to_table().fields) == nil)
 

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -97,6 +97,8 @@ const luaL_Reg ItemStackMetaRef::methods[] = {
 	luamethod(MetaDataRef, set_int),
 	luamethod(MetaDataRef, get_float),
 	luamethod(MetaDataRef, set_float),
+	luamethod(MetaDataRef, get_bool),
+	luamethod(MetaDataRef, set_bool),
 	luamethod(MetaDataRef, to_table),
 	luamethod(MetaDataRef, from_table),
 	luamethod(MetaDataRef, equals),

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -196,6 +196,42 @@ int MetaDataRef::l_set_float(lua_State *L)
 	return 0;
 }
 
+// get_bool(self, name)
+int MetaDataRef::l_get_bool(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
+	std::string name = luaL_checkstring(L, 2);
+
+	IMetadata *meta = ref->getmeta(false);
+	if (meta == NULL) {
+		lua_pushboolean(L, false);
+		return 1;
+	}
+
+	std::string str_;
+	const std::string &str = meta->getString(name, &str_);
+	lua_pushboolean(L, is_yes(str));
+	return 1;
+}
+
+// set_bool(self, name, var)
+int MetaDataRef::l_set_bool(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	MetaDataRef *ref = checkAnyMetadata(L, 1);
+	std::string name = luaL_checkstring(L, 2);
+	int a = lua_toboolean(L, 3);
+	std::string str = a ? "true" : "false";
+
+	IMetadata *meta = ref->getmeta(true);
+	if (meta != NULL && meta->setString(name, str))
+		ref->reportMetadataChange(&name);
+	return 0;
+}
+
 // to_table(self)
 int MetaDataRef::l_to_table(lua_State *L)
 {

--- a/src/script/lua_api/l_metadata.h
+++ b/src/script/lua_api/l_metadata.h
@@ -74,6 +74,12 @@ protected:
 	// set_float(self, name, var)
 	static int l_set_float(lua_State *L);
 
+	// get_bool(self, name)
+	static int l_get_bool(lua_State *L);
+
+	// set_bool(self, name, var)
+	static int l_set_bool(lua_State *L);
+
 	// to_table(self)
 	static int l_to_table(lua_State *L);
 

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -209,6 +209,8 @@ const luaL_Reg NodeMetaRef::methodsServer[] = {
 	luamethod(MetaDataRef, set_int),
 	luamethod(MetaDataRef, get_float),
 	luamethod(MetaDataRef, set_float),
+	luamethod(MetaDataRef, get_bool),
+	luamethod(MetaDataRef, set_bool),
 	luamethod(MetaDataRef, to_table),
 	luamethod(MetaDataRef, from_table),
 	luamethod(NodeMetaRef, get_inventory),
@@ -230,6 +232,7 @@ const luaL_Reg NodeMetaRef::methodsClient[] = {
 	luamethod(MetaDataRef, get_string),
 	luamethod(MetaDataRef, get_int),
 	luamethod(MetaDataRef, get_float),
+	luamethod(MetaDataRef, get_bool),
 	luamethod(MetaDataRef, to_table),
 	{0,0}
 };

--- a/src/script/lua_api/l_playermeta.cpp
+++ b/src/script/lua_api/l_playermeta.cpp
@@ -70,6 +70,8 @@ const luaL_Reg PlayerMetaRef::methods[] = {
 	luamethod(MetaDataRef, set_int),
 	luamethod(MetaDataRef, get_float),
 	luamethod(MetaDataRef, set_float),
+	luamethod(MetaDataRef, get_bool),
+	luamethod(MetaDataRef, set_bool),
 	luamethod(MetaDataRef, to_table),
 	luamethod(MetaDataRef, from_table),
 	luamethod(MetaDataRef, equals),

--- a/src/script/lua_api/l_storage.cpp
+++ b/src/script/lua_api/l_storage.cpp
@@ -74,6 +74,8 @@ const luaL_Reg StorageRef::methods[] = {
 	luamethod(MetaDataRef, set_int),
 	luamethod(MetaDataRef, get_float),
 	luamethod(MetaDataRef, set_float),
+	luamethod(MetaDataRef, get_bool),
+	luamethod(MetaDataRef, set_bool),
 	luamethod(MetaDataRef, to_table),
 	luamethod(MetaDataRef, from_table),
 	luamethod(MetaDataRef, equals),


### PR DESCRIPTION
This PR adds the missing `get_bool` and `set_bool` to the series of `meta:get_*`/`meta:set_*` functions.
The implementation mirrors the others.
I did not open a ticket for this, but I don't think there's much to discuss, and it's fine if this gets rejected.

## To do

This PR is Ready for Review.

## How to test

```lua
minetest.register_tool(":get_set_bool_test", {
  on_place = function(itemstack, player, pointed_thing)
    itemstack:get_meta():set_bool("mybool", true)
    return itemstack
  end,
  on_secondary_use = function(itemstack, player, pointed_thing)
    itemstack:get_meta():set_bool("mybool", false)
    return itemstack
  end,
  on_use = function(itemstack, player, pointed_thing)
    minetest.chat_send_player(player:get_player_name(),
      "Previously right clicked on node: " ..
      tostring(itemstack:get_meta():get_bool("mybool"))
    )
  end,
})
```
