### PR TITLE
Store `MapEditEvent` blocks in a vector

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -725,9 +725,7 @@ void *EmergeThread::run()
 		if (!modified_blocks.empty()) {
 			MapEditEvent event;
 			event.type = MEET_OTHER;
-			event.modified_blocks.reserve(modified_blocks.size());
-			for (const auto &modified_block : modified_blocks)
-				event.modified_blocks.push_back(modified_block.first);
+			event.setModifiedBlocks(modified_blocks);
 			MutexAutoLock envlock(m_server->m_env_mutex);
 			m_map->dispatchEvent(event);
 		}

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -725,9 +725,9 @@ void *EmergeThread::run()
 		if (!modified_blocks.empty()) {
 			MapEditEvent event;
 			event.type = MEET_OTHER;
-			for (const auto &pair : modified_blocks) {
-				event.modified_blocks.insert(pair.first);
-			}
+			event.modified_blocks.reserve(modified_blocks.size());
+			for (const auto &modified_block : modified_blocks)
+				event.modified_blocks.push_back(modified_block.first);
 			MutexAutoLock envlock(m_server->m_env_mutex);
 			m_map->dispatchEvent(event);
 		}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -263,9 +263,9 @@ bool Map::addNodeWithEvent(v3s16 p, MapNode n, bool remove_metadata)
 		addNodeAndUpdate(p, n, modified_blocks, remove_metadata);
 
 		// Copy modified_blocks to event
-		for (auto &modified_block : modified_blocks) {
-			event.modified_blocks.insert(modified_block.first);
-		}
+		event.modified_blocks.reserve(modified_blocks.size());
+		for (const auto &modified_block : modified_blocks)
+			event.modified_blocks.push_back(modified_block.first);
 	}
 	catch(InvalidPositionException &e){
 		succeeded = false;
@@ -288,9 +288,9 @@ bool Map::removeNodeWithEvent(v3s16 p)
 		removeNodeAndUpdate(p, modified_blocks);
 
 		// Copy modified_blocks to event
-		for (auto &modified_block : modified_blocks) {
-			event.modified_blocks.insert(modified_block.first);
-		}
+		event.modified_blocks.reserve(modified_blocks.size());
+		for (const auto &modified_block : modified_blocks)
+			event.modified_blocks.push_back(modified_block.first);
 	}
 	catch(InvalidPositionException &e){
 		succeeded = false;
@@ -1873,10 +1873,9 @@ MapBlock* ServerMap::loadBlock(v3s16 blockpos)
 			//Modified lighting, send event
 			MapEditEvent event;
 			event.type = MEET_OTHER;
-			std::map<v3s16, MapBlock *>::iterator it;
-			for (it = modified_blocks.begin();
-					it != modified_blocks.end(); ++it)
-				event.modified_blocks.insert(it->first);
+			event.modified_blocks.reserve(modified_blocks.size());
+			for (const auto &modified_block : modified_blocks)
+				event.modified_blocks.push_back(modified_block.first);
 			dispatchEvent(event);
 		}
 	}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -262,10 +262,7 @@ bool Map::addNodeWithEvent(v3s16 p, MapNode n, bool remove_metadata)
 		std::map<v3s16, MapBlock*> modified_blocks;
 		addNodeAndUpdate(p, n, modified_blocks, remove_metadata);
 
-		// Copy modified_blocks to event
-		event.modified_blocks.reserve(modified_blocks.size());
-		for (const auto &modified_block : modified_blocks)
-			event.modified_blocks.push_back(modified_block.first);
+		event.setModifiedBlocks(modified_blocks);
 	}
 	catch(InvalidPositionException &e){
 		succeeded = false;
@@ -287,10 +284,7 @@ bool Map::removeNodeWithEvent(v3s16 p)
 		std::map<v3s16, MapBlock*> modified_blocks;
 		removeNodeAndUpdate(p, modified_blocks);
 
-		// Copy modified_blocks to event
-		event.modified_blocks.reserve(modified_blocks.size());
-		for (const auto &modified_block : modified_blocks)
-			event.modified_blocks.push_back(modified_block.first);
+		event.setModifiedBlocks(modified_blocks);
 	}
 	catch(InvalidPositionException &e){
 		succeeded = false;
@@ -1873,9 +1867,7 @@ MapBlock* ServerMap::loadBlock(v3s16 blockpos)
 			//Modified lighting, send event
 			MapEditEvent event;
 			event.type = MEET_OTHER;
-			event.modified_blocks.reserve(modified_blocks.size());
-			for (const auto &modified_block : modified_blocks)
-				event.modified_blocks.push_back(modified_block.first);
+			event.setModifiedBlocks(modified_blocks);
 			dispatchEvent(event);
 		}
 	}

