### PR TITLE
Remove Minetest ASCII art at launch

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -539,17 +539,10 @@ void Server::start()
 	// Start thread
 	m_thread->start();
 
-	// ASCII art for the win!
-	std::cerr
-		<< "         __.               __.                 __.  " << std::endl
-		<< "  _____ |__| ____   _____ /  |_  _____  _____ /  |_ " << std::endl
-		<< " /     \\|  |/    \\ /  __ \\    _\\/  __ \\/   __>    _\\" << std::endl
-		<< "|  Y Y  \\  |   |  \\   ___/|  | |   ___/\\___  \\|  |  " << std::endl
-		<< "|__|_|  /  |___|  /\\______>  |  \\______>_____/|  |  " << std::endl
-		<< "      \\/ \\/     \\/         \\/                  \\/   " << std::endl;
+	std::cerr << std::endl
+			<< "---------------------------- LAUNCHING WORLD  ----------------------------" << std::endl;
 	actionstream << "World at [" << m_path_world << "]" << std::endl;
-	actionstream << "Server for gameid=\"" << m_gamespec.id
-			<< "\" listening on ";
+	actionstream << "Server for gameid=\"" << m_gamespec.id << "\" listening on ";
 	m_bind_addr.print(actionstream);
 	actionstream << "." << std::endl;
 }


### PR DESCRIPTION
Closes #13287

Maintenance aside, if we're going to change name  we'd have to redo it anyway. Let's cut the chase, I say

This is what it looks like now
![image](https://github.com/minetest/minetest/assets/63455151/33c3f6b5-4660-4c10-8f6d-6f3200cab4e5)

## To do

This PR is Ready for Review.
