### PR TITLE
[NOSQUASH] Use our GUIElement classes everywhere

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1776,7 +1776,6 @@ float Client::mediaReceiveProgress()
 }
 
 struct TextureUpdateArgs {
-	gui::IGUIEnvironment *guienv;
 	u64 last_time_ms;
 	u16 last_percent;
 	std::wstring text_base;
@@ -1802,7 +1801,7 @@ void Client::showUpdateProgressTexture(void *args, u32 progress, u32 max_progres
 			targs->last_time_ms = time_ms;
 			std::wostringstream strm;
 			strm << targs->text_base << L" " << targs->last_percent << L"%...";
-			m_rendering_engine->draw_load_screen(strm.str(), targs->guienv, targs->tsrc, 0,
+			m_rendering_engine->draw_load_screen(strm.str(), targs->tsrc, 0,
 				72 + (u16) ((18. / 100.) * (double) targs->last_percent));
 		}
 }
@@ -1822,19 +1821,19 @@ void Client::afterContentReceived()
 	// Rebuild inherited images and recreate textures
 	infostream<<"- Rebuilding images and textures"<<std::endl;
 	m_rendering_engine->draw_load_screen(wstrgettext("Loading textures..."),
-			guienv, m_tsrc, 0, 70);
+			m_tsrc, 0, 70);
 	m_tsrc->rebuildImagesAndTextures();
 
 	// Rebuild shaders
 	infostream<<"- Rebuilding shaders"<<std::endl;
 	m_rendering_engine->draw_load_screen(wstrgettext("Rebuilding shaders..."),
-			guienv, m_tsrc, 0, 71);
+			m_tsrc, 0, 71);
 	m_shsrc->rebuildShaders();
 
 	// Update node aliases
 	infostream<<"- Updating node aliases"<<std::endl;
 	m_rendering_engine->draw_load_screen(wstrgettext("Initializing nodes..."),
-			guienv, m_tsrc, 0, 72);
+			m_tsrc, 0, 72);
 	m_nodedef->updateAliases(m_itemdef);
 	for (const auto &path : getTextureDirs()) {
 		TextureOverrideSource override_source(path + DIR_DELIM + "override.txt");
@@ -1847,7 +1846,6 @@ void Client::afterContentReceived()
 	// Update node textures and assign shaders to each tile
 	infostream<<"- Updating node textures"<<std::endl;
 	TextureUpdateArgs tu_args;
-	tu_args.guienv = guienv;
 	tu_args.last_time_ms = porting::getTimeMs();
 	tu_args.last_percent = 0;
 	tu_args.text_base = wstrgettext("Initializing nodes");
@@ -1864,7 +1862,7 @@ void Client::afterContentReceived()
 	if (m_mods_loaded)
 		m_script->on_client_ready(m_env.getLocalPlayer());
 
-	m_rendering_engine->draw_load_screen(wstrgettext("Done!"), guienv, m_tsrc, 0, 100);
+	m_rendering_engine->draw_load_screen(wstrgettext("Done!"), m_tsrc, 0, 100);
 	infostream<<"Client::afterContentReceived() done"<<std::endl;
 }
 

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -42,7 +42,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /* mainmenumanager.h
  */
 gui::IGUIEnvironment *guienv = nullptr;
-gui::IGUIStaticText *guiroot = nullptr;
 MainMenuManager g_menumgr;
 
 bool isMenuActive()
@@ -217,14 +216,6 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 		try {	// This is used for catching disconnects
 
 			m_rendering_engine->get_gui_env()->clear();
-
-			/*
-				We need some kind of a root node to be able to add
-				custom gui elements directly on the screen.
-				Otherwise they won't be automatically drawn.
-			*/
-			guiroot = m_rendering_engine->get_gui_env()->addStaticText(L"",
-				core::rect<s32>(0, 0, 10000, 10000));
 
 			bool game_has_run = launch_game(error_message, reconnect_requested,
 				start_data, cmd_args);
@@ -556,7 +547,8 @@ void ClientLauncher::main_menu(MainMenuData *menudata)
 #endif
 
 	/* show main menu */
-	GUIEngine mymenu(&input->joystick, guiroot, m_rendering_engine, &g_menumgr, menudata, *kill);
+	GUIEngine mymenu(&input->joystick, m_rendering_engine->get_gui_env()->getRootGUIElement(),
+			m_rendering_engine, &g_menumgr, menudata, *kill);
 
 	/* leave scene manager in a clean state */
 	m_rendering_engine->get_scene_manager()->clear();

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -41,7 +41,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 /* mainmenumanager.h
  */
-gui::IGUIEnvironment *guienv = nullptr;
 MainMenuManager g_menumgr;
 
 bool isMenuActive()
@@ -135,7 +134,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	m_rendering_engine->get_scene_manager()->getParameters()->
 		setAttribute(scene::ALLOW_ZWRITE_ON_TRANSPARENT, true);
 
-	guienv = m_rendering_engine->get_gui_env();
+	gui::IGUIEnvironment *guienv = m_rendering_engine->get_gui_env();
 	skin = guienv->getSkin();
 	skin->setColor(gui::EGDC_BUTTON_TEXT, video::SColor(255, 255, 255, 255));
 	skin->setColor(gui::EGDC_3D_LIGHT, video::SColor(0, 0, 0, 0));

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1530,7 +1530,9 @@ bool Game::createClient(const GameStartData &start_data)
 
 bool Game::initGui()
 {
-	m_game_ui->init();
+	auto guienv = m_rendering_engine->get_gui_env();
+
+	m_game_ui->init(guienv);
 
 	// Remove stale "recent" chat messages from previous connections
 	chat_backend->clearRecentChat();
@@ -1725,11 +1727,11 @@ bool Game::getServerContent(bool *aborted)
 		if (!client->itemdefReceived()) {
 			progress = 25;
 			m_rendering_engine->draw_load_screen(wstrgettext("Item definitions..."),
-					guienv, texture_src, dtime, progress);
+					texture_src, dtime, progress);
 		} else if (!client->nodedefReceived()) {
 			progress = 30;
 			m_rendering_engine->draw_load_screen(wstrgettext("Node definitions..."),
-					guienv, texture_src, dtime, progress);
+					texture_src, dtime, progress);
 		} else {
 			std::ostringstream message;
 			std::fixed(message);
@@ -1754,7 +1756,7 @@ bool Game::getServerContent(bool *aborted)
 			}
 
 			progress = 30 + client->mediaReceiveProgress() * 35 + 0.5;
