### PR TITLE
[no sq.] Make client use second/fallback IP address from DNS

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -122,7 +122,6 @@ public:
 	Client(
 			const char *playername,
 			const std::string &password,
-			const std::string &address_name,
 			MapDrawControl &control,
 			IWritableTextureSource *tsrc,
 			IWritableShaderSource *shsrc,
@@ -131,7 +130,6 @@ public:
 			ISoundManager *sound,
 			MtEventManager *event,
 			RenderingEngine *rendering_engine,
-			bool ipv6,
 			GameUI *game_ui,
 			ELoginRegister allow_login_or_register
 	);
@@ -155,11 +153,8 @@ public:
 
 	bool isShutdown();
 
-	/*
-		The name of the local player should already be set when
-		calling this, as it is sent in the initialization.
-	*/
-	void connect(Address address, bool is_local_server);
+	void connect(const Address &address, const std::string &address_name,
+		bool is_local_server);
 
 	/*
 		Stuff that references the environment is valid only as
@@ -350,7 +345,7 @@ public:
 	bool activeObjectsReceived() const
 	{ return m_activeobjects_received; }
 
-	u16 getProtoVersion()
+	u16 getProtoVersion() const
 	{ return m_proto_ver; }
 
 	bool m_simple_singleplayer_mode;
@@ -362,6 +357,10 @@ public:
 
 	float getRTT();
 	float getCurRate();
+	// has the server ever replied to us, used for connection retry/fallback
+	bool hasServerReplied() const {
+		return getProtoVersion() != 0; // (set in TOCLIENT_HELLO)
+	}
 
 	Minimap* getMinimap() { return m_minimap; }
 	void setCamera(Camera* camera) { m_camera = camera; }
@@ -414,8 +413,10 @@ public:
 
 	void showMinimap(bool show = true);
 
+	// IP and port we're connected to
 	const Address getServerAddress();
 
+	// Hostname of the connected server (but can also be a numerical IP)
 	const std::string &getAddressName() const
 	{
 		return m_address_name;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1610,13 +1610,15 @@ bool Game::connectToServer(const GameStartData &start_data,
 	*connect_ok = false;	// Let's not be overly optimistic
 	*connection_aborted = false;
 	bool local_server_mode = false;
+	const auto &address_name = start_data.address;
 
 	showOverlayMessage(N_("Resolving address..."), 0, 15);
 
 	Address connect_address(0, 0, 0, 0, start_data.socket_port);
+	Address fallback_address;
 
 	try {
-		connect_address.Resolve(start_data.address.c_str());
+		connect_address.Resolve(address_name.c_str(), &fallback_address);
 
 		if (connect_address.isAny()) {
 			// replace with localhost IP
@@ -1636,38 +1638,50 @@ bool Game::connectToServer(const GameStartData &start_data,
 		return false;
 	}
 
-	if (connect_address.isIPv6() && !g_settings->getBool("enable_ipv6")) {
+	// this shouldn't normally happen since Address::Resolve() checks for enable_ipv6
+	if (g_settings->getBool("enable_ipv6")) {
+		// empty
+	} else if (connect_address.isIPv6()) {
 		*error_message = fmtgettext("Unable to connect to %s because IPv6 is disabled", connect_address.serializeString().c_str());
 		errorstream << *error_message << std::endl;
 		return false;
+	} else if (fallback_address.isIPv6()) {
+		fallback_address = Address();
 	}
+
+	fallback_address.setPort(connect_address.getPort());
+	if (fallback_address.isValid()) {
+		infostream << "Resolved two addresses for \"" << address_name
+			<< "\" isIPv6[0]=" << connect_address.isIPv6()
+			<< " isIPv6[1]=" << fallback_address.isIPv6() << std::endl;
+	} else {
+		infostream << "Resolved one address for \"" << address_name
+			<< "\" isIPv6=" << connect_address.isIPv6() << std::endl;
+	}
+
 
 	try {
 		client = new Client(start_data.name.c_str(),
-				start_data.password, start_data.address,
+				start_data.password,
 				*draw_control, texture_src, shader_src,
 				itemdef_manager, nodedef_manager, sound_manager.get(), eventmgr,
-				m_rendering_engine, connect_address.isIPv6(), m_game_ui.get(),
+				m_rendering_engine, m_game_ui.get(),
 				start_data.allow_login_or_register);
-		client->migrateModStorage();
 	} catch (const BaseException &e) {
 		*error_message = fmtgettext("Error creating client: %s", e.what());
 		errorstream << *error_message << std::endl;
 		return false;
 	}
 
+	client->migrateModStorage();
 	client->m_simple_singleplayer_mode = simple_singleplayer_mode;
-
-	infostream << "Connecting to server at ";
-	connect_address.print(infostream);
-	infostream << std::endl;
-
-	client->connect(connect_address,
-		simple_singleplayer_mode || local_server_mode);
 
 	/*
 		Wait for server to accept connection
 	*/
