### PR TITLE
Add ability to change language without a restart

### DIFF
--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -74,6 +74,19 @@ local REASON_UPDATE = "update"
 local REASON_DEPENDENCY = "dependency"
 
 
+function reset_contentdb()
+	store.load_ok = false
+	store.loading = false
+	store.load_error = false
+	store.packages = {}
+	store.packages_full = {}
+	store.packages_full_unordered = {}
+	store.aliases = {}
+	search_string = ""
+	cur_page = 1
+end
+
+
 local function get_download_url(package, reason)
 	local base_url = core.settings:get("contentdb_url")
 	local ret = base_url .. ("/packages/%s/releases/%d/download/"):format(

--- a/builtin/mainmenu/settings/components.lua
+++ b/builtin/mainmenu/settings/components.lua
@@ -163,6 +163,9 @@ function make.enum(setting)
 			self.resettable = core.settings:has(setting.name)
 
 			local labels = setting.option_labels or {}
+			if type(labels) == "function" then
+				labels = labels(self, setting, value)
+			end
 
 			local items = {}
 			for i, option in ipairs(setting.values) do
@@ -187,6 +190,14 @@ function make.enum(setting)
 			end
 
 			core.settings:set(setting.name, value)
+
+			if setting.name == "language" then
+				-- Refresh content to update translations
+				pkgmgr.refresh_globals()
+				pkgmgr.update_gamelist()
+				reset_contentdb()
+			end
+
 			return true
 		end,
 	}

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -15,6 +15,11 @@
 --with this program; if not, write to the Free Software Foundation, Inc.,
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+-- Capture translations without translating
+local function gettext_lazy(x)
+	return x
+end
+
 
 local component_funcs =  dofile(core.get_mainmenu_path() .. DIR_DELIM ..
 		"settings" .. DIR_DELIM .. "components.lua")
