### PR TITLE
Fix Devtest "get_version" unittest failure on release versions

### DIFF
--- a/games/devtest/mods/unittests/get_version.lua
+++ b/games/devtest/mods/unittests/get_version.lua
@@ -7,6 +7,10 @@ unittests.register("test_get_version", function()
     assert(type(version.proto_min) == "number")
     assert(type(version.proto_max) == "number")
     assert(version.proto_max >= version.proto_min)
-    assert(type(version.hash) == "string")
     assert(type(version.is_dev) == "boolean")
+    if version.is_dev then
+        assert(type(version.hash) == "string")
+    else
+        assert(version.hash == nil)
+    end
 end)


### PR DESCRIPTION
`minetest.get_version().hash` isn't set for release builds.

https://github.com/minetest/minetest/blob/55f40a7f8d9dc3bfee006ddea4574e843fd6b46a/doc/lua_api.md?plain=1#L5387-L5388

## To do

This PR is a Ready for Review.

## How to test

Verify that the Devtest unittests still pass on the "master" branch with this PR applied.

Verify that the Devtest unittest also pass on the 5.8.0 release with this PR applied.