### PR TITLE
Allow toggling touchscreen mode at runtime

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -71,7 +71,6 @@ files["builtin/mainmenu"] = {
 
 	read_globals = {
 		"PLATFORM",
-		"TOUCHSCREEN_GUI",
 	},
 }
 
@@ -80,11 +79,5 @@ files["builtin/common/tests"] = {
 		"describe",
 		"it",
 		"assert",
-	},
-}
-
-files["builtin/fstk"] = {
-	read_globals = {
-		"TOUCHSCREEN_GUI",
 	},
 }

--- a/builtin/fstk/buttonbar.lua
+++ b/builtin/fstk/buttonbar.lua
@@ -18,7 +18,7 @@
 
 
 local BASE_SPACING = 0.1
-local SCROLL_BTN_WIDTH = TOUCHSCREEN_GUI and 0.8 or 0.5
+local SCROLL_BTN_WIDTH = core.settings:get_bool("enable_touch") and 0.8 or 0.5
 
 local function buttonbar_formspec(self)
 	if self.hidden then

--- a/builtin/fstk/buttonbar.lua
+++ b/builtin/fstk/buttonbar.lua
@@ -18,7 +18,9 @@
 
 
 local BASE_SPACING = 0.1
-local SCROLL_BTN_WIDTH = core.settings:get_bool("enable_touch") and 0.8 or 0.5
+local function get_scroll_btn_width()
+	return core.settings:get_bool("enable_touch") and 0.8 or 0.5
+end
 
 local function buttonbar_formspec(self)
 	if self.hidden then
@@ -39,7 +41,7 @@ local function buttonbar_formspec(self)
 
 	-- The number of buttons per page is always calculated as if the scroll
     -- buttons were visible.
-	local avail_space = self.size.x - 2*BASE_SPACING - 2*SCROLL_BTN_WIDTH
+	local avail_space = self.size.x - 2*BASE_SPACING - 2*get_scroll_btn_width()
 	local btns_per_page = math.floor((avail_space - BASE_SPACING) / (btn_size + BASE_SPACING))
 
 	self.num_pages = math.ceil(#self.buttons / btns_per_page)
@@ -55,7 +57,7 @@ local function buttonbar_formspec(self)
 
 	local btn_start_x = self.pos.x + btn_spacing
 	if show_scroll_btns then
-		btn_start_x = btn_start_x + BASE_SPACING + SCROLL_BTN_WIDTH
+		btn_start_x = btn_start_x + BASE_SPACING + get_scroll_btn_width()
 	end
 
 	for i = first_btn, first_btn + btns_per_page - 1 do
@@ -80,7 +82,7 @@ local function buttonbar_formspec(self)
 			y = self.pos.y + BASE_SPACING,
 		}
 		local btn_next_pos = {
-			x = self.pos.x + self.size.x - BASE_SPACING - SCROLL_BTN_WIDTH,
+			x = self.pos.x + self.size.x - BASE_SPACING - get_scroll_btn_width(),
 			y = self.pos.y + BASE_SPACING,
 		}
 
@@ -88,11 +90,11 @@ local function buttonbar_formspec(self)
 				self.btn_prev_name, self.btn_next_name))
 
 		table.insert(formspec, string.format("button[%f,%f;%f,%f;%s;<]",
-				btn_prev_pos.x, btn_prev_pos.y, SCROLL_BTN_WIDTH, btn_size,
+				btn_prev_pos.x, btn_prev_pos.y, get_scroll_btn_width(), btn_size,
 				self.btn_prev_name))
 
 		table.insert(formspec, string.format("button[%f,%f;%f,%f;%s;>]",
-				btn_next_pos.x, btn_next_pos.y, SCROLL_BTN_WIDTH, btn_size,
+				btn_next_pos.x, btn_next_pos.y, get_scroll_btn_width(), btn_size,
 				self.btn_next_name))
 	end
 

