### PR TITLE
Implement adjustable sound quality with adjustable sound source limits

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -629,6 +629,16 @@ sound_volume (Volume) float 0.8 0.0 1.0
 #    pause menu.
 mute_sound (Mute sound) bool false
 
+#    Number of mono (3D) sound sources to request from the audio driver. 
+#    Set to -1 to use system default.
+#    A restart is required after changing this.
+sound_sources_mono (Mono/3D sound sources) int -1 -1 256
+
+#    Number of stereo sound sources to request from the audio driver. 
+#    Set to -1 to use system default.
+#    A restart is required after changing this.
+sound_sources_stereo (Stereo sound sources) int -1 -1 256
+
 [*User Interfaces]
 
 #    Set the language. Leave empty to use the system language.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -41,6 +41,8 @@ void set_default_settings()
 	settings->setDefault("enable_sound", "true");
 	settings->setDefault("sound_volume", "0.8");
 	settings->setDefault("mute_sound", "false");
+	settings->setDefault("sound_sources_mono", "-1");
+	settings->setDefault("sound_sources_stereo", "-1");
 	settings->setDefault("enable_mesh_cache", "false");
 	settings->setDefault("mesh_generation_interval", "0");
 	settings->setDefault("mesh_generation_threads", "0");


### PR DESCRIPTION
Reimplementation of pull request #13842. I couldn't figure out how to get git to accept my change and throw away my previous work while conflicting with renamed files, so I just made this new pull request.

I noticed a lot of warnings in the sound code, saying createPlayingSound had out of memory. I have a lot of memory and quickly found that it was the error code for hitting the limit on sound sources. I figured out how to add the setting and updated the sound initialization code. Surprisingly, nobody reported a bug for flooding warnings from createPlayingSound saying out of memory.

It fixes a flood of sound warnings when you are near a farm that is making a lot of sounds. There are no warnings with it set to 1024 for my farm. A much lower sound would work too. I checked `perf top`, and I can't even see sound related code in the profile.

If 128 sounds is an acceptable default number of sound sources, you can consider this ready to go. If you would prefer it preserve the previous behaviour as much as possible, I can make the setting "0" mean "default", and have it use a nullptr attribute list parameter, and only use the attribute list if the setting was not zero.

## How to test
I added a setting in the Audio page.
