### PR TITLE
Remove undocumented and useless `air_equivalent` parameter

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -367,7 +367,6 @@ core.register_node(":air", {
 	diggable = false,
 	buildable_to = true,
 	floodable = true,
-	air_equivalent = true,
 	drop = "",
 	groups = {not_in_creative_inventory=1},
 })
@@ -383,7 +382,6 @@ core.register_node(":ignore", {
 	pointable = false,
 	diggable = false,
 	buildable_to = true, -- A way to remove accidentally placed ignores
-	air_equivalent = true,
 	drop = "",
 	groups = {not_in_creative_inventory=1},
 	node_placement_prediction = "",


### PR DESCRIPTION
Fixes #13722 . The parameter doesn't appear anywhere in the code, it doesn't do anything

## To do
This PR is Ready for Review.

## How to test
--
