### PR TITLE
Option to invert direction or disable mouse wheel for hotbar item selection

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -108,6 +108,12 @@ invert_mouse (Invert mouse) bool false
 #    Mouse sensitivity multiplier.
 mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
 
+#    Invert mouse wheel (scroll) direction for item selection in hotbar.
+invert_hotbar_mouse_wheel (Hotbar: Invert mouse wheel direction) bool false
+
+#    Disable mouse wheel (scroll) for item selection in hotbar.
+disable_hotbar_mouse_wheel (Hotbar: Disable mouse wheel for selection) bool false
+
 [*Touchscreen]
 
 #    The length in pixels it takes for touch screen interaction to start.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -108,11 +108,11 @@ invert_mouse (Invert mouse) bool false
 #    Mouse sensitivity multiplier.
 mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
 
+#    Enable mouse wheel (scroll) for item selection in hotbar.
+enable_hotbar_mouse_wheel (Hotbar: Enable mouse wheel for selection) bool true
+
 #    Invert mouse wheel (scroll) direction for item selection in hotbar.
 invert_hotbar_mouse_wheel (Hotbar: Invert mouse wheel direction) bool false
-
-#    Disable mouse wheel (scroll) for item selection in hotbar.
-disable_hotbar_mouse_wheel (Hotbar: Disable mouse wheel for selection) bool false
 
 [*Touchscreen]
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1003,9 +1003,10 @@ private:
 	f32  m_cache_cam_smoothing;
 	f32  m_cache_fog_start;
 
-	bool m_invert_mouse = false;
-	bool m_invert_hotbar_mouse_wheel = false;
-	bool m_disable_hotbar_mouse_wheel = false;
+	bool m_invert_mouse;
+	bool m_enable_hotbar_mouse_wheel;
+	bool m_invert_hotbar_mouse_wheel;
+
 	bool m_first_loop_after_window_activation = false;
 	bool m_camera_offset_changed = false;
 	bool m_game_focused;
@@ -1151,9 +1152,6 @@ bool Game::startup(bool *kill,
 
 	m_game_ui->initFlags();
 
-	m_invert_mouse = g_settings->getBool("invert_mouse");
-	m_invert_hotbar_mouse_wheel = g_settings->getBool("invert_hotbar_mouse_wheel");
-	m_disable_hotbar_mouse_wheel = g_settings->getBool("disable_hotbar_mouse_wheel");
 	m_first_loop_after_window_activation = true;
 
 #ifdef HAVE_TOUCHSCREENGUI
@@ -2143,10 +2141,10 @@ void Game::processItemSelection(u16 *new_playeritem)
 		    player->hud_hotbar_itemcount - 1);
 
 	s32 wheel = input->getMouseWheel();
+	if (!m_enable_hotbar_mouse_wheel)
+		wheel = 0;
 	if (m_invert_hotbar_mouse_wheel)
 		wheel *= -1;
-	if (m_disable_hotbar_mouse_wheel)
-		wheel = 0;
 
 	s32 dir = wheel;
 
@@ -4307,6 +4305,10 @@ void Game::readSettings()
 	m_cache_fog_start = rangelim(m_cache_fog_start, 0.0f, 0.99f);
 	m_cache_cam_smoothing = rangelim(m_cache_cam_smoothing, 0.01f, 1.0f);
 	m_cache_mouse_sensitivity = rangelim(m_cache_mouse_sensitivity, 0.001, 100.0);
