### PR TITLE
Remove `core.translate` @ order check

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -601,13 +601,7 @@ function core.translate(textdomain, str, ...)
 	local translated = str:gsub("@(.)", function(matched)
 		local c = string.byte(matched)
 		if string.byte("1") <= c and c <= string.byte("9") then
-			local a = c - string.byte("0")
-			if a ~= arg_index then
-				error("Escape sequences in string given to core.translate " ..
-					"are not in the correct order: got @" .. matched ..
-					"but expected @" .. tostring(arg_index))
-			end
-			if a > arg.n then
+			if c - string.byte("0") > arg.n then
 				error("Not enough arguments provided to core.translate")
 			end
 			arg_index = arg_index + 1

--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -601,7 +601,8 @@ function core.translate(textdomain, str, ...)
 	local translated = str:gsub("@(.)", function(matched)
 		local c = string.byte(matched)
 		if string.byte("1") <= c and c <= string.byte("9") then
-			if c - string.byte("0") > arg.n then
+			local a = c - string.byte("0")
+			if a > arg.n then
 				error("Not enough arguments provided to core.translate")
 			end
 			arg_index = arg_index + 1


### PR DESCRIPTION
@'s can now be in any order.

- This PR removes the @ sign order check for translations.
- This PR is needed because being able to have variables in different orders is crucial towards translation.

## To do

Ready for Review.

## How to test

1. Write this mod:
```lua
local S = minetest.get_translator("modname")
local monster_name = "Oerkki"

minetest.register_on_dieplayer(function(player)
	minetest.chat_send_all(S("@2 got @1", player:get_player_name(), monster_name)
end)
```
2. Add this translation file:
```
# textdomain: modname
@2 got @1=@2 alcanzó a @1
```
3. Die. See the chat message.
