### PR TITLE
Extend roadmap approval time from one week to one month

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Contributions are welcome! Here's how you can help:
    developers.
 
    Any Pull Request that isn't a bug fix and isn't covered by
-   [the roadmap](../doc/direction.md) will be closed within a week unless it
+   [the roadmap](../doc/direction.md) will be closed within a month unless it
    receives a concept approval from a Core Developer. For this reason, it is
    recommended that you open an issue for any such pull requests before doing
    the work, to avoid disappointment.

--- a/doc/direction.md
+++ b/doc/direction.md
@@ -21,7 +21,7 @@ This should be reviewed approximately yearly, or when goals are achieved.
 
 Pull requests that address one of these goals will be labeled as "Roadmap".
 PRs that are not on the roadmap will be closed unless they receive a concept
-approval within a week, issues can be used for preapproval.
+approval within a month, issues can be used for preapproval.
 Bug fixes are exempt for this, and are always accepted and prioritized.
 See [CONTRIBUTING.md](../.github/CONTRIBUTING.md) for more info.
 


### PR DESCRIPTION
As stated by @rubenwardy during a meeting: https://irc.minetest.net/minetest-dev/2023-05-27#i_6087455
> the rule change we made was to discuss roadmap items at meetings, and increase the automatic close from 1 week(?) to a month

## To do

This PR is Ready for Review.
