### PR TITLE
Don't trigger a key event if a key with the same associated char was pressed

### DIFF
--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -38,7 +38,9 @@ public:
 
 	bool operator==(const KeyPress &o) const
 	{
-		return (Char > 0 && Char == o.Char) || (valid_kcode(Key) && Key == o.Key);
+		if (valid_kcode(Key) && valid_kcode(o.Key))
+			return Key == o.Key;
+		return Char > 0 && Char == o.Char;
 	}
 
 	const char *sym() const;

--- a/src/unittest/test_keycode.cpp
+++ b/src/unittest/test_keycode.cpp
@@ -111,7 +111,7 @@ void TestKeycode::testCompare()
 {
 	// Basic comparison
 	UASSERT(KeyPress("5") == KeyPress("KEY_KEY_5"));
-	UASSERT(!(KeyPress("5") == KeyPress("KEY_NUMPAD_5")));
+	UASSERT(!(KeyPress("5") == KeyPress("KEY_NUMPAD5")));
 
 	// Matching char suffices
 	// note: This is a real-world example, Irrlicht maps XK_equal to irr::KEY_PLUS on Linux
@@ -126,4 +126,11 @@ void TestKeycode::testCompare()
 	in.Char = L'\0';
 	in2.Char = L';';
 	UASSERT(KeyPress(in) == KeyPress(in2));
+
+	// Irrlicht sets chars to the according digit for numpad keys.
+	// We need to distinguish them in order to bind numpad keys.
+	irr::SEvent::SKeyInput in3;
+	in3.Key = irr::KEY_NUMPAD5;
+	in3.Char = L'5';
+	UASSERT(!(KeyPress("5") == KeyPress(in3)));
 }


### PR DESCRIPTION
Fix #13770
See https://github.com/minetest/minetest/issues/13770#issuecomment-1703328075

## To do

This PR is Ready for Review.

## How to test

Check that pressing a numpad key doesn't change the active item
