### PR TITLE
Spread updating the drawlist over multiple frames.

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -204,6 +204,20 @@ ClientMap::VisbleBlockCalculator::VisbleBlockCalculator() :
 {
 }
 
+ClientMap::VisbleBlockCalculator::~VisbleBlockCalculator()
+{
+	for (auto &i : m_drawlist) {
+		MapBlock *block = i.second;
+		block->refDrop();
+	}
+	m_drawlist.clear();
+
+	for (auto &block : m_keeplist) {
+		block->refDrop();
+	}
+	m_keeplist.clear();
+}
+
 void ClientMap::VisbleBlockCalculator::start(v3f m_camera_position)
 {
 	blocks_occlusion_culled = 0;
@@ -235,22 +249,12 @@ void ClientMap::VisbleBlockCalculator::start(v3f m_camera_position)
 	blocks_seen.getChunk(camera_block).getBits(camera_block) = 0x07; // mark all sides as visible
 }
 
-void ClientMap::VisbleBlockCalculator::swap(std::map<v3s16, MapBlock*, MapBlockComparer> &other_drawlist, std::vector<MapBlock*> &other_keeplist)
+void ClientMap::VisbleBlockCalculator::swap(
+		std::map<v3s16, MapBlock*, MapBlockComparer> &other_drawlist,
+		std::vector<MapBlock*> &other_keeplist)
 {
 	m_keeplist.swap(other_keeplist);
 	m_drawlist.swap(other_drawlist);
-
-	for (auto &i : m_drawlist) {
-		MapBlock *block = i.second;
-		block->refDrop();
-	}
-	m_drawlist.clear();
-
-	for (auto &block : m_keeplist) {
-		block->refDrop();
-	}
-	m_keeplist.clear();
-
 }
 
 bool ClientMap::VisbleBlockCalculator::isFinished()
@@ -260,7 +264,7 @@ bool ClientMap::VisbleBlockCalculator::isFinished()
 
 bool ClientMap::VisbleBlockCalculator::step(int limit_ms)
 {
-	TimeTaker timer("clientmap");
+	TimeTaker timer("Visible Block Calculator");
 
 	// No occlusion culling when free_move is on and camera is inside ground
 	bool occlusion_culling_enabled = true;

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -198,13 +198,13 @@ void ClientMap::getBlocksInViewRange(v3s16 cam_pos_nodes,
 			p_nodes_max.Z / MAP_BLOCKSIZE + 1);
 }
 
-ClientMap::VisbleBlockCalculator::VisbleBlockCalculator() :
+ClientMap::VisibleBlockCalculator::VisibleBlockCalculator() :
 		blocks_seen(v3s16(0,0,0), v3s16(0,0,0)),
 		m_drawlist(MapBlockComparer(v3s16(0,0,0)))
 {
 }
 
