### PR TITLE
Deprecate .bmp format

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -265,7 +265,7 @@ the clients (see [Translations]). Accepted characters for names are:
 
 Accepted formats are:
 
-    images: .png, .jpg, .bmp, .tga
+    images: .png, .jpg, .tga, (deprecated:) .bmp
     sounds: .ogg vorbis
     models: .x, .b3d, .obj
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2557,6 +2557,13 @@ bool Server::addMediaFile(const std::string &filename,
 		return false;
 	}
 
+	const char *deprecated_ext[] = { ".bmp", nullptr };
+	if (!removeStringEnd(filename, deprecated_ext).empty())
+	{
+		warningstream << "Media file \"" << filename << "\" is using a"
+			" deprecated format and will stop working in the future." << std::endl;
+	}
+
 	SHA1 sha1;
 	sha1.addBytes(filedata.c_str(), filedata.length());
 


### PR DESCRIPTION
implements #13918
removal can happen 5.9.0 earliest