### PR TITLE
Add flag to control mgv6 temple generation

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -70,6 +70,8 @@ local flag_checkboxes = {
 		{ "trees", fgettext("Trees and jungle grass") },
 		{ "flat", fgettext("Flat terrain") },
 		{ "mudflow", fgettext("Mud flow"), fgettext("Terrain surface erosion") },
+		{ "temples", fgettext("Desert temples"),
+		fgettext("Different dungeon variant generated in desert biomes (only if dungeons enabled)") },
 		-- Biome settings are in mgv6_biomes below
 	},
 }
@@ -279,7 +281,7 @@ local function create_world_formspec(dialogdata)
 	end
 
 	local retval =
-		"size[12.25,7,true]" ..
+		"size[12.25,7.4,true]" ..
 
 		-- Left side
 		"container[0,0]"..
@@ -321,8 +323,10 @@ local function create_world_formspec(dialogdata)
 		"container_end[]"..
 
 		-- Menu buttons
-		"button[3.25,6.5;3,0.5;world_create_confirm;" .. fgettext("Create") .. "]" ..
-		"button[6.25,6.5;3,0.5;world_create_cancel;" .. fgettext("Cancel") .. "]"
+		"container[0,6.9]"..
+		"button[3.25,0;3,0.5;world_create_confirm;" .. fgettext("Create") .. "]" ..
+		"button[6.25,0;3,0.5;world_create_cancel;" .. fgettext("Cancel") .. "]" ..
+		"container_end[]"
 
 	return retval
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1068,7 +1068,8 @@ mgv5_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2
 #    The 'snowbiomes' flag enables the new 5 biome system.
 #    When the 'snowbiomes' flag is enabled jungles are automatically enabled and
 #    the 'jungles' flag is ignored.
-mgv6_spflags (Mapgen V6 specific flags) flags jungles,biomeblend,mudflow,snowbiomes,noflat,trees jungles,biomeblend,mudflow,snowbiomes,flat,trees,nojungles,nobiomeblend,nomudflow,nosnowbiomes,noflat,notrees
+#    The 'temples' flag disables generation of desert temples. Normal dungeons will appear instead.
+mgv6_spflags (Mapgen V6 specific flags) flags jungles,biomeblend,mudflow,snowbiomes,noflat,trees,temples jungles,biomeblend,mudflow,snowbiomes,flat,trees,temples,nojungles,nobiomeblend,nomudflow,nosnowbiomes,noflat,notrees,notemples
 
 #    Deserts occur when np_biome exceeds this value.
 #    When the 'snowbiomes' flag is enabled, this is ignored.

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -47,6 +47,7 @@ FlagDesc flagdesc_mapgen_v6[] = {
 	{"snowbiomes", MGV6_SNOWBIOMES},
 	{"flat",       MGV6_FLAT},
 	{"trees",      MGV6_TREES},
+	{"temples",    MGV6_TEMPLES},
 	{NULL,         0}
 };
 
@@ -225,7 +226,8 @@ void MapgenV6Params::writeParams(Settings *settings) const
 void MapgenV6Params::setDefaultSettings(Settings *settings)
 {
 	settings->setDefault("mgv6_spflags", flagdesc_mapgen_v6, MGV6_JUNGLES |
-		MGV6_SNOWBIOMES | MGV6_TREES | MGV6_BIOMEBLEND | MGV6_MUDFLOW);
+		MGV6_SNOWBIOMES | MGV6_TREES | MGV6_BIOMEBLEND | MGV6_MUDFLOW |
+		MGV6_TEMPLES);
 }
 
 
@@ -578,7 +580,8 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 			dp.np_alt_wall
 				= NoiseParams(-0.4, 1.0, v3f(40.0, 40.0, 40.0), 32474, 6, 1.1, 2.0);
 
-			if (getBiome(0, v2s16(node_min.X, node_min.Z)) == BT_DESERT) {
+			if ((spflags & MGV6_TEMPLES) &&
+					getBiome(0, v2s16(node_min.X, node_min.Z)) == BT_DESERT) {
 				dp.c_wall              = c_desert_stone;
 				dp.c_alt_wall          = CONTENT_IGNORE;
 				dp.c_stair             = c_stair_desert_stone;

--- a/src/mapgen/mapgen_v6.h
+++ b/src/mapgen/mapgen_v6.h
@@ -39,6 +39,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MGV6_SNOWBIOMES 0x08
 #define MGV6_FLAT       0x10
 #define MGV6_TREES      0x20
+#define MGV6_TEMPLES    0x40
 
 
 extern FlagDesc flagdesc_mapgen_v6[];


### PR DESCRIPTION
fixes #13413

## To do

This PR is Ready for Review.

## How to test

1. Take an old mgv6 world and check that mgv6_spflags is updated to contain `temples` after you join it
2. Create mgv6 world with `notemples`. Locate a desert and find a dungeon. Ensure it looks like a normal one (made of cobble, small rooms).

Hint: MTG dungeon_loot can print the positions it has found. If you edit `MapgenV6::getBiome` you can turn everything into desert.