### PR TITLE
Don't enable relative mouse mode if in touchscreen mode

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -542,13 +542,13 @@ void ClientLauncher::main_menu(MainMenuData *menudata)
 	}
 	infostream << "Waited for other menus" << std::endl;
 
-#ifndef ANDROID
-	// Cursor can be non-visible when coming from the game
-	m_rendering_engine->get_raw_device()->getCursorControl()->setVisible(true);
-
-	// Set absolute mouse mode
-	m_rendering_engine->get_raw_device()->getCursorControl()->setRelativeMode(false);
-#endif
+	ICursorControl *cur_control = m_rendering_engine->get_raw_device()->getCursorControl();
+	if (cur_control) {
+		// Cursor can be non-visible when coming from the game
+		cur_control->setVisible(true);
+		// Set absolute mouse mode
+		cur_control->setRelativeMode(false);
+	}
 
 	/* show main menu */
 	GUIEngine mymenu(&input->joystick, guiroot, m_rendering_engine, &g_menumgr, menudata, *kill);

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -542,7 +542,7 @@ void ClientLauncher::main_menu(MainMenuData *menudata)
 	}
 	infostream << "Waited for other menus" << std::endl;
 
-	ICursorControl *cur_control = m_rendering_engine->get_raw_device()->getCursorControl();
+	auto *cur_control = m_rendering_engine->get_raw_device()->getCursorControl();
 	if (cur_control) {
 		// Cursor can be non-visible when coming from the game
 		cur_control->setVisible(true);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2613,7 +2613,7 @@ void Game::checkZoomEnabled()
 
 void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 {
-	ICursorControl *cur_control = device->getCursorControl();
+	auto *cur_control = device->getCursorControl();
 
 	/* With CIrrDeviceSDL on Linux and Windows, enabling relative mouse mode
 	somehow results in simulated mouse events being generated from touch events,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2613,23 +2613,27 @@ void Game::checkZoomEnabled()
 
 void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 {
-#ifndef __ANDROID__
-	if (isMenuActive())
-		device->getCursorControl()->setRelativeMode(false);
-	else
-		device->getCursorControl()->setRelativeMode(true);
+	ICursorControl *cur_control = device->getCursorControl();
+
+	/* With CIrrDeviceSDL on Linux and Windows, enabling relative mouse mode
+	somehow results in simulated mouse events being generated from touch events,
+	although SDL_HINT_MOUSE_TOUCH_EVENTS and SDL_HINT_TOUCH_MOUSE_EVENTS are set to 0.
+	Since Minetest has its own code to synthesize mouse events from touch events,
+	this results in duplicated input. To avoid that, we don't enable relative
+	mouse mode if we're in touchscreen mode. */
+#ifndef HAVE_TOUCHSCREENGUI
+	if (cur_control)
+		cur_control->setRelativeMode(!isMenuActive());
 #endif
 
 	if ((device->isWindowActive() && device->isWindowFocused()
 			&& !isMenuActive()) || input->isRandom()) {
 
-#ifndef __ANDROID__
-		if (!input->isRandom()) {
+		if (cur_control && !input->isRandom()) {
 			// Mac OSX gets upset if this is set every frame
-			if (device->getCursorControl()->isVisible())
-				device->getCursorControl()->setVisible(false);
+			if (cur_control->isVisible())
+				cur_control->setVisible(false);
 		}
-#endif
 
 		if (m_first_loop_after_window_activation) {
 			m_first_loop_after_window_activation = false;
@@ -2641,15 +2645,11 @@ void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 		}
 
 	} else {
-
-#ifndef ANDROID
 		// Mac OSX gets upset if this is set every frame
-		if (!device->getCursorControl()->isVisible())
-			device->getCursorControl()->setVisible(true);
-#endif
+		if (cur_control && !cur_control->isVisible())
+			cur_control->setVisible(true);
 
 		m_first_loop_after_window_activation = true;
-
 	}
 }
 


### PR DESCRIPTION
Resolves issue no. 2 described in minetest/irrlicht#262.

With `CIrrDeviceSDL` on Linux and Windows, enabling relative mouse mode somehow results in simulated mouse events being generated from touch events, although `SDL_HINT_MOUSE_TOUCH_EVENTS` and `SDL_HINT_TOUCH_MOUSE_EVENTS` are set to 0. Since Minetest has its own code to synthesize mouse events from touch events, this results in duplicated input. To avoid that, we don't enable relative mouse mode if we're in touchscreen mode.

## To do

This PR is a Ready for Review.

## How to test

Compile Minetest with `ENABLE_TOUCH=TRUE` and `USE_SDL2=TRUE`. See that you don't start digging just because you are touching the on-screen sneak button.

Verify that there are no crashes on Android because `getCursorControl` returns null.