### PR TITLE
Don't use a reference for RaycastState::m_pointabilities

### DIFF
--- a/src/raycast.h
+++ b/src/raycast.h
@@ -55,7 +55,7 @@ public:
 
 	bool m_objects_pointable;
 	bool m_liquids_pointable;
-	const std::optional<Pointabilities> &m_pointabilities;
+	const std::optional<Pointabilities> m_pointabilities;
 
 	//! The code needs to search these nodes around the center node.
 	core::aabbox3d<s16> m_search_range { 0, 0, 0, 0, 0, 0 };


### PR DESCRIPTION
Lua raycasts init the pointabilities with nullopt:
`LuaRaycast *o = new LuaRaycast(core::line3d<f32>(pos1, pos2), objects, liquids, std::nullopt);`
Which of course has a too short lifetime.

(If you want to reduce copies, `shared_ptr<const Pointabilities>` might work.)

Bug introduced by #13992 (after my review :3).

## To do

This PR is a Ready for Review.

## How to test

* Compile with asan.
* Spawn the devtest `testentities:selectionbox` entity.
