### PR TITLE
Use absolute URL for the roadmap

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Add compact, short information about your PR for easier understanding:
 - Goal of the PR
 - How does the PR work?
 - Does it resolve any reported issue?
-- Does this relate to a goal in [the roadmap](../doc/direction.md)?
+- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
 - If not a bug fix, why is this PR needed? What usecases does it solve?
 
 ## To do


### PR DESCRIPTION
A relative URL is good until the template is actually used. Then, the link becomes [404](../doc/direction.md) as it is now resolved relative to the PR URL and not to the template file. This PR replaces it with an absolute URL.