### PR TITLE
Use better buffer smart-ptrs

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <sstream>
 #include "clientiface.h"
 #include "network/connection.h"
+#include "network/networkpacket.h"
 #include "network/serveropcodes.h"
 #include "remoteplayer.h"
 #include "settings.h"

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -23,7 +23,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "constants.h"
 #include "serialization.h"             // for SER_FMT_VER_INVALID
-#include "network/networkpacket.h"
 #include "network/networkprotocol.h"
 #include "network/address.h"
 #include "porting.h"
@@ -39,6 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class MapBlock;
 class ServerEnvironment;
 class EmergeManager;
+class NetworkPacket;
 
 /*
  * State Transitions

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -428,7 +428,7 @@ void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int
 	writeU8(os, content_width);
 	writeU8(os, params_width);
 	if (version >= 29) {
-		os.write(reinterpret_cast<char*>(*buf), buf.size());
+		os.write(reinterpret_cast<char *>(buf.get()), buf.size());
 	} else {
 		// prior to 29 node data was compressed individually
 		compress(buf, os, version, compression_level);
@@ -670,7 +670,7 @@ void MapBlock::deSerialize_pre22(std::istream &is, u8 version, bool disk)
 
 	// Make a temporary buffer
 	u32 ser_length = MapNode::serializedLength(version);
-	SharedBuffer<u8> databuf_nodelist(nodecount * ser_length);
+	SharedBuffer<u8> databuf_nodelist = make_buffer<u8>(nodecount * ser_length);
 
 	// These have no compression
 	if (version <= 3 || version == 5 || version == 6) {
@@ -680,7 +680,7 @@ void MapBlock::deSerialize_pre22(std::istream &is, u8 version, bool disk)
 			throw SerializationError(std::string(FUNCTION_NAME)
 				+ ": not enough input data");
 		is_underground = tmp;
-		is.read((char *)*databuf_nodelist, nodecount * ser_length);
+		is.read((char *)databuf_nodelist.get(), nodecount * ser_length);
 		if ((u32)is.gcount() != nodecount * ser_length)
 			throw SerializationError(std::string(FUNCTION_NAME)
 				+ ": not enough input data");

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -427,7 +427,7 @@ void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int
 	writeU8(os, content_width);
 	writeU8(os, params_width);
 	if (version >= 29) {
-		os.write(reinterpret_cast<char*>(*buf), buf.getSize());
+		os.write(reinterpret_cast<char*>(*buf), buf.size());
 	} else {
 		// prior to 29 node data was compressed individually
 		compress(buf, os, version, compression_level);

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -36,6 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "porting.h"
 #include "util/string.h"
 #include "util/serialize.h"
+#include "util/pointer.h"
 #include "util/basic_macros.h"
 
 static const char *modified_reason_strings[] = {

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "util/numeric.h"
 #include "util/serialize.h"
+#include "util/pointer.h"
 #include "serialization.h"
 #include "filesys.h"
 #include "voxelalgorithms.h"

--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -65,7 +65,7 @@ void make_tree(MMVManip &vmanip, v3s16 p0, bool is_apple_tree,
 	p1.Y -= 1;
 
 	VoxelArea leaves_a(v3s16(-2, -1, -2), v3s16(2, 2, 2));
-	auto leaves_d = UniqueBuffer<u8>::makeForOverwrite(leaves_a.getVolume());
+	UniqueBuffer<u8> leaves_d = make_buffer_for_overwrite<u8>(leaves_a.getVolume());
 	for (s32 i = 0; i < leaves_a.getVolume(); i++)
 		leaves_d[i] = 0;
 
@@ -693,8 +693,7 @@ void make_jungletree(MMVManip &vmanip, v3s16 p0, const NodeDefManager *ndef,
 	p1.Y -= 1;
 
 	VoxelArea leaves_a(v3s16(-3, -2, -3), v3s16(3, 2, 3));
-	//SharedPtr<u8> leaves_d(new u8[leaves_a.getVolume()]);
-	auto leaves_d = UniqueBuffer<u8>::makeForOverwrite(leaves_a.getVolume());
+	UniqueBuffer<u8> leaves_d = make_buffer_for_overwrite<u8>(leaves_a.getVolume());
 	for (s32 i = 0; i < leaves_a.getVolume(); i++)
 		leaves_d[i] = 0;
 
@@ -783,7 +782,7 @@ void make_pine_tree(MMVManip &vmanip, v3s16 p0, const NodeDefManager *ndef,
 	p1.Y -= 1;
 
 	VoxelArea leaves_a(v3s16(-3, -6, -3), v3s16(3, 3, 3));
-	auto leaves_d = UniqueBuffer<u8>::makeForOverwrite(leaves_a.getVolume());
+	UniqueBuffer<u8> leaves_d = make_buffer_for_overwrite<u8>(leaves_a.getVolume());
 	for (s32 i = 0; i < leaves_a.getVolume(); i++)
 		leaves_d[i] = 0;
 

--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -65,7 +65,7 @@ void make_tree(MMVManip &vmanip, v3s16 p0, bool is_apple_tree,
 	p1.Y -= 1;
 
 	VoxelArea leaves_a(v3s16(-2, -1, -2), v3s16(2, 2, 2));
-	Buffer<u8> leaves_d(leaves_a.getVolume());
+	auto leaves_d = UniqueBuffer<u8>::makeForOverwrite(leaves_a.getVolume());
 	for (s32 i = 0; i < leaves_a.getVolume(); i++)
 		leaves_d[i] = 0;
 
@@ -694,7 +694,7 @@ void make_jungletree(MMVManip &vmanip, v3s16 p0, const NodeDefManager *ndef,
 
 	VoxelArea leaves_a(v3s16(-3, -2, -3), v3s16(3, 2, 3));
 	//SharedPtr<u8> leaves_d(new u8[leaves_a.getVolume()]);
-	Buffer<u8> leaves_d(leaves_a.getVolume());
+	auto leaves_d = UniqueBuffer<u8>::makeForOverwrite(leaves_a.getVolume());
 	for (s32 i = 0; i < leaves_a.getVolume(); i++)
 		leaves_d[i] = 0;
 
@@ -783,7 +783,7 @@ void make_pine_tree(MMVManip &vmanip, v3s16 p0, const NodeDefManager *ndef,
 	p1.Y -= 1;
 
 	VoxelArea leaves_a(v3s16(-3, -6, -3), v3s16(3, 3, 3));
-	Buffer<u8> leaves_d(leaves_a.getVolume());
+	auto leaves_d = UniqueBuffer<u8>::makeForOverwrite(leaves_a.getVolume());
 	for (s32 i = 0; i < leaves_a.getVolume(); i++)
 		leaves_d[i] = 0;
 

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -674,7 +674,8 @@ SharedBuffer<u8> MapNode::serializeBulk(int version,
 		throw SerializationError("MapNode::serializeBulk: serialization to "
 				"version < 24 not possible");
 
-	SharedBuffer<u8> databuf(nodecount * (content_width + params_width));
+	SharedBuffer<u8> databuf =
+			make_buffer_for_overwrite<u8>(nodecount * (content_width + params_width));
 
 	u32 start1 = content_width * nodecount;
 	u32 start2 = (content_width + 1) * nodecount;
@@ -703,7 +704,7 @@ void MapNode::deSerializeBulk(std::istream &is, int version,
 
 	// read data
 	const u32 len = nodecount * (content_width + params_width);
-	auto databuf = UniqueBuffer<u8>::makeForOverwrite(len);
+	UniqueBuffer<u8> databuf = make_buffer_for_overwrite<u8>(len);
 	is.read(reinterpret_cast<char *>(databuf.get()), len);
 
 	// Deserialize content

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -702,8 +702,8 @@ void MapNode::deSerializeBulk(std::istream &is, int version,
 
 	// read data
 	const u32 len = nodecount * (content_width + params_width);
-	Buffer<u8> databuf(len);
-	is.read(reinterpret_cast<char*>(*databuf), len);
+	auto databuf = UniqueBuffer<u8>::makeForOverwrite(len);
+	is.read(reinterpret_cast<char *>(databuf.get()), len);
 
 	// Deserialize content
 	if(content_width == 1)

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "content_mapnode.h" // For mapnode_translate_*_internal
 #include "serialization.h" // For ser_ver_supported
 #include "util/serialize.h"
+#include "util/pointer.h"
 #include "log.h"
 #include "util/directiontables.h"
 #include "util/numeric.h"

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -21,12 +21,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "irrlichttypes_bloated.h"
 #include "light.h"
-#include "util/pointer.h"
+#include "util/basic_macros.h"
 #include <string>
 #include <vector>
 
 class NodeDefManager;
 class Map;
+template <typename T>
+class SharedBuffer;
 
 /*
 	Naming scheme:

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -36,6 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/sound.h"
 #include "network/clientopcodes.h"
 #include "network/connection.h"
+#include "network/networkpacket.h"
 #include "script/scripting_client.h"
 #include "util/serialize.h"
 #include "util/srp.h"

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -59,7 +59,7 @@ u16 BufferedPacket::getSeqnum() const
 	return readU16(&data[BASE_HEADER_SIZE + 1]);
 }
 
-BufferedPacketPtr makePacket(Address &address, View<u8> data,
+BufferedPacketPtr makePacket(Address &address, ConstView<u8> data,
 		u32 protocol_id, session_t sender_peer_id, u8 channel)
 {
 	u32 packet_size = data.size() + BASE_HEADER_SIZE;
@@ -76,7 +76,7 @@ BufferedPacketPtr makePacket(Address &address, View<u8> data,
 	return p;
 }
 
-SharedBuffer<u8> makeOriginalPacket(View<u8> data)
+SharedBuffer<u8> makeOriginalPacket(ConstView<u8> data)
 {
 	u32 header_size = 1;
 	u32 packet_size = data.size() + header_size;
@@ -90,7 +90,7 @@ SharedBuffer<u8> makeOriginalPacket(View<u8> data)
 }
 
 // Split data in chunks and add TYPE_SPLIT headers to them
-void makeSplitPacket(View<u8> data, u32 chunksize_max, u16 seqnum,
+void makeSplitPacket(ConstView<u8> data, u32 chunksize_max, u16 seqnum,
 		std::list<SharedBuffer<u8>> *chunks)
 {
 	// Chunk packets, containing the TYPE_SPLIT header
@@ -130,7 +130,7 @@ void makeSplitPacket(View<u8> data, u32 chunksize_max, u16 seqnum,
 	}
 }
 
-void makeAutoSplitPacket(View<u8> data, u32 chunksize_max,
+void makeAutoSplitPacket(ConstView<u8> data, u32 chunksize_max,
 		u16 &split_seqnum, std::list<SharedBuffer<u8>> *list)
 {
 	u32 original_header_size = 1;
@@ -144,7 +144,7 @@ void makeAutoSplitPacket(View<u8> data, u32 chunksize_max,
 	list->push_back(makeOriginalPacket(data));
 }
 
-SharedBuffer<u8> makeReliablePacket(View<u8> data, u16 seqnum)
+SharedBuffer<u8> makeReliablePacket(ConstView<u8> data, u16 seqnum)
 {
 	u32 header_size = 3;
 	u32 packet_size = data.size() + header_size;

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -348,11 +348,11 @@ void ReliablePacketBuffer::incrementTimeouts(float dtime)
 	}
 }
 
-std::list<ConstSharedPtr<BufferedPacket>>
+std::list<std::shared_ptr<const BufferedPacket>>
 	ReliablePacketBuffer::getTimedOuts(float timeout, u32 max_packets)
 {
 	MutexAutoLock listlock(m_list_mutex);
-	std::list<ConstSharedPtr<BufferedPacket>> timed_outs;
+	std::list<std::shared_ptr<const BufferedPacket>> timed_outs;
 	for (auto &packet : m_list) {
 		if (packet->time < timeout)
 			continue;

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -211,16 +211,16 @@ typedef std::shared_ptr<BufferedPacket> BufferedPacketPtr;
 
 
 // This adds the base headers to the data and makes a packet out of it
-BufferedPacketPtr makePacket(Address &address, View<u8> data,
+BufferedPacketPtr makePacket(Address &address, ConstView<u8> data,
 		u32 protocol_id, session_t sender_peer_id, u8 channel);
 
 // Depending on size, make a TYPE_ORIGINAL or TYPE_SPLIT packet
 // Increments split_seqnum if a split packet is made
-void makeAutoSplitPacket(View<u8> data, u32 chunksize_max,
+void makeAutoSplitPacket(ConstView<u8> data, u32 chunksize_max,
 		u16 &split_seqnum, std::list<SharedBuffer<u8>> *list);
 
 // Add the TYPE_RELIABLE header to the data
-SharedBuffer<u8> makeReliablePacket(View<u8> data, u16 seqnum);
+SharedBuffer<u8> makeReliablePacket(ConstView<u8> data, u16 seqnum);
 
 struct IncomingSplitPacket
 {

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -211,16 +211,16 @@ typedef std::shared_ptr<BufferedPacket> BufferedPacketPtr;
 
 
 // This adds the base headers to the data and makes a packet out of it
-BufferedPacketPtr makePacket(Address &address, const SharedBuffer<u8> &data,
+BufferedPacketPtr makePacket(Address &address, View<u8> data,
 		u32 protocol_id, session_t sender_peer_id, u8 channel);
 
 // Depending on size, make a TYPE_ORIGINAL or TYPE_SPLIT packet
 // Increments split_seqnum if a split packet is made
-void makeAutoSplitPacket(const SharedBuffer<u8> &data, u32 chunksize_max,
+void makeAutoSplitPacket(View<u8> data, u32 chunksize_max,
 		u16 &split_seqnum, std::list<SharedBuffer<u8>> *list);
 
 // Add the TYPE_RELIABLE header to the data
-SharedBuffer<u8> makeReliablePacket(const SharedBuffer<u8> &data, u16 seqnum);
+SharedBuffer<u8> makeReliablePacket(View<u8> data, u16 seqnum);
 
 struct IncomingSplitPacket
 {
@@ -680,7 +680,7 @@ struct ConnectionEvent
 	DISABLE_CLASS_COPY(ConnectionEvent);
 
 	static ConnectionEventPtr create(ConnectionEventType type);
-	static ConnectionEventPtr dataReceived(session_t peer_id, const UniqueBuffer<u8> &data);
+	static ConnectionEventPtr dataReceived(session_t peer_id, UniqueBuffer<u8> data);
 	static ConnectionEventPtr peerAdded(session_t peer_id, Address address);
 	static ConnectionEventPtr peerRemoved(session_t peer_id, bool is_timeout, Address address);
 	static ConnectionEventPtr bindFailed();

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -326,7 +326,7 @@ struct ConnectionCommand
 	Address address;
 	session_t peer_id = PEER_ID_INEXISTENT;
 	u8 channelnum = 0;
-	Buffer<u8> data;
+	UniqueBuffer<u8> data;
 	bool reliable = false;
 	bool raw = false;
 
@@ -337,8 +337,8 @@ struct ConnectionCommand
 	static ConnectionCommandPtr disconnect();
 	static ConnectionCommandPtr disconnect_peer(session_t peer_id);
 	static ConnectionCommandPtr send(session_t peer_id, u8 channelnum, NetworkPacket *pkt, bool reliable);
-	static ConnectionCommandPtr ack(session_t peer_id, u8 channelnum, const Buffer<u8> &data);
-	static ConnectionCommandPtr createPeer(session_t peer_id, const Buffer<u8> &data);
+	static ConnectionCommandPtr ack(session_t peer_id, u8 channelnum, const UniqueBuffer<u8> &data);
+	static ConnectionCommandPtr createPeer(session_t peer_id, const UniqueBuffer<u8> &data);
 
 private:
 	ConnectionCommand(ConnectionCommandType type_) :
@@ -672,7 +672,7 @@ struct ConnectionEvent
 {
 	const ConnectionEventType type;
 	session_t peer_id = 0;
-	Buffer<u8> data;
+	UniqueBuffer<u8> data;
 	bool timeout = false;
 	Address address;
 
@@ -680,7 +680,7 @@ struct ConnectionEvent
 	DISABLE_CLASS_COPY(ConnectionEvent);
 
 	static ConnectionEventPtr create(ConnectionEventType type);
-	static ConnectionEventPtr dataReceived(session_t peer_id, const Buffer<u8> &data);
+	static ConnectionEventPtr dataReceived(session_t peer_id, const UniqueBuffer<u8> &data);
 	static ConnectionEventPtr peerAdded(session_t peer_id, Address address);
 	static ConnectionEventPtr peerRemoved(session_t peer_id, bool is_timeout, Address address);
 	static ConnectionEventPtr bindFailed();

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -264,7 +264,7 @@ public:
 	void insert(BufferedPacketPtr &p_ptr, u16 next_expected);
 
 	void incrementTimeouts(float dtime);
-	std::list<ConstSharedPtr<BufferedPacket>> getTimedOuts(float timeout, u32 max_packets);
+	std::list<std::shared_ptr<const BufferedPacket>> getTimedOuts(float timeout, u32 max_packets);
 
 	void print();
 	bool empty();

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -304,7 +304,7 @@ void ConnectionSendThread::sendAsPacketReliable(BufferedPacketPtr &p, Channel *c
 }
 
 bool ConnectionSendThread::rawSendAsPacket(session_t peer_id, u8 channelnum,
-		View<u8> data, bool reliable)
+		ConstView<u8> data, bool reliable)
 {
 	PeerHelper peer = m_connection->getPeerNoEx(peer_id);
 	if (!peer) {
@@ -544,7 +544,7 @@ void ConnectionSendThread::disconnect_peer(session_t peer_id)
 	dynamic_cast<UDPPeer *>(&peer)->m_pending_disconnect = true;
 }
 
-void ConnectionSendThread::send(session_t peer_id, u8 channelnum, View<u8> data)
+void ConnectionSendThread::send(session_t peer_id, u8 channelnum, ConstView<u8> data)
 {
 	assert(channelnum < CHANNEL_COUNT); // Pre-condition
 
@@ -584,7 +584,7 @@ void ConnectionSendThread::sendReliable(ConnectionCommandPtr &c)
 	peer->PutReliableSendCommand(c, m_max_packet_size);
 }
 
-void ConnectionSendThread::sendToAll(u8 channelnum, View<u8> data)
+void ConnectionSendThread::sendToAll(u8 channelnum, ConstView<u8> data)
 {
 	std::vector<session_t> peerids = m_connection->getPeerIDs();
 

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -982,8 +982,8 @@ void ConnectionReceiveThread::receive(SharedBuffer<u8> &packetdata,
 
 		try {
 			// Process it (the result is some data with no headers made by us)
-			SharedBuffer<u8> resultdata = processPacket
-				(channel, strippeddata, peer_id, channelnum, false);
+			SharedBuffer<u8> resultdata =
+					processPacket(channel, strippeddata, peer_id, channelnum, false);
 
 			LOG(dout_con << m_connection->getDesc()
 				<< " ProcessPacket from peer_id: " << peer_id
@@ -991,7 +991,7 @@ void ConnectionReceiveThread::receive(SharedBuffer<u8> &packetdata,
 				<< resultdata.size() << " bytes" << std::endl);
 
 			m_connection->putEvent(ConnectionEvent::dataReceived(peer_id,
-					resultdata.copy()));
+					resultdata.moveOrCopyOut()));
 		}
 		catch (ProcessedSilentlyException &e) {
 		}

--- a/src/network/connectionthreads.h
+++ b/src/network/connectionthreads.h
@@ -72,7 +72,7 @@ private:
 	void runTimeouts(float dtime);
 	void rawSend(const BufferedPacket *p);
 	bool rawSendAsPacket(session_t peer_id, u8 channelnum,
-			const SharedBuffer<u8> &data, bool reliable);
+			View<u8> data, bool reliable);
 
 	void processReliableCommand(ConnectionCommandPtr &c);
 	void processNonReliableCommand(ConnectionCommandPtr &c);
@@ -80,9 +80,9 @@ private:
 	void connect(Address address);
 	void disconnect();
 	void disconnect_peer(session_t peer_id);
-	void send(session_t peer_id, u8 channelnum, const SharedBuffer<u8> &data);
+	void send(session_t peer_id, u8 channelnum, View<u8> data);
 	void sendReliable(ConnectionCommandPtr &c);
-	void sendToAll(u8 channelnum, const SharedBuffer<u8> &data);
+	void sendToAll(u8 channelnum, View<u8> data);
 	void sendToAllReliable(ConnectionCommandPtr &c);
 
 	void sendPackets(float dtime);

--- a/src/network/connectionthreads.h
+++ b/src/network/connectionthreads.h
@@ -72,7 +72,7 @@ private:
 	void runTimeouts(float dtime);
 	void rawSend(const BufferedPacket *p);
 	bool rawSendAsPacket(session_t peer_id, u8 channelnum,
-			View<u8> data, bool reliable);
+			ConstView<u8> data, bool reliable);
 
 	void processReliableCommand(ConnectionCommandPtr &c);
 	void processNonReliableCommand(ConnectionCommandPtr &c);
@@ -80,9 +80,9 @@ private:
 	void connect(Address address);
 	void disconnect();
 	void disconnect_peer(session_t peer_id);
-	void send(session_t peer_id, u8 channelnum, View<u8> data);
+	void send(session_t peer_id, u8 channelnum, ConstView<u8> data);
 	void sendReliable(ConnectionCommandPtr &c);
-	void sendToAll(u8 channelnum, View<u8> data);
+	void sendToAll(u8 channelnum, ConstView<u8> data);
 	void sendToAllReliable(ConnectionCommandPtr &c);
 
 	void sendPackets(float dtime);

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -549,9 +549,9 @@ NetworkPacket& NetworkPacket::operator<<(video::SColor src)
 	return *this;
 }
 
-Buffer<u8> NetworkPacket::oldForgePacket()
+UniqueBuffer<u8> NetworkPacket::oldForgePacket()
 {
-	Buffer<u8> sb(m_datasize + 2);
+	auto sb = UniqueBuffer<u8>::makeForOverwrite(m_datasize + 2);
 	writeU16(&sb[0], m_command);
 	memcpy(&sb[2], m_data.data(), m_datasize);
 

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -551,7 +551,7 @@ NetworkPacket& NetworkPacket::operator<<(video::SColor src)
 
 UniqueBuffer<u8> NetworkPacket::oldForgePacket()
 {
-	auto sb = UniqueBuffer<u8>::makeForOverwrite(m_datasize + 2);
+	UniqueBuffer<u8> sb = make_buffer_for_overwrite<u8>(m_datasize + 2);
 	writeU16(&sb[0], m_command);
 	memcpy(&sb[2], m_data.data(), m_datasize);
 

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -116,7 +116,8 @@ public:
 
 	// Temp, we remove SharedBuffer when migration finished
 	// ^ this comment has been here for 4 years
-	Buffer<u8> oldForgePacket();
+	//   ^ the number of years in this comment may be out-of-date
+	UniqueBuffer<u8> oldForgePacket();
 
 private:
 	void checkReadOffset(u32 from_offset, u32 field_size);

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -31,6 +31,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "tool.h"
 #include "version.h"
 #include "network/connection.h"
+#include "network/networkpacket.h"
 #include "network/networkprotocol.h"
 #include "network/serveropcodes.h"
 #include "server/player_sao.h"

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <iostream>
 #include <map>
+#include <memory>
 #include "mapnode.h"
 #include "nameidmapping.h"
 #ifndef SERVER
@@ -299,7 +300,7 @@ struct TileDef
 
 struct ContentFeatures
 {
-	// PROTOCOL_VERSION >= 37. This is legacy and should not be increased anymore, 
+	// PROTOCOL_VERSION >= 37. This is legacy and should not be increased anymore,
 	// write checks that depend directly on the protocol version instead.
 	static const u8 CONTENTFEATURES_VERSION = 13;
 

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "serialization.h"
 
 #include "util/serialize.h"
+#include "util/pointer.h"
 
 #include <zlib.h>
 #include <zstd.h>

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -250,7 +250,7 @@ void compressZstd(const u8 *data, size_t data_size, std::ostream &os, int level)
 
 void compressZstd(const std::string &data, std::ostream &os, int level)
 {
-	compressZstd((u8*)data.c_str(), data.size(), os, level);
+	compressZstd((const u8 *)data.c_str(), data.size(), os, level);
 }
 
 void decompressZstd(std::istream &is, std::ostream &os)
@@ -296,7 +296,7 @@ void decompressZstd(std::istream &is, std::ostream &os)
 	}
 }
 
-void compress(u8 *data, u32 size, std::ostream &os, u8 version, int level)
+void compress(const u8 *data, u32 size, std::ostream &os, u8 version, int level)
 {
 	if(version >= 29)
 	{
@@ -346,14 +346,14 @@ void compress(u8 *data, u32 size, std::ostream &os, u8 version, int level)
 	os.write((char*)&current_byte, 1);
 }
 
-void compress(View<u8> data, std::ostream &os, u8 version, int level)
+void compress(ConstView<u8> data, std::ostream &os, u8 version, int level)
 {
 	compress(data.get(), data.size(), os, version, level);
 }
 
 void compress(const std::string &data, std::ostream &os, u8 version, int level)
 {
-	compress((u8*)data.c_str(), data.size(), os, version, level);
+	compress((const u8 *)data.c_str(), data.size(), os, version, level);
 }
 
 void decompress(std::istream &is, std::ostream &os, u8 version)

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -347,7 +347,7 @@ void compress(u8 *data, u32 size, std::ostream &os, u8 version, int level)
 
 void compress(const SharedBuffer<u8> &data, std::ostream &os, u8 version, int level)
 {
-	compress(*data, data.getSize(), os, version, level);
+	compress(*data, data.size(), os, version, level);
 }
 
 void compress(const std::string &data, std::ostream &os, u8 version, int level)

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -346,9 +346,9 @@ void compress(u8 *data, u32 size, std::ostream &os, u8 version, int level)
 	os.write((char*)&current_byte, 1);
 }
 
-void compress(const SharedBuffer<u8> &data, std::ostream &os, u8 version, int level)
+void compress(View<u8> data, std::ostream &os, u8 version, int level)
 {
-	compress(*data, data.size(), os, version, level);
+	compress(data.get(), data.size(), os, version, level);
 }
 
 void compress(const std::string &data, std::ostream &os, u8 version, int level)

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -22,7 +22,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes.h"
 #include "exceptions.h"
 #include <iostream>
-#include "util/pointer.h"
+
+template <typename T>
+class SharedBuffer;
 
 /*
 	Map format serialization version

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <iostream>
 
 template <typename T>
-class SharedBuffer;
+class View;
 
 /*
 	Map format serialization version
@@ -97,7 +97,7 @@ void compressZstd(const std::string &data, std::ostream &os, int level = 0);
 void decompressZstd(std::istream &is, std::ostream &os);
 
 // These choose between zlib and a self-made one according to version
-void compress(const SharedBuffer<u8> &data, std::ostream &os, u8 version, int level = -1);
+void compress(View<u8> data, std::ostream &os, u8 version, int level = -1);
 void compress(const std::string &data, std::ostream &os, u8 version, int level = -1);
 void compress(u8 *data, u32 size, std::ostream &os, u8 version, int level = -1);
 void decompress(std::istream &is, std::ostream &os, u8 version);

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -25,6 +25,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 template <typename T>
 class View;
+template <typename T>
+using ConstView = View<const T>;
 
 /*
 	Map format serialization version
@@ -97,7 +99,7 @@ void compressZstd(const std::string &data, std::ostream &os, int level = 0);
 void decompressZstd(std::istream &is, std::ostream &os);
 
 // These choose between zlib and a self-made one according to version
-void compress(View<u8> data, std::ostream &os, u8 version, int level = -1);
+void compress(ConstView<u8> data, std::ostream &os, u8 version, int level = -1);
 void compress(const std::string &data, std::ostream &os, u8 version, int level = -1);
-void compress(u8 *data, u32 size, std::ostream &os, u8 version, int level = -1);
+void compress(const u8 *data, u32 size, std::ostream &os, u8 version, int level = -1);
 void decompress(std::istream &is, std::ostream &os, u8 version);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <queue>
 #include <algorithm>
 #include "network/connection.h"
+#include "network/networkpacket.h"
 #include "network/networkprotocol.h"
 #include "network/serveropcodes.h"
 #include "ban.h"

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -22,6 +22,7 @@ set (UNITTEST_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/test_noderesolver.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_noise.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_objdef.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/test_pointer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_profiler.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_random.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_schematic.cpp

--- a/src/unittest/test_compression.cpp
+++ b/src/unittest/test_compression.cpp
@@ -98,7 +98,7 @@ void TestCompression::testRLECompression()
 		infostream << (u32) i << ",";
 	infostream << std::endl;
 
-	UASSERTEQ(size_t, str_out2.size(), fromdata.getSize());
+	UASSERTEQ(size_t, str_out2.size(), fromdata.size());
 
 	for (u32 i = 0; i < str_out2.size(); i++)
 		UASSERT(str_out2[i] == fromdata[i]);
@@ -113,7 +113,7 @@ void TestCompression::testZlibCompression()
 	fromdata[3]=1;
 
 	std::ostringstream os(std::ios_base::binary);
-	compressZlib(*fromdata, fromdata.getSize(), os);
+	compressZlib(*fromdata, fromdata.size(), os);
 
 	std::string str_out = os.str();
 
@@ -134,7 +134,7 @@ void TestCompression::testZlibCompression()
 		infostream << (u32) i << ",";
 	infostream << std::endl;
 
-	UASSERTEQ(size_t, str_out2.size(), fromdata.getSize());
+	UASSERTEQ(size_t, str_out2.size(), fromdata.size());
 
 	for (u32 i = 0; i < str_out2.size(); i++)
 		UASSERT(str_out2[i] == fromdata[i]);

--- a/src/unittest/test_compression.cpp
+++ b/src/unittest/test_compression.cpp
@@ -58,7 +58,7 @@ void TestCompression::runTests(IGameDef *gamedef)
 
 void TestCompression::testRLECompression()
 {
-	SharedBuffer<u8> fromdata(4);
+	SharedBuffer<u8> fromdata = make_buffer_for_overwrite<u8>(4);
 	fromdata[0]=1;
 	fromdata[1]=5;
 	fromdata[2]=5;
@@ -107,14 +107,14 @@ void TestCompression::testRLECompression()
 
 void TestCompression::testZlibCompression()
 {
-	SharedBuffer<u8> fromdata(4);
+	SharedBuffer<u8> fromdata = make_buffer_for_overwrite<u8>(4);
 	fromdata[0]=1;
 	fromdata[1]=5;
 	fromdata[2]=5;
 	fromdata[3]=1;
 
 	std::ostringstream os(std::ios_base::binary);
-	compressZlib(*fromdata, fromdata.size(), os);
+	compressZlib(fromdata.get(), fromdata.size(), os);
 
 	std::string str_out = os.str();
 

--- a/src/unittest/test_compression.cpp
+++ b/src/unittest/test_compression.cpp
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "serialization.h"
 #include "nodedef.h"
 #include "noise.h"
+#include "util/pointer.h"
 
 class TestCompression : public TestBase {
 public:

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -119,7 +119,7 @@ void TestConnection::testHelpers()
 	u32 proto_id = 0x12345678;
 	session_t peer_id = 123;
 	u8 channel = 2;
-	SharedBuffer<u8> data1(1);
+	SharedBuffer<u8> data1 = make_buffer_for_overwrite<u8>(1);
 	data1[0] = 100;
 	Address a(127,0,0,1, 10);
 	const u16 seqnum = 34352;

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -97,8 +97,8 @@ void TestConnection::testNetworkPacketSerialize()
 		pkt << std::wstring(L"\U00020b9a");
 
 		auto buf = pkt.oldForgePacket();
-		UASSERTEQ(int, buf.getSize(), sizeof(expected));
-		UASSERT(!memcmp(expected, &buf[0], buf.getSize()));
+		UASSERTEQ(int, buf.size(), sizeof(expected));
+		UASSERT(!memcmp(expected, &buf[0], buf.size()));
 	}
 
 	{
@@ -144,13 +144,13 @@ void TestConnection::testHelpers()
 
 	SharedBuffer<u8> p2 = con::makeReliablePacket(data1, seqnum);
 
-	/*infostream<<"p2.getSize()="<<p2.getSize()<<", data1.getSize()="
-			<<data1.getSize()<<std::endl;
+	/*infostream<<"p2.size()="<<p2.size()<<", data1.size()="
+			<<data1.size()<<std::endl;
 	infostream<<"readU8(&p2[3])="<<readU8(&p2[3])
 			<<" p2[3]="<<((u32)p2[3]&0xff)<<std::endl;
 	infostream<<"data1[0]="<<((u32)data1[0]&0xff)<<std::endl;*/
 
