### PR TITLE
Clean up and improve mainmenu theme / game theme code

### DIFF
--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -1177,12 +1177,8 @@ end
 
 function store.handle_events(event)
 	if event == "DialogShow" then
-		if TOUCHSCREEN_GUI then
-			-- Don't show the "MINETEST" header behind the dialog.
-			mm_game_theme.set_neutral()
-		else
-			mm_game_theme.set_engine()
-		end
+		-- On mobile, don't show the "MINETEST" header behind the dialog.
+		mm_game_theme.set_engine(TOUCHSCREEN_GUI)
 
 		-- If the store is already loaded, auto-install packages here.
 		do_auto_install()

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -1178,7 +1178,7 @@ end
 function store.handle_events(event)
 	if event == "DialogShow" then
 		if TOUCHSCREEN_GUI then
-			-- Don't show the "Minetest" header behind the dialog.
+			-- Don't show the "MINETEST" header behind the dialog.
 			mm_game_theme.set_neutral()
 		else
 			mm_game_theme.set_engine()

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -1177,8 +1177,16 @@ end
 
 function store.handle_events(event)
 	if event == "DialogShow" then
+		if TOUCHSCREEN_GUI then
+			-- Don't show the "Minetest" header behind the dialog.
+			mm_game_theme.set_neutral()
+		else
+			mm_game_theme.set_engine()
+		end
+
 		-- If the store is already loaded, auto-install packages here.
 		do_auto_install()
+
 		return true
 	end
 

--- a/builtin/mainmenu/dlg_reinstall_mtg.lua
+++ b/builtin/mainmenu/dlg_reinstall_mtg.lua
@@ -41,8 +41,6 @@ function check_reinstall_mtg()
 		return
 	end
 
-	mm_game_theme.reset()
-
 	local maintab = ui.find_by_name("maintab")
 
 	local dlg = create_reinstall_mtg_dlg()
@@ -96,7 +94,10 @@ local function buttonhandler(this, fields)
 end
 
 local function eventhandler(event)
-	if event == "MenuQuit" then
+	if event == "DialogShow" then
+		mm_game_theme.set_engine()
+		return true
+	elseif event == "MenuQuit" then
 		-- Don't allow closing the dialog with ESC, but still allow exiting
 		-- Minetest.
 		core.close()

--- a/builtin/mainmenu/dlg_version_info.lua
+++ b/builtin/mainmenu/dlg_version_info.lua
@@ -71,6 +71,15 @@ local function version_info_buttonhandler(this, fields)
 	return false
 end
 
+local function version_info_eventhandler(event)
+	if event == "DialogShow" then
+		mm_game_theme.set_engine()
+		return true
+	end
+
+	return false
+end
+
 local function create_version_info_dlg(new_version, url)
 	assert(type(new_version) == "string")
 	assert(type(url) == "string")
@@ -78,7 +87,7 @@ local function create_version_info_dlg(new_version, url)
 	local retval = dialog_create("version_info",
 		version_info_formspec,
 		version_info_buttonhandler,
-		nil)
+		version_info_eventhandler)
 
 	retval.data.new_version = new_version
 	retval.data.url = url

--- a/builtin/mainmenu/game_theme.lua
+++ b/builtin/mainmenu/game_theme.lua
@@ -22,7 +22,6 @@ mm_game_theme = {}
 function mm_game_theme.init()
 	mm_game_theme.defaulttexturedir = core.get_texturepath_share() .. DIR_DELIM .. "base" ..
 						DIR_DELIM .. "pack" .. DIR_DELIM
-	mm_game_theme.basetexturedir = mm_game_theme.defaulttexturedir
 
 	mm_game_theme.texturepack = core.settings:get("texture_path")
 
@@ -32,35 +31,40 @@ function mm_game_theme.init()
 end
 
 --------------------------------------------------------------------------------
-function mm_game_theme.update(tab,gamedetails)
-	if tab ~= "singleplayer" then
-		mm_game_theme.reset()
-		return
-	end
+function mm_game_theme.set_neutral()
+	mm_game_theme.gameid = nil
+	mm_game_theme.stop_music()
 
-	if gamedetails == nil then
-		return
-	end
+	mm_game_theme.clear_single("overlay")
+	mm_game_theme.clear_single("background")
+	mm_game_theme.clear_single("header")
+	mm_game_theme.clear_single("footer")
 
