### PR TITLE
[NOSQUASH] Fix some warnings

### DIFF
--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -13,6 +13,7 @@
 | LuaJIT     | 2.0+    | Bundled Lua 5.1 is used if not present |
 | GMP        | 5.0.0+  | Bundled mini-GMP is used if not present |
 | JsonCPP    | 1.0.0+  | Bundled JsonCPP is used if not present |
+| Curl       | 7.56.0+ | Optional   |
 
 For Debian/Ubuntu users:
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4376,7 +4376,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 					ItemStack slct = list_selected->getItem(m_selected_item->i);
 
-					for (s32 i = 0; i < list_s->getSize(); i++) {
+					for (s32 i = 0; i < (s32)list_s->getSize(); i++) {
 						// Skip the selected slot
 						if (i == m_selected_item->i)
 							continue;
@@ -4556,7 +4556,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 			// Pickup all of the item from the list
 			if (slct.count > 0) {
-				for (s32 i = 0; i < list_s->getSize(); i++) {
+				for (s32 i = 0; i < (s32)list_s->getSize(); i++) {
 					// Skip the selected slot
 					if (i == s.i)
 						continue;

--- a/src/unittest/test_irrptr.cpp
+++ b/src/unittest/test_irrptr.cpp
@@ -91,12 +91,14 @@ void TestIrrPtr::testRefCounting()
 			obj->getReferenceCount());
 }
 
-#if defined(__clang__)
+#if defined(__clang__) || defined(__GNUC__)
 	#pragma GCC diagnostic push
 	#if __clang_major__ >= 7
 		#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
 	#endif
-	#pragma GCC diagnostic ignored "-Wself-move"
+	#if defined(__clang__) || __GNUC__ >= 13
+		#pragma GCC diagnostic ignored "-Wself-move"
+	#endif
 #endif
 
 void TestIrrPtr::testSelfAssignment()
@@ -138,6 +140,6 @@ void TestIrrPtr::testNullHandling()
 	UASSERT(!p3);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) || defined(__GNUC__)
 	#pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
* An intentional self-move in the `irr_ptr` unittests.
  (Note: If not defined, macros, such as `__GNUC__`, are replaced 0, so this is fine.)
* ~~The minimum curl version is now specified as 7.68.0. This is the version on ubuntu 20.04.
  The actual minimum is probably 7.56.0, but I'm not sure if the other parts of the code use newer functions.
  FYI, ubuntu 18.04 seems to have curl 7.58.0.~~
  The minimum curl version is now specified as 7.56.0.
* The invlist warnings were introduced recently.
  (I'm assuming invlist size does not use the full range of values in u32. We should really start using one datatype for invlist indices everywhere at some point...)

## To do

This PR is a Ready for Review.

## How to test

* Build.
* Example to try the multipart http stuff:
```lua
local http = assert(minetest.request_http_api())

minetest.after(3, function()
	local req = {
		url = "https://httpbin.org/post",
		method = "POST",
		data = {foo = "bar", baz = "buzz", bla = "bli"},
		user_agent = " ",
		multipart = true,
	}
	http.fetch(req, function(res)
		minetest.log(dump(res))
	end)
	minetest.log("sent http request")
end)
```
