### PR TITLE
Add dynamic exposure correction

### DIFF
--- a/android/native/jni/Android.mk
+++ b/android/native/jni/Android.mk
@@ -194,6 +194,7 @@ LOCAL_SRC_FILES := \
 	../../src/itemdef.cpp                        \
 	../../src/itemstackmetadata.cpp              \
 	../../src/light.cpp                          \
+	../../src/lighting.cpp                       \
 	../../src/log.cpp                            \
 	../../src/main.cpp                           \
 	../../src/map.cpp                            \

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -457,6 +457,13 @@ shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 -60.0 60.0
 #    Range: from 0.1 to 10.0
 exposure_factor	(Exposure Factor) float 1.0 0.1 10.0
 
+#    Enable automatic exposure correction
+#    When enabled, the post-processing engine will
+#    automatically adjust to the brightness of the scene,
+#    simulating the behavior of human eye.
+enable_auto_exposure (Enable Automatic Exposure) bool false
+
+
 [**Bloom]
 
 #    Set to true to enable bloom effect.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -450,12 +450,10 @@ shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 -60.0 60.0
 
 [**Post processing]
 
-#    Set the exposure compensation factor.
-#    This factor is applied to linear color value 
-#    before all other post-processing effects.
-#    Value of 1.0 (default) means no exposure compensation.
-#    Range: from 0.1 to 10.0
-exposure_factor	(Exposure Factor) float 1.0 0.1 10.0
+#    Set the exposure compensation in EV units.
+#    Value of 0.0 (default) means no exposure compensation.
+#    Range: from -1 to 1.0
+exposure_compensation	(Exposure compensation) float 0.0 -1.0 1.0
 
 #    Enable automatic exposure correction
 #    When enabled, the post-processing engine will

--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -1,8 +1,12 @@
 #define rendered texture0
 
+struct ExposureParams {
+	float compensationFactor;
+};
+
 uniform sampler2D rendered;
-uniform mediump float exposureFactor;
 uniform mediump float bloomStrength;
+uniform ExposureParams exposureParams;
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -19,6 +23,6 @@ void main(void)
 	// translate to linear colorspace (approximate)
 	color = pow(color, vec3(2.2));
 
