### PR TITLE
Fix touchscreen crash due to missing rangeselect

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -87,7 +87,12 @@ void set_default_settings()
 	settings->setDefault("keymap_cmd_local", ".");
 	settings->setDefault("keymap_minimap", "KEY_KEY_V");
 	settings->setDefault("keymap_console", "KEY_F10");
+#if HAVE_TOUCHSCREENGUI
+	// See https://github.com/minetest/minetest/issues/12792
+	settings->setDefault("keymap_rangeselect", "KEY_KEY_R");
+#else
 	settings->setDefault("keymap_rangeselect", "");
+#endif
 	settings->setDefault("keymap_freemove", "KEY_KEY_K");
 	settings->setDefault("keymap_pitchmove", "KEY_KEY_P");
 	settings->setDefault("keymap_fastmove", "KEY_KEY_J");


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/12792. This is the simplest approach to doing so.

## To do

This PR is Ready for Review.

## How to test

Test on a device without a touchscreen to ensure that the rangeselect key still defaults to disabled. Test on an Android device to ensure that the game starts and that you can enable unlimited viewing range. To get it working on Android I had to merge https://github.com/minetest/minetest/pull/12960. You can get a pre-built APK with the patch here: https://github.com/TurkeyMcMac/minetest/actions/runs/3549853783. This APK also has some junk that makes it print information to errorstream. Just ignore that.
