### PR TITLE
Add `touch_controls` boolean to `get_player_window_information()`

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5350,6 +5350,11 @@ Utilities
       -- HUD Scaling multiplier
       -- Equal to the setting `hud_scaling` multiplied by `dpi / 96`
       real_hud_scaling = 1,
+
+      -- Whether the touchscreen controls are enabled.
+      -- Usually (but not always) `true` on Android.
+      -- Requires at least Minetest 5.9.0.
+      touch_controls = false,
   }
   ```
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5353,7 +5353,8 @@ Utilities
 
       -- Whether the touchscreen controls are enabled.
       -- Usually (but not always) `true` on Android.
-      -- Requires at least Minetest 5.9.0.
+      -- Requires at least Minetest 5.9.0 on the client. For older clients, it
+      -- is always set to `false`.
       touch_controls = false,
   }
   ```

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -249,6 +249,10 @@ GUI
       -- HUD Scaling multiplier
       -- Equal to the setting `hud_scaling` multiplied by `dpi / 96`
       real_hud_scaling = 1,
+
+      -- Whether the touchscreen controls are enabled.
+      -- Usually (but not always) `true` on Android.
+      touch_controls = false,
   }
   ```
 

--- a/games/devtest/mods/testfullscreenfs/init.lua
+++ b/games/devtest/mods/testfullscreenfs/init.lua
@@ -7,6 +7,8 @@ local function show_fullscreen_fs(name)
 	print(dump(window))
 
 	local size = { x = window.max_formspec_size.x * 1.1, y = window.max_formspec_size.y * 1.1 }
+	local touch_text = window.touch_controls and "Touch controls enabled" or
+			"Touch controls disabled"
 	local fs = {
 		"formspec_version[4]",
 		("size[%f,%f]"):format(size.x, size.y),
@@ -16,7 +18,8 @@ local function show_fullscreen_fs(name)
 		("button[%f,%f;1,1;%s;%s]"):format(size.x - 1, size.y - 1, "br", "BR"),
 		("button[%f,%f;1,1;%s;%s]"):format(0, size.y - 1, "bl", "BL"),
 
-		("label[%f,%f;%s]"):format(size.x / 2, size.y / 2, "Fullscreen")
+		("label[%f,%f;%s]"):format(size.x / 2, size.y / 2, "Fullscreen"),
+		("label[%f,%f;%s]"):format(size.x / 2, size.y / 2 + 1, touch_text),
 	}
 
 	minetest.show_formspec(name, "testfullscreenfs:fs", table.concat(fs))

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1439,6 +1439,7 @@ void Client::sendUpdateClientInfo(const ClientDynamicInfo& info)
 	pkt << info.real_gui_scaling;
 	pkt << info.real_hud_scaling;
 	pkt << (f32)info.max_fs_size.X << (f32)info.max_fs_size.Y;
+	pkt << info.touch_controls;
 
 	Send(&pkt);
 }

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -33,11 +33,13 @@ public:
 	f32 real_gui_scaling;
 	f32 real_hud_scaling;
 	v2f32 max_fs_size;
+	bool touch_controls;
 
 	bool equal(const ClientDynamicInfo &other) const {
 		return render_target_size == other.render_target_size &&
 				abs(real_gui_scaling - other.real_gui_scaling) < 0.001f &&
-				abs(real_hud_scaling - other.real_hud_scaling) < 0.001f;
+				abs(real_hud_scaling - other.real_hud_scaling) < 0.001f &&
+				touch_controls == other.touch_controls;
 	}
 
 #ifndef SERVER
@@ -48,10 +50,16 @@ public:
 		f32 hud_scaling = g_settings->getFloat("hud_scaling", 0.5f, 20.0f);
 		f32 real_gui_scaling = gui_scaling * density;
 		f32 real_hud_scaling = hud_scaling * density;
+#ifdef HAVE_TOUCHSCREENGUI
+		bool touch_controls = true;
+#else
+		bool touch_controls = false;
+#endif
 
 		return {
 			screen_size, real_gui_scaling, real_hud_scaling,
-			ClientDynamicInfo::calculateMaxFSSize(screen_size, gui_scaling)
+			ClientDynamicInfo::calculateMaxFSSize(screen_size, gui_scaling),
+			touch_controls
 		};
 	}
 #endif

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1866,7 +1866,7 @@ void Server::handleCommand_HaveMedia(NetworkPacket *pkt)
 
 void Server::handleCommand_UpdateClientInfo(NetworkPacket *pkt)
 {
-	ClientDynamicInfo info{};
+	ClientDynamicInfo info;
 	*pkt >> info.render_target_size.X;
 	*pkt >> info.render_target_size.Y;
 	*pkt >> info.real_gui_scaling;
@@ -1876,7 +1876,9 @@ void Server::handleCommand_UpdateClientInfo(NetworkPacket *pkt)
 	try {
 		// added in 5.9.0
 		*pkt >> info.touch_controls;
-	} catch (PacketError &e) {}
+	} catch (PacketError &e) {
+		info.touch_controls = false;
+	}
 
 	session_t peer_id = pkt->getPeerId();
 	RemoteClient *client = getClient(peer_id, CS_Invalid);

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1866,13 +1866,17 @@ void Server::handleCommand_HaveMedia(NetworkPacket *pkt)
 
 void Server::handleCommand_UpdateClientInfo(NetworkPacket *pkt)
 {
-	ClientDynamicInfo info;
+	ClientDynamicInfo info{};
 	*pkt >> info.render_target_size.X;
 	*pkt >> info.render_target_size.Y;
 	*pkt >> info.real_gui_scaling;
 	*pkt >> info.real_hud_scaling;
 	*pkt >> info.max_fs_size.X;
 	*pkt >> info.max_fs_size.Y;
+	try {
+		// added in 5.9.0
+		*pkt >> info.touch_controls;
+	} catch (PacketError &e) {}
 
 	session_t peer_id = pkt->getPeerId();
 	RemoteClient *client = getClient(peer_id, CS_Invalid);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -946,6 +946,10 @@ int ModApiMainMenu::l_get_window_info(lua_State *L)
 	lua_pushnumber(L, info.real_hud_scaling);
 	lua_settable(L, top);
 
+	lua_pushstring(L, "touch_controls");
+	lua_pushboolean(L, info.touch_controls);
+	lua_settable(L, top);
+
 	return 1;
 }
 

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -317,6 +317,11 @@ int ModApiServer::l_get_player_window_information(lua_State *L)
 	lua_pushstring(L, "real_hud_scaling");
 	lua_pushnumber(L, dynamic->real_hud_scaling);
 	lua_settable(L, dyn_table);
+
+	lua_pushstring(L, "touch_controls");
+	lua_pushboolean(L, dynamic->touch_controls);
+	lua_settable(L, dyn_table);
+
 	return 1;
 }
 


### PR DESCRIPTION
This PR adds a `touch_controls` boolean to the result of `minetest.get_player_window_information()`, so that you can detect whether players have enabled the touchscreen controls. If an old client connects to a new server, the field defaults to `false`.

Example use cases:

- Matchmaking (only allow touchscreen players as opponents for other touchscreen players)
- Touch-specific control hints (e.g. "Long tap to fire" instead of "Left-click to fire")
- *Touch-specific adaptation of  GUIs (e.g. wider scrollbars)* (conceptually, this isn't really the intended use)

Partially resolves (please don't link this, GitHub) #12264. As you can see by looking at that issue, an input method detection API can become arbitrarily complex. However, as stated in the issue, the new field I'm proposing in this PR is unambiguous:

> The only unambiguous value here is `has_touchscreen_controls`: the touchscreen controls are either enabled or not. The rest could be problematic - it's possible to have both a keyboard/mouse and gamepad connected, but only the former used.
> https://github.com/minetest/minetest/issues/12264#issue-1224073385

It doesn't conflict with a future, more complex API and solves real-world use cases.

## To do

This PR is a Ready for Review.

## How to test

Start a Devtest world and do `/testfullscreenfs`. See that the formspec correctly says "Touch controls enabled" or "Touch controls disabled".

Connect an old client to a new server. See that `/testfullscreenfs` always says "Touch controls disabled".