### PR TITLE
Return texture filter settings to previous state

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -381,15 +381,15 @@ enable_3d_clouds (3D clouds) bool true
 
 [**Filtering and Antialiasing]
 
-#    Use mipmaps when scaling textures down. May slightly increase performance,
+#    Use mipmaps when scaling textures. May slightly increase performance,
 #    especially when using a high-resolution texture pack.
 #    Gamma-correct downscaling is not supported.
 mip_map (Mipmapping) bool false
 
-#    Use bilinear filtering when scaling textures down.
+#    Use bilinear filtering when scaling textures.
 bilinear_filter (Bilinear filtering) bool false
 
-#    Use trilinear filtering when scaling textures down.
+#    Use trilinear filtering when scaling textures.
 #    If both bilinear and trilinear filtering are enabled, trilinear filtering
 #    is applied.
 trilinear_filter (Trilinear filtering) bool false
@@ -1827,7 +1827,14 @@ world_aligned_mode (World-aligned textures mode) enum enable disable,enable,forc
 #    Warning: This option is EXPERIMENTAL!
 autoscale_mode (Autoscaling mode) enum disable disable,enable,force
 
-#    The base node texture size used for world-aligned texture autoscaling.
+#    When using bilinear/trilinear/anisotropic filters, low-resolution textures
+#    can be blurred, so automatically upscale them with nearest-neighbor
+#    interpolation to preserve crisp pixels. This sets the minimum texture size
+#    for the upscaled textures; higher values look sharper, but require more
+#    memory. Powers of 2 are recommended. This setting is ONLY applied if
+#    bilinear/trilinear/anisotropic filtering is enabled.
+#    This is also used as the base node texture size for world-aligned
+#    texture autoscaling.
 texture_min_size (Base texture size) int 64 1 32768
 
 #    Side length of a cube of map blocks that the client will consider together

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1381,6 +1381,13 @@ void GenericCAO::updateTextures(std::string mod)
 				material.Lighting = true;
 				material.BackfaceCulling = m_prop.backface_culling;
 
+				// don't filter low-res textures, makes them look blurry
+				// player models have a res of 64
+				const core::dimension2d<u32> &size = texture->getOriginalSize();
+				const u32 res = std::min(size.Height, size.Width);
+				use_trilinear_filter &= res > 64;
+				use_bilinear_filter &= res > 64;
+
 				material.forEachTexture([=] (auto &tex) {
 					setMaterialFilters(tex, use_bilinear_filter, use_trilinear_filter,
 							use_anisotropic_filter);

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -506,7 +506,8 @@ scene::IMesh* convertNodeboxesToMesh(const std::vector<aabb3f> &boxes,
 	return dst_mesh;
 }
 
-void setMaterialFilters(video::SMaterialLayer &tex, bool bilinear, bool trilinear, bool anisotropic) {
+void setMaterialFilters(video::SMaterialLayer &tex, bool bilinear, bool trilinear, bool anisotropic)
+{
 	if (trilinear)
 		tex.MinFilter = video::ETMINF_LINEAR_MIPMAP_LINEAR;
 	else if (bilinear)
@@ -514,9 +515,7 @@ void setMaterialFilters(video::SMaterialLayer &tex, bool bilinear, bool trilinea
 	else
 		tex.MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
 
-	// "We don't want blurriness after all." ~ Desour, #13108
-	// (because of pixel art)
-	tex.MagFilter = video::ETMAGF_NEAREST;
+	tex.MagFilter = (trilinear || bilinear) ? video::ETMAGF_LINEAR : video::ETMAGF_NEAREST;
 
 	tex.AnisotropicFilter = anisotropic ? 0xFF : 0;
 }

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -297,8 +297,11 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 		material.MaterialType = m_material_type;
 		material.MaterialTypeParam = 0.5f;
 		material.BackfaceCulling = true;
+		// Enable bi/trilinear filtering only for high resolution textures
+		bool bilinear_filter = dim.Width > 32 && m_bilinear_filter;
+		bool trilinear_filter = dim.Width > 32 && m_trilinear_filter;
 		material.forEachTexture([=] (auto &tex) {
-			setMaterialFilters(tex, m_bilinear_filter, m_trilinear_filter,
+			setMaterialFilters(tex, bilinear_filter, trilinear_filter,
 					m_anisotropic_filter);
 		});
 		// mipmaps cause "thin black line" artifacts


### PR DESCRIPTION
original commit for reference: 72ef90885d5030bf6f7f9dd60a475339bde9a929

`texture_clean_transparent` was not returned since it's automatically enabled when needed and it's useless in other cases
