### PR TITLE
Add sound volume when unfocused setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -623,6 +623,9 @@ bloom_radius (Bloom Radius) float 1 0.1 8
 #    Requires the sound system to be enabled.
 sound_volume (Volume) float 0.8 0.0 1.0
 
+#    Volume of all sounds when the window is unfocused.
+sound_volume_unfocused (Volume when unfocused) float 0.24 0.0 1.0
+
 #    Whether to mute sounds. You can unmute sounds at any time, unless the
 #    sound system is disabled (enable_sound=false).
 #    In-game, you can toggle the mute state with the mute key or by using the

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -623,8 +623,8 @@ bloom_radius (Bloom Radius) float 1 0.1 8
 #    Requires the sound system to be enabled.
 sound_volume (Volume) float 0.8 0.0 1.0
 
-#    Volume of all sounds when the window is unfocused.
-sound_volume_unfocused (Volume when unfocused) float 0.24 0.0 1.0
+#    Volume multiplier when the window is unfocused.
+sound_volume_unfocused (Volume when unfocused) float 0.3 0.0 1.0
 
 #    Whether to mute sounds. You can unmute sounds at any time, unless the
 #    sound system is disabled (enable_sound=false).

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3209,7 +3209,7 @@ void Game::updateSound(f32 dtime)
 			camera->getDirection(),
 			camera->getCameraNode()->getUpVector());
 
-	sound_control_by_window(g_settings, sound_manager.get(), device);
+	sound_control_by_window(sound_manager.get(), device);
 
 	// Tell the sound maker whether to make footstep sounds
 	soundmaker->makes_footstep_sound = player->makes_footstep_sound;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3209,25 +3209,7 @@ void Game::updateSound(f32 dtime)
 			camera->getDirection(),
 			camera->getCameraNode()->getUpVector());
 
-	bool mute_sound = g_settings->getBool("mute_sound");
-	if (mute_sound) {
-		sound_manager->setListenerGain(0.0f);
-	} else {
-		// Check if volume is in the proper range, else fix it.
-		float old_volume = g_settings->getFloat("sound_volume");
-		float new_volume = rangelim(old_volume, 0.0f, 1.0f);
-
-		if (old_volume != new_volume) {
-			g_settings->setFloat("sound_volume", new_volume);
-		}
-
-		if (!device->isWindowActive()) {
-			new_volume *= g_settings->getFloat("sound_volume_unfocused");
-			new_volume = rangelim(new_volume, 0.0f, 1.0f);
-		}
-
-		sound_manager->setListenerGain(new_volume);
-	}
+	sound_control_by_window(g_settings, sound_manager.get(), device);
 
 	// Tell the sound maker whether to make footstep sounds
 	soundmaker->makes_footstep_sound = player->makes_footstep_sound;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3216,11 +3216,17 @@ void Game::updateSound(f32 dtime)
 		// Check if volume is in the proper range, else fix it.
 		float old_volume = g_settings->getFloat("sound_volume");
 		float new_volume = rangelim(old_volume, 0.0f, 1.0f);
-		sound_manager->setListenerGain(new_volume);
 
 		if (old_volume != new_volume) {
 			g_settings->setFloat("sound_volume", new_volume);
 		}
+
+		if (!m_game_focused) {
+			new_volume = g_settings->getFloat("sound_volume_unfocused");
+			new_volume = rangelim(new_volume, 0.0f, 1.0f);
+		}
+
+		sound_manager->setListenerGain(new_volume);
 	}
 
 	// Tell the sound maker whether to make footstep sounds

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3222,7 +3222,7 @@ void Game::updateSound(f32 dtime)
 		}
 
 		if (!m_game_focused) {
-			new_volume = g_settings->getFloat("sound_volume_unfocused");
+			new_volume *= g_settings->getFloat("sound_volume_unfocused");
 			new_volume = rangelim(new_volume, 0.0f, 1.0f);
 		}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3221,7 +3221,7 @@ void Game::updateSound(f32 dtime)
 			g_settings->setFloat("sound_volume", new_volume);
 		}
 
-		if (!m_game_focused) {
+		if (!device->isWindowActive()) {
 			new_volume *= g_settings->getFloat("sound_volume_unfocused");
 			new_volume = rangelim(new_volume, 0.0f, 1.0f);
 		}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3209,7 +3209,7 @@ void Game::updateSound(f32 dtime)
 			camera->getDirection(),
 			camera->getCameraNode()->getUpVector());
 
