### PR TITLE
[Fix] The trusted mods are prohibited from using IO functions.

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -737,6 +737,14 @@ bool ScriptApiSecurity::checkPath(lua_State *L, const char *path,
 	return false;
 }
 
+bool ScriptApiSecurity::isInWhitelist(const std::string &setting, const std::string &mod_name)
+{
+	std::string value = g_settings->get(setting);
+	value.erase(std::remove(value.begin(), value.end(), ' '), value.end());
+	auto mod_list = str_split(value, ',');
+	return CONTAINS(mod_list, mod_name);
+}
+
 bool ScriptApiSecurity::checkWhitelisted(lua_State *L, const std::string &setting)
 {
 	assert(str_starts_with(setting, "secure."));
@@ -752,11 +760,7 @@ bool ScriptApiSecurity::checkWhitelisted(lua_State *L, const std::string &settin
 	lua_pop(L, 1);  // Pop mod name
 	if (mod_name.empty()) return false;
 
-	std::string value = g_settings->get(setting);
-	value.erase(std::remove(value.begin(), value.end(), ' '), value.end());
-	auto mod_list = str_split(value, ',');
-
-	return CONTAINS(mod_list, mod_name);
+	return isInWhitelist(setting, mod_name);
 }
 
 

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -520,10 +520,14 @@ std::string inline _get_mod_name_from_debug(lua_Debug *info)
 	std::string GAME_DIR = BIN_DIR + ".." + DIR_DELIM + "games" + DIR_DELIM;
 
 
+	// Find the first "/bin/" string posistion.
 	size_t bin_pos = src.find(BIN_DIR);
+	// Find the first "/bin/../builtin/" string posistion.
 	size_t found = src.find(BUILTIN_DIR);
 	if (found != std::string::npos) {
 		// Check the path whether be faked.
+		// the found position should be different from bin_pos if it's faked
+		// eg, "/bin/../mods/faked_mod/bin/../builtin/"
 		if (bin_pos == found) {
 			mod_name = BUILTIN_MOD_NAME;
 		}
@@ -608,6 +612,8 @@ std::string inline _get_real_caller_mod_name(lua_State *L)
 			if (i == iMin) return executor_mod_name;
 
 			// get the first event trigger
+			// Sometimes, the initiator of the action is not a builtin module, but an event trigger from a third-party module. For example, triggered by `formspecs`.
+			// And it should be in the prev_mod's dependencies or optional dependencies.
 			while (i>iMin) {
 				result = caller_mods.at(i);
 				prev_mod_name = caller_mods.at(i-1);

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -796,7 +796,9 @@ int ScriptApiSecurity::sl_g_load(lua_State *L)
 	luaL_checktype(L, 1, LUA_TFUNCTION);
 	if (!lua_isnone(L, 2)) {
 		luaL_checktype(L, 2, LUA_TSTRING);
-		chunk_name = lua_tostring(L, 2);
+		const char *_chunk_name = lua_tostring(L, 2);
+		std::string BIN_DIR = std::string(DIR_DELIM) + "bin" + DIR_DELIM;
+		if (!strstr(_chunk_name, BIN_DIR.c_str()) || !isSecure(L)) chunk_name = _chunk_name;
 	}
 
 	while (true) {
@@ -876,6 +878,9 @@ int ScriptApiSecurity::sl_g_loadstring(lua_State *L)
 	if (!lua_isnone(L, 2)) {
 		luaL_checktype(L, 2, LUA_TSTRING);
 		chunk_name = lua_tostring(L, 2);
+		const char *_chunk_name = lua_tostring(L, 2);
+		std::string BIN_DIR = std::string(DIR_DELIM) + "bin" + DIR_DELIM;
+		if (!strstr(_chunk_name, BIN_DIR.c_str()) || !isSecure(L)) chunk_name = _chunk_name;
 	}
 
 	size_t size;

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -596,6 +596,19 @@ std::string inline _get_real_caller_mod_name(lua_State *L)
 	return result;
 }
 
+std::string ScriptApiSecurity::get_current_modname(lua_State *L)
+{
+	std::string result;
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
+	if (lua_isstring(L, -1)) {
+		result = readParam<std::string>(L, -1);
+	} else {
+		result = _get_real_caller_mod_name(L);
+	}
+	lua_pop(L, 1);
+	return result;
+}
+
 int ScriptApiSecurity::l_get_current_modname(lua_State *L)
 {
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -564,21 +564,20 @@ std::string inline _get_real_caller_mod_name(lua_State *L)
 			bool ok = false;
 			std::string prev_mod_name;
 			std::size_t i = caller_mods.size() - 1;
+			if (i == 0) return executor_mod_name;
 			// get the first event trigger
 			while (i>0) {
 				result = caller_mods.at(i);
-				if (i > 0) {
-					prev_mod_name = caller_mods.at(i-1);
-					const ModSpec *prev_mod = gamedef->getModSpec(prev_mod_name);
-					if (!CONTAINS(prev_mod->depends, result) && !CONTAINS(prev_mod->optdepends, result)) {
-						break;
-					}
-					if (prev_mod_name == executor_mod_name) {
-						ok = true;
-						// this means the second is the trigger, the first is caller for no more callers
-						if (i == 1) result = executor_mod_name;
-						break;
-					}
+				prev_mod_name = caller_mods.at(i-1);
+				const ModSpec *prev_mod = gamedef->getModSpec(prev_mod_name);
+				if (!CONTAINS(prev_mod->depends, result) && !CONTAINS(prev_mod->optdepends, result)) {
+					break;
+				}
+				if (prev_mod_name == executor_mod_name) {
+					ok = true;
+					// this means the second is the trigger, the first is caller for no more callers
+					if (i == 1) result = executor_mod_name;
+					break;
 				}
 				i--;
 			}

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -570,12 +570,11 @@ std::string inline _get_real_caller_mod_name(lua_State *L)
 			while (i>0) {
 				result = caller_mods.at(i);
 				prev_mod_name = caller_mods.at(i-1);
-				i--;
-
 				const ModSpec *prev_mod = gamedef->getModSpec(prev_mod_name);
 				if (!CONTAINS(prev_mod->depends, result) && !CONTAINS(prev_mod->optdepends, result)) {
 					break;
 				}
+				i--;
 				if (prev_mod_name == executor_mod_name) {
 					ok = true;
 					// this means the second is the trigger, the first is caller for no more callers

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -55,9 +55,9 @@ public:
 	// Check if mod is whitelisted in the given setting
 	// This additionally checks that the mod's main file scope is executing.
 	static bool checkWhitelisted(lua_State *L, const std::string &setting);
+	static std::string get_current_modname(lua_State *L);
 	// The internal implementation of get_current_modname()
 	static int l_get_current_modname(lua_State *L);
-
 private:
 	int getThread(lua_State *L);
 	// sets the enviroment to the table thats on top of the stack

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -55,6 +55,8 @@ public:
 	// Check if mod is whitelisted in the given setting
 	// This additionally checks that the mod's main file scope is executing.
 	static bool checkWhitelisted(lua_State *L, const std::string &setting);
+	// Whether the mod_name in Whitelist
+	static bool isInWhitelist(const std::string &setting, const std::string &mod_name);
 	static std::string get_current_modname(lua_State *L);
 	// The internal implementation of get_current_modname()
 	static int l_get_current_modname(lua_State *L);

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -55,6 +55,8 @@ public:
 	// Check if mod is whitelisted in the given setting
 	// This additionally checks that the mod's main file scope is executing.
 	static bool checkWhitelisted(lua_State *L, const std::string &setting);
+	// The internal implementation of get_current_modname()
+	static int l_get_current_modname(lua_State *L);
 
 private:
 	int getThread(lua_State *L);

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_content.h"
 #include "common/c_converter.h"
 #include "cpp_api/s_base.h"
+#include "cpp_api/s_security.h"
 #include "gettext.h"
 #include "l_internal.h"
 #include "lua_api/l_nodemeta.h"
@@ -62,8 +63,7 @@ const static CSMFlagDesc flagdesc_csm_restriction[] = {
 // get_current_modname()
 int ModApiClient::l_get_current_modname(lua_State *L)
 {
-	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
-	return 1;
+	return ScriptApiSecurity::l_get_current_modname(L);
 }
 
 // get_modpath(modname)

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -384,8 +384,7 @@ int ModApiServer::l_show_formspec(lua_State *L)
 int ModApiServer::l_get_current_modname(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
-	return 1;
+	return ScriptApiSecurity::l_get_current_modname(L);
 }
 
 // get_modpath(modname)


### PR DESCRIPTION
Purpose:

It should be safe to call between modules, whether it is a trusted module or a regular module.

* When a regular mod calls a function of a trusted mod, the privilege should not be elevated.
* When a trusted mod calls a function of a regular mod, the privilege should not downgrade.

Implementation:

Use the caller stack information of LUA Debug to obtain the information of the module in which each function is located, and then check the dependencies between the modules to finally decide whether the call can be trusted.

* `ScriptApiSecurity::checkPath` can correctly get caller's mod name now.
  * Allow writing to the directory where the mod is located,
* `ScriptApiSecurity::checkWhitelisted` can correctly get caller's mod name now.
* `ScriptApiSecurity::isSecure` uses `checkWhitelisted` now.
  * The trusted mods can use the io functions directly.
* Add the static method `l_get_current_modname` and `get_current_modname` to `ScriptApiSecurity` class.
* `ModApiClient::get_current_modname` and `ModApiServer::get_current_modname` can correctly get caller's mod name.
* Can analyze whether the function is injected or not.
  * (trusted mod call a injected function) the privilege will downgrade if it is injected and comming from untrusted mod 
  * (trusted mod call a injected function) the privilege will not downgrade if it is injected and comming from trusted mod 
* Disable lua load/loadstring functions from pretending to be mod via the chunk_name parameter.
  * Only trusted mod can use chunk_name with "/bin/"
* Related: #12857, #12948

## To do

This PR is a Ready for Review.

**Note**: 

* The Lua AOP(Aspect-Oriented Programming) IO Libraries that are used indirectly still cannot access the non-secure directories or the mod directory unless these libraries are also included in the trusted_mods.
* The world mods are always untrusted here.

**Known Issues**:

* `The LUA tail calls stack issue` make the function invsible in caller stack.
  * Workaround(temporarily): disable emit tail_call directive via patch LUA/LUAJIT code.
    * Disabling tail calls makes tail recursive usage impossible ([tail recursion must be eliminated](https://www.geeksforgeeks.org/tail-call-elimination/)). Fortunately, most languages do not have such tail call functionality.

## How to test

1. Trusted mod can use the IO function to write file now.
   * Enable the `yaml`, `trusted_mod` to the world.
   * Add `trusted_mod` to `secure.trusted_mods` setting.
2. Trusted mod can not use the IO function to write file if the `injecting_mod` exists.
   * Enable the `yaml`, `trusted_mod` and `injecting_mod` to the world.
   * Add `trusted_mod` to `secure.trusted_mods` setting.
3. Trusted mod can use the IO function to write file if the `injecting_mod` exists and `injecting_mod` in the `secure.trusted_mods` setting.
   * Enable the `yaml`, `trusted_mod` and `injecting_mod` to the world.
   * Add `trusted_mod` and `injecting_mod` to `secure.trusted_mods` setting.

### The Trusted Mod For Test

trusted_mod/mod.conf:

```ini
name=trusted_mod
depends=yaml
```

trusted_mod/init.lua:

```lua
local writeYamlFile = yaml.writeFile

local function test()
  local modName = minetest.get_current_modname()
  asset(modName == "trusted_mod")
  local modPath = minetest.get_modpath(ModName) .. "/"
  writeYamlFile(ModPath .. "test.yml", "hello")
  writeYamlFile("/tmp/tmp.yml", "hi")
end

test()

--  the caller mod is detected as yaml
minetest.after(0, writeYamlFile, modPath .. "test.yml", "hello") 

local function internWriteYamlFile(path, content)
  local result = writeYamlFile(path, content)
  return result
end

--  the caller mod is detected as trusted_mod now
minetest.after(0, internWriteYamlFile, modPath .. "test.yml", "hello") 
```

### The Injecting(AOP) Mod To Test


injecting_mod/mod.conf:

```ini
name=injecting_mod
depends=yaml
```

injecting_mod/init.lua:

```lua
local writeYamlFile = yaml.writeFile
local function writeYamlFileNew(filepath, content, mode)
  local str = yaml.dump(content)
  if str then
    print(str)
  end
  return writeYamlFile(filepath, content, mode)
end
yaml.writeFile = writeYamlFileNew
```