### PR TITLE
Add minetest.generate_biomes and minetest.generate_biome_dust

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6115,6 +6115,19 @@ Environment access
     * Generate all registered decorations within the VoxelManip `vm` and in the
       area from `pos1` to `pos2`.
     * `pos1` and `pos2` are optional and default to mapchunk minp and maxp.
+* `minetest.generate_biomes(vm, pos1, pos2[, noise_filler_depth])`
+    * Generate biome nodes according to the registered biomes and
+      temperature/humidity noises within the VoxelManip `vm` and in the area
+      from `pos1` to `pos2`.
+    * `noise_filler_depth` is an optional `PerlinNoiseMap` to add an offset to
+      the `depth_filler` of the biomes (see [Biome definition]).
+    * Must be called during mapgen (`on_generated()` callback)
+    * `pos1` and `pos2` should have the same X and Z size than mapgen chunks.
+    * The initial data in `vm` may only contain air, stone, water and
+      river water nodes (see [Essential aliases]). Other nodes are ignored.
+    * Also populates the mapgen objects `heatmap`, `humiditymap` and `biomemap`
+      (see [Mapgen objects]), so that `minetest.generate_decorations` and
+      `minetest.generate_ores` will take them into account.
 * `minetest.clear_objects([options])`
     * Clear all objects in the environment
     * Takes an optional table as an argument with the field `mode`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6126,8 +6126,18 @@ Environment access
     * The initial data in `vm` may only contain air, stone, water and
       river water nodes (see [Essential aliases]). Other nodes are ignored.
     * Also populates the mapgen objects `heatmap`, `humiditymap` and `biomemap`
-      (see [Mapgen objects]), so that `minetest.generate_decorations` and
-      `minetest.generate_ores` will take them into account.
+      (see [Mapgen objects]), so that `minetest.generate_decorations`,
+      `minetest.generate_ores` and `minetest.generate_biome_dust` will take
+      them into account.
+* `minetest.generate_biome_dust(vm, pos1, pos2)`
+    * Generate the `node_dust` of the biome (see [Biome definition]) within the
+      VoxelManip `vm` and in the area from `pos1` to `pos2`.
+    * `pos1` and `pos2` should have the same X and Z size than mapgen chunks.
+    * Nodes immediately above `pos2` must be generated (non-ignore). If the
+      mapgen does not over-generate 1 node up, consider offsetting `pos2.y`
+      by -1.
+    * Reads the mapgen object `biomemap` (see [Mapgen Objects]), that must be
+      already computed (ie. using `minetest.generate_biomes`).
 * `minetest.clear_objects([options])`
     * Clear all objects in the environment
     * Takes an optional table as an argument with the field `mode`.

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -292,7 +292,9 @@ private:
 	inheriting MapgenBasic.
 */
 class MapgenBasic : public Mapgen {
+	friend class ModApiMapgen;
 public:
+	MapgenBasic() = default;
 	MapgenBasic(int mapgenid, MapgenParams *params, EmergeParams *emerge);
 	virtual ~MapgenBasic();
 
@@ -306,7 +308,7 @@ public:
 protected:
 	BiomeManager *m_bmgr;
 
-	Noise *noise_filler_depth;
+	Noise *noise_filler_depth = nullptr;
 
 	v3s16 node_min;
 	v3s16 node_max;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1681,6 +1681,47 @@ int ModApiMapgen::l_generate_biomes(lua_State *L)
 }
 
 
