### PR TITLE
Corrections to loops and BFS cullers

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -269,6 +269,10 @@ void ClientMap::updateDrawList()
 
 	const v3s16 cam_pos_nodes = floatToInt(m_camera_position, BS);
 
+	v3s16 p_blocks_min;
+	v3s16 p_blocks_max;
+	getBlocksInViewRange(cam_pos_nodes, &p_blocks_min, &p_blocks_max);
+
 	// Number of blocks occlusion culled
 	u32 blocks_occlusion_culled = 0;
 	// Number of blocks frustum culled
@@ -304,12 +308,23 @@ void ClientMap::updateDrawList()
 	 frustum and display them.
 	 */
 	if (m_control.range_all || m_loops_occlusion_culler) {
+		// Number of blocks currently loaded by the client
+		u32 blocks_loaded = 0;
+		// Number of blocks with mesh in rendering range
+		u32 blocks_in_range_with_mesh = 0;
+
 		MapBlockVect sectorblocks;
 
 		for (auto &sector_it : m_sectors) {
 			MapSector *sector = sector_it.second;
-			if (!sector)
-				continue;
+			v2s16 sp = sector->getPos();
+
+			blocks_loaded += sector->size();
+			if (!m_control.range_all) {
+				if (sp.X < p_blocks_min.X || sp.X > p_blocks_max.X ||
+						sp.Y < p_blocks_min.Z || sp.Y > p_blocks_max.Z)
+					continue;
+			}
 
 			sectorblocks.clear();
 			sector->getBlocks(sectorblocks);
@@ -334,6 +349,16 @@ void ClientMap::updateDrawList()
 					mesh_sphere_radius = 0.0f;
 				}
 
+				// First, perform a simple distance check.
+				if (!m_control.range_all &&
+					mesh_sphere_center.getDistanceFrom(m_camera_position) >
+						m_control.wanted_range * BS + mesh_sphere_radius)
+					continue; // Out of range, skip.
+
+				// Keep the block alive as long as it is in range.
+				block->resetUsageTimer();
+				blocks_in_range_with_mesh++;
+
 				// Frustum culling
 				// Only do coarse culling here, to account for fast camera movement.
 				// This is needed because this function is not called every frame.
@@ -345,7 +370,7 @@ void ClientMap::updateDrawList()
 				}
 
 				// Raytraced occlusion culling - send rays from the camera to the block's corners
-				if (occlusion_culling_enabled && m_enable_raytraced_culling &&
+				if (!m_control.range_all && occlusion_culling_enabled && m_enable_raytraced_culling &&
 						mesh &&
 						isMeshOccluded(block, mesh_grid.cell_size, cam_pos_nodes)) {
 					blocks_occlusion_culled++;
@@ -367,15 +392,14 @@ void ClientMap::updateDrawList()
 				}
 			}
 		}
+
+		g_profiler->avg("MapBlock meshes in range [#]", blocks_in_range_with_mesh);
+		g_profiler->avg("MapBlocks loaded [#]", blocks_loaded);
 	} else {
 		// Blocks visited by the algorithm
 		u32 blocks_visited = 0;
 		// Block sides that were not traversed
 		u32 sides_skipped = 0;
-
-		v3s16 p_blocks_min;
-		v3s16 p_blocks_max;
-		getBlocksInViewRange(cam_pos_nodes, &p_blocks_min, &p_blocks_max);
 
 		std::queue<v3s16> blocks_to_consider;
 
@@ -595,7 +619,7 @@ void ClientMap::updateDrawList()
 
 void ClientMap::touchMapBlocks()
 {
-	if (!m_loops_occlusion_culler)
+	if (m_control.range_all || m_loops_occlusion_culler)
 		return;
 
 	v3s16 cam_pos_nodes = floatToInt(m_camera_position, BS);
@@ -608,8 +632,6 @@ void ClientMap::touchMapBlocks()
 	u32 blocks_loaded = 0;
 	// Number of blocks with mesh in rendering range
 	u32 blocks_in_range_with_mesh = 0;
-
-	v3f cam_pos_f = intToFloat(cam_pos_nodes, BS);
 
 	for (const auto &sector_it : m_sectors) {
 		MapSector *sector = sector_it.second;
@@ -630,23 +652,27 @@ void ClientMap::touchMapBlocks()
 		*/
 
 		for (MapBlock *block : sectorblocks) {
-			/*
-				Compare block position to camera position, skip
-				if not seen on display
-			*/
+			MapBlockMesh *mesh = block->mesh;
 
-			if (!block->mesh) {
-				// Ignore if mesh doesn't exist
-				continue;
+			// Calculate the coordinates for range and frustum culling
+			v3f mesh_sphere_center;
+			f32 mesh_sphere_radius;
+
+			v3s16 block_pos_nodes = block->getPos() * MAP_BLOCKSIZE;
+
+			if (mesh) {
+				mesh_sphere_center = intToFloat(block_pos_nodes, BS)
+						+ mesh->getBoundingSphereCenter();
+				mesh_sphere_radius = mesh->getBoundingRadius();
+			} else {
+				mesh_sphere_center = intToFloat(block_pos_nodes, BS)
+						+ v3f((MAP_BLOCKSIZE * 0.5f - 0.5f) * BS);
+				mesh_sphere_radius = 0.0f;
 			}
-
-			v3f mesh_sphere_center = intToFloat(block->getPosRelative(), BS)
-					+ block->mesh->getBoundingSphereCenter();
-			f32 mesh_sphere_radius = block->mesh->getBoundingRadius();
 
 			// First, perform a simple distance check.
 			if (!m_control.range_all &&
-				mesh_sphere_center.getDistanceFrom(cam_pos_f) >
+				mesh_sphere_center.getDistanceFrom(m_camera_position) >
 					m_control.wanted_range * BS + mesh_sphere_radius)
 				continue; // Out of range, skip.
 


### PR DESCRIPTION
This adds corrections to #13352. Fixes #13345 in the short term.

Things done:
* Reset usage timers and improve reporting of statistics in the loops culler
* Correctly touch map blocks when using bfs culler
* Align use of variables between the two algorithms.

## To do

This PR is Ready for Review.

## How to test

1. Clear your settings.
2. Set `client_unload_unused_data_timeout = 6`
3. Start a world and fly around
4. Mapblocks behind your back must not be unloaded by the client (they are within range).
5. There must not be any flickering of the wield mesh as you move or stand still (this happens if the air block your are in is unloaded and reloaded by the client).
6. Run `/set occlusion_culler loops`
7. In the profile screen check that the counters for 'Mapblocks loaded' and 'Meshes in range' are non-zero.
