### PR TITLE
Let mods choose a forceload limit

### DIFF
--- a/builtin/game/forceloading.lua
+++ b/builtin/game/forceloading.lua
@@ -33,7 +33,7 @@ local function get_relevant_tables(transient)
 	end
 end
 
-function core.forceload_block(pos, transient)
+function core.forceload_block(pos, transient, limit)
 	-- set changed flag
 	forceload_blocks_changed = true
 
@@ -46,7 +46,8 @@ function core.forceload_block(pos, transient)
 	elseif other_table[hash] ~= nil then
 		relevant_table[hash] = 1
 	else
-		if total_forceloaded >= (tonumber(core.settings:get("max_forceloaded_blocks")) or 16) then
+		limit = limit or tonumber(core.settings:get("max_forceloaded_blocks")) or 16
+		if limit >= 0 and total_forceloaded >= limit then
 			return false
 		end
 		total_forceloaded = total_forceloaded+1

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1875,8 +1875,9 @@ active_block_range (Active block range) int 4 1 65535
 #    From how far blocks are sent to clients, stated in mapblocks (16 nodes).
 max_block_send_distance (Max block send distance) int 12 1 65535
 
-#    Maximum number of forceloaded mapblocks.
-max_forceloaded_blocks (Maximum forceloaded blocks) int 16 0
+#    Default maximum number of forceloaded mapblocks.
+#    Set this to -1 to disable the limit.
+max_forceloaded_blocks (Maximum forceloaded blocks) int 16 -1
 
 #    Interval of sending time of day to clients, stated in seconds.
 time_send_interval (Time send interval) float 5.0 0.001

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6525,12 +6525,16 @@ Misc.
     * You may want to cache and call the old function to allow multiple mods to
       change knockback behavior.
 
-* `minetest.forceload_block(pos[, transient])`
+* `minetest.forceload_block(pos[, transient[, limit]])`
     * forceloads the position `pos`.
     * returns `true` if area could be forceloaded
     * If `transient` is `false` or absent, the forceload will be persistent
       (saved between server runs). If `true`, the forceload will be transient
       (not saved between server runs).
+    * `limit` is an optional limit on the number of blocks that can be
+      forceloaded at once. If `limit` is negative, there is no limit. If it is
+      absent, the limit is the value of the setting `"max_forceloaded_blocks"`.
+      If the call would put the number of blocks over the limit, the call fails.
 
 * `minetest.forceload_free_block(pos[, transient])`
     * stops forceloading the position `pos`


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/12990. Mods can now choose to use the configured limit, their own limit, or no limit at all.

## To do

This PR is Ready for Review.

## How to test

Run this code:

```lua
minetest.after(0, function()
	for i = 1, 1 do
		local pos = vector.new(i, i, i) * 16
		assert(minetest.forceload_block(pos, true))
	end
	for i = 2, 17 do
		local pos = vector.new(i, i, i) * 16
		assert(minetest.forceload_block(pos, true, -1))
		assert(minetest.forceload_block(pos, true))
	end
	for i = 18, 21 do
		local pos = vector.new(i, i, i) * 16
		assert(minetest.forceload_block(pos, true, 20) == (i <= 20))
	end
end)
```
