### PR TITLE
Make hypertext[] respect font size settings

### DIFF
--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -63,9 +63,15 @@ void ParsedText::Element::setStyle(StyleList &style)
 		this->hovercolor = color;
 
 	unsigned int font_size = std::atoi(style["fontsize"].c_str());
+
 	FontMode font_mode = FM_Standard;
 	if (style["fontstyle"] == "mono")
 		font_mode = FM_Mono;
+
+	// hypertext[] only accepts absolute font size values and has a hardcoded
+	// default font size of 16. This is the only way to make hypertext[]
+	// respect font size settings that I can think of.
+	font_size = myround(font_size / 16.0f * g_fontengine->getFontSize(font_mode));
 
 	FontSpec spec(font_size, font_mode,
 		is_yes(style["bold"]), is_yes(style["italic"]));


### PR DESCRIPTION
While testing #13850 on Android, I noticed that the text rendered by `hypertext[]` was larger than other text. `hypertext[]` has a hardcoded default font size of 16 and doesn't respect `font_size` and `mono_font_size`, which are set to 14 on Android by default.

Since modders can specify absolute font size values for `hypertext[]`, just using the mentioned settings as default values instead isn't enough. What this PR does is this:

```cpp
font_size = myround(font_size / 16.0f * g_fontengine->getFontSize(font_mode)); 
```

## To do

This PR is a Ready for Review.

## How to test

Set `font_size` to 10, set `mono_font_size` to 30. Execute `/test_formspec` in a Devtest world, go to the "Hypertext" tab and see that your font size settings are applied.