### PR TITLE
Improve the documentation for chat command definition in lua_api.txt.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -9311,7 +9311,8 @@ description fields is shown when the "/help" chatcommand is issued.
 		-- General description of the command's purpose.
 
         privs = {},
-		-- Required privileges to run. See [Privileges].
+		-- Required privileges to run. See `minetest.check_player_privs()` for
+		-- the format and see [Privileges] for an overview of privileges.
 
         func = function(name, param),
         -- Called when command is run.  

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -9299,20 +9299,31 @@ Chat command definition
 
 Used by `minetest.register_chatcommand`.
 
+Specifies the function to be called and the privileges required when a player
+issues the command.  A help message that is the concatenation of the params and
+description fields is shown when the "/help" chatcommand is issued with the
+command name as its argument, 
+
     {
-        params = "<name> <privilege>",  -- Short parameter description
+        params = "",
+		-- Short parameter description.  See the below note.
 
-        description = "Remove privilege from player",  -- Full description
+        description = "",
+		-- Full description of the command's purpose.
 
-        privs = {privs=true},  -- Require the "privs" privilege to run
+        privs = {},
+		-- Required privileges to run. See [Privileges].
 
         func = function(name, param),
-        -- Called when command is run. Returns boolean success and text output.
-        -- Special case: The help message is shown to the player if `func`
-        -- returns false without a text output.
+        -- Called when command is run.  
+		--	* `name` is the name of the player who issued the command.
+		--	* `param` is a string with the full arguments to the command.
+		-- Returns a boolean and a string value.  
+		-- The string is shown to the issuing player upon exit of `funct` or,
+		-- if `func` returns `false` and no string, the help message is shown.
     }
 
-Note that in params, use of symbols is as follows:
+Note that in params, the conventional use of symbols is as follows:
 
 * `<>` signifies a placeholder to be replaced when the command is used. For
   example, when a player name is needed: `<name>`
@@ -9323,6 +9334,18 @@ Note that in params, use of symbols is as follows:
   provided. For example: `<param1> | <param2>`
 * `()` signifies grouping. For example, when param1 and param2 are both
   required, or only param3 is required: `(<param1> <param2>) | <param3>`
+
+Example:
+
+    {
+        params = "<name> <privilege>",
+
+        description = "Remove privilege from player",
+
+        privs = {privs=true},  -- Require the "privs" privilege to run
+
+        func = function(name, param),
+    }
 
 Privilege definition
 --------------------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -9317,7 +9317,7 @@ description fields is shown when the "/help" chatcommand is issued.
         -- Called when command is run.  
 		--	* `name` is the name of the player who issued the command.
 		--	* `param` is a string with the full arguments to the command.
-		-- Returns a boolean and a string value.  
+		-- Returns a boolean for success and a string value.  
 		-- The string is shown to the issuing player upon exit of `func` or,
 		-- if `func` returns `false` and no string, the help message is shown.
     }

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -9301,15 +9301,14 @@ Used by `minetest.register_chatcommand`.
 
 Specifies the function to be called and the privileges required when a player
 issues the command.  A help message that is the concatenation of the params and
-description fields is shown when the "/help" chatcommand is issued with the
-command name as its argument, 
+description fields is shown when the "/help" chatcommand is issued.
 
     {
         params = "",
 		-- Short parameter description.  See the below note.
 
         description = "",
-		-- Full description of the command's purpose.
+		-- General description of the command's purpose.
 
         privs = {},
 		-- Required privileges to run. See [Privileges].
@@ -9319,7 +9318,7 @@ command name as its argument,
 		--	* `name` is the name of the player who issued the command.
 		--	* `param` is a string with the full arguments to the command.
 		-- Returns a boolean and a string value.  
-		-- The string is shown to the issuing player upon exit of `funct` or,
+		-- The string is shown to the issuing player upon exit of `func` or,
 		-- if `func` returns `false` and no string, the help message is shown.
     }
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -9305,22 +9305,22 @@ description fields is shown when the "/help" chatcommand is issued.
 
     {
         params = "",
-		-- Short parameter description.  See the below note.
+        -- Short parameter description.  See the below note.
 
         description = "",
-		-- General description of the command's purpose.
+        -- General description of the command's purpose.
 
         privs = {},
-		-- Required privileges to run. See `minetest.check_player_privs()` for
-		-- the format and see [Privileges] for an overview of privileges.
+        -- Required privileges to run. See `minetest.check_player_privs()` for
+        -- the format and see [Privileges] for an overview of privileges.
 
         func = function(name, param),
         -- Called when command is run.  
-		--	* `name` is the name of the player who issued the command.
-		--	* `param` is a string with the full arguments to the command.
-		-- Returns a boolean for success and a string value.  
-		-- The string is shown to the issuing player upon exit of `func` or,
-		-- if `func` returns `false` and no string, the help message is shown.
+        -- * `name` is the name of the player who issued the command.
+        -- * `param` is a string with the full arguments to the command.
+        -- Returns a boolean for success and a string value.  
+        -- The string is shown to the issuing player upon exit of `func` or,
+        -- if `func` returns `false` and no string, the help message is shown.
     }
 
 Note that in params, the conventional use of symbols is as follows:


### PR DESCRIPTION
When you need to read the source code in order to understand what the documentation means, then maybe the documentation isn't all it could be.

This PR aims to provide a minor update to doc/lua_apt.txt, specifically the chat command definition documentation.

Changes that this PR makes:

Improve the documentation of  "Chat command definition":
* Separate the description of the chat command definition from the example.
* Document the parameters to the called function.
* Clarify the composition and use of the help text.
* Point out the advisory nature of the extended params format description.

The PR makes no changes to runnable code. 

Testing these changes should involve proof-reading for:
* factual correctness;
* adherence to doc/lua_api.txt conventional style;
* proper use of the english language (submitter is not a native speaker.)