### PR TITLE
Touchscreen: Abort ongoing short taps if mode changes

### DIFF
--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -1091,6 +1091,15 @@ void TouchScreenGUI::applyContextControls(const TouchInteractionMode &mode)
 
 	u64 now = porting::getTimeMs();
 
+	// If the meanings of short and long taps have been swapped, abort any ongoing
+	// short taps because they would do something else than the player expected.
+	// Long taps don't need this, they're adjusted to the swapped meanings instead.
+	if (mode != m_last_mode) {
+		m_dig_pressed_until = 0;
+		m_place_pressed_until = 0;
+	}
+	m_last_mode = mode;
+
 	switch (m_tap_state) {
 	case TapState::ShortTap:
 		if (mode == SHORT_DIG_LONG_PLACE) {

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -314,6 +314,7 @@ private:
 
 	v2s32 getPointerPos();
 	void emitMouseEvent(EMOUSE_INPUT_EVENT type);
+	TouchInteractionMode m_last_mode = TouchInteractionMode_END;
 	TapState m_tap_state = TapState::None;
 
 	bool m_dig_pressed = false;


### PR DESCRIPTION
When the meanings of short and long taps are swapped, abort any ongoing short taps because they would do something else than the player expected. Long taps don't need this, they're adjusted to the swapped meanings instead.

This fixes some behavior introduced by #14087.

## To do

This PR is a Ready for Review.

## How to test

Play a MTG world in creative mode. Pick up a dropped item by short-tapping it and verify that no cracks appear on the node behind it.

Also test that this doesn't make PvP any harder.
