### PR TITLE
Guarantee m_active_objects is not modified while iterating

### DIFF
--- a/src/server/activeobjectmgr.cpp
+++ b/src/server/activeobjectmgr.cpp
@@ -27,17 +27,15 @@ namespace server
 
 void ActiveObjectMgr::clear(const std::function<bool(ServerActiveObject *, u16)> &cb)
 {
-	std::vector<u16> objects_to_remove;
-	for (auto &it : m_active_objects) {
-		if (cb(it.second, it.first)) {
-			// Id to be removed from m_active_objects
-			objects_to_remove.push_back(it.first);
-		}
-	}
+	// make a defensive copy in case the
+	// passed callback changes the set of active objects
+	auto cloned_map(m_active_objects);
 
-	// Remove references from m_active_objects
-	for (u16 i : objects_to_remove) {
-		m_active_objects.erase(i);
+	for (auto &it : cloned_map) {
+		if (cb(it.second, it.first)) {
+			// Remove reference from m_active_objects
+			m_active_objects.erase(it.first);
+		}
 	}
 }
 


### PR DESCRIPTION
Caused by dd5a732fa90550066bb96305b64b6648903cc822 , but there's a general problem.
The callbacks determining which active object should be removed could also change m_active_objects itself.

See comments in #13093 
`unordered_map` only invalidates iterators when re-hashing. So it happens only sometimes.

Note that this is a quick, safe fix. We should think through dd5a732fa90550066bb96305b64b6648903cc822 and see how it is done the "right way", this might need undoing that feature and/or some refactoring. If anyone has any ideas I'd like to hear them.

In theory this can be used for arbitrary code execution in minetest server, but it will be hard to exploit.

## To do

This PR Ready for Review.

## How to test

With unordered_map it's hard/random to reproduce. You can apply #13093 (which has this fix) and then use this mod: https://content.minetest.net/packages/TestificateMods/offhand/

`map` invalidates iterator on each change... So that's a way to verify the fix.