### PR TITLE
Fix minimap textures overwrite

### DIFF
--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -206,25 +206,6 @@ Minimap::Minimap(Client *client)
 
 	data->minimap_shape_round = g_settings->getBool("minimap_shape_round");
 
-	// Get round minimap textures
-	data->minimap_mask_round = driver->createImage(
-		m_tsrc->getTexture("minimap_mask_round.png"),
-		core::position2d<s32>(0, 0),
-		core::dimension2d<u32>(MINIMAP_MAX_SX, MINIMAP_MAX_SY));
-	data->minimap_overlay_round = m_tsrc->getTexture("minimap_overlay_round.png");
-
-	// Get square minimap textures
-	data->minimap_mask_square = driver->createImage(
-		m_tsrc->getTexture("minimap_mask_square.png"),
-		core::position2d<s32>(0, 0),
-		core::dimension2d<u32>(MINIMAP_MAX_SX, MINIMAP_MAX_SY));
-	data->minimap_overlay_square = m_tsrc->getTexture("minimap_overlay_square.png");
-
-	// Create player marker texture
-	data->player_marker = m_tsrc->getTexture("player_marker.png");
-	// Create object marker texture
-	data->object_marker_red = m_tsrc->getTexture("object_marker_red.png");
-
 	setModeIndex(0);
 
 	// Create mesh buffer for minimap
@@ -243,8 +224,10 @@ Minimap::~Minimap()
 
 	m_meshbuffer->drop();
 
-	data->minimap_mask_round->drop();
-	data->minimap_mask_square->drop();
+	if (data->minimap_mask_round)
+		data->minimap_mask_round->drop();
+	if (data->minimap_mask_square)
+		data->minimap_mask_square->drop();
 
 	driver->removeTexture(data->texture);
 	driver->removeTexture(data->heightmap_texture);
@@ -461,6 +444,29 @@ void Minimap::blitMinimapPixelsToImageSurface(
 	}
 }
 
