### PR TITLE
Introduce and start using microsecond sleep on Linux

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4244,7 +4244,7 @@ void FpsControl::limit(IrrlichtDevice *device, f32 *dtime)
 	if (busy_time < frametime_min) {
 		sleep_time = frametime_min - busy_time;
 		if (sleep_time > 1000)
-			sleep_ms(sleep_time / 1000);
+			sleep_us(sleep_time);
 	} else {
 		sleep_time = 0;
 	}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4243,7 +4243,7 @@ void FpsControl::limit(IrrlichtDevice *device, f32 *dtime)
 
 	if (busy_time < frametime_min) {
 		sleep_time = frametime_min - busy_time;
-		if (sleep_time > 1000)
+		if (sleep_time > 0)
 			sleep_us(sleep_time);
 	} else {
 		sleep_time = 0;

--- a/src/porting.h
+++ b/src/porting.h
@@ -54,6 +54,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#include <windows.h>
 
 	#define sleep_ms(x) Sleep(x)
+	#define sleep_us(x) Sleep(x/1000)
 #else
 	#include <unistd.h>
 	#include <cstdint> //for uintptr_t
@@ -67,6 +68,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#endif
 
 	#define sleep_ms(x) usleep(x*1000)
+	#define sleep_us(x) usleep(x)
 #endif
 
 #ifdef _MSC_VER

--- a/src/porting.h
+++ b/src/porting.h
@@ -54,7 +54,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#include <windows.h>
 
 	#define sleep_ms(x) Sleep(x)
-	#define sleep_us(x) Sleep(x/1000)
+	#define sleep_us(x) Sleep((x)/1000)
 #else
 	#include <unistd.h>
 	#include <cstdint> //for uintptr_t
@@ -67,7 +67,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		#define _GNU_SOURCE
 	#endif
 
-	#define sleep_ms(x) usleep(x*1000)
+	#define sleep_ms(x) usleep((x)*1000)
 	#define sleep_us(x) usleep(x)
 #endif
 


### PR DESCRIPTION
This is an attempt to help with https://github.com/minetest/minetest/issues/13399#issuecomment-1500993162.

The code previously had something like x/1000*1000 when it came to sleep times which is not particularly useful since the type of x was u64, so this was usually not the same as x.

This code now sleeps for x time on Linux etc., while keeping the same behaviour as before on Windows (which does not provide usleep).

Could someone affected by the FPS issue test whether this improves the issue on platforms that provide usleep?
