### PR TITLE
Add advanced settings checkbox and hide advanced settings by default

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -347,7 +347,9 @@ end
 
 
 function page_has_contents(page, actual_content)
-	local is_advanced = page.id:sub(1, #"mapgen") == "mapgen" or
+	local is_advanced =
+			page.id:sub(1, #"client_and_server") == "client_and_server" or
+			page.id:sub(1, #"mapgen") == "mapgen" or
 			page.id:sub(1, #"advanced") == "advanced"
 	local show_advanced = core.settings:get_bool("show_advanced")
 	if is_advanced and not show_advanced then

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -290,7 +290,7 @@ local function update_filtered_pages(query)
 
 	for _, page in ipairs(all_pages) do
 		local content, page_weight = filter_page_content(page, query_keywords)
-		if page_has_contents(content) then
+		if page_has_contents(page, content) then
 			local new_page = table.copy(page)
 			new_page.content = content
 
@@ -346,8 +346,15 @@ local function check_requirements(name, requires)
 end
 
 
-function page_has_contents(content)
-	for _, item in ipairs(content) do
+function page_has_contents(page, actual_content)
+	local is_advanced = page.id:sub(1, #"mapgen") == "mapgen" or
+			page.id:sub(1, #"advanced") == "advanced"
+	local show_advanced = core.settings:get_bool("show_advanced")
+	if is_advanced and not show_advanced then
+		return false
+	end
+
+	for _, item in ipairs(actual_content) do
 		if item == false or item.heading then --luacheck: ignore
 			-- skip
 		elseif type(item) == "string" then
@@ -437,7 +444,7 @@ local formspec_show_hack = false
 
 
 local function get_formspec(dialogdata)
-	local page_id = dialogdata.page_id or "most_used"
+	local page_id = dialogdata.page_id or "accessibility"
 	local page = filtered_page_by_id[page_id]
 
 	local extra_h = 1 -- not included in tabsize.height
@@ -451,8 +458,10 @@ local function get_formspec(dialogdata)
 	local left_pane_width = TOUCHSCREEN_GUI and 4.5 or 4.25
 	local search_width = left_pane_width + scrollbar_w - (0.75 * 2)
 
-	local technical_names_w = TOUCHSCREEN_GUI and 6 or 5
+	local back_w = 3
+	local checkbox_w = (tabsize.width - back_w - 2*0.2) / 2
 	local show_technical_names = core.settings:get_bool("show_technical_names")
+	local show_advanced = core.settings:get_bool("show_advanced")
 
 	formspec_show_hack = not formspec_show_hack
 
@@ -467,13 +476,20 @@ local function get_formspec(dialogdata)
 
 		"box[0,0;", tostring(tabsize.width), ",", tostring(tabsize.height), ";#0000008C]",
 
-		"button[0,", tostring(tabsize.height + 0.2), ";3,0.8;back;", fgettext("Back"), "]",
+		("button[0,%f;%f,0.8;back;%s]"):format(
+				tabsize.height + 0.2, back_w, fgettext("Back")),
 
 		("box[%f,%f;%f,0.8;#0000008C]"):format(
-			tabsize.width - technical_names_w, tabsize.height + 0.2, technical_names_w),
+			back_w + 0.2, tabsize.height + 0.2, checkbox_w),
 		("checkbox[%f,%f;show_technical_names;%s;%s]"):format(
-			tabsize.width - technical_names_w + 0.25, tabsize.height + 0.6,
+			back_w + 2*0.2, tabsize.height + 0.6,
 			fgettext("Show technical names"), tostring(show_technical_names)),
+
+		("box[%f,%f;%f,0.8;#0000008C]"):format(
+			back_w + 2*0.2 + checkbox_w, tabsize.height + 0.2, checkbox_w),
+		("checkbox[%f,%f;show_advanced;%s;%s]"):format(
+			back_w + 3*0.2 + checkbox_w, tabsize.height + 0.6,
+			fgettext("Show advanced settings"), tostring(show_advanced)),
 
 		"field[0.25,0.25;", tostring(search_width), ",0.75;search_query;;",
 			core.formspec_escape(dialogdata.query or ""), "]",
@@ -606,6 +622,23 @@ local function buttonhandler(this, fields)
 	if fields.show_technical_names ~= nil then
 		local value = core.is_yes(fields.show_technical_names)
 		core.settings:set_bool("show_technical_names", value)
+		return true
+	end
+
+	if fields.show_advanced ~= nil then
+		local value = core.is_yes(fields.show_advanced)
+		core.settings:set_bool("show_advanced", value)
+
+		local suggested_page_id = update_filtered_pages(dialogdata.query)
+
+		if not filtered_page_by_id[dialogdata.page_id] then
+			dialogdata.components = nil
+			dialogdata.leftscroll = 0
+			dialogdata.rightscroll = 0
+
+			dialogdata.page_id = suggested_page_id
+		end
+
 		return true
 	end
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2226,11 +2226,13 @@ continuous_forward (Continuous forward) bool false
 #    Useful for recording videos
 cinematic (Cinematic mode) bool false
 
-#    Whether to show technical names.
 #    Affects mods and texture packs in the Content and Select Mods menus, as well as
-#    setting names in All Settings.
-#    Controlled by the checkbox in the "All settings" menu.
+#    setting names.
+#    Controlled by a checkbox in the settings menu.
 show_technical_names (Show technical names) bool false
+
+#    Controlled by a checkbox in the settings menu.
+show_advanced (Show advanced settings) bool false
 
 #    Enables the sound system.
 #    If disabled, this completely disables all sounds everywhere and the in-game


### PR DESCRIPTION
Based on #13730, this PR adds a "Show advanced settings" checkbox to the new settings GUI. As discussed, the checkbox determines whether the "Advanced" and "Mapgen" toplevel categories are shown and is unchecked by default.

![screenshot](https://github.com/minetest/minetest/assets/82708541/5d003888-8abc-4605-be01-b74b0af8890e)

This is part of #13476 "Before 5.8.0". The creation of this PR was discussed on IRC: https://irc.minetest.net/minetest-dev/2023-10-01#i_6118939.

## To do

This PR is a Ready for Review.

## How to test

Open the settings and toggle the "Show advanced settings" checkbox. Verify that it changes the visibility of the "Advanced" and "Mapgen" toplevel categories, and nothing else.

Verify that you don't stay on an advanced settings page if you uncheck the checkbox while you are on an advanced settings page.

Verify that toggling the checkbox doesn't reset the current page and scroll position in other cases.