### PR TITLE
Rework server stepping and dtime calculation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -314,6 +314,13 @@ else()
 	endif()
 endif()
 
+# On clang and gcc, some functionalities of std::atomic require -latomic.
+# See <https://en.cppreference.com/w/cpp/atomic/atomic#Notes>.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+		OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	set(PLATFORM_LIBS ${PLATFORM_LIBS} atomic)
+endif()
+
 check_include_files(endian.h HAVE_ENDIAN_H)
 
 configure_file(

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1418,7 +1418,7 @@ void Connection::Disconnect()
 	putCommand(ConnectionCommand::disconnect());
 }
 
-bool Connection::Receive(NetworkPacket *pkt, u32 timeout)
+bool Connection::ReceiveTimeoutMs(NetworkPacket *pkt, u32 timeout_ms)
 {
 	/*
 		Note that this function can potentially wait infinitely if non-data
@@ -1426,7 +1426,7 @@ bool Connection::Receive(NetworkPacket *pkt, u32 timeout)
 		This is not considered to be a problem (is it?)
 	*/
 	for(;;) {
-		ConnectionEventPtr e_ptr = waitEvent(timeout);
+		ConnectionEventPtr e_ptr = waitEvent(timeout_ms);
 		const ConnectionEvent &e = *e_ptr;
 
 		if (e.type != CONNEVENT_NONE) {
@@ -1467,14 +1467,14 @@ bool Connection::Receive(NetworkPacket *pkt, u32 timeout)
 
 void Connection::Receive(NetworkPacket *pkt)
 {
-	bool any = Receive(pkt, m_bc_receive_timeout);
+	bool any = ReceiveTimeoutMs(pkt, m_bc_receive_timeout);
 	if (!any)
 		throw NoIncomingDataException("No incoming data");
 }
 
 bool Connection::TryReceive(NetworkPacket *pkt)
 {
-	return Receive(pkt, 0);
+	return ReceiveTimeoutMs(pkt, 0);
 }
 
 void Connection::Send(session_t peer_id, u8 channelnum,

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -714,7 +714,8 @@ public:
 	void Connect(Address address);
 	bool Connected();
 	void Disconnect();
-	void Receive(NetworkPacket* pkt);
+	bool ReceiveTimeoutMs(NetworkPacket *pkt, u32 timeout_ms);
+	void Receive(NetworkPacket *pkt);
 	bool TryReceive(NetworkPacket *pkt);
 	void Send(session_t peer_id, u8 channelnum, NetworkPacket *pkt, bool reliable);
 	session_t GetPeerID() const { return m_peer_id; }
@@ -746,8 +747,6 @@ protected:
 	UDPSocket m_udpSocket;
 	// Command queue: user -> SendThread
 	MutexedQueue<ConnectionCommandPtr> m_command_queue;
-
-	bool Receive(NetworkPacket *pkt, u32 timeout);
 
 	void putEvent(ConnectionEventPtr e);
 


### PR DESCRIPTION
Old:
* game or dedicated_server_step increment server dtime counter. ServerThread
  runs in a loop in which it receives for at least 30 ms (hardcoded in `Server::start()`
  via `m_con->SetTimeoutMs(30);`), and then reads and resets the dtime counter.
  If the counter is >= 1ms, it does a server-step (AsyncRunStep).
* There are aliasing effects. E.g. in singleplayer the server-step dtimes are
  0ms (0 frames, server-step skipped), 16ms (1 frame) and 33ms (2 frames), and
  the actual times between the server-steps are >30ms or >60ms.

New:
* ServerThread receives (with timeout) until next step shall start (or longer
  if there are more packets), and calculates dtime itself.
* In singleplayer, Game tells the server if the game is paused or unfocused.

Effects:
* Shorter server dtimes are possible (i.e. <30ms).
* No dtime value aliasing.
* Server-step dtime is decoupled from client-step dtime (i.e. low client fps
  doesn't cause coarse server-steps).
  Note that pause and unfocus are now handled explicitly. But the results are
  similar to before.
* The server steps are not slower if no packets are received (fixes issue reported at #14093).
  (In master, the receive of the first packet has a timeout of 30 ms.)

## To do

This PR is a Ready for Review.

## How to test

* Try to successfully start singleplyer and dedicated server.
* Print the dtime in `Server::AsyncRunStep` to errorstream.

To test the #14093 issue:
* Set `dedicated_server_step` to `0.016`.
* `/lua local function f() core.sound_play("item_drop_pickup_1") core.after(0, f) end f()`
  (Sound from here: https://github.com/minetest-mods/item_drop/blob/master/sounds/item_drop_pickup.1.ogg Other short sounds might work as well.)
* Alternatively, again print the dtime in `Server::AsyncRunStep` to errorstream.
* Notice how in master the sound plays faster (and the dtime is always about 0.016 s) when the player moves, or when you move the camera. With PR, dtime is always 16 ms.