### PR TITLE
Expose analog joystick input to the Lua API

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8244,12 +8244,18 @@ child will follow movement and rotation of that bone.
       bgcolor[], any non-style elements (eg: label) may result in weird behavior.
     * Only affects formspecs shown after this is called.
 * `get_formspec_prepend()`: returns a formspec string.
-* `get_player_control()`: returns table with player pressed keys
-    * The table consists of fields with the following boolean values
-      representing the pressed keys: `up`, `down`, `left`, `right`, `jump`,
-      `aux1`, `sneak`, `dig`, `place`, `LMB`, `RMB`, and `zoom`.
+* `get_player_control()`: returns table with player input
+    * The table contains the following boolean fields representing the pressed
+      keys: `up`, `down`, `left`, `right`, `jump`, `aux1`, `sneak`, `dig`,
+      `place`, `LMB`, `RMB`, and `zoom`.
     * The fields `LMB` and `RMB` are equal to `dig` and `place` respectively,
       and exist only to preserve backwards compatibility.
+    * The table also contains the float fields `movement_x` and `movement_y`.
+        * They represent the movement of the player. Values are floats in the
+          range [-1,+1].
+        * They take both keyboard and joystick input into account.
+        * You should ALWAYS use them for movement instead of `up`, `down`,
+          `left` and `right` to support different input methods correctly.
     * Returns an empty table `{}` if the object is not a player.
 * `get_player_control_bits()`: returns integer with bit packed player pressed
   keys.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8247,15 +8247,15 @@ child will follow movement and rotation of that bone.
 * `get_player_control()`: returns table with player input
     * The table contains the following boolean fields representing the pressed
       keys: `up`, `down`, `left`, `right`, `jump`, `aux1`, `sneak`, `dig`,
-      `place`, `LMB`, `RMB`, and `zoom`.
+      `place`, `LMB`, `RMB` and `zoom`.
     * The fields `LMB` and `RMB` are equal to `dig` and `place` respectively,
       and exist only to preserve backwards compatibility.
-    * The table also contains the float fields `movement_x` and `movement_y`.
-        * They represent the movement of the player. Values are floats in the
-          range [-1,+1].
+    * The table also contains the fields `movement_x` and `movement_y`.
+        * They represent the movement of the player. Values are numbers in the
+          range [-1.0,+1.0].
         * They take both keyboard and joystick input into account.
-        * You should ALWAYS use them for movement instead of `up`, `down`,
-          `left` and `right` to support different input methods correctly.
+        * You should prefer them over `up`, `down`, `left` and `right` to
+          support different input methods correctly.
     * Returns an empty table `{}` if the object is not a player.
 * `get_player_control_bits()`: returns integer with bit packed player pressed
   keys.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1034,7 +1034,7 @@ void Client::Send(NetworkPacket* pkt)
 	m_con->Send(PEER_ID_SERVER, scf.channel, pkt, scf.reliable);
 }
 
-// Will fill up 12 + 12 + 4 + 4 + 4 + 1 + 1 + 1 bytes
+// Will fill up 12 + 12 + 4 + 4 + 4 + 1 + 1 + 1 + 4 + 4 bytes
 void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *pkt, bool camera_inverted)
 {
 	v3f pf           = myplayer->getPosition() * 100;
@@ -1046,6 +1046,8 @@ void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *
 	u8 fov           = std::fmin(255.0f, clientMap->getCameraFov() * 80.0f);
 	u8 wanted_range  = std::fmin(255.0f,
 			std::ceil(clientMap->getWantedRange() * (1.0f / MAP_BLOCKSIZE)));
+	f32 movement_speed = myplayer->control.movement_speed;
+	f32 movement_dir = myplayer->control.movement_direction;
 
 	v3s32 position(pf.X, pf.Y, pf.Z);
 	v3s32 speed(sf.X, sf.Y, sf.Z);
@@ -1060,10 +1062,13 @@ void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *
 		[12+12+4+4+4] u8 fov*80
 		[12+12+4+4+4+1] u8 ceil(wanted_range / MAP_BLOCKSIZE)
 		[12+12+4+4+4+1+1] u8 camera_inverted (bool)
+		[12+12+4+4+4+1+1+1] f32 movement_speed
+		[12+12+4+4+4+1+1+1+4] f32 movement_direction
 	*/
 	*pkt << position << speed << pitch << yaw << keyPressed;
 	*pkt << fov << wanted_range;
 	*pkt << camera_inverted;
+	*pkt << movement_speed << movement_dir;
 }
 
 void Client::interact(InteractAction action, const PointedThing& pointed)
