### PR TITLE
 Add missing optional dependencies to Container Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,30 +11,29 @@ RUN apk add --no-cache git build-base cmake curl-dev zlib-dev zstd-dev \
 		gmp-dev jsoncpp-dev ninja ca-certificates
 
 WORKDIR /usr/src/
-RUN cd /usr/src/ && \
-	git clone --recursive https://github.com/jupp0r/prometheus-cpp/ && \
-	cd prometheus-cpp && \
-	cmake -B build \
-		-DCMAKE_INSTALL_PREFIX=/usr/local \
-		-DCMAKE_BUILD_TYPE=Release \
-		-DENABLE_TESTING=0 \
-		-GNinja && \
-	cmake --build build && \
-	cmake --install build && \
+RUN git clone --recursive https://github.com/jupp0r/prometheus-cpp/ && \
+		cd prometheus-cpp && \
+		cmake -B build \
+			-DCMAKE_INSTALL_PREFIX=/usr/local \
+			-DCMAKE_BUILD_TYPE=Release \
+			-DENABLE_TESTING=0 \
+			-GNinja && \
+		cmake --build build && \
+		cmake --install build && \
 	cd /usr/src/ && \
 	git clone --recursive https://github.com/libspatialindex/libspatialindex -b ${SPATIALINDEX_VERSION} && \
-	cd libspatialindex && \
-	cmake -B build \
-		-DCMAKE_INSTALL_PREFIX=/usr/local && \
-	cmake --build build && \
-	cmake --install build && \
+		cd libspatialindex && \
+		cmake -B build \
+			-DCMAKE_INSTALL_PREFIX=/usr/local && \
+		cmake --build build && \
+		cmake --install build && \
 	cd /usr/src/ && \
 	git clone --recursive https://luajit.org/git/luajit.git -b ${LUAJIT_VERSION} && \
-	cd luajit && \
-	make && make install && \
+		cd luajit && \
+		make && make install && \
 	cd /usr/src/ && \
 	git clone --depth=1 https://github.com/minetest/irrlicht/ -b ${IRRLICHT_VERSION} && \
-	cp -r irrlicht/include /usr/include/irrlichtmt
+		cp -r irrlicht/include /usr/include/irrlichtmt
 
 COPY .git /usr/src/minetest/.git
 COPY CMakeLists.txt /usr/src/minetest/CMakeLists.txt
@@ -52,23 +51,23 @@ COPY textures /usr/src/minetest/textures
 
 WORKDIR /usr/src/minetest
 RUN git clone --depth=1 -b ${MINETEST_GAME_VERSION} https://github.com/minetest/minetest_game.git ./games/minetest_game && \
-	rm -fr ./games/minetest_game/.git && \
-	cmake -B build \
-		-DCMAKE_INSTALL_PREFIX=/usr/local \
-		-DCMAKE_BUILD_TYPE=Release \
-		-DBUILD_SERVER=TRUE \
-		-DENABLE_PROMETHEUS=TRUE \
-		-DBUILD_UNITTESTS=FALSE \
-		-DBUILD_CLIENT=FALSE \
-		-GNinja && \
-	cmake --build build && \
-	cmake --install build
+		rm -fr ./games/minetest_game/.git && \
+		cmake -B build \
+			-DCMAKE_INSTALL_PREFIX=/usr/local \
+			-DCMAKE_BUILD_TYPE=Release \
+			-DBUILD_SERVER=TRUE \
+			-DENABLE_PROMETHEUS=TRUE \
+			-DBUILD_UNITTESTS=FALSE \
+			-DBUILD_CLIENT=FALSE \
+			-GNinja && \
+		cmake --build build && \
+		cmake --install build
 
 ARG DOCKER_IMAGE=alpine:3.16
 FROM $DOCKER_IMAGE AS runtime
 
 RUN apk add --no-cache curl gmp libstdc++ libgcc libpq jsoncpp zstd-libs \
-						sqlite-libs postgresql hiredis leveldb && \
+				sqlite-libs postgresql hiredis leveldb && \
 	adduser -D minetest --uid 30000 -h /var/lib/minetest && \
 	chown -R minetest:minetest /var/lib/minetest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ FROM $DOCKER_IMAGE AS builder
 ENV MINETEST_GAME_VERSION master
 ENV IRRLICHT_VERSION master
 ENV SPATIALINDEX_VERSION 1.9.3
+ENV LUAJIT_VERSION v2.1
 
 RUN apk add --no-cache git build-base cmake curl-dev zlib-dev zstd-dev \
 		sqlite-dev postgresql-dev hiredis-dev leveldb-dev \
