### PR TITLE
WIP: Do not set material for item stack needlessly

### DIFF
--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1096,6 +1096,7 @@ void drawItemStack(
 		video::SColor basecolor =
 			client->idef()->getItemstackColor(item, client);
 
+		video::SMaterial &prev_material = driver->getMaterial2D();
 		u32 mc = mesh->getMeshBufferCount();
 		for (u32 j = 0; j < mc; ++j) {
 			scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
@@ -1116,9 +1117,13 @@ void drawItemStack(
 				setMeshBufferColor(buf, c);
 
 			video::SMaterial &material = buf->getMaterial();
-			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
-			material.Lighting = false;
-			driver->setMaterial(material);
+			// only set material if it is not already set
+			if ( (0 == j) || (prev_material != material) ) {
+				material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+				material.Lighting = false;
+				driver->setMaterial(material);
+			}
+			prev_material = material;
 			driver->drawMeshBuffer(buf);
 		}
 


### PR DESCRIPTION
### Goal of the PR

Minetest's item stack rendering is very inefficient. This leads to much lower performance when an inventory is shown.

Look at an inventory using my `studs` mod and notice how Minetest framerate drops a lot.

This is a first attempt at reducing some of the inventory rendering load.

### How does the PR work?

The PR reduces the amount a material is set when rendering an Item Stack.

### Does it resolve any reported issue?

No, Minetest's item stack rendering is still very inefficient.

However, it is hopefully a tiny step towards addressing all issues that are caused by inventory being bad:

* https://github.com/minetest/minetest/issues/13920
* https://github.com/minetest/minetest/issues/11305
* https://github.com/minetest/minetest/issues/6905

### Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?

Unless setting materials is already optimized somewhere else to be a no-op in case this is the same as the old one, this should result in a tiny performance improvement … at least that is what I hope.

## To do

- [ ] Verify that ItemStacks render exactly as they do before
- [ ] Verify this actually improves performance by a tiny amount (i.e fewer OpenGL instructions)

## How to test

1. Render a frame with of loads of item stacks, both with and without this patch.
2. Trace the number of OpenGL commands sent and see if it is lower with this patch.
3. Verify that the two frames are pixel-wise identical when rendered on the same hardware.