+video::IImage *Minimap::getMinimapMask()
+{
+	if (data->minimap_shape_round) {
+		if (not data->minimap_mask_round) {
+			// Get round minimap textures
+			data->minimap_mask_round = driver->createImage(
+				m_tsrc->getTexture("minimap_mask_round.png"),
+				core::position2d<s32>(0, 0),
+				core::dimension2d<u32>(MINIMAP_MAX_SX, MINIMAP_MAX_SY));
+		}
+		return data->minimap_mask_round;
+	}
+
+	if (not data->minimap_mask_square) {
+		// Get square minimap textures
+		data->minimap_mask_square = driver->createImage(
+			m_tsrc->getTexture("minimap_mask_square.png"),
+			core::position2d<s32>(0, 0),
+			core::dimension2d<u32>(MINIMAP_MAX_SX, MINIMAP_MAX_SY));
+	}
+	return data->minimap_mask_square;
+}
+
 video::ITexture *Minimap::getMinimapTexture()
 {
 	// update minimap textures when new scan is ready
@@ -509,16 +515,13 @@ video::ITexture *Minimap::getMinimapTexture()
 	map_image->copyToScaling(minimap_image);
 	map_image->drop();
 
-	video::IImage *minimap_mask = data->minimap_shape_round ?
-		data->minimap_mask_round : data->minimap_mask_square;
+	video::IImage *minimap_mask = getMinimapMask();
 
-	if (minimap_mask) {
-		for (s16 y = 0; y < MINIMAP_MAX_SY; y++)
-		for (s16 x = 0; x < MINIMAP_MAX_SX; x++) {
-			const video::SColor &mask_col = minimap_mask->getPixel(x, y);
-			if (!mask_col.getAlpha())
-				minimap_image->setPixel(x, y, video::SColor(0,0,0,0));
-		}
+	for (s16 y = 0; y < MINIMAP_MAX_SY; y++)
+	for (s16 x = 0; x < MINIMAP_MAX_SX; x++) {
+		const video::SColor &mask_col = minimap_mask->getPixel(x, y);
+		if (!mask_col.getAlpha())
+			minimap_image->setPixel(x, y, video::SColor(0,0,0,0));
 	}
 
 	if (data->texture)
@@ -571,14 +574,22 @@ scene::SMeshBuffer *Minimap::getMinimapMeshBuffer()
 	return buf;
 }
 
-void Minimap::drawMinimap(core::rect<s32> rect) {
+void Minimap::drawMinimap(core::rect<s32> rect)
+{
+	if (data->mode.type == MINIMAP_TYPE_OFF)
+		return;
 
+	// Get textures
 	video::ITexture *minimap_texture = getMinimapTexture();
 	if (!minimap_texture)
 		return;
-
-	if (data->mode.type == MINIMAP_TYPE_OFF)
-		return;
+	if (not data->textures_initialised) {
+		data->minimap_overlay_round = m_tsrc->getTexture("minimap_overlay_round.png");
+		data->minimap_overlay_square = m_tsrc->getTexture("minimap_overlay_square.png");
+		data->player_marker = m_tsrc->getTexture("player_marker.png");
+		data->object_marker_red = m_tsrc->getTexture("object_marker_red.png");
+		data->textures_initialised = true;
+	}
 
 	updateActiveMarkers();
 
@@ -689,8 +700,7 @@ void Minimap::removeMarker(MinimapMarker **m)
 
 void Minimap::updateActiveMarkers()
 {
-	video::IImage *minimap_mask = data->minimap_shape_round ?
-		data->minimap_mask_round : data->minimap_mask_square;
+	video::IImage *minimap_mask = getMinimapMask();
 
 	m_active_markers.clear();
 	v3f cam_offset = intToFloat(client->getCamera()->getOffset(), BS);

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -447,7 +447,7 @@ void Minimap::blitMinimapPixelsToImageSurface(
 video::IImage *Minimap::getMinimapMask()
 {
 	if (data->minimap_shape_round) {
-		if (not data->minimap_mask_round) {
+		if (!data->minimap_mask_round) {
 			// Get round minimap textures
 			data->minimap_mask_round = driver->createImage(
 				m_tsrc->getTexture("minimap_mask_round.png"),
@@ -457,7 +457,7 @@ video::IImage *Minimap::getMinimapMask()
 		return data->minimap_mask_round;
 	}
 
-	if (not data->minimap_mask_square) {
+	if (!data->minimap_mask_square) {
 		// Get square minimap textures
 		data->minimap_mask_square = driver->createImage(
 			m_tsrc->getTexture("minimap_mask_square.png"),
@@ -583,7 +583,7 @@ void Minimap::drawMinimap(core::rect<s32> rect)
 	video::ITexture *minimap_texture = getMinimapTexture();
 	if (!minimap_texture)
 		return;
-	if (not data->textures_initialised) {
+	if (!data->textures_initialised) {
 		data->minimap_overlay_round = m_tsrc->getTexture("minimap_overlay_round.png");
 		data->minimap_overlay_square = m_tsrc->getTexture("minimap_overlay_square.png");
 		data->player_marker = m_tsrc->getTexture("player_marker.png");

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -78,8 +78,8 @@ struct MinimapData {
 	video::IImage *minimap_mask_round = nullptr;
 	video::IImage *minimap_mask_square = nullptr;
 	video::ITexture *texture = nullptr;
-	bool textures_initialised = false; // True if the following textures are not nullptrs.
 	video::ITexture *heightmap_texture = nullptr;
+	bool textures_initialised = false; // True if the following textures are not nullptrs.
 	video::ITexture *minimap_overlay_round = nullptr;
 	video::ITexture *minimap_overlay_square = nullptr;
 	video::ITexture *player_marker = nullptr;

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -78,6 +78,7 @@ struct MinimapData {
 	video::IImage *minimap_mask_round = nullptr;
 	video::IImage *minimap_mask_square = nullptr;
 	video::ITexture *texture = nullptr;
+	bool textures_initialised = false; // True if the following textures are not nullptrs.
 	video::ITexture *heightmap_texture = nullptr;
 	video::ITexture *minimap_overlay_round = nullptr;
 	video::ITexture *minimap_overlay_square = nullptr;
@@ -140,6 +141,7 @@ public:
 
 	MinimapModeDef getModeDef() const { return data->mode; }
 
+	video::IImage *getMinimapMask();
 	video::ITexture *getMinimapTexture();
 
 	void blitMinimapPixelsToImageRadar(video::IImage *map_image);


### PR DESCRIPTION
## Goal of the PR
- Fix #3098

## How does the PR work?

### What causes this bug.

I did some debugging and found out what causes this bug
It's not a loading priority issue, but a loading order/cache issue.
(The code is very entangled and hard to understand, so no surprise that it hasn't been fixed for almost 6 years.)

It happens with `player_marker.png` and not with`heart.png`, since for `player_marker.png`  `TextureSource::getTexture` is called before `Client::loadMedia` has been executed.

So when you block the first execution of `TextureSource::getTexture` to not cache it, you get the overridden texture, but for the minimap it still uses the texture from the first execution.

### How it is fixed.

To fix this, the minimap must not initialize its textures before the `ClientMediaDownloader` has loaded the media.
So with this PR the minimap does no longer use `getTexture` in the constructor, which is called at the same time as the client is constructed.

## To do

This PR is Ready for Review.

## How to test

Put some textures into a mod textures folders and see if they got overridden.
Those can be overridden.
```
minimap_overlay_round.png
minimap_overlay_square.png
player_marker.png
object_marker_red.png
minimap_mask_round.png
minimap_mask_square.png
```