### PR TITLE
Ambient light and server control for it

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -43,7 +43,8 @@ varying vec3 vPosition;
 // cameraOffset + worldPosition (for large coordinates the limits of float
 // precision must be considered).
 varying vec3 worldPosition;
-varying lowp vec4 varColor;
+varying lowp vec3 lightColor;
+varying vec3 hardwareColor;
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
 #else
@@ -432,7 +433,7 @@ void main(void)
 #endif
 
 	color = base.rgb;
-	vec4 col = vec4(color.rgb * varColor.rgb, 1.0);
+	vec4 col = vec4(color.rgb * hardwareColor.rgb * lightColor.rgb, 1.0);
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	// Fragment normal, can differ from vNormal which is derived from vertex normals.
@@ -535,7 +536,7 @@ void main(void)
 #if (defined(ENABLE_NODE_SPECULAR) && !defined(MATERIAL_WAVING_LIQUID))
 		// Apply specular to blocks.
 		if (dot(v_LightDirection, vNormal) < 0.0) {
-			float intensity = 2.0 * (1.0 - (base.r * varColor.r));
+			float intensity = 2.0 * (1.0 - (base.r * lightColor.r));
 			const float specular_exponent = 5.0;
 			const float fresnel_exponent =  4.0;
 
@@ -547,7 +548,7 @@ void main(void)
 
 #if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES) && defined(ENABLE_TRANSLUCENT_FOLIAGE)
 		// Simulate translucent foliage.
-		col.rgb += 4.0 * dayLight * base.rgb * normalize(base.rgb * varColor.rgb * varColor.rgb) * f_adj_shadow_strength * pow(max(-dot(v_LightDirection, viewVec), 0.0), 4.0) * max(1.0 - shadow_uncorrected, 0.0);
+		col.rgb += 4.0 * dayLight * base.rgb * normalize(base.rgb * lightColor.rgb * lightColor.rgb) * f_adj_shadow_strength * pow(max(-dot(v_LightDirection, viewVec), 0.0), 4.0) * max(1.0 - shadow_uncorrected, 0.0);
 #endif
 	}
 #endif

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -5,6 +5,7 @@ uniform vec3 dayLight;
 // The cameraOffset is the current center of the visible world.
 uniform highp vec3 cameraOffset;
 uniform float animationTimer;
+uniform vec3 ambientLight;
 
 varying vec3 vNormal;
 varying vec3 vPosition;
@@ -215,6 +216,8 @@ void main(void)
 	float brightness = (color.r + color.g + color.b) / 3.0;
 	color.b += max(0.0, 0.021 - abs(0.2 * brightness - 0.021) +
 		0.07 * brightness);
+
+	color.rgb += ambientLight;
 
 	varColor = clamp(color, 0.0, 1.0);
 

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -2,6 +2,7 @@ uniform mat4 mWorld;
 uniform vec3 dayLight;
 uniform float animationTimer;
 uniform lowp vec4 materialColor;
+uniform vec3 ambientLight;
 
 varying vec3 vNormal;
 varying vec3 vPosition;
@@ -124,6 +125,8 @@ void main(void)
 	float brightness = (color.r + color.g + color.b) / 3.0;
 	color.b += max(0.0, 0.021 - abs(0.2 * brightness - 0.021) +
 		0.07 * brightness);
+
+	color.rgb += ambientLight;
 
 	varColor = clamp(color, 0.0, 1.0);
 

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -110,25 +110,29 @@ void main(void)
 		: directional_ambient(normalize(inVertexNormal));
 #endif
 
-	vec4 color = inVertexColor;
+	// Calculate color.
 
-	color *= materialColor;
+	// Unpack the values from alpha
+	float ratio = floor(materialColor.a*16)/16;
+	float lightBase = floor((materialColor.a - ratio)*256)/16;
+
+	vec3 light = vec3(lightBase, lightBase, lightBase);
 
 	// The alpha gives the ratio of sunlight in the incoming light.
