### PR TITLE
Fix entity visiblity in bright artificial light (shaders=off)

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -883,10 +883,14 @@ void GenericCAO::updateLight(u32 day_night_ratio)
 	if (!pos_ok)
 		light_at_pos = LIGHT_SUN;
 
+	// Initialize with full alpha, otherwise entity won't be visible
+	video::SColor light{0xFFFFFFFF};
+
 	// Encode light into color, adding a small boost
 	// based on the entity glow.
-	video::SColor light = encode_light(light_at_pos, m_prop.glow);
-	if (!m_enable_shaders)
+	if (m_enable_shaders)
+		light = encode_light(light_at_pos, m_prop.glow);
+	else
 		final_color_blend(&light, light_at_pos, day_night_ratio);
 
 	if (light != m_last_light) {


### PR DESCRIPTION
Fix #12853.

Root cause is that encode_light stores balance between DAY and NIGHT banks for the containing node, and final_color_blend does not override the color alpha. As a result, entities in full artificial light get alpha == 0 and disappear due to material type being EMT_TRANSPARENT_ALPHA_CHANNEL_REF. 

## To do

This PR is Ready for Review.

## How to test

0. With shaders disabled
1. In devtest place a testentities:sprite or testentities:upright_sprite.
2. /time 0
3. Place lightsource near the entity
4. Entity becomes bright but does not disappear.
5. Repeat steps 1-4 with shaders enabled.