-	sound_control_by_window(sound_manager.get(), device);
+	sound_volume_control(sound_manager.get(), device->isWindowActive());
 
 	// Tell the sound maker whether to make footstep sounds
 	soundmaker->makes_footstep_sound = player->makes_footstep_sound;

--- a/src/client/sound.cpp
+++ b/src/client/sound.cpp
@@ -22,11 +22,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "log.h"
 #include "porting.h"
+#include "settings.h"
+#include "util/numeric.h"
 #include <algorithm>
 #include <string>
 #include <vector>
-#include "settings.h"
-#include "util/numeric.h"
 
 std::vector<std::string> SoundFallbackPathProvider::
 		getLocalFallbackPathsForSoundname(const std::string &name)

--- a/src/client/sound.cpp
+++ b/src/client/sound.cpp
@@ -25,6 +25,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <algorithm>
 #include <string>
 #include <vector>
+#include "settings.h"
+#include "util/numeric.h"
 
 std::vector<std::string> SoundFallbackPathProvider::
 		getLocalFallbackPathsForSoundname(const std::string &name)

--- a/src/client/sound.cpp
+++ b/src/client/sound.cpp
@@ -97,7 +97,8 @@ void ISoundManager::freeId(sound_handle_t id, u32 num_owners)
 		it->second -= num_owners;
 }
 
