### PR TITLE
3d line rendering.

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5950,6 +5950,9 @@ Environment access
     * Returns `ObjectRef`, or `nil` if failed
     * Entities with `static_save = true` can be added also 
       to unloaded and non-generated blocks.
+* `minetest.add_3dline(3dline_definition)`: returns `Lua3DLine`
+	* Creates and render a `Lua3DLine` object from the start to the end position.
+	* See for description of `3dline_definition` in `3D Line` definition section.
 * `minetest.add_item(pos, item)`: Spawn item
     * Returns `ObjectRef`, or `nil` if failed
     * Items can be added also to unloaded and non-generated blocks.
@@ -8269,6 +8272,20 @@ In multiplayer mode, the error may be arbitrarily large.
 
 * `next()`: returns a `pointed_thing` with exact pointing location
     * Returns the next thing pointed by the ray or nil.
+
+`Lua3DLine`
+--------
+
+A dynamic 3d line. Can be attached from both ends to objects.
+If the objects which they are attached to are invalid, automatically detach them.
+
+It can be created via `minetest.add_3dline(3dline_definition)`.
+
+### Methods
+
+* `set_properties(3dline_definition)`: overrides the given properties.
+* `remove()`: removes the Lua3DLine object.
+* `is_valid()`: returns true in case if the Lua3DLine object is valid, otherwise false.
 
 `SecureRandom`
 --------------
@@ -10732,6 +10749,82 @@ lifespan, and then vanish again before expiring.
 * float `alpha` (0.0 - 1.0): controls the visibility of the texture
 * vec2 `scale`: controls the size of the displayed billboard onscreen. Its units
   are multiples of the parent particle's assigned size (see the `size` property above)
