### PR TITLE
Don't apply gui_scaling & DPI twice to table[] / textlist[] scrollbar

### DIFF
--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -60,7 +60,7 @@ GUITable::GUITable(gui::IGUIEnvironment *env,
 		m_rowheight = MYMAX(m_rowheight, 1);
 	}
 
-	const s32 s = skin->getSize(gui::EGDS_SCROLLBAR_SIZE);
+	const s32 s = skin->getSize(gui::EGDS_SCROLLBAR_SIZE) * 1.5f;
 	m_scrollbar = new GUIScrollBar(Environment, this, -1,
 			core::rect<s32>(RelativeRect.getWidth() - s,
 					0,
@@ -77,18 +77,6 @@ GUITable::GUITable(gui::IGUIEnvironment *env,
 	setTabStop(true);
 	setTabOrder(-1);
 	updateAbsolutePosition();
-#ifdef HAVE_TOUCHSCREENGUI
-	float density = 1; // dp scaling is applied by the skin
-#else
-	float density = RenderingEngine::getDisplayDensity();
-#endif
-	core::rect<s32> relative_rect = m_scrollbar->getRelativePosition();
-	s32 width = (relative_rect.getWidth() / (2.0 / 3.0)) * density *
-			g_settings->getFloat("gui_scaling", 0.5f, 20.0f);
-	m_scrollbar->setRelativePosition(core::rect<s32>(
-			relative_rect.LowerRightCorner.X-width,relative_rect.UpperLeftCorner.Y,
-			relative_rect.LowerRightCorner.X,relative_rect.LowerRightCorner.Y
-			));
 }
 
 GUITable::~GUITable()


### PR DESCRIPTION
The scrollbar width of `GUITable` (used for `table` and `textlist` formspec elements) is set to `EGDS_SCROLLBAR_SIZE * gui_scaling * DPI * 1.5` . However, `EGDS_SCROLLBAR_SIZE` already includes both gui_scaling and DPI:

https://github.com/minetest/minetest/blob/2c44620e5e344ca2b4acaaaa5408502332ca5aff/src/client/clientlauncher.cpp#L149-L153

This means that these factors are applied twice. This bug was introduced by #13666 and is fixed by this PR.

*before this PR, `display_density_factor = 2`*

<img alt="screenshot before" src="https://github.com/minetest/minetest/assets/82708541/676ceff5-8e44-41b9-b524-98c792622fdc" width="512" />

*after this PR, `display_density_factor = 2`*

<img alt="screenshot after" src="https://github.com/minetest/minetest/assets/82708541/f819baf6-8b1f-4b61-9617-b009e492677f" width="512" />

## To do

This PR is a Ready for Review.

## How to test

Set `display_density_factor = 2` in minetest.conf (or have a high-DPI display). See that the scrollbar of the serverlist isn't oversized.

Note: Recalculating `EGDS_SCROLLBAR_SIZE` requires a restart.