### PR TITLE
Add additional game information to pause menu

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4429,7 +4429,10 @@ void Game::showPauseMenu()
 		}
 		os << "\n" << strgettext("- Port: ") << serverAddress.getPort() << "\n";
 	} else {
-		os << mode << strgettext("Singleplayer") << "\n";
+		std::string singleplayer_path = g_settings->get("selected_world_path");
+		os << mode << strgettext("Singleplayer") << "\n"
+		<< strgettext("- World: ") << getWorldName(singleplayer_path, strgettext("Unnamed World")) << "\n"
+		<< strgettext("- Game: ") << findWorldSubgame(singleplayer_path).title << "\n";
 	}
 	if (simple_singleplayer_mode || address.empty()) {
 		static const std::string on = strgettext("On");

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4429,10 +4429,10 @@ void Game::showPauseMenu()
 		}
 		os << "\n" << strgettext("- Port: ") << serverAddress.getPort() << "\n";
 	} else {
-		std::string singleplayer_path = g_settings->get("selected_world_path");
+		std::string WorldPath = server->getWorldPath();
 		os << mode << strgettext("Singleplayer") << "\n"
-		<< strgettext("- World: ") << getWorldName(singleplayer_path, strgettext("Unnamed World")) << "\n"
-		<< strgettext("- Game: ") << findWorldSubgame(singleplayer_path).title << "\n";
+		<< strgettext("- World: ") << getWorldName(WorldPath, strgettext("Unnamed World")) << "\n"
+		<< strgettext("- Game: ") << findWorldSubgame(WorldPath).title << "\n";
 	}
 	if (simple_singleplayer_mode || address.empty()) {
 		static const std::string on = strgettext("On");


### PR DESCRIPTION
Adds additional game information such as game name and world name to the singleplayer pause menu.

Fixes #11076.

## To do

This PR is ready for review and any suggestions for additional parameters.
<!-- ^ delete one -->

- [ ] Add any more suggested game info parameters.
- [x] Make it simpler?

## How to test

Open several worlds across several games, and make sure the game and world names show up correctly.
