### PR TITLE
Formspec/HUD Replacement

### DIFF
--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/hud.h"
 #include "client/minimap.h"
 #include "client/shadows/dynamicshadowsrender.h"
+#include "gui/manager.h"
 
 RenderingCore::RenderingCore(IrrlichtDevice *_device, Client *_client, Hud *_hud)
 	: device(_device), driver(device->getVideoDriver()), smgr(device->getSceneManager()),
@@ -121,6 +122,7 @@ void RenderingCore::drawHUD()
 			mapper->drawMinimap();
 	}
 	guienv->drawAll();
+	ui::g_manager.drawAll();
 }
 
 void RenderingCore::drawPostFx()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -27,6 +27,7 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiTable.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiHyperText.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiVolumeChange.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/json_reader.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/modalMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/profilergraph.cpp
 	${extra_gui_SRCS}

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -4,7 +4,11 @@ if(ENABLE_TOUCH)
 endif()
 
 set(gui_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/design.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/drawable.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/elem.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/elem_registry.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/env.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiAnimatedImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiBackgroundImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiBox.cpp
@@ -29,6 +33,7 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiHyperText.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiVolumeChange.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/json_reader.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/manager.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/modalMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/profilergraph.cpp
 	${extra_gui_SRCS}

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -4,6 +4,7 @@ if(ENABLE_TOUCH)
 endif()
 
 set(gui_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/drawable.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiAnimatedImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiBackgroundImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiBox.cpp

--- a/src/gui/design.cpp
+++ b/src/gui/design.cpp
@@ -1,0 +1,168 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "design.h"
+
+#include "manager.h"
+
+#include <cmath>
+#include <vector>
+
+namespace ui
+{
+	void Design::drawTo(Canvas &canvas, const Rect<float> &dest_rect)
+	{
+		// Draw the background color if it's not totally transparent.
+		if (m_color.getAlpha() != 0x0) {
+			canvas.drawRect(dest_rect, m_color);
+		}
+
+		// If there is no texture to draw, nothing else need be done.
+		if (m_texture.isScreen()) {
+			return;
+		}
+
+		// If we have animations, we need to adjust the source rect by the frame
+		// offset in accordance with the current frame.
+		Rect<float> norm_src_rect = m_src_rect;
+
+		if (m_frame_time != 0) {
+			s32 frame_idx = (g_manager.getTime() / m_frame_time) % m_num_frames;
+			norm_src_rect += m_frame_offset * frame_idx;
+		}
+
+		// Convert the normalized coordinates for the source rect to pixels.
+		Dim<s32> tex_size = m_texture.getSize();
+
+		Rect<s32> src_rect(
+			lround(left(norm_src_rect) * tex_size.Width),
+			lround(top(norm_src_rect) * tex_size.Height),
+			lround(right(norm_src_rect) * tex_size.Width),
+			lround(bottom(norm_src_rect) * tex_size.Height)
+		);
+
+		// Calculate the size of the rect to draw the texture in. This is just
+		// the destination rect if we aren't scaling, and the scaled source rect
+		// if we are.
+		Dim<float> draw_size(
+			(m_scale.X == 0.0f) ? dest_rect.getWidth() : src_rect.getWidth() * m_scale.X,
+			(m_scale.Y == 0.0f) ? dest_rect.getHeight() : src_rect.getHeight() * m_scale.Y
+		);
+
+		if (m_tile_mode[0] != TileMode::NONE) {
+			// At the current texture scale, compute the number of tiles we'll
+			// need to fully fill the destination rect.
+			float num_tiles = dest_rect.getWidth() / draw_size.Width;
+
+			if (m_tile_mode[0] == TileMode::REPEAT) {
+				/* If the texture just repeats, we ceil to get an integer number
+				 * of tiles to draw. The drawing size is increased by this
+				 * factor, meaning that it may be bigger than the destination
+				 * rect, as expected.
+				 */
+				num_tiles = ceil(num_tiles);
+				draw_size.Width *= num_tiles;
+			} else {
+				/* If the texture rounds, round the number of tiles to the
+				 * nearest integer to get the best fit. Set the drawing size to
+				 * the destination rect size plus space for one extra tile (see
+				 * below) since the tiled textures must fit perfectly.
+				 */
+				num_tiles = round(num_tiles);
+				draw_size.Width = dest_rect.getWidth();
+			}
+
+			/* Add the number of extra tiles needed to the end of the existing
+			 * source rect. This takes advantage of how Irrlicht automatically
+			 * wraps textures if their source rects are larger than the texture
+			 * bounds, which is much cleaner and almost certainly more
+			 * performant than drawing each tile in a loop. The only downside is
+			 * that it will wrap the entire image, not just the portion given by
+			 * the source rect, but this is good enough for most use-cases.
+			 */
+			right(src_rect) += src_rect.getWidth() * (num_tiles - 1);
+		}
+
+		if (m_tile_mode[1] != TileMode::NONE) {
+			// Tiling in the vertical direction behaves in the same manner as
+			// in the horizontal direction.
+			float num_tiles = dest_rect.getHeight() / draw_size.Height;
+
+			if (m_tile_mode[1] == TileMode::REPEAT) {
+				num_tiles = ceil(num_tiles);
+				draw_size.Height *= num_tiles;
+			} else {
+				num_tiles = round(num_tiles);
+				draw_size.Height = dest_rect.getHeight();
+			}
+
+			bottom(src_rect) += src_rect.getHeight() * (num_tiles - 1);
+		}
+
+		// Finally, we get the drawing position by just placing the drawing rect
+		// at the proper alignment within the destination rect.
+		Vec<float> draw_pos(
+			(dest_rect.getWidth() - draw_size.Width) * m_align.X + left(dest_rect),
+			(dest_rect.getHeight() - draw_size.Height) * m_align.Y + top(dest_rect)
+		);
+
+		// And huzzah, we draw the texture!
+		Rect<float> draw_rect(draw_pos, draw_size);
+		canvas.drawTexture(draw_rect, m_texture, &src_rect, &dest_rect, m_tint);
+	}
+
+	void Design::resetView()
+	{
+		m_color = BLANK;
+
+		m_texture = Texture();
+		m_src_rect = Rect<float>(0.0f, 0.0f, 1.0f, 1.0f);
+		m_tint = WHITE;
+
+		m_num_frames = 1;
+		m_frame_time = 0;
+		m_frame_offset = Vec<float>();
+
+		m_align = Vec<float>();
+		m_scale = Vec<float>();
+
+		m_tile_mode = {TileMode::NONE, TileMode::NONE};
+	}
+
+	void Design::applyView(const JsonReader &json)
+	{
+		json["color"].readColor(m_color);
+
+		if (auto val = json["texture"]) {
+			m_texture = Texture(g_manager.getTexture(val.toString()));
+		}
+		json["src_rect"].readRect(m_src_rect);
+		json["tint"].readColor(m_tint);
+
+		json["num_frames"].readNum(m_num_frames, 1);
+		json["frame_time"].readNum(m_frame_time);
+		json["frame_offset"].readVec(m_frame_offset);
+
+		json["align"].readVec(m_align, {0.0f, 0.0f}, {1.0f, 1.0f});
+		json["scale"].readVec(m_scale, {0.0f, 0.0f});
+
+		json["tile_mode"].readArray(m_tile_mode,
+				JSON_BIND_READ(readEnum<TileMode>, TILE_MODE_NAME_MAP));
+	}
+}

--- a/src/gui/design.h
+++ b/src/gui/design.h
@@ -1,0 +1,75 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "drawable.h"
+#include "json_reader.h"
+#include "ui_types.h"
+#include "util/string.h"
+
+#include <array>
+#include <string>
+#include <unordered_map>
+
+namespace ui
+{
+	enum class TileMode
+	{
+		NONE,
+		REPEAT,
+		ROUND
+	};
+
+	constexpr EnumNameMap<TileMode> TILE_MODE_NAME_MAP = {
+		{"none", TileMode::NONE},
+		{"repeat", TileMode::REPEAT},
+		{"round", TileMode::ROUND}
+	};
+
+	class Design
+	{
+	private:
+		Color m_color;
+
+		Texture m_texture;
+		Rect<float> m_src_rect;
+		Color m_tint;
+
+		s32 m_num_frames;
+		u32 m_frame_time;
+		Vec<float> m_frame_offset;
+
+		Vec<float> m_scale;
+		Vec<float> m_align;
+
+		std::array<TileMode, 2> m_tile_mode;
+
+	public:
+		Design()
+		{
+			resetView();
+		}
+
+		void drawTo(Canvas &canvas, const Rect<float> &rect);
+
+		void resetView();
+		void applyView(const JsonReader &json);
+	};
+}

--- a/src/gui/drawable.cpp
+++ b/src/gui/drawable.cpp
@@ -1,0 +1,276 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "drawable.h"
+
+#include "client/renderingengine.h"
+#include "exceptions.h"
+
+namespace ui
+{
+	static video::IVideoDriver *driver() {
+		return RenderingEngine::get_video_driver();
+	}
+
+	/** The current render target. We store this as bookkeeping in `set_as_target()` so we
+	  * don't change render targets more often than necessary. It is only valid between
+	  * `start_drawing()` and `end_drawing()`; otherwise, it's nullptr.
+	  */
+	video::ITexture *s_current_target = nullptr;
+
+	/** Sets a new render target, possibly clearing it to a new color. It will do nothing
+	  * (including clearing the texture) if the provided target is the current target. If
+	  * the target couldn't be set for some reason, an error is logged and the current
+	  * render target is set to the screen.
+	  *
+	  * \param target The new texture (or nullptr for screen) to set as the render target.
+	  * \param clear  Iff true, the texture will be cleared to a new color. Depth and
+	  *               stencil buffers will also be cleared.
+	  * \param color  The color to clear the texture to if `clear` is true.
+	  * \param force  Ignores the current state of `s_current_target` and sets the target
+	  *               anyway.
+	  */
+	static void set_as_target(video::ITexture *target, bool clear = false,
+			Color color = BLANK, bool force = false)
+	{
+		if (s_current_target == target && !force) {
+			return;
+		}
+
+		u16 to_clear = clear ? video::ECBF_ALL : video::ECBF_NONE;
+		if (driver()->setRenderTarget(target, to_clear, color)) {
+			s_current_target = target;
+		} else {
+			errorstream << "Unable to set render target" << std::endl;
+
+			// That failed for some reason; the driver probably doesn't support
+			// render textures. So, set it back to the screen. If *this* call
+			// errors, there's nothing we can do.
+			driver()->setRenderTarget(nullptr, to_clear, color);
+			s_current_target = nullptr;
+		}
+	}
+
+	Texture::Texture(const Dim<s32> &size) :
+		m_owner(true)
+	{
+		if (driver()->queryFeature(video::EVDF_RENDER_TO_TARGET)) {
+			m_texture = driver()->addRenderTargetTexture(core::dimension2du(size));
+		} else {
+			m_texture = nullptr;
+		}
+
+		if (m_texture != nullptr) {
+			// The default contents of a texture are actually unspecified,
+			// although it's usually transparent. So, we explicitly fill it.
+			drawFill(BLANK);
+			m_texture->grab();
+		}
+	}
+
+	Texture::~Texture()
+	{
+		// We don't have to do anything to the screen.
+		if (m_texture == nullptr) {
+			return;
+		}
+
+		m_texture->drop();
+
+		// If we own the texture and the reference count is one, only Irrlicht
+		// still holds a reference to the texture, so we can remove it from the
+		// driver.
+		if (m_owner && m_texture->getReferenceCount() == 1) {
+			driver()->removeTexture(m_texture);
+		}
+	}
+
+	Dim<s32> Texture::getSize() const
+	{
+		if (isScreen()) {
+			return Dim<s32>(driver()->getScreenSize());
+		}
+		return Dim<s32>(m_texture->getOriginalSize());
+	}
+
+	void Texture::drawPixel(const Vec<s32> &pos, Color color, const Rect<s32> *clip)
+	{
+		// We have to manually clip. `Rect::isPointInside()` doesn't do the
+		// trick because a pixel has a width of one, so the lower right corner
+		// must be exclusive.
+		if (clip != nullptr && (
+				pos.X < left(*clip) ||
+				pos.Y < top(*clip) ||
+				pos.X >= right(*clip) ||
+				pos.Y >= bottom(*clip))) {
+			return;
+		}
+
+		set_as_target(m_texture);
+		driver()->drawPixel(pos.X, pos.Y, color);
+	}
+
+	void Texture::drawRect(const Rect<s32> &rect, Color color, const Rect<s32> *clip)
+	{
+		set_as_target(m_texture);
+		driver()->draw2DRectangle(color, rect, clip);
+	}
+
+	void Texture::drawTexture(
+		const Vec<s32> &pos,
+		const Texture &texture,
+		const Rect<s32> *src,
+		const Rect<s32> *clip,
+		Color tint)
+	{
+		Dim<s32> size = (src != nullptr) ? src->getSize() : texture.getSize();
+		drawTexture(Rect<s32>(pos, size), texture, src, clip, tint);
+	}
+
+	void Texture::drawTexture(
+		const Rect<s32> &rect,
+		const Texture &texture,
+		const Rect<s32> *src,
+		const Rect<s32> *clip,
+		Color tint)
+	{
+		if (texture.isScreen()) {
+			errorstream << "Can't read from screen for drawing." << std::endl;
+			return;
+		}
+		if (*this == texture) {
+			errorstream << "Can't draw texture to itself" << std::endl;
+			return;
+		}
+
+		set_as_target(m_texture);
+
+		// If we don't have a source rectangle, make it encompass the entire
+		// texture.
+		Rect<s32> texture_rect(texture.getSize());
+		if (src == nullptr) {
+			src = &texture_rect;
+		}
+
+		video::SColor tints[] = {tint, tint, tint, tint};
+
+		driver()->draw2DImage(texture.m_texture, rect, *src, clip, tints, true);
+	}
+
+	void Texture::drawFill(Color color)
+	{
+		if (isScreen()) {
+			// The screen can't have transparency, so make the color opaque and
+			// draw a rectangle across the entire screen.
+			color.setAlpha(0xFF);
+			driver()->draw2DRectangle(color, Rect<s32>(getSize()));
+		} else {
+			/* There's no normal way to fill a texture with a color; drawing a
+			 * rect will add alpha, not replace it. So, use `setRenderTarget()`
+			 * to clear it instead. Irrlicht will ignore the call if this
+			 * texture is already the current render target, so set it to the
+			 * screen first before attempting to clear the texture.
+			 */
+			set_as_target(nullptr);
+			set_as_target(m_texture, true, color);
+		}
+	}
+
+	void Canvas::drawPixel(const Vec<float> &pos, Color color, const Rect<float> *clip)
+	{
+		drawRect(Rect<float>(pos, Dim<float>(1.0f, 1.0f)), color, clip);
+	}
+
+	void Canvas::drawRect(const Rect<float> &rect, Color color, const Rect<float> *clip)
+	{
+		Rect<s32> clipped = getClipRect(clip);
+		m_texture.drawRect(getDrawRect(rect), color, &clipped);
+	}
+
+	void Canvas::drawTexture(
+		const Vec<float> &pos,
+		const Texture &texture,
+		const Rect<s32> *src,
+		const Rect<float> *clip,
+		Color tint)
+	{
+		Dim<s32> size = (src != nullptr) ? src->getSize() : texture.getSize();
+		drawTexture(Rect<float>(pos, getCoordDim(size)), texture, src, clip, tint);
+	}
+
+	void Canvas::drawTexture(
+		const Rect<float> &rect,
+		const Texture &texture,
+		const Rect<s32> *src,
+		const Rect<float> *clip,
+		Color tint)
+	{
+		Rect<s32> clipped = getClipRect(clip);
+		m_texture.drawTexture(getDrawRect(rect), texture, src, &clipped, tint);
+	}
+
+	Vec<s32> Canvas::getDrawPos(const Vec<float> &pos) const
+	{
+		return Vec<s32>(
+			(pos.X * m_scale) + m_shift.X + left(m_sub_rect),
+			(pos.Y * m_scale) + m_shift.Y + top(m_sub_rect)
+		);
+	}
+
+	Dim<s32> Canvas::getDrawDim(const Dim<float> &dim) const
+	{
+		return Dim<s32>(dim.Width * m_scale, dim.Height * m_scale);
+	}
+
+	Rect<s32> Canvas::getDrawRect(const Rect<float> &rect) const
+	{
+		return Rect<s32>(getDrawPos(rect.UpperLeftCorner), getDrawDim(rect.getSize()));
+	}
+
+	Dim<float> Canvas::getCoordDim(const Dim<s32> &dim) const
+	{
+		return Dim<float>(dim.Width / m_scale, dim.Height / m_scale);
+	}
+
+	Rect<s32> Canvas::getClipRect(const Rect<float> *clip) const
+	{
+		Rect<float> clipped(getCoordDim(m_texture.getSize()));
+
+		if (clip != nullptr) {
+			clipped.clipAgainst(*clip);
+		}
+		if (!m_noclip) {
+			clipped.clipAgainst(m_sub_rect);
+		}
+
+		return getDrawRect(clipped);
+	}
+
+	void start_drawing()
+	{
+		// Force set the target since we don't know what the target was before,
+		// so `s_current_target` could possibly be invalid.
+		set_as_target(nullptr, false, BLANK, true);
+	}
+
+	void end_drawing()
+	{
+		set_as_target(nullptr);
+	}
+}

--- a/src/gui/drawable.h
+++ b/src/gui/drawable.h
@@ -1,0 +1,364 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "log.h"
+#include "ui_types.h"
+
+namespace ui
+{
+	/** Represents a texture-like surface, either an actual Irrlicht ITexture or the
+	  * screen.
+	  *
+	  * Textures have a concept of "ownership": If a Texture created the underlying
+	  * ITexture, a Texture will free that ITexture from the texture cache unless someone
+	  * else takes ownership of it. However, if the ITexture came from somewhere else, the
+	  * Texture will not free it. Note that the screen does not have or need ownership.
+	  *
+	  * Copied texture objects share the same underlying ITexture rather than copying it.
+	  */
+	class Texture
+	{
+	private:
+		/** The underlying ITexture, or nullptr for the screen. */
+		video::ITexture *m_texture;
+
+		/** True iff this Texture is an owner of the underlying texture and will free it
+		  * from the texture cache upon destruction if we hold the last reference to it.
+		  *
+		  * Textures we don't own can't be freed automatically because other code doesn't
+		  * necessarily call `grab()` on textures consistently.
+		  */
+		bool m_owner;
+
+	public:
+		/** Creates a new texture that points to the screen. */
+		Texture() :
+			Texture(nullptr)
+		{}
+
+		/** Creates a new Texture from an existing ITexture. It will not have ownership
+		  * for freeing it.
+		  *
+		  * \param texture The existing ITexture to use, or nullptr to use the screen.
+		  */
+		Texture(video::ITexture *texture) :
+			m_texture(texture),
+			m_owner(false)
+		{
+			if (m_texture != nullptr)
+				m_texture->grab();
+		}
+
+		/** Creates a new texture of the specified size. It will be transparent by
+		  * default. If texture creation fails or the driver doesn't support render
+		  * textures, this Texture object will point to the screen instead.
+		  *
+		  * \param size The size of the texture to create.
+		  */
+		Texture(const Dim<s32> &size);
+
+		Texture(const Texture &other) :
+			m_texture(other.m_texture),
+			m_owner(other.m_owner)
+		{
+			if (m_texture != nullptr)
+				m_texture->grab();
+		}
+
+		Texture(Texture &&other) noexcept :
+			Texture(nullptr)
+		{
+			swap(*this, other);
+		}
+
+		Texture &operator=(Texture other)
+		{
+			swap(*this, other);
+			return *this;
+		}
+
+		friend void swap(Texture &first, Texture &second)
+		{
+			using std::swap;
+			swap(first.m_owner, second.m_owner);
+			swap(first.m_texture, second.m_texture);
+		}
+
+		~Texture();
+
+		/** \return The size in pixels of this texture. */
+		Dim<s32> getSize() const;
+
+		/** \return The width of this texture in pixels. */
+		s32 getWidth() const
+		{
+			return getSize().Width;
+		}
+
+		/** \return The height of this texture in pixels. */
+		s32 getHeight() const
+		{
+			return getSize().Height;
+		}
+
+		/** \return True iff this is the screen. */
+		bool isScreen() const
+		{
+			return m_texture == nullptr;
+		}
+
+		/** Draws a pixel of the specified color.
+		  *
+		  * \param pos   The position of the top left corner of the pixel.
+		  * \param color The color of the pixel to draw. Alpha will be added.
+		  * \param clip  If non-null, the pixel will not be drawn if it falls outside
+		  *              these bounds.
+		  */
+		void drawPixel(const Vec<s32> &pos, Color color, const Rect<s32> *clip = nullptr);
+
+		/** Draws a filled rectangle of the specified color.
+		  *
+		  * \param rect  The rectangle to draw.
+		  * \param color The color to draw the rectangle. Alpha will be added.
+		  * \param clip  If non-null, the rectangle will be clipped to these bounds.
+		  */
+		void drawRect(const Rect<s32> &rect, Color color, const Rect<s32> *clip = nullptr);
+
+		/** Draws an unscaled texture at some position.
+		  *
+		  * \param pos     The position of the top left corner of the texture.
+		  * \param texture The texture to draw at that position. Alpha will be added. It
+		  *                may not be the screen or this texture.
+		  * \param src     If non-null, this is the sub-rectangle of the texture that will
+		  *                be drawn. Otherwise, the entire texture will be used.
+		  * \param clip    If non-null, parts of the texture outside these bounds will not
+		  *                be drawn.
+		  * \param tint    The color to multiply the texture by. `WHITE` will result in
+		  *                the texture being drawn normally.
+		  */
+		void drawTexture(
+			const Vec<s32> &pos,
+			const Texture &texture,
+			const Rect<s32> *src = nullptr,
+			const Rect<s32> *clip = nullptr,
+			Color tint = WHITE);
+
+		/** Draws a scaled texture at some position.
+		  *
+		  * \param rect The rectangle to draw the texture at. The texture will be scaled
+		  *             to this rectangle.
+		  * See the other `drawTexture()` overload for information on the other
+		  * parameters.
+		  */
+		void drawTexture(
+			const Rect<s32> &rect,
+			const Texture &texture,
+			const Rect<s32> *src = nullptr,
+			const Rect<s32> *clip = nullptr,
+			Color tint = WHITE);
+
+		/** Fills the texture entirely with a single color. Unlike `drawRect()`, this does
+		  * not add alpha, but replaces each pixel with the alpha verbatim.
+		  *
+		  * \param color The color to fill the texture with. Alpha is ignored if this is
+		  *              the screen.
+		  */
+		void drawFill(Color color);
+
+		/** \return True iff the two textures have the same underlying texture. */
+		friend bool operator==(const Texture &left, const Texture &right)
+		{
+			return left.m_texture == right.m_texture;
+		}
+
+		/** \return True iff the two textures do not have the same underlying texture. */
+		friend bool operator!=(const Texture &left, const Texture &right)
+		{
+			return !(left == right);
+		}
+	};
+
+	/** A drawable durface that works as an abstraction layer around a subset of a texture.
+	  * It effectively pretends that a certain sub-rectangle of a texture is the entire
+	  * texture, with all operations automatically drawing relative to the top right of
+	  * the sub-rectangle and clipping to that sub-rectangle.
+	  *
+	  * Canvases additionally support scaling and offsets built in. All coordinates passed
+	  * in are scaled by the scale factor and have the drawing offset added to them. As
+	  * such, all coordinates are specified in floating point multiples of that scaling
+	  * factor, and are rounded to the nearest pixel when drawing. Hence, a factor of 2.0
+	  * and a position of 1.5 would result in 3 pixels.
+	  *
+	  * All drawing operations still have clipping rectangles. Those rectangles are first
+	  * clipped to the sub-rectangle, and that new rectangle is used for the clipping
+	  * operations. Clipping can additionally be turned off with `setNoClip()` so drawing
+	  * operations may affect the entire underlying texture while still drawing relative
+	  * to the sub-rectangle.
+	  *
+	  * No clipping is done on the sub-rectangle against the texture since that doesn't
+	  * play well with the screen, which can resize. Additionally, drawing operations
+	  * already gracefully handle drawing out of bounds.
+	  */
+	class Canvas
+	{
+	private:
+		/** The underlying texture that is actually drawn to. */
+		Texture m_texture;
+
+		/** The scale factor of the canvas, i.e. what all dimensions will be multiplied by
+		  * when drawing.
+		  */
+		float m_scale;
+
+		/** The sub-rectangle of the underlying texture that all drawing draws relative to
+		  * and clips to. It is multiplied by the scale factor.
+		  */
+		Rect<float> m_sub_rect;
+
+		/** The shift that will be added to each position in drawing. It is multiplied by
+		  * the scale factor.
+		  */
+		Vec<float> m_shift;
+
+		/** Iff true, drawing operations will not clip to `m_sub_rect`. */
+		bool m_noclip = false;
+
+	public:
+		/** Creates a new canvas that draws to the entire area of a texture. It will have
+		  * a scale of zero and an empty sub-rectangle, so these must be configured before
+		  * anything will be drawn.
+		  *
+		  * \param texture The underlying texture to draw to.
+		  */
+		Canvas(Texture texture) :
+			m_texture(std::move(texture))
+		{}
+
+		Texture &getTexture()
+		{
+			return m_texture;
+		}
+
+		const Texture &getTexture() const
+		{
+			return m_texture;
+		}
+
+		void setTexture(Texture texture)
+		{
+			m_texture = std::move(texture);
+		}
+
+		float getScale() const
+		{
+			return m_scale;
+		}
+
+		void setScale(float scale)
+		{
+			m_scale = scale;
+		}
+
+		const Rect<float> &getSubRect() const
+		{
+			return m_sub_rect;
+		}
+
+		void setSubRect(const Rect<float> &sub_rect)
+		{
+			m_sub_rect = sub_rect;
+		}
+
+		const Vec<float> &getShift() const
+		{
+			return m_shift;
+		}
+
+		void setShift(const Vec<float> &shift)
+		{
+			m_shift = shift;
+		}
+
+		bool getNoClip() const
+		{
+			return m_noclip;
+		}
+
+		void setNoClip(bool noclip)
+		{
+			m_noclip = noclip;
+		}
+
+		void drawPixel(
+			const Vec<float> &pos,
+			Color color,
+			const Rect<float> *clip = nullptr);
+
+		void drawRect(
+			const Rect<float> &rect,
+			Color color,
+			const Rect<float> *clip = nullptr);
+
+		void drawTexture(
+			const Vec<float> &pos,
+			const Texture &texture,
+			const Rect<s32> *src = nullptr,
+			const Rect<float> *clip = nullptr,
+			Color tint = WHITE);
+
+		void drawTexture(
+			const Rect<float> &rect,
+			const Texture &texture,
+			const Rect<s32> *src = nullptr,
+			const Rect<float> *clip = nullptr,
+			Color tint = WHITE);
+
+	private:
+		Vec<s32> getDrawPos(const Vec<float> &pos) const;
+
+		Dim<s32> getDrawDim(const Dim<float> &dim) const;
+
+		Rect<s32> getDrawRect(const Rect<float> &rect) const;
+
+		Dim<float> getCoordDim(const Dim<s32> &dim) const;
+
+		/** Given a possibly nullptr clipping rectangle from some drawing operation,
+		  * returns a new rectangle that is the clipping rectangle clipped against the
+		  * sub-rectangle, taking into account no-clipping.
+		  *
+		  * \param The possibly nullptr clipping rectangle from the drawing operation.
+		  * \return The drawing rectangle to clip against for this drawing operation.
+		  */
+		Rect<s32> getClipRect(const Rect<float> *clip) const;
+	};
+
+	/** This should be called before performing any drawing with any Texture for this
+	  * frame. Drawing to Textures must not be interspersed with native Irrlicht or
+	  * OpenGL drawing.
+	  */
+	void start_drawing();
+
+	/** This should be called after all drawing with Textures is done for this frame.
+	  * Drawing with Irrlicht and OpenGL calls may be done again, and the current render
+	  * target will be set to the screen.
+	  */
+	void end_drawing();
+}

--- a/src/gui/elem.cpp
+++ b/src/gui/elem.cpp
@@ -22,29 +22,49 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "env.h"
 #include "manager.h"
 
+#include <unordered_map>
+
 namespace ui
 {
-	void Elem::draw(const Rect<float> &parent_rect)
+	void LayoutItem::applyLayout(const JsonReader &json)
+	{
+		json["elems"].readSet<size_t>(elems,
+				JSON_BIND_TO(toNum<size_t>, 0, Lim<size_t>::high()));
+		json["weight"].readNum(weight, 0.0f);
+	}
+
+	void LayoutAxis::applyLayout(const JsonReader &json)
+	{
+		json["dir"].readEnum(dir, LAYOUT_DIR_NAME_MAP);
+
+		json["items"].readVector<LayoutItem>(items, [](const JsonReader &val) {
+			LayoutItem item;
+			item.applyLayout(val);
+			return item;
+		});
+
+		json["spacing"].readArray(spacing,
+				JSON_BIND_READ(readNum<float>, Lim<float>::low(), Lim<float>::high()));
+
+		json["extra_space"].readEnum(extra_space, EXTRA_SPACE_NAME_MAP);
+		json["align"].readNum(align);
+	}
+
+	void Elem::draw()
 	{
 		if (!m_visible) {
 			return;
 		}
 
-		Vec<float> draw_pos(
-			m_pos.X - (m_anchor.X * m_size.Width),
-			m_pos.Y - (m_anchor.Y * m_size.Height)
-		);
-		m_draw_rect = Rect<float>(draw_pos, m_size);
-
 		Canvas canvas{Texture()};
 		canvas.setScale(m_env.getPixelSize());
-		canvas.setSubRect(parent_rect);
+		canvas.setSubRect(m_clip_rect);
 		canvas.setNoClip(m_noclip);
 
 		onDraw(canvas);
 
 		for (size_t i = 0; i < m_children.size(); i++) {
-			m_env.getElem(m_children[i]).draw(m_draw_rect);
+			m_env.getElem(m_children[i]).draw();
 		}
 	}
 
@@ -52,21 +72,13 @@ namespace ui
 	{
 		m_background.drawTo(canvas, m_draw_rect);
 
-		Rect<float> total_rect = add_rect_edges(m_draw_rect, m_border);
+		// For clarity and brevity's sake, we refer to the outside of the border
+		// as `outer` and the inside as `inner`.
+		const Rect<float> &outer = m_draw_rect;
+		Rect<float> inner = sub_rect_edges(m_draw_rect, m_border);
 
-		Rect<float> outer(
-			std::min(left(total_rect), left(m_draw_rect)),
-			std::min(top(total_rect), top(m_draw_rect)),
-			std::max(right(total_rect), right(m_draw_rect)),
-			std::max(bottom(total_rect), bottom(m_draw_rect))
-		);
-		Rect<float> inner(
-			std::max(left(total_rect), left(m_draw_rect)),
-			std::max(top(total_rect), top(m_draw_rect)),
-			std::min(right(total_rect), right(m_draw_rect)),
-			std::min(bottom(total_rect), bottom(m_draw_rect))
-		);
-
+		// Irrelevant to functionality, but I love how the length of these lines
+		// just happens to increase by one character each time.
 		m_slices[SLICE_TOP_LEFT].drawTo(canvas,
 				{left(outer), top(outer), left(inner), top(inner)});
 		m_slices[SLICE_TOP].drawTo(canvas,
@@ -94,8 +106,11 @@ namespace ui
 		if (auto val = json["state"]) {
 			applyState(val);
 		}
-		if (auto val = json["style"]) {
-			applyStyle(val);
+		if (auto val = json["layout"]) {
+			applyLayout(val);
+		}
+		if (auto val = json["view"]) {
+			applyView(val);
 		}
 	}
 
@@ -107,41 +122,57 @@ namespace ui
 				JSON_BIND_TO(toId, MAIN_ID_CHARS, false));
 	}
 
-	void Elem::resetStyle()
+	void Elem::resetLayout()
 	{
-		m_pos = Vec<float>(0.5f);
-		m_size = Vec<float>(1.0f);
-		m_anchor = Vec<float>(0.5f);
-
 		m_min_size = Vec<float>();
-		m_max_size = Vec<float>(Lim<float>::high());
+
+		m_scale = Vec<float>(1.0f);
+		m_align = Vec<float>(0.5f);
 
 		m_padding = Rect<float>();
 		m_border = Rect<float>();
 		m_margin = Rect<float>();
 
-		m_visible = true;
-		m_noclip = false;
+		m_aspect_ratio = 0.0f;
 
-		m_background.resetStyle();
-		for (size_t i = 0; i < m_slices.size(); i++) {
-			m_slices[i].resetStyle();
-		}
+		m_axes.clear();
 	}
 
-	void Elem::applyStyle(const JsonReader &json)
+	void Elem::applyLayout(const JsonReader &json)
 	{
-		json["pos"].readVec(m_pos);
-		json["size"].readDim(m_size);
-		json["anchor"].readVec(m_anchor);
-
 		json["min_size"].readDim(m_min_size);
-		json["max_size"].readDim(m_max_size);
+
+		json["scale"].readVec(m_scale, {0.0f, 0.0f});
+		json["align"].readVec(m_align);
 
 		json["padding"].readEdges(m_padding);
 		json["border"].readEdges(m_border);
 		json["margin"].readEdges(m_margin);
 
+		json["aspect_ratio"].readNum(m_aspect_ratio, 0.0f);
+
+		json["axes"].readVector<LayoutAxis>(m_axes, [](const JsonReader &val) {
+			LayoutAxis axis;
+			axis.applyLayout(val);
+			return axis;
+		});
+
+		m_env.requireLayout();
+	}
+
+	void Elem::resetView()
+	{
+		m_visible = true;
+		m_noclip = false;
+
+		m_background.resetView();
+		for (size_t i = 0; i < m_slices.size(); i++) {
+			m_slices[i].resetView();
+		}
+	}
+
+	void Elem::applyView(const JsonReader &json)
+	{
 		json["visible"].readBool(m_visible);
 		json["noclip"].readBool(m_noclip);
 
@@ -154,5 +185,287 @@ namespace ui
 				slice.applyView(val);
 			}
 		});
+	}
+
+	Rect<float> Elem::getDrawEdges() const
+	{
+		return add_edges(m_border, m_padding);
+	}
+
+	Rect<float> Elem::getAllEdges() const
+	{
+		return add_edges(getDrawEdges(), m_margin);
+	}
+
+	Dim<float> Elem::getMinDrawSize() const
+	{
+		/* The effective minimum size for an element is based on either the
+		 * content or the user minimum, depending on which is larger in each
+		 * direction. The padding and borders are added to this value since they
+		 * contribute to the final size of the element.
+		 */
+		Dim<float> total_min = dim_max(m_content_size, m_min_size) +
+				edges_dim(getDrawEdges());
+
+		/* If the element is supposed to be aspect corrected, increase its
+		 * minimum size to that aspect ratio for the final minimum size.
+		 * Increasing the size is performed to ensure that the element doesn't
+		 * shrink below the absolute minimum above.
+		 */
+		if (m_aspect_ratio != 0.0f) {
+			float ratio = total_min.Width / total_min.Height;
+			if (ratio < m_aspect_ratio) {
+				total_min.Width = total_min.Height * m_aspect_ratio;
+			} else {
+				total_min.Height = total_min.Width / m_aspect_ratio;
+			}
+		}
+		return total_min;
+	}
+
+	Dim<float> Elem::getMinMarginSize() const
+	{
+		return getMinDrawSize() + edges_dim(m_margin);
+	}
+
+	void Elem::layout()
+	{
+		// Perform the leaf-to-root pass, calculating the minimum sizes of child
+		// elements to determine the minimum sizes of their parent elements.
+		layoutContentSize();
+
+		/* Now that we have the minimum sizes, we perform the root-to-leaf pass,
+		 * positioning elements and comparing minimum sizes to available space
+		 * any allocating any spare space accordingly. We always start with the
+		 * screen size as our available space since we are the root element.
+		 */
+		m_clip_rect = Rect<float>({0.0f, 0.0f}, m_env.getScreenSize());
+		layoutDrawRect();
+	}
+
+	void Elem::layoutContentSize()
+	{
+		// Before anything else, zero the content size because elements start
+		// out with no space and expand as they need it.
+		m_content_size = Dim<float>();
+
+		// Before we can calculate our content size, we need the content size of
+		// all our children. So, instruct them to calculate it now.
+		for (size_t i = 0; i < m_children.size(); i++) {
+			m_env.getElem(m_children[i]).layoutContentSize();
+		}
+
+		// Now we run through the axes, calculating the minimum size for each
+		// element and keeping a running total.
+		for (LayoutAxis &axis : m_axes) {
+			// Reset the computed fields since they will contain values from the
+			// last layout.
+			axis.min_size = 0.0f;
+			axis.total_weight = 0.0f;
+
+			// Count how many times each element appears in this axis since such
+			// duplicate elements should add even proportions of its minimum
+			// size to each column rather than the whole amount.
+			std::unordered_map<size_t, size_t> elem_count;
+
+			for (const LayoutItem &item : axis.items) {
+				for (size_t index : item.elems) {
+					if (index < m_children.size()) {
+						// Since operator[] constructs in place, elements that
+						// haven't been seen yet are zero when we access them.
+						elem_count[index] += 1;
+					}
+				}
+			}
+
+			// Now we can compute the minimum sizes of each item in the axis.
+			for (LayoutItem &item : axis.items) {
+				// Again, reset the computed fields first.
+				item.size = 0.0f;
+
+				// Loop through the child element indices in this axis item to
+				// find their minimum sizes.
+				for (size_t index : item.elems) {
+					// Ignore child indices that are out of bounds; they will
+					// simply not appear in the layout.
+					if (index >= m_children.size()) {
+						continue;
+					}
+
+					const Elem &child = m_env.getElem(m_children[index]);
+					float elem_min = dim_at(child.getMinMarginSize(), axis.dir);
+
+					item.size = std::max(item.size, elem_min / elem_count[index]);
+				}
+
+				// Now that we have this item's minimum size, we can adjust
+				// the axis's minimum size accordingly.
+				axis.min_size += item.size;
+
+				// We also compute the total weight for the axis in this stage.
+				axis.total_weight += item.weight;
+			}
+
+			// Add the spacing between items to achieve the final minimum size.
+			axis.min_size += axis.spacing[SPACING_BEFORE];
+			axis.min_size += axis.spacing[SPACING_BETWEEN] * (axis.items.size() - 1);
+			axis.min_size += axis.spacing[SPACING_AFTER];
+
+			// Adjust the minimum size of the entire element to this new value.
+			float &total_min = dim_at(m_content_size, axis.dir);
+			total_min = std::max(total_min, axis.min_size);
+		}
+	}
+
+	void Elem::layoutDrawRect()
+	{
+		/* The size of the container that the element resides in is the size of
+		 * the clip rect, subtracting the element's margins since they decrease
+		 * the amount of space available for the normalized coordinates of scale
+		 * and align.
+		 */
+		Dim<float> cont_size = m_clip_rect.getSize() - edges_dim(m_margin);
+
+		/* The base size of the element is the proportion of the clip rect given
+		 * by the scale. This is then clamped to the absolute minimum size of
+		 * the element. Margins do not contribute to the element size, so this
+		 * size does not include them.
+		 */
+		Dim<float> draw_size = dim_max(Dim<float>(m_scale * cont_size), getMinDrawSize());
+
+		if (m_aspect_ratio != 0.0f) {
+			/* If our element needs to be aspect corrected, shrink the size to
+			 * that aspect ratio for the final element draw size. Decreasing the
+			 * size is performed to ensure that the element doesn't overflow its
+			 * clip rect. This can't shrink the size below the absolute minimum
+			 * since the minimum is already aspect corrected to the same ratio.
+			 */
+			float ratio = draw_size.Width / draw_size.Height;
+			if (ratio > m_aspect_ratio) {
+				draw_size.Width = draw_size.Height * m_aspect_ratio;
+			} else {
+				draw_size.Height = draw_size.Width / m_aspect_ratio;
+			}
+		}
+
+		// The position of the element is a proportion of the remaining space in
+		// the container after subtracting the size of the element from it.
+		Dim<float> draw_pos(
+			m_align.X * (cont_size.Width - draw_size.Width),
+			m_align.Y * (cont_size.Height - draw_size.Height)
+		);
+
+		m_draw_rect = Rect<float>(draw_pos, draw_size);
+
+		// Now that we have our content rect, we can calculate the clip rects of
+		// our children.
+		layoutClipRects();
+	}
+
+	void Elem::layoutClipRects()
+	{
+		// Calculate the rect in which all child elements will be positioned,
+		// which is our own rect without border and padding.
+		Rect<float> content_rect = sub_rect_edges(m_draw_rect, getDrawEdges());
+
+		/* Elements not constrained by an axis in some direction have no size
+		 * and are placed at the upper left corner of the parent element,
+		 * meaning they are effectively invisible. Set this as the initial rect
+		 * for all the child elements.
+		 */
+		Rect<float> default_clip(content_rect.UpperLeftCorner, content_rect.UpperLeftCorner);
+
+		for (size_t i = 0; i < m_children.size(); i++) {
+			Elem &child = m_env.getElem(m_children[i]);
+
+			child.m_clip_rect = default_clip;
+			child.m_clip_constrained = {false, false};
+		}
+
+		// Now we are ready to start laying out elements in each axis.
+		for (LayoutAxis &axis : m_axes) {
+			// Get the available space for this axis and the amount of extra
+			// space we have to throw around.
+			float content_space = dim_at(content_rect.getSize(), axis.dir);
+			float extra_space = std::max(content_space - axis.min_size, 0.0f);
+
+			// Depending on how we allocate extra space, we may have extra space
+			// before the elements and between each element.
+			float offset = 0.0f;
+			float between = 0.0f;
+
+			if (axis.total_weight > 0.0f) {
+				// Some elements have a weight; spend the rest of the space on
+				// each weighted element.
+				for (LayoutItem &item : axis.items) {
+					item.size += extra_space * (item.weight / axis.total_weight);
+				}
+			} else {
+				// Otherwise, use the extra space as blank spacing as specified.
+				switch (axis.extra_space) {
+				case ExtraSpace::OUTSIDE:
+					// Offset the elements by the current alignment amount.
+					offset = axis.align * extra_space;
+					break;
+				case ExtraSpace::AROUND:
+					// Place (n + 1) equal spaces around the n elements.
+					between = extra_space / (axis.items.size() + 1);
+					offset = between;
+					break;
+				case ExtraSpace::BETWEEN:
+					// Place (n - 1) equal spaces between the n elements.
+					between = extra_space / (axis.items.size() - 1);
+					break;
+				}
+			}
+
+			// Finally, we are ready to actually modify the rects of the
+			// elements in this axis. Start at the starting blank offset from
+			// the content rect.
+			float start = content_rect.UpperLeftCorner[axis.dir] + offset;
+			for (LayoutItem &item : axis.items) {
+				// The ending position of the rect is the size of this axis item
+				// added to the starting position.
+				float end = start + item.size;
+
+				for (size_t index : item.elems) {
+					// As usual, ignore the out of bounds child indices.
+					if (index >= m_children.size()) {
+						continue;
+					}
+
+					// Grab the child element and its relevant rect fields in
+					// this dimension.
+					Elem &child = m_env.getElem(m_children[index]);
+					float &before = child.m_clip_rect.UpperLeftCorner[axis.dir];
+					float &after = child.m_clip_rect.LowerRightCorner[axis.dir];
+
+					if (child.m_clip_constrained[axis.dir]) {
+						// If we've constrained this element in this dimension
+						// before, union the rect we gave it before with this
+						// new rect to get the total rect.
+						before = std::min(before, start);
+						after = std::max(after, end);
+					} else {
+						// Otherwise, just overwrite the default rect and mark
+						// it as having been constrained.
+						before = start;
+						after = end;
+
+						child.m_clip_constrained[axis.dir] = true;
+					}
+				}
+
+				// Having finished this axis item, add the between space to the
+				// ending position to get the next starting position.
+				start = end + between;
+			}
+		}
+
+		// Finally, having done all the clip rect calculations, we can let the
+		// child elements lay themselves out. Our work is done.
+		for (size_t i = 0; i < m_children.size(); i++) {
+			m_env.getElem(m_children[1]).layoutDrawRect();
+		}
 	}
 }

