### PR TITLE
Add physics overrides for walk speed and Fast Mode

### DIFF
--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -705,6 +705,7 @@ Methods:
             speed_climb = float,
             speed_crouch = float,
             speed_fast = float,
+            speed_walk = float,
             acceleration_default = float,
             acceleration_air = float,
             acceleration_fast = float,

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -702,8 +702,17 @@ Methods:
         ```lua
         {
             speed = float,
+            speed_climb = float,
+            speed_crouch = float,
+            speed_fast = float,
+            acceleration_default = float,
+            acceleration_air = float,
+            acceleration_fast = float,
             jump = float,
             gravity = float,
+            liquid_fluidity = float,
+            liquid_fluidity_smooth = float,
+            liquid_sink = float,
             sneak = boolean,
             sneak_glitch = boolean,
             new_move = boolean,
@@ -719,7 +728,8 @@ Methods:
 * `get_breath()`
     * returns the player's breath
 * `get_movement_acceleration()`
-    * returns acceleration of the player in different environments:
+    * returns acceleration of the player in different environments
+      (note: does not take physics overrides into account):
 
         ```lua
         {
@@ -730,7 +740,8 @@ Methods:
         ```
 
 * `get_movement_speed()`
-    * returns player's speed in different environments:
+    * returns player's speed in different environments
+      (note: does not take physics overrides into account):
 
         ```lua
         {
@@ -743,7 +754,8 @@ Methods:
         ```
 
 * `get_movement()`
-    * returns player's movement in different environments:
+    * returns player's movement in different environments
+      (note: does not take physics overrides into account):
 
         ```lua
         {

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7792,7 +7792,7 @@ child will follow movement and rotation of that bone.
           when jumping or falling (default: `1`)
             * Note: The actual acceleration is the product of `speed` and `acceleration_air`
         * `acceleration_fast`: multiplier to acceleration in Fast Mode (default: `1`)
-            * Note: The actual acceleration is the product of `speed_fast` and `acceleration_fast`
+            * Note: The actual acceleration is the product of `speed` and `acceleration_fast`
         * `sneak`: whether player can sneak (default: `true`)
         * `sneak_glitch`: whether player can use the new move code replications
           of the old sneak side-effects: sneak ladders and 2 node sneak jump

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7765,15 +7765,17 @@ child will follow movement and rotation of that bone.
 * `set_physics_override(override_table)`
     * Overrides the physics attributes of the player
     * `override_table` is a table with the following fields:
-        * `speed`: multiplier to default movement speed and acceleration values (default: `1`)
-        * `jump`: multiplier to default jump value (default: `1`)
-        * `gravity`: multiplier to default gravity value (default: `1`)
+        * `speed`: multiplier to *all* movement speed and acceleration values (default: `1`)
+                   (see note below)
+        * `speed_walk`: multiplier to default walk speed value (default: `1`)
         * `speed_climb`: multiplier to default climb speed value (default: `1`)
             * Note: The actual climb speed is the product of `speed` and `speed_climb`
         * `speed_crouch`: multiplier to default sneak speed value (default: `1`)
             * Note: The actual sneak speed is the product of `speed` and `speed_crouch`
         * `speed_fast`: multiplier to default speed value in Fast Mode (default: `1`)
             * Note: The actual fast speed is the product of `speed` and `speed_fast`
+        * `jump`: multiplier to default jump value (default: `1`)
+        * `gravity`: multiplier to default gravity value (default: `1`)
         * `liquid_fluidity`: multiplier to liquid movement resistance value
           (for nodes with `liquid_move_physics`); the higher this value, the lower the
           resistance to movement. At `math.huge`, the resistance is zero and you can
@@ -7800,6 +7802,10 @@ child will follow movement and rotation of that bone.
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behavior (default: `true`)
     * Note: All numeric fields above modify a corresponding `movement_*` setting.
+    * Note: `speed` and the other `speed_*` modifiers will be multiplied with
+      each other. Example: If `speed=2`, `speed_walk=3` and everything else is default,
+      walking speed factor is 6, while climbing, sneaking and Fast Mode speed has
+      a factor of 2.
     * For games, we recommend for simpler code to first modify the `movement_*`
       settings (e.g. via the game's `minetest.conf`) to set a global base value
       for all players and only use `set_physics_override` when you need to change

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7772,6 +7772,8 @@ child will follow movement and rotation of that bone.
             * Note: The actual climb speed is the product of `speed` and `speed_climb`
         * `speed_crouch`: multiplier to default sneak speed value (default: `1`)
             * Note: The actual sneak speed is the product of `speed` and `speed_crouch`
+        * `speed_fast`: multiplier to default speed value in Fast Mode (default: `1`)
+            * Note: The actual fast speed is the product of `speed` and `speed_fast`
         * `liquid_fluidity`: multiplier to liquid movement resistance value
           (for nodes with `liquid_move_physics`); the higher this value, the lower the
           resistance to movement. At `math.huge`, the resistance is zero and you can
@@ -7789,6 +7791,8 @@ child will follow movement and rotation of that bone.
         * `acceleration_air`: multiplier to acceleration
           when jumping or falling (default: `1`)
             * Note: The actual acceleration is the product of `speed` and `acceleration_air`
+        * `acceleration_fast`: multiplier to acceleration in Fast Mode (default: `1`)
+            * Note: The actual acceleration is the product of `speed_fast` and `acceleration_fast`
         * `sneak`: whether player can sneak (default: `true`)
         * `sneak_glitch`: whether player can use the new move code replications
           of the old sneak side-effects: sneak ladders and 2 node sneak jump

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7765,9 +7765,10 @@ child will follow movement and rotation of that bone.
 * `set_physics_override(override_table)`
     * Overrides the physics attributes of the player
     * `override_table` is a table with the following fields:
-        * `speed`: multiplier to *all* movement speed and acceleration values (default: `1`)
-                   (see note below)
+        * `speed`: multiplier to *all* movement speed (`speed_*`) and
+                   acceleration (`accelleration_*`) values (default: `1`)
         * `speed_walk`: multiplier to default walk speed value (default: `1`)
+            * Note: The actual walk speed is the product of `speed` and `speed_walk`
         * `speed_climb`: multiplier to default climb speed value (default: `1`)
             * Note: The actual climb speed is the product of `speed` and `speed_climb`
         * `speed_crouch`: multiplier to default sneak speed value (default: `1`)
@@ -7802,10 +7803,6 @@ child will follow movement and rotation of that bone.
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behavior (default: `true`)
     * Note: All numeric fields above modify a corresponding `movement_*` setting.
-    * Note: `speed` and the other `speed_*` modifiers will be multiplied with
-      each other. Example: If `speed=2`, `speed_walk=3` and everything else is default,
-      walking speed factor is 6, while climbing, sneaking and Fast Mode speed has
-      a factor of 2.
     * For games, we recommend for simpler code to first modify the `movement_*`
       settings (e.g. via the game's `minetest.conf`) to set a global base value
       for all players and only use `set_physics_override` when you need to change

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7766,7 +7766,7 @@ child will follow movement and rotation of that bone.
     * Overrides the physics attributes of the player
     * `override_table` is a table with the following fields:
         * `speed`: multiplier to *all* movement speed (`speed_*`) and
-                   acceleration (`accelleration_*`) values (default: `1`)
+                   acceleration (`acceleration_*`) values (default: `1`)
         * `speed_walk`: multiplier to default walk speed value (default: `1`)
             * Note: The actual walk speed is the product of `speed` and `speed_walk`
         * `speed_climb`: multiplier to default climb speed value (default: `1`)

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1806,6 +1806,7 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_speed_walk = readF32(is);
 		// fallback for new overrides (since 5.8.0)
 		if (is.eof()) {
+			// since 5.8.0
 			override_speed_climb = 1.0f;
 			override_speed_crouch = 1.0f;
 			override_liquid_fluidity = 1.0f;
@@ -1813,6 +1814,7 @@ void GenericCAO::processMessage(const std::string &data)
 			override_liquid_sink = 1.0f;
 			override_acceleration_default = 1.0f;
 			override_acceleration_air = 1.0f;
+			// since 5.9.0
 			override_speed_fast = 1.0f;
 			override_acceleration_fast = 1.0f;
 			override_speed_walk = 1.0f;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1801,6 +1801,8 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_liquid_sink = readF32(is);
 		float override_acceleration_default = readF32(is);
 		float override_acceleration_air = readF32(is);
+		float override_speed_fast = readF32(is);
+		float override_acceleration_fast = readF32(is);
 		// fallback for new overrides (since 5.8.0)
 		if (is.eof()) {
 			override_speed_climb = 1.0f;
@@ -1810,6 +1812,8 @@ void GenericCAO::processMessage(const std::string &data)
 			override_liquid_sink = 1.0f;
 			override_acceleration_default = 1.0f;
 			override_acceleration_air = 1.0f;
+			override_speed_fast = 1.0f;
+			override_acceleration_fast = 1.0f;
 		}
 
 		if (m_is_local_player) {
@@ -1827,6 +1831,8 @@ void GenericCAO::processMessage(const std::string &data)
 			phys.liquid_sink = override_liquid_sink;
 			phys.acceleration_default = override_acceleration_default;
 			phys.acceleration_air = override_acceleration_air;
+			phys.speed_fast = override_speed_fast;
+			phys.acceleration_fast = override_acceleration_fast;
 		}
 	} else if (cmd == AO_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1803,6 +1803,7 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_acceleration_air = readF32(is);
 		float override_speed_fast = readF32(is);
 		float override_acceleration_fast = readF32(is);
+		float override_speed_walk = readF32(is);
 		// fallback for new overrides (since 5.8.0)
 		if (is.eof()) {
 			override_speed_climb = 1.0f;
@@ -1814,6 +1815,7 @@ void GenericCAO::processMessage(const std::string &data)
 			override_acceleration_air = 1.0f;
 			override_speed_fast = 1.0f;
 			override_acceleration_fast = 1.0f;
+			override_speed_walk = 1.0f;
 		}
 
 		if (m_is_local_player) {
@@ -1833,6 +1835,7 @@ void GenericCAO::processMessage(const std::string &data)
 			phys.acceleration_air = override_acceleration_air;
 			phys.speed_fast = override_speed_fast;
 			phys.acceleration_fast = override_acceleration_fast;
+			phys.speed_walk = override_speed_walk;
 		}
 	} else if (cmd == AO_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -536,6 +536,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	// Whether superspeed mode is used or not
 	bool superspeed = false;
 
+	f32 speed_walk = movement_speed_walk * physics_override.speed_walk;
 	f32 speed_fast = movement_speed_fast * physics_override.speed_fast;
 
 	if (always_fly_fast && free_move && fast_move)
@@ -554,9 +555,9 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				if (fast_move)
 					speedV.Y = -speed_fast;
 				else
-					speedV.Y = -movement_speed_walk;
+					speedV.Y = -speed_walk;
 			} else if ((in_liquid || in_liquid_stable) && !m_disable_descend) {
-				speedV.Y = -movement_speed_walk;
+				speedV.Y = -speed_walk;
 				swimming_vertical = true;
 			} else if (is_climbing && !m_disable_descend) {
 				speedV.Y = -movement_speed_climb * physics_override.speed_climb;
@@ -586,12 +587,12 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				if (fast_move && (control.aux1 || always_fly_fast))
 					speedV.Y = -speed_fast;
 				else
-					speedV.Y = -movement_speed_walk;
+					speedV.Y = -speed_walk;
 			} else if ((in_liquid || in_liquid_stable) && !m_disable_descend) {
 				if (fast_climb)
 					speedV.Y = -speed_fast;
 				else
-					speedV.Y = -movement_speed_walk;
+					speedV.Y = -speed_walk;
 				swimming_vertical = true;
 			} else if (is_climbing && !m_disable_descend) {
 				if (fast_climb)
@@ -619,12 +620,12 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 					if (fast_move)
 						speedV.Y = speed_fast;
 					else
-						speedV.Y = movement_speed_walk;
+						speedV.Y = speed_walk;
 				} else {
 					if (fast_move && control.aux1)
 						speedV.Y = speed_fast;
 					else
-						speedV.Y = movement_speed_walk;
+						speedV.Y = speed_walk;
 				}
 			}
 		} else if (m_can_jump) {
@@ -643,7 +644,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			if (fast_climb)
 				speedV.Y = speed_fast;
 			else
-				speedV.Y = movement_speed_walk;
+				speedV.Y = speed_walk;
 			swimming_vertical = true;
 		} else if (is_climbing && !m_disable_jump && !control.sneak) {
 			if (fast_climb)
@@ -660,7 +661,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	else if (control.sneak && !free_move && !in_liquid && !in_liquid_stable)
 		speedH = speedH.normalize() * movement_speed_crouch * physics_override.speed_crouch;
 	else
-		speedH = speedH.normalize() * movement_speed_walk;
+		speedH = speedH.normalize() * speed_walk;
 
 	speedH *= control.movement_speed; /* Apply analog input */
 

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -536,6 +536,8 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	// Whether superspeed mode is used or not
 	bool superspeed = false;
 
+	f32 speed_fast = movement_speed_fast * physics_override.speed_fast;
+
 	if (always_fly_fast && free_move && fast_move)
 		superspeed = true;
 
@@ -550,7 +552,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			if (free_move) {
 				// In free movement mode, aux1 descends
 				if (fast_move)
-					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
+					speedV.Y = -speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 			} else if ((in_liquid || in_liquid_stable) && !m_disable_descend) {
@@ -582,18 +584,18 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			if (free_move) {
 				// In free movement mode, sneak descends
 				if (fast_move && (control.aux1 || always_fly_fast))
-					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
+					speedV.Y = -speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 			} else if ((in_liquid || in_liquid_stable) && !m_disable_descend) {
 				if (fast_climb)
-					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
+					speedV.Y = -speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 				swimming_vertical = true;
 			} else if (is_climbing && !m_disable_descend) {
 				if (fast_climb)
-					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
+					speedV.Y = -speed_fast;
 				else
 					speedV.Y = -movement_speed_climb * physics_override.speed_climb;
 			}
@@ -615,12 +617,12 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				// Don't fly up if sneak key is pressed
 				if (player_settings.aux1_descends || always_fly_fast) {
 					if (fast_move)
-						speedV.Y = movement_speed_fast * physics_override.speed_fast;
+						speedV.Y = speed_fast;
 					else
 						speedV.Y = movement_speed_walk;
 				} else {
 					if (fast_move && control.aux1)
-						speedV.Y = movement_speed_fast * physics_override.speed_fast;
+						speedV.Y = speed_fast;
 					else
 						speedV.Y = movement_speed_walk;
 				}
@@ -639,13 +641,13 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			}
 		} else if (in_liquid && !m_disable_jump && !control.sneak) {
 			if (fast_climb)
-				speedV.Y = movement_speed_fast * physics_override.speed_fast;
+				speedV.Y = speed_fast;
 			else
 				speedV.Y = movement_speed_walk;
 			swimming_vertical = true;
 		} else if (is_climbing && !m_disable_jump && !control.sneak) {
 			if (fast_climb)
-				speedV.Y = movement_speed_fast * physics_override.speed_fast;
+				speedV.Y = speed_fast;
 			else
 				speedV.Y = movement_speed_climb * physics_override.speed_climb;
 		}
@@ -654,7 +656,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	// The speed of the player (Y is ignored)
 	if (superspeed || (is_climbing && fast_climb) ||
 			((in_liquid || in_liquid_stable) && fast_climb))
-		speedH = speedH.normalize() * movement_speed_fast * physics_override.speed_fast;
+		speedH = speedH.normalize() * speed_fast;
 	else if (control.sneak && !free_move && !in_liquid && !in_liquid_stable)
 		speedH = speedH.normalize() * movement_speed_crouch * physics_override.speed_crouch;
 	else

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -550,7 +550,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			if (free_move) {
 				// In free movement mode, aux1 descends
 				if (fast_move)
-					speedV.Y = -movement_speed_fast;
+					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 			} else if ((in_liquid || in_liquid_stable) && !m_disable_descend) {
@@ -582,18 +582,18 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			if (free_move) {
 				// In free movement mode, sneak descends
 				if (fast_move && (control.aux1 || always_fly_fast))
-					speedV.Y = -movement_speed_fast;
+					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 			} else if ((in_liquid || in_liquid_stable) && !m_disable_descend) {
 				if (fast_climb)
-					speedV.Y = -movement_speed_fast;
+					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 				swimming_vertical = true;
 			} else if (is_climbing && !m_disable_descend) {
 				if (fast_climb)
-					speedV.Y = -movement_speed_fast;
+					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
 				else
 					speedV.Y = -movement_speed_climb * physics_override.speed_climb;
 			}
@@ -615,12 +615,12 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				// Don't fly up if sneak key is pressed
 				if (player_settings.aux1_descends || always_fly_fast) {
 					if (fast_move)
-						speedV.Y = movement_speed_fast;
+						speedV.Y = movement_speed_fast * physics_override.speed_fast;
 					else
 						speedV.Y = movement_speed_walk;
 				} else {
 					if (fast_move && control.aux1)
-						speedV.Y = movement_speed_fast;
+						speedV.Y = movement_speed_fast * physics_override.speed_fast;
 					else
 						speedV.Y = movement_speed_walk;
 				}
@@ -639,13 +639,13 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			}
 		} else if (in_liquid && !m_disable_jump && !control.sneak) {
 			if (fast_climb)
-				speedV.Y = movement_speed_fast;
+				speedV.Y = movement_speed_fast * physics_override.speed_fast;
 			else
 				speedV.Y = movement_speed_walk;
 			swimming_vertical = true;
 		} else if (is_climbing && !m_disable_jump && !control.sneak) {
 			if (fast_climb)
-				speedV.Y = movement_speed_fast;
+				speedV.Y = movement_speed_fast * physics_override.speed_fast;
 			else
 				speedV.Y = movement_speed_climb * physics_override.speed_climb;
 		}
@@ -654,7 +654,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	// The speed of the player (Y is ignored)
 	if (superspeed || (is_climbing && fast_climb) ||
 			((in_liquid || in_liquid_stable) && fast_climb))
-		speedH = speedH.normalize() * movement_speed_fast;
+		speedH = speedH.normalize() * movement_speed_fast * physics_override.speed_fast;
 	else if (control.sneak && !free_move && !in_liquid && !in_liquid_stable)
 		speedH = speedH.normalize() * movement_speed_crouch * physics_override.speed_crouch;
 	else
@@ -669,13 +669,13 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			(!free_move && m_can_jump && control.jump)) {
 		// Jumping and falling
 		if (superspeed || (fast_move && control.aux1))
-			incH = movement_acceleration_fast * BS * dtime;
+			incH = movement_acceleration_fast * physics_override.acceleration_fast * BS * dtime;
 		else
 			incH = movement_acceleration_air * physics_override.acceleration_air * BS * dtime;
 		incV = 0.0f; // No vertical acceleration in air
 	} else if (superspeed || (is_climbing && fast_climb) ||
 			((in_liquid || in_liquid_stable) && fast_climb)) {
-		incH = incV = movement_acceleration_fast * BS * dtime;
+		incH = incV = movement_acceleration_fast * physics_override.acceleration_fast * BS * dtime;
 	} else {
 		incH = incV = movement_acceleration_default * physics_override.acceleration_default * BS * dtime;
 	}

--- a/src/player.h
+++ b/src/player.h
@@ -115,6 +115,8 @@ struct PlayerPhysicsOverride
 	float liquid_sink = 1.f;
 	float acceleration_default = 1.f;
 	float acceleration_air = 1.f;
+	float speed_fast = 1.f;
+	float acceleration_fast = 1.f;
 };
 
 struct PlayerSettings

