### PR TITLE
Simulate all keys being released when when game loses focus

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1001,6 +1001,7 @@ private:
 	bool m_invert_mouse = false;
 	bool m_first_loop_after_window_activation = false;
 	bool m_camera_offset_changed = false;
+	bool m_game_focused;
 
 	bool m_does_lost_focus_pause_game = false;
 
@@ -1964,19 +1965,28 @@ void Game::processUserInput(f32 dtime)
 {
 	// Reset input if window not active or some menu is active
 	if (!device->isWindowActive() || isMenuActive() || guienv->hasFocus(gui_chat_console)) {
-		input->clear();
+		if(m_game_focused) {
+			m_game_focused = false;
+			infostream << "Game lost focus" << std::endl;
+			input->releaseAllKeys();
+		} else {
+			input->clear();
+		}
 #ifdef HAVE_TOUCHSCREENGUI
 		g_touchscreengui->hide();
 #endif
-	}
+	} else {
 #ifdef HAVE_TOUCHSCREENGUI
-	else if (g_touchscreengui) {
-		/* on touchscreengui step may generate own input events which ain't
-		 * what we want in case we just did clear them */
-		g_touchscreengui->show();
-		g_touchscreengui->step(dtime);
-	}
+		if (g_touchscreengui) {
+			/* on touchscreengui step may generate own input events which ain't
+			 * what we want in case we just did clear them */
+			g_touchscreengui->show();
+			g_touchscreengui->step(dtime);
+		}
 #endif
+
+		m_game_focused = true;
+	}
 
 	if (!guienv->hasFocus(gui_chat_console) && gui_chat_console->isOpen()) {
 		gui_chat_console->closeConsoleAtOnce();

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -124,6 +124,13 @@ public:
 			push_back(key);
 	}
 
+	void append(KeyList &other)
+	{
+		for (const KeyPress &key : other) {
+			set(key);
+		}
+	}
+
 	bool operator[](const KeyPress &key) const { return find(key) != end(); }
 };
 
@@ -176,6 +183,12 @@ public:
 		keyWasReleased.clear();
 
 		mouse_wheel = 0;
+	}
+
+	void releaseAllKeys()
+	{
+		keyWasReleased.append(keyIsDown);
+		keyIsDown.clear();
 	}
 
 	void clearWasKeyPressed()
@@ -263,6 +276,7 @@ public:
 	virtual void step(float dtime) {}
 
 	virtual void clear() {}
+	virtual void releaseAllKeys() {}
 
 	JoystickController joystick;
 	KeyCache keycache;
@@ -393,6 +407,12 @@ public:
 	{
 		joystick.clear();
 		m_receiver->clearInput();
+	}
+
+	void releaseAllKeys()
+	{
+		joystick.releaseAllKeys();
+		m_receiver->releaseAllKeys();
 	}
 
 private:

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -124,7 +124,7 @@ public:
 			push_back(key);
 	}
 
-	void append(KeyList &other)
+	void append(const KeyList &other)
 	{
 		for (const KeyPress &key : other) {
 			set(key);

--- a/src/client/joystick_controller.h
+++ b/src/client/joystick_controller.h
@@ -109,6 +109,12 @@ public:
 	bool handleEvent(const irr::SEvent::SJoystickEvent &ev);
 	void clear();
 
+	void releaseAllKeys()
+	{
+		m_keys_released |= m_keys_down;
+		m_keys_down.reset();
+	}
+
 	bool wasKeyDown(GameKeyType b)
 	{
 		bool r = m_past_keys_pressed[b];


### PR DESCRIPTION
Simulates all keys being released when the main game loses focus, such as the when the inventory or chat is opened. Fixes #5611

## To do

This PR is Ready for Review.

## How to test

See #5611.

Also, I do not have a joystick. Therefore, this should be tested to ensure that the joystick still works and that the problem is fixed for joysticks as well.