### PR TITLE
fix documentation of precision of floating point values

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7295,7 +7295,7 @@ of the `${k}` syntax in formspecs is not deprecated.
       The value will be converted into a string when stored.
 * `get_int(key)`: Returns `0` if key not present.
 * `set_float(key, value)`
-    * The range for the value is system-dependent (usually 32 bits).
+    * The range for the value is system-dependent (usually double precision).
       The value will be converted into a string when stored.
 * `get_float(key)`: Returns `0` if key not present.
 * `get_keys()`: returns a list of all keys in the metadata.


### PR DESCRIPTION
in #13855, documentation was added about the ranges of legal values for int and float datatypes for metadata. however, it wrongly states that floats are "usually 32 bits", when in fact they're usually double-precision values (64 bits). 
