### PR TITLE
Update porting.h to fix build errors on MacOS 14 / Xcode 15

### DIFF
--- a/src/porting.h
+++ b/src/porting.h
@@ -89,6 +89,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef _WIN32 // POSIX
 	#include <sys/time.h>
 	#include <ctime>
+    #if defined(__MACH__) && defined(__APPLE__)
+        #include <TargetConditionals.h>
+    #endif
 #endif
 
 namespace porting


### PR DESCRIPTION
error:

```
../minetest/src/porting.h:266:6: error: 'TARGET_OS_MAC' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGETOS]
  266 |         #if TARGET_OS_MAC
      |             ^
../minetest/src/porting.h:268:8: error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGETOS]
  268 |         #elif TARGET_OS_IPHONE
      |               ^
```