--- a/src/player.h
+++ b/src/player.h
@@ -117,6 +117,7 @@ struct PlayerPhysicsOverride
 	float acceleration_air = 1.f;
 	float speed_fast = 1.f;
 	float acceleration_fast = 1.f;
+	float speed_walk = 1.f;
 };
 
 struct PlayerSettings

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -198,6 +198,12 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushnumber(L, phys.acceleration_air);
 	lua_setfield(L, -2, "acceleration_air");
 
+	lua_pushnumber(L, phys.speed_fast);
+	lua_setfield(L, -2, "speed_fast");
+
+	lua_pushnumber(L, phys.acceleration_fast);
+	lua_setfield(L, -2, "acceleration_fast");
+
 	return 1;
 }
 

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -204,6 +204,8 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushnumber(L, phys.acceleration_fast);
 	lua_setfield(L, -2, "acceleration_fast");
 
+	lua_pushnumber(L, phys.speed_walk);
+	lua_setfield(L, -2, "speed_walk");
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1597,6 +1597,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		modified |= getfloatfield(L, 2, "acceleration_air", phys.acceleration_air);
 		modified |= getfloatfield(L, 2, "speed_fast", phys.speed_fast);
 		modified |= getfloatfield(L, 2, "acceleration_fast", phys.acceleration_fast);
