### PR TITLE
ContentCAO: Fix threshold of alpha channel textures

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -325,9 +325,7 @@ void TestCAO::processMessage(const std::string &data)
 #include "clientobject.h"
 
 GenericCAO::GenericCAO(Client *client, ClientEnvironment *env):
-		ClientActiveObject(0, client, env),
-		m_material_type(video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF),
-		m_material_type_param(0.5f)
+		ClientActiveObject(0, client, env)
 {
 	if (!client) {
 		ClientActiveObject::registerType(getType(), create);
@@ -621,6 +619,8 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 		return;
 
 	infostream << "GenericCAO::addToScene(): " << m_prop.visual << std::endl;
+
+	m_material_type_param = 0.5f; // May cut off alpha < 128 depending on m_material_type
 
 	if (m_enable_shaders) {
 		IShaderSource *shader_source = m_client->getShaderSource();

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -638,7 +638,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 	} else {
 		if (m_prop.use_texture_alpha) {
 			m_material_type = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-			m_material_type_param = 0.01f; // minimal alpha for texture rendering
+			m_material_type_param = 1.0f / 256.f; // minimal alpha for texture rendering
 		} else {
 			m_material_type = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
 		}

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -325,7 +325,9 @@ void TestCAO::processMessage(const std::string &data)
 #include "clientobject.h"
 
 GenericCAO::GenericCAO(Client *client, ClientEnvironment *env):
-		ClientActiveObject(0, client, env)
+		ClientActiveObject(0, client, env),
+		m_material_type(video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF),
+		m_material_type_param(0.5f)
 {
 	if (!client) {
 		ClientActiveObject::registerType(getType(), create);
@@ -634,8 +636,12 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 		u32 shader_id = shader_source->getShader("object_shader", material_type, NDT_NORMAL);
 		m_material_type = shader_source->getShaderInfo(shader_id).material;
 	} else {
-		m_material_type = (m_prop.use_texture_alpha) ?
-			video::EMT_TRANSPARENT_ALPHA_CHANNEL : video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+		if (m_prop.use_texture_alpha) {
+			m_material_type = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+			m_material_type_param = 0.01f; // minimal alpha for texture rendering
+		} else {
+			m_material_type = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+		}
 	}
 
 	auto grabMatrixNode = [this] {
@@ -1341,7 +1347,7 @@ void GenericCAO::updateTextures(std::string mod)
 
 			video::SMaterial &material = m_spritenode->getMaterial(0);
 			material.MaterialType = m_material_type;
-			material.MaterialTypeParam = 0.5f;
+			material.MaterialTypeParam = m_material_type_param;
 			material.setTexture(0, tsrc->getTextureForMesh(texturestring));
 
 			// This allows setting per-material colors. However, until a real lighting
@@ -1377,7 +1383,7 @@ void GenericCAO::updateTextures(std::string mod)
 				// Set material flags and texture
 				video::SMaterial &material = m_animated_meshnode->getMaterial(i);
 				material.MaterialType = m_material_type;
-				material.MaterialTypeParam = 0.5f;
+				material.MaterialTypeParam = m_material_type_param;
 				material.TextureLayers[0].Texture = texture;
 				material.Lighting = true;
 				material.BackfaceCulling = m_prop.backface_culling;
@@ -1421,7 +1427,7 @@ void GenericCAO::updateTextures(std::string mod)
 				// Set material flags and texture
 				video::SMaterial &material = m_meshnode->getMaterial(i);
 				material.MaterialType = m_material_type;
-				material.MaterialTypeParam = 0.5f;
+				material.MaterialTypeParam = m_material_type_param;
 				material.Lighting = false;
 				material.setTexture(0, tsrc->getTextureForMesh(texturestring));
 				material.getTextureMatrix(0).makeIdentity();

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -130,6 +130,7 @@ private:
 	bool m_is_visible = false;
 	// Material
 	video::E_MATERIAL_TYPE m_material_type;
+	f32 m_material_type_param;
 	// Settings
 	bool m_enable_shaders = false;
 


### PR DESCRIPTION
With disabled shaders, the material EMT_TRANSPARENT_ALPHA_CHANNEL uses the parameter as an alpha threshold to decide whether to draw the texture. Thus lowering this limit fixes the issue of vanishing textures below alpha 128.

Fixes #14204

## To do

This PR is Ready for Review.

## How to test

1.- Set enable_shaders = false in MT
2. Install the Citadel game (ContentDB)
3. Teleport/travel to (5, 2, 12)
4. Look south and upwards, and see (or don't) the ghost
5. edit `games/citadel/mods/citadel_core/ghost.lua`. Modify the opacity in the line `self.object:set_texture_mod` to 10, 127, 128 and make sure the texture is still rendered.