### PR TITLE
Restore the appearance of the "Start Game" tab after #13761

### DIFF
--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -201,7 +201,7 @@ local function get_formspec(tabview, name, tabdata)
 
 		-- Reset y so that the text fields always start at the same position,
 		-- regardless of whether some of the checkboxes are hidden.
-		y = 0.2 + 4*yo + 0.35
+		y = 0.2 + 4 * yo + 0.35
 
 		retval = retval .. "field[0," .. y .. ";4.5,0.75;te_playername;" .. fgettext("Name") .. ";" ..
 				core.formspec_escape(current_name) .. "]"

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -175,10 +175,10 @@ local function get_formspec(tabview, name, tabdata)
 	end
 
 	retval = retval ..
-			"container[5.25,4.75]" ..
-			"button[0,0;3.125,0.85;world_delete;".. fgettext("Delete") .. "]" ..
-			"button[3.375,0;3.125,0.85;world_configure;".. fgettext("Select Mods") .. "]" ..
-			"button[6.75,0;3.125,0.85;world_create;".. fgettext("New") .. "]" ..
+			"container[5.25,4.875]" ..
+			"button[0,0;3.225,0.8;world_delete;".. fgettext("Delete") .. "]" ..
+			"button[3.325,0;3.225,0.8;world_configure;".. fgettext("Select Mods") .. "]" ..
+			"button[6.65,0;3.225,0.8;world_create;".. fgettext("New") .. "]" ..
 			"container_end[]" ..
 			"container[0.375,0.375]" ..
 			creative ..
@@ -187,14 +187,14 @@ local function get_formspec(tabview, name, tabdata)
 			"container_end[]" ..
 			"container[5.25,0.375]" ..
 			"label[0,0.2;".. fgettext("Select World:") .. "]"..
-			"textlist[0,0.5;9.875,3.6;sp_worlds;" ..
+			"textlist[0,0.5;9.875,3.9;sp_worlds;" ..
 			menu_render_worldlist() ..
 			";" .. index .. "]" ..
 			"container_end[]"
 
 	if core.settings:get_bool("enable_server") and disabled_settings["enable_server"] == nil then
 		retval = retval ..
-				"button[10.1875,5.85;4.9375,0.85;play;".. fgettext("Host Game") .. "]" ..
+				"button[10.1875,5.925;4.9375,0.8;play;".. fgettext("Host Game") .. "]" ..
 				"container[0.375,0.375]" ..
 				"checkbox[0,"..y..";cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
 				dump(core.settings:get_bool("server_announce")) .. "]"
@@ -228,7 +228,7 @@ local function get_formspec(tabview, name, tabdata)
 		retval = retval .. "container_end[]"
 	else
 		retval = retval ..
-				"button[10.1875,5.85;4.9375,0.85;play;" .. fgettext("Play Game") .. "]"
+				"button[10.1875,5.925;4.9375,0.8;play;" .. fgettext("Play Game") .. "]"
 	end
 
 	return retval

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -194,12 +194,14 @@ local function get_formspec(tabview, name, tabdata)
 
 	if core.settings:get_bool("enable_server") and disabled_settings["enable_server"] == nil then
 		retval = retval ..
-				"button[11.025,5.85;4.1,0.85;play;".. fgettext("Host Game") .. "]" ..
+				"button[10.1875,5.85;4.9375,0.85;play;".. fgettext("Host Game") .. "]" ..
 				"container[0.375,0.375]" ..
 				"checkbox[0,"..y..";cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
 				dump(core.settings:get_bool("server_announce")) .. "]"
 
-		y = y + yo + 0.35
+		-- Reset y so that the text fields always start at the same position,
+		-- regardless of whether some of the checkboxes are hidden.
+		y = 0.2 + 4*yo + 0.35
 
 		retval = retval .. "field[0," .. y .. ";4.5,0.75;te_playername;" .. fgettext("Name") .. ";" ..
 				core.formspec_escape(current_name) .. "]"
@@ -226,7 +228,7 @@ local function get_formspec(tabview, name, tabdata)
 		retval = retval .. "container_end[]"
 	else
 		retval = retval ..
-				"button[11.025,5.85;4.1,0.85;play;" .. fgettext("Play Game") .. "]"
+				"button[10.1875,5.85;4.9375,0.85;play;" .. fgettext("Play Game") .. "]"
 	end
 
 	return retval


### PR DESCRIPTION
This PR mostly restores the appearance of the "Start Game" tab to how it was before #13761. Since that PR was only meant to migrate the tab to real coordinates, I assume that these visual changes were not intended. (There are more visual changes from that PR, but I have no idea whether they are good or bad.)

Good, `master` branch before #13761 (commit 7b56daa2368be8de8514487f6c937f342d2d6ac5)
<img src="https://user-images.githubusercontent.com/82708541/264292260-296004f7-58b4-44f0-94e6-8a927af6b215.png" alt="screenshot 1" width="512" />

Bad, current `master` branch (commit 0cbf96cc839e1b8202ad782420c9b50fa14ad052)
<img src="https://github.com/minetest/minetest/assets/82708541/3e77ee2b-2df2-486e-9a5d-43e536ea08cd" alt="screenshot 2" width="512" />

Good, this PR (commit ef07d8962e978e1d5afb19dcbeb1b5aaa07d0a5c)
<img src="https://user-images.githubusercontent.com/82708541/264292302-77e1136d-1527-4d92-98c6-2a6ad95f2405.png" alt="screenshot 3" width="512" />

## To do

This PR is a Ready for Review.

## How to test

Verify that the mainmenu looks closer to how it looked before #13761 again.