### PR TITLE
Error when `string.split` is given empty separator

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -170,6 +170,9 @@ end
 --------------------------------------------------------------------------------
 function string.split(str, delim, include_empty, max_splits, sep_is_pattern)
 	delim = delim or ","
+	if delim == "" then
+		error("string.split separator is empty", 2)
+	end
 	max_splits = max_splits or -2
 	local items = {}
 	local pos, len = 1, #str

--- a/builtin/common/tests/misc_helpers_spec.lua
+++ b/builtin/common/tests/misc_helpers_spec.lua
@@ -38,6 +38,12 @@ describe("string", function()
 			assert.same({ "one", "two" }, string.split("one,two", ",", false, -1, true))
 			assert.same({ "one", "two", "three" }, string.split("one2two3three", "%d", false, -1, true))
 		end)
+
+		it("rejects empty separator", function()
+			assert.has.errors(function()
+				string.split("", "")
+			end)
+		end)
 	end)
 end)
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3623,7 +3623,7 @@ Helper functions
 * `math.round(x)`: Returns `x` rounded to the nearest integer.
     * At a multiple of 0.5, rounds away from zero.
 * `string.split(str, separator, include_empty, max_splits, sep_is_pattern)`
-    * `separator`: string, default: `","`
+    * `separator`: string, cannot be empty, default: `","`
     * `include_empty`: boolean, default: `false`
     * `max_splits`: number, if it's negative, splits aren't limited,
       default: `-1`


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/13128.

## To do

This PR is Ready for Review.

## How to test

Run the busted unit tests.
