### PR TITLE
Allow saturation to be controlled by the server.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -366,15 +366,6 @@ enable_shaders (Shaders) bool true
 #    enhanced, highlights and shadows are gradually compressed.
 tone_mapping (Filmic tone mapping) bool false
 
-#    Adjust the saturation (or vividness) of the scene
-#    Values
-#    < 1.0 decrease saturation
-#    > 1.0 increase saturation
-#    1.0 = unchanged saturation
-#    0.0 = black and white
-#    (Tone mapping needs to be enabled.)
-saturation (Saturation) float 1.0 0.0 5.0
-
 [**Waving Nodes]
 
 #    Set to true to enable waving leaves.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7465,6 +7465,9 @@ child will follow movement and rotation of that bone.
     * Resource intensive - use sparsely
 * `set_lighting(light_definition)`: sets lighting for the player
     * `light_definition` is a table with the following optional fields:
+      * `saturation` sets the saturation (vividness).
+          values > 1 increase the saturation
+          values in [0,1) decrease the saturation
       * `shadows` is a table that controls ambient shadows
         * `intensity` sets the intensity of the shadows from 0 (no shadows, default) to 1 (blackness)
 * `get_lighting()`: returns the current state of lighting for the player.

--- a/games/devtest/mods/util_commands/init.lua
+++ b/games/devtest/mods/util_commands/init.lua
@@ -223,3 +223,12 @@ core.register_chatcommand("set_shadow", {
         minetest.get_player_by_name(player_name):set_lighting({shadows = { intensity = shadow_intensity} })
     end
 })
+
+core.register_chatcommand("set_saturation", {
+    params = "<saturation>",
+    description = "Set the saturation for current player.",
+    func = function(player_name, param)
+        local saturation = tonumber(param)
+        minetest.get_player_by_name(player_name):set_lighting({saturation = saturation })
+    end
+})

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -436,7 +436,6 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	float m_bloom_strength;
 	CachedPixelShaderSetting<float> m_bloom_radius_pixel;
 	float m_bloom_radius;
-	float m_saturation;
 	CachedPixelShaderSetting<float> m_saturation_pixel;
 
 public:
@@ -452,8 +451,6 @@ public:
 			m_bloom_strength = RenderingEngine::BASE_BLOOM_STRENGTH * g_settings->getFloat("bloom_strength_factor", 0.1f, 10.0f);
 		if (name == "bloom_radius")
 			m_bloom_radius = g_settings->getFloat("bloom_radius", 0.1f, 8.0f);
-		if (name == "saturation")
-			m_saturation = g_settings->getFloat("saturation", 0.0f, 5.0f);
 	}
 
 	static void settingsCallback(const std::string &name, void *userdata)
@@ -503,7 +500,6 @@ public:
 		m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.01f, 1.0f);
 		m_bloom_strength = RenderingEngine::BASE_BLOOM_STRENGTH * g_settings->getFloat("bloom_strength_factor", 0.1f, 10.0f);
 		m_bloom_radius = g_settings->getFloat("bloom_radius", 0.1f, 8.0f);
-		m_saturation = g_settings->getFloat("saturation", 0.0f, 5.0f);
 	}
 
 	~GameGlobalShaderConstantSetter()
@@ -591,7 +587,8 @@ public:
 			m_bloom_radius_pixel.set(&m_bloom_radius, services);
 			m_bloom_strength_pixel.set(&m_bloom_strength, services);
 		}
-		m_saturation_pixel.set(&m_saturation, services);
+		float saturation = m_client->getEnv().getLocalPlayer()->getLighting().saturation;
+		m_saturation_pixel.set(&saturation, services);
 	}
 
 	void onSetMaterial(const video::SMaterial &material)

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -281,7 +281,6 @@ void set_default_settings()
 	settings->setDefault("bloom_strength_factor", "1.0");
 	settings->setDefault("bloom_intensity", "0.05");
 	settings->setDefault("bloom_radius", "1");
-	settings->setDefault("saturation", "1.0");
 
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -24,4 +24,5 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 struct Lighting
 {
     float shadow_intensity {0.0f};
+    float saturation {1.0f};
 };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1764,4 +1764,6 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 
 	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.shadow_intensity;
+	if (pkt->getRemainingBytes() >= 4)
+		*pkt >> lighting.saturation;
 }

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -830,6 +830,7 @@ enum ToClientCommand
 	TOCLIENT_SET_LIGHTING = 0x63,
 	/*
 		f32 shadow_intensity
+		f32 saturation
 	*/
 
 	TOCLIENT_NUM_MSG_TYPES = 0x64,

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2294,8 +2294,9 @@ int ObjectRef::l_set_lighting(lua_State *L)
 	Lighting lighting = player->getLighting();
 	lua_getfield(L, 2, "shadows");
 	if (lua_istable(L, -1)) {
-		lighting.shadow_intensity = getfloatfield_default(L, -1, "intensity",    lighting.shadow_intensity);
+		lighting.shadow_intensity = getfloatfield_default(L, -1, "intensity", lighting.shadow_intensity);
 	}
+	lighting.saturation = getfloatfield_default(L, 2, "saturation", lighting.saturation);
 	lua_pop(L, -1);
 
 	getServer(L)->setLighting(player, lighting);
@@ -2318,6 +2319,8 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_pushnumber(L, lighting.shadow_intensity);
 	lua_setfield(L, -2, "intensity");
 	lua_setfield(L, -2, "shadows");
+	lua_pushnumber(L, lighting.saturation);
+	lua_setfield(L, -2, "saturation");
 	return 1;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1864,6 +1864,7 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 			4, peer_id);
 
 	pkt << lighting.shadow_intensity;
+	pkt << lighting.saturation;
 
 	Send(&pkt);
 }


### PR DESCRIPTION
This allows the saturation to be controlled by the server.

API:  `player:set_lighting( {saturation = float} )`

To test, go to devtest and set the saturation with `set_saturation xxx`