### PR TITLE
[NO SQUASH] Inventory: Fix assertion caused by a no-op stack movement

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4452,6 +4452,12 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 				if (m_left_drag_stacks.size() > 1) {
 					// Finalize the left-dragging
 					for (auto &ds : m_left_drag_stacks) {
+						if (ds.first == *m_selected_item) {
+							// This entry is needed to properly calculate the stack sizes.
+							// The stack already exists, hence no further action needed here.
+							continue;
+						}
+
 						// Check how many items we should move to this slot,
 						// it may be less than the full split
 						Inventory *inv_to = m_invmgr->getInventory(ds.first.inventoryloc);

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -43,7 +43,7 @@ public:
 		{
 		}
 
-		bool operator==(const ItemSpec& other)
+		bool operator==(const ItemSpec& other) const
 		{
 			return inventoryloc == other.inventoryloc &&
 					listname == other.listname && i == other.i;

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -354,6 +354,9 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		return;
 	}
 
+	if (list_from.get() == list_to.get() && from_i == to_i)
+		return; // Same slot
+
 	/*
 		Do not handle rollback if both inventories are that of the same player
 	*/


### PR DESCRIPTION
Fixes #13716

Moving a stack onto itself caused the assertion to fail because it cannot be swapped with itself. Hence such operations are now all considered as no-ops.

## To do

This PR is Ready for Review.

## How to test

1. As described in #13716