### PR TITLE
Fix texture filtering regressions

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -381,21 +381,35 @@ enable_3d_clouds (3D clouds) bool true
 
 [**Filtering and Antialiasing]
 
-#    Use mipmaps when scaling textures down. May slightly increase performance,
-#    especially when using a high-resolution texture pack.
-#    Gamma-correct downscaling is not supported.
+#    Use mipmapping to scale textures. May slightly increase performance,
+#    especially when using a high resolution texture pack.
+#    Gamma correct downscaling is not supported.
 mip_map (Mipmapping) bool false
 
-#    Use bilinear filtering when scaling textures down.
+#    Use anisotropic filtering when viewing at textures from an angle.
+anisotropic_filter (Anisotropic filtering) bool false
+
+#    Use bilinear filtering when scaling textures.
 bilinear_filter (Bilinear filtering) bool false
 
-#    Use trilinear filtering when scaling textures down.
-#    If both bilinear and trilinear filtering are enabled, trilinear filtering
-#    is applied.
+#    Use trilinear filtering when scaling textures.
 trilinear_filter (Trilinear filtering) bool false
 
-#    Use anisotropic filtering when looking at textures from an angle.
-anisotropic_filter (Anisotropic filtering) bool false
+#    Filtered textures can blend RGB values with fully-transparent neighbors,
+#    which PNG optimizers usually discard, often resulting in dark or
+#    light edges to transparent textures. Apply a filter to clean that up
+#    at texture load time. This is automatically enabled if mipmapping is enabled.
+texture_clean_transparent (Clean transparent textures) bool false
+
+#    When using bilinear/trilinear/anisotropic filters, low-resolution textures
+#    can be blurred, so automatically upscale them with nearest-neighbor
+#    interpolation to preserve crisp pixels. This sets the minimum texture size
+#    for the upscaled textures; higher values look sharper, but require more
+#    memory. Powers of 2 are recommended. This setting is ONLY applied if
+#    bilinear/trilinear/anisotropic filtering is enabled.
+#    This is also used as the base node texture size for world-aligned
+#    texture autoscaling.
+texture_min_size (Minimum texture size) int 64 1 32768
 
 #    Select the antialiasing method to apply.
 #
@@ -1826,9 +1840,6 @@ world_aligned_mode (World-aligned textures mode) enum enable disable,enable,forc
 #    See also texture_min_size.
 #    Warning: This option is EXPERIMENTAL!
 autoscale_mode (Autoscaling mode) enum disable disable,enable,force
-
-#    The base node texture size used for world-aligned texture autoscaling.
-texture_min_size (Base texture size) int 64 1 32768
 
 #    Side length of a cube of map blocks that the client will consider together
 #    when generating meshes.

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -19,7 +19,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "clientmap.h"
 #include "client.h"
-#include "client/mesh.h"
 #include "mapblock_mesh.h"
 #include <IMaterialRenderer.h>
 #include <matrix4.h>
@@ -845,7 +844,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 
 			// Apply filter settings
 			material.forEachTexture([this] (auto &tex) {
-				setMaterialFilters(tex, m_cache_bilinear_filter, m_cache_trilinear_filter,
+				tex.setFiltersMinetest(m_cache_bilinear_filter, m_cache_trilinear_filter,
 						m_cache_anistropic_filter);
 			});
 			material.Wireframe = m_control.show_wireframe;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1353,7 +1353,7 @@ void GenericCAO::updateTextures(std::string mod)
 			}
 
 			material.forEachTexture([=] (auto &tex) {
-				setMaterialFilters(tex, use_bilinear_filter, use_trilinear_filter,
+				tex.setFiltersMinetest(use_bilinear_filter, use_trilinear_filter,
 						use_anisotropic_filter);
 			});
 		}
@@ -1381,8 +1381,15 @@ void GenericCAO::updateTextures(std::string mod)
 				material.Lighting = true;
 				material.BackfaceCulling = m_prop.backface_culling;
 
