### PR TITLE
Clear exposure compensation textures on creation.

### DIFF
--- a/src/client/render/pipeline.cpp
+++ b/src/client/render/pipeline.cpp
@@ -40,7 +40,7 @@ video::ITexture *TextureBuffer::getTexture(u8 index)
 }
 
 
-void TextureBuffer::setTexture(u8 index, core::dimension2du size, const std::string &name, video::ECOLOR_FORMAT format)
+void TextureBuffer::setTexture(u8 index, core::dimension2du size, const std::string &name, video::ECOLOR_FORMAT format, bool clear)
 {
 	assert(index != NO_DEPTH_TEXTURE);
 
@@ -54,9 +54,10 @@ void TextureBuffer::setTexture(u8 index, core::dimension2du size, const std::str
 	definition.size = size;
 	definition.name = name;
 	definition.format = format;
+	definition.clear = clear;
 }
 
-void TextureBuffer::setTexture(u8 index, v2f scale_factor, const std::string &name, video::ECOLOR_FORMAT format)
+void TextureBuffer::setTexture(u8 index, v2f scale_factor, const std::string &name, video::ECOLOR_FORMAT format, bool clear)
 {
 	assert(index != NO_DEPTH_TEXTURE);
 
@@ -70,6 +71,7 @@ void TextureBuffer::setTexture(u8 index, v2f scale_factor, const std::string &na
 	definition.scale_factor = scale_factor;
 	definition.name = name;
 	definition.format = format;
+	definition.clear = clear;
 }
 
 void TextureBuffer::reset(PipelineContext &context)
@@ -135,10 +137,20 @@ bool TextureBuffer::ensureTexture(video::ITexture **texture, const TextureDefini
 	if (*texture)
 		m_driver->removeTexture(*texture);
 
-	if (definition.valid)
-		*texture = m_driver->addRenderTargetTexture(size, definition.name.c_str(), definition.format);
-	else
+	if (definition.valid) {
+		if (definition.clear) {
+			video::IImage *image = m_driver->createImage(definition.format, size);
+			image->fill(0u);
+			*texture = m_driver->addTexture(definition.name.c_str(), image);
+			image->drop();
+		}
+		else {
+			*texture = m_driver->addRenderTargetTexture(size, definition.name.c_str(), definition.format);
+		}
+	}
+	else {
 		*texture = nullptr;
+	}
 
 	return true;
 }

--- a/src/client/render/pipeline.h
+++ b/src/client/render/pipeline.h
@@ -126,7 +126,7 @@ public:
 	 * @param name unique name of the texture
 	 * @param format color format
 	 */
-	void setTexture(u8 index, core::dimension2du size, const std::string& name, video::ECOLOR_FORMAT format);
+	void setTexture(u8 index, core::dimension2du size, const std::string& name, video::ECOLOR_FORMAT format, bool clear = false);
 
 	/**
 	 * Configure relative-size texture for the specific index
@@ -136,7 +136,7 @@ public:
 	 * @param name unique name of the texture
 	 * @param format color format
 	 */
-	void setTexture(u8 index, v2f scale_factor, const std::string& name, video::ECOLOR_FORMAT format);
+	void setTexture(u8 index, v2f scale_factor, const std::string& name, video::ECOLOR_FORMAT format, bool clear = false);
 
 	virtual u8 getTextureCount() override { return m_textures.size(); }
 	virtual video::ITexture *getTexture(u8 index) override;
@@ -150,6 +150,7 @@ private:
 		bool valid { false };
 		bool fixed_size { false };
 		bool dirty { false };
+		bool clear { false };
 		v2f scale_factor;
 		core::dimension2du size;
 		std::string name;

--- a/src/client/render/secondstage.cpp
+++ b/src/client/render/secondstage.cpp
@@ -121,8 +121,8 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 	static const u8 TEXTURE_BLOOM_UP = 20;
 
 	buffer->setTexture(TEXTURE_COLOR, scale, "3d_render", color_format);
-	buffer->setTexture(TEXTURE_EXPOSURE_1, core::dimension2du(1,1), "exposure_1", color_format);
-	buffer->setTexture(TEXTURE_EXPOSURE_2, core::dimension2du(1,1), "exposure_2", color_format);
+	buffer->setTexture(TEXTURE_EXPOSURE_1, core::dimension2du(1,1), "exposure_1", color_format, /*clear:*/ true);
+	buffer->setTexture(TEXTURE_EXPOSURE_2, core::dimension2du(1,1), "exposure_2", color_format, /*clear:*/ true);
 	buffer->setTexture(TEXTURE_DEPTH, scale, "3d_depthmap", depth_format);
 
 	// attach buffer to the previous step


### PR DESCRIPTION
Avoid NaN condition in exposure compensation code and the resulting black screen by clearing the state textures on creation.

Co-Authored-By: sfan5

## To do

This PR is Ready for Review.

## How to test

1. Set `enable_dynamic_exposure = true`
2. Install and enable https://github.com/x2048/dynamic_exposure/
3. Start any world
4. The world (3D part) should render properly without black screen
