### PR TITLE
[no squash] Bypass media transfer in single player

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install deps
         run: |
           source ./util/ci/common.sh
-          install_linux_deps clang-7 valgrind
+          install_linux_deps clang-7 llvm
 
       - name: Build
         run: |
@@ -94,14 +94,11 @@ jobs:
         env:
           CC: clang-7
           CXX: clang++-7
+          CMAKE_FLAGS: '-DCMAKE_C_FLAGS="-fsanitize=address" -DCMAKE_CXX_FLAGS="-fsanitize=address"'
 
       - name: Unittest
         run: |
           ./bin/minetest --run-unittests
-
-      - name: Valgrind
-        run: |
-          valgrind --leak-check=full --leak-check-heuristics=all --undef-value-errors=no --error-exitcode=9 ./bin/minetest --run-unittests
 
   # Current clang version
   clang_14:

--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/serialize.h"
 #include "util/sha1.h"
 #include "util/string.h"
+#include <sstream>
 
 static std::string getMediaCacheDir()
 {
@@ -41,7 +42,16 @@ bool clientMediaUpdateCache(const std::string &raw_hash, const std::string &file
 	std::string sha1_hex = hex_encode(raw_hash);
 	if (!media_cache.exists(sha1_hex))
 		return media_cache.update(sha1_hex, filedata);
-	return true;
+	return false;
+}
+
+bool clientMediaUpdateCacheCopy(const std::string &raw_hash, const std::string &path)
+{
+	FileCache media_cache(getMediaCacheDir());
+	std::string sha1_hex = hex_encode(raw_hash);
+	if (!media_cache.exists(sha1_hex))
+		return media_cache.updateCopyFile(sha1_hex, path);
+	return false;
 }
 
 /*
@@ -188,10 +198,6 @@ void ClientMediaDownloader::initialStep(Client *client)
 	}
 
 	assert(m_uncached_received_count == 0);
-
-	// Create the media cache dir if we are likely to write to it
-	if (m_uncached_count != 0)
-		createCacheDirs();
 
 	// If we found all files in the cache, report this fact to the server.
 	// If the server reported no remote servers, immediately start
@@ -511,18 +517,6 @@ IClientMediaDownloader::IClientMediaDownloader():
 {
 }
 
-void IClientMediaDownloader::createCacheDirs()
-{
-	if (!m_write_to_cache)
-		return;
-
-	std::string path = getMediaCacheDir();
-	if (!fs::CreateAllDirs(path)) {
-		errorstream << "Client: Could not create media cache directory: "
-			<< path << std::endl;
-	}
-}
-
 bool IClientMediaDownloader::tryLoadFromCache(const std::string &name,
 	const std::string &sha1, Client *client)
 {
@@ -725,8 +719,6 @@ void SingleMediaDownloader::initialStep(Client *client)
 		m_stage = STAGE_DONE;
 	if (isDone())
 		return;
-
-	createCacheDirs();
 
 	// If the server reported no remote servers, immediately fall back to
 	// conventional transfer.

--- a/src/client/clientmedia.h
+++ b/src/client/clientmedia.h
@@ -22,7 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes.h"
 #include "filecache.h"
 #include "util/basic_macros.h"
-#include <ostream>
 #include <map>
 #include <set>
 #include <vector>
@@ -35,9 +34,14 @@ struct HTTPFetchResult;
 #define MTHASHSET_FILE_NAME "index.mth"
 
 // Store file into media cache (unless it exists already)
-// Validating the hash is responsibility of the caller
+// Caller should check the hash.
+// return true if something was updated
 bool clientMediaUpdateCache(const std::string &raw_hash,
 	const std::string &filedata);
+
+// Copy file on disk(!) into media cache (unless it exists already)
+bool clientMediaUpdateCacheCopy(const std::string &raw_hash,
+	const std::string &path);
 
 // more of a base class than an interface but this name was most convenient...
 class IClientMediaDownloader
@@ -80,8 +84,6 @@ protected:
 	// Forwards the call to the appropriate Client method
 	virtual bool loadMedia(Client *client, const std::string &data,
 		const std::string &name) = 0;
-
-	void createCacheDirs();
 
 	bool tryLoadFromCache(const std::string &name, const std::string &sha1,
 			Client *client);

--- a/src/client/filecache.cpp
+++ b/src/client/filecache.cpp
@@ -28,6 +28,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <fstream>
 #include <cstdlib>
 
+void FileCache::createDir()
+{
+	if (!fs::CreateAllDirs(m_dir)) {
+		errorstream << "Could not create cache directory: "
+			<< m_dir << std::endl;
+	}
+}
+
 bool FileCache::loadByPath(const std::string &path, std::ostream &os)
 {
 	std::ifstream fis(path.c_str(), std::ios_base::binary);
@@ -40,8 +48,8 @@ bool FileCache::loadByPath(const std::string &path, std::ostream &os)
 
 	bool bad = false;
 	for(;;){
-		char buf[1024];
-		fis.read(buf, 1024);
+		char buf[4096];
+		fis.read(buf, sizeof(buf));
 		std::streamsize len = fis.gcount();
 		os.write(buf, len);
 		if(fis.eof())
@@ -61,6 +69,7 @@ bool FileCache::loadByPath(const std::string &path, std::ostream &os)
 
 bool FileCache::updateByPath(const std::string &path, const std::string &data)
 {
+	createDir();
 	std::ofstream file(path.c_str(), std::ios_base::binary |
 			std::ios_base::trunc);
 
@@ -94,4 +103,12 @@ bool FileCache::exists(const std::string &name)
 	std::string path = m_dir + DIR_DELIM + name;
 	std::ifstream fis(path.c_str(), std::ios_base::binary);
 	return fis.good();
+}
+
+bool FileCache::updateCopyFile(const std::string &name, const std::string &src_path)
+{
+	std::string path = m_dir + DIR_DELIM + name;
+
+	createDir();
+	return fs::CopyFileContents(src_path, path);
 }

--- a/src/client/filecache.h
+++ b/src/client/filecache.h
@@ -35,9 +35,13 @@ public:
 	bool load(const std::string &name, std::ostream &os);
 	bool exists(const std::string &name);
 
+	// Copy another file on disk into the cache
+	bool updateCopyFile(const std::string &name, const std::string &src_path);
+
 private:
 	std::string m_dir;
 
+	void createDir();
 	bool loadByPath(const std::string &path, std::ostream &os);
 	bool updateByPath(const std::string &path, const std::string &data);
 };

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -33,6 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/mapblock_mesh.h"
 #include "client/sound.h"
 #include "clientmap.h"
+#include "clientmedia.h" // For clientMediaUpdateCacheCopy
 #include "clouds.h"
 #include "config.h"
 #include "content_cao.h"
@@ -776,6 +777,7 @@ protected:
 	bool initSound();
 	bool createSingleplayerServer(const std::string &map_dir,
 			const SubgameSpec &gamespec, u16 port);
+	void copyServerClientCache();
 
 	// Client creation
 	bool createClient(const GameStartData &start_data);
@@ -1459,7 +1461,29 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 			false, nullptr, error_message);
 	server->start();
 
+	copyServerClientCache();
+
 	return true;
+}
+
+void Game::copyServerClientCache()
+{
+	// It would be possible to let the client directly read the media files
+	// from where the server knows they are. But aside from being more complicated
+	// it would also *not* fill the media cache and cause slower joining of 
+	// remote servers.
+	// (Imagine that you launch a game once locally and then connect to a server.)
+
+	assert(server);
+	auto map = server->getMediaList();
+	u32 n = 0;
+	for (auto &it : map) {
+		assert(it.first.size() == 20); // SHA1
+		if (clientMediaUpdateCacheCopy(it.first, it.second))
+			n++;
+	}
+	infostream << "Copied " << n << " files directly from server to client cache"
+		<< std::endl;
 }
 
 bool Game::createClient(const GameStartData &start_data)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4080,6 +4080,19 @@ Translations *Server::getTranslationLanguage(const std::string &lang_code)
 	return translations;
 }
 
+std::unordered_map<std::string, std::string> Server::getMediaList()
+{
+	MutexAutoLock env_lock(m_env_mutex);
+
+	std::unordered_map<std::string, std::string> ret;
+	for (auto &it : m_media) {
+		if (it.second.no_announce)
+			continue;
+		ret.emplace(base64_decode(it.second.sha1_digest), it.second.path);
+	}
+	return ret;
+}
+
 ModStorageDatabase *Server::openModStorageDatabase(const std::string &world_path)
 {
 	std::string world_mt_path = world_path + DIR_DELIM + "world.mt";

--- a/src/server.h
+++ b/src/server.h
@@ -385,6 +385,10 @@ public:
 	// Get or load translations for a language
 	Translations *getTranslationLanguage(const std::string &lang_code);
 
+	// Returns all media files the server knows about
+	// map key = binary sha1, map value = file path
+	std::unordered_map<std::string, std::string> getMediaList();
+
 	static ModStorageDatabase *openModStorageDatabase(const std::string &world_path);
 
 	static ModStorageDatabase *openModStorageDatabase(const std::string &backend,

--- a/src/unittest/test_datastructures.cpp
+++ b/src/unittest/test_datastructures.cpp
@@ -108,6 +108,8 @@ void TestDataStructures::testMap1()
 			break;
 	}
 	UASSERT(once);
+
+	map.clear(); // ASan complains about stack-use-after-scope otherwise
 }
 
 void TestDataStructures::testMap2()
@@ -121,6 +123,8 @@ void TestDataStructures::testMap2()
 	UASSERT(t0.deleted);
 	UASSERT(!t1.copied);
 	UASSERT(!t1.deleted);
+
+	map.clear();
 }
 
 void TestDataStructures::testMap3()


### PR DESCRIPTION
aside from generally being faster, this fully "fixes" #9107 by just never doing media transfers in singleplayer.
(underlying issue is of course not solved)

## To do

This PR is Ready for Review.

## How to test

Remove `client/media` and start singleplayer.
