### PR TITLE
Add `vector.in_area()` utility function

### DIFF
--- a/builtin/common/tests/vector_spec.lua
+++ b/builtin/common/tests/vector_spec.lua
@@ -462,4 +462,11 @@ describe("vector", function()
 		end
 
 	end)
+
+	it("in_area()", function()
+		assert.True(vector.in_area(vector.zero(), vector.new(-10, -10, -10), vector.new(10, 10, 10)))
+		assert.True(vector.in_area(vector.new(-2, 5, -8), vector.new(-10, -10, -10), vector.new(10, 10, 10)))
+		assert.True(vector.in_area(vector.new(-10, -10, -10), vector.new(-10, -10, -10), vector.new(10, 10, 10)))
+		assert.False(vector.in_area(vector.new(-10, -10, -10), vector.new(10, 10, 10), vector.new(-11, -10, -10)))
+	end)
 end)

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -369,6 +369,12 @@ function vector.dir_to_rotation(forward, up)
 	return rot
 end
 
+function vector.contains(pos, min, max)
+	return (pos.x >= min.x) and (pos.x <= max.x) and
+		(pos.y >= min.y) and (pos.y <= max.y) and
+		(pos.z >= min.z) and (pos.z <= max.z)
+end
+
 if rawget(_G, "core") and core.set_read_vector and core.set_push_vector then
 	local function read_vector(v)
 		return v.x, v.y, v.z
@@ -386,10 +392,4 @@ if rawget(_G, "core") and core.set_read_vector and core.set_push_vector then
 		core.set_push_vector(fast_new)
 	end
 	core.set_push_vector = nil
-end
-
-function vector.contains(v1, v2, pos)
-	return (pos.x >= v1.x) and (pos.x <= v2.x) and
-		(pos.y >= v1.y) and (pos.y <= v2.y) and
-		(pos.z >= v1.z) and (pos.z <= v2.z)
 end

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -369,7 +369,7 @@ function vector.dir_to_rotation(forward, up)
 	return rot
 end
 
-function vector.contains(pos, min, max)
+function vector.in_area(pos, min, max)
 	return (pos.x >= min.x) and (pos.x <= max.x) and
 		(pos.y >= min.y) and (pos.y <= max.y) and
 		(pos.z >= min.z) and (pos.z <= max.z)

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -387,3 +387,9 @@ if rawget(_G, "core") and core.set_read_vector and core.set_push_vector then
 	end
 	core.set_push_vector = nil
 end
+
+function vector.contains(v1, v2, pos)
+	return (pos.x >= v1.x) and (pos.x <= v2.x) and
+		(pos.y >= v1.y) and (pos.y <= v2.y) and
+		(pos.z >= v1.z) and (pos.z <= v2.z)
+end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3540,6 +3540,8 @@ vectors are written like this: `(x, y, z)`:
     * Returns a boolean value indicating whether `v` is a real vector, eg. created
       by a `vector.*` function.
     * Returns `false` for anything else, including tables like `{x=3,y=1,z=4}`.
+* `vector.contains(v1, v2, pos)`:
+	* Returns a boolean value indicating if `pos` is inside area formed by `v1` and `v2`.
 
 For the following functions `x` can be either a vector or a number:
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3540,8 +3540,10 @@ vectors are written like this: `(x, y, z)`:
     * Returns a boolean value indicating whether `v` is a real vector, eg. created
       by a `vector.*` function.
     * Returns `false` for anything else, including tables like `{x=3,y=1,z=4}`.
-* `vector.contains(pos, min, max)`:
+* `vector.in_area(pos, min, max)`:
 	* Returns a boolean value indicating if `pos` is inside area formed by `min` and `max`.
+	* `min` and `max` are inclusive.
+	* If `min` is smaller than `max` on some axis, function always returns false.
 
 For the following functions `x` can be either a vector or a number:
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3543,7 +3543,8 @@ vectors are written like this: `(x, y, z)`:
 * `vector.in_area(pos, min, max)`:
 	* Returns a boolean value indicating if `pos` is inside area formed by `min` and `max`.
 	* `min` and `max` are inclusive.
-	* If `min` is smaller than `max` on some axis, function always returns false.
+	* If `min` is bigger than `max` on some axis, function always returns false.
+	* You can use `vector.sort` if you have two vectors and don't know which are the minimum and the maximum.
 
 For the following functions `x` can be either a vector or a number:
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3540,8 +3540,8 @@ vectors are written like this: `(x, y, z)`:
     * Returns a boolean value indicating whether `v` is a real vector, eg. created
       by a `vector.*` function.
     * Returns `false` for anything else, including tables like `{x=3,y=1,z=4}`.
-* `vector.contains(v1, v2, pos)`:
-	* Returns a boolean value indicating if `pos` is inside area formed by `v1` and `v2`.
+* `vector.contains(pos, min, max)`:
+	* Returns a boolean value indicating if `pos` is inside area formed by `min` and `max`.
 
 For the following functions `x` can be either a vector or a number:
 

--- a/games/devtest/mods/unittests/misc.lua
+++ b/games/devtest/mods/unittests/misc.lua
@@ -49,13 +49,6 @@ local function test_v3s16_metatable(player, pos)
 end
 unittests.register("test_v3s16_metatable", test_v3s16_metatable, {map=true})
 
-local function test_v3f_contains()
-	assert(vector.contains(vector.zero(), vector.new(-10, -10, -10), vector.new(10, 10, 10)))
-	assert(vector.contains(vector.new(-2, 5, -8), vector.new(-10, -10, -10), vector.new(10, 10, 10)))
-	assert(vector.contains(vector.new(-10, -10, -10), vector.new(-10, -10, -10), vector.new(10, 10, 10)))
-end
-unittests.register("test_v3f_contains", test_v3f_contains)
-
 local function test_clear_meta(_, pos)
 	local ref = core.get_meta(pos)
 

--- a/games/devtest/mods/unittests/misc.lua
+++ b/games/devtest/mods/unittests/misc.lua
@@ -49,6 +49,13 @@ local function test_v3s16_metatable(player, pos)
 end
 unittests.register("test_v3s16_metatable", test_v3s16_metatable, {map=true})
 
+local function test_v3f_contains()
+	assert(vector.contains(vector.zero(), vector.new(-10, -10, -10), vector.new(10, 10, 10)))
+	assert(vector.contains(vector.new(-2, 5, -8), vector.new(-10, -10, -10), vector.new(10, 10, 10)))
+	assert(vector.contains(vector.new(-10, -10, -10), vector.new(-10, -10, -10), vector.new(10, 10, 10)))
+end
+unittests.register("test_v3f_contains", test_v3f_contains)
+
 local function test_clear_meta(_, pos)
 	local ref = core.get_meta(pos)
 


### PR DESCRIPTION
Fix #13366 (@Zughy 's proposal)

## To do

- [x] Add function
- [x] Add `lua_api.txt` entry
- [x] Add unittests 

## How to test

```lua
-- Check is works exactly like `VoxelArea:contains()`
assert(vector.contains(vector.new(-10, -10, -10), vector.new(10, 10, 10), vector.zero()))
assert(vector.contains(vector.new(-10, -10, -10), vector.new(10, 10, 10), vector.new(-2, 5, -8)))
assert(vector.contains(vector.new(-10, -10, -10), vector.new(10, 10, 10), vector.new(-10, -10, -10)))

-- This test should not pass
-- assert(vector.contains(vector.new(-10, -10, -10), vector.new(10, 10, 10), vector.new(-11, -10, -10)))
```