+
+
+`3DLine` definition
+-------------------
+
+Used by `minetest.add_3dline`.
+
+```lua
+{
+	type = "flat",
+	-- Type can be "flat", "cylindric" and "dihedral".
+	-- It only affects the rendering of the line itself.
+	-- "flat": represents a 3d rectangle.
+	-- "dihedral": the same as "flat", but has two crossing rectangles under 90 degrees.
+	-- "cylindric": represents a 3d cylinder.
+	-- Default type is "flat".
+
+	start_pos = vector.new(0, 0, 0),
+	-- The start position of the line.
+	-- Default value is (0, 0, 0).
+
+	end_pos = vector.new(0, 0, 0),
+	-- Same as `start_pos`, but for the end vertex.
+
+	start_color = <ColorSpec>,
+	-- Color of the start vertex.
+	-- The color of the line is interpolated from `start_color` to `end_color`.
+	-- Default value is "0x000000" (black).
+
+	end_color = <ColorSpec>,
+	-- Same as `start_color`, but for the end vertex.
+
+	start_attach_to = <ObjectRef>,
+	-- Optional. If defined, position of the start vertex will be relative
+	-- to the ObjectRef's position and rotation and will follow it.
+	-- Setting it to 0 detaches it from that ObjectRef.
+
+	end_attach_to = <ObjectRef>,
+	-- Same as `start_attach_to`, but for the end vertex.
+
+	width = 0.05,
+	-- The diameter of the line. The higher value the line looks visually thicker.
+	-- Default value is 0.05.
+
+	texture = "texture.png",
+	-- Optional. The texture laid on the line.
+
+	clamp_mode = "repeat",
+	-- Optional. Next modes are supported: "repeat", "clamp", "clamp_to_edge" and "clamp_to_border".
+	-- Default mode is "repeat".
+
+	playername = "",
+	-- Optional. If specified, the line data will be sent for rendering
+	-- only to this client with the given name, otherwise to all ones.
+	-- Default value is "".
+
+	animation = {Tile Animation Definition},
+	-- Optional. Defines animation of the line texture.
+	-- Note: this is currently not supported for `cylindric` type.
+	-- See `Tile Animation Definition`.
+
+	backface_culling = false,
+	-- Optional. Defines whether enable backface_culling or not.
+	-- Default value is "false".
+
+	light_level = 5,
+	-- Optional. Level of the light of the line. Can be from 0 - 14 value.
+	-- Default value is 0.
+
+	axis_angle = math.pi/4,
+	-- Optional. Angle in radians around the lengthwise axis of the line.
+	-- Positive values mean counter-clockwise rotation,
+	-- negative ones - clockwise relatively if the axis looks at the watcher.
+	-- Default value is 0.0.
+}
+```
 
 `HTTPRequest` definition
 ------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -387,6 +387,7 @@ set(common_SRCS
 	itemstackmetadata.cpp
 	light.cpp
 	lighting.cpp
+	line_params.cpp
 	log.cpp
 	main.cpp
 	map.cpp

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -57,6 +57,7 @@ set(client_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/inputhandler.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/joystick_controller.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/keycode.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/line.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/localplayer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mapblock_mesh.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mesh.cpp

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -117,6 +117,7 @@ Client::Client(
 	m_sound(sound),
 	m_event(event),
 	m_rendering_engine(rendering_engine),
+	m_line_scenenode_manager(&m_env),
 	m_mesh_update_manager(std::make_unique<MeshUpdateManager>(this)),
 	m_env(
 		new ClientMap(this, rendering_engine, control, 666),

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -37,7 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gameparams.h"
 #include "clientdynamicinfo.h"
 #include <fstream>
-#include "util/numeric.h"
+#include "line.h"
 
 #define CLIENT_CHAT_MESSAGE_LIMIT_PER_10S 10.0f
 
@@ -230,6 +230,9 @@ public:
 	void handleCommand_MediaPush(NetworkPacket *pkt);
 	void handleCommand_MinimapModes(NetworkPacket *pkt);
 	void handleCommand_SetLighting(NetworkPacket *pkt);
+	void handleCommand_Add3DLine(NetworkPacket *pkt);
+	void handleCommand_Change3DLineProperties(NetworkPacket *pkt);
+	void handleCommand_Remove3DLine(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 
@@ -369,6 +372,8 @@ public:
 	Camera* getCamera () { return m_camera; }
 	scene::ISceneManager *getSceneManager();
 
+	LineSceneNodeManager *getLineSceneNodeManager() { return &m_line_scenenode_manager; }
+
 	bool shouldShowMinimap() const;
 
 	// IGameDef interface
@@ -489,7 +494,7 @@ private:
 	MtEventManager *m_event;
 	RenderingEngine *m_rendering_engine;
 
-
+	LineSceneNodeManager m_line_scenenode_manager;
 	std::unique_ptr<MeshUpdateManager> m_mesh_update_manager;
 	ClientEnvironment m_env;
 	std::unique_ptr<ParticleManager> m_particle_manager;

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -49,6 +49,9 @@ enum ClientEventType : u8
 	CE_SET_STARS,
 	CE_OVERRIDE_DAY_NIGHT_RATIO,
 	CE_CLOUD_PARAMS,
+	CE_ADD_3DLINE,
+	CE_CHANGE_3DLINE_PROPERTIES,
+	CE_REMOVE_3DLINE,
 	CLIENTEVENT_MAX,
 };
 
@@ -141,6 +144,15 @@ struct ClientEvent
 			f32 speed_x;
 			f32 speed_y;
 		} cloud_params;
+		struct
+		{
+			LineParams *p;
+			u32 id;
+		} line;
+		struct
+		{
+			u32 id;
+		} remove_line;
 		SunParams *sun_params;
 		MoonParams *moon_params;
 		StarParams *star_params;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -918,6 +918,7 @@ private:
 	void handleClientEvent_OverrideDayNigthRatio(ClientEvent *event,
 		CameraOrientation *cam);
 	void handleClientEvent_CloudParams(ClientEvent *event, CameraOrientation *cam);
+	void handleClientEvent_Handle3DLineEvent(ClientEvent *event, CameraOrientation *cam);
 
 	void updateChat(f32 dtime);
 
@@ -2851,6 +2852,9 @@ const ClientEventHandler Game::clientEventHandler[CLIENTEVENT_MAX] = {
 	{&Game::handleClientEvent_SetStars},
 	{&Game::handleClientEvent_OverrideDayNigthRatio},
 	{&Game::handleClientEvent_CloudParams},
+	{&Game::handleClientEvent_Handle3DLineEvent},
+	{&Game::handleClientEvent_Handle3DLineEvent},
+	{&Game::handleClientEvent_Handle3DLineEvent}
 };
 
 void Game::handleClientEvent_None(ClientEvent *event, CameraOrientation *cam)
@@ -3175,6 +3179,14 @@ void Game::handleClientEvent_CloudParams(ClientEvent *event, CameraOrientation *
 	clouds->setHeight(event->cloud_params.height);
 	clouds->setThickness(event->cloud_params.thickness);
 	clouds->setSpeed(v2f(event->cloud_params.speed_x, event->cloud_params.speed_y));
+}
+
+void Game::handleClientEvent_Handle3DLineEvent(ClientEvent *event, CameraOrientation *cam)
+{
+	if (event->type != CE_REMOVE_3DLINE)
+		client->getLineSceneNodeManager()->handle3DLineEvent(event->type, event->line.id, event->line.p);
+	else
+		client->getLineSceneNodeManager()->handle3DLineEvent(event->type, event->remove_line.id, nullptr);
 }
 
 void Game::processClientEvents(CameraOrientation *cam)
@@ -4131,6 +4143,11 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		Update particles
 	*/
 	client->getParticleManager()->step(dtime);
+
+	/*
+		Update 3d lines
+	*/
+	client->getLineSceneNodeManager()->step(dtime);
 
 	/*
 		Damage camera tilt

--- a/src/client/line.cpp
+++ b/src/client/line.cpp
@@ -1,0 +1,540 @@
+/*
+Minetest
+Copyright (C) 2023 Andrey2470T, AndreyT <andreyt2203@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "line.h"
+#include "content_cao.h"
+#include "client.h"
+#include "clientmap.h"
+#include "light.h"
+#include "mapnode.h"
+#include "nodedef.h"
+#include "log.h"
+#include "mapblock_mesh.h"
+
+LineSceneNode::LineSceneNode(LineParams params, ClientEnvironment *cenv,
+	scene::ISceneManager *mgr, s32 id)
+: scene::ISceneNode(mgr->getRootSceneNode(), mgr, id), params(params), env(cenv)
+{
+	mat.MaterialType = video::EMT_ONETEXTURE_BLEND;
+	mat.Lighting = false;
+	mat.NormalizeNormals = true;
+	mat.FogEnable = true;
+
+	updateMaterial();
+
+	mat.BlendOperation = video::EBO_ADD;
+	mat.MaterialTypeParam = video::pack_textureBlendFunc(
+		video::EBF_SRC_ALPHA,
+		video::EBF_ONE_MINUS_SRC_ALPHA,
+		video::EMFN_MODULATE_1X,
+		video::EAS_TEXTURE | video::EAS_VERTEX_COLOR
+	);
+
+	current_animation_frame = 0;
+	animation_time = 0.0f;
+
+	mat.TextureLayers[0].TextureWrapU = (u8)video::ETC_REPEAT;
+	mat.TextureLayers[0].TextureWrapV = (u8)video::ETC_REPEAT;
+}
+
+void LineSceneNode::updateEndsPositions()
+{
+	pos.first = calcPosition(params.attached_ids.first, params.pos.first);
+	pos.second = calcPosition(params.attached_ids.second, params.pos.second);
+}
+
+void LineSceneNode::updateEndsLights()
+{
+	color.first = calcLight(pos.first, params.color.first);
+	color.second = calcLight(pos.second, params.color.second);
+}
+
+v3f LineSceneNode::calcPosition(u16 id, v3f pos)
+{
+	GenericCAO* cao = env->getGenericCAO(id);
+
+	if (cao)
+		cao->getSceneNode()->getAbsoluteTransformation().transformVect(pos);
+	else
+		pos -= intToFloat(env->getCameraOffset(), BS);
+
+	return pos;
+}
+
+video::SColor LineSceneNode::calcLight(v3f pos, video::SColor color)
+{
+	ClientMap &map = env->getClientMap();
+
+	bool is_valid_pos;
+	MapNode node = map.getNode(floatToInt(pos, BS), &is_valid_pos);
+
+	u8 light = decode_light((is_valid_pos ? node.getLightBlend(env->getDayNightRatio(),
+		env->getGameDef()->getNodeDefManager()->getLightingFlags(node)) :
+		blend_light(env->getDayNightRatio(), LIGHT_SUN, 0)) + params.light_level);
+
+	color.setRed(light * color.getRed() / 255);
+	color.setGreen(light * color.getGreen() / 255);
+	color.setBlue(light * color.getBlue() / 255);
+
+	return color;
+}
+
+void LineSceneNode::updateAnimation(f32 dtime)
+{
+	if (params.animation.type == TAT_NONE)
+		return;
+
+	video::ITexture *tex = mat.getTexture(0);
+
+	if (!tex)
+		return;
+
+	animation_time += dtime;
+
+	v2u32 tex_size = tex->getSize();
+
+	int frames_count, frame_length;
+	params.animation.determineParams(tex_size, &frames_count, &frame_length, nullptr);
+	f32 frame_length_f = frame_length / 1000.0f;
+
+	u32 frames_delta = u32(animation_time / frame_length_f);
+
+	current_animation_frame += frames_delta;
+
+	if (current_animation_frame > (u32)frames_count)
+		current_animation_frame -= (u32)frames_count;
+
+	animation_time -= (frames_delta * frame_length_f);
+}
+
+void LineSceneNode::updateMaterial()
+{
+	mat.TextureLayers[0].Texture = env->getGameDef()->getTextureSource()->getTextureForMesh(params.texture);
+
+	mat.TextureLayers[0].MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
+	mat.TextureLayers[0].MagFilter = video::ETMAGF_NEAREST;
+
+	mat.BackfaceCulling = !params.backface_culling;
+}
+
+void LineSceneNode::draw3DLineStrip(bool vertical) const
+{
+	f32 dist = pos.first.getDistanceFrom(pos.second);
+
+	v3f positions[4];
+
+	if (!vertical) {
+		positions[0] = v3f(-params.width / 2, 0.0f, 0.0f); // LOWER LEFT
+		positions[1] = v3f(params.width / 2, 0.0f, 0.0f); // LOWER RIGHT
+		positions[2] = v3f(params.width / 2, 0.0f, dist); // UPPER LEFT
+		positions[3] = v3f(-params.width / 2, 0.0f, dist); // UPPER RIGHT
+	}
+	else {
+		positions[0] = v3f(0.0f, params.width / 2, 0.0f); // LOWER LEFT
+		positions[1] = v3f(0.0f, -params.width / 2, 0.0f); // LOWER RIGHT
+		positions[2] = v3f(0.0f, -params.width / 2, dist); // UPPER LEFT
+		positions[3] = v3f(0.0f, params.width / 2, dist); // UPPER RIGHT
+	}
+
+	v3f dir = pos.second - pos.first;
+	dir.normalize();
+
+	v3f rotations = dir.getHorizontalAngle();
+
+	core::matrix4 rot_mat, axis_rot_mat, trans_mat, res_mat;
+
+	rot_mat.setRotationRadians(v3f(core::degToRad(rotations.X), core::degToRad(rotations.Y), 0.0f));
+	axis_rot_mat.setRotationAxisRadians(params.axis_angle, dir);
+	trans_mat.setTranslation(pos.first);
+
+	res_mat = trans_mat * axis_rot_mat * rot_mat;
+
+	res_mat.transformVect(positions[0]);
+	res_mat.transformVect(positions[1]);
+	res_mat.transformVect(positions[2]);
+	res_mat.transformVect(positions[3]);
+
+	core::plane3df line_plane(positions[3], positions[2], positions[1]);
+
+	video::ITexture *tex = mat.getTexture(0);
+
+	v2f ll_corner_coords(0.0f, 0.0f);
+	v2f ur_corner_coords(1.0f, 1.0f);
+
+	if (tex) {
+		core::dimension2du tex_size = tex->getSize();
+
+		if (params.animation.type != TAT_NONE) {
+			v2u32 frame_size;
+			params.animation.determineParams(tex_size, nullptr, nullptr, &frame_size);
+
+			f32 aspect = (f32)frame_size.Y / frame_size.X;
+			f32 tcoords_u = dist * aspect / params.width;
+
+
+			ll_corner_coords = params.animation.getTextureCoords(tex_size, current_animation_frame);
+			ur_corner_coords.X = ll_corner_coords.X + (f32)frame_size.X / tex_size.Width * tcoords_u;
+			ur_corner_coords.Y = ll_corner_coords.Y + (f32)frame_size.Y / tex_size.Height;
+		}
+		else {
+			f32 aspect = (f32)tex_size.Height / tex_size.Width;
+			f32 tcoords_u = dist * aspect / params.width;
+
+			ur_corner_coords.X = tcoords_u;
+		}
+	}
+	video::S3DVertex vertices[4] = {
+		video::S3DVertex(positions[0], line_plane.Normal, color.first, ll_corner_coords),
+		video::S3DVertex(positions[1], line_plane.Normal, color.first, v2f(ll_corner_coords.X, ur_corner_coords.Y)),
+		video::S3DVertex(positions[2], line_plane.Normal, color.second, ur_corner_coords),
+		video::S3DVertex(positions[3], line_plane.Normal, color.second, v2f(ur_corner_coords.X, ll_corner_coords.Y))
+	};
+
+	video::IVideoDriver *vdrv = SceneManager->getVideoDriver();
+
+	vdrv->setTransform(video::ETS_WORLD, core::IdentityMatrix);
+	vdrv->setMaterial(mat);
+
+	u16 indices[] = {0, 1, 2, 2, 3, 0};
+
+	vdrv->drawIndexedTriangleList(vertices, 4, indices, 2);
+}
+
+void LineSceneNode::calc3DCircle(bool first, video::S3DVertex *verts, u16 *inds, u32 verts_c) const
+{
+	const v3f &center_pos = first ? pos.first : pos.second;
+	v3f normal(0.0f, 0.0f, first ? -1.0f : 1.0f);
+	video::SColor col = first ? color.first : color.second;
+
+	// Unfinished code of the future animation support for this type:
+	// https://gist.github.com/Andrey2470T/5a2b4af215f65306dfbaeae1a47e132e
+
+	v2f tcoords(0.5f, 0.5f);
+
+	verts[0] = video::S3DVertex(center_pos, normal, col, tcoords);
+
+	tcoords.X = -0.5f;
+	tcoords.Y = 0.0f;
+
+	v3f radius(-params.width / 2, 0.0f, 0.0f);
+
+	f32 rot_steps = 360.0f / (verts_c - 2);
+
+	inds[0] = 0;
+
+	core::matrix4 trans_mat, rot_mat;
+	trans_mat.setTranslation(center_pos);
+
+	v3f dist = pos.second - pos.first;
+
+	v3f rotations = dist.getHorizontalAngle();
+	rot_mat.setRotationRadians(v3f(core::degToRad(rotations.X), core::degToRad(rotations.Y), 0.0f));
+
+	core::matrix4 res_mat = trans_mat * rot_mat;
+
+	for (u32 i = 0; i < verts_c - 1; i++) {
+		v3f rotated_radius = radius;
+		rotated_radius.rotateXYBy(rot_steps * i);
+		res_mat.transformVect(rotated_radius);
+
+		v2f rotated_tcoords = tcoords;
+		rotated_tcoords.rotateBy(-rot_steps * i);
+		rotated_tcoords += v2f(0.5f, 0.5f);
+
+		verts[i + 1] = video::S3DVertex(
+			rotated_radius,
+			normal,
+			col,
+			rotated_tcoords
+		);
+
+		inds[i + 1] = i + 1;
+	}
+}
+
+void LineSceneNode::drawCylindricShape() const
+{
+	const u32 circle_verts_c = 22; // including the center and matching vertices at the seam
+	std::vector<video::S3DVertex> st_circle_verts(circle_verts_c);
+	std::vector<u16> st_circle_inds(circle_verts_c);
+
+	calc3DCircle(true, st_circle_verts.data(), st_circle_inds.data(), circle_verts_c);
+
+	std::vector<video::S3DVertex> end_circle_verts(circle_verts_c);
+	std::vector<u16> end_circle_inds(circle_verts_c);
+
+	calc3DCircle(false, end_circle_verts.data(), end_circle_inds.data(), circle_verts_c);
+
+	const u32 cyl_verts_c = (circle_verts_c - 1) * 2; // count of vertices on both circles + matching vertices
+	std::vector<video::S3DVertex> cylinder_verts;
+	std::vector<u16> cylinder_inds;
+
+	video::ITexture *tex = mat.getTexture(0);
+
+	f32 tcoords_u = 0.0f;
+	f32 tcoords_v = 0.0f;
+
+	f32 dist;
+	f32 cyl_length;
+	f32 aspect;
+
+	if (tex) {
+		core::dimension2du tex_size = mat.getTexture(0)->getSize();
+
+		aspect = (f32)tex_size.Height / tex_size.Width;
+
+		cyl_length = (circle_verts_c - 2) * st_circle_verts[1].Pos.getDistanceFrom(st_circle_verts[2].Pos);
+
+		dist = st_circle_verts[0].Pos.getDistanceFrom(end_circle_verts[0].Pos);
+		tcoords_u = dist * aspect / cyl_length;
+		tcoords_v = 1.0f;
+	}
+
+	for (u16 i = 1; i <= cyl_verts_c / 2; i++) {
+		video::S3DVertex vert1 = st_circle_verts[i];
+		video::S3DVertex vert2 = end_circle_verts[i];
+
+		static v3f normal;
+
+		normal = core::plane3df(
+			i == 1 ? st_circle_verts[circle_verts_c - 2].Pos : st_circle_verts[i - 1].Pos,
+			i == 1 ? end_circle_verts[circle_verts_c - 2].Pos : end_circle_verts[i - 1].Pos,
+			i == circle_verts_c - 1 ? end_circle_verts[2].Pos : end_circle_verts[i + 1].Pos
+		).Normal;
+
+		vert1.Normal = normal;
+		vert2.Normal = normal;
+
+		tcoords_v = tex ? 1.0f - (i - 1) * (1.0f / (circle_verts_c - 2)) : tcoords_v;
+
+		vert1.TCoords = tex ? v2f(0.0f, tcoords_v) : v2f(0.0f, 0.0f);
+		vert2.TCoords = tex ? v2f(tcoords_u, tcoords_v) : v2f(0.0f, 0.0f);
+
+		cylinder_verts.push_back(vert1);
+		cylinder_verts.push_back(vert2);
+	}
+
+	for (u16 i = 0; i < cyl_verts_c; i += 2) {
+		cylinder_inds.push_back(i);
+		cylinder_inds.push_back(i + 1);
+	}
+
+	video::IVideoDriver *vdrv = SceneManager->getVideoDriver();
+
+	vdrv->setTransform(video::ETS_WORLD, core::IdentityMatrix);
+	vdrv->setMaterial(mat);
+
+	vdrv->drawIndexedTriangleFan(st_circle_verts.data(), circle_verts_c, st_circle_inds.data(), circle_verts_c - 2);
+
+	vdrv->drawIndexedTriangleFan(end_circle_verts.data(), circle_verts_c, end_circle_inds.data(), circle_verts_c - 2);
+
+	vdrv->drawVertexPrimitiveList(
+		cylinder_verts.data(),
+		cyl_verts_c,
+		cylinder_inds.data(),
+		cyl_verts_c - 2,
+		video::EVT_STANDARD,
+		scene::EPT_TRIANGLE_STRIP,
+		video::EIT_16BIT
+	);
+}
+
+void LineSceneNode::render()
+{
+	switch(params.type) {
+		case LineType::FLAT:
+			draw3DLineStrip();
+			break;
+		case LineType::DIHEDRAL:
+			draw3DLineStrip();
+			draw3DLineStrip(true);
+			break;
+		case LineType::CYLINDRIC:
+			drawCylindricShape();
+			break;
+		default:
+			break;
+	}
+}
+
+void LineSceneNode::OnRegisterSceneNode()
+{
+	setAutomaticCulling(scene::EAC_OFF);
+	if (IsVisible)
+		SceneManager->registerNodeForRendering(this, scene::ESNRP_TRANSPARENT);
+
+	ISceneNode::OnRegisterSceneNode();
+}
+
+LineSceneNodeManager::~LineSceneNodeManager()
+{
+	MutexAutoLock lock(m_line_scenenode_list_lock);
+
+	for (auto &p : m_line_scenenode_list)
+		p.second->remove();
+}
+
+void LineSceneNodeManager::add3DLineToList(u32 id, LineSceneNode *line_node)
+{
+	MutexAutoLock lock(m_line_scenenode_list_lock);
+
+	m_line_scenenode_list.insert({id, line_node});
+}
+
+void LineSceneNodeManager::remove3DLineFromList(u32 id)
+{
+	MutexAutoLock lock(m_line_scenenode_list_lock);
+
+	if (!m_line_scenenode_list[id])
+		return;
+
+	m_line_scenenode_list[id]->remove();
+	m_line_scenenode_list.erase(id);
+}
+
+void LineSceneNodeManager::handle3DLineEvent(ClientEventType event_type, u32 id, LineParams *params)
+{
+	switch (event_type) {
+		case CE_ADD_3DLINE:
+		{
+			LineSceneNode *line = new LineSceneNode(
+				*params,
+				m_env,
+				m_env->getGameDef()->getSceneManager(),
+				id
+			);
+
+			add3DLineToList(id, line);
+			break;
+		}
+		case CE_CHANGE_3DLINE_PROPERTIES:
+		{
+			// If the client enviroment doesn't have the line with such id, skip it
+			// One of reasons may be joining a new player whose the lines nodes map is empty
+			if (!m_line_scenenode_list[id])
+				break;
+
+			auto& line_params = m_line_scenenode_list[id]->params;
+
+			for (u16 prop = 0; prop < LineParams::LP_COUNT; prop++) {
+				if (!params->last_changed_props[prop])
+					continue;
+
+				switch ((LineParams::LineProperty)prop) {
+					case LineParams::LP_TYPE:
+						line_params.type = params->type;
+						break;
+					case LineParams::LP_START_POS:
+						line_params.pos.first = params->pos.first;
+						break;
+					case LineParams::LP_END_POS:
+						line_params.pos.second = params->pos.second;
+						break;
+					case LineParams::LP_START_COLOR:
+						line_params.color.first = params->color.first;
+						break;
+					case LineParams::LP_END_COLOR:
+						line_params.color.second = params->color.second;
+						break;
+					case LineParams::LP_START_ATTACH_TO:
+						line_params.attached_ids.first = params->attached_ids.first;
+						break;
+					case LineParams::LP_END_ATTACH_TO:
+						line_params.attached_ids.second = params->attached_ids.second;
+						break;
+					case LineParams::LP_WIDTH:
+						line_params.width = params->width;
+						break;
+					case LineParams::LP_TEXTURE:
+						line_params.texture = params->texture;
+						m_line_scenenode_list[id]->updateMaterial();
+						break;
+					case LineParams::LP_PLAYERNAME:
+						line_params.playername = params->playername;
+						break;
+					case LineParams::LP_ANIMATION:
+						line_params.animation = params->animation;
+						break;
+					case LineParams::LP_BACKFACE_CULLING:
+						line_params.backface_culling = params->backface_culling;
+						m_line_scenenode_list[id]->updateMaterial();
+						break;
+					case LineParams::LP_LIGHT_LEVEL:
+						line_params.light_level = params->light_level;
+						break;
+					case LineParams::LP_AXIS_ANGLE:
+						line_params.axis_angle = params->axis_angle;
+						break;
+					default:
+						break;
+				}
+			}
+			break;
+		}
+		case CE_REMOVE_3DLINE:
+		{
+			remove3DLineFromList(id);
+			break;
+		}
+		default:
+			break;
+	}
+
+	delete params;
+}
+
+void LineSceneNodeManager::step(f32 dtime)
+{
+	MutexAutoLock lock(m_line_scenenode_list_lock);
+
+	const float radius = g_settings->getS16("max_block_send_distance") * MAP_BLOCKSIZE * BS;
+
+	v3f ppos = m_env->getLocalPlayer()->getPosition();
+
+	for (auto line : m_line_scenenode_list) {
+		auto &pos = line.second->pos;
+
+		v3f cam_offset = intToFloat(m_env->getCameraOffset(), BS);
+		bool is_far_from_start_pos = ppos.getDistanceFromSQ(pos.first+cam_offset) > radius * radius;
+		bool is_far_from_end_pos = ppos.getDistanceFromSQ(pos.second+cam_offset) > radius * radius;
+
+		bool attachments_invalid = false;
+
+		u16 first_attach_id = line.second->params.attached_ids.first;
+		u16 second_attach_id = line.second->params.attached_ids.second;
+
+		if (first_attach_id && !m_env->getGenericCAO(first_attach_id))
+			attachments_invalid = true;
+
+		if (second_attach_id && !m_env->getGenericCAO(second_attach_id))
+			attachments_invalid = true;
+
+		// The line gets to be invisible if distance to any of its ends exceeds 'max_block_send_distance' setting.
+		if (is_far_from_start_pos || is_far_from_end_pos || attachments_invalid)
+			line.second->setVisible(false);
+		else
+			line.second->setVisible(true);
+
+		line.second->updateAnimation(dtime);
+
+		line.second->updateEndsPositions();
+
+		line.second->updateEndsLights();
+	}
+}

--- a/src/client/line.h
+++ b/src/client/line.h
@@ -1,0 +1,136 @@
+/*
+Minetest
+Copyright (C) 2023 Andrey2470T, AndreyT <andreyt2203@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "line_params.h"
+#include <S3DVertex.h>
+#include <SMaterial.h>
+#include <ISceneNode.h>
+#include "clientenvironment.h"
+#include <ISceneManager.h>
+#include <unordered_map>
+#include "clientevent.h"
+#include "log.h"
+#include "../threading/mutex_auto_lock.h"
+
+class LineSceneNode;
+
+class LineSceneNodeManager
+{
+public:
+	LineSceneNodeManager(ClientEnvironment* env)
+	: m_env(env)
+	{
+	}
+
+	~LineSceneNodeManager();
+
+	void add3DLineToList(u32 id, LineSceneNode *line_node);
+	void remove3DLineFromList(u32 id);
+	void handle3DLineEvent(ClientEventType event_type, u32 id, LineParams *params);
+	void step(f32 dtime);
+
+private:
+	ClientEnvironment *m_env;
+	std::unordered_map<u32, LineSceneNode*> m_line_scenenode_list;
+	std::mutex m_line_scenenode_list_lock;
+};
+
+class LineSceneNode : public scene::ISceneNode
+{
+public:
+	// The aabbox of the line. Actually not used.
+	core::aabbox3df bounds;
+
+	// The properties of the line.
+	LineParams params;
+
+	// Actual positions and colors of the ends.
+	std::pair<v3f, v3f> pos;
+	std::pair<video::SColor, video::SColor> color;
+
+	// Only one material is used.
+	video::SMaterial mat;
+
+	ClientEnvironment *env;
+
+	u32 current_animation_frame;
+	f32 animation_time;
+
+	virtual void render();
+	virtual void OnRegisterSceneNode();
+	virtual void OnAnimate(u32 t)
+	{
+	}
+
+	virtual const core::aabbox3df &getBoundingBox() const
+	{
+		return bounds;
+	}
+
+	virtual u32 getMaterialCount() const
+	{
+		return 1;
+	}
+
+	virtual const video::SMaterial &getMaterial(u32 i = 0) const
+	{
+		return mat;
+	}
+
+	// Reloads the texture, updates the clamp mode and backface culling flag.
+	void updateMaterial();
+
+	LineSceneNode(
+		LineParams params,
+		ClientEnvironment* cenv,
+		scene::ISceneManager* mgr, s32 id
+	);
+
+private:
+	// Calculates a new position of the line end with current 'pos' position.
+	// If the end is attached to an object, 'pos' is relative.
+	v3f calcPosition(u16 attach_id, v3f pos);
+
+	// Calculates a new color of the line end based on the light level in the given 'pos' position
+	// and the light level emitted by the line.
+	video::SColor calcLight(v3f pos, video::SColor color);
+
+	// Updates both ends positions.
+	void updateEndsPositions();
+	// Updates both ends colors.
+	void updateEndsLights();
+	// Update animation frame.
+	void updateAnimation(f32 dtime);
+
+	// Draws a rectangular line in the 3D space.
+	// If 'vertical' = true, the line will be perpendicular to the horizontal plane.
+	void draw3DLineStrip(bool vertical = false) const;
+
+	// Calculates vertices of a circle in the 3D space.
+	// Helper method for 'drawCylindricShape()'.
+	void calc3DCircle(bool first, video::S3DVertex *verts, u16 *inds, u32 verts_c) const;
+
+	// Draws a cylinder in the 3D space.
+	// It draws two rounds with 20 vertices each and cylindrical surface between them.
+	void drawCylindricShape() const;
+
+	friend void LineSceneNodeManager::step(f32 dtime);
+};

--- a/src/line_params.cpp
+++ b/src/line_params.cpp
@@ -1,0 +1,110 @@
+/*
+Minetest
+Copyright (C) 2023 Andrey2470T, AndreyT <andreyt2203@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "line_params.h"
+#include "log.h"
+#include "constants.h"
+
+void LineParams::reset()
+{
+	type = LineType::FLAT;
+
+	pos.first = v3f(0.0f);
+	pos.second = v3f(0.0f);
+
+	color.first = video::SColor(0, 0, 0, 255);
+	color.second = video::SColor(0, 0, 0, 255);
+
+	attached_ids.first = 0;
+	attached_ids.second = 0;
+
+	width = 0.05f * BS;
+
+	texture = "";
+
+	playername = "";
+
+	backface_culling = false;
+
+	light_level = 0;
+
+	axis_angle = 0.0f;
+
+	last_changed_props.resize(LP_COUNT);
+}
+
+void LineParams::serialize(std::ostream &os, u16 protocol_version) const
+{
+	writeU8(os, (u16)type);
+
+	writeV3F32(os, pos.first);
+	writeV3F32(os, pos.second);
+
+	writeARGB8(os, color.first);
+	writeARGB8(os, color.second);
+
+	writeU16(os, attached_ids.first);
+	writeU16(os, attached_ids.second);
+
+	writeF32(os, width);
+
+	os << serializeString32(texture);
+	os << serializeString32(playername);
+
+	writeU8(os, (u8)backface_culling);
+
+	animation.serialize(os, protocol_version);
+
+	writeU16(os, light_level);
+
+	writeF32(os, axis_angle);
+
+	for (auto b : last_changed_props)
+		writeU8(os, (u8)b);
+}
+
+void LineParams::deserialize(std::istream &is, u16 protocol_version)
+{
+	type = (LineType)readU8(is);
+
+	pos.first = readV3F32(is);
+	pos.second = readV3F32(is);
+
+	color.first = readARGB8(is);
+	color.second = readARGB8(is);
+
+	attached_ids.first = readU16(is);
+	attached_ids.second = readU16(is);
+
+	width = readF32(is);
+
+	texture = deSerializeString32(is);
+	playername = deSerializeString32(is);
+
+	backface_culling = (bool)readU8(is);
+
+	animation.deSerialize(is, protocol_version);
+
+	light_level = readU16(is);
+
+	axis_angle = readF32(is);
+
+	for (u32 i = 0; i < last_changed_props.size(); i++)
+		last_changed_props[i] = (bool)readU8(is);
+}

--- a/src/line_params.h
+++ b/src/line_params.h
@@ -1,0 +1,100 @@
+/*
+Minetest
+Copyright (C) 2023 Andrey2470T, AndreyT <andrey012203@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes_bloated.h"
+#include <utility>
+#include <string>
+#include <sstream>
+#include <vector>
+#include "tileanimation.h"
+#include "script/common/c_content.h"
+#include <SMaterialLayer.h>
+
+enum class LineType {
+	FLAT,
+	DIHEDRAL,
+	CYLINDRIC,
+	NONE
+};
+
+struct LineParams {
+	enum LineProperty {
+		LP_TYPE = 0,
+		LP_START_POS,
+		LP_END_POS,
+		LP_START_COLOR,
+		LP_END_COLOR,
+		LP_START_ATTACH_TO,
+		LP_END_ATTACH_TO,
+		LP_WIDTH,
+		LP_TEXTURE,
+		LP_PLAYERNAME,
+		LP_ANIMATION,
+		LP_BACKFACE_CULLING,
+		LP_LIGHT_LEVEL,
+		LP_AXIS_ANGLE,
+		LP_COUNT
+	};
+
+	LineParams()
+	{
+		reset();
+	}
+
+	LineType type;
+
+	// Positions of start and env vertices.
+	std::pair<v3f, v3f> pos;
+	// Colors of start and end vertices.
+	std::pair<video::SColor, video::SColor> color;
+	// IDs of objects which start and end vertices are attached to.
+	std::pair<u16, u16> attached_ids;
+
+	// Thickness of the line.
+	f32 width;
+
+	std::string texture;
+
+	// If 'playername' is not empty string, the line will be sent only to the client with that name.
+	std::string playername;
+
+	bool backface_culling;
+
+	TileAnimationParams animation;
+
+	// Can be from 0-14 integers.
+	u8 light_level;
+
+	// Angle in radians around the line lengthwise axis
+	f32 axis_angle;
+
+	// Contains boolean value for each property.
+	// If property has 'true', it means the given property was changed in 'set_properties()' method.
+	// Otherwise it has 'false'.
+	// As there may be only a few changed params and a whole structure is sent, without this container
+	// it would be impossible to determine which params are actually changed.
+	std::vector<bool> last_changed_props;
+
+	void reset();
+
+	void serialize(std::ostream &os, u16 protocol_version) const;
+	void deserialize(std::istream &is, u16 protocol_version);
+};

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -126,6 +126,9 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_FORMSPEC_PREPEND",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FormspecPrepend }, // 0x61,
 	{ "TOCLIENT_MINIMAP_MODES",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MinimapModes }, // 0x62,
 	{ "TOCLIENT_SET_LIGHTING",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SetLighting }, // 0x63,
+	{ "TOCLIENT_ADD_3DLINE",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Add3DLine }, // 0x64
+	{ "TOCLIENT_CHANGE_3DLINE_PROPERTIES", TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Change3DLineProperties }, // 0x65
+	{ "TOCLIENT_REMOVE_3DLINE",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Remove3DLine } // 0x66
 };
 
 const static ServerCommandFactory null_command_factory = { nullptr, 0, false };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1827,3 +1827,51 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.volumetric_light_strength;
 }
+
+void Client::handleCommand_Add3DLine(NetworkPacket *pkt)
+{
+	std::string datastring(pkt->getString(0), pkt->getSize());
+	std::istringstream is(datastring, std::ios_base::binary);
+
+	u32 id = readU32(is);
+
+	LineParams *params = new LineParams();
+
+	params->deserialize(is, getProtoVersion());
+
+	ClientEvent *event = new ClientEvent();
+	event->type = CE_ADD_3DLINE;
+	event->line.p = params;
+	event->line.id = id;
+
+	m_client_event_queue.push(event);
+}
+
+void Client::handleCommand_Change3DLineProperties(NetworkPacket *pkt)
+{
+	std::string datastring(pkt->getString(0), pkt->getSize());
+	std::istringstream is(datastring, std::ios_base::binary);
+	u32 id = readU32(is);
+
+	LineParams *params = new LineParams();
+
+	params->deserialize(is, getProtoVersion());
+
+	ClientEvent *event = new ClientEvent();
+	event->type = CE_CHANGE_3DLINE_PROPERTIES;
+	event->line.p = params;
+	event->line.id = id;
+	m_client_event_queue.push(event);
+}
+
+void Client::handleCommand_Remove3DLine(NetworkPacket *pkt)
+{
+	std::string datastring(pkt->getString(0), pkt->getSize());
+	std::istringstream is(datastring, std::ios_base::binary);
+	u32 id = readU32(is);
+
+	ClientEvent *event = new ClientEvent();
+	event->type = CE_REMOVE_3DLINE;
+	event->remove_line.id = id;
+	m_client_event_queue.push(event);
+}

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -850,7 +850,45 @@ enum ToClientCommand : u16
 			f32 center_weight_power
 	*/
 
-	TOCLIENT_NUM_MSG_TYPES = 0x64,
+	TOCLIENT_ADD_3DLINE = 0x64,
+	/*
+		u32 id
+		LineType type
+		std::pair<v3f> pos
+		std::pair<video::SColor> color
+		std::pair<u16> attached_ids
+		f32 width
+		std::string texture
+		std::string playername
+		bool backface_culling
+		TileAnimationParams animation
+		u8 light_level
+		std::unordered_map<LineProperty, bool> last_changed
+	*/
+
+	TOCLIENT_CHANGE_3DLINE_PROPERTIES = 0x65,
+	/*
+		u32 id
+		LineType type
+		std::pair<v3f> pos
+		std::pair<video::SColor> color
+		std::pair<u16> attached_ids
+		f32 width
+		std::string texture
+		std::string playername
+		bool backface_culling
+		TileAnimationParams animation
+		u8 light_level
+		std::unordered_map<LineProperty, bool> last_changed
+	*/
+
+	TOCLIENT_REMOVE_3DLINE = 0x66,
+	/*
+		u32 id
+	*/
+
+	TOCLIENT_NUM_MSG_TYPES = 0x67,
+
 };
 
 enum ToServerCommand : u16

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -226,4 +226,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_FORMSPEC_PREPEND",         0, true }, // 0x61
 	{ "TOCLIENT_MINIMAP_MODES",            0, true }, // 0x62
 	{ "TOCLIENT_SET_LIGHTING",             0, true }, // 0x63
+	{ "TOCLIENT_ADD_3DLINE",               0, true }, // 0x64
+	{ "TOCLIENT_CHANGE_3DLINE_PROPERTIES", 0, true }, // 0x65
+	{ "TOCLIENT_REMOVE_3DLINE",            0, true }  // 0x66
 };

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -133,6 +133,9 @@ private:
 	// pos = {x=num, y=num, z=num}
 	static int l_add_entity(lua_State *L);
 
+	// add_3dline(line_params) -> Lua3DLine or nil
+	static int l_add_3dline(lua_State *L);
+
 	// add_item(pos, itemstack or itemstring or table) -> ObjectRef or nil
 	// pos = {x=num, y=num, z=num}
 	static int l_add_item(lua_State *L);
@@ -345,6 +348,34 @@ public:
 	static int create_object(lua_State *L);
 
 	//! Registers Raycast as a Lua userdata type.
+	static void Register(lua_State *L);
+
+	static const char className[];
+};
+
+class Lua3DLine : public ModApiBase
+{
+private:
+	u32 m_id;
+	bool m_pending_removal;
+
+	static int gc_object(lua_State *L);
+
+	static int objects_equal(lua_State *L);
+
+	static int l_is_valid(lua_State *L);
+
+	static int l_set_properties(lua_State *L);
+
+	static int l_remove(lua_State *L);
+
+	static const luaL_Reg methods[];
+public:
+	Lua3DLine(u32 id)
+		: m_id(id), m_pending_removal(false)
+	{
+	}
+
 	static void Register(lua_State *L);
 
 	static const char className[];

--- a/src/script/scripting_client.cpp
+++ b/src/script/scripting_client.cpp
@@ -75,7 +75,7 @@ void ClientScripting::InitializeModApi(lua_State *L, int top)
 	LuaCamera::Register(L);
 	ModChannelRef::Register(L);
 	LuaSettings::Register(L);
-	ClientSoundHandle::Register(L);
+	Lua3DLine::Register(L);
 
 	ModApiUtil::InitializeClient(L, top);
 	ModApiClient::Initialize(L, top);

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -154,6 +154,7 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	LuaSettings::Register(L);
 	StorageRef::Register(L);
 	ModChannelRef::Register(L);
+	Lua3DLine::Register(L);
 
 	// Initialize mod api modules
 	ModApiAuth::Initialize(L, top);

--- a/src/server.h
+++ b/src/server.h
@@ -44,6 +44,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <map>
 #include <vector>
 #include <unordered_set>
+#include "line_params.h"
 
 class ChatEvent;
 struct ChatEventChat;
@@ -257,6 +258,14 @@ public:
 		ServerActiveObject *attached, const std::string &playername);
 
 	void deleteParticleSpawner(const std::string &playername, u32 id);
