### PR TITLE
Add `.fleet` folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ gtags.files
 # Visual Studio Code & plugins
 .vscode/
 build/.cmake/
+# Fleet
+.fleet
 # Gradle
 .gradle
 # Clang


### PR DESCRIPTION
The new [Fleet](https://www.jetbrains.com/fleet/) editor by JetBrains store it's config files in a `.fleet` folder.

The `.idea` folder used by other JetBrains IDEs (PyCharm, CLion, etc) is already ignored, so I think it make sense to also ignore it. 
