### PR TITLE
Use hypertext[] for credits so that long lines are wrapped

### DIFF
--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -99,24 +99,17 @@ local previous_contributors = {
 }
 
 local function prepare_credits(dest, source)
-	for _, s in ipairs(source) do
-		-- if there's text inside brackets make it gray-ish
-		s = s:gsub("%[.-%]", core.colorize("#aaa", "%1"))
-		dest[#dest+1] = s
-	end
-end
+	local string = table.concat(source, "\n") .. "\n"
 
-local function build_hacky_list(items, spacing)
-	spacing = spacing or 0.5
-	local y = spacing / 2
-	local ret = {}
-	for _, item in ipairs(items) do
-		if item ~= "" then
-			ret[#ret+1] = ("label[0,%f;%s]"):format(y, core.formspec_escape(item))
-		end
-		y = y + spacing
-	end
-	return table.concat(ret, ""), y
+	local hypertext_escapes = {
+		["\\"] = "\\\\",
+		["<"] = "\\<",
+		[">"] = "\\>",
+	}
+	string = string:gsub("[\\<>]", hypertext_escapes)
+	string = string:gsub("%[.-%]", "<gray>%1</gray>")
+
+	table.insert(dest, string)
 end
 
 return {
@@ -127,50 +120,52 @@ return {
 		local logofile = defaulttexturedir .. "logo.png"
 		local version = core.get_version()
 
-		local credit_list = {}
-		table.insert_all(credit_list, {
-			core.colorize("#000", "Dedication of the current release"),
-			"The 5.7.0 release is dedicated to the memory of",
-			"Minetest developer Jude Melton-Houghton (TurkeyMcMac)",
-			"who died on February 1, 2023.",
-			"Our thoughts are with his family and friends.",
-			"",
-			core.colorize("#ff0", fgettext("Core Developers"))
+		local hypertext = {
+			"<tag name=heading color=#ff0>",
+			"<tag name=spacer size=1>",
+			"<tag name=gray color=#aaa>",
+		}
+
+		table.insert_all(hypertext, {
+			"<style color=#000>Dedication of the current release</style>\n",
+			"The 5.7.0 release is dedicated to the memory of\n",
+			"Minetest developer Jude Melton-Houghton (TurkeyMcMac)\n",
+			"who died on February 1, 2023.\n",
+			"Our thoughts are with his family and friends.\n",
+
+			"<spacer></spacer>\n",
+			"<heading>", fgettext_ne("Core Developers"), "</heading>\n",
 		})
-		prepare_credits(credit_list, core_developers)
-		table.insert_all(credit_list, {
-			"",
-			core.colorize("#ff0", fgettext("Core Team"))
+		prepare_credits(hypertext, core_developers)
+		table.insert_all(hypertext, {
+			"<spacer></spacer>\n",
+			"<heading>", fgettext_ne("Core Team"), "</heading>\n",
 		})
-		prepare_credits(credit_list, core_team)
-		table.insert_all(credit_list, {
-			"",
-			core.colorize("#ff0", fgettext("Active Contributors"))
+		prepare_credits(hypertext, core_team)
+		table.insert_all(hypertext, {
+			"<spacer></spacer>\n",
+			"<heading>", fgettext_ne("Active Contributors"), "</heading>\n",
 		})
-		prepare_credits(credit_list, active_contributors)
-		table.insert_all(credit_list, {
-			"",
-			core.colorize("#ff0", fgettext("Previous Core Developers"))
+		prepare_credits(hypertext, active_contributors)
+		table.insert_all(hypertext, {
+			"<spacer></spacer>\n",
+			"<heading>", fgettext_ne("Previous Core Developers"), "</heading>\n",
 		})
-		prepare_credits(credit_list, previous_core_developers)
-		table.insert_all(credit_list, {
-			"",
-			core.colorize("#ff0", fgettext("Previous Contributors"))
+		prepare_credits(hypertext, previous_core_developers)
+		table.insert_all(hypertext, {
+			"<spacer></spacer>\n",
+			"<heading>", fgettext_ne("Previous Contributors"), "</heading>\n",
 		})
-		prepare_credits(credit_list, previous_contributors)
-		local credit_fs, scroll_height = build_hacky_list(credit_list)
-		-- account for the visible portion
-		scroll_height = math.max(0, scroll_height - 6.9)
+		prepare_credits(hypertext, previous_contributors)
+
+		hypertext = table.concat(hypertext):sub(1, -2)
 
 		local fs = "image[1.5,0.6;2.5,2.5;" .. core.formspec_escape(logofile) .. "]" ..
 			"style[label_button;border=false]" ..
 			"button[0.1,3.4;5.3,0.5;label_button;" ..
 			core.formspec_escape(version.project .. " " .. version.string) .. "]" ..
 			"button[1.5,4.1;2.5,0.8;homepage;minetest.net]" ..
-			"scroll_container[5.5,0.1;9.5,6.9;scroll_credits;vertical;" ..
-			tostring(scroll_height / 1000) .. "]" .. credit_fs ..
-			"scroll_container_end[]"..
-			"scrollbar[15,0.1;0.4,6.9;vertical;scroll_credits;0]"
+			"hypertext[5.5,0.25;9.75,6.6;credits;" .. minetest.formspec_escape(hypertext) .. "]"
 
 		-- Render information
 		local active_renderer_info = fgettext("Active renderer:") .. " " ..

--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -122,7 +122,6 @@ return {
 
 		local hypertext = {
 			"<tag name=heading color=#ff0>",
-			"<tag name=spacer size=1>",
 			"<tag name=gray color=#aaa>",
 		}
 
@@ -132,28 +131,27 @@ return {
 			"Minetest developer Jude Melton-Houghton (TurkeyMcMac)\n",
 			"who died on February 1, 2023.\n",
 			"Our thoughts are with his family and friends.\n",
-
-			"<spacer></spacer>\n",
+			"\n",
 			"<heading>", fgettext_ne("Core Developers"), "</heading>\n",
 		})
 		prepare_credits(hypertext, core_developers)
 		table.insert_all(hypertext, {
-			"<spacer></spacer>\n",
+			"\n",
 			"<heading>", fgettext_ne("Core Team"), "</heading>\n",
 		})
 		prepare_credits(hypertext, core_team)
 		table.insert_all(hypertext, {
-			"<spacer></spacer>\n",
+			"\n",
 			"<heading>", fgettext_ne("Active Contributors"), "</heading>\n",
 		})
 		prepare_credits(hypertext, active_contributors)
 		table.insert_all(hypertext, {
-			"<spacer></spacer>\n",
+			"\n",
 			"<heading>", fgettext_ne("Previous Core Developers"), "</heading>\n",
 		})
 		prepare_credits(hypertext, previous_core_developers)
 		table.insert_all(hypertext, {
-			"<spacer></spacer>\n",
+			"\n",
 			"<heading>", fgettext_ne("Previous Contributors"), "</heading>\n",
 		})
 		prepare_credits(hypertext, previous_contributors)


### PR DESCRIPTION
This PR changes the credits on the "About" tab to use the hypertext[] formspec element. This has the advantage that long lines are wrapped. Fixes #13912.

![screenshot](https://github.com/minetest/minetest/assets/82708541/df65beb4-1db0-479c-b063-4bf95efe0c74)



## To do

This PR is a Ready for Review.

## How to test

Look at the "About" tab.
