### PR TITLE
CSM: Fix duplicate player names

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -575,7 +575,7 @@ void ChatPrompt::historyNext()
 	}
 }
 
-void ChatPrompt::nickCompletion(const std::list<std::string>& names, bool backwards)
+void ChatPrompt::nickCompletion(const std::set<std::string> &names, bool backwards)
 {
 	// Two cases:
 	// (a) m_nick_completion_start == m_nick_completion_end == 0

--- a/src/chat.h
+++ b/src/chat.h
@@ -190,7 +190,7 @@ public:
 	void historyNext();
 
 	// Nick completion
-	void nickCompletion(const std::list<std::string>& names, bool backwards);
+	void nickCompletion(const std::set<std::string> &names, bool backwards);
 
 	// Update console size and reformat the visible portion of the prompt
 	void reformat(u32 cols);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -288,7 +288,7 @@ public:
 	// Send the item number 'item' as player item to the server
 	void setPlayerItem(u16 item);
 
-	const std::list<std::string> &getConnectedPlayerNames()
+	const std::set<std::string> &getConnectedPlayerNames()
 	{
 		return m_env.getPlayerNames();
 	}

--- a/src/client/clientenvironment.h
+++ b/src/client/clientenvironment.h
@@ -20,10 +20,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "environment.h"
-#include <ISceneManager.h>
-#include "clientobject.h"
-#include "util/numeric.h"
-#include "activeobjectmgr.h"
+#include "util/numeric.h" // IntervalLimiter
+#include "activeobjectmgr.h" // client::ActiveObjectMgr
+#include <set>
 
 class ClientSimpleObject;
 class ClientMap;
@@ -135,9 +134,9 @@ public:
 		std::vector<PointedThing> &objects
 	);
 
-	const std::list<std::string> &getPlayerNames() { return m_player_names; }
-	void addPlayerName(const std::string &name) { m_player_names.push_back(name); }
-	void removePlayerName(const std::string &name) { m_player_names.remove(name); }
+	const std::set<std::string> &getPlayerNames() { return m_player_names; }
+	void addPlayerName(const std::string &name) { m_player_names.insert(name); }
+	void removePlayerName(const std::string &name) { m_player_names.erase(name); }
 	void updateCameraOffset(const v3s16 &camera_offset)
 	{ m_camera_offset = camera_offset; }
 	v3s16 getCameraOffset() const { return m_camera_offset; }
@@ -156,7 +155,7 @@ private:
 	std::vector<ClientSimpleObject*> m_simple_objects;
 	std::queue<ClientEnvEvent> m_client_event_queue;
 	IntervalLimiter m_active_object_light_update_interval;
-	std::list<std::string> m_player_names;
+	std::set<std::string> m_player_names;
 	v3s16 m_camera_offset;
 	u64 m_frame_time = 0;
 	u64 m_frame_dtime = 0;

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -645,7 +645,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		{
 			// Tab or Shift-Tab pressed
 			// Nick completion
-			std::list<std::string> names = m_client->getConnectedPlayerNames();
+			auto names = m_client->getConnectedPlayerNames();
 			bool backwards = event.KeyInput.Shift;
 			prompt.nickCompletion(names, backwards);
 			return true;

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -150,13 +150,12 @@ int ModApiClient::l_get_player_names(lua_State *L)
 	if (checkCSMRestrictionFlag(CSM_RF_READ_PLAYERINFO))
 		return 0;
 
-	const std::list<std::string> &plist = getClient(L)->getConnectedPlayerNames();
+	auto plist = getClient(L)->getConnectedPlayerNames();
 	lua_createtable(L, plist.size(), 0);
 	int newTable = lua_gettop(L);
 	int index = 1;
-	std::list<std::string>::const_iterator iter;
-	for (iter = plist.begin(); iter != plist.end(); ++iter) {
-		lua_pushstring(L, (*iter).c_str());
+	for (const std::string &name : plist) {
+		lua_pushstring(L, name.c_str());
 		lua_rawseti(L, newTable, index);
 		index++;
 	}

--- a/src/terminal_chat_console.cpp
+++ b/src/terminal_chat_console.cpp
@@ -323,10 +323,10 @@ void TerminalChatConsole::step(int ch)
 		ChatEvent *evt = m_chat_interface->outgoing_queue.pop_frontNoEx();
 		switch (evt->type) {
 			case CET_NICK_REMOVE:
-				m_nicks.remove(((ChatEventNick *)evt)->nick);
+				m_nicks.erase(((ChatEventNick *)evt)->nick);
 				break;
 			case CET_NICK_ADD:
-				m_nicks.push_back(((ChatEventNick *)evt)->nick);
+				m_nicks.insert(((ChatEventNick *)evt)->nick);
 				break;
 			case CET_CHAT:
 				complete_redraw_needed = true;

--- a/src/terminal_chat_console.h
+++ b/src/terminal_chat_console.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "threading/thread.h"
 #include "util/container.h"
 #include "log.h"
+#include <set>
 #include <sstream>
 
 
@@ -103,7 +104,7 @@ private:
 	u8 m_utf8_bytes_to_wait = 0;
 	std::string m_pending_utf8_bytes;
 
-	std::list<std::string> m_nicks;
+	std::set<std::string> m_nicks;
 
 	int m_cols;
 	int m_rows;


### PR DESCRIPTION
Fixes #13898

## To do

This PR is Ready for Review.

## How to test

1. Have a CSM mod enabled
2. This:
```Lua
minetest.register_chatcommand("p", {
    params = "command",
    func = function(param)
		local players = minetest.get_player_names()
		for i, v in pairs(players) do
			print(i, v)
		end
		return true, "---- END"
	end
})
```
3. Only unique names must appear.