### PR TITLE
Set item description as infotext for item entities

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -69,6 +69,7 @@ core.register_entity(":__builtin:item", {
 			automatic_rotate = math.pi * 0.5 * 0.2 / size,
 			wield_item = self.itemstring,
 			glow = glow,
+			infotext = stack:get_description(),
 		})
 
 		-- cache for usage in on_step


### PR DESCRIPTION
- Goal of the PR

this allows seeing what a dropped item is before you pick it up.

- How does the PR work?

it adds the item's description to the infotext in the item's properties.

- Does it resolve any reported issue?

i don't think so.

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?

probably not.

- If not a bug fix, why is this PR needed? What usecases does it solve?

this is just a minor quality-of-life tweak. 

## How to test

launch any world, drop an item, and point your reticle at it. 