### PR TITLE
Separate drawlist from non-rendered blocks.

### DIFF
--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -203,6 +203,7 @@ private:
 	bool m_needs_update_transparent_meshes = true;
 
 	std::map<v3s16, MapBlock*, MapBlockComparer> m_drawlist;
+	std::vector<MapBlock*> m_keeplist;
 	std::map<v3s16, MapBlock*> m_drawlist_shadow;
 	bool m_needs_update_drawlist;
 


### PR DESCRIPTION
The observation is that we have a list of blocks to draw and a separate list of blocks that the client should not unload.
Keeping track of the latter with a vector saves CPU cycles.

Looking up in the air with view_range of 800 pushed FPS from 8 to 32 on my machine.

Note that with this PR as is, the mesh-holding blocks might end up in the keeplist *and* the drawlist. Could check for that, but performance-wise it is not worth it. Reference counting is still correct.

As an added benefit the vector will size itself correctly after a while avoiding any re-allocations.

To test:

```
max_block_send_distance = 50
max_block_generate_distance = 49
block_send_optimize_distance = 50

view_range =800
```

Then look straight up... So that you see air-blocks only.
On my machine FPS goes from 8 to about 35 with this PR.
