### PR TITLE
Remove DIR_DELIM in builtin Lua

### DIFF
--- a/builtin/async/game.lua
+++ b/builtin/async/game.lua
@@ -12,8 +12,8 @@ function core.job_processor(func, params)
 end
 
 -- Import a bunch of individual files from builtin/game/
-local gamepath = core.get_builtin_path() .. "game" .. DIR_DELIM
-local commonpath = core.get_builtin_path() .. "common" .. DIR_DELIM
+local gamepath = core.get_builtin_path() .. "game/"
+local commonpath = core.get_builtin_path() .. "common/"
 
 local builtin_shared = {}
 

--- a/builtin/client/init.lua
+++ b/builtin/client/init.lua
@@ -1,7 +1,7 @@
 -- Minetest: builtin/client/init.lua
 local scriptpath = core.get_builtin_path()
-local clientpath = scriptpath.."client"..DIR_DELIM
-local commonpath = scriptpath.."common"..DIR_DELIM
+local clientpath = scriptpath.."client/"
+local commonpath = scriptpath.."common/"
 
 dofile(clientpath .. "register.lua")
 dofile(commonpath .. "after.lua")

--- a/builtin/emerge/init.lua
+++ b/builtin/emerge/init.lua
@@ -1,6 +1,6 @@
-local gamepath = core.get_builtin_path() .. "game" .. DIR_DELIM
-local commonpath = core.get_builtin_path() .. "common" .. DIR_DELIM
-local epath = core.get_builtin_path() .. "emerge" .. DIR_DELIM
+local gamepath = core.get_builtin_path() .. "game/"
+local commonpath = core.get_builtin_path() .. "common/"
+local epath = core.get_builtin_path() .. "emerge/"
 
 local builtin_shared = {}
 

--- a/builtin/game/init.lua
+++ b/builtin/game/init.lua
@@ -1,7 +1,7 @@
 
 local scriptpath = core.get_builtin_path()
-local commonpath = scriptpath .. "common" .. DIR_DELIM
-local gamepath   = scriptpath .. "game".. DIR_DELIM
+local commonpath = scriptpath .. "common/"
+local gamepath   = scriptpath .. "game/"
 
 -- Shared between builtin files, but
 -- not exposed to outer context
@@ -14,7 +14,7 @@ assert(loadfile(commonpath .. "register.lua"))(builtin_shared)
 assert(loadfile(gamepath .. "register.lua"))(builtin_shared)
 
 if core.settings:get_bool("profiler.load") then
-	profiler = dofile(scriptpath .. "profiler" .. DIR_DELIM .. "init.lua")
+	profiler = dofile(scriptpath .. "profiler/init.lua")
 end
 
 dofile(commonpath .. "after.lua")

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -31,8 +31,8 @@ minetest = core
 
 -- Load other files
 local scriptdir = core.get_builtin_path()
-local commonpath = scriptdir .. "common" .. DIR_DELIM
-local asyncpath = scriptdir .. "async" .. DIR_DELIM
+local commonpath = scriptdir .. "common/"
+local asyncpath = scriptdir .. "async/"
 
 dofile(commonpath .. "vector.lua")
 dofile(commonpath .. "strict.lua")
@@ -40,7 +40,7 @@ dofile(commonpath .. "serialize.lua")
 dofile(commonpath .. "misc_helpers.lua")
 
 if INIT == "game" then
-	dofile(scriptdir .. "game" .. DIR_DELIM .. "init.lua")
+	dofile(scriptdir .. "game/init.lua")
 	assert(not core.get_http_api)
 elseif INIT == "mainmenu" then
 	local mm_script = core.settings:get("main_menu_script")
@@ -58,7 +58,7 @@ elseif INIT == "mainmenu" then
 		end
 	end
 	if not custom_loaded then
