### PR TITLE
Code style: Use non-static member initialisation instead of member initialiser lists for shader uniform names

### DIFF
--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -47,10 +47,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class CAOShaderConstantSetter : public IShaderConstantSetter
 {
 public:
-	CAOShaderConstantSetter():
-			m_emissive_color_setting("emissiveColor")
-	{}
-
 	~CAOShaderConstantSetter() override = default;
 
 	void onSetConstants(video::IMaterialRendererServices *services) override
@@ -74,7 +70,8 @@ public:
 
 private:
 	video::SColor m_emissive_color;
-	CachedPixelShaderSetting<float, 4> m_emissive_color_setting;
+	CachedPixelShaderSetting<float, 4>
+		m_emissive_color_setting{"emissiveColor"};
 };
 
 class CAOShaderConstantSetterFactory : public IShaderConstantSetterFactory

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -373,43 +373,55 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	bool *m_force_fog_off;
 	f32 *m_fog_range;
 	bool m_fog_enabled;
-	CachedPixelShaderSetting<float, 4> m_sky_bg_color;
-	CachedPixelShaderSetting<float> m_fog_distance;
-	CachedPixelShaderSetting<float> m_fog_shading_parameter;
-	CachedVertexShaderSetting<float> m_animation_timer_vertex;
-	CachedPixelShaderSetting<float> m_animation_timer_pixel;
-	CachedVertexShaderSetting<float> m_animation_timer_delta_vertex;
-	CachedPixelShaderSetting<float> m_animation_timer_delta_pixel;
-	CachedPixelShaderSetting<float, 3> m_day_light;
-	CachedPixelShaderSetting<float, 4> m_star_color;
-	CachedPixelShaderSetting<float, 3> m_eye_position_pixel;
-	CachedVertexShaderSetting<float, 3> m_eye_position_vertex;
-	CachedPixelShaderSetting<float, 3> m_minimap_yaw;
-	CachedPixelShaderSetting<float, 3> m_camera_offset_pixel;
-	CachedPixelShaderSetting<float, 3> m_camera_offset_vertex;
-	CachedPixelShaderSetting<SamplerLayer_t> m_texture0;
-	CachedPixelShaderSetting<SamplerLayer_t> m_texture1;
-	CachedPixelShaderSetting<SamplerLayer_t> m_texture2;
-	CachedPixelShaderSetting<SamplerLayer_t> m_texture3;
-	CachedVertexShaderSetting<float, 2> m_texel_size0_vertex;
-	CachedPixelShaderSetting<float, 2> m_texel_size0_pixel;
+	CachedPixelShaderSetting<float, 4> m_sky_bg_color{"skyBgColor"};
+	CachedPixelShaderSetting<float> m_fog_distance{"fogDistance"};
+	CachedPixelShaderSetting<float>
+		m_fog_shading_parameter{"fogShadingParameter"};
+	CachedVertexShaderSetting<float> m_animation_timer_vertex{"animationTimer"};
+	CachedPixelShaderSetting<float> m_animation_timer_pixel{"animationTimer"};
+	CachedVertexShaderSetting<float>
+		m_animation_timer_delta_vertex{"animationTimerDelta"};
+	CachedPixelShaderSetting<float>
+		m_animation_timer_delta_pixel{"animationTimerDelta"};
+	CachedPixelShaderSetting<float, 3> m_day_light{"dayLight"};
+	CachedPixelShaderSetting<float, 4> m_star_color{"starColor"};
+	CachedPixelShaderSetting<float, 3> m_eye_position_pixel{"eyePosition"};
+	CachedVertexShaderSetting<float, 3> m_eye_position_vertex{"eyePosition"};
+	CachedPixelShaderSetting<float, 3> m_minimap_yaw{"yawVec"};
+	CachedPixelShaderSetting<float, 3> m_camera_offset_pixel{"cameraOffset"};
+	CachedPixelShaderSetting<float, 3> m_camera_offset_vertex{"cameraOffset"};
+	CachedPixelShaderSetting<SamplerLayer_t> m_texture0{"texture0"};
+	CachedPixelShaderSetting<SamplerLayer_t> m_texture1{"texture1"};
+	CachedPixelShaderSetting<SamplerLayer_t> m_texture2{"texture2"};
+	CachedPixelShaderSetting<SamplerLayer_t> m_texture3{"texture3"};
+	CachedVertexShaderSetting<float, 2> m_texel_size0_vertex{"texelSize0"};
+	CachedPixelShaderSetting<float, 2> m_texel_size0_pixel{"texelSize0"};
 	std::array<float, 2> m_texel_size0_values;
