### PR TITLE
Move drawing of wield tool into a dedicated step of the pipeline

### DIFF
--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -635,11 +635,14 @@ void Camera::wield(const ItemStack &item)
 
 void Camera::drawWieldedTool(irr::core::matrix4* translation)
 {
+	// Clear Z buffer so that the wielded tool stays in front of world geometry
+	m_wieldmgr->getVideoDriver()->clearBuffers(video::ECBF_DEPTH);
+
 	// Draw the wielded node (in a separate scene manager)
 	scene::ICameraSceneNode* cam = m_wieldmgr->getActiveCamera();
 	cam->setAspectRatio(m_cameranode->getAspectRatio());
 	cam->setFOV(72.0*M_PI/180.0);
-	cam->setNearValue(40); // give wield tool smaller z-depth than the world in most cases.
+	cam->setNearValue(10); // give wield tool smaller z-depth than the world in most cases.
 	cam->setFarValue(1000);
 	if (translation != NULL)
 	{

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -642,7 +642,7 @@ void Camera::drawWieldedTool(irr::core::matrix4* translation)
 	scene::ICameraSceneNode* cam = m_wieldmgr->getActiveCamera();
 	cam->setAspectRatio(m_cameranode->getAspectRatio());
 	cam->setFOV(72.0*M_PI/180.0);
-	cam->setNearValue(10); // give wield tool smaller z-depth than the world in most cases.
+	cam->setNearValue(10);
 	cam->setFarValue(1000);
 	if (translation != NULL)
 	{

--- a/src/client/render/anaglyph.cpp
+++ b/src/client/render/anaglyph.cpp
@@ -73,19 +73,20 @@ void populateAnaglyphPipeline(RenderPipeline *pipeline, Client *client)
 	step3D->setRenderTarget(enable_override_material);
 
 	// left eye
-	pipeline->addStep(pipeline->createOwned<OffsetCameraStep>(false));
-	pipeline->addStep(pipeline->createOwned<SetColorMaskStep>(video::ECP_RED));
+	pipeline->addStep<OffsetCameraStep>(false);
+	pipeline->addStep<SetColorMaskStep>(video::ECP_RED);
 	pipeline->addStep(step3D);
 
 	// right eye
-	pipeline->addStep(pipeline->createOwned<OffsetCameraStep>(true));
-	pipeline->addStep(pipeline->createOwned<SetColorMaskStep>(video::ECP_GREEN | video::ECP_BLUE));
+	pipeline->addStep<OffsetCameraStep>(true);
+	pipeline->addStep<SetColorMaskStep>(video::ECP_GREEN | video::ECP_BLUE);
 	pipeline->addStep(step3D);
 
 	// reset
-	pipeline->addStep(pipeline->createOwned<OffsetCameraStep>(0.0f));
-	pipeline->addStep(pipeline->createOwned<SetColorMaskStep>(video::ECP_ALL));
+	pipeline->addStep<OffsetCameraStep>(0.0f);
+	pipeline->addStep<SetColorMaskStep>(video::ECP_ALL);
 	
-	pipeline->addStep(pipeline->createOwned<MapPostFxStep>());
-	pipeline->addStep(pipeline->createOwned<DrawHUD>());
+	pipeline->addStep<DrawWield>();
+	pipeline->addStep<MapPostFxStep>();
+	pipeline->addStep<DrawHUD>();
 }

--- a/src/client/render/interlaced.cpp
+++ b/src/client/render/interlaced.cpp
@@ -69,6 +69,7 @@ void populateInterlacedPipeline(RenderPipeline *pipeline, Client *client)
 		auto output = pipeline->createOwned<TextureBufferOutput>(buffer, right ? TEXTURE_RIGHT : TEXTURE_LEFT);
 		pipeline->addStep<SetRenderTargetStep>(step3D, output);
 		pipeline->addStep(step3D);
+		pipeline->addStep<DrawWield>();
 		pipeline->addStep<MapPostFxStep>();
 	}
 

--- a/src/client/render/plain.cpp
+++ b/src/client/render/plain.cpp
@@ -41,11 +41,17 @@ void Draw3D::run(PipelineContext &context)
 	context.hud->drawSelectionMesh();
 }
 
-void DrawHUD::run(PipelineContext &context)
+void DrawWield::run(PipelineContext &context)
 {
+	if (m_target)
+		m_target->activate(context);
+
 	if (context.draw_wield_tool)
 		context.client->getCamera()->drawWieldedTool();
+}
 
+void DrawHUD::run(PipelineContext &context)
+{
 	if (context.show_hud) {
 		if (context.shadow_renderer)
 			context.shadow_renderer->drawDebug();
@@ -145,6 +151,7 @@ void populatePlainPipeline(RenderPipeline *pipeline, Client *client)
 	auto downscale_factor = getDownscaleFactor();
 	auto step3D = pipeline->own(create3DStage(client, downscale_factor));
 	pipeline->addStep(step3D);
+	pipeline->addStep<DrawWield>();
 	pipeline->addStep<MapPostFxStep>();
 
 	step3D = addUpscaling(pipeline, step3D, downscale_factor);

--- a/src/client/render/plain.cpp
+++ b/src/client/render/plain.cpp
@@ -39,12 +39,13 @@ void Draw3D::run(PipelineContext &context)
 		return;
 	context.hud->drawBlockBounds();
 	context.hud->drawSelectionMesh();
-	if (context.draw_wield_tool)
-		context.client->getCamera()->drawWieldedTool();
 }
 
 void DrawHUD::run(PipelineContext &context)
 {
+	if (context.draw_wield_tool)
+		context.client->getCamera()->drawWieldedTool();
+
 	if (context.show_hud) {
 		if (context.shadow_renderer)
 			context.shadow_renderer->drawDebug();

--- a/src/client/render/plain.h
+++ b/src/client/render/plain.h
@@ -38,6 +38,19 @@ private:
 	RenderTarget *m_target {nullptr};
 };
 
+class DrawWield : public RenderStep
+{
+public:
+	virtual void setRenderSource(RenderSource *) override {}
+	virtual void setRenderTarget(RenderTarget *target) override { m_target = target; }
+
+	virtual void reset(PipelineContext &context) override {}
+	virtual void run(PipelineContext &context) override;
+
+private:
+	RenderTarget *m_target {nullptr};
+};
+
 /**
  * Implements a pipeline step that renders the game HUD
  */

--- a/src/client/render/sidebyside.cpp
+++ b/src/client/render/sidebyside.cpp
@@ -73,6 +73,7 @@ void populateSideBySidePipeline(RenderPipeline *pipeline, Client *client, bool h
 		auto output = pipeline->createOwned<TextureBufferOutput>(buffer, right ? TEXTURE_RIGHT : TEXTURE_LEFT);
 		pipeline->addStep<SetRenderTargetStep>(step3D, output);
 		pipeline->addStep(step3D);
+		pipeline->addStep<DrawWield>();
 		pipeline->addStep<MapPostFxStep>();
 		pipeline->addStep<DrawHUD>();
 	}


### PR DESCRIPTION
Fixes #13329, fixes #13293, fixes #12826  by drawing the wield tool/hand after the post-processing effects.

This also removes the visual effects for the wield tool/hand (bloom, dynamic exposure etc.), restoring the 5.6 behavior.

## To do

This PR is Ready for Review.


## How to test

1. Enable effects and enter any game
2. Fly through blocks / leaves / water
3. See the hand NOT being clipped / cut by the 3D scene.
4. See also the referenced bugs
