### PR TITLE
Mitigate disappearing and reappearing node changes of dig and placement predictions

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1464,21 +1464,6 @@ void Client::sendUpdateClientInfo(const ClientDynamicInfo& info)
 	Send(&pkt);
 }
 
-void Client::removeNode(v3s16 p)
-{
-	std::map<v3s16, MapBlock*> modified_blocks;
-
-	try {
-		m_env.getMap().removeNodeAndUpdate(p, modified_blocks);
-	}
-	catch(InvalidPositionException &e) {
-	}
-
-	for (const auto &modified_block : modified_blocks) {
-		addUpdateMeshTaskWithEdge(modified_block.first, false, true);
-	}
-}
-
 /**
  * Helper function for Client Side Modding
  * CSM restrictions are applied there, this should not be used for core engine
@@ -1523,19 +1508,12 @@ v3s16 Client::CSMClampPos(v3s16 pos)
 	);
 }
 
-void Client::addNode(v3s16 p, MapNode n, bool remove_metadata)
+void Client::addReceivedNode(const v3s16 &p, const MapNode &n,
+	bool remove_metadata)
 {
-	//TimeTaker timer1("Client::addNode()");
-
 	std::map<v3s16, MapBlock*> modified_blocks;
-
-	try {
-		//TimeTaker timer3("Client::addNode(): addNodeAndUpdate");
-		m_env.getMap().addNodeAndUpdate(p, n, modified_blocks, remove_metadata);
-	}
-	catch(InvalidPositionException &e) {
-	}
-
+	m_env.getClientMap().addReceivedNode(p, n, modified_blocks,
+		remove_metadata);
 	for (const auto &modified_block : modified_blocks) {
 		addUpdateMeshTaskWithEdge(modified_block.first, false, true);
 	}

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -270,15 +270,16 @@ public:
 	const std::vector<ModSpec> &getMods() const override;
 	const ModSpec* getModSpec(const std::string &modname) const override;
 
-	// Causes urgent mesh updates (unlike Map::add/removeNodeWithEvent)
-	void removeNode(v3s16 p);
-
 	// helpers to enforce CSM restrictions
 	MapNode CSMGetNode(v3s16 p, bool *is_valid_position);
 	int CSMClampRadius(v3s16 pos, int radius);
 	v3s16 CSMClampPos(v3s16 pos);
 
-	void addNode(v3s16 p, MapNode n, bool remove_metadata = true);
+	/// Change a node in the local map and reapply a prediction if needed.
+	/// Causes urgent mesh updates (unlike Map::add/removeNodeWithEvent)
+	void addReceivedNode(const v3s16 &p, const MapNode &n,
+		bool remove_metadata);
+
 	/// Change a node in the local map and make ClientMap remember the
 	/// local-only change until it is no longer needed
 	void addPredictedNode(const v3s16 &p, const MapNode &n,

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -235,7 +235,16 @@ public:
 
 	void Send(NetworkPacket* pkt);
 
-	void interact(InteractAction action, const PointedThing &pointed);
+	/*! \brief Enqueue the sending of interaction information
+	 *
+	 * \param action Type of interaction, e.g. INTERACT_PLACE
+	 * \param pointed Thing with which the client interacts
+	 *
+	 * \return Sequence number of the next outgoing reliable packet.
+	 *   That packet or a later one contains the interaction information.
+	 *   In an unexpected error condition this method also returns 0.
+	 */
+	u16 interact(InteractAction action, const PointedThing &pointed);
 
 	void sendNodemetaFields(v3s16 p, const std::string &formname,
 		const StringMap &fields);
@@ -270,6 +279,10 @@ public:
 	v3s16 CSMClampPos(v3s16 pos);
 
 	void addNode(v3s16 p, MapNode n, bool remove_metadata = true);
+	/// Change a node in the local map and make ClientMap remember the
+	/// local-only change until it is no longer needed
+	void addPredictedNode(const v3s16 &p, const MapNode &n,
+		bool remove_metadata, u16 seqnum);
 
 	void setPlayerControl(PlayerControl &control);
 
@@ -441,6 +454,10 @@ public:
 	{
 		return m_mesh_grid;
 	}
+
+	/// Check if a reliable packet is not yet acknowledged on the channel
+	/// where interact (and other) packets are sent to the server
+	bool isUnackedOnInteractChan(u16 seqnum) const;
 
 	bool inhibit_inventory_revert = false;
 

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -121,7 +121,7 @@ public:
 
 	void onSettingChanged(const std::string &name);
 
