### PR TITLE
Continuation of x2048's Cascaded Shadows

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -498,14 +498,14 @@ shadow_strength_gamma (Shadow strength gamma) float 1.0 0.1 10.0
 #    Maximum distance to render shadows.
 #
 #    Requires: shaders, enable_dynamic_shadows, opengl
-shadow_map_max_distance (Shadow map max distance in nodes to render shadows) float 140.0 10.0 1000.0
+shadow_map_max_distance (Shadow map max distance in nodes to render shadows) float 200.0 10.0 1000.0
 
 #    Texture size to render the shadow map on.
 #    This must be a power of two.
 #    Bigger numbers create better shadows but it is also more expensive.
 #
 #    Requires: shaders, enable_dynamic_shadows, opengl
-shadow_map_texture_size (Shadow map texture size) int 2048 128 8192
+shadow_map_texture_size (Shadow map texture size) int 1024 128 8192
 
 #    Sets shadow texture quality to 32 bits.
 #    On false, 16 bits texture will be used.
@@ -524,8 +524,10 @@ shadow_poisson_filter (Poisson filtering) bool true
 #    This simulates the soft shadows effect by applying a PCF or Poisson disk
 #    but also uses more resources.
 #
+#    Note: Setting 1 enables simple 2x2 bilinear filter
+#
 #    Requires: shaders, enable_dynamic_shadows, opengl
-shadow_filters (Shadow filter quality) enum 1 0,1,2
+shadow_filters (Shadow filter quality) enum 1 0,1,2,3
 
 #    Enable colored shadows.
 #    On true translucent nodes cast colored shadows. This is expensive.
@@ -536,10 +538,10 @@ shadow_map_color (Colored shadows) bool false
 #    Spread a complete update of shadow map over given number of frames.
 #    Higher values might make shadows laggy, lower values
 #    will consume more resources.
-#    Minimum value: 1; maximum value: 16
+#    Minimum value: 1; maximum value: 64
 #
 #    Requires: shaders, enable_dynamic_shadows, opengl
-shadow_update_frames (Map shadows update frames) int 8 1 16
+shadow_update_frames (Map shadows update frames) int 16 1 64
 
 #    Set the soft shadow radius size.
 #    Lower values mean sharper shadows, bigger values mean softer shadows.

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -15,18 +15,25 @@ uniform float animationTimer;
 	// shadow uniforms
 	uniform vec3 v_LightDirection;
 	uniform float f_textureresolution;
-	uniform mat4 m_ShadowViewProj;
 	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
-	uniform vec4 CameraPos;
-	uniform float xyPerspectiveBias0;
-	uniform float xyPerspectiveBias1;
+	uniform float zPerspectiveBias;
 
+	struct ShadowCascade {
+		mat4 mViewProj; // view-projection matrix
+		float boundary; // boundary of the cascade in scene space
+		vec3 center; // center of the frustum in scene space
+	};
+
+	#define MAX_SHADOW_CASCADES 3
+
+	uniform ShadowCascade shadowCascades[MAX_SHADOW_CASCADES];
+	uniform int cascadeCount;
+
+	varying vec3 shadow_world_position;
 	varying float adj_shadow_strength;
 	varying float cosLight;
 	varying float f_normal_length;
-	varying vec3 shadow_position;
-	varying float perspective_factor;
 #endif
 
 
@@ -51,16 +58,37 @@ varying float vIDiff;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 
-// assuming near is always 1.0
-float getLinearDepth()
+float debug = 0.0;
+
+int getCascade()
 {
-	return 2.0 * f_shadowfar / (f_shadowfar + 1.0 - (2.0 * gl_FragCoord.z - 1.0) * (f_shadowfar - 1.0));
+	for (int i = 0; i < MAX_SHADOW_CASCADES; i++) {
+		if (i == cascadeCount)
+			break;
+		vec3 center_to_fragment = shadow_world_position - shadowCascades[i].center;
+		float projected_distance = length(center_to_fragment - v_LightDirection * dot(center_to_fragment, v_LightDirection));
+		if (i == 1)
+			debug = projected_distance / shadowCascades[i].boundary;
+
+		if (shadowCascades[i].boundary * 0.9 > projected_distance)
+			return i;
+	}
+	return cascadeCount - 1;
 }
 
-vec3 getLightSpacePosition()
+int cascade = getCascade();
+
+vec3 getLightSpacePosition(int cascade)
 {
-	return shadow_position * 0.5 + 0.5;
+	float cosine = dot(normalize(vNormal), -v_LightDirection); // cos(angle(light, normal))
+	float offset = pow(1. - pow(cosine, 2.), 0.5); // sin(angle...)
+	offset *= 2. * shadowCascades[cascade].boundary / f_textureresolution * (cosine > 0. ? -1. : 1.);
+	vec4 shadow_position = shadowCascades[cascade].mViewProj * vec4(shadow_world_position + vNormal * offset, 1.0);
+	shadow_position /= shadow_position.w;
+	shadow_position.z = shadow_position.z * zPerspectiveBias - 1e-3 * shadowCascades[cascade].boundary / f_textureresolution;
+	return shadow_position.xyz * 0.5 + 0.5;
 }
+
 // custom smoothstep implementation because it's not defined in glsl1.2
 // https://docs.gl/sl4/smoothstep
 float mtsmoothstep(in float edge0, in float edge1, in float x)
@@ -96,13 +124,41 @@ vec4 getHardShadowColor(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	vec4 texDepth = texture2D(shadowsampler, smTexCoord.xy).rgba;
 
 	float visibility = step(0.0, realDistance - texDepth.r);
-	vec4 result = vec4(visibility, vec3(0.0,0.0,0.0));//unpackColor(texDepth.g));
+	vec4 result = vec4(visibility, vec3(0.0,0.0,0.0));
 	if (visibility < 0.1) {
-		visibility = step(0.0, realDistance - texDepth.b);
-		result = vec4(visibility, unpackColor(texDepth.a));
+		visibility = step(0.0, realDistance - texDepth.g);
+		result = vec4(visibility, unpackColor(texDepth.b));
 	}
 	return result;
 }