-void sound_control_by_window(ISoundManager *sound_mgr, irr::IrrlichtDevice *device) {
+void sound_volume_control(ISoundManager *sound_mgr, bool is_window_active)
+{
 	bool mute_sound = g_settings->getBool("mute_sound");
 	if (mute_sound) {
 		sound_mgr->setListenerGain(0.0f);
@@ -110,7 +111,7 @@ void sound_control_by_window(ISoundManager *sound_mgr, irr::IrrlichtDevice *devi
 			g_settings->setFloat("sound_volume", new_volume);
 		}
 
-		if (!device->isWindowActive()) {
+		if (!is_window_active) {
 			new_volume *= g_settings->getFloat("sound_volume_unfocused");
 			new_volume = rangelim(new_volume, 0.0f, 1.0f);
 		}

--- a/src/client/sound.h
+++ b/src/client/sound.h
@@ -187,24 +187,4 @@ public:
 	void updateSoundPosVel(sound_handle_t sound, const v3f &pos, const v3f &vel) override {}
 };
 
-static void sound_control_by_window(Settings *settings, ISoundManager *sound_mgr, irr::IrrlichtDevice *device) {
-	bool mute_sound = settings->getBool("mute_sound");
-	if (mute_sound) {
-		sound_mgr->setListenerGain(0.0f);
-	} else {
-		// Check if volume is in the proper range, else fix it.
-		float old_volume = settings->getFloat("sound_volume");
-		float new_volume = rangelim(old_volume, 0.0f, 1.0f);
-
-		if (old_volume != new_volume) {
-			settings->setFloat("sound_volume", new_volume);
-		}
-
-		if (!device->isWindowActive()) {
-			new_volume *= settings->getFloat("sound_volume_unfocused");
-			new_volume = rangelim(new_volume, 0.0f, 1.0f);
-		}
-
-		sound_mgr->setListenerGain(new_volume);
-	}
-}
+void sound_control_by_window(ISoundManager *sound_mgr, irr::IrrlichtDevice *device);

--- a/src/client/sound.h
+++ b/src/client/sound.h
@@ -25,8 +25,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include "settings.h"
-#include "util/numeric.h"
 
 struct SoundSpec;
 

--- a/src/client/sound.h
+++ b/src/client/sound.h
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
+#include "irr_v3d.h"
 #include <limits>
 #include <string>
 #include <unordered_map>
@@ -185,4 +185,8 @@ public:
 	void updateSoundPosVel(sound_handle_t sound, const v3f &pos, const v3f &vel) override {}
 };
 
-void sound_control_by_window(ISoundManager *sound_mgr, irr::IrrlichtDevice *device);
+/**
+ * A helper function to control sound volume based on some values: sound volume
+ * settings, mute sound setting, and window activity.
+ */
+void sound_volume_control(ISoundManager *sound_mgr, bool is_window_active);

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -40,6 +40,7 @@ void set_default_settings()
 	settings->setDefault("address", "");
 	settings->setDefault("enable_sound", "true");
 	settings->setDefault("sound_volume", "0.8");
+	settings->setDefault("sound_volume_unfocused", "0.3");
 	settings->setDefault("mute_sound", "false");
 	settings->setDefault("enable_mesh_cache", "false");
 	settings->setDefault("mesh_generation_interval", "0");

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -310,7 +310,7 @@ void GUIEngine::run()
 
 		m_script->step();
 
-		sound_control_by_window(g_settings, m_sound_manager.get(), device);
+		sound_control_by_window(m_sound_manager.get(), device);
 
 		m_sound_manager->step(dtime);
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -310,7 +310,7 @@ void GUIEngine::run()
 
 		m_script->step();
 
-		sound_control_by_window(m_sound_manager.get(), device);
+		sound_volume_control(m_sound_manager.get(), device->isWindowActive());
 
 		m_sound_manager->step(dtime);
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -23,7 +23,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <ICameraSceneNode.h>
 #include "client/renderingengine.h"
 #include "scripting_mainmenu.h"
-#include "util/numeric.h"
 #include "config.h"
 #include "version.h"
 #include "porting.h"
@@ -311,25 +310,7 @@ void GUIEngine::run()
 
 		m_script->step();
 
-		bool mute_sound = g_settings->getBool("mute_sound");
-		if (mute_sound) {
-			m_sound_manager->setListenerGain(0.0f);
-		} else {
-			// Check if volume is in the proper range, else fix it.
-			float old_volume = g_settings->getFloat("sound_volume");
-			float new_volume = rangelim(old_volume, 0.0f, 1.0f);
-
-			if (old_volume != new_volume) {
-				g_settings->setFloat("sound_volume", new_volume);
-			}
-
-			if (!device->isWindowActive()) {
-				new_volume *= g_settings->getFloat("sound_volume_unfocused");
-				new_volume = rangelim(new_volume, 0.0f, 1.0f);
-			}
-
-			m_sound_manager->setListenerGain(new_volume);
-		}
+		sound_control_by_window(g_settings, m_sound_manager.get(), device);
 
 		m_sound_manager->step(dtime);
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -296,6 +296,7 @@ void GUIEngine::run()
 		driver->endScene();
 
 		IrrlichtDevice *device = m_rendering_engine->get_raw_device();
+
 		u32 frametime_min = 1000 / (device->isWindowFocused()
 			? g_settings->getFloat("fps_max")
 			: g_settings->getFloat("fps_max_unfocused"));
@@ -309,6 +310,26 @@ void GUIEngine::run()
 		t_last_frame = t_now;
 
 		m_script->step();
+
+		bool mute_sound = g_settings->getBool("mute_sound");
+		if (mute_sound) {
+			m_sound_manager->setListenerGain(0.0f);
+		} else {
+			// Check if volume is in the proper range, else fix it.
+			float old_volume = g_settings->getFloat("sound_volume");
+			float new_volume = rangelim(old_volume, 0.0f, 1.0f);
+
+			if (old_volume != new_volume) {
+				g_settings->setFloat("sound_volume", new_volume);
+			}
+
+			if (!device->isWindowActive()) {
+				new_volume *= g_settings->getFloat("sound_volume_unfocused");
+				new_volume = rangelim(new_volume, 0.0f, 1.0f);
+			}
+
+			m_sound_manager->setListenerGain(new_volume);
+		}
 
 		m_sound_manager->step(dtime);
 


### PR DESCRIPTION
**Goal of the PR**
This PR adds a new setting to set sound volume multiplier when Minetest window is unfocused/inactive (`sound_volume_unfocused`, located in Settings > Graphics and Audio > Audio > Volume when unfocused).

**How does the PR work?**
This PR checks whether the game window is focused. If the window is not focused, the sound volume will be multiplied by `sound_volume_unfocused` setting. The sound volume will be set back to `sound_volume` again when the window is focused.

**Does it resolve any reported issue?**
This PR tries to fix #14026.

**Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?**
Yes, this PR tries to fix a UI/UX issue.

## To do

This PR is Ready for Review.

## How to test

1. Play inside a world with music.
2. Wait/trigger the music inside the world.
3. Note the sound volume.
4. Focus to another window. Make Minetest window unfocused.
5. Notice that the sound volume is lower (depends on the set value).

## Additional comments

This PR changes the volume instantly. Is it fine or should a smooth transition be added for the volume change?

I am not sure whether this new setting should be in the in-game volume change dialog.

I also found that the main menu music (the game theme music) does not respect `sound_volume` setting.