### PR TITLE
Add new flags to minetest.features for 5.8.0 features

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -27,6 +27,7 @@ core.features = {
 	get_light_data_buffer = true,
 	mod_storage_on_disk = true,
 	compress_zstd = true,
+	sound_parameter_table_has_start_time = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -27,7 +27,7 @@ core.features = {
 	get_light_data_buffer = true,
 	mod_storage_on_disk = true,
 	compress_zstd = true,
-	sound_parameter_table_start_time = true,
+	sound_params_start_time = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -28,7 +28,7 @@ core.features = {
 	mod_storage_on_disk = true,
 	compress_zstd = true,
 	sound_params_start_time = true,
-	physics_overrides_version = 2,
+	physics_overrides_v2 = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -28,6 +28,7 @@ core.features = {
 	mod_storage_on_disk = true,
 	compress_zstd = true,
 	sound_params_start_time = true,
+	new_physics_overrides = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -28,7 +28,7 @@ core.features = {
 	mod_storage_on_disk = true,
 	compress_zstd = true,
 	sound_params_start_time = true,
-	new_physics_overrides = true,
+	physics_overrides_version = 2,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -27,7 +27,7 @@ core.features = {
 	get_light_data_buffer = true,
 	mod_storage_on_disk = true,
 	compress_zstd = true,
-	sound_parameter_table_has_start_time = true,
+	sound_parameter_table_start_time = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5272,10 +5272,12 @@ Utilities
       compress_zstd = true,
       -- Sound parameter tables support start_time (5.8.0)
       sound_params_start_time = true,
-      -- New fields for set_physics_override: speed_climb, speed_crouch,
-      -- liquid_fluidity, liquid_fluidity_smooth, liquid_sink,
-      -- acceleration_default, acceleration_air (5.8.0)
-      new_physics_overrides = true,
+      -- Version number for set_physics_override parameters.
+      -- * 1 or nil: (<= 5.7.0)
+      -- * 2: (5.8.0)
+      --   New fields: speed_climb, speed_crouch, liquid_fluidity,
+      --   acceleration_default, acceleration_air
+      physics_overrides_version = 2,
   }
   ```
 
@@ -7758,6 +7760,8 @@ child will follow movement and rotation of that bone.
       settings (e.g. via the game's `minetest.conf`) to set a global base value
       for all players and only use `set_physics_override` when you need to change
       from the base value on a per-player basis
+    * Note: Some of the fields don't exist in old API versions, see feature
+      `physics_overrides_version`.
 
 * `get_physics_override()`: returns the table given to `set_physics_override`
 * `hud_add(hud definition)`: add a HUD element described by HUD def, returns ID

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5270,8 +5270,12 @@ Utilities
       mod_storage_on_disk = true,
       -- "zstd" method for compress/decompress (5.7.0)
       compress_zstd = true,
-      -- sound parameter tables support start_time (5.8.0)
+      -- Sound parameter tables support start_time (5.8.0)
       sound_params_start_time = true,
+      -- New fields for set_physics_override: speed_climb, speed_crouch,
+      -- liquid_fluidity, liquid_fluidity_smooth, liquid_sink,
+      -- acceleration_default, acceleration_default (5.8.0)
+      new_physics_overrides = true,
   }
   ```
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5274,7 +5274,7 @@ Utilities
       sound_params_start_time = true,
       -- New fields for set_physics_override: speed_climb, speed_crouch,
       -- liquid_fluidity, liquid_fluidity_smooth, liquid_sink,
-      -- acceleration_default, acceleration_default (5.8.0)
+      -- acceleration_default, acceleration_air (5.8.0)
       new_physics_overrides = true,
   }
   ```

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1091,7 +1091,7 @@ Table used to specify how a sound is played:
     -- its end in `-start_time` seconds.
     -- It is unspecified what happens if `loop` is false and `start_time` is
     -- smaller than minus the sound's length.
-    -- Available since feature `sound_parameter_table_start_time`.
+    -- Available since feature `sound_params_start_time`.
 
     loop = false,
     -- If true, sound is played in a loop.
@@ -5271,7 +5271,7 @@ Utilities
       -- "zstd" method for compress/decompress (5.7.0)
       compress_zstd = true,
       -- sound parameter tables support start_time (5.8.0)
-      sound_parameter_table_start_time = true,
+      sound_params_start_time = true,
   }
   ```
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5272,12 +5272,10 @@ Utilities
       compress_zstd = true,
       -- Sound parameter tables support start_time (5.8.0)
       sound_params_start_time = true,
-      -- Version number for set_physics_override parameters.
-      -- * 1 or nil: (<= 5.7.0)
-      -- * 2: (5.8.0)
-      --   New fields: speed_climb, speed_crouch, liquid_fluidity,
-      --   acceleration_default, acceleration_air
-      physics_overrides_version = 2,
+      -- New fields for set_physics_override: speed_climb, speed_crouch,
+      -- liquid_fluidity, liquid_fluidity_smooth, liquid_sink,
+      -- acceleration_default, acceleration_air (5.8.0)
+      physics_overrides_v2 = true,
   }
   ```
 
@@ -7761,7 +7759,7 @@ child will follow movement and rotation of that bone.
       for all players and only use `set_physics_override` when you need to change
       from the base value on a per-player basis
     * Note: Some of the fields don't exist in old API versions, see feature
-      `physics_overrides_version`.
+      `physics_overrides_v2`.
 
 * `get_physics_override()`: returns the table given to `set_physics_override`
 * `hud_add(hud definition)`: add a HUD element described by HUD def, returns ID

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1091,6 +1091,7 @@ Table used to specify how a sound is played:
     -- its end in `-start_time` seconds.
     -- It is unspecified what happens if `loop` is false and `start_time` is
     -- smaller than minus the sound's length.
+    -- Available since feature `sound_parameter_table_has_start_time`.
 
     loop = false,
     -- If true, sound is played in a loop.
@@ -5269,6 +5270,8 @@ Utilities
       mod_storage_on_disk = true,
       -- "zstd" method for compress/decompress (5.7.0)
       compress_zstd = true,
+      -- sound parameter tables support start_time (5.8.0)
+      sound_parameter_table_has_start_time = true,
   }
   ```
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1091,7 +1091,7 @@ Table used to specify how a sound is played:
     -- its end in `-start_time` seconds.
     -- It is unspecified what happens if `loop` is false and `start_time` is
     -- smaller than minus the sound's length.
-    -- Available since feature `sound_parameter_table_has_start_time`.
+    -- Available since feature `sound_parameter_table_start_time`.
 
     loop = false,
     -- If true, sound is played in a loop.
@@ -5271,7 +5271,7 @@ Utilities
       -- "zstd" method for compress/decompress (5.7.0)
       compress_zstd = true,
       -- sound parameter tables support start_time (5.8.0)
-      sound_parameter_table_has_start_time = true,
+      sound_parameter_table_start_time = true,
   }
   ```
 


### PR DESCRIPTION
#12764 added the `start_time` sound param. The server needs to read this param and send it to the clients. Mods need this feature flag to check if the server supports this.

(Client support can only be checked via protocol version. AFAIK, it's like this for every feature, so this is fine.)

## To do

This PR is a Ready for Review.

## How to test

Read.