### PR TITLE
[no squash] Remove insecure environment from async and emerge environment

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6572,7 +6572,6 @@ Class instances that can be transferred between environments:
 Functions:
 * Standalone helpers such as logging, filesystem, encoding,
   hashing or compression APIs
-* `minetest.request_insecure_environment` (same restrictions apply)
 
 Variables:
 * `minetest.settings`
@@ -6641,7 +6640,6 @@ Classes:
 Functions:
 * Standalone helpers such as logging, filesystem, encoding,
   hashing or compression APIs
-* `minetest.request_insecure_environment` (same restrictions apply)
 * `minetest.get_biome_id`, `get_biome_name`, `get_heat`, `get_humidity`,
   `get_biome_data`, `get_mapgen_object`, `get_mapgen_params`, `get_mapgen_edges`,
   `get_mapgen_setting`, `get_noiseparams`, `get_decoration_id` and more

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -110,13 +110,29 @@ public:
 	Client* getClient();
 #endif
 
-	// IMPORTANT: these cannot be used for any security-related uses, they exist
-	// only to enrich error messages
+	// IMPORTANT: These cannot be used for any security-related uses, they exist
+	// only to enrich error messages.
 	const std::string &getOrigin() { return m_last_run_mod; }
 	void setOriginDirect(const char *origin);
 	void setOriginFromTableRaw(int index, const char *fxn);
 
+	// Returns the currently running mod, only during init time.
+	// The reason this is "insecure" is that mods can mess with each others code,
+	// so the boundary of who is responsible is fuzzy.
+	// Note: checking this against BUILTIN_MOD_NAME is always safe (not spoofable).
+	// returns "" on error
+	static std::string getCurrentModNameInsecure(lua_State *L);
+	// Returns the currently running mod, only during init time.
+	// This checks the Lua stack to only permit direct calls in the file
+	// scope. That way it is assured that it's really the mod it claims to be.
+	// returns "" on error
+	static std::string getCurrentModName(lua_State *L);
+
+#ifdef SERVER
+	inline void clientOpenLibs(lua_State *L) { assert(false); }
+#else
 	void clientOpenLibs(lua_State *L);
+#endif
 
 	// Check things that should be set by the builtin mod.
 	void checkSetByBuiltin();

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -82,8 +82,7 @@ EmergeThread *ModApiBase::getEmergeThread(lua_State *L)
 
 std::string ModApiBase::getCurrentModPath(lua_State *L)
 {
-	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
-	std::string current_mod_name = readParam<std::string>(L, -1, "");
+	std::string current_mod_name = ScriptApiBase::getCurrentModNameInsecure(L);
 	if (current_mod_name.empty())
 		return ".";
 

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -62,7 +62,11 @@ const static CSMFlagDesc flagdesc_csm_restriction[] = {
 // get_current_modname()
 int ModApiClient::l_get_current_modname(lua_State *L)
 {
-	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
+	std::string s = ScriptApiBase::getCurrentModNameInsecure(L);
+	if (!s.empty())
+		lua_pushstring(L, s.c_str());
+	else
+		lua_pushnil(L);
 	return 1;
 }
 
@@ -73,30 +77,6 @@ int ModApiClient::l_get_modpath(lua_State *L)
 	// Client mods use a virtual filesystem, see Client::scanModSubfolder()
 	std::string path = modname + ":";
 	lua_pushstring(L, path.c_str());
-	return 1;
-}
-
-// get_last_run_mod()
-int ModApiClient::l_get_last_run_mod(lua_State *L)
-{
-	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
-	std::string current_mod = readParam<std::string>(L, -1, "");
-	if (current_mod.empty()) {
-		lua_pop(L, 1);
-		lua_pushstring(L, getScriptApiBase(L)->getOrigin().c_str());
-	}
-	return 1;
-}
-
-// set_last_run_mod(modname)
-int ModApiClient::l_set_last_run_mod(lua_State *L)
-{
-	if (!lua_isstring(L, 1))
-		return 0;
-
-	const char *mod = lua_tostring(L, 1);
-	getScriptApiBase(L)->setOriginDirect(mod);
-	lua_pushboolean(L, true);
 	return 1;
 }
 
@@ -367,8 +347,6 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(send_chat_message);
 	API_FCT(clear_out_chat_queue);
 	API_FCT(get_player_names);
-	API_FCT(set_last_run_mod);
-	API_FCT(get_last_run_mod);
 	API_FCT(show_formspec);
 	API_FCT(send_respawn);
 	API_FCT(gettext);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -60,12 +60,6 @@ private:
 	// gettext(text)
 	static int l_gettext(lua_State *L);
 
-	// get_last_run_mod(n)
-	static int l_get_last_run_mod(lua_State *L);
-
-	// set_last_run_mod(modname)
-	static int l_set_last_run_mod(lua_State *L);
-
 	// get_node(pos)
 	static int l_get_node_or_nil(lua_State *L);
 

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -765,7 +765,7 @@ void ModApiUtil::InitializeAsync(lua_State *L, int top)
 	API_FCT(get_dir_list);
 	API_FCT(safe_file_write);
 
-	API_FCT(request_insecure_environment);
+	// no request_insecure_environment here! mod origins are not tracked securely here.
 
 	API_FCT(encode_base64);
 	API_FCT(decode_base64);

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -632,12 +632,10 @@ int ModApiUtil::l_get_last_run_mod(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
-	std::string current_mod = readParam<std::string>(L, -1, "");
-	if (current_mod.empty()) {
-		lua_pop(L, 1);
-		lua_pushstring(L, getScriptApiBase(L)->getOrigin().c_str());
-	}
+	std::string current_mod = ScriptApiBase::getCurrentModNameInsecure(L);
+	if (current_mod.empty())
+		current_mod = getScriptApiBase(L)->getOrigin();
+	lua_pushstring(L, current_mod.c_str());
 	return 1;
 }
 
@@ -734,6 +732,9 @@ void ModApiUtil::InitializeClient(lua_State *L, int top)
 	API_FCT(sha1);
 	API_FCT(colorspec_to_colorstring);
 	API_FCT(colorspec_to_bytes);
+
+	API_FCT(get_last_run_mod);
+	API_FCT(set_last_run_mod);
 
 	API_FCT(urlencode);
 


### PR DESCRIPTION
fixes https://github.com/minetest/minetest/pull/13092#discussion_r1488631900
since this affects the async environment too ~~we should create a security advisory~~ (done)

this situation does not have an obvious fix:
At the time `register_mapgen_script` is called the engine trusts the mod name. But this isn't safe because mods can (intentionally or unintentionally) call into each other's code.
* restricting `register_mapgen_script` to the top level (like `request_insecure_environment`) would be inconvenient
* in addition that still doesn't work if the mod registers a script at a global-writable location (e.g. world path)
* <i>alternatively</i>:
* the engine can tell which mod folder a file originated from
* but then the internal code needs to be reworked to differentiate between
  * "we know which mod is probably running" (`get_current_modname` would use this because it needs to stay working)
  * "we know which mod is running and trust this value" (requirement for `request_insecure_environment`)
* also quite inconvenient

So I chose to just remove the feature.

## To do

This PR is Ready for Review.

## How to test

1. make sure lua still works in general
2. make sure `request_insecure_environment` still works
