### PR TITLE
Move behavior out of CAO mgr into other classes

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -63,5 +63,6 @@ set(client_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/shadows/dynamicshadowsrender.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/shadows/shadowsshadercallbacks.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/shadows/shadowsScreenQuad.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/shootline.cpp
 	PARENT_SCOPE
 )

--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -19,8 +19,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
 #include "activeobject.h"
+#include "irrlichttypes_extrabloated.h"
+#include "shootline.h"
+
 #include <unordered_map>
 #include <unordered_set>
 
@@ -32,6 +34,8 @@ class IGameDef;
 class LocalPlayer;
 struct ItemStack;
 class WieldMeshSceneNode;
+
+class DistanceSortedActiveObject;
 
 class ClientActiveObject : public ActiveObject
 {
@@ -83,6 +87,9 @@ public:
 	// If returns true, punch will not be sent to the server
 	virtual bool directReportPunch(v3f dir, const ItemStack *punchitem = nullptr,
 		float time_from_last_punch = 1000000) { return false; }
+
+	void selectIfInRange(const Shootline &shootline,
+			std::vector<DistanceSortedActiveObject> &dest);
 
 protected:
 	// Used for creating objects based on type

--- a/src/client/shootline.cpp
+++ b/src/client/shootline.cpp
@@ -1,0 +1,46 @@
+/*
+Minetest
+Copyright (C) 2023 Josiah VanderZee <josiah_vanderzee@mediacombb.net>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "irrlichttypes_bloated.h"
+#include "shootline.h"
+
+#include <cmath>
+
+Shootline::Shootline(const core::line3d<f32> &shootline)
+{
+	m_dir = shootline.getVector().normalize();
+	v3f li2dir = m_dir + (std::fabs(m_dir.X) < 0.5f ? v3f(1, 0, 0) : v3f(0, 1, 0));
+	m_dir_ortho1 = m_dir.crossProduct(li2dir).normalize();
+	m_dir_ortho2 = m_dir.crossProduct(m_dir_ortho1);
+}
+
+bool Shootline::hitsSelectionBox(
+		const v3f &pos_diff, f32 dist, f32 selection_box_radius) const
+{
+	// backward- and far-plane
+	f32 max_d = m_line.getLength();
+	if (dist + selection_box_radius < 0.0f || dist - selection_box_radius > max_d)
+		return false;
+
+	// side-planes
+	if (std::fabs(m_dir_ortho1.dotProduct(pos_diff)) > selection_box_radius ||
+			std::fabs(m_dir_ortho2.dotProduct(pos_diff)) > selection_box_radius)
+		return false;
+	return true;
+}

--- a/src/client/shootline.h
+++ b/src/client/shootline.h
@@ -1,0 +1,39 @@
+/*
+Minetest
+Copyright (C) 2023 Josiah VanderZee <josiah_vanderzee@mediacombb.net>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes_bloated.h"
+
+class Shootline
+{
+public:
+	Shootline(const core::line3d<f32> &shootline);
+
+	bool hitsSelectionBox(const v3f &pos_diff, f32 dist, f32 selection_box_radius) const;
+
+	const v3f &getDir() const { return m_dir; }
+	const core::line3d<f32> &getLine() const { return m_line; }
+
+private:
+	v3f m_dir{};
+	v3f m_dir_ortho1{};
+	v3f m_dir_ortho2{};
+	core::line3d<f32> m_line{};
+};


### PR DESCRIPTION
This adds a Shootline class that does the selectionbox calculations instead of the client ActiveObjectMgr doing them directly. It also moves part of the logic to ClientActiveObject. This has greatly reduced the size of the client ActiveObjectMgr class, and most of what's left is object management behavior. In computer science jargon, we could say the codebase is more cohesive.