### PR TITLE
DOCS: state that get_wielded_item returns a copy of the item

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7457,7 +7457,7 @@ child will follow movement and rotation of that bone.
 * `get_wield_list()`: returns the name of the inventory list the wielded item
    is in.
 * `get_wield_index()`: returns the wield list index of the wielded item (starting with 1)
-* `get_wielded_item()`: returns the wielded item as an `ItemStack`
+* `get_wielded_item()`: returns a copy of the wielded item as an `ItemStack`
 * `set_wielded_item(item)`: replaces the wielded item, returns `true` if
   successful.
 * `get_armor_groups()`:


### PR DESCRIPTION
## To do

This PR is Ready for Review.

## How to test
If you change the meta of the currently wielded item, it doesn't change. E.g.  
```lua
player:get_wielded_item():get_meta():set_string("count_meta", "hii")
```
You have to do this instead

```lua
local item = player:get_wielded_item()
item:get_meta():set_string("count_meta", "hii")
player:set_wielded_item(item)
```