### PR TITLE
Fix texture paths for system-installed builds

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -150,7 +150,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	skin->setSize(gui::EGDS_SCROLLBAR_SIZE, (s32)(14.0f * density));
 	skin->setSize(gui::EGDS_WINDOW_BUTTON_WIDTH, (s32)(15.0f * density));
 	if (density > 1.5f) {
-		std::string sprite_path = porting::path_user + "/textures/base/pack/";
+		std::string sprite_path = porting::path_share + "/textures/base/pack/";
 		if (density > 3.5f)
 			sprite_path.append("checkbox_64.png");
 		else if (density > 2.0f)

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -210,7 +210,7 @@ bool RenderingEngine::setupTopLevelWindow()
 bool RenderingEngine::setWindowIcon()
 {
 	irr_ptr<video::IImage> img(driver->createImageFromFile(
-			(porting::path_user + "/textures/base/pack/logo.png").c_str()));
+			(porting::path_share + "/textures/base/pack/logo.png").c_str()));
 	if (!img) {
 		warningstream << "Could not load icon file." << std::endl;
 		return false;


### PR DESCRIPTION
When Minetest is run portably (`RUN_IN_PLACE=1`), the user and share path are the same. However, when Minetest is installed system-wide (`RUN_IN_PLACE=0`) the built-in textures are stored in the share path, not the user path, so it fails to load the icon.

```
WARNING[Main]: Irrlicht: Could not open file of image: /home/rollerozxa/.minetest/textures/base/pack/logo.png
WARNING[Main]: Could not load icon file.
```

This PR also fixes the same issue with the path to custom checkbox sprites used when touchscreen is enabled.

## To do
This PR is Ready for Review.

## How to test
Build with RUN_IN_PLACE=0, install, see that the window icon shows up.