### PR TITLE
Inventory::addList(): Don't allocate new list, just resize (if needed) and clear existing one

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -964,14 +964,11 @@ InventoryList * Inventory::addList(const std::string &name, u32 size)
 {
 	setModified();
 
-	// Remove existing lists
+	// Resize and clear existing list
 	s32 i = getListIndex(name);
 	if (i != -1) {
-		m_lists[i]->checkResizeLock();
-		delete m_lists[i];
-
-		m_lists[i] = new InventoryList(name, size, m_itemdef);
-		m_lists[i]->setModified();
+		m_lists[i]->setSize(size);
+		m_lists[i]->clearItems();
 		return m_lists[i];
 	}
 

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -332,7 +332,7 @@ public:
 	void serialize(std::ostream &os, bool incremental = false) const;
 	void deSerialize(std::istream &is);
 
-	// Creates a new list if none exists or truncates existing lists
+	// Creates a new list if none exists, or resizes and clears existing list
 	InventoryList * addList(const std::string &name, u32 size);
 	InventoryList * getList(const std::string &name);
 	const InventoryList * getList(const std::string &name) const;


### PR DESCRIPTION
Fixes #13490.

(Another possible fix would be to use operator= to assign a new invlist.)

Note: References returned by `InventoryList::getItem()`, as well as iterators into `InventoryList::getItems()` can be invalidated from lua (as increasing the item vector size can cause a realloc).
I haven't yet found an instance where this is causing troubles. ItemStacks are usually stored as copy, and `getItems()` is only used at once place.

## To do

This PR is a Ready for Review.

## How to test

For example:
```lua
minetest.register_node("test_inv_callbacks:node", {
	description = "inv callback node",
	tiles = {"default_cobble.png^heart.png"},
	groups = {choppy = 3, oddly_breakable_by_hand = 3},
	on_construct = function(pos)
		minetest.log("on_construct")
		local meta = minetest.get_meta(pos)
		local inv = meta:get_inventory()
		inv:set_size("mylist", 5)
		meta:set_string("formspec", "size[8,10]"
			.."list[current_player;main;0,3;8,4;]"
			.."list[current_name;mylist;0,0;10,1;]")
	end,
	allow_metadata_inventory_move = function(pos, from_list, from_index,
			to_list, to_index, count, player)
		minetest.log("allow_metadata_inventory_move")
		return count
	end,
	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
		minetest.log("allow_metadata_inventory_put")
		local meta = minetest.get_meta(pos)
		local inv = meta:get_inventory()
		inv:set_list("mylist", {})
		return stack:get_count()
	end,
	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
		minetest.log("allow_metadata_inventory_take")
		return stack:get_count()
	end,
	on_metadata_inventory_move = function(pos, from_list, from_index,
			to_list, to_index, count, player)
		minetest.log("on_metadata_inventory_move")
	end,
	on_metadata_inventory_put = function(pos, listname, index, stack, player)
		minetest.log("on_metadata_inventory_put")
	end,
	on_metadata_inventory_take = function(pos, listname, index, stack, player)
		minetest.log("on_metadata_inventory_take")
	end,
})
```

Then put an item into the invlist.
