### PR TITLE
Fix `decode_base64` to return `nil` on failure instead of nothing

### DIFF
--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -394,7 +394,8 @@ int ModApiUtil::l_decode_base64(lua_State *L)
 	const std::string data = std::string(d, size);
 
 	if (!base64_is_valid(data))
-		return 0;
+		lua_pushnil(L);
+		return 1;
 
 	std::string out = base64_decode(data);
 

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -393,9 +393,10 @@ int ModApiUtil::l_decode_base64(lua_State *L)
 	const char *d = luaL_checklstring(L, 1, &size);
 	const std::string data = std::string(d, size);
 
-	if (!base64_is_valid(data))
+	if (!base64_is_valid(data)) {
 		lua_pushnil(L);
 		return 1;
+	}
 
 	std::string out = base64_decode(data);
 


### PR DESCRIPTION
Fixes `minetest.decode_base64()` to return `nil` on failure instead of nothing, as per the documentation:

https://github.com/minetest/minetest/blob/c14e4d1795b97b55cf3a23aa347a9eabe0d722ea/doc/lua_api.md?plain=1#L6792

## To do

This PR is Ready for Review.

## How to test

Run this code snippet with your preferred method:
```lua
assert(type(minetest.decode_base64("abcde")) == "nil")
```
Without this PR it crashes with the error `bad argument #1 to 'type' (value expected)`, with this PR it executes successfully. 