### PR TITLE
Android: Add `field_enter_after_edit[]` formspec element

### DIFF
--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -833,7 +833,7 @@ function store.get_formspec(dlgdata)
 
 		"container[0.375,0.375]",
 		"field[0,0;7.225,0.8;search_string;;", core.formspec_escape(search_string), "]",
-		"field_close_on_enter[search_string;false]",
+		"field_enter_after_edit[search_string;true]",
 		"image_button[7.3,0;0.8,0.8;", core.formspec_escape(defaulttexturedir .. "search.png"), ";search;]",
 		"image_button[8.125,0;0.8,0.8;", core.formspec_escape(defaulttexturedir .. "clear.png"), ";clear;]",
 		"dropdown[9.175,0;2.7875,0.8;type;", table.concat(filter_types_titles, ","), ";", filter_type, "]",

--- a/builtin/mainmenu/settings/components.lua
+++ b/builtin/mainmenu/settings/components.lua
@@ -84,6 +84,7 @@ local function make_field(converter, validator, stringifier)
 
 				local fs = ("field[0,0.3;%f,0.8;%s;%s;%s]"):format(
 					avail_w - 1.5, setting.name, get_label(setting), core.formspec_escape(value))
+				fs = fs .. ("field_enter_after_edit[%s;true]"):format(setting.name)
 				fs = fs .. ("button[%f,0.3;1.5,0.8;%s;%s]"):format(avail_w - 1.5, "set_" .. setting.name, fgettext("Set"))
 
 				return fs, 1.1

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -477,6 +477,7 @@ local function get_formspec(dialogdata)
 
 		"field[0.25,0.25;", tostring(search_width), ",0.75;search_query;;",
 			core.formspec_escape(dialogdata.query or ""), "]",
+		"field_enter_after_edit[search_query;true]",
 		"container[", tostring(search_width + 0.25), ", 0.25]",
 			"image_button[0,0;0.75,0.75;", core.formspec_escape(defaulttexturedir .. "search.png"), ";search;]",
 			"image_button[0.75,0;0.75,0.75;", core.formspec_escape(defaulttexturedir .. "clear.png"), ";search_clear;]",

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -67,6 +67,7 @@ local function get_formspec(tabview, name, tabdata)
 	local retval =
 		-- Search
 		"field[0.25,0.25;7,0.75;te_search;;" .. core.formspec_escape(tabdata.search_for) .. "]" ..
+		"field_enter_after_edit[te_search;true]" ..
 		"container[7.25,0.25]" ..
 		"image_button[0,0;0.75,0.75;" .. core.formspec_escape(defaulttexturedir .. "search.png") .. ";btn_mp_search;]" ..
 		"image_button[0.75,0;0.75,0.75;" .. core.formspec_escape(defaulttexturedir .. "clear.png") .. ";btn_mp_clear;]" ..

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2645,7 +2645,7 @@ Version History
   * Add nine-slice images, animated_image, and fgimg_middle
 * Formspec version 7 (5.8.0):
   * style[]: Add focused state for buttons
-  * Add field_enter_after_edit[]
+  * Add field_enter_after_edit[] (experimental)
 
 Elements
 --------

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2928,6 +2928,7 @@ Elements
 
 ### `field_enter_after_edit[<name>;<enter_after_edit>]`
 
+* Experimental, may be subject to change or removal at any time.
 * Only affects Android clients.
 * `<name>` is the name of the field.
 * If `<enter_after_edit>` is true, pressing the "Done" button in the Android

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2928,7 +2928,7 @@ Elements
 * Only affects Android clients.
 * `<name>` is the name of the field.
 * If `<enter_after_edit>` is true, pressing the "Done" button in the Android
-  text editor dialog will simulate an <kbd>Enter</kbd> keypress.
+  text input dialog will simulate an <kbd>Enter</kbd> keypress.
 * Defaults to false when not specified (i.e. no tag for a field).
 
 ### `field_close_on_enter[<name>;<close_on_enter>]`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2890,7 +2890,7 @@ Elements
 ### `pwdfield[<X>,<Y>;<W>,<H>;<name>;<label>]`
 
 * Textual password style field; will be sent to server when a button is clicked