--- a/src/gui/elem.cpp
+++ b/src/gui/elem.cpp
@@ -1,0 +1,158 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "elem.h"
+
+#include "env.h"
+#include "manager.h"
+
+namespace ui
+{
+	void Elem::draw(const Rect<float> &parent_rect)
+	{
+		if (!m_visible) {
+			return;
+		}
+
+		Vec<float> draw_pos(
+			m_pos.X - (m_anchor.X * m_size.Width),
+			m_pos.Y - (m_anchor.Y * m_size.Height)
+		);
+		m_draw_rect = Rect<float>(draw_pos, m_size);
+
+		Canvas canvas{Texture()};
+		canvas.setScale(m_env.getPixelSize());
+		canvas.setSubRect(parent_rect);
+		canvas.setNoClip(m_noclip);
+
+		onDraw(canvas);
+
+		for (size_t i = 0; i < m_children.size(); i++) {
+			m_env.getElem(m_children[i]).draw(m_draw_rect);
+		}
+	}
+
+	void Elem::onDraw(Canvas &canvas)
+	{
+		m_background.drawTo(canvas, m_draw_rect);
+
+		Rect<float> total_rect = add_rect_edges(m_draw_rect, m_border);
+
+		Rect<float> outer(
+			std::min(left(total_rect), left(m_draw_rect)),
+			std::min(top(total_rect), top(m_draw_rect)),
+			std::max(right(total_rect), right(m_draw_rect)),
+			std::max(bottom(total_rect), bottom(m_draw_rect))
+		);
+		Rect<float> inner(
+			std::max(left(total_rect), left(m_draw_rect)),
+			std::max(top(total_rect), top(m_draw_rect)),
+			std::min(right(total_rect), right(m_draw_rect)),
+			std::min(bottom(total_rect), bottom(m_draw_rect))
+		);
+
+		m_slices[SLICE_TOP_LEFT].drawTo(canvas,
+				{left(outer), top(outer), left(inner), top(inner)});
+		m_slices[SLICE_TOP].drawTo(canvas,
+				{left(inner), top(outer), right(inner), top(inner)});
+		m_slices[SLICE_TOP_RIGHT].drawTo(canvas,
+				{right(inner), top(outer), right(outer), top(inner)});
+
+		m_slices[SLICE_LEFT].drawTo(canvas,
+				{left(outer), top(inner), left(inner), bottom(inner)});
+		m_slices[SLICE_CENTER].drawTo(canvas,
+				{left(inner), top(inner), right(inner), bottom(inner)});
+		m_slices[SLICE_RIGHT].drawTo(canvas,
+				{right(inner), top(inner), right(outer), bottom(inner)});
+
+		m_slices[SLICE_BOTTOM_LEFT].drawTo(canvas,
+				{left(outer), bottom(inner), left(inner), bottom(outer)});
+		m_slices[SLICE_BOTTOM].drawTo(canvas,
+				{left(inner), bottom(inner), right(inner), bottom(outer)});
+		m_slices[SLICE_BOTTOM_RIGHT].drawTo(canvas,
+				{right(inner), bottom(inner), right(outer), bottom(outer)});
+	}
+
+	void Elem::applyJson(const JsonReader &json)
+	{
+		if (auto val = json["state"]) {
+			applyState(val);
+		}
+		if (auto val = json["style"]) {
+			applyStyle(val);
+		}
+	}
+
+	void Elem::applyState(const JsonReader &json)
+	{
+		json["children"].readVector<std::string>(m_children,
+				JSON_BIND_TO(toId, MAIN_ID_CHARS, false));
+		json["classes"].readSet<std::string>(m_classes,
+				JSON_BIND_TO(toId, MAIN_ID_CHARS, false));
+	}
+
+	void Elem::resetStyle()
+	{
+		m_pos = Vec<float>(0.5f);
+		m_size = Vec<float>(1.0f);
+		m_anchor = Vec<float>(0.5f);
+
+		m_min_size = Vec<float>();
+		m_max_size = Vec<float>(Lim<float>::high());
+
+		m_padding = Rect<float>();
+		m_border = Rect<float>();
+		m_margin = Rect<float>();
+
+		m_visible = true;
+		m_noclip = false;
+
+		m_background.resetStyle();
+		for (size_t i = 0; i < m_slices.size(); i++) {
+			m_slices[i].resetStyle();
+		}
+	}
+
+	void Elem::applyStyle(const JsonReader &json)
+	{
+		json["pos"].readVec(m_pos);
+		json["size"].readDim(m_size);
+		json["anchor"].readVec(m_anchor);
+
+		json["min_size"].readDim(m_min_size);
+		json["max_size"].readDim(m_max_size);
+
+		json["padding"].readEdges(m_padding);
+		json["border"].readEdges(m_border);
+		json["margin"].readEdges(m_margin);
+
+		json["visible"].readBool(m_visible);
+		json["noclip"].readBool(m_noclip);
+
+		if (auto val = json["background"]) {
+			m_background.applyView(val);
+		}
+
+		json["slices"].readArray(m_slices, [](const JsonReader &val, Design &slice) {
+			if (val) {
+				slice.applyView(val);
+			}
+		});
+	}
+}

