### PR TITLE
Fix background[] pos-offset lower-right-corner being at least (1,1) 

### DIFF
--- a/src/gui/guiBackgroundImage.cpp
+++ b/src/gui/guiBackgroundImage.cpp
@@ -22,9 +22,10 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 GUIBackgroundImage::GUIBackgroundImage(gui::IGUIEnvironment *env,
 	gui::IGUIElement *parent, s32 id, const core::rect<s32> &rectangle,
 	const std::string &name, const core::rect<s32> &middle,
-	ISimpleTextureSource *tsrc, bool autoclip) :
+	ISimpleTextureSource *tsrc, bool autoclip, v2s32 autoclip_offset) :
 	gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rectangle),
-	m_name(name), m_middle(middle), m_tsrc(tsrc), m_autoclip(autoclip)
+	m_name(name), m_middle(middle), m_tsrc(tsrc), m_autoclip(autoclip),
+	m_autoclip_offset(autoclip_offset)
 {
 }
 
@@ -42,9 +43,14 @@ void GUIBackgroundImage::draw()
 		return;
 	}
 
-	core::rect<s32> rect = AbsoluteRect;
-	if (m_autoclip)
-		rect.LowerRightCorner += Parent->getAbsoluteClippingRect().getSize();
+	core::rect<s32> rect;
+	if (m_autoclip) {
+		rect = Parent->getAbsoluteClippingRect();
+		rect.UpperLeftCorner -= m_autoclip_offset;
+		rect.LowerRightCorner += m_autoclip_offset;
+	} else {
+		rect = AbsoluteRect;
+	}
 
 	video::IVideoDriver *driver = Environment->getVideoDriver();
 

--- a/src/gui/guiBackgroundImage.h
+++ b/src/gui/guiBackgroundImage.h
@@ -26,7 +26,8 @@ class GUIBackgroundImage : public gui::IGUIElement
 public:
 	GUIBackgroundImage(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
 		const core::rect<s32> &rectangle, const std::string &name,
-		const core::rect<s32> &middle, ISimpleTextureSource *tsrc, bool autoclip);
+		const core::rect<s32> &middle, ISimpleTextureSource *tsrc, bool autoclip,
+		v2s32 autoclip_offset);
 
 	virtual void draw() override;
 
@@ -35,4 +36,5 @@ private:
 	core::rect<s32> m_middle;
 	ISimpleTextureSource *m_tsrc;
 	bool m_autoclip;
+	v2s32 m_autoclip_offset;
 };

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1101,17 +1101,18 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 		258 + m_fields.size()
 	);
 
-	core::rect<s32> rect;
+	core::rect<s32> rect{};
+	v2s32 autoclip_offset{};
 	if (!clip) {
 		// no auto_clip => position like normal image
 		rect = core::rect<s32>(pos, pos + geom);
 	} else {
-		// it will be auto-clipped when drawing
-		rect = core::rect<s32>(-pos, pos);
+		// element will be auto-clipped when drawing
+		autoclip_offset = pos;
 	}
 
 	GUIBackgroundImage *e = new GUIBackgroundImage(Environment, data->background_parent.get(),
-			spec.fid, rect, name, middle, m_tsrc, clip);
+			spec.fid, rect, name, middle, m_tsrc, clip, autoclip_offset);
 
 	FATAL_ERROR_IF(!e, "Failed to create background formspec element");
 


### PR DESCRIPTION
IGUIElement has a MinSize for the RelativeRect, which is at least (1,1).
This means a pos offset of (0,0) will cause a seemingly off-by-1 error at the
lower right corner, and (0.1,0.1) for example will just not work on the lower
right corner.
Ergo, we can't use the AbsoluteRect for storing the pos offset.

Fixes #12798.

## To do

This PR is a Ready for Review.

## How to test

Use node meta editor in devtest.
Formspecs:
```
-- from the issue (with autoclip=false. also try autoclip=true)
formspec_version[6]
size[1.5,1.5]
no_prepend[]
list[current_player;main;0.25,0.25;1,1;]
background[0,0;1.5,1.5;blank.png^[noalpha;false]

-- see below
formspec_version[6]
size[1.5,1.5]
no_prepend[]
list[current_player;main;0.25,0.25;1,1;]
background[0,0.1;1.5,1.5;blank.png^[noalpha;true]
```
Comparison of the latter formspec:
master:
![screenshot_master](https://user-images.githubusercontent.com/7613443/224762297-12160ca6-d73a-4fa4-868c-e4e29ac4ddd6.png)
PR:
![screenshot_pr](https://user-images.githubusercontent.com/7613443/224762306-6cd4b2ae-a6fb-4598-9ad5-256611ebb88f.png)