-	/*! \brief Change a node and remember the change for reapplying
+	/*! \brief Change a node because of a prediction and remember the change
 	 *
 	 * \param p Position where the node is set
 	 * \param n The to-be-set node
@@ -134,6 +134,10 @@ public:
 	void addPredictedNode(const v3s16 &p, const MapNode &n,
 		std::map<v3s16, MapBlock*> &modified_blocks, bool remove_metadata,
 		u16 seqnum);
+
+	/// Update a node unless it is older than a prediction
+	void addReceivedNode(const v3s16 &p, const MapNode &n,
+		std::map<v3s16, MapBlock*> &modified_blocks, bool remove_metadata);
 
 	/// Update a mapblock and reapply predictions where needed
 	void updateBlockAndPredictions(std::istringstream &in_compressed,

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -121,6 +121,24 @@ public:
 
 	void onSettingChanged(const std::string &name);
 
+	/*! \brief Change a node and remember the change for reapplying
+	 *
+	 * \param p Position where the node is set
+	 * \param n The to-be-set node
+	 * \param modified_blocks Mapblocks TODO
+	 * \param remove_metadata If true, remove node metadata information
+	 * \param seqnum A reliable packet's sequence number which
+	 *   `updateBlockAndPredictions` uses for the decision whether the change
+	 *   needs to be reapplied when a mapblock from the server arrives
+	 */
+	void addPredictedNode(const v3s16 &p, const MapNode &n,
+		std::map<v3s16, MapBlock*> &modified_blocks, bool remove_metadata,
+		u16 seqnum);
+
+	/// Update a mapblock and reapply predictions where needed
+	void updateBlockAndPredictions(std::istringstream &in_compressed,
+		u8 version, MapBlock &block);
+
 protected:
 	void reportMetrics(u64 save_time_us, u32 saved_blocks, u32 all_blocks) override;
 private:
@@ -191,6 +209,16 @@ private:
 	bool m_needs_update_drawlist;
 
 	std::set<v2s16> m_last_drawn_sectors;
+
+	/*! \brief Positions and sequence numbers of predicted node changes
+	 *
+	 * As long as the packet with the given sequence number is not acknowledged,
+	 * and if there is no packet reordering,
+	 * any mapblock received from the server was sent before the server has
+	 * handled the interaction packet related to the prediction.
+	 * If there is packet reordering, TODO
+	 */
+	std::unordered_map<v3s16, u16> m_predictions;
 
 	bool m_cache_trilinear_filter;
 	bool m_cache_bilinear_filter;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3838,10 +3838,10 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 				(predicted_f.walkable &&
 					neighborpos != player->getStandingNodePos() + v3s16(0, 1, 0) &&
 					neighborpos != player->getStandingNodePos() + v3s16(0, 2, 0))) {
-			// This triggers the required mesh update too
-			client->addNode(p, predicted_node);
 			// Report to server
-			client->interact(INTERACT_PLACE, pointed);
+			u16 seqnum_next = client->interact(INTERACT_PLACE, pointed);
+			// This triggers the required mesh update too
+			client->addPredictedNode(p, predicted_node, false, seqnum_next);
 			// A node is predicted, also play a sound
 			soundmaker->m_player_rightpunch_sound = selected_def.sound_place;
 			return true;
@@ -4008,17 +4008,17 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 			return;
 		}
 
+		u16 seqnum_next = client->interact(INTERACT_DIGGING_COMPLETED, pointed);
+
 		if (features.node_dig_prediction == "air") {
-			client->removeNode(nodepos);
+			client->addPredictedNode(nodepos, CONTENT_AIR, true, seqnum_next);
 		} else if (!features.node_dig_prediction.empty()) {
 			content_t id;
 			bool found = nodedef_manager->getId(features.node_dig_prediction, id);
 			if (found)
-				client->addNode(nodepos, id, true);
+				client->addPredictedNode(nodepos, id, true, seqnum_next);
 		}
 		// implicit else: no prediction
-
-		client->interact(INTERACT_DIGGING_COMPLETED, pointed);
 
 		if (m_cache_enable_particles) {
 			client->getParticleManager()->addDiggingParticles(client,

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -246,7 +246,8 @@ void Client::handleCommand_RemoveNode(NetworkPacket* pkt)
 
 	v3s16 p;
 	*pkt >> p;
-	removeNode(p);
+
+	addReceivedNode(p, MapNode{CONTENT_AIR}, true);
 }
 
 void Client::handleCommand_AddNode(NetworkPacket* pkt)
@@ -266,7 +267,7 @@ void Client::handleCommand_AddNode(NetworkPacket* pkt)
 		remove_metadata = false;
 	}
 
