### PR TITLE
Add wear bar color API

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2387,6 +2387,75 @@ Table of resulting tool uses:
 
 
 
+Wear Bar Color
+==============
+
+'Wear Bar' is a property of items that defines the coloring
+of the bar that appears under damaged tools.
+If it is absent, the old behavior of green, yellow, red is
+used.
+
+Wear bar colors definition
+--------------------------
+
+### Syntax
+
+For non-blending mode:
+```lua
+{
+    {
+        color="#ff00ff",
+        min_durability=0.2, -- minimum durability is inclusive
+        max_durability=0.3  -- maximum durability is exclusive
+    },
+    {
+        color="#c0ffee",
+        min_durability=0.45,
+        max_durability=0.6
+    },
+    default="#ffff00",      -- color to use if no other ranges match the durability
+    blend=false
+}
+```
+
+For blending mode:
+```lua
+{
+    [0.2] = "#ff00ff",      -- specify color for a specific durability percent, and blend between them
+    [0.45] = "#c0ffee",
+    default="#ffff00",      -- used for 0.0% and 100.0% durability if no color explicitly specified
+    blend=true
+}
+```
+
+### Blend Mode `blend`
+
+When true, blends smoothly between each defined color point.
+When false, no interpolation is used, and instead colors are defined for ranges of durabilities.
+`blend` is optional and defaults false.
+
+### Default Color `default`
+
+When `blend` is false, the color to use if the percentage of remaining durability does not match any values.
+When `blend` is true, the color to use on the 'outside' of the range of colors, if no such color is defined
+
+### Color values
+
+In blending mode, specified as `float` keys assigned to a `ColorString` values.
+In non-blending mode, specified as tables containing the following keys:
+* `min_durability`: `float`, minimum durability to show color at (inclusive)
+* `max_durability`: `float`, maximum durability to show color at (exclusive)
+* `color`:          `ColorString`, color to use for bar in the specified range
+
+### Shortcut usage
+
+Wear bar color can also be specified as a single `ColorString` instead of a table.
+In this case, it is automatically converted to a table, where there are no color points,
+`blend` is false, and `default` is the specified `ColorString`.
+
+
+
+
 Entity damage mechanism
 =======================
 
@@ -7314,6 +7383,10 @@ Can be obtained via `item:get_meta()`.
     * Overrides the item's tool capabilities
     * A nil value will clear the override data and restore the original
       behavior.
+* `set_wear_bar_params([wear_bar_params])`
+    * Overrides the item's wear bar parameters (see "Wear Bar Color" section)
+    * A nil value will clear the override data and restore the original
+      behavior.
 
 `MetaDataRef`
 -------------
@@ -8814,13 +8887,29 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         -- fallback behavior.
     },
 
-    node_placement_prediction = nil,
-    -- If nil and item is node, prediction is made automatically.
-    -- If nil and item is not a node, no prediction is made.
-    -- If "" and item is anything, no prediction is made.
-    -- Otherwise should be name of node which the client immediately places
-    -- on ground when the player places the item. Server will always update
-    -- with actual result shortly.
+    -- See "Wear Bar Color" section for an example including explanation
+        wear_color = {
+            {
+                color="#ff00ff",
+                min_durability=0.2,
+                max_durability=0.3
+            },
+            {
+                color="#c0ffee",
+                min_durability=0.45,
+                max_durability=0.6
+            },
+            default="#ffff00",
+            blend=false
+        }
+
+        node_placement_prediction = nil,
+        -- If nil and item is node, prediction is made automatically.
+        -- If nil and item is not a node, no prediction is made.
+        -- If "" and item is anything, no prediction is made.
+        -- Otherwise should be name of node which the client immediately places
+        -- on ground when the player places the item. Server will always update
+        -- with actual result shortly.
 
     node_dig_prediction = "air",
     -- if "", no prediction is made.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2416,7 +2416,7 @@ Wear bar colors definition
 ### Blend mode `blend`
 
 * `linear`: blends smoothly between each defined color point.
-* `constant`: each color starts at its defined point, and continues up to to the next point
+* `constant`: each color starts at its defined point, and continues up to the next point
 
 ### Color stops `color_stops`
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8910,13 +8910,13 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         -- whether to blend the colors
     }
 
-        node_placement_prediction = nil,
-        -- If nil and item is node, prediction is made automatically.
-        -- If nil and item is not a node, no prediction is made.
-        -- If "" and item is anything, no prediction is made.
-        -- Otherwise should be name of node which the client immediately places
-        -- on ground when the player places the item. Server will always update
-        -- with actual result shortly.
+    node_placement_prediction = nil,
+    -- If nil and item is node, prediction is made automatically.
+    -- If nil and item is not a node, no prediction is made.
+    -- If "" and item is anything, no prediction is made.
+    -- Otherwise should be name of node which the client immediately places
+    -- on ground when the player places the item. Server will always update
+    -- with actual result shortly.
 
     node_dig_prediction = "air",
     -- if "", no prediction is made.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2400,62 +2400,31 @@ Wear bar colors definition
 
 ### Syntax
 
-For non-blending mode:
 ```lua
 {
-    {
-        color = "#ff00ff",
-        min_durability = 0.2, -- inclusive
-        max_durability = 0.3  -- exclusive
-    },
-    {
-        color = "#c0ffee",
-        min_durability = 0.45,
-        max_durability = 0.6
-    },
-    -- color to use if no other ranges match the durability
-    default = "#ffff00",
-    blend = false
-}
-```
-
-For blending mode:
-```lua
-{
-    -- specify color for a specific durability percent, and blend between them
-    [0.2] = "#ff00ff",
-    [0.45] = "#c0ffee",
-    -- used for 0% and 100% durability if no color explicitly specified
-    default = "#ffff00",
-    blend = true
+    -- 'constant' or 'linear'
+    -- (nil defaults to 'constant')
+    blend = "linear",
+    color_stops = {
+        [0.0] = "#ff0000",
+        [0.5] = "slateblue",
+        [1.0] = {r=0, g=255, b=0, a=150},
+    }
 }
 ```
 
 ### Blend mode `blend`
 
-* If true, it blends smoothly between each defined color point.
-* If false, no interpolation is used and instead colors are defined for ranges of durabilities.
-`blend` is optional and defaults false.
+* `linear`: blends smoothly between each defined color point.
+* `constant`: each color starts at its defined point, and continues up to to the next point
 
-### Default color `default`
+### Color stops `color_stops`
 
-* If `blend` is false, the color to use if the percentage of remaining durability does not match any values.
-* If `blend` is true, the color to use on the outside of the range of colors if no such color is defined.
-
-### Color values
-
-In blending mode, specified as `float` keys assigned to a `ColorString` values.
-
-In non-blending mode, specified as tables containing the following keys:
-* `min_durability`: `float`, minimum durability to show color at (inclusive)
-* `max_durability`: `float`, maximum durability to show color at (exclusive)
-* `color`: `ColorString`, color to use for bar in the specified range
+Specified as `float` keys assigned to `ColorSpec` values.
 
 ### Shortcut usage
 
-Wear bar color can also be specified as a single `ColorString` instead of a table.
-In this case, it is automatically converted to a table, where there are no color points,
-`blend` is false, and `default` is the specified `ColorString`.
+Wear bar color can also be specified as a single `ColorSpec` instead of a table.
 
 
 
@@ -8893,23 +8862,17 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         -- fallback behavior.
     },
 
