### PR TITLE
Add paramtype2 colorflowingliquid

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -27,6 +27,7 @@ core.features = {
 	get_light_data_buffer = true,
 	mod_storage_on_disk = true,
 	compress_zstd = true,
+	preserve_liquid_param2 = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -623,6 +623,7 @@ core.nodedef_default = {
 	tiles = nil,
 	special_tiles = nil,
 	post_effect_color = {a=0, r=0, g=0, b=0},
+	post_effect_use_node_color = false,
 	paramtype = "none",
 	paramtype2 = "none",
 	is_ground_content = true,

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -151,7 +151,8 @@ function core.register_item(name, itemdef)
 	end
 
 	-- Flowing liquid uses param2
-	if itemdef.type == "node" and itemdef.liquidtype == "flowing" then
+	if itemdef.type == "node" and itemdef.liquidtype == "flowing" and
+			itemdef.paramtype2 ~= "colorflowingliquid" then
 		itemdef.paramtype2 = "flowingliquid"
 	end
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1168,6 +1168,10 @@ The function of `param2` is determined by `paramtype2` in node definition.
     * The first (most-significant) three bits of `param2` tells which color
       is picked from the palette. The palette should have 8 pixels.
     * Remaining 5 bits store rotation in range 0–23 (i.e. in 15° steps)
+* `paramtype2 = "colorflowingliquid"`
+    * Same as `flowingliquid`, but with colors.
+    * The upper four bits of `param2` tell which color is picked from the
+      palette. The palette should have 16 pixels.
 * `paramtype2 = "none"`
     * `param2` will not be used by the engine and can be used to store
       an arbitrary value
@@ -4934,6 +4938,9 @@ Utilities
           mod_storage_on_disk = true,
           -- "zstd" method for compress/decompress (5.7.0)
           compress_zstd = true,
+          -- The upper four bits of liquid node param2 values are preserved
+          -- during liquid flow (5.7.0)
+          preserve_liquid_param2 = true,
       }
 
 * `minetest.has_feature(arg)`: returns `boolean, missing_features`
@@ -8206,6 +8213,10 @@ Used by `minetest.register_node`.
 
         post_effect_color = "#00000000",
         -- Screen tint if player is inside node, see "ColorSpec"
+
+        post_effect_use_node_color = false,
+        -- If true, the specific node's coloration (with param2 etc.) will be
+        -- applied to the post effect color as it is applied to the node itself.
 
         paramtype = "none",  -- See "Nodes"
 

--- a/games/devtest/mods/testnodes/param2.lua
+++ b/games/devtest/mods/testnodes/param2.lua
@@ -253,3 +253,50 @@ minetest.register_node("testnodes:colorwallmounted_nodebox", {
 	groups = { dig_immediate = 3 },
 })
 
+minetest.register_node("testnodes:colorflowingliquid_source", {
+	description = S("Color Flowingliquid Source Test Node").."\n"..
+		S("param2 = color + 4 unused bits"),
+	paramtype2 = "color",
+	paramtype = "light",
+	liquidtype = "source",
+	liquid_alternative_source = "testnodes:colorflowingliquid_source",
+	liquid_alternative_flowing = "testnodes:colorflowingliquid_flowing",
+	liquid_renewable = true,
+	liquid_range = 8,
+	walkable = false,
+	buildable_to = true,
+	is_ground_content = false,
+	drawtype = "liquid",
+	palette = "testnodes_palette_flowingliquid.png",
+	tiles = {"testnodes_node.png"},
+	special_tiles = {
+		{name = "testnodes_node.png", backface_culling = false},
+		{name = "testnodes_node.png", backface_culling = true},
+	},
+	post_effect_color = "#7d7d7d7d",
+	post_effect_use_node_color = true,
+})
+
+minetest.register_node("testnodes:colorflowingliquid_flowing", {
+	description = S("Color Flowingliquid Flowing Test Node").."\n"..
+		S("param2 = color + flowing liquid properties"),
+	paramtype2 = "colorflowingliquid",
+	paramtype = "light",
+	liquidtype = "flowing",
+	liquid_alternative_source = "testnodes:colorflowingliquid_source",
+	liquid_alternative_flowing = "testnodes:colorflowingliquid_flowing",
+	liquid_renewable = true,
+	liquid_range = 8,
+	walkable = false,
+	buildable_to = true,
+	is_ground_content = false,
+	drawtype = "flowingliquid",
+	palette = "testnodes_palette_flowingliquid.png",
+	tiles = {"testnodes_node.png"},
+	special_tiles = {
+		{name = "testnodes_node.png", backface_culling = false},
+		{name = "testnodes_node.png", backface_culling = true},
+	},
+	post_effect_color = "#7d7d7d7d",
+	post_effect_use_node_color = true,
+})

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -673,6 +673,15 @@ void ClientMap::renderPostFx(CameraMode cam_mode)
 
 	const ContentFeatures& features = m_nodedef->get(n);
 	video::SColor post_effect_color = features.post_effect_color;
+	if (features.post_effect_use_node_color) {
+		video::SColor color;
+		n.getColor(features, &color);
+		post_effect_color.set(
+				post_effect_color.getAlpha(),
+				(post_effect_color.getRed() * color.getRed()) / 255,
+				(post_effect_color.getGreen() * color.getGreen()) / 255,
+				(post_effect_color.getBlue() * color.getBlue()) / 255);
+	}
 
 	// If the camera is in a solid node, make everything black.
 	// (first person mode only)

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -768,12 +768,18 @@ void ServerMap::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 		 */
 		MapNode n00 = n0;
 		//bool flow_down_enabled = (flowing_down && ((n0.param2 & LIQUID_FLOW_DOWN_MASK) != LIQUID_FLOW_DOWN_MASK));
-		if (m_nodedef->get(new_node_content).liquid_type == LIQUID_FLOWING) {
-			// set level to last 3 bits, flowing down bit to 4th bit
-			n0.param2 = (flowing_down ? LIQUID_FLOW_DOWN_MASK : 0x00) | (new_node_level & LIQUID_LEVEL_MASK);
+		if (n00.getContent() == CONTENT_AIR || floodable_node != CONTENT_AIR ||
+				new_node_content == CONTENT_AIR) {
+			// Clear the extra bits.
+			n0.param2 = 0;
 		} else {
-			// set the liquid level and flow bits to 0
+			// Preserve the extra bits.
 			n0.param2 &= ~(LIQUID_LEVEL_MASK | LIQUID_FLOW_DOWN_MASK);
+		}
+		if (m_nodedef->get(new_node_content).liquid_type == LIQUID_FLOWING) {
+			if (flowing_down)
+				n0.param2 |= LIQUID_FLOW_DOWN_MASK;
+			n0.param2 |= new_node_level & LIQUID_LEVEL_MASK;
 		}
 
 		// change the node.

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -533,7 +533,8 @@ u8 MapNode::getMaxLevel(const NodeDefManager *nodemgr) const
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	// todo: after update in all games leave only if (f.param_type_2 ==
-	if( f.liquid_type == LIQUID_FLOWING || f.param_type_2 == CPT2_FLOWINGLIQUID)
+	if( f.liquid_type == LIQUID_FLOWING || f.param_type_2 == CPT2_FLOWINGLIQUID
+			|| f.param_type_2 == CPT2_COLORED_FLOWINGLIQUID)
 		return LIQUID_LEVEL_MAX;
 	if(f.leveled || f.param_type_2 == CPT2_LEVELED)
 		return f.leveled_max;
@@ -546,7 +547,7 @@ u8 MapNode::getLevel(const NodeDefManager *nodemgr) const
 	// todo: after update in all games leave only if (f.param_type_2 ==
 	if(f.liquid_type == LIQUID_SOURCE)
 		return LIQUID_LEVEL_SOURCE;
-	if (f.param_type_2 == CPT2_FLOWINGLIQUID)
+	if (f.param_type_2 == CPT2_FLOWINGLIQUID || f.param_type_2 == CPT2_COLORED_FLOWINGLIQUID)
 		return getParam2() & LIQUID_LEVEL_MASK;
 	if(f.liquid_type == LIQUID_FLOWING) // can remove if all param_type_2 setted
 		return getParam2() & LIQUID_LEVEL_MASK;
@@ -566,6 +567,7 @@ s8 MapNode::setLevel(const NodeDefManager *nodemgr, s16 level)
 	s8 rest = 0;
 	const ContentFeatures &f = nodemgr->get(*this);
 	if (f.param_type_2 == CPT2_FLOWINGLIQUID
+			|| f.param_type_2 == CPT2_COLORED_FLOWINGLIQUID
 			|| f.liquid_type == LIQUID_FLOWING
 			|| f.liquid_type == LIQUID_SOURCE) {
 		if (level <= 0) { // liquid can’t exist with zero level

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -372,6 +372,7 @@ void ContentFeatures::reset()
 		j = TileDef();
 	alpha = ALPHAMODE_OPAQUE;
 	post_effect_color = video::SColor(0, 0, 0, 0);
+	post_effect_use_node_color = false;
 	param_type = CPT_NONE;
 	param_type_2 = CPT2_NONE;
 	is_ground_content = false;
@@ -459,7 +460,12 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 		}
 	}
 	writeU8(os, param_type);
-	writeU8(os, param_type_2);
+	if (protocol_version < 41 && param_type_2 == CPT2_COLORED_FLOWINGLIQUID) {
+		// Old clients will not see color in the liquid
+		writeU8(os, CPT2_FLOWINGLIQUID);
+	} else {
+		writeU8(os, param_type_2);
+	}
 
 	// visual
 	writeU8(os, drawtype);
@@ -543,6 +549,7 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	writeU8(os, alpha);
 	writeU8(os, move_resistance);
 	writeU8(os, liquid_move_physics);
+	writeU8(os, post_effect_use_node_color);
 }
 
 void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
@@ -656,6 +663,11 @@ void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
 		if (is.eof())
 			throw SerializationError("");
 		liquid_move_physics = tmp;
+
+		tmp = readU8(is);
+		if (is.eof())
+			throw SerializationError("");
+		post_effect_use_node_color = tmp;
 	} catch(SerializationError &e) {};
 }
 
