### PR TITLE
Resolves some warnings for Android version

### DIFF
--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -169,7 +169,6 @@ private:
 	LocalPlayer *m_player;
 	ParticleSpawnerParameters p;
 	std::vector<ClientParticleTexture> m_texpool;
-	size_t m_texcount;
 	std::vector<float> m_spawntimes;
 	u16 m_attached_id;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -550,6 +550,7 @@ static bool create_userdata_path()
 }
 
 namespace {
+#if !defined(__ANDROID__)
 	std::string findProgram(const char *name)
 	{
 		char *path_c = getenv("PATH");
@@ -567,12 +568,14 @@ namespace {
 		}
 		return "";
 	}
+#endif
 
 #ifdef _WIN32
 	const char *debuggerNames[] = {"gdb.exe", "lldb.exe"};
-#else
+#elif !defined(__ANDROID__)
 	const char *debuggerNames[] = {"gdb", "lldb"};
 #endif
+
 	template <class T>
 	void getDebuggerArgs(T &out, int i) {
 		if (i == 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -567,6 +567,12 @@ namespace {
 		return "";
 	}
 
+#ifdef _WIN32
+	const char *debuggerNames[] = {"gdb.exe", "lldb.exe"};
+#else
+	[[maybe_unused]] const char *debuggerNames[] = {"gdb", "lldb"};
+#endif
+
 	template <class T>
 	void getDebuggerArgs(T &out, int i) {
 		if (i == 0) {
@@ -590,10 +596,6 @@ static bool use_debugger(int argc, char *argv[])
 		warningstream << "Process is already being debugged." << std::endl;
 		return false;
 	}
-
-	const char *debuggerNames[] = {"gdb.exe", "lldb.exe"};
-#else
-	const char *debuggerNames[] = {"gdb", "lldb"};
 #endif
 
 	char exec_path[1024];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -550,6 +550,23 @@ static bool create_userdata_path()
 }
 
 namespace {
+	[[maybe_unused]] std::string findProgram(const char *name) {
+		char *path_c = getenv("PATH");
+		if (!path_c)
+			return "";
+		std::istringstream iss(path_c);
+		std::string checkpath;
+		while (!iss.eof()) {
+			std::getline(iss, checkpath, PATH_DELIM[0]);
+			if (!checkpath.empty() && checkpath.back() != DIR_DELIM_CHAR)
+				checkpath.push_back(DIR_DELIM_CHAR);
+			checkpath.append(name);
+			if (fs::IsExecutable(checkpath))
+				return checkpath;
+		}
+		return "";
+	}
+
 	template <class T>
 	void getDebuggerArgs(T &out, int i) {
 		if (i == 0) {
@@ -578,23 +595,6 @@ static bool use_debugger(int argc, char *argv[])
 #else
 	const char *debuggerNames[] = {"gdb", "lldb"};
 #endif
-
-	const auto findProgram = [](const char *name) -> std::string {
-		char *path_c = getenv("PATH");
-		if (!path_c)
-			return "";
-		std::istringstream iss(path_c);
-		std::string checkpath;
-		while (!iss.eof()) {
-			std::getline(iss, checkpath, PATH_DELIM[0]);
-			if (!checkpath.empty() && checkpath.back() != DIR_DELIM_CHAR)
-				checkpath.push_back(DIR_DELIM_CHAR);
-			checkpath.append(name);
-			if (fs::IsExecutable(checkpath))
-				return checkpath;
-		}
-		return "";
-	};
 
 	char exec_path[1024];
 	if (!porting::getCurrentExecPath(exec_path, sizeof(exec_path)))


### PR DESCRIPTION
**Goal of the PR**
This PR tries to resolve some warnings.

**How does the PR work?**
- This PR moves `debuggerNames` to be inside of `use_debugger()` function.
- This PR adds `[[maybe_unused]]` to `findProgram()` function.
- ~This PR moves `findProgram()` and `debuggerNames` to be inside of `use_debugger()` function.~
- ~This PR adds preprocessor statements to hide `findProgram()` and `debuggerNames` when building for Android.~

**Does it resolve any reported issue?**
![MT compiler warning](https://cdn.discordapp.com/attachments/369137254641303560/1150113400563703888/MT-compiler-warning.png)

**Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?**
Yes, I guess.

## To do

This PR is a Ready for Review.

## How to test

1. Compile it for Android.
2. Those two warnings should be gone.
3. The compiled build can run normally.
4. Compile it for other OS.
5. The compiled build can run normally.