### PR TITLE
Replace PP with operator overload

### DIFF
--- a/src/database/database-leveldb.cpp
+++ b/src/database/database-leveldb.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "exceptions.h"
 #include "remoteplayer.h"
+#include "irrlicht_changes/printing.h"
 #include "server/player_sao.h"
 #include "util/serialize.h"
 #include "util/string.h"
@@ -58,7 +59,7 @@ bool Database_LevelDB::saveBlock(const v3s16 &pos, const std::string &data)
 			i64tos(getBlockAsInteger(pos)), data);
 	if (!status.ok()) {
 		warningstream << "saveBlock: LevelDB error saving block "
-			<< PP(pos) << ": " << status.ToString() << std::endl;
+			<< pos << ": " << status.ToString() << std::endl;
 		return false;
 	}
 
@@ -80,7 +81,7 @@ bool Database_LevelDB::deleteBlock(const v3s16 &pos)
 			i64tos(getBlockAsInteger(pos)));
 	if (!status.ok()) {
 		warningstream << "deleteBlock: LevelDB error deleting block "
-			<< PP(pos) << ": " << status.ToString() << std::endl;
+			<< pos << ": " << status.ToString() << std::endl;
 		return false;
 	}
 

--- a/src/database/database-redis.cpp
+++ b/src/database/database-redis.cpp
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "log.h"
 #include "exceptions.h"
+#include "irrlicht_changes/printing.h"
 #include "util/string.h"
 
 #include <hiredis.h>
@@ -98,13 +99,13 @@ bool Database_Redis::saveBlock(const v3s16 &pos, const std::string &data)
 			hash.c_str(), tmp.c_str(), data.c_str(), data.size()));
 	if (!reply) {
 		warningstream << "saveBlock: redis command 'HSET' failed on "
-			"block " << PP(pos) << ": " << ctx->errstr << std::endl;
+			"block " << pos << ": " << ctx->errstr << std::endl;
 		freeReplyObject(reply);
 		return false;
 	}
 
 	if (reply->type == REDIS_REPLY_ERROR) {
-		warningstream << "saveBlock: saving block " << PP(pos)
+		warningstream << "saveBlock: saving block " << pos
 			<< " failed: " << std::string(reply->str, reply->len) << std::endl;
 		freeReplyObject(reply);
 		return false;
@@ -134,7 +135,7 @@ void Database_Redis::loadBlock(const v3s16 &pos, std::string *block)
 	case REDIS_REPLY_ERROR: {
 		std::string errstr(reply->str, reply->len);
 		freeReplyObject(reply);
-		errorstream << "loadBlock: loading block " << PP(pos)
+		errorstream << "loadBlock: loading block " << pos
 			<< " failed: " << errstr << std::endl;
 		throw DatabaseException(std::string(
 			"Redis command 'HGET %s %s' errored: ") + errstr);
@@ -146,7 +147,7 @@ void Database_Redis::loadBlock(const v3s16 &pos, std::string *block)
 	}
 	}
 
-	errorstream << "loadBlock: loading block " << PP(pos)
+	errorstream << "loadBlock: loading block " << pos
 		<< " returned invalid reply type " << reply->type
 		<< ": " << std::string(reply->str, reply->len) << std::endl;
 	freeReplyObject(reply);
@@ -164,7 +165,7 @@ bool Database_Redis::deleteBlock(const v3s16 &pos)
 		throw DatabaseException(std::string(
 			"Redis command 'HDEL %s %s' failed: ") + ctx->errstr);
 	} else if (reply->type == REDIS_REPLY_ERROR) {
-		warningstream << "deleteBlock: deleting block " << PP(pos)
+		warningstream << "deleteBlock: deleting block " << pos
 			<< " failed: " << std::string(reply->str, reply->len) << std::endl;
 		freeReplyObject(reply);
 		return false;

--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -34,6 +34,7 @@ SQLite format specification:
 #include "porting.h"
 #include "util/string.h"
 #include "remoteplayer.h"
+#include "irrlicht_changes/printing.h"
 #include "server/player_sao.h"
 
 #include <cassert>
@@ -252,7 +253,7 @@ bool MapDatabaseSQLite3::deleteBlock(const v3s16 &pos)
 
 	if (!good) {
 		warningstream << "deleteBlock: Block failed to delete "
-			<< PP(pos) << ": " << sqlite3_errmsg(m_database) << std::endl;
+			<< pos << ": " << sqlite3_errmsg(m_database) << std::endl;
 	}
 	return good;
 }

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -31,6 +31,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "config.h"
 #include "constants.h"
 #include "environment.h"
+#include "irrlicht_changes/printing.h"
 #include "log.h"
 #include "map.h"
 #include "mapblock.h"
