### PR TITLE
MacOS: Add codesigning instr to docs

### DIFF
--- a/doc/compiling/macos.md
+++ b/doc/compiling/macos.md
@@ -33,13 +33,15 @@ mkdir build
 cd build
 
 cmake .. \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
     -DCMAKE_FIND_FRAMEWORK=LAST \
     -DCMAKE_INSTALL_PREFIX=../build/macos/ \
     -DRUN_IN_PLACE=FALSE -DENABLE_GETTEXT=TRUE
 
 make -j$(sysctl -n hw.logicalcpu)
 make install
+
+# M1 Macs w/ MacOS >= BigSur
+codesign --force --deep -s - macos/minetest.app
 ```
 
 ## Run


### PR DESCRIPTION
DCMAKE_OSX_DEPLOYMENT_TARGET is set automatically to host, see https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html

Without codesigning, the app will not start on M1 Macs.