--- a/src/gui/elem.h
+++ b/src/gui/elem.h
@@ -1,0 +1,138 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "design.h"
+#include "drawable.h"
+#include "json_reader.h"
+#include "ui_types.h"
+
+#include <array>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace ui
+{
+	enum Slice
+	{
+		SLICE_TOP_LEFT,
+		SLICE_TOP,
+		SLICE_TOP_RIGHT,
+		SLICE_LEFT,
+		SLICE_CENTER,
+		SLICE_RIGHT,
+		SLICE_BOTTOM_LEFT,
+		SLICE_BOTTOM,
+		SLICE_BOTTOM_RIGHT,
+
+		SLICE_LEN,
+	};
+
+	class Env;
+
+	class Elem
+	{
+	private:
+		Env &m_env;
+		std::string m_id; // Computed; cross reference to ID in Env
+
+		std::vector<std::string> m_children;
+		std::string m_parent; // Computed
+
+		std::unordered_set<std::string> m_classes;
+
+		Vec<float> m_pos;
+		Dim<float> m_size;
+		Vec<float> m_anchor;
+
+		Dim<float> m_min_size;
+		Dim<float> m_max_size;
+
+		Rect<float> m_padding;
+		Rect<float> m_border;
+		Rect<float> m_margin;
+
+		Dim<float> m_abs_min_size; // Computed by sizer
+		Rect<float> m_draw_rect; // Computed by sizer
+
+		bool m_visible;
+		bool m_noclip;
+
+		Design m_background;
+		std::array<Design, SLICE_LEN> m_slices;
+
+	public:
+		Elem(Env &env, std::string id) :
+			m_env(env),
+			m_id(std::move(id))
+		{
+			resetStyle();
+		}
+
+		Elem(const Elem &) = delete;
+		Elem &operator=(const Elem &) = delete;
+
+		virtual ~Elem() = default;
+
+		Env &getEnv()
+		{
+			return m_env;
+		}
+
+		const Env &getEnv() const
+		{
+			return m_env;
+		}
+
+		const std::string &getId() const
+		{
+			return m_id;
+		}
+
+		const std::vector<std::string> &getChildren() const
+		{
+			return m_children;
+		}
+
+		const std::string &getParent() const
+		{
+			return m_parent;
+		}
+
+		void draw(const Rect<float> &parent_rect);
+		virtual void onDraw(Canvas &canvas);
+
+		void applyJson(const JsonReader &json);
+		virtual void applyState(const JsonReader &json);
+		virtual void resetStyle();
+		virtual void applyStyle(const JsonReader &json);
+
+	private:
+		// Begin Env friend interface
+		friend class Env;
+
+		void setParent(std::string parent)
+		{
+			m_parent = std::move(parent);
+		}
+		// End Env friend interface
+	};
+}

