### PR TITLE
Inventory: Add remaining items into the source slot directly

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4643,6 +4643,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			// The split amount will always at least one, because the number
 			// of slots will never be greater than the selected amount
 			u16 split_amount = m_left_drag_amount / m_left_drag_stacks.size();
+			u16 split_remaining = m_left_drag_amount % m_left_drag_stacks.size();
 
 			ItemStack stack_from = m_left_drag_stack;
 			m_selected_amount = m_left_drag_amount;
@@ -4653,7 +4654,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 				if (ds.first == *m_selected_item) {
 					// Adding to the source stack, just change the selected amount
-					m_selected_amount -= split_amount;
+					m_selected_amount -= split_amount + split_remaining;
 
 				} else {
 					// Reset the stack to its original state


### PR DESCRIPTION
**Goal of the PR**
This PR tries to fix remaining items hanging to the pointer when splitting a stack evenly (click/tap + drag) in some cases.

**How does the PR work?**
This PR adds the remaining items into the source slot directly.

Currently, it only adds the result of division. This works when the original/source slot is not selected because the remaining items will be left there, but does not work when the original slot is selected (not empty).

**Does it resolve any reported issue?**
Yes, reported in PR 13872 by SmallJoker.

**Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?**
Yes, this PR fixes a UI/UX issue.

## To do

This PR is Ready for Review.

## How to test

1. Play in a world/server.
2. Open an inventory menu.
3. Single-click or single-tap a stack with `n` items.
4. Mouse-down or tap-and-hold the original/source slot.
5. Drag until visiting `k` slots.
6. Mouse-up or release-tap.
7. There should be no items left at the pointer.
8. Redo step 3–6, except start dragging _not_ from the original slot, but still visiting the original slot. There should be no items left at the pointer.
9. Redo step 8, but not visiting the original slot. The remaining items should be put back in the original slot.

The table below lists some `n` and `k` values that this PR fixes. The formula is

1. `n` is odd and `k` is 2 or
2. `n` is odd and `k` is `ceil(n / 2)`.

| `n` | `k` |
|:---:|:---:|
| 3 | 2 |
| 5 | 2 or 3 |
| 7 | 2 or 4 |
| 9 | 2 or 5 |
| 11 | 2 or 6 |
| 13 | 2 or 7 |
| 15 | 2 or 8 |
| 17 | 2 or 9 |
| 19 | 2 or 10 |
