### PR TITLE
WIP: Node damage with nodes position

### DIFF
--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -185,6 +185,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 	if (!isImmortal() && m_node_hurt_interval.step(dtime, 1.0f)) {
 		u32 damage_per_second = 0;
 		std::string nodename;
+        v3s16 node_pos;
 		// Lowest and highest damage points are 0.1 within collisionbox
 		float dam_top = m_prop.collisionbox.MaxEdge.Y - 0.1f;
 
@@ -198,6 +199,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 			if (c.damage_per_second > damage_per_second) {
 				damage_per_second = c.damage_per_second;
 				nodename = c.name;
+                node_pos = p;
 			}
 		}
 
@@ -209,12 +211,15 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		if (c.damage_per_second > damage_per_second) {
 			damage_per_second = c.damage_per_second;
 			nodename = c.name;
+            node_pos = ptop;
 		}
 
 		if (damage_per_second != 0 && m_hp > 0) {
 			s32 newhp = (s32)m_hp - (s32)damage_per_second;
-
-			PlayerHPChangeReason reason(PlayerHPChangeReason::NODE_DAMAGE, nodename, ptop);
+            // TODO Need to get the block that the player fell on... Not super sure how I am going to do this
+            // Assuming ptop which is how they get the ntop for dps and nodename is fine
+            warningstream << "Collided with " << node_pos.X << ", " << node_pos.Y << ", " << node_pos.Z << std::endl;
+			PlayerHPChangeReason reason(PlayerHPChangeReason::NODE_DAMAGE, nodename, node_pos);
 			setHP(newhp, reason);
 		}
 	}

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -216,8 +216,8 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 
 		if (damage_per_second != 0 && m_hp > 0) {
 			s32 newhp = (s32)m_hp - (s32)damage_per_second;
-            // TODO Need to get the block that the player fell on... Not super sure how I am going to do this
-            // Assuming ptop which is how they get the ntop for dps and nodename is fine
+
+            // TODO Remove this print
             warningstream << "Collided with " << node_pos.X << ", " << node_pos.Y << ", " << node_pos.Z << std::endl;
 			PlayerHPChangeReason reason(PlayerHPChangeReason::NODE_DAMAGE, nodename, node_pos);
 			setHP(newhp, reason);

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -213,7 +213,8 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 
 		if (damage_per_second != 0 && m_hp > 0) {
 			s32 newhp = (s32)m_hp - (s32)damage_per_second;
-			PlayerHPChangeReason reason(PlayerHPChangeReason::NODE_DAMAGE, nodename);
+
+			PlayerHPChangeReason reason(PlayerHPChangeReason::NODE_DAMAGE, nodename, ptop);
 			setHP(newhp, reason);
 		}
 	}

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -245,6 +245,7 @@ struct PlayerHPChangeReason
 	ServerActiveObject *object = nullptr;
 	// For NODE_DAMAGE
 	std::string node;
+    v3s16 node_pos;
 
 	inline bool hasLuaReference() const { return lua_reference >= 0; }
 
@@ -296,5 +297,5 @@ struct PlayerHPChangeReason
 	{
 	}
 
-	PlayerHPChangeReason(Type type, std::string node) : type(type), node(node) {}
+	PlayerHPChangeReason(Type type, std::string node, v3s16 node_pos) : type(type), node(node), node_pos(node_pos) {}
 };


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

This PR is to implement the feature request found here https://github.com/minetest/minetest/issues/13195.

I used the recommendation in the request to force node damage to require a position. This results in it being stored in PlayerHPChangeReason. I believe the change should work, I'm not sure of many good ways of testing it.

## To do

This PR is a Work in Progress.
<!-- ^ delete one -->

- [ ] Verify minetest.register_on_player_hpchange callback contains proper information

## How to test

Currently printing the position of the node when node damage is taking place.

<!-- Example code or instructions -->
