### PR TITLE
Legible Lua profiler

### DIFF
--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -55,7 +55,9 @@ end
 -- Generate a missing label with a running index number.
 --
 local counts = {}
-local worldmods_path = regex_escape(minetest.get_worldpath() .. DIR_DELIM .. "worldmods")
+local worldmods_path = regex_escape(core.get_worldpath())
+local user_path = regex_escape(core.get_user_path())
+local builtin_path = regex_escape(core.get_builtin_path())
 local function generate_name(def)
 	local class, label, func_name = def.class, def.label, def.func_name
 	if label then
@@ -71,13 +73,14 @@ local function generate_name(def)
 	local index = counts[index_id] or 1
 	counts[index_id] = index + 1
 	local info = debug.getinfo(def.func)
-	local modpath = regex_escape(minetest.get_modpath(def.mod) or "")
-	local source
-	if modpath == "" then
-		source = info.source:gsub(worldmods_path, "")
-	else
-		source = info.source:gsub(modpath, def.mod):gsub(worldmods_path, "")
+	local modpath = regex_escape(core.get_modpath(def.mod) or "")
+	local source = info.source
+	if modpath ~= "" then
+		source = source:gsub(modpath, def.mod)
 	end
+	source = source:gsub(worldmods_path, "")
+	source = source:gsub(builtin_path, "builtin" .. DIR_DELIM)
+	source = source:gsub(user_path, "")
 	return format("%s[%d] %s#%s", class or func_name, index, source, info.linedefined)
 end
 

--- a/builtin/profiler/reporter.lua
+++ b/builtin/profiler/reporter.lua
@@ -77,7 +77,7 @@ local Formatter = {
 	end
 }
 
-local widths = { 55, 9, 9, 9, 5, 5, 5 }
+local widths = { 80, 9, 9, 9, 5, 5, 5 }
 local txt_row_format = sprintf(" %%-%ds | %%%ds | %%%ds | %%%ds | %%%ds | %%%ds | %%%ds", unpack(widths))
 
 local HR = {}


### PR DESCRIPTION
- Goal of the PR
improve the usefulness of the profiler by indicating the place where the instrumented function was defined.

- How does the PR work?
uses lua's builtin debugging facilities to get that information

- Does it resolve any reported issue?
 #13261, possibly

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
probably not

- If not a bug fix, why is this PR needed? What usecases does it solve?
it makes it easier to see which bits of code are creating lag. 

## How to test

1. start any game in any world
2. `/profiler print`

![image](https://github.com/minetest/minetest/assets/25628292/dd92277d-b8c8-4b1f-85fa-7c79681783a9)

