### PR TITLE
send ParticleSpawners to all players when time = 0

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1621,8 +1621,9 @@ void Server::SendAddParticleSpawner(session_t peer_id, u16 protocol_version,
 		) / 4.0f * BS;
 		const float radius_sq = radius * radius;
 		/* Don't send short-lived spawners to distant players.
-		 * This could be replaced with proper tracking at some point. */
-		const bool distance_check = !attached_id && p.time <= 1.0f;
+		 * This could be replaced with proper tracking at some point.
+		 * A lifetime of 0 means that the spawner exists forever.*/
+		const bool distance_check = !attached_id && p.time <= 1.0f && p.time != 0.0f;
 
 		for (const session_t client_id : clients) {
 			RemotePlayer *player = m_env->getPlayer(client_id);


### PR DESCRIPTION
Currently, ParticleSpawners are not sent to all players when they are only short lived, which is implemented checking if time is under a hardcoded value (1). However, when time is euqal to 0, that condition is also true, even though it means that the spawner exists forever ([lua api](https://github.com/minetest/minetest/blob/master/doc/lua_api.md#particlespawner-definition)).

This PR fixes that bug by making sure time is not 0.

## How to test

- Modify a client to log the addition of ParticleSpawners
- Make sure they will recieve ParticleSpawners with time=0 even from far away