-	nightRatio = 1.0 - color.a;
-	color.rgb = color.rgb * (color.a * dayLight.rgb +
+	nightRatio = 1.0 - ratio;
+	light.rgb = light.rgb * (ratio * dayLight.rgb +
 		nightRatio * artificialLight.rgb) * 2.0;
-	color.a = 1.0;
 
 	// Emphase blue a bit in darker places
 	// See C++ implementation in mapblock_mesh.cpp final_color_blend()
-	float brightness = (color.r + color.g + color.b) / 3.0;
-	color.b += max(0.0, 0.021 - abs(0.2 * brightness - 0.021) +
+	float brightness = (light.r + light.g + light.b) / 3.0;
+	light.b += max(0.0, 0.021 - abs(0.2 * brightness - 0.021) +
 		0.07 * brightness);
 
-	color.rgb += ambientLight;
+	// In the end add the normalized ambient light and clamp that.
+	light.rgb += ambientLight;
 
-	varColor = clamp(color, 0.0, 1.0);
+	varColor = vec4(clamp(light.rgb, 0.0, 1.0), 1.0);
 
 
 #ifdef ENABLE_DYNAMIC_SHADOWS

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8757,6 +8757,14 @@ child will follow movement and rotation of that bone.
 * `set_lighting(light_definition)`: sets lighting for the player
     * Passing no arguments resets lighting to its default values.
     * `light_definition` is a table with the following optional fields:
+      * `ambient_light` is a ColorSpec controlling color of global ambient light;
+        (default: `{a = 255, r = 0, g = 0, b = 0}` / last set value).
+        * It works only if shaders are enabled.
+        * Alpha is ignored (it is always set to 255).
+        * Note: Total light is clamped before being applied.
+          This means that when an object is fully lit, ambient light
+          will take no effect. Setting ambient light to `"#FFFFFF"`
+          will make all objects be fully lit at all times ("fullbright").
       * `saturation` sets the saturation (vividness; default: `1.0`).
         * It is applied according to the function `result = b*(1-s) + c*s`, where:
           * `c` is the original color

--- a/games/devtest/mods/lighting/init.lua
+++ b/games/devtest/mods/lighting/init.lua
@@ -29,6 +29,14 @@ local lighting_sections = {
 			{n = "strength", d = "Strength", min = 0, max = 1},
 		},
 	},
+	{
+		n = "ambient_light", d = "Ambient Light",
+		entries = {
+			{n = "r", d = "Red", min = 0, max = 255},
+			{n = "g", d = "Green", min = 0, max = 255},
+			{n = "b", d = "Blue", min = 0, max = 255}
+		}
+	}
 }
 
 local function dump_lighting(lighting)

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -261,7 +261,11 @@ void ClientEnvironment::step(float dtime)
 
 		u16 light = getInteriorLight(node_at_lplayer, 0, m_client->ndef());
 		lplayer->light_color = encode_light(light, 0); // this transfers light.alpha
