### PR TITLE
Skip face culling in shadows for double-sided materials (e.g. plantlike)

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1187,8 +1187,12 @@ void ClientMap::renderMapShadows(video::IVideoDriver *driver,
 			// override some material properties
 			video::SMaterial local_material = buf->getMaterial();
 			local_material.MaterialType = material.MaterialType;
-			local_material.BackfaceCulling = material.BackfaceCulling;
-			local_material.FrontfaceCulling = material.FrontfaceCulling;
+			// do not override culling if the original material renders both back
+			// and front faces (e.g. plantlike)
+			if (local_material.BackfaceCulling || local_material.FrontfaceCulling) {
+				local_material.BackfaceCulling = material.BackfaceCulling;
+				local_material.FrontfaceCulling = material.FrontfaceCulling;
+			}
 			local_material.BlendOperation = material.BlendOperation;
 			local_material.Lighting = false;
 			driver->setMaterial(local_material);

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1188,8 +1188,10 @@ void ClientMap::renderMapShadows(video::IVideoDriver *driver,
 			video::SMaterial local_material = buf->getMaterial();
 			local_material.MaterialType = material.MaterialType;
 			// do not override culling if the original material renders both back
-			// and front faces (e.g. plantlike)
-			if (local_material.BackfaceCulling || local_material.FrontfaceCulling) {
+			// and front faces in solid mode (e.g. plantlike)
+			// Transparent plants would still render shadows only from one side,
+			// but this conflicts with water which occurs much more frequently
+			if (is_transparent_pass || local_material.BackfaceCulling || local_material.FrontfaceCulling) {
 				local_material.BackfaceCulling = material.BackfaceCulling;
 				local_material.FrontfaceCulling = material.FrontfaceCulling;
 			}


### PR DESCRIPTION
At some sun angles, plantlike nodes produce incomplete or no shadow. This is because they render double-sided (no face culling) but shadow renderer does not respect that and culls front faces.

This PR fixes this problem by only overriding culling for nodes where at least one side is culled in the original material.

## To do

This PR is Ready for Review.

## How to test

1. Use API to set negative tilt for the sun/moon
```
minetest.register_on_joinplayer(function(player)
	player:set_sky({body_orbit_tilt = -30})
end)
```
2. Enter the world and look at the shadows of plantlike nodes. Shadows must be correct at all times.
3. Check shadows of other nodes, they should also be correct.
