### PR TITLE
Return to the main menu if a shader compilation fails

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -277,6 +277,10 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 			error_message = gettext("Connection error (timed out?)");
 			errorstream << error_message << std::endl;
 		}
+		catch (ShaderException &e) {
+			error_message = debug_describe_exc(e);
+			errorstream << error_message << std::endl;
+		}
 
 #ifdef NDEBUG
 		catch (std::exception &e) {

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -278,7 +278,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 			errorstream << error_message << std::endl;
 		}
 		catch (ShaderException &e) {
-			error_message = debug_describe_exc(e);
+			error_message = e.what();
 			errorstream << error_message << std::endl;
 		}
 

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -35,6 +35,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IShaderConstantSetCallBack.h>
 #include "client/renderingengine.h"
 #include "EShaderTypes.h"
+#include "gettext.h"
 #include "log.h"
 #include "gamedef.h"
 #include "client/tile.h"
@@ -588,8 +589,8 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
 	if (!driver->queryFeature(video::EVDF_ARB_GLSL)) {
-		throw ShaderException("Shaders are enabled but GLSL is not supported "
-			"by the driver");
+		throw ShaderException(gettext("Shaders are enabled but GLSL is not "
+			"supported by the driver."));
 	}
 	video::IGPUProgrammingServices *gpu = driver->getGPUProgrammingServices();
 
@@ -790,8 +791,9 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		dumpShaderProgram(warningstream, "Vertex", vertex_shader);
 		dumpShaderProgram(warningstream, "Fragment", fragment_shader);
 		dumpShaderProgram(warningstream, "Geometry", geometry_shader);
-		throw ShaderException("Failed to compile the \"" + name + "\" shader. "
-			"Check debug.txt for details.");
+		throw ShaderException(
+			fmtgettext("Failed to compile the \"%s\" shader.", name.c_str()) +
+			strgettext("\nCheck debug.txt for details."));
 	}
 
 	// Apply the newly created material type

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -588,8 +588,8 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
 	if (!driver->queryFeature(video::EVDF_ARB_GLSL)) {
-		errorstream << "Shaders are enabled but GLSL is not supported by the driver\n";
-		return shaderinfo;
+		throw ShaderException("Shaders are enabled but GLSL is not supported "
+			"by the driver\n");
 	}
 	video::IGPUProgrammingServices *gpu = driver->getGPUProgrammingServices();
 
@@ -790,7 +790,8 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		dumpShaderProgram(warningstream, "Vertex", vertex_shader);
 		dumpShaderProgram(warningstream, "Fragment", fragment_shader);
 		dumpShaderProgram(warningstream, "Geometry", geometry_shader);
-		return shaderinfo;
+		throw ShaderException("Failed to compile the \"" + name + "\" shader. "
+			"Check the log for details.");
 	}
 
 	// Apply the newly created material type

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -589,7 +589,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
 	if (!driver->queryFeature(video::EVDF_ARB_GLSL)) {
 		throw ShaderException("Shaders are enabled but GLSL is not supported "
-			"by the driver\n");
+			"by the driver");
 	}
 	video::IGPUProgrammingServices *gpu = driver->getGPUProgrammingServices();
 
@@ -791,7 +791,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		dumpShaderProgram(warningstream, "Fragment", fragment_shader);
 		dumpShaderProgram(warningstream, "Geometry", geometry_shader);
 		throw ShaderException("Failed to compile the \"" + name + "\" shader. "
-			"Check the log for details.");
+			"Check debug.txt for details.");
 	}
 
 	// Apply the newly created material type

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -322,6 +322,44 @@ public:
 };
 
 
