### PR TITLE
Allow putting all media in respective folder in the game root

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -97,9 +97,11 @@ The game directory can contain the following files:
   In the same format as the one in builtin.
   This settingtypes.txt will be parsed by the menu and the settings will be
   displayed in the "Games" category in the advanced settings tab.
-* If the game contains a folder called `textures` the server will load it as a
-  texturepack, overriding mod textures.
-  Any server texturepack will override mod textures and the game texturepack.
+* `textures`, `sounds`, `media`, `models` and `locale` folders can be put in
+  the game folder, intended to contain the respective media type. These
+  folders take precedence if media files with the same name exist in a mod.
+  * A texture pack can be put in `textures` to be loaded by the server and
+    applies `override.txt` if one exists.
 
 Menu images
 -----------

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2594,7 +2594,9 @@ void Server::fillMediaCache()
 	// ordered in descending priority
 	paths.push_back(getBuiltinLuaPath() + DIR_DELIM + "locale");
 	fs::GetRecursiveDirs(paths, porting::path_user + DIR_DELIM + "textures" + DIR_DELIM + "server");
-	fs::GetRecursiveDirs(paths, m_gamespec.path + DIR_DELIM + "textures");
+	for (auto name : ServerModManager::media_folders)
+		fs::GetRecursiveDirs(paths, m_gamespec.path + DIR_DELIM + name);
+
 	m_modmgr->getModsMediaPaths(paths);
 
 	// Collect media file information from paths into cache

--- a/src/server/mods.cpp
+++ b/src/server/mods.cpp
@@ -24,6 +24,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "content/subgames.h"
 #include "porting.h"
 
+const char *ServerModManager::media_folders[5] = {
+	"textures", "sounds", "media", "models", "locale"
+};
+
 /**
  * Manage server mods
  *
@@ -99,10 +103,7 @@ void ServerModManager::getModsMediaPaths(std::vector<std::string> &paths) const
 	const auto &mods = configuration.getMods();
 	for (auto it = mods.crbegin(); it != mods.crend(); it++) {
 		const ModSpec &spec = *it;
-		fs::GetRecursiveDirs(paths, spec.path + DIR_DELIM + "textures");
-		fs::GetRecursiveDirs(paths, spec.path + DIR_DELIM + "sounds");
-		fs::GetRecursiveDirs(paths, spec.path + DIR_DELIM + "media");
-		fs::GetRecursiveDirs(paths, spec.path + DIR_DELIM + "models");
-		fs::GetRecursiveDirs(paths, spec.path + DIR_DELIM + "locale");
+		for (auto name : media_folders)
+			fs::GetRecursiveDirs(paths, spec.path + DIR_DELIM + name);
 	}
 }

--- a/src/server/mods.h
+++ b/src/server/mods.h
@@ -70,4 +70,6 @@ public:
 	 * @param paths result vector
 	 */
 	void getModsMediaPaths(std::vector<std::string> &paths) const;
+
+	static const char *media_folders[5];
 };


### PR DESCRIPTION
Closes #13927.

This PR makes it possible to put all media in their respective folder in the game root. The motivation for doing so can be seen in the issue for it. (TL:DR - Developing games from scratch without making use of the mod system)

## To do
This PR is a Ready for Review.

## How to test
Put some media into one of the folders in a game, and see that they load. (Also see that media still is able to load from mods)