### PR TITLE
Android: Segmentation fault fix, PendingIntent flag, and other fixes

### DIFF
--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -45,6 +45,7 @@ import java.util.Objects;
 // Native code finds these methods by name (see porting_android.cpp).
 // This annotation prevents the minifier/Proguard from mangling them.
 @Keep
+@SuppressWarnings("unused")
 public class GameActivity extends NativeActivity {
 	static {
 		System.loadLibrary("c++_shared");
@@ -180,11 +181,17 @@ public class GameActivity extends NativeActivity {
 	}
 
 	public String getUserDataPath() {
-		return Utils.getUserDataDirectory(this).getAbsolutePath();
+		return Objects.requireNonNull(
+			Utils.getUserDataDirectory(this),
+			"Cannot get user data directory"
+		).getAbsolutePath();
 	}
 
 	public String getCachePath() {
-		return Utils.getCacheDirectory(this).getAbsolutePath();
+		return Objects.requireNonNull(
+			Utils.getCacheDirectory(this),
+			"Cannot get cache directory"
+		).getAbsolutePath();
 	}
 
 	public void shareFile(String path) {

--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -181,17 +181,11 @@ public class GameActivity extends NativeActivity {
 	}
 
 	public String getUserDataPath() {
-		return Objects.requireNonNull(
-			Utils.getUserDataDirectory(this),
-			"Cannot get user data directory"
-		).getAbsolutePath();
+		return Utils.getUserDataDirectory(this).getAbsolutePath();
 	}
 
 	public String getCachePath() {
-		return Objects.requireNonNull(
-			Utils.getCacheDirectory(this),
-			"Cannot get cache directory"
-		).getAbsolutePath();
+		return Utils.getCacheDirectory(this).getAbsolutePath();
 	}
 
 	public void shareFile(String path) {

--- a/android/app/src/main/java/net/minetest/minetest/MainActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/MainActivity.java
@@ -127,8 +127,12 @@ public class MainActivity extends AppCompatActivity {
 	}
 
 	@Override
-	public void onRequestPermissionsResult(int requestCode,
-									@NonNull String[] permissions, @NonNull int[] grantResults) {
+	public void onRequestPermissionsResult(
+		int requestCode,
+		@NonNull String[] permissions,
+		@NonNull int[] grantResults
+	) {
+		super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 		if (requestCode == PERMISSIONS) {
 			for (int grantResult : grantResults) {
 				if (grantResult != PackageManager.PERMISSION_GRANTED) {

--- a/android/app/src/main/java/net/minetest/minetest/UnzipService.java
+++ b/android/app/src/main/java/net/minetest/minetest/UnzipService.java
@@ -29,10 +29,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Environment;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.annotation.StringRes;
 
 import java.io.File;
@@ -98,7 +98,9 @@ public class UnzipService extends IntentService {
 			failureMessage = e.getLocalizedMessage();
 		} finally {
 			setIsRunning(false);
-			zipFile.delete();
+			if (!zipFile.delete()) {
+				Log.w("UnzipService", "Minetest installation ZIP cannot be deleted");
+			}
 		}
 	}
 
@@ -131,8 +133,12 @@ public class UnzipService extends IntentService {
 		Intent notificationIntent = new Intent(this, MainActivity.class);
 		notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP
 			| Intent.FLAG_ACTIVITY_SINGLE_TOP);
+		int pendingIntentFlag = 0;
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+			pendingIntentFlag = PendingIntent.FLAG_MUTABLE;
+		}
 		PendingIntent intent = PendingIntent.getActivity(this, 0,
-			notificationIntent, 0);
+			notificationIntent, pendingIntentFlag);
 
 		builder.setContentTitle(getString(R.string.notification_title))
 				.setSmallIcon(R.mipmap.ic_launcher)
@@ -210,7 +216,9 @@ public class UnzipService extends IntentService {
 			return;
 
 		publishProgress(notificationBuilder, R.string.migrating, 0);
-		newLocation.mkdir();
+		if (!newLocation.mkdir()) {
+			Log.e("UnzipService", "New installation folder cannot be made");
+		}
 
 		String[] dirs = new String[] { "worlds", "games", "mods", "textures", "client" };
 		for (int i = 0; i < dirs.length; i++) {
@@ -228,7 +236,9 @@ public class UnzipService extends IntentService {
 			}
 		}
 
-		recursivelyDeleteDirectory(oldLocation);
+		if (!recursivelyDeleteDirectory(oldLocation)) {
+			Log.w("UnzipService", "Old installation files cannot be deleted successfully");
+		}
 	}
 
 	private void publishProgress(@Nullable  Notification.Builder notificationBuilder, @StringRes int message, int progress) {

--- a/android/app/src/main/java/net/minetest/minetest/UnzipService.java
+++ b/android/app/src/main/java/net/minetest/minetest/UnzipService.java
@@ -77,9 +77,6 @@ public class UnzipService extends IntentService {
 		try {
 			setIsRunning(true);
 			File userDataDirectory = Utils.getUserDataDirectory(this);
-			if (userDataDirectory == null) {
-				throw new IOException("Unable to find user data directory");
-			}
 
 			try (InputStream in = this.getAssets().open(zipFile.getName())) {
 				try (OutputStream out = new FileOutputStream(zipFile)) {

--- a/android/app/src/main/java/net/minetest/minetest/Utils.java
+++ b/android/app/src/main/java/net/minetest/minetest/Utils.java
@@ -1,6 +1,7 @@
 package net.minetest.minetest;
 
 import android.content.Context;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -10,7 +11,8 @@ public class Utils {
 	public static @NonNull File createDirs(File root, String dir) {
 		File f = new File(root, dir);
 		if (!f.isDirectory())
-			f.mkdirs();
+			if (!f.mkdirs())
+				Log.e("Utils", "Directory " + dir + " cannot be created");
 
 		return f;
 	}

--- a/android/app/src/main/java/net/minetest/minetest/Utils.java
+++ b/android/app/src/main/java/net/minetest/minetest/Utils.java
@@ -4,11 +4,12 @@ import android.content.Context;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import java.io.File;
+import java.util.Objects;
 
 public class Utils {
-	public static @NonNull File createDirs(File root, String dir) {
+	@NonNull
+	public static File createDirs(@NonNull File root, @NonNull String dir) {
 		File f = new File(root, dir);
 		if (!f.isDirectory())
 			if (!f.mkdirs())
@@ -17,22 +18,26 @@ public class Utils {
 		return f;
 	}
 
-	public static @Nullable File getUserDataDirectory(Context context) {
-		File extDir = context.getExternalFilesDir(null);
-		if (extDir == null) {
-			return null;
-		}
-
+	@NonNull
+	public static File getUserDataDirectory(@NonNull Context context) {
+		File extDir = Objects.requireNonNull(
+			context.getExternalFilesDir(null),
+			"Cannot get external file directory"
+		);
 		return createDirs(extDir, "Minetest");
 	}
 
-	public static @Nullable File getCacheDirectory(Context context) {
-		return context.getCacheDir();
+	@NonNull
+	public static File getCacheDirectory(@NonNull Context context) {
+		return Objects.requireNonNull(
+			context.getCacheDir(),
+			"Cannot get cache directory"
+		);
 	}
 
-	public static boolean isInstallValid(Context context) {
+	public static boolean isInstallValid(@NonNull Context context) {
 		File userDataDirectory = getUserDataDirectory(context);
-		return userDataDirectory != null && userDataDirectory.isDirectory() &&
+		return userDataDirectory.isDirectory() &&
 			new File(userDataDirectory, "games").isDirectory() &&
 			new File(userDataDirectory, "builtin").isDirectory() &&
 			new File(userDataDirectory, "client").isDirectory() &&

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1421,7 +1421,6 @@ bool Game::createClient(const GameStartData &start_data)
 	if (g_touchscreengui) {
 		g_touchscreengui->init(texture_src);
 		g_touchscreengui->hide();
-		g_touchscreengui->setUseCrosshair(!isNoCrosshairAllowed());
 	}
 #endif
 	if (!connectToServer(start_data, &could_connect, &connect_aborted))
@@ -1458,6 +1457,11 @@ bool Game::createClient(const GameStartData &start_data)
 	if (client->modsLoaded())
 		client->getScript()->on_camera_ready(camera);
 	client->setCamera(camera);
+#ifdef HAVE_TOUCHSCREENGUI
+	if (g_touchscreengui) {
+		g_touchscreengui->setUseCrosshair(!isNoCrosshairAllowed());
+	}
+#endif
 
 	/* Clouds
 	 */


### PR DESCRIPTION
**Goal of the PR**
This PR fixes several bugs and warnings (from the linter) for the Android build.

**How does the PR work?**
- Information about the crosshair is sent after camera initialisation.
- Since API 31, `PendingIntent` [requires mutability flag](https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability).
- `super` (class) is called in `onRequestPermissionsResult()`.
- `GameActivity` suppresses "unused" warning since most of its methods are called from native code.
- [Non-null safety](https://docs.oracle.com/javase/8/docs/api/java/util/Objects.html#requireNonNull-T-java.lang.String-) is added for nullable function calls.
- Warning/error logging is added for various function calls' return value.

**Does it resolve any reported issue?**
Yes, this PR tries to fix bugs and warnings (from Android Studio's linter):
- This PR tries to fix #12952 which is `UnzipService` can not create notification while copying since #12911.
- I made a mistake when creating #12910 as a fix. Minetest can not play any world because the camera has not been initialised.

**Does this relate to a goal in the roadmap?**
Probably, this PR tries to fix crashes and bugs specifically for the Android build.

## To do
This PR is Ready for Review.

## How to test
1. Compile Minetest for Android.
2. There should be no compilation error.
3. Run Minetest and play any world.
4. There should be no runtime error while playing.