### PR TITLE
[NO SQUASH] Delete blocks safely

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1312,6 +1312,8 @@ ServerMap::~ServerMap()
 	*/
 	delete dbase;
 	delete dbase_ro;
+
+	deleteDeletedBlocks();
 }
 
 MapgenParams *ServerMap::getMapgenParams()
@@ -1894,10 +1896,22 @@ bool ServerMap::deleteBlock(v3s16 blockpos)
 		MapSector *sector = getSectorNoGenerate(p2d);
 		if (!sector)
 			return false;
-		sector->deleteBlock(block);
+		// It may not be safe to delete the block from memory at the moment
+		// (pointers to it could still be in use)
+		sector->removeBlock(block);
+		m_deleted_blocks.push_back(block);
 	}
 
 	return true;
+}
+
+void ServerMap::deleteDeletedBlocks()
+{
+	for (MapBlock *block : m_deleted_blocks) {
+		assert(!block->getParent());
+		delete block;
+	}
+	m_deleted_blocks.clear();
 }
 
 void ServerMap::PrintInfo(std::ostream &out)

--- a/src/map.h
+++ b/src/map.h
@@ -403,7 +403,12 @@ public:
 	// Database version
 	void loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool save_after_load=false);
 
+	// Blocks are removed from the map but not deleted from memory until
+	// deleteDeletedBlocks() is called, since pointers to them may still exist
+	// when deleteBlock() is called.
 	bool deleteBlock(v3s16 blockpos) override;
+
+	void deleteDeletedBlocks();
 
 	void updateVManip(v3s16 pos);
 
@@ -447,6 +452,9 @@ private:
 	int m_map_compression_level;
 
 	std::set<v3s16> m_chunks_in_progress;
+
+	// used by deleteBlock() and deleteDeletedBlocks()
+	MapBlockVect m_deleted_blocks;
 
 	// Queued transforming water nodes
 	UniqueQueue<v3s16> m_transforming_liquid;

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -86,6 +86,11 @@ public:
 		return m_parent;
 	}
 
+	void makeOrphan()
+	{
+		m_parent = nullptr;
+	}
+
 	void reallocate()
 	{
 		for (u32 i = 0; i < nodecount; i++)

--- a/src/mapsector.cpp
+++ b/src/mapsector.cpp
@@ -110,6 +110,12 @@ void MapSector::insertBlock(MapBlock *block)
 
 void MapSector::deleteBlock(MapBlock *block)
 {
+	removeBlock(block);
+	delete block;
+}
+
+void MapSector::removeBlock(MapBlock *block)
+{
 	s16 block_y = block->getPos().Y;
 
 	// Clear from cache
@@ -118,8 +124,8 @@ void MapSector::deleteBlock(MapBlock *block)
 	// Remove from container
 	m_blocks.erase(block_y);
 
-	// Delete
-	delete block;
+	// Mark as removed
+	block->makeOrphan();
 }
 
 void MapSector::getBlocks(MapBlockVect &dest)

--- a/src/mapsector.h
+++ b/src/mapsector.h
@@ -58,6 +58,9 @@ public:
 
 	void deleteBlock(MapBlock *block);
 
+	// Remove a block from the map and the sector without deleting it
+	void removeBlock(MapBlock *block);
+
 	void getBlocks(MapBlockVect &dest);
 
 	bool empty() const { return m_blocks.empty(); }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -664,6 +664,12 @@ void Server::AsyncRunStep(bool initial_step)
 	}
 
 	/*
+		Delete from memory blocks removed by deleteBlocks() only when pointers
+		to them are (probably) no longer in use
+	*/
+	m_env->getServerMap().deleteDeletedBlocks();
+
+	/*
 		Listen to the admin chat, if available
 	*/
 	if (m_admin_chat) {

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -282,6 +282,8 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block,
 						continue;
 					for (auto lbmdef : *lbm_list) {
 						lbmdef->trigger(env, pos + pos_of_block, n, dtime_s);
+						if (!block->getParent())
+							return; // The block was deleted
 						n = block->getNodeNoCheck(pos);
 						if (n.getContent() != c)
 							break; // The node was changed and the LBMs no longer apply
@@ -949,6 +951,9 @@ public:
 				aabm.abm->trigger(m_env, p, n,
 					active_object_count, active_object_count_wider);
 
+				if (!block->getParent())
+					return; // block was deleted
+
 				// Count surrounding objects again if the abms added any
 				if(m_env->m_added_objects > 0) {
 					active_object_count = countObjects(block, map, active_object_count_wider);
@@ -1001,11 +1006,12 @@ void ServerEnvironment::activateBlock(MapBlock *block, u32 additional_dtime)
 	activateObjects(block, dtime_s);
 
 	/* Handle LoadingBlockModifiers */
-	m_lbm_mgr.applyLBMs(this, block, stamp, (float)dtime_s);
+	if (block->getParent()) // Block not deleted
+		m_lbm_mgr.applyLBMs(this, block, stamp, (float)dtime_s);
 
 	// Run node timers
 	block->step((float)dtime_s, [&](v3s16 p, MapNode n, f32 d) -> bool {
-		return m_script->node_on_timer(p, n, d);
+		return block->getParent() && m_script->node_on_timer(p, n, d);
 	});
 }
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -282,6 +282,9 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block,
 						continue;
 					for (auto lbmdef : *lbm_list) {
 						lbmdef->trigger(env, pos + pos_of_block, n, dtime_s);
+						n = block->getNodeNoCheck(pos);
+						if (n.getContent() != c)
+							break; // The node was changed and the LBMs no longer apply
 					}
 				}
 	}


### PR DESCRIPTION
Before this, blocks were deleted from memory immediately upon calling `minetest.delete_area`. The problem was that this function could be called in an ABM or another situation where code is using a pointer to the mapblock. In these situations, the function would cause invalid memory access. Now when a block is deleted it is removed from the map (marked by settings its parent to null) but not deleted from memory until a certain point in the main loop. Code can check that the block it is using has not been removed from the map.

There's also a commit that adds a necessary node check to LBMs. This check was previously added to ABMs.

A simpler solution to the deletion problem would be to not remove/delete blocks until a set point in the main loop, but this might break existing code that expects deletion to be synchronous.

## To do

This PR is Ready for Review.

## How to test

1. Test that ABMs work.
2. Test that LBMs work.
3. Test that node timers work.
4. Try the following code. placing `mymod:delete_block` should delete the block and not crash the game.

```lua
minetest.register_node(":mymod:delete_area", {
	description = "Delete Area ABM",
	tiles = {"testnodes_node.png"},
	groups = { dig_immediate = 2 },
})

minetest.register_abm({
	label = "Delete Area",
	nodenames = "mymod:delete_area",
	interval = 1,
	chance = 1,
	catch_up = false,
	action = function(pos, node)
		assert(node.name == "mymod:delete_area")
		minetest.delete_area(pos, pos)
	end,
})
```
