### PR TITLE
Add function to get all hud elements

### DIFF
--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -1152,6 +1152,8 @@ Methods:
     * See [`HUD definition`](#hud-definition-hud_add-hud_get)
 * `hud_get(id)`
     * returns the [`definition`](#hud-definition-hud_add-hud_get) of the HUD with that ID number or `nil`, if non-existent.
+* `hud_get_elements()`:
+    * returns a table indexed by all present HUD IDs and containing corresponding HUD element definition structures.
 * `hud_remove(id)`
     * remove the HUD element of the specified id, returns `true` on success
 * `hud_change(id, stat, value)`

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -1155,7 +1155,7 @@ Methods:
 * `hud_get_elements()`:
     * returns a table indexed by all present HUD IDs and containing corresponding HUD element definition structures.
     * A mod should keep track of its introduced IDs and only use this to access foreign elements.
-    * It is discourage to change foreign HUD elements.
+    * It is discouraged to change foreign HUD elements.
 * `hud_remove(id)`
     * remove the HUD element of the specified id, returns `true` on success
 * `hud_change(id, stat, value)`

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -1152,7 +1152,7 @@ Methods:
     * See [`HUD definition`](#hud-definition-hud_add-hud_get)
 * `hud_get(id)`
     * returns the [`definition`](#hud-definition-hud_add-hud_get) of the HUD with that ID number or `nil`, if non-existent.
-* `hud_get_elements()`:
+* `hud_get_all()`:
     * Returns a table in the form `{ [id] = HUD definition, [id] = ... }`.
     * A mod should keep track of its introduced IDs and only use this to access foreign elements.
     * It is discouraged to change foreign HUD elements.

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -1153,7 +1153,7 @@ Methods:
 * `hud_get(id)`
     * returns the [`definition`](#hud-definition-hud_add-hud_get) of the HUD with that ID number or `nil`, if non-existent.
 * `hud_get_elements()`:
-    * returns a table indexed by all present HUD IDs and containing corresponding HUD element definition structures.
+    * Returns a table in the form `{ [id] = HUD definition, [id] = ... }`.
     * A mod should keep track of its introduced IDs and only use this to access foreign elements.
     * It is discouraged to change foreign HUD elements.
 * `hud_remove(id)`

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -1154,6 +1154,8 @@ Methods:
     * returns the [`definition`](#hud-definition-hud_add-hud_get) of the HUD with that ID number or `nil`, if non-existent.
 * `hud_get_elements()`:
     * returns a table indexed by all present HUD IDs and containing corresponding HUD element definition structures.
+    * A mod should keep track of its introduced IDs and only use this to access foreign elements.
+    * It is discourage to change foreign HUD elements.
 * `hud_remove(id)`
     * remove the HUD element of the specified id, returns `true` on success
 * `hud_change(id, stat, value)`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7772,6 +7772,8 @@ child will follow movement and rotation of that bone.
     * `stat` supports the same keys as in the hud definition table except for
       `"hud_elem_type"`.
 * `hud_get(id)`: gets the HUD element definition structure of the specified ID
+* `hud_get_elements()`: returns a table indexed by all present HUD IDs and
+  containing corresponding HUD element definition structures.
 * `hud_set_flags(flags)`: sets specified HUD flags of player.
     * `flags`: A table with the following fields set to boolean values
         * `hotbar`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7772,8 +7772,10 @@ child will follow movement and rotation of that bone.
     * `stat` supports the same keys as in the hud definition table except for
       `"hud_elem_type"`.
 * `hud_get(id)`: gets the HUD element definition structure of the specified ID
-* `hud_get_elements()`: returns a table indexed by all present HUD IDs and
-  containing corresponding HUD element definition structures.
+* `hud_get_elements()`:
+    * returns a table indexed by all present HUD IDs and containing corresponding HUD element definition structures.
+    * A mod should keep track of its introduced IDs and only use this to access foreign elements.
+    * It is discourage to change foreign HUD elements.
 * `hud_set_flags(flags)`: sets specified HUD flags of player.
     * `flags`: A table with the following fields set to boolean values
         * `hotbar`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7772,7 +7772,7 @@ child will follow movement and rotation of that bone.
     * `stat` supports the same keys as in the hud definition table except for
       `"hud_elem_type"`.
 * `hud_get(id)`: gets the HUD element definition structure of the specified ID
-* `hud_get_elements()`:
+* `hud_get_all()`:
     * Returns a table in the form `{ [id] = HUD definition, [id] = ... }`.
     * A mod should keep track of its introduced IDs and only use this to access foreign elements.
     * It is discouraged to change foreign HUD elements.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7773,7 +7773,7 @@ child will follow movement and rotation of that bone.
       `"hud_elem_type"`.
 * `hud_get(id)`: gets the HUD element definition structure of the specified ID
 * `hud_get_elements()`:
-    * returns a table indexed by all present HUD IDs and containing corresponding HUD element definition structures.
+    * Returns a table in the form `{ [id] = HUD definition, [id] = ... }`.
     * A mod should keep track of its introduced IDs and only use this to access foreign elements.
     * It is discouraged to change foreign HUD elements.
 * `hud_set_flags(flags)`: sets specified HUD flags of player.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7775,7 +7775,7 @@ child will follow movement and rotation of that bone.
 * `hud_get_elements()`:
     * returns a table indexed by all present HUD IDs and containing corresponding HUD element definition structures.
     * A mod should keep track of its introduced IDs and only use this to access foreign elements.
-    * It is discourage to change foreign HUD elements.
+    * It is discouraged to change foreign HUD elements.
 * `hud_set_flags(flags)`: sets specified HUD flags of player.
     * `flags`: A table with the following fields set to boolean values
         * `hotbar`

--- a/games/devtest/mods/testhud/init.lua
+++ b/games/devtest/mods/testhud/init.lua
@@ -209,3 +209,23 @@ minetest.register_on_leaveplayer(function(player)
 	player_font_huds[player:get_player_name()] = nil
 	player_waypoints[player:get_player_name()] = nil
 end)
+
+minetest.register_chatcommand("hudprint", {
+	description = "Writes all used Lua HUD elements into chat.",
+	func = function(name, params)
+		local player = minetest.get_player_by_name(name)
+		if not player then
+			return false, "No player."
+		end
+		
+		local s = "HUD elements:"
+		for k, elem in pairs(player:hud_get_elements()) do
+			local ename = dump(elem.name)
+			local etype = dump(elem.type)
+			local epos = "{x="..elem.position.x..", y="..elem.position.y.."}"
+			s = s.."\n["..k.."]  type = "..etype.." | name = "..ename.." | pos = ".. epos
+		end
+		
+		return true, s
+	end
+})

--- a/games/devtest/mods/testhud/init.lua
+++ b/games/devtest/mods/testhud/init.lua
@@ -219,7 +219,7 @@ minetest.register_chatcommand("hudprint", {
 		end
 
 		local s = "HUD elements:"
-		for k, elem in pairs(player:hud_get_elements()) do
+		for k, elem in pairs(player:hud_get_all()) do
 			local ename = dump(elem.name)
 			local etype = dump(elem.type)
 			local epos = "{x="..elem.position.x..", y="..elem.position.y.."}"

--- a/games/devtest/mods/testhud/init.lua
+++ b/games/devtest/mods/testhud/init.lua
@@ -217,7 +217,7 @@ minetest.register_chatcommand("hudprint", {
 		if not player then
 			return false, "No player."
 		end
-		
+
 		local s = "HUD elements:"
 		for k, elem in pairs(player:hud_get_elements()) do
 			local ename = dump(elem.name)
@@ -225,7 +225,7 @@ minetest.register_chatcommand("hudprint", {
 			local epos = "{x="..elem.position.x..", y="..elem.position.y.."}"
 			s = s.."\n["..k.."]  type = "..etype.." | name = "..ename.." | pos = ".. epos
 		end
-		
+
 		return true, s
 	end
 })

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -139,10 +139,10 @@ HudElement* Player::getHud(u32 id)
 	return NULL;
 }
 
-u32 Player::getHudIdMax()
+void Player::hudApply(std::function<void(const std::vector<HudElement*>&)> f)
 {
 	MutexAutoLock lock(m_mutex);
-	return hud.size();
+	f(hud);
 }
 
 HudElement* Player::removeHud(u32 id)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -139,6 +139,12 @@ HudElement* Player::getHud(u32 id)
 	return NULL;
 }
 
+u32 Player::getHudIdMax()
+{
+	MutexAutoLock lock(m_mutex);
+	return hud.size();
+}
+
 HudElement* Player::removeHud(u32 id)
 {
 	MutexAutoLock lock(m_mutex);

--- a/src/player.h
+++ b/src/player.h
@@ -225,6 +225,7 @@ public:
 	}
 
 	HudElement* getHud(u32 id);
+	u32         getHudIdMax();
 	u32         addHud(HudElement* hud);
 	HudElement* removeHud(u32 id);
 	void        clearHud();

--- a/src/player.h
+++ b/src/player.h
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/basic_macros.h"
 #include <list>
 #include <mutex>
+#include <functional>
 
 #define PLAYERNAME_SIZE 20
 
@@ -225,7 +226,7 @@ public:
 	}
 
 	HudElement* getHud(u32 id);
-	u32         getHudIdMax();
+	void        hudApply(std::function<void(const std::vector<HudElement*>&)> f);
 	u32         addHud(HudElement* hud);
 	HudElement* removeHud(u32 id);
 	void        clearHud();

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -430,14 +430,15 @@ int LuaLocalPlayer::l_hud_get_elements(lua_State *L)
 		return 0;
 
 	lua_newtable(L);
-	u32 max = player->getHudIdMax();
-	for (u32 id = 0; id < max; id++) {
-		HudElement *elem = player->getHud(id);
-		if (elem != nullptr) {
-			push_hud_element(L, elem);
-			lua_rawseti(L, -2, id);
+	player->hudApply([&](const std::vector<HudElement*>& hud) {
+		for (std::size_t id = 0; id < hud.size(); ++id) {
+			HudElement *elem = hud[id];
+			if (elem != nullptr) {
+				push_hud_element(L, elem);
+				lua_rawseti(L, -2, id);
+			}
 		}
-	}
+	});
 	return 1;
 }
 

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -422,6 +422,25 @@ int LuaLocalPlayer::l_hud_get(lua_State *L)
 	return 1;
 }
 
+// hud_get_elements(self)
+int LuaLocalPlayer::l_hud_get_elements(lua_State *L)
+{
+	LocalPlayer *player = getobject(L, 1);
+	if (player == nullptr)
+		return 0;
+
+	lua_newtable(L);
+	u32 max = player->getHudIdMax();
+	for (u32 id = 0; id < max; id++) {
+		HudElement *elem = player->getHud(id);
+		if (elem != nullptr) {
+			push_hud_element(L, elem);
+			lua_rawseti(L, -2, id+1);
+		}
+	}
+	return 1;
+}
+
 LocalPlayer *LuaLocalPlayer::getobject(LuaLocalPlayer *ref)
 {
 	return ref->m_localplayer;
@@ -483,6 +502,7 @@ const luaL_Reg LuaLocalPlayer::methods[] = {
 		luamethod(LuaLocalPlayer, hud_remove),
 		luamethod(LuaLocalPlayer, hud_change),
 		luamethod(LuaLocalPlayer, hud_get),
+		luamethod(LuaLocalPlayer, hud_get_elements),
 
 		luamethod(LuaLocalPlayer, get_move_resistance),
 

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -435,7 +435,7 @@ int LuaLocalPlayer::l_hud_get_elements(lua_State *L)
 		HudElement *elem = player->getHud(id);
 		if (elem != nullptr) {
 			push_hud_element(L, elem);
-			lua_rawseti(L, -2, id+1);
+			lua_rawseti(L, -2, id);
 		}
 	}
 	return 1;

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -422,8 +422,8 @@ int LuaLocalPlayer::l_hud_get(lua_State *L)
 	return 1;
 }
 
-// hud_get_elements(self)
-int LuaLocalPlayer::l_hud_get_elements(lua_State *L)
+// hud_get_all(self)
+int LuaLocalPlayer::l_hud_get_all(lua_State *L)
 {
 	LocalPlayer *player = getobject(L, 1);
 	if (player == nullptr)
@@ -503,7 +503,7 @@ const luaL_Reg LuaLocalPlayer::methods[] = {
 		luamethod(LuaLocalPlayer, hud_remove),
 		luamethod(LuaLocalPlayer, hud_change),
 		luamethod(LuaLocalPlayer, hud_get),
-		luamethod(LuaLocalPlayer, hud_get_elements),
+		luamethod(LuaLocalPlayer, hud_get_all),
 
 		luamethod(LuaLocalPlayer, get_move_resistance),
 

--- a/src/script/lua_api/l_localplayer.h
+++ b/src/script/lua_api/l_localplayer.h
@@ -93,6 +93,8 @@ private:
 	static int l_hud_change(lua_State *L);
 	// hud_get(self, id)
 	static int l_hud_get(lua_State *L);
+	// hud_get_elements(self)
+	static int l_hud_get_elements(lua_State *L);
 
 	static int l_get_move_resistance(lua_State *L);
 

--- a/src/script/lua_api/l_localplayer.h
+++ b/src/script/lua_api/l_localplayer.h
@@ -93,8 +93,8 @@ private:
 	static int l_hud_change(lua_State *L);
 	// hud_get(self, id)
 	static int l_hud_get(lua_State *L);
-	// hud_get_elements(self)
-	static int l_hud_get_elements(lua_State *L);
+	// hud_get_all(self)
+	static int l_hud_get_all(lua_State *L);
 
 	static int l_get_move_resistance(lua_State *L);
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1606,14 +1606,15 @@ int ObjectRef::l_hud_get_elements(lua_State *L)
 		return 0;
 
 	lua_newtable(L);
-	u32 max = player->getHudIdMax();
-	for (u32 id = 0; id < max; id++) {
-		HudElement *elem = player->getHud(id);
-		if (elem != nullptr) {
-			push_hud_element(L, elem);
-			lua_rawseti(L, -2, id);
+	player->hudApply([&](const std::vector<HudElement*>& hud) {
+		for (std::size_t id = 0; id < hud.size(); ++id) {
+			HudElement *elem = hud[id];
+			if (elem != nullptr) {
+				push_hud_element(L, elem);
+				lua_rawseti(L, -2, id);
+			}
 		}
-	}
+	});
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1611,7 +1611,7 @@ int ObjectRef::l_hud_get_elements(lua_State *L)
 		HudElement *elem = player->getHud(id);
 		if (elem != nullptr) {
 			push_hud_element(L, elem);
-			lua_rawseti(L, -2, id+1);
+			lua_rawseti(L, -2, id);
 		}
 	}
 	return 1;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1596,8 +1596,8 @@ int ObjectRef::l_hud_get(lua_State *L)
 	return 1;
 }
 
-// hud_get_elements(self)
-int ObjectRef::l_hud_get_elements(lua_State *L)
+// hud_get_all(self)
+int ObjectRef::l_hud_get_all(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
@@ -2551,7 +2551,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, hud_remove),
 	luamethod(ObjectRef, hud_change),
 	luamethod(ObjectRef, hud_get),
-	luamethod(ObjectRef, hud_get_elements),
+	luamethod(ObjectRef, hud_get_all),
 	luamethod(ObjectRef, hud_set_flags),
 	luamethod(ObjectRef, hud_get_flags),
 	luamethod(ObjectRef, hud_set_hotbar_itemcount),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1596,6 +1596,27 @@ int ObjectRef::l_hud_get(lua_State *L)
 	return 1;
 }
 
+// hud_get_elements(self)
+int ObjectRef::l_hud_get_elements(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (player == nullptr)
+		return 0;
+
+	lua_newtable(L);
+	u32 max = player->getHudIdMax();
+	for (u32 id = 0; id < max; id++) {
+		HudElement *elem = player->getHud(id);
+		if (elem != nullptr) {
+			push_hud_element(L, elem);
+			lua_rawseti(L, -2, id+1);
+		}
+	}
+	return 1;
+}
+
 // hud_set_flags(self, flags)
 int ObjectRef::l_hud_set_flags(lua_State *L)
 {
@@ -2529,6 +2550,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, hud_remove),
 	luamethod(ObjectRef, hud_change),
 	luamethod(ObjectRef, hud_get),
+	luamethod(ObjectRef, hud_get_elements),
 	luamethod(ObjectRef, hud_set_flags),
 	luamethod(ObjectRef, hud_get_flags),
 	luamethod(ObjectRef, hud_set_hotbar_itemcount),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -288,8 +288,8 @@ private:
 	// hud_get(self, id)
 	static int l_hud_get(lua_State *L);
 
-	// hud_get_elements(self)
-	static int l_hud_get_elements(lua_State *L);
+	// hud_get_all(self)
+	static int l_hud_get_all(lua_State *L);
 
 	// hud_set_flags(self, flags)
 	static int l_hud_set_flags(lua_State *L);

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -287,7 +287,7 @@ private:
 
 	// hud_get(self, id)
 	static int l_hud_get(lua_State *L);
-	
+
 	// hud_get_elements(self)
 	static int l_hud_get_elements(lua_State *L);
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -287,6 +287,9 @@ private:
 
 	// hud_get(self, id)
 	static int l_hud_get(lua_State *L);
+	
+	// hud_get_elements(self)
+	static int l_hud_get_elements(lua_State *L);
 
 	// hud_set_flags(self, flags)
 	static int l_hud_set_flags(lua_State *L);


### PR DESCRIPTION
- Currently it is not possible to get all HUD element IDs. If you would try to enumerate them, it is impossible to know when to stop. You can't just stop after an ID is empty, since they are not consecutive if an element gets removed.
- This PR adds a `player:hud_get_all()` function which returns a table indexed by all present HUD ID's and containing the corresponding HUD element definition structures.
- Like the `get_lists()` function for inventories, it allows bulk access and makes it easy to iterate through all HUD elements.
- This PR adds the new function to the Lua API as well as to the client Lua API.

#### Does it resolve any reported issue?
No.
#### Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
No.

## To do
Ready for Review.


## How to test
- Start devtest
- Execute the `/hudprint` chat command
- To test some more, change the HUD with for example:
 ```
local def = {
	hud_elem_type = "text",
	name = "test",
	position = {x = 0.5, y = 0.5},
	text = "test"
}
player:hud_add(def)
local rid = player:hud_add(def)
player:hud_add(def)
player:hud_remove(rid)

 ```
and use `/hudprint` again or `print(dump(player:hud_get_all()))` 

To check whether the ids are correct
 ```
for id, elem in pairs(player:hud_get_all()) do
	if dump(elem) ~= dump(player:hud_get(id)) then
		print("Wrong ids")
	end
end
 ```
