### PR TITLE
formspec model camera position control

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2566,7 +2566,7 @@ Elements
     * Requires formspec version >= 6.
     * See `background9[]` documentation for more information.
 
-### `model[<X>,<Y>;<W>,<H>;<name>;<mesh>;<textures>;<rotation X,Y>;<continuous>;<mouse control>;<frame loop range>;<animation speed>]`
+### `model[<X>,<Y>;<W>,<H>;<name>;<mesh>;<textures>;<rotation X,Y>;<continuous>;<mouse control>;<frame loop range>;<animation speed>;<camera offset>;<camera distance clamp>]`
 
 * Show a mesh model.
 * `name`: Element name that can be used for styling
@@ -2581,6 +2581,14 @@ Elements
     * Defaults to the full range of all available frames.
     * Syntax: `<begin>,<end>`
 * `animation speed` (Optional): Sets the animation speed. Default 0 FPS.
+* `camera offset` (Optional): Sets the camera offset from the origin of the mesh. 
+    * Defaults to no offset.
+    * Syntax: `<X>,<Y>,<Z>`
+* `camera distance clamp` (Optional): Clamps the camera's distance from the mesh. Either one or two numbers can be supplied. 
+    * If one number `<min>` is used, and it is the minimum distance the camera can be from the model's origin.
+    * If two numbers `<min>,<max>` are used, it is the minimum and maximum clamping distance from the model's origin.
+    * If both numbers are 0, then the camera distance is unclamped.
+    * Defaults to no clamp distance.
 
 ### `item_image[<X>,<Y>;<W>,<H>;<item name>]`
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -17,7 +17,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-
 #include <cstdlib>
 #include <cmath>
 #include <algorithm>
@@ -39,7 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/renderingengine.h"
 #include "log.h"
 #include "client/tile.h" // ITextureSource
-#include "client/hud.h" // drawItemStack
+#include "client/hud.h"	 // drawItemStack
 #include "filesys.h"
 #include "gettime.h"
 #include "gettext.h"
@@ -68,24 +67,25 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiHyperText.h"
 #include "guiScene.h"
 
