### PR TITLE
Fix a very long time bug with server step when no one is moving

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1052,22 +1052,13 @@ void Server::Receive()
 {
 	NetworkPacket pkt;
 	session_t peer_id;
-	bool first = true;
 	for (;;) {
 		pkt.clear();
 		peer_id = 0;
 		try {
-			/*
-				In the first iteration *wait* for a packet, afterwards process
-				all packets that are immediately available (no waiting).
-			*/
-			if (first) {
-				m_con->Receive(&pkt);
-				first = false;
-			} else {
-				if (!m_con->TryReceive(&pkt))
-					return;
-			}
+
+			if (!m_con->TryReceive(&pkt))
+				return;
 
 			peer_id = pkt.getPeerId();
 			m_packet_recv_counter->increment();


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR

To fix a bug I've been searching for for a while now. When everyone in the server stops moving the server basically lags because clients don't seem to be sending packets. At the same rate. This can cause weird inconsistent behavior with how mods interact with the game engine. Like inconsistent set_yaw, etc.

If you want to know just how old this bug is, please see this video. https://youtu.be/ZUZGrqwwflg?feature=shared

- How does the PR work?

It stops the server from hanging while attempting to wait for a packet that will never come for about 0.03-0.3 ms, it's all over the place.

- Does it resolve any reported issue?

Not a single clue about that one.

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?

Not sure.

This PR is Ready for Review.


## How to test

Have a mod with 
```lua
minetest.register_globalstep(function(delta)
  print(delta)
end)
```

Move around, observe the server tick rate fluctuating. You can even just move your camera because that sends the yaw/pitch packets as well.

Patch your game.

Do the same thing again. In singleplayer, it makes the game EXTREMELY smooth.

<!-- Example code or instructions -->