+		modified |= getfloatfield(L, 2, "speed_walk", phys.speed_walk);
 		if (modified)
 			playersao->m_physics_override_sent = false;
 	} else {
@@ -1661,6 +1662,8 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "speed_fast");
 	lua_pushnumber(L, phys.acceleration_fast);
 	lua_setfield(L, -2, "acceleration_fast");
+	lua_pushnumber(L, phys.speed_walk);
+	lua_setfield(L, -2, "speed_walk");
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1595,6 +1595,8 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		modified |= getfloatfield(L, 2, "liquid_sink", phys.liquid_sink);
 		modified |= getfloatfield(L, 2, "acceleration_default", phys.acceleration_default);
 		modified |= getfloatfield(L, 2, "acceleration_air", phys.acceleration_air);
+		modified |= getfloatfield(L, 2, "speed_fast", phys.speed_fast);
+		modified |= getfloatfield(L, 2, "acceleration_fast", phys.acceleration_fast);
 		if (modified)
 			playersao->m_physics_override_sent = false;
 	} else {
@@ -1655,6 +1657,10 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "acceleration_default");
 	lua_pushnumber(L, phys.acceleration_air);
 	lua_setfield(L, -2, "acceleration_air");
+	lua_pushnumber(L, phys.speed_fast);
+	lua_setfield(L, -2, "speed_fast");
+	lua_pushnumber(L, phys.acceleration_fast);
+	lua_setfield(L, -2, "acceleration_fast");
 	return 1;
 }
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -333,6 +333,8 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeF32(os, phys.liquid_sink);
 	writeF32(os, phys.acceleration_default);
 	writeF32(os, phys.acceleration_air);