-		dofile(core.get_mainmenu_path() .. DIR_DELIM .. "init.lua")
+		dofile(core.get_mainmenu_path() .. "/init.lua")
 	end
 elseif INIT == "async"  then
 	dofile(asyncpath .. "mainmenu.lua")
@@ -66,9 +66,9 @@ elseif INIT == "async_game" then
 	dofile(commonpath .. "metatable.lua")
 	dofile(asyncpath .. "game.lua")
 elseif INIT == "client" then
-	dofile(scriptdir .. "client" .. DIR_DELIM .. "init.lua")
+	dofile(scriptdir .. "client/init.lua")
 elseif INIT == "emerge" then
-	dofile(scriptdir .. "emerge" .. DIR_DELIM .. "init.lua")
+	dofile(scriptdir .. "emerge/init.lua")
 else
 	error(("Unrecognized builtin initialization type %s!"):format(tostring(INIT)))
 end

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -229,7 +229,7 @@ end
 function menu_worldmt(selected, setting, value)
 	local world = menudata.worldlist:get_list()[selected]
 	if world then
-		local filename = world.path .. DIR_DELIM .. "world.mt"
+		local filename = world.path .. "/world.mt"
 		local world_conf = Settings(filename)
 
 		if value then

--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -39,7 +39,7 @@ local store = {
 local http = core.get_http_api()
 
 -- Screenshot
-local screenshot_dir = core.get_cache_path() .. DIR_DELIM .. "cdb"
+local screenshot_dir = core.get_cache_path() .. "/cdb"
 assert(core.create_dir(screenshot_dir))
 local screenshot_downloading = {}
 local screenshot_downloaded = {}
@@ -98,7 +98,7 @@ local function download_and_extract(param)
 
 	local tempfolder = core.get_temp_path()
 	if tempfolder ~= "" then
-		tempfolder = tempfolder .. DIR_DELIM .. "MT_" .. math.random(1, 1024000)
+		tempfolder = tempfolder .. "/MT_" .. math.random(1, 1024000)
 		if not core.extract_zip(filename, tempfolder) then
 			tempfolder = nil
 		end
@@ -141,15 +141,15 @@ local function start_install(package, reason)
 				if package.type == "mod" then
 					local actual_type = pkgmgr.get_folder_type(path)
 					if actual_type.type == "modpack" then
-						conf_path = path .. DIR_DELIM .. "modpack.conf"
+						conf_path = path .. "/modpack.conf"
 					else
-						conf_path = path .. DIR_DELIM .. "mod.conf"
+						conf_path = path .. "/mod.conf"
 					end
 				elseif package.type == "game" then
-					conf_path = path .. DIR_DELIM .. "game.conf"
+					conf_path = path .. "/game.conf"
 					name_is_title = true
 				elseif package.type == "txp" then
-					conf_path = path .. DIR_DELIM .. "texture_pack.conf"
+					conf_path = path .. "/texture_pack.conf"
 				end
 
 				if conf_path then
@@ -566,7 +566,7 @@ local function install_or_update_package(this, package)
 		dlg:set_parent(this)
 		this:hide()
 		dlg:show()
-	elseif not package.path and core.is_dir(install_parent .. DIR_DELIM .. package.name) then
+	elseif not package.path and core.is_dir(install_parent .. "/" .. package.name) then
 		local dlg = confirm_overwrite.create(package, on_confirm)
 		dlg:set_parent(this)
 		this:hide()
@@ -591,7 +591,7 @@ local function get_screenshot(package)
 
 	-- Get tmp screenshot path
 	local ext = get_file_extension(package.thumbnail)
-	local filepath = screenshot_dir .. DIR_DELIM ..
+	local filepath = screenshot_dir .. "/" ..
 		("%s-%s-%s.%s"):format(package.type, package.author, package.name, ext)
 
 	-- Return if already downloaded

--- a/builtin/mainmenu/content/init.lua
+++ b/builtin/mainmenu/content/init.lua
@@ -15,8 +15,8 @@
 --with this program; if not, write to the Free Software Foundation, Inc.,
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-local path = core.get_mainmenu_path() .. DIR_DELIM .. "content"
+local path = core.get_mainmenu_path() .. "/content"
 
-dofile(path .. DIR_DELIM .. "pkgmgr.lua")
-dofile(path .. DIR_DELIM .. "update_detector.lua")
-dofile(path .. DIR_DELIM .. "dlg_contentstore.lua")
+dofile(path .. "/pkgmgr.lua")
+dofile(path .. "/update_detector.lua")
+dofile(path .. "/dlg_contentstore.lua")

--- a/builtin/mainmenu/content/tests/pkgmgr_spec.lua
+++ b/builtin/mainmenu/content/tests/pkgmgr_spec.lua
@@ -24,7 +24,6 @@ local function reset()
 		core = {},
 		unpack = table.unpack or unpack,
 		pkgmgr = {},
-		DIR_DELIM = "/",
 	}
 	env._G = env
 	setmetatable(env, { __index = _G })

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -282,7 +282,7 @@ local function handle_buttons(this, fields)
 	end
 
 	if fields.btn_config_world_save then
