### PR TITLE
Fix crash on handling wallmounted nodes with invalid param2

### DIFF
--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -64,8 +64,12 @@ u8 MapNode::getFaceDir(const NodeDefManager *nodemgr,
 			f.param_type_2 == CPT2_COLORED_4DIR)
 		return getParam2() & 0x03;
 	if (allow_wallmounted && (f.param_type_2 == CPT2_WALLMOUNTED ||
-			f.param_type_2 == CPT2_COLORED_WALLMOUNTED))
-		return wallmounted_to_facedir[getParam2() & 0x07];
+			f.param_type_2 == CPT2_COLORED_WALLMOUNTED)) {
+		u8 wmountface = getParam2() & 0x07;
+		if (wmountface >= DWM_END)
+			wmountface = 0;
+		return wallmounted_to_facedir[wmountface];
+	}
 	return 0;
 }
 
@@ -74,7 +78,10 @@ u8 MapNode::getWallMounted(const NodeDefManager *nodemgr) const
 	const ContentFeatures &f = nodemgr->get(*this);
 	if (f.param_type_2 == CPT2_WALLMOUNTED ||
 			f.param_type_2 == CPT2_COLORED_WALLMOUNTED) {
-		return getParam2() & 0x07;
+		u8 wmountface = getParam2() & 0x07;
+		if (wmountface >= DWM_END)
+			wmountface = 0;
+		return wmountface;
 	} else if (f.drawtype == NDT_SIGNLIKE || f.drawtype == NDT_TORCHLIKE ||
 			f.drawtype == NDT_PLANTLIKE ||
 			f.drawtype == NDT_PLANTLIKE_ROOTED) {
@@ -161,7 +168,7 @@ void MapNode::rotateAlongYAxis(const NodeDefManager *nodemgr, Rotation rot)
 	} else if (cpt2 == CPT2_WALLMOUNTED ||
 			cpt2 == CPT2_COLORED_WALLMOUNTED) {
 		u8 wmountface = (param2 & 7);
-		if (wmountface <= 1)
+		if (wmountface <= 1 || wmountface >= DWM_END)
 			return;
 
 		Rotation oldrot = wallmounted_to_rot[wmountface - 2];

--- a/src/util/directiontables.h
+++ b/src/util/directiontables.h
@@ -22,23 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes.h"
 #include "irr_v3d.h"
 
-extern const v3s16 g_6dirs[6];
-
-extern const v3s16 g_7dirs[7];
-
-extern const v3s16 g_26dirs[26];
-
-// 26th is (0,0,0)
-extern const v3s16 g_27dirs[27];
-
-extern const u8 wallmounted_to_facedir[6];
-
-extern const v3s16 wallmounted_dirs[8];
-
-extern const v3s16 facedir_dirs[32];
-
-extern const v3s16 fourdir_dirs[4];
-
 /// Direction in the 6D format. g_27dirs contains corresponding vectors.
 /// Here P means Positive, N stands for Negative.
 enum Direction6D {
@@ -92,4 +75,22 @@ enum DirectionWallmounted {
 	DWM_XN,
 	DWM_ZP,
 	DWM_ZN,
+	DWM_END,
 };
+
+extern const v3s16 g_6dirs[DWM_END];
+
+extern const v3s16 g_7dirs[7];
+
+extern const v3s16 g_26dirs[26];
+
+// 26th is (0,0,0)
+extern const v3s16 g_27dirs[27];
+
+extern const u8 wallmounted_to_facedir[6];
+
+extern const v3s16 wallmounted_dirs[8];
+
+extern const v3s16 facedir_dirs[32];
+
+extern const v3s16 fourdir_dirs[4];


### PR DESCRIPTION
Wallmounted nodes are supposed to have param2 & 7 in range [0, 5]. Unfortunately, it's not enforced anywhere, and you can manually create a node with invalid param2, or it can happen due to bugs in mods.
When a client receives such a node, it randomly crashes due to array overflow. In practice, it happens rarely and on certain platforms, which actually makes it harder to debug.

## To do

This PR is Ready for Review.

## How to test

- Build minetest with asan.
- Create a wallmounted node with invalid param2.
- Join the server.
