### PR TITLE
Tile: Fix segfault caused by invalid PNG data

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -1869,6 +1869,11 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			video::IImage* pngimg = vd->createImageFromFile(memfile);
 			memfile->drop();
 
+			if (!pngimg) {
+				errorstream << "generateImagePart(): Invalid PNG data" << std::endl;
+				return false;
+			}
+
 			if (baseimg) {
 				blitBaseImage(pngimg, baseimg);
 			} else {


### PR DESCRIPTION
Fixes #13268. PR opened in case there's another issue to fix up in Tile.

## To do

This PR is Ready for Review.

## How to test

1. Code from #13268
2. Does not segfault
