### PR TITLE
[NOSQUASH] Sounds: Fix some fade-related bugs

### DIFF
--- a/src/client/sound/playing_sound.cpp
+++ b/src/client/sound/playing_sound.cpp
@@ -179,6 +179,9 @@ bool PlayingSound::doFade(f32 dtime) noexcept
 	if (!m_fade_state || isDead())
 		return false;
 
+	if (getState() == AL_PAUSED)
+		return true;
+
 	FadeState &fade = *m_fade_state;
 	assert(fade.step != 0.0f);
 

--- a/src/client/sound/sound_manager.cpp
+++ b/src/client/sound/sound_manager.cpp
@@ -517,7 +517,7 @@ void *OpenALSoundManager::run()
 		if (stop_requested)
 			break;
 
-		f32 dtime = get_time_since_last_step();
+		f32 dtime = get_time_since_last_step() * 1.0e-3f;
 		t_step_start = porting::getTimeMs();
 		step(dtime);
 	}


### PR DESCRIPTION
Fixes two bugs introduced in #13633:
* First is a missing conversion from milliseconds to seconds.
* Second is that the sound manager used to not be stepped while paused, and hence did not fade sounds while paused. But now the sound manager thread always steps. I forgot to handle this.

## To do

This PR is a Ready for Review.

## How to test

* Place a jukebox in devtest, and play some long sound, e.g. music.
* Set the fade step on the right to 0.1, and target gain to 0.
* For first commit: Press fade. Notice how it is by far too fast in master.
* For second commit: Press fade. Pause the game (via esc). Wait a moment. Unpause, and listen if the sound is still there.