### PR TITLE
Small setting-related fixes

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -129,6 +129,8 @@ safe_dig_and_place (Safe digging and placing) bool false
 invert_mouse (Invert mouse) bool false
 
 #    Mouse sensitivity multiplier.
+#
+#    Requires: keyboard_mouse
 mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
 
 #    Enable mouse wheel (scroll) for item selection in hotbar.
@@ -143,10 +145,15 @@ invert_hotbar_mouse_wheel (Hotbar: Invert mouse wheel direction) bool false
 
 [*Touchscreen]
 
-#    The length in pixels it takes for touch screen interaction to start.
+#    The length in pixels it takes for touchscreen interaction to start.
 #
 #    Requires: touchscreen_gui
-touchscreen_threshold (Touch screen threshold) int 20 0 100
+touchscreen_threshold (Touchscreen threshold) int 20 0 100
+
+#    Touchscreen sensitivity multiplier.
+#
+#    Requires: touchscreen_gui
+touchscreen_sensitivity (Touchscreen sensitivity) float 0.2 0.001 10.0
 
 #    Use crosshair to select object instead of whole screen.
 #    If enabled, a crosshair will be shown and will be used for selecting object.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -112,13 +112,16 @@ always_fly_fast (Always fly fast) bool true
 
 #    The time in seconds it takes between repeated node placements when holding
 #    the place button.
+#
+#    Requires: keyboard_mouse
 repeat_place_time (Place repetition interval) float 0.25 0.16 2
 
 #    Automatically jump up single-node obstacles.
 autojump (Automatic jumping) bool false
 
-#    Prevent digging and placing from repeating when holding the mouse buttons.
+#    Prevent digging and placing from repeating when holding the respective buttons.
 #    Enable this when you dig or place too often by accident.
+#    On touchscreens, this only affects digging.
 safe_dig_and_place (Safe digging and placing) bool false
 
 [*Keyboard and Mouse]

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -91,6 +91,8 @@
 camera_smoothing (Camera smoothing) float 0.0 0.0 0.99
 
 #    Smooths rotation of camera when in cinematic mode, 0 to disable. Enter cinematic mode by using the key set in Change Keys.
+#
+#    Requires: keyboard_mouse
 cinematic_camera_smoothing (Camera smoothing in cinematic mode) float 0.7 0.0 0.99
 
 #    If enabled, you can place nodes at the position (feet + eye level) where you stand.
@@ -127,8 +129,6 @@ safe_dig_and_place (Safe digging and placing) bool false
 invert_mouse (Invert mouse) bool false
 
 #    Mouse sensitivity multiplier.
-#
-#    Requires: keyboard_mouse
 mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
 
 #    Enable mouse wheel (scroll) for item selection in hotbar.
@@ -154,13 +154,13 @@ touchscreen_threshold (Touch screen threshold) int 20 0 100
 #    Requires: touchscreen_gui
 touch_use_crosshair (Use crosshair for touch screen) bool false
 
-#    (Android) Fixes the position of virtual joystick.
+#    Fixes the position of virtual joystick.
 #    If disabled, virtual joystick will center to first-touch's position.
 #
 #    Requires: touchscreen_gui
 fixed_virtual_joystick (Fixed virtual joystick) bool false
 
-#    (Android) Use virtual joystick to trigger "Aux1" button.
+#    Use virtual joystick to trigger "Aux1" button.
 #    If enabled, virtual joystick will also tap "Aux1" button when out of main circle.
 #
 #    Requires: touchscreen_gui

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -124,7 +124,7 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	// bpp, fsaa, vsync
 	bool vsync = g_settings->getBool("vsync");
 	bool enable_fsaa = g_settings->get("antialiasing") == "fsaa";
-	u16 fsaa = enable_fsaa ? g_settings->getU16("fsaa") : 0;
+	u16 fsaa = enable_fsaa ? MYMAX(2, g_settings->getU16("fsaa")) : 0;
 
 	// Determine driver
 	auto driverType = chooseVideoDriver();

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -172,7 +172,7 @@ void set_default_settings()
 #else
 	settings->setDefault("show_debug", "true");
 #endif
-	settings->setDefault("fsaa", "0");
+	settings->setDefault("fsaa", "2");
 	settings->setDefault("undersampling", "1");
 	settings->setDefault("world_aligned_mode", "enable");
 	settings->setDefault("autoscale_mode", "disable");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -473,7 +473,8 @@ void set_default_settings()
 #endif
 
 #ifdef HAVE_TOUCHSCREENGUI
-	settings->setDefault("touchscreen_threshold","20");
+	settings->setDefault("touchscreen_threshold", "20");
+	settings->setDefault("touchscreen_sensitivity", "0.2");
 	settings->setDefault("touch_use_crosshair", "false");
 	settings->setDefault("fixed_virtual_joystick", "false");
 	settings->setDefault("virtual_joystick_triggers_aux1", "false");

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -828,7 +828,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 					m_pointer_pos[event.TouchInput.ID] = touch_pos;
 
 					// adapt to similar behavior as pc screen
-					const double d = g_settings->getFloat("mouse_sensitivity", 0.001f, 10.0f) * 3.0f;
+					const double d = g_settings->getFloat("touchscreen_sensitivity", 0.001f, 10.0f) * 3.0f;
 
 					m_camera_yaw_change -= dir_free.X * d;
 					m_camera_pitch = MYMIN(MYMAX(m_camera_pitch + (dir_free.Y * d), -180.0f), 180.0f);


### PR DESCRIPTION
This PR contains some small setting-related fixes:

- It corrects the default value of the `fsaa` setting in `defaultsettings.cpp`. The default value of that setting was changed by #13253, but the change was only applied to `settingtypes.txt`.

- It hides the `cinematic_camera_smoothing` setting on ENABLE_TOUCH builds, as cinematic mode is not available there.

- It makes the `mouse_sensitivity` setting visible again on ENABLE_TOUCH builds, as it also affects "finger sensitivity":
  
  https://github.com/minetest/minetest/blob/72ef90885d5030bf6f7f9dd60a475339bde9a929/src/gui/touchscreengui.cpp#L830-L831

## To do

This PR is a Ready for Review.

## How to test

Look at the settings menu.
