### PR TITLE
Make content tab use real coordinates and minor cleanups

### DIFF
--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -16,19 +16,17 @@
 --with this program; if not, write to the Free Software Foundation, Inc.,
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-local packages_raw
-local packages
+local packages_raw, packages
 
---------------------------------------------------------------------------------
 local function get_formspec(tabview, name, tabdata)
-	if pkgmgr.global_mods == nil then
+	if not pkgmgr.global_mods then
 		pkgmgr.refresh_globals()
 	end
-	if pkgmgr.games == nil then
+	if not pkgmgr.games then
 		pkgmgr.update_gamelist()
 	end
 
-	if packages == nil then
+	if not packages then
 		packages_raw = {}
 		table.insert_all(packages_raw, pkgmgr.games)
 		table.insert_all(packages_raw, pkgmgr.get_texture_packs())
@@ -47,40 +45,38 @@ local function get_formspec(tabview, name, tabdata)
 				is_equal, nil, {})
 	end
 
-	if tabdata.selected_pkg == nil then
+	if not tabdata.selected_pkg then
 		tabdata.selected_pkg = 1
 	end
 
 	local use_technical_names = core.settings:get_bool("show_technical_names")
 
+	local retval = {
+		"label[0.4,0.4;", fgettext("Installed Packages:"), "]",
+		"tablecolumns[color;tree;text]",
+		"table[0.4,0.8;6.3,4.8;pkglist;",
+		pkgmgr.render_packagelist(packages, use_technical_names),
+		";", tabdata.selected_pkg, "]",
 
-	local retval =
-		"label[0.05,-0.25;".. fgettext("Installed Packages:") .. "]" ..
-		"tablecolumns[color;tree;text]" ..
-		"table[0,0.25;5.1,4.3;pkglist;" ..
-		pkgmgr.render_packagelist(packages, use_technical_names) ..
-		";" .. tabdata.selected_pkg .. "]" ..
-		"button[0,4.85;5.25,0.5;btn_contentdb;".. fgettext("Browse online content") .. "]"
-
+		"button[0.4,5.8;6.3,0.9;btn_contentdb;", fgettext("Browse online content"), "]"
+	}
 
 	local selected_pkg
 	if filterlist.size(packages) >= tabdata.selected_pkg then
 		selected_pkg = packages:get_list()[tabdata.selected_pkg]
 	end
 
-	if selected_pkg ~= nil then
-		--check for screenshot beeing available
+	if selected_pkg then
+		-- Check for screenshot being available
 		local screenshotfilename = selected_pkg.path .. DIR_DELIM .. "screenshot.png"
 		local screenshotfile, error = io.open(screenshotfilename, "r")
 
 		local modscreenshot
-		if error == nil then
+		if not error then
 			screenshotfile:close()
 			modscreenshot = screenshotfilename
-		end
-
-		if modscreenshot == nil then
-				modscreenshot = defaulttexturedir .. "no_screenshot.png"
+		else
+			modscreenshot = defaulttexturedir .. "no_screenshot.png"
 		end
 
 		local info = core.get_content_info(selected_pkg.path)
@@ -97,65 +93,65 @@ local function get_formspec(tabview, name, tabdata)
 				core.colorize("#BFBFBF", selected_pkg.name)
 		end
 
-		retval = retval ..
-				"image[5.5,0;3,2;" .. core.formspec_escape(modscreenshot) .. "]" ..
-				"label[8.25,0.6;" .. core.formspec_escape(title_and_name) .. "]" ..
-				"box[5.5,2.2;6.15,2.35;#000]"
+		table.insert_all(retval, {
+			"image[7.1,0.2;3,2;", core.formspec_escape(modscreenshot), "]",
+			"label[10.5,1;", core.formspec_escape(title_and_name), "]",
+			"box[7.1,2.4;8,3.1;#000]"
+		})
 
-		if selected_pkg.type == "mod" then
-			if selected_pkg.is_modpack then
-				retval = retval ..
-					"button[8.65,4.65;3.25,1;btn_mod_mgr_rename_modpack;" ..
-					fgettext("Rename") .. "]"
+		if selected_pkg.is_modpack then
+			table.insert_all(retval, {
+				"button[11.1,5.8;4,0.9;btn_mod_mgr_rename_modpack;",
+				fgettext("Rename"), "]"
+			})
+		elseif selected_pkg.type == "mod" then
+			-- Show dependencies for mods
+			desc = desc .. "\n\n"
+			local toadd_hard = table.concat(info.depends or {}, "\n")
+			local toadd_soft = table.concat(info.optional_depends or {}, "\n")
+			if toadd_hard == "" and toadd_soft == "" then
+				desc = desc .. fgettext("No dependencies.")
 			else
-				--show dependencies
-				desc = desc .. "\n\n"
-				local toadd_hard = table.concat(info.depends or {}, "\n")
-				local toadd_soft = table.concat(info.optional_depends or {}, "\n")
-				if toadd_hard == "" and toadd_soft == "" then
-					desc = desc .. fgettext("No dependencies.")
-				else
+				if toadd_hard ~= "" then
+					desc = desc ..fgettext("Dependencies:") ..
+						"\n" .. toadd_hard
+				end
+				if toadd_soft ~= "" then
 					if toadd_hard ~= "" then