@@ -631,7 +632,7 @@ MapBlock *EmergeThread::finishGen(v3s16 pos, BlockMakeData *bmdata,
 	MapBlock *block = m_map->getBlockNoCreateNoEx(pos);
 	if (!block) {
 		errorstream << "EmergeThread::finishGen: Couldn't grab block we "
-			"just generated: " << PP(pos) << std::endl;
+			"just generated: " << pos << std::endl;
 		return NULL;
 	}
 
@@ -701,7 +702,7 @@ void *EmergeThread::run()
 			continue;
 
 		bool allow_gen = bedata.flags & BLOCK_EMERGE_ALLOW_GEN;
-		EMERGE_DBG_OUT("pos=" PP(pos) " allow_gen=" << allow_gen);
+		EMERGE_DBG_OUT("pos=" << pos << " allow_gen=" << allow_gen);
 
 		action = getBlockOrStartGen(pos, allow_gen, &block, &bmdata);
 		if (action == EMERGE_GENERATED) {
@@ -733,7 +734,7 @@ void *EmergeThread::run()
 	}
 	} catch (VersionMismatchException &e) {
 		std::ostringstream err;
-		err << "World data version mismatch in MapBlock " << PP(pos) << std::endl
+		err << "World data version mismatch in MapBlock " << pos << std::endl
 			<< "----" << std::endl
 			<< "\"" << e.what() << "\"" << std::endl
 			<< "See debug.txt." << std::endl
@@ -742,7 +743,7 @@ void *EmergeThread::run()
 		m_server->setAsyncFatalError(err.str());
 	} catch (SerializationError &e) {
 		std::ostringstream err;
-		err << "Invalid data in MapBlock " << PP(pos) << std::endl
+		err << "Invalid data in MapBlock " << pos << std::endl
 			<< "----" << std::endl
 			<< "\"" << e.what() << "\"" << std::endl
 			<< "See debug.txt." << std::endl

--- a/src/irrlicht_changes/printing.h
+++ b/src/irrlicht_changes/printing.h
@@ -1,0 +1,39 @@
+/*
+Minetest
+Copyright (C) 2023 Vitaliy Lobachevskiy
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+#include <ostream>
+#include <vector2d.h>
+#include <vector3d.h>
+
+namespace irr::core {
+
+	template <class T>
+	std::ostream &operator<< (std::ostream &os, vector2d<T> vec)
+	{
+		return os << "(" << vec.X << "," << vec.Y << ")";
+	}
+
+	template <class T>
+	std::ostream &operator<< (std::ostream &os, vector3d<T> vec)
+	{
+		return os << "(" << vec.X << "," << vec.Y << "," << vec.Z << ")";
+	}
+
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes.h" // must be included before anything irrlicht, see comment in the file
 #include "irrlicht.h" // createDevice
 #include "irrlichttypes_extrabloated.h"
+#include "irrlicht_changes/printing.h"
 #include "benchmark/benchmark.h"
 #include "chat_interface.h"
 #include "debug.h"
@@ -1199,7 +1200,7 @@ static bool migrate_map_database(const GameParams &game_params, const Settings &
 		if (!data.empty()) {
 			new_db->saveBlock(*it, data);
 		} else {
-			errorstream << "Failed to load block " << PP(*it) << ", skipping it." << std::endl;
+			errorstream << "Failed to load block " << *it << ", skipping it." << std::endl;
 		}
 		if (++count % 0xFF == 0 && time(NULL) - last_update_time >= 1) {
 			std::cerr << " Migrated " << count << " blocks, "
@@ -1254,7 +1255,7 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 		std::string data;
 		db->loadBlock(*it, &data);
 		if (data.empty()) {
-			errorstream << "Failed to load block " << PP(*it) << std::endl;
+			errorstream << "Failed to load block " << *it << std::endl;
 			return false;
 		}
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -32,7 +32,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nodedef.h"
 #include "gamedef.h"
 #include "util/directiontables.h"
-#include "util/basic_macros.h"
 #include "rollback_interface.h"
 #include "environment.h"
 #include "reflowscan.h"
@@ -45,6 +44,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "database/database-dummy.h"
 #include "database/database-sqlite3.h"
 #include "script/scripting_server.h"
+#include "irrlicht_changes/printing.h"
 #include <deque>
 #include <queue>
 #if USE_LEVELDB
@@ -174,7 +174,7 @@ static void set_node_in_block(MapBlock *block, v3s16 relpos, MapNode n)
 		errorstream<<"Not allowing to place CONTENT_IGNORE"
 				<<" while trying to replace \""
 				<<nodedef->get(block->getNodeNoCheck(relpos)).name
-				<<"\" at "<<PP(p)<<" (block "<<PP(blockpos)<<")"<<std::endl;
+				<<"\" at "<<p<<" (block "<<blockpos<<")"<<std::endl;
 		return;
 	}
 	block->setNodeNoCheck(relpos, n);
@@ -917,7 +917,7 @@ std::vector<v3s16> Map::findNodesWithMetadata(v3s16 p1, v3s16 p2)
 		MapBlock *block = getBlockNoCreateNoEx(blockpos);
 		if (!block) {
 			verbosestream << "Map::getNodeMetadata(): Need to emerge "
-				<< PP(blockpos) << std::endl;
+				<< blockpos << std::endl;
 			block = emergeBlock(blockpos, false);
 		}
 		if (!block) {
@@ -947,7 +947,7 @@ NodeMetadata *Map::getNodeMetadata(v3s16 p)
 	MapBlock *block = getBlockNoCreateNoEx(blockpos);
 	if(!block){
 		infostream<<"Map::getNodeMetadata(): Need to emerge "
-				<<PP(blockpos)<<std::endl;
+				<<blockpos<<std::endl;
 		block = emergeBlock(blockpos, false);
 	}
 	if(!block){
@@ -966,7 +966,7 @@ bool Map::setNodeMetadata(v3s16 p, NodeMetadata *meta)
 	MapBlock *block = getBlockNoCreateNoEx(blockpos);
 	if(!block){
 		infostream<<"Map::setNodeMetadata(): Need to emerge "
-				<<PP(blockpos)<<std::endl;
+				<<blockpos<<std::endl;
 		block = emergeBlock(blockpos, false);
 	}
 	if(!block){
@@ -999,7 +999,7 @@ NodeTimer Map::getNodeTimer(v3s16 p)
 	MapBlock *block = getBlockNoCreateNoEx(blockpos);
 	if(!block){
 		infostream<<"Map::getNodeTimer(): Need to emerge "
-				<<PP(blockpos)<<std::endl;
+				<<blockpos<<std::endl;
 		block = emergeBlock(blockpos, false);
 	}
 	if(!block){
@@ -1020,7 +1020,7 @@ void Map::setNodeTimer(const NodeTimer &t)
 	MapBlock *block = getBlockNoCreateNoEx(blockpos);
 	if(!block){
 		infostream<<"Map::setNodeTimer(): Need to emerge "
-				<<PP(blockpos)<<std::endl;
+				<<blockpos<<std::endl;
 		block = emergeBlock(blockpos, false);
 	}
 	if(!block){
@@ -1348,7 +1348,7 @@ bool ServerMap::initBlockMake(v3s16 blockpos, BlockMakeData *data)
 		return false;
 
 	bool enable_mapgen_debug_info = m_emerge->enable_mapgen_debug_info;
-	EMERGE_DBG_OUT("initBlockMake(): " PP(bpmin) " - " PP(bpmax));
+	EMERGE_DBG_OUT("initBlockMake(): " << bpmin << " - " << bpmax);
 
 	v3s16 extra_borders(1, 1, 1);
 	v3s16 full_bpmin = bpmin - extra_borders;
@@ -1410,7 +1410,7 @@ void ServerMap::finishBlockMake(BlockMakeData *data,
 	v3s16 bpmax = data->blockpos_max;
 
 	bool enable_mapgen_debug_info = m_emerge->enable_mapgen_debug_info;
-	EMERGE_DBG_OUT("finishBlockMake(): " PP(bpmin) " - " PP(bpmax));
+	EMERGE_DBG_OUT("finishBlockMake(): " << bpmin << " - " << bpmax);
 
 	/*
 		Blit generated stuff to map

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nodedef.h"
 #include "nodemetadata.h"
 #include "gamedef.h"
+#include "irrlicht_changes/printing.h"
 #include "log.h"
 #include "nameidmapping.h"
 #include "content_mapnode.h"  // For legacy name-id mapping
@@ -91,13 +92,13 @@ bool MapBlock::onObjectsActivation()
 		return false;
 
 	verbosestream << "MapBlock::onObjectsActivation(): "
-			<< "activating objects of block " << PP(getPos()) << " ("
+			<< "activating objects of block " << getPos() << " ("
 			<< m_static_objects.getStoredSize() << " objects)" << std::endl;
 
 	if (m_static_objects.getStoredSize() > g_settings->getU16("max_objects_per_block")) {
 		errorstream << "suspiciously large amount of objects detected: "
 			<< m_static_objects.getStoredSize() << " in "
-			<< PP(getPos()) << "; removing all of them." << std::endl;
+			<< getPos() << "; removing all of them." << std::endl;
 		// Clear stored list
 		m_static_objects.clearStored();
 		raiseModified(MOD_STATE_WRITE_NEEDED, MOD_REASON_TOO_MANY_OBJECTS);
@@ -111,7 +112,7 @@ bool MapBlock::saveStaticObject(u16 id, const StaticObject &obj, u32 reason)
 {
 	if (m_static_objects.getStoredSize() >= g_settings->getU16("max_objects_per_block")) {
 		warningstream << "MapBlock::saveStaticObject(): Trying to store id = " << id
-				<< " statically but block " << PP(getPos()) << " already contains "
+				<< " statically but block " << getPos() << " already contains "
 				<< m_static_objects.getStoredSize() << " objects."
 				<< std::endl;
 		return false;
@@ -487,7 +488,7 @@ void MapBlock::deSerialize(std::istream &in_compressed, u8 version, bool disk)
 	if(!ser_ver_supported(version))
 		throw VersionMismatchException("ERROR: MapBlock format not supported");
 
-	TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())<<std::endl);
+	TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()<<std::endl);
 
 	m_day_night_differs_expired = false;
 
@@ -515,18 +516,18 @@ void MapBlock::deSerialize(std::istream &in_compressed, u8 version, bool disk)
 	NameIdMapping nimap;
 	if (disk && version >= 29) {
 		// Timestamp
-		TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())
+		TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
 				<<": Timestamp"<<std::endl);
 		setTimestampNoChangedFlag(readU32(is));
 		m_disk_timestamp = m_timestamp;
 
 		// Node/id mapping
-		TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())
+		TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
 				<<": NameIdMapping"<<std::endl);
 		nimap.deSerialize(is);
 	}
 
-	TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())
+	TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
 			<<": Bulk node data"<<std::endl);
 	u8 content_width = readU8(is);
 	u8 params_width = readU8(is);
@@ -551,7 +552,7 @@ void MapBlock::deSerialize(std::istream &in_compressed, u8 version, bool disk)
 	/*
 		NodeMetadata
 	*/
-	TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())
+	TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
 			<<": Node metadata"<<std::endl);
 	if (version >= 29) {
 		m_node_metadata.deSerialize(is, m_gamedef->idef());
@@ -570,7 +571,7 @@ void MapBlock::deSerialize(std::istream &in_compressed, u8 version, bool disk)
 		} catch(SerializationError &e) {
 			warningstream<<"MapBlock::deSerialize(): Ignoring an error"
 					<<" while deserializing node metadata at ("
-					<<PP(getPos())<<": "<<e.what()<<std::endl;
+					<<getPos()<<": "<<e.what()<<std::endl;
 		}
 	}
 
