### PR TITLE
Android: Reliably showing an IME for text input dialog

### DIFF
--- a/android/app/src/main/java/net/minetest/minetest/CustomEditText.java
+++ b/android/app/src/main/java/net/minetest/minetest/CustomEditText.java
@@ -2,6 +2,8 @@
 Minetest
 Copyright (C) 2014-2020 MoNTE48, Maksim Gamarnik <MoNTE48@mail.ua>
 Copyright (C) 2014-2020 ubulem,  Bektur Mambetov <berkut87@gmail.com>
+Copyright (C) 2023 srifqi, Muhammad Rifqi Priyo Susanto
+		<muhammadrifqipriyosusanto@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -29,17 +31,52 @@ import androidx.appcompat.widget.AppCompatEditText;
 import java.util.Objects;
 
 public class CustomEditText extends AppCompatEditText {
+	private int editType = 2; // single line text input as default
+	private boolean wantsToShowKeyboard = false;
+
 	public CustomEditText(Context context) {
 		super(context);
 	}
 
+	public CustomEditText(Context context, int _editType) {
+		super(context);
+		editType = _editType;
+	}
+
 	@Override
 	public boolean onKeyPreIme(int keyCode, KeyEvent event) {
-		if (keyCode == KeyEvent.KEYCODE_BACK) {
+		// For multi-line, do not close the dialog after pressing back button
+		if (editType != 1 && keyCode == KeyEvent.KEYCODE_BACK) {
 			InputMethodManager mgr = (InputMethodManager)
 					getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
 			Objects.requireNonNull(mgr).hideSoftInputFromWindow(this.getWindowToken(), 0);
 		}
 		return false;
+	}
+
+	@Override
+	public void onWindowFocusChanged(boolean hasWindowFocus) {
+		super.onWindowFocusChanged(hasWindowFocus);
+		tryShowKeyboard();
+	}
+
+	public void requestFocusTryShow() {
+		requestFocus();
+		wantsToShowKeyboard = true;
+		tryShowKeyboard();
+	}
+
+	private void tryShowKeyboard() {
+		if (hasWindowFocus() && wantsToShowKeyboard) {
+			if (isFocused()) {
+				CustomEditText that = this;
+				post(() -> {
+					final InputMethodManager imm = (InputMethodManager)
+							getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+					imm.showSoftInput(that, 0);
+				});
+			}
+			wantsToShowKeyboard = false;
+		}
 	}
 }

--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -31,7 +31,6 @@ import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.LinearLayout;
 
 import androidx.annotation.Keep;
@@ -97,21 +96,11 @@ public class GameActivity extends NativeActivity {
 		container.setOrientation(LinearLayout.VERTICAL);
 		builder.setView(container);
 		AlertDialog alertDialog = builder.create();
-		EditText editText;
-		// For multi-line, do not close the dialog after pressing back button
-		if (editType == 1) {
-			editText = new EditText(this);
-		} else {
-			editText = new CustomEditText(this);
-		}
+		CustomEditText editText = new CustomEditText(this, editType);
 		container.addView(editText);
 		editText.setMaxLines(8);
-		editText.requestFocus();
 		editText.setHint(hint);
 		editText.setText(current);
-		final InputMethodManager imm = (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
-		Objects.requireNonNull(imm).toggleSoftInput(InputMethodManager.SHOW_FORCED,
-				InputMethodManager.HIDE_IMPLICIT_ONLY);
 		if (editType == 1)
 			editText.setInputType(InputType.TYPE_CLASS_TEXT |
 					InputType.TYPE_TEXT_FLAG_MULTI_LINE);
@@ -120,7 +109,8 @@ public class GameActivity extends NativeActivity {
 					InputType.TYPE_TEXT_VARIATION_PASSWORD);
 		else
 			editText.setInputType(InputType.TYPE_CLASS_TEXT);
-		editText.setSelection(editText.getText().length());
+		editText.setSelection(Objects.requireNonNull(editText.getText()).length());
+		final InputMethodManager imm = (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
 		editText.setOnKeyListener((view, keyCode, event) -> {
 			// For multi-line, do not submit the text after pressing Enter key
 			if (keyCode == KeyEvent.KEYCODE_ENTER && editType != 1) {
@@ -144,12 +134,13 @@ public class GameActivity extends NativeActivity {
 				alertDialog.dismiss();
 			}));
 		}
-		alertDialog.show();
 		alertDialog.setOnCancelListener(dialog -> {
 			getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 			messageReturnValue = current;
 			messageReturnCode = -1;
 		});
+		alertDialog.show();
+		editText.requestFocusTryShow();
 	}
 
 	public int getDialogState() {


### PR DESCRIPTION
This PR is a continuation of #13495.

**Goal of the PR**
This PR tries to fix failure in showing any IME after targetting newer Android SDK version (c1e430ef68271b8769ae8852b2b4a2fa0fb7ccac).

**How does the PR work?**
This PR is inspired by this [blog post](https://developer.squareup.com/blog/showing-the-android-keyboard-reliably/).

**Does it resolve any reported issue?**
See #13495. Any IME does not show after opening the input dialog: only showed once and then immediately closed.

**Does this relate to a goal in the roadmap?**
Probably, this PR tries to fix a reported UX issue.

## To do
This PR is Ready for Review.

## How to test
1. Run Minetest on any Android device.
2. Tap on any text box, e.g. in the new world dialog or the online play tab.
3. An IME should show after tapping.
4. An IME should enter full-screen editing.

**Android APK builds**
- [armeabi-v7a](https://drive.google.com/file/d/1Ee63BdS4J0f8WDSSAvc1RTZcKxKGCRfp/view)
- [arm64-v8a](https://drive.google.com/file/d/1IRfw69v9DOMsc_LY_e9Vd3SgENqT4L4J/view)
- [x86](https://drive.google.com/file/d/1htgqViisrzs1bRI6HWhW3Vh2HOfcYj7X/view)
- [x86_64](https://drive.google.com/file/d/1htgqViisrzs1bRI6HWhW3Vh2HOfcYj7X/view)