### PR TITLE
Enable LTO building on supported platforms by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,3 +394,15 @@ if(DOXYGEN_FOUND)
 		COMMENT "Generating API documentation with Doxygen" VERBATIM
 	)
 endif()
+
+# enable LTO / IPO
+if (CMAKE_BUILD_TYPE STREQUAL Release)
+	include(CheckIPOSupported)
+	check_ipo_supported(RESULT result OUTPUT error)
+	if( result )
+	    message(STATUS "LTO / IPO enabled")
+	    set(INTERPROCEDURAL_OPTIMIZATION TRUE)
+	else()
+	    message(STATUS "LTO / IPO not supported: <${error}>")
+	endif()
+endif()


### PR DESCRIPTION
[While there was a PR before that made LTO builds possible](https://github.com/minetest/minetest/pull/11560), it was not enabled by default. Why not try flip the switch for release builds?

Link Time Optimization or Interprocedural Optimization is a build time optimisation gives the compiler information about how the individual source code files will be linked. This generally leads to a speed up for most C/C++ programs. This feature is enabled on a lot of major software projects as well as Linux distributions.
A good technical optimisation of how LTO works can be found here: https://www.llvm.org/docs/LinkTimeOptimization.html

Understandably it is still possible that one could run into issues here. If we do encounter them, then this PR can include fixes for broken code. If a build environment does not support LTO, the feature still remains off.

My proposal is to just merge this PR once it has been tested somewhat and if users do come back with issues, revert the PR and fix the issues.

## To do

This PR is a Work in Progress.

- [x] Test building on the minetest CI
- [x] Ask others to run builds locally

## How to test

Apply the change and build locally / in your buildsystem, or grab builds from the CI artifacts.