-ClientMap::VisbleBlockCalculator::~VisbleBlockCalculator()
+ClientMap::VisibleBlockCalculator::~VisibleBlockCalculator()
 {
 	for (auto &i : m_drawlist) {
 		MapBlock *block = i.second;
@@ -218,7 +218,7 @@ ClientMap::VisbleBlockCalculator::~VisbleBlockCalculator()
 	m_keeplist.clear();
 }
 
-void ClientMap::VisbleBlockCalculator::start(v3f m_camera_position)
+void ClientMap::VisibleBlockCalculator::start(v3f m_camera_position)
 {
 	blocks_occlusion_culled = 0;
 	blocks_visited = 0;
@@ -249,7 +249,7 @@ void ClientMap::VisbleBlockCalculator::start(v3f m_camera_position)
 	blocks_seen.getChunk(camera_block).getBits(camera_block) = 0x07; // mark all sides as visible
 }
 
-void ClientMap::VisbleBlockCalculator::swap(
+void ClientMap::VisibleBlockCalculator::swap(
 		std::map<v3s16, MapBlock*, MapBlockComparer> &other_drawlist,
 		std::vector<MapBlock*> &other_keeplist)
 {
@@ -257,12 +257,12 @@ void ClientMap::VisbleBlockCalculator::swap(
 	m_drawlist.swap(other_drawlist);
 }
 
-bool ClientMap::VisbleBlockCalculator::isFinished()
+bool ClientMap::VisibleBlockCalculator::isFinished()
 {
 	return blocks_to_consider.empty();
 }
 
-bool ClientMap::VisbleBlockCalculator::step(int limit_ms)
+bool ClientMap::VisibleBlockCalculator::step(int limit_ms)
 {
 	TimeTaker timer("Visible Block Calculator");
 

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -115,7 +115,7 @@ public:
 
 	void getBlocksInViewRange(v3s16 cam_pos_nodes,
 		v3s16 *p_blocks_min, v3s16 *p_blocks_max, float range=-1.0f);
-	void updateDrawList(bool force_reset);
+	void updateDrawList(bool force_reset, float drawtime_avg);
 	// @brief Calculate statistics about the map and keep the blocks alive
 	void touchMapBlocks();
 	void updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length);
@@ -242,7 +242,7 @@ private:
 		VisibleBlockTracker(ClientMap *map);
 		~VisibleBlockTracker();
 		void start(v3f m_camera_position);
-		bool step(int limit_ms);
+		bool step(u64 limit_us);
 		void swap(std::map<v3s16, MapBlock*, MapBlockComparer> &other_drawlist, std::vector<MapBlock*> &other_keeplist);
 		bool isFinished();
 	private:

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -236,11 +236,11 @@ private:
 		v3s16 volume;
 	};
 
-	class VisbleBlockCalculator
+	class VisibleBlockCalculator
 	{
 	public:
-		VisbleBlockCalculator();
-		~VisbleBlockCalculator();
+		VisibleBlockCalculator();
+		~VisibleBlockCalculator();
 		void start(v3f m_camera_position);
 		void init(ClientMap *map)
 		{
@@ -301,5 +301,5 @@ private:
 	u16 m_cache_transparency_sorting_distance;
 
 	bool m_enable_raytraced_culling;
-	VisbleBlockCalculator m_calculator;
+	VisibleBlockCalculator m_calculator;
 };

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -240,6 +240,7 @@ private:
 	{
 	public:
 		VisbleBlockCalculator();
+		~VisbleBlockCalculator();
 		void start(v3f m_camera_position);
 		void init(ClientMap *map)
 		{

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -236,21 +236,19 @@ private:
 		v3s16 volume;
 	};
 
-	class VisibleBlockCalculator
+	class VisibleBlockTracker
 	{
 	public:
-		VisibleBlockCalculator();
-		~VisibleBlockCalculator();
+		VisibleBlockTracker(ClientMap *map);
+		~VisibleBlockTracker();
 		void start(v3f m_camera_position);
-		void init(ClientMap *map)
-		{
-			this->m_map = map;
-		}
 		bool step(int limit_ms);
 		void swap(std::map<v3s16, MapBlock*, MapBlockComparer> &other_drawlist, std::vector<MapBlock*> &other_keeplist);
 		bool isFinished();
 	private:
-		ClientMap *m_map = nullptr;
+		ClientMap *m_map;
+
+		/// The following are updated/reset by the start() method ///
 		std::queue<v3s16> blocks_to_consider;
 
 		// Bits per block:
@@ -262,8 +260,8 @@ private:
 		v3s16 p_blocks_min;
 		v3s16 p_blocks_max;
 
-		std::map<v3s16, MapBlock*, MapBlockComparer> m_drawlist;
-		std::vector<MapBlock*> m_keeplist;
+		std::map<v3s16, MapBlock*, MapBlockComparer> drawlist;
+		std::vector<MapBlock*> keeplist;
 
 		// Number of blocks occlusion culled
 		u32 blocks_occlusion_culled = 0;
@@ -271,7 +269,6 @@ private:
 		u32 blocks_visited = 0;
 		// Block sides that were not traversed
 		u32 sides_skipped = 0;
-
 	};
 
 	Client *m_client;
@@ -291,7 +288,7 @@ private:
 	std::map<v3s16, MapBlock*, MapBlockComparer> m_drawlist;
 	std::vector<MapBlock*> m_keeplist;
 	std::map<v3s16, MapBlock*> m_drawlist_shadow;
-	bool m_needs_update_drawlist;
+	bool m_needs_update_drawlist = false;
 
 	std::set<v2s16> m_last_drawn_sectors;
 
@@ -301,5 +298,5 @@ private:
 	u16 m_cache_transparency_sorting_distance;
 
 	bool m_enable_raytraced_culling;
-	VisibleBlockCalculator m_calculator;
+	VisibleBlockTracker m_visible_block_tracker;
 };

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4075,7 +4075,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		runData.touch_blocks_timer = 0;
 	}
 
-	if (RenderingEngine::get_shadow_renderer()) {
+	if (!draw_list_updated && RenderingEngine::get_shadow_renderer()) {
 		updateShadows();
 	}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4060,12 +4060,12 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	float update_draw_list_delta = 0.2f;
 
 	v3f camera_direction = camera->getDirection();
+	bool force_drawlist_reset = runData.update_draw_list_last_cam_dir.getDistanceFrom(camera_direction) > 0.2 || m_camera_offset_changed;
 	if (runData.update_draw_list_timer >= update_draw_list_delta
-			|| runData.update_draw_list_last_cam_dir.getDistanceFrom(camera_direction) > 0.2
-			|| m_camera_offset_changed
+			|| force_drawlist_reset
 			|| client->getEnv().getClientMap().needsUpdateDrawList()) {
 		runData.update_draw_list_timer = 0;
-		client->getEnv().getClientMap().updateDrawList();
+		client->getEnv().getClientMap().updateDrawList(force_drawlist_reset);
 		runData.update_draw_list_last_cam_dir = camera_direction;
 		draw_list_updated = true;
 	}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4065,7 +4065,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 			|| force_drawlist_reset
 			|| client->getEnv().getClientMap().needsUpdateDrawList()) {
 		runData.update_draw_list_timer = 0;
-		client->getEnv().getClientMap().updateDrawList(force_drawlist_reset);
+		client->getEnv().getClientMap().updateDrawList(force_drawlist_reset, stats->drawtime_avg);
 		runData.update_draw_list_last_cam_dir = camera_direction;
 		draw_list_updated = true;
 	}
@@ -4180,6 +4180,8 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	driver->endScene();
 
 	stats->drawtime = tt_draw.stop(true);
+	stats->drawtime_avg *= 0.99f;
+	stats->drawtime_avg += stats->drawtime * 0.01f;
 	g_profiler->graphAdd("Draw scene [us]", stats->drawtime);
 	g_profiler->avg("Game::updateFrame(): update frame [ms]", tt_update.stop(true));
 }

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -34,6 +34,7 @@ struct Jitter {
 
 struct RunStats {
 	u64 drawtime; // (us)
+	float drawtime_avg; // (us)
 
 	Jitter dtime_jitter, busy_time_jitter;
 };

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -301,46 +301,48 @@ public:
 
 		// Set uniforms for Shadow shader
 		if (ShadowRenderer *shadow = RenderingEngine::get_shadow_renderer()) {
-			const auto &light = shadow->getDirectionalLight();
+			if (shadow->getDirectionalLightCount() > 0) {
+				const auto &light = shadow->getDirectionalLight();
 
-			core::matrix4 shadowViewProj = light.getProjectionMatrix();
-			shadowViewProj *= light.getViewMatrix();
-			m_shadow_view_proj.set(shadowViewProj.pointer(), services);
+				core::matrix4 shadowViewProj = light.getProjectionMatrix();
+				shadowViewProj *= light.getViewMatrix();
+				m_shadow_view_proj.set(shadowViewProj.pointer(), services);
 
-			f32 v_LightDirection[3];
-			light.getDirection().getAs3Values(v_LightDirection);
-			m_light_direction.set(v_LightDirection, services);
+				f32 v_LightDirection[3];
+				light.getDirection().getAs3Values(v_LightDirection);
+				m_light_direction.set(v_LightDirection, services);
 
-			f32 TextureResolution = light.getMapResolution();
-			m_texture_res.set(&TextureResolution, services);
+				f32 TextureResolution = light.getMapResolution();
+				m_texture_res.set(&TextureResolution, services);
 
-			f32 ShadowStrength = shadow->getShadowStrength();
-			m_shadow_strength.set(&ShadowStrength, services);
+				f32 ShadowStrength = shadow->getShadowStrength();
+				m_shadow_strength.set(&ShadowStrength, services);
 
-			f32 timeOfDay = shadow->getTimeOfDay();
-			m_time_of_day.set(&timeOfDay, services);
+				f32 timeOfDay = shadow->getTimeOfDay();
+				m_time_of_day.set(&timeOfDay, services);
 
-			f32 shadowFar = shadow->getMaxShadowFar();
-			m_shadowfar.set(&shadowFar, services);
+				f32 shadowFar = shadow->getMaxShadowFar();
+				m_shadowfar.set(&shadowFar, services);
 
-			f32 cam_pos[4];
-			shadowViewProj.transformVect(cam_pos, light.getPlayerPos());
-			m_camera_pos.set(cam_pos, services);
+				f32 cam_pos[4];
+				shadowViewProj.transformVect(cam_pos, light.getPlayerPos());
+				m_camera_pos.set(cam_pos, services);
 
-			// I don't like using this hardcoded value. maybe something like
-			// MAX_TEXTURE - 1 or somthing like that??
-			s32 TextureLayerID = 3;
-			m_shadow_texture.set(&TextureLayerID, services);
+				// I don't like using this hardcoded value. maybe something like
+				// MAX_TEXTURE - 1 or somthing like that??
+				s32 TextureLayerID = 3;
+				m_shadow_texture.set(&TextureLayerID, services);
 
-			f32 bias0 = shadow->getPerspectiveBiasXY();
-			m_perspective_bias0_vertex.set(&bias0, services);
-			m_perspective_bias0_pixel.set(&bias0, services);
-			f32 bias1 = 1.0f - bias0 + 1e-5f;
-			m_perspective_bias1_vertex.set(&bias1, services);
-			m_perspective_bias1_pixel.set(&bias1, services);
-			f32 zbias = shadow->getPerspectiveBiasZ();
-			m_perspective_zbias_vertex.set(&zbias, services);
-			m_perspective_zbias_pixel.set(&zbias, services);
+				f32 bias0 = shadow->getPerspectiveBiasXY();
+				m_perspective_bias0_vertex.set(&bias0, services);
+				m_perspective_bias0_pixel.set(&bias0, services);
+				f32 bias1 = 1.0f - bias0 + 1e-5f;
+				m_perspective_bias1_vertex.set(&bias1, services);
+				m_perspective_bias1_pixel.set(&bias1, services);
+				f32 zbias = shadow->getPerspectiveBiasZ();
+				m_perspective_zbias_vertex.set(&zbias, services);
+				m_perspective_zbias_pixel.set(&zbias, services);
+			}
 		}
 	}
 };


### PR DESCRIPTION
ClientMap::updateDrawList can be expensive for larger distances. Easily 30ms or more on my fairly fast machine.

So this does two things:
1. Make the recursive culler "interruptible".
2. Give each invocation a 5ms budget. 5ms tested nicely (by itself it would still allow 200 FPS).

## To do

This PR is Ready for Review

- [x] Bit more testing
- [x] I have observed one-frame "flashes" when the camera pans around quickly. Probably due to the frustum culler re-fetched at each partial invocation.
- [x] Need to figure out how to store a lambda as member, or turn the frustum-culler into a struct/functor instead.
- [x] Check for memory leaks.
- [x] Think up a better heuristic for the time budget. Is 5ms always good? What about slower machines? Maybe allow for x% for the frame time?

## How to test

Load any world. Set a large view_range (and the matching server settings). I tried with 1000(!) and client_mesh_chunk set of 8 (but you'll see the improvement with smaller values too).
Observe how updateDrawList is smoothed out over multiple frame, reducing the visible jitter.
