### PR TITLE
Reset player lighting when passing no arguments

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7676,8 +7676,9 @@ child will follow movement and rotation of that bone.
       the client already has the block)
     * Resource intensive - use sparsely
 * `set_lighting(light_definition)`: sets lighting for the player
+    * Passing no arguments resets lighting to its default values.
     * `light_definition` is a table with the following optional fields:
-      * `saturation` sets the saturation (vividness).
+      * `saturation` sets the saturation (vividness; default: `1.0`).
           values > 1 increase the saturation
           values in [0,1) decrease the saturation
             * This value has no effect on clients who have the "Tone Mapping" shader disabled.
@@ -7686,12 +7687,12 @@ child will follow movement and rotation of that bone.
             * This value has no effect on clients who have the "Dynamic Shadows" shader disabled.
       * `exposure` is a table that controls automatic exposure.
         The basic exposure factor equation is `e = 2^exposure_correction / clamp(luminance, 2^luminance_min, 2^luminance_max)`
-        * `luminance_min` set the lower luminance boundary to use in the calculation
-        * `luminance_max` set the upper luminance boundary to use in the calculation
-        * `exposure_correction` correct observed exposure by the given EV value
-        * `speed_dark_bright` set the speed of adapting to bright light
-        * `speed_bright_dark` set the speed of adapting to dark scene
-        * `center_weight_power` set the power factor for center-weighted luminance measurement
+        * `luminance_min` set the lower luminance boundary to use in the calculation (default: `-3.0`)
+        * `luminance_max` set the upper luminance boundary to use in the calculation (default: `-3.0`)
+        * `exposure_correction` correct observed exposure by the given EV value (default: `0.0`)
+        * `speed_dark_bright` set the speed of adapting to bright light (default: `1000.0`)
+        * `speed_bright_dark` set the speed of adapting to dark scene (default: `1000.0`)
+        * `center_weight_power` set the power factor for center-weighted luminance measurement (default: `1.0`)
 
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2301,26 +2301,30 @@ int ObjectRef::l_set_lighting(lua_State *L)
 	if (player == nullptr)
 		return 0;
 
-	luaL_checktype(L, 2, LUA_TTABLE);
-	Lighting lighting = player->getLighting();
-	lua_getfield(L, 2, "shadows");
-	if (lua_istable(L, -1)) {
-		getfloatfield(L, -1, "intensity", lighting.shadow_intensity);
-	}
-	lua_pop(L, 1); // shadows
+	Lighting lighting;
 
-	getfloatfield(L, -1, "saturation", lighting.saturation);
+	if (!lua_isnoneornil(L, 2)) {
+		luaL_checktype(L, 2, LUA_TTABLE);
+		lighting = player->getLighting();
+		lua_getfield(L, 2, "shadows");
+		if (lua_istable(L, -1)) {
+			getfloatfield(L, -1, "intensity", lighting.shadow_intensity);
+		}
+		lua_pop(L, 1); // shadows
 
-	lua_getfield(L, 2, "exposure");
-	if (lua_istable(L, -1)) {
-		lighting.exposure.luminance_min       = getfloatfield_default(L, -1, "luminance_min",       lighting.exposure.luminance_min);
-		lighting.exposure.luminance_max       = getfloatfield_default(L, -1, "luminance_max",       lighting.exposure.luminance_max);
-		lighting.exposure.exposure_correction = getfloatfield_default(L, -1, "exposure_correction",      lighting.exposure.exposure_correction);
-		lighting.exposure.speed_dark_bright   = getfloatfield_default(L, -1, "speed_dark_bright",   lighting.exposure.speed_dark_bright);
-		lighting.exposure.speed_bright_dark   = getfloatfield_default(L, -1, "speed_bright_dark",   lighting.exposure.speed_bright_dark);
-		lighting.exposure.center_weight_power = getfloatfield_default(L, -1, "center_weight_power", lighting.exposure.center_weight_power);
+		getfloatfield(L, -1, "saturation", lighting.saturation);
+
+		lua_getfield(L, 2, "exposure");
+		if (lua_istable(L, -1)) {
+			lighting.exposure.luminance_min       = getfloatfield_default(L, -1, "luminance_min",       lighting.exposure.luminance_min);
+			lighting.exposure.luminance_max       = getfloatfield_default(L, -1, "luminance_max",       lighting.exposure.luminance_max);
+			lighting.exposure.exposure_correction = getfloatfield_default(L, -1, "exposure_correction",      lighting.exposure.exposure_correction);
+			lighting.exposure.speed_dark_bright   = getfloatfield_default(L, -1, "speed_dark_bright",   lighting.exposure.speed_dark_bright);
+			lighting.exposure.speed_bright_dark   = getfloatfield_default(L, -1, "speed_bright_dark",   lighting.exposure.speed_bright_dark);
+			lighting.exposure.center_weight_power = getfloatfield_default(L, -1, "center_weight_power", lighting.exposure.center_weight_power);
+		}
+		lua_pop(L, 1); // exposure
 	}
-	lua_pop(L, 1); // exposure
 
 	getServer(L)->setLighting(player, lighting);
 	return 0;


### PR DESCRIPTION
- Goal of the PR: allow to reset lighting to its default values without having to look for them on the API and manually insert each one of them
- Does this relate to a goal in [the roadmap](../doc/direction.md)? 2.4 API convenience

## To do

This PR is Ready for Review.

## How to test
```lua
minetest.register_on_joinplayer(function(player)
	minetest.after(0.1, function()
		player:set_lighting({saturation=0, shadows={intensity=0.8}, exposure={luminance_max=-5.2, speed_dark_bright=2020.10}})
		minetest.after(2, function()
			player:set_lighting()
		end)
	end)
end)
```
