### PR TITLE
Reset day/night ratio even when passing no arguments

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7657,7 +7657,7 @@ child will follow movement and rotation of that bone.
 * `override_day_night_ratio(ratio or nil)`
     * `0`...`1`: Overrides day-night ratio, controlling sunlight to a specific
       amount.
-    * `nil`: Disables override, defaulting to sunlight based on day-night cycle
+    * Passing no arguments disables override, defaulting to sunlight based on day-night cycle
 * `get_day_night_ratio()`: returns the ratio or nil if it isn't overridden
 * `set_local_animation(idle, walk, dig, walk_while_dig, frame_speed)`:
   set animation for player model in third person view.

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2207,7 +2207,7 @@ int ObjectRef::l_override_day_night_ratio(lua_State *L)
 	bool do_override = false;
 	float ratio = 0.0f;
 
-	if (!lua_isnil(L, 2)) {
+	if (!lua_isnoneornil(L, 2)) {
 		do_override = true;
 		ratio = readParam<float>(L, 2);
 		luaL_argcheck(L, ratio >= 0.0f && ratio <= 1.0f, 1,


### PR DESCRIPTION
- Goal of the PR: creating coherence with celestial vault functions (`set_sun` etc.), which reset their fields if no argument is passed
- Does this relate to a goal in [the roadmap](../doc/direction.md)? 2.4. API convenience

## To do

This PR is Ready for Review.

## How to test
```lua
minetest.register_on_joinplayer(function(player)
	minetest.after(0.1, function()
		player:override_day_night_ratio(0.3)
		minetest.after(2, function()
			player:override_day_night_ratio()
		end)
	end)
end)
```

Crashes on master but not here
