### PR TITLE
Ensure deterministic client occlusion culling and minor improvements

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2103,7 +2103,7 @@ server_side_occlusion_culling (Server-side occlusion culling) bool true
 #    rendering glitches (missing blocks).
 #    This is especially useful for very large viewing range (upwards of 500).
 #    Stated in MapBlocks (16 nodes).
-block_cull_optimize_distance (Block cull optimize distance) int 20 2 2047
+block_cull_optimize_distance (Block cull optimize distance) int 25 2 2047
 
 [**Mapgen]
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -397,7 +397,7 @@ void set_default_settings()
 	// This causes frametime jitter on client side, or does it?
 	settings->setDefault("max_block_send_distance", "12");
 	settings->setDefault("block_send_optimize_distance", "4");
-	settings->setDefault("block_cull_optimize_distance", "20");
+	settings->setDefault("block_cull_optimize_distance", "25");
 	settings->setDefault("server_side_occlusion_culling", "true");
 	settings->setDefault("csm_restriction_flags", "62");
 	settings->setDefault("csm_restriction_noderange", "0");

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1193,6 +1193,9 @@ bool Map::isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool simple_c
 	// this is a HACK, we should think of a more precise algorithm
 	u32 needed_count = 2;
 
+	// This should be only used in server occlusion cullung.
+	// The client recalculates the complete drawlist periodically,
+	// and random sampling could lead to visible flicker.
 	if (simple_check) {
 		v3s16 random_point(myrand_range(-bs2, bs2), myrand_range(-bs2, bs2), myrand_range(-bs2, bs2));
 		return isOccluded(cam_pos_nodes, pos_blockcenter + random_point, step, stepfac,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1193,13 +1193,11 @@ bool Map::isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool simple_c
 	// this is a HACK, we should think of a more precise algorithm
 	u32 needed_count = 2;
 
-	v3s16 random_point(myrand_range(-bs2, bs2), myrand_range(-bs2, bs2), myrand_range(-bs2, bs2));
-	if (!isOccluded(cam_pos_nodes, pos_blockcenter + random_point, step, stepfac,
-				start_offset, end_offset, needed_count))
-		return false;
-
-	if (simple_check)
-		return true;
+	if (simple_check) {
+		v3s16 random_point(myrand_range(-bs2, bs2), myrand_range(-bs2, bs2), myrand_range(-bs2, bs2));
+		return isOccluded(cam_pos_nodes, pos_blockcenter + random_point, step, stepfac,
+					start_offset, end_offset, 1);
+	}
 
 	// Additional occlusion check, see comments in that function
 	v3s16 check;

--- a/src/map.h
+++ b/src/map.h
@@ -305,9 +305,9 @@ public:
 		}
 	}
 
-	bool isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes, bool simple_check = false)
+	bool isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes)
 	{
-		return isBlockOccluded(block->getPosRelative(), cam_pos_nodes, simple_check);
+		return isBlockOccluded(block->getPosRelative(), cam_pos_nodes, false);
 	}
 	bool isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool simple_check = false);
 


### PR DESCRIPTION
As described in #14186, I realized that client side occlusion culling must be deterministic. Otherwise there is a chance that the map on the client will flicker (if ray traced culling is used there).

This makes it so. Only the server will do sampling at a distance, as the set of blocks there is accumulative.
This also changes the default optimization distance from 20 to 25 (on the server).

And avoids requiring multiple solid nodes for the simple change (since we are sampling anyway, it does not matter, we will learn the correct set after a few round). As a benefit, this is far more accurate. In my test scene is avoids almost 2000 invisible blocks from being sent to the client (block count goes from about 10000 to about 8000). Especially for distant nodes we want to me more accurate, as there are so many of them,

- Goal of the PR
Avoid any chance to client side block flickering.

- How does the PR work?
See description.

- Does it resolve any reported issue?
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is Ready for Review.

## How to test

Load any world, set viewing_range to 1000 or something, client_mesh_chunk < 4. Check the world is eventually loaded, and no client flickering.
