### PR TITLE
Touchscreen: Camera movement improvements

### DIFF
--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -832,8 +832,8 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 				m_move_pos = touch_pos;
 				m_pointer_pos[event.TouchInput.ID] = touch_pos;
 
-				// adapt to similar behavior as pc screen
-				const double d = g_settings->getFloat("touchscreen_sensitivity", 0.001f, 10.0f) * 3.0f;
+				const double d = g_settings->getFloat("touchscreen_sensitivity", 0.001f, 10.0f)
+						* 6.0f / RenderingEngine::getDisplayDensity();
 
 				// update camera_yaw and camera_pitch
 				m_camera_yaw_change -= dir_free.X * d;

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -832,14 +832,12 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 				m_move_pos = touch_pos;
 				m_pointer_pos[event.TouchInput.ID] = touch_pos;
 
-				if (m_tap_state == TapState::None || m_draw_crosshair) {
-					// adapt to similar behavior as pc screen
-					const double d = g_settings->getFloat("touchscreen_sensitivity", 0.001f, 10.0f) * 3.0f;
+				// adapt to similar behavior as pc screen
+				const double d = g_settings->getFloat("touchscreen_sensitivity", 0.001f, 10.0f) * 3.0f;
 
-					// update camera_yaw and camera_pitch
-					m_camera_yaw_change -= dir_free.X * d;
-					m_camera_pitch_change += dir_free.Y * d;
-				}
+				// update camera_yaw and camera_pitch
+				m_camera_yaw_change -= dir_free.X * d;
+				m_camera_pitch_change += dir_free.Y * d;
 			}
 		}
 

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -295,6 +295,8 @@ private:
 	// apply joystick status
 	void applyJoystickStatus();
 
+	// map to store the IDs and original positions of currently pressed pointers
+	std::unordered_map<size_t, v2s32> m_pointer_downpos;
 	// map to store the IDs and positions of currently pressed pointers
 	std::unordered_map<size_t, v2s32> m_pointer_pos;
 


### PR DESCRIPTION
Fixes #11003.

On touchscreens, you can currently only move your camera while digging if `touch_use_crosshair = true` is set. This is an arbitrary and unnecessary limitation. The Android version of Minecraft doesn't have this issue. An example where it is especially annoying: If you're charging a bow in MineClone 2, you can't aim if you don't enable `touch_use_crosshair`.

This PR removes this limitation.

This PR also adjusts `touchscreen_sensitivity` to the display density to avoid too fast camera movement on high-DPI displays. The effective sensitivity stays the same for `xhdpi` displays, which is the most common density according to https://developer.android.com/about/dashboards/.

Additionally, this PR removes the visible camera jump when you cross the touchscreen_threshold.

## To do

This PR is a Ready for Review.

Looking for feedback from touchscreen players.

## How to test

Try moving the camera while digging (or aiming a bow in MineClone 2) with `touch_use_crosshair = false`.