### PR TITLE
Add irrlicht device info to the mainmenu About tab

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,6 +16,10 @@ You can use `minetest --version` to find it.
 
 ```
 
+<!-- For graphical and input-related issues. You can find these in the About tab in the mainmenu. -->
+Active renderer:
+Irrlicht device:
+
 ##### OS / Hardware
 <!-- General information about your hardware and operating system -->
 Operating system:

--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -172,10 +172,18 @@ return {
 			"scrollbar[15,0.1;0.4,6.9;vertical;scroll_credits;0]"
 
 		-- Render information
+		local active_renderer_info = fgettext("Active renderer:") .. " " ..
+			core.formspec_escape(core.get_active_renderer())
 		fs = fs .. "style[label_button2;border=false]" ..
-			"button[0.1,6;5.3,1;label_button2;" ..
-			fgettext("Active renderer:") .. "\n" ..
-			core.formspec_escape(core.get_active_renderer()) .. "]"
+			"button[0.1,6;5.3,0.5;label_button2;" .. active_renderer_info .. "]"..
+			"tooltip[label_button2;" .. active_renderer_info .. "]"
+
+		-- Irrlicht device information
+		local irrlicht_device_info = fgettext("Irrlicht device:") .. " " ..
+			core.formspec_escape(core.get_active_irrlicht_device())
+		fs = fs .. "style[label_button3;border=false]" ..
+			"button[0.1,6.5;5.3,0.5;label_button3;" .. irrlicht_device_info .. "]"..
+			"tooltip[label_button3;" .. irrlicht_device_info .. "]"
 
 		if PLATFORM == "Android" then
 			fs = fs .. "button[0.5,5.1;4.5,0.8;share_debug;" .. fgettext("Share debug log") .. "]"

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -213,6 +213,8 @@ GUI
   * technical name of active video driver, e.g. "opengl"
 * `core.get_active_renderer()`:
   * name of current renderer, e.g. "OpenGL 4.6"
+* `core.get_active_irrlicht_device()`:
+  * name of current irrlicht device, e.g. "SDL"
 * `core.get_window_info()`: Same as server-side `get_player_window_information` API.
 
   ```lua

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -968,6 +968,23 @@ int ModApiMainMenu::l_get_active_renderer(lua_State *L)
 }
 
 /******************************************************************************/
+int ModApiMainMenu::l_get_active_irrlicht_device(lua_State *L)
+{
+	const char *device_name = [] {
+		switch (RenderingEngine::get_raw_device()->getType()) {
+		case EIDT_WIN32: return "WIN32";
+		case EIDT_X11: return "X11";
+		case EIDT_OSX: return "OSX";
+		case EIDT_SDL: return "SDL";
+		case EIDT_ANDROID: return "ANDROID";
+		default: return "Unknown";
+		}
+	}();
+	lua_pushstring(L, device_name);
+	return 1;
+}
+
+/******************************************************************************/
 int ModApiMainMenu::l_get_min_supp_proto(lua_State *L)
 {
 	lua_pushinteger(L, CLIENT_PROTOCOL_VERSION_MIN);
@@ -1111,6 +1128,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(get_window_info);
 	API_FCT(get_active_driver);
 	API_FCT(get_active_renderer);
+	API_FCT(get_active_irrlicht_device);
 	API_FCT(get_min_supp_proto);
 	API_FCT(get_max_supp_proto);
 	API_FCT(open_url);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -110,6 +110,8 @@ private:
 
 	static int l_get_active_renderer(lua_State *L);
 
+	static int l_get_active_irrlicht_device(lua_State *L);
+
 	//filesystem
 
 	static int l_get_mainmenu_path(lua_State *L);


### PR DESCRIPTION
The irrlicht device is useful for issues.

Note: The output of `minetest --version` doesn't include this info because in theory there could be multiple compiled irrdevices.

The issue template is also updated. (How do I test this?)

## To do

This PR is a Ready for Review.

## How to test

* Open the About tab in mainmenu.

![2023-06-30-110314_1920x1080_scrot](https://github.com/minetest/minetest/assets/7613443/5af67c20-daac-45e9-ac70-8ddf8774087d)
