### PR TITLE
Add Lua function to remove a registered decoration, fix #12881

### DIFF
--- a/src/objdef.cpp
+++ b/src/objdef.cpp
@@ -136,6 +136,19 @@ void ObjDefManager::clear()
 }
 
 
+void ObjDefManager::clearByName(const std::string &name)
+{
+	for (auto it = m_objects.begin(); it != m_objects.end(); ++it) {
+		auto obj = *it;
+		if (obj && !strcasecmp(name.c_str(), obj->name.c_str())) {
+			delete obj;
+			m_objects.erase(it);
+			break;
+		}
+	}
+}
+
+
 u32 ObjDefManager::validateHandle(ObjDefHandle handle) const
 {
 	ObjDefType type;

--- a/src/objdef.h
+++ b/src/objdef.h
@@ -78,6 +78,7 @@ public:
 	virtual const char *getObjectTitle() const { return "ObjDef"; }
 
 	virtual void clear();
+	virtual void clearByName(const std::string &name);
 	virtual ObjDef *getByName(const std::string &name) const;
 
 	//// Add new/get/set object definitions by handle

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1428,6 +1428,20 @@ int ModApiMapgen::l_clear_registered_decorations(lua_State *L)
 }
 
 
+// clear_decoration(name)
+int ModApiMapgen::l_clear_decoration(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	luaL_checktype(L, 1, LUA_TSTRING);
+	const char *name = lua_tostring(L, 1);
+
+	DecorationManager *dmgr =
+		getServer(L)->getEmergeManager()->getWritableDecorationManager();
+	dmgr->clearByName(name);
+	return 0;
+}
+
+
 // clear_registered_ores()
 int ModApiMapgen::l_clear_registered_ores(lua_State *L)
 {
@@ -1880,6 +1894,7 @@ void ModApiMapgen::Initialize(lua_State *L, int top)
 
 	API_FCT(clear_registered_biomes);
 	API_FCT(clear_registered_decorations);
+	API_FCT(clear_decoration);
 	API_FCT(clear_registered_ores);
 	API_FCT(clear_registered_schematics);
 

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -114,6 +114,9 @@ private:
 	// clear_registered_decorations()
 	static int l_clear_registered_decorations(lua_State *L);
 
+	// clear_decoration()
+	static int l_clear_decoration(lua_State *L);
+
 	// clear_registered_schematics()
 	static int l_clear_registered_schematics(lua_State *L);
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- The goal of this PR is to enable the removal of decorations through the Lua API, so they can be disabled or re-registered with altered parameters.
- This is done by implementing the new method `ObjDefManager::clearByName(const std::string &name)` and exposing it via the Lua function `clear_decoration(name)`.
- This resolves #12881
- If the issue falls under "API convenience", then this relates to the roadmap
- This feature facilitates the reuse of mods, as they can be included without forking and modifying them, while still being able to exclude unwanted features. I think this is in the same spirit as functions like `minetest.clear_craft()`. In my specific use case, the mod "moonflowers" depends on "default" to define nodes on which to place the flowers on. I want to decouple the mod from default by exposing a method to re-register the flower decoration while allowing overrides of `.place_on` and/or `.biomes`. 

## To do

This PR is Ready for Review.

- [ ] I'll gladly add documentation if this implementation is approved

## How to test
- Create a MTG world and look for a decoration, for example "default:dry_shrub"
- Close world, delete map.sqlite
- Include a mod that executes `minetest.clear_decoration("default:dry_shrub")`
- Log in to world to regenerate it, no more dry_shrub