-#define MY_CHECKPOS(a,b)													\
-	if (v_pos.size() != 2) {												\
-		errorstream<< "Invalid pos for element " << a << " specified: \""	\
-			<< parts[b] << "\"" << std::endl;								\
-			return;															\
+#define MY_CHECKPOS(a, b)                                                                \
+	if (v_pos.size() != 2) {                                                             \
+		errorstream << "Invalid pos for element " << a << " specified: \"" << parts[b]   \
+					<< "\"" << std::endl;                                                \
+		return;                                                                          \
 	}
 
-#define MY_CHECKGEOM(a,b)													\
-	if (v_geom.size() != 2) {												\
-		errorstream<< "Invalid geometry for element " << a <<				\
-			" specified: \"" << parts[b] << "\"" << std::endl;				\
-			return;															\
+#define MY_CHECKGEOM(a, b)                                                               \
+	if (v_geom.size() != 2) {                                                            \
+		errorstream << "Invalid geometry for element " << a << " specified: \""          \
+					<< parts[b] << "\"" << std::endl;                                    \
+		return;                                                                          \
 	}
 
-#define MY_CHECKCLIENT(a) \
-	if (!m_client) { \
-		errorstream << "Attempted to use element " << a << " with m_client == nullptr." << std::endl; \
-		return; \
+#define MY_CHECKCLIENT(a)                                                                \
+	if (!m_client) {                                                                     \
+		errorstream << "Attempted to use element " << a << " with m_client == nullptr."  \
+					<< std::endl;                                                        \
+		return;                                                                          \
 	}
 
 /*
@@ -98,23 +98,17 @@ static unsigned int font_line_height(gui::IGUIFont *font)
 
 inline u32 clamp_u8(s32 value)
 {
-	return (u32) MYMIN(MYMAX(value, 0), 255);
+	return (u32)MYMIN(MYMAX(value, 0), 255);
 }
 
-GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
-		gui::IGUIElement *parent, s32 id, IMenuManager *menumgr,
-		Client *client, gui::IGUIEnvironment *guienv, ISimpleTextureSource *tsrc,
-		ISoundManager *sound_manager, IFormSource *fsrc, TextDest *tdst,
-		const std::string &formspecPrepend, bool remap_dbl_click):
-	GUIModalMenu(guienv, parent, id, menumgr, remap_dbl_click),
-	m_invmgr(client),
-	m_tsrc(tsrc),
-	m_sound_manager(sound_manager),
-	m_client(client),
-	m_formspec_prepend(formspecPrepend),
-	m_form_src(fsrc),
-	m_text_dst(tdst),
-	m_joystick(joystick)
+GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick, gui::IGUIElement *parent,
+		s32 id, IMenuManager *menumgr, Client *client, gui::IGUIEnvironment *guienv,
+		ISimpleTextureSource *tsrc, ISoundManager *sound_manager, IFormSource *fsrc,
+		TextDest *tdst, const std::string &formspecPrepend, bool remap_dbl_click) :
+		GUIModalMenu(guienv, parent, id, menumgr, remap_dbl_click),
+		m_invmgr(client), m_tsrc(tsrc), m_sound_manager(sound_manager), m_client(client),
+		m_formspec_prepend(formspecPrepend), m_form_src(fsrc), m_text_dst(tdst),
+		m_joystick(joystick)
 {
 	current_keys_pending.key_down = false;
 	current_keys_pending.key_up = false;
@@ -135,13 +129,14 @@ GUIFormSpecMenu::~GUIFormSpecMenu()
 }
 
 void GUIFormSpecMenu::create(GUIFormSpecMenu *&cur_formspec, Client *client,
-	gui::IGUIEnvironment *guienv, JoystickController *joystick, IFormSource *fs_src,
-	TextDest *txt_dest, const std::string &formspecPrepend, ISoundManager *sound_manager)
+		gui::IGUIEnvironment *guienv, JoystickController *joystick, IFormSource *fs_src,
+		TextDest *txt_dest, const std::string &formspecPrepend,
+		ISoundManager *sound_manager)
 {
 	if (cur_formspec == nullptr) {
-		cur_formspec = new GUIFormSpecMenu(joystick, guiroot, -1, &g_menumgr,
-			client, guienv, client->getTextureSource(), sound_manager, fs_src,
-			txt_dest, formspecPrepend);
+		cur_formspec = new GUIFormSpecMenu(joystick, guiroot, -1, &g_menumgr, client,
+				guienv, client->getTextureSource(), sound_manager, fs_src, txt_dest,
+				formspecPrepend);
 		cur_formspec->doPause = false;
 
 		/*
@@ -178,12 +173,11 @@ void GUIFormSpecMenu::setInitialFocus()
 	// 5. first focusable (not statictext, not tabheader)
 	// 6. first child element
 
-	const auto& children = getChildren();
+	const auto &children = getChildren();
 
 	// 1. first empty editbox
 	for (gui::IGUIElement *it : children) {
-		if (it->getType() == gui::EGUIET_EDIT_BOX
-				&& it->getText()[0] == 0) {
+		if (it->getType() == gui::EGUIET_EDIT_BOX && it->getText()[0] == 0) {
 			Environment->setFocus(it);
 			return;
 		}
@@ -216,7 +210,7 @@ void GUIFormSpecMenu::setInitialFocus()
 	// 5. first focusable (not statictext, not tabheader)
 	for (gui::IGUIElement *it : children) {
 		if (it->getType() != gui::EGUIET_STATIC_TEXT &&
-			it->getType() != gui::EGUIET_TAB_CONTROL) {
+				it->getType() != gui::EGUIET_TAB_CONTROL) {
 			Environment->setFocus(it);
 			return;
 		}
@@ -229,7 +223,7 @@ void GUIFormSpecMenu::setInitialFocus()
 		Environment->setFocus(children.front());
 }
 
-GUITable* GUIFormSpecMenu::getTable(const std::string &tablename)
+GUITable *GUIFormSpecMenu::getTable(const std::string &tablename)
 {
 	for (auto &table : m_tables) {
 		if (tablename == table.first.fname)
@@ -238,7 +232,7 @@ GUITable* GUIFormSpecMenu::getTable(const std::string &tablename)
 	return 0;
 }
 
-std::vector<std::string>* GUIFormSpecMenu::getDropDownValues(const std::string &name)
+std::vector<std::string> *GUIFormSpecMenu::getDropDownValues(const std::string &name)
 {
 	for (auto &dropdown : m_dropdowns) {
 		if (name == dropdown.first.fname)
@@ -260,7 +254,7 @@ v2s32 GUIFormSpecMenu::getElementBasePos(const std::vector<std::string> *v_pos)
 v2s32 GUIFormSpecMenu::getRealCoordinateBasePos(const std::vector<std::string> &v_pos)
 {
 	return v2s32((stof(v_pos[0]) + pos_offset.X) * imgsize.X,
-		(stof(v_pos[1]) + pos_offset.Y) * imgsize.Y);
+			(stof(v_pos[1]) + pos_offset.Y) * imgsize.Y);
 }
 
 v2s32 GUIFormSpecMenu::getRealCoordinateGeometry(const std::vector<std::string> &v_geom)
@@ -269,26 +263,27 @@ v2s32 GUIFormSpecMenu::getRealCoordinateGeometry(const std::vector<std::string> 
 }
 
 bool GUIFormSpecMenu::precheckElement(const std::string &name, const std::string &element,
-	size_t args_min, size_t args_max, std::vector<std::string> &parts)
+		size_t args_min, size_t args_max, std::vector<std::string> &parts)
 {
 	parts = split(element, ';');
-	if (parts.size() >= args_min && (parts.size() <= args_max || m_formspec_version > FORMSPEC_API_VERSION))
+	if (parts.size() >= args_min &&
+			(parts.size() <= args_max || m_formspec_version > FORMSPEC_API_VERSION))
 		return true;
 
-	errorstream << "Invalid " << name << " element(" << parts.size() << "): '" << element << "'" << std::endl;
+	errorstream << "Invalid " << name << " element(" << parts.size() << "): '" << element
+				<< "'" << std::endl;
 	return false;
 }
 
-void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseSize(parserData *data, const std::string &element)
 {
 	// Note: do not use precheckElement due to "," separator.
-	std::vector<std::string> parts = split(element,',');
+	std::vector<std::string> parts = split(element, ',');
 
 	if (((parts.size() == 2) || parts.size() == 3) ||
-		((parts.size() > 3) && (m_formspec_version > FORMSPEC_API_VERSION)))
-	{
+			((parts.size() > 3) && (m_formspec_version > FORMSPEC_API_VERSION))) {
 		if (parts[1].find(';') != std::string::npos)
-			parts[1] = parts[1].substr(0,parts[1].find(';'));
+			parts[1] = parts[1].substr(0, parts[1].find(';'));
 
 		data->invsize.X = MYMAX(0, stof(parts[0]));
 		data->invsize.Y = MYMAX(0, stof(parts[1]));
@@ -297,17 +292,18 @@ void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 #ifndef HAVE_TOUCHSCREENGUI
 		if (parts.size() == 3) {
 			if (parts[2] == "true") {
-				lockSize(true,v2u32(800,600));
+				lockSize(true, v2u32(800, 600));
 			}
 		}
 #endif
 		data->explicit_size = true;
 		return;
 	}
-	errorstream<< "Invalid size element (" << parts.size() << "): '" << element << "'"  << std::endl;
+	errorstream << "Invalid size element (" << parts.size() << "): '" << element << "'"
+				<< std::endl;
 }
 
-void GUIFormSpecMenu::parseContainer(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseContainer(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element, ',');
 
@@ -320,13 +316,16 @@ void GUIFormSpecMenu::parseContainer(parserData* data, const std::string &elemen
 		pos_offset.Y += stof(parts[1]);
 		return;
 	}
-	errorstream<< "Invalid container start element (" << parts.size() << "): '" << element << "'"  << std::endl;
+	errorstream << "Invalid container start element (" << parts.size() << "): '"
+				<< element << "'" << std::endl;
 }
 
-void GUIFormSpecMenu::parseContainerEnd(parserData* data)
+void GUIFormSpecMenu::parseContainerEnd(parserData *data)
 {
 	if (container_stack.empty()) {
-		errorstream<< "Invalid container end element, no matching container start element"  << std::endl;
+		errorstream
+				<< "Invalid container end element, no matching container start element"
+				<< std::endl;
 	} else {
 		pos_offset = container_stack.top();
 		container_stack.pop();
@@ -339,7 +338,7 @@ void GUIFormSpecMenu::parseScrollContainer(parserData *data, const std::string &
 	if (!precheckElement("scroll_container start", element, 4, 5, parts))
 		return;
 
-	std::vector<std::string> v_pos  = split(parts[0], ',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
 	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string scrollbar_name = parts[2];
 	std::string orientation = parts[3];
@@ -359,8 +358,8 @@ void GUIFormSpecMenu::parseScrollContainer(parserData *data, const std::string &
 		scroll_factor *= -imgsize.X;
 	else
 		warningstream << "GUIFormSpecMenu::parseScrollContainer(): "
-				<< "Invalid scroll_container orientation: " << orientation
-				<< std::endl;
+					  << "Invalid scroll_container orientation: " << orientation
+					  << std::endl;
 
 	// old parent (at first: this)
 	// ^ is parent of clipper
@@ -370,21 +369,16 @@ void GUIFormSpecMenu::parseScrollContainer(parserData *data, const std::string &
 	// make clipper
 	core::rect<s32> rect_clipper = core::rect<s32>(pos, pos + geom);
 
-	gui::IGUIElement *clipper = new gui::IGUIElement(EGUIET_ELEMENT, Environment,
-			data->current_parent, 0, rect_clipper);
+	gui::IGUIElement *clipper = new gui::IGUIElement(
+			EGUIET_ELEMENT, Environment, data->current_parent, 0, rect_clipper);
 
 	// make mover
-	FieldSpec spec_mover(
-		"",
-		L"",
-		L"",
-		258 + m_fields.size()
-	);
+	FieldSpec spec_mover("", L"", L"", 258 + m_fields.size());
 
 	core::rect<s32> rect_mover = core::rect<s32>(0, 0, geom.X, geom.Y);
 
-	GUIScrollContainer *mover = new GUIScrollContainer(Environment,
-			clipper, spec_mover.fid, rect_mover, orientation, scroll_factor);
+	GUIScrollContainer *mover = new GUIScrollContainer(
+			Environment, clipper, spec_mover.fid, rect_mover, orientation, scroll_factor);
 
 	data->current_parent = mover;
 
@@ -405,7 +399,7 @@ void GUIFormSpecMenu::parseScrollContainerEnd(parserData *data)
 	if (data->current_parent == this || data->current_parent->getParent() == this ||
 			container_stack.empty()) {
 		errorstream << "Invalid scroll_container end element, "
-				<< "no matching scroll_container start element" << std::endl;
+					<< "no matching scroll_container start element" << std::endl;
 		return;
 	}
 
@@ -415,7 +409,7 @@ void GUIFormSpecMenu::parseScrollContainerEnd(parserData *data)
 		// not 0,0, it is a normal container that was opened last, not a
 		// scroll_container
 		errorstream << "Invalid scroll_container end element, "
-				<< "an inner container was left open" << std::endl;
+					<< "an inner container was left open" << std::endl;
 		return;
 	}
 
@@ -434,14 +428,14 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 
 	std::string location = parts[0];
 	std::string listname = parts[1];
-	std::vector<std::string> v_pos  = split(parts[2],',');
-	std::vector<std::string> v_geom = split(parts[3],',');
+	std::vector<std::string> v_pos = split(parts[2], ',');
+	std::vector<std::string> v_geom = split(parts[3], ',');
 	std::string startindex;
 	if (parts.size() == 5)
 		startindex = parts[4];
 
-	MY_CHECKPOS("list",2);
-	MY_CHECKGEOM("list",3);
+	MY_CHECKPOS("list", 2);
+	MY_CHECKGEOM("list", 3);
 
 	InventoryLocation loc;
 
@@ -459,43 +453,34 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 		start_i = stoi(startindex);
 
 	if (geom.X < 0 || geom.Y < 0 || start_i < 0) {
-		errorstream << "Invalid list element: '" << element << "'"  << std::endl;
+		errorstream << "Invalid list element: '" << element << "'" << std::endl;
 		return;
 	}
 
 	if (!data->explicit_size)
 		warningstream << "invalid use of list without a size[] element" << std::endl;
 
-	FieldSpec spec(
-		"",
-		L"",
-		L"",
-		258 + m_fields.size(),
-		3
-	);
+	FieldSpec spec("", L"", L"", 258 + m_fields.size(), 3);
 
 	auto style = getDefaultStyleForElement("list", spec.fname);
 
 	v2f32 slot_scale = style.getVector2f(StyleSpec::SIZE, v2f32(0, 0));
 	v2f32 slot_size(
-		slot_scale.X <= 0 ? imgsize.X : std::max<f32>(slot_scale.X * imgsize.X, 1),
-		slot_scale.Y <= 0 ? imgsize.Y : std::max<f32>(slot_scale.Y * imgsize.Y, 1)
-	);
+			slot_scale.X <= 0 ? imgsize.X : std::max<f32>(slot_scale.X * imgsize.X, 1),
+			slot_scale.Y <= 0 ? imgsize.Y : std::max<f32>(slot_scale.Y * imgsize.Y, 1));
 
 	v2f32 slot_spacing = style.getVector2f(StyleSpec::SPACING, v2f32(-1, -1));
-	v2f32 default_spacing = data->real_coordinates ?
-			v2f32(imgsize.X * 0.25f, imgsize.Y * 0.25f) :
-			v2f32(spacing.X - imgsize.X, spacing.Y - imgsize.Y);
+	v2f32 default_spacing = data->real_coordinates
+									? v2f32(imgsize.X * 0.25f, imgsize.Y * 0.25f)
+									: v2f32(spacing.X - imgsize.X, spacing.Y - imgsize.Y);
 
-	slot_spacing.X = slot_spacing.X < 0 ? default_spacing.X :
-			imgsize.X * slot_spacing.X;
-	slot_spacing.Y = slot_spacing.Y < 0 ? default_spacing.Y :
-			imgsize.Y * slot_spacing.Y;
+	slot_spacing.X = slot_spacing.X < 0 ? default_spacing.X : imgsize.X * slot_spacing.X;
+	slot_spacing.Y = slot_spacing.Y < 0 ? default_spacing.Y : imgsize.Y * slot_spacing.Y;
 
 	slot_spacing += slot_size;
 
-	v2s32 pos = data->real_coordinates ? getRealCoordinateBasePos(v_pos) :
-			getElementBasePos(&v_pos);
+	v2s32 pos = data->real_coordinates ? getRealCoordinateBasePos(v_pos)
+									   : getElementBasePos(&v_pos);
 
 	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y,
 			pos.X + (geom.X - 1) * slot_spacing.X + slot_size.X,
@@ -543,17 +528,17 @@ void GUIFormSpecMenu::parseListRing(parserData *data, const std::string &element
 		return;
 	}
 
-	errorstream<< "Invalid list ring element(" << parts.size() << ", "
-		<< m_inventorylists.size() << "): '" << element << "'"  << std::endl;
+	errorstream << "Invalid list ring element(" << parts.size() << ", "
+				<< m_inventorylists.size() << "): '" << element << "'" << std::endl;
 }
 
-void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseCheckbox(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("checkbox", element, 3, 4, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
 	std::string name = parts[1];
 	std::string label = parts[2];
 	std::string selected;
@@ -561,7 +546,7 @@ void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element
 	if (parts.size() >= 4)
 		selected = parts[3];
 
-	MY_CHECKPOS("checkbox",0);
+	MY_CHECKPOS("checkbox", 0);
 
 	bool fselected = false;
 
@@ -579,33 +564,22 @@ void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element
 	if (data->real_coordinates) {
 		pos = getRealCoordinateBasePos(v_pos);
 
-		rect = core::rect<s32>(
-				pos.X,
-				pos.Y - y_center,
-				pos.X + label_size.Width + cb_size + 7,
-				pos.Y + y_center
-			);
+		rect = core::rect<s32>(pos.X, pos.Y - y_center,
+				pos.X + label_size.Width + cb_size + 7, pos.Y + y_center);
 	} else {
 		pos = getElementBasePos(&v_pos);
-		rect = core::rect<s32>(
-				pos.X,
-				pos.Y + imgsize.Y / 2 - y_center,
-				pos.X + label_size.Width + cb_size + 7,
-				pos.Y + imgsize.Y / 2 + y_center
-			);
+		rect = core::rect<s32>(pos.X, pos.Y + imgsize.Y / 2 - y_center,
+				pos.X + label_size.Width + cb_size + 7, pos.Y + imgsize.Y / 2 + y_center);
 	}
 
-	FieldSpec spec(
-			name,
-			wlabel, //Needed for displaying text on MSVC
-			wlabel,
-			258+m_fields.size()
-		);
+	FieldSpec spec(name,
+			wlabel, // Needed for displaying text on MSVC
+			wlabel, 258 + m_fields.size());
 
 	spec.ftype = f_CheckBox;
 
-	gui::IGUICheckBox *e = Environment->addCheckBox(fselected, rect,
-			data->current_parent, spec.fid, spec.flabel.c_str());
+	gui::IGUICheckBox *e = Environment->addCheckBox(
+			fselected, rect, data->current_parent, spec.fid, spec.flabel.c_str());
 
 	auto style = getDefaultStyleForElement("checkbox", name);
 
@@ -622,19 +596,19 @@ void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseScrollBar(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("scrollbar", element, 5, 5, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
-	std::vector<std::string> v_geom = split(parts[1],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string name = parts[3];
 	std::string value = parts[4];
 
-	MY_CHECKPOS("scrollbar",0);
-	MY_CHECKGEOM("scrollbar",1);
+	MY_CHECKPOS("scrollbar", 0);
+	MY_CHECKGEOM("scrollbar", 1);
 
 	v2s32 pos;
 	v2s32 dim;
@@ -648,15 +622,9 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 		dim.Y = stof(v_geom[1]) * spacing.Y;
 	}
 
-	core::rect<s32> rect =
-			core::rect<s32>(pos.X, pos.Y, pos.X + dim.X, pos.Y + dim.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + dim.X, pos.Y + dim.Y);
 
-	FieldSpec spec(
-			name,
-			L"",
-			L"",
-			258+m_fields.size()
-		);
+	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
 
 	bool is_horizontal = true;
 
@@ -664,9 +632,9 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 		is_horizontal = false;
 
 	spec.ftype = f_ScrollBar;
-	spec.send  = true;
-	GUIScrollBar *e = new GUIScrollBar(Environment, data->current_parent,
-			spec.fid, rect, is_horizontal, true);
+	spec.send = true;
+	GUIScrollBar *e = new GUIScrollBar(
+			Environment, data->current_parent, spec.fid, rect, is_horizontal, true);
 
 	auto style = getDefaultStyleForElement("scrollbar", name);
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
@@ -691,17 +659,17 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 		Environment->setFocus(e);
 	}
 
-	m_scrollbars.emplace_back(spec,e);
+	m_scrollbars.emplace_back(spec, e);
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseScrollBarOptions(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element, ';');
 
 	if (parts.size() == 0) {
-		warningstream << "Invalid scrollbaroptions element(" << parts.size() << "): '" <<
-			element << "'"  << std::endl;
+		warningstream << "Invalid scrollbaroptions element(" << parts.size() << "): '"
+					  << element << "'" << std::endl;
 		return;
 	}
 
@@ -709,8 +677,8 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string 
 		std::vector<std::string> options = split(i, '=');
 
 		if (options.size() != 2) {
-			warningstream << "Invalid scrollbaroptions option syntax: '" <<
-				element << "'" << std::endl;
+			warningstream << "Invalid scrollbaroptions option syntax: '" << element << "'"
+						  << std::endl;
 			continue; // Go to next option
 		}
 
@@ -743,12 +711,12 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string 
 			continue;
 		}
 
-		warningstream << "Invalid scrollbaroptions option(" << options[0] <<
-			"): '" << element << "'" << std::endl;
+		warningstream << "Invalid scrollbaroptions option(" << options[0] << "): '"
+					  << element << "'" << std::endl;
 	}
 }
 
-void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseImage(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("image", element, 2, 4, parts))
@@ -756,12 +724,12 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 
 	size_t offset = parts.size() >= 3;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
 	MY_CHECKPOS("image", 0);
 
 	std::vector<std::string> v_geom;
 	if (parts.size() >= 3) {
-		v_geom = split(parts[1],',');
+		v_geom = split(parts[1], ',');
 		MY_CHECKGEOM("image", 1);
 	}
 
@@ -796,13 +764,7 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 	if (!data->explicit_size)
 		warningstream << "Invalid use of image without a size[] element" << std::endl;
 
-	FieldSpec spec(
-		name,
-		L"",
-		L"",
-		258 + m_fields.size(),
-		1
-	);
+	FieldSpec spec(name, L"", L"", 258 + m_fields.size(), 1);
 
 	core::rect<s32> rect = core::rect<s32>(pos, pos + geom);
 
@@ -816,15 +778,15 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 
 	gui::IGUIElement *e;
 	if (middle.getArea() > 0) {
-		GUIAnimatedImage *image = new GUIAnimatedImage(Environment, data->current_parent,
-			spec.fid, rect);
+		GUIAnimatedImage *image =
+				new GUIAnimatedImage(Environment, data->current_parent, spec.fid, rect);
 
 		image->setTexture(texture);
 		image->setMiddleRect(middle);
 		e = image;
-	}
-	else {
-		gui::IGUIImage *image = Environment->addImage(rect, data->current_parent, spec.fid, nullptr, true);
+	} else {
+		gui::IGUIImage *image = Environment->addImage(
+				rect, data->current_parent, spec.fid, nullptr, true);
 		image->setImage(texture);
 		image->setScaleImage(true);
 		image->grab(); // compensate for drop in addImage
@@ -846,7 +808,7 @@ void GUIFormSpecMenu::parseAnimatedImage(parserData *data, const std::string &el
 	if (!precheckElement("animated_image", element, 6, 8, parts))
 		return;
 
-	std::vector<std::string> v_pos  = split(parts[0], ',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
 	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string name = parts[2];
 	std::string texture_name = unescape_string(parts[3]);
@@ -870,14 +832,9 @@ void GUIFormSpecMenu::parseAnimatedImage(parserData *data, const std::string &el
 
 	if (!data->explicit_size)
 		warningstream << "Invalid use of animated_image without a size[] element"
-				<< std::endl;
+					  << std::endl;
 
-	FieldSpec spec(
-		name,
-		L"",
-		L"",
-		258 + m_fields.size()
-	);
+	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
 	spec.ftype = f_AnimatedImage;
 	spec.send = true;
 
@@ -887,8 +844,8 @@ void GUIFormSpecMenu::parseAnimatedImage(parserData *data, const std::string &el
 	if (parts.size() >= 8)
 		parseMiddleRect(parts[7], &middle);
 
-	GUIAnimatedImage *e = new GUIAnimatedImage(Environment, data->current_parent,
-		spec.fid, rect);
+	GUIAnimatedImage *e =
+			new GUIAnimatedImage(Environment, data->current_parent, spec.fid, rect);
 
 	e->setTexture(m_tsrc->getTexture(texture_name));
 	e->setMiddleRect(middle);
@@ -906,18 +863,18 @@ void GUIFormSpecMenu::parseAnimatedImage(parserData *data, const std::string &el
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseItemImage(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseItemImage(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("item_image", element, 3, 3, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
-	std::vector<std::string> v_geom = split(parts[1],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string name = parts[2];
 
-	MY_CHECKPOS("item_image",0);
-	MY_CHECKGEOM("item_image",1);
+	MY_CHECKPOS("item_image", 0);
+	MY_CHECKGEOM("item_image", 1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -931,16 +888,11 @@ void GUIFormSpecMenu::parseItemImage(parserData* data, const std::string &elemen
 		geom.Y = stof(v_geom[1]) * (float)imgsize.Y;
 	}
 
-	if(!data->explicit_size)
-		warningstream<<"invalid use of item_image without a size[] element"<<std::endl;
+	if (!data->explicit_size)
+		warningstream << "invalid use of item_image without a size[] element"
+					  << std::endl;
 
-	FieldSpec spec(
-		"",
-		L"",
-		L"",
-		258 + m_fields.size(),
-		2
-	);
+	FieldSpec spec("", L"", L"", 258 + m_fields.size(), 2);
 	spec.ftype = f_ItemImage;
 
 	GUIItemImage *e = new GUIItemImage(Environment, data->current_parent, spec.fid,
@@ -954,20 +906,20 @@ void GUIFormSpecMenu::parseItemImage(parserData* data, const std::string &elemen
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
-		const std::string &type)
+void GUIFormSpecMenu::parseButton(
+		parserData *data, const std::string &element, const std::string &type)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("button", element, 4, 4, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
-	std::vector<std::string> v_geom = split(parts[1],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string name = parts[2];
 	std::string label = parts[3];
 
-	MY_CHECKPOS("button",0);
-	MY_CHECKGEOM("button",1);
+	MY_CHECKPOS("button", 0);
+	MY_CHECKGEOM("button", 1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -976,34 +928,28 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 	if (data->real_coordinates) {
 		pos = getRealCoordinateBasePos(v_pos);
 		geom = getRealCoordinateGeometry(v_geom);
-		rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X,
-			pos.Y+geom.Y);
+		rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
 	} else {
 		pos = getElementBasePos(&v_pos);
 		geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
-		pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
+		pos.Y += (stof(v_geom[1]) * (float)imgsize.Y) / 2;
 
-		rect = core::rect<s32>(pos.X, pos.Y - m_btn_height,
-					pos.X + geom.X, pos.Y + m_btn_height);
+		rect = core::rect<s32>(
+				pos.X, pos.Y - m_btn_height, pos.X + geom.X, pos.Y + m_btn_height);
 	}
 
-	if(!data->explicit_size)
-		warningstream<<"invalid use of button without a size[] element"<<std::endl;
+	if (!data->explicit_size)
+		warningstream << "invalid use of button without a size[] element" << std::endl;
 
 	std::wstring wlabel = translate_string(utf8_to_wide(unescape_string(label)));
 
-	FieldSpec spec(
-		name,
-		wlabel,
-		L"",
-		258 + m_fields.size()
-	);
+	FieldSpec spec(name, wlabel, L"", 258 + m_fields.size());
 	spec.ftype = f_Button;
-	if(type == "button_exit")
+	if (type == "button_exit")
 		spec.is_exit = true;
 
-	GUIButton *e = GUIButton::addButton(Environment, rect, m_tsrc,
-			data->current_parent, spec.fid, spec.flabel.c_str());
+	GUIButton *e = GUIButton::addButton(Environment, rect, m_tsrc, data->current_parent,
+			spec.fid, spec.flabel.c_str());
 
 	auto style = getStyleForElement(type, name, (type != "button") ? "button" : "");
 
@@ -1018,7 +964,8 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 	m_fields.push_back(spec);
 }
 
-bool GUIFormSpecMenu::parseMiddleRect(const std::string &value, core::rect<s32> *parsed_rect)
+bool GUIFormSpecMenu::parseMiddleRect(
+		const std::string &value, core::rect<s32> *parsed_rect)
 {
 	core::rect<s32> rect;
 	std::vector<std::string> v_rect = split(value, ',');
@@ -1029,7 +976,7 @@ bool GUIFormSpecMenu::parseMiddleRect(const std::string &value, core::rect<s32> 
 		rect.LowerRightCorner = core::vector2di(-x, -x);
 	} else if (v_rect.size() == 2) {
 		s32 x = stoi(v_rect[0]);
-		s32 y =	stoi(v_rect[1]);
+		s32 y = stoi(v_rect[1]);
 		rect.UpperLeftCorner = core::vector2di(x, y);
 		rect.LowerRightCorner = core::vector2di(-x, -y);
 		// `-x` is interpreted as `w - x`
@@ -1037,8 +984,8 @@ bool GUIFormSpecMenu::parseMiddleRect(const std::string &value, core::rect<s32> 
 		rect.UpperLeftCorner = core::vector2di(stoi(v_rect[0]), stoi(v_rect[1]));
 		rect.LowerRightCorner = core::vector2di(stoi(v_rect[2]), stoi(v_rect[3]));
 	} else {
-		warningstream << "Invalid rectangle string format: \"" << value
-				<< "\"" << std::endl;
+		warningstream << "Invalid rectangle string format: \"" << value << "\""
+					  << std::endl;
 		return false;
 	}
 
@@ -1047,18 +994,18 @@ bool GUIFormSpecMenu::parseMiddleRect(const std::string &value, core::rect<s32> 
 	return true;
 }
 
-void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseBackground(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("background", element, 3, 5, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
-	std::vector<std::string> v_geom = split(parts[1],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string name = unescape_string(parts[2]);
 
-	MY_CHECKPOS("background",0);
-	MY_CHECKGEOM("background",1);
+	MY_CHECKPOS("background", 0);
+	MY_CHECKGEOM("background", 1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -1081,7 +1028,7 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 			pos = getRealCoordinateBasePos(v_pos) * -1;
 			geom = v2s32(0, 0);
 		} else {
-			pos.X = stoi(v_pos[0]); //acts as offset
+			pos.X = stoi(v_pos[0]); // acts as offset
 			pos.Y = stoi(v_pos[1]);
 		}
 		clip = true;
@@ -1092,14 +1039,10 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 		parseMiddleRect(parts[4], &middle);
 
 	if (!data->explicit_size && !clip)
-		warningstream << "invalid use of unclipped background without a size[] element" << std::endl;
+		warningstream << "invalid use of unclipped background without a size[] element"
+					  << std::endl;
 
-	FieldSpec spec(
-		name,
-		L"",
-		L"",
-		258 + m_fields.size()
-	);
+	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
 
 	core::rect<s32> rect;
 	if (!clip) {
@@ -1110,8 +1053,8 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 		rect = core::rect<s32>(-pos, pos);
 	}
 
-	GUIBackgroundImage *e = new GUIBackgroundImage(Environment, data->background_parent.get(),
-			spec.fid, rect, name, middle, m_tsrc, clip);
+	GUIBackgroundImage *e = new GUIBackgroundImage(Environment,
+			data->background_parent.get(), spec.fid, rect, name, middle, m_tsrc, clip);
 
 	FATAL_ERROR_IF(!e, "Failed to create background formspec element");
 
@@ -1121,9 +1064,9 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 	e->drop();
 }
 
-void GUIFormSpecMenu::parseTableOptions(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseTableOptions(parserData *data, const std::string &element)
 {
-	std::vector<std::string> parts = split(element,';');
+	std::vector<std::string> parts = split(element, ';');
 
 	data->table_options.clear();
 	for (const std::string &part : parts) {
@@ -1133,13 +1076,13 @@ void GUIFormSpecMenu::parseTableOptions(parserData* data, const std::string &ele
 	}
 }
 
-void GUIFormSpecMenu::parseTableColumns(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseTableColumns(parserData *data, const std::string &element)
 {
-	std::vector<std::string> parts = split(element,';');
+	std::vector<std::string> parts = split(element, ';');
 
 	data->table_columns.clear();
 	for (const std::string &part : parts) {
-		std::vector<std::string> col_parts = split(part,',');
+		std::vector<std::string> col_parts = split(part, ',');
 		GUITable::TableColumn column;
 		// Parse column type
 		if (!col_parts.empty())
@@ -1153,23 +1096,23 @@ void GUIFormSpecMenu::parseTableColumns(parserData* data, const std::string &ele
 	}
 }
 
-void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseTable(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("table", element, 4, 5, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
-	std::vector<std::string> v_geom = split(parts[1],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string name = parts[2];
-	std::vector<std::string> items = split(parts[3],',');
+	std::vector<std::string> items = split(parts[3], ',');
 	std::string str_initial_selection;
 
 	if (parts.size() >= 5)
 		str_initial_selection = parts[4];
 
-	MY_CHECKPOS("table",0);
-	MY_CHECKGEOM("table",1);
+	MY_CHECKPOS("table", 0);
+	MY_CHECKGEOM("table", 1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -1183,14 +1126,9 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 		geom.Y = stof(v_geom[1]) * spacing.Y;
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
 
-	FieldSpec spec(
-		name,
-		L"",
-		L"",
-		258 + m_fields.size()
-	);
+	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
 
 	spec.ftype = f_Table;
 
@@ -1198,9 +1136,8 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 		item = wide_to_utf8(unescape_translate(utf8_to_wide(unescape_string(item))));
 	}
 
-	//now really show table
-	GUITable *e = new GUITable(Environment, data->current_parent, spec.fid,
-			rect, m_tsrc);
+	// now really show table
+	GUITable *e = new GUITable(Environment, data->current_parent, spec.fid, rect, m_tsrc);
 
 	if (spec.fname == m_focused_element) {
 		Environment->setFocus(e);
@@ -1223,16 +1160,16 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseTextList(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("textlist", element, 4, 6, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
-	std::vector<std::string> v_geom = split(parts[1],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string name = parts[2];
-	std::vector<std::string> items = split(parts[3],',');
+	std::vector<std::string> items = split(parts[3], ',');
 	std::string str_initial_selection;
 	std::string str_transparent = "false";
 
@@ -1242,8 +1179,8 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 	if (parts.size() >= 6)
 		str_transparent = parts[5];
 
-	MY_CHECKPOS("textlist",0);
-	MY_CHECKGEOM("textlist",1);
+	MY_CHECKPOS("textlist", 0);
+	MY_CHECKGEOM("textlist", 1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -1257,14 +1194,9 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 		geom.Y = stof(v_geom[1]) * spacing.Y;
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
 
-	FieldSpec spec(
-		name,
-		L"",
-		L"",
-		258 + m_fields.size()
-	);
+	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
 
 	spec.ftype = f_Table;
 
@@ -1272,9 +1204,8 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 		item = wide_to_utf8(unescape_translate(utf8_to_wide(unescape_string(item))));
 	}
 
-	//now really show list
-	GUITable *e = new GUITable(Environment, data->current_parent, spec.fid,
-			rect, m_tsrc);
+	// now really show list
+	GUITable *e = new GUITable(Environment, data->current_parent, spec.fid, rect, m_tsrc);
 
 	if (spec.fname == m_focused_element) {
 		Environment->setFocus(e);
@@ -1297,7 +1228,7 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseDropDown(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("dropdown", element, 5, 6, parts))
@@ -1311,57 +1242,49 @@ void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element
 	if (parts.size() >= 6 && is_yes(parts[5]))
 		m_dropdown_index_event[name] = true;
 
-	MY_CHECKPOS("dropdown",0);
+	MY_CHECKPOS("dropdown", 0);
 
 	v2s32 pos;
 	v2s32 geom;
 	core::rect<s32> rect;
 
 	if (data->real_coordinates) {
-		std::vector<std::string> v_geom = split(parts[1],',');
+		std::vector<std::string> v_geom = split(parts[1], ',');
 
 		if (v_geom.size() == 1)
 			v_geom.emplace_back("1");
 
-		MY_CHECKGEOM("dropdown",1);
+		MY_CHECKGEOM("dropdown", 1);
 
 		pos = getRealCoordinateBasePos(v_pos);
 		geom = getRealCoordinateGeometry(v_geom);
-		rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
+		rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
 	} else {
 		pos = getElementBasePos(&v_pos);
 
 		s32 width = stof(parts[1]) * spacing.Y;
 
-		rect = core::rect<s32>(pos.X, pos.Y,
-				pos.X + width, pos.Y + (m_btn_height * 2));
+		rect = core::rect<s32>(pos.X, pos.Y, pos.X + width, pos.Y + (m_btn_height * 2));
 	}
 
-	FieldSpec spec(
-		name,
-		L"",
-		L"",
-		258 + m_fields.size()
-	);
+	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
 
 	spec.ftype = f_DropDown;
 	spec.send = true;
 
-	//now really show list
-	gui::IGUIComboBox *e = Environment->addComboBox(rect, data->current_parent,
-			spec.fid);
+	// now really show list
+	gui::IGUIComboBox *e = Environment->addComboBox(rect, data->current_parent, spec.fid);
 
 	if (spec.fname == m_focused_element) {
 		Environment->setFocus(e);
 	}
 
 	for (const std::string &item : items) {
-		e->addItem(unescape_translate(unescape_string(
-			utf8_to_wide(item))).c_str());
+		e->addItem(unescape_translate(unescape_string(utf8_to_wide(item))).c_str());
 	}
 
 	if (!str_initial_selection.empty())
-		e->setSelected(stoi(str_initial_selection)-1);
+		e->setSelected(stoi(str_initial_selection) - 1);
 
 	auto style = getDefaultStyleForElement("dropdown", name);
 
@@ -1387,19 +1310,19 @@ void GUIFormSpecMenu::parseFieldCloseOnEnter(parserData *data, const std::string
 	field_close_on_enter[parts[0]] = is_yes(parts[1]);
 }
 
-void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parsePwdField(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("pwdfield", element, 4, 4, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
-	std::vector<std::string> v_geom = split(parts[1],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string name = parts[2];
 	std::string label = parts[3];
 
-	MY_CHECKPOS("pwdfield",0);
-	MY_CHECKGEOM("pwdfield",1);
+	MY_CHECKPOS("pwdfield", 0);
+	MY_CHECKGEOM("pwdfield", 1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -1413,27 +1336,20 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 
 		geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
 
-		pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
+		pos.Y += (stof(v_geom[1]) * (float)imgsize.Y) / 2;
 		pos.Y -= m_btn_height;
-		geom.Y = m_btn_height*2;
+		geom.Y = m_btn_height * 2;
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
 
 	std::wstring wlabel = translate_string(utf8_to_wide(unescape_string(label)));
 
-	FieldSpec spec(
-		name,
-		wlabel,
-		L"",
-		258 + m_fields.size(),
-		0,
-		ECI_IBEAM
-		);
+	FieldSpec spec(name, wlabel, L"", 258 + m_fields.size(), 0, ECI_IBEAM);
 
 	spec.send = true;
-	gui::IGUIEditBox *e = Environment->addEditBox(0, rect, true,
-			data->current_parent, spec.fid);
+	gui::IGUIEditBox *e =
+			Environment->addEditBox(0, rect, true, data->current_parent, spec.fid);
 
 	if (spec.fname == m_focused_element) {
 		Environment->setFocus(e);
@@ -1444,10 +1360,10 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		rect.UpperLeftCorner.Y -= font_height;
 		rect.LowerRightCorner.Y = rect.UpperLeftCorner.Y + font_height;
 		gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
-			data->current_parent, 0);
+				data->current_parent, 0);
 	}
 
-	e->setPasswordBox(true,L'*');
+	e->setPasswordBox(true, L'*');
 
 	auto style = getDefaultStyleForElement("pwdfield", name, "field");
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
@@ -1456,11 +1372,11 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 	e->setOverrideFont(style.getFont());
 
 	irr::SEvent evt;
-	evt.EventType            = EET_KEY_INPUT_EVENT;
-	evt.KeyInput.Key         = KEY_END;
-	evt.KeyInput.Char        = 0;
-	evt.KeyInput.Control     = false;
-	evt.KeyInput.Shift       = false;
+	evt.EventType = EET_KEY_INPUT_EVENT;
+	evt.KeyInput.Key = KEY_END;
+	evt.KeyInput.Char = 0;
+	evt.KeyInput.Control = false;
+	evt.KeyInput.Shift = false;
 	evt.KeyInput.PressedDown = true;
 	e->OnEvent(evt);
 
@@ -1470,8 +1386,8 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
-	core::rect<s32> &rect, bool is_multiline)
+void GUIFormSpecMenu::createTextField(
+		parserData *data, FieldSpec &spec, core::rect<s32> &rect, bool is_multiline)
 {
 	bool is_editable = !spec.fname.empty();
 	if (!is_editable && !is_multiline) {
@@ -1483,8 +1399,7 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 
 	if (is_editable) {
 		spec.send = true;
-	} else if (is_multiline &&
-			spec.fdefault.empty() && !spec.flabel.empty()) {
+	} else if (is_multiline && spec.fdefault.empty() && !spec.flabel.empty()) {
 		// Multiline textareas: swap default and label for backwards compat
 		spec.flabel.swap(spec.fdefault);
 	}
@@ -1494,12 +1409,13 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 		e = new GUIEditBoxWithScrollBar(spec.fdefault.c_str(), true, Environment,
 				data->current_parent, spec.fid, rect, is_editable, true);
 	} else if (is_editable) {
-		e = Environment->addEditBox(spec.fdefault.c_str(), rect, true,
-				data->current_parent, spec.fid);
+		e = Environment->addEditBox(
+				spec.fdefault.c_str(), rect, true, data->current_parent, spec.fid);
 		e->grab();
 	}
 
-	auto style = getDefaultStyleForElement(is_multiline ? "textarea" : "field", spec.fname);
+	auto style =
+			getDefaultStyleForElement(is_multiline ? "textarea" : "field", spec.fname);
 
 	if (e) {
 		if (is_editable && spec.fname == m_focused_element)
@@ -1511,17 +1427,18 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 			e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_UPPERLEFT);
 		} else {
 			irr::SEvent evt;
-			evt.EventType            = EET_KEY_INPUT_EVENT;
-			evt.KeyInput.Key         = KEY_END;
-			evt.KeyInput.Char        = 0;
-			evt.KeyInput.Control     = 0;
-			evt.KeyInput.Shift       = 0;
+			evt.EventType = EET_KEY_INPUT_EVENT;
+			evt.KeyInput.Key = KEY_END;
+			evt.KeyInput.Char = 0;
+			evt.KeyInput.Control = 0;
+			evt.KeyInput.Shift = 0;
 			evt.KeyInput.PressedDown = true;
 			e->OnEvent(evt);
 		}
 
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		e->setOverrideColor(
+				style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
 		bool border = style.getBool(StyleSpec::BORDER, true);
 		e->setDrawBorder(border);
 		e->setDrawBackground(border);
@@ -1534,16 +1451,15 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 		int font_height = g_fontengine->getTextHeight();
 		rect.UpperLeftCorner.Y -= font_height;
 		rect.LowerRightCorner.Y = rect.UpperLeftCorner.Y + font_height;
-		IGUIElement *t = gui::StaticText::add(Environment, spec.flabel.c_str(),
-				rect, false, true, data->current_parent, 0);
+		IGUIElement *t = gui::StaticText::add(Environment, spec.flabel.c_str(), rect,
+				false, true, data->current_parent, 0);
 
 		if (t)
 			t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 	}
 }
 
-void GUIFormSpecMenu::parseSimpleField(parserData *data,
-	std::vector<std::string> &parts)
+void GUIFormSpecMenu::parseSimpleField(parserData *data, std::vector<std::string> &parts)
 {
 	std::string name = parts[0];
 	std::string label = parts[1];
@@ -1552,32 +1468,23 @@ void GUIFormSpecMenu::parseSimpleField(parserData *data,
 	core::rect<s32> rect;
 
 	if (data->explicit_size)
-		warningstream << "invalid use of unpositioned \"field\" in inventory" << std::endl;
+		warningstream << "invalid use of unpositioned \"field\" in inventory"
+					  << std::endl;
 
 	v2s32 pos = getElementBasePos(nullptr);
 	pos.Y = (data->simple_field_count + 2) * 60;
 	v2s32 size = DesiredRect.getSize();
 
 	rect = core::rect<s32>(
-			size.X / 2 - 150,       pos.Y,
-			size.X / 2 - 150 + 300, pos.Y + m_btn_height * 2
-	);
-
+			size.X / 2 - 150, pos.Y, size.X / 2 - 150 + 300, pos.Y + m_btn_height * 2);
 
 	if (m_form_src)
 		default_val = m_form_src->resolveText(default_val);
 
-
 	std::wstring wlabel = translate_string(utf8_to_wide(unescape_string(label)));
 
-	FieldSpec spec(
-		name,
-		wlabel,
-		utf8_to_wide(unescape_string(default_val)),
-		258 + m_fields.size(),
-		0,
-		ECI_IBEAM
-	);
+	FieldSpec spec(name, wlabel, utf8_to_wide(unescape_string(default_val)),
+			258 + m_fields.size(), 0, ECI_IBEAM);
 
 	createTextField(data, spec, rect, false);
 
@@ -1586,17 +1493,17 @@ void GUIFormSpecMenu::parseSimpleField(parserData *data,
 	data->simple_field_count++;
 }
 
-void GUIFormSpecMenu::parseTextArea(parserData* data, std::vector<std::string>& parts,
-		const std::string &type)
+void GUIFormSpecMenu::parseTextArea(
+		parserData *data, std::vector<std::string> &parts, const std::string &type)
 {
-	std::vector<std::string> v_pos = split(parts[0],',');
-	std::vector<std::string> v_geom = split(parts[1],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string name = parts[2];
 	std::string label = parts[3];
 	std::string default_val = parts[4];
 
-	MY_CHECKPOS(type,0);
-	MY_CHECKGEOM(type,1);
+	MY_CHECKPOS(type, 0);
+	MY_CHECKGEOM(type, 1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -1610,38 +1517,29 @@ void GUIFormSpecMenu::parseTextArea(parserData* data, std::vector<std::string>& 
 
 		geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
 
-		if (type == "textarea")
-		{
-			geom.Y = (stof(v_geom[1]) * (float)imgsize.Y) - (spacing.Y-imgsize.Y);
+		if (type == "textarea") {
+			geom.Y = (stof(v_geom[1]) * (float)imgsize.Y) - (spacing.Y - imgsize.Y);
 			pos.Y += m_btn_height;
-		}
-		else
-		{
-			pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
+		} else {
+			pos.Y += (stof(v_geom[1]) * (float)imgsize.Y) / 2;
 			pos.Y -= m_btn_height;
-			geom.Y = m_btn_height*2;
+			geom.Y = m_btn_height * 2;
 		}
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
 
-	if(!data->explicit_size)
-		warningstream<<"invalid use of positioned "<<type<<" without a size[] element"<<std::endl;
+	if (!data->explicit_size)
+		warningstream << "invalid use of positioned " << type
+					  << " without a size[] element" << std::endl;
 
-	if(m_form_src)
+	if (m_form_src)
 		default_val = m_form_src->resolveText(default_val);
-
 
 	std::wstring wlabel = translate_string(utf8_to_wide(unescape_string(label)));
 
-	FieldSpec spec(
-		name,
-		wlabel,
-		utf8_to_wide(unescape_string(default_val)),
-		258 + m_fields.size(),
-		0,
-		ECI_IBEAM
-	);
+	FieldSpec spec(name, wlabel, utf8_to_wide(unescape_string(default_val)),
+			258 + m_fields.size(), 0, ECI_IBEAM);
 
 	createTextField(data, spec, rect, type == "textarea");
 
@@ -1651,8 +1549,8 @@ void GUIFormSpecMenu::parseTextArea(parserData* data, std::vector<std::string>& 
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseField(parserData* data, const std::string &element,
-		const std::string &type)
+void GUIFormSpecMenu::parseField(
+		parserData *data, const std::string &element, const std::string &type)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement(type, element, 3, 5, parts))
@@ -1700,15 +1598,11 @@ void GUIFormSpecMenu::parseHyperText(parserData *data, const std::string &elemen
 
 	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
 
-	if(m_form_src)
+	if (m_form_src)
 		text = m_form_src->resolveText(text);
 
-	FieldSpec spec(
-		name,
-		translate_string(utf8_to_wide(unescape_string(text))),
-		L"",
-		258 + m_fields.size()
-	);
+	FieldSpec spec(name, translate_string(utf8_to_wide(unescape_string(text))), L"",
+			258 + m_fields.size());
 
 	spec.ftype = f_HyperText;
 
@@ -1722,18 +1616,18 @@ void GUIFormSpecMenu::parseHyperText(parserData *data, const std::string &elemen
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseLabel(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("label", element, 2, 2, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
 
-	MY_CHECKPOS("label",0);
+	MY_CHECKPOS("label", 0);
 
-	if(!data->explicit_size)
-		warningstream<<"invalid use of label without a size[] element"<<std::endl;
+	if (!data->explicit_size)
+		warningstream << "invalid use of label without a size[] element" << std::endl;
 
 	auto style = getDefaultStyleForElement("label", "");
 	gui::IGUIFont *font = style.getFont();
@@ -1762,12 +1656,10 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 			v2s32 pos = getRealCoordinateBasePos(v_pos);
 
 			// Labels are positioned by their center, not their top.
-			pos.Y += (((float) imgsize.Y) / -2) + (((float) imgsize.Y) * i / 2);
+			pos.Y += (((float)imgsize.Y) / -2) + (((float)imgsize.Y) * i / 2);
 
-			rect = core::rect<s32>(
-				pos.X, pos.Y,
-				pos.X + font->getDimension(line.c_str()).Width,
-				pos.Y + imgsize.Y);
+			rect = core::rect<s32>(pos.X, pos.Y,
+					pos.X + font->getDimension(line.c_str()).Width, pos.Y + imgsize.Y);
 
 		} else {
 			// Lines are spaced at the nominal distance of
@@ -1784,28 +1676,20 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 			pos.X += stof(v_pos[0]) * spacing.X;
 			pos.Y += (stof(v_pos[1]) + 7.0f / 30.0f) * spacing.Y;
 
-			pos.Y += ((float) i) * spacing.Y * 2.0 / 5.0;
+			pos.Y += ((float)i) * spacing.Y * 2.0 / 5.0;
 
-			rect = core::rect<s32>(
-				pos.X, pos.Y - m_btn_height,
-				pos.X + font->getDimension(line.c_str()).Width,
-				pos.Y + m_btn_height);
+			rect = core::rect<s32>(pos.X, pos.Y - m_btn_height,
+					pos.X + font->getDimension(line.c_str()).Width, pos.Y + m_btn_height);
 		}
 
-		FieldSpec spec(
-			"",
-			L"",
-			L"",
-			258 + m_fields.size(),
-			4
-		);
-		gui::IGUIStaticText *e = gui::StaticText::add(Environment,
-				line, rect, false, false, data->current_parent,
-				spec.fid);
+		FieldSpec spec("", L"", L"", 258 + m_fields.size(), 4);
+		gui::IGUIStaticText *e = gui::StaticText::add(
+				Environment, line, rect, false, false, data->current_parent, spec.fid);
 		e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_CENTER);
 
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		e->setOverrideColor(
+				style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
 		e->setOverrideFont(font);
 
 		m_fields.push_back(spec);
@@ -1816,17 +1700,16 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 	}
 }
 
-void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseVertLabel(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("vertlabel", element, 2, 2, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
-	std::wstring text = unescape_translate(
-		unescape_string(utf8_to_wide(parts[1])));
+	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::wstring text = unescape_translate(unescape_string(utf8_to_wide(parts[1])));
 
-	MY_CHECKPOS("vertlabel",1);
+	MY_CHECKPOS("vertlabel", 1);
 
 	auto style = getDefaultStyleForElement("vertlabel", "", "label");
 	gui::IGUIFont *font = style.getFont();
@@ -1844,10 +1727,8 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 
 		// We use text.length + 1 because without it, the rect
 		// isn't quite tall enough and cuts off the text.
-		rect = core::rect<s32>(pos.X, pos.Y,
-			pos.X + imgsize.X,
-			pos.Y + font_line_height(font) *
-			(text.length() + 1));
+		rect = core::rect<s32>(pos.X, pos.Y, pos.X + imgsize.X,
+				pos.Y + font_line_height(font) * (text.length() + 1));
 
 	} else {
 		pos = getElementBasePos(&v_pos);
@@ -1855,16 +1736,14 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 		// As above, the length must be one longer. The width of
 		// the rect (15 pixels) seems rather arbitrary, but
 		// changing it might break something.
-		rect = core::rect<s32>(
-			pos.X, pos.Y+((imgsize.Y/2) - m_btn_height),
-			pos.X+15, pos.Y +
-				font_line_height(font) *
-				(text.length() + 1) +
-				((imgsize.Y/2) - m_btn_height));
+		rect = core::rect<s32>(pos.X, pos.Y + ((imgsize.Y / 2) - m_btn_height),
+				pos.X + 15,
+				pos.Y + font_line_height(font) * (text.length() + 1) +
+						((imgsize.Y / 2) - m_btn_height));
 	}
 
-	if(!data->explicit_size)
-		warningstream<<"invalid use of label without a size[] element"<<std::endl;
+	if (!data->explicit_size)
+		warningstream << "invalid use of label without a size[] element" << std::endl;
 
 	std::wstring label;
 
@@ -1873,14 +1752,9 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 		label += L"\n";
 	}
 
-	FieldSpec spec(
-		"",
-		label,
-		L"",
-		258 + m_fields.size()
-	);
-	gui::IGUIStaticText *e = gui::StaticText::add(Environment, spec.flabel.c_str(),
-			rect, false, false, data->current_parent, spec.fid);
+	FieldSpec spec("", label, L"", 258 + m_fields.size());
+	gui::IGUIStaticText *e = gui::StaticText::add(Environment, spec.flabel.c_str(), rect,
+			false, false, data->current_parent, spec.fid);
 	e->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_CENTER);
 
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
@@ -1894,8 +1768,8 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 	m_clickthrough_elements.push_back(e);
 }
 
-void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &element,
-		const std::string &type)
+void GUIFormSpecMenu::parseImageButton(
+		parserData *data, const std::string &element, const std::string &type)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("image_button", element, 5, 8, parts))
@@ -1903,18 +1777,19 @@ void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &elem
 
 	if (parts.size() == 6) {
 		// Invalid argument count.
-		errorstream << "Invalid image_button element(" << parts.size() << "): '" << element << "'" << std::endl;
+		errorstream << "Invalid image_button element(" << parts.size() << "): '"
+					<< element << "'" << std::endl;
 		return;
 	}
 
-	std::vector<std::string> v_pos = split(parts[0],',');
-	std::vector<std::string> v_geom = split(parts[1],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string image_name = parts[2];
 	std::string name = parts[3];
 	std::string label = parts[4];
 
-	MY_CHECKPOS("image_button",0);
-	MY_CHECKGEOM("image_button",1);
+	MY_CHECKPOS("image_button", 0);
+	MY_CHECKGEOM("image_button", 1);
 
 	std::string pressed_image_name;
 
@@ -1934,23 +1809,18 @@ void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &elem
 		geom.Y = (stof(v_geom[1]) * spacing.Y) - (spacing.Y - imgsize.Y);
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X,
-		pos.Y+geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
 
 	if (!data->explicit_size)
-		warningstream<<"invalid use of image_button without a size[] element"<<std::endl;
+		warningstream << "invalid use of image_button without a size[] element"
+					  << std::endl;
 
 	image_name = unescape_string(image_name);
 	pressed_image_name = unescape_string(pressed_image_name);
 
 	std::wstring wlabel = utf8_to_wide(unescape_string(label));
 
-	FieldSpec spec(
-		name,
-		wlabel,
-		utf8_to_wide(image_name),
-		258 + m_fields.size()
-	);
+	FieldSpec spec(name, wlabel, utf8_to_wide(image_name), 258 + m_fields.size());
 	spec.ftype = f_Button;
 	if (type == "image_button_exit")
 		spec.is_exit = true;
@@ -1984,21 +1854,22 @@ void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &elem
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseTabHeader(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("tabheader", element, 4, 7, parts))
 		return;
 
-	// Length 7: Additional "height" parameter after "pos". Only valid with real_coordinates.
-	// Note: New arguments for the "height" syntax cannot be added without breaking older clients.
+	// Length 7: Additional "height" parameter after "pos". Only valid with
+	// real_coordinates. Note: New arguments for the "height" syntax cannot be added
+	// without breaking older clients.
 	if (parts.size() == 5 || (parts.size() == 7 && !data->real_coordinates)) {
-		errorstream << "Invalid tabheader element(" << parts.size() << "): '"
-			<< element << "'" << std::endl;
+		errorstream << "Invalid tabheader element(" << parts.size() << "): '" << element
+					<< "'" << std::endl;
 		return;
 	}
 
-	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
 
 	// If we're using real coordinates, add an extra field for height.
 	// Width is not here because tabs are the width of the text, and
@@ -2016,9 +1887,9 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 			auto_width = false;
 	}
 
-	std::string name = parts[i+1];
-	std::vector<std::string> buttons = split(parts[i+2], ',');
-	std::string str_index = parts[i+3];
+	std::string name = parts[i + 1];
+	std::vector<std::string> buttons = split(parts[i + 2], ',');
+	std::string str_index = parts[i + 3];
 	bool show_background = true;
 	bool show_border = true;
 	int tab_index = stoi(str_index) - 1;
@@ -2026,18 +1897,13 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 	MY_CHECKPOS("tabheader", 0);
 
 	if (parts.size() == 6 + i) {
-		if (parts[4+i] == "true")
+		if (parts[4 + i] == "true")
 			show_background = false;
-		if (parts[5+i] == "false")
+		if (parts[5 + i] == "false")
 			show_border = false;
 	}
 
-	FieldSpec spec(
-		name,
-		L"",
-		L"",
-		258 + m_fields.size()
-	);
+	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
 
 	spec.ftype = f_TabHeader;
 
@@ -2066,11 +1932,10 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 		geom.X = DesiredRect.getWidth();
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X,
-			pos.Y+geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
 
-	gui::IGUITabControl *e = Environment->addTabControl(rect,
-			data->current_parent, show_background, show_border, spec.fid);
+	gui::IGUITabControl *e = Environment->addTabControl(
+			rect, data->current_parent, show_background, show_border, spec.fid);
 	e->setAlignment(irr::gui::EGUIA_UPPERLEFT, irr::gui::EGUIA_UPPERLEFT,
 			irr::gui::EGUIA_UPPERLEFT, irr::gui::EGUIA_LOWERRIGHT);
 	e->setTabHeight(geom.Y);
@@ -2082,23 +1947,23 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, true));
 
 	for (const std::string &button : buttons) {
-		auto tab = e->addTab(unescape_translate(unescape_string(
-			utf8_to_wide(button))).c_str(), -1);
+		auto tab = e->addTab(
+				unescape_translate(unescape_string(utf8_to_wide(button))).c_str(), -1);
 		if (style.isNotDefault(StyleSpec::BGCOLOR))
 			tab->setBackgroundColor(style.getColor(StyleSpec::BGCOLOR));
 
-		tab->setTextColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		tab->setTextColor(
+				style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
 	}
 
-	if ((tab_index >= 0) &&
-			(buttons.size() < INT_MAX) &&
-			(tab_index < (int) buttons.size()))
+	if ((tab_index >= 0) && (buttons.size() < INT_MAX) &&
+			(tab_index < (int)buttons.size()))
 		e->setActiveTab(tab_index);
 
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseItemImageButton(parserData *data, const std::string &element)
 {
 	MY_CHECKCLIENT("item_image_button");
 
@@ -2106,8 +1971,8 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 	if (!precheckElement("item_image_button", element, 5, 5, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
-	std::vector<std::string> v_geom = split(parts[1],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string item_name = parts[2];
 	std::string name = parts[3];
 	std::string label = parts[4];
@@ -2115,8 +1980,8 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 	label = unescape_string(label);
 	item_name = unescape_string(item_name);
 
-	MY_CHECKPOS("item_image_button",0);
-	MY_CHECKGEOM("item_image_button",1);
+	MY_CHECKPOS("item_image_button", 0);
+	MY_CHECKGEOM("item_image_button", 1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -2130,32 +1995,26 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 		geom.Y = (stof(v_geom[1]) * spacing.Y) - (spacing.Y - imgsize.Y);
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
 
-	if(!data->explicit_size)
-		warningstream<<"invalid use of item_image_button without a size[] element"<<std::endl;
+	if (!data->explicit_size)
+		warningstream << "invalid use of item_image_button without a size[] element"
+					  << std::endl;
 
 	IItemDefManager *idef = m_client->idef();
 	ItemStack item;
 	item.deSerialize(item_name, idef);
 
-	m_tooltips[name] =
-		TooltipSpec(utf8_to_wide(item.getDefinition(idef).description),
-					m_default_tooltip_bgcolor,
-					m_default_tooltip_color);
+	m_tooltips[name] = TooltipSpec(utf8_to_wide(item.getDefinition(idef).description),
+			m_default_tooltip_bgcolor, m_default_tooltip_color);
 
 	// the spec for the button
 	FieldSpec spec_btn(
-		name,
-		utf8_to_wide(label),
-		utf8_to_wide(item_name),
-		258 + m_fields.size(),
-		2
-	);
+			name, utf8_to_wide(label), utf8_to_wide(item_name), 258 + m_fields.size(), 2);
 
-	GUIButtonItemImage *e_btn = GUIButtonItemImage::addButton(Environment,
-			rect, m_tsrc, data->current_parent, spec_btn.fid, spec_btn.flabel.c_str(),
-			item_name, m_client);
+	GUIButtonItemImage *e_btn =
+			GUIButtonItemImage::addButton(Environment, rect, m_tsrc, data->current_parent,
+					spec_btn.fid, spec_btn.flabel.c_str(), item_name, m_client);
 
 	auto style = getStyleForElement("item_image_button", spec_btn.fname, "image_button");
 
@@ -2168,12 +2027,12 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 	}
 
 	spec_btn.ftype = f_Button;
-	rect += data->basepos-padding;
+	rect += data->basepos - padding;
 	spec_btn.rect = rect;
 	m_fields.push_back(spec_btn);
 }
 
-void GUIFormSpecMenu::parseBox(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseBox(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("box", element, 3, 3, parts))
@@ -2197,13 +2056,7 @@ void GUIFormSpecMenu::parseBox(parserData* data, const std::string &element)
 		geom.Y = stof(v_geom[1]) * spacing.Y;
 	}
 
-	FieldSpec spec(
-		"",
-		L"",
-		L"",
-		258 + m_fields.size(),
-		-2
-	);
+	FieldSpec spec("", L"", L"", 258 + m_fields.size(), -2);
 	spec.ftype = f_Box;
 
 	auto style = getDefaultStyleForElement("box", spec.fname);
@@ -2217,22 +2070,21 @@ void GUIFormSpecMenu::parseBox(parserData* data, const std::string &element)
 		colors = {tmp_color, tmp_color, tmp_color, tmp_color};
 	} else {
 		colors = style.getColorArray(StyleSpec::COLORS, {0x0, 0x0, 0x0, 0x0});
-		bordercolors = style.getColorArray(StyleSpec::BORDERCOLORS,
-			{0x0, 0x0, 0x0, 0x0});
+		bordercolors = style.getColorArray(StyleSpec::BORDERCOLORS, {0x0, 0x0, 0x0, 0x0});
 		borderwidths = style.getIntArray(StyleSpec::BORDERWIDTHS, {0, 0, 0, 0});
 	}
 
 	core::rect<s32> rect(pos, pos + geom);
 
-	GUIBox *e = new GUIBox(Environment, data->current_parent, spec.fid, rect,
-		colors, bordercolors, borderwidths);
+	GUIBox *e = new GUIBox(Environment, data->current_parent, spec.fid, rect, colors,
+			bordercolors, borderwidths);
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, m_formspec_version < 3));
 	e->drop();
 
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseBackgroundColor(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseBackgroundColor(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("bgcolor", element, 1, 3, parts))
@@ -2241,8 +2093,8 @@ void GUIFormSpecMenu::parseBackgroundColor(parserData* data, const std::string &
 	const u32 parameter_count = parts.size();
 
 	if (parameter_count > 2 && m_formspec_version < 3) {
-		errorstream << "Invalid bgcolor element(" << parameter_count << "): '"
-				<< element << "'" << std::endl;
+		errorstream << "Invalid bgcolor element(" << parameter_count << "): '" << element
+					<< "'" << std::endl;
 		return;
 	}
 
@@ -2269,18 +2121,18 @@ void GUIFormSpecMenu::parseBackgroundColor(parserData* data, const std::string &
 		parseColorString(parts[2], m_fullscreen_bgcolor, false);
 }
 
-void GUIFormSpecMenu::parseListColors(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseListColors(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
-	// Legacy Note: If clients older than 5.5.0-dev are supplied with additional arguments,
-	// the tooltip colors will be ignored.
+	// Legacy Note: If clients older than 5.5.0-dev are supplied with additional
+	// arguments, the tooltip colors will be ignored.
 	if (!precheckElement("listcolors", element, 2, 5, parts))
 		return;
 
 	if (parts.size() == 4) {
 		// Invalid argument combination
-		errorstream << "Invalid listcolors element(" << parts.size() << "): '"
-				<< element << "'" << std::endl;
+		errorstream << "Invalid listcolors element(" << parts.size() << "): '" << element
+					<< "'" << std::endl;
 		return;
 	}
 
@@ -2288,8 +2140,8 @@ void GUIFormSpecMenu::parseListColors(parserData* data, const std::string &eleme
 	parseColorString(parts[1], data->inventorylist_options.slotbg_h, false);
 
 	if (parts.size() >= 3) {
-		if (parseColorString(parts[2], data->inventorylist_options.slotbordercolor,
-				false)) {
+		if (parseColorString(
+					parts[2], data->inventorylist_options.slotbordercolor, false)) {
 			data->inventorylist_options.slotborder = true;
 		}
 	}
@@ -2311,7 +2163,7 @@ void GUIFormSpecMenu::parseListColors(parserData* data, const std::string &eleme
 	}
 }
 
-void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseTooltip(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("tooltip", element, 2, 5, parts))
@@ -2321,19 +2173,19 @@ void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)
 	bool rect_mode = parts[0].find(',') != std::string::npos;
 	size_t base_size = rect_mode ? 3 : 2;
 	if (parts.size() != base_size && parts.size() != base_size + 2) {
-		errorstream << "Invalid tooltip element(" << parts.size() << "): '"
-				<< element << "'"  << std::endl;
+		errorstream << "Invalid tooltip element(" << parts.size() << "): '" << element
+					<< "'" << std::endl;
 		return;
 	}
 
 	// Read colors
 	video::SColor bgcolor = m_default_tooltip_bgcolor;
-	video::SColor color   = m_default_tooltip_color;
+	video::SColor color = m_default_tooltip_color;
 	if (parts.size() == base_size + 2 &&
 			(!parseColorString(parts[base_size], bgcolor, false) ||
-				!parseColorString(parts[base_size + 1], color, false))) {
-		errorstream << "Invalid color in tooltip element(" << parts.size()
-				<< "): '" << element << "'"  << std::endl;
+					!parseColorString(parts[base_size + 1], color, false))) {
+		errorstream << "Invalid color in tooltip element(" << parts.size() << "): '"
+					<< element << "'" << std::endl;
 		return;
 	}
 
@@ -2343,7 +2195,7 @@ void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)
 
 	// Add tooltip
 	if (rect_mode) {
-		std::vector<std::string> v_pos  = split(parts[0], ',');
+		std::vector<std::string> v_pos = split(parts[0], ',');
 		std::vector<std::string> v_geom = split(parts[1], ',');
 
 		MY_CHECKPOS("tooltip", 0);
@@ -2361,17 +2213,12 @@ void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)
 			geom.Y = stof(v_geom[1]) * spacing.Y;
 		}
 
-		FieldSpec fieldspec(
-			"",
-			L"",
-			L"",
-			258 + m_fields.size()
-		);
+		FieldSpec fieldspec("", L"", L"", 258 + m_fields.size());
 
 		core::rect<s32> rect(pos, pos + geom);
 
-		gui::IGUIElement *e = new gui::IGUIElement(EGUIET_ELEMENT, Environment,
-				data->current_parent, fieldspec.fid, rect);
+		gui::IGUIElement *e = new gui::IGUIElement(
+				EGUIET_ELEMENT, Environment, data->current_parent, fieldspec.fid, rect);
 
 		// the element the rect tooltip is bound to should not block mouse-clicks
 		e->setVisible(false);
@@ -2386,11 +2233,11 @@ void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)
 
 bool GUIFormSpecMenu::parseVersionDirect(const std::string &data)
 {
-	//some prechecks
+	// some prechecks
 	if (data.empty())
 		return false;
 
-	std::vector<std::string> parts = split(data,'[');
+	std::vector<std::string> parts = split(data, '[');
 
 	if (parts.size() < 2) {
 		return false;
@@ -2408,12 +2255,12 @@ bool GUIFormSpecMenu::parseVersionDirect(const std::string &data)
 	return false;
 }
 
-bool GUIFormSpecMenu::parseSizeDirect(parserData* data, const std::string &element)
+bool GUIFormSpecMenu::parseSizeDirect(parserData *data, const std::string &element)
 {
 	if (element.empty())
 		return false;
 
-	std::vector<std::string> parts = split(element,'[');
+	std::vector<std::string> parts = split(element, '[');
 
 	if (parts.size() < 2)
 		return false;
@@ -2468,7 +2315,8 @@ void GUIFormSpecMenu::parsePosition(parserData *data, const std::string &element
 		return;
 	}
 
-	errorstream << "Invalid position element (" << parts.size() << "): '" << element << "'" << std::endl;
+	errorstream << "Invalid position element (" << parts.size() << "): '" << element
+				<< "'" << std::endl;
 }
 
 bool GUIFormSpecMenu::parseAnchorDirect(parserData *data, const std::string &element)
@@ -2507,8 +2355,8 @@ void GUIFormSpecMenu::parseAnchor(parserData *data, const std::string &element)
 		return;
 	}
 
-	errorstream << "Invalid anchor element (" << parts.size() << "): '" << element
-			<< "'" << std::endl;
+	errorstream << "Invalid anchor element (" << parts.size() << "): '" << element << "'"
+				<< std::endl;
 }
 
 bool GUIFormSpecMenu::parsePaddingDirect(parserData *data, const std::string &element)
@@ -2547,11 +2395,12 @@ void GUIFormSpecMenu::parsePadding(parserData *data, const std::string &element)
 		return;
 	}
 
-	errorstream << "Invalid padding element (" << parts.size() << "): '" << element
-			<< "'" << std::endl;
+	errorstream << "Invalid padding element (" << parts.size() << "): '" << element << "'"
+				<< std::endl;
 }
 
-bool GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element, bool style_type)
+bool GUIFormSpecMenu::parseStyle(
+		parserData *data, const std::string &element, bool style_type)
 {
 	std::vector<std::string> parts = split(element, ';');
 
@@ -2573,16 +2422,15 @@ bool GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element, b
 		}
 
 		std::string propname = trim(parts[i].substr(0, equal_pos));
-		std::string value    = trim(unescape_string(parts[i].substr(equal_pos + 1)));
+		std::string value = trim(unescape_string(parts[i].substr(equal_pos + 1)));
 
 		std::transform(propname.begin(), propname.end(), propname.begin(), ::tolower);
 
 		StyleSpec::Property prop = StyleSpec::GetPropertyByName(propname);
 		if (prop == StyleSpec::NONE) {
 			if (property_warned.find(propname) != property_warned.end()) {
-				warningstream << "Invalid style element (Unknown property " << propname << "): '"
-						<< element
-						<< "'" << std::endl;
+				warningstream << "Invalid style element (Unknown property " << propname
+							  << "): '" << element << "'" << std::endl;
 				property_warned.insert(propname);
 			}
 			continue;
@@ -2608,15 +2456,15 @@ bool GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element, b
 
 			if (state_str.empty()) {
 				errorstream << "Invalid style element (Invalid state): '" << element
-					<< "'" << std::endl;
+							<< "'" << std::endl;
 				state_valid = false;
 			} else {
 				std::vector<std::string> states = split(state_str, '+');
 				for (std::string &state : states) {
 					StyleSpec::State converted = StyleSpec::getStateByName(state);
 					if (converted == StyleSpec::STATE_INVALID) {
-						infostream << "Unknown style state " << state <<
-							" in element '" << element << "'" << std::endl;
+						infostream << "Unknown style state " << state << " in element '"
+								   << element << "'" << std::endl;
 						state_valid = false;
 						break;
 					}
@@ -2638,20 +2486,23 @@ bool GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element, b
 		}
 
 		// Backwards-compatibility for existing _hovered/_pressed properties
-		if (selector_spec.hasProperty(StyleSpec::BGCOLOR_HOVERED)
-				|| selector_spec.hasProperty(StyleSpec::BGIMG_HOVERED)
-				|| selector_spec.hasProperty(StyleSpec::FGIMG_HOVERED)) {
+		if (selector_spec.hasProperty(StyleSpec::BGCOLOR_HOVERED) ||
+				selector_spec.hasProperty(StyleSpec::BGIMG_HOVERED) ||
+				selector_spec.hasProperty(StyleSpec::FGIMG_HOVERED)) {
 			StyleSpec hover_spec;
 			hover_spec.addState(StyleSpec::STATE_HOVERED);
 
 			if (selector_spec.hasProperty(StyleSpec::BGCOLOR_HOVERED)) {
-				hover_spec.set(StyleSpec::BGCOLOR, selector_spec.get(StyleSpec::BGCOLOR_HOVERED, ""));
+				hover_spec.set(StyleSpec::BGCOLOR,
+						selector_spec.get(StyleSpec::BGCOLOR_HOVERED, ""));
 			}
 			if (selector_spec.hasProperty(StyleSpec::BGIMG_HOVERED)) {
-				hover_spec.set(StyleSpec::BGIMG, selector_spec.get(StyleSpec::BGIMG_HOVERED, ""));
+				hover_spec.set(StyleSpec::BGIMG,
+						selector_spec.get(StyleSpec::BGIMG_HOVERED, ""));
 			}
 			if (selector_spec.hasProperty(StyleSpec::FGIMG_HOVERED)) {
-				hover_spec.set(StyleSpec::FGIMG, selector_spec.get(StyleSpec::FGIMG_HOVERED, ""));
+				hover_spec.set(StyleSpec::FGIMG,
+						selector_spec.get(StyleSpec::FGIMG_HOVERED, ""));
 			}
 
 			if (style_type) {
@@ -2660,20 +2511,23 @@ bool GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element, b
 				theme_by_name[selector].push_back(hover_spec);
 			}
 		}
-		if (selector_spec.hasProperty(StyleSpec::BGCOLOR_PRESSED)
-				|| selector_spec.hasProperty(StyleSpec::BGIMG_PRESSED)
-				|| selector_spec.hasProperty(StyleSpec::FGIMG_PRESSED)) {
+		if (selector_spec.hasProperty(StyleSpec::BGCOLOR_PRESSED) ||
+				selector_spec.hasProperty(StyleSpec::BGIMG_PRESSED) ||
+				selector_spec.hasProperty(StyleSpec::FGIMG_PRESSED)) {
 			StyleSpec press_spec;
 			press_spec.addState(StyleSpec::STATE_PRESSED);
 
 			if (selector_spec.hasProperty(StyleSpec::BGCOLOR_PRESSED)) {
-				press_spec.set(StyleSpec::BGCOLOR, selector_spec.get(StyleSpec::BGCOLOR_PRESSED, ""));
+				press_spec.set(StyleSpec::BGCOLOR,
+						selector_spec.get(StyleSpec::BGCOLOR_PRESSED, ""));
 			}
 			if (selector_spec.hasProperty(StyleSpec::BGIMG_PRESSED)) {
-				press_spec.set(StyleSpec::BGIMG, selector_spec.get(StyleSpec::BGIMG_PRESSED, ""));
+				press_spec.set(StyleSpec::BGIMG,
+						selector_spec.get(StyleSpec::BGIMG_PRESSED, ""));
 			}
 			if (selector_spec.hasProperty(StyleSpec::FGIMG_PRESSED)) {
-				press_spec.set(StyleSpec::FGIMG, selector_spec.get(StyleSpec::FGIMG_PRESSED, ""));
+				press_spec.set(StyleSpec::FGIMG,
+						selector_spec.get(StyleSpec::FGIMG_PRESSED, ""));
 			}
 
 			if (style_type) {
@@ -2706,12 +2560,12 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	MY_CHECKCLIENT("model");
 
 	std::vector<std::string> parts;
-	if (!precheckElement("model", element, 5, 10, parts))
+	if (!precheckElement("model", element, 5, 12, parts))
 		return;
 
 	// Avoid length checks by resizing
-	if (parts.size() < 10)
-		parts.resize(10);
+	if (parts.size() < 12)
+		parts.resize(12);
 
 	std::vector<std::string> v_pos = split(parts[0], ',');
 	std::vector<std::string> v_geom = split(parts[1], ',');
@@ -2723,6 +2577,8 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	bool mousectrl = is_yes(parts[7]) || parts[7].empty(); // default true
 	std::vector<std::string> frame_loop = split(parts[8], ',');
 	std::string speed = unescape_string(parts[9]);
+	std::vector<std::string> camera_offset = split(parts[10], ',');
+	std::vector<std::string> camera_distance_clamping = split(parts[11], ',');
 
 	MY_CHECKPOS("model", 0);
 	MY_CHECKGEOM("model", 1);
@@ -2745,19 +2601,29 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	scene::IAnimatedMesh *mesh = m_client->getMesh(meshstr);
 
 	if (!mesh) {
-		errorstream << "Invalid model element: Unable to load mesh:"
-				<< std::endl << "\t" << meshstr << std::endl;
+		errorstream << "Invalid model element: Unable to load mesh:" << std::endl
+					<< "\t" << meshstr << std::endl;
 		return;
 	}
 
-	FieldSpec spec(
-		name,
-		L"",
-		L"",
-		258 + m_fields.size()
-	);
+	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
 
 	core::rect<s32> rect(pos, pos + geom);
+
+	v3f camera_offset_vector{0.0f, 0.0f, 0.0f};
+	if (camera_offset.size() == 3) {
+		camera_offset_vector.X = stof(camera_offset[0]);
+		camera_offset_vector.Y = stof(camera_offset[1]);
+		camera_offset_vector.Z = stof(camera_offset[2]);
+	}
+	float camera_clamp_min = 0.0f;
+	float camera_clamp_max = 0.0f;
+	if (camera_distance_clamping.size() > 0 && !camera_distance_clamping[0].empty()) {
+		camera_clamp_min = stof(camera_distance_clamping[0]);
+		if (camera_distance_clamping.size() > 1) {
+			camera_clamp_max = stof(camera_distance_clamping[1]);
+		}
+	}
 
 	GUIScene *e = new GUIScene(Environment, m_client->getSceneManager(),
 			data->current_parent, rect, spec.fid);
@@ -2770,6 +2636,9 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	if (vec_rot.size() >= 2)
 		e->setRotation(v2f(stof(vec_rot[0]), stof(vec_rot[1])));
 
+	e->setCameraOffsets(camera_offset_vector);
+	e->setCameraDistanceClamping(camera_clamp_min, camera_clamp_max);
+
 	e->enableContinuousRotation(inf_rotation);
 	e->enableMouseControl(mousectrl);
 
@@ -2777,8 +2646,8 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	s32 frame_loop_end = 0x7FFFFFFF;
 
 	if (frame_loop.size() == 2) {
-	    frame_loop_begin = stoi(frame_loop[0]);
-	    frame_loop_end = stoi(frame_loop[1]);
+		frame_loop_begin = stoi(frame_loop[0]);
+		frame_loop_end = stoi(frame_loop[1]);
 	}
 
 	e->setFrameLoop(frame_loop_begin, frame_loop_end);
@@ -2813,9 +2682,9 @@ void GUIFormSpecMenu::removeAll()
 		scroll_container_it.second->drop();
 }
 
-void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseElement(parserData *data, const std::string &element)
 {
-	//some prechecks
+	// some prechecks
 	if (element.empty())
 		return;
 
@@ -2827,7 +2696,7 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 		return;
 
 	std::string type = trim(element.substr(0, pos));
-	std::string description = element.substr(pos+1);
+	std::string description = element.substr(pos + 1);
 
 	if (type == "container") {
 		parseContainer(data, description);
@@ -2879,28 +2748,28 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 		return;
 	}
 
-	if (type == "tableoptions"){
-		parseTableOptions(data,description);
+	if (type == "tableoptions") {
+		parseTableOptions(data, description);
 		return;
 	}
 
-	if (type == "tablecolumns"){
-		parseTableColumns(data,description);
+	if (type == "tablecolumns") {
+		parseTableColumns(data, description);
 		return;
 	}
 
-	if (type == "table"){
-		parseTable(data,description);
+	if (type == "table") {
+		parseTable(data, description);
 		return;
 	}
 
-	if (type == "textlist"){
-		parseTextList(data,description);
+	if (type == "textlist") {
+		parseTextList(data, description);
 		return;
 	}
 
-	if (type == "dropdown"){
-		parseDropDown(data,description);
+	if (type == "dropdown") {
+		parseDropDown(data, description);
 		return;
 	}
 
@@ -2910,62 +2779,62 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 	}
 
 	if (type == "pwdfield") {
-		parsePwdField(data,description);
+		parsePwdField(data, description);
 		return;
 	}
 
-	if ((type == "field") || (type == "textarea")){
-		parseField(data,description,type);
+	if ((type == "field") || (type == "textarea")) {
+		parseField(data, description, type);
 		return;
 	}
 
 	if (type == "hypertext") {
-		parseHyperText(data,description);
+		parseHyperText(data, description);
 		return;
 	}
 
 	if (type == "label") {
-		parseLabel(data,description);
+		parseLabel(data, description);
 		return;
 	}
 
 	if (type == "vertlabel") {
-		parseVertLabel(data,description);
+		parseVertLabel(data, description);
 		return;
 	}
 
 	if (type == "item_image_button") {
-		parseItemImageButton(data,description);
+		parseItemImageButton(data, description);
 		return;
 	}
 
 	if ((type == "image_button") || (type == "image_button_exit")) {
-		parseImageButton(data,description,type);
+		parseImageButton(data, description, type);
 		return;
 	}
 
 	if (type == "tabheader") {
-		parseTabHeader(data,description);
+		parseTabHeader(data, description);
 		return;
 	}
 
 	if (type == "box") {
-		parseBox(data,description);
+		parseBox(data, description);
 		return;
 	}
 
 	if (type == "bgcolor") {
-		parseBackgroundColor(data,description);
+		parseBackgroundColor(data, description);
 		return;
 	}
 
 	if (type == "listcolors") {
-		parseListColors(data,description);
+		parseListColors(data, description);
 		return;
 	}
 
 	if (type == "tooltip") {
-		parseTooltip(data,description);
+		parseTooltip(data, description);
 		return;
 	}
 
@@ -3016,7 +2885,7 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 
 	// Ignore others
 	infostream << "Unknown DrawSpec: type=" << type << ", data=\"" << description << "\""
-			<< std::endl;
+			   << std::endl;
 }
 
 void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
@@ -3094,32 +2963,30 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	{
 		v3f formspec_bgcolor = g_settings->getV3F("formspec_default_bg_color");
 		m_bgcolor = video::SColor(
-			(u8) clamp_u8(g_settings->getS32("formspec_default_bg_opacity")),
-			clamp_u8(myround(formspec_bgcolor.X)),
-			clamp_u8(myround(formspec_bgcolor.Y)),
-			clamp_u8(myround(formspec_bgcolor.Z))
-		);
+				(u8)clamp_u8(g_settings->getS32("formspec_default_bg_opacity")),
+				clamp_u8(myround(formspec_bgcolor.X)),
+				clamp_u8(myround(formspec_bgcolor.Y)),
+				clamp_u8(myround(formspec_bgcolor.Z)));
 	}
 
 	{
 		v3f formspec_bgcolor = g_settings->getV3F("formspec_fullscreen_bg_color");
 		m_fullscreen_bgcolor = video::SColor(
-			(u8) clamp_u8(g_settings->getS32("formspec_fullscreen_bg_opacity")),
-			clamp_u8(myround(formspec_bgcolor.X)),
-			clamp_u8(myround(formspec_bgcolor.Y)),
-			clamp_u8(myround(formspec_bgcolor.Z))
-		);
+				(u8)clamp_u8(g_settings->getS32("formspec_fullscreen_bg_opacity")),
+				clamp_u8(myround(formspec_bgcolor.X)),
+				clamp_u8(myround(formspec_bgcolor.Y)),
+				clamp_u8(myround(formspec_bgcolor.Z)));
 	}
 
-	m_default_tooltip_bgcolor = video::SColor(255,110,130,60);
-	m_default_tooltip_color = video::SColor(255,255,255,255);
+	m_default_tooltip_bgcolor = video::SColor(255, 110, 130, 60);
+	m_default_tooltip_color = video::SColor(255, 255, 255, 255);
 
 	// Add tooltip
 	{
 		assert(!m_tooltip_element);
 		// Note: parent != this so that the tooltip isn't clipped by the menu rectangle
-		m_tooltip_element = gui::StaticText::add(Environment, L"",
-			core::rect<s32>(0, 0, 110, 18));
+		m_tooltip_element =
+				gui::StaticText::add(Environment, L"", core::rect<s32>(0, 0, 110, 18));
 		m_tooltip_element->enableOverrideColor(true);
 		m_tooltip_element->setBackgroundColor(m_default_tooltip_bgcolor);
 		m_tooltip_element->setDrawBackground(true);
@@ -3127,11 +2994,11 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		m_tooltip_element->setOverrideColor(m_default_tooltip_color);
 		m_tooltip_element->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_CENTER);
 		m_tooltip_element->setWordWrap(false);
-		//we're not parent so no autograb for this one!
+		// we're not parent so no autograb for this one!
 		m_tooltip_element->grab();
 	}
 
-	std::vector<std::string> elements = split(m_formspec_string,']');
+	std::vector<std::string> elements = split(m_formspec_string, ']');
 	unsigned int i = 0;
 
 	/* try to read version from first element only */
@@ -3143,21 +3010,21 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 	/* we need size first in order to calculate image scale */
 	mydata.explicit_size = false;
-	for (; i< elements.size(); i++) {
+	for (; i < elements.size(); i++) {
 		if (!parseSizeDirect(&mydata, elements[i])) {
 			break;
 		}
 	}
 
 	/* "position" element is always after "size" element if it used */
-	for (; i< elements.size(); i++) {
+	for (; i < elements.size(); i++) {
 		if (!parsePositionDirect(&mydata, elements[i])) {
 			break;
 		}
 	}
 
 	/* "anchor" element is always after "position" (or  "size" element) if it used */
-	for (; i< elements.size(); i++) {
+	for (; i < elements.size(); i++) {
 		if (!parseAnchorDirect(&mydata, elements[i])) {
 			break;
 		}
@@ -3197,7 +3064,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	if (mydata.explicit_size) {
 		// compute scaling for specified form size
 		if (m_lock) {
-			v2u32 current_screensize = RenderingEngine::get_video_driver()->getScreenSize();
+			v2u32 current_screensize =
+					RenderingEngine::get_video_driver()->getScreenSize();
 			v2u32 delta = current_screensize - m_lockscreensize;
 
 			if (current_screensize.Y > m_lockscreensize.Y)
@@ -3210,11 +3078,11 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			else
 				delta.X = 0;
 
-			offset = v2s32(delta.X,delta.Y);
+			offset = v2s32(delta.X, delta.Y);
 
 			mydata.screensize = m_lockscreensize;
 		} else {
-			offset = v2s32(0,0);
+			offset = v2s32(0, 0);
 		}
 
 		const double gui_scaling = g_settings->getFloat("gui_scaling", 0.5f, 42.0f);
@@ -3235,10 +3103,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			double fitx_imgsize;
 			double fity_imgsize;
 
-			v2f padded_screensize(
-				mydata.screensize.X * (1.0f - mydata.padding.X * 2.0f),
-				mydata.screensize.Y * (1.0f - mydata.padding.Y * 2.0f)
-			);
+			v2f padded_screensize(mydata.screensize.X * (1.0f - mydata.padding.X * 2.0f),
+					mydata.screensize.Y * (1.0f - mydata.padding.Y * 2.0f));
 
 			if (mydata.real_coordinates) {
 				fitx_imgsize = padded_screensize.X / mydata.invsize.X;
@@ -3247,10 +3113,10 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 				// The maximum imgsize in the old coordinate system also needs to
 				// factor in padding and spacing along with 0.1 inventory slot spare
 				// and help text space, hence the magic numbers.
-				fitx_imgsize = padded_screensize.X /
-						((5.0 / 4.0) * (0.5 + mydata.invsize.X));
-				fity_imgsize = padded_screensize.Y /
-						((15.0 / 13.0) * (0.85 + mydata.invsize.Y));
+				fitx_imgsize =
+						padded_screensize.X / ((5.0 / 4.0) * (0.5 + mydata.invsize.X));
+				fity_imgsize =
+						padded_screensize.Y / ((15.0 / 13.0) * (0.85 + mydata.invsize.Y));
 			}
 
 			s32 min_screen_dim = std::min(padded_screensize.X, padded_screensize.Y);
@@ -3265,8 +3131,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 #endif
 			// Try to use the preferred imgsize, but if that's bigger than the maximum
 			// size, use the maximum size.
-			use_imgsize = std::min(prefer_imgsize,
-					std::min(fitx_imgsize, fity_imgsize));
+			use_imgsize = std::min(prefer_imgsize, std::min(fitx_imgsize, fity_imgsize));
 		}
 
 		// Everything else is scaled in proportion to the
@@ -3278,42 +3143,45 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		// is 2/5 vertical inventory slot spacing, and button
 		// half-height is 7/8 of font height.
 		imgsize = v2s32(use_imgsize, use_imgsize);
-		spacing = v2f32(use_imgsize*5.0/4, use_imgsize*15.0/13);
-		padding = v2s32(use_imgsize*3.0/8, use_imgsize*3.0/8);
-		m_btn_height = use_imgsize*15.0/13 * 0.35;
+		spacing = v2f32(use_imgsize * 5.0 / 4, use_imgsize * 15.0 / 13);
+		padding = v2s32(use_imgsize * 3.0 / 8, use_imgsize * 3.0 / 8);
+		m_btn_height = use_imgsize * 15.0 / 13 * 0.35;
 
 		m_font = g_fontengine->getFont();
 
 		if (mydata.real_coordinates) {
-			mydata.size = v2s32(
-				mydata.invsize.X*imgsize.X,
-				mydata.invsize.Y*imgsize.Y
-			);
+			mydata.size =
+					v2s32(mydata.invsize.X * imgsize.X, mydata.invsize.Y * imgsize.Y);
 		} else {
 			mydata.size = v2s32(
-				padding.X*2+spacing.X*(mydata.invsize.X-1.0)+imgsize.X,
-				padding.Y*2+spacing.Y*(mydata.invsize.Y-1.0)+imgsize.Y + m_btn_height*2.0/3.0
-			);
+					padding.X * 2 + spacing.X * (mydata.invsize.X - 1.0) + imgsize.X,
+					padding.Y * 2 + spacing.Y * (mydata.invsize.Y - 1.0) + imgsize.Y +
+							m_btn_height * 2.0 / 3.0);
 		}
 
 		DesiredRect = mydata.rect = core::rect<s32>(
-				(s32)((f32)mydata.screensize.X * mydata.offset.X) - (s32)(mydata.anchor.X * (f32)mydata.size.X) + offset.X,
-				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) - (s32)(mydata.anchor.Y * (f32)mydata.size.Y) + offset.Y,
-				(s32)((f32)mydata.screensize.X * mydata.offset.X) + (s32)((1.0 - mydata.anchor.X) * (f32)mydata.size.X) + offset.X,
-				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) + (s32)((1.0 - mydata.anchor.Y) * (f32)mydata.size.Y) + offset.Y
-		);
+				(s32)((f32)mydata.screensize.X * mydata.offset.X) -
+						(s32)(mydata.anchor.X * (f32)mydata.size.X) + offset.X,
+				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) -
+						(s32)(mydata.anchor.Y * (f32)mydata.size.Y) + offset.Y,
+				(s32)((f32)mydata.screensize.X * mydata.offset.X) +
+						(s32)((1.0 - mydata.anchor.X) * (f32)mydata.size.X) + offset.X,
+				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) +
+						(s32)((1.0 - mydata.anchor.Y) * (f32)mydata.size.Y) + offset.Y);
 	} else {
 		// Non-size[] form must consist only of text fields and
 		// implicit "Proceed" button.  Use default font, and
 		// temporary form size which will be recalculated below.
 		m_font = g_fontengine->getFont();
 		m_btn_height = font_line_height(m_font) * 0.875;
-		DesiredRect = core::rect<s32>(
-			(s32)((f32)mydata.screensize.X * mydata.offset.X) - (s32)(mydata.anchor.X * 580.0),
-			(s32)((f32)mydata.screensize.Y * mydata.offset.Y) - (s32)(mydata.anchor.Y * 300.0),
-			(s32)((f32)mydata.screensize.X * mydata.offset.X) + (s32)((1.0 - mydata.anchor.X) * 580.0),
-			(s32)((f32)mydata.screensize.Y * mydata.offset.Y) + (s32)((1.0 - mydata.anchor.Y) * 300.0)
-		);
+		DesiredRect = core::rect<s32>((s32)((f32)mydata.screensize.X * mydata.offset.X) -
+											  (s32)(mydata.anchor.X * 580.0),
+				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) -
+						(s32)(mydata.anchor.Y * 300.0),
+				(s32)((f32)mydata.screensize.X * mydata.offset.X) +
+						(s32)((1.0 - mydata.anchor.X) * 580.0),
+				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) +
+						(s32)((1.0 - mydata.anchor.Y) * 300.0));
 	}
 	recalculateAbsolutePosition(false);
 	mydata.basepos = getBasePos();
