### PR TITLE
Clarify documentation of punch key

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Some can be changed in the key config dialog in the settings tab.
 | Shift                         | Sneak/move down                                                |
 | Q                             | Drop itemstack                                                 |
 | Shift + Q                     | Drop single item                                               |
-| Left mouse button             | Dig/punch/take item                                            |
+| Left mouse button             | Dig/punch/use                                                  |
 | Right mouse button            | Place/use                                                      |
 | Shift + right mouse button    | Build (without using)                                          |
 | I                             | Inventory menu                                                 |

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2147,11 +2147,13 @@ keymap_jump (Jump key) key KEY_SPACE
 #    Also used for climbing down and descending in water if aux1_descends is disabled.
 keymap_sneak (Sneak key) key KEY_LSHIFT
 
-#    Key for digging.
-keymap_dig (Dig key) key KEY_LBUTTON
+#    Key for digging, punching or using something.
+#    (Note: The actual meaning might vary on a per-game basis.)
+keymap_dig (Dig/punch/use key) key KEY_LBUTTON
 
-#    Key for placing.
-keymap_place (Place key) key KEY_RBUTTON
+#    Key for placing an item/block or for using something.
+#    (Note: The actual meaning might vary on a per-game basis.)
+keymap_place (Place/use key) key KEY_RBUTTON
 
 #    Key for opening the inventory.
 keymap_inventory (Inventory key) key KEY_KEY_I

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4336,7 +4336,7 @@ void Game::showPauseMenu()
 		"- %s: move left\n"
 		"- %s: move right\n"
 		"- %s: jump/climb up\n"
-		"- %s: dig/punch\n"
+		"- %s: dig/punch/use\n"
 		"- %s: place/use\n"
 		"- %s: sneak/climb down\n"
 		"- %s: drop item\n"


### PR DESCRIPTION
Fixes #2838 (probably).

This issue was about how the game describes the left/right mouse buttons like this:

```
- Mouse left: dig/punch
- Mouse right: place/use
```

This is inaccurate as many games use the leftclick for special uses other than digging and punching as well, like eating an apple in MTG any many other games.

This PR updates the description to:

```
- Mouse left: dig/punch/use
- Mouse right: place/use
```

This is deliberately kept rather vague because games tend to have different left/rightclick paradigms. And it now fits MTG perfectly.

Other info files like README are updated as well. Just read the diff.

Note that the complaints about `on_rightclick` are already solved in existing Minetest as `lua_api.txt` makes it clear that this function is not neccessarily about a literal rightclick.