### PR TITLE
Prevent early respawns caused by up/down button in the death screen

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -177,7 +177,14 @@ struct LocalFormspecHandler : public TextDest
 		}
 
 		if (m_formname == "MT_DEATH_SCREEN") {
-			assert(m_client != 0);
+			// This is needed because key_up and key_down are pending formspec
+			// key events (see GUIFormSpecMenu::fs_key_pending) so those events
+			// will enter this part of code. See issue #13863.
+			if (fields.find("key_up") != fields.end() ||
+					fields.find("key_down") != fields.end())
+				return;
+
+			assert(m_client != nullptr);
 			m_client->sendRespawn();
 			return;
 		}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -177,15 +177,11 @@ struct LocalFormspecHandler : public TextDest
 		}
 
 		if (m_formname == "MT_DEATH_SCREEN") {
-			// This is needed because key_up and key_down are pending formspec
-			// key events (see GUIFormSpecMenu::fs_key_pending) so those events
-			// will enter this part of code. See issue #13863.
-			if (fields.find("key_up") != fields.end() ||
-					fields.find("key_down") != fields.end())
-				return;
-
 			assert(m_client != nullptr);
-			m_client->sendRespawn();
+
+			if (fields.find("quit") != fields.end())
+				m_client->sendRespawn();
+
 			return;
 		}
 


### PR DESCRIPTION
**Goal of the PR**
This PR tries to prevent early respawns caused by up/down button.

**How does the PR work?**
This PR prevents `key_up` and `key_down` events from respawning the player in the death screen.

**Does it resolve any reported issue?**
Yes, this PR tries to fix #13863.

**Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?**
The reported issue is in the 5.8.0 milestone.

## To do

This PR is Ready for Review.

## How to test

1. Make the player's character die inside a Minetest world.
2. Press <kbd>↑</kbd>/<kbd>↓</kbd> (up/down button) when the "You died" dialog (death screen) is being shown.
3. Nothing should occur.