@@ -3330,13 +3198,14 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	// (We use an arbitrarily big rect. The actual size is determined later by
 	// clipping to `this`.)
 	core::rect<s32> background_parent_rect(0, 0, 100000, 100000);
-	mydata.background_parent.reset(new gui::IGUIElement(EGUIET_ELEMENT, Environment,
-			this, -1, background_parent_rect));
+	mydata.background_parent.reset(new gui::IGUIElement(
+			EGUIET_ELEMENT, Environment, this, -1, background_parent_rect));
 
 	pos_offset = v2f32();
 
 	// used for formspec versions < 3
-	std::list<IGUIElement *>::iterator legacy_sort_start = std::prev(Children.end()); // last element
+	std::list<IGUIElement *>::iterator legacy_sort_start =
+			std::prev(Children.end()); // last element
 
 	if (enable_prepends) {
 		// Backup the coordinates so that prepends can use the coordinates of choice.
@@ -3360,16 +3229,16 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		mydata.real_coordinates = rc_backup; // Restore coordinates
 	}
 
-	for (; i< elements.size(); i++) {
+	for (; i < elements.size(); i++) {
 		parseElement(&mydata, elements[i]);
 	}
 
 	if (mydata.current_parent != this) {
 		errorstream << "Invalid formspec string: scroll_container was never closed!"
-			<< std::endl;
+					<< std::endl;
 	} else if (!container_stack.empty()) {
 		errorstream << "Invalid formspec string: container was never closed!"
-			<< std::endl;
+					<< std::endl;
 	}
 
 	// get the scrollbar elements for scroll_containers
@@ -3385,12 +3254,9 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	// If there are fields without explicit size[], add a "Proceed"
 	// button and adjust size to fit all the fields.
 	if (mydata.simple_field_count > 0 && !mydata.explicit_size) {
-		mydata.rect = core::rect<s32>(
-				mydata.screensize.X / 2 - 580 / 2,
-				mydata.screensize.Y / 2 - 300 / 2,
-				mydata.screensize.X / 2 + 580 / 2,
-				mydata.screensize.Y / 2 + 240 / 2 + mydata.simple_field_count * 60
-		);
+		mydata.rect = core::rect<s32>(mydata.screensize.X / 2 - 580 / 2,
+				mydata.screensize.Y / 2 - 300 / 2, mydata.screensize.X / 2 + 580 / 2,
+				mydata.screensize.Y / 2 + 240 / 2 + mydata.simple_field_count * 60);
 
 		DesiredRect = mydata.rect;
 		recalculateAbsolutePosition(false);
@@ -3401,10 +3267,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			pos.Y = (mydata.simple_field_count + 2) * 60;
 
 			v2s32 size = DesiredRect.getSize();
-			mydata.rect = core::rect<s32>(
-					size.X / 2 - 70,       pos.Y,
-					size.X / 2 - 70 + 140, pos.Y + m_btn_height * 2
-			);
+			mydata.rect = core::rect<s32>(size.X / 2 - 70, pos.Y, size.X / 2 - 70 + 140,
+					pos.Y + m_btn_height * 2);
 			const wchar_t *text = wgettext("Proceed");
 			GUIButton::addButton(Environment, mydata.rect, m_tsrc, this, 257, text);
 			delete[] text;
@@ -3413,9 +3277,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 	// Set initial focus if parser didn't set it
 	gui::IGUIElement *focused_element = Environment->getFocus();
-	if (!focused_element
-			|| !isMyChild(focused_element)
-			|| focused_element->getType() == gui::EGUIET_TAB_CONTROL)
+	if (!focused_element || !isMyChild(focused_element) ||
+			focused_element->getType() == gui::EGUIET_TAB_CONTROL)
 		setInitialFocus();
 
 	skin->setFont(old_font);
@@ -3457,13 +3320,13 @@ void GUIFormSpecMenu::legacySortElements(std::list<IGUIElement *>::iterator from
 
 	// 2: Sort the container
 	std::stable_sort(elements.begin(), elements.end(),
-			[this] (const IGUIElement *a, const IGUIElement *b) -> bool {
-		// TODO: getSpecByID is a linear search. It should made O(1), or cached here.
-		const FieldSpec *spec_a = getSpecByID(a->getID());
-		const FieldSpec *spec_b = getSpecByID(b->getID());
-		return spec_a && spec_b &&
-			spec_a->priority < spec_b->priority;
-	});
+			[this](const IGUIElement *a, const IGUIElement *b) -> bool {
+				// TODO: getSpecByID is a linear search. It should made O(1), or cached
+				// here.
+				const FieldSpec *spec_a = getSpecByID(a->getID());
+				const FieldSpec *spec_b = getSpecByID(b->getID());
+				return spec_a && spec_b && spec_a->priority < spec_b->priority;
+			});
 
 	// 3: Re-assign the pointers
 	reorderChildren(from, to, elements);
@@ -3503,22 +3366,22 @@ GUIInventoryList::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 	for (const GUIInventoryList *e : m_inventorylists) {
 		s32 item_index = e->getItemIndexAtPos(p);
 		if (item_index != -1)
-			return GUIInventoryList::ItemSpec(e->getInventoryloc(), e->getListname(),
-					item_index, e->getSlotSize());
+			return GUIInventoryList::ItemSpec(
+					e->getInventoryloc(), e->getListname(), item_index, e->getSlotSize());
 	}
 
-	return GUIInventoryList::ItemSpec(InventoryLocation(), "", -1, {0,0});
+	return GUIInventoryList::ItemSpec(InventoryLocation(), "", -1, {0, 0});
 }
 
 void GUIFormSpecMenu::drawSelectedItem()
 {
-	video::IVideoDriver* driver = Environment->getVideoDriver();
+	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	if (!m_selected_item) {
 		// reset rotation time
 		drawItemStack(driver, m_font, ItemStack(),
-				core::rect<s32>(v2s32(0, 0), v2s32(0, 0)), NULL,
-				m_client, IT_ROT_DRAGGED);
+				core::rect<s32>(v2s32(0, 0), v2s32(0, 0)), NULL, m_client,
+				IT_ROT_DRAGGED);
 		return;
 	}
 
@@ -3547,7 +3410,7 @@ void GUIFormSpecMenu::drawMenu()
 		}
 	}
 
