### PR TITLE
Android: Use the correct value for notification

### DIFF
--- a/android/app/src/main/java/net/minetest/minetest/UnzipService.java
+++ b/android/app/src/main/java/net/minetest/minetest/UnzipService.java
@@ -22,7 +22,6 @@ package net.minetest.minetest;
 
 import android.app.IntentService;
 import android.app.Notification;
-import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -58,9 +57,11 @@ public class UnzipService extends IntentService {
 	private String failureMessage;
 
 	private static boolean isRunning = false;
+
 	public static synchronized boolean getIsRunning() {
 		return isRunning;
 	}
+
 	private static synchronized void setIsRunning(boolean v) {
 		isRunning = v;
 	}
@@ -99,28 +100,13 @@ public class UnzipService extends IntentService {
 		}
 	}
 
+	@NonNull
 	private Notification.Builder createNotification() {
-		String name = "net.minetest.minetest";
-		String channelId = "Minetest channel";
-		String description = "notifications from Minetest";
 		Notification.Builder builder;
 		if (mNotifyManager == null)
 			mNotifyManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			int importance = NotificationManager.IMPORTANCE_LOW;
-			NotificationChannel mChannel = null;
-			if (mNotifyManager != null)
-				mChannel = mNotifyManager.getNotificationChannel(channelId);
-			if (mChannel == null) {
-				mChannel = new NotificationChannel(channelId, name, importance);
-				mChannel.setDescription(description);
-				// Configure the notification channel, NO SOUND
-				mChannel.setSound(null, null);
-				mChannel.enableLights(false);
-				mChannel.enableVibration(false);
-				mNotifyManager.createNotificationChannel(mChannel);
-			}
-			builder = new Notification.Builder(this, channelId);
+			builder = new Notification.Builder(this, MainActivity.NOTIFICATION_CHANNEL_ID);
 		} else {
 			builder = new Notification.Builder(this);
 		}
@@ -135,9 +121,9 @@ public class UnzipService extends IntentService {
 		PendingIntent intent = PendingIntent.getActivity(this, 0,
 			notificationIntent, pendingIntentFlag);
 
-		builder.setContentTitle(getString(R.string.notification_title))
+		builder.setContentTitle(getString(R.string.unzip_notification_title))
 				.setSmallIcon(R.mipmap.ic_launcher)
-				.setContentText(getString(R.string.notification_description))
+				.setContentText(getString(R.string.unzip_notification_description))
 				.setContentIntent(intent)
 				.setOngoing(true)
 				.setProgress(0, 0, true);
@@ -198,7 +184,7 @@ public class UnzipService extends IntentService {
 		}
 	}
 
-	private void publishProgress(@Nullable  Notification.Builder notificationBuilder, @StringRes int message, int progress) {
+	private void publishProgress(@Nullable Notification.Builder notificationBuilder, @StringRes int message, int progress) {
 		Intent intentUpdate = new Intent(ACTION_UPDATE);
 		intentUpdate.putExtra(ACTION_PROGRESS, progress);
 		intentUpdate.putExtra(ACTION_PROGRESS_MESSAGE, message);

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,7 +2,9 @@
 <resources>
 	<string name="label">Minetest</string>
 	<string name="loading">Loading&#8230;</string>
-	<string name="notification_title">Loading Minetest</string>
-	<string name="notification_description">Less than 1 minute&#8230;</string>
+	<string name="notification_channel_name">General notification</string>
+	<string name="notification_channel_description">Notifications from Minetest</string>
+	<string name="unzip_notification_title">Loading Minetest</string>
+	<string name="unzip_notification_description">Less than 1 minute&#8230;</string>
 	<string name="ime_dialog_done">Done</string>
 </resources>


### PR DESCRIPTION
**Goal of the PR**
This PR fixes the settings of the notification channel on Android.

**How does the PR work?**
This PR uses the correct field of the notification channel on Android. Its effect is that there will be two notification channels (the old one and the new one) if Minetest is updated from the previous version.

The notification channel creation is also moved into the `MainActivity` class in preparation of other notifications.

**Does it resolve any reported issue?**
The issue has not been reported. See the comparisons below.

**Does this relate to a goal in the roadmap?**
Internal code refactoring and UX improvements

## To do
This PR is Ready for Review.

## How to test
1. Install version 5.8.0 or `master` of Minetest.
2. Open Minetest and close it.
3. Open Minetest's App info.
4. Open Notifications (App notifications) > Notification categories.
6. Open the only category in the list.
7. Check the values of each field.
8. Repeat for this PR version of Minetest.

### Test results
The test was run on Samsung Galaxy A72 (Android 13).

| Menu | Before | After |
|:----:|:------:|:-----:|
| Category List | ![category list before](https://github.com/minetest/minetest/assets/4017302/828193a0-defa-46a8-96d2-15799199ad7b) | ![category list after](https://github.com/minetest/minetest/assets/4017302/d4cf7c5a-33f1-4e6f-9010-5fbc3847c7fe) |
| Category Information | ![category information before](https://github.com/minetest/minetest/assets/4017302/4d613305-0c31-4e59-8f2a-51ad1b4af9d7) | ![category information after](https://github.com/minetest/minetest/assets/4017302/714e8043-6dc2-49de-a238-8640d92161a7) |