### PR TITLE
Add markdown admonition extension

### DIFF
--- a/doc/mkdocs/build.sh
+++ b/doc/mkdocs/build.sh
@@ -17,6 +17,7 @@ markdown_extensions:
     - pymdownx.superfences
     - pymdownx.highlight:
         css_class: codehilite
+    - gfm_admonition
 plugins:
     - search:
         separator: '[\s\-\.\(]+'

--- a/doc/mkdocs/requirements.txt
+++ b/doc/mkdocs/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs~=1.4.3
 pygments~=2.15.1
 pymdown-extensions~=10.3
+markdown-gfm-admonition~=0.1.0


### PR DESCRIPTION
## **This PR is a prerequisite to #14287!**

This adds an extension into the MkDocs workflow which renders Github admonition boxes correctly.

> [!NOTE]
> This is an admonition box.

> [!WARNING]
> This is another admonition box!

> \[!NOTE] This is what I would look like without this PR.