-			m_rendering_engine->draw_load_screen(utf8_to_wide(message.str()), guienv,
+			m_rendering_engine->draw_load_screen(utf8_to_wide(message.str()),
 				texture_src, dtime, progress);
 		}
 	}
@@ -1805,20 +1807,23 @@ inline bool Game::handleCallbacks()
 		return false;
 	}
 
+	auto guienv = m_rendering_engine->get_gui_env();
+	auto guiroot = guienv->getRootGUIElement();
+
 	if (g_gamecallback->changepassword_requested) {
-		(new GUIPasswordChange(guienv, guienv->getRootGUIElement(), -1,
+		(new GUIPasswordChange(guienv, guiroot, -1,
 				       &g_menumgr, client, texture_src))->drop();
 		g_gamecallback->changepassword_requested = false;
 	}
 
 	if (g_gamecallback->changevolume_requested) {
-		(new GUIVolumeChange(guienv, guienv->getRootGUIElement(), -1,
+		(new GUIVolumeChange(guienv, guiroot, -1,
 				     &g_menumgr, texture_src))->drop();
 		g_gamecallback->changevolume_requested = false;
 	}
 
 	if (g_gamecallback->keyconfig_requested) {
-		(new GUIKeyChangeMenu(guienv, guienv->getRootGUIElement(), -1,
+		(new GUIKeyChangeMenu(guienv, guiroot, -1,
 				      &g_menumgr, texture_src))->drop();
 		g_gamecallback->keyconfig_requested = false;
 	}
@@ -1949,6 +1954,8 @@ void Game::updateStats(RunStats *stats, const FpsControl &draw_times,
 
 void Game::processUserInput(f32 dtime)
 {
+	auto guienv = m_rendering_engine->get_gui_env();
+
 	// Reset input if window not active or some menu is active
 	if (!device->isWindowActive() || isMenuActive() || guienv->hasFocus(gui_chat_console)) {
 		if(m_game_focused) {
@@ -4282,7 +4289,7 @@ void FpsControl::limit(IrrlichtDevice *device, f32 *dtime)
 
 void Game::showOverlayMessage(const char *msg, float dtime, int percent, bool draw_sky)
 {
-	m_rendering_engine->draw_load_screen(wstrgettext(msg), guienv, texture_src,
+	m_rendering_engine->draw_load_screen(wstrgettext(msg), texture_src,
 			dtime, percent, draw_sky);
 }
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1806,19 +1806,19 @@ inline bool Game::handleCallbacks()
 	}
 
 	if (g_gamecallback->changepassword_requested) {
-		(new GUIPasswordChange(guienv, guiroot, -1,
+		(new GUIPasswordChange(guienv, guienv->getRootGUIElement(), -1,
 				       &g_menumgr, client, texture_src))->drop();
 		g_gamecallback->changepassword_requested = false;
 	}
 
 	if (g_gamecallback->changevolume_requested) {
-		(new GUIVolumeChange(guienv, guiroot, -1,
+		(new GUIVolumeChange(guienv, guienv->getRootGUIElement(), -1,
 				     &g_menumgr, texture_src))->drop();
 		g_gamecallback->changevolume_requested = false;
 	}
 
 	if (g_gamecallback->keyconfig_requested) {
-		(new GUIKeyChangeMenu(guienv, guiroot, -1,
+		(new GUIKeyChangeMenu(guienv, guienv->getRootGUIElement(), -1,
 				      &g_menumgr, texture_src))->drop();
 		g_gamecallback->keyconfig_requested = false;
 	}
@@ -4142,7 +4142,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		}
 
 		if (isMenuActive())
-			guiroot->bringToFront(formspec);
+			m_rendering_engine->get_gui_env()->getRootGUIElement()->bringToFront(formspec);
 	} while (false);
 
 	/*

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -53,6 +53,8 @@ GameUI::GameUI()
 }
 void GameUI::init()
 {
+	IGUIElement *guiroot = guienv->getRootGUIElement();
+
 	// First line of debug text
 	m_guitext = gui::StaticText::add(guienv, utf8_to_wide(PROJECT_NAME_C).c_str(),
 		core::rect<s32>(0, 0, 0, 0), false, true, guiroot);

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -43,17 +43,12 @@ inline static const char *yawToDirectionString(int yaw)
 	return direction[yaw];
 }
 
-GameUI::GameUI()
+void GameUI::init(gui::IGUIEnvironment *guienv)
 {
-	if (guienv && guienv->getSkin())
+	if (guienv->getSkin())
 		m_statustext_initial_color = guienv->getSkin()->getColor(gui::EGDC_BUTTON_TEXT);
-	else
-		m_statustext_initial_color = video::SColor(255, 0, 0, 0);
 
-}
-void GameUI::init()
-{
-	IGUIElement *guiroot = guienv->getRootGUIElement();
+	gui::IGUIElement *guiroot = guienv->getRootGUIElement();
 
 	// First line of debug text
 	m_guitext = gui::StaticText::add(guienv, utf8_to_wide(PROJECT_NAME_C).c_str(),

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -49,9 +49,6 @@ class GameUI
 	friend class TestGameUI;
 
 public:
-	GameUI();
-	~GameUI() = default;
-
 	// Flags that can, or may, change during main game loop
 	struct Flags
 	{
@@ -63,7 +60,7 @@ public:
 		bool show_profiler_graph = false;
 	};
 
-	void init();
+	void init(gui::IGUIEnvironment *m_guienv);
 	void update(const RunStats &stats, Client *client, MapDrawControl *draw_control,
 			const CameraOrientation &cam, const PointedThing &pointed_old,
 			const GUIChatConsole *chat_console, float dtime);
@@ -121,7 +118,7 @@ private:
 	gui::IGUIStaticText *m_guitext_status = nullptr;
 	std::wstring m_statustext;
 	float m_statustext_time = 0.0f;
-	video::SColor m_statustext_initial_color;
+	video::SColor m_statustext_initial_color = video::SColor(255, 0, 0, 0);
 
 	gui::IGUIStaticText *m_guitext_chat = nullptr; // Chat text
 	u32 m_recent_chat_count = 0;

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -37,6 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gettext.h"
 #include "filesys.h"
 #include "../gui/guiSkin.h"
+#include "irrlicht_changes/static_text.h"
 #include "irr_ptr.h"
 
 RenderingEngine *RenderingEngine::s_singleton = nullptr;
@@ -235,7 +236,7 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 	core::rect<s32> textrect(center - textsize / 2, center + textsize / 2);
 
 	gui::IGUIStaticText *guitext =
-			guienv->addStaticText(text.c_str(), textrect, false, false);
+			gui::StaticText::add(guienv, text, textrect, false, false);
 	guitext->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_UPPERLEFT);
 
 	if (sky && g_settings->getBool("menu_clouds")) {

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -226,9 +226,9 @@ bool RenderingEngine::setWindowIcon()
 	Additionally, a progressbar can be drawn when percent is set between 0 and 100.
 */
 void RenderingEngine::draw_load_screen(const std::wstring &text,
-		gui::IGUIEnvironment *guienv, ITextureSource *tsrc, float dtime,
-		int percent, bool sky)
+		ITextureSource *tsrc, float dtime, int percent, bool sky)
 {
+	gui::IGUIEnvironment *guienv = get_gui_env();
 	v2u32 screensize = getWindowSize();
 
 	v2s32 textsize(g_fontengine->getTextWidth(text), g_fontengine->getLineHeight());

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -110,8 +110,7 @@ public:
 		return m_device->getGUIEnvironment();
 	}
 
-	void draw_load_screen(const std::wstring &text,
-			gui::IGUIEnvironment *guienv, ITextureSource *tsrc,
+	void draw_load_screen(const std::wstring &text, ITextureSource *tsrc,
 			float dtime = 0, int percent = 0, bool sky = true);
 
 	void draw_scene(video::SColor skycolor, bool show_hud,

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -27,15 +27,10 @@ using namespace gui;
 
 //! constructor
 GUIButton::GUIButton(IGUIEnvironment* environment, IGUIElement* parent,
-			s32 id, core::rect<s32> rectangle, ISimpleTextureSource *tsrc,
-			bool noclip)
-: IGUIButton(environment, parent, id, rectangle),
-	SpriteBank(0), OverrideFont(0),
-	OverrideColorEnabled(false), OverrideColor(video::SColor(101,255,255,255)),
-	ClickTime(0), HoverTime(0), FocusTime(0),
-	ClickShiftState(false), ClickControlState(false),
-	IsPushButton(false), Pressed(false),
-	UseAlphaChannel(false), DrawBorder(true), ScaleImage(false), TSrc(tsrc)
+		s32 id, core::rect<s32> rectangle, ISimpleTextureSource *tsrc,
+		bool noclip) :
+	IGUIButton(environment, parent, id, rectangle),
+	TSrc(tsrc)
 {
 	setNotClipped(noclip);
 

--- a/src/gui/guiButton.h
+++ b/src/gui/guiButton.h
@@ -185,11 +185,9 @@ protected:
 
 	struct ButtonImage
 	{
-		ButtonImage() : Texture(0), SourceRect(core::rect<s32>(0,0,0,0))
-		{
-		}
+		ButtonImage() = default;
 
-		ButtonImage(const ButtonImage& other) : Texture(0), SourceRect(core::rect<s32>(0,0,0,0))
+		ButtonImage(const ButtonImage& other)
 		{
 			*this = other;
 		}
@@ -220,8 +218,8 @@ protected:
 		}
 
 
-		video::ITexture* Texture;
-		core::rect<s32> SourceRect;
+		video::ITexture* Texture = nullptr;
+		core::rect<s32> SourceRect = core::rect<s32>(0,0,0,0);
 	};
 
 	gui::EGUI_BUTTON_IMAGE_STATE getImageState(bool pressed, const ButtonImage* images) const;
@@ -230,43 +228,41 @@ private:
 
 	struct ButtonSprite
 	{
-		ButtonSprite() : Index(-1), Loop(false), Scale(false)
-		{
-		}
-
-		bool operator==(const ButtonSprite& other) const
+		bool operator==(const ButtonSprite &other) const
 		{
 			return Index == other.Index && Color == other.Color && Loop == other.Loop && Scale == other.Scale;
 		}
 
-		s32 Index;
+		s32 Index = -1;
 		video::SColor Color;
-		bool Loop;
-		bool Scale;
+		bool Loop = false;
+		bool Scale = false;
 	};
 
 	ButtonSprite ButtonSprites[gui::EGBS_COUNT];
-	gui::IGUISpriteBank* SpriteBank;
+	gui::IGUISpriteBank* SpriteBank = nullptr;
 
 	ButtonImage ButtonImages[gui::EGBIS_COUNT];
 
 	std::array<StyleSpec, StyleSpec::NUM_STATES> Styles;
 
-	gui::IGUIFont* OverrideFont;
+	gui::IGUIFont* OverrideFont = nullptr;
 
-	bool OverrideColorEnabled;
-	video::SColor OverrideColor;
+	bool OverrideColorEnabled = false;
+	video::SColor OverrideColor = video::SColor(101,255,255,255);
 
-	u32 ClickTime, HoverTime, FocusTime;
+	u32 ClickTime = 0;
+	u32 HoverTime = 0;
+	u32 FocusTime = 0;
 
-	bool ClickShiftState;
-	bool ClickControlState;
+	bool ClickShiftState = false;
+	bool ClickControlState = false;
 
-	bool IsPushButton;
-	bool Pressed;
-	bool UseAlphaChannel;
-	bool DrawBorder;
-	bool ScaleImage;
+	bool IsPushButton = false;
+	bool Pressed = false;
+	bool UseAlphaChannel = false;
+	bool DrawBorder = true;
+	bool ScaleImage = false;
 
 	video::SColor Colors[4];
 	// PATCH

--- a/src/gui/guiButton.h
+++ b/src/gui/guiButton.h
@@ -275,6 +275,6 @@ private:
 	core::rect<s32> BgMiddle;
 	core::rect<s32> Padding;
 	core::vector2d<s32> ContentOffset;
-	video::SColor BgColor;
+	video::SColor BgColor = video::SColor(0xFF,0xFF,0xFF,0xFF);
 	// END PATCH
 };

--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -25,9 +25,10 @@ numerical
 //! constructor
 GUIEditBoxWithScrollBar::GUIEditBoxWithScrollBar(const wchar_t* text, bool border,
 	IGUIEnvironment* environment, IGUIElement* parent, s32 id,
-	const core::rect<s32>& rectangle, bool writable, bool has_vscrollbar)
+	const core::rect<s32>& rectangle, ISimpleTextureSource *tsrc,
+	bool writable, bool has_vscrollbar)
 	: GUIEditBox(environment, parent, id, rectangle, border, writable),
-	m_background(true), m_bg_color_used(false)
+	m_background(true), m_bg_color_used(false), m_tsrc(tsrc)
 {
 #ifdef _DEBUG
 	setDebugName("GUIEditBoxWithScrollBar");
@@ -635,7 +636,7 @@ void GUIEditBoxWithScrollBar::createVScrollBar()
 	irr::core::rect<s32> scrollbarrect = m_frame_rect;
 	scrollbarrect.UpperLeftCorner.X += m_frame_rect.getWidth() - m_scrollbar_width;
 	m_vscrollbar = new GUIScrollBar(Environment, getParent(), -1,
-			scrollbarrect, false, true);
+			scrollbarrect, false, true, m_tsrc);
 
 	m_vscrollbar->setVisible(false);
 	m_vscrollbar->setSmallStep(3 * fontHeight);

--- a/src/gui/guiEditBoxWithScrollbar.h
+++ b/src/gui/guiEditBoxWithScrollbar.h
@@ -7,6 +7,8 @@
 
 #include "guiEditBox.h"
 
+class ISimpleTextureSource;
+
 class GUIEditBoxWithScrollBar : public GUIEditBox
 {
 public:
@@ -14,7 +16,7 @@ public:
 	//! constructor
 	GUIEditBoxWithScrollBar(const wchar_t* text, bool border, IGUIEnvironment* environment,
 		IGUIElement* parent, s32 id, const core::rect<s32>& rectangle,
-		bool writable = true, bool has_vscrollbar = true);
+		ISimpleTextureSource *tsrc, bool writable = true, bool has_vscrollbar = true);
 
 	//! destructor
 	virtual ~GUIEditBoxWithScrollBar() {}
@@ -56,6 +58,8 @@ protected:
 
 	bool m_bg_color_used;
 	video::SColor m_bg_color;
+
+	ISimpleTextureSource *m_tsrc;
 };
 
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -139,9 +139,9 @@ void GUIFormSpecMenu::create(GUIFormSpecMenu *&cur_formspec, Client *client,
 	TextDest *txt_dest, const std::string &formspecPrepend, ISoundManager *sound_manager)
 {
 	if (cur_formspec == nullptr) {
-		cur_formspec = new GUIFormSpecMenu(joystick, guiroot, -1, &g_menumgr,
-			client, guienv, client->getTextureSource(), sound_manager, fs_src,
-			txt_dest, formspecPrepend);
+		cur_formspec = new GUIFormSpecMenu(joystick, guienv->getRootGUIElement(),
+			-1, &g_menumgr, client, guienv, client->getTextureSource(), sound_manager,
+			fs_src, txt_dest, formspecPrepend);
 		cur_formspec->doPause = false;
 
 		/*

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -666,7 +666,7 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 	spec.ftype = f_ScrollBar;
 	spec.send  = true;
 	GUIScrollBar *e = new GUIScrollBar(Environment, data->current_parent,
-			spec.fid, rect, is_horizontal, true);
+			spec.fid, rect, is_horizontal, true, m_tsrc);
 
 	auto style = getDefaultStyleForElement("scrollbar", name);
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
@@ -1493,7 +1493,7 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 	gui::IGUIEditBox *e = nullptr;
 	if (is_multiline) {
 		e = new GUIEditBoxWithScrollBar(spec.fdefault.c_str(), true, Environment,
-				data->current_parent, spec.fid, rect, is_editable, true);
+				data->current_parent, spec.fid, rect, m_tsrc, is_editable, true);
 	} else if (is_editable) {
 		e = Environment->addEditBox(spec.fdefault.c_str(), rect, true,
 				data->current_parent, spec.fid);

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -1011,7 +1011,7 @@ GUIHyperText::GUIHyperText(const wchar_t *text, IGUIEnvironment *environment,
 			RelativeRect.getWidth() - m_scrollbar_width, 0,
 			RelativeRect.getWidth(), RelativeRect.getHeight());
 
-	m_vscrollbar = new GUIScrollBar(Environment, this, -1, rect, false, true);
+	m_vscrollbar = new GUIScrollBar(Environment, this, -1, rect, false, true, tsrc);
 	m_vscrollbar->setVisible(false);
 }
 

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -123,8 +123,8 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		core::rect<s32> rect(0, 0, 600 * s, 40 * s);
 		rect += topleft + v2s32(25 * s, 3 * s);
 		//gui::IGUIStaticText *t =
-		Environment->addStaticText(wstrgettext("Keybindings.").c_str(),
-								   rect, false, true, this, -1);
+		gui::StaticText::add(Environment, wstrgettext("Keybindings."), rect,
+				false, true, this, -1);
 		//t->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_UPPERLEFT);
 	}
 
@@ -138,8 +138,8 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect<s32> rect(0, 0, 150 * s, 20 * s);
 			rect += topleft + v2s32(offset.X, offset.Y);
-			Environment->addStaticText(k->button_name.c_str(), rect, false, true,
-					this, -1);
+			gui::StaticText::add(Environment, k->button_name, rect,
+					false, true, this, -1);
 		}
 
 		{
@@ -300,8 +300,8 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 		if (key_in_use && !this->key_used_text) {
 			core::rect<s32> rect(0, 0, 600, 40);
 			rect += v2s32(0, 0) + v2s32(25, 30);
-			this->key_used_text = Environment->addStaticText(
-					wstrgettext("Key already in use").c_str(),
+			this->key_used_text = gui::StaticText::add(Environment,
+					wstrgettext("Key already in use"),
 					rect, false, true, this, -1);
 		} else if (!key_in_use && this->key_used_text) {
 			this->key_used_text->remove();

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -89,7 +89,7 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	{
 		core::rect<s32> rect(0, 0, 150 * s, 20 * s);
 		rect += topleft_client + v2s32(25 * s, ypos + 6 * s);
-		Environment->addStaticText(wstrgettext("Old Password").c_str(), rect,
+		gui::StaticText::add(Environment, wstrgettext("Old Password"), rect,
 				false, true, this, -1);
 	}
 	{
@@ -104,8 +104,8 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	{
 		core::rect<s32> rect(0, 0, 150 * s, 20 * s);
 		rect += topleft_client + v2s32(25 * s, ypos + 6 * s);
-		Environment->addStaticText(wstrgettext("New Password").c_str(), rect, false, true,
-				this, -1);
+		gui::StaticText::add(Environment, wstrgettext("New Password"), rect,
+				false, true, this, -1);
 	}
 	{
 		core::rect<s32> rect(0, 0, 230 * s, 30 * s);
@@ -118,7 +118,7 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	{
 		core::rect<s32> rect(0, 0, 150 * s, 20 * s);
 		rect += topleft_client + v2s32(25 * s, ypos + 6 * s);
-		Environment->addStaticText(wstrgettext("Confirm Password").c_str(), rect,
+		gui::StaticText::add(Environment, wstrgettext("Confirm Password"), rect,
 				false, true, this, -1);
 	}
 	{
@@ -147,9 +147,9 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	{
 		core::rect<s32> rect(0, 0, 300 * s, 20 * s);
 		rect += topleft_client + v2s32(35 * s, ypos);
-		IGUIElement *e = Environment->addStaticText(
-				wstrgettext("Passwords do not match!").c_str(), rect, false,
-				true, this, ID_message);
+		IGUIElement *e = gui::StaticText::add(
+				Environment, wstrgettext("Passwords do not match!"), rect,
+				false, true, this, ID_message);
 		e->setVisible(false);
 	}
 }

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -11,17 +11,19 @@ the arrow buttons where there is insufficient space.
 */
 
 #include "guiScrollBar.h"
-#include <IGUIButton.h>
+#include "guiButton.h"
 #include <IGUISkin.h>
 
 GUIScrollBar::GUIScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s32 id,
-		core::rect<s32> rectangle, bool horizontal, bool auto_scale) :
+		core::rect<s32> rectangle, bool horizontal, bool auto_scale,
+		ISimpleTextureSource *tsrc) :
 		IGUIElement(EGUIET_ELEMENT, environment, parent, id, rectangle),
 		up_button(nullptr), down_button(nullptr), is_dragging(false),
 		is_horizontal(horizontal), is_auto_scaling(auto_scale),
 		dragged_by_slider(false), tray_clicked(false), scroll_pos(0),
 		draw_center(0), thumb_size(0), min_pos(0), max_pos(100), small_step(10),
-		large_step(50), drag_offset(0), page_size(100), border_size(0)
+		large_step(50), drag_offset(0), page_size(100), border_size(0),
+		m_tsrc(tsrc)
 {
 	refreshControls();
 	setNotClipped(false);
@@ -343,8 +345,9 @@ void GUIScrollBar::refreshControls()
 		s32 h = RelativeRect.getHeight();
 		border_size = RelativeRect.getWidth() < h * 4 ? 0 : h;
 		if (!up_button) {
-			up_button = Environment->addButton(
-					core::rect<s32>(0, 0, h, h), this);
+			core::rect<s32> up_button_rect(0, 0, h, h);
+			up_button = GUIButton::addButton(Environment, up_button_rect, m_tsrc,
+					this, -1, L"");
 			up_button->setSubElement(true);
 			up_button->setTabStop(false);
 		}
@@ -361,10 +364,12 @@ void GUIScrollBar::refreshControls()
 		up_button->setAlignment(EGUIA_UPPERLEFT, EGUIA_UPPERLEFT, EGUIA_UPPERLEFT,
 				EGUIA_LOWERRIGHT);
 		if (!down_button) {
-			down_button = Environment->addButton(
-					core::rect<s32>(RelativeRect.getWidth() - h, 0,
-							RelativeRect.getWidth(), h),
-					this);
+			core::rect<s32> down_button_rect(
+					RelativeRect.getWidth() - h, 0,
+					RelativeRect.getWidth(), h
+				);
+			down_button = GUIButton::addButton(Environment, down_button_rect, m_tsrc,
+					this, -1, L"");
 			down_button->setSubElement(true);
 			down_button->setTabStop(false);
 		}
@@ -386,8 +391,9 @@ void GUIScrollBar::refreshControls()
 		s32 w = RelativeRect.getWidth();
 		border_size = RelativeRect.getHeight() < w * 4 ? 0 : w;
 		if (!up_button) {
-			up_button = Environment->addButton(
-					core::rect<s32>(0, 0, w, w), this);
+			core::rect<s32> up_button_rect(0, 0, w, w);
+			up_button = GUIButton::addButton(Environment, up_button_rect, m_tsrc,
+					this, -1, L"");
 			up_button->setSubElement(true);
 			up_button->setTabStop(false);
 		}
@@ -404,10 +410,12 @@ void GUIScrollBar::refreshControls()
 		up_button->setAlignment(EGUIA_UPPERLEFT, EGUIA_LOWERRIGHT,
 				EGUIA_UPPERLEFT, EGUIA_UPPERLEFT);
 		if (!down_button) {
-			down_button = Environment->addButton(
-					core::rect<s32>(0, RelativeRect.getHeight() - w,
-							w, RelativeRect.getHeight()),
-					this);
+			core::rect<s32> down_button_rect(
+					0, RelativeRect.getHeight() - w,
+					w, RelativeRect.getHeight()
+				);
+			down_button = GUIButton::addButton(Environment, down_button_rect, m_tsrc,
+					this, -1, L"");
 			down_button->setSubElement(true);
 			down_button->setTabStop(false);
 		}

--- a/src/gui/guiScrollBar.h
+++ b/src/gui/guiScrollBar.h
@@ -14,6 +14,8 @@ the arrow buttons where there is insufficient space.
 
 #include "irrlichttypes_extrabloated.h"
 
+class ISimpleTextureSource;
+
 using namespace irr;
 using namespace gui;
 
@@ -21,7 +23,8 @@ class GUIScrollBar : public IGUIElement
 {
 public:
 	GUIScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s32 id,
-			core::rect<s32> rectangle, bool horizontal, bool auto_scale);
+			core::rect<s32> rectangle, bool horizontal, bool auto_scale,
+			ISimpleTextureSource *tsrc);
 
 	enum ArrowVisibility
 	{
@@ -74,4 +77,6 @@ private:
 
 	core::rect<s32> slider_rect;
 	video::SColor current_icon_color;
+
+	ISimpleTextureSource *m_tsrc;
 };

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -901,7 +901,7 @@ bool GUITable::OnEvent(const SEvent &event)
 		setToolTipText(cell ? m_strings[cell->tooltip_index].c_str() : L"");
 
 		// Fix for #1567/#1806:
-		// IGUIScrollBar passes double click events to its parent,
+		// GUIScrollBar passes double click events to its parent,
 		// which we don't want. Detect this case and discard the event
 		if (event.MouseInput.Event != EMIE_MOUSE_MOVED &&
 				m_scrollbar->isVisible() &&

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -66,7 +66,7 @@ GUITable::GUITable(gui::IGUIEnvironment *env,
 					0,
 					RelativeRect.getWidth(),
 					RelativeRect.getHeight()),
-			false, true);
+			false, true, tsrc);
 	m_scrollbar->setSubElement(true);
 	m_scrollbar->setTabStop(false);
 	m_scrollbar->setAlignment(gui::EGUIA_LOWERRIGHT, gui::EGUIA_LOWERRIGHT,

--- a/src/gui/guiVolumeChange.cpp
+++ b/src/gui/guiVolumeChange.cpp
@@ -20,11 +20,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "guiVolumeChange.h"
 #include "debug.h"
 #include "guiButton.h"
+#include "guiScrollBar.h"
 #include "serialization.h"
 #include <string>
 #include <IGUICheckBox.h>
 #include <IGUIButton.h>
-#include <IGUIScrollBar.h>
 #include <IGUIStaticText.h>
 #include <IGUIFont.h>
 #include "settings.h"
@@ -85,8 +85,8 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 	{
 		core::rect<s32> rect(0, 0, 300 * s, 20 * s);
 		rect = rect + v2s32(size.X / 2 - 150 * s, size.Y / 2);
-		gui::IGUIScrollBar *e = Environment->addScrollBar(true,
-			rect, this, ID_soundSlider);
+		auto e = make_irr<GUIScrollBar>(Environment, this,
+				ID_soundSlider, rect, true, false);
 		e->setMax(100);
 		e->setPos(volume);
 	}
@@ -151,7 +151,7 @@ bool GUIVolumeChange::OnEvent(const SEvent& event)
 		}
 		if (event.GUIEvent.EventType == gui::EGET_SCROLL_BAR_CHANGED) {
 			if (event.GUIEvent.Caller->getID() == ID_soundSlider) {
-				s32 pos = ((gui::IGUIScrollBar*)event.GUIEvent.Caller)->getPos();
+				s32 pos = static_cast<GUIScrollBar *>(event.GUIEvent.Caller)->getPos();
 				g_settings->setFloat("sound_volume", (float) pos / 100);
 
 				gui::IGUIElement *e = getElementFromId(ID_soundText);

--- a/src/gui/guiVolumeChange.cpp
+++ b/src/gui/guiVolumeChange.cpp
@@ -86,7 +86,7 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 		core::rect<s32> rect(0, 0, 300 * s, 20 * s);
 		rect = rect + v2s32(size.X / 2 - 150 * s, size.Y / 2);
 		auto e = make_irr<GUIScrollBar>(Environment, this,
-				ID_soundSlider, rect, true, false);
+				ID_soundSlider, rect, true, false, m_tsrc);
 		e->setMax(100);
 		e->setPos(volume);
 	}

--- a/src/gui/guiVolumeChange.cpp
+++ b/src/gui/guiVolumeChange.cpp
@@ -73,7 +73,7 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 		core::rect<s32> rect(0, 0, 160 * s, 20 * s);
 		rect = rect + v2s32(size.X / 2 - 80 * s, size.Y / 2 - 70 * s);
 
-		Environment->addStaticText(fwgettext("Sound Volume: %d%%", volume).c_str(),
+		StaticText::add(Environment, fwgettext("Sound Volume: %d%%", volume),
 				rect, false, true, this, ID_soundText);
 	}
 	{

--- a/src/gui/mainmenumanager.h
+++ b/src/gui/mainmenumanager.h
@@ -38,9 +38,6 @@ public:
 	virtual void signalKeyConfigChange() = 0;
 };
 
-// FIXME: do we really need this global variable?
-extern gui::IGUIEnvironment *guienv;
-
 // Handler for the modal menus
 
 class MainMenuManager : public IMenuManager

--- a/src/gui/mainmenumanager.h
+++ b/src/gui/mainmenumanager.h
@@ -38,8 +38,8 @@ public:
 	virtual void signalKeyConfigChange() = 0;
 };
 
+// FIXME: do we really need this global variable?
 extern gui::IGUIEnvironment *guienv;
-extern gui::IGUIStaticText *guiroot;
 
 // Handler for the modal menus
 

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/keycode.h"
 #include "client/renderingengine.h"
 #include "util/numeric.h"
+#include "guiButton.h"
 
 #include <iostream>
 #include <algorithm>
@@ -153,8 +154,8 @@ void AutoHideButtonBar::init(ISimpleTextureSource *tsrc,
 
 	rect<int> starter_rect = rect<s32>(UpperLeft.X, UpperLeft.Y, LowerRight.X, LowerRight.Y);
 
-	IGUIButton *starter_gui_button = m_guienv->addButton(starter_rect, nullptr,
-			button_id, L"", nullptr);
+	IGUIButton *starter_gui_button = GUIButton::addButton(m_guienv, starter_rect,
+			m_texturesource, nullptr, button_id, L"", nullptr);
 
 	m_starter.gui_button        = starter_gui_button;
 	m_starter.gui_button->grab();
@@ -238,8 +239,8 @@ void AutoHideButtonBar::addButton(touch_gui_button_id button_id, const wchar_t *
 		current_button = rect<s32>(m_upper_left.X, y_start, m_lower_right.Y, y_end);
 	}
 
-	IGUIButton *btn_gui_button = m_guienv->addButton(current_button, nullptr, button_id,
-			caption, nullptr);
+	IGUIButton *btn_gui_button = GUIButton::addButton(m_guienv, current_button,
+			m_texturesource, nullptr, button_id, caption, nullptr);
 
 	std::shared_ptr<button_info> btn(new button_info);
 	btn->gui_button        = btn_gui_button;
@@ -413,7 +414,8 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, IEventReceiver *receiver)
 void TouchScreenGUI::initButton(touch_gui_button_id id, const rect<s32> &button_rect,
 		const std::wstring &caption, bool immediate_release, float repeat_delay)
 {
-	IGUIButton *btn_gui_button = m_guienv->addButton(button_rect, nullptr, id, caption.c_str());
+	IGUIButton *btn_gui_button = GUIButton::addButton(m_guienv, button_rect,
+			m_texturesource, nullptr, id, caption.c_str());
 
 	button_info *btn       = &m_buttons[id];
 	btn->gui_button        = btn_gui_button;

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IrrlichtDevice.h>
 
 #include <map>
+#include <memory>
 #include <vector>
 
 #include "client/tile.h"
@@ -90,7 +91,7 @@ struct button_info
 		FIRST_TEXTURE,
 		SECOND_TEXTURE
 	} toggleable = NOT_TOGGLEABLE;
-	std::vector<const std::string> textures;
+	std::vector<std::string> textures;
 };
 
 class AutoHideButtonBar

--- a/src/irrlicht_changes/static_text.h
+++ b/src/irrlicht_changes/static_text.h
@@ -49,27 +49,7 @@ namespace gui
 			s32 id = -1,
 			bool fillBackground = false)
 		{
-			if (parent == NULL) {
-				// parent is NULL, so we must find one, or we need not to drop
-				// result, but then there will be a memory leak.
-				//
-				// What Irrlicht does is to use guienv as a parent, but the problem
-				// is that guienv is here only an IGUIEnvironment, while it is a
-				// CGUIEnvironment in Irrlicht, which inherits from both IGUIElement
-				// and IGUIEnvironment.
-				//
-				// A solution would be to dynamic_cast guienv to a
-				// IGUIElement*, but Irrlicht is shipped without rtti support
-				// in some distributions, causing the dymanic_cast to segfault.
-				//
-				// Thus, to find the parent, we create a dummy StaticText and ask
-				// for its parent, and then remove it.
-				irr::gui::IGUIStaticText *dummy_text =
-					guienv->addStaticText(L"", rectangle, border, wordWrap,
-						parent, id, fillBackground);
-				parent = dummy_text->getParent();
-				dummy_text->remove();
-			}
+			parent = parent ? parent : guienv->getRootGUIElement();
 			irr::gui::IGUIStaticText *result = new irr::gui::StaticText(
 				text, border, guienv, parent,
 				id, rectangle, fillBackground);


### PR DESCRIPTION
- Fixes #12366.
  * Note though that we can't yet delete the gui classes in irrlicht that we don't use, because irrlicht itself still uses them for other gui elements.
  * Also note that CGUIEditBox is not replaced by GUIEditBox, as latter is an abstract class, and I also don't know what it does different.
- Additionally, the globals `guienv` and `guiroot` are removed.
  -  `guiroot`: We don't actually need to create a root gui element (was a big static text). The guienvironment already provides a root element.
  - `guienv` : The `guienv` is always reachable through the renderingengine, so it's redundant.
* Least and first, touchscreengui is made to compile (had a missing header and a const in vector elem type).
* The color (`BgColor`) of buttons is now initialized.

## To do

This PR is a Ready for Review.

(I recommend reviewing commits separately.)

## How to test

* Compare before/after of:
  * Any scrollbar.
    Note how the arrow buttons are now brightened on hover.
    Styles, however, do not affect the buttons. (As expected.) See below for test formspec.
  * The volume change menu.
  * The key change menu.
  * The touchscreengui. (Compile with `-DENABLE_TOUCH=1`.) (Haven't tested on an actual phone.)
  
Formspec for testing possible style issues with scrollbar (set via devtest node meta editor):
```
formspec_version[6]
size[10,10]
style[*;bgcolor=red]
button[1,1;2,1;btn;Button]
scrollbar[1,3;0.25,3;vertical;scrbar;0]
```