### PR TITLE
Update docs to allow non-liquid nodes to use "liquid" drawtype

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1387,8 +1387,7 @@ Look for examples in `games/devtest` or `games/minetest_game`.
 * `liquid`
     * The cubic source node for a liquid.
     * Faces bordering to the same node are never rendered.
-    * Connects to node specified in `liquid_alternative_flowing`.
-    * You *must* set `liquid_alternative_source` to the node's own name.
+    * Connects to node specified in `liquid_alternative_flowing` if specified.
     * Use `backface_culling = false` for the tiles you want to make
       visible when inside the node.
 * `flowingliquid`
@@ -8944,10 +8943,8 @@ Used by `minetest.register_node`.
     -- flowing version (`liquid_alternative_flowing`) and
     -- source version (`liquid_alternative_source`) of a liquid.
     --
-    -- Specifically, these fields are required if any of these is true:
-    -- * `liquidtype ~= "none" or
-    -- * `drawtype == "liquid" or
-    -- * `drawtype == "flowingliquid"
+    -- Specifically, these fields are required if `liquidtype ~= "none"` or
+    -- `drawtype == "flowingliquid"`.
     --
     -- Liquids consist of up to two nodes: source and flowing.
     --


### PR DESCRIPTION
## Background

In Minetest, water is semi-opaque by default but it can be changed to fully opaque using the `opaque_water` setting.

In Mineclonia, we have semi-opaque ice. When a player has `opaque_water` enabled to save FPS on oceans, ice is still translucent which leads to significant FPS drops in frozen biomes.

We found a pretty neat solution for this, which is to make ice `drawtype == "liquid"`. It makes ice follow the opacity setting for water. This works for us without any noticable problems.

## Problem

Unfortunately, this appears to be forbidden according to the Minetest docs:

> ```lua
> liquid_alternative_flowing = "",
> liquid_alternative_source = "",
> -- These fields may contain node names that represent the
> -- flowing version (`liquid_alternative_flowing`) and
> -- source version (`liquid_alternative_source`) of a liquid.
> --
> -- Specifically, these fields are required if any of these is true:
> -- * `liquidtype ~= "none" or
> -- * `drawtype == "liquid" or
> -- * `drawtype == "flowingliquid"
> ```

It states that if `drawtype == "liquid"` then both `liquid_alternative_flowing` and `liquid_alternative_source` need to be specified. This is the case even if `liquidtype ~= "none"`.

## Solution

From testing, `drawtype == "liquid"` works with `liquidtype == "none"` even if the liquid alternative fields are not specified.

So this PR simply rewords the docs to make this conforming.

## How to test

It can be tested that it works without engine modifications using [this branch](https://codeberg.org/mineclonia/mineclonia/src/branch/ice-drawtype) of Mineclonia.  One can check this by placing a few ice blocks or do `/findbiome ColdTaiga` to teleport near naturally generated ice.

## Last words

Using `drawtype == "liquid"` to make opacity togglable for a non-liquid node might seem like a hack, but I think it makes a lot of sense to support for ice which is basically frozen oceans.

The reason we do not want to use a game setting for this is because then it would be server-side and not client-side.

I also think there are other games would be interested in using this for translucent ice.