### PR TITLE
Warn only once about positional stereo sounds

### DIFF
--- a/src/client/sound/sound_manager.cpp
+++ b/src/client/sound/sound_manager.cpp
@@ -164,10 +164,13 @@ std::shared_ptr<PlayingSound> OpenALSoundManager::createPlayingSound(
 		return nullptr;
 	}
 
-	if (lsnd->m_decode_info.is_stereo && pos_vel_opt.has_value()) {
+	if (lsnd->m_decode_info.is_stereo && pos_vel_opt.has_value()
+			&& m_warned_positional_stereo_sounds.find(sound_name)
+					== m_warned_positional_stereo_sounds.end()) {
 		warningstream << "OpenALSoundManager::createPlayingSound: "
 				<< "Creating positional stereo sound \"" << sound_name << "\"."
 				<< std::endl;
+		m_warned_positional_stereo_sounds.insert(sound_name);
 	}
 
 	ALuint source_id;

--- a/src/client/sound/sound_manager.h
+++ b/src/client/sound/sound_manager.h
@@ -77,6 +77,9 @@ private:
 	// if true, all sounds will be directly paused after creation
 	bool m_is_paused = false;
 
+	// used for printing warnings only once
+	std::unordered_set<std::string> m_warned_positional_stereo_sounds;
+
 public:
 	// used for communication with ProxySoundManager
 	MutexedQueue<SoundManagerMsgToMgr> m_queue_to_mgr;


### PR DESCRIPTION
Mistakenly positionally played stereo sounds are quite common. And warning about them gives no more value after the first time per sound. And it can probably be quite annoying for players.

Fixes #6622

(I had thought I already did this, oops.)

## To do

This PR is a Ready for Review.

## How to test

* Have some stereo sound in your sound pack, or add it to `devtest/mods/soundstuff/sounds/gitignored_sounds/`.
* In devtest, play the sound with the jukebox, with a position.
* Play it again.
* Look into chat.
