### PR TITLE
Scale culler steps proportionally to the mesh sizes

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -629,7 +629,8 @@ update_last_checked (Last update check) string
 update_last_known (Last known version update) int 0
 
 #    Use raytraced occlusion culling in the new culler.
-#	 This flag enables use of raytraced occlusion culling test
+#	 This flag enables use of raytraced occlusion culling test for
+#    client mesh sizes smaller than 4x4x4 map blocks.
 enable_raytraced_culling (Enable Raytraced Culling) bool true
 
 [*Server]

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -574,6 +574,7 @@ void Client::step(float dtime)
 				// Delete the old mesh
 				delete block->mesh;
 				block->mesh = nullptr;
+				block->solid_sides = r.solid_sides;
 
 				if (r.mesh) {
 					minimap_mapblocks = r.mesh->moveMinimapMapblocks();
@@ -596,12 +597,6 @@ void Client::step(float dtime)
 				}
 			} else {
 				delete r.mesh;
-			}
-
-			for (auto p : r.solid_sides) {
-				auto block = m_env.getMap().getBlockNoCreateNoEx(p.first);
-				if (block)
-					block->solid_sides = p.second;
 			}
 
 			if (m_minimap && do_mapper_update) {

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -277,8 +277,12 @@ void ClientMap::updateDrawList()
 	// Block sides that were not traversed
 	u32 sides_skipped = 0;
 
+	MeshGrid mesh_grid = m_client->getMeshGrid();
+
 	// No occlusion culling when free_move is on and camera is inside ground
-	bool occlusion_culling_enabled = true;
+	// No occlusion culling for chunk sizes of 4 and above
+	//   because the current occlusion culling test is highly inefficient at these sizes
+	bool occlusion_culling_enabled = mesh_grid.cell_size < 4;
 	if (m_control.allow_noclip) {
 		MapNode n = getNode(cam_pos_nodes);
 		if (n.getContent() == CONTENT_IGNORE || m_nodedef->get(n).solidness == 2)
@@ -296,7 +300,6 @@ void ClientMap::updateDrawList()
 	// 	occlusion_culling_enabled = porting::getTimeS() & 1;
 
 	std::queue<v3s16> blocks_to_consider;
-	MeshGrid mesh_grid = m_client->getMeshGrid();
 
 	v3s16 camera_mesh = mesh_grid.getMeshPos(camera_block);
 	v3s16 camera_cell = mesh_grid.getCellPos(camera_block);

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -266,7 +266,7 @@ void ClientMap::updateDrawList()
 
 	v3s16 p_blocks_min;
 	v3s16 p_blocks_max;
-	getBlocksInViewRange(cam_pos_nodes, &p_blocks_min, &p_blocks_max, m_control.range_all ? m_control.loaded_range : -1.0f);
+	getBlocksInViewRange(cam_pos_nodes, &p_blocks_min, &p_blocks_max);
 
 	// Number of blocks occlusion culled
 	u32 blocks_occlusion_culled = 0;
@@ -532,7 +532,6 @@ void ClientMap::touchMapBlocks()
 	// Number of blocks with mesh in rendering range
 	u32 blocks_in_range_with_mesh = 0;
 
-	float loaded_range = 0;
 	v3f cam_pos_f = intToFloat(cam_pos_nodes, BS);
 
 	for (const auto &sector_it : m_sectors) {
@@ -568,13 +567,10 @@ void ClientMap::touchMapBlocks()
 					+ block->mesh->getBoundingSphereCenter();
 			f32 mesh_sphere_radius = block->mesh->getBoundingRadius();
 
-			float range = mesh_sphere_center.getDistanceFrom(cam_pos_f);
-			if (range > loaded_range)
-				loaded_range = range;
-
 			// First, perform a simple distance check.
 			if (!m_control.range_all &&
-				range >	m_control.wanted_range * BS + mesh_sphere_radius)
+				mesh_sphere_center.getDistanceFrom(cam_pos_f) >
+					m_control.wanted_range * BS + mesh_sphere_radius)
 				continue; // Out of range, skip.
 
 			// Keep the block alive as long as it is in range.
@@ -583,8 +579,6 @@ void ClientMap::touchMapBlocks()
 		}
 	}
 
