### PR TITLE
fixed a README mistake on option SPATIAL_LIBRARY

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Library specific options:
     REDIS_INCLUDE_DIR               - Only when building with Redis; directory that contains hiredis.h
     REDIS_LIBRARY                   - Only when building with Redis; path to libhiredis.a/libhiredis.so
     SPATIAL_INCLUDE_DIR             - Only when building with LibSpatial; directory that contains spatialindex/SpatialIndex.h
-    SPATIAL_LIBRARY                 - Only when building with LibSpatial; path to libspatialindex_c.so/spatialindex-32.lib
+    SPATIAL_LIBRARY                 - Only when building with LibSpatial; path to libspatialindex.so/spatialindex-32.lib
     LUA_INCLUDE_DIR                 - Only if you want to use LuaJIT; directory where luajit.h is located
     LUA_LIBRARY                     - Only if you want to use LuaJIT; path to libluajit.a/libluajit.so
     OGG_DLL                         - Only if building with sound on Windows; path to libogg.dll


### PR DESCRIPTION
line 297, the CMake option `SPATIAL_LIBRARY` should be the path to `libspatialindex.so` , not `libspatialindex_c.so` .

- Goal of the PR: Fixed a README mistake.
- How does the PR work? Provide the right guidance to those who compile according to README.
- Does it resolve any reported issue? Hadn't been reported.
- Does this relate to a goal in [the roadmap](../doc/direction.md)? No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
