### PR TITLE
Load blocks and objects behind player when in third-persion front-view

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1014,8 +1014,8 @@ void Client::Send(NetworkPacket* pkt)
 		serverCommandFactoryTable[pkt->getCommand()].reliable);
 }
 
-// Will fill up 12 + 12 + 4 + 4 + 4 bytes
-void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *pkt)
+// Will fill up 12 + 12 + 4 + 4 + 4 + 1 + 1 bytes
+void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *pkt, bool camera_inverted)
 {
 	v3f pf           = myplayer->getPosition() * 100;
 	v3f sf           = myplayer->getSpeed() * 100;
@@ -1039,9 +1039,11 @@ void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *
 		[12+12+4+4] u32 keyPressed
 		[12+12+4+4+4] u8 fov*80
 		[12+12+4+4+4+1] u8 ceil(wanted_range / MAP_BLOCKSIZE)
+		[12+12+4+4+4+1+1] u8 camera_inverted (bool)
 	*/
 	*pkt << position << speed << pitch << yaw << keyPressed;
 	*pkt << fov << wanted_range;
+	*pkt << camera_inverted;
 }
 
 void Client::interact(InteractAction action, const PointedThing& pointed)
@@ -1076,7 +1078,7 @@ void Client::interact(InteractAction action, const PointedThing& pointed)
 
 	pkt.putLongString(tmp_os.str());
 
-	writePlayerPos(myplayer, &m_env.getClientMap(), &pkt);
+	writePlayerPos(myplayer, &m_env.getClientMap(), &pkt, m_camera->getCameraMode() == CAMERA_MODE_FIRST);
 
 	Send(&pkt);
 }
@@ -1378,28 +1380,31 @@ void Client::sendPlayerPos()
 	u8 wanted_range = map.getControl().wanted_range;
 
 	u32 keyPressed = player->control.getKeysPressed();
+	bool camera_inverted = m_camera->getCameraMode() == CAMERA_MODE_THIRD_FRONT;
 
 	if (
-			player->last_position     == player->getPosition() &&
-			player->last_speed        == player->getSpeed()    &&
-			player->last_pitch        == player->getPitch()    &&
-			player->last_yaw          == player->getYaw()      &&
-			player->last_keyPressed   == keyPressed            &&
-			player->last_camera_fov   == camera_fov            &&
-			player->last_wanted_range == wanted_range)
+			player->last_position        == player->getPosition() &&
+			player->last_speed           == player->getSpeed()    &&
+			player->last_pitch           == player->getPitch()    &&
+			player->last_yaw             == player->getYaw()      &&
+			player->last_keyPressed      == keyPressed            &&
+			player->last_camera_fov      == camera_fov            &&
+			player->last_camera_inverted == camera_inverted       &&
+			player->last_wanted_range    == wanted_range)
 		return;
 
-	player->last_position     = player->getPosition();
-	player->last_speed        = player->getSpeed();
-	player->last_pitch        = player->getPitch();
-	player->last_yaw          = player->getYaw();
-	player->last_keyPressed   = keyPressed;
-	player->last_camera_fov   = camera_fov;
-	player->last_wanted_range = wanted_range;
+	player->last_position        = player->getPosition();
+	player->last_speed           = player->getSpeed();
+	player->last_pitch           = player->getPitch();
+	player->last_yaw             = player->getYaw();
+	player->last_keyPressed      = keyPressed;
+	player->last_camera_fov      = camera_fov;
+	player->last_camera_inverted = camera_inverted;
+	player->last_wanted_range    = wanted_range;
 
-	NetworkPacket pkt(TOSERVER_PLAYERPOS, 12 + 12 + 4 + 4 + 4 + 1 + 1);
+	NetworkPacket pkt(TOSERVER_PLAYERPOS, 12 + 12 + 4 + 4 + 4 + 1 + 1 + 1);
 
-	writePlayerPos(player, &map, &pkt);
+	writePlayerPos(player, &map, &pkt, camera_inverted);
 
 	Send(&pkt);
 }

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1014,7 +1014,7 @@ void Client::Send(NetworkPacket* pkt)
 		serverCommandFactoryTable[pkt->getCommand()].reliable);
 }
 
-// Will fill up 12 + 12 + 4 + 4 + 4 + 1 + 1 bytes
+// Will fill up 12 + 12 + 4 + 4 + 4 + 1 + 1 + 1 bytes
 void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *pkt, bool camera_inverted)
 {
 	v3f pf           = myplayer->getPosition() * 100;
@@ -1078,7 +1078,7 @@ void Client::interact(InteractAction action, const PointedThing& pointed)
 
 	pkt.putLongString(tmp_os.str());
 
-	writePlayerPos(myplayer, &m_env.getClientMap(), &pkt, m_camera->getCameraMode() == CAMERA_MODE_FIRST);
+	writePlayerPos(myplayer, &m_env.getClientMap(), &pkt, m_camera->getCameraMode() == CAMERA_MODE_THIRD_FRONT);
 
 	Send(&pkt);
 }

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -84,6 +84,7 @@ public:
 	u32 last_keyPressed = 0;
 	u8 last_camera_fov = 0;
 	u8 last_wanted_range = 0;
