### PR TITLE
Improvement of #12974: better lin independent vector and remove sqrt

### DIFF
--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -117,7 +117,9 @@ void ActiveObjectMgr::getActiveSelectableObjects(const core::line3d<f32> &shootl
 
 	f32 max_d = shootline.getLength();
 	v3f dir = shootline.getVector().normalize();
-	v3f dir_ortho1 = dir.crossProduct(dir + v3f(1,0,0)).normalize();
+	// arbitrary linearly independent vector and orthogonal dirs
+	v3f li2dir = dir + (std::fabs(dir.X) < 0.5f ? v3f(1,0,0) : v3f(0,1,0));
+	v3f dir_ortho1 = dir.crossProduct(li2dir).normalize();
 	v3f dir_ortho2 = dir.crossProduct(dir_ortho1);
 
 	for (auto &ao_it : m_active_objects) {

--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -142,12 +142,14 @@ void ActiveObjectMgr::getActiveSelectableObjects(const core::line3d<f32> &shootl
 				|| sq(dir_ortho2.dotProduct(pos_diff)) > selection_box_radius2)
 			continue;
 
-		f32 selection_box_radius = std::sqrt(selection_box_radius2);
-
 		f32 d = dir.dotProduct(pos_diff);
 
-		// backward- and far-plane
-		if (d + selection_box_radius < 0.0f || d - selection_box_radius > max_d)
+		// backward-plane
+		if (d < 0.0f && sq(d) > selection_box_radius2)
+			continue;
+
+		// far-plane
+		if (d > max_d && sq(d - max_d) > selection_box_radius2)
 			continue;
 
 		dest.emplace_back(obj, d);

--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -115,7 +115,10 @@ void ActiveObjectMgr::getActiveSelectableObjects(const core::line3d<f32> &shootl
 	// shootline (+selection box radius forwards and backwards). We check whether
 	// the selection box center is inside this cuboid.
 
-	f32 max_d = shootline.getLength();
+	auto sq = [](f32 a) { return a * a; };
+
+	f32 max_d2 = shootline.getLengthSQ();
+	f32 max_d = std::sqrt(max_d2);
 	v3f dir = shootline.getVector().normalize();
 	// arbitrary linearly independent vector and orthogonal dirs
 	v3f li2dir = dir + (std::fabs(dir.X) < 0.5f ? v3f(1,0,0) : v3f(0,1,0));
@@ -129,20 +132,22 @@ void ActiveObjectMgr::getActiveSelectableObjects(const core::line3d<f32> &shootl
 		if (!obj->getSelectionBox(&selection_box))
 			continue;
 
-		// possible optimization: get rid of the sqrt here
-		f32 selection_box_radius = selection_box.getRadius();
+		// aabb3f::getRadius() squared
+		f32 selection_box_radius2 = selection_box.getExtent().getLengthSQ() * 0.25f;
 
 		v3f pos_diff = obj->getPosition() + selection_box.getCenter() - shootline.start;
+
+		// side-planes
+		if (sq(dir_ortho1.dotProduct(pos_diff)) > selection_box_radius2
+				|| sq(dir_ortho2.dotProduct(pos_diff)) > selection_box_radius2)
+			continue;
+
+		f32 selection_box_radius = std::sqrt(selection_box_radius2);
 
 		f32 d = dir.dotProduct(pos_diff);
 
 		// backward- and far-plane
 		if (d + selection_box_radius < 0.0f || d - selection_box_radius > max_d)
-			continue;
-
-		// side-planes
-		if (std::fabs(dir_ortho1.dotProduct(pos_diff)) > selection_box_radius
-				|| std::fabs(dir_ortho2.dotProduct(pos_diff)) > selection_box_radius)
 			continue;
 
 		dest.emplace_back(obj, d);


### PR DESCRIPTION
* First commit: The method of finding a lin indep vector in #12974 is broken if dir points towards x, oops. (No issues in practice, but mods could set view dir.)
* Other commits: Remove the use of sqrt, but make code a little less undersandable. 

## To do

This PR is a Ready for Review.

## How to test

I haven't managed to notice a difference in practice.

Performance is also not much better on my machine, so feel free to not merge the later commits.

<details>
<summary>Code for spawning many objs</summary>

```lua

minetest.register_entity("test_many_objs:ent", {
	initial_properties = {
		physical = false,
		collisionbox = {0, 0, 0, 0, 0, 0},
		selectionbox = {-0.1, -0.1, -0.1, 0.1, 0.1, 0.1},
		pointable = false,
		visual = "cube",
		visual_size = {x = 0.1, y = 0.1, z = 0.1},
		backface_culling = false,
		static_save = false,
	},
})

minetest.register_chatcommand("smo", {
	params = "",
	description = "Spawn many objects",
	privs = {},
	func = function(name, param)
		local player = minetest.get_player_by_name(name)
		if not player then
			return false, "Couldn't find you as a player."
		end
		local base_pos = player:get_pos()
		if not base_pos then
			return false, "You have not pos."
		end

		local radius = 20
		local step = 1

		local num = 0

		for x = base_pos.x - radius, base_pos.x + radius, step do
		local y = base_pos.y
		--~ for y = base_pos.y - radius, base_pos.y + radius, step do
		for z = base_pos.z - radius, base_pos.z + radius, step do
			if minetest.add_entity(vector.new(x,y,z), "test_many_objs:ent") then
				num = num + 1
			end
		end
		--~ end
		end

		return true, string.format("Spawned %s objs", num)
	end,
})
```

</details>