-	UASSERT(p2.getSize() == 3 + data1.getSize());
+	UASSERT(p2.size() == 3 + data1.size());
 	UASSERT(readU8(&p2[0]) == con::PACKET_TYPE_RELIABLE);
 	UASSERT(readU16(&p2[1]) == seqnum);
 	UASSERT(readU8(&p2[3]) == data1[0]);
@@ -297,7 +297,7 @@ void TestConnection::testConnectSendReceive()
 
 		auto recvdata = pkt.oldForgePacket();
 
-		UASSERT(memcmp(*sentdata, *recvdata, recvdata.getSize()) == 0);
+		UASSERT(memcmp(sentdata.get(), recvdata.get(), recvdata.size()) == 0);
 	}
 
 	session_t peer_id_client = 2;
@@ -330,7 +330,7 @@ void TestConnection::testConnectSendReceive()
 
 		//sleep_ms(3000);
 
-		Buffer<u8> recvdata;
+		UniqueBuffer<u8> recvdata;
 		infostream << "** running client.Receive()" << std::endl;
 		session_t peer_id = 132;
 		u16 size = 0;
@@ -366,7 +366,7 @@ void TestConnection::testConnectSendReceive()
 			infostream << "...";
 		infostream << std::endl;
 
-		UASSERT(memcmp(*sentdata, *recvdata, recvdata.getSize()) == 0);
+		UASSERT(memcmp(sentdata.get(), recvdata.get(), recvdata.size()) == 0);
 		UASSERT(peer_id == PEER_ID_SERVER);
 	}
 