--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -898,7 +898,7 @@ local function get_info_formspec(text)
 	return table.concat({
 		"formspec_version[6]",
 		"size[15.75,9.5]",
-		TOUCHSCREEN_GUI and "padding[0.01,0.01]" or "position[0.5,0.55]",
+		core.settings:get_bool("enable_touch") and "padding[0.01,0.01]" or "position[0.5,0.55]",
 
 		"label[4,4.35;", text, "]",
 		"container[0,", H - 0.8 - 0.375, "]",
@@ -928,7 +928,7 @@ function store.get_formspec(dlgdata)
 	local formspec = {
 		"formspec_version[6]",
 		"size[15.75,9.5]",
-		TOUCHSCREEN_GUI and "padding[0.01,0.01]" or "position[0.5,0.55]",
+		core.settings:get_bool("enable_touch") and "padding[0.01,0.01]" or "position[0.5,0.55]",
 
 		"style[status,downloading,queued;border=false]",
 
@@ -1175,8 +1175,8 @@ end
 
 function store.handle_events(event)
 	if event == "DialogShow" then
-		-- On mobile, don't show the "MINETEST" header behind the dialog.
-		mm_game_theme.set_engine(TOUCHSCREEN_GUI)
+		-- On touchscreen, Don't show the "MINETEST" header behind the dialog.
+		mm_game_theme.set_engine(core.settings:get_bool("enable_touch"))
 
 		-- If the store is already loaded, auto-install packages here.
 		do_auto_install()

--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -1175,7 +1175,7 @@ end
 
 function store.handle_events(event)
 	if event == "DialogShow" then
-		-- On touchscreen, Don't show the "MINETEST" header behind the dialog.
+		-- On touchscreen, don't show the "MINETEST" header behind the dialog.
 		mm_game_theme.set_engine(core.settings:get_bool("enable_touch"))
 
 		-- If the store is already loaded, auto-install packages here.

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -316,8 +316,8 @@ local function check_requirements(name, requires)
 	local special = {
 		android = PLATFORM == "Android",
 		desktop = PLATFORM ~= "Android",
-		touchscreen_gui = TOUCHSCREEN_GUI,
-		keyboard_mouse = not TOUCHSCREEN_GUI,
+		touchscreen_gui = core.settings:get_bool("enable_touch"),
+		keyboard_mouse = not core.settings:get_bool("enable_touch"),
 		shaders_support = shaders_support,
 		shaders = core.settings:get_bool("enable_shaders") and shaders_support,
 		opengl = video_driver == "opengl",
@@ -449,13 +449,13 @@ local function get_formspec(dialogdata)
 
 	local extra_h = 1 -- not included in tabsize.height
 	local tabsize = {
-		width = TOUCHSCREEN_GUI and 16.5 or 15.5,
-		height = TOUCHSCREEN_GUI and (10 - extra_h) or 12,
+		width = core.settings:get_bool("enable_touch") and 16.5 or 15.5,
+		height = core.settings:get_bool("enable_touch") and (10 - extra_h) or 12,
 	}
 
-	local scrollbar_w = TOUCHSCREEN_GUI and 0.6 or 0.4
+	local scrollbar_w = core.settings:get_bool("enable_touch") and 0.6 or 0.4
 
-	local left_pane_width = TOUCHSCREEN_GUI and 4.5 or 4.25
+	local left_pane_width = core.settings:get_bool("enable_touch") and 4.5 or 4.25
 	local search_width = left_pane_width + scrollbar_w - (0.75 * 2)
 
 	local back_w = 3
@@ -468,7 +468,7 @@ local function get_formspec(dialogdata)
 	local fs = {
 		"formspec_version[6]",
 		"size[", tostring(tabsize.width), ",", tostring(tabsize.height + extra_h), "]",
-		TOUCHSCREEN_GUI and "padding[0.01,0.01]" or "",
+		core.settings:get_bool("enable_touch") and "padding[0.01,0.01]" or "",
 		"bgcolor[#0000]",
 
 		-- HACK: this is needed to allow resubmitting the same formspec

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -641,7 +641,15 @@ local function buttonhandler(this, fields)
 		local value = core.is_yes(fields.show_advanced)
 		core.settings:set_bool("show_advanced", value)
 		write_settings_early()
+	end
 
+	if fields.enable_touch ~= nil then
+		local value = core.is_yes(fields.enable_touch)
+		core.settings:set_bool("enable_touch", value)
+		write_settings_early()
+	end
+
+	if fields.show_advanced ~= nil or fields.enable_touch ~= nil then
 		local suggested_page_id = update_filtered_pages(dialogdata.query)
 
 		if not filtered_page_by_id[dialogdata.page_id] then

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -643,6 +643,8 @@ local function buttonhandler(this, fields)
 		write_settings_early()
 	end
 
+	-- enable_touch is a checkbox in a setting component. We handle this
+	-- setting differently so we can hide/show pages using the next if-statement
 	if fields.enable_touch ~= nil then
 		local value = core.is_yes(fields.enable_touch)
 		core.settings:set_bool("enable_touch", value)

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -652,8 +652,9 @@ local function buttonhandler(this, fields)
 	if fields.show_advanced ~= nil or fields.enable_touch ~= nil then
 		local suggested_page_id = update_filtered_pages(dialogdata.query)
 
+		dialogdata.components = nil
+
 		if not filtered_page_by_id[dialogdata.page_id] then
-			dialogdata.components = nil
 			dialogdata.leftscroll = 0
 			dialogdata.rightscroll = 0
 

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -94,7 +94,7 @@ function singleplayer_refresh_gamebar()
 
 	local btnbar = buttonbar_create(
 			"game_button_bar",
-			TOUCHSCREEN_GUI and {x = 0, y = 7.25} or {x = 0, y = 7.475},
+			core.settings:get_bool("enable_touch") and {x = 0, y = 7.25} or {x = 0, y = 7.475},
 			{x = 15.5, y = 1.25},
 			"#000000",
 			game_buttonbar_button_handler)

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -148,6 +148,11 @@ invert_hotbar_mouse_wheel (Hotbar: Invert mouse wheel direction) bool false
 
 [*Touchscreen]
 
+#    Enables the touch screen.
+#    If disabled, touchscreen wouldn't be usable in-game
+#    Changing this setting requires a restart.
+enable_touch (Enable Touchscreen) bool true
+
 #    The length in pixels it takes for touchscreen interaction to start.
 #
 #    Requires: touchscreen_gui

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -149,6 +149,8 @@ invert_hotbar_mouse_wheel (Hotbar: Invert mouse wheel direction) bool false
 [*Touchscreen]
 
 #    Enables touchscreen mode, allowing you to play the game with a touchscreen.
+#
+#    Requires: !android
 enable_touch (Enable touchscreen) bool true
 
 #    The length in pixels it takes for touchscreen interaction to start.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -148,10 +148,8 @@ invert_hotbar_mouse_wheel (Hotbar: Invert mouse wheel direction) bool false
 
 [*Touchscreen]
 
-#    Enables the touch screen.
-#    If disabled, touchscreen wouldn't be usable in-game
-#    Changing this setting requires a restart.
-enable_touch (Enable Touchscreen) bool true
+#    Enables touchscreen mode, allowing you to play the game with a touchscreen.
+enable_touch (Enable touchscreen) bool true
 
 #    The length in pixels it takes for touchscreen interaction to start.
 #

--- a/doc/compiling/README.md
+++ b/doc/compiling/README.md
@@ -38,7 +38,7 @@ General options and their default values:
     INSTALL_DEVTEST=FALSE      - Whether the Development Test game should be installed alongside Minetest
     USE_GPROF=FALSE            - Enable profiling using GProf
     VERSION_EXTRA=             - Text to append to version (e.g. VERSION_EXTRA=foobar -> Minetest 0.4.9-foobar)
-    ENABLE_TOUCH=FALSE         - Enable Touchscreen support by default (requires support by IrrlichtMt)
+    ENABLE_TOUCH=FALSE         - Enable touchscreen support by default (requires support by IrrlichtMt)
 
 Library specific options:
 

--- a/doc/compiling/README.md
+++ b/doc/compiling/README.md
@@ -38,7 +38,7 @@ General options and their default values:
     INSTALL_DEVTEST=FALSE      - Whether the Development Test game should be installed alongside Minetest
     USE_GPROF=FALSE            - Enable profiling using GProf
     VERSION_EXTRA=             - Text to append to version (e.g. VERSION_EXTRA=foobar -> Minetest 0.4.9-foobar)
-    ENABLE_TOUCH=FALSE         - Enable Touchscreen support (requires support by IrrlichtMt)
+    ENABLE_TOUCH=FALSE         - Enable Touchscreen support by default (requires support by IrrlichtMt)
 
 Library specific options:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,9 +109,10 @@ if(BUILD_CLIENT AND ENABLE_SOUND)
 	endif()
 endif()
 
-option(ENABLE_TOUCH "Enable Touchscreen support" FALSE)
+option(ENABLE_TOUCH "Enable touchscreen by default" FALSE)
 if(ENABLE_TOUCH)
-	add_definitions(-DHAVE_TOUCHSCREENGUI)
+	message(STATUS "Touchscreen support enabled by default.")
+	add_definitions(-DENABLE_TOUCH)
 endif()
 
 if(BUILD_CLIENT)

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -242,10 +242,10 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 			m_rendering_engine->get_video_driver()->setTextureCreationFlag(
 					video::ETCF_CREATE_MIP_MAPS, g_settings->getBool("mip_map"));
 
-#ifdef HAVE_TOUCHSCREENGUI
-			receiver->m_touchscreengui = new TouchScreenGUI(m_rendering_engine->get_raw_device(), receiver);
-			g_touchscreengui = receiver->m_touchscreengui;
-#endif
+			if (g_settings->getBool("enable_touch")) {
+				receiver->m_touchscreengui = new TouchScreenGUI(m_rendering_engine->get_raw_device(), receiver);
+				g_touchscreengui = receiver->m_touchscreengui;
+			}
 
 			the_game(
 				kill,
@@ -276,11 +276,11 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 
 		m_rendering_engine->get_scene_manager()->clear();
 
-#ifdef HAVE_TOUCHSCREENGUI
-		delete g_touchscreengui;
+		if (g_touchscreengui) {
+			delete g_touchscreengui;
+		}
 		g_touchscreengui = NULL;
 		receiver->m_touchscreengui = NULL;
-#endif
 
 		/* Save the settings when leaving the game.
 		 * This makes sure that setting changes made in-game are persisted even

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -278,9 +278,9 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 
 		if (g_touchscreengui) {
 			delete g_touchscreengui;
+			g_touchscreengui = NULL;
+			receiver->m_touchscreengui = NULL;
 		}
-		g_touchscreengui = NULL;
-		receiver->m_touchscreengui = NULL;
 
 		/* Save the settings when leaving the game.
 		 * This makes sure that setting changes made in-game are persisted even

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3324,10 +3324,8 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	if (pointed != runData.pointed_old)
 		infostream << "Pointing at " << pointed.dump() << std::endl;
 
-#ifdef HAVE_TOUCHSCREENGUI
 	if (g_touchscreengui)
 		g_touchscreengui->applyContextControls(selected_def.touch_interaction.getMode(pointed));
-#endif
 
 	// Note that updating the selection mesh every frame is not particularly efficient,
 	// but the halo rendering code is already inefficient so there's no point in optimizing it here

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4493,16 +4493,16 @@ void Game::showPauseMenu()
 		os << "field[4.95,0;5,1.5;;" << strgettext("Game paused") << ";]";
 	}
 
-#ifndef __ANDROID__
-#if USE_SOUND
+#if USE_SOUND && !defined(__ANDROID__)
 	if (g_settings->getBool("enable_sound")) {
 		os << "button_exit[4," << (ypos++) << ";3,0.5;btn_sound;"
 			<< strgettext("Sound Volume") << "]";
 	}
 #endif
+	if (!g_touchscreengui) {
 	os		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_key_config;"
 		<< strgettext("Controls")  << "]";
-#endif
+	}
 	os		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_exit_menu;"
 		<< strgettext("Exit to Menu") << "]";
 	os		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_exit_os;"

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4435,17 +4435,15 @@ void Game::readSettings()
  ****************************************************************************/
 /****************************************************************************/
 
+static std::string size_tag() {
+  return g_touchscreengui ? "size[11,5.5]" : "size[11,5.5,true]";
+}
+
 void Game::showDeathFormspec()
 {
-	std::string size_tag;
-	if (g_touchscreengui)
-		size_tag = "size[11,5.5]";
-	else
-		size_tag = "size[11,5.5,true]"; // Fixed size on desktop
-
 	static std::string formspec_str =
 		std::string("formspec_version[1]") +
-		size_tag +
+		size_tag() +
 		"bgcolor[#320000b4;true]"
 		"label[4.85,1.35;" + gettext("You died") + "]"
 		"button_exit[4,3;3,0.5;btn_respawn;" + gettext("Respawn") + "]"
@@ -4467,10 +4465,9 @@ void Game::showDeathFormspec()
 #define GET_KEY_NAME(KEY) gettext(getKeySetting(#KEY).name())
 void Game::showPauseMenu()
 {
-	std::string control_text, size_tag;
+	std::string control_text;
 
 	if (g_touchscreengui) {
-		size_tag = "size[11,5.5]";
 		control_text = strgettext("Controls:\n"
 			"No menu open:\n"
 			"- slide finger: look around\n"
@@ -4489,7 +4486,7 @@ void Game::showPauseMenu()
 	float ypos = simple_singleplayer_mode ? 0.7f : 0.1f;
 	std::ostringstream os;
 
-	os << "formspec_version[1]" << size_tag
+	os << "formspec_version[1]" << size_tag()
 		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_continue;"
 		<< strgettext("Continue") << "]";
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4435,15 +4435,11 @@ void Game::readSettings()
  ****************************************************************************/
 /****************************************************************************/
 
-static std::string size_tag() {
-  return g_touchscreengui ? "size[11,5.5]" : "size[11,5.5,true]";
-}
-
 void Game::showDeathFormspec()
 {
 	static std::string formspec_str =
 		std::string("formspec_version[1]") +
-		size_tag() +
+		"size[11,5.5,true]" +
 		"bgcolor[#320000b4;true]"
 		"label[4.85,1.35;" + gettext("You died") + "]"
 		"button_exit[4,3;3,0.5;btn_respawn;" + gettext("Respawn") + "]"
@@ -4486,7 +4482,7 @@ void Game::showPauseMenu()
 	float ypos = simple_singleplayer_mode ? 0.7f : 0.1f;
 	std::ostringstream os;
 
-	os << "formspec_version[1]" << size_tag()
+	os << "formspec_version[1]" << "size[11,5.5,true]"
 		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_continue;"
 		<< strgettext("Continue") << "]";
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -664,6 +664,8 @@ public:
 	}
 };
 
+#define SIZE_TAG "size[11,5.5,true]" // Fixed size (ignored in touchscreen mode)
+
 /****************************************************************************
  ****************************************************************************/
 
@@ -2608,10 +2610,8 @@ void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 	Since Minetest has its own code to synthesize mouse events from touch events,
 	this results in duplicated input. To avoid that, we don't enable relative
 	mouse mode if we're in touchscreen mode. */
-#ifndef HAVE_TOUCHSCREENGUI
 	if (cur_control)
-		cur_control->setRelativeMode(!isMenuActive());
-#endif
+		cur_control->setRelativeMode(!g_touchscreengui && !isMenuActive());
 
 	if ((device->isWindowActive() && device->isWindowFocused()
 			&& !isMenuActive()) || input->isRandom()) {
@@ -4439,7 +4439,7 @@ void Game::showDeathFormspec()
 {
 	static std::string formspec_str =
 		std::string("formspec_version[1]") +
-		"size[11,5.5,true]" +
+		SIZE_TAG
 		"bgcolor[#320000b4;true]"
 		"label[4.85,1.35;" + gettext("You died") + "]"
 		"button_exit[4,3;3,0.5;btn_respawn;" + gettext("Respawn") + "]"
@@ -4482,7 +4482,7 @@ void Game::showPauseMenu()
 	float ypos = simple_singleplayer_mode ? 0.7f : 0.1f;
 	std::ostringstream os;
 
-	os << "formspec_version[1]" << "size[11,5.5,true]"
+	os << "formspec_version[1]" << SIZE_TAG
 		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_continue;"
 		<< strgettext("Continue") << "]";
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4502,7 +4502,7 @@ void Game::showPauseMenu()
 		<< strgettext("Exit to Menu") << "]";
 	os		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_exit_os;"
 		<< strgettext("Exit to OS")   << "]";
-	if (g_touchscreengui) {
+	if (!control_text.empty()) {
 	os		<< "textarea[7.5,0.25;3.9,6.25;;" << control_text << ";]";
 	}
 	os		<< "textarea[0.4,0.25;3.9,6.25;;" << PROJECT_NAME_C " " VERSION_STRING "\n"

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1015,7 +1015,7 @@ private:
 	// this happens in pause menu in singleplayer
 	bool m_is_paused = false;
 
-	bool m_cache_hold_aux1;
+	bool m_touch_simulate_aux1;
 	bool m_touch_use_crosshair;
 	inline bool isNoCrosshairAllowed() {
 		return !m_touch_use_crosshair && camera->getCameraMode() == CAMERA_MODE_FIRST;
@@ -1068,7 +1068,7 @@ Game::Game() :
 
 	readSettings();
 
-	m_cache_hold_aux1 = false;	// This is initialised properly later
+	m_touch_simulate_aux1 = false;	// This is initialised properly later
 
 }
 
@@ -1207,7 +1207,7 @@ void Game::run()
 
 	set_light_table(g_settings->getFloat("display_gamma"));
 
-	m_cache_hold_aux1 = g_settings->getBool("fast_move")
+	m_touch_simulate_aux1 = g_settings->getBool("fast_move")
 			&& client->checkPrivilege("fast");
 
 	const irr::core::dimension2du initial_screen_size(
@@ -2363,7 +2363,7 @@ void Game::toggleFast()
 		m_game_ui->showTranslatedStatusText("Fast mode disabled");
 	}
 
-	m_cache_hold_aux1 = fast_move && has_fast_privs;
+	m_touch_simulate_aux1 = fast_move && has_fast_privs;
 }
 
 
@@ -2721,7 +2721,7 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 	 * touch then its meaning is inverted (i.e. holding aux1 means walk and
 	 * not fast)
 	 */
-	if (g_touchscreengui && m_cache_hold_aux1) {
+	if (g_touchscreengui && m_touch_simulate_aux1) {
 		control.aux1 = control.aux1 ^ true;
 	}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4493,16 +4493,16 @@ void Game::showPauseMenu()
 		os << "field[4.95,0;5,1.5;;" << strgettext("Game paused") << ";]";
 	}
 
-#if USE_SOUND && !defined(__ANDROID__)
+#ifndef __ANDROID__
+#if USE_SOUND
 	if (g_settings->getBool("enable_sound")) {
 		os << "button_exit[4," << (ypos++) << ";3,0.5;btn_sound;"
 			<< strgettext("Sound Volume") << "]";
 	}
 #endif
-	if (!g_touchscreengui) {
 	os		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_key_config;"
 		<< strgettext("Controls")  << "]";
-	}
+#endif
 	os		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_exit_menu;"
 		<< strgettext("Exit to Menu") << "]";
 	os		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_exit_os;"

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1017,7 +1017,7 @@ private:
 	// this happens in pause menu in singleplayer
 	bool m_is_paused = false;
 
-	bool m_touch_simulate_aux1;
+	bool m_touch_simulate_aux1 = false;
 	bool m_touch_use_crosshair;
 	inline bool isTouchCrosshairDisabled() {
 		return !m_touch_use_crosshair && camera->getCameraMode() == CAMERA_MODE_FIRST;
@@ -1069,9 +1069,6 @@ Game::Game() :
 		&settingChangedCallback, this);
 
 	readSettings();
-
-	m_touch_simulate_aux1 = false;	// This is initialised properly later
-
 }
 
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1017,7 +1017,7 @@ private:
 
 	bool m_touch_simulate_aux1;
 	bool m_touch_use_crosshair;
-	inline bool isNoCrosshairAllowed() {
+	inline bool isTouchCrosshairDisabled() {
 		return !m_touch_use_crosshair && camera->getCameraMode() == CAMERA_MODE_FIRST;
 	}
 #ifdef __ANDROID__
@@ -1507,7 +1507,7 @@ bool Game::createClient(const GameStartData &start_data)
 	client->setCamera(camera);
 
 	if (g_touchscreengui) {
-		g_touchscreengui->setUseCrosshair(!isNoCrosshairAllowed());
+		g_touchscreengui->setUseCrosshair(!isTouchCrosshairDisabled());
 	}
 
 	/* Clouds
@@ -3205,7 +3205,7 @@ void Game::updateCamera(f32 dtime)
 		camera->toggleCameraMode();
 
 		if (g_touchscreengui)
-			g_touchscreengui->setUseCrosshair(!isNoCrosshairAllowed());
+			g_touchscreengui->setUseCrosshair(!isTouchCrosshairDisabled());
 
 		// Make the player visible depending on camera mode.
 		playercao->updateMeshCulling();
@@ -3306,7 +3306,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	}
 	shootline.end = shootline.start + camera_direction * BS * d;
 
-	if (g_touchscreengui && isNoCrosshairAllowed()) {
+	if (g_touchscreengui && isTouchCrosshairDisabled()) {
 		shootline = g_touchscreengui->getShootline();
 		// Scale shootline to the acual distance the player can reach
 		shootline.end = shootline.start +
@@ -4311,7 +4311,7 @@ void Game::drawScene(ProfilerGraph *graph, RunStats *stats)
 			(player->hud_flags & HUD_FLAG_CROSSHAIR_VISIBLE) &&
 			(this->camera->getCameraMode() != CAMERA_MODE_THIRD_FRONT));
 
-	if (g_touchscreengui && isNoCrosshairAllowed())
+	if (g_touchscreengui && isTouchCrosshairDisabled())
 		draw_crosshair = false;
 
 	this->m_rendering_engine->draw_scene(sky_color, this->m_game_ui->m_flags.show_hud,

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -39,10 +39,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "wieldmesh.h"
 #include "client/renderingengine.h"
 #include "client/minimap.h"
-
-#ifdef HAVE_TOUCHSCREENGUI
 #include "gui/touchscreengui.h"
-#endif
 
 #define OBJECT_CROSSHAIR_LINE_SIZE 8
 #define CROSSHAIR_LINE_SIZE 10
@@ -292,10 +289,8 @@ void Hud::drawItems(v2s32 upperleftpos, v2s32 screen_offset, s32 itemcount,
 
 		drawItem(mainlist->getItem(i), item_rect, (i + 1) == selectitem);
 
-#ifdef HAVE_TOUCHSCREENGUI
 		if (is_hotbar && g_touchscreengui)
 			g_touchscreengui->registerHotbarRect(i, item_rect);
-#endif
 	}
 }
 
@@ -749,10 +744,8 @@ void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir,
 
 void Hud::drawHotbar(u16 playeritem)
 {
-#ifdef HAVE_TOUCHSCREENGUI
 	if (g_touchscreengui)
 		g_touchscreengui->resetHotbarRects();
-#endif
 
 	InventoryList *mainlist = inventory->getList("main");
 	if (mainlist == NULL) {

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -102,11 +102,9 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 		React to nothing here if a menu is active
 	*/
 	if (isMenuActive()) {
-#ifdef HAVE_TOUCHSCREENGUI
 		if (m_touchscreengui) {
 			m_touchscreengui->setVisible(false);
 		}
-#endif
 		return g_menumgr.preprocessEvent(event);
 	}
 
@@ -130,12 +128,10 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 			return true;
 		}
 
-#ifdef HAVE_TOUCHSCREENGUI
 	} else if (m_touchscreengui && event.EventType == irr::EET_TOUCH_INPUT_EVENT) {
 		// In case of touchscreengui, we have to handle different events
 		m_touchscreengui->translateEvent(event);
 		return true;
-#endif
 
 	} else if (event.EventType == irr::EET_JOYSTICK_INPUT_EVENT) {
 		// joystick may be nullptr if game is launched with '--random-input' parameter

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -24,10 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <list>
 #include "keycode.h"
 #include "renderingengine.h"
-
-#ifdef HAVE_TOUCHSCREENGUI
 #include "gui/touchscreengui.h"
-#endif
 
 class InputHandler;
 
@@ -203,16 +200,12 @@ public:
 
 	MyEventReceiver()
 	{
-#ifdef HAVE_TOUCHSCREENGUI
 		m_touchscreengui = NULL;
-#endif
 	}
 
 	JoystickController *joystick = nullptr;
 
-#ifdef HAVE_TOUCHSCREENGUI
 	TouchScreenGUI *m_touchscreengui;
-#endif
 
 private:
 	s32 mouse_wheel = 0;
@@ -332,11 +325,9 @@ public:
 				return 0.0f;
 			return 1.0f; // If there is a keyboard event, assume maximum speed
 		}
-#ifdef HAVE_TOUCHSCREENGUI
-		return m_receiver->m_touchscreengui->getMovementSpeed();
-#else
+		if (m_receiver->m_touchscreengui && m_receiver->m_touchscreengui->getMovementSpeed())
+			return m_receiver->m_touchscreengui->getMovementSpeed();
 		return joystick.getMovementSpeed();
-#endif
 	}
 
 	virtual float getMovementDirection()
@@ -355,12 +346,9 @@ public:
 
 		if (x != 0 || z != 0) /* If there is a keyboard event, it takes priority */
 			return atan2(x, z);
-		else
-#ifdef HAVE_TOUCHSCREENGUI
+		else if (m_receiver->m_touchscreengui && m_receiver->m_touchscreengui->getMovementDirection())
 			return m_receiver->m_touchscreengui->getMovementDirection();
-#else
-			return joystick.getMovementDirection();
-#endif
+		return joystick.getMovementDirection();
 	}
 
 	virtual bool cancelPressed()

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -18,20 +18,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "keycode.h"
-#include "exceptions.h"
 #include "settings.h"
 #include "log.h"
 #include "debug.h"
 #include "util/hex.h"
 #include "util/string.h"
 #include "util/basic_macros.h"
-
-class UnknownKeycode : public BaseException
-{
-public:
-	UnknownKeycode(const char *s) :
-		BaseException(s) {};
-};
 
 struct table_key {
 	const char *Name;

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -19,10 +19,18 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "exceptions.h"
 #include "irrlichttypes.h"
 #include "Keycodes.h"
 #include <IEventReceiver.h>
 #include <string>
+
+class UnknownKeycode : public BaseException
+{
+public:
+	UnknownKeycode(const char *s) :
+		BaseException(s) {};
+};
 
 /* A key press, consisting of either an Irrlicht keycode
    or an actual char */

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef SERVER
 #include "settings.h"
 #include "client/renderingengine.h"
+#include "gui/touchscreengui.h"
 #endif
 
 
@@ -50,11 +51,7 @@ public:
 		f32 hud_scaling = g_settings->getFloat("hud_scaling", 0.5f, 20.0f);
 		f32 real_gui_scaling = gui_scaling * density;
 		f32 real_hud_scaling = hud_scaling * density;
-#ifdef HAVE_TOUCHSCREENGUI
-		bool touch_controls = true;
-#else
-		bool touch_controls = false;
-#endif
+		bool touch_controls = g_touchscreengui;
 
 		return {
 			screen_size, real_gui_scaling, real_hud_scaling,
@@ -67,12 +64,7 @@ public:
 private:
 #ifndef SERVER
 	static v2f32 calculateMaxFSSize(v2u32 render_target_size, f32 gui_scaling) {
-		f32 factor =
-#ifdef __ANDROID__
-				10 / gui_scaling;
-#else
-				15 / gui_scaling;
-#endif
+		f32 factor = (g_settings->getBool("enable_touch") ? 10 : 15) / gui_scaling;
 		f32 ratio = (f32)render_target_size.X / (f32)render_target_size.Y;
 		if (ratio < 1)
 			return { factor, factor / ratio };

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -68,7 +68,7 @@ private:
 #ifndef SERVER
 	static v2f32 calculateMaxFSSize(v2u32 render_target_size, f32 gui_scaling) {
 		f32 factor =
-#ifdef HAVE_TOUCHSCREENGUI
+#ifdef __ANDROID__
 				10 / gui_scaling;
 #else
 				15 / gui_scaling;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -39,6 +39,11 @@ void set_default_settings()
 	// Client
 	settings->setDefault("address", "");
 	settings->setDefault("enable_sound", "true");
+#if ENABLE_TOUCH
+	settings->setDefault("enable_touch", "true");
+#else
+	settings->setDefault("enable_touch", "false");
+#endif
 	settings->setDefault("sound_volume", "0.8");
 	settings->setDefault("sound_volume_unfocused", "0.3");
 	settings->setDefault("mute_sound", "false");
@@ -90,7 +95,7 @@ void set_default_settings()
 	settings->setDefault("keymap_cmd_local", ".");
 	settings->setDefault("keymap_minimap", "KEY_KEY_V");
 	settings->setDefault("keymap_console", "KEY_F10");
-#if HAVE_TOUCHSCREENGUI
+#if ENABLE_TOUCH
 	// See https://github.com/minetest/minetest/issues/12792
 	settings->setDefault("keymap_rangeselect", "KEY_KEY_R");
 #else
@@ -192,7 +197,11 @@ void set_default_settings()
 	settings->setDefault("screen_h", "600");
 	settings->setDefault("window_maximized", "false");
 	settings->setDefault("autosave_screensize", "true");
+#ifdef ENABLE_TOUCH
+	settings->setDefault("fullscreen", "true");
+#else
 	settings->setDefault("fullscreen", "false");
+#endif
 	settings->setDefault("vsync", "false");
 	settings->setDefault("fov", "72");
 	settings->setDefault("leaves_style", "fancy");
@@ -298,7 +307,7 @@ void set_default_settings()
 	settings->setDefault("aux1_descends", "false");
 	settings->setDefault("doubletap_jump", "false");
 	settings->setDefault("always_fly_fast", "true");
-#ifdef HAVE_TOUCHSCREENGUI
+#ifdef ENABLE_TOUCH
 	settings->setDefault("autojump", "true");
 #else
 	settings->setDefault("autojump", "false");
@@ -477,21 +486,23 @@ void set_default_settings()
 	settings->setDefault("keymap_sneak", "KEY_SHIFT");
 #endif
 
-#ifdef HAVE_TOUCHSCREENGUI
 	settings->setDefault("touchscreen_threshold", "20");
 	settings->setDefault("touchscreen_sensitivity", "0.2");
+#ifdef ENABLE_TOUCH
 	settings->setDefault("touch_use_crosshair", "false");
 	settings->setDefault("fixed_virtual_joystick", "false");
 	settings->setDefault("virtual_joystick_triggers_aux1", "false");
 	settings->setDefault("clickable_chat_weblinks", "false");
 #else
+	settings->setDefault("touch_use_crosshair", "true");
+	settings->setDefault("fixed_virtual_joystick", "true");
+	settings->setDefault("virtual_joystick_triggers_aux1", "true");
 	settings->setDefault("clickable_chat_weblinks", "true");
 #endif
 	// Altered settings for Android
 #ifdef __ANDROID__
 	settings->setDefault("screen_w", "0");
 	settings->setDefault("screen_h", "0");
-	settings->setDefault("fullscreen", "true");
 	settings->setDefault("performance_tradeoffs", "true");
 	settings->setDefault("max_simultaneous_block_sends_per_client", "10");
 	settings->setDefault("emergequeue_limit_diskonly", "16");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -488,15 +488,12 @@ void set_default_settings()
 
 	settings->setDefault("touchscreen_threshold", "20");
 	settings->setDefault("touchscreen_sensitivity", "0.2");
-#ifdef ENABLE_TOUCH
 	settings->setDefault("touch_use_crosshair", "false");
 	settings->setDefault("fixed_virtual_joystick", "false");
 	settings->setDefault("virtual_joystick_triggers_aux1", "false");
+#ifdef ENABLE_TOUCH
 	settings->setDefault("clickable_chat_weblinks", "false");
 #else
-	settings->setDefault("touch_use_crosshair", "true");
-	settings->setDefault("fixed_virtual_joystick", "true");
-	settings->setDefault("virtual_joystick_triggers_aux1", "true");
 	settings->setDefault("clickable_chat_weblinks", "true");
 #endif
 	// Altered settings for Android

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,8 +1,3 @@
-set(extra_gui_SRCS "")
-if(ENABLE_TOUCH)
-	set(extra_gui_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/touchscreengui.cpp)
-endif()
-
 set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiAnimatedImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiBackgroundImage.cpp
@@ -29,6 +24,6 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiVolumeChange.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/modalMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/profilergraph.cpp
-	${extra_gui_SRCS}
+	${CMAKE_CURRENT_SOURCE_DIR}/touchscreengui.cpp
 	PARENT_SCOPE
 )

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -316,13 +316,11 @@ void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 		data->invsize.Y = MYMAX(0, stof(parts[1]));
 
 		lockSize(false);
-#ifndef HAVE_TOUCHSCREENGUI
-		if (parts.size() == 3) {
+		if (!g_settings->getBool("enable_touch") && parts.size() == 3) {
 			if (parts[2] == "true") {
 				lockSize(true,v2u32(800,600));
 			}
 		}
-#endif
 		data->explicit_size = true;
 		return;
 	}
@@ -3284,14 +3282,15 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 			s32 min_screen_dim = std::min(padded_screensize.X, padded_screensize.Y);
 
-#ifdef HAVE_TOUCHSCREENGUI
-			// In Android, the preferred imgsize should be larger to accommodate the
-			// smaller screensize.
-			double prefer_imgsize = min_screen_dim / 10 * gui_scaling;
-#else
-			// Desktop computers have more space, so try to fit 15 coordinates.
-			double prefer_imgsize = min_screen_dim / 15 * gui_scaling;
-#endif
+			double prefer_imgsize;
+			if (g_settings->getBool("enable_touch")) {
+				// The preferred imgsize should be larger to accommodate the
+				// smaller screensize.
+				prefer_imgsize = min_screen_dim / 10 * gui_scaling;
+			} else {
+				// Desktop computers have more space, so try to fit 15 coordinates.
+				prefer_imgsize = min_screen_dim / 15 * gui_scaling;
+			}
 			// Try to use the preferred imgsize, but if that's bigger than the maximum
 			// size, use the maximum size.
 			use_imgsize = std::min(prefer_imgsize,

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -24,10 +24,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <IGUIButton.h>
 #include <IGUIStaticText.h>
 #include <IGUIFont.h>
-
-#ifdef HAVE_TOUCHSCREENGUI
-	#include "client/renderingengine.h"
-#endif
+#include "client/renderingengine.h"
 
 #include "porting.h"
 #include "gettext.h"
@@ -66,11 +63,8 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-#ifdef HAVE_TOUCHSCREENGUI
 	const float s = m_gui_scale * RenderingEngine::getDisplayDensity() / 2;
-#else
-	const float s = m_gui_scale;
-#endif
+
 	DesiredRect = core::rect<s32>(
 		screensize.X / 2 - 580 * s / 2,
 		screensize.Y / 2 - 300 * s / 2,

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -63,7 +63,7 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-	const float s = m_gui_scale * RenderingEngine::getDisplayDensity() / 2;
+	const float s = m_gui_scale;
 
 	DesiredRect = core::rect<s32>(
 		screensize.X / 2 - 580 * s / 2,

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -24,7 +24,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <IGUIButton.h>
 #include <IGUIStaticText.h>
 #include <IGUIFont.h>
-#include "client/renderingengine.h"
 
 #include "porting.h"
 #include "gettext.h"

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -42,7 +42,7 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
 	m_gui_scale = std::max(g_settings->getFloat("gui_scaling"), 0.5f);
 	const float screen_dpi_scale = RenderingEngine::getDisplayDensity();
 
-	if (g_touchscreengui) {
+	if (g_settings->getBool("enable_touch")) {
 		m_gui_scale *= 1.1f - 0.3f * screen_dpi_scale + 0.2f * screen_dpi_scale * screen_dpi_scale;
 	} else {
 		m_gui_scale *= screen_dpi_scale;

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -27,10 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gettext.h"
 #include "porting.h"
 #include "settings.h"
-
-#ifdef HAVE_TOUCHSCREENGUI
 #include "touchscreengui.h"
-#endif
 
 GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
 	s32 id, IMenuManager *menumgr, bool remap_dbl_click) :
@@ -44,11 +41,12 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
 {
 	m_gui_scale = std::max(g_settings->getFloat("gui_scaling"), 0.5f);
 	const float screen_dpi_scale = RenderingEngine::getDisplayDensity();
-#ifdef HAVE_TOUCHSCREENGUI
-	m_gui_scale *= 1.1f - 0.3f * screen_dpi_scale + 0.2f * screen_dpi_scale * screen_dpi_scale;
-#else
-	m_gui_scale *= screen_dpi_scale;
-#endif
+
+	if (g_touchscreengui) {
+		m_gui_scale *= 1.1f - 0.3f * screen_dpi_scale + 0.2f * screen_dpi_scale * screen_dpi_scale;
+	} else {
+		m_gui_scale *= screen_dpi_scale;
+	}
 
 	setVisible(true);
 	m_menumgr->createdMenu(this);
@@ -102,10 +100,8 @@ void GUIModalMenu::quitMenu()
 	Environment->removeFocus(this);
 	m_menumgr->deletingMenu(this);
 	this->remove();
-#ifdef HAVE_TOUCHSCREENGUI
 	if (g_touchscreengui)
 		g_touchscreengui->show();
-#endif
 }
 
 static bool isChild(gui::IGUIElement *tocheck, gui::IGUIElement *parent)

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -546,7 +546,7 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 			AHBB_Dir_Left_Right, 2.0f);
 
 	m_rare_controls_bar.addButton(chat_id, L"chat", "chat_btn.png");
-	m_rare_controls_bar.addButton(inventory_id, L"inv", "inventory_btn.png");
+	m_rare_controls_bar.addButton(inventory_id, L"inventory", "inventory_btn.png");
 	m_rare_controls_bar.addButton(drop_id, L"drop", "drop_btn.png");
 	m_rare_controls_bar.addButton(exit_id, L"exit", "exit_btn.png");
 

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -55,6 +55,7 @@ const std::string joystick_image_names[] = {
 
 static EKEY_CODE id_to_keycode(touch_gui_button_id id)
 {
+	EKEY_CODE code;
 	// ESC isn't part of the keymap.
 	if (id == exit_id)
 		return KEY_ESCAPE;
@@ -110,7 +111,15 @@ static EKEY_CODE id_to_keycode(touch_gui_button_id id)
 			break;
 	}
 	assert(!key.empty());
-	return keyname_to_keycode(g_settings->get("keymap_" + key).c_str());
+	std::string resolved = g_settings->get("keymap_" + key);
+	try {
+		code = keyname_to_keycode(resolved.c_str());
+	} catch (UnknownKeycode &e) {
+		code = KEY_KEY_CODES_COUNT;
+		warningstream << "TouchScreenGUI: Unknown key '" << resolved
+			      << "' for '" << key << "', hiding button." << std::endl;
+	}
+	return code;
 }
 
 static void load_button_texture(const button_info *btn, const std::string &path,
@@ -523,13 +532,22 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 							+ 0.5f * button_size),
 			AHBB_Dir_Right_Left, 3.0f);
 
-	m_settings_bar.addButton(fly_id, L"fly", "fly_btn.png");
-	m_settings_bar.addButton(noclip_id, L"noclip", "noclip_btn.png");
-	m_settings_bar.addButton(fast_id, L"fast", "fast_btn.png");
-	m_settings_bar.addButton(debug_id, L"debug", "debug_btn.png");
-	m_settings_bar.addButton(camera_id, L"camera", "camera_btn.png");
-	m_settings_bar.addButton(range_id, L"rangeview", "rangeview_btn.png");
-	m_settings_bar.addButton(minimap_id, L"minimap", "minimap_btn.png");
+	std::map<touch_gui_button_id,std::string> m_settings_bar_buttons {
+		{fly_id, "fly"},
+		{noclip_id, "noclip"},
+		{fast_id, "fast"},
+		{debug_id, "debug"},
+		{camera_id, "camera"},
+		{range_id, "rangeview"},
+		{minimap_id, "minimap"},
+	};
+	for (const auto &pair : m_settings_bar_buttons) {
+		if (id_to_keycode(pair.first) == KEY_KEY_CODES_COUNT)
+			continue;
+
+		const wchar_t* wide = utf8_to_wide(pair.second).c_str();
+		m_settings_bar.addButton(pair.first, wide, pair.second + "_btn.png");
+	}
 
 	// Chat is shown by default, so chat_hide_btn.png is shown first.
 	m_settings_bar.addToggleButton(toggle_chat_id, L"togglechat",
@@ -545,10 +563,19 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 							+ 0.5f * button_size),
 			AHBB_Dir_Left_Right, 2.0f);
 
-	m_rare_controls_bar.addButton(chat_id, L"chat", "chat_btn.png");
-	m_rare_controls_bar.addButton(inventory_id, L"inventory", "inventory_btn.png");
-	m_rare_controls_bar.addButton(drop_id, L"drop", "drop_btn.png");
-	m_rare_controls_bar.addButton(exit_id, L"exit", "exit_btn.png");
+	std::map<touch_gui_button_id,std::string> m_rare_controls_bar_buttons {
+		{chat_id, "chat"},
+		{chat_id, "inventory"},
+		{drop_id, "drop"},
+		{exit_id, "exit"},
+	};
+	for (const auto &pair : m_rare_controls_bar_buttons) {
+		if (id_to_keycode(pair.first) == KEY_KEY_CODES_COUNT)
+			continue;
+
+		const wchar_t* wide = utf8_to_wide(pair.second).c_str();
+		m_rare_controls_bar.addButton(pair.first, wide, pair.second + "_btn.png");
+	}
 
 	m_initialized = true;
 }

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -532,7 +532,7 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 							+ 0.5f * button_size),
 			AHBB_Dir_Right_Left, 3.0f);
 
-	std::map<touch_gui_button_id, std::string> settings_bar_buttons {
+	const static std::map<touch_gui_button_id, std::string> settings_bar_buttons {
 		{fly_id, "fly"},
 		{noclip_id, "noclip"},
 		{fast_id, "fast"},
@@ -564,7 +564,7 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 							+ 0.5f * button_size),
 			AHBB_Dir_Left_Right, 2.0f);
 
-	std::map<touch_gui_button_id, std::string> rare_controls_bar_buttons {
+	const static std::map<touch_gui_button_id, std::string> rare_controls_bar_buttons {
 		{chat_id, "chat"},
 		{inventory_id, "inventory"},
 		{drop_id, "drop"},

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -545,9 +545,9 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 		if (id_to_keycode(pair.first) == KEY_KEY_CODES_COUNT)
 			continue;
 
-		m_settings_bar.addButton(pair.first,
-					 utf8_to_wide(pair.second).c_str(),
-					 pair.second + "_btn.png");
+		std::wstring wide = utf8_to_wide(pair.second);
+		m_settings_bar.addButton(pair.first, wide.c_str(),
+				pair.second + "_btn.png");
 	}
 
 	// Chat is shown by default, so chat_hide_btn.png is shown first.
@@ -574,9 +574,9 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 		if (id_to_keycode(pair.first) == KEY_KEY_CODES_COUNT)
 			continue;
 
-		m_rare_controls_bar.addButton(pair.first,
-					      utf8_to_wide(pair.second).c_str(),
-					      pair.second + "_btn.png");
+		std::wstring wide = utf8_to_wide(pair.second);
+		m_rare_controls_bar.addButton(pair.first, wide.c_str(),
+				pair.second + "_btn.png");
 	}
 
 	m_initialized = true;

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -115,7 +115,7 @@ static EKEY_CODE id_to_keycode(touch_gui_button_id id)
 	try {
 		code = keyname_to_keycode(resolved.c_str());
 	} catch (UnknownKeycode &e) {
-		code = KEY_KEY_CODES_COUNT;
+		code = KEY_UNKNOWN;
 		warningstream << "TouchScreenGUI: Unknown key '" << resolved
 			      << "' for '" << key << "', hiding button." << std::endl;
 	}
@@ -542,7 +542,7 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 		{minimap_id, "minimap"},
 	};
 	for (const auto &pair : settings_bar_buttons) {
-		if (id_to_keycode(pair.first) == KEY_KEY_CODES_COUNT)
+		if (id_to_keycode(pair.first) == KEY_UNKNOWN)
 			continue;
 
 		std::wstring wide = utf8_to_wide(pair.second);
@@ -571,7 +571,7 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 		{exit_id, "exit"},
 	};
 	for (const auto &pair : rare_controls_bar_buttons) {
-		if (id_to_keycode(pair.first) == KEY_KEY_CODES_COUNT)
+		if (id_to_keycode(pair.first) == KEY_UNKNOWN)
 			continue;
 
 		std::wstring wide = utf8_to_wide(pair.second);

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -545,8 +545,9 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 		if (id_to_keycode(pair.first) == KEY_KEY_CODES_COUNT)
 			continue;
 
-		const wchar_t* wide = utf8_to_wide(pair.second).c_str();
-		m_settings_bar.addButton(pair.first, wide, pair.second + "_btn.png");
+		m_settings_bar.addButton(pair.first,
+					 utf8_to_wide(pair.second).c_str(),
+					 pair.second + "_btn.png");
 	}
 
 	// Chat is shown by default, so chat_hide_btn.png is shown first.
@@ -573,8 +574,9 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 		if (id_to_keycode(pair.first) == KEY_KEY_CODES_COUNT)
 			continue;
 
-		const wchar_t* wide = utf8_to_wide(pair.second).c_str();
-		m_rare_controls_bar.addButton(pair.first, wide, pair.second + "_btn.png");
+		m_rare_controls_bar.addButton(pair.first,
+					      utf8_to_wide(pair.second).c_str(),
+					      pair.second + "_btn.png");
 	}
 
 	m_initialized = true;

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -532,7 +532,7 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 							+ 0.5f * button_size),
 			AHBB_Dir_Right_Left, 3.0f);
 
-	std::map<touch_gui_button_id,std::string> m_settings_bar_buttons {
+	std::map<touch_gui_button_id, std::string> settings_bar_buttons {
 		{fly_id, "fly"},
 		{noclip_id, "noclip"},
 		{fast_id, "fast"},
@@ -541,7 +541,7 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 		{range_id, "rangeview"},
 		{minimap_id, "minimap"},
 	};
-	for (const auto &pair : m_settings_bar_buttons) {
+	for (const auto &pair : settings_bar_buttons) {
 		if (id_to_keycode(pair.first) == KEY_KEY_CODES_COUNT)
 			continue;
 
@@ -563,13 +563,13 @@ void TouchScreenGUI::init(ISimpleTextureSource *tsrc)
 							+ 0.5f * button_size),
 			AHBB_Dir_Left_Right, 2.0f);
 
-	std::map<touch_gui_button_id,std::string> m_rare_controls_bar_buttons {
+	std::map<touch_gui_button_id, std::string> rare_controls_bar_buttons {
 		{chat_id, "chat"},
-		{chat_id, "inventory"},
+		{inventory_id, "inventory"},
 		{drop_id, "drop"},
 		{exit_id, "exit"},
 	};
-	for (const auto &pair : m_rare_controls_bar_buttons) {
+	for (const auto &pair : rare_controls_bar_buttons) {
 		if (id_to_keycode(pair.first) == KEY_KEY_CODES_COUNT)
 			continue;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,9 +50,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gui/guiEngine.h"
 #include "gui/mainmenumanager.h"
 #endif
-#ifdef HAVE_TOUCHSCREENGUI
-	#include "gui/touchscreengui.h"
-#endif
+#include "gui/touchscreengui.h"
 
 // for version information only
 extern "C" {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gui/guiEngine.h"
 #include "gui/mainmenumanager.h"
 #endif
-#include "gui/touchscreengui.h"
 
 // for version information only
 extern "C" {

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -153,13 +153,6 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 	lua_pushstring(m_luastack, porting::getPlatformName());
 	lua_setglobal(m_luastack, "PLATFORM");
 
-#ifdef HAVE_TOUCHSCREENGUI
-	lua_pushboolean(m_luastack, true);
-#else
-	lua_pushboolean(m_luastack, false);
-#endif
-	lua_setglobal(m_luastack, "TOUCHSCREEN_GUI");
-
 	// Make sure Lua uses the right locale
 	setlocale(LC_NUMERIC, "C");
 }


### PR DESCRIPTION
#### What

Allow runtime switching between desktop and touchscreen mode.

#### How

This PR replaces hardcoded `#ifdef`s with setting (`enable_touch`).

#### Resolves:
 - Fixes (but just partly) https://github.com/minetest/minetest/issues/10062
 - Fixes https://github.com/minetest/minetest/issues/12785

#### Problem solved by this:

Ability to distribute one binary for touchscreen enabled and classic (desktops and laptops without touchscreens).

https://floss.social/@okias/111417351641760633

People love to play Minetest on Linux phones. Some of these phones are convergent, so they work as desktop when connected to USB-C.

Also we have Linux tablets and convertible PCs.


## How to test

In the settings appear new checkbox for the touchscreen. You can check it or uncheck it and see whats going to happen.

#### TODO
 - At some point would be lovely to have touchscreen getting auto-detected.

#### Depends
 - on 5.9 (currently `master` branch), for code applicable on 5.8, use https://github.com/okias/minetest/tree/linux-touch-5.8
 - https://github.com/minetest/minetest/pull/14117
 - https://github.com/minetest/minetest/pull/14146
 - https://github.com/minetest/minetest/pull/13282