### PR TITLE
Settings GUI: Noise parameter setting fixes

### DIFF
--- a/builtin/mainmenu/settings/components.lua
+++ b/builtin/mainmenu/settings/components.lua
@@ -370,8 +370,6 @@ local function noise_params(setting)
 		get_formspec = function(self, avail_w)
 			-- The "defaults" noise parameter flag doesn't reset a noise
 			-- setting to its default value, so we offer a regular reset button.
-			-- I'm not sure what the actual purpose of the "defaults" noise
-			-- parameter flag is.
 			self.resettable = core.settings:has(setting.name)
 
 			local fs = "label[0,0.4;" .. get_label(setting) .. "]" ..

--- a/builtin/mainmenu/settings/components.lua
+++ b/builtin/mainmenu/settings/components.lua
@@ -368,6 +368,12 @@ local function noise_params(setting)
 		setting = setting,
 
 		get_formspec = function(self, avail_w)
+			-- The "defaults" noise parameter flag doesn't reset a noise
+			-- setting to its default value, so we offer a regular reset button.
+			-- I'm not sure what the actual purpose of the "defaults" noise
+			-- parameter flag is.
+			self.resettable = core.settings:has(setting.name)
+
 			local fs = "label[0,0.4;" .. get_label(setting) .. "]" ..
 					("button[%f,0;2.5,0.8;%s;%s]"):format(avail_w - 2.5, "edit_" .. setting.name, fgettext("Edit"))
 			return fs, 0.8

--- a/builtin/mainmenu/settings/dlg_change_mapgen_flags.lua
+++ b/builtin/mainmenu/settings/dlg_change_mapgen_flags.lua
@@ -230,7 +230,7 @@ local function buttonhandler(this, fields)
 
 	for name, value in pairs(fields) do
 		if name:sub(1, 3) == "cb_" then
-			checkboxes[name] = value == "true"
+			checkboxes[name] = core.is_yes(value)
 			return false -- Don't update the formspec!
 		end
 	end

--- a/builtin/mainmenu/settings/dlg_change_mapgen_flags.lua
+++ b/builtin/mainmenu/settings/dlg_change_mapgen_flags.lua
@@ -49,18 +49,14 @@ local function get_formspec(dialogdata)
 	-- Final formspec will be created at the end of this function
 	-- Default values below, may be changed depending on setting type
 	local width = 10
-	local height = 3.5
-	local description_height = 3
+	local height = 2
+	local description_height = 1.5
 
 	local t = get_current_np_group(setting)
 	local dimension = 3
 	if setting.type == "noise_params_2d" then
 		dimension = 2
 	end
-
-	-- More space for 3x3 fields
-	description_height = description_height - 1.5
-	height = height - 1.5
 
 	local fields = {}
 	local function add_field(x, name, label, value)
@@ -109,21 +105,21 @@ local function get_formspec(dialogdata)
 			.. "checkbox[0.5," .. height - 0.6 .. ";cb_defaults;"
 			--[[~ "defaults" is a noise parameter flag.
 			It describes the default processing options
-			for noise settings in main menu -> "All Settings". ]]
+			for noise settings in the settings menu. ]]
 			.. fgettext("defaults") .. ";" -- defaults
 			.. tostring(flags["defaults"] == true) .. "]" -- to get false if nil
 			.. "checkbox[5," .. height - 0.6 .. ";cb_eased;"
 			--[[~ "eased" is a noise parameter flag.
 			It is used to make the map smoother and
 			can be enabled in noise settings in
-			main menu -> "All Settings". ]]
+			the settings menu. ]]
 			.. fgettext("eased") .. ";" -- eased
 			.. tostring(flags["eased"] == true) .. "]"
 			.. "checkbox[5," .. height - 0.15 .. ";cb_absvalue;"
 			--[[~ "absvalue" is a noise parameter flag.
 			It is short for "absolute value".
 			It can be enabled in noise settings in
-			main menu -> "All Settings". ]]
+			the settings menu. ]]
 			.. fgettext("absvalue") .. ";" -- absvalue
 			.. tostring(flags["absvalue"] == true) .. "]"
 
@@ -204,7 +200,7 @@ local function buttonhandler(this, fields)
 		checkboxes = {}
 
 		if setting.type == "noise_params_2d" then
-			 fields["te_spready"] = fields["te_spreadz"]
+			fields["te_spready"] = fields["te_spreadz"]
 		end
 		local new_value = {
 			offset = fields["te_offset"],
@@ -230,6 +226,13 @@ local function buttonhandler(this, fields)
 	if fields["btn_cancel"] then
 		this:delete()
 		return true
+	end
+
+	for name, value in pairs(fields) do
+		if name:sub(1, 3) == "cb_" then
+			checkboxes[name] = value == "true"
+			return false -- Don't update the formspec!
+		end
 	end
 
 	return false

--- a/builtin/mainmenu/settings/init.lua
+++ b/builtin/mainmenu/settings/init.lua
@@ -25,4 +25,4 @@ dofile(path .. DIR_DELIM .. "dlg_settings.lua")
 -- For RUN_IN_PLACE the generated files may appear in the 'bin' folder.
 -- See comment and alternative line at the end of 'generate_from_settingtypes.lua'.
 
---assert(loadfile(path .. DIR_DELIM .. "generate_from_settingtypes.lua"))(parse_config_file(true, false))
+-- assert(loadfile(path .. DIR_DELIM .. "generate_from_settingtypes.lua"))(settingtypes.parse_config_file(true, false))

--- a/builtin/mainmenu/settings/settingtypes.lua
+++ b/builtin/mainmenu/settings/settingtypes.lua
@@ -198,7 +198,6 @@ local function parse_setting_line(settings, line, read_all, base_level, allow_se
 		local flags = ""
 		if index then
 			flags = default:sub(index)
-			default = default:sub(1, index - 3) -- Make sure no flags in single-line format
 		end
 		table.insert(values, flags)
 


### PR DESCRIPTION
This PR makes two small fixes regarding noise parameter settings to the settings GUI:

- #12480 accidentally didn't copy over these lines from the deleted `dlg_settings_advanced.lua` to the newly added `dlg_change_mapgen_flags.lua`:
  
  https://github.com/minetest/minetest/blob/1b95998d11fb0d51fbfeedc56de4ca2191ad3f7a/builtin/mainmenu/dlg_settings_advanced.lua#L963-L967

  This means that if you change noise parameter flags using the checkboxes at the bottom of the noise parameter dialog, your changes won't be saved. This PR fixes that.

- Also, noise parameter settings now show a reset button if they have been changed.

Of course, the noise parameter dialog could be improved a lot more, see #13476.

## To do

This PR is a Ready for Review.

## How to test

Verify that the noise parameter dialog saves your changes to the flags (aka the checkboxes).

Verify that a reset button is shown for changed noise parameter settings.
