### PR TITLE
Fix occasional black screen on startup

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -555,7 +555,7 @@ public:
 		m_animation_timer_vertex.set(&animation_timer_f, services);
 		m_animation_timer_pixel.set(&animation_timer_f, services);
 
-		float animation_timer_delta_f = rangelim((float)m_client->getEnv().getFrameTimeDelta() / 100000.f, 0.f, 1.f);
+		float animation_timer_delta_f = (float)m_client->getEnv().getFrameTimeDelta() / 100000.f;
 		m_animation_timer_delta_vertex.set(&animation_timer_delta_f, services);
 		m_animation_timer_delta_pixel.set(&animation_timer_delta_f, services);
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -555,7 +555,7 @@ public:
 		m_animation_timer_vertex.set(&animation_timer_f, services);
 		m_animation_timer_pixel.set(&animation_timer_f, services);
 
-		float animation_timer_delta_f = (float)m_client->getEnv().getFrameTimeDelta() / 100000.f;
+		float animation_timer_delta_f = rangelim((float)m_client->getEnv().getFrameTimeDelta() / 100000.f, 0.f, 1.f);
 		m_animation_timer_delta_vertex.set(&animation_timer_delta_f, services);
 		m_animation_timer_delta_pixel.set(&animation_timer_delta_f, services);
 

--- a/src/client/render/pipeline.cpp
+++ b/src/client/render/pipeline.cpp
@@ -140,7 +140,8 @@ bool TextureBuffer::ensureTexture(video::ITexture **texture, const TextureDefini
 	if (definition.valid) {
 		if (definition.clear) {
 			video::IImage *image = m_driver->createImage(definition.format, size);
-			image->fill(0u);
+			// Cannot use image->fill because it's not implemented for all formats.
+			std::memset(image->getData(), 0, image->getDataSizeFromFormat(definition.format, size.Width, size.Height));
 			*texture = m_driver->addTexture(definition.name.c_str(), image);
 			image->drop();
 		}


### PR DESCRIPTION
Presumably fixes a case of black screen on game start when incorrect input to exponentiation sends exposure compensation through the roof.

The fix in #13151 was defunct because Irrlicht does not implement IImage::fill() for the texture formats that we use in TextureBuffer. I've changed the to a memset() with zeros for now.

## To do

This PR is Ready for Review.

## How to test

1. Enable dynamic exposure
2. Start any world (possibly multiple times)
3. World is rendered properly, no black screen.
