### PR TITLE
Inventory: Fix picking up items via drop and pickup doubleclick

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4420,9 +4420,10 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 						}
 					}
 				} else if (button == BET_LEFT && (empty || matching)) {
-					// We don't know if the user is left-dragging or just moving
-					// the item, so assume that they are left-dragging,
-					// and wait for the next event before moving the item
+					// We don't know if the user is left-dragging, just moving
+					// the item, or doing a pickup-all via doubleclick, so assume
+					// that they are left-dragging, and wait for the next event
+					// before moving the item, or doing a pickup-all
 					m_left_dragging = true;
 					m_client->inhibit_inventory_revert = true;
 					m_left_drag_stack = list_selected->getItem(m_selected_item->i);
@@ -4570,6 +4571,13 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			// Some other mouse event has occured
 			// Currently only left-double-click should trigger this
 			if (!s.isValid() || event.MouseInput.Event != EMIE_LMOUSE_DOUBLE_CLICK)
+				break;
+
+			// Only do the pickup all thing when putting down an item.
+			// Doubleclick events are triggered after press-down events, so if
+			// m_left_dragging is true here, the user just put down an itemstack,
+			// but didn't yet release the button to make it happen.
+			if (!m_left_dragging)
 				break;
 
 			// Abort left-dragging


### PR DESCRIPTION
Fixes #13849.

Turns out this wasn't *that* hard to fix.

(First to correct myself: Doubleclick events are not generated by guiformspecmenu, but in irrlicht by the IrrDevice.)

What happens on putting down an item with left-click is the following:
* Leftclick is pressed.
* Leftclick press event is triggered. The selected item (item in hand) is not moved. Instead, we go into left-drag mode.
* Doubleclick event is triggered, if the leftclick was a doubleclick. The pickup-all thing is done.

In case of a pick-up, we're not in left-drag mode when the doubleclick happens.

## To do

This PR is a Ready for Review.

## How to test

See #13849.