-	CachedStructPixelShaderSetting<float, 7> m_exposure_params_pixel;
+	CachedStructPixelShaderSetting<float, 7> m_exposure_params_pixel{
+		"exposureParams",
+		std::array<const char*, 7> {
+			"luminanceMin", "luminanceMax", "exposureCorrection",
+			"speedDarkBright", "speedBrightDark", "centerWeightPower",
+			"compensationFactor"
+		}};
 	float m_user_exposure_compensation;
 	bool m_bloom_enabled;
-	CachedPixelShaderSetting<float> m_bloom_intensity_pixel;
+	CachedPixelShaderSetting<float> m_bloom_intensity_pixel{"bloomIntensity"};
 	float m_bloom_intensity;
-	CachedPixelShaderSetting<float> m_bloom_strength_pixel;
+	CachedPixelShaderSetting<float> m_bloom_strength_pixel{"bloomStrength"};
 	float m_bloom_strength;
-	CachedPixelShaderSetting<float> m_bloom_radius_pixel;
+	CachedPixelShaderSetting<float> m_bloom_radius_pixel{"bloomRadius"};
 	float m_bloom_radius;
-	CachedPixelShaderSetting<float> m_saturation_pixel;
+	CachedPixelShaderSetting<float> m_saturation_pixel{"saturation"};
 	bool m_volumetric_light_enabled;
-	CachedPixelShaderSetting<float, 3> m_sun_position_pixel;
-	CachedPixelShaderSetting<float> m_sun_brightness_pixel;
-	CachedPixelShaderSetting<float, 3> m_moon_position_pixel;
-	CachedPixelShaderSetting<float> m_moon_brightness_pixel;
-	CachedPixelShaderSetting<float> m_volumetric_light_strength_pixel;
+	CachedPixelShaderSetting<float, 3>
+		m_sun_position_pixel{"sunPositionScreen"};
+	CachedPixelShaderSetting<float> m_sun_brightness_pixel{"sunBrightness"};
+	CachedPixelShaderSetting<float, 3>
+		m_moon_position_pixel{"moonPositionScreen"};
+	CachedPixelShaderSetting<float> m_moon_brightness_pixel{"moonBrightness"};
+	CachedPixelShaderSetting<float>
+		m_volumetric_light_strength_pixel{"volumetricLightStrength"};
 
 public:
 	void onSettingsChange(const std::string &name)
@@ -438,41 +450,7 @@ public:
 		m_sky(sky),
 		m_client(client),
 		m_force_fog_off(force_fog_off),