--- a/src/gui/elem_registry.cpp
+++ b/src/gui/elem_registry.cpp
@@ -1,0 +1,32 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "elem_registry.h"
+
+#include "elem.h"
+
+namespace ui
+{
+	ElemRegistry::ElemRegistry()
+	{
+		g_registry.registerElem<Elem>("Elem");
+	}
+
+	ElemRegistry g_registry;
+}

--- a/src/gui/elem_registry.h
+++ b/src/gui/elem_registry.h
@@ -1,0 +1,77 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "elem.h"
+
+#include <memory>
+#include <string>
+#include <typeinfo>
+#include <typeindex>
+#include <unordered_map>
+
+namespace ui
+{
+	class Env;
+
+	class ElemRegistry
+	{
+	public:
+		using ElemCtor = std::unique_ptr<Elem> (*)(Env &env, std::string id);
+
+	private:
+		std::unordered_map<std::type_index, std::string> m_elem_to_str;
+		std::unordered_map<std::string, ElemCtor> m_str_to_ctor;
+
+	public:
+		ElemRegistry();
+
+		template<typename T>
+		void registerElem(const std::string &name)
+		{
+			m_elem_to_str.emplace(std::type_index(typeid(T)), name);
+			m_str_to_ctor.emplace(name, [](Env &env, std::string id) {
+				return std::make_unique<T>(env, std::move(id));
+			});
+		}
+
+		template<typename T>
+		const std::string &getElemType() const
+		{
+			return m_elem_to_str.at(std::type_index(typeid(T)));
+		}
+
+		const std::string &getElemType(const Elem &elem) const
+		{
+			return m_elem_to_str.at(std::type_index(typeid(elem)));
+		}
+
+		const ElemCtor *getElemCtor(const std::string &name) const
+		{
+			auto it = m_str_to_ctor.find(name);
+			if (it == m_str_to_ctor.end()) {
+				return nullptr;
+			}
+			return &it->second;
+		}
+	};
+
+	extern ElemRegistry g_registry;
+}

