### PR TITLE
Fix settings dialog not resetting filter when closed

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -463,7 +463,6 @@ local function buttonhandler(this, fields)
 	dialogdata.query = fields.search_query
 
 	if fields.back then
-		dialogdata.page_id = update_filtered_pages("")
 		this:delete()
 		return true
 	end
@@ -517,5 +516,9 @@ end
 
 
 function create_settings_dlg()
-	return dialog_create("dlg_settings", get_formspec, buttonhandler, nil)
+	local dlg = dialog_create("dlg_settings", get_formspec, buttonhandler, nil)
+
+	dlg.data.page_id = update_filtered_pages("")
+
+	return dlg
 end

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -463,6 +463,7 @@ local function buttonhandler(this, fields)
 	dialogdata.query = fields.search_query
 
 	if fields.back then
+		dialogdata.page_id = update_filtered_pages("")
 		this:delete()
 		return true
 	end


### PR DESCRIPTION
This PR fixes the setting dialog's filter not being reset when the dialog is closed, leading to the last search being applied while nothing is shown in the search field.

![image](https://github.com/minetest/minetest/assets/60856959/f858f019-9a73-4a4f-8c02-0eee4172ffa0)

## To do
This PR is a Ready for Review.

## How to test
1. Go into the settings dialog, search for "eeeeeeeee", see "No results".
2. Back button, then go back into settings
3. The filter should have been reset now.