### PR TITLE
Add missing header for gcc-14

### DIFF
--- a/src/client/sound/sound_data.cpp
+++ b/src/client/sound/sound_data.cpp
@@ -25,6 +25,7 @@ with this program; ifnot, write to the Free Software Foundation, Inc.,
 #include "sound_data.h"
 
 #include "sound_constants.h"
+#include <algorithm>
 
 namespace sound {
 


### PR DESCRIPTION
https://gcc.gnu.org/gcc-14/porting_to.html

GCC-14 continues the process of eliminating implicit header includes, lower_bound being on the chopping block this time. So this pr includes the algorithm header accordingly where its needed.

https://bugs.gentoo.org/921131

## To do

Ready for Review.


## How to test

Build with GCC-14