+
+	u32 add3DLine(const LineParams &p);
+	void change3DLineProperties(u32 id, const LineParams &new_p);
+	void remove3DLine(u32 id);
+
+	void add3DLineToClient(const LineParams &p, RemotePlayer *player, u32 id);
+	void change3DLinePropertiesToClient(const LineParams &new_p, RemotePlayer *player, u32 id);
+	void remove3DLineToClient(RemotePlayer *player, u32 id);
 
 	bool dynamicAddMedia(std::string filepath, u32 token,
 		const std::string &to_player, bool ephemeral);
@@ -530,6 +539,9 @@ private:
 		const ParticleSpawnerParameters &p, u16 attached_id, u32 id);
 
 	void SendDeleteParticleSpawner(session_t peer_id, u32 id);
+
+	void Send3DLine(session_t peer_id, u32 proto_ver,
+		u32 id, u16 action = 2, const LineParams *p = nullptr);
 
 	// Spawns particle on peer with peer_id (PEER_ID_INEXISTENT == all)
 	void SendSpawnParticle(session_t peer_id, u16 protocol_version,

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1712,6 +1712,34 @@ void ServerEnvironment::deleteParticleSpawner(u32 id, bool remove_from_object)
 	}
 }
 
+u32 ServerEnvironment::addNew3DLine()
+{
+	static thread_local u32 id = 0;
+
+	// Searching for free id
+	std::set<u32>::iterator it;
+	do {
+		id++;
+		it = m_3dlines_ids.find(id);
+	}
+	while (it != m_3dlines_ids.end());
+
+	m_3dlines_ids.insert(id);
+
+	return id;
+}
+
+void ServerEnvironment::remove3DLine(u32 id)
+{
+	if (m_3dlines_ids.find(id) != m_3dlines_ids.end())
+		m_3dlines_ids.erase(id);
+}
+
+bool ServerEnvironment::is3DLineExists(u32 id)
+{
+	return m_3dlines_ids.find(id) != m_3dlines_ids.end();
+}
+
 u16 ServerEnvironment::addActiveObject(std::unique_ptr<ServerActiveObject> object)
 {
 	assert(object);	// Pre-condition

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -258,6 +258,9 @@ public:
 	u32 addParticleSpawner(float exptime, u16 attached_id);
 	void deleteParticleSpawner(u32 id, bool remove_from_object = true);
 
+	u32 addNew3DLine();
+	void remove3DLine(u32 id);
+	bool is3DLineExists(u32 id);
 	/*
 		External ActiveObject interface
 		-------------------------------------------
@@ -515,6 +518,7 @@ private:
 	u32 m_particle_spawners_id_last_used = 0;
 	std::unordered_map<u32, u16> m_particle_spawner_attachments;
 
+	std::set<u32> m_3dlines_ids;
 	// Environment metrics
 	MetricCounterPtr m_step_time_counter;
 	MetricGaugePtr m_active_block_gauge;


### PR DESCRIPTION
This PR is particularly based on the closed #10619 and introduces an early implementation of rendering dynamic 3d lines for various goals. Currently, it is possible to add/change positions and colors of both ends, diameter, attaching to objects, clamp mode, texture, backface culling, animation and light level.

Next visual types are supported:

- `sprite`: always facing to the player.
- `flat`: represents itself 3d rectangle.
- `dihedral`: two rectangles intersecting orthogonally to each other.
- `cylindric`: represents a cylinder whose rotation axis goes from the start point to the end one.

![Снимок экрана от 2022-12-04 20-59-20](https://user-images.githubusercontent.com/25750346/205508118-2ccc666e-4572-4cdd-8fc9-6d4a107fc440.png)
![Снимок экрана от 2022-12-04 21-00-16](https://user-images.githubusercontent.com/25750346/205508122-f167ddc6-a693-4ac4-a559-1e5b1d385e61.png)
![Снимок экрана от 2022-12-04 21-00-44](https://user-images.githubusercontent.com/25750346/205508123-f4bf3e85-538a-4ee3-ba3c-03448bcc1e66.png)

## To do

This PR is Ready for Review.


## How to test
1. Download the test mod: 
[line_test.zip](https://github.com/minetest/minetest/files/10149174/line_test.zip)
2. Enter `/add_3dline` to add new line with some default properties.
3. Then enter `/change_3dlines` to randomly change the properties of the current added lines (type, colors, width and texture).
4. If you don't need the lines anymore, summon `/remove_3dlines` that will remove all lines.
