### PR TITLE
Consider aliases when moving and comparing items

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4173,6 +4173,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 		m_old_tooltip_id = -1;
 		updateSelectedItem();
+		IItemDefManager *idef = m_client->idef();
 		GUIInventoryList::ItemSpec s = getItemAtPos(m_pointer);
 
 		Inventory *inv_selected = NULL;
@@ -4231,7 +4232,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 		if (m_selected_item && s.isValid()) {
 			ItemStack a = list_selected->getItem(m_selected_item->i);
 			ItemStack b = list_s->getItem(s.i);
-			matching = a.stacksWith(b);
+			matching = a.stacksWith(b, idef);
 		}
 
 		ButtonEventType button = BET_OTHER;
@@ -4377,7 +4378,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 							continue;
 						ItemStack item = list_s->getItem(i);
 
-						if (slct.stacksWith(item)) {
+						if (slct.stacksWith(item, idef)) {
 							IMoveAction *a = new IMoveAction();
 							a->count = item.count;
 							a->from_inv = s.inventoryloc;
@@ -4564,7 +4565,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 					ItemStack item = list_s->getItem(i);
 
-					if (slct.stacksWith(item)) {
+					if (slct.stacksWith(item, idef)) {
 						// Found a match, check if we can pick it up
 						bool full = false;
 						u16 amount = item.count;

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -330,7 +330,7 @@ ItemStack ItemStack::addItem(ItemStack newitem, IItemDefManager *itemdef)
 		newitem.clear();
 	}
 	// If item name or metadata differs, bail out
-	else if (name != newitem.name
+	else if (itemdef->getAlias(name) != itemdef->getAlias(newitem.name)
 		|| metadata != newitem.metadata)
 	{
 		// cannot be added
@@ -350,6 +350,7 @@ ItemStack ItemStack::addItem(ItemStack newitem, IItemDefManager *itemdef)
 		newitem.remove(freespace);
 	}
 
+	name = itemdef->getAlias(name);
 	return newitem;
 }
 
@@ -369,7 +370,7 @@ bool ItemStack::itemFits(ItemStack newitem,
 		newitem.clear();
 	}
 	// If item name or metadata differs, bail out
-	else if (name != newitem.name
+	else if (itemdef->getAlias(name) != itemdef->getAlias(newitem.name)
 		|| metadata != newitem.metadata)
 	{
 		// cannot be added
@@ -392,9 +393,9 @@ bool ItemStack::itemFits(ItemStack newitem,
 	return newitem.empty();
 }
 
-bool ItemStack::stacksWith(ItemStack other) const
+bool ItemStack::stacksWith(ItemStack other, IItemDefManager *itemdef) const
 {
-	return (this->name == other.name &&
+	return (itemdef->getAlias(this->name) == itemdef->getAlias(other.name) &&
 			this->wear == other.wear &&
 			this->metadata == other.metadata);
 }

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -164,7 +164,7 @@ struct ItemStack
 
 	// Checks if another itemstack would stack with this one.
 	// Does not check if the item actually fits in the stack.
-	bool stacksWith(ItemStack other) const;
+	bool stacksWith(ItemStack other, IItemDefManager *itemdef) const;
 
 	// Takes some items.
 	// If there are not enough, takes as many as it can.


### PR DESCRIPTION
Trying to fix #13467:
- Compare item aliases instead of names when moving and comparing item stacks.
- Rename the destiny item stack to its alias to prevent the spread of the aliased name.
