### PR TITLE
Use formspec version 6 in the main menu

### DIFF
--- a/builtin/fstk/buttonbar.lua
+++ b/builtin/fstk/buttonbar.lua
@@ -35,7 +35,7 @@ local function buttonbar_formspec(self)
 			(i - self.startbutton) * self.btn_size * 1.25 +       --button offset
 			self.btn_initial_offset
 		else
-			btn_pos.x = self.pos.x + self.size.x / 2 + self.btn_size / 2
+			btn_pos.x = self.pos.x + self.size.x / 2 - self.btn_size / 2
 		end
 
 		if self.orientation == "vertical" then

--- a/builtin/fstk/buttonbar.lua
+++ b/builtin/fstk/buttonbar.lua
@@ -22,8 +22,9 @@ local function buttonbar_formspec(self)
 		return ""
 	end
 
-	local formspec = string.format("box[%f,%f;%f,%f;%s]",
-			self.pos.x,self.pos.y ,self.size.x,self.size.y,self.bgcolor)
+	local formspec = "style_type[box;noclip=true]" ..
+			string.format("box[%f,%f;%f,%f;%s]", self.pos.x, self.pos.y, self.size.x, self.size.y, self.bgcolor) ..
+			"style_type[box;noclip=false]"
 
 	for i=self.startbutton,#self.buttons,1 do
 		local btn_name = self.buttons[i].name
@@ -31,18 +32,18 @@ local function buttonbar_formspec(self)
 
 		if self.orientation == "horizontal" then
 			btn_pos.x = self.pos.x + --base pos
-			(i - self.startbutton) * self.btn_size +       --button offset
+			(i - self.startbutton) * self.btn_size * 1.25 +       --button offset
 			self.btn_initial_offset
 		else
-			btn_pos.x = self.pos.x + (self.btn_size * 0.05)
+			btn_pos.x = self.pos.x + self.size.x / 2 + self.btn_size / 2
 		end
 
 		if self.orientation == "vertical" then
 			btn_pos.y = self.pos.y + --base pos
-			(i - self.startbutton) * self.btn_size +       --button offset
+			(i - self.startbutton) * self.btn_size * 1.25 +       --button offset
 			self.btn_initial_offset
 		else
-			btn_pos.y = self.pos.y + (self.btn_size * 0.05)
+			btn_pos.y = self.pos.y + self.size.y / 2 - self.btn_size / 2
 		end
 
 		if (self.orientation == "vertical" and
@@ -195,15 +196,16 @@ function buttonbar_create(name, cbf_buttonhandler, pos, orientation, size)
 	self.have_move_buttons = false
 	self.hidden = false
 
-	if self.orientation == "horizontal" then
-			self.btn_size = self.size.y
-	else
-			self.btn_size = self.size.x
+	if self.btn_initial_offset == nil then
+		self.btn_initial_offset = 0.375
 	end
 
-	if (self.btn_initial_offset == nil) then
-		self.btn_initial_offset = self.btn_size * 0.05
+	if self.orientation == "horizontal" then
+		self.btn_size = self.size.y - 2*0.1
+	else
+		self.btn_size = self.size.x - 2*0.1
 	end
+
 
 	self.userbuttonhandler = cbf_buttonhandler
 	self.buttons = {}

--- a/builtin/fstk/tabview.lua
+++ b/builtin/fstk/tabview.lua
@@ -42,7 +42,7 @@ local function add_tab(self,tab)
 		event_handler = tab.cbf_events,
 		get_formspec = tab.cbf_formspec,
 		tabsize = tab.tabsize,
-		formspec_version = tab.formspec_version,
+		formspec_version = tab.formspec_version or 6,
 		on_change = tab.on_change,
 		tabdata = {},
 	}

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -115,8 +115,7 @@ local function init_globals()
 	mm_game_theme.init()
 
 	-- Create main tabview
-	local tv_main = tabview_create("maintab", {x = 12, y = 5.4}, {x = 0, y = 0})
-	-- note: size would be 15.5,7.1 in real coordinates mode
+	local tv_main = tabview_create("maintab", {x = 15.5, y = 7.1}, {x = 0, y = 0})
 
 	tv_main:set_autosave_tab(true)
 	tv_main:add(tabs.local_game)