@@ -1397,6 +1402,8 @@ void Client::sendPlayerPos()
 
 	u32 keyPressed = player->control.getKeysPressed();
 	bool camera_inverted = m_camera->getCameraMode() == CAMERA_MODE_THIRD_FRONT;
+	f32 movement_speed = player->control.movement_speed;
+	f32 movement_dir = player->control.movement_direction;
 
 	if (
 			player->last_position        == player->getPosition() &&
@@ -1406,7 +1413,9 @@ void Client::sendPlayerPos()
 			player->last_keyPressed      == keyPressed            &&
 			player->last_camera_fov      == camera_fov            &&
 			player->last_camera_inverted == camera_inverted       &&
-			player->last_wanted_range    == wanted_range)
+			player->last_wanted_range    == wanted_range          &&
+			player->last_movement_speed  == movement_speed        &&
+			player->last_movement_dir    == movement_dir)
 		return;
 
 	player->last_position        = player->getPosition();
@@ -1417,8 +1426,10 @@ void Client::sendPlayerPos()
 	player->last_camera_fov      = camera_fov;
 	player->last_camera_inverted = camera_inverted;
 	player->last_wanted_range    = wanted_range;
+	player->last_movement_speed  = movement_speed;
+	player->last_movement_dir    = movement_dir;
 
-	NetworkPacket pkt(TOSERVER_PLAYERPOS, 12 + 12 + 4 + 4 + 4 + 1 + 1 + 1);
+	NetworkPacket pkt(TOSERVER_PLAYERPOS, 12 + 12 + 4 + 4 + 4 + 1 + 1 + 1 + 4 + 4);
 
 	writePlayerPos(player, &map, &pkt, camera_inverted);
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2755,6 +2755,7 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 		input->getMovementSpeed(),
 		input->getMovementDirection()
 	);
+	control.setMovementFromKeys();
 
 	// autoforward if set: move at maximum speed
 	if (player->getPlayerSettings().continuous_forward &&

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2752,8 +2752,8 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 		isKeyDown(KeyType::PLACE),
 		cam.camera_pitch,
 		cam.camera_yaw,
-		input->getMovementSpeed(),
-		input->getMovementDirection()
+		input->getJoystickSpeed(),
+		input->getJoystickDirection()
 	);
 	control.setMovementFromKeys();
 

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -220,19 +220,19 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 /*
  * RealInputHandler
  */
-float RealInputHandler::getMovementSpeed()
+float RealInputHandler::getJoystickSpeed()
 {
-	if (g_touchcontrols && g_touchcontrols->getMovementSpeed())
-		return g_touchcontrols->getMovementSpeed();
+	if (g_touchcontrols && g_touchcontrols->getJoystickSpeed())
+		return g_touchcontrols->getJoystickSpeed();
 	return joystick.getMovementSpeed();
 }
 
-float RealInputHandler::getMovementDirection()
+float RealInputHandler::getJoystickDirection()
 {
-	// `getMovementDirection() == 0` means forward, so we cannot use
-	// `getMovementDirection()` as a condition.
-	if (g_touchcontrols && g_touchcontrols->getMovementSpeed())
-		return g_touchcontrols->getMovementDirection();
+	// `getJoystickDirection() == 0` means forward, so we cannot use
+	// `getJoystickDirection()` as a condition.
+	if (g_touchcontrols && g_touchcontrols->getJoystickSpeed())
+		return g_touchcontrols->getJoystickDirection();
 	return joystick.getMovementDirection();
 }
 
