### PR TITLE
Remove use_texture_alpha compatibility code for nodeboxes & meshes

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8822,8 +8822,8 @@ Used by `minetest.register_node`.
     --           depending on the alpha channel being below/above 50% in value
     -- * "blend": The alpha channel specifies how transparent a given pixel
     --            of the rendered node is
-    -- The default is "opaque" for drawtypes normal, liquid and flowingliquid;
-    -- "clip" otherwise.
+    -- The default is "opaque" for drawtypes normal, liquid and flowingliquid,
+    -- mesh and nodebox or "clip" otherwise.
     -- If set to a boolean value (deprecated): true either sets it to blend
     -- or clip, false sets it to clip or opaque mode depending on the drawtype.
 

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -258,7 +258,7 @@ enum AlphaMode : u8 {
 	ALPHAMODE_BLEND,
 	ALPHAMODE_CLIP,
 	ALPHAMODE_OPAQUE,
-	ALPHAMODE_LEGACY_COMPAT, /* means either opaque or clip */
+	ALPHAMODE_LEGACY_COMPAT, /* only sent by old servers, equals OPAQUE */
 };
 
 
@@ -466,11 +466,9 @@ struct ContentFeatures
 		case NDT_NORMAL:
 		case NDT_LIQUID:
 		case NDT_FLOWINGLIQUID:
-			alpha = ALPHAMODE_OPAQUE;
-			break;
 		case NDT_NODEBOX:
 		case NDT_MESH:
-			alpha = ALPHAMODE_LEGACY_COMPAT; // this should eventually be OPAQUE
+			alpha = ALPHAMODE_OPAQUE;
 			break;
 		default:
 			alpha = ALPHAMODE_CLIP;
@@ -529,16 +527,6 @@ struct ContentFeatures
 #endif
 
 private:
-#ifndef SERVER
-	/*
-	 * Checks if any tile texture has any transparent pixels.
-	 * Prints a warning and returns true if that is the case, false otherwise.
-	 * This is supposed to be used for use_texture_alpha backwards compatibility.
-	 */
-	bool textureAlphaCheck(ITextureSource *tsrc, const TileDef *tiles,
-		int length);
-#endif
-
 	void setAlphaFromLegacy(u8 legacy_alpha);
 
 	u8 getAlphaForLegacy() const;


### PR DESCRIPTION
finishes what fff03931871b68e092e12bfce9056f760e8ec9dd started
compat code & warning has been in the engine for 3 releases (2+ years)

it means that: if you have a node with
* drawtype `nodebox` or `mesh`
* and `use_texture_alpha` *unset*

it will now always be opaque, just like the warning message used to say.

## To do

This PR is Ready for Review.

## How to test

Join ingame, look at a bunch of transparent, semi-transparent and opaque nodes.
Notice they are looking exactly as expected.