### PR TITLE
Offer ContentDB updates for leftover bundled Minetest Game

### DIFF
--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -777,36 +777,26 @@ function store.update_paths()
 	local mod_hash = {}
 	pkgmgr.refresh_globals()
 	for _, mod in pairs(pkgmgr.global_mods:get_list()) do
-		if mod.author and mod.release > 0 then
-			local id = mod.author:lower() .. "/" .. mod.name
-			mod_hash[store.aliases[id] or id] = mod
+		local cdb_id = pkgmgr.get_contentdb_id(mod)
+		if cdb_id then
+			mod_hash[store.aliases[cdb_id] or cdb_id] = mod
 		end
 	end
 
 	local game_hash = {}
 	pkgmgr.update_gamelist()
 	for _, game in pairs(pkgmgr.games) do
-		if game.author ~= "" and game.release > 0 then
-			local id = game.author:lower() .. "/" .. game.id
-			game_hash[store.aliases[id] or id] = game
-
-		-- Until Minetest 5.8.0, Minetest Game was bundled with Minetest.
-		-- Unfortunately, the bundled MTG was not versioned (missing "release"
-		-- field in game.conf).
-		-- Therefore, we consider any installation of MTG that is not versioned,
-		-- has not been cloned from Git, and is not system-wide to be updatable.
-		elseif game.id == "minetest" and game.release == 0 and
-				not core.is_dir(game.path .. "/.git") and core.may_modify_path(game.path) then
-			local id = "minetest/minetest"
-			game_hash[store.aliases[id] or id] = game
+		local cdb_id = pkgmgr.get_contentdb_id(game)
+		if cdb_id then
+			game_hash[store.aliases[cdb_id] or cdb_id] = game
 		end
 	end
 
 	local txp_hash = {}
 	for _, txp in pairs(pkgmgr.get_texture_packs()) do
-		if txp.author and txp.release > 0 then
-			local id = txp.author:lower() .. "/" .. txp.name
-			txp_hash[store.aliases[id] or id] = txp
+		local cdb_id = pkgmgr.get_contentdb_id(txp)
+		if cdb_id then
+			txp_hash[store.aliases[cdb_id] or cdb_id] = txp
 		end
 	end
 

--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -698,9 +698,7 @@ local function resolve_auto_install_spec()
 	local resolved = nil
 
 	for _, pkg in ipairs(store.packages_full_unordered) do
-		if pkg.author == auto_install_spec.author and
-				(pkg.name == auto_install_spec.name or
-					(pkg.type == "game" and pkg.name == auto_install_spec.name .. "_game")) then
+		if pkg.id == auto_install_spec then
 			resolved = pkg
 			break
 		end
@@ -1194,7 +1192,7 @@ end
 --- @param type string | nil
 --- Sets initial package filter. "game", "mod", "txp" or nil (no filter).
 --- @param install_spec table | nil
---- Package specification of the form { author = string, name = string }.
+--- ContentDB ID of package as returned by pkgmgr.get_contentdb_id().
 --- Sets package to install or update automatically.
 function create_store_dlg(type, install_spec)
 	search_string = ""

--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -789,6 +789,16 @@ function store.update_paths()
 		if game.author ~= "" and game.release > 0 then
 			local id = game.author:lower() .. "/" .. game.id
 			game_hash[store.aliases[id] or id] = game
+
+		-- Until Minetest 5.8.0, Minetest Game was bundled with Minetest.
+		-- Unfortunately, the bundled MTG was not versioned (missing "release"
+		-- field in game.conf).
+		-- Therefore, we consider any installation of MTG that is not versioned,
+		-- has not been cloned from Git, and is not system-wide to be updatable.
+		elseif game.id == "minetest" and game.release == 0 and
+				not core.is_dir(game.path .. "/.git") and core.may_modify_path(game.path) then
+			local id = "minetest/minetest"
+			game_hash[store.aliases[id] or id] = game
 		end
 	end
 
@@ -815,6 +825,7 @@ function store.update_paths()
 			package.installed_release = content.release or 0
 		else
 			package.path = nil
+			package.installed_release = nil
 		end
 	end
 end

--- a/builtin/mainmenu/content/pkgmgr.lua
+++ b/builtin/mainmenu/content/pkgmgr.lua
@@ -778,13 +778,14 @@ function pkgmgr.update_gamelist()
 end
 
 --------------------------------------------------------------------------------
-function pkgmgr.get_contentdb_id(pkg)
+-- Returns the ContentDB ID for an installed piece of content.
+function pkgmgr.get_contentdb_id(content)
 	-- core.get_games() will return "" instead of nil if there is no "author" field.
-	if pkg.author and pkg.author ~= "" and pkg.release > 0 then
-		if pkg.type == "game" then
-			return pkg.author:lower() .. "/" .. pkg.id
+	if content.author and content.author ~= "" and content.release > 0 then
+		if content.type == "game" then
+			return content.author:lower() .. "/" .. content.id
 		end
-		return pkg.author:lower() .. "/" .. pkg.name
+		return content.author:lower() .. "/" .. content.name
 	end
 
 	-- Until Minetest 5.8.0, Minetest Game was bundled with Minetest.
