### PR TITLE
Prevent Windows Defender warnings in singleplayer (Bind singleplayer server to 127.0.0.1)

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1384,7 +1384,15 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 {
 	showOverlayMessage(N_("Creating server..."), 0, 5);
 
-	std::string bind_str = g_settings->get("bind_address");
+	std::string bind_str;
+	if (simple_singleplayer_mode) {
+		// Make the simple singleplayer server only accept connections from localhost,
+		// which also makes Windows Defender not show a warning.
+		bind_str = "127.0.0.1";
+	} else {
+		bind_str = g_settings->get("bind_address");
+	}
+	
 	Address bind_addr(0, 0, 0, 0, port);
 
 	if (g_settings->getBool("ipv6_server"))


### PR DESCRIPTION
This PR stops Minetest from throwing Windows Defender firewall warnings on Windows when playing singleplayer, by always binding the simple singleplayer server to 127.0.0.1.

Previously, it would listen on 0.0.0.0. But even if it would refuse connections from anyone other than "singleplayer", Windows treats this as wanting to break through the firewall, showing the user a warning and asking if it should be allowed.

![image](https://github.com/minetest/minetest/assets/60856959/754fbc3d-8837-4ef5-9926-dea54aa2b896)

In addition to this looking a little bit sketchy for someone who's just starting up Minetest for the first time, if a player refuses this then hosting a server sometime later won't work unless you go into Windows Defender and edit the firewall rule.

## To do
This PR is Ready for Review.

## How to test
1. Obtain Windows, and have Windows Defender enabled (obviously)

2. Go into the Windows Defender firewall settings and make sure that there are no entries for `minetest.exe`, delete any that may already exist:

![image](https://github.com/minetest/minetest/assets/60856959/fc3a4a60-63ca-4896-99d7-01fd61caf469)

3. Run Minetest with this PR, and start a singleplayer world

4. There should be no Windows Defender warning that shows up.

In addition, test hosting a server from the main menu will bind to 0.0.0.0 by default (which *should* cause a warning in Windows Defender) and that connecting to a singleplayer server hasn't somehow broken on a platform because of this.