--- a/src/gui/env.cpp
+++ b/src/gui/env.cpp
@@ -51,11 +51,29 @@ namespace ui
 		return g_manager.getPixelSize(m_is_hud);
 	}
 
+	Dim<float> Env::getScreenSize() const
+	{
+		Dim<s32> screen_size = Texture().getSize();
+		float pixel_size = getPixelSize();
+
+		return Dim<float>(
+			screen_size.Width / pixel_size,
+			screen_size.Height / pixel_size
+		);
+	}
+
 	void Env::drawAll()
 	{
 		Elem &root = getElem(m_root_elem);
-		Rect<float> parent_rect({0.0f, 0.0f}, getScreenSize());
-		root.draw(parent_rect);
+
+		Dim<s32> screen_size = Texture().getSize();
+		if (m_needs_layout || m_last_screen_size != screen_size) {
+			root.layout();
+			m_needs_layout = false;
+			m_last_screen_size = screen_size;
+		}
+
+		root.draw();
 	}
 
 	void Env::applyJson(const JsonReader &json)

--- a/src/gui/env.cpp
+++ b/src/gui/env.cpp
@@ -1,0 +1,155 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "env.h"
+
+#include "manager.h"
+#include "client/renderingengine.h"
+
+#include <unordered_set>
+
+using namespace std::string_literals;
+
+namespace ui
+{
+	BadEnvException::BadEnvException(const Env *env, const std::string &message) :
+		UiException("Bad UI (env \""s + env->getId() + "\"): "s + message)
+	{}
+
+	BadElemException::BadElemException(const Elem *elem, const std::string &message) :
+		UiException("Bad UI (env \""s + elem->getEnv().getId() + "\", elem \"" +
+				elem->getId() + "\"): "s + message)
+	{}
+
+	Elem &Env::getElem(const std::string &id)
+	{
+		auto it = m_elems.find(id);
+		if (it == m_elems.end()) {
+			throw BadEnvException(this, "No element exists with ID \""s + id + "\"");
+		}
+		return *it->second;
+	}
+
+	float Env::getPixelSize() const
+	{
+		return g_manager.getPixelSize(m_is_hud);
+	}
+
+	void Env::drawAll()
+	{
+		Elem &root = getElem(m_root_elem);
+		Rect<float> parent_rect({0.0f, 0.0f}, getScreenSize());
+		root.draw(parent_rect);
+	}
+
+	void Env::applyJson(const JsonReader &json)
+	{
+		dissolveStructure();
+
+		std::unordered_map<std::string, std::unique_ptr<Elem>> old_elems;
+		m_elems.swap(old_elems);
+
+		for (const auto &elem : json["elems"].toVector()) {
+			std::string id = elem["id"].toId(MAIN_ID_CHARS, false);
+			std::string type = elem["type"].toString();
+
+			bool edit = false;
+			elem["edit"].readBool(edit);
+
+			if (m_elems.count(id)) {
+				throw BadEnvException(this, "Redefinition of element with ID \""s +
+						id + "\"");
+			}
+
+			if (edit) {
+				if (!old_elems.count(id)) {
+					throw BadEnvException(this, "Attempt to edit a non-existent "
+							"element \""s + id + "\"");
+				}
+
+				std::unique_ptr<Elem> old_elem = std::move(old_elems.at(id));
+
+				const std::string &old_type = g_registry.getElemType(*old_elem);
+				if (old_type != type) {
+					throw BadEnvException(this, "Attempt to edit an element with "
+							"type \""s + old_type + "\" to a different type of \"" +
+							type + "\"");
+				}
+
+				m_elems.emplace(id, std::move(old_elem));
+			} else {
+				auto ctor = g_registry.getElemCtor(type);
+				if (ctor == nullptr) {
+					throw BadEnvException(this, "No element exists with type \""s +
+							type + "\"");
+				}
+				m_elems.emplace(id, (*ctor)(*this, id));
+			}
+
+			m_elems.at(id)->applyJson(elem);
+		}
+
+		m_root_elem = json["root_elem"].toId(MAIN_ID_CHARS, false);
+		getElem(m_root_elem);
+
+		// If the user sets the active element, it must exist or it is an error.
+		// If the user doesn't change it, we need to set it to nothing if the
+		// old active element no longer exists.
+		bool found_active = json["active_elem"].readId(m_active_elem, VIRT_ID_CHARS, true);
+		if (found_active && m_active_elem != NO_ID) {
+			getElem(m_active_elem);
+		} else if (!hasElem(m_active_elem)) {
+			m_active_elem = NO_ID;
+		}
+
+		resolveStructure();
+		requireLayout();
+	}
+
+	void Env::dissolveStructure()
+	{
+		for (auto &pair : m_elems) {
+			pair.second->setParent(NO_ID);
+		}
+	}
+
+	void Env::resolveStructure()
+	{
+		std::unordered_set<std::string> found_ids;
+		resolveElementStructure(getElem(m_root_elem), found_ids);
+	}
+
+	void Env::resolveElementStructure(const Elem &elem,
+			std::unordered_set<std::string> &found_ids)
+	{
+		const std::string &id = elem.getId();
+		if (found_ids.count(id)) {
+			throw BadElemException(&elem, "Element is a child of multiple elements or "
+					"is used in a circular descendant loop");
+		}
+		found_ids.insert(id);
+
+		const std::vector<std::string> &children = elem.getChildren();
+		for (size_t i = 0; i < children.size(); i++) {
+			Elem &child = getElem(children[i]);
+			child.setParent(id);
+			resolveElementStructure(child, found_ids);
+		}
+	}
+}

--- a/src/gui/env.h
+++ b/src/gui/env.h
@@ -1,0 +1,116 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "elem.h"
+#include "elem_registry.h"
+#include "ui_types.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace ui
+{
+	class Env;
+
+	struct BadEnvException : UiException
+	{
+		BadEnvException(const Env *env, const std::string &message);
+	};
+
+	struct BadElemException : UiException
+	{
+		BadElemException(const Elem *elem, const std::string &message);
+	};
+
+	class Env
+	{
+	private:
+		std::string m_id; // Computed; cross reference to ID in Manager
+		bool m_is_hud;
+
+		std::unordered_map<std::string, std::unique_ptr<Elem>> m_elems;
+
+		std::string m_root_elem = NO_ID;
+		std::string m_active_elem = NO_ID;
+
+	public:
+		Env(std::string id, bool is_hud) :
+			m_id(std::move(id)),
+			m_is_hud(is_hud)
+		{}
+
+		Env(const Env &) = delete;
+		Env &operator=(const Env &) = delete;
+
+		const std::string &getId() const
+		{
+			return m_id;
+		}
+
+		bool hasElem(const std::string &id)
+		{
+			return m_elems.count(id);
+		}
+
+		Elem &getElem(const std::string &id);
+
+		template<typename T>
+		T &getElem(const std::string &id)
+		{
+			Elem &elem = getElem(id);
+			T *typed = dynamic_cast<T *>(&elem);
+			if (typed == nullptr) {
+				throw BadElemException(elem, "Expected element of type \""s +
+						g_registry.getElemType<T>() + "\", got type \"" +
+						g_registry.getElemType(elem) + "\"");
+			}
+
+			return typed;
+		}
+
+		bool isHud() const
+		{
+			return m_is_hud;
+		}
+
+		float getPixelSize() const;
+
+		Dim<float> getScreenSize() const
+		{
+			Dim<s32> int_size = Texture().getSize();
+			return Dim<float>(
+				int_size.Width / m_pixel_size,
+				int_size.Height / m_pixel_size
+			);
+		}
+
+		void drawAll();
+
+		void applyJson(const JsonReader &json);
+
+	private:
+		void dissolveStructure();
+		void resolveStructure();
+		void resolveElementStructure(const Elem &elem,
+				std::unordered_set<std::string> &found_ids);
+	};
+}

