### PR TITLE
add aux2 support for desktop

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2143,6 +2143,9 @@ keymap_inventory (Inventory key) key KEY_KEY_I
 #    Key for moving fast in fast mode.
 keymap_aux1 (Aux1 key) key KEY_KEY_E
 
+#    Key for additional auxiliary controls for games.
+keymap_aux2 (Aux2 key) key
+
 #    Key for opening the chat window.
 keymap_chat (Chat key) key KEY_KEY_T
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7223,7 +7223,7 @@ child will follow movement and rotation of that bone.
 * `get_player_control()`: returns table with player pressed keys
     * The table consists of fields with the following boolean values
       representing the pressed keys: `up`, `down`, `left`, `right`, `jump`,
-      `aux1`, `sneak`, `dig`, `place`, `LMB`, `RMB`, and `zoom`.
+      `aux1`, `aux2`, `sneak`, `dig`, `place`, `LMB`, `RMB`, and `zoom`.
     * The fields `LMB` and `RMB` are equal to `dig` and `place` respectively,
       and exist only to preserve backwards compatibility.
     * Returns an empty table `{}` if the object is not a player.
@@ -7240,6 +7240,7 @@ child will follow movement and rotation of that bone.
         * 7 - dig
         * 8 - place
         * 9 - zoom
+        * 10 - aux2
     * Returns `0` (no bits set) if the object is not a player.
 * `set_physics_override(override_table)`
     * `override_table` is a table with the following fields:

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2613,6 +2613,7 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 		isKeyDown(KeyType::RIGHT),
 		isKeyDown(KeyType::JUMP) || player->getAutojump(),
 		isKeyDown(KeyType::AUX1),
+		isKeyDown(KeyType::AUX2),
 		isKeyDown(KeyType::SNEAK),
 		isKeyDown(KeyType::ZOOM),
 		isKeyDown(KeyType::DIG),

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -36,6 +36,7 @@ void KeyCache::populate()
 	key[KeyType::RIGHT] = getKeySetting("keymap_right");
 	key[KeyType::JUMP] = getKeySetting("keymap_jump");
 	key[KeyType::AUX1] = getKeySetting("keymap_aux1");
+	key[KeyType::AUX2] = getKeySetting("keymap_aux2");
 	key[KeyType::SNEAK] = getKeySetting("keymap_sneak");
 	key[KeyType::DIG] = getKeySetting("keymap_dig");
 	key[KeyType::PLACE] = getKeySetting("keymap_place");
@@ -218,6 +219,7 @@ void RandomInputHandler::step(float dtime)
 	static RandomInputHandlerSimData rnd_data[] = {
 		{ "keymap_jump", 0.0f, 40 },
 		{ "keymap_aux1", 0.0f, 40 },
+		{ "keymap_aux2", 0.0f, 40 },
 		{ "keymap_forward", 0.0f, 40 },
 		{ "keymap_left", 0.0f, 40 },
 		{ "keymap_dig", 0.0f, 30 },

--- a/src/client/keys.h
+++ b/src/client/keys.h
@@ -33,6 +33,7 @@ public:
 		RIGHT,
 		JUMP,
 		AUX1,
+		AUX2,
 		SNEAK,
 		AUTOFORWARD,
 		DIG,

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -83,6 +83,7 @@ void set_default_settings()
 	settings->setDefault("keymap_zoom", "KEY_KEY_Z");
 	settings->setDefault("keymap_inventory", "KEY_KEY_I");
 	settings->setDefault("keymap_aux1", "KEY_KEY_E");
+	settings->setDefault("keymap_aux2", "");
 	settings->setDefault("keymap_chat", "KEY_KEY_T");
 	settings->setDefault("keymap_cmd", "/");
 	settings->setDefault("keymap_cmd_local", ".");

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -47,6 +47,7 @@ enum
 	GUI_ID_KEY_LEFT_BUTTON,
 	GUI_ID_KEY_RIGHT_BUTTON,
 	GUI_ID_KEY_AUX1_BUTTON,
+	GUI_ID_KEY_AUX2_BUTTON,
 	GUI_ID_KEY_FLY_BUTTON,
 	GUI_ID_KEY_FAST_BUTTON,
 	GUI_ID_KEY_JUMP_BUTTON,
@@ -406,6 +407,7 @@ void GUIKeyChangeMenu::init_keys()
 	this->add_key(GUI_ID_KEY_LEFT_BUTTON,         wgettext("Left"),             "keymap_left");
 	this->add_key(GUI_ID_KEY_RIGHT_BUTTON,        wgettext("Right"),            "keymap_right");
 	this->add_key(GUI_ID_KEY_AUX1_BUTTON,         wgettext("Aux1"),             "keymap_aux1");
+	this->add_key(GUI_ID_KEY_AUX2_BUTTON,         wgettext("Aux2"),             "keymap_aux2");
 	this->add_key(GUI_ID_KEY_JUMP_BUTTON,         wgettext("Jump"),             "keymap_jump");
 	this->add_key(GUI_ID_KEY_SNEAK_BUTTON,        wgettext("Sneak"),            "keymap_sneak");
 	this->add_key(GUI_ID_KEY_DROP_BUTTON,         wgettext("Drop"),             "keymap_drop");

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -170,7 +170,8 @@ u32 PlayerControl::getKeysPressed() const
 		( (u32)(sneak & 1) << 6) |
 		( (u32)(dig   & 1) << 7) |
 		( (u32)(place & 1) << 8) |
-		( (u32)(zoom  & 1) << 9)
+		( (u32)(zoom  & 1) << 9) |
+		( (u32)(aux2  & 1) << 10)
 	;
 
 	// If any direction keys are pressed pass those through
@@ -216,6 +217,7 @@ void PlayerControl::unpackKeysPressed(u32 keypress_bits)
 	dig   = keypress_bits & (1 << 7);
 	place = keypress_bits & (1 << 8);
 	zoom  = keypress_bits & (1 << 9);
+	aux2 = keypress_bits & (1 << 10);
 }
 
 void PlayerSettings::readGlobalSettings()

