### PR TITLE
Fix crack with animation

### DIFF
--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/directiontables.h"
 #include "client/meshgen/collector.h"
 #include "client/renderingengine.h"
+#include "util/string.h"
 #include <array>
 #include <algorithm>
 
@@ -1284,6 +1285,13 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 					for (FrameSpec &frame : *p.layer.frames) {
 						// Find the texture name plus ^[crack:1:
 						std::string name = m_tsrc->getTextureName(frame.texture_id);
+						{
+							// Remove superfluous [applyfiltersformesh
+							const char *remove_ends[] = {"^[applyfiltersformesh", nullptr};
+							std::string cleaned_name = removeStringEnd(name, remove_ends);
+							if (!cleaned_name.empty())
+								name = std::move(cleaned_name);
+						}
 						name += "^[crack";
 						if (p.layer.material_flags & MATERIAL_FLAG_CRACK_OVERLAY)
 							name += "o";  // use ^[cracko

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -244,6 +244,11 @@ private:
 		TileLayer tile;
 	};
 
+	struct CrackMaterials {
+		std::string main; // Main texture base
+		std::vector<std::string> frames; // Frame texture bases
+	};
+
 	scene::IMesh *m_mesh[MAX_TILE_LAYERS];
 	MinimapMapblock *m_minimap_mapblock;
 	ITextureSource *m_tsrc;
@@ -264,7 +269,7 @@ private:
 	// Last crack value passed to animate()
 	int m_last_crack;
 	// Maps mesh and mesh buffer (i.e. material) indices to base texture names
-	std::map<std::pair<u8, u32>, std::string> m_crack_materials;
+	std::map<std::pair<u8, u32>, CrackMaterials> m_crack_materials;
 
 	// Animation info: texture animation
 	// Maps mesh and mesh buffer indices to TileSpecs

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -294,6 +294,10 @@ struct TileLayer
 	//! If true, the tile has its own color.
 	bool has_color = false;
 
+	//! This is used by some code to determine whether to
+	//! delete frames on destruction.
+	bool frames_owned = false;
+
 	std::vector<FrameSpec> *frames = nullptr;
 
 	/*!


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/5317. Disclaimer: I haven't worked much on the rendering side of things.

## To do

This PR is a Ready for Review.

## How to test

Try breaking these nodes in devtest:

```lua
minetest.register_node(":mymod:anim_rooted", {
	description = "Animated rooted",
	paramtype = "light",
	drawtype = "plantlike_rooted",
	tiles = {},
	overlay_tiles = {
		{ name = "testnodes_anim.png",
		animation = {
			type = "vertical_frames",
			aspect_w = 16,
			aspect_h = 16,
			length = 4.0,
		}, },
	},
	special_tiles = {
		{ name = "testnodes_anim.png",
		animation = {
			type = "vertical_frames",
			aspect_w = 16,
			aspect_h = 16,
			length = 4.0,
		}, },
	},
	groups = { dig_immediate = 2 },
})

minetest.register_node(":mymod:anim_scaled", {
	description = "Animated scaled",
	tiles = {
		{ name = "testnodes_anim.png",
		align_style = "world",
		scale = 2,
		animation = {
			type = "vertical_frames",
			aspect_w = 16,
			aspect_h = 16,
			length = 4.0,
		}, },
	},
	groups = { dig_immediate = 2 },
})
```
