### PR TITLE
[NOSQUASH] Track server's maximum AsyncRunStep

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -50,6 +50,9 @@ ScopeProfiler::~ScopeProfiler()
 		case SPT_GRAPH_ADD:
 			m_profiler->graphAdd(m_name, duration);
 			break;
+		case SPT_MAX:
+			m_profiler->max(m_name, duration);
+			break;
 		}
 	}
 	delete m_timer;
@@ -64,7 +67,7 @@ void Profiler::add(const std::string &name, float value)
 {
 	MutexAutoLock lock(m_mutex);
 	{
-		/* No average shall have been used; mark add used as -2 */
+		/* No average shall have been used; mark add/max used as -2 */
 		std::map<std::string, int>::iterator n = m_avgcounts.find(name);
 		if (n == m_avgcounts.end()) {
 			m_avgcounts[name] = -2;
@@ -80,6 +83,29 @@ void Profiler::add(const std::string &name, float value)
 			m_data[name] = value;
 		else
 			n->second += value;
+	}
+}
+
+void Profiler::max(const std::string &name, float value)
+{
+	MutexAutoLock lock(m_mutex);
+	{
+		/* No average shall have been used; mark add/max used as -2 */
+		auto n = m_avgcounts.find(name);
+		if (n == m_avgcounts.end()) {
+			m_avgcounts[name] = -2;
+		} else {
+			if (n->second == -1)
+				n->second = -2;
+			assert(n->second == -2);
+		}
+	}
+	{
+		auto n = m_data.find(name);
+		if (n == m_data.end())
+			m_data[name] = value;
+		else if (value > n->second)
+			n->second = value;
 	}
 }
 

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -44,6 +44,7 @@ public:
 
 	void add(const std::string &name, float value);
 	void avg(const std::string &name, float value);
+	void max(const std::string &name, float value);
 	void clear();
 
 	float getValue(const std::string &name) const;
@@ -92,7 +93,8 @@ private:
 enum ScopeProfilerType{
 	SPT_ADD,
 	SPT_AVG,
-	SPT_GRAPH_ADD
+	SPT_GRAPH_ADD,
+	SPT_MAX
 };
 
 class ScopeProfiler

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -119,6 +119,7 @@ void *ServerThread::run()
 	}
 
 	while (!stopRequested()) {
+		ScopeProfiler spm(g_profiler, "Server::RunStep() (max)", SPT_MAX);
 		try {
 			m_server->AsyncRunStep();
 


### PR DESCRIPTION
In addition to the average AsyncRunStep it is quite helpful to track its maximum value - as that is the cause of jitter, rubberbanding, and the client and server generally getting out of sync w.r.t. the position and speed of entities.

This add a MAX option of the `ScopeProfiler` and uses it to track the maximum AsyncRunStep during the collection period.

## To do

This PR is Ready for Review.

## How to test

Open any world. Open the profile (F6) and notice there is now "AsyncRunStep (avg)" and "AsyncRunStep (max)". Check the values.