### PR TITLE
Fix out of range enum casts in deSerialize functions

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3019,7 +3019,7 @@ void Game::handleClientEvent_HudChange(ClientEvent *event, CameraOrientation *ca
 		CASE_SET(HUD_STAT_TEXT2, text2, sdata);
 
 		CASE_SET(HUD_STAT_STYLE, style, data);
-		
+
 		case HudElementStat_END:
 			break;
 	}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3019,6 +3019,9 @@ void Game::handleClientEvent_HudChange(ClientEvent *event, CameraOrientation *ca
 		CASE_SET(HUD_STAT_TEXT2, text2, sdata);
 
 		CASE_SET(HUD_STAT_STYLE, style, data);
+		
+		case HudElementStat_END:
+			break;
 	}
 
 #undef CASE_SET

--- a/src/hud.h
+++ b/src/hud.h
@@ -85,6 +85,7 @@ enum HudElementStat : u8 {
 	HUD_STAT_Z_INDEX,
 	HUD_STAT_TEXT2,
 	HUD_STAT_STYLE,
+	HudElementStat_END // Dummy for validity check
 };
 
 enum HudCompassDir {

--- a/src/hud.h
+++ b/src/hud.h
@@ -70,7 +70,7 @@ enum HudElementType {
 	HUD_ELEM_MINIMAP   = 7
 };
 
-enum HudElementStat {
+enum HudElementStat : u8 {
 	HUD_STAT_POS = 0,
 	HUD_STAT_NAME,
 	HUD_STAT_SCALE,

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -196,13 +196,11 @@ void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
 		throw SerializationError("unsupported ItemDefinition version");
 
 	type = static_cast<ItemType>(readU8(is));
-	name = deSerializeString16(is);
-	
 	if (type >= ItemType_END) {
-		warningstream << "Received unsupported ItemType for an item named "
-				<< name << std::endl;
+		type = ITEM_NONE;
 	}
-	
+
+	name = deSerializeString16(is);
 	description = deSerializeString16(is);
 	inventory_image = deSerializeString16(is);
 	wield_image = deSerializeString16(is);

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -196,17 +196,13 @@ void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
 		throw SerializationError("unsupported ItemDefinition version");
 
 	type = static_cast<ItemType>(readU8(is));
-	switch (type) {
-		case ITEM_NONE:
-		case ITEM_NODE:
-		case ITEM_CRAFT:
-		case ITEM_TOOL:
-			break;
-		default:
-			throw SerializationError("unsupported ItemType");
+	name = deSerializeString16(is);
+	
+	if (type >= ItemType_END) {
+		warningstream << "Received unsupported ItemType for an item named "
+				<< name << std::endl;
 	}
 	
-	name = deSerializeString16(is);
 	description = deSerializeString16(is);
 	inventory_image = deSerializeString16(is);
 	wield_image = deSerializeString16(is);

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -195,7 +195,17 @@ void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
 	if (version < 6)
 		throw SerializationError("unsupported ItemDefinition version");
 
-	type = (enum ItemType)readU8(is);
+	type = static_cast<ItemType>(readU8(is));
+	switch (type) {
+		case ITEM_NONE:
+		case ITEM_NODE:
+		case ITEM_CRAFT:
+		case ITEM_TOOL:
+			break;
+		default:
+			throw SerializationError("unsupported ItemType");
+	}
+	
 	name = deSerializeString16(is);
 	description = deSerializeString16(is);
 	inventory_image = deSerializeString16(is);

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -41,12 +41,13 @@ struct ItemStack;
 	Base item definition
 */
 
-enum ItemType
+enum ItemType : u8
 {
 	ITEM_NONE,
 	ITEM_NODE,
 	ITEM_CRAFT,
 	ITEM_TOOL,
+	ItemType_END // Dummy for validity check
 };
 
 struct ItemDefinition

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -604,6 +604,8 @@ void ServerMap::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 				floodable_node = n0.getContent();
 				liquid_kind = CONTENT_AIR;
 				break;
+			case LiquidType_END:
+				break;
 		}
 
 		/*
@@ -695,6 +697,8 @@ void ServerMap::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 						if (nb.t == NEIGHBOR_LOWER)
 							flowing_down = true;
 					}
+					break;
+				case LiquidType_END:
 					break;
 			}
 		}
@@ -847,6 +851,8 @@ void ServerMap::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 				// this flow has turned to air; neighboring flows might need to do the same
 				for (u16 i = 0; i < num_flows; i++)
 					m_transforming_liquid.push_back(flows[i].p);
+				break;
+			case LiquidType_END:
 				break;
 		}
 	}

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1228,9 +1228,14 @@ void Client::handleCommand_HudChange(NetworkPacket* pkt)
 	u8 stat;
 
 	*pkt >> server_id >> stat;
+	
+	if (stat > 13) {
+		warningstream << "Received unsupported HudElementStat for HudChange";
+		return;
+	}
 
 	// Keep in sync with:server.cpp -> SendHUDChange
-	switch ((HudElementStat)stat) {
+	switch (static_cast<HudElementStat>(stat)) {
 		case HUD_STAT_POS:
 		case HUD_STAT_SCALE:
 		case HUD_STAT_ALIGN:

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1229,8 +1229,8 @@ void Client::handleCommand_HudChange(NetworkPacket* pkt)
 
 	*pkt >> server_id >> stat;
 	
-	if (stat > 13) {
-		warningstream << "Received unsupported HudElementStat for HudChange";
+	if (stat >= HudElementStat_END) {
+		warningstream << "Received unsupported HudElementStat for HudChange." << std::endl;
 		return;
 	}
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1228,9 +1228,9 @@ void Client::handleCommand_HudChange(NetworkPacket* pkt)
 	u8 stat;
 
 	*pkt >> server_id >> stat;
-	
+
+	// Do nothing if stat is not known
 	if (stat >= HudElementStat_END) {
-		warningstream << "Received unsupported HudElementStat for HudChange." << std::endl;
 		return;
 	}
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -180,7 +180,7 @@ void NodeBox::deSerialize(std::istream &is)
 			break;
 		}
 		default:
-			warningstream << "Received unsupported NodeBoxType" << std::endl;
+			type = NODEBOX_REGULAR;
 			break;
 	}
 }
@@ -274,7 +274,7 @@ void TileDef::deSerialize(std::istream &is, NodeDrawType drawtype, u16 protocol_
 	if (has_align_style) {
 		align_style = static_cast<AlignStyle>(readU8(is));
 		if (align_style >= AlignStyle_END)
-			warningstream << "Received unsupported AlignStyle" << std::endl;
+			align_style = ALIGN_STYLE_NODE;
 	} else
 		align_style = ALIGN_STYLE_NODE;
 }
@@ -569,19 +569,16 @@ void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
 
 	param_type = static_cast<ContentParamType>(readU8(is));
 	if (param_type >= ContentParamType_END)
-		warningstream << "Received unsupported ContentParamType for a node named "
-			<< name << std::endl;
+		param_type = CPT_NONE;
 
 	param_type_2 = static_cast<ContentParamType2>(readU8(is));
 	if (param_type_2 >= ContentParamType2_END)
-		warningstream << "Received unsupported ContentParamType2 for a node named "
-			<< name << std::endl;
+		param_type_2 = CPT2_NONE;
 
 	// visual
 	drawtype = static_cast<NodeDrawType>(readU8(is));
 	if (drawtype >= NodeDrawType_END)
-		warningstream << "Received unsupported NodeDrawType for a node named "
-			<< name << std::endl;
+		drawtype = NDT_NORMAL;
 	mesh = deSerializeString16(is);
 	visual_scale = readF32(is);
 	if (readU8(is) != 6)
@@ -629,8 +626,7 @@ void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
 	// liquid
 	liquid_type = static_cast<LiquidType>(readU8(is));
 	if (liquid_type >= LiquidType_END)
-		warningstream << "Received unsupported LiquidType for a node named "
-			<< name << std::endl;
+		liquid_type = LIQUID_NONE;
 	liquid_move_physics = liquid_type != LIQUID_NONE;
 	liquid_alternative_flowing = deSerializeString16(is);
 	liquid_alternative_source = deSerializeString16(is);

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -275,8 +275,9 @@ void TileDef::deSerialize(std::istream &is, NodeDrawType drawtype, u16 protocol_
 		align_style = static_cast<AlignStyle>(readU8(is));
 		if (align_style >= AlignStyle_END)
 			align_style = ALIGN_STYLE_NODE;
-	} else
+	} else {
 		align_style = ALIGN_STYLE_NODE;
+	}
 }
 
 void TextureSettings::readSettings()

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -126,57 +126,62 @@ void NodeBox::deSerialize(std::istream &is)
 
 	reset();
 
-	type = (enum NodeBoxType)readU8(is);
-
-	if(type == NODEBOX_FIXED || type == NODEBOX_LEVELED)
-	{
-		u16 fixed_count = readU16(is);
-		while(fixed_count--)
-		{
-			aabb3f box;
-			box.MinEdge = readV3F32(is);
-			box.MaxEdge = readV3F32(is);
-			fixed.push_back(box);
+	type = static_cast<NodeBoxType>(readU8(is));
+	switch (type) {
+		case NODEBOX_REGULAR:
+			break;
+		case NODEBOX_FIXED:
+		case NODEBOX_LEVELED: {
+			u16 fixed_count = readU16(is);
+			while(fixed_count--) {
+				aabb3f box;
+				box.MinEdge = readV3F32(is);
+				box.MaxEdge = readV3F32(is);
+				fixed.push_back(box);
+			}
+			break;
 		}
-	}
-	else if(type == NODEBOX_WALLMOUNTED)
-	{
-		wall_top.MinEdge = readV3F32(is);
-		wall_top.MaxEdge = readV3F32(is);
-		wall_bottom.MinEdge = readV3F32(is);
-		wall_bottom.MaxEdge = readV3F32(is);
-		wall_side.MinEdge = readV3F32(is);
-		wall_side.MaxEdge = readV3F32(is);
-	}
-	else if (type == NODEBOX_CONNECTED)
-	{
+		case NODEBOX_WALLMOUNTED:
+			wall_top.MinEdge = readV3F32(is);
+			wall_top.MaxEdge = readV3F32(is);
+			wall_bottom.MinEdge = readV3F32(is);
+			wall_bottom.MaxEdge = readV3F32(is);
+			wall_side.MinEdge = readV3F32(is);
+			wall_side.MaxEdge = readV3F32(is);
+			break;
+		case NODEBOX_CONNECTED: {
 #define READBOXES(box) { \
-		count = readU16(is); \
-		(box).reserve(count); \
-		while (count--) { \
-			v3f min = readV3F32(is); \
-			v3f max = readV3F32(is); \
-			(box).emplace_back(min, max); }; }
+			count = readU16(is); \
+			(box).reserve(count); \
+			while (count--) { \
+				v3f min = readV3F32(is); \
+				v3f max = readV3F32(is); \
+				(box).emplace_back(min, max); }; }
 
-		u16 count;
+			u16 count;
 
-		auto &c = getConnected();
+			auto &c = getConnected();
 
-		READBOXES(fixed);
-		READBOXES(c.connect_top);
-		READBOXES(c.connect_bottom);
-		READBOXES(c.connect_front);
-		READBOXES(c.connect_left);
-		READBOXES(c.connect_back);
-		READBOXES(c.connect_right);
-		READBOXES(c.disconnected_top);
-		READBOXES(c.disconnected_bottom);
-		READBOXES(c.disconnected_front);
-		READBOXES(c.disconnected_left);
-		READBOXES(c.disconnected_back);
-		READBOXES(c.disconnected_right);
-		READBOXES(c.disconnected);
-		READBOXES(c.disconnected_sides);
+			READBOXES(fixed);
+			READBOXES(c.connect_top);
+			READBOXES(c.connect_bottom);
+			READBOXES(c.connect_front);
+			READBOXES(c.connect_left);
+			READBOXES(c.connect_back);
+			READBOXES(c.connect_right);
+			READBOXES(c.disconnected_top);
+			READBOXES(c.disconnected_bottom);
+			READBOXES(c.disconnected_front);
+			READBOXES(c.disconnected_left);
+			READBOXES(c.disconnected_back);
+			READBOXES(c.disconnected_right);
+			READBOXES(c.disconnected);
+			READBOXES(c.disconnected_sides);
+			break;
+		}
+		default:
+			throw SerializationError("unsupported NodeBoxType");
+			break;
 	}
 }
 
@@ -266,9 +271,12 @@ void TileDef::deSerialize(std::istream &is, NodeDrawType drawtype, u16 protocol_
 		color.setBlue(readU8(is));
 	}
 	scale = has_scale ? readU8(is) : 0;
-	if (has_align_style)
-		align_style = static_cast<AlignStyle>(readU8(is));
-	else
+	if (has_align_style) {
+		u8 tmp = readU8(is);
+		if (tmp > 2)
+			throw SerializationError("unsupported AlignStyle");
+		align_style = static_cast<AlignStyle>(tmp);
+	} else
 		align_style = ALIGN_STYLE_NODE;
 }
 
@@ -559,11 +567,24 @@ void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
 		int value = readS16(is);
 		groups[name] = value;
 	}
-	param_type = (enum ContentParamType) readU8(is);
-	param_type_2 = (enum ContentParamType2) readU8(is);
+	
+	u8 tmp = readU8(is);
+	if (tmp > 1)
+		throw SerializationError("unsupported ContentParamType");
+	param_type = static_cast<ContentParamType>(tmp);
+	
+	tmp = readU8(is);
+	if (tmp > 14)
+		throw SerializationError("unsupported ContentParamType2");
+	param_type_2 = static_cast<ContentParamType2>(tmp);
 
 	// visual
-	drawtype = (enum NodeDrawType) readU8(is);
+	
+	tmp = readU8(is);
+	if (tmp > 17)
+		throw SerializationError("unsupported NodeDrawType");
+	drawtype = static_cast<NodeDrawType>(tmp);
+	
 	mesh = deSerializeString16(is);
 	visual_scale = readF32(is);
 	if (readU8(is) != 6)
@@ -609,7 +630,10 @@ void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
 	damage_per_second = readU32(is);
 
 	// liquid
-	liquid_type = (enum LiquidType) readU8(is);
+	tmp = readU8(is);
+	if (tmp > 2)
+		throw SerializationError("unsupported LiquidType");
+	liquid_type = static_cast<LiquidType>(tmp);
 	liquid_move_physics = liquid_type != LIQUID_NONE;
 	liquid_alternative_flowing = deSerializeString16(is);
 	liquid_alternative_source = deSerializeString16(is);
@@ -645,6 +669,8 @@ void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
 		tmp = readU8(is);
 		if (is.eof())
 			throw SerializationError("");
+		if (tmp > 3)
+			throw SerializationError("unsupported AlphaMode");
 		alpha = static_cast<enum AlphaMode>(tmp);
 		if (alpha == ALPHAMODE_LEGACY_COMPAT)
 			alpha = ALPHAMODE_OPAQUE;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -180,7 +180,7 @@ void NodeBox::deSerialize(std::istream &is)
 			break;
 		}
 		default:
-			throw SerializationError("unsupported NodeBoxType");
+			warningstream << "Received unsupported NodeBoxType" << std::endl;
 			break;
 	}
 }
@@ -272,10 +272,9 @@ void TileDef::deSerialize(std::istream &is, NodeDrawType drawtype, u16 protocol_
 	}
 	scale = has_scale ? readU8(is) : 0;
 	if (has_align_style) {
-		u8 tmp = readU8(is);
-		if (tmp > 2)
-			throw SerializationError("unsupported AlignStyle");
-		align_style = static_cast<AlignStyle>(tmp);
+		align_style = static_cast<AlignStyle>(readU8(is));
+		if (align_style >= AlignStyle_END)
+			warningstream << "Received unsupported AlignStyle" << std::endl;
 	} else
 		align_style = ALIGN_STYLE_NODE;
 }
@@ -567,24 +566,22 @@ void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
 		int value = readS16(is);
 		groups[name] = value;
 	}
-	
-	u8 tmp = readU8(is);
-	if (tmp > 1)
-		throw SerializationError("unsupported ContentParamType");
-	param_type = static_cast<ContentParamType>(tmp);
-	
-	tmp = readU8(is);
-	if (tmp > 14)
-		throw SerializationError("unsupported ContentParamType2");
-	param_type_2 = static_cast<ContentParamType2>(tmp);
+
+	param_type = static_cast<ContentParamType>(readU8(is));
+	if (param_type >= ContentParamType_END)
+		warningstream << "Received unsupported ContentParamType for a node named "
+			<< name << std::endl;
+
+	param_type_2 = static_cast<ContentParamType2>(readU8(is));
+	if (param_type_2 >= ContentParamType2_END)
+		warningstream << "Received unsupported ContentParamType2 for a node named "
+			<< name << std::endl;
 
 	// visual
-	
-	tmp = readU8(is);
-	if (tmp > 17)
-		throw SerializationError("unsupported NodeDrawType");
-	drawtype = static_cast<NodeDrawType>(tmp);
-	
+	drawtype = static_cast<NodeDrawType>(readU8(is));
+	if (drawtype >= NodeDrawType_END)
+		warningstream << "Received unsupported NodeDrawType for a node named "
+			<< name << std::endl;
 	mesh = deSerializeString16(is);
 	visual_scale = readF32(is);
 	if (readU8(is) != 6)
@@ -630,10 +627,10 @@ void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
 	damage_per_second = readU32(is);
 
 	// liquid
-	tmp = readU8(is);
-	if (tmp > 2)
-		throw SerializationError("unsupported LiquidType");
-	liquid_type = static_cast<LiquidType>(tmp);
+	liquid_type = static_cast<LiquidType>(readU8(is));
+	if (liquid_type >= LiquidType_END)
+		warningstream << "Received unsupported LiquidType for a node named "
+			<< name << std::endl;
 	liquid_move_physics = liquid_type != LIQUID_NONE;
 	liquid_alternative_flowing = deSerializeString16(is);
 	liquid_alternative_source = deSerializeString16(is);
@@ -669,9 +666,9 @@ void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
 		tmp = readU8(is);
 		if (is.eof())
 			throw SerializationError("");
-		if (tmp > 3)
-			throw SerializationError("unsupported AlphaMode");
 		alpha = static_cast<enum AlphaMode>(tmp);
+		if (alpha >= AlphaMode_END)
+			throw SerializationError("unsupported AlphaMode");
 		if (alpha == ALPHAMODE_LEGACY_COMPAT)
 			alpha = ALPHAMODE_OPAQUE;
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -664,9 +664,7 @@ void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
 		if (is.eof())
 			throw SerializationError("");
 		alpha = static_cast<enum AlphaMode>(tmp);
-		if (alpha >= AlphaMode_END)
-			throw SerializationError("unsupported AlphaMode");
-		if (alpha == ALPHAMODE_LEGACY_COMPAT)
+		if (alpha >= AlphaMode_END || alpha == ALPHAMODE_LEGACY_COMPAT)
 			alpha = ALPHAMODE_OPAQUE;
 
 		tmp = readU8(is);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -49,6 +49,7 @@ enum ContentParamType : u8
 {
 	CPT_NONE,
 	CPT_LIGHT,
+	ContentParamType_END // Dummy for validity check
 };
 
 enum ContentParamType2 : u8
@@ -82,6 +83,8 @@ enum ContentParamType2 : u8
 	CPT2_4DIR,
 	// 6 bits of palette index, then 4dir
 	CPT2_COLORED_4DIR,
+	// Dummy for validity check
+	ContentParamType2_END
 };
 
 enum LiquidType : u8
@@ -89,6 +92,7 @@ enum LiquidType : u8
 	LIQUID_NONE,
 	LIQUID_FLOWING,
 	LIQUID_SOURCE,
+	LiquidType_END // Dummy for validity check
 };
 
 enum NodeBoxType : u8
@@ -233,6 +237,8 @@ enum NodeDrawType : u8
 	NDT_MESH,
 	// Combined plantlike-on-solid
 	NDT_PLANTLIKE_ROOTED,
+	// Dummy for validity check
+	NodeDrawType_END
 };
 
 // Mesh options for NDT_PLANTLIKE with CPT2_MESHOPTIONS
@@ -252,6 +258,7 @@ enum AlignStyle : u8 {
 	ALIGN_STYLE_NODE,
 	ALIGN_STYLE_WORLD,
 	ALIGN_STYLE_USER_DEFINED,
+	AlignStyle_END // Dummy for validity check
 };
 
 enum AlphaMode : u8 {
@@ -259,6 +266,7 @@ enum AlphaMode : u8 {
 	ALPHAMODE_CLIP,
 	ALPHAMODE_OPAQUE,
 	ALPHAMODE_LEGACY_COMPAT, /* only sent by old servers, equals OPAQUE */
+	AlphaMode_END // Dummy for validity check
 };
 
 

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -45,13 +45,13 @@ class NodeResolver;
 class TestSchematic;
 #endif
 
-enum ContentParamType
+enum ContentParamType : u8
 {
 	CPT_NONE,
 	CPT_LIGHT,
 };
 
-enum ContentParamType2
+enum ContentParamType2 : u8
 {
 	CPT2_NONE,
 	// Need 8-bit param2
@@ -84,14 +84,14 @@ enum ContentParamType2
 	CPT2_COLORED_4DIR,
 };
 
-enum LiquidType
+enum LiquidType : u8
 {
 	LIQUID_NONE,
 	LIQUID_FLOWING,
 	LIQUID_SOURCE,
 };
 
-enum NodeBoxType
+enum NodeBoxType : u8
 {
 	NODEBOX_REGULAR, // Regular block; allows buildable_to
 	NODEBOX_FIXED, // Static separately defined box(es)
@@ -189,7 +189,7 @@ public:
 	void readSettings();
 };
 
-enum NodeDrawType
+enum NodeDrawType : u8
 {
 	// A basic solid block
 	NDT_NORMAL,

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -84,6 +84,8 @@ T TweenedParameter<T>::blend(float fac) const
 					fac *= myrand_range(0.7f, 1.0f);
 				}
 			}
+			case TweenStyle::TweenStyle_END:
+				break;
 		}
 		if (fac>1.f)
 			fac = 1.f;
