### PR TITLE
Check if client has a block even if the server has unloaded it.

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -298,18 +298,19 @@ void RemoteClient::GetNextBlocks (
 				Check if map has this block
 			*/
 			MapBlock *block = env->getMap().getBlockNoCreateNoEx(p);
+			if (block) {
+				// First: Reset usage timer, this block will be of use in the future.
+				block->resetUsageTimer();
+			}
+
+			/*
+				Don't send already sent blocks
+			*/
+			if (m_blocks_sent.find(p) != m_blocks_sent.end())
+				continue;
 
 			bool block_not_found = false;
 			if (block) {
-				// Reset usage timer, this block will be of use in the future.
-				block->resetUsageTimer();
-
-				/*
-					Don't send already sent blocks
-				*/
-				if (m_blocks_sent.find(p) != m_blocks_sent.end())
-					continue;
-
 				// Check whether the block exists (with data)
 				if (!block->isGenerated())
 					block_not_found = true;


### PR DESCRIPTION
Addendum for #13255 (see last comment there for explanation)

Fixes a timing issues, if it takes more than 29s to get blocks to the client.

The correct order is:
1. If the block exists (in the server map) reset the usage time.
2. Check whether the client has it (even when the server happens to have unloaded the block)
3. Then follow the remainder of the logic.

This prevents another send, unload, resend loop.

## To do

This PR is Ready for Review.

## How to test

See #13255 