### PR TITLE
Avoid out-of-bounds memory access in attached node placement prediction

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3556,24 +3556,23 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 
 	const ContentFeatures &predicted_f = nodedef->get(id);
 
-	// Predict param2 for facedir and wallmounted nodes
-	// Compare core.item_place_node() for what the server does
-	u8 param2 = 0;
+	// Compare core.item_place_node() for what the server does with param2
+	MapNode predicted_node(id, 0, 0);
 
 	const u8 place_param2 = selected_def.place_param2;
 
 	if (place_param2) {
-		param2 = place_param2;
+		predicted_node.setParam2(place_param2);
 	} else if (predicted_f.param_type_2 == CPT2_WALLMOUNTED ||
 			predicted_f.param_type_2 == CPT2_COLORED_WALLMOUNTED) {
 		v3s16 dir = nodepos - neighborpos;
 
 		if (abs(dir.Y) > MYMAX(abs(dir.X), abs(dir.Z))) {
-			param2 = dir.Y < 0 ? 1 : 0;
+			predicted_node.setParam2(dir.Y < 0 ? 1 : 0);
 		} else if (abs(dir.X) > abs(dir.Z)) {
-			param2 = dir.X < 0 ? 3 : 2;
+			predicted_node.setParam2(dir.X < 0 ? 3 : 2);
 		} else {
-			param2 = dir.Z < 0 ? 5 : 4;
+			predicted_node.setParam2(dir.Z < 0 ? 5 : 4);
 		}
 	} else if (predicted_f.param_type_2 == CPT2_FACEDIR ||
 			predicted_f.param_type_2 == CPT2_COLORED_FACEDIR ||
@@ -3582,9 +3581,9 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 		v3s16 dir = nodepos - floatToInt(client->getEnv().getLocalPlayer()->getPosition(), BS);
 
 		if (abs(dir.X) > abs(dir.Z)) {
-			param2 = dir.X < 0 ? 3 : 1;
+			predicted_node.setParam2(dir.X < 0 ? 3 : 1);
 		} else {
-			param2 = dir.Z < 0 ? 2 : 0;
+			predicted_node.setParam2(dir.Z < 0 ? 2 : 0);
 		}
 	}
 
@@ -3599,17 +3598,16 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 			pp = p + v3s16(0, 1, 0);
 		} else if (an == 2) {
 			if (predicted_f.param_type_2 == CPT2_FACEDIR ||
-					predicted_f.param_type_2 == CPT2_COLORED_FACEDIR) {
-				pp = p + facedir_dirs[param2 % 32];
-			} else if (predicted_f.param_type_2 == CPT2_4DIR ||
-					predicted_f.param_type_2 == CPT2_COLORED_4DIR ) {
-				pp = p + fourdir_dirs[param2 % 4];
+					predicted_f.param_type_2 == CPT2_COLORED_FACEDIR ||
+					predicted_f.param_type_2 == CPT2_4DIR ||
+					predicted_f.param_type_2 == CPT2_COLORED_4DIR) {
+				pp = p + facedir_dirs[predicted_node.getFaceDir(nodedef)];
 			} else {
 				pp = p;
 			}
 		} else if (predicted_f.param_type_2 == CPT2_WALLMOUNTED ||
 				predicted_f.param_type_2 == CPT2_COLORED_WALLMOUNTED) {
-			pp = p + wallmounted_dirs[param2 % 8];
+			pp = p + predicted_node.getWallMountedDir(nodedef);
 		} else {
 			pp = p + v3s16(0, -1, 0);
 		}
