### PR TITLE
MSVC: Fix locale workaround code

### DIFF
--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -119,7 +119,7 @@ static const char* MSVC_LocaleLookup(const char* raw_shortname)
 	return "";
 }
 
-static void MSVC_LocaleWorkaround()
+static void MSVC_LocaleWorkaround(int argc, char* argv[])
 {
 	errorstream << "MSVC localization workaround active.  "
 		"Restarting " PROJECT_NAME_C " in a new environment!" << std::endl;
@@ -165,7 +165,6 @@ static void MSVC_LocaleWorkaround()
 		errorstream << "*******************************************************" << std::endl;
 	}
 }
-}
 
 #endif
 
@@ -195,7 +194,7 @@ void init_gettext(const char *path, const std::string &configured_language,
 #ifndef SERVER
 		// Hack to force gettext to see the right environment
 		if (current_language != configured_language)
-			MSVC_LocaleWorkaround();
+			MSVC_LocaleWorkaround(argc, argv);
 #else
 		errorstream << "*******************************************************" << std::endl;
 		errorstream << "Can't apply locale workaround for server!" << std::endl;


### PR DESCRIPTION
**Goal of the PR**
This PR fixes a bug when compiling in MSVC.

**How does the PR work?**
_(See changes)_

**Does it resolve any reported issue?**
I encountered it myself.

**Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?**
Yes, it is a bugfix.

## To do

This PR is Ready for Review.

## How to test

1. Compile Minetest using MSVC (in Visual Studio).
2. No compilation error should happen.