### PR TITLE
Fix typo in minimap bumpmapping shader

### DIFF
--- a/client/shaders/minimap_shader/opengl_fragment.glsl
+++ b/client/shaders/minimap_shader/opengl_fragment.glsl
@@ -12,13 +12,13 @@ void main (void)
 	//texture sampling rate
 	const float step = 1.0 / 256.0;
 	float tl = texture2D(normalTexture, vec2(uv.x - step, uv.y + step)).r;
-	float t  = texture2D(normalTexture, vec2(uv.x - step, uv.y - step)).r;
+	float t  = texture2D(normalTexture, vec2(uv.x,        uv.y + step)).r;
 	float tr = texture2D(normalTexture, vec2(uv.x + step, uv.y + step)).r;
-	float r  = texture2D(normalTexture, vec2(uv.x + step, uv.y)).r;
+	float r  = texture2D(normalTexture, vec2(uv.x + step, uv.y       )).r;
 	float br = texture2D(normalTexture, vec2(uv.x + step, uv.y - step)).r;
-	float b  = texture2D(normalTexture, vec2(uv.x, uv.y - step)).r;
+	float b  = texture2D(normalTexture, vec2(uv.x,        uv.y - step)).r;
 	float bl = texture2D(normalTexture, vec2(uv.x - step, uv.y - step)).r;
-	float l  = texture2D(normalTexture, vec2(uv.x - step, uv.y)).r;
+	float l  = texture2D(normalTexture, vec2(uv.x - step, uv.y       )).r;
 	float dX = (tr + 2.0 * r + br) - (tl + 2.0 * l + bl);
 	float dY = (bl + 2.0 * b + br) - (tl + 2.0 * t + tr);
 	vec4 bump = vec4 (normalize(vec3 (dX, dY, 0.1)),1.0);


### PR DESCRIPTION
`t` (top) was the same as `bl` (bottom left).

## To do

This PR is a Ready for Review.

## How to test

* Look at your minimap.

master (left) vs. PR (right):
![screenshot_master_PR](https://github.com/minetest/minetest/assets/7613443/f06b0d6a-2bdc-438e-8aa4-4c8f6e949129)

