### PR TITLE
Persist menu textinput

### DIFF
--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -205,7 +205,7 @@ local function get_formspec(tabview, name, tabdata)
 		else
 			retval = retval ..
 				"field[0.3,5.25;3.8,0.5;te_serverport;" .. fgettext("Server Port") .. ";" ..
-				core.formspec_escape(core.settings:get("port")) .. "]"
+				core.formspec_escape(current_port) .. "]"
 		end
 	else
 		retval = retval ..

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -23,6 +23,10 @@ local valid_disabled_settings = {
 	["enable_server"]=true,
 }
 
+-- Name and port stored to persist when updating the formspec
+local current_name = core.settings:get("name")
+local current_port = core.settings:get("port")
+
 -- Currently chosen game in gamebar for theming and filtering
 function current_game()
 	local last_game_id = core.settings:get("menu_last_game")
@@ -188,7 +192,7 @@ local function get_formspec(tabview, name, tabdata)
 				"checkbox[0,"..y..";cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
 				dump(core.settings:get_bool("server_announce")) .. "]" ..
 				"field[0.3,2.85;3.8,0.5;te_playername;" .. fgettext("Name") .. ";" ..
-				core.formspec_escape(core.settings:get("name")) .. "]" ..
+				core.formspec_escape(current_name) .. "]" ..
 				"pwdfield[0.3,4.05;3.8,0.5;te_passwd;" .. fgettext("Password") .. "]"
 
 		local bind_addr = core.settings:get("bind_address")
@@ -197,7 +201,7 @@ local function get_formspec(tabview, name, tabdata)
 				"field[0.3,5.25;2.5,0.5;te_serveraddr;" .. fgettext("Bind Address") .. ";" ..
 				core.formspec_escape(core.settings:get("bind_address")) .. "]" ..
 				"field[2.85,5.25;1.25,0.5;te_serverport;" .. fgettext("Port") .. ";" ..
-				core.formspec_escape(core.settings:get("port")) .. "]"
+				core.formspec_escape(current_port) .. "]"
 		else
 			retval = retval ..
 				"field[0.3,5.25;3.8,0.5;te_serverport;" .. fgettext("Server Port") .. ";" ..
@@ -220,6 +224,14 @@ local function main_button_handler(this, fields, name, tabdata)
 	end
 
 	local world_doubleclick = false
+
+	if fields["te_playername"] then
+		current_name = fields["te_playername"]
+	end
+
+	if fields["te_serverport"] then
+		current_port = fields["te_serverport"]
+	end
 
 	if fields["sp_worlds"] ~= nil then
 		local event = core.explode_textlist_event(fields["sp_worlds"])


### PR DESCRIPTION
This is purely a rebase and small fixup of https://github.com/minetest/minetest/pull/13612 . Credit to archfan7411 for the original commit. My fixups are (1) to move the new code block up as per SmallJoker's feedback and (2) a fix for when a bind address for the server is not configured, which was not working properly for the port field in the original PR.

Implementation note: The typed username persists so long as the main menu stays open, no matter what tab is visited, but isn't saved unless a server is launched or the setting is changed by some other means such as by joining a server or using the settings menu.

## To do

This PR is Ready for Review.

## How to test


### Test 1
1. Make sure that no bind address for the server is set.
2. In the main menu, open the Start Game tab. 
3. Modify the username and port fields, and then (un)check one of the checkboxes above them. The text in the fields should persist correctly.

### Test 2
1. Reconfigure Minetest by setting a bind address.
2. Proceed as for Test 1