### PR TITLE
show more lines in chat scrollback buffer

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -775,9 +775,9 @@ void ChatPrompt::clampView()
 
 
 ChatBackend::ChatBackend():
-	m_console_buffer(500),
+	m_console_buffer(1500),
 	m_recent_buffer(6),
-	m_prompt(L"]", 500)
+	m_prompt(L"]", 1500)
 {
 }
 


### PR DESCRIPTION
Sometimes the amount of lines shown in the chat scrollback buffer are just not sufficient. This is an attempt to get more lines for longer scrollback.

I've been using this for a while. Yet it's not perfect:
1. The number of (extra) lines ought to be configurable by the player.