### PR TITLE
Reduce server CPU consumption with large view_ranges

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -175,19 +175,14 @@ void RemoteClient::GetNextBlocks (
 	if (m_last_center != center) {
 		m_nearest_unsent_d = 0;
 		m_last_center = center;
-		m_blocks_occ.clear();
 	}
 	// reset the unsent distance if the view angle has changed more that 10% of the fov
 	// (this matches isBlockInSight which allows for an extra 10%)
 	if (camera_dir.dotProduct(m_last_camera_dir) < std::cos(camera_fov * 0.1f)) {
 		m_nearest_unsent_d = 0;
 		m_last_camera_dir = camera_dir;
-		m_blocks_occ.clear();
 	}
 	if (m_nearest_unsent_d > 0) {
-		if (!m_blocks_modified.empty()) {
-			m_blocks_occ.clear();
-		}
 		// make sure any blocks modified since the last time we sent blocks are resent
 		for (const v3s16 &p : m_blocks_modified) {
 			m_nearest_unsent_d = std::min(m_nearest_unsent_d, center.getDistanceFrom(p));
@@ -403,8 +398,10 @@ queue_full_break:
 		}
 	}
 
-	if (new_nearest_unsent_d != -1)
+	if (new_nearest_unsent_d != -1 && m_nearest_unsent_d != new_nearest_unsent_d) {
 		m_nearest_unsent_d = new_nearest_unsent_d;
+		m_blocks_occ.clear();
+	}
 }
 
 void RemoteClient::GotBlock(v3s16 p)

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -168,6 +168,9 @@ void RemoteClient::GetNextBlocks (
 	// Get view range and camera fov (radians) from the client
 	s16 wanted_range = sao->getWantedRange() + 1;
 	float camera_fov = sao->getFov();
+	// in case the wanted_range was decreased by the client
+	if (m_blocks_occ.size() > wanted_range)
+		m_blocks_occ.resize(wanted_range);
 
 	/*
 		Get the starting value of the block finder radius.
@@ -175,17 +178,34 @@ void RemoteClient::GetNextBlocks (
 	if (m_last_center != center) {
 		m_nearest_unsent_d = 0;
 		m_last_center = center;
+		// clear occlusion cache when we moved
+		m_blocks_occ.clear();
 	}
 	// reset the unsent distance if the view angle has changed more that 10% of the fov
 	// (this matches isBlockInSight which allows for an extra 10%)
 	if (camera_dir.dotProduct(m_last_camera_dir) < std::cos(camera_fov * 0.1f)) {
 		m_nearest_unsent_d = 0;
 		m_last_camera_dir = camera_dir;
+		// clear occlusion cache when we're looking somewhere else
+		m_blocks_occ.clear();
 	}
-	if (m_nearest_unsent_d > 0) {
+
+	if (!m_blocks_modified.empty()) {
 		// make sure any blocks modified since the last time we sent blocks are resent
+		s16 nearest_unsent_d = wanted_range;
 		for (const v3s16 &p : m_blocks_modified) {
-			m_nearest_unsent_d = std::min(m_nearest_unsent_d, center.getDistanceFrom(p));
+			nearest_unsent_d = std::min(nearest_unsent_d, center.getDistanceFrom(p));
+		}
+		if (nearest_unsent_d < m_nearest_unsent_d) {
+			m_nearest_unsent_d = nearest_unsent_d;
+
+			/*
+				We know that no visible block nearer than nearest_unsent_d has changed,
+				so visibility up to that has to be the same.
+				We already cleared the offending block(s) in SetBlock(s)NotSent
+				So any blocks that might become visible are farther away that this.
+			*/
+			m_blocks_occ.resize(nearest_unsent_d + 1);
 		}
 	}
 	m_blocks_modified.clear();
