### PR TITLE
Implement get_node with a get_node_raw

### DIFF
--- a/builtin/common/item_s.lua
+++ b/builtin/common/item_s.lua
@@ -239,18 +239,3 @@ if core.set_read_node and core.set_push_node then
 	core.set_push_node(push_node)
 	core.set_push_node = nil
 end
-
-if INIT == "game" then
-	local get_node_raw = core.get_node_raw
-	core.get_node_raw = nil
-
-	function core.get_node(pos)
-		local content, param1, param2 = get_node_raw(pos.x, pos.y, pos.z)
-		return {name = content2name[content], param1 = param1, param2 = param2}
-	end
-
-	function core.get_node_or_nil(pos)
-		local content, param1, param2, pos_ok = get_node_raw(pos.x, pos.y, pos.z)
-		return pos_ok and {name = content2name[content], param1 = param1, param2 = param2} or nil
-	end
-end

--- a/builtin/common/item_s.lua
+++ b/builtin/common/item_s.lua
@@ -239,3 +239,18 @@ if core.set_read_node and core.set_push_node then
 	core.set_push_node(push_node)
 	core.set_push_node = nil
 end
+
+if INIT == "game" then
+	local get_node_raw = core.get_node_raw
+	core.get_node_raw = nil
+
+	function core.get_node(pos)
+		local content, param1, param2 = get_node_raw(pos.x, pos.y, pos.z)
+		return {name = content2name[content], param1 = param1, param2 = param2}
+	end
+
+	function core.get_node_or_nil(pos)
+		local content, param1, param2, pos_ok = get_node_raw(pos.x, pos.y, pos.z)
+		return pos_ok and {name = content2name[content], param1 = param1, param2 = param2} or nil
+	end
+end

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -736,3 +736,22 @@ core.noneitemdef_default = {  -- This is used for the hand and unknown items
 	on_drop = nil,
 	on_use = nil,
 }
+
+--
+-- get_node implementation
+--
+
+local get_node_raw = core.get_node_raw
+core.get_node_raw = nil
+
+function core.get_node(pos)
+	local content, param1, param2 = get_node_raw(pos.x, pos.y, pos.z)
+	return {name = core.get_name_from_content_id(content), param1 = param1, param2 = param2}
+end
+
+function core.get_node_or_nil(pos)
+	local content, param1, param2, pos_ok = get_node_raw(pos.x, pos.y, pos.z)
+	return pos_ok and
+			{name = core.get_name_from_content_id(content), param1 = param1, param2 = param2}
+			or nil
+end

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -330,6 +330,7 @@ int ModApiEnv::l_get_node_raw(lua_State *L)
 	GET_ENV_PTR;
 
 	// pos
+	// mirrors implementation of read_v3s16 (with the exact same rounding)
 	double x = lua_tonumber(L, 1);
 	double y = lua_tonumber(L, 2);
 	double z = lua_tonumber(L, 3);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -324,39 +324,25 @@ int ModApiEnv::l_swap_node(lua_State *L)
 	return 1;
 }
 
-// get_node(pos)
-// pos = {x=num, y=num, z=num}
-int ModApiEnv::l_get_node(lua_State *L)
+// get_node_raw(x, y, z) -> content, param1, param2, pos_ok
+int ModApiEnv::l_get_node_raw(lua_State *L)
 {
 	GET_ENV_PTR;
 
 	// pos
-	v3s16 pos = read_v3s16(L, 1);
-	// Do it
-	MapNode n = env->getMap().getNode(pos);
-	// Return node
-	pushnode(L, n);
-	return 1;
-}
-
-// get_node_or_nil(pos)
-// pos = {x=num, y=num, z=num}
-int ModApiEnv::l_get_node_or_nil(lua_State *L)
-{
-	GET_ENV_PTR;
-
-	// pos
-	v3s16 pos = read_v3s16(L, 1);
+	double x = lua_tonumber(L, 1);
+	double y = lua_tonumber(L, 2);
+	double z = lua_tonumber(L, 3);
+	v3s16 pos = doubleToInt(v3d(x, y, z), 1.0);
 	// Do it
 	bool pos_ok;
 	MapNode n = env->getMap().getNode(pos, &pos_ok);
-	if (pos_ok) {
-		// Return node
-		pushnode(L, n);
-	} else {
-		lua_pushnil(L);
-	}
-	return 1;
+	// Return node and pos_ok
+	lua_pushinteger(L, n.getContent());
+	lua_pushinteger(L, n.getParam1());
+	lua_pushinteger(L, n.getParam2());
+	lua_pushboolean(L, pos_ok);
+	return 4;
 }
 
 // get_node_light(pos, timeofday)
