### PR TITLE
Separate anticheat settings

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -822,8 +822,14 @@ default_privs (Default privileges) string interact, shout
 #    Privileges that players with basic_privs can grant
 basic_privs (Basic privileges) string interact, shout
 
-#    If enabled, disable cheat prevention in multiplayer.
-disable_anticheat (Disable anticheat) bool false
+#    Enable digging cheats prevention in multiplayer.
+anticheat_digging (Prevent fast/instant digging cheats) bool true
+
+#    Enable interaction anticheat in multiplayer.
+anticheat_interacting (Enable anticheat for player interaction) bool true
+
+#    Enable movement cheats prevention in multiplayer.
+anticheat_movement (Prevent movement cheats) bool true
 
 #    If enabled, actions are recorded for rollback.
 #    This option is only read when server starts.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -792,9 +792,17 @@
 #    type: string
 # basic_privs = interact, shout
 
-#    If enabled, disable cheat prevention in multiplayer.
+#    Enable digging cheats prevention in multiplayer.
 #    type: bool
-# disable_anticheat = false
+anticheat_digging = true
+
+#    Enable interaction anticheat in multiplayer.
+#    type: bool
+anticheat_interacting = true
+
+#    Enable movement cheats prevention in multiplayer.
+#    type: bool
+anticheat_movement = true
 
 #    If enabled, actions are recorded for rollback.
 #    This option is only read when server starts.

--- a/po/minetest.pot
+++ b/po/minetest.pot
@@ -3555,11 +3555,27 @@ msgid "Privileges that players with basic_privs can grant"
 msgstr ""
 
 #: src/settings_translation_file.cpp
-msgid "Disable anticheat"
+msgid "Prevent fast/instant digging cheats"
 msgstr ""
 
 #: src/settings_translation_file.cpp
-msgid "If enabled, disable cheat prevention in multiplayer."
+msgid "Enable digging cheats prevention in multiplayer."
+msgstr ""
+
+#: src/settings_translation_file.cpp
+msgid "Enable anticheat for player interaction"
+msgstr ""
+
+#: src/settings_translation_file.cpp
+msgid "Enable interaction anticheat in multiplayer."
+msgstr ""
+
+#: src/settings_translation_file.cpp
+msgid "Prevent movement cheats"
+msgstr ""
+
+#: src/settings_translation_file.cpp
+msgid "Enable movement cheats prevention in multiplayer."
 msgstr ""
 
 #: src/settings_translation_file.cpp

--- a/po/ru/minetest.po
+++ b/po/ru/minetest.po
@@ -3197,8 +3197,28 @@ msgid "Digging particles"
 msgstr "Частицы при рытье"
 
 #: src/settings_translation_file.cpp
-msgid "Disable anticheat"
-msgstr "Отключить анти-чит"
+msgid "Prevent fast/instant digging cheats"
+msgstr "Предотвращение быстрого копания"
+
+#: src/settings_translation_file.cpp
+msgid "Enable digging cheats prevention in multiplayer."
+msgstr "Включить предотвращение использования читов на быстрое копание в мультиплеере."
+
+#: src/settings_translation_file.cpp
+msgid "Enable anticheat for player interaction"
+msgstr "Античит при взаимодействии"
+
+#: src/settings_translation_file.cpp
+msgid "Enable interaction anticheat in multiplayer."
+msgstr "Включить античит при взаимодействии в мультиплеере."
+
+#: src/settings_translation_file.cpp
+msgid "Prevent movement cheats"
+msgstr "Предотвращение читерного передвижения"
+
+#: src/settings_translation_file.cpp
+msgid "Enable movement cheats prevention in multiplayer."
+msgstr "Включить предотвращение использования читов для передвижения в мультиплеере."
 
 #: src/settings_translation_file.cpp
 msgid "Disallow empty passwords"
@@ -4098,10 +4118,6 @@ msgid ""
 msgstr ""
 "Если включено, действия записываются для отката.\n"
 "Этот параметр считывается только при запуске сервера."
