### PR TITLE
Fix AsyncRunStep() skipping steps when dtime < 1 ms

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -604,7 +604,8 @@ void Server::AsyncRunStep(float dtime, bool initial_step)
 		SendBlocks(dtime);
 	}
 
-	if ((dtime < 0.001f) && !initial_step)
+	// If paused, this function is called with a 0.0f literal
+	if ((dtime == 0.0f) && !initial_step)
 		return;
 
 	ScopeProfiler sp(g_profiler, "Server::AsyncRunStep()", SPT_AVG);


### PR DESCRIPTION
* Fixes #14181.
* `AsyncRunStep()` is only called from `ServerThread::run()`. The condition should be met if and only if `step_settings.pause` is true during a non-initial step.

## To do

This PR is a Ready for Review.

## How to test

* Use test code from #14181. (I suggest you also add a `core.log("foo")` in the if, to get a chat message when the bug triggers.)
* Set `fps_max` and `fps_max_unfocused` to 100000000
* Start a devtest world in singleplayer.
* (Starting a dedicated server with low `dedicated_server_step` might also work.)
* Try to minimize actual achieved dtime. E.g. set viewing range to 20.
* Watch for events described in #14181.