### PR TITLE
Notify users that they need to reinstall MTG if they still want it

### DIFF
--- a/builtin/fstk/dialog.lua
+++ b/builtin/fstk/dialog.lua
@@ -38,8 +38,18 @@ local dialog_metatable = {
 	handle_events  = function(self,event)
 				if not self.hidden then return self.eventhandler(self,event) end
 			end,
-	hide = function(self) self.hidden = true end,
-	show = function(self) self.hidden = false end,
+	hide = function(self)
+		if not self.hidden then
+			self.hidden = true
+			self.eventhandler(self, "DialogHide")
+		end
+	end,
+	show = function(self)
+		if self.hidden then
+			self.hidden = false
+			self.eventhandler(self, "DialogShow")
+		end
+	end,
 	delete = function(self)
 			if self.parent ~= nil then
 				self.parent:show()

--- a/builtin/mainmenu/dlg_reinstall_mtg.lua
+++ b/builtin/mainmenu/dlg_reinstall_mtg.lua
@@ -41,6 +41,8 @@ function check_reinstall_mtg()
 		return
 	end
 
+	mm_game_theme.reset()
+
 	local maintab = ui.find_by_name("maintab")
 
 	local dlg = create_reinstall_mtg_dlg()

--- a/builtin/mainmenu/dlg_reinstall_mtg.lua
+++ b/builtin/mainmenu/dlg_reinstall_mtg.lua
@@ -57,7 +57,7 @@ local function get_formspec(dialogdata)
 		"<big>", fgettext("Minetest Game is no longer installed by default"), "</big>\n",
 		fgettext("For a long time, the Minetest engine shipped with a default game called \"Minetest Game\". " ..
 				"Since Minetest 5.8.0, Minetest ships without a default game."), "\n",
-		fgettext("If you want to continue playing your Minetest Game worlds, you need to reinstall Minetest Game."),
+		fgettext("If you want to continue playing in your Minetest Game worlds, you need to reinstall Minetest Game."),
 	})
 
 	return table.concat({

--- a/builtin/mainmenu/dlg_reinstall_mtg.lua
+++ b/builtin/mainmenu/dlg_reinstall_mtg.lua
@@ -1,0 +1,112 @@
+--Minetest
+--Copyright (C) 2023 Gregor Parzefall
+--
+--This program is free software; you can redistribute it and/or modify
+--it under the terms of the GNU Lesser General Public License as published by
+--the Free Software Foundation; either version 2.1 of the License, or
+--(at your option) any later version.
+--
+--This program is distributed in the hope that it will be useful,
+--but WITHOUT ANY WARRANTY; without even the implied warranty of
+--MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--GNU Lesser General Public License for more details.
+--
+--You should have received a copy of the GNU Lesser General Public License along
+--with this program; if not, write to the Free Software Foundation, Inc.,
+--51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+function check_reinstall_mtg()
+	if core.settings:get_bool("no_mtg_notification") then
+		return
+	end
+
+	local games = core.get_games()
+	for _, game in ipairs(games) do
+		if game.id == "minetest" then
+			core.settings:set_bool("no_mtg_notification", true)
+			return
+		end
+	end
+
+	local mtg_world_found = false
+	local worlds = core.get_worlds()
+	for _, world in ipairs(worlds) do
+		if world.gameid == "minetest" then
+			mtg_world_found = true
+			break
+		end
+	end
+	if not mtg_world_found then
+		core.settings:set_bool("no_mtg_notification", true)
+		return
+	end
+
+	local maintab = ui.find_by_name("maintab")
+
+	local dlg = create_reinstall_mtg_dlg()
+	dlg:set_parent(maintab)
+	maintab:hide()
+	dlg:show()
+	ui.update()
+end
+
+local function get_formspec(dialogdata)
+	local markup = table.concat({
+		"<big>", fgettext("Minetest Game is no longer installed by default"), "</big>\n",
+		fgettext("For a long time, the Minetest engine shipped with a default game called \"Minetest Game\". " ..
+				"Since Minetest 5.8.0, Minetest ships without a default game."), "\n",
+		fgettext("If you want to continue playing your Minetest Game worlds, you need to reinstall Minetest Game."),
+	})
+
+	return table.concat({
+		"formspec_version[6]",
+		"size[12.8,7]",
+		"hypertext[0.375,0.375;12.05,5.2;text;", minetest.formspec_escape(markup), "]",
+		"container[0.375,5.825]",
+		"style[dismiss;bgcolor=red]",
+		"button[0,0;4,0.8;dismiss;", fgettext("Dismiss"), "]",
+		"button[4.25,0;8,0.8;reinstall;", fgettext("Reinstall Minetest Game"), "]",
+		"container_end[]",
+	})
+end
+
+local function buttonhandler(this, fields)
+	if fields.reinstall then
+		-- Don't set "no_mtg_notification" here so that the dialog will be shown
+		-- again if downloading MTG fails for whatever reason.
+		this:delete()
+
+		local maintab = ui.find_by_name("maintab")
+
+		local dlg = create_store_dlg(nil, { author = "Minetest", name = "minetest_game" })
+		dlg:set_parent(maintab)
+		maintab:hide()
+		dlg:show()
+
+		return true
+	end
+
+	if fields.dismiss then
+		core.settings:set_bool("no_mtg_notification", true)
+		this:delete()
+		return true
+	end
+end
+
+local function eventhandler(event)
+	if event == "MenuQuit" then
+		-- Don't allow closing the dialog with ESC, but still allow exiting
+		-- Minetest.
+		core.close()
+		return true
+	end
+	return false
+end
+
+function create_reinstall_mtg_dlg()
+	local dlg = dialog_create("dlg_reinstall_mtg", get_formspec,
+			buttonhandler, eventhandler)
+	return dlg
+end
+
+

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -50,6 +50,7 @@ dofile(menupath .. DIR_DELIM .. "dlg_delete_world.lua")
 dofile(menupath .. DIR_DELIM .. "dlg_register.lua")
 dofile(menupath .. DIR_DELIM .. "dlg_rename_modpack.lua")
 dofile(menupath .. DIR_DELIM .. "dlg_version_info.lua")
+dofile(menupath .. DIR_DELIM .. "dlg_reinstall_mtg.lua")
 
 local tabs = {
 	content  = dofile(menupath .. DIR_DELIM .. "tab_content.lua"),
@@ -121,9 +122,11 @@ local function init_globals()
 	})
 
 	ui.set_default("maintab")
-	check_new_version()
 	tv_main:show()
 	ui.update()
+
+	check_reinstall_mtg()
+	check_new_version()
 end
 
 init_globals()

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2248,6 +2248,10 @@ update_last_checked (Last update check) string
 #    Ex: 5.5.0 is 005005000
 update_last_known (Last known version update) int 0
 
+#    If this is set to true, the user will never (again) be shown the
+#    "reinstall Minetest Game" notification.
+no_mtg_notification (Don't show "reinstall Minetest Game" notification) bool false
+
 #    Key for moving the player forward.
 keymap_forward (Forward key) key KEY_KEY_W
 


### PR DESCRIPTION
Fixes #13800, prerequisite for #13818.

This PR adds a notification that is shown if someone upgrades from a previous version and has MTG worlds. Here is a video of it in action:

https://github.com/minetest/minetest/assets/82708541/80ef2f01-8f34-43bb-a7f4-eb71095b4ce5

The implementation is similar to rollerozxa's suggestion in https://github.com/minetest/minetest/issues/13550#issuecomment-1634180063, but there are a few differences (look at the diff and/or the video).

## To do

This PR is a Ready for Review.

## How to test

Verify that you are shown the "reinstall MTG" dialog if you test this PR for the first time and have MTG worlds, but no MTG.

Verify that you are never shown the dialog if you didn't meet the conditions the first time you started Minetest with this PR. 

Verify that you don't see the dialog a second time if you have dismissed it or if you have successfully reinstalled MTG.

Verify that you see the dialog a second time if reinstalling MTG has failed.

Verify that the ContentDB dialog still works as usual.