### PR TITLE
Make the loading screen progress bar respect "gui_scaling"

### DIFF
--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -249,8 +249,10 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 #ifndef __ANDROID__
 			const core::dimension2d<u32> &img_size =
 					progress_img_bg->getSize();
-			u32 imgW = rangelim(img_size.Width, 200, 600) * getDisplayDensity();
-			u32 imgH = rangelim(img_size.Height, 24, 72) * getDisplayDensity();
+			float density = g_settings->getFloat("gui_scaling", 0.5f, 20.0f) *
+					getDisplayDensity();
+			u32 imgW = rangelim(img_size.Width, 200, 600) * density;
+			u32 imgH = rangelim(img_size.Height, 24, 72) * density;
 #else
 			const core::dimension2d<u32> img_size(256, 48);
 			float imgRatio = (float)img_size.Height / img_size.Width;


### PR DESCRIPTION
Since #13055, the progress bar on the loading screen takes the display density into account. However, it doesn't respect "gui_scaling", so it still looks wrong with high "gui_scaling" values.

**`gui_scaling = 3` before this PR**

![screenshot before](https://github.com/minetest/minetest/assets/82708541/c8d447b5-68b6-4a0e-96fd-193e7cb41238)

**`gui_scaling = 3` after this PR**

![screenshot after](https://github.com/minetest/minetest/assets/82708541/3f1d5357-d712-4198-b724-6a0d94421b13)

## To do

This PR is a Ready for Review.

## How to test

Start a game and see the progress bar on the loading screen. Set different `gui_scaling` values and verify that it always looks correct.