### PR TITLE
Allow game to specify first and last mod in mod loading order. 

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -63,6 +63,8 @@ The game directory can contain the following files:
     * `name`: (Deprecated) same as title.
     * `description`: Short description to be shown in the content tab.
       See [Translating content meta](#translating-content-meta).
+    * `first_mod`: Use this to specify the mod that must be loaded before any other mod.
+    * `last_mod`: Use this to specify the mod that must be loaded after all other mods
     * `allowed_mapgens = <comma-separated mapgens>`
       e.g. `allowed_mapgens = v5,v6,flat`
       Mapgens not in this list are removed from the list of mapgens for the

--- a/games/devtest/game.conf
+++ b/games/devtest/game.conf
@@ -1,2 +1,4 @@
 title = Development Test
 description = Testing environment to help with testing the engine features of Minetest. It can also be helpful in mod development.
+first_mod = first_mod
+last_mod = last_mod

--- a/games/devtest/mods/first_mod/init.lua
+++ b/games/devtest/mods/first_mod/init.lua
@@ -1,0 +1,1 @@
+-- Nothing to do here, loading order is tested in C++ unittests.

--- a/games/devtest/mods/first_mod/mod.conf
+++ b/games/devtest/mods/first_mod/mod.conf
@@ -1,0 +1,2 @@
+name = first_mod
+description = Mod which should be loaded before every other mod.

--- a/games/devtest/mods/last_mod/init.lua
+++ b/games/devtest/mods/last_mod/init.lua
@@ -1,0 +1,1 @@
+-- Nothing to do here, loading order is tested in C++ unittests.

--- a/games/devtest/mods/last_mod/mod.conf
+++ b/games/devtest/mods/last_mod/mod.conf
@@ -1,0 +1,2 @@
+name = last_mod
+description = Mod which should be loaded as last mod.

--- a/games/devtest/mods/last_mod/mod.conf
+++ b/games/devtest/mods/last_mod/mod.conf
@@ -1,2 +1,5 @@
 name = last_mod
 description = Mod which should be loaded as last mod.
+# Test dependencies
+optional_depends = unittests
+depends = first_mod

--- a/games/devtest/mods/unittests/mod.conf
+++ b/games/devtest/mods/unittests/mod.conf
@@ -1,3 +1,4 @@
 name = unittests
 description = Adds automated unit tests for the engine
-depends = basenodes
+# Also test that it is possible to depend on first_mod
+depends = first_mod, basenodes

--- a/src/content/mod_configuration.cpp
+++ b/src/content/mod_configuration.cpp
@@ -228,9 +228,9 @@ void ModConfiguration::resolveDependencies()
 	std::set<std::string> modnames;
 	std::optional<ModSpec> first_mod_spec, last_mod_spec;
 	for (ModSpec &mod : m_unsatisfied_mods) {
-		if (m_first_mod.has_value() && mod.name == *m_first_mod) {
+		if (mod.name == m_first_mod) {
 			first_mod_spec = mod;
-		} else if (m_last_mod.has_value() && mod.name == *m_last_mod) {
+		} else if (mod.name == m_last_mod) {
 			// only non optional depends have to be check for last mod
 			mod.unsatisfied_depends = mod.depends;
 			last_mod_spec = mod;
@@ -249,9 +249,9 @@ void ModConfiguration::resolveDependencies()
 	}
 
 	// Check for presence of first and last mod
-	if (m_first_mod.has_value() && !first_mod_spec.has_value())
+	if (!m_first_mod.empty() && !first_mod_spec.has_value())
 		throw ModError("The mod specified as first by the game was not found.");
-	if (m_last_mod.has_value() && !last_mod_spec.has_value())
+	if (!m_last_mod.empty() && !last_mod_spec.has_value())
 		throw ModError("The mod specified as last by the game was not found.");
 
 	// Get dependencies (including optional dependencies)

--- a/src/content/mod_configuration.cpp
+++ b/src/content/mod_configuration.cpp
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gettext.h"
 #include "exceptions.h"
 #include "util/numeric.h"
-
+#include <optional>
 
 std::string ModConfiguration::getUnsatisfiedModsError() const
 {
@@ -266,7 +266,7 @@ void ModConfiguration::resolveDependencies()
 				mod.unsatisfied_depends.insert(optdep);
 		}
 		if (last_mod_spec.has_value() && mod.unsatisfied_depends.count(last_mod_spec->name) != 0) {
-			throw ModError("It is not allowed to have mod selected as last by the game in dependencies.");
+			throw ModError("Impossible to depend on the mod specified by last_mod");
 		}
 		// if a mod has no depends it is initially satisfied
 		if (mod.unsatisfied_depends.empty()) {
@@ -280,7 +280,7 @@ void ModConfiguration::resolveDependencies()
 	if (first_mod_spec.has_value()) {
 		// dependencies are not allowed for first mod
 		if (!first_mod_spec->depends.empty() || !first_mod_spec->optdepends.empty())
-			throw ModError("Mod selected as first by the game is not allowed to have dependencies.");
+			throw ModError("Mod specified by first_mod cannot have dependencies");
 
 		satisfied.push_back(*first_mod_spec);
 	}

--- a/src/content/mod_configuration.h
+++ b/src/content/mod_configuration.h
@@ -83,10 +83,16 @@ public:
 
 	/**
 	 * Call this function once all mods have been added
+	 *
+	 * @param first_mod First mod to be loaded
+	 * @param last_mod Last mod to be loaded
 	 */
 	void checkConflictsAndDeps();
 
 private:
+	std::string m_first_mod;
+	std::string m_last_mod;
+
 	std::vector<ModSpec> m_sorted_mods;
 
 	/**

--- a/src/content/mod_configuration.h
+++ b/src/content/mod_configuration.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "mods.h"
+#include <optional>
 
 
 /**
@@ -90,8 +91,8 @@ public:
 	void checkConflictsAndDeps();
 
 private:
-	std::string m_first_mod;
-	std::string m_last_mod;
+	std::optional<std::string> m_first_mod;
+	std::optional<std::string> m_last_mod;
 
 	std::vector<ModSpec> m_sorted_mods;
 

--- a/src/content/mod_configuration.h
+++ b/src/content/mod_configuration.h
@@ -20,7 +20,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "mods.h"
-#include <optional>
 
 
 /**

--- a/src/content/mod_configuration.h
+++ b/src/content/mod_configuration.h
@@ -84,15 +84,12 @@ public:
 
 	/**
 	 * Call this function once all mods have been added
-	 *
-	 * @param first_mod First mod to be loaded
-	 * @param last_mod Last mod to be loaded
 	 */
 	void checkConflictsAndDeps();
 
 private:
-	std::optional<std::string> m_first_mod;
-	std::optional<std::string> m_last_mod;
+	std::string m_first_mod; // "" <=> no mod
+	std::string m_last_mod; // "" <=> no mod
 
 	std::vector<ModSpec> m_sorted_mods;
 

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -94,6 +94,50 @@ std::string getSubgamePathEnv()
 	return "";
 }
 
+static SubgameSpec getSubgameSpec(const std::string &game_id,
+		const std::string &game_path,
+		const std::unordered_map<std::string, std::string> &mods_paths,
+		const std::string &menuicon_path)
+{
+	const auto gamemods_path = game_path + DIR_DELIM + "mods";
+	// Get meta
+	const std::string conf_path = game_path + DIR_DELIM + "game.conf";
+	Settings conf;
+	conf.readConfigFile(conf_path.c_str());
+
+	std::string game_title;
+	if (conf.exists("title"))
+		game_title = conf.get("title");
+	else if (conf.exists("name"))
+		game_title = conf.get("name");
+	else
+		game_title = game_id;
+
+	std::string game_author;
+	if (conf.exists("author"))
+		game_author = conf.get("author");
+
+	int game_release = 0;
+	if (conf.exists("release"))
+		game_release = conf.getS32("release");
+
+	std::string first_mod;
+	if (conf.exists("first_mod"))
+		first_mod = conf.get("first_mod");
+
+	std::string last_mod;
+	if (conf.exists("last_mod"))
+		last_mod = conf.get("last_mod");
+
+	SubgameSpec spec(game_id, game_path, gamemods_path, mods_paths, game_title,
+			menuicon_path, game_author, game_release, first_mod, last_mod);
+
+	if (conf.exists("name") && !conf.exists("title"))
+		spec.deprecation_msgs.push_back("\"name\" setting in game.conf is deprecated, please use \"title\" instead");
+
+	return spec;
+}
+
 SubgameSpec findSubgame(const std::string &id)
 {
 	if (id.empty())
@@ -137,8 +181,6 @@ SubgameSpec findSubgame(const std::string &id)
 	if (game_path.empty())
 		return SubgameSpec();
 
-	std::string gamemod_path = game_path + DIR_DELIM + "mods";
-
 	// Find mod directories
 	std::unordered_map<std::string, std::string> mods_paths;
 	mods_paths["mods"] = user + DIR_DELIM + "mods";
@@ -149,48 +191,13 @@ SubgameSpec findSubgame(const std::string &id)
 		mods_paths[fs::AbsolutePath(mod_path)] = mod_path;
 	}
 
-	// Get meta
-	std::string conf_path = game_path + DIR_DELIM + "game.conf";
-	Settings conf;
-	conf.readConfigFile(conf_path.c_str());
-
-	std::string game_title;
-	if (conf.exists("title"))
-		game_title = conf.get("title");
-	else if (conf.exists("name"))
-		game_title = conf.get("name");
-	else
-		game_title = id;
-
-	std::string game_author;
-	if (conf.exists("author"))
-		game_author = conf.get("author");
-
-	int game_release = 0;
-	if (conf.exists("release"))
-		game_release = conf.getS32("release");
-
-	std::string first_mod;
-	if (conf.exists("first_mod"))
-		first_mod = conf.get("first_mod");
-
-	std::string last_mod;
-	if (conf.exists("last_mod"))
-		last_mod = conf.get("last_mod");
-
 	std::string menuicon_path;
 #ifndef SERVER
 	menuicon_path = getImagePath(
 			game_path + DIR_DELIM + "menu" + DIR_DELIM + "icon.png");
 #endif
 
-	SubgameSpec spec(id, game_path, gamemod_path, mods_paths, game_title,
-			menuicon_path, game_author, game_release, first_mod, last_mod);
-
-	if (conf.exists("name") && !conf.exists("title"))
-		spec.deprecation_msgs.push_back("\"name\" setting in game.conf is deprecated, please use \"title\" instead");
-
-	return spec;
+	return getSubgameSpec(id, game_path, mods_paths, menuicon_path);
 }
 
 SubgameSpec findWorldSubgame(const std::string &world_path)
@@ -198,25 +205,8 @@ SubgameSpec findWorldSubgame(const std::string &world_path)
 	std::string world_gameid = getWorldGameId(world_path, true);
 	// See if world contains an embedded game; if so, use it.
 	std::string world_gamepath = world_path + DIR_DELIM + "game";
-	if (fs::PathExists(world_gamepath)) {
-		SubgameSpec gamespec;
-		gamespec.id = world_gameid;
-		gamespec.path = world_gamepath;
-		gamespec.gamemods_path = world_gamepath + DIR_DELIM + "mods";
-
-		Settings conf;
-		std::string conf_path = world_gamepath + DIR_DELIM + "game.conf";
-		conf.readConfigFile(conf_path.c_str());
-
-		if (conf.exists("title"))
-			gamespec.title = conf.get("title");
-		else if (conf.exists("name"))
-			gamespec.title = conf.get("name");
-		else
-			gamespec.title = world_gameid;
-
-		return gamespec;
-	}
+	if (fs::PathExists(world_gamepath))
+		return getSubgameSpec(world_gameid, world_gamepath, {}, "");
 	return findSubgame(world_gameid);
 }
 

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -170,13 +170,19 @@ SubgameSpec findSubgame(const std::string &id)
 	if (conf.exists("release"))
 		game_release = conf.getS32("release");
 
-	std::string first_mod;
-	if (conf.exists("first_mod"))
+	std::optional<std::string> first_mod;
+	if (conf.exists("first_mod")) {
 		first_mod = conf.get("first_mod");
+		if (first_mod->empty())
+			first_mod = std::nullopt;
+	}
 
-	std::string last_mod;
-	if (conf.exists("last_mod"))
+	std::optional<std::string> last_mod;
+	if (conf.exists("last_mod")) {
 		last_mod = conf.get("last_mod");
+		if (last_mod->empty())
+			last_mod = std::nullopt;
+	}
 
 	std::string menuicon_path;
 #ifndef SERVER

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -170,19 +170,13 @@ SubgameSpec findSubgame(const std::string &id)
 	if (conf.exists("release"))
 		game_release = conf.getS32("release");
 
-	std::optional<std::string> first_mod;
-	if (conf.exists("first_mod")) {
+	std::string first_mod;
+	if (conf.exists("first_mod"))
 		first_mod = conf.get("first_mod");
-		if (first_mod->empty())
-			first_mod = std::nullopt;
-	}
 
-	std::optional<std::string> last_mod;
-	if (conf.exists("last_mod")) {
+	std::string last_mod;
+	if (conf.exists("last_mod"))
 		last_mod = conf.get("last_mod");
-		if (last_mod->empty())
-			last_mod = std::nullopt;
-	}
 
 	std::string menuicon_path;
 #ifndef SERVER

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -170,6 +170,14 @@ SubgameSpec findSubgame(const std::string &id)
 	if (conf.exists("release"))
 		game_release = conf.getS32("release");
 
+	std::string first_mod;
+	if (conf.exists("first_mod"))
+		first_mod = conf.get("first_mod");
+
+	std::string last_mod;
+	if (conf.exists("last_mod"))
+		last_mod = conf.get("last_mod");
+
 	std::string menuicon_path;
 #ifndef SERVER
 	menuicon_path = getImagePath(
@@ -177,7 +185,7 @@ SubgameSpec findSubgame(const std::string &id)
 #endif
 
 	SubgameSpec spec(id, game_path, gamemod_path, mods_paths, game_title,
-			menuicon_path, game_author, game_release);
+			menuicon_path, game_author, game_release, first_mod, last_mod);
 
 	if (conf.exists("name") && !conf.exists("title"))
 		spec.deprecation_msgs.push_back("\"name\" setting in game.conf is deprecated, please use \"title\" instead");

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -33,8 +33,8 @@ struct SubgameSpec
 	std::string title;
 	std::string author;
 	int release;
-	std::optional<std::string> first_mod;
-	std::optional<std::string> last_mod;
+	std::string first_mod; // "" <=> no mod
+	std::string last_mod; // "" <=> no mod
 	std::string path;
 	std::string gamemods_path;
 
@@ -53,8 +53,8 @@ struct SubgameSpec
 			const std::string &title = "",
 			const std::string &menuicon_path = "",
 			const std::string &author = "", int release = 0,
-			const std::optional<std::string> &first_mod = std::nullopt,
-			const std::optional<std::string> &last_mod = std::nullopt) :
+			const std::string &first_mod = "",
+			const std::string &last_mod = "") :
 			id(id),
 			title(title), author(author), release(release),
 			first_mod(first_mod),

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -23,7 +23,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <set>
 #include <unordered_map>
 #include <vector>
