### PR TITLE
Settings GUI: Use language names rather than codes

### DIFF
--- a/builtin/mainmenu/settings/components.lua
+++ b/builtin/mainmenu/settings/components.lua
@@ -161,15 +161,17 @@ function make.enum(setting)
 			local value = core.settings:get(setting.name) or setting.default
 			self.resettable = core.settings:has(setting.name)
 
+			local labels = setting.option_labels or {}
+
 			local items = {}
 			for i, option in ipairs(setting.values) do
-				items[i] = core.formspec_escape(option)
+				items[i] = core.formspec_escape(labels[option] or option)
 			end
 
 			local selected_idx = table.indexof(setting.values, value)
 			local fs = "label[0,0.1;" .. get_label(setting) .. "]"
 
-			fs = fs .. ("dropdown[0,0.3;%f,0.8;%s;%s;%d]"):format(
+			fs = fs .. ("dropdown[0,0.3;%f,0.8;%s;%s;%d;true]"):format(
 				avail_w, setting.name, table.concat(items, ","), selected_idx, value)
 
 			return fs, 1.1
@@ -177,7 +179,8 @@ function make.enum(setting)
 
 		on_submit = function(self, fields)
 			local old_value = core.settings:get(setting.name) or setting.default
-			local value = fields[setting.name]
+			local idx = tonumber(fields[setting.name]) or 0
+			local value = setting.values[idx]
 			if value == nil or value == old_value then
 				return false
 			end

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -151,6 +151,72 @@ local function get_setting_info(name)
 end
 
 
+-- These must not be translated, as they need to show in the local
+-- language no matter the user's current language.
+get_setting_info("language").option_labels = {
+	[""] = fgettext_ne("(Use system language)"),
+	--ar = " [ar]", blacklisted
+	be = "Беларуская [be]",
+	bg = "Български [bg]",
+	ca = "Català [ca]",
+	cs = "Česky [cs]",
+	cy = "Cymraeg [cy]",
+	da = "Dansk [da]",
+	de = "Deutsch [de]",
+	--dv = " [dv]", blacklisted
+	el = "Ελληνικά [el]",
+	en = "English [en]",
+	eo = "Esperanto [eo]",
+	es = "Español [es]",
+	et = "Eesti [et]",
+	eu = "Euskara [eu]",
+	fi = "Suomi [fi]",
+	fil = "Wikang Filipino [fil]",
+	fr = "Français [fr]",
+	gd = "Gàidhlig [gd]",
+	gl = "Galego [gl]",
+	--he = " [he]", blacklisted
+	--hi = "हिन्दी [hi]", blacklisted
+	hu = "Magyar [hu]",
+	id = "Bahasa Indonesia [id]",
+	it = "Italiano [it]",
+	ja = "日本語 [ja]",
+	jbo = "Lojban [jbo]",
+	kk = "Қазақша [kk]",
+	--kn = "ಕನ್ನಡ [kn]", blacklisted
+	ko = "한국어 [ko]",
+	ky = "Kırgızca / Кыргызча [ky]",
+	lt = "Lietuvių [lt]",
+	lv = "Latviešu [lv]",
+	mn = "Монгол [mn]",
+	mr = "मराठी [mr]",
+	ms = "Bahasa Melayu [ms]",
+	--ms_Arab = "Malay (Jawi) [ms_Arab]", blacklisted
+	nb = "Norwegian Bokmål [nb]",
+	nl = "Nederlands [nl]",
+	nn = "Norsk (nynorsk)  [nn]",
+	oc = "Occitan [oc]",
+	pl = "Polski [pl]",
+	pt = "Português [pt]",
+	pt_BR = "Português (do Brasil) [pt_BR]",
+	ro = "Română [ro]",
+	ru = "Русский [ru]",
+	sk = "Slovenčina [sk]",
+	sl = "Slovenščina [sl]",
+	sr_Cyrl = "Српски [sr_Cyrl]",
+	sr_Latn = "Српски [sr_Latn]",
+	sv = "Svenska [sv]",
+	sw = "Kiswahili [sw]",
+	--th = "ไทย / Phasa Thai [th]", blacklisted
+	tr = "Türkçe [tr]",
+	tt = "Tatarça [tt]",
+	uk = "Українська [uk]",
+	vi = "Tiếng Việt [vi]",
+	zh_CN = "中文 (简体) [zh_CN]",
+	zh_TW = "正體中文 (繁體) [zh_TW]",
+}
+
+
 -- See if setting matches keywords
 local function get_setting_match_weight(entry, query_keywords)
 	local setting_score = 0

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -68,6 +68,8 @@ add_page({
 	id = "accessibility",
 	title = gettext("Accessibility"),
 	content = {
+		"language",
+		{ heading = gettext("General") },
 		"font_size",
 		"chat_font_size",
 		"gui_scaling",
@@ -176,14 +178,14 @@ get_setting_info("language").option_labels = {
 	gd = "Gàidhlig [gd]",
 	gl = "Galego [gl]",
 	--he = " [he]", blacklisted
-	--hi = "हिन्दी [hi]", blacklisted
+	--hi = " [hi]", blacklisted
 	hu = "Magyar [hu]",
 	id = "Bahasa Indonesia [id]",
 	it = "Italiano [it]",
 	ja = "日本語 [ja]",
 	jbo = "Lojban [jbo]",
 	kk = "Қазақша [kk]",
-	--kn = "ಕನ್ನಡ [kn]", blacklisted
+	--kn = " [kn]", blacklisted
 	ko = "한국어 [ko]",
 	ky = "Kırgızca / Кыргызча [ky]",
 	lt = "Lietuvių [lt]",
@@ -191,23 +193,23 @@ get_setting_info("language").option_labels = {
 	mn = "Монгол [mn]",
 	mr = "मराठी [mr]",
 	ms = "Bahasa Melayu [ms]",
-	--ms_Arab = "Malay (Jawi) [ms_Arab]", blacklisted
-	nb = "Norwegian Bokmål [nb]",
+	--ms_Arab = " [ms_Arab]", blacklisted
+	nb = "Norsk Bokmål [nb]",
 	nl = "Nederlands [nl]",
-	nn = "Norsk (nynorsk)  [nn]",
+	nn = "Norsk Nynorsk [nn]",
 	oc = "Occitan [oc]",
 	pl = "Polski [pl]",
 	pt = "Português [pt]",
-	pt_BR = "Português (do Brasil) [pt_BR]",
+	pt_BR = "Português do Brasil [pt_BR]",
 	ro = "Română [ro]",
 	ru = "Русский [ru]",
 	sk = "Slovenčina [sk]",
 	sl = "Slovenščina [sl]",
 	sr_Cyrl = "Српски [sr_Cyrl]",
-	sr_Latn = "Српски [sr_Latn]",
+	sr_Latn = "Srpski (Latinica) [sr_Latn]",
 	sv = "Svenska [sv]",
 	sw = "Kiswahili [sw]",
-	--th = "ไทย / Phasa Thai [th]", blacklisted
+	--th = " [th]", blacklisted
 	tr = "Türkçe [tr]",
 	tt = "Tatarça [tt]",
 	uk = "Українська [uk]",


### PR DESCRIPTION
Part of #13476

Showing language codes isn't very user friendly. This PR makes it so the language dropdown shows the local name for the language.

This is also a prerequisite to making other drop downs translatable (for that, I'll need to update the settingtypes parser to create these labels and update translation templates. For a future PR).

![image](https://github.com/minetest/minetest/assets/2122943/b247ca40-0417-4a79-9fff-9a6ef8044336)

![image](https://github.com/minetest/minetest/assets/2122943/7978370b-1a15-458c-814f-b5931e149746)

## To do

This PR is Ready for Review

## How to test

* Open settings GUI > user interfaces
* See dropdown
