### PR TITLE
Lua API: Document shader dependencies of set_lighting()

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7468,8 +7468,10 @@ child will follow movement and rotation of that bone.
       * `saturation` sets the saturation (vividness).
           values > 1 increase the saturation
           values in [0,1) decrease the saturation
+            * This value has no effect on clients who have the "Tone Mapping" shader disabled.
       * `shadows` is a table that controls ambient shadows
         * `intensity` sets the intensity of the shadows from 0 (no shadows, default) to 1 (blackness)
+            * This value has no effect on clients who have the "Dynamic Shadows" shader disabled.
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.
 * `respawn()`: Respawns the player using the same mechanism as the death screen,

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2294,10 +2294,10 @@ int ObjectRef::l_set_lighting(lua_State *L)
 	Lighting lighting = player->getLighting();
 	lua_getfield(L, 2, "shadows");
 	if (lua_istable(L, -1)) {
-		lighting.shadow_intensity = getfloatfield_default(L, -1, "intensity", lighting.shadow_intensity);
+		getfloatfield(L, -1, "intensity", lighting.shadow_intensity);
 	}
-	lighting.saturation = getfloatfield_default(L, 2, "saturation", lighting.saturation);
-	lua_pop(L, -1);
+	lua_pop(L, 1); // shadows
+	getfloatfield(L, -1, "saturation", lighting.saturation);
 
 	getServer(L)->setLighting(player, lighting);
 	return 0;


### PR DESCRIPTION
These values have no effect when the shaders are disabled. I believe this is important to mention for game developers so that they're aware of the caveats.

+ clean value pop on Lua C side (trivial)

## To do

This PR is Ready for Review.

## How to test

1. Read
2. Confirm that `/set_saturation 0.2` depends on Tone Mapping (and that it works with it enabled)
3. Same for `/set_shadow 0.9`