### PR TITLE
Allow controlling formspec closeability

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2708,6 +2708,12 @@ Elements
   (if present).
 * Disables player:set_formspec_prepend() from applying to this formspec.
 
+### `allow_quit[<bool>]`
+
+* Controls whether players can quit the formspec (e.g. by pressing ESC).
+* Players can still quit the formspec using exit buttons.
+* `minetest.close_formspec` will still work.
+
 ### `real_coordinates[<bool>]`
 
 * INFORMATION: Enable it automatically using `formspec_version` version 2 or newer.

--- a/games/devtest/mods/testentities/bone_overrides.lua
+++ b/games/devtest/mods/testentities/bone_overrides.lua
@@ -1,0 +1,34 @@
+local lastdir = {}
+
+minetest.register_globalstep(function(dtime)
+	for _, player in pairs(minetest.get_connected_players()) do
+		local pname = player:get_player_name()
+		local ldeg = -math.deg(player:get_look_vertical())
+		if lastdir[pname] == nil then
+			lastdir[pname] = 0
+		end
+		if lastdir[pname] then
+			if math.abs(lastdir[pname] - ldeg) > 4 then
+				lastdir[pname] = ldeg
+				player:set_bone_override("Head", {rotation = {vector = {x = ldeg, y = 0, z = 0}, absolute = true },
+				scale = {vector = { x = 1.5, y = 1.5, z = 1.5 }}})
+			end
+		end
+	end
+end)
+
+minetest.register_on_leaveplayer(function(player)
+	lastdir[player:get_player_name()] = nil
+end)
+
+minetest.register_chatcommand("headanim", {
+	func = function(name)
+		local player = assert(minetest.get_player_by_name(name))
+		if lastdir[name] then
+			lastdir[name] = false -- don't update Head in globalstep
+			player:set_bone_override"Head" -- clear override
+		else
+			lastdir[name] = 0
+		end
+	end
+})

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -464,6 +464,17 @@ mouse control = true]
 			background9[0,0;0,0;testformspec_bg_9slice.png;true;4,6]
 			background[1,1;0,0;testformspec_bg.png;true]
 		]],
+
+	-- Allow Close
+		[[
+			formspec_version[3]
+			size[12,4]
+			allow_quit[false]
+			button_exit[0.5,0.5;3,1;exitbtn;Exit (Button)]
+			button[0.5,2;3,1;exitapi;Exit (close_formspec)]
+			label[4,1;You should only be able to quit this formspec
+by clicking one of these buttons (or switching to another tab).]
+		]]
 }
 
 local page_id = 2
@@ -473,7 +484,7 @@ local function show_test_formspec(pname)
 		page = page()
 	end
 
-	local fs = page .. "tabheader[0,0;11,0.65;maintabs;Real Coord,Styles,Noclip,Hypertext,Tabs,Invs,Window,Anim,Model,ScrollC,Sound,Background,Unsized;" .. page_id .. ";false;false]"
+	local fs = page .. "tabheader[0,0;11,0.65;maintabs;Real Coord,Styles,Noclip,Hypertext,Tabs,Invs,Window,Anim,Model,ScrollC,Sound,Background,Unsized,Allow Close;" .. page_id .. ";false;false]"
 
 	minetest.show_formspec(pname, "testformspec:formspec", fs)
 end
@@ -520,6 +531,11 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 
 	if fields.submit_window then
 		show_test_formspec(player:get_player_name())
+	end
+
+	if fields.exitapi then
+		minetest.close_formspec(player:get_player_name(), "testformspec:formspec")
+		return true
 	end
 end)
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -176,7 +176,7 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 			"",
 			false);
 
-	m_menu->allowClose(false);
+	m_menu->setAllowCloseDefault(false);
 	m_menu->lockSize(true,v2u32(800,600));
 
 	// Initialize scripting

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3049,6 +3049,10 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 		return;
 	}
 
+	if (type == "allow_quit") {
+		data->allowclose = is_yes(description);
+	}
+
 	// Ignore others
 	infostream << "Unknown DrawSpec: type=" << type << ", data=\"" << description << "\""
 			<< std::endl;
@@ -3098,6 +3102,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	mydata.anchor = v2f32(0.5f, 0.5f);
 	mydata.padding = v2f32(0.05f, 0.05f);
 	mydata.simple_field_count = 0;
+	mydata.allowclose = m_allowclose_default;
 
 	// Base position of contents of form
 	mydata.basepos = getBasePos();
@@ -3457,6 +3462,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		m_last_formname = m_text_dst->m_formname;
 		m_is_form_regenerated = true;
 	}
+
+	m_allowclose = mydata.allowclose;
 }
 
 void GUIFormSpecMenu::legacySortElements(std::list<IGUIElement *>::iterator from)
@@ -4967,12 +4974,8 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 					s.send = true;
 					if (s.is_exit) {
-						if (m_allowclose) {
-							acceptInput(quit_mode_accept);
-							quitMenu();
-						} else {
-							m_text_dst->gotText(L"ExitButton");
-						}
+						acceptInput(quit_mode_accept);
+						quitMenu();
 						return true;
 					}
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -216,9 +216,9 @@ public:
 		m_text_dst = text_dst;
 	}
 
-	void allowClose(bool value)
+	void setAllowCloseDefault(bool value)
 	{
-		m_allowclose = value;
+		m_allowclose_default = value;
 	}
 
 	void lockSize(bool lock,v2u32 basescreensize=v2u32(0,0))
@@ -366,7 +366,8 @@ protected:
 	u64 m_hovered_time = 0;
 	s32 m_old_tooltip_id = -1;
 
-	bool m_allowclose = true;
+	bool m_allowclose_default = true;
+	bool m_allowclose;
 	bool m_lock = false;
 	v2u32 m_lockscreensize;
 
@@ -389,6 +390,7 @@ private:
 	struct parserData {
 		bool explicit_size;
 		bool real_coordinates;
+		bool allowclose;
 		u8 simple_field_count;
 		v2f invsize;
 		v2s32 size;


### PR DESCRIPTION
- Goal of the PR: Allow marking formspecs as "not closeable" using `allow_quit[false]`.
- How does the PR work?
  * Adds a new `allow_quit[<bool>]` formspec element. For simplicity, this element does not have to appear in a specific position.
  * Since main menu formspecs are "closeable" by default, a new field for the default of `m_allowclose` is needed.
  * Exit buttons are changed to *always exit*, disregarding `m_allowclose`. I've verified that our main menu code does use exit buttons (grepped).
- Does it resolve any reported issue? Closes #10380

## To Do

- [ ] Don't make mainmenu inaccessible

## How to test

* Verify that main menu is still "not closeable".
* Verify that regular formspecs are "closeable" by default.
* Do `/test_formspec`, switch to the "Allow Quit" tab. Verify that you can only close the formspec using the buttons.