### PR TITLE
Two ContentDB GUI fixes

### DIFF
--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -733,8 +733,16 @@ function store.sort_packages()
 		end
 	end
 
-	-- Sort installed content by title
+	-- Sort installed content first by "is there an update available?", then by title
 	table.sort(ret, function(a, b)
+		local a_updatable = a.installed_release < a.release
+		local b_updatable = b.installed_release < b.release
+		if a_updatable and not b_updatable then
+			return true
+		elseif b_updatable and not a_updatable then
+			return false
+		end
+
 		return a.title < b.title
 	end)
 
@@ -908,7 +916,10 @@ function store.get_formspec(dlgdata)
 		formspec[#formspec + 1] = "]"
 
 		-- buttons
-		local left_base = "image_button[-1.55,0;0.7,0.7;" .. core.formspec_escape(defaulttexturedir)
+		local description_width = W - 2.625 - 2*0.7 - 2*0.15
+
+		local second_base = "image_button[-1.55,0;0.7,0.7;" .. core.formspec_escape(defaulttexturedir)
+		local third_base = "image_button[-2.4,0;0.7,0.7;" .. core.formspec_escape(defaulttexturedir)
 		formspec[#formspec + 1] = "container["
 		formspec[#formspec + 1] = W - 0.375*2
 		formspec[#formspec + 1] = ",0.1]"
@@ -918,28 +929,28 @@ function store.get_formspec(dlgdata)
 			formspec[#formspec + 1] = core.formspec_escape(defaulttexturedir)
 			formspec[#formspec + 1] = "cdb_downloading.png;3;400;]"
 		elseif package.queued then
-			formspec[#formspec + 1] = left_base
+			formspec[#formspec + 1] = second_base
 			formspec[#formspec + 1] = "cdb_queued.png;queued;]"
 		elseif not package.path then
 			local elem_name = "install_" .. i .. ";"
 			formspec[#formspec + 1] = "style[" .. elem_name .. "bgcolor=#71aa34]"
-			formspec[#formspec + 1] = left_base .. "cdb_add.png;" .. elem_name .. "]"
+			formspec[#formspec + 1] = second_base .. "cdb_add.png;" .. elem_name .. "]"
 			formspec[#formspec + 1] = "tooltip[" .. elem_name .. fgettext("Install") .. tooltip_colors
 		else
 			if package.installed_release < package.release then
-
 				-- The install_ action also handles updating
 				local elem_name = "install_" .. i .. ";"
 				formspec[#formspec + 1] = "style[" .. elem_name .. "bgcolor=#28ccdf]"
-				formspec[#formspec + 1] = left_base .. "cdb_update.png;" .. elem_name .. "]"
+				formspec[#formspec + 1] = third_base .. "cdb_update.png;" .. elem_name .. "]"
 				formspec[#formspec + 1] = "tooltip[" .. elem_name .. fgettext("Update") .. tooltip_colors
-			else
 
-				local elem_name = "uninstall_" .. i .. ";"
-				formspec[#formspec + 1] = "style[" .. elem_name .. "bgcolor=#a93b3b]"
-				formspec[#formspec + 1] = left_base .. "cdb_clear.png;" .. elem_name .. "]"
-				formspec[#formspec + 1] = "tooltip[" .. elem_name .. fgettext("Uninstall") .. tooltip_colors
+				description_width = description_width - 0.7 - 0.15
 			end
+
+			local elem_name = "uninstall_" .. i .. ";"
+			formspec[#formspec + 1] = "style[" .. elem_name .. "bgcolor=#a93b3b]"
+			formspec[#formspec + 1] = second_base .. "cdb_clear.png;" .. elem_name .. "]"
+			formspec[#formspec + 1] = "tooltip[" .. elem_name .. fgettext("Uninstall") .. tooltip_colors
 		end
 
 		local web_elem_name = "view_" .. i .. ";"
@@ -950,7 +961,6 @@ function store.get_formspec(dlgdata)
 		formspec[#formspec + 1] = "container_end[]"
 
 		-- description
-		local description_width = W - 0.375*5 - 0.85 - 2*0.7 - 0.15
 		formspec[#formspec + 1] = "textarea[1.855,0.3;"
 		formspec[#formspec + 1] = tostring(description_width)
 		formspec[#formspec + 1] = ",0.8;;;"

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -916,7 +916,7 @@ function store.get_formspec(dlgdata)
 		formspec[#formspec + 1] = "]"
 
 		-- buttons
-		local description_width = W - 2.625 - 2*0.7 - 2*0.15
+		local description_width = W - 2.625 - 2 * 0.7 - 2 * 0.15
 
 		local second_base = "image_button[-1.55,0;0.7,0.7;" .. core.formspec_escape(defaulttexturedir)
 		local third_base = "image_button[-2.4,0;0.7,0.7;" .. core.formspec_escape(defaulttexturedir)

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -797,7 +797,7 @@ local function get_info_formspec(text)
 	return table.concat({
 		"formspec_version[6]",
 		"size[15.75,9.5]",
-		not TOUCHSCREEN_GUI and "position[0.5,0.55]" or "",
+		TOUCHSCREEN_GUI and "padding[0.01,0.01]" or "position[0.5,0.55]",
 
 		"label[4,4.35;", text, "]",
 		"container[0,", H - 0.8 - 0.375, "]",
@@ -827,7 +827,7 @@ function store.get_formspec(dlgdata)
 	local formspec = {
 		"formspec_version[6]",
 		"size[15.75,9.5]",
-		not TOUCHSCREEN_GUI and "position[0.5,0.55]" or "",
+		TOUCHSCREEN_GUI and "padding[0.01,0.01]" or "position[0.5,0.55]",
 
 		"style[status,downloading,queued;border=false]",
 


### PR DESCRIPTION
This PR fixes two minor issues with the ContentDB GUI. I know that a new CDB GUI is in the works, but these issues are such low hanging fruits that I think they should be fixed anyway.

- The dialog now sorts packages that have an update available before all other packages. This allows you to immediately see which packages will be updated when you click "Update All". Fixes #11155.

- You can now uninstall packages that have updates available. Fixes #12670.

## To do

This PR is a Ready for Review.

## How to test

In the CDB GUI:

 - Verify that updatable packages are shown before all other packages.

 - Verify that the "Uninstall" button is also shown for packages that have an update available.