-	color *= exposure * exposureFactor * bloomStrength;
+	color *= exposure * exposureParams.compensationFactor * bloomStrength;
 	gl_FragColor = vec4(color, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -23,6 +23,6 @@ void main(void)
 	// translate to linear colorspace (approximate)
 	color = pow(color, vec3(2.2));
 
-	color *= exposure * exposureParams.compensationFactor * bloomStrength;
+	color *= pow(2., exposure) * exposureParams.compensationFactor * bloomStrength;
 	gl_FragColor = vec4(color, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -10,6 +10,7 @@ varying mediump vec2 varTexCoord;
 centroid varying vec2 varTexCoord;
 #endif
 
+varying float exposure;
 
 void main(void)
 {
@@ -18,10 +19,6 @@ void main(void)
 	// translate to linear colorspace (approximate)
 	color = pow(color, vec3(2.2));
 
-	// Scale colors by luminance to amplify bright colors
-	// in SDR textures.
-	float luminance = dot(color, vec3(0.213, 0.515, 0.072));
-	luminance *= luminance;
-	color *= luminance * exposureFactor * bloomStrength;
+	color *= exposure * exposureFactor * bloomStrength;
 	gl_FragColor = vec4(color, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -87,7 +87,7 @@ void main(void)
 	if (uv.x > 0.5 || uv.y > 0.5)
 #endif
 	{
-		color.rgb *= pow(2., exposure) * exposureParams.compensationFactor;
+		color.rgb *= exposure * exposureParams.compensationFactor;
 	}
 
 

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -1,9 +1,14 @@
 #define rendered texture0
 #define bloom texture1
 
+struct ExposureParams {
+	float compensationFactor;
+};
+
 uniform sampler2D rendered;
 uniform sampler2D bloom;
-uniform mediump float exposureFactor;
+
+uniform ExposureParams exposureParams;
 uniform lowp float bloomIntensity;
 uniform lowp float saturation;
 
@@ -82,7 +87,7 @@ void main(void)
 	if (uv.x > 0.5 || uv.y > 0.5)
 #endif
 	{
-		color.rgb *= exposure * exposureFactor;
+		color.rgb *= exposure * exposureParams.compensationFactor;
 	}
 
 

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -87,7 +87,7 @@ void main(void)
 	if (uv.x > 0.5 || uv.y > 0.5)
 #endif
 	{
-		color.rgb *= exposure * exposureParams.compensationFactor;
+		color.rgb *= pow(2., exposure) * exposureParams.compensationFactor;
 	}
 
 

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -13,6 +13,8 @@ varying mediump vec2 varTexCoord;
 centroid varying vec2 varTexCoord;
 #endif
 
+varying float exposure;
+
 #ifdef ENABLE_BLOOM
 
 vec4 applyBloom(vec4 color, vec2 uv)
@@ -80,7 +82,7 @@ void main(void)
 	if (uv.x > 0.5 || uv.y > 0.5)
 #endif
 	{
-		color.rgb *= exposureFactor;
+		color.rgb *= exposure * exposureFactor;
 	}
 
 

--- a/client/shaders/second_stage/opengl_vertex.glsl
+++ b/client/shaders/second_stage/opengl_vertex.glsl
@@ -1,11 +1,23 @@
+#define exposureMap texture2
+
+uniform sampler2D exposureMap;
+
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
 #else
 centroid varying vec2 varTexCoord;
 #endif
 
+varying float exposure;
+
 void main(void)
 {
+#ifdef ENABLE_AUTO_EXPOSURE
+	exposure = texture2D(exposureMap, vec2(0.5)).r;
+#else
+	exposure = 1.0;
+#endif
+
 	varTexCoord.st = inTexCoord0.st;
 	gl_Position = inVertexPosition;
 }

--- a/client/shaders/second_stage/opengl_vertex.glsl
+++ b/client/shaders/second_stage/opengl_vertex.glsl
@@ -14,6 +14,7 @@ void main(void)
 {
 #ifdef ENABLE_AUTO_EXPOSURE
 	exposure = texture2D(exposureMap, vec2(0.5)).r;
+	exposure = pow(2., exposure);
 #else
 	exposure = 1.0;
 #endif

--- a/client/shaders/update_exposure/opengl_fragment.glsl
+++ b/client/shaders/update_exposure/opengl_fragment.glsl
@@ -1,17 +1,6 @@
 #define exposure texture0
 #define screen texture1
 
-uniform sampler2D exposure;
-uniform sampler2D screen;
-
-#ifdef ENABLE_BLOOM
-uniform float bloomStrength;
-#else
-const float bloomStrength = 1.0;
-#endif
-uniform mediump float exposureFactor;
-uniform float animationTimerDelta;
-
 struct ExposureParams {
 	float luminanceMin;
 	float luminanceMax;
@@ -20,7 +9,20 @@ struct ExposureParams {
 	float speedDarkBright;
 	float speedBrightDark;
 	float centerWeightPower;
-} exposureParams = ExposureParams(0.02, 10.0, 0.0, 0.5, 2.0, 0.2, 2.0);
+	float compensationFactor;
+};
+
+uniform sampler2D exposure;
+uniform sampler2D screen;
+
+#ifdef ENABLE_BLOOM
+uniform float bloomStrength;
+#else
+const float bloomStrength = 1.0;
+#endif
+uniform ExposureParams exposureParams;
+uniform float animationTimerDelta;
+
 
 const vec3 luminanceFactors = vec3(0.213, 0.715, 0.072);
 
@@ -54,7 +56,7 @@ void main(void)
 	float luminance = getLuminance(averageColor);
 	luminance /= n;
 
-	luminance /= bloomStrength * exposureFactor; // compensate for the configurable factors
+	luminance /= bloomStrength * exposureParams.compensationFactor; // compensate for the configurable factors
 
 	// Equations borrowed from https://knarkowicz.wordpress.com/2016/01/09/automatic-exposure/
 	float wantedExposure = exposureParams.luminanceKey / max(1e-10, clamp(luminance, exposureParams.luminanceMin, exposureParams.luminanceMax) - exposureParams.luminanceBias);

--- a/client/shaders/update_exposure/opengl_fragment.glsl
+++ b/client/shaders/update_exposure/opengl_fragment.glsl
@@ -47,7 +47,7 @@ void main(void)
 			averageColor += texture2D(screen, vec2(0.5 + 0.5 * x, 0.5 - 0.5 * y)).rgb;
 			averageColor += texture2D(screen, vec2(0.5 - 0.5 * x, 0.5 + 0.5 * y)).rgb;
 			averageColor += texture2D(screen, vec2(0.5 - 0.5 * x, 0.5 - 0.5 * y)).rgb;
-			n += 4;
+			n += 4.;
 		}
 	}
 

--- a/client/shaders/update_exposure/opengl_fragment.glsl
+++ b/client/shaders/update_exposure/opengl_fragment.glsl
@@ -1,0 +1,68 @@
+#define exposure texture0
+#define screen texture1
+
+uniform sampler2D exposure;
+uniform sampler2D screen;
+
+#ifdef ENABLE_BLOOM
+uniform float bloomStrength;
+#else
+const float bloomStrength = 1.0;
+#endif
+uniform mediump float exposureFactor;
+uniform float animationTimerDelta;
+
+struct ExposureParams {
+	float luminanceMin;
+	float luminanceMax;
+	float luminanceBias;
+	float luminanceKey;
+	float speedDarkBright;
+	float speedBrightDark;
+	float centerWeightPower;
+} exposureParams = ExposureParams(0.02, 10.0, 0.0, 0.5, 2.0, 0.2, 2.0);
+
+const vec3 luminanceFactors = vec3(0.213, 0.715, 0.072);
+
+float getLuminance(vec3 color)
+{
+	return dot(color, luminanceFactors);
+}
+
+void main(void)
+{
+	float previousExposure = texture2D(exposure, vec2(0.5, 0.5)).r;
+
+	previousExposure = clamp(previousExposure, 1e-10, 1e5);
+
+	vec3 averageColor = vec3(0.);
+	float n = 0.;
+
+	// Scan the screen with center-weighting and sample average color
+	for (float _x = 0.1; _x < 0.9; _x += 0.17) {
+		float x = pow(_x, exposureParams.centerWeightPower);
+		for (float _y = 0.1; _y < 0.9; _y += 0.17) {
+			float y = pow(_y, exposureParams.centerWeightPower);
+			averageColor += texture2D(screen, vec2(0.5 + 0.5 * x, 0.5 + 0.5 * y)).rgb;
+			averageColor += texture2D(screen, vec2(0.5 + 0.5 * x, 0.5 - 0.5 * y)).rgb;
+			averageColor += texture2D(screen, vec2(0.5 - 0.5 * x, 0.5 + 0.5 * y)).rgb;
+			averageColor += texture2D(screen, vec2(0.5 - 0.5 * x, 0.5 - 0.5 * y)).rgb;
+			n += 4;
+		}
+	}
+
+	float luminance = getLuminance(averageColor);
+	luminance /= n;
+
+	luminance /= bloomStrength * exposureFactor; // compensate for the configurable factors
+
+	// Equations borrowed from https://knarkowicz.wordpress.com/2016/01/09/automatic-exposure/
+	float wantedExposure = exposureParams.luminanceKey / max(1e-10, clamp(luminance, exposureParams.luminanceMin, exposureParams.luminanceMax) - exposureParams.luminanceBias);
+
+	if (wantedExposure < previousExposure)
+		wantedExposure = mix(previousExposure, wantedExposure, 1. - exp(-animationTimerDelta * 100. * exposureParams.speedDarkBright)); // dark -> bright
+	else
+		wantedExposure = mix(previousExposure, wantedExposure, 1. - exp(-animationTimerDelta * 100. * exposureParams.speedBrightDark)); // bright -> dark
+
+	gl_FragColor = vec4(vec3(wantedExposure), 1.);
+}

--- a/client/shaders/update_exposure/opengl_vertex.glsl
+++ b/client/shaders/update_exposure/opengl_vertex.glsl
@@ -1,19 +1,11 @@
-#define exposureMap texture1
-
-uniform sampler2D exposureMap;
-
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
 #else
 centroid varying vec2 varTexCoord;
 #endif
 
-varying float exposure;
-
 void main(void)
 {
-	exposure = texture2D(exposureMap, vec2(0.5)).r;
-
 	varTexCoord.st = inTexCoord0.st;
 	gl_Position = inVertexPosition;
 }

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7472,6 +7472,16 @@ child will follow movement and rotation of that bone.
       * `shadows` is a table that controls ambient shadows
         * `intensity` sets the intensity of the shadows from 0 (no shadows, default) to 1 (blackness)
             * This value has no effect on clients who have the "Dynamic Shadows" shader disabled.
+      * `exposure` is a table that controls automatic exposure if supported and enabled on the client
+        Basic exposure factor equation is `e = luminance_key / clamp(luminance + luminance_bias, luminance_min, luminance_max)`
+        * `luminance_min` set the lower  luminance boundary to use in the calculation
+        * `luminance_max` set the upper luminance boundary to use in the calculation
+        * `lumiance_bias` set the bias value to add to observed luminance when calculating exposure
+        * `luminance_key` set the target luminance value for the scene
+        * `speed_dark_bright` set the speed of adapting to bright light
+        * `speed_bright_dark` set the speed of adapting to dark scene
+        * `center_weight_power` set the power factor for center-weighted luminance measurement
+        * `compensation_factor` set the factor to apply exposure after the equation
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.
 * `respawn()`: Respawns the player using the same mechanism as the death screen,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7472,16 +7472,15 @@ child will follow movement and rotation of that bone.
       * `shadows` is a table that controls ambient shadows
         * `intensity` sets the intensity of the shadows from 0 (no shadows, default) to 1 (blackness)
             * This value has no effect on clients who have the "Dynamic Shadows" shader disabled.
-      * `exposure` is a table that controls automatic exposure if supported and enabled on the client
-        Basic exposure factor equation is `e = luminance_key / clamp(luminance + luminance_bias, luminance_min, luminance_max)`
-        * `luminance_min` set the lower  luminance boundary to use in the calculation
+      * `exposure` is a table that controls automatic exposure.
+        The basic exposure factor equation is `e = 2^exposure_correction / clamp(luminance, 2^luminance_min, 2^luminance_max)`
+        * `luminance_min` set the lower luminance boundary to use in the calculation
         * `luminance_max` set the upper luminance boundary to use in the calculation
-        * `lumiance_bias` set the bias value to add to observed luminance when calculating exposure
-        * `luminance_key` set the target luminance value for the scene
+        * `exposure_correction` correct observed exposure by the given EV value
         * `speed_dark_bright` set the speed of adapting to bright light
         * `speed_bright_dark` set the speed of adapting to dark scene
         * `center_weight_power` set the power factor for center-weighted luminance measurement
-        * `compensation_factor` set the factor to apply exposure after the equation
+
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.
 * `respawn()`: Respawns the player using the same mechanism as the death screen,

--- a/games/devtest/mods/lighting/init.lua
+++ b/games/devtest/mods/lighting/init.lua
@@ -1,0 +1,140 @@
+local lighting_sections = {
+	{n = "shadows", d = "Shadows",
+		entries = {
+			{ n = "intensity", d = "Shadow Intensity", min = 0, max = 1 }
+		}
+	},
+	{
+		n = "exposure", d = "Exposure",
+		entries = {
+			{n = "luminance_min", d = "Minimum Luminance", min = -10, max = 10},
+			{n = "luminance_max", d = "Maximum Luminance", min = -10, max = 10},
+			{n = "exposure_correction", d = "Exposure Correction", min = -10, max = 10},
+			{n = "speed_dark_bright", d = "Bright light adaptation speed", min = -10, max = 10, type="log2"},
+			{n = "speed_bright_dark", d = "Dark scene adaptation speed", min = -10, max = 10, type="log2"},
+			{n = "center_weight_power", d = "Power factor for center-weighting", min = 0.1, max = 10},
+		}
+	}
+}
+
+local function dump_lighting(lighting)
+	local result = "{\n"
+	local section_count = 0
+	for _,section in ipairs(lighting_sections) do
+		section_count = section_count + 1
+
+		local parameters = section.entries or {}
+		local state = lighting[section.n] or {}
+
+		result = result.."  "..section.n.." = {\n"
+
+		local count = 0
+		for _,v in ipairs(parameters) do
+			count = count + 1
+			result = result.."    "..v.n.." = "..(math.floor(state[v.n] * 1000)/1000)
+			if count < #parameters then
+				result = result..","
+			end
+			result = result.."\n"
+		end
+
+		result = result.."  }"
+
+		if section_count < #lighting_sections then
+			result = result..","
+		end
+		result = result.."\n"
+	end
+	result = result .."}"
+	return result
+end
+
+minetest.register_chatcommand("set_lighting", {
+	params = "",
+	description = "Tune lighting parameters",
+	func = function(player_name, param)
+		local player = minetest.get_player_by_name(player_name);
+		if not player then return end
+
+		local lighting = player:get_lighting()
+		local exposure = lighting.exposure or {}
+
+		local form = {
+			"formspec_version[2]",
+			"size[15,30]",
+			"position[0.99,0.15]",
+			"anchor[1,0]",
+			"padding[0.05,0.1]",
+			"no_prepend[]"
+		};
+
+		local line = 1
+		for _,section in ipairs(lighting_sections) do
+			local parameters = section.entries or {}
+			local state = lighting[section.n] or {}
+
+			table.insert(form, "label[1,"..line..";"..section.d.."]")
+			line  = line + 1
+
+			for _,v in ipairs(parameters) do
+				table.insert(form, "label[2,"..line..";"..v.d.."]")
+				table.insert(form, "scrollbaroptions[min=0;max=1000;smallstep=10;largestep=100;thumbsize=10]")
+				local value = state[v.n]
+				if v.type == "log2" then
+					value = math.log(value or 1) / math.log(2)
+				end
+				local sb_scale = math.floor(1000 * (math.max(v.min, value or 0) - v.min) / (v.max - v.min))
+				table.insert(form, "scrollbar[2,"..(line+0.7)..";12,1;horizontal;"..section.n.."."..v.n..";"..sb_scale.."]")
+				line = line + 2.7
+			end
+
+			line = line + 1
+		end
+
+		minetest.show_formspec(player_name, "lighting", table.concat(form))
+		local debug_value = dump_lighting(lighting)
+		local debug_ui = player:hud_add({type="text", position={x=0.1, y=0.3}, scale={x=1,y=1}, alignment = {x=1, y=1}, text=debug_value, number=0xFFFFFF})
+		player:get_meta():set_int("lighting_hud", debug_ui)
+	end
+})
+
+minetest.register_on_player_receive_fields(function(player, formname, fields)
+	if formname ~= "lighting" then return end
+
+	if not player then return end
+
+	local hud_id = player:get_meta():get_int("lighting_hud")
+
+	if fields.quit then
+		player:hud_remove(hud_id)
+		player:get_meta():set_int("lighting_hud", -1)
+		return
+	end
+
+	local lighting = player:get_lighting()
+	for _,section in ipairs(lighting_sections) do
+		local parameters = section.entries or {}
+
+		local state = (lighting[section.n] or {})
+		lighting[section.n] = state
+
+		for _,v in ipairs(parameters) do
+			
+			if fields[section.n.."."..v.n] then
+				local event = minetest.explode_scrollbar_event(fields[section.n.."."..v.n])
+				if event.type == "CHG" then
+					local value = v.min + (v.max - v.min) * (event.value / 1000);
+					if v.type == "log2" then
+						value = math.pow(2, value);
+					end
+					state[v.n] = value;
+				end
+			end
+		end
+	end
+
+	local debug_value = dump_lighting(lighting)
+	player:hud_change(hud_id, "text", debug_value)
+
+	player:set_lighting(lighting)
+end)

--- a/games/devtest/mods/lighting/mod.conf
+++ b/games/devtest/mods/lighting/mod.conf
@@ -1,0 +1,2 @@
+name = lighting
+description = UI to control and debug lighting parameters

--- a/games/devtest/mods/util_commands/init.lua
+++ b/games/devtest/mods/util_commands/init.lua
@@ -210,20 +210,6 @@ minetest.register_chatcommand("dump_item", {
 	end,
 })
 
--- shadow control
-minetest.register_on_joinplayer(function (player)
-	player:set_lighting({shadows={intensity = 0.33}})
-end)
-
-core.register_chatcommand("set_shadow", {
-    params = "<shadow_intensity>",
-    description = "Set shadow parameters of current player.",
-    func = function(player_name, param)
-        local shadow_intensity = tonumber(param)
-        minetest.get_player_by_name(player_name):set_lighting({shadows = { intensity = shadow_intensity} })
-    end
-})
-
 core.register_chatcommand("set_saturation", {
     params = "<saturation>",
     description = "Set the saturation for current player.",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -375,6 +375,7 @@ set(common_SRCS
 	itemdef.cpp
 	itemstackmetadata.cpp
 	light.cpp
+	lighting.cpp
 	log.cpp
 	main.cpp
 	map.cpp

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -531,8 +531,13 @@ void ClientEnvironment::updateFrameTime(bool is_paused)
 {
 	// if paused, m_frame_time_pause_accumulator increases by dtime,
 	// otherwise, m_frame_time increases by dtime
-	if (is_paused)
+	if (is_paused) {
+		m_frame_dtime = 0;
 		m_frame_time_pause_accumulator = porting::getTimeMs() - m_frame_time;
-	else
-		m_frame_time = porting::getTimeMs() - m_frame_time_pause_accumulator;
+	}
+	else {
+		auto new_frame_time = porting::getTimeMs() - m_frame_time_pause_accumulator;
+		m_frame_dtime = new_frame_time - MYMAX(m_frame_time, m_frame_time_pause_accumulator);
+		m_frame_time = new_frame_time;
+	}
 }

--- a/src/client/clientenvironment.h
+++ b/src/client/clientenvironment.h
@@ -144,6 +144,7 @@ public:
 
 	void updateFrameTime(bool is_paused);
 	u64 getFrameTime() const { return m_frame_time; }
+	u64 getFrameTimeDelta() const { return m_frame_dtime; }
 
 private:
 	ClientMap *m_map;
@@ -158,5 +159,6 @@ private:
 	std::list<std::string> m_player_names;
 	v3s16 m_camera_offset;
 	u64 m_frame_time = 0;
+	u64 m_frame_dtime = 0;
 	u64 m_frame_time_pause_accumulator = 0;
 };

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -430,7 +430,7 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<float, 2> m_texel_size0;
 	std::array<float, 2> m_texel_size0_values;
 	CachedStructPixelShaderSetting<float, 7> m_exposure_params_pixel;
-	float m_user_exposure_factor;
+	float m_user_exposure_compensation;
 	bool m_bloom_enabled;
 	CachedPixelShaderSetting<float> m_bloom_intensity_pixel;
 	float m_bloom_intensity;
@@ -445,8 +445,8 @@ public:
 	{
 		if (name == "enable_fog")
 			m_fog_enabled = g_settings->getBool("enable_fog");
-		if (name == "exposure_factor")
-			m_user_exposure_factor = g_settings->getFloat("exposure_factor", 0.1f, 10.0f);
+		if (name == "exposure_compensation")
+			m_user_exposure_compensation = g_settings->getFloat("exposure_compensation", -1.0f, 1.0f);
 		if (name == "bloom_intensity")
 			m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.01f, 1.0f);
 		if (name == "bloom_strength_factor")
@@ -497,13 +497,13 @@ public:
 		m_saturation_pixel("saturation")
 	{
 		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
-		g_settings->registerChangedCallback("exposure_factor", settingsCallback, this);
+		g_settings->registerChangedCallback("exposure_compensation", settingsCallback, this);
 		g_settings->registerChangedCallback("bloom_intensity", settingsCallback, this);
 		g_settings->registerChangedCallback("bloom_strength_factor", settingsCallback, this);
 		g_settings->registerChangedCallback("bloom_radius", settingsCallback, this);
 		g_settings->registerChangedCallback("saturation", settingsCallback, this);
 		m_fog_enabled = g_settings->getBool("enable_fog");
-		m_user_exposure_factor = g_settings->getFloat("exposure_factor", 0.1f, 10.0f);
+		m_user_exposure_compensation = g_settings->getFloat("exposure_compensation", -1.0f, 1.0f);
 		m_bloom_enabled = g_settings->getBool("enable_bloom");
 		m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.01f, 1.0f);
 		m_bloom_strength = RenderingEngine::BASE_BLOOM_STRENGTH * g_settings->getFloat("bloom_strength_factor", 0.1f, 10.0f);
@@ -597,7 +597,7 @@ public:
 			exposure_params.speed_dark_bright,
 			exposure_params.speed_bright_dark,
 			exposure_params.center_weight_power,
-			m_user_exposure_factor
+			powf(2.f, m_user_exposure_compensation)
 		};
 		m_exposure_params_pixel.set(exposure_buffer.data(), services);
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -414,6 +414,8 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<float> m_fog_distance;
 	CachedVertexShaderSetting<float> m_animation_timer_vertex;
 	CachedPixelShaderSetting<float> m_animation_timer_pixel;
+	CachedVertexShaderSetting<float> m_animation_timer_delta_vertex;
+	CachedPixelShaderSetting<float> m_animation_timer_delta_pixel;
 	CachedPixelShaderSetting<float, 3> m_day_light;
 	CachedPixelShaderSetting<float, 4> m_star_color;
 	CachedPixelShaderSetting<float, 3> m_eye_position_pixel;
@@ -470,6 +472,8 @@ public:
 		m_fog_distance("fogDistance"),
 		m_animation_timer_vertex("animationTimer"),
 		m_animation_timer_pixel("animationTimer"),
+		m_animation_timer_delta_vertex("animationTimerDelta"),
+		m_animation_timer_delta_pixel("animationTimerDelta"),
 		m_day_light("dayLight"),
 		m_star_color("starColor"),
 		m_eye_position_pixel("eyePosition"),
@@ -545,6 +549,10 @@ public:
 		float animation_timer_f = (float)animation_timer / 100000.f;
 		m_animation_timer_vertex.set(&animation_timer_f, services);
 		m_animation_timer_pixel.set(&animation_timer_f, services);
+
+		float animation_timer_delta_f = (float)m_client->getEnv().getFrameTimeDelta() / 100000.f;
+		m_animation_timer_delta_vertex.set(&animation_timer_delta_f, services);
+		m_animation_timer_delta_pixel.set(&animation_timer_delta_f, services);
 
 		float eye_position_array[3];
 		v3f epos = m_client->getEnv().getLocalPlayer()->getEyePosition();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -429,7 +429,7 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<SamplerLayer_t> m_texture3;
 	CachedPixelShaderSetting<float, 2> m_texel_size0;
 	std::array<float, 2> m_texel_size0_values;
-	CachedStructPixelShaderSetting<float, 8> m_exposure_params_pixel;
+	CachedStructPixelShaderSetting<float, 7> m_exposure_params_pixel;
 	float m_user_exposure_factor;
 	bool m_bloom_enabled;
 	CachedPixelShaderSetting<float> m_bloom_intensity_pixel;
@@ -487,8 +487,8 @@ public:
 		m_texture3("texture3"),
 		m_texel_size0("texelSize0"),
 		m_exposure_params_pixel("exposureParams",
-				std::array<const char*, 8> {
-						"luminanceMin", "luminanceMax", "luminanceBias", "luminanceKey", 
+				std::array<const char*, 7> {
+						"luminanceMin", "luminanceMax", "exposureCorrection",
 						"speedDarkBright", "speedBrightDark", "centerWeightPower", "compensationFactor"
 				}),
 		m_bloom_intensity_pixel("bloomIntensity"),
@@ -590,15 +590,14 @@ public:
 		m_texel_size0.set(m_texel_size0_values.data(), services);
 
 		const AutoExposure &exposure_params = m_client->getEnv().getLocalPlayer()->getLighting().exposure;
-		std::array<float, 8> exposure_buffer = {
-			exposure_params.luminance_min,
-			exposure_params.luminance_max,
-			exposure_params.luminance_bias,
-			exposure_params.luminance_key,
+		std::array<float, 7> exposure_buffer = {
+			std::pow(2.0f, exposure_params.luminance_min),
+			std::pow(2.0f, exposure_params.luminance_max),
+			exposure_params.exposure_correction,
 			exposure_params.speed_dark_bright,
 			exposure_params.speed_bright_dark,
 			exposure_params.center_weight_power,
-			exposure_params.compensation_factor * m_user_exposure_factor
+			m_user_exposure_factor
 		};
 		m_exposure_params_pixel.set(exposure_buffer.data(), services);
 

--- a/src/client/render/pipeline.cpp
+++ b/src/client/render/pipeline.cpp
@@ -101,6 +101,16 @@ void TextureBuffer::reset(PipelineContext &context)
 	RenderSource::reset(context);
 }
 
+void TextureBuffer::swapTextures(u8 texture_a, u8 texture_b)
+{
+	assert(m_definitions[texture_a].valid && m_definitions[texture_b].valid);
+
+	video::ITexture *temp = m_textures[texture_a];
+	m_textures[texture_a] = m_textures[texture_b];
+	m_textures[texture_b] = temp;
+}
+
+
 bool TextureBuffer::ensureTexture(video::ITexture **texture, const TextureDefinition& definition, PipelineContext &context)
 {
 	bool modify;
@@ -228,6 +238,16 @@ SetRenderTargetStep::SetRenderTargetStep(RenderStep *_step, RenderTarget *_targe
 void SetRenderTargetStep::run(PipelineContext &context)
 {
 	step->setRenderTarget(target);
+}
+
+SwapTexturesStep::SwapTexturesStep(TextureBuffer *_buffer, u8 _texture_a, u8 _texture_b)
+		: buffer(_buffer), texture_a(_texture_a), texture_b(_texture_b)
+{
+}
+
+void SwapTexturesStep::run(PipelineContext &context)
+{
+	buffer->swapTextures(texture_a, texture_b);
 }
 
 RenderSource *RenderPipeline::getInput()

--- a/src/client/render/pipeline.h
+++ b/src/client/render/pipeline.h
@@ -53,7 +53,7 @@ struct PipelineContext
 
 /**
  * Base object that can be owned by RenderPipeline
- * 
+ *
  */
 class RenderPipelineObject
 {
@@ -74,7 +74,7 @@ public:
 	virtual u8 getTextureCount() = 0;
 
 	/**
-	 * Get a texture by index. 
+	 * Get a texture by index.
 	 * Returns nullptr is the texture does not exist.
 	 */
 	virtual video::ITexture *getTexture(u8 index) = 0;
@@ -119,7 +119,7 @@ public:
 
 	/**
 	 * Configure fixed-size texture for the specific index
-	 * 
+	 *
 	 * @param index index of the texture
 	 * @param size width and height of the texture in pixels
 	 * @param height height of the texture in pixels
@@ -130,7 +130,7 @@ public:
 
 	/**
 	 * Configure relative-size texture for the specific index
-	 * 
+	 *
 	 * @param index index of the texture
 	 * @param scale_factor relation of the texture dimensions to the screen dimensions
 	 * @param name unique name of the texture
@@ -141,6 +141,7 @@ public:
 	virtual u8 getTextureCount() override { return m_textures.size(); }
 	virtual video::ITexture *getTexture(u8 index) override;
 	virtual void reset(PipelineContext &context) override;
+	void swapTextures(u8 texture_a, u8 texture_b);
 private:
 	static const u8 NO_DEPTH_TEXTURE = 255;
 
@@ -193,7 +194,7 @@ private:
 
 /**
  * Allows remapping texture indicies in another RenderSource.
- * 
+ *
  * @note all unmapped indexes are passed through to the underlying render source.
  */
 class RemappingSource : RenderSource
@@ -205,7 +206,7 @@ public:
 
 	/**
 	 * Maps texture index to a different index in the dependent source.
-	 * 
+	 *
 	 * @param index texture index as requested by the @see RenderStep.
 	 * @param target_index matching texture index in the underlying @see RenderSource.
 	 */
@@ -250,7 +251,7 @@ public:
 	virtual u8 getTextureCount() override;
 
 	/**
-	 * Get a texture by index. 
+	 * Get a texture by index.
 	 * Returns nullptr is the texture does not exist.
 	 */
 	virtual video::ITexture *getTexture(u8 index) override;
@@ -288,14 +289,14 @@ class RenderStep : virtual public RenderPipelineObject
 public:
 	/**
 	 * Assigns render source to this step.
-	 * 
+	 *
 	 * @param source source of rendering information
 	 */
 	virtual void setRenderSource(RenderSource *source) = 0;
 
 	/**
 	 * Assigned render target to this step.
-	 * 
+	 *
 	 * @param target render target to send output to.
 	 */
 	virtual void setRenderTarget(RenderTarget *target) = 0;
@@ -319,7 +320,7 @@ public:
 
 /**
  * Dynamically changes render target of another step.
- * 
+ *
  * This allows re-running parts of the pipeline with different outputs
  */
 class SetRenderTargetStep : public TrivialRenderStep
@@ -333,8 +334,23 @@ private:
 };
 
 /**
+ * Swaps two textures in the texture buffer.
+ *
+ */
+class SwapTexturesStep : public TrivialRenderStep
+{
+public:
+	SwapTexturesStep(TextureBuffer *buffer, u8 texture_a, u8 texture_b);
+	virtual void run(PipelineContext &context) override;
+private:
+	TextureBuffer *buffer;
+	u8 texture_a;
+	u8 texture_b;
+};
+
+/**
  * Render Pipeline provides a flexible way to execute rendering steps in the engine.
- * 
+ *
  * RenderPipeline also implements @see RenderStep, allowing for nesting of the pipelines.
  */
 class RenderPipeline : public RenderStep
@@ -342,7 +358,7 @@ class RenderPipeline : public RenderStep
 public:
 	/**
 	 * Add a step to the end of the pipeline
-	 * 
+	 *
 	 * @param step reference to a @see RenderStep implementation.
 	 */
 	RenderStep *addStep(RenderStep *step)
@@ -353,9 +369,9 @@ public:
 
 	/**
 	 * Capture ownership of a dynamically created @see RenderStep instance.
-	 * 
+	 *
 	 * RenderPipeline will delete the instance when the pipeline is destroyed.
-	 * 
+	 *
 	 * @param step reference to the instance.
 	 * @return RenderStep* value of the 'step' parameter.
 	 */

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -56,7 +56,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 
 RenderingEngine *RenderingEngine::s_singleton = nullptr;
-const float RenderingEngine::BASE_BLOOM_STRENGTH = 8.0f;
+const float RenderingEngine::BASE_BLOOM_STRENGTH = 1.0f;
 
 
 static gui::GUISkin *createSkin(gui::IGUIEnvironment *environment,

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -784,6 +784,9 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 			shaders_header << "#define ENABLE_BLOOM_DEBUG 1\n";
 	}
 
+	if (g_settings->getBool("enable_auto_exposure"))
+		shaders_header << "#define ENABLE_AUTO_EXPOSURE 1\n";
+
 	shaders_header << "#line 0\n"; // reset the line counter for meaningful diagnostics
 
 	std::string common_header = shaders_header.str();

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -276,7 +276,7 @@ void set_default_settings()
 	settings->setDefault("water_wave_speed", "5.0");
 	settings->setDefault("enable_waving_leaves", "false");
 	settings->setDefault("enable_waving_plants", "false");
-	settings->setDefault("exposure_factor", "1.0");
+	settings->setDefault("exposure_compensation", "0.0");
 	settings->setDefault("enable_auto_exposure", "false");
 	settings->setDefault("enable_bloom", "false");
 	settings->setDefault("enable_bloom_debug", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -277,6 +277,7 @@ void set_default_settings()
 	settings->setDefault("enable_waving_leaves", "false");
 	settings->setDefault("enable_waving_plants", "false");
 	settings->setDefault("exposure_factor", "1.0");
+	settings->setDefault("enable_auto_exposure", "false");
 	settings->setDefault("enable_bloom", "false");
 	settings->setDefault("enable_bloom_debug", "false");
 	settings->setDefault("bloom_strength_factor", "1.0");

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -20,10 +20,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lighting.h"
 
 AutoExposure::AutoExposure()
-        : luminance_min(0.f),
-        luminance_max(0.f),
+        : luminance_min(-3.f),
+        luminance_max(-3.f),
         exposure_correction(0.0f),
-        speed_dark_bright(0.f),
-        speed_bright_dark(0.f),
+        speed_dark_bright(1000.f),
+        speed_bright_dark(1000.f),
         center_weight_power(1.f)
 {}

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -1,0 +1,29 @@
+/*
+Minetest
+Copyright (C) 2021 x2048, Dmitry Kostenko <codeforsmile@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "lighting.h"
+
+AutoExposure::AutoExposure()
+        : luminance_min(0.f),
+        luminance_max(0.f),
+        exposure_correction(0.0f),
+        speed_dark_bright(0.f),
+        speed_bright_dark(0.f),
+        center_weight_power(1.f)
+{}

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -25,27 +25,25 @@ with this program; if not, write to the Free Software Foundation, Inc.,
  *
  * Automatic exposure compensation uses the following equation:
  *
- * wanted_exposure = luminance_key / clamp(observed_luminance + luminance_bias, luminance_min, luminance_max)
+ * wanted_exposure = 2^exposure_correction / clamp(observed_luminance, 2^luminance_min, 2^luminance_max)
  *
  */
 struct AutoExposure
 {
     /// @brief Minimum boundary for computed luminance
-    float luminance_min { 0.02f };
+    float luminance_min;
     /// @brief Maximum boundary for computed luminance
-    float luminance_max { 10.0f };
+    float luminance_max;
     /// @brief Luminance bias. Higher values make the scene darker, can be negative.
-    float luminance_bias { 0.f };
-    /// @brief Target luminance value
-    float luminance_key { 0.5f };
+    float exposure_correction;
     /// @brief Speed of transition from dark to bright scenes
-    float speed_dark_bright { 2.0f };
+    float speed_dark_bright;
     /// @brief Speed of transition from bright to dark scenes
-    float speed_bright_dark { 0.2f };
+    float speed_bright_dark;
     /// @brief Power value for center-weighted metering. Value of 1.0 measures entire screen uniformly
-    float center_weight_power { 2.0f };
-    /// @brief Post-processing exposure compentation factor
-    float compensation_factor { 1.0f };
+    float center_weight_power;
+
+    AutoExposure();
 };
 
 /** Describes ambient light settings for a player

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -31,9 +31,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 struct AutoExposure
 {
     /// @brief Minimum boundary for computed luminance
-    float luminance_min { 0.02f};
+    float luminance_min { 0.02f };
     /// @brief Maximum boundary for computed luminance
-    float luminance_max { 10.0f};
+    float luminance_max { 10.0f };
     /// @brief Luminance bias. Higher values make the scene darker, can be negative.
     float luminance_bias { 0.f };
     /// @brief Target luminance value

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -19,10 +19,40 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+
+/**
+ * Parameters for automatic exposure compensation
+ *
+ * Automatic exposure compensation uses the following equation:
+ *
+ * wanted_exposure = luminance_key / clamp(observed_luminance + luminance_bias, luminance_min, luminance_max)
+ *
+ */
+struct AutoExposure
+{
+    /// @brief Minimum boundary for computed luminance
+    float luminance_min { 0.02f};
+    /// @brief Maximum boundary for computed luminance
+    float luminance_max { 10.0f};
+    /// @brief Luminance bias. Higher values make the scene darker, can be negative.
+    float luminance_bias { 0.f };
+    /// @brief Target luminance value
+    float luminance_key { 0.5f };
+    /// @brief Speed of transition from dark to bright scenes
+    float speed_dark_bright { 2.0f };
+    /// @brief Speed of transition from bright to dark scenes
+    float speed_bright_dark { 0.2f };
+    /// @brief Power value for center-weighted metering. Value of 1.0 measures entire screen uniformly
+    float center_weight_power { 2.0f };
+    /// @brief Post-processing exposure compentation factor
+    float compensation_factor { 1.0f };
+};
+
 /** Describes ambient light settings for a player
  */
 struct Lighting
 {
+    AutoExposure exposure;
     float shadow_intensity {0.0f};
     float saturation {1.0f};
 };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1766,14 +1766,12 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 		*pkt >> lighting.shadow_intensity;
 	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.saturation;
-	if (pkt->getRemainingBytes() >= 32) {
-		*pkt >> lighting.exposure.luminance_min;
-		*pkt >> lighting.exposure.luminance_max;
-		*pkt >> lighting.exposure.luminance_bias;
-		*pkt >> lighting.exposure.luminance_key;
-		*pkt >> lighting.exposure.speed_dark_bright;
-		*pkt >> lighting.exposure.speed_bright_dark;
-		*pkt >> lighting.exposure.center_weight_power;
-		*pkt >> lighting.exposure.compensation_factor;
+	if (pkt->getRemainingBytes() >= 24) {
+		*pkt >> lighting.exposure.luminance_min
+				>> lighting.exposure.luminance_max
+				>> lighting.exposure.exposure_correction
+				>> lighting.exposure.speed_dark_bright
+				>> lighting.exposure.speed_bright_dark
+				>> lighting.exposure.center_weight_power;
 	}
 }

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1766,4 +1766,14 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 		*pkt >> lighting.shadow_intensity;
 	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.saturation;
+	if (pkt->getRemainingBytes() >= 32) {
+		*pkt >> lighting.exposure.luminance_min;
+		*pkt >> lighting.exposure.luminance_max;
+		*pkt >> lighting.exposure.luminance_bias;
+		*pkt >> lighting.exposure.luminance_key;
+		*pkt >> lighting.exposure.speed_dark_bright;
+		*pkt >> lighting.exposure.speed_bright_dark;
+		*pkt >> lighting.exposure.center_weight_power;
+		*pkt >> lighting.exposure.compensation_factor;
+	}
 }

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -834,12 +834,10 @@ enum ToClientCommand
 		exposure parameters
 			f32 luminance_min
 			f32 luminance_max
-			f32 luminance_bias
-			f32 luminance_key
+			f32 exposure_correction
 			f32 speed_dark_bright
 			f32 speed_bright_dark
 			f32 center_weight_power
-			f32 compensation_factor
 	*/
 
 	TOCLIENT_NUM_MSG_TYPES = 0x64,

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -831,6 +831,15 @@ enum ToClientCommand
 	/*
 		f32 shadow_intensity
 		f32 saturation
+		exposure parameters
+			f32 luminance_min
+			f32 luminance_max
+			f32 luminance_bias
+			f32 luminance_key
+			f32 speed_dark_bright
+			f32 speed_bright_dark
+			f32 center_weight_power
+			f32 compensation_factor
 	*/
 
 	TOCLIENT_NUM_MSG_TYPES = 0x64,

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2304,12 +2304,10 @@ int ObjectRef::l_set_lighting(lua_State *L)
 	if (lua_istable(L, -1)) {
 		lighting.exposure.luminance_min       = getfloatfield_default(L, -1, "luminance_min",       lighting.exposure.luminance_min);
 		lighting.exposure.luminance_max       = getfloatfield_default(L, -1, "luminance_max",       lighting.exposure.luminance_max);
-		lighting.exposure.luminance_bias      = getfloatfield_default(L, -1, "luminance_bias",      lighting.exposure.luminance_bias);
-		lighting.exposure.luminance_key       = getfloatfield_default(L, -1, "luminance_key",       lighting.exposure.luminance_key);
+		lighting.exposure.exposure_correction = getfloatfield_default(L, -1, "exposure_correction",      lighting.exposure.exposure_correction);
 		lighting.exposure.speed_dark_bright   = getfloatfield_default(L, -1, "speed_dark_bright",   lighting.exposure.speed_dark_bright);
 		lighting.exposure.speed_bright_dark   = getfloatfield_default(L, -1, "speed_bright_dark",   lighting.exposure.speed_bright_dark);
 		lighting.exposure.center_weight_power = getfloatfield_default(L, -1, "center_weight_power", lighting.exposure.center_weight_power);
-		lighting.exposure.compensation_factor = getfloatfield_default(L, -1, "compensation_factor", lighting.exposure.compensation_factor);
 	}
 	lua_pop(L, 1); // exposure
 
@@ -2340,18 +2338,14 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_setfield(L, -2, "luminance_min");
 	lua_pushnumber(L, lighting.exposure.luminance_max);
 	lua_setfield(L, -2, "luminance_max");
-	lua_pushnumber(L, lighting.exposure.luminance_bias);
-	lua_setfield(L, -2, "luminance_bias");
-	lua_pushnumber(L, lighting.exposure.luminance_key);
-	lua_setfield(L, -2, "luminance_key");
+	lua_pushnumber(L, lighting.exposure.exposure_correction);
+	lua_setfield(L, -2, "exposure_correction");
 	lua_pushnumber(L, lighting.exposure.speed_dark_bright);
 	lua_setfield(L, -2, "speed_dark_bright");
 	lua_pushnumber(L, lighting.exposure.speed_bright_dark);
 	lua_setfield(L, -2, "speed_bright_dark");
 	lua_pushnumber(L, lighting.exposure.center_weight_power);
 	lua_setfield(L, -2, "center_weight_power");
-	lua_pushnumber(L, lighting.exposure.compensation_factor);
-	lua_setfield(L, -2, "compensation_factor");
 	lua_setfield(L, -2, "exposure");
 	return 1;
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2297,7 +2297,21 @@ int ObjectRef::l_set_lighting(lua_State *L)
 		getfloatfield(L, -1, "intensity", lighting.shadow_intensity);
 	}
 	lua_pop(L, 1); // shadows
+
 	getfloatfield(L, -1, "saturation", lighting.saturation);
+
+	lua_getfield(L, 2, "exposure");
+	if (lua_istable(L, -1)) {
+		lighting.exposure.luminance_min       = getfloatfield_default(L, -1, "luminance_min",       lighting.exposure.luminance_min);
+		lighting.exposure.luminance_max       = getfloatfield_default(L, -1, "luminance_max",       lighting.exposure.luminance_max);
+		lighting.exposure.luminance_bias      = getfloatfield_default(L, -1, "luminance_bias",      lighting.exposure.luminance_bias);
+		lighting.exposure.luminance_key       = getfloatfield_default(L, -1, "luminance_key",       lighting.exposure.luminance_key);
+		lighting.exposure.speed_dark_bright   = getfloatfield_default(L, -1, "speed_dark_bright",   lighting.exposure.speed_dark_bright);
+		lighting.exposure.speed_bright_dark   = getfloatfield_default(L, -1, "speed_bright_dark",   lighting.exposure.speed_bright_dark);
+		lighting.exposure.center_weight_power = getfloatfield_default(L, -1, "center_weight_power", lighting.exposure.center_weight_power);
+		lighting.exposure.compensation_factor = getfloatfield_default(L, -1, "compensation_factor", lighting.exposure.compensation_factor);
+	}
+	lua_pop(L, 1); // exposure
 
 	getServer(L)->setLighting(player, lighting);
 	return 0;
@@ -2321,6 +2335,24 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_setfield(L, -2, "shadows");
 	lua_pushnumber(L, lighting.saturation);
 	lua_setfield(L, -2, "saturation");
+	lua_newtable(L); // "exposure"
+	lua_pushnumber(L, lighting.exposure.luminance_min);
+	lua_setfield(L, -2, "luminance_min");
+	lua_pushnumber(L, lighting.exposure.luminance_max);
+	lua_setfield(L, -2, "luminance_max");
+	lua_pushnumber(L, lighting.exposure.luminance_bias);
+	lua_setfield(L, -2, "luminance_bias");
+	lua_pushnumber(L, lighting.exposure.luminance_key);
+	lua_setfield(L, -2, "luminance_key");
+	lua_pushnumber(L, lighting.exposure.speed_dark_bright);
+	lua_setfield(L, -2, "speed_dark_bright");
+	lua_pushnumber(L, lighting.exposure.speed_bright_dark);
+	lua_setfield(L, -2, "speed_bright_dark");
+	lua_pushnumber(L, lighting.exposure.center_weight_power);
+	lua_setfield(L, -2, "center_weight_power");
+	lua_pushnumber(L, lighting.exposure.compensation_factor);
+	lua_setfield(L, -2, "compensation_factor");
+	lua_setfield(L, -2, "exposure");
 	return 1;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1866,14 +1866,12 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 	pkt << lighting.shadow_intensity;
 	pkt << lighting.saturation;
 
-	pkt << lighting.exposure.luminance_min;
-	pkt << lighting.exposure.luminance_max;
-	pkt << lighting.exposure.luminance_bias;
-	pkt << lighting.exposure.luminance_key;
-	pkt << lighting.exposure.speed_dark_bright;
-	pkt << lighting.exposure.speed_bright_dark;
-	pkt << lighting.exposure.center_weight_power;
-	pkt << lighting.exposure.compensation_factor;
+	pkt << lighting.exposure.luminance_min
+			<< lighting.exposure.luminance_max
+			<< lighting.exposure.exposure_correction
+			<< lighting.exposure.speed_dark_bright
+			<< lighting.exposure.speed_bright_dark
+			<< lighting.exposure.center_weight_power;
 
 	Send(&pkt);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1866,6 +1866,15 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 	pkt << lighting.shadow_intensity;
 	pkt << lighting.saturation;
 
+	pkt << lighting.exposure.luminance_min;
+	pkt << lighting.exposure.luminance_max;
+	pkt << lighting.exposure.luminance_bias;
+	pkt << lighting.exposure.luminance_key;
+	pkt << lighting.exposure.speed_dark_bright;
+	pkt << lighting.exposure.speed_bright_dark;
+	pkt << lighting.exposure.center_weight_power;
+	pkt << lighting.exposure.compensation_factor;
+
 	Send(&pkt);
 }
 


### PR DESCRIPTION
This PR adds shader code to simulate behavior of human eye and make proper use of the bloom.

# Process

1. Average scene color and luminance are computed using progressively downsampled screen image. Color is sampled at `(x,y) = (0.5, 0.5) + (0.5, 0.5) * pow((i, j), center_weight_power)` for i, j from 0 to 1.
2.  Target exposure is calculated according to the [Frostbite](https://media.contentapi.ea.com/content/dam/eacom/frostbite/files/course-notes-moving-frostbite-to-pbr-v2.pdf) paper.
3. Exposure is blended in time using exponential falloff `current_exposure = previous_exposure + (target_exposure - previous_exposure) * (1 - exp(-speed * time)` to untie the speed of transition from FPS.
4. Final color value is `color = color * pow(2, current_exposure) * compensation_factor`

# Client-side controls

* `enable_auto_exposure` setting allows to enable the feature on the client.

# Game-side controls

 there are new parameters to `player:set_lighting`:

```
player:set_lighting({
  exposure = {
    luminance_min = <float>, -- lower bound of observed scene luminance
    luminance_max = <float>, -- upper bound of observed scene luminance
    luminance_bias = <float>, -- bias value in the equation. Higher values make scene darker
    luminance_key = <float>, -- target luminance value in the equation
    speed_dark_bright = <float>, -- speed of adaptation to bright light
    speed_bright_dark = <float>, -- speed of adaptation to dark scene
    center_weight_power = <float>, -- power for center-weighting the color samples
    compensation_factor = <float>, -- final compensation factor
  }
})
```

## To do

This PR is Ready for Review.

## How to test

1.Set `enable_auto_exposure` to true. Optionally set `enable_bloom` to true.
2. Start devtest
3. Walk in bright and dark areas and observe how scene brightness is corrected automatically, and the amount of e.g. bloom changes.
4. Type `/set_lighting`
5. Play with the controls on the right side of the screen - every control must have effect on the screen.
6. For other games there is an example [mod](https://github.com/x2048/dynamic_exposure/).
