### PR TITLE
[pls do not squash :3] Allow limiting object observers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,16 @@
 [*]
 end_of_line = lf
 
-[*.{cpp,h,lua,txt,glsl,md,c,cmake,java,gradle}]
+[*.{cpp,h,lua,txt,glsl,c,cmake,java,gradle}]
 charset = utf-8
 indent_size = 4
 indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+charset = utf-8
+indent_size = 4
+indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7097,6 +7097,8 @@ Misc.
 * `minetest.is_player(obj)`: boolean, whether `obj` is a player
 * `minetest.player_exists(name)`: boolean, whether player exists
   (regardless of online status)
+* `minetest.is_valid_player_name(name)`: boolean, whether the given name
+  could be used as a player name (regardless of whether said player exists).
 * `minetest.hud_replace_builtin(name, hud_definition)`
     * Replaces definition of a builtin hud element
     * `name`: `"breath"`, `"health"` or `"minimap"`
@@ -7989,9 +7991,9 @@ child will follow movement and rotation of that bone.
 * `set_observers(observers)`: sets observers (players this object is sent to)
     * If `observers` is `nil`, the object's observers are "unmanaged":
       The object is sent to all players as governed by server settings. This is the default.
-    * `observers` is a "set" of player names: `{[player name] = true, [other player name] = true, ...}`
-        * A set is a table where the keys are the elements of the set (in this case, player names)
-          and the values are all `true`.
+    * `observers` is a "set" of player names: `{name1 = true, name2 = true, ...}`
+        * A set is a table where the keys are the elements of the set
+          (in this case, *valid* player names) and the values are all `true`.
     * Attachments: The *effective observers* of an object are made up of
       all players who can observe the object *and* are also effective observers
       of its parent object (if there is one).

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7986,6 +7986,29 @@ child will follow movement and rotation of that bone.
 * `get_bone_overrides()`: returns all bone overrides as table `{[bonename] = override, ...}`
 * `set_properties(object property table)`
 * `get_properties()`: returns a table of all object properties
+* `set_observers(observers)`: sets observers (players this object is sent to)
+    * If `observers` is `nil`, the object's observers are "unmanaged":
+      The object is sent to all players as governed by server settings. This is the default.
+    * `observers` is a "set" of player names: `{[player name] = true, [other player name] = true, ...}`
+        * A set is a table where the keys are the elements of the set (in this case, player names)
+          and the values are all `true`.
+    * Attachments: The *effective observers* of an object are made up of
+      all players who can observe the object *and* are also effective observers
+      of its parent object (if there is one).
+    * Players are automatically added to their own observer sets.
+      Players **must** effectively observe themselves.
+    * Object activation and deactivation are unaffected by observability.
+    * Attached sounds do not work correctly and thus should not be used
+      on objects with managed observers yet.
+* `get_observers()`:
+    * throws an error if the object is invalid
+    * returns `nil` if the observers are unmanaged
+    * returns a table with all observer names as keys and `true` values (a "set") otherwise
+* `get_effective_observers()`:
+    * Like `get_observers()`, but returns the "effective" observers, taking into account attachments
+    * Time complexity: O(nm)
+        * n: number of observers of the involved entities
+        * m: number of ancestors along the attachment chain
 * `is_player()`: returns true for players, false otherwise
 * `get_nametag_attributes()`
     * returns a table with the attributes of the nametag of an object

--- a/games/devtest/mods/testentities/init.lua
+++ b/games/devtest/mods/testentities/init.lua
@@ -1,4 +1,5 @@
 dofile(minetest.get_modpath("testentities").."/visuals.lua")
+dofile(minetest.get_modpath("testentities").."/observers.lua")
 dofile(minetest.get_modpath("testentities").."/selectionbox.lua")
 dofile(minetest.get_modpath("testentities").."/armor.lua")
 dofile(minetest.get_modpath("testentities").."/pointable.lua")

