### PR TITLE
Fix no color values on bloom texture

### DIFF
--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -14,7 +14,9 @@ varying mediump vec2 varTexCoord;
 centroid varying vec2 varTexCoord;
 #endif
 
-varying float exposure;
+#ifdef ENABLE_AUTO_EXPOSURE
+varying float exposure; // linear exposure factor, see vertex shader
+#endif
 
 void main(void)
 {
@@ -23,6 +25,11 @@ void main(void)
 	// translate to linear colorspace (approximate)
 	color = pow(color, vec3(2.2));
 
-	color *= pow(2., exposure) * exposureParams.compensationFactor * bloomStrength;
+	color *= exposureParams.compensationFactor * bloomStrength;
+
+#ifdef ENABLE_AUTO_EXPOSURE
+	color *= exposure;
+#endif
+
 	gl_FragColor = vec4(color, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/extract_bloom/opengl_vertex.glsl
+++ b/client/shaders/extract_bloom/opengl_vertex.glsl
@@ -1,6 +1,10 @@
+#ifdef ENABLE_AUTO_EXPOSURE
 #define exposureMap texture1
 
 uniform sampler2D exposureMap;
+
+varying float exposure;
+#endif
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -8,11 +12,14 @@ varying mediump vec2 varTexCoord;
 centroid varying vec2 varTexCoord;
 #endif
 
-varying float exposure;
 
 void main(void)
 {
+#ifdef ENABLE_AUTO_EXPOSURE
+	// value in the texture is on a logarithtmic scale
 	exposure = texture2D(exposureMap, vec2(0.5)).r;
+	exposure = pow(2., exposure);
+#endif
 
 	varTexCoord.st = inTexCoord0.st;
 	gl_Position = inVertexPosition;

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -18,7 +18,9 @@ varying mediump vec2 varTexCoord;
 centroid varying vec2 varTexCoord;
 #endif
 
-varying float exposure;
+#ifdef ENABLE_AUTO_EXPOSURE
+varying float exposure; // linear exposure factor, see vertex shader
+#endif
 
 #ifdef ENABLE_BLOOM
 
@@ -87,7 +89,10 @@ void main(void)
 	if (uv.x > 0.5 || uv.y > 0.5)
 #endif
 	{
-		color.rgb *= exposure * exposureParams.compensationFactor;
+		color.rgb *= exposureParams.compensationFactor;
+#ifdef ENABLE_AUTO_EXPOSURE
+		color.rgb *= exposure;
+#endif
 	}
 
 

--- a/client/shaders/second_stage/opengl_vertex.glsl
+++ b/client/shaders/second_stage/opengl_vertex.glsl
@@ -1,6 +1,10 @@
+#ifdef ENABLE_AUTO_EXPOSURE
 #define exposureMap texture2
 
 uniform sampler2D exposureMap;
+
+varying float exposure;
+#endif
 
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
@@ -8,15 +12,12 @@ varying mediump vec2 varTexCoord;
 centroid varying vec2 varTexCoord;
 #endif
 
-varying float exposure;
-
 void main(void)
 {
 #ifdef ENABLE_AUTO_EXPOSURE
+	// value in the texture is on a logarithtmic scale
 	exposure = texture2D(exposureMap, vec2(0.5)).r;
 	exposure = pow(2., exposure);
-#else
-	exposure = 1.0;
 #endif
 
 	varTexCoord.st = inTexCoord0.st;


### PR DESCRIPTION
Aligns the use of exposure variable in different shader stages and avoids multiplying colors in bloom effect texture by 0.0 when dynamic_auto_exposure is disabled.

Attempts to make #13190 better.

## To do

This PR is Ready for Review.

## How to test

1. Set `enable_bloom_debug` to true
2. Play the game using different combinations of `enable_bloom` and `enable_auto_exposure` parameters
3. The bloom texture (bottom right quadrant) must always be lighter than the other quadrants of the screen and never black.