-#include <optional>
 
 class Settings;
 

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <set>
 #include <unordered_map>
 #include <vector>
+#include <optional>
 
 class Settings;
 
@@ -32,8 +33,8 @@ struct SubgameSpec
 	std::string title;
 	std::string author;
 	int release;
-	std::string first_mod;
-	std::string last_mod;
+	std::optional<std::string> first_mod;
+	std::optional<std::string> last_mod;
 	std::string path;
 	std::string gamemods_path;
 
@@ -52,11 +53,15 @@ struct SubgameSpec
 			const std::string &title = "",
 			const std::string &menuicon_path = "",
 			const std::string &author = "", int release = 0,
-			const std::string &first_mod = "", const std::string &last_mod = "") :
+			const std::optional<std::string> &first_mod = std::nullopt,
+			const std::optional<std::string> &last_mod = std::nullopt) :
 			id(id),
 			title(title), author(author), release(release),
-			first_mod(first_mod), last_mod(last_mod), path(path),
-			gamemods_path(gamemods_path), addon_mods_paths(addon_mods_paths),
+			first_mod(first_mod),
+			last_mod(last_mod),
+			path(path),
+			gamemods_path(gamemods_path),
+			addon_mods_paths(addon_mods_paths),
 			menuicon_path(menuicon_path)
 	{
 	}

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -32,6 +32,8 @@ struct SubgameSpec
 	std::string title;
 	std::string author;
 	int release;
