### PR TITLE
Enable connected glass by default

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -185,7 +185,7 @@ opaque_water (Opaque liquids) bool false
 leaves_style (Leaves style) enum fancy fancy,simple,opaque
 
 #    Connects glass if supported by node.
-connected_glass (Connect glass) bool false
+connected_glass (Connect glass) bool true
 
 #    Enable smooth lighting with simple ambient occlusion.
 #    Disable for speed or for different looks.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -165,7 +165,7 @@
 
 #    Connects glass if supported by node.
 #    type: bool
-# connected_glass = false
+# connected_glass = true
 
 #    Enable smooth lighting with simple ambient occlusion.
 #    Disable for speed or for different looks.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -195,7 +195,7 @@ void set_default_settings()
 	settings->setDefault("vsync", "false");
 	settings->setDefault("fov", "72");
 	settings->setDefault("leaves_style", "fancy");
-	settings->setDefault("connected_glass", "false");
+	settings->setDefault("connected_glass", "true");
 	settings->setDefault("smooth_lighting", "true");
 	settings->setDefault("performance_tradeoffs", "false");
 	settings->setDefault("lighting_alpha", "0.0");


### PR DESCRIPTION
Enables the connected glass setting by default.

This PR Fixes #8290.

## How to test

On master, see how the connected glass setting is disabled by default. On branch, ensure it is enabled by default.