@@ -991,6 +1003,7 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 				tdef_spec[j].backface_culling, tsettings);
 
 	if (param_type_2 == CPT2_COLOR ||
+			param_type_2 == CPT2_COLORED_FLOWINGLIQUID ||
 			param_type_2 == CPT2_COLORED_FACEDIR ||
 			param_type_2 == CPT2_COLORED_4DIR ||
 			param_type_2 == CPT2_COLORED_WALLMOUNTED ||

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -82,6 +82,8 @@ enum ContentParamType2
 	CPT2_4DIR,
 	// 6 bits of palette index, then 4dir
 	CPT2_COLORED_4DIR,
+	// 4 bits of palette index, then flowing liquid properties
+	CPT2_COLORED_FLOWINGLIQUID,
 };
 
 enum LiquidType
@@ -364,6 +366,8 @@ struct ContentFeatures
 	std::vector<content_t> connects_to_ids;
 	// Post effect color, drawn when the camera is inside the node.
 	video::SColor post_effect_color;
+	// Whether to apply the node's coloration to the post effect color.
+	bool post_effect_use_node_color;
 	// Flowing liquid or leveled nodebox, value = default level
 	u8 leveled;
 	// Maximum value for leveled nodes

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -677,6 +677,8 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 	read_color(L, -1, &f.post_effect_color);
 	lua_pop(L, 1);
 
