### PR TITLE
Add hotbar Lua HUD element and replace hardcoded hotbar

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -42,6 +42,7 @@ core.features = {
 	node_interaction_actor = true,
 	moveresult_new_pos = true,
 	override_item_remove_fields = true,
+	hotbar_hud_element = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/hud.lua
+++ b/builtin/game/hud.lua
@@ -259,3 +259,18 @@ register_builtin_hud_element("minimap", {
 				core.get_player_information(player:get_player_name()).protocol_version >= 44
 	end,
 })
+
+--- Hotbar
+
+register_builtin_hud_element("hotbar", {
+	elem_def = {
+		type = "hotbar",
+		position = {x = 0.5, y = 1},
+		direction = 0,
+		alignment = {x = 0, y = -1},
+		offset = {x = 0, y = -4}, -- Extra padding below.
+	},
+	show_elem = function(player, flags)
+		return flags.hotbar
+	end,
+})

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1744,6 +1744,13 @@ Displays a horizontal bar made up of half-images with an optional background.
 * `item`: Position of item that is selected.
 * `direction`: Direction the list will be displayed in
 * `offset`: offset in pixels from position.
+* `alignment`: The alignment of the inventory. Aligned at the top left corner if not specified.
+
+### `hotbar`
+
+* `direction`: Direction the list will be displayed in
+* `offset`: offset in pixels from position.
+* `alignment`: The alignment of the inventory.
 
 ### `waypoint`
 
@@ -3658,7 +3665,7 @@ Player Inventory lists
 * `hand`: list containing an override for the empty hand
     * Is not created automatically, use `InvRef:set_size`
     * Is only used to enhance the empty hand's tool capabilities
- 
+
 Custom lists can be added and deleted with `InvRef:set_size(name, size)` like
 any other inventory.
 
@@ -5456,6 +5463,8 @@ Utilities
       moveresult_new_pos = true,
       -- Allow removing definition fields in `minetest.override_item` (5.9.0)
       override_item_remove_fields = true,
+      -- The predefined hotbar is a Lua HUD element of type `hotbar` (5.10.0)
+      hotbar_hud_element = true,
   }
   ```
 
@@ -7099,7 +7108,7 @@ Misc.
   (regardless of online status)
 * `minetest.hud_replace_builtin(name, hud_definition)`
     * Replaces definition of a builtin hud element
-    * `name`: `"breath"`, `"health"` or `"minimap"`
+    * `name`: `"breath"`, `"health"`, `"minimap"` or `"hotbar"`
     * `hud_definition`: definition to replace builtin definition
 * `minetest.parse_relative_number(arg, relative_to)`: returns number or nil
     * Helper function for chat commands.
@@ -10612,8 +10621,9 @@ Used by `ObjectRef:hud_add`. Returned by `ObjectRef:hud_get`.
 ```lua
 {
     type = "image",
-    -- Type of element, can be "image", "text", "statbar", "inventory",
-    -- "waypoint", "image_waypoint", "compass" or "minimap"
+    -- Type of element, can be "compass", "hotbar" (46 ¹), "image", "image_waypoint",
+    -- "inventory", "minimap" (44 ¹), "statbar", "text" or "waypoint"
+    -- ¹: minimal protocol version for client-side support
     -- If undefined "text" will be used.
 
     hud_elem_type = "image",

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -240,7 +240,7 @@ void Hud::drawItem(const ItemStack &item, const core::rect<s32>& rect,
 
 // NOTE: selectitem = 0 -> no selected; selectitem is 1-based
 // mainlist can be NULL, but draw the frame anyway.
-void Hud::drawItems(v2s32 upperleftpos, v2s32 screen_offset, s32 itemcount,
+void Hud::drawItems(v2s32 screen_pos, v2s32 screen_offset, s32 itemcount, v2f alignment,
 		s32 inv_offset, InventoryList *mainlist, u16 selectitem, u16 direction,
 		bool is_hotbar)
 {
@@ -253,9 +253,11 @@ void Hud::drawItems(v2s32 upperleftpos, v2s32 screen_offset, s32 itemcount,
 		width = tmp;
 	}
 
-	// Position of upper left corner of bar
-	v2s32 pos = screen_offset * m_scale_factor;
-	pos += upperleftpos;
+	// Position: screen_pos + screen_offset + alignment
+	v2s32 pos(screen_offset.X * m_scale_factor, screen_offset.Y * m_scale_factor);
+	pos += screen_pos;
+	pos.X += (alignment.X - 1.0f) * (width * 0.5f);
+	pos.Y += (alignment.Y - 1.0f) * (height * 0.5f);
 
 	// Store hotbar_image in member variable, used by drawItem()
 	if (hotbar_image != player->hotbar_image) {
@@ -353,12 +355,19 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 	std::vector<HudElement*> elems;
 	elems.reserve(player->maxHudId());
 
-	// Add builtin minimap if the server doesn't send it.
+	// Add builtin elements if the server doesn't send them.
+	// Declared here such that they have the same lifetime as the elems vector
 	HudElement minimap;
+	HudElement hotbar;
 	if (client->getProtoVersion() < 44 && (player->hud_flags & HUD_FLAG_MINIMAP_VISIBLE)) {
 		minimap = {HUD_ELEM_MINIMAP, v2f(1, 0), "", v2f(), "", 0 , 0, 0, v2f(-1, 1),
 				v2f(-10, 10), v3f(), v2s32(256, 256), 0, "", 0};
 		elems.push_back(&minimap);
+	}
+	if (client->getProtoVersion() < 46 && player->hud_flags & HUD_FLAG_HOTBAR_VISIBLE) {
+		hotbar = {HUD_ELEM_HOTBAR, v2f(0.5, 1), "", v2f(), "", 0 , 0, 0, v2f(-0.5, -1),
+				v2f(0, -4), v3f(), v2s32(), 0, "", 0};
+		elems.push_back(&hotbar);
 	}
 
 	for (size_t i = 0; i != player->maxHudId(); i++) {
@@ -434,7 +443,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				InventoryList *inv = inventory->getList(e->text);
 				if (!inv)
 					warningstream << "HUD: Unknown inventory list. name=" << e->text << std::endl;
-				drawItems(pos, v2s32(e->offset.X, e->offset.Y), e->number, 0,
+				drawItems(pos, v2s32(e->offset.X, e->offset.Y), e->number, e->align, 0,
 					inv, e->item, e->dir, false);
 				break; }
 			case HUD_ELEM_WAYPOINT: {
@@ -558,6 +567,9 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				rect += pos + offset + v2s32(e->offset.X * m_scale_factor,
 				                             e->offset.Y * m_scale_factor);
 				client->getMinimap()->drawMinimap(rect);
+				break; }
+			case HUD_ELEM_HOTBAR: {
+				drawHotbar(pos, e->offset, e->dir, e->align);
 				break; }
 			default:
 				infostream << "Hud::drawLuaElements: ignoring drawform " << e->type
@@ -768,9 +780,7 @@ void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir,
 		}
 	}
 }
-
-
-void Hud::drawHotbar(u16 playeritem)
+void Hud::drawHotbar(const v2s32 &pos, const v2f &offset, u16 dir, const v2f &align)
 {
 	if (g_touchscreengui)
 		g_touchscreengui->resetHotbarRects();
@@ -781,30 +791,30 @@ void Hud::drawHotbar(u16 playeritem)
 		return;
 	}
 
+	u16 playeritem = player->getWieldIndex();
+	v2s32 screen_offset(offset.X, offset.Y);
+
 	v2s32 centerlowerpos(m_displaycenter.X, m_screensize.Y);
 
 	s32 hotbar_itemcount = player->getMaxHotbarItemcount();
 	s32 width = hotbar_itemcount * (m_hotbar_imagesize + m_padding * 2);
-	v2s32 pos = centerlowerpos - v2s32(width / 2, m_hotbar_imagesize + m_padding * 3);
 
 	const v2u32 &window_size = RenderingEngine::getWindowSize();
 	if ((float) width / (float) window_size.X <=
 			g_settings->getFloat("hud_hotbar_max_width")) {
-		if (player->hud_flags & HUD_FLAG_HOTBAR_VISIBLE) {
-			drawItems(pos, v2s32(0, 0), hotbar_itemcount, 0, mainlist, playeritem + 1, 0, true);
-		}
+		drawItems(pos, screen_offset, hotbar_itemcount, align, 0,
+			mainlist, playeritem + 1, dir, true);
 	} else {
-		pos.X += width/4;
+		v2s32 firstpos = pos;
+		firstpos.X += width/4;
 
-		v2s32 secondpos = pos;
-		pos = pos - v2s32(0, m_hotbar_imagesize + m_padding);
+		v2s32 secondpos = firstpos;
+		firstpos = firstpos - v2s32(0, m_hotbar_imagesize + m_padding);
 
-		if (player->hud_flags & HUD_FLAG_HOTBAR_VISIBLE) {
-			drawItems(pos, v2s32(0, 0), hotbar_itemcount / 2, 0,
-				mainlist, playeritem + 1, 0, true);
-			drawItems(secondpos, v2s32(0, 0), hotbar_itemcount,
-				hotbar_itemcount / 2, mainlist, playeritem + 1, 0, true);
-		}
+		drawItems(firstpos, screen_offset, hotbar_itemcount / 2, align, 0,
+			mainlist, playeritem + 1, dir, true);
+		drawItems(secondpos, screen_offset, hotbar_itemcount, align,
+			hotbar_itemcount / 2, mainlist, playeritem + 1, dir, true);
 	}
 }
 

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -63,7 +63,7 @@ public:
 	void disableBlockBounds();
 	void drawBlockBounds();
 
-	void drawHotbar(u16 playeritem);
+	void drawHotbar(const v2s32 &pos, const v2f &offset, u16 direction, const v2f &align);
 	void resizeHotbar();
 	void drawCrosshair();
 	void drawSelectionMesh();
@@ -99,7 +99,7 @@ private:
 			const std::string &texture, const std::string& bgtexture,
 			s32 count, s32 maxcount, v2s32 offset, v2s32 size = v2s32());
 
-	void drawItems(v2s32 upperleftpos, v2s32 screen_offset, s32 itemcount,
+	void drawItems(v2s32 screen_pos, v2s32 screen_offset, s32 itemcount, v2f alignment,
 			s32 inv_offset, InventoryList *mainlist, u16 selectitem,
 			u16 direction, bool is_hotbar);
 

--- a/src/client/render/plain.cpp
+++ b/src/client/render/plain.cpp
@@ -61,7 +61,6 @@ void DrawHUD::run(PipelineContext &context)
 		if (context.draw_crosshair)
 			context.hud->drawCrosshair();
 
-		context.hud->drawHotbar(context.client->getEnv().getLocalPlayer()->getWieldIndex());
 		context.hud->drawLuaElements(context.client->getCamera()->getOffset());
 		context.client->getCamera()->drawNametags();
 	}

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -30,6 +30,7 @@ const struct EnumString es_HudElementType[] =
 	{HUD_ELEM_IMAGE_WAYPOINT, "image_waypoint"},
 	{HUD_ELEM_COMPASS,   "compass"},
 	{HUD_ELEM_MINIMAP,   "minimap"},
+	{HUD_ELEM_HOTBAR,    "hotbar"},
 	{0, NULL},
 };
 