-	m_control.loaded_range = loaded_range / BS;
-	g_profiler->avg("MapBlock loaded range", m_control.loaded_range);
 	g_profiler->avg("MapBlock meshes in range [#]", blocks_in_range_with_mesh);
 	g_profiler->avg("MapBlocks loaded [#]", blocks_loaded);
 }

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -65,6 +65,59 @@ static void on_settings_changed(const std::string &name, void *data)
 {
 	static_cast<ClientMap*>(data)->onSettingChanged(name);
 }
+
+static bool isMeshOccluded(ClientMap* map, MapBlock *mesh_block, u16 mesh_size, v3s16 cam_pos_nodes)
+{
+	if (mesh_size == 1)
+		return map->isBlockOccluded(mesh_block, cam_pos_nodes);
+
+	v3s16 min_edge = mesh_block->getPosRelative();
+	v3s16 max_edge = min_edge + mesh_size * MAP_BLOCKSIZE -1;
+	bool check_axis[3] = { false, false, false };
+	u16 closest_side[3] = { 0, 0, 0 };
+
+	for (int axis = 0; axis < 3; axis++) {
+		if (cam_pos_nodes[axis] < min_edge[axis])
+			check_axis[axis] = true;
+		else if (cam_pos_nodes[axis] > max_edge[axis]) {
+			check_axis[axis] = true;
+			closest_side[axis] = mesh_size - 1;
+		}
+	}
+
+	std::vector<bool> processed_blocks(mesh_size * mesh_size * mesh_size);
+
+	// scan the side
+	for (u16 i = 0; i < mesh_size; i++)
+	for (u16 j = 0; j < mesh_size; j++) {
+		v3s16 offsets[3] = {
+			v3s16(closest_side[0], i, j),
+			v3s16(i, closest_side[1], j),
+			v3s16(i, j, closest_side[2])
+		};
+		for (int axis = 0; axis < 3; axis++) {
+			v3s16 offset = offsets[axis];
+			int block_index = offset.X + offset.Y * mesh_size + offset.Z * mesh_size * mesh_size;
+			if (check_axis[axis] && !processed_blocks[block_index]) {
+				processed_blocks[block_index] = true;
+				v3s16 block_pos = mesh_block->getPos() + offset;
+				MapBlock *block;
+
+				if (mesh_block->getPos() == block_pos)
+					block = mesh_block;
+				else
+					block = map->getBlockNoCreateNoEx(block_pos);
+
+				if (block && !map->isBlockOccluded(block, cam_pos_nodes))
+					return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+
 // ClientMap
 
 ClientMap::ClientMap(
@@ -84,7 +137,7 @@ ClientMap::ClientMap(
 
 	/*
 	 * @Liso: Sadly C++ doesn't have introspection, so the only way we have to know
-	 * the class is whith a name ;) Name property cames from ISceneNode base class.
+	 * the class is with a name ;) Name property cames from ISceneNode base class.
 	 */
 	Name = "ClientMap";
 	m_box = aabb3f(-BS*1000000,-BS*1000000,-BS*1000000,
@@ -379,7 +432,7 @@ void ClientMap::updateDrawList()
 		// Raytraced occlusion culling - send rays from the camera to the block's corners
 		if (occlusion_culling_enabled && m_enable_raytraced_culling &&
 				block && mesh &&
-				visible_outer_sides != 0x07 && isMeshOccluded(block, mesh_grid.cell_size, cam_pos_nodes)) {
+				visible_outer_sides != 0x07 && isMeshOccluded(this, block, mesh_grid.cell_size, cam_pos_nodes)) {
 			blocks_occlusion_culled++;
 			continue;
 		}
@@ -1255,53 +1308,3 @@ void ClientMap::DrawDescriptor::draw(video::IVideoDriver* driver)
 	}
 }
 
-bool ClientMap::isMeshOccluded(MapBlock *mesh_block, u16 mesh_size, v3s16 cam_pos_nodes)
-{
-	if (mesh_size == 1)
-		return isBlockOccluded(mesh_block, cam_pos_nodes);
-
-	v3s16 min_edge = mesh_block->getPosRelative();
-	v3s16 max_edge = min_edge + mesh_size * MAP_BLOCKSIZE -1;
-	bool check_axis[3] = { false, false, false };
-	u16 closest_side[3] = { 0, 0, 0 };
-
-	for (int axis = 0; axis < 3; axis++) {
-		if (cam_pos_nodes[axis] < min_edge[axis])
-			check_axis[axis] = true;
-		else if (cam_pos_nodes[axis] > max_edge[axis]) {
-			check_axis[axis] = true;
-			closest_side[axis] = mesh_size - 1;
-		}
-	}
-
-	std::vector<bool> processed_blocks(mesh_size * mesh_size * mesh_size);
-
-	// scan the side
-	for (u16 i = 0; i < mesh_size; i++)
-	for (u16 j = 0; j < mesh_size; j++) {
-		v3s16 offsets[3] = {
-			v3s16(closest_side[0], i, j),
-			v3s16(i, closest_side[1], j),
-			v3s16(i, j, closest_side[2])
-		};
-		for (int axis = 0; axis < 3; axis++) {
-			v3s16 offset = offsets[axis];
-			int block_index = offset.X + offset.Y * mesh_size + offset.Z * mesh_size * mesh_size;
-			if (check_axis[axis] && !processed_blocks[block_index]) {
-				processed_blocks[block_index] = true;
-				v3s16 block_pos = mesh_block->getPos() + offset;
-				MapBlock *block;
-
-				if (mesh_block->getPos() == block_pos)
-					block = mesh_block;
-				else
-					block = getBlockNoCreateNoEx(block_pos);
-
-				if (block && !isBlockOccluded(block, cam_pos_nodes))
-					return false;
-			}
-		}
-	}
-
-	return true;
-}

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -377,7 +377,7 @@ void ClientMap::updateDrawList()
 		// Raytraced occlusion culling - send rays from the camera to the block's corners
 		if (occlusion_culling_enabled && m_enable_raytraced_culling &&
 				block && mesh &&
-				visible_outer_sides != 0x07 && isBlockOccluded(block, cam_pos_nodes)) {
+				visible_outer_sides != 0x07 && isMeshOccluded(block, mesh_grid.cell_size, cam_pos_nodes)) {
 			blocks_occlusion_culled++;
 			continue;
 		}
@@ -1245,4 +1245,55 @@ void ClientMap::DrawDescriptor::draw(video::IVideoDriver* driver)
 	} else {
 		driver->drawMeshBuffer(m_buffer);
 	}
+}
+
+bool ClientMap::isMeshOccluded(MapBlock *mesh_block, u16 mesh_size, v3s16 cam_pos_nodes)
+{
+	if (mesh_size == 1)
+		return isBlockOccluded(mesh_block, cam_pos_nodes);
+
+	v3s16 min_edge = mesh_block->getPosRelative();
+	v3s16 max_edge = min_edge + mesh_size * MAP_BLOCKSIZE -1;
+	bool check_axis[3] = { false, false, false };
+	u16 closest_side[3] = { 0, 0, 0 };
+
+	for (int axis = 0; axis < 3; axis++) {
+		if (cam_pos_nodes[axis] < min_edge[axis])
+			check_axis[axis] = true;
+		else if (cam_pos_nodes[axis] > max_edge[axis]) {
+			check_axis[axis] = true;
+			closest_side[axis] = mesh_size - 1;
+		}
+	}
+
+	std::vector<bool> processed_blocks(mesh_size * mesh_size * mesh_size);
+
+	// scan the side
+	for (u16 i = 0; i < mesh_size; i++)
+	for (u16 j = 0; j < mesh_size; j++) {
+		v3s16 offsets[3] = {
+			v3s16(closest_side[0], i, j),
+			v3s16(i, closest_side[1], j),
+			v3s16(i, j, closest_side[2])
+		};
+		for (int axis = 0; axis < 3; axis++) {
+			v3s16 offset = offsets[axis];
+			int block_index = offset.X + offset.Y * mesh_size + offset.Z * mesh_size * mesh_size;
+			if (check_axis[axis] && !processed_blocks[block_index]) {
+				processed_blocks[block_index] = true;
+				v3s16 block_pos = mesh_block->getPos() + offset;
+				MapBlock *block;
+
+				if (mesh_block->getPos() == block_pos)
+					block = mesh_block;
+				else
+					block = getBlockNoCreateNoEx(block_pos);
+
+				if (block && !isBlockOccluded(block, cam_pos_nodes))
+					return false;
+			}
+		}
+	}
+
+	return true;
 }

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -270,6 +270,8 @@ void ClientMap::updateDrawList()
 
 	// Number of blocks occlusion culled
 	u32 blocks_occlusion_culled = 0;
+	// Number of blocks frustum culled
+	u32 blocks_frustum_culled = 0;
 	// Blocks visited by the algorithm
 	u32 blocks_visited = 0;
 	// Block sides that were not traversed
@@ -343,8 +345,8 @@ void ClientMap::updateDrawList()
 			mesh_sphere_radius = mesh->getBoundingRadius();
 		}
 		else {
-			mesh_sphere_center = intToFloat(block_pos_nodes, BS) + v3f((MAP_BLOCKSIZE * 0.5f - 0.5f) * BS);
-			mesh_sphere_radius = 0.0f;
+			mesh_sphere_center = intToFloat(block_pos_nodes, BS) + v3f((mesh_grid.cell_size * MAP_BLOCKSIZE * 0.5f - 0.5f) * BS);
+			mesh_sphere_radius = 0.87f * mesh_grid.cell_size * MAP_BLOCKSIZE * BS;
 		}
 
 		// First, perform a simple distance check.
@@ -358,8 +360,10 @@ void ClientMap::updateDrawList()
 		// This is needed because this function is not called every frame.
 		float frustum_cull_extra_radius = 300.0f;
 		if (is_frustum_culled(mesh_sphere_center,
-				mesh_sphere_radius + frustum_cull_extra_radius))
+				mesh_sphere_radius + frustum_cull_extra_radius)) {
+			blocks_frustum_culled++;
 			continue;
+		}
 
 		// Calculate the vector from the camera block to the current block
 		// We use it to determine through which sides of the current block we can continue the search
