### PR TITLE
Add option to display reconnect on shutdown

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1843,6 +1843,9 @@ chatcommand_msg_time_threshold (Chat command time message threshold) float 0.1 0
 #    A message to be displayed to all clients when the server shuts down.
 kick_msg_shutdown (Shutdown message) string Server shutting down.
 
+#    Whether to ask clients to reconnect after a shutdown request.
+ask_reconnect_on_shutdown (Ask to reconnect after shutdown request) bool false
+
 #    A message to be displayed to all clients when the server crashes.
 kick_msg_crash (Crash message) string This server has experienced an internal error. You will now be disconnected.
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -2902,6 +2902,10 @@
 #    type: string
 # kick_msg_shutdown = Server shutting down.
 
+#    Whether to ask clients to reconnect after a shutdown request.
+#    type: bool
+# ask_reconnect_on_shutdown = false
+
 #    A message to be displayed to all clients when the server crashes.
 #    type: string
 # kick_msg_crash = This server has experienced an internal error. You will now be disconnected.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -380,6 +380,7 @@ void set_default_settings()
 	settings->setDefault("deprecated_lua_api_handling", "log");
 
 	settings->setDefault("kick_msg_shutdown", "Server shutting down.");
+	settings->setDefault("ask_reconnect_on_shutdown", "false");
 	settings->setDefault("kick_msg_crash", "This server has experienced an internal error. You will now be disconnected.");
 	settings->setDefault("ask_reconnect_on_crash", "false");
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -328,6 +328,7 @@ Server::~Server()
 			kick_msg = m_shutdown_state.message;
 		}
 		if (kick_msg.empty()) {
+			reconnect = g_settings->getBool("ask_reconnect_on_shutdown");
 			kick_msg = g_settings->get("kick_msg_shutdown");
 		}
 		m_env->saveLoadedPlayers(true);


### PR DESCRIPTION
This PR optionally allows the reconnect button to show on the client when a server is restarted via a service manager.
Most service manager's use proper signalling which means Minetest shuts down normally and doesn't treat it as a crash.

This PR is a Ready for Review.

## How to test
Add `ask_reconnect_on_shutdown = true` in your server configuration file and then shutdown the Minetest server.
