### PR TITLE
Avoid short overflow with large viewing ranges

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -228,7 +228,8 @@ void RemoteClient::GetNextBlocks (
 		wanted_range);
 	const s16 d_cull_opt = std::min(adjustDist(m_block_cull_optimize_distance, prop_zoom_fov),
 		wanted_range);
-	const s16 d_blocks_in_sight = full_d_max * BS * MAP_BLOCKSIZE;
+	// f32 to prevent overflow, it is also what isBlockInSight(...) expects
+	const f32 d_blocks_in_sight = full_d_max * BS * MAP_BLOCKSIZE;
 
 	s16 d_max_gen = std::min(adjustDist(m_max_gen_distance, prop_zoom_fov),
 		wanted_range);


### PR DESCRIPTION
I noticed that with a large viewing_range (like 1500) zooming would just stop loading any blocks. The zoom range is then 3616.

I tracked it down to an overflow in d_blocks_in_sight in clientiface. An s16 that is calculated as wanted_range (in blocks) times BS times blocksize. Hence 32767/10/16 or 240 blocks or 3276 nodes would be the largest working range, which is less than our supported 4000.

d_blocks_in_sight is later uses as an f32 (see arguments to isBlockInSight, and so the trivial fix is to just change the type to f32 right away. I do not think any fancy rounding is needed.

- Goal of the PR
Allow viewing range (mostly zoom) past 3276

- How does the PR work?
See description above

- Does it resolve any reported issue?
Nope. But I could an issue :)

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
Nope.

- If not a bug fix, why is this PR needed? What usecases does it solve?
See description

## To do

This PR is Ready for Review.

## How to test

Set viewing_range to 1500, now zoom. Notice that blocks are still loaded (without this PR loading would stop completely as d_blocks_in_sight would turn negative)