### PR TITLE
Remove unused "mNormal" uniform to fix crash on GLES2 with shaders

### DIFF
--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -233,8 +233,6 @@ class MainShaderConstantSetter : public IShaderConstantSetter
 	CachedVertexShaderSetting<float, 16> m_world_view;
 	// Texture matrix
 	CachedVertexShaderSetting<float, 16> m_texture;
-	// Normal matrix
-	CachedVertexShaderSetting<float, 9> m_normal;
 
 public:
 	MainShaderConstantSetter() :
@@ -256,7 +254,6 @@ public:
 		, m_perspective_zbias_pixel("zPerspectiveBias")
 		, m_world_view("mWorldView")
 		, m_texture("mTexture")
-		, m_normal("mNormal")
 	{}
 	~MainShaderConstantSetter() = default;
 
@@ -283,16 +280,6 @@ public:
 			core::matrix4 texture = driver->getTransform(video::ETS_TEXTURE_0);
 			m_world_view.set(*reinterpret_cast<float(*)[16]>(worldView.pointer()), services);
 			m_texture.set(*reinterpret_cast<float(*)[16]>(texture.pointer()), services);
-
-			core::matrix4 normal;
-			worldView.getTransposed(normal);
-			sanity_check(normal.makeInverse());
-			float m[9] = {
-				normal[0], normal[1], normal[2],
-				normal[4], normal[5], normal[6],
-				normal[8], normal[9], normal[10],
-			};
-			m_normal.set(m, services);
 		}
 
 		// Set uniforms for Shadow shader
@@ -639,7 +626,6 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 			uniform highp mat4 mWorldView;
 			uniform highp mat4 mWorldViewProj;
 			uniform mediump mat4 mTexture;
-			uniform mediump mat3 mNormal;
 
 			attribute highp vec4 inVertexPosition;
 			attribute lowp vec4 inVertexColor;
@@ -662,7 +648,6 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 			#define mWorldView gl_ModelViewMatrix
 			#define mWorldViewProj gl_ModelViewProjectionMatrix
 			#define mTexture (gl_TextureMatrix[0])
-			#define mNormal gl_NormalMatrix
 
 			#define inVertexPosition gl_Vertex
 			#define inVertexColor gl_Color


### PR DESCRIPTION
Fixes #13841.

Clients with `video_driver = ogles2` and `enable_shaders = true` (the defaults on Android) sometimes crash with the following error:

```
ERROR[Main]: /mt/src/client/shader.cpp:121: virtual void MainShaderConstantSetter::onSetConstants(video::IMaterialRendererServices *): An engine assumption 'normal.makeInverse()' failed.
```

I have no minimal reproducible example for triggering the crash, but you can trigger it by playing the "Murder" minigame as seen on the "[Minigames] A.E.S." server.

The crash occurs in the code that is responsible for calculating the value of the `mNormal` shader uniform on GLES2. I have no idea what's going on there, maybe the math is wrong, but: The uniform is unused, and it looks like it has been unused since its introduction in #10506.

Since `mNormal` is unused, I simply removed it. That fixes the crash.

## To do

This PR is a Ready for Review.

## How to test

1. Compile Minetest with `ENABLE_GLES2=TRUE` and put `video_driver = ogles2` and `enable_shaders = true` into your `minetest.conf`.
   
   OR
   
   Use an Android build.

2. Join the "[Minigames] A.E.S." server on the public serverlist with three clients and play the "Murder" minigame.

3. Verify that none of your clients crash during the game.