+
+	client->connect(connect_address, address_name,
+		simple_singleplayer_mode || local_server_mode);
 
 	try {
 		input->clear();
@@ -1675,6 +1689,7 @@ bool Game::connectToServer(const GameStartData &start_data,
 		FpsControl fps_control;
 		f32 dtime;
 		f32 wait_time = 0; // in seconds
+		bool did_fallback = false;
 
 		fps_control.reset();
 
@@ -1709,8 +1724,15 @@ bool Game::connectToServer(const GameStartData &start_data,
 			}
 
 			wait_time += dtime;
-			// Only time out if we aren't waiting for the server we started
-			if (!start_data.address.empty() && wait_time > 10) {
+			if (local_server_mode) {
+				// never time out
+			} else if (wait_time > GAME_FALLBACK_TIMEOUT && !did_fallback) {
+				if (!client->hasServerReplied() && fallback_address.isValid()) {
+					client->connect(fallback_address, address_name,
+						simple_singleplayer_mode || local_server_mode);
+				}
+				did_fallback = true;
+			} else if (wait_time > GAME_CONNECTION_TIMEOUT) {
 				*error_message = gettext("Connection timed out.");
 				errorstream << *error_message << std::endl;
 				break;
@@ -1720,8 +1742,7 @@ bool Game::connectToServer(const GameStartData &start_data,
 			showOverlayMessage(N_("Connecting to server..."), dtime, 20);
 		}
 	} catch (con::PeerNotFoundException &e) {
-		// TODO: Should something be done here? At least an info/error
-		// message?
+		warningstream << "This should not happen. Please report a bug." << std::endl;
 		return false;
 	}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1618,7 +1618,8 @@ bool Game::connectToServer(const GameStartData &start_data,
 	try {
 		connect_address.Resolve(start_data.address.c_str());
 
-		if (connect_address.isZero()) { // i.e. INADDR_ANY, IN6ADDR_ANY
+		if (connect_address.isAny()) {
+			// replace with localhost IP
 			if (connect_address.isIPv6()) {
 				IPv6AddressBytes addr_bytes;
 				addr_bytes.bytes[15] = 1;

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -43,6 +43,8 @@ struct CameraOrientation {
 	f32 camera_pitch;  // "up/down"
 };
 
+#define GAME_FALLBACK_TIMEOUT 1.8f
+#define GAME_CONNECTION_TIMEOUT 10.0f
 
 void the_game(bool *kill,
 		InputHandler *input,

--- a/src/network/address.cpp
+++ b/src/network/address.cpp
@@ -84,7 +84,7 @@ Address::Address(const IPv6AddressBytes *ipv6_bytes, u16 port)
 }
 
 // Equality (address family, IP and port must be equal)
-bool Address::operator==(const Address &other)
+bool Address::operator==(const Address &other) const
 {
 	if (other.m_addr_family != m_addr_family || other.m_port != m_port)
 		return false;
@@ -101,44 +101,60 @@ bool Address::operator==(const Address &other)
 	return false;
 }
 
-void Address::Resolve(const char *name)
+void Address::Resolve(const char *name, Address *fallback)
 {
 	if (!name || name[0] == 0) {
 		if (m_addr_family == AF_INET)
 			setAddress(static_cast<u32>(0));
 		else if (m_addr_family == AF_INET6)
 			setAddress(static_cast<IPv6AddressBytes*>(nullptr));
+		if (fallback)
+			*fallback = Address();
 		return;
 	}
 
-	struct addrinfo *resolved, hints;
+	const auto &copy_from_ai = [] (const struct addrinfo *ai, Address *to) {
+		if (ai->ai_family == AF_INET) {
+			struct sockaddr_in *t = (struct sockaddr_in *)ai->ai_addr;
+			to->m_addr_family = AF_INET;
+			to->m_address.ipv4 = t->sin_addr;
+		} else if (ai->ai_family == AF_INET6) {
+			struct sockaddr_in6 *t = (struct sockaddr_in6 *)ai->ai_addr;
+			to->m_addr_family = AF_INET6;
+			to->m_address.ipv6 = t->sin6_addr;
+		} else {
+			to->m_addr_family = 0;
+		}
+	};
+
+	struct addrinfo hints;
 	memset(&hints, 0, sizeof(hints));
 
-	// Setup hints
+	// set a type, so every unique address is only returned once
+	hints.ai_socktype = SOCK_DGRAM;
 	if (g_settings->getBool("enable_ipv6")) {
 		// AF_UNSPEC allows both IPv6 and IPv4 addresses to be returned
 		hints.ai_family = AF_UNSPEC;
 	} else {
 		hints.ai_family = AF_INET;
 	}
+	hints.ai_flags = AI_ADDRCONFIG;
 
 	// Do getaddrinfo()
-	int e = getaddrinfo(name, NULL, &hints, &resolved);
+	struct addrinfo *resolved = nullptr;
+	int e = getaddrinfo(name, nullptr, &hints, &resolved);
 	if (e != 0)
 		throw ResolveError(gai_strerror(e));
+	assert(resolved);
 
 	// Copy data
-	if (resolved->ai_family == AF_INET) {
-		struct sockaddr_in *t = (struct sockaddr_in *)resolved->ai_addr;
-		m_addr_family = AF_INET;
-		m_address.ipv4 = t->sin_addr;
-	} else if (resolved->ai_family == AF_INET6) {
-		struct sockaddr_in6 *t = (struct sockaddr_in6 *)resolved->ai_addr;
-		m_addr_family = AF_INET6;
-		m_address.ipv6 = t->sin6_addr;
-	} else {
-		m_addr_family = 0;
+	copy_from_ai(resolved, this);
+	if (fallback) {
+		*fallback = Address();
+		if (resolved->ai_next)
+			copy_from_ai(resolved->ai_next, fallback);
 	}
+
 	freeaddrinfo(resolved);
 }
 
@@ -151,28 +167,11 @@ std::string Address::serializeString() const
 	return str;
 }
 
-struct in_addr Address::getAddress() const
-{
-	return m_address.ipv4;
-}
-
-struct in6_addr Address::getAddress6() const
-{
-	return m_address.ipv6;
-}
-
-u16 Address::getPort() const
-{
-	return m_port;
-}
-
-bool Address::isZero() const
+bool Address::isAny() const
 {
 	if (m_addr_family == AF_INET) {
 		return m_address.ipv4.s_addr == 0;
-	}
-
-	if (m_addr_family == AF_INET6) {
+	} else if (m_addr_family == AF_INET6) {
 		static const char zero[16] = {0};
 		return memcmp(m_address.ipv6.s6_addr, zero, 16) == 0;
 	}
@@ -218,18 +217,19 @@ void Address::print(std::ostream& s) const
 
 bool Address::isLocalhost() const
 {
-	if (isIPv6()) {
+	if (m_addr_family == AF_INET6) {
 		static const u8 localhost_bytes[] = {
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
 		static const u8 mapped_ipv4_localhost[] = {
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0x7f, 0, 0, 0};
 
-		auto addr = m_address.ipv6.s6_addr;
+		auto *addr = m_address.ipv6.s6_addr;
 
 		return memcmp(addr, localhost_bytes, 16) == 0 ||
 			memcmp(addr, mapped_ipv4_localhost, 13) == 0;
+	} else if (m_addr_family == AF_INET) {
+		auto addr = ntohl(m_address.ipv4.s_addr);
+		return (addr >> 24) == 0x7f;
 	}
-
-	auto addr = ntohl(m_address.ipv4.s_addr);
-	return (addr >> 24) == 0x7f;
+	return false;
 }

--- a/src/network/address.h
+++ b/src/network/address.h
@@ -47,21 +47,29 @@ public:
 	Address(u8 a, u8 b, u8 c, u8 d, u16 port);
 	Address(const IPv6AddressBytes *ipv6_bytes, u16 port);
 
-	bool operator==(const Address &address);
-	bool operator!=(const Address &address) { return !(*this == address); }
+	bool operator==(const Address &address) const;
+	bool operator!=(const Address &address) const { return !(*this == address); }
 
-	struct in_addr getAddress() const;
-	struct in6_addr getAddress6() const;
-	u16 getPort() const;
 	int getFamily() const { return m_addr_family; }
+	bool isValid() const { return m_addr_family != 0; }
 	bool isIPv6() const { return m_addr_family == AF_INET6; }
-	bool isZero() const;
+	struct in_addr getAddress() const { return m_address.ipv4; }
+	struct in6_addr getAddress6() const { return m_address.ipv6; }
+	u16 getPort() const { return m_port; }
+
 	void print(std::ostream &s) const;
 	std::string serializeString() const;
+
+	// Is this an address that binds to all interfaces (like INADDR_ANY)?
+	bool isAny() const;
+	// Is this an address referring to the local host?
 	bool isLocalhost() const;
 
-	// Resolve() may throw ResolveError (address is unchanged in this case)
-	void Resolve(const char *name);
+	// `name`: hostname or numeric IP
+	// `fallback`: fallback IP to try gets written here
+	// any empty name resets the IP to the "any address"
+	// may throw ResolveError (address is unchanged in this case)
+	void Resolve(const char *name, Address *fallback = nullptr);
 
 	void setAddress(u32 address);
 	void setAddress(u8 a, u8 b, u8 c, u8 d);
@@ -75,5 +83,6 @@ private:
 		struct in_addr ipv4;
 		struct in6_addr ipv6;
 	} m_address;
-	u16 m_port = 0; // Port is separate from sockaddr structures
+	// port is separate from in_addr structures
+	u16 m_port = 0;
 };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -163,6 +163,7 @@ void Client::handleCommand_AuthAccept(NetworkPacket* pkt)
 
 	m_state = LC_Init;
 }
+
 void Client::handleCommand_AcceptSudoMode(NetworkPacket* pkt)
 {
 	deleteAuthData();

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -73,6 +73,7 @@ void sockets_cleanup()
 	// On Windows, cleanup sockets after use
 	WSACleanup();
 #endif
+	g_sockets_initialized = false;
 }
 
 /*
@@ -87,8 +88,16 @@ UDPSocket::UDPSocket(bool ipv6)
 bool UDPSocket::init(bool ipv6, bool noExceptions)
 {
 	if (!g_sockets_initialized) {
-		tracestream << "Sockets not initialized" << std::endl;
+		verbosestream << "Sockets not initialized" << std::endl;
 		return false;
+	}
+
+	if (m_handle >= 0) {
+		auto msg = "Cannot initialize socket twice";
+		verbosestream << msg << std::endl;
+		if (noExceptions)
+			return false;
+		throw SocketException(msg);
 	}
 
 	// Use IPv6 if specified
@@ -101,7 +110,7 @@ bool UDPSocket::init(bool ipv6, bool noExceptions)
 			<< std::endl;
 	}
 
-	if (m_handle <= 0) {
+	if (m_handle < 0) {
 		if (noExceptions) {
 			return false;
 		}
@@ -131,11 +140,13 @@ UDPSocket::~UDPSocket()
 			<< std::endl;
 	}
 
+	if (m_handle >= 0) {
 #ifdef _WIN32
-	closesocket(m_handle);
+		closesocket(m_handle);
 #else
-	close(m_handle);
+		close(m_handle);
 #endif
+	}
 }
 
 void UDPSocket::Bind(Address addr)
@@ -251,8 +262,11 @@ void UDPSocket::Send(const Address &destination, const void *data, int size)
 int UDPSocket::Receive(Address &sender, void *data, int size)
 {
 	// Return on timeout
+	assert(m_timeout_ms >= 0);
 	if (!WaitData(m_timeout_ms))
 		return -1;
+
+	size = MYMAX(size, 0);
 
 	int received;
 	if (m_addr_family == AF_INET6) {
@@ -309,11 +323,6 @@ int UDPSocket::Receive(Address &sender, void *data, int size)
 	}
 
 	return received;
-}
-
-int UDPSocket::GetHandle()
-{
-	return m_handle;
 }
 
 void UDPSocket::setTimeoutMs(int timeout_ms)

--- a/src/network/socket.h
+++ b/src/network/socket.h
@@ -34,23 +34,24 @@ class UDPSocket
 {
 public:
 	UDPSocket() = default;
-
-	UDPSocket(bool ipv6);
+	UDPSocket(bool ipv6); // calls init()
 	~UDPSocket();
-	void Bind(Address addr);
-
 	bool init(bool ipv6, bool noExceptions = false);
+
+	void Bind(Address addr);
 
 	void Send(const Address &destination, const void *data, int size);
 	// Returns -1 if there is no data
 	int Receive(Address &sender, void *data, int size);
-	int GetHandle(); // For debugging purposes only
 	void setTimeoutMs(int timeout_ms);
 	// Returns true if there is data, false if timeout occurred
 	bool WaitData(int timeout_ms);
 
+	// Debugging purposes only
+	int GetHandle() const { return m_handle; };
+
 private:
-	int m_handle;
-	int m_timeout_ms;
-	int m_addr_family;
+	int m_handle = -1;
+	int m_timeout_ms = -1;
+	unsigned short m_addr_family = 0;
 };


### PR DESCRIPTION
For a problem description see [this Wikipedia article](https://en.wikipedia.org/wiki/Happy_Eyeballs) but note I am *not* implementing what is written there.
Minetest will simply try the second address if it hasn't received any reply after 1.8s. This is invisible to the user.

tl;dr You can now host a dual-stack server without risking that a client will prefer IPv6, fail to connect and never try via IPv4 which would have worked fine. 

## To do

This PR is Ready for Review.

## How to test

For one, go test the normal stuff like singleplayer or connecting to a remote server.

To test fallback:
1. ensure you have ipv6 and your host prefers it
2. Run `./bin/minetest --go --name test --address test14200.nekomimi.pw --verbose`
3. Observe nothing happening for ~2s, this is when it tries IPv6
4. After that time you will receive an error because the IPv4 points to some random 0.4.x server I pulled from the list