### PR TITLE
Don't copy user texture packs into Android bundle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -81,7 +81,7 @@ task prepareAssets() {
 			from "${projRoot}/fonts" include "*.ttf" into "${assetsFolder}/fonts"
 		}
 		copy {
-			from "${projRoot}/textures" into "${assetsFolder}/textures"
+			from "${projRoot}/textures/base/pack" into "${assetsFolder}/textures/base/pack"
 		}
 
 		// compile translations


### PR DESCRIPTION
Currently, any texture packs you've downloaded will be included in the Android data bundle. This is annoying because it can make extracting take very long.

With this PR, only Minetest's built-in textures are included in the data bundle.

## To do

This PR is a Ready for Review.

## How to test

Download some texture packs and compile Minetest for Android. Verify that the texture packs aren't included in the Android build.

Also verify that all necessary textures are still included.