### PR TITLE
Add an option to prevent the player from continuously jumping while holding the jump key down.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -96,6 +96,9 @@ repeat_place_time (Place repetition interval) float 0.25 0.16 2
 #    Automatically jump up single-node obstacles.
 autojump (Automatic jumping) bool false
 
+#    Jump while the jump key is held down.
+jump_on_key_held (Jump on key held) bool true
+
 #    Prevent digging and placing from repeating when holding the mouse buttons.
 #    Enable this when you dig or place too often by accident.
 safe_dig_and_place (Safe digging and placing) bool false

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -54,6 +54,10 @@
 #    type: bool
 # autojump = false
 
+#    Jump while the jump key is held down.
+#    type: bool
+# jump_on_key_held = true;
+
 #    Prevent digging and placing from repeating when holding the mouse buttons.
 #    Enable this when you dig or place too often by accident.
 #    type: bool

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -497,6 +497,9 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d)
 	move(dtime, env, pos_max_d, NULL);
 }
 
+
+bool was_jump_key_held = false;
+
 void LocalPlayer::applyControl(float dtime, Environment *env)
 {
 	// Clear stuff
@@ -621,7 +624,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 						speedV.Y = movement_speed_walk;
 				}
 			}
-		} else if (m_can_jump) {
+		} else if (m_can_jump && !was_jump_key_held) {
 			/*
 				NOTE: The d value in move() affects jump height by
 				raising the height at which the jump speed is kept
@@ -645,6 +648,13 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			else
 				speedV.Y = movement_speed_climb;
 		}
+	}
+
+	if (player_settings.jump_on_key_held){
+		was_jump_key_held = false;
+	}
+	else{
+		was_jump_key_held = control.jump;
 	}
 
 	// The speed of the player (Y is ignored)

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -294,6 +294,7 @@ void set_default_settings()
 	settings->setDefault("aux1_descends", "false");
 	settings->setDefault("doubletap_jump", "false");
 	settings->setDefault("always_fly_fast", "true");
+	settings->setDefault("jump_on_key_held", "true");
 #ifdef HAVE_TOUCHSCREENGUI
 	settings->setDefault("autojump", "true");
 #else

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -229,6 +229,7 @@ void PlayerSettings::readGlobalSettings()
 	aux1_descends = g_settings->getBool("aux1_descends");
 	noclip = g_settings->getBool("noclip");
 	autojump = g_settings->getBool("autojump");
+	jump_on_key_held = g_settings->getBool("jump_on_key_held");
 }
 
 void Player::settingsChangedCallback(const std::string &name, void *data)

--- a/src/player.h
+++ b/src/player.h
@@ -119,9 +119,9 @@ struct PlayerSettings
 	bool noclip = false;
 	bool autojump = false;
 
-	const std::string setting_names[8] = {
+	const std::string setting_names[9] = {
 		"free_move", "pitch_move", "fast_move", "continuous_forward", "always_fly_fast",
-		"aux1_descends", "noclip", "autojump"
+		"aux1_descends", "noclip", "autojump", "jump_on_key_held"
 	};
 	void readGlobalSettings();
 };


### PR DESCRIPTION
I wrote patch to allow players to disable the ability for the player to continuously jump while holding the jump key down.

I prefer having this disabled as the alternative feels like my character has no weight when just jumping around and especially felt when holding the jump key while moving up hill or up a mountain.

I understand that having to press the jump key a lot more is tedious for some, so if there is a way to move this setting into the 'accessibility tab' that would be welcome. I haven't figured out how to do that yet as this is a not-well put together patch as this is my first public project that I've tried to contribute to.

Also, I have this setting set to 'enabled' by default as to keep the user experience the same for those who don't change this. (Plus, for the reason as mentioned above.) 

Let me know what more to change, if this option could make it into the actual game, me and my friends would be really grateful. Cheers!