### PR TITLE
Add debug output for exposure

### DIFF
--- a/client/shaders/second_stage/opengl_vertex.glsl
+++ b/client/shaders/second_stage/opengl_vertex.glsl
@@ -4,6 +4,9 @@
 uniform sampler2D exposureMap;
 
 varying float exposure;
+varying float ll;
+varying float ev;
+varying float targetEv;
 #endif
 
 #ifdef GL_ES
@@ -16,8 +19,11 @@ void main(void)
 {
 #ifdef ENABLE_AUTO_EXPOSURE
 	// value in the texture is on a logarithtmic scale
-	exposure = texture2D(exposureMap, vec2(0.5)).r;
-	exposure = pow(2., exposure);
+	vec4 sample = texture2D(exposureMap, vec2(0.5));
+	ev = sample.r;
+	targetEv = sample.g;
+	ll = sample.b;
+	exposure = pow(2., ev);
 #endif
 
 	varTexCoord.st = inTexCoord0.st;

--- a/client/shaders/update_exposure/opengl_fragment.glsl
+++ b/client/shaders/update_exposure/opengl_fragment.glsl
@@ -65,11 +65,10 @@ void main(void)
 	// 3. exposure = 1 / Lmax
 	//    => exposure = 2^EC / (9.6 * luminance)
 	float wantedExposure = exposureParams.exposureCorrection - log(luminance)/0.693147180559945 - 3.263034405833794;
+	float speed = wantedExposure < previousExposure ? exposureParams.speedDarkBright : exposureParams.speedBrightDark;
+	float result = mix(wantedExposure, previousExposure, exp(-animationTimerDelta * speed));
 
-	if (wantedExposure < previousExposure)
-		wantedExposure = mix(wantedExposure, previousExposure, exp(-animationTimerDelta * exposureParams.speedDarkBright)); // dark -> bright
-	else
-		wantedExposure = mix(wantedExposure, previousExposure, exp(-animationTimerDelta * exposureParams.speedBrightDark)); // bright -> dark
+	result = clamp(result, -20., 20.);
 
-	gl_FragColor = vec4(vec3(wantedExposure), 1.);
+	gl_FragColor = vec4(result, wantedExposure, -log(luminance), 1.);
 }


### PR DESCRIPTION
Display measured luminance (green), target exposure (blue) and current exposure (red) on a log2 (EV) scale from -20 to 20. Ticks at +-1,2,3,4... For the fun of it.

What would be the best way to integrate this into the debug information? I'm thinking another F5 mode for bloom and F5 mode for this.

## To do

This PR is a Work in Progress

## How to test

1. Enable dynamic exposure
2. Start devtest
3. Use `/set_lighting` to tune exposure parameters
4. See the bars move around as the scene changes.
