### PR TITLE
Fix hypertext[] sometimes calculating incorrect scrollbar height

### DIFF
--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -1132,8 +1132,16 @@ void GUIHyperText::draw()
 	m_display_text_rect = AbsoluteRect;
 	m_drawer.place(m_display_text_rect);
 
-	// Show scrollbar if text overflow
+	// Show a scrollbar if the text overflows vertically
 	if (m_drawer.getHeight() > m_display_text_rect.getHeight()) {
+		// Showing a scrollbar will reduce the width of the viewport, causing
+		// more text to be wrapped and thus increasing the height of the text.
+		// Therefore, we have to re-layout the text *before* setting the height
+		// of the scrollbar.
+		core::rect<s32> smaller_rect = m_display_text_rect;
+		smaller_rect.LowerRightCorner.X -= m_scrollbar_width;
+		m_drawer.place(smaller_rect);
+
 		m_vscrollbar->setSmallStep(m_display_text_rect.getHeight() * 0.1f);
 		m_vscrollbar->setLargeStep(m_display_text_rect.getHeight() * 0.5f);
 		m_vscrollbar->setMax(m_drawer.getHeight() - m_display_text_rect.getHeight());
@@ -1141,11 +1149,6 @@ void GUIHyperText::draw()
 		m_vscrollbar->setVisible(true);
 
 		m_vscrollbar->setPageSize(s32(m_drawer.getHeight()));
-
-		core::rect<s32> smaller_rect = m_display_text_rect;
-
-		smaller_rect.LowerRightCorner.X -= m_scrollbar_width;
-		m_drawer.place(smaller_rect);
 	} else {
 		m_vscrollbar->setMax(0);
 		m_vscrollbar->setPos(0);


### PR DESCRIPTION
Using the hypertext formspec element for credits (#13914) uncovered another bug: hypertext sometimes calculates an incorrect (too low) scrollbar height. This bug is reproducible e.g. with a high DPI value or a very small window. For details, see my comment in the code.

Before this PR on my Android device (notice that you can't scroll to the end of the credits, JacobF and Jeija are missing)
<img alt="screenshot before" src="https://github.com/minetest/minetest/assets/82708541/9af15cc8-2c64-407a-8412-f92c7fee3a40" width="512" />

After this PR on my Android device
<img alt="screenshot after" src="https://github.com/minetest/minetest/assets/82708541/0ba09320-ebf9-4dc2-8b90-fd52d50a8c03" width="512" />

## To do


This PR is a Ready for Review.

## How to test

Open the About tab. Verify that you can scroll to the end of the credits, both on desktop and on Android.
