### PR TITLE
Inline g/setPixel in imageCleanTransparent

### DIFF
--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -74,8 +74,6 @@ void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
 
 	auto get_pixel = [src, src_data, dim](u32 x, u32 y) -> video::SColor {
 		if constexpr (IS_A8R8G8B8) {
-			if (x >= dim.Width || y >= dim.Height)
-				return video::SColor(0);
 			return reinterpret_cast<u32 *>(src_data)[y*dim.Width + x];
 		} else {
 			return src->getPixel(x, y);
@@ -83,8 +81,6 @@ void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
 	};
 	auto set_pixel = [src, src_data, src_pitch, dim](u32 x, u32 y, video::SColor color) {
 		if constexpr (IS_A8R8G8B8) {
-			if (x >= dim.Width || y >= dim.Height)
-				return;
 			u32 *dest = reinterpret_cast<u32 *>(
 					reinterpret_cast<u8 *>(src_data) + (y * src_pitch) + (x << 2));
 			*dest = color.color;

--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -70,7 +70,6 @@ static void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
 {
 	void *const src_data = src->getData();
 	const core::dimension2d<u32> dim = src->getDimension();
-	const u32 src_pitch = src->getPitch();
 
 	auto get_pixel = [src, src_data, dim](u32 x, u32 y) -> video::SColor {
 		if constexpr (IS_A8R8G8B8) {
@@ -79,10 +78,9 @@ static void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
 			return src->getPixel(x, y);
 		}
 	};
-	auto set_pixel = [src, src_data, src_pitch, dim](u32 x, u32 y, video::SColor color) {
+	auto set_pixel = [src, src_data, dim](u32 x, u32 y, video::SColor color) {
 		if constexpr (IS_A8R8G8B8) {
-			u32 *dest = reinterpret_cast<u32 *>(
-					reinterpret_cast<u8 *>(src_data) + (y * src_pitch) + (x << 2));
+			u32 *dest = &reinterpret_cast<u32 *>(src_data)[y*dim.Width + x];
 			*dest = color.color;
 		} else {
 			src->setPixel(x, y, color);

--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -65,9 +65,33 @@ public:
 	}
 };
 
-static void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
+template <bool IS_A8R8G8B8>
+void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
 {
+	void *src_data = src->getData();
 	core::dimension2d<u32> dim = src->getDimension();
+	u32 src_pitch = src->getPitch();
+
+	auto get_pixel = [src, src_data, dim](u32 x, u32 y) -> video::SColor {
+		if constexpr (IS_A8R8G8B8) {
+			if (x >= dim.Width || y >= dim.Height)
+				return video::SColor(0);
+			return reinterpret_cast<u32 *>(src_data)[y*dim.Width + x];
+		} else {
+			return src->getPixel(x, y);
+		}
+	};
+	auto set_pixel = [src, src_data, src_pitch, dim](u32 x, u32 y, video::SColor color) {
+		if constexpr (IS_A8R8G8B8) {
+			if (x >= dim.Width || y >= dim.Height)
+				return;
+			u32 *dest = reinterpret_cast<u32 *>(
+					reinterpret_cast<u8 *>(src_data) + (y * src_pitch) + (x << 2));
+			*dest = color.color;
+		} else {
+			src->setPixel(x, y, color);
+		}
+	};
 
 	Bitmap bitmap(dim.Width, dim.Height);
 
@@ -75,7 +99,7 @@ static void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
 	// Note: loop y around x for better cache locality.
 	for (u32 ctry = 0; ctry < dim.Height; ctry++)
 	for (u32 ctrx = 0; ctrx < dim.Width; ctrx++) {
-		if (src->getPixel(ctrx, ctry).getAlpha() > threshold)
+		if (get_pixel(ctrx, ctry).getAlpha() > threshold)
 			bitmap.set(ctrx, ctry);
 	}
 
@@ -114,7 +138,7 @@ static void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
 
 			// Add RGB values weighted by alpha IF the pixel is opaque, otherwise
 			// use full weight since we want to propagate colors.
-			video::SColor d = src->getPixel(sx, sy);
+			video::SColor d = get_pixel(sx, sy);
 			u32 a = d.getAlpha() <= threshold ? 255 : d.getAlpha();
 			ss += a;
 			sr += a * d.getRed();
@@ -124,11 +148,11 @@ static void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
 
 		// Set pixel to average weighted by alpha
 		if (ss > 0) {
-			video::SColor c = src->getPixel(ctrx, ctry);
+			video::SColor c = get_pixel(ctrx, ctry);
 			c.setRed(sr / ss);
 			c.setGreen(sg / ss);
 			c.setBlue(sb / ss);
-			src->setPixel(ctrx, ctry, c);
+			set_pixel(ctrx, ctry, c);
 			newmap.set(ctrx, ctry);
 		}
 	}
@@ -161,7 +185,10 @@ void imageCleanTransparent(video::IImage *src, u32 threshold)
 {
 	TimeTaker tt("imageCleanTransparent", nullptr, PRECISION_MICRO);
 
-	imageCleanTransparentWithInlining(src, threshold);
+	if (src->getColorFormat() == video::ECF_A8R8G8B8)
+		imageCleanTransparentWithInlining<true>(src, threshold);
+	else
+		imageCleanTransparentWithInlining<false>(src, threshold);
 
 	u64 t = tt.stop(true);
 	static thread_local u64 s_t_sum = 0;

--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -66,11 +66,11 @@ public:
 };
 
 template <bool IS_A8R8G8B8>
-void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
+static void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
 {
-	void *src_data = src->getData();
-	core::dimension2d<u32> dim = src->getDimension();
-	u32 src_pitch = src->getPitch();
+	void *const src_data = src->getData();
+	const core::dimension2d<u32> dim = src->getDimension();
+	const u32 src_pitch = src->getPitch();
 
 	auto get_pixel = [src, src_data, dim](u32 x, u32 y) -> video::SColor {
 		if constexpr (IS_A8R8G8B8) {

--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -163,9 +163,6 @@ static void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
 	}
 }
 
-#include "util/timetaker.h"
-#include "log.h"
-
 /* Fill in RGB values for transparent pixels, to correct for odd colors
  * appearing at borders when blending.  This is because many PNG optimizers
  * like to discard RGB values of transparent pixels, but when blending then
@@ -179,24 +176,10 @@ static void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
  */
 void imageCleanTransparent(video::IImage *src, u32 threshold)
 {
-	TimeTaker tt("imageCleanTransparent", nullptr, PRECISION_MICRO);
-
 	if (src->getColorFormat() == video::ECF_A8R8G8B8)
 		imageCleanTransparentWithInlining<true>(src, threshold);
 	else
 		imageCleanTransparentWithInlining<false>(src, threshold);
-
-	u64 t = tt.stop(true);
-	static thread_local u64 s_t_sum = 0;
-	static thread_local u64 s_ctr = 0;
-	s_t_sum += t;
-	s_ctr += 1;
-	if (s_t_sum >= 500000) {
-		errorstream << "imageCleanTransparent: " << s_ctr << " invocations after "
-				<< ((double)s_t_sum * 1.0e-6) << " s" << std::endl;
-		s_t_sum = 0;
-		s_ctr = 0;
-	}
 }
 
 /* Scale a region of an image into another image, using nearest-neighbor with

--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -143,6 +143,8 @@ static void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
 	}
 }
 
+#include "util/timetaker.h"
+#include "log.h"
 
 /* Fill in RGB values for transparent pixels, to correct for odd colors
  * appearing at borders when blending.  This is because many PNG optimizers
@@ -157,7 +159,21 @@ static void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
  */
 void imageCleanTransparent(video::IImage *src, u32 threshold)
 {
-	imageCleanTransparentWithInlining(sry, threshold);
+	TimeTaker tt("imageCleanTransparent", nullptr, PRECISION_MICRO);
+
+	imageCleanTransparentWithInlining(src, threshold);
+
+	u64 t = tt.stop(true);
+	static thread_local u64 s_t_sum = 0;
+	static thread_local u64 s_ctr = 0;
+	s_t_sum += t;
+	s_ctr += 1;
+	if (s_t_sum >= 500000) {
+		errorstream << "imageCleanTransparent: " << s_ctr << " invocations after "
+				<< ((double)s_t_sum * 1.0e-6) << " s" << std::endl;
+		s_t_sum = 0;
+		s_ctr = 0;
+	}
 }
 
 /* Scale a region of an image into another image, using nearest-neighbor with

--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -65,18 +65,7 @@ public:
 	}
 };
 
-/* Fill in RGB values for transparent pixels, to correct for odd colors
- * appearing at borders when blending.  This is because many PNG optimizers
- * like to discard RGB values of transparent pixels, but when blending then
- * with non-transparent neighbors, their RGB values will show up nonetheless.
- *
- * This function modifies the original image in-place.
- *
- * Parameter "threshold" is the alpha level below which pixels are considered
- * transparent. Should be 127 when the texture is used with ALPHA_CHANNEL_REF,
- * 0 when alpha blending is used.
- */
-void imageCleanTransparent(video::IImage *src, u32 threshold)
+static void imageCleanTransparentWithInlining(video::IImage *src, u32 threshold)
 {
 	core::dimension2d<u32> dim = src->getDimension();
 
@@ -152,6 +141,23 @@ void imageCleanTransparent(video::IImage *src, u32 threshold)
 	newmap.copy(bitmap);
 
 	}
+}
+
+
+/* Fill in RGB values for transparent pixels, to correct for odd colors
+ * appearing at borders when blending.  This is because many PNG optimizers
+ * like to discard RGB values of transparent pixels, but when blending then
+ * with non-transparent neighbors, their RGB values will show up nonetheless.
+ *
+ * This function modifies the original image in-place.
+ *
+ * Parameter "threshold" is the alpha level below which pixels are considered
+ * transparent. Should be 127 when the texture is used with ALPHA_CHANNEL_REF,
+ * 0 when alpha blending is used.
+ */
+void imageCleanTransparent(video::IImage *src, u32 threshold)
+{
+	imageCleanTransparentWithInlining(sry, threshold);
 }
 
 /* Scale a region of an image into another image, using nearest-neighbor with


### PR DESCRIPTION
* Improves a little: #14322
* How: `IImage::getPixel` in `imageCleanTransparent` is a polymorphic call, and will hence not be inlined (at least not without LTO). 
  Most of our images are in `A8R8G8B8` color format, so I've copied what `CImage::getPixel` does in that case.

## To do

This PR is a Ready for Review.

## How to test

* Steps in #14322.
* Checkout the non-HEAD commits of this PR for a timetaker.
  *Grossly rounded* results: Master: 3 prints (=took 1.5s): 700, 200, 200; PR: 2 prints (=took 1s): 800, 300
