### PR TITLE
Add keybinds for camera panning to allow keyboard-only gameplay

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -99,6 +99,12 @@ cinematic_camera_smoothing (Camera smoothing in cinematic mode) float 0.7 0.0 0.
 #    This is helpful when working with nodeboxes in small areas.
 enable_build_where_you_stand (Build inside player) bool false
 
+#    Turn speed with the keyboard in degree per second.
+key_look_sensitivity_horizontal (Keyboard look horizontal sensitivity) float 100.0
+
+#    Look up/down speed with the keyboard in degree per second.
+key_look_sensitivity_vertical (Keyboard look vertical sensitivity) float 75.0
+
 #    If enabled, "Aux1" key instead of "Sneak" key is used for climbing down and
 #    descending.
 aux1_descends (Aux1 key for climbing/descending) bool false

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -31,6 +31,14 @@
 #    type: bool
 # enable_build_where_you_stand = false
 
+#    Horizontal look sensitivity with the keyboard, in degree per second.
+#    type: float
+# key_look_sensitivity_horizontal = 100.0
+
+#    Vertical look sensitivity with the keyboard, in degree per second.
+#    type: float
+# key_look_sensitivity_vertical = 75.0
+
 #    If enabled, "Aux1" key instead of "Sneak" key is used for climbing down and
 #    descending.
 #    type: bool
@@ -3298,6 +3306,26 @@
 #    See https://github.com/minetest/irrlicht/blob/master/include/Keycodes.h
 #    type: key
 # keymap_right = KEY_KEY_D
+
+#    Key for looking upward.
+#    See https://github.com/minetest/irrlicht/blob/master/include/Keycodes.h
+#    type: key
+# keymap_look_up = KEY_UP
+
+#    Key for looking downward.
+#    See https://github.com/minetest/irrlicht/blob/master/include/Keycodes.h
+#    type: key
+# keymap_look_down = KEY_DOWN
+
+#    Key for looking to the left.
+#    See https://github.com/minetest/irrlicht/blob/master/include/Keycodes.h
+#    type: key
+# keymap_look_up = KEY_LEFT
+
+#    Key for looking to the right.
+#    See https://github.com/minetest/irrlicht/blob/master/include/Keycodes.h
+#    type: key
+# keymap_look_up = KEY_RIGHT
 
 #    Key for jumping.
 #    See https://github.com/minetest/irrlicht/blob/master/include/Keycodes.h

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1028,6 +1028,8 @@ private:
 	bool m_cache_enable_noclip;
 	bool m_cache_enable_free_move;
 	f32  m_cache_mouse_sensitivity;
+	f32  m_cache_key_look_sensitivity_h;
+	f32  m_cache_key_look_sensitivity_v;
 	f32  m_cache_joystick_frustum_sensitivity;
 	f32  m_repeat_place_time;
 	f32  m_cache_cam_smoothing;
@@ -2690,6 +2692,19 @@ void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 		cam->camera_pitch += input->joystick.getAxisWithoutDead(JA_FRUSTUM_VERTICAL) * c;
 	}
 
+	if (input->isKeyDown(KeyType::LOOK_UP)) {
+		cam->camera_pitch -= m_cache_key_look_sensitivity_v * dtime;
+	}
+	if (input->isKeyDown(KeyType::LOOK_DOWN)) {
+		cam->camera_pitch += m_cache_key_look_sensitivity_v * dtime;
+	}
+	if (input->isKeyDown(KeyType::LOOK_LEFT)) {
+		cam->camera_yaw += m_cache_key_look_sensitivity_h * dtime;
+	}
+	if (input->isKeyDown(KeyType::LOOK_RIGHT)) {
+		cam->camera_yaw -= m_cache_key_look_sensitivity_h * dtime;
+	}
+
 	cam->camera_pitch = rangelim(cam->camera_pitch, -89.5, 89.5);
 }
 
@@ -2707,6 +2722,10 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 		isKeyDown(KeyType::RIGHT),
 		isKeyDown(KeyType::JUMP) || player->getAutojump(),
 		isKeyDown(KeyType::AUX1),
+		isKeyDown(KeyType::LOOK_UP),
+		isKeyDown(KeyType::LOOK_DOWN),
+		isKeyDown(KeyType::LOOK_LEFT),
+		isKeyDown(KeyType::LOOK_RIGHT),
 		isKeyDown(KeyType::SNEAK),
 		isKeyDown(KeyType::ZOOM),
 		isKeyDown(KeyType::DIG),
@@ -4389,6 +4408,9 @@ void Game::readSettings()
 	m_cache_joystick_frustum_sensitivity = std::max(g_settings->getFloat("joystick_frustum_sensitivity"), 0.001f);
 	m_repeat_place_time                  = g_settings->getFloat("repeat_place_time", 0.16f, 2.0);
 
+	m_cache_key_look_sensitivity_h       = g_settings->getFloat("key_look_sensitivity_horizontal");
+	m_cache_key_look_sensitivity_v       = g_settings->getFloat("key_look_sensitivity_vertical");
+
 	m_cache_enable_noclip                = g_settings->getBool("noclip");
 	m_cache_enable_free_move             = g_settings->getBool("free_move");
 
