### PR TITLE
Occlusion culling algorithm based on recursive descend

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -623,6 +623,9 @@ update_last_checked (Last update check) string
 #    Ex: 5.5.0 is 005005000
 update_last_known (Last known version update) int 0
 
+#    Type of occlusion_culler
+occlusion_culler (Occlusion Culler) enum old old,new
+
 [*Server]
 
 #    Name of the player.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -626,6 +626,10 @@ update_last_known (Last known version update) int 0
 #    Type of occlusion_culler
 occlusion_culler (Occlusion Culler) enum old old,new
 
+#    Use raytraced occlusion culling in the new culler.
+#	 This flag enables use of raytraced occlusion culling test
+enable_raytraced_culling (Enable Raytraced Culling) bool true
+
 [*Server]
 
 #    Name of the player.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -624,7 +624,9 @@ update_last_checked (Last update check) string
 update_last_known (Last known version update) int 0
 
 #    Type of occlusion_culler
-occlusion_culler (Occlusion Culler) enum old old,new
+#    "loops" is the legacy algorithm with nested loops and O(N^3) complexity
+#    "bfs" is the new algorithm based on breadth-first-search and side culling
+occlusion_culler (Occlusion Culler) enum bfs bfs,loops
 
 #    Use raytraced occlusion culling in the new culler.
 #	 This flag enables use of raytraced occlusion culling test

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -561,7 +561,7 @@ void Client::step(float dtime)
 				block->mesh = nullptr;
 
 				if (r.mesh) {
-					block->solid_sides = r.mesh->getSolidSides();
+					block->solid_sides = r.solid_sides;
 					minimap_mapblock = r.mesh->moveMinimapMapblock();
 					if (minimap_mapblock == NULL)
 						do_mapper_update = false;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -561,6 +561,7 @@ void Client::step(float dtime)
 				block->mesh = nullptr;
 
 				if (r.mesh) {
+					block->solid_sides = r.mesh->getSolidSides();
 					minimap_mapblock = r.mesh->moveMinimapMapblock();
 					if (minimap_mapblock == NULL)
 						do_mapper_update = false;

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -207,7 +207,6 @@ class MapBlockFlags
 public:
 	static constexpr u16 CHUNK_EDGE = 8;
 	static constexpr u16 CHUNK_MASK = CHUNK_EDGE - 1;
-	static constexpr u16 CHUNK_MASK_INV = ~CHUNK_MASK;
 	static constexpr std::size_t CHUNK_VOLUME = CHUNK_EDGE * CHUNK_EDGE * CHUNK_EDGE; // volume of a chunk
 
 	MapBlockFlags(v3s16 min_pos, v3s16 max_pos)

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -103,7 +103,7 @@ ClientMap::ClientMap(
 	m_cache_bilinear_filter   = g_settings->getBool("bilinear_filter");
 	m_cache_anistropic_filter = g_settings->getBool("anisotropic_filter");
 	m_cache_transparency_sorting_distance = g_settings->getU16("transparency_sorting_distance");
-	m_new_occlusion_culler = g_settings->get("occlusion_culler") == "new";
+	m_new_occlusion_culler = g_settings->get("occlusion_culler") == "bfs";
 	g_settings->registerChangedCallback("occlusion_culler", on_settings_changed, this);
 	m_enable_raytraced_culling = g_settings->getBool("enable_raytraced_culling");
 	g_settings->registerChangedCallback("enable_raytraced_culling", on_settings_changed, this);
@@ -112,7 +112,7 @@ ClientMap::ClientMap(
 void ClientMap::onSettingChanged(const std::string &name)
 {
 	if (name == "occlusion_culler")
-		m_new_occlusion_culler = g_settings->get("occlusion_culler") == "new";
+		m_new_occlusion_culler = g_settings->get("occlusion_culler") == "bfs";
 	if (name == "enable_raytraced_culling")
 		m_enable_raytraced_culling = g_settings->getBool("enable_raytraced_culling");
 }

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -30,9 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/basic_macros.h"
 #include "client/renderingengine.h"
 
-#include <algorithm>
 #include <queue>
-#include <bitset>
 
 // struct MeshBufListList
 void MeshBufListList::clear()

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -418,7 +418,7 @@ void ClientMap::updateDrawList()
 
 			// The rule for any far side to be visible:
 			// * Any of the adjacent near sides is transparent (different axes)
-			// * The opposite near side (same axis) transparent, and is the dominant axis of the look vector
+			// * The opposite near side (same axis) is transparent, if it is the dominant axis of the look vector
 
 			// dominant axis flag
 			u8 dominant_axis = (abs(look.X) > abs(look.Y) && abs(look.X) > abs(look.Z)) |

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -408,7 +408,7 @@ void ClientMap::updateDrawList()
 			// compress block transparent sides to ZYX mask of see-through axes
 			u8 near_transparency = ((transparent_sides & near_inner_sides) | ignore_inner_sides) & 0x3F;
 
-			near_transparency = (near_transparency | (near_transparency >> 1)) & 0x15;
+			near_transparency |= (near_transparency >> 1);
 			near_transparency = (near_transparency & 1) |
 					((near_transparency >> 1) & 2) |
 					((near_transparency >> 2) & 4);
@@ -422,7 +422,7 @@ void ClientMap::updateDrawList()
 
 			// dominant axis flag
 			u8 dominant_axis = (abs(look.X) > abs(look.Y) && abs(look.X) > abs(look.Z)) |
-						((abs(look.Y) > abs(look.Z) && abs(look.Y) > abs(look.Z)) << 1) |
+						((abs(look.Y) > abs(look.Z) && abs(look.Y) > abs(look.X)) << 1) |
 						((abs(look.Z) > abs(look.X) && abs(look.Z) > abs(look.Y)) << 2);
 
 			// Queue next blocks for processing:

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -61,7 +61,7 @@ void MeshBufListList::add(scene::IMeshBuffer *buf, v3s16 position, u8 layer)
 	list.emplace_back(l);
 }
 
-static void onSettingsChanged(const std::string &name, void *data)
+static void on_settings_changed(const std::string &name, void *data)
 {
 	static_cast<ClientMap*>(data)->onSettingChanged(name);
 }
@@ -104,9 +104,9 @@ ClientMap::ClientMap(
 	m_cache_anistropic_filter = g_settings->getBool("anisotropic_filter");
 	m_cache_transparency_sorting_distance = g_settings->getU16("transparency_sorting_distance");
 	m_new_occlusion_culler = g_settings->get("occlusion_culler") == "new";
-	g_settings->registerChangedCallback("occlusion_culler", onSettingsChanged, this);
+	g_settings->registerChangedCallback("occlusion_culler", on_settings_changed, this);
 	m_enable_raytraced_culling = g_settings->getBool("enable_raytraced_culling");
-	g_settings->registerChangedCallback("enable_raytraced_culling", onSettingsChanged, this);
+	g_settings->registerChangedCallback("enable_raytraced_culling", on_settings_changed, this);
 }
 
 void ClientMap::onSettingChanged(const std::string &name)
@@ -119,8 +119,8 @@ void ClientMap::onSettingChanged(const std::string &name)
 
 ClientMap::~ClientMap()
 {
-	g_settings->deregisterChangedCallback("occlusion_culler", onSettingsChanged, this);
-	g_settings->deregisterChangedCallback("enable_raytraced_culling", onSettingsChanged, this);
+	g_settings->deregisterChangedCallback("occlusion_culler", on_settings_changed, this);
+	g_settings->deregisterChangedCallback("enable_raytraced_culling", on_settings_changed, this);
 }
 
 void ClientMap::updateCamera(v3f pos, v3f dir, f32 fov, v3s16 offset)

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -346,7 +346,7 @@ void ClientMap::updateDrawList()
 			}
 			else {
 				mesh_sphere_center = intToFloat(block_pos_nodes, BS) + v3f((MAP_BLOCKSIZE * 0.5f - 0.5f) * BS);
-				mesh_sphere_radius = std::sqrt(3.) * MAP_BLOCKSIZE * BS / 2;
+				mesh_sphere_radius = 0.0f;
 			}
 
 			// First, perform a simple distance check.

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -297,8 +297,8 @@ void ClientMap::updateDrawList()
 
 		// Uncomment to debug occluded blocks in the wireframe mode
 		// TODO: Include this as a flag for an extended debugging setting
-		if (occlusion_culling_enabled && m_control.show_wireframe)
-			occlusion_culling_enabled = porting::getTimeS() & 1;
+		// if (occlusion_culling_enabled && m_control.show_wireframe)
+		// 	occlusion_culling_enabled = porting::getTimeS() & 1;
 
 		std::queue<v3s16> blocks_to_consider;
 		MapBlockFlags blocks_seen(p_blocks_min, p_blocks_max);

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -205,16 +205,14 @@ void ClientMap::getBlocksInViewRange(v3s16 cam_pos_nodes,
 class MapBlockFlags
 {
 public:
-	static constexpr u16 CHUNK_INNER_BITS  = 3; // number of bits to address inside a chunk
-	static constexpr u16 CHUNK_EDGE = 8; // 2 ^ CHUNK_SHIFT
-	static constexpr u16 CHUNK_MASK = 0x0007u; // CHUNK_EDGE-1
+	static constexpr u16 CHUNK_EDGE = 8;
+	static constexpr u16 CHUNK_MASK = CHUNK_EDGE - 1;
 	static constexpr u16 CHUNK_MASK_INV = ~CHUNK_MASK;
 	static constexpr std::size_t CHUNK_VOLUME = CHUNK_EDGE * CHUNK_EDGE * CHUNK_EDGE; // volume of a chunk
 
 	MapBlockFlags(v3s16 min_pos, v3s16 max_pos)
-			: min_pos(min_pos), volume(max_pos - min_pos)
+			: min_pos(min_pos), volume((max_pos - min_pos) / CHUNK_EDGE + 1)
 	{
-		volume = v3s16(volume.X >> CHUNK_INNER_BITS, volume.Y >> CHUNK_INNER_BITS, volume.Z >> CHUNK_INNER_BITS) + 1;
 		chunks.resize(volume.X * volume.Y * volume.Z);
 	}
 
@@ -238,8 +236,8 @@ public:
 
 	Chunk &getChunk(v3s16 pos)
 	{
-		v3s16 delta = pos - min_pos;
-		std::size_t address = (delta.X + delta.Y * volume.X + delta.Z * volume.X * volume.Y) >> CHUNK_INNER_BITS;
+		v3s16 delta = (pos - min_pos) / CHUNK_EDGE;
+		std::size_t address = delta.X + delta.Y * volume.X + delta.Z * volume.X * volume.Y;
 		Chunk *chunk = chunks[address].get();
 		if (!chunk) {
 			chunk = new Chunk();

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -396,7 +396,7 @@ void ClientMap::updateDrawList()
 			// Decide which sides to traverse next or to block away
 
 			// First, find the near sides that would occlude the far sides
-			// * A near side can itself by occluded a nearby block (the test above ^^)
+			// * A near side can itself be occluded by a nearby block (the test above ^^)
 			// * A near side can be visible but fully opaque by itself (e.g. ground at the 0 level)
 
 			// mesh solid sides are +Z-Z+Y-Y+X-X

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -371,9 +371,17 @@ void ClientMap::updateDrawList()
 					mesh_sphere_radius + frustum_cull_extra_radius))
 				continue;
 
+			// Calculate the vector from the camera block to the current block
+			// We use it to determine through which sides of the current block we can continue the search
+			v3s16 look = block_coord - camera_block;
+
+			// Occluded near sides will further occlude the far sides
+			u8 visible_outer_sides = flags & 0x07;
+
 			// Raytraced occlusion culling - send rays from the camera to the block's corners
 			if (occlusion_culling_enabled && m_enable_raytraced_culling &&
-					block && mesh && isBlockOccluded(block, cam_pos_nodes)) {
+					block && mesh &&
+					visible_outer_sides != 0x07 && isBlockOccluded(block, cam_pos_nodes)) {
 				blocks_occlusion_culled++;
 				continue;
 			}
@@ -386,13 +394,6 @@ void ClientMap::updateDrawList()
 			}
 
 			// Decide which sides to traverse next or to block away
-
-			// Calculate the vector from the camera block to the current block
-			// We use it to determine through which sides of the current block we can continue the search
-			v3s16 look = block_coord - camera_block;
-
-			// Occluded near sides will further occlude the far sides
-			u8 visible_outer_sides = flags & 0x07;
 
 			// First, find the near sides that would occlude the far sides
 			// * A near side can itself by occluded a nearby block (the test above ^^)

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -402,14 +402,16 @@ void ClientMap::updateDrawList()
 			
 			// This bitset is +Z-Z+Y-Y+X-X (See MapBlockMesh), and axis is XYZ.
 			// Get he block's transparent sides
-			u8 transparent_sides = (occlusion_culling_enabled && block && block_inner_sides != 0x3F) ? ~block->solid_sides : 0x3F;
+			u8 transparent_sides = (occlusion_culling_enabled && block) ? ~block->solid_sides : 0x3F;
+
+			// compress block transparent sides to ZYX mask of see-through axes
+			u8 near_transparency =  (block_inner_sides == 0x3F) ? near_inner_sides : (transparent_sides & near_inner_sides);
 
 			// when we are inside the camera block, do not block any sides
 			if (block_inner_sides == 0x3F)
 				block_inner_sides = 0;
 
-			// compress block transparent sides to ZYX mask of see-through axes
-			u8 near_transparency = ((transparent_sides & near_inner_sides) & ~block_inner_sides) & 0x3F;
+			near_transparency &= ~block_inner_sides & 0x3F;
 
 			near_transparency |= (near_transparency >> 1);
 			near_transparency = (near_transparency & 1) |

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -417,7 +417,9 @@ void ClientMap::updateDrawList()
 			// * Any of the adjacent near sides is transparent (different axes)
 			// * The opposite near side (same axis) is transparent, if it is the dominant axis of the look vector
 
-			v3s16 precise_look = block_pos_nodes + MAP_BLOCKSIZE / 2 - cam_pos_nodes;
+			// Calculate vector from camera to mapblock center. Because we only need relation between
+			// coordinates we scale by 2 to avoid precision loss.
+			v3s16 precise_look = 2 * (block_pos_nodes - cam_pos_nodes) + MAP_BLOCKSIZE - 1;
 
 			// dominant axis flag
 			u8 dominant_axis = (abs(precise_look.X) > abs(precise_look.Y) && abs(precise_look.X) > abs(precise_look.Z)) |

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -420,10 +420,12 @@ void ClientMap::updateDrawList()
 			// * Any of the adjacent near sides is transparent (different axes)
 			// * The opposite near side (same axis) is transparent, if it is the dominant axis of the look vector
 
+			v3s16 precise_look = block_pos_nodes + MAP_BLOCKSIZE / 2 - cam_pos_nodes;
+
 			// dominant axis flag
-			u8 dominant_axis = (abs(look.X) > abs(look.Y) && abs(look.X) > abs(look.Z)) |
-						((abs(look.Y) > abs(look.Z) && abs(look.Y) > abs(look.X)) << 1) |
-						((abs(look.Z) > abs(look.X) && abs(look.Z) > abs(look.Y)) << 2);
+			u8 dominant_axis = (abs(precise_look.X) > abs(precise_look.Y) && abs(precise_look.X) > abs(precise_look.Z)) |
+						((abs(precise_look.Y) > abs(precise_look.Z) && abs(precise_look.Y) > abs(precise_look.X)) << 1) |
+						((abs(precise_look.Z) > abs(precise_look.X) && abs(precise_look.Z) > abs(precise_look.Y)) << 2);
 
 			// Queue next blocks for processing:
 			// - Examine "far" sides of the current blocks, i.e. never move towards the camera

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -423,7 +423,6 @@ void ClientMap::updateDrawList()
 
 			u8 visible_sides = 0;
 
-			int descend_count = 0;
 			// Recursive descend in the look direction
 			for (s16 axis = 0; axis < 3; axis++) {
 				// flags are +Z-Z+Y-Y+X-X (See MapBlockMesh), and axis is XYZ.

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -76,7 +76,7 @@ public:
 			s32 id
 	);
 
-	virtual ~ClientMap() = default;
+	virtual ~ClientMap();
 
 	bool maySaveBlocks() override
 	{
@@ -116,6 +116,8 @@ public:
 	void getBlocksInViewRange(v3s16 cam_pos_nodes,
 		v3s16 *p_blocks_min, v3s16 *p_blocks_max, float range=-1.0f);
 	void updateDrawList();
+	// @brief Calculate statistics about the map and keep the blocks alive
+	void touchMapBlocks();
 	void updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length);
 	// Returns true if draw list needs updating before drawing the next frame.
 	bool needsUpdateDrawList() { return m_needs_update_drawlist; }
@@ -136,10 +138,13 @@ public:
 	f32 getWantedRange() const { return m_control.wanted_range; }
 	f32 getCameraFov() const { return m_camera_fov; }
 
+	void onSettingChanged(const std::string &name);
+
 private:
 
 	// update the vertex order in transparent mesh buffers
 	void updateTransparentMeshBuffers();
+
 
 	// Orders blocks by distance to the camera
 	class MapBlockComparer
@@ -205,4 +210,6 @@ private:
 	bool m_cache_bilinear_filter;
 	bool m_cache_anistropic_filter;
 	u16 m_cache_transparency_sorting_distance;
+
+	bool m_new_occlusion_culler;
 };

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -212,4 +212,5 @@ private:
 	u16 m_cache_transparency_sorting_distance;
 
 	bool m_new_occlusion_culler;
+	bool m_enable_raytraced_culling;
 };

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -696,6 +696,7 @@ struct GameRunData {
 
 	float damage_flash;
 	float update_draw_list_timer;
+	float touch_blocks_timer;
 
 	f32 fog_range;
 
@@ -4030,6 +4031,9 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		changed much
 	*/
 	runData.update_draw_list_timer += dtime;
+	runData.touch_blocks_timer += dtime;
+
+	bool draw_list_updated = false;
 
 	float update_draw_list_delta = 0.2f;
 
@@ -4041,6 +4045,12 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		runData.update_draw_list_timer = 0;
 		client->getEnv().getClientMap().updateDrawList();
 		runData.update_draw_list_last_cam_dir = camera_direction;
+		draw_list_updated = true;
+	}
+
+	if (runData.touch_blocks_timer > update_draw_list_delta && !draw_list_updated) {
+		client->getEnv().getClientMap().touchMapBlocks();
+		runData.touch_blocks_timer = 0;
 	}
 
 	if (RenderingEngine::get_shadow_renderer()) {

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1604,7 +1604,7 @@ u8 get_solid_sides(MeshMakeData *data)
 		for (u8 k = 0; k < 6; k++) {
 			const MapNode &top = data->m_vmanip.getNodeRefUnsafe(blockpos_nodes + positions[k]);
 			if (ndef->get(top).solidness != 2)
-				result &= ~(1 << i);
+				result &= ~(1 << k);
 		}
 	}
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1266,9 +1266,9 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 	}
 
 	m_solid_sides = 0;
