### PR TITLE
Change how max_lag is calculated and reported

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2014,9 +2014,10 @@ ask_reconnect_on_crash (Ask to reconnect after crash) bool false
 
 [**Server/Env Performance]
 
-#    Length of a server tick and the interval at which objects are generally updated over
-#    network, stated in seconds.
-dedicated_server_step (Dedicated server step) float 0.09 0.0
+#    Length of a server tick (the interval at which everything is generally updated),
+#    stated in seconds.
+#    Does not apply to sessions hosted from the client menu.
+dedicated_server_step (Dedicated server step) float 0.09 0.0 1.0
 
 #    Whether players are shown to clients without any range limit.
 #    Deprecated, use the setting player_transfer_distance instead.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2781,10 +2781,16 @@ inline void Game::step(f32 dtime)
 				g_settings->getFloat("fps_max_unfocused") :
 				g_settings->getFloat("fps_max");
 		fps_max = std::max(fps_max, 1.0f);
-		float steplen = 1.0f / fps_max;
+		/*
+		 * Unless you have a barebones game, running the server at more than 60Hz
+		 * is hardly realistic and you're at the point of diminishing returns.
+		 * fps_max is also not necessarily anywhere near the FPS actually achieved
+		 * (also due to vsync).
+		 */
+		fps_max = std::min(fps_max, 60.0f);
 
 		server->setStepSettings(Server::StepSettings{
-				steplen,
+				1.0f / fps_max,
 				m_is_paused
 			});
 

--- a/src/server.h
+++ b/src/server.h
@@ -608,12 +608,14 @@ private:
 	MutexedVariable<std::string> m_async_fatal_error;
 
 	// Some timers
+	float m_time_of_day_send_timer = 0.0f;
 	float m_liquid_transform_timer = 0.0f;
 	float m_liquid_transform_every = 1.0f;
 	float m_masterserver_timer = 0.0f;
 	float m_emergethread_trigger_timer = 0.0f;
 	float m_savemap_timer = 0.0f;
 	IntervalLimiter m_map_timer_and_unload_interval;
+	IntervalLimiter m_max_lag_decrease;
 
 	// Environment
 	ServerEnvironment *m_env = nullptr;
@@ -660,12 +662,6 @@ private:
 
 	// The server mainly operates in this thread
 	ServerThread *m_thread = nullptr;
-
-	/*
-		Time related stuff
-	*/
-	// Timer for sending time of day over network
-	float m_time_of_day_send_timer = 0.0f;
 
 	/*
 	 	Client interface

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -367,7 +367,7 @@ public:
 	u32 getGameTime() const { return m_game_time; }
 
 	void reportMaxLagEstimate(float f) { m_max_lag_estimate = f; }
-	float getMaxLagEstimate() { return m_max_lag_estimate; }
+	float getMaxLagEstimate() const { return m_max_lag_estimate; }
 
 	std::set<v3s16>* getForceloadedBlocks() { return &m_active_blocks.m_forceloaded_list; }
 

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -350,12 +350,10 @@ class IntervalLimiter
 public:
 	IntervalLimiter() = default;
 
-	/*
-		dtime: time from last call to this method
-		wanted_interval: interval wanted
-		return value:
-			true: action should be skipped
-			false: action should be done
+	/**
+		@param dtime time from last call to this method
+		@param wanted_interval interval wanted
+		@return true if action should be done
 	*/
 	bool step(float dtime, float wanted_interval)
 	{


### PR DESCRIPTION
Note to first commit:
The max_lag estimate is also used to determine the lag "pool" for player movement verification.
Having this value halve itself in 5 minutes seemed quite excessive, I changed it to 1m. But it could be that this has unexpected negative effects (anticheat false-positives).

What does this actually fix: I noticed in #14375 that you can't really tell any useful information about server lag just from the log.

## To do

This PR is Ready for Review.
