### PR TITLE
Make the settings GUI more usable on Android

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -110,12 +110,6 @@ add_page({
 })
 
 
-local tabsize = {
-	width = 15.5,
-	height= 12,
-}
-
-
 local function load_settingtypes()
 	local page = nil
 	local section = nil
@@ -316,10 +310,12 @@ local function get_formspec(dialogdata)
 	local page_id = dialogdata.page_id or "most_used"
 	local page = filtered_page_by_id[page_id]
 
-	local scrollbar_w = 0.4
-	if PLATFORM == "Android" then
-		scrollbar_w = 0.6
-	end
+	local tabsize = {
+		width = 15.5,
+		height = TOUCHSCREEN_GUI and 10 or 12,
+	}
+
+	local scrollbar_w = TOUCHSCREEN_GUI and 0.6 or 0.4
 
 	local left_pane_width = 4.25
 	local search_width = left_pane_width + scrollbar_w - (0.75 * 2)
@@ -331,6 +327,7 @@ local function get_formspec(dialogdata)
 	local fs = {
 		"formspec_version[6]",
 		"size[", tostring(tabsize.width), ",", tostring(tabsize.height + 1), "]",
+		TOUCHSCREEN_GUI and "padding[0.01,0.01]" or "", -- makes a noticeable difference
 		"bgcolor[#0000]",
 
 		-- HACK: this is needed to allow resubmitting the same formspec

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -153,6 +153,13 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 	lua_pushstring(m_luastack, porting::getPlatformName());
 	lua_setglobal(m_luastack, "PLATFORM");
 
+#ifdef HAVE_TOUCHSCREENGUI
+	lua_pushboolean(m_luastack, true);
+#else
+	lua_pushboolean(m_luastack, false);
+#endif
+	lua_setglobal(m_luastack, "TOUCHSCREEN_GUI");
+
 	// Make sure Lua uses the right locale
 	setlocale(LC_NUMERIC, "C");
 }


### PR DESCRIPTION
The settings GUI is currently always "scaled down" on Android because its height exceeds the maximum formspec size on `ENABLE_TOUCH` builds (the maximum is 10 if no custom `gui_scaling` setting is involved). This PR makes the settings GUI smaller and reduces its padding on `ENABLE_TOUCH` builds.

before:
![screenshot before](https://github.com/minetest/minetest/assets/82708541/af16a0a0-bd02-46d4-8d16-36896a61cac5)

after:
![screenshot after](https://github.com/minetest/minetest/assets/82708541/eef695ef-c4e6-4663-993a-59218caccd14)

The menu should look exactly the same as before on desktop. Of course, more could be done (see e.g. https://github.com/rollerozxa/rollertest/commit/2439b9b614d86873f9d0ce72ab9bb15b5ced140a), but this is already a big improvement in my opinion.

## To do

This PR is a Ready for Review.

## How to test

Open the settings GUI on Android.