### PR TITLE
[NOSQUASH] Cleanup tile rotation

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -208,30 +208,6 @@ static std::array<video::S3DVertex, 24> setupCuboidVertices(const aabb3f &box, c
 			case TileRotation::R270:
 				tcoords.set(tcoords.Y, -tcoords.X);
 				break;
-			case TileRotation::FXR90:
-				tcoords.X = 1.0 - tcoords.X;
-				tcoords.set(-tcoords.Y, tcoords.X);
-				break;
-			case TileRotation::FXR270:
-				tcoords.X = 1.0 - tcoords.X;
-				tcoords.set(tcoords.Y, -tcoords.X);
-				break;
-			case TileRotation::FYR90:
-				tcoords.Y = 1.0 - tcoords.Y;
-				tcoords.set(-tcoords.Y, tcoords.X);
-				break;
-			case TileRotation::FYR270:
-				tcoords.Y = 1.0 - tcoords.Y;
-				tcoords.set(tcoords.Y, -tcoords.X);
-				break;
-			case TileRotation::FX:
-				tcoords.X = 1.0 - tcoords.X;
-				break;
-			case TileRotation::FY:
-				tcoords.Y = 1.0 - tcoords.Y;
-				break;
-			default:
-				break;
 			}
 		}
 	}

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -200,29 +200,29 @@ static std::array<video::S3DVertex, 24> setupCuboidVertices(const aabb3f &box, c
 			case 0:
 				break;
 			case 1: // R90
-				tcoords.rotateBy(90, irr::core::vector2df(0, 0));
+				tcoords.set(-tcoords.Y, tcoords.X);
 				break;
 			case 2: // R180
-				tcoords.rotateBy(180, irr::core::vector2df(0, 0));
+				tcoords.set(-tcoords.X, -tcoords.Y);
 				break;
 			case 3: // R270
-				tcoords.rotateBy(270, irr::core::vector2df(0, 0));
+				tcoords.set(tcoords.Y, -tcoords.X);
 				break;
 			case 4: // FXR90
 				tcoords.X = 1.0 - tcoords.X;
-				tcoords.rotateBy(90, irr::core::vector2df(0, 0));
+				tcoords.set(-tcoords.Y, tcoords.X);
 				break;
 			case 5: // FXR270
 				tcoords.X = 1.0 - tcoords.X;
-				tcoords.rotateBy(270, irr::core::vector2df(0, 0));
+				tcoords.set(tcoords.Y, -tcoords.X);
 				break;
 			case 6: // FYR90
 				tcoords.Y = 1.0 - tcoords.Y;
-				tcoords.rotateBy(90, irr::core::vector2df(0, 0));
+				tcoords.set(-tcoords.Y, tcoords.X);
 				break;
 			case 7: // FYR270
 				tcoords.Y = 1.0 - tcoords.Y;
-				tcoords.rotateBy(270, irr::core::vector2df(0, 0));
+				tcoords.set(tcoords.Y, -tcoords.X);
 				break;
 			case 8: // FX
 				tcoords.X = 1.0 - tcoords.X;

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -197,37 +197,37 @@ static std::array<video::S3DVertex, 24> setupCuboidVertices(const aabb3f &box, c
 			video::S3DVertex &vertex = vertices[face * 4 + j];
 			v2f &tcoords = vertex.TCoords;
 			switch (tile.rotation) {
-			case 0:
+			case TileRotation::None:
 				break;
-			case 1: // R90
+			case TileRotation::R90:
 				tcoords.set(-tcoords.Y, tcoords.X);
 				break;
-			case 2: // R180
+			case TileRotation::R180:
 				tcoords.set(-tcoords.X, -tcoords.Y);
 				break;
-			case 3: // R270
+			case TileRotation::R270:
 				tcoords.set(tcoords.Y, -tcoords.X);
 				break;
-			case 4: // FXR90
+			case TileRotation::FXR90:
 				tcoords.X = 1.0 - tcoords.X;
 				tcoords.set(-tcoords.Y, tcoords.X);
 				break;
-			case 5: // FXR270
+			case TileRotation::FXR270:
 				tcoords.X = 1.0 - tcoords.X;
 				tcoords.set(tcoords.Y, -tcoords.X);
 				break;
-			case 6: // FYR90
+			case TileRotation::FYR90:
 				tcoords.Y = 1.0 - tcoords.Y;
 				tcoords.set(-tcoords.Y, tcoords.X);
 				break;
-			case 7: // FYR270
+			case TileRotation::FYR270:
 				tcoords.Y = 1.0 - tcoords.Y;
 				tcoords.set(tcoords.Y, -tcoords.X);
 				break;
-			case 8: // FX
+			case TileRotation::FX:
 				tcoords.X = 1.0 - tcoords.X;
 				break;
-			case 9: // FY
+			case TileRotation::FY:
 				tcoords.Y = 1.0 - tcoords.Y;
 				break;
 			default:
@@ -1326,7 +1326,7 @@ void MapblockMeshGenerator::drawFencelikeNode()
 
 	// Put wood the right way around in the posts
 	TileSpec tile_rot = tile;
-	tile_rot.rotation = 1;
+	tile_rot.rotation = TileRotation::R90;
 
 	static const f32 post_rad = BS / 8;
 	static const f32 bar_rad  = BS / 16;

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -400,42 +400,48 @@ void getNodeTile(MapNode mn, const v3s16 &p, const v3s16 &dir, MeshMakeData *dat
 	// Get rotation for things like chests
 	u8 facedir = mn.getFaceDir(ndef, true);
 
+	static constexpr auto
+		R0 = TileRotation::None,
+		R1 = TileRotation::R90,
+		R2 = TileRotation::R180,
+		R3 = TileRotation::R270;
 	static const struct {
-		u8 tile, rotation;
+		u8 tile;
+		TileRotation rotation;
 	} dir_to_tile[24][8] = {
 		// 0     +X    +Y    +Z           -Z    -Y    -X   ->   value=tile,rotation
-		   0,0,  2,0 , 0,0 , 4,0 ,  0,0,  5,0 , 1,0 , 3,0 ,  // rotate around y+ 0 - 3
-		   0,0,  4,0 , 0,3 , 3,0 ,  0,0,  2,0 , 1,1 , 5,0 ,
-		   0,0,  3,0 , 0,2 , 5,0 ,  0,0,  4,0 , 1,2 , 2,0 ,
-		   0,0,  5,0 , 0,1 , 2,0 ,  0,0,  3,0 , 1,3 , 4,0 ,
+		   0,R0,  2,R0 , 0,R0 , 4,R0 ,  0,R0,  5,R0 , 1,R0 , 3,R0 ,  // rotate around y+ 0 - 3
+		   0,R0,  4,R0 , 0,R3 , 3,R0 ,  0,R0,  2,R0 , 1,R1 , 5,R0 ,
+		   0,R0,  3,R0 , 0,R2 , 5,R0 ,  0,R0,  4,R0 , 1,R2 , 2,R0 ,
+		   0,R0,  5,R0 , 0,R1 , 2,R0 ,  0,R0,  3,R0 , 1,R3 , 4,R0 ,
 
-		   0,0,  2,3 , 5,0 , 0,2 ,  0,0,  1,0 , 4,2 , 3,1 ,  // rotate around z+ 4 - 7
-		   0,0,  4,3 , 2,0 , 0,1 ,  0,0,  1,1 , 3,2 , 5,1 ,
-		   0,0,  3,3 , 4,0 , 0,0 ,  0,0,  1,2 , 5,2 , 2,1 ,
-		   0,0,  5,3 , 3,0 , 0,3 ,  0,0,  1,3 , 2,2 , 4,1 ,
+		   0,R0,  2,R3 , 5,R0 , 0,R2 ,  0,R0,  1,R0 , 4,R2 , 3,R1 ,  // rotate around z+ 4 - 7
+		   0,R0,  4,R3 , 2,R0 , 0,R1 ,  0,R0,  1,R1 , 3,R2 , 5,R1 ,
+		   0,R0,  3,R3 , 4,R0 , 0,R0 ,  0,R0,  1,R2 , 5,R2 , 2,R1 ,
+		   0,R0,  5,R3 , 3,R0 , 0,R3 ,  0,R0,  1,R3 , 2,R2 , 4,R1 ,
 
-		   0,0,  2,1 , 4,2 , 1,2 ,  0,0,  0,0 , 5,0 , 3,3 ,  // rotate around z- 8 - 11
-		   0,0,  4,1 , 3,2 , 1,3 ,  0,0,  0,3 , 2,0 , 5,3 ,
-		   0,0,  3,1 , 5,2 , 1,0 ,  0,0,  0,2 , 4,0 , 2,3 ,
-		   0,0,  5,1 , 2,2 , 1,1 ,  0,0,  0,1 , 3,0 , 4,3 ,
+		   0,R0,  2,R1 , 4,R2 , 1,R2 ,  0,R0,  0,R0 , 5,R0 , 3,R3 ,  // rotate around z- 8 - 11
+		   0,R0,  4,R1 , 3,R2 , 1,R3 ,  0,R0,  0,R3 , 2,R0 , 5,R3 ,
+		   0,R0,  3,R1 , 5,R2 , 1,R0 ,  0,R0,  0,R2 , 4,R0 , 2,R3 ,
+		   0,R0,  5,R1 , 2,R2 , 1,R1 ,  0,R0,  0,R1 , 3,R0 , 4,R3 ,
 
-		   0,0,  0,3 , 3,3 , 4,1 ,  0,0,  5,3 , 2,3 , 1,3 ,  // rotate around x+ 12 - 15
-		   0,0,  0,2 , 5,3 , 3,1 ,  0,0,  2,3 , 4,3 , 1,0 ,
-		   0,0,  0,1 , 2,3 , 5,1 ,  0,0,  4,3 , 3,3 , 1,1 ,
-		   0,0,  0,0 , 4,3 , 2,1 ,  0,0,  3,3 , 5,3 , 1,2 ,
+		   0,R0,  0,R3 , 3,R3 , 4,R1 ,  0,R0,  5,R3 , 2,R3 , 1,R3 ,  // rotate around x+ 12 - 15
+		   0,R0,  0,R2 , 5,R3 , 3,R1 ,  0,R0,  2,R3 , 4,R3 , 1,R0 ,
+		   0,R0,  0,R1 , 2,R3 , 5,R1 ,  0,R0,  4,R3 , 3,R3 , 1,R1 ,
+		   0,R0,  0,R0 , 4,R3 , 2,R1 ,  0,R0,  3,R3 , 5,R3 , 1,R2 ,
 
-		   0,0,  1,1 , 2,1 , 4,3 ,  0,0,  5,1 , 3,1 , 0,1 ,  // rotate around x- 16 - 19
-		   0,0,  1,2 , 4,1 , 3,3 ,  0,0,  2,1 , 5,1 , 0,0 ,
-		   0,0,  1,3 , 3,1 , 5,3 ,  0,0,  4,1 , 2,1 , 0,3 ,
-		   0,0,  1,0 , 5,1 , 2,3 ,  0,0,  3,1 , 4,1 , 0,2 ,
+		   0,R0,  1,R1 , 2,R1 , 4,R3 ,  0,R0,  5,R1 , 3,R1 , 0,R1 ,  // rotate around x- 16 - 19
+		   0,R0,  1,R2 , 4,R1 , 3,R3 ,  0,R0,  2,R1 , 5,R1 , 0,R0 ,
+		   0,R0,  1,R3 , 3,R1 , 5,R3 ,  0,R0,  4,R1 , 2,R1 , 0,R3 ,
+		   0,R0,  1,R0 , 5,R1 , 2,R3 ,  0,R0,  3,R1 , 4,R1 , 0,R2 ,
 
-		   0,0,  3,2 , 1,2 , 4,2 ,  0,0,  5,2 , 0,2 , 2,2 ,  // rotate around y- 20 - 23
-		   0,0,  5,2 , 1,3 , 3,2 ,  0,0,  2,2 , 0,1 , 4,2 ,
-		   0,0,  2,2 , 1,0 , 5,2 ,  0,0,  4,2 , 0,0 , 3,2 ,
-		   0,0,  4,2 , 1,1 , 2,2 ,  0,0,  3,2 , 0,3 , 5,2
+		   0,R0,  3,R2 , 1,R2 , 4,R2 ,  0,R0,  5,R2 , 0,R2 , 2,R2 ,  // rotate around y- 20 - 23
+		   0,R0,  5,R2 , 1,R3 , 3,R2 ,  0,R0,  2,R2 , 0,R1 , 4,R2 ,
+		   0,R0,  2,R2 , 1,R0 , 5,R2 ,  0,R0,  4,R2 , 0,R0 , 3,R2 ,
+		   0,R0,  4,R2 , 1,R1 , 2,R2 ,  0,R0,  3,R2 , 0,R3 , 5,R2
 	};
 	getNodeTileN(mn, p, dir_to_tile[facedir][dir_i].tile, data, tile);
-	tile.rotation = tile.world_aligned ? 0 : dir_to_tile[facedir][dir_i].rotation;
+	tile.rotation = tile.world_aligned ? TileRotation::None : dir_to_tile[facedir][dir_i].rotation;
 }
 
 static void applyTileColor(PreMeshBuffer &pmb)

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -395,13 +395,14 @@ void getNodeTile(MapNode mn, const v3s16 &p, const v3s16 &dir, MeshMakeData *dat
 	//  5 = (0,0,-1)
 	//  6 = (0,-1,0)
 	//  7 = (-1,0,0)
-	u8 dir_i = ((dir.X + 2 * dir.Y + 3 * dir.Z) & 7) * 2;
+	u8 dir_i = (dir.X + 2 * dir.Y + 3 * dir.Z) & 7;
 
 	// Get rotation for things like chests
 	u8 facedir = mn.getFaceDir(ndef, true);
 
-	static const u16 dir_to_tile[24 * 16] =
-	{
+	static const struct {
+		u8 tile, rotation;
+	} dir_to_tile[24][8] = {
 		// 0     +X    +Y    +Z           -Z    -Y    -X   ->   value=tile,rotation
 		   0,0,  2,0 , 0,0 , 4,0 ,  0,0,  5,0 , 1,0 , 3,0 ,  // rotate around y+ 0 - 3
 		   0,0,  4,0 , 0,3 , 3,0 ,  0,0,  2,0 , 1,1 , 5,0 ,
@@ -432,11 +433,9 @@ void getNodeTile(MapNode mn, const v3s16 &p, const v3s16 &dir, MeshMakeData *dat
 		   0,0,  5,2 , 1,3 , 3,2 ,  0,0,  2,2 , 0,1 , 4,2 ,
 		   0,0,  2,2 , 1,0 , 5,2 ,  0,0,  4,2 , 0,0 , 3,2 ,
 		   0,0,  4,2 , 1,1 , 2,2 ,  0,0,  3,2 , 0,3 , 5,2
-
 	};
-	u16 tile_index = facedir * 16 + dir_i;
-	getNodeTileN(mn, p, dir_to_tile[tile_index], data, tile);
-	tile.rotation = tile.world_aligned ? 0 : dir_to_tile[tile_index + 1];
+	getNodeTileN(mn, p, dir_to_tile[facedir][dir_i].tile, data, tile);
+	tile.rotation = tile.world_aligned ? 0 : dir_to_tile[facedir][dir_i].rotation;
 }
 
 static void applyTileColor(PreMeshBuffer &pmb)

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -295,6 +295,19 @@ struct TileLayer
 	u8 scale = 1;
 };
 
+enum class TileRotation: u8 {
+	None,
+	R90,
+	R180,
+	R270,
+	FXR90,
+	FXR270,
+	FYR90,
+	FYR270,
+	FX,
+	FY,
+};
+
 /*!
  * Defines a face of a node. May have up to two layers.
  */
@@ -305,7 +318,7 @@ struct TileSpec
 	//! If true, the tile rotation is ignored.
 	bool world_aligned = false;
 	//! Tile rotation.
-	u8 rotation = 0;
+	TileRotation rotation = TileRotation::None;
 	//! This much light does the tile emit.
 	u8 emissive_light = 0;
 	//! The first is base texture, the second is overlay.

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -300,12 +300,6 @@ enum class TileRotation: u8 {
 	R90,
 	R180,
 	R270,
-	FXR90,
-	FXR270,
-	FYR90,
-	FYR270,
-	FX,
-	FY,
 };
 
 /*!


### PR DESCRIPTION
* Fixes #13218 
* Replaces magic rotation numbers with a enum
* Removes tile rotations that weren’t used for years, if at all

## To do

This PR is Ready for Review.

## How to test

Test facedir nodes.
I guess this should be unit-testable but there aren’t any tests yet.