### PR TITLE
Do not render objects that are invisble into the shadow map

### DIFF
--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -463,8 +463,8 @@ void ShadowRenderer::renderShadowObjects(
 	m_driver->setTransform(video::ETS_PROJECTION, light.getProjectionMatrix());
 
 	for (const auto &shadow_node : m_shadow_node_array) {
-		// we only take care of the shadow casters
-		if (shadow_node.shadowMode == ESM_RECEIVE)
+		// we only take care of the shadow casters and only visible nodes cast shadows
+		if (shadow_node.shadowMode == ESM_RECEIVE || !shadow_node.node->isVisible())
 			continue;
 
 		// render other objects


### PR DESCRIPTION
## Changes:

Adds a check during the render call for dynamic shadows if the object is visible.
This addresses issue #12630

I am not sure if this is the desired solution as the problem might also be solved by still updating transformation matrices for invisible objects.

## How to test
This snippet can be used for testing.
```lua
local entity_name = "testmod:entity"
minetest.register_entity(entity_name, {
	visual = "cube",
})
minetest.after(5, function()
	local player = minetest.get_player_by_name("singleplayer")
	local pos = player:get_pos()
	local entity = minetest.add_entity(pos, entity_name)
	entity:set_attach(player)
end)
```
