### PR TITLE
Improve chat history

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -503,14 +503,13 @@ void ChatPrompt::addToHistory(const std::wstring &line)
 {
 	std::wstring old_line = getLine();
 	if (m_history_index < m_history.size()) {
-		HistoryEntry &entry = m_history[m_history_index];
-		if (entry.saved && entry.line == line) {
-			entry.line = *entry.saved;
-			entry.saved = nullopt;
+		auto entry = m_history.begin() + m_history_index;
+		if (entry->saved && entry->line == line) {
+			entry->line = *entry->saved;
+			entry->saved = nullopt;
 			// Remove the entry if it is now a duplicate
-			if (std::find(m_history.begin() + m_history_index + 1, m_history.end(), entry)
-					!= m_history.end())
-				m_history.erase(m_history.begin() + m_history_index);
+			if (std::find(entry + 1, m_history.end(), *entry) != m_history.end())
+				m_history.erase(entry);
 		}
 	}
 	if (!line.empty() &&

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -507,8 +507,11 @@ void ChatPrompt::addToHistory(const std::wstring &line)
 		if (entry->saved && entry->line == line) {
 			entry->line = *entry->saved;
 			entry->saved = nullopt;
-			// Remove the entry if it is now a duplicate
-			if (std::find(entry + 1, m_history.end(), *entry) != m_history.end())
+			// Remove potential duplicates
+			auto dup_before = std::find(m_history.begin(), entry, *entry);
+			if (dup_before != entry)
+				m_history.erase(dup_before);
+			else if (std::find(entry + 1, m_history.end(), *entry) != m_history.end())
 				m_history.erase(entry);
 		}
 	}

--- a/src/chat.h
+++ b/src/chat.h
@@ -246,6 +246,7 @@ protected:
 private:
 	struct HistoryEntry {
 		std::wstring line;
+		// If line is edited, saved holds the unedited version.
 		Optional<std::wstring> saved;
 
 		HistoryEntry(const std::wstring &line): line(line) {}

--- a/src/chat.h
+++ b/src/chat.h
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "irrlichttypes.h"
 #include "util/enriched_string.h"
+#include "util/Optional.h"
 #include "settings.h"
 
 // Chat console related classes
@@ -172,10 +173,10 @@ public:
 	void addToHistory(const std::wstring &line);
 
 	// Get current line
-	std::wstring getLine() const { return m_line; }
+	std::wstring getLine() const { return getLineRef(); }
 
 	// Get section of line that is currently selected
-	std::wstring getSelection() const { return m_line.substr(m_cursor, m_cursor_len); }
+	std::wstring getSelection() const { return getLineRef().substr(m_cursor, m_cursor_len); }
 
 	// Clear the current line
 	void clear();
@@ -233,18 +234,32 @@ public:
 	void cursorOperation(CursorOp op, CursorOpDir dir, CursorOpScope scope);
 
 protected:
+	const std::wstring &getLineRef() const;
+
+	std::wstring &makeLineRef();
+
 	// set m_view to ensure that 0 <= m_view <= m_cursor < m_view + m_cols
 	// if line can be fully shown, set m_view to zero
 	// else, also ensure m_view <= m_line.size() + 1 - m_cols
 	void clampView();
 
 private:
+	struct HistoryEntry {
+		std::wstring line;
+		Optional<std::wstring> saved;
+
+		HistoryEntry(const std::wstring &line): line(line) {}
+
+		bool operator==(const HistoryEntry &other);
+		bool operator!=(const HistoryEntry &other) { return !(*this == other); }
+	};
+
 	// Prompt prefix
 	std::wstring m_prompt = L"";
-	// Currently edited line
+	// Non-historical edited line
 	std::wstring m_line = L"";
 	// History buffer
-	std::vector<std::wstring> m_history;
+	std::vector<HistoryEntry> m_history;
 	// History index (0 <= m_history_index <= m_history.size())
 	u32 m_history_index = 0;
 	// Maximum number of history entries


### PR DESCRIPTION
Closes https://github.com/minetest/minetest/issues/12918.

- The current line is preserved even if one presses up then down again.
- Each line in history can be edited but stores the original line too. If one presses enter after editing a line of history, this line is appended to history and the entry you were at is restored to its original form. This seems to be the way Bash does it.
- Line editing is kept pretty much the same otherwise.

## To do

This PR is Ready for Review.

## How to test

1. Enter "1" in chat.
2. Enter "2" in chat.
3. Enter "3" in chat.
4. Type "4" in chat without pressing enter.
5. Edit the "1" in history to be "11" without pressing enter.
6. Go back to "4".
7. Change "4" to "1" and press enter.
8. Go back up to "11" and press enter.
9. There should be no "1" in history before "2".
10. Go to "2" in history and change it to "22" then back to "2" without pressing enter.
11. Go back to the bottom of history and enter "2".
13. There should be no "2" in history before "3".
14. Go to "3" and change it to "33" then press enter.
15. "3" should still exist in history.
11. Go back to the bottom of history and enter "3".
12. Now "3" should only appear in history after "33".
13. Repeat this procedure on the terminal console.
