### PR TITLE
Android: Add confirm dialog before unzip

### DIFF
--- a/android/app/src/main/java/net/minetest/minetest/MainActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/MainActivity.java
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 package net.minetest.minetest;
 
 import android.Manifest;
-impott android.app.AlertDialog;
+import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;

--- a/android/app/src/main/java/net/minetest/minetest/MainActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/MainActivity.java
@@ -147,19 +147,23 @@ public class MainActivity extends AppCompatActivity {
 
 	private void checkAppVersion() {
 		if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
+			// if no external storage mounted found, Toast a String (see xml file)
 			Toast.makeText(this, R.string.no_external_storage, Toast.LENGTH_LONG).show();
 			finish();
 			return;
 		}
 
 		if (UnzipService.getIsRunning()) {
+			// if unzipping, make progress bar visible
 			mProgressBar.setVisibility(View.VISIBLE);
 			mProgressBar.setIndeterminate(true);
 			mTextView.setVisibility(View.VISIBLE);
 		} else if (sharedPreferences.getInt(TAG_VERSION_CODE, 0) == versionCode &&
 				Utils.isInstallValid(this)) {
+			// if everything set, start Minetest!
 			startNative();
 		} else {
+			// else UnzipService not running nor everything set, start UnzipService and make progress bar visible
 			mProgressBar.setVisibility(View.VISIBLE);
 			mProgressBar.setIndeterminate(true);
 			mTextView.setVisibility(View.VISIBLE);

--- a/android/app/src/main/java/net/minetest/minetest/MainActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/MainActivity.java
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 package net.minetest.minetest;
 
 import android.Manifest;
+impott android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -58,6 +59,12 @@ public class MainActivity extends AppCompatActivity {
 	private ProgressBar mProgressBar;
 	private TextView mTextView;
 	private SharedPreferences sharedPreferences;
+
+	AlertDialog.Builder builder = new AlertDialog.Builder(this);
+
+	builder.setMessage(R.string.unzip_confirm).setTitle("PLACE HOLDER");
+
+	AlertDialog dialog = builder.create();
 
 	private final BroadcastReceiver myReceiver = new BroadcastReceiver() {
 		@Override

--- a/android/app/src/main/java/net/minetest/minetest/MainActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/MainActivity.java
@@ -71,11 +71,11 @@ public class MainActivity extends AppCompatActivity {
 	builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
            public void onClick(DialogInterface dialog, int id) {
                // no
-               Toast.makeText(this, "PLACE HOLDER", Toast.LENGTH_SHORT).show();
+               Toast.makeText(this, R.string.unzip_confirm_cancelled, Toast.LENGTH_SHORT).show();
            }
        });
 
-	builder.setMessage(R.string.unzip_confirm).setTitle("PLACE HOLDER");
+	builder.setMessage(R.string.unzip_confirm).setTitle(unzip_confirm_title);
 
 	AlertDialog unzipConfirmDialog = builder.create();
 

--- a/android/app/src/main/java/net/minetest/minetest/MainActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/MainActivity.java
@@ -62,9 +62,22 @@ public class MainActivity extends AppCompatActivity {
 
 	AlertDialog.Builder builder = new AlertDialog.Builder(this);
 
+	builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+           public void onClick(DialogInterface dialog, int id) {
+               // yes
+               checkAppVersion();
+           }
+       });
+	builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
+           public void onClick(DialogInterface dialog, int id) {
+               // no
+               Toast.makeText(this, "PLACE HOLDER", Toast.LENGTH_SHORT).show();
+           }
+       });
+
 	builder.setMessage(R.string.unzip_confirm).setTitle("PLACE HOLDER");
 
-	AlertDialog dialog = builder.create();
+	AlertDialog unzipConfirmDialog = builder.create();
 
 	private final BroadcastReceiver myReceiver = new BroadcastReceiver() {
 		@Override
@@ -112,7 +125,7 @@ public class MainActivity extends AppCompatActivity {
 				Build.VERSION.SDK_INT < Build.VERSION_CODES.R)
 			checkPermission();
 		else
-			checkAppVersion();
+			unzipConfirmDialog.show();
 	}
 
 	private void checkPermission() {
@@ -148,7 +161,7 @@ public class MainActivity extends AppCompatActivity {
 					return;
 				}
 			}
-			checkAppVersion();
+			unzipConfirmDialog.show();
 		}
 	}
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,6 +8,9 @@
 	<string name="notification_title">Loading Minetest</string>
 	<string name="notification_description">Less than 1 minute&#8230;</string>
 	<string name="ime_dialog_done">Done</string>
+	<string name="unzip_confirm">Do you want to unpack necessary files\?</string>
+ 	<string name="yes">Yes</string>
+ 	<string name="no">No</string>
 	<string name="no_external_storage">External storage isn\'t available. If you use an SDCard, please reinsert it. Otherwise, try restarting your phone or contacting the Minetest developers</string>
 
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -9,6 +9,8 @@
 	<string name="notification_description">Less than 1 minute&#8230;</string>
 	<string name="ime_dialog_done">Done</string>
 	<string name="unzip_confirm">Do you want to unpack necessary files\?</string>
+ 	<string name="unzip_confirm_title">Unpack Files Confirm</string>
+ 	<string name="unzip_cancelled">Minetest require some necessary files to work</string>
  	<string name="yes">Yes</string>
  	<string name="no">No</string>
 	<string name="no_external_storage">External storage isn\'t available. If you use an SDCard, please reinsert it. Otherwise, try restarting your phone or contacting the Minetest developers</string>


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
Give user the right to unzip Minetest files or not, this is useful for low end device users
- How does the PR work?
meaning 0: replace checkAppVersion with dialog show, meaning 1: not tested yet
- Does it resolve any reported issue?
not yet checked
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
seems not
- If not a bug fix, why is this PR needed? What usecases does it solve?
idk
## To do

Ready for Review.
<!-- ^ delete one -->

## How to test
0. install Minetest on Android
1. delete data if there's already a Minetest installed (¡¡¡BACKUP FIRST!!!)
2. play the game as normal, a dialog should appear asking do you want to unpack files
<!-- Example code or instructions -->