-	mm_game_theme.update_game(gamedetails)
+	if core.settings:get_bool("menu_clouds") then
+		core.set_clouds(true)
+	else
+		mm_game_theme.set_dirt_bg()
+	end
 end
 
 --------------------------------------------------------------------------------
-function mm_game_theme.reset()
+function mm_game_theme.set_engine()
 	mm_game_theme.gameid = nil
+	mm_game_theme.stop_music()
+
 	local have_bg      = false
-	local have_overlay = mm_game_theme.set_generic("overlay")
+	local have_overlay = mm_game_theme.set_engine_single("overlay")
 
 	if not have_overlay then
-		have_bg = mm_game_theme.set_generic("background")
+		have_bg = mm_game_theme.set_engine_single("background")
 	end
 
-	mm_game_theme.clear("header")
-	mm_game_theme.clear("footer")
+	mm_game_theme.clear_single("header")
+	mm_game_theme.clear_single("footer")
 	core.set_clouds(false)
 
-	mm_game_theme.set_generic("footer")
-	mm_game_theme.set_generic("header")
+	mm_game_theme.set_engine_single("header")
+	mm_game_theme.set_engine_single("footer")
 
 	if not have_bg then
 		if core.settings:get_bool("menu_clouds") then
@@ -69,51 +73,46 @@ function mm_game_theme.reset()
 			mm_game_theme.set_dirt_bg()
 		end
 	end
-
-	if mm_game_theme.music_handle ~= nil then
-		core.sound_stop(mm_game_theme.music_handle)
-	end
 end
 
 --------------------------------------------------------------------------------
-function mm_game_theme.update_game(gamedetails)
+function mm_game_theme.set_game(gamedetails)
 	if mm_game_theme.gameid == gamedetails.id then
 		return
 	end
+	mm_game_theme.gameid = gamedetails.id
+	mm_game_theme.set_music(gamedetails)
 
 	local have_bg      = false
-	local have_overlay = mm_game_theme.set_game("overlay",gamedetails)
+	local have_overlay = mm_game_theme.set_game_single("overlay", gamedetails)
 
 	if not have_overlay then
-		have_bg = mm_game_theme.set_game("background",gamedetails)
+		have_bg = mm_game_theme.set_game_single("background", gamedetails)
 	end
 
-	mm_game_theme.clear("header")
-	mm_game_theme.clear("footer")
+	mm_game_theme.clear_single("header")
+	mm_game_theme.clear_single("footer")
 	core.set_clouds(false)
 
-	if not have_bg then
+	mm_game_theme.set_game_single("header", gamedetails)
+	mm_game_theme.set_game_single("footer", gamedetails)
 
+	if not have_bg then
 		if core.settings:get_bool("menu_clouds") then
 			core.set_clouds(true)
 		else
 			mm_game_theme.set_dirt_bg()
 		end
 	end
-
-	mm_game_theme.set_game("footer",gamedetails)
-	mm_game_theme.set_game("header",gamedetails)
-
-	mm_game_theme.gameid = gamedetails.id
 end
 
 --------------------------------------------------------------------------------
-function mm_game_theme.clear(identifier)
+function mm_game_theme.clear_single(identifier)
 	core.set_background(identifier,"")
 end
 
 --------------------------------------------------------------------------------
-function mm_game_theme.set_generic(identifier)
+function mm_game_theme.set_engine_single(identifier)
 	--try texture pack first
 	if mm_game_theme.texturepack ~= nil then
 		local path = mm_game_theme.texturepack .. DIR_DELIM .."menu_" ..
@@ -135,13 +134,10 @@ function mm_game_theme.set_generic(identifier)
 end
 
 --------------------------------------------------------------------------------
-function mm_game_theme.set_game(identifier, gamedetails)
-
+function mm_game_theme.set_game_single(identifier, gamedetails)
 	if gamedetails == nil then
 		return false
 	end
-
-	mm_game_theme.set_music(gamedetails)
 
 	if mm_game_theme.texturepack ~= nil then
 		local path = mm_game_theme.texturepack .. DIR_DELIM ..
@@ -194,10 +190,16 @@ function mm_game_theme.set_dirt_bg()
 end
 
 --------------------------------------------------------------------------------
-function mm_game_theme.set_music(gamedetails)
+function mm_game_theme.stop_music()
 	if mm_game_theme.music_handle ~= nil then
 		core.sound_stop(mm_game_theme.music_handle)
 	end
