### PR TITLE
Basic implementation of working server to server message.

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -561,6 +561,7 @@ core.registered_allow_player_inventory_actions, core.register_allow_player_inven
 core.registered_on_rightclickplayers, core.register_on_rightclickplayer = make_registration()
 core.registered_on_liquid_transformed, core.register_on_liquid_transformed = make_registration()
 core.registered_on_mapblocks_changed, core.register_on_mapblocks_changed = make_registration()
+core.registered_on_server_receive_message, core.register_on_server_receive_message = make_registration()
 
 core.register_on_mods_loaded(function()
 	core.after(0, function()

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5763,6 +5763,11 @@ Call these functions only at load time!
       The set is a table where the keys are hashes and the values are `true`.
     * `modified_block_count` is the number of entries in the set.
     * Note: callbacks must be registered at mod load time.
+* `minetest.register_server_receive_message(function(server_name, message))`
+    * Called after message from another server is received.
+    * `server_name` is name of server identified by using data 
+      from `minetest.set_another_server`
+    * `message` is a string message received.
 
 Setting-related
 ---------------
@@ -6572,6 +6577,19 @@ Server
     * Clients will attempt to fetch files added this way via remote media,
       this can make transfer of bigger files painless (if set up). Nevertheless
       it is advised not to use dynamic media for big media files.
+* `minetest.set_another_server(name, server_spec)`: 
+    * `name`: Unique name of another server
+    * `server spec`: 
+      * Set this to nil for remove server.
+      * Table with server specification to be set:
+        * `address`: Address of server.
+        * `port`: Port where is server listening.
+        * `auth_send`: Authorization string to be used to verify sender ofserver message on receiver side.
+        * `auth_receive`: Authorization string to be used to verify sender identity of received server messages.
+    * Returns boolean indicating success (false if player nonexistent)
+* `minetest.get_another_server(name)`: 
+    * `name`: Name of another server
+    * Returns table contains server data or nil if server is not known
 
 Bans
 ----

--- a/games/devtest/mods/testservermessages/init.lua
+++ b/games/devtest/mods/testservermessages/init.lua
@@ -1,0 +1,61 @@
+
+-- this is minimal try to test sending and receiving of server messages
+
+local worldpath = minetest.get_worldpath()
+
+local conf = worldpath.."/network.conf"
+
+local f=io.open(conf,"r")
+if f then
+	f:close()
+
+	conf = Settings(conf)
+
+	local index = 0;
+	local server = {}
+	local servers = {}
+
+	while true do
+		if conf:has("server"..index.."_name") then
+			server.name = conf:get("server"..index.."_name")
+			server.address = conf:get("server"..index.."_address") or "localhost"
+			server.port = tonumber(conf:get("server"..index.."_port") or "30000")
+			server.auth_send = conf:get("server"..index.."_auth_send") or "NO_AUTH"
+			server.auth_receive = conf:get("server"..index.."_auth_receive") or "NO_AUTH"
+
+			minetest.set_another_server(server.name, server)
+			local check = minetest.get_another_server(server.name)
+			if check then
+				table.insert(servers, server.name)
+			else
+				error("[devtest] Another server "..server.name.." setting failed: "..dump(server))
+			end
+		else
+			break
+		end
+    index = index + 1
+	end
+
+	minetest.register_chatcommand("send_msg_to_server", {
+			params = "server_name message",
+			description = "Tune lighting parameters",
+			privs = {server = true},
+			func = function(player_name, param)
+				local params = string.split(param, " ", false, 2)
+				if #params < 2 then
+					return false, "Expected server name and message body as argument."
+				end
+				if minetest.send_msg_another_server(params[1], params[2]) then
+					return true, "Message has been sent."
+				else
+					return false, "Message sending failed."
+				end
+			end
+		})
+	minetest.register_on_server_receive_message(
+			function (name, message)
+				minetest.chat_send_all("Received server message from server "..name.."with body: "..message)
+				minetest.log("action", "[devtest] Received server message from server "..name.."with body: "..message)
+			end
+		)
+end

--- a/games/devtest/mods/testservermessages/mod.conf
+++ b/games/devtest/mods/testservermessages/mod.conf
@@ -1,0 +1,1 @@
+name = testservermessages

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -415,6 +415,7 @@ set(common_SRCS
 	serialization.cpp
 	server.cpp
 	serverenvironment.cpp
+	serveriface.cpp
 	serverlist.cpp
 	settings.cpp
 	staticobject.cpp

--- a/src/network/address.cpp
+++ b/src/network/address.cpp
@@ -84,7 +84,7 @@ Address::Address(const IPv6AddressBytes *ipv6_bytes, u16 port)
 }
 
 // Equality (address family, IP and port must be equal)
-bool Address::operator==(const Address &other)
+bool Address::operator==(const Address &other) const
 {
 	if (other.m_addr_family != m_addr_family || other.m_port != m_port)
 		return false;

--- a/src/network/address.h
+++ b/src/network/address.h
@@ -47,8 +47,8 @@ public:
 	Address(u8 a, u8 b, u8 c, u8 d, u16 port);
 	Address(const IPv6AddressBytes *ipv6_bytes, u16 port);
 
-	bool operator==(const Address &address);
-	bool operator!=(const Address &address) { return !(*this == address); }
+	bool operator==(const Address &address) const;
+	bool operator!=(const Address &address) const { return !(*this == address); }
 
 	struct in_addr getAddress() const;
 	struct in6_addr getAddress6() const;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -895,6 +895,14 @@ enum ToServerCommand
 		std::string player name
 	*/
 
+	/*
+		Sent message to another minetest server
+
+		std::string authorization
+		std::string message
+	*/
+	TOSERVER_SERVERMSG = 0x08,
+
 	TOSERVER_INIT_LEGACY = 0x10, // Obsolete
 
 	TOSERVER_INIT2 = 0x11,

--- a/src/network/peerhandler.h
+++ b/src/network/peerhandler.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "networkprotocol.h"
+#include "address.h"
 
 namespace con
 {
@@ -64,14 +65,16 @@ enum PeerChangeType : u8
 
 struct PeerChange
 {
-	PeerChange(PeerChangeType t, session_t _peer_id, bool _timeout) :
-			type(t), peer_id(_peer_id), timeout(_timeout)
+	PeerChange(PeerChangeType t, session_t _peer_id, bool _another_server, Address &_address, bool _timeout) :
+			type(t), peer_id(_peer_id), another_server(_another_server), address(_address), timeout(_timeout)
 	{
 	}
 	PeerChange() = delete;
 
 	PeerChangeType type;
 	session_t peer_id;
+	bool another_server;
+	Address address;
 	bool timeout;
 };
 }

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -225,3 +225,101 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_MINIMAP_MODES",            0, true }, // 0x62
 	{ "TOCLIENT_SET_LIGHTING",             0, true }, // 0x63
 };
+
+const static ServerToServerCommandFactory null_command_factory_2 = { "TOSERVER_NULL", 0, false };
+
+/*
+	Channels used for Server -> Server communication
+	0: messages
+
+	Packet order is only guaranteed inside a channel, so packets that operate on
+	the same objects are *required* to be in the same channel.
+*/
+
+const ServerToServerCommandFactory serverToServerCommandFactoryTable[TOSERVER_NUM_MSG_TYPES] =
+{
+	null_command_factory_2, // 0x00
+	null_command_factory_2, // 0x01
+	null_command_factory_2, // 0x02
+	null_command_factory_2, // 0x03
+	null_command_factory_2, // 0x04
+	null_command_factory_2, // 0x05
+	null_command_factory_2, // 0x06
+	null_command_factory_2, // 0x07
+	{ "TOSERVER_SERVERMSG",              0, true }, // 0x08
+	null_command_factory_2, // 0x09
+	null_command_factory_2, // 0x0a
+	null_command_factory_2, // 0x0b
+	null_command_factory_2, // 0x0c
+	null_command_factory_2, // 0x0d
+	null_command_factory_2, // 0x0e
+	null_command_factory_2, // 0x0f
+	null_command_factory_2, // 0x10
+	null_command_factory_2, // 0x11
+	null_command_factory_2, // 0x12
+	null_command_factory_2, // 0x13
+	null_command_factory_2, // 0x14
+	null_command_factory_2, // 0x15
+	null_command_factory_2, // 0x16
+	null_command_factory_2, // 0x17
+	null_command_factory_2, // 0x18
+	null_command_factory_2, // 0x19
+	null_command_factory_2, // 0x1a
+	null_command_factory_2, // 0x1b
+	null_command_factory_2, // 0x1c
+	null_command_factory_2, // 0x1d
+	null_command_factory_2, // 0x1e
+	null_command_factory_2, // 0x1f
+	null_command_factory_2, // 0x20
+	null_command_factory_2, // 0x21
+	null_command_factory_2, // 0x22
+	null_command_factory_2, // 0x23
+	null_command_factory_2, // 0x24
+	null_command_factory_2, // 0x25
+	null_command_factory_2, // 0x26
+	null_command_factory_2, // 0x27
+	null_command_factory_2, // 0x28
+	null_command_factory_2, // 0x29
+	null_command_factory_2, // 0x2a
+	null_command_factory_2, // 0x2b
+	null_command_factory_2, // 0x2c
+	null_command_factory_2, // 0x2d
+	null_command_factory_2, // 0x2e
+	null_command_factory_2, // 0x2f
+	null_command_factory_2, // 0x30
+	null_command_factory_2, // 0x31
+	null_command_factory_2, // 0x32
+	null_command_factory_2, // 0x33
+	null_command_factory_2, // 0x34
+	null_command_factory_2, // 0x35
+	null_command_factory_2, // 0x36
+	null_command_factory_2, // 0x37
+	null_command_factory_2, // 0x38
+	null_command_factory_2, // 0x39
+	null_command_factory_2, // 0x3a
+	null_command_factory_2, // 0x3b
+	null_command_factory_2, // 0x3c
+	null_command_factory_2, // 0x3d
+	null_command_factory_2, // 0x3e
+	null_command_factory_2, // 0x3f
+	null_command_factory_2, // 0x40
+	null_command_factory_2, // 0x10
+	null_command_factory_2, // 0x42
+	null_command_factory_2, // 0x43
+	null_command_factory_2, // 0x44
+	null_command_factory_2, // 0x45
+	null_command_factory_2, // 0x46
+	null_command_factory_2, // 0x47
+	null_command_factory_2, // 0x48
+	null_command_factory_2, // 0x49
+	null_command_factory_2, // 0x4a
+	null_command_factory_2, // 0x4b
+	null_command_factory_2, // 0x4c
+	null_command_factory_2, // 0x4d
+	null_command_factory_2, // 0x4e
+	null_command_factory_2, // 0x4f
+	null_command_factory_2, // 0x50
+	null_command_factory_2, // 0x51
+	null_command_factory_2, // 0x52
+	null_command_factory_2, // 0x53
+};

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -32,7 +32,7 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_handler, // 0x05
 	null_command_handler, // 0x06
 	null_command_handler, // 0x07
-	null_command_handler, // 0x08
+	{ "TOSERVER_SERVERMSG",                TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_ServerMsg}, // 0x08
 	null_command_handler, // 0x09
 	null_command_handler, // 0x0a
 	null_command_handler, // 0x0b

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -45,6 +45,10 @@ struct ClientCommandFactory
 	bool reliable;
 };
 
+typedef ClientCommandFactory ServerToServerCommandFactory;
+
 extern const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES];
 
 extern const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES];