--- a/games/devtest/mods/testentities/observers.lua
+++ b/games/devtest/mods/testentities/observers.lua
@@ -1,0 +1,37 @@
+local function player_names_excluding(exclude_player_name)
+	local player_names = {}
+	for _, player in ipairs(minetest.get_connected_players()) do
+		player_names[player:get_player_name()] = true
+	end
+	player_names[exclude_player_name] = nil
+	return player_names
+end
+
+minetest.register_entity("testentities:observable", {
+	initial_properties = {
+		visual = "sprite",
+		textures = { "testentities_sprite.png" },
+		static_save = false,
+		infotext = "Punch to set observers to anyone but you"
+	},
+	on_activate = function(self)
+		self.object:set_armor_groups({punch_operable = 1})
+		assert(self.object:get_observers() == nil)
+		-- Using a value of `false` in the table should error.
+		assert(not pcall(self.object, self.object.set_observers, self.object, {test = false}))
+	end,
+	on_punch = function(self, puncher)
+		local puncher_name = puncher:get_player_name()
+		local observers = player_names_excluding(puncher_name)
+		self.object:set_observers(observers)
+		local got_observers = self.object:get_observers()
+		for name in pairs(observers) do
+			assert(got_observers[name])
+		end
+		for name in pairs(got_observers) do
+			assert(observers[name])
+		end
+		self.object:set_properties({infotext = "Excluding " .. puncher_name})
+		return true
+	end
+})

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1594,7 +1594,7 @@ Inventory* Client::getInventory(const InventoryLocation &loc)
 	{
 		// Check if we are working with local player inventory
 		LocalPlayer *player = m_env.getLocalPlayer();
-		if (!player || strcmp(player->getName(), loc.name.c_str()) != 0)
+		if (!player || player->getName() != loc.name)
 			return NULL;
 		return &player->inventory;
 	}

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -385,7 +385,7 @@ void GenericCAO::processInitData(const std::string &data)
 	if (m_is_player) {
 		// Check if it's the current player
 		LocalPlayer *player = m_env->getLocalPlayer();
-		if (player && strcmp(player->getName(), m_name.c_str()) == 0) {
+		if (player && player->getName() == m_name) {
 			m_is_local_player = true;
 			m_is_visible = false;
 			player->setCAO(this);

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -19,7 +19,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "localplayer.h"
 #include <cmath>
-#include <string>
 #include "mtevent.h"
 #include "collision.h"
 #include "nodedef.h"

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "localplayer.h"
 #include <cmath>
+#include <string>
 #include "mtevent.h"
 #include "collision.h"
 #include "nodedef.h"
@@ -75,7 +76,7 @@ void PlayerSettings::settingsChangedCallback(const std::string &name, void *data
 	LocalPlayer
 */
 
-LocalPlayer::LocalPlayer(Client *client, const char *name):
+LocalPlayer::LocalPlayer(Client *client, const std::string &name):
 	Player(name, client->idef()),
 	m_client(client)
 {

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "constants.h"
 #include "settings.h"
 #include "lighting.h"
+#include <string>
 
 class Client;
 class Environment;
@@ -63,7 +64,8 @@ private:
 class LocalPlayer : public Player
 {
 public:
-	LocalPlayer(Client *client, const char *name);
+
+	LocalPlayer(Client *client, const std::string &name);
 	virtual ~LocalPlayer();
 
 	// Initialize hp to 0, so that no hearts will be shown if server

--- a/src/database/database-files.cpp
+++ b/src/database/database-files.cpp
@@ -48,8 +48,7 @@ void PlayerDatabaseFiles::deSerialize(RemotePlayer *p, std::istream &is,
 
 	p->m_dirty = true;
 	//args.getS32("version"); // Version field value not used
-	const std::string &name = args.get("name");
-	strlcpy(p->m_name, name.c_str(), PLAYERNAME_SIZE);
+	p->m_name = args.get("name");
 
 	if (sao) {
 		try {
@@ -96,7 +95,7 @@ void PlayerDatabaseFiles::deSerialize(RemotePlayer *p, std::istream &is,
 		p->inventory.deSerialize(is);
 	} catch (SerializationError &e) {
 		errorstream << "Failed to deserialize player inventory. player_name="
-			<< name << " " << e.what() << std::endl;
+			<< p->getName() << " " << e.what() << std::endl;
 	}
 
 	if (!p->inventory.getList("craftpreview") && p->inventory.getList("craftresult")) {
@@ -119,7 +118,7 @@ void PlayerDatabaseFiles::serialize(RemotePlayer *p, std::ostream &os)
 	// Utilize a Settings object for storing values
 	Settings args("PlayerArgsEnd");
 	args.setS32("version", 1);
-	args.set("name", p->m_name);
+	args.set("name", p->getName());
 
 	PlayerSAO *sao = p->getPlayerSAO();
 	// This should not happen
@@ -171,7 +170,7 @@ void PlayerDatabaseFiles::savePlayer(RemotePlayer *player)
 
 		deSerialize(&testplayer, is, path, NULL);
 		is.close();
-		if (strcmp(testplayer.getName(), player->getName()) == 0) {
+		if (testplayer.getName() == player->getName()) {
 			path_found = true;
 			continue;
 		}

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -468,7 +468,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 	std::string hp = itos(sao->getHP());
 	std::string breath = itos(sao->getBreath());
 	const char *values[] = {
-		player->getName(),
+		player->getName().c_str(),
 		pitch.c_str(),
 		yaw.c_str(),
 		posx.c_str(), posy.c_str(), posz.c_str(),
@@ -476,7 +476,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 		breath.c_str()
 	};
 
-	const char* rmvalues[] = { player->getName() };
+	const char* rmvalues[] = { player->getName().c_str() };
 	beginSave();
 
 	if (getPGVersion() < 90500) {
@@ -501,7 +501,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 			inv_id = itos(i), lsize = itos(list->getSize());
 
 		const char* inv_values[] = {
-			player->getName(),
+			player->getName().c_str(),
 			inv_id.c_str(),
 			width.c_str(),
 			name.c_str(),
@@ -516,7 +516,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 			std::string itemStr = oss.str(), slotId = itos(j);
 
 			const char* invitem_values[] = {
-				player->getName(),
+				player->getName().c_str(),
 				inv_id.c_str(),
 				slotId.c_str(),
 				itemStr.c_str()
@@ -529,7 +529,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 	const StringMap &attrs = sao->getMeta().getStrings();
 	for (const auto &attr : attrs) {
 		const char *meta_values[] = {
-			player->getName(),
+			player->getName().c_str(),
 			attr.first.c_str(),
 			attr.second.c_str()
 		};
@@ -545,7 +545,7 @@ bool PlayerDatabasePostgreSQL::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 	sanity_check(sao);
 	verifyDatabase();
 
-	const char *values[] = { player->getName() };
+	const char *values[] = { player->getName().c_str() };
 	PGresult *results = execPrepared("load_player", 1, values, false, false);
 
 	// Player not found, return not found
@@ -580,7 +580,7 @@ bool PlayerDatabasePostgreSQL::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 		std::string invIdStr = itos(invId);
 
 		const char* values2[] = {
-			player->getName(),
+			player->getName().c_str(),
 			invIdStr.c_str()
 		};
 		PGresult *results2 = execPrepared("load_player_inventory_items", 2,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1095,13 +1095,9 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 
 	if (cmd_args.exists("terminal")) {
 #if USE_CURSES
-		bool name_ok = true;
 		std::string admin_nick = g_settings->get("name");
 
-		name_ok = name_ok && !admin_nick.empty();
-		name_ok = name_ok && string_allowed(admin_nick, PLAYERNAME_ALLOWED_CHARS);
-
-		if (!name_ok) {
+		if (!is_valid_player_name(admin_nick)) {
 			if (admin_nick.empty()) {
 				errorstream << "No name given for admin. "
 					<< "Please check your minetest.conf that it "
@@ -1110,7 +1106,8 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 			} else {
 				errorstream << "Name for admin '"
 					<< admin_nick << "' is not valid. "
-					<< "Please check that it only contains allowed characters. "
+					<< "Please check that it only contains allowed characters "
+					<< "and that it is at most 20 characters long. "
 					<< "Valid characters are: " << PLAYERNAME_ALLOWED_CHARS_USER_EXPL
 					<< std::endl;
 			}

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -615,7 +615,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 
 	// If something goes wrong, this player is to blame
 	RollbackScopeActor rollback_scope(m_rollback,
-			std::string("player:")+player->getName());
+			"player:" + player->getName());
 
 	/*
 		Note: Always set inventory not sent, to repair cases
@@ -1069,7 +1069,7 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 		If something goes wrong, this player is to blame
 	*/
 	RollbackScopeActor rollback_scope(m_rollback,
-			std::string("player:")+player->getName());
+			"player:" + player->getName());
 
 	switch (action) {
 	// Start digging or punch object
@@ -1400,7 +1400,7 @@ void Server::handleCommand_NodeMetaFields(NetworkPacket* pkt)
 
 	// If something goes wrong, this player is to blame
 	RollbackScopeActor rollback_scope(m_rollback,
-			std::string("player:")+player->getName());
+			"player:" + player->getName());
 
 	// Check the target node for rollback data; leave others unnoticed
 	RollbackNode rn_old(&m_env->getMap(), p, this);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -30,10 +30,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "porting.h"  // strlcpy
 
 
-Player::Player(const char *name, IItemDefManager *idef):
+Player::Player(const std::string name, IItemDefManager *idef):
 	inventory(idef)
 {
-	strlcpy(m_name, name, PLAYERNAME_SIZE);
+	m_name = name;
 
 	inventory.clear();
 	inventory.addList("main", PLAYER_INVENTORY_SIZE);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -30,7 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "porting.h"  // strlcpy
 
 
-Player::Player(const std::string name, IItemDefManager *idef):
+Player::Player(const std::string &name, IItemDefManager *idef):
 	inventory(idef)
 {
 	m_name = name;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -30,6 +30,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "porting.h"  // strlcpy
 
 
+bool is_valid_player_name(std::string_view name) {
+	return !name.empty() && name.size() <= PLAYERNAME_SIZE && string_allowed(name, PLAYERNAME_ALLOWED_CHARS);
+}
+
 Player::Player(const std::string &name, IItemDefManager *idef):
 	inventory(idef)
 {

--- a/src/player.h
+++ b/src/player.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "constants.h"
 #include "network/networkprotocol.h"
 #include "util/basic_macros.h"
+#include "util/string.h"
 #include <list>
 #include <mutex>
 #include <functional>
@@ -34,6 +35,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define PLAYERNAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
 #define PLAYERNAME_ALLOWED_CHARS_USER_EXPL "'a' to 'z', 'A' to 'Z', '0' to '9', '-', '_'"
+
+bool is_valid_player_name(std::string_view name);
 
 struct PlayerFovSpec
 {

--- a/src/player.h
+++ b/src/player.h
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <mutex>
 #include <functional>
 #include <tuple>
+#include <string>
 
 #define PLAYERNAME_SIZE 20
 
@@ -158,7 +159,7 @@ class Player
 {
 public:
 
-	Player(const char *name, IItemDefManager *idef);
+	Player(const std::string &name, IItemDefManager *idef);
 	virtual ~Player() = 0;
 
 	DISABLE_CLASS_COPY(Player);
@@ -178,7 +179,7 @@ public:
 	// in BS-space
 	v3f getSpeed() const { return m_speed; }
 
-	const char *getName() const { return m_name; }
+	const std::string& getName() const { return m_name; }
 
 	u32 getFreeHudID()
 	{
@@ -251,7 +252,7 @@ public:
 	u16 getMaxHotbarItemcount();
 
 protected:
-	char m_name[PLAYERNAME_SIZE];
+	std::string m_name;
 	v3f m_speed; // velocity; in BS-space
 	u16 m_wield_index = 0;
 	PlayerFovSpec m_fov_override_spec = { 0.0f, false, 0.0f };

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -37,7 +37,7 @@ bool RemotePlayer::m_setting_cache_loaded = false;
 float RemotePlayer::m_setting_chat_message_limit_per_10sec = 0.0f;
 u16 RemotePlayer::m_setting_chat_message_limit_trigger_kick = 0;
 
-RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
+RemotePlayer::RemotePlayer(const std::string &name, IItemDefManager *idef):
 	Player(name, idef)
 {
 	if (!RemotePlayer::m_setting_cache_loaded) {

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -41,7 +41,7 @@ class RemotePlayer : public Player
 	friend class PlayerDatabaseFiles;
 
 public:
-	RemotePlayer(const char *name, IItemDefManager *idef);
+	RemotePlayer(const std::string &name, IItemDefManager *idef);
 	virtual ~RemotePlayer();
 
 	PlayerSAO *getPlayerSAO() { return m_sao; }

--- a/src/script/cpp_api/s_server.cpp
+++ b/src/script/cpp_api/s_server.cpp
@@ -246,7 +246,7 @@ void ScriptApiServer::freeDynamicMediaCallback(u32 token)
 	lua_pop(L, 2);
 }
 
-void ScriptApiServer::on_dynamic_media_added(u32 token, const char *playername)
+void ScriptApiServer::on_dynamic_media_added(u32 token, const std::string &playername)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
@@ -257,6 +257,6 @@ void ScriptApiServer::on_dynamic_media_added(u32 token, const char *playername)
 	lua_rawgeti(L, -1, token);
 	luaL_checktype(L, -1, LUA_TFUNCTION);
 
-	lua_pushstring(L, playername);
+	lua_pushstring(L, playername.c_str());
 	PCALL_RES(lua_pcall(L, 1, 0, error_handler));
 }

--- a/src/script/cpp_api/s_server.h
+++ b/src/script/cpp_api/s_server.h
@@ -53,7 +53,7 @@ public:
 	/* dynamic media handling */
 	static u32 allocateDynamicMediaCallback(lua_State *L, int f_idx);
 	void freeDynamicMediaCallback(u32 token);
-	void on_dynamic_media_added(u32 token, const char *playername);
+	void on_dynamic_media_added(u32 token, const std::string &playername);
 
 private:
 	void getAuthHandler();

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -72,7 +72,7 @@ int LuaLocalPlayer::l_get_name(lua_State *L)
 {
 	LocalPlayer *player = getobject(L, 1);
 
-	lua_pushstring(L, player->getName());
+	lua_pushstring(L, player->getName().c_str());
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1166,7 +1166,7 @@ int ObjectRef::l_get_player_name(lua_State *L)
 		return 1;
 	}
 
-	lua_pushstring(L, player->getName());
+	lua_pushstring(L, player->getName().c_str());
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -27,6 +27,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include "log.h"
+#include "player.h"
+#include "server/serveractiveobject.h"
 #include "tool.h"
 #include "remoteplayer.h"
 #include "server.h"
@@ -36,6 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server/player_sao.h"
 #include "server/serverinventorymgr.h"
 #include "server/unit_sao.h"
+#include "util/string.h"
 
 using object_t = ServerActiveObject::object_t;
 
@@ -835,6 +838,85 @@ int ObjectRef::l_get_properties(lua_State *L)
 
 	push_object_properties(L, prop);
 	return 1;
+}
+
+// set_observers(self, observers)
+int ObjectRef::l_set_observers(lua_State *L)
+{
+	GET_ENV_PTR;
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
+	ServerActiveObject *sao = getobject(ref);
+	if (sao == nullptr)
+		throw LuaError("Invalid ObjectRef");
+
+	// Reset object to "unmanaged" (sent to everyone)?
+	if (lua_isnoneornil(L, 2)) {
+		sao->m_observers.reset();
+		return 0;
+	}
+
+	std::unordered_set<std::string> observer_names;
+	lua_pushnil(L);
+	while (lua_next(L, 2) != 0) {
+		std::string name = readParam<std::string>(L, -2);
+		if (name.empty())
+			throw LuaError("Observer name is empty");
+		if (name.size() > PLAYERNAME_SIZE)
+			throw LuaError("Observer name is too long");
+		if (!string_allowed(name, PLAYERNAME_ALLOWED_CHARS))
+			throw LuaError("Observer name contains invalid characters");
+		if (!lua_toboolean(L, -1)) // falsy value?
+			throw LuaError("Values in the `observers` table need to be true");
+		observer_names.insert(std::move(name));
+		lua_pop(L, 1); // pop value, keep key
+	}
+
+	RemotePlayer *player = getplayer(ref);
+	if (player != nullptr) {
+		observer_names.insert(player->getName());
+	}
+
+	sao->m_observers = std::move(observer_names);
+	return 0;
+}
+
+template<typename F>
+static int get_observers(lua_State *L, F observer_getter)
+{
+	ObjectRef *ref = ObjectRef::checkObject<ObjectRef>(L, 1);
+	ServerActiveObject *sao = ObjectRef::getobject(ref);
+	if (sao == nullptr)
+		throw LuaError("invalid ObjectRef");
+
+	const auto observers = observer_getter(sao);
+	if (!observers) {
+		lua_pushnil(L);
+		return 1;
+	}
+	// Push set of observers {[name] = true}
+	lua_createtable(L, 0, observers->size());
+	for (auto &name : *observers) {
+		lua_pushboolean(L, true);
+		lua_setfield(L, -2, name.c_str());
+	}
+	return 1;
+}
+
+// get_observers(self)
+int ObjectRef::l_get_observers(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	return get_observers(L, [](auto sao) { return sao->m_observers; });
+}
+
+// get_effective_observers(self)
+int ObjectRef::l_get_effective_observers(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	return get_observers(L, [](auto sao) {
+		// The cache may be outdated, so we always have to recalculate.
+		return sao->recalculateEffectiveObservers();
+	});
 }
 
 // is_player(self)
@@ -2676,6 +2758,9 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_properties),
 	luamethod(ObjectRef, set_nametag_attributes),
 	luamethod(ObjectRef, get_nametag_attributes),
+	luamethod(ObjectRef, set_observers),
+	luamethod(ObjectRef, get_observers),
+	luamethod(ObjectRef, get_effective_observers),
 
 	luamethod_aliased(ObjectRef, set_velocity, setvelocity),
 	luamethod_aliased(ObjectRef, add_velocity, add_player_velocity),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -859,12 +859,8 @@ int ObjectRef::l_set_observers(lua_State *L)
 	lua_pushnil(L);
 	while (lua_next(L, 2) != 0) {
 		std::string name = readParam<std::string>(L, -2);
-		if (name.empty())
-			throw LuaError("Observer name is empty");
-		if (name.size() > PLAYERNAME_SIZE)
-			throw LuaError("Observer name is too long");
-		if (!string_allowed(name, PLAYERNAME_ALLOWED_CHARS))
-			throw LuaError("Observer name contains invalid characters");
+		if (!is_valid_player_name(name))
+			throw LuaError("Observer name is not a valid player name");
 		if (!lua_toboolean(L, -1)) // falsy value?
 			throw LuaError("Values in the `observers` table need to be true");
 		observer_names.insert(std::move(name));

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -163,6 +163,15 @@ private:
 	// get_properties(self)
 	static int l_get_properties(lua_State *L);
 
+	// set_observers(self, observers)
+	static int l_set_observers(lua_State *L);
+
+	// get_observers(self)
+	static int l_get_observers(lua_State *L);
+
+	// get_effective_observers(self)
+	static int l_get_effective_observers(lua_State *L);
+
 	// is_player(self)
 	static int l_is_player(lua_State *L);
 

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -44,6 +44,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/sha1.h"
 #include "my_sha256.h"
 #include "util/png.h"
+#include "player.h"
 #include <cstdio>
 
 // only available in zstd 1.3.5+
@@ -674,6 +675,16 @@ int ModApiUtil::l_urlencode(lua_State *L)
 	return 1;
 }
 
+// is_valid_player_name(name)
+int ModApiUtil::l_is_valid_player_name(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	auto s = readParam<std::string_view>(L, 1);
+	lua_pushboolean(L, is_valid_player_name(s));
+	return 1;
+}
+
 void ModApiUtil::Initialize(lua_State *L, int top)
 {
 	API_FCT(log);
@@ -722,6 +733,7 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 	API_FCT(set_last_run_mod);
 
 	API_FCT(urlencode);
+	API_FCT(is_valid_player_name);
 
 	LuaSettings::create(L, g_settings, g_settings_path);
 	lua_setfield(L, top, "settings");

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -134,6 +134,9 @@ private:
 	// urlencode(value)
 	static int l_urlencode(lua_State *L);
 
+	// is_valid_player_name(name)
+	static int l_is_valid_player_name(lua_State *L);
+
 public:
 	static void Initialize(lua_State *L, int top);
 	static void InitializeAsync(lua_State *L, int top);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1153,7 +1153,7 @@ PlayerSAO* Server::StageTwoClientInit(session_t peer_id)
 	*/
 	{
 		NetworkPacket notice_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, PEER_ID_INEXISTENT);
-		notice_pkt << (u8) PLAYER_LIST_ADD << (u16) 1 << std::string(player->getName());
+		notice_pkt << (u8) PLAYER_LIST_ADD << (u16) 1 << player->getName();
 		m_clients.sendToAll(&notice_pkt);
 	}
 	{
@@ -3176,7 +3176,7 @@ std::string Server::getStatusString()
 			RemotePlayer *player = m_env->getPlayer(client_id);
 
 			// Get name of player
-			const char *name = player ? player->getName() : "<unknown>";
+			const std::string name = player ? player->getName() : "<unknown>";
 
 			// Add name to information string
 			if (!first)

--- a/src/server/activeobjectmgr.h
+++ b/src/server/activeobjectmgr.h
@@ -38,15 +38,18 @@ public:
 	bool registerObject(std::unique_ptr<ServerActiveObject> obj) override;
 	void removeObject(u16 id) override;
 
+	void invalidateActiveObjectObserverCaches();
+
 	void getObjectsInsideRadius(const v3f &pos, float radius,
 			std::vector<ServerActiveObject *> &result,
 			std::function<bool(ServerActiveObject *obj)> include_obj_cb);
 	void getObjectsInArea(const aabb3f &box,
 			std::vector<ServerActiveObject *> &result,
 			std::function<bool(ServerActiveObject *obj)> include_obj_cb);
-
-	void getAddedActiveObjectsAroundPos(v3f player_pos, f32 radius,
-			f32 player_radius, const std::set<u16> &current_objects,
+	void getAddedActiveObjectsAroundPos(
+			const v3f &player_pos, const std::string &player_name,
+			f32 radius, f32 player_radius,
+			const std::set<u16> &current_objects,
 			std::vector<u16> &added_objects);
 };
 } // namespace server

--- a/src/server/serveractiveobject.cpp
+++ b/src/server/serveractiveobject.cpp
@@ -18,11 +18,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "serveractiveobject.h"
-#include <fstream>
 #include "inventory.h"
 #include "inventorymanager.h"
 #include "constants.h" // BS
-#include "log.h"
 
 ServerActiveObject::ServerActiveObject(ServerEnvironment *env, v3f pos):
 	ActiveObject(0),
@@ -94,4 +92,49 @@ void ServerActiveObject::markForDeactivation()
 InventoryLocation ServerActiveObject::getInventoryLocation() const
 {
 	return InventoryLocation();
+}
+
+void ServerActiveObject::invalidateEffectiveObservers()
+{
+	m_effective_observers.reset();
+}
+
+using Observers = ServerActiveObject::Observers;
+
+const Observers &ServerActiveObject::getEffectiveObservers()
+{
+	if (m_effective_observers) // cached
+		return *m_effective_observers;
+
+	auto parent = getParent();
+	if (parent == nullptr)
+		return *(m_effective_observers = m_observers);
+	auto parent_observers = parent->getEffectiveObservers();
+	if (!parent_observers) // parent is unmanaged
+		return *(m_effective_observers = m_observers);
+	if (!m_observers) // we are unmanaged
+		return *(m_effective_observers = parent_observers);
+	// Set intersection between parent_observers and m_observers
+	// Avoid .clear() to free the allocated memory.
+	m_effective_observers = std::unordered_set<std::string>();
+	for (const auto &observer_name : *m_observers) {
+		if (parent_observers->count(observer_name) > 0)
+			(*m_effective_observers)->insert(observer_name);
+	}
+	return *m_effective_observers;
+}
+
+const Observers& ServerActiveObject::recalculateEffectiveObservers()
+{
+	// Invalidate final observers for this object and all of its parents.
+	for (auto obj = this; obj != nullptr; obj = obj->getParent())
+		obj->invalidateEffectiveObservers();
+	// getEffectiveObservers will now be forced to recalculate.
+	return getEffectiveObservers();
+}
+
+bool ServerActiveObject::isEffectivelyObservedBy(const std::string &player_name)
+{
+	auto effective_observers = getEffectiveObservers();
+	return !effective_observers || effective_observers->count(player_name) > 0;
 }

--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <cassert>
 #include <unordered_set>
+#include <optional>
 #include "irrlichttypes_bloated.h"
 #include "activeobject.h"
 #include "itemgroup.h"
@@ -236,7 +237,25 @@ public:
 	*/
 	v3s16 m_static_block = v3s16(1337,1337,1337);
 
+	// Names of players to whom the object is to be sent, not considering parents.
+	using Observers = std::optional<std::unordered_set<std::string>>;
+	Observers m_observers;
+
+	/// Invalidate final observer cache. This needs to be done whenever
+	/// the observers of this object or any of its ancestors may have changed.
+	void invalidateEffectiveObservers();
+	/// Cache `m_effective_observers` with the names of all observers,
+	/// also indirect observers (object attachment chain).
+	const Observers &getEffectiveObservers();
+	/// Force a recalculation of final observers (including all parents).
+	const Observers &recalculateEffectiveObservers();
+	/// Whether the object is sent to `player_name`
+	bool isEffectivelyObservedBy(const std::string &player_name);
+
 protected:
+	// Cached intersection of m_observers of this object and all its parents.
+	std::optional<Observers> m_effective_observers;
+
 	virtual void onMarkedForDeactivation() {}
 	virtual void onMarkedForRemoval() {}
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -575,10 +575,10 @@ RemotePlayer *ServerEnvironment::getPlayer(const session_t peer_id)
 	return NULL;
 }
 
-RemotePlayer *ServerEnvironment::getPlayer(const char* name, bool match_invalid_peer)
+RemotePlayer *ServerEnvironment::getPlayer(const std::string &name, bool match_invalid_peer)
 {
 	for (RemotePlayer *player : m_players) {
-		if (strcmp(player->getName(), name) != 0)
+		if (player->getName() != name)
 			continue;
 
 		if (match_invalid_peer || player->getPeerId() != PEER_ID_INEXISTENT)

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -277,6 +277,8 @@ public:
 	*/
 	u16 addActiveObject(std::unique_ptr<ServerActiveObject> object);
 
+	void invalidateActiveObjectObserverCaches();
+
 	/*
 		Find out what new objects have been added to
 		inside a radius around a position

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -379,7 +379,7 @@ public:
 		bool static_exists, v3s16 static_block=v3s16(0,0,0));
 
 	RemotePlayer *getPlayer(const session_t peer_id);
-	RemotePlayer *getPlayer(const char* name, bool match_invalid_peer = false);
+	RemotePlayer *getPlayer(const std::string &name, bool match_invalid_peer = false);
 	const std::vector<RemotePlayer *> getPlayers() const { return m_players; }
 	u32 getPlayerCount() const { return m_players.size(); }
 

--- a/src/unittest/test_serveractiveobjectmgr.cpp
+++ b/src/unittest/test_serveractiveobjectmgr.cpp
@@ -175,12 +175,12 @@ void TestServerActiveObjectMgr::testGetAddedActiveObjectsAroundPos()
 
 	std::vector<u16> result;
 	std::set<u16> cur_objects;
-	saomgr.getAddedActiveObjectsAroundPos(v3f(), 100, 50, cur_objects, result);
+	saomgr.getAddedActiveObjectsAroundPos(v3f(), "singleplayer", 100, 50, cur_objects, result);
 	UASSERTCMP(int, ==, result.size(), 1);
 
 	result.clear();
 	cur_objects.clear();
-	saomgr.getAddedActiveObjectsAroundPos(v3f(), 740, 50, cur_objects, result);
+	saomgr.getAddedActiveObjectsAroundPos(v3f(), "singleplayer", 740, 50, cur_objects, result);
 	UASSERTCMP(int, ==, result.size(), 2);
 
 	saomgr.clear();


### PR DESCRIPTION
Closes https://github.com/minetest/minetest/issues/8045 straightforwardly: By managing an opt-in set of observers per-entity; in the process I also made players use a proper `std::string` for their name rather than a `char*`.

This feature should work with newer servers and older clients as well.

## To do

- [x] API design: I am considering incremental methods `add_observers` / `remove_observers` in addition to the current `set_observers` / `get_observers`. Opinions?
  - Considered, not really necessary for a minimal feature yet. Unless someone asks for them, I won't add them; note that you can always easily implement them yourselves.
- [x] What about `static_save`? The easiest solution would probably be to disallow `static_save` for entities with managed observers.
- [ ] What else did I fail to take into account?
  - Well well, let's find out! This PR is suspiciously simple, isn't it?

Feedback welcome!

## How to test

Join a server with two clients. Spawn a `testentities:observable`. Punch the observable on one client: It should disappear for you and appear for the other client.
