### PR TITLE
Sky: transmit body_orbit_tilt to client.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -443,11 +443,6 @@ shadow_update_frames (Map shadows update frames) int 8 1 16
 #    Minimum value: 1.0; maximum value: 15.0
 shadow_soft_radius (Soft shadow radius) float 5.0 1.0 15.0
 
-#    Set the tilt of Sun/Moon orbit in degrees.
-#    Value of 0 means no tilt / vertical orbit.
-#    Minimum value: 0.0; maximum value: 60.0
-shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 -60.0 60.0
-
 [**Post processing]
 
 #    Set the exposure compensation in EV units.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7314,6 +7314,8 @@ child will follow movement and rotation of that bone.
     * `sky_parameters` is a table with the following optional fields:
         * `base_color`: ColorSpec, changes fog in "skybox" and "plain".
           (default: `#ffffff`)
+        * `body_orbit_tilt`: Float, angle of sun/moon orbit in degrees, relative to Y axis.
+           Valid range [-60.0,60.0] (default: 0.0)
         * `type`: Available types:
             * `"regular"`: Uses 0 textures, `base_color` ignored
             * `"skybox"`: Uses 6 textures, `base_color` used as fog.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -484,12 +484,6 @@
 #    type: float min: 1 max: 15
 # shadow_soft_radius = 5.0
 
-#    Set the tilt of Sun/Moon orbit in degrees.
-#    Value of 0 means no tilt / vertical orbit.
-#    Minimum value: 0.0; maximum value: 60.0
-#    type: float min: -60 max: 60
-# shadow_sky_body_orbit_tilt = 0.0
-
 ### Post processing
 
 #    Set the exposure compensation factor.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2980,6 +2980,9 @@ void Game::handleClientEvent_SetSky(ClientEvent *event, CameraOrientation *cam)
 		);
 	}
 
+	// Orbit Tilt:
+	sky->setBodyOrbitTilt(event->set_sky->body_orbit_tilt);
+
 	delete event->set_sky;
 }
 

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -103,9 +103,6 @@ Sky::Sky(s32 id, RenderingEngine *rendering_engine, ITextureSource *tsrc, IShade
 
 	m_directional_colored_fog = g_settings->getBool("directional_colored_fog");
 
-	if (g_settings->getBool("enable_dynamic_shadows"))
-		m_sky_body_orbit_tilt = g_settings->getFloat("shadow_sky_body_orbit_tilt", -60.0f, 60.0f);
-
 	setStarCount(1000);
 }
 
