### PR TITLE
Update guiEditBoxWithScrollbar.cpp

### DIFF
--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -106,9 +106,8 @@ void GUIEditBoxWithScrollBar::draw()
 			skin->draw3DSunkenPane(this, bg_color, false, m_background,
 				AbsoluteRect, &AbsoluteClippingRect);
 		}
-
-		calculateFrameRect();
 	}
+	calculateFrameRect();
 
 	core::rect<s32> local_clip_rect = m_frame_rect;
 	local_clip_rect.clipAgainst(AbsoluteClippingRect);


### PR DESCRIPTION
Fix bug #13677 ("Vertical scrollbar of a textarea formspec with border=false does not work")

## To do

This PR is Ready for Review.


## How to test

<!-- Example code or instructions -->
See issue #13677
