### PR TITLE
[NOSQUASH] Fix tonemapping and apply saturation even if tonemapping is disabled

### DIFF
--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -78,6 +78,7 @@ vec4 applyToneMapping(vec4 color)
 	color.rgb *= whiteScale;
 	return vec4(pow(color.rgb, vec3(1.0 / gamma)), color.a);
 }
+#endif
 
 vec3 applySaturation(vec3 color, float factor)
 {
@@ -86,7 +87,6 @@ vec3 applySaturation(vec3 color, float factor)
 	float brightness = dot(color, vec3(0.2125, 0.7154, 0.0721));
 	return mix(vec3(brightness), color, factor);
 }
-#endif
 
 #ifdef ENABLE_DITHERING
 // From http://alex.vlachos.com/graphics/Alex_Vlachos_Advanced_VR_Rendering_GDC2015.pdf
@@ -144,8 +144,9 @@ void main(void)
 	{
 #if ENABLE_TONE_MAPPING
 		color = applyToneMapping(color);
-		color.rgb = applySaturation(color.rgb, saturation);
 #endif
+
+		color.rgb = applySaturation(color.rgb, saturation);
 	}
 
 #ifdef ENABLE_DITHERING

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -68,13 +68,15 @@ vec3 uncharted2Tonemap(vec3 x)
 
 vec4 applyToneMapping(vec4 color)
 {
-	const float exposureBias = 2.0;
+	color = vec4(pow(color.rgb, vec3(2.2)), color.a);
+	const float gamma = 1.6;
+	const float exposureBias = 5.5;
 	color.rgb = uncharted2Tonemap(exposureBias * color.rgb);
 	// Precalculated white_scale from
 	//vec3 whiteScale = 1.0 / uncharted2Tonemap(vec3(W));
 	vec3 whiteScale = vec3(1.036015346);
 	color.rgb *= whiteScale;
-	return color;
+	return vec4(pow(color.rgb, vec3(1.0 / gamma)), color.a);
 }
 
 vec3 applySaturation(vec3 color, float factor)
@@ -130,6 +132,12 @@ void main(void)
 	color = applyBloom(color, uv);
 #endif
 
+
+	color.rgb = clamp(color.rgb, vec3(0.), vec3(1.));
+
+	// return to sRGB colorspace (approximate)
+	color.rgb = pow(color.rgb, vec3(1.0 / 2.2));
+
 #ifdef ENABLE_BLOOM_DEBUG
 	if (uv.x > 0.5 || uv.y > 0.5)
 #endif
@@ -139,11 +147,6 @@ void main(void)
 		color.rgb = applySaturation(color.rgb, saturation);
 #endif
 	}
-
-	color.rgb = clamp(color.rgb, vec3(0.), vec3(1.));
-
-	// return to sRGB colorspace (approximate)
-	color.rgb = pow(color.rgb, vec3(1.0 / 2.2));
 
 #ifdef ENABLE_DITHERING
 	// Apply dithering just before quantisation

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8028,9 +8028,8 @@ child will follow movement and rotation of that bone.
     * Passing no arguments resets lighting to its default values.
     * `light_definition` is a table with the following optional fields:
       * `saturation` sets the saturation (vividness; default: `1.0`).
-          values > 1 increase the saturation
-          values in [0,1) decrease the saturation
-            * This value has no effect on clients who have the "Tone Mapping" shader disabled.
+        * values > 1 increase the saturation
+        * values in [0,1] decrease the saturation
       * `shadows` is a table that controls ambient shadows
         * `intensity` sets the intensity of the shadows from 0 (no shadows, default) to 1 (blackness)
             * This value has no effect on clients who have the "Dynamic Shadows" shader disabled.


### PR DESCRIPTION
Fixes #14088

This PR fixes the tonemapping effect and makes it look like it used to before bloom being added, by moving it above the "linear colorspace" conversion and reverting the changes made in `applyToneMapping`.

It also moves the saturation effect outside of `ENABLE_TONE_MAPPING` so it's possible to use it without requiring tone mapping to be enabled. I don't know why it was made like that and it still works when moving it outside of the preprocessor blocks. If that should be moved into a separate PR then let me know.

## To do
This PR is Ready for Review.

## How to test
Test with tonemapping enabled, see that it looks like it used to. (See https://github.com/minetest/minetest/issues/14088#issue-2034013620)

Also test such that other shader effects such as saturation aren't messed up because of the change (to test the saturation effect, you can install the [Saturation Adjustment](https://content.minetest.net/packages/ROllerozxa/saturation_adjustment/) mod)