@@ -230,6 +250,10 @@ void RemoteClient::GetNextBlocks (
 	//bool queue_is_full = false;
 
 	const v3s16 cam_pos_nodes = floatToInt(camera_pos, BS);
+
+	// ensure space for this iteration
+	if (m_blocks_occ.size() < d_max + 1)
+		m_blocks_occ.resize(d_max + 1);
 
 	s16 d;
 	for (d = d_start; d <= d_max; d++) {
@@ -301,6 +325,12 @@ void RemoteClient::GetNextBlocks (
 				continue;
 
 			/*
+				Or blocks we already have occlusion culled
+			*/
+			if (m_blocks_occ[d].find(p) != m_blocks_occ[d].end())
+				continue;
+
+			/*
 				Check if map has this block
 			*/
 			MapBlock *block = env->getMap().getBlockNoCreateNoEx(p);
@@ -326,15 +356,9 @@ void RemoteClient::GetNextBlocks (
 						continue;
 				}
 
-				/*
-					Check occlusion cache first
-				*/
-				if (m_blocks_occ.find(p) != m_blocks_occ.end())
-					continue;
-
 				if (m_occ_cull && !block_not_found &&
 						env->getMap().isBlockOccluded(block, cam_pos_nodes)) {
-					m_blocks_occ.insert(p);
+					m_blocks_occ[d].insert(p);
 					continue;
 				}
 			}
@@ -398,12 +422,8 @@ queue_full_break:
 		}
 	}
 
-	if (new_nearest_unsent_d != -1 && m_nearest_unsent_d != new_nearest_unsent_d) {
+	if (new_nearest_unsent_d != -1)
 		m_nearest_unsent_d = new_nearest_unsent_d;
-		if (num_blocks_selected > 0)
-			// if the distance changes and we sent something, reset the occlusion cache
-			m_blocks_occ.clear();
-	}
 }
 
 void RemoteClient::GotBlock(v3s16 p)
@@ -433,8 +453,16 @@ void RemoteClient::SetBlockNotSent(v3s16 p)
 
 	// remove the block from sending and sent sets,
 	// and mark as modified if found
-	if (m_blocks_sending.erase(p) + m_blocks_sent.erase(p) > 0)
+	if (m_blocks_sending.erase(p) + m_blocks_sent.erase(p) > 0) {
 		m_blocks_modified.insert(p);
+		// if the block was visible it could have occluded other blocks
+		// so clear it from the cache
+		for (auto &occ : m_blocks_occ) {
+			if (occ.erase(p) > 0) {
+				break;
+			}
+		}
+	}
 }
 
 void RemoteClient::SetBlocksNotSent(std::map<v3s16, MapBlock*> &blocks)
@@ -445,8 +473,16 @@ void RemoteClient::SetBlocksNotSent(std::map<v3s16, MapBlock*> &blocks)
 		v3s16 p = block.first;
 		// remove the block from sending and sent sets,
 		// and mark as modified if found
-		if (m_blocks_sending.erase(p) + m_blocks_sent.erase(p) > 0)
+		if (m_blocks_sending.erase(p) + m_blocks_sent.erase(p) > 0) {
 			m_blocks_modified.insert(p);
+			// if the block was visible it could have occluded other blocks
+			// so clear it from the cache
+			for (auto &occ : m_blocks_occ) {
+				if (occ.erase(p) > 0) {
+					break;
+				}
+			}
+		}
 	}
 }
 

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -295,12 +295,6 @@ void RemoteClient::GetNextBlocks (
 			}
 
 			/*
-				Don't send already sent blocks
-			*/
-			if (m_blocks_sent.find(p) != m_blocks_sent.end())
-				continue;
-
-			/*
 				Check if map has this block
 			*/
 			MapBlock *block = env->getMap().getBlockNoCreateNoEx(p);
