### PR TITLE
Fix compiler errors on MSVC with ENABLE_TOUCH=TRUE

### DIFF
--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -35,14 +35,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 using namespace irr::core;
 
-const char **button_imagenames = (const char *[]) {
+const char *button_imagenames[] = {
 	"jump_btn.png",
 	"down.png",
 	"zoom.png",
 	"aux1_btn.png"
 };
 
-const char **joystick_imagenames = (const char *[]) {
+const char *joystick_imagenames[] = {
 	"joystick_off.png",
 	"joystick_bg.png",
 	"joystick_center.png"

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -85,8 +85,8 @@ typedef enum
 // Very slow button repeat frequency
 #define SLOW_BUTTON_REPEAT 1.0f
 
-extern const char **button_imagenames;
-extern const char **joystick_imagenames;
+extern const char *button_imagenames[];
+extern const char *joystick_imagenames[];
 
 struct button_info
 {


### PR DESCRIPTION
Minetest currently doesn't compile with `-DENABLE_TOUCH=TRUE` on Windows due to these compiler errors:

```
C:\mtbuild\minetest-grorp-nonbroken\src\gui\touchscreengui.cpp(43,1): error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax [C:\mtbuild\minetest-grorp-nonbroken-built\src\minetest.vcxproj]
C:\mtbuild\minetest-grorp-nonbroken\src\gui\touchscreengui.cpp(49,1): error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax [C:\mtbuild\minetest-grorp-nonbroken-built\src\minetest.vcxproj]
```

This PR fixes these compiler errors.

## To do

This PR is a Ready for Review.

## How to test

Verify that you can compile Minetest with `-DENABLE_TOUCH=TRUE` on Windows.
