### PR TITLE
Make text containers wider in the Volume Change dialog

### DIFF
--- a/src/gui/guiVolumeChange.cpp
+++ b/src/gui/guiVolumeChange.cpp
@@ -70,15 +70,15 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 		Add stuff
 	*/
 	{
-		core::rect<s32> rect(0, 0, 160 * s, 20 * s);
-		rect = rect + v2s32(size.X / 2 - 80 * s, size.Y / 2 - 70 * s);
+		core::rect<s32> rect(0, 0, 300 * s, 20 * s);
+		rect = rect + v2s32(size.X / 2 - 150 * s, size.Y / 2 - 70 * s);
 
 		StaticText::add(Environment, fwgettext("Sound Volume: %d%%", volume),
 				rect, false, true, this, ID_soundText);
 	}
 	{
-		core::rect<s32> rect(0, 0, 80 * s, 30 * s);
-		rect = rect + v2s32(size.X / 2 - 80 * s / 2, size.Y / 2 + 55 * s);
+		core::rect<s32> rect(0, 0, 100 * s, 30 * s);
+		rect = rect + v2s32(size.X / 2 - 100 * s / 2, size.Y / 2 + 55 * s);
 		GUIButton::addButton(Environment, rect, m_tsrc, this, ID_soundExitButton,
 				wstrgettext("Exit").c_str());
 	}
@@ -91,8 +91,8 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 		e->setPos(volume);
 	}
 	{
-		core::rect<s32> rect(0, 0, 160 * s, 20 * s);
-		rect = rect + v2s32(size.X / 2 - 80 * s, size.Y / 2 - 35 * s);
+		core::rect<s32> rect(0, 0, 300 * s, 20 * s);
+		rect = rect + v2s32(size.X / 2 - 150 * s, size.Y / 2 - 35 * s);
 		Environment->addCheckBox(g_settings->getBool("mute_sound"), rect, this,
 				ID_soundMuteButton, wstrgettext("Muted").c_str());
 	}


### PR DESCRIPTION
**Goal of the PR**
This PR tries to make some texts' container in the Volume Change dialog wider to account for translations.

**How does the PR work?**
This PR changes dimensions of some GUI elements in the Volume Change dialog:

| Element | Before | After |
|:------- |:------:|:-----:|
| `Sound Volume: 50%` text | 160 × 20 | 300 × 20 |
| `Muted` checkbox | 160 × 20 | 300 × 20 |
| `Exit` button | 80 × 30 | 100 × 30 |

Those dimensions are set to match the scroll bar width (and in turns making those texts look left-aligned).

**Does it resolve any reported issue?**
Not reported. Some translations get chopped off/wrapped in the Volume Change dialog. See below for examples.

**Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?**
Yes, this PR tries to create a better UI/UX.

## To do

This PR is Ready for Review.

## How to test

1. Set Minetest language to other languages with long string/text for sound volume.
2. Start/restart Minetest to apply the language setting.
3. Play in a world/server.
4. Open the Pause menu (<kbd>Esc</kbd> key).
5. Open the Volume Change dialog (click the Sound Volume button).
6. Read the text. Make sure that the text is not chopped/wrapped.

### Test results

| Lang. | Before | After |
|:-----:|:------:|:-----:|
| `es` | ![es before](https://github.com/minetest/minetest/assets/4017302/2cdf5759-4c65-4d4d-a625-5c0840b721f8) | ![es after](https://github.com/minetest/minetest/assets/4017302/3e17ccbe-d3aa-482c-8b9b-81353fae8f36) |
| `fi` | ![fi before](https://github.com/minetest/minetest/assets/4017302/248274ca-8403-4cbf-befc-bc06d7bee0cc) | ![fi after](https://github.com/minetest/minetest/assets/4017302/7d729d0f-2c12-4c1b-bbda-6975cbd28090) |
| `fil` | ![fil before](https://github.com/minetest/minetest/assets/4017302/cfa3bcd4-69a0-49a7-9ebd-4f90ffda8895) | ![fil after](https://github.com/minetest/minetest/assets/4017302/8a562937-c8ad-43a3-93c4-2e7537d38791) |
| `ru` | ![ru before](https://github.com/minetest/minetest/assets/4017302/f9f9d869-aa1a-4177-a7cc-4dd168ef44a5) | ![ru after](https://github.com/minetest/minetest/assets/4017302/bf26c179-bd23-4f74-add9-2bc2c0c9a803) |
