### PR TITLE
Lump MT_LOGCOLOR environ together with other color environs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,7 @@ extern "C" {
 #define DEBUGFILE "debug.txt"
 #define DEFAULT_SERVER_PORT 30000
 
+#define ENV_MT_LOGCOLOR "MT_LOGCOLOR"
 #define ENV_NO_COLOR "NO_COLOR"
 #define ENV_CLICOLOR "CLICOLOR"
 #define ENV_CLICOLOR_FORCE "CLICOLOR_FORCE"
@@ -287,6 +288,13 @@ int main(int argc, char *argv[])
 
 static void get_env_opts(Settings &args)
 {
+#if !defined(_WIN32)
+	const char *mt_logcolor = std::getenv(ENV_MT_LOGCOLOR);
+	if (mt_logcolor) {
+		args.set("color", mt_logcolor);
+	}
+#endif
+
 	// CLICOLOR is a de-facto standard option for colors <https://bixense.com/clicolors/>
 	// CLICOLOR != 0: ANSI colors are supported (auto-detection, this is the default)
 	// CLICOLOR == 0: ANSI colors are NOT supported
@@ -493,12 +501,6 @@ static bool setup_log_params(const Settings &cmd_args)
 	std::string color_mode;
 	if (cmd_args.exists("color")) {
 		color_mode = cmd_args.get("color");
-#if !defined(_WIN32)
-	} else {
-		char *color_mode_env = getenv("MT_LOGCOLOR");
-		if (color_mode_env)
-			color_mode = color_mode_env;
-#endif
 	}
 	if (!color_mode.empty()) {
 		if (color_mode == "auto") {


### PR DESCRIPTION
value of `MT_LOGCOLOR` is also stored inside `args` rather than kept separate and not acknowledged by it. Functionally, should be the same as before.