### PR TITLE
Fix freeze in core.check_for_falling

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -529,16 +529,14 @@ function core.check_single_for_falling(p)
 			if same and d_bottom.paramtype2 == "leveled" and
 					core.get_node_level(p_bottom) <
 					core.get_node_max_level(p_bottom) then
-				convert_to_falling_node(p, n)
-				return true
+				return convert_to_falling_node(p, n)
 			end
 			-- Otherwise only if the bottom node is considered "fall through"
 			if not same and
 					(not d_bottom.walkable or d_bottom.buildable_to) and
 					(core.get_item_group(n.name, "float") == 0 or
 					d_bottom.liquidtype == "none") then
-				convert_to_falling_node(p, n)
-				return true
+				return convert_to_falling_node(p, n)
 			end
 		end
 	end

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -529,14 +529,16 @@ function core.check_single_for_falling(p)
 			if same and d_bottom.paramtype2 == "leveled" and
 					core.get_node_level(p_bottom) <
 					core.get_node_max_level(p_bottom) then
-				return convert_to_falling_node(p, n)
+				local success, _ = convert_to_falling_node(p, n)
+				return success
 			end
 			-- Otherwise only if the bottom node is considered "fall through"
 			if not same and
 					(not d_bottom.walkable or d_bottom.buildable_to) and
 					(core.get_item_group(n.name, "float") == 0 or
 					d_bottom.liquidtype == "none") then
-				return convert_to_falling_node(p, n)
+				local success, _ = convert_to_falling_node(p, n)
+				return success
 			end
 		end
 	end


### PR DESCRIPTION
`core.add_entity(pos, "__builtin:falling_node")` can fail if there are too many entities already. In this case, `convert_to_falling_node` https://github.com/minetest/minetest/blob/7b3ed3200325ce913a6a2d884ae1ba1ccb08aad5/builtin/game/falling.lua#L412-L414 returns false, and the falling node is not removed. But `core.check_single_for_falling` didn't forward the error https://github.com/minetest/minetest/blob/7b3ed3200325ce913a6a2d884ae1ba1ccb08aad5/builtin/game/falling.lua#L532-L533. Therefore `core.check_for_falling` tries to remove this node again https://github.com/minetest/minetest/blob/7b3ed3200325ce913a6a2d884ae1ba1ccb08aad5/builtin/game/falling.lua#L617-L620 and the server freezes in an infinite loop.

## To do

This PR is Ready for Review.

## How to test

- Replace `local obj = core.add_entity(pos, "__builtin:falling_node")` with `local obj = nil`
- Place a falling node, for example, a sand
- Check that the server is not frozen