@@ -291,25 +291,11 @@ void RandomInputHandler::step(float dtime)
 		counterMovement -= dtime;
 		if (counterMovement < 0.0) {
 			counterMovement = 0.1 * Rand(1, 40);
-			movementSpeed = Rand(0,100)*0.01;
-			movementDirection = Rand(-100, 100)*0.01 * M_PI;
+			joystickSpeed = Rand(0,100)*0.01;
+			joystickDirection = Rand(-100, 100)*0.01 * M_PI;
 		}
 	} else {
-		bool f = keydown[keycache.key[KeyType::FORWARD]],
-			l = keydown[keycache.key[KeyType::LEFT]];
-		if (f || l) {
-			movementSpeed = 1.0f;
-			if (f && !l)
-				movementDirection = 0.0;
-			else if (!f && l)
-				movementDirection = -M_PI_2;
-			else if (f && l)
-				movementDirection = -M_PI_4;
-			else
-				movementDirection = 0.0;
-		} else {
-			movementSpeed = 0.0;
-			movementDirection = 0.0;
-		}
+		joystickSpeed = 0.0f;
+		joystickDirection = 0.0f;
 	}
 }

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -222,21 +222,6 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
  */
 float RealInputHandler::getMovementSpeed()
 {
-	bool f = m_receiver->IsKeyDown(keycache.key[KeyType::FORWARD]),
-		b = m_receiver->IsKeyDown(keycache.key[KeyType::BACKWARD]),
-		l = m_receiver->IsKeyDown(keycache.key[KeyType::LEFT]),
-		r = m_receiver->IsKeyDown(keycache.key[KeyType::RIGHT]);
-	if (f || b || l || r)
-	{
-		// if contradictory keys pressed, stay still
-		if (f && b && l && r)
-			return 0.0f;
-		else if (f && b && !l && !r)
-			return 0.0f;
-		else if (!f && !b && l && r)
-			return 0.0f;
-		return 1.0f; // If there is a keyboard event, assume maximum speed
-	}
 	if (g_touchcontrols && g_touchcontrols->getMovementSpeed())
 		return g_touchcontrols->getMovementSpeed();
 	return joystick.getMovementSpeed();
@@ -244,23 +229,9 @@ float RealInputHandler::getMovementSpeed()
 
 float RealInputHandler::getMovementDirection()
 {
-	float x = 0, z = 0;
-
-	/* Check keyboard for input */
-	if (m_receiver->IsKeyDown(keycache.key[KeyType::FORWARD]))
-		z += 1;
-	if (m_receiver->IsKeyDown(keycache.key[KeyType::BACKWARD]))
-		z -= 1;
-	if (m_receiver->IsKeyDown(keycache.key[KeyType::RIGHT]))
-		x += 1;
-	if (m_receiver->IsKeyDown(keycache.key[KeyType::LEFT]))
-		x -= 1;
-
-	if (x != 0 || z != 0) /* If there is a keyboard event, it takes priority */
-		return std::atan2(x, z);
 	// `getMovementDirection() == 0` means forward, so we cannot use
 	// `getMovementDirection()` as a condition.
-	else if (g_touchcontrols && g_touchcontrols->getMovementSpeed())
+	if (g_touchcontrols && g_touchcontrols->getMovementSpeed())
 		return g_touchcontrols->getMovementDirection();
 	return joystick.getMovementDirection();
 }

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -247,8 +247,8 @@ public:
 	virtual bool wasKeyReleased(GameKeyType k) = 0;
 	virtual bool cancelPressed() = 0;
 
-	virtual float getMovementSpeed() = 0;
-	virtual float getMovementDirection() = 0;
+	virtual float getJoystickSpeed() = 0;
+	virtual float getJoystickDirection() = 0;
 
 	virtual void clearWasKeyPressed() {}
 	virtual void clearWasKeyReleased() {}
@@ -304,9 +304,9 @@ public:
 		return m_receiver->WasKeyReleased(keycache.key[k]) || joystick.wasKeyReleased(k);
 	}
 
-	virtual float getMovementSpeed();
+	virtual float getJoystickSpeed();
 
