### PR TITLE
Remove nonsensical editorconfig setting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,6 @@ end_of_line = lf
 
 [*.{cpp,h,lua,txt,glsl,md,c,cmake,java,gradle}]
 charset = utf8
-indent_size = 4
 indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
For indent_style=tab, indent_size doesn’t make much sense as it wouldn’t affect file content in any way. Unless one tries to align with tabs that is, but such attempts are nonsensical anyway (except of elastic tabs but these aren’t widely supported).