### PR TITLE
avoid `UnitSAO::clearChildAttachments` iterator invalidation

### DIFF
--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -179,12 +179,16 @@ void UnitSAO::getAttachment(int *parent_id, std::string *bone, v3f *position,
 
 void UnitSAO::clearChildAttachments()
 {
-	for (int child_id : m_attachment_child_ids) {
+	// Cannot use for-loop here: setAttachment() modifies 'm_attachment_child_ids'!
+	while (!m_attachment_child_ids.empty()) {
+		int child_id = *m_attachment_child_ids.begin();
+
 		// Child can be NULL if it was deleted earlier
 		if (ServerActiveObject *child = m_env->getActiveObject(child_id))
 			child->setAttachment(0, "", v3f(0, 0, 0), v3f(0, 0, 0), false);
+
+		removeAttachmentChild(child_id);
 	}
-	m_attachment_child_ids.clear();
 }
 
 void UnitSAO::clearParentAttachment()


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/12986. I copied the implementation from `src/client/content_cao.cpp`.

## To do

This PR is Ready for Review.

## How to test

Try to reproduce https://github.com/minetest/minetest/issues/12986 with the procedure described there.

Using the mod from that issue, attach the host player to the guest player, then have the guest player leave. The server should not crash, the test object should be removed, and the host should detach correctly.