### PR TITLE
Use multiple threads for mesh generation

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1685,7 +1685,7 @@ mesh_generation_interval (Mapblock mesh generation delay) int 0 0 50
 
 #    Number of threads to use for mesh generation.
 #    Value of 0 (default) will let Minetest autodetect the number of available threads.
-mesh_generation_threads (Mapblock mesh generation threads) int 0 0 32
+mesh_generation_threads (Mapblock mesh generation threads) int 0 0 8
 
 
 #    Size of the MapBlock cache of the mesh generator. Increasing this will

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1683,6 +1683,11 @@ enable_mesh_cache (Mesh cache) bool false
 #    down the rate of mesh updates, thus reducing jitter on slower clients.
 mesh_generation_interval (Mapblock mesh generation delay) int 0 0 50
 
+#    Number of threads to use for mesh generation.
+#    Value of 0 (default) will let Minetest autodetect the number of available threads.
+mesh_generation_threads (Mapblock mesh generation threads) int 0 0 32
+
+
 #    Size of the MapBlock cache of the mesh generator. Increasing this will
 #    increase the cache hit %, reducing the data being copied from the main
 #    thread, thus reducing jitter.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -338,11 +338,9 @@ Client::~Client()
 	m_mesh_update_manager.stop();
 	m_mesh_update_manager.wait();
 	
-	while (!m_mesh_update_manager.m_queue_out.empty()) {
-		MeshUpdateResult r = m_mesh_update_manager.m_queue_out.pop_frontNoEx();
+	MeshUpdateResult r;
+	while (m_mesh_update_manager.getNextResult(r))
 		delete r.mesh;
-	}
-
 
 	delete m_inventory_from_server;
 
@@ -548,14 +546,14 @@ void Client::step(float dtime)
 		int num_processed_meshes = 0;
 		std::vector<v3s16> blocks_to_ack;
 		bool force_update_shadows = false;
