### PR TITLE
DevTest: Move generated textures to world dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,6 @@ src/test_config.h
 src/cmake_config.h
 src/cmake_config_githash.h
 src/unittest/test_world/world.mt
-games/devtest/mods/testnodes/textures/testnodes_generated_*.png
 /locale/
 .directory
 *.cbp

--- a/games/devtest/mods/testnodes/textures.lua
+++ b/games/devtest/mods/testnodes/textures.lua
@@ -151,18 +151,41 @@ checker = nil
 
 local textures_path = minetest.get_worldpath() .. "/generated_textures/"
 local path_created = minetest.mkdir(textures_path)
+local gen_files = {
+	{
+		name = "testnodes_generated_mb.png",
+		encode_args = { 512, 512, "rgb", data_mb },
+	},
+	{
+		name = "testnodes_generated_ck.png",
+		encode_args = { 512, 512, "gray", data_ck },
+	}
+}
 if not path_created then
 	minetest.log("error", "[testnodes] Could not create path for generated textures at "..textures_path)
 else
-	minetest.safe_file_write(
-		textures_path .. "testnodes_generated_mb.png",
-		encode_and_check(512, 512, "rgb", data_mb)
-	)
-	minetest.safe_file_write(
-		textures_path .. "testnodes_generated_ck.png",
-		encode_and_check(512, 512, "gray", data_ck)
-	)
+	for f=1, #gen_files do
+		local name = gen_files[f].name
+		local encode_args = gen_files[f].encode_args
+		minetest.safe_file_write(
+			textures_path .. name,
+			encode_and_check(unpack(encode_args))
+		)
+	end
 end
+
+minetest.after(0, function()
+	for f=1, #gen_files do
+		local name = gen_files[f].name
+		local callback = function()
+			minetest.log("action", "[testnodes] Received dynamic media: "..name)
+		end
+		local ok = minetest.dynamic_add_media({filepath = textures_path .. name}, callback)
+		if not ok then
+			minetest.log("error", "[testnodes] Could not add dynamic media: " .. name)
+		end
+	end
+end)
 
 minetest.register_node("testnodes:generated_png_mb", {
 	description = S("Generated Mandelbrot PNG Test Node"),

--- a/games/devtest/mods/testnodes/textures.lua
+++ b/games/devtest/mods/testnodes/textures.lua
@@ -149,15 +149,20 @@ fractal = nil
 frac_emb = nil
 checker = nil
 
-local textures_path = minetest.get_modpath( minetest.get_current_modname() ) .. "/textures/"
-minetest.safe_file_write(
-	textures_path .. "testnodes_generated_mb.png",
-	encode_and_check(512, 512, "rgb", data_mb)
-)
-minetest.safe_file_write(
-	textures_path .. "testnodes_generated_ck.png",
-	encode_and_check(512, 512, "gray", data_ck)
-)
+local textures_path = minetest.get_worldpath() .. "/generated_textures/"
+local path_created = minetest.mkdir(textures_path)
+if not path_created then
+	minetest.log("error", "[testnodes] Could not create path for generated textures at "..textures_path)
+else
+	minetest.safe_file_write(
+		textures_path .. "testnodes_generated_mb.png",
+		encode_and_check(512, 512, "rgb", data_mb)
+	)
+	minetest.safe_file_write(
+		textures_path .. "testnodes_generated_ck.png",
+		encode_and_check(512, 512, "gray", data_ck)
+	)
+end
 
 minetest.register_node("testnodes:generated_png_mb", {
 	description = S("Generated Mandelbrot PNG Test Node"),


### PR DESCRIPTION
I always had this annoying issue with DevTest on my computer by spitting out errors that the generated textures `testnodes_generated_*.png` could not be read. This is because DevTest is installed system-wide and DevTest tries to put the textures into the mod directory, but it's write-protected without root rights. (I'm on an Arch-Linux-like system btw).

So I've decided to move the generated textures into the world path instead. This works fine. The world path is a "safer" option anyway.