### PR TITLE
Don't expire blocks visible to the client.

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -295,12 +295,6 @@ void RemoteClient::GetNextBlocks (
 			}
 
 			/*
-				Don't send already sent blocks
-			*/
-			if (m_blocks_sent.find(p) != m_blocks_sent.end())
-				continue;
-
-			/*
 				Check if map has this block
 			*/
 			MapBlock *block = env->getMap().getBlockNoCreateNoEx(p);
@@ -309,6 +303,12 @@ void RemoteClient::GetNextBlocks (
 			if (block) {
 				// Reset usage timer, this block will be of use in the future.
 				block->resetUsageTimer();
+
+				/*
+					Don't send already sent blocks
+				*/
+				if (m_blocks_sent.find(p) != m_blocks_sent.end())
+					continue;
 
 				// Check whether the block exists (with data)
 				if (!block->isGenerated())


### PR DESCRIPTION
Finally figured our the problem mentioned here: https://github.com/minetest/minetest/pull/13213#issuecomment-1440767021

Without this change the server will happily expire blocks that are visible to the client, just to sent them again.

This is a minor change that allows the server the reset the usage counter when the block is visible to the client (even when the client already has that block).

This removes the entire late flurry sending of blocks. This will also end up sending (far) fewer blocks to the client as the server has to consider unloaded blocks as transparent, so many resent-expired blocks are uselessly sent to the client, because they are not (yet) occlusion culled. The culling is corrected at the server when all the blocks are reloaded, but by that time they have already been sent to the client - defeating some of the server side occlusion culling.

And as the cycle of unloaded/reloading/resending is repeated more and more useless blocks are sent to the client.
Of course this also put undue and unneeded load on the server database.

## To do

This PR is Ready for Review.

## How to test

Load any world. Notice how after the initial set of blocks is loaded there is no followup flurry of blocks loaded, yet there are no missing visible blocks on the client.