-		m_fog_range(fog_range),
-		m_sky_bg_color("skyBgColor"),
-		m_fog_distance("fogDistance"),
-		m_fog_shading_parameter("fogShadingParameter"),
-		m_animation_timer_vertex("animationTimer"),
-		m_animation_timer_pixel("animationTimer"),
-		m_animation_timer_delta_vertex("animationTimerDelta"),
-		m_animation_timer_delta_pixel("animationTimerDelta"),
-		m_day_light("dayLight"),
-		m_star_color("starColor"),
-		m_eye_position_pixel("eyePosition"),
-		m_eye_position_vertex("eyePosition"),
-		m_minimap_yaw("yawVec"),
-		m_camera_offset_pixel("cameraOffset"),
-		m_camera_offset_vertex("cameraOffset"),
-		m_texture0("texture0"),
-		m_texture1("texture1"),
-		m_texture2("texture2"),
-		m_texture3("texture3"),
-		m_texel_size0_vertex("texelSize0"),
-		m_texel_size0_pixel("texelSize0"),
-		m_exposure_params_pixel("exposureParams",
-				std::array<const char*, 7> {
-						"luminanceMin", "luminanceMax", "exposureCorrection",
-						"speedDarkBright", "speedBrightDark", "centerWeightPower", "compensationFactor"
-				}),
-		m_bloom_intensity_pixel("bloomIntensity"),
-		m_bloom_strength_pixel("bloomStrength"),
-		m_bloom_radius_pixel("bloomRadius"),
-		m_saturation_pixel("saturation"),
-		m_sun_position_pixel("sunPositionScreen"),
-		m_sun_brightness_pixel("sunBrightness"),
-		m_moon_position_pixel("moonPositionScreen"),
-		m_moon_brightness_pixel("moonBrightness"),
-		m_volumetric_light_strength_pixel("volumetricLightStrength")
+		m_fog_range(fog_range)
 	{
 		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
 		g_settings->registerChangedCallback("exposure_compensation", settingsCallback, this);

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -210,51 +210,36 @@ public:
 
 class MainShaderConstantSetter : public IShaderConstantSetter
 {
-	CachedVertexShaderSetting<f32, 16> m_world_view_proj;
-	CachedVertexShaderSetting<f32, 16> m_world;
+	CachedVertexShaderSetting<f32, 16> m_world_view_proj{"mWorldViewProj"};
+	CachedVertexShaderSetting<f32, 16> m_world{"mWorld"};
 
 	// Shadow-related
-	CachedPixelShaderSetting<f32, 16> m_shadow_view_proj;
-	CachedPixelShaderSetting<f32, 3> m_light_direction;
-	CachedPixelShaderSetting<f32> m_texture_res;
-	CachedPixelShaderSetting<f32> m_shadow_strength;
-	CachedPixelShaderSetting<f32> m_time_of_day;
-	CachedPixelShaderSetting<f32> m_shadowfar;
-	CachedPixelShaderSetting<f32, 4> m_camera_pos;
-	CachedPixelShaderSetting<s32> m_shadow_texture;
-	CachedVertexShaderSetting<f32> m_perspective_bias0_vertex;
-	CachedPixelShaderSetting<f32> m_perspective_bias0_pixel;
-	CachedVertexShaderSetting<f32> m_perspective_bias1_vertex;
-	CachedPixelShaderSetting<f32> m_perspective_bias1_pixel;
-	CachedVertexShaderSetting<f32> m_perspective_zbias_vertex;
-	CachedPixelShaderSetting<f32> m_perspective_zbias_pixel;
+	CachedPixelShaderSetting<f32, 16> m_shadow_view_proj{"m_ShadowViewProj"};
+	CachedPixelShaderSetting<f32, 3> m_light_direction{"v_LightDirection"};
+	CachedPixelShaderSetting<f32> m_texture_res{"f_textureresolution"};
+	CachedPixelShaderSetting<f32> m_shadow_strength{"f_shadow_strength"};
+	CachedPixelShaderSetting<f32> m_time_of_day{"f_timeofday"};
+	CachedPixelShaderSetting<f32> m_shadowfar{"f_shadowfar"};
+	CachedPixelShaderSetting<f32, 4> m_camera_pos{"CameraPos"};
+	CachedPixelShaderSetting<s32> m_shadow_texture{"ShadowMapSampler"};
+	CachedVertexShaderSetting<f32>
+		m_perspective_bias0_vertex{"xyPerspectiveBias0"};
+	CachedPixelShaderSetting<f32>
+		m_perspective_bias0_pixel{"xyPerspectiveBias0"};
+	CachedVertexShaderSetting<f32>
+		m_perspective_bias1_vertex{"xyPerspectiveBias1"};
+	CachedPixelShaderSetting<f32>
+		m_perspective_bias1_pixel{"xyPerspectiveBias1"};
+	CachedVertexShaderSetting<f32>
+		m_perspective_zbias_vertex{"zPerspectiveBias"};
+	CachedPixelShaderSetting<f32> m_perspective_zbias_pixel{"zPerspectiveBias"};
 
 	// Modelview matrix
-	CachedVertexShaderSetting<float, 16> m_world_view;
+	CachedVertexShaderSetting<float, 16> m_world_view{"mWorldView"};
 	// Texture matrix
-	CachedVertexShaderSetting<float, 16> m_texture;
+	CachedVertexShaderSetting<float, 16> m_texture{"mTexture"};
 
 public:
-	MainShaderConstantSetter() :
-		  m_world_view_proj("mWorldViewProj")
-		, m_world("mWorld")
-		, m_shadow_view_proj("m_ShadowViewProj")
-		, m_light_direction("v_LightDirection")
-		, m_texture_res("f_textureresolution")
-		, m_shadow_strength("f_shadow_strength")
-		, m_time_of_day("f_timeofday")
-		, m_shadowfar("f_shadowfar")
-		, m_camera_pos("CameraPos")
-		, m_shadow_texture("ShadowMapSampler")
-		, m_perspective_bias0_vertex("xyPerspectiveBias0")
-		, m_perspective_bias0_pixel("xyPerspectiveBias0")
-		, m_perspective_bias1_vertex("xyPerspectiveBias1")
-		, m_perspective_bias1_pixel("xyPerspectiveBias1")
-		, m_perspective_zbias_vertex("zPerspectiveBias")
-		, m_perspective_zbias_pixel("zPerspectiveBias")
-		, m_world_view("mWorldView")
-		, m_texture("mTexture")
-	{}
 	~MainShaderConstantSetter() = default;
 
 	virtual void onSetConstants(video::IMaterialRendererServices *services) override

--- a/src/client/shadows/shadowsScreenQuad.h
+++ b/src/client/shadows/shadowsScreenQuad.h
@@ -39,16 +39,12 @@ private:
 class shadowScreenQuadCB : public video::IShaderConstantSetCallBack
 {
 public:
-	shadowScreenQuadCB() :
-			m_sm_client_map_setting("ShadowMapClientMap"),
-			m_sm_client_map_trans_setting("ShadowMapClientMapTraslucent"),
-			m_sm_dynamic_sampler_setting("ShadowMapSamplerdynamic")
-	{}
-
 	virtual void OnSetConstants(video::IMaterialRendererServices *services,
 			s32 userData);
 private:
-	CachedPixelShaderSetting<s32> m_sm_client_map_setting;
-	CachedPixelShaderSetting<s32> m_sm_client_map_trans_setting;
-	CachedPixelShaderSetting<s32> m_sm_dynamic_sampler_setting;
+	CachedPixelShaderSetting<s32> m_sm_client_map_setting{"ShadowMapClientMap"};
+	CachedPixelShaderSetting<s32>
+		m_sm_client_map_trans_setting{"ShadowMapClientMapTraslucent"};
+	CachedPixelShaderSetting<s32>
+		m_sm_dynamic_sampler_setting{"ShadowMapSamplerdynamic"};
 };

--- a/src/client/shadows/shadowsshadercallbacks.h
+++ b/src/client/shadows/shadowsshadercallbacks.h
@@ -26,17 +26,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class ShadowDepthShaderCB : public video::IShaderConstantSetCallBack
 {
 public:
-	ShadowDepthShaderCB() :
-			m_light_mvp_setting("LightMVP"),
-			m_map_resolution_setting("MapResolution"),
-			m_max_far_setting("MaxFar"),
-			m_color_map_sampler_setting("ColorMapSampler"),
-			m_perspective_bias0("xyPerspectiveBias0"),
-			m_perspective_bias1("xyPerspectiveBias1"),
-			m_perspective_zbias("zPerspectiveBias"),
-			m_cam_pos_setting("CameraPos")
-	{}
-
 	void OnSetMaterial(const video::SMaterial &material) override {}
 
 	void OnSetConstants(video::IMaterialRendererServices *services,
@@ -47,12 +36,13 @@ public:
 	v3f CameraPos;
 
 private:
-	CachedVertexShaderSetting<f32, 16> m_light_mvp_setting;
-	CachedVertexShaderSetting<f32> m_map_resolution_setting;
-	CachedVertexShaderSetting<f32> m_max_far_setting;
-	CachedPixelShaderSetting<s32> m_color_map_sampler_setting;
-	CachedVertexShaderSetting<f32> m_perspective_bias0;
-	CachedVertexShaderSetting<f32> m_perspective_bias1;
-	CachedVertexShaderSetting<f32> m_perspective_zbias;
-	CachedVertexShaderSetting<f32, 4> m_cam_pos_setting;
+	CachedVertexShaderSetting<f32, 16> m_light_mvp_setting{"LightMVP"};
+	CachedVertexShaderSetting<f32> m_map_resolution_setting{"MapResolution"};
+	CachedVertexShaderSetting<f32> m_max_far_setting{"MaxFar"};
+	CachedPixelShaderSetting<s32>
+		m_color_map_sampler_setting{"ColorMapSampler"};
+	CachedVertexShaderSetting<f32> m_perspective_bias0{"xyPerspectiveBias0"};
+	CachedVertexShaderSetting<f32> m_perspective_bias1{"xyPerspectiveBias1"};
+	CachedVertexShaderSetting<f32> m_perspective_zbias{"zPerspectiveBias"};
+	CachedVertexShaderSetting<f32, 4> m_cam_pos_setting{"CameraPos"};
 };


### PR DESCRIPTION
Before this change, the member type and member name are at one place, and the member name and uniform name are at another place. 
If the uniform name is written directly at the member declaration, the member type, member name and uniform name are all at one place, which leads to shorter code and may be easier to read.

According to the [code style guidelines](https://dev.minetest.net/Code_style_guidelines#Do_not_be_too_C.2B.2By), initializer lists should only be used when absolutely necessary, but I don't know if that is about [std::initializer_list](https://en.cppreference.com/w/cpp/utility/initializer_list) or [member initialiser lists](https://en.cppreference.com/w/cpp/language/constructor).

Roadmap goal: 2.2 Internal code refactoring

## To do

This PR is a Ready for Review.

## How to test

Read the code before and after the changes