### PR TITLE
Fix safeLoadFile() skipping 2 chars too much from the shebang

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -457,11 +457,10 @@ bool ScriptApiSecurity::safeLoadFile(lua_State *L, const char *path, const char 
 	size_t start = 0;
 	int c = std::getc(fp);
 	if (c == '#') {
-		// Skip the first line
-		while ((c = std::getc(fp)) != EOF && c != '\n') {}
-		if (c == '\n')
-			std::getc(fp);
-		start = std::ftell(fp);
+		// Skip the content of the first line
+		while (c != EOF && c != '\n')
+			c = std::getc(fp);
+		start = std::ftell(fp) - 1;
 	}
 
 	// Read the file

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -457,7 +457,7 @@ bool ScriptApiSecurity::safeLoadFile(lua_State *L, const char *path, const char 
 	size_t start = 0;
 	int c = std::getc(fp);
 	if (c == '#') {
-		// Skip the content of the first line
+		// Skip the shebang line (but keep line-ending)
 		while (c != EOF && c != '\n')
 			c = std::getc(fp);
 		start = std::ftell(fp) - 1;


### PR DESCRIPTION

* If there's no EOF after the shebang, the char after '\n' is read, which is the char of the next line. This is just wrong. It either reads the '\n' of the next (empty) line, or it removes part of the code there, causing weird errors.
* Even the '\n' in the shebang's line should be kept, to get correct line numbers.

(Btw. it's weird that our `loadfile` supports loading from stdin.)

## To do

This PR is a Ready for Review.

## How to test

In init.lua:
```lua
--#bla

"fail
```
vs.
```lua
#bla

"fail
```
And compare the error msg lines.

Or, for example:
```lua
#bla
print("bla")
```
In master, `print` becomes `rint`.