-		final_color_blend(&lplayer->light_color, light, day_night_ratio);
+
+		video::SColor ambient_light = g_settings->getBool("enable_shaders") ?
+			lplayer->getLighting().ambient_light : video::SColor(255, 0, 0, 0);
+
+		final_color_blend(&lplayer->light_color, light, day_night_ratio, ambient_light);
 	}
 
 	/*

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -905,6 +905,8 @@ void GenericCAO::updateLight(u32 day_night_ratio)
 	// Initialize with full alpha, otherwise entity won't be visible
 	video::SColor light{0xFFFFFFFF};
 
+	// Encode light into color, adding a small boost
+	// based on the entity glow.
 	if (m_enable_shaders)
 		light = encode_light(light_at_pos, m_prop.glow);
 	else

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -907,12 +907,8 @@ void GenericCAO::updateLight(u32 day_night_ratio)
 
 	if (m_enable_shaders)
 		light = encode_light(light_at_pos, m_prop.glow);
-	else {
-		video::SColor ambient_light = g_settings->getBool("enable_shaders") ?
-		m_env->getLocalPlayer()->getLighting().ambient_light : video::SColor(255, 0, 0, 0);
-
-		final_color_blend(&light, light_at_pos, day_night_ratio, ambient_light);
-	}
+	else
+		final_color_blend(&light, light_at_pos, day_night_ratio);
 
 	if (light != m_last_light) {
 		m_last_light = light;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -905,12 +905,14 @@ void GenericCAO::updateLight(u32 day_night_ratio)
 	// Initialize with full alpha, otherwise entity won't be visible
 	video::SColor light{0xFFFFFFFF};
 
-	// Encode light into color, adding a small boost
-	// based on the entity glow.
 	if (m_enable_shaders)
 		light = encode_light(light_at_pos, m_prop.glow);
-	else
-		final_color_blend(&light, light_at_pos, day_night_ratio);
+	else {
+		video::SColor ambient_light = g_settings->getBool("enable_shaders") ?
+		m_env->getLocalPlayer()->getLighting().ambient_light : video::SColor(255, 0, 0, 0);
+
+		final_color_blend(&light, light_at_pos, day_night_ratio, ambient_light);
+	}
 
 	if (light != m_last_light) {
 		m_last_light = light;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -447,9 +447,6 @@ public:
 
 		m_user_exposure_compensation = g_settings->getFloat("exposure_compensation", -1.0f, 1.0f);
 		m_bloom_enabled = g_settings->getBool("enable_bloom");
-		m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.01f, 1.0f);
-		m_bloom_strength = RenderingEngine::BASE_BLOOM_STRENGTH * g_settings->getFloat("bloom_strength_factor", 0.1f, 10.0f);
-		m_bloom_radius = g_settings->getFloat("bloom_radius", 0.1f, 8.0f);
 		m_volumetric_light_enabled = g_settings->getBool("enable_volumetric_lighting") && m_bloom_enabled;
 	}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -384,6 +384,7 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<float>
 		m_animation_timer_delta_pixel{"animationTimerDelta"};
 	CachedPixelShaderSetting<float, 3> m_day_light{"dayLight"};
+	CachedVertexShaderSetting<float, 3> m_ambient_light{"ambientLight"};
 	CachedPixelShaderSetting<float, 3> m_minimap_yaw{"yawVec"};
 	CachedPixelShaderSetting<float, 3> m_camera_offset_pixel{"cameraOffset"};
 	CachedVertexShaderSetting<float, 3> m_camera_offset_vertex{"cameraOffset"};
@@ -446,6 +447,9 @@ public:
 
 		m_user_exposure_compensation = g_settings->getFloat("exposure_compensation", -1.0f, 1.0f);
 		m_bloom_enabled = g_settings->getBool("enable_bloom");
+		m_bloom_intensity = g_settings->getFloat("bloom_intensity", 0.01f, 1.0f);
+		m_bloom_strength = RenderingEngine::BASE_BLOOM_STRENGTH * g_settings->getFloat("bloom_strength_factor", 0.1f, 10.0f);
+		m_bloom_radius = g_settings->getFloat("bloom_radius", 0.1f, 8.0f);
 		m_volumetric_light_enabled = g_settings->getBool("enable_volumetric_lighting") && m_bloom_enabled;
 	}
 
@@ -461,6 +465,11 @@ public:
 		video::SColorf sunlight;
 		get_sunlight_color(&sunlight, daynight_ratio);
 		m_day_light.set(sunlight, services);
+
+		const auto &lighting = m_client->getEnv().getLocalPlayer()->getLighting();
+
+		video::SColorf ambient_light_f(lighting.ambient_light);
+		m_ambient_light.set(ambient_light_f, services);
 
 		u32 animation_timer = m_client->getEnv().getFrameTime() % 1000000;
 		float animation_timer_f = (float)animation_timer / 100000.f;
@@ -497,16 +506,13 @@ public:
 		m_texel_size0_vertex.set(m_texel_size0, services);
 		m_texel_size0_pixel.set(m_texel_size0, services);
 
-		const auto &lighting = m_client->getEnv().getLocalPlayer()->getLighting();
-
-		const AutoExposure &exposure_params = lighting.exposure;
 		std::array<float, 7> exposure_buffer = {
-			std::pow(2.0f, exposure_params.luminance_min),
-			std::pow(2.0f, exposure_params.luminance_max),
-			exposure_params.exposure_correction,
-			exposure_params.speed_dark_bright,
-			exposure_params.speed_bright_dark,
-			exposure_params.center_weight_power,
+			std::pow(2.0f, lighting.exposure.luminance_min),
+			std::pow(2.0f, lighting.exposure.luminance_max),
+			lighting.exposure.exposure_correction,
+			lighting.exposure.speed_dark_bright,
+			lighting.exposure.speed_bright_dark,
+			lighting.exposure.center_weight_power,
 			powf(2.f, m_user_exposure_compensation)
 		};
 		m_exposure_params_pixel.set(exposure_buffer.data(), services);

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -427,8 +427,7 @@ void getNodeTile(MapNode mn, const v3s16 &p, const v3s16 &dir, MeshMakeData *dat
 static void applyTileColor(PreMeshBuffer &pmb)
 {
 	video::SColor tc = pmb.layer.color;
-	if (tc == video::SColor(0xFFFFFFFF))
-		return;
+
 	for (video::S3DVertex &vertex : pmb.vertices) {
 		video::SColor *c = &vertex.Color;
 		c->setRed(tc.getRed());
@@ -975,7 +974,7 @@ video::SColor encode_light(u16 light, u8 emissive_light)
 		r = 0;
 	// Average light:
 	u32 b = (day + night) / 30;
-	return video::SColor((r<<4)|b, 255, 255, 255);
+	return video::SColor((r<<4)|b, 0, 0, 0);
 }
 
 u8 get_solid_sides(MeshMakeData *data)

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -291,16 +291,18 @@ void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio){
 }
 
 void final_color_blend(video::SColor *result,
-		u16 light, u32 daynight_ratio)
+		u16 light, u32 daynight_ratio,
+		const video::SColorf &ambientLight)
 {
 	video::SColorf dayLight;
 	get_sunlight_color(&dayLight, daynight_ratio);
 	final_color_blend(result,
-		encode_light(light, 0), dayLight);
+		encode_light(light, 0), dayLight, ambientLight);
 }
 
 void final_color_blend(video::SColor *result,
-		const video::SColor &data, const video::SColorf &dayLight)
+		const video::SColor &data, const video::SColorf &dayLight,
+		const video::SColorf &ambientLight)
 {
 	static const video::SColorf artificialColor(1.04f, 1.04f, 1.04f);
 
@@ -320,6 +322,11 @@ void final_color_blend(video::SColor *result,
 
 	b += emphase_blue_when_dark[irr::core::clamp((s32) ((r + g + b) / 3 * 255),
 		0, 255) / 8] / 255.0f;
+
+	// Add ambient light
+	r += ambientLight.r;
+	g += ambientLight.g;
+	b += ambientLight.b;
 
 	result->setRed(core::clamp((s32) (r * 255.0f), 0, 255));
 	result->setGreen(core::clamp((s32) (g * 255.0f), 0, 255));

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -969,12 +969,16 @@ video::SColor encode_light(u16 light, u8 emissive_light)
 	// Ratio of sunlight:
 	u32 r;
 	if (sum > 0)
-		r = day * 15 / sum;
+		r = day * 255 / sum;
 	else
 		r = 0;
+	if (r < 0xF0 && r&0b1100)
+		r += 0x10;
 	// Average light:
-	u32 b = (day + night) / 30;
-	return video::SColor((r<<4)|b, 0, 0, 0);
+	u32 b = sum / 2;
+	if (b < 0xF0 && b&0b1100)
+		b += 0x10;
+	return video::SColor((r&0xF0)|(b>>4), 0, 0, 0);
 }
 
 u8 get_solid_sides(MeshMakeData *data)

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -319,7 +319,8 @@ void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio);
  * night light
  */
 void final_color_blend(video::SColor *result,
-		u16 light, u32 daynight_ratio);
+		u16 light, u32 daynight_ratio,
+		const video::SColorf &ambientLight=video::SColorf(0.0f, 0.0f, 0.0f, 1.0f));
 
 /*!
  * Gives the final  SColor shown on screen.
@@ -329,7 +330,8 @@ void final_color_blend(video::SColor *result,
  * \param dayLight color of the sunlight
  */
 void final_color_blend(video::SColor *result,
-		const video::SColor &data, const video::SColorf &dayLight);
+		const video::SColor &data, const video::SColorf &dayLight,
+		const video::SColorf &ambientLight=video::SColorf(0.0f, 0.0f, 0.0f, 1.0f));
 
 // Retrieves the TileSpec of a face of a node
 // Adds MATERIAL_FLAG_CRACK if the node is cracked

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/content_cao.h"
 #include "client/clientevent.h"
 #include "client/renderingengine.h"
