### PR TITLE
Add option to display webpage titles by right clicking in chat

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -714,6 +714,8 @@ chat_weblink_color (Weblink color) string #8888FF
 #    Value 0 will use the default font size.
 chat_font_size (Chat font size) int 0 0 72
 
+#	Right Click links to show webpage title
+right_click_chat_web_titles (Rightclick webpage title) bool false
 
 [**Content Repository]
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -68,6 +68,7 @@ void set_default_settings()
 	settings->setDefault("occlusion_culler", "bfs");
 	settings->setDefault("enable_raytraced_culling", "true");
 	settings->setDefault("chat_weblink_color", "#8888FF");
+	settings->setDefault("right_click_chat_web_titles","false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -812,6 +812,10 @@ void GUIChatConsole::weblinkClickTitle(const std::string &weblink, ChatBackend* 
 	HTTPFetchRequest fetch_request;
 	fetch_request.url = weblink;
 	fetch_request.caller = caller;
+	fetch_request.max_file_size = 1.5 * 1024 * 1024; // 1.5 megabyte should be more than enoght for HTML!
+	std::vector<std::string> htmlheader {"Accept: text/html"};
+	fetch_request.extra_headers = htmlheader;
+
 	httpfetch_sync(fetch_request, fetch_result); // sync because this is not the main thread
 
 	httpfetch_caller_free(caller);

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -797,7 +797,7 @@ bool GUIChatConsole::weblinkClickOpen(s32 col, s32 row)
 	return false;
 }
 
