### PR TITLE
Rename MINETEST_SUBGAME_PATH to MINETEST_GAME_PATH

### DIFF
--- a/doc/minetest.6
+++ b/doc/minetest.6
@@ -119,7 +119,7 @@ Display an interactive terminal over ncurses during execution.
 
 .SH ENVIRONMENT
 .TP
-.B MINETEST_SUBGAME_PATH
+.B MINETEST_GAME_PATH
 Colon delimited list of directories to search for games.
 .TP
 .B MINETEST_MOD_PATH

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -78,7 +78,13 @@ struct GameFindPath
 std::string getSubgamePathEnv()
 {
 	char *subgame_path = getenv("MINETEST_SUBGAME_PATH");
-	return subgame_path ? std::string(subgame_path) : "";
+	if (subgame_path) {
+		warningstream << "MINETEST_SUBGAME_PATH is deprecated, use MINETEST_GAME_PATH instead."
+				<< std::endl;
+	}
+
+	char *game_path = getenv("MINETEST_GAME_PATH");
+	return game_path ? std::string(game_path) : subgame_path ? std::string(subgame_path) : "";
 }
 
 SubgameSpec findSubgame(const std::string &id)


### PR DESCRIPTION
Resolves #12036
(There is still a lot of subgame terminology inside minetest which is not visible from outside.)

## To do

This PR is Ready for Review.

## How to test
```
export MINETEST_GAME_PATH=<mypath1>
export MINETEST_SUBGAME_PATH=<mypath2>
./bin/minetest
```