### PR TITLE
Add mesh-holding blocks to shadow drawlist.

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1137,6 +1137,11 @@ void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir,
 			Loop through blocks in sector
 		*/
 		for (MapBlock *block : sectorblocks) {
+			if (mesh_grid.cell_size == 1 && !block->mesh) {
+				// fast out in the case of no mesh chunking
+				continue;
+			}
+
 			v3f block_pos = intToFloat(block->getPos() * MAP_BLOCKSIZE, BS);
 			v3f projection = shadow_light_pos + shadow_light_dir * shadow_light_dir.dotProduct(block_pos - shadow_light_pos);
 			if (projection.getDistanceFrom(block_pos) > radius)
@@ -1166,7 +1171,7 @@ void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir,
 	}
 	for (auto pos : shortlist) {
 		MapBlock * block = getBlockNoCreateNoEx(pos);
-		if (block && m_drawlist_shadow.emplace(pos, block).second) {
+		if (block && block->mesh && m_drawlist_shadow.emplace(pos, block).second) {
 			block->refGrab();
 		}
 	}


### PR DESCRIPTION
Just like the regular drawlist, the shadow drawlist needs to have the mesh-holding blocks added to it. Otherwise some meshes (i.e. parts of the shadows) will not be displayed.

## How to test

Set client_mesh_chunk to a large value (like 8 or 16), enable shadows, see how most shadows are not displayed without this PR.
With the PR shadows are displayed correctly.
This also happens with smaller client_mesh_chunk sizes (anything larger than 1), it's just harder to notice.
