### PR TITLE
Avoid shadow flicker at certain angles

### DIFF
--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -41,10 +41,13 @@ static v3f quantizeDirection(v3f direction, float step)
 
 void DirectionalLight::createSplitMatrices(const Camera *cam)
 {
-	const float DISTANCE_STEP = BS * 2.0; // 2 meters
+	static const float COS_15_DEG = 0.965926f;
 	v3f newCenter;
-	v3f look = cam->getDirection();
-	look = quantizeDirection(look, M_PI / 12.0); // 15 degrees
+	v3f look = cam->getDirection().normalize();
+	if (look.dotProduct(last_look) >= COS_15_DEG)
+		look = last_look;
+	else
+		last_look = look;
 
 	// camera view tangents
 	float tanFovY = tanf(cam->getFovY() * 0.5f);
@@ -56,10 +59,11 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 
 	// adjusted camera positions
 	v3f cam_pos_world = cam->getPosition();
-	cam_pos_world = v3f(
-			floor(cam_pos_world.X / DISTANCE_STEP) * DISTANCE_STEP,
-			floor(cam_pos_world.Y / DISTANCE_STEP) * DISTANCE_STEP,
-			floor(cam_pos_world.Z / DISTANCE_STEP) * DISTANCE_STEP);
+	if (cam_pos_world.getDistanceFromSQ(last_cam_pos_world) < BS * BS)
+		cam_pos_world = last_cam_pos_world;
+	else
+		last_cam_pos_world = cam_pos_world;
+
 	v3f cam_pos_scene = v3f(cam_pos_world.X - cam->getOffset().X * BS,
 			cam_pos_world.Y - cam->getOffset().Y * BS,
 			cam_pos_world.Z - cam->getOffset().Z * BS);

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -44,6 +44,9 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	static const float COS_15_DEG = 0.965926f;
 	v3f newCenter;
 	v3f look = cam->getDirection().normalize();
+
+	// if current look direction is < 15 degrees away from the captured
+	// look direction then stick to the captured value, otherwise recapture.
 	if (look.dotProduct(last_look) >= COS_15_DEG)
 		look = last_look;
 	else
@@ -59,6 +62,9 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 
 	// adjusted camera positions
 	v3f cam_pos_world = cam->getPosition();
+
+	// if world position is less than 1 block away from the captured
+	// world position then stick to the captured value, otherwise recapture.
 	if (cam_pos_world.getDistanceFromSQ(last_cam_pos_world) < BS * BS)
 		cam_pos_world = last_cam_pos_world;
 	else

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -114,6 +114,10 @@ private:
 
 	v3f pos;
 	v3f direction{0};
+
+	v3f last_cam_pos_world{0,0,0};
+	v3f last_look{0,1,0};
+
 	shadowFrustum shadow_frustum;
 	shadowFrustum future_frustum;
 	bool dirty{false};


### PR DESCRIPTION
Change the way look direction and camera position are quantized when calculating light frustum, so that walking at 90 degrees to Sun rays does not cause shadow near player to flicker.

## To do

This PR is Ready for Review.

## How to test

1. Enable shadows
2. `/time 9000`
3. Find a cave or a wall orthogonal to Sun rays and walk along it (on the shadow side)
4. Shadow on the ground must not flicker