-    -- Set wear bar color of the tool by setting color points or ranges
-    -- See "Wear Bar Color" section for further explanation including example
+    -- Set wear bar color of the tool by setting color stops and blend mode
+    -- See "Wear Bar Color" section for further explanation including an example
     wear_color = {
-        {
-            color = "#ff00ff",
-            min_durability = 0.2,
-            max_durability = 0.3
-        },
-        {
-            color = "#c0ffee",
-            min_durability = 0.45,
-            max_durability = 0.6
-        },
-        default = "#ffff00",
-        -- default color for fallback
-        blend = false
-        -- whether to blend the colors
+        -- interpolation mode: 'constant' or 'linear'
+        -- (nil defaults to 'constant')
+        blend = "linear",
+        color_stops = {
+            [0.0] = "#ff0000",
+            [0.5] = "#ffff00",
+            [1.0] = "#00ff00",
+        }
     },
 
     node_placement_prediction = nil,

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2422,10 +2422,10 @@ For non-blending mode:
 For blending mode:
 ```lua
 {
-	-- specify color for a specific durability percent, and blend between them
+    -- specify color for a specific durability percent, and blend between them
     [0.2] = "#ff00ff",
     [0.45] = "#c0ffee",
-	-- used for 0% and 100% durability if no color explicitly specified
+    -- used for 0% and 100% durability if no color explicitly specified
     default = "#ffff00",
     blend = true
 }

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2387,48 +2387,6 @@ Table of resulting tool uses:
 
 
 
-Wear Bar Color
-==============
-
-'Wear Bar' is a property of items that defines the coloring
-of the bar that appears under damaged tools.
-If it is absent, the old behavior of green-yellow-red is
-used.
-
-Wear bar colors definition
---------------------------
-
-### Syntax
-
-```lua
-{
-    -- 'constant' or 'linear'
-    -- (nil defaults to 'constant')
-    blend = "linear",
-    color_stops = {
-        [0.0] = "#ff0000",
-        [0.5] = "slateblue",
-        [1.0] = {r=0, g=255, b=0, a=150},
-    }
-}
-```
-
-### Blend mode `blend`
-
-* `linear`: blends smoothly between each defined color point.
-* `constant`: each color starts at its defined point, and continues up to the next point
-
-### Color stops `color_stops`
-
-Specified as `float` keys assigned to `ColorSpec` values.
-
-### Shortcut usage
-
-Wear bar color can also be specified as a single `ColorSpec` instead of a table.
-
-
-
-
 Entity damage mechanism
 =======================
 
@@ -9440,6 +9398,44 @@ Used by `minetest.register_node`.
     -- nodename will show "othermodname", but mod_origin will say "modname"
 }
 ```
+
+Wear Bar Color
+--------------
+
+'Wear Bar' is a property of items that defines the coloring
+of the bar that appears under damaged tools.
+If it is absent, the default behavior of green-yellow-red is
+used.
+
+### Wear bar colors definition
+
+#### Syntax
+
+```lua
+{
+    -- 'constant' or 'linear'
+    -- (nil defaults to 'constant')
+    blend = "linear",
+    color_stops = {
+        [0.0] = "#ff0000",
+        [0.5] = "slateblue",
+        [1.0] = {r=0, g=255, b=0, a=150},
+    }
+}
+```
+
+#### Blend mode `blend`
+
+* `linear`: blends smoothly between each defined color point.
+* `constant`: each color starts at its defined point, and continues up to the next point
+
+#### Color stops `color_stops`
+
+Specified as `ColorSpec` color values assigned to `float` durability keys.
+
+#### Shortcut usage
+
+Wear bar color can also be specified as a single `ColorSpec` instead of a table.
 
 Crafting recipes
 ----------------

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2392,7 +2392,7 @@ Wear Bar Color
 
 'Wear Bar' is a property of items that defines the coloring
 of the bar that appears under damaged tools.
-If it is absent, the old behavior of green, yellow, red is
+If it is absent, the old behavior of green-yellow-red is
 used.
 
 Wear bar colors definition

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2404,48 +2404,52 @@ For non-blending mode:
 ```lua
 {
     {
-        color="#ff00ff",
-        min_durability=0.2, -- minimum durability is inclusive
-        max_durability=0.3  -- maximum durability is exclusive
+        color = "#ff00ff",
+        min_durability = 0.2, -- inclusive
+        max_durability = 0.3  -- exclusive
     },
     {
-        color="#c0ffee",
-        min_durability=0.45,
-        max_durability=0.6
+        color = "#c0ffee",
+        min_durability = 0.45,
+        max_durability = 0.6
     },
-    default="#ffff00",      -- color to use if no other ranges match the durability
-    blend=false
+    -- color to use if no other ranges match the durability
+    default = "#ffff00",
+    blend = false
 }
 ```
 
 For blending mode:
 ```lua
 {
-    [0.2] = "#ff00ff",      -- specify color for a specific durability percent, and blend between them
+	-- specify color for a specific durability percent, and blend between them
+    [0.2] = "#ff00ff",
     [0.45] = "#c0ffee",
-    default="#ffff00",      -- used for 0.0% and 100.0% durability if no color explicitly specified
-    blend=true
+	-- used for 0% and 100% durability if no color explicitly specified
+    default = "#ffff00",
+    blend = true
 }
 ```
 
-### Blend Mode `blend`
+### Blend mode `blend`
 
-When true, blends smoothly between each defined color point.
-When false, no interpolation is used, and instead colors are defined for ranges of durabilities.
+* If true, it blends smoothly between each defined color point.
+* If false, no interpolation is used and instead colors are defined for ranges of durabilities.
 `blend` is optional and defaults false.
 
-### Default Color `default`
+### Default color `default`
 
-When `blend` is false, the color to use if the percentage of remaining durability does not match any values.
-When `blend` is true, the color to use on the 'outside' of the range of colors, if no such color is defined
+* If `blend` is false, the color to use if the percentage of remaining durability does not match any values.
+* If `blend` is true, the color to use on the outside of the range of colors if no such color is defined.
 
 ### Color values
 
 In blending mode, specified as `float` keys assigned to a `ColorString` values.
+
 In non-blending mode, specified as tables containing the following keys:
 * `min_durability`: `float`, minimum durability to show color at (inclusive)
 * `max_durability`: `float`, maximum durability to show color at (exclusive)
-* `color`:          `ColorString`, color to use for bar in the specified range
+* `color`: `ColorString`, color to use for bar in the specified range
 
 ### Shortcut usage
 
@@ -8887,21 +8891,24 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         -- fallback behavior.
     },
 
-    -- See "Wear Bar Color" section for an example including explanation
-        wear_color = {
-            {
-                color="#ff00ff",
-                min_durability=0.2,
-                max_durability=0.3
-            },
-            {
-                color="#c0ffee",
-                min_durability=0.45,
-                max_durability=0.6
-            },
-            default="#ffff00",
-            blend=false
-        }
+    -- Set wear bar color of the tool by setting color points or ranges
+    -- See "Wear Bar Color" section for further explanation including example
+    wear_color = {
+        {
+            color = "#ff00ff",
+            min_durability = 0.2,
+            max_durability = 0.3
+        },
+        {
+            color = "#c0ffee",
+            min_durability = 0.45,
+            max_durability = 0.6
+        },
+        default = "#ffff00",
+        -- default color for fallback
+        blend = false
+        -- whether to blend the colors
+    }
 
         node_placement_prediction = nil,
         -- If nil and item is node, prediction is made automatically.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7346,6 +7346,8 @@ an itemstring, a table or `nil`.
       the item breaks after `max_uses` times
     * Valid `max_uses` range is [0,65536]
     * Does nothing if item is not a tool or if `max_uses` is 0
+* `get_wear_bar_params()`: returns the wear bar parameters of the item,
+  or nil if none are defined for this item type or in the stack's meta
 * `add_item(item)`: returns leftover `ItemStack`
     * Put some item or stack onto this stack
 * `item_fits(item)`: returns `true` if item or stack can be fully added to
@@ -8908,7 +8910,7 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         -- default color for fallback
         blend = false
         -- whether to blend the colors
-    }
+    },
 
     node_placement_prediction = nil,
     -- If nil and item is node, prediction is made automatically.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9433,6 +9433,8 @@ used.
 
 Specified as `ColorSpec` color values assigned to `float` durability keys.
 
+"Durability" is defined as `1 - (wear / 65535)`.
+
 #### Shortcut usage
 
 Wear bar color can also be specified as a single `ColorSpec` instead of a table.

--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -436,7 +436,7 @@ local wear_colors = { nil, nil, nil, "#5865f2", "slateblue", {blend=true, defaul
                                                                                                                                                default="#ffff00",      -- color to use if no other ranges match the durability
                                                                                                                                                blend=false
                                                                                                                                            }, nil, nil, nil }
-local wear_color_desc = { nil, nil, nil, "Solid color: #5865f2", "Solid color: slateblue", "Range from thistle to blue to red", "Random blocks", nil, nil, nil }
+local wear_color_desc = { nil, nil, nil, "Solid color: #5865f2", "Solid color: slateblue", "Ranges from blue to yellow to red", "Random blocks", nil, nil, nil }
 for i=1, #uses do
 	local u = uses[i]
 	local wc = wear_colors[i]

