### PR TITLE
Crafting refactor: efficient bulk crafting

### DIFF
--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -1107,7 +1107,7 @@ public:
 						max_crafts_fit = is.getStackMax(gamedef->idef()) / output_count;
 					}
 					else {
-						max_crafts_fit = is.getStackMax(gamedef->idef()); // Prevent division by 0 for recipes that decrement the input, like fuel
+						max_crafts_fit = is.getStackMax(gamedef->idef()); // Prevent division by 0 for recipes that have no output, like fuel recipes
 					}
 
 					operation_count = std::min(max_crafts_fit, operation_count);

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -1100,18 +1100,24 @@ public:
 					}
 
 					int output_count = 1;
+					// Recipes' quantity is in the string, so we need to split it out
 					std::vector<std::string>split = str_split(out.item, ' ');
+					// If we ended up with more than one element in the vector, get the output quantity from the second item
 					if (split.size() > 1) {
 						output_count = stoi(split[1]);
 					}
+					// Ensure that we don't craft a larger stack than can be held in one slot
 					operation_count = std::min(u16 (is.getStackMax(gamedef->idef()) / output_count), operation_count);
+					// Get total quantity of output stack
 					output_count = output_count * operation_count;
+					// Quantity goes into second element of vector
 					if (split.size() > 1) {
 						split[1] = itos(output_count);
 					}
 					else {
 						split.push_back(itos(output_count));
 					}
+					// Vector merges back down into string, sets item output stacksize
 					out.item = str_join(split, " ");
 
 					output = out;

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -1117,8 +1117,10 @@ public:
 					else {
 						split.push_back(itos(output_count));
 					}
-					// Vector merges back down into string, sets item output stacksize
-					out.item = str_join(split, " ");
+					// Vector merges back down into string, sets item output stacksize, if greater than 1
+					if (output_count > 1) {
+						out.item = str_join(split, " ");
+					}
 
 					output = out;
 					priority_best = priority;

--- a/src/craftdef.h
+++ b/src/craftdef.h
@@ -444,8 +444,7 @@ public:
 	virtual std::vector<CraftDefinition*> getCraftRecipes(CraftOutput &output,
 			IGameDef *gamedef, unsigned limit=0) const=0;
 
-	virtual u16 getCraftOutputCount(const CraftOutput &output) const=0;
-	virtual bool setCraftOutputCount(CraftOutput &output, u16 newCount) const=0;
+	virtual void setCraftOutputCount(ItemStack &output, u16 newCount) const=0;
 
 	virtual bool clearCraftsByOutput(const CraftOutput &output, IGameDef *gamedef) = 0;
 	virtual bool clearCraftsByInput(const CraftInput &input, IGameDef *gamedef) = 0;

--- a/src/craftdef.h
+++ b/src/craftdef.h
@@ -440,9 +440,12 @@ public:
 	// The main crafting function
 	virtual bool getCraftResult(CraftInput &input, CraftOutput &output,
 			std::vector<ItemStack> &output_replacements,
-			bool decrementInput, IGameDef *gamedef, u16 operation_count) const=0;
+			bool decrementInput, IGameDef *gamedef, u16 operation_count=1) const=0;
 	virtual std::vector<CraftDefinition*> getCraftRecipes(CraftOutput &output,
 			IGameDef *gamedef, unsigned limit=0) const=0;
+
+	virtual u16 getCraftOutputCount(const CraftOutput &output) const=0;
+	virtual bool setCraftOutputCount(CraftOutput &output, u16 newCount) const=0;
 
 	virtual bool clearCraftsByOutput(const CraftOutput &output, IGameDef *gamedef) = 0;
 	virtual bool clearCraftsByInput(const CraftInput &input, IGameDef *gamedef) = 0;

--- a/src/craftdef.h
+++ b/src/craftdef.h
@@ -168,7 +168,7 @@ public:
 	virtual CraftInput getInput(const CraftOutput &output, IGameDef *gamedef) const=0;
 	// Decreases count of every input item
 	virtual void decrementInput(CraftInput &input,
-		std::vector<ItemStack> &output_replacements, IGameDef *gamedef) const=0;
+		std::vector<ItemStack> &output_replacements, IGameDef *gamedef, u16 operation_count) const=0;
 
 	CraftHashType getHashType() const
 	{
@@ -209,7 +209,7 @@ public:
 	virtual CraftOutput getOutput(const CraftInput &input, IGameDef *gamedef) const;
 	virtual CraftInput getInput(const CraftOutput &output, IGameDef *gamedef) const;
 	virtual void decrementInput(CraftInput &input,
-		std::vector<ItemStack> &output_replacements, IGameDef *gamedef) const;
+		std::vector<ItemStack> &output_replacements, IGameDef *gamedef, u16 operation_count) const;
 
 	virtual u64 getHash(CraftHashType type) const;
 
