### PR TITLE
Alternative II: Activate objects immediately after a player joined

### DIFF
--- a/src/emerge.h
+++ b/src/emerge.h
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define BLOCK_EMERGE_ALLOW_GEN   (1 << 0)
 #define BLOCK_EMERGE_FORCE_QUEUE (1 << 1)
+#define BLOCK_EMERGE_ACTIVATE (1 << 2)
 
 #define EMERGE_DBG_OUT(x) {                            \
 	if (enable_mapgen_debug_info)                      \
@@ -174,7 +175,8 @@ public:
 		session_t peer_id,
 		v3s16 blockpos,
 		bool allow_generate,
-		bool ignore_queue_limits=false);
+		bool ignore_queue_limits=false,
+		bool activate_on_load=false);
 
 	bool enqueueBlockEmergeEx(
 		v3s16 blockpos,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1558,11 +1558,11 @@ MapBlock * ServerMap::emergeBlock(v3s16 p, bool create_blank)
 	return NULL;
 }
 
-MapBlock *ServerMap::getBlockOrEmerge(v3s16 p3d)
+MapBlock *ServerMap::getBlockOrEmerge(v3s16 p3d, bool activate_on_load)
 {
 	MapBlock *block = getBlockNoCreateNoEx(p3d);
 	if (block == NULL)
-		m_emerge->enqueueBlockEmerge(PEER_ID_INEXISTENT, p3d, false);
+		m_emerge->enqueueBlockEmerge(PEER_ID_INEXISTENT, p3d, false, false, activate_on_load);
 
 	return block;
 }

--- a/src/map.h
+++ b/src/map.h
@@ -374,7 +374,7 @@ public:
 		- Memory
 		- Emerge Queue (deferred disk or generate)
 	*/
-	MapBlock *getBlockOrEmerge(v3s16 p3d);
+	MapBlock *getBlockOrEmerge(v3s16 p3d, bool activate_on_load = false);
 
 	bool isBlockInQueue(v3s16 pos);
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1382,7 +1382,7 @@ void ServerEnvironment::step(float dtime)
 		*/
 
 		for (const v3s16 &p: blocks_added) {
-			MapBlock *block = m_map->getBlockOrEmerge(p);
+			MapBlock *block = m_map->getBlockOrEmerge(p, m_force_update_active_blocks);
 			if (!block) {
 				// TODO: The blocks removed here will only be picked up again
 				// on the next cycle. To minimize the latency of objects being

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -312,6 +312,11 @@ public:
 	void activateBlock(MapBlock *block, u32 additional_dtime=0);
 
 	/*
+		Convert stored objects from block to active
+	*/
+	void activateObjects(MapBlock *block, u32 dtime_s);
+
+	/*
 		{Active,Loading}BlockModifiers
 		-------------------------------------------
 	*/
@@ -416,11 +421,6 @@ private:
 		Remove all objects that satisfy (isGone() && m_known_by_count==0)
 	*/
 	void removeRemovedObjects();
-
-	/*
-		Convert stored objects from block to active
-	*/
-	void activateObjects(MapBlock *block, u32 dtime_s);
 
 	/*
 		Convert objects that are not in active blocks to static.


### PR DESCRIPTION
Alternative to #12925

See motivation and test instructions there.

Note that 
1. On objects for blocks requested as active blocks immediately after a player joined are expedited.
2. It's not activating the block, but just its objects to avoid multiple block activation.
