### PR TITLE
Reduce client's packet processing budget per iteration from 100 to 10ms.

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -923,7 +923,7 @@ void Client::ReceiveAll()
 {
 	NetworkPacket pkt;
 	u64 start_ms = porting::getTimeMs();
-	const u64 budget = 100;
+	const u64 budget = 10;
 	for(;;) {
 		// Limit time even if there would be huge amounts of data to
 		// process


### PR DESCRIPTION
Closes #13236

If folks are worried I can make this configurable, too.
100ms as a hard-coded limit seems definitely too much.

## To do

This PR is Ready for Review.

## How to test

**set on server:**
max_simultaneous_block_sends_per_client = 512
emergequeue_limit_diskonly = 512
emergequeue_limit_generate = 512

max_block_send_distance = 64
max_block_generate_distance = 63

**on client:**
viewing_range = 1000

In the debug graphs (F5) observe the large spikes in "Time non-rendering" without this PR, this really goes up to 100ms and the gaps in between where nothing seems to be happening.
Then apply this, and observer again.

_This is part of making MT useful for larger viewing distances._

## Further Testing:

Revert these back to defaults:
max_simultaneous_block_sends_per_client
emergequeue_limit_diskonly
emergequeue_limit_generate

Observe that spikes stay below 10ms (discount the 0.2s spikes from updateDrawList) almost all the time (i.e. this has no effect if we do not want to send many blocks)
