### PR TITLE
Settings GUI: Fix path settings on Windows

### DIFF
--- a/builtin/mainmenu/settings/components.lua
+++ b/builtin/mainmenu/settings/components.lua
@@ -199,7 +199,7 @@ function make.path(setting)
 			self.resettable = core.settings:has(setting.name)
 
 			local fs = ("field[0,0.3;%f,0.8;%s;%s;%s]"):format(
-				avail_w - 3, setting.name, get_label(setting), value)
+				avail_w - 3, setting.name, get_label(setting), core.formspec_escape(value))
 			fs = fs .. ("button[%f,0.3;1.5,0.8;%s;%s]"):format(avail_w - 3, "pick_" .. setting.name, fgettext("Browse"))
 			fs = fs .. ("button[%f,0.3;1.5,0.8;%s;%s]"):format(avail_w - 1.5, "set_" .. setting.name, fgettext("Set"))
 


### PR DESCRIPTION
Split off from #13512. Fixes path settings on Windows by escaping the value, so backslashes show up again.

## To do
This PR is Ready for Review.

## How to test
Put backslashes in a path, and see that the settings dialog preserves them.