### PR TITLE
Replace `chat_font_size` with `mono_font_size` in the accessibility settings

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -71,7 +71,7 @@ add_page({
 		"language",
 		{ heading = gettext("General") },
 		"font_size",
-		"chat_font_size",
+		"mono_font_size",
 		"gui_scaling",
 		"hud_scaling",
 		"show_nametag_backgrounds",

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -707,7 +707,7 @@ clickable_chat_weblinks (Chat weblinks) bool true
 chat_weblink_color (Weblink color) string #8888FF
 
 #    Font size of the recent chat text and chat prompt in point (pt).
-#    Value 0 will use the default font size.
+#    Value 0 will use the monospace font size.
 chat_font_size (Chat font size) int 0 0 72
 
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -331,7 +331,7 @@ void set_default_settings()
 	std::string font_size_str = std::to_string(TTF_DEFAULT_FONT_SIZE);
 	settings->setDefault("font_size", font_size_str);
 	settings->setDefault("mono_font_size", font_size_str);
-	settings->setDefault("chat_font_size", "0"); // Default "font_size"
+	settings->setDefault("chat_font_size", "0"); // Default "mono_font_size"
 
 	// ContentDB
 	settings->setDefault("contentdb_url", "https://content.minetest.net");


### PR DESCRIPTION
Currently, the accessibility settings include `chat_font_size`, but not `mono_font_size`. This PR reverses that.

`chat_font_size` defaults to `mono_font_size`. Being able to set `mono_font_size` is more useful than being able to set `chat_font_size` because `mono_font_size` could affect more than just the chat.

This PR also corrects the documentation which states that `chat_font_size` defaults to `font_size` even though it actually defaults to `mono_font_size`.

## To do

This PR is a Ready for Review.

## How to test

Look at the accessibility settings menu.

Change `mono_font_size`, verify that it affects the chat font size.
