### PR TITLE
Fix Enter key after creating a new world

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -353,6 +353,8 @@ local function create_world_buttonhandler(this, fields)
 		fields["key_enter"] then
 
 		if fields["key_enter"] then
+			-- HACK: This timestamp prevents double-triggering when pressing Enter on an input box
+			-- and releasing it on a button[] or textlist[] due to instant formspec updates.
 			this.parent.dlg_create_world_closed_at = core.get_us_time()
 		end
 

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -352,6 +352,10 @@ local function create_world_buttonhandler(this, fields)
 	if fields["world_create_confirm"] or
 		fields["key_enter"] then
 
+		if not fields["key_enter"] then
+			this.parent.dlg_create_world_just_closed = true
+		end
+
 		local worldname = fields["te_world_name"]
 		local game, _ = pkgmgr.find_by_gameid(core.settings:get("menu_last_game"))
 
@@ -435,7 +439,7 @@ local function create_world_buttonhandler(this, fields)
 	end
 
 	if fields["world_create_cancel"] then
-		this.parent.is_dlg_create_world_canceled = true
+		this.parent.dlg_create_world_just_closed = true
 		this:delete()
 		return true
 	end

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -352,8 +352,8 @@ local function create_world_buttonhandler(this, fields)
 	if fields["world_create_confirm"] or
 		fields["key_enter"] then
 
-		if not fields["key_enter"] then
-			this.parent.dlg_create_world_just_closed = true
+		if fields["key_enter"] then
+			this.parent.dlg_create_world_closed_at = core.get_us_time()
 		end
 
 		local worldname = fields["te_world_name"]
@@ -439,7 +439,6 @@ local function create_world_buttonhandler(this, fields)
 	end
 
 	if fields["world_create_cancel"] then
-		this.parent.dlg_create_world_just_closed = true
 		this:delete()
 		return true
 	end

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -435,6 +435,7 @@ local function create_world_buttonhandler(this, fields)
 	end
 
 	if fields["world_create_cancel"] then
+		this.parent.is_dlg_create_world_canceled = true
 		this:delete()
 		return true
 	end

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -273,7 +273,7 @@ local function main_button_handler(this, fields, name, tabdata)
 		if is_in_dlg_create_world then
 			is_in_dlg_create_world = false
 
-			if fields["play"] == nil and not this.is_dlg_create_world_canceled then
+			if fields["play"] == nil and not this.dlg_create_world_just_closed then
 				return true
 			end
 		end
@@ -326,7 +326,7 @@ local function main_button_handler(this, fields, name, tabdata)
 
 	if fields["world_create"] ~= nil then
 		is_in_dlg_create_world = true
-		this.is_dlg_create_world_canceled = false
+		this.dlg_create_world_just_closed = false
 		local create_world_dlg = create_create_world_dlg()
 		create_world_dlg:set_parent(this)
 		this:hide()

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -22,7 +22,6 @@ local valid_disabled_settings = {
 	["creative_mode"]=true,
 	["enable_server"]=true,
 }
-local is_in_dlg_create_world = false
 
 -- Currently chosen game in gamebar for theming and filtering
 function current_game()
@@ -270,12 +269,10 @@ local function main_button_handler(this, fields, name, tabdata)
 	end
 
 	if fields["play"] ~= nil or world_doubleclick or fields["key_enter"] then
-		if is_in_dlg_create_world then
-			is_in_dlg_create_world = false
-
-			if fields["play"] == nil and not this.dlg_create_world_just_closed then
-				return true
-			end
+		local enter_key_duration = core.get_us_time() - this.dlg_create_world_closed_at
+		if world_doubleclick and enter_key_duration <= 200000 then -- 200 ms
+			this.dlg_create_world_closed_at = 0
+			return true
 		end
 
 		local selected = core.get_textlist_index("sp_worlds")
@@ -325,8 +322,7 @@ local function main_button_handler(this, fields, name, tabdata)
 	end
 
 	if fields["world_create"] ~= nil then
-		is_in_dlg_create_world = true
-		this.dlg_create_world_just_closed = false
+		this.dlg_create_world_closed_at = 0
 		local create_world_dlg = create_create_world_dlg()
 		create_world_dlg:set_parent(this)
 		this:hide()

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -215,6 +215,10 @@ local function main_button_handler(this, fields, name, tabdata)
 
 	assert(name == "local")
 
+	if this.dlg_create_world_closed_at == nil then
+		this.dlg_create_world_closed_at = 0
+	end
+
 	local world_doubleclick = false
 
 	if fields["sp_worlds"] ~= nil then

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -22,6 +22,7 @@ local valid_disabled_settings = {
 	["creative_mode"]=true,
 	["enable_server"]=true,
 }
+local is_in_dlg_create_world = false
 
 -- Currently chosen game in gamebar for theming and filtering
 function current_game()
@@ -269,6 +270,14 @@ local function main_button_handler(this, fields, name, tabdata)
 	end
 
 	if fields["play"] ~= nil or world_doubleclick or fields["key_enter"] then
+		if is_in_dlg_create_world then
+			is_in_dlg_create_world = false
+
+			if fields["play"] == nil and not this.is_dlg_create_world_canceled then
+				return true
+			end
+		end
+
 		local selected = core.get_textlist_index("sp_worlds")
 		gamedata.selected_world = menudata.worldlist:get_raw_index(selected)
 
@@ -316,6 +325,8 @@ local function main_button_handler(this, fields, name, tabdata)
 	end
 
 	if fields["world_create"] ~= nil then
+		is_in_dlg_create_world = true
+		this.is_dlg_create_world_canceled = false
 		local create_world_dlg = create_create_world_dlg()
 		create_world_dlg:set_parent(this)
 		this:hide()


### PR DESCRIPTION
**Goal of the PR**
This PR changes the behaviour of <kbd>Enter</kbd> key after creating a new world.

**How does the PR work?**
- Disable <kbd>Enter</kbd> key before opening create world dialog.
- Enable it again if the world creation is cancelled or after the world is created and an <kbd>Enter</kbd> key event is received.

**Does it resolve any reported issue?**
Yes, this PR tries to fix #11608.

**Does this relate to a goal in the roadmap?**
Probably, this PR tries to fix a reported UX issue.

## To do
This PR is Ready for Review.

## How to test
1. Run Minetest.
2. Open the Start Game tab, click New, and fill in the name.
4. Press <kbd>Enter</kbd>.
5. It should **only** create the world (**not** playing it directly).
6. Press <kbd>Enter</kbd> again to play the selected world.
7. It should play the selected world.
8. Restart Minetest (or Exit to Menu).
9. Open the Start Game tab, click New, and click Cancel or press <kbd>Esc</kbd>.
10. Press <kbd>Enter</kbd> to play the selected world.
11. It should play the selected world.