+	getboolfield(L, index, "post_effect_use_node_color", f.post_effect_use_node_color);
+
 	f.param_type = (ContentParamType)getenumfield(L, index, "paramtype",
 			ScriptApiNode::es_ContentParamType, CPT_NONE);
 	f.param_type_2 = (ContentParamType2)getenumfield(L, index, "paramtype2",
@@ -687,7 +689,8 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 			f.param_type_2 == CPT2_COLORED_FACEDIR ||
 			f.param_type_2 == CPT2_COLORED_WALLMOUNTED ||
 			f.param_type_2 == CPT2_COLORED_DEGROTATE ||
-			f.param_type_2 == CPT2_COLORED_4DIR))
+			f.param_type_2 == CPT2_COLORED_4DIR ||
+			f.param_type_2 == CPT2_COLORED_FLOWINGLIQUID))
 		warningstream << "Node " << f.name.c_str()
 			<< " has a palette, but not a suitable paramtype2." << std::endl;
 
@@ -908,6 +911,8 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 
 	push_ARGB8(L, c.post_effect_color);
 	lua_setfield(L, -2, "post_effect_color");
+	lua_pushboolean(L, c.post_effect_use_node_color);
+	lua_setfield(L, -2, "post_effect_use_node_color");
 	lua_pushnumber(L, c.leveled);
 	lua_setfield(L, -2, "leveled");
 	lua_pushnumber(L, c.leveled_max);

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -68,6 +68,7 @@ struct EnumString ScriptApiNode::es_ContentParamType2[] =
 		{CPT2_COLORED_DEGROTATE, "colordegrotate"},
 		{CPT2_4DIR, "4dir"},
 		{CPT2_COLORED_4DIR, "color4dir"},
+		{CPT2_COLORED_FLOWINGLIQUID, "colorflowingliquid"},
 		{0, NULL},
 	};
 


### PR DESCRIPTION
Closes https://github.com/minetest/minetest/issues/12897.

- `colorflowingliquid` has been added.
- The upper four bits of flowing liquid nodes are not cleared by liquid transformation.
- `post_effect_use_node_color` has been added, which lets the post effect color vary depending on a node's param2 color.

## To do

This PR is Ready for Review.

- Are nodes colored correctly when using `post_effect_use_node_color`? I copied the procedure from the `[multiply` texture modifier.

## How to test

1. Try the new liquid whose source node is `testnodes:colorflowingliquid_source`. Try changing the color of some flowing liquid using the param2 tool. Make sure the post effect color varies with the palette index.
2. Test the liquid color and post effect color on an old client.
3. Try connecting to an old server with a new client.
4. Make sure liquid flow still works.