### PR TITLE
Remove unused meshgen_block_cache_size setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1826,11 +1826,6 @@ mesh_generation_interval (Mapblock mesh generation delay) int 0 0 50
 #    Value of 0 (default) will let Minetest autodetect the number of available threads.
 mesh_generation_threads (Mapblock mesh generation threads) int 0 0 8
 
-#    Size of the MapBlock cache of the mesh generator. Increasing this will
-#    increase the cache hit %, reducing the data being copied from the main
-#    thread, thus reducing jitter.
-meshgen_block_cache_size (Mapblock mesh generator's MapBlock cache size in MB) int 20 0 1000
-
 #    True = 256
 #    False = 128
 #    Usable to make minimap smoother on slower machines.

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -54,7 +54,6 @@ MeshUpdateQueue::MeshUpdateQueue(Client *client):
 {
 	m_cache_enable_shaders = g_settings->getBool("enable_shaders");
 	m_cache_smooth_lighting = g_settings->getBool("smooth_lighting");
-	m_meshgen_block_cache_size = g_settings->getS32("meshgen_block_cache_size");
 }
 
 MeshUpdateQueue::~MeshUpdateQueue()

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -87,7 +87,6 @@ private:
 	// TODO: Add callback to update these when g_settings changes
 	bool m_cache_enable_shaders;
 	bool m_cache_smooth_lighting;
-	int m_meshgen_block_cache_size;
 
 	void fillDataFromMapBlocks(QueuedMeshUpdate *q);
 	void cleanupCache();

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -46,7 +46,6 @@ void set_default_settings()
 	settings->setDefault("enable_mesh_cache", "false");
 	settings->setDefault("mesh_generation_interval", "0");
 	settings->setDefault("mesh_generation_threads", "0");
-	settings->setDefault("meshgen_block_cache_size", "20");
 	settings->setDefault("enable_vbo", "true");
 	settings->setDefault("free_move", "false");
 	settings->setDefault("pitch_move", "false");


### PR DESCRIPTION
Just noticed this unused setting. Removing it.

## To do

This PR is Ready for Review.

## How to test

Make sure it still compiles.