@@ -1479,8 +1465,7 @@ void ModApiEnv::Initialize(lua_State *L, int top)
 	API_FCT(swap_node);
 	API_FCT(add_item);
 	API_FCT(remove_node);
-	API_FCT(get_node);
-	API_FCT(get_node_or_nil);
+	API_FCT(get_node_raw);
 	API_FCT(get_node_light);
 	API_FCT(get_natural_light);
 	API_FCT(place_node);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -76,6 +76,7 @@ private:
 
 	// get_node_raw(x, y, z) -> content, param1, param2, pos_ok
 	// Used to implement get_node and get_node_or_nil in lua.
+	// This is still faster than doing it from C++ even with optimized pushnode.
 	static int l_get_node_raw(lua_State *L);
 
 	// get_node_light(pos, timeofday)

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -74,13 +74,9 @@ private:
 	// pos = {x=num, y=num, z=num}
 	static int l_swap_node(lua_State *L);
 
-	// get_node(pos)
-	// pos = {x=num, y=num, z=num}
-	static int l_get_node(lua_State *L);
-
-	// get_node_or_nil(pos)
-	// pos = {x=num, y=num, z=num}
-	static int l_get_node_or_nil(lua_State *L);
+	// get_node_raw(x, y, z) -> content, param1, param2, pos_ok
+	// Used to implement get_node and get_node_or_nil in lua.
+	static int l_get_node_raw(lua_State *L);
 
 	// get_node_light(pos, timeofday)
 	// pos = {x=num, y=num, z=num}
@@ -245,7 +241,7 @@ public:
 
 /*
  * Duplicates of certain env APIs that operate not on the global
- * map but on a VoxelManipulator. This is for emerge scripting. 
+ * map but on a VoxelManipulator. This is for emerge scripting.
  */
 class ModApiEnvVM : public ModApiEnvBase {
 private:


### PR DESCRIPTION
* Goal: Improve performance of `get_node`.
* How: `get_node` is implemented in builtin with a `get_node_raw(x, y, z) -> content, param1, param2, pos_ok`.
* Why is this beneficial: In master, `get_node` calls lua functions to push nodes, and to read vectors. This is much faster if done in lua.

Flamegraphs:
master:
![master](https://github.com/minetest/minetest/assets/7613443/a1ef4f4d-690b-43be-9052-71036cb1b21d)
PR:
![pr](https://github.com/minetest/minetest/assets/7613443/c648813a-38cf-41c8-80c7-b07fc17c0c75)

Rough benchmark results:
master: 450-850 ms
PR: around 270-300 ms (it's *much* more persistent, idk why)

Benchmark function adopted from #14225 by @sfence. (Added you as co-author. :))

## To do

This PR is a Ready for Review.

## How to test

* `/bench_bulk_get_node`
* TODO: Do we have unit tests for `get_node` and `get_node_or_nil`?


Here's some instructions I've noted down at some point to disable cpu scaling, for better testing:
<details>

```
info:
	https://www.kernel.org/doc/html/v5.11/admin-guide/pm/cpufreq.html
	https://wiki.archlinux.org/index.php/CPU_frequency_scaling


check:
	sudo cpupower frequency-info
	watch grep \"cpu MHz\" /proc/cpuinfo


cpu-scaling off:
	sudo sh -c "echo 0 > /sys/devices/system/cpu/cpufreq/boost"
	sudo cpupower frequency-set -g userspace
	sudo cpupower frequency-set -f 1600MHz

cpu-scaling on:
	sudo cpupower frequency-set -g schedutil
	sudo sh -c "echo 1 > /sys/devices/system/cpu/cpufreq/boost"
```

</details>