### PR TITLE
Fix typo and missing entry in serveropcodes

### DIFF
--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -219,7 +219,8 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_factory, // 0x5d
 	null_command_factory, // 0x5e
 	null_command_factory, // 0x5f
-	{ "TOSERVER_SRP_BYTES_S_B",            0, true }, // 0x60
+	{ "TOCLIENT_SRP_BYTES_S_B",            0, true }, // 0x60
 	{ "TOCLIENT_FORMSPEC_PREPEND",         0, true }, // 0x61
 	{ "TOCLIENT_MINIMAP_MODES",            0, true }, // 0x62
+	{ "TOCLIENT_SET_LIGHTING",             0, true }, // 0x63
 };


### PR DESCRIPTION
Adds missing entry for TOCLIENT_SET_LIGHTING. I assumed the command is meant to be sent reliably, since other commands of this kind are. Because of the missing entry, it is likely that TOCLIENT_SET_LIGHTING is currently being sent on channel 0, unreliable. So this is a slight protocol change.