-void GUIChatConsole::weblinkClickTitle(std::string weblink, ChatBackend* chat_backend){
+void GUIChatConsole::weblinkClickTitle(const std::string &weblink, ChatBackend* chat_backend){
 	if (weblink.empty()){
 		return;
 	}
@@ -822,7 +822,7 @@ void GUIChatConsole::weblinkClickTitle(std::string weblink, ChatBackend* chat_ba
 			msg << gettext("Unable to find title tags in webpage!");
 		} else {
 			std::string title = fetch_result.data.substr(start + start_tag.length(), end - start - end_tag.length() + 1);
-			unsigned int start_end = title.find(">"); // the reason we need to do this is title tags like <title foo="bar"> (like above)
+			unsigned int start_end = title.find('>'); // the reason we need to do this is title tags like <title foo="bar"> (like above)
 			if (start_end == std::string::npos){ start_end = 0; } // this should never happen, but it's better to have the end of a tag somewhere than notthing
 			title = title.substr(start_end + 1);
 			msg << gettext("Webpage title:") << " '" << title << "'";

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -823,15 +823,13 @@ void GUIChatConsole::weblinkClickTitle(const std::string &weblink, ChatBackend* 
 	if (fetch_result.succeeded) {
 		const std::regex r("<title.*?>(.*?)</title.*?>");
 		std::smatch matches;
-		if (std::regex_search(fetch_result.data, matches, r) || !matches.empty()){
+		if (std::regex_search(fetch_result.data, matches, r) || !matches.empty()) {
 			const std::string title = matches.str(1); // pick the first one, what if this is a webpage teaching html and explain the title tag in the CONTENT section...
 			msg << gettext("Webpage title:") << " '" << title << "'";
 		} else {
-			msg << gettext("Unable to get the title from HTML!");
+			msg << gettext("Unable to get the title from webpage!"); // Either the HTML document doesn't have a title tag OR the server reponded with another format
 		}
-	} else {
-		msg << gettext("Unable to get HTML from the webpage (contains title)!");
-	}
+	} // No need to print some text of it fails here, httpfetch already does that
 #else
 	msg << gettext("Unable to connect to webpage (cURL missing)!");
 #endif

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -815,7 +815,7 @@ void GUIChatConsole::weblinkClickTitle(const std::string &weblink, ChatBackend* 
 	httpfetch_sync(fetch_request, fetch_result); // sync because this is not the main thread
 
 	httpfetch_caller_free(caller);
-	
+
 	if (fetch_result.succeeded) {
 		const std::regex r("<title.*?>(.*?)</title.*?>");
 		std::smatch matches;
@@ -826,10 +826,10 @@ void GUIChatConsole::weblinkClickTitle(const std::string &weblink, ChatBackend* 
 			msg << gettext("Unable to get the title from HTML!");
 		}
 	} else {
-		msg << gettext("Error while getting webpage title!");
+		msg << gettext("Unable to get HTML from the webpage (contains title)!");
 	}
 #else
-	msg << gettext("Unable to get webpage title (cURL missing)!");
+	msg << gettext("Unable to connect to webpage (cURL missing)!");
 #endif
 	chat_backend->addUnparsedMessage(utf8_to_wide(msg.str()));
 

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -813,6 +813,8 @@ void GUIChatConsole::weblinkClickTitle(const std::string &weblink, ChatBackend* 
 	fetch_request.url = weblink;
 	fetch_request.caller = caller;
 	httpfetch_sync(fetch_request, fetch_result); // sync because this is not the main thread
+
+	httpfetch_caller_free(caller);
 	
 	if (fetch_result.succeeded) {
 		const std::regex r("<title.*?>(.*?)</title.*?>");
@@ -826,8 +828,6 @@ void GUIChatConsole::weblinkClickTitle(const std::string &weblink, ChatBackend* 
 	} else {
 		msg << gettext("Error while getting webpage title!");
 	}
-
-	httpfetch_caller_free(caller);
 #else
 	msg << gettext("Unable to get webpage title (cURL missing)!");
 #endif

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -813,8 +813,7 @@ void GUIChatConsole::weblinkClickTitle(const std::string &weblink, ChatBackend* 
 	fetch_request.url = weblink;
 	fetch_request.caller = caller;
 	fetch_request.max_file_size = 1.5 * 1024 * 1024; // 1.5 megabyte should be more than enoght for HTML!
-	std::vector<std::string> htmlheader {"Accept: text/html"};
-	fetch_request.extra_headers = htmlheader;
+	fetch_request.extra_headers = {"Accept: text/html"};
 
 	httpfetch_sync(fetch_request, fetch_result); // sync because this is not the main thread
 

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -37,8 +37,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "httpfetch.h"
 #include <thread> // we only need threads when curl is there (as getting a webpage title could freeze the entire client otherwise)
 #include <regex>
-
-#define HTMLTITLEREGEX	"<title.*?>(.*?)</title.*?>"
 #endif
 
 inline u32 clamp_u8(s32 value)
@@ -817,7 +815,7 @@ void GUIChatConsole::weblinkClickTitle(const std::string &weblink, ChatBackend* 
 	httpfetch_sync(fetch_request, fetch_result); // sync because this is not the main thread
 	
 	if (fetch_result.succeeded) {
-		const std::regex r(HTMLTITLEREGEX);
+		const std::regex r("<title.*?>(.*?)</title.*?>");
 		std::smatch matches;
 		if (std::regex_search(fetch_result.data, matches, r) || !matches.empty()){
 			const std::string title = matches.str(1); // pick the first one, what if this is a webpage teaching html and explain the title tag in the CONTENT section...
@@ -829,9 +827,7 @@ void GUIChatConsole::weblinkClickTitle(const std::string &weblink, ChatBackend* 
 		msg << gettext("Error while getting webpage title!");
 	}
 
-
 	httpfetch_caller_free(caller);
-	
 #else
 	msg << gettext("Unable to get webpage title (cURL missing)!");
 #endif

--- a/src/gui/guiChatConsole.h
+++ b/src/gui/guiChatConsole.h
@@ -92,7 +92,7 @@ private:
 	bool weblinkClickOpen(s32 col, s32 row);
 
 	// If a weblink was clicked, this will get the page's title and display it in chat
-	void weblinkClickTitle(s32 col, s32 row);
+	void weblinkClickTitle(std::string weblink, ChatBackend* chat_backen);
 
 	// If the selected text changed, we need to update the (X11) primary selection.
 	void updatePrimarySelection();

--- a/src/gui/guiChatConsole.h
+++ b/src/gui/guiChatConsole.h
@@ -92,7 +92,7 @@ private:
 	bool weblinkClickOpen(s32 col, s32 row);
 
 	// If a weblink was clicked, this will get the page's title and display it in chat
-	void weblinkClickTitle(std::string weblink, ChatBackend* chat_backen);
+	void weblinkClickTitle(const std::string &weblink, ChatBackend* chat_backen);
 
 	// If the selected text changed, we need to update the (X11) primary selection.
 	void updatePrimarySelection();

--- a/src/gui/guiChatConsole.h
+++ b/src/gui/guiChatConsole.h
@@ -84,9 +84,15 @@ private:
 	void drawText();
 	void drawPrompt();
 
+	// If there is a weblink at the specified place, it gets returned. Empty string otherwise
+	std::string getLinkAt(s32 col, s32 row);
+
 	// If clicked fragment has a web url, send it to the system default web browser.
 	// Returns true if, and only if a web url was pressed.
-	bool weblinkClick(s32 col, s32 row);
+	bool weblinkClickOpen(s32 col, s32 row);
+
+	// If a weblink was clicked, this will get the page's title and display it in chat
+	void weblinkClickTitle(s32 col, s32 row);
 
 	// If the selected text changed, we need to update the (X11) primary selection.
 	void updatePrimarySelection();
@@ -136,6 +142,8 @@ private:
 
 	// Enable clickable chat weblinks
 	bool m_cache_clickable_chat_weblinks;
+	// Enable right clickable chat website titles
+	bool m_cache_right_click_chat_web_titles;
 	// Track if a ctrl key is currently held down
 	bool m_is_ctrl_down;
 };

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -275,6 +275,7 @@ HTTPFetchOngoing::HTTPFetchOngoing(const HTTPFetchRequest &request_,
 			request.timeout);
 	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS,
 			request.connect_timeout);
+	curl_easy_setopt(curl, CURLOPT_MAXFILESIZE , request.max_file_size);
 
 	if (!request.useragent.empty())
 		curl_easy_setopt(curl, CURLOPT_USERAGENT, request.useragent.c_str());

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -66,6 +66,9 @@ struct HTTPFetchRequest
 	// application/x-www-form-urlencoded.  POST-only.
 	bool multipart = false;
 
+	// The maximum file size in bytes. Allow any size by default
+	long max_file_size = -1;
+
 	//  The Method to use default = GET
 	//  Avaible methods GET, POST, PUT, DELETE
 	HttpMethod method = HTTP_GET;


### PR DESCRIPTION
This simple PR adds a setting that allows you to display the title of a webpage (like it would be displayed in your browser) by simply right-clicking them in chat. It does so by getting the website's HTML using cURL, and then extracting the title tag.

**Why is this PR needed**
While playing in multiplayer, players may come across links where it's not obvious where they lead you to. With this feature, you can find that out just with a single click, and without the need of opening a browser.


## To do

This PR is a Ready for Review¹.
1: Since it compiled and works just fine I would mark this as "Ready for review" for now. However, due to this being my first PR to the minetest engine itself, I do expect tons of changes I'll have to implement before it's in a case where merging it is actually considered.

## How to test

- download the branch and compile a client
- enable the newly added setting
- hop into the game
- send some chat messages that contain links
- open chat and right-click those links
- send a weblink leading to a site without title (like https://cplusplus.com/reference/regex/)
- verify that this case is handled

![grafik](https://github.com/minetest/minetest/assets/95762086/85ebbef2-7e15-4d1f-a81a-488c48a1a994)

