### PR TITLE
Decrease sneak margin to combat phasing through thin walls

### DIFF
--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -60,6 +60,8 @@ bool LocalPlayer::updateSneakNode(Map *map, const v3f &position,
 	const v3f &sneak_max)
 {
 	// Acceptable distance to node center
+	// This must be > 0.5 units to get the sneak ladder to work
+	// 0.05 prevents sideways teleporting through 1/16 thick walls
 	constexpr f32 allowed_range = (0.5f + 0.05f) * BS;
 	static const v3s16 dir9_center[9] = {
 		v3s16( 0, 0,  0),

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -60,7 +60,7 @@ bool LocalPlayer::updateSneakNode(Map *map, const v3f &position,
 	const v3f &sneak_max)
 {
 	// Acceptable distance to node center
-	constexpr f32 allowed_range = (0.5f + 0.1f) * BS;
+	constexpr f32 allowed_range = (0.5f + 0.05f) * BS;
 	static const v3s16 dir9_center[9] = {
 		v3s16( 0, 0,  0),
 		v3s16( 1, 0,  0),


### PR DESCRIPTION
Fixes [#13527](https://github.com/minetest/minetest/issues/13527)

A 1/16th-node-thick wall is 0.625 meters thick, and the previous margin of 0.1 meters meant that these walls could be phased through by sneaking against them. A margin lower than 0.625 prevents this.

I understand that this margin is necessary to prevent players from sneaking off of nodes; however, a value of 0.05 still appears sufficient to prevent this, even at high velocities and low FPS settings.

## To do

This PR is Ready for Review.

## How to test

While on the interior side of a 1/16th-node-thick wall, press the player against it, and try to sneak through.
