### PR TITLE
Improve messages when changing viewing range and exceeding server-set limit

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2489,16 +2489,18 @@ void Game::increaseViewRange()
 {
 	s16 range = g_settings->getS16("viewing_range");
 	s16 range_new = range + 10;
+	s16 server_limit = sky->getFogDistance();
 
-	if (range_new > 4000) {
+	if (range_new >= 4000) {
 		range_new = 4000;
-		std::wstring msg = fwgettext("Viewing range is at maximum: %d", range_new);
-		m_game_ui->showStatusText(msg);
-	} else if (sky->getFogDistance() >= 0 && range_new > sky->getFogDistance()) {
-		std::wstring msg = fwgettext("Viewing range changed to %d, but limited to %d set by server", range_new, sky->getFogDistance());
+		std::wstring msg = server_limit >= 0 && range_new > server_limit ?
+				fwgettext("Viewing range changed to %d (the maximum), but limited to %d by server", range_new, server_limit) :
+				fwgettext("Viewing range changed to %d (the maximum)", range_new);
 		m_game_ui->showStatusText(msg);
 	} else {
-		std::wstring msg = fwgettext("Viewing range changed to %d", range_new);
+		std::wstring msg = server_limit >= 0 && range_new > server_limit ?
+				fwgettext("Viewing range changed to %d, but limited to %d by server", range_new, server_limit) :
+				fwgettext("Viewing range changed to %d", range_new);
 		m_game_ui->showStatusText(msg);
 	}
 	g_settings->set("viewing_range", itos(range_new));
@@ -2509,16 +2511,18 @@ void Game::decreaseViewRange()
 {
 	s16 range = g_settings->getS16("viewing_range");
 	s16 range_new = range - 10;
+	s16 server_limit = sky->getFogDistance();
 
-	if (range_new < 20) {
+	if (range_new <= 20) {
 		range_new = 20;
-		std::wstring msg = fwgettext("Viewing range is at minimum: %d", range_new);
-		m_game_ui->showStatusText(msg);
-	} else if (sky->getFogDistance() >= 0 && range_new > sky->getFogDistance()) {
-		std::wstring msg = fwgettext("Viewing range changed to %d, but limited to %d set by server", range_new, sky->getFogDistance());
+		std::wstring msg = server_limit >= 0 && range_new > server_limit ?
+				fwgettext("Viewing changed to %d (the minimum), but limited to %d by server", range_new, server_limit) :
+				fwgettext("Viewing changed to %d (the minimum)", range_new);
 		m_game_ui->showStatusText(msg);
 	} else {
-		std::wstring msg = fwgettext("Viewing range changed to %d", range_new);
+		std::wstring msg = server_limit >= 0 && range_new > server_limit ?
+				fwgettext("Viewing range changed to %d, but limited to %d by server", range_new, server_limit) :
+				fwgettext("Viewing range changed to %d", range_new);
 		m_game_ui->showStatusText(msg);
 	}
 	g_settings->set("viewing_range", itos(range_new));
@@ -2530,12 +2534,12 @@ void Game::toggleFullViewRange()
 	draw_control->range_all = !draw_control->range_all;
 	if (draw_control->range_all) {
 		if (sky->getFogDistance() >= 0) {
-			m_game_ui->showTranslatedStatusText("The server has disabled unlimited viewing range");
+			m_game_ui->showTranslatedStatusText("Unlimited viewing range enabled, but not allowed by server");
 		} else {
-			m_game_ui->showTranslatedStatusText("Enabled unlimited viewing range");
+			m_game_ui->showTranslatedStatusText("Unlimited viewing range enabled");
 		}
 	} else {
-		m_game_ui->showTranslatedStatusText("Disabled unlimited viewing range");
+		m_game_ui->showTranslatedStatusText("Unlimited viewing range disabled");
 	}
 }
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2344,7 +2344,7 @@ void Game::toggleBlockBounds()
 {
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
 	if (!(client->checkPrivilege("debug") || (player->hud_flags & HUD_FLAG_BASIC_DEBUG))) {
-		m_game_ui->showTranslatedStatusText("Can't show block bounds (disabled by mod or game)");
+		m_game_ui->showTranslatedStatusText("Can't show block bounds (disabled by game or mod)");
 		return;
 	}
 	enum Hud::BlockBoundsMode newmode = hud->toggleBlockBounds();
@@ -2494,12 +2494,12 @@ void Game::increaseViewRange()
 	if (range_new >= 4000) {
 		range_new = 4000;
 		std::wstring msg = server_limit >= 0 && range_new > server_limit ?
-				fwgettext("Viewing range changed to %d (the maximum), but limited to %d by server", range_new, server_limit) :
+				fwgettext("Viewing range changed to %d (the maximum), but limited to %d by game or mod", range_new, server_limit) :
 				fwgettext("Viewing range changed to %d (the maximum)", range_new);
 		m_game_ui->showStatusText(msg);
 	} else {
 		std::wstring msg = server_limit >= 0 && range_new > server_limit ?
-				fwgettext("Viewing range changed to %d, but limited to %d by server", range_new, server_limit) :
+				fwgettext("Viewing range changed to %d, but limited to %d by game or mod", range_new, server_limit) :
 				fwgettext("Viewing range changed to %d", range_new);
 		m_game_ui->showStatusText(msg);
 	}
@@ -2516,12 +2516,12 @@ void Game::decreaseViewRange()
 	if (range_new <= 20) {
 		range_new = 20;
 		std::wstring msg = server_limit >= 0 && range_new > server_limit ?
-				fwgettext("Viewing changed to %d (the minimum), but limited to %d by server", range_new, server_limit) :
+				fwgettext("Viewing changed to %d (the minimum), but limited to %d by game or mod", range_new, server_limit) :
 				fwgettext("Viewing changed to %d (the minimum)", range_new);
 		m_game_ui->showStatusText(msg);
 	} else {
 		std::wstring msg = server_limit >= 0 && range_new > server_limit ?
-				fwgettext("Viewing range changed to %d, but limited to %d by server", range_new, server_limit) :
+				fwgettext("Viewing range changed to %d, but limited to %d by game or mod", range_new, server_limit) :
 				fwgettext("Viewing range changed to %d", range_new);
 		m_game_ui->showStatusText(msg);
 	}
@@ -2534,7 +2534,7 @@ void Game::toggleFullViewRange()
 	draw_control->range_all = !draw_control->range_all;
 	if (draw_control->range_all) {
 		if (sky->getFogDistance() >= 0) {
-			m_game_ui->showTranslatedStatusText("Unlimited viewing range enabled, but not allowed by server");
+			m_game_ui->showTranslatedStatusText("Unlimited viewing range enabled, but forbidden by game or mod");
 		} else {
 			m_game_ui->showTranslatedStatusText("Unlimited viewing range enabled");
 		}


### PR DESCRIPTION
This PR improves the "status text" messages that are shown when you increase or decrease the viewing range or toggle unlimited viewing range and exceed the server-set limit (set via `set_sky`, see PR #13448).

## To do

This PR is a Ready for Review.

## How to test

Set various `fog_distance` values via `player:set_sky`. Increase and decrease the viewing range and toggle unlimited viewing range. Verify that the messages always make sense, correctly reflect what has happened and are unambiguous.