+				// don't filter low-res textures, makes them look blurry
+				// player models have a res of 64
+				const core::dimension2d<u32> &size = texture->getOriginalSize();
+				const u32 res = std::min(size.Height, size.Width);
+				use_trilinear_filter &= res > 64;
+				use_bilinear_filter &= res > 64;
+
 				material.forEachTexture([=] (auto &tex) {
-					setMaterialFilters(tex, use_bilinear_filter, use_trilinear_filter,
+					tex.setFiltersMinetest(use_bilinear_filter, use_trilinear_filter,
 							use_anisotropic_filter);
 				});
 			}
@@ -1429,7 +1436,7 @@ void GenericCAO::updateTextures(std::string mod)
 				}
 
 				material.forEachTexture([=] (auto &tex) {
-					setMaterialFilters(tex, use_bilinear_filter, use_trilinear_filter,
+					tex.setFiltersMinetest(use_bilinear_filter, use_trilinear_filter,
 							use_anisotropic_filter);
 				});
 			}
@@ -1454,7 +1461,7 @@ void GenericCAO::updateTextures(std::string mod)
 				}
 
 				material.forEachTexture([=] (auto &tex) {
-					setMaterialFilters(tex, use_bilinear_filter, use_trilinear_filter,
+					tex.setFiltersMinetest(use_bilinear_filter, use_trilinear_filter,
 							use_anisotropic_filter);
 				});
 			}
@@ -1483,7 +1490,7 @@ void GenericCAO::updateTextures(std::string mod)
 				}
 
 				material.forEachTexture([=] (auto &tex) {
-					setMaterialFilters(tex, use_bilinear_filter, use_trilinear_filter,
+					tex.setFiltersMinetest(use_bilinear_filter, use_trilinear_filter,
 							use_anisotropic_filter);
 				});
 			}

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -505,18 +505,3 @@ scene::IMesh* convertNodeboxesToMesh(const std::vector<aabb3f> &boxes,
 	}
 	return dst_mesh;
 }
-
-void setMaterialFilters(video::SMaterialLayer &tex, bool bilinear, bool trilinear, bool anisotropic) {
-	if (trilinear)
-		tex.MinFilter = video::ETMINF_LINEAR_MIPMAP_LINEAR;
-	else if (bilinear)
-		tex.MinFilter = video::ETMINF_LINEAR_MIPMAP_NEAREST;
-	else
-		tex.MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
-
-	// "We don't want blurriness after all." ~ Desour, #13108
-	// (because of pixel art)
-	tex.MagFilter = video::ETMAGF_NEAREST;
-
-	tex.AnisotropicFilter = anisotropic ? 0xFF : 0;
-}

--- a/src/client/mesh.h
+++ b/src/client/mesh.h
@@ -19,7 +19,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "SMaterialLayer.h"
 #include "irrlichttypes_extrabloated.h"
 #include "nodedef.h"
 
@@ -134,10 +133,3 @@ void recalculateBoundingBox(scene::IMesh *src_mesh);
 	We assume normal to be valid when it's 0 < length < Inf. and not NaN
  */
 bool checkMeshNormals(scene::IMesh *mesh);
-
-/*
-	Set the MinFilter, MagFilter and AnisotropicFilter properties of a texture
-	layer according to the three relevant boolean values found in the Minetest
-	settings.
-*/ 
-void setMaterialFilters(video::SMaterialLayer &tex, bool bilinear, bool trilinear, bool anisotropic);

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -433,8 +433,10 @@ private:
 	// Maps image file names to loaded palettes.
 	std::unordered_map<std::string, Palette> m_palettes;
 
-	// Cached settings needed for making textures for meshes
-	bool m_mesh_texture_prefilter;
+	// Cached settings needed for making textures from meshes
+	bool m_setting_mipmap;
+	bool m_setting_trilinear_filter;
+	bool m_setting_bilinear_filter;
 };
 
 IWritableTextureSource *createTextureSource()
@@ -453,9 +455,9 @@ TextureSource::TextureSource()
 	// Cache some settings
 	// Note: Since this is only done once, the game must be restarted
 	// for these settings to take effect
-	m_mesh_texture_prefilter =
-			g_settings->getBool("mip_map") || g_settings->getBool("bilinear_filter") ||
-			g_settings->getBool("trilinear_filter") || g_settings->getBool("anisotropic_filter");
+	m_setting_mipmap = g_settings->getBool("mip_map");
+	m_setting_trilinear_filter = g_settings->getBool("trilinear_filter");
+	m_setting_bilinear_filter = g_settings->getBool("bilinear_filter");
 }
 
 TextureSource::~TextureSource()
