### PR TITLE
Don't crash if a Lua error occurs inside get_staticdata

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4536,7 +4536,7 @@ void the_game(bool *kill,
 		error_message = e.what();
 		errorstream << "ServerError: " << error_message << std::endl;
 	} catch (ModError &e) {
-		// DO NOT TRANSLATE the `ModError`, it's used by ui.lua
+		// DO NOT TRANSLATE the `ModError`, it's used by `ui.lua`
 		error_message = std::string("ModError: ") + e.what() +
 				strgettext("\nCheck debug.txt for details.");
 		errorstream << error_message << std::endl;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -74,6 +74,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "database/database-dummy.h"
 #include "gameparams.h"
 #include "particles.h"
+#include "gettext.h"
 
 class ClientNotFoundException : public BaseException
 {
@@ -3750,6 +3751,23 @@ const ModSpec *Server::getModSpec(const std::string &modname) const
 std::string Server::getBuiltinLuaPath()
 {
 	return porting::path_share + DIR_DELIM + "builtin";
+}
+
+// Not thread-safe.
+void Server::addShutdownError(const ModError &e)
+{
+	// DO NOT TRANSLATE the `ModError`, it's used by `ui.lua`
+	std::string msg = fmtgettext("%s while shutting down: ", "ModError") +
+			e.what() + strgettext("\nCheck debug.txt for details.");
+	errorstream << msg << std::endl;
+
+	if (m_shutdown_errmsg) {
+		if (m_shutdown_errmsg->empty()) {
+			*m_shutdown_errmsg = msg;
+		} else {
+			*m_shutdown_errmsg += "\n\n" + msg;
+		}
+	}
 }
 
 v3f Server::findSpawnPos()

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -235,7 +235,7 @@ Server::Server(
 		Address bind_addr,
 		bool dedicated,
 		ChatInterface *iface,
-		std::string *on_shutdown_errmsg
+		std::string *shutdown_errmsg
 	):
 	m_bind_addr(bind_addr),
 	m_path_world(path_world),
@@ -254,7 +254,7 @@ Server::Server(
 	m_thread(new ServerThread(this)),
 	m_clients(m_con),
 	m_admin_chat(iface),
-	m_on_shutdown_errmsg(on_shutdown_errmsg),
+	m_shutdown_errmsg(shutdown_errmsg),
 	m_modchannel_mgr(new ModChannelMgr())
 {
 	if (m_path_world.empty())
@@ -353,14 +353,7 @@ Server::~Server()
 		try {
 			m_script->on_shutdown();
 		} catch (ModError &e) {
-			errorstream << "ModError: " << e.what() << std::endl;
-			if (m_on_shutdown_errmsg) {
-				if (m_on_shutdown_errmsg->empty()) {
-					*m_on_shutdown_errmsg = std::string("ModError: ") + e.what();
-				} else {
-					*m_on_shutdown_errmsg += std::string("\nModError: ") + e.what();
-				}
-			}
+			addShutdownError(e);
 		}
 
 		infostream << "Server: Saving environment metadata" << std::endl;

--- a/src/server.h
+++ b/src/server.h
@@ -38,7 +38,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "chatmessage.h"
 #include "sound.h"
 #include "translation.h"
-#include "gettext.h"
 #include <string>
 #include <list>
 #include <map>
@@ -302,20 +301,7 @@ public:
 	}
 
 	// Not thread-safe.
-	inline void addShutdownError(const ModError &e) {
-		// DO NOT TRANSLATE the `ModError`, it's used by `ui.lua`
-		std::string msg = fmtgettext("%s while shutting down: ", "ModError") +
-				e.what() + strgettext("\nCheck debug.txt for details.");
-		errorstream << msg << std::endl;
-
-		if (m_shutdown_errmsg) {
-			if (m_shutdown_errmsg->empty()) {
-				*m_shutdown_errmsg = msg;
-			} else {
-				*m_shutdown_errmsg += "\n\n" + msg;
-			}
-		}
-	}
+	void addShutdownError(const ModError &e);
 
 	bool showFormspec(const char *name, const std::string &formspec, const std::string &formname);
 	Map & getMap() { return m_env->getMap(); }

--- a/src/server.h
+++ b/src/server.h
@@ -304,7 +304,7 @@ public:
 	// Not thread-safe.
 	inline void addShutdownError(const ModError &e) {
 		// DO NOT TRANSLATE the `ModError`, it's used by `ui.lua`
-		std::string msg = std::string("ModError while shutting down: ") +
+		std::string msg = fmtgettext("%s while shutting down: ", "ModError") +
 				e.what() + strgettext("\nCheck debug.txt for details.");
 		errorstream << msg << std::endl;
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -510,8 +510,12 @@ ServerEnvironment::~ServerEnvironment()
 	// This makes the next one delete all active objects.
 	m_active_blocks.clear();
 
-	// Convert all objects to static and delete the active objects
-	deactivateFarObjects(true);
+	try {
+		// Convert all objects to static and delete the active objects
+		deactivateFarObjects(true);
+	} catch (ModError &e) {
+		m_server->addShutdownError(e);
+	}
 
 	// Drop/delete map
 	if (m_map)


### PR DESCRIPTION
Fixes #13620. The problem was that `get_staticdata` threw a Lua error twice: The first time while being called regularly, and the second time when it was called while the server was shutting down because of the Lua error. The first occurence of the error was handled fine, the second one wasn't handled and caused the crash.

This PR extends the solution for Lua errors that occur in `on_shutdown` to Lua errors that occur in `get_staticdata` during shutdown.

Related PR: #10314

## To do

This PR is a Ready for Review.

## How to test

Put this code into a mod:

```lua
local after_shutdown = false

minetest.register_entity(":crash_test", {
    get_staticdata = function()
        if after_shutdown then
            error("thrown from get_staticdata after on_shutdown was called")
        else
            error("thrown from get_staticdata before on_shutdown was called")
        end
    end
})

minetest.register_on_joinplayer(function(player)
    minetest.add_entity(player:get_pos(), "crash_test")
end)

minetest.register_on_shutdown(function()
    after_shutdown = true
    error("thrown from on_shutdown")
end)
```

Behavior before this PR: Minetest crashes.
Behavior after this PR: An error dialog with approximately the following content is shown:

```
AsyncErr: Lua: Runtime error from mod 'ctd' in callback on_joinplayer(): Runtime error from mod 'ctd' in callback luaentity_GetStaticdata(): /home/g/minetest/bin/../mods/ctd/init.lua:8: thrown from get_staticdata before on_shutdown was called
stack traceback:
	[C]: in function 'error'
	/home/g/minetest/bin/../mods/ctd/init.lua:8: in function </home/g/minetest/bin/../mods/ctd/init.lua:4>
	[C]: in function 'add_entity'
	/home/g/minetest/bin/../mods/ctd/init.lua:14: in function </home/g/minetest/bin/../mods/ctd/init.lua:13>
	...minetest/bin/../builtin/common/register.lua:26: in function <...minetest/bin/../builtin/common/register.lua:12>
stack traceback:
	[C]: in function 'add_entity'
	/home/g/minetest/bin/../mods/ctd/init.lua:14: in function </home/g/minetest/bin/../mods/ctd/init.lua:13>
	...minetest/bin/../builtin/common/register.lua:26: in function <...minetest/bin/../builtin/common/register.lua:12>

ModError while shutting down: Runtime error from mod 'ctd' in callback on_shutdown(): /home/g/minetest/bin/../mods/ctd/init.lua:19: thrown from on_shutdown
stack traceback:
	[C]: in function 'error'
	/home/g/minetest/bin/../mods/ctd/init.lua:19: in function </home/g/minetest/bin/../mods/ctd/init.lua:17>
	...minetest/bin/../builtin/common/register.lua:26: in function <...minetest/bin/../builtin/common/register.lua:12>
Check debug.txt for details.

ModError while shutting down: Runtime error from mod 'ctd' in callback luaentity_GetStaticdata(): /home/g/minetest/bin/../mods/ctd/init.lua:6: thrown from get_staticdata after on_shutdown was called
stack traceback:
	[C]: in function 'error'
	/home/g/minetest/bin/../mods/ctd/init.lua:6: in function </home/g/minetest/bin/../mods/ctd/init.lua:4>
Check debug.txt for details.
```