### PR TITLE
Remove default keybind for pitchmove

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,9 @@ Some can be changed in the key config dialog in the settings tab.
 | T                             | Chat                                                           |
 | /                             | Command                                                        |
 | Esc                           | Pause menu/abort/exit (pauses only singleplayer game)          |
-| R                             | Enable/disable full range view                                 |
 | +                             | Increase view range                                            |
 | -                             | Decrease view range                                            |
 | K                             | Enable/disable fly mode (needs fly privilege)                  |
-| P                             | Enable/disable pitch move mode                                 |
 | J                             | Enable/disable fast mode (needs fast privilege)                |
 | H                             | Enable/disable noclip mode (needs noclip privilege)            |
 | E                             | Aux1 (Move fast in fast mode. Games may add special features)  |

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2170,7 +2170,7 @@ keymap_rangeselect (Range select key) key
 keymap_freemove (Fly key) key KEY_KEY_K
 
 #    Key for toggling pitch move mode.
-keymap_pitchmove (Pitch move key) key KEY_KEY_P
+keymap_pitchmove (Pitch move key) key
 
 #    Key for toggling fast mode.
 keymap_fastmove (Fast key) key KEY_KEY_J

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -95,7 +95,7 @@ void set_default_settings()
 	settings->setDefault("keymap_rangeselect", "");
 #endif
 	settings->setDefault("keymap_freemove", "KEY_KEY_K");
-	settings->setDefault("keymap_pitchmove", "KEY_KEY_P");
+	settings->setDefault("keymap_pitchmove", "");
 	settings->setDefault("keymap_fastmove", "KEY_KEY_J");
 	settings->setDefault("keymap_noclip", "KEY_KEY_H");
 	settings->setDefault("keymap_hotbar_next", "KEY_KEY_N");


### PR DESCRIPTION
Inspired by #12632 (infinite view range, done) and #13318 (mute button).

This PR removes the default keybind for toggling pitchmove (<kbd>P</kbd>). You can still use pitchmove, but you have to bind it to a key manually to be able to do so. I would have opened a proposal issue first, but the change is trivial.

New or inexperienced players often accidentally enable pitchmove. Then they are confused by the "weird" movement behavior in water and don't know how to disable it again. Or they think it's a bug. When I played on servers like CTF regularly, every now and then I saw someone complaining in chat that they somehow "couldn't move in the water anymore". Everyone then started to write "press P" into the chat.

Players used to pitchmove can just bind it to a key again.

## To do

This PR is a Ready for Review.

## How to test

Verify that pitchmove isn't bound to any key by default.
