### PR TITLE
Touchscreen: Recognize double-taps as double-clicks 

### DIFF
--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -51,11 +51,8 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
 	setVisible(true);
 	m_menumgr->createdMenu(this);
 
-	m_doubleclickdetect[0].time = 0;
-	m_doubleclickdetect[1].time = 0;
-
-	m_doubleclickdetect[0].pos = v2s32(0, 0);
-	m_doubleclickdetect[1].pos = v2s32(0, 0);
+	m_last_touch.time = 0;
+	m_last_touch.pos = v2s32(0, 0);
 }
 
 GUIModalMenu::~GUIModalMenu()
@@ -109,7 +106,18 @@ void GUIModalMenu::quitMenu()
 #endif
 }
 
-bool GUIModalMenu::DoubleClickDetection(const SEvent &event)
+static bool isChild(gui::IGUIElement *tocheck, gui::IGUIElement *parent)
+{
+	while (tocheck) {
+		if (tocheck == parent) {
+			return true;
+		}
+		tocheck = tocheck->getParent();
+	}
+	return false;
+}
+
+bool GUIModalMenu::remapDoubleClick(const SEvent &event)
 {
 	/* The following code is for capturing double-clicks of the mouse button
 	 * and translating the double-click into an EET_KEY_INPUT_EVENT event
@@ -124,55 +132,34 @@ bool GUIModalMenu::DoubleClickDetection(const SEvent &event)
 	if (!m_remap_dbl_click)
 		return false;
 
-	if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
-		m_doubleclickdetect[0].pos = m_doubleclickdetect[1].pos;
-		m_doubleclickdetect[0].time = m_doubleclickdetect[1].time;
+	if (event.EventType != EET_MOUSE_INPUT_EVENT ||
+			event.MouseInput.Event != EMIE_LMOUSE_DOUBLE_CLICK)
+		return false;
 
-		m_doubleclickdetect[1].pos = m_pointer;
-		m_doubleclickdetect[1].time = porting::getTimeMs();
-	} else if (event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP) {
-		u64 delta = porting::getDeltaMs(
-			m_doubleclickdetect[0].time, porting::getTimeMs());
-		if (delta > 400)
-			return false;
+	// Only exit if the double-click happened outside the menu.
+	gui::IGUIElement *hovered =
+			Environment->getRootGUIElement()->getElementFromPoint(m_pointer);
+	if (isChild(hovered, this))
+		return false;
 
-		double squaredistance = m_doubleclickdetect[0].pos.
-			getDistanceFromSQ(m_doubleclickdetect[1].pos);
+	// Translate double-click to escape.
+	SEvent translated{};
+	translated.EventType            = EET_KEY_INPUT_EVENT;
+	translated.KeyInput.Key         = KEY_ESCAPE;
+	translated.KeyInput.Control     = false;
+	translated.KeyInput.Shift       = false;
+	translated.KeyInput.PressedDown = true;
+	translated.KeyInput.Char        = 0;
+	OnEvent(translated);
 
-		if (squaredistance > (30 * 30)) {
-			return false;
-		}
-
-		SEvent translated{};
-		// translate doubleclick to escape
-		translated.EventType            = EET_KEY_INPUT_EVENT;
-		translated.KeyInput.Key         = KEY_ESCAPE;
-		translated.KeyInput.Control     = false;
-		translated.KeyInput.Shift       = false;
-		translated.KeyInput.PressedDown = true;
-		translated.KeyInput.Char        = 0;
-		OnEvent(translated);
-
-		return true;
-	}
-
-	return false;
-}
-
-static bool isChild(gui::IGUIElement *tocheck, gui::IGUIElement *parent)
-{
-	while (tocheck) {
-		if (tocheck == parent) {
-			return true;
-		}
-		tocheck = tocheck->getParent();
-	}
-	return false;
+	return true;
 }
 
 bool GUIModalMenu::simulateMouseEvent(
 		gui::IGUIElement *target, ETOUCH_INPUT_EVENT touch_event)
 {
+	gui::IGUIElement *focused = Environment->getFocus();
+
 	SEvent mouse_event{}; // value-initialized, not unitialized
 	mouse_event.EventType = EET_MOUSE_INPUT_EVENT;
 	mouse_event.MouseInput.X = m_pointer.X;
@@ -189,6 +176,11 @@ bool GUIModalMenu::simulateMouseEvent(
 	case ETIE_LEFT_UP:
 		mouse_event.MouseInput.Event = EMIE_LMOUSE_LEFT_UP;
 		mouse_event.MouseInput.ButtonStates = 0;
+		break;
+	case ETIE_COUNT:
+		// ETIE_COUNT is used for double-tap events.
+		mouse_event.MouseInput.Event = EMIE_LMOUSE_DOUBLE_CLICK;
+		mouse_event.MouseInput.ButtonStates = EMBSM_LEFT;
 		break;
 	default:
 		return false;
@@ -208,6 +200,10 @@ bool GUIModalMenu::simulateMouseEvent(
 		retval = target->OnEvent(mouse_event);
 	} while (false);
 	m_simulated_mouse = false;
+
+	if (!retval && target == focused && m_touch_hovered != focused) {
+		return simulateMouseEvent(m_touch_hovered.get(), touch_event);
+	}
 
 	return retval;
 }
@@ -295,10 +291,27 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 			}
 			gui::IGUIElement *focused = Environment->getFocus();
 			bool ret = simulateMouseEvent(focused, event.TouchInput.Event);
-			if (!ret && m_touch_hovered != focused)
-				ret = simulateMouseEvent(m_touch_hovered.get(), event.TouchInput.Event);
 			if (event.TouchInput.Event == ETIE_LEFT_UP)
 				leave();
+
+			// Detect double-taps and convert them into double-click events.
+			if (event.TouchInput.Event == ETIE_PRESSED_DOWN) {
+				u64 time_now = porting::getTimeMs();
+				u64 time_delta = porting::getDeltaMs(m_last_touch.time, time_now);
+
+				v2s32 pos_delta = m_pointer - m_last_touch.pos;
+				f32 distance_sq = (f32)pos_delta.X * pos_delta.X +
+						(f32)pos_delta.Y * pos_delta.Y;
+
+				if (time_delta < 400 && distance_sq < (30 * 30)) {
+					// ETIE_COUNT is used for double-tap events.
+					simulateMouseEvent(focused, ETIE_COUNT);
+				}
+
+				m_last_touch.time = time_now;
+				m_last_touch.pos = m_pointer;
+			}
+
 			return ret;
 		} else if (event.TouchInput.touchedCount == 2) {
 			if (event.TouchInput.Event != ETIE_LEFT_UP)
@@ -325,13 +338,8 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 			m_touch_hovered.reset();
 		}
 
-		gui::IGUIElement *hovered =
-				Environment->getRootGUIElement()->getElementFromPoint(m_pointer);
-		if (!isChild(hovered, this)) {
-			if (DoubleClickDetection(event)) {
-				return true;
-			}
-		}
+		if (remapDoubleClick(event))
+			return true;
 	}
 
 	return false;

--- a/src/gui/modalMenu.h
+++ b/src/gui/modalMenu.h
@@ -108,7 +108,7 @@ private:
 
 	irr_ptr<gui::IGUIElement> m_touch_hovered;
 
-	bool simulateMouseEvent(gui::IGUIElement *target, ETOUCH_INPUT_EVENT touch_event);
+	bool simulateMouseEvent(ETOUCH_INPUT_EVENT touch_event, bool second_try=false);
 	void enter(gui::IGUIElement *element);
 	void leave();
 

--- a/src/gui/modalMenu.h
+++ b/src/gui/modalMenu.h
@@ -69,13 +69,6 @@ protected:
 	virtual std::wstring getLabelByID(s32 id) = 0;
 	virtual std::string getNameByID(s32 id) = 0;
 
-	/**
-	 * check if event is part of a double click
-	 * @param event event to evaluate
-	 * @return true/false if a doubleclick was detected
-	 */
-	bool DoubleClickDetection(const SEvent &event);
-
 	// Stores the last known pointer type.
 	PointerType m_pointer_type = PointerType::Mouse;
 	// Stores the last known pointer position.
@@ -97,13 +90,6 @@ protected:
 	bool m_simulated_mouse = false;
 
 private:
-	struct clickpos
-	{
-		v2s32 pos;
-		s64 time;
-	};
-	clickpos m_doubleclickdetect[2];
-
 	IMenuManager *m_menumgr;
 	/* If true, remap a double-click (or double-tap) action to ESC. This is so
 	 * that, for example, Android users can double-tap to close a formspec.
@@ -112,6 +98,8 @@ private:
 	 * and the default value for the setting is true.
 	 */
 	bool m_remap_dbl_click;
+	bool remapDoubleClick(const SEvent &event);
+
 	// This might be necessary to expose to the implementation if it
 	// wants to launch other menus
 	bool m_allow_focus_removal = false;
@@ -123,4 +111,10 @@ private:
 	bool simulateMouseEvent(gui::IGUIElement *target, ETOUCH_INPUT_EVENT touch_event);
 	void enter(gui::IGUIElement *element);
 	void leave();
+
+	// Used to detect double-taps and convert them into double-click events.
+	struct {
+		v2s32 pos;
+		s64 time;
+	} m_last_touch;
 };


### PR DESCRIPTION
With this PR, double-taps are recognized as double-clicks. This means that Android users can now do things that were previously only possible on desktop, such as double-tapping to pick up all items of the same type.

Here's a video of it in action:

https://github.com/minetest/minetest/assets/82708541/76b50244-ba62-4bec-948b-b5d832f63747

This PR also fixes an old bug where menus would often close after a single-tap outside the menu (instead of after a double-tap outside the menu), presumably due to a bug in the double-click detection code.

## To do

This PR is a Ready for Review.

## How to test

Play Minetest on Android. Verify that double-taps are recognized as double-clicks, e.g. for inventory management.

Verify that double-tapping outside a menu to close it still works. Verify that menus no longer close after a single tap outside.
