### PR TITLE
[no squash] Fix task ordering and more in Gradle Android build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -53,51 +53,59 @@ android {
 
 task prepareAssets() {
 	def assetsFolder = "build/assets"
-	def projRoot = "../.."
+	def projRoot = rootDir.parent
 	def gameToCopy = "minetest_game"
 
-	copy {
-		from "${projRoot}/minetest.conf.example", "${projRoot}/README.md" into assetsFolder
+	doFirst {
+		logger.lifecycle('Preparing assets at {}', assetsFolder)
 	}
-	copy {
-		from "${projRoot}/doc/lgpl-2.1.txt" into "${assetsFolder}"
-	}
-	copy {
-		from "${projRoot}/builtin" into "${assetsFolder}/builtin"
-	}
-	copy {
-		from "${projRoot}/client/shaders" into "${assetsFolder}/client/shaders"
-	}
-	copy {
-		from "../native/deps/armeabi-v7a/Irrlicht/Shaders" into "${assetsFolder}/client/shaders/Irrlicht"
-	}
-	copy {
-		from "${projRoot}/fonts" include "*.ttf" into "${assetsFolder}/fonts"
-	}
-	copy {
-		from "${projRoot}/games/${gameToCopy}" into "${assetsFolder}/games/${gameToCopy}"
-	}
-	fileTree("${projRoot}/po").include("**/*.po").forEach { poFile ->
-		def moPath = "${assetsFolder}/locale/${poFile.parentFile.name}/LC_MESSAGES/"
-		file(moPath).mkdirs()
-		exec {
-			commandLine 'msgfmt', '-o', "${moPath}/minetest.mo", poFile
+	doLast {
+		copy {
+			from "${projRoot}/minetest.conf.example", "${projRoot}/README.md" into assetsFolder
 		}
-	}
-	copy {
-		from "${projRoot}/textures" into "${assetsFolder}/textures"
+		copy {
+			from "${projRoot}/doc/lgpl-2.1.txt" into assetsFolder
+		}
+		copy {
+			from "${projRoot}/builtin" into "${assetsFolder}/builtin"
+		}
+		copy {
+			from "${projRoot}/client/shaders" into "${assetsFolder}/client/shaders"
+		}
+		copy {
+			from "../native/deps/armeabi-v7a/Irrlicht/Shaders" into "${assetsFolder}/client/shaders/Irrlicht"
+		}
+		copy {
+			from "${projRoot}/fonts" include "*.ttf" into "${assetsFolder}/fonts"
+		}
+		copy {
+			from "${projRoot}/games/${gameToCopy}" into "${assetsFolder}/games/${gameToCopy}"
+		}
+		copy {
+			from "${projRoot}/textures" into "${assetsFolder}/textures"
+		}
+
+		// compile translations
+		fileTree("${projRoot}/po").include("**/*.po").forEach { poFile ->
+			def moPath = "${assetsFolder}/locale/${poFile.parentFile.name}/LC_MESSAGES/"
+			file(moPath).mkdirs()
+			exec {
+				commandLine 'msgfmt', '-o', "${moPath}/minetest.mo", poFile
+			}
+		}
+
+		file("${assetsFolder}/.nomedia").text = ""
 	}
 
-	file("${assetsFolder}/.nomedia").text = ""
-
-	task zipAssets(type: Zip) {
+	task zipAssets(dependsOn: prepareAssets, type: Zip) {
 		archiveFileName = "Minetest.zip"
-		from "${assetsFolder}"
+		from assetsFolder
 		destinationDirectory = file("src/main/assets")
 	}
 }
 
 preBuild.dependsOn zipAssets
+prepareAssets.dependsOn ':native:getDeps'
 
 // Map for the version code that gives each ABI a value.
 import com.android.build.OutputFile

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,5 +33,4 @@ allprojects {
 
 task clean(type: Delete) {
 	delete rootProject.buildDir
-	delete 'native/deps'
 }

--- a/android/native/build.gradle
+++ b/android/native/build.gradle
@@ -52,18 +52,23 @@ android {
 
 // get precompiled deps
 task downloadDeps(type: Download) {
-	src 'https://github.com/minetest/minetest_android_deps/releases/download/latest/deps.zip'
-	dest new File(buildDir, 'deps.zip')
-	overwrite false
-}
+	def depsDir = new File(buildDir.parent, 'deps')
+	def depsZip = new File(buildDir, 'deps.zip')
 
-task getDeps(dependsOn: downloadDeps, type: Copy) {
-	def deps = new File(buildDir.parent, 'deps')
-	if (!deps.exists()) {
-		deps.mkdir()
-		from zipTree(downloadDeps.dest)
-		into deps
+	src 'https://github.com/minetest/minetest_android_deps/releases/download/latest/deps.zip'
+	dest depsZip
+	overwrite false
+
+	task getDeps(dependsOn: downloadDeps, type: Copy) {
+		depsDir.mkdir()
+		from zipTree(depsZip)
+		into depsDir
+		doFirst { logger.lifecycle('Extracting to {}', depsDir) }
 	}
 }
 
 preBuild.dependsOn getDeps
+
+clean {
+	delete new File(buildDir.parent, 'deps')
+}

--- a/src/porting_android.cpp
+++ b/src/porting_android.cpp
@@ -46,10 +46,9 @@ void android_main(android_app *app)
 
 	Thread::setName("Main");
 
+	char *argv[] = {strdup(PROJECT_NAME), strdup("--verbose"), nullptr};
 	try {
-		char *argv[] = {strdup(PROJECT_NAME), nullptr};
 		main(ARRLEN(argv) - 1, argv);
-		free(argv[0]);
 	} catch (std::exception &e) {
 		errorstream << "Uncaught exception in main thread: " << e.what() << std::endl;
 		retval = -1;
@@ -57,6 +56,8 @@ void android_main(android_app *app)
 		errorstream << "Uncaught exception in main thread!" << std::endl;
 		retval = -1;
 	}
+	free(argv[0]);
+	free(argv[1]);
 
 	porting::cleanupAndroid();
 	infostream << "Shutting down." << std::endl;


### PR DESCRIPTION
fixes #12863 because now the shaders are copied correctly

<hr>

whoever wrote the gradle script produced hot garbage, including this:
```groovy
task example() {
  println 'Hello World'
}
```
this declares a task that prints some text when run, obvious, right?
<b>wrong!</b> it declares a task that does _nothing_ and the text is printed every time the build script is read

## To do

This PR is Ready for Review.

## How to test

Run `./gradlew assembleRelease` and `./gradlew clean` multiple times in different order and see that it doesn't fall apart.