### PR TITLE
Document the gain of auto-selected dig sounds

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -8438,7 +8438,7 @@ Used by `minetest.register_node`.
             dig = <SimpleSoundSpec> or "__group",
             -- While digging node.
             -- If `"__group"`, then the sound will be
-            -- `default_dig_<groupname>`, where `<groupname>` is the
+            -- `{name = "default_dig_<groupname>", gain = 0.5}` , where `<groupname>` is the
             -- name of the item's digging group with the fastest digging time.
             -- In case of a tie, one of the sounds will be played (but we
             -- cannot predict which one)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -981,7 +981,7 @@ These sound files are played back by the engine if provided.
  * `player_falling_damage`: Played when the local player takes
    damage by falling (gain = 0.5)
  * `player_jump`: Played when the local player jumps
- * `default_dig_<groupname>`: Default node digging sound
+ * `default_dig_<groupname>`: Default node digging sound (gain = 0.5)
    (see node sound definition for details)
 
 Registered definitions


### PR DESCRIPTION
If you don't specify a dig sound, Minetest selects one based on the node groups:

https://github.com/minetest/minetest/blob/587f6656a4b86346e35da1b43b48b832d3f1b32e/doc/lua_api.txt#L8206-L8213

The automatically selected sound is played with a gain of 0.5 ([reference](https://github.com/minetest/minetest/blob/587f6656a4b86346e35da1b43b48b832d3f1b32e/src/client/game.cpp#L3664)). This isn't documented in lua_api.txt. This PR adds documentation about the sound being played with a gain of 0.5 to lua_api.txt.

- If not a bug fix, why is this PR needed? What usecases does it solve?
  It improves the documentation.

## To do

This PR is Ready for Review.

## How to test

Look at lua_api.txt.