-* When enter is pressed in field, fields.key_enter_field will be sent with the
+* When enter is pressed in field, `fields.key_enter_field` will be sent with the
   name of this field.
 * With the old coordinate system, fields are a set height, but will be vertically
   centered on `H`. With the new coordinate system, `H` will modify the height.
@@ -2923,12 +2923,20 @@ Elements
 * A "Proceed" button will be added automatically
 * See `field_close_on_enter` to stop enter closing the formspec
 
+### `field_enter_after_edit[<name>;<enter_after_edit>]`
+
+* Only affects Android clients.
+* `<name>` is the name of the field.
+* If `<enter_after_edit>` is true, pressing the "Done" button in the Android
+  text editor dialog will simulate an <kbd>Enter</kbd> keypress.
+* Defaults to false when not specified (i.e. no tag for a field).
+
 ### `field_close_on_enter[<name>;<close_on_enter>]`
 
-* <name> is the name of the field
-* if <close_on_enter> is false, pressing enter in the field will submit the
-  form but not close it.
-* defaults to true when not specified (ie: no tag for a field)
+* `<name>` is the name of the field.
+* If `<close_on_enter>` is false, pressing <kbd>Enter</kbd> in the field will
+  submit the form but not close it.
+* Defaults to true when not specified (i.e. no tag for a field).
 
 ### `textarea[<X>,<Y>;<W>,<H>;<name>;<label>;<default>]`
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2643,6 +2643,9 @@ Version History
   * Added padding[] element
 * Formspec version 6 (5.6.0):
   * Add nine-slice images, animated_image, and fgimg_middle
+* Formspec version 7 (5.8.0):
+  * style[]: Add focused state for buttons
+  * Add field_enter_after_edit[]
 
 Elements
 --------

--- a/games/devtest/mods/chest_of_everything/init.lua
+++ b/games/devtest/mods/chest_of_everything/init.lua
@@ -236,6 +236,7 @@ local function get_formspec(page, name)
 	"label[9,5.1;"..F(S("Trash:")).."]" ..
 	"list[detached:chest_of_everything_trash_"..name..";main;9,5.5;1,1]" ..
 	"field[2.2,5.75;4,1;search;;"..F(search_text).."]" ..
+	"field_enter_after_edit[search;true]" ..
 	"field_close_on_enter[search;false]" ..
 	"button[6,5.45;1.6,1;search_button_start;"..F(S("Search")).."]" ..
 	"button[7.6,5.45;0.8,1;search_button_reset;"..F(S("X")).."]" ..

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1379,6 +1379,14 @@ void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element
 	}
 }
 
+void GUIFormSpecMenu::parseFieldEnterAfterEdit(parserData *data, const std::string &element)
+{
+	std::vector<std::string> parts;
+	if (!precheckElement("field_enter_after_edit", element, 2, 2, parts))
+		return;
+
+	field_enter_after_edit[parts[0]] = is_yes(parts[1]);
+}
 void GUIFormSpecMenu::parseFieldCloseOnEnter(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;
@@ -2903,6 +2911,11 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 		return;
 	}
 
+	if (type == "field_enter_after_edit") {
+		parseFieldEnterAfterEdit(data, description);
+		return;
+	}
+
 	if (type == "field_close_on_enter") {
 		parseFieldCloseOnEnter(data, description);
 		return;
@@ -3082,6 +3095,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	theme_by_name.clear();
 	theme_by_type.clear();
 	m_clickthrough_elements.clear();
+	field_enter_after_edit.clear();
 	field_close_on_enter.clear();
 	m_dropdown_index_event.clear();
 
@@ -3480,8 +3494,23 @@ bool GUIFormSpecMenu::getAndroidUIInput()
 		if (!element || element->getType() != irr::gui::EGUIET_EDIT_BOX)
 			return false;
 
+		gui::IGUIEditBox *editbox = (gui::IGUIEditBox *)element;
 		std::string text = porting::getInputDialogValue();
-		((gui::IGUIEditBox *)element)->setText(utf8_to_wide(text).c_str());
+		editbox->setText(utf8_to_wide(text).c_str());
+
+		bool enter_after_edit = false;
+		auto iter = field_enter_after_edit.find(fieldname);
+		if (iter != field_enter_after_edit.end()) {
+			enter_after_edit = iter->second;
+		}
+		if (enter_after_edit && editbox->getParent()) {
+			SEvent enter;
+			enter.EventType = EET_GUI_EVENT;
+			enter.GUIEvent.Caller = editbox;
+			enter.GUIEvent.Element = 0;
+			enter.GUIEvent.EventType = gui::EGET_EDITBOX_ENTER;
+			editbox->getParent()->OnEvent(enter);
+		}
 	}
 	return false;
 }

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3508,7 +3508,7 @@ bool GUIFormSpecMenu::getAndroidUIInput()
 			SEvent enter;
 			enter.EventType = EET_GUI_EVENT;
 			enter.GUIEvent.Caller = editbox;
