### PR TITLE
Allow large -z eye offsets

### DIFF
--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -449,7 +449,7 @@ int ObjectRef::l_set_eye_offset(lua_State *L)
 
 	// Prevent abuse of offset values (keep player always visible)
 	offset_third.X = rangelim(offset_third.X,-10,10);
-	offset_third.Z = rangelim(offset_third.Z,-5,5);
+	offset_third.Z = rangelim(offset_third.Z,-150,5);
 	/* TODO: if possible: improve the camera collision detection to allow Y <= -1.5) */
 	offset_third.Y = rangelim(offset_third.Y,-10,15); //1.5*BS
 


### PR DESCRIPTION
This is probably controversial. See #13364 for discussion.

A simple way for solving this is allowing mods to set a larger negative Z offset.
Since the server has to set this, this cannot be abused by the client alone.

The alternative is to remove these limits and let the modders decide. But NB, the camera is still where the player is (excluding the eye-offset) so blocks are retrieved and culled from the wrong place (of the eye-offset is very large).

## To do

For larger offsets we should take this into account for the camera position, otherwise the wrong blocks might be occlusion culled.

This PR is Ready for Review.

## How to test

Use a mod like the https://content.minetest.net/packages/apercy/steampunk_blimp/ 

Add this to a custom mod:
```
core.register_on_joinplayer(function(player)
    player:set_eye_offset({x=0, y=0, z=0}, {x=0, y=15, z=-100})
end)
```

Now observe how the 3rd person view actually makes sense.
The idea is that a mod could increase the -Z eye offset when a player attaches to a large entity.
