### PR TITLE
Set window caption to subgame name

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1470,9 +1470,14 @@ bool Game::createClient(const GameStartData &start_data)
 
 	/* Set window caption
 	 */
-	std::wstring str = utf8_to_wide(PROJECT_NAME_C);
-	str += L" ";
-	str += utf8_to_wide(g_version_hash);
+	// set caption to subgame name in singleplayer mode
+	std::wstring str = utf8_to_wide(start_data.game_spec.title);
+	if (!simple_singleplayer_mode)
+	{
+		str = utf8_to_wide(PROJECT_NAME_C);
+		str += L" ";
+		str += utf8_to_wide(g_version_hash);
+	}
 	{
 		const wchar_t *text = nullptr;
 		if (simple_singleplayer_mode)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1470,14 +1470,21 @@ bool Game::createClient(const GameStartData &start_data)
 
 	/* Set window caption
 	 */
-	// set caption to subgame name in singleplayer mode
-	std::wstring str = utf8_to_wide(start_data.game_spec.title);
-	if (!simple_singleplayer_mode)
+	std::wstring str;
+	
+	if (simple_singleplayer_mode && !start_data.game_spec.title.empty())
 	{
+		// set caption to game title in singleplayer mode
+		str = utf8_to_wide(start_data.game_spec.title);
+	}
+	else
+	{
+		// set caption to project name in multiplayer mode
 		str = utf8_to_wide(PROJECT_NAME_C);
 		str += L" ";
 		str += utf8_to_wide(g_version_hash);
 	}
+	
 	{
 		const wchar_t *text = nullptr;
 		if (simple_singleplayer_mode)


### PR DESCRIPTION
- The title of the window should be the name of the game and not the name of the engine since you are playing a game and not an engine.
- I didn't open an issue because it didn't take much effort to change this. I think it can be discussed here...

## To do

Ready for Review.

- [ ] (Maybe put the caption on the server game name too, how could that be done? Or just display "Minetest Client"?)

## How to test

- Start worlds in different games, check that the caption shows the game title.
- Join servers, the caption should still be the name of the engine + version.