### PR TITLE
Fix liquid falling if in "float" group, fixes #13782

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -79,6 +79,9 @@ core.register_entity(":__builtin:falling_node", {
 		-- Cache whether we're supposed to float on water
 		self.floats = core.get_item_group(node.name, "float") ~= 0
 
+		-- Save liquidtype for falling water
+        self.liquidtype = def.liquidtype
+
 		-- Set entity visuals
 		if def.drawtype == "torchlike" or def.drawtype == "signlike" then
 			local textures
@@ -273,7 +276,8 @@ core.register_entity(":__builtin:falling_node", {
 		-- Decide if we're replacing the node or placing on top
 		local np = vector.copy(bcp)
 		if bcd and bcd.buildable_to and
-				(not self.floats or bcd.liquidtype == "none") then
+			((not self.floats or bcd.liquidtype == "none") or
+             (self.floats and self.liquidtype ~= "none" and bcd.liquidtype ~= "source")) then
 			core.remove_node(bcp)
 		else
 			np.y = np.y + 1
@@ -284,7 +288,7 @@ core.register_entity(":__builtin:falling_node", {
 		local nd = core.registered_nodes[n2.name]
 		-- If it's not air or liquid, remove node and replace it with
 		-- it's drops
-		if n2.name ~= "air" and (not nd or nd.liquidtype == "none") then
+		if n2.name ~= "air" and (not nd or nd.liquidtype ~= "source") then
 			if nd and nd.buildable_to == false then
 				nd.on_dig(np, n2, nil)
 				-- If it's still there, it might be protected

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -274,10 +274,17 @@ core.register_entity(":__builtin:falling_node", {
 		end
 
 		-- Decide if we're replacing the node or placing on top
+		-- This condition is very similar to the check in core.check_single_for_falling(p)
 		local np = vector.copy(bcp)
-		if bcd and bcd.buildable_to and
-			((not self.floats or bcd.liquidtype == "none") or
-             (self.floats and self.liquidtype ~= "none" and bcd.liquidtype ~= "source")) then
+		if bcd and bcd.buildable_to
+				and -- Take "float" group into consideration:
+				(
+					-- Fall through non-liquids
+					not self.floats or bcd.liquidtype == "none" or
+					-- Only let sources fall through flowing liquids
+					(self.floats and self.liquidtype ~= "none" and bcd.liquidtype ~= "source")
+				) then
+
 			core.remove_node(bcp)
 		else
 			np.y = np.y + 1

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -537,16 +537,20 @@ function core.check_single_for_falling(p)
 				return success
 			end
 			local d_falling = core.registered_nodes[n.name]
+			local do_float = core.get_item_group(n.name, "float") > 0
 			-- Otherwise only if the bottom node is considered "fall through"
 			if not same and
-			    (not d_bottom.walkable or d_bottom.buildable_to) and
-			    ((core.get_item_group(n.name, "float") == 0 or
-			      d_bottom.liquidtype == "none") or
-				(core.get_item_group(n.name, "float") > 0 and
-				 d_falling.liquidtype == "source" and
-				 d_bottom.liquidtype ~= "source")) then
-			    local success, _ = convert_to_falling_node(p, n)
-			    return success
+					(not d_bottom.walkable or d_bottom.buildable_to)
+					and -- Take "float" group into consideration:
+					(
+						-- Fall through non-liquids
+						not do_float or d_bottom.liquidtype == "none" or
+						-- Only let sources fall through flowing liquids
+						(do_float and d_falling.liquidtype == "source" and d_bottom.liquidtype ~= "source")
+					) then
+
+				local success, _ = convert_to_falling_node(p, n)
+				return success
 			end
 		end
 	end

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -536,13 +536,17 @@ function core.check_single_for_falling(p)
 				local success, _ = convert_to_falling_node(p, n)
 				return success
 			end
+			local d_falling = core.registered_nodes[n.name]
 			-- Otherwise only if the bottom node is considered "fall through"
 			if not same and
-					(not d_bottom.walkable or d_bottom.buildable_to) and
-					(core.get_item_group(n.name, "float") == 0 or
-					d_bottom.liquidtype == "none") then
-				local success, _ = convert_to_falling_node(p, n)
-				return success
+			    (not d_bottom.walkable or d_bottom.buildable_to) and
+			    ((core.get_item_group(n.name, "float") == 0 or
+			      d_bottom.liquidtype == "none") or
+				(core.get_item_group(n.name, "float") > 0 and
+				 d_falling.liquidtype == "source" and
+				 d_bottom.liquidtype ~= "source")) then
+			    local success, _ = convert_to_falling_node(p, n)
+			    return success
 			end
 		end
 	end

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2156,6 +2156,8 @@ to games.
   Negative damage values are discarded as no damage.
 * `falling_node`: if there is no walkable block under the node it will fall
 * `float`: the node will not fall through liquids (`liquidtype ~= "none"`)
+     * A liquid source with `groups = {falling_node = 1, float = 1}`
+       will fall through flowing liquids.
 * `level`: Can be used to give an additional sense of progression in the game.
      * A larger level will cause e.g. a weapon of a lower level make much less
        damage, and get worn out much faster, or not be able to get drops

--- a/games/devtest/mods/testnodes/liquids.lua
+++ b/games/devtest/mods/testnodes/liquids.lua
@@ -9,7 +9,7 @@ for d=0, 8 do
 	end
 	minetest.register_node("testnodes:rliquid_"..d, {
 		description = "Test Liquid Source, Range "..d..
-			tt_normal,
+			tt_normal .. "\n" .. "(falling & floating node)",
 		drawtype = "liquid",
 		tiles = {"testnodes_liquidsource_r"..d..".png"},
 		special_tiles = {
@@ -25,6 +25,8 @@ for d=0, 8 do
 		liquid_alternative_flowing = "testnodes:rliquid_flowing_"..d,
 		liquid_alternative_source = "testnodes:rliquid_"..d,
 		liquid_range = d,
+		-- Also use these nodes to test falling, floating liquid source nodes
+		groups = {float = 1, falling_node = 1},
 	})
 
 	minetest.register_node("testnodes:rliquid_flowing_"..d, {


### PR DESCRIPTION
## Goal of the PR

(Hopefully) fixes #13782

## How does the PR work?

It makes liquid source nodes that are in `falling_node = 1` and `float = 1` fall correctly if `liquidtype = "flowing"` is below. It also makes liquid source nodes replace flowing nodes when it falls.

## Does it resolve any reported issue?

Yes #13782

## Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?

No.

## If not a bug fix, why is this PR needed? What usecases does it solve?

I didn't fill a proper bug report because I initially though it was a mistake on my side, but after doing some test I believe this is a bug.
A liquid node that is in `falling_node = 1` and `float = 1` can't fall because it is often surrounded with flowing liquid nodes. Sources almost always are surrounded by flowing nodes, and rarely with air. This means they can only fall if a solid node under them is removed or directly after placing. Existing water fountains can't really fall and I believe this is a bug.

## Nothing to do

This PR is Ready for Review.

## How to test

Create a liquid in `falling_node = 1` and `float = 1`. The flowing variant should **not** be in `falling_node = 1`.
Place the liquid on the ground and wait for it to spawn flowing nodes. Drop a source node on the flowing nodes and see as it replaces the flowing node on the ground.

Build a tower, place a source node on top. Place a source node over the column of flowing water nodes. The source node should fall to the bottom of the column and touch the ground instead of hitting the topmost flowing node like it was doing before this PR.

Try dropping a source node on another source node - the source node should float on top of  the other source node.

Make an ordinary solid node in `falling_node = 1` and `float = 1` groups, drop it on flowing and source liquid nodes. The node should float on both like it did before this PR.