@@ -792,8 +793,8 @@ function pkgmgr.get_contentdb_id(pkg)
 	-- field in game.conf).
 	-- Therefore, we consider any installation of MTG that is not versioned,
 	-- has not been cloned from Git, and is not system-wide to be updatable.
-	if pkg.type == "game" and pkg.id == "minetest" and pkg.release == 0 and
-			not core.is_dir(pkg.path .. "/.git") and core.may_modify_path(pkg.path) then
+	if content.type == "game" and content.id == "minetest" and content.release == 0 and
+			not core.is_dir(content.path .. "/.git") and core.may_modify_path(content.path) then
 		return "minetest/minetest"
 	end
 

--- a/builtin/mainmenu/content/pkgmgr.lua
+++ b/builtin/mainmenu/content/pkgmgr.lua
@@ -778,6 +778,29 @@ function pkgmgr.update_gamelist()
 end
 
 --------------------------------------------------------------------------------
+function pkgmgr.get_contentdb_id(pkg)
+	-- core.get_games() will return "" instead of nil if there is no "author" field.
+	if pkg.author and pkg.author ~= "" and pkg.release > 0 then
+		if pkg.type == "game" then
+			return pkg.author:lower() .. "/" .. pkg.id
+		end
+		return pkg.author:lower() .. "/" .. pkg.name
+	end
+
+	-- Until Minetest 5.8.0, Minetest Game was bundled with Minetest.
+	-- Unfortunately, the bundled MTG was not versioned (missing "release"
+	-- field in game.conf).
+	-- Therefore, we consider any installation of MTG that is not versioned,
+	-- has not been cloned from Git, and is not system-wide to be updatable.
+	if pkg.type == "game" and pkg.id == "minetest" and pkg.release == 0 and
+			not core.is_dir(pkg.path .. "/.git") and core.may_modify_path(pkg.path) then
+		return "minetest/minetest"
+	end
+
+	return nil
+end
+
+--------------------------------------------------------------------------------
 -- read initial data
 --------------------------------------------------------------------------------
 pkgmgr.update_gamelist()

--- a/builtin/mainmenu/content/update_detector.lua
+++ b/builtin/mainmenu/content/update_detector.lua
@@ -59,7 +59,7 @@ local function has_packages_from_cdb()
 	pkgmgr.update_gamelist()
 
 	for _, content in pairs(pkgmgr.get_all()) do
-		if content.author and content.release > 0 then
+		if pkgmgr.get_contentdb_id(content) then
 			return true
 		end
 	end
@@ -114,18 +114,13 @@ function update_detector.get_all()
 	local ret = {}
 	local all_content = pkgmgr.get_all()
 	for _, content in ipairs(all_content) do
-		if content.author and content.release > 0 then
-			-- The backend will account for aliases in `latest_releases`
-			local id = content.author:lower() .. "/"
-			if content.type == "game" then
-				id = id .. content.id
-			else
-				id = id .. content.name
-			end
+		local cdb_id = pkgmgr.get_contentdb_id(content)
 
-			local latest_release = latest_releases[id]
+		if cdb_id then
+			-- The backend will account for aliases in `latest_releases`
+			local latest_release = latest_releases[cdb_id]
 			if not latest_release and content.type == "game" then
-				latest_release = latest_releases[id .. "_game"]
+				latest_release = latest_releases[cdb_id .. "_game"]
 			end
 
 			if latest_release and latest_release > content.release then

--- a/builtin/mainmenu/dlg_reinstall_mtg.lua
+++ b/builtin/mainmenu/dlg_reinstall_mtg.lua
@@ -78,7 +78,7 @@ local function buttonhandler(this, fields)
 
 		local maintab = ui.find_by_name("maintab")
 
-		local dlg = create_store_dlg(nil, { author = "Minetest", name = "minetest_game" })
+		local dlg = create_store_dlg(nil, "minetest/minetest")
 		dlg:set_parent(maintab)
 		maintab:hide()
 		dlg:show()

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -254,7 +254,7 @@ local function handle_buttons(tabview, fields, tabname, tabdata)
 
 	if fields.btn_mod_mgr_update then
 		local pkg = packages:get_list()[tabdata.selected_pkg]
-		local dlg = create_store_dlg(nil, { author = pkg.author, name = pkg.id or pkg.name })
+		local dlg = create_store_dlg(nil, pkgmgr.get_contentdb_id(pkg))
 		dlg:set_parent(tabview)
 		tabview:hide()
 		dlg:show()


### PR DESCRIPTION
Resolves item 3 from https://github.com/minetest/minetest/pull/13818#issuecomment-1742113761.

Windows users apparently update Minetest by extracting the new ZIP file over their existing installation. This means that Minetest Game will remain installed for them. Since the bundled Minetest Game has no "release" field in its game.conf, it won't receive updates from ContentDB and Windows users will stay on MTG 5.7.0 forever.

This PR fixes that by considering any installation of MTG that is not versioned (i.e. no "release" field), has not been cloned from Git, and is not system-wide to be updatable.

## To do

This PR is a Ready for Review.

## How to test

Install Minetest Game from ContentDB. Remove the "release" field from game.conf and verify that you are offered an update in the "Browse online content" dialog.