### PR TITLE
API for light intensity and color at night and day

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -58,6 +58,7 @@ core.features = {
 	hud_hideable_field = true,
 	compress_raw_deflate = true,
 	get_all_craft_recipes_fuel = true,
+	sky_light = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6247,6 +6247,8 @@ Utilities
       -- Whether `core.get_all_craft_recipes` returns the correct `method` for fuels
       -- `width = 0` for non-shaped recipes and provides the optional `time` field (5.17.0)
       get_all_craft_recipes_fuel = true,
+      -- set_lighting support sky_light table (5.15.0)
+      sky_light = true,
   }
   ```
 
@@ -9645,6 +9647,18 @@ You **must not** mix names and track numbers to refer to the same animation.
             * Currently, bloom `intensity` and `strength_factor` affect volumetric
               lighting `strength` and vice versa. This behavior is to be changed
               in the future, do not rely on it.
+      * `sky_light` is a table that controls calculation of sun light color.
+        `sun_color = color_offset + color_ratio_coef*daynight_ratio` where `daynight_ratio` is not linear to day time.
+        Result color lesser or equal to 0.0 means no color in light.
+        Result color greater or equal to 1.0 means full color in light.
+        * `color_offset` is a table that controls red, green and blue color offsets.
+          * `r` (default: `-0.04`)
+          * `g` (default: `-0.04`)
+          * `b` (default: `0.078`)
+        * `color_ratio_coef` is a table that controls red, green and blue color ration coefficients.
+          * `r` (default: `0.001`)
+          * `g` (default: `0.001`)
+          * `b` (default: `0.00098`)
 
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.

--- a/games/devtest/mods/lighting/init.lua
+++ b/games/devtest/mods/lighting/init.lua
@@ -1,4 +1,113 @@
-local lighting_sections = {
+
+local modpath = core.get_modpath(core.get_current_modname())
+
+
+local function dumpByRecipe(data, recipe)
+	local result = "{\n"
+	local section_count = 0
+	for _,section in ipairs(recipe) do
+		section_count = section_count + 1
+
+		local parameters = section.entries or {}
+		local state = data[section.n] or {}
+
+		result = result.."  "..section.n.." = {\n"
+
+		local count = 0
+		for _,v in ipairs(parameters) do
+			count = count + 1
+			result = result.."    "..v.n.." = "..(math.floor(state[v.n] * 1000)/1000)
+			if count < #parameters then
+				result = result..","
+			end
+			result = result.."\n"
+		end
+
+		result = result.."  }"
+
+		if section_count < #recipe then
+			result = result..","
+		end
+		result = result.."\n"
+	end
+	result = result .."}"
+	return result
+end
+
+local function buildGUI(player, data, recipe, gui_name)
+	local form = {
+		"formspec_version[2]",
+		"size[15,30]",
+		"position[0.99,0.15]",
+		"anchor[1,0]",
+		"padding[0.05,0.1]",
+		"no_prepend[]"
+	};
+
+	local line = 1
+	for _,section in ipairs(recipe) do
+		local parameters = section.entries or {}
+		local state = data[section.n] or {}
+
+		table.insert(form, "label[1,"..line..";"..section.d.."]")
+		line  = line + 1
+
+		for _,v in ipairs(parameters) do
+			table.insert(form, "label[2,"..line..";"..v.d.."]")
+			table.insert(form, "scrollbaroptions[min=0;max=1000;smallstep=10;largestep=100;thumbsize=10]")
+			local value = state[v.n]
+			if v.type == "log2" then
+				value = math.log(value or 1) / math.log(2)
+			end
+			local sb_scale = math.floor(1000 * (math.max(v.min, value or 0) - v.min) / (v.max - v.min))
+			table.insert(form, "scrollbar[2,"..(line+0.7)..";12,1;horizontal;"..section.n.."."..v.n..";"..sb_scale.."]")
+			line = line + 2.7
+		end
+
+		line = line + 1
+	end
+
+	core.show_formspec(player:get_player_name(), gui_name, table.concat(form))
+	local debug_value = dumpByRecipe(data, recipe)
+	local debug_ui = player:hud_add({type="text", position={x=0.1, y=0.3}, scale={x=1,y=1}, alignment = {x=1, y=1}, text=debug_value, number=0xFFFFFF})
+	player:get_meta():set_int(gui_name.."_hud", debug_ui)
+end
+
+local function receiveFields(player, fields, data, recipe, gui_name)
+	local hud_id = player:get_meta():get_int(gui_name.."_hud")
+
+	if fields.quit then
+		player:hud_remove(hud_id)
+		player:get_meta():set_int(gui_name.."_hud", -1)
+		return
+	end
+
+	for _,section in ipairs(recipe) do
+		local parameters = section.entries or {}
+
+		local state = (data[section.n] or {})
+		data[section.n] = state
+
+		for _,v in ipairs(parameters) do
+
+			if fields[section.n.."."..v.n] then
+				local event = core.explode_scrollbar_event(fields[section.n.."."..v.n])
+				if event.type == "CHG" then
+					local value = v.min + (v.max - v.min) * (event.value / 1000);
+					if v.type == "log2" then
+						value = math.pow(2, value);
+					end
+					state[v.n] = value;
+				end
+			end
+		end
+	end
+
+	local debug_value = dumpByRecipe(data, recipe)
+	player:hud_change(hud_id, "text", debug_value)
+end
+
+local lighting_recipe = {
 	{n = "shadows", d = "Shadows",
 		entries = {
 			{ n = "intensity", d = "Shadow Intensity", min = 0, max = 1 }
@@ -31,86 +140,16 @@ local lighting_sections = {
 	},
 }
 
-local function dump_lighting(lighting)
-	local result = "{\n"
-	local section_count = 0
-	for _,section in ipairs(lighting_sections) do
-		section_count = section_count + 1
-
-		local parameters = section.entries or {}
-		local state = lighting[section.n] or {}
-
-		result = result.."  "..section.n.." = {\n"
-
-		local count = 0
-		for _,v in ipairs(parameters) do
-			count = count + 1
-			result = result.."    "..v.n.." = "..(math.floor(state[v.n] * 1000)/1000)
-			if count < #parameters then
-				result = result..","
-			end
-			result = result.."\n"
-		end
-
-		result = result.."  }"
-
-		if section_count < #lighting_sections then
-			result = result..","
-		end
-		result = result.."\n"
-	end
-	result = result .."}"
-	return result
-end
-
 core.register_chatcommand("set_lighting", {
 	params = "",
 	description = "Tune lighting parameters",
 	func = function(player_name, param)
-		local player = core.get_player_by_name(player_name);
+		local player = core.get_player_by_name(player_name)
 		if not player then return end
 
 		local lighting = player:get_lighting()
-		local exposure = lighting.exposure or {}
 
-		local content = {}
-		local line = 1
-		for _,section in ipairs(lighting_sections) do
-			local parameters = section.entries or {}
-			local state = lighting[section.n] or {}
-
-			table.insert(content, "label[1,"..line..";"..section.d.."]")
-			line  = line + 1
-
-			for _,v in ipairs(parameters) do
-				table.insert(content, "label[2,"..line..";"..v.d.."]")
-				table.insert(content, "scrollbaroptions[min=0;max=1000;smallstep=10;largestep=100;thumbsize=10]")
-				local value = state[v.n]
-				if v.type == "log2" then
-					value = math.log(value or 1) / math.log(2)
-				end
-				local sb_scale = math.floor(1000 * (math.max(v.min, value or 0) - v.min) / (v.max - v.min))
-				table.insert(content, "scrollbar[2,"..(line+0.7)..";12,1;horizontal;"..section.n.."."..v.n..";"..sb_scale.."]")
-				line = line + 2.7
-			end
-
-			line = line + 1
-		end
-
-		local form = {
-			"formspec_version[2]",
-			"size[15,", line, "]",
-			"position[0.99,0.15]",
-			"anchor[1,0]",
-			"padding[0.05,0.1]",
-			"no_prepend[]",
-		}
-		table.insert_all(form, content)
-	
-		core.show_formspec(player_name, "lighting", table.concat(form))
-		local debug_value = dump_lighting(lighting)
-		local debug_ui = player:hud_add({type="text", position={x=0.1, y=0.3}, scale={x=1,y=1}, alignment = {x=1, y=1}, text=debug_value, number=0xFFFFFF})
-		player:get_meta():set_int("lighting_hud", debug_ui)
+		buildGUI(player, lighting, lighting_recipe, "lighting")
 	end
 })
 
@@ -119,38 +158,55 @@ core.register_on_player_receive_fields(function(player, formname, fields)
 
 	if not player then return end
 
-	local hud_id = player:get_meta():get_int("lighting_hud")
-
-	if fields.quit then
-		player:hud_remove(hud_id)
-		player:get_meta():set_int("lighting_hud", -1)
-		return
-	end
-
 	local lighting = player:get_lighting()
-	for _,section in ipairs(lighting_sections) do
-		local parameters = section.entries or {}
 
-		local state = (lighting[section.n] or {})
-		lighting[section.n] = state
-
-		for _,v in ipairs(parameters) do
-
-			if fields[section.n.."."..v.n] then
-				local event = core.explode_scrollbar_event(fields[section.n.."."..v.n])
-				if event.type == "CHG" then
-					local value = v.min + (v.max - v.min) * (event.value / 1000);
-					if v.type == "log2" then
-						value = math.pow(2, value);
-					end
-					state[v.n] = value;
-				end
-			end
-		end
-	end
-
-	local debug_value = dump_lighting(lighting)
-	player:hud_change(hud_id, "text", debug_value)
+	receiveFields(player, fields, lighting, lighting_recipe, "lighting")
 
 	player:set_lighting(lighting)
 end)
+
+local sky_light_recipe = {
+	{n = "color_offset", d = "Color offset",
+		entries = {
+			{n = "r", d = "Red color offset", min = -1, max = 2},
+			{n = "g", d = "Green color offset", min = -1, max = 2},
+			{n = "b", d = "Blue color offset", min = -1, max = 2},
+		}
+	},
+	{n = "color_ratio_coef", d = "Color day-night ratio coefficient",
+		entries = {
+			{n = "r", d = "Red color day-night ratio coefficient", min = -1e-3, max = 2e-3},
+			{n = "g", d = "Green color day-night ratio coefficient", min = -1e-3, max = 2e-3},
+			{n = "b", d = "Blue color day-night ratio coefficient", min = -1e-3, max = 2e-3},
+		}
+	}
+}
+
+
+core.register_chatcommand("set_sky_light", {
+	params = "",
+	description = "Tune lighting sky_light parameters",
+	func = function(player_name, param)
+		local player = core.get_player_by_name(player_name)
+		if not player then return end
+
+		local lighting = player:get_lighting()
+		local sky_light = lighting.sky_light
+
+		buildGUI(player, sky_light, sky_light_recipe, "sky_light")
+	end
+})
+
+core.register_on_player_receive_fields(function(player, formname, fields)
+	if formname ~= "sky_light" then return end
+
+	if not player then return end
+
+	local lighting = player:get_lighting()
+	local sky_light = lighting.sky_light
+
+	receiveFields(player, fields, sky_light, sky_light_recipe, "sky_light")
+
+	player:set_lighting(lighting)
+end)
+

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -242,7 +242,8 @@ void ClientEnvironment::step(float dtime)
 
 		u16 light = getInteriorLight(node_at_lplayer, 0, m_client->ndef());
 		lplayer->light_color = encode_light(light, 0); // this transfers light.alpha
-		final_color_blend(&lplayer->light_color, light, day_night_ratio);
+		const SkyLight &sky_light = m_client->getEnv().getLocalPlayer()->getLighting().sky_light;
+		final_color_blend(&lplayer->light_color, light, day_night_ratio, sky_light);
 	}
 
 	/*

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -15,6 +15,7 @@
 #include "node_visuals.h"
 #include "nodedef.h"
 #include "player.h" // CameraMode
+#include "localplayer.h" // getLighting
 #include "profiler.h"
 #include "settings.h"
 #include "camera.h"
@@ -996,6 +997,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	const float animation_time = m_client->getAnimationTime();
 	const int crack = m_client->getCrackLevel();
 	const u32 daynight_ratio = m_client->getEnv().getDayNightRatio();
+	const Lighting &lighting = m_client->getEnv().getLocalPlayer()->getLighting();
 
 	const v3f camera_position = m_camera_position;
 
@@ -1055,7 +1057,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 					mesh_animate_count < (m_control.range_all ? 200 : 50)) {
 
 				bool animated = block_mesh->animate(faraway, animation_time,
-					crack, daynight_ratio);
+					crack, daynight_ratio, lighting.sky_light);
 				if (animated)
 					mesh_animate_count++;
 			} else {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -148,9 +148,10 @@ public:
 	void onSetUniforms(video::IMaterialRendererServices *services) override
 	{
 		u32 daynight_ratio = (float)m_client->getEnv().getDayNightRatio();
-		video::SColorf sunlight;
-		get_sunlight_color(&sunlight, daynight_ratio);
-		m_day_light.set(sunlight, services);
+		const auto &lighting = m_client->getEnv().getLocalPlayer()->getLighting();
+		video::SColorf skylight;
+		get_skylight_color(&skylight, daynight_ratio, lighting.sky_light);
+		m_day_light.set(skylight, services);
 
 		u32 animation_timer = m_client->getEnv().getFrameTime() % 1000000;
 		float animation_timer_f = (float)animation_timer / 100000.f;
@@ -185,8 +186,6 @@ public:
 			tmp = m_crack_texture_scale_i;
 			m_crack_texture_scale.set(&tmp, services);
 		}
-
-		const auto &lighting = m_client->getEnv().getLocalPlayer()->getLighting();
 
 		const AutoExposure &exposure_params = lighting.exposure;
 		std::array<float, 7> exposure_buffer = {
@@ -2895,8 +2894,9 @@ PointedThing Game::updatePointedThing(
 		}
 
 		u32 daynight_ratio = client->getEnv().getDayNightRatio();
+		const Lighting &lighting = client->getEnv().getLocalPlayer()->getLighting();
 		video::SColor c;
-		final_color_blend(&c, light_level, daynight_ratio);
+		final_color_blend(&c, light_level, daynight_ratio, lighting.sky_light);
 
 		// Modify final color a bit with time
 		u32 timer = client->getEnv().getFrameTime() % 5000;

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -15,6 +15,7 @@
 #include "util/tracy_wrapper.h"
 #include "client/meshgen/collector.h"
 #include "client/renderingengine.h"
+#include "client/localplayer.h"
 #include <array>
 #include <algorithm>
 #include <cmath>
@@ -151,7 +152,7 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 	u8 light_source_max = 0;
 	u16 light_day = 0;
 	u16 light_night = 0;
-	bool direct_sunlight = false;
+	bool direct_skylight = false;
 
 	auto add_node = [&] (u8 i, bool obstructed = false) -> bool {
 		if (obstructed) {
@@ -169,7 +170,7 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 			u8 light_level_day = n.getLight(LIGHTBANK_DAY, f.getLightingFlags());
 			u8 light_level_night = n.getLight(LIGHTBANK_NIGHT, f.getLightingFlags());
 			if (light_level_day == LIGHT_SUN)
-				direct_sunlight = true;
+				direct_skylight = true;
 			light_day += decode_light(light_level_day);
 			light_night += decode_light(light_level_night);
 			light_count++;
@@ -203,8 +204,8 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 		light_night /= light_count;
 	}
 
-	// boost direct sunlight, if any
-	if (direct_sunlight)
+	// boost direct skylight, if any
+	if (direct_skylight)
 		light_day = 0xFF;
 
 	// Boost brightness around light sources
@@ -278,35 +279,32 @@ u16 getSmoothLightTransparent(const v3s16 &p, const v3s16 &corner, MeshMakeData 
 	return getSmoothLightCombined(p, dirs, data);
 }
 
-void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio)
-{
-	f32 rg = daynight_ratio / 1000.0f - 0.04f;
-	f32 b = (0.98f * daynight_ratio) / 1000.0f + 0.078f;
-	sunlight->r = rg;
-	sunlight->g = rg;
-	sunlight->b = b;
+void get_skylight_color(video::SColorf *skylight, u32 daynight_ratio, const SkyLight &sky_light){
+	skylight->r = sky_light.color_offset.X + sky_light.color_ratio_coef.X * daynight_ratio;
+	skylight->g = sky_light.color_offset.Y + sky_light.color_ratio_coef.Y * daynight_ratio;
+	skylight->b = sky_light.color_offset.Z + sky_light.color_ratio_coef.Z * daynight_ratio;
 }
 
 void final_color_blend(video::SColor *result,
-		u16 light, u32 daynight_ratio)
+		u16 light, u32 daynight_ratio, const SkyLight &sky_light)
 {
-	video::SColorf dayLight;
-	get_sunlight_color(&dayLight, daynight_ratio);
+	video::SColorf day_light;
+	get_skylight_color(&day_light, daynight_ratio, sky_light);
 	final_color_blend(result,
-		encode_light(light, 0), dayLight);
+		encode_light(light, 0), day_light);
 }
 
 void final_color_blend(video::SColor *result,
-		const video::SColor &data, const video::SColorf &dayLight)
+		const video::SColor &data, const video::SColorf &day_light)
 {
-	static const video::SColorf artificialColor(1.04f, 1.04f, 1.04f);
+	static const video::SColorf artificial_color(1.04f, 1.04f, 1.04f);
 
 	video::SColorf c(data);
 	f32 n = 1 - c.a;
 
-	f32 r = c.r * (c.a * dayLight.r + n * artificialColor.r) * 2.0f;
-	f32 g = c.g * (c.a * dayLight.g + n * artificialColor.g) * 2.0f;
-	f32 b = c.b * (c.a * dayLight.b + n * artificialColor.b) * 2.0f;
+	f32 r = c.r * (c.a * day_light.r + n * artificial_color.r) * 2.0f;
+	f32 g = c.g * (c.a * day_light.g + n * artificial_color.g) * 2.0f;
+	f32 b = c.b * (c.a * day_light.b + n * artificial_color.b) * 2.0f;
 
 	// Emphase blue a bit in darker places
 	// Each entry of this array represents a range of 8 blue levels
@@ -689,10 +687,9 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data):
 			assert(!p.empty());
 
 			// Generate animation data
-			if (p.layer.material_flags & MATERIAL_FLAG_ANIMATION) {
+			if (p.layer.material_flags & MATERIAL_FLAG_ANIMATION)
 				// Add to MapBlockMesh in order to animate these tiles
 				m_animation_info.emplace(std::make_pair(layer, i), AnimationInfo(p.layer));
-			}
 
 			// Create material
 			video::SMaterial material;
@@ -771,7 +768,7 @@ MapBlockMesh::~MapBlockMesh()
 }
 
 bool MapBlockMesh::animate(bool faraway, float time, int crack,
-	u32 daynight_ratio)
+	u32 daynight_ratio, const SkyLight &sky_light)
 {
 	if (!m_has_animation) {
 		m_animation_force_timer = 100000;
@@ -914,7 +911,7 @@ video::SColor encode_light(u16 light, u8 emissive_light)
 	night += emissive_light * 2.5f;
 	if (night > 255)
 		night = 255;
-	// Since we don't know if the day light is sunlight or
+	// Since we don't know if the day light is skylight or
 	// artificial light, assume it is artificial when the night
 	// light bank is also lit.
 	if (day < night)
@@ -922,7 +919,7 @@ video::SColor encode_light(u16 light, u8 emissive_light)
 	else
 		day = day - night;
 	u32 sum = day + night;
-	// Ratio of sunlight:
+	// Ratio of skylight:
 	u32 r;
 	if (sum > 0)
 		r = day * 255 / sum;

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -12,6 +12,7 @@
 #include "util/numeric.h"
 #include "client/tile.h"
 #include "voxel.h"
+#include "lighting.h"
 #include <map>
 
 namespace video {
@@ -185,7 +186,7 @@ public:
 	//   daynight_ratio: 0 .. 1000
 	//   crack: -1 .. CRACK_ANIMATION_LENGTH (-1 for off)
 	// Returns true if anything has been changed.
-	bool animate(bool faraway, float time, int crack, u32 daynight_ratio);
+	bool animate(bool faraway, float time, int crack, u32 daynight_ratio, const SkyLight &sky_light);
 
 	/// @warning ClientMap requires that the vertex and index data is not modified
 	scene::IMesh *getMesh()
@@ -330,10 +331,10 @@ u16 getSmoothLightSolid(const v3s16 &p, const v3s16 &face_dir, const v3s16 &corn
 u16 getSmoothLightTransparent(const v3s16 &p, const v3s16 &corner, MeshMakeData *data);
 
 /*!
- * Returns the sunlight's color from the current
+ * Returns the skylight's color from the current
  * day-night ratio.
  */
-void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio);
+void get_skylight_color(video::SColorf *skylight, u32 daynight_ratio, const SkyLight &sky_light);
 
 /*!
  * Gives the final  SColor shown on screen.
@@ -343,14 +344,14 @@ void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio);
  * night light
  */
 void final_color_blend(video::SColor *result,
-		u16 light, u32 daynight_ratio);
+		u16 light, u32 daynight_ratio, const SkyLight &sky_light);
 
 /*!
  * Gives the final  SColor shown on screen.
  *
  * \param result output color
  * \param data the half-baked vertex color
- * \param dayLight color of the sunlight
+ * \param dayLight color of the skylight
  */
 void final_color_blend(video::SColor *result,
 		const video::SColor &data, const video::SColorf &dayLight);

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -11,6 +11,7 @@
 #include "client/clientevent.h"
 #include "client/renderingengine.h"
 #include "client/texturesource.h"
+#include "client/mapblock_mesh.h"
 #include "util/numeric.h"
 #include "light.h"
 #include "localplayer.h"
@@ -179,7 +180,6 @@ void Particle::step(float dtime, ClientEnvironment *env)
 
 video::SColor Particle::updateLight(ClientEnvironment *env)
 {
-	u8 light = 0;
 	bool pos_ok;
 
 	v3s16 p = v3s16(
@@ -187,18 +187,38 @@ video::SColor Particle::updateLight(ClientEnvironment *env)
 		floor(m_pos.Y+0.5),
 		floor(m_pos.Z+0.5)
 	);
+	video::SColor light;
+	video::SColor data;
+	u32 daynight_ratio = env->getDayNightRatio();
+	const Lighting &lighting = env->getLocalPlayer()->getLighting();
 	MapNode n = env->getClientMap().getNode(p, &pos_ok);
-	if (pos_ok)
-		light = n.getLightBlend(env->getDayNightRatio(),
-				env->getGameDef()->ndef()->getLightingFlags(n));
-	else
-		light = blend_light(env->getDayNightRatio(), LIGHT_SUN, 0);
+	if (pos_ok) {
+		u16 light_level = getInteriorLight(n, -1, env->getGameDef()->ndef());
+		ContentLightingFlags f = env->getGameDef()->ndef()->getLightingFlags(n);
+		data = encode_light(light_level, f.light_source);
+	} else {
+		// night<<8 has no effect
+		u16 light_level = LIGHT_SUN;
+		data = encode_light(light_level, 0);
+	}
+	video::SColorf day_light;
+	get_skylight_color(&day_light, daynight_ratio, lighting.sky_light);
+	data.setRed(data.getRed() * m_base_color.getRed()/ 255);
+	data.setGreen(data.getGreen() * m_base_color.getGreen()/ 255);
+	data.setBlue(data.getBlue() * m_base_color.getBlue() / 255);
+	final_color_blend(&light, data, day_light);
 
-	u8 m_light = decode_light(light + m_p.glow);
+	// divided by maximum allowed value of particle glow - 14
 	return video::SColor(255,
-		m_light * m_base_color.getRed() / 255,
-		m_light * m_base_color.getGreen() / 255,
-		m_light * m_base_color.getBlue() / 255);
+		core::clamp(
+			(s32) (light.getRed() + m_p.glow * m_base_color.getRed() / 14),
+			0, 255),
+		core::clamp(
+			(s32) (light.getGreen() + m_p.glow * m_base_color.getGreen() / 14),
+			0, 255),
+		core::clamp(
+			(s32) (light.getBlue() + m_p.glow * m_base_color.getBlue() / 14),
+			0, 255));
 }
 
 void Particle::updateVertices(ClientEnvironment *env, video::SColor color)

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -6,6 +6,7 @@
 #include "SColor.h"
 #include "irr_v3d.h"
 
+#include "irr_v3d.h"
 
 /**
  * Parameters for automatic exposure compensation
@@ -40,11 +41,36 @@ struct AutoExposure
 	{}
 };
 
+/**
+ * Parameters for set color and intensity of night and day light.
+ *
+ * Light color is calculated in function get_sunlight_color.
+ * Variable daynight_ration can be from 0 to 1000.
+ *
+ * sky_light->r = color_offset.X+color_ratio_coef.X*daynight_ratio;
+ * sky_light->g = color_offset.Y+color_ratio_coef.Y*daynight_ratio;
+ * sky_light->b = color_offset.Z+color_ratio_coef.Z*daynight_ratio;
+ *
+ */
+struct SkyLight
+{
+	/// @brief Sunlight color offset
+	v3f color_offset;
+	/// @brief Sunlight color dayratio effect
+	v3f color_ratio_coef;
+
+	constexpr SkyLight()
+		: color_offset{-0.04, -0.04, 0.078},
+		color_ratio_coef{1e-3, 1e-3, 0.98e-3}
+	{}
+};
+
 /** Describes ambient light settings for a player
  */
 struct Lighting
 {
 	AutoExposure exposure;
+	SkyLight sky_light;
 	float shadow_intensity {0.0f};
 	float saturation {1.0f};
 	float volumetric_light_strength {0.0f};

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1916,5 +1916,14 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 			break;
 		// >= 5.16.0-dev
 		*pkt >> lighting.shadow_direction;
+		if (!pkt->hasRemainingBytes())
+			break;
+		// >= 5.17.0-dev
+		*pkt >> lighting.sky_light.color_offset.X
+				>> lighting.sky_light.color_offset.Y
+				>> lighting.sky_light.color_offset.Z
+				>> lighting.sky_light.color_ratio_coef.X
+				>> lighting.sky_light.color_ratio_coef.Y
+				>> lighting.sky_light.color_ratio_coef.Z;
 	} while (0);
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2853,7 +2853,7 @@ int ObjectRef::l_set_lighting(lua_State *L)
 		if (lua_istable(L, -1)) {
 			lighting.exposure.luminance_min       = getfloatfield_default(L, -1, "luminance_min",       lighting.exposure.luminance_min);
 			lighting.exposure.luminance_max       = getfloatfield_default(L, -1, "luminance_max",       lighting.exposure.luminance_max);
-			lighting.exposure.exposure_correction = getfloatfield_default(L, -1, "exposure_correction",      lighting.exposure.exposure_correction);
+			lighting.exposure.exposure_correction = getfloatfield_default(L, -1, "exposure_correction", lighting.exposure.exposure_correction);
 			lighting.exposure.speed_dark_bright   = getfloatfield_default(L, -1, "speed_dark_bright",   lighting.exposure.speed_dark_bright);
 			lighting.exposure.speed_bright_dark   = getfloatfield_default(L, -1, "speed_bright_dark",   lighting.exposure.speed_bright_dark);
 			lighting.exposure.center_weight_power = getfloatfield_default(L, -1, "center_weight_power", lighting.exposure.center_weight_power);
@@ -2874,7 +2874,26 @@ int ObjectRef::l_set_lighting(lua_State *L)
 			lighting.bloom_radius          = getfloatfield_default(L, -1, "radius",          lighting.bloom_radius);
 		}
 		lua_pop(L, 1); // bloom
-}
+
+		lua_getfield(L, 2, "sky_light");
+		if (lua_istable(L, -1)) {
+			lua_getfield(L, 3, "color_offset");
+			if (lua_istable(L, -1)) {
+				lighting.sky_light.color_offset.X = getfloatfield_default(L, -1, "r", lighting.sky_light.color_offset.X);
+				lighting.sky_light.color_offset.Y = getfloatfield_default(L, -1, "g", lighting.sky_light.color_offset.Y);
+				lighting.sky_light.color_offset.Z = getfloatfield_default(L, -1, "b", lighting.sky_light.color_offset.Z);
+			}
+			lua_pop(L, 1); // color_offset
+			lua_getfield(L, 3, "color_ratio_coef");
+			if (lua_istable(L, -1)) {
+				lighting.sky_light.color_ratio_coef.X = getfloatfield_default(L, -1, "r", lighting.sky_light.color_ratio_coef.X);
+				lighting.sky_light.color_ratio_coef.Y = getfloatfield_default(L, -1, "g", lighting.sky_light.color_ratio_coef.Y);
+				lighting.sky_light.color_ratio_coef.Z = getfloatfield_default(L, -1, "b", lighting.sky_light.color_ratio_coef.Z);
+			}
+			lua_pop(L, 1); // color_ratio_coef
+		}
+		lua_pop(L, 1); // sky_light
+	}
 
 	getServer(L)->setLighting(player, lighting);
 	return 0;
@@ -2928,6 +2947,24 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_pushnumber(L, lighting.bloom_radius);
 	lua_setfield(L, -2, "radius");
 	lua_setfield(L, -2, "bloom");
+	lua_newtable(L); // "sky_light"
+	lua_newtable(L); // "color_offset"
+	lua_pushnumber(L, lighting.sky_light.color_offset.X);
+	lua_setfield(L, -2, "r");
+	lua_pushnumber(L, lighting.sky_light.color_offset.Y);
+	lua_setfield(L, -2, "g");
+	lua_pushnumber(L, lighting.sky_light.color_offset.Z);
+	lua_setfield(L, -2, "b");
+	lua_setfield(L, -2, "color_offset");
+	lua_newtable(L); // "color_ratio_coef"
+	lua_pushnumber(L, lighting.sky_light.color_ratio_coef.X);
+	lua_setfield(L, -2, "r");
+	lua_pushnumber(L, lighting.sky_light.color_ratio_coef.Y);
+	lua_setfield(L, -2, "g");
+	lua_pushnumber(L, lighting.sky_light.color_ratio_coef.Z);
+	lua_setfield(L, -2, "b");
+	lua_setfield(L, -2, "color_ratio_coef");
+	lua_setfield(L, -2, "sky_light");
 	return 1;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2061,6 +2061,13 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 
 	pkt << lighting.shadow_direction;
 
+	pkt << lighting.sky_light.color_offset.X
+			<< lighting.sky_light.color_offset.Y
+			<< lighting.sky_light.color_offset.Z
+			<< lighting.sky_light.color_ratio_coef.X
+			<< lighting.sky_light.color_ratio_coef.Y
+			<< lighting.sky_light.color_ratio_coef.Z;
+
 	Send(&pkt);
 }
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Allows games to change sun color, intensity, and night's darkness.
- It changed `get_sunlight_color` function, so no constants are used for sun color calculation, but configurable parameters.
- This can be useful with mods that control moon phases and weather. It also can be useful in space games.
- With this, heavy cloudy nights can be darkness than normal nights, etc.

## To do

This PR is Ready for Review.

## How to test

Run game devtest and run command `set_light_intensity` from lighting mod.


https://github.com/minetest/minetest/assets/17455197/fee53e6b-3bbe-4b31-8f03-e1dddb629672