@@ -503,6 +507,7 @@ void ClientMap::updateDrawList()
 	}
 
 	g_profiler->avg("MapBlocks occlusion culled [#]", blocks_occlusion_culled);
+	g_profiler->avg("MapBlocks frustum culled [#]", blocks_frustum_culled);
 	g_profiler->avg("MapBlocks sides skipped [#]", sides_skipped);
 	g_profiler->avg("MapBlocks examined [#]", blocks_visited);
 	g_profiler->avg("MapBlocks drawn [#]", m_drawlist.size());

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -297,11 +297,11 @@ void ClientMap::updateDrawList()
 
 	// Bits per block:
 	// [ visited | 0 | 0 | 0 | 0 | Z visible | Y visible | X visible ]
-	MapBlockFlags blocks_seen(p_blocks_min, p_blocks_max);
+	MapBlockFlags meshes_seen(p_blocks_min, p_blocks_max);
 
 	// Start breadth-first search with the block the camera is in
 	blocks_to_consider.push(camera_block);
-	blocks_seen.getChunk(camera_block).getBits(camera_block) = 0x07; // mark all sides as visible
+	meshes_seen.getChunk(camera_block).getBits(camera_block) = 0x07; // mark all sides as visible
 
 	std::set<v3s16> shortlist;
 	MeshGrid mesh_grid = m_client->getMeshGrid();
