### PR TITLE
GUI: Autofocus newly opened GUIModalMenu instances

### DIFF
--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -114,7 +114,6 @@ void GUIChatConsole::openConsole(f32 scale)
 	reformatConsole();
 	m_animate_time_old = porting::getTimeMs();
 	IGUIElement::setVisible(true);
-	Environment->setFocus(this);
 	m_menumgr->createdMenu(this);
 }
 

--- a/src/gui/mainmenumanager.h
+++ b/src/gui/mainmenumanager.h
@@ -57,6 +57,7 @@ public:
 		if(!m_stack.empty())
 			m_stack.back()->setVisible(false);
 		m_stack.push_back(menu);
+		guienv->setFocus(m_stack.back());
 	}
 
 	virtual void deletingMenu(gui::IGUIElement *menu)
@@ -64,8 +65,10 @@ public:
 		// Remove all entries if there are duplicates
 		m_stack.remove(menu);
 
-		if(!m_stack.empty())
+		if(!m_stack.empty()) {
 			m_stack.back()->setVisible(true);
+			guienv->setFocus(m_stack.back());
+		}
 	}
 
 	// Returns true to prevent further processing

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -49,7 +49,6 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
 #endif
 
 	setVisible(true);
-	Environment->setFocus(this);
 	m_menumgr->createdMenu(this);
 
 	m_doubleclickdetect[0].time = 0;


### PR DESCRIPTION
This in particular fixes incorrect event propagation to menus that are no longer shown, such as the key change menu when opened within the settings tab.

Fixes #13908

## To do

This PR is Ready for Review.

## How to test

See issue text.
