### PR TITLE
Decrease minimum for repeat_place_time

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -95,7 +95,7 @@ always_fly_fast (Always fly fast) bool true
 
 #    The time in seconds it takes between repeated node placements when holding
 #    the place button.
-repeat_place_time (Place repetition interval) float 0.25 0.25 2
+repeat_place_time (Place repetition interval) float 0.25 0.16 2
 
 #    Automatically jump up single-node obstacles.
 autojump (Automatic jumping) bool false
@@ -469,7 +469,7 @@ enable_auto_exposure (Enable Automatic Exposure) bool false
 enable_bloom (Enable Bloom) bool false
 
 #    Set to true to render debugging breakdown of the bloom effect.
-#    In debug mode, the screen is split into 4 quadrants: 
+#    In debug mode, the screen is split into 4 quadrants:
 #    top-left - processed base image, top-right - final image
 #    bottom-left - raw base image, bottom-right - bloom texture.
 enable_bloom_debug (Enable Bloom Debug) bool false

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4291,7 +4291,7 @@ void Game::readSettings()
 	m_cache_enable_fog                   = g_settings->getBool("enable_fog");
 	m_cache_mouse_sensitivity            = g_settings->getFloat("mouse_sensitivity", 0.001f, 10.0f);
 	m_cache_joystick_frustum_sensitivity = std::max(g_settings->getFloat("joystick_frustum_sensitivity"), 0.001f);
-	m_repeat_place_time                  = g_settings->getFloat("repeat_place_time", 0.25f, 2.0);
+	m_repeat_place_time                  = g_settings->getFloat("repeat_place_time", 0.16f, 2.0);
 
 	m_cache_enable_noclip                = g_settings->getBool("noclip");
 	m_cache_enable_free_move             = g_settings->getBool("free_move");


### PR DESCRIPTION
Decreases the minimum for the `repeat_place_time` setting to `0.16`.
I've found this value empirically with the code in `How to test`. I can easily reach this speed by clicking manually.

Why this is needed:
* #12450 has increased the minimum from `0.001` to `0.25` (`0.25` is also the default).
  The old value was inhumanly low, thus possibly giving an unfair advantage in combat-focused games. The new minimum in this PR doesn't have this issue.
* When building stuff, `0.25` is too slow for some people (i.e. for me). So these people have to click manually, which is tiring over time (and wears the mouse). (=> The repeat place feature looses its purpose.)
  (This could actually prevent some people from upgrading to new versions, which we don't want.)

## To do

This PR is a Ready for Review.

## How to test

```lua
local last_place = minetest.get_us_time()

minetest.register_node("test_place_speed:node", {
	description = "Place speed measurement node",
	tiles = {"ignore.png^server_public.png"},
	groups = {cracky = 1},
	on_place = function(...)
		local t = minetest.get_us_time()
		minetest.log(string.format("time from last place: %s s", (t - last_place) * 1.0e-6))
		last_place = t
		return minetest.item_place(...)
	end,
})
```

Set `repeat_place_time` to minimum, and compare placement speed of holding rightclick vs. spamming rightclick.
