### PR TITLE
Cull liquid back face on liquid-glasslike interface

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -457,11 +457,9 @@ void MapblockMeshGenerator::drawSolidNode()
 			if (f2.solidness == 2)
 				continue;
 			if (f->drawtype == NDT_LIQUID) {
-				if (n2 == nodedef->getId(f->liquid_alternative_flowing))
+				if (f->sameLiquidRender(f2))
 					continue;
-				if (n2 == nodedef->getId(f->liquid_alternative_source))
-					continue;
-				backface_culling = f2.solidness >= 1;
+				backface_culling = f2.solidness || f2.visual_solidness;
 			}
 		}
 		faces |= 1 << face;
@@ -469,8 +467,6 @@ void MapblockMeshGenerator::drawSolidNode()
 		for (auto &layer : tiles[face].layers) {
 			if (backface_culling)
 				layer.material_flags |= MATERIAL_FLAG_BACKFACE_CULLING;
-			else
-				layer.material_flags &= ~MATERIAL_FLAG_BACKFACE_CULLING;
 			layer.material_flags |= MATERIAL_FLAG_TILEABLE_HORIZONTAL;
 			layer.material_flags |= MATERIAL_FLAG_TILEABLE_VERTICAL;
 		}


### PR DESCRIPTION
Fix #13569.
Closes #13593 (alternative).

Note: does not fix flowing liquid, it was z-fighting against glasslike in 5.7.0 and needs a separate fix (enabling backface culling for each face independently).

Note: this keeps interliquid boundaries visible:
<img width="1920" alt="image" src="https://github.com/minetest/minetest/assets/7352626/d37c28cd-bb6a-4b6b-ab54-2ed351c22a95">

## To do

This PR is Ready for Review.

## How to test

Place `glasslike`, `glasslike_framed`, `allfaces` nodes into a transparent liquid.
Mix different transparent liquids.
