### PR TITLE
Batched rendering of particles

### DIFF
--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -166,7 +166,7 @@ void Particle::render()
 {
 	video::IVideoDriver *driver = SceneManager->getVideoDriver();
 	driver->setMaterial(m_material);
-	driver->setTransform(video::ETS_WORLD, AbsoluteTransformation);
+	driver->setTransform(video::ETS_WORLD, core::matrix4());
 
 	u16 indices[] = {0,1,2, 2,3,0};
 	driver->drawVertexPrimitiveList(m_vertices, 4,
@@ -251,9 +251,6 @@ void Particle::step(float dtime)
 	// Update model
 	updateVertices();
 
-	// Update position -- see #10398
-	v3s16 camera_offset = m_env->getCameraOffset();
-	setPosition(m_pos*BS - intToFloat(camera_offset, BS));
 }
 
 void Particle::updateLight()
@@ -327,6 +324,9 @@ void Particle::updateVertices()
 	// particle position is now handled by step()
 	m_box.reset(v3f());
 
+	// Update position -- see #10398
+	v3s16 camera_offset = m_env->getCameraOffset();
+
 	for (video::S3DVertex &vertex : m_vertices) {
 		if (m_vertical) {
 			v3f ppos = m_player->getPosition()/BS;
@@ -336,6 +336,7 @@ void Particle::updateVertices()
 			vertex.Pos.rotateYZBy(m_player->getPitch());
 			vertex.Pos.rotateXZBy(m_player->getYaw());
 		}
+		vertex.Pos += m_pos * BS - intToFloat(camera_offset, BS);
 		m_box.addInternalPoint(vertex.Pos);
 	}
 }

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -591,7 +591,8 @@ void ParticleSpawner::step(float dtime, ClientEnvironment *env)
 	}
 }
 
