### PR TITLE
Allow unsafe access into MapSector::m_blocks

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -339,11 +339,9 @@ void ClientMap::updateDrawList()
 					continue;
 			}
 
-			sectorblocks.clear();
-			sector->getBlocks(sectorblocks);
-
 			// Loop through blocks in sector
-			for (MapBlock *block : sectorblocks) {
+			for (const auto &entry : sector->getBlocksUnsafe()) {
+				MapBlock *block = entry.second.get();
 				MapBlockMesh *mesh = block->mesh;
 
 				// Calculate the coordinates for range and frustum culling
@@ -659,14 +657,12 @@ void ClientMap::touchMapBlocks()
 				continue;
 		}
 
-		MapBlockVect sectorblocks;
-		sector->getBlocks(sectorblocks);
-
 		/*
 			Loop through blocks in sector
 		*/
 
-		for (MapBlock *block : sectorblocks) {
+		for (const auto &entry : sector->getBlocksUnsafe()) {
+			MapBlock *block = entry.second.get();
 			MapBlockMesh *mesh = block->mesh;
 
 			// Calculate the coordinates for range and frustum culling
@@ -1271,13 +1267,11 @@ void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir,
 			continue;
 		blocks_loaded += sector->size();
 
-		MapBlockVect sectorblocks;
-		sector->getBlocks(sectorblocks);
-
 		/*
 			Loop through blocks in sector
 		*/
-		for (MapBlock *block : sectorblocks) {
+		for (const auto &entry : sector->getBlocksUnsafe()) {
+			MapBlock *block = entry.second.get();
 			MapBlockMesh *mesh = block->mesh;
 			if (!mesh) {
 				// Ignore if mesh doesn't exist

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -329,7 +329,7 @@ void ClientMap::updateDrawList()
 		MapBlockVect sectorblocks;
 
 		for (auto &sector_it : m_sectors) {
-			MapSector *sector = sector_it.second;
+			const MapSector *sector = sector_it.second;
 			v2s16 sp = sector->getPos();
 
 			blocks_loaded += sector->size();
@@ -647,7 +647,7 @@ void ClientMap::touchMapBlocks()
 	u32 blocks_in_range_with_mesh = 0;
 
 	for (const auto &sector_it : m_sectors) {
-		MapSector *sector = sector_it.second;
+		const MapSector *sector = sector_it.second;
 		v2s16 sp = sector->getPos();
 
 		blocks_loaded += sector->size();
@@ -1262,7 +1262,7 @@ void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir,
 	u32 blocks_in_range_with_mesh = 0;
 
 	for (auto &sector_it : m_sectors) {
-		MapSector *sector = sector_it.second;
+		const MapSector *sector = sector_it.second;
 		if (!sector)
 			continue;
 		blocks_loaded += sector->size();

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -340,7 +340,7 @@ void ClientMap::updateDrawList()
 			}
 
 			// Loop through blocks in sector
-			for (const auto &entry : sector->getBlocksUnsafe()) {
+			for (const auto &entry : sector->getBlocks()) {
 				MapBlock *block = entry.second.get();
 				MapBlockMesh *mesh = block->mesh;
 
@@ -661,7 +661,7 @@ void ClientMap::touchMapBlocks()
 			Loop through blocks in sector
 		*/
 
-		for (const auto &entry : sector->getBlocksUnsafe()) {
+		for (const auto &entry : sector->getBlocks()) {
 			MapBlock *block = entry.second.get();
 			MapBlockMesh *mesh = block->mesh;
 
@@ -1270,7 +1270,7 @@ void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir,
 		/*
 			Loop through blocks in sector
 		*/
-		for (const auto &entry : sector->getBlocksUnsafe()) {
+		for (const auto &entry : sector->getBlocks()) {
 			MapBlock *block = entry.second.get();
 			MapBlockMesh *mesh = block->mesh;
 			if (!mesh) {

--- a/src/mapsector.h
+++ b/src/mapsector.h
@@ -62,12 +62,13 @@ public:
 	// Returns an owning ptr to block.
 	std::unique_ptr<MapBlock> detachBlock(MapBlock *block);
 
+	// This makes a copy of the internal collection.
+	// Prefer getBlocks() if possible.
 	void getBlocks(MapBlockVect &dest);
 
-	// Get access to the internal map.
-	// When iterating over this map, do NOT call any MapSector methods that modify this map
-	const auto & getBlocksUnsafe() const { return m_blocks; }
-	const auto & getBlocksUnsafe() = delete;
+	// Get access to the internal map. Only allowed from a const MapSector.
+	const auto & getBlocks() const { return m_blocks; }
+	const auto & getBlocks() = delete;
 
 	bool empty() const { return m_blocks.empty(); }
 

--- a/src/mapsector.h
+++ b/src/mapsector.h
@@ -66,9 +66,11 @@ public:
 	// Prefer getBlocks() if possible.
 	void getBlocks(MapBlockVect &dest);
 
-	// Get access to the internal map. Only allowed from a const MapSector.
-	const auto & getBlocks() const { return m_blocks; }
-	const auto & getBlocks() = delete;
+	// Get access to the internal collection
+	// This is explicitly only allowed on a const object since modifying anything while iterating is unsafe.
+	// The caller needs to make sure that this does not happen.
+	const auto &getBlocks() const { return m_blocks; }
+	const auto &getBlocks() = delete;
 
 	bool empty() const { return m_blocks.empty(); }
 

--- a/src/mapsector.h
+++ b/src/mapsector.h
@@ -64,6 +64,10 @@ public:
 
 	void getBlocks(MapBlockVect &dest);
 
+	// Get access to the internal map.
+	// When iterating over this map, do NOT call any MapSector methods that modify this map
+	const auto & getBlocksUnsafe() const { return m_blocks; }
+
 	bool empty() const { return m_blocks.empty(); }
 
 	int size() const { return m_blocks.size(); }

--- a/src/mapsector.h
+++ b/src/mapsector.h
@@ -45,7 +45,7 @@ public:
 
 	void deleteBlocks();
 
-	v2s16 getPos()
+	v2s16 getPos() const
 	{
 		return m_pos;
 	}
@@ -67,6 +67,7 @@ public:
 	// Get access to the internal map.
 	// When iterating over this map, do NOT call any MapSector methods that modify this map
 	const auto & getBlocksUnsafe() const { return m_blocks; }
+	const auto & getBlocksUnsafe() = delete;
 
 	bool empty() const { return m_blocks.empty(); }
 


### PR DESCRIPTION
Over the weekend I realized that with many blocks loaded, sometime just enumerating all these blocks takes time.
As you fly around in a map and have a large viewing_range set, it is not uncommon to have 100.000 or more blocks loaded on the client.

I so made this simple change, that just allows internal access to a sector's blocks.

- Goal of the PR
Reduce the cost enumerating blocks in ClientMap.

- How does the PR work?
It allows limited access to the map stored inside MapSector, without making a copy.

- Does it resolve any reported issue?
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?

- If not a bug fix, why is this PR needed? What usecases does it solve?

Better client performance.
With 60k blocks. touchMapBlocks goes from taking 11.5ms to 9ms, and updateDrawListShadow from 8.5ms to 4.5ms.
With more blocks (especially when loaded, but outside of the current viewing_range) this would be even worse.
This should also help with many allocations, as we copy the MapBlock pointers into new/growing vectors.

## To do

This PR is Ready for Review.

## How to test

Join any world. Set `client_mapblock_limit` to 100.000 or more. Fly around until many blocks are loaded. Look at the debug view (F6) and note the time spent in:

- updateDrawlist (if client_mesh_chunk < 4)
- touchMapBlocks (if client_mesh_chunk >= 4)
- updateDrawlistShadow (if shadows are enabled)