+// generate_biome_dust(vm, p1, p2)
+int ModApiMapgen::l_generate_biome_dust(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	EmergeManager *emerge = getServer(L)->getEmergeManager();
+	if (!emerge)
+		return 0;
+
+	Mapgen *mg_current = emerge->getCurrentMapgen();
+	if (!mg_current || !mg_current->biomegen ||
+			mg_current->biomegen->getType() != BIOMEGEN_ORIGINAL)
+		return 0;
+
+	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
+
+	MapgenBasic mg;
+
+	mg.vm   = checkObject<LuaVoxelManip>(L, 1)->vm;
+	mg.m_bmgr = mg_current->m_emerge->biomemgr;
+	mg.ndef = ndef;
+	mg.biomegen = mg_current->biomegen;
+	mg.biomemap = mg_current->biomegen->biomemap;
+	mg.water_level = mg_current->water_level;
+
+	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
+			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
+	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
+			mg.vm->m_area.MaxEdge - v3s16(1,1,1) * MAP_BLOCKSIZE;
+	sortBoxVerticies(pmin, pmax);
+
+	mg.node_min = pmin;
+	mg.node_max = pmax;
+	mg.full_node_min = mg.vm->m_area.MinEdge;
+	mg.full_node_max = mg.vm->m_area.MaxEdge;
+	mg.dustTopNodes();
+
+	return 0;
+}
+
+
 // create_schematic(p1, p2, probability_list, filename, y_slice_prob_list)
 int ModApiMapgen::l_create_schematic(lua_State *L)
 {
@@ -2094,6 +2135,7 @@ void ModApiMapgen::Initialize(lua_State *L, int top)
 	API_FCT(generate_ores);
 	API_FCT(generate_decorations);
 	API_FCT(generate_biomes);
+	API_FCT(generate_biome_dust);
 	API_FCT(create_schematic);
 	API_FCT(place_schematic);
 	API_FCT(place_schematic_on_vmanip);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_mapgen.h"
 #include "lua_api/l_internal.h"
 #include "lua_api/l_vmanip.h"
+#include "lua_api/l_noise.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include "cpp_api/s_security.h"
@@ -27,6 +28,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server.h"
 #include "environment.h"
 #include "emerge_internal.h"
+#include "emerge.h"
+#include "noise.h"
 #include "mapgen/mg_biome.h"
 #include "mapgen/mg_ore.h"
 #include "mapgen/mg_decoration.h"
@@ -1557,6 +1560,11 @@ int ModApiMapgen::l_generate_ores(lua_State *L)
 	mg.vm   = checkObject<LuaVoxelManip>(L, 1)->vm;
 	mg.ndef = emerge->ndef;
 
+	Mapgen *mg_current = emerge->getCurrentMapgen();
+	if (mg_current && mg_current->biomegen &&
+			mg_current->biomegen->getType() == BIOMEGEN_ORIGINAL)
+		mg.biomemap = mg_current->biomegen->biomemap;
+
 	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
 			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
 	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
@@ -1592,6 +1600,11 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 	mg.vm   = checkObject<LuaVoxelManip>(L, 1)->vm;
 	mg.ndef = emerge->ndef;
 
+	Mapgen *mg_current = emerge->getCurrentMapgen();
+	if (mg_current && mg_current->biomegen &&
+			mg_current->biomegen->getType() == BIOMEGEN_ORIGINAL)
+		mg.biomemap = mg_current->biomegen->biomemap;
+
 	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
 			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
 	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
@@ -1601,6 +1614,68 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 	u32 blockseed = Mapgen::getBlockSeed(pmin, mg.seed);
 
 	decomgr->placeAllDecos(&mg, blockseed, pmin, pmax);
+
+	return 0;
+}
+
+
+// generate_biomes(vm, p1, p2, [noise_filler_depth])
+int ModApiMapgen::l_generate_biomes(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	EmergeManager *emerge = getServer(L)->getEmergeManager();
+	if (!emerge)
+		return 0;
+
+	Mapgen *mg_current = emerge->getCurrentMapgen();
+	if (!mg_current || !mg_current->biomegen ||
+			mg_current->biomegen->getType() != BIOMEGEN_ORIGINAL)
+		return 0;
+
+	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
+
+	MapgenBasic mg;
+
+	mg.c_stone              = ndef->getId("mapgen_stone");
+	mg.c_water_source       = ndef->getId("mapgen_water_source");
+	mg.c_river_water_source = ndef->getId("mapgen_river_water_source");
+
+	mg.vm   = checkObject<LuaVoxelManip>(L, 1)->vm;
+	mg.ndef = ndef;
+	mg.biomegen = mg_current->biomegen;
+	mg.biomemap = mg_current->biomegen->biomemap;
+	mg.water_level = mg_current->water_level;
+
+	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
+			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
+	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
+			mg.vm->m_area.MaxEdge - v3s16(1,1,1) * MAP_BLOCKSIZE;
+	sortBoxVerticies(pmin, pmax);
+	v3s16 psize = pmax - pmin + v3s16(1,1,1);
+
+	if (psize.X != (s16)mg_current->csize.X ||
+			psize.Z > (s16)mg_current->csize.Z) {
+		errorstream << "generate_biomes: X/Z extent must match"
+				" mapgen chunk size" << std::endl;
+		return 0;
+	}
+
+	mg.biomegen->calcBiomeNoise(pmin);
+
+	if (lua_isuserdata(L, 4)) {
+		LuaPerlinNoiseMap *nmap = checkObject<LuaPerlinNoiseMap>(L, 4);
+		Noise *noise = nmap->noise;
+		if ((s16)noise->sx == psize.X && (s16)noise->sz >= psize.Z)
+			mg.noise_filler_depth = noise;
+		else
+			warningstream << "generate_biomes: size of noisemap is inconsistent with chunk size,"
+					" noise will not be used" << std::endl;
+	}
+
+	mg.node_min = pmin;
+	mg.node_max = pmax;
+	mg.generateBiomes();
 
 	return 0;
 }
