### PR TITLE
Restart map-send cycle if visible blocks are soon to be unloaded.

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -187,12 +187,14 @@ void RemoteClient::GetNextBlocks (
 	if (m_last_center != center) {
 		m_nearest_unsent_d = 0;
 		m_last_center = center;
+		m_map_send_completion_timer = 0.0f;
 	}
 	// reset the unsent distance if the view angle has changed more that 10% of the fov
 	// (this matches isBlockInSight which allows for an extra 10%)
 	if (camera_dir.dotProduct(m_last_camera_dir) < std::cos(camera_fov * 0.1f)) {
 		m_nearest_unsent_d = 0;
 		m_last_camera_dir = camera_dir;
+		m_map_send_completion_timer = 0.0f;
 	}
 	if (m_nearest_unsent_d > 0) {
 		// make sure any blocks modified since the last time we sent blocks are resent

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -102,10 +102,10 @@ void RemoteClient::GetNextBlocks (
 	m_map_send_completion_timer += dtime;
 
 	if (m_map_send_completion_timer > g_settings->getFloat("server_unload_unused_data_timeout") * 0.8f) {
-		infostream << "Server: Player " << m_name << ", RemoteClient " << peer_id
-				<< ": full map send is taking too long "
+		infostream << "Server: Player " << m_name << ", peer_id=" << peer_id
+				<< ": full map send is taking too long ("
 				<< m_map_send_completion_timer
-				<< "s, restarting to avoid visible blocks being unloaded."
+				<< "s), restarting to avoid visible blocks being unloaded."
 				<< std::endl;
 		m_map_send_completion_timer = 0.0f;
 		m_nearest_unsent_d = 0;

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -102,11 +102,10 @@ void RemoteClient::GetNextBlocks (
 	m_map_send_completion_timer += dtime;
 
 	if (m_map_send_completion_timer > g_settings->getFloat("server_unload_unused_data_timeout") * 0.8f) {
-		warningstream << "Server: Player " << m_name << ", RemoteClient " << peer_id
+		infostream << "Server: Player " << m_name << ", RemoteClient " << peer_id
 				<< ": full map send is taking too long "
 				<< m_map_send_completion_timer
-				<< "s, restarting to avoid visible blocks being unloaded. \n"
-				<< "Consider increasing `server_unload_unused_data_timeout`"
+				<< "s, restarting to avoid visible blocks being unloaded."
 				<< std::endl;
 		m_map_send_completion_timer = 0.0f;
 		m_nearest_unsent_d = 0;


### PR DESCRIPTION
Implements (8) from #13262

Background: If the server takes longer to cycle through the distance layers for a remote client then its configured unload timeout, it will unload blocks visible to the client (just to then reload them again, and in the process temporarily making some occlusion culled blocks visible that are now sent to the client unnecessarily)

The idea is to detect when this is about to happen and then start with the closest blocks again (for each client). These are likely at the client and won't have to be resent, so handling those layers is quick, and in the process the blocks' usage timers are reset.
This is done per client, so the server will keep the important parts of the map in memory and is allowed to unload the rest.

I tested this and it works quite well.

An additional benefit is that *if* blocks are unloaded, it will more likely hit the distant ones, and that has two advantages: (1) closed unloaded blocks won't make distant blocks visible temporarily, and (2) distant blocks are ... distant, so are less noticed.

## To do

This PR is a Ready for Review; but needs testing.

## How to test

Set viewing_range to 1000 (and all the corresponding server settings). Observe how long the map takes to load and how many blocks are loaded. Then set `server_unload_unused_data_timeout` to 600 and try again. Note that the maps loads faster and fewer blocks are sent (because no blocks are unloaded).

Then reset `server_unload_unused_data_timeout` to its default (29s) and apply this PR.
Note the warnings, but also that the map loads in roughly the same time (only slightly slower) compared to the larger unload setting and that fewer blocks are sent again.
