### PR TITLE
Rename `hud_elem_type` to `type`

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -29,6 +29,7 @@ core.features = {
 	compress_zstd = true,
 	sound_params_start_time = true,
 	physics_overrides_v2 = true,
+	hud_def_type_field = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -139,7 +139,8 @@ end
 
 function core.hud_replace_builtin(hud_name, definition)
 	if type(definition) ~= "table" or
-			definition.type ~= "statbar" then
+			(definition.hud_elem_type ~= "statbar" and
+			definition.type ~= "statbar") then
 		return false
 	end
 

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -139,8 +139,7 @@ end
 
 function core.hud_replace_builtin(hud_name, definition)
 	if type(definition) ~= "table" or
-			(definition.hud_elem_type ~= "statbar" and
-			definition.type ~= "statbar") then
+			(definition.type or definition.hud_elem_type) ~= "statbar" then
 		return false
 	end
 

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -3,7 +3,7 @@ local enable_damage = core.settings:get_bool("enable_damage")
 
 local bar_definitions = {
 	hp = {
-		hud_elem_type = "statbar",
+		type = "statbar",
 		position = {x = 0.5, y = 1},
 		text = "heart.png",
 		text2 = "heart_gone.png",
@@ -14,7 +14,7 @@ local bar_definitions = {
 		offset = {x = (-10 * 24) - 25, y = -(48 + 24 + 16)},
 	},
 	breath = {
-		hud_elem_type = "statbar",
+		type = "statbar",
 		position = {x = 0.5, y = 1},
 		text = "bubble.png",
 		text2 = "bubble_gone.png",
@@ -139,7 +139,7 @@ end
 
 function core.hud_replace_builtin(hud_name, definition)
 	if type(definition) ~= "table" or
-			definition.hud_elem_type ~= "statbar" then
+			definition.type ~= "statbar" then
 		return false
 	end
 

--- a/clientmods/preview/init.lua
+++ b/clientmods/preview/init.lua
@@ -33,7 +33,7 @@ end)
 core.after(1, function()
 	print("armor: " .. dump(core.localplayer:get_armor_groups()))
 	id = core.localplayer:hud_add({
-			hud_elem_type = "text",
+			type = "text",
 			name = "example",
 			number = 0xff0000,
 			position = {x=0, y=1},

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -1334,8 +1334,9 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
 {
     type = "image", -- see HUD element types, default "text"
 --  ^ type of HUD element, can be either of "image", "text", "statbar", or "inventory"
+--	If undefined "text" will be used.
     hud_elem_type = "image",
---  ^ Deprecated, same as "type"
+--  ^ Deprecated, same as `type`. In case both are specified `type` will be used.
     position = {x=0.5, y=0.5},
 --  ^ Left corner position of element, default `{x=0,y=0}`.
     name = "<name>",    -- default ""

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -1332,8 +1332,10 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
 
 ```lua
 {
-    hud_elem_type = "image", -- see HUD element types, default "text"
+    type = "image", -- see HUD element types, default "text"
 --  ^ type of HUD element, can be either of "image", "text", "statbar", or "inventory"
+    hud_elem_type = "image",
+--  ^ Deprecated, same as "type"
     position = {x=0.5, y=0.5},
 --  ^ Left corner position of element, default `{x=0,y=0}`.
     name = "<name>",    -- default ""

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -1334,7 +1334,6 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
 {
     type = "image", -- see HUD element types, default "text"
 --  ^ type of HUD element, can be either of "image", "text", "statbar", or "inventory"
---	If undefined "text" will be used.
     hud_elem_type = "image",
 --  ^ Deprecated, same as `type`. In case both are specified `type` will be used.
     position = {x=0.5, y=0.5},

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7791,7 +7791,7 @@ child will follow movement and rotation of that bone.
 * `hud_change(id, stat, value)`: change a value of a previously added HUD
   element.
     * `stat` supports the same keys as in the hud definition table except for
-      `"hud_elem_type"`.
+      `"type"` (and deprecated `"hud_elem_type"`).
 * `hud_get(id)`: gets the HUD element definition structure of the specified ID
 * `hud_set_flags(flags)`: sets specified HUD flags of player.
     * `flags`: A table with the following fields set to boolean values
@@ -10051,9 +10051,12 @@ Used by `ObjectRef:hud_add`. Returned by `ObjectRef:hud_get`.
 
 ```lua
 {
-    hud_elem_type = "image",
+    type = "image",
     -- Type of element, can be "image", "text", "statbar", "inventory",
     -- "waypoint", "image_waypoint", "compass" or "minimap"
+    
+    hud_elem_type = "image",
+    -- Deprecated, same as "type"
 
     position = {x=0.5, y=0.5},
     -- Top left corner position of element

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7793,7 +7793,7 @@ child will follow movement and rotation of that bone.
 * `hud_change(id, stat, value)`: change a value of a previously added HUD
   element.
     * `stat` supports the same keys as in the hud definition table except for
-      `"type"` (and deprecated `"hud_elem_type"`).
+      `"type"` (or the deprecated `"hud_elem_type"`).
 * `hud_get(id)`: gets the HUD element definition structure of the specified ID
 * `hud_set_flags(flags)`: sets specified HUD flags of player.
     * `flags`: A table with the following fields set to boolean values

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -10054,9 +10054,11 @@ Used by `ObjectRef:hud_add`. Returned by `ObjectRef:hud_get`.
     type = "image",
     -- Type of element, can be "image", "text", "statbar", "inventory",
     -- "waypoint", "image_waypoint", "compass" or "minimap"
+    -- If undefined "text" will be used.
     
     hud_elem_type = "image",
-    -- Deprecated, same as "type"
+    -- Deprecated, same as `type`.
+    -- In case both are specified `type` will be used.
 
     position = {x=0.5, y=0.5},
     -- Top left corner position of element

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5278,6 +5278,8 @@ Utilities
       -- liquid_fluidity, liquid_fluidity_smooth, liquid_sink,
       -- acceleration_default, acceleration_air (5.8.0)
       physics_overrides_v2 = true,
+      -- In HUD definitions the field `type` is used and `hud_elem_type` is deprecated
+      hud_def_type_field = true,
   }
   ```
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5278,7 +5278,7 @@ Utilities
       -- liquid_fluidity, liquid_fluidity_smooth, liquid_sink,
       -- acceleration_default, acceleration_air (5.8.0)
       physics_overrides_v2 = true,
-      -- In HUD definitions the field `type` is used and `hud_elem_type` is deprecated
+      -- In HUD definitions the field `type` is used and `hud_elem_type` is deprecated (5.9.0)
       hud_def_type_field = true,
   }
   ```
@@ -10057,7 +10057,7 @@ Used by `ObjectRef:hud_add`. Returned by `ObjectRef:hud_get`.
     -- Type of element, can be "image", "text", "statbar", "inventory",
     -- "waypoint", "image_waypoint", "compass" or "minimap"
     -- If undefined "text" will be used.
-    
+
     hud_elem_type = "image",
     -- Deprecated, same as `type`.
     -- In case both are specified `type` will be used.

--- a/games/devtest/mods/testentities/selectionbox.lua
+++ b/games/devtest/mods/testentities/selectionbox.lua
@@ -66,7 +66,7 @@ minetest.register_globalstep(function()
 			local ent = pointed_thing.ref:get_luaentity()
 			if ent and ent.name == "testentities:selectionbox" then
 				hud_ids[pname] = hud_id or player:hud_add({
-					hud_elem_type = "text",  -- See HUD element types
+					type = "text",  -- See HUD element types
 					position = {x=0.5, y=0.5},
 			        text = "X",
 					number = 0xFF0000,

--- a/games/devtest/mods/testhud/init.lua
+++ b/games/devtest/mods/testhud/init.lua
@@ -12,7 +12,7 @@ local font_states = {
 
 
 local font_default_def = {
-	hud_elem_type = "text",
+	type = "text",
 	position = {x = 0.5, y = 0.5},
 	scale = {x = 2, y = 2},
 	alignment = { x = 0, y = 0 },
@@ -102,14 +102,14 @@ minetest.register_chatcommand("hudwaypoints", {
 			return false
 		end
 		local regular = player:hud_add {
-			hud_elem_type = "waypoint",
+			type = "waypoint",
 			name = "regular waypoint",
 			text = "m",
 			number = 0xFFFFFF,
 			world_pos = vector.add(player:get_pos(), {x = 0, y = 1.5, z = 0})
 		}
 		local reduced_precision = player:hud_add {
-			hud_elem_type = "waypoint",
+			type = "waypoint",
 			name = "imprecise waypoint",
 			text = "m (0.1 steps, precision = 10)",
 			precision = 10,
@@ -117,7 +117,7 @@ minetest.register_chatcommand("hudwaypoints", {
 			world_pos = vector.add(player:get_pos(), {x = 0, y = 1, z = 0})
 		}
 		local hidden_distance = player:hud_add {
-			hud_elem_type = "waypoint",
+			type = "waypoint",
 			name = "waypoint with hidden distance",
 			text = "this text is hidden as well (precision = 0)",
 			precision = 0,
@@ -149,7 +149,7 @@ minetest.register_chatcommand("hudwaypoints", {
 			minetest.after(0.5, change, player)
 		end
 		local image_waypoint = player:hud_add {
-			hud_elem_type = "image_waypoint",
+			type = "image_waypoint",
 			text = "testhud_waypoint.png",
 			world_pos = player:get_pos(),
 			scale = {x = 3, y = 3},

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1961,7 +1961,7 @@ void read_hud_element(lua_State *L, HudElement *elem)
 {
 	std::string type_string;
 	bool has_type = getstringfield(L, 2, "type", type_string);
-	
+
 	// Handle deprecated hud_elem_type
 	std::string deprecated_type_string;
 	if (getstringfield(L, 2, "hud_elem_type", deprecated_type_string)) {
@@ -1975,10 +1975,10 @@ void read_hud_element(lua_State *L, HudElement *elem)
 					warningstream);
 		}
 	}
-	
+
 	int type_enum;
 	if (has_type && string_to_enum(es_HudElementType, type_enum, type_string))
-		elem->type = (HudElementType)type_enum;
+		elem->type = static_cast<HudElementType>(type_enum);
 	else
 		elem->type = HUD_ELEM_TEXT;
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1962,7 +1962,8 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	// Handle deprecated hud_elem_type
 	std::string type_string;
 	if (getstringfield(L, 2, "hud_elem_type", type_string)) {
-		log_deprecated(L, "Deprecated \"hud_elem_type\" field, use \"type\" instead.");
+		script_log_unique(L, "Deprecated \"hud_elem_type\" field, use \"type\" instead.",
+				warningstream);
 		int type_enum;
 		if (string_to_enum(es_HudElementType, type_enum, type_string))
 			elem->type = (HudElementType)type_enum;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1960,10 +1960,7 @@ void push_objectRef(lua_State *L, const u16 id)
 void read_hud_element(lua_State *L, HudElement *elem)
 {
 	std::string type_string;
-	bool has_type = false;
-	if (getstringfield(L, 2, "type", type_string)) {
-		has_type = true;
-	}
+	bool has_type = getstringfield(L, 2, "type", type_string);
 	
 	// Handle deprecated hud_elem_type
 	std::string deprecated_type_string;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1959,8 +1959,18 @@ void push_objectRef(lua_State *L, const u16 id)
 
 void read_hud_element(lua_State *L, HudElement *elem)
 {
-	elem->type = (HudElementType)getenumfield(L, 2, "hud_elem_type",
-									es_HudElementType, HUD_ELEM_TEXT);
+	// Handle deprecated hud_elem_type
+	std::string type_string;
+	if (getstringfield(L, 2, "hud_elem_type", type_string)) {
+		log_deprecated(L, "Deprecated \"hud_elem_type\" field, use \"type\" instead.");
+		int type_enum;
+		if (string_to_enum(es_HudElementType, type_enum, type_string))
+			elem->type = (HudElementType)type_enum;
+		else
+			elem->type = HUD_ELEM_TEXT;
+	} else {
+		elem->type = (HudElementType)getenumfield(L, 2, "type", es_HudElementType, HUD_ELEM_TEXT);
+	}
 
 	lua_getfield(L, 2, "position");
 	elem->pos = lua_istable(L, -1) ? read_v2f(L, -1) : v2f();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1966,13 +1966,13 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	std::string deprecated_type_string;
 	if (getstringfield(L, 2, "hud_elem_type", deprecated_type_string)) {
 		if (has_type && deprecated_type_string != type_string) {
-			script_log_unique(L, "Ambiguous HUD element fields \"type\" and \"hud_elem_type\", "
-					"\"type\" will be used.", warningstream);
+			log_deprecated(L, "Ambiguous HUD element fields \"type\" and \"hud_elem_type\", "
+					"\"type\" will be used.", 1, true);
 		} else {
 			has_type = true;
 			type_string = deprecated_type_string;
-			script_log_unique(L, "Deprecated \"hud_elem_type\" field, use \"type\" instead.",
-					warningstream);
+			log_deprecated(L, "Deprecated \"hud_elem_type\" field, use \"type\" instead.",
+					1, true);
 		}
 	}
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1968,12 +1968,15 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	// Handle deprecated hud_elem_type
 	std::string deprecated_type_string;
 	if (getstringfield(L, 2, "hud_elem_type", deprecated_type_string)) {
-		if (has_type && deprecated_type_string != type_string)
-			throw LuaError("Ambiguous HUD element fields: \"type\", \"hud_elem_type\".");
-		has_type = true;
-		type_string = deprecated_type_string;
-		script_log_unique(L, "Deprecated \"hud_elem_type\" field, use \"type\" instead.",
-				warningstream);
+		if (has_type && deprecated_type_string != type_string) {
+			script_log_unique(L, "Ambiguous HUD element fields \"type\" and \"hud_elem_type\", "
+					"\"type\" will be used.", warningstream);
+		} else {
+			has_type = true;
+			type_string = deprecated_type_string;
+			script_log_unique(L, "Deprecated \"hud_elem_type\" field, use \"type\" instead.",
+					warningstream);
+		}
 	}
 	
 	int type_enum;


### PR DESCRIPTION
- This makes `hud_elem_type` deprecated and replaces it with `type`.
- Backward compatibility is retained.
- `player:hud_get(id)` does not change, since it already used `type` instead of `hud_elem_type`.
- Fixes #14043

## To do
This PR is Ready for Review.

## How to test
- Start devest and confirm you can see all HUD elements.
- Change `type` to `hud_elem_type` in for example builtin/game/statbars.lua and check if you can still see the statbar and get a deprecated message.
- Also try to use `type` and `hud_elem_type` at the same time. In this case `type` should be used.