### PR TITLE
Revisit F6 statistics formatting

### DIFF
--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -92,7 +92,7 @@ void GameUI::init()
 	m_guitext_profiler = gui::StaticText::add(guienv, L"<Profiler>",
 		core::rect<s32>(0, 0, 0, 0), false, false, guiroot);
 	m_guitext_profiler->setOverrideFont(g_fontengine->getFont(
-		g_fontengine->getDefaultFontSize() * 0.85f, FM_Mono));
+		g_fontengine->getDefaultFontSize() * 0.9f, FM_Mono));
 	m_guitext_profiler->setVisible(false);
 }
 
@@ -276,7 +276,7 @@ void GameUI::updateProfiler()
 
 		core::dimension2d<u32> size = m_guitext_profiler->getOverrideFont()->
 				getDimension(str.c_str());
-		core::position2di upper_left(6, 50);
+		core::position2di upper_left(6, m_guitext->getTextHeight() * 2.5f);
 		core::position2di lower_right = upper_left;
 		lower_right.X += size.Width + 10;
 		lower_right.Y += size.Height;

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -92,7 +92,7 @@ void GameUI::init()
 	m_guitext_profiler = gui::StaticText::add(guienv, L"<Profiler>",
 		core::rect<s32>(0, 0, 0, 0), false, false, guiroot);
 	m_guitext_profiler->setOverrideFont(g_fontengine->getFont(
-		g_fontengine->getDefaultFontSize() * 0.9f, FM_Mono));
+		g_fontengine->getDefaultFontSize() * 0.85f, FM_Mono));
 	m_guitext_profiler->setVisible(false);
 }
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -273,7 +273,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	std::vector<NearbyCollisionInfo> cinfo;
 	{
 	//TimeTaker tt2("collisionMoveSimple collect boxes");
-	ScopeProfiler sp2(g_profiler, PROFILER_NAME("collisionMoveSimple(): collect boxes"), SPT_AVG);
+	ScopeProfiler sp2(g_profiler, PROFILER_NAME("collision collect boxes"), SPT_AVG);
 
 	v3f minpos_f(
 		MYMIN(pos_f->X, newpos_f.X),

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -137,7 +137,7 @@ int Profiler::print(std::ostream &o, u32 page, u32 pagecount)
 {
 	GraphValues values;
 	getPage(values, page, pagecount);
-	char num_buf[50];
+	char buffer[50];
 
 	for (const auto &i : values) {
 		o << "  " << i.first << " ";
@@ -146,16 +146,17 @@ int Profiler::print(std::ostream &o, u32 page, u32 pagecount)
 			continue;
 		}
 
-		s32 space = 44 - i.first.size();
-		for (s32 j = 0; j < space; j++) {
-			if ((j & 1) && j < space - 1)
-				o << ".";
-			else
-				o << " ";
+		{
+			// Padding
+			s32 space = std::max(0, 44 - (s32)i.first.size());
+			memset(buffer, '_', space);
+			buffer[space] = '\0';
+			o << buffer;
 		}
-		porting::mt_snprintf(num_buf, sizeof(num_buf), "% 4ix % 3g",
+
+		porting::mt_snprintf(buffer, sizeof(buffer), "% 5ix % 4.4g",
 				getAvgCount(i.first), i.second);
-		o << num_buf << std::endl;
+		o << buffer << std::endl;
 	}
 	return values.size();
 }


### PR DESCRIPTION
This maintenance commit corrects the alignment of the F6 debugger and limits the floating point prevision to not clutter the output. The floating point alignment is far from perfect but for a tool like this I believe that's still acceptable.

**Before:** (line overshoot caused by 55804c56)
![grafik](https://user-images.githubusercontent.com/1497498/211196903-c4ee2627-36ae-42a3-9081-c83266761661.png)


**After:**
![grafik](https://user-images.githubusercontent.com/1497498/211196825-7eee30a2-4300-4525-a015-7b61234713c5.png)


## To do

This PR is Ready for Review.

## How to test

1. Debug dump screen
