### PR TITLE
Allow synchronous HTTP fetches to be interrupted

### DIFF
--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -587,7 +587,8 @@ bool GUIEngine::downloadFile(const std::string &url, const std::string &target)
 	fetch_request.url = url;
 	fetch_request.caller = HTTPFETCH_SYNC;
 	fetch_request.timeout = g_settings->getS32("curl_file_download_timeout");
-	httpfetch_sync(fetch_request, fetch_result);
+	if (!httpfetch_sync_interruptible(fetch_request, fetch_result))
+		return false;
 
 	if (!fetch_result.succeeded) {
 		target_file.close();

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -886,6 +886,7 @@ bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
 		do {
 			if (thread->stopRequested()) {
 				httpfetch_caller_free_async(req.caller);
+				fetch_result = HTTPFetchResult(fetch_request);
 				return false;
 			}
 			sleep_ms(interval);

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -128,6 +128,15 @@ u64 httpfetch_caller_alloc_secure();
 // to stop any ongoing fetches for the given caller.
 void httpfetch_caller_free(u64 caller);
 
+// This does the same thing but returns before the caller has been freed.
+void httpfetch_caller_free_async(u64 caller);
+
 // Performs a synchronous HTTP request. This blocks and therefore should
 // only be used from background threads.
 void httpfetch_sync(const HTTPFetchRequest &fetch_request, HTTPFetchResult &fetch_result);
+
+// Performs a synchronous HTTP request that is interruptible if the current
+// thread is a Thread object. interval is the completion check interval in ms.
+// Returned is whether the request completed without interruption.
+bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
+		HTTPFetchResult &fetch_result, long interval = 100);

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -114,9 +114,9 @@ int ModApiHttp::l_http_fetch_sync(lua_State *L)
 	infostream << "Mod performs HTTP request with URL " << req.url << std::endl;
 
 	HTTPFetchResult res;
-	httpfetch_sync(req, res);
+	bool completed = httpfetch_sync_interruptible(req, res);
 
-	push_http_fetch_result(L, res, true);
+	push_http_fetch_result(L, res, completed);
 
 	return 1;
 }

--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -60,6 +60,9 @@ DEALINGS IN THE SOFTWARE.
 #endif
 
 
+thread_local Thread *current_thread = nullptr;
+
+
 Thread::Thread(const std::string &name) :
 	m_name(name),
 	m_request_stop(false),
@@ -176,6 +179,8 @@ void Thread::threadProc(Thread *thr)
 	thr->m_kernel_thread_id = thread_self();
 #endif
 
+	current_thread = thr;
+
 	thr->setName(thr->m_name);
 
 	g_logger.registerThread(thr->m_name);
@@ -193,6 +198,12 @@ void Thread::threadProc(Thread *thr)
 	// released. We try to unlock it from caller thread and it's refused by system.
 	thr->m_start_finished_mutex.unlock();
 	g_logger.deregisterThread();
+}
+
+
+Thread *Thread::getCurrentThread()
+{
+	return current_thread;
 }
 
 

--- a/src/threading/thread.h
+++ b/src/threading/thread.h
@@ -120,6 +120,11 @@ public:
 	bool setPriority(int prio);
 
 	/*
+	 * Returns the current thread object if it exists.
+	 */
+	static Thread *getCurrentThread();
+
+	/*
 	 * Sets the currently executing thread's name to where supported; useful
 	 * for debugging.
 	 */


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/12815. The fix was fairly complicated. `httpfetch_sync_interruptible` calls the async fetch function at an interval, checking also whether a stop was requested for the current thread.

## To do

This PR is Ready for Review.

## How to test

Turn off your internet or otherwise cause HTTP requests to take a while then fail. Try looking at the serverlist then quickly opening a world. The game should not hang. After closing and reopening Minetest, try looking at the serverlist then quickly exiting the game. The program should finish after some time.  After closing and reopening Minetest, try looking at the serverlist and waiting for fetch error messages to appear in the log.

Also check that the serverlist and ContentDB still work under normal conditions.