### PR TITLE
Android: Increase target/compiled SDK version to 32

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 android {
-	compileSdkVersion 30
-	buildToolsVersion '30.0.3'
+	compileSdkVersion 32
+	buildToolsVersion '32.0.0'
 	ndkVersion "$ndk_version"
 	defaultConfig {
 		applicationId 'net.minetest.minetest'
 		minSdkVersion 16
-		targetSdkVersion 30
+		targetSdkVersion 32
 		versionName "${versionMajor}.${versionMinor}.${versionPatch}"
 		versionCode project.versionCode
 	}
@@ -87,12 +87,12 @@ task prepareAssets() {
 		from "${projRoot}/textures" into "${assetsFolder}/textures"
 	}
 
-	file("${assetsFolder}/.nomedia").text = "";
+	file("${assetsFolder}/.nomedia").text = ""
 
 	task zipAssets(type: Zip) {
-		archiveName "Minetest.zip"
+		archiveFileName = "Minetest.zip"
 		from "${assetsFolder}"
-		destinationDir file("src/main/assets")
+		destinationDirectory = file("src/main/assets")
 	}
 }
 
@@ -112,5 +112,5 @@ android.applicationVariants.all { variant ->
 
 dependencies {
 	implementation project(':native')
-	implementation 'androidx.appcompat:appcompat:1.3.1'
+	implementation 'androidx.appcompat:appcompat:1.5.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,13 +11,13 @@ project.ext.set("developmentBuild", 1) // Whether it is a development build, or 
 // each APK must have a larger `versionCode` than the previous
 
 buildscript {
-	ext.ndk_version = '23.2.8568313'
+	ext.ndk_version = '25.1.8937393'
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.0.3'
+		classpath 'com.android.tools.build:gradle:7.2.2'
 		classpath 'de.undercouch:gradle-download-task:4.1.1'
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files
@@ -27,7 +27,7 @@ buildscript {
 allprojects {
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 	}
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip

--- a/android/native/build.gradle
+++ b/android/native/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'de.undercouch.download'
 
 android {
-	compileSdkVersion 30
-	buildToolsVersion '30.0.3'
+	compileSdkVersion 32
+	buildToolsVersion '32.0.0'
 	ndkVersion "$ndk_version"
 	defaultConfig {
 		minSdkVersion 16
-		targetSdkVersion 30
+		targetSdkVersion 32
 		externalNativeBuild {
 			ndkBuild {
 				arguments '-j' + Runtime.getRuntime().availableProcessors(),


### PR DESCRIPTION
**Goal of the PR**
This PR increases target/compiled SDK version to 32 and also updates Build Tools, NDK, and Gradle for Android build.

**How does the PR work?**
- Target/compiled SDK version: 30 -> 32
- Android Build Tools: 30.0.3 -> 32.0.0
- Android NDK: 23.2.8568313 -> 25.1.8937393 (r25b)
- Gradle: 7.2 -> 7.3.3
- Android Gradle plugin (for Build Tools): 7.0.3 -> 7.2.2
- Change `jcenter()` to `mavenCentral()`
- `androidx.appcompat:appcompat`: 1.3.1 -> 1.5.1

I tested before and found that the minetest/minetest_android_deps still works with this higher version. It is optional to be the same version as this PR (NDK r25b).

**Does it resolve any reported issue?**
Yes, this PR tries to fix failed build on GitHub Action. The error message is as below:
```
* What went wrong:
Execution failed for task ':native:extractReleaseAnnotations'.
> Could not resolve all dependencies for configuration ':native:lintClassPath'.
   > Could not determine artifacts for org.codehaus.groovy:groovy-all:3.0.7: Skipped due to earlier error
```
I am not sure whether this is the correct way to fix it, but this is good as a periodic dependencies update.

Another thing to note is that [Google Play will require updates to be targeting 31+ since 1 November 2022](https://support.google.com/googleplay/android-developer/answer/11926878).

**Does this relate to a goal in the roadmap?**
Probably, this PR tries to fix a continuous integration (CI) problem and to fulfil Google Play's requirement.

## To do
This PR is Ready for Review.

## How to test
1. Compile Minetest for Android.
2. There should be no compilation error and no regression.