@@ -4400,6 +4422,8 @@ void Game::readSettings()
 
 	m_cache_cam_smoothing = rangelim(m_cache_cam_smoothing, 0.01f, 1.0f);
 	m_cache_mouse_sensitivity = rangelim(m_cache_mouse_sensitivity, 0.001, 100.0);
+	m_cache_key_look_sensitivity_h = rangelim(m_cache_key_look_sensitivity_h, 0.001, 360.0);
+	m_cache_key_look_sensitivity_v = rangelim(m_cache_key_look_sensitivity_v, 0.001, 360.0);
 
 	m_invert_mouse = g_settings->getBool("invert_mouse");
 	m_enable_hotbar_mouse_wheel = g_settings->getBool("enable_hotbar_mouse_wheel");

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -34,6 +34,10 @@ void KeyCache::populate()
 	key[KeyType::BACKWARD] = getKeySetting("keymap_backward");
 	key[KeyType::LEFT] = getKeySetting("keymap_left");
 	key[KeyType::RIGHT] = getKeySetting("keymap_right");
+	key[KeyType::LOOK_UP] = getKeySetting("keymap_look_up");
+	key[KeyType::LOOK_DOWN] = getKeySetting("keymap_look_down");
+	key[KeyType::LOOK_LEFT] = getKeySetting("keymap_look_left");
+	key[KeyType::LOOK_RIGHT] = getKeySetting("keymap_look_right");
 	key[KeyType::JUMP] = getKeySetting("keymap_jump");
 	key[KeyType::AUX1] = getKeySetting("keymap_aux1");
 	key[KeyType::SNEAK] = getKeySetting("keymap_sneak");

--- a/src/client/keys.h
+++ b/src/client/keys.h
@@ -38,6 +38,12 @@ public:
 		DIG,
 		PLACE,
 
+		// Player look
+		LOOK_UP,
+		LOOK_DOWN,
+		LOOK_LEFT,
+		LOOK_RIGHT,
+
 		ESC,
 
 		// Other

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -77,6 +77,10 @@ void set_default_settings()
 	settings->setDefault("keymap_backward", "KEY_KEY_S");
 	settings->setDefault("keymap_left", "KEY_KEY_A");
 	settings->setDefault("keymap_right", "KEY_KEY_D");
+	settings->setDefault("keymap_look_up", "KEY_UP");
+	settings->setDefault("keymap_look_down", "KEY_DOWN");
+	settings->setDefault("keymap_look_left", "KEY_LEFT");
+	settings->setDefault("keymap_look_right", "KEY_RIGHT");
 	settings->setDefault("keymap_jump", "KEY_SPACE");
 	settings->setDefault("keymap_sneak", "KEY_LSHIFT");
 	settings->setDefault("keymap_dig", "KEY_LBUTTON");
@@ -297,6 +301,8 @@ void set_default_settings()
 	settings->setDefault("aux1_descends", "false");
 	settings->setDefault("doubletap_jump", "false");
 	settings->setDefault("always_fly_fast", "true");
+	settings->setDefault("key_look_sensitivity_horizontal", "100.0");
+	settings->setDefault("key_look_sensitivity_vertical", "75.0");
 #ifdef HAVE_TOUCHSCREENGUI
 	settings->setDefault("autojump", "true");
 #else

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -423,8 +423,8 @@ void GUIKeyChangeMenu::init_keys()
 	this->add_key(GUI_ID_KEY_CHATLOG_BUTTON,      wstrgettext("Toggle chat log"),  "keymap_toggle_chat");
 	this->add_key(GUI_ID_KEY_FOG_BUTTON,          wstrgettext("Toggle fog"),       "keymap_toggle_fog");
 	// keyboard look control
-	this->add_key(GUI_ID_KEY_LOOK_UP_BUTTON,      wgettext("Look up"),             "keymap_look_up");
-	this->add_key(GUI_ID_KEY_LOOK_DOWN_BUTTON,    wgettext("Look down"),           "keymap_look_down");
-	this->add_key(GUI_ID_KEY_LOOK_LEFT_BUTTON,    wgettext("Look left"),           "keymap_look_left");
-	this->add_key(GUI_ID_KEY_LOOK_RIGHT_BUTTON,   wgettext("Look right"),          "keymap_look_right");
+	this->add_key(GUI_ID_KEY_LOOK_UP_BUTTON,      wstrgettext("Look up"),          "keymap_look_up");
+	this->add_key(GUI_ID_KEY_LOOK_DOWN_BUTTON,    wstrgettext("Look down"),        "keymap_look_down");
+	this->add_key(GUI_ID_KEY_LOOK_LEFT_BUTTON,    wstrgettext("Look left"),        "keymap_look_left");
+	this->add_key(GUI_ID_KEY_LOOK_RIGHT_BUTTON,   wstrgettext("Look right"),       "keymap_look_right");
 }

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -80,6 +80,11 @@ enum
 	GUI_ID_CB_AUX1_DESCENDS,
 	GUI_ID_CB_DOUBLETAP_JUMP,
 	GUI_ID_CB_AUTOJUMP,