+#include "client/mapblock_mesh.h"
 #include "util/numeric.h"
 #include "light.h"
 #include "localplayer.h"
@@ -185,11 +186,19 @@ video::SColor Particle::updateLight(ClientEnvironment *env)
 	else
 		light = blend_light(env->getDayNightRatio(), LIGHT_SUN, 0);
 
-	u8 m_light = decode_light(light + m_p.glow);
+	light = decode_light(light + m_p.glow);
+
+	video::SColor light_color(0xFFFFFFFF);
+	video::SColor ambient_light = g_settings->getBool("enable_shaders") ?
+		env->getLocalPlayer()->getLighting().ambient_light : video::SColor(255, 0, 0, 0);
+
+	final_color_blend(&light_color, static_cast<u16>(light) * 255, env->getDayNightRatio(),
+			ambient_light);
+
 	return video::SColor(255,
-		m_light * m_base_color.getRed() / 255,
-		m_light * m_base_color.getGreen() / 255,
-		m_light * m_base_color.getBlue() / 255);
+		light_color.getRed() * m_base_color.getRed() / 255,
+		light_color.getGreen() * m_base_color.getGreen() / 255,
+		light_color.getBlue() * m_base_color.getBlue() / 255);
 }
 
 void Particle::updateVertices(ClientEnvironment *env, video::SColor color)

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -52,6 +52,8 @@ struct AutoExposure
  */
 struct Lighting
 {
+	/// @brief Ambient light color & intensity for nodes & entities. Alpha is ignored.
+	video::SColor ambient_light {255, 0, 0, 0};
 	AutoExposure exposure;
 	float shadow_intensity {0.0f};
 	float saturation {1.0f};

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1808,21 +1808,22 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 {
 	Lighting& lighting = m_env.getLocalPlayer()->getLighting();
 
-	if (pkt->getRemainingBytes() >= 4)
+	//if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.shadow_intensity;
-	if (pkt->getRemainingBytes() >= 4)
+		*pkt >> lighting.ambient_light;
+	//if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.saturation;
-	if (pkt->getRemainingBytes() >= 24) {
+	//if (pkt->getRemainingBytes() >= 24) {
 		*pkt >> lighting.exposure.luminance_min
 				>> lighting.exposure.luminance_max
 				>> lighting.exposure.exposure_correction
 				>> lighting.exposure.speed_dark_bright
 				>> lighting.exposure.speed_bright_dark
 				>> lighting.exposure.center_weight_power;
-	}
-	if (pkt->getRemainingBytes() >= 4)
+	//}
+	//if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.volumetric_light_strength;
-	if (pkt->getRemainingBytes() >= 4)
+	//if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.shadow_tint;
 	if (pkt->getRemainingBytes() >= 12) {
 		*pkt >> lighting.bloom_intensity

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1808,26 +1808,27 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 {
 	Lighting& lighting = m_env.getLocalPlayer()->getLighting();
 
-	//if (pkt->getRemainingBytes() >= 4)
+	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.shadow_intensity;
-		*pkt >> lighting.ambient_light;
-	//if (pkt->getRemainingBytes() >= 4)
+	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.saturation;
-	//if (pkt->getRemainingBytes() >= 24) {
+	if (pkt->getRemainingBytes() >= 24) {
 		*pkt >> lighting.exposure.luminance_min
 				>> lighting.exposure.luminance_max
 				>> lighting.exposure.exposure_correction
 				>> lighting.exposure.speed_dark_bright
 				>> lighting.exposure.speed_bright_dark
 				>> lighting.exposure.center_weight_power;
-	//}
-	//if (pkt->getRemainingBytes() >= 4)
+	}
+	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.volumetric_light_strength;
-	//if (pkt->getRemainingBytes() >= 4)
+	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.shadow_tint;
 	if (pkt->getRemainingBytes() >= 12) {
 		*pkt >> lighting.bloom_intensity
 				>> lighting.bloom_strength_factor
 				>> lighting.bloom_radius;
 	}
+	if (pkt->getRemainingBytes() >= 4)
+		*pkt >> lighting.ambient_light;
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2630,6 +2630,13 @@ int ObjectRef::l_set_lighting(lua_State *L)
 		}
 		lua_pop(L, 1); // shadows
 
+		lua_getfield(L, 2, "ambient_light");
+		if (!lua_isnil(L, -1)) {
+			read_color(L, -1, &lighting.ambient_light);
+			lighting.ambient_light.setAlpha(255); // alpha should always be 255
+		}
+		lua_pop(L, 1); // ambient light
+
 		getfloatfield(L, -1, "saturation", lighting.saturation);
 
 		lua_getfield(L, 2, "exposure");
@@ -2681,6 +2688,16 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	push_ARGB8(L, lighting.shadow_tint);
 	lua_setfield(L, -2, "tint");
 	lua_setfield(L, -2, "shadows");
+	lua_newtable(L); // "ambient_light"
+	lua_pushnumber(L, lighting.ambient_light.getRed());
+	lua_setfield(L, -2, "r");
+	lua_pushnumber(L, lighting.ambient_light.getGreen());
+	lua_setfield(L, -2, "g");
+	lua_pushnumber(L, lighting.ambient_light.getBlue());
+	lua_setfield(L, -2, "b");
+	lua_pushnumber(L, 255);
+	lua_setfield(L, -2, "a");
+	lua_setfield(L, -2, "ambient_light");
 	lua_pushnumber(L, lighting.saturation);
 	lua_setfield(L, -2, "saturation");
 	lua_newtable(L); // "exposure"

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1919,7 +1919,6 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 			4, peer_id);
 
 	pkt << lighting.shadow_intensity;
-	pkt << lighting.ambient_light;
 	pkt << lighting.saturation;
 
 	pkt << lighting.exposure.luminance_min
@@ -1932,6 +1931,8 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 	pkt << lighting.volumetric_light_strength << lighting.shadow_tint;
 	pkt << lighting.bloom_intensity << lighting.bloom_strength_factor <<
 			lighting.bloom_radius;
+
+	pkt << lighting.ambient_light;
 
 	Send(&pkt);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1919,6 +1919,7 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 			4, peer_id);
 
 	pkt << lighting.shadow_intensity;
+	pkt << lighting.ambient_light;
 	pkt << lighting.saturation;
 
 	pkt << lighting.exposure.luminance_min


### PR DESCRIPTION
This PR allows to add ambient light for environment per player that exists independently from the natural and artificial light sources. It is controlled by the new property `ambient_light = <ColorSpec>` of `player:set_lighting`. It makes possible to adjust brightness and color of poorly eliminated places e.g. caves, nether biome and any other closed spaces.

**Youtube Demo Video**
https://m.youtube.com/watch?v=Lfk4XTqnZEU

<details><summary>Some old screenshots</summary>
<p>

https://github.com/minetest/minetest/assets/25750346/23f3d464-dff2-4e70-bd1d-5c1490c6e0eb

**{luminance = 8, color = "green"}**
![Снимок экрана от 2024-02-03 22-41-22](https://github.com/minetest/minetest/assets/25750346/c9a84ce7-03ee-4c14-aacc-17294681b944)


**{luminance = 5, color = "yellow"}**
![Снимок экрана от 2024-02-03 22-42-25](https://github.com/minetest/minetest/assets/25750346/6df6517a-81f4-4ba7-a3ff-90ad91019afc)


**{luminance = 3, color = "red"}**
![Снимок экрана от 2024-02-03 22-51-32](https://github.com/minetest/minetest/assets/25750346/7940f597-ddcd-4b4c-8257-def1bdd4549f)
</p>
</details> 

This PR is Ready for Review.

## How to test

1. Enable shaders in the settings.
2. Select `devtest` game and start the world.
3. Enter `/set_lighting` command that will show the menu with scrollbars adjusting some lighting parameters.
4. Adjust the red, green, blue channels of the ambient light.