### PR TITLE
Fix max_formspec_size not taking gui_scaling into account

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2594,12 +2594,13 @@ ClientDynamicInfo Game::getCurrentDynamicInfo() const
 {
 	v2u32 screen_size = RenderingEngine::getWindowSize();
 	f32 density = RenderingEngine::getDisplayDensity();
-	f32 gui_scaling = g_settings->getFloat("gui_scaling") * density;
-	f32 hud_scaling = g_settings->getFloat("hud_scaling") * density;
+	f32 gui_scaling = g_settings->getFloat("gui_scaling");
+	f32 real_gui_scaling = gui_scaling * density;
+	f32 real_hud_scaling = g_settings->getFloat("hud_scaling") * density;
 
 	return {
-		screen_size, gui_scaling, hud_scaling,
-		ClientDynamicInfo::calculateMaxFSSize(screen_size)
+		screen_size, real_gui_scaling, real_hud_scaling,
+		ClientDynamicInfo::calculateMaxFSSize(screen_size, gui_scaling)
 	};
 }
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1208,7 +1208,7 @@ void Game::run()
 		//  + Sleep time until the wanted FPS are reached
 		draw_times.limit(device, &dtime);
 
-		auto current_dynamic_info = ClientDynamicInfo::get_current();
+		auto current_dynamic_info = ClientDynamicInfo::getCurrent();
 		if (!current_dynamic_info.equal(client_display_info)) {
 			client_display_info = current_dynamic_info;
 			dynamic_info_send_timer = 0.2f;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -919,7 +919,6 @@ private:
 	static const ClientEventHandler clientEventHandler[CLIENTEVENT_MAX];
 
 	f32 getSensitivityScaleFactor() const;
-	ClientDynamicInfo getCurrentDynamicInfo() const;
 
 	InputHandler *input = nullptr;
 
@@ -1209,7 +1208,7 @@ void Game::run()
 		//  + Sleep time until the wanted FPS are reached
 		draw_times.limit(device, &dtime);
 
-		const auto current_dynamic_info = getCurrentDynamicInfo();
+		auto current_dynamic_info = ClientDynamicInfo::get_current();
 		if (!current_dynamic_info.equal(client_display_info)) {
 			client_display_info = current_dynamic_info;
 			dynamic_info_send_timer = 0.2f;
@@ -2588,20 +2587,6 @@ f32 Game::getSensitivityScaleFactor() const
 	// 16:9 aspect ratio to minimize disruption of existing sensitivity
 	// settings.
 	return tan(fov_y / 2.0f) * 1.3763818698f;
-}
-
-ClientDynamicInfo Game::getCurrentDynamicInfo() const
-{
-	v2u32 screen_size = RenderingEngine::getWindowSize();
-	f32 density = RenderingEngine::getDisplayDensity();
-	f32 gui_scaling = g_settings->getFloat("gui_scaling");
-	f32 real_gui_scaling = gui_scaling * density;
-	f32 real_hud_scaling = g_settings->getFloat("hud_scaling") * density;
-
-	return {
-		screen_size, real_gui_scaling, real_hud_scaling,
-		ClientDynamicInfo::calculateMaxFSSize(screen_size, gui_scaling)
-	};
 }
 
 void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1208,7 +1208,7 @@ void Game::run()
 		//  + Sleep time until the wanted FPS are reached
 		draw_times.limit(device, &dtime);
 
-		auto current_dynamic_info = ClientDynamicInfo::getCurrent();
+		const auto current_dynamic_info = ClientDynamicInfo::getCurrent();
 		if (!current_dynamic_info.equal(client_display_info)) {
 			client_display_info = current_dynamic_info;
 			dynamic_info_send_timer = 0.2f;

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -35,12 +35,12 @@ struct ClientDynamicInfo
 				abs(real_hud_scaling - other.real_hud_scaling) < 0.001f;
 	}
 
-	static v2f32 calculateMaxFSSize(v2u32 render_target_size) {
+	static v2f32 calculateMaxFSSize(v2u32 render_target_size, f32 gui_scaling) {
 		f32 factor =
 #ifdef HAVE_TOUCHSCREENGUI
-				10;
+				10 / gui_scaling;
 #else
-				15;
+				15 / gui_scaling;
 #endif
 		f32 ratio = (f32)render_target_size.X / (f32)render_target_size.Y;
 		if (ratio < 1)

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -20,8 +20,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "irrTypes.h"
+#ifndef SERVER
 #include "settings.h"
 #include "client/renderingengine.h"
+#endif
 
 
 struct ClientDynamicInfo
@@ -32,7 +34,8 @@ public:
 	f32 real_hud_scaling;
 	v2f32 max_fs_size;
 
-	static const ClientDynamicInfo get_current() {
+#ifndef SERVER
+	static const ClientDynamicInfo getCurrent() {
 		v2u32 screen_size = RenderingEngine::getWindowSize();
 		f32 density = RenderingEngine::getDisplayDensity();
 		f32 gui_scaling = g_settings->getFloat("gui_scaling", 0.5f, 20.0f);
@@ -45,6 +48,7 @@ public:
 			ClientDynamicInfo::calculateMaxFSSize(screen_size, gui_scaling)
 		};
 	}
+#endif
 
 	bool equal(const ClientDynamicInfo &other) const {
 		return render_target_size == other.render_target_size &&

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrTypes.h"
+#include "irrlichttypes_bloated.h"
 #ifndef SERVER
 #include "settings.h"
 #include "client/renderingengine.h"
@@ -41,7 +41,7 @@ public:
 	}
 
 #ifndef SERVER
-	static const ClientDynamicInfo getCurrent() {
+	static ClientDynamicInfo getCurrent() {
 		v2u32 screen_size = RenderingEngine::getWindowSize();
 		f32 density = RenderingEngine::getDisplayDensity();
 		f32 gui_scaling = g_settings->getFloat("gui_scaling", 0.5f, 20.0f);

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -20,14 +20,31 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "irrTypes.h"
+#include "settings.h"
+#include "client/renderingengine.h"
 
 
 struct ClientDynamicInfo
 {
+public:
 	v2u32 render_target_size;
 	f32 real_gui_scaling;
 	f32 real_hud_scaling;
 	v2f32 max_fs_size;
+
+	static const ClientDynamicInfo get_current() {
+		v2u32 screen_size = RenderingEngine::getWindowSize();
+		f32 density = RenderingEngine::getDisplayDensity();
+		f32 gui_scaling = g_settings->getFloat("gui_scaling", 0.5f, 20.0f);
+		f32 hud_scaling = g_settings->getFloat("hud_scaling", 0.5f, 20.0f);
+		f32 real_gui_scaling = gui_scaling * density;
+		f32 real_hud_scaling = hud_scaling * density;
+
+		return {
+			screen_size, real_gui_scaling, real_hud_scaling,
+			ClientDynamicInfo::calculateMaxFSSize(screen_size, gui_scaling)
+		};
+	}
 
 	bool equal(const ClientDynamicInfo &other) const {
 		return render_target_size == other.render_target_size &&
@@ -35,6 +52,7 @@ struct ClientDynamicInfo
 				abs(real_hud_scaling - other.real_hud_scaling) < 0.001f;
 	}
 
+private:
 	static v2f32 calculateMaxFSSize(v2u32 render_target_size, f32 gui_scaling) {
 		f32 factor =
 #ifdef HAVE_TOUCHSCREENGUI

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -34,6 +34,12 @@ public:
 	f32 real_hud_scaling;
 	v2f32 max_fs_size;
 
+	bool equal(const ClientDynamicInfo &other) const {
+		return render_target_size == other.render_target_size &&
+				abs(real_gui_scaling - other.real_gui_scaling) < 0.001f &&
+				abs(real_hud_scaling - other.real_hud_scaling) < 0.001f;
+	}
+
 #ifndef SERVER
 	static const ClientDynamicInfo getCurrent() {
 		v2u32 screen_size = RenderingEngine::getWindowSize();
@@ -50,13 +56,8 @@ public:
 	}
 #endif
 
-	bool equal(const ClientDynamicInfo &other) const {
-		return render_target_size == other.render_target_size &&
-				abs(real_gui_scaling - other.real_gui_scaling) < 0.001f &&
-				abs(real_hud_scaling - other.real_hud_scaling) < 0.001f;
-	}
-
 private:
+#ifndef SERVER
 	static v2f32 calculateMaxFSSize(v2u32 render_target_size, f32 gui_scaling) {
 		f32 factor =
 #ifdef HAVE_TOUCHSCREENGUI
@@ -70,4 +71,5 @@ private:
 		else
 			return { factor * ratio, factor };
 	}
+#endif
 };

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -928,26 +928,22 @@ int ModApiMainMenu::l_get_window_info(lua_State *L)
 	lua_newtable(L);
 	int top = lua_gettop(L);
 
-	const v2u32 &window_size = RenderingEngine::getWindowSize();
-	f32 density = RenderingEngine::getDisplayDensity();
-	f32 gui_scaling = g_settings->getFloat("gui_scaling");
-	f32 real_gui_scaling = gui_scaling * density;
-	f32 real_hud_scaling = g_settings->getFloat("hud_scaling") * density;
+	auto info = ClientDynamicInfo::get_current();
 
 	lua_pushstring(L, "size");
-	push_v2u32(L, window_size);
+	push_v2u32(L, info.render_target_size);
 	lua_settable(L, top);
 
 	lua_pushstring(L, "max_formspec_size");
-	push_v2f(L, ClientDynamicInfo::calculateMaxFSSize(window_size, gui_scaling));
+	push_v2f(L, info.max_fs_size);
 	lua_settable(L, top);
 
 	lua_pushstring(L, "real_gui_scaling");
-	lua_pushnumber(L, real_gui_scaling);
+	lua_pushnumber(L, info.real_gui_scaling);
 	lua_settable(L, top);
 
 	lua_pushstring(L, "real_hud_scaling");
-	lua_pushnumber(L, real_hud_scaling);
+	lua_pushnumber(L, info.real_hud_scaling);
 	lua_settable(L, top);
 
 	return 1;

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -930,23 +930,24 @@ int ModApiMainMenu::l_get_window_info(lua_State *L)
 
 	const v2u32 &window_size = RenderingEngine::getWindowSize();
 	f32 density = RenderingEngine::getDisplayDensity();
-	f32 gui_scaling = g_settings->getFloat("gui_scaling") * density;
-	f32 hud_scaling = g_settings->getFloat("hud_scaling") * density;
+	f32 gui_scaling = g_settings->getFloat("gui_scaling");
+	f32 real_gui_scaling = gui_scaling * density;
+	f32 real_hud_scaling = g_settings->getFloat("hud_scaling") * density;
 
 	lua_pushstring(L, "size");
 	push_v2u32(L, window_size);
 	lua_settable(L, top);
 
 	lua_pushstring(L, "max_formspec_size");
-	push_v2f(L, ClientDynamicInfo::calculateMaxFSSize(window_size));
+	push_v2f(L, ClientDynamicInfo::calculateMaxFSSize(window_size, gui_scaling));
 	lua_settable(L, top);
 
 	lua_pushstring(L, "real_gui_scaling");
-	lua_pushnumber(L, gui_scaling);
+	lua_pushnumber(L, real_gui_scaling);
 	lua_settable(L, top);
 
 	lua_pushstring(L, "real_hud_scaling");
-	lua_pushnumber(L, hud_scaling);
+	lua_pushnumber(L, real_hud_scaling);
 	lua_settable(L, top);
 
 	return 1;

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -928,7 +928,7 @@ int ModApiMainMenu::l_get_window_info(lua_State *L)
 	lua_newtable(L);
 	int top = lua_gettop(L);
 
-	auto info = ClientDynamicInfo::get_current();
+	auto info = ClientDynamicInfo::getCurrent();
 
 	lua_pushstring(L, "size");
 	push_v2u32(L, info.render_target_size);


### PR DESCRIPTION
The `max_formspec_size` value returned by `minetest.get_player_window_information()` is currently incorrect if the player has set the `gui_scaling` setting to a value other than 1.

That's because `prefer_imgsize` in `GUIFormSpecMenu::regenerateGui`  (<a href="https://github.com/minetest/minetest/blob/65692ad1b556c4e7b7e815e24270c869e8c20adf/src/gui/guiFormSpecMenu.cpp#L3250-L3257">link to the code</a>) is scaled by `gui_scaling`, but `ClientDynamicInfo::calculateMaxFSSize` (<a href="https://github.com/minetest/minetest/blob/65692ad1b556c4e7b7e815e24270c869e8c20adf/src/clientdynamicinfo.h#L38-L51">link to the code</a>) doesn't care. This PR just adds a division by `gui_scaling` to `calculateMaxFSSize`.

This bug cannot be worked around by mods since mods don't get the `gui_scaling`, but only the `real_gui_scaling` (`gui_scaling` * display density) of the player. Therefore, fixing this bug cannot not break any mods that already work around it.

## To do

This PR is a Ready for Review.

## How to test

Set `gui_scaling` to 0.5.
On the master branch, start Devtest and do `/testfullscreenfs`. The formspec won't be shown fullscreen.
Do the same on this PR. The formspec will be shown fullscreen.