### PR TITLE
Remove server's address and port from pause menu

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4460,19 +4460,16 @@ void Game::showPauseMenu()
 		<< "\n"
 		<<  strgettext("Game info:") << "\n";
 	const std::string &address = client->getAddressName();
-	static const std::string mode = strgettext("- Mode: ");
+	os << strgettext("- Mode: ");
 	if (!simple_singleplayer_mode) {
-		Address serverAddress = client->getServerAddress();
-		if (!address.empty()) {
-			os << mode << strgettext("Remote server") << "\n"
-					<< strgettext("- Address: ") << address;
-		} else {
-			os << mode << strgettext("Hosting server");
-		}
-		os << "\n" << strgettext("- Port: ") << serverAddress.getPort() << "\n";
+		if (address.empty())
+			os << strgettext("Hosting server");
+		else
+			os << strgettext("Remote server");
 	} else {
-		os << mode << strgettext("Singleplayer") << "\n";
+		os << strgettext("Singleplayer");
 	}
+	os << "\n";
 	if (simple_singleplayer_mode || address.empty()) {
 		static const std::string on = strgettext("On");
 		static const std::string off = strgettext("Off");


### PR DESCRIPTION
**Goal of the PR**
This PR removes server's address and port from the pause menu.

**How does the PR work?**
This PR removes server's address and port from the pause menu's formspec string. The code is also restructured.

**Does it resolve any reported issue?**
This PR tries to fix #13853.

**Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?**
Yes, this PR tries to fix a UI/UX issue.

## To do

This PR is Ready for Review.

## How to test

1. Play in a remote server (from Join Game tab).
2. Open the pause menu (e.g. pressing <kbd>Esc</kbd>).
3. Notice that the server's address is _not_ mentioned.
4. Create a server via main menu (Start Game tab, Host Server checkbox).
5. Play inside the hosted game.
6. Open the pause menu (e.g. pressing <kbd>Esc</kbd>).
7. Notice that the server's port is _not_ mentioned.

### Test results

| Case | `5.8.0` | This PR |
|:----:|:-------:|:-------:|
| Play in a remote server | ![Play in a remote server in 5.8.0](https://github.com/minetest/minetest/assets/4017302/1b896f64-e36c-4c27-9524-c85f4539b3ba) | ![Play in a remote server in this PR](https://github.com/minetest/minetest/assets/4017302/53ac768b-6f02-4dc3-8685-e73801496ed8) |
| Play and host a server | ![Play and host a server in 5.8.0](https://github.com/minetest/minetest/assets/4017302/7cc190cb-ec86-4156-8482-0f38598c3018) | ![Play and host a server in this PR](https://github.com/minetest/minetest/assets/4017302/11b36903-dc03-482f-9167-f77843b34ef1) |