### PR TITLE
game.conf: Add setting to use volatile a map backend

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -85,6 +85,8 @@ The game directory can contain the following files:
       (this does not work for `enable_server`).
       Only these settings are supported:
           `enable_damage`, `creative_mode`, `enable_server`.
+    * `backend`: Specifies the desired map backend for this game. If the backend is not
+      available or cannot be initialized, the default backend will be used.
     * `author`: The author of the game. It only appears when downloaded from
                 ContentDB.
     * `release`: Ignore this: Should only ever be set by ContentDB, as it is

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -85,8 +85,8 @@ The game directory can contain the following files:
       (this does not work for `enable_server`).
       Only these settings are supported:
           `enable_damage`, `creative_mode`, `enable_server`.
-    * `backend`: Specifies the desired map backend for this game. If the backend is not
-      available or cannot be initialized, the default backend will be used.
+    * `map_persistent`: Specifies whether newly created worlds should use
+      a persistent map backend. Defaults to `true` (= "sqlite3")
     * `author`: The author of the game. It only appears when downloaded from
                 ContentDB.
     * `release`: Ignore this: Should only ever be set by ContentDB, as it is

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -25,8 +25,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "util/strfnd.h"
 #include "defaultsettings.h" // for set_default_settings
-#include "map.h" // for probing supported worlds
-#include "database/database.h"
 #include "map_settings_manager.h"
 #include "util/string.h"
 
@@ -392,16 +390,8 @@ void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 		conf.set("gameid", gamespec.id);
 
 		std::string backend = "sqlite3";
-		if (gameconf.getNoEx("backend", backend)) {
-			try {
-				// Probe whether the backend is supported
-				MapDatabase *mapdb = ServerMap::createDatabase(backend, final_path, conf);
-				delete mapdb;
-			} catch (BaseException &e) {
-				backend = "sqlite3";
-				warningstream << "Game-requested map backend cannot be created. Falling back to "
-					<< backend << ". Reason: " << e.what() << std::endl;
-			}
+		if (gameconf.exists("map_persistent") && !gameconf.getBool("map_persistent")) {
+			backend = "dummy";
 		}
 		conf.set("backend", backend);
 


### PR DESCRIPTION
Fixes #11883. (by implementation)

## To do

This PR is Ready for Review.

## How to test

1. Edit `game.conf`
2. Add `map_persistent = false` (-> dummy) or `map_persistent = true` (-> sqlite3)
3. Test it.
