### PR TITLE
ActiveObjectMgr::getActiveSelectableObjects

### DIFF
--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -110,17 +110,8 @@ void ActiveObjectMgr::getActiveObjects(const v3f &origin, f32 max_d,
 std::vector<DistanceSortedActiveObject> ActiveObjectMgr::getActiveSelectableObjects(const core::line3d<f32> &shootline)
 {
 	std::vector<DistanceSortedActiveObject> dest;
-	// Imagine a not-axis-aligned cuboid oriented into the direction of the shootline,
-	// with the width of the object's selection box radius * 2 and with length of the
-	// shootline (+selection box radius forwards and backwards). We check whether
-	// the selection box center is inside this cuboid.
-
 	f32 max_d = shootline.getLength();
 	v3f dir = shootline.getVector().normalize();
-	// arbitrary linearly independent vector and orthogonal dirs
-	v3f li2dir = dir + (std::fabs(dir.X) < 0.5f ? v3f(1,0,0) : v3f(0,1,0));
-	v3f dir_ortho1 = dir.crossProduct(li2dir).normalize();
-	v3f dir_ortho2 = dir.crossProduct(dir_ortho1);
 
 	for (auto &ao_it : m_active_objects) {
 		ClientActiveObject *obj = ao_it.second;
@@ -129,23 +120,22 @@ std::vector<DistanceSortedActiveObject> ActiveObjectMgr::getActiveSelectableObje
 		if (!obj->getSelectionBox(&selection_box))
 			continue;
 
-		// possible optimization: get rid of the sqrt here
-		f32 selection_box_radius = selection_box.getRadius();
+		v3f obj_center = obj->getPosition() + selection_box.getCenter();
+		f32 obj_radius_sq = selection_box.getExtent().getLengthSQ() / 4;
 
-		v3f pos_diff = obj->getPosition() + selection_box.getCenter() - shootline.start;
+		v3f c = obj_center - shootline.start;
+		f32 a = dir.dotProduct(c);           // project c onto dir
+		f32 b_sq = c.getLengthSQ() - a * a;  // distance from shootline to obj_center, squared
 
-		f32 d = dir.dotProduct(pos_diff);
+		if (b_sq > obj_radius_sq)
+			continue;
 
 		// backward- and far-plane
-		if (d + selection_box_radius < 0.0f || d - selection_box_radius > max_d)
+		f32 obj_radius = std::sqrt(obj_radius_sq);
+		if (a < -obj_radius || a > max_d + obj_radius)
 			continue;
 
-		// side-planes
-		if (std::fabs(dir_ortho1.dotProduct(pos_diff)) > selection_box_radius
-				|| std::fabs(dir_ortho2.dotProduct(pos_diff)) > selection_box_radius)
-			continue;
-
-		dest.emplace_back(obj, d);
+		dest.emplace_back(obj, a);
 	}
 	return dest;
 }

--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -107,9 +107,9 @@ void ActiveObjectMgr::getActiveObjects(const v3f &origin, f32 max_d,
 	}
 }
 
-void ActiveObjectMgr::getActiveSelectableObjects(const core::line3d<f32> &shootline,
-		std::vector<DistanceSortedActiveObject> &dest)
+std::vector<DistanceSortedActiveObject> ActiveObjectMgr::getActiveSelectableObjects(const core::line3d<f32> &shootline)
 {
+	std::vector<DistanceSortedActiveObject> dest;
 	// Imagine a not-axis-aligned cuboid oriented into the direction of the shootline,
 	// with the width of the object's selection box radius * 2 and with length of the
 	// shootline (+selection box radius forwards and backwards). We check whether
@@ -147,6 +147,7 @@ void ActiveObjectMgr::getActiveSelectableObjects(const core::line3d<f32> &shootl
 
 		dest.emplace_back(obj, d);
 	}
+	return dest;
 }
 
 } // namespace client

--- a/src/client/activeobjectmgr.h
+++ b/src/client/activeobjectmgr.h
@@ -37,12 +37,10 @@ public:
 
 	void getActiveObjects(const v3f &origin, f32 max_d,
 			std::vector<DistanceSortedActiveObject> &dest);
-	// Similar to above, but takes selection box sizes, and line direction into
-	// account.
-	// Objects without selectionbox are not returned.
-	// Returned distances are in direction of shootline.
-	// Distance check is coarse.
-	void getActiveSelectableObjects(const core::line3d<f32> &shootline,
-			std::vector<DistanceSortedActiveObject> &dest);
+
+	/// Gets all CAOs whose selection boxes may intersect the @p shootline.
+	/// @note CAOs without a selection box are not returned.
+	/// @note Distances are along the @p shootline.
+	std::vector<DistanceSortedActiveObject> getActiveSelectableObjects(const core::line3d<f32> &shootline);
 };
 } // namespace client

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -495,8 +495,7 @@ void ClientEnvironment::getSelectedActiveObjects(
 	const core::line3d<f32> &shootline_on_map,
 	std::vector<PointedThing> &objects)
 {
-	std::vector<DistanceSortedActiveObject> allObjects;
-	m_ao_manager.getActiveSelectableObjects(shootline_on_map, allObjects);
+	auto allObjects = m_ao_manager.getActiveSelectableObjects(shootline_on_map);
 	const v3f line_vector = shootline_on_map.getVector();
 
 	for (const auto &allObject : allObjects) {


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR:
  Simplify math
- How does the PR work?
  ![shootline drawio](https://github.com/minetest/minetest/assets/7352626/7c2811b8-551e-4d78-920e-02212f3ae08b)
- Does it resolve any reported issue?
  No.
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is a Work in Progress.
- [x] Add unit tests
- [x] Sort out commits
- [ ] (maybe) Update docs

## How to test

Check that object selection works as usual. Pay attention to rotating selection boxes.