### PR TITLE
doc: fix improper code blocks parsing for lua_api_deploy by using pymdown-extensions

### DIFF
--- a/doc/mkdocs/build.sh
+++ b/doc/mkdocs/build.sh
@@ -14,7 +14,9 @@ extra_css:
 markdown_extensions:
     - toc:
         permalink: True
-    - codehilite
+    - pymdownx.superfences
+    - pymdownx.highlight:
+        css_class: codehilite
 plugins:
     - search:
         separator: '[\s\-\.\(]+'

--- a/doc/mkdocs/requirements.txt
+++ b/doc/mkdocs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs~=1.4.3
 pygments~=2.15.1
+pymdown-extensions~=10.3


### PR DESCRIPTION
This PR replaces the default fenced code blocks extension with a workaround extension, [pymdown-extension's superfences](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/). As I don't have experience with deploying on github pages, i was only able to verify this locally and see that the codeblock for `minetest.features` is rendered as expected.

### Notes

Minetest uses [mkdocs](https://www.mkdocs.org/) to build documentation, which in turn uses [python-markdown](https://python-markdown.github.io/) which then notes:

> This is not a CommonMark implementation; nor is it trying to be! Python-Markdown was developed long before the CommonMark specification was released and has always (mostly) followed the [syntax rules](https://daringfireball.net/projects/markdown/syntax) and behavior of the original reference implementation. No accommodations have been made to address the changes which CommonMark has suggested. It is recommended that you look elsewhere if you want an implementation which follows the CommonMark specification.

With this in mind, the project does not implement fenced code blocks like \`\`\`lua .. \`\`\` used currently in `doc/`. This feature is brought in by mkdocs using [fenced_code_blocks](https://python-markdown.github.io/extensions/fenced_code_blocks/) extension which doesn't support nesting it inside container blocks (i.e. lists) or even having any indentation to the whole block. furthermore, changes to `doc/` from someone expecting a full [commonmark implementation](https://spec.commonmark.org/current/) may result in improper formatting.