### PR TITLE
Make ABM changable at runtime and add posibility for postpone ABMs.

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -30,6 +30,7 @@ core.features = {
 	sound_params_start_time = true,
 	physics_overrides_v2 = true,
 	hud_def_type_field = true,
+	abm_cancelable = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2068,6 +2068,14 @@ abm_interval (ABM interval) float 1.0 0.0
 #    (as a fraction of the ABM Interval)
 abm_time_budget (ABM time budget) float 0.2 0.1 0.9
 
+#    Size for postponed ABMs cache size.
+#    Zero size means, that postponed chache is disabled.
+abm_postponed_cache_size (ABM postponed cache size) int 0 0 4294967295
+
+#    Control if information about missed ABMs calls, due to limited time budget,
+#    is printed as warning or verbose information.
+abm_missed_as_warning (ABM missed printed as warning) bool true
+
 #    Length of time between NodeTimer execution cycles, stated in seconds.
 nodetimer_interval (NodeTimer interval) float 0.2 0.0
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5284,6 +5284,8 @@ Utilities
       physics_overrides_v2 = true,
       -- In HUD definitions the field `type` is used and `hud_elem_type` is deprecated (5.9.0)
       hud_def_type_field = true,
+      -- ABM can be set as uncancelable and ABM postponed buffer can be configured (5.9.0)
+      abm_cancelable = true,
   }
   ```
 
@@ -5461,6 +5463,8 @@ Call these functions only at load time!
       according to its nature: `minetest.registered_nodes`, etc.
 * `minetest.register_entity(name, entity definition)`
 * `minetest.register_abm(abm definition)`
+* `minetest.change_abm(abm_name, changed parameters)`
+    * see abm definition for changable parameters
 * `minetest.register_lbm(lbm definition)`
 * `minetest.register_alias(alias, original_name)`
     * Also use this to set the 'mapgen aliases' needed in a game for the core
@@ -8510,6 +8514,10 @@ Used by `minetest.register_abm`.
 
 ```lua
 {
+    name = "",
+    -- Optional name of ABM.
+    -- ABM with name can be changed at runtime (See `minetest.change_abm`).
+
     label = "Lava cooling",
     -- Descriptive label for profiling purposes (optional).
     -- Definitions with identical labels will be listed as one.
@@ -8526,14 +8534,26 @@ Used by `minetest.register_abm`.
 
     interval = 10.0,
     -- Operation interval in seconds
+    -- This value can be changed by `minetest.change_abm` call.
+    -- A negative interval value means that ABM is disabled.
+    -- The counter is running for disabled ABM as well. So it is recommended to use a negative value of normal interval to disable it.
+    -- If the interval is reduced to 50% or more, it can happen that ABM will be triggered in a few following server steps repeatedly.
 
     chance = 50,
     -- Chance of triggering `action` per-node per-interval is 1.0 / chance
+    -- This value can be changed by `minetest.change_abm` call.
 
     min_y = -32768,
     max_y = 32767,
     -- min and max height levels where ABM will be processed (inclusive)
     -- can be used to reduce CPU usage
+    -- These values can be changed by `minetest.change_abm` call.
+
+    cancelable = true,
+    -- Cancelable ABM will not be postponed if the postponed cache is enabled on the server.
+    -- Postponed ABMs will be called in some of the following server steps.
+    -- For postponed ABMs, the interval between calling ABM for the same node can be variable.
+    -- This value can be changed by `minetest.change_abm` call.
 
     catch_up = true,
     -- If true, catch-up behavior is enabled: The `chance` value is

--- a/games/devtest/mods/testuncancelableabm/init.lua
+++ b/games/devtest/mods/testuncancelableabm/init.lua
@@ -1,0 +1,67 @@
+
+local postponed_cache_size = tonumber(minetest.settings:get("abm_postponed_cache_size"))
+
+local abm_first_run = false;
+
+minetest.register_chatcommand("uncancelableABM", {
+	params = "enable | disable | interval_1 | interval_5",
+	description = "Active/Deactivate ABM which can be postponed.",
+	func = function(name, param)
+		if param == "enable" then
+			minetest.change_abm("testuncancelableabm:abm", {
+					interval = 30.0,
+				})
+			abm_first_run = true;
+			if postponed_cache_size == 0 then
+				return true, "ABM has been enabled, but ABM postponed cache is disabled."
+			else
+				return true, "ABM has been enabled and should be postponed."
+			end
+		elseif param == "interval_1" then
+			minetest.change_abm("testuncancelableabm:abm", {
+					interval = 1.0,
+				})
+			abm_first_run = true;
+			if postponed_cache_size == 0 then
+				return true, "ABM has been enabled with interval 1, but ABM postponed cache is disabled."
+			else
+				return true, "ABM has been enabled with interval 1 and should be postponed."
+			end
+		elseif param == "interval_5" then
+			minetest.change_abm("testuncancelableabm:abm", {
+					interval = 5.0,
+				})
+			abm_first_run = true;
+			if postponed_cache_size == 0 then
+				return true, "ABM has been enabled with interval 5, but ABM postponed cache is disabled."
+			else
+				return true, "ABM has been enabled with interval 5 and should be postponed."
+			end
+		elseif param == "disable" then
+			minetest.change_abm("testuncancelableabm:abm", {
+					interval = -30.0,
+				})
+			return true, "ABM has been disabled."
+		else
+			return false, "Check /help uncancelableABB for allowed parameters."
+		end
+	end,
+})
+
+minetest.register_abm({
+		name = "testuncancelableabm:abm",
+		nodenames = "basenodes:stone",
+		interval = -30.0,
+		chance = 1,
+		cancelable = false,
+		action = function(pos)
+			local time = minetest.get_us_time()
+			-- waste some time, to make ABM long
+			while time == minetest.get_us_time() do
+			end
+			if abm_first_run then
+				minetest.chat_send_all("Uncancelable ABM runs first time after enable.")
+				abm_first_run = false
+			end
+		end,
+	})

--- a/games/devtest/mods/testuncancelableabm/mod.conf
+++ b/games/devtest/mods/testuncancelableabm/mod.conf
@@ -1,0 +1,2 @@
+name = testuncancelabledabm
+description = Add command to enable/disable uncancelable ABM which should be postponed if postpone cache is enabled.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -418,6 +418,8 @@ void set_default_settings()
 	settings->setDefault("active_block_mgmt_interval", "2.0");
 	settings->setDefault("abm_interval", "1.0");
 	settings->setDefault("abm_time_budget", "0.2");
+	settings->setDefault("abm_postponed_cache_size", "0");
+	settings->setDefault("abm_missed_as_warning", "true");
 	settings->setDefault("nodetimer_interval", "0.2");
 	settings->setDefault("ignore_world_load_errors", "false");
 	settings->setDefault("remote_media", "");

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -37,6 +37,8 @@ Environment::Environment(IGameDef *gamedef):
 	m_cache_abm_interval = g_settings->getFloat("abm_interval");
 	m_cache_nodetimer_interval = g_settings->getFloat("nodetimer_interval");
 	m_cache_abm_time_budget = g_settings->getFloat("abm_time_budget");
+	m_cache_abm_postponed_cache_size = g_settings->getU32("abm_postponed_cache_size");
+	m_cache_abm_missed_as_warning = g_settings->getBool("abm_missed_as_warning");
 
 	m_time_of_day = g_settings->getU32("world_start_time");
 	m_time_of_day_f = (float)m_time_of_day / 24000.0f;

--- a/src/environment.h
+++ b/src/environment.h
@@ -148,6 +148,8 @@ protected:
 	float m_cache_abm_interval;
 	float m_cache_nodetimer_interval;
 	float m_cache_abm_time_budget;
+	u32 m_cache_abm_postponed_cache_size;
+	bool m_cache_abm_missed_as_warning;
 
 	IGameDef *m_gamedef;
 

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -98,6 +98,9 @@ void ScriptApiEnv::initializeEnvironment(ServerEnvironment *env)
 		int id = lua_tonumber(L, -2);
 		int current_abm = lua_gettop(L);
 
+		std::string name;
+		getstringfield(L, current_abm, "name", name);
+
 		std::vector<std::string> trigger_contents;
 		lua_getfield(L, current_abm, "nodenames");
 		if (lua_istable(L, -1)) {
@@ -147,12 +150,16 @@ void ScriptApiEnv::initializeEnvironment(ServerEnvironment *env)
 		s16 max_y = INT16_MAX;
 		getintfield(L, current_abm, "max_y", max_y);
 
+		bool cancelable = true;
+		getboolfield(L, current_abm, "cancelable", cancelable);
+
 		lua_getfield(L, current_abm, "action");
 		luaL_checktype(L, current_abm + 1, LUA_TFUNCTION);
 		lua_pop(L, 1);
 
-		LuaABM *abm = new LuaABM(L, id, trigger_contents, required_neighbors,
-			trigger_interval, trigger_chance, simple_catch_up, min_y, max_y);
+		LuaABM *abm = new LuaABM(L, id, name, trigger_contents, required_neighbors,
+			trigger_interval, trigger_chance, simple_catch_up, min_y, max_y,
+			cancelable);
 
 		env->addActiveBlockModifier(abm);
 

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1437,6 +1437,30 @@ int ModApiEnv::l_get_translated_string(lua_State * L)
 	return 1;
 }
 
+// change_abm(abm_name, parameters)
+int ModApiEnv::l_change_abm(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	std::string abm_name = readParam<std::string>(L, 1);
+
+	ActiveBlockModifier *abm = env->getActiveBlockModifierNoEx(abm_name);
+	if (!abm) {
+		throw LuaError("ABM not found.");
+		return 0;
+	}
+
+	float interval = getfloatfield_default(L, 2, "interval", abm->getTriggerInterval());
+	int chance = getintfield_default(L, 2, "chance", abm->getTriggerChance());
+	int min_y = getintfield_default(L, 2, "min_y", abm->getMinY());
+	int max_y = getintfield_default(L, 2, "max_y", abm->getMaxY());
+	bool cancelable = getboolfield_default(L, 2, "cancelable", abm->getCancelable());
+
+	abm->change(interval ,chance, min_y, max_y, cancelable);
+
+	return 0;
+}
+
 void ModApiEnv::Initialize(lua_State *L, int top)
 {
 	API_FCT(set_node);
@@ -1488,6 +1512,7 @@ void ModApiEnv::Initialize(lua_State *L, int top)
 	API_FCT(forceload_free_block);
 	API_FCT(compare_block_status);
 	API_FCT(get_translated_string);
+	API_FCT(change_abm);
 }
 
 void ModApiEnv::InitializeClient(lua_State *L, int top)

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -232,6 +232,8 @@ private:
 	// get_translated_string(lang_code, string)
 	static int l_get_translated_string(lua_State * L);
 
+	// change_abm(abm_name, parameters)
+	static int l_change_abm(lua_State *L);
 public:
 	static void Initialize(lua_State *L, int top);
 	static void InitializeClient(lua_State *L, int top);
@@ -240,6 +242,7 @@ public:
 class LuaABM : public ActiveBlockModifier {
 private:
 	int m_id;
+	std::string m_name;
 
 	std::vector<std::string> m_trigger_contents;
 	std::vector<std::string> m_required_neighbors;
@@ -248,20 +251,28 @@ private:
 	bool m_simple_catch_up;
 	s16 m_min_y;
 	s16 m_max_y;
+	bool m_cancelable;
 public:
-	LuaABM(lua_State *L, int id,
+	LuaABM(lua_State *L, int id, const std::string &name,
 			const std::vector<std::string> &trigger_contents,
 			const std::vector<std::string> &required_neighbors,
-			float trigger_interval, u32 trigger_chance, bool simple_catch_up, s16 min_y, s16 max_y):
+			float trigger_interval, u32 trigger_chance, bool simple_catch_up,
+			s16 min_y, s16 max_y, bool cancelable):
 		m_id(id),
+		m_name(name),
 		m_trigger_contents(trigger_contents),
 		m_required_neighbors(required_neighbors),
 		m_trigger_interval(trigger_interval),
 		m_trigger_chance(trigger_chance),
 		m_simple_catch_up(simple_catch_up),
 		m_min_y(min_y),
-		m_max_y(max_y)
+		m_max_y(max_y),
+		m_cancelable(cancelable)
 	{
+	}
+	virtual const std::string &getName()
+	{
+		return m_name;
 	}
 	virtual const std::vector<std::string> &getTriggerContents() const
 	{
@@ -290,6 +301,18 @@ public:
 	virtual s16 getMaxY()
 	{
 		return m_max_y;
+	}
+	virtual bool getCancelable()
+	{
+		return m_cancelable;
+	}
+	virtual void change(float interval, u32 chance, s16 min_y, s16 max_y, bool cancelable)
+	{
+		m_trigger_interval = interval;
+		m_trigger_chance = chance;
+		m_min_y = min_y;
+		m_max_y = max_y;
+		m_cancelable = cancelable;
 	}
 	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n,
 			u32 active_object_count, u32 active_object_count_wider);


### PR DESCRIPTION
- Goal of the PR
Allow admins/modders to have better control over ABMs calling.
- How does the PR work?
This PR adds a postponed cache for ABMs, which allows postponed ABM calls to the next server steps.
- Does it resolve any reported issue?
Yes, this should resolve #14011, resolve #14114 and particularly resolve #13112.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?
This allows admins to better control server lags and load when a large number of ABM calls are used.

## To do

This PR is a Ready for Review.

## How to test

Start devtest game and use command /uncancelableABM to enable uncancelable ABM.
For testing postponed cache, I recommend the use of  `/uncancelableABM interval_5` or `/uncancelableABM interval_1`.

The postponed cache is disabled by default, size is set to 0. For small cache sizes and short intervals, you should be able to see warnings about missed ABMs because of a fully postponed cache. For the default ABM interval which takes 30 seconds, you should be able to see a warning about uncompleted calls only if postpone cached is disabled.
The behaviors can be different on computers with different performances.

![shot](https://github.com/minetest/minetest/assets/17455197/a28a4232-bd4a-49ff-8ad8-9fcb1c0789a8)

