### PR TITLE
Fix touch input on Linux

### DIFF
--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -273,7 +273,7 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 		irr_ptr<GUIModalMenu> holder;
 		holder.grab(this); // keep this alive until return (it might be dropped downstream [?])
 
-		if (event.TouchInput.ID == 0) {
+		if (event.TouchInput.touchedCount == 1) {
 			if (event.TouchInput.Event == ETIE_PRESSED_DOWN || event.TouchInput.Event == ETIE_MOVED)
 				m_pointer = v2s32(event.TouchInput.X, event.TouchInput.Y);
 			gui::IGUIElement *hovered = Environment->getRootGUIElement()->getElementFromPoint(core::position2d<s32>(m_pointer));
@@ -290,7 +290,7 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 			if (event.TouchInput.Event == ETIE_LEFT_UP)
 				leave();
 			return ret;
-		} else if (event.TouchInput.ID == 1) {
+		} else if (event.TouchInput.touchedCount == 2) {
 			if (event.TouchInput.Event != ETIE_LEFT_UP)
 				return true; // ignore
 			auto focused = Environment->getFocus();


### PR DESCRIPTION
Fixes #14111.

The code relied on touch IDs being consecutive. This is true on Android, but not on Linux. Therefore, touch input on Linux was broken since 53886dcdb52de80d862539e22950c84fbf88df88.

## To do

This PR is a Ready for Review.

## How to test

Play Minetest on Android. Verify that touchscreen input, and especially stack splitting, still work.

Play Minetest on Linux with a touchscreen. Verify that touchscreen input, and especially stack splitting, work again.
