### PR TITLE
Fix reading schematics after their resolution

### DIFF
--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1694,6 +1694,7 @@ int ModApiMapgen::l_read_schematic(lua_State *L)
 
 	const SchematicManager *schemmgr =
 		getServer(L)->getEmergeManager()->getSchematicManager();
+	const NodeDefManager *ndef = getGameDef(L)->ndef();
 
 	//// Read options
 	std::string write_yslice = getstringfield_default(L, 2, "write_yslice_prob", "all");
@@ -1713,6 +1714,7 @@ int ModApiMapgen::l_read_schematic(lua_State *L)
 
 	//// Create the Lua table
 	u32 numnodes = schem->size.X * schem->size.Y * schem->size.Z;
+	bool resolve_done = schem->isResolveDone();
 	const std::vector<std::string> &names = schem->m_nodenames;
 
 	lua_createtable(L, 0, (write_yslice == "none") ? 2 : 3);
@@ -1742,10 +1744,12 @@ int ModApiMapgen::l_read_schematic(lua_State *L)
 	lua_createtable(L, numnodes, 0); // data table
 	for (u32 i = 0; i < numnodes; ++i) {
 		MapNode node = schem->schemdata[i];
+		const std::string &name =
+				resolve_done ? ndef->get(node.getContent()).name : names[node.getContent()];
 		u8 probability   = node.param1 & MTSCHEM_PROB_MASK;
 		bool force_place = node.param1 & MTSCHEM_FORCE_PLACE;
 		lua_createtable(L, 0, force_place ? 4 : 3);
-		lua_pushstring(L, names[schem->schemdata[i].getContent()].c_str());
+		lua_pushstring(L, name.c_str());
 		lua_setfield(L, 3, "name");
 		lua_pushinteger(L, probability * 2);
 		lua_setfield(L, 3, "prob");


### PR DESCRIPTION
I think this fixes https://github.com/minetest/minetest/issues/12908. It allows reading schematics after load time. After load time, the content IDs in the schematic data are no longer indices into `m_nodenames`, and `m_nodenames` is cleared.

## To do

This PR is Ready for Review.

## How to test

Run this code in Minetest Game:

```lua
local function deepequal(a, b)
	if type(a) ~= "table" then
		return a == b
	elseif type(b) ~= "table" then
		return false
	end
	for k, v in pairs(a) do
		if not deepequal(v, b[k]) then
			return false
		end
	end
	for k, v in pairs(b) do
		if not deepequal(a[k], v) then
			return false
		end
	end
	return true
end
local path = minetest.get_modpath("default") .. "/schematics/aspen_tree.mts" 
local s1 = minetest.read_schematic(path, {})
minetest.after(0, function()
	local s2 = minetest.read_schematic(path, {})
	assert(deepequal(s1, s2))
end)
```