--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -472,8 +472,8 @@ for i, params in ipairs(tool_params) do
 	local color = string.format("#FF00%02X", math.floor(((i-1)/#tool_params) * 255))
 	minetest.register_tool("basetools:pick_uses_"..string.format("%05d", uses), {
 		description = ustring.." Pickaxe".."\n"..
-			"Digs cracky=3".."\n"..
-			(params.wear_description and "Wear bar: " .. params.wear_description or ""),
+			"Digs cracky=3"..
+			(params.wear_description and "\n".."Wear bar: " .. params.wear_description or ""),
 		inventory_image = "basetools_usespick.png^[colorize:"..color..":127",
 		tool_capabilities = {
 			max_drop_level=0,

--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -435,7 +435,7 @@ local wear_colors = { nil, nil, nil, "#5865f2", "slateblue",
            min_durability = 0.45,
            max_durability = 0.6
        },
-       default=  "#ffff00",      -- color to use if no other ranges match the durability
+       default = "#ffff00",      -- color to use if no other ranges match the durability
        blend = false
     }, nil, nil, nil }
 local wear_color_desc = { nil, nil, nil, "Solid color: #5865f2", "Solid color: slateblue", "Ranges from blue to yellow to red", "Random blocks", nil, nil, nil }

--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -436,7 +436,7 @@ local wear_colors = { nil, nil, nil, "#5865f2", "slateblue", {blend=true, defaul
                                                                                                                                                default="#ffff00",      -- color to use if no other ranges match the durability
                                                                                                                                                blend=false
                                                                                                                                            }, nil, nil, nil }
-local wear_color_desc = { nil, nil, nil, "Solid color: #5865f2", "Solid color: slateblue", "Ranges from blue to yellow to red", "Random blocks", nil, nil, nil }
+local wear_color_desc = { nil, nil, nil, "Solid color: #5865f2", "Solid color: slateblue", "Range from thistle to blue to red", "Random blocks", nil, nil, nil }
 for i=1, #uses do
 	local u = uses[i]
 	local wc = wear_colors[i]

--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -423,20 +423,20 @@ minetest.register_tool("basetools:dagger_steel", {
 -- Test tool uses, punch_attack_uses, and wear bar coloring
 local uses = { 1, 2, 3, 5, 10, 50, 100, 1000, 10000, 65535 }
 local wear_colors = { nil, nil, nil, "#5865f2", "slateblue",
-    {blend=true, default="#ff00ff", [0.0]="red", [0.5]="yellow", [1.0]="blue"},
+    {blend = true, default = "#ff00ff", [0.0] = "red", [0.5] = "yellow", [1.0] = "blue"},
     {
         {
-           color="#ff00ff",
-           min_durability=0.2, -- minimum durability is inclusive
-           max_durability=0.3  -- maximum durability is exclusive
+           color = "#ff00ff",
+           min_durability = 0.2, -- minimum durability is inclusive
+           max_durability = 0.3  -- maximum durability is exclusive
        },
        {
-           color="#c0ffee",
-           min_durability=0.45,
-           max_durability=0.6
+           color = "#c0ffee",
+           min_durability = 0.45,
+           max_durability = 0.6
        },
-       default="#ffff00",      -- color to use if no other ranges match the durability
-       blend=false
+       default=  "#ffff00",      -- color to use if no other ranges match the durability
+       blend = false
     }, nil, nil, nil }
 local wear_color_desc = { nil, nil, nil, "Solid color: #5865f2", "Solid color: slateblue", "Ranges from blue to yellow to red", "Random blocks", nil, nil, nil }
 for i=1, #uses do

--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -422,20 +422,22 @@ minetest.register_tool("basetools:dagger_steel", {
 
 -- Test tool uses, punch_attack_uses, and wear bar coloring
 local uses = { 1, 2, 3, 5, 10, 50, 100, 1000, 10000, 65535 }
-local wear_colors = { nil, nil, nil, "#5865f2", "slateblue", {blend=true, default="#ff00ff", [0.0]="red", [0.5]="yellow", [1.0]="blue"}, {
-                                                                                                                                               {
-                                                                                                                                                   color="#ff00ff",
-                                                                                                                                                   min_durability=0.2, -- minimum durability is inclusive
-                                                                                                                                                   max_durability=0.3  -- maximum durability is exclusive
-                                                                                                                                               },
-                                                                                                                                               {
-                                                                                                                                                   color="#c0ffee",
-                                                                                                                                                   min_durability=0.45,
-                                                                                                                                                   max_durability=0.6
-                                                                                                                                               },
-                                                                                                                                               default="#ffff00",      -- color to use if no other ranges match the durability
-                                                                                                                                               blend=false
-                                                                                                                                           }, nil, nil, nil }
+local wear_colors = { nil, nil, nil, "#5865f2", "slateblue",
+    {blend=true, default="#ff00ff", [0.0]="red", [0.5]="yellow", [1.0]="blue"},
+    {
+        {
+           color="#ff00ff",
+           min_durability=0.2, -- minimum durability is inclusive
+           max_durability=0.3  -- maximum durability is exclusive
+       },
+       {
+           color="#c0ffee",
+           min_durability=0.45,
+           max_durability=0.6
+       },
+       default="#ffff00",      -- color to use if no other ranges match the durability
+       blend=false
+    }, nil, nil, nil }
 local wear_color_desc = { nil, nil, nil, "Solid color: #5865f2", "Solid color: slateblue", "Ranges from blue to yellow to red", "Random blocks", nil, nil, nil }
 for i=1, #uses do
 	local u = uses[i]

--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -423,20 +423,23 @@ minetest.register_tool("basetools:dagger_steel", {
 -- Test tool uses, punch_attack_uses, and wear bar coloring
 local uses = { 1, 2, 3, 5, 10, 50, 100, 1000, 10000, 65535 }
 local wear_colors = { nil, nil, nil, "#5865f2", "slateblue",
-    {blend = true, default = "#ff00ff", [0.0] = "red", [0.5] = "yellow", [1.0] = "blue"},
     {
-        {
-           color = "#ff00ff",
-           min_durability = 0.2, -- minimum durability is inclusive
-           max_durability = 0.3  -- maximum durability is exclusive
-       },
-       {
-           color = "#c0ffee",
-           min_durability = 0.45,
-           max_durability = 0.6
-       },
-       default = "#ffff00",      -- color to use if no other ranges match the durability
-       blend = false
+    	color_stops = {
+    		[0] = "red",
+    		[0.5] = "yellow",
+    		[1.0] = "blue"
+    	},
+    	blend = "linear"
+    },
+    {
+    	color_stops = {
+    		[0] = "#ffff00",
+    		[0.2] = "#ff00ff",
+    		[0.3] = "#ffff00",
+    		[0.45] = "#c0ffee",
+    		[0.6] = {r=255, g=255, b=0, a=100}, -- continues until the end
+    	},
+    	blend = "constant"
     }, nil, nil, nil }
 local wear_color_desc = { nil, nil, nil, "Solid color: #5865f2", "Solid color: slateblue", "Ranges from blue to yellow to red", "Random blocks", nil, nil, nil }
 for i=1, #uses do

--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -423,24 +423,24 @@ minetest.register_tool("basetools:dagger_steel", {
 -- Test tool uses, punch_attack_uses, and wear bar coloring
 local uses = { 1, 2, 3, 5, 10, 50, 100, 1000, 10000, 65535 }
 local wear_colors = { nil, nil, nil, "#5865f2", "slateblue",
-    {
-    	color_stops = {
-    		[0] = "red",
-    		[0.5] = "yellow",
-    		[1.0] = "blue"
-    	},
-    	blend = "linear"
-    },
-    {
-    	color_stops = {
-    		[0] = "#ffff00",
-    		[0.2] = "#ff00ff",
-    		[0.3] = "#ffff00",
-    		[0.45] = "#c0ffee",
-    		[0.6] = {r=255, g=255, b=0, a=100}, -- continues until the end
-    	},
-    	blend = "constant"
-    }, nil, nil, nil }
+	{
+		color_stops = {
+			[0] = "red",
+			[0.5] = "yellow",
+			[1.0] = "blue"
+		},
+		blend = "linear"
+	},
+	{
+		color_stops = {
+			[0] = "#ffff00",
+			[0.2] = "#ff00ff",
+			[0.3] = "#ffff00",
+			[0.45] = "#c0ffee",
+			[0.6] = {r=255, g=255, b=0, a=100}, -- continues until the end
+		},
+		blend = "constant"
+	}, nil, nil, nil }
 local wear_color_desc = { nil, nil, nil, "Solid color: #5865f2", "Solid color: slateblue", "Ranges from blue to yellow to red", "Random blocks", nil, nil, nil }
 for i=1, #uses do
 	local u = uses[i]
@@ -489,8 +489,8 @@ minetest.register_chatcommand("wear_color", {
 		local wear_desc = "Reset override"
 
 		if param ~= "" then
-		    wear_color = wear_colors[tonumber(param)]
-		    wear_desc = "Set override: "..(wear_color_desc[tonumber(param)] or "Default behavior")
+			wear_color = wear_colors[tonumber(param)]
+			wear_desc = "Set override: "..(wear_color_desc[tonumber(param)] or "Default behavior")
 		end
 		local tool = player:get_wielded_item()
 		if tool:get_count() == 0 then

--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -508,6 +508,7 @@ local wear_on_use = function(itemstack, user, pointed_thing)
 	minetest.log("action", "[basetool] Wear bar color of "..itemstack:get_name().." changed to "..colorstr)
 	return itemstack
 end
+
 -- Place handler to clear item metadata color
 local wear_on_place = function(itemstack, user, pointed_thing)
 	local meta = itemstack:get_meta()

--- a/games/devtest/mods/util_commands/init.lua
+++ b/games/devtest/mods/util_commands/init.lua
@@ -210,6 +210,31 @@ minetest.register_chatcommand("dump_item", {
 	end,
 })
 
+minetest.register_chatcommand("dump_itemdef", {
+	params = "",
+	description = "Prints a dump of the wielded item's definition in table form",
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+		local item = player:get_wielded_item()
+		local def = minetest.registered_items[item:get_name()]
+		local str = dump(def)
+		print(str)
+		return true, str
+	end,
+})
+
+minetest.register_chatcommand("dump_wear_bar", {
+	params = "",
+	description = "Prints a dump of the wielded item's wear bar parameters in table form",
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+		local item = player:get_wielded_item()
+		local str = dump(item:get_wear_bar_params())
+		print(str)
+		return true, str
+	end,
+})
+
 core.register_chatcommand("set_saturation", {
     params = "<saturation>",
     description = "Set the saturation for current player.",

--- a/games/devtest/mods/util_commands/init.lua
+++ b/games/devtest/mods/util_commands/init.lua
@@ -215,9 +215,7 @@ minetest.register_chatcommand("dump_itemdef", {
 	description = "Prints a dump of the wielded item's definition in table form",
 	func = function(name, param)
 		local player = minetest.get_player_by_name(name)
-		local item = player:get_wielded_item()
-		local def = minetest.registered_items[item:get_name()]
-		local str = dump(def)
+		local str = dump(player:get_wielded_item():get_definition())
 		print(str)
 		return true, str
 	end,

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1185,10 +1185,10 @@ void drawItemStack(
 		//   wear = 1.0: red
 
 		video::SColor color;
-		WearBarParams barParams;
-		if (item.getWearBarParams(client->idef(), barParams)) {
-			float durabilityPercent = 1.0 - wear;
-			color = barParams.getWearBarColor(durabilityPercent);
+		auto barParams = item.getWearBarParams(client->idef());
+		if (barParams.has_value()) {
+			f32 durabilityPercent = 1.0 - wear;
+			color = barParams->getWearBarColor(durabilityPercent);
 		} else {
 			color = video::SColor(255, 255, 255, 255);
 			int wear_i = MYMIN(std::floor(wear * 600), 511);

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1179,17 +1179,68 @@ void drawItemStack(
 			(1 - wear) * progressrect.LowerRightCorner.X;
 
 		// Compute progressbar color
+		// old scheme:
 		//   wear = 0.0: green
 		//   wear = 0.5: yellow
 		//   wear = 1.0: red
-		video::SColor color(255, 255, 255, 255);
-		int wear_i = MYMIN(std::floor(wear * 600), 511);
-		wear_i = MYMIN(wear_i + 10, 511);
 
-		if (wear_i <= 255)
-			color.set(255, wear_i, 255, 0);
-		else
-			color.set(255, 255, 511 - wear_i, 0);
+		video::SColor color;
+		WearBarParams barParams;
+		if (item.getWearBarParams(client->idef(), barParams)) {
+			float durabilityPercent = 1.0 - wear;
+			color = barParams.defaultColor;
+			if (barParams.blend) {
+				const video::SColor *upperBoundColor = &barParams.defaultColor;
+				const video::SColor *lowerBoundColor = &barParams.defaultColor;
+				float upperBound = 2.0f;
+				float lowerBound = -1.0f;
+				for (const WearBarParam &param : barParams.params) {
+					if (param.minPercent <= durabilityPercent && param.minPercent > lowerBound) {
+						lowerBound = param.minPercent;
+						lowerBoundColor = &param.color;
+					}
+					if (durabilityPercent < param.minPercent && param.minPercent < upperBound) {
+						upperBound = param.minPercent;
+						upperBoundColor = &param.color;
+					}
+				}
+				if (upperBound == 2.0f && lowerBound == -1.0f) {
+					color = *upperBoundColor;
+				} else {
+					if (upperBound == 2.0f) {
+						upperBound = 1.0f;
+					} else if (lowerBound == -1.0f) {
+						lowerBound = 0.0f;
+					}
+					float progress = (durabilityPercent-lowerBound)/(upperBound-lowerBound); //from lower to upper
+					u32 alpha = (progress * upperBoundColor->getAlpha()) + ((1.0f - progress) * lowerBoundColor->getAlpha());
+					u32 lb_red = lowerBoundColor->getRed();
+					u32 ub_red = upperBoundColor->getRed();
+					u32 red = (progress * ub_red) + ((1.0f - progress) * lb_red);
+					color = video::SColor(
+							alpha, // A
+							red,     // R
+							(progress * upperBoundColor->getGreen()) + ((1.0f - progress) * lowerBoundColor->getGreen()), // G
+							(progress * upperBoundColor->getBlue()) + ((1.0f - progress) * lowerBoundColor->getBlue()));  // B
+				}
+			} else {
+				for (const WearBarParam &param : barParams.params) {
+					if (param.matches(durabilityPercent)) {
+						color = param.color;
+						break;
+					}
+				}
+			}
+		} else {
+			color = video::SColor(255, 255, 255, 255);
+			int wear_i = MYMIN(std::floor(wear * 600), 511);
+			wear_i = MYMIN(wear_i + 10, 511);
+
+			if (wear_i <= 255)
+				color.set(255, wear_i, 255, 0);
+			else
+				color.set(255, 255, 511 - wear_i, 0);
+		}
 
 		core::rect<s32> progressrect2 = progressrect;
 		progressrect2.LowerRightCorner.X = progressmid;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1179,7 +1179,7 @@ void drawItemStack(
 			(1 - wear) * progressrect.LowerRightCorner.X;
 
 		// Compute progressbar color
-		// old scheme:
+		// default scheme:
 		//   wear = 0.0: green
 		//   wear = 0.5: yellow
 		//   wear = 1.0: red

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1212,7 +1212,7 @@ void drawItemStack(
 					} else if (lowerBound == -1.0f) {
 						lowerBound = 0.0f;
 					}
-					float progress = (durabilityPercent-lowerBound)/(upperBound-lowerBound); //from lower to upper
+					float progress = (durabilityPercent - lowerBound) / (upperBound - lowerBound); //from lower to upper
 					u32 alpha = (progress * upperBoundColor->getAlpha()) + ((1.0f - progress) * lowerBoundColor->getAlpha());
 					u32 lb_red = lowerBoundColor->getRed();
 					u32 ub_red = upperBoundColor->getRed();

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1188,49 +1188,7 @@ void drawItemStack(
 		WearBarParams barParams;
 		if (item.getWearBarParams(client->idef(), barParams)) {
 			float durabilityPercent = 1.0 - wear;
-			color = barParams.defaultColor;
-			if (barParams.blend) {
-				const video::SColor *upperBoundColor = &barParams.defaultColor;
-				const video::SColor *lowerBoundColor = &barParams.defaultColor;
-				float upperBound = 2.0f;
-				float lowerBound = -1.0f;
-				for (const WearBarParam &param : barParams.params) {
-					if (param.minPercent <= durabilityPercent && param.minPercent > lowerBound) {
-						lowerBound = param.minPercent;
-						lowerBoundColor = &param.color;
-					}
-					if (durabilityPercent < param.minPercent && param.minPercent < upperBound) {
-						upperBound = param.minPercent;
-						upperBoundColor = &param.color;
-					}
-				}
-				if (upperBound == 2.0f && lowerBound == -1.0f) {
-					color = *upperBoundColor;
-				} else {
-					if (upperBound == 2.0f) {
-						upperBound = 1.0f;
-					} else if (lowerBound == -1.0f) {
-						lowerBound = 0.0f;
-					}
-					float progress = (durabilityPercent - lowerBound) / (upperBound - lowerBound); //from lower to upper
-					u32 alpha = (progress * upperBoundColor->getAlpha()) + ((1.0f - progress) * lowerBoundColor->getAlpha());
-					u32 lb_red = lowerBoundColor->getRed();
-					u32 ub_red = upperBoundColor->getRed();
-					u32 red = (progress * ub_red) + ((1.0f - progress) * lb_red);
-					color = video::SColor(
-							alpha, // A
-							red,     // R
-							(progress * upperBoundColor->getGreen()) + ((1.0f - progress) * lowerBoundColor->getGreen()), // G
-							(progress * upperBoundColor->getBlue()) + ((1.0f - progress) * lowerBoundColor->getBlue()));  // B
-				}
-			} else {
-				for (const WearBarParam &param : barParams.params) {
-					if (param.matches(durabilityPercent)) {
-						color = param.color;
-						break;
-					}
-				}
-			}
+			color = barParams.getWearBarColor(durabilityPercent);
 		} else {
 			color = video::SColor(255, 255, 255, 255);
 			int wear_i = MYMIN(std::floor(wear * 600), 511);

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -131,6 +131,21 @@ struct ItemStack
 		return metadata.getToolCapabilities(*item_cap); // Check for override
 	}
 
+	// Get wear bar parameters, returning true if they exist
+	bool getWearBarParams(
+			const IItemDefManager *itemdef,
+			WearBarParams &params
+			) const
+	{
+		WearBarParams *params_ = itemdef->get(name).wear_bar_params;
+
+		if (params_ == NULL)
+			return metadata.getWearBarParamOverride(params);
+
+		params = metadata.getWearBarParams(*params_);
+		return true;
+	}
+
 	// Wear out (only tools)
 	// Returns true if the item is (was) a tool
 	bool addWear(s32 amount, const IItemDefManager *itemdef)

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -134,8 +134,7 @@ struct ItemStack
 	// Get wear bar parameters, returning true if they exist
 	bool getWearBarParams(
 			const IItemDefManager *itemdef,
-			WearBarParams &params
-			) const
+			WearBarParams &params) const
 	{
 		WearBarParams *params_ = itemdef->get(name).wear_bar_params;
 

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -136,12 +136,12 @@ struct ItemStack
 			const IItemDefManager *itemdef,
 			WearBarParams &params) const
 	{
-		WearBarParams *params_ = itemdef->get(name).wear_bar_params;
+		std::optional<WearBarParams *> params_ = itemdef->get(name).wear_bar_params;
 
-		if (params_ == NULL)
+		if (!params_.has_value())
 			return metadata.getWearBarParamOverride(params);
 
-		params = metadata.getWearBarParams(*params_);
+		params = metadata.getWearBarParams(*params_.value());
 		return true;
 	}
 

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -131,18 +131,13 @@ struct ItemStack
 		return metadata.getToolCapabilities(*item_cap); // Check for override
 	}
 
-	// Get wear bar parameters, returning true if they exist
-	bool getWearBarParams(
-			const IItemDefManager *itemdef,
-			WearBarParams &params) const
+	const std::optional<WearBarParams> &getWearBarParams(
+			const IItemDefManager *itemdef) const
 	{
-		std::optional<WearBarParams *> params_ = itemdef->get(name).wear_bar_params;
-
-		if (!params_.has_value())
-			return metadata.getWearBarParamOverride(params);
-
-		params = metadata.getWearBarParams(*params_.value());
-		return true;
+		auto &meta_override = metadata.getWearBarParamOverride();
+		if (meta_override.has_value())
+			return meta_override;
+		return itemdef->get(name).wear_bar_params;
 	}
 
 	// Wear out (only tools)

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -125,6 +125,8 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	pointabilities = def.pointabilities;
 	if (def.tool_capabilities)
 		tool_capabilities = new ToolCapabilities(*def.tool_capabilities);
+	if (def.wear_bar_params)
+		wear_bar_params = new WearBarParams(*def.wear_bar_params);
 	groups = def.groups;
 	node_placement_prediction = def.node_placement_prediction;
 	place_param2 = def.place_param2;
@@ -149,6 +151,7 @@ void ItemDefinition::resetInitial()
 {
 	// Initialize pointers to NULL so reset() does not delete undefined pointers
 	tool_capabilities = NULL;
+	wear_bar_params = NULL;
 	reset();
 }
 
@@ -171,6 +174,8 @@ void ItemDefinition::reset()
 	pointabilities = std::nullopt;
 	delete tool_capabilities;
 	tool_capabilities = NULL;
+	delete wear_bar_params;
+	wear_bar_params = NULL;
 	groups.clear();
 	sound_place = SoundSpec();
 	sound_place_failed = SoundSpec();
@@ -251,6 +256,13 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 		pointabilities_s = tmp_os.str();
 	}
 	os << serializeString16(pointabilities_s);
+
+	if (wear_bar_params) {
+		writeU8(os, 1);
+		wear_bar_params->serialize(os, protocol_version);
+	} else {
+		writeU8(os, 0);
+	}
 }
 
 void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
@@ -332,6 +344,11 @@ void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
 			std::istringstream tmp_is(pointabilities_s, std::ios::binary);
 			pointabilities = std::make_optional<Pointabilities>();
 			pointabilities->deSerialize(tmp_is);
+		}
+
+		if (readU8(is)) {
+			wear_bar_params = new WearBarParams;
+			wear_bar_params->deSerialize(is);
 		}
 	} catch(SerializationError &e) {};
 }

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -125,8 +125,7 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	pointabilities = def.pointabilities;
 	if (def.tool_capabilities)
 		tool_capabilities = new ToolCapabilities(*def.tool_capabilities);
-	if (def.wear_bar_params.has_value())
-		wear_bar_params = std::optional(new WearBarParams(*def.wear_bar_params.value()));
+	wear_bar_params = def.wear_bar_params;
 	groups = def.groups;
 	node_placement_prediction = def.node_placement_prediction;
 	place_param2 = def.place_param2;
@@ -145,10 +144,6 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 ItemDefinition::~ItemDefinition()
 {
 	reset();
-}
-
-std::optional<WearBarParams> nullInit() {
-	return std::nullopt;
 }
 
 void ItemDefinition::resetInitial()
@@ -262,7 +257,7 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 
 	if (wear_bar_params.has_value()) {
 		writeU8(os, 1);
-		wear_bar_params.value()->serialize(os, protocol_version);
+		wear_bar_params->serialize(os);
 	} else {
 		writeU8(os, 0);
 	}
@@ -350,8 +345,7 @@ void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
 		}
 
 		if (readU8(is)) {
-			wear_bar_params = std::optional(new WearBarParams());
-			wear_bar_params.value()->deSerialize(is);
+			wear_bar_params = WearBarParams::deserialize(is);
 		}
 	} catch(SerializationError &e) {};
 }

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -103,8 +103,7 @@ struct ItemDefinition
 
 	// They may be NULL. If non-NULL, deleted by destructor
 	ToolCapabilities *tool_capabilities;
-	// May be NULL. If non-NULL, deleted by destructor
-	WearBarParams *wear_bar_params;
+	std::optional<WearBarParams*> wear_bar_params;
 
 	ItemGroupList groups;
 	SoundSpec sound_place;

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -33,6 +33,7 @@ class IGameDef;
 class Client;
 struct ToolCapabilities;
 struct PointedThing;
+struct WearBarParams;
 #ifndef SERVER
 #include "client/tile.h"
 struct ItemMesh;
@@ -102,6 +103,8 @@ struct ItemDefinition
 
 	// They may be NULL. If non-NULL, deleted by destructor
 	ToolCapabilities *tool_capabilities;
+	// May be NULL. If non-NULL, deleted by destructor
+	WearBarParams *wear_bar_params;
 
 	ItemGroupList groups;
 	SoundSpec sound_place;

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -28,12 +28,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "itemgroup.h"
 #include "sound.h"
 #include "texture_override.h" // TextureOverride
+#include "tool.h"
 #include "util/pointabilities.h"
 class IGameDef;
 class Client;
 struct ToolCapabilities;
 struct PointedThing;
-struct WearBarParams;
 #ifndef SERVER
 #include "client/tile.h"
 struct ItemMesh;
@@ -103,7 +103,8 @@ struct ItemDefinition
 
 	// They may be NULL. If non-NULL, deleted by destructor
 	ToolCapabilities *tool_capabilities;
-	std::optional<WearBarParams*> wear_bar_params;
+
+	std::optional<WearBarParams> wear_bar_params;
 
 	ItemGroupList groups;
 	SoundSpec sound_place;

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -31,11 +31,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define DESERIALIZE_PAIR_DELIM_STR "\x03"
 
 #define TOOLCAP_KEY "tool_capabilities"
+#define WEAR_BAR_KEY "wear_color"
 
 void ItemStackMetadata::clear()
 {
 	SimpleMetadata::clear();
 	updateToolCapabilities();
+	updateWearBarParams();
 }
 
 static void sanitize_string(std::string &str)
@@ -55,6 +57,8 @@ bool ItemStackMetadata::setString(const std::string &name, const std::string &va
 	bool result = SimpleMetadata::setString(clean_name, clean_var);
 	if (clean_name == TOOLCAP_KEY)
 		updateToolCapabilities();
+	else if (clean_name == WEAR_BAR_KEY)
+		updateWearBarParams();
 	return result;
 }
 
@@ -91,6 +95,7 @@ void ItemStackMetadata::deSerialize(std::istream &is)
 		}
 	}
 	updateToolCapabilities();
+	updateWearBarParams();
 }
 
 void ItemStackMetadata::updateToolCapabilities()
@@ -115,4 +120,27 @@ void ItemStackMetadata::setToolCapabilities(const ToolCapabilities &caps)
 void ItemStackMetadata::clearToolCapabilities()
 {
 	setString(TOOLCAP_KEY, "");
+}
+
+void ItemStackMetadata::updateWearBarParams()
+{
+	if (contains(WEAR_BAR_KEY)) {
+		wear_bar_overridden = true;
+		wear_bar_override = WearBarParams();
+		std::istringstream is(getString(WEAR_BAR_KEY));
+		wear_bar_override.deserializeJson(is);
+	} else {
+		wear_bar_overridden = false;
+	}
+}
+
+void ItemStackMetadata::setWearBarParams(const WearBarParams &params)
+{
+	std::ostringstream os;
+	params.serializeJson(os);
+	setString(WEAR_BAR_KEY, os.str());
+}
+void ItemStackMetadata::clearWearBarParams()
+{
+	setString(WEAR_BAR_KEY, "");
 }

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -21,7 +21,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "itemstackmetadata.h"
 #include "util/serialize.h"
 #include "util/strfnd.h"
+
 #include <algorithm>
+#include <optional>
 
 #define DESERIALIZE_START '\x01'
 #define DESERIALIZE_KV_DELIM '\x02'
@@ -125,12 +127,10 @@ void ItemStackMetadata::clearToolCapabilities()
 void ItemStackMetadata::updateWearBarParams()
 {
 	if (contains(WEAR_BAR_KEY)) {
-		wear_bar_overridden = true;
-		wear_bar_override = WearBarParams();
 		std::istringstream is(getString(WEAR_BAR_KEY));
-		wear_bar_override.deserializeJson(is);
+		wear_bar_override = WearBarParams::deserializeJson(is);
 	} else {
-		wear_bar_overridden = false;
+		wear_bar_override.reset();
 	}
 }
 

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -140,6 +140,7 @@ void ItemStackMetadata::setWearBarParams(const WearBarParams &params)
 	params.serializeJson(os);
 	setString(WEAR_BAR_KEY, os.str());
 }
+
 void ItemStackMetadata::clearWearBarParams()
 {
 	setString(WEAR_BAR_KEY, "");

--- a/src/itemstackmetadata.h
+++ b/src/itemstackmetadata.h
@@ -28,7 +28,10 @@ class IItemDefManager;
 class ItemStackMetadata : public SimpleMetadata
 {
 public:
-	ItemStackMetadata() : toolcaps_overridden(false) {}
+	ItemStackMetadata():
+			toolcaps_overridden(false),
+			wear_bar_overridden(false)
+	{}
 
 	// Overrides
 	void clear() override;
@@ -46,9 +49,28 @@ public:
 	void setToolCapabilities(const ToolCapabilities &caps);
 	void clearToolCapabilities();
 
+	const WearBarParams &getWearBarParams(
+			const WearBarParams &default_params) const
+	{
+		return wear_bar_overridden ? wear_bar_override : default_params;
+	}
+
+	const bool &getWearBarParamOverride(WearBarParams &target) const
+	{
+		if (wear_bar_overridden)
+			target = wear_bar_override;
+		return wear_bar_overridden;
+	}
+
+	void setWearBarParams(const WearBarParams &params);
+	void clearWearBarParams();
+
 private:
 	void updateToolCapabilities();
+	void updateWearBarParams();
 
 	bool toolcaps_overridden;
 	ToolCapabilities toolcaps_override;
+	bool wear_bar_overridden;
+	WearBarParams wear_bar_override;
 };

--- a/src/itemstackmetadata.h
+++ b/src/itemstackmetadata.h
@@ -22,6 +22,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "metadata.h"
 #include "tool.h"
 
+#include <optional>
+
 class Inventory;
 class IItemDefManager;
 
@@ -29,8 +31,7 @@ class ItemStackMetadata : public SimpleMetadata
 {
 public:
 	ItemStackMetadata():
-			toolcaps_overridden(false),
-			wear_bar_overridden(false)
+			toolcaps_overridden(false)
 	{}
 
 	// Overrides
@@ -49,18 +50,11 @@ public:
 	void setToolCapabilities(const ToolCapabilities &caps);
 	void clearToolCapabilities();
 
-	const WearBarParams &getWearBarParams(
-			const WearBarParams &default_params) const
+	const std::optional<WearBarParams> &getWearBarParamOverride() const
 	{
-		return wear_bar_overridden ? wear_bar_override : default_params;
+		return wear_bar_override;
 	}
 
-	const bool &getWearBarParamOverride(WearBarParams &target) const
-	{
-		if (wear_bar_overridden)
-			target = wear_bar_override;
-		return wear_bar_overridden;
-	}
 
 	void setWearBarParams(const WearBarParams &params);
 	void clearWearBarParams();
@@ -71,6 +65,5 @@ private:
 
 	bool toolcaps_overridden;
 	ToolCapabilities toolcaps_override;
-	bool wear_bar_overridden;
-	WearBarParams wear_bar_override;
+	std::optional<WearBarParams> wear_bar_override;
 };

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1787,10 +1787,10 @@ WearBarParams read_wear_bar_params(
 	int table_values = lua_gettop(L);
 	lua_pushnil(L);
 	while(lua_next(L, table_values) != 0) {
-		// key at index -2 and value at index -1=
-		// values are stored in a flat table along with the default color,
-		// but values can be distinguished by them being a table
-		// (in blend mode, they can be distinguished by having a numerical key)
+		// key at index -2 and value at index -1 within table_values
+		// color value entries are stored in a flat 'list' along with the default color,
+		// but in non-blend mode color entries can be distinguished by that value being a table
+		// (in blend mode, color entries can be distinguished by having a numerical key)
 		if (lua_istable(L, -1)) {
 			int value_table = lua_gettop(L);
 			WearBarParam param;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -96,8 +96,7 @@ void read_item_definition(lua_State* L, int index,
 	}
 	lua_getfield(L, index, "wear_color");
 	if (lua_istable(L, -1)) {
-		def.wear_bar_params = new WearBarParams(
-				read_wear_bar_params(L, -1));
+		def.wear_bar_params = new WearBarParams(read_wear_bar_params(L, -1));
 	} else if (lua_isstring(L, -1)) {
 		def.wear_bar_params = new WearBarParams();
 		parseColorString(luaL_checkstring(L, -1), def.wear_bar_params->defaultColor, false);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1773,7 +1773,7 @@ WearBarParams read_wear_bar_params(
 	}
 
 	if (!lua_istable(L, stack_idx))
-		throw LuaError("expected wear bar color table or colorstring");
+		throw LuaError("Expected wear bar color table or colorstring");
 
 	lua_getfield(L, stack_idx, "color_stops");
 	if (!check_field_or_nil(L, -1, LUA_TTABLE, "color_stops"))
@@ -1787,7 +1787,7 @@ WearBarParams read_wear_bar_params(
 		// key at index -2 and value at index -1 within table_values
 		f32 point = luaL_checknumber(L, -2);
 		if (point < 0 || point > 1)
-			throw LuaError("wear bar color stop key out of range");
+			throw LuaError("Wear bar color stop key out of range");
 		video::SColor color;
 		read_color(L, -1, &color);
 		colorStops.emplace(point, color);
@@ -1802,7 +1802,7 @@ WearBarParams read_wear_bar_params(
 	if (check_field_or_nil(L, -1, LUA_TSTRING, "blend")) {
 		int blendInt;
 		if (!string_to_enum(WearBarParams::es_BlendMode, blendInt, std::string(lua_tostring(L, -1))))
-			throw LuaError("invalid wear bar color blend mode");
+			throw LuaError("Invalid wear bar color blend mode");
 		blend = static_cast<WearBarParams::BlendMode>(blendInt);
 	}
 	lua_pop(L, 1);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -96,10 +96,10 @@ void read_item_definition(lua_State* L, int index,
 	}
 	lua_getfield(L, index, "wear_color");
 	if (lua_istable(L, -1)) {
-		def.wear_bar_params = new WearBarParams(read_wear_bar_params(L, -1));
+		def.wear_bar_params = std::optional(new WearBarParams(read_wear_bar_params(L, -1)));
 	} else if (lua_isstring(L, -1)) {
-		def.wear_bar_params = new WearBarParams();
-		parseColorString(luaL_checkstring(L, -1), def.wear_bar_params->defaultColor, false);
+		def.wear_bar_params = std::optional(new WearBarParams());
+		parseColorString(luaL_checkstring(L, -1), def.wear_bar_params.value()->defaultColor, false);
 	}
 
 	// If name is "" (hand), ensure there are ToolCapabilities
@@ -220,8 +220,8 @@ void push_item_definition_full(lua_State *L, const ItemDefinition &i)
 		push_tool_capabilities(L, *i.tool_capabilities);
 		lua_setfield(L, -2, "tool_capabilities");
 	}
-	if (i.wear_bar_params) {
-		push_wear_bar_params(L, *i.wear_bar_params);
+	if (i.wear_bar_params.has_value()) {
+		push_wear_bar_params(L, *i.wear_bar_params.value());
 		lua_setfield(L, -2, "wear_color");
 	}
 	push_groups(L, i.groups);

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -118,7 +118,7 @@ void               push_tool_capabilities    (lua_State *L,
                                               const ToolCapabilities &prop);
 WearBarParams      read_wear_bar_params      (lua_State *L, int table);
 void               push_wear_bar_params      (lua_State *L,
-		                                      const WearBarParams &prop);
+                                              const WearBarParams &prop);
 
 void read_item_definition (lua_State *L, int index, const ItemDefinition &default_def,
 		ItemDefinition &def);

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -116,6 +116,9 @@ void               push_pointabilities       (lua_State *L, const Pointabilities
 ToolCapabilities   read_tool_capabilities    (lua_State *L, int table);
 void               push_tool_capabilities    (lua_State *L,
                                               const ToolCapabilities &prop);
+WearBarParams      read_wear_bar_params      (lua_State *L, int table);
+void               push_wear_bar_params      (lua_State *L,
+		                                      const WearBarParams &prop);
 
 void read_item_definition (lua_State *L, int index, const ItemDefinition &default_def,
 		ItemDefinition &def);

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -379,7 +379,7 @@ int LuaItemStack::l_add_wear_by_uses(lua_State *L)
 // get_wear_bar_params(self) -> table
 // Returns the effective wear bar parameters.
 // Returns nil if this item has none associated.
-int LuaItemStack::l_get_wear_bar_params(lua_State *L) // todo test
+int LuaItemStack::l_get_wear_bar_params(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -384,9 +384,9 @@ int LuaItemStack::l_get_wear_bar_params(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
-	WearBarParams params;
-	if (item.getWearBarParams(getGameDef(L)->idef(), params)) {
-		push_wear_bar_params(L, params);
+	auto params = item.getWearBarParams(getGameDef(L)->idef());
+	if (params.has_value()) {
+		push_wear_bar_params(L, *params);
 		return 1;
 	}
 	return 0;

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -376,6 +376,22 @@ int LuaItemStack::l_add_wear_by_uses(lua_State *L)
 	return 1;
 }
 
+// get_wear_bar_params(self) -> table
+// Returns the effective wear bar parameters.
+// Returns nil if this item has none associated.
+int LuaItemStack::l_get_wear_bar_params(lua_State *L) // todo test
+{
+	NO_MAP_LOCK_REQUIRED;
+	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
+	ItemStack &item = o->m_stack;
+	WearBarParams params;
+	if (item.getWearBarParams(getGameDef(L)->idef(), params)) {
+		push_wear_bar_params(L, params);
+		return 1;
+	}
+	return 0;
+}
+
 // add_item(self, itemstack or itemstring or table or nil) -> itemstack
 // Returns leftover item stack
 int LuaItemStack::l_add_item(lua_State *L)
@@ -551,6 +567,7 @@ const luaL_Reg LuaItemStack::methods[] = {
 	luamethod(LuaItemStack, get_tool_capabilities),
 	luamethod(LuaItemStack, add_wear),
 	luamethod(LuaItemStack, add_wear_by_uses),
+	luamethod(LuaItemStack, get_wear_bar_params),
 	luamethod(LuaItemStack, add_item),
 	luamethod(LuaItemStack, item_fits),
 	luamethod(LuaItemStack, take_item),

--- a/src/script/lua_api/l_item.h
+++ b/src/script/lua_api/l_item.h
@@ -125,6 +125,11 @@ private:
 	// Returns true if the item is (or was) a tool.
 	static int l_add_wear_by_uses(lua_State *L);
 
+	// get_wear_bar_params(self) -> table
+	// Returns the effective wear bar parameters.
+	// Returns nil if this item has none associated.
+	static int l_get_wear_bar_params(lua_State *L);
+
 	// add_item(self, itemstack or itemstring or table or nil) -> itemstack
 	// Returns leftover item stack
 	static int l_add_item(lua_State *L);

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -58,6 +58,25 @@ int ItemStackMetaRef::l_set_tool_capabilities(lua_State *L)
 	return 0;
 }
 
+int ItemStackMetaRef::l_set_wear_bar_params(lua_State *L)
+{
+	ItemStackMetaRef *metaref = checkObject<ItemStackMetaRef>(L, 1);
+	if (lua_isnoneornil(L, 2)) {
+		metaref->clearWearBarParams();
+	} else if (lua_istable(L, 2)) {
+		WearBarParams params = read_wear_bar_params(L, 2);
+		metaref->setWearBarParams(params);
+	} else if (lua_isstring(L, 2)) {
+		WearBarParams params;
+		parseColorString(luaL_checkstring(L, 2), params.defaultColor, false);
+		metaref->setWearBarParams(params);
+	} else {
+		luaL_typerror(L, 2, "table, ColorString, or nil");
+	}
+
+	return 0;
+}
+
 ItemStackMetaRef::ItemStackMetaRef(LuaItemStack *istack): istack(istack)
 {
 	istack->grab();
@@ -102,5 +121,6 @@ const luaL_Reg ItemStackMetaRef::methods[] = {
 	luamethod(MetaDataRef, from_table),
 	luamethod(MetaDataRef, equals),
 	luamethod(ItemStackMetaRef, set_tool_capabilities),
+	luamethod(ItemStackMetaRef, set_wear_bar_params),
 	{0,0}
 };

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_itemstackmeta.h"
 #include "lua_api/l_internal.h"
 #include "common/c_content.h"
+#include "common/c_converter.h"
 
 /*
 	ItemStackMetaRef
@@ -68,7 +69,9 @@ int ItemStackMetaRef::l_set_wear_bar_params(lua_State *L)
 		metaref->setWearBarParams(params);
 	} else if (lua_isstring(L, 2)) {
 		WearBarParams params;
-		parseColorString(luaL_checkstring(L, 2), params.defaultColor, false);
+		video::SColor color;
+		read_color(L, 2, &color);
+		params.colorStops.emplace(0, color);
 		metaref->setWearBarParams(params);
 	} else {
 		luaL_typerror(L, 2, "table, ColorString, or nil");

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_internal.h"
 #include "common/c_content.h"
 #include "common/c_converter.h"
+#include "tool.h"
 
 /*
 	ItemStackMetaRef
@@ -64,15 +65,8 @@ int ItemStackMetaRef::l_set_wear_bar_params(lua_State *L)
 	ItemStackMetaRef *metaref = checkObject<ItemStackMetaRef>(L, 1);
 	if (lua_isnoneornil(L, 2)) {
 		metaref->clearWearBarParams();
-	} else if (lua_istable(L, 2)) {
-		WearBarParams params = read_wear_bar_params(L, 2);
-		metaref->setWearBarParams(params);
-	} else if (lua_isstring(L, 2)) {
-		WearBarParams params;
-		video::SColor color;
-		read_color(L, 2, &color);
-		params.colorStops.emplace(0, color);
-		metaref->setWearBarParams(params);
+	} else if (lua_istable(L, 2) || lua_isstring(L, 2)) {
+		metaref->setWearBarParams(read_wear_bar_params(L, 2));
 	} else {
 		luaL_typerror(L, 2, "table, ColorString, or nil");
 	}

--- a/src/script/lua_api/l_itemstackmeta.h
+++ b/src/script/lua_api/l_itemstackmeta.h
@@ -49,8 +49,19 @@ private:
 		istack->getItem().metadata.clearToolCapabilities();
 	}
 
+	void setWearBarParams(const WearBarParams &params)
+	{
+		istack->getItem().metadata.setWearBarParams(params);
+	}
+
+	void clearWearBarParams()
+	{
+		istack->getItem().metadata.clearWearBarParams();
+	}
+
 	// Exported functions
 	static int l_set_tool_capabilities(lua_State *L);
+	static int l_set_wear_bar_params(lua_State *L);
 public:
 	// takes a reference
 	ItemStackMetaRef(LuaItemStack *istack);

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -233,6 +233,7 @@ void WearBarParams::deSerialize(std::istream &is)
 		params.emplace_back(color, minPercent, maxPercent);
 	}
 }
+
 void WearBarParams::serializeJson(std::ostream &os) const
 {
 	Json::Value root;
@@ -246,6 +247,7 @@ void WearBarParams::serializeJson(std::ostream &os) const
 
 	fastWriteJson(root, os);
 }
+
 void WearBarParams::deserializeJson(std::istream &is)
 {
 	Json::Value root;

--- a/src/tool.h
+++ b/src/tool.h
@@ -129,7 +129,7 @@ struct WearBarParams
 	void serializeJson(std::ostream &os) const;
 	void deserializeJson(std::istream &is);
 };
-Wear Bar
+
 struct DigParams
 {
 	bool diggable;

--- a/src/tool.h
+++ b/src/tool.h
@@ -24,6 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <iostream>
 #include "itemgroup.h"
 #include "json-forwards.h"
+#include <json/json.h>
+#include <SColor.h>
 
 struct ItemDefinition;
 
@@ -82,6 +84,52 @@ struct ToolCapabilities
 	void deserializeJson(std::istream &is);
 };
 
+struct WearBarParam
+{
+	video::SColor color;
+	float minPercent; // minimum percentage *durability* to apply color for (inclusive)
+	float maxPercent; // maximum percentage *durability* to apply color for (exclusive)
+	WearBarParam(
+			const video::SColor &color_ = video::SColor(255, 255, 255, 255),
+			float minPercent_ = 0.0f,
+			float maxPercent_ = 0.0f
+			):
+			color(color_),
+			minPercent(minPercent_),
+			maxPercent(maxPercent_)
+	{}
+
+	void fromJson(Json::Value &value);
+	void toJson(Json::Value &value) const;
+
+	bool matches(float percent) const
+	{
+		return minPercent <= percent && percent < maxPercent;
+	}
+};
+
+struct WearBarParams
+{
+	video::SColor defaultColor;
+	std::vector<WearBarParam> params;
+	bool blend;
+
+	WearBarParams(
+			const video::SColor &defaultColor_ = video::SColor(255, 255, 255, 255),
+			const std::vector<WearBarParam> &params_ = std::vector<WearBarParam>(),
+			const bool blend_ = false
+			):
+			defaultColor(defaultColor_),
+			params(params_),
+			blend(blend_)
+	{}
+
+	void serialize(std::ostream &os, u16 version) const;
+	void deSerialize(std::istream &is);
+	void serializeJson(std::ostream &os) const;
+	void deserializeJson(std::istream &is);
+};
+Wear Bar
 struct DigParams
 {
 	bool diggable;

--- a/src/tool.h
+++ b/src/tool.h
@@ -128,6 +128,7 @@ struct WearBarParams
 	void deSerialize(std::istream &is);
 	void serializeJson(std::ostream &os) const;
 	void deserializeJson(std::istream &is);
+	video::SColor getWearBarColor(float durabilityPercent);
 };
 
 struct DigParams

--- a/src/tool.h
+++ b/src/tool.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <iostream>
 #include "itemgroup.h"
 #include "json-forwards.h"
+#include "common/c_types.h"
 #include <json/json.h>
 #include <SColor.h>
 
@@ -99,28 +100,30 @@ struct WearBarParam
 			maxPercent(maxPercent_)
 	{}
 
-	void fromJson(Json::Value &value);
-	void toJson(Json::Value &value) const;
-
 	bool matches(float percent) const
 	{
 		return minPercent <= percent && percent < maxPercent;
 	}
 };
 
+enum BlendMode: u8 {
+    BLEND_MODE_CONSTANT,
+    BLEND_MODE_LINEAR,
+    BlendMode_END // Dummy for validity check
+};
+
+extern const EnumString es_BlendMode[];
+
 struct WearBarParams
 {
-	video::SColor defaultColor;
-	std::vector<WearBarParam> params;
-	bool blend;
+	std::map<float, video::SColor> colorStops;
+	BlendMode blend;
 
 	WearBarParams(
-			const video::SColor &defaultColor_ = video::SColor(255, 255, 255, 255),
-			const std::vector<WearBarParam> &params_ = std::vector<WearBarParam>(),
-			const bool blend_ = false
+			const std::map<float, video::SColor> &color_stops_ = std::map<float, video::SColor>(),
+			const BlendMode blend_ = BLEND_MODE_CONSTANT
 			):
-			defaultColor(defaultColor_),
-			params(params_),
+			colorStops(color_stops_),
 			blend(blend_)
 	{}
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -574,6 +574,20 @@ bool parseColorString(const std::string &value, video::SColor &color, bool quiet
 	return success;
 }
 
+std::string encodeHexColorString(const video::SColor &color)
+{
+	std::string color_string = "#";
+	const char red = color.getRed();
+	const char green = color.getGreen();
+	const char blue = color.getBlue();
+	const char alpha = color.getAlpha();
+	color_string += hex_encode(&red, 1);
+	color_string += hex_encode(&green, 1);
+	color_string += hex_encode(&blue, 1);
+	color_string += hex_encode(&alpha, 1);
+	return color_string;
+}
+
 void str_replace(std::string &str, char from, char to)
 {
 	std::replace(str.begin(), str.end(), from, to);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -88,6 +88,7 @@ char *mystrtok_r(char *s, const char *sep, char **lasts) noexcept;
 u64 read_seed(const char *str);
 bool parseColorString(const std::string &value, video::SColor &color, bool quiet,
 		unsigned char default_alpha = 0xff);
+std::string encodeHexColorString(const video::SColor &color);
 
 
 /**


### PR DESCRIPTION
Adds an api for modders to change the appearance of the wear bar on their tools.

Currently, the tool damage bar (called "wear bar" by dev wiki) color cannot be customized by modders, and is listed under hardcoded features. This PR fixes that by adding fields in item def as well as item metadata to change the appearance. (See lua_api.txt for api specifics)
Resolves #13325

## Summary
The `wear_bar` field in item definitions and item meta allows modders to customize the color of wear bars in a variety of ways.

## To do

This PR is Ready for Review.

## How to test

In the devtest game, grab a few of the pickaxes (5, 10, 50, and 100 use pickaxes are customized) and dig some stone, allowing their wear bars to appear. Note the progression through different colors (as described by the tool description) when the pickaxe takes more damage.
Additionally, there is a pickaxe called "Wear Bar Color Test," that when punched with will use a random color for its wear bar. You can use the  `/use_tool` command to damage the tool a bit in order to allow the wear bar to appear.

Screenshot demonstrating the different color possibilities:
![minetest_wear_bar_color_explanation](https://user-images.githubusercontent.com/77073745/225460982-7f44083d-843a-443d-8c3b-680cdf4990c6.png)