@@ -109,10 +111,9 @@ void TweenedParameter<T>::serialize(std::ostream &os) const
 template<typename T>
 void TweenedParameter<T>::deSerialize(std::istream &is)
 {
-	u8 tmp = readU8(is);
-	if (tmp > 3)
-		throw SerializationError("unsupported TweenStyle");
-	style = static_cast<TweenStyle>(tmp);
+	style = static_cast<TweenStyle>(readU8(is));
+	if (style >= TweenStyle::TweenStyle_END)
+		warningstream << "Received unsupported TweenStyle." << std::endl;
 	reps = readU16(is);
 	beginning = readF32(is);
 	start.deSerialize(is);

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -109,7 +109,10 @@ void TweenedParameter<T>::serialize(std::ostream &os) const
 template<typename T>
 void TweenedParameter<T>::deSerialize(std::istream &is)
 {
-	style = static_cast<TweenStyle>(readU8(is));
+	u8 tmp = readU8(is);
+	if (tmp > 3)
+		throw SerializationError("unsupported TweenStyle");
+	style = static_cast<TweenStyle>(tmp);
 	reps = readU16(is);
 	beginning = readF32(is);
 	start.deSerialize(is);

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -113,7 +113,7 @@ void TweenedParameter<T>::deSerialize(std::istream &is)
 {
 	style = static_cast<TweenStyle>(readU8(is));
 	if (style >= TweenStyle::TweenStyle_END)
-		warningstream << "Received unsupported TweenStyle." << std::endl;
+		style = TweenStyle::fwd;
 	reps = readU16(is);
 	beginning = readF32(is);
 	start.deSerialize(is);

--- a/src/particles.h
+++ b/src/particles.h
@@ -202,7 +202,8 @@ namespace ParticleParamTypes
 	}
 
 	// Animation styles (fwd is normal, linear interpolation)
-	enum class TweenStyle : u8 { fwd, rev, pulse, flicker };
+	// TweenStyle_END is a dummy value for validity check
+	enum class TweenStyle : u8 { fwd, rev, pulse, flicker, TweenStyle_END};
 
 	// "Tweened" pretty much means "animated" in this context
 	template <typename T>

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2100,7 +2100,7 @@ bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void 
 			return false;
 		}
 
-		stat = (HudElementStat)statint;
+		stat = static_cast<HudElementStat>(statint);
 	}
 
 	switch (stat) {
@@ -2161,6 +2161,9 @@ bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void 
 		case HUD_STAT_STYLE:
 			elem->style = luaL_checknumber(L, 4);
 			*value = &elem->style;
+			break;
+		case HudElementStat_END:
+			return false;
 			break;
 	}
 

