### PR TITLE
Fix `.clang-format` file config values

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,10 +3,10 @@ IndentWidth: 4
 UseTab: Always
 TabWidth: 4
 BreakBeforeBraces: Custom
-Standard: Cpp11
+Standard: c++11
 BraceWrapping:
   AfterClass: true
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum: true
   AfterFunction: true
   AfterNamespace: true
@@ -20,7 +20,7 @@ IndentCaseLabels: false
 AccessModifierOffset: -4
 ColumnLimit: 90
 AllowShortFunctionsOnASingleLine: InlineOnly
-SortIncludes: false
+SortIncludes: Never
 IncludeCategories:
   - Regex:           '^".*'
     Priority:        2

--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@ IndentWidth: 4
 UseTab: Always
 TabWidth: 4
 BreakBeforeBraces: Custom
-Standard: c++11
+Standard: c++17
 BraceWrapping:
   AfterClass: true
   AfterControlStatement: Never


### PR DESCRIPTION
Fix config options in `.clang-format` to match the documentation.

https://clang.llvm.org/docs/ClangFormatStyleOptions.html#standard
https://clang.llvm.org/docs/ClangFormatStyleOptions.html#bracewrapping
https://clang.llvm.org/docs/ClangFormatStyleOptions.html#sortincludes

- Does it resolve any reported issue? No
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)? IDK
- If not a bug fix, why is this PR needed? What usecases does it solve? Cleaner config file

## To do

This PR is Ready for Review.

## How to test

Check clang format still work.
