### PR TITLE
Check specific outputs for `isatty`

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -124,9 +124,10 @@ public:
 		m_stream(stream)
 	{
 #if !defined(_WIN32)
-		is_tty = isatty(fileno(stdout));
-#else
-		is_tty = false;
+		if (&stream == &std::cout)
+			is_tty = isatty(STDOUT_FILENO);
+		else if (&stream == &std::cerr)
+			is_tty = isatty(STDERR_FILENO);
 #endif
 	}
 
@@ -134,7 +135,7 @@ public:
 
 private:
 	std::ostream &m_stream;
-	bool is_tty;
+	bool is_tty = false;
 };
 
 class FileLogOutput : public ICombinedLogOutput {


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/12653. The implementation is a bit hacky, but I think it's acceptable, as it preserves the generality of the constructor.

## To do

This PR is Ready for Review.

## How to test

1. Run `minetest > out`. stderr should be colorized.
2. Run `minetest 2> err`. `err` should not be colorized.