--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -194,7 +194,7 @@ return {
 			fs = fs .. "button[0.5,5.1;4.5,0.8;userdata;" .. fgettext("Open User Data Directory") .. "]"
 		end
 
-		return fs, "size[15.5,7.1,false]real_coordinates[true]"
+		return fs
 	end,
 	cbf_button_handler = function(this, fields, name, tabdata)
 		if fields.homepage then

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -148,8 +148,7 @@ local function get_formspec(tabview, name, tabdata)
 		end
 	end
 
-	return table.concat(retval),
-		"size[15.5,7.1,false]real_coordinates[true]"
+	return table.concat(retval)
 end
 
 local function handle_doubleclick(pkg)

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -186,8 +186,8 @@ local function get_formspec(tabview, name, tabdata)
 			host ..
 			"container_end[]" ..
 			"container[5.25,0.375]" ..
-			"label[0,-0.05;".. fgettext("Select World:") .. "]"..
-			"textlist[0,0.4;9.875,3.7;sp_worlds;" ..
+			"label[0,0.2;".. fgettext("Select World:") .. "]"..
+			"textlist[0,0.5;9.875,3.6;sp_worlds;" ..
 			menu_render_worldlist() ..
 			";" .. index .. "]" ..
 			"container_end[]"

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -201,25 +201,25 @@ local function get_formspec(tabview, name, tabdata)
 
 		y = y + yo + 0.25
 
-		retval = retval .. "field[0," .. y .. ";3.8,0.75;te_playername;" .. fgettext("Name") .. ";" ..
+		retval = retval .. "field[0," .. y .. ";4.5,0.75;te_playername;" .. fgettext("Name") .. ";" ..
 				core.formspec_escape(current_name) .. "]"
 
 		y = y + 1 + 0.25
 
-		retval = retval .. "pwdfield[0," .. y .. ";3.8,0.75;te_passwd;" .. fgettext("Password") .. "]"
+		retval = retval .. "pwdfield[0," .. y .. ";4.5,0.75;te_passwd;" .. fgettext("Password") .. "]"
 
 		y = y + 1 + 0.25
 
 		local bind_addr = core.settings:get("bind_address")
 		if bind_addr ~= nil and bind_addr ~= "" then
 			retval = retval ..
-				"field[0," .. y .. ";2.5,0.75;te_serveraddr;" .. fgettext("Bind Address") .. ";" ..
+				"field[0," .. y .. ";3,0.75;te_serveraddr;" .. fgettext("Bind Address") .. ";" ..
 				core.formspec_escape(core.settings:get("bind_address")) .. "]" ..
-				"field[2.85," .. y .. ";1.25,0.75;te_serverport;" .. fgettext("Port") .. ";" ..
+				"field[3.25," .. y .. ";1.25,0.75;te_serverport;" .. fgettext("Port") .. ";" ..
 				core.formspec_escape(current_port) .. "]"
 		else
 			retval = retval ..
-				"field[0," .. y .. ";3.8,0.75;te_serverport;" .. fgettext("Server Port") .. ";" ..
+				"field[0," .. y .. ";4.5,0.75;te_serverport;" .. fgettext("Server Port") .. ";" ..
 				core.formspec_escape(current_port) .. "]"
 		end
 

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -83,7 +83,7 @@ function singleplayer_refresh_gamebar()
 
 	local btnbar = buttonbar_create("game_button_bar",
 		game_buttonbar_button_handler,
-		{x=-0.3,y=5.9}, "horizontal", {x=12.4,y=1.15})
+		{x=0,y=7.475}, "horizontal", {x=15.5,y=1.25})
 
 	for _, game in ipairs(pkgmgr.games) do
 		local btn_name = "game_btnbar_" .. game.id
@@ -155,7 +155,7 @@ local function get_formspec(tabview, name, tabdata)
 	local creative, damage, host = "", "", ""
 
 	-- Y offsets for game settings checkboxes
-	local y = -0.2
+	local y = 0.2
 	local yo = 0.45
 
 	if disabled_settings["creative_mode"] == nil then
@@ -175,41 +175,58 @@ local function get_formspec(tabview, name, tabdata)
 	end
 
 	retval = retval ..
-			"button[3.9,3.8;2.8,1;world_delete;".. fgettext("Delete") .. "]" ..
-			"button[6.55,3.8;2.8,1;world_configure;".. fgettext("Select Mods") .. "]" ..
-			"button[9.2,3.8;2.8,1;world_create;".. fgettext("New") .. "]" ..
-			"label[3.9,-0.05;".. fgettext("Select World:") .. "]"..
+			"container[5.25,4.75]" ..
+			"button[0,0;3.125,0.85;world_delete;".. fgettext("Delete") .. "]" ..
+			"button[3.375,0;3.125,0.85;world_configure;".. fgettext("Select Mods") .. "]" ..
+			"button[6.75,0;3.125,0.85;world_create;".. fgettext("New") .. "]" ..
+			"container_end[]" ..
+			"container[0.375,0.375]" ..
 			creative ..
 			damage ..
 			host ..
-			"textlist[3.9,0.4;7.9,3.45;sp_worlds;" ..
+			"container_end[]" ..
+			"container[5.25,0.375]" ..
+			"label[0,-0.05;".. fgettext("Select World:") .. "]"..
+			"textlist[0,0.4;9.875,3.7;sp_worlds;" ..
 			menu_render_worldlist() ..
