### PR TITLE
Add option to silence HTTP errors

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -9844,6 +9844,10 @@ Used by `HTTPApiTable.fetch` and `HTTPApiTable.fetch_async`.
         -- Default is false.
         -- Post only, data must be array
 
+        print_error = boolean,
+        -- Optional, if true then an error message is printed on failure.
+        -- Default is true.
+
         post_data = "Raw POST request data string" OR {field1 = "data1", field2 = "data2"},
         -- Deprecated, use `data` instead. Forces `method = "POST"`.
     }

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -390,17 +390,19 @@ const HTTPFetchResult * HTTPFetchOngoing::complete(CURLcode res)
 		result.response_code = 0;
 	}
 
-	if (res != CURLE_OK) {
-		errorstream << "HTTPFetch for " << request.url << " failed ("
-			<< curl_easy_strerror(res) << ")" << std::endl;
-	} else if (result.response_code >= 400) {
-		errorstream << "HTTPFetch for " << request.url
-			<< " returned response code " << result.response_code
-			<< std::endl;
-		if (result.caller == HTTPFETCH_PRINT_ERR && !result.data.empty()) {
-			errorstream << "Response body:" << std::endl;
-			safe_print_string(errorstream, result.data);
-			errorstream << std::endl;
+	if (request.print_error) {
+		if (res != CURLE_OK) {
+			errorstream << "HTTPFetch for " << request.url << " failed ("
+				<< curl_easy_strerror(res) << ")" << std::endl;
+		} else if (result.response_code >= 400) {
+			errorstream << "HTTPFetch for " << request.url
+				<< " returned response code " << result.response_code
+				<< std::endl;
+			if (result.caller == HTTPFETCH_PRINT_BODY && !result.data.empty()) {
+				errorstream << "Response body:" << std::endl;
+				safe_print_string(errorstream, result.data);
+				errorstream << std::endl;
+			}
 		}
 	}
 

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -31,7 +31,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // requests because the result does not have to be retrieved later).
 #define HTTPFETCH_SYNC 1
 // Print response body to console if the server returns an error code.
-#define HTTPFETCH_PRINT_ERR 2
+#define HTTPFETCH_PRINT_BODY 2
 // Start of regular allocated caller IDs.
 #define HTTPFETCH_CID_START 3
 
@@ -81,6 +81,9 @@ struct HTTPFetchRequest
 
 	// useragent to use
 	std::string useragent;
+
+	// If true, print to errorstream when result is not OK.
+	bool print_error = true;
 
 	HTTPFetchRequest();
 };

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -91,6 +91,8 @@ void ModApiHttp::read_http_fetch_request(lua_State *L, HTTPFetchRequest &req)
 		}
 	}
 	lua_pop(L, 1);
+
+	req.print_error = getboolfield_default(L, 1, "print_error", true);
 }
 
 void ModApiHttp::push_http_fetch_result(lua_State *L, HTTPFetchResult &res, bool completed)

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -97,7 +97,7 @@ void sendAnnounce(AnnounceAction action,
 	}
 
 	HTTPFetchRequest fetch_request;
-	fetch_request.caller = HTTPFETCH_PRINT_ERR;
+	fetch_request.caller = HTTPFETCH_PRINT_BODY;
 	fetch_request.url = g_settings->get("serverlist_url") + std::string("/announce");
 	fetch_request.method = HTTP_POST;
 	fetch_request.fields["json"] = fastWriteJson(server);


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/12827.

- Adds `print_error` option to HTTP request table.
- Adds `print_error` to HTTP request struct in C++.
- Renames `HTTPFETCH_PRINT_ERR` to `HTTPFETCH_PRINT_BODY` to avoid confusion.

## To do

This PR is Ready for Review.

## How to test

- This request should succeed:
  ```lua
  {
  	url = "http://example.org",
  	timeout = 10,
  	method = "GET",
  	data = {field1 = "data1", field2 = "data2"},
  	user_agent = "ExampleUserAgent",
  	extra_headers = { "Accept-Language: en-us", "Accept-Charset: utf-8" },
  	multipart = false,
  	post_data = {field1 = "data1", field2 = "data2"},
  }
  ```
- This request should print an error:
  ```lua
  {
  	url = "http://example.orgfjjkfjkg",
  	timeout = 10,
  	method = "GET",
  	data = {field1 = "data1", field2 = "data2"},
  	user_agent = "ExampleUserAgent",
  	extra_headers = { "Accept-Language: en-us", "Accept-Charset: utf-8" },
  	multipart = false,
  	post_data = {field1 = "data1", field2 = "data2"},
  }
  ```
- This request should not:
  ```lua
  {
  	url = "http://example.orgfjjkfjkg",
  	timeout = 10,
  	method = "GET",
  	data = {field1 = "data1", field2 = "data2"},
  	user_agent = "ExampleUserAgent",
  	extra_headers = { "Accept-Language: en-us", "Accept-Charset: utf-8" },
  	multipart = false,
  	post_data = {field1 = "data1", field2 = "data2"},
  	print_error = false,
  }
  ```
- Try changing the server list URL to some domain that doesn't exist. When the requests sent by the server list tab fail, they should print errors.
