### PR TITLE
Enabled shift-click crafting

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4314,9 +4314,6 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 				if (button == BET_MIDDLE)
 					craft_amount = 10;
 				else if (event.MouseInput.Shift && button == BET_LEFT)
-					// TODO: We should craft everything with shift-left-click,
-					// but the slow crafting code limits us, so we only craft one
-					// craft_amount = 1;
 					craft_amount = list_s->getItem(s.i).getStackMax(m_client->idef());
 				else
 					craft_amount = 1;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4316,8 +4316,8 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 				else if (event.MouseInput.Shift && button == BET_LEFT)
 					// TODO: We should craft everything with shift-left-click,
 					// but the slow crafting code limits us, so we only craft one
-					craft_amount = 1;
-					//craft_amount = list_s->getItem(s.i).getStackMax(m_client->idef());
+					// craft_amount = 1;
+					craft_amount = list_s->getItem(s.i).getStackMax(m_client->idef());
 				else
 					craft_amount = 1;
 


### PR DESCRIPTION
- Enables the formerly commented out line from PR #13146, which now allows shift-click crafting to function like it does in Minecraft. This was previously blocked by performance issues, as noted in the comment. PR #13234 fixes the performance issues (as best I can tell), so there shouldn't be any reason not to go ahead and use it now, especially that it's made its way into the master branch.

## To do

This PR is Ready for Review.