### PR TITLE
Define strlcpy only on platforms where it's not available

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -695,6 +695,8 @@ endif()
 include(CheckCSourceCompiles)
 include(CheckSymbolExists)
 
+check_symbol_exists(strlcpy "string.h" HAVE_STRLCPY)
+
 set(CMAKE_REQUIRED_INCLUDES ${LUA_INCLUDE_DIR})
 if(USE_LUAJIT)
 	set(CMAKE_REQUIRED_LIBRARIES ${LUA_LIBRARY})

--- a/src/cmake_config.h.in
+++ b/src/cmake_config.h.in
@@ -30,6 +30,7 @@
 #cmakedefine01 USE_SYSTEM_JSONCPP
 #cmakedefine01 USE_REDIS
 #cmakedefine01 HAVE_ENDIAN_H
+#cmakedefine01 HAVE_STRLCPY
 #cmakedefine01 CURSES_HAVE_CURSES_H
 #cmakedefine01 CURSES_HAVE_NCURSES_H
 #cmakedefine01 CURSES_HAVE_NCURSES_NCURSES_H

--- a/src/porting.h
+++ b/src/porting.h
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 // Be mindful of what you include here!
 #include <string>
+#include "config.h"
 #include "irrlichttypes.h" // u64
 #include "debug.h"
 #include "constants.h"
@@ -70,21 +71,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#define strtok_r(x, y, z) mystrtok_r(x, y, z)
 #endif
 
-// strlcpy is missing from glibc.  thanks a lot, drepper.
-// strlcpy is also missing from AIX and HP-UX because they aim to be weird.
-// We can't simply alias strlcpy to MSVC's strcpy_s, since strcpy_s by
-// default raises an assertion error and aborts the program if the buffer is
-// too small.
-#if defined(__FreeBSD__) || defined(__NetBSD__)    || \
-	defined(__OpenBSD__) || defined(__DragonFly__) || \
-	defined(__APPLE__)   ||                           \
-	defined(__sun)       || defined(sun)           || \
-	defined(__QNX__)     || defined(__QNXNTO__)
-	#define HAVE_STRLCPY
-#endif
-
-// So we need to define our own.
-#ifndef HAVE_STRLCPY
+#if !HAVE_STRLCPY
 	#define strlcpy(d, s, n) mystrlcpy(d, s, n)
 #endif
 


### PR DESCRIPTION
Be smart, do not list platforms and combination which has `strlcpy`, but detect it.

Right now, we conflict with some variation used on musl-libc on ppc64le. This should resolve it.

Btw. recently released glibc [have it]( https://news.ycombinator.com/item?id=36765747) (we can forgive Ulrich Drepper now :rofl: )