### PR TITLE
Sounds: Don't pause new sounds when paused

### DIFF
--- a/src/client/sound/sound_manager.cpp
+++ b/src/client/sound/sound_manager.cpp
@@ -184,8 +184,7 @@ std::shared_ptr<PlayingSound> OpenALSoundManager::createPlayingSound(
 			volume, pitch, start_time, pos_vel_opt);
 
 	sound->play();
-	if (m_is_paused)
-		sound->pause();
+
 	warn_if_al_error("createPlayingSound");
 	return sound;
 }


### PR DESCRIPTION
Quick fix for #13931.

Rationale:
AFAIK, sounds are usually not played while paused (apart from the pause menu sounds), because mods get no callbacks anyway.
So, to get a playSound command to the sound manager while it's paused, you'd probably need some kind of race condition where the game is paused while the server's sound is passed to the client. This should happen very seldom in singleplayer (note that pause is a singleplayer-only feature). And if it happens, it will likely be a short sound, because those are more common than long ones.

## To do

This PR is a Ready for Review.

## How to test

See #13931.
