### PR TITLE
Improve `MetaDataRef:{get,set}_float` precision

### DIFF
--- a/games/devtest/mods/unittests/metadata.lua
+++ b/games/devtest/mods/unittests/metadata.lua
@@ -69,8 +69,6 @@ local function test_metadata(meta)
 	assert(meta:get_float("j") == -1 / 0)
 	meta:set_float("j", 0 / 0)
 	assert(core.is_nan(meta:get_float("j")))
-	meta:set_string("j", "-5j")
-	assert(meta:get_float("j") == -5.0)
 
 	meta:from_table()
 	assert(next(meta:to_table().fields) == nil)

--- a/games/devtest/mods/unittests/metadata.lua
+++ b/games/devtest/mods/unittests/metadata.lua
@@ -69,6 +69,8 @@ local function test_metadata(meta)
 	assert(meta:get_float("j") == -1 / 0)
 	meta:set_float("j", 0 / 0)
 	assert(core.is_nan(meta:get_float("j")))
+	meta:set_string("j", "-5j")
+	assert(meta:get_float("j") == -5.0)
 
 	meta:from_table()
 	assert(next(meta:to_table().fields) == nil)

--- a/games/devtest/mods/unittests/metadata.lua
+++ b/games/devtest/mods/unittests/metadata.lua
@@ -63,6 +63,13 @@ local function test_metadata(meta)
 	assert(meta:get_float("h") > 1)
 	assert(meta:get_string("i") == "${f}")
 
+	meta:set_float("j", 1.23456789)
+	assert(meta:get_float("j") == 1.23456789)
+	meta:set_float("j", -1 / 0)
+	assert(meta:get_float("j") == -1 / 0)
+	meta:set_float("j", 0 / 0)
+	assert(meta:get_float("j") ~= 0)
+
 	meta:from_table()
 	assert(next(meta:to_table().fields) == nil)
 	assert(#meta:get_keys() == 0)

--- a/games/devtest/mods/unittests/metadata.lua
+++ b/games/devtest/mods/unittests/metadata.lua
@@ -68,7 +68,7 @@ local function test_metadata(meta)
 	meta:set_float("j", -1 / 0)
 	assert(meta:get_float("j") == -1 / 0)
 	meta:set_float("j", 0 / 0)
-	assert(meta:get_float("j") ~= 0)
+	assert(core.is_nan(meta:get_float("j")))
 
 	meta:from_table()
 	assert(next(meta:to_table().fields) == nil)

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -177,7 +177,9 @@ int MetaDataRef::l_get_float(lua_State *L)
 
 	std::string str_;
 	const std::string &str = meta->getString(name, &str_);
-	lua_pushnumber(L, atof(str.c_str()));
+	// Convert with Lua, as is done in set_float.
+	lua_pushlstring(L, str.data(), str.size());
+	lua_pushnumber(L, lua_tonumber(L, -1));
 	return 1;
 }
 

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -189,6 +189,7 @@ int MetaDataRef::l_set_float(lua_State *L)
 	MetaDataRef *ref = checkAnyMetadata(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	luaL_checknumber(L, 3);
+	// Convert number to string with Lua as it gives good precision.
 	std::string str = readParam<std::string>(L, 3);
 
 	IMetadata *meta = ref->getmeta(true);

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -177,7 +177,7 @@ int MetaDataRef::l_get_float(lua_State *L)
 
 	std::string str_;
 	const std::string &str = meta->getString(name, &str_);
-	lua_pushnumber(L, stof(str));
+	lua_pushnumber(L, atof(str.c_str()));
 	return 1;
 }
 
@@ -188,8 +188,8 @@ int MetaDataRef::l_set_float(lua_State *L)
 
 	MetaDataRef *ref = checkAnyMetadata(L, 1);
 	std::string name = luaL_checkstring(L, 2);
-	float a = readParam<float>(L, 3);
-	std::string str = ftos(a);
+	luaL_checknumber(L, 3);
+	std::string str = readParam<std::string>(L, 3);
 
 	IMetadata *meta = ref->getmeta(true);
 	if (meta != NULL && meta->setString(name, str))


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/13129. Lua's built-in number to string conversion is used. This may cause an extra Lua allocation per call to `set_float`.

## To do

This PR is Ready for Review.

## How to test

Run the unit tests.
