### PR TITLE
[NO SQUASH] Revert "Add mesh-holding blocks to shadow drawlist. (#13203)"

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1240,9 +1240,6 @@ void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir,
 	// Number of blocks occlusion culled
 	u32 blocks_occlusion_culled = 0;
 
-	std::set<v3s16> shortlist;
-	MeshGrid mesh_grid = m_client->getMeshGrid();
-
 	for (auto &sector_it : m_sectors) {
 		MapSector *sector = sector_it.second;
 		if (!sector)
@@ -1256,8 +1253,8 @@ void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir,
 			Loop through blocks in sector
 		*/
 		for (MapBlock *block : sectorblocks) {
-			if (mesh_grid.cell_size == 1 && !block->mesh) {
-				// fast out in the case of no mesh chunking
+			if (!block->mesh) {
+				// Ignore if mesh doesn't exist
 				continue;
 			}
 
@@ -1265,17 +1262,6 @@ void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir,
 			v3f projection = shadow_light_pos + shadow_light_dir * shadow_light_dir.dotProduct(block_pos - shadow_light_pos);
 			if (projection.getDistanceFrom(block_pos) > radius)
 				continue;
-
-			if (mesh_grid.cell_size > 1) {
-				// Block meshes are stored in the corner block of a chunk
-				// (where all coordinate are divisible by the chunk size)
-				// Add them to the de-dup set.
-				shortlist.emplace(mesh_grid.getMeshPos(block->getPos()));
-			}
-			if (!block->mesh) {
-				// Ignore if mesh doesn't exist
-				continue;
-			}
 
 			blocks_in_range_with_mesh++;
 
@@ -1286,12 +1272,6 @@ void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir,
 			if (m_drawlist_shadow.emplace(block->getPos(), block).second) {
 				block->refGrab();
 			}
-		}
-	}
-	for (auto pos : shortlist) {
-		MapBlock * block = getBlockNoCreateNoEx(pos);
-		if (block && block->mesh && m_drawlist_shadow.emplace(pos, block).second) {
-			block->refGrab();
 		}
 	}
 


### PR DESCRIPTION
This reverts commit 2a8becd650a8adaa86fd7f76122ea75f11f49dad.

I changed my mind on this, after some thinking caused by the discussion on #13379

The only way for a block to be excluded in updateDrawListShadow is by distances from the shadow light source.
Crucially, that distance is derived from viewing_range and the limit is configurable (`shadow_map_max_distance`).

It makes no sense, I think, to add mesh-holding blocks even if their non-mesh blocks are within the distance, when the max is limited by config.

This cuts 50% of the time spent in updateDrawListShadow.

@x2048 @Desour Please correct me if I'm full of sh*t here :)

## To do

This PR is Ready for Review.

## How to test

Load any world. With a large client_mesh_chunk (8+) fly around and make not shadows are unduly missing.
