### PR TITLE
Clarify documentation of inventory actions

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5317,9 +5317,12 @@ Call these functions only at load time!
 * `minetest.register_craft_predict(function(itemstack, player, old_craft_grid, craft_inv))`
     * The same as before, except that it is called before the player crafts, to
       make craft prediction, and it should not change anything.
-* `minetest.register_allow_player_inventory_action(function(player, action, inventory, inventory_info))`
-    * Determines how much of a stack may be taken, put or moved to a
-      player inventory.
+* `minetest.register_on_player_inventory_action(function(player, action, inventory, inventory_info))`
+    * Called after an item take, put or move event from/to/in a player inventory
+    * These inventory actions are recognized:
+        * move: Item was moved within the player inventory
+        * put: Item was put into player inventory from another inventory
+        * take: Item was taken from player inventory and put into another inventory
     * `player` (type `ObjectRef`) is the player who modified the inventory
       `inventory` (type `InvRef`).
     * List of possible `action` (string) values and their
@@ -5327,12 +5330,13 @@ Call these functions only at load time!
         * `move`: `{from_list=string, to_list=string, from_index=number, to_index=number, count=number}`
         * `put`:  `{listname=string, index=number, stack=ItemStack}`
         * `take`: Same as `put`
+    * Does not accept or handle any return value.
+* `minetest.register_allow_player_inventory_action(function(player, action, inventory, inventory_info))`
+    * Determines how much of a stack may be taken, put or moved to a
+      player inventory.
+    * Function arguments: see `minetest.register_on_player_inventory_action`
     * Return a numeric value to limit the amount of items to be taken, put or
       moved. A value of `-1` for `take` will make the source stack infinite.
-* `minetest.register_on_player_inventory_action(function(player, action, inventory, inventory_info))`
-    * Called after a take, put or move event from/to/in a player inventory
-    * Function arguments: see `minetest.register_allow_player_inventory_action`
-    * Does not accept or handle any return value.
 * `minetest.register_on_protection_violation(function(pos, name))`
     * Called by `builtin` and mods when a player violates protection at a
       position (eg, digs a node or punches a protected entity).

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5317,6 +5317,12 @@ Call these functions only at load time!
 * `minetest.register_craft_predict(function(itemstack, player, old_craft_grid, craft_inv))`
     * The same as before, except that it is called before the player crafts, to
       make craft prediction, and it should not change anything.
+* `minetest.register_allow_player_inventory_action(function(player, action, inventory, inventory_info))`
+    * Determines how much of a stack may be taken, put or moved to a
+      player inventory.
+    * Function arguments: see `minetest.register_on_player_inventory_action`
+    * Return a numeric value to limit the amount of items to be taken, put or
+      moved. A value of `-1` for `take` will make the source stack infinite.
 * `minetest.register_on_player_inventory_action(function(player, action, inventory, inventory_info))`
     * Called after an item take, put or move event from/to/in a player inventory
     * These inventory actions are recognized:
@@ -5331,12 +5337,6 @@ Call these functions only at load time!
         * `put`:  `{listname=string, index=number, stack=ItemStack}`
         * `take`: Same as `put`
     * Does not accept or handle any return value.
-* `minetest.register_allow_player_inventory_action(function(player, action, inventory, inventory_info))`
-    * Determines how much of a stack may be taken, put or moved to a
-      player inventory.
-    * Function arguments: see `minetest.register_on_player_inventory_action`
-    * Return a numeric value to limit the amount of items to be taken, put or
-      moved. A value of `-1` for `take` will make the source stack infinite.
 * `minetest.register_on_protection_violation(function(pos, name))`
     * Called by `builtin` and mods when a player violates protection at a
       position (eg, digs a node or punches a protected entity).


### PR DESCRIPTION
This PR improves the help for `minetest.register_allow_player_inventory_action` and `minetest.register_on_player_inventory_action` in `lua_api.txt`.

The text was not clear enough on what these do *exactly*. It was written in a way that sounded like this allows you to capture *ALL* inventory changes of the player inventory. However, this is not true: It only captures inventory changes within the player inventory or when the item was exchanged with another inventory. If an item was added with e.g. `inv:set_stack` or `inv:add_item` or similar, this callback is *NOT* called. This has tripped me up in my modding.

Thus, I explained what the 3 actions "put", "take" and "move" mean so it should be clear that only those 3 events matter (and not e.g. a `set_stack` call)

I also flipped the order in which these functions appear in the documentation simply to make it a bit easier to explain.