+end
+
+--------------------------------------------------------------------------------
+function mm_game_theme.set_music(gamedetails)
+	mm_game_theme.stop_music()
+
 	local music_path = gamedetails.path .. DIR_DELIM .. "menu" .. DIR_DELIM .. "theme"
 	mm_game_theme.music_handle = core.sound_play(music_path, true)
 end

--- a/builtin/mainmenu/game_theme.lua
+++ b/builtin/mainmenu/game_theme.lua
@@ -20,9 +20,6 @@ mm_game_theme = {}
 
 --------------------------------------------------------------------------------
 function mm_game_theme.init()
-	mm_game_theme.defaulttexturedir = core.get_texturepath_share() .. DIR_DELIM .. "base" ..
-						DIR_DELIM .. "pack" .. DIR_DELIM
-
 	mm_game_theme.texturepack = core.settings:get("texture_path")
 
 	mm_game_theme.gameid = nil
@@ -81,6 +78,8 @@ end
 
 --------------------------------------------------------------------------------
 function mm_game_theme.set_game(gamedetails)
+	assert(gamedetails ~= nil)
+
 	if mm_game_theme.gameid == gamedetails.id then
 		return
 	end
@@ -128,12 +127,9 @@ function mm_game_theme.set_engine_single(identifier)
 		end
 	end
 
-	if mm_game_theme.defaulttexturedir ~= nil then
-		local path = mm_game_theme.defaulttexturedir .. DIR_DELIM .."menu_" ..
-										identifier .. ".png"
-		if core.set_background(identifier,path) then
-			return true
-		end
+	local path = defaulttexturedir .. DIR_DELIM .. "menu_" .. identifier .. ".png"
+	if core.set_background(identifier, path) then
+		return true
 	end
 
 	return false
@@ -141,6 +137,8 @@ end
 
 --------------------------------------------------------------------------------
 function mm_game_theme.set_game_single(identifier, gamedetails)
+	assert(gamedetails ~= nil)
+
 	if mm_game_theme.texturepack ~= nil then
 		local path = mm_game_theme.texturepack .. DIR_DELIM ..
 			gamedetails.id .. "_menu_" .. identifier .. ".png"
@@ -201,6 +199,8 @@ end
 --------------------------------------------------------------------------------
 function mm_game_theme.set_music(gamedetails)
 	mm_game_theme.stop_music()
+
+	assert(gamedetails ~= nil)
 
 	local music_path = gamedetails.path .. DIR_DELIM .. "menu" .. DIR_DELIM .. "theme"
 	mm_game_theme.music_handle = core.sound_play(music_path, true)

--- a/builtin/mainmenu/game_theme.lua
+++ b/builtin/mainmenu/game_theme.lua
@@ -28,26 +28,7 @@ function mm_game_theme.init()
 end
 
 --------------------------------------------------------------------------------
-function mm_game_theme.set_neutral()
-	mm_game_theme.gameid = nil
-	mm_game_theme.stop_music()
-
-	core.set_topleft_text("")
-
-	mm_game_theme.clear_single("overlay")
-	mm_game_theme.clear_single("background")
-	mm_game_theme.clear_single("header")
-	mm_game_theme.clear_single("footer")
-
-	if core.settings:get_bool("menu_clouds") then
-		core.set_clouds(true)
-	else
-		mm_game_theme.set_dirt_bg()
-	end
-end
-
---------------------------------------------------------------------------------
-function mm_game_theme.set_engine()
+function mm_game_theme.set_engine(hide_decorations)
 	mm_game_theme.gameid = nil
 	mm_game_theme.stop_music()
 
@@ -64,8 +45,10 @@ function mm_game_theme.set_engine()
 	mm_game_theme.clear_single("footer")
 	core.set_clouds(false)
 
-	mm_game_theme.set_engine_single("header")
-	mm_game_theme.set_engine_single("footer")
+	if not hide_decorations then
+		mm_game_theme.set_engine_single("header")
+		mm_game_theme.set_engine_single("footer")
+	end
 
 	if not have_bg then
 		if core.settings:get_bool("menu_clouds") then

--- a/builtin/mainmenu/game_theme.lua
+++ b/builtin/mainmenu/game_theme.lua
@@ -35,6 +35,8 @@ function mm_game_theme.set_neutral()
 	mm_game_theme.gameid = nil
 	mm_game_theme.stop_music()
 
+	core.set_topleft_text("")
+
 	mm_game_theme.clear_single("overlay")
 	mm_game_theme.clear_single("background")
 	mm_game_theme.clear_single("header")