-						desc = desc ..fgettext("Dependencies:") ..
-							"\n" .. toadd_hard
+						desc = desc .. "\n\n"
 					end
-					if toadd_soft ~= "" then
-						if toadd_hard ~= "" then
-							desc = desc .. "\n\n"
-						end
-						desc = desc .. fgettext("Optional dependencies:") ..
-							"\n" .. toadd_soft
-					end
+					desc = desc .. fgettext("Optional dependencies:") ..
+						"\n" .. toadd_soft
 				end
 			end
-
-		else
-			if selected_pkg.type == "txp" then
-				if selected_pkg.enabled then
-					retval = retval ..
-						"button[8.65,4.65;3.25,1;btn_mod_mgr_disable_txp;" ..
-						fgettext("Disable Texture Pack") .. "]"
-				else
-					retval = retval ..
-						"button[8.65,4.65;3.25,1;btn_mod_mgr_use_txp;" ..
-						fgettext("Use Texture Pack") .. "]"
-				end
+		elseif selected_pkg.type == "txp" then
+			if selected_pkg.enabled then
+				table.insert_all(retval, {
+					"button[11.1,5.8;4,0.9;btn_mod_mgr_disable_txp;",
+					fgettext("Disable Texture Pack"), "]"
+				})
+			else
+				table.insert_all(retval, {
+					"button[11.1,5.8;4,0.9;btn_mod_mgr_use_txp;",
+					fgettext("Use Texture Pack"), "]"
+				})
 			end
 		end
 
-		retval = retval .. "textarea[5.85,2.2;6.35,2.9;;" ..
-			fgettext("Information:") .. ";" .. desc .. "]"
+		table.insert_all(retval, {"textarea[7.1,2.4;8,3.1;;;", desc, "]"})
 
 		if core.may_modify_path(selected_pkg.path) then
-			retval = retval ..
-				"button[5.5,4.65;3.25,1;btn_mod_mgr_delete_mod;" ..
-				fgettext("Uninstall Package") .. "]"
+			table.insert_all(retval, {
+				"button[7.1,5.8;4,0.9;btn_mod_mgr_delete_mod;",
+				fgettext("Uninstall Package"), "]"
+			})
 		end
 	end
-	return retval
+
+	return table.concat(retval),
+		"size[15.5,7.1,false]real_coordinates[true]"
 end
 
---------------------------------------------------------------------------------
 local function handle_doubleclick(pkg)
 	if pkg.type == "txp" then
 		if core.settings:get("texture_path") == pkg.path then
@@ -170,10 +166,10 @@ local function handle_doubleclick(pkg)
 	end
 end
 
---------------------------------------------------------------------------------
 local function handle_buttons(tabview, fields, tabname, tabdata)
-	if fields["pkglist"] ~= nil then
-		local event = core.explode_table_event(fields["pkglist"])
+
+	if fields.pkglist then
+		local event = core.explode_table_event(fields.pkglist)
 		tabdata.selected_pkg = event.row
 		if event.type == "DCL" then
 			handle_doubleclick(packages:get_list()[tabdata.selected_pkg])
@@ -181,7 +177,7 @@ local function handle_buttons(tabview, fields, tabname, tabdata)
 		return true
 	end
 
-	if fields["btn_contentdb"] ~= nil then
+	if fields.btn_contentdb then
 		local dlg = create_store_dlg()
 		dlg:set_parent(tabview)
 		tabview:hide()
@@ -190,7 +186,7 @@ local function handle_buttons(tabview, fields, tabname, tabdata)
 		return true
 	end
 
-	if fields["btn_mod_mgr_rename_modpack"] ~= nil then
+	if fields.btn_mod_mgr_rename_modpack then
 		local mod = packages:get_list()[tabdata.selected_pkg]
 		local dlg_renamemp = create_rename_modpack_dlg(mod)
 		dlg_renamemp:set_parent(tabview)
@@ -200,7 +196,7 @@ local function handle_buttons(tabview, fields, tabname, tabdata)
 		return true
 	end
 
-	if fields["btn_mod_mgr_delete_mod"] ~= nil then
+	if fields.btn_mod_mgr_delete_mod then
 		local mod = packages:get_list()[tabdata.selected_pkg]
 		local dlg_delmod = create_delete_content_dlg(mod)
 		dlg_delmod:set_parent(tabview)
@@ -227,7 +223,6 @@ local function handle_buttons(tabview, fields, tabname, tabdata)
 	return false
 end
 
---------------------------------------------------------------------------------
 return {
 	name = "content",
 	caption = fgettext("Content"),


### PR DESCRIPTION
This PR switches the content tab over to use real coordinates. The design stays mostly the same other than the description box being slightly larger to fit more text in it.

![image](https://github.com/minetest/minetest/assets/60856959/941f41d2-79ee-41e1-9281-360d78279c20)

Also includes some cleanups to the code.

## To do
This PR is Ready for Review.

## How to test
See that the content tab still works.