### PR TITLE
Fix sound and particlespawner id generation

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2172,7 +2172,7 @@ void Server::SendPlayerSpeed(session_t peer_id, const v3f &added_vel)
 inline s32 Server::nextSoundId()
 {
 	s32 free_id = m_playing_sounds_id_last_used;
-	while (free_id == 0 || m_playing_sounds.find(free_id) != m_playing_sounds.end()) {
+	do {
 		if (free_id == INT32_MAX)
 			free_id = 0; // signed overflow is undefined
 		else
@@ -2180,7 +2180,8 @@ inline s32 Server::nextSoundId()
 
 		if (free_id == m_playing_sounds_id_last_used)
 			return 0;
-	}
+	} while (free_id == 0 || m_playing_sounds.find(free_id) != m_playing_sounds.end());
+
 	m_playing_sounds_id_last_used = free_id;
 	return free_id;
 }

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1638,11 +1638,11 @@ u32 ServerEnvironment::addParticleSpawner(float exptime)
 	float time = exptime > 0.f ? exptime : PARTICLE_SPAWNER_NO_EXPIRY;
 
 	u32 free_id = m_particle_spawners_id_last_used;
-	while (free_id == 0 || m_particle_spawners.find(free_id) != m_particle_spawners.end()) {
+	do {
+		free_id++;
 		if (free_id == m_particle_spawners_id_last_used)
 			return 0; // full
-		free_id++;
-	}
+	} while (free_id == 0 || m_particle_spawners.find(free_id) != m_particle_spawners.end());
 
 	m_particle_spawners_id_last_used = free_id;
 	m_particle_spawners[free_id] = time;


### PR DESCRIPTION
#14045 caused some issues:
* https://github.com/minetest/minetest/pull/14045#issuecomment-1832876219
* Particlespawner ids were always 0.

With this PR, ids always grow, and don't return the last returned id. This is important, because the last returned id is likely to still be kept in lua.

cc @SmallJoker 

## To do

This PR is a Ready for Review.

## How to test

* Sound ids: https://github.com/minetest/minetest/pull/14045#issuecomment-1832876219
* Particlespawner ids: `/lua local p=me:get_pos(); return core.add_particlespawner({time=10,minpos=p:offset(0,1,0),maxpos=p,texture="heart.png",amount=20})`
