### PR TITLE
Fix HUD inventory direction position

### DIFF
--- a/games/devtest/mods/testhud/init.lua
+++ b/games/devtest/mods/testhud/init.lua
@@ -272,11 +272,81 @@ minetest.register_chatcommand("hudhotbars", {
 	end
 })
 
+-- Inventories
+
+local hud_inventory_defs = {
+	{
+		type = "inventory",
+		position = {x=0.2, y=0.5},
+		direction = 0,
+		text = "main",
+		number = 4,
+		item = 2,
+	},
+	{
+		type = "inventory",
+		position = {x=0.2, y=0.5},
+		direction = 2,
+		text = "main",
+		number = 4,
+		item = 2,
+	},
+	{
+		type = "inventory",
+		position = {x=0.7, y=0.5},
+		direction = 1,
+		text = "main",
+		number = 4,
+		item = 2,
+	},
+	{
+		type = "inventory",
+		position = {x=0.7, y=0.5},
+		direction = 3,
+		text = "main",
+		number = 4,
+		item = 2,
+	},
+}
+
+local player_hud_inventories= {}
+minetest.register_chatcommand("hudinventories", {
+	description = "Shows some test Lua HUD elements of type inventory. (add: Adds elements (default). remove: Removes elements)",
+	params = "[ add | remove ]",
+	func = function(name, params)
+		local player = minetest.get_player_by_name(name)
+		if not player then
+			return false, "No player."
+		end
+
+		local id_table = player_hud_inventories[name]
+		if not id_table then
+			id_table = {}
+			player_hud_inventories[name] = id_table
+		end
+
+		if params == "remove" then
+			for _, id in ipairs(id_table) do
+				player:hud_remove(id)
+			end
+			return true, "HUD Inventories removed."
+		end
+
+		-- params == "add" or default
+		for _, def in ipairs(hud_inventory_defs) do
+			table.insert(id_table, player:hud_add(def))
+		end
+		return true, #hud_inventory_defs .." HUD Inventories added."
+	end
+})
+
 
 minetest.register_on_leaveplayer(function(player)
-	player_font_huds[player:get_player_name()] = nil
-	player_waypoints[player:get_player_name()] = nil
-	player_hud_hotbars[player:get_player_name()] = nil
+	local playername = player:get_player_name()
+	player_font_huds[playername] = nil
+	player_waypoints[playername] = nil
+	player_hud_hotbars[playername] = nil
+	player_hud_inventories[playername] = nil
 end)
 
 minetest.register_chatcommand("hudprint", {

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -300,20 +300,20 @@ void Hud::drawItems(v2s32 screen_pos, v2s32 screen_offset, s32 itemcount, v2f al
 
 	// Draw items
 	core::rect<s32> imgrect(0, 0, m_hotbar_imagesize, m_hotbar_imagesize);
-	const s32 list_size = mainlist ? mainlist->getSize() : 0;
-	for (s32 i = inv_offset; i < itemcount && i < list_size; i++) {
+	const s32 list_max = std::min(itemcount, (s32) (mainlist ? mainlist->getSize() : 0 ));
+	for (s32 i = inv_offset; i < list_max; i++) {
 		s32 fullimglen = m_hotbar_imagesize + m_padding * 2;
 
 		v2s32 steppos;
 		switch (direction) {
 		case HUD_DIR_RIGHT_LEFT:
-			steppos = v2s32(-(m_padding + (i - inv_offset) * fullimglen), m_padding);
+			steppos = v2s32(m_padding + (list_max - 1 - i - inv_offset) * fullimglen, m_padding);
 			break;
 		case HUD_DIR_TOP_BOTTOM:
 			steppos = v2s32(m_padding, m_padding + (i - inv_offset) * fullimglen);
 			break;
 		case HUD_DIR_BOTTOM_TOP:
-			steppos = v2s32(m_padding, -(m_padding + (i - inv_offset) * fullimglen));
+			steppos = v2s32(m_padding, m_padding + (list_max - 1 - i - inv_offset) * fullimglen);
 			break;
 		default:
 			steppos = v2s32(m_padding + (i - inv_offset) * fullimglen, m_padding);


### PR DESCRIPTION
## What does this PR do?

- This PR fixes the position of HUD elements of type `inventory` when using `direction = 1` or `direction = 3`.
- Normally, HUD inventories get drawn starting from the top left corner (plus some padding), but when the direction is 1 or 3 the position is wrong.
  (It is also not correct if you would assume that it is not starting from the top left corner anymore.)

## Screenshots
<details>
<summary>Click me</summary>


- On the left hand side are two inventories of `direction = 0` and `direction = 2`
- On the right hand side are two inventories of  `direction = 1` and `direction = 3`.
- The second pictures show the same as on the right hand side but starting at the crosshair position, such that you can see it more clearly.

### Currently:
![b](https://github.com/minetest/minetest/assets/7302071/2871a8ca-94da-4d47-818a-11cc2fda9a2f)

![b2](https://github.com/minetest/minetest/assets/7302071/79123f2c-85b6-47f3-b9da-f791c8832d7d)

### With this PR:
![a](https://github.com/minetest/minetest/assets/7302071/b1460b11-e395-403c-b7ae-cef63a1abbfb)
![a2](https://github.com/minetest/minetest/assets/7302071/88160ec5-3d0f-4127-9934-9632bffea312)

</details>

## To do

This PR is Ready for Review.

## How to test
Start devtest and use the `/hudinventories` command.