### PR TITLE
Fix sound manager not being stepped by GUIEngine

### DIFF
--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -259,6 +259,9 @@ void GUIEngine::run()
 		);
 	const bool initial_window_maximized = g_settings->getBool("window_maximized");
 
+	u64 t_last_frame = porting::getTimeUs();
+	f32 dtime = 0.0f;
+
 	while (m_rendering_engine->run() && (!m_startgame) && (!m_kill)) {
 
 		//check if we need to update the "upper left corner"-text
@@ -293,7 +296,13 @@ void GUIEngine::run()
 		else
 			sleep_ms(frametime_min);
 
+		u64 t_now = porting::getTimeUs();
+		dtime = static_cast<f32>(t_now - t_last_frame) * 1.0e-6f;
+		t_last_frame = t_now;
+
 		m_script->step();
+
+		m_sound_manager->step(dtime);
 
 #ifdef __ANDROID__
 		m_menu->getAndroidUIInput();


### PR DESCRIPTION
Fixes #13660.

(The dtime calculation is not perfect here, i.e. we still always sleep for a fixed time. I'll leave that to another PR.)

In case you're worried that sounds are streamed too infrequently if the window is unfocused:
* There's #13633 for this.
* We could pause all sounds if the main menu window is unfocused, like in singleplayer game. I'm undecided in this.

## To do

This PR is a Ready for Review.

## How to test

* Put a music file at `devtest/menu/theme.ogg`.
  Side note: Putting `menu_music.ogg` in one's sound pack doesn't work anymore since #11241. :/
* Launch minetest, and listen.