### PR TITLE
Disable vertical movement in free_move when both jump and sneak keys are pressed

### DIFF
--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -575,11 +575,13 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 
 		if (control.sneak) {
 			if (free_move) {
-				// In free movement mode, sneak descends
-				if (fast_move && (control.aux1 || always_fly_fast))
-					speedV.Y = -movement_speed_fast;
-				else
-					speedV.Y = -movement_speed_walk;
+				if (!control.jump) {
+					// In free movement mode, sneak descends if jump key isn't pressed
+					if (fast_move && (control.aux1 || always_fly_fast))
+						speedV.Y = -movement_speed_fast;
+					else
+						speedV.Y = -movement_speed_walk;
+				}
 			} else if (in_liquid || in_liquid_stable) {
 				if (fast_climb)
 					speedV.Y = -movement_speed_fast;
@@ -606,16 +608,19 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 
 	if (control.jump) {
 		if (free_move) {
-			if (player_settings.aux1_descends || always_fly_fast) {
-				if (fast_move)
-					speedV.Y = movement_speed_fast;
-				else
-					speedV.Y = movement_speed_walk;
-			} else {
-				if (fast_move && control.aux1)
-					speedV.Y = movement_speed_fast;
-				else
-					speedV.Y = movement_speed_walk;
+			if (!control.sneak) {
+				// Don't fly up if sneak key is pressed
+				if (player_settings.aux1_descends || always_fly_fast) {
+					if (fast_move)
+						speedV.Y = movement_speed_fast;
+					else
+						speedV.Y = movement_speed_walk;
+				} else {
+					if (fast_move && control.aux1)
+						speedV.Y = movement_speed_fast;
+					else
+						speedV.Y = movement_speed_walk;
+				}
 			}
 		} else if (m_can_jump) {
 			/*

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -573,15 +573,14 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			}
 		}
 
-		if (control.sneak) {
+		if (control.sneak && !control.jump) {
+			// Descend player in freemove mode, liquids and climbable nodes by sneak key, only if jump key is released
 			if (free_move) {
-				if (!control.jump) {
-					// In free movement mode, sneak descends if jump key isn't pressed
-					if (fast_move && (control.aux1 || always_fly_fast))
-						speedV.Y = -movement_speed_fast;
-					else
-						speedV.Y = -movement_speed_walk;
-				}
+				// In free movement mode, sneak descends
+				if (fast_move && (control.aux1 || always_fly_fast))
+					speedV.Y = -movement_speed_fast;
+				else
+					speedV.Y = -movement_speed_walk;
 			} else if (in_liquid || in_liquid_stable) {
 				if (fast_climb)
 					speedV.Y = -movement_speed_fast;
@@ -634,13 +633,13 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				setSpeed(speedJ);
 				m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_JUMP));
 			}
-		} else if (in_liquid && !m_disable_jump) {
+		} else if (in_liquid && !m_disable_jump && !control.sneak) {
 			if (fast_climb)
 				speedV.Y = movement_speed_fast;
 			else
 				speedV.Y = movement_speed_walk;
 			swimming_vertical = true;
-		} else if (is_climbing && !m_disable_jump) {
+		} else if (is_climbing && !m_disable_jump && !control.sneak) {
 			if (fast_climb)
 				speedV.Y = movement_speed_fast;
 			else


### PR DESCRIPTION
Currently, when you press both `jump` and `sneak` keys in free mode(fly mode), you will just fly upwards.
This PR makes so localplayer will not fly up or down if you holding `jump` and `sneak` keys at the same time.
This feature is pretty useful when building with advanced tools, for example, node replacer mod uses `sneak + place` combination to set the replacent tool to the pointed node. Currently, you have to fastly click `sneak + place` before you descent from pointed node. With my patch, you will can just press `sneak` and `jump` keys simultaneously and don't rush to click `place` key.