### PR TITLE
Settings GUI: Hide advanced settings by default

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -385,6 +385,7 @@ local function get_formspec(dialogdata)
 
 	local technical_names_w = TOUCHSCREEN_GUI and 6 or 5
 	local show_technical_names = core.settings:get_bool("show_technical_names")
+	local show_advanced = core.settings:get_bool("show_advanced")
 
 	formspec_show_hack = not formspec_show_hack
 
@@ -406,6 +407,12 @@ local function get_formspec(dialogdata)
 		("checkbox[%f,%f;show_technical_names;%s;%s]"):format(
 			tabsize.width - technical_names_w + 0.25, tabsize.height + 0.6,
 			fgettext("Show technical names"), tostring(show_technical_names)),
+
+		("box[%f,%f;%f,0.8;#0000008C]"):format(
+			tabsize.width - technical_names_w*2 - 0.25, tabsize.height + 0.2, technical_names_w),
+		("checkbox[%f,%f;show_advanced;%s;%s]"):format(
+			tabsize.width - technical_names_w*2, tabsize.height + 0.6,
+			fgettext("Show advanced settings"), tostring(show_advanced)),
 
 		"field[0.25,0.25;", tostring(search_width), ",0.75;search_query;;",
 			core.formspec_escape(dialogdata.query or ""), "]",
@@ -537,6 +544,17 @@ local function buttonhandler(this, fields)
 	if fields.show_technical_names ~= nil then
 		local value = core.is_yes(fields.show_technical_names)
 		core.settings:set_bool("show_technical_names", value)
+		return true
+	end
+
+	if fields.show_advanced ~= nil then
+		local value = core.is_yes(fields.show_advanced)
+		core.settings:set_bool("show_advanced", value)
+
+		dialogdata.components = nil
+		dialogdata.leftscroll = 0
+		dialogdata.rightscroll = 0
+		dialogdata.page_id = update_filtered_pages(dialogdata.query)
 		return true
 	end
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -57,11 +57,12 @@
 # Comments and (Readable name) are handled by gettext.
 # Comments should be complete sentences that describe the setting and possibly
 #  give the user additional useful insight.
+#
 # The last line of a comment can contain the requirements for the setting, ie:
 #
 #    # This is a comment
 #    #
-#    # Requires: shaders, enable_dynamic_shadows, !touchscreen_gui
+#    # Requires: show_advanced, shaders, enable_dynamic_shadows, !touchscreen_gui
 #    name (Readable name) type type_args
 #
 # A requirement can be the name of a boolean setting or an engine-defined value.
@@ -69,6 +70,7 @@
 #
 # * The value of a boolean setting, such as enable_dynamic_shadows
 # * An engine-defined value:
+#     * show_advanced: Only shows if advanced settings are being shown
 #     * shaders_support (a video driver that supports shaders, may not be enabled)
 #     * shaders (both enable_shaders and shaders_support)
 #     * desktop / android
@@ -318,7 +320,7 @@ screenshot_format (Screenshot format) enum png png,jpg
 #    1 means worst quality; 100 means best quality.
 #    Use 0 for default quality.
 #
-#    Requires: desktop
+#    Requires: show_advanced, desktop
 screenshot_quality (Screenshot quality) int 0 0 100
 
 [**Node and Entity Highlighting]
@@ -331,17 +333,25 @@ node_highlighting (Node highlighting) enum box box,halo,none
 show_entity_selectionbox (Show entity selection boxes) bool false
 
 #    Selection box border color (R,G,B).
+#
+#    Requires: show_advanced
 selectionbox_color (Selection box color) string (0,0,0)
 
 #    Width of the selection box lines around nodes.
+#
+#    Requires: show_advanced
 selectionbox_width (Selection box width) int 2 1 5
 
 #    Crosshair color (R,G,B).
 #    Also controls the object crosshair color
+#
+#    Requires: show_advanced
 crosshair_color (Crosshair color) string (255,255,255)
 
 #    Crosshair alpha (opaqueness, between 0 and 255).
 #    This also applies to the object crosshair.
+#
+#    Requires: show_advanced
 crosshair_alpha (Crosshair alpha) int 255 0 255
 
 [**Fog]
@@ -389,6 +399,8 @@ trilinear_filter (Trilinear filtering) bool false
 #    which PNG optimizers usually discard, often resulting in dark or
 #    light edges to transparent textures. Apply a filter to clean that up
 #    at texture load time. This is automatically enabled if mipmapping is enabled.
+#
+#    Requires: show_advanced
 texture_clean_transparent (Clean transparent textures) bool false
 
 #    When using bilinear/trilinear/anisotropic filters, low-resolution textures
@@ -431,11 +443,15 @@ fsaa (Anti-aliasing scale) enum 2 2,4,8,16
 #    "bfs" is the new algorithm based on breadth-first-search and side culling
 #
 #    This setting should only be changed if you have performance problems.
+#
+#    Requires: show_advanced
 occlusion_culler (Occlusion Culler) enum bfs bfs,loops
 
 #    Use raytraced occlusion culling in the new culler.
-#	 This flag enables use of raytraced occlusion culling test for
+#    This flag enables use of raytraced occlusion culling test for
 #    client mesh sizes smaller than 4x4x4 map blocks.
+#
+#    Requires: show_advanced
 enable_raytraced_culling (Enable Raytraced Culling) bool true
 
 
@@ -471,70 +487,70 @@ enable_waving_water (Waving liquids) bool false
 #    0.0 = Wave doesn't move at all.
 #    Default is 1.0 (1/2 node).
 #
-#    Requires: shaders, enable_waving_water
+#    Requires: show_advanced, shaders, enable_waving_water
 water_wave_height (Waving liquids wave height) float 1.0 0.0 4.0
 
 #    Length of liquid waves.
 #
-#    Requires: shaders, enable_waving_water
+#    Requires: show_advanced, shaders, enable_waving_water
 water_wave_length (Waving liquids wavelength) float 20.0 0.1
 
 #    How fast liquid waves will move. Higher = faster.
 #    If negative, liquid waves will move backwards.
 #
-#    Requires: shaders, enable_waving_water
+#    Requires: show_advanced, shaders, enable_waving_water
 water_wave_speed (Waving liquids wave speed) float 5.0
 
 [**Dynamic shadows]
 
 #    Set to true to enable Shadow Mapping.
 #
-#    Requires: shaders, opengl
+#    Requires: show_advanced, shaders, opengl
 enable_dynamic_shadows (Dynamic shadows) bool false
 
 #    Set the shadow strength gamma.
 #    Adjusts the intensity of in-game dynamic shadows.
 #    Lower value means lighter shadows, higher value means darker shadows.
 #
-#    Requires: shaders, enable_dynamic_shadows, opengl
+#    Requires: show_advanced, shaders, enable_dynamic_shadows, opengl
 shadow_strength_gamma (Shadow strength gamma) float 1.0 0.1 10.0
 
 #    Maximum distance to render shadows.
 #
-#    Requires: shaders, enable_dynamic_shadows, opengl
+#    Requires: show_advanced, shaders, enable_dynamic_shadows, opengl
 shadow_map_max_distance (Shadow map max distance in nodes to render shadows) float 140.0 10.0 1000.0
 
 #    Texture size to render the shadow map on.
 #    This must be a power of two.
 #    Bigger numbers create better shadows but it is also more expensive.
 #
-#    Requires: shaders, enable_dynamic_shadows, opengl
+#    Requires: show_advanced, shaders, enable_dynamic_shadows, opengl
 shadow_map_texture_size (Shadow map texture size) int 2048 128 8192
 
 #    Sets shadow texture quality to 32 bits.
 #    On false, 16 bits texture will be used.
 #    This can cause much more artifacts in the shadow.
 #
-#    Requires: shaders, enable_dynamic_shadows, opengl
+#    Requires: show_advanced, shaders, enable_dynamic_shadows, opengl
 shadow_map_texture_32bit (Shadow map texture in 32 bits) bool true
 
 #    Enable Poisson disk filtering.
 #    On true uses Poisson disk to make "soft shadows". Otherwise uses PCF filtering.
 #
-#    Requires: shaders, enable_dynamic_shadows, opengl
+#    Requires: show_advanced, shaders, enable_dynamic_shadows, opengl
 shadow_poisson_filter (Poisson filtering) bool true
 
 #    Define shadow filtering quality.
 #    This simulates the soft shadows effect by applying a PCF or Poisson disk
 #    but also uses more resources.
 #
-#    Requires: shaders, enable_dynamic_shadows, opengl
+#    Requires: show_advanced, shaders, enable_dynamic_shadows, opengl
 shadow_filters (Shadow filter quality) enum 1 0,1,2
 
 #    Enable colored shadows.
 #    On true translucent nodes cast colored shadows. This is expensive.
 #
-#    Requires: shaders, enable_dynamic_shadows, opengl
+#    Requires: show_advanced, shaders, enable_dynamic_shadows, opengl
 shadow_map_color (Colored shadows) bool false
 
 #    Spread a complete update of shadow map over given amount of frames.
@@ -542,21 +558,21 @@ shadow_map_color (Colored shadows) bool false
 #    will consume more resources.
 #    Minimum value: 1; maximum value: 16
 #
-#    Requires: shaders, enable_dynamic_shadows, opengl
+#    Requires: show_advanced, shaders, enable_dynamic_shadows, opengl
 shadow_update_frames (Map shadows update frames) int 8 1 16
 
 #    Set the soft shadow radius size.
 #    Lower values mean sharper shadows, bigger values mean softer shadows.
 #    Minimum value: 1.0; maximum value: 15.0
 #
-#    Requires: shaders, enable_dynamic_shadows, opengl
+#    Requires: show_advanced, shaders, enable_dynamic_shadows, opengl
 shadow_soft_radius (Soft shadow radius) float 5.0 1.0 15.0
 
 #    Set the default tilt of Sun/Moon orbit in degrees.
 #    Games may change orbit tilt via API.
 #    Value of 0 means no tilt / vertical orbit.
 #
-#    Requires: shaders, enable_dynamic_shadows, opengl
+#    Requires: show_advanced, shaders, enable_dynamic_shadows, opengl
 shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 -60.0 60.0
 
 [**Post Processing]
@@ -581,7 +597,7 @@ enable_auto_exposure (Enable Automatic Exposure) bool false
 #    Value of 0.0 (default) means no exposure compensation.
 #    Range: from -1 to 1.0
 #
-#    Requires: shaders, enable_auto_exposure
+#    Requires: show_advanced, shaders, enable_auto_exposure
 exposure_compensation (Exposure compensation) float 0.0 -1.0 1.0
 
 [**Bloom]
@@ -597,7 +613,7 @@ enable_bloom (Enable Bloom) bool false
 #    top-left - processed base image, top-right - final image
 #    bottom-left - raw base image, bottom-right - bloom texture.
 #