-	s16 full_side = MAP_BLOCKSIZE * MAP_BLOCKSIZE;
+	constexpr s16 FULL_SIDE = MAP_BLOCKSIZE * MAP_BLOCKSIZE;
 	for (u8 i = 0; i < 6; i++)
-		if (solid_node_counts[i] == full_side)
+		if (solid_node_counts[i] == FULL_SIDE)
 			m_solid_sides |= (1 << i);
 
 	/*

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1242,6 +1242,35 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 		}
 	}
 
+	std::array<s16, 6> solid_node_counts = {0, 0, 0, 0, 0, 0};
+	const NodeDefManager *ndef = data->m_client->ndef();
+
+	v3s16 blockpos_nodes = data->m_blockpos * MAP_BLOCKSIZE;
+
+	for (s16 i = 0; i < MAP_BLOCKSIZE; i++)
+	for (s16 j = 0; j < MAP_BLOCKSIZE; j++) {
+		v3s16 positions[6] = {
+			v3s16(0, i, j),
+			v3s16(MAP_BLOCKSIZE - 1, i, j),
+			v3s16(i, 0, j),
+			v3s16(i, MAP_BLOCKSIZE - 1, j),
+			v3s16(i, j, 0),
+			v3s16(i, j, MAP_BLOCKSIZE - 1)
+		};
+
+		for (u8 k = 0; k < 6; k++) {
+			const MapNode &top = data->m_vmanip.getNodeRefUnsafe(blockpos_nodes + positions[k]);
+			if (ndef->get(top).solidness == 2)
+				solid_node_counts[k]++;
+		}
+	}
+
+	m_solid_sides = 0;
+	s16 full_side = MAP_BLOCKSIZE * MAP_BLOCKSIZE;
+	for (u8 i = 0; i < 6; i++)
+		if (solid_node_counts[i] == full_side)
+			m_solid_sides |= (1 << i);
+
 	/*
 		Add special graphics:
 		- torches

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1242,35 +1242,6 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 		}
 	}
 
-	std::array<s16, 6> solid_node_counts = {0, 0, 0, 0, 0, 0};
-	const NodeDefManager *ndef = data->m_client->ndef();
-
-	v3s16 blockpos_nodes = data->m_blockpos * MAP_BLOCKSIZE;
-
-	for (s16 i = 0; i < MAP_BLOCKSIZE; i++)
-	for (s16 j = 0; j < MAP_BLOCKSIZE; j++) {
-		v3s16 positions[6] = {
-			v3s16(0, i, j),
-			v3s16(MAP_BLOCKSIZE - 1, i, j),
-			v3s16(i, 0, j),
-			v3s16(i, MAP_BLOCKSIZE - 1, j),
-			v3s16(i, j, 0),
-			v3s16(i, j, MAP_BLOCKSIZE - 1)
-		};
-
-		for (u8 k = 0; k < 6; k++) {
-			const MapNode &top = data->m_vmanip.getNodeRefUnsafe(blockpos_nodes + positions[k]);
-			if (ndef->get(top).solidness == 2)
-				solid_node_counts[k]++;
-		}
-	}
-
-	m_solid_sides = 0;
-	constexpr s16 FULL_SIDE = MAP_BLOCKSIZE * MAP_BLOCKSIZE;
-	for (u8 i = 0; i < 6; i++)
-		if (solid_node_counts[i] == FULL_SIDE)
-			m_solid_sides |= (1 << i);
-
 	/*
 		Add special graphics:
 		- torches
@@ -1610,4 +1581,32 @@ video::SColor encode_light(u16 light, u8 emissive_light)
 	// Average light:
 	float b = (day + night) / 2;
 	return video::SColor(r, b, b, b);
+}
+
+u8 get_solid_sides(MeshMakeData *data)
+{
+	v3s16 blockpos_nodes = data->m_blockpos * MAP_BLOCKSIZE;
+	const NodeDefManager *ndef = data->m_client->ndef();
+
+	u8 result = 0x3F; // all sides solid;
+
+	for (s16 i = 0; i < MAP_BLOCKSIZE && result != 0; i++)
+	for (s16 j = 0; j < MAP_BLOCKSIZE && result != 0; j++) {
+		v3s16 positions[6] = {
+			v3s16(0, i, j),
+			v3s16(MAP_BLOCKSIZE - 1, i, j),
+			v3s16(i, 0, j),
+			v3s16(i, MAP_BLOCKSIZE - 1, j),
+			v3s16(i, j, 0),
+			v3s16(i, j, MAP_BLOCKSIZE - 1)
+		};
+
+		for (u8 k = 0; k < 6; k++) {
+			const MapNode &top = data->m_vmanip.getNodeRefUnsafe(blockpos_nodes + positions[k]);
+			if (ndef->get(top).solidness != 2)
+				result &= ~(1 << i);
+		}
+	}
+
+	return result;
 }

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -237,8 +237,6 @@ public:
 		return this->m_transparent_buffers;
 	}
 
-	u8 getSolidSides() const { return m_solid_sides; }
-
 private:
 	struct AnimationInfo {
 		int frame; // last animation frame
@@ -287,12 +285,6 @@ private:
 	MapBlockBspTree m_bsp_tree;
 	// Ordered list of references to parts of transparent buffers to draw
 	std::vector<PartialMeshBuffer> m_transparent_buffers;
-
-	// @brief
-	// Bit set of the sides of the mapblock that consist of solid nodes only
-	// Bits:
-	// 0 0 -Z +Z -X +X -Y +Y
-	u8 m_solid_sides;
 };
 
 /*!
@@ -348,3 +340,8 @@ void final_color_blend(video::SColor *result,
 // TileFrame vector copy cost very much to client
 void getNodeTileN(MapNode mn, const v3s16 &p, u8 tileindex, MeshMakeData *data, TileSpec &tile);
 void getNodeTile(MapNode mn, const v3s16 &p, const v3s16 &dir, MeshMakeData *data, TileSpec &tile);
+
+/// Return bitset of the sides of the mapblock that consist of solid nodes only
+/// Bits:
+/// 0 0 -Z +Z -X +X -Y +Y
+u8 get_solid_sides(MeshMakeData *data);

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -237,6 +237,8 @@ public:
 		return this->m_transparent_buffers;
 	}
 
+	u8 getSolidSides() const { return m_solid_sides; }
+
 private:
 	struct AnimationInfo {
 		int frame; // last animation frame
@@ -285,6 +287,12 @@ private:
 	MapBlockBspTree m_bsp_tree;
 	// Ordered list of references to parts of transparent buffers to draw
 	std::vector<PartialMeshBuffer> m_transparent_buffers;
+
+	// @brief
+	// Bit set of the sides of the mapblock that consist of solid nodes only
+	// Bits:
+	// 0 0 -Z +Z -X +X -Y +Y
+	u8 m_solid_sides;
 };
 
 /*!

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -299,6 +299,7 @@ void MeshUpdateWorkerThread::doUpdate()
 		MeshUpdateResult r;
 		r.p = q->p;
 		r.mesh = mesh_new;
+		r.solid_sides = get_solid_sides(q->data);
 		r.ack_block_to_server = q->ack_block_to_server;
 		r.urgent = q->urgent;
 

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -111,6 +111,7 @@ struct MeshUpdateResult
 {
 	v3s16 p = v3s16(-1338, -1338, -1338);
 	MapBlockMesh *mesh = nullptr;
+	u8 solid_sides = 0;
 	bool ack_block_to_server = false;
 	bool urgent = false;
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -66,6 +66,7 @@ void set_default_settings()
 	settings->setDefault("max_out_chat_queue_size", "20");
 	settings->setDefault("pause_on_lost_focus", "false");
 	settings->setDefault("enable_split_login_register", "true");
+	settings->setDefault("occlusion_culler", "old");
 	settings->setDefault("chat_weblink_color", "#8888FF");
 
 	// Keymap

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -67,6 +67,7 @@ void set_default_settings()
 	settings->setDefault("pause_on_lost_focus", "false");
 	settings->setDefault("enable_split_login_register", "true");
 	settings->setDefault("occlusion_culler", "old");
+	settings->setDefault("enable_raytraced_culling", "true");
 	settings->setDefault("chat_weblink_color", "#8888FF");
 
 	// Keymap

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -66,7 +66,7 @@ void set_default_settings()
 	settings->setDefault("max_out_chat_queue_size", "20");
 	settings->setDefault("pause_on_lost_focus", "false");
 	settings->setDefault("enable_split_login_register", "true");
-	settings->setDefault("occlusion_culler", "old");
+	settings->setDefault("occlusion_culler", "bfs");
 	settings->setDefault("enable_raytraced_culling", "true");
 	settings->setDefault("chat_weblink_color", "#8888FF");
 

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -469,6 +469,8 @@ public:
 	bool contents_cached = false;
 	// True if we never want to cache content types for this block
 	bool do_not_cache_contents = false;
+	// marks the sides which are opaque: 00+Z-Z+Y-Y+X-X
+	u8 solid_sides {0};
 
 private:
 	/*


### PR DESCRIPTION
This is inspired by portal-based occlusion culling technique (https://www.youtube.com/watch?v=8xgb-ZcZV9s).

Every mapblock side is treated as a portal, and the map is walked recursively through the portals. Simple logical rule appled - a 'far' side of a mapblock is visible if :
* If adjacent 'near' sides are see-through (block is not occluded, and adjacent block does not have a solid side)
* If opposite 'near' side is see-through, and it overlaps the 'far' side (so called dominant axis in the look vector)

A side is traversed if it's visible and not fully solid, otherwise it's marked as opaque for the next mapblock.

## To do

This PR is Ready for Review.

## How to test

0. Configure server parameters to send more blocks by default:
```
max_block_send_distance = 40
max_block_generate_distance = 40
block_send_optimize_distance = 40
client_unload_unused_data_timeout = 6000
client_mapblock_limit = -1
max_simultaneous_block_sends_per_client = 80
```
1. Enter MTG and set view distance to 400-600
2. Enable F6 profiler and F5 graphs
3. Flip between `/set occlusion_culler new` and `/set occlusion_culler old`
4. Mark the change in `updateDrawList` value, `MapBlocks drawn`, `Time non-rendering` and `jitter %`
5. The game must work more smoothly even with large number of mapblocks loaded.