@@ -253,7 +253,7 @@ public:
 	virtual CraftOutput getOutput(const CraftInput &input, IGameDef *gamedef) const;
 	virtual CraftInput getInput(const CraftOutput &output, IGameDef *gamedef) const;
 	virtual void decrementInput(CraftInput &input,
-		std::vector<ItemStack> &output_replacements, IGameDef *gamedef) const;
+		std::vector<ItemStack> &output_replacements, IGameDef *gamedef, u16 operation_count) const;
 
 	virtual u64 getHash(CraftHashType type) const;
 
@@ -293,7 +293,7 @@ public:
 	virtual CraftOutput getOutput(const CraftInput &input, IGameDef *gamedef) const;
 	virtual CraftInput getInput(const CraftOutput &output, IGameDef *gamedef) const;
 	virtual void decrementInput(CraftInput &input,
-		std::vector<ItemStack> &output_replacements, IGameDef *gamedef) const;
+		std::vector<ItemStack> &output_replacements, IGameDef *gamedef, u16 operation_count) const;
 
 	virtual u64 getHash(CraftHashType type) const { return 2; }
 
@@ -334,7 +334,7 @@ public:
 	virtual CraftOutput getOutput(const CraftInput &input, IGameDef *gamedef) const;
 	virtual CraftInput getInput(const CraftOutput &output, IGameDef *gamedef) const;
 	virtual void decrementInput(CraftInput &input,
-		std::vector<ItemStack> &output_replacements, IGameDef *gamedef) const;
+		std::vector<ItemStack> &output_replacements, IGameDef *gamedef, u16 operation_count) const;
 
 	virtual u64 getHash(CraftHashType type) const;
 
@@ -377,7 +377,7 @@ public:
 	virtual CraftOutput getOutput(const CraftInput &input, IGameDef *gamedef) const;
 	virtual CraftInput getInput(const CraftOutput &output, IGameDef *gamedef) const;
 	virtual void decrementInput(CraftInput &input,
-		std::vector<ItemStack> &output_replacements, IGameDef *gamedef) const;
+		std::vector<ItemStack> &output_replacements, IGameDef *gamedef, u16 operation_count) const;
 
 	virtual u64 getHash(CraftHashType type) const;
 
@@ -417,11 +417,12 @@ public:
 	 * in the input if the stack of the replaced item has a count of 1.
 	 * @param decrementInput If true, consume or replace input items.
 	 * @param gamedef
+	 * @param operation_count Number of operations to perform
 	 * @return true if a result was found, otherwise false.
 	 */
 	virtual bool getCraftResult(CraftInput &input, CraftOutput &output,
 			std::vector<ItemStack> &output_replacements,
-			bool decrementInput, IGameDef *gamedef) const=0;
+			bool decrementInput, IGameDef *gamedef, u16 operation_count) const=0;
 
 	virtual std::vector<CraftDefinition*> getCraftRecipes(CraftOutput &output,
 			IGameDef *gamedef, unsigned limit=0) const=0;
@@ -439,7 +440,7 @@ public:
 	// The main crafting function
 	virtual bool getCraftResult(CraftInput &input, CraftOutput &output,
 			std::vector<ItemStack> &output_replacements,
-			bool decrementInput, IGameDef *gamedef) const=0;
+			bool decrementInput, IGameDef *gamedef, u16 operation_count) const=0;
 	virtual std::vector<CraftDefinition*> getCraftRecipes(CraftOutput &output,
 			IGameDef *gamedef, unsigned limit=0) const=0;
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4314,9 +4314,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 				if (button == BET_MIDDLE)
 					craft_amount = 10;
 				else if (event.MouseInput.Shift && button == BET_LEFT)
-					// TODO: We should craft everything with shift-left-click,
-					// but the slow crafting code limits us, so we only craft one
-					craft_amount = 1;
+					craft_amount = 99;
 					//craft_amount = list_s->getItem(s.i).getStackMax(m_client->idef());
 				else
 					craft_amount = 1;

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -991,8 +991,9 @@ u16 getCraftOperationCount(CraftInput ci, u16 desired_crafts)
 	// Find out how many operations we can actually perform
 	u16 max_operations = desired_crafts;
 	for(u16 i = 0; i < ci.items.size(); i++) {
-		if(ci.items[i].count > 0)
+		if(ci.items[i].count > 0) {
 			max_operations = std::min(max_operations, ci.items[i].count);
+		}
 	}
 	return max_operations;
 }

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -986,6 +986,16 @@ void ICraftAction::clientApply(InventoryManager *mgr, IGameDef *gamedef)
 	// to make lag less apparent.
 }
 
