### PR TITLE
Fix progress bar look on HiDPI displays

### DIFF
--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -466,8 +466,8 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 #ifndef __ANDROID__
 			const core::dimension2d<u32> &img_size =
 					progress_img_bg->getSize();
-			u32 imgW = rangelim(img_size.Width, 200, 600);
-			u32 imgH = rangelim(img_size.Height, 24, 72);
+			u32 imgW = rangelim(img_size.Width, 200, 600) * getDisplayDensity();
+			u32 imgH = rangelim(img_size.Height, 24, 72) * getDisplayDensity();
 #else
 			const core::dimension2d<u32> img_size(256, 48);
 			float imgRatio = (float)img_size.Height / img_size.Width;


### PR DESCRIPTION
The progress bar looks bad on HiDPI displays (4K, Retina). This patch fixes this using a correct `display_density_factor` setting.

Before:

![Capture d’écran du 2022-12-19 10-46-57](https://user-images.githubusercontent.com/7883281/208397487-2d6bcaf9-ce87-4d86-97e7-dbfd9f1a2152.png)

After:

![Capture d’écran du 2022-12-19 10-46-33](https://user-images.githubusercontent.com/7883281/208397638-39f67538-6760-4b3f-879b-eb1dc0dbdee7.png)

