### PR TITLE
Warning: inform about entity name when bug detected about attachement

### DIFF
--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -139,7 +139,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 	// If attached, check that our parent is still there. If it isn't, detach.
 	if (m_attachment_parent_id && !isAttached()) {
 		// This is handled when objects are removed from the map
-		warningstream << "LuaEntitySAO::step() id=" << m_id <<
+		warningstream << "LuaEntitySAO::step() " << m_init_name << " id=" << m_id <<
 			" is attached to nonexistent parent. This is a bug." << std::endl;
 		clearParentAttachment();
 		sendPosition(false, true);

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -139,7 +139,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 	// If attached, check that our parent is still there. If it isn't, detach.
 	if (m_attachment_parent_id && !isAttached()) {
 		// This is handled when objects are removed from the map
-		warningstream << "LuaEntitySAO::step() " << m_init_name << " id=" << m_id <<
+		warningstream << "LuaEntitySAO::step() " << m_init_name << " at: " << PP(m_last_sent_position) << ", id=" << m_id <<
 			" is attached to nonexistent parent. This is a bug." << std::endl;
 		clearParentAttachment();
 		sendPosition(false, true);


### PR DESCRIPTION
Adding an info about entity "name" in message greatly helped me to target where the bug was coming from.
Id of the entity did not really help.

I'm sorry I don't know if this PR respect format of warning. Just wait for feedback