### PR TITLE
Fix missing shadows when sun tilt is zero

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -392,7 +392,7 @@ void main(void)
 		float distance_rate = (1.0 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 10.0));
 		if (max(abs(posLightSpace.x - 0.5), abs(posLightSpace.y - 0.5)) > 0.5)
 			distance_rate = 0.0;
-		float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z),0.0);
+		float f_adj_shadow_strength = max(adj_shadow_strength - mtsmoothstep(0.9, 1.1, posLightSpace.z),0.0);
 
 		if (distance_rate > 1e-7) {
 

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -241,7 +241,7 @@ void main(void)
 		float pFactor = getPerspectiveFactor(getRelativePosition(m_ShadowViewProj * mWorld * shadow_pos));
 		if (f_normal_length > 0.0) {
 			nNormal = normalize(vNormal);
-			cosLight = dot(nNormal, -v_LightDirection);
+			cosLight = max(1e-5, dot(nNormal, -v_LightDirection));
 			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
 			normalOffsetScale = 2.0 * pFactor * pFactor * sinLight * min(f_shadowfar, 500.0) /
 					xyPerspectiveBias1 / f_textureresolution;

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -393,7 +393,7 @@ void main(void)
 		float distance_rate = (1.0 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 10.0));
 		if (max(abs(posLightSpace.x - 0.5), abs(posLightSpace.y - 0.5)) > 0.5)
 			distance_rate = 0.0;
-		float f_adj_shadow_strength = max(adj_shadow_strength-mtsmoothstep(0.9,1.1,  posLightSpace.z),0.0);
+		float f_adj_shadow_strength = max(adj_shadow_strength - mtsmoothstep(0.9, 1.1, posLightSpace.z),0.0);
 
 		if (distance_rate > 1e-7) {
 

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -146,7 +146,7 @@ void main(void)
 		float pFactor = getPerspectiveFactor(getRelativePosition(m_ShadowViewProj * mWorld * inVertexPosition));
 		if (f_normal_length > 0.0) {
 			nNormal = normalize(vNormal);
-			cosLight = dot(nNormal, -v_LightDirection);
+			cosLight = max(1e-5, dot(nNormal, -v_LightDirection));
 			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
 			normalOffsetScale = 0.1 * pFactor * pFactor * sinLight * min(f_shadowfar, 500.0) / 
 					xyPerspectiveBias1 / f_textureresolution;


### PR DESCRIPTION
This PR fixes calculation errors for shadow offset values used to mitigate shadow acne. The errors caused shadow not to be rendered on some sides of nodes and entities depending on the orientation in space.

Example:
![image](https://user-images.githubusercontent.com/4933697/223265689-b10354ad-91d7-4b1a-bc43-eb0aa0d282f5.png)

Correct rendering:
![image](https://user-images.githubusercontent.com/4933697/223265921-55cd0f26-36f3-4543-85c6-88a8e6179a93.png)


## To do

This PR is Ready for Review.

## How to test

1. Use defaults in 5.7.0
2. Enable shadows
3. Start MTG game
4. Check the shadowing of Z-facing sides of the nodes
5. Add hot air baloons mod
6. Place a baloon in the world
7. Check the shadowing of Z-facing sides of the baloon.


