### PR TITLE
Send crosshair setting after the touch screen GUI has been initialized

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1407,6 +1407,7 @@ bool Game::createClient(const GameStartData &start_data)
 	if (g_touchscreengui) {
 		g_touchscreengui->init(texture_src);
 		g_touchscreengui->hide();
+		g_touchscreengui->setUseCrosshair(!isNoCrosshairAllowed());
 	}
 #endif
 	if (!connectToServer(start_data, &could_connect, &connect_aborted))


### PR DESCRIPTION
**Goal of the PR**
Touch-screen players will be able to rotate the camera while punching/mining using the crosshair as soon as the touch screen GUI is ready.

**How does the PR work?**
The crosshair's state/setting is sent to the touch screen GUI after it has been initialised. The setting was only sent after camera/viewing mode change before this PR.

**Does it resolve any reported issue?**
Yes, this PR tries to fix [a reported issue on the Discord server](https://cdn.discordapp.com/attachments/369123125021114369/1035588946870153256/recording_20221028_122000.mp4) ([link to the message](https://discord.com/channels/369122544273588224/369123125021114369/1035588947356688465)). Touch-screen players using the crosshair were only able to rotate the camera while punching/mining _after_ changing the camera/viewing mode before this PR.

**Does this relate to a goal in the roadmap?**
Probably, this PR tries to fix gameplay/control-related bug.

## To do
This PR is Ready for Review.

## How to test
1. Use a device that uses touch screen.
2. Enable `touch_use_crosshair`.
3. Play any Minetest world.
4. Do not change the camera/viewing mode!
5. Tap and hold until punching/mining is triggered.
6. Move the finger/tapping position.
7. The camera should rotate following the finger's movement direction.