### PR TITLE
Add libjpeg-turbo-devel to fedora deps <DO NOT CLOSE THIS ONE>

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ For Debian/Ubuntu users:
 
 For Fedora users:
 
-    sudo dnf install make automake gcc gcc-c++ kernel-devel cmake libcurl-devel openal-soft-devel libvorbis-devel libXi-devel libogg-devel freetype-devel mesa-libGL-devel zlib-devel jsoncpp-devel gmp-devel sqlite-devel luajit-devel leveldb-devel ncurses-devel spatialindex-devel libzstd-devel
+    sudo dnf install make automake gcc gcc-c++ kernel-devel cmake libcurl-devel openal-soft-devel libvorbis-devel libXi-devel libogg-devel freetype-devel mesa-libGL-devel zlib-devel jsoncpp-devel gmp-devel sqlite-devel luajit-devel leveldb-devel ncurses-devel spatialindex-devel libzstd-devel libjpeg-turbo-devel
 
 For Arch users:
 


### PR DESCRIPTION
<DO NOT CLOSE THIS ONE>
libjpeg-turbo-devel IS REQUIRED to compile the game on fedora, people shouldn't have to go out of their way to figure out what this means on fedora workstations when trying to compile this game, this has been opened like 3 times, just add it in already.

Add compact, short information about your PR for easier understanding:

- Goal of the PR
Let's people compile this game engine on fedora workstations.
- How does the PR work?
Tells people that libjpeg-turbo-devel is required so they can compile the game on fedora workstations.
- Does it resolve any reported issue?
It resolved my issue trying to compile the game on fedora 36 and 37 workstations.
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
No idea.
- If not a bug fix, why is this PR needed? What usecases does it solve?
Because libjpeg-turbo-devel is required to compile the game on fedora workstations.


This PR is a Work in Ready for people to use libjpeg-turbo-devel.

- [X] Add
- [X] libjpeg-turbo-devel
- [X] To
- [X] Fedora
- [X] Deps

## How to test
Try to compile this thing on fedora 36 and 37 without libjpeg-turbo-devel. You can't
<!-- Example code or instructions -->
```sudo dnf install libjpeg-turbo-devel```