@@ -561,12 +558,12 @@ static v3f getSkyBodyPosition(float horizon_position, float day_position, float 
 
 v3f Sky::getSunDirection()
 {
-	return getSkyBodyPosition(90, getWickedTimeOfDay(m_time_of_day) * 360 - 90, m_sky_body_orbit_tilt);
+	return getSkyBodyPosition(90, getWickedTimeOfDay(m_time_of_day) * 360 - 90, m_sky_params.body_orbit_tilt);
 }
 
 v3f Sky::getMoonDirection()
 {
-	return getSkyBodyPosition(270, getWickedTimeOfDay(m_time_of_day) * 360 - 90, m_sky_body_orbit_tilt);
+	return getSkyBodyPosition(270, getWickedTimeOfDay(m_time_of_day) * 360 - 90, m_sky_params.body_orbit_tilt);
 }
 
 void Sky::draw_sun(video::IVideoDriver *driver, const video::SColor &suncolor,
@@ -726,7 +723,7 @@ void Sky::place_sky_body(
 	* day_position: turn the body around the Z axis, to place it depending of the time of the day
 	*/
 {
-	v3f centrum = getSkyBodyPosition(horizon_position, day_position, m_sky_body_orbit_tilt);
+	v3f centrum = getSkyBodyPosition(horizon_position, day_position, m_sky_params.body_orbit_tilt);
 	v3f untilted_centrum = getSkyBodyPosition(horizon_position, day_position, 0.f);
 	for (video::S3DVertex &vertex : vertices) {
 		// Body is directed to -Z (south) by default

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -96,6 +96,10 @@ public:
 	{
 		m_fallback_bg_color = fallback_bg_color;
 	}
+	void setBodyOrbitTilt(float body_orbit_tilt)
+	{
+		m_sky_params.body_orbit_tilt = body_orbit_tilt;
+	}
 	void overrideColors(video::SColor bgcolor, video::SColor skycolor)
 	{
 		m_bgcolor = bgcolor;
@@ -164,7 +168,6 @@ private:
 	bool m_directional_colored_fog;
 	bool m_in_clouds = true; // Prevent duplicating bools to remember old values
 	bool m_enable_shaders = false;
-	float m_sky_body_orbit_tilt = 0.0f;
 
 	video::SColorf m_bgcolor_bright_f = video::SColorf(1.0f, 1.0f, 1.0f, 1.0f);
 	video::SColorf m_skycolor_bright_f = video::SColorf(1.0f, 1.0f, 1.0f, 1.0f);

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -297,7 +297,6 @@ void set_default_settings()
 	settings->setDefault("shadow_poisson_filter", "true");
 	settings->setDefault("shadow_update_frames", "8");
 	settings->setDefault("shadow_soft_radius", "5.0");
-	settings->setDefault("shadow_sky_body_orbit_tilt", "0.0");
 
 	// Input
 	settings->setDefault("invert_mouse", "false");

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1367,6 +1367,10 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 				>> skybox.sky_color.indoors;
 		}
 
+		try {
+			*pkt >> skybox.body_orbit_tilt;
+		} catch (PacketError &e) {}
+
 		ClientEvent *event = new ClientEvent();
 		event->type = CE_SET_SKY;
 		event->set_sky = new SkyboxParams(skybox);

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -701,6 +701,7 @@ enum ToClientCommand
 		u8[4] fog_sun_tint (ARGB)
 		u8[4] fog_moon_tint (ARGB)
 		std::string fog_tint_type
+		float body_orbit_tilt
 	*/
 
 	TOCLIENT_OVERRIDE_DAY_NIGHT_RATIO = 0x50,

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1724,6 +1724,12 @@ int ObjectRef::l_set_sky(lua_State *L)
 			read_color(L, -1, &sky_params.bgcolor);
 		lua_pop(L, 1);
 
+		lua_getfield(L, 2, "body_orbit_tilt");
+		if (!lua_isnil(L, -1)) {
+			sky_params.body_orbit_tilt = rangelim(static_cast<float>(luaL_checknumber(L, -1)), -60.0f, 60.0f);
+		}
+		lua_pop(L, 1);
+
 		lua_getfield(L, 2, "type");
 		if (!lua_isnil(L, -1))
 			sky_params.type = luaL_checkstring(L, -1);
@@ -1912,6 +1918,9 @@ int ObjectRef::l_get_sky(lua_State *L)
 	lua_setfield(L, -2, "base_color");
 	lua_pushlstring(L, skybox_params.type.c_str(), skybox_params.type.size());
 	lua_setfield(L, -2, "type");
+
+	lua_pushnumber(L, skybox_params.body_orbit_tilt);
+	lua_setfield(L, -2, "body_orbit_tilt");
 
 	lua_newtable(L);
 	s16 i = 1;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1726,7 +1726,7 @@ int ObjectRef::l_set_sky(lua_State *L)
 
 		lua_getfield(L, 2, "body_orbit_tilt");
 		if (!lua_isnil(L, -1)) {
-			sky_params.body_orbit_tilt = rangelim(static_cast<float>(luaL_checknumber(L, -1)), -60.0f, 60.0f);
+			sky_params.body_orbit_tilt = rangelim(readParam<float>(L, -1), -60.0f, 60.0f);
 		}
 		lua_pop(L, 1);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1808,6 +1808,8 @@ void Server::SendSetSky(session_t peer_id, const SkyboxParams &params)
 				<< params.sky_color.night_sky << params.sky_color.night_horizon
 				<< params.sky_color.indoors;
 		}
+
+		pkt << params.body_orbit_tilt;
 	}
 
 	Send(&pkt);

--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -40,6 +40,7 @@ struct SkyboxParams
 	video::SColor fog_sun_tint;
 	video::SColor fog_moon_tint;
 	std::string fog_tint_type;
+	float body_orbit_tilt;
 };
 
 struct SunParams
@@ -95,6 +96,7 @@ public:
 		sky.fog_sun_tint = video::SColor(255, 244, 125, 29);
 		sky.fog_moon_tint = video::SColorf(0.5, 0.6, 0.8, 1).toSColor();
 		sky.fog_tint_type = "default";
+		sky.body_orbit_tilt = 0.0f;
 		return sky;
 	}
 


### PR DESCRIPTION
This obsoletes the current client-side setting entirely. The server can transmit the tilt to the client directly and will send 0.0f as default value.

To enable the server transmitting this event, you can add a mod like the following (this was used for testing:)

```
minetest.register_on_joinplayer(function(player)
	player:set_lighting({ shadows = { intensity = 0.33 } })
	player:set_sky({body_orbit_tilt = -30.0})
end)
```
