### PR TITLE
Only pause rendering if the Android activity is stopped

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4207,7 +4207,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	/*
 		==================== Drawing begins ====================
 	*/
-	if (RenderingEngine::shouldRender())
+	if (device->isWindowVisible())
 		drawScene(graph, stats);
 	/*
 		==================== End scene ====================

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -138,17 +138,6 @@ public:
 			const irr::core::dimension2d<u32> initial_screen_size,
 			const bool initial_window_maximized);
 
-	static bool shouldRender()
-	{
-		// On Android, pause rendering while the app is in background (generally not visible).
-		// Don't do this on desktop because windows can be partially visible.
-#ifdef __ANDROID__
-		return get_raw_device()->isWindowActive();
-#else
-		return true;
-#endif
-	};
-
 private:
 	v2u32 _getWindowSize() const;
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -231,6 +231,7 @@ bool GUIEngine::loadMainMenuScript()
 /******************************************************************************/
 void GUIEngine::run()
 {
+	IrrlichtDevice *device = m_rendering_engine->get_raw_device();
 	// Always create clouds because they may or may not be
 	// needed based on the game selected
 	video::IVideoDriver *driver = m_rendering_engine->get_video_driver();
@@ -265,7 +266,7 @@ void GUIEngine::run()
 	f32 dtime = 0.0f;
 
 	while (m_rendering_engine->run() && (!m_startgame) && (!m_kill)) {
-		if (RenderingEngine::shouldRender()) {
+		if (device->isWindowVisible()) {
 			// check if we need to update the "upper left corner"-text
 			if (text_height != g_fontengine->getTextHeight()) {
 				updateTopLeftTextSize();
@@ -294,8 +295,6 @@ void GUIEngine::run()
 
 			driver->endScene();
 		}
-
-		IrrlichtDevice *device = m_rendering_engine->get_raw_device();
 
 		u32 frametime_min = 1000 / (device->isWindowFocused()
 			? g_settings->getFloat("fps_max")


### PR DESCRIPTION
Depends on minetest/irrlicht#269.

Since #14058, rendering is paused on Android when the app is paused. However, it is also paused when the app is merely "unfocused" (e.g. a text input dialog is open). This is a problem because:

- The app might still be partially visible when it is "unfocused".

- It seems to result in bugs with text input: https://github.com/minetest/minetest/pull/13814#pullrequestreview-1793108110. I have no idea why since the paused rendering shouldn't affect event handling, but this PR seems to fix the issue.

## To do

This PR is a Ready for Review.

## How to test

Verify that rendering still happens while the text input dialog is open.

Verify that the issue described in https://github.com/minetest/minetest/pull/13814#pullrequestreview-1793108110 is fixed.
