### PR TITLE
GUIFormspecMenu: Fix race condition between quit event and cleanup in Game

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4124,6 +4124,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 			break;
 
 		if (formspec->getReferenceCount() == 1) {
+			// See GUIFormSpecMenu::create what refcnt = 1 means
 			m_game_ui->deleteFormspec();
 			break;
 		}


### PR DESCRIPTION
To not instantly free GUIFormSpec upon close/quit, Game periodically cleans up the remaining instance on the next frame.

When a new formspec is received and processed after closing the previous formspec but before the cleanup in Game, the formspec would be closed regardless. This now re-creates the formspec when the old one is already pending for removal.

Fixes #11907

## To do

This PR is Ready for Review.

## How to test

1. See sample code in #11907
2. Hold down Enter
    * master: the formspec closes after a few tries
    * PR: it should never close


