### PR TITLE
Move rendering engine reset after deletion of game objects

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1113,6 +1113,8 @@ Game::~Game()
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("camera_smoothing",
 		&settingChangedCallback, this);
+	if (m_rendering_engine)
+		m_rendering_engine->finalize();
 }
 
 bool Game::startup(bool *kill,
@@ -1289,8 +1291,6 @@ void Game::run()
 
 void Game::shutdown()
 {
-	m_rendering_engine->finalize();
-
 	auto formspec = m_game_ui->getFormspecGUI();
 	if (formspec)
 		formspec->quitMenu();


### PR DESCRIPTION
Fixes #13292.

The problem was in destruction sequence:
a) some scene objects register with shadow renderer as shadow casters/receivers
b) rendering core (and shadow renderer) were destroyed before the scene was cleared of the objects, causing them to access shadow renderer after deletion.

## To do

This PR is Ready for Review.

## How to test

1. Start any game/world/server
2. Drop an item on the ground
3. Exit to main menu
4. The client must not crash
