### PR TITLE
TouchScreenGUI: Read coordinates directly for virtual joystick

### DIFF
--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -332,7 +332,11 @@ public:
 				return 0.0f;
 			return 1.0f; // If there is a keyboard event, assume maximum speed
 		}
+#ifdef HAVE_TOUCHSCREENGUI
+		return m_receiver->m_touchscreengui->getMovementSpeed();
+#else
 		return joystick.getMovementSpeed();
+#endif
 	}
 
 	virtual float getMovementDirection()
@@ -352,7 +356,11 @@ public:
 		if (x != 0 || z != 0) /* If there is a keyboard event, it takes priority */
 			return atan2(x, z);
 		else
+#ifdef HAVE_TOUCHSCREENGUI
+			return m_receiver->m_touchscreengui->getMovementDirection();
+#else
 			return joystick.getMovementDirection();
+#endif
 	}
 
 	virtual bool cancelPressed()

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -52,18 +52,6 @@ static irr::EKEY_CODE id2keycode(touch_gui_button_id id)
 {
 	std::string key = "";
 	switch (id) {
-		case forward_id:
-			key = "forward";
-			break;
-		case left_id:
-			key = "left";
-			break;
-		case right_id:
-			key = "right";
-			break;
-		case backward_id:
-			key = "backward";
-			break;
 		case inventory_id:
 			key = "inventory";
 			break;

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -702,8 +702,9 @@ void TouchScreenGUI::handleReleaseEvent(size_t evt_id)
 		m_has_joystick_id = false;
 
 		// reset joystick
-		for (unsigned int i = 0; i < 4; i++)
-			m_joystick_status[i] = false;
+		m_joystick_direction = 0.0f;
+		m_joystick_speed = 0.0f;
+		m_joystick_status_aux1 = false;
 		applyJoystickStatus();
 
 		m_joystick_btn_off->guibutton->setVisible(true);
@@ -844,8 +845,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 						(m_pointerpos[event.TouchInput.ID].Y - event.TouchInput.Y) *
 						(m_pointerpos[event.TouchInput.ID].Y - event.TouchInput.Y));
 
-				if ((distance > m_touchscreen_threshold) ||
-						(m_move_has_really_moved)) {
+				if (distance > m_touchscreen_threshold || m_move_has_really_moved) {
 					m_move_has_really_moved = true;
 					s32 X = event.TouchInput.X;
 					s32 Y = event.TouchInput.Y;
@@ -868,8 +868,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 							->getSceneCollisionManager()
 							->getRayFromScreenCoordinates(v2s32(X, Y));
 				}
-			} else if ((event.TouchInput.ID == m_move_id) &&
-					(m_move_sent_as_mouse_event)) {
+			} else if (event.TouchInput.ID == m_move_id && m_move_sent_as_mouse_event) {
 				m_shootline = m_device
 						->getSceneManager()
 						->getSceneCollisionManager()
@@ -899,45 +898,21 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 					(!m_fixed_joystick &&
 					distance_sq > m_touchscreen_threshold * m_touchscreen_threshold)) {
 				m_joystick_has_really_moved = true;
+
+				m_joystick_direction = atan2(dx, -dy);
+
 				double distance = sqrt(distance_sq);
-
-				// angle in degrees
-				double angle = acos(dx / distance) * 180 / M_PI;
-				if (dy < 0)
-					angle *= -1;
-				// rotate to make comparing easier
-				angle = fmod(angle + 180 + 22.5, 360);
-
-				// reset state before applying
-				for (bool & joystick_status : m_joystick_status)
-					joystick_status = false;
-
 				if (distance <= m_touchscreen_threshold) {
-					// do nothing
-				} else if (angle < 45)
-					m_joystick_status[j_left] = true;
-				else if (angle < 90) {
-					m_joystick_status[j_forward] = true;
-					m_joystick_status[j_left] = true;
-				} else if (angle < 135)
-					m_joystick_status[j_forward] = true;
-				else if (angle < 180) {
-					m_joystick_status[j_forward] = true;
-					m_joystick_status[j_right] = true;
-				} else if (angle < 225)
-					m_joystick_status[j_right] = true;
-				else if (angle < 270) {
-					m_joystick_status[j_backward] = true;
-					m_joystick_status[j_right] = true;
-				} else if (angle < 315)
-					m_joystick_status[j_backward] = true;
-				else if (angle <= 360) {
-					m_joystick_status[j_backward] = true;
-					m_joystick_status[j_left] = true;
+					m_joystick_speed = 0.0f;
+				} else {
+					m_joystick_speed = distance / button_size;
+					if (m_joystick_speed > 1.0f)
+						m_joystick_speed = 1.0f;
 				}
 
+				m_joystick_status_aux1 = distance > (button_size * 1.5f);
+
 				if (distance > button_size) {
-					m_joystick_status[j_aux1] = true;
 					// move joystick "button"
 					s32 ndx = button_size * dx / distance - button_size / 2.0f;
 					s32 ndy = button_size * dy / distance - button_size / 2.0f;
@@ -971,7 +946,7 @@ void TouchScreenGUI::handleChangedButton(const SEvent &event)
 		for (auto iter = m_buttons[i].ids.begin();
 				iter != m_buttons[i].ids.end(); ++iter) {
 			if (event.TouchInput.ID == *iter) {
-				int current_button_id =
+				auto current_button_id =
 						getButtonID(event.TouchInput.X, event.TouchInput.Y);
 
 				if (current_button_id == i)
@@ -1038,17 +1013,14 @@ bool TouchScreenGUI::doRightClick()
 
 void TouchScreenGUI::applyJoystickStatus()
 {
-	for (unsigned int i = 0; i < 5; i++) {
-		if (i == 4 && !m_joystick_triggers_aux1)
-			continue;
-
+	if (m_joystick_triggers_aux1) {
 		SEvent translated{};
 		translated.EventType            = irr::EET_KEY_INPUT_EVENT;
-		translated.KeyInput.Key         = id2keycode(m_joystick_names[i]);
+		translated.KeyInput.Key         = id2keycode(aux1_id);
 		translated.KeyInput.PressedDown = false;
 		m_receiver->OnEvent(translated);
 
-		if (m_joystick_status[i]) {
+		if (m_joystick_status_aux1) {
 			translated.KeyInput.PressedDown = true;
 			m_receiver->OnEvent(translated);
 		}
@@ -1110,12 +1082,7 @@ void TouchScreenGUI::step(float dtime)
 	}
 
 	// joystick
-	for (unsigned int i = 0; i < 4; i++) {
-		if (m_joystick_status[i]) {
-			applyJoystickStatus();
-			break;
-		}
-	}
+	applyJoystickStatus();
 
 	// if a new placed pointer isn't moved for some time start digging
 	if (m_has_move_id &&

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -54,10 +54,6 @@ typedef enum
 	chat_id,
 	inventory_id,
 	drop_id,
-	forward_id,
-	backward_id,
-	left_id,
-	right_id,
 	joystick_off_id,
 	joystick_bg_id,
 	joystick_center_id

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -194,6 +194,9 @@ public:
 	 */
 	line3d<f32> getShootline() { return m_shootline; }
 
+	float getMovementDirection() { return m_joystick_direction; }
+	float getMovementSpeed() { return m_joystick_speed; }
+
 	void step(float dtime);
 	void resetHud();
 	void registerHudItem(int index, const rect<s32> &rect);
@@ -220,11 +223,6 @@ private:
 	double m_camera_yaw_change = 0.0;
 	double m_camera_pitch = 0.0;
 
-	// forward, backward, left, right
-	touch_gui_button_id m_joystick_names[5] = {
-			forward_id, backward_id, left_id, right_id, aux1_id};
-	bool m_joystick_status[5] = {false, false, false, false, false};
-
 	/*
 	 * A line starting at the camera and pointing towards the
 	 * selected object.
@@ -238,11 +236,14 @@ private:
 	bool m_move_has_really_moved = false;
 	u64 m_move_downtime = 0;
 	bool m_move_sent_as_mouse_event = false;
-	v2s32 m_move_downlocation = v2s32(-10000, -10000);
+	v2s32 m_move_downlocation = v2s32(-10000, -10000); // off-screen
 
 	bool m_has_joystick_id = false;
 	size_t m_joystick_id;
 	bool m_joystick_has_really_moved = false;
+	float m_joystick_direction = 0.0f; // assume forward
+	float m_joystick_speed = 0.0f; // no movement
+	bool m_joystick_status_aux1 = false;
 	bool m_fixed_joystick = false;
 	bool m_joystick_triggers_aux1 = false;
 	bool m_draw_crosshair = false;


### PR DESCRIPTION
**Goal of the PR**
This PR makes the input handler to use virtual joystick's coordinate directly instead of using keyboard event so that the movement can be smooth and not limited to 8 direction and full speed.

[YouTube video](https://youtu.be/FEWO15rOSyk)

**How does the PR work?**
The movement's direction and speed are calculated directly from the virtual joystick button's screen coordinate.

The only virtual joystick status left is for Aux1 button (used if `virtual_joystick_triggers_aux1` is enabled).

**Does it resolve any reported issue?**
This PR tries to fix #12436.

**Does this relate to a goal in the roadmap?**
Probably, this PR tries to fix a reported UX issue.

## To do

This PR is a Ready for Review.

## How to test

1. Run Minetest on a touch-screen device.
2. Play in a world or on a server.
3. Use the virtual joystick with incrementing distance from its centre.
4. The movement's speed should be linearly proportional to the button's distance from its container's centre.
5. Back to Menu.
6. Enable `virtual_joystick_triggers_aux1`.
7. Play in a world or on a server with a sprinting mod.
8. Use the virtual joystick to move forward until the button is outside its container.
9. The Aux1 button should be pressed automatically while moving forward (e.g. sprinting is happening).

**Android: APK builds**
- [armeabi-v7a](https://drive.google.com/file/d/1lxGAmjfd2GT1ZNICN-VGTd3DhlqCdtcw/view)
- [arm64-v8a](https://drive.google.com/file/d/18JiRD-VGNYGm3WvAStFQp4NheRB3-dvb/view)
- [x86](https://drive.google.com/file/d/1CPr46jx4x8SHxPyiHWBwBMzI3qkBAQHj/view)
- [x86_64](https://drive.google.com/file/d/1z0CYD03RvaVkZbNL14eC17ZyDOHv9QA7/view)