### PR TITLE
Cascaded Shadow Maps

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -498,14 +498,14 @@ shadow_strength_gamma (Shadow strength gamma) float 1.0 0.1 10.0
 #    Maximum distance to render shadows.
 #
 #    Requires: shaders, enable_dynamic_shadows, opengl
-shadow_map_max_distance (Shadow map max distance in nodes to render shadows) float 140.0 10.0 1000.0
+shadow_map_max_distance (Shadow map max distance in nodes to render shadows) float 200.0 10.0 1000.0
 
 #    Texture size to render the shadow map on.
 #    This must be a power of two.
 #    Bigger numbers create better shadows but it is also more expensive.
 #
 #    Requires: shaders, enable_dynamic_shadows, opengl
-shadow_map_texture_size (Shadow map texture size) int 2048 128 8192
+shadow_map_texture_size (Shadow map texture size) int 1024 128 8192
 
 #    Sets shadow texture quality to 32 bits.
 #    On false, 16 bits texture will be used.
@@ -538,10 +538,10 @@ shadow_map_color (Colored shadows) bool false
 #    Spread a complete update of shadow map over given amount of frames.
 #    Higher values might make shadows laggy, lower values
 #    will consume more resources.
-#    Minimum value: 1; maximum value: 16
+#    Minimum value: 1; maximum value: 64
 #
 #    Requires: shaders, enable_dynamic_shadows, opengl
-shadow_update_frames (Map shadows update frames) int 8 1 16
+shadow_update_frames (Map shadows update frames) int 16 1 64
 
 #    Set the soft shadow radius size.
 #    Lower values mean sharper shadows, bigger values mean softer shadows.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -524,8 +524,10 @@ shadow_poisson_filter (Poisson filtering) bool true
 #    This simulates the soft shadows effect by applying a PCF or Poisson disk
 #    but also uses more resources.
 #
+#    Note: Setting 1 enables simple 2x2 bilinear filter
+#
 #    Requires: shaders, enable_dynamic_shadows, opengl
