### PR TITLE
Remove shader-variable caching hack.

### DIFF
--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -214,13 +214,13 @@ class MainShaderConstantSetter : public IShaderConstantSetter
 	CachedVertexShaderSetting<f32, 16> m_world;
 
 	// Shadow-related
-	CachedPixelShaderSetting<f32, 16, false> m_shadow_view_proj;
+	CachedPixelShaderSetting<f32, 16> m_shadow_view_proj;
 	CachedPixelShaderSetting<f32, 3> m_light_direction;
 	CachedPixelShaderSetting<f32> m_texture_res;
 	CachedPixelShaderSetting<f32> m_shadow_strength;
 	CachedPixelShaderSetting<f32> m_time_of_day;
 	CachedPixelShaderSetting<f32> m_shadowfar;
-	CachedPixelShaderSetting<f32, 4, false> m_camera_pos;
+	CachedPixelShaderSetting<f32, 4> m_camera_pos;
 	CachedPixelShaderSetting<s32> m_shadow_texture;
 	CachedVertexShaderSetting<f32> m_perspective_bias0_vertex;
 	CachedPixelShaderSetting<f32> m_perspective_bias0_pixel;


### PR DESCRIPTION
The caching hack is no longer needed. (I think it was fixed as part of #12898)
So we can remove these hacks now for slightly better performance.

## How to test

Just make sure shadows still work for blocks and for entities.
I had this change in for over a week and have not seen the original problem.