### PR TITLE
Fix GameUI text staying visible during shutdown

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1673,6 +1673,10 @@ bool Client::getChatMessage(std::wstring &res)
 	m_chat_queue.pop();
 
 	res = L"";
+	//Save messages in debug.txt
+	std::wstring msg;
+	msg = L"Client: CHAT:"+chatMessage->message;
+	actionstream<<wide_to_utf8(msg)<<std::endl;
 
 	switch (chatMessage->type) {
 		case CHATMESSAGE_TYPE_RAW:

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1673,10 +1673,6 @@ bool Client::getChatMessage(std::wstring &res)
 	m_chat_queue.pop();
 
 	res = L"";
-	//Save messages in debug.txt
-	std::wstring msg;
-	msg = L"Client: CHAT:"+chatMessage->message;
-	actionstream<<wide_to_utf8(msg)<<std::endl;
 
 	switch (chatMessage->type) {
 		case CHATMESSAGE_TYPE_RAW:

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4182,6 +4182,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		runData.damage_flash -= 384.0f * dtime;
 	}
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 =======
 		s32 chat_y = screensize.Y - 130;
@@ -4189,6 +4190,10 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		driver->draw2DRectangle(color, 
 					core::rect<s32>(10, chat_y, screensize.X - 20, 0),
 					NULL);
+=======
+	
+	
+>>>>>>> 3a84b9472 (Fix game.cpp)
 	/*
 		==================== End scene ====================
 	*/

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1332,7 +1332,10 @@ void Game::shutdown()
 	auto formspec = m_game_ui->getFormspecGUI();
 	if (formspec)
 		formspec->quitMenu();
-	m_game_ui->Clear();
+		
+	// Clear text when leaving.
+	m_game_ui->clearText();
+	
 #ifdef HAVE_TOUCHSCREENGUI
 	g_touchscreengui->hide();
 #endif

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4181,19 +4181,9 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	if (runData.damage_flash > 0.0f) {
 		runData.damage_flash -= 384.0f * dtime;
 	}
-<<<<<<< HEAD
-<<<<<<< HEAD
 
-=======
-		s32 chat_y = screensize.Y - 130;
-		video::SColor color(200, 200, 0, 0);
-		driver->draw2DRectangle(color, 
-					core::rect<s32>(10, chat_y, screensize.X - 20, 0),
-					NULL);
-=======
-	
-	
->>>>>>> 3a84b9472 (Fix game.cpp)
+
+
 	/*
 		==================== End scene ====================
 	*/

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4192,7 +4192,6 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 
 	stats->drawtime = tt_draw.stop(true);
 	g_profiler->graphAdd("Draw scene [us]", stats->drawtime);
->>>>>>> 1fc712969 (Fix bug)
 	g_profiler->avg("Game::updateFrame(): update frame [ms]", tt_update.stop(true));
 }
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1332,7 +1332,7 @@ void Game::shutdown()
 	auto formspec = m_game_ui->getFormspecGUI();
 	if (formspec)
 		formspec->quitMenu();
-
+	m_game_ui->Clear();
 #ifdef HAVE_TOUCHSCREENGUI
 	g_touchscreengui->hide();
 #endif

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4181,7 +4181,23 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	if (runData.damage_flash > 0.0f) {
 		runData.damage_flash -= 384.0f * dtime;
 	}
+<<<<<<< HEAD
 
+=======
+		s32 chat_y = screensize.Y - 130;
+		video::SColor color(200, 200, 0, 0);
+		driver->draw2DRectangle(color, 
+					core::rect<s32>(10, chat_y, screensize.X - 20, 0),
+					NULL);
+	/*
+		==================== End scene ====================
+	*/
+
+	driver->endScene();
+
+	stats->drawtime = tt_draw.stop(true);
+	g_profiler->graphAdd("Draw scene [us]", stats->drawtime);
+>>>>>>> 1fc712969 (Fix bug)
 	g_profiler->avg("Game::updateFrame(): update frame [ms]", tt_update.stop(true));
 }
 

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -334,3 +334,15 @@ void GameUI::deleteFormspec()
 
 	m_formname.clear();
 }
+void GameUI::Clear()
+{
+	
+	if(m_guitext_chat)
+	{
+		m_guitext_chat->setText(L"");
+	}
+	if(m_guitext)
+	{
+		m_guitext->setText(L"");
+	}
+}

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -338,21 +338,28 @@ void GameUI::deleteFormspec()
 
 void GameUI::clearText()
 {
-	if (m_guitext_chat)
-		m_guitext_chat->setText(L"");
-	
-	if (m_guitext)
-		m_guitext->setText(L"");
-		
-	if (m_guitext2)
-		m_guitext2->setText(L"");
-	
-	if (m_guitext_info)
-		m_guitext_info->setText(L"");
-		
-	if (m_guitext_status)
-		m_guitext_status->setText(L"");
-		
-	if(m_guitext_profiler)
-		m_guitext_profiler->setText(L"");
+	if (m_guitext_chat) {
+		m_guitext_chat->remove();
+		m_guitext_chat = nullptr;
+	}
+	if (m_guitext) {
+		m_guitext->remove();
+		m_guitext = nullptr;
+	}
+	if (m_guitext2) {
+		m_guitext2->remove();
+		m_guitext2 = nullptr;
+	}
+	if (m_guitext_info) {
+		m_guitext_info->remove();
+		m_guitext_info = nullptr;
+	}
+	if (m_guitext_status) {
+		m_guitext_status->remove();
+		m_guitext_status = nullptr;
+	}	
+	if (m_guitext_profiler) {
+		m_guitext_profiler->remove();
+		m_guitext_profiler = nullptr;
+	}
 }

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -343,4 +343,16 @@ void GameUI::clearText()
 	
 	if (m_guitext)
 		m_guitext->setText(L"");
+		
+	if (m_guitext2)
+		m_guitext2->setText(L"");
+	
+	if (m_guitext_info)
+		m_guitext_info->setText(L"");
+		
+	if (m_guitext_status)
+		m_guitext_status->setText(L"");
+		
+	if(m_guitext_profiler)
+		m_guitext_profiler->setText(L"");
 }

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -334,15 +334,13 @@ void GameUI::deleteFormspec()
 
 	m_formname.clear();
 }
-void GameUI::Clear()
+
+
+void GameUI::clearText()
 {
-	
-	if(m_guitext_chat)
-	{
+	if (m_guitext_chat)
 		m_guitext_chat->setText(L"");
-	}
-	if(m_guitext)
-	{
+	
+	if (m_guitext)
 		m_guitext->setText(L"");
-	}
 }

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -106,7 +106,7 @@ public:
 	const std::string &getFormspecName() { return m_formname; }
 	GUIFormSpecMenu *&getFormspecGUI() { return m_formspec; }
 	void deleteFormspec();
-
+	void Clear();
 private:
 	Flags m_flags;
 

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -106,7 +106,8 @@ public:
 	const std::string &getFormspecName() { return m_formname; }
 	GUIFormSpecMenu *&getFormspecGUI() { return m_formspec; }
 	void deleteFormspec();
-	void Clear();
+	void clearText();
+	
 private:
 	Flags m_flags;
 


### PR DESCRIPTION
Hello! 
I fixed the bug. This bug is that when you exit the game you see text from the chat or from the debug menu. 
![image](https://github.com/minetest/minetest/assets/131448485/53533f67-4132-45e7-8495-6bbbc79cc049)
(Screenshot was taken from my client, sorry)
I added function to save chat in the debug.txt. 
I think this function will help moderators  if they forgot make screenshot where shows violation in chat.  
(I make PR second time, so i noob in it)