### PR TITLE
Safety check the map's blocksize

### DIFF
--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -390,6 +390,8 @@ void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 		conf.set("mod_storage_backend", "sqlite3");
 		conf.setBool("creative_mode", g_settings->getBool("creative_mode"));
 		conf.setBool("enable_damage", g_settings->getBool("enable_damage"));
+		if (MAP_BLOCKSIZE != 16)
+			conf.set("blocksize", std::to_string(MAP_BLOCKSIZE));
 
 		if (!conf.updateConfigFile(worldmt_path.c_str())) {
 			throw BaseException("Failed to update the config file");

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -420,6 +420,13 @@ void ServerEnvironment::init()
 
 	// If we open world.mt read the backend configurations.
 	if (succeeded) {
+		// Check that the world's blocksize matches the compiled MAP_BLOCKSIZE
+		u16 blocksize = 16;
+		conf.getU16NoEx("blocksize", blocksize);
+		if (blocksize != MAP_BLOCKSIZE) {
+			throw BaseException(std::string("The map's blocksize is not supported."));
+		}
+
 		// Read those values before setting defaults
 		bool player_backend_exists = conf.exists("player_backend");
 		bool auth_backend_exists = conf.exists("auth_backend");


### PR DESCRIPTION
Low priority: Most folks won't need this. However, for those like me who have MT compiled with a different MAP_BLOCKSIZE for performance would benefit from a safety check.

If you never change MAP_BLOCKSIZE from it's default of 16 nothing changes.
Otherwise the blocksize is written into world.mt and checked when the server opens the map.

I corrupted a few world with that by accident and a safety check does not hurt.

To test, compile MT with a different MAP_BLOCKSIZE. Then (1) attempt to open an existing world, should fail, (2) create a world, then with default MAP_BLOCKSIZE again, attempt to open that world.

Note: I considered map_meta.txt, but this did not fit nicely with the way inheritance and defaults are handled.