+	bool last_camera_inverted = false;
 
 	float camera_impact = 0.0f;
 

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -149,6 +149,9 @@ void RemoteClient::GetNextBlocks (
 	camera_dir.rotateYZBy(sao->getLookPitch());
 	camera_dir.rotateXZBy(sao->getRotation().Y);
 
+	if (sao->getCameraInverted())
+		camera_dir = -camera_dir;
+
 	u16 max_simul_sends_usually = m_max_simul_sends;
 
 	/*

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -920,7 +920,7 @@ enum ToServerCommand
 		[2+12+12] s32 pitch*100
 		[2+12+12+4] s32 yaw*100
 		[2+12+12+4+4] u32 keyPressed
-		[2+12+12+4+4+1] u8 fov*80
+		[2+12+12+4+4+4] u8 fov*80
 		[2+12+12+4+4+4+1] u8 ceil(wanted_range / MAP_BLOCKSIZE)
 		[2+12+12+4+4+4+1+1] u8 camera_inverted (bool)
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -922,6 +922,8 @@ enum ToServerCommand
 		[2+12+12+4+4] u32 keyPressed
 		[2+12+12+4+4+1] u8 fov*80
 		[2+12+12+4+4+4+1] u8 ceil(wanted_range / MAP_BLOCKSIZE)
+		[2+12+12+4+4+4+1+1] u8 camera_inverted (bool)
+
 	*/
 
 	TOSERVER_GOTBLOCKS = 0x24,

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -478,7 +478,7 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 
 	f32 fov = 0;
 	u8 wanted_range = 0;
-	u8 bits; // bits instead of bool so it is extensible later
+	u8 bits = 0; // bits instead of bool so it is extensible later
 
 	*pkt >> keyPressed;
 	*pkt >> f32fov;
@@ -503,7 +503,7 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	playersao->setPlayerYaw(yaw);
 	playersao->setFov(fov);
 	playersao->setWantedRange(wanted_range);
-	playersao->setCameraInverted(bits && 0x01);
+	playersao->setCameraInverted(bits & 0x01);
 
 	player->control.unpackKeysPressed(keyPressed);
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -478,11 +478,14 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 
 	f32 fov = 0;
 	u8 wanted_range = 0;
+	u8 bits; // bits instead of bool so it is extensible later
 
 	*pkt >> keyPressed;
 	*pkt >> f32fov;
 	fov = (f32)f32fov / 80.0f;
 	*pkt >> wanted_range;
+	if (pkt->getRemainingBytes() >= 1)
+		*pkt >> bits;
 
 	v3f position((f32)ps.X / 100.0f, (f32)ps.Y / 100.0f, (f32)ps.Z / 100.0f);
 	v3f speed((f32)ss.X / 100.0f, (f32)ss.Y / 100.0f, (f32)ss.Z / 100.0f);
@@ -500,6 +503,7 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	playersao->setPlayerYaw(yaw);
 	playersao->setFov(fov);
 	playersao->setWantedRange(wanted_range);
+	playersao->setCameraInverted(bits && 0x01);
 
 	player->control.unpackKeysPressed(keyPressed);
 

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -105,7 +105,7 @@ public:
 	f32 getFov() const { return m_fov; }
 	void setWantedRange(const s16 range);
 	s16 getWantedRange() const { return m_wanted_range; }
-	void setCameraInverted(bool camera_inverted) { m_camera_inverted = camera_inverted; } // not stored
+	void setCameraInverted(bool camera_inverted) { m_camera_inverted = camera_inverted; }
 	bool getCameraInverted() const { return m_camera_inverted; }
 
 	/*
@@ -220,7 +220,8 @@ private:
 	f32 m_pitch = 0.0f;
 	f32 m_fov = 0.0f;
 	s16 m_wanted_range = 0.0f;
-	bool m_camera_inverted = false;
+
+	bool m_camera_inverted = false; // this is not store in the player db
 
 	SimpleMetadata m_meta;
 

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -105,6 +105,8 @@ public:
 	f32 getFov() const { return m_fov; }
 	void setWantedRange(const s16 range);
 	s16 getWantedRange() const { return m_wanted_range; }
+	void setCameraInverted(bool camera_inverted) { m_camera_inverted = camera_inverted; } // not stored
+	bool getCameraInverted() const { return m_camera_inverted; }
 
 	/*
 		Interaction interface
@@ -218,6 +220,7 @@ private:
 	f32 m_pitch = 0.0f;
 	f32 m_fov = 0.0f;
 	s16 m_wanted_range = 0.0f;
+	bool m_camera_inverted = false;
 
 	SimpleMetadata m_meta;
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -352,6 +352,8 @@ void ActiveBlockList::update(std::vector<PlayerSAO*> &active_players,
 			v3f camera_dir = v3f(0,0,1);
 			camera_dir.rotateYZBy(playersao->getLookPitch());
 			camera_dir.rotateXZBy(playersao->getRotation().Y);
+			if (playersao->getCameraInverted())
+				camera_dir = -camera_dir;
 			fillViewConeBlock(pos,
 				player_ao_range,
 				playersao->getEyePosition(),


### PR DESCRIPTION
2nd attempt. This time send a bit to the server if the client is in 3rd person front mode. That setting is not stored in the player database.

An alternative would be to actually send the client's camera orientation to the server. That way in the future we can allow for alternate camera angles - although for that we have the camera API PR.

Also fixes: #12770

## To do

This PR is Ready for Review.

## How to test

Load any world. Go to 3rd person front view. Observer that blocks and objects behind the player are loaded.
