### PR TITLE
Throw Hopcroft-Karp at shapeless craft recipes

### DIFF
--- a/src/craftdef.h
+++ b/src/craftdef.h
@@ -266,7 +266,7 @@ private:
 	std::string output;
 	// Recipe list (itemstrings)
 	std::vector<std::string> recipe;
-	// Recipe list (item names)
+	// Recipe list (item names), sorted
 	std::vector<std::string> recipe_names;
 	// bool indicating if initHash has been called already
 	bool hash_inited = false;

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -8,6 +8,7 @@ set (UNITTEST_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/test_collision.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_compression.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_connection.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/test_craft.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_filepath.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_inventory.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_irrptr.cpp

--- a/src/unittest/test_craft.cpp
+++ b/src/unittest/test_craft.cpp
@@ -1,0 +1,275 @@
+/*
+Minetest
+Copyright (C) 2023 DS
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "test.h"
+
+#include "craftdef.h"
+
+class TestCraft : public TestBase
+{
+public:
+	TestCraft() { TestManager::registerTestModule(this); }
+	const char *getName() { return "TestCraft"; }
+
+	void runTests(IGameDef *gamedef);
+
+	static std::string getDumpedCraftResult(CraftInput input, IGameDef *gamedef);
+	static void registerItemWithGroups(const std::string &itemname,
+			const std::vector<std::string> &groups, IGameDef *gamedef);
+
+	void testShapeless(IGameDef *gamedef);
+};
+
+static TestCraft g_test_instance;
+
+void TestCraft::runTests(IGameDef *gamedef)
+{
+	TEST(testShapeless, gamedef);
+}
+
+std::string TestCraft::getDumpedCraftResult(CraftInput input, IGameDef *gamedef)
+{
+	// (input is passed by value, because getCraftResult needs a non-const ref
+	// for decrementing input)
+
+	IWritableCraftDefManager *cdef = (IWritableCraftDefManager *)gamedef->getCraftDefManager();
+
+	CraftOutput output{};
+	std::vector<ItemStack> output_replacements;
+
+	cdef->getCraftResult(input, output, output_replacements, false, gamedef);
+
+	return output.dump();
+}
+
+void TestCraft::registerItemWithGroups(const std::string &itemname,
+		const std::vector<std::string> &groups, IGameDef *gamedef)
+{
+	IWritableItemDefManager *idef = (IWritableItemDefManager *)gamedef->getItemDefManager();
+
+	if (idef->isKnown(itemname)) {
+		// already registered. check that the groups match
+		const ItemDefinition &itemdef = idef->get(itemname);
+
+		SANITY_CHECK(itemdef.groups.size() == groups.size());
+		for (const auto &g : groups) {
+			auto it = itemdef.groups.find(g);
+			SANITY_CHECK(it != itemdef.groups.end());
+			SANITY_CHECK(it->second == 1);
+		}
+
+	} else {
+		// register it
+		ItemDefinition itemdef{};
+
+		itemdef.type = ITEM_CRAFT;
+		itemdef.name = itemname;
+		itemdef.description = itemname;
+		for (const auto &g : groups)
+			itemdef.groups[g] = 1;
+		idef->registerItem(itemdef);
+	}
+}
+
+void TestCraft::testShapeless(IGameDef *gamedef)
+{
+	IWritableItemDefManager *idef = (IWritableItemDefManager *)gamedef->getItemDefManager();
+	IWritableCraftDefManager *cdef = (IWritableCraftDefManager *)gamedef->getCraftDefManager();
+
+	auto to_item = [&](const std::string &itemstring) -> ItemStack {
+		ItemStack item;
+		item.deSerialize(itemstring, idef);
+		return item;
+	};
+
+	cdef->clear();
+
+	idef->registerAlias("crafttest:a1", "crafttest:i1");
+	registerItemWithGroups("crafttest:i1", {}, gamedef);
+	registerItemWithGroups("crafttest:i2", {}, gamedef);
+	registerItemWithGroups("crafttest:i3", {}, gamedef);
+	registerItemWithGroups("crafttest:i4", {}, gamedef);
+	registerItemWithGroups("crafttest:g1g2", {"crafttest_g1", "crafttest_g2"}, gamedef);
+
+	cdef->registerCraft(new CraftDefinitionShapeless(
+				"crafttest:i1",
+				{
+					"crafttest:i1",
+					"crafttest:a1",
+				},
+				CraftReplacements{}
+			), gamedef);
+
+	cdef->registerCraft(new CraftDefinitionShapeless(
+				"crafttest:i2",
+				{
+					"crafttest:i2",
+					"crafttest:i1",
+					"crafttest:i2",
+					"crafttest:i1",
+					"crafttest:i2",
+					"crafttest:i1",
+					"crafttest:i2",
+					"crafttest:i1",
+					"crafttest:i2",
+					"crafttest:i1",
+					"crafttest:i2",
+					"crafttest:i1",
+				},
+				CraftReplacements{}
+			), gamedef);
+
+	cdef->registerCraft(new CraftDefinitionShapeless(
+				"crafttest:i3",
+				{
+					"crafttest:i2",
+					"crafttest:i1",
+					"crafttest:i2",
+					"group:crafttest_g1",
+				},
+				CraftReplacements{}
+			), gamedef);
+
+	cdef->registerCraft(new CraftDefinitionShapeless(
+				"crafttest:i4",
+				{
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+					"group:crafttest_g2",
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+					"group:crafttest_g1",
+				},
+				CraftReplacements{}
+			), gamedef);
+
+	UASSERTEQ(std::string, getDumpedCraftResult(CraftInput(CRAFT_METHOD_NORMAL, 3,
+			{
+				to_item("crafttest:i1"),
+				to_item("crafttest:i1"),
+			}), gamedef),
+			"(item=\"crafttest:i1\", time=0)");
+
+	cdef->initHashes(gamedef);
+
+	UASSERTEQ(std::string, getDumpedCraftResult(CraftInput(CRAFT_METHOD_NORMAL, 3,
+			{
+				to_item("crafttest:i1"),
+				to_item("crafttest:i1"),
+			}), gamedef),
+			"(item=\"crafttest:i1\", time=0)");
+
+	UASSERTEQ(std::string, getDumpedCraftResult(CraftInput(CRAFT_METHOD_NORMAL, 3,
+			{
+				to_item("crafttest:i1"),
+				to_item(""),
+				to_item("crafttest:i1"),
+			}), gamedef),
+			"(item=\"crafttest:i1\", time=0)");
+
+	UASSERTEQ(std::string, getDumpedCraftResult(CraftInput(CRAFT_METHOD_NORMAL, 4,
+			{
+				to_item("crafttest:i1"),
+				to_item("crafttest:i1"),
+			}), gamedef),
+			"(item=\"crafttest:i1\", time=0)");
+
+	UASSERTEQ(std::string, getDumpedCraftResult(CraftInput(CRAFT_METHOD_NORMAL, 3,
+			{
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+			}), gamedef),
+			"(item=\"crafttest:i2\", time=0)");
+
+	UASSERTEQ(std::string, getDumpedCraftResult(CraftInput(CRAFT_METHOD_NORMAL, 4,
+			{
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+			}), gamedef),
+			"(item=\"crafttest:i2\", time=0)");
+
+	UASSERTEQ(std::string, getDumpedCraftResult(CraftInput(CRAFT_METHOD_NORMAL, 3,
+			{
+				to_item("crafttest:i2"),
+				to_item("crafttest:i1"),
+				to_item("crafttest:i2"),
+				to_item("crafttest:g1g2"),
+			}), gamedef),
+			"(item=\"crafttest:i3\", time=0)");
+
+	UASSERTEQ(std::string, getDumpedCraftResult(CraftInput(CRAFT_METHOD_NORMAL, 3,
+			{
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:i1"),
+				to_item("crafttest:i2"),
+				to_item("crafttest:i2"),
+			}), gamedef),
+			"(item=\"crafttest:i3\", time=0)");
+
+	UASSERTEQ(std::string, getDumpedCraftResult(CraftInput(CRAFT_METHOD_NORMAL, 3,
+			{
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+				to_item("crafttest:g1g2"),
+			}), gamedef),
+			"(item=\"crafttest:i4\", time=0)");
+}


### PR DESCRIPTION
Fixes performance for shapeless recipes with groups.
Fixes #11224.

The reason why it was so slow is that the craft check tries out all permutations of the recipe. In the worst case, that's 9! = 362880 possibilities.
In the best case, there are no groups and the first permutation matches because recipe and input are sorted. And the prefiltering works perfectly, so the check will always pass.
If there is at least one group however, the prefiltering just filters by count, and well, it gets bad. In the test code, I've used many different items, to create more permutations.

Fixing this is not hard. Each input item can satisfy some recipe slots. If you imagine the input and recipe slots as nodes in a graph, and the satisfaction relationships as edges, you get a bipartite graph. We just have to find out if we can find a matching in this bipartite graph that matches every node. Finding a maximum-cardinality matching in a bipartite graph is easy, i.e. by using the hopcroft-karp algorithm. See <https://en.wikipedia.org/w/index.php?title=Hopcroft%E2%80%93Karp_algorithm&useskin=vector>.

I've also added code to filter out non-recipe slots, as that's simply a cheap sorted merge.

Note that there can still be done more to do for faster crafting (it's still super slow, i.e. 200us for a single craft check), i.e. better filtering, and also caching. I've already planned to do a PR for the former.

## To do

This PR is a Ready for Review.

For reviewing, you can compare my code with the pseudocode on wikipedia, as it's almost the same: <https://en.wikipedia.org/w/index.php?title=Hopcroft%E2%80%93Karp_algorithm&useskin=vector#Pseudocode>

## How to test

### For performance:
```lua
minetest.after(1, function()
	minetest.log("[bench_craft] doing...")

	local input = {
			method = "normal",
			width = 3,
			items = {
				"default:stone", "default:cobble", "default:cobble",
				"default:stone", "default:cobble", "default:cobble",
				"default:stone", "default:cobble", "default:cobble",
			},
		}

	local t0 = minetest.get_us_time() * 1e-6

	minetest.get_craft_result(input)

	local t1 = minetest.get_us_time() * 1e-6

	minetest.log("[bench_craft] it took "..((t1-t0) * 1e6).." us")
end)

-- comment this out to compare the difference
minetest.register_craft({
	type = "shapeless",
	output = "default:dirt",
	recipe = {
		"group:wood", "default:tree", "default:stick",
		"default:leaves", "default:dirt", "default:dirt_with_grass",
		"group:stone", "default:cobble", "default:cactus",
	},
})
```
In master, the recipe adds about 80 ms (milliseconds!) to the single `get_craft_result` call.
With the PR, the added recipe makes no significant difference.

### For correctness:
* Look through the code.
* Try out your favourite craft recipes.
* Run the unittest: `$ minetest --run-unittests`

I've also compared the results of my implementation of the algorithm with a the results of a lib that can compute the same: <https://luarocks.org/modules/chen0040/luagraphs>
(I first wanted to compare to boost, but that's too complicated for me now.)
To run the test, follow the following steps:
* Install luagraphs: luarocks install luagraphs.
* Fetch and build this branch: <https://github.com/Desour/minetest/tree/craft_bip_match_test_compare>
* Create a new mod with the following code in init.lua:
<details>

```lua

local ffi = require("ffi")

ffi.cdef([[
int ffi_hopcroft_karp_num_matches(const bool *bip_graph_arr, int graph_size);
]])

local luagraphs_data_network = require('luagraphs.data.network')
local luagraphs_flow_FordFulkerson = require('luagraphs.flow.FordFulkerson')

local function max_flow_my(matrix, size)
	local bip_graph_arr = ffi.new("bool[81]", matrix)

	return ffi.C.ffi_hopcroft_karp_num_matches(bip_graph_arr, size)
end

local function max_flow_luagraphs(matrix, size)
	local num_nodes = 1+size+size+1
	local s = 0
	local t = num_nodes-1
	local u_min = 1
	local u_max = u_min+size-1
	local v_min = u_max+1
	local v_max = v_min+size-1
	assert(v_max+1 == t)

	local g = luagraphs_data_network.FlowNetwork.create(num_nodes)

	for u = u_min, u_max do
		g:addEdge(s, u, 1)
	end
	for v = v_min, v_max do
		g:addEdge(v, t, 1)
	end

	for u = 0, size-1 do
		for v = 0, size-1 do
			if matrix[u*9+v] then
				g:addEdge(u_min+u, v_min+v, 1)
			end
		end
	end

	local method = luagraphs_flow_FordFulkerson.create()
	return method:run(g, s, t)
end


minetest.after(1, function()
	minetest.log("sarting...")
	math.randomseed(35134) -- change this

	local matrix = {}
	for i = 0, 81-1 do
		matrix[i] = false
	end

	for i = 1, 10000 do
		local size = math.random(9)
		local fill_rate = math.random()

		for u = 0, size-1 do
			for v = 0, size-1 do
				matrix[u*9+v] = math.random() > fill_rate
			end
		end

		local result_my = max_flow_my(matrix, size)
		local result_luagraphs = max_flow_luagraphs(matrix, size)
		if result_my ~= result_luagraphs then
			minetest.log("oh no!")
			minetest.log(string.format("%s ~= %s", result_my, result_luagraphs))
			--~ minetest.log(dump({size = size, matrix = matrix}))
			return
		end
	end

	minetest.log("all fine.")
end)

```

</details>

* Optional: Change the randomseed.
* Enable the mod.
* Disable mod security.
* Start the world.
* Wait a second and look into chat. Expected: "all fine."
* Don't forget to enable mod security again.