### PR TITLE
Translation Updater: Source file comment ends header comment

### DIFF
--- a/util/mod_translation_updater.py
+++ b/util/mod_translation_updater.py
@@ -304,11 +304,14 @@ def import_tr_file(tr_file):
 					if header_comments != None:
 						in_header = False
 					continue
-				# comment lines
+				# Comment lines
 				elif line.startswith("#"):
-					# source file comments: ##[ file.lua ] ##
+					# Source file comments: ##[ file.lua ]##
 					if line.startswith(symbol_source_prefix) and line.endswith(symbol_source_suffix):
-						# remove those comments; they may be added back automatically
+						# This line marks the end of header comments.
+						if params["print-source"]:
+							in_header = False
+						# Remove those comments; they may be added back automatically.
 						continue
 
 					# Store first occurance of textdomain


### PR DESCRIPTION
**Goal of the PR**
This PR tries to prevent moving the first string's comments to the top of file when print-source is enabled.

**How does the PR work?**
This PR marks source file comments as the end of header comments.

**Does it resolve any reported issue?**
This PR tries to fix #13946.

**Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?**
Probably.

## To do

This PR is Ready for Review.

## How to test

1. Create an example mod with some translatable strings.
2. Run the Mod Translation Updater script with `-p` flag.
3. Add comments directly below the first source file comment line.
4. Re-run the script again with the same flag.
5. The previously added comments should **not** be moved to the top of the file.
