### PR TITLE
Add ability to specify several nodes in node_riverbed

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9454,8 +9454,10 @@ performance and computing power the practical limit is much lower.
     -- default:river_water
 
     node_riverbed = "default:gravel",
+    node_riverbed = {"default:gravel", "default:stone"},
     depth_riverbed = 2,
-    -- Node placed under river water and thickness of this layer
+    -- Nodes placed under river water and thickness of this layer
+    -- Multiple nodes can be specified, they will be chosen at random.
 
     node_cave_liquid = "default:lava_source",
     node_cave_liquid = {"default:water_source", "default:lava_source"},

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -74,6 +74,8 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 	assert(vm);
 	assert(biomemap);
 
+	PseudoRandom ps(86219);
+
 	noise_cave1->perlinMap3D(nmin.X, nmin.Y - 1, nmin.Z);
 	noise_cave2->perlinMap3D(nmin.X, nmin.Y - 1, nmin.Z);
 
@@ -136,7 +138,7 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 				// Tunnel entrance floor, place biome surface nodes
 				if (is_under_river) {
 					if (nplaced < depth_riverbed) {
-						vm->m_data[vi] = MapNode(biome->c_riverbed);
+						vm->m_data[vi] = MapNode(biome->c_riverbed[ps.range(0, biome->c_riverbed.size() - 1)]);
 						is_top_filler_above = true;
 						nplaced++;
 					} else {

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -631,6 +631,8 @@ void MapgenBasic::generateBiomes()
 	assert(biomegen);
 	assert(biomemap);
 
+	PseudoRandom ps(blockseed + 88535);
+
 	const v3s16 &em = vm->m_area.getExtent();
 	u32 index = 0;
 
@@ -710,7 +712,7 @@ void MapgenBasic::generateBiomes()
 
 				if (river_water_above) {
 					if (nplaced < depth_riverbed) {
-						vm->m_data[vi] = MapNode(biome->c_riverbed);
+						vm->m_data[vi] = MapNode(biome->c_riverbed[ps.range(0, biome->c_riverbed.size() - 1)]);
 						nplaced++;
 					} else {
 						nplaced = U16_MAX;  // Disable top/filler placement

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -61,6 +61,7 @@ BiomeManager::BiomeManager(Server *server) :
 	b->m_nodenames.emplace_back("mapgen_water_source");
 	b->m_nodenames.emplace_back("mapgen_river_water_source");
 	b->m_nodenames.emplace_back("mapgen_stone");
+	b->m_nnlistsizes.push_back(1);
 	b->m_nodenames.emplace_back("ignore");
 	b->m_nodenames.emplace_back("ignore");
 	b->m_nnlistsizes.push_back(1);
@@ -322,7 +323,7 @@ void Biome::resolveNodeNames()
 	getIdFromNrBacklog(&c_water_top,     "mapgen_water_source",       CONTENT_AIR,    false);
 	getIdFromNrBacklog(&c_water,         "mapgen_water_source",       CONTENT_AIR,    false);
 	getIdFromNrBacklog(&c_river_water,   "mapgen_river_water_source", CONTENT_AIR,    false);
-	getIdFromNrBacklog(&c_riverbed,      "mapgen_stone",              CONTENT_AIR,    false);
+	getIdsFromNrBacklog(&c_riverbed);
 	getIdFromNrBacklog(&c_dust,          "ignore",                    CONTENT_IGNORE, false);
 	getIdsFromNrBacklog(&c_cave_liquid);
 	getIdFromNrBacklog(&c_dungeon,       "ignore",                    CONTENT_IGNORE, false);

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -52,7 +52,7 @@ public:
 	content_t c_water_top;
 	content_t c_water;
 	content_t c_river_water;
-	content_t c_riverbed;
+	std::vector<content_t> c_riverbed;
 	content_t c_dust;
 	std::vector<content_t> c_cave_liquid;
 	content_t c_dungeon;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -403,10 +403,17 @@ Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef)
 	nn.push_back(getstringfield_default(L, index, "node_water_top",     ""));
 	nn.push_back(getstringfield_default(L, index, "node_water",         ""));
 	nn.push_back(getstringfield_default(L, index, "node_river_water",   ""));
-	nn.push_back(getstringfield_default(L, index, "node_riverbed",      ""));
+
+	size_t nnames = getstringlistfield(L, index, "node_riverbed", &nn);
+	if (nnames == 0) {
+		nn.emplace_back("mapgen_stone");
+		nnames = 1;
+	}
+	b->m_nnlistsizes.push_back(nnames);
+
 	nn.push_back(getstringfield_default(L, index, "node_dust",          ""));
 
-	size_t nnames = getstringlistfield(L, index, "node_cave_liquid", &nn);
+	nnames = getstringlistfield(L, index, "node_cave_liquid", &nn);
 	// If no cave liquids defined, set list to "ignore" to trigger old hardcoded
 	// cave liquid behavior.
 	if (nnames == 0) {


### PR DESCRIPTION
This PR allows specifying multiple nodes in `node_riverbed` which will be chosen at random while generating.

Fixes #13447.

## How to test
* Change `node_riverbed` to have multiple nodes.
* Find a river.

Example:
![image](https://github.com/minetest/minetest/assets/30466983/7d4ecfd5-7142-4eb1-8d43-131be8e8344b)
 