### PR TITLE
Fix bad translation function names in builtin

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -27,7 +27,6 @@ local full_settings = settingtypes.parse_config_file(false, true)
 local info_icon_path = core.formspec_escape(defaulttexturedir .. "settings_info.png")
 local reset_icon_path = core.formspec_escape(defaulttexturedir .. "settings_reset.png")
 
-local gettext = fgettext_ne
 local all_pages = {}
 local page_by_id = {}
 local filtered_pages = all_pages
@@ -66,23 +65,23 @@ local change_keys = {
 
 add_page({
 	id = "accessibility",
-	title = gettext("Accessibility"),
+	title = fgettext_ne("Accessibility"),
 	content = {
 		"language",
-		{ heading = gettext("General") },
+		{ heading = fgettext_ne("General") },
 		"font_size",
 		"chat_font_size",
 		"gui_scaling",
 		"hud_scaling",
 		"show_nametag_backgrounds",
-		{ heading = gettext("Chat") },
+		{ heading = fgettext_ne("Chat") },
 		"console_height",
 		"console_alpha",
 		"console_color",
-		{ heading = gettext("Controls") },
+		{ heading = fgettext_ne("Controls") },
 		"autojump",
 		"safe_dig_and_place",
-		{ heading = gettext("Movement") },
+		{ heading = fgettext_ne("Movement") },
 		"arm_inertia",
 		"view_bobbing_amount",
 		"fall_bobbing_amount",
@@ -97,7 +96,7 @@ local function load_settingtypes()
 		if not page then
 			page = add_page({
 				id = (section or "general"):lower():gsub(" ", "_"),
-				title = section or gettext("General"),
+				title = section or fgettext_ne("General"),
 				section = section,
 				content = {},
 			})
@@ -123,7 +122,7 @@ local function load_settingtypes()
 			elseif entry.level == 2 then
 				ensure_page_started()
 				page.content[#page.content + 1] = {
-					heading = gettext(entry.readable_name or entry.name),
+					heading = fgettext_ne(entry.readable_name or entry.name),
 				}
 			end
 		else


### PR DESCRIPTION
Builtin had a few strings translated with the wrong function. `fgettext_ne` was aliased with `gettext` in a file but this is not correct because `updatepo.sh` does not recognize this name. Thus, a few strings were "overlooked" by `updatepo.sh`.

The fix is to remove this alias and call `fgettext_ne` directly at the offending places.

**Please add this to the 5.8.0 Milestone!**

**Please refresh translations with `updatepo.sh` after merging this (and please Weblate as well) because it will reveal a few new strings it has previously overlooked.**
