### PR TITLE
Always set globals in `__newindex` in strict.lua

### DIFF
--- a/builtin/common/strict.lua
+++ b/builtin/common/strict.lua
@@ -14,6 +14,7 @@ local declared = {}
 local warned = {}
 
 function meta:__newindex(name, value)
+	rawset(self, name, value)
 	if declared[name] then
 		return
 	end
@@ -25,7 +26,6 @@ function meta:__newindex(name, value)
 				:format(name, desc))
 		warned[warn_key] = true
 	end
-	rawset(self, name, value)
 	declared[name] = true
 end
 


### PR DESCRIPTION
`rawset` should always be called inside `__newindex`. Otherwise some assignments to globals will be missed.

## To do

This PR is Ready for Review.

## How to test

Run this code in a mod:

```lua
local function f()
	_G._global = nil
	_G._global = 123
	return _G._global
end
core.debug(f())
f()
```

You should get a warning and "123" should be printed.