### PR TITLE
Get rid of hidden settings in settings_translation_file.cpp

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -116,9 +116,7 @@ local function load_settingtypes()
 					content = {},
 				}
 
-				if page.title:sub(1, 5) ~= "Hide:" then
-					page = add_page(page)
-				end
+				page = add_page(page)
 			elseif entry.level == 2 then
 				ensure_page_started()
 				page.content[#page.content + 1] = {

--- a/builtin/mainmenu/settings/generate_from_settingtypes.lua
+++ b/builtin/mainmenu/settings/generate_from_settingtypes.lua
@@ -1,5 +1,3 @@
-local settings = ...
-
 local concat = table.concat
 local insert = table.insert
 local sprintf = string.format
@@ -36,7 +34,7 @@ local group_format_template = [[
 
 ]]
 
-local function create_minetest_conf_example()
+local function create_minetest_conf_example(settings)
 	local result = { minetest_example_header }
 	for _, entry in ipairs(settings) do
 		if entry.type == "category" then
@@ -108,14 +106,11 @@ local translation_file_header = [[
 
 fake_function() {]]
 
-local function create_translation_file()
+local function create_translation_file(settings)
 	local result = { translation_file_header }
 	for _, entry in ipairs(settings) do
 		if entry.type == "category" then
 			insert(result, sprintf("\tgettext(%q);", entry.name))
-		elseif entry.type == "key" then --luacheck: ignore
-			-- Neither names nor descriptions of keys are used since we have a
-			-- dedicated menu for them.
 		else
 			if entry.readable_name then
 				insert(result, sprintf("\tgettext(%q);", entry.readable_name))
@@ -132,12 +127,13 @@ local function create_translation_file()
 end
 
 local file = assert(io.open("minetest.conf.example", "w"))
-file:write(create_minetest_conf_example())
+file:write(create_minetest_conf_example(settingtypes.parse_config_file(true, false)))
 file:close()
 
 file = assert(io.open("src/settings_translation_file.cpp", "w"))
 -- If 'minetest.conf.example' appears in the 'bin' folder, the line below may have to be
 -- used instead. The file will also appear in the 'bin' folder.
 --file = assert(io.open("settings_translation_file.cpp", "w"))
-file:write(create_translation_file())
+-- We don't want hidden settings to be translated, so we set read_all to false.
+file:write(create_translation_file(settingtypes.parse_config_file(false, false)))
 file:close()

--- a/builtin/mainmenu/settings/init.lua
+++ b/builtin/mainmenu/settings/init.lua
@@ -25,4 +25,4 @@ dofile(path .. DIR_DELIM .. "dlg_settings.lua")
 -- For RUN_IN_PLACE the generated files may appear in the 'bin' folder.
 -- See comment and alternative line at the end of 'generate_from_settingtypes.lua'.
 
--- assert(loadfile(path .. DIR_DELIM .. "generate_from_settingtypes.lua"))(settingtypes.parse_config_file(true, false))
+-- dofile(path .. DIR_DELIM .. "generate_from_settingtypes.lua")


### PR DESCRIPTION
Fixes #13945.

> Right now the names and descriptions of non-key settings in the "Hide: Temporary Settings" category are included when generating `settings_translation_file.cpp`, causing some unused strings to get translated. They should be excluded.

Currently, the `"Hide:"` category prefix is only respected by the settings GUI. This PR adds proper support (including nesting) for this prefix to the settingtypes parser. "settings_translation_file.cpp" now excludes hidden settings, but "minetest.conf.example" still includes them.

If that's desired, I can also include the changes to the generated files caused by my changes to the generator in this PR.

## To do

This PR is a Ready for Review.

Ideally, this PR should be merged before the next translation update.

## How to test

Verify that the settings GUI still contains no hidden settings, and that it still contains all non-hidden settings.

Run the generator by uncommenting the relevant line in `builtin/mainmenu/settings/init.lua`. Verify that "minetest.conf.example" still contains hidden settings. Verify that "settings_translation_file.cpp" doesn't contain hidden settings anymore.