### PR TITLE
Android: Pause rendering while the app is paused

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1252,7 +1252,8 @@ void Game::run()
 		updateCamera(dtime);
 		updateSound(dtime);
 		processPlayerInteraction(dtime, m_game_ui->m_flags.show_hud);
-		updateFrame(&graph, &stats, dtime, cam_view);
+		if (RenderingEngine::shouldRender())
+			updateFrame(&graph, &stats, dtime, cam_view);
 		updateProfilerGraphs(&graph);
 
 		// Update if minimap has been disabled by the server

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1252,8 +1252,7 @@ void Game::run()
 		updateCamera(dtime);
 		updateSound(dtime);
 		processPlayerInteraction(dtime, m_game_ui->m_flags.show_hud);
-		if (RenderingEngine::shouldRender())
-			updateFrame(&graph, &stats, dtime, cam_view);
+		updateFrame(&graph, &stats, dtime, cam_view);
 		updateProfilerGraphs(&graph);
 
 		// Update if minimap has been disabled by the server
@@ -4012,31 +4011,6 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	client->getParticleManager()->step(dtime);
 
 	/*
-		Fog
-	*/
-	if (m_cache_enable_fog) {
-		driver->setFog(
-				sky->getBgColor(),
-				video::EFT_FOG_LINEAR,
-				runData.fog_range * sky->getFogStart(),
-				runData.fog_range * 1.0,
-				0.01,
-				false, // pixel fog
-				true // range fog
-		);
-	} else {
-		driver->setFog(
-				sky->getBgColor(),
-				video::EFT_FOG_LINEAR,
-				100000 * BS,
-				110000 * BS,
-				0.01f,
-				false, // pixel fog
-				false // range fog
-		);
-	}
-
-	/*
 		Damage camera tilt
 	*/
 	if (player->hurt_tilt_timer > 0.0f) {
@@ -4135,7 +4109,8 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	/*
 		==================== Drawing begins ====================
 	*/
-	drawScene(graph, stats);
+	if (RenderingEngine::shouldRender())
+		drawScene(graph, stats);
 	/*
 		==================== End scene ====================
 	*/
@@ -4215,10 +4190,39 @@ void Game::updateShadows()
 
 void Game::drawScene(ProfilerGraph *graph, RunStats *stats)
 {
-	const video::SColor skycolor = this->sky->getSkyColor();
+	const video::SColor bg_color = this->sky->getBgColor();
+	const video::SColor sky_color = this->sky->getSkyColor();
 
+	/*
+		Fog
+	*/
+	if (this->m_cache_enable_fog) {
+		this->driver->setFog(
+				bg_color,
+				video::EFT_FOG_LINEAR,
+				this->runData.fog_range * this->sky->getFogStart(),
+				this->runData.fog_range * 1.0f,
+				0.01f,
+				false, // pixel fog
+				true // range fog
+		);
+	} else {
+		this->driver->setFog(
+				bg_color,
+				video::EFT_FOG_LINEAR,
+				100000 * BS,
+				110000 * BS,
+				0.01f,
+				false, // pixel fog
+				false // range fog
+		);
+	}
+
+	/*
+		Drawing
+	*/
 	TimeTaker tt_draw("Draw scene", nullptr, PRECISION_MICRO);
-	this->driver->beginScene(true, true, skycolor);
+	this->driver->beginScene(true, true, sky_color);
 
 	const LocalPlayer *player = this->client->getEnv().getLocalPlayer();
 	bool draw_wield_tool = (this->m_game_ui->m_flags.show_hud &&
@@ -4231,7 +4235,7 @@ void Game::drawScene(ProfilerGraph *graph, RunStats *stats)
 	if (this->isNoCrosshairAllowed())
 		draw_crosshair = false;
 #endif
-	this->m_rendering_engine->draw_scene(skycolor, this->m_game_ui->m_flags.show_hud,
+	this->m_rendering_engine->draw_scene(sky_color, this->m_game_ui->m_flags.show_hud,
 			this->m_game_ui->m_flags.show_minimap, draw_wield_tool, draw_crosshair);
 
 	/*

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -138,6 +138,16 @@ public:
 			const irr::core::dimension2d<u32> initial_screen_size,
 			const bool initial_window_maximized);
 
+	static bool shouldRender()
+	{
+#ifdef __ANDROID__
+		// On Android, pause rendering while the app is paused.
+		return get_raw_device()->isWindowActive();
+#else
+		return true;
+#endif
+	};
+
 private:
 	v2u32 _getWindowSize() const;
 

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -140,8 +140,9 @@ public:
 
 	static bool shouldRender()
 	{
+		// On Android, pause rendering while the app is in background (generally not visible).
+		// Don't do this on desktop because windows can be partially visible.
 #ifdef __ANDROID__
-		// On Android, pause rendering while the app is paused.
 		return get_raw_device()->isWindowActive();
 #else
 		return true;

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -265,34 +265,35 @@ void GUIEngine::run()
 	f32 dtime = 0.0f;
 
 	while (m_rendering_engine->run() && (!m_startgame) && (!m_kill)) {
+		if (RenderingEngine::shouldRender()) {
+			// check if we need to update the "upper left corner"-text
+			if (text_height != g_fontengine->getTextHeight()) {
+				updateTopLeftTextSize();
+				text_height = g_fontengine->getTextHeight();
+			}
 
-		//check if we need to update the "upper left corner"-text
-		if (text_height != g_fontengine->getTextHeight()) {
-			updateTopLeftTextSize();
-			text_height = g_fontengine->getTextHeight();
+			driver->beginScene(true, true, RenderingEngine::MENU_SKY_COLOR);
+
+			if (m_clouds_enabled)
+			{
+				cloudPreProcess();
+				drawOverlay(driver);
+			}
+			else
+				drawBackground(driver);
+
+			drawFooter(driver);
+
+			m_rendering_engine->get_gui_env()->drawAll();
+
+			// The header *must* be drawn after the menu because it uses
+			// GUIFormspecMenu::getAbsoluteRect().
+			// The header *can* be drawn after the menu because it never intersects
+			// the menu.
+			drawHeader(driver);
+
+			driver->endScene();
 		}
-
-		driver->beginScene(true, true, RenderingEngine::MENU_SKY_COLOR);
-
-		if (m_clouds_enabled)
-		{
-			cloudPreProcess();
-			drawOverlay(driver);
-		}
-		else
-			drawBackground(driver);
-
-		drawFooter(driver);
-
-		m_rendering_engine->get_gui_env()->drawAll();
-
-		// The header *must* be drawn after the menu because it uses
-		// GUIFormspecMenu::getAbsoluteRect().
-		// The header *can* be drawn after the menu because it never intersects
-		// the menu.
-		drawHeader(driver);
-
-		driver->endScene();
 
 		IrrlichtDevice *device = m_rendering_engine->get_raw_device();
 


### PR DESCRIPTION
Currently, Minetest on Android is fully paused while the Android app is paused. This is good for battery usage, but bad for multiplayer (see #10842).

After minetest/irrlicht#255, this will no longer be the case. To avoid an unnecessarily large increase in battery usage, this PR pauses the rendering while the Android app is paused.

## To do

This PR is a Ready for Review.

I wasn't sure about the organization of `RenderingEngine`, feel free to suggest a better place for `shouldRender`.

I didn't pause the rendering of the loading screen because that sometimes resulted in the following crash:

```
D Minetest: INFO[Main]: NodeDefManager::updateTextures(): Updating textures in node definitions
F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0 in tid 18333 (MinetestNativeT), pid 18229 (netest.minetest)
F DEBUG   : Process name is net.minetest.minetest, not key_process
F DEBUG   : Cmdline: net.minetest.minetest
F DEBUG   : pid: 18229, tid: 18333, name: MinetestNativeT  >>> net.minetest.minetest <<<
F DEBUG   :       #02 pc 0000000000b320d4  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (ShaderSource::generateShader(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, MaterialType, NodeDrawType)+1112) (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
F DEBUG   :       #03 pc 0000000000b319bc  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (ShaderSource::getShaderIdDirect(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, MaterialType, NodeDrawType)+380) (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
F DEBUG   :       #04 pc 0000000000b311c0  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (ShaderSource::getShader(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, MaterialType, NodeDrawType)+116) (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
F DEBUG   :       #05 pc 0000000000f49d44  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (ContentFeatures::updateTextures(ITextureSource*, IShaderSource*, irr::scene::IMeshManipulator*, Client*, TextureSettings const&)+2468) (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
F DEBUG   :       #06 pc 0000000000f4e148  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (NodeDefManager::updateTextures(IGameDef*, void*)+292) (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
F DEBUG   :       #07 pc 00000000009b8174  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (Client::afterContentReceived()+1356) (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
F DEBUG   :       #08 pc 0000000000a72190  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (Game::createClient(GameStartData const&)+576) (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
F DEBUG   :       #09 pc 0000000000a71cd8  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (Game::startup(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >&, bool*, ChatBackend*)+620) (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
F DEBUG   :       #10 pc 0000000000a88c40  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (the_game(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >&, ChatBackend&, bool*)+100) (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
F DEBUG   :       #11 pc 00000000009fc940  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (ClientLauncher::run(GameStartData&, Settings const&)+4400) (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
F DEBUG   :       #12 pc 0000000000f0adec  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (main+2648) (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
F DEBUG   :       #13 pc 0000000000f76d58  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (android_main+128) (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
F DEBUG   :       #14 pc 00000000009833f4  /data/app/~~2ej2zR8y5sYv1inJ-YnmTw==/net.minetest.minetest-C2tslvyKddqndEIJuJOmuQ==/lib/arm64/libminetest.so (BuildId: ab184003c7091391160f403a07ae8546ce729d55)
```

## How to test

Play Minetest on Android and enable the F5 graphs. Switch to another app while Minetest is running, then switch back to Minetest and see that there is a hole in the "Draw scene [us]" graph.

I recommend reviewing the code with whitespace changes hidden.
