### PR TITLE
Warn about unsupported file extensions for media

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -259,7 +259,7 @@ time, if necessary. (See [`Settings`])
 
 Media files (textures, sounds, whatever) that will be transferred to the
 client and will be available for use by the mod and translation files for
-the clients (see [Translations]). Accepted name characters are:
+the clients (see [Translations]). Accepted characters for names are:
 
     a-zA-Z0-9_.-
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -265,8 +265,8 @@ the clients (see [Translations]). Accepted characters for names are:
 
 Accepted formats are:
 
-    images: .png, .jpg, .bmp, .tga
-    sounds: .ogg
+    images: .png, .jpg, .bmp, (deprecated) .tga
+    sounds: .ogg vorbis
     models: .x, .b3d, .obj
 
 Other formats won't be sent to the client (e.g. you can store .blend files

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -259,7 +259,18 @@ time, if necessary. (See [`Settings`])
 
 Media files (textures, sounds, whatever) that will be transferred to the
 client and will be available for use by the mod and translation files for
-the clients (see [Translations]).
+the clients (see [Translations]). Accepted name characters are:
+
+    a-zA-Z0-9_.-
+
+Accepted formats are:
+
+    images: .png, .jpg, .bmp, .tga
+    sounds: .ogg
+    models: .x, .b3d, .obj
+
+Other formats won't be sent to the client (e.g. you can store .blend files
+in a folder for convenience, without the risk that such files are transferred)
 
 It is suggested to use the folders for the purpose they are thought for,
 eg. put textures into `textures`, translation files into `locale`,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2513,7 +2513,7 @@ bool Server::addMediaFile(const std::string &filename,
 {
 	// If name contains illegal characters, ignore the file
 	if (!string_allowed(filename, TEXTURENAME_ALLOWED_CHARS)) {
-		infostream << "Server: ignoring illegal file name: \""
+		warningstream << "Server: ignoring illegal file name: \""
 				<< filename << "\"" << std::endl;
 		return false;
 	}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2513,7 +2513,7 @@ bool Server::addMediaFile(const std::string &filename,
 {
 	// If name contains illegal characters, ignore the file
 	if (!string_allowed(filename, TEXTURENAME_ALLOWED_CHARS)) {
-		warningstream << "Server: ignoring illegal file name: \""
+		warningstream << "Server: ignoring file as it has disallowed characters: \""
 				<< filename << "\"" << std::endl;
 		return false;
 	}


### PR DESCRIPTION
Fixes #13708 

I've also specified in the documentation which files are accepted and I've provided an example (since I asked about .blend files the other day on Matrix)

EDIT: I've pushed another commit, it's been two minutes and I can't see it yet in here, wtf? https://github.com/minetest/minetest/commit/d53b5752a28939b13455b5470401ba85a09dcb57

## To do

This PR is Ready for Review.

## How to test
:eye: 
