### PR TITLE
Alternative I: Reduce active mgmt interval for a bit when a player joins

### DIFF
--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -462,7 +462,7 @@ private:
 	IntervalLimiter m_object_management_interval;
 	// List of active blocks
 	ActiveBlockList m_active_blocks;
-	bool m_force_update_active_blocks = false;
+	int m_fast_active_block_divider = 1;
 	IntervalLimiter m_active_blocks_mgmt_interval;
 	IntervalLimiter m_active_block_modifier_interval;
 	IntervalLimiter m_active_blocks_nodemetadata_interval;


### PR DESCRIPTION
Alternative to #12927
Fixes #10884 

When a player joins, active blocks take a bit to be emerged and activated, which means entities stored there take some time to appear.
When the player has been attached to (say) a flying entity they will now fall to their deatch.

Is this a quick fix. A full fix would enqueue these blocks immediately and then activate them upon emerge.

Downside: The server does more work for a short time when the effective mgmt interval is shortened for everyone.

## How to test

Attach yourself to a flying entity. Try the ~~balloon,~~ blimp or similar mods. Leave and rejoin. You should be re-attached immediately.