--- a/src/map.h
+++ b/src/map.h
@@ -82,13 +82,14 @@ struct MapEditEvent
 	// Sets the event's position and marks the block as modified.
 	void setPositionModified(v3s16 pos)
 	{
+		assert(modified_blocks.empty()); // only meant for initialization (once)
 		p = pos;
 		modified_blocks.push_back(getNodeBlockPos(pos));
 	}
 
 	void setModifiedBlocks(const std::map<v3s16, MapBlock *> blocks)
 	{
-		modified_blocks.clear();
+		assert(modified_blocks.empty()); // only meant for initialization (once)
 		modified_blocks.reserve(blocks.size());
 		for (const auto &block : blocks)
 			modified_blocks.push_back(block.first);

--- a/src/map.h
+++ b/src/map.h
@@ -86,6 +86,14 @@ struct MapEditEvent
 		modified_blocks.push_back(getNodeBlockPos(pos));
 	}
 
+	void setModifiedBlocks(const std::map<v3s16, MapBlock *> blocks)
+	{
+		modified_blocks.clear();
+		modified_blocks.reserve(blocks.size());
+		for (const auto &block : blocks)
+			modified_blocks.push_back(block.first);
+	}
+
 	VoxelArea getArea() const
 	{
 		switch(type){

--- a/src/map.h
+++ b/src/map.h
@@ -74,7 +74,7 @@ struct MapEditEvent
 	MapEditEventType type = MEET_OTHER;
 	v3s16 p;
 	MapNode n = CONTENT_AIR;
-	std::set<v3s16> modified_blocks;
+	std::vector<v3s16> modified_blocks; // Represents a set
 	bool is_private_change = false;
 
 	MapEditEvent() = default;
@@ -83,7 +83,7 @@ struct MapEditEvent
 	void setPositionModified(v3s16 pos)
 	{
 		p = pos;
-		modified_blocks.insert(getNodeBlockPos(pos));
+		modified_blocks.push_back(getNodeBlockPos(pos));
 	}
 
 	VoxelArea getArea() const

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -273,8 +273,9 @@ void Schematic::placeOnMap(ServerMap *map, v3s16 p, u32 flags,
 	//// Create & dispatch map modification events to observers
 	MapEditEvent event;
 	event.type = MEET_OTHER;
-	for (it = modified_blocks.begin(); it != modified_blocks.end(); ++it)
-		event.modified_blocks.insert(it->first);
+	event.modified_blocks.reserve(modified_blocks.size());
+	for (const auto &modified_block : modified_blocks)
+		event.modified_blocks.push_back(modified_block.first);
 
 	map->dispatchEvent(event);
 }

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -273,9 +273,7 @@ void Schematic::placeOnMap(ServerMap *map, v3s16 p, u32 flags,
 	//// Create & dispatch map modification events to observers
 	MapEditEvent event;
 	event.type = MEET_OTHER;
-	event.modified_blocks.reserve(modified_blocks.size());
-	for (const auto &modified_block : modified_blocks)
-		event.modified_blocks.push_back(modified_block.first);
+	event.setModifiedBlocks(modified_blocks);
 
 	map->dispatchEvent(event);
 }

--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -137,8 +137,9 @@ treegen::error spawn_ltree(ServerMap *map, v3s16 p0,
 	// Send a MEET_OTHER event
 	MapEditEvent event;
 	event.type = MEET_OTHER;
-	for (auto &modified_block : modified_blocks)
-		event.modified_blocks.insert(modified_block.first);
+	event.modified_blocks.reserve(modified_blocks.size());
+	for (const auto &modified_block : modified_blocks)
+		event.modified_blocks.push_back(modified_block.first);
 	map->dispatchEvent(event);
 	return SUCCESS;
 }

--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -137,9 +137,7 @@ treegen::error spawn_ltree(ServerMap *map, v3s16 p0,
 	// Send a MEET_OTHER event
 	MapEditEvent event;
 	event.type = MEET_OTHER;
-	event.modified_blocks.reserve(modified_blocks.size());
-	for (const auto &modified_block : modified_blocks)
-		event.modified_blocks.push_back(modified_block.first);
+	event.setModifiedBlocks(modified_blocks);
 	map->dispatchEvent(event);
 	return SUCCESS;
 }

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1131,8 +1131,9 @@ int ModApiEnvMod::l_fix_light(lua_State *L)
 	if (!modified_blocks.empty()) {
 		MapEditEvent event;
 		event.type = MEET_OTHER;
-		for (auto &modified_block : modified_blocks)
-			event.modified_blocks.insert(modified_block.first);
+		event.modified_blocks.reserve(modified_blocks.size());
+		for (const auto &modified_block : modified_blocks)
+			event.modified_blocks.push_back(modified_block.first);
 
 		map.dispatchEvent(event);
 	}
@@ -1238,7 +1239,7 @@ int ModApiEnvMod::l_delete_area(lua_State *L)
 		v3s16 bp(x, y, z);
 		if (map.deleteBlock(bp)) {
 			env->setStaticForActiveObjectsInBlock(bp, false);
-			event.modified_blocks.insert(bp);
+			event.modified_blocks.push_back(bp);
 		} else {
 			success = false;
 		}

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1131,9 +1131,7 @@ int ModApiEnvMod::l_fix_light(lua_State *L)
 	if (!modified_blocks.empty()) {
 		MapEditEvent event;
 		event.type = MEET_OTHER;
-		event.modified_blocks.reserve(modified_blocks.size());
-		for (const auto &modified_block : modified_blocks)
-			event.modified_blocks.push_back(modified_block.first);
+		event.setModifiedBlocks(modified_blocks);
 
 		map.dispatchEvent(event);
 	}

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -128,9 +128,7 @@ int LuaVoxelManip::l_write_to_map(lua_State *L)
 
 	MapEditEvent event;
 	event.type = MEET_OTHER;
-	event.modified_blocks.reserve(modified_blocks.size());
-	for (const auto &modified_block : modified_blocks)
-		event.modified_blocks.push_back(modified_block.first);
+	event.setModifiedBlocks(modified_blocks);
 	map->dispatchEvent(event);
 
 	return 0;

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -128,8 +128,9 @@ int LuaVoxelManip::l_write_to_map(lua_State *L)
 
 	MapEditEvent event;
 	event.type = MEET_OTHER;
-	for (const auto &it : modified_blocks)
-		event.modified_blocks.insert(it.first);
+	event.modified_blocks.reserve(modified_blocks.size());
+	for (const auto &modified_block : modified_blocks)
+		event.modified_blocks.push_back(modified_block.first);
 	map->dispatchEvent(event);
 
 	return 0;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -699,9 +699,7 @@ void Server::AsyncRunStep(bool initial_step)
 		if (!modified_blocks.empty()) {
 			MapEditEvent event;
 			event.type = MEET_OTHER;
-			event.modified_blocks.reserve(modified_blocks.size());
-			for (const auto &modified_block : modified_blocks)
-				event.modified_blocks.push_back(modified_block.first);
+			event.setModifiedBlocks(modified_blocks);
 			m_env->getMap().dispatchEvent(event);
 		}
 	}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -699,9 +699,9 @@ void Server::AsyncRunStep(bool initial_step)
 		if (!modified_blocks.empty()) {
 			MapEditEvent event;
 			event.type = MEET_OTHER;
-			for (const auto &pair : modified_blocks) {
-				event.modified_blocks.insert(pair.first);
-			}
+			event.modified_blocks.reserve(modified_blocks.size());
+			for (const auto &modified_block : modified_blocks)
+				event.modified_blocks.push_back(modified_block.first);
 			m_env->getMap().dispatchEvent(event);
 		}
 	}


### PR DESCRIPTION
As far as I can tell, every position inserted into `MapEditEvent::modified_blocks` is known to be unique. Since elements are also only retrieved through iteration, the set of positions might as well be represented by a vector. This brings down insertion time from O(log n) to O(1). In addition, I believe `std::set` allocates each node separately, whereas vector elements are all put in the same allocation.

## To do

This PR is Ready for Review.

## How to test

Test that changes from liquid flow, mapgen, etc. still show up on the client.
