### PR TITLE
Devtest: Don't use set_list in chest-of-everything trash's on_put

### DIFF
--- a/games/devtest/mods/chest_of_everything/init.lua
+++ b/games/devtest/mods/chest_of_everything/init.lua
@@ -41,7 +41,7 @@ local function add_detached_inventories(player)
 			return 0
 		end,
 		on_put = function(inv, listname, index, stack, player)
-			inv:set_list(listname, {})
+			inv:set_stack(listname, index, "")
 		end,
 	}, name)
 	inv_trash:set_size("main", 1)


### PR DESCRIPTION
Otherwise crashes if you insert an item using the listring.
For some reason, putting the item per hand into the trash is not affected.
Other mods (e.g. minetest_game's creative) have the same issue.

Edit: Looks like this only happens on shift-click because there are two `list_to_lock`s in case of `move_somewhere`, of which only one is released.

## To do

This PR is a Ready for Review.

We might however prefer to choose a different fix, as other mods are broken.

## How to test

* Shift-click an item into the trash.

cc @SmallJoker @Wuzzy2 
