### PR TITLE
Change some keys to be triggered once every key press

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2076,29 +2076,29 @@ void Game::processKeyInput()
 #endif
 	} else if (wasKeyDown(KeyType::CINEMATIC)) {
 		toggleCinematic();
-	} else if (wasKeyDown(KeyType::SCREENSHOT)) {
+	} else if (wasKeyPressed(KeyType::SCREENSHOT)) {
 		client->makeScreenshot();
-	} else if (wasKeyDown(KeyType::TOGGLE_BLOCK_BOUNDS)) {
+	} else if (wasKeyPressed(KeyType::TOGGLE_BLOCK_BOUNDS)) {
 		toggleBlockBounds();
-	} else if (wasKeyDown(KeyType::TOGGLE_HUD)) {
+	} else if (wasKeyPressed(KeyType::TOGGLE_HUD)) {
 		m_game_ui->toggleHud();
-	} else if (wasKeyDown(KeyType::MINIMAP)) {
+	} else if (wasKeyPressed(KeyType::MINIMAP)) {
 		toggleMinimap(isKeyDown(KeyType::SNEAK));
-	} else if (wasKeyDown(KeyType::TOGGLE_CHAT)) {
+	} else if (wasKeyPressed(KeyType::TOGGLE_CHAT)) {
 		m_game_ui->toggleChat(client);
-	} else if (wasKeyDown(KeyType::TOGGLE_FOG)) {
+	} else if (wasKeyPressed(KeyType::TOGGLE_FOG)) {
 		toggleFog();
 	} else if (wasKeyDown(KeyType::TOGGLE_UPDATE_CAMERA)) {
 		toggleUpdateCamera();
-	} else if (wasKeyDown(KeyType::TOGGLE_DEBUG)) {
+	} else if (wasKeyPressed(KeyType::TOGGLE_DEBUG)) {
 		toggleDebug();
-	} else if (wasKeyDown(KeyType::TOGGLE_PROFILER)) {
+	} else if (wasKeyPressed(KeyType::TOGGLE_PROFILER)) {
 		m_game_ui->toggleProfiler();
 	} else if (wasKeyDown(KeyType::INCREASE_VIEWING_RANGE)) {
 		increaseViewRange();
 	} else if (wasKeyDown(KeyType::DECREASE_VIEWING_RANGE)) {
 		decreaseViewRange();
-	} else if (wasKeyDown(KeyType::RANGESELECT)) {
+	} else if (wasKeyPressed(KeyType::RANGESELECT)) {
 		toggleFullViewRange();
 	} else if (wasKeyDown(KeyType::ZOOM)) {
 		checkZoomEnabled();
@@ -3134,7 +3134,7 @@ void Game::updateCamera(f32 dtime)
 
 	v3s16 old_camera_offset = camera->getOffset();
 
-	if (wasKeyDown(KeyType::CAMERA_MODE)) {
+	if (wasKeyPressed(KeyType::CAMERA_MODE)) {
 		GenericCAO *playercao = player->getCAO();
 
 		// If playercao not loaded, don't change camera


### PR DESCRIPTION
**Goal of the PR**
This PR tries to make some keys to be triggered once every key press (using `wasKeyPressed()`).
Those keys are listed below:
- `KeyType::CAMERA_MODE`
- `KeyType::SCREENSHOT`
- `KeyType::TOGGLE_BLOCK_BOUNDS`
- `KeyType::TOGGLE_HUD`
- `KeyType::MINIMAP`
- `KeyType::TOGGLE_CHAT`
- `KeyType::TOGGLE_FOG`
- `KeyType::TOGGLE_DEBUG`
- `KeyType::TOGGLE_PROFILER`
- `KeyType::RANGESELECT`

**How does the PR work?**
This PR changes the key detection from `wasKeyDown()` to `wasKeyPressed()` for the keys listed above. The list contains keys that might cause sudden graphical changes (or creating new image files for `KeyType::SCREENSHOT`) when being pressed down continuously.

**Does it resolve any reported issue?**
Yes, this PR tries to fix #13868 (and also some of #11900).

**Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?**
Yes, this PR tries to create a better UI/UX.

## To do

This PR is Ready for Review.

## How to test

1. Play in a Minetest world.
2. Press down (and hold) the toggle camera mode key.
3. The action is triggered once.
4. Release the key.
5. Repeat step 2–4 with the rest: take screenshot, toggle block bounds, toggle HUD, toggle minimap, toggle chat, toggle fog, toggle debug, toggle profiler, and toggle (maximum) range select.