### PR TITLE
log chat messages

### DIFF
--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -435,6 +435,9 @@ void Client::handleCommand_ChatMessage(NetworkPacket *pkt)
 
 	chatMessage->type = (ChatMessageType) message_type;
 
+	// log the chat message
+	actionstream << "[Chat] " << wide_to_utf8(chatMessage->message) << std::endl;
+
 	// @TODO send this to CSM using ChatMessage object
 	if (modsLoaded() && m_script->on_receiving_message(
 			wide_to_utf8(chatMessage->message))) {


### PR DESCRIPTION
Many players including myself wish to be able to log chat messages. Reading a text file is way more convenient than scrolling up and down ingame. Plus it adds timestamps. Sometimes colors in chat may be hard to read. And sometimes conversations are more complex than exchanging "Hi"'s.

This PR adds the form of logging that I'm personally using since some years and that other players have asked for and included in their builds. It requires editing whenever the upstream file is changed. And some players who want chat logging lack the skill to patch the code themshelves.

The PR is not perfect. Improvements are welcome! In particular:
1. Logging to an extra file (perhaps a logfile for each day, perhaps even include server name) would be better than debug.txt
2. The "ACTION[Main]: [Chat]" marker is currently needed for finding/grepping such entries in debug.txt but makes the whole thing less readable. Extra files would be better.
3. There ought to be a settings option to turn logging on and off.
4. If possible it would be great to see which server the player connected to.