### PR TITLE
Add repeat_dig_time setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -116,6 +116,10 @@ always_fly_fast (Always fly fast) bool true
 #    Requires: keyboard_mouse
 repeat_place_time (Place repetition interval) float 0.25 0.16 2
 
+#    The minimum time in seconds it takes between digging nodes when holding
+#    the dig button.
+repeat_dig_time (Dig repetition interval) float 0.15 0.15 2.0
+
 #    Automatically jump up single-node obstacles.
 autojump (Automatic jumping) bool false
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -114,7 +114,7 @@ always_fly_fast (Always fly fast) bool true
 #    the place button.
 #
 #    Requires: keyboard_mouse
-repeat_place_time (Place repetition interval) float 0.25 0.16 2
+repeat_place_time (Place repetition interval) float 0.25 0.15 2.0
 
 #    The minimum time in seconds it takes between digging nodes when holding
 #    the dig button.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4434,7 +4434,7 @@ void Game::readSettings()
 	m_cache_enable_fog                   = g_settings->getBool("enable_fog");
 	m_cache_mouse_sensitivity            = g_settings->getFloat("mouse_sensitivity", 0.001f, 10.0f);
 	m_cache_joystick_frustum_sensitivity = std::max(g_settings->getFloat("joystick_frustum_sensitivity"), 0.001f);
-	m_repeat_place_time                  = g_settings->getFloat("repeat_place_time", 0.16f, 2.0);
+	m_repeat_place_time                  = g_settings->getFloat("repeat_place_time", 0.15f, 2.0f);
 	m_repeat_dig_time                    = g_settings->getFloat("repeat_dig_time", 0.15f, 2.0f);
 
 	m_cache_enable_noclip                = g_settings->getBool("noclip");

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1009,6 +1009,7 @@ private:
 	f32  m_cache_mouse_sensitivity;
 	f32  m_cache_joystick_frustum_sensitivity;
 	f32  m_repeat_place_time;
+	f32  m_repeat_dig_time;
 	f32  m_cache_cam_smoothing;
 
 	bool m_invert_mouse;
@@ -1056,6 +1057,8 @@ Game::Game() :
 	g_settings->registerChangedCallback("joystick_frustum_sensitivity",
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("repeat_place_time",
+		&settingChangedCallback, this);
+	g_settings->registerChangedCallback("repeat_dig_time",
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("noclip",
 		&settingChangedCallback, this);
@@ -1127,6 +1130,8 @@ Game::~Game()
 	g_settings->deregisterChangedCallback("joystick_frustum_sensitivity",
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("repeat_place_time",
+		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("repeat_dig_time",
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("noclip",
 		&settingChangedCallback, this);
@@ -3982,12 +3987,14 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 		runData.nodig_delay_timer =
 				runData.dig_time_complete / (float)crack_animation_length;
 
-		// We don't want a corresponding delay to very time consuming nodes
-		// and nodes without digging time (e.g. torches) get a fixed delay.
-		if (runData.nodig_delay_timer > 0.3)
-			runData.nodig_delay_timer = 0.3;
-		else if (runData.dig_instantly)
-			runData.nodig_delay_timer = 0.15;
+		// Don't add a corresponding delay to very time consuming nodes.
+		runData.nodig_delay_timer = std::min(runData.nodig_delay_timer, 0.3f);
+
+		// Ensure that the delay between breaking nodes
+		// (dig_time_complete + nodig_delay_timer) is at least the
+		// value of the repeat_dig_time setting.
+		runData.nodig_delay_timer = std::max(runData.nodig_delay_timer,
+				m_repeat_dig_time - runData.dig_time_complete);
 
 		if (client->modsLoaded() &&
 				client->getScript()->on_dignode(nodepos, n)) {
@@ -4428,6 +4435,7 @@ void Game::readSettings()
 	m_cache_mouse_sensitivity            = g_settings->getFloat("mouse_sensitivity", 0.001f, 10.0f);
 	m_cache_joystick_frustum_sensitivity = std::max(g_settings->getFloat("joystick_frustum_sensitivity"), 0.001f);
 	m_repeat_place_time                  = g_settings->getFloat("repeat_place_time", 0.16f, 2.0);
+	m_repeat_dig_time                    = g_settings->getFloat("repeat_dig_time", 0.15f, 2.0f);
 
 	m_cache_enable_noclip                = g_settings->getBool("noclip");
 	m_cache_enable_free_move             = g_settings->getBool("free_move");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -292,6 +292,7 @@ void set_default_settings()
 	settings->setDefault("invert_hotbar_mouse_wheel", "false");
 	settings->setDefault("mouse_sensitivity", "0.2");
 	settings->setDefault("repeat_place_time", "0.25");
+	settings->setDefault("repeat_dig_time", "0.15");
 	settings->setDefault("safe_dig_and_place", "false");
 	settings->setDefault("random_input", "false");
 	settings->setDefault("aux1_descends", "false");


### PR DESCRIPTION
#### Goal of the PR

Provide better accessibility for people who accidentally dig instant breakable nodes but want dig repetition and cannot use the `safe_dig_and_place` setting.

This PR solves this problem by introducing a `repeat_dig_interval` which is like `repeat_place_interval` but for digging. The setting simply ensures that it will take at minimum the settings value from finishing digging one node to starting to dig the next node.

#### Does it resolve any reported issue?

Yes, #13726.

## To do

This PR is ready to review.

## How to test

Hop into a world and hold the dig button on nodes which are instant breakable. Could be done by hopping into a creative world in Mineclonia and start digging any nodes.

Try it with the default value and verify that the digging speed remains the same as previously. Then go into the settings menu and update the _Dig repetition interval_ setting to a higher value. Hop into the world again and dig nodes, verify that there is a larger delay between digging each node.

## Things to consider

The range of values allowed is probably something which should be discussed. Previously, the hardcoded value was 0.15. Currently I made the minimum setting value 0.15 and the maximum 2.0 with the default being 0.15.

The `repeat_place_interval` is minimum 0.16 and maximum 2.0. It could be argued that maybe its minimum value should be lowered to 0.15 for consistency with the `repeat_dig_interval` setting.

But perhaps the minimum value of `repeat_dig_inverval` could be lower?