### PR TITLE
Try to fix safeWriteToFile producing empty files on Windows

### DIFF
--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -9,7 +9,7 @@ set (UNITTEST_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/test_compression.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_connection.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_craft.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/test_filepath.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/test_filesys.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_inventory.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_irrptr.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_lua.cpp

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -26,10 +26,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nodedef.h"
 #include "noise.h"
 
-class TestFilePath : public TestBase {
+class TestFileSys : public TestBase
+{
 public:
-	TestFilePath() { TestManager::registerTestModule(this); }
-	const char *getName() { return "TestFilePath"; }
+	TestFileSys() {	TestManager::registerTestModule(this); }
+	const char *getName() {	return "TestFileSys"; }
 
 	void runTests(IGameDef *gamedef);
 
@@ -38,17 +39,19 @@ public:
 	void testRemoveLastPathComponent();
 	void testRemoveLastPathComponentWithTrailingDelimiter();
 	void testRemoveRelativePathComponent();
+	void testSafeWriteToFile();
 };
 
-static TestFilePath g_test_instance;
+static TestFileSys g_test_instance;
 
-void TestFilePath::runTests(IGameDef *gamedef)
+void TestFileSys::runTests(IGameDef *gamedef)
 {
 	TEST(testIsDirDelimiter);
 	TEST(testPathStartsWith);
 	TEST(testRemoveLastPathComponent);
 	TEST(testRemoveLastPathComponentWithTrailingDelimiter);
 	TEST(testRemoveRelativePathComponent);
+	TEST(testSafeWriteToFile);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -74,7 +77,7 @@ std::string p(std::string path)
 }
 
 
-void TestFilePath::testIsDirDelimiter()
+void TestFileSys::testIsDirDelimiter()
 {
 	UASSERT(fs::IsDirDelimiter('/') == true);
 	UASSERT(fs::IsDirDelimiter('A') == false);
@@ -87,7 +90,7 @@ void TestFilePath::testIsDirDelimiter()
 }
 
 
-void TestFilePath::testPathStartsWith()
+void TestFileSys::testPathStartsWith()
 {
 	const int numpaths = 12;
 	std::string paths[numpaths] = {
@@ -163,7 +166,7 @@ void TestFilePath::testPathStartsWith()
 }
 
 
-void TestFilePath::testRemoveLastPathComponent()
+void TestFileSys::testRemoveLastPathComponent()
 {
 	std::string path, result, removed;
 
@@ -200,7 +203,7 @@ void TestFilePath::testRemoveLastPathComponent()
 }
 
 
-void TestFilePath::testRemoveLastPathComponentWithTrailingDelimiter()
+void TestFileSys::testRemoveLastPathComponentWithTrailingDelimiter()
 {
 	std::string path, result, removed;
 
@@ -236,7 +239,7 @@ void TestFilePath::testRemoveLastPathComponentWithTrailingDelimiter()
 }
 
 
-void TestFilePath::testRemoveRelativePathComponent()
+void TestFileSys::testRemoveRelativePathComponent()
 {
 	std::string path, result;
 
@@ -261,4 +264,15 @@ void TestFilePath::testRemoveRelativePathComponent()
 	path = p("/a/b/c/.././../d/../e/f/g/../h/i/j/../../../..");
 	result = fs::RemoveRelativePathComponents(path);
 	UASSERT(result == p("/a/e"));
+}
+
+
+void TestFileSys::testSafeWriteToFile()
+{
+	const std::string dest_path = fs::TempPath() + DIR_DELIM + "testSafeWriteToFile.txt";
+	fs::safeWriteToFile(dest_path, "test");
+	UASSERT(fs::PathExists(dest_path));
+	std::string contents_actual;
+	UASSERT(fs::ReadFile(dest_path, contents_actual));
+	UASSERT(contents_actual == "test");
 }

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -270,7 +270,7 @@ void TestFileSys::testRemoveRelativePathComponent()
 void TestFileSys::testSafeWriteToFile()
 {
 	const std::string dest_path = fs::TempPath() + DIR_DELIM + "testSafeWriteToFile.txt";
-	constexpr std::string test_data("hello\0world", 11);
+	const std::string test_data("hello\0world", 11);
 	fs::safeWriteToFile(dest_path, test_data);
 	UASSERT(fs::PathExists(dest_path));
 	std::string contents_actual;

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -270,9 +270,10 @@ void TestFileSys::testRemoveRelativePathComponent()
 void TestFileSys::testSafeWriteToFile()
 {
 	const std::string dest_path = fs::TempPath() + DIR_DELIM + "testSafeWriteToFile.txt";
-	fs::safeWriteToFile(dest_path, "test");
+	constexpr std::string test_data("hello\0world", 11);
+	fs::safeWriteToFile(dest_path, test_data);
 	UASSERT(fs::PathExists(dest_path));
 	std::string contents_actual;
 	UASSERT(fs::ReadFile(dest_path, contents_actual));
-	UASSERT(contents_actual == "test");
+	UASSERT(contents_actual == test_data);
 }


### PR DESCRIPTION
Use win32 APIs to write the temporary file before copying to the final destination. Because we've observed the final file being empty, we suspect that std::ostream::flush is not flushing.

Also add a test for it. It seemed some things in the `fs` namespace were already tested in test_filepath, so I renamed that to test_filesys and added the test there.

## How to test

Unit test tests the happy path. The case where the file rename fails is hard to test, so I think we should just try it and see if the issue is resolved.

Fixes https://github.com/minetest/minetest/issues/9425