### PR TITLE
Make it possible again to see item tooltips on Android

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3633,7 +3633,7 @@ void GUIFormSpecMenu::drawMenu()
 			NULL, m_client, IT_ROT_HOVERED);
 	}
 
-/* TODO find way to show tooltips on touchscreen */
+	// On touchscreens, m_pointer is set by GUIModalMenu::preprocessEvent instead.
 #ifndef HAVE_TOUCHSCREENGUI
 	m_pointer = RenderingEngine::get_raw_device()->getCursorControl()->getPosition();
 #endif

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -154,8 +154,7 @@ void GUIInventoryList::draw()
 		bool show_tooltip = !item.empty() && hovering && !selected_item;
 #ifdef HAVE_TOUCHSCREENGUI
 		// Make it possible to see item tooltips on touchscreens
-		// Note that the selected item can't be empty during drawing.
-		show_tooltip |= hovering && selected;
+		show_tooltip |= hovering && selected && m_fs_menu->getSelectedAmount() != 0;
 #endif
 		if (show_tooltip) {
 			std::string tooltip = orig_item.getDescription(client->idef());

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -99,6 +99,7 @@ void GUIInventoryList::draw()
 				(i / m_geom.X) * m_slot_spacing.Y);
 		core::rect<s32> rect = imgrect + base_pos + p;
 		ItemStack item = ilist->getItem(item_i);
+		ItemStack orig_item = item;
 
 		bool selected = selected_item
 			&& m_invmgr->getInventory(selected_item->inventoryloc) == inv
@@ -147,13 +148,20 @@ void GUIInventoryList::draw()
 			// Draw item stack
 			drawItemStack(driver, m_font, item, rect, &AbsoluteClippingRect,
 					client, rotation_kind);
-			// Add hovering tooltip
-			if (hovering && !selected_item) {
-				std::string tooltip = item.getDescription(client->idef());
-				if (m_fs_menu->doTooltipAppendItemname())
-					tooltip += "\n[" + item.name + "]";
-				m_fs_menu->addHoveredItemTooltip(tooltip);
-			}
+		}
+
+		// Add hovering tooltip
+		bool show_tooltip = !item.empty() && hovering && !selected_item;
+#ifdef HAVE_TOUCHSCREENGUI
+		// Make it possible to see item tooltips on touchscreens
+		// Note that the selected item can't be empty during drawing.
+		show_tooltip |= hovering && selected;
+#endif
+		if (show_tooltip) {
+			std::string tooltip = orig_item.getDescription(client->idef());
+			if (m_fs_menu->doTooltipAppendItemname())
+				tooltip += "\n[" + orig_item.name + "]";
+			m_fs_menu->addHoveredItemTooltip(tooltip);
 		}
 	}
 


### PR DESCRIPTION
This PR is a quick fix so that item tooltips show again on Android. Fixes (<- Github, don't link this please) https://github.com/minetest/minetest/issues/13822#issuecomment-1773789974, a regression from #13146.

Please test this PR and let me know whether you think that the new behavior of the tooltips makes sense.

## To do

This PR is a Ready for Review.

## How to test

Play Minetest on a desktop computer. Verify that item tooltips still work the same as before.

Play Minetest on Android. Verify that it is possible to see item tooltips.