--- a/src/gui/env.h
+++ b/src/gui/env.h
@@ -52,6 +52,9 @@ namespace ui
 		std::string m_root_elem = NO_ID;
 		std::string m_active_elem = NO_ID;
 
+		bool m_needs_layout = true;
+		Dim<s32> m_last_screen_size;
+
 	public:
 		Env(std::string id, bool is_hud) :
 			m_id(std::move(id)),
@@ -94,13 +97,11 @@ namespace ui
 
 		float getPixelSize() const;
 
-		Dim<float> getScreenSize() const
+		Dim<float> getScreenSize() const;
+
+		void requireLayout()
 		{
-			Dim<s32> int_size = Texture().getSize();
-			return Dim<float>(
-				int_size.Width / m_pixel_size,
-				int_size.Height / m_pixel_size
-			);
+			m_needs_layout = true;
 		}
 
 		void drawAll();

--- a/src/gui/json_reader.cpp
+++ b/src/gui/json_reader.cpp
@@ -1,0 +1,86 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "json_reader.h"
+
+namespace ui
+{
+	JsonException::JsonException(const JsonReader *json, const std::string &message) :
+		UiException("Bad UI JSON ("s + json->getPath() + "): " + message)
+	{}
+
+	std::string JsonReader::toId(const char *allowed_chars, bool allow_empty) const
+	{
+		std::string id = toString();
+		if (!allow_empty && id.empty()) {
+			throw JsonException(this, "ID may not be empty");
+		} else if (!string_allowed(id, allowed_chars)) {
+			throw JsonException(this, "Invalid characters in ID: only \""s +
+					allowed_chars + "\" are allowed");
+		}
+		return id;
+	}
+
+	std::vector<JsonReader> JsonReader::toVector() const
+	{
+		checkArrayType();
+
+		std::vector<JsonReader> vec;
+		vec.reserve(m_value.size());
+		for (size_t i = 0; i < m_value.size(); i++) {
+			vec.emplace_back(m_value[(Json::ArrayIndex)i], pathTo(i));
+		}
+		return vec;
+	}
+
+	std::vector<JsonReader> JsonReader::toVector(size_t size) const
+	{
+		checkArrayType();
+		if (m_value.size() != size) {
+			throw JsonException(this, "Expected array to have size "s +
+					std::to_string(size));
+		}
+		return toVector();
+	}
+
+	std::vector<JsonReader> JsonReader::toVector(size_t min, size_t max) const
+	{
+		checkArrayType();
+		if (m_value.size() < min || m_value.size() > max) {
+			throw JsonException(this, "Expected array to have size in range "s +
+					std::to_string(min) + ".." + std::to_string(max));
+		}
+		return toVector();
+	}
+
+	std::unordered_map<std::string, JsonReader> JsonReader::toMap() const
+	{
+		if (!m_value.isObject()) {
+			throwTypeException("object");
+		}
+
+		std::unordered_map<std::string, JsonReader> map;
+		std::vector<std::string> keys = m_value.getMemberNames();
+		for (size_t i = 0; i < keys.size(); i++) {
+			const std::string &key = keys[i];
+			map[key] = JsonReader(m_value[key], pathTo(key));
+		}
+		return map;
+	}
+}

--- a/src/gui/json_reader.h
+++ b/src/gui/json_reader.h
@@ -1,0 +1,548 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "convert_json.h"
+#include "debug.h"
+#include "ui_types.h"
+#include "util/functional.h"
+#include "util/string.h"
+
+#include <array>
+#include <initializer_list>
+#include <limits>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+using namespace std::string_literals;
+
+namespace ui
+{
+	class JsonReader;
+
+	struct JsonException : UiException
+	{
+		JsonException(const JsonReader *json, const std::string &message);
+	};
+
+	template<typename T, typename = void>
+	struct Lim {};
+
+	template<typename T>
+	struct Lim<T, std::enable_if_t<std::is_integral<T>::value>>
+	{
+		static T low()
+		{
+			return std::numeric_limits<T>::min();
+		}
+
+		static T high()
+		{
+			return std::numeric_limits<T>::max();
+		}
+	};
+
+	template<typename T>
+	struct Lim<T, std::enable_if_t<std::is_floating_point<T>::value>>
+	{
+		static T low()
+		{
+			return -std::numeric_limits<T>::infinity();
+		}
+
+		static T high()
+		{
+			return std::numeric_limits<T>::infinity();
+		}
+	};
+
+#define JSON_BIND_TO_0(member) std::bind(&JsonReader::member, pl::_1)
+#define JSON_BIND_TO(member, ...) std::bind(&JsonReader::member, pl::_1, __VA_ARGS__)
+
+#define JSON_BIND_READ_0(member) JSON_BIND_TO(member, pl::_2)
+#define JSON_BIND_READ(member, ...) JSON_BIND_TO(member, pl::_2, __VA_ARGS__)
+
+	class JsonReader
+	{
+	public:
+		static constexpr float EXCLUSIVE_FLOAT = 0.000001f;
+		static constexpr double EXCLUSIVE_DOUBLE = 0.000001;
+
+	private:
+		Json::Value m_value;
+		std::string m_path;
+
+	public:
+		JsonReader() :
+			m_path("json")
+		{}
+
+		JsonReader(Json::Value value) :
+			JsonReader(std::move(value), "json")
+		{}
+
+		JsonReader(Json::Value value, std::string path) :
+			m_value(std::move(value)),
+			m_path(std::move(path))
+		{}
+
+		const Json::Value &getJson() const
+		{
+			return m_value;
+		}
+
+		const std::string &getPath() const
+		{
+			return m_path;
+		}
+
+		JsonReader operator[](const std::string &key) const
+		{
+			return JsonReader(m_value.get(key, Json::Value()), pathTo(key));
+		}
+
+		bool isNull() const
+		{
+			return m_value.isNull();
+		}
+
+		explicit operator bool() const
+		{
+			return !isNull();
+		}
+
+		bool toBool() const
+		{
+			if (!m_value.isBool()) {
+				throwTypeException("boolean");
+			}
+			return m_value.asBool();
+		}
+
+		bool readBool(bool &into) const
+		{
+			if (!isNull()) {
+				into = toBool();
+				return true;
+			}
+			return false;
+		}
+
+		template<typename T, std::enable_if_t<
+				std::is_integral<T>::value && std::is_signed<T>::value, int> = 0>
+		T toNum(T min = Lim<T>::low(), T max = Lim<T>::high()) const
+		{
+			if (!m_value.isInt64()) {
+				throwTypeException("integer");
+			}
+
+			T num = m_value.asInt64();
+
+			if (num < min || num > max) {
+				throw JsonException(this, "Expected integer in range "s +
+						std::to_string(min) + ".." + std::to_string(max));
+			}
+
+			return num;
+		}
+
+		template<typename T, std::enable_if_t<
+				std::is_unsigned<T>::value && !std::is_same<T, bool>::value, int> = 0>
+		T toNum(T min = Lim<T>::low(), T max = Lim<T>::high()) const
+		{
+			if (!m_value.isUInt64()) {
+				throwTypeException("unsigned integer");
+			}
+
+			T num = m_value.asUInt64();
+
+			if (num < min || num > max) {
+				throw JsonException(this, "Expected integer in range "s +
+						std::to_string(min) + ".." + std::to_string(max));
+			}
+			return num;
+		}
+
+		template<typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+		T toNum(T min = Lim<T>::low(), T max = Lim<T>::high()) const
+		{
+			if (!m_value.isDouble()) {
+				throwTypeException("number");
+			}
+
+			T num = m_value.asDouble();
+
+			if (num < min || num > max) {
+				throw JsonException(this, "Expected number in range "s +
+						std::to_string(min) + ".." + std::to_string(max));
+			}
+			return num;
+		}
+
+		template<typename T>
+		bool readNum(T &into, T min = Lim<T>::low(), T max = Lim<T>::high()) const
+		{
+			if (!isNull()) {
+				into = toNum<T>(min, max);
+				return true;
+			}
+			return false;
+		}
+
+		template<typename T>
+		bool readVec(
+			Vec<T> &into,
+			Vec<T> min = {Lim<T>::low(), Lim<T>::low()},
+			Vec<T> max = {Lim<T>::high(), Lim<T>::high()}) const
+		{
+			if (!isNull()) {
+				auto arr = toArray<2>();
+				arr[0].readNum(into.X, min.X, max.X);
+				arr[1].readNum(into.Y, min.Y, max.Y);
+				return true;
+			}
+			return false;
+		}
+
+		template<typename T>
+		bool readDim(
+			Dim<T> &into,
+			Dim<T> min = {0, 0},
+			Dim<T> max = {Lim<T>::high(), Lim<T>::high()}) const
+		{
+			if (!isNull()) {
+				auto arr = toArray<2>();
+				arr[0].readNum(into.Width, min.Width, max.Width);
+				arr[1].readNum(into.Height, min.Height, max.Height);
+				return true;
+			}
+			return false;
+		}
+
+		template<typename T>
+		bool readRect(
+			Rect<T> &into,
+			Rect<T> inside = {
+				Lim<T>::low(), Lim<T>::low(), Lim<T>::high(), Lim<T>::high()
+			}) const
+		{
+			if (!isNull()) {
+				auto arr = toArray<4>();
+				arr[0].readNum(left(into), left(inside), right(inside));
+				arr[1].readNum(top(into), top(inside), bottom(inside));
+				arr[2].readNum(right(into), left(into), right(inside));
+				arr[3].readNum(bottom(into), top(into), bottom(inside));
+				return true;
+			}
+			return false;
+		}
+
+		template<typename T>
+		bool readEdges(
+			Rect<T> &into,
+			Rect<T> min = {0.0f, 0.0f, 0.0f, 0.0f},
+			Rect<T> max = {
+				Lim<T>::high(), Lim<T>::high(), Lim<T>::high(), Lim<T>::high()
+			}) const
+		{
+			if (!isNull()) {
+				auto arr = toArray<4>();
+				arr[0].readNum(left(into), left(min), left(max));
+				arr[1].readNum(top(into), top(min), top(max));
+				arr[2].readNum(right(into), right(min), right(max));
+				arr[3].readNum(bottom(into), bottom(min), bottom(max));
+				return true;
+			}
+			return false;
+		}
+
+		std::string toString() const
+		{
+			if (!m_value.isString()) {
+				throwTypeException("string");
+			}
+			return m_value.asString();
+		}
+
+		bool readString(std::string &into) const
+		{
+			if (!isNull()) {
+				into = toString();
+				return true;
+			}
+			return false;
+		}
+
+		std::string toId(const char *allowed_chars, bool allow_empty) const;
+
+		bool readId(std::string &into, const char *allowed_chars, bool allow_empty) const
+		{
+			if (!isNull()) {
+				into = toId(allowed_chars, allow_empty);
+				return true;
+			}
+			return false;
+		}
+
+		Color toColor() const
+		{
+			Color color;
+			if (!parseColorString(toString(), color, true)) {
+				throw JsonException(this, "Invalid color string");
+			}
+			return color;
+		}
+
+		bool readColor(Color &into) const
+		{
+			if (!isNull()) {
+				into = toColor();
+				return true;
+			}
+			return false;
+		}
+
+		template<typename T>
+		T toEnum(const EnumNameMap<T> &map) const
+		{
+			std::string name = toString();
+			T value;
+			if (!str_to_enum(&value, map, name.c_str())) {
+				throw JsonException(this, "Invalid enum value");
+			}
+			return value;
+		}
+
+		template<typename T>
+		bool readEnum(T &into, const EnumNameMap<T> &map) const
+		{
+			if (!isNull()) {
+				into = toEnum(map);
+				return true;
+			}
+			return false;
+		}
+
+		std::vector<JsonReader> toVector() const;
+		std::vector<JsonReader> toVector(size_t size) const;
+		std::vector<JsonReader> toVector(size_t min, size_t max) const;
+
+		template<typename Container>
+		std::vector<JsonReader> toVector(const Container &sizes) const
+		{
+			checkArrayType();
+			if (std::find(sizes.begin(), sizes.end(), m_value.size()) == sizes.end()) {
+				throw JsonException(this, "Expected array to have size of one of "s +
+						str_join(sizes, ", "));
+			}
+			return toVector();
+		}
+
+		template<size_t N>
+		std::array<JsonReader, N> toArray() const
+		{
+			checkArrayType();
+			if (m_value.size() != N) {
+				throw JsonException(this, "Expected array to have size "s + std::to_string(N));
+			}
+
+			std::array<JsonReader, N> arr;
+			for (size_t i = 0; i < N; i++) {
+				arr[i] = JsonReader(m_value[(Json::ArrayIndex)i], pathTo(i));
+			}
+			return arr;
+		}
+
+		std::unordered_map<std::string, JsonReader> toMap() const;
+
+		template<typename T, typename Func, typename ...Args>
+		std::vector<T> mapVector(const Func &func, Args &&...args) const
+		{
+			return map_vec<T>(toVector(std::forward<Args>(args)...), func);
+		}
+
+		template<typename T, typename Func, typename ...Args>
+		bool readVector(std::vector<T> &into, const Func &func, Args &&...args) const
+		{
+			if (!isNull()) {
+				into = mapVector<T>(func, std::forward<Args>(args)...);
+				return true;
+			}
+			return false;
+		}
+
+		template<typename T, typename Func, typename ...Args>
+		std::unordered_set<T> mapSet(const Func &func, Args &&...args) const
+		{
+			return map_set<T>(toVector(std::forward<Args>(args)...), func);
+		}
+
+		template<typename T, typename Func, typename ...Args>
+		bool readSet(std::unordered_set<T> &into, const Func &func, Args &&...args) const
+		{
+			if (!isNull()) {
+				into = mapSet<T>(func, std::forward<Args>(args)...);
+				return true;
+			}
+			return false;
+		}
+
+		template<typename T, size_t N, typename Func>
+		bool readArray(std::array<T, N> &into, const Func &func) const
+		{
+			if (!isNull()) {
+				auto arr = toArray<N>();
+				for (size_t i = 0; i < N; i++) {
+					func(arr[i], into[i]);
+				}
+				return true;
+			}
+			return false;
+		}
+
+	private:
+		std::string pathTo(size_t index) const
+		{
+			return m_path + '[' + std::to_string(index) + ']';
+		}
+
+		std::string pathTo(const std::string &key) const
+		{
+			return m_path + '[' + fastWriteJson(Json::Value(key)) + ']';
+		}
+
+		void checkArrayType() const
+		{
+			if (!m_value.isArray()) {
+				throwTypeException("array");
+			}
+		}
+
+		void throwTypeException(const std::string &type) const
+		{
+			throw JsonException(this, "Expected value of type \""s + type + "\"");
+		}
+	};
+
+	class JsonWriter
+	{
+		static Json::Value array()
+		{
+			return Json::Value(Json::arrayValue);
+		}
+
+		static Json::Value object()
+		{
+			return Json::Value(Json::objectValue);
+		}
+
+		static Json::Value fromBool(bool value)
+		{
+			return Json::Value(value);
+		}
+
+		template<typename T>
+		static Json::Value fromNum(T num)
+		{
+			return Json::Value(num);
+		}
+
+		template<typename T>
+		static Json::Value fromVec(const Vec<T> &vec)
+		{
+			Json::Value json = array();
+			json[0] = fromNum(vec.X);
+			json[1] = fromNum(vec.Y);
+			return json;
+		}
+
+		template<typename T>
+		static Json::Value fromDim(const Dim<T> &dim)
+		{
+			Json::Value json = array();
+			json[0] = fromNum(dim.Width);
+			json[1] = fromNum(dim.Height);
+			return json;
+		}
+
+		template<typename T>
+		static Json::Value fromRect(const Rect<T> &rect)
+		{
+			Json::Value json = array();
+			json[0] = fromNum(left(rect));
+			json[1] = fromNum(top(rect));
+			json[2] = fromNum(right(rect));
+			json[3] = fromNum(bottom(rect));
+			return json;
+		}
+
+		template<typename T>
+		static Json::Value fromEdges(const Rect<T> &edges)
+		{
+			return fromRect(edges);
+		}
+
+		static Json::Value fromString(const std::string &str)
+		{
+			return Json::Value(str);
+		}
+
+		static Json::Value fromId(const std::string &str)
+		{
+			return fromString(str);
+		}
+
+		static Json::Value fromColor(Color color)
+		{
+			return Json::Value(to_color_string(color));
+		}
+
+		template<typename T>
+		static Json::Value fromEnum(T value, const EnumNameMap<T> &map)
+		{
+			const char *name = enum_to_str(map, value);
+			sanity_check(name != nullptr);
+			return Json::Value(name);
+		}
+
+		template<typename Container>
+		static Json::Value fromList(const Container &cont)
+		{
+			Json::Value json = array();
+			for (const auto &value : cont) {
+				json.append(value);
+			}
+			return json;
+		}
+
+		template<typename Map>
+		static Json::Value fromMap(const Map &map)
+		{
+			Json::Value json = JsonWriter::object();
+			for (const auto &pair : map) {
+				json[std::to_string(pair.first)] = pair.second;
+			}
+			return json;
+		}
+	};
+}

