### PR TITLE
Docs: Add dependencies for building documentation for Ubuntu

### DIFF
--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -19,10 +19,12 @@
 | JsonCPP    | 1.0.0+  | Bundled JsonCPP is used if not present |
 | Curl       | 7.56.0+ | Optional   |
 | gettext    | -       | Optional   |
+| doxygen    | -       | (only needed when building documentation) |
+| dot        | -       | (only needed when building documentation) |
 
 For Debian/Ubuntu users:
 
-    sudo apt install g++ make libc6-dev cmake libpng-dev libjpeg-dev libxi-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev libzstd-dev libluajit-5.1-dev gettext libsdl2-dev
+    sudo apt install g++ make libc6-dev cmake libpng-dev libjpeg-dev libxi-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev libzstd-dev libluajit-5.1-dev gettext libsdl2-dev doxygen dot
 
 For Fedora users:
 


### PR DESCRIPTION
By default, the documentation gets built as well. So we add the needed libraries in the table and the Debian/Ubuntu command.

Without doxygen, the build failed with:

  -- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)

Without dot, the build failed with:

  -- Found Doxygen: /usr/bin/doxygen (found version "1.8.13") found components:  doxygen missing components:  dot

Add compact, short information about your PR for easier understanding:

- Goal of the PR? See above.
- How does the PR work? See "How to test" below.
- Does it resolve any reported issue? No.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)? No.
- If not a bug fix, why is this PR needed? What usecases does it solve? The usecase is to allow to compile on Debian by simply following the docs.

## To do

This PR is Ready for Review.

## How to test

1. Set up a fresh Debian buster
2. Install the documented dependencies
   `sudo apt install g++ make libc6-dev cmake libpng-dev libjpeg-dev libxi-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev libzstd-dev libluajit-5.1-dev gettext libsdl2-dev`
4. Install git
   `sudo apt install git`
6. Clone minetest
   `git clone --depth 1 https://github.com/minetest/minetest.git`
8. Change into directory
   `cd minetest`
10. Add Irrlicht
   `git clone --depth 1 --branch "$(cat misc/irrlichtmt_tag.txt)" https://github.com/minetest/irrlicht.git lib/irrlichtmt`
12. Run
   `cmake . -DRUN_IN_PLACE=TRUE`
14. CMake fails due to missing dependency on Doxygen. Once Doxygen is installed, building fails complaining about missing `dot`.