-		while (!m_mesh_update_manager.m_queue_out.empty())
+		MeshUpdateResult r;
+		while (m_mesh_update_manager.getNextResult(r))
 		{
 			num_processed_meshes++;
 
 			MinimapMapblock *minimap_mapblock = NULL;
 			bool do_mapper_update = true;
 
-			MeshUpdateResult r = m_mesh_update_manager.m_queue_out.pop_frontNoEx();
 			MapBlock *block = m_env.getMap().getBlockNoCreateNoEx(r.p);
 			if (block) {
 				// Delete the old mesh

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -111,7 +111,7 @@ Client::Client(
 	m_sound(sound),
 	m_event(event),
 	m_rendering_engine(rendering_engine),
-	m_mesh_update_thread(this),
+	m_mesh_update_manager(this),
 	m_env(
 		new ClientMap(this, rendering_engine, control, 666),
 		tsrc, this
@@ -312,7 +312,7 @@ void Client::Stop()
 	if (m_mods_loaded)
 		m_script->on_shutdown();
 	//request all client managed threads to stop
-	m_mesh_update_thread.stop();
+	m_mesh_update_manager.stop();
 	// Save local server map
 	if (m_localdb) {
 		infostream << "Local map saving ended." << std::endl;
@@ -325,7 +325,7 @@ void Client::Stop()
 
 bool Client::isShutdown()
 {
-	return m_shutdown || !m_mesh_update_thread.isRunning();
+	return m_shutdown || !m_mesh_update_manager.isRunning();
 }
 
 Client::~Client()
@@ -335,11 +335,11 @@ Client::~Client()
 
 	deleteAuthData();
 
-	m_mesh_update_thread.stop();
-	m_mesh_update_thread.wait();
+	m_mesh_update_manager.stop();
+	m_mesh_update_manager.wait();
 	
-	while (!m_mesh_update_thread.m_queue_out.empty()) {
-		MeshUpdateResult r = m_mesh_update_thread.m_queue_out.pop_frontNoEx();
+	while (!m_mesh_update_manager.m_queue_out.empty()) {
+		MeshUpdateResult r = m_mesh_update_manager.m_queue_out.pop_frontNoEx();
 		delete r.mesh;
 	}
 
@@ -548,16 +548,16 @@ void Client::step(float dtime)
 		int num_processed_meshes = 0;
 		std::vector<v3s16> blocks_to_ack;
 		bool force_update_shadows = false;
-		auto mesh_queue_size = m_mesh_update_thread.m_queue_out.size();
+		auto mesh_queue_size = m_mesh_update_manager.m_queue_out.size();
 		m_avg_mesh_queue_size = MYMIN(mesh_queue_size, 0.95 * m_avg_mesh_queue_size + 0.05 * mesh_queue_size);
-		while (!m_mesh_update_thread.m_queue_out.empty() && num_processed_meshes < 0.33 * m_avg_mesh_queue_size)
+		while (!m_mesh_update_manager.m_queue_out.empty() && num_processed_meshes < 0.33 * m_avg_mesh_queue_size)
 		{
 			num_processed_meshes++;
 
 			MinimapMapblock *minimap_mapblock = NULL;
 			bool do_mapper_update = true;
 
-			MeshUpdateResult r = m_mesh_update_thread.m_queue_out.pop_frontNoEx();
+			MeshUpdateResult r = m_mesh_update_manager.m_queue_out.pop_frontNoEx();
 			MapBlock *block = m_env.getMap().getBlockNoCreateNoEx(r.p);
 			if (block) {
 				// Delete the old mesh
@@ -1658,12 +1658,12 @@ void Client::addUpdateMeshTask(v3s16 p, bool ack_to_server, bool urgent)
 	if (b == NULL)
 		return;
 
-	m_mesh_update_thread.updateBlock(&m_env.getMap(), p, ack_to_server, urgent);
+	m_mesh_update_manager.updateBlock(&m_env.getMap(), p, ack_to_server, urgent);
 }
 
 void Client::addUpdateMeshTaskWithEdge(v3s16 blockpos, bool ack_to_server, bool urgent)
 {
-	m_mesh_update_thread.updateBlock(&m_env.getMap(), blockpos, ack_to_server, urgent, true);
+	m_mesh_update_manager.updateBlock(&m_env.getMap(), blockpos, ack_to_server, urgent, true);
 }
 
 void Client::addUpdateMeshTaskForNode(v3s16 nodepos, bool ack_to_server, bool urgent)
@@ -1677,7 +1677,7 @@ void Client::addUpdateMeshTaskForNode(v3s16 nodepos, bool ack_to_server, bool ur
 
 	v3s16 blockpos = getNodeBlockPos(nodepos);
 	v3s16 blockpos_relative = blockpos * MAP_BLOCKSIZE;
-	m_mesh_update_thread.updateBlock(&m_env.getMap(), blockpos, ack_to_server, urgent, false);
+	m_mesh_update_manager.updateBlock(&m_env.getMap(), blockpos, ack_to_server, urgent, false);
 	// Leading edge
 	if (nodepos.X == blockpos_relative.X)
 		addUpdateMeshTask(blockpos + v3s16(-1, 0, 0), false, urgent);
@@ -1796,7 +1796,7 @@ void Client::afterContentReceived()
 
 	// Start mesh update thread after setting up content definitions
 	infostream<<"- Starting mesh update thread"<<std::endl;
-	m_mesh_update_thread.start();
+	m_mesh_update_manager.start();
 
 	m_state = LC_Ready;
 	sendReady();

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -548,9 +548,7 @@ void Client::step(float dtime)
 		int num_processed_meshes = 0;
 		std::vector<v3s16> blocks_to_ack;
 		bool force_update_shadows = false;
-		auto mesh_queue_size = m_mesh_update_manager.m_queue_out.size();
-		m_avg_mesh_queue_size = MYMAX(20, 0.95 * m_avg_mesh_queue_size + 0.05 * mesh_queue_size);
-		while (!m_mesh_update_manager.m_queue_out.empty() && num_processed_meshes < m_avg_mesh_queue_size)
+		while (!m_mesh_update_manager.m_queue_out.empty())
 		{
 			num_processed_meshes++;
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -337,6 +337,7 @@ Client::~Client()
 
 	m_mesh_update_thread.stop();
 	m_mesh_update_thread.wait();
+	
 	while (!m_mesh_update_thread.m_queue_out.empty()) {
 		MeshUpdateResult r = m_mesh_update_thread.m_queue_out.pop_frontNoEx();
 		delete r.mesh;
@@ -547,7 +548,9 @@ void Client::step(float dtime)
 		int num_processed_meshes = 0;
 		std::vector<v3s16> blocks_to_ack;
 		bool force_update_shadows = false;
-		while (!m_mesh_update_thread.m_queue_out.empty())
+		auto mesh_queue_size = m_mesh_update_thread.m_queue_out.size();
+		m_avg_mesh_queue_size = MYMIN(mesh_queue_size, 0.95 * m_avg_mesh_queue_size + 0.05 * mesh_queue_size);
+		while (!m_mesh_update_thread.m_queue_out.empty() && num_processed_meshes < 0.33 * m_avg_mesh_queue_size)
 		{
 			num_processed_meshes++;
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -549,8 +549,8 @@ void Client::step(float dtime)
 		std::vector<v3s16> blocks_to_ack;
 		bool force_update_shadows = false;
 		auto mesh_queue_size = m_mesh_update_manager.m_queue_out.size();
-		m_avg_mesh_queue_size = MYMIN(mesh_queue_size, 0.95 * m_avg_mesh_queue_size + 0.05 * mesh_queue_size);
-		while (!m_mesh_update_manager.m_queue_out.empty() && num_processed_meshes < 0.33 * m_avg_mesh_queue_size)
+		m_avg_mesh_queue_size = MYMAX(20, 0.95 * m_avg_mesh_queue_size + 0.05 * mesh_queue_size);
+		while (!m_mesh_update_manager.m_queue_out.empty() && num_processed_meshes < m_avg_mesh_queue_size)
 		{
 			num_processed_meshes++;
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -484,7 +484,6 @@ private:
 
 
 	MeshUpdateManager m_mesh_update_manager;
-	float m_avg_mesh_queue_size {0};
 	ClientEnvironment m_env;
 	ParticleManager m_particle_manager;
 	std::unique_ptr<con::Connection> m_con;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -484,7 +484,7 @@ private:
 
 
 	MeshUpdateManager m_mesh_update_manager;
-	int m_avg_mesh_queue_size {0};
+	float m_avg_mesh_queue_size {0};
 	ClientEnvironment m_env;
 	ParticleManager m_particle_manager;
 	std::unique_ptr<con::Connection> m_con;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -484,6 +484,7 @@ private:
 
 
 	MeshUpdateThread m_mesh_update_thread;
+	int m_avg_mesh_queue_size {0};
 	ClientEnvironment m_env;
 	ParticleManager m_particle_manager;
 	std::unique_ptr<con::Connection> m_con;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -313,7 +313,7 @@ public:
 	void addUpdateMeshTaskForNode(v3s16 nodepos, bool ack_to_server=false, bool urgent=false);
 
 	void updateCameraOffset(v3s16 camera_offset)
-	{ m_mesh_update_thread.m_camera_offset = camera_offset; }
+	{ m_mesh_update_manager.m_camera_offset = camera_offset; }
 
 	bool hasClientEvents() const { return !m_client_event_queue.empty(); }
 	// Get event from queue. If queue is empty, it triggers an assertion failure.
@@ -483,7 +483,7 @@ private:
 	RenderingEngine *m_rendering_engine;
 
 
-	MeshUpdateThread m_mesh_update_thread;
+	MeshUpdateManager m_mesh_update_manager;
 	int m_avg_mesh_queue_size {0};
 	ClientEnvironment m_env;
 	ParticleManager m_particle_manager;

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -148,6 +148,7 @@ QueuedMeshUpdate *MeshUpdateQueue::pop()
 		QueuedMeshUpdate *q = *i;
 		if (must_be_urgent && m_urgents.count(q->p) == 0)
 			continue;
+		// Make sure no two threads are processing the same mapblock, as that causes racing conditions
 		if (m_inflight_blocks.find(q->p) != m_inflight_blocks.end())
 			continue;
 		m_queue.erase(i);

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -308,11 +308,11 @@ void MeshUpdateWorkerThread::doUpdate()
 MeshUpdateManager::MeshUpdateManager(Client *client):
 	m_queue_in(client)
 {
-	int number_of_threads = rangelim(g_settings->getS32("mesh_generation_threads"), 0, 32);
+	int number_of_threads = rangelim(g_settings->getS32("mesh_generation_threads"), 0, 8);
 
-	// Automatically use 33% of the system cores for mesh generation
+	// Automatically use 33% of the system cores for mesh generation, max 4
 	if (number_of_threads == 0)
-		number_of_threads = std::thread::hardware_concurrency() / 3;
+		number_of_threads = MYMIN(4, Thread::getNumberOfProcessors() / 3);
 	
 	// use at least one thread
 	number_of_threads = MYMAX(1, number_of_threads);

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -292,7 +292,10 @@ void MeshUpdateWorkerThread::doUpdate()
 		r.ack_block_to_server = q->ack_block_to_server;
 		r.urgent = q->urgent;
 
-		m_queue_out->push_back(r);
+		if (r.urgent)
+			m_queue_out->push_front(r);
+		else
+			m_queue_out->push_back(r);
 
 		delete q;
 	}

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -322,6 +322,7 @@ MeshUpdateManager::MeshUpdateManager(Client *client):
 	
 	// use at least one thread
 	number_of_threads = MYMAX(1, number_of_threads);
+	infostream << "MeshUpdateManager: using " << number_of_threads << " threads" << std::endl;
 
 	for (int i = 0; i < number_of_threads; i++)
 		m_workers.push_back(std::make_unique<MeshUpdateWorkerThread>(&m_queue_in, this, &m_camera_offset));

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -284,6 +284,8 @@ void MeshUpdateWorkerThread::doUpdate()
 
 		MapBlockMesh *mesh_new = new MapBlockMesh(q->data, *m_camera_offset);
 
+		
+
 		MeshUpdateResult r;
 		r.p = q->p;
 		r.mesh = mesh_new;

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -299,10 +299,10 @@ void MeshUpdateWorkerThread::doUpdate()
 }
 
 /*
-	MeshUpdateThread
+	MeshUpdateManager
 */
 
-MeshUpdateThread::MeshUpdateThread(Client *client):
+MeshUpdateManager::MeshUpdateManager(Client *client):
 	m_queue_in(client)
 {
 	int number_of_threads = rangelim(g_settings->getS32("mesh_generation_threads"), 0, 32);
@@ -318,7 +318,7 @@ MeshUpdateThread::MeshUpdateThread(Client *client):
 		m_workers.push_back(std::make_unique<MeshUpdateWorkerThread>(&m_queue_in, &m_queue_out, &m_camera_offset));
 }
 
-void MeshUpdateThread::updateBlock(Map *map, v3s16 p, bool ack_block_to_server,
+void MeshUpdateManager::updateBlock(Map *map, v3s16 p, bool ack_block_to_server,
 		bool urgent, bool update_neighbors)
 {
 	static thread_local const bool many_neighbors =
@@ -341,31 +341,31 @@ void MeshUpdateThread::updateBlock(Map *map, v3s16 p, bool ack_block_to_server,
 	deferUpdate();
 }
 
-void MeshUpdateThread::deferUpdate()
+void MeshUpdateManager::deferUpdate()
 {
 	for (auto &thread : m_workers)
 		thread->deferUpdate();
 }
 
-void MeshUpdateThread::start()
+void MeshUpdateManager::start()
 {
 	for (auto &thread: m_workers)
 		thread->start();
 }
 
-void MeshUpdateThread::stop()
+void MeshUpdateManager::stop()
 {
 	for (auto &thread: m_workers)
 		thread->stop();
 }
 
-void MeshUpdateThread::wait()
+void MeshUpdateManager::wait()
 {
 	for (auto &thread: m_workers)
 		thread->wait();
 }
 
-bool MeshUpdateThread::isRunning()
+bool MeshUpdateManager::isRunning()
 {
 	for (auto &thread: m_workers)
 		if (thread->isRunning())

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -77,6 +77,9 @@ public:
 	// Returns NULL if queue is empty
 	QueuedMeshUpdate *pop();
 
+	// Marks a position as finished, unblocking the next update
+	void done(v3s16 pos);
+
 	u32 size()
 	{
 		MutexAutoLock lock(m_mutex);
@@ -88,6 +91,7 @@ private:
 	std::vector<QueuedMeshUpdate *> m_queue;
 	std::unordered_set<v3s16> m_urgents;
 	std::unordered_map<v3s16, CachedMapBlockData *> m_cache;
+	std::unordered_set<v3s16> m_inflight_blocks;
 	u64 m_next_cache_cleanup; // milliseconds
 	std::mutex m_mutex;
 

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -117,17 +117,19 @@ struct MeshUpdateResult
 	MeshUpdateResult() = default;
 };
 
+class MeshUpdateManager;
+
 class MeshUpdateWorkerThread : public UpdateThread
 {
 public:
-	MeshUpdateWorkerThread(MeshUpdateQueue *queue_in, MutexedQueue<MeshUpdateResult> *queue_out, v3s16 *camera_offset);
+	MeshUpdateWorkerThread(MeshUpdateQueue *queue_in, MeshUpdateManager *manager, v3s16 *camera_offset);
 
 protected:
 	virtual void doUpdate();
 
 private:
 	MeshUpdateQueue *m_queue_in;
-	MutexedQueue<MeshUpdateResult> *m_queue_out;
+	MeshUpdateManager *m_manager;
 	v3s16 *m_camera_offset;
 
 	// TODO: Add callback to update these when g_settings changes
@@ -143,8 +145,9 @@ public:
 	// update for the block at p
 	void updateBlock(Map *map, v3s16 p, bool ack_block_to_server, bool urgent,
 			bool update_neighbors = false);
+	void putResult(const MeshUpdateResult &r);
+	bool getNextResult(MeshUpdateResult &r);
 
-	MutexedQueue<MeshUpdateResult> m_queue_out;
 
 	v3s16 m_camera_offset;
 
@@ -159,5 +162,8 @@ private:
 
 
 	MeshUpdateQueue m_queue_in;
+	MutexedQueue<MeshUpdateResult> m_queue_out;
+	MutexedQueue<MeshUpdateResult> m_queue_out_urgent;
+
 	std::vector<std::unique_ptr<MeshUpdateWorkerThread>> m_workers;
 };

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -130,10 +130,10 @@ private:
 	int m_generation_interval;
 };
 
-class MeshUpdateThread
+class MeshUpdateManager
 {
 public:
-	MeshUpdateThread(Client *client);
+	MeshUpdateManager(Client *client);
 
 	// Caches the block at p and its neighbors (if needed) and queues a mesh
 	// update for the block at p

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -491,7 +491,7 @@ u32 TextureSource::getTextureId(const std::string &name)
 	infostream<<"getTextureId(): Queued: name=\""<<name<<"\""<<std::endl;
 
 	// We're gonna ask the result to be put into here
-	static ResultQueue<std::string, u32, u8, u8> result_queue;
+	static thread_local ResultQueue<std::string, u32, u8, u8> result_queue;
 
 	// Throw a request in
 	m_get_texture_queue.add(name, 0, 0, &result_queue);
@@ -500,7 +500,7 @@ u32 TextureSource::getTextureId(const std::string &name)
 		while(true) {
 			// Wait result for a second
 			GetResult<std::string, u32, u8, u8>
-				result = result_queue.pop_front(1000);
+				result = result_queue.pop_front(4000);
 
 			if (result.key == name) {
 				return result.item;

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -498,7 +498,7 @@ u32 TextureSource::getTextureId(const std::string &name)
 
 	try {
 		while(true) {
-			// Wait result for a second
+			// Wait for result for up to 4 seconds (empirical value)
 			GetResult<std::string, u32, u8, u8>
 				result = result_queue.pop_front(4000);
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -44,6 +44,7 @@ void set_default_settings()
 	settings->setDefault("mute_sound", "false");
 	settings->setDefault("enable_mesh_cache", "false");
 	settings->setDefault("mesh_generation_interval", "0");
+	settings->setDefault("mesh_generation_threads", "0");
 	settings->setDefault("meshgen_block_cache_size", "20");
 	settings->setDefault("enable_vbo", "true");
 	settings->setDefault("free_move", "false");

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -673,7 +673,7 @@ void Client::handleCommand_AnnounceMedia(NetworkPacket* pkt)
 
 	// Mesh update thread must be stopped while
 	// updating content definitions
-	sanity_check(!m_mesh_update_thread.isRunning());
+	sanity_check(!m_mesh_update_manager.isRunning());
 
 	for (u16 i = 0; i < num_files; i++) {
 		std::string name, sha1_base64;
@@ -733,7 +733,7 @@ void Client::handleCommand_Media(NetworkPacket* pkt)
 	if (init_phase) {
 		// Mesh update thread must be stopped while
 		// updating content definitions
-		sanity_check(!m_mesh_update_thread.isRunning());
+		sanity_check(!m_mesh_update_manager.isRunning());
 	}
 
 	for (u32 i = 0; i < num_files; i++) {
@@ -770,7 +770,7 @@ void Client::handleCommand_NodeDef(NetworkPacket* pkt)
 
 	// Mesh update thread must be stopped while
 	// updating content definitions
-	sanity_check(!m_mesh_update_thread.isRunning());
+	sanity_check(!m_mesh_update_manager.isRunning());
 
 	// Decompress node definitions
 	std::istringstream tmp_is(pkt->readLongString(), std::ios::binary);
@@ -789,7 +789,7 @@ void Client::handleCommand_ItemDef(NetworkPacket* pkt)
 
 	// Mesh update thread must be stopped while
 	// updating content definitions
-	sanity_check(!m_mesh_update_thread.isRunning());
+	sanity_check(!m_mesh_update_manager.isRunning());
 
 	// Decompress item definitions
 	std::istringstream tmp_is(pkt->readLongString(), std::ios::binary);

--- a/src/util/container.h
+++ b/src/util/container.h
@@ -133,6 +133,20 @@ public:
 		return m_queue.empty();
 	}
 
+	void push_front(const T &t)
+	{
+		MutexAutoLock lock(m_mutex);
+		m_queue.push_front(t);
+		m_signal.post();
+	}
+
+	void push_front(T &&t)
+	{
+		MutexAutoLock lock(m_mutex);
+		m_queue.push_front(std::move(t));
+		m_signal.post();
+	}
+
 	void push_back(const T &t)
 	{
 		MutexAutoLock lock(m_mutex);

--- a/src/util/container.h
+++ b/src/util/container.h
@@ -227,6 +227,11 @@ public:
 		return t;
 	}
 
+	std::size_t size()
+	{
+		return m_queue.size();
+	}
+
 protected:
 	std::mutex &getMutex() { return m_mutex; }
 

--- a/src/util/container.h
+++ b/src/util/container.h
@@ -133,20 +133,6 @@ public:
 		return m_queue.empty();
 	}
 
-	void push_front(const T &t)
-	{
-		MutexAutoLock lock(m_mutex);
-		m_queue.push_front(t);
-		m_signal.post();
-	}
-
-	void push_front(T &&t)
-	{
-		MutexAutoLock lock(m_mutex);
-		m_queue.push_front(std::move(t));
-		m_signal.post();
-	}
-
 	void push_back(const T &t)
 	{
 		MutexAutoLock lock(m_mutex);
@@ -239,11 +225,6 @@ public:
 		T t = std::move(m_queue.back());
 		m_queue.pop_back();
 		return t;
-	}
-
-	std::size_t size()
-	{
-		return m_queue.size();
 	}
 
 protected:


### PR DESCRIPTION
This is a proposal to make more use of available hardware to speed up mesh generation, as it quickly becomes a bottleneck at larger render distances (>250).

## To do

This PR is Ready for Review.

## How to test

1. Set mesh_generation_threads to 1
2. Start any game and mapblocks must appear on the screen with the same speed as in older versions
3. In the profiler, `Client: Mesh making (sum)` must be less than 3000

4. Set mesh_generation_threads to 2
5. Start any game, and mapblocks apear on the screen faster
6. The game must not crash
7. In the profiler, `Client: Mesh making (sum)` must be more than 3000.

On a 6+ cores machine:

8. Set mesh_generation_threads to 0
9. Start any game
10. In the profiler, `Client: Mesh making (sum)` must be more than 3000.