+	std::string first_mod;
+	std::string last_mod;
 	std::string path;
 	std::string gamemods_path;
 
@@ -49,9 +51,11 @@ struct SubgameSpec
 			const std::unordered_map<std::string, std::string> &addon_mods_paths = {},
 			const std::string &title = "",
 			const std::string &menuicon_path = "",
-			const std::string &author = "", int release = 0) :
+			const std::string &author = "", int release = 0,
+			const std::string &first_mod = "", const std::string &last_mod = "") :
 			id(id),
-			title(title), author(author), release(release), path(path),
+			title(title), author(author), release(release),
+			first_mod(first_mod), last_mod(last_mod), path(path),
 			gamemods_path(gamemods_path), addon_mods_paths(addon_mods_paths),
 			menuicon_path(menuicon_path)
 	{

--- a/src/unittest/test_servermodmanager.cpp
+++ b/src/unittest/test_servermodmanager.cpp
@@ -139,6 +139,9 @@ void TestServerModManager::testGetMods()
 
 	UASSERTEQ(bool, default_found, true);
 	UASSERTEQ(bool, test_mod_found, true);
+
+	UASSERT(mods.front().name == "first_mod");
+	UASSERT(mods.back().name == "last_mod");
 }
 
 void TestServerModManager::testGetModspec()