+
+extern const ServerToServerCommandFactory serverToServerCommandFactoryTable[TOSERVER_NUM_MSG_TYPES];

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1882,3 +1882,15 @@ void Server::handleCommand_UpdateClientInfo(NetworkPacket *pkt)
 	RemoteClient *client = getClient(peer_id, CS_Invalid);
 	client->setDynamicInfo(info);
 }
+
+void Server::handleCommand_ServerMsg(NetworkPacket *pkt)
+{
+	std::string auth;
+	std::string msg;
+	*pkt >> auth;
+	*pkt >> msg;
+
+	verbosestream << "Server received MSG from another server \"" << msg << "\" received." << std::endl;
+
+	getScriptIface()->on_server_receive_msg(auth, msg);
+}

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -33,6 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapgen/mg_schematic.h"
 #include "noise.h"
 #include "server/player_sao.h"
+#include "server/servernetwork.h"
 #include "util/pointedthing.h"
 #include "debug.h" // For FATAL_ERROR
 #include <json/json.h>
@@ -2253,4 +2254,33 @@ void push_mod_spec(lua_State *L, const ModSpec &spec, bool include_unsatisfied)
 		lua_rawseti(L, -2, i++);
 	}
 	lua_setfield(L, -2, "unsatisfied_depends");
+}
+
+/******************************************************************************/
+void read_anotherserver(lua_State *L, int index, AnotherServer &server)
+{
+	if(index < 0)
+		index = lua_gettop(L) + 1 + index;
+	if (lua_isnil(L, index))
+		return;
+
+	if (lua_istable(L, index)) {
+		getstringfield(L, index, "address", server.address_string);
+		getintfield<u16>(L, index, "port", server.port);
+		getstringfield(L, index, "auth_send", server.auth_send);
+		getstringfield(L, index, "auth_receive", server.auth_receive);
+	}
+}
+
+void push_anotherserver(lua_State *L, const AnotherServer &server)
+{
+	lua_createtable(L, 0, 3);
+	lua_pushstring(L, server.address_string.c_str());
+	lua_setfield(L, -2, "address");
+	lua_pushnumber(L, server.port);
+	lua_setfield(L, -2, "port");
+	lua_pushstring(L, server.auth_send.c_str());
+	lua_setfield(L, -2, "auth_send");
+	lua_pushstring(L, server.auth_receive.c_str());
+	lua_setfield(L, -2, "auth_receive");
 }

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -69,6 +69,7 @@ struct NoiseParams;
 class Schematic;
 class ServerActiveObject;
 struct collisionMoveResult;
