### PR TITLE
Remove obsolete rendering core init code.

### DIFF
--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -36,14 +36,6 @@ RenderingCore::~RenderingCore()
 	delete shadow_renderer;
 }
 
-void RenderingCore::initialize()
-{
-	if (shadow_renderer)
-		pipeline->addStep<RenderShadowMapStep>();
-
-	createPipeline();
-}
-
 void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
 		bool _draw_wield_tool, bool _draw_crosshair)
 {

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -42,8 +42,6 @@ protected:
 	v2f virtual_size_scale;
 	v2u32 virtual_size { 0, 0 };
 
-	virtual void createPipeline() {}
-
 public:
 	RenderingCore(IrrlichtDevice *device, Client *client, Hud *hud, 
 			ShadowRenderer *shadow_renderer, RenderPipeline *pipeline,
@@ -55,7 +53,6 @@ public:
 	RenderingCore &operator=(const RenderingCore &) = delete;
 	RenderingCore &operator=(RenderingCore &&) = delete;
 
-	void initialize();
 	void draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
 			bool _draw_wield_tool, bool _draw_crosshair);
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -541,7 +541,6 @@ void RenderingEngine::initialize(Client *client, Hud *hud)
 {
 	const std::string &draw_mode = g_settings->get("3d_mode");
 	core.reset(createRenderingCore(draw_mode, m_device, client, hud));
-	core->initialize();
 }
 
 void RenderingEngine::finalize()


### PR DESCRIPTION
Also removes duplicate call to shadow render step, improving performance

## To do

This PR is Ready for Review.

## How to test

1. Enable shadows
2. Enter a world which supports shadows
3. Shadows are there.
