### PR TITLE
Fix missing limit check for block y pos

### DIFF
--- a/src/mapsector.cpp
+++ b/src/mapsector.cpp
@@ -71,6 +71,9 @@ std::unique_ptr<MapBlock> MapSector::createBlankBlockNoInsert(s16 y)
 {
 	assert(getBlockBuffered(y) == nullptr); // Pre-condition
 
+	if (blockpos_over_max_limit(v3s16(0, y, 0)))
+		throw InvalidPositionException("createBlankBlockNoInsert(): pos over max mapgen limit");
+
 	v3s16 blockpos_map(m_pos.X, y, m_pos.Y);
 
 	return std::make_unique<MapBlock>(blockpos_map, m_gamedef);


### PR DESCRIPTION
## To do

This PR is Ready for Review.

## How to test

**Note**: do this test in a temporary world, otherwise the existence of the out-of-range block from the first run will mess up the second.

```lua
core.after(1, function()
	local p = vector.new(0, 32761, 0)
	core.load_area(p)
	core.add_node(p, {name="default:stone"})
	print(core.get_node(p).name)
end)
```
should return `"ignore"`