--- a/src/unittest/test_servermodmanager.cpp
+++ b/src/unittest/test_servermodmanager.cpp
@@ -121,7 +121,8 @@ void TestServerModManager::testGetMods()
 {
 	ServerModManager sm(m_worlddir);
 	const auto &mods = sm.getMods();
-	UASSERTEQ(bool, mods.empty(), false);
+	// `ls ./games/devtest/mods | wc -l` + 1 (test mod)
+	UASSERTEQ(std::size_t, mods.size(), 31 + 1);
 
 	// Ensure we found basenodes mod (part of devtest)
 	// and test_mod (for testing MINETEST_MOD_PATH).


### PR DESCRIPTION
Allow games to do something at the beginning and end of the mod loading process.

- Allows game creators to do something before all other mods are loaded and after all other mods are loaded.
- Use added parameter lines `first_mod` and `last_mod` in `game.conf` to determine which mod has to be loaded first and which has to be loaded last.
- This should fix #8934.
- This should help with the solution of issue #13442.

## To do

This PR is Ready for Review.

- [x] Get feedback
- [x] Apply feedback
- [x] Add documentation to lua_doc.md

## How to test

Switch to this branch and load the devtest game.
In devtest `game.conf` lines `first_mod` and `last_mod` are added. There are added checks in every devtest mod and in `last_mod` mod to verify if the loading order is right.
