### PR TITLE
Do not send air-only blocks to the client unless they are close.

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -314,6 +314,9 @@ void RemoteClient::GetNextBlocks (
 				if (!block->isGenerated())
 					block_not_found = true;
 
+				if (d >= 3 && block->isOnlyAir())
+					continue;
+
 				/*
 					If block is not close, don't send it unless it is near
 					ground level.

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -325,6 +325,19 @@ public:
 		return m_day_night_differs;
 	}
 
+	inline bool isOnlyAir()
+	{
+		bool only_air = true;
+		for (u32 i = 0; i < nodecount; i++) {
+			MapNode &n = data[i];
+			if (n.getContent() != CONTENT_AIR) {
+				only_air = false;
+				break;
+			}
+		}
+		return only_air;
+	}
+
 	bool onObjectsActivation();
 	bool saveStaticObject(u16 id, const StaticObject &obj, u32 reason);
 


### PR DESCRIPTION
Air only blocks are not needed on the client to display correctly. Juggling many blocks puts considerable load on the both the server and the client.

## Notes

Air-only blocks are already not sent to the client (see `MapBlock::actuallyUpdateDayNightDiff`). We added the isUnderground check for caves and underwater places (see `RemoteClient::GetNextBlocks`), because many visible blocks would be omitted underground. This PR does not have this problem.

## How to test

Load any world. Try open air scenes, caves, underwater, etc. There must be no glitches, and the player must never collide with a `CONTENT_IGNORE` block.

Set `block_send_optimize_distance` to a large value. Note that not many more blocks are transmitted. (Unlike `block_send_optimize_distance` this will not cause any visible blocks to be omitted.) Especially underground, such as the nether, this will significantly reduce the number of blocks to be sent.

In a local test with `view_range` set 600 this reduce the number of blocks transmitted from client from over 42000 in over two minutes to less than 4000 in about 20s.
