### PR TITLE
added group soft_falling for not crushing buildable_to nodes

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -315,7 +315,12 @@ core.register_entity(":__builtin:falling_node", {
 					return false
 				end
 			else
-				core.remove_node(np)
+				-- if we are a soft_falling node: do not crush buildable_to nodes
+				if core.get_item_group(self.node.name, "soft_falling") == 0 then
+					core.remove_node(np)
+				else
+					np.y = np.y + 1
+				end
 			end
 		end
 
@@ -547,6 +552,11 @@ function core.check_single_for_falling(p)
 		local n_bottom = core.get_node_or_nil(p_bottom)
 		local d_bottom = n_bottom and core.registered_nodes[n_bottom.name]
 		if d_bottom then
+			-- if we are a soft_falling node: do not start a falling node cascade
+			if(d_bottom.name and d_bottom.name ~= "air"
+			  and core.get_item_group(n.name, "soft_falling") > 0) then
+				return false
+			end
 			local same = n.name == n_bottom.name
 			-- Let leveled nodes fall if it can merge with the bottom node
 			if same and d_bottom.paramtype2 == "leveled" and


### PR DESCRIPTION
This PR might be more controversial as it might be too specific.

Sadly the alternative is to copy those functions and replace them with modified versions in my moresnow mod -> maintenance hell.

When a node like snow (not the block - the snowball, thin layer of snow) falls on a buildable_to node it crushes the buildable_to node. That is fine for sand and gravel. But snow is much softer. My moresnow mod creates specific snow covers for diffrent nodes (fence posts, variants of stairs, some slopes from the moreblocks mod, plus a general one for meshes, plants etc.). It does that by cheating as of course not two nodes can exist at the same place. The snow cover is stored in the node *above* the covered node - and *visually* shows up in the node below, creating a nice wintery sugar coating on the node below.

Mapgen of mg_villages puts such snow covers on grown wheat and cotton plants around the villages. Real farmers might be horrified by snow on their not-yet-harvested crops - but it does look great :-)

Trouble is that digging or placing a node next to/in that generated snow covered field triggers a cascade. They're falling nodes - and there's a node below them that lets them fall - so the snow disappears in a big cascade. There's also no way for the player to let snow drop on plants again.

This PR solves that by adding the soft_falling group. Nodes with that group set will not crush buildable_to nodes (they'll be placed in the node above) and will not trigger a cascade.