### PR TITLE
Fix hypertext in the mainmenu

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1670,8 +1670,6 @@ void GUIFormSpecMenu::parseField(parserData* data, const std::string &element,
 
 void GUIFormSpecMenu::parseHyperText(parserData *data, const std::string &element)
 {
-	MY_CHECKCLIENT("hypertext");
-
 	std::vector<std::string> parts;
 	if (!precheckElement("hypertext", element, 4, 4, parts))
 		return;

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -600,8 +600,7 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 
 TextDrawer::TextDrawer(const wchar_t *text, Client *client,
 		gui::IGUIEnvironment *environment, ISimpleTextureSource *tsrc) :
-		m_text(text),
-		m_client(client), m_environment(environment)
+		m_text(text), m_client(client), m_tsrc(tsrc), m_environment(environment)
 {
 	// Size all elements
 	for (auto &p : m_text.m_paragraphs) {
@@ -632,7 +631,7 @@ TextDrawer::TextDrawer(const wchar_t *text, Client *client,
 
 				if (e.type == ParsedText::ELEMENT_IMAGE) {
 					video::ITexture *texture =
-						m_client->getTextureSource()->
+						m_tsrc->
 							getTexture(stringw_to_utf8(e.text));
 					if (texture)
 						dim = texture->getOriginalSize();
@@ -958,7 +957,7 @@ void TextDrawer::draw(const core::rect<s32> &clip_rect,
 
 			case ParsedText::ELEMENT_IMAGE: {
 				video::ITexture *texture =
-						m_client->getTextureSource()->getTexture(
+						m_tsrc->getTexture(
 								stringw_to_utf8(el.text));
 				if (texture != 0)
 					m_environment->getVideoDriver()->draw2DImage(
@@ -970,15 +969,15 @@ void TextDrawer::draw(const core::rect<s32> &clip_rect,
 			} break;
 
 			case ParsedText::ELEMENT_ITEM: {
-				IItemDefManager *idef = m_client->idef();
-				ItemStack item;
-				item.deSerialize(stringw_to_utf8(el.text), idef);
+				if (m_client) {
+					IItemDefManager *idef = m_client->idef();
+					ItemStack item;
+					item.deSerialize(stringw_to_utf8(el.text), idef);
 
-				drawItemStack(
-						m_environment->getVideoDriver(),
-						g_fontengine->getFont(), item, rect, &clip_rect,
-						m_client, IT_ROT_OTHER, el.angle, el.rotation
-				);
+					drawItemStack(m_environment->getVideoDriver(),
+							g_fontengine->getFont(), item, rect, &clip_rect, m_client,
+							IT_ROT_OTHER, el.angle, el.rotation);
+				}
 			} break;
 			}
 		}
@@ -993,7 +992,7 @@ GUIHyperText::GUIHyperText(const wchar_t *text, IGUIEnvironment *environment,
 		IGUIElement *parent, s32 id, const core::rect<s32> &rectangle,
 		Client *client, ISimpleTextureSource *tsrc) :
 		IGUIElement(EGUIET_ELEMENT, environment, parent, id, rectangle),
-		m_client(client), m_vscrollbar(nullptr),
+		m_tsrc(tsrc), m_vscrollbar(nullptr),
 		m_drawer(text, client, environment, tsrc), m_text_scrollpos(0, 0)
 {
 

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -600,7 +600,7 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 
 TextDrawer::TextDrawer(const wchar_t *text, Client *client,
 		gui::IGUIEnvironment *environment, ISimpleTextureSource *tsrc) :
-		m_text(text), m_client(client), m_tsrc(tsrc), m_environment(environment)
+		m_text(text), m_client(client), m_tsrc(tsrc), m_guienv(environment)
 {
 	// Size all elements
 	for (auto &p : m_text.m_paragraphs) {
@@ -913,7 +913,7 @@ void TextDrawer::place(const core::rect<s32> &dest_rect)
 void TextDrawer::draw(const core::rect<s32> &clip_rect,
 		const core::position2d<s32> &dest_offset)
 {
-	irr::video::IVideoDriver *driver = m_environment->getVideoDriver();
+	irr::video::IVideoDriver *driver = m_guienv->getVideoDriver();
 	core::position2d<s32> offset = dest_offset;
 	offset.Y += m_voffset;
 
@@ -960,7 +960,7 @@ void TextDrawer::draw(const core::rect<s32> &clip_rect,
 						m_tsrc->getTexture(
 								stringw_to_utf8(el.text));
 				if (texture != 0)
-					m_environment->getVideoDriver()->draw2DImage(
+					m_guienv->getVideoDriver()->draw2DImage(
 							texture, rect,
 							irr::core::rect<s32>(
 									core::position2d<s32>(0, 0),
@@ -974,7 +974,7 @@ void TextDrawer::draw(const core::rect<s32> &clip_rect,
 					ItemStack item;
 					item.deSerialize(stringw_to_utf8(el.text), idef);
 
-					drawItemStack(m_environment->getVideoDriver(),
+					drawItemStack(m_guienv->getVideoDriver(),
 							g_fontengine->getFont(), item, rect, &clip_rect, m_client,
 							IT_ROT_OTHER, el.angle, el.rotation);
 				}

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -188,9 +188,9 @@ protected:
 	};
 
 	ParsedText m_text;
-	Client *m_client; //< may be null
+	Client *m_client; ///< null in the mainmenu
 	ISimpleTextureSource *m_tsrc;
-	gui::IGUIEnvironment *m_environment;
+	gui::IGUIEnvironment *m_guienv;
 	s32 m_height;
 	s32 m_voffset;
 	std::vector<RectWithMargin> m_floating;

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -188,7 +188,8 @@ protected:
 	};
 
 	ParsedText m_text;
-	Client *m_client;
+	Client *m_client; //< may be null
+	ISimpleTextureSource *m_tsrc;
 	gui::IGUIEnvironment *m_environment;
 	s32 m_height;
 	s32 m_voffset;
@@ -216,7 +217,7 @@ public:
 
 protected:
 	// GUI members
-	Client *m_client;
+	ISimpleTextureSource *m_tsrc;
 	GUIScrollBar *m_vscrollbar;
 	TextDrawer m_drawer;
 


### PR DESCRIPTION
The hypertext element is currently disabled in the mainmenu because the client object is used to get the texture source and item definitions. This PR makes the client object optional

![image](https://github.com/minetest/minetest/assets/2122943/88c2b2a2-4d3a-45a2-a549-6aca886cb788)


## To do

This PR is Ready for Review

## How to test

Replace `builtin/mainmenu/tab_about.lua` with the following content:

```lua
local logofile = defaulttexturedir .. "logo.png"
local hypertext = "<tag name=code color=#7bf font=mono> <tag name=action color=#77f hovercolor=#aaf>" ..
		"<img name=" .. logofile .. " width=64>\n" ..
		"<b>Overview</b>\nConquer is a mod that adds RTS gameplay. It allows players to start Conquer sub-games, where they can place buildings, train units, and fight other players.\nConquer is designed with the intention to eventually convert it into a game, with custom mapgen and richer features. This standalone mini-game version will remain, however.\n\n<b>Starting or joining a Conquer session</b>\nStart a new conquer game by running:\n<code>/conquer start</code>\nYou'll switch into Conquer playing mode, where you will be given buildings that you can place.\nYou'll need to place a keep, which you must protect at all costs.\nOther players can join your conquer session if they are within 50 nodes by typing:\n<code>/conquer join yourname</code>\nYou may leave a game and return to normal playing mode at any time by typing:\n<code>/conquer leave</code>\n\n<b>Conquer GUI</b>\nThe Conquer GUI is the central place for monitoring your kingdom. Once in a session, you can view it by pressing the inventory key (I), or by punching/right-clicking the keep node.\n\n<b>Recruiting Units</b>\nYou'll need to place a barracks to be able to train new units. Once you have done that, open the Conquer GUI and select a unit to train.\nTraining a unit requires time and resources. The barracks will start training the unit as soon as you select it, and with spawn the unit nearby when complete.\nCurrently, there is no way to obtain resources. This is on the to-do list.\n\n<b>Controlling Units</b>\nSelect a unit by left clicking. You can select multiple units using shift+click. You can deselect units by pressing Q or clicking somewhere else.\nRight-click to command the unit to do something.\nChange the active wand by scrolling or pressing a number - just like with normal hotbars.\n<img name=blank.png width=16 height=1>• <b>Move:</b> right-click on a node to move the unit there.\n<img name=blank.png width=16 height=1>• <b>Melee Attack:</b> right-click on a unit or building to move the unit there, and attack.\n<img name=blank.png width=16 height=1>• <b>Ranged Attack:</b> right-click on a unit to fire arrows. The unit must be in sight, and must be less than 10 nodes and more than 2 nodes away.\nAttacking buildings will damage them. Damaged buildings will be repaired automatically when there are no enemies nearby.\n\n<b>Winning</b>\nYou win the game by being the last surviving country. To defeat another kingdom, you will need to destroy their keep.\nYou can destroy an enemy's barracks to prevent them from training troops.\n"

return {
	name = "about",
	caption = fgettext("About"),
	cbf_formspec = function(tabview, name, tabdata)
		local fs =
			"hypertext[5.5,0.1;9.5,6.9;ht;" .. core.formspec_escape(hypertext) .. "]"

		return fs, "size[15.5,7.1,false]real_coordinates[true]"
	end,
	cbf_button_handler = function(this, fields, name, tabdata)
	end,
}
```
