### PR TITLE
Fix auto_install_spec being used as a table

### DIFF
--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -705,8 +705,7 @@ local function resolve_auto_install_spec()
 	end
 
 	if not resolved then
-		gamedata.errormessage = fgettext("The package $1/$2 was not found.",
-				auto_install_spec.author, auto_install_spec.name)
+		gamedata.errormessage = fgettext("The package $1 was not found.", auto_install_spec)
 		ui.update()
 
 		auto_install_spec = nil


### PR DESCRIPTION
I missed that line in #13906, where I changed the type of `auto_install_spec` from table to string. This resulted in wrong error messages when a package to be auto-installed was not found.

## To do

This PR is a Ready for Review.

## How to test

Pass an invalid auto-install specification to `create_store_dlg`. Enjoy seeing a correct error message.