-	virtual float getMovementDirection();
+	virtual float getJoystickDirection();
 
 	virtual bool cancelPressed()
 	{
@@ -388,8 +388,8 @@ public:
 	virtual bool wasKeyPressed(GameKeyType k) { return false; }
 	virtual bool wasKeyReleased(GameKeyType k) { return false; }
 	virtual bool cancelPressed() { return false; }
-	virtual float getMovementSpeed() { return movementSpeed; }
-	virtual float getMovementDirection() { return movementDirection; }
+	virtual float getJoystickSpeed() { return joystickSpeed; }
+	virtual float getJoystickDirection() { return joystickDirection; }
 	virtual v2s32 getMousePos() { return mousepos; }
 	virtual void setMousePos(s32 x, s32 y) { mousepos = v2s32(x, y); }
 
@@ -403,6 +403,6 @@ private:
 	KeyList keydown;
 	v2s32 mousepos;
 	v2s32 mousespeed;
-	float movementSpeed;
-	float movementDirection;
+	float joystickSpeed;
+	float joystickDirection;
 };

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -105,6 +105,8 @@ public:
 	u8 last_camera_fov = 0;
 	u8 last_wanted_range = 0;
 	bool last_camera_inverted = false;
+	f32 last_movement_speed = 0.0f;
+	f32 last_movement_dir = 0.0f;
 
 	float camera_impact = 0.0f;
 

--- a/src/gui/touchcontrols.h
+++ b/src/gui/touchcontrols.h
@@ -163,8 +163,8 @@ public:
 	 */
 	line3d<f32> getShootline() { return m_shootline; }
 
-	float getMovementDirection() { return m_joystick_direction; }
-	float getMovementSpeed() { return m_joystick_speed; }
+	float getJoystickDirection() { return m_joystick_direction; }
+	float getJoystickSpeed() { return m_joystick_speed; }
 
 	void step(float dtime);
 	inline void setUseCrosshair(bool use_crosshair) { m_draw_crosshair = use_crosshair; }

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -962,6 +962,8 @@ enum ToServerCommand : u16
 		[2+12+12+4+4+4] u8 fov*80
 		[2+12+12+4+4+4+1] u8 ceil(wanted_range / MAP_BLOCKSIZE)
 		[2+12+12+4+4+4+1+1] u8 camera_inverted (bool)
+		[2+12+12+4+4+4+1+1+1] f32 movement_speed
+		[2+12+12+4+4+4+1+1+1+4] f32 movement_direction
 
 	*/
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -477,11 +477,23 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	u8 bits = 0; // bits instead of bool so it is extensible later
 
 	*pkt >> keyPressed;
+	player->control.unpackKeysPressed(keyPressed);
+
 	*pkt >> f32fov;
 	fov = (f32)f32fov / 80.0f;
 	*pkt >> wanted_range;
+
 	if (pkt->getRemainingBytes() >= 1)
 		*pkt >> bits;
+
+	if (pkt->getRemainingBytes() >= 8) {
+		*pkt >> player->control.movement_speed;
+		*pkt >> player->control.movement_direction;
+	} else {
+		player->control.movement_speed = 0.0f;
+		player->control.movement_direction = 0.0f;
+		player->control.setMovementFromKeys();
+	}
 
 	v3f position((f32)ps.X / 100.0f, (f32)ps.Y / 100.0f, (f32)ps.Z / 100.0f);
 	v3f speed((f32)ss.X / 100.0f, (f32)ss.Y / 100.0f, (f32)ss.Z / 100.0f);
@@ -500,8 +512,6 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	playersao->setFov(fov);
 	playersao->setWantedRange(wanted_range);
 	playersao->setCameraInverted(bits & 0x01);
-
-	player->control.unpackKeysPressed(keyPressed);
 
 	if (playersao->checkMovementCheat()) {
 		// Call callbacks

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -194,19 +194,19 @@ void PlayerControl::setMovementFromKeys()
 	}
 
 	// Check keyboard for input
-	float x = 0, z = 0;
+	float x = 0, y = 0;
 	if (a_up)
-		z += 1;
+		y += 1;
 	if (a_down)
