### PR TITLE
Fix some memleaks from GUIButtonImage

### DIFF
--- a/src/gui/guiButtonImage.cpp
+++ b/src/gui/guiButtonImage.cpp
@@ -39,20 +39,14 @@ GUIButtonImage::GUIButtonImage(gui::IGUIEnvironment *environment,
 	sendToBack(m_image);
 }
 
-void GUIButtonImage::setForegroundImage(video::ITexture *image,
+void GUIButtonImage::setForegroundImage(irr_ptr<video::ITexture> image,
 		const core::rect<s32> &middle)
 {
 	if (image == m_foreground_image)
 		return;
 
-	if (image != nullptr)
-		image->grab();
-
-	if (m_foreground_image != nullptr)
-		m_foreground_image->drop();
-
-	m_foreground_image = image;
-	m_image->setTexture(image);
+	m_foreground_image = std::move(image);
+	m_image->setTexture(m_foreground_image.get());
 	m_image->setMiddleRect(middle);
 }
 
@@ -67,8 +61,8 @@ void GUIButtonImage::setFromStyle(const StyleSpec &style)
 		video::ITexture *texture = style.getTexture(StyleSpec::FGIMG,
 				getTextureSource());
 
-		setForegroundImage(guiScalingImageButton(driver, texture,
-				AbsoluteRect.getWidth(), AbsoluteRect.getHeight()),
+		setForegroundImage(::grab(guiScalingImageButton(driver, texture,
+				AbsoluteRect.getWidth(), AbsoluteRect.getHeight())),
 				style.getRect(StyleSpec::FGIMG_MIDDLE, m_image->getMiddleRect()));
 	} else {
 		setForegroundImage();

--- a/src/gui/guiButtonImage.cpp
+++ b/src/gui/guiButtonImage.cpp
@@ -35,8 +35,8 @@ GUIButtonImage::GUIButtonImage(gui::IGUIEnvironment *environment,
 	: GUIButton(environment, parent, id, rectangle, tsrc, noclip)
 {
 	GUIButton::setScaleImage(true);
-	m_image = new GUIAnimatedImage(environment, this, id, rectangle);
-	sendToBack(m_image);
+	m_image = make_irr<GUIAnimatedImage>(environment, this, id, rectangle);
+	sendToBack(m_image.get());
 }
 
 void GUIButtonImage::setForegroundImage(irr_ptr<video::ITexture> image,
@@ -74,7 +74,7 @@ GUIButtonImage *GUIButtonImage::addButton(IGUIEnvironment *environment,
 		IGUIElement *parent, s32 id, const wchar_t *text,
 		const wchar_t *tooltiptext)
 {
-	GUIButtonImage *button = new GUIButtonImage(environment,
+	auto button = make_irr<GUIButtonImage>(environment,
 			parent ? parent : environment->getRootGUIElement(), id, rectangle, tsrc);
 
 	if (text)
@@ -83,6 +83,5 @@ GUIButtonImage *GUIButtonImage::addButton(IGUIEnvironment *environment,
 	if (tooltiptext)
 		button->setToolTipText(tooltiptext);
 
-	button->drop();
-	return button;
+	return button.get();
 }

--- a/src/gui/guiButtonImage.h
+++ b/src/gui/guiButtonImage.h
@@ -48,5 +48,5 @@ public:
 
 private:
 	irr_ptr<video::ITexture> m_foreground_image;
-	GUIAnimatedImage *m_image;
+	irr_ptr<GUIAnimatedImage> m_image;
 };

--- a/src/gui/guiButtonImage.h
+++ b/src/gui/guiButtonImage.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiButton.h"
 #include "IGUIButton.h"
 #include "guiAnimatedImage.h"
+#include "irr_ptr.h"
 
 using namespace irr;
 
@@ -33,7 +34,7 @@ public:
 			s32 id, core::rect<s32> rectangle, ISimpleTextureSource *tsrc,
 			bool noclip = false);
 
-	void setForegroundImage(video::ITexture *image = nullptr,
+	void setForegroundImage(irr_ptr<video::ITexture> image = nullptr,
 			const core::rect<s32> &middle = core::rect<s32>());
 
 	//! Set element properties from a StyleSpec
@@ -46,6 +47,6 @@ public:
 			const wchar_t *tooltiptext = L"");
 
 private:
-	video::ITexture *m_foreground_image = nullptr;
+	irr_ptr<video::ITexture> m_foreground_image;
 	GUIAnimatedImage *m_image;
 };


### PR DESCRIPTION
* `m_foreground_image` was grabbed, but not dropped in the destructor.
* `m_image` was created with new. It is grabbed by itself and by the env (not only by the env!, so it's an owning ptr). This owning ptr also was never dropped.

Also use `irr_ptr`s.

(Found via leak sanitizer.)

## To do

This PR is a Ready for Review.

## How to test

* Read code. :eye: :eye: 
* Compile, preferably with sanitizers.
* Run.
* It does not crash.
