### PR TITLE
Fix ChatPrompt crash in very narrow windows

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -672,7 +672,7 @@ std::wstring ChatPrompt::getVisiblePortion() const
 {
 	const std::wstring &line_ref = getLineRef();
 	if ((size_t)m_view >= line_ref.size())
-		return L"";
+		return m_prompt;
 	else
 		return m_prompt + line_ref.substr(m_view, m_cols);
 }

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -229,8 +229,8 @@ void ChatBuffer::scrollBottom()
 	m_scroll = getBottomScrollPos();
 }
 
-u32 ChatBuffer::formatChatLine(const ChatLine& line, u32 cols,
-		std::vector<ChatFormattedLine>& destination) const
+u32 ChatBuffer::formatChatLine(const ChatLine &line, u32 cols,
+		std::vector<ChatFormattedLine> &destination) const
 {
 	u32 num_added = 0;
 	std::vector<ChatFormattedFragment> next_frags;
@@ -269,7 +269,10 @@ u32 ChatBuffer::formatChatLine(const ChatLine& line, u32 cols,
 		// Very long names
 		hanging_indentation = 2;
 	}
-	//EnrichedString line_text(line.text);
+	// If there are no columns remaining after the indentation (window is very
+	// narrow), we can't write anything
+	if (hanging_indentation >= cols)
+		return 0;
 
 	next_line.first = true;
 	// Set/use forced newline after the last frag in each line

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -670,7 +670,11 @@ void ChatPrompt::reformat(u32 cols)
 
 std::wstring ChatPrompt::getVisiblePortion() const
 {
-	return m_prompt + getLineRef().substr(m_view, m_cols);
+	const std::wstring &line_ref = getLineRef();
+	if ((size_t)m_view >= line_ref.size())
+		return L"";
+	else
+		return m_prompt + line_ref.substr(m_view, m_cols);
 }
 
 s32 ChatPrompt::getVisibleCursorPosition() const


### PR DESCRIPTION
Fixes #13298.

In very narrow windows, `m_cols` can be small (i.e. 0).
Hence, `m_view <= m_line.size() + 1 - m_cols` (see `clampView()`) does not guarantee `m_view <= m_line.size()`.
`std::string::substr(pos, npos)` requires `pos <= size()`.

Second commit fixes an infinite loop happening if a window is very narrow and there's a player message in opened chat. The reason for this seems to be related to the indentation happening in follow-up lines.

## To do

This PR is a RFR.

## How to test

First commit:
* Open chat.
* Resize your window to be *very* narrow.

Second commit:
* Checkout first commit.
* Write something into chat.
* Open chat.
* Resize your window to be *very* narrow.
* Kill minetest before it eats up all your memory.