--- a/src/unittest/test_pointer.cpp
+++ b/src/unittest/test_pointer.cpp
@@ -1,0 +1,209 @@
+/*
+Minetest
+Copyright (C) 2023 DS
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "test.h"
+
+#include "util/pointer.h"
+#include <array>
+
+class TestPointer : public TestBase
+{
+public:
+	TestPointer() { TestManager::registerTestModule(this); }
+	const char *getName() { return "TestPointer"; }
+
+	void runTests(IGameDef *gamedef);
+
+	void testUniqueBuffer();
+	void testSharedBuffer();
+	void testView();
+};
+
+static TestPointer g_test_instance;
+
+void TestPointer::runTests(IGameDef *gamedef)
+{
+	TEST(testUniqueBuffer);
+	TEST(testSharedBuffer);
+	TEST(testView);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TestPointer::testUniqueBuffer()
+{
+	struct A {
+		int a;
+		int b;
+		A() = default;
+		A(int x, int y) : a(x), b(y) {}
+	};
+
+	UniqueBuffer<A> ubuf1 = make_buffer<A>(12);
+	UniqueBuffer<A> ubuf2 = make_buffer_for_overwrite<A>(42);
+	UniqueBuffer<A> ubuf3;
+	UniqueBuffer<A> ubuf4 = make_buffer_for_overwrite<A>(0);
+	ubuf1.at(2) = A(4, 5);
+	ubuf1.at(0);
+	ubuf1.at(11);
+	UASSERT(ubuf1);
+	UASSERT(ubuf2);
+	UASSERT(!ubuf3);
+	UASSERT(!ubuf4);
+
+	ubuf3 = std::move(ubuf2);
+	UASSERT(ubuf3);
+	UASSERT(!ubuf2);
+	UASSERT(ubuf3.size() == 42);
+	UASSERT(ubuf2.size() == 0);
+
+	std::unique_ptr<A[]> up1 = ubuf3.release();
+	std::unique_ptr<A[]> up2 = make_unique_for_overwrite<A[]>(13);
+	std::unique_ptr<A> up3 = make_unique_for_overwrite<A>();
+	std::unique_ptr<A> up4 = std::make_unique<A>(1, 2);
+	UASSERT(!ubuf3);
+	UASSERT(ubuf3.size() == 0);
+
+	ubuf2.reset(std::move(up1), 42);
+	UASSERT(!up1);
+	UASSERT(ubuf2);
+	UASSERT(ubuf2.size() == 42);
+	UASSERT(ubuf2.get());
+
+	ubuf2.copyTo(ubuf3);
+	ubuf3.copyTo(ubuf2);
+	ubuf1 = ubuf3.copy();
+	UASSERT(ubuf1.size() == 42);
+}
+
+void TestPointer::testSharedBuffer()
+{
+	struct A {
+		int a;
+		int b;
+		A() = default;
+		A(int x, int y) : a(x), b(y) {}
+	};
+
+	UniqueBuffer<A> ubuf1 = make_buffer<A>(14);
+	SharedBuffer<A> sbuf1 = make_buffer<A>(13);
+	SharedBuffer<A> sbuf2 = make_buffer_for_overwrite<A>(42);
+	SharedBuffer<A> sbuf3 = std::move(ubuf1);
+	SharedBuffer<A> sbuf4;
+	SharedBuffer<A> sbuf5 = make_buffer<A>(0);
+	sbuf2[0];
+	sbuf3.at(13);
+	UASSERT(sbuf1);
+	UASSERT(sbuf1.get());
+	UASSERT(sbuf1.size() == 13);
+	UASSERT(!sbuf1.empty());
+	UASSERT(sbuf3);
+	UASSERT(sbuf3.size() == 14);
+	UASSERT(ubuf1.empty());
+	UASSERT(!ubuf1);
+	UASSERT(sbuf5.empty());
+	UASSERT(!sbuf5);
+	UASSERT(!sbuf5.get());
+
+	sbuf4 = sbuf3;
+	UASSERT(sbuf4.get() == sbuf3.get());
+
+	sbuf4 = std::move(sbuf3);
+	UASSERT(!sbuf3);
+	UASSERT(sbuf4);
+
+	sbuf2.reset();
+	UASSERT(sbuf2.empty());
+
+	sbuf2 = sbuf4.moveOut();
+	UASSERT(!sbuf4);
+
+	sbuf4 = sbuf2;
+	sbuf5 = sbuf4.moveOrCopyOut();
+	UASSERT(sbuf5.get() != sbuf2.get());
+	UASSERT(!sbuf4);
+	UASSERT(sbuf5);
+	UASSERT(sbuf2);
+}
+
+void TestPointer::testView()
+{
+	struct A {
+		int a;
+		int b;
+		A() = default;
+		A(int x, int y) : a(x), b(y) {}
+	};
+
+	std::array<A, 4> arr1;
+	UniqueBuffer<A> ubuf1 = make_buffer<A>(13);
+	UniqueBuffer<A> ubuf2;
+	SharedBuffer<A> sbuf1 = make_buffer<A>(14);
+
+	View<A> v1;
+	View<A> v2 = nullptr;
+	View<A> v3 = {&arr1[0], arr1.size()};
+	View<A> v4(&arr1[0], arr1.size());
+	View<A> v5 = {arr1.begin(), arr1.end()};
+	View<A> v6 = ubuf1;
+	View<A> v7 = sbuf1;
+	View<A> v8 = {arr1.data(), 1};
+	View<A> v9 = {arr1.data(), 0};
+	View<A> v10 = ubuf2;
+	v7.at(13);
+	UASSERT(!v1);
+	UASSERT(v1.empty());
+	UASSERT(!v1.get());
+	UASSERT(v1.size() == 0);
+	UASSERT(!v2);
+	UASSERT(v3.get() == arr1.data());
+	UASSERT(v3.size() == 4);
+	UASSERT(!v3.empty());
+	UASSERT(v4.size() == 4);
+	UASSERT(v4.get() == v3.get());
+	UASSERT(v5.size() == 4);
+	UASSERT(v5.get() == v3.get());
+	UASSERT(v6.get() == ubuf1.get());
+	UASSERT(v6.size() == ubuf1.size());
+	UASSERT(v7.get() == sbuf1.get());
+	UASSERT(v7.size() == sbuf1.size());
+	UASSERT(v8.get() == arr1.data());
+	UASSERT(v8.size() == 1);
+	UASSERT(v9.get() == arr1.data());
+	UASSERT(v9.size() == 0);
+	UASSERT(v9.empty());
+	UASSERT(v9);
+	UASSERT(!v10);
+	UASSERT(v10.size() == 0);
+
+	v6.reset();
+	v7.reset(arr1.data(), 2);
+	v8.reset(v8.begin()+1, v8.end());
+	ubuf2 = v3.copy();
+	UASSERT(!v6);
+	UASSERT(v6.empty());
+	UASSERT(v7.get() == arr1.data());
+	UASSERT(v7.size() == 2);
+	UASSERT(v8.get() == &arr1[1]);
+	UASSERT(v8.size() == 0);
+	UASSERT(v8.get() == &arr1[1]);
+	UASSERT(v8.size() == 0);
+	UASSERT(ubuf2);
+	UASSERT(ubuf2.size() == 4);
+}

--- a/src/util/pointer.h
+++ b/src/util/pointer.h
@@ -25,19 +25,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <memory> // std::shared_ptr
 
 
-template<typename T> class ConstSharedPtr {
-public:
-	ConstSharedPtr(T *ptr) : ptr(ptr) {}
-	ConstSharedPtr(const std::shared_ptr<T> &ptr) : ptr(ptr) {}
-
-	const T* get() const noexcept { return ptr.get(); }
-	const T& operator*() const noexcept { return *ptr.get(); }
-	const T* operator->() const noexcept { return ptr.get(); }
-
-private:
-	std::shared_ptr<T> ptr;
-};
-
 template <typename T>
 class Buffer
 {


### PR DESCRIPTION
This is a maintenance/refactor PR.

We have smart-ptrs for buffers, i.e. SharedBuffer<T>. These are mainly used for network stuff.

Improvements:
* Less unnecessary copying and value-initialization (aka 0-initialization).
* Types bigger than 1 byte work. (There were `memcpy`s that didn't take the type's size into account.)
* Values are copied using copy constructor (as opposed to forced memcpy).
* Copies are explicit: `some_fun(buffer.copy())` instead of `some_fun(buffer)`
* There's a `View<T>` class, and `ConstView<T> = View<const T>`, for borrowing buffer data.
* `Buffer<T>` is replaced with `UniqueBuffer<T>`, which is a more descriptive and grep-able name. It also does things different than `Buffer<T>`, it's essentially a `unique_ptr<T[]>` with a size.
* There's also a `make_unique_for_override` function (like the C++20 thing).
* `ConstSharedPtr<T>` is removed. It was just essentially a `shared_ptr<const T>` and not worth keeping.
* There are unittests.

## To do

This PR is a Ready for Review.

## How to test

* Compile.
* Run the unittests: `$ minetest_dev --run-unittests`
* Look at the code.
* Look at util/pointer.h first.
