### PR TITLE
GUIInventoryList: Keep item size while moving

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3515,10 +3515,10 @@ GUIInventoryList::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 		s32 item_index = e->getItemIndexAtPos(p);
 		if (item_index != -1)
 			return GUIInventoryList::ItemSpec(e->getInventoryloc(), e->getListname(),
-					item_index);
+					item_index, e->getSlotSize());
 	}
 
-	return GUIInventoryList::ItemSpec(InventoryLocation(), "", -1);
+	return GUIInventoryList::ItemSpec(InventoryLocation(), "", -1, {0,0});
 }
 
 void GUIFormSpecMenu::drawSelectedItem()
@@ -3540,7 +3540,8 @@ void GUIFormSpecMenu::drawSelectedItem()
 	ItemStack stack = list->getItem(m_selected_item->i);
 	stack.count = m_selected_amount;
 
-	core::rect<s32> imgrect(0,0,imgsize.X,imgsize.Y);
+	v2s32 slotsize = m_selected_item->slotsize;
+	core::rect<s32> imgrect(0, 0, slotsize.X, slotsize.Y);
 	core::rect<s32> rect = imgrect + (m_pointer - imgrect.getCenter());
 	rect.constrainTo(driver->getViewPort());
 	drawItemStack(driver, m_font, stack, rect, NULL, m_client, IT_ROT_DRAGGED);
@@ -3791,6 +3792,7 @@ void GUIFormSpecMenu::updateSelectedItem()
 			m_selected_item->inventoryloc = e->getInventoryloc();
 			m_selected_item->listname = "craftresult";
 			m_selected_item->i = 0;
+			m_selected_item->slotsize = e->getSlotSize();
 			m_selected_amount = item.count;
 			m_selected_dragging = false;
 			break;

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -34,10 +34,12 @@ public:
 
 		ItemSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				s32 a_i) :
+				s32 a_i,
+				const v2s32 slotsize) :
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
-			i(a_i)
+			i(a_i),
+			slotsize(slotsize)
 		{
 		}
 
@@ -46,6 +48,7 @@ public:
 		InventoryLocation inventoryloc;
 		std::string listname;
 		s32 i = -1;
+		v2s32 slotsize;
 	};
 
 	// options for inventorylists that are setable with the lua api
@@ -97,6 +100,11 @@ public:
 	{
 		m_options.slotborder = slotborder;
 		m_options.slotbordercolor = slotbordercolor;
+	}
+
+	const v2s32 getSlotSize() const noexcept
+	{
+		return m_slot_size;
 	}
 
 	// returns -1 if not item is at pos p


### PR DESCRIPTION
Currently, the engine weirdly assumes that the slot of destination is likely of size `1,1`.

This patch makes the sizes of moving items inheriting from their sizes in their slots of origin.

In practice, this patch looks like this: 

![ezgif-1-c63094566a](https://user-images.githubusercontent.com/7883281/197427051-84f81473-18a8-47b8-af69-ae553f3ba86a.gif)

Instead of (in upstream):

![ezgif-1-3ddfb045f4](https://user-images.githubusercontent.com/7883281/197427420-6e378e88-5e91-4446-8fc9-dcccc342efa9.gif)