+struct AnotherServer;
 
 extern struct EnumString es_TileAnimationType[];
 
@@ -210,3 +211,6 @@ bool read_hud_change           (lua_State *L, HudElementStat &stat, HudElement *
 void push_collision_move_result(lua_State *L, const collisionMoveResult &res);
 
 void push_mod_spec(lua_State *L, const ModSpec &spec, bool include_unsatisfied);
+
+void read_anotherserver(lua_State *L, int index, AnotherServer &server);
+void push_anotherserver(lua_State *L, const AnotherServer &server);

--- a/src/script/cpp_api/s_server.cpp
+++ b/src/script/cpp_api/s_server.cpp
@@ -260,3 +260,20 @@ void ScriptApiServer::on_dynamic_media_added(u32 token, const char *playername)
 	lua_pushstring(L, playername);
 	PCALL_RES(lua_pcall(L, 1, 0, error_handler));
 }
+
+// on receive server message
+void ScriptApiServer::on_server_receive_msg(const std::string &name, const std::string &msg)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_server_receive_msgs
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_server_receive_message");
+	// Call callbacks
+	// param 1
+	lua_pushstring(L, name.c_str());
+	// param 2
+	lua_pushstring(L, msg.c_str());
+
+	runCallbacks(2, RUN_CALLBACKS_MODE_OR_SC);
+}

