### PR TITLE
Expose dtime_s to LBM handler

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7949,8 +7949,9 @@ gets activated (not loaded!)
         -- and not only the first time the block gets activated after the LBM
         -- was introduced.
 
-        action = function(pos, node),
+        action = function(pos, node, dtime_s),
         -- Function triggered for each qualifying node.
+        -- `dtime_s` is the in-game time elapsed since the block was last active
     }
 
 Tile definition

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7951,7 +7951,8 @@ gets activated (not loaded!)
 
         action = function(pos, node, dtime_s),
         -- Function triggered for each qualifying node.
-        -- `dtime_s` is the in-game time elapsed since the block was last active
+        -- `dtime_s` is the in-game time (in seconds) elapsed since the block
+        -- was last active
     }
 
 Tile definition

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -109,7 +109,8 @@ void LuaABM::trigger(ServerEnvironment *env, v3s16 p, MapNode n,
 	lua_pop(L, 1); // Pop error handler
 }
 
-void LuaLBM::trigger(ServerEnvironment *env, v3s16 p, MapNode n)
+void LuaLBM::trigger(ServerEnvironment *env, v3s16 p,
+	const MapNode n, const float dtime_s)
 {
 	ServerScripting *scriptIface = env->getScriptIface();
 	scriptIface->realityCheck();
@@ -141,8 +142,9 @@ void LuaLBM::trigger(ServerEnvironment *env, v3s16 p, MapNode n)
 	lua_remove(L, -2); // Remove registered_lbms[m_id]
 	push_v3s16(L, p);
 	pushnode(L, n);
+	lua_pushnumber(L, dtime_s);
 
-	int result = lua_pcall(L, 2, 0, error_handler);
+	int result = lua_pcall(L, 3, 0, error_handler);
 	if (result)
 		scriptIface->scriptError(result, "LuaLBM::trigger");
 

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -287,7 +287,7 @@ public:
 		this->trigger_contents = trigger_contents;
 		this->name = name;
 	}
-	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n);
+	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n, float dtime_s);
 };
 
 //! Lua wrapper for RaycastState objects

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -249,7 +249,8 @@ std::string LBMManager::createIntroductionTimesString()
 	return oss.str();
 }
 
-void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
+void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block,
+		const u32 stamp, const float dtime_s)
 {
 	// Precondition, we need m_lbm_lookup to be initialized
 	FATAL_ERROR_IF(!m_query_mode,
@@ -280,7 +281,7 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
 					if (!lbm_list)
 						continue;
 					for (auto lbmdef : *lbm_list) {
-						lbmdef->trigger(env, pos + pos_of_block, n);
+						lbmdef->trigger(env, pos + pos_of_block, n, dtime_s);
 					}
 				}
 	}
@@ -992,7 +993,7 @@ void ServerEnvironment::activateBlock(MapBlock *block, u32 additional_dtime)
 	activateObjects(block, dtime_s);
 
 	/* Handle LoadingBlockModifiers */
-	m_lbm_mgr.applyLBMs(this, block, stamp);
+	m_lbm_mgr.applyLBMs(this, block, stamp, (float)dtime_s);
 
 	// Run node timers
 	block->step((float)dtime_s, [&](v3s16 p, MapNode n, f32 d) -> bool {

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -95,7 +95,8 @@ struct LoadingBlockModifierDef
 
 	virtual ~LoadingBlockModifierDef() = default;
 
-	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n){};
+	virtual void trigger(ServerEnvironment *env, v3s16 p,
+			MapNode n, float dtime_s) {};
 };
 
 struct LBMContentMapping
@@ -129,7 +130,8 @@ public:
 	std::string createIntroductionTimesString();
 
 	// Don't call this before loadIntroductionTimes() ran.
-	void applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp);
+	void applyLBMs(ServerEnvironment *env, MapBlock *block,
+			u32 stamp, float dtime_s);
 
 	// Warning: do not make this std::unordered_map, order is relevant here
 	typedef std::map<u32, LBMContentMapping> lbm_lookup_map;


### PR DESCRIPTION
With this information LBMs can be used as an alternative to node timers to e.g. simulate environmental changes while a block is deactivated

## To do

This PR is Ready for Review.

## How to test

```lua
local lbp = -1
minetest.register_lbm({
	name = "test2:example",
	nodenames = {"air"},
	run_at_every_load = true,
	action = function(pos, node, dtime_s)
		local bp = vector.floor(vector.divide(pos, 16))
		if core.hash_node_position(bp) == lbp then
			return
		end
		lbp = core.hash_node_position(bp)
		print("block " .. core.pos_to_string(bp) .. " has slept for " .. dtime_s)
	end,
})
```