### PR TITLE
Fix rotation of 4dir in schematic placement

### DIFF
--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -154,7 +154,7 @@ void MapNode::rotateAlongYAxis(const NodeDefManager *nodemgr, Rotation rot)
 			param2 |= rotate_facedir[index];
 		} else if (cpt2 == CPT2_4DIR || cpt2 == CPT2_COLORED_4DIR) {
 			u8 fourdir = param2 & 3;
-			u8 index = fourdir + rot;
+			u8 index = fourdir * 4 + rot;
 			param2 &= ~3;
 			param2 |= rotate_facedir[index];
 		}


### PR DESCRIPTION
Sadly, the 4dir / color4dir paramtype2 is incorrectly rotated when a 4dir node is placed in a schematic. The rotation code had a bug.

This PR fixes the rotation of 4dir and color4dir nodes if placed in a schematic.

How to test:
Place a schematic with 4dir nodes.