### PR TITLE
Fix short raycasts missing large objects

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8397,8 +8397,8 @@ Player properties need to be saved manually.
     -- If `rotate = false`, the selection box will not rotate with the object itself, remaining fixed to the axes.
     -- If `rotate = true`, it will match the object's rotation and any attachment rotations.
     -- Raycasts use the selection box and object's rotation, but do *not* obey attachment rotations.
-    -- For serverside raycasts to work correctly,
-    -- the selectionbox should extend at most 5 units in each direction.
+    -- For server-side raycasts to work correctly,
+    -- the selection box should extend at most 5 units in each direction.
 
 
     pointable = true,

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8397,6 +8397,8 @@ Player properties need to be saved manually.
     -- If `rotate = false`, the selection box will not rotate with the object itself, remaining fixed to the axes.
     -- If `rotate = true`, it will match the object's rotation and any attachment rotations.
     -- Raycasts use the selection box and object's rotation, but do *not* obey attachment rotations.
+    -- For serverside raycasts to work correctly,
+    -- the selectionbox should extend at most 5 units in each direction.
 
 
     pointable = true,

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1834,8 +1834,8 @@ void ServerEnvironment::getSelectedActiveObjects(
 	const std::optional<Pointabilities> &pointabilities)
 {
 	std::vector<ServerActiveObject *> objs;
-	getObjectsInsideRadius(objs, shootline_on_map.start,
-		shootline_on_map.getLength() + 10.0f, nullptr);
+	getObjectsInsideRadius(objs, shootline_on_map.getMiddle(),
+		0.5 * shootline_on_map.getLength() + 5 * BS, nullptr);
 	const v3f line_vector = shootline_on_map.getVector();
 
 	for (auto obj : objs) {


### PR DESCRIPTION
Increases the tolerance from one node to five nodes. Also optimizes the "sphere" used for pre-filtering entities to start in the middle of the line segment rather than at the start.

Fixes #14337

## How to test

See the issue. Note: The mod depends on `futil` and `fmod` (mods by flux, available on CDB). Alternatively, you can modify it to use particles (which I find slightly nicer), and also use that to look at the raycasts:

```diff
diff --git a/init.lua b/init.lua
index 53177e5..a71925f 100644
--- a/init.lua
+++ b/init.lua
@@ -30,15 +30,26 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	player:set_wielded_item(wielded_item)
 end)
 
+local function add_marker(pos, color)
+	minetest.add_particle({
+		pos = pos,
+		texture = "short_raycast_waypoint.png^[multiply:" .. color,
+		expirationtime = 60,
+		size = 1,
+	})
+end
+
 local function multicast(start, stop, objects, liquids, step)
 	local pos = start
 	local delta = (stop - start):normalize() * step
+	add_marker(pos, "red")
 	local function get_next_ray()
 		local old_pos = pos
 		pos = pos + delta
 		if start:distance(pos) > start:distance(stop) then
 			return
 		end
+		add_marker(pos, "red")
 		return Raycast(old_pos, pos, objects, liquids)
 	end
 	local ray = get_next_ray()
@@ -72,13 +83,7 @@ minetest.register_tool("short_raycast:caster", {
 
 		for pt in multicast(start, start + (100 * look), true, false, step) do
 			if pt.type ~= "object" or pt.ref ~= user then
-				futil.create_ephemeral_hud(user, 60, {
-					hud_elem_type = "image_waypoint",
-					text = "short_raycast_waypoint.png",
-					scale = { x = -1 / 16 * 9, y = -1 },
-					alignment = { x = 0, y = -1 },
-					world_pos = pt.intersection_point,
-				})
+				add_marker(pt.intersection_point, "white")
 				break
 			end
 		end
```

It should look something like this:

![Screenshot from 2024-02-02 22-55-24](https://github.com/minetest/minetest/assets/34514239/f6107b3f-1d18-41ec-9309-972069c654c9)