+
+	m_invert_mouse = g_settings->getBool("invert_mouse");
+	m_enable_hotbar_mouse_wheel = g_settings->getBool("enable_hotbar_mouse_wheel");
+	m_invert_hotbar_mouse_wheel = g_settings->getBool("invert_hotbar_mouse_wheel");
 
 	m_does_lost_focus_pause_game = g_settings->getBool("pause_on_lost_focus");
 }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1037,7 +1037,7 @@ Game::Game() :
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("enable_clouds",
 		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("doubletap_joysticks",
+	g_settings->registerChangedCallback("enable_joysticks",
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("enable_particles",
 		&settingChangedCallback, this);
@@ -1053,11 +1053,21 @@ Game::Game() :
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("free_move",
 		&settingChangedCallback, this);
+	g_settings->registerChangedCallback("fog_start",
+		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("cinematic",
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("cinematic_camera_smoothing",
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("camera_smoothing",
+		&settingChangedCallback, this);
+	g_settings->registerChangedCallback("invert_mouse",
+		&settingChangedCallback, this);
+	g_settings->registerChangedCallback("enable_hotbar_mouse_wheel",
+		&settingChangedCallback, this);
+	g_settings->registerChangedCallback("invert_hotbar_mouse_wheel",
+		&settingChangedCallback, this);
+	g_settings->registerChangedCallback("pause_on_lost_focus",
 		&settingChangedCallback, this);
 
 	readSettings();
@@ -1098,11 +1108,15 @@ Game::~Game()
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("enable_clouds",
 		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("enable_joysticks",
+		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("enable_particles",
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("enable_fog",
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("mouse_sensitivity",
+		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("joystick_frustum_sensitivity",
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("repeat_place_time",
 		&settingChangedCallback, this);
@@ -1110,11 +1124,21 @@ Game::~Game()
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("free_move",
 		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("fog_start",
+		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("cinematic",
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("cinematic_camera_smoothing",
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("camera_smoothing",
+		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("invert_mouse",
+		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("enable_hotbar_mouse_wheel",
+		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("invert_hotbar_mouse_wheel",
+		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("pause_on_lost_focus",
 		&settingChangedCallback, this);
 	if (m_rendering_engine)
 		m_rendering_engine->finalize();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1004,6 +1004,8 @@ private:
 	f32  m_cache_fog_start;
 
 	bool m_invert_mouse = false;
+	bool m_invert_hotbar_mouse_wheel = false;
+	bool m_disable_hotbar_mouse_wheel = false;
 	bool m_first_loop_after_window_activation = false;
 	bool m_camera_offset_changed = false;
 	bool m_game_focused;
@@ -1150,6 +1152,8 @@ bool Game::startup(bool *kill,
 	m_game_ui->initFlags();
 
 	m_invert_mouse = g_settings->getBool("invert_mouse");
+	m_invert_hotbar_mouse_wheel = g_settings->getBool("invert_hotbar_mouse_wheel");
+	m_disable_hotbar_mouse_wheel = g_settings->getBool("disable_hotbar_mouse_wheel");
 	m_first_loop_after_window_activation = true;
 
 #ifdef HAVE_TOUCHSCREENGUI
@@ -2135,9 +2139,14 @@ void Game::processItemSelection(u16 *new_playeritem)
 	/* Item selection using mouse wheel
 	 */
 	*new_playeritem = player->getWieldIndex();
-	s32 wheel = input->getMouseWheel();
 	u16 max_item = MYMIN(PLAYER_INVENTORY_SIZE - 1,
 		    player->hud_hotbar_itemcount - 1);
+
+	s32 wheel = input->getMouseWheel();
+	if (m_invert_hotbar_mouse_wheel)
+		wheel *= -1;
+	if (m_disable_hotbar_mouse_wheel)
+		wheel = 0;
 
 	s32 dir = wheel;
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -285,6 +285,8 @@ void set_default_settings()
 
 	// Input
 	settings->setDefault("invert_mouse", "false");
+	settings->setDefault("invert_hotbar_mouse_wheel", "false");
+	settings->setDefault("disable_hotbar_mouse_wheel", "false");
 	settings->setDefault("mouse_sensitivity", "0.2");
 	settings->setDefault("repeat_place_time", "0.25");
 	settings->setDefault("safe_dig_and_place", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -285,8 +285,8 @@ void set_default_settings()
 
 	// Input
 	settings->setDefault("invert_mouse", "false");
+	settings->setDefault("enable_hotbar_mouse_wheel", "true");
 	settings->setDefault("invert_hotbar_mouse_wheel", "false");
-	settings->setDefault("disable_hotbar_mouse_wheel", "false");
 	settings->setDefault("mouse_sensitivity", "0.2");
 	settings->setDefault("repeat_place_time", "0.25");
 	settings->setDefault("safe_dig_and_place", "false");


### PR DESCRIPTION
**Goal of the PR**
This PR adds ability to (1) invert mouse wheel direction and (2) disable mouse wheel for selecting items in the hotbar.

There are two new settings (Controls -> Keyboard and Mouse):
- `enable_hotbar_mouse_wheel` (default: `true`)
- `invert_hotbar_mouse_wheel` (default: `false`)

**How does the PR work?**
This PR multiplies the wheel amount by `-1` if inverted or `0` if disabled. This differs with just changing the key mapping for hotbar prev/next.

**Does it resolve any reported issue?**
This PR tries to fix #13516 (for inverting direction).

There are also some posts about it and even disabling mouse wheel in other games (Minecraft: [2014](https://www.minecraftforum.net/forums/minecraft-java-edition/discussion/2209042-how-to-invert-the-mouse-wheel), [2018](https://feedback.minecraft.net/hc/en-us/community/posts/360014290711-Add-option-to-change-inventory-scroll-direction), and [2019](https://www.reddit.com/r/Minecraft/comments/bs4ll9/mouse_scrolls_wrong_way_through_hotbar_new_player/); Terraria: [2022](https://forums.terraria.org/index.php?threads/add-option-to-invert-mouse-wheel-scroll-directions-for-crafting-hotbar.113802/); Satisfactory Game: [2022](https://www.reddit.com/r/SatisfactoryGame/comments/ukiqz8/cannot_invert_hotbar_scroll_direction/)). Most of them are about improving user's QoL.

**Does this relate to a goal in the roadmap?**
Probably, this PR tries to fix a reported UX issue.

## To do
This PR is Ready for Review.

## How to test
1. Run Minetest on desktop (with mouse wheel/trackpad with scroll support).
2. Play in any world/server.
3. Scroll up and down. Watch the direction of selected item in the hotbar.
4. Exit to main menu.
5. Change the `invert_hotbar_mouse_wheel` setting to `true`.
6. Play again in any world/server.
7. Scroll up and down. Watch the direction of selected item in the hotbar. It should be the opposite of before.
8. Exit to main menu.
9. Change the `enable_hotbar_mouse_wheel` setting to `false`.
10. Play again in any world/server.
11. Scroll up and down. Watch the direction of selected item in the hotbar. There should be no selection change in the hotbar.