### PR TITLE
Say /setpassword is insecure

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -456,7 +456,7 @@ core.register_chatcommand("setpassword", {
 
 core.register_chatcommand("clearpassword", {
 	params = S("<name>"),
-	description = S("Set empty password for a player"),
+	description = S("Set player's password (sent unencrypted, thus insecure)"),
 	privs = {password=true},
 	func = function(name, param)
 		local toname = param


### PR DESCRIPTION
Manually write the following git change to Github because push does not work

```
From 856868b1e273c4ca26bc930d1212bf6d75909194 Mon Sep 17 00:00:00 2001
From: 56independent <emailchecker506@gmail.com>
Date: Fri, 16 Dec 2022 18:40:35 +0100
Subject: Say /setpassword is insecure for issue #8982


diff --git a/builtin/game/chat.lua b/builtin/game/chat.lua
index bbcdcf2d0..baab5212f 100644
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -416,7 +416,7 @@ core.register_chatcommand("revokeme", {
 
 core.register_chatcommand("setpassword", {
 	params = S("<name> <password>"),
-	description = S("Set player's password"),
+	description = S("Set player's password (sent unencrypted, thus insecure)"),
 	privs = {password=true},
 	func = function(name, param)
 		local toname, raw_password = string.match(param, "^([^ ]+) +(.+)$")
```

This PR is a Ready for Review

## How to test

run `/setpassword` i guess