### PR TITLE
Fix concurrency in texture source

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -498,7 +498,7 @@ u32 TextureSource::getTextureId(const std::string &name)
 
 	try {
 		while(true) {
-			// Wait for result for up to 4 seconds (empirical value)
+			// Wait for result for up to 1 seconds (empirical value)
 			GetResult<std::string, u32, std::thread::id, u8>
 				result = result_queue.pop_front(1000);
 

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -405,7 +405,7 @@ private:
 	std::mutex m_textureinfo_cache_mutex;
 
 	// Queued texture fetches (to be processed by the main thread)
-	RequestQueue<std::string, u32, u8, u8> m_get_texture_queue;
+	RequestQueue<std::string, u32, std::thread::id, u8> m_get_texture_queue;
 
 	// Textures that have been overwritten with other ones
 	// but can't be deleted because the ITexture* might still be used
@@ -491,16 +491,16 @@ u32 TextureSource::getTextureId(const std::string &name)
 	infostream<<"getTextureId(): Queued: name=\""<<name<<"\""<<std::endl;
 
 	// We're gonna ask the result to be put into here
-	static thread_local ResultQueue<std::string, u32, u8, u8> result_queue;
+	static thread_local ResultQueue<std::string, u32, std::thread::id, u8> result_queue;
 
 	// Throw a request in
-	m_get_texture_queue.add(name, 0, 0, &result_queue);
+	m_get_texture_queue.add(name, std::this_thread::get_id(), 0, &result_queue);
 
 	try {
 		while(true) {
 			// Wait for result for up to 4 seconds (empirical value)
-			GetResult<std::string, u32, u8, u8>
-				result = result_queue.pop_front(4000);
+			GetResult<std::string, u32, std::thread::id, u8>
+				result = result_queue.pop_front(1000);
 
 			if (result.key == name) {
 				return result.item;
@@ -726,10 +726,10 @@ void TextureSource::processQueue()
 	/*
 		Fetch textures
 	*/
-	//NOTE this is only thread safe for ONE consumer thread!
-	if (!m_get_texture_queue.empty())
+	// NOTE: process outstanding requests from all mesh generation threads
+	while (!m_get_texture_queue.empty())
 	{
-		GetRequest<std::string, u32, u8, u8>
+		GetRequest<std::string, u32, std::thread::id, u8>
 				request = m_get_texture_queue.pop();
 
 		/*infostream<<"TextureSource::processQueue(): "


### PR DESCRIPTION
Fixes `ERROR[MeshUpdate]: Waiting for texture X timed out.` messages when using multiple mesh generation threads (see #13062).

Problem reports [1](https://github.com/minetest/minetest/pull/13062#issuecomment-1384173153), [2](https://discord.com/channels/369122544273588224/369137254641303560/1063642183682494565), [3](https://discord.com/channels/369122544273588224/369137254641303560/1061621677429104640)

Reverts the timeout value to 1000ms.

## To do

This PR is Ready for Review.

## How to test

1. Build a high 1x1 tower of random blocks
2. Dig down the tower
3. There should be no ERROR messages in the log/chat.
