### PR TITLE
Remove sound attached to active object when active objects is removed

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -2133,3 +2133,11 @@ const std::string &Client::getFormspecPrepend() const
 {
 	return m_env.getLocalPlayer()->formspec_prepend;
 }
+
+void Client::removeActiveObjectSounds(u16 id)
+{
+	for (auto it : m_sounds_to_objects) {
+		if (it.second == id)
+			m_sound->stopSound(it.first);
+	}
+}

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -475,6 +475,9 @@ private:
 
 	bool canSendChatMessage() const;
 
+	// helper method for manage sounds
+  void removeActiveObjectSounds(u16 id);
+
 	float m_packetcounter_timer = 0.0f;
 	float m_connection_reinit_timer = 0.1f;
 	float m_avg_rtt_timer = 0.0f;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -475,8 +475,8 @@ private:
 
 	bool canSendChatMessage() const;
 
-	// helper method for manage sounds
-  void removeActiveObjectSounds(u16 id);
+	// remove sounds attached to object
+	void removeActiveObjectSounds(u16 id);
 
 	float m_packetcounter_timer = 0.0f;
 	float m_connection_reinit_timer = 0.1f;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -471,6 +471,7 @@ void Client::handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt)
 		for (u16 i = 0; i < removed_count; i++) {
 			*pkt >> id;
 			m_env.removeActiveObject(id);
+			removeActiveObjectSounds(id);
 		}
 
 		// Read added objects

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2261,13 +2261,15 @@ void Server::stopAttachedSounds(u16 id)
 {
 	assert(id);
 
-	for (const auto &sit: m_playing_sounds) {
-		const ServerPlayingSound &sound = sit.second;
+	for (auto it = m_playing_sounds.begin(); it != m_playing_sounds.end(); ) {
+		const ServerPlayingSound &sound = it->second;
 
-		if (sound.object != id)
-			continue;
-
-		stopSound(sit.first);
+		if (sound.object == id) {
+			// Remove sound reference
+			it = m_playing_sounds.erase(it);
+		}
+		else
+			it++;
 	}
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -234,7 +234,7 @@ public:
 	s32 playSound(ServerPlayingSound &params, bool ephemeral=false);
 	void stopSound(s32 handle);
 	void fadeSound(s32 handle, float step, float gain);
-	void removeSoundsClient(u16 id, session_t peer_id);
+	void stopAttachedSounds(u16 id);
 
 	// Envlock
 	std::set<std::string> getPlayerEffectivePrivs(const std::string &name);

--- a/src/server.h
+++ b/src/server.h
@@ -234,6 +234,7 @@ public:
 	s32 playSound(ServerPlayingSound &params, bool ephemeral=false);
 	void stopSound(s32 handle);
 	void fadeSound(s32 handle, float step, float gain);
+	void removeSoundsClient(u16 id, session_t peer_id);
 
 	// Envlock
 	std::set<std::string> getPlayerEffectivePrivs(const std::string &name);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1252,12 +1252,7 @@ void ServerEnvironment::clearObjects(ClearObjectsMode mode)
 			return false;
 		}
 
-		// Tell the object about removal
-		obj->removingFromEnvironment();
-		// Deregister in scripting api
-		m_script->removeObjectReference(obj);
-		// stop attached sounds
-		m_server->stopAttachedSounds(id);
+		processActiveObjectRemove(obj, id);
 
 		// Delete active object
 		return true;
@@ -1975,12 +1970,7 @@ void ServerEnvironment::removeRemovedObjects()
 			}
 		}
 
-		// Tell the object about removal
-		obj->removingFromEnvironment();
-		// Deregister in scripting api
-		m_script->removeObjectReference(obj);
-		// stop attached sounds
-		m_server->stopAttachedSounds(id);
+		processActiveObjectRemove(obj, id);
 
 		// Delete
 		return true;
@@ -2217,12 +2207,7 @@ void ServerEnvironment::deactivateFarObjects(bool _force_delete)
 			return false;
 		}
 
-		// Tell the object about removal
-		obj->removingFromEnvironment();
-		// Deregister in scripting api
-		m_script->removeObjectReference(obj);
-		// stop attached sounds
-		m_server->stopAttachedSounds(id);
+		processActiveObjectRemove(obj, id);
 
 		// Delete active object
 		return true;
@@ -2283,6 +2268,16 @@ bool ServerEnvironment::saveStaticToBlock(
 	obj->m_static_block = blockpos;
 
 	return true;
+}
+
+void ServerEnvironment::processActiveObjectRemove(ServerActiveObject *obj, u16 id)
+{
+	// Tell the object about removal
+	obj->removingFromEnvironment();
+	// Deregister in scripting api
+	m_script->removeObjectReference(obj);
+	// stop attached sounds
+	m_server->stopAttachedSounds(id);
 }
 
 PlayerDatabase *ServerEnvironment::openPlayerDatabase(const std::string &name,

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1256,6 +1256,8 @@ void ServerEnvironment::clearObjects(ClearObjectsMode mode)
 		obj->removingFromEnvironment();
 		// Deregister in scripting api
 		m_script->removeObjectReference(obj);
+		// stop attached sounds
+		m_server->stopAttachedSounds(id);
 
 		// Delete active object
 		return true;
@@ -1977,6 +1979,8 @@ void ServerEnvironment::removeRemovedObjects()
 		obj->removingFromEnvironment();
 		// Deregister in scripting api
 		m_script->removeObjectReference(obj);
+		// stop attached sounds
+		m_server->stopAttachedSounds(id);
 
 		// Delete
 		return true;
@@ -2217,6 +2221,8 @@ void ServerEnvironment::deactivateFarObjects(bool _force_delete)
 		obj->removingFromEnvironment();
 		// Deregister in scripting api
 		m_script->removeObjectReference(obj);
+		// stop attached sounds
+		m_server->stopAttachedSounds(id);
 
 		// Delete active object
 		return true;

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -454,6 +454,8 @@ private:
 	bool saveStaticToBlock(v3s16 blockpos, u16 store_id,
 			ServerActiveObject *obj, const StaticObject &s_obj, u32 mod_reason);
 
+	void processActiveObjectRemove(ServerActiveObject *obj, u16 id);
+
 	/*
 		Member variables
 	*/


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
Fixes #11521.
- How does the PR work?
Remove sounds attached to removed active objects on the client side.
- Does it resolve any reported issue?
Bug #11521 and fixes #8094.

## To do

This PR is a Ready for Review.

## How to test

Attach sound in the loop to ActiveObject via jukebox in devtest and destroy an object.
With this fix, sounds should disappear.
