### PR TITLE
Allow place_param2 = 0 node placement predictions

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3630,7 +3630,7 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 	const auto place_param2 = selected_def.place_param2;
 
 	if (place_param2) {
-		predicted_node.setParam2(place_param2.value());
+		predicted_node.setParam2(*place_param2);
 	} else if (predicted_f.param_type_2 == CPT2_WALLMOUNTED ||
 			predicted_f.param_type_2 == CPT2_COLORED_WALLMOUNTED) {
 		v3s16 dir = nodepos - neighborpos;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3627,10 +3627,10 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 	// Compare core.item_place_node() for what the server does with param2
 	MapNode predicted_node(id, 0, 0);
 
-	const s16 place_param2 = selected_def.place_param2;
+	const auto place_param2 = selected_def.place_param2;
 
-	if (place_param2 >= 0) {
-		predicted_node.setParam2(place_param2);
+	if (place_param2) {
+		predicted_node.setParam2(place_param2.value());
 	} else if (predicted_f.param_type_2 == CPT2_WALLMOUNTED ||
 			predicted_f.param_type_2 == CPT2_COLORED_WALLMOUNTED) {
 		v3s16 dir = nodepos - neighborpos;
@@ -3689,7 +3689,7 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 	}
 
 	// Apply color
-	if (place_param2 < 0 && (predicted_f.param_type_2 == CPT2_COLOR
+	if (!place_param2 && (predicted_f.param_type_2 == CPT2_COLOR
 			|| predicted_f.param_type_2 == CPT2_COLORED_FACEDIR
 			|| predicted_f.param_type_2 == CPT2_COLORED_4DIR
 			|| predicted_f.param_type_2 == CPT2_COLORED_WALLMOUNTED)) {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3627,9 +3627,9 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 	// Compare core.item_place_node() for what the server does with param2
 	MapNode predicted_node(id, 0, 0);
 
-	const u8 place_param2 = selected_def.place_param2;
+	const s16 place_param2 = selected_def.place_param2;
 
-	if (place_param2) {
+	if (place_param2 >= 0) {
 		predicted_node.setParam2(place_param2);
 	} else if (predicted_f.param_type_2 == CPT2_WALLMOUNTED ||
 			predicted_f.param_type_2 == CPT2_COLORED_WALLMOUNTED) {
@@ -3689,7 +3689,7 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 	}
 
 	// Apply color
-	if (!place_param2 && (predicted_f.param_type_2 == CPT2_COLOR
+	if (place_param2 < 0 && (predicted_f.param_type_2 == CPT2_COLOR
 			|| predicted_f.param_type_2 == CPT2_COLORED_FACEDIR
 			|| predicted_f.param_type_2 == CPT2_COLORED_4DIR
 			|| predicted_f.param_type_2 == CPT2_COLORED_WALLMOUNTED)) {

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -444,7 +444,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 			// Render non-trivial drawtypes like the actual node
 			MapNode n(id);
 			if (def.place_param2)
-				n.setParam2(def.place_param2.value());
+				n.setParam2(*def.place_param2);
 
 			mesh = createSpecialNodeMesh(client, n, &m_colors, f);
 			changeToMesh(mesh);
@@ -640,7 +640,7 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 			// Render non-trivial drawtypes like the actual node
 			MapNode n(id);
 			if (def.place_param2)
-				n.setParam2(def.place_param2.value());
+				n.setParam2(*def.place_param2);
 
 			mesh = createSpecialNodeMesh(client, n, &result->buffer_colors, f);
 			scaleMesh(mesh, v3f(0.12, 0.12, 0.12));

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -443,8 +443,8 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		default: {
 			// Render non-trivial drawtypes like the actual node
 			MapNode n(id);
-			if (def.place_param2 >= 0)
-				n.setParam2(def.place_param2);
+			if (def.place_param2)
+				n.setParam2(def.place_param2.value());
 
 			mesh = createSpecialNodeMesh(client, n, &m_colors, f);
 			changeToMesh(mesh);
@@ -639,8 +639,8 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 		default: {
 			// Render non-trivial drawtypes like the actual node
 			MapNode n(id);
-			if (def.place_param2 >= 0)
-				n.setParam2(def.place_param2);
+			if (def.place_param2)
+				n.setParam2(def.place_param2.value());
 
 			mesh = createSpecialNodeMesh(client, n, &result->buffer_colors, f);
 			scaleMesh(mesh, v3f(0.12, 0.12, 0.12));

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -443,7 +443,8 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		default: {
 			// Render non-trivial drawtypes like the actual node
 			MapNode n(id);
-			n.setParam2(def.place_param2);
+			if (def.place_param2 >= 0)
+				n.setParam2(def.place_param2);
 
 			mesh = createSpecialNodeMesh(client, n, &m_colors, f);
 			changeToMesh(mesh);
@@ -638,7 +639,8 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 		default: {
 			// Render non-trivial drawtypes like the actual node
 			MapNode n(id);
-			n.setParam2(def.place_param2);
+			if (def.place_param2 >= 0)
+				n.setParam2(def.place_param2);
 
 			mesh = createSpecialNodeMesh(client, n, &result->buffer_colors, f);
 			scaleMesh(mesh, v3f(0.12, 0.12, 0.12));

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -172,7 +172,7 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	if (protocol_version <= 43) {
 		// Uncertainity whether 0 is the specified prediction or means disabled
 		if (place_param2)
-			os << place_param2.value();
+			os << *place_param2;
 		else
 			os << (u8)0;
 	}
@@ -182,7 +182,7 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 
 	os << (u8)place_param2.has_value(); // protocol_version >= 43
 	if (place_param2)
-		os << place_param2.value();
+		os << *place_param2;
 }
 
 void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -87,7 +87,7 @@ struct ItemDefinition
 	// Server will update the precise end result a moment later.
 	// "" = no prediction
 	std::string node_placement_prediction;
-	u8 place_param2;
+	s16 place_param2; // -1: not defined, >= 0: hardcoded prediction
 
 	/*
 		Some helpful methods

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include <string>
 #include <iostream>
+#include <optional>
 #include <set>
 #include "itemgroup.h"
 #include "sound.h"
@@ -87,7 +88,7 @@ struct ItemDefinition
 	// Server will update the precise end result a moment later.
 	// "" = no prediction
 	std::string node_placement_prediction;
-	s16 place_param2; // -1: not defined, >= 0: hardcoded prediction
+	std::optional<u8> place_param2;
 
 	/*
 		Some helpful methods

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -217,6 +217,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		[scheduled bump for 5.7.0]
 	PROTOCOL VERSION 43:
 		"start_time" added to TOCLIENT_PLAY_SOUND
+		place_param2 type change u8 -> s16
 		[scheduled bump for 5.8.0]
 */
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -217,7 +217,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		[scheduled bump for 5.7.0]
 	PROTOCOL VERSION 43:
 		"start_time" added to TOCLIENT_PLAY_SOUND
-		place_param2 type change u8 -> s16
+		place_param2 type change u8 -> optional<u8>
 		[scheduled bump for 5.8.0]
 */
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -133,8 +133,9 @@ void read_item_definition(lua_State* L, int index,
 	getstringfield(L, index, "node_placement_prediction",
 			def.node_placement_prediction);
 
-	int place_param2 = getintfield_default(L, index, "place_param2", -1);
-	def.place_param2 = rangelim(place_param2, -1, U8_MAX);
+	int place_param2;
+	if (getintfield(L, index, "place_param2", place_param2))
+		def.place_param2 = rangelim(place_param2, 0, U8_MAX);
 }
 
 /******************************************************************************/

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -133,7 +133,8 @@ void read_item_definition(lua_State* L, int index,
 	getstringfield(L, index, "node_placement_prediction",
 			def.node_placement_prediction);
 
-	getintfield(L, index, "place_param2", def.place_param2);
+	int place_param2 = getintfield_default(L, index, "place_param2", -1);
+	def.place_param2 = rangelim(place_param2, -1, U8_MAX);
 }
 
 /******************************************************************************/


### PR DESCRIPTION
The placement prediction value 0 was accidentally ignored and made the clients fall back to automatic rotation based on the node paramtype2 value.

This now changes the internal representation to s16 to properly indicate the disabled state (e.g. 'nil' in Lua).

*Should* fix #13784

## To do

This PR is Ready for Review.

## How to test

@rollerozxa I currently do not have a good example mod at hand. Would you please be so nice to check whether this PR produces the results you were expecting? Thank you.
