### PR TITLE
Avoid unnessary string copies in istringstream

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1786,7 +1786,7 @@ bool ServerMap::saveBlock(MapBlock *block, MapDatabase *db, int compression_leve
 void ServerMap::loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool save_after_load)
 {
 	try {
-		std::istringstream is(*blob, std::ios_base::binary);
+		zcistream is(*blob);
 
 		u8 version = SER_FMT_VER_INVALID;
 		is.read((char*)&version, 1);

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -272,7 +272,7 @@ void Client::handleCommand_NodemetaChanged(NetworkPacket *pkt)
 	if (pkt->getSize() < 1)
 		return;
 
-	std::istringstream is(pkt->readLongString(), std::ios::binary);
+	zcistream is(pkt->readLongString());
 	std::stringstream sstr(std::ios::binary | std::ios::in | std::ios::out);
 	decompressZlib(is, sstr);
 
@@ -302,8 +302,7 @@ void Client::handleCommand_BlockData(NetworkPacket* pkt)
 	v3s16 p;
 	*pkt >> p;
 
-	std::string datastring(pkt->getString(6), pkt->getSize() - 6);
-	std::istringstream istr(datastring, std::ios_base::binary);
+	zcistream istr(pkt->getString(6), pkt->getSize() - 6);
 
 	MapSector *sector;
 	MapBlock *block;
@@ -345,8 +344,7 @@ void Client::handleCommand_Inventory(NetworkPacket* pkt)
 	if (pkt->getSize() < 1)
 		return;
 
-	std::string datastring(pkt->getString(0), pkt->getSize());
-	std::istringstream is(datastring, std::ios_base::binary);
+	zcistream is(pkt->getString(0), pkt->getSize());
 
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player != NULL);
@@ -499,8 +497,7 @@ void Client::handleCommand_ActiveObjectMessages(NetworkPacket* pkt)
 			string message
 		}
 	*/