--- a/src/tileanimation.cpp
+++ b/src/tileanimation.cpp
@@ -56,7 +56,7 @@ void TileAnimationParams::deSerialize(std::istream &is, u16 protocol_ver)
 			sheet_2d.frame_length = readF32(is);
 			break;
 		default:
-			warningstream << "Received unsupported TileAnimationType" << std::endl;
+			type = TAT_NONE;
 			break;
 	}
 }

--- a/src/tileanimation.cpp
+++ b/src/tileanimation.cpp
@@ -41,16 +41,23 @@ void TileAnimationParams::serialize(std::ostream &os, u16 protocol_ver) const
 
 void TileAnimationParams::deSerialize(std::istream &is, u16 protocol_ver)
 {
-	type = (TileAnimationType) readU8(is);
-
-	if (type == TAT_VERTICAL_FRAMES) {
-		vertical_frames.aspect_w = readU16(is);
-		vertical_frames.aspect_h = readU16(is);
-		vertical_frames.length = readF32(is);
-	} else if (type == TAT_SHEET_2D) {
-		sheet_2d.frames_w = readU8(is);
-		sheet_2d.frames_h = readU8(is);
-		sheet_2d.frame_length = readF32(is);
+	type = static_cast<TileAnimationType>(readU8(is));
+	switch(type) {
+		case(TAT_NONE):
+			break;
+		case(TAT_VERTICAL_FRAMES):
+			vertical_frames.aspect_w = readU16(is);
+			vertical_frames.aspect_h = readU16(is);
+			vertical_frames.length = readF32(is);
+			break;
+		case(TAT_SHEET_2D):
+			sheet_2d.frames_w = readU8(is);
+			sheet_2d.frames_h = readU8(is);
+			sheet_2d.frame_length = readF32(is);
+			break;
+		default:
+			throw SerializationError("unsupported TileAnimationType");
+			break;
 	}
 }
 

--- a/src/tileanimation.cpp
+++ b/src/tileanimation.cpp
@@ -43,14 +43,14 @@ void TileAnimationParams::deSerialize(std::istream &is, u16 protocol_ver)
 {
 	type = static_cast<TileAnimationType>(readU8(is));
 	switch(type) {
-		case(TAT_NONE):
+		case TAT_NONE:
 			break;
-		case(TAT_VERTICAL_FRAMES):
+		case TAT_VERTICAL_FRAMES:
 			vertical_frames.aspect_w = readU16(is);
 			vertical_frames.aspect_h = readU16(is);
 			vertical_frames.length = readF32(is);
 			break;
-		case(TAT_SHEET_2D):
+		case TAT_SHEET_2D:
 			sheet_2d.frames_w = readU8(is);
 			sheet_2d.frames_h = readU8(is);
 			sheet_2d.frame_length = readF32(is);

--- a/src/tileanimation.cpp
+++ b/src/tileanimation.cpp
@@ -56,7 +56,7 @@ void TileAnimationParams::deSerialize(std::istream &is, u16 protocol_ver)
 			sheet_2d.frame_length = readF32(is);
 			break;
 		default:
-			throw SerializationError("unsupported TileAnimationType");
+			warningstream << "Received unsupported TileAnimationType" << std::endl;
 			break;
 	}
 }

--- a/src/tileanimation.h
+++ b/src/tileanimation.h
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <iostream>
 #include "irrlichttypes_bloated.h"
 
-enum TileAnimationType
+enum TileAnimationType : u8
 {
 	TAT_NONE = 0,
 	TAT_VERTICAL_FRAMES = 1,

--- a/src/util/pointedthing.cpp
+++ b/src/util/pointedthing.cpp
@@ -92,7 +92,7 @@ void PointedThing::deSerialize(std::istream &is)
 	int version = readU8(is);
 	if (version != 0) throw SerializationError(
 			"unsupported PointedThing version");
-	type = (PointedThingType) readU8(is);
+	type = static_cast<PointedThingType>(readU8(is));
 	switch (type) {
 	case POINTEDTHING_NOTHING:
 		break;

--- a/src/util/pointedthing.h
+++ b/src/util/pointedthing.h
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <iostream>
 #include <string>
 
-enum PointedThingType
+enum PointedThingType : u8
 {
 	POINTEDTHING_NOTHING,
 	POINTEDTHING_NODE,


### PR DESCRIPTION
- When Desour reviewed my tool specific pointing PR he complained about undefined behavior. It appeared because I tried to make my code similar to the existing one. So it should probably also be fixed in the existing code.
- This PR
  - Defines an underlying type for all enums that are cast from u8 to avoid **undefined behavior**. [Security info](https://wiki.sei.cmu.edu/confluence/display/cplusplus/INT50-CPP.+Do+not+cast+to+an+out-of-range+enumeration+value)
  -  ~~Sends warnings if the received enum values are not supported. (I'm not sure how necessary this is so please tell me if they should be removed.)~~
  -  Defaults deserialized enum values which are not supported, previously they were unhandled and passed on.
  - Makes a few code style improvements. E.g. replaces some C-style casts with static_cast, since as far as I'm concerned they are bad practice in C++.
- I looked into all of the deserializing code, but maybe I missed something, since I'm not very familiar with the Minetest code base.

Note:
This undefined behavior could have been found with sanitizers. E.g. using the `-fsanitize=enum` flag.

### Does it resolve any reported issue?
I don't think so.

### Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
Probably  2.2 Internal code refactoring

## To do

This PR is Ready for Review.

## How to test
- Compile Minetets with `-fsanitize=undefined`
- Pass out of range values to the deSerialize functions.
- Read the warnings.
