### PR TITLE
Enable negative values for sun/moon orbit tilt (Northern hemisphere)

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -447,7 +447,7 @@ shadow_soft_radius (Soft shadow radius) float 5.0 1.0 15.0
 #    Set the tilt of Sun/Moon orbit in degrees.
 #    Value of 0 means no tilt / vertical orbit.
 #    Minimum value: 0.0; maximum value: 60.0
-shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 0.0 60.0
+shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 -60.0 60.0
 
 [**Post processing]
 

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -103,10 +103,8 @@ Sky::Sky(s32 id, RenderingEngine *rendering_engine, ITextureSource *tsrc, IShade
 
 	m_directional_colored_fog = g_settings->getBool("directional_colored_fog");
 
-	if (g_settings->getBool("enable_dynamic_shadows")) {
-		float val = g_settings->getFloat("shadow_sky_body_orbit_tilt");
-		m_sky_body_orbit_tilt = rangelim(val, 0.0f, 60.0f);
-	}
+	if (g_settings->getBool("enable_dynamic_shadows"))
+		m_sky_body_orbit_tilt = g_settings->getFloat("shadow_sky_body_orbit_tilt", -60.0f, 60.0f);
 
 	setStarCount(1000);
 }


### PR DESCRIPTION
Fixes #12893

## To do

This PR is Ready for Review.

## How to test

1. Set `sky_body_orbit_tilt = 45`
2. Start world, set `/time 8000`
3. Face east, see the Sun on the left (North-East)
4. Set `sky_body_orbit_tilt = -45`
5. Strt world, set `/time 8000`
6. Face East, see the Sun on the right (South-East)
