### PR TITLE
remove unsupported media formats from client.cpp

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -770,7 +770,6 @@ bool Client::loadMedia(const std::string &data, const std::string &filename,
 
 	const char *image_ext[] = {
 		".png", ".jpg", ".bmp", ".tga",
-		".pcx", ".ppm", ".psd", ".wal", ".rgb",
 		NULL
 	};
 	name = removeStringEnd(filename, image_ext);
@@ -818,7 +817,7 @@ bool Client::loadMedia(const std::string &data, const std::string &filename,
 	}
 
 	const char *model_ext[] = {
-		".x", ".b3d", ".md2", ".obj",
+		".x", ".b3d", ".obj",
 		NULL
 	};
 	name = removeStringEnd(filename, model_ext);


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

removes unsupported media from client.cpp as pointed out on matrix

as noted on matrix, shouldnt really be a problem as the formats should be prevented from the server at https://github.com/minetest/minetest/blob/master/src/server.cpp#L2524

## How to test

use your eyes, test compiling.
