### PR TITLE
Fix documentation of spawn_by for decorations

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -9193,7 +9193,7 @@ See [Decoration types]. Used by `minetest.register_decoration`.
         spawn_by = "default:water",
         -- Node (or list of nodes) that the decoration only spawns next to.
         -- Checks the 8 neighboring nodes on the same Y, and also the ones
-        -- at Y+1, excluding both center nodes.
+        -- at Y-1, excluding both center nodes.
 
         num_spawn_by = 1,
         -- Number of spawn_by nodes that must be surrounding the decoration


### PR DESCRIPTION
The documentation is wrong here.
This is the relevant code src/mapgen/mg_decoration.cpp#L88

Example	from orion

```Lua
NAME = minetest.get_current_modname()
name = stone
minetest.register_decoration({
	deco_type = "simple",
	num_spawn_by = 9,
	flags = "force_placement",
	place_on = NAME .. ":" .. name,
	spawn_by = NAME .. ":" .. name,
	decoration = NAME .. ":".. name .."_lower",
	name = NAME .. ":".. name .."_lower",
	height = 1,
	fill_ratio = 10,
})
```

This will for orion spawn the _lower variant of stones next to stones, this is used to make the player only need to walk half slabs. If the documentation was right before the num_spawn_by would work with = 1, but this will spawn the decoration ontop of every eligable block.
(the above code can be tested for example with placing flowers on grass or so in mtg)