-	std::string datastring(pkt->getString(0), pkt->getSize());
-	std::istringstream is(datastring, std::ios_base::binary);
+	zcistream is(pkt->getString(0), pkt->getSize());
 
 	try {
 		while (is.good()) {
@@ -775,7 +772,7 @@ void Client::handleCommand_NodeDef(NetworkPacket* pkt)
 	sanity_check(!m_mesh_update_manager->isRunning());
 
 	// Decompress node definitions
-	std::istringstream tmp_is(pkt->readLongString(), std::ios::binary);
+	zcistream tmp_is(pkt->readLongString());
 	std::stringstream tmp_os(std::ios::binary | std::ios::in | std::ios::out);
 	decompressZlib(tmp_is, tmp_os);
 
@@ -794,7 +791,7 @@ void Client::handleCommand_ItemDef(NetworkPacket* pkt)
 	sanity_check(!m_mesh_update_manager->isRunning());
 
 	// Decompress item definitions
-	std::istringstream tmp_is(pkt->readLongString(), std::ios::binary);
+	zcistream tmp_is(pkt->readLongString());
 	std::stringstream tmp_os(std::ios::binary | std::ios::in | std::ios::out);
 	decompressZlib(tmp_is, tmp_os);
 
@@ -966,8 +963,7 @@ void Client::handleCommand_DetachedInventory(NetworkPacket* pkt)
 	u16 ignore;
 	*pkt >> ignore; // this used to be the length of the following string, ignore it
 
-	std::string contents(pkt->getRemainingString(), pkt->getRemainingBytes());
-	std::istringstream is(contents, std::ios::binary);
+	zcistream is(pkt->getRemainingString(), pkt->getRemainingBytes());
 	inv->deSerialize(is);
 }
 
@@ -989,8 +985,7 @@ void Client::handleCommand_ShowFormSpec(NetworkPacket* pkt)
 
 void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
 {
-	std::string datastring(pkt->getString(0), pkt->getSize());
-	std::istringstream is(datastring, std::ios_base::binary);
+	zcistream is(pkt->getString(0), pkt->getSize());
 
 	ParticleParameters p;
 	p.deSerialize(is, m_proto_ver);
@@ -1004,8 +999,7 @@ void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
 
 void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 {
-	std::string datastring(pkt->getString(0), pkt->getSize());
-	std::istringstream is(datastring, std::ios_base::binary);
+	zcistream is(pkt->getString(0), pkt->getSize());
 
 	ParticleSpawnerParameters p;
 	u32 server_id;
@@ -1320,8 +1314,7 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 	if (m_proto_ver < 39) {
 		// Handle Protocol 38 and below servers with old set_sky,
 		// ensuring the classic look is kept.
-		std::string datastring(pkt->getString(0), pkt->getSize());
-		std::istringstream is(datastring, std::ios_base::binary);
+		zcistream is(pkt->getString(0), pkt->getSize());
 
 		SkyboxParams skybox;
 		skybox.bgcolor = video::SColor(readARGB8(is));

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -272,7 +272,9 @@ void Client::handleCommand_NodemetaChanged(NetworkPacket *pkt)
 	if (pkt->getSize() < 1)
 		return;
 
-	zcistream is(pkt->readLongString());
+	u32 strlen;
+	*pkt >> strlen;
+	zcistream is(pkt->readLongString(strlen), strlen);
 	std::stringstream sstr(std::ios::binary | std::ios::in | std::ios::out);
 	decompressZlib(is, sstr);
 
@@ -772,7 +774,9 @@ void Client::handleCommand_NodeDef(NetworkPacket* pkt)
 	sanity_check(!m_mesh_update_manager->isRunning());
 
 	// Decompress node definitions
-	zcistream tmp_is(pkt->readLongString());
+	u32 strlen;
+	*pkt >> strlen;
+	zcistream tmp_is(pkt->readLongString(strlen), strlen);
 	std::stringstream tmp_os(std::ios::binary | std::ios::in | std::ios::out);
 	decompressZlib(tmp_is, tmp_os);
 
@@ -791,7 +795,9 @@ void Client::handleCommand_ItemDef(NetworkPacket* pkt)
 	sanity_check(!m_mesh_update_manager->isRunning());
 
 	// Decompress item definitions
-	zcistream tmp_is(pkt->readLongString());
+	u32 strlen;
+	*pkt >> strlen;
+	zcistream tmp_is(pkt->readLongString(strlen), strlen);
 	std::stringstream tmp_os(std::ios::binary | std::ios::in | std::ios::out);
 	decompressZlib(tmp_is, tmp_os);
 

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -245,6 +245,20 @@ std::string NetworkPacket::readLongString()
 	return dst;
 }
 
+const char *NetworkPacket::readLongString(u32 strLen)
+{
+	if (strLen > LONG_STRING_MAX_LEN) {
+		throw PacketError("String too long");
+	}
+
+	checkReadOffset(m_read_offset, strLen);
+
+	char *res = (char*)&m_data[m_read_offset];
+
+	m_read_offset += strLen;
+	return res;
+}
+
 NetworkPacket& NetworkPacket::operator>>(char& dst)
 {
 	checkReadOffset(m_read_offset, 1);

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -63,6 +63,7 @@ public:
 	NetworkPacket &operator<<(const std::wstring &src);
 
 	std::string readLongString();
+	const char *readLongString(u32 strLen);
 
 	NetworkPacket &operator>>(char &dst);
 	NetworkPacket &operator<<(char src);

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -116,9 +116,9 @@ class zcistream : public std::istream
 	};
 
 public:
-	zcistream(const std::string &s) : buf(s) { this->init(&buf); }
-	zcistream(const char *c, std::size_t l) : buf(c, l) { this->init(&buf); }
-	zcistream(char *c, std::size_t l) : buf(c, l) { this->init(&buf); }
+	zcistream(const std::string &s) : std::istream(&buf), buf(s) {}
+	zcistream(const char *c, std::size_t l) : std::istream(&buf), buf(c, l) {}
+	zcistream(char *c, std::size_t l) : std::istream(&buf), buf(c, l) {}
 
 private:
 	zcbuf buf;


### PR DESCRIPTION
See #13559

This PR is WIP

## How to test

Load any world. Make sure everything works.
I observed a 5-8% speed up in load time (especially for large viewing_ranges).

I wondering whether this helps with #14015, since it potentially can prevent a LOT of small heap allocations.
