### PR TITLE
Make safeWriteToFile more likely to succeed on Windows.

### DIFF
--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -25,6 +25,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cstring>
 #include <cerrno>
 #include <fstream>
+#include <random>
+#include <sstream>
 #include "log.h"
 #include "config.h"
 #include "porting.h"
@@ -755,49 +757,64 @@ const char *GetFilenameFromPath(const char *path)
 
 bool safeWriteToFile(const std::string &path, const std::string &content)
 {
-	std::string tmp_file = path + ".~mt";
+	// Write to tmp file
+	std::random_device rd;
+	std::mt19937 gen(rd());
+	std::uniform_int_distribution<unsigned int> distrib(0);
 
-	// Write to a tmp file
-	std::ofstream os(tmp_file.c_str(), std::ios::binary);
-	if (!os.good())
-		return false;
-	os << content;
-	os.flush();
-	os.close();
-	if (os.fail()) {
-		// Remove the temporary file because writing it failed and it's useless.
-		remove(tmp_file.c_str());
+	int random_int = distrib(gen);
+
+	std::stringstream ss;
+	ss << std::hex << random_int;
+
+	std::string tmp_path = TempPath() + DIR_DELIM + "minetest_" + ss.str();
+	std::ofstream tmp_os(tmp_path.c_str(), std::ios::binary);
+	if (!tmp_os.good()) {
+		warningstream << "Failed to create temp file: " << tmp_path << std::endl;
 		return false;
 	}
 
-	bool rename_success = false;
+	{ // scope for the unique_ptr
+		// Attempt to remove the temporary file on exit, but don't worry about checking
+		// success since the OS should clean it up anyway.
+		auto deleter = [&tmp_path](std::ofstream *os) { std::remove(tmp_path.c_str()); };
+		std::unique_ptr<std::ofstream, decltype(deleter)> tmp_os_ptr(&tmp_os, deleter);
+		tmp_os << content;
+		tmp_os.flush();
+		tmp_os.close();
+		if (tmp_os.fail()) {
+			warningstream << "Failed to write to temp file: " << tmp_path << std::endl;
+			return false;
+		}
 
-	// Move the finished temporary file over the real file
+		bool write_succeeded = false;
 #ifdef _WIN32
-	// When creating the file, it can cause Windows Search indexer, virus scanners and other apps
-	// to query the file. This can make the move file call below fail.
-	// We retry up to 5 times, with a 1ms sleep between, before we consider the whole operation failed
-	int number_attempts = 0;
-	while (number_attempts < 5) {
-		rename_success = MoveFileEx(tmp_file.c_str(), path.c_str(),
-				MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
-		if (rename_success)
-			break;
-		sleep_ms(1);
-		++number_attempts;
-	}
+		// On Windows we've observed that the newly created temp file is often
+		// being read by other processes and Windows does not allow moving
+		// of a file while it is being read, so we retry and then fall back to copying.
+		// NOTE: once Windows 10 is the lowest supported verison, we should consider
+		// using FILE_DISPOSITION_POSIX_SEMANTICS to avoid this issue.
+		for (int attempts = 0; attempts < 5; attempts++) {
+			write_succeeded = MoveFileEx(tmp_path.c_str(), path.c_str(),
+					MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+			if (write_succeeded)
+				break;
+			sleep_ms(attempts + 1);
+		}
+		if (!write_succeeded) {
+			write_succeeded = CopyFile(tmp_path.c_str(), path.c_str(), false);
+		}
 #else
-	// On POSIX compliant systems rename() is specified to be able to swap the
-	// file in place of the destination file, making this a truly error-proof
-	// transaction.
-	rename_success = rename(tmp_file.c_str(), path.c_str()) == 0;
+		// On POSIX rename() is able to swap the file in place of the destination file,
+		// even if it's being read.
+		write_succeeded = (std::rename(tmp_path.c_str(), path.c_str()) == 0);
 #endif
-	if (!rename_success) {
-		warningstream << "Failed to write to file: " << path.c_str() << std::endl;
-		// Remove the temporary file because moving it over the target file
-		// failed.
-		remove(tmp_file.c_str());
-		return false;
+		if (write_succeeded) {
+			tmp_os_ptr.release(); // Deletion no longer needed.
+		} else {
+			warningstream << "Failed to write to file: " << path.c_str() << std::endl;
+			return false;
+		}
 	}
 
 	return true;

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -9,7 +9,7 @@ set (UNITTEST_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/test_compression.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_connection.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_craft.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/test_filepath.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/test_filesys.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_inventory.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_irrptr.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_lua.cpp

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -26,10 +26,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nodedef.h"
 #include "noise.h"
 
-class TestFilePath : public TestBase {
+class TestFileSys : public TestBase
+{
 public:
-	TestFilePath() { TestManager::registerTestModule(this); }
-	const char *getName() { return "TestFilePath"; }
+	TestFileSys() {	TestManager::registerTestModule(this); }
+	const char *getName() {	return "TestFileSys"; }
 
 	void runTests(IGameDef *gamedef);
 
@@ -38,17 +39,19 @@ public:
 	void testRemoveLastPathComponent();
 	void testRemoveLastPathComponentWithTrailingDelimiter();
 	void testRemoveRelativePathComponent();
+	void testSafeWriteToFile();
 };
 
-static TestFilePath g_test_instance;
+static TestFileSys g_test_instance;
 
-void TestFilePath::runTests(IGameDef *gamedef)
+void TestFileSys::runTests(IGameDef *gamedef)
 {
 	TEST(testIsDirDelimiter);
 	TEST(testPathStartsWith);
 	TEST(testRemoveLastPathComponent);
 	TEST(testRemoveLastPathComponentWithTrailingDelimiter);
 	TEST(testRemoveRelativePathComponent);
+	TEST(testSafeWriteToFile);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -74,7 +77,7 @@ std::string p(std::string path)
 }
 
 
-void TestFilePath::testIsDirDelimiter()
+void TestFileSys::testIsDirDelimiter()
 {
 	UASSERT(fs::IsDirDelimiter('/') == true);
 	UASSERT(fs::IsDirDelimiter('A') == false);
@@ -87,7 +90,7 @@ void TestFilePath::testIsDirDelimiter()
 }
 
 
-void TestFilePath::testPathStartsWith()
+void TestFileSys::testPathStartsWith()
 {
 	const int numpaths = 12;
 	std::string paths[numpaths] = {
@@ -163,7 +166,7 @@ void TestFilePath::testPathStartsWith()
 }
 
 
-void TestFilePath::testRemoveLastPathComponent()
+void TestFileSys::testRemoveLastPathComponent()
 {
 	std::string path, result, removed;
 
@@ -200,7 +203,7 @@ void TestFilePath::testRemoveLastPathComponent()
 }
 
 
-void TestFilePath::testRemoveLastPathComponentWithTrailingDelimiter()
+void TestFileSys::testRemoveLastPathComponentWithTrailingDelimiter()
 {
 	std::string path, result, removed;
 
@@ -236,7 +239,7 @@ void TestFilePath::testRemoveLastPathComponentWithTrailingDelimiter()
 }
 
 
-void TestFilePath::testRemoveRelativePathComponent()
+void TestFileSys::testRemoveRelativePathComponent()
 {
 	std::string path, result;
 
@@ -261,4 +264,15 @@ void TestFilePath::testRemoveRelativePathComponent()
 	path = p("/a/b/c/.././../d/../e/f/g/../h/i/j/../../../..");
 	result = fs::RemoveRelativePathComponents(path);
 	UASSERT(result == p("/a/e"));
+}
+
+
+void TestFileSys::testSafeWriteToFile()
+{
+	const std::string dest_path = fs::TempPath() + DIR_DELIM + "testSafeWriteToFile.txt";
+	fs::safeWriteToFile(dest_path, "test");
+	UASSERT(fs::PathExists(dest_path));
+	std::string contents_actual;
+	UASSERT(fs::ReadFile(dest_path, contents_actual));
+	UASSERT(contents_actual == "test");
 }


### PR DESCRIPTION
* Create the temp file in a temp directory. That way the OS should delete it in case this code does not manage to.
* Increase the amount of time between attempts to move the file.
* After all attempts fail, fall back to copying. The deletion of the source temporary file may fail for the same reason that MoveFileEx failed, but the OS should clean it up eventually.

Also add a test for it. It seemed some things in the `fs` namespace were already tested in test_filepath, so I renamed that to test_filesys and added the test there.

This PR is Ready for Review.

## How to test

Unit test tests the happy path. The case where the file rename fails is hard to test, so I think we should just try it and see if the issue is resolved.

Fixes https://github.com/minetest/minetest/issues/9425