### PR TITLE
Add wrappers for memcpy and memset

### DIFF
--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -57,7 +57,7 @@ JoystickLayout create_default_layout()
 		{3, 1}, // JA_FRUSTUM_HORIZONTAL
 		{4, 1}, // JA_FRUSTUM_VERTICAL
 	};
-	memcpy(jlo.axes, axes, sizeof(jlo.axes));
+	my_memcpy(jlo.axes, axes, sizeof(jlo.axes));
 
 	u32 sb = 1 << 7; // START button mask
 	u32 fb = 1 << 3; // FOUR button mask
@@ -118,7 +118,7 @@ JoystickLayout create_xbox_layout()
 		{2, 1}, // JA_FRUSTUM_HORIZONTAL
 		{3, 1}, // JA_FRUSTUM_VERTICAL
 	};
-	memcpy(jlo.axes, axes, sizeof(jlo.axes));
+	my_memcpy(jlo.axes, axes, sizeof(jlo.axes));
 
 	// The back button means "ESC".
 	JLO_B_PB(KeyType::ESC,        1 << 8,  1 << 8); // back
@@ -170,7 +170,7 @@ JoystickLayout create_dragonrise_gamecube_layout()
 		{3, 1}, // JA_FRUSTUM_HORIZONTAL
 		{4, 1}, // JA_FRUSTUM_VERTICAL
 	};
-	memcpy(jlo.axes, axes, sizeof(jlo.axes));
+	my_memcpy(jlo.axes, axes, sizeof(jlo.axes));
 
 	// The center button
 	JLO_B_PB(KeyType::ESC, 1 << 9, 1 << 9); // Start/Pause Button

--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -301,7 +301,7 @@ void JoystickController::clear()
 	m_keys_down.reset();
 	m_past_keys_pressed.reset();
 	m_keys_released.reset();
-	memset(m_axes_vals, 0, sizeof(m_axes_vals));
+	my_memset(m_axes_vals, 0, sizeof(m_axes_vals));
 }
 
 float JoystickController::getAxisWithoutDead(JoystickAxis axis)

--- a/src/client/render/interlaced.cpp
+++ b/src/client/render/interlaced.cpp
@@ -42,7 +42,7 @@ void InitInterlacedMaskStep::run(PipelineContext &context)
 	u8 *data = reinterpret_cast<u8 *>(mask->lock());
 	for (u32 j = 0; j < size.Height; j++) {
 		u8 val = j % 2 ? 0xff : 0x00;
-		memset(data, val, 4 * size.Width);
+		my_memset(data, val, 4 * size.Width);
 		data += 4 * size.Width;
 	}
 	mask->unlock();

