### PR TITLE
Fix weblink to Database_backends wiki page

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4085,7 +4085,7 @@ ModStorageDatabase *Server::openModStorageDatabase(const std::string &world_path
 		warningstream << "/!\\ You are using the old mod storage files backend. "
 			<< "This backend is deprecated and may be removed in a future release /!\\"
 			<< std::endl << "Switching to SQLite3 is advised, "
-			<< "please read http://wiki.minetest.net/Database_backends." << std::endl;
+			<< "please read http://wiki.minetest.net/Database_backends ." << std::endl;
 
 	return openModStorageDatabase(backend, world_path, world_mt);
 }

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -485,14 +485,14 @@ void ServerEnvironment::init()
 		warningstream << "/!\\ You are using old player file backend. "
 				<< "This backend is deprecated and will be removed in a future release /!\\"
 				<< std::endl << "Switching to SQLite3 or PostgreSQL is advised, "
-				<< "please read http://wiki.minetest.net/Database_backends." << std::endl;
+				<< "please read http://wiki.minetest.net/Database_backends ." << std::endl;
 	}
 
 	if (auth_backend_name == "files") {
 		warningstream << "/!\\ You are using old auth file backend. "
 				<< "This backend is deprecated and will be removed in a future release /!\\"
 				<< std::endl << "Switching to SQLite3 is advised, "
-				<< "please read http://wiki.minetest.net/Database_backends." << std::endl;
+				<< "please read http://wiki.minetest.net/Database_backends ." << std::endl;
 	}
 
 	m_player_database = openPlayerDatabase(player_backend_name, m_path_world, conf);


### PR DESCRIPTION
`clickable_chat_weblinks` considers the `.` at the end as part of the URI, and opens <http://wiki.minetest.net/Database_backends.>.
Note that using angle brackets (`<link>`) is sadly also not supported by `clickable_chat_weblinks`.

## To do

This PR is a Ready for Review.

## How to test

* Enable `clickable_chat_weblinks`.
* Open an old world, or migrate to old db backend.
* Open chat, ctrl+click the link.
