### PR TITLE
Mainmenu: Avoid the header being displayed behind the formspec

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -247,6 +247,15 @@ std::vector<std::string>* GUIFormSpecMenu::getDropDownValues(const std::string &
 	return NULL;
 }
 
+// This will only return a meaningful value if called after drawMenu().
+core::rect<s32> GUIFormSpecMenu::getAbsoluteRect()
+{
+	core::rect<s32> rect = AbsoluteRect;
+	// Some extra space in case there is a tabheader[] element.
+	rect.UpperLeftCorner.Y -= imgsize.Y * 0.85f;
+	return rect;
+}
+
 v2s32 GUIFormSpecMenu::getElementBasePos(const std::vector<std::string> *v_pos)
 {
 	v2f32 pos_f = v2f32(padding.X, padding.Y) + pos_offset * spacing;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -251,8 +251,7 @@ std::vector<std::string>* GUIFormSpecMenu::getDropDownValues(const std::string &
 core::rect<s32> GUIFormSpecMenu::getAbsoluteRect()
 {
 	core::rect<s32> rect = AbsoluteRect;
-	// Some extra space in case there is a tabheader[] element.
-	rect.UpperLeftCorner.Y -= imgsize.Y * 0.85f;
+	rect.UpperLeftCorner.Y += m_tabheader_upper_edge;
 	return rect;
 }
 
@@ -2113,6 +2112,7 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 		e->setActiveTab(tab_index);
 
 	m_fields.push_back(spec);
+	m_tabheader_upper_edge = MYMIN(m_tabheader_upper_edge, rect.UpperLeftCorner.Y);
 }
 
 void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &element)
@@ -3114,6 +3114,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 	m_formspec_version = 1;
 	m_bgcolor = video::SColor(140, 0, 0, 0);
+	m_tabheader_upper_edge = 0;
 
 	{
 		v3f formspec_bgcolor = g_settings->getV3F("formspec_fullscreen_bg_color");

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -502,6 +502,9 @@ private:
 
 	int m_btn_height;
 	gui::IGUIFont *m_font = nullptr;
+
+	// used by getAbsoluteRect
+	s32 m_tabheader_upper_edge = 0;
 };
 
 class FormspecFormSource: public IFormSource

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -282,6 +282,9 @@ public:
 	GUITable* getTable(const std::string &tablename);
 	std::vector<std::string>* getDropDownValues(const std::string &name);
 
+	// This will only return a meaningful value if called after drawMenu().
+	core::rect<s32> getAbsoluteRect();
+
 #ifdef __ANDROID__
 	bool getAndroidUIInput();
 #endif


### PR DESCRIPTION
Currently, the mainmenu header image is usually displayed behind the mainmenu formspec on Android. This results in three problems:

- The header is hard/impossible to read.
- The part of the formspec that is in front of the header is hard to read.
- It looks ugly.

This PR keeps the current header placement code, but adds additional code to make sure the header doesn't end up behind the formspec. I don't claim that it's beautiful now, but I think it's better than before.

Here's a before/after comparison on Android:
<img src="https://github.com/minetest/minetest/assets/82708541/04d94923-abb9-4811-9b92-e1fc0d828d52" width="512" alt="screenshot before this PR" /> <img src="https://github.com/minetest/minetest/assets/82708541/baa69b15-b9b1-41eb-aa9b-2a860d182cd5" width="512" alt="screenshot after this PR" />

On desktop, it looks the same as before.

## To do

This PR is a Ready for Review.

A future PR could move the mainmenu formspec down a bit, giving more space to the header.

## How to test

Start Minetest on your Android device. Verify that the mainmenu header isn't displayed behind the mainmenu formspec.
