### PR TITLE
Do not call updateDrawList, updateDrawListShadow, and touchMapBlocks in the same frame

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4223,8 +4223,6 @@ void Game::updateShadows()
 
 	v3f sun_pos = light * offset_constant;
 
-	if (shadow->getDirectionalLightCount() == 0)
-		shadow->addDirectionalLight();
 	shadow->getDirectionalLight().setDirection(sun_pos);
 	shadow->setTimeOfDay(in_timeofday);
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4086,11 +4086,12 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	runData.update_draw_list_timer += dtime;
 	runData.touch_blocks_timer += dtime;
 
-	bool draw_list_updated = false;
-
 	float update_draw_list_delta = 0.2f;
 
 	v3f camera_direction = camera->getDirection();
+
+	// call only one of updateDrawList, touchMapBlocks, or updateShadow per frame
+	// (the else-ifs below are intentional)
 	if (runData.update_draw_list_timer >= update_draw_list_delta
 			|| runData.update_draw_list_last_cam_dir.getDistanceFrom(camera_direction) > 0.2
 			|| m_camera_offset_changed
@@ -4098,15 +4099,10 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		runData.update_draw_list_timer = 0;
 		client->getEnv().getClientMap().updateDrawList();
 		runData.update_draw_list_last_cam_dir = camera_direction;
-		draw_list_updated = true;
-	}
-
-	if (runData.touch_blocks_timer > update_draw_list_delta && !draw_list_updated) {
+	} else if (runData.touch_blocks_timer > update_draw_list_delta) {
 		client->getEnv().getClientMap().touchMapBlocks();
 		runData.touch_blocks_timer = 0;
-	}
-
-	if (RenderingEngine::get_shadow_renderer()) {
+	} else if (RenderingEngine::get_shadow_renderer()) {
 		updateShadows();
 	}
 

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -53,6 +53,9 @@ ShadowRenderer::ShadowRenderer(IrrlichtDevice *device, Client *client) :
 	m_shadow_map_colored = g_settings->getBool("shadow_map_color");
 	m_shadow_samples = g_settings->getS32("shadow_filters");
 	m_map_shadow_update_frames = g_settings->getS16("shadow_update_frames");
+
+	// add at least one light
+	addDirectionalLight();
 }
 
 ShadowRenderer::~ShadowRenderer()
@@ -157,11 +160,8 @@ size_t ShadowRenderer::getDirectionalLightCount() const
 
 f32 ShadowRenderer::getMaxShadowFar() const
 {
-	if (!m_light_list.empty()) {
-		float zMax = m_light_list[0].getFarValue();
-		return zMax;
-	}
-	return 0.0f;
+	float zMax = m_light_list[0].getFarValue();
+	return zMax;
 }
 
 void ShadowRenderer::setShadowIntensity(float shadow_intensity)
@@ -258,7 +258,7 @@ void ShadowRenderer::updateSMTextures()
 			node.node->setMaterialTexture(TEXTURE_LAYER_SHADOW, shadowMapTextureFinal);
 	}
 
-	if (!m_shadow_node_array.empty() && !m_light_list.empty()) {
+	if (!m_shadow_node_array.empty()) {
 		bool reset_sm_texture = false;
 
 		// detect if SM should be regenerated
@@ -344,7 +344,7 @@ void ShadowRenderer::update(video::ITexture *outputTarget)
 	}
 
 
-	if (!m_shadow_node_array.empty() && !m_light_list.empty()) {
+	if (!m_shadow_node_array.empty()) {
 
 		for (DirectionalLight &light : m_light_list) {
 			// Static shader values for entities are set in updateSMTextures


### PR DESCRIPTION
All of updateDrawList, updateDrawListShadow, and touchMapBlocks can take a few milliseconds with larg'ish viewing ranges. This avoids calling any combination of them in the same frame.

This also required a change to the shadow renderer. Before the game would add a directional light upon the first use. Now it's in the constructor, and it allow some slight simplification.
The alternative is to check for this in `MainShaderConstantSetter::onSetConstants`, but this seems cleaner.

## To do

This PR is Ready for Review.

## How to test

Load any world. Make sure there are no crashes :)
Try with shadows and note how the "not rendering time" in the usage graphs is better spread over the frames.
