### PR TITLE
Remove a misleading MutexAutoLock in l_to_table

### DIFF
--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -332,7 +332,6 @@ int LuaSettings::l_to_table(lua_State* L)
 	NO_MAP_LOCK_REQUIRED;
 	LuaSettings* o = checkObject<LuaSettings>(L, 1);
 
-	MutexAutoLock(o->m_settings->m_mutex);
 	push_settings_table(L, o->m_settings);
 	return 1;
 }


### PR DESCRIPTION
The temporary is immediately destructed, so the mutex isn't locked after the line.
Removed the lock, because the Settings member-functions used by push_settings_table lock the mutex and are thread-safe, but would cause a dead-lock.

(Found no similar mistake in the code-base.)

## To do

This PR is a Ready for Review.

## How to test

* Launch the mainmenu (it seems to call the function).