+u16 getCraftOperationCount(CraftInput ci, u16 desired_crafts)
+{
+	// Find out how many operations we can actually perform
+	u16 max_operations = desired_crafts;
+	for(u16 i = 0; i < ci.items.size(); i++) {
+		if(ci.items[i].count > 0)
+			max_operations = std::min(max_operations, ci.items[i].count);
+	}
+	return max_operations;
+}
 
 // Crafting helper
 bool getCraftingResult(Inventory *inv, ItemStack &result,
@@ -1006,16 +1016,12 @@ bool getCraftingResult(Inventory *inv, ItemStack &result,
 	for (u16 i=0; i < clist->getSize(); i++)
 		ci.items.push_back(clist->getItem(i));
 
-	// Find out how many operations we can actually perform
-	u16 max_operations = desired_crafts;
-	for(u16 i = 0; i < ci.items.size(); i++) {
-		if(ci.items[i].count > 0)
-			max_operations = std::min(max_operations, ci.items[i].count);
-	}
+	u16 craft_op_count = getCraftOperationCount(ci, desired_crafts);
+
 	// Find out what is crafted and add it to result item slot
 	CraftOutput co;
 	bool found = gamedef->getCraftDefManager()->getCraftResult(
-			ci, co, output_replacements, decrementInput, gamedef, max_operations);
+			ci, co, output_replacements, decrementInput, gamedef, craft_op_count);
 	if (found)
 		result.deSerialize(co.item, gamedef->getItemDefManager());
 
@@ -1028,4 +1034,3 @@ bool getCraftingResult(Inventory *inv, ItemStack &result,
 
 	return found;
 }
-

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -1007,11 +1007,8 @@ bool getCraftingResult(Inventory *inv, ItemStack &result,
 		ci.items.push_back(clist->getItem(i));
 
 	// Find out how many operations we can actually perform
-	// There's a warning about a comparison between int and
-	// unsigned long, but it's unlikely anyone will ever
-	// have a craft requiring more than 65k unique items
 	u16 max_operations = desired_crafts;
-	for(int i = 0; i < ci.items.size(); i++) {
+	for(u16 i = 0; i < ci.items.size(); i++) {
 		if(ci.items[i].count > 0)
 			max_operations = std::min(max_operations, ci.items[i].count);
 	}

--- a/src/inventorymanager.h
+++ b/src/inventorymanager.h
@@ -260,4 +260,4 @@ struct ICraftAction : public InventoryAction
 // Crafting helper
 bool getCraftingResult(Inventory *inv, ItemStack &result,
 		std::vector<ItemStack> &output_replacements,
-		bool decrementInput, IGameDef *gamedef);
+		bool decrementInput, IGameDef *gamedef, u16 desired_crafts);

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -390,7 +390,7 @@ int ModApiCraft::l_get_craft_result(lua_State *L)
 	CraftInput input(method, width, items);
 	CraftOutput output;
 	std::vector<ItemStack> output_replacements;
-	bool got = cdef->getCraftResult(input, output, output_replacements, true, gdef);
+	bool got = cdef->getCraftResult(input, output, output_replacements, true, gdef, 1);
 	lua_newtable(L); // output table
 	if (got) {
 		ItemStack item;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2994,7 +2994,8 @@ void Server::UpdateCrafting(RemotePlayer *player)
 	InventoryLocation loc;
 	loc.setPlayer(player->getName());
 	std::vector<ItemStack> output_replacements;
-	getCraftingResult(&player->inventory, preview, output_replacements, false, this);
+	// Preview is always going to be the preview for a single craft, so hardcoding in 1
+	getCraftingResult(&player->inventory, preview, output_replacements, false, this, 1);
 	m_env->getScriptIface()->item_CraftPredict(preview, player->getPlayerSAO(),
 			clist, loc);
 

--- a/src/unittest/test_craft.cpp
+++ b/src/unittest/test_craft.cpp
@@ -53,7 +53,7 @@ std::string TestCraft::getDumpedCraftResult(CraftInput input, IGameDef *gamedef)
 	CraftOutput output{};
 	std::vector<ItemStack> output_replacements;
 
-	cdef->getCraftResult(input, output, output_replacements, false, gamedef, 1);
+	cdef->getCraftResult(input, output, output_replacements, false, gamedef);
 
 	return output.dump();
 }

--- a/src/unittest/test_craft.cpp
+++ b/src/unittest/test_craft.cpp
@@ -53,7 +53,7 @@ std::string TestCraft::getDumpedCraftResult(CraftInput input, IGameDef *gamedef)
 	CraftOutput output{};
 	std::vector<ItemStack> output_replacements;
 
-	cdef->getCraftResult(input, output, output_replacements, false, gamedef);
+	cdef->getCraftResult(input, output, output_replacements, false, gamedef, 1);
 
 	return output.dump();
 }


### PR DESCRIPTION
Refactors the crafting system to allow bulk crafting with less strain on the client and server, and also adds shift-click crafting to craft up to one full stack of output. Cleans up a TODO of the mouse shortcuts PR #13146, and improves performance related to crafting.

This PR is a Work in Progress.

- [ ] Needs unit test
- [ ] Needs further bug testinggg