-			enter.GUIEvent.Element = 0;
+			enter.GUIEvent.Element = nullptr;
 			enter.GUIEvent.EventType = gui::EGET_EDITBOX_ENTER;
 			editbox->getParent()->OnEvent(enter);
 		}

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1387,6 +1387,7 @@ void GUIFormSpecMenu::parseFieldEnterAfterEdit(parserData *data, const std::stri
 
 	field_enter_after_edit[parts[0]] = is_yes(parts[1]);
 }
+
 void GUIFormSpecMenu::parseFieldCloseOnEnter(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -331,6 +331,7 @@ protected:
 
 	std::vector<GUIInventoryList *> m_inventorylists;
 	std::vector<ListRingSpec> m_inventory_rings;
+	std::unordered_map<std::string, bool> field_enter_after_edit;
 	std::unordered_map<std::string, bool> field_close_on_enter;
 	std::unordered_map<std::string, bool> m_dropdown_index_event;
 	std::vector<FieldSpec> m_fields;
@@ -448,6 +449,7 @@ private:
 	void parseTable(parserData* data, const std::string &element);
 	void parseTextList(parserData* data, const std::string &element);
 	void parseDropDown(parserData* data, const std::string &element);
+	void parseFieldEnterAfterEdit(parserData *data, const std::string &element);
 	void parseFieldCloseOnEnter(parserData *data, const std::string &element);
 	void parsePwdField(parserData* data, const std::string &element);
 	void parseField(parserData* data, const std::string &element, const std::string &type);

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -241,7 +241,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
                             // base64-encoded SHA-1 (27+\0).
 
 // See also formspec [Version History] in doc/lua_api.md
-#define FORMSPEC_API_VERSION 6
+#define FORMSPEC_API_VERSION 7
 
 #define TEXTURENAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
 


### PR DESCRIPTION
## The problem

The other day, there was a discussion on Discord about automatically submitting formspecs when closing the Android text input dialog. Here is a small excerpt:

> **rollerozxa:** someone raised an issue to me about rollertest that some settings wouldn't save in the new dialog. in reality it's caused by the fact you can't easily set settings with an input dialog without pressing the set button on android

> **rollerozxa:** on desktop you're able to simply press enter and it will be set, so it would be neat if there could be a little hack that automatically presses enter on input boxes once submitted from the native dialog (either just in the settings dialog or everywhere)

> **grorp:** Doing this (automatically pressing enter when closing the input dialog) everywhere would cause problems in the "Join Game" tab. You'd enter your username, exit the input dialog, and then Minetest would automatically try to join the server. You wouldn't even have a chance to enter a password.

> **rollerozxa:** yeah it would need to be enabled per formspec I think

The discussion starts at https://discord.com/channels/369122544273588224/369137254641303560/1152532281408372788.

## The solution

This PR introduces a new formspec element:

```markdown
### `field_enter_after_edit[<name>;<enter_after_edit>]`

* Only affects Android clients.
* `<name>` is the name of the field.
* If `<enter_after_edit>` is true, pressing the "Done" button in the Android
  text input dialog will simulate an <kbd>Enter</kbd> keypress.
* Defaults to false when not specified (i.e. no tag for a field).
```

This also works for textareas, btw. There are already many use cases for this in `builtin` alone. I've enabled `enter_after_edit` for the following fields:

- Serverlist search
- ContentDB search
- New settings dialog search
- New settings dialog settings
- Devtest "chest of everything" / "bag of everything" search

I'm open to suggestions for better solutions to this problem.

## To do

This PR is a Ready for Review.

## How to test

Verify that pressing the "Done" button in the Android text input dialog still doesn't trigger an <kbd>Enter</kbd> keypress by default. Verify that it does trigger an <kbd>Enter</kbd> keypress in the cases mentioned above.

CC @rollerozxa
