### PR TITLE
Add MINETEST_TEXTURE_PATH environment variable

### DIFF
--- a/doc/minetest.6
+++ b/doc/minetest.6
@@ -125,6 +125,9 @@ Colon delimited list of directories to search for games.
 .B MINETEST_MOD_PATH
 Colon delimited list of directories to search for mods.
 .TP
+.B MINETEST_TEXTURE_PATH
+Colon delimited list of directories to search for textures.
+.TP
 .B MINETEST_USER_PATH
 Path to Minetest user data directory.
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -51,6 +51,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "modchannels.h"
 #include "serverlist.h"
 #include "util/string.h"
+#include "util/strfnd.h"
 #include "rollback.h"
 #include "util/serialize.h"
 #include "util/thread.h"
@@ -2602,6 +2603,7 @@ void Server::fillMediaCache()
 
 	// ordered in descending priority
 	paths.push_back(getBuiltinLuaPath() + DIR_DELIM + "locale");
+	getEnvTextureDirs(paths);
 	fs::GetRecursiveDirs(paths, porting::path_user + DIR_DELIM + "textures" + DIR_DELIM + "server");
 	fs::GetRecursiveDirs(paths, m_gamespec.path + DIR_DELIM + "textures");
 	m_modmgr->getModsMediaPaths(paths);
@@ -3778,6 +3780,14 @@ const ModSpec *Server::getModSpec(const std::string &modname) const
 std::string Server::getBuiltinLuaPath()
 {
 	return porting::path_share + DIR_DELIM + "builtin";
+}
+
+void Server::getEnvTextureDirs(std::vector<std::string> &paths) const
+{
+	const char *c_texture_path = getenv("MINETEST_TEXTURE_PATH");
+	Strfnd search_paths(c_texture_path ? c_texture_path : "");
+	while (!search_paths.at_end())
+		fs::GetRecursiveDirs(paths, search_paths.next(PATH_DELIM));
 }
 
 // Not thread-safe.

--- a/src/server.h
+++ b/src/server.h
@@ -289,6 +289,7 @@ public:
 	virtual const ModSpec* getModSpec(const std::string &modname) const;
 	virtual const SubgameSpec* getGameSpec() const { return &m_gamespec; }
 	static std::string getBuiltinLuaPath();
+	void getEnvTextureDirs(std::vector<std::string> &paths) const;
 	virtual std::string getWorldPath() const { return m_path_world; }
 
 	inline bool isSingleplayer() const


### PR DESCRIPTION
## Goal of the PR
- Resolves #12835
## How does the PR work?
- It adds a `MINETEST_TEXTURE_PATH` environment variable which you can use to specify additional texture paths.
- The paths behave like using a texture pack named `"server"` so they are also used by other clients when hosting a server.
- In particular the paths are **not used for texture packs**, since texture packs only use the `texture_path` setting, which gets set when enabling them in the main menu. So you can already use a  texture pack outside the textures folder by manually changing the `texture_path` setting, but this is only client side. So with this PR you can also change server side textures without relying on the `$MINETEST_USER_PATH/textures/server` path.
## Other considerations
- Adding an option for paths to search for texture packs makes no sense to me, since this is only handled in Lua by the main menu, and by the time you configured it you could just directly change the `texture_path` setting.
- However I think the main menu should allow enabling texture packs from anywhere. If I remember correctly in the past you could freely change the `texture_path` setting in the menu, but currently it is a hidden setting and you have to edit `minetest.conf` manually.
- I hope the variable name is appropriate. Alternatively it could be `MINETEST_SERVER_TEXTURES_PATH` to emphasize that it does not represent `minetest/textures/`.

## To do

This PR is Ready for Review.

## How to test

- Create some folders and put textures into them, e.g. a texture pack.
- Start minetest with for example `env MINETEST_TEXTURE_PATH="<path1>:<path2>:<path3>:..." ./bin/minetest `
- Check if the textures are used.

