### PR TITLE
Use default values from cpp_api/s_env.cpp for register_abm in lua_api.txt

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7945,7 +7945,7 @@ Used by `minetest.register_abm`.
         -- Operation interval in seconds
 
         chance = 50,
-        -- Chance of triggering `action` per-node per-interval is 1.0 / this
+        -- Chance of triggering `action` per-node per-interval is 1.0 / chance
 
         min_y = -32768,
         max_y = 32767,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7941,12 +7941,11 @@ Used by `minetest.register_abm`.
         -- If left out or empty, any neighbor will do.
         -- `group:groupname` can also be used here.
 
-        interval = 1.0,
+        interval = 10.0,
         -- Operation interval in seconds
 
-        chance = 1,
+        chance = 50,
         -- Chance of triggering `action` per-node per-interval is 1.0 / this
-        -- value
 
         min_y = -32768,
         max_y = 32767,


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - This PR changes the example values in lua_api.txt under register_abm to the ones used as default values in https://github.com/minetest/minetest/blob/master/src/script/cpp_api/s_env.cpp.
- How does the PR work?
  - It just changes a tiny amount of information in lua_api.txt
- Does it resolve any reported issue?
  - #7404 does relate very remotely to this (I searched for 'register_abm')
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
  - no
- If not a bug fix, why is this PR needed? What usecases does it solve?
  - When I used register_abm without defining chance, I was confused why it didn't act on all nodes, because I assumed the default chance would be 1 like in https://github.com/minetest/minetest/blob/master/doc/lua_api.txt#L7947

## To do

This PR is  Ready for Review.

- [X] Document default values

## How to test

- lua_api.txt should have chance = 50 and interval = 10.0 written around line 7950