-			";" .. index .. "]"
+			";" .. index .. "]" ..
+			"container_end[]"
 
 	if core.settings:get_bool("enable_server") and disabled_settings["enable_server"] == nil then
 		retval = retval ..
-				"button[7.9,4.75;4.1,1;play;".. fgettext("Host Game") .. "]" ..
+				"button[11.025,5.85;4.1,0.85;play;".. fgettext("Host Game") .. "]" ..
+				"container[0.375,0.375]" ..
 				"checkbox[0,"..y..";cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
-				dump(core.settings:get_bool("server_announce")) .. "]" ..
-				"field[0.3,2.85;3.8,0.5;te_playername;" .. fgettext("Name") .. ";" ..
-				core.formspec_escape(current_name) .. "]" ..
-				"pwdfield[0.3,4.05;3.8,0.5;te_passwd;" .. fgettext("Password") .. "]"
+				dump(core.settings:get_bool("server_announce")) .. "]"
+
+		y = y + yo + 0.25
+
+		retval = retval .. "field[0," .. y .. ";3.8,0.75;te_playername;" .. fgettext("Name") .. ";" ..
+				core.formspec_escape(current_name) .. "]"
+
+		y = y + 1 + 0.25
+
+		retval = retval .. "pwdfield[0," .. y .. ";3.8,0.75;te_passwd;" .. fgettext("Password") .. "]"
+
+		y = y + 1 + 0.25
 
 		local bind_addr = core.settings:get("bind_address")
 		if bind_addr ~= nil and bind_addr ~= "" then
 			retval = retval ..
-				"field[0.3,5.25;2.5,0.5;te_serveraddr;" .. fgettext("Bind Address") .. ";" ..
+				"field[0," .. y .. ";2.5,0.75;te_serveraddr;" .. fgettext("Bind Address") .. ";" ..
 				core.formspec_escape(core.settings:get("bind_address")) .. "]" ..
-				"field[2.85,5.25;1.25,0.5;te_serverport;" .. fgettext("Port") .. ";" ..
+				"field[2.85," .. y .. ";1.25,0.75;te_serverport;" .. fgettext("Port") .. ";" ..
 				core.formspec_escape(current_port) .. "]"
 		else
 			retval = retval ..
-				"field[0.3,5.25;3.8,0.5;te_serverport;" .. fgettext("Server Port") .. ";" ..
+				"field[0," .. y .. ";3.8,0.75;te_serverport;" .. fgettext("Server Port") .. ";" ..
 				core.formspec_escape(current_port) .. "]"
 		end
+
+		retval = retval .. "container_end[]"
 	else
 		retval = retval ..
-				"button[7.9,4.75;4.1,1;play;" .. fgettext("Play Game") .. "]"
+				"button[11.025,5.85;4.1,0.85;play;" .. fgettext("Play Game") .. "]"
 	end
 
 	return retval

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -199,16 +199,16 @@ local function get_formspec(tabview, name, tabdata)
 				"checkbox[0,"..y..";cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
 				dump(core.settings:get_bool("server_announce")) .. "]"
 
-		y = y + yo + 0.25
+		y = y + yo + 0.35
 
 		retval = retval .. "field[0," .. y .. ";4.5,0.75;te_playername;" .. fgettext("Name") .. ";" ..
 				core.formspec_escape(current_name) .. "]"
 
-		y = y + 1 + 0.25
+		y = y + 1.15 + 0.25
 
 		retval = retval .. "pwdfield[0," .. y .. ";4.5,0.75;te_passwd;" .. fgettext("Password") .. "]"
 
-		y = y + 1 + 0.25
+		y = y + 1.15 + 0.25
 
 		local bind_addr = core.settings:get("bind_address")
 		if bind_addr ~= nil and bind_addr ~= "" then

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -156,7 +156,7 @@ local function get_formspec(tabview, name, tabdata)
 
 	-- Y offsets for game settings checkboxes
 	local y = 0.2
-	local yo = 0.45
+	local yo = 0.5625
 
 	if disabled_settings["creative_mode"] == nil then
 		creative = "checkbox[0,"..y..";cb_creative_mode;".. fgettext("Creative Mode") .. ";" ..

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -180,7 +180,7 @@ local function get_formspec(tabview, name, tabdata)
 		retval = retval .. ";0]"
 	end
 
-	return retval, "size[15.5,7.1,false]real_coordinates[true]"
+	return retval
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This makes all the tabs in the mainmenu use formspec version 6 and real coordinates. To do this, the local tab has been updated to work with real coordinates

This is a prerequisite to replacing the settings tab with a settings button, part of #13476 

![image](https://github.com/minetest/minetest/assets/2122943/be6e78fb-3191-40ea-8c73-d86d95ae0fe7)



## To do

This PR is Ready for Review 

- [x] Make fields on the left longer, to take up available space minus a margin

## How to test

* Open main menu 
* Test that the Start Game tab works as expected