@@ -699,8 +701,12 @@ video::ITexture* TextureSource::getTexture(const std::string &name, u32 *id)
 
 video::ITexture* TextureSource::getTextureForMesh(const std::string &name, u32 *id)
 {
+	static thread_local bool filter_needed =
+		g_settings->getBool("texture_clean_transparent") || m_setting_mipmap ||
+		((m_setting_trilinear_filter || m_setting_bilinear_filter) &&
+		g_settings->getS32("texture_min_size") > 1);
 	// Avoid duplicating texture if it won't actually change
-	if (m_mesh_texture_prefilter)
+	if (filter_needed)
 		return getTexture(name + "^[applyfiltersformesh", id);
 	return getTexture(name, id);
 }
@@ -1735,8 +1741,46 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			}
 
 			// Apply the "clean transparent" filter, if needed
-			if (m_mesh_texture_prefilter)
+			if (m_setting_mipmap || g_settings->getBool("texture_clean_transparent"))
 				imageCleanTransparent(baseimg, 127);
+
+			/* Upscale textures to user's requested minimum size.  This is a trick to make
+			 * filters look as good on low-res textures as on high-res ones, by making
+			 * low-res textures BECOME high-res ones.  This is helpful for worlds that
+			 * mix high- and low-res textures, or for mods with least-common-denominator
+			 * textures that don't have the resources to offer high-res alternatives.
+			 */
+			const bool filter = m_setting_trilinear_filter || m_setting_bilinear_filter;
+			const s32 scaleto = filter ? g_settings->getU16("texture_min_size") : 1;
+			if (scaleto > 1) {
+				const core::dimension2d<u32> dim = baseimg->getDimension();
+
+				/* Calculate scaling needed to make the shortest texture dimension
+				 * equal to the target minimum.  If e.g. this is a vertical frames
+				 * animation, the short dimension will be the real size.
+				 */
+				if ((dim.Width == 0) || (dim.Height == 0)) {
+					errorstream << "generateImagePart(): Illegal 0 dimension "
+						<< "for part_of_name=\""<< part_of_name
+						<< "\", cancelling." << std::endl;
+					return false;
+				}
+				u32 xscale = scaleto / dim.Width;
+				u32 yscale = scaleto / dim.Height;
+				u32 scale = (xscale > yscale) ? xscale : yscale;
+
+				// Never downscale; only scale up by 2x or more.
+				if (scale > 1) {
+					u32 w = scale * dim.Width;
+					u32 h = scale * dim.Height;
+					const core::dimension2d<u32> newdim = core::dimension2d<u32>(w, h);
+					video::IImage *newimg = driver->createImage(
+							baseimg->getColorFormat(), newdim);
+					baseimg->copyToScaling(newimg);
+					baseimg->drop();
+					baseimg = newimg;
+				}
+			}
 		}
 		/*
 			[resize:WxH

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -297,8 +297,11 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 		material.MaterialType = m_material_type;
 		material.MaterialTypeParam = 0.5f;
 		material.BackfaceCulling = true;
+		// Enable bi/trilinear filtering only for high resolution textures
+		bool bilinear_filter = dim.Width > 32 && m_bilinear_filter;
+		bool trilinear_filter = dim.Width > 32 && m_trilinear_filter;
 		material.forEachTexture([=] (auto &tex) {
-			setMaterialFilters(tex, m_bilinear_filter, m_trilinear_filter,
+			tex.setFiltersMinetest(bilinear_filter, trilinear_filter,
 					m_anisotropic_filter);
 		});
 		// mipmaps cause "thin black line" artifacts
@@ -463,7 +466,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 			material.MaterialTypeParam = 0.5f;
 			material.BackfaceCulling = cull_backface;
 			material.forEachTexture([this] (auto &tex) {
-				setMaterialFilters(tex, m_bilinear_filter, m_trilinear_filter,
+				tex.setFiltersMinetest(m_bilinear_filter, m_trilinear_filter,
 						m_anisotropic_filter);
 			});
 		}

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -176,7 +176,6 @@ void set_default_settings()
 	settings->setDefault("undersampling", "1");
 	settings->setDefault("world_aligned_mode", "enable");
 	settings->setDefault("autoscale_mode", "disable");
-	settings->setDefault("texture_min_size", "64");
 	settings->setDefault("enable_fog", "true");
 	settings->setDefault("fog_start", "0.4");
 	settings->setDefault("3d_mode", "none");
@@ -236,6 +235,8 @@ void set_default_settings()
 	settings->setDefault("hud_hotbar_max_width", "1.0");
 	settings->setDefault("enable_local_map_saving", "false");
 	settings->setDefault("show_entity_selectionbox", "false");
+	settings->setDefault("texture_clean_transparent", "false");
+	settings->setDefault("texture_min_size", "64");
 	settings->setDefault("ambient_occlusion_gamma", "1.8");
 	settings->setDefault("enable_shaders", "true");
 	settings->setDefault("enable_particles", "true");
@@ -251,9 +252,9 @@ void set_default_settings()
 	settings->setDefault("directional_colored_fog", "true");
 	settings->setDefault("inventory_items_animations", "false");
 	settings->setDefault("mip_map", "false");
+	settings->setDefault("anisotropic_filter", "false");
 	settings->setDefault("bilinear_filter", "false");
 	settings->setDefault("trilinear_filter", "false");
-	settings->setDefault("anisotropic_filter", "false");
 	settings->setDefault("tone_mapping", "false");
 	settings->setDefault("enable_waving_water", "false");
 	settings->setDefault("water_wave_height", "1.0");


### PR DESCRIPTION
This reverts commit 72ef90885d5030bf6f7f9dd60a475339bde9a929. It needs the irrlichtmt patch from https://github.com/minetest/irrlicht/pull/254 to compile.

The reverted commit caused several regressions in rendering textures
using bilinear, trilinear or anisotropic filtering. In particular:

* Textures with a height or width lower than “texture_min_size” were no
  longer upscaled and then filtered – textures were not filtered at all
  when being upscaled instead, to achieve a crisper look. To users this
  looked like bilinear and trilinear filtering options were not working,
  as most textures in Minetest are rather small and thus often upscaled.
  Anisotropic filter effects were affected in different ways; depending
   on vendor filtering could happen when upscaling textures (see below).

* On Intel GPUs (and possibly others), anisotropic filtering would blur
  textures with small height or width extremely due to GL_NEAREST being
  set. The effect of that combination depends on driver internals – see
  <https://github.com/KhronosGroup/Vulkan-Docs/issues/1361> and Vulkan
  1.3.249 spec update for details. Note that Khronos Group explicitly
  warned against using GL_NEAREST in this scenario, as it can not be
  expected to result in a consistent look with different GPUs, ever.

### How to test

You need the oddly sized checkerboard test nodes from this PR of mine: https://github.com/minetest/minetest/pull/13955

I have made them available separately: <https://git.minetest.land/erlehmann/oddly_sized_checkerboard_testnodes_2>

Always compare between:

a) A version of Minetest before commit 72ef90885d5030bf6f7f9dd60a475339bde9a929.
b) A version of Minetest between commit 72ef90885d5030bf6f7f9dd60a475339bde9a929 and Minetest with this patch.
c) The version of MInetest with this patch.

#### Steps

1. Compare how checkerboard test nodes with the same tiling look without filtering. They should look the same across all versions.
2. Compare how checkerboard test nodes with the same tiling look with bilinear filtering. They should look the same in the version of Minetest with this patch and before 72ef90885d5030bf6f7f9dd60a475339bde9a929 and unfiltered in 72ef90885d5030bf6f7f9dd60a475339bde9a929 .
3. Compare how checkerboard test nodes with the same tiling look with trilinear filtering. They should look the same in the version of Minetest with this patch and before 72ef90885d5030bf6f7f9dd60a475339bde9a929 and unfiltered in 72ef90885d5030bf6f7f9dd60a475339bde9a929 .
4. Compare how checkerboard test nodes with the same tiling look with anisotropic filtering:  They should look the same in the version of Minetest with this patch and before 72ef90885d5030bf6f7f9dd60a475339bde9a929 and at least with intel GPUs should have a bilinear filtered look in 72ef90885d5030bf6f7f9dd60a475339bde9a929  even if bilinear filtering is turned off.