@@ -51,6 +53,8 @@ end
 function mm_game_theme.set_engine()
 	mm_game_theme.gameid = nil
 	mm_game_theme.stop_music()
+
+	core.set_topleft_text("")
 
 	local have_bg      = false
 	local have_overlay = mm_game_theme.set_engine_single("overlay")
@@ -82,6 +86,8 @@ function mm_game_theme.set_game(gamedetails)
 	end
 	mm_game_theme.gameid = gamedetails.id
 	mm_game_theme.set_music(gamedetails)
+
+	core.set_topleft_text(gamedetails.name)
 
 	local have_bg      = false
 	local have_overlay = mm_game_theme.set_game_single("overlay", gamedetails)
@@ -135,10 +141,6 @@ end
 
 --------------------------------------------------------------------------------
 function mm_game_theme.set_game_single(identifier, gamedetails)
-	if gamedetails == nil then
-		return false
-	end
-
 	if mm_game_theme.texturepack ~= nil then
 		local path = mm_game_theme.texturepack .. DIR_DELIM ..
 			gamedetails.id .. "_menu_" .. identifier .. ".png"

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -89,7 +89,7 @@ local function init_globals()
 	menudata.worldlist:set_sortmode("alphabetic")
 
 	mm_game_theme.init()
-	mm_game_theme.reset()
+	mm_game_theme.set_engine() -- This is just a fallback.
 
 	-- Create main tabview
 	local tv_main = tabview_create("maintab", {x = 15.5, y = 7.1}, {x = 0, y = 0})

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -694,7 +694,7 @@ end
 
 local function eventhandler(event)
 	if event == "DialogShow" then
-		-- Don't show the "Minetest" header behind the dialog.
+		-- Don't show the "MINETEST" header behind the dialog.
 		mm_game_theme.set_neutral()
 		return true
 	end

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -692,8 +692,19 @@ local function buttonhandler(this, fields)
 end
 
 
+local function eventhandler(event)
+	if event == "DialogShow" then
+		-- Don't show the "Minetest" header behind the dialog.
+		mm_game_theme.set_neutral()
+		return true
+	end
+
+	return false
+end
+
+
 function create_settings_dlg()
-	local dlg = dialog_create("dlg_settings", get_formspec, buttonhandler, nil)
+	local dlg = dialog_create("dlg_settings", get_formspec, buttonhandler, eventhandler)
 
 	dlg.data.page_id = update_filtered_pages("")
 

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -695,7 +695,7 @@ end
 local function eventhandler(event)
 	if event == "DialogShow" then
 		-- Don't show the "MINETEST" header behind the dialog.
-		mm_game_theme.set_neutral()
+		mm_game_theme.set_engine(true)
 		return true
 	end
 