+	writeF32(os, phys.speed_fast);
+	writeF32(os, phys.acceleration_fast);
 	return os.str();
 }
 
@@ -641,8 +643,8 @@ bool PlayerSAO::checkMovementCheat()
 	float player_max_walk = 0; // horizontal movement
 	float player_max_jump = 0; // vertical upwards movement
 
-	float speed_walk   = m_player->movement_speed_walk;
-	float speed_fast   = m_player->movement_speed_fast;
+	float speed_walk = m_player->movement_speed_walk * m_player->physics_override.speed;
+	float speed_fast = m_player->movement_speed_fast * m_player->physics_override.speed_fast;
 	float speed_crouch = m_player->movement_speed_crouch * m_player->physics_override.speed_crouch;
 	float speed_climb  = m_player->movement_speed_climb  * m_player->physics_override.speed_climb;
 	speed_walk   *= m_player->physics_override.speed;

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -335,6 +335,7 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeF32(os, phys.acceleration_air);
 	writeF32(os, phys.speed_fast);
 	writeF32(os, phys.acceleration_fast);
+	writeF32(os, phys.speed_walk);
 	return os.str();
 }
 
@@ -643,14 +644,15 @@ bool PlayerSAO::checkMovementCheat()
 	float player_max_walk = 0; // horizontal movement
 	float player_max_jump = 0; // vertical upwards movement
 
