### PR TITLE
Drop dependency on IrrCompileConfig

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -553,12 +553,8 @@ void ClientLauncher::main_menu(MainMenuData *menudata)
 	m_rendering_engine->get_raw_device()->getCursorControl()->setVisible(true);
 
 	// Set absolute mouse mode
-#if IRRLICHT_VERSION_MT_REVISION >= 9
 	m_rendering_engine->get_raw_device()->getCursorControl()->setRelativeMode(false);
 #endif
-
-#endif
-
 
 	/* show main menu */
 	GUIEngine mymenu(&input->joystick, guiroot, m_rendering_engine, &g_menumgr, menudata, *kill);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2531,7 +2531,7 @@ void Game::checkZoomEnabled()
 
 void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 {
-#if !defined(__ANDROID__) && IRRLICHT_VERSION_MT_REVISION >= 9
+#ifndef __ANDROID__
 	if (isMenuActive())
 		device->getCursorControl()->setRelativeMode(false);
 	else

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -21,7 +21,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <algorithm>
 #include <ICameraSceneNode.h>
-#include <IrrCompileConfig.h>
 #include "util/string.h"
 #include "util/container.h"
 #include "util/thread.h"

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -17,7 +17,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <IrrCompileConfig.h>
 #include "settings.h"
 #include "porting.h"
 #include "filesys.h"
@@ -208,11 +207,7 @@ void set_default_settings()
 	settings->setDefault("texture_path", "");
 	settings->setDefault("shader_path", "");
 #if ENABLE_GLES
-#ifdef _IRR_COMPILE_WITH_OGLES1_
-	settings->setDefault("video_driver", "ogles1");
-#else
 	settings->setDefault("video_driver", "ogles2");
-#endif
 #else
 	settings->setDefault("video_driver", "opengl");
 #endif

--- a/src/gui/guiButton.h
+++ b/src/gui/guiButton.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "IrrCompileConfig.h"
-
 #include <IGUIStaticText.h>
 #include "irrlicht_changes/static_text.h"
 #include "IGUIButton.h"

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -17,7 +17,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include "IrrCompileConfig.h"
 #include "guiChatConsole.h"
 #include "chat.h"
 #include "client/client.h"

--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -19,7 +19,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "guiEditBox.h"
 
-#include "IrrCompileConfig.h"
 #include "IGUISkin.h"
 #include "IGUIEnvironment.h"
 #include "IGUIFont.h"

--- a/src/gui/guiSkin.cpp
+++ b/src/gui/guiSkin.cpp
@@ -5,7 +5,6 @@
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
 #include "guiSkin.h"
-#ifdef _IRR_COMPILE_WITH_GUI_
 
 #include "IGUIFont.h"
 #include "IGUISpriteBank.h"
@@ -1036,7 +1035,3 @@ void GUISkin::getColors(video::SColor* colors)
 
 } // end namespace gui
 } // end namespace irr
-
-
-#endif // _IRR_COMPILE_WITH_GUI_
-

--- a/src/gui/guiSkin.h
+++ b/src/gui/guiSkin.h
@@ -5,9 +5,6 @@
 #ifndef __GUI_SKIN_H_INCLUDED__
 #define __GUI_SKIN_H_INCLUDED__
 
-#include "IrrCompileConfig.h"
-#ifdef _IRR_COMPILE_WITH_GUI_
-
 #include "IGUISkin.h"
 #include "irrString.h"
 #include <string>
@@ -359,8 +356,5 @@ inline void setShading(video::SColor &color,f32 s) // :PATCH:
 	}
 }
 } // end namespace irr
-
-
-#endif // _IRR_COMPILE_WITH_GUI_
 
 #endif

--- a/src/irrlicht_changes/static_text.cpp
+++ b/src/irrlicht_changes/static_text.cpp
@@ -5,7 +5,6 @@
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
 #include "static_text.h"
-#ifdef _IRR_COMPILE_WITH_GUI_
 
 #include <IGUIFont.h>
 #include <IVideoDriver.h>
@@ -582,6 +581,3 @@ s32 StaticText::getTextWidth() const
 } // end namespace gui
 
 } // end namespace irr
-
-
-#endif // _IRR_COMPILE_WITH_GUI_

--- a/src/irrlicht_changes/static_text.h
+++ b/src/irrlicht_changes/static_text.h
@@ -6,9 +6,6 @@
 
 #pragma once
 
-#include "IrrCompileConfig.h"
-#ifdef _IRR_COMPILE_WITH_GUI_
-
 #include "IGUIStaticText.h"
 #include "irrArray.h"
 
@@ -231,5 +228,3 @@ inline void setStaticText(irr::gui::IGUIStaticText *static_text, const wchar_t *
 {
 	setStaticText(static_text, EnrichedString(text, static_text->getOverrideColor()));
 }
-
-#endif // _IRR_COMPILE_WITH_GUI_


### PR DESCRIPTION
Follow-up to 3bafbaac49e3d5d1d633b26f60fd4e919399819b. Closes #13227. The only remaining thing is `IRRLICHT_SDK_VERSION` via `irrlicht.h`.

## To do

This PR is Ready for Review.
