### PR TITLE
Fix active object adding to not generated block

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5949,10 +5949,10 @@ Environment access
   position.
     * Returns `ObjectRef`, or `nil` if failed
     * Entities with `static_save = true` can be added also 
-      to unloaded/nongenerated blocks.
+      to unloaded and non-generated blocks.
 * `minetest.add_item(pos, item)`: Spawn item
     * Returns `ObjectRef`, or `nil` if failed
-    * Items can be added also to unloaded/nongenerated blocks.
+    * Items can be added also to unloaded and non-generated blocks.
 * `minetest.get_player_by_name(name)`: Get an `ObjectRef` to a player
 * `minetest.get_objects_inside_radius(pos, radius)`: returns a list of
   ObjectRefs.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5948,8 +5948,11 @@ Environment access
 * `minetest.add_entity(pos, name, [staticdata])`: Spawn Lua-defined entity at
   position.
     * Returns `ObjectRef`, or `nil` if failed
+    * Entities with `static_save = true` can be added also 
+      to unloaded/nongenerated blocks.
 * `minetest.add_item(pos, item)`: Spawn item
     * Returns `ObjectRef`, or `nil` if failed
+    * Items can be added also to unloaded/nongenerated blocks.
 * `minetest.get_player_by_name(name)`: Get an `ObjectRef` to a player
 * `minetest.get_objects_inside_radius(pos, radius)`: returns a list of
   ObjectRefs.

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1918,9 +1918,9 @@ u16 ServerEnvironment::addActiveObjectRaw(std::unique_ptr<ServerActiveObject> ob
 					MOD_REASON_ADD_ACTIVE_OBJECT_RAW);
 		} else {
 			v3s16 p = floatToInt(objectpos, BS);
-			errorstream<<"ServerEnvironment::addActiveObjectRaw(): "
-				<<"could not emerge block for storing id="<<object->getId()
-				<<" statically (pos="<<p<<")"<<std::endl;
+			errorstream << "ServerEnvironment::addActiveObjectRaw(): "
+				<< "could not emerge block " << p << " for storing id="
+				<< object->getId() << " statically" << std::endl;
 			m_ao_manager.removeObject(object->getId());
 			return 0;
 		}

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1051,7 +1051,8 @@ void ServerEnvironment::activateBlock(MapBlock *block, u32 additional_dtime)
 			<<stamp<<", game time: "<<m_game_time<<std::endl;*/
 
 	// Remove stored static objects if clearObjects was called since block's timestamp
-	if (stamp < m_last_clear_objects_time) {
+	// Note that non-generated blocks may still have stored static objects
+	if (stamp != BLOCK_TIMESTAMP_UNDEFINED && stamp < m_last_clear_objects_time) {
 		block->m_static_objects.clearStored();
 		// do not set changed flag to avoid unnecessary mapblock writes
 	}

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1901,11 +1901,6 @@ u16 ServerEnvironment::addActiveObjectRaw(std::unique_ptr<ServerActiveObject> ob
 		return 0;
 	}
 
-	// Register reference in scripting api (must be done before post-init)
-	m_script->addObjectReference(object);
-	// Post-initialize object
-	object->addedToEnvironment(dtime_s);
-
 	// Add static data to block
 	if (object->isStaticAllowed()) {
 		// Add static object to active static list of the block
@@ -1928,12 +1923,15 @@ u16 ServerEnvironment::addActiveObjectRaw(std::unique_ptr<ServerActiveObject> ob
 				<< "could not emerge block " << p << " for storing id="
 				<< object->getId() << " statically" << std::endl;
 			// clean in case of error
-			object->removingFromEnvironment();
-			m_script->removeObjectReference(object);
 			m_ao_manager.removeObject(object->getId());
 			return 0;
 		}
 	}
+
+	// Register reference in scripting api (must be done before post-init)
+	m_script->addObjectReference(object);
+	// Post-initialize object
+	object->addedToEnvironment(dtime_s);
 
 	return object->getId();
 }

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1901,6 +1901,11 @@ u16 ServerEnvironment::addActiveObjectRaw(std::unique_ptr<ServerActiveObject> ob
 		return 0;
 	}
 
+	// Register reference in scripting api (must be done before post-init)
+	m_script->addObjectReference(object);
+	// Post-initialize object
+	object->addedToEnvironment(dtime_s);
+
 	// Add static data to block
 	if (object->isStaticAllowed()) {
 		// Add static object to active static list of the block
@@ -1922,15 +1927,13 @@ u16 ServerEnvironment::addActiveObjectRaw(std::unique_ptr<ServerActiveObject> ob
 			errorstream << "ServerEnvironment::addActiveObjectRaw(): "
 				<< "could not emerge block " << p << " for storing id="
 				<< object->getId() << " statically" << std::endl;
+			// clean in case of error
+			object->removingFromEnvironment();
+			m_script->removeObjectReference(object);
 			m_ao_manager.removeObject(object->getId());
 			return 0;
 		}
 	}
-
-	// Register reference in scripting api (must be done before post-init)
-	m_script->addObjectReference(object);
-	// Post-initialize object
-	object->addedToEnvironment(dtime_s);
 
 	return object->getId();
 }

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1051,7 +1051,7 @@ void ServerEnvironment::activateBlock(MapBlock *block, u32 additional_dtime)
 			<<stamp<<", game time: "<<m_game_time<<std::endl;*/
 
 	// Remove stored static objects if clearObjects was called since block's timestamp
-	if (stamp == BLOCK_TIMESTAMP_UNDEFINED || stamp < m_last_clear_objects_time) {
+	if (stamp < m_last_clear_objects_time) {
 		block->m_static_objects.clearStored();
 		// do not set changed flag to avoid unnecessary mapblock writes
 	}
@@ -1909,7 +1909,6 @@ u16 ServerEnvironment::addActiveObjectRaw(std::unique_ptr<ServerActiveObject> ob
 		v3s16 blockpos = getNodeBlockPos(floatToInt(objectpos, BS));
 		MapBlock *block = m_map->emergeBlock(blockpos);
 		if (block) {
-			block->setTimestampNoChangedFlag(m_game_time);
 			block->m_static_objects.setActive(object->getId(), s_obj);
 			object->m_static_exists = true;
 			object->m_static_block = blockpos;


### PR DESCRIPTION
- Goal of the PR
Fix #4759.
- How does the PR work?
It disables saving Active objects to a blank map block, so the error is not masked.
- Does it resolve any reported issue?
Fix #4759.

## To do

This PR is a Ready for Review.

## How to test

Try to spawn an entity with the command `/spawnentity` in not generated part of the map and teleport to that part.
