### PR TITLE
Return shadow_sky_body_orbit_tilt setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -443,6 +443,12 @@ shadow_update_frames (Map shadows update frames) int 8 1 16
 #    Minimum value: 1.0; maximum value: 15.0
 shadow_soft_radius (Soft shadow radius) float 5.0 1.0 15.0
 
+#    Set the default tilt of Sun/Moon orbit in degrees.
+#    Games may change orbit tilt via API.
+#    Value of 0 means no tilt / vertical orbit.
+#    type: float min: -60 max: 60
+shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 -60.0 60.0
+
 [**Post processing]
 
 #    Set the exposure compensation in EV units.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7354,8 +7354,10 @@ child will follow movement and rotation of that bone.
     * `sky_parameters` is a table with the following optional fields:
         * `base_color`: ColorSpec, changes fog in "skybox" and "plain".
           (default: `#ffffff`)
-        * `body_orbit_tilt`: Float, angle of sun/moon orbit in degrees, relative to Y axis.
-           Valid range [-60.0,60.0] (default: 0.0)
+        * `body_orbit_tilt`: Float, rotation angle of sun/moon orbit in degrees.
+           By default, orbit is controlled by a client-side setting, and this field is not set.
+           After a value is assigned, it can only be changed to another float value.
+           Valid range [-60.0,60.0] (default: not set)
         * `type`: Available types:
             * `"regular"`: Uses 0 textures, `base_color` ignored
             * `"skybox"`: Uses 6 textures, `base_color` used as fog.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -473,6 +473,12 @@
 #    type: float min: 1 max: 15
 # shadow_soft_radius = 5.0
 
+#    Set the default tilt of Sun/Moon orbit in degrees.
+#    Games may change orbit tilt via API.
+#    Value of 0 means no tilt / vertical orbit.
+#    type: float min: -60 max: 60
+# shadow_sky_body_orbit_tilt = 0.0
+
 ### Post processing
 
 #    Set the exposure compensation in EV units.

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -97,6 +97,7 @@ Sky::Sky(s32 id, RenderingEngine *rendering_engine, ITextureSource *tsrc, IShade
 	}
 
 	m_directional_colored_fog = g_settings->getBool("directional_colored_fog");
+	m_sky_params.body_orbit_tilt = g_settings->getFloat("shadow_sky_body_orbit_tilt", -60., 60.);
 
 	setStarCount(1000);
 }

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -98,7 +98,9 @@ public:
 	}
 	void setBodyOrbitTilt(float body_orbit_tilt)
 	{
-		m_sky_params.body_orbit_tilt = body_orbit_tilt;
+		warningstream << "body orbit tilt " << body_orbit_tilt << std::endl;
+		if (body_orbit_tilt != SkyboxParams::INVALID_SKYBOX_TILT)
+			m_sky_params.body_orbit_tilt = rangelim(body_orbit_tilt, -90.f, 90.f);
 	}
 	void overrideColors(video::SColor bgcolor, video::SColor skycolor)
 	{

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -98,7 +98,6 @@ public:
 	}
 	void setBodyOrbitTilt(float body_orbit_tilt)
 	{
-		warningstream << "body orbit tilt " << body_orbit_tilt << std::endl;
 		if (body_orbit_tilt != SkyboxParams::INVALID_SKYBOX_TILT)
 			m_sky_params.body_orbit_tilt = rangelim(body_orbit_tilt, -90.f, 90.f);
 	}

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -288,6 +288,7 @@ void set_default_settings()
 	settings->setDefault("shadow_poisson_filter", "true");
 	settings->setDefault("shadow_update_frames", "8");
 	settings->setDefault("shadow_soft_radius", "5.0");
+	settings->setDefault("shadow_sky_body_orbit_tilt", "0.0");
 
 	// Input
 	settings->setDefault("invert_mouse", "false");

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1919,8 +1919,10 @@ int ObjectRef::l_get_sky(lua_State *L)
 	lua_pushlstring(L, skybox_params.type.c_str(), skybox_params.type.size());
 	lua_setfield(L, -2, "type");
 
-	lua_pushnumber(L, skybox_params.body_orbit_tilt);
-	lua_setfield(L, -2, "body_orbit_tilt");
+	if (skybox_params.body_orbit_tilt != SkyboxParams::INVALID_SKYBOX_TILT) {
+		lua_pushnumber(L, skybox_params.body_orbit_tilt);
+		lua_setfield(L, -2, "body_orbit_tilt");
+	}
 
 	lua_newtable(L);
 	s16 i = 1;

--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -19,6 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <cmath>
+
 struct SkyColor
 {
 	video::SColor day_sky;
@@ -32,6 +34,8 @@ struct SkyColor
 
 struct SkyboxParams
 {
+	static constexpr float INVALID_SKYBOX_TILT = -1024.f;
+
 	video::SColor bgcolor;
 	std::string type;
 	std::vector<std::string> textures;
@@ -40,7 +44,7 @@ struct SkyboxParams
 	video::SColor fog_sun_tint;
 	video::SColor fog_moon_tint;
 	std::string fog_tint_type;
-	float body_orbit_tilt;
+	float body_orbit_tilt { INVALID_SKYBOX_TILT };
 };
 
 struct SunParams
@@ -96,7 +100,6 @@ public:
 		sky.fog_sun_tint = video::SColor(255, 244, 125, 29);
 		sky.fog_moon_tint = video::SColorf(0.5, 0.6, 0.8, 1).toSColor();
 		sky.fog_tint_type = "default";
-		sky.body_orbit_tilt = 0.0f;
 		return sky;
 	}
 

--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -19,7 +19,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include <cmath>
 
 struct SkyColor
 {


### PR DESCRIPTION
Used as a default value when the game does not change the value via API (e.g. legacy server)

Fixes #13302.

## To do

This PR is Ready for Review.

## How to test

1. Set the setting `shadow_sky_body_orbit_tilt = 60`
2. Enable shadows
3. Start a 5.7.0 game with shadows, notice the sun orbit tilt is 60 degrees
4. Connect to a 5.6.1 server, notice sun orbit tilt is 60 degrees
5. Add a mod with the following code:
```
minetest.register_on_joinplayer(function(player)
	player:set_sky({body_orbit_tilt = 30})
end)
```
7.  Enable the mod and start the game
8. Notice the orbit tilt is 30 degrees