+
+#if SHADOW_FILTER == 1
+vec4 getFilteredShadowColor(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
+{
+	vec2 texelSize = vec2(1. / f_textureresolution / cascadeCount, 1. / f_textureresolution);
+	vec2 texelCoord = smTexCoord * vec2(f_textureresolution * cascadeCount, f_textureresolution);
+
+	vec2 fraction = texelCoord - floor(texelCoord);
+	float scale = 1.0;
+	vec2 sampleTexCoord = (floor(texelCoord) + 0.5 * scale) * texelSize;
+
+	float texDepth = texture2D(shadowsampler, sampleTexCoord).r;
+	vec4 visibility = (1. - fraction.x) * (1. - fraction.y) * getHardShadowColor(shadowsampler, sampleTexCoord, realDistance);
+
+	sampleTexCoord.x += texelSize.x * scale;
+	texDepth = texture2D(shadowsampler, sampleTexCoord).r;
+	visibility += fraction.x * (1. - fraction.y) * getHardShadowColor(shadowsampler, sampleTexCoord, realDistance);
+
+	sampleTexCoord.y += texelSize.y * scale;
+	texDepth = texture2D(shadowsampler, sampleTexCoord).r;
+	visibility += fraction.x * fraction.y * getHardShadowColor(shadowsampler, sampleTexCoord, realDistance);
+
+	sampleTexCoord.x -= texelSize.x * scale;
+	texDepth = texture2D(shadowsampler, sampleTexCoord).r;
+	visibility += (1. - fraction.x) * fraction.y * getHardShadowColor(shadowsampler, sampleTexCoord, realDistance);
+	return visibility;
+}
+#endif
 
 #else
 
@@ -113,13 +169,41 @@ float getHardShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance
 	return visibility;
 }
 
+#if SHADOW_FILTER == 1
+float getFilteredShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
+{
+	vec2 texelSize = vec2(1. / f_textureresolution / cascadeCount, 1. / f_textureresolution);
+	vec2 texelCoord = smTexCoord * vec2(f_textureresolution * cascadeCount, f_textureresolution);
+
+	vec2 fraction = texelCoord - floor(texelCoord);
+	float scale = 1.0;
+	vec2 sampleTexCoord = (floor(texelCoord) + 0.5 * scale) * texelSize;
+
+	float texDepth = texture2D(shadowsampler, sampleTexCoord).r;
+	float visibility = (1. - fraction.x) * (1. - fraction.y) * getHardShadow(shadowsampler, sampleTexCoord, realDistance);
+
+	sampleTexCoord.x += texelSize.x * scale;
+	texDepth = texture2D(shadowsampler, sampleTexCoord).r;
+	visibility += fraction.x * (1. - fraction.y) * getHardShadow(shadowsampler, sampleTexCoord, realDistance);
+
+	sampleTexCoord.y += texelSize.y * scale;
+	texDepth = texture2D(shadowsampler, sampleTexCoord).r;
+	visibility += fraction.x * fraction.y * getHardShadow(shadowsampler, sampleTexCoord, realDistance);
+
+	sampleTexCoord.x -= texelSize.x * scale;
+	texDepth = texture2D(shadowsampler, sampleTexCoord).r;
+	visibility += (1. - fraction.x) * fraction.y * getHardShadow(shadowsampler, sampleTexCoord, realDistance);
+	return visibility;
+}
+#endif
+
 #endif
 
 
-#if SHADOW_FILTER == 2
+#if SHADOW_FILTER == 3
 	#define PCFBOUND 2.0 // 5x5
 	#define PCFSAMPLES 25
-#elif SHADOW_FILTER == 1
+#elif SHADOW_FILTER == 2
 	#define PCFBOUND 1.0 // 3x3
 	#define PCFSAMPLES 9
 #else
@@ -155,19 +239,18 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	float y, x;
 	float depth = getHardShadowDepth(shadowsampler, smTexCoord.xy, realDistance);
 	// A factor from 0 to 1 to reduce blurring of short shadows
-	float sharpness_factor = 1.0;
+	float sharpness_factor = 0.0;
 	// conversion factor from shadow depth to blur radius
-	float depth_to_blur = f_shadowfar / SOFTSHADOWRADIUS / xyPerspectiveBias0;
+	float depth_to_blur = f_shadowfar / SOFTSHADOWRADIUS;
 	if (depth > 0.0 && f_normal_length > 0.0)
-		// 5 is empirical factor that controls how fast shadow loses sharpness
-		sharpness_factor = clamp(5 * depth * depth_to_blur, 0.0, 1.0);
+		sharpness_factor = clamp(2e-1 * depth * depth_to_blur, 0.0, 1.0);
 	depth = 0.0;
 
-	float world_to_texture = xyPerspectiveBias1 / perspective_factor / perspective_factor
-			* f_textureresolution / 2.0 / f_shadowfar;
+	float world_to_texture = f_textureresolution / 2. / shadowCascades[cascade].boundary;
 	float world_radius = 0.2; // shadow blur radius in world float coordinates, e.g. 0.2 = 0.02 of one node
+	float base_radius = max(BASEFILTERRADIUS, SOFTSHADOWRADIUS / 5.);
 
-	return max(BASEFILTERRADIUS * f_textureresolution / 4096.0,  sharpness_factor * world_radius * world_to_texture * SOFTSHADOWRADIUS);
+	return max(base_radius,  sharpness_factor * world_radius * world_to_texture * SOFTSHADOWRADIUS);
 }
 
 #ifdef POISSON_FILTER
@@ -239,9 +322,13 @@ const vec2[64] poissonDisk = vec2[64](
 );
 
 #ifdef COLORED_SHADOWS
