### PR TITLE
Replace clientmap's MeshBufListList with a hashmap

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -35,8 +35,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <queue>
 
 //FIXME: where should I move this to?
-// std::hash for integral types, including ptrs, is identity, which is bad for
-// aligned ptrs.
+// std::hash for integral types, including ptrs, is identity. This is bad for
+// aligned ptrs, because hashtables use modulo base bucket count on the hashcode
+// to get the bucket index.
 template <typename T>
 struct PtrHash
 {
@@ -81,8 +82,13 @@ namespace {
 			// Append to the correct layer
 			auto &map = maps[layer];
 			const video::SMaterial &m = buf->getMaterial();
+			size_t old_bucket_cnt = map.bucket_count();
 			auto &bufs = map[m]; // default constructs if non-existent
+			size_t bucket_cnt = map.bucket_count();
 			bufs.emplace_back(position, buf);
+			if (bucket_cnt != old_bucket_cnt) {
+				errorstream << "new bucket count: "<<bucket_cnt <<std::endl;
+			}
 		}
 	};
 }

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -34,36 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <queue>
 
-// struct MeshBufListList
-void MeshBufListList::clear()
-{
-	for (auto &list : lists)
-		list.clear();
-}
-
-void MeshBufListList::add(scene::IMeshBuffer *buf, v3s16 position, u8 layer)
-{
-	// Append to the correct layer
-	std::vector<MeshBufList> &list = lists[layer];
-	const video::SMaterial &m = buf->getMaterial();
-	for (MeshBufList &l : list) {
-		// comparing a full material is quite expensive so we don't do it if
-		// not even first texture is equal
-		if (l.m.TextureLayers[0].Texture != m.TextureLayers[0].Texture)
-			continue;
-
-		if (l.m == m) {
-			l.bufs.emplace_back(position, buf);
-			return;
-		}
-	}
-	MeshBufList l;
-	l.m = m;
-	l.bufs.emplace_back(position, buf);
-	list.emplace_back(l);
-}
-
-//TODO:move
+//FIXME: where should I move this to?
 // std::hash for integral types, including ptrs, is identity, which is bad for
 // aligned ptrs.
 template <typename T>
@@ -85,6 +56,7 @@ namespace {
 		{
 			size_t operator()(const video::SMaterial &m) const noexcept
 			{
+				// Only hash first texture. Simple and fast.
 				return PtrHash<video::ITexture>{}(m.TextureLayers[0].Texture);
 			}
 		};

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -76,6 +76,8 @@ namespace {
 
 		void add(scene::IMeshBuffer *buf, v3s16 position, u8 layer)
 		{
+			assert(layer < MAX_TILE_LAYERS);
+
 			// Append to the correct layer
 			auto &map = maps[layer];
 			const video::SMaterial &m = buf->getMaterial();

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -37,25 +37,6 @@ struct MapDrawControl
 	bool show_wireframe = false;
 };
 
-struct MeshBufList
-{
-	video::SMaterial m;
-	std::vector<std::pair<v3s16,scene::IMeshBuffer*>> bufs;
-};
-
-struct MeshBufListList
-{
-	/*!
-	 * Stores the mesh buffers of the world.
-	 * The array index is the material's layer.
-	 * The vector part groups vertices by material.
-	 */
-	std::vector<MeshBufList> lists[MAX_TILE_LAYERS];
-
-	void clear();
-	void add(scene::IMeshBuffer *buf, v3s16 position, u8 layer);
-};
-
 class Client;
 class ITextureSource;
 class PartialMeshBuffer;


### PR DESCRIPTION
* I once found out during profiling that `MeshBufListList::add` is a bottleneck.
  ~~(I sadly can't reproduce the profiling results right now, because I can't get hotspot to work again.)~~
* `MeshBufListList::add` has O(n) time where n is the number of unique materials in mapblocks in the scene. And it is called for each meshbuffer.
* This PR replaces it with a hashmap (see `MeshBufListMaps`).
* Can result in a drawtime reduction of 24%.

## To do

This PR is a Ready for Review.
~~TODO: Where should I put `PtrHash`?~~

## How to test

* Create a singlenode world with this mapgen mod: <https://codeberg.org/Desour/test_mapblock_drawcalls>
* Look towards the red-blue corner, with viewing range 200.
* Rejoin and wait until drawtime stabilizes. Do the same with the other branch.
* Results: master: fps 8 Hz, drawtime 112 ms; PR: fps 10 Hz, drawtime 85 ms (76%)
* Note: Real world results are probably less fruitful. But the fruit is hanging low.
* Edit: Also tried the spawn of a server: master: fps 19 Hz, drawtime 45 ms, PR 20 fps, 41 ms (91%)