--- a/src/script/cpp_api/s_server.h
+++ b/src/script/cpp_api/s_server.h
@@ -55,6 +55,9 @@ public:
 	void freeDynamicMediaCallback(u32 token);
 	void on_dynamic_media_added(u32 token, const char *playername);
 
+	// Called when message from another server is received
+	void on_server_receive_msg(const std::string &name, const std::string &msg);
+
 private:
 	void getAuthHandler();
 	void readPrivileges(int index, std::set<std::string> &result);

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -121,6 +121,14 @@ private:
 	// serialize_roundtrip(obj)
 	static int l_serialize_roundtrip(lua_State *L);
 
+	// set_another_server(name, server_spec)
+	static int l_set_another_server(lua_State *L);
+
+	// get_another_server(name)
+	static int l_get_another_server(lua_State *L);
+
+	// send_msg_another_server(name, msg)
+	static int l_send_msg_another_server(lua_State *L);
 public:
 	static void Initialize(lua_State *L, int top);
 	static void InitializeAsync(lua_State *L, int top);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -24,7 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "network/connection.h"
 #include "network/networkprotocol.h"
 #include "network/serveropcodes.h"
-#include "network/clientopcodes.h"
 #include "ban.h"
 #include "environment.h"
 #include "map.h"
@@ -1390,9 +1389,9 @@ void Server::Send(session_t peer_id, NetworkPacket *pkt)
 void Server::SendToServer(session_t peer_id, NetworkPacket *pkt)
 {
 	m_con->Send(peer_id,
-		serverCommandFactoryTable[pkt->getCommand()].channel,
+		serverToServerCommandFactoryTable[pkt->getCommand()].channel,
 		pkt,
-		serverCommandFactoryTable[pkt->getCommand()].reliable);
+		serverToServerCommandFactoryTable[pkt->getCommand()].reliable);
 }
 
 void Server::SendMovement(session_t peer_id)

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -5,5 +5,6 @@ set(server_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/player_sao.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/serveractiveobject.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/serverinventorymgr.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/servernetwork.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/unit_sao.cpp
 	PARENT_SCOPE)

