### PR TITLE
Escape package description in content tab

### DIFF
--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -142,7 +142,7 @@ local function get_formspec(tabview, name, tabdata)
 			end
 		end
 
-		table.insert_all(retval, {"textarea[7.1,2.4;8,3.1;;;", desc, "]"})
+		table.insert_all(retval, {"textarea[7.1,2.4;8,3.1;;;", core.formspec_escape(desc), "]"})
 
 		if core.may_modify_path(selected_pkg.path) then
 			table.insert_all(retval, {

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -86,7 +86,7 @@ local function get_formspec(tabview, name, tabdata)
 		local info = core.get_content_info(selected_pkg.path)
 		local desc = fgettext("No package description available")
 		if info.description and info.description:trim() ~= "" then
-			desc = info.description
+			desc = core.formspec_escape(info.description)
 		end
 
 		local title_and_name
@@ -142,7 +142,7 @@ local function get_formspec(tabview, name, tabdata)
 			end
 		end
 
-		table.insert_all(retval, {"textarea[7.1,2.4;8,3.1;;;", core.formspec_escape(desc), "]"})
+		table.insert_all(retval, {"textarea[7.1,2.4;8,3.1;;;", desc, "]"})
 
 		if core.may_modify_path(selected_pkg.path) then
 			table.insert_all(retval, {


### PR DESCRIPTION
Trivial PR to fix package description not being escaped in the content tab.

## To do
This PR is Ready for Review.

## How to test
Test with any description with characters that need to be escaped. I initially found the issue with [`modpack_w_long_desc`](https://github.com/rollerozxa/minetest-mod-tests/blob/master/modpack_w_long_desc/modpack.conf) which has the GNU/Linux copypasta as the description, with this PR it should properly show up in the content tab.

![image](https://github.com/minetest/minetest/assets/60856959/11e25db2-f882-4a63-9303-a24302f7b2b1)