### PR TITLE
Avoid resetting music when dialog opens

### DIFF
--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -379,7 +379,10 @@ local function on_change(type, old_tab, new_tab)
 			gamebar:hide()
 		end
 		core.set_topleft_text("")
-		mm_game_theme.update(new_tab,nil)
+		-- If new_tab is nil, a dialog is being shown; avoid resetting the theme
+		if new_tab then
+			mm_game_theme.update(new_tab,nil)
+		end
 	end
 end
 


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/13001. The theme is not updated when the `singleplayer` tab is hidden, which AFAICT only happens when it opens a dialog. 

## To do

This PR is Ready for Review.

## How to test

Try out a game with menu music. Make sure there aren't any scenarios I failed to consider, i.e. where the tab being hidden does not mean a dialog has been opened.