### PR TITLE
Deprecate special handling of `${key}` syntax in metadata values

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -250,11 +250,12 @@ local formspec_escapes = {
 	["["] = "\\[",
 	["]"] = "\\]",
 	[";"] = "\\;",
-	[","] = "\\,"
+	[","] = "\\,",
+	["$"] = "\\$",
 }
 function core.formspec_escape(text)
 	-- Use explicit character set instead of dot here because it doubles the performance
-	return text and string.gsub(text, "[\\%[%];,]", formspec_escapes)
+	return text and string.gsub(text, "[\\%[%];,$]", formspec_escapes)
 end
 
 

--- a/doc/breakages.md
+++ b/doc/breakages.md
@@ -9,3 +9,4 @@ This document contains a list of breaking changes to be made in the next major v
 * remove `depends.txt` / `description.txt` (would simplify ContentDB and Minetest code a little)
 * rotate moon texture by 180°, making it coherent with the sun (see https://github.com/minetest/minetest/pull/11902)
 * remove undocumented `set_physics_override(num, num, num)`
+* remove special handling of `${key}` syntax in metadata values

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6854,6 +6854,10 @@ Can be obtained via `item:get_meta()`.
 Base class used by [`StorageRef`], [`NodeMetaRef`], [`ItemStackMetaRef`],
 and [`PlayerMetaRef`].
 
+Note: If a metadata value is in the format `${k}`, an attempt to get the value
+will return the value associated with key `k`. There is a low recursion limit.
+This behavior is **deprecated** and will be removed in a future version.
+
 ### Methods
 
 * `contains(key)`: Returns true if key present, otherwise false.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6856,7 +6856,8 @@ and [`PlayerMetaRef`].
 
 Note: If a metadata value is in the format `${k}`, an attempt to get the value
 will return the value associated with key `k`. There is a low recursion limit.
-This behavior is **deprecated** and will be removed in a future version.
+This behavior is **deprecated** and will be removed in a future version. Usage
+of the `${k}` syntax in formspecs is not deprecated.
 
 ### Methods
 

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "metadata.h"
 #include "log.h"
+#include "convert_json.h"
 
 /*
 	IMetadata
@@ -51,7 +52,7 @@ const std::string &IMetadata::getString(const std::string &name, std::string *pl
 		return empty_string;
 	}
 
-	return resolveString(*raw, place, recursion);
+	return resolveString(*raw, place, recursion, true);
 }
 
 bool IMetadata::getStringToRef(const std::string &name,
@@ -61,16 +62,19 @@ bool IMetadata::getStringToRef(const std::string &name,
 	if (!raw)
 		return false;
 
-	const std::string &resolved = resolveString(*raw, &str, recursion);
+	const std::string &resolved = resolveString(*raw, &str, recursion, true);
 	if (&resolved != &str)
 		str = resolved;
 	return true;
 }
 
 const std::string &IMetadata::resolveString(const std::string &str, std::string *place,
-		u16 recursion) const
+		u16 recursion, bool deprecated) const
 {
 	if (recursion <= 1 && str.substr(0, 2) == "${" && str[str.length() - 1] == '}') {
+		if (deprecated)
+			warningstream << "Deprecated use of recursive resolution syntax in metadata: "
+					<< fastWriteJson(Json::Value(str)) << std::endl;
 		// It may be the case that &str == place, but that's fine.
 		return getString(str.substr(2, str.length() - 3), place, recursion + 1);
 	}

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -19,7 +19,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "metadata.h"
 #include "log.h"
-#include "convert_json.h"
 
 /*
 	IMetadata
@@ -72,9 +71,11 @@ const std::string &IMetadata::resolveString(const std::string &str, std::string 
 		u16 recursion, bool deprecated) const
 {
 	if (recursion <= 1 && str.substr(0, 2) == "${" && str[str.length() - 1] == '}') {
-		if (deprecated)
-			warningstream << "Deprecated use of recursive resolution syntax in metadata: "
-					<< fastWriteJson(Json::Value(str)) << std::endl;
+		if (deprecated) {
+			warningstream << "Deprecated use of recursive resolution syntax in metadata: ";
+			safe_print_string(warningstream, str);
+			warningstream << std::endl;
+		}
 		// It may be the case that &str == place, but that's fine.
 		return getString(str.substr(2, str.length() - 3), place, recursion + 1);
 	}

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -65,7 +65,7 @@ public:
 
 	// Add support for variable names in values. Uses place like getString.
 	const std::string &resolveString(const std::string &str, std::string *place,
-			u16 recursion = 0) const;
+			u16 recursion = 0, bool deprecated = false) const;
 
 protected:
 	// Returns nullptr to indicate absence of value. Uses place like getString.

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -459,6 +459,7 @@ inline void str_formspec_escape(std::string &str)
 	str_replace(str, "[", "\\[");
 	str_replace(str, ";", "\\;");
 	str_replace(str, ",", "\\,");
+	str_replace(str, "$", "\\$");
 }
 
 /**


### PR DESCRIPTION
Closes https://github.com/minetest/minetest/issues/12577. IMO this behavior is not desirable. The `${key}` syntax is only deprecated in metadata values, not in formspecs. You can see the deprecated behavior in action here: https://github.com/minetest/minetest/blob/6bf662cb9ee598a9bcd1b91a7d9293b852b5129b/games/devtest/mods/unittests/metadata.lua#L59-L64

This PR also escapes "$" in formspec strings to avoid accidental substitution.

## To do

This PR is Ready for Review.

## How to test

1. Run the unit tests. See that warnings are printed by the metadata tests.
2. Try using a sign from Minetest Game. No warnings should be printed.
3. Try setting the sign's text to "${formspec}". When you open the form again, the text input should read "field[text;;${text}]". A deprecation warning should have been printed.
4. Try changing a sign's formspec from `"field[text;;${text}]"` to `"field[text;;\\${text}]"`. The text input should read "${text}".
