### PR TITLE
Support OpenGL 3

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -314,7 +314,7 @@ local function check_requirements(name, requires)
 	end
 
 	local video_driver = core.get_active_driver()
-	local shaders_support = video_driver == "opengl" or video_driver == "ogles2"
+	local shaders_support = video_driver == "opengl" or video_driver == "opengl3" or video_driver == "ogles2"
 	local special = {
 		android = PLATFORM == "Android",
 		desktop = PLATFORM ~= "Android",

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -440,7 +440,6 @@ enable_raytraced_culling (Enable Raytraced Culling) bool true
 
 #    Shaders allow advanced visual effects and may increase performance on some video
 #    cards.
-#    This only works with the OpenGL video backend.
 #
 #    Requires: shaders_support
 enable_shaders (Shaders) bool true
@@ -1772,8 +1771,8 @@ shader_path (Shader path) path
 #    The rendering back-end.
 #    Note: A restart is required after changing this!
 #    OpenGL is the default for desktop, and OGLES2 for Android.
-#    Shaders are supported by OpenGL and OGLES2 (experimental).
-video_driver (Video driver) enum  ,opengl,ogles1,ogles2
+#    Shaders are supported by everything but OGLES1.
+video_driver (Video driver) enum  ,opengl,opengl3,ogles1,ogles2
 
 #    Distance in nodes at which transparency depth sorting is enabled
 #    Use this to limit the performance impact of transparency depth sorting

--- a/client/shaders/blur_h/opengl_fragment.glsl
+++ b/client/shaders/blur_h/opengl_fragment.glsl
@@ -14,7 +14,7 @@ centroid varying vec2 varTexCoord;
 // smoothstep - squared
 float smstsq(float f)
 {
-	f = f * f * (3 - 2 * f);
+	f = f * f * (3. - 2. * f);
 	return f;
 }
 

--- a/client/shaders/blur_v/opengl_fragment.glsl
+++ b/client/shaders/blur_v/opengl_fragment.glsl
@@ -14,7 +14,7 @@ centroid varying vec2 varTexCoord;
 // smoothstep - squared
 float smstsq(float f)
 {
-	f = f * f * (3 - 2 * f);
+	f = f * f * (3. - 2. * f);
 	return f;
 }
 

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -161,7 +161,7 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	float depth_to_blur = f_shadowfar / SOFTSHADOWRADIUS / xyPerspectiveBias0;
 	if (depth > 0.0 && f_normal_length > 0.0)
 		// 5 is empirical factor that controls how fast shadow loses sharpness
-		sharpness_factor = clamp(5 * depth * depth_to_blur, 0.0, 1.0);
+		sharpness_factor = clamp(5.0 * depth * depth_to_blur, 0.0, 1.0);
 	depth = 0.0;
 
 	float world_to_texture = xyPerspectiveBias1 / perspective_factor / perspective_factor

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -242,7 +242,7 @@ void main(void)
 		if (f_normal_length > 0.0) {
 			nNormal = normalize(vNormal);
 			cosLight = max(1e-5, dot(nNormal, -v_LightDirection));
-			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
+			float sinLight = pow(1.0 - pow(cosLight, 2.0), 0.5);
 			normalOffsetScale = 2.0 * pFactor * pFactor * sinLight * min(f_shadowfar, 500.0) /
 					xyPerspectiveBias1 / f_textureresolution;
 			z_bias = 1.0 * sinLight / cosLight;
@@ -250,7 +250,7 @@ void main(void)
 		else {
 			nNormal = vec3(0.0);
 			cosLight = clamp(dot(v_LightDirection, normalize(vec3(v_LightDirection.x, 0.0, v_LightDirection.z))), 1e-2, 1.0);
-			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
+			float sinLight = pow(1.0 - pow(cosLight, 2.0), 0.5);
 			normalOffsetScale = 0.0;
 			z_bias = 3.6e3 * sinLight / cosLight;
 		}

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -147,7 +147,7 @@ void main(void)
 		if (f_normal_length > 0.0) {
 			nNormal = normalize(vNormal);
 			cosLight = max(1e-5, dot(nNormal, -v_LightDirection));
-			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
+			float sinLight = pow(1.0 - pow(cosLight, 2.0), 0.5);
 			normalOffsetScale = 0.1 * pFactor * pFactor * sinLight * min(f_shadowfar, 500.0) /
 					xyPerspectiveBias1 / f_textureresolution;
 			z_bias = 1e3 * sinLight / cosLight * (0.5 + f_textureresolution / 1024.0);
@@ -155,7 +155,7 @@ void main(void)
 		else {
 			nNormal = vec3(0.0);
 			cosLight = clamp(dot(v_LightDirection, normalize(vec3(v_LightDirection.x, 0.0, v_LightDirection.z))), 1e-2, 1.0);
-			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
+			float sinLight = pow(1.0 - pow(cosLight, 2.0), 0.5);
 			normalOffsetScale = 0.0;
 			z_bias = 3.6e3 * sinLight / cosLight;
 		}

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -212,7 +212,8 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 		m_rendering_engine->get_raw_device()->
 			setWindowCaption((utf8_to_wide(PROJECT_NAME_C) +
 			L" " + utf8_to_wide(g_version_hash) +
-			L" [" + wstrgettext("Main Menu") + L"]").c_str());
+			L" [" + wstrgettext("Main Menu") + L"]" +
+			L" [" + m_rendering_engine->getVideoDriver()->getName() + L"]"	).c_str());
 
 		try {	// This is used for catching disconnects
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -305,9 +305,9 @@ std::vector<video::E_DRIVER_TYPE> RenderingEngine::getSupportedVideoDrivers()
 	};
 	std::vector<video::E_DRIVER_TYPE> drivers;
 
-	for (u32 i = 0; i < ARRLEN(glDrivers); i++) {
-		if (IrrlichtDevice::isDriverSupported(glDrivers[i]))
-			drivers.push_back(glDrivers[i]);
+	for (video::E_DRIVER_TYPE driver: glDrivers) {
+		if (IrrlichtDevice::isDriverSupported(driver))
+			drivers.push_back(driver);
 	}
 
 	return drivers;

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -299,6 +299,7 @@ std::vector<video::E_DRIVER_TYPE> RenderingEngine::getSupportedVideoDrivers()
 	// Order by preference (best first)
 	static const video::E_DRIVER_TYPE glDrivers[] = {
 		video::EDT_OPENGL,
+		video::EDT_OPENGL3,
 		video::EDT_OGLES2,
 		video::EDT_OGLES1,
 		video::EDT_NULL,
@@ -335,6 +336,7 @@ const VideoDriverInfo &RenderingEngine::getVideoDriverInfo(irr::video::E_DRIVER_
 	static const std::unordered_map<int, VideoDriverInfo> driver_info_map = {
 		{(int)video::EDT_NULL,   {"null",   "NULL Driver"}},
 		{(int)video::EDT_OPENGL, {"opengl", "OpenGL"}},
+		{(int)video::EDT_OPENGL3, {"opengl3", "OpenGL 3+"}},
 		{(int)video::EDT_OGLES1, {"ogles1", "OpenGL ES1"}},
 		{(int)video::EDT_OGLES2, {"ogles2", "OpenGL ES2"}},
 	};

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -279,7 +279,7 @@ public:
 		worldViewProj *= worldView;
 		m_world_view_proj.set(*reinterpret_cast<float(*)[16]>(worldViewProj.pointer()), services);
 
-		if (driver->getDriverType() == video::EDT_OGLES2) {
+		if (driver->getDriverType() == video::EDT_OGLES2 || driver->getDriverType() == video::EDT_OPENGL3) {
 			core::matrix4 texture = driver->getTransform(video::ETS_TEXTURE_0);
 			m_world_view.set(*reinterpret_cast<float(*)[16]>(worldView.pointer()), services);
 			m_texture.set(*reinterpret_cast<float(*)[16]>(texture.pointer()), services);
@@ -624,17 +624,19 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 	video::IGPUProgrammingServices *gpu = driver->getGPUProgrammingServices();
 
 	// Create shaders header
-	bool use_gles = driver->getDriverType() == video::EDT_OGLES2;
+	bool fully_programmable = driver->getDriverType() == video::EDT_OGLES2 || driver->getDriverType() == video::EDT_OPENGL3;
 	std::stringstream shaders_header;
 	shaders_header
 		<< std::noboolalpha
 		<< std::showpoint // for GLSL ES
 		;
 	std::string vertex_header, fragment_header, geometry_header;
-	if (use_gles) {
-		shaders_header << R"(
-			#version 100
-		)";
+	if (fully_programmable) {
+		if (driver->getDriverType() == video::EDT_OPENGL3) {
+			shaders_header << "#version 150\n";
+		} else {
+			shaders_header << "#version 100\n";
+		}
 		vertex_header = R"(
 			precision mediump float;
 
@@ -690,7 +692,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		abort();
 	}
 
-	bool use_discard = use_gles;
+	bool use_discard = fully_programmable;
 	// For renderers that should use discard instead of GL_ALPHA_TEST
 	const char *renderer = reinterpret_cast<const char*>(GL.GetString(GL.RENDERER));
 	if (strstr(renderer, "GC7000"))


### PR DESCRIPTION
Support OpenGL 3 from minetest/irrlicht#167.

Requires #13280.
Requires minetest/irrlicht#167.

## To do

This PR is Ready for Review
- [x] Merge #13280
- [x] Merge minetest/irrlicht#167
- [x] ~~In this PR, update `misc/irrlichtmt_tag.txt` to refer to the new Irrlicht~~ was updated in master

## How to test

* Build Irrlicht with `USE_SDL2` and `ENABLE_OPENGL3`.
* Copy Irrlicht shaders to `client/shaders/Irrlicht` (as if testing GLES2/desktop)
* Set `video_driver` to `opengl3` in the Minetest config.
* Run Minetest. It should work well, and with no “defaulting to” in the log.

Note: a way to make sure it uses the new driver is *remove* `client/shaders/Irrlicht`. If that breaks rendering, it’s either the proper one or GLES2. It would be better would the *actual* driver used be logged anywhere...