@@ -2018,6 +2093,7 @@ void ModApiMapgen::Initialize(lua_State *L, int top)
 
 	API_FCT(generate_ores);
 	API_FCT(generate_decorations);
+	API_FCT(generate_biomes);
 	API_FCT(create_schematic);
 	API_FCT(place_schematic);
 	API_FCT(place_schematic_on_vmanip);

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -134,6 +134,9 @@ private:
 
 	// generate_biomes(vm, p1, p2, [noise_filler_depth])
 	static int l_generate_biomes(lua_State *L);
+	
+	// generate_biome_dust(vm, p1, p2)
+	static int l_generate_biome_dust(lua_State *L);
 
 	// clear_registered_ores
 	static int l_clear_registered_ores(lua_State *L);

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -132,6 +132,9 @@ private:
 	// generate_decorations(vm, p1, p2)
 	static int l_generate_decorations(lua_State *L);
 
+	// generate_biomes(vm, p1, p2, [noise_filler_depth])
+	static int l_generate_biomes(lua_State *L);
+
 	// clear_registered_ores
 	static int l_clear_registered_ores(lua_State *L);
 

--- a/src/script/lua_api/l_noise.h
+++ b/src/script/lua_api/l_noise.h
@@ -62,6 +62,7 @@ public:
 */
 class LuaPerlinNoiseMap : public ModApiBase
 {
+	friend class ModApiMapgen;
 	Noise *noise;
 
 	static luaL_Reg methods[];


### PR DESCRIPTION
Rebase of #11953, fixes #8329, with some additions.

## What it does?
This allows to use core biome generator for Lua mapgens, by adding two functions:
- `minetest.generate_biomes(vm, pos1, pos2, nobj_filler_depth)` to generate biome nodes in the `VoxelManip`, and update `heatmap`, `humiditymap` and `biomemap` like a core mapgen would do. A latter `minetest.generate_ores` or `minetest.generate_decorations` will take the biomemap into account, so that biome-dependant ores/decos will be placed on the right biome (which was previously not possible in a full Lua mapgen). It must be called during mapgen (`register_on_generated` callback), and the X/Z extent of `pos1`-`pos2` must match mapgen chunk size, for the buffers to work correctly. It is however possible (and I even recommend it) to offset `pos1.y` by -1 node to avoid border effects.
- `minetest.generate_biome_dust(vm, pos1, pos2)` to generate dust nodes (snow...) above ground and decorations. Nodes above `pos2` must be generated, so I also recommend, if the mapgen does not overgenerate 1 node up/down, to offset `pos2.y` by -1 node.

These functions are available in both server and emerge environments, like most mapgen-related functions.

As stated in the previous PR, they create a temporary `MapgenBasic` object and call `MapgenBasic::generateBiomes()` or `MapgenBasic::dustTopNodes()`. Class definition is modified to allow this.

## Why is it interesting/needed?
- This makes easier to add biomes to a Lua mapgen, without having to reinvent the wheel.
- Allows compatibility between Lua mapgens and mods acting on the biome system.
- Faster than Lua-only implementations of the biome system.

I believe Lua Mapgens have a large potential for Minetest, because they are able to adapt the terrain to a game's needs in a way core mapgens can't always offer. But sadly, they are often regarded as second-class mapgens, because of their relative slowness and incompatibility with most mods. They can take months to develop, but rarely end up deployed on servers or used by gamers for anything more than experiments. My PR goes in the direction to change that.

## How to use?
I have made [a modified version of `lvm_example`](https://github.com/gaelysam/lvm_example/tree/use_core_biomegen) to test this. Do not hesitate to add biome mods (Ethereal, Variety...) to see how it reacts.

To test on emerge environment, I have also made [a fork of sfan5's flatgen](https://gist.github.com/gaelysam/07b8fd39b8682241fe4270da4d49b688).

If you want to add it to another mapgen, the full workflow is the following:
```lua
vm:set_data(data)
minetest.generate_biomes(vm, {x=minp.x, y=minp.y-1, z=minp.z}, maxp, nobj_filler_depth)
minetest.generate_ores(vm, minp, maxp)
minetest.generate_decorations(vm, minp, maxp)
minetest.generate_biome_dust(vm, minp, {x=maxp.x, y=maxp.y-1, z=maxp.z})
vm:calc_lighting()
vm:write_to_map()
vm:update_liquids()
```
![screenshot_20240114_230500](https://github.com/minetest/minetest/assets/6905002/cb68b972-4972-4193-b97d-b3c84ec527e3)
^ This PR + lvm_example + [variety](https://content.minetest.net/packages/Atlante/variety/)

## Status
This PR is ready for review.