--- a/src/gui/manager.cpp
+++ b/src/gui/manager.cpp
@@ -1,0 +1,112 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "manager.h"
+
+#include "elem_registry.h"
+#include "util/string.h"
+
+namespace ui
+{
+	constexpr EnumNameMap<bool> ENV_TYPE_MAP = {
+		{"gui", false},
+		{"hud", true}
+	};
+
+	Env &Manager::getEnv(const std::string &id)
+	{
+		auto it = m_envs.find(id);
+		if (it == m_envs.end()) {
+			throw BadUiException("No env exists with ID \""s + id + "\"");
+		}
+		return *it->second;
+	}
+
+	void Manager::drawAll()
+	{
+		for (auto &pair : m_envs) {
+			pair.second->drawAll();
+		}
+	}
+
+	void Manager::applyJson(const JsonReader &json)
+	{
+		if (auto edit = json["edit"]) {
+			if (!edit.toBool()) {
+				resetAll();
+			}
+		}
+
+		std::unordered_map<std::string, std::unique_ptr<Env>> old_envs;
+		m_envs.swap(old_envs);
+
+		for (const auto &env : json["envs"].toVector()) {
+			std::string id = env["id"].toId(MAIN_ID_CHARS, false);
+			bool is_hud = env["type"].toEnum(ENV_TYPE_MAP);
+
+			bool edit = false;
+			json["edit"].readBool(edit);
+
+			if (m_envs.count(id)) {
+				throw BadUiException("Redefinition of environment with ID \""s +
+						id + "\"");
+			}
+
+			if (edit) {
+				if (!old_envs.count(id)) {
+					throw BadUiException("Attempt to edit a non-existent "
+							"environment \""s + id + "\"");
+				}
+
+				std::unique_ptr<Env> old_env = std::move(old_envs.at(id));
+				if (old_env->isHud() != is_hud) {
+					throw BadEnvException(old_env.get(),
+							"Attempt to edit an environment with type \""s +
+							enum_to_str(ENV_TYPE_MAP, old_env->isHud()) +
+							"\" with a different type of \"" +
+							enum_to_str(ENV_TYPE_MAP, is_hud) + "\"");
+				}
+
+				m_envs.emplace(id, std::move(old_env));
+			} else {
+				m_envs.emplace(id, std::make_unique<Env>(id, is_hud));
+			}
+
+			m_envs.at(id)->applyJson(env);
+		}
+
+		m_active_env = json["active_env"].toId(MAIN_ID_CHARS, true);
+		if (m_active_env != NO_ID) {
+			getEnv(m_active_env);
+		}
+	}
+
+	float Manager::getPixelSize(bool is_hud) const
+	{
+		if (m_gui_pixel_size == 0.0f) {
+			float base_size = RenderingEngine::getDisplayDensity();
+			m_gui_pixel_size = base_size * g_settings->getFloat("gui_scaling");
+			m_hud_pixel_size = base_size * g_settings->getFloat("hud_scaling");
+		}
+
+		return (is_hud) ? m_hud_pixel_size : m_gui_pixel_size;
+	}
+
+	Manager g_manager;
+}

--- a/src/gui/manager.h
+++ b/src/gui/manager.h
@@ -1,0 +1,111 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "client/client.h"
+#include "client/renderingengine.h"
+#include "elem.h"
+#include "env.h"
+#include "ui_types.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+using namespace std::string_literals;
+
+namespace ui
+{
+	struct BadUiException : UiException
+	{
+		BadUiException(const std::string &message) :
+			UiException("Bad UI: "s + message)
+		{}
+	};
+
+	class Manager
+	{
+	private:
+		/* We store the Envs in unique_ptrs because we have references to an Env
+		 * in each Elem, so they need to have the same memory location at all
+		 * times. Since we move them around between maps, this is not true
+		 * without the unique_ptrs.
+		 */
+		std::unordered_map<std::string, std::unique_ptr<Env>> m_envs;
+		std::string m_active_env = NO_ID;
+
+		Client *m_client = nullptr;
+
+		mutable float m_gui_pixel_size = 0.0f; // Cached value
+		mutable float m_hud_pixel_size = 0.0f; // Cached value
+
+	public:
+		Manager() = default;
+
+		Manager(const Manager &) = delete;
+		Manager &operator=(const Manager &) = delete;
+
+		bool hasEnv(const std::string &id)
+		{
+			return m_envs.count(id);
+		}
+
+		Env &getEnv(const std::string &id);
+
+		void drawAll();
+
+		void resetAll()
+		{
+			m_envs.clear();
+			m_active_env = NO_ID;
+		}
+
+		void applyJson(const JsonReader &json);
+
+		Client *getClient()
+		{
+			return m_client;
+		}
+
+		const Client *getClient() const
+		{
+			return m_client;
+		}
+
+		void setClient(Client *client)
+		{
+			m_client = client;
+		}
+
+		Texture getTexture(const std::string &name)
+		{
+			return Texture(m_client->tsrc()->getTexture(name));
+		}
+
+		u32 getTime() const
+		{
+			return RenderingEngine::get_raw_device()->getTimer()->getTime();
+		}
+
+		float getPixelSize(bool is_hud) const;
+	};
+
+	extern Manager g_manager;
+}

--- a/src/gui/ui_types.h
+++ b/src/gui/ui_types.h
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "debug.h"
 #include "exceptions.h"
 #include "irrlichttypes_extrabloated.h"
 
