### PR TITLE
Avoid movement jitter while attached

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -393,8 +393,8 @@ void Client::connect(Address address, bool is_local_server)
 void Client::step(float dtime)
 {
 	// Limit a bit
-	if (dtime > 2.0)
-		dtime = 2.0;
+	if (dtime > DTIME_LIMIT)
+		dtime = DTIME_LIMIT;
 
 	m_animation_time += dtime;
 	if(m_animation_time > 60.0)

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -241,13 +241,13 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	/*
 		Calculate new velocity
 	*/
-	if (dtime > 0.5f) {
+	if (dtime > DTIME_LIMIT) {
 		if (!time_notification_done) {
 			time_notification_done = true;
-			infostream << "collisionMoveSimple: maximum step interval exceeded,"
+			warningstream << "collisionMoveSimple: maximum step interval exceeded,"
 					" lost movement details!"<<std::endl;
 		}
-		dtime = 0.5f;
+		dtime = DTIME_LIMIT;
 	} else {
 		time_notification_done = false;
 	}

--- a/src/constants.h
+++ b/src/constants.h
@@ -57,6 +57,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define BLOCK_SEND_DISABLE_LIMITS_MAX_D 1
 
 /*
+    Client/Server
+*/
+
+// Limit maximum dtime in client/server step(...) and for collision detection
+#define DTIME_LIMIT 2.5f
+
+/*
     Map-related things
 */
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -577,8 +577,8 @@ void Server::stop()
 void Server::step(float dtime)
 {
 	// Limit a bit
-	if (dtime > 2.0)
-		dtime = 2.0;
+	if (dtime > DTIME_LIMIT)
+		dtime = DTIME_LIMIT;
 	{
 		MutexAutoLock lock(m_step_dtime_mutex);
 		m_step_dtime += dtime;


### PR DESCRIPTION
This does two things:
1. Remove sources of discontinuous movement on server and client. (Remove time limit in client, server, and collision code). This allows the client and server to agree on the position of objects and attached players even when there is lag. _Assuming < 0.5s server lag is ridiculous!_
~~2. Orders objects, so attachments are handled (likely) in order of creations, which make it less likely that attached nodes are jittering.~~ In #12439 

Fixes #13083

Note that even with all the limits removed in (1) I have not observed anything unduly, as all collision detection and prediction is time based anyway.

**Testing**

Apply. Then play some game with high server lag (Mineclone2 or 5) with a high viewing range. Attach to objects. Observe how there is much less jitter (as the client position and collision prediction matches that of the server)
