### PR TITLE
Add missing sector view range check in updateDrawListShadow

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1265,6 +1265,12 @@ void ClientMap::updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir,
 		const MapSector *sector = sector_it.second;
 		if (!sector)
 			continue;
+
+		v2s16 sp = sector->getPos();
+		if (sp.X < p_blocks_min.X || sp.X > p_blocks_max.X ||
+				sp.Y < p_blocks_min.Z || sp.Y > p_blocks_max.Z)
+			continue;
+
 		blocks_loaded += sector->size();
 
 		/*


### PR DESCRIPTION
We duly get the view range in `updateDrawListShadow`, but we never use it.
This adds it for a performance gain - sectors outside this range are not considered.
In my tests this shaves 20-30% off the time spent in `updateDrawListShadow`.

- Goal of the PR
Add forgotten check. Performance improvement.

- How does the PR work?
Add that trivial check.

- Does it resolve any reported issue?
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is Ready for Review.

## How to test

This is a trivial change, but if you wanted to: Load any world, enable shadows, nothing should change.