### PR TITLE
Fix string conversion for FreeBSD

### DIFF
--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -93,7 +93,7 @@ std::wstring utf8_to_wide(const std::string &input)
 	std::wstring out;
 	out.resize(outbuf_size / sizeof(wchar_t));
 
-#if defined(__ANDROID__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__ANDROID__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__FreeBSD__)
 	static_assert(sizeof(wchar_t) == 4, "Unexpected wide char size");
 #endif
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -70,7 +70,7 @@ static bool convert(const char *to, const char *from, char *outbuf,
 #ifdef __ANDROID__
 // On Android iconv disagrees how big a wchar_t is for whatever reason
 const char *DEFAULT_ENCODING = "UTF-32LE";
-#elif defined(__NetBSD__) || defined(__OpenBSD__)
+#elif defined(__NetBSD__) || defined(__OpenBSD__) || defined(__FreeBSD__)
 	// NetBSD does not allow "WCHAR_T" as a charset input to iconv.
 	#include <sys/endian.h>
 	#if BYTE_ORDER == BIG_ENDIAN


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

Fixes "\<invalid UTF-8 string\>" issue on FreeBSD.

I think it should work, dunno haven't tested it. But I'm certain it works.

Reproduce: Press F5 in game, look at coordinate information

Issue: https://forum.minetest.net/viewtopic.php?f=6&t=27100

