### PR TITLE
Remove formspec_default_bg_color/opacity settings

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2109,12 +2109,6 @@ noclip (Noclip) bool false
 #    Press the autoforward key again or the backwards movement to disable.
 continuous_forward (Continuous forward) bool false
 
-#    Formspec default background opacity (between 0 and 255).
-formspec_default_bg_opacity (Formspec Default Background Opacity) int 140 0 255
-
-#    Formspec default background color (R,G,B).
-formspec_default_bg_color (Formspec Default Background Color) string (0,0,0)
-
 #    Whether to show technical names.
 #    Affects mods and texture packs in the Content and Select Mods menus, as well as
 #    setting names in All Settings.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -3233,14 +3233,6 @@
 #    type: bool
 # continuous_forward = false
 
-#    Formspec default background opacity (between 0 and 255).
-#    type: int min: 0 max: 255
-# formspec_default_bg_opacity = 140
-
-#    Formspec default background color (R,G,B).
-#    type: string
-# formspec_default_bg_color = (0,0,0)
-
 #    Whether to show technical names.
 #    Affects mods and texture packs in the Content and Select Mods menus, as well as
 #    setting names in All Settings.
@@ -3611,4 +3603,3 @@
 #    See https://github.com/minetest/irrlicht/blob/master/include/Keycodes.h
 #    type: key
 # keymap_decrease_viewing_range_min = -
-

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -220,8 +220,6 @@ void set_default_settings()
 	settings->setDefault("console_alpha", "200");
 	settings->setDefault("formspec_fullscreen_bg_color", "(0,0,0)");
 	settings->setDefault("formspec_fullscreen_bg_opacity", "140");
-	settings->setDefault("formspec_default_bg_color", "(0,0,0)");
-	settings->setDefault("formspec_default_bg_opacity", "140");
 	settings->setDefault("selectionbox_color", "(0,0,0)");
 	settings->setDefault("selectionbox_width", "2");
 	settings->setDefault("node_highlighting", "box");

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3090,16 +3090,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	m_bgfullscreen = false;
 
 	m_formspec_version = 1;
-
-	{
-		v3f formspec_bgcolor = g_settings->getV3F("formspec_default_bg_color");
-		m_bgcolor = video::SColor(
-			(u8) clamp_u8(g_settings->getS32("formspec_default_bg_opacity")),
-			clamp_u8(myround(formspec_bgcolor.X)),
-			clamp_u8(myround(formspec_bgcolor.Y)),
-			clamp_u8(myround(formspec_bgcolor.Z))
-		);
-	}
+	m_bgcolor = video::SColor(140, 0, 0, 0);
 
 	{
 		v3f formspec_bgcolor = g_settings->getV3F("formspec_fullscreen_bg_color");


### PR DESCRIPTION
These settings are unnecessary. They only apply when formspecs don't have a background/bgcolor set. In practice, most games do theme their GUIs. Removing low value settings simplifies code and improves UX by decluttering the settings menu

Split out from #12140 

## To do

This PR is Ready for Review.

## How to test

<!-- Example code or instructions -->
