### PR TITLE
CI: Decrease compilation times with Ccache

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,6 +38,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
       - name: Install deps
         run: |
           source ./util/ci/common.sh
@@ -59,6 +63,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
       - name: Install deps
         run: |
           source ./util/ci/common.sh
@@ -83,6 +91,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
       - name: Install deps
         run: |
           source ./util/ci/common.sh
@@ -105,6 +117,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
       - name: Install deps
         run: |
           source ./util/ci/common.sh
@@ -131,6 +147,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
       - name: Install deps
         run: |
           source ./util/ci/common.sh

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.job }}
+
     - name: Install deps
       run: |
         source ./util/ci/common.sh
@@ -44,6 +49,10 @@ jobs:
     steps:
 
     - uses: actions/checkout@v4
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.job }}
     - uses: leafo/gh-actions-lua@v10
       with:
         luaVersion: "5.1.5"
@@ -51,6 +60,7 @@ jobs:
 
     - name: Install LuaJIT
       run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         cd $HOME
         git clone https://github.com/LuaJIT/LuaJIT/
         cd LuaJIT

--- a/util/buildbot/buildwin32.sh
+++ b/util/buildbot/buildwin32.sh
@@ -62,6 +62,8 @@ cmake_args=(
 	-DENABLE_GETTEXT=1
 	-DENABLE_LEVELDB=1
 )
+# Use ccache if it is available
+command -v ccache >/dev/null && cmake_args+=(-DCMAKE_{C,CXX}_COMPILER_LAUNCHER=ccache)
 add_cmake_libs
 cmake -S $sourcedir -B build "${cmake_args[@]}"
 

--- a/util/buildbot/buildwin64.sh
+++ b/util/buildbot/buildwin64.sh
@@ -62,6 +62,8 @@ cmake_args=(
 	-DENABLE_GETTEXT=1
 	-DENABLE_LEVELDB=1
 )
+# Use ccache if it is available
+command -v ccache >/dev/null && cmake_args+=(-DCMAKE_{C,CXX}_COMPILER_LAUNCHER=ccache)
 add_cmake_libs
 cmake -S $sourcedir -B build "${cmake_args[@]}"
 

--- a/util/ci/build.sh
+++ b/util/ci/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash -e
 
+# Use ccache if it is available
+extra_args=()
+command -v ccache >/dev/null && extra_args+=(-DCMAKE_{C,CXX}_COMPILER_LAUNCHER=ccache)
+
 cmake -B build \
+	"${extra_args[@]}" \
 	-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Debug} \
 	-DENABLE_LTO=FALSE \
 	-DRUN_IN_PLACE=TRUE \

--- a/util/ci/build_prometheus_cpp.sh
+++ b/util/ci/build_prometheus_cpp.sh
@@ -1,10 +1,15 @@
 #! /bin/bash -eu
 
+# Use ccache if it is available
+extra_args=()
+command -v ccache >/dev/null && extra_args+=(-DCMAKE_{C,CXX}_COMPILER_LAUNCHER=ccache)
+
 cd /tmp
 git clone --recursive https://github.com/jupp0r/prometheus-cpp
 mkdir prometheus-cpp/build
 cd prometheus-cpp/build
 cmake .. \
+	"${extra_args[@]}" \
 	-DCMAKE_INSTALL_PREFIX=/usr/local \
 	-DCMAKE_BUILD_TYPE=Release \
 	-DENABLE_TESTING=0


### PR DESCRIPTION
I've excluded the docker build since it would probably require a modified Dockerfile, 
and Ccache did not work with macos and VS 2019 builds for some reason.

- Goal of the PR: Speed up the CI
- How does the PR work? It uses the github action cache together with Ccache to re-use previous compilations.
- Does it resolve any reported issue? Yes, it resolves #11667.
- Does this relate to a goal in [the roadmap](../doc/direction.md)? I don't think so.
- If not a bug fix, why is this PR needed? What usecases does it solve? The usecases are already mentioned in the Issue.


## How to test

* Fork this branch
* Enable github actions on the fork
* Wait until the action for the forked branch completes
* Do a change in, for example, the `build.yml` workflow file, create a commit and push to the forked branch
* Wait until the action for the forked branch completes
* Compare the times between the first and second github action runs
<!-- Example code or instructions -->