-		z -= 1;
+		y -= 1;
 	if (a_left)
 		x -= 1;
 	if (a_right)
 		x += 1;
 
-	if (x != 0 || z != 0)
+	if (x != 0 || y != 0)
 		// If there is a keyboard event, it takes priority
-		movement_direction = std::atan2(x, z);
+		movement_direction = std::atan2(x, y);
 }
 
 #ifndef SERVER

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -173,6 +173,42 @@ u16 Player::getMaxHotbarItemcount()
 	return mainlist ? std::min(mainlist->getSize(), (u32) hud_hotbar_itemcount) : 0;
 }
 
+void PlayerControl::setMovementFromKeys()
+{
+	bool a_up = direction_keys & (1 << 0),
+		a_down = direction_keys & (1 << 1),
+		a_left = direction_keys & (1 << 2),
+		a_right = direction_keys & (1 << 3);
+
+	if (a_up || a_down || a_left || a_right)  {
+		// if contradictory keys pressed, stay still
+		if (a_up && a_down && a_left && a_right)
+			movement_speed = 0.0f;
+		else if (a_up && a_down && !a_left && !a_right)
+			movement_speed = 0.0f;
+		else if (!a_up && !a_down && a_left && a_right)
+			movement_speed =  0.0f;
+		else
+			// If there is a keyboard event, assume maximum speed
+			movement_speed = 1.0f;
+	}
+
+	// Check keyboard for input
+	float x = 0, z = 0;
+	if (a_up)
+		z += 1;
+	if (a_down)
+		z -= 1;
+	if (a_left)
+		x -= 1;
+	if (a_right)
+		x += 1;
+
+	if (x != 0 || z != 0)
+		// If there is a keyboard event, it takes priority
+		movement_direction = std::atan2(x, z);
+}
+
 #ifndef SERVER
 
 u32 PlayerControl::getKeysPressed() const
@@ -245,4 +281,9 @@ static auto tie(const PlayerPhysicsOverride &o)
 bool PlayerPhysicsOverride::operator==(const PlayerPhysicsOverride &other) const
 {
 	return tie(*this) == tie(other);
+}
+
+v2f PlayerControl::getMovement() const
+{
+	return v2f(sinf(movement_direction), cosf(movement_direction)) * movement_speed;
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -187,7 +187,7 @@ void PlayerControl::setMovementFromKeys()
 		else if (a_up && a_down && !a_left && !a_right)
 			movement_speed = 0.0f;
 		else if (!a_up && !a_down && a_left && a_right)
-			movement_speed =  0.0f;
+			movement_speed = 0.0f;
 		else
 			// If there is a keyboard event, assume maximum speed
 			movement_speed = 1.0f;
@@ -267,6 +267,11 @@ void PlayerControl::unpackKeysPressed(u32 keypress_bits)
 	zoom  = keypress_bits & (1 << 9);
 }
 
+v2f PlayerControl::getMovement() const
+{
+	return v2f(std::sin(movement_direction), std::cos(movement_direction)) * movement_speed;
+}
+
 static auto tie(const PlayerPhysicsOverride &o)
 {
 	// Make sure to add new members to this list!
@@ -281,9 +286,4 @@ static auto tie(const PlayerPhysicsOverride &o)
 bool PlayerPhysicsOverride::operator==(const PlayerPhysicsOverride &other) const
 {
 	return tie(*this) == tie(other);
-}
-
-v2f PlayerControl::getMovement() const
-{
-	return v2f(std::sin(movement_direction), std::cos(movement_direction)) * movement_speed;
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -285,5 +285,5 @@ bool PlayerPhysicsOverride::operator==(const PlayerPhysicsOverride &other) const
 
 v2f PlayerControl::getMovement() const
 {
-	return v2f(sinf(movement_direction), cosf(movement_direction)) * movement_speed;
+	return v2f(std::sin(movement_direction), std::cos(movement_direction)) * movement_speed;
 }

--- a/src/player.h
+++ b/src/player.h
@@ -86,6 +86,10 @@ struct PlayerControl
 		movement_direction = a_movement_direction;
 	}
 
+	// Sets movement_speed and movement_direction according to direction_keys
+	// if direction_keys != 0.
+	void setMovementFromKeys();
+
 #ifndef SERVER
 	// For client use
 	u32 getKeysPressed() const;
@@ -94,6 +98,7 @@ struct PlayerControl
 
 	// For server use
 	void unpackKeysPressed(u32 keypress_bits);
+	v2f getMovement() const;
 
 	u8 direction_keys = 0;
 	bool jump = false;
@@ -102,7 +107,7 @@ struct PlayerControl
 	bool zoom = false;
 	bool dig = false;
 	bool place = false;
-	// Note: These four are NOT available on the server
+	// Note: These two are NOT available on the server
 	float pitch = 0.0f;
 	float yaw = 0.0f;
 	float movement_speed = 0.0f;

--- a/src/player.h
+++ b/src/player.h
@@ -87,7 +87,8 @@ struct PlayerControl
 	}
 
 	// Sets movement_speed and movement_direction according to direction_keys
