### PR TITLE
Fully remove pageflip 3D mode

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -208,9 +208,8 @@ enable_particles (Digging particles) bool true
 #    -    topbottom: split screen top/bottom.
 #    -    sidebyside: split screen side by side.
 #    -    crossview: Cross-eyed 3d
-#    -    pageflip: quadbuffer based 3d.
 #    Note that the interlaced mode requires shaders to be enabled.
-3d_mode (3D mode) enum none none,anaglyph,interlaced,topbottom,sidebyside,crossview,pageflip
+3d_mode (3D mode) enum none none,anaglyph,interlaced,topbottom,sidebyside,crossview
 
 #    Strength of 3D mode parallax.
 3d_paralax_strength (3D mode parallax strength) float 0.025 -0.087 0.087

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1258,11 +1258,7 @@ void Game::run()
 void Game::shutdown()
 {
 	m_rendering_engine->finalize();
-#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 8
-	if (g_settings->get("3d_mode") == "pageflip") {
-		driver->setRenderTarget(irr::video::ERT_STEREO_BOTH_BUFFERS);
-	}
-#endif
+
 	auto formspec = m_game_ui->getFormspecGUI();
 	if (formspec)
 		formspec->quitMenu();

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -98,9 +98,6 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	bool vsync = g_settings->getBool("vsync");
 	u16 fsaa = g_settings->getU16("fsaa");
 
-	// stereo buffer required for pageflip stereo
-	bool stereo_buffer = g_settings->get("3d_mode") == "pageflip";
-
 	// Determine driver
 	video::E_DRIVER_TYPE driverType = video::EDT_OPENGL;
 	const std::string &driverstring = g_settings->get("video_driver");
@@ -128,7 +125,6 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	params.AntiAlias = fsaa;
 	params.Fullscreen = fullscreen;
 	params.Stencilbuffer = false;
-	params.Stereobuffer = stereo_buffer;
 	params.Vsync = vsync;
 	params.EventReceiver = receiver;
 	params.HighPrecisionFPU = true;


### PR DESCRIPTION
The pageflip 3D mode was broken in 5.5.0 alongside switching to IrrlichtMt based off of 1.9.0, which removed what pageflip relied on. This was seemingly forgotten about, and while most of the pageflip-related code was removed in ff6dcfea, pageflip still exists as an option in the 3d_mode setting which causes Minetest to crash on next startup (#12489).

## To do
This PR is a Ready for Review.

## How to test
See that pageflip is gone? Also, manually set `3d_mode = pageflip` in minetest.conf and try to start Minetest. Previously it would always crash with a `No doublebuffering available.` message before segfaulting, it should just ignore the setting with this PR.