@@ -584,25 +585,25 @@ void MapBlock::deSerialize(std::istream &in_compressed, u8 version, bool disk)
 			readU8(is);
 		}
 		if (version == 24) {
-			TRACESTREAM(<< "MapBlock::deSerialize " << PP(getPos())
+			TRACESTREAM(<< "MapBlock::deSerialize " << getPos()
 						<< ": Node timers (ver==24)" << std::endl);
 			m_node_timers.deSerialize(is, version);
 		}
 
 		// Static objects
-		TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())
+		TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
 				<<": Static objects"<<std::endl);
 		m_static_objects.deSerialize(is);
 
 		if (version < 29) {
 			// Timestamp
-			TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())
+			TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
 				    <<": Timestamp"<<std::endl);
 			setTimestampNoChangedFlag(readU32(is));
 			m_disk_timestamp = m_timestamp;
 
 			// Node/id mapping
-			TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())
+			TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
 				    <<": NameIdMapping"<<std::endl);
 			nimap.deSerialize(is);
 		}
@@ -611,13 +612,13 @@ void MapBlock::deSerialize(std::istream &in_compressed, u8 version, bool disk)
 		correctBlockNodeIds(&nimap, data, m_gamedef);
 
 		if(version >= 25){
-			TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())
+			TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
 					<<": Node timers (ver>=25)"<<std::endl);
 			m_node_timers.deSerialize(is, version);
 		}
 	}
 
