### PR TITLE
Revert "Don't trigger a key event if a key with the same associated char was pressed (#13773)"

### DIFF
--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -38,9 +38,7 @@ public:
 
 	bool operator==(const KeyPress &o) const
 	{
-		if (valid_kcode(Key) && valid_kcode(o.Key))
-			return Key == o.Key;
-		return Char > 0 && Char == o.Char;
+		return (Char > 0 && Char == o.Char) || (valid_kcode(Key) && Key == o.Key);
 	}
 
 	const char *sym() const;

--- a/src/unittest/test_keycode.cpp
+++ b/src/unittest/test_keycode.cpp
@@ -126,11 +126,4 @@ void TestKeycode::testCompare()
 	in.Char = L'\0';
 	in2.Char = L';';
 	UASSERT(KeyPress(in) == KeyPress(in2));
-
-	// Irrlicht sets chars to the according digit for numpad keys.
-	// We need to distinguish them in order to bind numpad keys.
-	irr::SEvent::SKeyInput in3;
-	in3.Key = irr::KEY_NUMPAD5;
-	in3.Char = L'5';
-	UASSERT(!(KeyPress("5") == KeyPress(in3)));
 }


### PR DESCRIPTION
This reverts commit d57c936b080f404df0b544561242b0c45c57f04d.

The reverted commit prevented recognition of key combinations.

Several keyboard layouts use a key combination to input a “+” (e.g. Neo2);
therefore some users could no longer input “+” to increase the view range.

### Goal of the PR

I want to be able to input a “+” again in Minetest, outside of chat.

### How does the PR work?

The PR simply reverts the logic that prevents recognition of key combinations.

### Does it resolve any reported issue?

This PR resolves two issues actually:

* https://github.com/minetest/minetest/issues/13890
* https://github.com/minetest/minetest/issues/13899

The PR unresolves this issue:

* https://github.com/minetest/minetest/issues/13773

It is probably possible to fix this issue again in a way that does not cause multiple regressions.
In any case, reverting the solution for #13773 just restores what Minetest did for many years.

### Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?

* Fixing issues
* General correctness.

Default keybindings being unusable unless you have a layout where “+” can be input without using a modifier key seems incorrect to me.

## How to test

1. Set your keyboard layout to German (Neo2).
2. Verify that you can not increase the viewing range by pressing ISO Level 3 Shift (the key above the left Shift key) and b together (which inputs a “+”) at the commit previous to this patch.
3. Verify that you can increase the viewing range by pressing ISO Level 3 Shift (the key above the left Shift key) and b together (which inputs a “+” ) with the patch in this PR.
4. Verify that you can increase the viewing range by pressing the “+” key on the Numpad with the patch in this PR.