### PR TITLE
Do not emerge blocks in the active_object_send_range_blocks range

### DIFF
--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -394,6 +394,22 @@ void ActiveBlockList::update(std::vector<PlayerSAO*> &active_players,
 			std::inserter(blocks_removed, blocks_removed.end()));
 
 	/*
+		Some sanity checks
+	 */
+	assert(newlist.size() >= extralist.size());
+	assert(blocks_removed.size() <= m_list.size());
+	if (!blocks_added.empty())
+	  assert(newlist.count(*blocks_added.begin()) > 0);
+	if (!extra_blocks_added.empty()) {
+	  assert(newlist.count(*extra_blocks_added.begin()) > 0);
+	  assert(blocks_added.count(*extra_blocks_added.begin()) == 0);
+	}
+	if (!blocks_removed.empty()) {
+	  assert(newlist.count(*blocks_removed.begin()) == 0);
+	  assert(m_list.count(*blocks_removed.begin()) > 0);
+	}
+
+	/*
 		Update m_list
 	*/
 	m_list = std::move(newlist);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -367,32 +367,31 @@ void ActiveBlockList::update(std::vector<PlayerSAO*> &active_players,
 	}
 
 	/*
-		Find out which blocks on the old list are not on the new list
-	*/
-	// Go through old list
-	for (v3s16 p : m_list) {
-		// If not on new list, it's been removed
-		if (newlist.find(p) == newlist.end() && extralist.find(p) == newlist.end())
-			blocks_removed.insert(p);
-	}
-
-	/*
 		Find out which blocks on the new list are not on the old list
 	*/
-	// Go through new list
 	for (v3s16 p : newlist) {
-		// remove duplicate blocks from the extra list
+		// also remove duplicate blocks from the extra list
 		extralist.erase(p);
 		// If not on old list, it's been added
 		if (m_list.find(p) == m_list.end())
 			blocks_added.insert(p);
 	}
+	/*
+		Find out which blocks on the extra list are not on the old list
+	*/
 	for (v3s16 p : extralist) {
+		// also make sure newlist has all blocks
 		newlist.insert(p);
 		// If not on old list, it's been added
 		if (m_list.find(p) == m_list.end())
 			extra_blocks_added.insert(p);
 	}
+
+	/*
+		Find out which blocks on the old list are not on the new + extra list
+	*/
+	std::set_difference(m_list.begin(), m_list.end(), newlist.begin(), newlist.end(),
+			std::inserter(blocks_removed, blocks_removed.end()));
 
 	/*
 		Update m_list

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -168,7 +168,8 @@ public:
 		s16 active_block_range,
 		s16 active_object_range,
 		std::set<v3s16> &blocks_removed,
-		std::set<v3s16> &blocks_added);
+		std::set<v3s16> &blocks_added,
+		std::set<v3s16> &extra_blocks_added);
 
 	bool contains(v3s16 p) const {
 		return (m_list.find(p) != m_list.end());


### PR DESCRIPTION
See comments on #14148

When I added the extra range to `active_object_send_range_blocks` a while back the intention was to keep active objects that were already seen on loaded blocks in sight.

When looking at #14148 I noticed that all of these blocks are placed on the emerge queue. This is neither intended nor desired.
In particular it lead to the same blocks being enqueue over and over again if they have not been generated, yet.

Most folks do not set `active_object_send_range_blocks` and so won't be affected by the problem.

- Goal of the PR
Do not emerge that only on the `active_object_send_range_blocks` range. Activate them when existing, ignore them otherwise.

- How does the PR work?
This these blocks in a separate list. Blocks in the `active_block_range` are emerged as before, but extra blocks in the `active_object_send_range_blocks` view cone are only activate when they exists and not emerged otherwise.

- Does it resolve any reported issue?
No. But it reduces load on the emerge threads and DB if `active_object_send_range_blocks` is set to larg'ish value.

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?

- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is Ready for Review.

## How to test

Set `active_object_send_range_blocks` larger than `active_block_range`. Observe that visible any entities out of `active_block_range` but sight in closer than `active_object_send_range_blocks` are still visible (as long as their block is visible).
