### PR TITLE
[NOSQUASH] Move soundmanager into its own thread

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,21 +76,21 @@ jobs:
           ./bin/minetest --run-unittests
 
   # Older clang version (should be close to our minimum supported version)
-  clang_6_0:
+  clang_7:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Install deps
         run: |
           source ./util/ci/common.sh
-          install_linux_deps clang-6.0 valgrind
+          install_linux_deps clang-7 valgrind
 
       - name: Build
         run: |
           ./util/ci/build.sh
         env:
-          CC: clang-6.0
-          CXX: clang++-6.0
+          CC: clang-7
+          CXX: clang++-7
 
       - name: Unittest
         run: |

--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -4,7 +4,7 @@
 
 | Dependency | Version | Commentary |
 | ---------- | ------- | ---------- |
-| GCC        | 7.5+    | or Clang 6.0+ |
+| GCC        | 7.5+    | or Clang 7.0.1+ |
 | CMake      | 3.5+    |            |
 | IrrlichtMt | -       | Custom version of Irrlicht, see https://github.com/minetest/irrlicht |
 | Freetype   | 2.0+    |            |

--- a/src/client/sound_openal.cpp
+++ b/src/client/sound_openal.cpp
@@ -38,5 +38,5 @@ std::shared_ptr<SoundManagerSingleton> createSoundManagerSingleton()
 std::unique_ptr<ISoundManager> createOpenALSoundManager(SoundManagerSingleton *smg,
 		std::unique_ptr<SoundFallbackPathProvider> fallback_path_provider)
 {
-	return std::make_unique<OpenALSoundManager>(smg, std::move(fallback_path_provider));
+	return std::make_unique<ProxySoundManager>(smg, std::move(fallback_path_provider));
 };


### PR DESCRIPTION
* What: Moves the soundmgr into a thread. It's communicating with a proxy soundmgr via mutexed queues.
* Why: If some client step takes too long, the sound queues run empty. (There's also a warning when this happens.) The separate thread is not affected by these hiccups.
  It's also nice to leverage more cpu cores, and not take time from the main client thread's step time for loading sounds.

This PR also bumps the minimum clang version to 7, because older clang has issues with `std::variant`.

## To do

This PR is a Ready for Review.

## How to test

* Keep playing a long sound.
* Cause client lag.
  * With CPCSM: `.lua local gut=core.get_us_time local t0 = gut() while gut()-t0 < 2e6 do end`
  * Or e.g. open a formspec that takes long to load, like the first time you open a unifined inv inv on some servers.