### PR TITLE
Allow running individual tests

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -217,7 +217,10 @@ int main(int argc, char *argv[])
 	// Run unit tests
 	if (cmd_args.getFlag("run-unittests")) {
 #if BUILD_UNITTESTS
-		return run_tests() ? 0 : 1;
+		if (cmd_args.exists("test-module"))
+			return run_tests(cmd_args.get("test-module")) ? 0 : 1;
+		else
+			return run_tests() ? 0 : 1;
 #else
 		errorstream << "Unittest support is not enabled in this binary. "
 			<< "If you want to enable it, compile project with BUILD_UNITTESTS=1 flag."
@@ -327,6 +330,8 @@ static void set_allowed_options(OptionList *allowed_options)
 			_("Run the unit tests and exit"))));
 	allowed_options->insert(std::make_pair("run-benchmarks", ValueSpec(VALUETYPE_FLAG,
 			_("Run the benchmarks and exit"))));
+	allowed_options->insert(std::make_pair("test-module", ValueSpec(VALUETYPE_STRING,
+			_("Only run the specified test module"))));
 	allowed_options->insert(std::make_pair("map-dir", ValueSpec(VALUETYPE_STRING,
 			_("Same as --world (deprecated)"))));
 	allowed_options->insert(std::make_pair("world", ValueSpec(VALUETYPE_STRING,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
 	// Run unit tests
 	if (cmd_args.getFlag("run-unittests")) {
 #if BUILD_UNITTESTS
-		return run_tests();
+		return run_tests() ? 0 : 1;
 #else
 		errorstream << "Unittest support is not enabled in this binary. "
 			<< "If you want to enable it, compile project with BUILD_UNITTESTS=1 flag."

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -254,6 +254,48 @@ bool run_tests()
 	return num_modules_failed == 0;
 }
 
+static TestBase *findTestModule(const std::string &module_name) {
+	std::vector<TestBase *> &testmods = TestManager::getTestModules();
+	for (auto *testmod: testmods) {
+		if (module_name == testmod->getName())
+			return testmod;
+	}
+	return nullptr;
+}
+
+bool run_tests(const std::string &module_name)
+{
+	TestGameDef gamedef;
+
+	auto testmod = findTestModule(module_name);
+	if (!testmod) {
+		errorstream << "Test module not found: " << module_name << std::endl;
+		return 1;
+	}
+
+	g_logger.setLevelSilenced(LL_ERROR, true);
+	u64 t1 = porting::getTimeMs();
+
+	bool ok = testmod->testModule(&gamedef);
+
+	u64 tdiff = porting::getTimeMs() - t1;
+	g_logger.setLevelSilenced(LL_ERROR, false);
+
+	const char *overall_status = ok ? "PASSED" : "FAILED";
+
+	rawstream
+		<< "++++++++++++++++++++++++++++++++++++++++"
+		<< "++++++++++++++++++++++++++++++++++++++++" << std::endl
+		<< "Unit Test Results: " << overall_status << std::endl
+		<< "    " << testmod->num_tests_failed << " / "
+		<< testmod->num_tests_run << " failed tests." << std::endl
+		<< "    Testing took " << tdiff << "ms." << std::endl
+		<< "++++++++++++++++++++++++++++++++++++++++"
+		<< "++++++++++++++++++++++++++++++++++++++++" << std::endl;
+
+	return ok;
+}
+
 ////
 //// TestBase
 ////

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -226,12 +226,12 @@ bool run_tests()
 	u32 num_total_tests_failed = 0;
 	u32 num_total_tests_run    = 0;
 	std::vector<TestBase *> &testmods = TestManager::getTestModules();
-	for (size_t i = 0; i != testmods.size(); i++) {
-		if (!testmods[i]->testModule(&gamedef))
+	for (auto *testmod: testmods) {
+		if (!testmod->testModule(&gamedef))
 			num_modules_failed++;
 
-		num_total_tests_failed += testmods[i]->num_tests_failed;
-		num_total_tests_run += testmods[i]->num_tests_run;
+		num_total_tests_failed += testmod->num_tests_failed;
+		num_total_tests_run += testmod->num_tests_run;
 	}
 
 	u64 tdiff = porting::getTimeMs() - t1;

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -251,7 +251,7 @@ bool run_tests()
 		<< "++++++++++++++++++++++++++++++++++++++++"
 		<< "++++++++++++++++++++++++++++++++++++++++" << std::endl;
 
-	return num_modules_failed;
+	return num_modules_failed == 0;
 }
 
 ////

--- a/src/unittest/test.h
+++ b/src/unittest/test.h
@@ -140,3 +140,4 @@ extern content_t t_CONTENT_LAVA;
 extern content_t t_CONTENT_BRICK;
 
 bool run_tests();
+bool run_tests(const std::string &module_name);


### PR DESCRIPTION
- Goal of the PR
  Speed up the edit-compile-test cycle.
- How does the PR work?
  Allows running only the tests the developer is interesting in right at the moment.
- Does it resolve any reported issue?
  No AFAIK
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
  Dunno.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  Running all tests takes some time, and will only take more as more tests are added. But when developing a specific feature, only single test set is needed usually, which takes much shorter time.

Note: extracted from #13616 as independently useful.

## To do

This PR is Ready for Review.

## How to test

- Run unit tests.
- Run a specific unit test set with `--test-module`
- Try running a non-existent unit test set (it should fail)