### PR TITLE
Resize hotbar immediately before drawing

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1204,8 +1204,6 @@ void Game::run()
 		processQueues();
 
 		m_game_ui->clearInfoText();
-		hud->resizeHotbar();
-
 
 		updateProfilers(stats, draw_times, dtime);
 		processUserInput(dtime);

--- a/src/client/render/plain.cpp
+++ b/src/client/render/plain.cpp
@@ -52,6 +52,7 @@ void DrawHUD::run(PipelineContext &context)
 		if (context.draw_crosshair)
 			context.hud->drawCrosshair();
 
+		context.hud->resizeHotbar();
 		context.hud->drawHotbar(context.client->getEnv().getLocalPlayer()->getWieldIndex());
 		context.hud->drawLuaElements(context.client->getCamera()->getOffset());
 		context.client->getCamera()->drawNametags();

--- a/src/client/render/plain.cpp
+++ b/src/client/render/plain.cpp
@@ -49,10 +49,11 @@ void DrawHUD::run(PipelineContext &context)
 		if (context.shadow_renderer)
 			context.shadow_renderer->drawDebug();
 
+		context.hud->resizeHotbar();
+
 		if (context.draw_crosshair)
 			context.hud->drawCrosshair();
 
-		context.hud->resizeHotbar();
 		context.hud->drawHotbar(context.client->getEnv().getLocalPlayer()->getWieldIndex());
 		context.hud->drawLuaElements(context.client->getCamera()->getOffset());
 		context.client->getCamera()->drawNametags();


### PR DESCRIPTION
Avoids incorrect rendering when hotbar uses outdated screen dimensions

Fixes #12852.

## To do

This PR is Ready for Review.

## How to test

1. Set fps = 2
2. Start the game (assuming you have at least one node item in the inventory)
      - NO fullscreen inventory item should be rendered in the first frame.
3. Press ESC
4. Resize the window quickly (maximize/restore)
      - no fullscreen inventory item should be rendered in any frame.

