### PR TITLE
Kubernetes: Deployments are stable since v1.16

### DIFF
--- a/misc/kubernetes.yml
+++ b/misc/kubernetes.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#deployment-v116 K8s Version v1.16 doesn't allow `extensions/v1beta1` as API version.