--- a/src/client/render/pipeline.cpp
+++ b/src/client/render/pipeline.cpp
@@ -142,7 +142,8 @@ bool TextureBuffer::ensureTexture(video::ITexture **texture, const TextureDefini
 		if (definition.clear) {
 			video::IImage *image = m_driver->createImage(definition.format, size);
 			// Cannot use image->fill because it's not implemented for all formats.
-			std::memset(image->getData(), 0, image->getDataSizeFromFormat(definition.format, size.Width, size.Height));
+			my_memset(image->getData(), 0,
+					image->getDataSizeFromFormat(definition.format, size.Width, size.Height));
 			*texture = m_driver->addTexture(definition.name.c_str(), image);
 			image->drop();
 		}

--- a/src/client/sound_openal_internal.cpp
+++ b/src/client/sound_openal_internal.cpp
@@ -112,7 +112,7 @@ size_t OggVorbisBufferSource::read_func(void *ptr, size_t size, size_t nmemb,
 {
 	OggVorbisBufferSource *s = (OggVorbisBufferSource *)datasource;
 	size_t copied_size = MYMIN(s->buf.size() - s->cur_offset, size);
-	memcpy(ptr, s->buf.data() + s->cur_offset, copied_size);
+	my_memcpy_cast(ptr, s->buf.data() + s->cur_offset, copied_size);
 	s->cur_offset += copied_size;
 	return copied_size;
 }

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -43,7 +43,7 @@ BOOL CALLBACK UpdateLocaleCallback(LPTSTR pStr)
 	int LOCALEID = strtol(pStr, &endptr,16);
 
 	wchar_t buffer[LOCALE_NAME_MAX_LENGTH];
-	memset(buffer, 0, sizeof(buffer));
+	my_memset(buffer, 0, sizeof(buffer));
 	if (GetLocaleInfoW(
 		LOCALEID,
 		LOCALE_SISO639LANGNAME,
@@ -52,7 +52,7 @@ BOOL CALLBACK UpdateLocaleCallback(LPTSTR pStr)
 
 		std::wstring name = buffer;
 
-		memset(buffer, 0, sizeof(buffer));
+		my_memset(buffer, 0, sizeof(buffer));
 		GetLocaleInfoW(
 		LOCALEID,
 		LOCALE_SISO3166CTRYNAME,
@@ -61,7 +61,7 @@ BOOL CALLBACK UpdateLocaleCallback(LPTSTR pStr)
 
 		std::wstring country = buffer;
 
-		memset(buffer, 0, sizeof(buffer));
+		my_memset(buffer, 0, sizeof(buffer));
 		GetLocaleInfoW(
 		LOCALEID,
 		LOCALE_SENGLISHLANGUAGENAME,

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -1109,7 +1109,7 @@ void GUITable::sendTableEvent(s32 column, bool doubleclick)
 	m_sel_doubleclick = doubleclick;
 	if (Parent) {
 		SEvent e;
-		memset(&e, 0, sizeof e);
+		my_memset(&e, 0, sizeof e);
 		e.EventType = EET_GUI_EVENT;
 		e.GUIEvent.Caller = this;
 		e.GUIEvent.Element = 0;

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -447,8 +447,7 @@ void GUITable::setTable(const TableOptions &options,
 			Row *row = &m_rows[i];
 			row->cellcount = rows[i].cells.size();
 			row->cells = new Cell[row->cellcount];
-			memcpy((void*) row->cells, (void*) &rows[i].cells[0],
-					row->cellcount * sizeof(Cell));
+			my_memcpy(row->cells, &rows[i].cells[0], row->cellcount * sizeof(Cell));
 			row->indent = rows[i].indent;
 			row->visible_index = i;
 			m_visible_rows.push_back(i);

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -32,6 +32,7 @@
 #include <irrlicht.h>
 #include <iostream>
 #include "CGUITTFont.h"
+#include "util/string.h" // my_memset
 
 namespace irr
 {
@@ -43,7 +44,7 @@ struct SGUITTFace : public virtual irr::IReferenceCounted
 {
 	SGUITTFace() : face_buffer(0), face_buffer_size(0)
 	{
-		memset((void*)&face, 0, sizeof(FT_Face));
+		my_memset(&face, 0, sizeof(FT_Face));
 	}
 
 	~SGUITTFace()

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2009,7 +2009,7 @@ void MMVManip::initialEmerge(v3s16 blockpos_min, v3s16 blockpos_max,
 				for(s32 y=a.MinEdge.Y; y<=a.MaxEdge.Y; y++)
 				{
 					s32 i = m_area.index(a.MinEdge.X,y,z);
-					memset(&m_flags[i], VOXELFLAG_NO_DATA, MAP_BLOCKSIZE);
+					my_memset(&m_flags[i], VOXELFLAG_NO_DATA, MAP_BLOCKSIZE);
 				}
 			}
 		}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2059,11 +2059,11 @@ MMVManip *MMVManip::clone() const
 	ret->m_area = m_area;
 	if (m_data) {
 		ret->m_data = new MapNode[size];
-		memcpy(ret->m_data, m_data, size * sizeof(MapNode));
+		my_memcpy(ret->m_data, m_data, size * sizeof(MapNode));
 	}
 	if (m_flags) {
 		ret->m_flags = new u8[size];
-		memcpy(ret->m_flags, m_flags, size * sizeof(u8));
+		my_memcpy(ret->m_flags, m_flags, size * sizeof(u8));
 	}
 
 	ret->m_is_dirty = m_is_dirty;

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -274,7 +274,7 @@ static void getBlockNodeIdMapping(NameIdMapping *nimap, MapNode *nodes,
 	if (!mapping)
 		mapping = std::make_unique<content_t[]>(USHRT_MAX + 1);
 
-	memset(mapping.get(), 0xFF, (USHRT_MAX + 1) * sizeof(content_t));
+	my_memset(mapping.get(), 0xFF, (USHRT_MAX + 1) * sizeof(content_t));
 
 	std::unordered_set<content_t> unknown_contents;
 	content_t id_counter = 0;

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -405,7 +405,7 @@ void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int
  	if(disk)
 	{
 		MapNode *tmp_nodes = new MapNode[nodecount];
-		memcpy(tmp_nodes, data, nodecount * sizeof(MapNode));
+		my_memcpy(tmp_nodes, data, nodecount * sizeof(MapNode));
 		getBlockNodeIdMapping(&nimap, tmp_nodes, m_gamedef->ndef());
 
 		buf = MapNode::serializeBulk(version, tmp_nodes, nodecount,

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -146,7 +146,7 @@ BiomeGenOriginal::BiomeGenOriginal(BiomeManager *biomemgr,
 	// Initialise with the ID of 'BIOME_NONE' so that cavegen can get the
 	// fallback biome when biome generation (which calculates the biomemap IDs)
 	// is disabled.
-	memset(biomemap, 0, sizeof(biome_t) * m_csize.X * m_csize.Z);
+	my_memset(biomemap, 0, sizeof(biome_t) * m_csize.X * m_csize.Z);
 
 	// Calculating the bounding position of each biome so we know when we might switch
 	// First gathering all heights where we might switch

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -172,7 +172,7 @@ BiomeGenOriginal::BiomeGenOriginal(BiomeManager *biomemgr,
 	}
 
 	biome_transitions = new s16[out_pos];
-	memcpy(biome_transitions, temp_transition_heights.data(), sizeof(s16) * out_pos);
+	my_memcpy(biome_transitions, temp_transition_heights.data(), sizeof(s16) * out_pos);
 }
 
 BiomeGenOriginal::~BiomeGenOriginal()

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -94,9 +94,9 @@ ObjDef *Schematic::clone() const
 	FATAL_ERROR_IF(!schemdata, "Schematic can only be cloned after loading");
 	u32 nodecount = size.X * size.Y * size.Z;
 	def->schemdata = new MapNode[nodecount];
-	memcpy(def->schemdata, schemdata, sizeof(MapNode) * nodecount);
+	my_memcpy(def->schemdata, schemdata, sizeof(MapNode) * nodecount);
 	def->slice_probs = new u8[size.Y];
-	memcpy(def->slice_probs, slice_probs, sizeof(u8) * size.Y);
+	my_memcpy(def->slice_probs, slice_probs, sizeof(u8) * size.Y);
 
 	return def;
 }

--- a/src/network/address.cpp
+++ b/src/network/address.cpp
@@ -59,26 +59,26 @@ typedef int socket_t;
 
 Address::Address()
 {
-	memset(&m_address, 0, sizeof(m_address));
+	my_memset(&m_address, 0, sizeof(m_address));
 }
 
 Address::Address(u32 address, u16 port)
 {
-	memset(&m_address, 0, sizeof(m_address));
+	my_memset(&m_address, 0, sizeof(m_address));
 	setAddress(address);
 	setPort(port);
 }
 
 Address::Address(u8 a, u8 b, u8 c, u8 d, u16 port)
 {
-	memset(&m_address, 0, sizeof(m_address));
+	my_memset(&m_address, 0, sizeof(m_address));
 	setAddress(a, b, c, d);
 	setPort(port);
 }
 
 Address::Address(const IPv6AddressBytes *ipv6_bytes, u16 port)
 {
-	memset(&m_address, 0, sizeof(m_address));
+	my_memset(&m_address, 0, sizeof(m_address));
 	setAddress(ipv6_bytes);
 	setPort(port);
 }
@@ -112,7 +112,7 @@ void Address::Resolve(const char *name)
 	}
 
 	struct addrinfo *resolved, hints;
-	memset(&hints, 0, sizeof(hints));
+	my_memset(&hints, 0, sizeof(hints));
 
 	// Setup hints
 	if (g_settings->getBool("enable_ipv6")) {

--- a/src/network/address.cpp
+++ b/src/network/address.cpp
@@ -196,9 +196,9 @@ void Address::setAddress(const IPv6AddressBytes *ipv6_bytes)
 {
 	m_addr_family = AF_INET6;
 	if (ipv6_bytes)
-		memcpy(m_address.ipv6.s6_addr, ipv6_bytes->bytes, 16);
+		my_memcpy(m_address.ipv6.s6_addr, ipv6_bytes->bytes, 16);
 	else
-		memset(m_address.ipv6.s6_addr, 0, 16);
+		my_memset(m_address.ipv6.s6_addr, 0, 16);
 }
 
 void Address::setPort(u16 port)

--- a/src/network/address.h
+++ b/src/network/address.h
@@ -35,8 +35,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 struct IPv6AddressBytes
 {
-	u8 bytes[16];
-	IPv6AddressBytes() { memset(bytes, 0, 16); }
+	u8 bytes[16] = {};
 };
 
 class Address

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -71,7 +71,7 @@ BufferedPacketPtr makePacket(Address &address, const SharedBuffer<u8> &data,
 	writeU16(&p->data[4], sender_peer_id);
 	writeU8(&p->data[6], channel);
 
-	memcpy(&p->data[BASE_HEADER_SIZE], *data, data.getSize());
+	my_memcpy(&p->data[BASE_HEADER_SIZE], *data, data.getSize());
 
 	return p;
 }
@@ -84,7 +84,7 @@ SharedBuffer<u8> makeOriginalPacket(const SharedBuffer<u8> &data)
 
 	writeU8(&(b[0]), PACKET_TYPE_ORIGINAL);
 	if (data.getSize() > 0) {
-		memcpy(&(b[header_size]), *data, data.getSize());
+		my_memcpy(&(b[header_size]), *data, data.getSize());
 	}
 	return b;
 }
@@ -114,7 +114,7 @@ void makeSplitPacket(const SharedBuffer<u8> &data, u32 chunksize_max, u16 seqnum
 		writeU16(&chunk[1], seqnum);
 		// [3] u16 chunk_count is written at next stage
 		writeU16(&chunk[5], chunk_num);
-		memcpy(&chunk[chunk_header_size], &data[start], payload_size);
+		my_memcpy(&chunk[chunk_header_size], &data[start], payload_size);
 
 		chunks->push_back(chunk);
 		chunk_count++;
@@ -153,7 +153,7 @@ SharedBuffer<u8> makeReliablePacket(const SharedBuffer<u8> &data, u16 seqnum)
 	writeU8(&b[0], PACKET_TYPE_RELIABLE);
 	writeU16(&b[1], seqnum);
 
-	memcpy(&b[header_size], *data, data.getSize());
+	my_memcpy(&b[header_size], *data, data.getSize());
 
 	return b;
 }
@@ -404,7 +404,7 @@ SharedBuffer<u8> IncomingSplitPacket::reassemble()
 	u32 start = 0;
 	for (u32 chunk_i = 0; chunk_i < chunk_count; chunk_i++) {
 		const SharedBuffer<u8> &buf = chunks[chunk_i];
-		memcpy(&fulldata[start], *buf, buf.getSize());
+		my_memcpy(&fulldata[start], *buf, buf.getSize());
 		start += buf.getSize();
 	}
 
@@ -472,7 +472,7 @@ SharedBuffer<u8> IncomingSplitBuffer::insert(BufferedPacketPtr &p_ptr, bool reli
 	// Cut chunk data out of packet
 	u32 chunkdatasize = p.size() - headersize;
 	SharedBuffer<u8> chunkdata(chunkdatasize);
-	memcpy(*chunkdata, &(p.data[headersize]), chunkdatasize);
+	my_memcpy(*chunkdata, &(p.data[headersize]), chunkdatasize);
 
 	if (!sp->insert(chunk_num, chunkdata))
 		return SharedBuffer<u8>();

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -977,7 +977,7 @@ void ConnectionReceiveThread::receive(SharedBuffer<u8> &packetdata,
 
 		// Make a new SharedBuffer from the data without the base headers
 		SharedBuffer<u8> strippeddata(received_size - BASE_HEADER_SIZE);
-		memcpy(*strippeddata, &packetdata[BASE_HEADER_SIZE],
+		my_memcpy(*strippeddata, &packetdata[BASE_HEADER_SIZE],
 			strippeddata.getSize());
 
 		try {
@@ -1056,7 +1056,7 @@ bool ConnectionReceiveThread::checkIncomingBuffers(Channel *channel,
 	u32 headers_size = BASE_HEADER_SIZE + RELIABLE_HEADER_SIZE;
 	// Get out the inside packet and re-process it
 	SharedBuffer<u8> payload(p->size() - headers_size);
-	memcpy(*payload, &p->data[headers_size], payload.getSize());
+	my_memcpy(*payload, &p->data[headers_size], payload.getSize());
 
 	dst = processPacket(channel, payload, peer_id, channelnum, true);
 	return true;
@@ -1212,7 +1212,7 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Original(Channel *cha
 		<< std::endl);
 	// Get the inside packet out and return it
 	SharedBuffer<u8> payload(packetdata.getSize() - ORIGINAL_HEADER_SIZE);
-	memcpy(*payload, &(packetdata[ORIGINAL_HEADER_SIZE]), payload.getSize());
+	my_memcpy(*payload, &(packetdata[ORIGINAL_HEADER_SIZE]), payload.getSize());
 	return payload;
 }
 
@@ -1350,7 +1350,7 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Reliable(Channel *cha
 
 	// Get out the inside packet and re-process it
 	SharedBuffer<u8> payload(packetdata.getSize() - RELIABLE_HEADER_SIZE);
-	memcpy(*payload, &packetdata[RELIABLE_HEADER_SIZE], payload.getSize());
+	my_memcpy(*payload, &packetdata[RELIABLE_HEADER_SIZE], payload.getSize());
 
 	return processPacket(channel, payload, peer->id, channelnum, true);
 }

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -63,7 +63,7 @@ void NetworkPacket::putRawPacket(const u8 *data, u32 datasize, session_t peer_id
 
 	// split command and datas
 	m_command = readU16(&data[0]);
-	memcpy(m_data.data(), &data[2], m_datasize);
+	my_memcpy(m_data.data(), &data[2], m_datasize);
 }
 
 void NetworkPacket::clear()
@@ -92,7 +92,7 @@ void NetworkPacket::putRawString(const char* src, u32 len)
 	if (len == 0)
 		return;
 
-	memcpy(&m_data[m_read_offset], src, len);
+	my_memcpy_cast(&m_data[m_read_offset], src, len);
 	m_read_offset += len;
 }
 
@@ -553,7 +553,7 @@ Buffer<u8> NetworkPacket::oldForgePacket()
 {
 	Buffer<u8> sb(m_datasize + 2);
 	writeU16(&sb[0], m_command);
-	memcpy(&sb[2], m_data.data(), m_datasize);
+	my_memcpy(&sb[2], m_data.data(), m_datasize);
 
 	return sb;
 }

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -157,7 +157,7 @@ void UDPSocket::Bind(Address addr)
 
 	if (m_addr_family == AF_INET6) {
 		struct sockaddr_in6 address;
-		memset(&address, 0, sizeof(address));
+		my_memset(&address, 0, sizeof(address));
 
 		address.sin6_family = AF_INET6;
 		address.sin6_addr = addr.getAddress6();
@@ -167,7 +167,7 @@ void UDPSocket::Bind(Address addr)
 				sizeof(struct sockaddr_in6));
 	} else {
 		struct sockaddr_in address;
-		memset(&address, 0, sizeof(address));
+		my_memset(&address, 0, sizeof(address));
 
 		address.sin_family = AF_INET;
 		address.sin_addr = addr.getAddress();
@@ -257,7 +257,7 @@ int UDPSocket::Receive(Address &sender, void *data, int size)
 	int received;
 	if (m_addr_family == AF_INET6) {
 		struct sockaddr_in6 address;
-		memset(&address, 0, sizeof(address));
+		my_memset(&address, 0, sizeof(address));
 		socklen_t address_len = sizeof(address);
 
 		received = recvfrom(m_handle, (char *)data, size, 0,
@@ -272,7 +272,7 @@ int UDPSocket::Receive(Address &sender, void *data, int size)
 		sender = Address(bytes, address_port);
 	} else {
 		struct sockaddr_in address;
-		memset(&address, 0, sizeof(address));
+		my_memset(&address, 0, sizeof(address));
 
 		socklen_t address_len = sizeof(address);
 

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -26,7 +26,6 @@
 #include <cmath>
 #include "noise.h"
 #include <iostream>
-#include <cstring> // memset
 #include "debug.h"
 #include "util/numeric.h"
 #include "util/string.h"
@@ -637,7 +636,7 @@ float *Noise::perlinMap2D(float x, float y, float *persistence_map)
 	x /= np.spread.X;
 	y /= np.spread.Y;
 
-	memset(result, 0, sizeof(float) * bufsize);
+	my_memset(result, 0, sizeof(float) * bufsize);
 
 	if (persistence_map) {
 		if (!persist_buf)
@@ -675,7 +674,7 @@ float *Noise::perlinMap3D(float x, float y, float z, float *persistence_map)
 	y /= np.spread.Y;
 	z /= np.spread.Z;
 
-	memset(result, 0, sizeof(float) * bufsize);
+	my_memset(result, 0, sizeof(float) * bufsize);
 
 	if (persistence_map) {
 		if (!persist_buf)

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "profiler.h"
 #include "porting.h"
+#include "util/string.h"
 
 static Profiler main_profiler;
 Profiler *g_profiler = &main_profiler;
@@ -175,7 +176,7 @@ int Profiler::print(std::ostream &o, u32 page, u32 pagecount)
 		{
 			// Padding
 			s32 space = std::max(0, 44 - (s32)i.first.size());
-			memset(buffer, '_', space);
+			my_memset(buffer, '_', space);
 			buffer[space] = '\0';
 			o << buffer;
 		}

--- a/src/reflowscan.cpp
+++ b/src/reflowscan.cpp
@@ -41,7 +41,7 @@ void ReflowScan::scan(MapBlock *block, UniqueQueue<v3s16> *liquid_queue)
 	// needed. The lookup is indexed manually to use the same index in a
 	// bit-array (of uint32 type) which stores for unloaded blocks that they
 	// were already fetched from Map but were actually nullptr.
-	memset(m_lookup, 0, sizeof(m_lookup));
+	my_memset(m_lookup, 0, sizeof(m_lookup));
 	int block_idx = 1 + (1 * 9) + (1 * 3);
 	m_lookup[block_idx] = block;
 	m_lookup_state_bitset = 1 << block_idx;

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -571,11 +571,11 @@ int LuaSecureRandom::l_next_bytes(lua_State *L)
 		char output_buf[RAND_BUF_SIZE];
 
 		// Copy over with what we have left from our current buffer
-		memcpy(output_buf, o->m_rand_buf + o->m_rand_idx, count_remaining);
+		my_memcpy(output_buf, o->m_rand_buf + o->m_rand_idx, count_remaining);
 
 		// Refill buffer and copy over the remainder of what was requested
 		o->fillRandBuf();
-		memcpy(output_buf + count_remaining, o->m_rand_buf, count - count_remaining);
+		my_memcpy(output_buf + count_remaining, o->m_rand_buf, count - count_remaining);
 
 		// Update index
 		o->m_rand_idx = count - count_remaining;

--- a/src/unittest/test_address.cpp
+++ b/src/unittest/test_address.cpp
@@ -58,10 +58,10 @@ void TestAddress::testIsLocalhost()
 	// v6
 	auto ipv6Bytes = std::make_unique<IPv6AddressBytes>();
 	std::vector<u8> ipv6RawAddr = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-	memcpy(ipv6Bytes->bytes, &ipv6RawAddr[0], 16);
+	my_memcpy(ipv6Bytes->bytes, &ipv6RawAddr[0], 16);
 	UASSERT(Address(ipv6Bytes.get(), 0).isLocalhost())
 
 	ipv6RawAddr = {16, 34, 0, 0, 0, 0, 29, 0, 0, 0, 188, 0, 0, 0, 0, 14};
-	memcpy(ipv6Bytes->bytes, &ipv6RawAddr[0], 16);
+	my_memcpy(ipv6Bytes->bytes, &ipv6RawAddr[0], 16);
 	UASSERT(!Address(ipv6Bytes.get(), 0).isLocalhost())
 }

--- a/src/unittest/test_random.cpp
+++ b/src/unittest/test_random.cpp
@@ -123,12 +123,12 @@ void TestRandom::testPcgRandomBytes()
 	char buf[32];
 	PcgRandom r(1538, 877);
 
-	memset(buf, 0, sizeof(buf));
+	my_memset(buf, 0, sizeof(buf));
 	r.bytes(buf + 5, 23);
 	UASSERT(memcmp(buf + 5, expected_pcgrandom_bytes_result,
 		sizeof(expected_pcgrandom_bytes_result)) == 0);
 
-	memset(buf, 0, sizeof(buf));
+	my_memset(buf, 0, sizeof(buf));
 	r.bytes(buf, 17);
 	UASSERT(memcmp(buf, expected_pcgrandom_bytes_result2,
 		sizeof(expected_pcgrandom_bytes_result2)) == 0);
@@ -142,7 +142,7 @@ void TestRandom::testPcgRandomNormalDist()
 	static const int num_trials = 20;
 	static const u32 num_samples = 61000;
 	s32 bins[max - min + 1];
-	memset(bins, 0, sizeof(bins));
+	my_memset(bins, 0, sizeof(bins));
 
 	PcgRandom r(486179 + (int)time(NULL));
 

--- a/src/unittest/test_serialization.cpp
+++ b/src/unittest/test_serialization.cpp
@@ -395,7 +395,7 @@ void TestSerialization::testFloatFormat()
 		return;
 
 	auto test_single = [&fs, &fm](const u32 &i) -> bool {
-		memcpy(&fm, &i, 4);
+		my_memcpy_cast(&fm, &i, 4);
 		fs = u32Tof32Slow(i);
 		if (fm != fs) {
 			printf("u32Tof32Slow failed on 0x%X, expected %.9g, actual %.9g\n",

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -77,7 +77,7 @@ u64 murmur_hash_64_ua(const void *key, int len, unsigned int seed)
 
 	while (data != end) {
 		u64 k;
-		memcpy(&k, data, sizeof(u64));
+		my_memcpy_cast(&k, data, sizeof(u64));
 		data += sizeof(u64);
 
 		k *= m;

--- a/src/util/pointer.h
+++ b/src/util/pointer.h
@@ -79,7 +79,7 @@ public:
 		if(size != 0)
 		{
 			data = new T[size];
-			memcpy(data, t, size);
+			my_memcpy(data, t, size);
 		}
 		else
 			data = nullptr;
@@ -113,7 +113,7 @@ public:
 		buffer.m_size = m_size;
 		if (m_size != 0) {
 			buffer.data = new T[m_size];
-			memcpy(buffer.data, data, m_size);
+			my_memcpy(buffer.data, data, m_size);
 		} else {
 			buffer.data = nullptr;
 		}
@@ -198,7 +198,7 @@ public:
 		if(m_size != 0)
 		{
 			data = new T[m_size];
-			memcpy(data, t, m_size);
+			my_memcpy(data, t, m_size);
 		}
 		else
 			data = nullptr;
@@ -213,7 +213,7 @@ public:
 		m_size = buffer.getSize();
 		if (m_size != 0) {
 				data = new T[m_size];
-				memcpy(data, *buffer, buffer.getSize());
+				my_memcpy(data, *buffer, buffer.getSize());
 		}
 		else
 			data = nullptr;

--- a/src/util/pointer.h
+++ b/src/util/pointer.h
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "irrlichttypes.h"
 #include "debug.h" // For assert()
-#include <cstring>
+#include "util/string.h" // my_memcpy, my_memset
 #include <memory> // std::shared_ptr
 
 
@@ -168,7 +168,7 @@ public:
 		else
 			data = nullptr;
 		refcount = new unsigned int;
-		memset(data,0,sizeof(T)*m_size);
+		my_memset(data,0,sizeof(T)*m_size);
 		(*refcount) = 1;
 	}
 	SharedBuffer(const SharedBuffer &buffer)

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_bloated.h"
 #include "exceptions.h" // for SerializationError
 #include "debug.h" // for assert
+#include "util/string.h" // for my_memcpy_cast
 #include "ieee_float.h"
 
 #include "config.h"
@@ -38,7 +39,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		#include <endian.h>
 	#endif
 #endif
-#include <cstring> // for memcpy
 #include <iostream>
 #include <string>
 #include <vector>
@@ -70,40 +70,40 @@ extern FloatType g_serialize_f32_type;
 inline u16 readU16(const u8 *data)
 {
 	u16 val;
-	memcpy(&val, data, 2);
+	my_memcpy_cast(&val, data, 2);
 	return be16toh(val);
 }
 
 inline u32 readU32(const u8 *data)
 {
 	u32 val;
-	memcpy(&val, data, 4);
+	my_memcpy_cast(&val, data, 4);
 	return be32toh(val);
 }
 
 inline u64 readU64(const u8 *data)
 {
 	u64 val;
-	memcpy(&val, data, 8);
+	my_memcpy_cast(&val, data, 8);
 	return be64toh(val);
 }
 
 inline void writeU16(u8 *data, u16 i)
 {
 	u16 val = htobe16(i);
-	memcpy(data, &val, 2);
+	my_memcpy_cast(data, &val, 2);
 }
 
 inline void writeU32(u8 *data, u32 i)
 {
 	u32 val = htobe32(i);
-	memcpy(data, &val, 4);
+	my_memcpy_cast(data, &val, 4);
 }
 
 inline void writeU64(u8 *data, u64 i)
 {
 	u64 val = htobe64(i);
-	memcpy(data, &val, 8);
+	my_memcpy_cast(data, &val, 8);
 }
 
 #else
@@ -198,7 +198,7 @@ inline f32 readF32(const u8 *data)
 	switch (g_serialize_f32_type) {
 	case FLOATTYPE_SYSTEM: {
 			f32 f;
-			memcpy(&f, &u, 4);
+			my_memcpy_cast(&f, &u, 4);
 			return f;
 		}
 	case FLOATTYPE_SLOW:
@@ -314,7 +314,7 @@ inline void writeF32(u8 *data, f32 i)
 	switch (g_serialize_f32_type) {
 	case FLOATTYPE_SYSTEM: {
 			u32 u;
-			memcpy(&u, &i, 4);
+			my_memcpy_cast(&u, &i, 4);
 			return writeU32(data, u);
 		}
 	case FLOATTYPE_SLOW:

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -89,7 +89,7 @@ std::wstring utf8_to_wide(const std::string &input)
 	size_t outbuf_size = input.length() * sizeof(wchar_t);
 
 	char *inbuf = new char[inbuf_size]; // intentionally NOT null-terminated
-	memcpy(inbuf, input.c_str(), inbuf_size);
+	my_memcpy(inbuf, input.c_str(), inbuf_size);
 	std::wstring out;
 	out.resize(outbuf_size / sizeof(wchar_t));
 
@@ -117,7 +117,7 @@ std::string wide_to_utf8(const std::wstring &input)
 	size_t outbuf_size = input.length() * 4;
 
 	char *inbuf = new char[inbuf_size]; // intentionally NOT null-terminated
-	memcpy(inbuf, input.c_str(), inbuf_size);
+	my_memcpy_cast(inbuf, input.c_str(), inbuf_size);
 	std::string out;
 	out.resize(outbuf_size);
 
@@ -261,7 +261,7 @@ size_t mystrlcpy(char *dst, const char *src, size_t size)
 	size_t copylen = MYMIN(srclen, size);
 
 	if (copylen > 0) {
-		memcpy(dst, src, copylen);
+		my_memcpy(dst, src, copylen);
 		dst[copylen - 1] = '\0';
 	}
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -139,7 +139,7 @@ std::wstring utf8_to_wide(const std::string &input)
 {
 	size_t outbuf_size = input.size() + 1;
 	wchar_t *outbuf = new wchar_t[outbuf_size];
-	memset(outbuf, 0, outbuf_size * sizeof(wchar_t));
+	my_memset(outbuf, 0, outbuf_size * sizeof(wchar_t));
 	MultiByteToWideChar(CP_UTF8, 0, input.c_str(), input.size(),
 		outbuf, outbuf_size);
 	std::wstring out(outbuf);
@@ -151,7 +151,7 @@ std::string wide_to_utf8(const std::wstring &input)
 {
 	size_t outbuf_size = (input.size() + 1) * 6;
 	char *outbuf = new char[outbuf_size];
-	memset(outbuf, 0, outbuf_size);
+	my_memset(outbuf, 0, outbuf_size);
 	WideCharToMultiByte(CP_UTF8, 0, input.c_str(), input.size(),
 		outbuf, outbuf_size, NULL, NULL);
 	std::string out(outbuf);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -773,3 +773,65 @@ void safe_print_string(std::ostream &os, const std::string &str);
  * @return
  */
 v3f str_to_v3f(const std::string &str);
+
+/**
+ * Wrapper around memcpy, which:
+ * * Checks that the type is trivially copyable.
+ * * Allows passing invalid ptrs and nullptrs if \p n is 0. (This is UB for
+ *   normal memcpy.)
+ *
+ * @param dest
+ * @param src
+ * @param n
+ * @return dest
+ */
+template <typename D, typename S>
+inline void *my_memcpy_cast(D *dest, const S *src, size_t n)
+{
+	static_assert(std::is_trivially_copyable_v<D> || std::is_same_v<D, void>,
+			"Can't memcpy non-trivially-copyable types");
+	static_assert(std::is_trivially_copyable_v<S> || std::is_same_v<S, void>,
+			"Can't memcpy non-trivially-copyable types");
+
+	if (n > 0)
+		return memcpy(dest, src, n);
+	else
+		return dest;
+}
+
+/**
+ * Wrapper around my_memcpy_cast, which does not allow type-conversion.
+ *
+ * @param dest
+ * @param src
+ * @param n
+ * @return dest
+ */
+template <typename T>
+inline void *my_memcpy(T *dest, const T *src, size_t n)
+{
+	return my_memcpy_cast(dest, src, n);
+}
+
+/**
+ * Wrapper around memset, which:
+ * * Checks that the type is trivially copyable.
+ * * Allows passing invalid ptrs and nullptrs if \p n is 0. (This is UB for
+ *   normal memset.)
+ *
+ * @param s
+ * @param c
+ * @param n
+ * @return s
+ */
+template <typename T>
+inline void *my_memset(T *s, int c, size_t n)
+{
+	static_assert(std::is_trivially_copyable_v<T> || std::is_same_v<T, void>,
+			"Can't memset non-trivially-copyable types");
+
+	if (n > 0)
+		return memset(s, c, n);
+	else
+		return s;
+}

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -168,7 +168,7 @@ void VoxelManipulator::addArea(const VoxelArea &area)
 	assert(new_data);
 	u8 *new_flags = new u8[new_size];
 	assert(new_flags);
-	memset(new_flags, VOXELFLAG_NO_DATA, new_size);
+	my_memset(new_flags, VOXELFLAG_NO_DATA, new_size);
 
 	// Copy old data
 	s32 old_x_width = m_area.MaxEdge.X - m_area.MinEdge.X + 1;
@@ -243,7 +243,7 @@ void VoxelManipulator::copyFrom(MapNode *src, const VoxelArea& src_area,
 	for (s16 z = 0; z < size.Z; z++) {
 		for (s16 y = 0; y < size.Y; y++) {
 			my_memcpy(&m_data[i_local], &src[i_src], size.X * sizeof(*m_data));
-			memset(&m_flags[i_local], 0, size.X);
+			my_memset(&m_flags[i_local], 0, size.X);
 			i_src += src_step;
 			i_local += dest_step;
 		}

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nodedef.h"
 #include "util/directiontables.h"
 #include "util/timetaker.h"
-#include <cstring>  // memcpy, memset
+#include "util/string.h"  // my_memcpy, my_memset
 
 /*
 	Debug stuff
@@ -178,9 +178,9 @@ void VoxelManipulator::addArea(const VoxelArea &area)
 		unsigned int old_index = m_area.index(m_area.MinEdge.X,y,z);
 		unsigned int new_index = new_area.index(m_area.MinEdge.X,y,z);
 
-		memcpy(&new_data[new_index], &m_data[old_index],
+		my_memcpy(&new_data[new_index], &m_data[old_index],
 				old_x_width * sizeof(MapNode));
-		memcpy(&new_flags[new_index], &m_flags[old_index],
+		my_memcpy(&new_flags[new_index], &m_flags[old_index],
 				old_x_width * sizeof(u8));
 	}
 
@@ -242,7 +242,7 @@ void VoxelManipulator::copyFrom(MapNode *src, const VoxelArea& src_area,
 
 	for (s16 z = 0; z < size.Z; z++) {
 		for (s16 y = 0; y < size.Y; y++) {
-			memcpy(&m_data[i_local], &src[i_src], size.X * sizeof(*m_data));
+			my_memcpy(&m_data[i_local], &src[i_src], size.X * sizeof(*m_data));
 			memset(&m_flags[i_local], 0, size.X);
 			i_src += src_step;
 			i_local += dest_step;


### PR DESCRIPTION
Issue:
Calling memcpy or memset with nullptrs or invalid ptrs is UB, even if the length is 0. This happens at some places in minetest.

This PR fixes this by introducing these three wrappers:
* `my_memset`
* `my_memcpy`
* `my_memcpy_cast`

`my_memcpy_cast` is like `my_memcpy`, but it allows different src and dst types. I thought it's good to have the cast explicit. The non-cast version is much more common.

They all do nothing if the lenght is 0.

They also check that the type is actually trivially copyable (or void).

## To do

This PR is a Ready for Review.

## How to test

* Build.
* Build with sanitizers, and run the game.
  In master you can see messages like the following: `src/network/networkpacket.cpp:556:8: runtime error: null pointer passed as argument 2, which is declared to never be null`