@@ -61,10 +62,76 @@ namespace ui
 	Rect<T> add_rect_edges(const Rect<T> &rect, const Rect<T> &edges)
 	{
 		return Rect<T>(
-			left(rect) + left(edges),
-			top(rect) + top(edges),
-			right(rect) - right(edges),
-			bottom(rect) - bottom(edges)
+			rect.UpperLeftCorner - edges.UpperLeftCorner,
+			rect.LowerRightCorner + edges.LowerRightCorner
+		);
+	}
+
+	template<typename T>
+	Rect<T> sub_rect_edges(const Rect<T> &rect, const Rect<T> &edges)
+	{
+		return Rect<T>(
+			rect.UpperLeftCorner + edges.UpperLeftCorner,
+			rect.LowerRightCorner - edges.LowerRightCorner
+		);
+	}
+
+	template<typename T>
+	Rect<T> add_edges(const Rect<T> &lhs, const Rect<T> &rhs)
+	{
+		return Rect<T>(
+			lhs.UpperLeftCorner + rhs.UpperLeftCorner,
+			lhs.LowerRightCorner + rhs.LowerRightCorner
+		);
+	}
+
+	template<typename T>
+	Rect<T> sub_edges(const Rect<T> &lhs, const Rect<T> &rhs)
+	{
+		return Rect<T>(
+			lhs.UpperLeftCorner - rhs.UpperLeftCorner,
+			lhs.LowerRightCorner - rhs.LowerRightCorner
+		);
+	}
+
+	template<typename T>
+	Dim<T> edges_dim(const Rect<T> &edges)
+	{
+		return Dim<T>(
+			left(edges) + right(edges),
+			top(edges) + bottom(edges)
+		);
+	}
+
+	template<typename T>
+	const T &dim_at(const Dim<T> &dim, size_t index)
+	{
+		sanity_check(index < 2);
+		return index == 1 ? dim.Height : dim.Width;
+	}
+
+	template<typename T>
+	T &dim_at(Dim<T> &dim, size_t index)
+	{
+		sanity_check(index < 2);
+		return index == 1 ? dim.Height : dim.Width;
+	}
+
+	template<typename T>
+	Dim<T> dim_min(const Dim<T> &first, const Dim<T> &second)
+	{
+		return Dim<T>(
+			std::min(first.Width, second.Width),
+			std::min(first.Height, second.Height)
+		);
+	}
+
+	template<typename T>
+	Dim<T> dim_max(const Dim<T> &first, const Dim<T> &second)
+	{
+		return Dim<T>(
+			std::max(first.Width, second.Width),
+			std::max(first.Height, second.Height)
 		);
 	}
 

--- a/src/gui/ui_types.h
+++ b/src/gui/ui_types.h
@@ -1,0 +1,64 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "exceptions.h"
+#include "irrlichttypes_extrabloated.h"
+
+namespace ui
+{
+	template<typename T>
+	using Vec = core::vector2d<T>;
+	template<typename T>
+	using Dim = core::dimension2d<T>;
+	template<typename T>
+	using Rect = core::rect<T>;
+
+	using Color = video::SColor;
+
+	const Color BLANK = 0x00000000;
+	const Color WHITE = 0xFFFFFFFF;
+	const Color BLACK = 0xFF000000;
+
+	template<typename T>
+	T &left(Rect<T> &rect) { return rect.UpperLeftCorner.X; }
+	template<typename T>
+	const T &left(const Rect<T> &rect) { return rect.UpperLeftCorner.X; }
+
+	template<typename T>
+	T &top(Rect<T> &rect) { return rect.UpperLeftCorner.Y; }
+	template<typename T>
+	const T &top(const Rect<T> &rect) { return rect.UpperLeftCorner.Y; }
+
+	template<typename T>
+	T &right(Rect<T> &rect) { return rect.LowerRightCorner.X; }
+	template<typename T>
+	const T &right(const Rect<T> &rect) { return rect.LowerRightCorner.X; }
+
+	template<typename T>
+	T &bottom(Rect<T> &rect) { return rect.LowerRightCorner.Y; }
+	template<typename T>
+	const T &bottom(const Rect<T> &rect) { return rect.LowerRightCorner.Y; }
+
+	struct UiException : BaseException
+	{
+		UiException(const std::string &message) : BaseException(message) {}
+	};
+}

--- a/src/gui/ui_types.h
+++ b/src/gui/ui_types.h
@@ -57,8 +57,26 @@ namespace ui
 	template<typename T>
 	const T &bottom(const Rect<T> &rect) { return rect.LowerRightCorner.Y; }
 
+	template<typename T>
+	Rect<T> add_rect_edges(const Rect<T> &rect, const Rect<T> &edges)
+	{
+		return Rect<T>(
+			left(rect) + left(edges),
+			top(rect) + top(edges),
+			right(rect) - right(edges),
+			bottom(rect) - bottom(edges)
+		);
+	}
+
 	struct UiException : BaseException
 	{
 		UiException(const std::string &message) : BaseException(message) {}
 	};
+
+	constexpr const char *NO_ID = "";
+
+	constexpr const char *MAIN_ID_CHARS =
+			"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-";
+	constexpr const char *VIRT_ID_CHARS =
+			"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-@";
 }

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -519,10 +519,7 @@ int ModApiUtil::l_colorspec_to_colorstring(lua_State *L)
 
 	video::SColor color(0);
 	if (read_color(L, 1, &color)) {
-		char colorstring[10];
-		snprintf(colorstring, 10, "#%02X%02X%02X%02X",
-			color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha());
-		lua_pushstring(L, colorstring);
+		lua_pushstring(L, to_color_string(color).c_str());
 		return 1;
 	}
 

--- a/src/util/functional.h
+++ b/src/util/functional.h
@@ -1,0 +1,86 @@
+/*
+Minetest
+Copyright (C) 2022 v-rob, Vincent Robinson <robinsonvincent89@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <iterator>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace pl = std::placeholders;
+
+template<typename T, typename Container, typename Func>
+std::vector<T> map_vec(const Container &cont, const Func &func)
+{
+	std::vector<T> result;
+	result.reserve(cont.size());
+
+	std::transform(cont.begin(), cont.end(), std::back_inserter(result), func);
+	return result;
+}
+
+template<typename T, typename Container, typename Func>
+std::unordered_set<T> map_set(const Container &cont, const Func &func)
+{
+	std::unordered_set<T> result;
+	result.reserve(cont.size());
+
+	std::transform(cont.begin(), cont.end(), std::inserter(result, result.begin()), func);
+	return result;
+}
+
+template<typename T, size_t N, typename Value, typename Func>
+std::array<T, N> map_array(const std::array<Value, N> &cont, const Func &func)
+{
+	std::array<T, N> result;
+	std::transform(cont.begin(), cont.end(), result.begin(), func);
+	return result;
+}
+
+template<typename K, typename V, typename Map, typename Func>
+std::unordered_map<K, V> map_pair_map(const Map &map, const Func &func)
+{
+	std::unordered_map<K, V> result;
+	result.reserve(map.size());
+
+	for (const auto &pair : map) {
+		result.insert(func(pair.first, pair.second));
+	}
+	return result;
+}
+
+template<typename K, typename V, typename Map, typename Func>
+std::unordered_map<K, V> map_key_map(const Map &map, const Func &func)
+{
+	return map_pair_map<K, V>(map, [&](auto key, auto value) {
+		return std::make_pair(key, func(value));
+	});
+}
+
+template<typename K, typename V, typename Map, typename Func>
+std::unordered_map<K, V> map_value_map(const Map &map, const Func &func)
+{
+	return map_pair_map<K, V>(map, [&](auto key, auto value) {
+		return std::make_pair(func(key), value);
+	});
+}

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -583,6 +583,14 @@ bool parseColorString(const std::string &value, video::SColor &color, bool quiet
 	return success;
 }
 
+std::string to_color_string(video::SColor color)
+{
+	char colorstring[10];
+	snprintf(colorstring, 10, "#%02X%02X%02X%02X",
+			color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha());
+	return colorstring;
+}
+
 void str_replace(std::string &str, char from, char to)
 {
 	std::replace(str.begin(), str.end(), from, to);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <vector>
 #include <map>
 #include <sstream>
+#include <initializer_list>
 #include <iomanip>
 #include <cctype>
 #include <unordered_map>
@@ -82,7 +83,7 @@ char *mystrtok_r(char *s, const char *sep, char **lasts);
 u64 read_seed(const char *str);
 bool parseColorString(const std::string &value, video::SColor &color, bool quiet,
 		unsigned char default_alpha = 0xff);
-
+std::string to_color_string(video::SColor color);
 
 /**
  * Returns a copy of \p str with spaces inserted at the right hand side to ensure
@@ -710,12 +711,13 @@ inline const std::string duration_to_string(int sec)
 }
 
 /**
- * Joins a vector of strings by the string \p delimiter.
+ * Joins a container of values that can be written to a stream with the string
+ * \p delimiter.
  *
  * @return A std::string
  */
-inline std::string str_join(const std::vector<std::string> &list,
-		const std::string &delimiter)
+template<typename Container>
+std::string str_join(const Container &list, const std::string &delimiter)
 {
 	std::ostringstream oss;
 	bool first = true;
@@ -761,3 +763,29 @@ std::string sanitizeDirName(const std::string &str, const std::string &optional_
  * brackets (e.g. "a\x1eb" -> "a<1e>b").
  */
 void safe_print_string(std::ostream &os, const std::string &str);
+
+template<typename T>
+using EnumNameMap = std::initializer_list<std::pair<const char *, T>>;
+
+template<typename T>
+bool str_to_enum(T *value, const EnumNameMap<T> &map, const char *name)
+{
+	for (const auto &pair : map) {
+		if (strcmp(pair.first, name) == 0) {
+			*value = pair.second;
+			return true;
+		}
+	}
+	return false;
+}
+
+template<typename T>
+const char *enum_to_str(const EnumNameMap<T> &map, T value)
+{
+	for (const auto &pair : map) {
+		if (pair.second == value) {
+			return pair.first;
+		}
+	}
+	return nullptr;
+}


### PR DESCRIPTION
They say good things come to those who wait.  Or maybe v-rob's just a perfectionist or lazy or something.  You decide.  But in any case, I'm tenacious, so here's the current code for the fabled _Formspec Replacement_<sup> TM</sup>.  This is the real deal, the actual base that everything's going to be built off of.

Will resolve #6527, if you couldn't guess.  But it's also the HUD replacement.

Before anyone asks (and I know someone will), there is no frontend API, and there won't be for some time.  I care about the client code and the JSON backend right now.  If you want a frontend, write it yourself for now.

## Screenshots?

Sure, here's a lame screenshot of round-mode tiling of textures with a partially transparent fill color of red via the `Design` class, set as the background of a centered `Elem` with a size of half the screen:

![image](https://user-images.githubusercontent.com/31123645/199861831-1bde5cd9-a11a-43f7-9cef-3592b7a99321.png)

## Documentation?

Nope.  I haven't taken the time yet, but it's high on the TODO list so people can actually test this ~~garbage~~stuff out if they want to.  I wanted to get this PR out here today, but I just spent the entire day debugging a particularly nasty piece of undefined behaviour with only `std::cout` statements because Visual Studio is no help, and so I didn't feel like writing documentation.

The same rationale applies to a test program and better screenshots.

## To do

Lots and lots.  Each of these is approximately a commit of its own except for the later ones where everything's still fuzzy.

- [X] JSON serializer and deserializer
- [X] Irrlicht texture wrapper so Irrlicht texture management, drawing, clipping, and stuff are safely abstracted away.
- [X] Basic UI: `Manager` manages a list of `Env`s, `Env` manages a hierarchy of `Elem`s, `Elem`s can draw basic stuff to the screen. Send the UI from the server via a JSON string through `minetest.show_formspec()` with a formname of `__builtin:__ui_update`.
- [X] Layout with axis layout system.
- [ ] Make documentation for the JSON serialization structure and layout system.
- [ ] Make new GUI drawing interact well with existing GUI instead of drawing right on top--this includes interfacing properly with z-indexing for the HUD.
- [ ] Create event handling infrastructure. Create Button class, sans text, to be the first non-Elem element. Send event handling to server via `minetest.register_on_player_receive_fields()` with a formname of `__builtin:__ui_event`.
- [ ] Implement state-based styling. Create `Style` element or something in `Env` to allow styling based on universal, element type, ID, class, state. Child/parent/other hierarchy selectors may be good extensions, but are by no means necessary at this stage. Remove inline styles from JSON; equivalent is style by ID (since all elements have IDs). Implement equivalent of formspec prepends for styles in `Manager`.
- [ ] Add a virtual element system, e.g. for buttons in scrollbars and for scrollbars in scroll containers. Allow styling them with things like CSS pseudo-selectors. Implement both scrollbars and scroll containers.
- [ ] Implement text with HarfBuzz and ICU. Implement static text fields and text in buttons.
- [ ] Create all the other elements. There's probably a few steps inside here :)
- [ ] Maybe improve styling further wishlist.  Child/parent/other hierarchy selectors would be useful.  Animations would be awesome.
- [ ] Make a proper Lua API at some point during this process instead of just having a JSON backend.
- [ ] Probably should make a proper network process for sending the UI instead of hijacking existing formspec APIs. But for now, _ehh_, who cares?

## How to test

`minetest.show_formspec(player, "__builtin:__ui_update", "backend JSON data")`.  Yes, this is clunky for now, get over it.  I appropriated the formspec API temporarily because it was easy to do that.