### PR TITLE
Fix various cases of double-escaped error messages

### DIFF
--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -62,8 +62,8 @@ function ui.update()
 
 	-- handle errors
 	if gamedata ~= nil and gamedata.reconnect_requested then
-		local error_message = core.formspec_escape(
-				gamedata.errormessage or fgettext("<none available>"))
+		local error_message = core.formspec_escape(gamedata.errormessage)
+				or fgettext("<none available>")
 		formspec = {
 			"size[14,8]",
 			"real_coordinates[true]",

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -89,7 +89,7 @@ local function download_and_extract(param)
 	if filename == "" or not core.download_file(param.url, filename) then
 		core.log("error", "Downloading " .. dump(param.url) .. " failed")
 		return {
-			msg = fgettext("Failed to download \"$1\"", package.title)
+			msg = fgettext_ne("Failed to download \"$1\"", package.title)
 		}
 	end
 
@@ -105,7 +105,7 @@ local function download_and_extract(param)
 	os.remove(filename)
 	if not tempfolder then
 		return {
-			msg = fgettext("Failed to extract \"$1\" (unsupported file type or broken archive)", package.title),
+			msg = fgettext_ne("Failed to extract \"$1\" (unsupported file type or broken archive)", package.title),
 		}
 	end
 
@@ -129,7 +129,7 @@ local function start_install(package, reason)
 			local path, msg = pkgmgr.install_dir(package.type, result.path, package.name, package.path)
 			core.delete_dir(result.path)
 			if not path then
-				gamedata.errormessage = fgettext("Error installing \"$1\": $2", package.title, msg)
+				gamedata.errormessage = fgettext_ne("Error installing \"$1\": $2", package.title, msg)
 			else
 				core.log("action", "Installed package to " .. path)
 
@@ -184,7 +184,7 @@ local function start_install(package, reason)
 
 	if not core.handle_async(download_and_extract, params, callback) then
 		core.log("error", "ERROR: async event failed")
-		gamedata.errormessage = fgettext("Failed to download $1", package.name)
+		gamedata.errormessage = fgettext_ne("Failed to download $1", package.name)
 		return
 	end
 end

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -363,7 +363,7 @@ local function create_world_buttonhandler(this, fields)
 
 		local message
 		if game == nil then
-			message = fgettext("No game selected")
+			message = fgettext_ne("No game selected")
 		end
 
 		if message == nil then
@@ -382,7 +382,7 @@ local function create_world_buttonhandler(this, fields)
 			end
 
 			if menudata.worldlist:uid_exists_raw(worldname) then
-				message = fgettext("A world named \"$1\" already exists", worldname)
+				message = fgettext_ne("A world named \"$1\" already exists", worldname)
 			end
 		end
 

--- a/builtin/mainmenu/dlg_delete_content.lua
+++ b/builtin/mainmenu/dlg_delete_content.lua
@@ -34,7 +34,7 @@ local function delete_content_buttonhandler(this, fields)
 				this.data.content.path ~= core.get_gamepath() and
 				this.data.content.path ~= core.get_texturepath() then
 			if not core.delete_dir(this.data.content.path) then
-				gamedata.errormessage = fgettext("pkgmgr: failed to delete \"$1\"", this.data.content.path)
+				gamedata.errormessage = fgettext_ne("pkgmgr: failed to delete \"$1\"", this.data.content.path)
 			end
 
 			if this.data.content.type == "game" then
@@ -43,7 +43,7 @@ local function delete_content_buttonhandler(this, fields)
 				pkgmgr.refresh_globals()
 			end
 		else
-			gamedata.errormessage = fgettext("pkgmgr: invalid path \"$1\"", this.data.content.path)
+			gamedata.errormessage = fgettext_ne("pkgmgr: invalid path \"$1\"", this.data.content.path)
 		end
 		this:delete()
 		return true

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -534,7 +534,7 @@ function pkgmgr.install_dir(expected_type, path, basename, targetpath)
 		-- There's no good way to detect a texture pack, so let's just assume
 		-- it's correct for now.
 		if basefolder and basefolder.type ~= "invalid" and basefolder.type ~= "txp" then
-			return nil, fgettext("Unable to install a $1 as a texture pack", basefolder.type)
+			return nil, fgettext_ne("Unable to install a $1 as a texture pack", basefolder.type)
 		end
 
 		local from = basefolder and basefolder.path or path
@@ -544,17 +544,17 @@ function pkgmgr.install_dir(expected_type, path, basename, targetpath)
 		core.delete_dir(targetpath)
 		if not core.copy_dir(from, targetpath, false) then
 			return nil,
-				fgettext("Failed to install $1 to $2", basename, targetpath)
+				fgettext_ne("Failed to install $1 to $2", basename, targetpath)
 		end
 		return targetpath, nil
 
 	elseif not basefolder then
-		return nil, fgettext("Unable to find a valid mod, modpack, or game")
+		return nil, fgettext_ne("Unable to find a valid mod, modpack, or game")
 	end
 
 	-- Check type
 	if basefolder.type ~= expected_type and (basefolder.type ~= "modpack" or expected_type ~= "mod") then
-		return nil, fgettext("Unable to install a $1 as a $2", basefolder.type, expected_type)
+		return nil, fgettext_ne("Unable to install a $1 as a $2", basefolder.type, expected_type)
 	end
 
 	-- Set targetpath if not predetermined
@@ -575,7 +575,7 @@ function pkgmgr.install_dir(expected_type, path, basename, targetpath)
 			targetpath = content_path .. DIR_DELIM .. basename
 		else
 			return nil,
-				fgettext("Install: Unable to find suitable folder name for $1", path)
+				fgettext_ne("Install: Unable to find suitable folder name for $1", path)
 		end
 	end
 
@@ -583,7 +583,7 @@ function pkgmgr.install_dir(expected_type, path, basename, targetpath)
 	core.delete_dir(targetpath)
 	if not core.copy_dir(basefolder.path, targetpath, false) then
 		return nil,
-			fgettext("Failed to install $1 to $2", basename, targetpath)
+			fgettext_ne("Failed to install $1 to $2", basename, targetpath)
 	end
 
 	if basefolder.type == "game" then

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -284,7 +284,7 @@ local function main_button_handler(this, fields, name, tabdata)
 
 		if selected == nil or gamedata.selected_world == 0 then
 			gamedata.errormessage =
-					fgettext("No world created or selected!")
+					fgettext_ne("No world created or selected!")
 			return true
 		end
 

--- a/builtin/mainmenu/tests/pkgmgr_spec.lua
+++ b/builtin/mainmenu/tests/pkgmgr_spec.lua
@@ -52,7 +52,7 @@ local function reset()
 	function core.get_gamepath()
 		return games_dir
 	end
-	function env.fgettext(fmt, ...)
+	function env.fgettext_ne(fmt, ...)
 		return fmt
 	end
 


### PR DESCRIPTION
The error message box itself applies `core.formspec_escape` to the error message (<a href="https://github.com/minetest/minetest/blob/7221de6edeb80b0512934118bb972288b6825e91/builtin/fstk/ui.lua#L79">link to the code</a>), but in some places it is passed already formspec-escaped strings. This results in double and sometimes even triple escaping.

An example case of triple escaping:

before this PR:
<img src="https://github.com/minetest/minetest/assets/82708541/7dc25439-2a3a-4bbf-b9db-49d65b1e036d" alt="screenshot before" width="512">

after this PR:
<img src="https://github.com/minetest/minetest/assets/82708541/3ed3da11-8b81-4ccc-bd0c-2b6a22ead3a0" alt="screenshot after" width="512">

This PR replaces `fgettext` by `fgettext_ne` in various places to avoid "multi-escaping".

## To do

This PR is a Ready for Review.

## How to test

Trigger some of the previously affected error messages and see that they are displayed correctly.