### PR TITLE
GUI: Automatic scaling of checkboxes and scrollbars

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -144,8 +144,9 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	skin->setColor(gui::EGDC_3D_SHADOW, video::SColor(255, 0, 0, 0));
 	skin->setColor(gui::EGDC_HIGH_LIGHT, video::SColor(255, 70, 120, 50));
 	skin->setColor(gui::EGDC_HIGH_LIGHT_TEXT, video::SColor(255, 255, 255, 255));
-#ifdef HAVE_TOUCHSCREENGUI
-	float density = RenderingEngine::getDisplayDensity();
+
+	float density = rangelim(g_settings->getFloat("gui_scaling"), 0.5, 20) *
+		RenderingEngine::getDisplayDensity();
 	skin->setSize(gui::EGDS_CHECK_BOX_WIDTH, (s32)(17.0f * density));
 	skin->setSize(gui::EGDS_SCROLLBAR_SIZE, (s32)(14.0f * density));
 	skin->setSize(gui::EGDS_WINDOW_BUTTON_WIDTH, (s32)(15.0f * density));
@@ -167,7 +168,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 				skin->setIcon(gui::EGDI_CHECK_BOX_CHECKED, sprite_id);
 		}
 	}
-#endif
+
 	g_fontengine = new FontEngine(guienv);
 	FATAL_ERROR_IF(g_fontengine == NULL, "Font engine creation failed.");
 


### PR DESCRIPTION
Fixes #13665 by taking `gui_scaling` and the display density into account for checkboxes, scrollbars and Irrlicht window buttons (currently used in file picker).

I do not know why this code was limited to touchscreens but it does produce acceptable results on my 1080p screen with different GUI scaling factors.

## To do

This PR is Ready for Review.

## How to test

1. `minetest --config <(echo gui_scaling=0.5)` (thanks sfan5)
2. `gui_scaling = 2`
3. Have a high-DPI screen