--- a/src/server/servernetwork.cpp
+++ b/src/server/servernetwork.cpp
@@ -1,0 +1,69 @@
+/*
+Minetest
+Copyright (C) 2024 SFENCE <sfence.software@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "servernetwork.h"
+#include "log.h"
+#include <stdexcept>
+
+	
+// get name of server
+const std::string *ServerNetwork::getName(const Address &address, const std::string &auth) const
+{
+	for (auto it = m_servers.begin(); it != m_servers.end(); ++it)
+	{
+		if ((it->second.auth_receive == auth) && (it->second.address == address)) {
+			return &it->first;
+		}
+	}
+	return nullptr;
+}
+
+// add/set server
+void ServerNetwork::setServer(const std::string &name, const AnotherServer &server_def)
+{
+	m_servers[name] = server_def;
+
+	AnotherServer &server = m_servers[name];
+	
+	server.address.setPort(server.port);
+
+	server.address.Resolve(server.address_string.c_str());
+
+	if (server.address.isZero()) { // i.e. INADDR_ANY, IN6ADDR_ANY
+		throw ResolveError("Resolved as zero address.");
+	}
+
+	verbosestream << "Another server address " << server.address_string << " resolved as " << server.address.serializeString();
+}
+// get server
+const AnotherServer* ServerNetwork::getServer(const std::string &name)
+{
+	try {
+		const AnotherServer &server = m_servers.at(name);
+		return &server;
+	}
+	catch (std::out_of_range &key) {
+	}
+	return nullptr;
+}
+// remove server
+void ServerNetwork::removeServer(const std::string &name)
+{
+	m_servers.erase(name);
+}

--- a/src/server/servernetwork.h
+++ b/src/server/servernetwork.h
@@ -1,0 +1,57 @@
+/*
+Minetest
+Copyright (C) 2024 SFENCE <sfence.software@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes.h"
+#include "util/basic_macros.h"
+#include "network/address.h"
+#include <string>
+#include <map>
+
+struct AnotherServer
+{
+	std::string address_string;
+	Address address;
+	u16 port;
+	std::string auth_send;
+	std::string auth_receive;
+};
+
+class ServerNetwork
+{
+public:
+	ServerNetwork() = default;
+	~ServerNetwork() = default;
+	DISABLE_CLASS_COPY(ServerNetwork);
+
+	// get name of server
+	const std::string *getName(const Address &address, const std::string &auth) const;
+
+	// add/set server
+	void setServer(const std::string &name, const AnotherServer &server);
+	// get server
+	const AnotherServer *getServer(const std::string &name);
+	// remove server
+	void removeServer(const std::string &name);
+
+private:
+	std::map<std::string, AnotherServer> m_servers;
+};
+

--- a/src/serveriface.cpp
+++ b/src/serveriface.cpp
@@ -1,0 +1,156 @@
+/*
+Minetest
+Copyright (C) 2024 SFENCE <sfence.software@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <sstream>
+#include "serveriface.h"
+#include "network/connection.h"
+#include "network/clientopcodes.h"
+#include "network/networkpacket.h"
+#include "settings.h"
+#include "emerge.h"
+#include "log.h"
+#include "util/srp.h"
+#include "face_position_cache.h"
+
+RemoteServer::RemoteServer(session_t peer_id_, const Address &address) :
+	peer_id(peer_id_),
+	m_addr(address)
+{
+}
+
+/*
+void RemoteServer::resetChosenMech()
+{
+	if (auth_data) {
+		srp_verifier_delete((SRPVerifier *) auth_data);
+		auth_data = nullptr;
+	}
+	chosen_mech = AUTH_MECHANISM_NONE;
+}
+*/
+
+u64 RemoteServer::uptime() const
+{
+	return porting::getTimeS() - m_connection_time;
+}
+
+ServerInterface::ServerInterface(const std::shared_ptr<con::Connection> & con)
+:
+	m_con(con)
+{
+
+}
+ServerInterface::~ServerInterface()
+{
+	/*
+		Delete servers
+	*/
+	{
+		RecursiveMutexAutoLock serverslock(m_servers_mutex);
+
+		for (auto &server_it : m_servers) {
+			// Delete server
+			delete server_it.second;
+		}
+	}
+}
+
+std::vector<session_t> ServerInterface::getServerIDs()
+{
+	std::vector<session_t> reply;
+	RecursiveMutexAutoLock serverslock(m_servers_mutex);
+
+	for (const auto &m_server : m_servers) {
+		reply.push_back(m_server.second->peer_id);
+	}
+
+	return reply;
+}
+
+void ServerInterface::send(session_t peer_id, u8 channelnum,
+		NetworkPacket *pkt, bool reliable)
+{
+	m_con->Send(peer_id, channelnum, pkt, reliable);
+}
+
+void ServerInterface::sendToAll(NetworkPacket *pkt)
+{
+	RecursiveMutexAutoLock serverslock(m_servers_mutex);
+	for (auto &server_it : m_servers) {
+		RemoteServer *server = server_it.second;
+
+		m_con->Send(server->peer_id,
+				serverCommandFactoryTable[pkt->getCommand()].channel, pkt,
+				serverCommandFactoryTable[pkt->getCommand()].reliable);
+	}
+}
+
+RemoteServer* ServerInterface::getServerNoEx(session_t peer_id)
+{
+	RecursiveMutexAutoLock serverslock(m_servers_mutex);
+	RemoteServerMap::const_iterator n = m_servers.find(peer_id);
+	// The server may not exist; servers are immediately removed if their
+	// access is denied, and this event occurs later then.
+	if (n == m_servers.end())
+		return NULL;
+
+	return n->second;
+}
+
+RemoteServer* ServerInterface::lockedGetServerNoEx(session_t peer_id)
+{
+	RemoteServerMap::const_iterator n = m_servers.find(peer_id);
+	// The server may not exist; servers are immediately removed if their
+	// access is denied, and this event occurs later then.
+	if (n == m_servers.end())
+		return NULL;
+
+	return n->second;
+}
+
+void ServerInterface::DeleteServer(session_t peer_id)
+{
+	RecursiveMutexAutoLock conlock(m_servers_mutex);
+
+	// Error check
+	RemoteServerMap::iterator n = m_servers.find(peer_id);
+	// The server may not exist; servers are immediately removed if their
+	// access is denied, and this event occurs later then.
+	if (n == m_servers.end())
+		return;
+
+	// Delete server
+	delete m_servers[peer_id];
+	m_servers.erase(peer_id);
+}
+
+void ServerInterface::CreateServer(session_t peer_id, const Address &address)
+{
+	RecursiveMutexAutoLock conlock(m_servers_mutex);
+
+	// Error check
+	RemoteServerMap::iterator n = m_servers.find(peer_id);
+	// The server shouldn't already exist
+	if (n != m_servers.end()) return;
+
+	// Create server
+	RemoteServer *server = new RemoteServer(peer_id, address);
+	m_servers[server->peer_id] = server;
+}
+

