### PR TITLE
Instrument touchMapBlocks and block loading/deserialization.

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -623,6 +623,8 @@ void ClientMap::touchMapBlocks()
 	if (m_control.range_all || m_loops_occlusion_culler)
 		return;
 
+	ScopeProfiler sp(g_profiler, "CM::touchMapBlocks()", SPT_AVG);
+
 	v3s16 cam_pos_nodes = floatToInt(m_camera_position, BS);
 
 	v3s16 p_blocks_min;

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -600,7 +600,6 @@ EmergeAction EmergeThread::getBlockOrStartGen(
 		if ((*block)->isGenerated())
 			return EMERGE_FROM_MEMORY;
 	} else {
-		ScopeProfiler sp(g_profiler, "EmergeThread: load block", SPT_AVG);
 		// 2). Attempt to load block from disk if it was not in the memory
 		*block = m_map->loadBlock(pos);
 		if (*block && (*block)->isGenerated())

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -600,6 +600,7 @@ EmergeAction EmergeThread::getBlockOrStartGen(
 		if ((*block)->isGenerated())
 			return EMERGE_FROM_MEMORY;
 	} else {
+		ScopeProfiler sp(g_profiler, "EmergeThread: load block", SPT_AVG);
 		// 2). Attempt to load block from disk if it was not in the memory
 		*block = m_map->loadBlock(pos);
 		if (*block && (*block)->isGenerated())

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1785,7 +1785,6 @@ bool ServerMap::saveBlock(MapBlock *block, MapDatabase *db, int compression_leve
 
 void ServerMap::loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool save_after_load)
 {
-	ScopeProfiler sp(g_profiler, "ServerMap: deSer block", SPT_AVG);
 	try {
 		std::istringstream is(*blob, std::ios_base::binary);
 
@@ -1804,8 +1803,11 @@ void ServerMap::loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool 
 			block = block_created_new.get();
 		}
 
+		{
+		ScopeProfiler sp(g_profiler, "ServerMap: deSer block", SPT_AVG);
 		// Read basic data
 		block->deSerialize(is, version, true);
+		}
 
 		// If it's a new block, insert it to the map
 		if (block_created_new) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1785,6 +1785,7 @@ bool ServerMap::saveBlock(MapBlock *block, MapDatabase *db, int compression_leve
 
 void ServerMap::loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool save_after_load)
 {
+	ScopeProfiler sp(g_profiler, "ServerMap: deSer block", SPT_AVG);
 	try {
 		std::istringstream is(*blob, std::ios_base::binary);
 
@@ -1845,6 +1846,7 @@ void ServerMap::loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool 
 
 MapBlock* ServerMap::loadBlock(v3s16 blockpos)
 {
+	ScopeProfiler sp(g_profiler, "ServerMap: load block", SPT_AVG);
 	bool created_new = (getBlockNoCreateNoEx(blockpos) == NULL);
 
 	v2s16 p2d(blockpos.X, blockpos.Z);


### PR DESCRIPTION
This simply adds some useful instrumentation:
1. (Attempted) load blocks on the emerge thread. This is useful to find good settings for these settings: `max_simultaneous_block_sends_per_client`, `emergequeue_limit_diskonly`, `emergequeue_limit_generate`, `emergequeue_limit_total`, `max_packets_per_iteration`, `num_emerge_threads`
2. Time spent in ClientMap::touchMapBlocks

## To do

This PR is Ready for Review.

## How to test

Load any world (in singleplayer) and notice the new entries in the profiler view (F6),