@@ -309,6 +303,12 @@ void RemoteClient::GetNextBlocks (
 			if (block) {
 				// Reset usage timer, this block will be of use in the future.
 				block->resetUsageTimer();
+
+				/*
+					Don't send already sent blocks
+				*/
+				if (m_blocks_sent.find(p) != m_blocks_sent.end())
+					continue;
 
 				// Check whether the block exists (with data)
 				if (!block->isGenerated())

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -301,12 +301,6 @@ void RemoteClient::GetNextBlocks (
 				continue;
 
 			/*
-				Or blocks we already have occlusion culled
-			*/
-			if (m_blocks_occ.find(p) != m_blocks_occ.end())
-				continue;
-
-			/*
 				Check if map has this block
 			*/
 			MapBlock *block = env->getMap().getBlockNoCreateNoEx(p);
@@ -331,6 +325,12 @@ void RemoteClient::GetNextBlocks (
 					if (!block->getIsUnderground() && !block->getDayNightDiff())
 						continue;
 				}
+
+				/*
+					Check occlusion cache first
+				*/
+				if (m_blocks_occ.find(p) != m_blocks_occ.end())
+					continue;
 
 				if (m_occ_cull && !block_not_found &&
 						env->getMap().isBlockOccluded(block, cam_pos_nodes)) {

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -175,12 +175,14 @@ void RemoteClient::GetNextBlocks (
 	if (m_last_center != center) {
 		m_nearest_unsent_d = 0;
 		m_last_center = center;
+		m_blocks_occ.clear();
 	}
 	// reset the unsent distance if the view angle has changed more that 10% of the fov
 	// (this matches isBlockInSight which allows for an extra 10%)
 	if (camera_dir.dotProduct(m_last_camera_dir) < std::cos(camera_fov * 0.1f)) {
 		m_nearest_unsent_d = 0;
 		m_last_camera_dir = camera_dir;
+		m_blocks_occ.clear();
 	}
 	if (m_nearest_unsent_d > 0) {
 		// make sure any blocks modified since the last time we sent blocks are resent
@@ -300,6 +302,9 @@ void RemoteClient::GetNextBlocks (
 			if (m_blocks_sent.find(p) != m_blocks_sent.end())
 				continue;
 
+			if (m_blocks_occ.find(p) != m_blocks_occ.end())
+				continue;
+
 			/*
 				Check if map has this block
 			*/
@@ -328,6 +333,7 @@ void RemoteClient::GetNextBlocks (
 
 				if (m_occ_cull && !block_not_found &&
 						env->getMap().isBlockOccluded(block, cam_pos_nodes)) {
+					m_blocks_occ.insert(p);
 					continue;
 				}
 			}

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -185,6 +185,9 @@ void RemoteClient::GetNextBlocks (
 		m_blocks_occ.clear();
 	}
 	if (m_nearest_unsent_d > 0) {
+		if (!m_blocks_modified.empty()) {
+			m_blocks_occ.clear();
+		}
 		// make sure any blocks modified since the last time we sent blocks are resent
 		for (const v3s16 &p : m_blocks_modified) {
 			m_nearest_unsent_d = std::min(m_nearest_unsent_d, center.getDistanceFrom(p));
@@ -302,6 +305,9 @@ void RemoteClient::GetNextBlocks (
 			if (m_blocks_sent.find(p) != m_blocks_sent.end())
 				continue;
 
+			/*
+				Or blocks we already have occlusion culled
+			*/
 			if (m_blocks_occ.find(p) != m_blocks_occ.end())
 				continue;
 

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -400,7 +400,9 @@ queue_full_break:
 
 	if (new_nearest_unsent_d != -1 && m_nearest_unsent_d != new_nearest_unsent_d) {
 		m_nearest_unsent_d = new_nearest_unsent_d;
-		m_blocks_occ.clear();
+		if (num_blocks_selected > 0)
+			// if the distance changes and we sent something, reset the occlusion cache
+			m_blocks_occ.clear();
 	}
 }
 

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -32,6 +32,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <list>
 #include <vector>
 #include <set>
+#include <unordered_set>
 #include <memory>
 #include <mutex>
 
@@ -372,7 +373,15 @@ private:
 		List of block positions.
 		No MapBlock* is stored here because the blocks can get deleted.
 	*/
-	std::set<v3s16> m_blocks_sent;
+	std::unordered_set<v3s16> m_blocks_sent;
+
+	/*
+		Cache of blocks that have been occlusion culled. Occlusion culling is expensive.
+		Similar to m_blocks_sent, these represent blocks that would have been sent to the client.
+		Reset when the player moves or changes view-direction.
+	 */
+	std::unordered_set<v3s16> m_blocks_occ;
+
 	s16 m_nearest_unsent_d = 0;
 	v3s16 m_last_center;
 	v3f m_last_camera_dir;
@@ -392,7 +401,7 @@ private:
 		Block is removed when GOTBLOCKS is received.
 		Value is time from sending. (not used at the moment)
 	*/
-	std::map<v3s16, float> m_blocks_sending;
+	std::unordered_map<v3s16, float> m_blocks_sending;
 
 	/*
 		Blocks that have been modified since blocks were
@@ -402,7 +411,7 @@ private:
 
 		List of block positions.
 	*/
-	std::set<v3s16> m_blocks_modified;
+	std::unordered_set<v3s16> m_blocks_modified;
 
 	/*
 		Count of excess GotBlocks().

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -376,9 +376,9 @@ private:
 	std::unordered_set<v3s16> m_blocks_sent;
 
 	/*
-		Cache of blocks that have been occlusion culled. Occlusion culling is expensive.
-		Similar to m_blocks_sent, these represent blocks that would have been sent to the client.
-		Reset when the player moves or changes view-direction.
+		Cache of blocks that have been occlusion culled at the current distance.
+		As GetNextBlocks traverses the same distance multiple times, this saves
+		significant CPU time.
 	 */
 	std::unordered_set<v3s16> m_blocks_occ;
 

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -376,11 +376,13 @@ private:
 	std::unordered_set<v3s16> m_blocks_sent;
 
 	/*
-		Cache of blocks that have been occlusion culled at the current distance.
-		As GetNextBlocks traverses the same distance multiple times, this saves
-		significant CPU time.
+		Cache of blocks that have been occlusion culled partitioned by distance/layer.
+		Occlusion culling is expensive.
+		Reset when the player moves or changes view-direction.
+		Outer layers are reset when blocks in inner layers that were visible to the client
+		have been changed, as they could have occluded farther blocks.
 	 */
-	std::unordered_set<v3s16> m_blocks_occ;
+	std::vector<std::unordered_set<v3s16>> m_blocks_occ;
 
 	s16 m_nearest_unsent_d = 0;
 	v3s16 m_last_center;

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -376,13 +376,11 @@ private:
 	std::unordered_set<v3s16> m_blocks_sent;
 
 	/*
-		Cache of blocks that have been occlusion culled partitioned by distance/layer.
-		Occlusion culling is expensive.
-		Reset when the player moves or changes view-direction.
-		Outer layers are reset when blocks in inner layers that were visible to the client
-		have been changed, as they could have occluded farther blocks.
+		Cache of blocks that have been occlusion culled at the current distance.
+		As GetNextBlocks traverses the same distance multiple times, this saves
+		significant CPU time.
 	 */
-	std::vector<std::unordered_set<v3s16>> m_blocks_occ;
+	std::unordered_set<v3s16> m_blocks_occ;
 
 	s16 m_nearest_unsent_d = 0;
 	v3s16 m_last_center;


### PR DESCRIPTION
The remote client spends a lot of time in occlusion culling. In a sense that is good, all these blocks would have otherwise been sent to the client.

On the other hand... As the number of blocks culled gets large, this gets quite expensive as the server has to the check the same blocks over and over again.

So here we cache these. This is similar to m_blocks_sent (the set of the blocks that the client has), as these would be blocks the client would have if they were not culled.

Since the remote client cannot sent while it is collecting blocks, this speeds up sending blocks to the client significantly.
(time collecting blocks went from 1.5s to 300ms in my case).

The set has to be reset each time the player moved or changes the camera angle.

This also switches the other collections from ordered to unordered for performance.

## How to test

Load any world. Make sure no blocks are missing.