-
 vec4 getShadowColor(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 {
+#if SHADOW_FILTER == 0
+	return getHardShadowColor(shadowsampler, smTexCoord, realDistance);
+#elif SHADOW_FILTER == 1
+	return getFilteredShadowColor(shadowsampler, smTexCoord, realDistance);
+#else
 	float radius = getPenumbraRadius(shadowsampler, smTexCoord, realDistance);
 	if (radius < 0.1) {
 		// we are in the middle of even brightness, no need for filtering
@@ -263,12 +350,18 @@ vec4 getShadowColor(sampler2D shadowsampler, vec2 smTexCoord, float realDistance
 	}
 
 	return visibility / samples;
+#endif
 }
 
 #else
 
 float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 {
+#if SHADOW_FILTER == 0
+	return getHardShadow(shadowsampler, smTexCoord, realDistance);
+#elif SHADOW_FILTER == 1
+	return getFilteredShadow(shadowsampler, smTexCoord, realDistance);
+#else
 	float radius = getPenumbraRadius(shadowsampler, smTexCoord, realDistance);
 	if (radius < 0.1) {
 		// we are in the middle of even brightness, no need for filtering
@@ -290,6 +383,7 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 	}
 
 	return visibility / samples;
+#endif
 }
 
 #endif
@@ -301,6 +395,11 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 
 vec4 getShadowColor(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 {
+#if SHADOW_FILTER == 0
+	return getHardShadowColor(shadowsampler, smTexCoord, realDistance);
+#elif SHADOW_FILTER == 1
+	return getFilteredShadowColor(shadowsampler, smTexCoord, realDistance);
+#else
 	float radius = getPenumbraRadius(shadowsampler, smTexCoord, realDistance);
 	if (radius < 0.1) {
 		// we are in the middle of even brightness, no need for filtering
@@ -324,11 +423,17 @@ vec4 getShadowColor(sampler2D shadowsampler, vec2 smTexCoord, float realDistance
 	}
 
 	return visibility / max(n, 1.0);
+#endif
 }
 
 #else
 float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 {
+#if SHADOW_FILTER == 0
+	return getHardShadow(shadowsampler, smTexCoord, realDistance);
+#elif SHADOW_FILTER == 1
+	return getFilteredShadow(shadowsampler, smTexCoord, realDistance);
+#else
 	float radius = getPenumbraRadius(shadowsampler, smTexCoord, realDistance);
 	if (radius < 0.1) {
 		// we are in the middle of even brightness, no need for filtering
@@ -352,13 +457,13 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 	}
 
 	return visibility / max(n, 1.0);
+#endif
 }
 
 #endif
 
 #endif
 #endif
-
 
 void main(void)
 {
@@ -386,14 +491,22 @@ void main(void)
 	if (f_shadow_strength > 0.0) {
 		float shadow_int = 0.0;
 		vec3 shadow_color = vec3(0.0, 0.0, 0.0);
-		vec3 posLightSpace = getLightSpacePosition();
 
-		float distance_rate = (1.0 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 10.0));
-		if (max(abs(posLightSpace.x - 0.5), abs(posLightSpace.y - 0.5)) > 0.5)
-			distance_rate = 0.0;
+		vec3 posLightSpace = getLightSpacePosition(cascade); // 0..1 within a single cascade in the shadow map
+
+		float distance_rate = 1.0;
+		if (cascade == cascadeCount - 1) {
+			distance_rate = (1.0 - pow(clamp(2.0 * length(posLightSpace.xy - 0.5),0.0,1.0), 10.0));
+			if (max(abs(posLightSpace.x - 0.5), abs(posLightSpace.y - 0.5)) > 0.5)
+				distance_rate = 0.0;
+		}
+
 		float f_adj_shadow_strength = max(adj_shadow_strength - mtsmoothstep(0.9, 1.1, posLightSpace.z),0.0);
 
 		if (distance_rate > 1e-7) {
+
+			// shift posLightSpace to the right cascade in the shadow map
+			posLightSpace.x = (posLightSpace.x + float(cascade)) / cascadeCount;
 
 #ifdef COLORED_SHADOWS
 			vec4 visibility;
@@ -421,7 +534,7 @@ void main(void)
 
 		// Apply self-shadowing when light falls at a narrow angle to the surface
 		// Cosine of the cut-off angle.
-		const float self_shadow_cutoff_cosine = 0.14;
+		const float self_shadow_cutoff_cosine = 0.035;
 		if (f_normal_length != 0 && cosLight < self_shadow_cutoff_cosine) {
 			shadow_int = max(shadow_int, 1 - clamp(cosLight, 0.0, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);
 			shadow_color = mix(vec3(0.0), shadow_color, min(cosLight, self_shadow_cutoff_cosine)/self_shadow_cutoff_cosine);

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -1,37 +1,45 @@
 uniform mat4 mWorld;
+// Color of the light emitted by the sun.
 uniform vec3 dayLight;
 uniform vec3 eyePosition;
+
+// The cameraOffset is the current center of the visible world.
+uniform vec3 cameraOffset;
 uniform float animationTimer;
 uniform vec4 emissiveColor;
-uniform vec3 cameraOffset;
-
 
 varying vec3 vNormal;
 varying vec3 vPosition;
+// World position in the visible world (i.e. relative to the cameraOffset.)
+// This can be used for many shader effects without loss of precision.
+// If the absolute position is required it can be calculated with
+// cameraOffset + worldPosition (for large coordinates the limits of float
+// precision must be considered).
 varying vec3 worldPosition;
 varying lowp vec4 varColor;
+// The centroid keyword ensures that after interpolation the texture coordinates
+// lie within the same bounds when MSAA is en- and disabled.
+// This fixes the stripes problem with nearest-neighbor textures and MSAA.
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
 #else
 centroid varying vec2 varTexCoord;
 #endif
-
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	// shadow uniforms
 	uniform vec3 v_LightDirection;
 	uniform float f_textureresolution;
-	uniform mat4 m_ShadowViewProj;
-	uniform float f_shadowfar;
 	uniform float f_shadow_strength;
 	uniform float f_timeofday;
-	uniform vec4 CameraPos;
 
 	varying float cosLight;
+	varying float normalOffsetScale;
 	varying float adj_shadow_strength;
 	varying float f_normal_length;
-	varying vec3 shadow_position;
-	varying float perspective_factor;
+	varying vec3 shadow_world_position;
 #endif
+
+varying float area_enable_parallax;
 
 varying vec3 eyeVec;
 varying float nightRatio;
@@ -40,37 +48,8 @@ const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
 varying float vIDiff;
 const float e = 2.718281828459;
 const float BS = 10.0;
-uniform float xyPerspectiveBias0;
-uniform float xyPerspectiveBias1;
-uniform float zPerspectiveBias;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
-
-vec4 getRelativePosition(in vec4 position)
-{
-	vec2 l = position.xy - CameraPos.xy;
-	vec2 s = l / abs(l);
-	s = (1.0 - s * CameraPos.xy);
-	l /= s;
-	return vec4(l, s);
-}
-
-float getPerspectiveFactor(in vec4 relativePosition)
-{
-	float pDistance = length(relativePosition.xy);
-	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-	return pFactor;
-}
-
-vec4 applyPerspectiveDistortion(in vec4 position)
-{
-	vec4 l = getRelativePosition(position);
-	float pFactor = getPerspectiveFactor(l);
-	l.xy /= pFactor;
-	position.xy = l.xy * l.zw + CameraPos.xy;
-	position.z *= zPerspectiveBias;
-	return position;
-}
 
 // custom smoothstep implementation because it's not defined in glsl1.2
 // https://docs.gl/sl4/smoothstep
@@ -112,6 +91,12 @@ void main(void)
 		: directional_ambient(normalize(inVertexNormal));
 #endif
 
+
+	// Calculate color.
+	// Red, green and blue components are pre-multiplied with
+	// the brightness, so now we have to multiply these
+	// colors with the color of the incoming light.
+	// The pre-baked colors are halved to prevent overflow.
 #ifdef GL_ES
 	vec4 color = inVertexColor.bgra;
 #else
@@ -134,36 +119,19 @@ void main(void)
 
 	varColor = clamp(color, 0.0, 1.0);
 
-
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	if (f_shadow_strength > 0.0) {
-		vec3 nNormal = normalize(vNormal);
+
+		shadow_world_position = (mWorld * inVertexPosition).xyz;
+
 		f_normal_length = length(vNormal);
 
-		/* normalOffsetScale is in world coordinates (1/10th of a meter)
-		   z_bias is in light space coordinates */
-		float normalOffsetScale, z_bias;
-		float pFactor = getPerspectiveFactor(getRelativePosition(m_ShadowViewProj * mWorld * inVertexPosition));
-		if (f_normal_length > 0.0) {
+		vec3 nNormal;
+		if (f_normal_length > 0.0)
 			nNormal = normalize(vNormal);
-			cosLight = max(1e-5, dot(nNormal, -v_LightDirection));
-			float sinLight = pow(1.0 - pow(cosLight, 2.0), 0.5);
-			normalOffsetScale = 0.1 * pFactor * pFactor * sinLight * min(f_shadowfar, 500.0) /
-					xyPerspectiveBias1 / f_textureresolution;
-			z_bias = 1e3 * sinLight / cosLight * (0.5 + f_textureresolution / 1024.0);
-		}
-		else {
-			nNormal = vec3(0.0);
-			cosLight = clamp(dot(v_LightDirection, normalize(vec3(v_LightDirection.x, 0.0, v_LightDirection.z))), 1e-2, 1.0);
-			float sinLight = pow(1.0 - pow(cosLight, 2.0), 0.5);
-			normalOffsetScale = 0.0;
-			z_bias = 3.6e3 * sinLight / cosLight;
-		}
-		z_bias *= pFactor * pFactor / f_textureresolution / f_shadowfar;
-
-		shadow_position = applyPerspectiveDistortion(m_ShadowViewProj * mWorld * (inVertexPosition + vec4(normalOffsetScale * nNormal, 0.0))).xyz;
-		shadow_position.z -= z_bias;
-		perspective_factor = pFactor;
+		else
+			nNormal = normalize(vec3(-v_LightDirection.x, 0.0, -v_LightDirection.z));
+		cosLight = dot(nNormal, -v_LightDirection);
 
 		if (f_timeofday < 0.2) {
 			adj_shadow_strength = f_shadow_strength * 0.5 *

--- a/client/shaders/shadow_shaders/pass1_fragment.glsl
+++ b/client/shaders/shadow_shaders/pass1_fragment.glsl
@@ -1,11 +1,13 @@
 uniform sampler2D ColorMapSampler;
+uniform int Cascade;
+
 varying vec4 tPos;
 
 void main()
 {
 	vec4 col = texture2D(ColorMapSampler, gl_TexCoord[0].st);
 
-	if (col.a < 0.70)
+	if (Cascade < 2 && col.a < 0.70)
 		discard;
 
 	float depth = 0.5 + tPos.z * 0.5;

--- a/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_trans_vertex.glsl
@@ -1,36 +1,15 @@
 uniform mat4 LightMVP; // world matrix
-uniform vec4 CameraPos;
+uniform float zPerspectiveBias;
+
 varying vec4 tPos;
 #ifdef COLORED_SHADOWS
 varying vec3 varColor;
 #endif
 
-uniform float xyPerspectiveBias0;
-uniform float xyPerspectiveBias1;
-uniform float zPerspectiveBias;
-
-vec4 getRelativePosition(in vec4 position)
-{
-	vec2 l = position.xy - CameraPos.xy;
-	vec2 s = l / abs(l);
-	s = (1.0 - s * CameraPos.xy);
-	l /= s;
-	return vec4(l, s);
-}
-
-float getPerspectiveFactor(in vec4 relativePosition)
-{
-	float pDistance = length(relativePosition.xy);
-	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-	return pFactor;
-}
 
 vec4 applyPerspectiveDistortion(in vec4 position)
 {
-	vec4 l = getRelativePosition(position);
-	float pFactor = getPerspectiveFactor(l);
-	l.xy /= pFactor;
-	position.xy = l.xy * l.zw + CameraPos.xy;
+	position /= position.w;
 	position.z *= zPerspectiveBias;
 	return position;
 }

--- a/client/shaders/shadow_shaders/pass1_vertex.glsl
+++ b/client/shaders/shadow_shaders/pass1_vertex.glsl
@@ -1,33 +1,12 @@
 uniform mat4 LightMVP; // world matrix
-uniform vec4 CameraPos; // camera position
-varying vec4 tPos;
-
-uniform float xyPerspectiveBias0;
-uniform float xyPerspectiveBias1;
 uniform float zPerspectiveBias;
 
-vec4 getRelativePosition(in vec4 position)
-{
-	vec2 l = position.xy - CameraPos.xy;
-	vec2 s = l / abs(l);
-	s = (1.0 - s * CameraPos.xy);
-	l /= s;
-	return vec4(l, s);
-}
+varying vec4 tPos;
 
-float getPerspectiveFactor(in vec4 relativePosition)
-{
-	float pDistance = length(relativePosition.xy);
-	float pFactor = pDistance * xyPerspectiveBias0 + xyPerspectiveBias1;
-	return pFactor;
-}
 
 vec4 applyPerspectiveDistortion(in vec4 position)
 {
-	vec4 l = getRelativePosition(position);
-	float pFactor = getPerspectiveFactor(l);
-	l.xy /= pFactor;
-	position.xy = l.xy * l.zw + CameraPos.xy;
+	position /= position.w;
 	position.z *= zPerspectiveBias;
 	return position;
 }

--- a/client/shaders/shadow_shaders/pass2_fragment.glsl
+++ b/client/shaders/shadow_shaders/pass2_fragment.glsl
@@ -6,17 +6,15 @@ uniform sampler2D ShadowMapSamplerdynamic;
 
 void main() {
 
-#ifdef COLORED_SHADOWS
-	vec2 first_depth = texture2D(ShadowMapClientMap, gl_TexCoord[0].st).rg;
-	vec2 depth_splitdynamics = vec2(texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st).r, 0.0);
-	if (first_depth.r > depth_splitdynamics.r)
-		first_depth = depth_splitdynamics;
-	vec2 depth_color = texture2D(ShadowMapClientMapTraslucent, gl_TexCoord[1].st).rg;
-	gl_FragColor = vec4(first_depth.r, first_depth.g, depth_color.r, depth_color.g);
-#else
 	float first_depth = texture2D(ShadowMapClientMap, gl_TexCoord[0].st).r;
-	float depth_splitdynamics = texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st).r;
-	first_depth = min(first_depth, depth_splitdynamics);
+	if (gl_TexCoord[2].s < 2./3.) {
+		float depth_splitdynamics = texture2D(ShadowMapSamplerdynamic, gl_TexCoord[2].st * vec2(1.5, 1.)).r;
+		first_depth = min(first_depth, depth_splitdynamics);
+	}
+#ifdef COLORED_SHADOWS
+	vec2 depth_color = texture2D(ShadowMapClientMapTraslucent, gl_TexCoord[1].st).rg;
+	gl_FragColor = vec4(first_depth, depth_color.r, depth_color.g, 0.);
+#else
 	gl_FragColor = vec4(first_depth, 0.0, 0.0, 1.0);
 #endif
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -437,13 +437,13 @@
 
 #    Maximum distance to render shadows.
 #    type: float min: 10 max: 1000
-# shadow_map_max_distance = 140.0
+# shadow_map_max_distance = 200.0
 
 #    Texture size to render the shadow map on.
 #    This must be a power of two.
 #    Bigger numbers create better shadows but it is also more expensive.
 #    type: int min: 128 max: 8192
-# shadow_map_texture_size = 2048
+# shadow_map_texture_size = 1024
 
 #    Sets shadow texture quality to 32 bits.
 #    On false, 16 bits texture will be used.
@@ -459,7 +459,8 @@
 #    Define shadow filtering quality.
 #    This simulates the soft shadows effect by applying a PCF or Poisson disk
 #    but also uses more resources.
-#    type: enum values: 0, 1, 2
+#    Value of 1 enables fast bilinear filter
+#    type: enum values: 0, 1, 2, 3
 # shadow_filters = 1
 
 #    Enable colored shadows.
@@ -470,9 +471,9 @@
 #    Spread a complete update of shadow map over given number of frames.
 #    Higher values might make shadows laggy, lower values
 #    will consume more resources.
-#    Minimum value: 1; maximum value: 16
-#    type: int min: 1 max: 16
-# shadow_update_frames = 8
+#    Minimum value: 1; maximum value: 64
+#    type: int min: 1 max: 64
+# shadow_update_frames = 16 
 
 #    Set the soft shadow radius size.
 #    Lower values mean sharper shadows, bigger values mean softer shadows.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -579,7 +579,6 @@ void Client::step(float dtime)
 	{
 		int num_processed_meshes = 0;
 		std::vector<v3s16> blocks_to_ack;
-		bool force_update_shadows = false;
 		MeshUpdateResult r;
 		while (m_mesh_update_manager->getNextResult(r))
 		{
@@ -619,8 +618,6 @@ void Client::step(float dtime)
 					else {
 						// Replace with the new mesh
 						block->mesh = r.mesh;
-						if (r.urgent)
-							force_update_shadows = true;
 					}
 				}
 			} else {
@@ -660,10 +657,6 @@ void Client::step(float dtime)
 
 		if (num_processed_meshes > 0)
 			g_profiler->graphAdd("num_processed_meshes", num_processed_meshes);
-
-		auto shadow_renderer = RenderingEngine::get_shadow_renderer();
-		if (shadow_renderer && force_update_shadows)
-			shadow_renderer->setForceUpdateShadowMap();
 	}
 
 	/*

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1096,9 +1096,13 @@ void ClientMap::PrintInfo(std::ostream &out)
 	out<<"ClientMap: ";
 }
 
-void ClientMap::renderMapShadows(video::IVideoDriver *driver,
+void ClientMap::renderMapShadows(u8 cascade, video::IVideoDriver *driver,
 		const video::SMaterial &material, s32 pass, int frame, int total_frames)
 {
+	// don't draw if the cascade is not defined yet
+	if (cascade >= m_drawlist_shadow.size())
+		return;
+
 	bool is_transparent_pass = pass != scene::ESNRP_SOLID;
 	std::string prefix;
 	if (is_transparent_pass)
@@ -1109,14 +1113,21 @@ void ClientMap::renderMapShadows(video::IVideoDriver *driver,
 	u32 drawcall_count = 0;
 	u32 vertex_count = 0;
 
+	/*
+		Update transparent meshes
+	*/
+	if (is_transparent_pass)
+		updateTransparentMeshBuffers();
+
 	MeshBufListMaps grouped_buffers;
 	std::vector<DrawDescriptor> draw_order;
 
+	drawlist_t &drawlist = m_drawlist_shadow.at(cascade);
 
 	std::size_t count = 0;
-	std::size_t meshes_per_frame = m_drawlist_shadow.size() / total_frames + 1;
+	std::size_t meshes_per_frame = drawlist.size() / total_frames + 1;
 	std::size_t low_bound = is_transparent_pass ? 0 : meshes_per_frame * frame;
-	std::size_t high_bound = is_transparent_pass ? m_drawlist_shadow.size() : meshes_per_frame * (frame + 1);
+	std::size_t high_bound = is_transparent_pass ? drawlist.size() : meshes_per_frame * (frame + 1);
 
 	// transparent pass should be rendered in one go
 	if (is_transparent_pass && frame != total_frames - 1) {
@@ -1124,7 +1135,7 @@ void ClientMap::renderMapShadows(video::IVideoDriver *driver,
 	}
 
 	const MeshGrid mesh_grid = m_client->getMeshGrid();
-	for (const auto &i : m_drawlist_shadow) {
+	for (const auto &i : drawlist) {
 		// only process specific part of the list & break early
 		++count;
 		if (count <= low_bound)
@@ -1238,18 +1249,29 @@ void ClientMap::renderMapShadows(video::IVideoDriver *driver,
 	g_profiler->avg(prefix + "material swaps [#]", material_swaps);
 }
 
+void ClientMap::allocateDrawListShadowCascades(u8 n_cascades)
+{
+	m_drawlist_shadow.resize(n_cascades);
+}
+
 /*
 	Custom update draw list for the pov of shadow light.
 */
-void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length)
+void ClientMap::updateDrawListShadowCascade(u8 cascade, v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length)
 {
+	// don't generate a draw list if the cascade is not defined yet
+	if (cascade >= m_drawlist_shadow.size())
+		return;
+
 	ScopeProfiler sp(g_profiler, "CM::updateDrawListShadow()", SPT_AVG);
 
-	for (auto &i : m_drawlist_shadow) {
+	drawlist_t &drawlist = m_drawlist_shadow.at(cascade);
+
+	for (auto &i : drawlist) {
 		MapBlock *block = i.second;
 		block->refDrop();
 	}
-	m_drawlist_shadow.clear();
+	drawlist.clear();
 
 	// Number of blocks currently loaded by the client
 	u32 blocks_loaded = 0;
@@ -1284,15 +1306,17 @@ void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir,
 			block->resetUsageTimer();
 
 			// Add to set
-			if (m_drawlist_shadow.emplace(block->getPos(), block).second) {
+			if (drawlist.emplace(block->getPos(), block).second) {
 				block->refGrab();
 			}
 		}
 	}
+	
+	std::string cascade_name = std::to_string(cascade);
 
-	g_profiler->avg("SHADOW MapBlock meshes in range [#]", blocks_in_range_with_mesh);
-	g_profiler->avg("SHADOW MapBlocks drawn [#]", m_drawlist_shadow.size());
-	g_profiler->avg("SHADOW MapBlocks loaded [#]", blocks_loaded);
+	g_profiler->avg("SHADOW MapBlock meshes in range " + cascade_name + "[#]", blocks_in_range_with_mesh);
+	g_profiler->avg("SHADOW MapBlocks drawn " + cascade_name + " [#]", drawlist.size());
+	g_profiler->avg("SHADOW MapBlocks loaded " + cascade_name + "[#]", blocks_loaded);
 }
 
 void ClientMap::reportMetrics(u64 save_time_us, u32 saved_blocks, u32 all_blocks)

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -99,12 +99,13 @@ public:
 	void updateDrawList();
 	// @brief Calculate statistics about the map and keep the blocks alive
 	void touchMapBlocks();
-	void updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length);
+	void allocateDrawListShadowCascades(u8 n_cascades);
+	void updateDrawListShadowCascade(u8 cascade, v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length);
 	// Returns true if draw list needs updating before drawing the next frame.
 	bool needsUpdateDrawList() { return m_needs_update_drawlist; }
 	void renderMap(video::IVideoDriver* driver, s32 pass);
 
-	void renderMapShadows(video::IVideoDriver *driver,
+	void renderMapShadows(u8 cascade, video::IVideoDriver *driver,
 			const video::SMaterial &material, s32 pass, int frame, int total_frames);
 
 	int getBackgroundBrightness(float max_d, u32 daylight_factor,
@@ -187,7 +188,8 @@ private:
 
 	std::map<v3s16, MapBlock*, MapBlockComparer> m_drawlist;
 	std::vector<MapBlock*> m_keeplist;
-	std::map<v3s16, MapBlock*> m_drawlist_shadow;
+	typedef std::map<v3s16, MapBlock*> drawlist_t;
+	std::vector<drawlist_t> m_drawlist_shadow; // cascades
 	bool m_needs_update_drawlist;
 
 	std::set<v2s16> m_last_drawn_sectors;

--- a/src/client/shader.h
+++ b/src/client/shader.h
@@ -82,23 +82,24 @@ public:
 
 template <typename T, std::size_t count, bool cache>
 class CachedShaderSetting {
-	const char *m_name;
+	const std::string m_name;
 	T m_sent[count];
 	bool has_been_set = false;
 	bool is_pixel;
 protected:
-	CachedShaderSetting(const char *name, bool is_pixel) :
+	CachedShaderSetting(const std::string &name, bool is_pixel) :
 		m_name(name), is_pixel(is_pixel)
 	{}
 public:
+	const std::string &getname() { return m_name; }
 	void set(const T value[count], video::IMaterialRendererServices *services)
 	{
 		if (cache && has_been_set && std::equal(m_sent, m_sent + count, value))
 			return;
 		if (is_pixel)
-			services->setPixelShaderConstant(services->getPixelShaderConstantID(m_name), value, count);
+			services->setPixelShaderConstant(services->getPixelShaderConstantID(m_name.c_str()), value, count);
 		else
-			services->setVertexShaderConstant(services->getVertexShaderConstantID(m_name), value, count);
+			services->setVertexShaderConstant(services->getVertexShaderConstantID(m_name.c_str()), value, count);
 
 		if (cache) {
 			std::copy(value, value + count, m_sent);
@@ -110,14 +111,14 @@ public:
 template <typename T, std::size_t count = 1, bool cache=true>
 class CachedPixelShaderSetting : public CachedShaderSetting<T, count, cache> {
 public:
-	CachedPixelShaderSetting(const char *name) :
+	CachedPixelShaderSetting(const std::string &name) :
 		CachedShaderSetting<T, count, cache>(name, true){}
 };
 
 template <typename T, std::size_t count = 1, bool cache=true>
 class CachedVertexShaderSetting : public CachedShaderSetting<T, count, cache> {
 public:
-	CachedVertexShaderSetting(const char *name) :
+	CachedVertexShaderSetting(const std::string &name) :
 		CachedShaderSetting<T, count, cache>(name, false){}
 };
 

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -191,7 +191,8 @@ void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool fo
 {
 	client->getEnv().getClientMap().allocateDrawListShadowCascades(getCascadesCount());
 
-	f32 scale = 20. * BS / getFarValue();
+	// start with 10% of the shadow range
+	f32 scale = 0.1;
 	f32 scale_factor = 1./pow(scale, 1./(cascades.size() - 1.));
 
 	for (auto &cascade: cascades) {

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -35,7 +35,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 ShadowRenderer::ShadowRenderer(IrrlichtDevice *device, Client *client) :
 		m_smgr(device->getSceneManager()), m_driver(device->getVideoDriver()),
-		m_client(client), m_perspective_bias_z(0.5)
+		m_client(client), m_perspective_bias_z(0.25)
 {
 	(void) m_client;
 

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -76,7 +76,6 @@ public:
 	void removeNodeFromShadowList(scene::ISceneNode *node);
 
 	void update(video::ITexture *outputTarget = nullptr);
-	void setForceUpdateShadowMap() { m_force_update_shadow_map = true; }
 	void drawDebug();
 
 	video::ITexture *get_texture()
@@ -93,20 +92,22 @@ public:
 	float getShadowStrength() const { return m_shadows_enabled ? m_shadow_strength : 0.0f; }
 	float getTimeOfDay() const { return m_time_day; }
 
-	f32 getPerspectiveBiasXY() { return m_perspective_bias_xy; }
 	f32 getPerspectiveBiasZ() { return m_perspective_bias_z; }
 
 private:
 	video::ITexture *getSMTexture(const std::string &shadow_map_name,
-			video::ECOLOR_FORMAT texture_format,
+			video::ECOLOR_FORMAT texture_format, u8 n_cascades,
 			bool force_creation = false);
 
-	void renderShadowMap(video::ITexture *target, DirectionalLight &light,
+	void renderShadowMap(video::ITexture *target, u8 cascade_index, const ShadowCascade &cascade,
 			scene::E_SCENE_NODE_RENDER_PASS pass =
 					scene::ESNRP_SOLID);
-	void renderShadowObjects(video::ITexture *target, DirectionalLight &light);
+	void renderShadowObjects(video::ITexture *target, const ShadowCascade &cascade);
 	void mixShadowsQuad();
-	void updateSMTextures();
+	void ensureSMTextures(u8 n_cascades);
+	void renderMapShadows();
+	void renderEntityShadows();
+	void mergeShadowMaps();
 
 	void disable();
 	void enable() { m_shadows_enabled = m_shadows_supported; }
@@ -116,7 +117,7 @@ private:
 	video::IVideoDriver *m_driver{nullptr};
 	Client *m_client{nullptr};
 	video::ITexture *shadowMapClientMap{nullptr};
-	video::ITexture *shadowMapClientMapFuture{nullptr};
+	std::vector<video::ITexture *>shadowMapClientMapFuture;
 	video::ITexture *shadowMapTextureFinal{nullptr};
 	video::ITexture *shadowMapTextureDynamicObjects{nullptr};
 	video::ITexture *shadowMapTextureColors{nullptr};
@@ -134,10 +135,6 @@ private:
 	bool m_shadows_enabled;
 	bool m_shadows_supported;
 	bool m_shadow_map_colored;
-	bool m_force_update_shadow_map;
-	u8 m_map_shadow_update_frames; /* Use this number of frames to update map shaodw */
-	u8 m_current_frame{0}; /* Current frame */
-	f32 m_perspective_bias_xy;
 	f32 m_perspective_bias_z;
 
 	video::ECOLOR_FORMAT m_texture_format{video::ECOLOR_FORMAT::ECF_R16F};

--- a/src/client/shadows/shadowsScreenQuad.cpp
+++ b/src/client/shadows/shadowsScreenQuad.cpp
@@ -19,12 +19,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "shadowsScreenQuad.h"
 
-shadowScreenQuad::shadowScreenQuad()
+shadowScreenQuad::shadowScreenQuad(video::SColor color)
 {
 	Material.Wireframe = false;
 	Material.Lighting = false;
+	Material.ZBuffer = video::ECFN_DISABLED;
 
-	video::SColor color(0x0);
 	Vertices[0] = video::S3DVertex(
 			-1.0f, -1.0f, 0.0f, 0, 0, 1, color, 0.0f, 1.0f);
 	Vertices[1] = video::S3DVertex(
@@ -43,6 +43,8 @@ void shadowScreenQuad::render(video::IVideoDriver *driver)
 {
 	u16 indices[6] = {0, 1, 2, 3, 4, 5};
 	driver->setMaterial(Material);
+	driver->setTransform(video::ETS_PROJECTION, core::matrix4());
+	driver->setTransform(video::ETS_VIEW, core::matrix4());
 	driver->setTransform(video::ETS_WORLD, core::matrix4());
 	driver->drawIndexedTriangleList(&Vertices[0], 6, &indices[0], 2);
 }

--- a/src/client/shadows/shadowsScreenQuad.h
+++ b/src/client/shadows/shadowsScreenQuad.h
@@ -26,7 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class shadowScreenQuad
 {
 public:
-	shadowScreenQuad();
+	shadowScreenQuad(video::SColor color = video::SColor(0x0));
 
 	void render(video::IVideoDriver *driver);
 	video::SMaterial &getMaterial() { return Material; }

--- a/src/client/shadows/shadowsshadercallbacks.cpp
+++ b/src/client/shadows/shadowsshadercallbacks.cpp
@@ -26,10 +26,6 @@ void ShadowDepthShaderCB::OnSetConstants(
 
 	core::matrix4 lightMVP = driver->getTransform(video::ETS_PROJECTION);
 	lightMVP *= driver->getTransform(video::ETS_VIEW);
-
-	f32 cam_pos[4];
-	lightMVP.transformVect(cam_pos, CameraPos);
-
 	lightMVP *= driver->getTransform(video::ETS_WORLD);
 
 	m_light_mvp_setting.set(lightMVP.pointer(), services);
@@ -37,12 +33,7 @@ void ShadowDepthShaderCB::OnSetConstants(
 	m_max_far_setting.set(&MaxFar, services);
 	s32 TextureId = 0;
 	m_color_map_sampler_setting.set(&TextureId, services);
-	f32 bias0 = PerspectiveBiasXY;
-	m_perspective_bias0.set(&bias0, services);
-	f32 bias1 = 1.0f - bias0 + 1e-5f;
-	m_perspective_bias1.set(&bias1, services);
 	f32 zbias = PerspectiveBiasZ;
 	m_perspective_zbias.set(&zbias, services);
-
-	m_cam_pos_setting.set(cam_pos, services);
+	m_cascade_setting.set(&Cascade, services);
 }

--- a/src/client/shadows/shadowsshadercallbacks.h
+++ b/src/client/shadows/shadowsshadercallbacks.h
@@ -32,8 +32,8 @@ public:
 			s32 userData) override;
 
 	f32 MaxFar{2048.0f}, MapRes{1024.0f};
-	f32 PerspectiveBiasXY {0.9f}, PerspectiveBiasZ {0.5f};
-	v3f CameraPos;
+	f32 PerspectiveBiasZ {0.5f};
+	s32 Cascade;
 
 private:
 	CachedVertexShaderSetting<f32, 16> m_light_mvp_setting{"LightMVP"};
@@ -41,8 +41,6 @@ private:
 	CachedVertexShaderSetting<f32> m_max_far_setting{"MaxFar"};
 	CachedPixelShaderSetting<s32>
 		m_color_map_sampler_setting{"ColorMapSampler"};
-	CachedVertexShaderSetting<f32> m_perspective_bias0{"xyPerspectiveBias0"};
-	CachedVertexShaderSetting<f32> m_perspective_bias1{"xyPerspectiveBias1"};
 	CachedVertexShaderSetting<f32> m_perspective_zbias{"zPerspectiveBias"};
-	CachedVertexShaderSetting<f32, 4> m_cam_pos_setting{"CameraPos"};
+	CachedPixelShaderSetting<s32> m_cascade_setting{"Cascade"};
 };

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -277,13 +277,13 @@ void set_default_settings()
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");
 	settings->setDefault("shadow_strength_gamma", "1.0");
-	settings->setDefault("shadow_map_max_distance", "140.0");
-	settings->setDefault("shadow_map_texture_size", "2048");
+	settings->setDefault("shadow_map_max_distance", "200.0");
+	settings->setDefault("shadow_map_texture_size", "1024");
 	settings->setDefault("shadow_map_texture_32bit", "true");
 	settings->setDefault("shadow_map_color", "false");
 	settings->setDefault("shadow_filters", "1");
 	settings->setDefault("shadow_poisson_filter", "true");
-	settings->setDefault("shadow_update_frames", "8");
+	settings->setDefault("shadow_update_frames", "16");
 	settings->setDefault("shadow_soft_radius", "5.0");
 	settings->setDefault("shadow_sky_body_orbit_tilt", "0.0");
 


### PR DESCRIPTION
**From #13833:**
-------------------------------------------------

Upgrades the current shadow mapping implementation to cascaded shadow maps.

Benefits:
* Affine transformation for the shadow = simpler math, faster shader, less maintenance
* Fixes shadows for large objects/meshes such as e.g. in Little Lady or shadows for clouds in the future
* Smoother updates of shadows (every cascade updates at its own pace, cascade 0 updates every frame)
* Much less peter-panning
* Less VRAM consumption for similar shadow quality/scale
* Visible area covered with shadows in most cases even with fast camera movement

Other fixes:
* Removed flicker when mapblock is updated (e.g. flowing water)
* Removed flicker when camera offset changes (every 200 nodes)
* Added bilinear filter for SHADOW_FILTER == 1 for playable shadow quality with more performance

Notes:
* 3 cascades
* Cascade 0 is fixed small size in world and updates every frame, giving reasonable shadow quality close to the player
* Cascade 2 is updated every shadow_update_frames frame (up to 32) and cascade 1 somewhere in-between
* Entity shadows on cascades 0 and 1
* Colored shadows work
* Soft shadows work (may need some tuning)
* Shadow performance with client_mesh_chunk_size = 1 may be lower because of increased number of drawcalls covering larger area. Increasing shadow_update_frames should help spread out the updates.
* shadow_map_texture_size now controls resolution of each of 3 cascades (2 for entities) and should be divided by 2 when migrating

## To do

This PR is Ready for Review.

- [ ] Testing needed
- [x] Tuning/defaults feedback needed
- [ ] Performance testing

## Changes from #13833:
- rebased
- fixed z bias
- fixes size of cascades relative to viewing_range

## How to test

1. Turn on the shadows
2. Enter a game that supports shadows
3. Check the shadows both at close and long distance, when flying etc.
