### PR TITLE
Fix server-side formspec state keeping issue

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1539,8 +1539,10 @@ void Server::SendShowFormspecMessage(session_t peer_id, const std::string &forms
 {
 	NetworkPacket pkt(TOCLIENT_SHOW_FORMSPEC, 0, peer_id);
 	if (formspec.empty()){
-		//the client should close the formspec
-		//but make sure there wasn't another one open in meantime
+		// The client should close the formspec
+		// But make sure there wasn't another one open in meantime
+		// If the formname is empty, any open formspec will be closed so the
+		// form name should always be erased from the state.
 		const auto it = m_formspec_state_data.find(peer_id);
 		if (it != m_formspec_state_data.end() &&
 				(it->second == formname || formname.empty())) {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1542,7 +1542,8 @@ void Server::SendShowFormspecMessage(session_t peer_id, const std::string &forms
 		//the client should close the formspec
 		//but make sure there wasn't another one open in meantime
 		const auto it = m_formspec_state_data.find(peer_id);
-		if (it != m_formspec_state_data.end() && it->second == formname) {
+		if (it != m_formspec_state_data.end() &&
+				(it->second == formname || formname.empty())) {
 			m_formspec_state_data.erase(peer_id);
 		}
 		pkt.putLongString("");


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
Fix #13331
- How does the PR work?
By removing the player's entry from `m_formspec_state_data` when `minetest.close_formspec(name, "")` is called
- Does it resolve any reported issue?
#13331
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
No

## To do

This PR is a Ready for Review.

## How to test

See #13331