### PR TITLE
Persist text inputs in mainmenu local tab

### DIFF
--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -23,6 +23,10 @@ local valid_disabled_settings = {
 	["enable_server"]=true,
 }
 
+-- Name and port stored to persist when resending the formspec
+local current_name = core.settings:get("name")
+local current_port = core.settings:get("port")
+
 -- Currently chosen game in gamebar for theming and filtering
 function current_game()
 	local last_game_id = core.settings:get("menu_last_game")
@@ -188,7 +192,7 @@ local function get_formspec(tabview, name, tabdata)
 				"checkbox[0,"..y..";cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
 				dump(core.settings:get_bool("server_announce")) .. "]" ..
 				"field[0.3,2.85;3.8,0.5;te_playername;" .. fgettext("Name") .. ";" ..
-				core.formspec_escape(core.settings:get("name")) .. "]" ..
+				core.formspec_escape(current_name) .. "]" ..
 				"pwdfield[0.3,4.05;3.8,0.5;te_passwd;" .. fgettext("Password") .. "]"
 
 		local bind_addr = core.settings:get("bind_address")
@@ -197,7 +201,7 @@ local function get_formspec(tabview, name, tabdata)
 				"field[0.3,5.25;2.5,0.5;te_serveraddr;" .. fgettext("Bind Address") .. ";" ..
 				core.formspec_escape(core.settings:get("bind_address")) .. "]" ..
 				"field[2.85,5.25;1.25,0.5;te_serverport;" .. fgettext("Port") .. ";" ..
-				core.formspec_escape(core.settings:get("port")) .. "]"
+				core.formspec_escape(current_port) .. "]"
 		else
 			retval = retval ..
 				"field[0.3,5.25;3.8,0.5;te_serverport;" .. fgettext("Server Port") .. ";" ..
@@ -240,6 +244,14 @@ local function main_button_handler(this, fields, name, tabdata)
 
 	if menu_handle_key_up_down(fields,"sp_worlds","mainmenu_last_selected_world") then
 		return true
+	end
+
+	if fields["te_playername"] then
+		current_name = fields["te_playername"]
+	end
+
+	if fields["te_serverport"] then
+		current_port = fields["te_serverport"]
 	end
 
 	if fields["cb_creative_mode"] then


### PR DESCRIPTION
Fixes #13114, and I agree with Wuzzy's proposed method therein

This is a bug that has bothered me for a *very* long time. Previously, the username and port fields would be reset to their defaults when the formspec is re-sent. This now persists any changes made when the formspec is sent.

I opted to use local variables to store the state because I assumed it would be undesirable to commit changes to the settings until the server is actually started.

## To do

This PR is Ready for Review.

## How to test

In the main menu, open the Start Game tab. Modify the username or port fields, and then (un)check one of the checkboxes above. The text in the fields should persist correctly.
