### PR TITLE
Add OpenGL 3 as a video driver

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -315,6 +315,7 @@ local function check_requirements(name, requires)
 
 	local video_driver = core.get_active_driver()
 	local shaders_support = video_driver == "opengl" or video_driver == "ogles2"
+						 or video_driver == "opengl3"
 	local special = {
 		android = PLATFORM == "Android",
 		desktop = PLATFORM ~= "Android",

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1773,7 +1773,7 @@ shader_path (Shader path) path
 #    Note: A restart is required after changing this!
 #    OpenGL is the default for desktop, and OGLES2 for Android.
 #    Shaders are supported by OpenGL and OGLES2 (experimental).
-video_driver (Video driver) enum  ,opengl,ogles1,ogles2
+video_driver (Video driver) enum  ,opengl,opengl3,ogles1,ogles2
 
 #    Distance in nodes at which transparency depth sorting is enabled
 #    Use this to limit the performance impact of transparency depth sorting

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1772,7 +1772,7 @@ shader_path (Shader path) path
 #    The rendering back-end.
 #    Note: A restart is required after changing this!
 #    OpenGL is the default for desktop, and OGLES2 for Android.
-#    Shaders are supported by OpenGL and OGLES2 (experimental).
+#    Shaders are supported by OpenGL, OpenGL3 (experimental) and OGLES2 (experimental).
 video_driver (Video driver) enum  ,opengl,opengl3,ogles1,ogles2
 
 #    Distance in nodes at which transparency depth sorting is enabled

--- a/client/shaders/Irrlicht/COGLES2OneTextureBlend.fsh
+++ b/client/shaders/Irrlicht/COGLES2OneTextureBlend.fsh
@@ -1,0 +1,75 @@
+precision mediump float;
+
+/* Uniforms */
+
+uniform int uTextureUsage0;
+uniform sampler2D uTextureUnit0;
+uniform int uBlendType;
+uniform int uFogEnable;
+uniform int uFogType;
+uniform vec4 uFogColor;
+uniform float uFogStart;
+uniform float uFogEnd;
+uniform float uFogDensity;
+
+/* Varyings */
+
+varying vec2 vTextureCoord0;
+varying vec4 vVertexColor;
+varying vec4 vSpecularColor;
+varying float vFogCoord;
+
+float computeFog()
+{
+	const float LOG2 = 1.442695;
+	float FogFactor = 0.0;
+
+	if (uFogType == 0) // Exp
+	{
+		FogFactor = exp2(-uFogDensity * vFogCoord * LOG2);
+	}
+	else if (uFogType == 1) // Linear
+	{
+		float Scale = 1.0 / (uFogEnd - uFogStart);
+		FogFactor = (uFogEnd - vFogCoord) * Scale;
+	}
+	else if (uFogType == 2) // Exp2
+	{
+		FogFactor = exp2(-uFogDensity * uFogDensity * vFogCoord * vFogCoord * LOG2);
+	}
+
+	FogFactor = clamp(FogFactor, 0.0, 1.0);
+
+	return FogFactor;
+}
+
+void main()
+{
+	vec4 Color0 = vVertexColor;
+	vec4 Color1 = vec4(1.0, 1.0, 1.0, 1.0);
+
+	if (bool(uTextureUsage0))
+		Color1 = texture2D(uTextureUnit0, vTextureCoord0);
+
+	vec4 FinalColor = Color0 * Color1;
+	FinalColor += vSpecularColor;
+
+	if (uBlendType == 1)
+	{
+		FinalColor.w = Color0.w;
+	}
+	else if (uBlendType == 2)
+	{
+		FinalColor.w = Color1.w;
+	}
+
+	if (bool(uFogEnable))
+	{
+		float FogFactor = computeFog();
+		vec4 FogColor = uFogColor;
+		FogColor.a = 1.0;
+		FinalColor = mix(FogColor, FinalColor, FogFactor);
+	}
+
+	gl_FragColor = FinalColor;
+}

--- a/client/shaders/Irrlicht/COGLES2Renderer2D.fsh
+++ b/client/shaders/Irrlicht/COGLES2Renderer2D.fsh
@@ -1,0 +1,21 @@
+precision mediump float;
+
+/* Uniforms */
+
+uniform int uTextureUsage;
+uniform sampler2D uTextureUnit;
+
+/* Varyings */
+
+varying vec2 vTextureCoord;
+varying vec4 vVertexColor;
+
+void main()
+{
+	vec4 Color = vVertexColor;
+
+	if (bool(uTextureUsage))
+		Color *= texture2D(uTextureUnit, vTextureCoord);
+
+	gl_FragColor = Color;
+}

--- a/client/shaders/Irrlicht/COGLES2Renderer2D.vsh
+++ b/client/shaders/Irrlicht/COGLES2Renderer2D.vsh
@@ -1,0 +1,22 @@
+/* Attributes */
+
+attribute vec4 inVertexPosition;
+attribute vec4 inVertexColor;
+attribute vec2 inTexCoord0;
+
+/* Uniforms */
+
+uniform float uThickness;
+
+/* Varyings */
+
+varying vec2 vTextureCoord;
+varying vec4 vVertexColor;
+
+void main()
+{
+	gl_Position = inVertexPosition;
+	gl_PointSize = uThickness;
+	vTextureCoord = inTexCoord0;
+	vVertexColor = inVertexColor.bgra;
+}

--- a/client/shaders/Irrlicht/COGLES2Renderer2D_noTex.fsh
+++ b/client/shaders/Irrlicht/COGLES2Renderer2D_noTex.fsh
@@ -1,0 +1,9 @@
+precision mediump float;
+
+/* Varyings */
+varying vec4 vVertexColor;
+
+void main()
+{
+	gl_FragColor = vVertexColor;
+}

--- a/client/shaders/Irrlicht/COGLES2Solid.fsh
+++ b/client/shaders/Irrlicht/COGLES2Solid.fsh
@@ -1,0 +1,62 @@
+precision mediump float;
+
+/* Uniforms */
+
+uniform int uTextureUsage0;
+uniform sampler2D uTextureUnit0;
+uniform int uFogEnable;
+uniform int uFogType;
+uniform vec4 uFogColor;
+uniform float uFogStart;
+uniform float uFogEnd;
+uniform float uFogDensity;
+
+/* Varyings */
+
+varying vec2 vTextureCoord0;
+varying vec4 vVertexColor;
+varying vec4 vSpecularColor;
+varying float vFogCoord;
+
+float computeFog()
+{
+	const float LOG2 = 1.442695;
+	float FogFactor = 0.0;
+
+	if (uFogType == 0) // Exp
+	{
+		FogFactor = exp2(-uFogDensity * vFogCoord * LOG2);
+	}
+	else if (uFogType == 1) // Linear
+	{
+		float Scale = 1.0 / (uFogEnd - uFogStart);
+		FogFactor = (uFogEnd - vFogCoord) * Scale;
+	}
+	else if (uFogType == 2) // Exp2
+	{
+		FogFactor = exp2(-uFogDensity * uFogDensity * vFogCoord * vFogCoord * LOG2);
+	}
+
+	FogFactor = clamp(FogFactor, 0.0, 1.0);
+
+	return FogFactor;
+}
+
+void main()
+{
+	vec4 Color = vVertexColor;
+
+	if (bool(uTextureUsage0))
+		Color *= texture2D(uTextureUnit0, vTextureCoord0);
+	Color += vSpecularColor;
+
+	if (bool(uFogEnable))
+	{
+		float FogFactor = computeFog();
+		vec4 FogColor = uFogColor;
+		FogColor.a = 1.0;
+		Color = mix(FogColor, Color, FogFactor);
+	}
+
+	gl_FragColor = Color;
+}

--- a/client/shaders/Irrlicht/COGLES2Solid.vsh
+++ b/client/shaders/Irrlicht/COGLES2Solid.vsh
@@ -1,0 +1,45 @@
+/* Attributes */
+
+attribute vec3 inVertexPosition;
+attribute vec3 inVertexNormal;
+attribute vec4 inVertexColor;
+attribute vec2 inTexCoord0;
+
+/* Uniforms */
+
+uniform mat4 uWVPMatrix;
+uniform mat4 uWVMatrix;
+uniform mat4 uNMatrix;
+uniform mat4 uTMatrix0;
+
+uniform vec4 uGlobalAmbient;
+uniform vec4 uMaterialAmbient;
+uniform vec4 uMaterialDiffuse;
+uniform vec4 uMaterialEmissive;
+uniform vec4 uMaterialSpecular;
+uniform float uMaterialShininess;
+
+uniform float uThickness;
+
+/* Varyings */
+
+varying vec2 vTextureCoord0;
+varying vec4 vVertexColor;
+varying vec4 vSpecularColor;
+varying float vFogCoord;
+
+void main()
+{
+	gl_Position = uWVPMatrix * vec4(inVertexPosition, 1.0);
+	gl_PointSize = uThickness;
+
+	vec4 TextureCoord0 = vec4(inTexCoord0.x, inTexCoord0.y, 1.0, 1.0);
+	vTextureCoord0 = vec4(uTMatrix0 * TextureCoord0).xy;
+
+	vVertexColor = inVertexColor.bgra;
+	vSpecularColor = vec4(0.0, 0.0, 0.0, 0.0);
+
+	vec3 Position = (uWVMatrix * vec4(inVertexPosition, 1.0)).xyz;
+
+	vFogCoord = length(Position);
+}

--- a/client/shaders/Irrlicht/COGLES2TransparentAlphaChannel.fsh
+++ b/client/shaders/Irrlicht/COGLES2TransparentAlphaChannel.fsh
@@ -1,0 +1,69 @@
+precision mediump float;
+
+/* Uniforms */
+
+uniform float uAlphaRef;
+uniform int uTextureUsage0;
+uniform sampler2D uTextureUnit0;
+uniform int uFogEnable;
+uniform int uFogType;
+uniform vec4 uFogColor;
+uniform float uFogStart;
+uniform float uFogEnd;
+uniform float uFogDensity;
+
+/* Varyings */
+
+varying vec2 vTextureCoord0;
+varying vec4 vVertexColor;
+varying vec4 vSpecularColor;
+varying float vFogCoord;
+
+float computeFog()
+{
+	const float LOG2 = 1.442695;
+	float FogFactor = 0.0;
+
+	if (uFogType == 0) // Exp
+	{
+		FogFactor = exp2(-uFogDensity * vFogCoord * LOG2);
+	}
+	else if (uFogType == 1) // Linear
+	{
+		float Scale = 1.0 / (uFogEnd - uFogStart);
+		FogFactor = (uFogEnd - vFogCoord) * Scale;
+	}
+	else if (uFogType == 2) // Exp2
+	{
+		FogFactor = exp2(-uFogDensity * uFogDensity * vFogCoord * vFogCoord * LOG2);
+	}
+
+	FogFactor = clamp(FogFactor, 0.0, 1.0);
+
+	return FogFactor;
+}
+
+void main()
+{
+	vec4 Color = vVertexColor;
+
+	if (bool(uTextureUsage0))
+	{
+		Color *= texture2D(uTextureUnit0, vTextureCoord0);
+		
+		// TODO: uAlphaRef should rather control sharpness of alpha, don't know how to do that right now and this works in most cases.
+		if (Color.a < uAlphaRef)
+			discard;
+	}
+	Color += vSpecularColor;
+
+	if (bool(uFogEnable))
+	{
+		float FogFactor = computeFog();
+		vec4 FogColor = uFogColor;
+		FogColor.a = 1.0;
+		Color = mix(FogColor, Color, FogFactor);
+	}
+
+	gl_FragColor = Color;
+}

--- a/client/shaders/Irrlicht/COGLES2TransparentAlphaChannelRef.fsh
+++ b/client/shaders/Irrlicht/COGLES2TransparentAlphaChannelRef.fsh
@@ -1,0 +1,67 @@
+precision mediump float;
+
+/* Uniforms */
+
+uniform float uAlphaRef;
+uniform int uTextureUsage0;
+uniform sampler2D uTextureUnit0;
+uniform int uFogEnable;
+uniform int uFogType;
+uniform vec4 uFogColor;
+uniform float uFogStart;
+uniform float uFogEnd;
+uniform float uFogDensity;
+
+/* Varyings */
+
+varying vec2 vTextureCoord0;
+varying vec4 vVertexColor;
+varying vec4 vSpecularColor;
+varying float vFogCoord;
+
+float computeFog()
+{
+	const float LOG2 = 1.442695;
+	float FogFactor = 0.0;
+
+	if (uFogType == 0) // Exp
+	{
+		FogFactor = exp2(-uFogDensity * vFogCoord * LOG2);
+	}
+	else if (uFogType == 1) // Linear
+	{
+		float Scale = 1.0 / (uFogEnd - uFogStart);
+		FogFactor = (uFogEnd - vFogCoord) * Scale;
+	}
+	else if (uFogType == 2) // Exp2
+	{
+		FogFactor = exp2(-uFogDensity * uFogDensity * vFogCoord * vFogCoord * LOG2);
+	}
+
+	FogFactor = clamp(FogFactor, 0.0, 1.0);
+
+	return FogFactor;
+}
+
+void main()
+{
+	vec4 Color = vVertexColor;
+
+	if (bool(uTextureUsage0))
+		Color *= texture2D(uTextureUnit0, vTextureCoord0);
+
+	if (Color.a < uAlphaRef)
+		discard;
+		
+	Color += vSpecularColor;
+
+	if (bool(uFogEnable))
+	{
+		float FogFactor = computeFog();
+		vec4 FogColor = uFogColor;
+		FogColor.a = 1.0;
+		Color = mix(FogColor, Color, FogFactor);
+	}
+
+	gl_FragColor = Color;
+}

--- a/client/shaders/Irrlicht/COGLES2TransparentVertexAlpha.fsh
+++ b/client/shaders/Irrlicht/COGLES2TransparentVertexAlpha.fsh
@@ -1,0 +1,62 @@
+precision mediump float;
+
+/* Uniforms */
+
+uniform int uTextureUsage0;
+uniform sampler2D uTextureUnit0;
+uniform int uFogEnable;
+uniform int uFogType;
+uniform vec4 uFogColor;
+uniform float uFogStart;
+uniform float uFogEnd;
+uniform float uFogDensity;
+
+/* Varyings */
+
+varying vec2 vTextureCoord0;
+varying vec4 vVertexColor;
+varying vec4 vSpecularColor;
+varying float vFogCoord;
+
+float computeFog()
+{
+	const float LOG2 = 1.442695;
+	float FogFactor = 0.0;
+
+	if (uFogType == 0) // Exp
+	{
+		FogFactor = exp2(-uFogDensity * vFogCoord * LOG2);
+	}
+	else if (uFogType == 1) // Linear
+	{
+		float Scale = 1.0 / (uFogEnd - uFogStart);
+		FogFactor = (uFogEnd - vFogCoord) * Scale;
+	}
+	else if (uFogType == 2) // Exp2
+	{
+		FogFactor = exp2(-uFogDensity * uFogDensity * vFogCoord * vFogCoord * LOG2);
+	}
+
+	FogFactor = clamp(FogFactor, 0.0, 1.0);
+
+	return FogFactor;
+}
+
+void main()
+{
+	vec4 Color = vVertexColor;
+
+	if (bool(uTextureUsage0))
+		Color *= texture2D(uTextureUnit0, vTextureCoord0);
+	Color += vSpecularColor;
+
+	if (bool(uFogEnable))
+	{
+		float FogFactor = computeFog();
+		vec4 FogColor = uFogColor;
+		FogColor.a = 1.0;
+		Color = mix(FogColor, Color, FogFactor);
+	}
+
+	gl_FragColor = Color;
+}

--- a/client/shaders/Irrlicht/OneTextureBlend.fsh
+++ b/client/shaders/Irrlicht/OneTextureBlend.fsh
@@ -1,0 +1,75 @@
+#version 100
+
+precision mediump float;
+
+/* Uniforms */
+
+uniform int uTextureUsage0;
+uniform sampler2D uTextureUnit0;
+uniform int uBlendType;
+uniform int uFogEnable;
+uniform int uFogType;
+uniform vec4 uFogColor;
+uniform float uFogStart;
+uniform float uFogEnd;
+uniform float uFogDensity;
+
+/* Varyings */
+
+varying vec2 vTextureCoord0;
+varying vec4 vVertexColor;
+varying float vFogCoord;
+
+float computeFog()
+{
+	const float LOG2 = 1.442695;
+	float FogFactor = 0.0;
+
+	if (uFogType == 0) // Exp
+	{
+		FogFactor = exp2(-uFogDensity * vFogCoord * LOG2);
+	}
+	else if (uFogType == 1) // Linear
+	{
+		float Scale = 1.0 / (uFogEnd - uFogStart);
+		FogFactor = (uFogEnd - vFogCoord) * Scale;
+	}
+	else if (uFogType == 2) // Exp2
+	{
+		FogFactor = exp2(-uFogDensity * uFogDensity * vFogCoord * vFogCoord * LOG2);
+	}
+
+	FogFactor = clamp(FogFactor, 0.0, 1.0);
+
+	return FogFactor;
+}
+
+void main()
+{
+	vec4 Color0 = vVertexColor;
+	vec4 Color1 = vec4(1.0, 1.0, 1.0, 1.0);
+
+	if (bool(uTextureUsage0))
+		Color1 = texture2D(uTextureUnit0, vTextureCoord0);
+
+	vec4 FinalColor = Color0 * Color1;
+
+	if (uBlendType == 1)
+	{
+		FinalColor.w = Color0.w;
+	}
+	else if (uBlendType == 2)
+	{
+		FinalColor.w = Color1.w;
+	}
+
+	if (bool(uFogEnable))
+	{
+		float FogFactor = computeFog();
+		vec4 FogColor = uFogColor;
+		FogColor.a = 1.0;
+		FinalColor = mix(FogColor, FinalColor, FogFactor);
+	}
+
+	gl_FragColor = FinalColor;
+}

--- a/client/shaders/Irrlicht/Renderer2D.fsh
+++ b/client/shaders/Irrlicht/Renderer2D.fsh
@@ -1,0 +1,23 @@
+#version 100
+
+precision mediump float;
+
+/* Uniforms */
+
+uniform int uTextureUsage;
+uniform sampler2D uTextureUnit;
+
+/* Varyings */
+
+varying vec2 vTextureCoord;
+varying vec4 vVertexColor;
+
+void main()
+{
+	vec4 Color = vVertexColor;
+
+	if (bool(uTextureUsage))
+		Color *= texture2D(uTextureUnit, vTextureCoord);
+
+	gl_FragColor = Color;
+}

--- a/client/shaders/Irrlicht/Renderer2D.vsh
+++ b/client/shaders/Irrlicht/Renderer2D.vsh
@@ -1,0 +1,24 @@
+#version 100
+
+/* Attributes */
+
+attribute vec4 inVertexPosition;
+attribute vec4 inVertexColor;
+attribute vec2 inTexCoord0;
+
+/* Uniforms */
+
+uniform float uThickness;
+
+/* Varyings */
+
+varying vec2 vTextureCoord;
+varying vec4 vVertexColor;
+
+void main()
+{
+	gl_Position = inVertexPosition;
+	gl_PointSize = uThickness;
+	vTextureCoord = inTexCoord0;
+	vVertexColor = inVertexColor.bgra;
+}

--- a/client/shaders/Irrlicht/Renderer2D_noTex.fsh
+++ b/client/shaders/Irrlicht/Renderer2D_noTex.fsh
@@ -1,0 +1,11 @@
+#version 100
+
+precision mediump float;
+
+/* Varyings */
+varying vec4 vVertexColor;
+
+void main()
+{
+	gl_FragColor = vVertexColor;
+}

--- a/client/shaders/Irrlicht/Solid.fsh
+++ b/client/shaders/Irrlicht/Solid.fsh
@@ -1,0 +1,62 @@
+#version 100
+
+precision mediump float;
+
+/* Uniforms */
+
+uniform int uTextureUsage0;
+uniform sampler2D uTextureUnit0;
+uniform int uFogEnable;
+uniform int uFogType;
+uniform vec4 uFogColor;
+uniform float uFogStart;
+uniform float uFogEnd;
+uniform float uFogDensity;
+
+/* Varyings */
+
+varying vec2 vTextureCoord0;
+varying vec4 vVertexColor;
+varying float vFogCoord;
+
+float computeFog()
+{
+	const float LOG2 = 1.442695;
+	float FogFactor = 0.0;
+
+	if (uFogType == 0) // Exp
+	{
+		FogFactor = exp2(-uFogDensity * vFogCoord * LOG2);
+	}
+	else if (uFogType == 1) // Linear
+	{
+		float Scale = 1.0 / (uFogEnd - uFogStart);
+		FogFactor = (uFogEnd - vFogCoord) * Scale;
+	}
+	else if (uFogType == 2) // Exp2
+	{
+		FogFactor = exp2(-uFogDensity * uFogDensity * vFogCoord * vFogCoord * LOG2);
+	}
+
+	FogFactor = clamp(FogFactor, 0.0, 1.0);
+
+	return FogFactor;
+}
+
+void main()
+{
+	vec4 Color = vVertexColor;
+
+	if (bool(uTextureUsage0))
+		Color *= texture2D(uTextureUnit0, vTextureCoord0);
+
+	if (bool(uFogEnable))
+	{
+		float FogFactor = computeFog();
+		vec4 FogColor = uFogColor;
+		FogColor.a = 1.0;
+		Color = mix(FogColor, Color, FogFactor);
+	}
+
+	gl_FragColor = Color;
+}

--- a/client/shaders/Irrlicht/Solid.vsh
+++ b/client/shaders/Irrlicht/Solid.vsh
@@ -1,0 +1,38 @@
+#version 100
+
+/* Attributes */
+
+attribute vec3 inVertexPosition;
+attribute vec3 inVertexNormal;
+attribute vec4 inVertexColor;
+attribute vec2 inTexCoord0;
+
+/* Uniforms */
+
+uniform mat4 uWVPMatrix;
+uniform mat4 uWVMatrix;
+uniform mat4 uNMatrix;
+uniform mat4 uTMatrix0;
+
+uniform float uThickness;
+
+/* Varyings */
+
+varying vec2 vTextureCoord0;
+varying vec4 vVertexColor;
+varying float vFogCoord;
+
+void main()
+{
+	gl_Position = uWVPMatrix * vec4(inVertexPosition, 1.0);
+	gl_PointSize = uThickness;
+
+	vec4 TextureCoord0 = vec4(inTexCoord0.x, inTexCoord0.y, 1.0, 1.0);
+	vTextureCoord0 = vec4(uTMatrix0 * TextureCoord0).xy;
+
+	vVertexColor = inVertexColor.bgra;
+
+	vec3 Position = (uWVMatrix * vec4(inVertexPosition, 1.0)).xyz;
+
+	vFogCoord = length(Position);
+}

--- a/client/shaders/Irrlicht/TransparentAlphaChannel.fsh
+++ b/client/shaders/Irrlicht/TransparentAlphaChannel.fsh
@@ -1,0 +1,69 @@
+#version 100
+
+precision mediump float;
+
+/* Uniforms */
+
+uniform float uAlphaRef;
+uniform int uTextureUsage0;
+uniform sampler2D uTextureUnit0;
+uniform int uFogEnable;
+uniform int uFogType;
+uniform vec4 uFogColor;
+uniform float uFogStart;
+uniform float uFogEnd;
+uniform float uFogDensity;
+
+/* Varyings */
+
+varying vec2 vTextureCoord0;
+varying vec4 vVertexColor;
+varying float vFogCoord;
+
+float computeFog()
+{
+	const float LOG2 = 1.442695;
+	float FogFactor = 0.0;
+
+	if (uFogType == 0) // Exp
+	{
+		FogFactor = exp2(-uFogDensity * vFogCoord * LOG2);
+	}
+	else if (uFogType == 1) // Linear
+	{
+		float Scale = 1.0 / (uFogEnd - uFogStart);
+		FogFactor = (uFogEnd - vFogCoord) * Scale;
+	}
+	else if (uFogType == 2) // Exp2
+	{
+		FogFactor = exp2(-uFogDensity * uFogDensity * vFogCoord * vFogCoord * LOG2);
+	}
+
+	FogFactor = clamp(FogFactor, 0.0, 1.0);
+
+	return FogFactor;
+}
+
+void main()
+{
+	vec4 Color = vVertexColor;
+
+	if (bool(uTextureUsage0))
+	{
+		Color *= texture2D(uTextureUnit0, vTextureCoord0);
+
+		// TODO: uAlphaRef should rather control sharpness of alpha, don't know how to do that right now and this works in most cases.
+		if (Color.a < uAlphaRef)
+			discard;
+	}
+
+	if (bool(uFogEnable))
+	{
+		float FogFactor = computeFog();
+		vec4 FogColor = uFogColor;
+		FogColor.a = 1.0;
+		Color = mix(FogColor, Color, FogFactor);
+	}
+
+	gl_FragColor = Color;
+}

--- a/client/shaders/Irrlicht/TransparentAlphaChannelRef.fsh
+++ b/client/shaders/Irrlicht/TransparentAlphaChannelRef.fsh
@@ -1,0 +1,66 @@
+#version 100
+
+precision mediump float;
+
+/* Uniforms */
+
+uniform float uAlphaRef;
+uniform int uTextureUsage0;
+uniform sampler2D uTextureUnit0;
+uniform int uFogEnable;
+uniform int uFogType;
+uniform vec4 uFogColor;
+uniform float uFogStart;
+uniform float uFogEnd;
+uniform float uFogDensity;
+
+/* Varyings */
+
+varying vec2 vTextureCoord0;
+varying vec4 vVertexColor;
+varying float vFogCoord;
+
+float computeFog()
+{
+	const float LOG2 = 1.442695;
+	float FogFactor = 0.0;
+
+	if (uFogType == 0) // Exp
+	{
+		FogFactor = exp2(-uFogDensity * vFogCoord * LOG2);
+	}
+	else if (uFogType == 1) // Linear
+	{
+		float Scale = 1.0 / (uFogEnd - uFogStart);
+		FogFactor = (uFogEnd - vFogCoord) * Scale;
+	}
+	else if (uFogType == 2) // Exp2
+	{
+		FogFactor = exp2(-uFogDensity * uFogDensity * vFogCoord * vFogCoord * LOG2);
+	}
+
+	FogFactor = clamp(FogFactor, 0.0, 1.0);
+
+	return FogFactor;
+}
+
+void main()
+{
+	vec4 Color = vVertexColor;
+
+	if (bool(uTextureUsage0))
+		Color *= texture2D(uTextureUnit0, vTextureCoord0);
+
+	if (Color.a < uAlphaRef)
+		discard;
+
+	if (bool(uFogEnable))
+	{
+		float FogFactor = computeFog();
+		vec4 FogColor = uFogColor;
+		FogColor.a = 1.0;
+		Color = mix(FogColor, Color, FogFactor);
+	}
+
+	gl_FragColor = Color;
+}

--- a/client/shaders/Irrlicht/TransparentVertexAlpha.fsh
+++ b/client/shaders/Irrlicht/TransparentVertexAlpha.fsh
@@ -1,0 +1,62 @@
+#version 100
+
+precision mediump float;
+
+/* Uniforms */
+
+uniform int uTextureUsage0;
+uniform sampler2D uTextureUnit0;
+uniform int uFogEnable;
+uniform int uFogType;
+uniform vec4 uFogColor;
+uniform float uFogStart;
+uniform float uFogEnd;
+uniform float uFogDensity;
+
+/* Varyings */
+
+varying vec2 vTextureCoord0;
+varying vec4 vVertexColor;
+varying float vFogCoord;
+
+float computeFog()
+{
+	const float LOG2 = 1.442695;
+	float FogFactor = 0.0;
+
+	if (uFogType == 0) // Exp
+	{
+		FogFactor = exp2(-uFogDensity * vFogCoord * LOG2);
+	}
+	else if (uFogType == 1) // Linear
+	{
+		float Scale = 1.0 / (uFogEnd - uFogStart);
+		FogFactor = (uFogEnd - vFogCoord) * Scale;
+	}
+	else if (uFogType == 2) // Exp2
+	{
+		FogFactor = exp2(-uFogDensity * uFogDensity * vFogCoord * vFogCoord * LOG2);
+	}
+
+	FogFactor = clamp(FogFactor, 0.0, 1.0);
+
+	return FogFactor;
+}
+
+void main()
+{
+	vec4 Color = vVertexColor;
+
+	if (bool(uTextureUsage0))
+		Color *= texture2D(uTextureUnit0, vTextureCoord0);
+
+	if (bool(uFogEnable))
+	{
+		float FogFactor = computeFog();
+		vec4 FogColor = uFogColor;
+		FogColor.a = 1.0;
+		Color = mix(FogColor, Color, FogFactor);
+	}
+
+	gl_FragColor = Color;
+}

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -299,6 +299,7 @@ std::vector<video::E_DRIVER_TYPE> RenderingEngine::getSupportedVideoDrivers()
 	// Order by preference (best first)
 	static const video::E_DRIVER_TYPE glDrivers[] = {
 		video::EDT_OPENGL,
+		video::EDT_OPENGL3,
 		video::EDT_OGLES2,
 		video::EDT_OGLES1,
 		video::EDT_NULL,
@@ -335,6 +336,7 @@ const VideoDriverInfo &RenderingEngine::getVideoDriverInfo(irr::video::E_DRIVER_
 	static const std::unordered_map<int, VideoDriverInfo> driver_info_map = {
 		{(int)video::EDT_NULL,   {"null",   "NULL Driver"}},
 		{(int)video::EDT_OPENGL, {"opengl", "OpenGL"}},
+		{(int)video::EDT_OPENGL3, {"opengl3", "OpenGL 3"}},
 		{(int)video::EDT_OGLES1, {"ogles1", "OpenGL ES1"}},
 		{(int)video::EDT_OGLES2, {"ogles2", "OpenGL ES2"}},
 	};

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -279,7 +279,7 @@ public:
 		worldViewProj *= worldView;
 		m_world_view_proj.set(*reinterpret_cast<float(*)[16]>(worldViewProj.pointer()), services);
 
-		if (driver->getDriverType() == video::EDT_OGLES2) {
+		if (driver->getDriverType() == video::EDT_OGLES2 || driver->getDriverType() == video::EDT_OPENGL3) {
 			core::matrix4 texture = driver->getTransform(video::ETS_TEXTURE_0);
 			m_world_view.set(*reinterpret_cast<float(*)[16]>(worldView.pointer()), services);
 			m_texture.set(*reinterpret_cast<float(*)[16]>(texture.pointer()), services);
@@ -624,14 +624,14 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 	video::IGPUProgrammingServices *gpu = driver->getGPUProgrammingServices();
 
 	// Create shaders header
-	bool use_gles = driver->getDriverType() == video::EDT_OGLES2;
+	bool use_modern_gl = driver->getDriverType() == video::EDT_OGLES2 || driver->getDriverType() == video::EDT_OPENGL3;
 	std::stringstream shaders_header;
 	shaders_header
 		<< std::noboolalpha
 		<< std::showpoint // for GLSL ES
 		;
 	std::string vertex_header, fragment_header, geometry_header;
-	if (use_gles) {
+	if (use_modern_gl) {
 		shaders_header << R"(
 			#version 100
 		)";
@@ -690,7 +690,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		abort();
 	}
 
-	bool use_discard = use_gles;
+	bool use_discard = use_modern_gl;
 	// For renderers that should use discard instead of GL_ALPHA_TEST
 	const char *renderer = reinterpret_cast<const char*>(GL.GetString(GL.RENDERER));
 	if (strstr(renderer, "GC7000"))


### PR DESCRIPTION
Adds OpenGL 3 as a video driver and puts the necessary shaders in the client/shaders directory so that the OpenGL 3 and GLES 2 video drivers for Irrlicht work out of the box. Right now the GLES 2 video driver does not work out of the box since these shaders are not there, and the OpenGL 3 video driver is not usable by minetest without patches. Feel free to deny this pull request if that is intentional.

## To do

This PR is Ready for Review.

## How to test

First, compile minetest with OpenGL 3 and GLES 2 support. Alternatively, you could also compile irrlicht with this support and then link minetest to irrlicht.

    cmake . -DRUN_IN_PLACE=TRUE -DENABLE_GLES2=ON -DUSE_SDL2=ON -DENABLE_OPENGL3=ON
    make -j$(nproc)

Then, add "video_driver = gles2" or "video_driver = opengl3" to minetest.conf in order to test the two other video drivers.