@@ -312,7 +312,7 @@ void ClientMap::updateDrawList()
 		v3s16 block_coord = blocks_to_consider.front();
 		blocks_to_consider.pop();
 
-		auto &flags = blocks_seen.getChunk(block_coord).getBits(block_coord);
+		auto &flags = meshes_seen.getChunk(block_coord).getBits(block_coord);
 
 		// Only visit each block once (it may have been queued up to three times)
 		if ((flags & 0x80) == 0x80)
@@ -469,7 +469,7 @@ void ClientMap::updateDrawList()
 
 				// If a side is a see-through, mark the next block's side as visible, and queue
 				if (side_visible) {
-					auto &next_flags = blocks_seen.getChunk(next_pos).getBits(next_pos);
+					auto &next_flags = meshes_seen.getChunk(next_pos).getBits(next_pos);
 					next_flags |= my_side;
 					blocks_to_consider.push(next_pos);
 				}

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -143,6 +143,7 @@ public:
 protected:
 	void reportMetrics(u64 save_time_us, u32 saved_blocks, u32 all_blocks) override;
 private:
+	bool isMeshOccluded(MapBlock *mesh_block, u16 mesh_size, v3s16 cam_pos_nodes);
 
 	// update the vertex order in transparent mesh buffers
 	void updateTransparentMeshBuffers();

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -29,8 +29,6 @@ struct MapDrawControl
 {
 	// Wanted drawing range
 	float wanted_range = 0.0f;
-	// Loaded range
-	float loaded_range = 0.0f;
 	// Overrides limits by drawing everything
 	bool range_all = false;
 	// Allow rendering out of bounds

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -143,6 +143,8 @@ public:
 protected:
 	void reportMetrics(u64 save_time_us, u32 saved_blocks, u32 all_blocks) override;
 private:
+	bool isMeshOccluded(MapBlock *mesh_block, u16 mesh_size, v3s16 cam_pos_nodes);
+
 	// update the vertex order in transparent mesh buffers
 	void updateTransparentMeshBuffers();
 

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -29,6 +29,8 @@ struct MapDrawControl
 {
 	// Wanted drawing range
 	float wanted_range = 0.0f;
+	// Loaded range
+	float loaded_range = 0.0f;
 	// Overrides limits by drawing everything
 	bool range_all = false;
 	// Allow rendering out of bounds

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -143,8 +143,6 @@ public:
 protected:
 	void reportMetrics(u64 save_time_us, u32 saved_blocks, u32 all_blocks) override;
 private:
-	bool isMeshOccluded(MapBlock *mesh_block, u16 mesh_size, v3s16 cam_pos_nodes);
-
 	// update the vertex order in transparent mesh buffers
 	void updateTransparentMeshBuffers();
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1169,6 +1169,7 @@ void PartialMeshBuffer::afterDraw() const
 MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 	m_tsrc(data->m_client->getTextureSource()),
 	m_shdrsrc(data->m_client->getShaderSource()),
+	m_bounding_sphere_center((data->side_length * 0.5f - 0.5f) * BS),
 	m_animation_force_timer(0), // force initial animation
 	m_last_crack(-1),
 	m_last_daynight_ratio((u32) -1)

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1573,40 +1573,31 @@ video::SColor encode_light(u16 light, u8 emissive_light)
 	return video::SColor(r, b, b, b);
 }
 
-std::unordered_map<v3s16, u8> get_solid_sides(MeshMakeData *data)
+u8 get_solid_sides(MeshMakeData *data)
 {
 	std::unordered_map<v3s16, u8> results;
 	v3s16 ofs;
-	const u16 mesh_chunk = data->side_length / MAP_BLOCKSIZE;
+	v3s16 blockpos_nodes = data->m_blockpos * MAP_BLOCKSIZE;
+	const NodeDefManager *ndef = data->m_client->ndef();
 
-	for (ofs.X = 0; ofs.X < mesh_chunk; ofs.X++)
-	for (ofs.Y = 0; ofs.Y < mesh_chunk; ofs.Y++)
-	for (ofs.Z = 0; ofs.Z < mesh_chunk; ofs.Z++) {
-		v3s16 blockpos = data->m_blockpos + ofs;
-		v3s16 blockpos_nodes = blockpos * MAP_BLOCKSIZE;
-		const NodeDefManager *ndef = data->m_client->ndef();
+	u8 result = 0x3F; // all sides solid;
 
-		u8 result = 0x3F; // all sides solid;
+	for (s16 i = 0; i < data->side_length && result != 0; i++)
+	for (s16 j = 0; j < data->side_length && result != 0; j++) {
+		v3s16 positions[6] = {
+			v3s16(0, i, j),
+			v3s16(data->side_length - 1, i, j),
+			v3s16(i, 0, j),
+			v3s16(i, data->side_length - 1, j),
+			v3s16(i, j, 0),
+			v3s16(i, j, data->side_length - 1)
+		};
 
-		for (s16 i = 0; i < MAP_BLOCKSIZE && result != 0; i++)
-		for (s16 j = 0; j < MAP_BLOCKSIZE && result != 0; j++) {
-			v3s16 positions[6] = {
-				v3s16(0, i, j),
-				v3s16(MAP_BLOCKSIZE - 1, i, j),
-				v3s16(i, 0, j),
-				v3s16(i, MAP_BLOCKSIZE - 1, j),
-				v3s16(i, j, 0),
-				v3s16(i, j, MAP_BLOCKSIZE - 1)
-			};
-
-			for (u8 k = 0; k < 6; k++) {
-				const MapNode &top = data->m_vmanip.getNodeRefUnsafe(blockpos_nodes + positions[k]);
-				if (ndef->get(top).solidness != 2)
-					result &= ~(1 << k);
-			}
+		for (u8 k = 0; k < 6; k++) {
+			const MapNode &top = data->m_vmanip.getNodeRefUnsafe(blockpos_nodes + positions[k]);
+			if (ndef->get(top).solidness != 2)
+				result &= ~(1 << k);
 		}
-
-		results[blockpos] = result;
 	}
-	return results;
+	return result;
 }

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -248,7 +248,7 @@ private:
 
 	f32 m_bounding_radius;
 	// MapblockMeshGenerator uses the same as mapblock center
-	v3f m_bounding_sphere_center = v3f((MAP_BLOCKSIZE * 0.5f - 0.5f) * BS);
+	v3f m_bounding_sphere_center;
 
 	bool m_enable_shaders;
 	bool m_enable_vbo;

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -338,7 +338,7 @@ void final_color_blend(video::SColor *result,
 void getNodeTileN(MapNode mn, const v3s16 &p, u8 tileindex, MeshMakeData *data, TileSpec &tile);
 void getNodeTile(MapNode mn, const v3s16 &p, const v3s16 &dir, MeshMakeData *data, TileSpec &tile);
 
-/// Return bitset of the sides of the mapblock that consist of solid nodes only
+/// Return bitset of the sides of the mesh that consist of solid nodes only
 /// Bits:
 /// 0 0 -Z +Z -X +X -Y +Y
-std::unordered_map<v3s16, u8> get_solid_sides(MeshMakeData *data);
+u8 get_solid_sides(MeshMakeData *data);

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -247,7 +247,6 @@ private:
 	IShaderSource *m_shdrsrc;
 
 	f32 m_bounding_radius;
-	// MapblockMeshGenerator uses the same as mapblock center
 	v3f m_bounding_sphere_center;
 
 	bool m_enable_shaders;

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -97,7 +97,7 @@ struct MeshUpdateResult
 {
 	v3s16 p = v3s16(-1338, -1338, -1338);
 	MapBlockMesh *mesh = nullptr;
-	std::unordered_map<v3s16, u8> solid_sides;
+	u8 solid_sides;
 	std::vector<v3s16> ack_list;
 	bool urgent = false;
 	std::vector<MapBlock *> map_blocks;

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -151,10 +151,22 @@ struct MeshGrid {
 
 	u32 getCellVolume() const { return cell_size * cell_size * cell_size; }
 
+	/// @brief returns coordinate of mesh cell given coordinate of a map block
+	s16 getCellPos(s16 p) const
+	{
+		return (p - (p < 0) * (cell_size - 1)) / cell_size;
+	}
+
+	/// @brief returns position of mesh cell in the grid given position of a map block
+	v3s16 getCellPos(v3s16 block_pos) const
+	{
+		return v3s16(getCellPos(block_pos.X), getCellPos(block_pos.Y), getCellPos(block_pos.Z));
+	}
+
 	/// @brief returns closest step of the grid smaller than p
 	s16 getMeshPos(s16 p) const
 	{
-		return ((p - (p < 0) * (cell_size - 1)) / cell_size * cell_size);
+		return getCellPos(p) * cell_size;
 	}
 
 	/// @brief Returns coordinates of the origin of the grid cell containing p


### PR DESCRIPTION
This is an attempt to make culler work faster at larger sizes of client_mesh_chunk and larger view ranges.

The PR also includes the following:
* raytraced occlusion culling is disabled for mesh chunk sizes of 4x4x4 and larger due to high cost

## To do

This PR is Ready for review

## How to test

* Tune client_mesh_chunk and view_range according to the table below
* Start the game
* updateDrawList should take reasonable time(~10-15ms)

| client_mesh_chunk | view_range |
|----|------------------|
| 1 | 125 |
| 2 | 250 |
| 4 | 500 | 
| 8 | 1000 |