-	gui::IGUISkin* skin = Environment->getSkin();
+	gui::IGUISkin *skin = Environment->getSkin();
 	sanity_check(skin != NULL);
 	gui::IGUIFont *old_font = skin->getFont();
 	skin->setFont(m_font);
@@ -3556,7 +3419,7 @@ void GUIFormSpecMenu::drawMenu()
 
 	updateSelectedItem();
 
-	video::IVideoDriver* driver = Environment->getVideoDriver();
+	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	/*
 		Draw background color
@@ -3594,8 +3457,7 @@ void GUIFormSpecMenu::drawMenu()
 	*/
 	for (auto child : Children)
 		if (child->isNotClipped() ||
-				AbsoluteClippingRect.isRectCollided(
-						child->getAbsolutePosition()))
+				AbsoluteClippingRect.isRectCollided(child->getAbsolutePosition()))
 			child->draw();
 
 	for (gui::IGUIElement *e : m_clickthrough_elements)
@@ -3610,8 +3472,8 @@ void GUIFormSpecMenu::drawMenu()
 	if (m_hovered_item_tooltips.empty()) {
 		// reset rotation time
 		drawItemStack(driver, m_font, ItemStack(),
-			core::rect<s32>(v2s32(0, 0), v2s32(0, 0)),
-			NULL, m_client, IT_ROT_HOVERED);
+				core::rect<s32>(v2s32(0, 0), v2s32(0, 0)), NULL, m_client,
+				IT_ROT_HOVERED);
 	}
 
 /* TODO find way to show tooltips on touchscreen */
@@ -3626,8 +3488,8 @@ void GUIFormSpecMenu::drawMenu()
 			Environment->getRootGUIElement()->getElementFromPoint(m_pointer);
 
 #ifndef HAVE_TOUCHSCREENGUI
-	gui::ICursorControl *cursor_control = RenderingEngine::get_raw_device()->
-			getCursorControl();
+	gui::ICursorControl *cursor_control =
+			RenderingEngine::get_raw_device()->getCursorControl();
 	gui::ECURSOR_ICON current_cursor_icon = cursor_control->getActiveIcon();
 #endif
 	bool hovered_element_found = false;
@@ -3670,7 +3532,7 @@ void GUIFormSpecMenu::drawMenu()
 					const std::wstring &text = m_tooltips[field.fname].tooltip;
 					if (!text.empty())
 						showTooltip(text, m_tooltips[field.fname].color,
-							m_tooltips[field.fname].bgcolor);
+								m_tooltips[field.fname].bgcolor);
 				}
 
 #ifndef HAVE_TOUCHSCREENGUI
@@ -3704,9 +3566,8 @@ void GUIFormSpecMenu::drawMenu()
 	skin->setFont(old_font);
 }
 
-
 void GUIFormSpecMenu::showTooltip(const std::wstring &text,
-	const irr::video::SColor &color, const irr::video::SColor &bgcolor)
+		const irr::video::SColor &color, const irr::video::SColor &bgcolor)
 {
 	EnrichedString ntext(text);
 	ntext.setDefaultColor(color);
@@ -3724,7 +3585,7 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 	int tooltip_offset_y = m_btn_height;
 #ifdef HAVE_TOUCHSCREENGUI
 	tooltip_offset_x *= 3;
-	tooltip_offset_y  = 0;
+	tooltip_offset_y = 0;
 	if (m_pointer.X > (s32)screenSize.X / 2)
 		tooltip_offset_x = -(tooltip_offset_x + tooltip_width);
 
@@ -3737,16 +3598,13 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 	s32 tooltip_x = m_pointer.X + tooltip_offset_x;
 	s32 tooltip_y = m_pointer.Y + tooltip_offset_y;
 	if (tooltip_x + tooltip_width > (s32)screenSize.X)
-		tooltip_x = (s32)screenSize.X - tooltip_width  - m_btn_height;
+		tooltip_x = (s32)screenSize.X - tooltip_width - m_btn_height;
 	if (tooltip_y + tooltip_height > (s32)screenSize.Y)
 		tooltip_y = (s32)screenSize.Y - tooltip_height - m_btn_height;
 
 	m_tooltip_element->setRelativePosition(
-		core::rect<s32>(
-			core::position2d<s32>(tooltip_x, tooltip_y),
-			core::dimension2d<s32>(tooltip_width, tooltip_height)
-		)
-	);
+			core::rect<s32>(core::position2d<s32>(tooltip_x, tooltip_y),
+					core::dimension2d<s32>(tooltip_width, tooltip_height)));
 
 	// Display the tooltip
 	m_tooltip_element->setVisible(true);
