### PR TITLE
Remove deprecation mark on TGA texture format in lua_api.md

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -265,7 +265,7 @@ the clients (see [Translations]). Accepted characters for names are:
 
 Accepted formats are:
 
-    images: .png, .jpg, .bmp, (deprecated) .tga
+    images: .png, .jpg, .bmp, .tga
     sounds: .ogg vorbis
     models: .x, .b3d, .obj
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
To not make the api docs say tga is deprecated.

- How does the PR work?
It removes the (deprecated) before .tga

- Does it resolve any reported issue?
Yes. It partly resolves #13794 

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
I do not think so.

- If not a bug fix, why is this PR needed? What usecases does it solve?
TGA was removed previously and then re-added. I do not see how the situation has changed since then.
See https://github.com/minetest/minetest/pull/11598 and https://github.com/minetest/irrlicht/pull/64

TGA support is actively used in both mineclonia and mineclone2, it is also used by the tga_encoder, unicode_text and my recent unicode_signs mod which uses the former 2.

If anything .bmp should be removed and not tga, which would save a lot more code as well if I understand it right (which I maybe do not).

## How to test
* Read the lua_api.md in master and be shocked by the fact that TGA is marked as deprecated.
* Read it again on this branch and rejoice in the fact that the deprecation mark was removed.