### PR TITLE
build: Allow disabling documentation build + print more build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(BUILD_CLIENT TRUE CACHE BOOL "Build client")
 set(BUILD_SERVER FALSE CACHE BOOL "Build server")
 set(BUILD_UNITTESTS TRUE CACHE BOOL "Build unittests")
 set(BUILD_BENCHMARKS FALSE CACHE BOOL "Build benchmarks")
+set(BUILD_DOCUMENTATION TRUE CACHE BOOL "Build documentation")
 
 set(WARN_ALL TRUE CACHE BOOL "Enable -Wall for Release build")
 
@@ -394,13 +395,15 @@ include(CPack)
 
 
 # Add a target to generate API documentation with Doxygen
-find_package(Doxygen)
-if(DOXYGEN_FOUND)
-	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc/Doxyfile.in
-			${CMAKE_CURRENT_BINARY_DIR}/doc/Doxyfile @ONLY)
-	add_custom_target(doc
-		${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/doc/Doxyfile
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc
-		COMMENT "Generating API documentation with Doxygen" VERBATIM
-	)
+if(BUILD_DOCUMENTATION)
+	find_package(Doxygen)
+	if(DOXYGEN_FOUND)
+		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc/Doxyfile.in
+				${CMAKE_CURRENT_BINARY_DIR}/doc/Doxyfile @ONLY)
+		add_custom_target(doc
+			${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/doc/Doxyfile
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc
+			COMMENT "Generating API documentation with Doxygen" VERBATIM
+		)
+	endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,13 @@ if (CMAKE_BUILD_TYPE STREQUAL Debug)
 	set(VERSION_STRING "${VERSION_STRING}-debug")
 endif()
 
-message(STATUS "*** Will build version ${VERSION_STRING} ***")
-
-
 # Configuration options
+set(BUILD_CLIENT TRUE CACHE BOOL "Build client")
+set(BUILD_SERVER FALSE CACHE BOOL "Build server")
+set(BUILD_UNITTESTS TRUE CACHE BOOL "Build unittests")
+set(BUILD_BENCHMARKS FALSE CACHE BOOL "Build benchmarks")
+set(BUILD_DOCUMENTATION TRUE CACHE BOOL "Build documentation")
+
 set(DEFAULT_RUN_IN_PLACE FALSE)
 if(WIN32)
 	set(DEFAULT_RUN_IN_PLACE TRUE)
@@ -48,12 +51,13 @@ endif()
 set(RUN_IN_PLACE ${DEFAULT_RUN_IN_PLACE} CACHE BOOL
 	"Run directly in source directory structure")
 
-
-set(BUILD_CLIENT TRUE CACHE BOOL "Build client")
-set(BUILD_SERVER FALSE CACHE BOOL "Build server")
-set(BUILD_UNITTESTS TRUE CACHE BOOL "Build unittests")
-set(BUILD_BENCHMARKS FALSE CACHE BOOL "Build benchmarks")
-set(BUILD_DOCUMENTATION TRUE CACHE BOOL "Build documentation")
+message(STATUS "*** Will build version ${VERSION_STRING} ***")
+message(STATUS "BUILD_CLIENT: " ${BUILD_CLIENT})
+message(STATUS "BUILD_SERVER: " ${BUILD_SERVER})
+message(STATUS "BUILD_UNITTESTS: " ${BUILD_UNITTESTS})
+message(STATUS "BUILD_BENCHMARKS: " ${BUILD_BENCHMARKS})
+message(STATUS "BUILD_DOCUMENTATION: " ${BUILD_DOCUMENTATION})
+message(STATUS "RUN_IN_PLACE: " ${RUN_IN_PLACE})
 
 set(WARN_ALL TRUE CACHE BOOL "Enable -Wall for Release build")
 

--- a/doc/compiling/README.md
+++ b/doc/compiling/README.md
@@ -13,6 +13,7 @@ General options and their default values:
     BUILD_SERVER=FALSE         - Build Minetest server
     BUILD_UNITTESTS=TRUE       - Build unittest sources
     BUILD_BENCHMARKS=FALSE     - Build benchmark sources
+    BUILD_DOCUMENTATION=TRUE   - Build doxygen documentation
     CMAKE_BUILD_TYPE=Release   - Type of build (Release vs. Debug)
         Release                - Release build
         Debug                  - Debug build


### PR DESCRIPTION
I currently had a doxygen setup issue on my side, for unknown reason anyway.

It triggers issue on my side like this

```
minetest-stock/cmake-build-release on  master [$!] via △ v3.27.7 took 50s 
❯ cmake .. -D RUN_IN_PLACE=1
-- *** Will build version 5.8.0-dev ***
-- Using user-provided IrrlichtMt at subdirectory 'lib/irrlichtmt'
-- *** Building IrrlichtMt 1.9.0.12 ***
-- Performing Test REVISION_SANITY_CHECK
-- Performing Test REVISION_SANITY_CHECK - Success
-- Device: X11
-- OpenGL: ON
-- OpenGL 3: FALSE
-- OpenGL ES: OFF
-- OpenGL ES 2: OFF
-- WebGL: OFF
-- Found IrrlichtMt 1.9.0.12
-- Using GMP provided by system.
-- Using bundled JsonCpp library.
-- LuaJIT detection disabled! (ENABLE_LUAJIT=0)
-- LuaJIT not found, using bundled Lua.
-- cURL support enabled.
-- GetText enabled; locales found: ar;be;bg;ca;cs;cy;da;de;dv;el;eo;es;et;eu;fi;fil;fr;gd;gl;he;hi;hu;id;it;ja;jbo;kk;kn;ko;ky;lt;lv;lzh;mn;mr;ms;ms_Arab;nb;nl;nn;oc;pl;pt;pt_BR;ro;ru;sk;sl;sr_Cyrl;sr_Latn;sv;sw;th;tr;tt;uk;vi;yue;zh_CN;zh_TW
-- Sound enabled.
-- ncurses console enabled.
-- PostgreSQL backend enabled
-- PostgreSQL includes: /usr/include;/usr/include/postgresql/server
-- LevelDB not found!
-- Redis backend enabled.
-- Prometheus client disabled.
-- SpatialIndex AreaStore backend enabled.
-- Looking for ZSTD_initCStream
-- Looking for ZSTD_initCStream - found
-- Locale blacklist applied; Locales used: be;bg;ca;cs;cy;da;de;el;eo;es;et;eu;fi;fil;fr;gd;gl;hu;id;it;ja;jbo;kk;ko;ky;lt;lv;lzh;mn;mr;ms;nb;nl;nn;oc;pl;pt;pt_BR;ro;ru;sk;sl;sr_Cyrl;sr_Latn;sv;sw;tr;tt;uk;vi;yue;zh_CN;zh_TW
-- Performing Test HAVE_ATCCALL
-- Performing Test HAVE_ATCCALL - Success
CMake Warning at /usr/share/cmake/Modules/FindDoxygen.cmake:497 (message):
  Unable to determine doxygen version: No such file or directory
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindDoxygen.cmake:660 (_Doxygen_find_doxygen)
  CMakeLists.txt:399 (find_package)


CMake Error at /usr/share/cmake/Modules/FindDoxygen.cmake:739 (message):
  Unable to generate Doxyfile template: No such file or directory
Call Stack (most recent call first):
  CMakeLists.txt:399 (find_package)
```

I added a cmake build flag (`BUILD_DOCUMENTATION`) to disable documentation build (default is enabled)

I also added output for some interesting flags, to remember what targets we wanted to build

```
❯ cmake .. -D RUN_IN_PLACE=TRUE -DBUILD_DOCUMENTATION=FALSE
-- *** Will build version 5.8.0-dev ***
-- Compiling client: TRUE
-- Compiling server: FALSE
-- Compiling unittests: TRUE
-- Compiling benchmarks: FALSE
-- Generating documentation: FALSE
-- Run in place build: TRUE
-- Using user-provided IrrlichtMt at subdirectory 'lib/irrlichtmt'
-- *** Building IrrlichtMt 1.9.0.12 ***
```