### PR TITLE
Object selection: Improve distance checks

### DIFF
--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -106,4 +106,44 @@ void ActiveObjectMgr::getActiveObjects(const v3f &origin, f32 max_d,
 	}
 }
 
+void ActiveObjectMgr::getActiveSelectableObjects(const core::line3d<f32> &shootline,
+		std::vector<DistanceSortedActiveObject> &dest)
+{
+	// Imagine a not-axis-aligned cuboid oriented into the direction of the shootline,
+	// with the width of the object's selection box radius * 2 and with length of the
+	// shootline (+selection box radius forwards and backwards). We check whether
+	// the selection box center is inside this cuboid.
+
+	f32 max_d = shootline.getLength();
+	v3f dir = shootline.getVector().normalize();
+	v3f dir_ortho1 = dir.crossProduct(dir + v3f(1,0,0)).normalize();
+	v3f dir_ortho2 = dir.crossProduct(dir_ortho1);
+
+	for (auto &ao_it : m_active_objects) {
+		ClientActiveObject *obj = ao_it.second;
+
+		aabb3f selection_box;
+		if (!obj->getSelectionBox(&selection_box))
+			continue;
+
+		// possible optimization: get rid of the sqrt here
+		f32 selection_box_radius = selection_box.getRadius();
+
+		v3f pos_diff = obj->getPosition() + selection_box.getCenter() - shootline.start;
+
+		f32 d = dir.dotProduct(pos_diff);
+
+		// backward- and far-plane
+		if (d + selection_box_radius < 0.0f || d - selection_box_radius > max_d)
+			continue;
+
+		// side-planes
+		if (std::fabs(dir_ortho1.dotProduct(pos_diff)) > selection_box_radius
+				|| std::fabs(dir_ortho2.dotProduct(pos_diff)) > selection_box_radius)
+			continue;
+
+		dest.emplace_back(obj, d);
+	}
+}
+
 } // namespace client

--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include <math>
 #include <log.h>
 #include "profiler.h"
 #include "activeobjectmgr.h"

--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -17,7 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <math>
+#include <cmath>
 #include <log.h>
 #include "profiler.h"
 #include "activeobjectmgr.h"

--- a/src/client/activeobjectmgr.h
+++ b/src/client/activeobjectmgr.h
@@ -37,5 +37,12 @@ public:
 
 	void getActiveObjects(const v3f &origin, f32 max_d,
 			std::vector<DistanceSortedActiveObject> &dest);
+	// Similar to above, but takes selection box sizes, and line direction into
+	// account.
+	// Objects without selectionbox are not returned.
+	// Returned distances are in direction of shootline.
+	// Distance check is coarse.
+	void getActiveSelectableObjects(const core::line3d<f32> &shootline,
+			std::vector<DistanceSortedActiveObject> &dest);
 };
 } // namespace client

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -495,8 +495,7 @@ void ClientEnvironment::getSelectedActiveObjects(
 	std::vector<PointedThing> &objects)
 {
 	std::vector<DistanceSortedActiveObject> allObjects;
-	getActiveObjects(shootline_on_map.start,
-		shootline_on_map.getLength() + 10.0f, allObjects);
+	m_ao_manager.getActiveSelectableObjects(shootline_on_map, allObjects);
 	const v3f line_vector = shootline_on_map.getVector();
 
 	for (const auto &allObject : allObjects) {


### PR DESCRIPTION

- Goal of the PR: Fix the bug that if you move away from an object's origin, but the box is still in range, then you can't select the object anymore.
- How does the PR work: See code comment.
- Does it resolve any reported issue: Haven't found any.
- Bugfix, and possibly a small performance improvement if there are many objects nearby.

## To do

This PR is a Ready for Review.

## How to test

* Start devtest.
* Spawn an object (with entity spawner).
* Use object property editor tool on obj, select the selection box from the list, edit one bound to some high value (i.e. 10).
* Point to selection box, move to change distance.
