### PR TITLE
Fix Minetest startup after removing last used game

### DIFF
--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -86,9 +86,12 @@ local function init_globals()
 	menudata.worldlist:add_sort_mechanism("alphabetic", sort_worlds_alphabetic)
 	menudata.worldlist:set_sortmode("alphabetic")
 
-	if not core.settings:get("menu_last_game") then
-		local default_game = core.settings:get("default_game") or "minetest"
-		core.settings:set("menu_last_game", default_game)
+	local gameid = core.settings:get("menu_last_game")
+	local game = gameid and pkgmgr.find_by_gameid(gameid)
+	if not game then
+		gameid = core.settings:get("default_game") or "minetest"
+		game = pkgmgr.find_by_gameid(gameid)
+		core.settings:set("menu_last_game", gameid)
 	end
 
 	mm_game_theme.init()
@@ -115,11 +118,8 @@ local function init_globals()
 
 	-- In case the folder of the last selected game has been deleted,
 	-- display "Minetest" as a header
-	if tv_main.current_tab == "local" then
-		local game = pkgmgr.find_by_gameid(core.settings:get("menu_last_game"))
-		if game == nil then
-			mm_game_theme.reset()
-		end
+	if tv_main.current_tab == "local" and not game then
+		mm_game_theme.reset()
 	end
 
 	ui.set_default("maintab")


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/12919.

## To do

This PR is Ready for Review.

## How to test

- Test that the linked bug is fixed.
- Test that the menu still works (you can create worlds etc.)
- Test that the menu behaves the same as before when `menu_last_game` is unset and Minetest Game (or whatever is your default) is absent.
- Test that the menu behaves the same as before when there are no games.
