### PR TITLE
Clamp player wieldindex when processing hotbar item selection

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2113,7 +2113,6 @@ void Game::processItemSelection(u16 *new_playeritem)
 	/* Item selection using mouse wheel
 	 */
 	*new_playeritem = player->getWieldIndex();
-
 	s32 wheel = input->getMouseWheel();
 	u16 max_item = MYMIN(PLAYER_INVENTORY_SIZE - 1,
 		    player->hud_hotbar_itemcount - 1);
@@ -2140,6 +2139,9 @@ void Game::processItemSelection(u16 *new_playeritem)
 			break;
 		}
 	}
+
+	// Clamp selection again in case it wasn't changed but max_item was
+	*new_playeritem = MYMIN(*new_playeritem, max_item);
 }
 
 


### PR DESCRIPTION
Fixes #11921. Now player wieldindex is shifted to highest index after resizing.