### PR TITLE
Lua API: Catch serialization error for chat messages

### DIFF
--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -85,7 +85,14 @@ int ModApiServer::l_chat_send_all(lua_State *L)
 	// Get server from registry
 	Server *server = getServer(L);
 	// Send
-	server->notifyPlayers(utf8_to_wide(text));
+	try {
+		server->notifyPlayers(utf8_to_wide(text));
+	} catch (PacketError &e) {
+		warningstream << "Exception caught: " << e.what() << std::endl
+			<< script_get_backtrace(L) << std::endl;
+		server->notifyPlayers(utf8_to_wide(std::string("Internal error: ") + e.what()));
+	}
+
 	return 0;
 }
 
@@ -99,7 +106,13 @@ int ModApiServer::l_chat_send_player(lua_State *L)
 	// Get server from registry
 	Server *server = getServer(L);
 	// Send
-	server->notifyPlayer(name, utf8_to_wide(text));
+	try {
+		server->notifyPlayer(name, utf8_to_wide(text));
+	} catch (PacketError &e) {
+		warningstream << "Exception caught: " << e.what() << std::endl
+			<< script_get_backtrace(L) << std::endl;
+		server->notifyPlayer(name, utf8_to_wide(std::string("Internal error: ") + e.what()));
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Fixes #9326 and https://github.com/minetest-mods/MoreMesecons/pull/29 by logging a warning instead of shutting down the server.

## To do

This PR is Ready for Review.

## How to test

```Lua
minetest.register_chatcommand("x", {
	func = function(name, param)
		minetest.chat_send_player(name, "Please do not crash "
			.. string.rep(" :)", math.floor(2^16 / 3)))
	end
})
```