### PR TITLE
Server enforcement for fog_distance (#13448) to block cheating

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -180,7 +180,12 @@ void RemoteClient::GetNextBlocks (
 	s32 new_nearest_unsent_d = -1;
 
 	// Get view range and camera fov (radians) from the client
+	s16 fog_distance = sao->getPlayer()->getSkyParams().fog_distance;
 	s16 wanted_range = sao->getWantedRange() + 1;
+	if (fog_distance >= 0) {
+		// enforce if limited by mod
+		wanted_range = std::min<unsigned>(wanted_range, std::ceil((float)fog_distance / MAP_BLOCKSIZE));
+	}
 	float camera_fov = sao->getFov();
 
 	/*

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1806,6 +1806,10 @@ int ObjectRef::l_set_sky(lua_State *L)
 		lua_getfield(L, 2, "fog");
 		if (lua_istable(L, -1)) {
 			sky_params.fog_distance = getintfield_default(L, -1,  "fog_distance", sky_params.fog_distance);
+			if (sky_params.fog_distance >= 0) {
+				// if set, enforce game limits
+				sky_params.fog_distance = rangelim(sky_params.fog_distance, 20, 4000);
+			}
 			sky_params.fog_start = getfloatfield_default(L, -1,  "fog_start", sky_params.fog_start);
 		}
 	} else {

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1806,10 +1806,6 @@ int ObjectRef::l_set_sky(lua_State *L)
 		lua_getfield(L, 2, "fog");
 		if (lua_istable(L, -1)) {
 			sky_params.fog_distance = getintfield_default(L, -1,  "fog_distance", sky_params.fog_distance);
-			if (sky_params.fog_distance >= 0) {
-				// if set, enforce game limits
-				sky_params.fog_distance = rangelim(sky_params.fog_distance, 20, 4000);
-			}
 			sky_params.fog_start = getfloatfield_default(L, -1,  "fog_start", sky_params.fog_start);
 		}
 	} else {


### PR DESCRIPTION
Followup from #13448 

- Goal of the PR
Enforce fog_distance at the server to block cheating clients.
~~Only allow reasonable values to set for fog_distance, i.e. the same limits we have now: 20 to 4000~~

## To do

This PR is Ready for Review.

## How to test

~~Set fog_distance to 0. Ensure it uses 20.~~
~~Set fog_distance to 1000000, make sure it all works.~~
Can't really test a cheating client without changing the code. If you want to hard code wanted_range in client and see how the server still won't send more data. At least make sure the server never sends less that what is expected.
