### PR TITLE
Expose Sha256 algorithm to lua api

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5426,6 +5426,9 @@ Utilities
 * `minetest.sha1(data, [raw])`: returns the sha1 hash of data
     * `data`: string of data to hash
     * `raw`: return raw bytes instead of hex digits, default: false
+* `minetest.sha256(data, [raw])`: returns the sha256 hash of data
+    * `data`: string of data to hash
+    * `raw`: return raw bytes instead of hex digits, default: false
 * `minetest.colorspec_to_colorstring(colorspec)`: Converts a ColorSpec to a
   ColorString. If the ColorSpec is invalid, returns `nil`.
     * `colorspec`: The ColorSpec to convert

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -42,6 +42,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "version.h"
 #include "util/hex.h"
 #include "util/sha1.h"
+#include "util/sha256.h"
 #include "util/png.h"
 #include <cstdio>
 
@@ -551,7 +552,7 @@ int ModApiUtil::l_sha1(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	size_t size;
 	const char *data = luaL_checklstring(L, 1, &size);
-	bool hex = !lua_isboolean(L, 2) || !readParam<bool>(L, 2);
+	const bool hex = !lua_isboolean(L, 2) || !readParam<bool>(L, 2);
 
 	// Compute actual checksum of data
 	std::string data_sha1;
@@ -570,6 +571,25 @@ int ModApiUtil::l_sha1(lua_State *L)
 		lua_pushlstring(L, data_sha1.data(), data_sha1.size());
 	}
 
+	return 1;
+}
+
+int ModApiUtil::l_sha256(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	size_t size;
+	const char *data = luaL_checklstring(L, 1, &size);
+	const bool hex = !lua_isboolean(L, 2) || !readParam<bool>(L, 2);
+	
+	std::string data_sha256;
+	data_sha256.assign((char *) SHA256((const unsigned char*) data, size, NULL), SHA256_DIGEST_LENGTH);
+
+	if (hex) {
+		std::string sha256_hex = hex_encode(data_sha256);
+		lua_pushstring(L, sha256_hex.c_str());
+	} else {
+		lua_pushlstring(L, data_sha256.data(), data_sha256.size());
+	}
 	return 1;
 }
 
@@ -699,6 +719,7 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 
 	API_FCT(get_version);
 	API_FCT(sha1);
+	API_FCT(sha256);
 	API_FCT(colorspec_to_colorstring);
 	API_FCT(colorspec_to_bytes);
 
@@ -732,6 +753,7 @@ void ModApiUtil::InitializeClient(lua_State *L, int top)
 
 	API_FCT(get_version);
 	API_FCT(sha1);
+	API_FCT(sha256);
 	API_FCT(colorspec_to_colorstring);
 	API_FCT(colorspec_to_bytes);
 
@@ -772,6 +794,7 @@ void ModApiUtil::InitializeAsync(lua_State *L, int top)
 
 	API_FCT(get_version);
 	API_FCT(sha1);
+	API_FCT(sha256);
 	API_FCT(colorspec_to_colorstring);
 	API_FCT(colorspec_to_bytes);
 

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -113,6 +113,9 @@ private:
 	// sha1(string, raw)
 	static int l_sha1(lua_State *L);
 
+	// sha256(string, raw)
+	static int l_sha256(lua_State *L);
+
 	// colorspec_to_colorstring(colorspec)
 	static int l_colorspec_to_colorstring(lua_State *L);
 
@@ -130,7 +133,6 @@ private:
 
 	// urlencode(value)
 	static int l_urlencode(lua_State *L);
-
 public:
 	static void Initialize(lua_State *L, int top);
 	static void InitializeAsync(lua_State *L, int top);


### PR DESCRIPTION
This is a pull request allowing the sha225 algorithm that already is in minetest's code to be used by mods, which are currently limited to just sha1. This allows mods to hash a given set of data in a more secure way if needed.

**This PR Ready for Review.**
## How to test

1. Clone my branch and compile minetest
2. Call minetest.sha256 as a mod, and log the result
3. Use an external tool/webpage [like this](https://emn178.github.io/online-tools/) to verify the hash is correct.
