### PR TITLE
Restore pre-5.9.0-dev behavior of touch_use_crosshair=false shootline

### DIFF
--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -981,7 +981,9 @@ void TouchScreenGUI::step(float dtime)
 	// thus the camera position can change, it doesn't suffice to update the
 	// shootline when a touch event occurs.
 	// Note that the shootline isn't used if touch_use_crosshair is enabled.
-	if (!m_draw_crosshair) {
+	// Only updating when m_has_move_id means that the shootline will stay at
+	// it's last in-world position when the player doesn't need it.
+	if (!m_draw_crosshair && m_has_move_id) {
 		v2s32 pointer_pos = getPointerPos();
 		m_shootline = m_device
 				->getSceneManager()
@@ -1050,6 +1052,8 @@ v2s32 TouchScreenGUI::getPointerPos()
 {
 	if (m_draw_crosshair)
 		return v2s32(m_screensize.X / 2, m_screensize.Y / 2);
+	// We can't just use m_pointer_pos[m_move_id] because applyContextControls
+	// may emit release events after m_pointer_pos[m_move_id] is erased.
 	return m_move_pos;
 }
 

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -246,6 +246,8 @@ private:
 	size_t m_move_id;
 	bool m_move_has_really_moved = false;
 	u64 m_move_downtime = 0;
+	// m_move_pos stays valid even after m_move_id has been released.
+	v2s32 m_move_pos;
 
 	bool m_has_joystick_id = false;
 	size_t m_joystick_id;
@@ -281,16 +283,6 @@ private:
 			const rect<s32> &button_rect, int texture_id,
 			bool visible = true);
 
-	struct id_status
-	{
-		size_t id;
-		int X;
-		int Y;
-	};
-
-	// vector to store known ids and their initial touch positions
-	std::vector<id_status> m_known_ids;
-
 	// handle a button event
 	void handleButtonEvent(touch_gui_button_id bID, size_t eventID, bool action);
 
@@ -303,7 +295,7 @@ private:
 	// apply joystick status
 	void applyJoystickStatus();
 
-	// array for saving last known position of a pointer
+	// map to store the IDs and positions of currently pressed pointers
 	std::unordered_map<size_t, v2s32> m_pointer_pos;
 
 	// settings bar


### PR DESCRIPTION
On Android with `touch_use_crosshair=false`, if you move the camera, release your finger again and then put your finger on any on-screen button or the joystick, the shootline will be updated according to the new position of your finger. This happens because Android reuses pointer IDs.

This bug was introduced by #14087. This PR fixes it by storing the position of the pointer used for the shootline separately.

We can't just use a zero-length shootline after the pointer is released because that breaks short-tapping.

## To do

This PR is a Ready for Review.

## How to test

As described above:

1. Play Minetest on Android with `touch_use_crosshair=false`
2. Start moving the camera
3. Release your finger
4. Put your finger on the joystick

before this PR: the shootline is updated to start behind the joystick
after this PR: the shootline stays the same
