### PR TITLE
[NOSQUASH] Inventory: Release resizes-locked lists on all `on_`-callbacks, and fix `Inventory *` UaF

### DIFF
--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -592,16 +592,21 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		Report move to endpoints
 	*/
 	list_to.reset();
+	list_from.reset();
 
 	// Source = destination => move
 	if (from_inv == to_inv) {
 		onMove(count, player);
 		if (did_swap) {
 			// Item is now placed in source list
-			src_item = list_from->getItem(from_i);
-			swapDirections();
-			onMove(src_item.count, player);
-			swapDirections();
+			list_from = get_borrow_checked_invlist(inv_from, from_list);
+			if (list_from) {
+				src_item = list_from->getItem(from_i);
+				list_from.reset();
+				swapDirections();
+				onMove(src_item.count, player);
+				swapDirections();
+			}
 		}
 		mgr->setInventoryModified(from_inv);
 	} else {
@@ -616,10 +621,14 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			src_item.count = src_item_count;
 		if (did_swap) {
 			// Item is now placed in source list
-			src_item = list_from->getItem(from_i);
-			swapDirections();
-			onPutAndOnTake(src_item, player);
-			swapDirections();
+			list_from = get_borrow_checked_invlist(inv_from, from_list);
+			if (list_from) {
+				src_item = list_from->getItem(from_i);
+				list_from.reset();
+				swapDirections();
+				onPutAndOnTake(src_item, player);
+				swapDirections();
+			}
 		}
 		mgr->setInventoryModified(to_inv);
 		mgr->setInventoryModified(from_inv);


### PR DESCRIPTION
* Fixes #13785.
* `on_` callbacks can now delete inventories.
  (FYI, the locked lists were already released around the recursive apply calls in the case of `move_somewhere` (aka listring).)
* `get_borrow_checked_invlist` now takes an inv location to avoid UaFs.
  (Oops. I had already checked that the inventory pointer of the `from_inv` isn't used after a lua callback, but it looks like I didn't correctly check for the `to_inv`, which is already in master used after the recursive call.)

## To do

This PR is a Ready for Review.

## How to test

```lua
minetest.register_node("test_inv_callbacks:node", {
	description = "inv callback node",
	tiles = {"default_cobble.png^heart.png"},
	groups = {choppy = 3, oddly_breakable_by_hand = 3},

	on_construct = function(pos)
		minetest.log("on_construct")
		local meta = minetest.get_meta(pos)
		local inv = meta:get_inventory()
		inv:set_size("mylist", 5)
		meta:set_string("formspec", "size[8,10]"
			.."list[current_player;main;0,3;8,4;]"
			.."list[current_name;mylist;0,0;10,1;]"
			.."listring[]")
	end,
	on_receive_fields = function(pos, formname, fields, sender)
		minetest.log("on_receive_fields")
	end,
	allow_metadata_inventory_move = function(pos, from_list, from_index,
			to_list, to_index, count, player)
		minetest.log("allow_metadata_inventory_move")
		--~ core.remove_node(pos)
		return count
	end,
	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
		minetest.log("allow_metadata_inventory_put")
		--~ core.remove_node(pos)
		return stack:get_count()
	end,
	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
		minetest.log("allow_metadata_inventory_take")
		--~ core.remove_node(pos)
		return stack:get_count()
	end,
	on_metadata_inventory_move = function(pos, from_list, from_index,
			to_list, to_index, count, player)
		minetest.log("on_metadata_inventory_move")
		--~ core.remove_node(pos)
	end,
	on_metadata_inventory_put = function(pos, listname, index, stack, player)
		minetest.log("on_metadata_inventory_put")
		--~ core.remove_node(pos)
	end,
	on_metadata_inventory_take = function(pos, listname, index, stack, player)
		minetest.log("on_metadata_inventory_take")
		--~ core.remove_node(pos)
	end,
})
```

* Uncomment one of the `remove_node`.
* Trigger the action.
* Also try swapping and using the listring.
* What happens with PR: `allow_*` causes mod error. `on_*` stops after first callback, and removes node.