### PR TITLE
Add Void Linux specifics to build documentation

### DIFF
--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -32,6 +32,10 @@ For Alpine users:
 
     sudo apk add build-base cmake libpng-dev jpeg-dev libxi-dev mesa-dev sqlite-dev libogg-dev libvorbis-dev openal-soft-dev curl-dev freetype-dev zlib-dev gmp-dev jsoncpp-dev luajit-dev zstd-dev gettext
 
+For Void users:
+
+    sudo xbps-install cmake libpng-devel jpeg-devel libXi-devel mesa sqlite-devel libogg-devel libvorbis-devel libopenal-devel libcurl-devel freetype-devel zlib-devel gmp-devel jsoncpp-devel LuaJIT-devel libzstd-devel gettext
+
 ## Download
 
 You can install Git for easily keeping your copy up to date.
@@ -51,6 +55,10 @@ For Arch users:
 For Alpine users:
 
 	sudo apk add git
+
+For Void users:
+
+    sudo xbps-install git
 
 Download source (this is the URL to the latest of source repository, which might not work at all times) using Git:
 


### PR DESCRIPTION
Just a documentation update. Void Linux seem to be quite popular desktop distribution nowadays, so extra few lines about local package names might be handy for those who want to build the stuff themselves (latest stable Minetest is in official packages list).
