### PR TITLE
Disable `desynchronize_mapblock_texture_animation` by default

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1667,7 +1667,7 @@ enable_vbo (VBO) bool true
 cloud_radius (Cloud radius) int 12 1 62
 
 #    Whether node texture animations should be desynchronized per mapblock.
-desynchronize_mapblock_texture_animation (Desynchronize block animation) bool true
+desynchronize_mapblock_texture_animation (Desynchronize block animation) bool false
 
 #    Enables caching of facedir rotated meshes.
 enable_mesh_cache (Mesh cache) bool false

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -2681,7 +2681,7 @@
 
 #    Whether node texture animations should be desynchronized per mapblock.
 #    type: bool
-# desynchronize_mapblock_texture_animation = true
+# desynchronize_mapblock_texture_animation = false
 
 #    Enables caching of facedir rotated meshes.
 #    type: bool

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -231,7 +231,7 @@ void set_default_settings()
 	settings->setDefault("gui_scaling", "1.0");
 	settings->setDefault("gui_scaling_filter", "false");
 	settings->setDefault("gui_scaling_filter_txr2img", "true");
-	settings->setDefault("desynchronize_mapblock_texture_animation", "true");
+	settings->setDefault("desynchronize_mapblock_texture_animation", "false");
 	settings->setDefault("hud_hotbar_max_width", "1.0");
 	settings->setDefault("enable_local_map_saving", "false");
 	settings->setDefault("show_entity_selectionbox", "false");


### PR DESCRIPTION
This PR disables the `desynchronize_mapblock_texture_animation` setting by default. When enabled, it makes it impossible to keep animated node textures in sync between mapblocks, they will always intentionally be out of sync. 

Below is an example, with the Rainbow Wool node on Voxelmanip Classic (animated to cycle between wool colours), when the setting is enabled:

![image](https://github.com/minetest/minetest/assets/60856959/9511e149-8bb7-43a1-8132-8f401c8ae2c3)

What I *actually* want it to look is like this, when the setting is disabled:

![image](https://github.com/minetest/minetest/assets/60856959/a5fc24b2-40ff-415e-827a-77aef8a2243b)

I don't see any reason as to why a game, mod or server would want to show off glaring mapblock seams like this, so I believe it should be disabled by default.

Another example with a less obnoxious animated texture, MTG's lava shows an ugly checkerboard pattern with the setting enabled.

![image](https://github.com/minetest/minetest/assets/60856959/f677a1ef-2262-4a52-bde2-c69120e6aeee)

## To do
This PR is a Ready for Review.

## How to test
:eyes: 