-#    Requires: shaders, enable_bloom
+#    Requires: show_advanced, shaders, enable_bloom
 enable_bloom_debug (Enable Bloom Debug) bool false
 
 #    Defines how much bloom is applied to the rendered image
@@ -660,15 +676,21 @@ formspec_fullscreen_bg_color (Formspec Full-Screen Background Color) string (0,0
 #    When gui_scaling_filter is true, all GUI images need to be
 #    filtered in software, but some images are generated directly
 #    to hardware (e.g. render-to-texture for nodes in inventory).
+#
+#    Requires: show_advanced
 gui_scaling_filter (GUI scaling filter) bool false
 
 #    When gui_scaling_filter_txr2img is true, copy those images
 #    from hardware to software for scaling.  When false, fall back
 #    to the old scaling method, for video drivers that don't
 #    properly support downloading textures back from hardware.
+#
+#    Requires: show_advanced
 gui_scaling_filter_txr2img (GUI scaling filter txr2img) bool true
 
 #    Delay showing tooltips, stated in milliseconds.
+#
+#    Requires: show_advanced
 tooltip_show_delay (Tooltip delay) int 400 0 18446744073709551615
 
 #    Append item name to tooltip.
@@ -714,10 +736,88 @@ chat_weblink_color (Weblink color) string #8888FF
 #    Value 0 will use the default font size.
 chat_font_size (Chat font size) int 0 0 72
 
+[**Font]
+
+font_bold (Font bold by default) bool false
+
+#    Requires: show_advanced
+font_italic (Font italic by default) bool false
+
+#    Shadow offset (in pixels) of the default font. If 0, then shadow will not be drawn.
+#
+#    Requires: show_advanced
+font_shadow (Font shadow) int 1 0 65535
+
+#    Opaqueness (alpha) of the shadow behind the default font, between 0 and 255.
+#
+#    Requires: show_advanced
+font_shadow_alpha (Font shadow alpha) int 127 0 255
+
+#    Font size of the default font where 1 unit = 1 pixel at 96 DPI
+font_size (Font size) int 16 5 72
+
+#    For pixel-style fonts that do not scale well, this ensures that font sizes used
+#    with this font will always be divisible by this value, in pixels. For instance,
+#    a pixel font 16 pixels tall should have this set to 16, so it will only ever be
+#    sized 16, 32, 48, etc., so a mod requesting a size of 25 will get 32.
+#
+#    Requires: show_advanced
+font_size_divisible_by (Font size divisible by) int 1 1
+
+#    Path to the default font. Must be a TrueType font.
+#    The fallback font will be used if the font cannot be loaded.
+#
+#    Requires: show_advanced
+font_path (Regular font path) filepath fonts/Arimo-Regular.ttf
+
+#    Requires: show_advanced
+font_path_bold (Bold font path) filepath fonts/Arimo-Bold.ttf
+
+#    Requires: show_advanced
+font_path_italic (Italic font path) filepath fonts/Arimo-Italic.ttf
+
+#    Requires: show_advanced
+font_path_bold_italic (Bold and italic font path) filepath fonts/Arimo-BoldItalic.ttf
+
+#    Font size of the monospace font where 1 unit = 1 pixel at 96 DPI
+#
+#    Requires: show_advanced
+mono_font_size (Monospace font size) int 16 5 72
+
+#    For pixel-style fonts that do not scale well, this ensures that font sizes used
+#    with this font will always be divisible by this value, in pixels. For instance,
+#    a pixel font 16 pixels tall should have this set to 16, so it will only ever be
+#    sized 16, 32, 48, etc., so a mod requesting a size of 25 will get 32.
+#
+#    Requires: show_advanced
+mono_font_size_divisible_by (Monospace font size divisible by) int 1 1
+
+#    Path to the monospace font. Must be a TrueType font.
+#    This font is used for e.g. the console and profiler screen.
+#
+#    Requires: show_advanced
+mono_font_path (Monospace font path) filepath fonts/Cousine-Regular.ttf
+
+#    Requires: show_advanced
+mono_font_path_bold (Bold monospace font path) filepath fonts/Cousine-Bold.ttf
+
+#    Requires: show_advanced
+mono_font_path_italic (Italic monospace font path) filepath fonts/Cousine-Italic.ttf
+
+#    Requires: show_advanced
+mono_font_path_bold_italic (Bold and italic monospace font path) filepath fonts/Cousine-BoldItalic.ttf
+
+#    Path of the fallback font. Must be a TrueType font.
+#    This font will be used for certain languages or if the default font is unavailable.
+#
+#    Requires: show_advanced
+fallback_font_path (Fallback font path) filepath fonts/DroidSansFallbackFull.ttf
 
 [**Content Repository]
 
 #    The URL for the content repository
+#
+#    Requires: show_advanced
 contentdb_url (ContentDB URL) string https://content.minetest.net
 
 #    Comma-separated list of flags to hide in the content repository.
@@ -741,13 +841,19 @@ contentdb_max_concurrent_downloads (ContentDB Max Concurrent Downloads) int 3 1
 enable_local_map_saving (Saving map received from server) bool false
 
 #    URL to the server list displayed in the Multiplayer Tab.
+#
+#    Requires: show_advanced
 serverlist_url (Serverlist URL) string servers.minetest.net
 
 #    If enabled, account registration is separate from login in the UI.
 #    If disabled, new accounts will be registered automatically when logging in.
+#
+#    Requires: show_advanced
 enable_split_login_register (Enable split login/register) bool true
 
 #    URL to JSON file which provides information about the newest Minetest release
+#
+#    Requires: show_advanced
 update_information_url (Update information URL) string https://www.minetest.net/release_info.json
 
 [*Server]
@@ -755,82 +861,124 @@ update_information_url (Update information URL) string https://www.minetest.net/
 #    Name of the player.
 #    When running a server, clients connecting with this name are admins.
 #    When starting from the main menu, this is overridden.
+#
+#    Requires: show_advanced
 name (Admin name) string
 
 [**Serverlist and MOTD]
 
 #    Name of the server, to be displayed when players join and in the serverlist.
+#
+#    Requires: show_advanced
 server_name (Server name) string Minetest server
 
 #    Description of server, to be displayed when players join and in the serverlist.
+#
+#    Requires: show_advanced
 server_description (Server description) string mine here
 
 #    Domain name of server, to be displayed in the serverlist.
+#
+#    Requires: show_advanced
 server_address (Server address) string game.minetest.net
 
 #    Homepage of server, to be displayed in the serverlist.
+#
+#    Requires: show_advanced
 server_url (Server URL) string https://minetest.net
 
 #    Automatically report to the serverlist.
+#
+#    Requires: show_advanced
 server_announce (Announce server) bool false
 
 #    Announce to this serverlist.
+#
+#    Requires: show_advanced
 serverlist_url (Serverlist URL) string servers.minetest.net
 
 #    Message of the day displayed to players connecting.
+#
+#    Requires: show_advanced
 motd (Message of the day) string
 
 #    Maximum number of players that can be connected simultaneously.
+#
+#    Requires: show_advanced
 max_users (Maximum users) int 15 0 65535
 
 #    If this is set, players will always (re)spawn at the given position.
+#
+#    Requires: show_advanced
 static_spawnpoint (Static spawnpoint) string
 
 [**Networking]
 
 #    Network port to listen (UDP).
 #    This value will be overridden when starting from the main menu.
+#
+#    Requires: show_advanced
 port (Server port) int 30000 1 65535
 
 #    The network interface that the server listens on.
+#
+#    Requires: show_advanced
 bind_address (Bind address) string
 
 #    Enable to disallow old clients from connecting.
 #    Older clients are compatible in the sense that they will not crash when connecting
 #    to new servers, but they may not support all new features that you are expecting.
+#
+#    Requires: show_advanced
 strict_protocol_version_checking (Strict protocol checking) bool false
 
 #    Specifies URL from which client fetches media instead of using UDP.
 #    $filename should be accessible from $remote_media$filename via cURL
 #    (obviously, remote_media should end with a slash).
 #    Files that are not present will be fetched the usual way.
+#
+#    Requires: show_advanced
 remote_media (Remote media) string
 
 #    Enable/disable running an IPv6 server.
 #    Ignored if bind_address is set.
 #    Needs enable_ipv6 to be enabled.
+#
+#    Requires: show_advanced
 ipv6_server (IPv6 server) bool false
 
 [*Server Security]
 
 #    New users need to input this password.
+#
+#    Requires: show_advanced
 default_password (Default password) string
 
 #    If enabled, players cannot join without a password or change theirs to an empty password.
+#
+#    Requires: show_advanced
 disallow_empty_password (Disallow empty passwords) bool false
 
 #    The privileges that new users automatically get.
 #    See /privs in game for a full list on your server and mod configuration.
+#
+#    Requires: show_advanced
 default_privs (Default privileges) string interact, shout
 
 #    Privileges that players with basic_privs can grant
+#
+#    Requires: show_advanced
 basic_privs (Basic privileges) string interact, shout
 
 #    If enabled, disable cheat prevention in multiplayer.
+#
+#    Requires: show_advanced
 disable_anticheat (Disable anticheat) bool false
 
 #    If enabled, actions are recorded for rollback.
 #    This option is only read when server starts.
+#
+#    Requires: show_advanced
 enable_rollback_recording (Rollback recording) bool false
 
 [**Client-side Modding]
@@ -845,25 +993,37 @@ enable_rollback_recording (Rollback recording) bool false
 #    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to
 #    csm_restriction_noderange)
 #    READ_PLAYERINFO: 32 (disable get_player_names call client-side)
+#
+#    Requires: show_advanced
 csm_restriction_flags (Client side modding restrictions) int 62 0 63
 
 #   If the CSM restriction for node range is enabled, get_node calls are limited
 #   to this distance from the player to the node.
+#
+#    Requires: show_advanced
 csm_restriction_noderange (Client side node lookup range restriction) int 0 0 4294967295
 
 [**Chat]
 
 #    Remove color codes from incoming chat messages
 #    Use this to stop players from being able to use color in their messages
+#
+#    Requires: show_advanced
 strip_color_codes (Strip color codes) bool false
 
 #    Set the maximum length of a chat message (in characters) sent by clients.
+#
+#    Requires: show_advanced
 chat_message_max_size (Chat message max length) int 500 10 65535
 
 #    Amount of messages a player may send per 10 seconds.
+#
+#    Requires: show_advanced
 chat_message_limit_per_10sec (Chat message count limit) float 8.0 1.0
 
 #    Kick players who sent more than X messages per 10 seconds.
+#
+#    Requires: show_advanced
 chat_message_limit_trigger_kick (Chat message kick threshold) int 50 1 65535
 
 [*Server Gameplay]
@@ -933,112 +1093,174 @@ movement_gravity (Gravity) float 9.81
 
 #    A chosen map seed for a new map, leave empty for random.
 #    Will be overridden when creating a new world in the main menu.
+#
+#    Requires: show_advanced
 fixed_map_seed (Fixed map seed) string
 
 #    Name of map generator to be used when creating a new world.
 #    Creating a world in the main menu will override this.
 #    Current mapgens in a highly unstable state:
 #    -    The optional floatlands of v7 (disabled by default).
+#
+#    Requires: show_advanced
 mg_name (Mapgen name) enum v7 v7,valleys,carpathian,v5,flat,fractal,singlenode,v6
 
 #    Water surface level of the world.
+#
+#    Requires: show_advanced
 water_level (Water level) int 1 -31000 31000
 
 #    From how far blocks are generated for clients, stated in mapblocks (16 nodes).
+#
+#    Requires: show_advanced
 max_block_generate_distance (Max block generate distance) int 10 1 32767
 
 #    Limit of map generation, in nodes, in all 6 directions from (0, 0, 0).
 #    Only mapchunks completely within the mapgen limit are generated.
 #    Value is stored per-world.
+#
+#    Requires: show_advanced
 mapgen_limit (Map generation limit) int 31007 0 31007
 
 #    Global map generation attributes.
 #    In Mapgen v6 the 'decorations' flag controls all decorations except trees
 #    and jungle grass, in all other mapgens this flag controls all decorations.
+#
+#    Requires: show_advanced
 mg_flags (Mapgen flags) flags caves,dungeons,light,decorations,biomes,ores caves,dungeons,light,decorations,biomes,ores,nocaves,nodungeons,nolight,nodecorations,nobiomes,noores
 
 [*Biome API noise parameters]
 
 #    Temperature variation for biomes.
+#
+#    Requires: show_advanced
 mg_biome_np_heat (Heat noise) noise_params_2d 50, 50, (1000, 1000, 1000), 5349, 3, 0.5, 2.0, eased
 
 #    Small-scale temperature variation for blending biomes on borders.
+#
+#    Requires: show_advanced
 mg_biome_np_heat_blend (Heat blend noise) noise_params_2d 0, 1.5, (8, 8, 8), 13, 2, 1.0, 2.0, eased
 
 #    Humidity variation for biomes.
+#
+#    Requires: show_advanced
 mg_biome_np_humidity (Humidity noise) noise_params_2d 50, 50, (1000, 1000, 1000), 842, 3, 0.5, 2.0, eased
 
 #    Small-scale humidity variation for blending biomes on borders.
+#
+#    Requires: show_advanced
 mg_biome_np_humidity_blend (Humidity blend noise) noise_params_2d 0, 1.5, (8, 8, 8), 90003, 2, 1.0, 2.0, eased
 
 [*Mapgen V5]
 
 #    Map generation attributes specific to Mapgen v5.
+#
+#    Requires: show_advanced
 mgv5_spflags (Mapgen V5 specific flags) flags caverns caverns,nocaverns
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
 #    intensive noise calculations.
+#
+#    Requires: show_advanced
 mgv5_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
+#
+#    Requires: show_advanced
 mgv5_large_cave_depth (Large cave depth) int -256 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
+#
+#    Requires: show_advanced
 mgv5_small_cave_num_min (Small cave minimum number) int 0 0 256
 
 #    Maximum limit of random number of small caves per mapchunk.
+#
+#    Requires: show_advanced
 mgv5_small_cave_num_max (Small cave maximum number) int 0 0 256
 
 #    Minimum limit of random number of large caves per mapchunk.
+#
+#    Requires: show_advanced
 mgv5_large_cave_num_min (Large cave minimum number) int 0 0 64
 
 #    Maximum limit of random number of large caves per mapchunk.
+#
+#    Requires: show_advanced
 mgv5_large_cave_num_max (Large cave maximum number) int 2 0 64
 
 #    Proportion of large caves that contain liquid.
+#
+#    Requires: show_advanced
 mgv5_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Y-level of cavern upper limit.
+#
+#    Requires: show_advanced
 mgv5_cavern_limit (Cavern limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
+#
+#    Requires: show_advanced
 mgv5_cavern_taper (Cavern taper) int 256 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
+#
+#    Requires: show_advanced
 mgv5_cavern_threshold (Cavern threshold) float 0.7
 
 #    Lower Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgv5_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgv5_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
 #    Variation of biome filler depth.
+#
+#    Requires: show_advanced
 mgv5_np_filler_depth (Filler depth noise) noise_params_2d 0, 1, (150, 150, 150), 261, 4, 0.7, 2.0, eased
 
 #    Variation of terrain vertical scale.
 #    When noise is < -0.55 terrain is near-flat.
+#
+#    Requires: show_advanced
 mgv5_np_factor (Factor noise) noise_params_2d 0, 1, (250, 250, 250), 920381, 3, 0.45, 2.0, eased
 
 #    Y-level of average terrain surface.
+#
+#    Requires: show_advanced
 mgv5_np_height (Height noise) noise_params_2d 0, 10, (250, 250, 250), 84174, 4, 0.5, 2.0, eased
 
 #    First of two 3D noises that together define tunnels.
+#
+#    Requires: show_advanced
 mgv5_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
 
 #    Second of two 3D noises that together define tunnels.
+#
+#    Requires: show_advanced
 mgv5_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
 
 #    3D noise defining giant caverns.
+#
+#    Requires: show_advanced
 mgv5_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
 
 #    3D noise defining terrain.
+#
+#    Requires: show_advanced
 mgv5_np_ground (Ground noise) noise_params_3d 0, 40, (80, 80, 80), 983240, 4, 0.55, 2.0, eased
 
 #    3D noise that determines number of dungeons per mapchunk.
+#
+#    Requires: show_advanced
 mgv5_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
 
 [*Mapgen V6]
@@ -1047,54 +1269,86 @@ mgv5_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2
 #    The 'snowbiomes' flag enables the new 5 biome system.
 #    When the 'snowbiomes' flag is enabled jungles are automatically enabled and
 #    the 'jungles' flag is ignored.
+#
+#    Requires: show_advanced
 mgv6_spflags (Mapgen V6 specific flags) flags jungles,biomeblend,mudflow,snowbiomes,noflat,trees jungles,biomeblend,mudflow,snowbiomes,flat,trees,nojungles,nobiomeblend,nomudflow,nosnowbiomes,noflat,notrees
 
 #    Deserts occur when np_biome exceeds this value.
 #    When the 'snowbiomes' flag is enabled, this is ignored.
+#
+#    Requires: show_advanced
 mgv6_freq_desert (Desert noise threshold) float 0.45
 
 #    Sandy beaches occur when np_beach exceeds this value.
+#
+#    Requires: show_advanced
 mgv6_freq_beach (Beach noise threshold) float 0.15
 
 #    Lower Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgv6_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgv6_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
 #    Y-level of lower terrain and seabed.
+#
+#    Requires: show_advanced
 mgv6_np_terrain_base (Terrain base noise) noise_params_2d -4, 20, (250, 250, 250), 82341, 5, 0.6, 2.0, eased
 
 #    Y-level of higher terrain that creates cliffs.
+#
+#    Requires: show_advanced
 mgv6_np_terrain_higher (Terrain higher noise) noise_params_2d 20, 16, (500, 500, 500), 85039, 5, 0.6, 2.0, eased
 
 #    Varies steepness of cliffs.
+#
+#    Requires: show_advanced
 mgv6_np_steepness (Steepness noise) noise_params_2d 0.85, 0.5, (125, 125, 125), -932, 5, 0.7, 2.0, eased
 
 #    Defines distribution of higher terrain.
+#
+#    Requires: show_advanced
 mgv6_np_height_select (Height select noise) noise_params_2d 0.5, 1, (250, 250, 250), 4213, 5, 0.69, 2.0, eased
 
 #    Varies depth of biome surface nodes.
+#
+#    Requires: show_advanced
 mgv6_np_mud (Mud noise) noise_params_2d 4, 2, (200, 200, 200), 91013, 3, 0.55, 2.0, eased
 
 #    Defines areas with sandy beaches.
+#
+#    Requires: show_advanced
 mgv6_np_beach (Beach noise) noise_params_2d 0, 1, (250, 250, 250), 59420, 3, 0.50, 2.0, eased
 
 #    Temperature variation for biomes.
+#
+#    Requires: show_advanced
 mgv6_np_biome (Biome noise) noise_params_2d 0, 1, (500, 500, 500), 9130, 3, 0.50, 2.0, eased
 
 #    Variation of number of caves.
+#
+#    Requires: show_advanced
 mgv6_np_cave (Cave noise) noise_params_2d 6, 6, (250, 250, 250), 34329, 3, 0.50, 2.0, eased
 
 #    Humidity variation for biomes.
+#
+#    Requires: show_advanced
 mgv6_np_humidity (Humidity noise) noise_params_2d 0.5, 0.5, (500, 500, 500), 72384, 3, 0.50, 2.0, eased
 
 #    Defines tree areas and tree density.
+#
+#    Requires: show_advanced
 mgv6_np_trees (Trees noise) noise_params_2d 0, 1, (125, 125, 125), 2, 4, 0.66, 2.0, eased
 
 #    Defines areas where trees have apples.
+#
+#    Requires: show_advanced
 mgv6_np_apple_trees (Apple trees noise) noise_params_2d 0, 1, (100, 100, 100), 342902, 3, 0.45, 2.0, eased
 
 [*Mapgen V7]
@@ -1103,21 +1357,31 @@ mgv6_np_apple_trees (Apple trees noise) noise_params_2d 0, 1, (100, 100, 100), 3
 #    'ridges': Rivers.
 #    'floatlands': Floating land masses in the atmosphere.
 #    'caverns': Giant caves deep underground.
+#
+#    Requires: show_advanced
 mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,caverns mountains,ridges,floatlands,caverns,nomountains,noridges,nofloatlands,nocaverns
 
 #    Y of mountain density gradient zero level. Used to shift mountains vertically.
+#
+#    Requires: show_advanced
 mgv7_mount_zero_level (Mountain zero level) int 0 -31000 31000
 
 #    Lower Y limit of floatlands.
+#
+#    Requires: show_advanced
 mgv7_floatland_ymin (Floatland minimum Y) int 1024 -31000 31000
 
 #    Upper Y limit of floatlands.
+#
+#    Requires: show_advanced
 mgv7_floatland_ymax (Floatland maximum Y) int 4096 -31000 31000
 
 #    Y-distance over which floatlands taper from full density to nothing.
 #    Tapering starts at this distance from the Y limit.
 #    For a solid floatland layer, this controls the height of hills/mountains.
 #    Must be less than or equal to half the distance between the Y limits.
+#
+#    Requires: show_advanced
 mgv7_floatland_taper (Floatland tapering distance) int 256 0 32767
 
 #    Exponent of the floatland tapering. Alters the tapering behavior.
@@ -1126,6 +1390,8 @@ mgv7_floatland_taper (Floatland tapering distance) int 256 0 32767
 #    floatlands.
 #    Values < 1.0 (for example 0.25) create a more defined surface level with
 #    flatter lowlands, suitable for a solid floatland layer.
+#
+#    Requires: show_advanced
 mgv7_float_taper_exp (Floatland taper exponent) float 2.0
 
 #    Adjusts the density of the floatland layer.
@@ -1133,6 +1399,8 @@ mgv7_float_taper_exp (Floatland taper exponent) float 2.0
 #    Value = 0.0: 50% of volume is floatland.
 #    Value = 2.0 (can be higher depending on 'mgv7_np_floatland', always test
 #    to be sure) creates a solid floatland layer.
+#
+#    Requires: show_advanced
 mgv7_floatland_density (Floatland density) float -0.6
 
 #    Surface level of optional water placed on a solid floatland layer.
@@ -1145,284 +1413,454 @@ mgv7_floatland_density (Floatland density) float -0.6
 #    required value depending on 'mgv7_np_floatland'), to avoid
 #    server-intensive extreme water flow and to avoid vast flooding of the
 #    world surface below.
+#
+#    Requires: show_advanced
 mgv7_floatland_ywater (Floatland water level) int -31000 -31000 31000
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
 #    intensive noise calculations.
+#
+#    Requires: show_advanced
 mgv7_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
+#
+#    Requires: show_advanced
 mgv7_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
+#
+#    Requires: show_advanced
 mgv7_small_cave_num_min (Small cave minimum number) int 0 0 256
 
 #    Maximum limit of random number of small caves per mapchunk.
+#
+#    Requires: show_advanced
 mgv7_small_cave_num_max (Small cave maximum number) int 0 0 256
 
 #    Minimum limit of random number of large caves per mapchunk.
+#
+#    Requires: show_advanced
 mgv7_large_cave_num_min (Large cave minimum number) int 0 0 64
 
 #    Maximum limit of random number of large caves per mapchunk.
+#
+#    Requires: show_advanced
 mgv7_large_cave_num_max (Large cave maximum number) int 2 0 64
 
 #    Proportion of large caves that contain liquid.
+#
+#    Requires: show_advanced
 mgv7_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Y-level of cavern upper limit.
+#
+#    Requires: show_advanced
 mgv7_cavern_limit (Cavern limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
+#
+#    Requires: show_advanced
 mgv7_cavern_taper (Cavern taper) int 256 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
+#
+#    Requires: show_advanced
 mgv7_cavern_threshold (Cavern threshold) float 0.7
 
 #    Lower Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgv7_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgv7_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
 #    Y-level of higher terrain that creates cliffs.
+#
+#    Requires: show_advanced
 mgv7_np_terrain_base (Terrain base noise) noise_params_2d 4, 70, (600, 600, 600), 82341, 5, 0.6, 2.0, eased
 
 #    Y-level of lower terrain and seabed.
+#
+#    Requires: show_advanced
 mgv7_np_terrain_alt (Terrain alternative noise) noise_params_2d 4, 25, (600, 600, 600), 5934, 5, 0.6, 2.0, eased
 
 #    Varies roughness of terrain.
 #    Defines the 'persistence' value for terrain_base and terrain_alt noises.
+#
+#    Requires: show_advanced
 mgv7_np_terrain_persist (Terrain persistence noise) noise_params_2d 0.6, 0.1, (2000, 2000, 2000), 539, 3, 0.6, 2.0, eased
 
 #    Defines distribution of higher terrain and steepness of cliffs.
+#
+#    Requires: show_advanced
 mgv7_np_height_select (Height select noise) noise_params_2d -8, 16, (500, 500, 500), 4213, 6, 0.7, 2.0, eased
 
 #    Variation of biome filler depth.
+#
+#    Requires: show_advanced
 mgv7_np_filler_depth (Filler depth noise) noise_params_2d 0, 1.2, (150, 150, 150), 261, 3, 0.7, 2.0, eased
 
 #    Variation of maximum mountain height (in nodes).
+#
+#    Requires: show_advanced
 mgv7_np_mount_height (Mountain height noise) noise_params_2d 256, 112, (1000, 1000, 1000), 72449, 3, 0.6, 2.0, eased
 
 #    Defines large-scale river channel structure.
+#
+#    Requires: show_advanced
 mgv7_np_ridge_uwater (Ridge underwater noise) noise_params_2d 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0, eased
 
 #    3D noise defining mountain structure and height.
 #    Also defines structure of floatland mountain terrain.
+#
+#    Requires: show_advanced
 mgv7_np_mountain (Mountain noise) noise_params_3d -0.6, 1, (250, 350, 250), 5333, 5, 0.63, 2.0
 
 #    3D noise defining structure of river canyon walls.
+#
+#    Requires: show_advanced
 mgv7_np_ridge (Ridge noise) noise_params_3d 0, 1, (100, 100, 100), 6467, 4, 0.75, 2.0
 
 #    3D noise defining structure of floatlands.
 #    If altered from the default, the noise 'scale' (0.7 by default) may need
 #    to be adjusted, as floatland tapering functions best when this noise has
 #    a value range of approximately -2.0 to 2.0.
+#
+#    Requires: show_advanced
 mgv7_np_floatland (Floatland noise) noise_params_3d 0, 0.7, (384, 96, 384), 1009, 4, 0.75, 1.618
 
 #    3D noise defining giant caverns.
+#
+#    Requires: show_advanced
 mgv7_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
 
 #    First of two 3D noises that together define tunnels.
+#
+#    Requires: show_advanced
 mgv7_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
 
 #    Second of two 3D noises that together define tunnels.
+#
+#    Requires: show_advanced
 mgv7_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
 
 #    3D noise that determines number of dungeons per mapchunk.
+#
+#    Requires: show_advanced
 mgv7_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
 
 [*Mapgen Carpathian]
 
 #    Map generation attributes specific to Mapgen Carpathian.
+#
+#    Requires: show_advanced
 mgcarpathian_spflags (Mapgen Carpathian specific flags) flags caverns,norivers caverns,rivers,nocaverns,norivers
 
 #    Defines the base ground level.
+#
+#    Requires: show_advanced
 mgcarpathian_base_level (Base ground level) float 12.0
 
 #    Defines the width of the river channel.
+#
+#    Requires: show_advanced
 mgcarpathian_river_width (River channel width) float 0.05
 
 #    Defines the depth of the river channel.
+#
+#    Requires: show_advanced
 mgcarpathian_river_depth (River channel depth) float 24.0
 
 #    Defines the width of the river valley.
+#
+#    Requires: show_advanced
 mgcarpathian_valley_width (River valley width) float 0.25
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
 #    intensive noise calculations.
+#
+#    Requires: show_advanced
 mgcarpathian_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
+#
+#    Requires: show_advanced
 mgcarpathian_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
+#
+#    Requires: show_advanced
 mgcarpathian_small_cave_num_min (Small cave minimum number) int 0 0 256
 
 #    Maximum limit of random number of small caves per mapchunk.
+#
+#    Requires: show_advanced
 mgcarpathian_small_cave_num_max (Small cave maximum number) int 0 0 256
 
 #    Minimum limit of random number of large caves per mapchunk.
+#
+#    Requires: show_advanced
 mgcarpathian_large_cave_num_min (Large cave minimum number) int 0 0 64
 
 #    Maximum limit of random number of large caves per mapchunk.
+#
+#    Requires: show_advanced
 mgcarpathian_large_cave_num_max (Large cave maximum number) int 2 0 64
 
 #    Proportion of large caves that contain liquid.
+#
+#    Requires: show_advanced
 mgcarpathian_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Y-level of cavern upper limit.
+#
+#    Requires: show_advanced
 mgcarpathian_cavern_limit (Cavern limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
+#
+#    Requires: show_advanced
 mgcarpathian_cavern_taper (Cavern taper) int 256 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
+#
+#    Requires: show_advanced
 mgcarpathian_cavern_threshold (Cavern threshold) float 0.7
 
 #    Lower Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgcarpathian_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgcarpathian_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
 #    Variation of biome filler depth.
+#
+#    Requires: show_advanced
 mgcarpathian_np_filler_depth (Filler depth noise) noise_params_2d 0, 1, (128, 128, 128), 261, 3, 0.7, 2.0, eased
 
 #    First of 4 2D noises that together define hill/mountain range height.
+#
+#    Requires: show_advanced
 mgcarpathian_np_height1 (Hilliness1 noise) noise_params_2d 0, 5, (251, 251, 251), 9613, 5, 0.5, 2.0, eased
 
 #    Second of 4 2D noises that together define hill/mountain range height.
+#
+#    Requires: show_advanced
 mgcarpathian_np_height2 (Hilliness2 noise) noise_params_2d 0, 5, (383, 383, 383), 1949, 5, 0.5, 2.0, eased
 
 #    Third of 4 2D noises that together define hill/mountain range height.
+#
+#    Requires: show_advanced
 mgcarpathian_np_height3 (Hilliness3 noise) noise_params_2d 0, 5, (509, 509, 509), 3211, 5, 0.5, 2.0, eased
 
 #    Fourth of 4 2D noises that together define hill/mountain range height.
+#
+#    Requires: show_advanced
 mgcarpathian_np_height4 (Hilliness4 noise) noise_params_2d 0, 5, (631, 631, 631), 1583, 5, 0.5, 2.0, eased
 
 #    2D noise that controls the size/occurrence of rolling hills.
+#
+#    Requires: show_advanced
 mgcarpathian_np_hills_terrain (Rolling hills spread noise) noise_params_2d 1, 1, (1301, 1301, 1301), 1692, 3, 0.5, 2.0, eased
 
 #    2D noise that controls the size/occurrence of ridged mountain ranges.
+#
+#    Requires: show_advanced
 mgcarpathian_np_ridge_terrain (Ridge mountain spread noise) noise_params_2d 1, 1, (1889, 1889, 1889), 3568, 3, 0.5, 2.0, eased
 
 #    2D noise that controls the size/occurrence of step mountain ranges.
+#
+#    Requires: show_advanced
 mgcarpathian_np_step_terrain (Step mountain spread noise) noise_params_2d 1, 1, (1889, 1889, 1889), 4157, 3, 0.5, 2.0, eased
 
 #    2D noise that controls the shape/size of rolling hills.
+#
+#    Requires: show_advanced
 mgcarpathian_np_hills (Rolling hill size noise) noise_params_2d 0, 3, (257, 257, 257), 6604, 6, 0.5, 2.0, eased
 
 #    2D noise that controls the shape/size of ridged mountains.
+#
+#    Requires: show_advanced
 mgcarpathian_np_ridge_mnt (Ridged mountain size noise) noise_params_2d 0, 12, (743, 743, 743), 5520, 6, 0.7, 2.0, eased
 
 #    2D noise that controls the shape/size of step mountains.
+#
+#    Requires: show_advanced
 mgcarpathian_np_step_mnt (Step mountain size noise) noise_params_2d 0, 8, (509, 509, 509), 2590, 6, 0.6, 2.0, eased
 
 #    2D noise that locates the river valleys and channels.
+#
+#    Requires: show_advanced
 mgcarpathian_np_rivers (River noise) noise_params_2d 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0, eased
 
 #    3D noise for mountain overhangs, cliffs, etc. Usually small variations.
+#
+#    Requires: show_advanced
 mgcarpathian_np_mnt_var (Mountain variation noise) noise_params_3d 0, 1, (499, 499, 499), 2490, 5, 0.55, 2.0
 
 #    First of two 3D noises that together define tunnels.
+#
+#    Requires: show_advanced
 mgcarpathian_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
 
 #    Second of two 3D noises that together define tunnels.
+#
+#    Requires: show_advanced
 mgcarpathian_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
 
 #    3D noise defining giant caverns.
+#
+#    Requires: show_advanced
 mgcarpathian_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
 
 #    3D noise that determines number of dungeons per mapchunk.
+#
+#    Requires: show_advanced
 mgcarpathian_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
 
 [*Mapgen Flat]
 
 #    Map generation attributes specific to Mapgen Flat.
 #    Occasional lakes and hills can be added to the flat world.
+#
+#    Requires: show_advanced
 mgflat_spflags (Mapgen Flat specific flags) flags nolakes,nohills,nocaverns lakes,hills,caverns,nolakes,nohills,nocaverns
 
 #    Y of flat ground.
+#
+#    Requires: show_advanced
 mgflat_ground_level (Ground level) int 8 -31000 31000
 
 #    Y of upper limit of large caves.
+#
+#    Requires: show_advanced
 mgflat_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
+#
+#    Requires: show_advanced
 mgflat_small_cave_num_min (Small cave minimum number) int 0 0 256
 
 #    Maximum limit of random number of small caves per mapchunk.
+#
+#    Requires: show_advanced
 mgflat_small_cave_num_max (Small cave maximum number) int 0 0 256
 
 #    Minimum limit of random number of large caves per mapchunk.
+#
+#    Requires: show_advanced
 mgflat_large_cave_num_min (Large cave minimum number) int 0 0 64
 
 #    Maximum limit of random number of large caves per mapchunk.
+#
+#    Requires: show_advanced
 mgflat_large_cave_num_max (Large cave maximum number) int 2 0 64
 
 #    Proportion of large caves that contain liquid.
+#
+#    Requires: show_advanced
 mgflat_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
 #    intensive noise calculations.
+#
+#    Requires: show_advanced
 mgflat_cave_width (Cave width) float 0.09
 
 #    Terrain noise threshold for lakes.
 #    Controls proportion of world area covered by lakes.
 #    Adjust towards 0.0 for a larger proportion.
+#
+#    Requires: show_advanced
 mgflat_lake_threshold (Lake threshold) float -0.45
 
 #    Controls steepness/depth of lake depressions.
+#
+#    Requires: show_advanced
 mgflat_lake_steepness (Lake steepness) float 48.0
 
 #    Terrain noise threshold for hills.
 #    Controls proportion of world area covered by hills.
 #    Adjust towards 0.0 for a larger proportion.
+#
+#    Requires: show_advanced
 mgflat_hill_threshold (Hill threshold) float 0.45
 
 #    Controls steepness/height of hills.
+#
+#    Requires: show_advanced
 mgflat_hill_steepness (Hill steepness) float 64.0
 
 #    Y-level of cavern upper limit.
+#
+#    Requires: show_advanced
 mgflat_cavern_limit (Cavern limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
+#
+#    Requires: show_advanced
 mgflat_cavern_taper (Cavern taper) int 256 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
+#
+#    Requires: show_advanced
 mgflat_cavern_threshold (Cavern threshold) float 0.7
 
 #    Lower Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgflat_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgflat_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 [**Noises]
 
 #    Defines location and terrain of optional hills and lakes.
+#
+#    Requires: show_advanced
 mgflat_np_terrain (Terrain noise) noise_params_2d 0, 1, (600, 600, 600), 7244, 5, 0.6, 2.0, eased
 
 #    Variation of biome filler depth.
+#
+#    Requires: show_advanced
 mgflat_np_filler_depth (Filler depth noise) noise_params_2d 0, 1.2, (150, 150, 150), 261, 3, 0.7, 2.0, eased
 
 #    First of two 3D noises that together define tunnels.
+#
+#    Requires: show_advanced
 mgflat_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
 
 #    Second of two 3D noises that together define tunnels.
+#
+#    Requires: show_advanced
 mgflat_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
 
 #    3D noise defining giant caverns.
+#
+#    Requires: show_advanced
 mgflat_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
 
 #    3D noise that determines number of dungeons per mapchunk.
+#
+#    Requires: show_advanced
 mgflat_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
 
 [*Mapgen Fractal]
@@ -1430,35 +1868,55 @@ mgflat_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0,
 #    Map generation attributes specific to Mapgen Fractal.
 #    'terrain' enables the generation of non-fractal terrain:
 #    ocean, islands and underground.
+#
+#    Requires: show_advanced
 mgfractal_spflags (Mapgen Fractal specific flags) flags terrain terrain,noterrain
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
 #    intensive noise calculations.
+#
+#    Requires: show_advanced
 mgfractal_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
+#
+#    Requires: show_advanced
 mgfractal_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
+#
+#    Requires: show_advanced
 mgfractal_small_cave_num_min (Small cave minimum number) int 0 0 256
 
 #    Maximum limit of random number of small caves per mapchunk.
+#
+#    Requires: show_advanced
 mgfractal_small_cave_num_max (Small cave maximum number) int 0 0 256
 
 #    Minimum limit of random number of large caves per mapchunk.
+#
+#    Requires: show_advanced
 mgfractal_large_cave_num_min (Large cave minimum number) int 0 0 64
 
 #    Maximum limit of random number of large caves per mapchunk.
+#
+#    Requires: show_advanced
 mgfractal_large_cave_num_max (Large cave maximum number) int 2 0 64
 
 #    Proportion of large caves that contain liquid.
+#
+#    Requires: show_advanced
 mgfractal_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Lower Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgfractal_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgfractal_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 
 #    Selects one of 18 fractal types.
@@ -1480,12 +1938,16 @@ mgfractal_dungeon_ymax (Dungeon maximum Y) int 31000 -31000 31000
 #    16 = 3D "Cosine Mandelbulb" Julia set.
 #    17 = 4D "Mandelbulb" Mandelbrot set.
 #    18 = 4D "Mandelbulb" Julia set.
+#
+#    Requires: show_advanced
 mgfractal_fractal (Fractal type) int 1 1 18
 
 #    Iterations of the recursive function.
 #    Increasing this increases the amount of fine detail, but also
 #    increases processing load.
 #    At iterations = 20 this mapgen has a similar load to mapgen V7.
+#
+#    Requires: show_advanced
 mgfractal_iterations (Iterations) int 11 1 65535
 
 #    (X,Y,Z) scale of fractal in nodes.
@@ -1495,6 +1957,8 @@ mgfractal_iterations (Iterations) int 11 1 65535
 #    Increase these to 'zoom' into the detail of the fractal.
 #    Default is for a vertically-squashed shape suitable for
 #    an island, set all 3 numbers equal for the raw shape.
+#
+#    Requires: show_advanced
 mgfractal_scale (Scale) v3f (4096.0, 1024.0, 4096.0)
 
 #    (X,Y,Z) offset of fractal from world center in units of 'scale'.
@@ -1505,6 +1969,8 @@ mgfractal_scale (Scale) v3f (4096.0, 1024.0, 4096.0)
 #    sets with default parameters, it may need altering in other
 #    situations.
 #    Range roughly -2 to 2. Multiply by 'scale' for offset in nodes.
+#
+#    Requires: show_advanced
 mgfractal_offset (Offset) v3f (1.79, 0.0, 0.0)
 
 #    W coordinate of the generated 3D slice of a 4D fractal.
@@ -1512,24 +1978,32 @@ mgfractal_offset (Offset) v3f (1.79, 0.0, 0.0)
 #    Alters the shape of the fractal.
 #    Has no effect on 3D fractals.
 #    Range roughly -2 to 2.
+#
+#    Requires: show_advanced
 mgfractal_slice_w (Slice w) float 0.0
 
 #    Julia set only.
 #    X component of hypercomplex constant.
 #    Alters the shape of the fractal.
 #    Range roughly -2 to 2.
+#
+#    Requires: show_advanced
 mgfractal_julia_x (Julia x) float 0.33
 
 #    Julia set only.
 #    Y component of hypercomplex constant.
 #    Alters the shape of the fractal.
 #    Range roughly -2 to 2.
+#
+#    Requires: show_advanced
 mgfractal_julia_y (Julia y) float 0.33
 
 #    Julia set only.
 #    Z component of hypercomplex constant.
 #    Alters the shape of the fractal.
 #    Range roughly -2 to 2.
+#
+#    Requires: show_advanced
 mgfractal_julia_z (Julia z) float 0.33
 
 #    Julia set only.
@@ -1537,23 +2011,35 @@ mgfractal_julia_z (Julia z) float 0.33
 #    Alters the shape of the fractal.
 #    Has no effect on 3D fractals.
 #    Range roughly -2 to 2.
+#
+#    Requires: show_advanced
 mgfractal_julia_w (Julia w) float 0.33
 
 [**Noises]
 
 #    Y-level of seabed.
+#
+#    Requires: show_advanced
 mgfractal_np_seabed (Seabed noise) noise_params_2d -14, 9, (600, 600, 600), 41900, 5, 0.6, 2.0, eased
 
 #    Variation of biome filler depth.
+#
+#    Requires: show_advanced
 mgfractal_np_filler_depth (Filler depth noise) noise_params_2d 0, 1.2, (150, 150, 150), 261, 3, 0.7, 2.0, eased
 
 #    First of two 3D noises that together define tunnels.
+#
+#    Requires: show_advanced
 mgfractal_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
 
 #    Second of two 3D noises that together define tunnels.
+#
+#    Requires: show_advanced
 mgfractal_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
 
 #    3D noise that determines number of dungeons per mapchunk.
+#
+#    Requires: show_advanced
 mgfractal_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
 
 [*Mapgen Valleys]
@@ -1564,107 +2050,154 @@ mgfractal_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500),
 #    'vary_river_depth': If enabled, low humidity and high heat causes rivers
 #    to become shallower and occasionally dry.
 #    'altitude_dry': Reduces humidity with altitude.
+#
+#    Requires: show_advanced
 mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_rivers,vary_river_depth,altitude_dry altitude_chill,humid_rivers,vary_river_depth,altitude_dry,noaltitude_chill,nohumid_rivers,novary_river_depth,noaltitude_dry
 
 #    The vertical distance over which heat drops by 20 if 'altitude_chill' is
 #    enabled. Also the vertical distance over which humidity drops by 10 if
 #    'altitude_dry' is enabled.
+#
+#    Requires: show_advanced
 mgvalleys_altitude_chill (Altitude chill) int 90 0 65535
 
 #    Depth below which you'll find large caves.
+#
+#    Requires: show_advanced
 mgvalleys_large_cave_depth (Large cave depth) int -33 -31000 31000
 
 #    Minimum limit of random number of small caves per mapchunk.
+#
+#    Requires: show_advanced
 mgvalleys_small_cave_num_min (Small cave minimum number) int 0 0 256
 
 #    Maximum limit of random number of small caves per mapchunk.
+#
+#    Requires: show_advanced
 mgvalleys_small_cave_num_max (Small cave maximum number) int 0 0 256
 
 #    Minimum limit of random number of large caves per mapchunk.
+#
+#    Requires: show_advanced
 mgvalleys_large_cave_num_min (Large cave minimum number) int 0 0 64
 
 #    Maximum limit of random number of large caves per mapchunk.
+#
+#    Requires: show_advanced
 mgvalleys_large_cave_num_max (Large cave maximum number) int 2 0 64
 
 #    Proportion of large caves that contain liquid.
+#
+#    Requires: show_advanced
 mgvalleys_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Depth below which you'll find giant caverns.
+#
+#    Requires: show_advanced
 mgvalleys_cavern_limit (Cavern upper limit) int -256 -31000 31000
 
 #    Y-distance over which caverns expand to full size.
+#
+#    Requires: show_advanced
 mgvalleys_cavern_taper (Cavern taper) int 192 0 32767
 
 #    Defines full size of caverns, smaller values create larger caverns.
+#
+#    Requires: show_advanced
 mgvalleys_cavern_threshold (Cavern threshold) float 0.6
 
 #    How deep to make rivers.
+#
+#    Requires: show_advanced
 mgvalleys_river_depth (River depth) int 4 0 65535
 
 #    How wide to make rivers.
+#
+#    Requires: show_advanced
 mgvalleys_river_size (River size) int 5 0 65535
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
 #    intensive noise calculations.
+#
+#    Requires: show_advanced
 mgvalleys_cave_width (Cave width) float 0.09
 
 #    Lower Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgvalleys_dungeon_ymin (Dungeon minimum Y) int -31000 -31000 31000
 
 #    Upper Y limit of dungeons.
+#
+#    Requires: show_advanced
 mgvalleys_dungeon_ymax (Dungeon maximum Y) int 63 -31000 31000
 
 [**Noises]
 
 #    First of two 3D noises that together define tunnels.
+#
+#    Requires: show_advanced
 mgvalleys_np_cave1 (Cave noise #1) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
 
 #    Second of two 3D noises that together define tunnels.
+#
+#    Requires: show_advanced
 mgvalleys_np_cave2 (Cave noise #2) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
 
 #    The depth of dirt or other biome filler node.
+#
+#    Requires: show_advanced
 mgvalleys_np_filler_depth (Filler depth) noise_params_2d 0, 1.2, (256, 256, 256), 1605, 3, 0.5, 2.0, eased
 
 #    3D noise defining giant caverns.
+#
+#    Requires: show_advanced
 mgvalleys_np_cavern (Cavern noise) noise_params_3d 0, 1, (768, 256, 768), 59033, 6, 0.63, 2.0
 
 #    Defines large-scale river channel structure.
+#
+#    Requires: show_advanced
 mgvalleys_np_rivers (River noise) noise_params_2d 0, 1, (256, 256, 256), -6050, 5, 0.6, 2.0, eased
 
 #    Base terrain height.
+#
+#    Requires: show_advanced
 mgvalleys_np_terrain_height (Terrain height) noise_params_2d -10, 50, (1024, 1024, 1024), 5202, 6, 0.4, 2.0, eased
 
 #    Raises terrain to make valleys around the rivers.
+#
+#    Requires: show_advanced
 mgvalleys_np_valley_depth (Valley depth) noise_params_2d 5, 4, (512, 512, 512), -1914, 1, 1.0, 2.0, eased
 
 #    Slope and fill work together to modify the heights.
+#
+#    Requires: show_advanced
 mgvalleys_np_inter_valley_fill (Valley fill) noise_params_3d 0, 1, (256, 512, 256), 1993, 6, 0.8, 2.0
 
 #    Amplifies the valleys.
+#
+#    Requires: show_advanced
 mgvalleys_np_valley_profile (Valley profile) noise_params_2d 0.6, 0.5, (512, 512, 512), 777, 1, 1.0, 2.0, eased
 
 #    Slope and fill work together to modify the heights.
+#
+#    Requires: show_advanced
 mgvalleys_np_inter_valley_slope (Valley slope) noise_params_2d 0.5, 0.5, (128, 128, 128), 746, 1, 1.0, 2.0, eased
 
 #    3D noise that determines number of dungeons per mapchunk.
+#
+#    Requires: show_advanced
 mgvalleys_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
 
 
 [Advanced]
 
-[*Developer Options]
-
-#    Enable Lua modding support on client.
-#    This support is experimental and API can change.
-enable_client_modding (Client modding) bool false
-
-#    Replaces the default main menu with a custom one.
-main_menu_script (Main menu script) string
-
-[**Mod Security]
+[*Mod Security]
 
 #    Prevent mods from doing insecure things like running shell commands.
+#
+#    Requires: show_advanced
 secure.enable_security (Enable mod security) bool true
 
 #    Comma-separated list of trusted mods that are allowed to access insecure
@@ -1674,6 +2207,19 @@ secure.trusted_mods (Trusted mods) string
 #    Comma-separated list of mods that are allowed to access HTTP APIs, which
 #    allow them to upload and download data to/from the internet.
 secure.http_mods (HTTP mods) string
+
+[*Developer Options]
+
+#    Enable Lua modding support on client.
+#    This support is experimental and API can change.
+#
+#    Requires: show_advanced
+enable_client_modding (Client modding) bool false
+
+#    Replaces the default main menu with a custom one.
+#
+#    Requires: show_advanced
+main_menu_script (Main menu script) string
 
 [**Debugging]
 
@@ -1686,27 +2232,39 @@ secure.http_mods (HTTP mods) string
 #    -    info
 #    -    verbose
 #    -    trace
+#
+#    Requires: show_advanced
 debug_log_level (Debug log level) enum action ,none,error,warning,action,info,verbose,trace
 
 #    If the file size of debug.txt exceeds the number of megabytes specified in
 #    this setting when it is opened, the file is moved to debug.txt.1,
 #    deleting an older debug.txt.1 if it exists.
 #    debug.txt is only moved if this setting is positive.
+#
+#    Requires: show_advanced
 debug_log_size_max (Debug log file size threshold) int 50 1
 
 #    Minimal level of logging to be written to chat.
+#
+#    Requires: show_advanced
 chat_log_level (Chat log level) enum error ,none,error,warning,action,info,verbose,trace
 
 #    Handling for deprecated Lua API calls:
 #    -    none: Do not log deprecated calls
 #    -    log: mimic and log backtrace of deprecated call (default).
 #    -    error: abort on usage of deprecated call (suggested for mod developers).
+#
+#    Requires: show_advanced
 deprecated_lua_api_handling (Deprecated Lua API handling) enum log none,log,error
 
 #    Enable random user input (only used for testing).
+#
+#    Requires: show_advanced
 random_input (Random input) bool false
 
 #    Enable mod channels support.
+#
+#    Requires: show_advanced
 enable_mod_channels (Mod channels) bool false
 
 [**Mod Profiler]
@@ -1714,45 +2272,67 @@ enable_mod_channels (Mod channels) bool false
 #    Load the game profiler to collect game profiling data.
 #    Provides a /profiler command to access the compiled profile.
 #    Useful for mod developers and server operators.
+#
+#    Requires: show_advanced
 profiler.load (Load the game profiler) bool false
 
 #    The default format in which profiles are being saved,
 #    when calling `/profiler save [format]` without format.
+#
+#    Requires: show_advanced
 profiler.default_report_format (Default report format) enum txt txt,csv,lua,json,json_pretty
 
 #    The file path relative to your worldpath in which profiles will be saved to.
+#
+#    Requires: show_advanced
 profiler.report_path (Report path) string ""
 
 #    Instrument the methods of entities on registration.
+#
+#    Requires: show_advanced
 instrument.entity (Entity methods) bool true
 
 #    Instrument the action function of Active Block Modifiers on registration.
+#
+#    Requires: show_advanced
 instrument.abm (Active Block Modifiers) bool true
 
 #    Instrument the action function of Loading Block Modifiers on registration.
+#
+#    Requires: show_advanced
 instrument.lbm (Loading Block Modifiers) bool true
 
 #    Instrument chat commands on registration.
+#
+#    Requires: show_advanced
 instrument.chatcommand (Chat commands) bool true
 
 #    Instrument global callback functions on registration.
 #    (anything you pass to a minetest.register_*() function)
+#
+#    Requires: show_advanced
 instrument.global_callback (Global callbacks) bool true
 
 #    Instrument builtin.
 #    This is usually only needed by core/builtin contributors
+#
+#    Requires: show_advanced
 instrument.builtin (Builtin) bool false
 
 #    Have the profiler instrument itself:
 #     * Instrument an empty function.
 #       This estimates the overhead, that instrumentation is adding (+1 function call).
 #     * Instrument the sampler being used to update the statistics.
+#
+#    Requires: show_advanced
 instrument.profiler (Profiler) bool false
 
 [**Engine profiler]
 
 #    Print the engine's profiling data in regular intervals (in seconds).
 #    0 = disable. Useful for developers.
+#
+#    Requires: show_advanced
 profiler_print_interval (Engine profiling data print interval) int 0 0
 
 
@@ -1760,59 +2340,83 @@ profiler_print_interval (Engine profiling data print interval) int 0 0
 
 #    Enable IPv6 support (for both client and server).
 #    Required for IPv6 connections to work at all.
+#
+#    Requires: show_advanced
 enable_ipv6 (IPv6) bool true
 
 #    If enabled, invalid world data won't cause the server to shut down.
 #    Only enable this if you know what you are doing.
+#
+#    Requires: show_advanced
 ignore_world_load_errors (Ignore world errors) bool false
 
 [**Graphics]
 
 #    Path to shader directory. If no path is defined, default location will be used.
 #
-#    Requires: shaders
+#    Requires: show_advanced, shaders
 shader_path (Shader path) path
 
 #    The rendering back-end.
 #    Note: A restart is required after changing this!
 #    OpenGL is the default for desktop, and OGLES2 for Android.
 #    Shaders are supported by OpenGL and OGLES2 (experimental).
+#
+#    Requires: show_advanced
 video_driver (Video driver) enum  ,opengl,ogles1,ogles2
 
 #    Distance in nodes at which transparency depth sorting is enabled
 #    Use this to limit the performance impact of transparency depth sorting
+#
+#    Requires: show_advanced
 transparency_sorting_distance (Transparency Sorting Distance) int 16 0 128
 
 #    Enable vertex buffer objects.
 #    This should greatly improve graphics performance.
+#
+#    Requires: show_advanced
 enable_vbo (VBO) bool true
 
 #    Radius of cloud area stated in number of 64 node cloud squares.
 #    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.
+#
+#    Requires: show_advanced
 cloud_radius (Cloud radius) int 12 1 62
 
 #    Whether node texture animations should be desynchronized per mapblock.
+#
+#    Requires: show_advanced
 desynchronize_mapblock_texture_animation (Desynchronize block animation) bool false
 
 #    Enables caching of facedir rotated meshes.
+#
+#    Requires: show_advanced
 enable_mesh_cache (Mesh cache) bool false
 
 #    Delay between mesh updates on the client in ms. Increasing this will slow
 #    down the rate of mesh updates, thus reducing jitter on slower clients.
+#
+#    Requires: show_advanced
 mesh_generation_interval (Mapblock mesh generation delay) int 0 0 50
 
 #    Number of threads to use for mesh generation.
 #    Value of 0 (default) will let Minetest autodetect the number of available threads.
+#
+#    Requires: show_advanced
 mesh_generation_threads (Mapblock mesh generation threads) int 0 0 8
 
 #    Size of the MapBlock cache of the mesh generator. Increasing this will
 #    increase the cache hit %, reducing the data being copied from the main
 #    thread, thus reducing jitter.
+#
+#    Requires: show_advanced
 meshgen_block_cache_size (Mapblock mesh generator's MapBlock cache size in MB) int 20 0 1000
 
 #    True = 256
 #    False = 128
 #    Usable to make minimap smoother on slower machines.
+#
+#    Requires: show_advanced
 minimap_double_scan_height (Minimap scan height) bool true
 
 #    Textures on a node may be aligned either to the node or to the world.
@@ -1821,6 +2425,8 @@ minimap_double_scan_height (Minimap scan height) bool true
 #    However, as this possibility is new, thus may not be used by older servers,
 #    this option allows enforcing it for certain node types. Note though that
 #    that is considered EXPERIMENTAL and may not work properly.
+#
+#    Requires: show_advanced
 world_aligned_mode (World-aligned textures mode) enum enable disable,enable,force_solid,force_nodebox
 
 #    World-aligned textures may be scaled to span several nodes. However,
@@ -1829,6 +2435,8 @@ world_aligned_mode (World-aligned textures mode) enum enable disable,enable,forc
 #    to determine the scale automatically basing on the texture size.
 #    See also texture_min_size.
 #    Warning: This option is EXPERIMENTAL!
+#
+#    Requires: show_advanced
 autoscale_mode (Autoscaling mode) enum disable disable,enable,force
 
 #    Side length of a cube of map blocks that the client will consider together
@@ -1836,80 +2444,42 @@ autoscale_mode (Autoscaling mode) enum disable disable,enable,force
 #    Larger values increase the utilization of the GPU by reducing the number of
 #    draw calls, benefiting especially high-end GPUs.
 #    Systems with a low-end GPU (or no GPU) would benefit from smaller values.
+#
+#    Requires: show_advanced
 client_mesh_chunk (Client Mesh Chunksize) int 1 1 16
-
-[**Font]
-
-font_bold (Font bold by default) bool false
-
-font_italic (Font italic by default) bool false
-
-#    Shadow offset (in pixels) of the default font. If 0, then shadow will not be drawn.
-font_shadow (Font shadow) int 1 0 65535
-
-#    Opaqueness (alpha) of the shadow behind the default font, between 0 and 255.
-font_shadow_alpha (Font shadow alpha) int 127 0 255
-
-#    Font size of the default font where 1 unit = 1 pixel at 96 DPI
-font_size (Font size) int 16 5 72
-
-#    For pixel-style fonts that do not scale well, this ensures that font sizes used
-#    with this font will always be divisible by this value, in pixels. For instance,
-#    a pixel font 16 pixels tall should have this set to 16, so it will only ever be
-#    sized 16, 32, 48, etc., so a mod requesting a size of 25 will get 32.
-font_size_divisible_by (Font size divisible by) int 1 1
-
-#    Path to the default font. Must be a TrueType font.
-#    The fallback font will be used if the font cannot be loaded.
-font_path (Regular font path) filepath fonts/Arimo-Regular.ttf
-
-font_path_bold (Bold font path) filepath fonts/Arimo-Bold.ttf
-font_path_italic (Italic font path) filepath fonts/Arimo-Italic.ttf
-font_path_bold_italic (Bold and italic font path) filepath fonts/Arimo-BoldItalic.ttf
-
-#    Font size of the monospace font where 1 unit = 1 pixel at 96 DPI
-mono_font_size (Monospace font size) int 16 5 72
-
-#    For pixel-style fonts that do not scale well, this ensures that font sizes used
-#    with this font will always be divisible by this value, in pixels. For instance,
-#    a pixel font 16 pixels tall should have this set to 16, so it will only ever be
-#    sized 16, 32, 48, etc., so a mod requesting a size of 25 will get 32.
-mono_font_size_divisible_by (Monospace font size divisible by) int 1 1
-
-#    Path to the monospace font. Must be a TrueType font.
-#    This font is used for e.g. the console and profiler screen.
-mono_font_path (Monospace font path) filepath fonts/Cousine-Regular.ttf
-
-mono_font_path_bold (Bold monospace font path) filepath fonts/Cousine-Bold.ttf
-mono_font_path_italic (Italic monospace font path) filepath fonts/Cousine-Italic.ttf
-mono_font_path_bold_italic (Bold and italic monospace font path) filepath fonts/Cousine-BoldItalic.ttf
-
-#    Path of the fallback font. Must be a TrueType font.
-#    This font will be used for certain languages or if the default font is unavailable.
-fallback_font_path (Fallback font path) filepath fonts/DroidSansFallbackFull.ttf
 
 [**Lighting]
 
 #    Gradient of light curve at minimum light level.
 #    Controls the contrast of the lowest light levels.
+#
+#    Requires: show_advanced
 lighting_alpha (Light curve low gradient) float 0.0 0.0 3.0
 
 #    Gradient of light curve at maximum light level.
 #    Controls the contrast of the highest light levels.
+#
+#    Requires: show_advanced
 lighting_beta (Light curve high gradient) float 1.5 0.0 3.0
 
 #    Strength of light curve boost.
 #    The 3 'boost' parameters define a range of the light
 #    curve that is boosted in brightness.
+#
+#    Requires: show_advanced
 lighting_boost (Light curve boost) float 0.2 0.0 0.4
 
 #    Center of light curve boost range.
 #    Where 0.0 is minimum light level, 1.0 is maximum light level.
+#
+#    Requires: show_advanced
 lighting_boost_center (Light curve boost center) float 0.5 0.0 1.0
 
 #    Spread of light curve boost range.
 #    Controls the width of the range to be boosted.
 #    Standard deviation of the light curve boost Gaussian.
+#
+#    Requires: show_advanced
 lighting_boost_spread (Light curve boost spread) float 0.2 0.0 0.4
 
 [**Networking]
@@ -1918,73 +2488,102 @@ lighting_boost_spread (Light curve boost spread) float 0.2 0.0 0.4
 #    If Minetest is compiled with ENABLE_PROMETHEUS option enabled,
 #    enable metrics listener for Prometheus on that address.
 #    Metrics can be fetched on http://127.0.0.1:30000/metrics
+#
+#    Requires: show_advanced
 prometheus_listener_address (Prometheus listener address) string 127.0.0.1:30000
 
 #    Maximum size of the out chat queue.
 #    0 to disable queueing and -1 to make the queue size unlimited.
+#
+#    Requires: show_advanced
 max_out_chat_queue_size (Maximum size of the out chat queue) int 20 -1 32767
 
 #    Timeout for client to remove unused map data from memory, in seconds.
+#
+#    Requires: show_advanced
 client_unload_unused_data_timeout (Mapblock unload timeout) float 600.0 0.0
 
 #    Maximum number of mapblocks for client to be kept in memory.
 #    Set to -1 for unlimited amount.
+#
+#    Requires: show_advanced
 client_mapblock_limit (Mapblock limit) int 7500 -1 2147483647
-
-#    Whether to show the client debug info (has the same effect as hitting F5).
-show_debug (Show debug info) bool false
 
 #    Maximum number of blocks that are simultaneously sent per client.
 #    The maximum total count is calculated dynamically:
 #    max_total = ceil((#clients + max_users) * per_client / 4)
+#
+#    Requires: show_advanced
 max_simultaneous_block_sends_per_client (Maximum simultaneous block sends per client) int 40 1 4294967295
 
 #    To reduce lag, block transfers are slowed down when a player is building something.
 #    This determines how long they are slowed down after placing or removing a node.
+#
+#    Requires: show_advanced
 full_block_send_enable_min_time_from_building (Delay in sending blocks after building) float 2.0 0.0
 
 #    Maximum number of packets sent per send step, if you have a slow connection
 #    try reducing it, but don't reduce it to a number below double of targeted
 #    client number.
+#
+#    Requires: show_advanced
 max_packets_per_iteration (Max. packets per iteration) int 1024 1 65535
 
 #    Compression level to use when sending mapblocks to the client.
 #    -1 - use default compression level
 #     0 - least compression, fastest
 #     9 - best compression, slowest
+#
+#    Requires: show_advanced
 map_compression_level_net (Map Compression Level for Network Transfer) int -1 -1 9
 
 [**Server]
 
 #    Format of player chat messages. The following strings are valid placeholders:
 #    @name, @message, @timestamp (optional)
+#
+#    Requires: show_advanced
 chat_message_format (Chat message format) string <@name> @message
 
 #    If the execution of a chat command takes longer than this specified time in
 #    seconds, add the time information to the chat command message
+#
+#    Requires: show_advanced
 chatcommand_msg_time_threshold (Chat command time message threshold) float 0.1 0.0
 
 #    A message to be displayed to all clients when the server shuts down.
+#
+#    Requires: show_advanced
 kick_msg_shutdown (Shutdown message) string Server shutting down.
 
 #    A message to be displayed to all clients when the server crashes.
+#
+#    Requires: show_advanced
 kick_msg_crash (Crash message) string This server has experienced an internal error. You will now be disconnected.
 
 #    Whether to ask clients to reconnect after a (Lua) crash.
 #    Set this to true if your server is set up to restart automatically.
+#
+#    Requires: show_advanced
 ask_reconnect_on_crash (Ask to reconnect after crash) bool false
 
 [**Server/Env Performance]
 
 #    Length of a server tick and the interval at which objects are generally updated over
 #    network, stated in seconds.
+#
+#    Requires: show_advanced
 dedicated_server_step (Dedicated server step) float 0.09 0.0
 
 #    Whether players are shown to clients without any range limit.
 #    Deprecated, use the setting player_transfer_distance instead.
+#
+#    Requires: show_advanced
 unlimited_player_transfer_distance (Unlimited player transfer distance) bool true
 
 #    Defines the maximal player transfer distance in blocks (0 = unlimited).
+#
+#    Requires: show_advanced
 player_transfer_distance (Player transfer distance) int 0 0 65535
 
 #    From how far clients know about objects, stated in mapblocks (16 nodes).
@@ -1992,6 +2591,8 @@ player_transfer_distance (Player transfer distance) int 0 0 65535
 #    Setting this larger than active_block_range will also cause the server
 #    to maintain active objects up to this distance in the direction the
 #    player is looking. (This can avoid mobs suddenly disappearing from view)
+#
+#    Requires: show_advanced
 active_object_send_range_blocks (Active object send range) int 8 1 65535
 
 #    The radius of the volume of blocks around every player that is subject to the
@@ -1999,50 +2600,78 @@ active_object_send_range_blocks (Active object send range) int 8 1 65535
 #    In active blocks objects are loaded and ABMs run.
 #    This is also the minimum range in which active objects (mobs) are maintained.
 #    This should be configured together with active_object_send_range_blocks.
+#
+#    Requires: show_advanced
 active_block_range (Active block range) int 4 1 65535
 
 #    From how far blocks are sent to clients, stated in mapblocks (16 nodes).
+#
+#    Requires: show_advanced
 max_block_send_distance (Max block send distance) int 12 1 65535
 
 #    Default maximum number of forceloaded mapblocks.
 #    Set this to -1 to disable the limit.
+#
+#    Requires: show_advanced
 max_forceloaded_blocks (Maximum forceloaded blocks) int 16 -1
 
 #    Interval of sending time of day to clients, stated in seconds.
+#
+#    Requires: show_advanced
 time_send_interval (Time send interval) float 5.0 0.001
 
 #    Interval of saving important changes in the world, stated in seconds.
+#
+#    Requires: show_advanced
 server_map_save_interval (Map save interval) float 5.3 0.001
 
 #    How long the server will wait before unloading unused mapblocks, stated in seconds.
 #    Higher value is smoother, but will use more RAM.
+#
+#    Requires: show_advanced
 server_unload_unused_data_timeout (Unload unused server data) int 29 0 4294967295
 
 #    Maximum number of statically stored objects in a block.
+#
+#    Requires: show_advanced
 max_objects_per_block (Maximum objects per block) int 256 1 65535
 
 #    Length of time between active block management cycles, stated in seconds.
+#
+#    Requires: show_advanced
 active_block_mgmt_interval (Active block management interval) float 2.0 0.0
 
 #    Length of time between Active Block Modifier (ABM) execution cycles, stated in seconds.
+#
+#    Requires: show_advanced
 abm_interval (ABM interval) float 1.0 0.0
 
 #    The time budget allowed for ABMs to execute on each step
 #    (as a fraction of the ABM Interval)
+#
+#    Requires: show_advanced
 abm_time_budget (ABM time budget) float 0.2 0.1 0.9
 
 #    Length of time between NodeTimer execution cycles, stated in seconds.
+#
+#    Requires: show_advanced
 nodetimer_interval (NodeTimer interval) float 0.2 0.0
 
 #    Max liquids processed per step.
+#
+#    Requires: show_advanced
 liquid_loop_max (Liquid loop max) int 100000 1 4294967295
 
 #    The time (in seconds) that the liquids queue may grow beyond processing
 #    capacity until an attempt is made to decrease its size by dumping old queue
 #    items.  A value of 0 disables the functionality.
+#
+#    Requires: show_advanced
 liquid_queue_purge_time (Liquid queue purge time) int 0 0 65535
 
 #    Liquid update interval in seconds.
+#
+#    Requires: show_advanced
 liquid_update (Liquid update tick) float 1.0 0.001
 
 #    At this distance the server will aggressively optimize which blocks are sent to
@@ -2053,12 +2682,16 @@ liquid_update (Liquid update tick) float 1.0 0.001
 #    Setting this to a value greater than max_block_send_distance disables this
 #    optimization.
 #    Stated in mapblocks (16 nodes).
+#
+#    Requires: show_advanced
 block_send_optimize_distance (Block send optimize distance) int 4 2 32767
 
 #    If enabled the server will perform map block occlusion culling based on
 #    on the eye position of the player. This can reduce the number of blocks
 #    sent to the client 50-80%. The client will not longer receive most invisible
 #    so that the utility of noclip mode is reduced.
+#
+#    Requires: show_advanced
 server_side_occlusion_culling (Server side occlusion culling) bool true
 
 [**Mapgen]
@@ -2069,20 +2702,30 @@ server_side_occlusion_culling (Server side occlusion culling) bool true
 #    Reducing this value increases cave and dungeon density.
 #    Altering this value is for special usage, leaving it unchanged is
 #    recommended.
+#
+#    Requires: show_advanced
 chunksize (Chunk size) int 5 1 10
 
 #    Dump the mapgen debug information.
+#
+#    Requires: show_advanced
 enable_mapgen_debug_info (Mapgen debug) bool false
 
 #    Maximum number of blocks that can be queued for loading.
+#
+#    Requires: show_advanced
 emergequeue_limit_total (Absolute limit of queued blocks to emerge) int 1024 1 1000000
 
 #    Maximum number of blocks to be queued that are to be loaded from file.
 #    This limit is enforced per player.
+#
+#    Requires: show_advanced
 emergequeue_limit_diskonly (Per-player limit of queued blocks load from disk) int 128 1 1000000
 
 #    Maximum number of blocks to be queued that are to be generated.
 #    This limit is enforced per player.
+#
+#    Requires: show_advanced
 emergequeue_limit_generate (Per-player limit of queued blocks to generate) int 128 1 1000000
 
 #    Number of emerge threads to use.
@@ -2095,11 +2738,15 @@ emergequeue_limit_generate (Per-player limit of queued blocks to generate) int 1
 #    speed, but this may harm game performance by interfering with other
 #    processes, especially in singleplayer and/or when running Lua code in
 #    'on_generated'. For many users the optimum setting may be '1'.
+#
+#    Requires: show_advanced
 num_emerge_threads (Number of emerge threads) int 1 0 32767
 
 [**cURL]
 
 #    Maximum time an interactive request (e.g. server list fetch) may take, stated in milliseconds.
+#
+#    Requires: show_advanced
 curl_timeout (cURL interactive timeout) int 20000 100 2147483647
 
 #    Limits number of parallel HTTP requests. Affects:
@@ -2107,48 +2754,70 @@ curl_timeout (cURL interactive timeout) int 20000 100 2147483647
 #    -    Serverlist download and server announcement.
 #    -    Downloads performed by main menu (e.g. mod manager).
 #    Only has an effect if compiled with cURL.
+#
+#    Requires: show_advanced
 curl_parallel_limit (cURL parallel limit) int 8 1 2147483647
 
 #    Maximum time a file download (e.g. a mod download) may take, stated in milliseconds.
+#
+#    Requires: show_advanced
 curl_file_download_timeout (cURL file download timeout) int 300000 100 2147483647
 
 [**Misc]
 
 #    Adjust dpi configuration to your screen (non X11/Android only) e.g. for 4k screens.
+#
+#    Requires: show_advanced
 screen_dpi (DPI) int 72 1
 
 #    Adjust the detected display density, used for scaling UI elements.
+#
+#    Requires: show_advanced
 display_density_factor (Display Density Scaling Factor) float 1 0.5 5.0
 
 #    Windows systems only: Start Minetest with the command line window in the background.
 #    Contains the same information as the file debug.txt (default name).
+#
+#    Requires: show_advanced
 enable_console (Enable console window) bool false
 
 #    Number of extra blocks that can be loaded by /clearobjects at once.
 #    This is a trade-off between SQLite transaction overhead and
 #    memory consumption (4096=100MB, as a rule of thumb).
+#
+#    Requires: show_advanced
 max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096 0 4294967295
 
 #    World directory (everything in the world is stored here).
 #    Not needed if starting from the main menu.
+#
+#    Requires: show_advanced
 map-dir (Map directory) path
 
 #    See https://www.sqlite.org/pragma.html#pragma_synchronous
+#
+#    Requires: show_advanced
 sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2
 
 #    Compression level to use when saving mapblocks to disk.
 #    -1 - use default compression level
 #     0 - least compression, fastest
 #     9 - best compression, slowest
+#
+#    Requires: show_advanced
 map_compression_level_disk (Map Compression Level for Disk Storage) int -1 -1 9
 
 #    Enable usage of remote media server (if provided by server).
 #    Remote servers offer a significantly faster way to download media (e.g. textures)
 #    when connecting to the server.
+#
+#    Requires: show_advanced
 enable_remote_media_server (Connect to external media server) bool true
 
 #    File in client/serverlist/ that contains your favorite servers displayed in the
 #    Multiplayer Tab.
+#
+#    Requires: show_advanced
 serverlist_file (Serverlist file) string favoriteservers.json
 
 
@@ -2158,24 +2827,40 @@ serverlist_file (Serverlist file) string favoriteservers.json
 enable_joysticks (Enable joysticks) bool false
 
 #    The identifier of the joystick to use
+#
+#    Requires: enable_joysticks
 joystick_id (Joystick ID) int 0 0 255
 
 #    The type of joystick
+#
+#    Requires: enable_joysticks
 joystick_type (Joystick type) enum auto auto,generic,xbox,dragonrise_gamecube
 
 #    The time in seconds it takes between repeated events
 #    when holding down a joystick button combination.
+#
+#    Requires: enable_joysticks
 repeat_joystick_button_time (Joystick button repetition interval) float 0.17 0.001
 
 #    The dead zone of the joystick
+#
+#    Requires: enable_joysticks
 joystick_deadzone (Joystick dead zone) int 2048 0 65535
 
 #    The sensitivity of the joystick axes for moving the
 #    in-game view frustum around.
+#
+#    Requires: enable_joysticks
 joystick_frustum_sensitivity (Joystick frustum sensitivity) float 170.0 0.001
 
 
 [*Hide: Temporary Settings]
+
+#    Show advanced settings in the settings GUI
+show_advanced (Show advanced settings) bool false
+
+#    Whether to show the client debug info (has the same effect as hitting F5).
+show_debug (Show debug info) bool false
 
 #    Path to texture directory. All textures are first searched from here.
 texture_path (Texture path) path


### PR DESCRIPTION
Part of  #13476

Adds a new checkbox to show/hide advanced settings, hidden by default. By hiding advanced settings, the settings GUI is less overwhelming.

![image](https://github.com/minetest/minetest/assets/2122943/434fcdc2-ee39-483f-9f4c-5eff6e0f7fde)

## To do

This PR is Ready for Review.

Questions:

- Resolve the ambiguity between different types of advanced settings (there's both an "Advanced" section and the advanced checkbox now)
- Finalise which settings are considered advanced

## How to test

* Run MT, open settings
* Toggle show advanced settings dialog, look at settings
* See all settings marked as advanced in settingtypes.txt