### PR TITLE
Fix signed overflow UB in PseudoRandom::next()

### DIFF
--- a/src/noise.h
+++ b/src/noise.h
@@ -56,9 +56,9 @@ public:
 
 	inline u32 next()
 	{
-		m_next = (u32)m_next * 1103515245U + 12345U;
+		m_next = static_cast<u32>(m_next) * 1103515245U + 12345U;
 		// Signed division is required due to backwards compatibility
-		return (u32)(m_next / 65536) % (RANDOM_RANGE + 1U);
+		return static_cast<u32>(m_next / 65536) % (RANDOM_RANGE + 1U);
 	}
 
 	inline s32 range(s32 min, s32 max)
@@ -71,7 +71,7 @@ public:
 		PcgRandom, we cannot modify this RNG's range as it would change the
 		output of this RNG for reverse compatibility.
 		*/
-		if ((u32)(max - min) > (RANDOM_RANGE + 1) / 5)
+		if (static_cast<u32>(max - min) > (RANDOM_RANGE + 1) / 5)
 			throw PrngException("Range too large");
 
 		return (next() % (max - min + 1)) + min;

--- a/src/noise.h
+++ b/src/noise.h
@@ -56,8 +56,9 @@ public:
 
 	inline u32 next()
 	{
-		m_next = m_next * 1103515245 + 12345;
-		return (u32)(m_next / 65536) % (RANDOM_RANGE + 1);
+		m_next = (u32)m_next * 1103515245U + 12345U;
+		// Signed division is required due to backwards compatibility
+		return (u32)(m_next / 65536) % (RANDOM_RANGE + 1U);
 	}
 
 	inline s32 range(s32 min, s32 max)


### PR DESCRIPTION
On x86-64 with gcc or clang, produces the same assembly as the old code, see:
https://godbolt.org/z/3b85aj8aE

It would be bad if the prng produced different results on different platforms or compilers. Without UB, this isn't possible.

## To do

This PR is a Ready for Review.

## How to test

* Compile with ubsan.
* Run unittests.
