### PR TITLE
Fix get_tool_wear_after_use for one use (insta-break)

### DIFF
--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -166,8 +166,8 @@ int ModApiUtil::l_get_tool_wear_after_use(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	u32 uses = readParam<int>(L, 1);
 	u16 initial_wear = readParam<int>(L, 2, 0);
-	u16 wear = calculateResultWear(uses, initial_wear);
-	lua_pushnumber(L, wear);
+	u32 add_wear = calculateResultWear(uses, initial_wear);
+	lua_pushnumber(L, add_wear);
 	return 1;
 }
 


### PR DESCRIPTION
https://github.com/minetest/minetest/blob/6191bafcadc21277be5527ed1ac05f7902e710ad/doc/lua_api.txt#L3683-L3688

Currently `minetest.get_tool_wear_after_use(1, 0)` (tool should break after 1 use and doesn't have any wear yet) returns `0`. Actually it should return `65536` in order to instantly break the tool. The wrong return value is caused by `ModApiUtil::l_get_tool_wear_after_use` incorrectly casting the return value of `calculateResultWear` from `u32` to `u16`. This PR fixes that.

- Does it resolve any reported issue?
  No, I thought it was small enough not to open an issue.

- If not a bug fix, why is this PR needed? What usecases does it solve?
  It's a bug fix.

## To do

This PR is Ready for Review.

## How to test

Try `minetest.get_tool_wear_after_use(1, 0)`. It should return `65536`.