### PR TITLE
Reduce server CPU consumed by occlusion culling.

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -327,8 +327,15 @@ void RemoteClient::GetNextBlocks (
 						continue;
 				}
 
+				/*
+					Check occlusion cache first.
+				 */
+				if (m_blocks_occ.find(p) != m_blocks_occ.end())
+					continue;
+
 				if (m_occ_cull && !block_not_found &&
 						env->getMap().isBlockOccluded(block, cam_pos_nodes)) {
+					m_blocks_occ.insert(p);
 					continue;
 				}
 			}
@@ -392,8 +399,11 @@ queue_full_break:
 		}
 	}
 
-	if (new_nearest_unsent_d != -1)
+	if (new_nearest_unsent_d != -1 && m_nearest_unsent_d != new_nearest_unsent_d) {
 		m_nearest_unsent_d = new_nearest_unsent_d;
+		// if the distance has changed, clear the occlusion cache
+		m_blocks_occ.clear();
+	}
 }
 
 void RemoteClient::GotBlock(v3s16 p)

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -32,6 +32,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <list>
 #include <vector>
 #include <set>
+#include <unordered_set>
 #include <memory>
 #include <mutex>
 
@@ -372,7 +373,15 @@ private:
 		List of block positions.
 		No MapBlock* is stored here because the blocks can get deleted.
 	*/
-	std::set<v3s16> m_blocks_sent;
+	std::unordered_set<v3s16> m_blocks_sent;
+
+	/*
+		Cache of blocks that have been occlusion culled at the current distance.
+		As GetNextBlocks traverses the same distance multiple times, this saves
+		significant CPU time.
+	 */
+	std::unordered_set<v3s16> m_blocks_occ;
+
 	s16 m_nearest_unsent_d = 0;
 	v3s16 m_last_center;
 	v3f m_last_camera_dir;
@@ -392,7 +401,7 @@ private:
 		Block is removed when GOTBLOCKS is received.
 		Value is time from sending. (not used at the moment)
 	*/
-	std::map<v3s16, float> m_blocks_sending;
+	std::unordered_map<v3s16, float> m_blocks_sending;
 
 	/*
 		Blocks that have been modified since blocks were
@@ -402,7 +411,7 @@ private:
 
 		List of block positions.
 	*/
-	std::set<v3s16> m_blocks_modified;
+	std::unordered_set<v3s16> m_blocks_modified;
 
 	/*
 		Count of excess GotBlocks().


### PR DESCRIPTION
Retry... Cache occluded blocks for a particular distance.
The server usually visits the same distances many time, especially as distances get larger.
In that case the server has to work out occlusion culling again for all those blocks it is just going to skip at this distance.

Caching those avoids that work, leader to faster map transfer.

## To do

This PR is Ready for Review.

## How to test

Load any world. Observer how the load time reduces *and* server CPU time is reduces.
