### PR TITLE
Don't throw resize lock exception in destructor when removing nodemeta inventory

### DIFF
--- a/src/nodemetadata.cpp
+++ b/src/nodemetadata.cpp
@@ -225,8 +225,13 @@ void NodeMetadataList::remove(v3s16 p)
 {
 	NodeMetadata *olddata = get(p);
 	if (olddata) {
-		if (m_is_metadata_owner)
+		if (m_is_metadata_owner) {
+			// clearing can throw an exception due to the invlist resize lock,
+			// which we don't want to happen in the noexcept destructor
+			// => call clear before
+			olddata->clear();
 			delete olddata;
+		}
 		m_data.erase(p);
 	}
 }


### PR DESCRIPTION

If you remove an inventory in meta in one of its inv callbacks, minetest currently crashes due to a resizelock exception in a destructor.
This PR triggers the exception before calling the destructor, so there will only be a lua error.
(The nodemeta will be left half-deleted. Only has the inventory will remain remain, not meta fields or privateness info.)

Fixes <https://github.com/minetest/minetest/issues/13785#issuecomment-1710358232>.

## To do

This PR is a Ready for Review.

## How to test

```lua
minetest.register_node("test_inv_callbacks:node", {
	description = "inv callback node",
	tiles = {"default_cobble.png^heart.png"},
	groups = {choppy = 3, oddly_breakable_by_hand = 3},

	on_construct = function(pos)
		minetest.log("on_construct")
		local meta = minetest.get_meta(pos)
		local inv = meta:get_inventory()
		inv:set_size("mylist", 5)
		meta:set_string("formspec", "size[8,10]"
			.."list[current_player;main;0,3;8,4;]"
			.."list[current_name;mylist;0,0;10,1;]")
	end,
	on_metadata_inventory_move = function(pos, from_list, from_index,
			to_list, to_index, count, player)
		minetest.log("on_metadata_inventory_move")
		core.remove_node(pos)
	end,
})
```
