### PR TITLE
Fix UB in modulo360f (bugfix for #13960)

### DIFF
--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -202,7 +202,7 @@ struct MeshGrid {
  */
 inline float modulo360f(float f)
 {
-	return std::fmodf(f, 360.0f);
+	return fmodf(f, 360.0f);
 }
 		
 

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -202,25 +202,9 @@ struct MeshGrid {
  */
 inline float modulo360f(float f)
 {
-	int sign;
-	int whole;
-	float fraction;
-
-	if (f < 0) {
-		f = -f;
-		sign = -1;
-	} else {
-		sign = 1;
-	}
-
-	whole = f;
-
-	fraction = f - whole;
-	whole %= 360;
-
-	return sign * (whole + fraction);
+	return std::fmodf(f, 360.0f);
 }
-
+		
 
 /** Returns \p f wrapped to the range [0, 360]
   */

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -195,16 +195,12 @@ struct MeshGrid {
  *
  *  \note This is also used in cases where degrees wrapped to the range [0, 360]
  *  is innapropriate (e.g. pitch needs negative values)
- *
- *  \internal functionally equivalent -- although precision may vary slightly --
- *  to fmodf((f), 360.0f) however empirical tests indicate that this approach is
- *  faster.
  */
 inline float modulo360f(float f)
 {
 	return fmodf(f, 360.0f);
 }
-		
+
 
 /** Returns \p f wrapped to the range [0, 360]
   */

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irr_aabb3d.h"
 #include "SColor.h"
 #include <matrix4.h>
+#include <cmath>
 
 #define rangelim(d, min, max) ((d) < (min) ? (min) : ((d) > (max) ? (max) : (d)))
 #define myfloor(x) ((x) < 0.0 ? (int)(x) - 1 : (int)(x))


### PR DESCRIPTION
- Goal of the PR

fix #13960

- How does the PR work?

use fmodf instead of homegrown modulo function (which has UB in it leading to a crash on macOS/arm64)

- Does it resolve any reported issue?

fix #13960

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?