-		gmp-dev jsoncpp-dev ninja luajit-dev ca-certificates
+		gmp-dev jsoncpp-dev ninja ca-certificates
 
 WORKDIR /usr/src/
 RUN cd /usr/src/ && \
@@ -66,7 +67,7 @@ RUN git clone --depth=1 -b ${MINETEST_GAME_VERSION} https://github.com/minetest/
 ARG DOCKER_IMAGE=alpine:3.16
 FROM $DOCKER_IMAGE AS runtime
 
-RUN apk add --no-cache curl gmp libstdc++ libgcc libpq luajit jsoncpp zstd-libs \
+RUN apk add --no-cache curl gmp libstdc++ libgcc libpq jsoncpp zstd-libs \
 						sqlite-libs postgresql hiredis leveldb && \
 	adduser -D minetest --uid 30000 -h /var/lib/minetest && \
 	chown -R minetest:minetest /var/lib/minetest
@@ -77,6 +78,7 @@ COPY --from=builder /usr/local/share/minetest /usr/local/share/minetest
 COPY --from=builder /usr/local/bin/minetestserver /usr/local/bin/minetestserver
 COPY --from=builder /usr/local/share/doc/minetest/minetest.conf.example /etc/minetest/minetest.conf
 COPY --from=builder /usr/local/lib/libspatialindex* /usr/local/lib/
+COPY --from=builder /usr/local/lib/libluajit* /usr/local/lib/
 USER minetest:minetest
 
 EXPOSE 30000/udp 30000/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ FROM $DOCKER_IMAGE AS builder
 ENV MINETEST_GAME_VERSION master
 ENV IRRLICHT_VERSION master
 
-RUN apk add --no-cache git build-base cmake sqlite-dev curl-dev zlib-dev zstd-dev \
-		gmp-dev jsoncpp-dev postgresql-dev ninja luajit-dev ca-certificates
+RUN apk add --no-cache git build-base cmake curl-dev zlib-dev zstd-dev \
+		sqlite-dev postgresql-dev hiredis-dev leveldb-dev \
+		gmp-dev jsoncpp-dev ninja luajit-dev ca-certificates
 
 WORKDIR /usr/src/
 RUN git clone --recursive https://github.com/jupp0r/prometheus-cpp/ && \
@@ -52,7 +53,8 @@ RUN git clone --depth=1 -b ${MINETEST_GAME_VERSION} https://github.com/minetest/
 ARG DOCKER_IMAGE=alpine:3.16
 FROM $DOCKER_IMAGE AS runtime
 
-RUN apk add --no-cache sqlite-libs curl gmp libstdc++ libgcc libpq luajit jsoncpp zstd-libs && \
+RUN apk add --no-cache curl gmp libstdc++ libgcc libpq luajit jsoncpp zstd-libs \
+						sqlite-libs postgresql hiredis leveldb && \
 	adduser -D minetest --uid 30000 -h /var/lib/minetest && \
 	chown -R minetest:minetest /var/lib/minetest
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR:
   - _The Docker image should support all DB backends that Minetest supports_
   - _All other optional dependencies should be included in the build_
- How does the PR work?: _Dockerfile's build stage and runtime packages were adjusted_
- Does it resolve any reported issue? _No_ 
- Does this relate to a goal in [the roadmap](../doc/direction.md)? _Couldn't find anything related to db backends._
- If not a bug fix, why is this PR needed? What usecases does it solve?: _Users of the Docker image can now use all database backends which was not possible before. Also a newer luajit version is now in use that brings some bugfixes not found in the Alpine package for luajit._

## To do

Ready for Review.

## How to test

After you have cloned the branch:

```bash
docker build -t minetest_ .
# Check the cmake section to see if all optional dependencies were found.
docker run --rm -d --name minetest -p 30000:30000 minetest_
docker run --rm -d --name redis -p 6379:6379 registry.opensuse.org/opensuse/redis
docker run --rm -d --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=lol -d docker.io/postgres
docker exec -it minetest /bin/sh
echo 'redis_address=host-ip-or-internal-docker-ip' >> /var/lib/minetest/.minetest/worlds/world/world.mt
echo 'redis_hash=' >> /var/lib/minetest/.minetest/worlds/world/world.mt
echo 'pgsql_player_connection=host=host-ip-or-internal-docker-ip user=postgres password=lol dbname=postgres' >> /var/lib/minetest/.minetest/worlds/world/world.mt
minetestserver --migrate redis --world /var/lib/minetest/.minetest/worlds/world/
minetestserver --migrate-players postgresql --world /var/lib/minetest/.minetest/worlds/world/
minetestserver --migrate-auth leveldb --world /var/lib/minetest/.minetest/worlds/world/

docker ps
docker stop minetest redis postgres
```