-	// if direction_keys != 0.
+	// if direction_keys != 0, otherwise leaves them unchanged to preserve
+	// joystick input.
 	void setMovementFromKeys();
 
 #ifndef SERVER

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -260,12 +260,13 @@ int LuaLocalPlayer::l_get_control(lua_State *L)
 	set("zoom",  c.zoom);
 	set("dig",   c.dig);
 	set("place", c.place);
-	// Player movement in polar coordinates and non-binary speed
-	lua_pushnumber(L, c.movement_speed);
-	lua_setfield(L, -2, "movement_speed");
-	lua_pushnumber(L, c.movement_direction);
-	lua_setfield(L, -2, "movement_direction");
-	// Provide direction keys to ensure compatibility
+
+	v2f movement = c.getMovement();
+	lua_pushnumber(L, movement.X);
+	lua_setfield(L, -2, "movement_x");
+	lua_pushnumber(L, movement.Y);
+	lua_setfield(L, -2, "movement_y");
+
 	set("up",    c.direction_keys & (1 << 0));
 	set("down",  c.direction_keys & (1 << 1));
 	set("left",  c.direction_keys & (1 << 2));

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1622,6 +1622,13 @@ int ObjectRef::l_get_player_control(lua_State *L)
 	lua_setfield(L, -2, "dig");
 	lua_pushboolean(L, control.place);
 	lua_setfield(L, -2, "place");
+
+	v2f movement = control.getMovement();
+	lua_pushnumber(L, movement.X);
+	lua_setfield(L, -2, "movement_x");
+	lua_pushnumber(L, movement.Y);
+	lua_setfield(L, -2, "movement_y");
+
 	// Legacy fields to ensure mod compatibility
 	lua_pushboolean(L, control.dig);
 	lua_setfield(L, -2, "LMB");


### PR DESCRIPTION
This PR exposes analog joystick input to the Lua API. This allows games like PRANG! to have better movement. It adds two new fields, `movement_x` and `movement_y`, to `player:get_player_control()`.

These fields are set according to keyboard input when not available:

- when an old client connects, this happens on the server
- when a new client connects and the player uses the keyboard, this happens on the client

## To do

This PR is a Ready for Review.

## How to test

Verify that keyboard input still works.

Install PRANG! from ContentDB on an Android device and apply this patch:

```diff
diff --git a/mods/prang/init.lua b/mods/prang/init.lua
index e45550a..aadd301 100644
--- a/mods/prang/init.lua
+++ b/mods/prang/init.lua
@@ -586,11 +586,8 @@ function Player:tick(game, dtime, controls)
         speed = speed * (8/3)
     end
 
-    local dx = get_direction(speed, controls.left, controls.right)
-    local dy = get_direction(speed, controls.up, controls.down)
-    if dx ~= 0 and dy ~= 0 then
-        dx, dy = dx / sqrt_2, dy / sqrt_2
-    end
+    local dx = controls.movement_x * speed
+    local dy = -controls.movement_y * speed
     self:move(dx, dy)
 end
 
```

Play PRANG! and enjoy the virtual analog joystick. (Should probably use `math.ceil` here.)