-	float speed_walk = m_player->movement_speed_walk * m_player->physics_override.speed;
+	float speed_walk = m_player->movement_speed_walk * m_player->physics_override.speed_walk;
 	float speed_fast = m_player->movement_speed_fast * m_player->physics_override.speed_fast;
 	float speed_crouch = m_player->movement_speed_crouch * m_player->physics_override.speed_crouch;
-	float speed_climb  = m_player->movement_speed_climb  * m_player->physics_override.speed_climb;
-	speed_walk   *= m_player->physics_override.speed;
-	speed_fast   *= m_player->physics_override.speed;
+	float speed_climb = m_player->movement_speed_climb * m_player->physics_override.speed_climb;
+
+	speed_walk *= m_player->physics_override.speed;
+	speed_fast *= m_player->physics_override.speed;
 	speed_crouch *= m_player->physics_override.speed;
-	speed_climb  *= m_player->physics_override.speed;
+	speed_climb *= m_player->physics_override.speed;
 
 	// Get permissible max. speed
 	if (m_privs.count("fast") != 0) {


### PR DESCRIPTION
Follow-up PR for #11465 based on a suggestion by @grorp.

This PR adds the following new fields to `set_physics_override`:

* `speed_walk`: Normal walking speed
* `speed_fast`: Speed in Fast Mode
* `acceleration_fast`: Acceleration in Fast Mode

`speed_fast` and `acceleration_fast` modify the `movement_speed_fast` and `movement_acceleration_fast` settings by simple multiplication. Like most physics modifiers, they default to 1.

`speed_walk` will multiply `movement_speed_walk` and only affects the walking speed, i.e. not crouching, climbing or Fast Mode.

The player physics are not changed, this PR merely exposes some player physics values to be modifiable by Lua.

Additionally, the Client mod documentation is updated for the new physics overrides (including those added by #11465).

Also, I fixed a small bug in the anticheat because it underestimated the possible max. speed.

**With this PR, every player physics value (`movement_` settings) will be overridable by Lua.** The walk speed and Fast Mode settings are the missing ones.

## How to test

Please test this extensively before merging!

I recommend you to use `luacmd` and `orienteering` mods. Get yourself a speedometer with `/giveme orienteering:speedometer` and put it in the hotbar. This displays your speed at the top which is very useful for testing.

Now, in DevTest, call `me:set_physics_override(table_of_physics_you_want_to_test)`. Test the normal walk speed and Fast Mode. Also test sneaking and climbing if you want to, just to make sure those still work as expected.
Then check if it does what you expect to / what the documentation promises.

Note that the player physics must be completely unchanged if you have not called this function so far. It is also very important this PR is 100% backwards-compatible.

I made some basic tests playing around with various physics overrides. But I did not test networking.

## Notes about speed

Note that `speed` and the other `speed_*` settings are multiplied with each other. `speed` is supposed to affect *all* player speed, no matter the movement type. This is required to keep backwards-compability. All the other `speed_*` values like `speed_fast` will only affect the corresponding movement type.

Example 1: `speed=2, speed_fast=6` must result in 6× speed in fast mode but only 2× speed for all other movement types.

Example 2: `speed=0` must stop all player movement.

Example 3: `speed_walk=0` must only stop walking speed but Fast Mode, sneaking and climbing must be unaffected.
