### PR TITLE
Update range values of meta set functions in the documentation

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7277,8 +7277,12 @@ of the `${k}` syntax in formspecs is not deprecated.
 * `set_string(key, value)`: Value of `""` will delete the key.
 * `get_string(key)`: Returns `""` if key not present.
 * `set_int(key, value)`
+    * The range for the value is system-dependent (usually 32 bits).
+      The value will be converted into a string when stored.
 * `get_int(key)`: Returns `0` if key not present.
 * `set_float(key, value)`
+    * The range for the value is system-dependent (usually 32 bits).
+      The value will be converted into a string when stored.
 * `get_float(key)`: Returns `0` if key not present.
 * `get_keys()`: returns a list of all keys in the metadata.
 * `to_table()`:


### PR DESCRIPTION
Closes https://github.com/minetest/minetest/issues/13531

This PR updates the documentation of the `MetaDataRef` and reinforces the behaviour of the methods `set_int` and `set_float` since the range values for both methods are implicit and system-dependent.

Also, clarify that the values are converted to strings.