+        // keyboard look control
+	GUI_ID_KEY_LOOK_UP_BUTTON,
+	GUI_ID_KEY_LOOK_DOWN_BUTTON,
+	GUI_ID_KEY_LOOK_LEFT_BUTTON,
+	GUI_ID_KEY_LOOK_RIGHT_BUTTON,
 };
 
 GUIKeyChangeMenu::GUIKeyChangeMenu(gui::IGUIEnvironment* env,
@@ -417,4 +422,9 @@ void GUIKeyChangeMenu::init_keys()
 	this->add_key(GUI_ID_KEY_HUD_BUTTON,          wstrgettext("Toggle HUD"),       "keymap_toggle_hud");
 	this->add_key(GUI_ID_KEY_CHATLOG_BUTTON,      wstrgettext("Toggle chat log"),  "keymap_toggle_chat");
 	this->add_key(GUI_ID_KEY_FOG_BUTTON,          wstrgettext("Toggle fog"),       "keymap_toggle_fog");
+	// keyboard look control
+	this->add_key(GUI_ID_KEY_LOOK_UP_BUTTON,      wgettext("Look up"),             "keymap_look_up");
+	this->add_key(GUI_ID_KEY_LOOK_DOWN_BUTTON,    wgettext("Look down"),           "keymap_look_down");
+	this->add_key(GUI_ID_KEY_LOOK_LEFT_BUTTON,    wgettext("Look left"),           "keymap_look_left");
+	this->add_key(GUI_ID_KEY_LOOK_RIGHT_BUTTON,   wgettext("Look right"),          "keymap_look_right");
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -171,7 +171,11 @@ u32 PlayerControl::getKeysPressed() const
 		( (u32)(sneak & 1) << 6) |
 		( (u32)(dig   & 1) << 7) |
 		( (u32)(place & 1) << 8) |
-		( (u32)(zoom  & 1) << 9)
+		( (u32)(zoom  & 1) << 9) |
+		( (u32)(look_up    & 1) << 10) |
+		( (u32)(look_down  & 1) << 11) |
+		( (u32)(look_left  & 1) << 12) |
+		( (u32)(look_right & 1) << 13)
 	;
 
 	// If any direction keys are pressed pass those through

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -172,10 +172,10 @@ u32 PlayerControl::getKeysPressed() const
 		( (u32)(dig   & 1) << 7) |
 		( (u32)(place & 1) << 8) |
 		( (u32)(zoom  & 1) << 9) |
-		( (u32)(look_up    & 1) << 10) |
-		( (u32)(look_down  & 1) << 11) |
-		( (u32)(look_left  & 1) << 12) |
-		( (u32)(look_right & 1) << 13)
+		( (u32)(lookup    & 1) << 10) |
+		( (u32)(lookdown  & 1) << 11) |
+		( (u32)(lookleft  & 1) << 12) |
+		( (u32)(lookright & 1) << 13)
 	;
 
 	// If any direction keys are pressed pass those through

--- a/src/player.h
+++ b/src/player.h
@@ -50,6 +50,7 @@ struct PlayerControl
 
 	PlayerControl(
 		bool a_up, bool a_down, bool a_left, bool a_right,
+		bool a_lookup, bool a_lookdown, bool a_lookleft, bool a_lookright,
 		bool a_jump, bool a_aux1, bool a_sneak,
 		bool a_zoom,
 		bool a_dig, bool a_place,
@@ -61,6 +62,12 @@ struct PlayerControl
 		// as movement_{speed,direction} is supposed to be the source of truth.
 		direction_keys = (a_up&1) | ((a_down&1) << 1) |
 			((a_left&1) << 2) | ((a_right&1) << 3);
+		// Allow keyboard control of the look direction
+		// TODO conver to single value like above
+		lookup = a_lookup,
+		lookdown = a_lookdown,
+		lookleft = a_lookleft,
+		lookright = a_lookright,
 		jump = a_jump;
 		aux1 = a_aux1;
 		sneak = a_sneak;
@@ -83,6 +90,10 @@ struct PlayerControl
 	void unpackKeysPressed(u32 keypress_bits);
 
 	u8 direction_keys = 0;
+	bool lookup = false;
+	bool lookdown = false;
+	bool lookleft = false;
+	bool lookright = false;
 	bool jump = false;
 	bool aux1 = false;
 	bool sneak = false;


### PR DESCRIPTION
This is a DRAFT WORK-IN-PROGRESS for comment

That being said:

- Goal of the PR: enable keyboard only (or one-hand? .. see https://github.com/minetest/minetest/issues/11684 ) 
- How does the PR work: This adds support for using the keyboard only for controlling look direction

## To do

This PR is a Work in Progress 

## How to test

compile and use the arrow keys.

Currently "KEY_LEFT" is incorrectly mapped to both left, and jump. 
