### PR TITLE
Get rid of wgettext

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -208,12 +208,10 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	while (m_rendering_engine->run() && !*kill &&
 		!g_gamecallback->shutdown_requested) {
 		// Set the window caption
-		const wchar_t *text = wgettext("Main Menu");
 		m_rendering_engine->get_raw_device()->
 			setWindowCaption((utf8_to_wide(PROJECT_NAME_C) +
 			L" " + utf8_to_wide(g_version_hash) +
-			L" [" + text + L"]").c_str());
-		delete[] text;
+			L" [" + wstrgettext("Main Menu") + L"]").c_str());
 
 		try {	// This is used for catching disconnects
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1519,17 +1519,10 @@ bool Game::createClient(const GameStartData &start_data)
 	std::wstring str = utf8_to_wide(PROJECT_NAME_C);
 	str += L" ";
 	str += utf8_to_wide(g_version_hash);
-	{
-		const wchar_t *text = nullptr;
-		if (simple_singleplayer_mode)
-			text = wgettext("Singleplayer");
-		else
-			text = wgettext("Multiplayer");
-		str += L" [";
-		str += text;
-		str += L"]";
-		delete[] text;
-	}
+	str += L" [";
+	str += simple_singleplayer_mode ? wstrgettext("Singleplayer")
+			: wstrgettext("Multiplayer");
+	str += L"]";
 	str += L" [";
 	str += driver->getName();
 	str += L"]";
@@ -1745,17 +1738,13 @@ bool Game::getServerContent(bool *aborted)
 		int progress = 25;
 
 		if (!client->itemdefReceived()) {
-			const wchar_t *text = wgettext("Item definitions...");
 			progress = 25;
-			m_rendering_engine->draw_load_screen(text, guienv, texture_src,
-				dtime, progress);
-			delete[] text;
+			m_rendering_engine->draw_load_screen(wstrgettext("Item definitions..."),
+					guienv, texture_src, dtime, progress);
 		} else if (!client->nodedefReceived()) {
-			const wchar_t *text = wgettext("Node definitions...");
 			progress = 30;
-			m_rendering_engine->draw_load_screen(text, guienv, texture_src,
-				dtime, progress);
-			delete[] text;
+			m_rendering_engine->draw_load_screen(wstrgettext("Node definitions..."),
+					guienv, texture_src, dtime, progress);
 		} else {
 			std::ostringstream message;
 			std::fixed(message);
@@ -4278,10 +4267,8 @@ void FpsControl::limit(IrrlichtDevice *device, f32 *dtime)
 
 void Game::showOverlayMessage(const char *msg, float dtime, int percent, bool draw_clouds)
 {
-	const wchar_t *wmsg = wgettext(msg);
-	m_rendering_engine->draw_load_screen(wmsg, guienv, texture_src, dtime, percent,
-		draw_clouds);
-	delete[] wmsg;
+	m_rendering_engine->draw_load_screen(wstrgettext(msg), guienv, texture_src,
+			dtime, percent, draw_clouds);
 }
 
 void Game::settingChangedCallback(const std::string &setting_name, void *data)

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -226,9 +226,7 @@ void GameUI::showMinimap(bool show)
 
 void GameUI::showTranslatedStatusText(const char *str)
 {
-	const wchar_t *wmsg = wgettext(str);
-	showStatusText(wmsg);
-	delete[] wmsg;
+	showStatusText(wstrgettext(str));
 }
 
 void GameUI::setChatText(const EnrichedString &chat_text, u32 recent_chat_count)

--- a/src/gettext.h
+++ b/src/gettext.h
@@ -20,8 +20,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "config.h" // for USE_GETTEXT
-#include <string>
 #include "porting.h"
+#include "util/string.h"
 
 #if USE_GETTEXT
 	#include <libintl.h>
@@ -46,18 +46,25 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 void init_gettext(const char *path, const std::string &configured_language,
 	int argc, char *argv[]);
 
-extern wchar_t *utf8_to_wide_c(const char *str);
-
-// The returned string must be freed using delete[]
-inline const wchar_t *wgettext(const char *str)
+inline std::string strgettext(const char *str)
 {
 	// We must check here that is not an empty string to avoid trying to translate it
-	return str[0] ? utf8_to_wide_c(gettext(str)) : utf8_to_wide_c("");
+	return str[0] ? gettext(str) : "";
 }
 
-inline std::string strgettext(const std::string &text)
+inline std::string strgettext(const std::string &str)
 {
-	return text.empty() ? "" : gettext(text.c_str());
+	return strgettext(str.c_str());
+}
+
+inline std::wstring wstrgettext(const char *str)
+{
+	return utf8_to_wide(strgettext(str));
+}
+
+inline std::wstring wstrgettext(const std::string &str)
+{
+	return wstrgettext(str.c_str());
 }
 
 /**
@@ -72,9 +79,8 @@ template <typename ...Args>
 inline std::wstring fwgettext(const char *src, Args&&... args)
 {
 	wchar_t buf[255];
-	const wchar_t* str = wgettext(src);
-	swprintf(buf, sizeof(buf) / sizeof(wchar_t), str, std::forward<Args>(args)...);
-	delete[] str;
+	swprintf(buf, sizeof(buf) / sizeof(wchar_t), wstrgettext(src).c_str(),
+			std::forward<Args>(args)...);
 	return std::wstring(buf);
 }
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3405,9 +3405,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 					size.X / 2 - 70,       pos.Y,
 					size.X / 2 - 70 + 140, pos.Y + m_btn_height * 2
 			);
-			const wchar_t *text = wgettext("Proceed");
-			GUIButton::addButton(Environment, mydata.rect, m_tsrc, this, 257, text);
-			delete[] text;
+			GUIButton::addButton(Environment, mydata.rect, m_tsrc, this, 257,
+					wstrgettext("Proceed").c_str());
 		}
 	}
 

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -97,7 +97,6 @@ GUIKeyChangeMenu::~GUIKeyChangeMenu()
 	key_used_text = nullptr;
 
 	for (key_setting *ks : key_settings) {
-		delete[] ks->button_name;
 		delete ks;
 	}
 	key_settings.clear();
@@ -124,10 +123,8 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		core::rect<s32> rect(0, 0, 600 * s, 40 * s);
 		rect += topleft + v2s32(25 * s, 3 * s);
 		//gui::IGUIStaticText *t =
-		const wchar_t *text = wgettext("Keybindings.");
-		Environment->addStaticText(text,
+		Environment->addStaticText(wstrgettext("Keybindings.").c_str(),
 								   rect, false, true, this, -1);
-		delete[] text;
 		//t->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_UPPERLEFT);
 	}
 
@@ -141,15 +138,15 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect<s32> rect(0, 0, 150 * s, 20 * s);
 			rect += topleft + v2s32(offset.X, offset.Y);
-			Environment->addStaticText(k->button_name, rect, false, true, this, -1);
+			Environment->addStaticText(k->button_name.c_str(), rect, false, true,
+					this, -1);
 		}
 
 		{
 			core::rect<s32> rect(0, 0, 100 * s, 30 * s);
 			rect += topleft + v2s32(offset.X + 150 * s, offset.Y - 5 * s);
-			const wchar_t *text = wgettext(k->key.name());
-			k->button = GUIButton::addButton(Environment, rect, m_tsrc, this, k->id, text);
-			delete[] text;
+			k->button = GUIButton::addButton(Environment, rect, m_tsrc, this, k->id,
+					wstrgettext(k->key.name()).c_str());
 		}
 		if ((i + 1) % KMaxButtonPerColumns == 0) {
 			offset.X += 260 * s;
@@ -166,10 +163,8 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect<s32> rect(0, 0, option_w, 30 * s);
 			rect += topleft + v2s32(option_x, option_y);
-			const wchar_t *text = wgettext("\"Aux1\" = climb down");
 			Environment->addCheckBox(g_settings->getBool("aux1_descends"), rect, this,
-					GUI_ID_CB_AUX1_DESCENDS, text);
-			delete[] text;
+					GUI_ID_CB_AUX1_DESCENDS, wstrgettext("\"Aux1\" = climb down").c_str());
 		}
 		offset += v2s32(0, 25 * s);
 	}
@@ -181,10 +176,8 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect<s32> rect(0, 0, option_w, 30 * s);
 			rect += topleft + v2s32(option_x, option_y);
-			const wchar_t *text = wgettext("Double tap \"jump\" to toggle fly");
 			Environment->addCheckBox(g_settings->getBool("doubletap_jump"), rect, this,
-					GUI_ID_CB_DOUBLETAP_JUMP, text);
-			delete[] text;
+					GUI_ID_CB_DOUBLETAP_JUMP, wstrgettext("Double tap \"jump\" to toggle fly").c_str());
 		}
 		offset += v2s32(0, 25 * s);
 	}
@@ -196,10 +189,8 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect<s32> rect(0, 0, option_w, 30 * s);
 			rect += topleft + v2s32(option_x, option_y);
-			const wchar_t *text = wgettext("Automatic jumping");
 			Environment->addCheckBox(g_settings->getBool("autojump"), rect, this,
-					GUI_ID_CB_AUTOJUMP, text);
-			delete[] text;
+					GUI_ID_CB_AUTOJUMP, wstrgettext("Automatic jumping").c_str());
 		}
 		offset += v2s32(0, 25);
 	}
@@ -207,16 +198,14 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 	{
 		core::rect<s32> rect(0, 0, 100 * s, 30 * s);
 		rect += topleft + v2s32(size.X / 2 - 105 * s, size.Y - 40 * s);
-		const wchar_t *text =  wgettext("Save");
-		GUIButton::addButton(Environment, rect, m_tsrc, this, GUI_ID_BACK_BUTTON, text);
-		delete[] text;
+		GUIButton::addButton(Environment, rect, m_tsrc, this, GUI_ID_BACK_BUTTON,
+				wstrgettext("Save").c_str());
 	}
 	{
 		core::rect<s32> rect(0, 0, 100 * s, 30 * s);
 		rect += topleft + v2s32(size.X / 2 + 5 * s, size.Y - 40 * s);
-		const wchar_t *text = wgettext("Cancel");
-		GUIButton::addButton(Environment, rect, m_tsrc, this, GUI_ID_ABORT_BUTTON, text);
-		delete[] text;
+		GUIButton::addButton(Environment, rect, m_tsrc, this, GUI_ID_ABORT_BUTTON,
+				wstrgettext("Cancel").c_str());
 	}
 }
 
@@ -271,9 +260,7 @@ bool GUIKeyChangeMenu::acceptInput()
 bool GUIKeyChangeMenu::resetMenu()
 {
 	if (active_key) {
-		const wchar_t *text = wgettext(active_key->key.name());
-		active_key->button->setText(text);
-		delete[] text;
+		active_key->button->setText(wstrgettext(active_key->key.name()).c_str());
 		active_key = nullptr;
 		return false;
 	}
@@ -313,10 +300,9 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 		if (key_in_use && !this->key_used_text) {
 			core::rect<s32> rect(0, 0, 600, 40);
 			rect += v2s32(0, 0) + v2s32(25, 30);
-			const wchar_t *text = wgettext("Key already in use");
-			this->key_used_text = Environment->addStaticText(text,
+			this->key_used_text = Environment->addStaticText(
+					wstrgettext("Key already in use").c_str(),
 					rect, false, true, this, -1);
-			delete[] text;
 		} else if (!key_in_use && this->key_used_text) {
 			this->key_used_text->remove();
 			this->key_used_text = nullptr;
@@ -325,9 +311,7 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 		// But go on
 		{
 			active_key->key = kp;
-			const wchar_t *text = wgettext(kp.name());
-			active_key->button->setText(text);
-			delete[] text;
+			active_key->button->setText(wstrgettext(kp.name()).c_str());
 
 			// Allow characters made with shift
 			if (shift_went_down){
@@ -377,9 +361,7 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 					FATAL_ERROR_IF(!active_key, "Key setting not found");
 
 					shift_down = false;
-					const wchar_t *text = wgettext("press key");
-					active_key->button->setText(text);
-					delete[] text;
+					active_key->button->setText(wstrgettext("press key").c_str());
 					break;
 			}
 			Environment->setFocus(this);
@@ -388,12 +370,12 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 	return Parent ? Parent->OnEvent(event) : false;
 }
 
-void GUIKeyChangeMenu::add_key(int id, const wchar_t *button_name, const std::string &setting_name)
+void GUIKeyChangeMenu::add_key(int id, std::wstring button_name, const std::string &setting_name)
 {
 	key_setting *k = new key_setting;
 	k->id = id;
 
-	k->button_name = button_name;
+	k->button_name = std::move(button_name);
 	k->setting_name = setting_name;
 	k->key = getKeySetting(k->setting_name.c_str());
 	key_settings.push_back(k);
@@ -401,38 +383,38 @@ void GUIKeyChangeMenu::add_key(int id, const wchar_t *button_name, const std::st
 
 void GUIKeyChangeMenu::init_keys()
 {
-	this->add_key(GUI_ID_KEY_FORWARD_BUTTON,      wgettext("Forward"),          "keymap_forward");
-	this->add_key(GUI_ID_KEY_BACKWARD_BUTTON,     wgettext("Backward"),         "keymap_backward");
-	this->add_key(GUI_ID_KEY_LEFT_BUTTON,         wgettext("Left"),             "keymap_left");
-	this->add_key(GUI_ID_KEY_RIGHT_BUTTON,        wgettext("Right"),            "keymap_right");
-	this->add_key(GUI_ID_KEY_AUX1_BUTTON,         wgettext("Aux1"),             "keymap_aux1");
-	this->add_key(GUI_ID_KEY_JUMP_BUTTON,         wgettext("Jump"),             "keymap_jump");
-	this->add_key(GUI_ID_KEY_SNEAK_BUTTON,        wgettext("Sneak"),            "keymap_sneak");
-	this->add_key(GUI_ID_KEY_DROP_BUTTON,         wgettext("Drop"),             "keymap_drop");
-	this->add_key(GUI_ID_KEY_INVENTORY_BUTTON,    wgettext("Inventory"),        "keymap_inventory");
-	this->add_key(GUI_ID_KEY_HOTBAR_PREV_BUTTON,  wgettext("Prev. item"),       "keymap_hotbar_previous");
-	this->add_key(GUI_ID_KEY_HOTBAR_NEXT_BUTTON,  wgettext("Next item"),        "keymap_hotbar_next");
-	this->add_key(GUI_ID_KEY_ZOOM_BUTTON,         wgettext("Zoom"),             "keymap_zoom");
-	this->add_key(GUI_ID_KEY_CAMERA_BUTTON,       wgettext("Change camera"),    "keymap_camera_mode");
-	this->add_key(GUI_ID_KEY_MINIMAP_BUTTON,      wgettext("Toggle minimap"),   "keymap_minimap");
-	this->add_key(GUI_ID_KEY_FLY_BUTTON,          wgettext("Toggle fly"),       "keymap_freemove");
-	this->add_key(GUI_ID_KEY_PITCH_MOVE,          wgettext("Toggle pitchmove"), "keymap_pitchmove");
-	this->add_key(GUI_ID_KEY_FAST_BUTTON,         wgettext("Toggle fast"),      "keymap_fastmove");
-	this->add_key(GUI_ID_KEY_NOCLIP_BUTTON,       wgettext("Toggle noclip"),    "keymap_noclip");
-	this->add_key(GUI_ID_KEY_MUTE_BUTTON,         wgettext("Mute"),             "keymap_mute");
-	this->add_key(GUI_ID_KEY_DEC_VOLUME_BUTTON,   wgettext("Dec. volume"),      "keymap_decrease_volume");
-	this->add_key(GUI_ID_KEY_INC_VOLUME_BUTTON,   wgettext("Inc. volume"),      "keymap_increase_volume");
-	this->add_key(GUI_ID_KEY_AUTOFWD_BUTTON,      wgettext("Autoforward"),      "keymap_autoforward");
-	this->add_key(GUI_ID_KEY_CHAT_BUTTON,         wgettext("Chat"),             "keymap_chat");
-	this->add_key(GUI_ID_KEY_SCREENSHOT_BUTTON,   wgettext("Screenshot"),       "keymap_screenshot");
-	this->add_key(GUI_ID_KEY_RANGE_BUTTON,        wgettext("Range select"),     "keymap_rangeselect");
-	this->add_key(GUI_ID_KEY_DEC_RANGE_BUTTON,    wgettext("Dec. range"),       "keymap_decrease_viewing_range_min");
-	this->add_key(GUI_ID_KEY_INC_RANGE_BUTTON,    wgettext("Inc. range"),       "keymap_increase_viewing_range_min");
-	this->add_key(GUI_ID_KEY_CONSOLE_BUTTON,      wgettext("Console"),          "keymap_console");
-	this->add_key(GUI_ID_KEY_CMD_BUTTON,          wgettext("Command"),          "keymap_cmd");
-	this->add_key(GUI_ID_KEY_CMD_LOCAL_BUTTON,    wgettext("Local command"),    "keymap_cmd_local");
-	this->add_key(GUI_ID_KEY_BLOCK_BOUNDS_BUTTON, wgettext("Block bounds"),     "keymap_toggle_block_bounds");
-	this->add_key(GUI_ID_KEY_HUD_BUTTON,          wgettext("Toggle HUD"),       "keymap_toggle_hud");
-	this->add_key(GUI_ID_KEY_CHATLOG_BUTTON,      wgettext("Toggle chat log"),  "keymap_toggle_chat");
-	this->add_key(GUI_ID_KEY_FOG_BUTTON,          wgettext("Toggle fog"),       "keymap_toggle_fog");
+	this->add_key(GUI_ID_KEY_FORWARD_BUTTON,      wstrgettext("Forward"),          "keymap_forward");
+	this->add_key(GUI_ID_KEY_BACKWARD_BUTTON,     wstrgettext("Backward"),         "keymap_backward");
+	this->add_key(GUI_ID_KEY_LEFT_BUTTON,         wstrgettext("Left"),             "keymap_left");
+	this->add_key(GUI_ID_KEY_RIGHT_BUTTON,        wstrgettext("Right"),            "keymap_right");
+	this->add_key(GUI_ID_KEY_AUX1_BUTTON,         wstrgettext("Aux1"),             "keymap_aux1");
+	this->add_key(GUI_ID_KEY_JUMP_BUTTON,         wstrgettext("Jump"),             "keymap_jump");
+	this->add_key(GUI_ID_KEY_SNEAK_BUTTON,        wstrgettext("Sneak"),            "keymap_sneak");
+	this->add_key(GUI_ID_KEY_DROP_BUTTON,         wstrgettext("Drop"),             "keymap_drop");
+	this->add_key(GUI_ID_KEY_INVENTORY_BUTTON,    wstrgettext("Inventory"),        "keymap_inventory");
+	this->add_key(GUI_ID_KEY_HOTBAR_PREV_BUTTON,  wstrgettext("Prev. item"),       "keymap_hotbar_previous");
+	this->add_key(GUI_ID_KEY_HOTBAR_NEXT_BUTTON,  wstrgettext("Next item"),        "keymap_hotbar_next");
+	this->add_key(GUI_ID_KEY_ZOOM_BUTTON,         wstrgettext("Zoom"),             "keymap_zoom");
+	this->add_key(GUI_ID_KEY_CAMERA_BUTTON,       wstrgettext("Change camera"),    "keymap_camera_mode");
+	this->add_key(GUI_ID_KEY_MINIMAP_BUTTON,      wstrgettext("Toggle minimap"),   "keymap_minimap");
+	this->add_key(GUI_ID_KEY_FLY_BUTTON,          wstrgettext("Toggle fly"),       "keymap_freemove");
+	this->add_key(GUI_ID_KEY_PITCH_MOVE,          wstrgettext("Toggle pitchmove"), "keymap_pitchmove");
+	this->add_key(GUI_ID_KEY_FAST_BUTTON,         wstrgettext("Toggle fast"),      "keymap_fastmove");
+	this->add_key(GUI_ID_KEY_NOCLIP_BUTTON,       wstrgettext("Toggle noclip"),    "keymap_noclip");
+	this->add_key(GUI_ID_KEY_MUTE_BUTTON,         wstrgettext("Mute"),             "keymap_mute");
+	this->add_key(GUI_ID_KEY_DEC_VOLUME_BUTTON,   wstrgettext("Dec. volume"),      "keymap_decrease_volume");
+	this->add_key(GUI_ID_KEY_INC_VOLUME_BUTTON,   wstrgettext("Inc. volume"),      "keymap_increase_volume");
+	this->add_key(GUI_ID_KEY_AUTOFWD_BUTTON,      wstrgettext("Autoforward"),      "keymap_autoforward");
+	this->add_key(GUI_ID_KEY_CHAT_BUTTON,         wstrgettext("Chat"),             "keymap_chat");
+	this->add_key(GUI_ID_KEY_SCREENSHOT_BUTTON,   wstrgettext("Screenshot"),       "keymap_screenshot");
+	this->add_key(GUI_ID_KEY_RANGE_BUTTON,        wstrgettext("Range select"),     "keymap_rangeselect");
+	this->add_key(GUI_ID_KEY_DEC_RANGE_BUTTON,    wstrgettext("Dec. range"),       "keymap_decrease_viewing_range_min");
+	this->add_key(GUI_ID_KEY_INC_RANGE_BUTTON,    wstrgettext("Inc. range"),       "keymap_increase_viewing_range_min");
+	this->add_key(GUI_ID_KEY_CONSOLE_BUTTON,      wstrgettext("Console"),          "keymap_console");
+	this->add_key(GUI_ID_KEY_CMD_BUTTON,          wstrgettext("Command"),          "keymap_cmd");
+	this->add_key(GUI_ID_KEY_CMD_LOCAL_BUTTON,    wstrgettext("Local command"),    "keymap_cmd_local");
+	this->add_key(GUI_ID_KEY_BLOCK_BOUNDS_BUTTON, wstrgettext("Block bounds"),     "keymap_toggle_block_bounds");
+	this->add_key(GUI_ID_KEY_HUD_BUTTON,          wstrgettext("Toggle HUD"),       "keymap_toggle_hud");
+	this->add_key(GUI_ID_KEY_CHATLOG_BUTTON,      wstrgettext("Toggle chat log"),  "keymap_toggle_chat");
+	this->add_key(GUI_ID_KEY_FOG_BUTTON,          wstrgettext("Toggle fog"),       "keymap_toggle_fog");
 }

--- a/src/gui/guiKeyChangeMenu.h
+++ b/src/gui/guiKeyChangeMenu.h
@@ -33,7 +33,7 @@ class ISimpleTextureSource;
 struct key_setting
 {
 	int id;
-	const wchar_t *button_name;
+	std::wstring button_name;
 	KeyPress key;
 	std::string setting_name;
 	gui::IGUIButton *button;
@@ -68,7 +68,7 @@ private:
 
 	bool resetMenu();
 
-	void add_key(int id, const wchar_t *button_name, const std::string &setting_name);
+	void add_key(int id, std::wstring button_name, const std::string &setting_name);
 
 	bool shift_down = false;
 

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -82,8 +82,6 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	v2s32 size = DesiredRect.getSize();
 	v2s32 topleft_client(40 * s, 0);
 
-	const wchar_t *text;
-
 	/*
 		Add stuff
 	*/
@@ -91,9 +89,8 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	{
 		core::rect<s32> rect(0, 0, 150 * s, 20 * s);
 		rect += topleft_client + v2s32(25 * s, ypos + 6 * s);
-		text = wgettext("Old Password");
-		Environment->addStaticText(text, rect, false, true, this, -1);
-		delete[] text;
+		Environment->addStaticText(wstrgettext("Old Password").c_str(), rect,
+				false, true, this, -1);
 	}
 	{
 		core::rect<s32> rect(0, 0, 230 * s, 30 * s);
@@ -107,9 +104,8 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	{
 		core::rect<s32> rect(0, 0, 150 * s, 20 * s);
 		rect += topleft_client + v2s32(25 * s, ypos + 6 * s);
-		text = wgettext("New Password");
-		Environment->addStaticText(text, rect, false, true, this, -1);
-		delete[] text;
+		Environment->addStaticText(wstrgettext("New Password").c_str(), rect, false, true,
+				this, -1);
 	}
 	{
 		core::rect<s32> rect(0, 0, 230 * s, 30 * s);
@@ -122,9 +118,8 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	{
 		core::rect<s32> rect(0, 0, 150 * s, 20 * s);
 		rect += topleft_client + v2s32(25 * s, ypos + 6 * s);
-		text = wgettext("Confirm Password");
-		Environment->addStaticText(text, rect, false, true, this, -1);
-		delete[] text;
+		Environment->addStaticText(wstrgettext("Confirm Password").c_str(), rect,
+				false, true, this, -1);
 	}
 	{
 		core::rect<s32> rect(0, 0, 230 * s, 30 * s);
@@ -138,28 +133,24 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	{
 		core::rect<s32> rect(0, 0, 100 * s, 30 * s);
 		rect = rect + v2s32(size.X / 4 + 56 * s, ypos);
-		text = wgettext("Change");
-		GUIButton::addButton(Environment, rect, m_tsrc, this, ID_change, text);
-		delete[] text;
+		GUIButton::addButton(Environment, rect, m_tsrc, this, ID_change,
+				wstrgettext("Change").c_str());
 	}
 	{
 		core::rect<s32> rect(0, 0, 100 * s, 30 * s);
 		rect = rect + v2s32(size.X / 4 + 185 * s, ypos);
-		text = wgettext("Cancel");
-		GUIButton::addButton(Environment, rect, m_tsrc, this, ID_cancel, text);
-		delete[] text;
+		GUIButton::addButton(Environment, rect, m_tsrc, this, ID_cancel,
+				wstrgettext("Cancel").c_str());
 	}
 
 	ypos += 50 * s;
 	{
 		core::rect<s32> rect(0, 0, 300 * s, 20 * s);
 		rect += topleft_client + v2s32(35 * s, ypos);
-		text = wgettext("Passwords do not match!");
-		IGUIElement *e =
-			Environment->addStaticText(
-			text, rect, false, true, this, ID_message);
+		IGUIElement *e = Environment->addStaticText(
+				wstrgettext("Passwords do not match!").c_str(), rect, false,
+				true, this, ID_message);
 		e->setVisible(false);
-		delete[] text;
 	}
 }
 

--- a/src/gui/guiVolumeChange.cpp
+++ b/src/gui/guiVolumeChange.cpp
@@ -73,21 +73,14 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 		core::rect<s32> rect(0, 0, 160 * s, 20 * s);
 		rect = rect + v2s32(size.X / 2 - 80 * s, size.Y / 2 - 70 * s);
 
-		wchar_t text[100];
-		const wchar_t *str = wgettext("Sound Volume: %d%%");
-		swprintf(text, sizeof(text) / sizeof(wchar_t), str, volume);
-		delete[] str;
-		core::stringw volume_text = text;
-
-		Environment->addStaticText(volume_text.c_str(), rect, false,
-				true, this, ID_soundText);
+		Environment->addStaticText(fwgettext("Sound Volume: %d%%", volume).c_str(),
+				rect, false, true, this, ID_soundText);
 	}
 	{
 		core::rect<s32> rect(0, 0, 80 * s, 30 * s);
 		rect = rect + v2s32(size.X / 2 - 80 * s / 2, size.Y / 2 + 55 * s);
-		const wchar_t *text = wgettext("Exit");
-		GUIButton::addButton(Environment, rect, m_tsrc, this, ID_soundExitButton, text);
-		delete[] text;
+		GUIButton::addButton(Environment, rect, m_tsrc, this, ID_soundExitButton,
+				wstrgettext("Exit").c_str());
 	}
 	{
 		core::rect<s32> rect(0, 0, 300 * s, 20 * s);
@@ -100,10 +93,8 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 	{
 		core::rect<s32> rect(0, 0, 160 * s, 20 * s);
 		rect = rect + v2s32(size.X / 2 - 80 * s, size.Y / 2 - 35 * s);
-		const wchar_t *text = wgettext("Muted");
 		Environment->addCheckBox(g_settings->getBool("mute_sound"), rect, this,
-				ID_soundMuteButton, text);
-		delete[] text;
+				ID_soundMuteButton, wstrgettext("Muted").c_str());
 	}
 }
 
@@ -164,14 +155,7 @@ bool GUIVolumeChange::OnEvent(const SEvent& event)
 				g_settings->setFloat("sound_volume", (float) pos / 100);
 
 				gui::IGUIElement *e = getElementFromId(ID_soundText);
-				wchar_t text[100];
-				const wchar_t *str = wgettext("Sound Volume: %d%%");
-				swprintf(text, sizeof(text) / sizeof(wchar_t), str, pos);
-				delete[] str;
-
-				core::stringw volume_text = text;
-
-				e->setText(volume_text.c_str());
+				e->setText(fwgettext("Sound Volume: %d%%", pos).c_str());
 				return true;
 			}
 		}

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -202,7 +202,7 @@ int ModApiClient::l_disconnect(lua_State *L)
 // gettext(text)
 int ModApiClient::l_gettext(lua_State *L)
 {
-	std::string text = strgettext(std::string(luaL_checkstring(L, 1)));
+	std::string text = strgettext(luaL_checkstring(L, 1));
 	lua_pushstring(L, text.c_str());
 
 	return 1;

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -161,15 +161,6 @@ std::string wide_to_utf8(const std::wstring &input)
 
 #endif // _WIN32
 
-wchar_t *utf8_to_wide_c(const char *str)
-{
-	std::wstring ret = utf8_to_wide(std::string(str));
-	size_t len = ret.length();
-	wchar_t *ret_c = new wchar_t[len + 1];
-	memcpy(ret_c, ret.c_str(), (len + 1) * sizeof(wchar_t));
-	return ret_c;
-}
-
 
 std::string urlencode(const std::string &str)
 {

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -79,10 +79,6 @@ struct FlagDesc {
 std::wstring utf8_to_wide(const std::string &input);
 std::string wide_to_utf8(const std::wstring &input);
 
-// You must free the returned string!
-// The returned string is allocated using new[]
-wchar_t *utf8_to_wide_c(const char *str);
-
 std::string urlencode(const std::string &str);
 std::string urldecode(const std::string &str);
 u32 readFlagString(std::string str, const FlagDesc *flagdesc, u32 *flagmask);


### PR DESCRIPTION
This is a maintenance/refactor PR.

`wgettext()` is annoying, as it returns a string that has to be manually freed. This results in less readable (and writable) code and exception-unsafety.

There's now a `wstrgettext()` that does the same, but returns a `std::wstring` instead.
There are also overloads for `const std::string &` and `const char *`.

## To do

This PR is a Ready for Review.

## How to test

* Read the code.
* Start reviewing at `gettext.h`.