### PR TITLE
[NOSQUASH :3] Fix some invalid float to integer conversions

### DIFF
--- a/games/devtest/mods/testnodes/properties.lua
+++ b/games/devtest/mods/testnodes/properties.lua
@@ -428,17 +428,17 @@ local MAX_BOUNCE_NONJUMPY = 140
 for i=-MAX_BOUNCE_NONJUMPY, MAX_BOUNCE_JUMPY, 20 do
 	if i ~= 0 then
 		local desc
-		local val = math.floor(((i-20)/200)*255)
-		local val2 = math.max(0, 200 - val)
+		local val = math.floor((math.abs(i) - 20) / 200 * 255)
+		local val2 = math.max(0, 255 - val)
 		local num = string.format("%03d", math.abs(i))
 		if i > 0 then
 			desc = S("Bouncy Node (@1%), jumpy", i).."\n"..
 				S("Sneaking/jumping affects bounce")
-			color = { r=255-val, g=255-val, b=255, a=255 }
+			color = { r=val2, g=val2, b=255, a=255 }
 		else
 			desc = S("Bouncy Node (@1%), non-jumpy", math.abs(i)).."\n"..
 				S("Sneaking/jumping does not affect bounce")
-			color = { r=val, g=255, b=val, a=255 }
+			color = { r=val2, g=255, b=val2, a=255 }
 			num = "NEG"..num
 		end
 		minetest.register_node("testnodes:bouncy"..num, {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1034,9 +1034,9 @@ void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *
 	s32 yaw          = myplayer->getYaw() * 100;
 	u32 keyPressed   = myplayer->control.getKeysPressed();
 	// scaled by 80, so that pi can fit into a u8
-	u8 fov           = clientMap->getCameraFov() * 80;
-	u8 wanted_range  = MYMIN(255,
-			std::ceil(clientMap->getControl().wanted_range / MAP_BLOCKSIZE));
+	u8 fov           = std::fmin(255.0f, clientMap->getCameraFov() * 80.0f);
+	u8 wanted_range  = std::fmin(255.0f,
+			std::ceil(clientMap->getWantedRange() * (1.0f / MAP_BLOCKSIZE)));
 
 	v3s32 position(pf.X, pf.Y, pf.Z);
 	v3s32 speed(sf.X, sf.Y, sf.Z);
@@ -1385,8 +1385,9 @@ void Client::sendPlayerPos()
 		return;
 
 	ClientMap &map = m_env.getClientMap();
-	u8 camera_fov   = map.getCameraFov();
-	u8 wanted_range = map.getControl().wanted_range;
+	u8 camera_fov   = std::fmin(255.0f, map.getCameraFov() * 80.0f);
+	u8 wanted_range = std::fmin(255.0f,
+			std::ceil(map.getWantedRange() * (1.0f / MAP_BLOCKSIZE)));
 
 	u32 keyPressed = player->control.getKeysPressed();
 	bool camera_inverted = m_camera->getCameraMode() == CAMERA_MODE_THIRD_FRONT;

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -266,8 +266,8 @@ void GUIScrollBar::setPos(const s32 &pos)
 	}
 
 	if (is_auto_scaling)
-		thumb_size = s32(thumb_area /
-				 (f32(page_size) / f32(thumb_area + border_size * 2)));
+		thumb_size = (s32)std::fmin(S32_MAX,
+				thumb_area / (f32(page_size) / f32(thumb_area + border_size * 2)));
 
 	thumb_size = core::s32_clamp(thumb_size, thumb_min, thumb_area);
 	scroll_pos = core::s32_clamp(pos, min_pos, max_pos);

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -294,19 +294,23 @@ bool read_color(lua_State *L, int index, video::SColor *color)
 
 video::SColor read_ARGB8(lua_State *L, int index)
 {
+	auto clamp_col = [](double c) -> u32 {
+		return std::fmax(0.0, std::fmin(255.0, c));
+	};
+
 	video::SColor color(0);
 	CHECK_TYPE(index, "ARGB color", LUA_TTABLE);
 	lua_getfield(L, index, "a");
-	color.setAlpha(lua_isnumber(L, -1) ? lua_tonumber(L, -1) : 0xFF);
+	color.setAlpha(lua_isnumber(L, -1) ? clamp_col(lua_tonumber(L, -1)) : 0xFF);
 	lua_pop(L, 1);
 	lua_getfield(L, index, "r");
-	color.setRed(lua_tonumber(L, -1));
+	color.setRed(clamp_col(lua_tonumber(L, -1)));
 	lua_pop(L, 1);
 	lua_getfield(L, index, "g");
-	color.setGreen(lua_tonumber(L, -1));
+	color.setGreen(clamp_col(lua_tonumber(L, -1)));
 	lua_pop(L, 1);
 	lua_getfield(L, index, "b");
-	color.setBlue(lua_tonumber(L, -1));
+	color.setBlue(clamp_col(lua_tonumber(L, -1)));
 	lua_pop(L, 1);
 	return color;
 }


### PR DESCRIPTION
* Fixes  #13979, and more.
* There are more easy things left in irrlicht, FYI.
* The bouncy nodes in devtest used invalid color values, so I fixed that, as the invalid values now cause other colors than before. (Issuing warnings for invalid colors might be better, but idk how to do that properly, and without spamming.) (Btw. why does devtest's luacheckrc ignore unused vars?)

## To do

This PR is a Ready for Review.

## How to test

* Read.
* Compile with clang's sanitizers. (gcc doesn't catch these.)
* Start devtest.
