### PR TITLE
Fix TouchScreenGUI ignoring server-sent pitch changes

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2617,7 +2617,7 @@ void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 #ifdef HAVE_TOUCHSCREENGUI
 	if (g_touchscreengui) {
 		cam->camera_yaw   += g_touchscreengui->getYawChange();
-		cam->camera_pitch  = g_touchscreengui->getPitch();
+		cam->camera_pitch += g_touchscreengui->getPitchChange();
 	} else {
 #endif
 		v2s32 center(driver->getScreenSize().Width / 2, driver->getScreenSize().Height / 2);

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -832,7 +832,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 					const double d = g_settings->getFloat("touchscreen_sensitivity", 0.001f, 10.0f) * 3.0f;
 
 					m_camera_yaw_change -= dir_free.X * d;
-					m_camera_pitch = MYMIN(MYMAX(m_camera_pitch + (dir_free.Y * d), -180.0f), 180.0f);
+					m_camera_pitch_change += dir_free.Y * d;
 
 					// update shootline
 					// no need to update (X, Y) when using crosshair since the shootline is not used

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -171,7 +171,11 @@ public:
 		return res;
 	}
 
-	double getPitch() { return m_camera_pitch; }
+	double getPitchChange() {
+		double res = m_camera_pitch_change;
+		m_camera_pitch_change = 0;
+		return res;
+	}
 
 	/**
 	 * Returns a line which describes what the player is pointing at.
@@ -213,7 +217,7 @@ private:
 
 	// value in degree
 	double m_camera_yaw_change = 0.0;
-	double m_camera_pitch = 0.0;
+	double m_camera_pitch_change = 0.0;
 
 	/**
 	 * A line starting at the camera and pointing towards the selected object.


### PR DESCRIPTION
This PR changes TouchScreenGUI to store a pitch difference instead of an absolute pitch value, like it is already done for yaw. This is necessary so that server-sent pitch changes (`player:set_look_vertical(radians)`) are applied.

## To do

This PR is a Ready for Review.

## How to test

Install Worldedit and verify that this command works:

```
//lua minetest.get_connected_players()[1]:set_look_vertical(-math.pi / 2)
```
