### PR TITLE
Batched rendering of particles

### DIFF
--- a/src/tileanimation.h
+++ b/src/tileanimation.h
@@ -31,7 +31,7 @@ enum TileAnimationType
 
 struct TileAnimationParams
 {
-	enum TileAnimationType type;
+	enum TileAnimationType type = TileAnimationType::TAT_NONE;
 	union
 	{
 		// struct {


### PR DESCRIPTION
I would like to preface this PR adoption with: x2048 is cool.

Original PR: https://github.com/minetest/minetest/pull/13834

Improves performance by rendering particles with the same texture as a single mesh buffer. Possibly resolves #1414

Puts limits on how many particles can be drawn:
 
    * 16K particles per texture.

    * 64K particles in total.

    * Within 200 nodes from the local player.


Example results: AMD Renoir 34K particles on the screen 13 FPS on master 45 FPS on the branch.
## To do

This PR is Ready for Review.
## How to test

Minimal test:

    1. Launch dev test

    2. Get particle spawner

    3. Spawn particles around and watch them animate and disappear. No glitches.


Example code for performance test:

```
local nodes = {}
local players = {}

local torch_colors = {
	"#0F0000",
	"#0F0800",
	"#080F00",
	"#080F00",
	"#000808"
}


minetest.register_abm({
	nodenames = { "default:torch" },
	interval = 1,
	chance = 1,
	catch_up = false,
	action = function(pos, node)
		local meta = minetest.get_meta(pos)
		local color = meta:get("colored_torch:color")
		if color == nil then
			color = torch_colors[math.floor(math.random() * #torch_colors) + 1]
			meta:set_string("colored_torch:color", color)
		end
		minetest.add_particlespawner({
			pos = { min = vector.add(pos, vector.new(-0.2, 0.35, -0.2)), max = vector.add(pos, vector.new(0.2, 0.45, 0.2)) },
			vel = { min = vector.new(-2, 7, -2), max = vector.new( 2, 5, 2) },
			acc = { min = vector.new(0, -6, 0), max = vector.new(0, -5, 0) },
			time = 1,
			amount = 160,
			exptime = 6,
			collisiondetection = false,
			collision_removal = false,
			glow = 14,
			texpool = {
				{ name = "flame_spark.png^[multiply:"..color, blend = "screen", scale = 3 },
			}
		})
	end
})
```
