### PR TITLE
Android: Increase minimum SDK version to 21

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,12 +1,13 @@
 apply plugin: 'com.android.application'
+
 android {
-	compileSdkVersion 32
-	buildToolsVersion '32.0.0'
+	compileSdkVersion 33
+	buildToolsVersion '33.0.2'
 	ndkVersion "$ndk_version"
 	defaultConfig {
 		applicationId 'net.minetest.minetest'
-		minSdkVersion 16
-		targetSdkVersion 32
+		minSdkVersion 21
+		targetSdkVersion 33
 		versionName "${versionMajor}.${versionMinor}.${versionPatch}"
 		versionCode project.versionCode
 	}
@@ -112,5 +113,5 @@ android.applicationVariants.all { variant ->
 
 dependencies {
 	implementation project(':native')
-	implementation 'androidx.appcompat:appcompat:1.5.1'
+	implementation 'androidx.appcompat:appcompat:1.6.0'
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -113,5 +113,5 @@ android.applicationVariants.all { variant ->
 
 dependencies {
 	implementation project(':native')
-	implementation 'androidx.appcompat:appcompat:1.6.0'
+	implementation 'androidx.appcompat:appcompat:1.6.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,13 +11,13 @@ project.ext.set("developmentBuild", 1) // Whether it is a development build, or 
 // each APK must have a larger `versionCode` than the previous
 
 buildscript {
-	ext.ndk_version = '25.1.8937393'
+	ext.ndk_version = '25.2.9519653'
 	repositories {
 		google()
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.2.2'
+		classpath 'com.android.tools.build:gradle:7.4.1'
 		classpath 'de.undercouch:gradle-download-task:4.1.1'
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/android/native/build.gradle
+++ b/android/native/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'de.undercouch.download'
 
 android {
-	compileSdkVersion 32
-	buildToolsVersion '32.0.0'
+	compileSdkVersion 33
+	buildToolsVersion '33.0.2'
 	ndkVersion "$ndk_version"
 	defaultConfig {
-		minSdkVersion 16
-		targetSdkVersion 32
+		minSdkVersion 21
+		targetSdkVersion 33
 		externalNativeBuild {
 			ndkBuild {
 				arguments '-j' + Runtime.getRuntime().availableProcessors(),


### PR DESCRIPTION
**Goal of the PR**
This PR increases minimum SDK version to 21, increases target/compiled SDK version to 33, and also updates Build Tools, NDK, and Gradle for Android build.

**How does the PR work?**
- Minimum SDK version: 16 -> 21
- Target/compiled SDK version: 32 -> 33
- Android Build Tools: 32.0.0 -> 33.0.2
- Android NDK: 25.1.8937393 (r25b) -> 25.2.9519653 (r25c)
- Gradle: 7.3.3 -> 7.5
- Android Gradle plugin (for Build Tools): 7.2.2 -> 7.4.1
- `androidx.appcompat:appcompat`: 1.5.1 -> 1.6.1

Reasons for choosing 21 (Lollipop, Android 5.0) for the minimum SDK version:
- NDK r26 (2023 LTS) will drop support for API level below 21. See android/ndk#1751
- [OpenGL ES 3.1 is supported since API level 21.](https://developer.android.com/develop/ui/views/graphics/opengl/about-opengl?hl=en)

From statistics collected [here](https://apilevels.com/), these changes still cover around 99.4% of Android users globally.

I have tested this before and found that the minetest/minetest_android_deps still works with this higher version. It is optional to be the same version as this PR (NDK r25c), but note that it might need to be updated for the upcoming NDK r26.

**Does it resolve any reported issue?**
Resolves #13137

Comparisons between related "block" (voxel) games on the Google Play Store:
| Name | Min. API Level |
| ---- | -------------- |
| [Minetest](https://play.google.com/store/apps/details?id=net.minetest.minetest) | `16` (4.1, current), `21` (5.0, this PR) |
| [Minecraft](https://play.google.com/store/apps/details?id=com.mojang.minecraftpe) | `21` (Android 5.0) |
| [Minecraft: Education Edition](https://play.google.com/store/apps/details?id=com.mojang.minecraftedu) | `26` (Android 8.0) |
| [MultiCraft](https://play.google.com/store/apps/details?id=com.multicraft.game) | `21` (Android 5.0) |
| [WorldCraft](https://play.google.com/store/apps/details?id=com.craftgames.worldcrft) | `21` (Android 5.0) |

**Does this relate to a goal in the roadmap?**
I do not know.

## To do
This PR is Ready for Review.

## How to test
1. Compile Minetest for Android.
2. There should be no compilation error and no regression.