### PR TITLE
Check if liquid can flow into empty node before picking it as source

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -512,7 +512,7 @@ struct NodeNeighbor {
 	{ }
 };
 
-s8 getMaxLiquidLevel(NodeNeighbor nb, s8 current_max_node_level)
+static s8 getMaxLiquidLevel(NodeNeighbor nb, s8 current_max_node_level)
 {
 	s8 max_node_level = current_max_node_level;
 	u8 nb_liquid_level = (nb.n.param2 & LIQUID_LEVEL_MASK);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -684,10 +684,9 @@ void ServerMap::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 						s8 maxLiquidLevelFromNeighbor = getMaxLiquidLevel(nb, -1);
 						u8 range = m_nodedef->get(cfnb.liquid_alternative_flowing_id).liquid_range;
 
-						if (liquid_kind == CONTENT_AIR
-							&& maxLiquidLevelFromNeighbor >= (LIQUID_LEVEL_MAX + 1 - range)) {
+						if (liquid_kind == CONTENT_AIR &&
+								maxLiquidLevelFromNeighbor >= (LIQUID_LEVEL_MAX + 1 - range))
 							liquid_kind = cfnb.liquid_alternative_flowing_id;
-						}
 					}
 					if (cfnb.liquid_alternative_flowing_id != liquid_kind) {
 						neutrals[num_neutrals++] = nb;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -512,7 +512,7 @@ struct NodeNeighbor {
 	{ }
 };
 
-static s8 getMaxLiquidLevel(NodeNeighbor nb, s8 current_max_node_level)
+static s8 get_max_liquid_level(NodeNeighbor nb, s8 current_max_node_level)
 {
 	s8 max_node_level = current_max_node_level;
 	u8 nb_liquid_level = (nb.n.param2 & LIQUID_LEVEL_MASK);
@@ -681,7 +681,7 @@ void ServerMap::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 						// but exclude falling liquids on the same level, they cannot flow here anyway
 
 						// used to determine if the neighbor can even flow into this node
-						s8 maxLiquidLevelFromNeighbor = getMaxLiquidLevel(nb, -1);
+						s8 maxLiquidLevelFromNeighbor = get_max_liquid_level(nb, -1);
 						u8 range = m_nodedef->get(cfnb.liquid_alternative_flowing_id).liquid_range;
 
 						if (liquid_kind == CONTENT_AIR &&
@@ -730,7 +730,7 @@ void ServerMap::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 		} else {
 			// no surrounding sources, so get the maximum level that can flow into this node
 			for (u16 i = 0; i < num_flows; i++) {
-				max_node_level = getMaxLiquidLevel(flows[i], max_node_level);
+				max_node_level = get_max_liquid_level(flows[i], max_node_level);
 			}
 
 			u8 viscosity = m_nodedef->get(liquid_kind).liquid_viscosity;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -681,11 +681,11 @@ void ServerMap::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 						// but exclude falling liquids on the same level, they cannot flow here anyway
 
 						// used to determine if the neighbor can even flow into this node
-						s8 maxLiquidLevelFromNeighbor = get_max_liquid_level(nb, -1);
+						s8 max_level_from_neighbor = get_max_liquid_level(nb, -1);
 						u8 range = m_nodedef->get(cfnb.liquid_alternative_flowing_id).liquid_range;
 
 						if (liquid_kind == CONTENT_AIR &&
-								maxLiquidLevelFromNeighbor >= (LIQUID_LEVEL_MAX + 1 - range))
+								max_level_from_neighbor >= (LIQUID_LEVEL_MAX + 1 - range))
 							liquid_kind = cfnb.liquid_alternative_flowing_id;
 					}
 					if (cfnb.liquid_alternative_flowing_id != liquid_kind) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -512,6 +512,31 @@ struct NodeNeighbor {
 	{ }
 };
 
+s8 getMaxLiquidLevel(NodeNeighbor nb, s8 current_max_node_level)
+{
+	s8 max_node_level = current_max_node_level;
+	u8 nb_liquid_level = (nb.n.param2 & LIQUID_LEVEL_MASK);
+	switch (nb.t) {
+		case NEIGHBOR_UPPER:
+			if (nb_liquid_level + WATER_DROP_BOOST > current_max_node_level) {
+				max_node_level = LIQUID_LEVEL_MAX;
+				if (nb_liquid_level + WATER_DROP_BOOST < LIQUID_LEVEL_MAX)
+					max_node_level = nb_liquid_level + WATER_DROP_BOOST;
+			} else if (nb_liquid_level > current_max_node_level) {
+				max_node_level = nb_liquid_level;
+			}
+			break;
+		case NEIGHBOR_LOWER:
+			break;
+		case NEIGHBOR_SAME_LEVEL:
+			if ((nb.n.param2 & LIQUID_FLOW_DOWN_MASK) != LIQUID_FLOW_DOWN_MASK &&
+					nb_liquid_level > 0 && nb_liquid_level - 1 > max_node_level)
+				max_node_level = nb_liquid_level - 1;
+			break;
+	}
+	return max_node_level;
+}
+
 void ServerMap::transforming_liquid_add(v3s16 p) {
 		m_transforming_liquid.push_back(p);
 }
@@ -654,8 +679,15 @@ void ServerMap::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 						(nb.n.param2 & LIQUID_FLOW_DOWN_MASK) != LIQUID_FLOW_DOWN_MASK) {
 						// if this node is not (yet) of a liquid type, choose the first liquid type we encounter
 						// but exclude falling liquids on the same level, they cannot flow here anyway
-						if (liquid_kind == CONTENT_AIR)
+
+						// used to determine if the neighbor can even flow into this node
+						s8 maxLiquidLevelFromNeighbor = getMaxLiquidLevel(nb, -1);
+						u8 range = m_nodedef->get(cfnb.liquid_alternative_flowing_id).liquid_range;
+
+						if (liquid_kind == CONTENT_AIR
+							&& maxLiquidLevelFromNeighbor >= (LIQUID_LEVEL_MAX + 1 - range)) {
 							liquid_kind = cfnb.liquid_alternative_flowing_id;
+						}
 					}
 					if (cfnb.liquid_alternative_flowing_id != liquid_kind) {
 						neutrals[num_neutrals++] = nb;
@@ -699,25 +731,7 @@ void ServerMap::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 		} else {
 			// no surrounding sources, so get the maximum level that can flow into this node
 			for (u16 i = 0; i < num_flows; i++) {
-				u8 nb_liquid_level = (flows[i].n.param2 & LIQUID_LEVEL_MASK);
-				switch (flows[i].t) {
-					case NEIGHBOR_UPPER:
-						if (nb_liquid_level + WATER_DROP_BOOST > max_node_level) {
-							max_node_level = LIQUID_LEVEL_MAX;
-							if (nb_liquid_level + WATER_DROP_BOOST < LIQUID_LEVEL_MAX)
-								max_node_level = nb_liquid_level + WATER_DROP_BOOST;
-						} else if (nb_liquid_level > max_node_level) {
-							max_node_level = nb_liquid_level;
-						}
-						break;
-					case NEIGHBOR_LOWER:
-						break;
-					case NEIGHBOR_SAME_LEVEL:
-						if ((flows[i].n.param2 & LIQUID_FLOW_DOWN_MASK) != LIQUID_FLOW_DOWN_MASK &&
-								nb_liquid_level > 0 && nb_liquid_level - 1 > max_node_level)
-							max_node_level = nb_liquid_level - 1;
-						break;
-				}
+				max_node_level = getMaxLiquidLevel(flows[i], max_node_level);
 			}
 
 			u8 viscosity = m_nodedef->get(liquid_kind).liquid_viscosity;


### PR DESCRIPTION
##  Purpose

This PR is to fix #12549

The cause of the bug was that the liquid to flow into the current node was picked as the first one encountered, despite the fact that the first encountered liquid may not be able to flow into the node, due to being at its max range already.

The PR fixes this by:
1. Abstracting the logic to get liquid level from neighbor into a function
2. Calling that logic/function before picking which liquid to flow from, and checking if the liquid would indeed be able to flow - and only picking it if that was a possibility.

## How to test

As per bug report, there's a small mod that can be used to test this: https://github.com/minetest/minetest/files/9128298/void_liquid.zip - but it's easy to reproduce this in MTG using water and river water as well.

Place the 1st liquid in 4 corners of a rectangle so that there's space in the center, then place the 2nd liquid in the center.

## Screenshots
Before fix:
![image](https://github.com/minetest/minetest/assets/118483769/a4099ed1-cbc4-4146-b8c0-108496dda019)

After fix:
![image](https://github.com/minetest/minetest/assets/118483769/318a1706-6254-4423-8d0c-11227361ed81)