### PR TITLE
Fix that negative integer values for float settings don't get a ".0" suffix

### DIFF
--- a/builtin/mainmenu/settings/components.lua
+++ b/builtin/mainmenu/settings/components.lua
@@ -113,7 +113,7 @@ end
 
 make.float = make_field(tonumber, is_valid_number, function(x)
 	local str = tostring(x)
-	if str:match("^%d+$") then
+	if str:match("^[+-]?%d+$") then
 		str = str .. ".0"
 	end
 	return str


### PR DESCRIPTION
If you enter a positive integer value (or zero) for a float setting using the new settings GUI, it gets a `.0` suffix. If you do the same with a negative integer value, it doesn't get a `.0` suffix.

This PR fixes that. Both the feature and the bug were introduced with #13489.

## To do

This PR is a Ready for Review.

## How to test

Verify that float settings always get a `.0` suffix if they have no decimal places
