### PR TITLE
Cavegen y biome check

### DIFF
--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -38,14 +38,16 @@ static NoiseParams nparams_caveliquids(0, 1, v3f(150.0, 150.0, 150.0), 776, 3, 0
 ////
 
 CavesNoiseIntersection::CavesNoiseIntersection(
-	const NodeDefManager *nodedef, BiomeManager *biomemgr, v3s16 chunksize,
+	const NodeDefManager *nodedef, BiomeManager *biomemgr, BiomeGen *biomegen, v3s16 chunksize,
 	NoiseParams *np_cave1, NoiseParams *np_cave2, s32 seed, float cave_width)
 {
 	assert(nodedef);
 	assert(biomemgr);
+	assert(biomegen);
 
 	m_ndef = nodedef;
 	m_bmgr = biomemgr;
+	m_bmgn = biomegen;
 
 	m_csize = chunksize;
 	m_cave_width = cave_width;
@@ -96,6 +98,7 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 		u16 base_filler = depth_top + biome->depth_filler;
 		u16 depth_riverbed = biome->depth_riverbed;
 		u16 nplaced = 0;
+
 		// Don't excavate the overgenerated stone at nmax.Y + 1,
 		// this creates a 'roof' over the tunnel, preventing light in
 		// tunnels at mapchunk borders when generating mapchunks upwards.
@@ -103,6 +106,12 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 		for (s16 y = nmax.Y; y >= nmin.Y - 1; y--,
 				index3d -= m_ystride,
 				VoxelArea::add_y(em, vi, -1)) {
+			// TODO
+			if (y < biome->min_pos.Y) {
+				// TODO Need to get a biome generator here
+				biome = m_bmgn->getBiomeAtIndex(index2d, v3s16(x, y, z));
+			}
+
 			content_t c = vm->m_data[vi].getContent();
 
 			if (c == CONTENT_AIR || c == biome->c_water_top ||

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -104,9 +104,6 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 
 		cur_biome_depth = 0;
 		s16 nextBiomeY = biome_transitions[cur_biome_depth];
-		while (nmax.Y < nextBiomeY) {
-			nextBiomeY = biome_transitions[++cur_biome_depth];
-		}
 
 		// Don't excavate the overgenerated stone at nmax.Y + 1,
 		// this creates a 'roof' over the tunnel, preventing light in
@@ -118,7 +115,12 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 			// We need this check to make sure that biomes don't generate too far down
 			if (y < nextBiomeY) {
 				biome = m_bmgn->getBiomeAtIndex(index2d, v3s16(x, y, z));
-				nextBiomeY = biome_transitions[++cur_biome_depth];
+
+				// Finding the height of the next biome
+				// On first iteration this may loop a couple times after than it should just run once
+				while (nmax.Y < nextBiomeY) {
+					nextBiomeY = biome_transitions[++cur_biome_depth];
+				}
 
 				/* if (x == nmin.X && z == nmin.Z) */
 				/* 	printf("Cave: check @ %i -> %s -> again at %i\n", y, biome->name.c_str(), nextBiomeY); */

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -82,8 +82,7 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 	const v3s16 &em = vm->m_area.getExtent();
 	u32 index2d = 0;  // Biomemap index
 
-	s16* biome_transitions = m_bmgn->getBiomeTransitions();
-	int cur_biome_depth;
+	s16 *biome_transitions = m_bmgn->getBiomeTransitions();
 
 	for (s16 z = nmin.Z; z <= nmax.Z; z++)
 	for (s16 x = nmin.X; x <= nmax.X; x++, index2d++) {
@@ -102,8 +101,8 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 		u16 depth_riverbed = biome->depth_riverbed;
 		u16 nplaced = 0;
 
-		cur_biome_depth = 0;
-		s16 nextBiomeY = biome_transitions[cur_biome_depth];
+		int cur_biome_depth = 0;
+		s16 biome_y_min = biome_transitions[cur_biome_depth];
 
 		// Don't excavate the overgenerated stone at nmax.Y + 1,
 		// this creates a 'roof' over the tunnel, preventing light in
@@ -113,17 +112,17 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 				index3d -= m_ystride,
 				VoxelArea::add_y(em, vi, -1)) {
 			// We need this check to make sure that biomes don't generate too far down
-			if (y < nextBiomeY) {
+			if (y < biome_y_min) {
 				biome = m_bmgn->getBiomeAtIndex(index2d, v3s16(x, y, z));
 
 				// Finding the height of the next biome
 				// On first iteration this may loop a couple times after than it should just run once
-				while (nmax.Y < nextBiomeY) {
-					nextBiomeY = biome_transitions[++cur_biome_depth];
+				while (y < biome_y_min) {
+					biome_y_min = biome_transitions[++cur_biome_depth];
 				}
 
-				/* if (x == nmin.X && z == nmin.Z) */
-				/* 	printf("Cave: check @ %i -> %s -> again at %i\n", y, biome->name.c_str(), nextBiomeY); */
+				/*if (x == nmin.X && z == nmin.Z)
+					printf("Cave: check @ %i -> %s -> again at %i\n", y, biome->name.c_str(), biome_y_min);*/
 			}
 
 			content_t c = vm->m_data[vi].getContent();

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -104,6 +104,9 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 
 		cur_biome_depth = 0;
 		s16 nextBiomeY = biome_transitions[cur_biome_depth];
+		while (nmax.Y < nextBiomeY) {
+			nextBiomeY = biome_transitions[++cur_biome_depth];
+		}
 
 		// Don't excavate the overgenerated stone at nmax.Y + 1,
 		// this creates a 'roof' over the tunnel, preventing light in
@@ -115,12 +118,8 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 			// We need this check to make sure that biomes don't generate too far down
 			if (y < nextBiomeY) {
 				biome = m_bmgn->getBiomeAtIndex(index2d, v3s16(x, y, z));
-				cur_biome_depth++;
-				nextBiomeY = biome_transitions[cur_biome_depth];
+				nextBiomeY = biome_transitions[++cur_biome_depth];
 
-				while (y < nextBiomeY) {
-					nextBiomeY = biome_transitions[++cur_biome_depth];
-				}
 				/* if (x == nmin.X && z == nmin.Z) */
 				/* 	printf("Cave: check @ %i -> %s -> again at %i\n", y, biome->name.c_str(), nextBiomeY); */
 			}

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -110,18 +110,8 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 				VoxelArea::add_y(em, vi, -1)) {
 			// We need this check to make sure that biomes don't generate too far down
 			if (y < nextBiomeY) {
-				biome = m_bmgn->getBiomeAtIndex(index2d, v3s16(x, y, z));
-				// If the new biome goes to the top of the next biome this will be used
-				nextBiomeY = biome->min_pos.Y;
-
-				// Otherwise we need to make sure that we don't miss a biome because it is ontop of another one
-				for (size_t i = 1; i < m_bmgr->getNumObjects(); i++) {
-					Biome *b = (Biome *)m_bmgr->getRaw(i);
-
-					if (b->max_pos.Y < y && b->max_pos.Y > nextBiomeY) {
-						nextBiomeY = b->max_pos.Y;
-					}
-				}
+				// We pass in the nextBiomeY float so we know where next to query for the next biome
+				biome = m_bmgn->getBiomeAtIndex(index2d, v3s16(x, y, z), &nextBiomeY);
 			}
 
 			content_t c = vm->m_data[vi].getContent();

--- a/src/mapgen/cavegen.h
+++ b/src/mapgen/cavegen.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "mapgen.h"
 #define VMANIP_FLAG_CAVE VOXELFLAG_CHECKED1
 
 typedef u16 biome_t;  // copy from mg_biome.h to avoid an unnecessary include
@@ -42,7 +43,7 @@ class CavesNoiseIntersection
 {
 public:
 	CavesNoiseIntersection(const NodeDefManager *nodedef,
-		BiomeManager *biomemgr, v3s16 chunksize, NoiseParams *np_cave1,
+		BiomeManager *biomemgr, BiomeGen *biomegen, v3s16 chunksize, NoiseParams *np_cave1,
 		NoiseParams *np_cave2, s32 seed, float cave_width);
 	~CavesNoiseIntersection();
 
@@ -51,6 +52,8 @@ public:
 private:
 	const NodeDefManager *m_ndef;
 	BiomeManager *m_bmgr;
+
+	BiomeGen *m_bmgn;
 
 	// configurable parameters
 	v3s16 m_csize;

--- a/src/mapgen/cavegen.h
+++ b/src/mapgen/cavegen.h
@@ -20,12 +20,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "mapgen.h"
 #define VMANIP_FLAG_CAVE VOXELFLAG_CHECKED1
 
 typedef u16 biome_t;  // copy from mg_biome.h to avoid an unnecessary include
 
 class GenerateNotifier;
+
+class BiomeGen;
 
 /*
 	CavesNoiseIntersection is a cave digging algorithm that carves smooth,

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -651,6 +651,9 @@ void MapgenBasic::generateBiomes()
 
 		cur_biome_depth = 0;
 		s16 biome_y_min = biome_transitions[cur_biome_depth];
+		while (node_max.Y < biome_y_min) {
+			biome_y_min = biome_transitions[++cur_biome_depth];
+		}
 
 		// Check node at base of mapchunk above, either a node of a previously
 		// generated mapchunk or if not, a node of overgenerated base terrain.
@@ -683,13 +686,8 @@ void MapgenBasic::generateBiomes()
 				if (!biome || y < biome_y_min) {
 					// (Re)calculate biome
 					biome = biomegen->getBiomeAtIndex(index, v3s16(x, y, z));
+					biome_y_min = biome_transitions[++cur_biome_depth];
 
-					cur_biome_depth++;
-					biome_y_min = biome_transitions[cur_biome_depth];
-
-					while (y < biome_y_min) {
-						biome_y_min = biome_transitions[++cur_biome_depth];
-					}
 					/* if (x == node_min.X && z == node_min.Z) */
 					/* 	printf("Map: check @ %i -> %s -> again at %i\n", y, biome->name.c_str(), biome_y_min); */
 				}

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -693,7 +693,18 @@ void MapgenBasic::generateBiomes()
 					noise_filler_depth->result[index], 0.0f);
 				depth_water_top = biome->depth_water_top;
 				depth_riverbed = biome->depth_riverbed;
+
 				biome_y_min = biome->min_pos.Y;
+
+				// Trying to make sure we get the correct next min position
+				// We may have run into a biome that overlaps another one entirely
+				for (size_t i = 1; i < this->m_bmgr->getNumObjects(); i++) {
+					Biome *b = (Biome *)this->m_bmgr->getRaw(i);
+
+					if (b->max_pos.Y < y && b->max_pos.Y > biome_y_min) {
+						biome_y_min = b->max_pos.Y;
+					}
+				}
 			}
 
 			if (c == c_stone) {

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -833,7 +833,6 @@ void MapgenBasic::generateCavesNoiseIntersection(s16 max_stone_y)
 	if (node_min.Y > max_stone_y || cave_width >= 10.0f)
 		return;
 
-	/* biomegen = emerge->biomegen; */
 	CavesNoiseIntersection caves_noise(ndef, m_bmgr, biomegen, csize,
 		&np_cave1, &np_cave2, seed, cave_width);
 

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -636,6 +636,9 @@ void MapgenBasic::generateBiomes()
 
 	noise_filler_depth->perlinMap2D(node_min.X, node_min.Z);
 
+	s16* biome_transitions = biomegen->getBiomeTransitions();
+	int cur_biome_depth;
+
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, index++) {
 		Biome *biome = NULL;
@@ -644,8 +647,10 @@ void MapgenBasic::generateBiomes()
 		u16 base_filler = 0;
 		u16 depth_water_top = 0;
 		u16 depth_riverbed = 0;
-		s16 biome_y_min = -MAX_MAP_GENERATION_LIMIT;
 		u32 vi = vm->m_area.index(x, node_max.Y, z);
+
+		cur_biome_depth = 0;
+		s16 biome_y_min = biome_transitions[cur_biome_depth];
 
 		// Check node at base of mapchunk above, either a node of a previously
 		// generated mapchunk or if not, a node of overgenerated base terrain.
@@ -675,8 +680,19 @@ void MapgenBasic::generateBiomes()
 				(air_above || !biome || y < biome_y_min); // 2, 3, 4
 
 			if (is_stone_surface || is_water_surface) {
-				// (Re)calculate biome
-				biome = biomegen->getBiomeAtIndex(index, v3s16(x, y, z), &biome_y_min);
+				if (!biome || y < biome_y_min) {
+					// (Re)calculate biome
+					biome = biomegen->getBiomeAtIndex(index, v3s16(x, y, z));
+
+					cur_biome_depth++;
+					biome_y_min = biome_transitions[cur_biome_depth];
+
+					while (y < biome_y_min) {
+						biome_y_min = biome_transitions[++cur_biome_depth];
+					}
+					/* if (x == node_min.X && z == node_min.Z) */
+					/* 	printf("Map: check @ %i -> %s -> again at %i\n", y, biome->name.c_str(), biome_y_min); */
+				}
 
 				// Add biome to biomemap at first stone surface detected
 				if (biomemap[index] == BIOME_NONE && is_stone_surface)

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -651,9 +651,6 @@ void MapgenBasic::generateBiomes()
 
 		cur_biome_depth = 0;
 		s16 biome_y_min = biome_transitions[cur_biome_depth];
-		while (node_max.Y < biome_y_min) {
-			biome_y_min = biome_transitions[++cur_biome_depth];
-		}
 
 		// Check node at base of mapchunk above, either a node of a previously
 		// generated mapchunk or if not, a node of overgenerated base terrain.
@@ -686,7 +683,12 @@ void MapgenBasic::generateBiomes()
 				if (!biome || y < biome_y_min) {
 					// (Re)calculate biome
 					biome = biomegen->getBiomeAtIndex(index, v3s16(x, y, z));
-					biome_y_min = biome_transitions[++cur_biome_depth];
+
+					// Finding the height of the next biome
+					// On first iteration this may loop a couple times after than it should just run once
+					while (node_max.Y < biome_y_min) {
+						biome_y_min = biome_transitions[++cur_biome_depth];
+					}
 
 					/* if (x == node_min.X && z == node_min.Z) */
 					/* 	printf("Map: check @ %i -> %s -> again at %i\n", y, biome->name.c_str(), biome_y_min); */

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -833,7 +833,8 @@ void MapgenBasic::generateCavesNoiseIntersection(s16 max_stone_y)
 	if (node_min.Y > max_stone_y || cave_width >= 10.0f)
 		return;
 
-	CavesNoiseIntersection caves_noise(ndef, m_bmgr, csize,
+	/* biomegen = emerge->biomegen; */
+	CavesNoiseIntersection caves_noise(ndef, m_bmgr, biomegen, csize,
 		&np_cave1, &np_cave2, seed, cave_width);
 
 	caves_noise.generateCaves(vm, node_min, node_max, biomemap);

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -689,7 +689,7 @@ void MapgenBasic::generateBiomes()
 						biome_y_min = biome_transitions[++cur_biome_depth];
 					}
 
-					/*if (x == node_min.X && z == node_min.Z) */
+					/*if (x == node_min.X && z == node_min.Z)
 						printf("Map: check @ %i -> %s -> again at %i\n", y, biome->name.c_str(), biome_y_min);*/
 				}
 

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -636,8 +636,7 @@ void MapgenBasic::generateBiomes()
 
 	noise_filler_depth->perlinMap2D(node_min.X, node_min.Z);
 
-	s16* biome_transitions = biomegen->getBiomeTransitions();
-	int cur_biome_depth;
+	s16 *biome_transitions = biomegen->getBiomeTransitions();
 
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, index++) {
@@ -649,7 +648,7 @@ void MapgenBasic::generateBiomes()
 		u16 depth_riverbed = 0;
 		u32 vi = vm->m_area.index(x, node_max.Y, z);
 
-		cur_biome_depth = 0;
+		int cur_biome_depth = 0;
 		s16 biome_y_min = biome_transitions[cur_biome_depth];
 
 		// Check node at base of mapchunk above, either a node of a previously
@@ -686,12 +685,12 @@ void MapgenBasic::generateBiomes()
 
 					// Finding the height of the next biome
 					// On first iteration this may loop a couple times after than it should just run once
-					while (node_max.Y < biome_y_min) {
+					while (y < biome_y_min) {
 						biome_y_min = biome_transitions[++cur_biome_depth];
 					}
 
-					/* if (x == node_min.X && z == node_min.Z) */
-					/* 	printf("Map: check @ %i -> %s -> again at %i\n", y, biome->name.c_str(), biome_y_min); */
+					/*if (x == node_min.X && z == node_min.Z) */
+						printf("Map: check @ %i -> %s -> again at %i\n", y, biome->name.c_str(), biome_y_min);*/
 				}
 
 				// Add biome to biomemap at first stone surface detected

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -676,7 +676,7 @@ void MapgenBasic::generateBiomes()
 
 			if (is_stone_surface || is_water_surface) {
 				// (Re)calculate biome
-				biome = biomegen->getBiomeAtIndex(index, v3s16(x, y, z));
+				biome = biomegen->getBiomeAtIndex(index, v3s16(x, y, z), &biome_y_min);
 
 				// Add biome to biomemap at first stone surface detected
 				if (biomemap[index] == BIOME_NONE && is_stone_surface)
@@ -693,18 +693,6 @@ void MapgenBasic::generateBiomes()
 					noise_filler_depth->result[index], 0.0f);
 				depth_water_top = biome->depth_water_top;
 				depth_riverbed = biome->depth_riverbed;
-
-				biome_y_min = biome->min_pos.Y;
-
-				// Trying to make sure we get the correct next min position
-				// We may have run into a biome that overlaps another one entirely
-				for (size_t i = 1; i < this->m_bmgr->getNumObjects(); i++) {
-					Biome *b = (Biome *)this->m_bmgr->getRaw(i);
-
-					if (b->max_pos.Y < y && b->max_pos.Y > biome_y_min) {
-						biome_y_min = b->max_pos.Y;
-					}
-				}
 			}
 
 			if (c == c_stone) {

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -150,7 +150,7 @@ BiomeGenOriginal::BiomeGenOriginal(BiomeManager *biomemgr,
 	// is disabled.
 	memset(biomemap, 0, sizeof(biome_t) * m_csize.X * m_csize.Z);
 
-	// Calculating the max position of each biome so we know when we might switch
+	// Calculating the bounding position of each biome so we know when we might switch
 	biomeTransitions = new s16[m_bmgr->getNumObjects() * 2];
 	for (size_t i = 1; i < m_bmgr->getNumObjects(); i++) {
 		Biome *b = (Biome *)m_bmgr->getRaw(i);
@@ -158,8 +158,10 @@ BiomeGenOriginal::BiomeGenOriginal(BiomeManager *biomemgr,
 		biomeTransitions[2 * (i - 1) + 1] = b->min_pos.Y;
 	}
 
+	// Sorting the biome transition points
 	std::sort(biomeTransitions, biomeTransitions + m_bmgr->getNumObjects() * 2, std::greater<int>());
 
+	// Getting rid of duplicate biome transition points
 	std::vector<s16> t;
 	s16 last = biomeTransitions[0];
 	t.push_back(last);
@@ -170,7 +172,7 @@ BiomeGenOriginal::BiomeGenOriginal(BiomeManager *biomemgr,
 		}
 	}
 	t.push_back(-MAX_MAP_GENERATION_LIMIT);
-	delete biomeTransitions;
+	delete []biomeTransitions;
 
 	biomeTransitions = new s16[t.size()];
 	memcpy(biomeTransitions, t.data(), sizeof(s16) * t.size());

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -280,7 +280,7 @@ Biome *BiomeGenOriginal::calcBiomeFromNoise(float heat, float humidity, v3s16 po
 			float d_humidity = humidity - b->humidity_point;
 			float dist = (d_heat * d_heat) + (d_humidity * d_humidity);
 
-			if (dist < dist_min && b->max_pos.Y > *min_y) { // Biome below will show since it has a better distance
+			if (dist < dist_min && b->max_pos.Y + b->vertical_blend > *min_y) { // Biome below will show since it has a better distance
 				// Returning the maximum height this biome can generate to
 				*min_y = b->max_pos.Y + b->vertical_blend;
 			}

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -132,7 +132,7 @@ public:
 
 	// Result of calcBiomes bulk computation.
 	biome_t *biomemap = nullptr;
-	s16 *biomeTransitions = nullptr;
+	s16 *biome_transitions = nullptr;
 
 protected:
 	BiomeManager *m_bmgr = nullptr;

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -127,7 +127,9 @@ public:
 
 	// Same as above, but uses a raw numeric index correlating to the (x,z) position.
 	// It also returns the current biomes minimum y value taking into account any
-	// biomes that are ontop of each other into min_y
+	// biomes that are ontop of each other into min_y.
+	// The minimum y value accounts for biome blending so if you query for a y value
+	// you may get a large y value than requested.
 	virtual Biome *getBiomeAtIndex(size_t index, v3s16 pos, s16* min_y = nullptr) const = 0;
 
 	// Result of calcBiomes bulk computation.

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -126,14 +126,13 @@ public:
 	virtual Biome *getBiomeAtPoint(v3s16 pos) const = 0;
 
 	// Same as above, but uses a raw numeric index correlating to the (x,z) position.
-	// It also returns the current biomes minimum y value taking into account any
-	// biomes that are ontop of each other into min_y.
-	// The minimum y value accounts for biome blending so if you query for a y value
-	// you may get a large y value than requested.
-	virtual Biome *getBiomeAtIndex(size_t index, v3s16 pos, s16* min_y = nullptr) const = 0;
+	virtual Biome *getBiomeAtIndex(size_t index, v3s16 pos) const = 0;
+
+	virtual s16 *getBiomeTransitions() const = 0;
 
 	// Result of calcBiomes bulk computation.
 	biome_t *biomemap = nullptr;
+	s16 *biomeTransitions = nullptr;
 
 protected:
 	BiomeManager *m_bmgr = nullptr;
@@ -187,9 +186,10 @@ public:
 
 	biome_t *getBiomes(s16 *heightmap, v3s16 pmin);
 	Biome *getBiomeAtPoint(v3s16 pos) const;
-	Biome *getBiomeAtIndex(size_t index, v3s16 pos, s16* min_y = nullptr) const;
+	Biome *getBiomeAtIndex(size_t index, v3s16 pos) const;
 
-	Biome *calcBiomeFromNoise(float heat, float humidity, v3s16 pos, s16* min_y = nullptr) const;
+	Biome *calcBiomeFromNoise(float heat, float humidity, v3s16 pos) const;
+	s16 *getBiomeTransitions() const;
 
 	float *heatmap;
 	float *humidmap;

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -126,7 +126,9 @@ public:
 	virtual Biome *getBiomeAtPoint(v3s16 pos) const = 0;
 
 	// Same as above, but uses a raw numeric index correlating to the (x,z) position.
-	virtual Biome *getBiomeAtIndex(size_t index, v3s16 pos) const = 0;
+	// It also returns the current biomes minimum y value taking into account any
+	// biomes that are ontop of each other into min_y
+	virtual Biome *getBiomeAtIndex(size_t index, v3s16 pos, s16* min_y = nullptr) const = 0;
 
 	// Result of calcBiomes bulk computation.
 	biome_t *biomemap = nullptr;
@@ -183,9 +185,9 @@ public:
 
 	biome_t *getBiomes(s16 *heightmap, v3s16 pmin);
 	Biome *getBiomeAtPoint(v3s16 pos) const;
-	Biome *getBiomeAtIndex(size_t index, v3s16 pos) const;
+	Biome *getBiomeAtIndex(size_t index, v3s16 pos, s16* min_y = nullptr) const;
 
-	Biome *calcBiomeFromNoise(float heat, float humidity, v3s16 pos) const;
+	Biome *calcBiomeFromNoise(float heat, float humidity, v3s16 pos, s16* min_y = nullptr) const;
 
 	float *heatmap;
 	float *humidmap;


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- The goal of this PR is to solve https://github.com/minetest/minetest/issues/13440 where biomes go outside their intended bounds.
- This PR works by modifying cave generation to change biome at a minimum Y value during generation
- It fixes https://github.com/minetest/minetest/issues/13440
- Does this relate to a goal in [the roadmap](../doc/direction.md)? This does try to make things more generally correct since mod biomes are currently not working as expected.

## To do

This PR is a Work in Progress
<!-- ^ delete one -->

- [x] Find if there are unintended consequences to the change, mostly due to the cavegen assuming it would only be one biome
- [x] See if we can/want to handle multiple biomes in the same cave generation, currently this doesn't seem to work even with the fix.

## How to test
```Lua
minetest.clear_registered_biomes()

minetest.register_biome({
	name = "dirt_plate",
	node_stone  = "basenodes:dirt",
	y_max = -5000,
	y_min = -11000,
	vertical_blend = 0,
	heat_point = 50,
	humidity_point = 50,
})

minetest.register_biome({
	name = "dirt_plate_2",
	node_stone  = "basenodes:dirt",
	y_max = -11010,
	y_min = -11020,
	vertical_blend = 0,
	heat_point = 50,
	humidity_point = 50,
})
```
Current Lua mod that I am using. dirt_plate_2 currently never generates as far as I can see.

<!-- Example code or instructions -->
