### PR TITLE
Made sure var 'pos' was only assigned locally to function

### DIFF
--- a/util/wireshark/minetest.lua
+++ b/util/wireshark/minetest.lua
@@ -1299,6 +1299,7 @@ do
 		t:set_text("Minetest, Peer: " .. buffer(4,2):uint() .. ", Channel: " .. buffer(6,1):uint())
 
 		local reliability_info
+		local pos
 		if buffer(7,1):uint() == 3 then
 			-- Reliable message
 			reliability_info = "Seq=" .. buffer(8,2):uint()


### PR DESCRIPTION
The function is assigning to a var named `pos` but it was not declared as local, instead it was assigning to a global variable. Considering it's a really common name for a var, which messes with IDE linting, and that the fix is tiny, I think it's worth just making it `local`.

## To do

Ready for Review.

## How to test

n/a
