### PR TITLE
TouchScreenGUI: Make server-sent overrides of button textures work

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1489,12 +1489,6 @@ bool Game::createClient(const GameStartData &start_data)
 		return false;
 
 	bool could_connect, connect_aborted;
-#ifdef HAVE_TOUCHSCREENGUI
-	if (g_touchscreengui) {
-		g_touchscreengui->init(texture_src);
-		g_touchscreengui->hide();
-	}
-#endif
 	if (!connectToServer(start_data, &could_connect, &connect_aborted))
 		return false;
 
@@ -1603,10 +1597,8 @@ bool Game::initGui()
 			-1, chat_backend, client, &g_menumgr);
 
 #ifdef HAVE_TOUCHSCREENGUI
-
 	if (g_touchscreengui)
-		g_touchscreengui->show();
-
+		g_touchscreengui->init(texture_src);
 #endif
 
 	return true;


### PR DESCRIPTION
Currently, `g_touchscreengui` is initialized before media loading, so you can't override touchscreen button textures from games/mods.

This PR moves the initialization of `g_touchscreengui` after media loading so that overriding button textures works. This shouldn't cause any crashes because #13484 prevents them.

## To do

This PR is a Ready for Review.

## How to test

Put a custom `aux1_btn.png` texture into a mod. Verify that it is used.

Verify that there are no crashes.