### PR TITLE
Add button_url[] and hypertext element to allow mods to open web pages

### DIFF
--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -158,7 +158,7 @@ return {
 			"style[label_button;border=false]" ..
 			"button[0.1,3.4;5.3,0.5;label_button;" ..
 			core.formspec_escape(version.project .. " " .. version.string) .. "]" ..
-			"button[1.5,4.1;2.5,0.8;homepage;minetest.net]" ..
+			"button_url[1.5,4.1;2.5,0.8;homepage;minetest.net;https://www.minetest.net/]" ..
 			"hypertext[5.5,0.25;9.75,6.6;credits;" .. minetest.formspec_escape(hypertext) .. "]"
 
 		-- Render information
@@ -188,10 +188,6 @@ return {
 	end,
 
 	cbf_button_handler = function(this, fields, name, tabdata)
-		if fields.homepage then
-			core.open_url("https://www.minetest.net")
-		end
-
 		if fields.share_debug then
 			local path = core.get_user_path() .. DIR_DELIM .. "debug.txt"
 			core.share_file(path)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3017,6 +3017,14 @@ Elements
   centered on `H`. With the new coordinate system, `H` will modify the height.
 * `label` is the text on the button
 
+### `button_url[<X>,<Y>;<W>,<H>;<name>;<label>;url]`
+
+* Clickable button. When clicked, fields will be sent.
+* With the old coordinate system, buttons are a set height, but will be vertically
+  centered on `H`. With the new coordinate system, `H` will modify the height.
+* `label` is the text on the button.
+* `url` must be a valid web URL, wstarting with `http://` or `https://`.
+
 ### `image_button[<X>,<Y>;<W>,<H>;<texture name>;<name>;<label>]`
 
 * `texture name` is the filename of an image
@@ -3042,6 +3050,11 @@ Elements
 
 * When clicked, fields will be sent and the form will quit.
 * Same as `button` in all other respects.
+
+### `button_url_exit[<X>,<Y>;<W>,<H>;<name>;<label>;url]`
+
+* When clicked, fields will be sent and the form will quit.
+* Same as `button_url` in all other respects.
 
 ### `image_button_exit[<X>,<Y>;<W>,<H>;<texture name>;<name>;<label>]`
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3538,11 +3538,13 @@ Changes the style of the text.
 Sets global style.
 
 Global only styles:
+
 * `background`: Text background, a `colorspec` or `none`.
 * `margin`: Page margins in pixel.
 * `valign`: Text vertical alignment (`top`, `middle`, `bottom`).
 
 Inheriting styles (affects child elements):
+
 * `color`: Default text color. Given color is a `colorspec`.
 * `hovercolor`: Color of <action> tags when mouse is over.
 * `size`: Default text size.
@@ -3556,6 +3558,7 @@ tags appear.
 `<tag name=... color=... hovercolor=... font=... size=...>`
 
 Defines or redefines tag style. This can be used to define new tags.
+
 * `name`: Name of the tag to define or change.
 * `color`: Text color. Given color is a `colorspec`.
 * `hovercolor`: Text color when element hovered (only for `action` tags). Given color is a `colorspec`.
@@ -3588,6 +3591,7 @@ Other tags can be added using `<tag ...>` tag.
 Make that text a clickable text triggering an action.
 
 * `name`: Name of the action (mandatory).
+* `url`: URL to open when the action is triggered (optional).
 
 When clicked, the formspec is send to the server. The value of the text field
 sent to `on_player_receive_fields` will be "action:" concatenated to the action

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3019,12 +3019,13 @@ Elements
 
 ### `button_url[<X>,<Y>;<W>,<H>;<name>;<label>;<url>]`
 
-* Clickable button. When clicked, fields will be sent.
+* Clickable button. When clicked, fields will be sent and the user will be given the
+  option to open the URL in a browser.
 * With the old coordinate system, buttons are a set height, but will be vertically
   centered on `H`. With the new coordinate system, `H` will modify the height.
 * To make this into an `image_button`, you can use formspec styling.
 * `label` is the text on the button.
-* `url` must be a valid web URL, wstarting with `http://` or `https://`.
+* `url` must be a valid web URL, starting with `http://` or `https://`.
 
 ### `image_button[<X>,<Y>;<W>,<H>;<texture name>;<name>;<label>]`
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3017,11 +3017,12 @@ Elements
   centered on `H`. With the new coordinate system, `H` will modify the height.
 * `label` is the text on the button
 
-### `button_url[<X>,<Y>;<W>,<H>;<name>;<label>;url]`
+### `button_url[<X>,<Y>;<W>,<H>;<name>;<label>;<url>]`
 
 * Clickable button. When clicked, fields will be sent.
 * With the old coordinate system, buttons are a set height, but will be vertically
   centered on `H`. With the new coordinate system, `H` will modify the height.
+* To make this into an `image_button`, you can use formspec styling.
 * `label` is the text on the button.
 * `url` must be a valid web URL, wstarting with `http://` or `https://`.
 
@@ -3051,7 +3052,7 @@ Elements
 * When clicked, fields will be sent and the form will quit.
 * Same as `button` in all other respects.
 
-### `button_url_exit[<X>,<Y>;<W>,<H>;<name>;<label>;url]`
+### `button_url_exit[<X>,<Y>;<W>,<H>;<name>;<label>;<url>]`
 
 * When clicked, fields will be sent and the form will quit.
 * Same as `button_url` in all other respects.

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -1,12 +1,15 @@
 local color = minetest.colorize
 
+-- The "a" in this text is actually a cyrillic small a (\u0430)
+local unsafe_url = "https://u:p@wikipediа.org:1233/heIIoll?a=b#c"
+
 local clip_fs = [[
 	style_type[label,button,image_button,item_image_button,
 			tabheader,scrollbar,table,animated_image
 			,field,textarea,checkbox,dropdown;noclip=%c]
 
 	label[0,0;A clipping test]
-	button_url[0,1;3,0.8;clip_button;A clipping test;https://u:p@wikipediа.org:1233/heIIoll?a=b#c]
+	button_url[0,1;3,0.8;clip_button;A clipping test;]] .. unsafe_url .. [[]
 	image_button[0,2;3,0.8;testformspec_button_image.png;clip_image_button;A clipping test]
 	item_image_button[0,3;3,0.8;testformspec:item;clip_item_image_button;A clipping test]
 	tabheader[0,4.7;3,0.63;clip_tabheader;Clip,Test,Text,Tabs;1;false;false]
@@ -146,7 +149,7 @@ local hypertext_fs = "hypertext[0,0;11,9;hypertext;"..minetest.formspec_escape(h
 local style_fs = [[
 	style[one_btn1;bgcolor=red;textcolor=yellow;bgcolor_hovered=orange;
 		bgcolor_pressed=purple]
-	button_url[0,0;2.5,0.8;one_btn1;Button;https://u:p@wikipediа.org:1233/heIIoll?a=b#c]
+	button_url[0,0;2.5,0.8;one_btn1;Button;]] .. unsafe_url .. [[]
 
 	style[one_btn2;border=false;textcolor=cyan] ]]..
 	"button[0,1.05;2.5,0.8;one_btn2;Text " .. color("#FF0", "Yellow") .. [[]

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -6,7 +6,7 @@ local clip_fs = [[
 			,field,textarea,checkbox,dropdown;noclip=%c]
 
 	label[0,0;A clipping test]
-	button[0,1;3,0.8;clip_button;A clipping test]
+	button_url[0,1;3,0.8;clip_button;A clipping test;https://example.com]
 	image_button[0,2;3,0.8;testformspec_button_image.png;clip_image_button;A clipping test]
 	item_image_button[0,3;3,0.8;testformspec:item;clip_item_image_button;A clipping test]
 	tabheader[0,4.7;3,0.63;clip_tabheader;Clip,Test,Text,Tabs;1;false;false]
@@ -145,7 +145,7 @@ local hypertext_fs = "hypertext[0,0;11,9;hypertext;"..minetest.formspec_escape(h
 local style_fs = [[
 	style[one_btn1;bgcolor=red;textcolor=yellow;bgcolor_hovered=orange;
 		bgcolor_pressed=purple]
-	button[0,0;2.5,0.8;one_btn1;Button]
+	button_url[0,0;2.5,0.8;one_btn1;Button;https://example.com]
 
 	style[one_btn2;border=false;textcolor=cyan] ]]..
 	"button[0,1.05;2.5,0.8;one_btn2;Text " .. color("#FF0", "Yellow") .. [[]

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -149,7 +149,7 @@ local hypertext_fs = "hypertext[0,0;11,9;hypertext;"..minetest.formspec_escape(h
 local style_fs = [[
 	style[one_btn1;bgcolor=red;textcolor=yellow;bgcolor_hovered=orange;
 		bgcolor_pressed=purple]
-	button_url[0,0;2.5,0.8;one_btn1;Button;]] .. unsafe_url .. [[]
+	button_url_exit[0,0;2.5,0.8;one_btn1;Button;]] .. unsafe_url .. [[]
 
 	style[one_btn2;border=false;textcolor=cyan] ]]..
 	"button[0,1.05;2.5,0.8;one_btn2;Text " .. color("#FF0", "Yellow") .. [[]

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -6,7 +6,7 @@ local clip_fs = [[
 			,field,textarea,checkbox,dropdown;noclip=%c]
 
 	label[0,0;A clipping test]
-	button_url[0,1;3,0.8;clip_button;A clipping test;https://example.com]
+	button_url[0,1;3,0.8;clip_button;A clipping test;https://u:p@wikipediа.org:1233/heIIoll?a=b#c]
 	image_button[0,2;3,0.8;testformspec_button_image.png;clip_image_button;A clipping test]
 	item_image_button[0,3;3,0.8;testformspec:item;clip_item_image_button;A clipping test]
 	tabheader[0,4.7;3,0.63;clip_tabheader;Clip,Test,Text,Tabs;1;false;false]
@@ -145,7 +145,7 @@ local hypertext_fs = "hypertext[0,0;11,9;hypertext;"..minetest.formspec_escape(h
 local style_fs = [[
 	style[one_btn1;bgcolor=red;textcolor=yellow;bgcolor_hovered=orange;
 		bgcolor_pressed=purple]
-	button_url[0,0;2.5,0.8;one_btn1;Button;https://example.com]
+	button_url[0,0;2.5,0.8;one_btn1;Button;https://u:p@wikipediа12.org:1233/heIIoll?a=b#c]
 
 	style[one_btn2;border=false;textcolor=cyan] ]]..
 	"button[0,1.05;2.5,0.8;one_btn2;Text " .. color("#FF0", "Yellow") .. [[]

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -92,6 +92,7 @@ This is a normal text.
 <t_green>color=green</t_green>
 Action: <action name=color><t_green>color=green</t_green></action>
 Action: <action name=hovercolor><t_hover>hovercolor=yellow</t_hover></action>
+Action URL: <action name=open url=https://example.com/?a=b#c>open URL</action>
 <t_size>size=24</t_size>
 <t_mono>font=mono</t_mono>
 <t_multi>color=green font=mono size=24</t_multi>
@@ -145,7 +146,7 @@ local hypertext_fs = "hypertext[0,0;11,9;hypertext;"..minetest.formspec_escape(h
 local style_fs = [[
 	style[one_btn1;bgcolor=red;textcolor=yellow;bgcolor_hovered=orange;
 		bgcolor_pressed=purple]
-	button_url[0,0;2.5,0.8;one_btn1;Button;https://u:p@wikipediа12.org:1233/heIIoll?a=b#c]
+	button_url[0,0;2.5,0.8;one_btn1;Button;https://u:p@wikipediа.org:1233/heIIoll?a=b#c]
 
 	style[one_btn2;border=false;textcolor=cyan] ]]..
 	"button[0,1.05;2.5,0.8;one_btn2;Text " .. color("#FF0", "Yellow") .. [[]

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -1,7 +1,7 @@
 local color = minetest.colorize
 
--- The "a" in this text is actually a cyrillic small a (\u0430)
-local unsafe_url = "https://u:p@wikipediа.org:1233/heIIoll?a=b#c"
+-- \208\176 is a cyrillic small a
+local unsafe_url = minetest.formspec_escape("https://u:p@wikipedi\208\176.org:1233/heIIoll?a=b#c")
 
 local clip_fs = [[
 	style_type[label,button,image_button,item_image_button,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -50,6 +50,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gui/guiFormSpecMenu.h"
 #include "gui/guiKeyChangeMenu.h"
 #include "gui/guiPasswordChange.h"
+#include "gui/guiOpenURL.h"
 #include "gui/guiVolumeChange.h"
 #include "gui/mainmenumanager.h"
 #include "gui/profilergraph.h"
@@ -1813,6 +1814,12 @@ inline bool Game::handleCallbacks()
 		(new GUIKeyChangeMenu(guienv, guiroot, -1,
 				      &g_menumgr, texture_src))->drop();
 		g_gamecallback->keyconfig_requested = false;
+	}
+
+	if (!g_gamecallback->show_open_url_dialog.empty()) {
+		(new GUIOpenURLMenu(guienv, guiroot, -1,
+				 &g_menumgr, texture_src, g_gamecallback->show_open_url_dialog))->drop();
+		g_gamecallback->show_open_url_dialog = "";
 	}
 
 	if (g_gamecallback->keyconfig_changed) {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1819,7 +1819,7 @@ inline bool Game::handleCallbacks()
 	if (!g_gamecallback->show_open_url_dialog.empty()) {
 		(new GUIOpenURLMenu(guienv, guiroot, -1,
 				 &g_menumgr, texture_src, g_gamecallback->show_open_url_dialog))->drop();
-		g_gamecallback->show_open_url_dialog = "";
+		g_gamecallback->show_open_url_dialog.clear();
 	}
 
 	if (g_gamecallback->keyconfig_changed) {

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -13,6 +13,7 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiInventoryList.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiItemImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiKeyChangeMenu.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/guiOpenURL.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiPasswordChange.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiPathSelectMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiScene.cpp

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -976,7 +976,7 @@ void GUIFormSpecMenu::parseItemImage(parserData* data, const std::string &elemen
 void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 		const std::string &type)
 {
-	int expected_parts = type == "button_url" ? 5 : 4;
+	int expected_parts = (type == "button_url" || type == "button_url_exit") ? 5 : 4;
 	std::vector<std::string> parts;
 	if (!precheckElement("button", element, expected_parts, expected_parts, parts))
 		return;
@@ -986,7 +986,7 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 	std::string name = parts[2];
 	std::string label = parts[3];
 	std::string url;
-	if (type == "button_url")
+	if (type == "button_url" || type == "button_url_exit")
 		url = parts[4];
 
 	MY_CHECKPOS("button",0);
@@ -1022,9 +1022,9 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 		258 + m_fields.size()
 	);
 	spec.ftype = f_Button;
-	if (type == "button_exit")
+	if (type == "button_exit" || type == "button_url_exit")
 		spec.is_exit = true;
-	if (type == "button_url")
+	if (type == "button_url" || type == "button_url_exit")
 		spec.url = url;
 
 	GUIButton *e = GUIButton::addButton(Environment, rect, m_tsrc,
@@ -2903,7 +2903,7 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 		return;
 	}
 
-	if (type == "button" || type == "button_exit" || type == "button_url") {
+	if (type == "button" || type == "button_exit" || type == "button_url" || type == "button_url_exit") {
 		parseButton(data, description, type);
 		return;
 	}
@@ -4974,15 +4974,6 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 						m_sound_manager->playSound(0, SoundSpec(s.sound, 1.0f));
 
 					s.send = true;
-					if (s.is_exit) {
-						if (m_allowclose) {
-							acceptInput(quit_mode_accept);
-							quitMenu();
-						} else {
-							m_text_dst->gotText(L"ExitButton");
-						}
-						return true;
-					}
 
 					if (!s.url.empty()) {
 						if (m_client) {
@@ -4992,6 +4983,16 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 							// main menu
 							porting::open_url(s.url);
 						}
+					}
+
+					if (s.is_exit) {
+						if (m_allowclose) {
+							acceptInput(quit_mode_accept);
+							quitMenu();
+						} else {
+							m_text_dst->gotText(L"ExitButton");
+						}
+						return true;
 					}
 
 					acceptInput(quit_mode_no);

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4986,8 +4986,10 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 					if (!s.url.empty()) {
 						if (m_client) {
+							// in game
 							g_gamecallback->showOpenURLDialog(s.url);
 						} else {
+							// main menu
 							porting::open_url(s.url);
 						}
 					}

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -137,6 +137,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 		std::string fname;
 		std::wstring flabel;
 		std::wstring fdefault;
+		std::string url;
 		s32 fid;
 		bool send;
 		FormspecFieldType ftype;
@@ -447,6 +448,7 @@ private:
 	void parseItemImage(parserData* data, const std::string &element);
 	void parseButton(parserData* data, const std::string &element,
 			const std::string &typ);
+	void parseButtonURL(parserData *data, const std::string &element);
 	void parseBackground(parserData* data, const std::string &element);
 	void parseTableOptions(parserData* data, const std::string &element);
 	void parseTableColumns(parserData* data, const std::string &element);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -448,7 +448,6 @@ private:
 	void parseItemImage(parserData* data, const std::string &element);
 	void parseButton(parserData* data, const std::string &element,
 			const std::string &typ);
-	void parseButtonURL(parserData *data, const std::string &element);
 	void parseBackground(parserData* data, const std::string &element);
 	void parseTableOptions(parserData* data, const std::string &element);
 	void parseTableColumns(parserData* data, const std::string &element);

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -999,7 +999,7 @@ GUIHyperText::GUIHyperText(const wchar_t *text, IGUIEnvironment *environment,
 		IGUIElement *parent, s32 id, const core::rect<s32> &rectangle,
 		Client *client, ISimpleTextureSource *tsrc) :
 		IGUIElement(EGUIET_ELEMENT, environment, parent, id, rectangle),
-		m_client(client), m_tsrc(tsrc), m_vscrollbar(nullptr),
+		m_tsrc(tsrc), m_vscrollbar(nullptr),
 		m_drawer(text, client, environment, tsrc), m_text_scrollpos(0, 0)
 {
 

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h"
 #include "irrlicht_changes/CGUITTFont.h"
 #include "mainmenumanager.h"
+#include "porting.h"
 
 using namespace irr::gui;
 
@@ -998,7 +999,7 @@ GUIHyperText::GUIHyperText(const wchar_t *text, IGUIEnvironment *environment,
 		IGUIElement *parent, s32 id, const core::rect<s32> &rectangle,
 		Client *client, ISimpleTextureSource *tsrc) :
 		IGUIElement(EGUIET_ELEMENT, environment, parent, id, rectangle),
-		m_tsrc(tsrc), m_vscrollbar(nullptr),
+		m_client(client), m_tsrc(tsrc), m_vscrollbar(nullptr),
 		m_drawer(text, client, environment, tsrc), m_text_scrollpos(0, 0)
 {
 
@@ -1110,7 +1111,13 @@ bool GUIHyperText::OnEvent(const SEvent &event)
 
 						auto url_it = tag->attrs.find("url");
 						if (url_it != tag->attrs.end()) {
-							g_gamecallback->showOpenURLDialog(url_it->second);
+							if (m_client) {
+								// in game
+								g_gamecallback->showOpenURLDialog(url_it->second);
+							} else {
+								// main menu
+								porting::open_url(url_it->second);
+							}
 						}
 
 						break;

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -1111,7 +1111,7 @@ bool GUIHyperText::OnEvent(const SEvent &event)
 
 						auto url_it = tag->attrs.find("url");
 						if (url_it != tag->attrs.end()) {
-							if (m_client) {
+							if (g_gamecallback) {
 								// in game
 								g_gamecallback->showOpenURLDialog(url_it->second);
 							} else {

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "inventory.h"
 #include "util/string.h"
 #include "irrlicht_changes/CGUITTFont.h"
+#include "mainmenumanager.h"
 
 using namespace irr::gui;
 
@@ -1106,6 +1107,12 @@ bool GUIHyperText::OnEvent(const SEvent &event)
 							newEvent.GUIEvent.EventType = EGET_BUTTON_CLICKED;
 							Parent->OnEvent(newEvent);
 						}
+
+						auto url_it = tag->attrs.find("url");
+						if (url_it != tag->attrs.end()) {
+							g_gamecallback->showOpenURLDialog(url_it->second);
+						}
+
 						break;
 					}
 				}

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -217,7 +217,6 @@ public:
 
 protected:
 	// GUI members
-	Client *m_client;
 	ISimpleTextureSource *m_tsrc;
 	GUIScrollBar *m_vscrollbar;
 	TextDrawer m_drawer;

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -217,6 +217,7 @@ public:
 
 protected:
 	// GUI members
+	Client *m_client;
 	ISimpleTextureSource *m_tsrc;
 	GUIScrollBar *m_vscrollbar;
 	TextDrawer m_drawer;

--- a/src/gui/guiOpenURL.cpp
+++ b/src/gui/guiOpenURL.cpp
@@ -114,7 +114,6 @@ void GUIOpenURLMenu::regenerateGui(v2u32 screensize)
 		e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_UPPERLEFT);
 		e->setDrawBorder(true);
 		e->setDrawBackground(true);
-
 		e->setOverrideFont(mono_font);
 		e->drop();
 	}

--- a/src/gui/guiOpenURL.cpp
+++ b/src/gui/guiOpenURL.cpp
@@ -72,7 +72,12 @@ std::string colorize_url(const std::string &url) {
 	char *zoneid;
 	curl_url_get(h, CURLUPART_FRAGMENT, &fragment, 0);
 	// Get host as punycode to explicitly show homographs
+#ifdef CURLU_PUNYCODE
 	curl_url_get(h, CURLUPART_HOST, &host, CURLU_PUNYCODE);
+#else
+	// TODO: confirm this renders as `xn--`
+	curl_url_get(h, CURLUPART_HOST, &host, 0);
+#endif
 	curl_url_get(h, CURLUPART_PASSWORD, &password, 0);
 	curl_url_get(h, CURLUPART_PATH, &path, 0);
 	curl_url_get(h, CURLUPART_PORT, &port, 0);

--- a/src/gui/guiOpenURL.cpp
+++ b/src/gui/guiOpenURL.cpp
@@ -19,20 +19,17 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "guiButton.h"
 #include "guiEditBoxWithScrollbar.h"
 #include <IGUIEditBox.h>
-#include <IGUIStaticText.h>
 #include <IGUIFont.h>
-
-#ifdef HAVE_TOUCHSCREENGUI
-	#include "client/renderingengine.h"
-#endif
-
+#include "client/renderingengine.h"
 #include "porting.h"
 #include "gettext.h"
 #include "util/colorize.h"
 
-const int ID_url = 256;
-const int ID_open = 259;
-const int ID_cancel = 261;
+namespace {
+	constexpr int ID_url = 256;
+	constexpr int ID_open = 259;
+	constexpr int ID_cancel = 261;
+}
 
 GUIOpenURLMenu::GUIOpenURLMenu(gui::IGUIEnvironment* env,
 		gui::IGUIElement* parent, s32 id,
@@ -56,11 +53,7 @@ void GUIOpenURLMenu::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-#ifdef HAVE_TOUCHSCREENGUI
-	const float s = m_gui_scale * RenderingEngine::getDisplayDensity() / 2;
-#else
 	const float s = m_gui_scale;
-#endif
 	DesiredRect = core::rect<s32>(
 		screensize.X / 2 - 580 * s / 2,
 		screensize.Y / 2 - 250 * s / 2,

--- a/src/gui/guiOpenURL.cpp
+++ b/src/gui/guiOpenURL.cpp
@@ -156,7 +156,6 @@ void GUIOpenURLMenu::regenerateGui(v2u32 screensize)
 		auto mono_font = g_fontengine->getFont(FONT_SIZE_UNSPECIFIED, FM_Mono);
 		int scrollbar_width = Environment->getSkin()->getSize(gui::EGDS_SCROLLBAR_SIZE);
 		int max_cols = (rect.getWidth() - scrollbar_width - 10) / mono_font->getDimension(L"x").Width;
-		errorstream << max_cols << std::endl;
 
 		std::string text = colorize_url(url);
 		if (text.empty()) {

--- a/src/gui/guiOpenURL.cpp
+++ b/src/gui/guiOpenURL.cpp
@@ -1,6 +1,6 @@
 /*
 Part of Minetest
-Copyright (C) 2023 rubenwardy
+Copyright (C) 2023-24 rubenwardy
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
@@ -28,9 +28,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include "porting.h"
 #include "gettext.h"
-#ifdef USE_CURL
-#include <curl/urlapi.h>
-#endif
+#include "util/colorize.h"
 
 const int ID_url = 256;
 const int ID_open = 259;
@@ -47,73 +45,6 @@ GUIOpenURLMenu::GUIOpenURLMenu(gui::IGUIEnvironment* env,
 {
 }
 
-std::string colorize_url(const std::string &url) {
-#ifdef USE_CURL
-	// Forbid escape codes in URL
-	if (url.find('\x1b') != std::string::npos) {
-		return "";
-	}
-
-	CURLU *h = curl_url();
-	auto rc = curl_url_set(h, CURLUPART_URL, url.c_str(), 0);
-	if (rc != CURLUE_OK) {
-		curl_url_cleanup(h);
-		return "";
-	}
-
-	char *fragment;
-	char *host;
-	char *password;
-	char *path;
-	char *port;
-	char *query;
-	char *scheme;
-	char *user;
-	char *zoneid;
-	curl_url_get(h, CURLUPART_FRAGMENT, &fragment, 0);
-	// Get host as punycode to explicitly show homographs
-#ifdef CURLU_PUNYCODE
-	curl_url_get(h, CURLUPART_HOST, &host, CURLU_PUNYCODE);
-#else
-	// TODO: confirm this renders as `xn--`
-	curl_url_get(h, CURLUPART_HOST, &host, 0);
-#endif
-	curl_url_get(h, CURLUPART_PASSWORD, &password, 0);
-	curl_url_get(h, CURLUPART_PATH, &path, 0);
-	curl_url_get(h, CURLUPART_PORT, &port, 0);
-	curl_url_get(h, CURLUPART_QUERY, &query, 0);
-	curl_url_get(h, CURLUPART_SCHEME, &scheme, 0);
-	curl_url_get(h, CURLUPART_USER, &user, 0);
-	curl_url_get(h, CURLUPART_ZONEID, &zoneid, 0);
-
-	std::ostringstream os;
-
-	const std::string white = "\x1b(c@#fff)";
-	const std::string grey = "\x1b(c@#aaa)";
-
-	os << grey << scheme << "://";
-	if (user != NULL)
-		os << user;
-	if (password != NULL)
-		os << ":" << password;
-	if (user != NULL || password != NULL)
-		os << "@";
-
-	os << white << host << grey;
-	if (port != NULL)
-		os << ":" << port;
-	os << path;
-	if (query != NULL)
-		os << "?" << query;
-	if (fragment != NULL)
-		os << "#" << fragment;
-
-	curl_url_cleanup(h);
-	return os.str();
-#else
-	return str;
-#endif
-}
 
 void GUIOpenURLMenu::regenerateGui(v2u32 screensize)
 {

--- a/src/gui/guiOpenURL.cpp
+++ b/src/gui/guiOpenURL.cpp
@@ -93,11 +93,16 @@ void GUIOpenURLMenu::regenerateGui(v2u32 screensize)
 		int scrollbar_width = Environment->getSkin()->getSize(gui::EGDS_SCROLLBAR_SIZE);
 		int max_cols = (rect.getWidth() - scrollbar_width - 10) / mono_font->getDimension(L"x").Width;
 
-		std::string text = colorize_url(url);
-		if (text.empty()) {
+#ifdef USE_CURL
+		std::string text;
+		if (!colorize_url(text, url)) {
+			errorstream << text << " when attempting to show open dialog for " << url << std::endl;
 			quitMenu();
 			return;
 		}
+#else
+		std::string text = url;
+#endif
 
 		text = wrap_rows(text, max_cols, true);
 

--- a/src/gui/guiOpenURL.cpp
+++ b/src/gui/guiOpenURL.cpp
@@ -1,0 +1,172 @@
+/*
+Part of Minetest
+Copyright (C) 2023 rubenwardy
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "guiOpenURL.h"
+#include "guiButton.h"
+#include "guiEditBoxWithScrollbar.h"
+#include <IGUIEditBox.h>
+#include <IGUIStaticText.h>
+#include <IGUIFont.h>
+
+#ifdef HAVE_TOUCHSCREENGUI
+	#include "client/renderingengine.h"
+#endif
+
+#include "porting.h"
+#include "gettext.h"
+
+const int ID_url = 256;
+const int ID_open = 259;
+const int ID_cancel = 261;
+
+GUIOpenURLMenu::GUIOpenURLMenu(gui::IGUIEnvironment* env,
+		gui::IGUIElement* parent, s32 id,
+		IMenuManager *menumgr,
+		ISimpleTextureSource *tsrc, const std::string &url
+):
+	GUIModalMenu(env, parent, id, menumgr),
+	m_tsrc(tsrc),
+	url(url)
+{
+}
+
+void GUIOpenURLMenu::regenerateGui(v2u32 screensize)
+{
+	/*
+		Remove stuff
+	*/
+	removeAllChildren();
+
+	/*
+		Calculate new sizes and positions
+	*/
+#ifdef HAVE_TOUCHSCREENGUI
+	const float s = m_gui_scale * RenderingEngine::getDisplayDensity() / 2;
+#else
+	const float s = m_gui_scale;
+#endif
+	DesiredRect = core::rect<s32>(
+		screensize.X / 2 - 580 * s / 2,
+		screensize.Y / 2 - 250 * s / 2,
+		screensize.X / 2 + 580 * s / 2,
+		screensize.Y / 2 + 250 * s / 2
+	);
+	recalculateAbsolutePosition(false);
+
+	v2s32 size = DesiredRect.getSize();
+	v2s32 topleft_client(40 * s, 0);
+
+	/*
+		Add stuff
+	*/
+	s32 ypos = 40 * s;
+
+	{
+		core::rect<s32> rect(0, 0, 500 * s, 20 * s);
+		rect += topleft_client + v2s32(20 * s, ypos);
+		gui::StaticText::add(Environment, wstrgettext("Open URL?"), rect,
+				false, true, this, -1);
+	}
+
+	ypos += 50 * s;
+
+	{
+		core::rect<s32> rect(0, 0, 440 * s, 60 * s);
+		rect += topleft_client + v2s32(20 * s, ypos);
+		IGUIEditBox *e = new GUIEditBoxWithScrollBar(utf8_to_wide(url).c_str(), true, Environment,
+				this, ID_url, rect, m_tsrc, false, true);
+		e->setMultiLine(true);
+		e->setWordWrap(true);
+		e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_UPPERLEFT);
+		e->setDrawBorder(true);
+		e->setDrawBackground(true);
+		e->drop();
+	}
+
+	ypos += 80 * s;
+	{
+		core::rect<s32> rect(0, 0, 100 * s, 40 * s);
+		rect = rect + v2s32(size.X / 2 - 150 * s, ypos);
+		GUIButton::addButton(Environment, rect, m_tsrc, this, ID_open,
+				wstrgettext("Open").c_str());
+	}
+	{
+		core::rect<s32> rect(0, 0, 100 * s, 40 * s);
+		rect = rect + v2s32(size.X / 2 + 50 * s, ypos);
+		GUIButton::addButton(Environment, rect, m_tsrc, this, ID_cancel,
+				wstrgettext("Cancel").c_str());
+	}
+}
+
+void GUIOpenURLMenu::drawMenu()
+{
+	gui::IGUISkin *skin = Environment->getSkin();
+	if (!skin)
+		return;
+	video::IVideoDriver *driver = Environment->getVideoDriver();
+
+	video::SColor bgcolor(140, 0, 0, 0);
+	driver->draw2DRectangle(bgcolor, AbsoluteRect, &AbsoluteClippingRect);
+
+	gui::IGUIElement::draw();
+#ifdef __ANDROID__
+	getAndroidUIInput();
+#endif
+}
+
+bool GUIOpenURLMenu::OnEvent(const SEvent &event)
+{
+	if (event.EventType == EET_KEY_INPUT_EVENT) {
+		if ((event.KeyInput.Key == KEY_ESCAPE ||
+				event.KeyInput.Key == KEY_CANCEL) &&
+				event.KeyInput.PressedDown) {
+			quitMenu();
+			return true;
+		}
+		if (event.KeyInput.Key == KEY_RETURN && event.KeyInput.PressedDown) {
+			porting::open_url(url);
+			quitMenu();
+			return true;
+		}
+	}
+
+	if (event.EventType == EET_GUI_EVENT) {
+		if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST &&
+				isVisible()) {
+			if (!canTakeFocus(event.GUIEvent.Element)) {
+				infostream << "GUIOpenURLMenu: Not allowing focus change."
+					<< std::endl;
+				// Returning true disables focus change
+				return true;
+			}
+		}
+
+		if (event.GUIEvent.EventType == gui::EGET_BUTTON_CLICKED) {
+			switch (event.GUIEvent.Caller->getID()) {
+			case ID_open:
+				porting::open_url(url);
+				quitMenu();
+				return true;
+			case ID_cancel:
+				quitMenu();
+				return true;
+			}
+		}
+	}
+
+	return Parent ? Parent->OnEvent(event) : false;
+}

--- a/src/gui/guiOpenURL.h
+++ b/src/gui/guiOpenURL.h
@@ -1,0 +1,50 @@
+/*
+Part of Minetest
+Copyright (C) 2023 rubenwardy
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#pragma once
+
+#include "irrlichttypes_extrabloated.h"
+#include "modalMenu.h"
+#include <string>
+
+class Client;
+class ISimpleTextureSource;
+
+class GUIOpenURLMenu : public GUIModalMenu
+{
+public:
+	GUIOpenURLMenu(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
+			IMenuManager *menumgr,
+			ISimpleTextureSource *tsrc, const std::string &url);
+
+	/*
+		Remove and re-add (or reposition) stuff
+	*/
+	void regenerateGui(v2u32 screensize);
+
+	void drawMenu();
+
+	bool OnEvent(const SEvent &event);
+
+protected:
+	std::wstring getLabelByID(s32 id) { return L""; }
+	std::string getNameByID(s32 id) { return ""; }
+
+private:
+	ISimpleTextureSource *m_tsrc;
+	std::string url;
+};

--- a/src/gui/mainmenumanager.h
+++ b/src/gui/mainmenumanager.h
@@ -34,7 +34,7 @@ public:
 	virtual void disconnect() = 0;
 	virtual void changePassword() = 0;
 	virtual void changeVolume() = 0;
-
+	virtual void showOpenURLDialog(const std::string &url) = 0;
 	virtual void signalKeyConfigChange() = 0;
 };
 
@@ -108,44 +108,47 @@ public:
 	MainGameCallback() = default;
 	virtual ~MainGameCallback() = default;
 
-	virtual void exitToOS()
+	void exitToOS() override
 	{
 		shutdown_requested = true;
 	}
 
-	virtual void disconnect()
+	void disconnect() override
 	{
 		disconnect_requested = true;
 	}
 
-	virtual void changePassword()
+	void changePassword() override
 	{
 		changepassword_requested = true;
 	}
 
-	virtual void changeVolume()
+	void changeVolume() override
 	{
 		changevolume_requested = true;
 	}
 
-	virtual void keyConfig()
+	void keyConfig() override
 	{
 		keyconfig_requested = true;
 	}
 
-	virtual void signalKeyConfigChange()
+	void signalKeyConfigChange() override
 	{
 		keyconfig_changed = true;
 	}
 
+	void showOpenURLDialog(const std::string &url) override {
+		show_open_url_dialog = url;
+	}
 
 	bool disconnect_requested = false;
 	bool changepassword_requested = false;
 	bool changevolume_requested = false;
 	bool keyconfig_requested = false;
 	bool shutdown_requested = false;
-
 	bool keyconfig_changed = false;
+	std::string show_open_url_dialog = "";
 };
 
 extern MainGameCallback *g_gamecallback;

--- a/src/unittest/test_utilities.cpp
+++ b/src/unittest/test_utilities.cpp
@@ -717,14 +717,13 @@ void TestUtilities::testIsBlockInSight()
 void TestUtilities::testColorizeURL()
 {
 #ifdef USE_CURL
+	#define RED COLOR_CODE("#faa")
 	#define GREY COLOR_CODE("#aaa")
 	#define WHITE COLOR_CODE("#fff")
 
 	UASSERT(colorize_url("http://example.com/") ==
 		(GREY "http://" WHITE "example.com" GREY "/"));
 	UASSERT(colorize_url("https://u:p@wikipediа.org:1234/heIIoll?a=b#c") ==
-		(GREY "https://u:p@" WHITE "xn--wikipedi-86g.org" GREY ":1234/heIIoll?a=b#c"));
-	UASSERT(colorize_url("https://räksmörgås.se/path?q#frag") ==
-		(GREY "https://" WHITE "xn--rksmrgs-5wao1o.se" GREY "/path?q#frag"));
+		(GREY "https://u:p@" WHITE "wikipedi" RED "%d0%b0" WHITE ".org" GREY ":1234/heIIoll?a=b#c"));
 #endif
 }

--- a/src/unittest/test_utilities.cpp
+++ b/src/unittest/test_utilities.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h"
 #include "util/string.h"
 #include "util/base64.h"
+#include "util/colorize.h"
 
 class TestUtilities : public TestBase {
 public:
@@ -59,6 +60,7 @@ public:
 	void testBase64();
 	void testSanitizeDirName();
 	void testIsBlockInSight();
+	void testColorizeURL();
 };
 
 static TestUtilities g_test_instance;
@@ -92,6 +94,7 @@ void TestUtilities::runTests(IGameDef *gamedef)
 	TEST(testBase64);
 	TEST(testSanitizeDirName);
 	TEST(testIsBlockInSight);
+	TEST(testColorizeURL);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -709,4 +712,19 @@ void TestUtilities::testIsBlockInSight()
 		// should still be considered visible
 		UASSERT(isBlockInSight({-1, 0, 0}, cam_pos, cam_dir, fov, range));
 	}
+}
+
+void TestUtilities::testColorizeURL()
+{
+#ifdef USE_CURL
+	#define GREY COLOR_CODE("#aaa")
+	#define WHITE COLOR_CODE("#fff")
+
+	UASSERT(colorize_url("http://example.com/") ==
+		(GREY "http://" WHITE "example.com" GREY "/"));
+	UASSERT(colorize_url("https://u:p@wikipediа.org:1234/heIIoll?a=b#c") ==
+		(GREY "https://u:p@" WHITE "xn--wikipedi-86g.org" GREY ":1234/heIIoll?a=b#c"));
+	UASSERT(colorize_url("https://räksmörgås.se/path?q#frag") ==
+		(GREY "https://" WHITE "xn--rksmrgs-5wao1o.se" GREY "/path?q#frag"));
+#endif
 }

--- a/src/unittest/test_utilities.cpp
+++ b/src/unittest/test_utilities.cpp
@@ -721,12 +721,10 @@ void TestUtilities::testColorizeURL()
 	#define GREY COLOR_CODE("#aaa")
 	#define WHITE COLOR_CODE("#fff")
 
-	std::string result;
-
-	UASSERT(colorize_url(result, "http://example.com/"));
+	std::string result = colorize_url("http://example.com/");
 	UASSERT(result == (GREY "http://" WHITE "example.com" GREY "/"));
 
-	UASSERT(colorize_url(result, u8"https://u:p@wikipedi\u0430.org:1234/heIIoll?a=b#c"));
+	result = colorize_url(u8"https://u:p@wikipedi\u0430.org:1234/heIIoll?a=b#c");
 	UASSERT(result ==
 		(GREY "https://u:p@" WHITE "wikipedi" RED "%d0%b0" WHITE ".org" GREY ":1234/heIIoll?a=b#c"));
 #endif

--- a/src/unittest/test_utilities.cpp
+++ b/src/unittest/test_utilities.cpp
@@ -726,7 +726,7 @@ void TestUtilities::testColorizeURL()
 	UASSERT(colorize_url(result, "http://example.com/"));
 	UASSERT(result == (GREY "http://" WHITE "example.com" GREY "/"));
 
-	UASSERT(colorize_url(result, "https://u:p@wikipedi\ud0b0.org:1234/heIIoll?a=b#c"));
+	UASSERT(colorize_url(result, u8"https://u:p@wikipedi\u0430.org:1234/heIIoll?a=b#c"));
 	UASSERT(result ==
 		(GREY "https://u:p@" WHITE "wikipedi" RED "%d0%b0" WHITE ".org" GREY ":1234/heIIoll?a=b#c"));
 #endif

--- a/src/unittest/test_utilities.cpp
+++ b/src/unittest/test_utilities.cpp
@@ -721,9 +721,13 @@ void TestUtilities::testColorizeURL()
 	#define GREY COLOR_CODE("#aaa")
 	#define WHITE COLOR_CODE("#fff")
 
-	UASSERT(colorize_url("http://example.com/") ==
-		(GREY "http://" WHITE "example.com" GREY "/"));
-	UASSERT(colorize_url("https://u:p@wikipediа.org:1234/heIIoll?a=b#c") ==
+	std::string result;
+
+	UASSERT(colorize_url(result, "http://example.com/"));
+	UASSERT(result == (GREY "http://" WHITE "example.com" GREY "/"));
+
+	UASSERT(colorize_url(result, "https://u:p@wikipedi\ud0b0.org:1234/heIIoll?a=b#c"));
+	UASSERT(result ==
 		(GREY "https://u:p@" WHITE "wikipedi" RED "%d0%b0" WHITE ".org" GREY ":1234/heIIoll?a=b#c"));
 #endif
 }

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(UTIL_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/areastore.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/auth.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/colorize.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/base64.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/directiontables.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/enriched_string.cpp

--- a/src/util/colorize.cpp
+++ b/src/util/colorize.cpp
@@ -64,6 +64,7 @@ bool colorize_url(std::string &out, const std::string &url) {
 	if (user || password)
 		os << "@";
 
+	// Print hostname, escaping unsafe characters
 	os << white;
 	bool was_alphanum = true;
 	std::string host_s = host;
@@ -83,18 +84,19 @@ bool colorize_url(std::string &out, const std::string &url) {
 			os << c;
 		} else {
 			os << "%" << std::setfill('0') << std::setw(2) << std::hex
-			   << (static_cast<unsigned int>(c) & 0xff);
+				<< (static_cast<unsigned int>(c) & 0xff);
 		}
 	}
 
-
 	os << grey;
-	if (port != NULL)
+	if (zoneid)
+		os << "%" << zoneid;
+	if (port)
 		os << ":" << port;
 	os << path;
-	if (query != NULL)
+	if (query)
 		os << "?" << query;
-	if (fragment != NULL)
+	if (fragment)
 		os << "#" << fragment;
 
 	curl_url_cleanup(h);

--- a/src/util/colorize.cpp
+++ b/src/util/colorize.cpp
@@ -99,6 +99,15 @@ bool colorize_url(std::string &out, const std::string &url) {
 	if (fragment)
 		os << "#" << fragment;
 
+	curl_free(fragment);
+	curl_free(host);
+	curl_free(password);
+	curl_free(path);
+	curl_free(port);
+	curl_free(query);
+	curl_free(scheme);
+	curl_free(user);
+	curl_free(zoneid);
 	curl_url_cleanup(h);
 	out = os.str();
 	return true;

--- a/src/util/colorize.cpp
+++ b/src/util/colorize.cpp
@@ -24,12 +24,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "string.h"
 #include <sstream>
 
-bool colorize_url(std::string &out, const std::string &url)
+std::string colorize_url(const std::string &url)
 {
 	// Forbid escape codes in URL
 	if (url.find('\x1b') != std::string::npos) {
-		out = "Unable to open URL as it contains escape codes";
-		return false;
+		throw std::runtime_error("Unable to open URL as it contains escape codes");
 	}
 
 	auto urlHandleRAII = std::unique_ptr<CURLU, decltype(&curl_url_cleanup)>(
@@ -38,9 +37,7 @@ bool colorize_url(std::string &out, const std::string &url)
 
 	auto rc = curl_url_set(urlHandle, CURLUPART_URL, url.c_str(), 0);
 	if (rc != CURLUE_OK) {
-		out = "Unable to open URL as it is not valid";
-		curl_url_cleanup(urlHandle);
-		return false;
+		throw std::runtime_error("Unable to open URL as it is not valid");
 	}
 
 	auto url_get = [&] (CURLUPart what) -> std::string {
@@ -110,8 +107,7 @@ bool colorize_url(std::string &out, const std::string &url)
 	if (!fragment.empty())
 		os << "#" << fragment;
 
-	out = os.str();
-	return true;
+	return os.str();
 }
 
 #endif

--- a/src/util/colorize.cpp
+++ b/src/util/colorize.cpp
@@ -1,0 +1,93 @@
+/*
+Part of Minetest
+Copyright (C) 2024 rubenwardy
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "config.h"
+
+#ifdef USE_CURL
+#include <curl/urlapi.h>
+#endif
+
+#include "colorize.h"
+#include <sstream>
+
+std::string colorize_url(const std::string &url) {
+#ifdef USE_CURL
+	// Forbid escape codes in URL
+	if (url.find('\x1b') != std::string::npos) {
+		return "";
+	}
+
+	CURLU *h = curl_url();
+	auto rc = curl_url_set(h, CURLUPART_URL, url.c_str(), 0);
+	if (rc != CURLUE_OK) {
+		curl_url_cleanup(h);
+		return "";
+	}
+
+	char *fragment;
+	char *host;
+	char *password;
+	char *path;
+	char *port;
+	char *query;
+	char *scheme;
+	char *user;
+	char *zoneid;
+	curl_url_get(h, CURLUPART_FRAGMENT, &fragment, 0);
+	// Get host as punycode to explicitly show homographs
+#ifdef CURLU_PUNYCODE
+	curl_url_get(h, CURLUPART_HOST, &host, CURLU_PUNYCODE);
+#else
+	// TODO: confirm this renders as `xn--`
+	curl_url_get(h, CURLUPART_HOST, &host, 0);
+#endif
+	curl_url_get(h, CURLUPART_PASSWORD, &password, 0);
+	curl_url_get(h, CURLUPART_PATH, &path, 0);
+	curl_url_get(h, CURLUPART_PORT, &port, 0);
+	curl_url_get(h, CURLUPART_QUERY, &query, 0);
+	curl_url_get(h, CURLUPART_SCHEME, &scheme, 0);
+	curl_url_get(h, CURLUPART_USER, &user, 0);
+	curl_url_get(h, CURLUPART_ZONEID, &zoneid, 0);
+
+	std::ostringstream os;
+
+	const std::string white = COLOR_CODE("#fff");
+	const std::string grey = COLOR_CODE("#aaa");
+
+	os << grey << scheme << "://";
+	if (user != NULL)
+		os << user;
+	if (password != NULL)
+		os << ":" << password;
+	if (user != NULL || password != NULL)
+		os << "@";
+
+	os << white << host << grey;
+	if (port != NULL)
+		os << ":" << port;
+	os << path;
+	if (query != NULL)
+		os << "?" << query;
+	if (fragment != NULL)
+		os << "#" << fragment;
+
+	curl_url_cleanup(h);
+	return os.str();
+#else
+	return str;
+#endif
+}

--- a/src/util/colorize.cpp
+++ b/src/util/colorize.cpp
@@ -53,11 +53,15 @@ std::string colorize_url(const std::string &url) {
 	curl_url_get(h, CURLUPART_FRAGMENT, &fragment, 0);
 	// Get host as punycode to explicitly show homographs
 #ifdef CURLU_PUNYCODE
-	curl_url_get(h, CURLUPART_HOST, &host, CURLU_PUNYCODE);
-#else
-	// TODO: confirm this renders as `xn--`
-	curl_url_get(h, CURLUPART_HOST, &host, 0);
+	rc = curl_url_get(h, CURLUPART_HOST, &host, CURLU_PUNYCODE);
+	if (rc == CURLUE_LACKS_IDN) {
 #endif
+		curl_url_get(h, CURLUPART_HOST, &host, 0);
+		// TODO: manually punycode here
+#ifdef CURLU_PUNYCODE
+	}
+#endif
+
 	curl_url_get(h, CURLUPART_PASSWORD, &password, 0);
 	curl_url_get(h, CURLUPART_PATH, &path, 0);
 	curl_url_get(h, CURLUPART_PORT, &port, 0);

--- a/src/util/colorize.cpp
+++ b/src/util/colorize.cpp
@@ -24,7 +24,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "string.h"
 #include <sstream>
 
-bool colorize_url(std::string &out, const std::string &url) {
+bool colorize_url(std::string &out, const std::string &url)
+{
 	// Forbid escape codes in URL
 	if (url.find('\x1b') != std::string::npos) {
 		out = "Unable to open URL as it contains escape codes";
@@ -80,7 +81,7 @@ bool colorize_url(std::string &out, const std::string &url) {
 	std::string host_s = host;
 	for (size_t i = 0; i < host_s.size(); i++) {
 		char c = host_s[i];
-		bool is_alphanum = !IS_UTF8_MULTB_INNER(c) && (isalnum(c) || ispunct(c));
+		bool is_alphanum = isalnum(c) || ispunct(c);
 		if (is_alphanum == was_alphanum) {
 			// skip
 		} else if (is_alphanum) {

--- a/src/util/colorize.cpp
+++ b/src/util/colorize.cpp
@@ -22,18 +22,21 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #endif
 
 #include "colorize.h"
+#include "log.h"
 #include <sstream>
 
 std::string colorize_url(const std::string &url) {
 #ifdef USE_CURL
 	// Forbid escape codes in URL
 	if (url.find('\x1b') != std::string::npos) {
+		errorstream << "Unable to open URL as it contains escape codes" << std::endl;
 		return "";
 	}
 
 	CURLU *h = curl_url();
 	auto rc = curl_url_set(h, CURLUPART_URL, url.c_str(), 0);
 	if (rc != CURLUE_OK) {
+		errorstream << "Unable to open URL as it is not valid ( " << url << " )" << std::endl;
 		curl_url_cleanup(h);
 		return "";
 	}

--- a/src/util/colorize.h
+++ b/src/util/colorize.h
@@ -1,0 +1,24 @@
+/*
+Part of Minetest
+Copyright (C) 2024 rubenwardy
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#pragma once
+
+#include <string>
+
+#define COLOR_CODE(color) "\x1b(c@" color
+
+std::string colorize_url(const std::string &url);

--- a/src/util/colorize.h
+++ b/src/util/colorize.h
@@ -18,7 +18,19 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #pragma once
 
 #include <string>
+#include "config.h"
 
 #define COLOR_CODE(color) "\x1b(c@" color ")"
 
-std::string colorize_url(const std::string &url);
+#ifdef USE_CURL
+
+/**
+ * Colorize URL to highlight domain and unsafe characters
+ *
+ * @param out either the output string or an error message
+ * @param url URL to format
+ * @return true for success, false otherwise
+ */
+bool colorize_url(std::string &out, const std::string &url);
+
+#endif

--- a/src/util/colorize.h
+++ b/src/util/colorize.h
@@ -25,12 +25,10 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifdef USE_CURL
 
 /**
- * Colorize URL to highlight domain and unsafe characters
+ * Colorize URL to highlight the hostname and any unsafe characters
  *
- * @param out either the output string or an error message
- * @param url URL to format
- * @return true for success, false otherwise
+ * Throws an exception if the url is invalid
  */
-bool colorize_url(std::string &out, const std::string &url);
+std::string colorize_url(const std::string &url);
 
 #endif

--- a/src/util/colorize.h
+++ b/src/util/colorize.h
@@ -19,6 +19,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <string>
 
-#define COLOR_CODE(color) "\x1b(c@" color
+#define COLOR_CODE(color) "\x1b(c@" color ")"
 
 std::string colorize_url(const std::string &url);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -524,35 +524,7 @@ inline bool string_allowed_blacklist(std::string_view str,
  * @param has_color_codes Whether the source string has colorize codes.
  * @return A new string with the wrapping applied.
  */
-inline std::string wrap_rows(std::string_view from, unsigned row_len, bool has_color_codes = false)
-{
-	std::string to;
-	to.reserve(from.size());
-
-	unsigned character_idx = 0;
-	bool inside_colorize = false;
-	for (size_t i = 0; i < from.size(); i++) {
-		if (!IS_UTF8_MULTB_INNER(from[i])) {
-			if (inside_colorize) {
-				if (from[i] == ')') {
-					inside_colorize = false;
-				} else {
-					// keep reading
-				}
-			} else if (has_color_codes && from[i] == '\x1b') {
-				inside_colorize = true;
-			} else {
-				// Wrap string after last inner byte of char
-				if (character_idx > 0 && character_idx % row_len == 0)
-					to += '\n';
-				character_idx++;
-			}
-		}
-		to += from[i];
-	}
-
-	return to;
-}
+std::string wrap_rows(std::string_view from, unsigned row_len, bool has_color_codes = false);
 
 
 /**

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -512,7 +512,7 @@ inline bool string_allowed_blacklist(std::string_view str,
  * Create a string based on \p from where a newline is forcefully inserted
  * every \p row_len characters.
  *
- * @note This function does not honour word wraps and blindy inserts a newline
+ * @note This function does not honour word wraps and blindly inserts a newline
  *	every \p row_len characters whether it breaks a word or not.  It is
  *	intended to be used for, for example, showing paths in the GUI.
  *
@@ -521,20 +521,32 @@ inline bool string_allowed_blacklist(std::string_view str,
  *
  * @param from The (utf-8) string to be wrapped into rows.
  * @param row_len The row length (in characters).
+ * @param has_color_codes Whether the source string has colorize codes.
  * @return A new string with the wrapping applied.
  */
-inline std::string wrap_rows(std::string_view from, unsigned row_len)
+inline std::string wrap_rows(std::string_view from, unsigned row_len, bool has_color_codes = false)
 {
 	std::string to;
 	to.reserve(from.size());
 
 	unsigned character_idx = 0;
+	bool inside_colorize = false;
 	for (size_t i = 0; i < from.size(); i++) {
 		if (!IS_UTF8_MULTB_INNER(from[i])) {
-			// Wrap string after last inner byte of char
-			if (character_idx > 0 && character_idx % row_len == 0)
-				to += '\n';
-			character_idx++;
+			if (inside_colorize) {
+				if (from[i] == ')') {
+					inside_colorize = false;
+				} else {
+					// keep reading
+				}
+			} else if (has_color_codes && from[i] == '\x1b') {
+				inside_colorize = true;
+			} else {
+				// Wrap string after last inner byte of char
+				if (character_idx > 0 && character_idx % row_len == 0)
+					to += '\n';
+				character_idx++;
+			}
 		}
 		to += from[i];
 	}


### PR DESCRIPTION
Fixes #12500

This adds a new type of button and a hypertext attribute to allow opening URLs in a web browser. A button is used to require user interaction before opening URLs.

A confirmation dialog is shown, to allow the user to see the URL. Unfortunately, this confirmation dialog has to be implemented using raw Irrlicht GUI for security reasons, so cannot be themed by games and looks a bit odd compared to the rest of the GUI. This should be improved in the future

![image](https://github.com/minetest/minetest/assets/2122943/f41942ce-7922-415c-a68c-8a9575ebdfe5)

## To do

This PR is Ready for Review

- [x] Clean up parseButtonURL duplication
- [x] Fix line wrapping / scrolling to see entire URL in box
- [x] Highlight domain name
- [x] Add hypertext tag (maybe for a next PR?)
- [x] Fix `CURLU_PUNYCODE` requiring Curl 7.88
- [x] ~~Improve dialog message (suggestions welcome)~~

For future PRs:

- Add ability to 'trust' domain names

## How to test

Click the red button in the Styled tab of `/test_formspec` in devtest

Click the URL link in the hypertext tab
