### PR TITLE
Add "--needed" to Arch command to avoid reinstalling packages

### DIFF
--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -30,7 +30,7 @@ For openSUSE users:
 
 For Arch users:
 
-    sudo pacman -S base-devel libcurl-gnutls cmake libxi libpng sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext
+    sudo pacman -S base-devel libcurl-gnutls cmake libxi libpng sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext --needed
 
 For Alpine users:
 

--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -30,7 +30,7 @@ For openSUSE users:
 
 For Arch users:
 
-    sudo pacman -S base-devel libcurl-gnutls cmake libxi libpng sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext --needed
+    sudo pacman -S --needed base-devel libcurl-gnutls cmake libxi libpng sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext
 
 For Alpine users:
 


### PR DESCRIPTION
Tiny fix for doc/compiling/linux.md, do not reinstall arch packages if installed