### PR TITLE
Fix empty port assertion error in 'Join Game' menu.

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -400,7 +400,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	if fields.btn_mp_register and host_filled then
 		local idx = core.get_table_index("servers")
 		local server = idx and tabdata.lookup[idx]
-		if server and server.address ~= fields.te_address or server.port ~= te_port_number then
+		if server and (server.address ~= fields.te_address or server.port ~= te_port_number) then
 			server = nil
 		end
 

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -400,7 +400,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	if fields.btn_mp_register and host_filled then
 		local idx = core.get_table_index("servers")
 		local server = idx and tabdata.lookup[idx]
-		if server and (server.address ~= fields.te_address or server.port ~= te_port_number then
+		if server and server.address ~= fields.te_address or server.port ~= te_port_number then
 			server = nil
 		end
 

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -346,12 +346,8 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		return true
 	end
 
+	local host_filled = (fields.te_address ~= "") and fields.te_port:match("^%s*[1-9][0-9]*%s*$")
 	local te_port_number = tonumber(fields.te_port)
-	-- te_port_number will be nil if input is not a number
-	-- '%1' gets fractional part, which is zero for integers
-	-- '1/0' is infinity, which a port cannot be
-	local host_filled = (fields.te_address ~= "") and te_port_number
-		and (te_port_number > 0) and (te_port_number ~= 1/0) and (te_port_number % 1 == 0)
 
 	if (fields.btn_mp_login or fields.key_enter) and host_filled then
 		gamedata.playername = fields.te_name

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -349,7 +349,9 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	local te_port_number = tonumber(fields.te_port)
 	-- te_port_number will be nil if input is not a number
 	-- '%1' gets fractional part, which is zero for integers
-	local host_filled = (fields.te_address ~= "") and te_port_number and (te_port_number % 1 == 0)
+	-- '1/0' is infinity, which a port cannot be
+	local host_filled = (fields.te_address ~= "") and te_port_number
+		and (te_port_number > 0) and (te_port_number ~= 1/0) and (te_port_number % 1 == 0)
 
 	if (fields.btn_mp_login or fields.key_enter) and host_filled then
 		gamedata.playername = fields.te_name

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -346,12 +346,16 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		return true
 	end
 
-	if (fields.btn_mp_login or fields.key_enter)
-			and fields.te_address ~= "" and fields.te_port then
+	local te_port_number = tonumber(fields.te_port)
+	-- te_port_number will be nil if input is not a number
+	-- '%1' gets fractional part, which is zero for integers
+	local host_filled = (fields.te_address ~= "") and te_port_number and (te_port_number % 1 == 0)
+
+	if (fields.btn_mp_login or fields.key_enter) and host_filled then
 		gamedata.playername = fields.te_name
 		gamedata.password   = fields.te_pwd
 		gamedata.address    = fields.te_address
-		gamedata.port       = tonumber(fields.te_port)
+		gamedata.port       = te_port_number
 
 		local enable_split_login_register = core.settings:get_bool("enable_split_login_register")
 		gamedata.allow_login_or_register = enable_split_login_register and "login" or "any"
@@ -391,10 +395,10 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		return true
 	end
 
-	if fields.btn_mp_register and fields.te_address ~= "" and fields.te_port then
+	if fields.btn_mp_register and host_filled then
 		local idx = core.get_table_index("servers")
 		local server = idx and tabdata.lookup[idx]
-		if server and (server.address ~= fields.te_address or server.port ~= tonumber(fields.te_port)) then
+		if server and (server.address ~= fields.te_address or server.port ~= te_port_number then
 			server = nil
 		end
 
@@ -403,7 +407,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 			return true
 		end
 
-		local dlg = create_register_dialog(fields.te_address, tonumber(fields.te_port), server)
+		local dlg = create_register_dialog(fields.te_address, te_port_number, server)
 		dlg:set_parent(tabview)
 		tabview:hide()
 		dlg:show()


### PR DESCRIPTION
Pressing 'Register' when the port field was empty led to an assertion error inside `create_register_dialog`, it was simply checking the port was a number.
This was not checked in the caller, it blindly `tonumber`ed and assumed all was well.
Checks are now added to ensure it is a number, with the bonus of also checking it's a valid integer port.
It may be better to warn the user it is empty rather than simply doing nothing, however that is not done here.

Original error (empty port field):
```
Main menu error: Runtime error from mod '??' in callback handleMainMenuButtons(): ...\builtin\mainmenu\dlg_register.lua:112: assertion failed!
stack traceback:
    [C]: in function 'assert'
    ...\builtin\mainmenu\dlg_register.lua:112: in function 'create_register_dialog'
    ...\builtin\mainmenu\tab_online.lua:406: in function 'handle_buttons'
    ...\builtin\fstk\ui.lua:142: in function 'handle_buttons'
    ...\builtin\fstk\ui.lua:186: in function <...\builtin\fstk\ui.lua:172>
```

***This PR is a trivial bug fix, ready for review.***