### PR TITLE
Fix error when enabling texture packs in the "Content" tab

### DIFF
--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -18,11 +18,7 @@
 
 local packages_raw, packages
 
-local function on_change(type)
-	if type ~= "ENTER" then
-		return
-	end
-
+local function update_packages()
 	if not pkgmgr.global_mods then
 		pkgmgr.refresh_globals()
 	end
@@ -48,7 +44,17 @@ local function on_change(type)
 			is_equal, nil, {})
 end
 
+local function on_change(type)
+	if type == "ENTER" then
+		update_packages()
+	end
+end
+
 local function get_formspec(tabview, name, tabdata)
+	if not packages then
+		update_packages()
+	end
+
 	if not tabdata.selected_pkg then
 		tabdata.selected_pkg = 1
 	end


### PR DESCRIPTION
Since #13550, enabling or disabling texture packs in the "Content" tab triggers this error:

```
Runtime error from mod '??' in callback handleMainMenuButtons(): /mt/bin/../builtin/common/filterlist.lua:209: attempt to index local 'self' (a nil value)
stack traceback:
	/mt/bin/../builtin/common/filterlist.lua:209: in function 'size'
	/mt/bin/../builtin/mainmenu/tab_content.lua:69: in function 'get_formspec'
	/mt/bin/../builtin/fstk/tabview.lua:67: in function 'get_formspec'
	/mt/bin/../builtin/fstk/ui.lua:101: in function 'update'
	/mt/bin/../builtin/fstk/ui.lua:145: in function 'handle_buttons'
	/mt/bin/../builtin/fstk/ui.lua:186: in function </mt/bin/../builtin/fstk/ui.lua:172>
```

This PR fixes that by restoring the previous behavior of re-creating the filterlist in `get_formspec` if it is nil.

CC @rollerozxa

## To do

This PR is a Ready for Review.

## How to test

Verify that you can enable and disable texture packs without triggering an error dialog.