--- a/src/serveriface.cpp
+++ b/src/serveriface.cpp
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <sstream>
 #include "serveriface.h"
 #include "network/connection.h"
-#include "network/clientopcodes.h"
+#include "network/serveropcodes.h"
 #include "network/networkpacket.h"
 #include "settings.h"
 #include "emerge.h"
@@ -96,8 +96,8 @@ void ServerInterface::sendToAll(NetworkPacket *pkt)
 		RemoteServer *server = server_it.second;
 
 		m_con->Send(server->peer_id,
-				serverCommandFactoryTable[pkt->getCommand()].channel, pkt,
-				serverCommandFactoryTable[pkt->getCommand()].reliable);
+				serverToServerCommandFactoryTable[pkt->getCommand()].channel, pkt,
+				serverToServerCommandFactoryTable[pkt->getCommand()].reliable);
 	}
 }
 

--- a/src/serveriface.h
+++ b/src/serveriface.h
@@ -1,0 +1,121 @@
+/*
+Minetest
+Copyright (C) 2024 SFENCE <sfence.software@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "network/address.h"
+#include "network/connection.h"
+#include "threading/mutex_auto_lock.h"
+
+#include <list>
+#include <vector>
+#include <set>
+#include <unordered_set>
+#include <memory>
+#include <mutex>
+
+class RemoteServer
+{
+public:
+	// peer_id=0 means this server has no associated peer
+	// NOTE: If server is made allowed to exist while peer doesn't,
+	//       this has to be set to 0 when there is no peer.
+	//       Also, the server must be moved to some other container.
+	session_t peer_id = PEER_ID_INEXISTENT;
+
+	/* Authentication information */
+	/*
+	std::string enc_pwd = "";
+	bool create_player_on_auth_success = false;
+	AuthMechanism chosen_mech  = AUTH_MECHANISM_NONE;
+	void *auth_data = nullptr;
+	u32 allowed_auth_mechs = 0;
+	u32 allowed_sudo_mechs = 0;
+
+	void resetChosenMech();
+	*/
+
+
+	RemoteServer() = default;
+	RemoteServer(session_t peer_id, const Address &address);
+	~RemoteServer() = default;
+
+	/* get uptime */
+	u64 uptime() const;
+
+	const Address &getAddress() const { return m_addr; }
+private:
+	// Cached here so retrieval doesn't have to go to connection API
+	Address m_addr;
+
+	/*
+		time this server was created
+	 */
+	const u64 m_connection_time = porting::getTimeS();
+};
+
+typedef std::unordered_map<u16, RemoteServer*> RemoteServerMap;
+
+class ServerInterface {
+public:
+
+	friend class Server;
+
+	ServerInterface(const std::shared_ptr<con::Connection> &con);
+	~ServerInterface();
+
+	/* get list of active server id's */
+	std::vector<session_t> getServerIDs();
+
+	/* send message to server */
+	void send(session_t peer_id, u8 channelnum, NetworkPacket *pkt, bool reliable);
+
+	/* send to all servers */
+	void sendToAll(NetworkPacket *pkt);
+
+	/* delete a server */
+	void DeleteServer(session_t peer_id);
+
+	/* create server */
+	void CreateServer(session_t peer_id, const Address &address);
+
+	/* get a server by peer_id */
+	RemoteServer *getServerNoEx(session_t peer_id);
+
+	/* get server by peer_id (make sure you have list lock before!*/
+	RemoteServer *lockedGetServerNoEx(session_t peer_id);
+
+protected:
+	class AutoLock {
+	public:
+		AutoLock(ServerInterface &iface): m_lock(iface.m_servers_mutex) {}
+
+	private:
+		RecursiveMutexAutoLock m_lock;
+	};
+
+	RemoteServerMap& getServerList() { return m_servers; }
+
+private:
+	// Connection
+	std::shared_ptr<con::Connection> m_con;
+	std::recursive_mutex m_servers_mutex;
+	// Connected servers (behind the con mutex)
+	RemoteServerMap m_servers;
+};