-	TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())
+	TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
 			<<": Done."<<std::endl);
 }
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "tool.h"
 #include "version.h"
+#include "irrlicht_changes/printing.h"
 #include "network/connection.h"
 #include "network/networkprotocol.h"
 #include "network/serveropcodes.h"
@@ -813,7 +814,7 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 		}
 
 		actionstream << player->getName() << " damaged by "
-				<< (int)damage << " hp at " << PP(playersao->getBasePosition() / BS)
+				<< (int)damage << " hp at " << (playersao->getBasePosition() / BS)
 				<< std::endl;
 
 		PlayerHPChangeReason reason(PlayerHPChangeReason::FALL);
@@ -883,7 +884,7 @@ void Server::handleCommand_Respawn(NetworkPacket* pkt)
 	RespawnPlayer(peer_id);
 
 	actionstream << player->getName() << " respawns at "
-			<< PP(playersao->getBasePosition() / BS) << std::endl;
+			<< (playersao->getBasePosition() / BS) << std::endl;
 
 	// ActiveObject is added to environment in AsyncRunStep after
 	// the previous addition has been successfully removed
@@ -1149,8 +1150,8 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 			if (nocheat_p != p_under) {
 				infostream << "Server: " << player->getName()
 						<< " started digging "
-						<< PP(nocheat_p) << " and completed digging "
-						<< PP(p_under) << "; not digging." << std::endl;
+						<< nocheat_p << " and completed digging "
+						<< p_under << "; not digging." << std::endl;
 				is_valid_dig = false;
 				// Call callbacks
 				m_script->on_cheat(playersao, "finished_unknown_dig");
@@ -1173,7 +1174,7 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 			// If can't dig, ignore dig
 			if (!params.diggable) {
 				infostream << "Server: " << player->getName()
-						<< " completed digging " << PP(p_under)
+						<< " completed digging " << p_under
 						<< ", which is not diggable with tool; not digging."
 						<< std::endl;
 				is_valid_dig = false;
@@ -1199,7 +1200,7 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 			// Dig not possible
 			else {
 				infostream << "Server: " << player->getName()
-						<< " completed digging " << PP(p_under)
+						<< " completed digging " << p_under
 						<< "too fast; not digging." << std::endl;
 				is_valid_dig = false;
 				// Call callbacks
@@ -1394,7 +1395,7 @@ void Server::handleCommand_NodeMetaFields(NetworkPacket* pkt)
 
 	if (!pkt_read_formspec_fields(pkt, fields)) {
 		warningstream << "Too large formspec fields! Ignoring for pos="
-			<< PP(p) << ", player=" << player->getName() << std::endl;
+			<< p << ", player=" << player->getName() << std::endl;
 		return;
 	}
 

--- a/src/nodemetadata.cpp
+++ b/src/nodemetadata.cpp
@@ -21,9 +21,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "exceptions.h"
 #include "gamedef.h"
 #include "inventory.h"
+#include "irrlicht_changes/printing.h"
 #include "log.h"
 #include "util/serialize.h"
-#include "util/basic_macros.h"
 #include "constants.h" // MAP_BLOCKSIZE
 #include <sstream>
 
@@ -187,7 +187,7 @@ void NodeMetadataList::deSerialize(std::istream &is,
 		}
 		if (m_data.find(p) != m_data.end()) {
 			warningstream << "NodeMetadataList::deSerialize(): "
-					<< "already set data at position " << PP(p)
+					<< "already set data at position " << p
 					<< ": Ignoring." << std::endl;
 			continue;
 		}

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -18,10 +18,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "object_properties.h"
+#include "irrlicht_changes/printing.h"
 #include "irrlichttypes_bloated.h"
 #include "exceptions.h"
 #include "util/serialize.h"
-#include "util/basic_macros.h"
 #include <sstream>
 
 static const video::SColor NULL_BGCOLOR{0, 1, 1, 1};
@@ -39,10 +39,10 @@ std::string ObjectProperties::dump()
 	os << ", breath_max=" << breath_max;
 	os << ", physical=" << physical;
 	os << ", collideWithObjects=" << collideWithObjects;
-	os << ", collisionbox=" << PP(collisionbox.MinEdge) << "," << PP(collisionbox.MaxEdge);
+	os << ", collisionbox=" << collisionbox.MinEdge << "," << collisionbox.MaxEdge;
 	os << ", visual=" << visual;
 	os << ", mesh=" << mesh;
-	os << ", visual_size=" << PP(visual_size);
+	os << ", visual_size=" << visual_size;
 	os << ", textures=[";
 	for (const std::string &texture : textures) {
 		os << "\"" << texture << "\" ";
@@ -54,8 +54,8 @@ std::string ObjectProperties::dump()
 			<< color.getGreen() << "," << color.getBlue() << "\" ";
 	}
 	os << "]";
-	os << ", spritediv=" << PP2(spritediv);
-	os << ", initial_sprite_basepos=" << PP2(initial_sprite_basepos);
+	os << ", spritediv=" << spritediv;
+	os << ", initial_sprite_basepos=" << initial_sprite_basepos;
 	os << ", is_visible=" << is_visible;
 	os << ", makes_footstep_sound=" << makes_footstep_sound;
 	os << ", automatic_rotate="<< automatic_rotate;
@@ -71,7 +71,7 @@ std::string ObjectProperties::dump()
 	else
 		os << ", nametag_bgcolor=null ";
 
-	os << ", selectionbox=" << PP(selectionbox.MinEdge) << "," << PP(selectionbox.MaxEdge);
+	os << ", selectionbox=" << selectionbox.MinEdge << "," << selectionbox.MaxEdge;
 	os << ", rotate_selectionbox=" << rotate_selectionbox;
 	os << ", pointable=" << pointable;
 	os << ", static_save=" << static_save;

--- a/src/particles.h
+++ b/src/particles.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <vector>
 #include <ctgmath>
 #include <type_traits>
+#include "irrlicht_changes/printing.h"
 #include "irrlichttypes_bloated.h"
 #include "tileanimation.h"
 #include "mapnode.h"
@@ -138,10 +139,7 @@ namespace ParticleParamTypes
 	inline std::string dump(const VectorParameter<T,N>& v)
 	{
 		std::ostringstream oss;
-		if (N == 3)
-			oss << PP(v.val);
-		else
-			oss << PP2(v.val);
+		oss << v.val;
 		return oss.str();
 	}
 

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "pathfinder.h"
 #include "map.h"
 #include "nodedef.h"
+#include "irrlicht_changes/printing.h"
 
 //#define PATHFINDER_DEBUG
 //#define PATHFINDER_CALC_TIME
@@ -524,25 +525,25 @@ void GridNodeContainer::initNode(v3s16 ipos, PathGridnode *p_node)
 
 	if ((current.param0 == CONTENT_IGNORE) ||
 			(below.param0 == CONTENT_IGNORE)) {
-		DEBUG_OUT("Pathfinder: " << PP(realpos) <<
+		DEBUG_OUT("Pathfinder: " << realpos <<
 			" current or below is invalid element" << std::endl);
 		if (current.param0 == CONTENT_IGNORE) {
 			elem.type = 'i';
-			DEBUG_OUT(PP(ipos) << ": " << 'i' << std::endl);
+			DEBUG_OUT(ipos << ": " << 'i' << std::endl);
 		}
 		return;
 	}
 
 	//don't add anything if it isn't an air node
 	if (ndef->get(current).walkable || !ndef->get(below).walkable) {
-			DEBUG_OUT("Pathfinder: " << PP(realpos)
+			DEBUG_OUT("Pathfinder: " << realpos
 				<< " not on surface" << std::endl);
 			if (ndef->get(current).walkable) {
 				elem.type = 's';
-				DEBUG_OUT(PP(ipos) << ": " << 's' << std::endl);
+				DEBUG_OUT(ipos << ": " << 's' << std::endl);
 			} else {
 				elem.type = '-';
-				DEBUG_OUT(PP(ipos) << ": " << '-' << std::endl);
+				DEBUG_OUT(ipos << ": " << '-' << std::endl);
 			}
 			return;
 	}
@@ -550,7 +551,7 @@ void GridNodeContainer::initNode(v3s16 ipos, PathGridnode *p_node)
 	elem.valid = true;
 	elem.pos   = realpos;
 	elem.type  = 'g';
-	DEBUG_OUT(PP(ipos) << ": " << 'a' << std::endl);
+	DEBUG_OUT(ipos << ": " << 'a' << std::endl);
 
 	if (m_pathf->m_prefetch) {
 		elem.directions[DIR_XP] = m_pathf->calcCost(realpos, v3s16( 1, 0, 0));
@@ -667,13 +668,13 @@ std::vector<v3s16> Pathfinder::getPath(v3s16 source,
 	MapNode node_at_pos = m_map->getNode(destination);
 	if (m_ndef->get(node_at_pos).walkable) {
 		VERBOSE_TARGET << "Destination is walkable. " <<
-				"Pos: " << PP(destination) << std::endl;
+				"Pos: " << destination << std::endl;
 		return retval;
 	}
 	node_at_pos = m_map->getNode(source);
 	if (m_ndef->get(node_at_pos).walkable) {
 		VERBOSE_TARGET << "Source is walkable. " <<
-				"Pos: " << PP(source) << std::endl;
+				"Pos: " << source << std::endl;
 		return retval;
 	}
 
@@ -701,14 +702,14 @@ std::vector<v3s16> Pathfinder::getPath(v3s16 source,
 
 	if (!startpos.valid) {
 		VERBOSE_TARGET << "Invalid startpos " <<
-				"Index: " << PP(StartIndex) <<
-				"Realpos: " << PP(getRealPos(StartIndex)) << std::endl;
+				"Index: " << StartIndex <<
+				"Realpos: " << getRealPos(StartIndex) << std::endl;
 		return retval;
 	}
 	if (!endpos.valid) {
 		VERBOSE_TARGET << "Invalid stoppos " <<
-				"Index: " << PP(EndIndex) <<
-				"Realpos: " << PP(getRealPos(EndIndex)) << std::endl;
+				"Index: " << EndIndex <<
+				"Realpos: " << getRealPos(EndIndex) << std::endl;
 		return retval;
 	}
 
@@ -833,7 +834,7 @@ PathCost Pathfinder::calcCost(v3s16 pos, v3s16 dir)
 
 	//check limits
 	if (!m_limits.isPointInside(pos2)) {
-		DEBUG_OUT("Pathfinder: " << PP(pos2) <<
+		DEBUG_OUT("Pathfinder: " << pos2 <<
 				" no cost -> out of limits" << std::endl);
 		return retval;
 	}
@@ -843,7 +844,7 @@ PathCost Pathfinder::calcCost(v3s16 pos, v3s16 dir)
 	//did we get information about node?
 	if (node_at_pos2.param0 == CONTENT_IGNORE ) {
 			VERBOSE_TARGET << "Pathfinder: (1) area at pos: "
-					<< PP(pos2) << " not loaded";
+					<< pos2 << " not loaded";
 			return retval;
 	}
 
@@ -854,7 +855,7 @@ PathCost Pathfinder::calcCost(v3s16 pos, v3s16 dir)
 		//did we get information about node?
 		if (node_below_pos2.param0 == CONTENT_IGNORE ) {
 				VERBOSE_TARGET << "Pathfinder: (2) area at pos: "
-					<< PP((pos2 + v3s16(0, -1, 0))) << " not loaded";
+					<< (pos2 + v3s16(0, -1, 0)) << " not loaded";
 				return retval;
 		}
 
@@ -864,7 +865,7 @@ PathCost Pathfinder::calcCost(v3s16 pos, v3s16 dir)
 			retval.valid = true;
 			retval.value = 1;
 			retval.y_change = 0;
-			DEBUG_OUT("Pathfinder: "<< PP(pos)
+			DEBUG_OUT("Pathfinder: "<< pos
 					<< " cost same height found" << std::endl);
 		}
 		else {
@@ -1040,8 +1041,8 @@ bool Pathfinder::updateAllCosts(v3s16 ipos,
 				v3s16 ipos2 = ipos + direction;
 
 				if (!isValidIndex(ipos2)) {
-					DEBUG_OUT(LVL " Pathfinder: " << PP(ipos2) <<
-						" out of range, max=" << PP(m_limits.MaxEdge) << std::endl);
+					DEBUG_OUT(LVL " Pathfinder: " << ipos2 <<
+						" out of range, max=" << m_limits.MaxEdge << std::endl);
 					continue;
 				}
 
@@ -1049,7 +1050,7 @@ bool Pathfinder::updateAllCosts(v3s16 ipos,
 
 				if (!g_pos2.valid) {
 					VERBOSE_TARGET << LVL "Pathfinder: no data for new position: "
-												<< PP(ipos2) << std::endl;
+												<< ipos2 << std::endl;
 					continue;
 				}
 
@@ -1066,7 +1067,7 @@ bool Pathfinder::updateAllCosts(v3s16 ipos,
 				if ((g_pos2.totalcost < 0) ||
 						(g_pos2.totalcost > new_cost)) {
 					DEBUG_OUT(LVL "Pathfinder: updating path at: "<<
-							PP(ipos2) << " from: " << g_pos2.totalcost << " to "<<
+							ipos2 << " from: " << g_pos2.totalcost << " to "<<
 							new_cost << std::endl);
 					if (updateAllCosts(ipos2, invert(direction),
 											new_cost, level)) {
@@ -1076,13 +1077,13 @@ bool Pathfinder::updateAllCosts(v3s16 ipos,
 				else {
 					DEBUG_OUT(LVL "Pathfinder:"
 							" already found shorter path to: "
-							<< PP(ipos2) << std::endl);
+							<< ipos2 << std::endl);
 				}
 			}
 			else {
 				DEBUG_OUT(LVL "Pathfinder:"
 						" not moving to invalid direction: "
-						<< PP(directions[i]) << std::endl);
+						<< directions[i] << std::endl);
 			}
 		}
 	}
@@ -1145,8 +1146,8 @@ bool Pathfinder::updateCostHeuristic(v3s16 isource, v3s16 idestination)
 
 		// check if node is inside searchdistance and valid
 		if (!isValidIndex(ipos)) {
-			DEBUG_OUT(LVL " Pathfinder: " << PP(current_pos) <<
-				" out of search distance, max=" << PP(m_limits.MaxEdge) << std::endl);
+			DEBUG_OUT(LVL " Pathfinder: " << current_pos <<
+				" out of search distance, max=" << m_limits.MaxEdge << std::endl);
 			continue;
 		}
 
@@ -1258,8 +1259,8 @@ v3s16 Pathfinder::walkDownwards(v3s16 pos, unsigned int max_down) {
 		}
 		else {
 			VERBOSE_TARGET << "Pos too far above ground: " <<
-				"Index: " << PP(getIndexPos(pos)) <<
-				"Realpos: " << PP(getRealPos(getIndexPos(pos))) << std::endl;
+				"Index: " << getIndexPos(pos) <<
+				"Realpos: " << getRealPos(getIndexPos(pos)) << std::endl;
 		}
 	} else {
 		DEBUG_OUT("Pathfinder: no surface found below pos" << std::endl);
@@ -1433,7 +1434,7 @@ void Pathfinder::printPath(const std::vector<v3s16> &path)
 	unsigned int current = 0;
 	for (std::vector<v3s16>::iterator i = path.begin();
 			i != path.end(); ++i) {
-		std::cout << std::setw(3) << current << ":" << PP((*i)) << std::endl;
+		std::cout << std::setw(3) << current << ":" << *i << std::endl;
 		current++;
 	}
 }

--- a/src/rollback_interface.cpp
+++ b/src/rollback_interface.cpp
@@ -22,7 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/serialize.h"
 #include "util/string.h"
 #include "util/numeric.h"
-#include "util/basic_macros.h"
 #include "map.h"
 #include "gamedef.h"
 #include "nodedef.h"
@@ -31,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "inventorymanager.h"
 #include "inventory.h"
+#include "irrlicht_changes/printing.h"
 #include "mapblock.h"
 
 
@@ -55,7 +55,7 @@ std::string RollbackAction::toString() const
 	std::ostringstream os(std::ios::binary);
 	switch (type) {
 	case TYPE_SET_NODE:
-		os << "set_node " << PP(p);
+		os << "set_node " << p;
 		os << ": (" << serializeJsonString(n_old.name);
 		os << ", " << itos(n_old.param1);
 		os << ", " << itos(n_old.param2);
@@ -152,7 +152,7 @@ bool RollbackAction::applyRevert(Map *map, InventoryManager *imgr, IGameDef *gam
 				if (!map->addNodeWithEvent(p, n)) {
 					infostream << "RollbackAction::applyRevert(): "
 						<< "AddNodeWithEvent failed at "
-						<< PP(p) << " for " << n_old.name
+						<< p << " for " << n_old.name
 						<< std::endl;
 					return false;
 				}
@@ -166,7 +166,7 @@ bool RollbackAction::applyRevert(Map *map, InventoryManager *imgr, IGameDef *gam
 							delete meta;
 							infostream << "RollbackAction::applyRevert(): "
 								<< "setNodeMetadata failed at "
-								<< PP(p) << " for " << n_old.name
+								<< p << " for " << n_old.name
 								<< std::endl;
 							return false;
 						}

--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/pointedthing.h"
 #include "inventory.h"
 #include "inventorymanager.h"
+#include "irrlicht_changes/printing.h"
 
 #define WRAP_LUAERROR(e, detail) \
 	LuaError(std::string(__FUNCTION__) + ": " + (e).what() + ". " detail)
@@ -238,7 +239,7 @@ bool ScriptApiItem::getItemCallback(const char *name, const char *callbackname,
 		// Report error and clean up
 		errorstream << "Item \"" << name << "\" not defined";
 		if (p)
-			errorstream << " at position " << PP(*p);
+			errorstream << " at position " << *p;
 		errorstream << std::endl;
 		lua_pop(L, 1);
 

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "collision.h"
 #include "constants.h"
 #include "inventory.h"
+#include "irrlicht_changes/printing.h"
 #include "player_sao.h"
 #include "scripting_server.h"
 #include "server.h"
@@ -390,7 +391,7 @@ std::string LuaEntitySAO::getDescription()
 	std::ostringstream oss;
 	oss << "LuaEntitySAO \"" << m_init_name << "\" ";
 	auto pos = floatToInt(m_base_position, BS);
-	oss << "at " << PP(pos);
+	oss << "at " << pos;
 	return oss.str();
 }
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -48,6 +48,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #if USE_LEVELDB
 #include "database/database-leveldb.h"
 #endif
+#include "irrlicht_changes/printing.h"
 #include "server/luaentity_sao.h"
 #include "server/player_sao.h"
 
@@ -1282,7 +1283,7 @@ void ServerEnvironment::clearObjects(ClearObjectsMode mode)
 		MapBlock *block = m_map->emergeBlock(p, false);
 		if (!block) {
 			errorstream << "ServerEnvironment::clearObjects(): "
-				<< "Failed to emerge block " << PP(p) << std::endl;
+				<< "Failed to emerge block " << p << std::endl;
 			continue;
 		}
 
@@ -1858,7 +1859,7 @@ u16 ServerEnvironment::addActiveObjectRaw(ServerActiveObject *object,
 			v3s16 p = floatToInt(objectpos, BS);
 			errorstream<<"ServerEnvironment::addActiveObjectRaw(): "
 				<<"could not emerge block for storing id="<<object->getId()
-				<<" statically (pos="<<PP(p)<<")"<<std::endl;
+				<<" statically (pos="<<p<<")"<<std::endl;
 		}
 	}
 
@@ -1906,7 +1907,7 @@ void ServerEnvironment::removeRemovedObjects()
 					warningstream << "ServerEnvironment::removeRemovedObjects(): "
 							<< "id=" << id << " m_static_exists=true but "
 							<< "static data doesn't actually exist in "
-							<< PP(obj->m_static_block) << std::endl;
+							<< obj->m_static_block << std::endl;
 				}
 			} else {
 				infostream << "Failed to emerge block from which an object to "
@@ -1996,7 +1997,7 @@ void ServerEnvironment::activateObjects(MapBlock *block, u32 dtime_s)
 		if (!obj) {
 			errorstream << "ServerEnvironment::activateObjects(): "
 				<< "failed to create active object from static object "
-				<< "in block " << PP(s_obj.pos / BS)
+				<< "in block " << (s_obj.pos / BS)
 				<< " type=" << (int)s_obj.type << " data:" << std::endl;
 			print_hexdump(verbosestream, s_obj.data);
 
@@ -2004,7 +2005,7 @@ void ServerEnvironment::activateObjects(MapBlock *block, u32 dtime_s)
 			continue;
 		}
 		verbosestream << "ServerEnvironment::activateObjects(): "
-			<< "activated static object pos=" << PP(s_obj.pos / BS)
+			<< "activated static object pos=" << (s_obj.pos / BS)
 			<< " type=" << (int)s_obj.type << std::endl;
 		// This will also add the object to the active static list
 		addActiveObjectRaw(obj, false, dtime_s);
@@ -2085,7 +2086,7 @@ void ServerEnvironment::deactivateFarObjects(bool _force_delete)
 
 		verbosestream << "ServerEnvironment::deactivateFarObjects(): "
 					  << "deactivating object id=" << id << " on inactive block "
-					  << PP(blockpos_o) << std::endl;
+					  << blockpos_o << std::endl;
 
 		// If known by some client, don't immediately delete.
 		bool pending_delete = (obj->m_known_by_count > 0 && !force_delete);
@@ -2119,7 +2120,7 @@ void ServerEnvironment::deactivateFarObjects(bool _force_delete)
 						warningstream << "ServerEnvironment::deactivateFarObjects(): "
 								<< "id=" << id << " m_static_exists=true but "
 								<< "static data doesn't actually exist in "
-								<< PP(obj->m_static_block) << std::endl;
+								<< obj->m_static_block << std::endl;
 					}
 				}
 			}
@@ -2189,7 +2190,7 @@ void ServerEnvironment::deleteStaticFromBlock(
 		block = m_map->emergeBlock(obj->m_static_block, false);
 	if (!block) {
 		if (!no_emerge)
-			errorstream << "ServerEnv: Failed to emerge block " << PP(obj->m_static_block)
+			errorstream << "ServerEnv: Failed to emerge block " << obj->m_static_block
 					<< " when deleting static data of object from it. id=" << id << std::endl;
 		return;
 	}
@@ -2216,7 +2217,7 @@ bool ServerEnvironment::saveStaticToBlock(
 	}
 
 	if (!block) {
-		errorstream << "ServerEnv: Failed to emerge block " << PP(obj->m_static_block)
+		errorstream << "ServerEnv: Failed to emerge block " << obj->m_static_block
 				<< " when saving static data of object to it. id=" << store_id << std::endl;
 		return false;
 	}

--- a/src/util/basic_macros.h
+++ b/src/util/basic_macros.h
@@ -42,11 +42,3 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	C(C &&other) = default;      \
 	C &operator=(C &&) = default;
 
-// Macros to facilitate writing position vectors to a stream
-// Usage:
-//	v3s16 pos(1,2,3);
-//	mystream << "message " << PP(pos) << std::endl;
-
-#define PP(x) "("<<(x).X<<","<<(x).Y<<","<<(x).Z<<")"
-
-#define PP2(x) "("<<(x).X<<","<<(x).Y<<")"

--- a/src/voxel.h
+++ b/src/voxel.h
@@ -27,7 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapnode.h"
 #include <set>
 #include <list>
-#include "util/basic_macros.h"
+#include "irrlicht_changes/printing.h"
 
 class NodeDefManager;
 
@@ -314,7 +314,7 @@ public:
 	*/
 	void print(std::ostream &o) const
 	{
-		o << PP(MinEdge) << PP(MaxEdge) << "="
+		o << MinEdge << MaxEdge << "="
 			<< m_cache_extent.X << "x" << m_cache_extent.Y << "x" << m_cache_extent.Z
 			<< "=" << getVolume();
 	}


### PR DESCRIPTION
- Goal of the PR
  Code cleanness
- How does the PR work?
  Replaces the `PP` and `PP2` macros with overloaded `<<` operators. The operator are in the `irr::core` namespace but are found with ADL.
- Does it resolve any reported issue?
  No AFAIK
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
  Yes, 2.2 “Internal code refactoring”
- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is Ready for Review.

## How to test

<!-- Example code or instructions -->