-shadow_filters (Shadow filter quality) enum 1 0,1,2
+shadow_filters (Shadow filter quality) enum 1 0,1,2,3
 
 #    Enable colored shadows.
 #    On true translucent nodes cast colored shadows. This is expensive.

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -82,9 +82,9 @@ int getCascade()
 
 vec3 getLightSpacePosition(int cascade)
 {
-	float offset = dot(vNormal, -v_LightDirection); // cos(angle(light, normal))
-	offset = 1. - pow(offset, 2.); // sin(angle...)
-	offset *= 2. * shadowCascades[cascade].boundary / f_textureresolution;
+	float cosine = dot(vNormal, v_LightDirection); // cos(angle(light, normal))
+	float offset = 1. - pow(cosine, 2.); // sin(angle...)
+	offset *= 2. * shadowCascades[cascade].boundary / f_textureresolution * (cosine > 0. ? -1. : 1.);
 	vec4 shadow_position = shadowCascades[cascade].mViewProj * vec4(shadow_world_position + vNormal * offset, 1.0);
 	shadow_position /= shadow_position.w;
 	shadow_position.z = shadow_position.z * zPerspectiveBias - 1e-3 * shadowCascades[cascade].boundary / f_textureresolution;

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -397,14 +397,14 @@ void main(void)
 #ifdef COLORED_SHADOWS
 			vec4 visibility;
 			if (cosLight > 0.0 || f_normal_length < 1e-3)
-				visibility = getShadowColor(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
+				visibility = getShadowColor(ShadowMapSampler, posLightSpace.xy * vec2(1./3., 1.), posLightSpace.z);
 			else
 				visibility = vec4(1.0, 0.0, 0.0, 0.0);
 			shadow_int = visibility.r;
 			shadow_color = visibility.gba;
 #else
 			if (cosLight > 0.0 || f_normal_length < 1e-3)
-				shadow_int = getShadow(ShadowMapSampler, posLightSpace.xy, posLightSpace.z);
+				shadow_int = getShadow(ShadowMapSampler, posLightSpace.xy * vec2(1./3., 1.), posLightSpace.z);
 			else
 				shadow_int = 1.0;
 #endif

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -74,6 +74,8 @@ int getCascade()
 	return cascadeCount - 1;
 }
 
+int cascade = getCascade();
+
 vec3 getLightSpacePosition(int cascade)
 {
 	float cosine = dot(vNormal, v_LightDirection); // cos(angle(light, normal))
@@ -486,7 +488,6 @@ void main(void)
 		float shadow_int = 0.0;
 		vec3 shadow_color = vec3(0.0, 0.0, 0.0);
 
-		int cascade = getCascade();
 		vec3 posLightSpace = getLightSpacePosition(cascade); // 0..1 within a single cascade in the shadow map
 
 		float distance_rate = 1.0;

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -74,7 +74,7 @@ int getCascade()
 		vec3 center_to_fragment = shadow_world_position - shadowCascades[i].center;
 		float projected_distance = length(center_to_fragment - v_LightDirection * dot(center_to_fragment, v_LightDirection));
 
-		if (shadowCascades[i].boundary * 0.9 > projected_distance)
+		if (shadowCascades[i].boundary > projected_distance)
 			return i;
 	}
 	return cascadeCount - 1;

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -121,10 +121,10 @@ vec4 getHardShadowColor(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	vec4 texDepth = texture2D(shadowsampler, smTexCoord.xy).rgba;
 
 	float visibility = step(0.0, realDistance - texDepth.r);
-	vec4 result = vec4(visibility, vec3(0.0,0.0,0.0));//unpackColor(texDepth.g));
+	vec4 result = vec4(visibility, vec3(0.0,0.0,0.0));
 	if (visibility < 0.1) {
-		visibility = step(0.0, realDistance - texDepth.b);
-		result = vec4(visibility, unpackColor(texDepth.a));
+		visibility = step(0.0, realDistance - texDepth.g);
+		result = vec4(visibility, unpackColor(texDepth.b));
 	}
 	return result;
 }

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -18,14 +18,10 @@ uniform float animationTimer;
 	uniform mat4 m_ShadowViewProj;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
-	uniform vec4 CameraPos;
-	uniform float xyPerspectiveBias0;
-	uniform float xyPerspectiveBias1;
 	uniform float zPerspectiveBias;
 
 	struct ShadowCascade {
 		mat4 mViewProj; // view-projection matrix
-		vec3 cameraPosition; // position of the camera as seen by the cascade, in scene space
 		float boundary; // boundary of the cascade in scene space
 		vec3 center; // center of the frustum in scene space
 	};
@@ -39,8 +35,6 @@ uniform float animationTimer;
 	varying float adj_shadow_strength;
 	varying float cosLight;
 	varying float f_normal_length;
-	varying vec3 shadow_position;
-	varying float perspective_factor;
 #endif
 
 
@@ -242,14 +236,13 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	// A factor from 0 to 1 to reduce blurring of short shadows
 	float sharpness_factor = 1.0;
 	// conversion factor from shadow depth to blur radius
-	float depth_to_blur = f_shadowfar / SOFTSHADOWRADIUS / xyPerspectiveBias0;
+	float depth_to_blur = f_shadowfar / SOFTSHADOWRADIUS;
 	if (depth > 0.0 && f_normal_length > 0.0)
 		// 5 is empirical factor that controls how fast shadow loses sharpness
 		sharpness_factor = clamp(5 * depth * depth_to_blur, 0.0, 1.0);
 	depth = 0.0;
 
-	float world_to_texture = xyPerspectiveBias1 / perspective_factor / perspective_factor
-			* f_textureresolution / 2.0 / f_shadowfar;
+	float world_to_texture = f_textureresolution / 2.0 / f_shadowfar;
 	float world_radius = 0.2; // shadow blur radius in world float coordinates, e.g. 0.2 = 0.02 of one node
 
 	return max(BASEFILTERRADIUS * f_textureresolution / 4096.0,  sharpness_factor * world_radius * world_to_texture * SOFTSHADOWRADIUS);

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -15,7 +15,6 @@ uniform float animationTimer;
 	// shadow uniforms
 	uniform vec3 v_LightDirection;
 	uniform float f_textureresolution;
-	uniform mat4 m_ShadowViewProj;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
 	uniform float zPerspectiveBias;

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -77,7 +77,7 @@ int getCascade()
 vec3 getLightSpacePosition(int cascade)
 {
 	float cosine = dot(vNormal, v_LightDirection); // cos(angle(light, normal))
-	float offset = 1. - pow(cosine, 2.); // sin(angle...)
+	float offset = pow(1. - pow(cosine, 2.), 0.5); // sin(angle...)
 	offset *= 2. * shadowCascades[cascade].boundary / f_textureresolution * (cosine > 0. ? -1. : 1.);
 	vec4 shadow_position = shadowCascades[cascade].mViewProj * vec4(shadow_world_position + vNormal * offset, 1.0);
 	shadow_position /= shadow_position.w;

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -236,18 +236,18 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	float y, x;
 	float depth = getHardShadowDepth(shadowsampler, smTexCoord.xy, realDistance);
 	// A factor from 0 to 1 to reduce blurring of short shadows
-	float sharpness_factor = 1.0;
+	float sharpness_factor = 0.0;
 	// conversion factor from shadow depth to blur radius
 	float depth_to_blur = f_shadowfar / SOFTSHADOWRADIUS;
 	if (depth > 0.0 && f_normal_length > 0.0)
-		// 5 is empirical factor that controls how fast shadow loses sharpness
-		sharpness_factor = clamp(5 * depth * depth_to_blur, 0.0, 1.0);
+		sharpness_factor = clamp(2e-1 * depth * depth_to_blur, 0.0, 1.0);
 	depth = 0.0;
 
-	float world_to_texture = f_textureresolution / 2.0 / f_shadowfar;
+	float world_to_texture = f_textureresolution / 2. / shadowCascades[cascade].boundary;
 	float world_radius = 0.2; // shadow blur radius in world float coordinates, e.g. 0.2 = 0.02 of one node
+	float base_radius = max(BASEFILTERRADIUS, SOFTSHADOWRADIUS / 5.);
 
-	return max(BASEFILTERRADIUS * f_textureresolution / 4096.0,  sharpness_factor * world_radius * world_to_texture * SOFTSHADOWRADIUS);
+	return max(base_radius,  sharpness_factor * world_radius * world_to_texture * SOFTSHADOWRADIUS);
 }
 
 #ifdef POISSON_FILTER

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -87,7 +87,7 @@ vec3 getLightSpacePosition(int cascade)
 	offset *= 2. * shadowCascades[cascade].boundary / f_textureresolution;
 	vec4 shadow_position = shadowCascades[cascade].mViewProj * vec4(shadow_world_position + vNormal * offset, 1.0);
 	shadow_position /= shadow_position.w;
-	shadow_position.z *= zPerspectiveBias;
+	shadow_position.z = shadow_position.z * zPerspectiveBias - 1e-3 * shadowCascades[cascade].boundary / f_textureresolution;
 	return shadow_position.xyz * 0.5 + 0.5;
 }
 // custom smoothstep implementation because it's not defined in glsl1.2

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -140,7 +140,7 @@ vec4 getFilteredShadowColor(sampler2D shadowsampler, vec2 smTexCoord, float real
 	vec2 texelCoord = smTexCoord * vec2(f_textureresolution * cascadeCount, f_textureresolution);
 
 	vec2 fraction = texelCoord - floor(texelCoord);
-	float scale = dot(vNormal, -v_LightDirection);
+	float scale = 1.0;
 	vec2 sampleTexCoord = (floor(texelCoord) + 0.5 * scale) * texelSize;
 
 	float texDepth = texture2D(shadowsampler, sampleTexCoord).r;

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -27,12 +27,8 @@ centroid varying vec2 varTexCoord;
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	// shadow uniforms
 	uniform vec3 v_LightDirection;
-	uniform float f_textureresolution;
-	uniform mat4 m_ShadowViewProj;
-	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
 	uniform float f_timeofday;
-	uniform float zPerspectiveBias;
 
 	varying float cosLight;
 	varying float normalOffsetScale;
@@ -51,13 +47,6 @@ const float e = 2.718281828459;
 const float BS = 10.0;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
-
-vec4 applyPerspectiveDistortion(in vec4 position)
-{
-	position /= position.w;
-	position.z *= zPerspectiveBias;
-	return position;
-}
 
 // custom smoothstep implementation because it's not defined in glsl1.2
 // https://docs.gl/sl4/smoothstep

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -40,6 +40,7 @@ centroid varying vec2 varTexCoord;
 	varying float f_normal_length;
 	varying vec3 shadow_position;
 	varying float perspective_factor;
+	varying vec3 shadow_world_position;
 #endif
 
 varying float area_enable_parallax;
@@ -232,6 +233,8 @@ void main(void)
 #else
 		vec4 shadow_pos = pos;
 #endif
+		shadow_world_position = (mWorld * shadow_pos).xyz;
+
 		vec3 nNormal;
 		f_normal_length = length(vNormal);
 

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -32,14 +32,12 @@ centroid varying vec2 varTexCoord;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
 	uniform float f_timeofday;
-	uniform vec4 CameraPos;
+	uniform float zPerspectiveBias;
 
 	varying float cosLight;
 	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float f_normal_length;
-	varying vec3 shadow_position;
-	varying float perspective_factor;
 	varying vec3 shadow_world_position;
 #endif
 
@@ -51,34 +49,12 @@ varying float nightRatio;
 const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
 const float e = 2.718281828459;
 const float BS = 10.0;
-uniform float xyPerspectiveBias0;
-uniform float xyPerspectiveBias1;
-uniform float zPerspectiveBias;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 
-vec4 getRelativePosition(in vec4 position)
-{
-	vec2 l = position.xy - CameraPos.xy;
-	vec2 s = l / abs(l);
-	s = (1.0 - s * CameraPos.xy);
-	l /= s;
-	return vec4(l, s);
-}
-
-float getPerspectiveFactor(in vec4 relativePosition)
-{
-	float pDistance = length(relativePosition.xy);
-	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-	return pFactor;
-}
-
 vec4 applyPerspectiveDistortion(in vec4 position)
 {
-	vec4 l = getRelativePosition(position);
-	float pFactor = getPerspectiveFactor(l);
-	l.xy /= pFactor;
-	position.xy = l.xy * l.zw + CameraPos.xy;
+	position /= position.w;
 	position.z *= zPerspectiveBias;
 	return position;
 }
@@ -235,33 +211,14 @@ void main(void)
 #endif
 		shadow_world_position = (mWorld * shadow_pos).xyz;
 
-		vec3 nNormal;
 		f_normal_length = length(vNormal);
 
-		/* normalOffsetScale is in world coordinates (1/10th of a meter)
-		   z_bias is in light space coordinates */
-		float normalOffsetScale, z_bias;
-		float pFactor = getPerspectiveFactor(getRelativePosition(m_ShadowViewProj * mWorld * shadow_pos));
-		if (f_normal_length > 0.0) {
+		vec3 nNormal;
+		if (f_normal_length > 0.0)
 			nNormal = normalize(vNormal);
-			cosLight = max(1e-5, dot(nNormal, -v_LightDirection));
-			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
-			normalOffsetScale = 2.0 * pFactor * pFactor * sinLight * min(f_shadowfar, 500.0) /
-					xyPerspectiveBias1 / f_textureresolution;
-			z_bias = 1.0 * sinLight / cosLight;
-		}
-		else {
-			nNormal = vec3(0.0);
-			cosLight = clamp(dot(v_LightDirection, normalize(vec3(v_LightDirection.x, 0.0, v_LightDirection.z))), 1e-2, 1.0);
-			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
-			normalOffsetScale = 0.0;
-			z_bias = 3.6e3 * sinLight / cosLight;
-		}
-		z_bias *= pFactor * pFactor / f_textureresolution / f_shadowfar;
-
-		shadow_position = applyPerspectiveDistortion(m_ShadowViewProj * mWorld * (shadow_pos + vec4(normalOffsetScale * nNormal, 0.0))).xyz;
-		shadow_position.z -= z_bias;
-		perspective_factor = pFactor;
+		else
+			nNormal = normalize(vec3(-v_LightDirection.x, 0.0, -v_LightDirection.z));
+		cosLight = dot(nNormal, -v_LightDirection);
 
 		if (f_timeofday < 0.2) {
 			adj_shadow_strength = f_shadow_strength * 0.5 *

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -18,14 +18,10 @@ uniform float animationTimer;
 	uniform mat4 m_ShadowViewProj;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
-	uniform vec4 CameraPos;
-	uniform float xyPerspectiveBias0;
-	uniform float xyPerspectiveBias1;
 	uniform float zPerspectiveBias;
 
 	struct ShadowCascade {
 		mat4 mViewProj; // view-projection matrix
-		vec3 cameraPosition; // position of the camera as seen by the cascade, in scene space
 		float boundary; // boundary of the cascade in scene space
 		vec3 center; // center of the frustum in scene space
 	};
@@ -39,8 +35,6 @@ uniform float animationTimer;
 	varying float adj_shadow_strength;
 	varying float cosLight;
 	varying float f_normal_length;
-	varying vec3 shadow_position;
-	varying float perspective_factor;
 #endif
 
 
@@ -246,14 +240,13 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	// A factor from 0 to 1 to reduce blurring of short shadows
 	float sharpness_factor = 1.0;
 	// conversion factor from shadow depth to blur radius
-	float depth_to_blur = f_shadowfar / SOFTSHADOWRADIUS / xyPerspectiveBias0;
+	float depth_to_blur = f_shadowfar / SOFTSHADOWRADIUS;
 	if (depth > 0.0 && f_normal_length > 0.0)
 		// 5 is empirical factor that controls how fast shadow loses sharpness
 		sharpness_factor = clamp(5 * depth * depth_to_blur, 0.0, 1.0);
 	depth = 0.0;
 
-	float world_to_texture = xyPerspectiveBias1 / perspective_factor / perspective_factor
-			* f_textureresolution / 2.0 / f_shadowfar;
+	float world_to_texture = f_textureresolution / 2.0 / f_shadowfar;
 	float world_radius = 0.2; // shadow blur radius in world float coordinates, e.g. 0.2 = 0.02 of one node
 
 	return max(BASEFILTERRADIUS * f_textureresolution / 4096.0,  sharpness_factor * world_radius * world_to_texture * SOFTSHADOWRADIUS);

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -85,11 +85,15 @@ int getCascade()
 
 vec3 getLightSpacePosition(int cascade)
 {
-	vec4 shadow_position = shadowCascades[cascade].mViewProj * vec4(shadow_world_position, 1.0);
+	float offset = dot(vNormal, -v_LightDirection); // cos(angle(light, normal))
+	offset = 1. - pow(offset, 2.); // sin(angle...)
+	offset *= 2. * shadowCascades[cascade].boundary / f_textureresolution;
+	vec4 shadow_position = shadowCascades[cascade].mViewProj * vec4(shadow_world_position + vNormal * offset, 1.0);
 	shadow_position /= shadow_position.w;
-	shadow_position.z *= zPerspectiveBias;
+	shadow_position.z = shadow_position.z * zPerspectiveBias - 1e-3 * shadowCascades[cascade].boundary / f_textureresolution;
 	return shadow_position.xyz * 0.5 + 0.5;
 }
+
 // custom smoothstep implementation because it's not defined in glsl1.2
 // https://docs.gl/sl4/smoothstep
 float mtsmoothstep(in float edge0, in float edge1, in float x)

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -15,7 +15,6 @@ uniform float animationTimer;
 	// shadow uniforms
 	uniform vec3 v_LightDirection;
 	uniform float f_textureresolution;
-	uniform mat4 m_ShadowViewProj;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
 	uniform float zPerspectiveBias;

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -77,6 +77,8 @@ int getCascade()
 	return cascadeCount - 1;
 }
 
+int cascade = getCascade();
+
 vec3 getLightSpacePosition(int cascade)
 {
 	float cosine = dot(normalize(vNormal), -v_LightDirection); // cos(angle(light, normal))
@@ -491,7 +493,6 @@ void main(void)
 		float shadow_int = 0.0;
 		vec3 shadow_color = vec3(0.0, 0.0, 0.0);
 
-		int cascade = getCascade();
 		vec3 posLightSpace = getLightSpacePosition(cascade); // 0..1 within a single cascade in the shadow map
 
 		float distance_rate = 1.0;

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -85,9 +85,9 @@ int getCascade()
 
 vec3 getLightSpacePosition(int cascade)
 {
-	float offset = dot(vNormal, -v_LightDirection); // cos(angle(light, normal))
-	offset = 1. - pow(offset, 2.); // sin(angle...)
-	offset *= 2. * shadowCascades[cascade].boundary / f_textureresolution;
+	float cosine = dot(normalize(vNormal), -v_LightDirection); // cos(angle(light, normal))
+	float offset = pow(1. - pow(cosine, 2.), 0.5); // sin(angle...)
+	offset *= 2. * shadowCascades[cascade].boundary / f_textureresolution * (cosine > 0. ? -1. : 1.);
 	vec4 shadow_position = shadowCascades[cascade].mViewProj * vec4(shadow_world_position + vNormal * offset, 1.0);
 	shadow_position /= shadow_position.w;
 	shadow_position.z = shadow_position.z * zPerspectiveBias - 1e-3 * shadowCascades[cascade].boundary / f_textureresolution;

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -21,7 +21,21 @@ uniform float animationTimer;
 	uniform vec4 CameraPos;
 	uniform float xyPerspectiveBias0;
 	uniform float xyPerspectiveBias1;
+	uniform float zPerspectiveBias;
 
+	struct ShadowCascade {
+		mat4 mViewProj; // view-projection matrix
+		vec3 cameraPosition; // position of the camera as seen by the cascade, in scene space
+		float boundary; // boundary of the cascade in scene space
+		vec3 center; // center of the frustum in scene space
+	};
+
+	#define MAX_SHADOW_CASCADES 3
+
+	uniform ShadowCascade shadowCascades[MAX_SHADOW_CASCADES];
+	uniform int cascadeCount;
+
+	varying vec3 shadow_world_position;
 	varying float adj_shadow_strength;
 	varying float cosLight;
 	varying float f_normal_length;
@@ -51,15 +65,30 @@ varying float vIDiff;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 
-// assuming near is always 1.0
-float getLinearDepth()
+float debug = 0.0;
+
+int getCascade()
 {
-	return 2.0 * f_shadowfar / (f_shadowfar + 1.0 - (2.0 * gl_FragCoord.z - 1.0) * (f_shadowfar - 1.0));
+	for (int i = 0; i < MAX_SHADOW_CASCADES; i++) {
+		if (i == cascadeCount)
+			break;
+		vec3 center_to_fragment = shadow_world_position - shadowCascades[i].center;
+		float projected_distance = length(center_to_fragment - v_LightDirection * dot(center_to_fragment, v_LightDirection));
+		if (i == 1)
+			debug = projected_distance / shadowCascades[i].boundary;
+
+		if (shadowCascades[i].boundary * 0.9 > projected_distance)
+			return i;
+	}
+	return cascadeCount - 1;
 }
 
-vec3 getLightSpacePosition()
+vec3 getLightSpacePosition(int cascade)
 {
-	return shadow_position * 0.5 + 0.5;
+	vec4 shadow_position = shadowCascades[cascade].mViewProj * vec4(shadow_world_position, 1.0);
+	shadow_position /= shadow_position.w;
+	shadow_position.z *= zPerspectiveBias;
+	return shadow_position.xyz * 0.5 + 0.5;
 }
 // custom smoothstep implementation because it's not defined in glsl1.2
 // https://docs.gl/sl4/smoothstep
@@ -359,7 +388,6 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 #endif
 #endif
 
-
 void main(void)
 {
 	vec3 color;
@@ -386,14 +414,23 @@ void main(void)
 	if (f_shadow_strength > 0.0) {
 		float shadow_int = 0.0;
 		vec3 shadow_color = vec3(0.0, 0.0, 0.0);
-		vec3 posLightSpace = getLightSpacePosition();
 
-		float distance_rate = (1.0 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 10.0));
-		if (max(abs(posLightSpace.x - 0.5), abs(posLightSpace.y - 0.5)) > 0.5)
-			distance_rate = 0.0;
+		int cascade = getCascade();
+		vec3 posLightSpace = getLightSpacePosition(cascade); // 0..1 within a single cascade in the shadow map
+
+		float distance_rate = 1.0;
+		if (cascade == cascadeCount - 1) {
+			distance_rate = (1.0 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 10.0));
+			if (max(abs(posLightSpace.x - 0.5), abs(posLightSpace.y - 0.5)) > 0.5)
+				distance_rate = 0.0;
+		}
+
 		float f_adj_shadow_strength = max(adj_shadow_strength - mtsmoothstep(0.9, 1.1, posLightSpace.z),0.0);
 
 		if (distance_rate > 1e-7) {
+
+			// shift posLightSpace to the right cascade in the shadow map
+			posLightSpace.x = (posLightSpace.x + float(cascade)) / cascadeCount;
 
 #ifdef COLORED_SHADOWS
 			vec4 visibility;
@@ -421,7 +458,7 @@ void main(void)
 
 		// Apply self-shadowing when light falls at a narrow angle to the surface
 		// Cosine of the cut-off angle.
-		const float self_shadow_cutoff_cosine = 0.14;
+		const float self_shadow_cutoff_cosine = 0.035;
 		if (f_normal_length != 0 && cosLight < self_shadow_cutoff_cosine) {
 			shadow_int = max(shadow_int, 1 - clamp(cosLight, 0.0, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);
 			shadow_color = mix(vec3(0.0), shadow_color, min(cosLight, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -125,10 +125,10 @@ vec4 getHardShadowColor(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	vec4 texDepth = texture2D(shadowsampler, smTexCoord.xy).rgba;
 
 	float visibility = step(0.0, realDistance - texDepth.r);
-	vec4 result = vec4(visibility, vec3(0.0,0.0,0.0));//unpackColor(texDepth.g));
+	vec4 result = vec4(visibility, vec3(0.0,0.0,0.0));
 	if (visibility < 0.1) {
-		visibility = step(0.0, realDistance - texDepth.b);
-		result = vec4(visibility, unpackColor(texDepth.a));
+		visibility = step(0.0, realDistance - texDepth.g);
+		result = vec4(visibility, unpackColor(texDepth.b));
 	}
 	return result;
 }

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -240,18 +240,18 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	float y, x;
 	float depth = getHardShadowDepth(shadowsampler, smTexCoord.xy, realDistance);
 	// A factor from 0 to 1 to reduce blurring of short shadows
-	float sharpness_factor = 1.0;
+	float sharpness_factor = 0.0;
 	// conversion factor from shadow depth to blur radius
 	float depth_to_blur = f_shadowfar / SOFTSHADOWRADIUS;
 	if (depth > 0.0 && f_normal_length > 0.0)
-		// 5 is empirical factor that controls how fast shadow loses sharpness
-		sharpness_factor = clamp(5 * depth * depth_to_blur, 0.0, 1.0);
+		sharpness_factor = clamp(2e-1 * depth * depth_to_blur, 0.0, 1.0);
 	depth = 0.0;
 
-	float world_to_texture = f_textureresolution / 2.0 / f_shadowfar;
+	float world_to_texture = f_textureresolution / 2. / shadowCascades[cascade].boundary;
 	float world_radius = 0.2; // shadow blur radius in world float coordinates, e.g. 0.2 = 0.02 of one node
+	float base_radius = max(BASEFILTERRADIUS, SOFTSHADOWRADIUS / 5.);
 
-	return max(BASEFILTERRADIUS * f_textureresolution / 4096.0,  sharpness_factor * world_radius * world_to_texture * SOFTSHADOWRADIUS);
+	return max(base_radius,  sharpness_factor * world_radius * world_to_texture * SOFTSHADOWRADIUS);
 }
 
 #ifdef POISSON_FILTER

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -29,11 +29,8 @@ centroid varying vec2 varTexCoord;
 	// shadow uniforms
 	uniform vec3 v_LightDirection;
 	uniform float f_textureresolution;
-	uniform mat4 m_ShadowViewProj;
-	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
 	uniform float f_timeofday;
-	uniform float zPerspectiveBias;
 
 	varying float cosLight;
 	varying float normalOffsetScale;
@@ -53,13 +50,6 @@ const float e = 2.718281828459;
 const float BS = 10.0;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
-
-vec4 applyPerspectiveDistortion(in vec4 position)
-{
-	position /= position.w;
-	position.z *= zPerspectiveBias;
-	return position;
-}
 
 // custom smoothstep implementation because it's not defined in glsl1.2
 // https://docs.gl/sl4/smoothstep

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -33,14 +33,12 @@ centroid varying vec2 varTexCoord;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
 	uniform float f_timeofday;
-	uniform vec4 CameraPos;
+	uniform float zPerspectiveBias;
 
 	varying float cosLight;
 	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float f_normal_length;
-	varying vec3 shadow_position;
-	varying float perspective_factor;
 	varying vec3 shadow_world_position;
 #endif
 
@@ -53,34 +51,12 @@ const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
 varying float vIDiff;
 const float e = 2.718281828459;
 const float BS = 10.0;
-uniform float xyPerspectiveBias0;
-uniform float xyPerspectiveBias1;
-uniform float zPerspectiveBias;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 
-vec4 getRelativePosition(in vec4 position)
-{
-	vec2 l = position.xy - CameraPos.xy;
-	vec2 s = l / abs(l);
-	s = (1.0 - s * CameraPos.xy);
-	l /= s;
-	return vec4(l, s);
-}
-
-float getPerspectiveFactor(in vec4 relativePosition)
-{
-	float pDistance = length(relativePosition.xy);
-	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-	return pFactor;
-}
-
 vec4 applyPerspectiveDistortion(in vec4 position)
 {
-	vec4 l = getRelativePosition(position);
-	float pFactor = getPerspectiveFactor(l);
-	l.xy /= pFactor;
-	position.xy = l.xy * l.zw + CameraPos.xy;
+	position /= position.w;
 	position.z *= zPerspectiveBias;
 	return position;
 }
@@ -155,34 +131,17 @@ void main(void)
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	if (f_shadow_strength > 0.0) {
-		vec3 nNormal = normalize(vNormal);
-		f_normal_length = length(vNormal);
+
 		shadow_world_position = (mWorld * inVertexPosition).xyz;
 
-		/* normalOffsetScale is in world coordinates (1/10th of a meter)
-		   z_bias is in light space coordinates */
-		float normalOffsetScale, z_bias;
-		float pFactor = getPerspectiveFactor(getRelativePosition(m_ShadowViewProj * mWorld * inVertexPosition));
-		if (f_normal_length > 0.0) {
-			nNormal = normalize(vNormal);
-			cosLight = max(1e-5, dot(nNormal, -v_LightDirection));
-			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
-			normalOffsetScale = 0.1 * pFactor * pFactor * sinLight * min(f_shadowfar, 500.0) /
-					xyPerspectiveBias1 / f_textureresolution;
-			z_bias = 1e3 * sinLight / cosLight * (0.5 + f_textureresolution / 1024.0);
-		}
-		else {
-			nNormal = vec3(0.0);
-			cosLight = clamp(dot(v_LightDirection, normalize(vec3(v_LightDirection.x, 0.0, v_LightDirection.z))), 1e-2, 1.0);
-			float sinLight = pow(1 - pow(cosLight, 2.0), 0.5);
-			normalOffsetScale = 0.0;
-			z_bias = 3.6e3 * sinLight / cosLight;
-		}
-		z_bias *= pFactor * pFactor / f_textureresolution / f_shadowfar;
+		f_normal_length = length(vNormal);
 
-		shadow_position = applyPerspectiveDistortion(m_ShadowViewProj * mWorld * (inVertexPosition + vec4(normalOffsetScale * nNormal, 0.0))).xyz;
-		shadow_position.z -= z_bias;
-		perspective_factor = pFactor;
+		vec3 nNormal;
+		if (f_normal_length > 0.0)
+			nNormal = normalize(vNormal);
+		else
+			nNormal = normalize(vec3(-v_LightDirection.x, 0.0, -v_LightDirection.z));
+		cosLight = dot(nNormal, -v_LightDirection);
 
 		if (f_timeofday < 0.2) {
 			adj_shadow_strength = f_shadow_strength * 0.5 *

--- a/client/shaders/shadow_shaders/pass1_fragment.glsl
+++ b/client/shaders/shadow_shaders/pass1_fragment.glsl
@@ -1,11 +1,13 @@
 uniform sampler2D ColorMapSampler;
+uniform int Cascade;
+
 varying vec4 tPos;
 
 void main()
 {
 	vec4 col = texture2D(ColorMapSampler, gl_TexCoord[0].st);
 
-	if (col.a < 0.70)
+	if (Cascade < 2 && col.a < 0.70)
 		discard;
 
 	float depth = 0.5 + tPos.z * 0.5;

--- a/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
@@ -1,36 +1,15 @@
 uniform mat4 LightMVP; // world matrix
-uniform vec4 CameraPos;
+uniform float zPerspectiveBias;
+
 varying vec4 tPos;
 #ifdef COLORED_SHADOWS
 varying vec3 varColor;
 #endif
 
-uniform float xyPerspectiveBias0;
-uniform float xyPerspectiveBias1;
-uniform float zPerspectiveBias;
-
-vec4 getRelativePosition(in vec4 position)
-{
-	vec2 l = position.xy - CameraPos.xy;
-	vec2 s = l / abs(l);
-	s = (1.0 - s * CameraPos.xy);
-	l /= s;
-	return vec4(l, s);
-}
-
-float getPerspectiveFactor(in vec4 relativePosition)
-{
-	float pDistance = length(relativePosition.xy);
-	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-	return pFactor;
-}
 
 vec4 applyPerspectiveDistortion(in vec4 position)
 {
-	vec4 l = getRelativePosition(position);
-	float pFactor = getPerspectiveFactor(l);
-	l.xy /= pFactor;
-	position.xy = l.xy * l.zw + CameraPos.xy;
+	position /= position.w;
 	position.z *= zPerspectiveBias;
 	return position;
 }

--- a/client/shaders/shadow_shaders/pass1_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_vertex.glsl
@@ -1,33 +1,12 @@
 uniform mat4 LightMVP; // world matrix
-uniform vec4 CameraPos; // camera position
-varying vec4 tPos;
-
-uniform float xyPerspectiveBias0;
-uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
 
-vec4 getRelativePosition(in vec4 position)
-{
-	vec2 l = position.xy - CameraPos.xy;
-	vec2 s = l / abs(l);
-	s = (1.0 - s * CameraPos.xy);
-	l /= s;
-	return vec4(l, s);
-}
+varying vec4 tPos;
 
-float getPerspectiveFactor(in vec4 relativePosition)
-{
-	float pDistance = length(relativePosition.xy);
-	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-	return pFactor;
-}
 
 vec4 applyPerspectiveDistortion(in vec4 position)
 {
-	vec4 l = getRelativePosition(position);
-	float pFactor = getPerspectiveFactor(l);
-	l.xy /= pFactor;
-	position.xy = l.xy * l.zw + CameraPos.xy;
+	position /= position.w;
 	position.z *= zPerspectiveBias;
 	return position;
 }

--- a/client/shaders/shadow_shaders/pass2_fragment.glsl
+++ b/client/shaders/shadow_shaders/pass2_fragment.glsl
@@ -8,15 +8,20 @@ void main() {
 
 #ifdef COLORED_SHADOWS
 	vec2 first_depth = texture2D(ShadowMapClientMap, gl_TexCoord[0].st).rg;
-	vec2 depth_splitdynamics = vec2(texture2D(ShadowMapSamplerdynamic, min(gl_TexCoord[2].st * vec2(3., 1.), vec2(1., 1.))).r, 0.0);
-	if (first_depth.r > depth_splitdynamics.r)
-		first_depth = depth_splitdynamics;
+	if (gl_TexCoord[2].s < 1./3.) {
+		vec2 depth_splitdynamics = vec2(texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st * vec2(3., 1.)).r, 0.0);
+
+		if (first_depth.r > depth_splitdynamics.r)
+			first_depth = depth_splitdynamics;
+	}
 	vec2 depth_color = texture2D(ShadowMapClientMapTraslucent, gl_TexCoord[1].st).rg;
 	gl_FragColor = vec4(first_depth.r, first_depth.g, depth_color.r, depth_color.g);
 #else
 	float first_depth = texture2D(ShadowMapClientMap, gl_TexCoord[0].st).r;
-	float depth_splitdynamics = texture2D(ShadowMapSamplerdynamic, min(gl_TexCoord[2].st * vec2(3., 1.), vec2(1., 1.))).r;
-	first_depth = min(first_depth, depth_splitdynamics);
+	if (gl_TexCoord[2].s < 1./3.) {
+		float depth_splitdynamics = texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st * vec2(3., 1.)).r;
+		first_depth = min(first_depth, depth_splitdynamics);
+	}
 	gl_FragColor = vec4(first_depth, 0.0, 0.0, 1.0);
 #endif
 

--- a/client/shaders/shadow_shaders/pass2_fragment.glsl
+++ b/client/shaders/shadow_shaders/pass2_fragment.glsl
@@ -8,8 +8,8 @@ void main() {
 
 #ifdef COLORED_SHADOWS
 	vec2 first_depth = texture2D(ShadowMapClientMap, gl_TexCoord[0].st).rg;
-	if (gl_TexCoord[2].s < 1./3.) {
-		vec2 depth_splitdynamics = vec2(texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st * vec2(3., 1.)).r, 0.0);
+	if (gl_TexCoord[2].s < 2./3.) {
+		vec2 depth_splitdynamics = vec2(texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st * vec2(1.5, 1.)).r, 0.0);
 
 		if (first_depth.r > depth_splitdynamics.r)
 			first_depth = depth_splitdynamics;
@@ -18,8 +18,8 @@ void main() {
 	gl_FragColor = vec4(first_depth.r, first_depth.g, depth_color.r, depth_color.g);
 #else
 	float first_depth = texture2D(ShadowMapClientMap, gl_TexCoord[0].st).r;
-	if (gl_TexCoord[2].s < 1./3.) {
-		float depth_splitdynamics = texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st * vec2(3., 1.)).r;
+	if (gl_TexCoord[2].s < 2./3.) {
+		float depth_splitdynamics = texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st * vec2(1.5, 1.)).r;
 		first_depth = min(first_depth, depth_splitdynamics);
 	}
 	gl_FragColor = vec4(first_depth, 0.0, 0.0, 1.0);

--- a/client/shaders/shadow_shaders/pass2_fragment.glsl
+++ b/client/shaders/shadow_shaders/pass2_fragment.glsl
@@ -6,22 +6,15 @@ uniform sampler2D ShadowMapSamplerdynamic;
 
 void main() {
 
-#ifdef COLORED_SHADOWS
-	vec2 first_depth = texture2D(ShadowMapClientMap, gl_TexCoord[0].st).rg;
-	if (gl_TexCoord[2].s < 2./3.) {
-		vec2 depth_splitdynamics = vec2(texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st * vec2(1.5, 1.)).r, 0.0);
-
-		if (first_depth.r > depth_splitdynamics.r)
-			first_depth = depth_splitdynamics;
-	}
-	vec2 depth_color = texture2D(ShadowMapClientMapTraslucent, gl_TexCoord[1].st).rg;
-	gl_FragColor = vec4(first_depth.r, first_depth.g, depth_color.r, depth_color.g);
-#else
 	float first_depth = texture2D(ShadowMapClientMap, gl_TexCoord[0].st).r;
 	if (gl_TexCoord[2].s < 2./3.) {
 		float depth_splitdynamics = texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st * vec2(1.5, 1.)).r;
 		first_depth = min(first_depth, depth_splitdynamics);
 	}
+#ifdef COLORED_SHADOWS
+	vec2 depth_color = texture2D(ShadowMapClientMapTraslucent, gl_TexCoord[1].st).rg;
+	gl_FragColor = vec4(first_depth, depth_color.r, depth_color.g, 0.);
+#else
 	gl_FragColor = vec4(first_depth, 0.0, 0.0, 1.0);
 #endif
 

--- a/client/shaders/shadow_shaders/pass2_fragment.glsl
+++ b/client/shaders/shadow_shaders/pass2_fragment.glsl
@@ -8,14 +8,14 @@ void main() {
 
 #ifdef COLORED_SHADOWS
 	vec2 first_depth = texture2D(ShadowMapClientMap, gl_TexCoord[0].st).rg;
-	vec2 depth_splitdynamics = vec2(texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st).r, 0.0);
+	vec2 depth_splitdynamics = vec2(texture2D(ShadowMapSamplerdynamic, min(gl_TexCoord[2].st * vec2(3., 1.), vec2(1., 1.))).r, 0.0);
 	if (first_depth.r > depth_splitdynamics.r)
 		first_depth = depth_splitdynamics;
 	vec2 depth_color = texture2D(ShadowMapClientMapTraslucent, gl_TexCoord[1].st).rg;
 	gl_FragColor = vec4(first_depth.r, first_depth.g, depth_color.r, depth_color.g);
 #else
 	float first_depth = texture2D(ShadowMapClientMap, gl_TexCoord[0].st).r;
-	float depth_splitdynamics = texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st).r;
+	float depth_splitdynamics = texture2D(ShadowMapSamplerdynamic, min(gl_TexCoord[2].st * vec2(3., 1.), vec2(1., 1.))).r;
 	first_depth = min(first_depth, depth_splitdynamics);
 	gl_FragColor = vec4(first_depth, 0.0, 0.0, 1.0);
 #endif

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -433,13 +433,13 @@
 
 #    Maximum distance to render shadows.
 #    type: float min: 10 max: 1000
-# shadow_map_max_distance = 140.0
+# shadow_map_max_distance = 200.0
 
 #    Texture size to render the shadow map on.
 #    This must be a power of two.
 #    Bigger numbers create better shadows but it is also more expensive.
 #    type: int min: 128 max: 8192
-# shadow_map_texture_size = 2048
+# shadow_map_texture_size = 1024
 
 #    Sets shadow texture quality to 32 bits.
 #    On false, 16 bits texture will be used.
@@ -455,7 +455,8 @@
 #    Define shadow filtering quality.
 #    This simulates the soft shadows effect by applying a PCF or Poisson disk
 #    but also uses more resources.
-#    type: enum values: 0, 1, 2
+#    Value of 1 enables fast bilinear filter
+#    type: enum values: 0, 1, 2, 3
 # shadow_filters = 1
 
 #    Enable colored shadows.
@@ -466,9 +467,9 @@
 #    Spread a complete update of shadow map over given amount of frames.
 #    Higher values might make shadows laggy, lower values
 #    will consume more resources.
-#    Minimum value: 1; maximum value: 16
-#    type: int min: 1 max: 16
-# shadow_update_frames = 8
+#    Minimum value: 1; maximum value: 64
+#    type: int min: 1 max: 64
+# shadow_update_frames = 16 
 
 #    Set the soft shadow radius size.
 #    Lower values mean sharper shadows, bigger values mean softer shadows.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -561,7 +561,6 @@ void Client::step(float dtime)
 	{
 		int num_processed_meshes = 0;
 		std::vector<v3s16> blocks_to_ack;
-		bool force_update_shadows = false;
 		MeshUpdateResult r;
 		while (m_mesh_update_manager->getNextResult(r))
 		{
@@ -601,8 +600,6 @@ void Client::step(float dtime)
 					else {
 						// Replace with the new mesh
 						block->mesh = r.mesh;
-						if (r.urgent)
-							force_update_shadows = true;
 					}
 				}
 			} else {
@@ -642,10 +639,6 @@ void Client::step(float dtime)
 
 		if (num_processed_meshes > 0)
 			g_profiler->graphAdd("num_processed_meshes", num_processed_meshes);
-
-		auto shadow_renderer = RenderingEngine::get_shadow_renderer();
-		if (shadow_renderer && force_update_shadows)
-			shadow_renderer->setForceUpdateShadowMap();
 	}
 
 	/*

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1093,6 +1093,10 @@ void ClientMap::PrintInfo(std::ostream &out)
 void ClientMap::renderMapShadows(u8 cascade, video::IVideoDriver *driver,
 		const video::SMaterial &material, s32 pass, int frame, int total_frames)
 {
+	// don't draw if the cascade is not defined yet
+	if (cascade >= m_drawlist_shadow.size())
+		return;
+
 	bool is_transparent_pass = pass != scene::ESNRP_SOLID;
 	std::string prefix;
 	if (is_transparent_pass)
@@ -1243,6 +1247,10 @@ void ClientMap::allocateDrawListShadowCascades(u8 n_cascades)
 */
 void ClientMap::updateDrawListShadowCascade(u8 cascade, v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length)
 {
+	// don't generate a draw list if the cascade is not defined yet
+	if (cascade >= m_drawlist_shadow.size())
+		return;
+
 	ScopeProfiler sp(g_profiler, "CM::updateDrawListShadow()", SPT_AVG);
 
 	v3s16 cam_pos_nodes = floatToInt(shadow_light_pos, BS);

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1107,6 +1107,12 @@ void ClientMap::renderMapShadows(u8 cascade, video::IVideoDriver *driver,
 	u32 drawcall_count = 0;
 	u32 vertex_count = 0;
 
+	/*
+		Update transparent meshes
+	*/
+	if (is_transparent_pass)
+		updateTransparentMeshBuffers();
+
 	MeshBufListList grouped_buffers;
 	std::vector<DrawDescriptor> draw_order;
 

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -118,12 +118,13 @@ public:
 	void updateDrawList();
 	// @brief Calculate statistics about the map and keep the blocks alive
 	void touchMapBlocks();
-	void updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length);
+	void allocateDrawListShadowCascades(u8 n_cascades);
+	void updateDrawListShadowCascade(u8 cascade, v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length);
 	// Returns true if draw list needs updating before drawing the next frame.
 	bool needsUpdateDrawList() { return m_needs_update_drawlist; }
 	void renderMap(video::IVideoDriver* driver, s32 pass);
 
-	void renderMapShadows(video::IVideoDriver *driver,
+	void renderMapShadows(u8 cascade, video::IVideoDriver *driver,
 			const video::SMaterial &material, s32 pass, int frame, int total_frames);
 
 	int getBackgroundBrightness(float max_d, u32 daylight_factor,
@@ -206,7 +207,8 @@ private:
 
 	std::map<v3s16, MapBlock*, MapBlockComparer> m_drawlist;
 	std::vector<MapBlock*> m_keeplist;
-	std::map<v3s16, MapBlock*> m_drawlist_shadow;
+	typedef std::map<v3s16, MapBlock*> drawlist_t;
+	std::vector<drawlist_t> m_drawlist_shadow; // cascades
 	bool m_needs_update_drawlist;
 
 	std::set<v2s16> m_last_drawn_sectors;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -684,6 +684,7 @@ struct GameRunData {
 	float damage_flash;
 	float update_draw_list_timer;
 	float touch_blocks_timer;
+	float update_shadow_frames_skipped;
 
 	f32 fog_range;
 
@@ -815,7 +816,7 @@ protected:
 			const ItemStack &selected_item, const ItemStack &hand_item, f32 dtime);
 	void updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 			const CameraOrientation &cam);
-	void updateShadows();
+	void updateShadows(u8 max_cascades);
 
 	// Misc
 	void showOverlayMessage(const char *msg, float dtime, int percent,
@@ -4107,24 +4108,33 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 
 	v3f camera_direction = camera->getDirection();
 
+	// Always update cascade 0 and try to update all cascades when camera offset changes or enough frames pass
+	if (RenderingEngine::get_shadow_renderer()) {
+		bool force = (m_camera_offset_changed || runData.update_shadow_frames_skipped > 5);
+		// prioritize shadow frustum update if camera offset changes
+		updateShadows(force ? SHADOW_CASCADES : 1);
+		if (force)
+			runData.update_shadow_frames_skipped = 0;
+	}
+
 	// call only one of updateDrawList, touchMapBlocks, or updateShadow per frame
 	// (the else-ifs below are intentional)
-	if (RenderingEngine::get_shadow_renderer() && m_camera_offset_changed) {
-		// prioritize shadow frustum update if camera offset changes
-		updateShadows();
-	}
-	else if (runData.update_draw_list_timer >= update_draw_list_delta
+	if (runData.update_draw_list_timer >= update_draw_list_delta
 			|| runData.update_draw_list_last_cam_dir.getDistanceFrom(camera_direction) > 0.2
 			|| m_camera_offset_changed
 			|| client->getEnv().getClientMap().needsUpdateDrawList()) {
 		runData.update_draw_list_timer = 0;
 		client->getEnv().getClientMap().updateDrawList();
 		runData.update_draw_list_last_cam_dir = camera_direction;
+		runData.update_shadow_frames_skipped++;
 	} else if (runData.touch_blocks_timer > update_draw_list_delta) {
 		client->getEnv().getClientMap().touchMapBlocks();
 		runData.touch_blocks_timer = 0;
+		runData.update_shadow_frames_skipped++;
 	} else if (RenderingEngine::get_shadow_renderer()) {
-		updateShadows();
+		// when we have enough capacity to update shadows more frequently than every 5th frame
+		updateShadows(SHADOW_CASCADES);
+		runData.update_shadow_frames_skipped = 0;
 	}
 
 	m_game_ui->update(*stats, client, draw_control, cam, runData.pointed_old, gui_chat_console, dtime);
@@ -4220,7 +4230,7 @@ inline void Game::updateProfilerGraphs(ProfilerGraph *graph)
 /****************************************************************************
  * Shadows
  *****************************************************************************/
-void Game::updateShadows()
+void Game::updateShadows(u8 max_cascades)
 {
 	ShadowRenderer *shadow = RenderingEngine::get_shadow_renderer();
 	if (!shadow)
@@ -4243,7 +4253,7 @@ void Game::updateShadows()
 	shadow->getDirectionalLight().setDirection(sun_pos);
 	shadow->setTimeOfDay(in_timeofday);
 
-	shadow->getDirectionalLight().update_frustum(camera, client, m_camera_offset_changed);
+	shadow->getDirectionalLight().update_frustum(camera, client, m_camera_offset_changed, max_cascades);
 }
 
 /****************************************************************************

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4109,7 +4109,11 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 
 	// call only one of updateDrawList, touchMapBlocks, or updateShadow per frame
 	// (the else-ifs below are intentional)
-	if (runData.update_draw_list_timer >= update_draw_list_delta
+	if (RenderingEngine::get_shadow_renderer() && m_camera_offset_changed) {
+		// prioritize shadow frustum update if camera offset changes
+		updateShadows();
+	}
+	else if (runData.update_draw_list_timer >= update_draw_list_delta
 			|| runData.update_draw_list_last_cam_dir.getDistanceFrom(camera_direction) > 0.2
 			|| m_camera_offset_changed
 			|| client->getEnv().getClientMap().needsUpdateDrawList()) {

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -299,8 +299,8 @@ public:
 		if (ShadowRenderer *shadow = RenderingEngine::get_shadow_renderer()) {
 			const auto &light = shadow->getDirectionalLight();
 
-			core::matrix4 shadowViewProj = light.getProjectionMatrix();
-			shadowViewProj *= light.getViewMatrix();
+			core::matrix4 shadowViewProj = light.getCascade(0).getProjectionMatrix();
+			shadowViewProj *= light.getCascade(0).getViewMatrix();
 			m_shadow_view_proj.set(shadowViewProj.pointer(), services);
 
 			f32 v_LightDirection[3];
@@ -320,7 +320,7 @@ public:
 			m_shadowfar.set(&shadowFar, services);
 
 			f32 cam_pos[4];
-			shadowViewProj.transformVect(cam_pos, light.getPlayerPos());
+			shadowViewProj.transformVect(cam_pos, light.getCascade(0).getPlayerPos());
 			m_camera_pos.set(cam_pos, services);
 
 			// I don't like using this hardcoded value. maybe something like

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -805,7 +805,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		if (g_settings->getBool("shadow_poisson_filter"))
 			shaders_header << "#define POISSON_FILTER 1\n";
 
-		s32 shadow_filter = g_settings->getS32("shadow_filters");
+		s32 shadow_filter = rangelim(g_settings->getS32("shadow_filters"), 0, 3);
 		shaders_header << "#define SHADOW_FILTER " << shadow_filter << "\n";
 
 		float shadow_soft_radius = g_settings->getFloat("shadow_soft_radius");

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -217,13 +217,11 @@ class MainShaderConstantSetter : public IShaderConstantSetter
 	struct ShadowCascadeShaderSettings {
 		ShadowCascadeShaderSettings(int cascade):
 				m_shadow_view_proj(std::string("shadowCascades[") + std::to_string(cascade) + "].mViewProj"),
-				m_camera_world_position(std::string("shadowCascades[") + std::to_string(cascade) + "].cameraPosition"),
 				m_boundary(std::string("shadowCascades[") + std::to_string(cascade) + "].boundary"),
 				m_center(std::string("shadowCascades[") + std::to_string(cascade) + "].center")
 		{}
 
 		CachedVertexShaderSetting<f32, 16> m_shadow_view_proj;
-		CachedVertexShaderSetting<f32, 3> m_camera_world_position;
 		CachedVertexShaderSetting<f32> m_boundary;
 		CachedVertexShaderSetting<f32, 3> m_center;
 
@@ -234,9 +232,6 @@ class MainShaderConstantSetter : public IShaderConstantSetter
 			f32 boundary = cascade.current_frustum.radius;
 			m_boundary.set(&boundary, services);
 			m_center.set(&cascade.current_frustum.center.X, services);
-
-			v3f camera_world_position = cascade.getPlayerPos();
-			m_camera_world_position.set(&camera_world_position.X, services);
 		}
 	};
 
@@ -247,12 +242,7 @@ class MainShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<f32> m_shadow_strength;
 	CachedPixelShaderSetting<f32> m_time_of_day;
 	CachedPixelShaderSetting<f32> m_shadowfar;
-	CachedPixelShaderSetting<f32, 4> m_camera_pos;
 	CachedPixelShaderSetting<s32> m_shadow_texture;
-	CachedVertexShaderSetting<f32> m_perspective_bias0_vertex;
-	CachedPixelShaderSetting<f32> m_perspective_bias0_pixel;
-	CachedVertexShaderSetting<f32> m_perspective_bias1_vertex;
-	CachedPixelShaderSetting<f32> m_perspective_bias1_pixel;
 	CachedVertexShaderSetting<f32> m_perspective_zbias_vertex;
 	CachedPixelShaderSetting<f32> m_perspective_zbias_pixel;
 	CachedVertexShaderSetting<s32> m_cascade_count;
@@ -275,12 +265,7 @@ public:
 		, m_shadow_strength("f_shadow_strength")
 		, m_time_of_day("f_timeofday")
 		, m_shadowfar("f_shadowfar")
-		, m_camera_pos("CameraPos")
 		, m_shadow_texture("ShadowMapSampler")
-		, m_perspective_bias0_vertex("xyPerspectiveBias0")
-		, m_perspective_bias0_pixel("xyPerspectiveBias0")
-		, m_perspective_bias1_vertex("xyPerspectiveBias1")
-		, m_perspective_bias1_pixel("xyPerspectiveBias1")
 		, m_perspective_zbias_vertex("zPerspectiveBias")
 		, m_perspective_zbias_pixel("zPerspectiveBias")
 		, m_cascade_count("cascadeCount")
@@ -363,22 +348,11 @@ public:
 			f32 shadowFar = shadow->getMaxShadowFar();
 			m_shadowfar.set(&shadowFar, services);
 
-			f32 cam_pos[4];
-			shadowViewProj.transformVect(cam_pos, light.getCascade(0).getPlayerPos());
-			m_camera_pos.set(cam_pos, services);
-
-
 			// I don't like using this hardcoded value. maybe something like
 			// MAX_TEXTURE - 1 or somthing like that??
 			s32 TextureLayerID = 3;
 			m_shadow_texture.set(&TextureLayerID, services);
 
-			f32 bias0 = shadow->getPerspectiveBiasXY();
-			m_perspective_bias0_vertex.set(&bias0, services);
-			m_perspective_bias0_pixel.set(&bias0, services);
-			f32 bias1 = 1.0f - bias0 + 1e-5f;
-			m_perspective_bias1_vertex.set(&bias1, services);
-			m_perspective_bias1_pixel.set(&bias1, services);
 			f32 zbias = shadow->getPerspectiveBiasZ();
 			m_perspective_zbias_vertex.set(&zbias, services);
 			m_perspective_zbias_pixel.set(&zbias, services);

--- a/src/client/shader.h
+++ b/src/client/shader.h
@@ -82,23 +82,24 @@ public:
 
 template <typename T, std::size_t count, bool cache>
 class CachedShaderSetting {
-	const char *m_name;
+	const std::string m_name;
 	T m_sent[count];
 	bool has_been_set = false;
 	bool is_pixel;
 protected:
-	CachedShaderSetting(const char *name, bool is_pixel) :
+	CachedShaderSetting(const std::string &name, bool is_pixel) :
 		m_name(name), is_pixel(is_pixel)
 	{}
 public:
+	const std::string &getname() { return m_name; }
 	void set(const T value[count], video::IMaterialRendererServices *services)
 	{
 		if (cache && has_been_set && std::equal(m_sent, m_sent + count, value))
 			return;
 		if (is_pixel)
-			services->setPixelShaderConstant(services->getPixelShaderConstantID(m_name), value, count);
+			services->setPixelShaderConstant(services->getPixelShaderConstantID(m_name.c_str()), value, count);
 		else
-			services->setVertexShaderConstant(services->getVertexShaderConstantID(m_name), value, count);
+			services->setVertexShaderConstant(services->getVertexShaderConstantID(m_name.c_str()), value, count);
 
 		if (cache) {
 			std::copy(value, value + count, m_sent);
@@ -110,14 +111,14 @@ public:
 template <typename T, std::size_t count = 1, bool cache=true>
 class CachedPixelShaderSetting : public CachedShaderSetting<T, count, cache> {
 public:
-	CachedPixelShaderSetting(const char *name) :
+	CachedPixelShaderSetting(const std::string &name) :
 		CachedShaderSetting<T, count, cache>(name, true){}
 };
 
 template <typename T, std::size_t count = 1, bool cache=true>
 class CachedVertexShaderSetting : public CachedShaderSetting<T, count, cache> {
 public:
-	CachedVertexShaderSetting(const char *name) :
+	CachedVertexShaderSetting(const std::string &name) :
 		CachedShaderSetting<T, count, cache>(name, false){}
 };
 

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -96,7 +96,6 @@ ShadowFrustum ShadowCascade::createFrustum(v3f direction, const Camera *cam, f32
 	
 	// we must compute the viewmat with the position - the camera offset
 	// but the future_frustum position must be the actual world position
-	v3f eye = center_scene - eye_displacement;
 	ShadowFrustum f;
 	f.player = cam_pos_scene;
 	f.center = center_scene;
@@ -105,7 +104,7 @@ ShadowFrustum ShadowCascade::createFrustum(v3f direction, const Camera *cam, f32
 	f.radius = radius;
 	f.zNear = near_value;
 	f.zFar = far_value;
-	f.ViewMat.buildCameraLookAtMatrixLH(eye, center_scene, v3f(0.0f, 1.0f, 0.0f));
+	f.ViewMat.buildCameraLookAtMatrixLH(center_scene, center_scene + eye_displacement, v3f(0.0f, 1.0f, 0.0f));
 	f.ProjOrthMat.buildProjectionMatrixOrthoLH(2.0 * radius, 2.0 * radius,
 			0.0f, length, false);
 	f.camera_offset = cam->getOffset();

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -181,13 +181,6 @@ DirectionalLight::DirectionalLight(const u32 shadowMapResolution,
 		diffuseColor(lightColor),
 		farPlane(farValue), mapRes(shadowMapResolution), pos(position)
 {
-	f32 scale_factor = 4.;
-	f32 scale = 1.0 / powf32(scale_factor, cascades.size() - 1);
-	for (auto &cascade: cascades) {
-		cascade.farPlane = farPlane;
-		cascade.scale = scale;
-		scale *= scale_factor;
-	}
 }
 
 void DirectionalLight::setDirection(v3f dir)
@@ -199,6 +192,17 @@ void DirectionalLight::setDirection(v3f dir)
 void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool force)
 {
 	client->getEnv().getClientMap().allocateDrawListShadowCascades(getCascadesCount());
+
+	f32 scale = 20. * BS / getFarValue();
+	f32 scale_factor = 1./pow(scale, 1./(cascades.size() - 1.));
+
+	warningstream << "FP: " << farPlane << " scale: " << scale << " F: " << scale_factor << std::endl;
+	for (auto &cascade: cascades) {
+		cascade.farPlane = farPlane;
+		cascade.scale = scale;
+		scale *= scale_factor;
+	}
+
 	for (u8 i = 0; i < getCascadesCount(); i++) {
 		auto &cascade = getCascade(i);
 		if (cascade.update_frustum(direction, cam, client, force)) {

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -128,8 +128,9 @@ void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool fo
 	future_frustum = createFrustum(cam, zNear, zFar, 0.35);
 
 	// get the draw list for shadows
-	client->getEnv().getClientMap().updateDrawListShadow(
-			getPosition(), getDirection(), future_frustum.radius, future_frustum.length);
+	client->getEnv().getClientMap().allocateDrawListShadowCascades(1);
+	client->getEnv().getClientMap().updateDrawListShadowCascade(
+			0, getPosition(), getDirection(), future_frustum.radius, future_frustum.length);
 	should_update_map_shadow = true;
 	dirty = true;
 

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -118,7 +118,7 @@ bool ShadowCascade::update_frustum(v3f direction, const Camera *cam, Client *cli
 	if (!client->getEnv().getClientMap().getControl().range_all)
 		zFar = MYMIN(zFar, client->getEnv().getClientMap().getControl().wanted_range * BS);
 
-	future_frustum = createFrustum(direction, cam, zNear, zFar, 0.35);
+	future_frustum = createFrustum(direction, cam, zNear, zFar * scale, 0.35);
 
 	dirty = true;
 
@@ -189,8 +189,12 @@ DirectionalLight::DirectionalLight(const u32 shadowMapResolution,
 		diffuseColor(lightColor),
 		farPlane(farValue), mapRes(shadowMapResolution), pos(position)
 {
-	for (auto &cascade: cascades)
+	f32 scale = 1./9.;
+	for (auto &cascade: cascades) {
 		cascade.farPlane = farPlane;
+		cascade.scale = scale;
+		scale *= 3.;
+	}
 }
 
 void DirectionalLight::setDirection(v3f dir)

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -52,9 +52,9 @@ ShadowFrustum ShadowCascade::createFrustum(v3f direction, const Camera *cam, f32
 	else
 		last_look = look;
 
-	// adjusted frustum boundaries
+	// adjusted frustum boundaries for the frustum's size
 	float sfNear = near_value;
-	float sfFar = far_value;
+	float sfFar = far_value * scale;
 
 	// adjusted camera positions
 	v3f cam_pos_world = cam->getPosition();
@@ -76,13 +76,10 @@ ShadowFrustum ShadowCascade::createFrustum(v3f direction, const Camera *cam, f32
 	v3f center_scene = cam_pos_scene + look * center_ratio * (sfFar - sfNear);
 	v3f center_world = cam_pos_world + look * center_ratio * (sfFar - sfNear);
 
-	float radius = sfFar; // assume radius simply to be the far plane
-	float length = radius * 3.0f;
+	float radius = sfFar * (1. - center_ratio); // assume radius is the distance from center to camera's far plane
+	float length = far_value * 3.0f;
 	v3f eye_displacement = quantizeDirection(direction, M_PI / 2880 /*15 seconds*/) * length;
 
-	// Adjust frustum radius for the cascade scale
-	radius *= scale;
-	
 	// we must compute the viewmat with the position - the camera offset
 	// but the future_frustum position must be the actual world position
 	ShadowFrustum f;
@@ -110,7 +107,7 @@ bool ShadowCascade::update_frustum(v3f direction, const Camera *cam, Client *cli
 	if (!client->getEnv().getClientMap().getControl().range_all)
 		zFar = MYMIN(zFar, client->getEnv().getClientMap().getControl().wanted_range * BS);
 
-	future_frustum = createFrustum(direction, cam, zNear, zFar, 0.);
+	future_frustum = createFrustum(direction, cam, zNear, zFar, 0.3);
 
 	dirty = true;
 

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -115,9 +115,13 @@ bool ShadowCascade::update_frustum(v3f direction, const Camera *cam, Client *cli
 	// when camera offset changes, adjust the current frustum view matrix to avoid flicker
 	v3s16 cam_offset = cam->getOffset();
 	if (cam_offset != current_frustum.camera_offset) {
-		v3f rotated_offset;
-		current_frustum.ViewMat.rotateVect(rotated_offset, intToFloat(cam_offset - current_frustum.camera_offset, BS));
-		current_frustum.ViewMat.setTranslation(current_frustum.ViewMat.getTranslation() + rotated_offset);
+		v3f delta = intToFloat(cam_offset - current_frustum.camera_offset, BS);
+
+		current_frustum.center -= delta;
+
+		v3f rotated_delta;
+		current_frustum.ViewMat.rotateVect(rotated_delta, delta);
+		current_frustum.ViewMat.setTranslation(current_frustum.ViewMat.getTranslation() + rotated_delta);
 		current_frustum.camera_offset = cam_offset;
 	}
 	return true;

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -84,7 +84,6 @@ ShadowFrustum ShadowCascade::createFrustum(v3f direction, const Camera *cam, f32
 	// we must compute the viewmat with the position - the camera offset
 	// but the future_frustum position must be the actual world position
 	ShadowFrustum f;
-	f.player = cam_pos_scene;
 	f.center = center_scene;
 	f.position = center_world - eye_displacement;
 	f.length = length;
@@ -119,7 +118,6 @@ bool ShadowCascade::update_frustum(v3f direction, const Camera *cam, Client *cli
 		v3f rotated_offset;
 		current_frustum.ViewMat.rotateVect(rotated_offset, intToFloat(cam_offset - current_frustum.camera_offset, BS));
 		current_frustum.ViewMat.setTranslation(current_frustum.ViewMat.getTranslation() + rotated_offset);
-		current_frustum.player += intToFloat(current_frustum.camera_offset - cam->getOffset(), BS);
 		current_frustum.camera_offset = cam_offset;
 	}
 	return true;
@@ -137,16 +135,6 @@ void ShadowCascade::commitFrustum()
 v3f ShadowCascade::getPosition() const
 {
 	return current_frustum.position;
-}
-
-v3f ShadowCascade::getPlayerPos() const
-{
-	return current_frustum.player;
-}
-
-v3f ShadowCascade::getFuturePlayerPos() const
-{
-	return future_frustum.player;
 }
 
 const m4f &ShadowCascade::getViewMatrix() const

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -52,10 +52,6 @@ ShadowFrustum ShadowCascade::createFrustum(v3f direction, const Camera *cam, f32
 	else
 		last_look = look;
 
-	// camera view tangents
-	float tanFovY = tanf(cam->getFovY() * 0.5f);
-	float tanFovX = tanf(cam->getFovX() * 0.5f);
-
 	// adjusted frustum boundaries
 	float sfNear = near_value;
 	float sfFar = far_value;
@@ -80,14 +76,7 @@ ShadowFrustum ShadowCascade::createFrustum(v3f direction, const Camera *cam, f32
 	v3f center_scene = cam_pos_scene + look * center_ratio * (sfFar - sfNear);
 	v3f center_world = cam_pos_world + look * center_ratio * (sfFar - sfNear);
 
-	// Create a vector to the frustum far corner
-	const v3f &viewUp = cam->getCameraNode()->getUpVector();
-	v3f viewRight = look.crossProduct(viewUp);
-
-	v3f farCorner = (look + viewRight * tanFovX + viewUp * tanFovY).normalize();
-	// Compute the frustumBoundingSphere radius
-	v3f boundVec = (cam_pos_scene + farCorner * sfFar) - center_scene;
-	float radius = boundVec.getLength();
+	float radius = sfFar; // assume radius simply to be the far plane
 	float length = radius * 3.0f;
 	v3f eye_displacement = quantizeDirection(direction, M_PI / 2880 /*15 seconds*/) * length;
 

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -187,7 +187,7 @@ void DirectionalLight::setDirection(v3f dir)
 	direction.normalize();
 }
 
-void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool force)
+void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool force, u8 max_cascades)
 {
 	client->getEnv().getClientMap().allocateDrawListShadowCascades(getCascadesCount());
 
@@ -200,7 +200,7 @@ void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool fo
 		scale *= scale_factor;
 	}
 
-	for (u8 i = 0; i < getCascadesCount(); i++) {
+	for (u8 i = 0; i < MYMIN(max_cascades, getCascadesCount()); i++) {
 		auto &cascade = getCascade(i);
 		if (cascade.update_frustum(direction, cam, client, force)) {
 			// get the draw list for shadows

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -193,7 +193,6 @@ void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool fo
 	f32 scale = 20. * BS / getFarValue();
 	f32 scale_factor = 1./pow(scale, 1./(cascades.size() - 1.));
 
-	warningstream << "FP: " << farPlane << " scale: " << scale << " F: " << scale_factor << std::endl;
 	for (auto &cascade: cascades) {
 		cascade.farPlane = farPlane;
 		cascade.scale = scale;

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -41,7 +41,6 @@ struct ShadowFrustum
 	v3f position;
 	v3f player;
 	v3s16 camera_offset;
-
 };
 
 class DirectionalLight;
@@ -54,6 +53,7 @@ struct ShadowCascade {
 	v3f last_cam_pos_world{0,0,0};
 	v3f last_look{0,1,0};
 	bool dirty {false};
+	f32 scale;
 
 	// Creates a frustum with parameters
 	// z_near, z_far - distances of player's camera to take in to account for the frustum

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -27,7 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class Camera;
 class Client;
 
-struct shadowFrustum
+struct ShadowFrustum
 {
 	f32 zNear{0.0f};
 	f32 zFar{0.0f};
@@ -105,7 +105,10 @@ public:
 	void commitFrustum();
 
 private:
-	void createSplitMatrices(const Camera *cam);
+	// Creates a frustum with parameters
+	// z_near, z_far - distances of player's camera to take in to account for the frustum
+	// center_ratio - interpolation ratio for center of shadow frustum between z_near and z_far
+	ShadowFrustum createFrustum(const Camera *cam, f32 z_near, f32 z_far, f32 center_ratio);
 
 	video::SColorf diffuseColor;
 
@@ -118,7 +121,7 @@ private:
 	v3f last_cam_pos_world{0,0,0};
 	v3f last_look{0,1,0};
 
-	shadowFrustum shadow_frustum;
-	shadowFrustum future_frustum;
+	ShadowFrustum shadow_frustum;
+	ShadowFrustum future_frustum;
 	bool dirty{false};
 };

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -40,6 +40,7 @@ struct ShadowFrustum
 	core::matrix4 ViewMat;
 	v3f position;
 	v3f player;
+	v3f center;
 	v3s16 camera_offset;
 };
 
@@ -82,7 +83,7 @@ struct ShadowCascade {
 	const core::matrix4 &getProjectionMatrix() const;
 	const core::matrix4 &getFutureViewMatrix() const;
 	const core::matrix4 &getFutureProjectionMatrix() const;
-	core::matrix4 getViewProjMatrix();
+	core::matrix4 getViewProjMatrix() const;
 
 	void commitFrustum();
 };
@@ -115,7 +116,7 @@ public:
 	/// Gets the current far value of the light
 	f32 getFarValue() const
 	{
-		return getCascade(0).getFarValue();
+		return getCascade(getCascadesCount() - 1).getFarValue();
 	}
 
 

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -99,7 +99,7 @@ public:
 
 	//DISABLE_CLASS_COPY(DirectionalLight)
 
-	void update_frustum(const Camera *cam, Client *client, bool force = false);
+	void update_frustum(const Camera *cam, Client *client, bool force, u8 max_cascades);
 
 	// when set direction is updated to negative normalized(direction)
 	void setDirection(v3f dir);

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -78,8 +78,6 @@ struct ShadowCascade {
 	}
 
 	v3f getPosition() const;
-	v3f getPlayerPos() const;
-	v3f getFuturePlayerPos() const;
 
 	const core::matrix4 &getViewMatrix() const;
 	const core::matrix4 &getProjectionMatrix() const;

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -50,18 +50,20 @@ struct ShadowCascade {
 	ShadowFrustum current_frustum;
 	ShadowFrustum future_frustum;
 
-	f32 farPlane;
-	v3f last_cam_pos_world{0,0,0};
-	v3f last_look{0,1,0};
+	f32 farPlane {1.0};
+	v3f last_cam_pos_world {0,0,0};
+	v3f last_look {0,1,0};
 	bool dirty {false};
-	f32 scale;
+	f32 scale {1.0f};
+	u8 max_frames {1};
+	u8 current_frame {0};
 
 	// Creates a frustum with parameters
 	// z_near, z_far - distances of player's camera to take in to account for the frustum
 	// center_ratio - interpolation ratio for center of shadow frustum between z_near and z_far
 	ShadowFrustum createFrustum(v3f direction, const Camera *cam, f32 z_near, f32 z_far, f32 center_ratio);
 	// returns true if the frustum was changed
-	bool update_frustum(v3f direction, const Camera *cam, Client *client, u8 index, bool force = false);
+	bool update_frustum(v3f direction, const Camera *cam, Client *client, bool force = false);
 
 	/// Gets the light's maximum far value, i.e. the shadow boundary
 	f32 getMaxFarValue() const
@@ -139,8 +141,6 @@ public:
 	}
 
 	bool should_update_map_shadow{true};
-
-	void commitFrustum();
 
 	u8 getCascadesCount() const { return cascades.size(); }
 	const ShadowCascade &getCascade(u8 index) const { return cascades.at(index); }

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <array>
 #include "irrlichttypes_bloated.h"
 #include <matrix4.h>
 #include "util/basic_macros.h"
@@ -26,6 +27,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class Camera;
 class Client;
+
+#define SHADOW_CASCADES 3
 
 struct ShadowFrustum
 {
@@ -138,7 +141,9 @@ public:
 
 	void commitFrustum();
 
-	const ShadowCascade &getCascade(u8 index) const { return cascade; }
+	u8 getCascadesCount() const { return cascades.size(); }
+	const ShadowCascade &getCascade(u8 index) const { return cascades.at(index); }
+	ShadowCascade &getCascade(u8 index) { return cascades.at(index); }
 
 private:
 	video::SColorf diffuseColor;
@@ -149,5 +154,5 @@ private:
 	v3f pos;
 	v3f direction{0};
 
-	ShadowCascade cascade;
+	std::array<ShadowCascade, SHADOW_CASCADES> cascades;
 };

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -294,7 +294,7 @@ void ShadowRenderer::updateSMTextures()
 					cb->MaxFar = (f32)m_shadow_map_max_distance * BS;
 					cb->PerspectiveBiasXY = getPerspectiveBiasXY();
 					cb->PerspectiveBiasZ = getPerspectiveBiasZ();
-					cb->CameraPos = light.getFuturePlayerPos();
+					cb->CameraPos = light.getCascade(0).getFuturePlayerPos();
 				}
 
 			// set the Render Target
@@ -361,7 +361,7 @@ void ShadowRenderer::update(video::ITexture *outputTarget)
 			// Static shader values for entities are set in updateSMTextures
 			// SM texture for entities is not updated incrementally and
 			// must by updated using current player position.
-			m_shadow_depth_entity_cb->CameraPos = light.getPlayerPos();
+			m_shadow_depth_entity_cb->CameraPos = light.getCascade(0).getPlayerPos();
 
 			// render shadows for the n0n-map objects.
 			m_driver->setRenderTarget(shadowMapTextureDynamicObjects, true,
@@ -391,7 +391,7 @@ void ShadowRenderer::update(video::ITexture *outputTarget)
 void ShadowRenderer::drawDebug()
 {
 	/* this code just shows shadows textures in screen and in ONLY for debugging*/
-	#if 0
+	#if 1
 	// this is debug, ignore for now.
 	if (shadowMapTextureFinal)
 		m_driver->draw2DImage(shadowMapTextureFinal,
@@ -436,8 +436,8 @@ video::ITexture *ShadowRenderer::getSMTexture(const std::string &shadow_map_name
 void ShadowRenderer::renderShadowMap(video::ITexture *target,
 		DirectionalLight &light, scene::E_SCENE_NODE_RENDER_PASS pass)
 {
-	m_driver->setTransform(video::ETS_VIEW, light.getFutureViewMatrix());
-	m_driver->setTransform(video::ETS_PROJECTION, light.getFutureProjectionMatrix());
+	m_driver->setTransform(video::ETS_VIEW, light.getCascade(0).getFutureViewMatrix());
+	m_driver->setTransform(video::ETS_PROJECTION, light.getCascade(0).getFutureProjectionMatrix());
 
 	ClientMap &map_node = static_cast<ClientMap &>(m_client->getEnv().getMap());
 
@@ -470,8 +470,8 @@ void ShadowRenderer::renderShadowMap(video::ITexture *target,
 void ShadowRenderer::renderShadowObjects(
 		video::ITexture *target, DirectionalLight &light)
 {
-	m_driver->setTransform(video::ETS_VIEW, light.getViewMatrix());
-	m_driver->setTransform(video::ETS_PROJECTION, light.getProjectionMatrix());
+	m_driver->setTransform(video::ETS_VIEW, light.getCascade(0).getViewMatrix());
+	m_driver->setTransform(video::ETS_PROJECTION, light.getCascade(0).getProjectionMatrix());
 
 	for (const auto &shadow_node : m_shadow_node_array) {
 		// we only take care of the shadow casters and only visible nodes cast shadows

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -294,7 +294,6 @@ static void drawQuad(video::SColor color, video::ITexture *texture, video::IVide
 	auto &material = quad.getMaterial();
 	material.MaterialType = video::EMT_SOLID;
 	material.TextureLayers[0].Texture = texture;
-	material.ZBuffer = video::E_COMPARISON_FUNC::ECFN_DISABLED;
 	quad.render(driver);
 }
 

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -205,7 +205,7 @@ void ShadowRenderer::removeNodeFromShadowList(scene::ISceneNode *node)
 	}
 }
 
-void ShadowRenderer::updateSMTextures()
+void ShadowRenderer::ensureSMTextures()
 {
 	if (!m_shadows_enabled || m_smgr->getActiveCamera() == nullptr) {
 		return;
@@ -268,6 +268,15 @@ void ShadowRenderer::updateSMTextures()
 				mat.setTexture(TEXTURE_LAYER_SHADOW, shadowMapTextureFinal);
 			});
 	}
+}
+
+void ShadowRenderer::updateSMTextures()
+{
+	if (!m_shadows_enabled || m_smgr->getActiveCamera() == nullptr) {
+		return;
+	}
+
+	ensureSMTextures();
 
 	if (!m_shadow_node_array.empty()) {
 		bool reset_sm_texture = false;

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -464,7 +464,7 @@ void ShadowRenderer::renderShadowMap(video::ITexture *target,
 	int frame = m_force_update_shadow_map ? 0 : m_current_frame;
 	int total_frames = m_force_update_shadow_map ? 1 : m_map_shadow_update_frames;
 
-	map_node.renderMapShadows(m_driver, material, pass, frame, total_frames);
+	map_node.renderMapShadows(0, m_driver, material, pass, frame, total_frames);
 }
 
 void ShadowRenderer::renderShadowObjects(

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -475,8 +475,8 @@ void ShadowRenderer::renderShadowMap(video::ITexture *target, u8 cascade_index,
 		material = map_node.getMaterial(0);
 	}
 
-	material.BackfaceCulling = false;
-	material.FrontfaceCulling = true;
+	material.BackfaceCulling = true;
+	material.FrontfaceCulling = false;
 
 	if (m_shadow_map_colored && pass != scene::ESNRP_SOLID) {
 		material.MaterialType = (video::E_MATERIAL_TYPE) depth_shader_trans;

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -475,7 +475,7 @@ void ShadowRenderer::renderShadowMap(video::ITexture *target, u8 cascade_index,
 		material = map_node.getMaterial(0);
 	}
 
-	material.BackfaceCulling = true;
+	material.BackfaceCulling = false;
 	material.FrontfaceCulling = false;
 
 	if (m_shadow_map_colored && pass != scene::ESNRP_SOLID) {

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -443,7 +443,7 @@ void ShadowRenderer::update(video::ITexture *outputTarget)
 void ShadowRenderer::drawDebug()
 {
 	/* this code just shows shadows textures in screen and in ONLY for debugging*/
-	#if 1
+	#if 0
 	// this is debug, ignore for now.
 	if (shadowMapTextureFinal)
 		m_driver->draw2DImage(shadowMapTextureFinal,

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -338,12 +338,11 @@ void ShadowRenderer::renderMapShadows()
 					}
 				}
 				else
+					// shadowMapClientFuture has one less cascade
 					m_driver->setRenderTarget(shadowMapClientMapFuture.at(i-1), cascade.current_frame == 0, true, video::SColor(0xFFFFFFFF));
 
 				renderShadowMap(shadowMapClientMap, i, cascade);
 
-				// Render transparent part in one pass.
-				// This is also handled in ClientMap.
 				if (cascade.current_frame == cascade.max_frames - 1) {
 					if (i > 0) {
 						// blit current texture to the main
@@ -354,6 +353,8 @@ void ShadowRenderer::renderMapShadows()
 						drawQuad(video::SColor(0xFFFFFFFF), shadowMapClientMapFuture.at(i-1), m_driver);
 					}
 
+					// Render transparent part in one pass.
+					// This is also handled in ClientMap.
 					if (m_shadow_map_colored) {
 						m_driver->setRenderTarget(shadowMapTextureColors,
 								false, true);
@@ -397,9 +398,6 @@ void ShadowRenderer::renderEntityShadows()
 				renderShadowObjects(shadowMapTextureDynamicObjects, cascade);
 			} // end for cascades
 		} // end for lights
-
-		// clear the Render Target
-		m_driver->setRenderTarget(0, false, false);
 	}
 }
 
@@ -418,7 +416,6 @@ void ShadowRenderer::mergeShadowMaps()
 	m_driver->setRenderTarget(shadowMapTextureFinal, false, false,
 			video::SColor(255, 255, 255, 255));
 	m_screen_quad->render(m_driver);
-	m_driver->setRenderTarget(0, false, false);
 }
 
 void ShadowRenderer::update(video::ITexture *outputTarget)
@@ -509,9 +506,6 @@ void ShadowRenderer::renderShadowMap(video::ITexture *target, u8 cascade_index,
 		material.MaterialType = (video::E_MATERIAL_TYPE) depth_shader;
 		material.BlendOperation = video::EBO_MIN;
 	}
-
-	m_driver->setTransform(video::ETS_WORLD,
-			map_node.getAbsoluteTransformation());
 
 	int frame = cascade.current_frame;
 	int total_frames = cascade.max_frames;

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -35,8 +35,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 ShadowRenderer::ShadowRenderer(IrrlichtDevice *device, Client *client) :
 		m_smgr(device->getSceneManager()), m_driver(device->getVideoDriver()),
-		m_client(client),
-		m_perspective_bias_xy(0.0), m_perspective_bias_z(0.5)
+		m_client(client), m_perspective_bias_z(0.5)
 {
 	(void) m_client;
 
@@ -318,9 +317,7 @@ void ShadowRenderer::renderMapShadows()
 					if (cb) {
 						cb->MapRes = (f32)m_shadow_map_texture_size;
 						cb->MaxFar = (f32)m_shadow_map_max_distance * BS;
-						cb->PerspectiveBiasXY = getPerspectiveBiasXY();
 						cb->PerspectiveBiasZ = getPerspectiveBiasZ();
-						cb->CameraPos = cascade.getFuturePlayerPos();
 						cb->Cascade = i;
 					}
 
@@ -390,9 +387,6 @@ void ShadowRenderer::renderEntityShadows()
 					break;
 				const auto &cascade = light.getCascade(i);
 				// Static shader values for entities are set in updateSMTextures
-				// SM texture for entities is not updated incrementally and
-				// must by updated using current player position.
-				m_shadow_depth_entity_cb->CameraPos = cascade.getPlayerPos();
 				m_shadow_depth_entity_cb->Cascade = i;
 
 				m_driver->setViewPort(core::rect<s32>(

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -248,7 +248,7 @@ void ShadowRenderer::ensureSMTextures(u8 n_cascades)
 			video::ITexture *cascade_texture = getSMTexture(
 					std::string("shadow_clientmap_bb_") + itos(i) + std::string("_") + itos(m_shadow_map_texture_size),
 					m_texture_format,
-					n_cascades, true);
+					1, true);
 			assert(cascade_texture != nullptr);
 			shadowMapClientMapFuture.push_back(cascade_texture);
 		}

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -295,8 +295,6 @@ static void drawQuad(video::SColor color, video::ITexture *texture, video::IVide
 	material.MaterialType = video::EMT_SOLID;
 	material.TextureLayers[0].Texture = texture;
 	material.ZBuffer = video::E_COMPARISON_FUNC::ECFN_DISABLED;
-	driver->setTransform(video::ETS_VIEW, core::matrix4());
-	driver->setTransform(video::ETS_PROJECTION, core::matrix4());
 	quad.render(driver);
 }
 

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -304,6 +304,7 @@ void ShadowRenderer::renderMapShadows()
 						cb->PerspectiveBiasXY = getPerspectiveBiasXY();
 						cb->PerspectiveBiasZ = getPerspectiveBiasZ();
 						cb->CameraPos = cascade.getFuturePlayerPos();
+						cb->Cascade = i;
 					}
 
 				// set the Render Target

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -366,6 +366,7 @@ void ShadowRenderer::renderEntityShadows()
 			// SM texture for entities is not updated incrementally and
 			// must by updated using current player position.
 			m_shadow_depth_entity_cb->CameraPos = light.getCascade(0).getPlayerPos();
+			m_shadow_depth_entity_cb->Cascade = 0;
 
 			// render shadows for the n0n-map objects.
 			m_driver->setRenderTarget(shadowMapTextureDynamicObjects, true,

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -229,17 +229,17 @@ void ShadowRenderer::ensureSMTextures(u8 n_cascades)
 	if (!shadowMapTextureDynamicObjects) {
 
 		shadowMapTextureDynamicObjects = getSMTexture(
-			std::string("shadow_dynamic_") + itos(m_shadow_map_texture_size),
-			m_texture_format, MYMIN(2, n_cascades), true);
+				std::string("shadow_dynamic_") + itos(m_shadow_map_texture_size),
+				m_texture_format, MYMIN(2, n_cascades), true);
 		assert(shadowMapTextureDynamicObjects != nullptr);
 	}
 
 	if (!shadowMapClientMap) {
 
 		shadowMapClientMap = getSMTexture(
-			std::string("shadow_clientmap_") + itos(m_shadow_map_texture_size),
-			m_shadow_map_colored ? m_texture_format_color : m_texture_format,
-			n_cascades, true);
+				std::string("shadow_clientmap_") + itos(m_shadow_map_texture_size),
+				m_texture_format,
+				n_cascades, true);
 		assert(shadowMapClientMap != nullptr);
 	}
 
@@ -247,7 +247,7 @@ void ShadowRenderer::ensureSMTextures(u8 n_cascades)
 		for (u8 i = 1; i < n_cascades; i++) {
 			video::ITexture *cascade_texture = getSMTexture(
 					std::string("shadow_clientmap_bb_") + itos(i) + std::string("_") + itos(m_shadow_map_texture_size),
-					m_shadow_map_colored ? m_texture_format_color : m_texture_format,
+					m_texture_format,
 					n_cascades, true);
 			assert(cascade_texture != nullptr);
 			shadowMapClientMapFuture.push_back(cascade_texture);
@@ -256,9 +256,9 @@ void ShadowRenderer::ensureSMTextures(u8 n_cascades)
 
 	if (m_shadow_map_colored && !shadowMapTextureColors) {
 		shadowMapTextureColors = getSMTexture(
-			std::string("shadow_colored_") + itos(m_shadow_map_texture_size),
-			m_shadow_map_colored ? m_texture_format_color : m_texture_format,
-			n_cascades, true);
+				std::string("shadow_colored_") + itos(m_shadow_map_texture_size),
+				m_texture_format_color,
+				n_cascades, true);
 		assert(shadowMapTextureColors != nullptr);
 	}
 

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -98,15 +98,15 @@ public:
 
 private:
 	video::ITexture *getSMTexture(const std::string &shadow_map_name,
-			video::ECOLOR_FORMAT texture_format,
+			video::ECOLOR_FORMAT texture_format, u8 n_cascades,
 			bool force_creation = false);
 
-	void renderShadowMap(video::ITexture *target, DirectionalLight &light,
+	void renderShadowMap(video::ITexture *target, const ShadowCascade &cascade,
 			scene::E_SCENE_NODE_RENDER_PASS pass =
 					scene::ESNRP_SOLID);
-	void renderShadowObjects(video::ITexture *target, DirectionalLight &light);
+	void renderShadowObjects(video::ITexture *target, const ShadowCascade &cascade);
 	void mixShadowsQuad();
-	void ensureSMTextures();
+	void ensureSMTextures(u8 n_cascades);
 	void renderMapShadows();
 	void renderEntityShadows();
 	void mergeShadowMaps();

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -107,7 +107,9 @@ private:
 	void renderShadowObjects(video::ITexture *target, DirectionalLight &light);
 	void mixShadowsQuad();
 	void ensureSMTextures();
-	void updateSMTextures();
+	void renderMapShadows();
+	void renderEntityShadows();
+	void mergeShadowMaps();
 
 	void disable();
 	void enable() { m_shadows_enabled = m_shadows_supported; }

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -106,6 +106,7 @@ private:
 					scene::ESNRP_SOLID);
 	void renderShadowObjects(video::ITexture *target, DirectionalLight &light);
 	void mixShadowsQuad();
+	void ensureSMTextures();
 	void updateSMTextures();
 
 	void disable();

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -101,7 +101,7 @@ private:
 			video::ECOLOR_FORMAT texture_format, u8 n_cascades,
 			bool force_creation = false);
 
-	void renderShadowMap(video::ITexture *target, const ShadowCascade &cascade,
+	void renderShadowMap(video::ITexture *target, u8 cascade_index, const ShadowCascade &cascade,
 			scene::E_SCENE_NODE_RENDER_PASS pass =
 					scene::ESNRP_SOLID);
 	void renderShadowObjects(video::ITexture *target, const ShadowCascade &cascade);

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -92,7 +92,6 @@ public:
 	float getShadowStrength() const { return m_shadows_enabled ? m_shadow_strength : 0.0f; }
 	float getTimeOfDay() const { return m_time_day; }
 
-	f32 getPerspectiveBiasXY() { return m_perspective_bias_xy; }
 	f32 getPerspectiveBiasZ() { return m_perspective_bias_z; }
 
 private:
@@ -136,7 +135,6 @@ private:
 	bool m_shadows_enabled;
 	bool m_shadows_supported;
 	bool m_shadow_map_colored;
-	f32 m_perspective_bias_xy;
 	f32 m_perspective_bias_z;
 
 	video::ECOLOR_FORMAT m_texture_format{video::ECOLOR_FORMAT::ECF_R16F};

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -76,7 +76,6 @@ public:
 	void removeNodeFromShadowList(scene::ISceneNode *node);
 
 	void update(video::ITexture *outputTarget = nullptr);
-	void setForceUpdateShadowMap() { m_force_update_shadow_map = true; }
 	void drawDebug();
 
 	video::ITexture *get_texture()
@@ -119,7 +118,7 @@ private:
 	video::IVideoDriver *m_driver{nullptr};
 	Client *m_client{nullptr};
 	video::ITexture *shadowMapClientMap{nullptr};
-	video::ITexture *shadowMapClientMapFuture{nullptr};
+	std::vector<video::ITexture *>shadowMapClientMapFuture;
 	video::ITexture *shadowMapTextureFinal{nullptr};
 	video::ITexture *shadowMapTextureDynamicObjects{nullptr};
 	video::ITexture *shadowMapTextureColors{nullptr};
@@ -137,9 +136,6 @@ private:
 	bool m_shadows_enabled;
 	bool m_shadows_supported;
 	bool m_shadow_map_colored;
-	bool m_force_update_shadow_map;
-	u8 m_map_shadow_update_frames; /* Use this number of frames to update map shaodw */
-	u8 m_current_frame{0}; /* Current frame */
 	f32 m_perspective_bias_xy;
 	f32 m_perspective_bias_z;
 

--- a/src/client/shadows/shadowsScreenQuad.cpp
+++ b/src/client/shadows/shadowsScreenQuad.cpp
@@ -23,6 +23,7 @@ shadowScreenQuad::shadowScreenQuad(video::SColor color)
 {
 	Material.Wireframe = false;
 	Material.Lighting = false;
+	Material.ZBuffer = video::ECFN_DISABLED;
 
 	Vertices[0] = video::S3DVertex(
 			-1.0f, -1.0f, 0.0f, 0, 0, 1, color, 0.0f, 1.0f);

--- a/src/client/shadows/shadowsScreenQuad.cpp
+++ b/src/client/shadows/shadowsScreenQuad.cpp
@@ -19,12 +19,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "shadowsScreenQuad.h"
 
-shadowScreenQuad::shadowScreenQuad()
+shadowScreenQuad::shadowScreenQuad(video::SColor color)
 {
 	Material.Wireframe = false;
 	Material.Lighting = false;
 
-	video::SColor color(0x0);
 	Vertices[0] = video::S3DVertex(
 			-1.0f, -1.0f, 0.0f, 0, 0, 1, color, 0.0f, 1.0f);
 	Vertices[1] = video::S3DVertex(

--- a/src/client/shadows/shadowsScreenQuad.cpp
+++ b/src/client/shadows/shadowsScreenQuad.cpp
@@ -42,6 +42,8 @@ void shadowScreenQuad::render(video::IVideoDriver *driver)
 {
 	u16 indices[6] = {0, 1, 2, 3, 4, 5};
 	driver->setMaterial(Material);
+	driver->setTransform(video::ETS_PROJECTION, core::matrix4());
+	driver->setTransform(video::ETS_VIEW, core::matrix4());
 	driver->setTransform(video::ETS_WORLD, core::matrix4());
 	driver->drawIndexedTriangleList(&Vertices[0], 6, &indices[0], 2);
 }

--- a/src/client/shadows/shadowsScreenQuad.h
+++ b/src/client/shadows/shadowsScreenQuad.h
@@ -26,7 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class shadowScreenQuad
 {
 public:
-	shadowScreenQuad();
+	shadowScreenQuad(video::SColor color = video::SColor(0x0));
 
 	void render(video::IVideoDriver *driver);
 	video::SMaterial &getMaterial() { return Material; }

--- a/src/client/shadows/shadowsshadercallbacks.cpp
+++ b/src/client/shadows/shadowsshadercallbacks.cpp
@@ -43,6 +43,7 @@ void ShadowDepthShaderCB::OnSetConstants(
 	m_perspective_bias1.set(&bias1, services);
 	f32 zbias = PerspectiveBiasZ;
 	m_perspective_zbias.set(&zbias, services);
+	m_cascade_setting.set(&Cascade, services);
 
 	m_cam_pos_setting.set(cam_pos, services);
 }

--- a/src/client/shadows/shadowsshadercallbacks.cpp
+++ b/src/client/shadows/shadowsshadercallbacks.cpp
@@ -26,10 +26,6 @@ void ShadowDepthShaderCB::OnSetConstants(
 
 	core::matrix4 lightMVP = driver->getTransform(video::ETS_PROJECTION);
 	lightMVP *= driver->getTransform(video::ETS_VIEW);
-
-	f32 cam_pos[4];
-	lightMVP.transformVect(cam_pos, CameraPos);
-
 	lightMVP *= driver->getTransform(video::ETS_WORLD);
 
 	m_light_mvp_setting.set(lightMVP.pointer(), services);
@@ -37,13 +33,7 @@ void ShadowDepthShaderCB::OnSetConstants(
 	m_max_far_setting.set(&MaxFar, services);
 	s32 TextureId = 0;
 	m_color_map_sampler_setting.set(&TextureId, services);
-	f32 bias0 = PerspectiveBiasXY;
-	m_perspective_bias0.set(&bias0, services);
-	f32 bias1 = 1.0f - bias0 + 1e-5f;
-	m_perspective_bias1.set(&bias1, services);
 	f32 zbias = PerspectiveBiasZ;
 	m_perspective_zbias.set(&zbias, services);
 	m_cascade_setting.set(&Cascade, services);
-
-	m_cam_pos_setting.set(cam_pos, services);
 }

--- a/src/client/shadows/shadowsshadercallbacks.h
+++ b/src/client/shadows/shadowsshadercallbacks.h
@@ -34,7 +34,8 @@ public:
 			m_perspective_bias0("xyPerspectiveBias0"),
 			m_perspective_bias1("xyPerspectiveBias1"),
 			m_perspective_zbias("zPerspectiveBias"),
-			m_cam_pos_setting("CameraPos")
+			m_cam_pos_setting("CameraPos"),
+			m_cascade_setting("Cascade")
 	{}
 
 	void OnSetMaterial(const video::SMaterial &material) override {}
@@ -45,6 +46,7 @@ public:
 	f32 MaxFar{2048.0f}, MapRes{1024.0f};
 	f32 PerspectiveBiasXY {0.9f}, PerspectiveBiasZ {0.5f};
 	v3f CameraPos;
+	s32 Cascade;
 
 private:
 	CachedVertexShaderSetting<f32, 16> m_light_mvp_setting;
@@ -55,4 +57,5 @@ private:
 	CachedVertexShaderSetting<f32> m_perspective_bias1;
 	CachedVertexShaderSetting<f32> m_perspective_zbias;
 	CachedVertexShaderSetting<f32, 4> m_cam_pos_setting;
+	CachedPixelShaderSetting<s32> m_cascade_setting;
 };

--- a/src/client/shadows/shadowsshadercallbacks.h
+++ b/src/client/shadows/shadowsshadercallbacks.h
@@ -31,10 +31,7 @@ public:
 			m_map_resolution_setting("MapResolution"),
 			m_max_far_setting("MaxFar"),
 			m_color_map_sampler_setting("ColorMapSampler"),
-			m_perspective_bias0("xyPerspectiveBias0"),
-			m_perspective_bias1("xyPerspectiveBias1"),
 			m_perspective_zbias("zPerspectiveBias"),
-			m_cam_pos_setting("CameraPos"),
 			m_cascade_setting("Cascade")
 	{}
 
@@ -44,8 +41,7 @@ public:
 			s32 userData) override;
 
 	f32 MaxFar{2048.0f}, MapRes{1024.0f};
-	f32 PerspectiveBiasXY {0.9f}, PerspectiveBiasZ {0.5f};
-	v3f CameraPos;
+	f32 PerspectiveBiasZ {0.5f};
 	s32 Cascade;
 
 private:
@@ -53,9 +49,6 @@ private:
 	CachedVertexShaderSetting<f32> m_map_resolution_setting;
 	CachedVertexShaderSetting<f32> m_max_far_setting;
 	CachedPixelShaderSetting<s32> m_color_map_sampler_setting;
-	CachedVertexShaderSetting<f32> m_perspective_bias0;
-	CachedVertexShaderSetting<f32> m_perspective_bias1;
 	CachedVertexShaderSetting<f32> m_perspective_zbias;
-	CachedVertexShaderSetting<f32, 4> m_cam_pos_setting;
 	CachedPixelShaderSetting<s32> m_cascade_setting;
 };

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -273,13 +273,13 @@ void set_default_settings()
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");
 	settings->setDefault("shadow_strength_gamma", "1.0");
-	settings->setDefault("shadow_map_max_distance", "140.0");
-	settings->setDefault("shadow_map_texture_size", "2048");
+	settings->setDefault("shadow_map_max_distance", "200.0");
+	settings->setDefault("shadow_map_texture_size", "1024");
 	settings->setDefault("shadow_map_texture_32bit", "true");
 	settings->setDefault("shadow_map_color", "false");
 	settings->setDefault("shadow_filters", "1");
 	settings->setDefault("shadow_poisson_filter", "true");
-	settings->setDefault("shadow_update_frames", "8");
+	settings->setDefault("shadow_update_frames", "16");
 	settings->setDefault("shadow_soft_radius", "5.0");
 	settings->setDefault("shadow_sky_body_orbit_tilt", "0.0");
 


### PR DESCRIPTION
Upgrades the current shadow mapping implementation to cascaded shadow maps.

Benefits:
* Affine transformation for the shadow = simpler math, faster shader, less maintenance
* Fixes shadows for large objects/meshes such as e.g. in Little Lady or shadows for clouds in the future
* Smoother updates of shadows (every cascade updates at its own pace, cascade 0 updates every frame)
* Much less peter-panning
* Less VRAM consumption for similar shadow quality/scale
* Visible area covered with shadows in most cases even with fast camera movement

Other fixes:
* Removed flicker when mapblock is updated (e.g. flowing water)
* Removed flicker when camera offset changes (every 200 nodes)
* Added bilinear filter for SHADOW_FILTER == 1 for playable shadow quality with more performance

Notes:
* 3 cascades
* Cascade 0 is fixed small size in world and updates every frame, giving reasonable shadow quality close to the player
* Cascade 2 is updated every shadow_update_frames frame (up to 32) and cascade 1 somewhere in-between
* Entity shadows on cascades 0 and 1
* Colored shadows work
* Soft shadows work (may need some tuning)
* Shadow performance with client_mesh_chunk_size = 1 may be lower because of increased number of drawcalls covering larger area. Increasing shadow_update_frames should help spread out the updates.
* shadow_map_texture_size now controls resolution of each of 3 cascades (2 for entities) and should be divided by 2 when migrating

## To do

This PR is Ready for Review.

- [ ] Testing needed
- [ ] Tuning/defaults feedback needed

## How to test

1. Turn on the shadows
2. Enter a game that supports shadows
3. Check the shadows both at close and long distance, when flying etc.
