### PR TITLE
Place nodes with single tap on Android (+ bugfix)

### DIFF
--- a/doc/android.md
+++ b/doc/android.md
@@ -1,5 +1,3 @@
-**This document is based on the Minetest 5.6.1 version for Android**
-
 # Minetest Android build
 All Minetest builds, including the Android variant, are based on the same code.
 However, additional Java code is used for proper Android integration.
@@ -11,8 +9,8 @@ due to limited capabilities of common devices. What can be done is described bel
 While you're playing the game normally (that is, no menu or inventory is
 shown), the following controls are available:
 * Look around: touch screen and slide finger
-* Double tap: Place a node
-* Long tap: Dig node or use the holding item
+* Tap: Place a node
+* Long tap: Dig node or use the held item
 * Press back: Pause menu
 * Touch buttons: Press button
 * Buttons:
@@ -33,9 +31,8 @@ When a menu or inventory is displayed:
   --> places a single item from dragged stack into current (first touched) slot. If a stack is selected, the stack will be split as half and one of the splitted stack will be selected
 
 ### Limitations
-* Android player have to double tap to place node, this can be annoying in some game/mod
 * Some old Android device only support 2 touch at a time, some game/mod contain button combination that need 3 touch (example: jump + Aux1 + hold)
-* Complicated control like pick up an cart in MTG can be difficult or impossible on Android device
+* Complicated control can be difficult or impossible on Android device
 
 ## File Path
 There are some settings especially useful for Android users. The Minetest-wide

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4335,14 +4335,14 @@ void Game::showDeathFormspec()
 void Game::showPauseMenu()
 {
 #ifdef HAVE_TOUCHSCREENGUI
-	static const std::string control_text = strgettext("Default Controls:\n"
-		"No menu visible:\n"
-		"- single tap: button activate\n"
-		"- double tap: place/use\n"
+	static const std::string control_text = strgettext("Default controls:\n"
+		"No menu open:\n"
 		"- slide finger: look around\n"
-		"Menu/Inventory visible:\n"
+		"- tap: place/use\n"
+		"- long tap: dig/punch/use\n"
+		"Menu/inventory open:\n"
 		"- double tap (outside):\n"
-		" -->close\n"
+		" --> close\n"
 		"- touch stack, touch slot:\n"
 		" --> move stack\n"
 		"- touch&drag, tap 2nd finger\n"

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4335,7 +4335,7 @@ void Game::showDeathFormspec()
 void Game::showPauseMenu()
 {
 #ifdef HAVE_TOUCHSCREENGUI
-	static const std::string control_text = strgettext("Default controls:\n"
+	static const std::string control_text = strgettext("Controls:\n"
 		"No menu open:\n"
 		"- slide finger: look around\n"
 		"- tap: place/use\n"

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -772,8 +772,14 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 			// already handled in isSettingsBarButton()
 		} else {
 			// handle non button events
-			m_settingsbar.deactivate();
-			m_rarecontrolsbar.deactivate();
+			if (m_settingsbar.active()) {
+				m_settingsbar.deactivate();
+				return;
+			}
+			if (m_rarecontrolsbar.active()) {
+				m_rarecontrolsbar.deactivate();
+				return;
+			}
 
 			s32 dxj = event.TouchInput.X - button_size * 5.0f / 2.0f;
 			s32 dyj = event.TouchInput.Y - (s32)m_screensize.Y + button_size * 5.0f / 2.0f;

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -772,11 +772,8 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 			// already handled in isSettingsBarButton()
 		} else {
 			// handle non button events
-			if (m_settingsbar.active()) {
+			if (m_settingsbar.active() || m_rarecontrolsbar.active()) {
 				m_settingsbar.deactivate();
-				return;
-			}
-			if (m_rarecontrolsbar.active()) {
 				m_rarecontrolsbar.deactivate();
 				return;
 			}
@@ -1095,10 +1092,6 @@ void TouchScreenGUI::step(float dtime)
 	for (auto &button : m_buttons) {
 		if (!button.ids.empty()) {
 			button.repeatcounter += dtime;
-
-			// in case we're moving around digging does not happen
-			if (m_has_move_id)
-				m_move_has_really_moved = true;
 
 			if (button.repeatcounter < button.repeatdelay)
 				continue;

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -692,9 +692,8 @@ void TouchScreenGUI::handleReleaseEvent(size_t evt_id)
 			}
 			m_receiver->OnEvent(*translated);
 			delete translated;
-		} else {
-			// do double tap detection
-			doubleTapDetection();
+		} else if (!m_move_has_really_moved) {
+			doRightClick();
 		}
 	}
 
@@ -999,29 +998,9 @@ void TouchScreenGUI::handleChangedButton(const SEvent &event)
 				event.TouchInput.ID, true);
 }
 
-bool TouchScreenGUI::doubleTapDetection()
+bool TouchScreenGUI::doRightClick()
 {
-	m_key_events[0].down_time = m_key_events[1].down_time;
-	m_key_events[0].x         = m_key_events[1].x;
-	m_key_events[0].y         = m_key_events[1].y;
-	m_key_events[1].down_time = m_move_downtime;
-	m_key_events[1].x         = m_move_downlocation.X;
-	m_key_events[1].y         = m_move_downlocation.Y;
-
-	u64 delta = porting::getDeltaMs(m_key_events[0].down_time, porting::getTimeMs());
-	if (delta > 400)
-		return false;
-
-	double distance = sqrt(
-			(m_key_events[0].x - m_key_events[1].x) *
-			(m_key_events[0].x - m_key_events[1].x) +
-			(m_key_events[0].y - m_key_events[1].y) *
-			(m_key_events[0].y - m_key_events[1].y));
-
-	if (distance > (20 + m_touchscreen_threshold))
-		return false;
-
-	v2s32 mPos = v2s32(m_key_events[0].x, m_key_events[0].y);
+	v2s32 mPos = v2s32(m_move_downlocation.X, m_move_downlocation.Y);
 	if (m_draw_crosshair) {
 		mPos.X = m_screensize.X / 2;
 		mPos.Y = m_screensize.Y / 2;

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -130,7 +130,7 @@ public:
 	// step handler
 	void step(float dtime);
 
-	// check if the button bar is active
+	// return whether the button bar is active
 	bool active() { return m_active; }
 
 	// deactivate button bar

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -130,6 +130,9 @@ public:
 	// step handler
 	void step(float dtime);
 
+	// check if the button bar is active
+	bool active() { return m_active; }
+
 	// deactivate button bar
 	void deactivate();
 

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -284,8 +284,8 @@ private:
 	// handle pressed hud buttons
 	bool isHUDButton(const SEvent &event);
 
-	// handle double taps
-	bool doubleTapDetection();
+	// do a right-click
+	bool doRightClick();
 
 	// handle release event
 	void handleReleaseEvent(size_t evt_id);
@@ -293,19 +293,8 @@ private:
 	// apply joystick status
 	void applyJoystickStatus();
 
-	// double-click detection variables
-	struct key_event
-	{
-		u64 down_time;
-		s32 x;
-		s32 y;
-	};
-
 	// array for saving last known position of a pointer
 	std::map<size_t, v2s32> m_pointerpos;
-
-	// array for double tap detection
-	key_event m_key_events[2];
 
 	// settings bar
 	AutoHideButtonBar m_settingsbar;


### PR DESCRIPTION
#### Goal of the PR

Allow Android players to place nodes with a single tap. Currently, you have to double-tap to place nodes.
Also: Fix not being able to dig/punch while pressing sneak/aux on Android.

#### How does the PR work?

Place a node when a tap is detected that meets the following criteria:

1.  The finger was not moved enough during the tap to trigger moving the camera.
2.  The tap was not long enough to trigger digging.

Also, don't move the joystick, move the camera, dig or place when a button bar is closed by tapping outside of it. This is to prevent accidentally placing nodes when closing a button bar.

Without this PR, while you hold down the jump button (or any other button, e.g. sneak or aux), you cannot start digging, but you can _continue_ digging and you can place. This PR changes the behavior so that while you hold down the jump button, you can also _start_ digging.

#### Does it resolve any reported issue?

Closes #2761
Closes #11404

#### Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?

I don't think so.

#### If not a bug fix, why is this PR needed? What usecases does it solve?

Part 1: See [this comment on #2761](https://github.com/minetest/minetest/issues/2761#issuecomment-381328474).
Part 2 is a bugfix.

## To do

This PR is Ready for Review.

## How to test

Use Minetest on Android. Verify that ...

- ... you can place nodes with a single tap.
- ... no node is placed when you close a button bar by tapping outside of it.
- ... you can start digging even while you are holding down the jump button (or any other button, e.g. sneak or aux).
- ... all other controls still work the same as before.

APKs generated by GitHub Actions: https://github.com/minetest/minetest/actions/runs/4406654941#artifacts (sign in to download)
