### PR TITLE
Wrap debug text on screen

### DIFF
--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -55,11 +55,11 @@ void GameUI::init()
 {
 	// First line of debug text
 	m_guitext = gui::StaticText::add(guienv, utf8_to_wide(PROJECT_NAME_C).c_str(),
-		core::rect<s32>(0, 0, 0, 0), false, false, guiroot);
+		core::rect<s32>(0, 0, 0, 0), false, true, guiroot);
 
 	// Second line of debug text
 	m_guitext2 = gui::StaticText::add(guienv, L"", core::rect<s32>(0, 0, 0, 0), false,
-		false, guiroot);
+		true, guiroot);
 
 	// Chat text
 	m_guitext_chat = gui::StaticText::add(guienv, L"", core::rect<s32>(0, 0, 0, 0),
@@ -102,6 +102,8 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 {
 	v2u32 screensize = RenderingEngine::getWindowSize();
 
+	s32 minimal_debug_height = 0;
+
 	// Minimal debug text must only contain info that can't give a gameplay advantage
 	if (m_flags.show_minimal_debug) {
 		const u16 fps = 1.0 / stats.dtime_jitter.avg;
@@ -122,10 +124,13 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			<< (draw_control->range_all ? "All" : itos(draw_control->wanted_range))
 			<< std::setprecision(2)
 			<< " | RTT: " << (client->getRTT() * 1000.0f) << "ms";
-		setStaticText(m_guitext, utf8_to_wide(os.str()).c_str());
 
 		m_guitext->setRelativePosition(core::rect<s32>(5, 5, screensize.X,
-			5 + g_fontengine->getTextHeight()));
+			5 + g_fontengine->getTextHeight() * 2));
+
+		setStaticText(m_guitext, utf8_to_wide(os.str()).c_str());
+
+		minimal_debug_height = m_guitext->getTextHeight();
 	}
 
 	// Finally set the guitext visible depending on the flag
@@ -161,12 +166,12 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			}
 		}
 
-		setStaticText(m_guitext2, utf8_to_wide(os.str()).c_str());
-
 		m_guitext2->setRelativePosition(core::rect<s32>(5,
-			5 + g_fontengine->getTextHeight(), screensize.X,
-			5 + g_fontengine->getTextHeight() * 2
+			5 + minimal_debug_height, screensize.X,
+			5 + minimal_debug_height + g_fontengine->getTextHeight() * 2
 		));
+
+		setStaticText(m_guitext2, utf8_to_wide(os.str()).c_str());
 	}
 
 	m_guitext2->setVisible(m_flags.show_basic_debug);
@@ -241,9 +246,9 @@ void GameUI::updateChatSize()
 	s32 chat_y = 5;
 
 	if (m_flags.show_minimal_debug)
-		chat_y += g_fontengine->getLineHeight();
+		chat_y += m_guitext->getTextHeight();
 	if (m_flags.show_basic_debug)
-		chat_y += g_fontengine->getLineHeight();
+		chat_y += m_guitext2->getTextHeight();
 
 	const v2u32 &window_size = RenderingEngine::getWindowSize();
 

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -125,8 +125,7 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			<< std::setprecision(2)
 			<< " | RTT: " << (client->getRTT() * 1000.0f) << "ms";
 
-		m_guitext->setRelativePosition(core::rect<s32>(5, 5, screensize.X,
-			5 + g_fontengine->getTextHeight() * 2));
+		m_guitext->setRelativePosition(core::rect<s32>(5, 5, screensize.X, screensize.Y));
 
 		setStaticText(m_guitext, utf8_to_wide(os.str()).c_str());
 
@@ -166,10 +165,8 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			}
 		}
 
-		m_guitext2->setRelativePosition(core::rect<s32>(5,
-			5 + minimal_debug_height, screensize.X,
-			5 + minimal_debug_height + g_fontengine->getTextHeight() * 2
-		));
+		m_guitext2->setRelativePosition(core::rect<s32>(5, 5 + minimal_debug_height,
+				screensize.X, screensize.Y));
 
 		setStaticText(m_guitext2, utf8_to_wide(os.str()).c_str());
 	}


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/12977. Minimal and basic debug text is now wrapped.

## To do

This PR is Ready for Review.

## How to test

Try making the screen narrow with minimal and basic debug enabled, and with just minimal debug enabled. Chat should adjust to the debug text height.

Ideally, test on Android too so as to ensure https://github.com/minetest/minetest/issues/12977 is fixed.