### PR TITLE
Fix that transparent text still draws a text shadow

### DIFF
--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -695,7 +695,7 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 				for (size_t i = 0; i < tmp_positions.size(); ++i)
 					tmp_positions[i] += core::vector2di(shadow_offset, shadow_offset);
 
-				u32 new_shadow_alpha = core::clamp(core::round32(shadow_alpha * (colprev.getAlpha() / 255.0f)), 0, 255);
+				u32 new_shadow_alpha = core::clamp(core::round32(shadow_alpha * colprev.getAlpha() / 255.0f), 0, 255);
 				video::SColor shadow_color = video::SColor(new_shadow_alpha, 0, 0, 0);
 				Driver->draw2DImageBatch(page->texture, tmp_positions, tmp_source_rects, clip, shadow_color, true);
 

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -695,9 +695,8 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 				for (size_t i = 0; i < tmp_positions.size(); ++i)
 					tmp_positions[i] += core::vector2di(shadow_offset, shadow_offset);
 
-				// Never let the opacity of the text shadow exceed the opacity of
-				// the text itself, so that we can render completely transparent text.
-				video::SColor shadow_color = video::SColor(std::min(shadow_alpha, colprev.getAlpha()), 0, 0, 0);
+				u32 new_shadow_alpha = core::clamp(core::round32(shadow_alpha * (colprev.getAlpha() / 255.0f)), 0, 255);
+				video::SColor shadow_color = video::SColor(new_shadow_alpha, 0, 0, 0);
 				Driver->draw2DImageBatch(page->texture, tmp_positions, tmp_source_rects, clip, shadow_color, true);
 
 				for (size_t i = 0; i < tmp_positions.size(); ++i)

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -691,6 +691,9 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 			tmp_source_rects.set_data(&page->render_source_rects[ibegin], i - ibegin);
 			--i;
 
+			if (!use_transparency)
+				colprev.color |= 0xff000000;
+
 			if (shadow_offset) {
 				for (size_t i = 0; i < tmp_positions.size(); ++i)
 					tmp_positions[i] += core::vector2di(shadow_offset, shadow_offset);
@@ -703,8 +706,6 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 					tmp_positions[i] -= core::vector2di(shadow_offset, shadow_offset);
 			}
 
-			if (!use_transparency)
-				colprev.color |= 0xff000000;
 			Driver->draw2DImageBatch(page->texture, tmp_positions, tmp_source_rects, clip, colprev, true);
 		}
 	}


### PR DESCRIPTION
Currently, text shadows don't respect the alpha value of text. This is a problem for status text messages, which are faded out by changing their alpha value. This video shows the incorrect "out-fading" before this PR:

https://github.com/minetest/minetest/assets/82708541/e1f0cb52-e845-4ae8-9729-614a05e8aaf8

Notice that the text fades to grey (the color of the text shadow) and then just disappears.

This PR changes the rendering of text shadows so that the alpha value of the text shadow is multiplied by the alpha value of the text itself. This results in correct "out-fading":

https://github.com/minetest/minetest/assets/82708541/a5827e6f-e0c1-49a4-ab65-851cba36678d

(The second video is outdated, it was taken before bf1e6a3cdda38ddf39923577f0aba379e049a8d4.)

Notice that the text fades out until it is fully transparent.

## To do

This PR is a Ready for Review.

## How to test

Trigger some status text messages. Verify that they fade out until they are fully transparent.