### PR TITLE
Take aliases into account for automatic package installation

### DIFF
--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -695,10 +695,11 @@ local function resolve_auto_install_spec()
 		return nil
 	end
 
+	local spec = store.aliases[auto_install_spec] or auto_install_spec
 	local resolved = nil
 
 	for _, pkg in ipairs(store.packages_full_unordered) do
-		if pkg.id == auto_install_spec then
+		if pkg.id == spec then
 			resolved = pkg
 			break
 		end


### PR DESCRIPTION
Fixes #14050.

## To do

This PR is a Ready for Review.

## How to test

From #14050:

1. Download an old copy of driftgame from the [2020-09-15 release](https://content.minetest.net/packages/mt-mods/driftgame/releases/6455/download/) available on ContentDB.
2. Extract that copy of driftgame into your game directory.
3. Since ContentDB manual downloads don't include a release number in the game.conf, add this line manually to the `game.conf` of driftgame: `release = 6455`.
4. Launch Minetest, go to the Content tab, notice driftgame has an update, and press the Update button on that tab.
5. ~~You should get the same error as given in the summary.~~ You should get no error.