@@ -3632,36 +3630,34 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 		if (!indexstr.empty()) {
 			s32 index = mystoi(indexstr);
 			if (predicted_f.param_type_2 == CPT2_COLOR) {
-				param2 = index;
+				predicted_node.setParam2(index);
 			} else if (predicted_f.param_type_2 == CPT2_COLORED_WALLMOUNTED) {
 				// param2 = pure palette index + other
-				param2 = (index & 0xf8) | (param2 & 0x07);
+				predicted_node.setParam2((index & 0xf8) | (predicted_node.getParam2() & 0x07));
 			} else if (predicted_f.param_type_2 == CPT2_COLORED_FACEDIR) {
 				// param2 = pure palette index + other
-				param2 = (index & 0xe0) | (param2 & 0x1f);
+				predicted_node.setParam2((index & 0xe0) | (predicted_node.getParam2() & 0x1f));
 			} else if (predicted_f.param_type_2 == CPT2_COLORED_4DIR) {
 				// param2 = pure palette index + other
-				param2 = (index & 0xfc) | (param2 & 0x03);
+				predicted_node.setParam2((index & 0xfc) | (predicted_node.getParam2() & 0x03));
 			}
 		}
 	}
 
 	// Add node to client map
-	MapNode n(id, 0, param2);
-
 	try {
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
 
 		// Don't place node when player would be inside new node
 		// NOTE: This is to be eventually implemented by a mod as client-side Lua
-		if (!nodedef->get(n).walkable ||
+		if (!predicted_f.walkable ||
 				g_settings->getBool("enable_build_where_you_stand") ||
 				(client->checkPrivilege("noclip") && g_settings->getBool("noclip")) ||
-				(nodedef->get(n).walkable &&
+				(predicted_f.walkable &&
 					neighborpos != player->getStandingNodePos() + v3s16(0, 1, 0) &&
 					neighborpos != player->getStandingNodePos() + v3s16(0, 2, 0))) {
 			// This triggers the required mesh update too
-			client->addNode(p, n);
+			client->addNode(p, predicted_node);
 			// Report to server
 			client->interact(INTERACT_PLACE, pointed);
 			// A node is predicted, also play a sound

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3600,16 +3600,16 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 		} else if (an == 2) {
 			if (predicted_f.param_type_2 == CPT2_FACEDIR ||
 					predicted_f.param_type_2 == CPT2_COLORED_FACEDIR) {
-				pp = p + facedir_dirs[param2];
+				pp = p + facedir_dirs[param2 % 32];
 			} else if (predicted_f.param_type_2 == CPT2_4DIR ||
 					predicted_f.param_type_2 == CPT2_COLORED_4DIR ) {
-				pp = p + fourdir_dirs[param2];
+				pp = p + fourdir_dirs[param2 % 4];
 			} else {
 				pp = p;
 			}
 		} else if (predicted_f.param_type_2 == CPT2_WALLMOUNTED ||
 				predicted_f.param_type_2 == CPT2_COLORED_WALLMOUNTED) {
-			pp = p + wallmounted_dirs[param2];
+			pp = p + wallmounted_dirs[param2 % 8];
 		} else {
 			pp = p + v3s16(0, -1, 0);
 		}


### PR DESCRIPTION
If a high value of `place_param2` was given, this could lead to out-of-bounds memory access.

## To do

This PR is Ready for Review.

## How to test

Apply this patch:

```patch
diff --git a/games/devtest/mods/testnodes/properties.lua b/games/devtest/mods/testnodes/properties.lua
index c51db810c..d19913ce2 100644
--- a/games/devtest/mods/testnodes/properties.lua
+++ b/games/devtest/mods/testnodes/properties.lua
@@ -64,6 +64,7 @@ minetest.register_node("testnodes:attached_wallmounted", {
 		S("Attaches to wall; drops as item if neighbor node is gone").."\n"..
 		S("param2 = wallmounted rotation (0..5)"),
 	paramtype2 = "wallmounted",
+	place_param2 = 32,
 	tiles = {
 		"testnodes_attachedw_top.png",
 		"testnodes_attachedw_bottom.png",

```

Try placing `testnodes:attached_wallmounted`. There should be no failure of placement prediction.

Also test placement prediction in general.