@@ -3805,7 +3663,7 @@ ItemStack GUIFormSpecMenu::verifySelectedItem()
 			Inventory *inv = m_invmgr->getInventory(m_selected_item->inventoryloc);
 			if (inv) {
 				InventoryList *list = inv->getList(m_selected_item->listname);
-				if (list && (u32) m_selected_item->i < list->getSize()) {
+				if (list && (u32)m_selected_item->i < list->getSize()) {
 					ItemStack stack = list->getItem(m_selected_item->i);
 					if (!m_selected_swap.empty()) {
 						if (m_selected_swap.name == stack.name &&
@@ -3832,8 +3690,7 @@ ItemStack GUIFormSpecMenu::verifySelectedItem()
 
 void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 {
-	if(m_text_dst)
-	{
+	if (m_text_dst) {
 		StringMap fields;
 
 		if (quitmode == quit_mode_accept) {
@@ -3890,7 +3747,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 						e = static_cast<gui::IGUIComboBox *>(element);
 					} else {
 						warningstream << "GUIFormSpecMenu::acceptInput: dropdown "
-								<< "field without dropdown element" << std::endl;
+									  << "field without dropdown element" << std::endl;
 						continue;
 					}
 					s32 selected = e->getSelected();
@@ -3900,8 +3757,9 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 							fields[name] = std::to_string(selected + 1);
 						} else {
 							std::vector<std::string> *dropdown_values =
-								getDropDownValues(s.fname);
-							if (dropdown_values && selected < (s32)dropdown_values->size())
+									getDropDownValues(s.fname);
+							if (dropdown_values &&
+									selected < (s32)dropdown_values->size())
 								fields[name] = (*dropdown_values)[selected];
 						}
 					}
@@ -3923,7 +3781,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 					IGUIElement *element = getElementFromId(s.fid, true);
 					gui::IGUICheckBox *e = nullptr;
 					if ((element) && (element->getType() == gui::EGUIET_CHECK_BOX)) {
-						e = static_cast<gui::IGUICheckBox*>(element);
+						e = static_cast<gui::IGUICheckBox *>(element);
 					}
 
 					if (e != 0) {
@@ -3945,7 +3803,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 							fields[name] = "CHG:" + itos(e->getPos());
 						else
 							fields[name] = "VAL:" + itos(e->getPos());
- 					}
+					}
 				} else if (s.ftype == f_AnimatedImage) {
 					// No dynamic cast possible due to some distributions shipped
 					// without rtti support in Irrlicht
@@ -3968,7 +3826,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 	}
 }
 
-bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
+bool GUIFormSpecMenu::preprocessEvent(const SEvent &event)
 {
 	// The IGUITabControl renders visually using the skin's selected
 	// font, which we override for the duration of form drawing,
@@ -3980,12 +3838,11 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 			event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP) {
 		s32 x = event.MouseInput.X;
 		s32 y = event.MouseInput.Y;
-		gui::IGUIElement *hovered =
-			Environment->getRootGUIElement()->getElementFromPoint(
+		gui::IGUIElement *hovered = Environment->getRootGUIElement()->getElementFromPoint(
 				core::position2d<s32>(x, y));
 		if (hovered && isMyChild(hovered) &&
 				hovered->getType() == gui::EGUIET_TAB_CONTROL) {
-			gui::IGUISkin* skin = Environment->getSkin();
+			gui::IGUISkin *skin = Environment->getSkin();
 			sanity_check(skin != NULL);
 			gui::IGUIFont *old_font = skin->getFont();
 			skin->setFont(m_font);
@@ -3997,16 +3854,16 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 
 	// Fix Esc/Return key being eaten by checkboxen and tables
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
-			KeyPress kp(event.KeyInput);
-		if (kp == EscapeKey || kp == CancelKey
-				|| kp == getKeySetting("keymap_inventory")
-				|| event.KeyInput.Key==KEY_RETURN) {
+		KeyPress kp(event.KeyInput);
+		if (kp == EscapeKey || kp == CancelKey ||
+				kp == getKeySetting("keymap_inventory") ||
+				event.KeyInput.Key == KEY_RETURN) {
 			gui::IGUIElement *focused = Environment->getFocus();
 			if (focused && isMyChild(focused) &&
 					(focused->getType() == gui::EGUIET_LIST_BOX ||
-					focused->getType() == gui::EGUIET_CHECK_BOX) &&
+							focused->getType() == gui::EGUIET_CHECK_BOX) &&
 					(focused->getParent()->getType() != gui::EGUIET_COMBO_BOX ||
-					event.KeyInput.Key != KEY_RETURN)) {
+							event.KeyInput.Key != KEY_RETURN)) {
 				OnEvent(event);
 				return true;
 			}
@@ -4015,12 +3872,11 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 	// Mouse wheel and move events: send to hovered element instead of focused
 	if (event.EventType == EET_MOUSE_INPUT_EVENT &&
 			(event.MouseInput.Event == EMIE_MOUSE_WHEEL ||
-			(event.MouseInput.Event == EMIE_MOUSE_MOVED &&
-			event.MouseInput.ButtonStates == 0))) {
+					(event.MouseInput.Event == EMIE_MOUSE_MOVED &&
+							event.MouseInput.ButtonStates == 0))) {
 		s32 x = event.MouseInput.X;
 		s32 y = event.MouseInput.Y;
-		gui::IGUIElement *hovered =
-			Environment->getRootGUIElement()->getElementFromPoint(
+		gui::IGUIElement *hovered = Environment->getRootGUIElement()->getElementFromPoint(
 				core::position2d<s32>(x, y));
 		if (hovered && isMyChild(hovered)) {
 			hovered->OnEvent(event);
@@ -4074,13 +3930,14 @@ enum ButtonEventType : u8
 	BET_OTHER
 };
 
-bool GUIFormSpecMenu::OnEvent(const SEvent& event)
+bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 {
-	if (event.EventType==EET_KEY_INPUT_EVENT) {
+	if (event.EventType == EET_KEY_INPUT_EVENT) {
 		KeyPress kp(event.KeyInput);
-		if (event.KeyInput.PressedDown && (
-				(kp == EscapeKey) || (kp == CancelKey) ||
-				((m_client != NULL) && (kp == getKeySetting("keymap_inventory"))))) {
+		if (event.KeyInput.PressedDown &&
+				((kp == EscapeKey) || (kp == CancelKey) ||
+						((m_client != NULL) &&
+								(kp == getKeySetting("keymap_inventory"))))) {
 			tryClose();
 			return true;
 		}
@@ -4094,25 +3951,23 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			m_show_debug = !m_show_debug;
 
 		if (event.KeyInput.PressedDown &&
-			(event.KeyInput.Key==KEY_RETURN ||
-			 event.KeyInput.Key==KEY_UP ||
-			 event.KeyInput.Key==KEY_DOWN)
-			) {
+				(event.KeyInput.Key == KEY_RETURN || event.KeyInput.Key == KEY_UP ||
+						event.KeyInput.Key == KEY_DOWN)) {
 			switch (event.KeyInput.Key) {
-				case KEY_RETURN:
-					current_keys_pending.key_enter = true;
-					break;
-				case KEY_UP:
-					current_keys_pending.key_up = true;
-					break;
-				case KEY_DOWN:
-					current_keys_pending.key_down = true;
-					break;
+			case KEY_RETURN:
+				current_keys_pending.key_enter = true;
 				break;
-				default:
-					//can't happen at all!
-					FATAL_ERROR("Reached a source line that can't ever been reached");
-					break;
+			case KEY_UP:
+				current_keys_pending.key_up = true;
+				break;
+			case KEY_DOWN:
+				current_keys_pending.key_down = true;
+				break;
+				break;
+			default:
+				// can't happen at all!
+				FATAL_ERROR("Reached a source line that can't ever been reached");
+				break;
 			}
 			if (current_keys_pending.key_enter && m_allowclose) {
 				acceptInput(quit_mode_accept);
@@ -4122,7 +3977,6 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			}
 			return true;
 		}
-
 	}
 
 	/* Mouse event other than movement, or crossing the border of inventory
@@ -4130,9 +3984,10 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 	 */
 	if (event.EventType == EET_MOUSE_INPUT_EVENT &&
 			(event.MouseInput.Event != EMIE_MOUSE_MOVED ||
-			 (event.MouseInput.Event == EMIE_MOUSE_MOVED &&
-			  event.MouseInput.isRightPressed() &&
-			  getItemAtPos(m_pointer).i != getItemAtPos(m_old_pointer).i))) {
+					(event.MouseInput.Event == EMIE_MOUSE_MOVED &&
+							event.MouseInput.isRightPressed() &&
+							getItemAtPos(m_pointer).i !=
+									getItemAtPos(m_old_pointer).i))) {
 
 		// Get selected item and hovered/clicked item (s)
 
@@ -4153,66 +4008,70 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 		u32 s_count = 0;
 
 		if (s.isValid())
-		do { // breakable
-			inv_s = m_invmgr->getInventory(s.inventoryloc);
+			do { // breakable
+				inv_s = m_invmgr->getInventory(s.inventoryloc);
 
-			if (!inv_s) {
-				errorstream << "InventoryMenu: The selected inventory location "
-						<< "\"" << s.inventoryloc.dump() << "\" doesn't exist"
-						<< std::endl;
-				s.i = -1;  // make it invalid again
-				break;
-			}
+				if (!inv_s) {
+					errorstream << "InventoryMenu: The selected inventory location "
+								<< "\"" << s.inventoryloc.dump() << "\" doesn't exist"
+								<< std::endl;
+					s.i = -1; // make it invalid again
+					break;
+				}
 
-			list_s = inv_s->getList(s.listname);
-			if (list_s == NULL) {
-				verbosestream << "InventoryMenu: The selected inventory list \""
-						<< s.listname << "\" does not exist" << std::endl;
-				s.i = -1;  // make it invalid again
-				break;
-			}
+				list_s = inv_s->getList(s.listname);
+				if (list_s == NULL) {
+					verbosestream << "InventoryMenu: The selected inventory list \""
+								  << s.listname << "\" does not exist" << std::endl;
+					s.i = -1; // make it invalid again
+					break;
+				}
 
-			if ((u32)s.i >= list_s->getSize()) {
-				infostream << "InventoryMenu: The selected inventory list \""
-						<< s.listname << "\" is too small (i=" << s.i << ", size="
-						<< list_s->getSize() << ")" << std::endl;
-				s.i = -1;  // make it invalid again
-				break;
-			}
+				if ((u32)s.i >= list_s->getSize()) {
+					infostream << "InventoryMenu: The selected inventory list \""
+							   << s.listname << "\" is too small (i=" << s.i
+							   << ", size=" << list_s->getSize() << ")" << std::endl;
+					s.i = -1; // make it invalid again
+					break;
+				}
 
-			s_count = list_s->getItem(s.i).count;
-		} while(0);
+				s_count = list_s->getItem(s.i).count;
+			} while (0);
 
-		bool identical = m_selected_item && s.isValid() &&
-			(inv_selected == inv_s) &&
-			(m_selected_item->listname == s.listname) &&
-			(m_selected_item->i == s.i);
+		bool identical = m_selected_item && s.isValid() && (inv_selected == inv_s) &&
+						 (m_selected_item->listname == s.listname) &&
+						 (m_selected_item->i == s.i);
 
 		ButtonEventType button = BET_LEFT;
 		ButtonEventType updown = BET_OTHER;
 		switch (event.MouseInput.Event) {
 		case EMIE_LMOUSE_PRESSED_DOWN:
-			button = BET_LEFT; updown = BET_DOWN;
+			button = BET_LEFT;
+			updown = BET_DOWN;
 			break;
 		case EMIE_RMOUSE_PRESSED_DOWN:
-			button = BET_RIGHT; updown = BET_DOWN;
+			button = BET_RIGHT;
+			updown = BET_DOWN;
 			break;
 		case EMIE_MMOUSE_PRESSED_DOWN:
-			button = BET_MIDDLE; updown = BET_DOWN;
+			button = BET_MIDDLE;
+			updown = BET_DOWN;
 			break;
 		case EMIE_MOUSE_WHEEL:
-			button = (event.MouseInput.Wheel > 0) ?
-				BET_WHEEL_UP : BET_WHEEL_DOWN;
+			button = (event.MouseInput.Wheel > 0) ? BET_WHEEL_UP : BET_WHEEL_DOWN;
 			updown = BET_DOWN;
 			break;
 		case EMIE_LMOUSE_LEFT_UP:
-			button = BET_LEFT; updown = BET_UP;
+			button = BET_LEFT;
+			updown = BET_UP;
 			break;
 		case EMIE_RMOUSE_LEFT_UP:
-			button = BET_RIGHT; updown = BET_UP;
+			button = BET_RIGHT;
+			updown = BET_UP;
 			break;
 		case EMIE_MMOUSE_LEFT_UP:
-			button = BET_MIDDLE; updown = BET_UP;
+			button = BET_MIDDLE;
+			updown = BET_UP;
 			break;
 		case EMIE_MOUSE_MOVED:
 			updown = BET_MOVE;
@@ -4240,7 +4099,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 		case BET_DOWN:
 			// Some mouse button has been pressed
 
-			//infostream << "Mouse button " << button << " pressed at p=("
+			// infostream << "Mouse button " << button << " pressed at p=("
 			//	<< event.MouseInput.X << "," << event.MouseInput.Y << ")"
 			//	<< std::endl;
 
@@ -4261,7 +4120,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 						count = MYMIN(s_count, 10);
 					else if (button == BET_WHEEL_DOWN)
 						count = 1;
-					else  // left
+					else // left
 						count = s_count;
 
 					if (!event.MouseInput.Shift) {
@@ -4299,22 +4158,22 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 							move_amount = 0;
 						}
 					}
-				} else if (!getAbsoluteClippingRect().isPointInside(m_pointer)
-						&& button != BET_WHEEL_DOWN) {
+				} else if (!getAbsoluteClippingRect().isPointInside(m_pointer) &&
+						   button != BET_WHEEL_DOWN) {
 					// Clicked outside of the window: drop
 					if (button == BET_RIGHT || button == BET_WHEEL_UP)
 						drop_amount = 1;
 					else if (button == BET_MIDDLE)
 						drop_amount = MYMIN(m_selected_amount, 10);
-					else  // left
+					else // left
 						drop_amount = m_selected_amount;
 				}
 			}
-		break;
+			break;
 		case BET_UP:
 			// Some mouse button has been released
 
-			//infostream<<"Mouse button "<<button<<" released at p=("
+			// infostream<<"Mouse button "<<button<<" released at p=("
 			//	<<p.X<<","<<p.Y<<")"<<std::endl;
 
 			if (m_selected_dragging && m_selected_item) {
@@ -4335,7 +4194,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			// + click changes to drop item when moved mode
 			if (m_selected_item)
 				m_auto_place = true;
-		break;
+			break;
 		case BET_MOVE:
 			// Mouse has been moved and rmb is down and mouse pointer just
 			// entered a new inventory field (checked in the entry-if, this
@@ -4347,7 +4206,8 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 					// Only move an item if the destination slot is empty
 					// or contains the same item type as what is going to be
 					// moved
-					InventoryList *list_from = inv_selected->getList(m_selected_item->listname);
+					InventoryList *list_from =
+							inv_selected->getList(m_selected_item->listname);
 					InventoryList *list_to = list_s;
 					assert(list_from && list_to);
 					ItemStack stack_from = list_from->getItem(m_selected_item->i);
@@ -4356,7 +4216,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 						move_amount = 1;
 				}
 			}
-		break;
+			break;
 		default:
 			break;
 		}
@@ -4381,8 +4241,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			bool move = true;
 			// If source stack cannot be added to destination stack at all,
 			// they are swapped
-			if (leftover.count == stack_from.count &&
-					leftover.name == stack_from.name) {
+			if (leftover.count == stack_from.count && leftover.name == stack_from.name) {
 
 				if (m_selected_swap.empty()) {
 					m_selected_amount = stack_to.count;
@@ -4422,8 +4281,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			u32 i = 0;
 			for (; i < mis; i++) {
 				const ListRingSpec &sp = m_inventory_rings[i];
-				if (sp.inventoryloc == s.inventoryloc
-						&& sp.listname == s.listname)
+				if (sp.inventoryloc == s.inventoryloc && sp.listname == s.listname)
 					break;
 			}
 			do {
@@ -4480,8 +4338,8 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 			// if there are no items selected or the selected item
 			// belongs to craftresult list, proceed with crafting
-			if (!m_selected_item ||
-					!m_selected_item->isValid() || m_selected_item->listname == "craftresult") {
+			if (!m_selected_item || !m_selected_item->isValid() ||
+					m_selected_item->listname == "craftresult") {
 
 				assert(inv_s);
 
@@ -4506,8 +4364,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 	}
 
 	if (event.EventType == EET_GUI_EVENT) {
-		if (event.GUIEvent.EventType == gui::EGET_TAB_CHANGED
-				&& isVisible()) {
+		if (event.GUIEvent.EventType == gui::EGET_TAB_CHANGED && isVisible()) {
 			// find the element that was clicked
 			for (GUIFormSpecMenu::FieldSpec &s : m_fields) {
 				if ((s.ftype == f_TabHeader) &&
@@ -4521,11 +4378,9 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 				}
 			}
 		}
-		if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST
-				&& isVisible()) {
+		if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST && isVisible()) {
 			if (!canTakeFocus(event.GUIEvent.Element)) {
-				infostream<<"GUIFormSpecMenu: Not allowing focus change."
-						<<std::endl;
+				infostream << "GUIFormSpecMenu: Not allowing focus change." << std::endl;
 				// Returning true disables focus change
 				return true;
 			}
@@ -4611,7 +4466,8 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 		if (event.GUIEvent.EventType == gui::EGET_SCROLL_BAR_CHANGED) {
 			// move scroll_containers
-			for (const std::pair<std::string, GUIScrollContainer *> &c : m_scroll_containers)
+			for (const std::pair<std::string, GUIScrollContainer *> &c :
+					m_scroll_containers)
 				c.second->onScrollEvent(event.GUIEvent.Caller);
 		}
 
@@ -4619,11 +4475,10 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			if (event.GUIEvent.Caller->getID() > 257) {
 				bool close_on_enter = true;
 				for (GUIFormSpecMenu::FieldSpec &s : m_fields) {
-					if (s.ftype == f_Unknown &&
-							s.fid == event.GUIEvent.Caller->getID()) {
+					if (s.ftype == f_Unknown && s.fid == event.GUIEvent.Caller->getID()) {
 						current_field_enter_pending = s.fname;
 						std::unordered_map<std::string, bool>::const_iterator it =
-							field_close_on_enter.find(s.fname);
+								field_close_on_enter.find(s.fname);
 						if (it != field_close_on_enter.end())
 							close_on_enter = (*it).second;
 
@@ -4654,7 +4509,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 					if ((s.ftype == f_Table) && (s.fid == current_id)) {
 						s.send = true;
 						acceptInput();
-						s.send=false;
+						s.send = false;
 					}
 				}
 				return true;
@@ -4679,7 +4534,6 @@ std::string GUIFormSpecMenu::getNameByID(s32 id)
 	return "";
 }
 
-
 const GUIFormSpecMenu::FieldSpec *GUIFormSpecMenu::getSpecByID(s32 id)
 {
 	for (FieldSpec &spec : m_fields) {
@@ -4703,13 +4557,14 @@ std::wstring GUIFormSpecMenu::getLabelByID(s32 id)
 	return L"";
 }
 
-StyleSpec GUIFormSpecMenu::getDefaultStyleForElement(const std::string &type,
-		const std::string &name, const std::string &parent_type) {
+StyleSpec GUIFormSpecMenu::getDefaultStyleForElement(
+		const std::string &type, const std::string &name, const std::string &parent_type)
+{
 	return getStyleForElement(type, name, parent_type)[StyleSpec::STATE_DEFAULT];
 }
 
 std::array<StyleSpec, StyleSpec::NUM_STATES> GUIFormSpecMenu::getStyleForElement(
-	const std::string &type, const std::string &name, const std::string &parent_type)
+		const std::string &type, const std::string &name, const std::string &parent_type)
 {
 	std::array<StyleSpec, StyleSpec::NUM_STATES> ret;
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+
 #include <cstdlib>
 #include <cmath>
 #include <algorithm>
@@ -38,7 +39,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/renderingengine.h"
 #include "log.h"
 #include "client/tile.h" // ITextureSource
-#include "client/hud.h"	 // drawItemStack
+#include "client/hud.h" // drawItemStack
 #include "filesys.h"
 #include "gettime.h"
 #include "gettext.h"
@@ -67,25 +68,24 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiHyperText.h"
 #include "guiScene.h"
 
-#define MY_CHECKPOS(a, b)                                                                \
-	if (v_pos.size() != 2) {                                                             \
-		errorstream << "Invalid pos for element " << a << " specified: \"" << parts[b]   \
-					<< "\"" << std::endl;                                                \
-		return;                                                                          \
+#define MY_CHECKPOS(a,b)													\
+	if (v_pos.size() != 2) {												\
+		errorstream<< "Invalid pos for element " << a << " specified: \""	\
+			<< parts[b] << "\"" << std::endl;								\
+			return;															\
 	}
 
-#define MY_CHECKGEOM(a, b)                                                               \
-	if (v_geom.size() != 2) {                                                            \
-		errorstream << "Invalid geometry for element " << a << " specified: \""          \
-					<< parts[b] << "\"" << std::endl;                                    \
-		return;                                                                          \
+#define MY_CHECKGEOM(a,b)													\
+	if (v_geom.size() != 2) {												\
+		errorstream<< "Invalid geometry for element " << a <<				\
+			" specified: \"" << parts[b] << "\"" << std::endl;				\
+			return;															\
 	}
 
-#define MY_CHECKCLIENT(a)                                                                \
-	if (!m_client) {                                                                     \
-		errorstream << "Attempted to use element " << a << " with m_client == nullptr."  \
-					<< std::endl;                                                        \
-		return;                                                                          \
+#define MY_CHECKCLIENT(a) \
+	if (!m_client) { \
+		errorstream << "Attempted to use element " << a << " with m_client == nullptr." << std::endl; \
+		return; \
 	}
 
 /*
@@ -98,17 +98,23 @@ static unsigned int font_line_height(gui::IGUIFont *font)
 
 inline u32 clamp_u8(s32 value)
 {
-	return (u32)MYMIN(MYMAX(value, 0), 255);
+	return (u32) MYMIN(MYMAX(value, 0), 255);
 }
 
-GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick, gui::IGUIElement *parent,
-		s32 id, IMenuManager *menumgr, Client *client, gui::IGUIEnvironment *guienv,
-		ISimpleTextureSource *tsrc, ISoundManager *sound_manager, IFormSource *fsrc,
-		TextDest *tdst, const std::string &formspecPrepend, bool remap_dbl_click) :
-		GUIModalMenu(guienv, parent, id, menumgr, remap_dbl_click),
-		m_invmgr(client), m_tsrc(tsrc), m_sound_manager(sound_manager), m_client(client),
-		m_formspec_prepend(formspecPrepend), m_form_src(fsrc), m_text_dst(tdst),
-		m_joystick(joystick)
+GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
+		gui::IGUIElement *parent, s32 id, IMenuManager *menumgr,
+		Client *client, gui::IGUIEnvironment *guienv, ISimpleTextureSource *tsrc,
+		ISoundManager *sound_manager, IFormSource *fsrc, TextDest *tdst,
+		const std::string &formspecPrepend, bool remap_dbl_click):
+	GUIModalMenu(guienv, parent, id, menumgr, remap_dbl_click),
+	m_invmgr(client),
+	m_tsrc(tsrc),
+	m_sound_manager(sound_manager),
+	m_client(client),
+	m_formspec_prepend(formspecPrepend),
+	m_form_src(fsrc),
+	m_text_dst(tdst),
+	m_joystick(joystick)
 {
 	current_keys_pending.key_down = false;
 	current_keys_pending.key_up = false;
@@ -129,14 +135,13 @@ GUIFormSpecMenu::~GUIFormSpecMenu()
 }
 
 void GUIFormSpecMenu::create(GUIFormSpecMenu *&cur_formspec, Client *client,
-		gui::IGUIEnvironment *guienv, JoystickController *joystick, IFormSource *fs_src,
-		TextDest *txt_dest, const std::string &formspecPrepend,
-		ISoundManager *sound_manager)
+	gui::IGUIEnvironment *guienv, JoystickController *joystick, IFormSource *fs_src,
+	TextDest *txt_dest, const std::string &formspecPrepend, ISoundManager *sound_manager)
 {
 	if (cur_formspec == nullptr) {
-		cur_formspec = new GUIFormSpecMenu(joystick, guiroot, -1, &g_menumgr, client,
-				guienv, client->getTextureSource(), sound_manager, fs_src, txt_dest,
-				formspecPrepend);
+		cur_formspec = new GUIFormSpecMenu(joystick, guiroot, -1, &g_menumgr,
+			client, guienv, client->getTextureSource(), sound_manager, fs_src,
+			txt_dest, formspecPrepend);
 		cur_formspec->doPause = false;
 
 		/*
@@ -173,11 +178,12 @@ void GUIFormSpecMenu::setInitialFocus()
 	// 5. first focusable (not statictext, not tabheader)
 	// 6. first child element
 
-	const auto &children = getChildren();
+	const auto& children = getChildren();
 
 	// 1. first empty editbox
 	for (gui::IGUIElement *it : children) {
-		if (it->getType() == gui::EGUIET_EDIT_BOX && it->getText()[0] == 0) {
+		if (it->getType() == gui::EGUIET_EDIT_BOX
+				&& it->getText()[0] == 0) {
 			Environment->setFocus(it);
 			return;
 		}
@@ -210,7 +216,7 @@ void GUIFormSpecMenu::setInitialFocus()
 	// 5. first focusable (not statictext, not tabheader)
 	for (gui::IGUIElement *it : children) {
 		if (it->getType() != gui::EGUIET_STATIC_TEXT &&
-				it->getType() != gui::EGUIET_TAB_CONTROL) {
+			it->getType() != gui::EGUIET_TAB_CONTROL) {
 			Environment->setFocus(it);
 			return;
 		}
@@ -223,7 +229,7 @@ void GUIFormSpecMenu::setInitialFocus()
 		Environment->setFocus(children.front());
 }
 
-GUITable *GUIFormSpecMenu::getTable(const std::string &tablename)
+GUITable* GUIFormSpecMenu::getTable(const std::string &tablename)
 {
 	for (auto &table : m_tables) {
 		if (tablename == table.first.fname)
@@ -232,7 +238,7 @@ GUITable *GUIFormSpecMenu::getTable(const std::string &tablename)
 	return 0;
 }
 
-std::vector<std::string> *GUIFormSpecMenu::getDropDownValues(const std::string &name)
+std::vector<std::string>* GUIFormSpecMenu::getDropDownValues(const std::string &name)
 {
 	for (auto &dropdown : m_dropdowns) {
 		if (name == dropdown.first.fname)
@@ -254,7 +260,7 @@ v2s32 GUIFormSpecMenu::getElementBasePos(const std::vector<std::string> *v_pos)
 v2s32 GUIFormSpecMenu::getRealCoordinateBasePos(const std::vector<std::string> &v_pos)
 {
 	return v2s32((stof(v_pos[0]) + pos_offset.X) * imgsize.X,
-			(stof(v_pos[1]) + pos_offset.Y) * imgsize.Y);
+		(stof(v_pos[1]) + pos_offset.Y) * imgsize.Y);
 }
 
 v2s32 GUIFormSpecMenu::getRealCoordinateGeometry(const std::vector<std::string> &v_geom)
@@ -263,27 +269,26 @@ v2s32 GUIFormSpecMenu::getRealCoordinateGeometry(const std::vector<std::string> 
 }
 
 bool GUIFormSpecMenu::precheckElement(const std::string &name, const std::string &element,
-		size_t args_min, size_t args_max, std::vector<std::string> &parts)
+	size_t args_min, size_t args_max, std::vector<std::string> &parts)
 {
 	parts = split(element, ';');
-	if (parts.size() >= args_min &&
-			(parts.size() <= args_max || m_formspec_version > FORMSPEC_API_VERSION))
+	if (parts.size() >= args_min && (parts.size() <= args_max || m_formspec_version > FORMSPEC_API_VERSION))
 		return true;
 
-	errorstream << "Invalid " << name << " element(" << parts.size() << "): '" << element
-				<< "'" << std::endl;
+	errorstream << "Invalid " << name << " element(" << parts.size() << "): '" << element << "'" << std::endl;
 	return false;
 }
 
-void GUIFormSpecMenu::parseSize(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 {
 	// Note: do not use precheckElement due to "," separator.
-	std::vector<std::string> parts = split(element, ',');
+	std::vector<std::string> parts = split(element,',');
 
 	if (((parts.size() == 2) || parts.size() == 3) ||
-			((parts.size() > 3) && (m_formspec_version > FORMSPEC_API_VERSION))) {
+		((parts.size() > 3) && (m_formspec_version > FORMSPEC_API_VERSION)))
+	{
 		if (parts[1].find(';') != std::string::npos)
-			parts[1] = parts[1].substr(0, parts[1].find(';'));
+			parts[1] = parts[1].substr(0,parts[1].find(';'));
 
 		data->invsize.X = MYMAX(0, stof(parts[0]));
 		data->invsize.Y = MYMAX(0, stof(parts[1]));
@@ -292,18 +297,17 @@ void GUIFormSpecMenu::parseSize(parserData *data, const std::string &element)
 #ifndef HAVE_TOUCHSCREENGUI
 		if (parts.size() == 3) {
 			if (parts[2] == "true") {
-				lockSize(true, v2u32(800, 600));
+				lockSize(true,v2u32(800,600));
 			}
 		}
 #endif
 		data->explicit_size = true;
 		return;
 	}
-	errorstream << "Invalid size element (" << parts.size() << "): '" << element << "'"
-				<< std::endl;
+	errorstream<< "Invalid size element (" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseContainer(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseContainer(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element, ',');
 
@@ -316,16 +320,13 @@ void GUIFormSpecMenu::parseContainer(parserData *data, const std::string &elemen
 		pos_offset.Y += stof(parts[1]);
 		return;
 	}
-	errorstream << "Invalid container start element (" << parts.size() << "): '"
-				<< element << "'" << std::endl;
+	errorstream<< "Invalid container start element (" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseContainerEnd(parserData *data)
+void GUIFormSpecMenu::parseContainerEnd(parserData* data)
 {
 	if (container_stack.empty()) {
-		errorstream
-				<< "Invalid container end element, no matching container start element"
-				<< std::endl;
+		errorstream<< "Invalid container end element, no matching container start element"  << std::endl;
 	} else {
 		pos_offset = container_stack.top();
 		container_stack.pop();
@@ -338,7 +339,7 @@ void GUIFormSpecMenu::parseScrollContainer(parserData *data, const std::string &
 	if (!precheckElement("scroll_container start", element, 4, 5, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_pos  = split(parts[0], ',');
 	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string scrollbar_name = parts[2];
 	std::string orientation = parts[3];
@@ -358,8 +359,8 @@ void GUIFormSpecMenu::parseScrollContainer(parserData *data, const std::string &
 		scroll_factor *= -imgsize.X;
 	else
 		warningstream << "GUIFormSpecMenu::parseScrollContainer(): "
-					  << "Invalid scroll_container orientation: " << orientation
-					  << std::endl;
+				<< "Invalid scroll_container orientation: " << orientation
+				<< std::endl;
 
 	// old parent (at first: this)
 	// ^ is parent of clipper
@@ -369,16 +370,21 @@ void GUIFormSpecMenu::parseScrollContainer(parserData *data, const std::string &
 	// make clipper
 	core::rect<s32> rect_clipper = core::rect<s32>(pos, pos + geom);
 
-	gui::IGUIElement *clipper = new gui::IGUIElement(
-			EGUIET_ELEMENT, Environment, data->current_parent, 0, rect_clipper);
+	gui::IGUIElement *clipper = new gui::IGUIElement(EGUIET_ELEMENT, Environment,
+			data->current_parent, 0, rect_clipper);
 
 	// make mover
-	FieldSpec spec_mover("", L"", L"", 258 + m_fields.size());
+	FieldSpec spec_mover(
+		"",
+		L"",
+		L"",
+		258 + m_fields.size()
+	);
 
 	core::rect<s32> rect_mover = core::rect<s32>(0, 0, geom.X, geom.Y);
 
-	GUIScrollContainer *mover = new GUIScrollContainer(
-			Environment, clipper, spec_mover.fid, rect_mover, orientation, scroll_factor);
+	GUIScrollContainer *mover = new GUIScrollContainer(Environment,
+			clipper, spec_mover.fid, rect_mover, orientation, scroll_factor);
 
 	data->current_parent = mover;
 
@@ -399,7 +405,7 @@ void GUIFormSpecMenu::parseScrollContainerEnd(parserData *data)
 	if (data->current_parent == this || data->current_parent->getParent() == this ||
 			container_stack.empty()) {
 		errorstream << "Invalid scroll_container end element, "
-					<< "no matching scroll_container start element" << std::endl;
+				<< "no matching scroll_container start element" << std::endl;
 		return;
 	}
 
@@ -409,7 +415,7 @@ void GUIFormSpecMenu::parseScrollContainerEnd(parserData *data)
 		// not 0,0, it is a normal container that was opened last, not a
 		// scroll_container
 		errorstream << "Invalid scroll_container end element, "
-					<< "an inner container was left open" << std::endl;
+				<< "an inner container was left open" << std::endl;
 		return;
 	}
 
@@ -428,14 +434,14 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 
 	std::string location = parts[0];
 	std::string listname = parts[1];
-	std::vector<std::string> v_pos = split(parts[2], ',');
-	std::vector<std::string> v_geom = split(parts[3], ',');
+	std::vector<std::string> v_pos  = split(parts[2],',');
+	std::vector<std::string> v_geom = split(parts[3],',');
 	std::string startindex;
 	if (parts.size() == 5)
 		startindex = parts[4];
 
-	MY_CHECKPOS("list", 2);
-	MY_CHECKGEOM("list", 3);
+	MY_CHECKPOS("list",2);
+	MY_CHECKGEOM("list",3);
 
 	InventoryLocation loc;
 
@@ -453,34 +459,43 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 		start_i = stoi(startindex);
 
 	if (geom.X < 0 || geom.Y < 0 || start_i < 0) {
-		errorstream << "Invalid list element: '" << element << "'" << std::endl;
+		errorstream << "Invalid list element: '" << element << "'"  << std::endl;
 		return;
 	}
 
 	if (!data->explicit_size)
 		warningstream << "invalid use of list without a size[] element" << std::endl;
 
-	FieldSpec spec("", L"", L"", 258 + m_fields.size(), 3);
+	FieldSpec spec(
+		"",
+		L"",
+		L"",
+		258 + m_fields.size(),
+		3
+	);
 
 	auto style = getDefaultStyleForElement("list", spec.fname);
 
 	v2f32 slot_scale = style.getVector2f(StyleSpec::SIZE, v2f32(0, 0));
 	v2f32 slot_size(
-			slot_scale.X <= 0 ? imgsize.X : std::max<f32>(slot_scale.X * imgsize.X, 1),
-			slot_scale.Y <= 0 ? imgsize.Y : std::max<f32>(slot_scale.Y * imgsize.Y, 1));
+		slot_scale.X <= 0 ? imgsize.X : std::max<f32>(slot_scale.X * imgsize.X, 1),
+		slot_scale.Y <= 0 ? imgsize.Y : std::max<f32>(slot_scale.Y * imgsize.Y, 1)
+	);
 
 	v2f32 slot_spacing = style.getVector2f(StyleSpec::SPACING, v2f32(-1, -1));
-	v2f32 default_spacing = data->real_coordinates
-									? v2f32(imgsize.X * 0.25f, imgsize.Y * 0.25f)
-									: v2f32(spacing.X - imgsize.X, spacing.Y - imgsize.Y);
+	v2f32 default_spacing = data->real_coordinates ?
+			v2f32(imgsize.X * 0.25f, imgsize.Y * 0.25f) :
+			v2f32(spacing.X - imgsize.X, spacing.Y - imgsize.Y);
 
-	slot_spacing.X = slot_spacing.X < 0 ? default_spacing.X : imgsize.X * slot_spacing.X;
-	slot_spacing.Y = slot_spacing.Y < 0 ? default_spacing.Y : imgsize.Y * slot_spacing.Y;
+	slot_spacing.X = slot_spacing.X < 0 ? default_spacing.X :
+			imgsize.X * slot_spacing.X;
+	slot_spacing.Y = slot_spacing.Y < 0 ? default_spacing.Y :
+			imgsize.Y * slot_spacing.Y;
 
 	slot_spacing += slot_size;
 
-	v2s32 pos = data->real_coordinates ? getRealCoordinateBasePos(v_pos)
-									   : getElementBasePos(&v_pos);
+	v2s32 pos = data->real_coordinates ? getRealCoordinateBasePos(v_pos) :
+			getElementBasePos(&v_pos);
 
 	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y,
 			pos.X + (geom.X - 1) * slot_spacing.X + slot_size.X,
@@ -528,17 +543,17 @@ void GUIFormSpecMenu::parseListRing(parserData *data, const std::string &element
 		return;
 	}
 
-	errorstream << "Invalid list ring element(" << parts.size() << ", "
-				<< m_inventorylists.size() << "): '" << element << "'" << std::endl;
+	errorstream<< "Invalid list ring element(" << parts.size() << ", "
+		<< m_inventorylists.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseCheckbox(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("checkbox", element, 3, 4, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
 	std::string name = parts[1];
 	std::string label = parts[2];
 	std::string selected;
@@ -546,7 +561,7 @@ void GUIFormSpecMenu::parseCheckbox(parserData *data, const std::string &element
 	if (parts.size() >= 4)
 		selected = parts[3];
 
-	MY_CHECKPOS("checkbox", 0);
+	MY_CHECKPOS("checkbox",0);
 
 	bool fselected = false;
 
@@ -564,22 +579,33 @@ void GUIFormSpecMenu::parseCheckbox(parserData *data, const std::string &element
 	if (data->real_coordinates) {
 		pos = getRealCoordinateBasePos(v_pos);
 
-		rect = core::rect<s32>(pos.X, pos.Y - y_center,
-				pos.X + label_size.Width + cb_size + 7, pos.Y + y_center);
+		rect = core::rect<s32>(
+				pos.X,
+				pos.Y - y_center,
+				pos.X + label_size.Width + cb_size + 7,
+				pos.Y + y_center
+			);
 	} else {
 		pos = getElementBasePos(&v_pos);
-		rect = core::rect<s32>(pos.X, pos.Y + imgsize.Y / 2 - y_center,
-				pos.X + label_size.Width + cb_size + 7, pos.Y + imgsize.Y / 2 + y_center);
+		rect = core::rect<s32>(
+				pos.X,
+				pos.Y + imgsize.Y / 2 - y_center,
+				pos.X + label_size.Width + cb_size + 7,
+				pos.Y + imgsize.Y / 2 + y_center
+			);
 	}
 
-	FieldSpec spec(name,
-			wlabel, // Needed for displaying text on MSVC
-			wlabel, 258 + m_fields.size());
+	FieldSpec spec(
+			name,
+			wlabel, //Needed for displaying text on MSVC
+			wlabel,
+			258+m_fields.size()
+		);
 
 	spec.ftype = f_CheckBox;
 
-	gui::IGUICheckBox *e = Environment->addCheckBox(
-			fselected, rect, data->current_parent, spec.fid, spec.flabel.c_str());
+	gui::IGUICheckBox *e = Environment->addCheckBox(fselected, rect,
+			data->current_parent, spec.fid, spec.flabel.c_str());
 
 	auto style = getDefaultStyleForElement("checkbox", name);
 
@@ -596,19 +622,19 @@ void GUIFormSpecMenu::parseCheckbox(parserData *data, const std::string &element
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseScrollBar(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("scrollbar", element, 5, 5, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
-	std::vector<std::string> v_geom = split(parts[1], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string name = parts[3];
 	std::string value = parts[4];
 
-	MY_CHECKPOS("scrollbar", 0);
-	MY_CHECKGEOM("scrollbar", 1);
+	MY_CHECKPOS("scrollbar",0);
+	MY_CHECKGEOM("scrollbar",1);
 
 	v2s32 pos;
 	v2s32 dim;
@@ -622,9 +648,15 @@ void GUIFormSpecMenu::parseScrollBar(parserData *data, const std::string &elemen
 		dim.Y = stof(v_geom[1]) * spacing.Y;
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + dim.X, pos.Y + dim.Y);
+	core::rect<s32> rect =
+			core::rect<s32>(pos.X, pos.Y, pos.X + dim.X, pos.Y + dim.Y);
 
-	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
+	FieldSpec spec(
+			name,
+			L"",
+			L"",
+			258+m_fields.size()
+		);
 
 	bool is_horizontal = true;
 
@@ -632,9 +664,9 @@ void GUIFormSpecMenu::parseScrollBar(parserData *data, const std::string &elemen
 		is_horizontal = false;
 
 	spec.ftype = f_ScrollBar;
-	spec.send = true;
-	GUIScrollBar *e = new GUIScrollBar(
-			Environment, data->current_parent, spec.fid, rect, is_horizontal, true);
+	spec.send  = true;
+	GUIScrollBar *e = new GUIScrollBar(Environment, data->current_parent,
+			spec.fid, rect, is_horizontal, true);
 
 	auto style = getDefaultStyleForElement("scrollbar", name);
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
@@ -659,17 +691,17 @@ void GUIFormSpecMenu::parseScrollBar(parserData *data, const std::string &elemen
 		Environment->setFocus(e);
 	}
 
-	m_scrollbars.emplace_back(spec, e);
+	m_scrollbars.emplace_back(spec,e);
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseScrollBarOptions(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element, ';');
 
 	if (parts.size() == 0) {
-		warningstream << "Invalid scrollbaroptions element(" << parts.size() << "): '"
-					  << element << "'" << std::endl;
+		warningstream << "Invalid scrollbaroptions element(" << parts.size() << "): '" <<
+			element << "'"  << std::endl;
 		return;
 	}
 
@@ -677,8 +709,8 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData *data, const std::string 
 		std::vector<std::string> options = split(i, '=');
 
 		if (options.size() != 2) {
-			warningstream << "Invalid scrollbaroptions option syntax: '" << element << "'"
-						  << std::endl;
+			warningstream << "Invalid scrollbaroptions option syntax: '" <<
+				element << "'" << std::endl;
 			continue; // Go to next option
 		}
 
@@ -711,12 +743,12 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData *data, const std::string 
 			continue;
 		}
 
-		warningstream << "Invalid scrollbaroptions option(" << options[0] << "): '"
-					  << element << "'" << std::endl;
+		warningstream << "Invalid scrollbaroptions option(" << options[0] <<
+			"): '" << element << "'" << std::endl;
 	}
 }
 
-void GUIFormSpecMenu::parseImage(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("image", element, 2, 4, parts))
@@ -724,12 +756,12 @@ void GUIFormSpecMenu::parseImage(parserData *data, const std::string &element)
 
 	size_t offset = parts.size() >= 3;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
 	MY_CHECKPOS("image", 0);
 
 	std::vector<std::string> v_geom;
 	if (parts.size() >= 3) {
-		v_geom = split(parts[1], ',');
+		v_geom = split(parts[1],',');
 		MY_CHECKGEOM("image", 1);
 	}
 
@@ -764,7 +796,13 @@ void GUIFormSpecMenu::parseImage(parserData *data, const std::string &element)
 	if (!data->explicit_size)
 		warningstream << "Invalid use of image without a size[] element" << std::endl;
 
-	FieldSpec spec(name, L"", L"", 258 + m_fields.size(), 1);
+	FieldSpec spec(
+		name,
+		L"",
+		L"",
+		258 + m_fields.size(),
+		1
+	);
 
 	core::rect<s32> rect = core::rect<s32>(pos, pos + geom);
 
@@ -778,15 +816,15 @@ void GUIFormSpecMenu::parseImage(parserData *data, const std::string &element)
 
 	gui::IGUIElement *e;
 	if (middle.getArea() > 0) {
-		GUIAnimatedImage *image =
-				new GUIAnimatedImage(Environment, data->current_parent, spec.fid, rect);
+		GUIAnimatedImage *image = new GUIAnimatedImage(Environment, data->current_parent,
+			spec.fid, rect);
 
 		image->setTexture(texture);
 		image->setMiddleRect(middle);
 		e = image;
-	} else {
-		gui::IGUIImage *image = Environment->addImage(
-				rect, data->current_parent, spec.fid, nullptr, true);
+	}
+	else {
+		gui::IGUIImage *image = Environment->addImage(rect, data->current_parent, spec.fid, nullptr, true);
 		image->setImage(texture);
 		image->setScaleImage(true);
 		image->grab(); // compensate for drop in addImage
@@ -808,7 +846,7 @@ void GUIFormSpecMenu::parseAnimatedImage(parserData *data, const std::string &el
 	if (!precheckElement("animated_image", element, 6, 8, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_pos  = split(parts[0], ',');
 	std::vector<std::string> v_geom = split(parts[1], ',');
 	std::string name = parts[2];
 	std::string texture_name = unescape_string(parts[3]);
@@ -832,9 +870,14 @@ void GUIFormSpecMenu::parseAnimatedImage(parserData *data, const std::string &el
 
 	if (!data->explicit_size)
 		warningstream << "Invalid use of animated_image without a size[] element"
-					  << std::endl;
+				<< std::endl;
 
-	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
+	FieldSpec spec(
+		name,
+		L"",
+		L"",
+		258 + m_fields.size()
+	);
 	spec.ftype = f_AnimatedImage;
 	spec.send = true;
 
@@ -844,8 +887,8 @@ void GUIFormSpecMenu::parseAnimatedImage(parserData *data, const std::string &el
 	if (parts.size() >= 8)
 		parseMiddleRect(parts[7], &middle);
 
-	GUIAnimatedImage *e =
-			new GUIAnimatedImage(Environment, data->current_parent, spec.fid, rect);
+	GUIAnimatedImage *e = new GUIAnimatedImage(Environment, data->current_parent,
+		spec.fid, rect);
 
 	e->setTexture(m_tsrc->getTexture(texture_name));
 	e->setMiddleRect(middle);
@@ -863,18 +906,18 @@ void GUIFormSpecMenu::parseAnimatedImage(parserData *data, const std::string &el
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseItemImage(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseItemImage(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("item_image", element, 3, 3, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
-	std::vector<std::string> v_geom = split(parts[1], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string name = parts[2];
 
-	MY_CHECKPOS("item_image", 0);
-	MY_CHECKGEOM("item_image", 1);
+	MY_CHECKPOS("item_image",0);
+	MY_CHECKGEOM("item_image",1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -888,11 +931,16 @@ void GUIFormSpecMenu::parseItemImage(parserData *data, const std::string &elemen
 		geom.Y = stof(v_geom[1]) * (float)imgsize.Y;
 	}
 
-	if (!data->explicit_size)
-		warningstream << "invalid use of item_image without a size[] element"
-					  << std::endl;
+	if(!data->explicit_size)
+		warningstream<<"invalid use of item_image without a size[] element"<<std::endl;
 
-	FieldSpec spec("", L"", L"", 258 + m_fields.size(), 2);
+	FieldSpec spec(
+		"",
+		L"",
+		L"",
+		258 + m_fields.size(),
+		2
+	);
 	spec.ftype = f_ItemImage;
 
 	GUIItemImage *e = new GUIItemImage(Environment, data->current_parent, spec.fid,
@@ -906,20 +954,20 @@ void GUIFormSpecMenu::parseItemImage(parserData *data, const std::string &elemen
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseButton(
-		parserData *data, const std::string &element, const std::string &type)
+void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
+		const std::string &type)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("button", element, 4, 4, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
-	std::vector<std::string> v_geom = split(parts[1], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string name = parts[2];
 	std::string label = parts[3];
 
-	MY_CHECKPOS("button", 0);
-	MY_CHECKGEOM("button", 1);
+	MY_CHECKPOS("button",0);
+	MY_CHECKGEOM("button",1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -928,28 +976,34 @@ void GUIFormSpecMenu::parseButton(
 	if (data->real_coordinates) {
 		pos = getRealCoordinateBasePos(v_pos);
 		geom = getRealCoordinateGeometry(v_geom);
-		rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
+		rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X,
+			pos.Y+geom.Y);
 	} else {
 		pos = getElementBasePos(&v_pos);
 		geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
-		pos.Y += (stof(v_geom[1]) * (float)imgsize.Y) / 2;
+		pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
 
-		rect = core::rect<s32>(
-				pos.X, pos.Y - m_btn_height, pos.X + geom.X, pos.Y + m_btn_height);
+		rect = core::rect<s32>(pos.X, pos.Y - m_btn_height,
+					pos.X + geom.X, pos.Y + m_btn_height);
 	}
 
-	if (!data->explicit_size)
-		warningstream << "invalid use of button without a size[] element" << std::endl;
+	if(!data->explicit_size)
+		warningstream<<"invalid use of button without a size[] element"<<std::endl;
 
 	std::wstring wlabel = translate_string(utf8_to_wide(unescape_string(label)));
 
-	FieldSpec spec(name, wlabel, L"", 258 + m_fields.size());
+	FieldSpec spec(
+		name,
+		wlabel,
+		L"",
+		258 + m_fields.size()
+	);
 	spec.ftype = f_Button;
-	if (type == "button_exit")
+	if(type == "button_exit")
 		spec.is_exit = true;
 
-	GUIButton *e = GUIButton::addButton(Environment, rect, m_tsrc, data->current_parent,
-			spec.fid, spec.flabel.c_str());
+	GUIButton *e = GUIButton::addButton(Environment, rect, m_tsrc,
+			data->current_parent, spec.fid, spec.flabel.c_str());
 
 	auto style = getStyleForElement(type, name, (type != "button") ? "button" : "");
 
@@ -964,8 +1018,7 @@ void GUIFormSpecMenu::parseButton(
 	m_fields.push_back(spec);
 }
 
-bool GUIFormSpecMenu::parseMiddleRect(
-		const std::string &value, core::rect<s32> *parsed_rect)
+bool GUIFormSpecMenu::parseMiddleRect(const std::string &value, core::rect<s32> *parsed_rect)
 {
 	core::rect<s32> rect;
 	std::vector<std::string> v_rect = split(value, ',');
@@ -976,7 +1029,7 @@ bool GUIFormSpecMenu::parseMiddleRect(
 		rect.LowerRightCorner = core::vector2di(-x, -x);
 	} else if (v_rect.size() == 2) {
 		s32 x = stoi(v_rect[0]);
-		s32 y = stoi(v_rect[1]);
+		s32 y =	stoi(v_rect[1]);
 		rect.UpperLeftCorner = core::vector2di(x, y);
 		rect.LowerRightCorner = core::vector2di(-x, -y);
 		// `-x` is interpreted as `w - x`
@@ -984,8 +1037,8 @@ bool GUIFormSpecMenu::parseMiddleRect(
 		rect.UpperLeftCorner = core::vector2di(stoi(v_rect[0]), stoi(v_rect[1]));
 		rect.LowerRightCorner = core::vector2di(stoi(v_rect[2]), stoi(v_rect[3]));
 	} else {
-		warningstream << "Invalid rectangle string format: \"" << value << "\""
-					  << std::endl;
+		warningstream << "Invalid rectangle string format: \"" << value
+				<< "\"" << std::endl;
 		return false;
 	}
 
@@ -994,18 +1047,18 @@ bool GUIFormSpecMenu::parseMiddleRect(
 	return true;
 }
 
-void GUIFormSpecMenu::parseBackground(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("background", element, 3, 5, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
-	std::vector<std::string> v_geom = split(parts[1], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string name = unescape_string(parts[2]);
 
-	MY_CHECKPOS("background", 0);
-	MY_CHECKGEOM("background", 1);
+	MY_CHECKPOS("background",0);
+	MY_CHECKGEOM("background",1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -1028,7 +1081,7 @@ void GUIFormSpecMenu::parseBackground(parserData *data, const std::string &eleme
 			pos = getRealCoordinateBasePos(v_pos) * -1;
 			geom = v2s32(0, 0);
 		} else {
-			pos.X = stoi(v_pos[0]); // acts as offset
+			pos.X = stoi(v_pos[0]); //acts as offset
 			pos.Y = stoi(v_pos[1]);
 		}
 		clip = true;
@@ -1039,10 +1092,14 @@ void GUIFormSpecMenu::parseBackground(parserData *data, const std::string &eleme
 		parseMiddleRect(parts[4], &middle);
 
 	if (!data->explicit_size && !clip)
-		warningstream << "invalid use of unclipped background without a size[] element"
-					  << std::endl;
+		warningstream << "invalid use of unclipped background without a size[] element" << std::endl;
 
-	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
+	FieldSpec spec(
+		name,
+		L"",
+		L"",
+		258 + m_fields.size()
+	);
 
 	core::rect<s32> rect;
 	if (!clip) {
@@ -1053,8 +1110,8 @@ void GUIFormSpecMenu::parseBackground(parserData *data, const std::string &eleme
 		rect = core::rect<s32>(-pos, pos);
 	}
 
-	GUIBackgroundImage *e = new GUIBackgroundImage(Environment,
-			data->background_parent.get(), spec.fid, rect, name, middle, m_tsrc, clip);
+	GUIBackgroundImage *e = new GUIBackgroundImage(Environment, data->background_parent.get(),
+			spec.fid, rect, name, middle, m_tsrc, clip);
 
 	FATAL_ERROR_IF(!e, "Failed to create background formspec element");
 
@@ -1064,9 +1121,9 @@ void GUIFormSpecMenu::parseBackground(parserData *data, const std::string &eleme
 	e->drop();
 }
 
-void GUIFormSpecMenu::parseTableOptions(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseTableOptions(parserData* data, const std::string &element)
 {
-	std::vector<std::string> parts = split(element, ';');
+	std::vector<std::string> parts = split(element,';');
 
 	data->table_options.clear();
 	for (const std::string &part : parts) {
@@ -1076,13 +1133,13 @@ void GUIFormSpecMenu::parseTableOptions(parserData *data, const std::string &ele
 	}
 }
 
-void GUIFormSpecMenu::parseTableColumns(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseTableColumns(parserData* data, const std::string &element)
 {
-	std::vector<std::string> parts = split(element, ';');
+	std::vector<std::string> parts = split(element,';');
 
 	data->table_columns.clear();
 	for (const std::string &part : parts) {
-		std::vector<std::string> col_parts = split(part, ',');
+		std::vector<std::string> col_parts = split(part,',');
 		GUITable::TableColumn column;
 		// Parse column type
 		if (!col_parts.empty())
@@ -1096,23 +1153,23 @@ void GUIFormSpecMenu::parseTableColumns(parserData *data, const std::string &ele
 	}
 }
 
-void GUIFormSpecMenu::parseTable(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("table", element, 4, 5, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
-	std::vector<std::string> v_geom = split(parts[1], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string name = parts[2];
-	std::vector<std::string> items = split(parts[3], ',');
+	std::vector<std::string> items = split(parts[3],',');
 	std::string str_initial_selection;
 
 	if (parts.size() >= 5)
 		str_initial_selection = parts[4];
 
-	MY_CHECKPOS("table", 0);
-	MY_CHECKGEOM("table", 1);
+	MY_CHECKPOS("table",0);
+	MY_CHECKGEOM("table",1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -1126,9 +1183,14 @@ void GUIFormSpecMenu::parseTable(parserData *data, const std::string &element)
 		geom.Y = stof(v_geom[1]) * spacing.Y;
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 
-	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
+	FieldSpec spec(
+		name,
+		L"",
+		L"",
+		258 + m_fields.size()
+	);
 
 	spec.ftype = f_Table;
 
@@ -1136,8 +1198,9 @@ void GUIFormSpecMenu::parseTable(parserData *data, const std::string &element)
 		item = wide_to_utf8(unescape_translate(utf8_to_wide(unescape_string(item))));
 	}
 
-	// now really show table
-	GUITable *e = new GUITable(Environment, data->current_parent, spec.fid, rect, m_tsrc);
+	//now really show table
+	GUITable *e = new GUITable(Environment, data->current_parent, spec.fid,
+			rect, m_tsrc);
 
 	if (spec.fname == m_focused_element) {
 		Environment->setFocus(e);
@@ -1160,16 +1223,16 @@ void GUIFormSpecMenu::parseTable(parserData *data, const std::string &element)
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseTextList(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("textlist", element, 4, 6, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
-	std::vector<std::string> v_geom = split(parts[1], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string name = parts[2];
-	std::vector<std::string> items = split(parts[3], ',');
+	std::vector<std::string> items = split(parts[3],',');
 	std::string str_initial_selection;
 	std::string str_transparent = "false";
 
@@ -1179,8 +1242,8 @@ void GUIFormSpecMenu::parseTextList(parserData *data, const std::string &element
 	if (parts.size() >= 6)
 		str_transparent = parts[5];
 
-	MY_CHECKPOS("textlist", 0);
-	MY_CHECKGEOM("textlist", 1);
+	MY_CHECKPOS("textlist",0);
+	MY_CHECKGEOM("textlist",1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -1194,9 +1257,14 @@ void GUIFormSpecMenu::parseTextList(parserData *data, const std::string &element
 		geom.Y = stof(v_geom[1]) * spacing.Y;
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 
-	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
+	FieldSpec spec(
+		name,
+		L"",
+		L"",
+		258 + m_fields.size()
+	);
 
 	spec.ftype = f_Table;
 
@@ -1204,8 +1272,9 @@ void GUIFormSpecMenu::parseTextList(parserData *data, const std::string &element
 		item = wide_to_utf8(unescape_translate(utf8_to_wide(unescape_string(item))));
 	}
 
-	// now really show list
-	GUITable *e = new GUITable(Environment, data->current_parent, spec.fid, rect, m_tsrc);
+	//now really show list
+	GUITable *e = new GUITable(Environment, data->current_parent, spec.fid,
+			rect, m_tsrc);
 
 	if (spec.fname == m_focused_element) {
 		Environment->setFocus(e);
@@ -1228,7 +1297,7 @@ void GUIFormSpecMenu::parseTextList(parserData *data, const std::string &element
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseDropDown(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("dropdown", element, 5, 6, parts))
@@ -1242,49 +1311,57 @@ void GUIFormSpecMenu::parseDropDown(parserData *data, const std::string &element
 	if (parts.size() >= 6 && is_yes(parts[5]))
 		m_dropdown_index_event[name] = true;
 
-	MY_CHECKPOS("dropdown", 0);
+	MY_CHECKPOS("dropdown",0);
 
 	v2s32 pos;
 	v2s32 geom;
 	core::rect<s32> rect;
 
 	if (data->real_coordinates) {
-		std::vector<std::string> v_geom = split(parts[1], ',');
+		std::vector<std::string> v_geom = split(parts[1],',');
 
 		if (v_geom.size() == 1)
 			v_geom.emplace_back("1");
 
-		MY_CHECKGEOM("dropdown", 1);
+		MY_CHECKGEOM("dropdown",1);
 
 		pos = getRealCoordinateBasePos(v_pos);
 		geom = getRealCoordinateGeometry(v_geom);
-		rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
+		rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 	} else {
 		pos = getElementBasePos(&v_pos);
 
 		s32 width = stof(parts[1]) * spacing.Y;
 
-		rect = core::rect<s32>(pos.X, pos.Y, pos.X + width, pos.Y + (m_btn_height * 2));
+		rect = core::rect<s32>(pos.X, pos.Y,
+				pos.X + width, pos.Y + (m_btn_height * 2));
 	}
 
-	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
+	FieldSpec spec(
+		name,
+		L"",
+		L"",
+		258 + m_fields.size()
+	);
 
 	spec.ftype = f_DropDown;
 	spec.send = true;
 
-	// now really show list
-	gui::IGUIComboBox *e = Environment->addComboBox(rect, data->current_parent, spec.fid);
+	//now really show list
+	gui::IGUIComboBox *e = Environment->addComboBox(rect, data->current_parent,
+			spec.fid);
 
 	if (spec.fname == m_focused_element) {
 		Environment->setFocus(e);
 	}
 
 	for (const std::string &item : items) {
-		e->addItem(unescape_translate(unescape_string(utf8_to_wide(item))).c_str());
+		e->addItem(unescape_translate(unescape_string(
+			utf8_to_wide(item))).c_str());
 	}
 
 	if (!str_initial_selection.empty())
-		e->setSelected(stoi(str_initial_selection) - 1);
+		e->setSelected(stoi(str_initial_selection)-1);
 
 	auto style = getDefaultStyleForElement("dropdown", name);
 
@@ -1310,19 +1387,19 @@ void GUIFormSpecMenu::parseFieldCloseOnEnter(parserData *data, const std::string
 	field_close_on_enter[parts[0]] = is_yes(parts[1]);
 }
 
-void GUIFormSpecMenu::parsePwdField(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("pwdfield", element, 4, 4, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
-	std::vector<std::string> v_geom = split(parts[1], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string name = parts[2];
 	std::string label = parts[3];
 
-	MY_CHECKPOS("pwdfield", 0);
-	MY_CHECKGEOM("pwdfield", 1);
+	MY_CHECKPOS("pwdfield",0);
+	MY_CHECKGEOM("pwdfield",1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -1336,20 +1413,27 @@ void GUIFormSpecMenu::parsePwdField(parserData *data, const std::string &element
 
 		geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
 
-		pos.Y += (stof(v_geom[1]) * (float)imgsize.Y) / 2;
+		pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
 		pos.Y -= m_btn_height;
-		geom.Y = m_btn_height * 2;
+		geom.Y = m_btn_height*2;
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 
 	std::wstring wlabel = translate_string(utf8_to_wide(unescape_string(label)));
 
-	FieldSpec spec(name, wlabel, L"", 258 + m_fields.size(), 0, ECI_IBEAM);
+	FieldSpec spec(
+		name,
+		wlabel,
+		L"",
+		258 + m_fields.size(),
+		0,
+		ECI_IBEAM
+		);
 
 	spec.send = true;
-	gui::IGUIEditBox *e =
-			Environment->addEditBox(0, rect, true, data->current_parent, spec.fid);
+	gui::IGUIEditBox *e = Environment->addEditBox(0, rect, true,
+			data->current_parent, spec.fid);
 
 	if (spec.fname == m_focused_element) {
 		Environment->setFocus(e);
@@ -1360,10 +1444,10 @@ void GUIFormSpecMenu::parsePwdField(parserData *data, const std::string &element
 		rect.UpperLeftCorner.Y -= font_height;
 		rect.LowerRightCorner.Y = rect.UpperLeftCorner.Y + font_height;
 		gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
-				data->current_parent, 0);
+			data->current_parent, 0);
 	}
 
-	e->setPasswordBox(true, L'*');
+	e->setPasswordBox(true,L'*');
 
 	auto style = getDefaultStyleForElement("pwdfield", name, "field");
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
@@ -1372,11 +1456,11 @@ void GUIFormSpecMenu::parsePwdField(parserData *data, const std::string &element
 	e->setOverrideFont(style.getFont());
 
 	irr::SEvent evt;
-	evt.EventType = EET_KEY_INPUT_EVENT;
-	evt.KeyInput.Key = KEY_END;
-	evt.KeyInput.Char = 0;
-	evt.KeyInput.Control = false;
-	evt.KeyInput.Shift = false;
+	evt.EventType            = EET_KEY_INPUT_EVENT;
+	evt.KeyInput.Key         = KEY_END;
+	evt.KeyInput.Char        = 0;
+	evt.KeyInput.Control     = false;
+	evt.KeyInput.Shift       = false;
 	evt.KeyInput.PressedDown = true;
 	e->OnEvent(evt);
 
@@ -1386,8 +1470,8 @@ void GUIFormSpecMenu::parsePwdField(parserData *data, const std::string &element
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::createTextField(
-		parserData *data, FieldSpec &spec, core::rect<s32> &rect, bool is_multiline)
+void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
+	core::rect<s32> &rect, bool is_multiline)
 {
 	bool is_editable = !spec.fname.empty();
 	if (!is_editable && !is_multiline) {
@@ -1399,7 +1483,8 @@ void GUIFormSpecMenu::createTextField(
 
 	if (is_editable) {
 		spec.send = true;
-	} else if (is_multiline && spec.fdefault.empty() && !spec.flabel.empty()) {
+	} else if (is_multiline &&
+			spec.fdefault.empty() && !spec.flabel.empty()) {
 		// Multiline textareas: swap default and label for backwards compat
 		spec.flabel.swap(spec.fdefault);
 	}
@@ -1409,13 +1494,12 @@ void GUIFormSpecMenu::createTextField(
 		e = new GUIEditBoxWithScrollBar(spec.fdefault.c_str(), true, Environment,
 				data->current_parent, spec.fid, rect, is_editable, true);
 	} else if (is_editable) {
-		e = Environment->addEditBox(
-				spec.fdefault.c_str(), rect, true, data->current_parent, spec.fid);
+		e = Environment->addEditBox(spec.fdefault.c_str(), rect, true,
+				data->current_parent, spec.fid);
 		e->grab();
 	}
 
-	auto style =
-			getDefaultStyleForElement(is_multiline ? "textarea" : "field", spec.fname);
+	auto style = getDefaultStyleForElement(is_multiline ? "textarea" : "field", spec.fname);
 
 	if (e) {
 		if (is_editable && spec.fname == m_focused_element)
@@ -1427,18 +1511,17 @@ void GUIFormSpecMenu::createTextField(
 			e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_UPPERLEFT);
 		} else {
 			irr::SEvent evt;
-			evt.EventType = EET_KEY_INPUT_EVENT;
-			evt.KeyInput.Key = KEY_END;
-			evt.KeyInput.Char = 0;
-			evt.KeyInput.Control = 0;
-			evt.KeyInput.Shift = 0;
+			evt.EventType            = EET_KEY_INPUT_EVENT;
+			evt.KeyInput.Key         = KEY_END;
+			evt.KeyInput.Char        = 0;
+			evt.KeyInput.Control     = 0;
+			evt.KeyInput.Shift       = 0;
 			evt.KeyInput.PressedDown = true;
 			e->OnEvent(evt);
 		}
 
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-		e->setOverrideColor(
-				style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
 		bool border = style.getBool(StyleSpec::BORDER, true);
 		e->setDrawBorder(border);
 		e->setDrawBackground(border);
@@ -1451,15 +1534,16 @@ void GUIFormSpecMenu::createTextField(
 		int font_height = g_fontengine->getTextHeight();
 		rect.UpperLeftCorner.Y -= font_height;
 		rect.LowerRightCorner.Y = rect.UpperLeftCorner.Y + font_height;
-		IGUIElement *t = gui::StaticText::add(Environment, spec.flabel.c_str(), rect,
-				false, true, data->current_parent, 0);
+		IGUIElement *t = gui::StaticText::add(Environment, spec.flabel.c_str(),
+				rect, false, true, data->current_parent, 0);
 
 		if (t)
 			t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 	}
 }
 
-void GUIFormSpecMenu::parseSimpleField(parserData *data, std::vector<std::string> &parts)
+void GUIFormSpecMenu::parseSimpleField(parserData *data,
+	std::vector<std::string> &parts)
 {
 	std::string name = parts[0];
 	std::string label = parts[1];
@@ -1468,23 +1552,32 @@ void GUIFormSpecMenu::parseSimpleField(parserData *data, std::vector<std::string
 	core::rect<s32> rect;
 
 	if (data->explicit_size)
-		warningstream << "invalid use of unpositioned \"field\" in inventory"
-					  << std::endl;
+		warningstream << "invalid use of unpositioned \"field\" in inventory" << std::endl;
 
 	v2s32 pos = getElementBasePos(nullptr);
 	pos.Y = (data->simple_field_count + 2) * 60;
 	v2s32 size = DesiredRect.getSize();
 
 	rect = core::rect<s32>(
-			size.X / 2 - 150, pos.Y, size.X / 2 - 150 + 300, pos.Y + m_btn_height * 2);
+			size.X / 2 - 150,       pos.Y,
+			size.X / 2 - 150 + 300, pos.Y + m_btn_height * 2
+	);
+
 
 	if (m_form_src)
 		default_val = m_form_src->resolveText(default_val);
 
+
 	std::wstring wlabel = translate_string(utf8_to_wide(unescape_string(label)));
 
-	FieldSpec spec(name, wlabel, utf8_to_wide(unescape_string(default_val)),
-			258 + m_fields.size(), 0, ECI_IBEAM);
+	FieldSpec spec(
+		name,
+		wlabel,
+		utf8_to_wide(unescape_string(default_val)),
+		258 + m_fields.size(),
+		0,
+		ECI_IBEAM
+	);
 
 	createTextField(data, spec, rect, false);
 
@@ -1493,17 +1586,17 @@ void GUIFormSpecMenu::parseSimpleField(parserData *data, std::vector<std::string
 	data->simple_field_count++;
 }
 
-void GUIFormSpecMenu::parseTextArea(
-		parserData *data, std::vector<std::string> &parts, const std::string &type)
+void GUIFormSpecMenu::parseTextArea(parserData* data, std::vector<std::string>& parts,
+		const std::string &type)
 {
-	std::vector<std::string> v_pos = split(parts[0], ',');
-	std::vector<std::string> v_geom = split(parts[1], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string name = parts[2];
 	std::string label = parts[3];
 	std::string default_val = parts[4];
 
-	MY_CHECKPOS(type, 0);
-	MY_CHECKGEOM(type, 1);
+	MY_CHECKPOS(type,0);
+	MY_CHECKGEOM(type,1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -1517,29 +1610,38 @@ void GUIFormSpecMenu::parseTextArea(
 
 		geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
 
-		if (type == "textarea") {
-			geom.Y = (stof(v_geom[1]) * (float)imgsize.Y) - (spacing.Y - imgsize.Y);
+		if (type == "textarea")
+		{
+			geom.Y = (stof(v_geom[1]) * (float)imgsize.Y) - (spacing.Y-imgsize.Y);
 			pos.Y += m_btn_height;
-		} else {
-			pos.Y += (stof(v_geom[1]) * (float)imgsize.Y) / 2;
+		}
+		else
+		{
+			pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
 			pos.Y -= m_btn_height;
-			geom.Y = m_btn_height * 2;
+			geom.Y = m_btn_height*2;
 		}
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 
-	if (!data->explicit_size)
-		warningstream << "invalid use of positioned " << type
-					  << " without a size[] element" << std::endl;
+	if(!data->explicit_size)
+		warningstream<<"invalid use of positioned "<<type<<" without a size[] element"<<std::endl;
 
-	if (m_form_src)
+	if(m_form_src)
 		default_val = m_form_src->resolveText(default_val);
+
 
 	std::wstring wlabel = translate_string(utf8_to_wide(unescape_string(label)));
 
-	FieldSpec spec(name, wlabel, utf8_to_wide(unescape_string(default_val)),
-			258 + m_fields.size(), 0, ECI_IBEAM);
+	FieldSpec spec(
+		name,
+		wlabel,
+		utf8_to_wide(unescape_string(default_val)),
+		258 + m_fields.size(),
+		0,
+		ECI_IBEAM
+	);
 
 	createTextField(data, spec, rect, type == "textarea");
 
@@ -1549,8 +1651,8 @@ void GUIFormSpecMenu::parseTextArea(
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseField(
-		parserData *data, const std::string &element, const std::string &type)
+void GUIFormSpecMenu::parseField(parserData* data, const std::string &element,
+		const std::string &type)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement(type, element, 3, 5, parts))
@@ -1598,11 +1700,15 @@ void GUIFormSpecMenu::parseHyperText(parserData *data, const std::string &elemen
 
 	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
 
-	if (m_form_src)
+	if(m_form_src)
 		text = m_form_src->resolveText(text);
 
-	FieldSpec spec(name, translate_string(utf8_to_wide(unescape_string(text))), L"",
-			258 + m_fields.size());
+	FieldSpec spec(
+		name,
+		translate_string(utf8_to_wide(unescape_string(text))),
+		L"",
+		258 + m_fields.size()
+	);
 
 	spec.ftype = f_HyperText;
 
@@ -1616,18 +1722,18 @@ void GUIFormSpecMenu::parseHyperText(parserData *data, const std::string &elemen
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseLabel(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("label", element, 2, 2, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
 
-	MY_CHECKPOS("label", 0);
+	MY_CHECKPOS("label",0);
 
-	if (!data->explicit_size)
-		warningstream << "invalid use of label without a size[] element" << std::endl;
+	if(!data->explicit_size)
+		warningstream<<"invalid use of label without a size[] element"<<std::endl;
 
 	auto style = getDefaultStyleForElement("label", "");
 	gui::IGUIFont *font = style.getFont();
@@ -1656,10 +1762,12 @@ void GUIFormSpecMenu::parseLabel(parserData *data, const std::string &element)
 			v2s32 pos = getRealCoordinateBasePos(v_pos);
 
 			// Labels are positioned by their center, not their top.
-			pos.Y += (((float)imgsize.Y) / -2) + (((float)imgsize.Y) * i / 2);
+			pos.Y += (((float) imgsize.Y) / -2) + (((float) imgsize.Y) * i / 2);
 
-			rect = core::rect<s32>(pos.X, pos.Y,
-					pos.X + font->getDimension(line.c_str()).Width, pos.Y + imgsize.Y);
+			rect = core::rect<s32>(
+				pos.X, pos.Y,
+				pos.X + font->getDimension(line.c_str()).Width,
+				pos.Y + imgsize.Y);
 
 		} else {
 			// Lines are spaced at the nominal distance of
@@ -1676,20 +1784,28 @@ void GUIFormSpecMenu::parseLabel(parserData *data, const std::string &element)
 			pos.X += stof(v_pos[0]) * spacing.X;
 			pos.Y += (stof(v_pos[1]) + 7.0f / 30.0f) * spacing.Y;
 
-			pos.Y += ((float)i) * spacing.Y * 2.0 / 5.0;
+			pos.Y += ((float) i) * spacing.Y * 2.0 / 5.0;
 
-			rect = core::rect<s32>(pos.X, pos.Y - m_btn_height,
-					pos.X + font->getDimension(line.c_str()).Width, pos.Y + m_btn_height);
+			rect = core::rect<s32>(
+				pos.X, pos.Y - m_btn_height,
+				pos.X + font->getDimension(line.c_str()).Width,
+				pos.Y + m_btn_height);
 		}
 
-		FieldSpec spec("", L"", L"", 258 + m_fields.size(), 4);
-		gui::IGUIStaticText *e = gui::StaticText::add(
-				Environment, line, rect, false, false, data->current_parent, spec.fid);
+		FieldSpec spec(
+			"",
+			L"",
+			L"",
+			258 + m_fields.size(),
+			4
+		);
+		gui::IGUIStaticText *e = gui::StaticText::add(Environment,
+				line, rect, false, false, data->current_parent,
+				spec.fid);
 		e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_CENTER);
 
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-		e->setOverrideColor(
-				style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
 		e->setOverrideFont(font);
 
 		m_fields.push_back(spec);
@@ -1700,16 +1816,17 @@ void GUIFormSpecMenu::parseLabel(parserData *data, const std::string &element)
 	}
 }
 
-void GUIFormSpecMenu::parseVertLabel(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("vertlabel", element, 2, 2, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
-	std::wstring text = unescape_translate(unescape_string(utf8_to_wide(parts[1])));
+	std::vector<std::string> v_pos = split(parts[0],',');
+	std::wstring text = unescape_translate(
+		unescape_string(utf8_to_wide(parts[1])));
 
-	MY_CHECKPOS("vertlabel", 1);
+	MY_CHECKPOS("vertlabel",1);
 
 	auto style = getDefaultStyleForElement("vertlabel", "", "label");
 	gui::IGUIFont *font = style.getFont();
@@ -1727,8 +1844,10 @@ void GUIFormSpecMenu::parseVertLabel(parserData *data, const std::string &elemen
 
 		// We use text.length + 1 because without it, the rect
 		// isn't quite tall enough and cuts off the text.
-		rect = core::rect<s32>(pos.X, pos.Y, pos.X + imgsize.X,
-				pos.Y + font_line_height(font) * (text.length() + 1));
+		rect = core::rect<s32>(pos.X, pos.Y,
+			pos.X + imgsize.X,
+			pos.Y + font_line_height(font) *
+			(text.length() + 1));
 
 	} else {
 		pos = getElementBasePos(&v_pos);
@@ -1736,14 +1855,16 @@ void GUIFormSpecMenu::parseVertLabel(parserData *data, const std::string &elemen
 		// As above, the length must be one longer. The width of
 		// the rect (15 pixels) seems rather arbitrary, but
 		// changing it might break something.
-		rect = core::rect<s32>(pos.X, pos.Y + ((imgsize.Y / 2) - m_btn_height),
-				pos.X + 15,
-				pos.Y + font_line_height(font) * (text.length() + 1) +
-						((imgsize.Y / 2) - m_btn_height));
+		rect = core::rect<s32>(
+			pos.X, pos.Y+((imgsize.Y/2) - m_btn_height),
+			pos.X+15, pos.Y +
+				font_line_height(font) *
+				(text.length() + 1) +
+				((imgsize.Y/2) - m_btn_height));
 	}
 
-	if (!data->explicit_size)
-		warningstream << "invalid use of label without a size[] element" << std::endl;
+	if(!data->explicit_size)
+		warningstream<<"invalid use of label without a size[] element"<<std::endl;
 
 	std::wstring label;
 
@@ -1752,9 +1873,14 @@ void GUIFormSpecMenu::parseVertLabel(parserData *data, const std::string &elemen
 		label += L"\n";
 	}
 
-	FieldSpec spec("", label, L"", 258 + m_fields.size());
-	gui::IGUIStaticText *e = gui::StaticText::add(Environment, spec.flabel.c_str(), rect,
-			false, false, data->current_parent, spec.fid);
+	FieldSpec spec(
+		"",
+		label,
+		L"",
+		258 + m_fields.size()
+	);
+	gui::IGUIStaticText *e = gui::StaticText::add(Environment, spec.flabel.c_str(),
+			rect, false, false, data->current_parent, spec.fid);
 	e->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_CENTER);
 
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
@@ -1768,8 +1894,8 @@ void GUIFormSpecMenu::parseVertLabel(parserData *data, const std::string &elemen
 	m_clickthrough_elements.push_back(e);
 }
 
-void GUIFormSpecMenu::parseImageButton(
-		parserData *data, const std::string &element, const std::string &type)
+void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &element,
+		const std::string &type)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("image_button", element, 5, 8, parts))
@@ -1777,19 +1903,18 @@ void GUIFormSpecMenu::parseImageButton(
 
 	if (parts.size() == 6) {
 		// Invalid argument count.
-		errorstream << "Invalid image_button element(" << parts.size() << "): '"
-					<< element << "'" << std::endl;
+		errorstream << "Invalid image_button element(" << parts.size() << "): '" << element << "'" << std::endl;
 		return;
 	}
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
-	std::vector<std::string> v_geom = split(parts[1], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string image_name = parts[2];
 	std::string name = parts[3];
 	std::string label = parts[4];
 
-	MY_CHECKPOS("image_button", 0);
-	MY_CHECKGEOM("image_button", 1);
+	MY_CHECKPOS("image_button",0);
+	MY_CHECKGEOM("image_button",1);
 
 	std::string pressed_image_name;
 
@@ -1809,18 +1934,23 @@ void GUIFormSpecMenu::parseImageButton(
 		geom.Y = (stof(v_geom[1]) * spacing.Y) - (spacing.Y - imgsize.Y);
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X,
+		pos.Y+geom.Y);
 
 	if (!data->explicit_size)
-		warningstream << "invalid use of image_button without a size[] element"
-					  << std::endl;
+		warningstream<<"invalid use of image_button without a size[] element"<<std::endl;
 
 	image_name = unescape_string(image_name);
 	pressed_image_name = unescape_string(pressed_image_name);
 
 	std::wstring wlabel = utf8_to_wide(unescape_string(label));
 
-	FieldSpec spec(name, wlabel, utf8_to_wide(image_name), 258 + m_fields.size());
+	FieldSpec spec(
+		name,
+		wlabel,
+		utf8_to_wide(image_name),
+		258 + m_fields.size()
+	);
 	spec.ftype = f_Button;
 	if (type == "image_button_exit")
 		spec.is_exit = true;
@@ -1854,22 +1984,21 @@ void GUIFormSpecMenu::parseImageButton(
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseTabHeader(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("tabheader", element, 4, 7, parts))
 		return;
 
-	// Length 7: Additional "height" parameter after "pos". Only valid with
-	// real_coordinates. Note: New arguments for the "height" syntax cannot be added
-	// without breaking older clients.
+	// Length 7: Additional "height" parameter after "pos". Only valid with real_coordinates.
+	// Note: New arguments for the "height" syntax cannot be added without breaking older clients.
 	if (parts.size() == 5 || (parts.size() == 7 && !data->real_coordinates)) {
-		errorstream << "Invalid tabheader element(" << parts.size() << "): '" << element
-					<< "'" << std::endl;
+		errorstream << "Invalid tabheader element(" << parts.size() << "): '"
+			<< element << "'" << std::endl;
 		return;
 	}
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
 
 	// If we're using real coordinates, add an extra field for height.
 	// Width is not here because tabs are the width of the text, and
@@ -1887,9 +2016,9 @@ void GUIFormSpecMenu::parseTabHeader(parserData *data, const std::string &elemen
 			auto_width = false;
 	}
 
-	std::string name = parts[i + 1];
-	std::vector<std::string> buttons = split(parts[i + 2], ',');
-	std::string str_index = parts[i + 3];
+	std::string name = parts[i+1];
+	std::vector<std::string> buttons = split(parts[i+2], ',');
+	std::string str_index = parts[i+3];
 	bool show_background = true;
 	bool show_border = true;
 	int tab_index = stoi(str_index) - 1;
@@ -1897,13 +2026,18 @@ void GUIFormSpecMenu::parseTabHeader(parserData *data, const std::string &elemen
 	MY_CHECKPOS("tabheader", 0);
 
 	if (parts.size() == 6 + i) {
-		if (parts[4 + i] == "true")
+		if (parts[4+i] == "true")
 			show_background = false;
-		if (parts[5 + i] == "false")
+		if (parts[5+i] == "false")
 			show_border = false;
 	}
 
-	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
+	FieldSpec spec(
+		name,
+		L"",
+		L"",
+		258 + m_fields.size()
+	);
 
 	spec.ftype = f_TabHeader;
 
@@ -1932,10 +2066,11 @@ void GUIFormSpecMenu::parseTabHeader(parserData *data, const std::string &elemen
 		geom.X = DesiredRect.getWidth();
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X,
+			pos.Y+geom.Y);
 
-	gui::IGUITabControl *e = Environment->addTabControl(
-			rect, data->current_parent, show_background, show_border, spec.fid);
+	gui::IGUITabControl *e = Environment->addTabControl(rect,
+			data->current_parent, show_background, show_border, spec.fid);
 	e->setAlignment(irr::gui::EGUIA_UPPERLEFT, irr::gui::EGUIA_UPPERLEFT,
 			irr::gui::EGUIA_UPPERLEFT, irr::gui::EGUIA_LOWERRIGHT);
 	e->setTabHeight(geom.Y);
@@ -1947,23 +2082,23 @@ void GUIFormSpecMenu::parseTabHeader(parserData *data, const std::string &elemen
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, true));
 
 	for (const std::string &button : buttons) {
-		auto tab = e->addTab(
-				unescape_translate(unescape_string(utf8_to_wide(button))).c_str(), -1);
+		auto tab = e->addTab(unescape_translate(unescape_string(
+			utf8_to_wide(button))).c_str(), -1);
 		if (style.isNotDefault(StyleSpec::BGCOLOR))
 			tab->setBackgroundColor(style.getColor(StyleSpec::BGCOLOR));
 
-		tab->setTextColor(
-				style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		tab->setTextColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
 	}
 
-	if ((tab_index >= 0) && (buttons.size() < INT_MAX) &&
-			(tab_index < (int)buttons.size()))
+	if ((tab_index >= 0) &&
+			(buttons.size() < INT_MAX) &&
+			(tab_index < (int) buttons.size()))
 		e->setActiveTab(tab_index);
 
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseItemImageButton(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &element)
 {
 	MY_CHECKCLIENT("item_image_button");
 
@@ -1971,8 +2106,8 @@ void GUIFormSpecMenu::parseItemImageButton(parserData *data, const std::string &
 	if (!precheckElement("item_image_button", element, 5, 5, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0], ',');
-	std::vector<std::string> v_geom = split(parts[1], ',');
+	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string item_name = parts[2];
 	std::string name = parts[3];
 	std::string label = parts[4];
@@ -1980,8 +2115,8 @@ void GUIFormSpecMenu::parseItemImageButton(parserData *data, const std::string &
 	label = unescape_string(label);
 	item_name = unescape_string(item_name);
 
-	MY_CHECKPOS("item_image_button", 0);
-	MY_CHECKGEOM("item_image_button", 1);
+	MY_CHECKPOS("item_image_button",0);
+	MY_CHECKGEOM("item_image_button",1);
 
 	v2s32 pos;
 	v2s32 geom;
@@ -1995,26 +2130,32 @@ void GUIFormSpecMenu::parseItemImageButton(parserData *data, const std::string &
 		geom.Y = (stof(v_geom[1]) * spacing.Y) - (spacing.Y - imgsize.Y);
 	}
 
-	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X + geom.X, pos.Y + geom.Y);
+	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 
-	if (!data->explicit_size)
-		warningstream << "invalid use of item_image_button without a size[] element"
-					  << std::endl;
+	if(!data->explicit_size)
+		warningstream<<"invalid use of item_image_button without a size[] element"<<std::endl;
 
 	IItemDefManager *idef = m_client->idef();
 	ItemStack item;
 	item.deSerialize(item_name, idef);
 
-	m_tooltips[name] = TooltipSpec(utf8_to_wide(item.getDefinition(idef).description),
-			m_default_tooltip_bgcolor, m_default_tooltip_color);
+	m_tooltips[name] =
+		TooltipSpec(utf8_to_wide(item.getDefinition(idef).description),
+					m_default_tooltip_bgcolor,
+					m_default_tooltip_color);
 
 	// the spec for the button
 	FieldSpec spec_btn(
-			name, utf8_to_wide(label), utf8_to_wide(item_name), 258 + m_fields.size(), 2);
+		name,
+		utf8_to_wide(label),
+		utf8_to_wide(item_name),
+		258 + m_fields.size(),
+		2
+	);
 
-	GUIButtonItemImage *e_btn =
-			GUIButtonItemImage::addButton(Environment, rect, m_tsrc, data->current_parent,
-					spec_btn.fid, spec_btn.flabel.c_str(), item_name, m_client);
+	GUIButtonItemImage *e_btn = GUIButtonItemImage::addButton(Environment,
+			rect, m_tsrc, data->current_parent, spec_btn.fid, spec_btn.flabel.c_str(),
+			item_name, m_client);
 
 	auto style = getStyleForElement("item_image_button", spec_btn.fname, "image_button");
 
@@ -2027,12 +2168,12 @@ void GUIFormSpecMenu::parseItemImageButton(parserData *data, const std::string &
 	}
 
 	spec_btn.ftype = f_Button;
-	rect += data->basepos - padding;
+	rect += data->basepos-padding;
 	spec_btn.rect = rect;
 	m_fields.push_back(spec_btn);
 }
 
-void GUIFormSpecMenu::parseBox(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseBox(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("box", element, 3, 3, parts))
@@ -2056,7 +2197,13 @@ void GUIFormSpecMenu::parseBox(parserData *data, const std::string &element)
 		geom.Y = stof(v_geom[1]) * spacing.Y;
 	}
 
-	FieldSpec spec("", L"", L"", 258 + m_fields.size(), -2);
+	FieldSpec spec(
+		"",
+		L"",
+		L"",
+		258 + m_fields.size(),
+		-2
+	);
 	spec.ftype = f_Box;
 
 	auto style = getDefaultStyleForElement("box", spec.fname);
@@ -2070,21 +2217,22 @@ void GUIFormSpecMenu::parseBox(parserData *data, const std::string &element)
 		colors = {tmp_color, tmp_color, tmp_color, tmp_color};
 	} else {
 		colors = style.getColorArray(StyleSpec::COLORS, {0x0, 0x0, 0x0, 0x0});
-		bordercolors = style.getColorArray(StyleSpec::BORDERCOLORS, {0x0, 0x0, 0x0, 0x0});
+		bordercolors = style.getColorArray(StyleSpec::BORDERCOLORS,
+			{0x0, 0x0, 0x0, 0x0});
 		borderwidths = style.getIntArray(StyleSpec::BORDERWIDTHS, {0, 0, 0, 0});
 	}
 
 	core::rect<s32> rect(pos, pos + geom);
 
-	GUIBox *e = new GUIBox(Environment, data->current_parent, spec.fid, rect, colors,
-			bordercolors, borderwidths);
+	GUIBox *e = new GUIBox(Environment, data->current_parent, spec.fid, rect,
+		colors, bordercolors, borderwidths);
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, m_formspec_version < 3));
 	e->drop();
 
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseBackgroundColor(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseBackgroundColor(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("bgcolor", element, 1, 3, parts))
@@ -2093,8 +2241,8 @@ void GUIFormSpecMenu::parseBackgroundColor(parserData *data, const std::string &
 	const u32 parameter_count = parts.size();
 
 	if (parameter_count > 2 && m_formspec_version < 3) {
-		errorstream << "Invalid bgcolor element(" << parameter_count << "): '" << element
-					<< "'" << std::endl;
+		errorstream << "Invalid bgcolor element(" << parameter_count << "): '"
+				<< element << "'" << std::endl;
 		return;
 	}
 
@@ -2121,18 +2269,18 @@ void GUIFormSpecMenu::parseBackgroundColor(parserData *data, const std::string &
 		parseColorString(parts[2], m_fullscreen_bgcolor, false);
 }
 
-void GUIFormSpecMenu::parseListColors(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseListColors(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
-	// Legacy Note: If clients older than 5.5.0-dev are supplied with additional
-	// arguments, the tooltip colors will be ignored.
+	// Legacy Note: If clients older than 5.5.0-dev are supplied with additional arguments,
+	// the tooltip colors will be ignored.
 	if (!precheckElement("listcolors", element, 2, 5, parts))
 		return;
 
 	if (parts.size() == 4) {
 		// Invalid argument combination
-		errorstream << "Invalid listcolors element(" << parts.size() << "): '" << element
-					<< "'" << std::endl;
+		errorstream << "Invalid listcolors element(" << parts.size() << "): '"
+				<< element << "'" << std::endl;
 		return;
 	}
 
@@ -2140,8 +2288,8 @@ void GUIFormSpecMenu::parseListColors(parserData *data, const std::string &eleme
 	parseColorString(parts[1], data->inventorylist_options.slotbg_h, false);
 
 	if (parts.size() >= 3) {
-		if (parseColorString(
-					parts[2], data->inventorylist_options.slotbordercolor, false)) {
+		if (parseColorString(parts[2], data->inventorylist_options.slotbordercolor,
+				false)) {
 			data->inventorylist_options.slotborder = true;
 		}
 	}
@@ -2163,7 +2311,7 @@ void GUIFormSpecMenu::parseListColors(parserData *data, const std::string &eleme
 	}
 }
 
-void GUIFormSpecMenu::parseTooltip(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
 	if (!precheckElement("tooltip", element, 2, 5, parts))
@@ -2173,19 +2321,19 @@ void GUIFormSpecMenu::parseTooltip(parserData *data, const std::string &element)
 	bool rect_mode = parts[0].find(',') != std::string::npos;
 	size_t base_size = rect_mode ? 3 : 2;
 	if (parts.size() != base_size && parts.size() != base_size + 2) {
-		errorstream << "Invalid tooltip element(" << parts.size() << "): '" << element
-					<< "'" << std::endl;
+		errorstream << "Invalid tooltip element(" << parts.size() << "): '"
+				<< element << "'"  << std::endl;
 		return;
 	}
 
 	// Read colors
 	video::SColor bgcolor = m_default_tooltip_bgcolor;
-	video::SColor color = m_default_tooltip_color;
+	video::SColor color   = m_default_tooltip_color;
 	if (parts.size() == base_size + 2 &&
 			(!parseColorString(parts[base_size], bgcolor, false) ||
-					!parseColorString(parts[base_size + 1], color, false))) {
-		errorstream << "Invalid color in tooltip element(" << parts.size() << "): '"
-					<< element << "'" << std::endl;
+				!parseColorString(parts[base_size + 1], color, false))) {
+		errorstream << "Invalid color in tooltip element(" << parts.size()
+				<< "): '" << element << "'"  << std::endl;
 		return;
 	}
 
@@ -2195,7 +2343,7 @@ void GUIFormSpecMenu::parseTooltip(parserData *data, const std::string &element)
 
 	// Add tooltip
 	if (rect_mode) {
-		std::vector<std::string> v_pos = split(parts[0], ',');
+		std::vector<std::string> v_pos  = split(parts[0], ',');
 		std::vector<std::string> v_geom = split(parts[1], ',');
 
 		MY_CHECKPOS("tooltip", 0);
@@ -2213,12 +2361,17 @@ void GUIFormSpecMenu::parseTooltip(parserData *data, const std::string &element)
 			geom.Y = stof(v_geom[1]) * spacing.Y;
 		}
 
-		FieldSpec fieldspec("", L"", L"", 258 + m_fields.size());
+		FieldSpec fieldspec(
+			"",
+			L"",
+			L"",
+			258 + m_fields.size()
+		);
 
 		core::rect<s32> rect(pos, pos + geom);
 
-		gui::IGUIElement *e = new gui::IGUIElement(
-				EGUIET_ELEMENT, Environment, data->current_parent, fieldspec.fid, rect);
+		gui::IGUIElement *e = new gui::IGUIElement(EGUIET_ELEMENT, Environment,
+				data->current_parent, fieldspec.fid, rect);
 
 		// the element the rect tooltip is bound to should not block mouse-clicks
 		e->setVisible(false);
@@ -2233,11 +2386,11 @@ void GUIFormSpecMenu::parseTooltip(parserData *data, const std::string &element)
 
 bool GUIFormSpecMenu::parseVersionDirect(const std::string &data)
 {
-	// some prechecks
+	//some prechecks
 	if (data.empty())
 		return false;
 
-	std::vector<std::string> parts = split(data, '[');
+	std::vector<std::string> parts = split(data,'[');
 
 	if (parts.size() < 2) {
 		return false;
@@ -2255,12 +2408,12 @@ bool GUIFormSpecMenu::parseVersionDirect(const std::string &data)
 	return false;
 }
 
-bool GUIFormSpecMenu::parseSizeDirect(parserData *data, const std::string &element)
+bool GUIFormSpecMenu::parseSizeDirect(parserData* data, const std::string &element)
 {
 	if (element.empty())
 		return false;
 
-	std::vector<std::string> parts = split(element, '[');
+	std::vector<std::string> parts = split(element,'[');
 
 	if (parts.size() < 2)
 		return false;
@@ -2315,8 +2468,7 @@ void GUIFormSpecMenu::parsePosition(parserData *data, const std::string &element
 		return;
 	}
 
-	errorstream << "Invalid position element (" << parts.size() << "): '" << element
-				<< "'" << std::endl;
+	errorstream << "Invalid position element (" << parts.size() << "): '" << element << "'" << std::endl;
 }
 
 bool GUIFormSpecMenu::parseAnchorDirect(parserData *data, const std::string &element)
@@ -2355,8 +2507,8 @@ void GUIFormSpecMenu::parseAnchor(parserData *data, const std::string &element)
 		return;
 	}
 
-	errorstream << "Invalid anchor element (" << parts.size() << "): '" << element << "'"
-				<< std::endl;
+	errorstream << "Invalid anchor element (" << parts.size() << "): '" << element
+			<< "'" << std::endl;
 }
 
 bool GUIFormSpecMenu::parsePaddingDirect(parserData *data, const std::string &element)
@@ -2395,12 +2547,11 @@ void GUIFormSpecMenu::parsePadding(parserData *data, const std::string &element)
 		return;
 	}
 
-	errorstream << "Invalid padding element (" << parts.size() << "): '" << element << "'"
-				<< std::endl;
+	errorstream << "Invalid padding element (" << parts.size() << "): '" << element
+			<< "'" << std::endl;
 }
 
-bool GUIFormSpecMenu::parseStyle(
-		parserData *data, const std::string &element, bool style_type)
+bool GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element, bool style_type)
 {
 	std::vector<std::string> parts = split(element, ';');
 
@@ -2422,15 +2573,16 @@ bool GUIFormSpecMenu::parseStyle(
 		}
 
 		std::string propname = trim(parts[i].substr(0, equal_pos));
-		std::string value = trim(unescape_string(parts[i].substr(equal_pos + 1)));
+		std::string value    = trim(unescape_string(parts[i].substr(equal_pos + 1)));
 
 		std::transform(propname.begin(), propname.end(), propname.begin(), ::tolower);
 
 		StyleSpec::Property prop = StyleSpec::GetPropertyByName(propname);
 		if (prop == StyleSpec::NONE) {
 			if (property_warned.find(propname) != property_warned.end()) {
-				warningstream << "Invalid style element (Unknown property " << propname
-							  << "): '" << element << "'" << std::endl;
+				warningstream << "Invalid style element (Unknown property " << propname << "): '"
+						<< element
+						<< "'" << std::endl;
 				property_warned.insert(propname);
 			}
 			continue;
@@ -2456,15 +2608,15 @@ bool GUIFormSpecMenu::parseStyle(
 
 			if (state_str.empty()) {
 				errorstream << "Invalid style element (Invalid state): '" << element
-							<< "'" << std::endl;
+					<< "'" << std::endl;
 				state_valid = false;
 			} else {
 				std::vector<std::string> states = split(state_str, '+');
 				for (std::string &state : states) {
 					StyleSpec::State converted = StyleSpec::getStateByName(state);
 					if (converted == StyleSpec::STATE_INVALID) {
-						infostream << "Unknown style state " << state << " in element '"
-								   << element << "'" << std::endl;
+						infostream << "Unknown style state " << state <<
+							" in element '" << element << "'" << std::endl;
 						state_valid = false;
 						break;
 					}
@@ -2486,23 +2638,20 @@ bool GUIFormSpecMenu::parseStyle(
 		}
 
 		// Backwards-compatibility for existing _hovered/_pressed properties
-		if (selector_spec.hasProperty(StyleSpec::BGCOLOR_HOVERED) ||
-				selector_spec.hasProperty(StyleSpec::BGIMG_HOVERED) ||
-				selector_spec.hasProperty(StyleSpec::FGIMG_HOVERED)) {
+		if (selector_spec.hasProperty(StyleSpec::BGCOLOR_HOVERED)
+				|| selector_spec.hasProperty(StyleSpec::BGIMG_HOVERED)
+				|| selector_spec.hasProperty(StyleSpec::FGIMG_HOVERED)) {
 			StyleSpec hover_spec;
 			hover_spec.addState(StyleSpec::STATE_HOVERED);
 
 			if (selector_spec.hasProperty(StyleSpec::BGCOLOR_HOVERED)) {
-				hover_spec.set(StyleSpec::BGCOLOR,
-						selector_spec.get(StyleSpec::BGCOLOR_HOVERED, ""));
+				hover_spec.set(StyleSpec::BGCOLOR, selector_spec.get(StyleSpec::BGCOLOR_HOVERED, ""));
 			}
 			if (selector_spec.hasProperty(StyleSpec::BGIMG_HOVERED)) {
-				hover_spec.set(StyleSpec::BGIMG,
-						selector_spec.get(StyleSpec::BGIMG_HOVERED, ""));
+				hover_spec.set(StyleSpec::BGIMG, selector_spec.get(StyleSpec::BGIMG_HOVERED, ""));
 			}
 			if (selector_spec.hasProperty(StyleSpec::FGIMG_HOVERED)) {
-				hover_spec.set(StyleSpec::FGIMG,
-						selector_spec.get(StyleSpec::FGIMG_HOVERED, ""));
+				hover_spec.set(StyleSpec::FGIMG, selector_spec.get(StyleSpec::FGIMG_HOVERED, ""));
 			}
 
 			if (style_type) {
@@ -2511,23 +2660,20 @@ bool GUIFormSpecMenu::parseStyle(
 				theme_by_name[selector].push_back(hover_spec);
 			}
 		}
-		if (selector_spec.hasProperty(StyleSpec::BGCOLOR_PRESSED) ||
-				selector_spec.hasProperty(StyleSpec::BGIMG_PRESSED) ||
-				selector_spec.hasProperty(StyleSpec::FGIMG_PRESSED)) {
+		if (selector_spec.hasProperty(StyleSpec::BGCOLOR_PRESSED)
+				|| selector_spec.hasProperty(StyleSpec::BGIMG_PRESSED)
+				|| selector_spec.hasProperty(StyleSpec::FGIMG_PRESSED)) {
 			StyleSpec press_spec;
 			press_spec.addState(StyleSpec::STATE_PRESSED);
 
 			if (selector_spec.hasProperty(StyleSpec::BGCOLOR_PRESSED)) {
-				press_spec.set(StyleSpec::BGCOLOR,
-						selector_spec.get(StyleSpec::BGCOLOR_PRESSED, ""));
+				press_spec.set(StyleSpec::BGCOLOR, selector_spec.get(StyleSpec::BGCOLOR_PRESSED, ""));
 			}
 			if (selector_spec.hasProperty(StyleSpec::BGIMG_PRESSED)) {
-				press_spec.set(StyleSpec::BGIMG,
-						selector_spec.get(StyleSpec::BGIMG_PRESSED, ""));
+				press_spec.set(StyleSpec::BGIMG, selector_spec.get(StyleSpec::BGIMG_PRESSED, ""));
 			}
 			if (selector_spec.hasProperty(StyleSpec::FGIMG_PRESSED)) {
-				press_spec.set(StyleSpec::FGIMG,
-						selector_spec.get(StyleSpec::FGIMG_PRESSED, ""));
+				press_spec.set(StyleSpec::FGIMG, selector_spec.get(StyleSpec::FGIMG_PRESSED, ""));
 			}
 
 			if (style_type) {
@@ -2601,16 +2747,21 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	scene::IAnimatedMesh *mesh = m_client->getMesh(meshstr);
 
 	if (!mesh) {
-		errorstream << "Invalid model element: Unable to load mesh:" << std::endl
-					<< "\t" << meshstr << std::endl;
+		errorstream << "Invalid model element: Unable to load mesh:"
+				<< std::endl << "\t" << meshstr << std::endl;
 		return;
 	}
 
-	FieldSpec spec(name, L"", L"", 258 + m_fields.size());
+	FieldSpec spec(
+		name,
+		L"",
+		L"",
+		258 + m_fields.size()
+	);
 
 	core::rect<s32> rect(pos, pos + geom);
 
-	v3f camera_offset_vector{0.0f, 0.0f, 0.0f};
+	v3f camera_offset_vector{ 0.0f, 0.0f, 0.0f };
 	if (camera_offset.size() == 3) {
 		camera_offset_vector.X = stof(camera_offset[0]);
 		camera_offset_vector.Y = stof(camera_offset[1]);
@@ -2646,8 +2797,8 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	s32 frame_loop_end = 0x7FFFFFFF;
 
 	if (frame_loop.size() == 2) {
-		frame_loop_begin = stoi(frame_loop[0]);
-		frame_loop_end = stoi(frame_loop[1]);
+	    frame_loop_begin = stoi(frame_loop[0]);
+	    frame_loop_end = stoi(frame_loop[1]);
 	}
 
 	e->setFrameLoop(frame_loop_begin, frame_loop_end);
@@ -2682,9 +2833,9 @@ void GUIFormSpecMenu::removeAll()
 		scroll_container_it.second->drop();
 }
 
-void GUIFormSpecMenu::parseElement(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 {
-	// some prechecks
+	//some prechecks
 	if (element.empty())
 		return;
 
@@ -2696,7 +2847,7 @@ void GUIFormSpecMenu::parseElement(parserData *data, const std::string &element)
 		return;
 
 	std::string type = trim(element.substr(0, pos));
-	std::string description = element.substr(pos + 1);
+	std::string description = element.substr(pos+1);
 
 	if (type == "container") {
 		parseContainer(data, description);
@@ -2748,28 +2899,28 @@ void GUIFormSpecMenu::parseElement(parserData *data, const std::string &element)
 		return;
 	}
 
-	if (type == "tableoptions") {
-		parseTableOptions(data, description);
+	if (type == "tableoptions"){
+		parseTableOptions(data,description);
 		return;
 	}
 
-	if (type == "tablecolumns") {
-		parseTableColumns(data, description);
+	if (type == "tablecolumns"){
+		parseTableColumns(data,description);
 		return;
 	}
 
-	if (type == "table") {
-		parseTable(data, description);
+	if (type == "table"){
+		parseTable(data,description);
 		return;
 	}
 
-	if (type == "textlist") {
-		parseTextList(data, description);
+	if (type == "textlist"){
+		parseTextList(data,description);
 		return;
 	}
 
-	if (type == "dropdown") {
-		parseDropDown(data, description);
+	if (type == "dropdown"){
+		parseDropDown(data,description);
 		return;
 	}
 
@@ -2779,62 +2930,62 @@ void GUIFormSpecMenu::parseElement(parserData *data, const std::string &element)
 	}
 
 	if (type == "pwdfield") {
-		parsePwdField(data, description);
+		parsePwdField(data,description);
 		return;
 	}
 
-	if ((type == "field") || (type == "textarea")) {
-		parseField(data, description, type);
+	if ((type == "field") || (type == "textarea")){
+		parseField(data,description,type);
 		return;
 	}
 
 	if (type == "hypertext") {
-		parseHyperText(data, description);
+		parseHyperText(data,description);
 		return;
 	}
 
 	if (type == "label") {
-		parseLabel(data, description);
+		parseLabel(data,description);
 		return;
 	}
 
 	if (type == "vertlabel") {
-		parseVertLabel(data, description);
+		parseVertLabel(data,description);
 		return;
 	}
 
 	if (type == "item_image_button") {
-		parseItemImageButton(data, description);
+		parseItemImageButton(data,description);
 		return;
 	}
 
 	if ((type == "image_button") || (type == "image_button_exit")) {
-		parseImageButton(data, description, type);
+		parseImageButton(data,description,type);
 		return;
 	}
 
 	if (type == "tabheader") {
-		parseTabHeader(data, description);
+		parseTabHeader(data,description);
 		return;
 	}
 
 	if (type == "box") {
-		parseBox(data, description);
+		parseBox(data,description);
 		return;
 	}
 
 	if (type == "bgcolor") {
-		parseBackgroundColor(data, description);
+		parseBackgroundColor(data,description);
 		return;
 	}
 
 	if (type == "listcolors") {
-		parseListColors(data, description);
+		parseListColors(data,description);
 		return;
 	}
 
 	if (type == "tooltip") {
-		parseTooltip(data, description);
+		parseTooltip(data,description);
 		return;
 	}
 
@@ -2885,7 +3036,7 @@ void GUIFormSpecMenu::parseElement(parserData *data, const std::string &element)
 
 	// Ignore others
 	infostream << "Unknown DrawSpec: type=" << type << ", data=\"" << description << "\""
-			   << std::endl;
+			<< std::endl;
 }
 
 void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
@@ -2963,30 +3114,32 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	{
 		v3f formspec_bgcolor = g_settings->getV3F("formspec_default_bg_color");
 		m_bgcolor = video::SColor(
-				(u8)clamp_u8(g_settings->getS32("formspec_default_bg_opacity")),
-				clamp_u8(myround(formspec_bgcolor.X)),
-				clamp_u8(myround(formspec_bgcolor.Y)),
-				clamp_u8(myround(formspec_bgcolor.Z)));
+			(u8) clamp_u8(g_settings->getS32("formspec_default_bg_opacity")),
+			clamp_u8(myround(formspec_bgcolor.X)),
+			clamp_u8(myround(formspec_bgcolor.Y)),
+			clamp_u8(myround(formspec_bgcolor.Z))
+		);
 	}
 
 	{
 		v3f formspec_bgcolor = g_settings->getV3F("formspec_fullscreen_bg_color");
 		m_fullscreen_bgcolor = video::SColor(
-				(u8)clamp_u8(g_settings->getS32("formspec_fullscreen_bg_opacity")),
-				clamp_u8(myround(formspec_bgcolor.X)),
-				clamp_u8(myround(formspec_bgcolor.Y)),
-				clamp_u8(myround(formspec_bgcolor.Z)));
+			(u8) clamp_u8(g_settings->getS32("formspec_fullscreen_bg_opacity")),
+			clamp_u8(myround(formspec_bgcolor.X)),
+			clamp_u8(myround(formspec_bgcolor.Y)),
+			clamp_u8(myround(formspec_bgcolor.Z))
+		);
 	}
 
-	m_default_tooltip_bgcolor = video::SColor(255, 110, 130, 60);
-	m_default_tooltip_color = video::SColor(255, 255, 255, 255);
+	m_default_tooltip_bgcolor = video::SColor(255,110,130,60);
+	m_default_tooltip_color = video::SColor(255,255,255,255);
 
 	// Add tooltip
 	{
 		assert(!m_tooltip_element);
 		// Note: parent != this so that the tooltip isn't clipped by the menu rectangle
-		m_tooltip_element =
-				gui::StaticText::add(Environment, L"", core::rect<s32>(0, 0, 110, 18));
+		m_tooltip_element = gui::StaticText::add(Environment, L"",
+			core::rect<s32>(0, 0, 110, 18));
 		m_tooltip_element->enableOverrideColor(true);
 		m_tooltip_element->setBackgroundColor(m_default_tooltip_bgcolor);
 		m_tooltip_element->setDrawBackground(true);
@@ -2994,11 +3147,11 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		m_tooltip_element->setOverrideColor(m_default_tooltip_color);
 		m_tooltip_element->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_CENTER);
 		m_tooltip_element->setWordWrap(false);
-		// we're not parent so no autograb for this one!
+		//we're not parent so no autograb for this one!
 		m_tooltip_element->grab();
 	}
 
-	std::vector<std::string> elements = split(m_formspec_string, ']');
+	std::vector<std::string> elements = split(m_formspec_string,']');
 	unsigned int i = 0;
 
 	/* try to read version from first element only */
@@ -3010,21 +3163,21 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 	/* we need size first in order to calculate image scale */
 	mydata.explicit_size = false;
-	for (; i < elements.size(); i++) {
+	for (; i< elements.size(); i++) {
 		if (!parseSizeDirect(&mydata, elements[i])) {
 			break;
 		}
 	}
 
 	/* "position" element is always after "size" element if it used */
-	for (; i < elements.size(); i++) {
+	for (; i< elements.size(); i++) {
 		if (!parsePositionDirect(&mydata, elements[i])) {
 			break;
 		}
 	}
 
 	/* "anchor" element is always after "position" (or  "size" element) if it used */
-	for (; i < elements.size(); i++) {
+	for (; i< elements.size(); i++) {
 		if (!parseAnchorDirect(&mydata, elements[i])) {
 			break;
 		}
@@ -3064,8 +3217,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	if (mydata.explicit_size) {
 		// compute scaling for specified form size
 		if (m_lock) {
-			v2u32 current_screensize =
-					RenderingEngine::get_video_driver()->getScreenSize();
+			v2u32 current_screensize = RenderingEngine::get_video_driver()->getScreenSize();
 			v2u32 delta = current_screensize - m_lockscreensize;
 
 			if (current_screensize.Y > m_lockscreensize.Y)
@@ -3078,11 +3230,11 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			else
 				delta.X = 0;
 
-			offset = v2s32(delta.X, delta.Y);
+			offset = v2s32(delta.X,delta.Y);
 
 			mydata.screensize = m_lockscreensize;
 		} else {
-			offset = v2s32(0, 0);
+			offset = v2s32(0,0);
 		}
 
 		const double gui_scaling = g_settings->getFloat("gui_scaling", 0.5f, 42.0f);
@@ -3103,8 +3255,10 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			double fitx_imgsize;
 			double fity_imgsize;
 
-			v2f padded_screensize(mydata.screensize.X * (1.0f - mydata.padding.X * 2.0f),
-					mydata.screensize.Y * (1.0f - mydata.padding.Y * 2.0f));
+			v2f padded_screensize(
+				mydata.screensize.X * (1.0f - mydata.padding.X * 2.0f),
+				mydata.screensize.Y * (1.0f - mydata.padding.Y * 2.0f)
+			);
 
 			if (mydata.real_coordinates) {
 				fitx_imgsize = padded_screensize.X / mydata.invsize.X;
@@ -3113,10 +3267,10 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 				// The maximum imgsize in the old coordinate system also needs to
 				// factor in padding and spacing along with 0.1 inventory slot spare
 				// and help text space, hence the magic numbers.
-				fitx_imgsize =
-						padded_screensize.X / ((5.0 / 4.0) * (0.5 + mydata.invsize.X));
-				fity_imgsize =
-						padded_screensize.Y / ((15.0 / 13.0) * (0.85 + mydata.invsize.Y));
+				fitx_imgsize = padded_screensize.X /
+						((5.0 / 4.0) * (0.5 + mydata.invsize.X));
+				fity_imgsize = padded_screensize.Y /
+						((15.0 / 13.0) * (0.85 + mydata.invsize.Y));
 			}
 
 			s32 min_screen_dim = std::min(padded_screensize.X, padded_screensize.Y);
@@ -3131,7 +3285,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 #endif
 			// Try to use the preferred imgsize, but if that's bigger than the maximum
 			// size, use the maximum size.
-			use_imgsize = std::min(prefer_imgsize, std::min(fitx_imgsize, fity_imgsize));
+			use_imgsize = std::min(prefer_imgsize,
+					std::min(fitx_imgsize, fity_imgsize));
 		}
 
 		// Everything else is scaled in proportion to the
@@ -3143,45 +3298,42 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		// is 2/5 vertical inventory slot spacing, and button
 		// half-height is 7/8 of font height.
 		imgsize = v2s32(use_imgsize, use_imgsize);
-		spacing = v2f32(use_imgsize * 5.0 / 4, use_imgsize * 15.0 / 13);
-		padding = v2s32(use_imgsize * 3.0 / 8, use_imgsize * 3.0 / 8);
-		m_btn_height = use_imgsize * 15.0 / 13 * 0.35;
+		spacing = v2f32(use_imgsize*5.0/4, use_imgsize*15.0/13);
+		padding = v2s32(use_imgsize*3.0/8, use_imgsize*3.0/8);
+		m_btn_height = use_imgsize*15.0/13 * 0.35;
 
 		m_font = g_fontengine->getFont();
 
 		if (mydata.real_coordinates) {
-			mydata.size =
-					v2s32(mydata.invsize.X * imgsize.X, mydata.invsize.Y * imgsize.Y);
+			mydata.size = v2s32(
+				mydata.invsize.X*imgsize.X,
+				mydata.invsize.Y*imgsize.Y
+			);
 		} else {
 			mydata.size = v2s32(
-					padding.X * 2 + spacing.X * (mydata.invsize.X - 1.0) + imgsize.X,
-					padding.Y * 2 + spacing.Y * (mydata.invsize.Y - 1.0) + imgsize.Y +
-							m_btn_height * 2.0 / 3.0);
+				padding.X*2+spacing.X*(mydata.invsize.X-1.0)+imgsize.X,
+				padding.Y*2+spacing.Y*(mydata.invsize.Y-1.0)+imgsize.Y + m_btn_height*2.0/3.0
+			);
 		}
 
 		DesiredRect = mydata.rect = core::rect<s32>(
-				(s32)((f32)mydata.screensize.X * mydata.offset.X) -
-						(s32)(mydata.anchor.X * (f32)mydata.size.X) + offset.X,
-				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) -
-						(s32)(mydata.anchor.Y * (f32)mydata.size.Y) + offset.Y,
-				(s32)((f32)mydata.screensize.X * mydata.offset.X) +
-						(s32)((1.0 - mydata.anchor.X) * (f32)mydata.size.X) + offset.X,
-				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) +
-						(s32)((1.0 - mydata.anchor.Y) * (f32)mydata.size.Y) + offset.Y);
+				(s32)((f32)mydata.screensize.X * mydata.offset.X) - (s32)(mydata.anchor.X * (f32)mydata.size.X) + offset.X,
+				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) - (s32)(mydata.anchor.Y * (f32)mydata.size.Y) + offset.Y,
+				(s32)((f32)mydata.screensize.X * mydata.offset.X) + (s32)((1.0 - mydata.anchor.X) * (f32)mydata.size.X) + offset.X,
+				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) + (s32)((1.0 - mydata.anchor.Y) * (f32)mydata.size.Y) + offset.Y
+		);
 	} else {
 		// Non-size[] form must consist only of text fields and
 		// implicit "Proceed" button.  Use default font, and
 		// temporary form size which will be recalculated below.
 		m_font = g_fontengine->getFont();
 		m_btn_height = font_line_height(m_font) * 0.875;
-		DesiredRect = core::rect<s32>((s32)((f32)mydata.screensize.X * mydata.offset.X) -
-											  (s32)(mydata.anchor.X * 580.0),
-				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) -
-						(s32)(mydata.anchor.Y * 300.0),
-				(s32)((f32)mydata.screensize.X * mydata.offset.X) +
-						(s32)((1.0 - mydata.anchor.X) * 580.0),
-				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) +
-						(s32)((1.0 - mydata.anchor.Y) * 300.0));
+		DesiredRect = core::rect<s32>(
+			(s32)((f32)mydata.screensize.X * mydata.offset.X) - (s32)(mydata.anchor.X * 580.0),
+			(s32)((f32)mydata.screensize.Y * mydata.offset.Y) - (s32)(mydata.anchor.Y * 300.0),
+			(s32)((f32)mydata.screensize.X * mydata.offset.X) + (s32)((1.0 - mydata.anchor.X) * 580.0),
+			(s32)((f32)mydata.screensize.Y * mydata.offset.Y) + (s32)((1.0 - mydata.anchor.Y) * 300.0)
+		);
 	}
 	recalculateAbsolutePosition(false);
 	mydata.basepos = getBasePos();
@@ -3198,14 +3350,13 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	// (We use an arbitrarily big rect. The actual size is determined later by
 	// clipping to `this`.)
 	core::rect<s32> background_parent_rect(0, 0, 100000, 100000);
-	mydata.background_parent.reset(new gui::IGUIElement(
-			EGUIET_ELEMENT, Environment, this, -1, background_parent_rect));
+	mydata.background_parent.reset(new gui::IGUIElement(EGUIET_ELEMENT, Environment,
+			this, -1, background_parent_rect));
 
 	pos_offset = v2f32();
 
 	// used for formspec versions < 3
-	std::list<IGUIElement *>::iterator legacy_sort_start =
-			std::prev(Children.end()); // last element
+	std::list<IGUIElement *>::iterator legacy_sort_start = std::prev(Children.end()); // last element
 
 	if (enable_prepends) {
 		// Backup the coordinates so that prepends can use the coordinates of choice.
@@ -3229,16 +3380,16 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		mydata.real_coordinates = rc_backup; // Restore coordinates
 	}
 
-	for (; i < elements.size(); i++) {
+	for (; i< elements.size(); i++) {
 		parseElement(&mydata, elements[i]);
 	}
 
 	if (mydata.current_parent != this) {
 		errorstream << "Invalid formspec string: scroll_container was never closed!"
-					<< std::endl;
+			<< std::endl;
 	} else if (!container_stack.empty()) {
 		errorstream << "Invalid formspec string: container was never closed!"
-					<< std::endl;
+			<< std::endl;
 	}
 
 	// get the scrollbar elements for scroll_containers
@@ -3254,9 +3405,12 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	// If there are fields without explicit size[], add a "Proceed"
 	// button and adjust size to fit all the fields.
 	if (mydata.simple_field_count > 0 && !mydata.explicit_size) {
-		mydata.rect = core::rect<s32>(mydata.screensize.X / 2 - 580 / 2,
-				mydata.screensize.Y / 2 - 300 / 2, mydata.screensize.X / 2 + 580 / 2,
-				mydata.screensize.Y / 2 + 240 / 2 + mydata.simple_field_count * 60);
+		mydata.rect = core::rect<s32>(
+				mydata.screensize.X / 2 - 580 / 2,
+				mydata.screensize.Y / 2 - 300 / 2,
+				mydata.screensize.X / 2 + 580 / 2,
+				mydata.screensize.Y / 2 + 240 / 2 + mydata.simple_field_count * 60
+		);
 
 		DesiredRect = mydata.rect;
 		recalculateAbsolutePosition(false);
@@ -3267,8 +3421,10 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			pos.Y = (mydata.simple_field_count + 2) * 60;
 
 			v2s32 size = DesiredRect.getSize();
-			mydata.rect = core::rect<s32>(size.X / 2 - 70, pos.Y, size.X / 2 - 70 + 140,
-					pos.Y + m_btn_height * 2);
+			mydata.rect = core::rect<s32>(
+					size.X / 2 - 70,       pos.Y,
+					size.X / 2 - 70 + 140, pos.Y + m_btn_height * 2
+			);
 			const wchar_t *text = wgettext("Proceed");
 			GUIButton::addButton(Environment, mydata.rect, m_tsrc, this, 257, text);
 			delete[] text;
@@ -3277,8 +3433,9 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 	// Set initial focus if parser didn't set it
 	gui::IGUIElement *focused_element = Environment->getFocus();
-	if (!focused_element || !isMyChild(focused_element) ||
-			focused_element->getType() == gui::EGUIET_TAB_CONTROL)
+	if (!focused_element
+			|| !isMyChild(focused_element)
+			|| focused_element->getType() == gui::EGUIET_TAB_CONTROL)
 		setInitialFocus();
 
 	skin->setFont(old_font);
@@ -3320,13 +3477,13 @@ void GUIFormSpecMenu::legacySortElements(std::list<IGUIElement *>::iterator from
 
 	// 2: Sort the container
 	std::stable_sort(elements.begin(), elements.end(),
-			[this](const IGUIElement *a, const IGUIElement *b) -> bool {
-				// TODO: getSpecByID is a linear search. It should made O(1), or cached
-				// here.
-				const FieldSpec *spec_a = getSpecByID(a->getID());
-				const FieldSpec *spec_b = getSpecByID(b->getID());
-				return spec_a && spec_b && spec_a->priority < spec_b->priority;
-			});
+			[this] (const IGUIElement *a, const IGUIElement *b) -> bool {
+		// TODO: getSpecByID is a linear search. It should made O(1), or cached here.
+		const FieldSpec *spec_a = getSpecByID(a->getID());
+		const FieldSpec *spec_b = getSpecByID(b->getID());
+		return spec_a && spec_b &&
+			spec_a->priority < spec_b->priority;
+	});
 
 	// 3: Re-assign the pointers
 	reorderChildren(from, to, elements);
@@ -3366,22 +3523,22 @@ GUIInventoryList::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 	for (const GUIInventoryList *e : m_inventorylists) {
 		s32 item_index = e->getItemIndexAtPos(p);
 		if (item_index != -1)
-			return GUIInventoryList::ItemSpec(
-					e->getInventoryloc(), e->getListname(), item_index, e->getSlotSize());
+			return GUIInventoryList::ItemSpec(e->getInventoryloc(), e->getListname(),
+					item_index, e->getSlotSize());
 	}
 
-	return GUIInventoryList::ItemSpec(InventoryLocation(), "", -1, {0, 0});
+	return GUIInventoryList::ItemSpec(InventoryLocation(), "", -1, {0,0});
 }
 
 void GUIFormSpecMenu::drawSelectedItem()
 {
-	video::IVideoDriver *driver = Environment->getVideoDriver();
+	video::IVideoDriver* driver = Environment->getVideoDriver();
 
 	if (!m_selected_item) {
 		// reset rotation time
 		drawItemStack(driver, m_font, ItemStack(),
-				core::rect<s32>(v2s32(0, 0), v2s32(0, 0)), NULL, m_client,
-				IT_ROT_DRAGGED);
+				core::rect<s32>(v2s32(0, 0), v2s32(0, 0)), NULL,
+				m_client, IT_ROT_DRAGGED);
 		return;
 	}
 
@@ -3410,7 +3567,7 @@ void GUIFormSpecMenu::drawMenu()
 		}
 	}
 
-	gui::IGUISkin *skin = Environment->getSkin();
+	gui::IGUISkin* skin = Environment->getSkin();
 	sanity_check(skin != NULL);
 	gui::IGUIFont *old_font = skin->getFont();
 	skin->setFont(m_font);
@@ -3419,7 +3576,7 @@ void GUIFormSpecMenu::drawMenu()
 
 	updateSelectedItem();
 
-	video::IVideoDriver *driver = Environment->getVideoDriver();
+	video::IVideoDriver* driver = Environment->getVideoDriver();
 
 	/*
 		Draw background color
@@ -3457,7 +3614,8 @@ void GUIFormSpecMenu::drawMenu()
 	*/
 	for (auto child : Children)
 		if (child->isNotClipped() ||
-				AbsoluteClippingRect.isRectCollided(child->getAbsolutePosition()))
+				AbsoluteClippingRect.isRectCollided(
+						child->getAbsolutePosition()))
 			child->draw();
 
 	for (gui::IGUIElement *e : m_clickthrough_elements)
@@ -3472,8 +3630,8 @@ void GUIFormSpecMenu::drawMenu()
 	if (m_hovered_item_tooltips.empty()) {
 		// reset rotation time
 		drawItemStack(driver, m_font, ItemStack(),
-				core::rect<s32>(v2s32(0, 0), v2s32(0, 0)), NULL, m_client,
-				IT_ROT_HOVERED);
+			core::rect<s32>(v2s32(0, 0), v2s32(0, 0)),
+			NULL, m_client, IT_ROT_HOVERED);
 	}
 
 /* TODO find way to show tooltips on touchscreen */
@@ -3488,8 +3646,8 @@ void GUIFormSpecMenu::drawMenu()
 			Environment->getRootGUIElement()->getElementFromPoint(m_pointer);
 
 #ifndef HAVE_TOUCHSCREENGUI
-	gui::ICursorControl *cursor_control =
-			RenderingEngine::get_raw_device()->getCursorControl();
+	gui::ICursorControl *cursor_control = RenderingEngine::get_raw_device()->
+			getCursorControl();
 	gui::ECURSOR_ICON current_cursor_icon = cursor_control->getActiveIcon();
 #endif
 	bool hovered_element_found = false;
@@ -3532,7 +3690,7 @@ void GUIFormSpecMenu::drawMenu()
 					const std::wstring &text = m_tooltips[field.fname].tooltip;
 					if (!text.empty())
 						showTooltip(text, m_tooltips[field.fname].color,
-								m_tooltips[field.fname].bgcolor);
+							m_tooltips[field.fname].bgcolor);
 				}
 
 #ifndef HAVE_TOUCHSCREENGUI
@@ -3566,8 +3724,9 @@ void GUIFormSpecMenu::drawMenu()
 	skin->setFont(old_font);
 }
 
+
 void GUIFormSpecMenu::showTooltip(const std::wstring &text,
-		const irr::video::SColor &color, const irr::video::SColor &bgcolor)
+	const irr::video::SColor &color, const irr::video::SColor &bgcolor)
 {
 	EnrichedString ntext(text);
 	ntext.setDefaultColor(color);
@@ -3585,7 +3744,7 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 	int tooltip_offset_y = m_btn_height;
 #ifdef HAVE_TOUCHSCREENGUI
 	tooltip_offset_x *= 3;
-	tooltip_offset_y = 0;
+	tooltip_offset_y  = 0;
 	if (m_pointer.X > (s32)screenSize.X / 2)
 		tooltip_offset_x = -(tooltip_offset_x + tooltip_width);
 
@@ -3598,13 +3757,16 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 	s32 tooltip_x = m_pointer.X + tooltip_offset_x;
 	s32 tooltip_y = m_pointer.Y + tooltip_offset_y;
 	if (tooltip_x + tooltip_width > (s32)screenSize.X)
-		tooltip_x = (s32)screenSize.X - tooltip_width - m_btn_height;
+		tooltip_x = (s32)screenSize.X - tooltip_width  - m_btn_height;
 	if (tooltip_y + tooltip_height > (s32)screenSize.Y)
 		tooltip_y = (s32)screenSize.Y - tooltip_height - m_btn_height;
 
 	m_tooltip_element->setRelativePosition(
-			core::rect<s32>(core::position2d<s32>(tooltip_x, tooltip_y),
-					core::dimension2d<s32>(tooltip_width, tooltip_height)));
+		core::rect<s32>(
+			core::position2d<s32>(tooltip_x, tooltip_y),
+			core::dimension2d<s32>(tooltip_width, tooltip_height)
+		)
+	);
 
 	// Display the tooltip
 	m_tooltip_element->setVisible(true);
@@ -3663,7 +3825,7 @@ ItemStack GUIFormSpecMenu::verifySelectedItem()
 			Inventory *inv = m_invmgr->getInventory(m_selected_item->inventoryloc);
 			if (inv) {
 				InventoryList *list = inv->getList(m_selected_item->listname);
-				if (list && (u32)m_selected_item->i < list->getSize()) {
+				if (list && (u32) m_selected_item->i < list->getSize()) {
 					ItemStack stack = list->getItem(m_selected_item->i);
 					if (!m_selected_swap.empty()) {
 						if (m_selected_swap.name == stack.name &&
@@ -3690,7 +3852,8 @@ ItemStack GUIFormSpecMenu::verifySelectedItem()
 
 void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 {
-	if (m_text_dst) {
+	if(m_text_dst)
+	{
 		StringMap fields;
 
 		if (quitmode == quit_mode_accept) {
@@ -3747,7 +3910,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 						e = static_cast<gui::IGUIComboBox *>(element);
 					} else {
 						warningstream << "GUIFormSpecMenu::acceptInput: dropdown "
-									  << "field without dropdown element" << std::endl;
+								<< "field without dropdown element" << std::endl;
 						continue;
 					}
 					s32 selected = e->getSelected();
@@ -3757,9 +3920,8 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 							fields[name] = std::to_string(selected + 1);
 						} else {
 							std::vector<std::string> *dropdown_values =
-									getDropDownValues(s.fname);
-							if (dropdown_values &&
-									selected < (s32)dropdown_values->size())
+								getDropDownValues(s.fname);
+							if (dropdown_values && selected < (s32)dropdown_values->size())
 								fields[name] = (*dropdown_values)[selected];
 						}
 					}
@@ -3781,7 +3943,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 					IGUIElement *element = getElementFromId(s.fid, true);
 					gui::IGUICheckBox *e = nullptr;
 					if ((element) && (element->getType() == gui::EGUIET_CHECK_BOX)) {
-						e = static_cast<gui::IGUICheckBox *>(element);
+						e = static_cast<gui::IGUICheckBox*>(element);
 					}
 
 					if (e != 0) {
@@ -3803,7 +3965,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 							fields[name] = "CHG:" + itos(e->getPos());
 						else
 							fields[name] = "VAL:" + itos(e->getPos());
-					}
+ 					}
 				} else if (s.ftype == f_AnimatedImage) {
 					// No dynamic cast possible due to some distributions shipped
 					// without rtti support in Irrlicht
@@ -3826,7 +3988,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 	}
 }
 
-bool GUIFormSpecMenu::preprocessEvent(const SEvent &event)
+bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 {
 	// The IGUITabControl renders visually using the skin's selected
 	// font, which we override for the duration of form drawing,
@@ -3838,11 +4000,12 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent &event)
 			event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP) {
 		s32 x = event.MouseInput.X;
 		s32 y = event.MouseInput.Y;
-		gui::IGUIElement *hovered = Environment->getRootGUIElement()->getElementFromPoint(
+		gui::IGUIElement *hovered =
+			Environment->getRootGUIElement()->getElementFromPoint(
 				core::position2d<s32>(x, y));
 		if (hovered && isMyChild(hovered) &&
 				hovered->getType() == gui::EGUIET_TAB_CONTROL) {
-			gui::IGUISkin *skin = Environment->getSkin();
+			gui::IGUISkin* skin = Environment->getSkin();
 			sanity_check(skin != NULL);
 			gui::IGUIFont *old_font = skin->getFont();
 			skin->setFont(m_font);
@@ -3854,16 +4017,16 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent &event)
 
 	// Fix Esc/Return key being eaten by checkboxen and tables
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
-		KeyPress kp(event.KeyInput);
-		if (kp == EscapeKey || kp == CancelKey ||
-				kp == getKeySetting("keymap_inventory") ||
-				event.KeyInput.Key == KEY_RETURN) {
+			KeyPress kp(event.KeyInput);
+		if (kp == EscapeKey || kp == CancelKey
+				|| kp == getKeySetting("keymap_inventory")
+				|| event.KeyInput.Key==KEY_RETURN) {
 			gui::IGUIElement *focused = Environment->getFocus();
 			if (focused && isMyChild(focused) &&
 					(focused->getType() == gui::EGUIET_LIST_BOX ||
-							focused->getType() == gui::EGUIET_CHECK_BOX) &&
+					focused->getType() == gui::EGUIET_CHECK_BOX) &&
 					(focused->getParent()->getType() != gui::EGUIET_COMBO_BOX ||
-							event.KeyInput.Key != KEY_RETURN)) {
+					event.KeyInput.Key != KEY_RETURN)) {
 				OnEvent(event);
 				return true;
 			}
@@ -3872,11 +4035,12 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent &event)
 	// Mouse wheel and move events: send to hovered element instead of focused
 	if (event.EventType == EET_MOUSE_INPUT_EVENT &&
 			(event.MouseInput.Event == EMIE_MOUSE_WHEEL ||
-					(event.MouseInput.Event == EMIE_MOUSE_MOVED &&
-							event.MouseInput.ButtonStates == 0))) {
+			(event.MouseInput.Event == EMIE_MOUSE_MOVED &&
+			event.MouseInput.ButtonStates == 0))) {
 		s32 x = event.MouseInput.X;
 		s32 y = event.MouseInput.Y;
-		gui::IGUIElement *hovered = Environment->getRootGUIElement()->getElementFromPoint(
+		gui::IGUIElement *hovered =
+			Environment->getRootGUIElement()->getElementFromPoint(
 				core::position2d<s32>(x, y));
 		if (hovered && isMyChild(hovered)) {
 			hovered->OnEvent(event);
@@ -3930,14 +4094,13 @@ enum ButtonEventType : u8
 	BET_OTHER
 };
 
-bool GUIFormSpecMenu::OnEvent(const SEvent &event)
+bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 {
-	if (event.EventType == EET_KEY_INPUT_EVENT) {
+	if (event.EventType==EET_KEY_INPUT_EVENT) {
 		KeyPress kp(event.KeyInput);
-		if (event.KeyInput.PressedDown &&
-				((kp == EscapeKey) || (kp == CancelKey) ||
-						((m_client != NULL) &&
-								(kp == getKeySetting("keymap_inventory"))))) {
+		if (event.KeyInput.PressedDown && (
+				(kp == EscapeKey) || (kp == CancelKey) ||
+				((m_client != NULL) && (kp == getKeySetting("keymap_inventory"))))) {
 			tryClose();
 			return true;
 		}
@@ -3951,23 +4114,25 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 			m_show_debug = !m_show_debug;
 
 		if (event.KeyInput.PressedDown &&
-				(event.KeyInput.Key == KEY_RETURN || event.KeyInput.Key == KEY_UP ||
-						event.KeyInput.Key == KEY_DOWN)) {
+			(event.KeyInput.Key==KEY_RETURN ||
+			 event.KeyInput.Key==KEY_UP ||
+			 event.KeyInput.Key==KEY_DOWN)
+			) {
 			switch (event.KeyInput.Key) {
-			case KEY_RETURN:
-				current_keys_pending.key_enter = true;
+				case KEY_RETURN:
+					current_keys_pending.key_enter = true;
+					break;
+				case KEY_UP:
+					current_keys_pending.key_up = true;
+					break;
+				case KEY_DOWN:
+					current_keys_pending.key_down = true;
+					break;
 				break;
-			case KEY_UP:
-				current_keys_pending.key_up = true;
-				break;
-			case KEY_DOWN:
-				current_keys_pending.key_down = true;
-				break;
-				break;
-			default:
-				// can't happen at all!
-				FATAL_ERROR("Reached a source line that can't ever been reached");
-				break;
+				default:
+					//can't happen at all!
+					FATAL_ERROR("Reached a source line that can't ever been reached");
+					break;
 			}
 			if (current_keys_pending.key_enter && m_allowclose) {
 				acceptInput(quit_mode_accept);
@@ -3977,6 +4142,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 			}
 			return true;
 		}
+
 	}
 
 	/* Mouse event other than movement, or crossing the border of inventory
@@ -3984,10 +4150,9 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 	 */
 	if (event.EventType == EET_MOUSE_INPUT_EVENT &&
 			(event.MouseInput.Event != EMIE_MOUSE_MOVED ||
-					(event.MouseInput.Event == EMIE_MOUSE_MOVED &&
-							event.MouseInput.isRightPressed() &&
-							getItemAtPos(m_pointer).i !=
-									getItemAtPos(m_old_pointer).i))) {
+			 (event.MouseInput.Event == EMIE_MOUSE_MOVED &&
+			  event.MouseInput.isRightPressed() &&
+			  getItemAtPos(m_pointer).i != getItemAtPos(m_old_pointer).i))) {
 
 		// Get selected item and hovered/clicked item (s)
 
@@ -4008,70 +4173,66 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 		u32 s_count = 0;
 
 		if (s.isValid())
-			do { // breakable
-				inv_s = m_invmgr->getInventory(s.inventoryloc);
+		do { // breakable
+			inv_s = m_invmgr->getInventory(s.inventoryloc);
 
-				if (!inv_s) {
-					errorstream << "InventoryMenu: The selected inventory location "
-								<< "\"" << s.inventoryloc.dump() << "\" doesn't exist"
-								<< std::endl;
-					s.i = -1; // make it invalid again
-					break;
-				}
+			if (!inv_s) {
+				errorstream << "InventoryMenu: The selected inventory location "
+						<< "\"" << s.inventoryloc.dump() << "\" doesn't exist"
+						<< std::endl;
+				s.i = -1;  // make it invalid again
+				break;
+			}
 
-				list_s = inv_s->getList(s.listname);
-				if (list_s == NULL) {
-					verbosestream << "InventoryMenu: The selected inventory list \""
-								  << s.listname << "\" does not exist" << std::endl;
-					s.i = -1; // make it invalid again
-					break;
-				}
+			list_s = inv_s->getList(s.listname);
+			if (list_s == NULL) {
+				verbosestream << "InventoryMenu: The selected inventory list \""
+						<< s.listname << "\" does not exist" << std::endl;
+				s.i = -1;  // make it invalid again
+				break;
+			}
 
-				if ((u32)s.i >= list_s->getSize()) {
-					infostream << "InventoryMenu: The selected inventory list \""
-							   << s.listname << "\" is too small (i=" << s.i
-							   << ", size=" << list_s->getSize() << ")" << std::endl;
-					s.i = -1; // make it invalid again
-					break;
-				}
+			if ((u32)s.i >= list_s->getSize()) {
+				infostream << "InventoryMenu: The selected inventory list \""
+						<< s.listname << "\" is too small (i=" << s.i << ", size="
+						<< list_s->getSize() << ")" << std::endl;
+				s.i = -1;  // make it invalid again
+				break;
+			}
 
-				s_count = list_s->getItem(s.i).count;
-			} while (0);
+			s_count = list_s->getItem(s.i).count;
+		} while(0);
 
-		bool identical = m_selected_item && s.isValid() && (inv_selected == inv_s) &&
-						 (m_selected_item->listname == s.listname) &&
-						 (m_selected_item->i == s.i);
+		bool identical = m_selected_item && s.isValid() &&
+			(inv_selected == inv_s) &&
+			(m_selected_item->listname == s.listname) &&
+			(m_selected_item->i == s.i);
 
 		ButtonEventType button = BET_LEFT;
 		ButtonEventType updown = BET_OTHER;
 		switch (event.MouseInput.Event) {
 		case EMIE_LMOUSE_PRESSED_DOWN:
-			button = BET_LEFT;
-			updown = BET_DOWN;
+			button = BET_LEFT; updown = BET_DOWN;
 			break;
 		case EMIE_RMOUSE_PRESSED_DOWN:
-			button = BET_RIGHT;
-			updown = BET_DOWN;
+			button = BET_RIGHT; updown = BET_DOWN;
 			break;
 		case EMIE_MMOUSE_PRESSED_DOWN:
-			button = BET_MIDDLE;
-			updown = BET_DOWN;
+			button = BET_MIDDLE; updown = BET_DOWN;
 			break;
 		case EMIE_MOUSE_WHEEL:
-			button = (event.MouseInput.Wheel > 0) ? BET_WHEEL_UP : BET_WHEEL_DOWN;
+			button = (event.MouseInput.Wheel > 0) ?
+				BET_WHEEL_UP : BET_WHEEL_DOWN;
 			updown = BET_DOWN;
 			break;
 		case EMIE_LMOUSE_LEFT_UP:
-			button = BET_LEFT;
-			updown = BET_UP;
+			button = BET_LEFT; updown = BET_UP;
 			break;
 		case EMIE_RMOUSE_LEFT_UP:
-			button = BET_RIGHT;
-			updown = BET_UP;
+			button = BET_RIGHT; updown = BET_UP;
 			break;
 		case EMIE_MMOUSE_LEFT_UP:
-			button = BET_MIDDLE;
-			updown = BET_UP;
+			button = BET_MIDDLE; updown = BET_UP;
 			break;
 		case EMIE_MOUSE_MOVED:
 			updown = BET_MOVE;
@@ -4099,7 +4260,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 		case BET_DOWN:
 			// Some mouse button has been pressed
 
-			// infostream << "Mouse button " << button << " pressed at p=("
+			//infostream << "Mouse button " << button << " pressed at p=("
 			//	<< event.MouseInput.X << "," << event.MouseInput.Y << ")"
 			//	<< std::endl;
 
@@ -4120,7 +4281,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 						count = MYMIN(s_count, 10);
 					else if (button == BET_WHEEL_DOWN)
 						count = 1;
-					else // left
+					else  // left
 						count = s_count;
 
 					if (!event.MouseInput.Shift) {
@@ -4158,22 +4319,22 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 							move_amount = 0;
 						}
 					}
-				} else if (!getAbsoluteClippingRect().isPointInside(m_pointer) &&
-						   button != BET_WHEEL_DOWN) {
+				} else if (!getAbsoluteClippingRect().isPointInside(m_pointer)
+						&& button != BET_WHEEL_DOWN) {
 					// Clicked outside of the window: drop
 					if (button == BET_RIGHT || button == BET_WHEEL_UP)
 						drop_amount = 1;
 					else if (button == BET_MIDDLE)
 						drop_amount = MYMIN(m_selected_amount, 10);
-					else // left
+					else  // left
 						drop_amount = m_selected_amount;
 				}
 			}
-			break;
+		break;
 		case BET_UP:
 			// Some mouse button has been released
 
-			// infostream<<"Mouse button "<<button<<" released at p=("
+			//infostream<<"Mouse button "<<button<<" released at p=("
 			//	<<p.X<<","<<p.Y<<")"<<std::endl;
 
 			if (m_selected_dragging && m_selected_item) {
@@ -4194,7 +4355,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 			// + click changes to drop item when moved mode
 			if (m_selected_item)
 				m_auto_place = true;
-			break;
+		break;
 		case BET_MOVE:
 			// Mouse has been moved and rmb is down and mouse pointer just
 			// entered a new inventory field (checked in the entry-if, this
@@ -4206,8 +4367,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 					// Only move an item if the destination slot is empty
 					// or contains the same item type as what is going to be
 					// moved
-					InventoryList *list_from =
-							inv_selected->getList(m_selected_item->listname);
+					InventoryList *list_from = inv_selected->getList(m_selected_item->listname);
 					InventoryList *list_to = list_s;
 					assert(list_from && list_to);
 					ItemStack stack_from = list_from->getItem(m_selected_item->i);
@@ -4216,7 +4376,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 						move_amount = 1;
 				}
 			}
-			break;
+		break;
 		default:
 			break;
 		}
@@ -4241,7 +4401,8 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 			bool move = true;
 			// If source stack cannot be added to destination stack at all,
 			// they are swapped
-			if (leftover.count == stack_from.count && leftover.name == stack_from.name) {
+			if (leftover.count == stack_from.count &&
+					leftover.name == stack_from.name) {
 
 				if (m_selected_swap.empty()) {
 					m_selected_amount = stack_to.count;
@@ -4281,7 +4442,8 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 			u32 i = 0;
 			for (; i < mis; i++) {
 				const ListRingSpec &sp = m_inventory_rings[i];
-				if (sp.inventoryloc == s.inventoryloc && sp.listname == s.listname)
+				if (sp.inventoryloc == s.inventoryloc
+						&& sp.listname == s.listname)
 					break;
 			}
 			do {
@@ -4338,8 +4500,8 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 
 			// if there are no items selected or the selected item
 			// belongs to craftresult list, proceed with crafting
-			if (!m_selected_item || !m_selected_item->isValid() ||
-					m_selected_item->listname == "craftresult") {
+			if (!m_selected_item ||
+					!m_selected_item->isValid() || m_selected_item->listname == "craftresult") {
 
 				assert(inv_s);
 
@@ -4364,7 +4526,8 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 	}
 
 	if (event.EventType == EET_GUI_EVENT) {
-		if (event.GUIEvent.EventType == gui::EGET_TAB_CHANGED && isVisible()) {
+		if (event.GUIEvent.EventType == gui::EGET_TAB_CHANGED
+				&& isVisible()) {
 			// find the element that was clicked
 			for (GUIFormSpecMenu::FieldSpec &s : m_fields) {
 				if ((s.ftype == f_TabHeader) &&
@@ -4378,9 +4541,11 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 				}
 			}
 		}
-		if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST && isVisible()) {
+		if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST
+				&& isVisible()) {
 			if (!canTakeFocus(event.GUIEvent.Element)) {
-				infostream << "GUIFormSpecMenu: Not allowing focus change." << std::endl;
+				infostream<<"GUIFormSpecMenu: Not allowing focus change."
+						<<std::endl;
 				// Returning true disables focus change
 				return true;
 			}
@@ -4466,8 +4631,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 
 		if (event.GUIEvent.EventType == gui::EGET_SCROLL_BAR_CHANGED) {
 			// move scroll_containers
-			for (const std::pair<std::string, GUIScrollContainer *> &c :
-					m_scroll_containers)
+			for (const std::pair<std::string, GUIScrollContainer *> &c : m_scroll_containers)
 				c.second->onScrollEvent(event.GUIEvent.Caller);
 		}
 
@@ -4475,10 +4639,11 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 			if (event.GUIEvent.Caller->getID() > 257) {
 				bool close_on_enter = true;
 				for (GUIFormSpecMenu::FieldSpec &s : m_fields) {
-					if (s.ftype == f_Unknown && s.fid == event.GUIEvent.Caller->getID()) {
+					if (s.ftype == f_Unknown &&
+							s.fid == event.GUIEvent.Caller->getID()) {
 						current_field_enter_pending = s.fname;
 						std::unordered_map<std::string, bool>::const_iterator it =
-								field_close_on_enter.find(s.fname);
+							field_close_on_enter.find(s.fname);
 						if (it != field_close_on_enter.end())
 							close_on_enter = (*it).second;
 
@@ -4509,7 +4674,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 					if ((s.ftype == f_Table) && (s.fid == current_id)) {
 						s.send = true;
 						acceptInput();
-						s.send = false;
+						s.send=false;
 					}
 				}
 				return true;
@@ -4534,6 +4699,7 @@ std::string GUIFormSpecMenu::getNameByID(s32 id)
 	return "";
 }
 
+
 const GUIFormSpecMenu::FieldSpec *GUIFormSpecMenu::getSpecByID(s32 id)
 {
 	for (FieldSpec &spec : m_fields) {
@@ -4557,14 +4723,13 @@ std::wstring GUIFormSpecMenu::getLabelByID(s32 id)
 	return L"";
 }
 
-StyleSpec GUIFormSpecMenu::getDefaultStyleForElement(
-		const std::string &type, const std::string &name, const std::string &parent_type)
-{
+StyleSpec GUIFormSpecMenu::getDefaultStyleForElement(const std::string &type,
+		const std::string &name, const std::string &parent_type) {
 	return getStyleForElement(type, name, parent_type)[StyleSpec::STATE_DEFAULT];
 }
 
 std::array<StyleSpec, StyleSpec::NUM_STATES> GUIFormSpecMenu::getStyleForElement(
-		const std::string &type, const std::string &name, const std::string &parent_type)
+	const std::string &type, const std::string &name, const std::string &parent_type)
 {
 	std::array<StyleSpec, StyleSpec::NUM_STATES> ret;
 

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -24,8 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "porting.h"
 
 GUIScene::GUIScene(gui::IGUIEnvironment *env, scene::ISceneManager *smgr,
-		gui::IGUIElement *parent, core::recti rect, s32 id) :
-		IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rect)
+		   gui::IGUIElement *parent, core::recti rect, s32 id)
+	: IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rect)
 {
 	m_driver = env->getVideoDriver();
 	m_smgr = smgr->createNewSceneManager(false);
@@ -91,7 +91,7 @@ void GUIScene::draw()
 		core::recti borderRect =
 				Environment->getRootGUIElement()->getAbsoluteClippingRect();
 		Environment->getSkin()->draw3DSunkenPane(
-				this, m_bgcolor, false, true, borderRect, 0);
+			this, m_bgcolor, false, true, borderRect, 0);
 	}
 
 	core::dimension2d<s32> size = getAbsoluteClippingRect().getSize();
@@ -230,7 +230,7 @@ void GUIScene::updateCamera(scene::ISceneNode *target)
 	m_target->setParent(m_mesh);
 	updateTargetPos();
 
-	// m_last_target_pos = m_target_pos;
+	m_last_target_pos = m_target_pos;
 	updateCameraPos();
 
 	m_update_cam = true;
@@ -288,8 +288,7 @@ void GUIScene::cameraLoop()
 		m_update_cam = true;
 
 	if (m_update_cam) {
-		m_cam_pos =
-				m_target_pos + (m_cam_pos - m_target_pos).normalize() * m_cam_distance;
+		m_cam_pos = m_target_pos + (m_cam_pos - m_target_pos).normalize() * m_cam_distance;
 
 		v3f rot = getCameraRotation();
 		if (correctBounds(rot))

--- a/src/gui/guiScene.h
+++ b/src/gui/guiScene.h
@@ -29,7 +29,7 @@ class GUIScene : public gui::IGUIElement
 {
 public:
 	GUIScene(gui::IGUIEnvironment *env, scene::ISceneManager *smgr,
-			gui::IGUIElement *parent, core::recti rect, s32 id = -1);
+		 gui::IGUIElement *parent, core::recti rect, s32 id = -1);
 
 	~GUIScene();
 
@@ -80,9 +80,8 @@ private:
 	v3f m_cam_pos;
 	v3f m_target_pos;
 	v3f m_last_target_pos;
-	v3f m_target_offset_pos;	 // Defined offset from formspec
-	float m_camera_min_distance; // Clamping values for the camera. if both are 0, then it
-								 // is unclamped.
+	v3f m_target_offset_pos;	 // Defined offset from model origin
+	float m_camera_min_distance; // Clamping values for the camera. if both are 0, then it is unclamped.
 	float m_camera_max_distance;
 	// Cursor positions
 	v2f m_curr_pos;
@@ -92,7 +91,7 @@ private:
 
 	bool m_mouse_ctrl = true;
 	bool m_update_cam = false;
-	bool m_inf_rot = false;
+	bool m_inf_rot    = false;
 	bool m_initial_rotation = true;
 
 	video::SColor m_bgcolor = 0;

--- a/src/gui/guiScene.h
+++ b/src/gui/guiScene.h
@@ -29,7 +29,7 @@ class GUIScene : public gui::IGUIElement
 {
 public:
 	GUIScene(gui::IGUIEnvironment *env, scene::ISceneManager *smgr,
-		 gui::IGUIElement *parent, core::recti rect, s32 id = -1);
+			gui::IGUIElement *parent, core::recti rect, s32 id = -1);
 
 	~GUIScene();
 
@@ -42,6 +42,8 @@ public:
 	void setRotation(v2f rot) noexcept { m_custom_rot = rot; };
 	void enableContinuousRotation(bool enable) noexcept { m_inf_rot = enable; };
 	void setStyles(const std::array<StyleSpec, StyleSpec::NUM_STATES> &styles);
+	void setCameraOffsets(const v3f &offset);
+	void setCameraDistanceClamping(float min, float max);
 
 	virtual void draw();
 	virtual bool OnEvent(const SEvent &event);
@@ -56,8 +58,14 @@ private:
 	void cameraLoop();
 
 	void updateCameraPos() { m_cam_pos = m_cam->getPosition(); };
-	v3f getCameraRotation() const { return (m_cam_pos - m_target_pos).getHorizontalAngle(); };
-	void rotateCamera(const v3f &delta) { setCameraRotation(getCameraRotation() + delta); };
+	v3f getCameraRotation() const
+	{
+		return (m_cam_pos - m_target_pos).getHorizontalAngle();
+	};
+	void rotateCamera(const v3f &delta)
+	{
+		setCameraRotation(getCameraRotation() + delta);
+	};
 
 	scene::ISceneManager *m_smgr;
 	video::IVideoDriver *m_driver;
@@ -72,6 +80,10 @@ private:
 	v3f m_cam_pos;
 	v3f m_target_pos;
 	v3f m_last_target_pos;
+	v3f m_target_offset_pos;	 // Defined offset from formspec
+	float m_camera_min_distance; // Clamping values for the camera. if both are 0, then it
+								 // is unclamped.
+	float m_camera_max_distance;
 	// Cursor positions
 	v2f m_curr_pos;
 	v2f m_last_pos;
@@ -80,7 +92,7 @@ private:
 
 	bool m_mouse_ctrl = true;
 	bool m_update_cam = false;
-	bool m_inf_rot    = false;
+	bool m_inf_rot = false;
 	bool m_initial_rotation = true;
 
 	video::SColor m_bgcolor = 0;


### PR DESCRIPTION
This adds the ability to control the camera's orbit point and distance from it to the `model[` formspec element.

This is in response to a bug where, the second time a UI element with a model element is opened, the origin moves:
First Open:
![before-orig](https://user-images.githubusercontent.com/21015354/224516231-407b088b-b79d-4dac-b867-4981e4809b10.png)
Second Open:
![after-orig](https://user-images.githubusercontent.com/21015354/224516241-c86bf259-5d07-4c4e-9912-382acc3cfd20.png)
![after-orig2](https://user-images.githubusercontent.com/21015354/224516338-4a234345-cdcf-42c4-84ba-ec63df6a5565.png)


With these changes, it will position the camera's orbit point at the model's origin + whatever offset is supplied. The distance from that point can also be clamped, or by having the same min and max, precisely controlled. The default autodetection of a good camera distance remains when unclamped, or the autodetected distance is within the clamping range.
First Open, with fix:
![before-modified](https://user-images.githubusercontent.com/21015354/224516340-2a025fef-ba27-430e-9c00-eddcbead1b2b.png)

Second Open, with fix:
![after-modified](https://user-images.githubusercontent.com/21015354/224516343-87730723-b0c8-41cc-a292-94f683f3fd86.png)
![after-modified2](https://user-images.githubusercontent.com/21015354/224516345-bb3ebcae-03c1-40b5-8b2f-654e4413f2aa.png)