### PR TITLE
Allow shaders with disabled post processing pipeline

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -401,7 +401,8 @@ anisotropic_filter (Anisotropic filtering) bool false
 #
 #    * None - No antialiasing (default)
 #
-#    * FSAA - Hardware-provided full-screen antialiasing (incompatible with shaders)
+#    * FSAA - Hardware-provided full-screen antialiasing
+#             (incompatible with Post Processing and Undersampling)
 #             A.K.A multi-sample antialiasing (MSAA)
 #             Smoothens out block edges but does not affect the insides of textures.
 #             A restart is required to change this option.
@@ -556,12 +557,17 @@ shadow_sky_body_orbit_tilt (Sky Body Orbit Tilt) float 0.0 -60.0 60.0
 
 [**Post Processing]
 
+#    Enables the post processing pipeline.
+#
+#    Requires: shaders
+enable_post_processing (Enable Post Processing) bool true
+
 #    Enables Hable's 'Uncharted 2' filmic tone mapping.
 #    Simulates the tone curve of photographic film and how this approximates the
 #    appearance of high dynamic range images. Mid-range contrast is slightly
 #    enhanced, highlights and shadows are gradually compressed.
 #
-#    Requires: shaders
+#    Requires: shaders, enable_post_processing
 tone_mapping (Filmic tone mapping) bool false
 
 #    Enable automatic exposure correction
@@ -569,14 +575,14 @@ tone_mapping (Filmic tone mapping) bool false
 #    automatically adjust to the brightness of the scene,
 #    simulating the behavior of human eye.
 #
-#    Requires: shaders
+#    Requires: shaders, enable_post_processing
 enable_auto_exposure (Enable Automatic Exposure) bool false
 
 #    Set the exposure compensation in EV units.
 #    Value of 0.0 (default) means no exposure compensation.
 #    Range: from -1 to 1.0
 #
-#    Requires: shaders, enable_auto_exposure
+#    Requires: shaders, enable_post_processing, enable_auto_exposure
 exposure_compensation (Exposure compensation) float 0.0 -1.0 1.0
 
 #    Apply dithering to reduce color banding artifacts.
@@ -587,7 +593,7 @@ exposure_compensation (Exposure compensation) float 0.0 -1.0 1.0
 #    With OpenGL ES, dithering only works if the shader supports high
 #    floating-point precision and it may have a higher performance impact.
 #
-#    Requires: shaders
+#    Requires: shaders, enable_post_processing
 debanding (Enable Debanding) bool true
 
 [**Bloom]
@@ -595,7 +601,7 @@ debanding (Enable Debanding) bool true
 #    Set to true to enable bloom effect.
 #    Bright colors will bleed over the neighboring objects.
 #
-#    Requires: shaders
+#    Requires: shaders, enable_post_processing
 enable_bloom (Enable Bloom) bool false
 
 #    Set to true to render debugging breakdown of the bloom effect.
@@ -603,32 +609,32 @@ enable_bloom (Enable Bloom) bool false
 #    top-left - processed base image, top-right - final image
 #    bottom-left - raw base image, bottom-right - bloom texture.
 #
-#    Requires: shaders, enable_bloom
+#    Requires: shaders, enable_post_processing, enable_bloom
 enable_bloom_debug (Enable Bloom Debug) bool false
 
 #    Defines how much bloom is applied to the rendered image
 #    Smaller values make bloom more subtle
 #    Range: from 0.01 to 1.0, default: 0.05
 #
-#    Requires: shaders, enable_bloom
+#    Requires: shaders, enable_post_processing, enable_bloom
 bloom_intensity (Bloom Intensity) float 0.05 0.01 1.0
 
 #    Defines the magnitude of bloom overexposure.
 #    Range: from 0.1 to 10.0, default: 1.0
 #
-#    Requires: shaders, enable_bloom
+#    Requires: shaders, enable_post_processing, enable_bloom
 bloom_strength_factor (Bloom Strength Factor) float 1.0 0.1 10.0
 
 #    Logical value that controls how far the bloom effect spreads
 #    from the bright objects.
 #    Range: from 0.1 to 8, default: 1
 #
-#    Requires: shaders, enable_bloom
+#    Requires: shaders, enable_post_processing, enable_bloom
 bloom_radius (Bloom Radius) float 1 0.1 8
 
 #    Set to true to enable volumetric lighting effect (a.k.a. "Godrays").
 #
-#    Requires: shaders, enable_bloom
+#    Requires: shaders, enable_post_processing, enable_bloom
 enable_volumetric_lighting (Volumetric lighting) bool false
 
 [*Audio]

--- a/src/client/render/plain.cpp
+++ b/src/client/render/plain.cpp
@@ -103,7 +103,7 @@ void UpscaleStep::run(PipelineContext &context)
 std::unique_ptr<RenderStep> create3DStage(Client *client, v2f scale)
 {
 	RenderStep *step = new Draw3D();
-	if (g_settings->getBool("enable_shaders")) {
+	if (g_settings->getBool("enable_shaders") && g_settings->getBool("enable_post_processing")) {
 		RenderPipeline *pipeline = new RenderPipeline();
 		pipeline->addStep(pipeline->own(std::unique_ptr<RenderStep>(step)));
 
@@ -128,7 +128,7 @@ RenderStep* addUpscaling(RenderPipeline *pipeline, RenderStep *previousStep, v2f
 		return previousStep;
 
 	// When shaders are enabled, post-processing pipeline takes care of rescaling
-	if (g_settings->getBool("enable_shaders"))
+	if (g_settings->getBool("enable_shaders") && g_settings->getBool("enable_post_processing"))
 		return previousStep;
 
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -503,6 +503,7 @@ void set_default_settings()
 	settings->setDefault("active_block_range", "2");
 	settings->setDefault("viewing_range", "50");
 	settings->setDefault("leaves_style", "simple");
+	settings->setDefault("enable_post_processing", "false");
 	settings->setDefault("debanding", "false");
 	settings->setDefault("curl_verify_cert", "false");
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -249,6 +249,7 @@ void set_default_settings()
 	settings->setDefault("minimap_double_scan_height", "true");
 
 	// Effects
+	settings->setDefault("enable_post_processing", "true");
 	settings->setDefault("directional_colored_fog", "true");
 	settings->setDefault("inventory_items_animations", "false");
 	settings->setDefault("mip_map", "false");


### PR DESCRIPTION
This allows disabling the post-processing pipeline while leaving Shader enabled.

So "geometric" shader feature - shadows, waves, waving plants, etc - remain enabled, and all post-processing that relies to intermediary textures are disabled.

See also #14285. Currently post processing silently disables FSAA.
FSAA is the only (performance) option we have to avoid geometry aliasing (not texture aliasing).

In general it seems reasonable to allow shaders but disable post processing.

## To do

This PR is Ready for Review.

## How to test

Enable shaders, and disable post processing, make sure all non-post-processing shader features still work: shadows, waves, waving plants, smooth day-night change, etc., and that everything still renders OK.

Enable FSAA, try some different FSAA values.
Notice the absence of Moire effect caused by geometry aliasing. (see images on #14285).
(Remember changing FSAA requires a restart of MT)
