### PR TITLE
Extract updatePauseState from Game::run

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1239,12 +1239,11 @@ void Game::run()
 				cam_view.camera_pitch) * m_cache_cam_smoothing;
 		updatePlayerControl(cam_view);
 
-		this->updatePauseState();
-		if (m_is_paused) {
+		updatePauseState();
+		if (m_is_paused)
 			dtime = 0.0f;
-		} else {
+		else
 			step(dtime);
-		}
 
 		processClientEvents(&cam_view_target);
 		updateDebugState();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -788,6 +788,7 @@ protected:
 	void updateCameraDirection(CameraOrientation *cam, float dtime);
 	void updateCameraOrientation(CameraOrientation *cam, float dtime);
 	void updatePlayerControl(const CameraOrientation &cam);
+	void updatePauseState();
 	void step(f32 dtime);
 	void processClientEvents(CameraOrientation *cam);
 	void updateCamera(f32 dtime);
@@ -1238,23 +1239,13 @@ void Game::run()
 				cam_view.camera_pitch) * m_cache_cam_smoothing;
 		updatePlayerControl(cam_view);
 
-		{
-			bool was_paused = m_is_paused;
-			m_is_paused = simple_singleplayer_mode && g_menumgr.pausesGame();
-			if (m_is_paused)
-				dtime = 0.0f;
-
-			if (!was_paused && m_is_paused) {
-				pauseAnimation();
-				sound_manager->pauseAll();
-			} else if (was_paused && !m_is_paused) {
-				resumeAnimation();
-				sound_manager->resumeAll();
-			}
+		this->updatePauseState();
+		if (m_is_paused) {
+			dtime = 0.0f;
+		} else {
+			step(dtime);
 		}
 
-		if (!m_is_paused)
-			step(dtime);
 		processClientEvents(&cam_view_target);
 		updateDebugState();
 		updateCamera(dtime);
@@ -2694,6 +2685,20 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 	client->setPlayerControl(control);
 
 	//tt.stop();
+}
+
+void Game::updatePauseState()
+{
+	bool was_paused = this->m_is_paused;
+	m_is_paused = simple_singleplayer_mode && g_menumgr.pausesGame();
+
+	if (!was_paused && m_is_paused) {
+		this->pauseAnimation();
+		this->sound_manager->pauseAll();
+	} else if (was_paused && !m_is_paused) {
+		this->resumeAnimation();
+		this->sound_manager->resumeAll();
+	}
 }
 
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2689,12 +2689,12 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 void Game::updatePauseState()
 {
 	bool was_paused = this->m_is_paused;
-	m_is_paused = simple_singleplayer_mode && g_menumgr.pausesGame();
+	this->m_is_paused = simple_singleplayer_mode && g_menumgr.pausesGame();
 
-	if (!was_paused && m_is_paused) {
+	if (!was_paused && this->m_is_paused) {
 		this->pauseAnimation();
 		this->sound_manager->pauseAll();
-	} else if (was_paused && !m_is_paused) {
+	} else if (was_paused && !this->m_is_paused) {
 		this->resumeAnimation();
 		this->sound_manager->resumeAll();
 	}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2689,7 +2689,7 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 void Game::updatePauseState()
 {
 	bool was_paused = this->m_is_paused;
-	this->m_is_paused = simple_singleplayer_mode && g_menumgr.pausesGame();
+	this->m_is_paused = this->simple_singleplayer_mode && g_menumgr.pausesGame();
 
 	if (!was_paused && this->m_is_paused) {
 		this->pauseAnimation();


### PR DESCRIPTION
This seeks to improve the readability of Game::run by extracting some of the behavior into a function. The inspiration for the refactor came from the beautiful chart in #13879 showing the high-level overview of the logic flow in Game::run.

## To do

Ready for Review.

## How to test

Confirm that in multiplayer the game keeps running in the background when the main menu is open, and that in singleplayer the game stops running in the background when the main menu is open. "stops running" should mean the animation stops, and the sound stops.
