### PR TITLE
Add L-system trees as decorations

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -37,6 +37,7 @@ core.features = {
 	blocking_pointability_type = true,
 	dynamic_add_media_startup = true,
 	dynamic_add_media_filepath = true,
+	lsystem_decoration_type = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -10261,20 +10261,9 @@ See [Decoration types]. Used by `minetest.register_decoration`.
     -- Ignored by 'y_min', 'y_max' and 'spawn_by' checks, which always refer
     -- to the 'place_on' node.
 
-    treedef = {
-		axiom="FFFFFAFFBF",
-		rules_a="[&&&FFFFF&&FFFF][&&&++++FFFFF&&FFFF][&&&----FFFFF&&FFFF]",
-		rules_b="[&&&++FFFFF&&FFFF][&&&--FFFFF&&FFFF][&&&------FFFFF&&FFFF]",
-		trunk="default:tree",
-		leaves="default:leaves",
-		angle=30,
-		iterations=2,
-		random_level=0,
-		trunk_type="single",
-		thin_branches=true,
-		fruit_chance=10,
-		fruit="default:apple"
-	},
+    ----- L-system-type parameters
+
+    treedef = {},
     -- Same as for `minetest.spawn_tree`.
     -- See section [L-system trees] for more details.
 }

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4519,10 +4519,10 @@ structures, such as trees, cave spikes, rocks, and so on.
 
 `lsystem`
 -----------
+
 Generates a L-system tree at the position where the decoration is placed.
 Uses the same L-system as `minetest.spawn_tree`, but is faster than using it manually.
 The `treedef` field in the decoration definition is used for the tree definition.
-
 
 
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5366,6 +5366,8 @@ Utilities
       dynamic_add_media_startup = true,
       -- dynamic_add_media supports `filename` and `filedata` parameters (5.9.0)
       dynamic_add_media_filepath = true,
