### PR TITLE
Comply with base64 library license terms

### DIFF
--- a/src/util/base64.cpp
+++ b/src/util/base64.cpp
@@ -2,6 +2,7 @@
 base64.cpp and base64.h
 
 Copyright (C) 2004-2008 René Nyffenegger
+Stricter validation added by the Minetest Contributors.
 
 This source code is provided 'as-is', without any express or implied
 warranty. In no event will the author be held liable for any damages

--- a/src/util/base64.h
+++ b/src/util/base64.h
@@ -1,20 +1,29 @@
 /*
-Minetest
-Copyright (C) 2013-2017 celeron55, Perttu Ahola <celeron55@gmail.com>
+base64.cpp and base64.h
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation; either version 2.1 of the License, or
-(at your option) any later version.
+Copyright (C) 2004-2008 René Nyffenegger
+Minor modifications by the Minetest Contributors.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
+This source code is provided 'as-is', without any express or implied
+warranty. In no event will the author be held liable for any damages
+arising from the use of this software.
 
-You should have received a copy of the GNU Lesser General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this source code must not be misrepresented; you must not
+   claim that you wrote the original source code. If you use this source code
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original source code.
+
+3. This notice may not be removed or altered from any source distribution.
+
+René Nyffenegger rene.nyffenegger@adp-gmbh.ch
+
 */
 
 #pragma once


### PR DESCRIPTION
* The base64 license states that "the origin of this source code must not be misrepresented", but in `base64.h` we were doing just that.
* The license also states that "altered source versions must be plainly marked as such", but we (this includes me when I tightened validation) weren't doing this.

This PR should address both violations.

The license terms seem compatible with LGPLv2.1, but I hope someone with more experience can check this. A crayon-ish license in Minetest's source code slightly worries me. In spirit, it seems to be similar to BSD3, but I'm not sure about the exact wording, and some details are different.

I've opened an issue on the base64 repo: https://github.com/ReneNyffenegger/cpp-base64/issues/44.

(I stumbled upon this when repurposing base64 for the glTF PR.)