--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -122,6 +122,7 @@ end
 return {
 	name = "about",
 	caption = fgettext("About"),
+
 	cbf_formspec = function(tabview, name, tabdata)
 		local logofile = defaulttexturedir .. "logo.png"
 		local version = core.get_version()
@@ -196,6 +197,7 @@ return {
 
 		return fs
 	end,
+
 	cbf_button_handler = function(this, fields, name, tabdata)
 		if fields.homepage then
 			core.open_url("https://www.minetest.net")
@@ -208,6 +210,12 @@ return {
 
 		if fields.userdata then
 			core.open_dir(core.get_user_path())
+		end
+	end,
+
+	on_change = function(type)
+		if type == "ENTER" then
+			mm_game_theme.set_engine()
 		end
 	end,
 }

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -46,6 +46,7 @@ end
 
 local function on_change(type)
 	if type == "ENTER" then
+		mm_game_theme.set_engine()
 		update_packages()
 	end
 end
@@ -171,7 +172,7 @@ local function handle_doubleclick(pkg)
 		packages = nil
 
 		mm_game_theme.init()
-		mm_game_theme.reset()
+		mm_game_theme.set_engine()
 	end
 end
 
@@ -225,7 +226,7 @@ local function handle_buttons(tabview, fields, tabname, tabdata)
 		packages = nil
 
 		mm_game_theme.init()
-		mm_game_theme.reset()
+		mm_game_theme.set_engine()
 		return true
 	end
 

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -441,6 +441,8 @@ local function on_change(type)
 		local game = current_game()
 		if game then
 			apply_game(game)
+		else
+			mm_game_theme.set_engine()
 		end
 
 		if singleplayer_refresh_gamebar() then

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -57,7 +57,7 @@ function apply_game(game)
 	core.settings:set("menu_last_game", game.id)
 	menudata.worldlist:set_filtercriteria(game.id)
 
-	mm_game_theme.update("singleplayer", game) -- this refreshes the formspec
+	mm_game_theme.set_game(game)
 
 	local index = filterlist.get_current_index(menudata.worldlist,
 		tonumber(core.settings:get("mainmenu_last_selected_world")))
@@ -396,7 +396,6 @@ local function main_button_handler(this, fields, name, tabdata)
 		create_world_dlg:set_parent(this)
 		this:hide()
 		create_world_dlg:show()
-		mm_game_theme.update("singleplayer", current_game())
 		return true
 	end
 
@@ -413,7 +412,6 @@ local function main_button_handler(this, fields, name, tabdata)
 				delete_world_dlg:set_parent(this)
 				this:hide()
 				delete_world_dlg:show()
-				mm_game_theme.update("singleplayer",current_game())
 			end
 		end
 
@@ -431,7 +429,6 @@ local function main_button_handler(this, fields, name, tabdata)
 				configdialog:set_parent(this)
 				this:hide()
 				configdialog:show()
-				mm_game_theme.update("singleplayer",current_game())
 			end
 		end
 
@@ -439,8 +436,8 @@ local function main_button_handler(this, fields, name, tabdata)
 	end
 end
 
-local function on_change(type, old_tab, new_tab)
-	if (type == "ENTER") then
+local function on_change(type)
+	if type == "ENTER" then
 		local game = current_game()
 		if game then
 			apply_game(game)
@@ -449,17 +446,13 @@ local function on_change(type, old_tab, new_tab)
 		if singleplayer_refresh_gamebar() then
 			ui.find_by_name("game_button_bar"):show()
 		end
-	else
+	elseif type == "LEAVE" then
 		menudata.worldlist:set_filtercriteria(nil)
 		local gamebar = ui.find_by_name("game_button_bar")
 		if gamebar then
 			gamebar:hide()
 		end
 		core.set_topleft_text("")
-		-- If new_tab is nil, a dialog is being shown; avoid resetting the theme
-		if new_tab then
-			mm_game_theme.update(new_tab,nil)
-		end
 	end
 end
 

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -53,7 +53,6 @@ end
 
 -- Apply menu changes from given game
 function apply_game(game)
-	core.set_topleft_text(game.name)
 	core.settings:set("menu_last_game", game.id)
 	menudata.worldlist:set_filtercriteria(game.id)
 
@@ -454,7 +453,6 @@ local function on_change(type)
 		if gamebar then
 			gamebar:hide()
 		end
-		core.set_topleft_text("")
 	end
 end
 

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -416,9 +416,11 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	return false
 end
 
-local function on_change(type, old_tab, new_tab)
-	if type == "LEAVE" then return end
-	serverlistmgr.sync()
+local function on_change(type)
+	if type == "ENTER" then
+		mm_game_theme.set_engine()
+		serverlistmgr.sync()
+	end
 end
 
 return {


### PR DESCRIPTION
This PR reworks the code that sets the mainmenu theme aka game theme. It resolves the "Hide 'Minetest' header in dialog" to-do from #13476, the last remaining "Before 5.8.0" to-do in that issue.

Improvements:

- In addition to the engine theme ("MINETEST" header) and to game-specific themes, a new "neutral" theme is introduced. This theme is used by the settings dialog to avoid the "MINETEST" header appearing behind the dialog.

- The ContentDB dialog now always uses the engine theme. Previously, it would use the theme of the currently selected game if it was opened from the "Start Game" tab.

- On touchscreen builds, the ContentDB dialog uses the neutral theme instead of the engine theme to avoid the "MINETEST" header appearing behind the dialog.

- The update notification dialog now always uses the engine theme.

- The game-specific "topleft text" on the "Start Game" tab (`core.set_topleft_text`) no longer disappears when a dialog (e.g. "Select Mods") is opened. This is archieved by moving the responsibility for that text to the mainmenu theme as well.

- Cleaner code: Before this PR, the "Start Game" tab was responsible for setting the mainmenu theme for all other tabs. After this PR, all tabs and dialogs themselves are responsible for setting the mainmenu theme.

## To do

This PR is a Ready for Review.

## How to test

Click your way through the mainmenu and verify that all tabs and dialogs use the correct background, header, footer, music, etc.