+       -- L-system decoration type (5.9.0)
+      lsystem_decoration_type = true,
   }
   ```
 
@@ -6017,7 +6019,7 @@ Environment access
 * `minetest.add_entity(pos, name, [staticdata])`: Spawn Lua-defined entity at
   position.
     * Returns `ObjectRef`, or `nil` if failed
-    * Entities with `static_save = true` can be added also 
+    * Entities with `static_save = true` can be added also
       to unloaded and non-generated blocks.
 * `minetest.add_item(pos, item)`: Spawn item
     * Returns `ObjectRef`, or `nil` if failed

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4517,6 +4517,12 @@ Can specify a probability of a node randomly appearing when placed.
 This decoration type is intended to be used for multi-node sized discrete
 structures, such as trees, cave spikes, rocks, and so on.
 
+`lsystem`
+-----------
+Generates a L-system tree at the position where the decoration is placed.
+Uses the same L-system as `minetest.spawn_tree`, but is faster than using it manually.
+The `treedef` field in the decoration definition is used for the tree definition.
+
 
 
 
@@ -10101,7 +10107,7 @@ See [Decoration types]. Used by `minetest.register_decoration`.
 ```lua
 {
     deco_type = "simple",
-    -- Type. "simple" or "schematic" supported
+    -- Type. "simple", "schematic" or "lsystem" supported
 
     place_on = "default:dirt_with_grass",
     -- Node (or list of nodes) that the decoration can be placed on
@@ -10254,6 +10260,23 @@ See [Decoration types]. Used by `minetest.register_decoration`.
     -- Effect is inverted for "all_ceilings" decorations.
     -- Ignored by 'y_min', 'y_max' and 'spawn_by' checks, which always refer
     -- to the 'place_on' node.
+
+    treedef = {
+		axiom="FFFFFAFFBF",
+		rules_a="[&&&FFFFF&&FFFF][&&&++++FFFFF&&FFFF][&&&----FFFFF&&FFFF]",
+		rules_b="[&&&++FFFFF&&FFFF][&&&--FFFFF&&FFFF][&&&------FFFFF&&FFFF]",
+		trunk="default:tree",
+		leaves="default:leaves",
+		angle=30,
+		iterations=2,
+		random_level=0,
+		trunk_type="single",
+		thin_branches=true,
+		fruit_chance=10,
+		fruit="default:apple"
+	},
+    -- Same as for `minetest.spawn_tree`.
+    -- See section [L-system trees] for more details.
 }
 ```
 

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -489,5 +489,8 @@ size_t DecoLSystem::generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling)
 {
 	if (!canPlaceDecoration(vm, p))
 		return 0;
-	return treegen::make_ltree(*vm, p, m_ndef, *tree_def);
+
+	// Make sure that tree_def can't be overridden, since it is shared.
+	const auto &ref = *tree_def;
+	return treegen::make_ltree(*vm, p, m_ndef, ref);
 }

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -491,9 +491,3 @@ size_t DecoLSystem::generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling)
 		return 0;
 	return treegen::make_ltree(*vm, p, m_ndef, *tree_def);
 }
-
-void DecoLSystem::resolveNodeNames()
-{
-	Decoration::resolveNodeNames();
-	tree_def->resolveNodeNames();
-}

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -490,7 +490,7 @@ size_t DecoLSystem::generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling)
 	if (!canPlaceDecoration(vm, p))
 		return 0;
 
-	// Make sure that tree_def can't be overridden, since it is shared.
+	// Make sure that tree_def can't be modified, since it is shared.
 	const auto &ref = *tree_def;
 	return treegen::make_ltree(*vm, p, m_ndef, ref);
 }

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -472,3 +472,21 @@ size_t DecoSchematic::generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceilin
 
 	return 1;
 }
+
+///////////////////////////////////////////////////////////////////////////////
+ObjDef *DecoLSystem::clone() const
+{
+	auto def = new DecoLSystem();
+	Decoration::cloneTo(def);
+
+	def->ndef = ndef;
+
+	def->tree_def = tree_def;
+	return def;
+}
+
+
+size_t DecoLSystem::generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling)
+{
+	return treegen::make_ltree(*vm, p, ndef, tree_def);
+}

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h"
 #include <algorithm>
 #include <vector>
+#include "mapgen/treegen.h"
 
 
 FlagDesc flagdesc_deco[] = {
@@ -486,5 +487,5 @@ ObjDef *DecoLSystem::clone() const
 
 size_t DecoLSystem::generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling)
 {
-	return treegen::make_ltree(*vm, p, m_ndef, tree_def);
+	return treegen::make_ltree(*vm, p, m_ndef, *tree_def);
 }

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -487,5 +487,13 @@ ObjDef *DecoLSystem::clone() const
 
 size_t DecoLSystem::generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling)
 {
+	if (!canPlaceDecoration(vm, p))
+		return 0;
 	return treegen::make_ltree(*vm, p, m_ndef, *tree_def);
+}
+
+void DecoLSystem::resolveNodeNames()
+{
+	Decoration::resolveNodeNames();
+	tree_def->resolveNodeNames();
 }

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -479,8 +479,6 @@ ObjDef *DecoLSystem::clone() const
 	auto def = new DecoLSystem();
 	Decoration::cloneTo(def);
 
-	def->ndef = ndef;
-
 	def->tree_def = tree_def;
 	return def;
 }
@@ -488,5 +486,5 @@ ObjDef *DecoLSystem::clone() const
 
 size_t DecoLSystem::generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling)
 {
-	return treegen::make_ltree(*vm, p, ndef, tree_def);
+	return treegen::make_ltree(*vm, p, m_ndef, tree_def);
 }

--- a/src/mapgen/mg_decoration.h
+++ b/src/mapgen/mg_decoration.h
@@ -117,6 +117,7 @@ class DecoLSystem : public Decoration {
 public:
 	ObjDef *clone() const;
 
+	virtual void resolveNodeNames();
 	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling);
 
 	// In case it gets cloned it uses the same tree def.

--- a/src/mapgen/mg_decoration.h
+++ b/src/mapgen/mg_decoration.h
@@ -117,7 +117,6 @@ class DecoLSystem : public Decoration {
 public:
 	ObjDef *clone() const;
 
-	virtual void resolveNodeNames();
 	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling);
 
 	// In case it gets cloned it uses the same tree def.

--- a/src/mapgen/mg_decoration.h
+++ b/src/mapgen/mg_decoration.h
@@ -119,7 +119,6 @@ public:
 
 	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling);
 
-	const NodeDefManager *ndef;
 	treegen::TreeDef tree_def;
 };
 

--- a/src/mapgen/mg_decoration.h
+++ b/src/mapgen/mg_decoration.h
@@ -24,7 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "objdef.h"
 #include "noise.h"
 #include "nodedef.h"
-#include "mapgen/treegen.h"
 
 typedef u16 biome_t;  // copy from mg_biome.h to avoid an unnecessary include
 
@@ -32,6 +31,7 @@ class Mapgen;
 class MMVManip;
 class PcgRandom;
 class Schematic;
+namespace treegen { struct TreeDef; }
 
 enum DecorationType {
 	DECO_SIMPLE,
@@ -119,7 +119,8 @@ public:
 
 	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling);
 
-	treegen::TreeDef tree_def;
+	// In case it gets cloned it uses the same tree def.
+	std::shared_ptr<treegen::TreeDef> tree_def;
 };
 
 

--- a/src/mapgen/mg_decoration.h
+++ b/src/mapgen/mg_decoration.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "objdef.h"
 #include "noise.h"
 #include "nodedef.h"
+#include "mapgen/treegen.h"
 
 typedef u16 biome_t;  // copy from mg_biome.h to avoid an unnecessary include
 
@@ -112,12 +113,15 @@ public:
 };
 
 
-/*
 class DecoLSystem : public Decoration {
 public:
-	virtual void generate(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
+	ObjDef *clone() const;
+
+	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling);
+
+	const NodeDefManager *ndef;
+	treegen::TreeDef tree_def;
 };
-*/
 
 
 class DecorationManager : public ObjDefManager {
@@ -139,8 +143,8 @@ public:
 			return new DecoSimple;
 		case DECO_SCHEMATIC:
 			return new DecoSchematic;
-		//case DECO_LSYSTEM:
-		//	return new DecoLSystem;
+		case DECO_LSYSTEM:
+			return new DecoLSystem;
 		default:
 			return NULL;
 		}

--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -34,12 +34,12 @@ namespace treegen
 
 void TreeDef::resolveNodeNames()
 {
-	getIdFromNrBacklog(&trunknode.param0, "", CONTENT_IGNORE, false);
-	getIdFromNrBacklog(&leavesnode.param0, "", CONTENT_IGNORE, false);
-	if(leaves2_chance)
-		getIdFromNrBacklog(&leaves2node.param0, "", CONTENT_IGNORE, false);
-	if(fruit_chance)
-		getIdFromNrBacklog(&fruitnode.param0, "", CONTENT_IGNORE, false);
+	getIdFromNrBacklog(&trunknode.param0, "", CONTENT_IGNORE);
+	getIdFromNrBacklog(&leavesnode.param0, "", CONTENT_IGNORE);
+	if (leaves2_chance)
+		getIdFromNrBacklog(&leaves2node.param0, "", CONTENT_IGNORE);
+	if (fruit_chance)
+		getIdFromNrBacklog(&fruitnode.param0, "", CONTENT_IGNORE);
 }
 
 void make_tree(MMVManip &vmanip, v3s16 p0, bool is_apple_tree,

--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -34,12 +34,12 @@ namespace treegen
 
 void TreeDef::resolveNodeNames()
 {
-	getIdFromNrBacklog(&trunknode.param0, "", CONTENT_IGNORE);
-	getIdFromNrBacklog(&leavesnode.param0, "", CONTENT_IGNORE);
+	getIdFromNrBacklog(&trunknode.param0, "", CONTENT_UNKNOWN);
+	getIdFromNrBacklog(&leavesnode.param0, "", CONTENT_UNKNOWN);
 	if (leaves2_chance)
-		getIdFromNrBacklog(&leaves2node.param0, "", CONTENT_IGNORE);
+		getIdFromNrBacklog(&leaves2node.param0, "", CONTENT_UNKNOWN);
 	if (fruit_chance)
-		getIdFromNrBacklog(&fruitnode.param0, "", CONTENT_IGNORE);
+		getIdFromNrBacklog(&fruitnode.param0, "", CONTENT_UNKNOWN);
 }
 
 void make_tree(MMVManip &vmanip, v3s16 p0, bool is_apple_tree,

--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -34,12 +34,12 @@ namespace treegen
 
 void TreeDef::resolveNodeNames()
 {
-	getIdFromNrBacklog(&trunknode.param0, "", CONTENT_UNKNOWN);
-	getIdFromNrBacklog(&leavesnode.param0, "", CONTENT_UNKNOWN);
+	getIdFromNrBacklog(&trunknode.param0, "", CONTENT_IGNORE);
+	getIdFromNrBacklog(&leavesnode.param0, "", CONTENT_IGNORE);
 	if (leaves2_chance)
-		getIdFromNrBacklog(&leaves2node.param0, "", CONTENT_UNKNOWN);
+		getIdFromNrBacklog(&leaves2node.param0, "", CONTENT_IGNORE);
 	if (fruit_chance)
-		getIdFromNrBacklog(&fruitnode.param0, "", CONTENT_UNKNOWN);
+		getIdFromNrBacklog(&fruitnode.param0, "", CONTENT_IGNORE);
 }
 
 void make_tree(MMVManip &vmanip, v3s16 p0, bool is_apple_tree,

--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -34,8 +34,6 @@ namespace treegen
 
 void TreeDef::resolveNodeNames()
 {
-	sanity_check(m_ndef);
-
 	getIdFromNrBacklog(&trunknode.param0, "", CONTENT_IGNORE, false);
 	getIdFromNrBacklog(&leavesnode.param0, "", CONTENT_IGNORE, false);
 	if(leaves2_chance)

--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -32,6 +32,18 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace treegen
 {
 
+void TreeDef::resolveNodeNames()
+{
+	sanity_check(m_ndef);
+
+	getIdFromNrBacklog(&trunknode.param0, "", CONTENT_IGNORE, false);
+	getIdFromNrBacklog(&leavesnode.param0, "", CONTENT_IGNORE, false);
+	if(leaves2_chance)
+		getIdFromNrBacklog(&leaves2node.param0, "", CONTENT_IGNORE, false);
+	if(fruit_chance)
+		getIdFromNrBacklog(&fruitnode.param0, "", CONTENT_IGNORE, false);
+}
+
 void make_tree(MMVManip &vmanip, v3s16 p0, bool is_apple_tree,
 	const NodeDefManager *ndef, s32 seed)
 {

--- a/src/mapgen/treegen.h
+++ b/src/mapgen/treegen.h
@@ -35,7 +35,14 @@ namespace treegen {
 		UNBALANCED_BRACKETS
 	};
 
-	struct TreeDef {
+	struct TreeDef : public NodeResolver {
+		void resolveNodeNames();
+
+		// Needed since m_ndef can't be accessed in read_tree_def.
+		void setNodeDefManager(const NodeDefManager* ndef) {
+			NodeResolver::m_ndef = ndef;
+		}
+
 		std::string initial_axiom;
 		std::string rules_a;
 		std::string rules_b;

--- a/src/mapgen/treegen.h
+++ b/src/mapgen/treegen.h
@@ -36,12 +36,7 @@ namespace treegen {
 	};
 
 	struct TreeDef : public NodeResolver {
-		void resolveNodeNames();
-
-		// Needed since m_ndef can't be accessed in read_tree_def.
-		void setNodeDefManager(const NodeDefManager* ndef) {
-			NodeResolver::m_ndef = ndef;
-		}
+		virtual void resolveNodeNames();
 
 		std::string initial_axiom;
 		std::string rules_a;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -37,6 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "debug.h" // For FATAL_ERROR
 #include <SColor.h>
 #include <json/json.h>
+#include "mapgen/treegen.h"
 
 struct EnumString es_TileAnimationType[] =
 {

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2009,6 +2009,45 @@ void push_noiseparams(lua_State *L, NoiseParams *np)
 	lua_setfield(L, -2, "spread");
 }
 
+bool read_tree_def(lua_State *L, int idx, const NodeDefManager *ndef,
+		treegen::TreeDef &tree_def)
+{
+	std::string trunk, leaves, fruit;
+	if (!lua_istable(L, idx))
+		return false;
+
+	getstringfield(L, idx, "axiom", tree_def.initial_axiom);
+	getstringfield(L, idx, "rules_a", tree_def.rules_a);
+	getstringfield(L, idx, "rules_b", tree_def.rules_b);
+	getstringfield(L, idx, "rules_c", tree_def.rules_c);
+	getstringfield(L, idx, "rules_d", tree_def.rules_d);
+	getstringfield(L, idx, "trunk", trunk);
+	tree_def.trunknode = ndef->getId(trunk);
+	getstringfield(L, idx, "leaves", leaves);
+	tree_def.leavesnode = ndef->getId(leaves);
+	tree_def.leaves2_chance = 0;
+	getstringfield(L, idx, "leaves2", leaves);
+	if (!leaves.empty()) {
+		tree_def.leaves2node = ndef->getId(leaves);
+		getintfield(L, idx, "leaves2_chance", tree_def.leaves2_chance);
+	}
+	getintfield(L, idx, "angle", tree_def.angle);
+	getintfield(L, idx, "iterations", tree_def.iterations);
+	if (!getintfield(L, idx, "random_level", tree_def.iterations_random_level))
+		tree_def.iterations_random_level = 0;
+	getstringfield(L, idx, "trunk_type", tree_def.trunk_type);
+	getboolfield(L, idx, "thin_branches", tree_def.thin_branches);
+	tree_def.fruit_chance = 0;
+	getstringfield(L, idx, "fruit", fruit);
+	if (!fruit.empty()) {
+		tree_def.fruitnode = ndef->getId(fruit);
+		getintfield(L, idx, "fruit_chance", tree_def.fruit_chance);
+	}
+	tree_def.explicit_seed = getintfield(L, idx, "seed", tree_def.seed);
+
+	return true;
+}
+
 /******************************************************************************/
 // Returns depth of json value tree
 static int push_json_value_getdepth(const Json::Value &value)

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -70,6 +70,7 @@ struct NoiseParams;
 class Schematic;
 class ServerActiveObject;
 struct collisionMoveResult;
+namespace treegen { struct TreeDef; }
 
 extern struct EnumString es_TileAnimationType[];
 
@@ -188,6 +189,10 @@ bool               string_to_enum            (const EnumString *spec,
 bool               read_noiseparams          (lua_State *L, int index,
                                               NoiseParams *np);
 void               push_noiseparams          (lua_State *L, NoiseParams *np);
+
+bool               read_tree_def             (lua_State *L, int idx,
+                                              const NodeDefManager *ndef,
+                                              treegen::TreeDef &tree_def);
 
 void               luaentity_get             (lua_State *L,u16 id);
 

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -192,7 +192,8 @@ void               push_noiseparams          (lua_State *L, NoiseParams *np);
 
 bool               read_tree_def             (lua_State *L, int idx,
                                               const NodeDefManager *ndef,
-                                              treegen::TreeDef &tree_def);
+                                              treegen::TreeDef &tree_def,
+                                              bool unresolved = false);
 
 void               luaentity_get             (lua_State *L,u16 id);
 

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -192,8 +192,7 @@ void               push_noiseparams          (lua_State *L, NoiseParams *np);
 
 bool               read_tree_def             (lua_State *L, int idx,
                                               const NodeDefManager *ndef,
-                                              treegen::TreeDef &tree_def,
-                                              bool unresolved = false);
+                                              treegen::TreeDef &tree_def);
 
 void               luaentity_get             (lua_State *L,u16 id);
 

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1342,45 +1342,6 @@ int ModApiEnv::l_find_path(lua_State *L)
 	return 0;
 }
 
-bool ModApiEnvVM::read_tree_def(lua_State *L, int idx,
-	const NodeDefManager *ndef, treegen::TreeDef &tree_def)
-{
-	std::string trunk, leaves, fruit;
-	if (!lua_istable(L, idx))
-		return false;
-
-	getstringfield(L, idx, "axiom", tree_def.initial_axiom);
-	getstringfield(L, idx, "rules_a", tree_def.rules_a);
-	getstringfield(L, idx, "rules_b", tree_def.rules_b);
-	getstringfield(L, idx, "rules_c", tree_def.rules_c);
-	getstringfield(L, idx, "rules_d", tree_def.rules_d);
-	getstringfield(L, idx, "trunk", trunk);
-	tree_def.trunknode = ndef->getId(trunk);
-	getstringfield(L, idx, "leaves", leaves);
-	tree_def.leavesnode = ndef->getId(leaves);
-	tree_def.leaves2_chance = 0;
-	getstringfield(L, idx, "leaves2", leaves);
-	if (!leaves.empty()) {
-		tree_def.leaves2node = ndef->getId(leaves);
-		getintfield(L, idx, "leaves2_chance", tree_def.leaves2_chance);
-	}
-	getintfield(L, idx, "angle", tree_def.angle);
-	getintfield(L, idx, "iterations", tree_def.iterations);
-	if (!getintfield(L, idx, "random_level", tree_def.iterations_random_level))
-		tree_def.iterations_random_level = 0;
-	getstringfield(L, idx, "trunk_type", tree_def.trunk_type);
-	getboolfield(L, idx, "thin_branches", tree_def.thin_branches);
-	tree_def.fruit_chance = 0;
-	getstringfield(L, idx, "fruit", fruit);
-	if (!fruit.empty()) {
-		tree_def.fruitnode = ndef->getId(fruit);
-		getintfield(L, idx, "fruit_chance", tree_def.fruit_chance);
-	}
-	tree_def.explicit_seed = getintfield(L, idx, "seed", tree_def.seed);
-
-	return true;
-}
-
 // spawn_tree(pos, treedef)
 int ModApiEnv::l_spawn_tree(lua_State *L)
 {
@@ -1391,7 +1352,7 @@ int ModApiEnv::l_spawn_tree(lua_State *L)
 	treegen::TreeDef tree_def;
 	const NodeDefManager *ndef = env->getGameDef()->ndef();
 
-	if (!ModApiEnvVM::read_tree_def(L, 2, ndef, tree_def))
+	if (!read_tree_def(L, 2, ndef, tree_def))
 		return 0;
 
 	ServerMap *map = &env->getServerMap();

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1342,7 +1342,7 @@ int ModApiEnv::l_find_path(lua_State *L)
 	return 0;
 }
 
-static bool read_tree_def(lua_State *L, int idx,
+bool ModApiEnv::read_tree_def(lua_State *L, int idx,
 	const NodeDefManager *ndef, treegen::TreeDef &tree_def)
 {
 	std::string trunk, leaves, fruit;

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1342,7 +1342,7 @@ int ModApiEnv::l_find_path(lua_State *L)
 	return 0;
 }
 
-bool ModApiEnv::read_tree_def(lua_State *L, int idx,
+bool ModApiEnvVM::read_tree_def(lua_State *L, int idx,
 	const NodeDefManager *ndef, treegen::TreeDef &tree_def)
 {
 	std::string trunk, leaves, fruit;
@@ -1391,7 +1391,7 @@ int ModApiEnv::l_spawn_tree(lua_State *L)
 	treegen::TreeDef tree_def;
 	const NodeDefManager *ndef = env->getGameDef()->ndef();
 
-	if (!read_tree_def(L, 2, ndef, tree_def))
+	if (!ModApiEnvVM::read_tree_def(L, 2, ndef, tree_def))
 		return 0;
 
 	ServerMap *map = &env->getServerMap();

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -280,8 +280,6 @@ private:
 
 public:
 	static void InitializeEmerge(lua_State *L, int top);
-	static bool read_tree_def(lua_State *L, int idx,
-			const NodeDefManager *ndef, treegen::TreeDef &tree_def);
 };
 
 class LuaABM : public ActiveBlockModifier {

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -22,7 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_base.h"
 #include "serverenvironment.h"
 #include "raycast.h"
-#include "mapgen/treegen.h"
 
 // base class containing helpers
 class ModApiEnvBase : public ModApiBase {

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_base.h"
 #include "serverenvironment.h"
 #include "raycast.h"
+#include "mapgen/treegen.h"
 
 // base class containing helpers
 class ModApiEnvBase : public ModApiBase {
@@ -241,6 +242,8 @@ private:
 public:
 	static void Initialize(lua_State *L, int top);
 	static void InitializeClient(lua_State *L, int top);
+	static bool read_tree_def(lua_State *L, int idx,
+			const NodeDefManager *ndef, treegen::TreeDef &tree_def);
 };
 
 /*

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -245,7 +245,7 @@ public:
 
 /*
  * Duplicates of certain env APIs that operate not on the global
- * map but on a VoxelManipulator. This is for emerge scripting.
+ * map but on a VoxelManipulator. This is for emerge scripting. 
  */
 class ModApiEnvVM : public ModApiEnvBase {
 private:

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -242,13 +242,11 @@ private:
 public:
 	static void Initialize(lua_State *L, int top);
 	static void InitializeClient(lua_State *L, int top);
-	static bool read_tree_def(lua_State *L, int idx,
-			const NodeDefManager *ndef, treegen::TreeDef &tree_def);
 };
 
 /*
  * Duplicates of certain env APIs that operate not on the global
- * map but on a VoxelManipulator. This is for emerge scripting. 
+ * map but on a VoxelManipulator. This is for emerge scripting.
  */
 class ModApiEnvVM : public ModApiEnvBase {
 private:
@@ -282,6 +280,8 @@ private:
 
 public:
 	static void InitializeEmerge(lua_State *L, int top);
+	static bool read_tree_def(lua_State *L, int idx,
+			const NodeDefManager *ndef, treegen::TreeDef &tree_def);
 };
 
 class LuaABM : public ActiveBlockModifier {

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_mapgen.h"
 #include "lua_api/l_internal.h"
 #include "lua_api/l_vmanip.h"
+#include "lua_api/l_env.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include "cpp_api/s_security.h"
@@ -110,6 +111,7 @@ bool read_schematic_def(lua_State *L, int index,
 
 bool read_deco_simple(lua_State *L, DecoSimple *deco);
 bool read_deco_schematic(lua_State *L, SchematicManager *schemmgr, DecoSchematic *deco);
+bool read_deco_lsystem(lua_State *L, const NodeDefManager *ndef, DecoLSystem *deco);
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1226,6 +1228,7 @@ int ModApiMapgen::l_register_decoration(lua_State *L)
 		success = read_deco_schematic(L, schemmgr, (DecoSchematic *)deco);
 		break;
 	case DECO_LSYSTEM:
+		success = read_deco_lsystem(L, ndef, (DecoLSystem *)deco);
 		break;
 	}
 
@@ -1306,6 +1309,17 @@ bool read_deco_schematic(lua_State *L, SchematicManager *schemmgr, DecoSchematic
 
 	deco->schematic = schem;
 	return schem != NULL;
+}
+
+bool read_deco_lsystem(lua_State *L, const NodeDefManager *ndef, DecoLSystem *deco)
+{
+	deco->ndef = ndef;
+
+	lua_getfield(L, 1, "treedef");
+	bool has_def = ModApiEnv::read_tree_def(L, -1, ndef, deco->tree_def);
+	lua_pop(L, 1);
+
+	return has_def;
 }
 
 

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1316,7 +1316,7 @@ bool read_deco_lsystem(lua_State *L, const NodeDefManager *ndef, DecoLSystem *de
 	deco->tree_def = std::make_shared<treegen::TreeDef>();
 
 	lua_getfield(L, 1, "treedef");
-	bool has_def = read_tree_def(L, -1, ndef, *(deco->tree_def), true);
+	bool has_def = read_tree_def(L, -1, ndef, *(deco->tree_def));
 	lua_pop(L, 1);
 
 	return has_def;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1314,7 +1314,7 @@ bool read_deco_schematic(lua_State *L, SchematicManager *schemmgr, DecoSchematic
 bool read_deco_lsystem(lua_State *L, const NodeDefManager *ndef, DecoLSystem *deco)
 {
 	lua_getfield(L, 1, "treedef");
-	bool has_def = read_tree_def(L, -1, ndef, deco->tree_def);
+	bool has_def = read_tree_def(L, -1, ndef, *(deco->tree_def));
 	lua_pop(L, 1);
 
 	return has_def;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1314,7 +1314,7 @@ bool read_deco_schematic(lua_State *L, SchematicManager *schemmgr, DecoSchematic
 bool read_deco_lsystem(lua_State *L, const NodeDefManager *ndef, DecoLSystem *deco)
 {
 	lua_getfield(L, 1, "treedef");
-	bool has_def = ModApiEnvVM::read_tree_def(L, -1, ndef, deco->tree_def);
+	bool has_def = read_tree_def(L, -1, ndef, deco->tree_def);
 	lua_pop(L, 1);
 
 	return has_def;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1313,8 +1313,6 @@ bool read_deco_schematic(lua_State *L, SchematicManager *schemmgr, DecoSchematic
 
 bool read_deco_lsystem(lua_State *L, const NodeDefManager *ndef, DecoLSystem *deco)
 {
-	deco->ndef = ndef;
-
 	lua_getfield(L, 1, "treedef");
 	bool has_def = ModApiEnvVM::read_tree_def(L, -1, ndef, deco->tree_def);
 	lua_pop(L, 1);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -20,7 +20,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_mapgen.h"
 #include "lua_api/l_internal.h"
 #include "lua_api/l_vmanip.h"
-#include "lua_api/l_env.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include "cpp_api/s_security.h"
@@ -34,10 +33,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapgen/mg_schematic.h"
 #include "mapgen/mapgen_v5.h"
 #include "mapgen/mapgen_v7.h"
+#include "mapgen/treegen.h"
 #include "filesys.h"
 #include "settings.h"
 #include "log.h"
-#include "mapgen/treegen.h"
 
 struct EnumString ModApiMapgen::es_BiomeTerrainType[] =
 {

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1316,7 +1316,7 @@ bool read_deco_lsystem(lua_State *L, const NodeDefManager *ndef, DecoLSystem *de
 	deco->tree_def = std::make_shared<treegen::TreeDef>();
 
 	lua_getfield(L, 1, "treedef");
-	bool has_def = read_tree_def(L, -1, ndef, *(deco->tree_def));
+	bool has_def = read_tree_def(L, -1, ndef, *(deco->tree_def), true);
 	lua_pop(L, 1);
 
 	return has_def;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -37,6 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "settings.h"
 #include "log.h"
+#include "mapgen/treegen.h"
 
 struct EnumString ModApiMapgen::es_BiomeTerrainType[] =
 {
@@ -1313,6 +1314,8 @@ bool read_deco_schematic(lua_State *L, SchematicManager *schemmgr, DecoSchematic
 
 bool read_deco_lsystem(lua_State *L, const NodeDefManager *ndef, DecoLSystem *deco)
 {
+	deco->tree_def = std::make_shared<treegen::TreeDef>();
+
 	lua_getfield(L, 1, "treedef");
 	bool has_def = read_tree_def(L, -1, ndef, *(deco->tree_def));
 	lua_pop(L, 1);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1316,7 +1316,7 @@ bool read_deco_lsystem(lua_State *L, const NodeDefManager *ndef, DecoLSystem *de
 	deco->ndef = ndef;
 
 	lua_getfield(L, 1, "treedef");
-	bool has_def = ModApiEnv::read_tree_def(L, -1, ndef, deco->tree_def);
+	bool has_def = ModApiEnvVM::read_tree_def(L, -1, ndef, deco->tree_def);
 	lua_pop(L, 1);
 
 	return has_def;


### PR DESCRIPTION
## Goal of the PR
Resolves #7346

## How does it work
It uses the same L-system as `minetest.spawn_tree`, but it's faster since it uses the engine version of `make_ltree`, which directly writes it into the VoxelManipulator during map generation and does not trigger a light update. 

## Roadmap
It's listed at https://dev.minetest.net/TODO.

## To do

This PR is Ready for Review.

## How to test

Add some Decorations, e.g. in MTG.
(`aaa` is a good seed for v7)
```lua
minetest.register_decoration({
	name = "default:testdeco",
	deco_type = "lsystem",
	place_on = {"default:dirt_with_grass", "default:sand"},
	sidelen = 80,
	fill_ratio = 0.005,
	y_max = 31000,
	y_min = 1,
	treedef = {
		axiom="FFFFFA",
		rules_a="[&&&F][&&&++++F][&&&----F]",
		trunk="default:coral_skeleton",
		leaves="default:permafrost_with_stones",
		angle=30,
		iterations=2,
		random_level=0,
		trunk_type="single",
		thin_branches=true,
	},
})
```

Also test if alias work:

- replace `default:coral_skeleton` with `alias_test1`,
- replace `default:permafrost_with_stones` with `alias_test2`
- and add:

```lua
minetest.register_alias("alias_test1", "default:sand")
minetest.register_alias("alias_test2", "default:snow")
```
