### PR TITLE
add ads mouse sensitivity setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -112,6 +112,10 @@ invert_mouse (Invert mouse) bool false
 #    Mouse sensitivity multiplier.
 mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
 
+#    ADS mouse sensitivity multiplier.
+ads_sensitivity (ADS sensitivity) float 1.0 0.0 100.0
+
+
 [*Touchscreen]
 
 #    The length in pixels it takes for touch screen interaction to start.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -74,6 +74,10 @@
 #    type: float min: 0.001 max: 10
 # mouse_sensitivity = 0.2
 
+#    ADS mouse sensitivity multiplier.
+#    type: float
+# ADS_sensitivity = 1.0
+
 ## Touchscreen
 
 #    The length in pixels it takes for touch screen interaction to start.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -293,6 +293,7 @@ void set_default_settings()
 	// Input
 	settings->setDefault("invert_mouse", "false");
 	settings->setDefault("mouse_sensitivity", "0.2");
+	settings->setDefault("ads_sensitivity", "1.0");
 	settings->setDefault("repeat_place_time", "0.25");
 	settings->setDefault("safe_dig_and_place", "false");
 	settings->setDefault("random_input", "false");


### PR DESCRIPTION
Improved version of [this pr](https://github.com/minetest/minetest/pull/12483), couldn't find a way to change the branch for it. All changes have been squashed and rebased

this adds a setting called FOV mouse sensitivity that adjusts how the mouse sensitivity behaves to fov changes

currently there's an system in place to try and keep screen movement distance equal with any fov, but this is more disorienting to some players than keeping the same amount of rotation (for example me)

at 1.0, the behavior is unchanged, at 0.0, it keeps the same rotations

a more common name for this would be ADS sensitivity (aim down sights) but this implies a shooter game, so i didn't go for this name.

## To do

This PR is Ready for Review.

- [ ] possibly change the name to something clearer
- [ ] fix some other code issues

## How to test

for checking whether mouse sensitivity here increases or decreases, measure the angles, for example by checking the mouse distance for a 360 rotation

- at any negative values, the sensitivity should decrease with higher fov
- at 0.0, the sensitivity should stay the exact same for all fov
- at 1.0, the sensitivity should behave exactly as it does originally
- at any positive value, the sensitivity should increase for higher fov