### PR TITLE
Perform server occlusion check before a block is loaded or generated.

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -358,6 +358,9 @@ void RemoteClient::GetNextBlocks (
 			if (m_blocks_occ.find(p) != m_blocks_occ.end())
 				continue;
 
+			/*
+				Note that we do this even before the block is loaded as this does not depend on its contents.
+			 */
 			if (m_occ_cull &&
 					env->getMap().isBlockOccluded(p * MAP_BLOCKSIZE, cam_pos_nodes, d >= d_cull_opt)) {
 				m_blocks_occ.insert(p);

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -350,18 +350,18 @@ void RemoteClient::GetNextBlocks (
 					if (!block->getIsUnderground() && !block->getDayNightDiff())
 						continue;
 				}
+			}
 
-				/*
-					Check occlusion cache first.
-				 */
-				if (m_blocks_occ.find(p) != m_blocks_occ.end())
-					continue;
+			/*
+				Check occlusion cache first.
+			 */
+			if (m_blocks_occ.find(p) != m_blocks_occ.end())
+				continue;
 
-				if (m_occ_cull && !block_not_found &&
-						env->getMap().isBlockOccluded(block, cam_pos_nodes, d >= d_cull_opt)) {
-					m_blocks_occ.insert(p);
-					continue;
-				}
+			if (m_occ_cull && !block_not_found &&
+					env->getMap().isBlockOccluded(p * MAP_BLOCKSIZE, cam_pos_nodes, d >= d_cull_opt)) {
+				m_blocks_occ.insert(p);
+				continue;
 			}
 
 			/*

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -358,7 +358,7 @@ void RemoteClient::GetNextBlocks (
 			if (m_blocks_occ.find(p) != m_blocks_occ.end())
 				continue;
 
-			if (m_occ_cull && !block_not_found &&
+			if (m_occ_cull &&
 					env->getMap().isBlockOccluded(p * MAP_BLOCKSIZE, cam_pos_nodes, d >= d_cull_opt)) {
 				m_blocks_occ.insert(p);
 				continue;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1155,7 +1155,11 @@ bool Map::isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
 	return false;
 }
 
-bool Map::isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes, bool simple_check)
+bool Map::isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes, bool simple_check) {
+	return isBlockOccluded(block->getPosRelative(), cam_pos_nodes, simple_check);
+}
+
+bool Map::isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool simple_check)
 {
 	// Check occlusion for center and all 8 corners of the mapblock
 	// Overshoot a little for less flickering
@@ -1172,7 +1176,7 @@ bool Map::isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes, bool simple_chec
 		v3s16(-1, -1, -1) * bs2,
 	};
 
-	v3s16 pos_blockcenter = block->getPosRelative() + (MAP_BLOCKSIZE / 2);
+	v3s16 pos_blockcenter = pos_relative + (MAP_BLOCKSIZE / 2);
 
 	// Starting step size, value between 1m and sqrt(3)m
 	float step = BS * 1.2f;
@@ -1203,7 +1207,7 @@ bool Map::isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes, bool simple_chec
 
 	// Additional occlusion check, see comments in that function
 	v3s16 check;
-	if (determineAdditionalOcclusionCheck(cam_pos_nodes, block->getBox(), check)) {
+	if (determineAdditionalOcclusionCheck(cam_pos_nodes, MapBlock::getBox(pos_relative), check)) {
 		// node is always on a side facing the camera, end_offset can be lower
 		if (!isOccluded(cam_pos_nodes, check, step, stepfac, start_offset,
 				-1.0f, needed_count))

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1155,10 +1155,6 @@ bool Map::isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
 	return false;
 }
 
-bool Map::isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes, bool simple_check) {
-	return isBlockOccluded(block->getPosRelative(), cam_pos_nodes, simple_check);
-}
-
 bool Map::isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool simple_check)
 {
 	// Check occlusion for center and all 8 corners of the mapblock

--- a/src/map.h
+++ b/src/map.h
@@ -305,8 +305,12 @@ public:
 		}
 	}
 
-	bool isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes, bool simple_check = false);
+	bool isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes, bool simple_check = false)
+	{
+		return isBlockOccluded(block->getPosRelative(), cam_pos_nodes, simple_check);
+	}
 	bool isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool simple_check = false);
+
 protected:
 	IGameDef *m_gamedef;
 

--- a/src/map.h
+++ b/src/map.h
@@ -306,6 +306,7 @@ public:
 	}
 
 	bool isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes, bool simple_check = false);
+	bool isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool simple_check = false);
 protected:
 	IGameDef *m_gamedef;
 

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -216,10 +216,14 @@ public:
 		return m_pos_relative;
 	}
 
-	inline core::aabbox3d<s16> getBox()
+	inline core::aabbox3d<s16> getBox() {
+		return getBox(getPosRelative());
+	}
+
+	static inline core::aabbox3d<s16> getBox(const v3s16 &pos_relative)
 	{
-		return core::aabbox3d<s16>(getPosRelative(),
-				getPosRelative()
+		return core::aabbox3d<s16>(pos_relative,
+				pos_relative
 				+ v3s16(MAP_BLOCKSIZE, MAP_BLOCKSIZE, MAP_BLOCKSIZE)
 				- v3s16(1,1,1));
 	}


### PR DESCRIPTION
As I looked into loading times for large viewing ranges, it became obvious that loading blocks from the DB (including deserialization) as well as generating non-existent blocks is the limiting factor.

It turns out that in order to do server-side occlusion checks we do not actually need the block loaded.

So what this is doing is to occlusion-cull blocks before they are loaded and do not load them at all if they not visible in the first place.
I easily get a **3x improvement** in loading times at `viewing_range` = 1000. And about a 2x improvement from generate times.
(20s as opposed a minute)

- Goal of the PR
Reduce map loading time.

- How does the PR work?
Occlusion check blocks before they are loaded, and avoid loading them if they are not visible.

- Does it resolve any reported issue?
No directly.

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
Perhaps. Larger viewing ranging is a goal, no?

- If not a bug fix, why is this PR needed? What usecases does it solve?
Significantly improve map loading time. Significantly reduce database load

## To do

This PR is Ready for Review.

## How to test

`viewing_range` = 1000
`max_block_send_distance` = 64
`max_block_generate_distance` = 64
`client_mapblock_limit` = 300000

`max_simultaneous_block_sends_per_client` = 160
`emergequeue_limit_diskonly` = 256
`emergequeue_limit_generate` = 256

Note the times it takes to load the full map with and without the PR. The set of blocks displayed should be the same.