### PR TITLE
Android: Add selection dialog (drop down/combo box)

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2274,7 +2274,7 @@ void Game::openConsole(float scale, const wchar_t *line)
 	assert(scale > 0.0f && scale <= 1.0f);
 
 #ifdef __ANDROID__
-	porting::showInputDialog(gettext("ok"), "", "", 2);
+	porting::showTextInputDialog("", "", 2);
 	m_android_chat_open = true;
 #else
 	if (gui_chat_console->isOpenInhibited())
@@ -2290,14 +2290,18 @@ void Game::openConsole(float scale, const wchar_t *line)
 #ifdef __ANDROID__
 void Game::handleAndroidChatInput()
 {
-	if (m_android_chat_open && porting::getInputDialogState() == 0) {
-		std::string text = porting::getInputDialogValue();
-		client->typeChatMessage(utf8_to_wide(text));
-		m_android_chat_open = false;
+	// It has to be a text input
+	if (m_android_chat_open && porting::getLastInputDialogType() == porting::TEXT_INPUT) {
+		porting::AndroidDialogState dialogState = porting::getInputDialogState();
+		if (dialogState == porting::DIALOG_INPUTTED) {
+			std::string text = porting::getInputDialogMessage();
+			client->typeChatMessage(utf8_to_wide(text));
+		}
+		if (dialogState != porting::DIALOG_SHOWN)
+			m_android_chat_open = false;
 	}
 }
 #endif
-
 
 void Game::toggleFreeMove()
 {

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -286,7 +286,7 @@ public:
 	core::rect<s32> getAbsoluteRect();
 
 #ifdef __ANDROID__
-	bool getAndroidUIInput();
+	void getAndroidUIInput();
 #endif
 
 protected:

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -264,14 +264,19 @@ std::string GUIPasswordChange::getNameByID(s32 id)
 }
 
 #ifdef __ANDROID__
-bool GUIPasswordChange::getAndroidUIInput()
+void GUIPasswordChange::getAndroidUIInput()
 {
-	if (!hasAndroidUIInput())
-		return false;
+	porting::AndroidDialogState dialogState = getAndroidUIInputState();
+	if (dialogState == porting::DIALOG_SHOWN) {
+		return;
+	} else if (dialogState == porting::DIALOG_CANCELED) {
+		m_jni_field_name.clear();
+		return;
+	}
 
-	// still waiting
-	if (porting::getInputDialogState() == -1)
-		return true;
+	// It has to be a text input
+	if (porting::getLastInputDialogType() != porting::TEXT_INPUT)
+		return;
 
 	gui::IGUIElement *e = nullptr;
 	if (m_jni_field_name == "old_password")
@@ -283,10 +288,10 @@ bool GUIPasswordChange::getAndroidUIInput()
 	m_jni_field_name.clear();
 
 	if (!e || e->getType() != irr::gui::EGUIET_EDIT_BOX)
-		return false;
+		return;
 
-	std::string text = porting::getInputDialogValue();
+	std::string text = porting::getInputDialogMessage();
 	e->setText(utf8_to_wide(text).c_str());
-	return false;
+	return;
 }
 #endif

--- a/src/gui/guiPasswordChange.h
+++ b/src/gui/guiPasswordChange.h
@@ -45,7 +45,7 @@ public:
 
 	bool OnEvent(const SEvent &event);
 #ifdef __ANDROID__
-	bool getAndroidUIInput();
+	void getAndroidUIInput();
 #endif
 
 protected:

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -270,9 +270,32 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 			if (((gui::IGUIEditBox *)hovered)->isPasswordBox())
 				type = 3;
 
-			porting::showInputDialog(gettext("OK"), "",
-				wide_to_utf8(((gui::IGUIEditBox *)hovered)->getText()), type);
+			porting::showTextInputDialog("",
+					wide_to_utf8(((gui::IGUIEditBox *) hovered)->getText()), type);
 			return retval;
+		}
+	}
+
+	if (event.EventType == EET_GUI_EVENT) {
+		if (event.GUIEvent.EventType == gui::EGET_LISTBOX_OPENED) {
+			gui::IGUIComboBox *dropdown = (gui::IGUIComboBox *) event.GUIEvent.Caller;
+
+			std::string field_name = getNameByID(dropdown->getID());
+			if (field_name.empty())
+				return false;
+
+			m_jni_field_name = field_name;
+
+			s32 selected_idx = dropdown->getSelected();
+			s32 option_size = dropdown->getItemCount();
+			std::string list_of_options[option_size];
+
+			for (s32 i = 0; i < option_size; i++) {
+				list_of_options[i] = wide_to_utf8(dropdown->getItem(i));
+			}
+
+			porting::showComboBoxDialog(list_of_options, option_size, selected_idx);
+			return true; // Prevent the Irrlicht dropdown from opening.
 		}
 	}
 #endif