-	addNode(p, n, remove_metadata);
+	addReceivedNode(p, n, remove_metadata);
 }
 
 void Client::handleCommand_NodemetaChanged(NetworkPacket *pkt)

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/base64.h"
 #include "client/camera.h"
 #include "client/mesh_generator_thread.h"
+#include "client/clientmap.h"
 #include "chatmessage.h"
 #include "client/clientmedia.h"
 #include "log.h"
@@ -316,16 +317,11 @@ void Client::handleCommand_BlockData(NetworkPacket* pkt)
 
 	block = sector->getBlockNoCreateNoEx(p.Y);
 	if (block) {
-		/*
-			Update an existing block
-		*/
-		block->deSerialize(istr, m_server_ser_ver, false);
-		block->deSerializeNetworkSpecific(istr);
-	}
-	else {
-		/*
-			Create a new block
-		*/
+		// Update an existing block and reapply predictions if needed
+		m_env.getClientMap().updateBlockAndPredictions(istr, m_server_ser_ver,
+			*block);
+	} else {
+		// Create a new block
 		block = sector->createBlankBlock(p.Y);
 		block->deSerialize(istr, m_server_ser_ver, false);
 		block->deSerializeNetworkSpecific(istr);

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1670,6 +1670,23 @@ void Connection::DisconnectPeer(session_t peer_id)
 	putCommand(ConnectionCommand::disconnect_peer(peer_id));
 }
 
+bool Connection::isUnacked(session_t peer_id, u8 channel, u16 seqnum)
+{
+	PeerHelper peer = getPeerNoEx(peer_id);
+	if (!peer)
+		// We couldn't get our own peer? are you serious???
+		return false;
+	return dynamic_cast<Peer *>(&peer)->isUnacked(channel, seqnum);
+}
+
+u16 Connection::getNextSequenceNumber(session_t peer_id, u8 channel)
+{
+	PeerHelper peer = getPeerNoEx(peer_id);
+	if (!peer)
+		throw PeerNotFoundException("Could not get the peer!");
+	return dynamic_cast<Peer *>(&peer)->getNextSequenceNumber(channel);
+}
+
 void Connection::doResendOne(session_t peer_id)
 {
 	assert(peer_id != PEER_ID_INEXISTENT);


### PR DESCRIPTION
If a player has a slow connection to the server and they successively places nodes in the same mapblock, the predictions can be temporarily undone if an outdated mapblock is received from the server. This is especially problematic on servers with a Skyblock game. A similar problem happens when digging nodes; in this case nodes temporarily reappear.

Example; client side:
1. The player places a node at pos1. The prediction makes it appear immediately.
3. The player places a node at pos2, which is in the same mapblock. The prediction makes it appear immediately.
4. block1 arrives. It is integrated into the client-side map and undoes the prediction at pos2.
5. block2 arrives. It is integrated into the client-side map and redoes the predicted change at pos2.

Example; server side:
1. An interaction at pos1 arrives. The server modifies the map and sends the modified mapblock block1 to the client.
2. An interaction at pos2 arrives. The server modifies the map and sends the modified mapblock block2 to the client.

Here is a video of the problem: 
https://github.com/minetest/minetest/assets/3192173/180e2c19-300c-476b-99f0-9fba5981cf77

To mitigate the problem,
I change the client so that it reapplies placement and dig predictions when a mapblock arrives while the sent interact packet is not yet acknowledged.

If, for some reason, an updated mapblock arrives even if the sent packet with interact information has not yet been acknowledged, ghost nodes can appear now. This could happen if the server sends an updated mapblock before sending the acknowledgement for the arrival of the packet with interact information. 

I don't know if my understanding of the problem is correct, so the above text may contain mistakes.

Addressed issue: #7098
Related issue: #7602 


## To do

This PR is a Work in Progress.

- [ ] With the current implementation, it is probably not yet robust against packet reordering. To fix this, the list of predictions could, in addition to the sequence number, contain the non-predicted node and the time when the prediction was added. If the sequence number of a prediction is not unacknowledged and a timeout is reached, the prediction should be undone to prevent ghost nodes. 
- [ ] Thoroughly test the changes and document how to do the tests below
- [x] Reapply predictions if node packets arrive, too, and not only if whole mapblocks arrive


## How to test

* Simulate a slow network. On GNU/Linux this is possible with the following commands:
```
#sudo tc qdisc add dev lo root handle 1: htb default 12
#sudo tc class add dev lo parent 1:1 classid 1:12 htb rate 16kbps ceil 32kbps
sudo tc qdisc add dev lo root netem delay 700ms 500ms
```
* Join a world in singleplayer
* Successively place nodes and check if they temporarily disappear; also check it near mapblock boundaries