-static const ParticleTexture default_particle_texture;
+static const ParticleTexture default_particle_texture {
+		false, ParticleParamTypes::BlendMode::alpha, { TAT_NONE, { 0, 0, 0.f } } };
 
 ParticleBuffer::ParticleBuffer(ClientEnvironment *env, const ClientTexRef &_texture)
 	: scene::ISceneNode(

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -32,6 +32,9 @@ class ClientEnvironment;
 struct MapNode;
 struct ContentFeatures;
 
+#define MAX_PARTICLES 64000
+#define PARTICLES_MAX_DISTANCE_NODES 200
+
 struct ClientTexture
 {
 	/* per-spawner structure used to store the ParticleTexture structs
@@ -90,7 +93,7 @@ public:
 	ParticleSpawner *m_parent;
 
 	const ClientTexRef &getTextureRef() const { return m_texture; }
-	void attachBuffer(ParticleBuffer *buffer);
+	bool attachToBuffer(ParticleBuffer *buffer);
 
 private:
 	void updateLight();
@@ -231,7 +234,8 @@ protected:
 		ParticleParameters &p, video::ITexture **texture, v2f &texpos,
 		v2f &texsize, video::SColor *color, u8 tilenum = 0);
 
-	void addParticle(Particle* toadd);
+	bool canAddParticle() { return m_particles.size() < MAX_PARTICLES; }
+	bool addParticle(Particle* toadd);
 
 private:
 	void addParticleSpawner(u64 id, ParticleSpawner *toadd);

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -175,7 +175,7 @@ public:
 	ParticleBuffer(ClientEnvironment *env, const ClientTexRef& texture);
 	~ParticleBuffer();
 
-	u16 allocate();
+	bool allocate(u16 &index);
 	void release(u16 index);
 
 	video::S3DVertex *getVertices(u16 index);

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -183,9 +183,9 @@ public:
 
 	video::S3DVertex *getVertices(u16 index);
 
-	virtual const core::aabbox3d<f32>& getBoundingBox() const;
+	virtual const core::aabbox3d<f32>& getBoundingBox() const override;
 	virtual void render() override;
-	virtual void OnRegisterSceneNode();
+	virtual void OnRegisterSceneNode() override;
 private:
 	ClientTexture texture;
 	scene::SMeshBuffer *buffer;

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include <iostream>
+#include <vector>
 #include "irrlichttypes_extrabloated.h"
 #include "client/tile.h"
 #include "localplayer.h"
@@ -41,7 +42,10 @@ struct ClientTexture
 	ClientTexture() = default;
 	ClientTexture(const ServerParticleTexture& p, ITextureSource *t):
 			tex(p),
-			ref(t->getTextureForMesh(p.string)) {};
+			ref(t->getTextureForMesh(p.string)) {}
+	ClientTexture(const ParticleTexture& p, video::ITexture *t):
+			tex(p),
+			ref(t) {}
 };
 
 struct ClientTexRef
@@ -61,8 +65,9 @@ struct ClientTexRef
 };
 
 class ParticleSpawner;
+class ParticleBuffer;
 
-class Particle : public scene::ISceneNode
+class Particle
 {
 public:
 	Particle(
@@ -77,24 +82,6 @@ public:
 	);
 	~Particle();
 
-	virtual const aabb3f &getBoundingBox() const
-	{
-		return m_box;
-	}
-
-	virtual u32 getMaterialCount() const
-	{
-		return 1;
-	}
-
-	virtual video::SMaterial& getMaterial(u32 i)
-	{
-		return m_material;
-	}
-
-	virtual void OnRegisterSceneNode();
-	virtual void render();
-
 	void step(float dtime);
 
 	bool get_expired ()
@@ -102,12 +89,16 @@ public:
 
 	ParticleSpawner *m_parent;
 
+	const ClientTexRef &getTextureRef() const { return m_texture; }
+	void attachBuffer(ParticleBuffer *buffer);
+
 private:
 	void updateLight();
 	void updateVertices();
 	void setVertexAlpha(float a);
 
-	video::S3DVertex m_vertices[4];
+	ParticleBuffer *buffer{nullptr};
+	u16 index;
 	float m_time = 0.0f;
 	float m_expiration;
 
@@ -116,7 +107,6 @@ private:
 	aabb3f m_box;
 	aabb3f m_collisionbox;
 	ClientTexRef m_texture;
-	video::SMaterial m_material;
 	v2f m_texpos;
 	v2f m_texsize;
 	v3f m_pos;
@@ -179,6 +169,28 @@ private:
 	u16 m_attached_id;
 };
 
+class ParticleBuffer : public scene::ISceneNode
+{
+public:
+	ParticleBuffer(ClientEnvironment *env, const ClientTexRef& texture);
+	~ParticleBuffer();
+
+	u16 allocate();
+	void release(u16 index);
+
+	video::S3DVertex *getVertices(u16 index);
+
+	virtual const core::aabbox3d<f32>& getBoundingBox() const;
+	virtual void render() override;
+	virtual void OnRegisterSceneNode();
+private:
+	ClientTexture texture;
+	scene::SMeshBuffer *buffer;
+	u16 count = 0;
+	std::vector<u16> free_list;
+	bool bounding_box_dirty = true;
+};
+
 /**
  * Class doing particle as well as their spawners handling
  */
@@ -232,6 +244,7 @@ private:
 
 	std::vector<Particle*> m_particles;
 	std::unordered_map<u64, ParticleSpawner*> m_particle_spawners;
+	std::unordered_map<video::ITexture*, ParticleBuffer*> m_particle_buffers;
 	// Start the particle spawner ids generated from here after u32_max. lower values are
 	// for server sent spawners.
 	u64 m_next_particle_spawner_id = U32_MAX + 1;

--- a/src/tileanimation.h
+++ b/src/tileanimation.h
@@ -31,7 +31,7 @@ enum TileAnimationType
 
 struct TileAnimationParams
 {
-	enum TileAnimationType type;
+	enum TileAnimationType type = TileAnimationType::TAT_NONE;
 	union
 	{
 		// struct {


### PR DESCRIPTION
Improves performance by rendering particles with the same texture as a single mesh buffer. Possibly resolves #1414 

Puts limits on how many particles can be drawn:
* 16K particles per texture.
* 64K particles in total.
* Within 200 nodes from the local player.


Example results:
AMD Renoir
34K particles on the screen
13 FPS on master
45 FPS on the branch. 

## To do

This PR is  Ready for Review.

## How to test

Minimal test:
1. Launch dev test
2. Get particle spawner
3. Spawn particles around and watch them animate and disappear. No glitches.

Example code for performance test:
```
local nodes = {}
local players = {}

local torch_colors = {
	"#0F0000",
	"#0F0800",
	"#080F00",
	"#080F00",
	"#000808"
}


minetest.register_abm({
	nodenames = { "default:torch" },
	interval = 1,
	chance = 1,
	catch_up = false,
	action = function(pos, node)
		local meta = minetest.get_meta(pos)
		local color = meta:get("colored_torch:color")
		if color == nil then
			color = torch_colors[math.floor(math.random() * #torch_colors) + 1]
			meta:set_string("colored_torch:color", color)
		end
		minetest.add_particlespawner({
			pos = { min = vector.add(pos, vector.new(-0.2, 0.35, -0.2)), max = vector.add(pos, vector.new(0.2, 0.45, 0.2)) },
			vel = { min = vector.new(-2, 7, -2), max = vector.new( 2, 5, 2) },
			acc = { min = vector.new(0, -6, 0), max = vector.new(0, -5, 0) },
			time = 1,
			amount = 160,
			exptime = 6,
			collisiondetection = false,
			collision_removal = false,
			glow = 14,
			texpool = {
				{ name = "flame_spark.png^[multiply:"..color, blend = "screen", scale = 3 },
			}
		})
	end
})
```