@@ -65,23 +70,23 @@ local change_keys = {
 
 add_page({
 	id = "accessibility",
-	title = fgettext_ne("Accessibility"),
+	title = gettext_lazy("Accessibility"),
 	content = {
 		"language",
-		{ heading = fgettext_ne("General") },
+		{ heading = gettext_lazy("General") },
 		"font_size",
 		"chat_font_size",
 		"gui_scaling",
 		"hud_scaling",
 		"show_nametag_backgrounds",
-		{ heading = fgettext_ne("Chat") },
+		{ heading = gettext_lazy("Chat") },
 		"console_height",
 		"console_alpha",
 		"console_color",
-		{ heading = fgettext_ne("Controls") },
+		{ heading = gettext_lazy("Controls") },
 		"autojump",
 		"safe_dig_and_place",
-		{ heading = fgettext_ne("Movement") },
+		{ heading = gettext_lazy("Movement") },
 		"arm_inertia",
 		"view_bobbing_amount",
 		"fall_bobbing_amount",
@@ -96,7 +101,7 @@ local function load_settingtypes()
 		if not page then
 			page = add_page({
 				id = (section or "general"):lower():gsub(" ", "_"),
-				title = section or fgettext_ne("General"),
+				title = section or gettext_lazy("General"),
 				section = section,
 				content = {},
 			})
@@ -120,7 +125,7 @@ local function load_settingtypes()
 			elseif entry.level == 2 then
 				ensure_page_started()
 				page.content[#page.content + 1] = {
-					heading = fgettext_ne(entry.readable_name or entry.name),
+					heading = entry.readable_name or entry.name,
 				}
 			end
 		else
@@ -153,68 +158,70 @@ end
 -- These must not be translated, as they need to show in the local
 -- language no matter the user's current language.
 -- This list must be kept in sync with src/unsupported_language_list.txt.
-get_setting_info("language").option_labels = {
-	[""] = fgettext_ne("(Use system language)"),
-	--ar = " [ar]", blacklisted
-	be = "Беларуская [be]",
-	bg = "Български [bg]",
-	ca = "Català [ca]",
-	cs = "Česky [cs]",
-	cy = "Cymraeg [cy]",
-	da = "Dansk [da]",
-	de = "Deutsch [de]",
-	--dv = " [dv]", blacklisted
-	el = "Ελληνικά [el]",
-	en = "English [en]",
-	eo = "Esperanto [eo]",
-	es = "Español [es]",
-	et = "Eesti [et]",
-	eu = "Euskara [eu]",
-	fi = "Suomi [fi]",
-	fil = "Wikang Filipino [fil]",
-	fr = "Français [fr]",
-	gd = "Gàidhlig [gd]",
-	gl = "Galego [gl]",
-	--he = " [he]", blacklisted
-	--hi = " [hi]", blacklisted
-	hu = "Magyar [hu]",
-	id = "Bahasa Indonesia [id]",
-	it = "Italiano [it]",
-	ja = "日本語 [ja]",
-	jbo = "Lojban [jbo]",
-	kk = "Қазақша [kk]",
-	--kn = " [kn]", blacklisted
-	ko = "한국어 [ko]",
-	ky = "Kırgızca / Кыргызча [ky]",
-	lt = "Lietuvių [lt]",
-	lv = "Latviešu [lv]",
-	mn = "Монгол [mn]",
-	mr = "मराठी [mr]",
-	ms = "Bahasa Melayu [ms]",
-	--ms_Arab = " [ms_Arab]", blacklisted
-	nb = "Norsk Bokmål [nb]",
-	nl = "Nederlands [nl]",
-	nn = "Norsk Nynorsk [nn]",
-	oc = "Occitan [oc]",
-	pl = "Polski [pl]",
-	pt = "Português [pt]",
-	pt_BR = "Português do Brasil [pt_BR]",
-	ro = "Română [ro]",
-	ru = "Русский [ru]",
-	sk = "Slovenčina [sk]",
-	sl = "Slovenščina [sl]",
-	sr_Cyrl = "Српски [sr_Cyrl]",
-	sr_Latn = "Srpski (Latinica) [sr_Latn]",
-	sv = "Svenska [sv]",
-	sw = "Kiswahili [sw]",
-	--th = " [th]", blacklisted
-	tr = "Türkçe [tr]",
-	tt = "Tatarça [tt]",
-	uk = "Українська [uk]",
-	vi = "Tiếng Việt [vi]",
-	zh_CN = "中文 (简体) [zh_CN]",
-	zh_TW = "正體中文 (繁體) [zh_TW]",
-}
+get_setting_info("language").option_labels = function()
+	return {
+		[""] = fgettext_ne("(Use system language)"),
+		--ar = " [ar]", blacklisted
+		be = "Беларуская [be]",
+		bg = "Български [bg]",
+		ca = "Català [ca]",
+		cs = "Česky [cs]",
+		cy = "Cymraeg [cy]",
+		da = "Dansk [da]",
+		de = "Deutsch [de]",
+		--dv = " [dv]", blacklisted
+		el = "Ελληνικά [el]",
+		en = "English [en]",
+		eo = "Esperanto [eo]",
+		es = "Español [es]",
+		et = "Eesti [et]",
+		eu = "Euskara [eu]",
+		fi = "Suomi [fi]",
+		fil = "Wikang Filipino [fil]",
+		fr = "Français [fr]",
+		gd = "Gàidhlig [gd]",
+		gl = "Galego [gl]",
+		--he = " [he]", blacklisted
+		--hi = " [hi]", blacklisted
+		hu = "Magyar [hu]",
+		id = "Bahasa Indonesia [id]",
+		it = "Italiano [it]",
+		ja = "日本語 [ja]",
+		jbo = "Lojban [jbo]",
+		kk = "Қазақша [kk]",
+		--kn = " [kn]", blacklisted
+		ko = "한국어 [ko]",
+		ky = "Kırgızca / Кыргызча [ky]",
+		lt = "Lietuvių [lt]",
+		lv = "Latviešu [lv]",
+		mn = "Монгол [mn]",
+		mr = "मराठी [mr]",
+		ms = "Bahasa Melayu [ms]",
+		--ms_Arab = " [ms_Arab]", blacklisted
+		nb = "Norsk Bokmål [nb]",
+		nl = "Nederlands [nl]",
+		nn = "Norsk Nynorsk [nn]",
+		oc = "Occitan [oc]",
+		pl = "Polski [pl]",
+		pt = "Português [pt]",
+		pt_BR = "Português do Brasil [pt_BR]",
+		ro = "Română [ro]",
+		ru = "Русский [ru]",
+		sk = "Slovenčina [sk]",
+		sl = "Slovenščina [sl]",
+		sr_Cyrl = "Српски [sr_Cyrl]",
+		sr_Latn = "Srpski (Latinica) [sr_Latn]",
+		sv = "Svenska [sv]",
+		sw = "Kiswahili [sw]",
+		--th = " [th]", blacklisted
+		tr = "Türkçe [tr]",
+		tt = "Tatarça [tt]",
+		uk = "Українська [uk]",
+		vi = "Tiếng Việt [vi]",
+		zh_CN = "中文 (简体) [zh_CN]",
+		zh_TW = "正體中文 (繁體) [zh_TW]",
+	}
+end
 
 
 -- See if setting matches keywords
@@ -420,7 +427,7 @@ local function build_page_components(page)
 		elseif item.get_formspec then
 			retval[i] = item
 		elseif item.heading then
-			retval[i] = component_funcs.heading(item.heading)
+			retval[i] = component_funcs.heading(fgettext_ne(item.heading))
 		end
 	end
 	return retval

--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -116,7 +116,9 @@ end
 
 return {
 	name = "about",
-	caption = fgettext("About"),
+	caption = function()
+		return fgettext("About")
+	end,
 
 	cbf_formspec = function(tabview, name, tabdata)
 		local logofile = defaulttexturedir .. "logo.png"

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -459,7 +459,9 @@ end
 --------------------------------------------------------------------------------
 return {
 	name = "local",
-	caption = fgettext("Start Game"),
+	caption = function()
+		return fgettext("Start Game")
+	end ,
 	cbf_formspec = get_formspec,
 	cbf_button_handler = main_button_handler,
 	on_change = on_change

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -425,7 +425,9 @@ end
 
 return {
 	name = "online",
-	caption = fgettext("Join Game"),
+	caption = function()
+		return fgettext("Join Game")
+	end,
 	cbf_formspec = get_formspec,
 	cbf_button_handler = main_button_handler,
 	on_change = on_change

--- a/src/gettext.h
+++ b/src/gettext.h
@@ -46,6 +46,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 void init_gettext(const char *path, const std::string &configured_language,
 	int argc, char *argv[]);
 
+/**
+ * Change the language
+ *
+ * @param configured_language Language code
+ */
+void set_gettext_language(std::string configured_language);
+
 inline std::string strgettext(const char *str)
 {
 	// We must check here that is not an empty string to avoid trying to translate it

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -708,6 +708,10 @@ static bool init_common(const Settings &cmd_args, int argc, char *argv[])
 	init_gettext(porting::path_locale.c_str(),
 		g_settings->get("language"), argc, argv);
 
+	g_settings->registerChangedCallback("language", [](auto _name, auto _data) {
+		set_gettext_language(g_settings->get("language"));
+	});
+
 	return true;
 }
 

--- a/util/updatepo.sh
+++ b/util/updatepo.sh
@@ -58,6 +58,7 @@ xgettext --package-name=minetest \
 	--keyword=fwgettext \
 	--keyword=fgettext \
 	--keyword=fgettext_ne \
+	--keyword=gettext_lazy \
 	--keyword=strgettext \
 	--keyword=wstrgettext \
 	--keyword=core.gettext \


### PR DESCRIPTION
This allows changing the current language without restarting Minetest. Gettext reads the `language` env var for every call, so we just need to change this and notify gettext about the change

## To do

This PR is  Ready for Review.

## How to test

* Set system language to non-English, ie French
* Clear minetest.conf
* Open Minetest, see in French language
* Change Minetest language setting to German. See it change to German
* Change Minetest language setting back to (Use system language). See French

