### PR TITLE
Document mod storage psql settings in world_format.txt

### DIFF
--- a/doc/world_format.txt
+++ b/doc/world_format.txt
@@ -130,6 +130,7 @@ Example content (added indentation and - explanations):
   player_backend = sqlite3      - which DB backend to use for player data
   readonly_backend = sqlite3    - optionally readonly seed DB (DB file _must_ be located in "readonly" subfolder)
   auth_backend = files          - which DB backend to use for authentication data
+  mod_storage_backend = sqlite3 - which DB backend to use for mod storage
   server_announce = false       - whether the server is publicly announced or not
   load_mod_<mod> = false        - whether <mod> is to be loaded in this world
 
@@ -150,6 +151,7 @@ PostgreSQL backend specific settings:
   pgsql_player_connection = (same parameters as above)
   pgsql_readonly_connection = (same parameters as above)
   pgsql_auth_connection = (same parameters as above)
+  pgsql_mod_storage_connection = (same parameters as above)
 
 Redis backend specific settings:
   redis_address = 127.0.0.1  - Redis server address


### PR DESCRIPTION
Went looking for mod storage settings in the docs and noticed they were missing. Took a look in the code and found that mod storage PostgreSQL support was added in #12879 however the relevant settings were left undocumented.

This PR adds the two relevant settings to `doc/world.mt` so that others may find them and use them.