### PR TITLE
Allow active blocks to be generated

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1579,11 +1579,11 @@ MapBlock * ServerMap::emergeBlock(v3s16 p, bool create_blank)
 	return NULL;
 }
 
-MapBlock *ServerMap::getBlockOrEmerge(v3s16 p3d)
+MapBlock *ServerMap::getBlockOrEmerge(v3s16 p3d, bool generate)
 {
 	MapBlock *block = getBlockNoCreateNoEx(p3d);
 	if (block == NULL)
-		m_emerge->enqueueBlockEmerge(PEER_ID_INEXISTENT, p3d, true);
+		m_emerge->enqueueBlockEmerge(PEER_ID_INEXISTENT, p3d, generate);
 
 	return block;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1583,7 +1583,7 @@ MapBlock *ServerMap::getBlockOrEmerge(v3s16 p3d)
 {
 	MapBlock *block = getBlockNoCreateNoEx(p3d);
 	if (block == NULL)
-		m_emerge->enqueueBlockEmerge(PEER_ID_INEXISTENT, p3d, false);
+		m_emerge->enqueueBlockEmerge(PEER_ID_INEXISTENT, p3d, true);
 
 	return block;
 }

--- a/src/map.h
+++ b/src/map.h
@@ -388,7 +388,7 @@ public:
 		- Memory
 		- Emerge Queue (deferred disk or generate)
 	*/
-	MapBlock *getBlockOrEmerge(v3s16 p3d);
+	MapBlock *getBlockOrEmerge(v3s16 p3d, bool generate);
 
 	bool isBlockInQueue(v3s16 pos);
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1457,7 +1457,7 @@ void ServerEnvironment::step(float dtime)
 		*/
 
 		for (const v3s16 &p: blocks_added) {
-			MapBlock *block = m_map->getBlockOrEmerge(p);
+			MapBlock *block = m_map->getBlockOrEmerge(p, true);
 			if (!block) {
 				// TODO: The blocks removed here will only be picked up again
 				// on the next cycle. To minimize the latency of objects being


### PR DESCRIPTION
Currently active but invisible blocks are not generated. The code attempt to get them from the in memory map or load them from the database, but it will not generate these blocks.

That seems wrong. Active blocks are small sphere around each player in which active "things" happen, for example spawning entities. So we should always attempt to create the blocks if they do not exist.

Note that the change is trivial (just one flag), but the consequence is that now more blocks are generated - if the player just looks in one direction.
With default setting that would be blocks outside of the players view-code, roughly 2/3 * 4/3*pi*4^3. Maybe about 170 blocks

- Goal of the PR
Allow active blocks to be generate

- How does the PR work?
A one line change that allows active blocks to be generated

- Does it resolve any reported issue?
No

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
No

- If not a bug fix, why is this PR needed? What usecases does it solve?
A better play experience. As far as a player is concerned blocks in the database or blocks to be generated should not be different.

## To do

This PR is Ready for Review.

## How to test

Not exactly sure. Create a new world that has mob-mods. Notice how eventually mobs are spawned behind you even when you do not block.
Or watch ABMs do their work, even behind you.