### PR TITLE
Increase `ftos` precision

### DIFF
--- a/src/unittest/test_settings.cpp
+++ b/src/unittest/test_settings.cpp
@@ -72,7 +72,7 @@ const char *TestSettings::config_text_before =
 	"some multiline text\n"
 	"     with leading whitespace!\n"
 	"\"\"\"\n"
-	"np_terrain = 5, 40, (250, 250, 250), 12341, 5, 0.75, 2.25\n"
+	"np_terrain = 5, 40, (250, 250, 250), 12341, 5, 0.700012505, 2.40012503\n"
 	"zoop = true\n"
 	"[dummy_eof_end_tag]\n";
 
@@ -100,10 +100,10 @@ const std::string TestSettings::config_text_after =
 	"\"\"\"\n"
 	"np_terrain = {\n"
 	"	flags = defaults\n"
-	"	lacunarity = 2.25\n"
+	"	lacunarity = 2.40012503\n"
 	"	octaves = 6\n"
 	"	offset = 3.5\n"
-	"	persistence = 0.75\n"
+	"	persistence = 0.700012505\n"
 	"	scale = 40\n"
 	"	seed = 12341\n"
 	"	spread = (250,250,250)\n"
@@ -210,7 +210,7 @@ void TestSettings::testAllSettings()
 	UASSERT(std::fabs(np.spread.Z - 250) < 0.001f);
 	UASSERT(np.seed == 12341);
 	UASSERT(np.octaves == 5);
-	UASSERT(std::fabs(np.persist - 0.75) < 0.001f);
+	UASSERT(std::fabs(np.persist - 0.7) < 0.001f);
 
 	np.offset  = 3.5;
 	np.octaves = 6;

--- a/src/unittest/test_settings.cpp
+++ b/src/unittest/test_settings.cpp
@@ -72,7 +72,7 @@ const char *TestSettings::config_text_before =
 	"some multiline text\n"
 	"     with leading whitespace!\n"
 	"\"\"\"\n"
-	"np_terrain = 5, 40, (250, 250, 250), 12341, 5, 0.7, 2.4\n"
+	"np_terrain = 5, 40, (250, 250, 250), 12341, 5, 0.75, 2.25\n"
 	"zoop = true\n"
 	"[dummy_eof_end_tag]\n";
 
@@ -100,17 +100,17 @@ const std::string TestSettings::config_text_after =
 	"\"\"\"\n"
 	"np_terrain = {\n"
 	"	flags = defaults\n"
-	"	lacunarity = 2.4\n"
+	"	lacunarity = 2.25\n"
 	"	octaves = 6\n"
 	"	offset = 3.5\n"
-	"	persistence = 0.7\n"
+	"	persistence = 0.75\n"
 	"	scale = 40\n"
 	"	seed = 12341\n"
 	"	spread = (250,250,250)\n"
 	"}\n"
 	"zoop = true\n"
 	"coord2 = (1,2,3.3)\n"
-	"floaty_thing_2 = 1.2\n"
+	"floaty_thing_2 = 1.25\n"
 	"groupy_thing = {\n"
 	"	animals = cute\n"
 	"	num_apples = 4\n"
@@ -160,10 +160,10 @@ void TestSettings::testAllSettings()
 	UASSERT(fabs(s.getV3F("coord").Z - 4.5) < 0.001);
 
 	// Test the setting of settings too
-	s.setFloat("floaty_thing_2", 1.2);
+	s.setFloat("floaty_thing_2", 1.25);
 	s.setV3F("coord2", v3f(1, 2, 3.3));
-	UASSERT(s.get("floaty_thing_2").substr(0,3) == "1.2");
-	UASSERT(fabs(s.getFloat("floaty_thing_2") - 1.2) < 0.001);
+	UASSERT(s.get("floaty_thing_2").substr(0,4) == "1.25");
+	UASSERT(fabs(s.getFloat("floaty_thing_2") - 1.25) < 0.001);
 	UASSERT(fabs(s.getV3F("coord2").X - 1.0) < 0.001);
 	UASSERT(fabs(s.getV3F("coord2").Y - 2.0) < 0.001);
 	UASSERT(fabs(s.getV3F("coord2").Z - 3.3) < 0.001);
@@ -210,7 +210,7 @@ void TestSettings::testAllSettings()
 	UASSERT(std::fabs(np.spread.Z - 250) < 0.001f);
 	UASSERT(np.seed == 12341);
 	UASSERT(np.octaves == 5);
-	UASSERT(std::fabs(np.persist - 0.7) < 0.001f);
+	UASSERT(std::fabs(np.persist - 0.75) < 0.001f);
 
 	np.offset  = 3.5;
 	np.octaves = 6;

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <cstring>
 #include <vector>
+#include <limits>
 #include <map>
 #include <sstream>
 #include <iomanip>
@@ -429,14 +430,11 @@ inline std::string itos(s32 i) { return std::to_string(i); }
 /// Returns a string representing the decimal value of the 64-bit value \p i.
 inline std::string i64tos(s64 i) { return std::to_string(i); }
 
-// std::to_string uses the '%.6f' conversion, which is inconsistent with
-// std::ostream::operator<<() and impractical too.  ftos() uses the
-// more generic and std::ostream::operator<<()-compatible '%G' format.
-/// Returns a string representing the decimal value of the float value \p f.
+/// Returns a string representing the exact decimal value of the float value \p f.
 inline std::string ftos(float f)
 {
 	std::ostringstream oss;
-	oss << f;
+	oss << std::setprecision(std::numeric_limits<float>::max_digits10) << f;
 	return oss.str();
 }
 


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/13138. [This should be enough precision to preserve values exactly](https://en.cppreference.com/w/cpp/types/numeric_limits/max_digits10).

## To do

This PR is Ready for Review.

## How to test

Try this code:

```lua
local meta = ItemStack("air"):get_meta()
meta:set_float("1", 1.23456789)
assert(meta:get_string("1") == "1.23456788")
meta:set_float("2", 1.25)
assert(meta:get_string("2") == "1.25")
```