--- a/src/player.h
+++ b/src/player.h
@@ -50,7 +50,7 @@ struct PlayerControl
 
 	PlayerControl(
 		bool a_up, bool a_down, bool a_left, bool a_right,
-		bool a_jump, bool a_aux1, bool a_sneak,
+		bool a_jump, bool a_aux1, bool a_aux2, bool a_sneak,
 		bool a_zoom,
 		bool a_dig, bool a_place,
 		float a_pitch, float a_yaw,
@@ -63,6 +63,7 @@ struct PlayerControl
 			((a_left&1) << 2) | ((a_right&1) << 3);
 		jump = a_jump;
 		aux1 = a_aux1;
+		aux2 = a_aux2;
 		sneak = a_sneak;
 		zoom = a_zoom;
 		dig = a_dig;
@@ -85,6 +86,7 @@ struct PlayerControl
 	u8 direction_keys = 0;
 	bool jump = false;
 	bool aux1 = false;
+	bool aux2 = false;
 	bool sneak = false;
 	bool zoom = false;
 	bool dig = false;

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -226,6 +226,7 @@ int LuaLocalPlayer::l_get_control(lua_State *L)
 	lua_createtable(L, 0, 12);
 	set("jump",  c.jump);
 	set("aux1",  c.aux1);
+	set("aux2", c.aux2);
 	set("sneak", c.sneak);
 	set("zoom",  c.zoom);
 	set("dig",   c.dig);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1370,6 +1370,8 @@ int ObjectRef::l_get_player_control(lua_State *L)
 	lua_setfield(L, -2, "jump");
 	lua_pushboolean(L, control.aux1);
 	lua_setfield(L, -2, "aux1");
+	lua_pushboolean(L, control.aux2);
+	lua_setfield(L, -2, "aux2");
 	lua_pushboolean(L, control.sneak);
 	lua_setfield(L, -2, "sneak");
 	lua_pushboolean(L, control.dig);
@@ -1408,7 +1410,8 @@ int ObjectRef::l_get_player_control_bits(lua_State *L)
 		( (u32)(c.sneak & 1) << 6) |
 		( (u32)(c.dig   & 1) << 7) |
 		( (u32)(c.place & 1) << 8) |
-		( (u32)(c.zoom  & 1) << 9)
+		( (u32)(c.zoom  & 1) << 9) |
+		( (u32)(c.aux2  & 1) << 10)
 	;
 
 	lua_pushinteger(L, keypress_bits);


### PR DESCRIPTION
Fixes #11446. Adding support for touchscreen and gamepad inputs are not implemented. not ideal. Either i get help on this, or someone else make a better/subsequent PR. I have a game controller I can test this with, but I can't or don't know how to make it work for minetest on linux yet. i'll try it on windows later.

**NOTE**: default key for AUX2 is unassigned. I don't know what key it should be.

Simple mod to test this: [aux2_test.tar.gz](https://github.com/minetest/minetest/files/10319846/aux2_test.tar.gz)

1. Install and activate mod on a world on a game, such as [void](https://content.minetest.net/packages/Linuxdirk/void/)
2. Open the keybindings dialog and bind your AUX2 to a key.
3. Press the key in-game. A message should appear telling you AUX2 is pressed. Releasing AUX2 will notify you too.

**Backwards compatibility**: i've made it so that AUX2 is set to control bit 10 on all bit packed player control data for backwards compatibility.