### PR TITLE
Fix set_bone_position regressions

### DIFF
--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -149,8 +149,9 @@ DeprecatedHandlingMode get_deprecated_handling_mode();
  * @param message The deprecation method
  * @param stack_depth How far on the stack to the first user function
  *        (ie: not builtin or core). -1 to disabled.
+ * @param once Log the deprecation warning only once per callsite.
  */
-void log_deprecated(lua_State *L, std::string message, int stack_depth = 1);
+void log_deprecated(lua_State *L, std::string message, int stack_depth = 1, bool once = false);
 
 // Safely call string.dump on a function value
 // (does not pop, leaves one value on stack)

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -520,7 +520,7 @@ int ObjectRef::l_set_bone_position(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	log_deprecated(L,"Deprecated call to set_bone_position, use set_bone_override instead");
+	log_deprecated(L, "Deprecated call to set_bone_position, use set_bone_override instead", 1, true);
 
 	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
@@ -546,7 +546,7 @@ int ObjectRef::l_get_bone_position(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	log_deprecated(L,"Deprecated call to get_bone_position, use get_bone_override instead");
+	log_deprecated(L, "Deprecated call to get_bone_position, use get_bone_override instead", 1, true);
 
 	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -528,12 +528,12 @@ int ObjectRef::l_set_bone_position(lua_State *L)
 		return 0;
 
 	std::string bone;
-	if (!lua_isnil(L, 2))
+	if (!lua_isnoneornil(L, 2))
 		bone = readParam<std::string>(L, 2);
 	BoneOverride props;
-	if (!lua_isnil(L, 3))
+	if (!lua_isnoneornil(L, 3))
 		props.position.vector = check_v3f(L, 3);
-	if (!lua_isnil(L, 4))
+	if (!lua_isnoneornil(L, 4))
 		props.rotation.next = core::quaternion(check_v3f(L, 4) * core::DEGTORAD);
 	props.position.absolute = true;
 	props.rotation.absolute = true;


### PR DESCRIPTION
Without this, omitting the parameters (but not explicitly passing them as `nil`) causes a crash. This is a regression caused by #12388; `readParam` treats `nil` and none the same.

Reported by @grorp as causing a crash when using Mineclone.

Not tested yet, but there is no reason why this shouldn't work.