### PR TITLE
Fix `/help` privs checks

### DIFF
--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -22,6 +22,7 @@ local LIST_FORMSPEC_DESCRIPTION = [[
 
 local F = core.formspec_escape
 local S = core.get_translator("__builtin")
+local check_player_privs = core.check_player_privs
 
 
 -- CHAT COMMANDS FORMSPEC
@@ -57,11 +58,10 @@ local function build_chatcommands_formspec(name, sel, copy)
 		.. "any entry in the list.").. "\n" ..
 		S("Double-click to copy the entry to the chat history.")
 
-	local privs = core.get_player_privs(name)
 	for i, data in ipairs(mod_cmds) do
 		rows[#rows + 1] = COLOR_BLUE .. ",0," .. F(data[1]) .. ","
 		for j, cmds in ipairs(data[2]) do
-			local has_priv = privs[cmds[2].privs]
+			local has_priv = check_player_privs(name, cmds[2].privs)
 			rows[#rows + 1] = ("%s,1,%s,%s"):format(
 				has_priv and COLOR_GREEN or COLOR_GRAY,
 				cmds[1], F(cmds[2].params))


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/13007 by partially reverting e8b2954586ebd9e35e3f9f7230ff6713b65c4967. I decided to just revert the optimization rather than trying to fix it. I'd rather not have to reimplement `check_player_privs`\*. The optimization could be saved without doing so, but this would still complicate the code, which I don't know to be worth it. @appgurueu, how significant was this optimization?

\* There is least one mod that sets `privs` to a string: https://github.com/everamzah/pvp_areas/blob/6e4d66d6e8e9520180f71e4f955eff8e7f4e1799/init.lua#L77.

## To do

This PR is Ready for Review.

## How to test

Check that the `/help` formspec colors commands green if you have sufficient privileges to run them.
