### PR TITLE
TouchScreenGUI: Fix only 9 hotbar slots being usable

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2168,6 +2168,14 @@ void Game::processItemSelection(u16 *new_playeritem)
 		}
 	}
 
+#ifdef HAVE_TOUCHSCREENGUI
+	if (g_touchscreengui) {
+		std::optional<u16> selection = g_touchscreengui->getHotbarSelection();
+		if (selection)
+			*new_playeritem = *selection;
+	}
+#endif
+
 	// Clamp selection again in case it wasn't changed but max_item was
 	*new_playeritem = MYMIN(*new_playeritem, max_item);
 }

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -223,7 +223,7 @@ void Hud::drawItem(const ItemStack &item, const core::rect<s32>& rect,
 		client, selected ? IT_ROT_SELECTED : IT_ROT_NONE);
 }
 
-//NOTE: selectitem = 0 -> no selected; selectitem 1-based
+// NOTE: selectitem = 0 -> no selected; selectitem is 1-based
 // mainlist can be NULL, but draw the frame anyway.
 void Hud::drawItems(v2s32 upperleftpos, v2s32 screen_offset, s32 itemcount,
 		s32 inv_offset, InventoryList *mainlist, u16 selectitem, u16 direction,

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -101,7 +101,7 @@ private:
 
 	void drawItems(v2s32 upperleftpos, v2s32 screen_offset, s32 itemcount,
 			s32 inv_offset, InventoryList *mainlist, u16 selectitem,
-			u16 direction);
+			u16 direction, bool is_hotbar);
 
 	void drawItem(const ItemStack &item, const core::rect<s32> &rect, bool selected);
 

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -585,9 +585,10 @@ touch_gui_button_id TouchScreenGUI::getButtonID(size_t eventID)
 
 bool TouchScreenGUI::isHotbarButton(const SEvent &event)
 {
+	const v2s32 touch_pos = v2s32(event.TouchInput.X, event.TouchInput.Y);
 	// check if hotbar item is pressed
 	for (auto &[index, rect] : m_hotbar_rects) {
-		if (rect.isPointInside(v2s32(event.TouchInput.X, event.TouchInput.Y))) {
+		if (rect.isPointInside(touch_pos)) {
 			// We can't just emit a keypress event because the number keys
 			// range from 1 to 9, but there may be more hotbar items.
 			m_hotbar_selection = index;

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -24,8 +24,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IGUIEnvironment.h>
 #include <IrrlichtDevice.h>
 
-#include <map>
 #include <memory>
+#include <optional>
+#include <unordered_map>
 #include <vector>
 
 #include "client/tile.h"
@@ -186,13 +187,15 @@ public:
 	float getMovementSpeed() { return m_joystick_speed; }
 
 	void step(float dtime);
-	void resetHud();
-	void registerHudItem(int index, const rect<s32> &rect);
 	inline void setUseCrosshair(bool use_crosshair) { m_draw_crosshair = use_crosshair; }
 
 	void setVisible(bool visible);
 	void hide();
 	void show();
+
+	void resetHotbarRects();
+	void registerHotbarRect(u16 index, const rect<s32> &rect);
+	std::optional<u16> getHotbarSelection();
 
 private:
 	bool m_initialized = false;
@@ -203,9 +206,10 @@ private:
 	v2u32 m_screensize;
 	s32 button_size;
 	double m_touchscreen_threshold;
-	std::map<int, rect<s32>> m_hud_rects;
-	std::map<size_t, EKEY_CODE> m_hud_ids;
 	bool m_visible; // is the whole touch screen gui visible
+
+	std::unordered_map<u16, rect<s32>> m_hotbar_rects;
+	std::optional<u16> m_hotbar_selection = std::nullopt;
 
 	// value in degree
 	double m_camera_yaw_change = 0.0;
@@ -272,8 +276,8 @@ private:
 	// handle a button event
 	void handleButtonEvent(touch_gui_button_id bID, size_t eventID, bool action);
 
-	// handle pressed hud buttons
-	bool isHUDButton(const SEvent &event);
+	// handle pressing hotbar items
+	bool isHotbarButton(const SEvent &event);
 
 	// do a right-click
 	bool doRightClick();
@@ -285,7 +289,7 @@ private:
 	void applyJoystickStatus();
 
 	// array for saving last known position of a pointer
-	std::map<size_t, v2s32> m_pointer_pos;
+	std::unordered_map<size_t, v2s32> m_pointer_pos;
 
 	// settings bar
 	AutoHideButtonBar m_settings_bar;


### PR DESCRIPTION
This PR fixes #13691.

Before this PR, TouchScreenGUI simply emitted a keypress event for one of the number keys when a hotbar item was pressed. After the 9th hotbar item (the last one for which there is a number key), it started pressing "random" keys.

After this PR, all hotbar items are selectable (except if they are hidden behind other controls, but that's a different issue). 

## To do

This PR is a Ready for Review.

## How to test

Install the CI-built APK on your Android device. Start a Devtest world and execute `/hotbar 20`. Verify that you can select all hotbar slots. Verify that you *cannot* use the 19th hotbar slot to change your camera mode.

Because I rebased this PR, you'll experience #13743 while testing.