### PR TITLE
Display whole profiler numbers up to 999999 without scientific notation.

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -154,8 +154,8 @@ int Profiler::print(std::ostream &o, u32 page, u32 pagecount)
 			o << buffer;
 		}
 
-		porting::mt_snprintf(buffer, sizeof(buffer), "% 5ix % 4.4g",
-				getAvgCount(i.first), i.second);
+		porting::mt_snprintf(buffer, sizeof(buffer), "% 5ix % 7g",
+				getAvgCount(i.first), floor(i.second * 1000.0) / 1000.0);
 		o << buffer << std::endl;
 	}
 	return values.size();


### PR DESCRIPTION
Small change to #13126

Keeps most of the aligned formatting, but allow whole number to be displayed in non-scientific notation.

For example 12345 would be displayed as 1.234e+04 instead.
`% 7g` (the same as `% 7.6g` as per C++ standard) would only display millions, i.e. 1.23456e+06.
Also note that even 1234567 uses up less space than 12.345+e07.

7.6g as oppose to 6.6g so that whole number line up correctly with leading spaces.
```
 123456
     56
```

Fractions would also be up 6 digits, i.e. `0.123456`

Before #13126 the formatting was `% 3g` (equivalent to `% 3.6g`). So this PR restores the precision, but keeps the alignment.

Up to 1.000.000 and definitely up to 100.000 I'd want to see precise numbers, for example the number of blocks loaded.