@@ -338,22 +361,12 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 }
 
 #ifdef __ANDROID__
-bool GUIModalMenu::hasAndroidUIInput()
+porting::AndroidDialogState GUIModalMenu::getAndroidUIInputState()
 {
-	// no dialog shown
+	// No dialog is shown
 	if (m_jni_field_name.empty())
-		return false;
+		return porting::DIALOG_CANCELED;
 
-	// still waiting
-	if (porting::getInputDialogState() == -1)
-		return true;
-
-	// no value abort dialog processing
-	if (porting::getInputDialogState() != 0) {
-		m_jni_field_name.clear();
-		return false;
-	}
-
-	return true;
+	return porting::getInputDialogState();
 }
 #endif

--- a/src/gui/modalMenu.h
+++ b/src/gui/modalMenu.h
@@ -22,6 +22,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include "irr_ptr.h"
 #include "util/string.h"
+#ifdef __ANDROID__
+	#include <porting_android.h>
+#endif
 
 enum class PointerType {
 	Mouse,
@@ -59,8 +62,8 @@ public:
 	virtual bool OnEvent(const SEvent &event) { return false; };
 	virtual bool pausesGame() { return false; } // Used for pause menu
 #ifdef __ANDROID__
-	virtual bool getAndroidUIInput() { return false; }
-	bool hasAndroidUIInput();
+	virtual void getAndroidUIInput() {};
+	porting::AndroidDialogState getAndroidUIInputState();
 #endif
 
 	PointerType getPointerType() { return m_pointer_type; };

--- a/src/porting_android.h
+++ b/src/porting_android.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #ifndef __ANDROID__
-#error this include has to be included on android port only!
+#error This header has to be included on Android port only!
 #endif
 
 #include <jni.h>
@@ -30,22 +30,28 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 
 namespace porting {
-// java app
+// Java app
 extern android_app *app_global;
 
-// java <-> c++ interaction interface
+// Java <-> C++ interaction interface
 extern JNIEnv *jnienv;
 
 /**
- * show text input dialog in java
- * @param acceptButton text to display on accept button
- * @param hint hint to show
- * @param current initial value to display
- * @param editType type of texfield
- * (1==multiline text input; 2==single line text input; 3=password field)
+ * Show a text input dialog in Java
+ * @param hint Hint to be shown
+ * @param current Initial value to be displayed
+ * @param editType Type of the text field
+ * (1 = multi-line text input; 2 = single-line text input; 3 = password field)
  */
-void showInputDialog(const std::string &acceptButton,
-					const std::string &hint, const std::string &current, int editType);
+void showTextInputDialog(const std::string &hint, const std::string &current, int editType);
+
+/**
+ * Show a selection dialog in Java
+ * @param optionList The list of options
+ * @param listSize Size of the list
+ * @param selectedIdx Selected index
+ */
+void showComboBoxDialog(const std::string optionList[], s32 listSize, s32 selectedIdx);
 
 /**
  * Opens a share intent to the file at path
@@ -54,17 +60,48 @@ void showInputDialog(const std::string &acceptButton,
  */
 void shareFileAndroid(const std::string &path);
 
-/**
- * WORKAROUND for not working callbacks from java -> c++
- * get current state of input dialog
+/*
+ * Types of Android input dialog:
+ * 1. Text input (single/multi-line text and password field)
+ * 2. Selection input (combo box)
  */
-int getInputDialogState();
+enum AndroidDialogType { TEXT_INPUT, SELECTION_INPUT };
 
-/**
- * WORKAROUND for not working callbacks from java -> c++
- * get text in current input dialog
+/*
+ * WORKAROUND for not working callbacks from Java -> C++
+ * Get the type of the last input dialog
  */
-std::string getInputDialogValue();
+AndroidDialogType getLastInputDialogType();
+
+/*
+ * States of Android input dialog:
+ * 1. The dialog is currently shown.
+ * 2. The dialog has its input sent.
+ * 3. The dialog is canceled/dismissed.
+ */
+enum AndroidDialogState { DIALOG_SHOWN, DIALOG_INPUTTED, DIALOG_CANCELED };
+
+/*
+ * WORKAROUND for not working callbacks from Java -> C++
+ * Get the state of the input dialog
+ */
+AndroidDialogState getInputDialogState();
+
+/*
+ * WORKAROUND for not working callbacks from Java -> C++
+ * Get the text in the current/last input dialog
+ * This function clears the dialog state (set to canceled). Make sure to save
+ * the dialog state before calling this function.
+ */
+std::string getInputDialogMessage();
+
+/*
+ * WORKAROUND for not working callbacks from Java -> C++
+ * Get the selection in the current/last input dialog
+ * This function clears the dialog state (set to canceled). Make sure to save
+ * the dialog state before calling this function.
+ */
+int getInputDialogSelection();
 
 #ifndef SERVER
 float getDisplayDensity();


### PR DESCRIPTION
**Goal of the PR**
This PR adds selection dialog on Android that will be shown when a player taps a drop down (combo box).

![Minetest Android selection dialog](https://github.com/minetest/minetest/assets/4017302/bbc95c9b-08c3-4c67-8f79-0ce45f0d522e)

<details>
<summary>Videos</summary>

https://github.com/minetest/minetest/assets/4017302/45c566dc-cca2-4ea6-b486-fdbbf45fcf0b

https://github.com/minetest/minetest/assets/4017302/4fb5315d-4ba4-4241-aea0-6fd48238a616

</details>

**How does the PR work?**
In `GUIFormSpecMenu::getAndroidUIInput()` and `GUIModalMenu::preprocessEvent()`, combo boxes are also processed.

This PR also refactors and simplifies interaction between the Java (Android) part and the C++ part (see `porting_android.cpp/h`). See the commit message for more technical information.

**Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?**
Yes, this PR tries to improve user experiences.

**If not a bug fix, why is this PR needed? What usecases does it solve?**
The Irrlicht's combo box (drop down) is small and hard to navigate on Android (touch-screen devices). Hard to scroll worsen this issue.

## To do

This PR is a Ready for Review.

## How to test

To test the change in the main menu,
1. Run Minetest on a touch-screen device.
2. Open any dialog/setting that has selections/drop downs/combo boxes.
3. Tap it.
4. A selection dialog should show up.
5. Tap a different selection.
6. The formspec should update with new data.
7. Repeat step 3 to 5, but with the same selection (as given).
8. The formspec should stay the same.
9. Repeat step 3 to 4.
10. Tap outside the dialog.
11. The formspec should stay the same.

To test the change inside a world,
1. Run Minetest on a touch-screen device.
2. Create a world (optional) and use a mod that has selections/drop downs/combo boxes.
3. Enter the world.
4. Open the dialog from the mod.
5. Try the same as testing in the main menu above.

**Android: APK builds**
Included in these builds is [the Mail mod](https://content.minetest.net/packages/mt-mods/mail/). Type `/mail` in the chat to open the formspec. These builds use https://github.com/minetest/irrlicht/pull/241 for their IrrlichtMT library.
- [armeabi-v7a](https://drive.google.com/file/d/1PS2wtbOZI6dxzG5xtps_PIZRrs4Tg2eu/view)
- [arm64-v8a](https://drive.google.com/file/d/1ZN3j9q7LKdhT9OaoMI7vRFx1moLglcea/view)
- [x86](https://drive.google.com/file/d/13rw5QI9ac3bX_alnJda7YJaCLDU3f2JN/view)
- [x86_64](https://drive.google.com/file/d/1QAYgt0XNcwjXofZZgft_F7sn1-aig2sp/view)

<details>
<summary>Old builds (without the PR in the IrrlichtMT)</summary>

- [armeabi-v7a](https://drive.google.com/file/d/1JtBIqEZ_yykSBPVyjcdQGZJDz3ScM0qn/view)
- [arm64-v8a](https://drive.google.com/file/d/1LtE8sALurnDHNwU9tiKnQtOf8xyVP17o/view)
- [x86](https://drive.google.com/file/d/1OdaE85rq4DZkjNagRDVP49Q027YIYC15/view)
- [x86_64](https://drive.google.com/file/d/17Fn511yhdNxaixVASN5oCbn9jpY64d-1/view)
</details>