### PR TITLE
Remove old rollback migration code

### DIFF
--- a/src/rollback.h
+++ b/src/rollback.h
@@ -73,7 +73,6 @@ private:
 			int range, int limit);
 	const std::list<RollbackAction> getActionsSince(time_t firstTime,
 			const std::string & actor = "");
-	void migrate(const std::string & filepath);
 	static float getSuspectNearness(bool is_guess, v3s16 suspect_p,
 		time_t suspect_t, v3s16 action_p, time_t action_t);
 


### PR DESCRIPTION
This PR removes migration code for the old plaintext rollback code. It has existed since November 2013 (0.4.9), and any servers with rollback running any newer version get automatically migrated to the new SQLite database format so it should be safe to remove at this point.

## To do
This PR is a Ready for Review.

## How to test
Test that it still compiles and doesn't crash I guess.