### PR DESCRIPTION
- Goal of the PR
Add ability for server-to-server communication in connection with #14129.
- How does the PR work?
Send string from one to another server. It is on Lua to serialize/deserialize string and do something around it.
- Does it resolve any reported issue?
- Yes, it should fix part of #5813.
- If not a bug fix, why is this PR needed? What usecases does it solve?
With this, a network of servers should be created. So some networks like one server for space and another server for each planet, can be created and players can be transferred between servers by #14129 and their inventories and other states can be synced by server-to-server communication.

## To do

This PR is a Work in Progress.

- [ ] Get feedback.
- [ ] Apply feedback.
- [ ] Add better authorization.

## How to test

1. Compile Minetest with this branch.
1. Create two worlds with the game devtest.

1. To `server0` world directory save file [network_server_0.txt](https://github.com/minetest/minetest/files/13853410/network_server_0.txt) as `network.conf`.
1. To `server1` world directory save file [network_server_1.txt](https://github.com/minetest/minetest/files/13853411/network_server_1.txt) as `network.conf`.

1. Host server for game `server0` on port `30000`.
1. Host server for game `server1` on port `30000`.

1. Call command `/send_msg_to_server server0 HELLO_SERVER!` on `server1` or
   command `/send_msg_to_server server1 HELLO_SERVER!` on `server0`.
1. The first message is lost at the moment, so send the same message again to see it.
1. Received message should be printed as a message for all players on the second server.



https://github.com/minetest/minetest/assets/17455197/46de45f8-da97-4199-b79c-557c510ac4ba

