### PR TITLE
Update nodes in LBM loop

### DIFF
--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -282,6 +282,9 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block,
 						continue;
 					for (auto lbmdef : *lbm_list) {
 						lbmdef->trigger(env, pos + pos_of_block, n, dtime_s);
+						n = block->getNodeNoCheck(pos);
+						if (n.getContent() != c)
+							break; // The node was changed and the LBMs no longer apply
 					}
 				}
 	}


### PR DESCRIPTION
(Unmodified) adopted first commit of #13025.

(Same as for ABMs, see #12998.)

## To do

This PR is a Ready for Review.

## How to test

```lua
minetest.register_node("test_tmp:node1", {
	description = "Node1",
	tiles = {"default_pine_tree_top.png"},
	groups = { dig_immediate = 2 },
})

local check_param2 = false -- also try true here

local function create_lbm_action(where)
	return function(pos, node, dtime_s)
		local actual_node = minetest.get_node(pos)
		assert(node.name == "test_tmp:node1", where.." (check1)")
		assert(actual_node.name == node.name, where.." (check2)")
		assert(actual_node.param1 == node.param1, where.." (check3)")
		assert(actual_node.param2 == node.param2, where.." (check4)")

		if check_param2 then
			minetest.set_node(pos, {name = node.name, param2 = node.param2 + 1})
		else
			minetest.remove_node(pos)
		end
	end
end

minetest.register_lbm({
	label = "Remove Node1 (1)",
	name = "test_tmp:remove_node1_1",
	nodenames = {"test_tmp:node1"},
	run_at_every_load = true,
	action = create_lbm_action("test_tmp:remove_node1_1"),
})

minetest.register_lbm({
	label = "Remove Node1 (2)",
	name = "test_tmp:remove_node1_2",
	nodenames = {"test_tmp:node1"},
	run_at_every_load = true,
	action = create_lbm_action("test_tmp:remove_node1_2"),
})
```

* Place a Node1.
* Trigger lbm.
* It should not crash.
* Also try with `check_param2 = true`.