### PR TITLE
[NOSQUASH] Remove trigonometry from liquid drawing

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -774,15 +774,28 @@ void MapblockMeshGenerator::drawLiquidTop()
 	// Positive if liquid moves towards +X
 	f32 dx = (corner_levels[0][0] + corner_levels[1][0]) -
 	         (corner_levels[0][1] + corner_levels[1][1]);
-	f32 tcoord_angle = atan2(dz, dx) * core::RADTODEG;
 	v2f tcoord_center(0.5, 0.5);
 	v2f tcoord_translate(blockpos_nodes.Z + p.Z, blockpos_nodes.X + p.X);
-	tcoord_translate.rotateBy(tcoord_angle);
+	v2f dir = v2f(dx, dz).normalize();
+	if (dir == v2f{0.0f, 0.0f}) // if corners are symmetrical
+		dir = v2f{1.0f, 0.0f};
+
+	// Rotate tcoord_translate around the origin. The X axis turns to dir.
+	tcoord_translate.set(
+		dir.X * tcoord_translate.X - dir.Y * tcoord_translate.Y,
+		dir.Y * tcoord_translate.X + dir.X * tcoord_translate.Y);
+
 	tcoord_translate.X -= floor(tcoord_translate.X);
 	tcoord_translate.Y -= floor(tcoord_translate.Y);
 
 	for (video::S3DVertex &vertex : vertices) {
-		vertex.TCoords.rotateBy(tcoord_angle, tcoord_center);
+		// Rotate vertex.TCoords around tcoord_center. The X axis turns to dir.
+		vertex.TCoords -= tcoord_center;
+		vertex.TCoords.set(
+			dir.X * vertex.TCoords.X - dir.Y * vertex.TCoords.Y,
+			dir.Y * vertex.TCoords.X + dir.X * vertex.TCoords.Y);
+		vertex.TCoords += tcoord_center;
+
 		vertex.TCoords += tcoord_translate;
 	}
 

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -603,7 +603,7 @@ void MapblockMeshGenerator::getLiquidNeighborhood()
 		v3s16 p2 = p + v3s16(u, 0, w);
 		MapNode n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
 		neighbor.content = n2.getContent();
-		neighbor.level = -0.5 * BS;
+		neighbor.level = -0.5f;
 		neighbor.is_same_liquid = false;
 		neighbor.top_is_same_liquid = false;
 
@@ -612,7 +612,7 @@ void MapblockMeshGenerator::getLiquidNeighborhood()
 
 		if (neighbor.content == c_source) {
 			neighbor.is_same_liquid = true;
-			neighbor.level = 0.5 * BS;
+			neighbor.level = 0.5f;
 		} else if (neighbor.content == c_flowing) {
 			neighbor.is_same_liquid = true;
 			u8 liquid_level = (n2.param2 & LIQUID_LEVEL_MASK);
@@ -620,7 +620,7 @@ void MapblockMeshGenerator::getLiquidNeighborhood()
 				liquid_level = 0;
 			else
 				liquid_level -= (LIQUID_LEVEL_MAX + 1 - range);
-			neighbor.level = (-0.5 + (liquid_level + 0.5) / range) * BS;
+			neighbor.level = (-0.5f + (liquid_level + 0.5f) / range);
 		}
 
 		// Check node above neighbor.
@@ -652,11 +652,11 @@ f32 MapblockMeshGenerator::getCornerLevel(int i, int k)
 
 		// If top is liquid, draw starting from top of node
 		if (neighbor_data.top_is_same_liquid)
-			return 0.5 * BS;
+			return 0.5f;
 
 		// Source always has the full height
 		if (content == c_source)
-			return 0.5 * BS;
+			return 0.5f;
 
 		// Flowing liquid has level information
 		if (content == c_flowing) {
@@ -667,7 +667,7 @@ f32 MapblockMeshGenerator::getCornerLevel(int i, int k)
 		}
 	}
 	if (air_count >= 2)
-		return -0.5 * BS + 0.2;
+		return -0.5f + 0.2f / BS;
 	if (count > 0)
 		return sum / count;
 	return 0;
@@ -725,12 +725,12 @@ void MapblockMeshGenerator::drawLiquidSides()
 			pos.X = (base.X - 0.5f) * BS;
 			pos.Z = (base.Z - 0.5f) * BS;
 			if (vertex.v) {
-				pos.Y = neighbor.is_same_liquid ? corner_levels[base.Z][base.X] : -0.5f * BS;
+				pos.Y = (neighbor.is_same_liquid ? corner_levels[base.Z][base.X] : -0.5f) * BS;
 			} else if (top_is_same_liquid) {
 				pos.Y = 0.5f * BS;
 			} else {
-				pos.Y = corner_levels[base.Z][base.X];
-				v += (0.5f * BS - corner_levels[base.Z][base.X]) / BS;
+				pos.Y = corner_levels[base.Z][base.X] * BS;
+				v += 0.5f - corner_levels[base.Z][base.X];
 			}
 
 			if (data->m_smooth_lighting)
@@ -759,7 +759,7 @@ void MapblockMeshGenerator::drawLiquidTop()
 	for (int i = 0; i < 4; i++) {
 		int u = corner_resolve[i][0];
 		int w = corner_resolve[i][1];
-		vertices[i].Pos.Y += corner_levels[w][u];
+		vertices[i].Pos.Y += corner_levels[w][u] * BS;
 		if (data->m_smooth_lighting)
 			vertices[i].Color = blendLightColor(vertices[i].Pos);
 		vertices[i].Pos += origin;


### PR DESCRIPTION
Fix #13217 
Replaces `atan2`+`rotateBy` combo with matrix multiplication (inlined, since Irrlicht lacks 2×2 matrix type apparently).
Also, some cleanup in nearby code to ensure exact values are exact (avoiding `*BS/BS`).

## To do

This PR is Ready for Review.

## How to test

Look at flowing liquid. Compare with current master. Pay attention to symmetrical cases (e.g. a flowing liquid node surrounded with sources at all 4 sides).