+namespace {
+	class IrrlichtErrorCapturer : public IEventReceiver
+	{
+		std::string &m_output;
+		IEventReceiver *m_old_recv;
+
+	public:
+		IrrlichtErrorCapturer(std::string &output):
+			m_output{output}
+		{
+			IrrlichtDevice *device{RenderingEngine::get_raw_device()};
+			m_old_recv = device->getEventReceiver();
+			device->setEventReceiver(this);
+		}
+
+		~IrrlichtErrorCapturer()
+		{
+			IrrlichtDevice *device{RenderingEngine::get_raw_device()};
+			device->setEventReceiver(m_old_recv);
+		}
+
+		IrrlichtErrorCapturer(const IrrlichtErrorCapturer&) = delete;
+		IrrlichtErrorCapturer &operator=(const IrrlichtErrorCapturer&) = delete;
+
+		virtual bool OnEvent(const SEvent &event)
+		{
+			if (event.EventType == EET_LOG_TEXT_EVENT &&
+					event.LogEvent.Level == ELL_ERROR) {
+				// Log messages from Irrlicht are *usually* not
+				// newline-terminated.
+				m_output.append(event.LogEvent.Text).append("\n");
+				return true;
+			}
+			return m_old_recv->OnEvent(event);
+		}
+	};
+}
+
 /*
 	ShaderSource
 */
@@ -777,11 +815,16 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 
 	irr_ptr<ShaderCallback> cb{new ShaderCallback(m_setter_factories)};
 	infostream<<"Compiling high level shaders for "<<name<<std::endl;
-	s32 shadermat = gpu->addHighLevelShaderMaterial(
-		vertex_shader.c_str(), nullptr, video::EVST_VS_1_1,
-		fragment_shader.c_str(), nullptr, video::EPST_PS_1_1,
-		geometry_shader_ptr, nullptr, video::EGST_GS_4_0, scene::EPT_TRIANGLES, scene::EPT_TRIANGLES, 0,
-		cb.get(), shaderinfo.base_material,  1);
+	std::string shader_compilation_errors{""};
+	s32 shadermat;
+	{
+		IrrlichtErrorCapturer capturer{shader_compilation_errors};
+		shadermat = gpu->addHighLevelShaderMaterial(
+			vertex_shader.c_str(), nullptr, video::EVST_VS_1_1,
+			fragment_shader.c_str(), nullptr, video::EPST_PS_1_1,
+			geometry_shader_ptr, nullptr, video::EGST_GS_4_0, scene::EPT_TRIANGLES, scene::EPT_TRIANGLES, 0,
+			cb.get(), shaderinfo.base_material,  1);
+	}
 	if (shadermat == -1) {
 		errorstream<<"generate_shader(): "
 				"failed to generate \""<<name<<"\", "
@@ -790,8 +833,13 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		dumpShaderProgram(warningstream, "Vertex", vertex_shader);
 		dumpShaderProgram(warningstream, "Fragment", fragment_shader);
 		dumpShaderProgram(warningstream, "Geometry", geometry_shader);
-		throw ShaderException("Failed to compile the \"" + name + "\" shader. "
+		throw ShaderException(
+			"Failed to compile the \"" + name + "\" shader.\n" +
+			shader_compilation_errors +
 			"Check debug.txt for details.");
+	} else if (!shader_compilation_errors.empty()) {
+		// Don't suppress any error messages.
+		errorstream << shader_compilation_errors;
 	}
 
 	// Apply the newly created material type

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -92,6 +92,11 @@ public:
 	PrngException(const std::string &s): BaseException(s) {}
 };
 
+class ShaderException : public BaseException {
+public:
+	ShaderException(const std::string &s): BaseException(s) {}
+};
+
 class ModError : public BaseException {
 public:
 	ModError(const std::string &s): BaseException(s) {}


### PR DESCRIPTION
Before this change, if the shaders are broken, only an error message is shown and the player enters the world nonetheless, where he/she sees broken graphics. For a shader developer, being thrown back to the main menu can be more convenient.

To throw the player back to the main menu, we add an exception. Since BaseException is only catched if NDEBUG is set, we add a new exception dedicated to shaders.

Closes: #10097
Previous pull request: #10240 


## To do

This PR is a Ready for Review.

## How to test

* Execute this in a Bash Shell:
  ```bash
  <<< nyan cat >> client/shaders/nodes_shader/opengl_fragment.glsl
  ```
* Enter the game
