### PR TITLE
Reverse eye-offset Z-coordinate in 3rd person front view

### DIFF
--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -375,10 +375,19 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 tool_reload_ratio)
 	// Calculate and translate the head SceneNode offsets
 	{
 		v3f eye_offset = player->getEyeOffset();
-		if (m_camera_mode == CAMERA_MODE_FIRST)
+		switch(m_camera_mode) {
+		case CAMERA_MODE_FIRST:
 			eye_offset += player->eye_offset_first;
-		else
+			break;
+		case CAMERA_MODE_THIRD:
 			eye_offset += player->eye_offset_third;
+			break;
+		case CAMERA_MODE_THIRD_FRONT:
+			eye_offset.X += player->eye_offset_third.X;
+			eye_offset.Y += player->eye_offset_third.Y;
+			eye_offset.Z -= player->eye_offset_third.Z;
+			break;
+		}
 
 		// Set head node transformation
 		eye_offset.Y += cameratilt * -player->hurt_tilt_strength + fall_bobbing;


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

Fixes #11965 

## To do

This PR is Ready for Review.

## How to test

`player:set_eye_offset({x=0, y=0, z=0}, {x=0, y=0, z=-5})`

Then switch between 3d person and 3rd person front views. Note how the z-coordinate is correctly reversed.
