### PR TITLE
Fix crash on Android with IrrlichtMt9

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -548,14 +548,17 @@ void ClientLauncher::main_menu(MainMenuData *menudata)
 	}
 	infostream << "Waited for other menus" << std::endl;
 
-	// Cursor can be non-visible when coming from the game
 #ifndef ANDROID
+	// Cursor can be non-visible when coming from the game
 	m_rendering_engine->get_raw_device()->getCursorControl()->setVisible(true);
-#endif
+
 	// Set absolute mouse mode
 #if IRRLICHT_VERSION_MT_REVISION >= 9
 	m_rendering_engine->get_raw_device()->getCursorControl()->setRelativeMode(false);
 #endif
+
+#endif
+
 
 	/* show main menu */
 	GUIEngine mymenu(&input->joystick, guiroot, m_rendering_engine, &g_menumgr, menudata, *kill);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2544,7 +2544,6 @@ void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 	if ((device->isWindowActive() && device->isWindowFocused()
 			&& !isMenuActive()) || input->isRandom()) {
 
-
 #ifndef __ANDROID__
 		if (!input->isRandom()) {
 			// Mac OSX gets upset if this is set every frame

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2533,14 +2533,13 @@ void Game::checkZoomEnabled()
 
 void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 {
-#ifndef __ANDROID__
-#if IRRLICHT_VERSION_MT_REVISION >= 9
+#if !defined(__ANDROID__) && IRRLICHT_VERSION_MT_REVISION >= 9
 	if (isMenuActive())
 		device->getCursorControl()->setRelativeMode(false);
 	else
 		device->getCursorControl()->setRelativeMode(true);
 #endif
-#endif
+
 	if ((device->isWindowActive() && device->isWindowFocused()
 			&& !isMenuActive()) || input->isRandom()) {
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2533,6 +2533,7 @@ void Game::checkZoomEnabled()
 
 void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 {
+#ifndef __ANDROID__
 #if IRRLICHT_VERSION_MT_REVISION >= 9
 	if (isMenuActive())
 		device->getCursorControl()->setRelativeMode(false);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2542,6 +2542,7 @@ void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 #endif
 	if ((device->isWindowActive() && device->isWindowFocused()
 			&& !isMenuActive()) || input->isRandom()) {
+#endif
 
 #ifndef __ANDROID__
 		if (!input->isRandom()) {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2540,9 +2540,10 @@ void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 	else
 		device->getCursorControl()->setRelativeMode(true);
 #endif
+#endif
 	if ((device->isWindowActive() && device->isWindowFocused()
 			&& !isMenuActive()) || input->isRandom()) {
-#endif
+
 
 #ifndef __ANDROID__
 		if (!input->isRandom()) {


### PR DESCRIPTION
https://github.com/minetest/minetest/pull/12636 causes Android to crash with IrrlichtMt9, which was updated to in the Android dependencies 4 days ago

## To do
This PR is a Ready for Review.


## How to test
Test that you can start Minetest and launch a world on Android
