### PR TITLE
Fix rounding errors when slicing the shadow draw list

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -978,9 +978,10 @@ void ClientMap::renderMapShadows(video::IVideoDriver *driver,
 	std::vector<DrawDescriptor> draw_order;
 
 
-	int count = 0;
-	int low_bound = is_transparent_pass ? 0 : m_drawlist_shadow.size() / total_frames * frame;
-	int high_bound = is_transparent_pass ? m_drawlist_shadow.size() : m_drawlist_shadow.size() / total_frames * (frame + 1);
+	std::size_t count = 0;
+	std::size_t meshes_per_frame = m_drawlist_shadow.size() / total_frames + 1;
+	std::size_t low_bound = is_transparent_pass ? 0 : meshes_per_frame * frame;
+	std::size_t high_bound = is_transparent_pass ? m_drawlist_shadow.size() : meshes_per_frame * (frame + 1);
 
 	// transparent pass should be rendered in one go
 	if (is_transparent_pass && frame != total_frames - 1) {


### PR DESCRIPTION
Fix rounding errors when splitting the shadow draw list for incremental update between frames. When the number of meshes in the list was smaller than the number of frames, the shadows would not be drawn at all. The problem is easy to reproduce with client_mesh_chunk = 8.

## To do

This PR is Ready for Review.

## How to test

1. Set client_mesh_chunk = 8
2. Enable shadows at any quality
3. Shadows must be rendered no matter how many blocks / meshes are in the shadow draw list.