--- a/src/hud.h
+++ b/src/hud.h
@@ -67,7 +67,8 @@ enum HudElementType {
 	HUD_ELEM_WAYPOINT  = 4,
 	HUD_ELEM_IMAGE_WAYPOINT = 5,
 	HUD_ELEM_COMPASS   = 6,
-	HUD_ELEM_MINIMAP   = 7
+	HUD_ELEM_MINIMAP   = 7,
+	HUD_ELEM_HOTBAR    = 8,
 };
 
 enum HudElementStat : u8 {

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -224,9 +224,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Add TOCLIENT_MOVE_PLAYER_REL
 		Move default minimap from client-side C++ to server-side builtin Lua
 		[scheduled bump for 5.9.0]
+	PROTOCOL VERSION 45:
+		Reserved for minimap size change
+	PROTOCOL VERSION 46:
+		Move default hotbar from client-side C++ to server-side builtin Lua
+		[scheduled bump for 5.10.0]
 */
 
-#define LATEST_PROTOCOL_VERSION 44
+#define LATEST_PROTOCOL_VERSION 46
 #define LATEST_PROTOCOL_VERSION_STRING TOSTRING(LATEST_PROTOCOL_VERSION)
 
 // Server's supported network protocol range

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2306,7 +2306,10 @@ void read_hud_element(lua_State *L, HudElement *elem)
 		elem->dir = getintfield_default(L, 2, "dir", 0);
 
 	lua_getfield(L, 2, "alignment");
-	elem->align = lua_istable(L, -1) ? read_v2f(L, -1) : v2f();
+	if (lua_istable(L, -1))
+		elem->align = read_v2f(L, -1);
+	else
+		elem->align = elem->type == HUD_ELEM_INVENTORY ? v2f(1.0f, 1.0f) : v2f();
 	lua_pop(L, 1);
 
 	lua_getfield(L, 2, "offset");


### PR DESCRIPTION
## Goal of the PR
- Combined with my other PRs this resolves #9270, except for the nametags part, since they are somewhat different.
  (nametag attributes already exist, so maybe the attributes should also allow a z-index)
- (Solves a very old issue, but it is already closed #2139.)
- #6793 will also be easily solvable after this PR.

## How does the PR work?
- A new Lua HUD element for the hotbar gets added.
- The hardcoded hotbar is replaced by a Lua HUD element.
- Backward compatibility is retained. If the client connects to an old server that does not have the hotbar in builtin, the hotbar is added nonetheless.
- A new alignment feature for Lua HUD elements of type `inventory` gets added. Such that the hotbar can also use it.
  (Note that there is a bug with the direction, but #14318 will fix this.)
- Fixes a bug where the `offset` of HUD elements of type `inventory` is wrong when `m_scale_factor % 1 != 0`.

## Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
- 2.3 UI Improvements
- 2.2 Internal code refactoring
- maybe also 2.1 Rendering/Graphics improvements

## To do
This PR is Ready for Review.
-  A protocol bump is reqired, for it to work properly with version 5.10.0, since it already got released, but everything else should work fine and is ready for review.

## How to test
- Start devtest  and use the commands:
  - `/hudprint` to see that the predefined hotbar is now a Lua HUD element
  - `/hudhotbars` to show different hotbars and check if the element parameters work as expected.
  - `/hudtoggleflag hotbar` to see if the flag disables the builtin hotbar.
- Use this to see if the builtin hotbar can be changed:
```lua
minetest.hud_replace_builtin("hotbar", {
	type = "hotbar",
	position = {x = 0.5, y = 0.5},
	alignment = {x = -0.5, y = 0},
})
```
- Check if the top left corner alignment for `inventory` elements with unspecified alignment works.
```lua
{
	type = "inventory",
	position = {x=0.5, y=0.5},
	text = "main",
	number = 8
},
{
	type = "inventory",
	position = {x=0.5, y=0.5},
	alignment = {x=0, y=0},
	text = "main",
	number = 8
},
```
## Showcase
https://github.com/minetest/minetest/assets/7302071/4925e700-8f2c-4600-bc5b-29294655adfb

