### PR TITLE
Fix black loading screen background if `menu_clouds = false`

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1775,7 +1775,7 @@ void Client::showUpdateProgressTexture(void *args, u32 progress, u32 max_progres
 			std::wostringstream strm;
 			strm << targs->text_base << L" " << targs->last_percent << L"%...";
 			m_rendering_engine->draw_load_screen(strm.str(), targs->guienv, targs->tsrc, 0,
-				72 + (u16) ((18. / 100.) * (double) targs->last_percent), true);
+				72 + (u16) ((18. / 100.) * (double) targs->last_percent));
 		}
 }
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4271,10 +4271,10 @@ void FpsControl::limit(IrrlichtDevice *device, f32 *dtime)
 	last_time = time;
 }
 
-void Game::showOverlayMessage(const char *msg, float dtime, int percent, bool draw_clouds)
+void Game::showOverlayMessage(const char *msg, float dtime, int percent, bool draw_sky)
 {
 	m_rendering_engine->draw_load_screen(wstrgettext(msg), guienv, texture_src,
-			dtime, percent, draw_clouds);
+			dtime, percent, draw_sky);
 }
 
 void Game::settingChangedCallback(const std::string &setting_name, void *data)

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -53,6 +53,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 
 RenderingEngine *RenderingEngine::s_singleton = nullptr;
+const video::SColor RenderingEngine::MENU_SKY_COLOR = video::SColor(255, 140, 186, 250);
 const float RenderingEngine::BASE_BLOOM_STRENGTH = 1.0f;
 
 
@@ -428,7 +429,7 @@ bool RenderingEngine::setXorgWindowIconFromPath(const std::string &icon_file)
 */
 void RenderingEngine::draw_load_screen(const std::wstring &text,
 		gui::IGUIEnvironment *guienv, ITextureSource *tsrc, float dtime,
-		int percent, bool clouds)
+		int percent, bool sky)
 {
 	v2u32 screensize = getWindowSize();
 
@@ -440,14 +441,14 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 			guienv->addStaticText(text.c_str(), textrect, false, false);
 	guitext->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_UPPERLEFT);
 
-	bool cloud_menu_background = clouds && g_settings->getBool("menu_clouds");
-	if (cloud_menu_background) {
+	if (sky && g_settings->getBool("menu_clouds")) {
 		g_menuclouds->step(dtime * 3);
 		g_menuclouds->render();
-		get_video_driver()->beginScene(
-				true, true, video::SColor(255, 140, 186, 250));
+		get_video_driver()->beginScene(true, true, RenderingEngine::MENU_SKY_COLOR);
 		g_menucloudsmgr->drawAll();
-	} else
+	} else if (sky)
+		get_video_driver()->beginScene(true, true, RenderingEngine::MENU_SKY_COLOR);
+	else
 		get_video_driver()->beginScene(true, true, video::SColor(255, 0, 0, 0));
 
 	// draw progress bar
@@ -493,26 +494,6 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 	guienv->drawAll();
 	get_video_driver()->endScene();
 	guitext->remove();
-}
-
-/*
-	Draws the menu scene including (optional) cloud background.
-*/
-void RenderingEngine::draw_menu_scene(gui::IGUIEnvironment *guienv,
-		float dtime, bool clouds)
-{
-	bool cloud_menu_background = clouds && g_settings->getBool("menu_clouds");
-	if (cloud_menu_background) {
-		g_menuclouds->step(dtime * 3);
-		g_menuclouds->render();
-		get_video_driver()->beginScene(
-				true, true, video::SColor(255, 140, 186, 250));
-		g_menucloudsmgr->drawAll();
-	} else
-		get_video_driver()->beginScene(true, true, video::SColor(255, 0, 0, 0));
-
-	guienv->drawAll();
-	get_video_driver()->endScene();
 }
 
 std::vector<video::E_DRIVER_TYPE> RenderingEngine::getSupportedVideoDrivers()

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -46,6 +46,7 @@ class RenderingCore;
 class RenderingEngine
 {
 public:
+	static const video::SColor MENU_SKY_COLOR;
 	static const float BASE_BLOOM_STRENGTH;
 
 	RenderingEngine(IEventReceiver *eventReceiver);
@@ -113,9 +114,8 @@ public:
 
 	void draw_load_screen(const std::wstring &text,
 			gui::IGUIEnvironment *guienv, ITextureSource *tsrc,
-			float dtime = 0, int percent = 0, bool clouds = true);
+			float dtime = 0, int percent = 0, bool sky = true);
 
-	void draw_menu_scene(gui::IGUIEnvironment *guienv, float dtime, bool clouds);
 	void draw_scene(video::SColor skycolor, bool show_hud,
 			bool show_minimap, bool draw_wield_tool, bool draw_crosshair);
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -252,8 +252,6 @@ void GUIEngine::run()
 	irr::core::dimension2d<u32> previous_screen_size(g_settings->getU16("screen_w"),
 		g_settings->getU16("screen_h"));
 
-	static const video::SColor sky_color(255, 140, 186, 250);
-
 	// Reset fog color
 	{
 		video::SColor fog_color;
@@ -266,8 +264,8 @@ void GUIEngine::run()
 		driver->getFog(fog_color, fog_type, fog_start, fog_end, fog_density,
 				fog_pixelfog, fog_rangefog);
 
-		driver->setFog(sky_color, fog_type, fog_start, fog_end, fog_density,
-				fog_pixelfog, fog_rangefog);
+		driver->setFog(RenderingEngine::MENU_SKY_COLOR, fog_type, fog_start,
+				fog_end, fog_density, fog_pixelfog, fog_rangefog);
 	}
 
 	while (m_rendering_engine->run() && (!m_startgame) && (!m_kill)) {
@@ -291,7 +289,7 @@ void GUIEngine::run()
 			text_height = g_fontengine->getTextHeight();
 		}
 
-		driver->beginScene(true, true, sky_color);
+		driver->beginScene(true, true, RenderingEngine::MENU_SKY_COLOR);
 
 		if (m_clouds_enabled)
 		{


### PR DESCRIPTION
Fixes #13317

On `master`, the loading screen background is black if `menu_clouds = false`, with this PR, the loading screen background is sky-colored if `menu_clouds = false`.

The loading screen still doesn't have the same (game-provided) background as the main menu with this PR, that would be a feature and not a bugfix.

Related: #13058 (customizable loading screen)

## To do

This PR is a Ready for Review.

## How to test

Verify that the loading screen has a blue background when `menu_clouds = false`. Also verify that the look of the loading screen with `menu_clouds = true` and the look of the "unloading" / "leaving world" screen haven't changed.