### PR TITLE
Draw irrlicht tooltips ourself

### DIFF
--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -30,7 +30,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiInventoryList.h"
 #include "guiScrollBar.h"
 #include "guiTable.h"
-#include "network/networkprotocol.h"
 #include "client/joystick_controller.h"
 #include "util/Optional.h"
 #include "util/string.h"
@@ -320,7 +319,7 @@ protected:
 	std::vector<FieldSpec> m_fields;
 	std::vector<std::pair<FieldSpec, GUITable *>> m_tables;
 	std::vector<std::pair<FieldSpec, gui::IGUICheckBox *>> m_checkboxes;
-	std::map<std::string, TooltipSpec> m_tooltips;
+	std::unordered_map<std::string, TooltipSpec> m_tooltips;
 	std::vector<std::pair<gui::IGUIElement *, TooltipSpec>> m_tooltip_rects;
 	std::vector<std::pair<FieldSpec, GUIScrollBar *>> m_scrollbars;
 	std::vector<std::pair<FieldSpec, std::vector<std::string>>> m_dropdowns;
@@ -466,6 +465,10 @@ private:
 
 	void showTooltip(const std::wstring &text, const irr::video::SColor &color,
 		const irr::video::SColor &bgcolor);
+	void showTooltip(const TooltipSpec &tooltip)
+	{
+		showTooltip(tooltip.tooltip, tooltip.color, tooltip.bgcolor);
+	}
 
 	/**
 	 * In formspec version < 2 the elements were not ordered properly. Some element


### PR DESCRIPTION
* Fixes #4937.
* Also, `table[]` tooltips now look like all the other tooltips.
* Note that `table[]` is the only thing where the irrlicht ToolTipText is used. (`(guienv|imagebutton|button)::addButton()` also calls `setToolTipText()`, but we never call `addButton()` with a tooltip text.)
* Tooltip drawing in irrlicht should be disabled, so try with this: https://github.com/minetest/irrlicht/pull/170
* (There are also some other small clean-ups, like using an `unordered_map`.)

## To do

This PR is a Ready for Review.

## How to test

* Go to the online tab in main-menu.
* Hover the columns.
* Open your eyes.
