### PR TITLE
Clarify `get_translated_string` string argument

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4114,7 +4114,7 @@ that:
 `minetest.get_translated_string(lang_code, string)`: resolves translations in
 the given string just like the client would, using the translation files for
 `lang_code`. For this to have any effect, the string needs to contain translation
-markup, e.g. `minetest.get_translated_string("fr", S("Hello")`.
+markup, e.g. `minetest.get_translated_string("fr", S("Hello"))`.
 
 The `lang_code` to use for a given player can be retrieved from
 the table returned by `minetest.get_player_information(name)`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4111,10 +4111,10 @@ On some specific cases, server translation could be useful. For example, filter
 a list on labels and send results to client. A method is supplied to achieve
 that:
 
-`minetest.get_translated_string(lang_code, S(string))`: resolves translations in
+`minetest.get_translated_string(lang_code, string)`: resolves translations in
 the given string just like the client would, using the translation files for
 `lang_code`. For this to have any effect, the string needs to contain translation
-markup (as made by `minetest.translate` or `S()`).
+markup, e.g. `minetest.get_translated_string("fr", S("Hello")`.
 
 The `lang_code` to use for a given player can be retrieved from
 the table returned by `minetest.get_player_information(name)`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4111,9 +4111,9 @@ On some specific cases, server translation could be useful. For example, filter
 a list on labels and send results to client. A method is supplied to achieve
 that:
 
-`minetest.get_translated_string(lang_code, string)`: Translates `string` using
-translations for `lang_code` language. It gives the same result as if the string
-was translated by the client.
+`minetest.get_translated_string(lang_code, S(string))`: returns the translation in
+`lang_code` language of `S(string)`. It gives the same result as if the string was
+translated by the client.
 
 The `lang_code` to use for a given player can be retrieved from
 the table returned by `minetest.get_player_information(name)`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4111,9 +4111,10 @@ On some specific cases, server translation could be useful. For example, filter
 a list on labels and send results to client. A method is supplied to achieve
 that:
 
-`minetest.get_translated_string(lang_code, S(string))`: resolves translations in the given string
-just like the client would, using the translation files for `lang_code`.
-For this to have any effect, the string needs to contain translation markup (as made by `minetest.translate`, `get_translator`, or `S()`).
+`minetest.get_translated_string(lang_code, S(string))`: resolves translations in
+the given string just like the client would, using the translation files for
+`lang_code`. For this to have any effect, the string needs to contain translation
+markup (as made by `minetest.translate`, `get_translator`, or `S()`).
 
 The `lang_code` to use for a given player can be retrieved from
 the table returned by `minetest.get_player_information(name)`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4114,7 +4114,7 @@ that:
 `minetest.get_translated_string(lang_code, S(string))`: resolves translations in
 the given string just like the client would, using the translation files for
 `lang_code`. For this to have any effect, the string needs to contain translation
-markup (as made by `minetest.translate`, `get_translator`, or `S()`).
+markup (as made by `minetest.translate` or `S()`).
 
 The `lang_code` to use for a given player can be retrieved from
 the table returned by `minetest.get_player_information(name)`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4111,9 +4111,9 @@ On some specific cases, server translation could be useful. For example, filter
 a list on labels and send results to client. A method is supplied to achieve
 that:
 
-`minetest.get_translated_string(lang_code, S(string))`: returns the translation in
-`lang_code` language of `S(string)`. It gives the same result as if the string was
-translated by the client.
+`minetest.get_translated_string(lang_code, S(string))`: resolves translations in the given string
+just like the client would, using the translation files for `lang_code`.
+For this to have any effect, the string needs to contain translation markup (as made by `minetest.translate`, `get_translator`, or `S()`).
 
 The `lang_code` to use for a given player can be retrieved from
 the table returned by `minetest.get_player_information(name)`.


### PR DESCRIPTION
It took me a while to understand that `string` had to be the translated string. To be more exact, I looked for issues about `get_translated_string` to see if the function was broken, and code snippets in #9845 told me that I needed to provide the translated string. I don't think it's intuitive at all

## To do

This PR is Ready for Review.

## How to test
👁️ 
