### PR TITLE
Inventory: Allow InvRef:set_list with new_size >= old_size

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -964,7 +964,10 @@ InventoryList * Inventory::addList(const std::string &name, u32 size)
 {
 	setModified();
 
-	// Reset existing lists
+	// Reset existing lists instead of re-creating if possible.
+	// InventoryAction::apply() largely caches InventoryList pointers which must not be
+	// invalidated by Lua API calls (e.g. InvRef:set_list), hence do resize & clear which
+	// also include the neccessary resize lock checks.
 	s32 i = getListIndex(name);
 	if (i != -1) {
 		InventoryList *list = m_lists[i];

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -964,15 +964,13 @@ InventoryList * Inventory::addList(const std::string &name, u32 size)
 {
 	setModified();
 
-	// Remove existing lists
+	// Reset existing lists
 	s32 i = getListIndex(name);
 	if (i != -1) {
-		m_lists[i]->checkResizeLock();
-		delete m_lists[i];
-
-		m_lists[i] = new InventoryList(name, size, m_itemdef);
-		m_lists[i]->setModified();
-		return m_lists[i];
+		InventoryList *list = m_lists[i];
+		list->setSize(size);
+		list->clearItems();
+		return list;
 	}
 
 	//don't create list with invalid name


### PR DESCRIPTION
Fixes a regression introduced by enforced checks to work with valid pointers within inventory actions.

Instead of deleting the inventory list, it is resized and cleared to achieve the same functional result.
Making lists smaller is however still not allowed because the inventory actions might perform out-of-bounds accesses in follow-up callbacks.

## To do

This PR is Ready for Review.

## How to test

1. #13490 must pass. The first `set_list` call within the callback is valid too because it preserves the inventory size.