### PR TITLE
Fix core.item_eat for same-item replace_with_item and split stacks before dropping

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -390,22 +390,20 @@ function core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed
 
 	-- Changing hp might kill the player causing mods to do who-knows-what to the
 	-- inventory, so do this before set_hp().
-	if replace_with_item then
-		if itemstack:is_empty() then
-			itemstack:add_item(replace_with_item)
-		else
-			local inv = user:get_inventory()
-			-- Check if inv is null, since non-players don't have one
-			if inv and inv:room_for_item("main", {name=replace_with_item}) then
-				inv:add_item("main", replace_with_item)
-			else
+	user:set_wielded_item(itemstack)
+	replace_with_item = ItemStack(replace_with_item)
+	if not replace_with_item:is_empty() then
+		local inv = user:get_inventory()
+		-- Check if inv is null, since non-players don't have one
+		if inv then
+			replace_with_item = inv:add_item("main", replace_with_item)
+			if not replace_with_item:is_empty() then
 				local pos = user:get_pos()
 				pos.y = math.floor(pos.y + 0.5)
 				core.add_item(pos, replace_with_item)
 			end
 		end
 	end
-	user:set_wielded_item(itemstack)
 
 	user:set_hp(user:get_hp() + hp_change)
 

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -397,11 +397,11 @@ function core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed
 		-- Check if inv is null, since non-players don't have one
 		if inv then
 			replace_with_item = inv:add_item("main", replace_with_item)
-			if not replace_with_item:is_empty() then
-				local pos = user:get_pos()
-				pos.y = math.floor(pos.y + 0.5)
-				core.add_item(pos, replace_with_item)
-			end
+		end
+		if not replace_with_item:is_empty() then
+			local pos = user:get_pos()
+			pos.y = math.floor(pos.y + 0.5)
+			core.add_item(pos, replace_with_item)
 		end
 	end
 

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -390,19 +390,19 @@ function core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed
 
 	-- Changing hp might kill the player causing mods to do who-knows-what to the
 	-- inventory, so do this before set_hp().
+	replace_with_item = itemstack:add_item(replace_with_item)
 	user:set_wielded_item(itemstack)
-	replace_with_item = ItemStack(replace_with_item)
 	if not replace_with_item:is_empty() then
 		local inv = user:get_inventory()
 		-- Check if inv is null, since non-players don't have one
 		if inv then
 			replace_with_item = inv:add_item("main", replace_with_item)
 		end
-		if not replace_with_item:is_empty() then
-			local pos = user:get_pos()
-			pos.y = math.floor(pos.y + 0.5)
-			core.add_item(pos, replace_with_item)
-		end
+	end
+	if not replace_with_item:is_empty() then
+		local pos = user:get_pos()
+		pos.y = math.floor(pos.y + 0.5)
+		core.add_item(pos, replace_with_item)
 	end
 
 	user:set_hp(user:get_hp() + hp_change)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6064,8 +6064,8 @@ Defaults for the `on_place` and `on_drop` item definition functions
     * Returns `function(itemstack, user, pointed_thing)` as a
       function wrapper for `minetest.do_item_eat`.
     * `replace_with_item` is the itemstring which is added to the inventory.
-      If the player is eating a stack, then replace_with_item goes to a
-      different spot.
+      If the player is eating a stack and `replace_with_item` doesn't fit onto
+      the eaten stack, then the remainings go to a different spot, or are dropped.
 
 Defaults for the `on_punch` and `on_dig` node definition callbacks
 ------------------------------------------------------------------


### PR DESCRIPTION
The replace_with_item can be added to the slot of the wield item, which is afterwards overwritten. This causes item loss.
This PR fixes this.

Also, if the inventory is full, the replace item is first split up and only the remains are dropped.

This is a bugfix.

Bug was introduced / not properly fixed here: https://github.com/minetest/minetest/commit/efa977518a60c47f3c409449be202298900372e8

## To do

This PR is a Ready for Review.

## How to test

```lua
minetest.register_craftitem("test_eat_repl:food", {
	description = "Food1",
	inventory_image = "default_dirt.png",
	stack_max = 16,
	on_use = minetest.item_eat(1, "test_eat_repl:food 4"),
})

minetest.register_craftitem("test_eat_repl:food2", {
	description = "Food2",
	inventory_image = "default_dirt.png^default_apple.png",
	stack_max = 16,
	on_use = minetest.item_eat(1, "basenodes:dirt 2"),
})

minetest.register_craftitem("test_eat_repl:food3", {
	description = "Food3",
	inventory_image = "default_apple.png",
	stack_max = 16,
	on_use = minetest.item_eat(1),
})
```

Eat it.