-		local filename = this.data.worldspec.path .. DIR_DELIM .. "world.mt"
+		local filename = this.data.worldspec.path .. "/world.mt"
 
 		local worldfile = Settings(filename)
 		local mods = worldfile:to_table()

--- a/builtin/mainmenu/dlg_rename_modpack.lua
+++ b/builtin/mainmenu/dlg_rename_modpack.lua
@@ -43,7 +43,7 @@ end
 local function rename_modpack_buttonhandler(this, fields)
 	if fields["dlg_rename_modpack_confirm"] ~= nil then
 		local oldpath = this.data.mod.path
-		local targetpath = this.data.mod.parent_dir .. DIR_DELIM .. fields["te_modpack_name"]
+		local targetpath = this.data.mod.parent_dir .. "/" .. fields["te_modpack_name"]
 		os.rename(oldpath, targetpath)
 		pkgmgr.refresh_globals()
 		pkgmgr.selected_mod = pkgmgr.global_mods:get_current_index(

--- a/builtin/mainmenu/game_theme.lua
+++ b/builtin/mainmenu/game_theme.lua
@@ -103,14 +103,14 @@ end
 function mm_game_theme.set_engine_single(identifier)
 	--try texture pack first
 	if mm_game_theme.texturepack ~= nil then
-		local path = mm_game_theme.texturepack .. DIR_DELIM .."menu_" ..
+		local path = mm_game_theme.texturepack .. "/menu_" ..
 										identifier .. ".png"
 		if core.set_background(identifier,path) then
 			return true
 		end
 	end
 
-	local path = defaulttexturedir .. DIR_DELIM .. "menu_" .. identifier .. ".png"
+	local path = defaulttexturedir .. "/menu_" .. identifier .. ".png"
 	if core.set_background(identifier, path) then
 		return true
 	end
@@ -123,7 +123,7 @@ function mm_game_theme.set_game_single(identifier, gamedetails)
 	assert(gamedetails ~= nil)
 
 	if mm_game_theme.texturepack ~= nil then
-		local path = mm_game_theme.texturepack .. DIR_DELIM ..
+		local path = mm_game_theme.texturepack .. "/" ..
 			gamedetails.id .. "_menu_" .. identifier .. ".png"
 		if core.set_background(identifier, path) then
 			return true
@@ -133,7 +133,7 @@ function mm_game_theme.set_game_single(identifier, gamedetails)
 	-- Find out how many randomized textures the game provides
 	local n = 0
 	local filename
-	local menu_files = core.get_dir_list(gamedetails.path .. DIR_DELIM .. "menu", false)
+	local menu_files = core.get_dir_list(gamedetails.path .. "/menu", false)
 	for i = 1, #menu_files do
 		filename = identifier .. "." .. i .. ".png"
 		if table.indexof(menu_files, filename) == -1 then
@@ -149,8 +149,7 @@ function mm_game_theme.set_game_single(identifier, gamedetails)
 		filename = identifier .. "." .. n .. ".png"
 	end
 
-	local path = gamedetails.path .. DIR_DELIM .. "menu" ..
-		DIR_DELIM .. filename
+	local path = gamedetails.path .. "/menu/" .. filename
 	if core.set_background(identifier, path) then
 		return true
 	end
@@ -161,7 +160,7 @@ end
 --------------------------------------------------------------------------------
 function mm_game_theme.set_dirt_bg()
 	if mm_game_theme.texturepack ~= nil then
-		local path = mm_game_theme.texturepack .. DIR_DELIM .."default_dirt.png"
+		local path = mm_game_theme.texturepack .. "/default_dirt.png"
 		if core.set_background("background", path, true, 128) then
 			return true
 		end
@@ -185,6 +184,6 @@ function mm_game_theme.set_music(gamedetails)
 
 	assert(gamedetails ~= nil)
 
-	local music_path = gamedetails.path .. DIR_DELIM .. "menu" .. DIR_DELIM .. "theme"
+	local music_path = gamedetails.path .. "/menu/theme"
 	mm_game_theme.music_handle = core.sound_play(music_path, true)
 end

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -25,37 +25,36 @@ mt_color_red = "#FF3300"
 
 local menupath = core.get_mainmenu_path()
 local basepath = core.get_builtin_path()
-defaulttexturedir = core.get_texturepath_share() .. DIR_DELIM .. "base" ..
-					DIR_DELIM .. "pack" .. DIR_DELIM
+defaulttexturedir = core.get_texturepath_share() .. "/base/pack/"
 
-dofile(menupath .. DIR_DELIM .. "misc.lua")
+dofile(menupath .. "/misc.lua")
 
-dofile(basepath .. "common" .. DIR_DELIM .. "filterlist.lua")
-dofile(basepath .. "fstk" .. DIR_DELIM .. "buttonbar.lua")
-dofile(basepath .. "fstk" .. DIR_DELIM .. "dialog.lua")
-dofile(basepath .. "fstk" .. DIR_DELIM .. "tabview.lua")
-dofile(basepath .. "fstk" .. DIR_DELIM .. "ui.lua")
-dofile(menupath .. DIR_DELIM .. "async_event.lua")
-dofile(menupath .. DIR_DELIM .. "common.lua")
-dofile(menupath .. DIR_DELIM .. "serverlistmgr.lua")
-dofile(menupath .. DIR_DELIM .. "game_theme.lua")
-dofile(menupath .. DIR_DELIM .. "content" .. DIR_DELIM .. "init.lua")
+dofile(basepath .. "common/filterlist.lua")
+dofile(basepath .. "fstk/buttonbar.lua")
+dofile(basepath .. "fstk/dialog.lua")
+dofile(basepath .. "fstk/tabview.lua")
+dofile(basepath .. "fstk/ui.lua")
+dofile(menupath .. "/async_event.lua")
+dofile(menupath .. "/common.lua")
+dofile(menupath .. "/serverlistmgr.lua")
+dofile(menupath .. "/game_theme.lua")
+dofile(menupath .. "/content/init.lua")
 
-dofile(menupath .. DIR_DELIM .. "dlg_config_world.lua")
-dofile(menupath .. DIR_DELIM .. "settings" .. DIR_DELIM .. "init.lua")
-dofile(menupath .. DIR_DELIM .. "dlg_create_world.lua")
-dofile(menupath .. DIR_DELIM .. "dlg_delete_content.lua")
-dofile(menupath .. DIR_DELIM .. "dlg_delete_world.lua")
-dofile(menupath .. DIR_DELIM .. "dlg_register.lua")
-dofile(menupath .. DIR_DELIM .. "dlg_rename_modpack.lua")
-dofile(menupath .. DIR_DELIM .. "dlg_version_info.lua")
-dofile(menupath .. DIR_DELIM .. "dlg_reinstall_mtg.lua")
+dofile(menupath .. "/dlg_config_world.lua")
+dofile(menupath .. "/settings/init.lua")
+dofile(menupath .. "/dlg_create_world.lua")
+dofile(menupath .. "/dlg_delete_content.lua")
+dofile(menupath .. "/dlg_delete_world.lua")
+dofile(menupath .. "/dlg_register.lua")
+dofile(menupath .. "/dlg_rename_modpack.lua")
+dofile(menupath .. "/dlg_version_info.lua")
+dofile(menupath .. "/dlg_reinstall_mtg.lua")
 
 local tabs = {
-	content  = dofile(menupath .. DIR_DELIM .. "tab_content.lua"),
-	about = dofile(menupath .. DIR_DELIM .. "tab_about.lua"),
-	local_game = dofile(menupath .. DIR_DELIM .. "tab_local.lua"),
-	play_online = dofile(menupath .. DIR_DELIM .. "tab_online.lua")
+	content  = dofile(menupath .. "/tab_content.lua"),
+	about = dofile(menupath .. "/tab_about.lua"),
+	local_game = dofile(menupath .. "/tab_local.lua"),
+	play_online = dofile(menupath .. "/tab_online.lua")
 }
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -197,7 +197,7 @@ end
 
 --------------------------------------------------------------------------------
 local function get_favorites_path(folder)
-	local base = core.get_user_path() .. DIR_DELIM .. "client" .. DIR_DELIM .. "serverlist" .. DIR_DELIM
+	local base = core.get_user_path() .. "/client/serverlist/"
 	if folder then
 		return base
 	end

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -16,12 +16,8 @@
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
-local component_funcs =  dofile(core.get_mainmenu_path() .. DIR_DELIM ..
-		"settings" .. DIR_DELIM .. "components.lua")
-
-local shadows_component =  dofile(core.get_mainmenu_path() .. DIR_DELIM ..
-		"settings" .. DIR_DELIM .. "shadows_component.lua")
-
+local component_funcs =  dofile(core.get_mainmenu_path() .. "/settings/components.lua")
+local shadows_component =  dofile(core.get_mainmenu_path() .. "/settings/shadows_component.lua")
 
 local full_settings = settingtypes.parse_config_file(false, true)
 local info_icon_path = core.formspec_escape(defaulttexturedir .. "settings_info.png")

--- a/builtin/mainmenu/settings/init.lua
+++ b/builtin/mainmenu/settings/init.lua
@@ -15,14 +15,14 @@
 --with this program; if not, write to the Free Software Foundation, Inc.,
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-local path = core.get_mainmenu_path() .. DIR_DELIM .. "settings"
+local path = core.get_mainmenu_path() .. "/settings"
 
-dofile(path .. DIR_DELIM .. "settingtypes.lua")
-dofile(path .. DIR_DELIM .. "dlg_change_mapgen_flags.lua")
-dofile(path .. DIR_DELIM .. "dlg_settings.lua")
+dofile(path .. "/settingtypes.lua")
+dofile(path .. "/dlg_change_mapgen_flags.lua")
+dofile(path .. "/dlg_settings.lua")
 
 -- Uncomment to generate 'minetest.conf.example' and 'settings_translation_file.cpp'.
 -- For RUN_IN_PLACE the generated files may appear in the 'bin' folder.
 -- See comment and alternative line at the end of 'generate_from_settingtypes.lua'.
 
--- dofile(path .. DIR_DELIM .. "generate_from_settingtypes.lua")
+-- dofile(path .. "/generate_from_settingtypes.lua")

--- a/builtin/mainmenu/settings/settingtypes.lua
+++ b/builtin/mainmenu/settings/settingtypes.lua
@@ -412,7 +412,7 @@ function settingtypes.parse_config_file(read_all, parse_mods)
 		-- Parse games
 		local games_category_initialized = false
 		for _, game in ipairs(pkgmgr.games) do
-			local path = game.path .. DIR_DELIM .. FILENAME
+			local path = game.path .. "/" .. FILENAME
 			local file = io.open(path, "r")
 			if file then
 				if not games_category_initialized then
@@ -445,7 +445,7 @@ function settingtypes.parse_config_file(read_all, parse_mods)
 		table.sort(mods, function(a, b) return a.name < b.name end)
 
 		for _, mod in ipairs(mods) do
-			local path = mod.path .. DIR_DELIM .. FILENAME
+			local path = mod.path .. "/" .. FILENAME
 			local file = io.open(path, "r")
 			if file then
 				if not mods_category_initialized then
@@ -476,7 +476,7 @@ function settingtypes.parse_config_file(read_all, parse_mods)
 		local clientmods = {}
 		pkgmgr.get_mods(core.get_clientmodpath(), "clientmods", clientmods)
 		for _, mod in ipairs(clientmods) do
-			local path = mod.path .. DIR_DELIM .. FILENAME
+			local path = mod.path .. "/" .. FILENAME
 			local file = io.open(path, "r")
 			if file then
 				if not clientmods_category_initialized then

--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -193,7 +193,7 @@ return {
 		end
 
 		if fields.share_debug then
-			local path = core.get_user_path() .. DIR_DELIM .. "debug.txt"
+			local path = core.get_user_path() .. "/debug.txt"
 			core.share_file(path)
 		end
 

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -103,7 +103,7 @@ local function get_formspec(tabview, name, tabdata)
 
 	if selected_pkg then
 		-- Check for screenshot being available
-		local screenshotfilename = selected_pkg.path .. DIR_DELIM .. "screenshot.png"
+		local screenshotfilename = selected_pkg.path .. "/screenshot.png"
 		local screenshotfile, error = io.open(screenshotfilename, "r")
 
 		local modscreenshot

--- a/builtin/profiler/init.lua
+++ b/builtin/profiler/init.lua
@@ -25,7 +25,7 @@ local function get_bool_default(name, default)
 	return val
 end
 
-local profiler_path = core.get_builtin_path().."profiler"..DIR_DELIM
+local profiler_path = core.get_builtin_path().."profiler/"
 local profiler = {}
 local sampler = assert(loadfile(profiler_path .. "sampling.lua"))(profiler)
 local instrumentation  = assert(loadfile(profiler_path .. "instrumentation.lua"))(profiler, sampler, get_bool_default)

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -79,7 +79,7 @@ local function generate_name(def)
 		source = source:gsub(modpath, def.mod)
 	end
 	source = source:gsub(worldmods_path, "")
-	source = source:gsub(builtin_path, "builtin" .. DIR_DELIM)
+	source = source:gsub(builtin_path, "builtin/")
 	source = source:gsub(user_path, "")
 	return format("%s[%d] %s#%s", class or func_name, index, source, info.linedefined)
 end

--- a/games/devtest/mods/unittests/async_env.lua
+++ b/games/devtest/mods/unittests/async_env.lua
@@ -1,7 +1,7 @@
 -- helper
 
 core.register_async_dofile(core.get_modpath(core.get_current_modname()) ..
-	DIR_DELIM .. "inside_async_env.lua")
+	"/inside_async_env.lua")
 
 local function deepequal(a, b)
 	if type(a) == "function" then


### PR DESCRIPTION
Lua is a cross-platform language. The standard library allows you to use forward slash on Windows, so that Lua code doesn't need to care about whether the platform uses a different path separator.

This PR makes builtin Lua use "/" instead of "DIR_DELIM. This improves the code quality and readability of parts by a fair amount.

The value DIR_DELIM has not been changed, however it should be deprecated

## To do

This PR is Ready for Review

## How to test

<!-- Example code or instructions -->