-
-#: src/settings_translation_file.cpp
-msgid "If enabled, disable cheat prevention in multiplayer."
-msgstr "Если включено, отключается защита от читерства в сетевой игре."
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -376,7 +376,9 @@ void set_default_settings()
 	settings->setDefault("enable_pvp", "true");
 	settings->setDefault("enable_mod_channels", "false");
 	settings->setDefault("disallow_empty_password", "false");
-	settings->setDefault("disable_anticheat", "false");
+	settings->setDefault("anticheat_digging", "true");
+	settings->setDefault("anticheat_interacting", "true");
+	settings->setDefault("anticheat_movement", "true");
 	settings->setDefault("enable_rollback_recording", "false");
 	settings->setDefault("deprecated_lua_api_handling", "log");
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1034,12 +1034,10 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 	/*
 		Check that target is reasonably close
 	*/
-	static thread_local const bool enable_anticheat =
-			!g_settings->getBool("disable_anticheat");
 
 	if ((action == INTERACT_START_DIGGING || action == INTERACT_DIGGING_COMPLETED ||
 			action == INTERACT_PLACE || action == INTERACT_USE) &&
-			enable_anticheat && !isSingleplayer()) {
+			g_settings->getBool("anticheat_interacting") && !isSingleplayer()) {
 		v3f target_pos = player_pos;
 		if (pointed.type == POINTEDTHING_NODE) {
 			target_pos = intToFloat(pointed.node_undersurface, BS);
@@ -1142,7 +1140,7 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 
 		/* Cheat prevention */
 		bool is_valid_dig = true;
-		if (enable_anticheat && !isSingleplayer()) {
+		if (g_settings->getBool("anticheat_digging") && !isSingleplayer()) {
 			v3s16 nocheat_p = playersao->getNoCheatDigPos();
 			float nocheat_t = playersao->getNoCheatDigTime();
 			playersao->noCheatDigEnd();

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -590,7 +590,7 @@ bool PlayerSAO::checkMovementCheat()
 {
 	if (m_is_singleplayer ||
 			isAttached() ||
-			g_settings->getBool("disable_anticheat")) {
+			!g_settings->getBool("anticheat_movement")) {
 		m_last_good_position = m_base_position;
 		return false;
 	}

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -316,8 +316,12 @@ fake_function() {
 	gettext("The privileges that new users automatically get.\nSee /privs in game for a full list on your server and mod configuration.");
 	gettext("Basic privileges");
 	gettext("Privileges that players with basic_privs can grant");
-	gettext("Disable anticheat");
-	gettext("If enabled, disable cheat prevention in multiplayer.");
+	gettext("Prevent fast/instant digging cheats");
+	gettext("Enable digging cheats prevention in multiplayer.");
+	gettext("Enable anticheat for player interaction");
+	gettext("Enable interaction anticheat in multiplayer.");
+	gettext("Prevent movement cheats");
+	gettext("Enable movement cheats prevention in multiplayer.");
 	gettext("Rollback recording");
 	gettext("If enabled, actions are recorded for rollback.\nThis option is only read when server starts.");
 	gettext("Client-side Modding");


### PR DESCRIPTION
This PR divides old `disable_anticheat` setting to three settings:
* `anticheat_digging`
* `anticheat_interaction`
* `anticheat_movement`

Both of these settings are enabled by default.

The goal of PR is to make anticheat more configurable.
Movement anticheat causes annoyances on high latency where players get position rubber banding while running, and, according to my experience, also increases CPU usage and server's `max_lag`. So some server owners turn `disable_anticheat` option to `true` and make their own "anti-speedhack" mods. Thus, they get a side effect - cheaters can break nodes very fast. Separated anticheat settings allow to disable that movement anticheat and keep node digging check on. Thus, the server gets more safe.

## To do

This PR is a Work in Progress


- [ ] Add a translations for description of each new setting and remove translations of descriptions of `disable_anticheat` setting
- [ ] Something else?


## How to test

Test each setting using a cheat client
