### PR TITLE
[manual merge] VBO-related optimizations and improvements

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1816,10 +1816,6 @@ video_driver (Video driver) enum  ,opengl,opengl3,ogles1,ogles2
 #    Use this to limit the performance impact of transparency depth sorting
 transparency_sorting_distance (Transparency Sorting Distance) int 16 0 128
 
-#    Enable vertex buffer objects.
-#    This should greatly improve graphics performance.
-enable_vbo (VBO) bool true
-
 #    Radius of cloud area stated in number of 64 node cloud squares.
 #    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.
 cloud_radius (Cloud radius) int 12 1 62

--- a/client/shaders/cloud_shader/opengl_fragment.glsl
+++ b/client/shaders/cloud_shader/opengl_fragment.glsl
@@ -1,0 +1,6 @@
+varying lowp vec4 varColor;
+
+void main(void)
+{
+	gl_FragColor = varColor;
+}

--- a/client/shaders/cloud_shader/opengl_fragment.glsl
+++ b/client/shaders/cloud_shader/opengl_fragment.glsl
@@ -1,6 +1,17 @@
+uniform vec4 fogColor;
+uniform float fogDistance;
+uniform float fogShadingParameter;
+varying vec3 eyeVec;
+
 varying lowp vec4 varColor;
 
 void main(void)
 {
-	gl_FragColor = varColor;
+	vec4 col = varColor;
+
+	float clarity = clamp(fogShadingParameter
+		- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
+	col.rgb = mix(fogColor.rgb, col.rgb, clarity);
+
+	gl_FragColor = col;
 }

--- a/client/shaders/cloud_shader/opengl_vertex.glsl
+++ b/client/shaders/cloud_shader/opengl_vertex.glsl
@@ -2,6 +2,8 @@ uniform vec4 emissiveColor;
 
 varying lowp vec4 varColor;
 
+varying vec3 eyeVec;
+
 void main(void)
 {
 	gl_Position = mWorldViewProj * inVertexPosition;
@@ -13,6 +15,7 @@ void main(void)
 #endif
 
 	color *= emissiveColor;
-
 	varColor = color;
+
+	eyeVec = -(mWorldView * inVertexPosition).xyz;
 }

--- a/client/shaders/cloud_shader/opengl_vertex.glsl
+++ b/client/shaders/cloud_shader/opengl_vertex.glsl
@@ -1,0 +1,18 @@
+uniform vec4 emissiveColor;
+
+varying lowp vec4 varColor;
+
+void main(void)
+{
+	gl_Position = mWorldViewProj * inVertexPosition;
+
+#ifdef GL_ES
+	vec4 color = inVertexColor.bgra;
+#else
+	vec4 color = inVertexColor;
+#endif
+
+	color *= emissiveColor;
+
+	varColor = color;
+}

--- a/client/shaders/stars_shader/opengl_fragment.glsl
+++ b/client/shaders/stars_shader/opengl_fragment.glsl
@@ -1,6 +1,6 @@
-uniform vec4 starColor;
+uniform vec4 emissiveColor;
 
 void main(void)
 {
-	gl_FragColor = starColor;
+	gl_FragColor = emissiveColor;
 }

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -43,7 +43,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	CAOShaderConstantSetter
 */
 
-//! Shader constant setter for passing material emissive color to the CAO object_shader
+// Shader constant setter for passing material emissive color to a shader
+// Used by:
+// - CAO shader
+// - cloud shader
 class CAOShaderConstantSetter : public IShaderConstantSetter
 {
 public:
@@ -51,7 +54,6 @@ public:
 
 	void onSetConstants(video::IMaterialRendererServices *services) override
 	{
-		// Ambient color
 		video::SColorf emissive_color(m_emissive_color);
 
 		float as_array[4] = {

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -40,55 +40,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/renderingengine.h"
 
 /*
-	CAOShaderConstantSetter
-*/
-
-// Shader constant setter for passing material emissive color to a shader
-// Used by:
-// - CAO shader
-// - cloud shader
-class CAOShaderConstantSetter : public IShaderConstantSetter
-{
-public:
-	~CAOShaderConstantSetter() override = default;
-
-	void onSetConstants(video::IMaterialRendererServices *services) override
-	{
-		video::SColorf emissive_color(m_emissive_color);
-
-		float as_array[4] = {
-			emissive_color.r,
-			emissive_color.g,
-			emissive_color.b,
-			emissive_color.a,
-		};
-		m_emissive_color_setting.set(as_array, services);
-	}
-
-	void onSetMaterial(const video::SMaterial& material) override
-	{
-		m_emissive_color = material.EmissiveColor;
-	}
-
-private:
-	video::SColor m_emissive_color;
-	CachedPixelShaderSetting<float, 4>
-		m_emissive_color_setting{"emissiveColor"};
-};
-
-class CAOShaderConstantSetterFactory : public IShaderConstantSetterFactory
-{
-public:
-	CAOShaderConstantSetterFactory()
-	{}
-
-	virtual IShaderConstantSetter* create()
-	{
-		return new CAOShaderConstantSetter();
-	}
-};
-
-/*
 	ClientEnvironment
 */
 
@@ -99,8 +50,6 @@ ClientEnvironment::ClientEnvironment(ClientMap *map,
 	m_texturesource(texturesource),
 	m_client(client)
 {
-	auto *shdrsrc = m_client->getShaderSource();
-	shdrsrc->addShaderConstantSetterFactory(new CAOShaderConstantSetterFactory());
 }
 
 ClientEnvironment::~ClientEnvironment()

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -107,7 +107,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 		return false;
 	}
 
-	if (m_rendering_engine->get_video_driver() == NULL) {
+	if (!m_rendering_engine->get_video_driver()) {
 		errorstream << "Could not initialize video driver." << std::endl;
 		return false;
 	}
@@ -125,51 +125,16 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 		setAttribute(scene::ALLOW_ZWRITE_ON_TRANSPARENT, true);
 
 	guienv = m_rendering_engine->get_gui_env();
-	skin = guienv->getSkin();
-	skin->setColor(gui::EGDC_WINDOW_SYMBOL, video::SColor(255, 255, 255, 255));
-	skin->setColor(gui::EGDC_BUTTON_TEXT, video::SColor(255, 255, 255, 255));
-	skin->setColor(gui::EGDC_3D_LIGHT, video::SColor(0, 0, 0, 0));
-	skin->setColor(gui::EGDC_3D_HIGH_LIGHT, video::SColor(255, 30, 30, 30));
-	skin->setColor(gui::EGDC_3D_SHADOW, video::SColor(255, 0, 0, 0));
-	skin->setColor(gui::EGDC_HIGH_LIGHT, video::SColor(255, 70, 120, 50));
-	skin->setColor(gui::EGDC_HIGH_LIGHT_TEXT, video::SColor(255, 255, 255, 255));
-
-	float density = rangelim(g_settings->getFloat("gui_scaling"), 0.5, 20) *
-		RenderingEngine::getDisplayDensity();
-	skin->setSize(gui::EGDS_CHECK_BOX_WIDTH, (s32)(17.0f * density));
-	skin->setSize(gui::EGDS_SCROLLBAR_SIZE, (s32)(14.0f * density));
-	skin->setSize(gui::EGDS_WINDOW_BUTTON_WIDTH, (s32)(15.0f * density));
-	if (density > 1.5f) {
-		std::string sprite_path = porting::path_share + "/textures/base/pack/";
-		if (density > 3.5f)
-			sprite_path.append("checkbox_64.png");
-		else if (density > 2.0f)
-			sprite_path.append("checkbox_32.png");
-		else
-			sprite_path.append("checkbox_16.png");
-		// Texture dimensions should be a power of 2
-		gui::IGUISpriteBank *sprites = skin->getSpriteBank();
-		video::IVideoDriver *driver = m_rendering_engine->get_video_driver();
-		video::ITexture *sprite_texture = driver->getTexture(sprite_path.c_str());
-		if (sprite_texture) {
-			s32 sprite_id = sprites->addTextureAsSprite(sprite_texture);
-			if (sprite_id != -1)
-				skin->setIcon(gui::EGDI_CHECK_BOX_CHECKED, sprite_id);
-		}
-	}
+	init_guienv(guienv);
 
 	g_fontengine = new FontEngine(guienv);
-	FATAL_ERROR_IF(g_fontengine == NULL, "Font engine creation failed.");
-
-	// Irrlicht 1.8 input colours
-	skin->setColor(gui::EGDC_EDITABLE, video::SColor(255, 128, 128, 128));
-	skin->setColor(gui::EGDC_FOCUSED_EDITABLE, video::SColor(255, 96, 134, 49));
+	FATAL_ERROR_IF(!g_fontengine, "Font engine creation failed.");
 
 	// Create the menu clouds
-	if (!g_menucloudsmgr)
-		g_menucloudsmgr = m_rendering_engine->get_scene_manager()->createNewSceneManager();
-	if (!g_menuclouds)
-		g_menuclouds = new Clouds(g_menucloudsmgr, nullptr, -1, rand());
+	// This is only global so it can be used by RenderingEngine::draw_load_screen().
+	assert(!g_menucloudsmgr && !g_menuclouds);
+	g_menucloudsmgr = m_rendering_engine->get_scene_manager()->createNewSceneManager();
+	g_menuclouds = new Clouds(g_menucloudsmgr, nullptr, -1, rand());
 	g_menuclouds->setHeight(100.0f);
 	g_menuclouds->update(v3f(0, 0, 0), video::SColor(255, 240, 240, 255));
 	scene::ICameraSceneNode* camera;
@@ -223,7 +188,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 			guiroot = m_rendering_engine->get_gui_env()->addStaticText(L"",
 				core::rect<s32>(0, 0, 10000, 10000));
 
-			bool game_has_run = launch_game(error_message, reconnect_requested,
+			bool should_run_game = launch_game(error_message, reconnect_requested,
 				start_data, cmd_args);
 
 			// Reset the reconnect_requested flag
@@ -232,22 +197,17 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 			// If skip_main_menu, we only want to startup once
 			if (skip_main_menu && !first_loop)
 				break;
-
 			first_loop = false;
 
-			if (!game_has_run) {
+			if (!should_run_game) {
 				if (skip_main_menu)
 					break;
-
 				continue;
 			}
 
 			// Break out of menu-game loop to shut down cleanly
 			if (!m_rendering_engine->run() || *kill)
 				break;
-
-			m_rendering_engine->get_video_driver()->setTextureCreationFlag(
-					video::ETCF_CREATE_MIP_MAPS, g_settings->getBool("mip_map"));
 
 			if (g_settings->getBool("enable_touch")) {
 				receiver->m_touchscreengui = new TouchScreenGUI(m_rendering_engine->get_raw_device(), receiver);
@@ -301,17 +261,18 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 
 		// If no main menu, show error and exit
 		if (skip_main_menu) {
-			if (!error_message.empty()) {
-				verbosestream << "error_message = "
-				              << error_message << std::endl;
+			if (!error_message.empty())
 				retval = false;
-			}
 			break;
 		}
 	} // Menu-game loop
 
+	assert(g_menuclouds->getReferenceCount() == 1);
 	g_menuclouds->drop();
+	g_menuclouds = nullptr;
+	assert(g_menucloudsmgr->getReferenceCount() == 1);
 	g_menucloudsmgr->drop();
+	g_menucloudsmgr = nullptr;
 
 	return retval;
 }
@@ -369,6 +330,45 @@ void ClientLauncher::init_input()
 			input->joystick.onJoystickConnect(joystick_infos);
 		} else {
 			errorstream << "Could not activate joystick support." << std::endl;
+		}
+	}
+}
+
+void ClientLauncher::init_guienv(gui::IGUIEnvironment *guienv)
+{
+	gui::IGUISkin *skin = guienv->getSkin();
+
+	skin->setColor(gui::EGDC_WINDOW_SYMBOL, video::SColor(255, 255, 255, 255));
+	skin->setColor(gui::EGDC_BUTTON_TEXT, video::SColor(255, 255, 255, 255));
+	skin->setColor(gui::EGDC_3D_LIGHT, video::SColor(0, 0, 0, 0));
+	skin->setColor(gui::EGDC_3D_HIGH_LIGHT, video::SColor(255, 30, 30, 30));
+	skin->setColor(gui::EGDC_3D_SHADOW, video::SColor(255, 0, 0, 0));
+	skin->setColor(gui::EGDC_HIGH_LIGHT, video::SColor(255, 70, 120, 50));
+	skin->setColor(gui::EGDC_HIGH_LIGHT_TEXT, video::SColor(255, 255, 255, 255));
+	skin->setColor(gui::EGDC_EDITABLE, video::SColor(255, 128, 128, 128));
+	skin->setColor(gui::EGDC_FOCUSED_EDITABLE, video::SColor(255, 96, 134, 49));
+
+	float density = rangelim(g_settings->getFloat("gui_scaling"), 0.5f, 20) *
+		RenderingEngine::getDisplayDensity();
+	skin->setSize(gui::EGDS_CHECK_BOX_WIDTH, (s32)(17.0f * density));
+	skin->setSize(gui::EGDS_SCROLLBAR_SIZE, (s32)(14.0f * density));
+	skin->setSize(gui::EGDS_WINDOW_BUTTON_WIDTH, (s32)(15.0f * density));
+	if (density > 1.5f) {
+		std::string sprite_path = porting::path_share + "/textures/base/pack/";
+		if (density > 3.5f)
+			sprite_path.append("checkbox_64.png");
+		else if (density > 2.0f)
+			sprite_path.append("checkbox_32.png");
+		else
+			sprite_path.append("checkbox_16.png");
+		// Texture dimensions should be a power of 2
+		gui::IGUISpriteBank *sprites = skin->getSpriteBank();
+		video::IVideoDriver *driver = m_rendering_engine->get_video_driver();
+		video::ITexture *sprite_texture = driver->getTexture(sprite_path.c_str());
+		if (sprite_texture) {
+			s32 sprite_id = sprites->addTextureAsSprite(sprite_texture);
+			if (sprite_id != -1)
+				skin->setIcon(gui::EGDI_CHECK_BOX_CHECKED, sprite_id);
 		}
 	}
 }

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -169,7 +169,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	if (!g_menucloudsmgr)
 		g_menucloudsmgr = m_rendering_engine->get_scene_manager()->createNewSceneManager();
 	if (!g_menuclouds)
-		g_menuclouds = new Clouds(g_menucloudsmgr, -1, rand());
+		g_menuclouds = new Clouds(g_menucloudsmgr, nullptr, -1, rand());
 	g_menuclouds->setHeight(100.0f);
 	g_menuclouds->update(v3f(0, 0, 0), video::SColor(255, 240, 240, 255));
 	scene::ICameraSceneNode* camera;

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -38,6 +38,7 @@ private:
 	void init_args(GameStartData &start_data, const Settings &cmd_args);
 	bool init_engine();
 	void init_input();
+	void init_guienv(gui::IGUIEnvironment *guienv);
 
 	bool launch_game(std::string &error_message, bool reconnect_requested,
 		GameStartData &start_data, const Settings &cmd_args);
@@ -49,5 +50,4 @@ private:
 	RenderingEngine *m_rendering_engine = nullptr;
 	InputHandler *input = nullptr;
 	MyEventReceiver *receiver = nullptr;
-	gui::IGUISkin *skin = nullptr;
 };

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -72,15 +72,12 @@ Clouds::Clouds(scene::ISceneManager* mgr, IShaderSource *ssrc,
 
 	updateBox();
 
-	m_meshbuffer = new scene::SMeshBuffer();
+	m_meshbuffer.reset(new scene::SMeshBuffer());
 	m_meshbuffer->setHardwareMappingHint(scene::EHM_DYNAMIC);
 }
 
 Clouds::~Clouds()
 {
-	if (m_meshbuffer)
-		m_meshbuffer->drop();
-
 	g_settings->deregisterChangedCallback("enable_3d_clouds",
 		&cloud_3d_setting_changed, this);
 }
@@ -181,7 +178,7 @@ void Clouds::updateMesh()
 	}
 
 
-	auto *mb = m_meshbuffer;
+	auto *mb = m_meshbuffer.get();
 	{
 		const u32 vertex_count = num_faces_to_draw * 16 * m_cloud_radius_i * m_cloud_radius_i;
 		const u32 quad_count = vertex_count / 4;
@@ -393,7 +390,7 @@ void Clouds::render()
 				cloud_full_radius*1.2, fog_density, fog_pixelfog, fog_rangefog);
 	}
 
-	driver->drawMeshBuffer(m_meshbuffer);
+	driver->drawMeshBuffer(m_meshbuffer.get());
 
 	// Restore fog settings
 	driver->setFog(fog_color, fog_type, fog_start, fog_end, fog_density,

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -108,7 +108,6 @@ void Clouds::updateMesh()
 	);
 
 	// Only update mesh if it has moved enough, this saves lots of GPU buffer uploads.
-	// In practice the fog hides the delay in updating.
 	constexpr float max_d = 5 * BS;
 
 	if (!m_mesh_valid) {

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -72,7 +72,7 @@ public:
 
 	void update(const v3f &camera_p, const video::SColorf &color);
 
-	void updateCameraOffset(const v3s16 &camera_offset)
+	void updateCameraOffset(v3s16 camera_offset)
 	{
 		m_camera_offset = camera_offset;
 		updateBox();
@@ -83,23 +83,24 @@ public:
 	void setDensity(float density)
 	{
 		m_params.density = density;
-		// currently does not need bounding
+		invalidateMesh();
 	}
 
-	void setColorBright(const video::SColor &color_bright)
+	void setColorBright(video::SColor color_bright)
 	{
 		m_params.color_bright = color_bright;
 	}
 
-	void setColorAmbient(const video::SColor &color_ambient)
+	void setColorAmbient(video::SColor color_ambient)
 	{
 		m_params.color_ambient = color_ambient;
 	}
 
 	void setHeight(float height)
 	{
-		m_params.height = height; // add bounding when necessary
+		m_params.height = height;
 		updateBox();
+		invalidateMesh();
 	}
 
 	void setSpeed(v2f speed)
@@ -111,6 +112,7 @@ public:
 	{
 		m_params.thickness = thickness;
 		updateBox();
+		invalidateMesh();
 	}
 
 	bool isCameraInsideCloud() const { return m_camera_inside_cloud; }
@@ -127,20 +129,29 @@ private:
 	}
 
 	void updateMesh();
+	void invalidateMesh()
+	{
+		if (m_meshbuffer)
+			m_meshbuffer->Vertices.set_used(0);
+	}
 
 	bool gridFilled(int x, int y) const;
 
 	video::SMaterial m_material;
 	scene::SMeshBuffer *m_meshbuffer = nullptr;
+	// Value of m_origin at the time the mesh was last updated
+	v2f m_mesh_origin;
+
 	aabb3f m_box;
+	v2f m_origin;
 	u16 m_cloud_radius_i;
-	bool m_enable_3d;
 	u32 m_seed;
 	v3f m_camera_pos;
-	v2f m_origin;
+
 	v3s16 m_camera_offset;
-	video::SColorf m_color = video::SColorf(1.0f, 1.0f, 1.0f, 1.0f);
-	CloudParams m_params;
 	bool m_camera_inside_cloud = false;
 
+	bool m_enable_3d;
+	video::SColorf m_color = video::SColorf(1.0f, 1.0f, 1.0f, 1.0f);
+	CloudParams m_params;
 };

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -24,6 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "constants.h"
 #include "skyparams.h"
 
+class IShaderSource;
+
 // Menu clouds
 class Clouds;
 extern Clouds *g_menuclouds;
@@ -34,7 +36,7 @@ extern scene::ISceneManager *g_menucloudsmgr;
 class Clouds : public scene::ISceneNode
 {
 public:
-	Clouds(scene::ISceneManager* mgr,
+	Clouds(scene::ISceneManager* mgr, IShaderSource *ssrc,
 			s32 id,
 			u32 seed
 	);
@@ -151,7 +153,7 @@ private:
 	v3s16 m_camera_offset;
 	bool m_camera_inside_cloud = false;
 
-	bool m_enable_3d;
+	bool m_enable_shaders, m_enable_3d;
 	video::SColorf m_color = video::SColorf(1.0f, 1.0f, 1.0f, 1.0f);
 	CloudParams m_params;
 };

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -19,10 +19,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
-#include <iostream>
 #include "constants.h"
+#include "irr_ptr.h"
+#include "irrlichttypes_extrabloated.h"
 #include "skyparams.h"
+#include <iostream>
 
 class IShaderSource;
 
@@ -145,7 +146,7 @@ private:
 	bool gridFilled(int x, int y) const;
 
 	video::SMaterial m_material;
-	scene::SMeshBuffer *m_meshbuffer = nullptr;
+	irr_ptr<scene::SMeshBuffer> m_meshbuffer;
 	// Value of m_origin at the time the mesh was last updated
 	v2f m_mesh_origin;
 	// Value of center_of_drawing_in_noise_i at the time the mesh was last updated

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -126,9 +126,12 @@ private:
 				BS * 1000000.0f, height_bs + thickness_bs - BS * m_camera_offset.Y, BS * 1000000.0f);
 	}
 
+	void updateMesh();
+
 	bool gridFilled(int x, int y) const;
 
 	video::SMaterial m_material;
+	scene::SMeshBuffer *m_meshbuffer = nullptr;
 	aabb3f m_box;
 	u16 m_cloud_radius_i;
 	bool m_enable_3d;

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -84,6 +84,8 @@ public:
 
 	void setDensity(float density)
 	{
+		if (m_params.density == density)
+			return;
 		m_params.density = density;
 		invalidateMesh();
 	}
@@ -100,6 +102,8 @@ public:
 
 	void setHeight(float height)
 	{
+		if (m_params.height == height)
+			return;
 		m_params.height = height;
 		updateBox();
 		invalidateMesh();
@@ -112,6 +116,8 @@ public:
 
 	void setThickness(float thickness)
 	{
+		if (m_params.thickness == thickness)
+			return;
 		m_params.thickness = thickness;
 		updateBox();
 		invalidateMesh();
@@ -133,8 +139,7 @@ private:
 	void updateMesh();
 	void invalidateMesh()
 	{
-		if (m_meshbuffer)
-			m_meshbuffer->Vertices.set_used(0);
+		m_mesh_valid = false;
 	}
 
 	bool gridFilled(int x, int y) const;
@@ -143,6 +148,10 @@ private:
 	scene::SMeshBuffer *m_meshbuffer = nullptr;
 	// Value of m_origin at the time the mesh was last updated
 	v2f m_mesh_origin;
+	// Value of center_of_drawing_in_noise_i at the time the mesh was last updated
+	v2s16 m_last_noise_center;
+	// Was the mesh ever generated?
+	bool m_mesh_valid = false;
 
 	aabb3f m_box;
 	v2f m_origin;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -812,7 +812,6 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 			(m_prop.visual == "wielditem"));
 
 		m_wield_meshnode->setScale(m_prop.visual_size / 2.0f);
-		m_wield_meshnode->setColor(video::SColor(0xFFFFFFFF));
 	} else {
 		infostream<<"GenericCAO::addToScene(): \""<<m_prop.visual
 				<<"\" not supported"<<std::endl;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -818,6 +818,18 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 				<<"\" not supported"<<std::endl;
 	}
 
+	/* Set VBO hint */
+	// - if shaders are disabled we modify the mesh often
+	// - sprites are also modified often
+	// - the wieldmesh sets its own hint
+	// - bone transformations do not need to modify the vertex data
+	if (m_enable_shaders && (m_meshnode || m_animated_meshnode)) {
+		if (m_meshnode)
+			m_meshnode->getMesh()->setHardwareMappingHint(scene::EHM_STATIC);
+		if (m_animated_meshnode)
+			m_animated_meshnode->getMesh()->setHardwareMappingHint(scene::EHM_STATIC);
+	}
+
 	/* don't update while punch texture modifier is active */
 	if (m_reset_textures_timer < 0)
 		updateTextures(m_current_texture_modifier);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1495,6 +1495,8 @@ bool Game::createClient(const GameStartData &start_data)
 			&m_flags.force_fog_off, &runData.fog_range, client);
 	shader_src->addShaderConstantSetterFactory(scsf);
 
+	ShadowRenderer::preInit(shader_src);
+
 	// Update cached textures, meshes and materials
 	client->afterContentReceived();
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1454,7 +1454,7 @@ bool Game::createClient(const GameStartData &start_data)
 	/* Clouds
 	 */
 	if (m_cache_enable_clouds)
-		clouds = new Clouds(smgr, -1, time(0));
+		clouds = new Clouds(smgr, shader_src, -1, time(0));
 
 	/* Skybox
 	 */

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -650,20 +650,6 @@ public:
 
 const static float object_hit_delay = 0.2;
 
-struct FpsControl {
-	FpsControl() : last_time(0), busy_time(0), sleep_time(0) {}
-
-	void reset();
-
-	void limit(IrrlichtDevice *device, f32 *dtime);
-
-	u32 getBusyMs() const { return busy_time / 1000; }
-
-	// all values in microseconds (us)
-	u64 last_time, busy_time, sleep_time;
-};
-
-
 /* The reason the following structs are not anonymous structs within the
  * class is that they are not used by the majority of member functions and
  * many functions that do require objects of thse types do not modify them
@@ -1201,7 +1187,7 @@ void Game::run()
 		// Calculate dtime =
 		//    m_rendering_engine->run() from this iteration
 		//  + Sleep time until the wanted FPS are reached
-		draw_times.limit(device, &dtime);
+		draw_times.limit(device, &dtime, g_menumgr.pausesGame());
 
 		const auto current_dynamic_info = ClientDynamicInfo::getCurrent();
 		if (!current_dynamic_info.equal(client_display_info)) {
@@ -4323,48 +4309,6 @@ void Game::drawScene(ProfilerGraph *graph, RunStats *stats)
 /****************************************************************************
  Misc
  ****************************************************************************/
-
-void FpsControl::reset()
-{
-	last_time = porting::getTimeUs();
-}
-
-/*
- * On some computers framerate doesn't seem to be automatically limited
- */
-void FpsControl::limit(IrrlichtDevice *device, f32 *dtime)
-{
-	const float fps_limit = (device->isWindowFocused() && !g_menumgr.pausesGame())
-			? g_settings->getFloat("fps_max")
-			: g_settings->getFloat("fps_max_unfocused");
-	const u64 frametime_min = 1000000.0f / std::max(fps_limit, 1.0f);
-
-	u64 time = porting::getTimeUs();
-
-	if (time > last_time) // Make sure time hasn't overflowed
-		busy_time = time - last_time;
-	else
-		busy_time = 0;
-
-	if (busy_time < frametime_min) {
-		sleep_time = frametime_min - busy_time;
-		if (sleep_time > 0)
-			sleep_us(sleep_time);
-	} else {
-		sleep_time = 0;
-	}
-
-	// Read the timer again to accurately determine how long we actually slept,
-	// rather than calculating it by adding sleep_time to time.
-	time = porting::getTimeUs();
-
-	if (time > last_time) // Make sure last_time hasn't overflowed
-		*dtime = (time - last_time) / 1000000.0f;
-	else
-		*dtime = 0;
-
-	last_time = time;
-}
 
 void Game::showOverlayMessage(const char *msg, float dtime, int percent, bool draw_sky)
 {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -524,7 +524,9 @@ public:
 			m_bloom_radius_pixel.set(&m_bloom_radius, services);
 			m_bloom_strength_pixel.set(&m_bloom_strength, services);
 		}
-		float saturation = m_client->getEnv().getLocalPlayer()->getLighting().saturation;
+
+		const auto &lighting = m_client->getEnv().getLocalPlayer()->getLighting();
+		float saturation = lighting.saturation;
 		m_saturation_pixel.set(&saturation, services);
 
 		if (m_volumetric_light_enabled) {
@@ -535,13 +537,13 @@ public:
 
 			if (m_sky->getSunVisible()) {
 				v3f sun_position = camera_node->getAbsolutePosition() +
-						10000. * m_sky->getSunDirection();
+						10000.f * m_sky->getSunDirection();
 				transform.transformVect(sun_position);
 				sun_position.normalize();
 
 				m_sun_position_pixel.set(sun_position, services);
 
-				float sun_brightness = rangelim(107.143f * m_sky->getSunDirection().dotProduct(v3f(0.f, 1.f, 0.f)), 0.f, 1.f);
+				float sun_brightness = core::clamp(107.143f * m_sky->getSunDirection().Y, 0.f, 1.f);
 				m_sun_brightness_pixel.set(&sun_brightness, services);
 			} else {
 				m_sun_position_pixel.set(v3f(0.f, 0.f, -1.f), services);
@@ -552,13 +554,13 @@ public:
 
 			if (m_sky->getMoonVisible()) {
 				v3f moon_position = camera_node->getAbsolutePosition() +
-						10000. * m_sky->getMoonDirection();
+						10000.f * m_sky->getMoonDirection();
 				transform.transformVect(moon_position);
 				moon_position.normalize();
 
 				m_moon_position_pixel.set(moon_position, services);
 
-				float moon_brightness = rangelim(107.143f * m_sky->getMoonDirection().dotProduct(v3f(0.f, 1.f, 0.f)), 0.f, 1.f);
+				float moon_brightness = core::clamp(107.143f * m_sky->getMoonDirection().Y, 0.f, 1.f);
 				m_moon_brightness_pixel.set(&moon_brightness, services);
 			} else {
 				m_moon_position_pixel.set(v3f(0.f, 0.f, -1.f), services);
@@ -566,7 +568,8 @@ public:
 				float moon_brightness = 0.f;
 				m_moon_brightness_pixel.set(&moon_brightness, services);
 			}
-			float volumetric_light_strength = m_client->getEnv().getLocalPlayer()->getLighting().volumetric_light_strength;
+
+			float volumetric_light_strength = lighting.volumetric_light_strength;
 			m_volumetric_light_strength_pixel.set(&volumetric_light_strength, services);
 		}
 	}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1451,7 +1451,7 @@ bool Game::createClient(const GameStartData &start_data)
 	/* Clouds
 	 */
 	if (m_cache_enable_clouds)
-		clouds = new Clouds(smgr, shader_src, -1, time(0));
+		clouds = new Clouds(smgr, shader_src, -1, rand());
 
 	/* Skybox
 	 */

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -379,7 +379,6 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<float>
 		m_animation_timer_delta_pixel{"animationTimerDelta"};
 	CachedPixelShaderSetting<float, 3> m_day_light{"dayLight"};
-	CachedPixelShaderSetting<float, 4> m_star_color{"starColor"};
 	CachedPixelShaderSetting<float, 3> m_eye_position_pixel{"eyePosition"};
 	CachedVertexShaderSetting<float, 3> m_eye_position_vertex{"eyePosition"};
 	CachedPixelShaderSetting<float, 3> m_minimap_yaw{"yawVec"};
@@ -472,10 +471,6 @@ public:
 		video::SColorf sunlight;
 		get_sunlight_color(&sunlight, daynight_ratio);
 		m_day_light.set(sunlight, services);
-
-		video::SColorf star_color = m_sky->getCurrentStarColor();
-		float clr[4] = {star_color.r, star_color.g, star_color.b, star_color.a};
-		m_star_color.set(clr, services);
 
 		u32 animation_timer = m_client->getEnv().getFrameTime() % 1000000;
 		float animation_timer_f = (float)animation_timer / 100000.f;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1094,6 +1094,8 @@ bool Game::startup(bool *kill,
 	driver = device->getVideoDriver();
 	smgr = m_rendering_engine->get_scene_manager();
 
+	driver->setTextureCreationFlag(video::ETCF_CREATE_MIP_MAPS, g_settings->getBool("mip_map"));
+
 	smgr->getParameters()->setAttribute(scene::OBJ_LOADER_IGNORE_MATERIAL_FILES, true);
 
 	// Reinit runData

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -135,6 +135,7 @@ Hud::Hud(Client *client, LocalPlayer *player,
 
 	m_rotation_mesh_buffer.getMaterial().Lighting = false;
 	m_rotation_mesh_buffer.getMaterial().MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+	m_rotation_mesh_buffer.setHardwareMappingHint(scene::EHM_STATIC);
 }
 
 Hud::~Hud()

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -97,7 +97,7 @@ Hud::Hud(Client *client, LocalPlayer *player,
 
 	if (g_settings->getBool("enable_shaders")) {
 		IShaderSource *shdrsrc = client->getShaderSource();
-		u16 shader_id = shdrsrc->getShader(
+		auto shader_id = shdrsrc->getShader(
 			m_mode == HIGHLIGHT_HALO ? "selection_shader" : "default_shader", TILE_MATERIAL_ALPHA);
 		m_selection_material.MaterialType = shdrsrc->getShaderInfo(shader_id).material;
 	} else {

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1100,24 +1100,23 @@ void drawItemStack(
 		video::SColor basecolor =
 			client->idef()->getItemstackColor(item, client);
 
-		u32 mc = mesh->getMeshBufferCount();
+		const u32 mc = mesh->getMeshBufferCount();
+		if (mc > imesh->buffer_colors.size())
+			imesh->buffer_colors.resize(mc);
 		for (u32 j = 0; j < mc; ++j) {
 			scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
-			// we can modify vertices relatively fast,
-			// because these meshes are not buffered.
-			assert(buf->getHardwareMappingHint_Vertex() == scene::EHM_NEVER);
 			video::SColor c = basecolor;
 
-			if (imesh->buffer_colors.size() > j) {
-				ItemPartColor *p = &imesh->buffer_colors[j];
-				if (p->override_base)
-					c = p->color;
-			}
+			auto &p = imesh->buffer_colors[j];
+			p.applyOverride(c);
 
-			if (imesh->needs_shading)
-				colorizeMeshBuffer(buf, &c);
-			else
-				setMeshBufferColor(buf, c);
+			if (p.needColorize(c)) {
+				buf->setDirty(scene::EBT_VERTEX);
+				if (imesh->needs_shading)
+					colorizeMeshBuffer(buf, &c);
+				else
+					setMeshBufferColor(buf, c);
+			}
 
 			video::SMaterial &material = buf->getMaterial();
 			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -250,7 +250,6 @@ private:
 	v3f m_bounding_sphere_center;
 
 	bool m_enable_shaders;
-	bool m_enable_vbo;
 
 	// Must animate() be called before rendering?
 	bool m_has_animation;

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -571,6 +571,7 @@ scene::SMeshBuffer *Minimap::getMinimapMeshBuffer()
 	buf->Indices[4] = 3;
 	buf->Indices[5] = 0;
 
+	buf->setHardwareMappingHint(scene::EHM_STATIC);
 	return buf;
 }
 

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -615,7 +615,7 @@ void Minimap::drawMinimap(core::rect<s32> rect)
 	material.TextureLayers[1].Texture = data->heightmap_texture;
 
 	if (m_enable_shaders && data->mode.type == MINIMAP_TYPE_SURFACE) {
-		u16 sid = m_shdrsrc->getShader("minimap_shader", TILE_MATERIAL_ALPHA);
+		auto sid = m_shdrsrc->getShader("minimap_shader", TILE_MATERIAL_ALPHA);
 		material.MaterialType = m_shdrsrc->getShaderInfo(sid).material;
 	} else {
 		material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -94,7 +94,7 @@ class FogShaderConstantSetter : public IShaderConstantSetter
 public:
 	void onSetConstants(video::IMaterialRendererServices *services) override
 	{
-		auto *driver = RenderingEngine::get_video_driver();
+		auto *driver = services->getVideoDriver();
 		assert(driver);
 
 		video::SColor fog_color(0);

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -314,15 +314,17 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 			gui::StaticText::add(guienv, text, textrect, false, false);
 	guitext->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_UPPERLEFT);
 
-	if (sky && g_settings->getBool("menu_clouds")) {
-		g_menuclouds->step(dtime * 3);
-		g_menuclouds->render();
-		get_video_driver()->beginScene(true, true, RenderingEngine::MENU_SKY_COLOR);
-		g_menucloudsmgr->drawAll();
-	} else if (sky)
-		get_video_driver()->beginScene(true, true, RenderingEngine::MENU_SKY_COLOR);
-	else
-		get_video_driver()->beginScene(true, true, video::SColor(255, 0, 0, 0));
+	auto *driver = get_video_driver();
+
+	if (sky) {
+		driver->beginScene(true, true, RenderingEngine::MENU_SKY_COLOR);
+		if (g_settings->getBool("menu_clouds")) {
+			g_menuclouds->step(dtime * 3);
+			g_menucloudsmgr->drawAll();
+		}
+	} else {
+		driver->beginScene(true, true, video::SColor(255, 0, 0, 0));
+	}
 
 	// draw progress bar
 	if ((percent >= 0) && (percent <= 100)) {
@@ -367,7 +369,7 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 	}
 
 	guienv->drawAll();
-	get_video_driver()->endScene();
+	driver->endScene();
 	guitext->remove();
 }
 

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include "irrlichttypes_extrabloated.h"
 #include "debug.h"
+#include "client/shader.h"
 #include "client/render/core.h"
 // include the shadow mapper classes too
 #include "client/shadows/dynamicshadowsrender.h"
@@ -46,6 +47,8 @@ class RenderingCore;
 // Instead of a mechanism to disable fog we just set it to be really far away
 #define FOG_RANGE_ALL (100000 * BS)
 
+/* Helpers */
+
 struct FpsControl {
 	FpsControl() : last_time(0), busy_time(0), sleep_time(0) {}
 
@@ -58,6 +61,16 @@ struct FpsControl {
 	// all values in microseconds (us)
 	u64 last_time, busy_time, sleep_time;
 };
+
+// Populates fogColor, fogDistance, fogShadingParameter with values from Irrlicht
+class FogShaderConstantSetterFactory : public IShaderConstantSetterFactory
+{
+public:
+	FogShaderConstantSetterFactory() {};
+	virtual IShaderConstantSetter *create();
+};
+
+/* Rendering engine class */
 
 class RenderingEngine
 {

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -90,7 +90,6 @@ public:
 
 	bool setupTopLevelWindow();
 	bool setWindowIcon();
-	static bool print_video_modes();
 	void cleanupMeshCache();
 
 	void removeMesh(const scene::IMesh* mesh);

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -46,6 +46,19 @@ class RenderingCore;
 // Instead of a mechanism to disable fog we just set it to be really far away
 #define FOG_RANGE_ALL (100000 * BS)
 
+struct FpsControl {
+	FpsControl() : last_time(0), busy_time(0), sleep_time(0) {}
+
+	void reset();
+
+	void limit(IrrlichtDevice *device, f32 *dtime, bool assume_paused = false);
+
+	u32 getBusyMs() const { return busy_time / 1000; }
+
+	// all values in microseconds (us)
+	u64 last_time, busy_time, sleep_time;
+};
+
 class RenderingEngine
 {
 public:
@@ -101,11 +114,6 @@ public:
 	{
 		sanity_check(s_singleton && s_singleton->m_device);
 		return s_singleton->m_device;
-	}
-
-	u32 get_timer_time()
-	{
-		return m_device->getTimer()->getTime();
 	}
 
 	gui::IGUIEnvironment *get_gui_env()

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -227,7 +227,7 @@ public:
 
 		// Set world matrix
 		core::matrix4 world = driver->getTransform(video::ETS_WORLD);
-		m_world.set(*reinterpret_cast<float(*)[16]>(world.pointer()), services);
+		m_world.set(world, services);
 
 		// Set clip matrix
 		core::matrix4 worldView;
@@ -237,12 +237,12 @@ public:
 		core::matrix4 worldViewProj;
 		worldViewProj = driver->getTransform(video::ETS_PROJECTION);
 		worldViewProj *= worldView;
-		m_world_view_proj.set(*reinterpret_cast<float(*)[16]>(worldViewProj.pointer()), services);
+		m_world_view_proj.set(worldViewProj, services);
 
 		if (driver->getDriverType() == video::EDT_OGLES2 || driver->getDriverType() == video::EDT_OPENGL3) {
 			core::matrix4 texture = driver->getTransform(video::ETS_TEXTURE_0);
-			m_world_view.set(*reinterpret_cast<float(*)[16]>(worldView.pointer()), services);
-			m_texture.set(*reinterpret_cast<float(*)[16]>(texture.pointer()), services);
+			m_world_view.set(worldView, services);
+			m_texture.set(texture, services);
 		}
 	}
 };

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -389,8 +389,10 @@ private:
 	// The former container is behind this mutex
 	std::mutex m_shaderinfo_cache_mutex;
 
+#if 0
 	// Queued shader fetches (to be processed by the main thread)
 	RequestQueue<std::string, u32, u8, u8> m_get_shader_queue;
+#endif
 
 	// Global constant setter factories
 	std::vector<std::unique_ptr<IShaderConstantSetterFactory>> m_setter_factories;
@@ -427,8 +429,10 @@ u32 ShaderSource::getShader(const std::string &name,
 		return getShaderIdDirect(name, material_type, drawtype);
 	}
 
-	/*errorstream<<"getShader(): Queued: name=\""<<name<<"\""<<std::endl;*/
+	errorstream << "ShaderSource::getShader(): getting from "
+		"other thread not implemented" << std::endl;
 
+#if 0
 	// We're gonna ask the result to be put into here
 
 	static ResultQueue<std::string, u32, u8, u8> result_queue;
@@ -451,6 +455,7 @@ u32 ShaderSource::getShader(const std::string &name,
 	}
 
 	infostream << "getShader(): Failed" << std::endl;
+#endif
 
 	return 0;
 }

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -232,7 +232,7 @@ public:
 	virtual void onSetConstants(video::IMaterialRendererServices *services) override
 	{
 		video::IVideoDriver *driver = services->getVideoDriver();
-		sanity_check(driver);
+		assert(driver);
 
 		// Set world matrix
 		core::matrix4 world = driver->getTransform(video::ETS_WORLD);

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -545,11 +545,11 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		return shaderinfo;
 
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
-	if (!driver->queryFeature(video::EVDF_ARB_GLSL)) {
+	video::IGPUProgrammingServices *gpu = driver->getGPUProgrammingServices();
+	if (!driver->queryFeature(video::EVDF_ARB_GLSL) || !gpu) {
 		throw ShaderException(gettext("Shaders are enabled but GLSL is not "
 			"supported by the driver."));
 	}
-	video::IGPUProgrammingServices *gpu = driver->getGPUProgrammingServices();
 
 	// Create shaders header
 	bool fully_programmable = driver->getDriverType() == video::EDT_OGLES2 || driver->getDriverType() == video::EDT_OPENGL3;
@@ -609,14 +609,6 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		#define normalTexture texture1
 		#define textureFlags texture2
 	)";
-
-	// Since this is the first time we're using the GL bindings be extra careful.
-	// This should be removed before 5.6.0 or similar.
-	if (!GL.GetString) {
-		errorstream << "OpenGL procedures were not loaded correctly, "
-			"please open a bug report with details about your platform/OS." << std::endl;
-		abort();
-	}
 
 	bool use_discard = fully_programmable;
 	// For renderers that should use discard instead of GL_ALPHA_TEST

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -217,8 +217,17 @@ class MainShaderConstantSetter : public IShaderConstantSetter
 	// Texture matrix
 	CachedVertexShaderSetting<float, 16> m_texture{"mTexture"};
 
+	// commonly used way to pass material color to shader
+	video::SColor m_emissive_color;
+	CachedPixelShaderSetting<float, 4> m_emissive_color_setting{"emissiveColor"};
+
 public:
 	~MainShaderConstantSetter() = default;
+
+	virtual void onSetMaterial(const video::SMaterial& material) override
+	{
+		m_emissive_color = material.EmissiveColor;
+	}
 
 	virtual void onSetConstants(video::IMaterialRendererServices *services) override
 	{
@@ -244,6 +253,9 @@ public:
 			m_world_view.set(worldView, services);
 			m_texture.set(texture, services);
 		}
+
+		video::SColorf emissive_color(m_emissive_color);
+		m_emissive_color_setting.set(emissive_color, services);
 	}
 };
 

--- a/src/client/shader.h
+++ b/src/client/shader.h
@@ -105,6 +105,57 @@ public:
 			has_been_set = true;
 		}
 	}
+
+	/* Type specializations */
+
+	/*
+	 * T2 looks redundant here but it is necessary so the compiler won't
+	 * resolve the templates at class instantiation and then fail because
+	 * some of these methods don't have valid types (= are not usable).
+	 * ref: <https://stackoverflow.com/a/6972771>
+	 *
+	 * Note: a `bool dummy` template parameter would have been easier but MSVC
+	 * does not like that. Also make sure not to define different specializations
+	 * with the same parameters, MSVC doesn't like that either.
+	 * I extend my thanks to Microsoft®
+	 */
+#define SPECIALIZE(_type, _count_expr) \
+	template<typename T2 = T> \
+	std::enable_if_t<std::is_same_v<T, T2> && std::is_same_v<T2, _type> && (_count_expr)>
+
+	SPECIALIZE(float, count == 2)
+	set(const v2f value, video::IMaterialRendererServices *services)
+	{
+		float array[2] = { value.X, value.Y };
+		set(array, services);
+	}
+
+	SPECIALIZE(float, count == 3)
+	set(const v3f value, video::IMaterialRendererServices *services)
+	{
+		float array[3] = { value.X, value.Y, value.Z };
+		set(array, services);
+	}
+
+	SPECIALIZE(float, count == 3 || count == 4)
+	set(const video::SColorf value, video::IMaterialRendererServices *services)
+	{
+		if constexpr (count == 3) {
+			float array[3] = { value.r, value.g, value.b };
+			set(array, services);
+		} else {
+			float array[4] = { value.r, value.g, value.b, value.a };
+			set(array, services);
+		}
+	}
+
+	SPECIALIZE(float, count == 16)
+	set(const core::matrix4 &value, video::IMaterialRendererServices *services)
+	{
+		set(value.pointer(), services);
+	}
+
+#undef SPECIALIZE
 };
 
 template <typename T, std::size_t count = 1, bool cache=true>

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -118,20 +118,29 @@ void ShadowRenderer::disable()
 		});
 }
 
+void ShadowRenderer::preInit(IWritableShaderSource *shsrc)
+{
+	if (g_settings->getBool("enable_shaders") &&
+			g_settings->getBool("enable_dynamic_shadows")) {
+		shsrc->addShaderConstantSetterFactory(new ShadowConstantSetterFactory());
+	}
+}
+
 void ShadowRenderer::initialize()
 {
 	auto *gpu = m_driver->getGPUProgrammingServices();
 
 	// we need glsl
-	if (m_shadows_supported && gpu && m_driver->queryFeature(video::EVDF_ARB_GLSL)) {
-		createShaders();
-	} else {
+	if (!m_shadows_supported || !gpu || !m_driver->queryFeature(video::EVDF_ARB_GLSL)) {
 		m_shadows_supported = false;
 
 		warningstream << "Shadows: GLSL Shader not supported on this system."
 			<< std::endl;
 		return;
 	}
+
+	createShaders();
+	
 
 	m_texture_format = m_shadow_map_texture_32bit
 					   ? video::ECOLOR_FORMAT::ECF_R32F

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class ShadowDepthShaderCB;
 class shadowScreenQuad;
 class shadowScreenQuadCB;
+class IWritableShaderSource;
 
 enum E_SHADOW_MODE : u8
 {
@@ -54,8 +55,12 @@ public:
 	static const int TEXTURE_LAYER_SHADOW = 3;
 
 	ShadowRenderer(IrrlichtDevice *device, Client *client);
-
 	~ShadowRenderer();
+
+	// Call before generating any shaders
+	// This is required because this class is initialized much later than all
+	// the shaders are dealt with.
+	static void preInit(IWritableShaderSource *shsrc);
 
 	void initialize();
 

--- a/src/client/shadows/shadowsshadercallbacks.cpp
+++ b/src/client/shadows/shadowsshadercallbacks.cpp
@@ -18,6 +18,53 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "client/shadows/shadowsshadercallbacks.h"
+#include "client/renderingengine.h"
+
+void ShadowConstantSetter::onSetConstants(video::IMaterialRendererServices *services)
+{
+	auto *shadow = RenderingEngine::get_shadow_renderer();
+	if (!shadow)
+		return;
+
+	const auto &light = shadow->getDirectionalLight();
+
+	core::matrix4 shadowViewProj = light.getProjectionMatrix();
+	shadowViewProj *= light.getViewMatrix();
+	m_shadow_view_proj.set(shadowViewProj.pointer(), services);
+
+	f32 v_LightDirection[3];
+	light.getDirection().getAs3Values(v_LightDirection);
+	m_light_direction.set(v_LightDirection, services);
+
+	f32 TextureResolution = light.getMapResolution();
+	m_texture_res.set(&TextureResolution, services);
+
+	f32 ShadowStrength = shadow->getShadowStrength();
+	m_shadow_strength.set(&ShadowStrength, services);
+
+	f32 timeOfDay = shadow->getTimeOfDay();
+	m_time_of_day.set(&timeOfDay, services);
+
+	f32 shadowFar = shadow->getMaxShadowFar();
+	m_shadowfar.set(&shadowFar, services);
+
+	f32 cam_pos[4];
+	shadowViewProj.transformVect(cam_pos, light.getPlayerPos());
+	m_camera_pos.set(cam_pos, services);
+
+	s32 TextureLayerID = ShadowRenderer::TEXTURE_LAYER_SHADOW;
+	m_shadow_texture.set(&TextureLayerID, services);
+
+	f32 bias0 = shadow->getPerspectiveBiasXY();
+	m_perspective_bias0_vertex.set(&bias0, services);
+	m_perspective_bias0_pixel.set(&bias0, services);
+	f32 bias1 = 1.0f - bias0 + 1e-5f;
+	m_perspective_bias1_vertex.set(&bias1, services);
+	m_perspective_bias1_pixel.set(&bias1, services);
+	f32 zbias = shadow->getPerspectiveBiasZ();
+	m_perspective_zbias_vertex.set(&zbias, services);
+	m_perspective_zbias_pixel.set(&zbias, services);
+}
 
 void ShadowDepthShaderCB::OnSetConstants(
 		video::IMaterialRendererServices *services, s32 userData)

--- a/src/client/shadows/shadowsshadercallbacks.cpp
+++ b/src/client/shadows/shadowsshadercallbacks.cpp
@@ -32,9 +32,7 @@ void ShadowConstantSetter::onSetConstants(video::IMaterialRendererServices *serv
 	shadowViewProj *= light.getViewMatrix();
 	m_shadow_view_proj.set(shadowViewProj.pointer(), services);
 
-	f32 v_LightDirection[3];
-	light.getDirection().getAs3Values(v_LightDirection);
-	m_light_direction.set(v_LightDirection, services);
+	m_light_direction.set(light.getDirection(), services);
 
 	f32 TextureResolution = light.getMapResolution();
 	m_texture_res.set(&TextureResolution, services);
@@ -79,7 +77,7 @@ void ShadowDepthShaderCB::OnSetConstants(
 
 	lightMVP *= driver->getTransform(video::ETS_WORLD);
 
-	m_light_mvp_setting.set(lightMVP.pointer(), services);
+	m_light_mvp_setting.set(lightMVP, services);
 	m_map_resolution_setting.set(&MapRes, services);
 	m_max_far_setting.set(&MaxFar, services);
 	s32 TextureId = 0;

--- a/src/client/shadows/shadowsshadercallbacks.h
+++ b/src/client/shadows/shadowsshadercallbacks.h
@@ -23,6 +23,47 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IShaderConstantSetCallBack.h>
 #include "client/shader.h"
 
+// Used by main game rendering
+
+class ShadowConstantSetter : public IShaderConstantSetter
+{
+	CachedPixelShaderSetting<f32, 16> m_shadow_view_proj{"m_ShadowViewProj"};
+	CachedPixelShaderSetting<f32, 3> m_light_direction{"v_LightDirection"};
+	CachedPixelShaderSetting<f32> m_texture_res{"f_textureresolution"};
+	CachedPixelShaderSetting<f32> m_shadow_strength{"f_shadow_strength"};
+	CachedPixelShaderSetting<f32> m_time_of_day{"f_timeofday"};
+	CachedPixelShaderSetting<f32> m_shadowfar{"f_shadowfar"};
+	CachedPixelShaderSetting<f32, 4> m_camera_pos{"CameraPos"};
+	CachedPixelShaderSetting<s32> m_shadow_texture{"ShadowMapSampler"};
+	CachedVertexShaderSetting<f32>
+		m_perspective_bias0_vertex{"xyPerspectiveBias0"};
+	CachedPixelShaderSetting<f32>
+		m_perspective_bias0_pixel{"xyPerspectiveBias0"};
+	CachedVertexShaderSetting<f32>
+		m_perspective_bias1_vertex{"xyPerspectiveBias1"};
+	CachedPixelShaderSetting<f32>
+		m_perspective_bias1_pixel{"xyPerspectiveBias1"};
+	CachedVertexShaderSetting<f32>
+		m_perspective_zbias_vertex{"zPerspectiveBias"};
+	CachedPixelShaderSetting<f32> m_perspective_zbias_pixel{"zPerspectiveBias"};
+
+public:
+	ShadowConstantSetter() = default;
+	~ShadowConstantSetter() = default;
+
+	virtual void onSetConstants(video::IMaterialRendererServices *services) override;
+};
+
+class ShadowConstantSetterFactory : public IShaderConstantSetterFactory
+{
+public:
+	virtual IShaderConstantSetter *create() {
+		return new ShadowConstantSetter();
+	}
+};
+
+// Used by depth shader
+
 class ShadowDepthShaderCB : public video::IShaderConstantSetCallBack
 {
 public:

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -77,6 +77,7 @@ Sky::Sky(s32 id, RenderingEngine *rendering_engine, ITextureSource *tsrc, IShade
 	// Create materials
 
 	m_materials[0] = baseMaterial();
+	// FIXME: shouldn't this check m_enable_shaders?
 	m_materials[0].MaterialType = ssrc->getShaderInfo(ssrc->getShader("stars_shader", TILE_MATERIAL_ALPHA)).material;
 	m_materials[0].Lighting = true;
 	m_materials[0].ColorMaterial = video::ECM_NONE;

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -683,11 +683,12 @@ void Sky::draw_stars(video::IVideoDriver * driver, float wicked_time_of_day)
 	float starbrightness = (0.25f - fabs(tod)) * 20.0f;
 	float alpha = clamp(starbrightness, day_opacity, 1.0f);
 
-	m_star_color = m_star_params.starcolor;
-	m_star_color.a *= alpha;
-	if (m_star_color.a <= 0.0f) // Stars are only drawn when not fully transparent
+	video::SColorf color(m_star_params.starcolor);
+	color.a *= alpha;
+	if (color.a <= 0.0f) // Stars are only drawn when not fully transparent
 		return;
-	m_materials[0].DiffuseColor = m_materials[0].EmissiveColor = m_star_color.toSColor();
+	m_materials[0].EmissiveColor = color.toSColor();
+
 	auto sky_rotation = core::matrix4().setRotationAxisRadians(2.0f * M_PI * (wicked_time_of_day - 0.25f), v3f(0.0f, 0.0f, 1.0f));
 	auto world_matrix = driver->getTransform(video::ETS_WORLD);
 	driver->setTransform(video::ETS_WORLD, world_matrix * sky_rotation);

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -114,7 +114,6 @@ public:
 	void clearSkyboxTextures() { m_sky_params.textures.clear(); }
 	void addTextureToSkybox(const std::string &texture, int material_id,
 		ITextureSource *tsrc);
-	const video::SColorf &getCurrentStarColor() const { return m_star_color; }
 
 	// Note: the Sky class doesn't use these values. It just stores them.
 	void setFogDistance(s16 fog_distance) { m_sky_params.fog_distance = fog_distance; }
@@ -210,7 +209,6 @@ private:
 
 	u64 m_seed = 0;
 	irr_ptr<scene::SMeshBuffer> m_stars;
-	video::SColorf m_star_color;
 
 	video::ITexture *m_sun_texture;
 	video::ITexture *m_moon_texture;

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -508,21 +508,26 @@ void WieldMeshSceneNode::setColor(video::SColor c)
 	u8 red = c.getRed();
 	u8 green = c.getGreen();
 	u8 blue = c.getBlue();
-	u32 mc = mesh->getMeshBufferCount();
+
+	const u32 mc = mesh->getMeshBufferCount();
+	if (mc > m_colors.size())
+		m_colors.resize(mc);
 	for (u32 j = 0; j < mc; j++) {
 		video::SColor bc(m_base_color);
-		if ((m_colors.size() > j) && (m_colors[j].override_base))
-			bc = m_colors[j].color;
+		m_colors[j].applyOverride(bc);
 		video::SColor buffercolor(255,
 			bc.getRed() * red / 255,
 			bc.getGreen() * green / 255,
 			bc.getBlue() * blue / 255);
 		scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
 
-		if (m_enable_shaders)
-			setMeshBufferColor(buf, buffercolor);
-		else
-			colorizeMeshBuffer(buf, &buffercolor);
+		if (m_colors[j].needColorize(buffercolor)) {
+			buf->setDirty(scene::EBT_VERTEX);
+			if (m_enable_shaders)
+				setMeshBufferColor(buf, buffercolor);
+			else
+				colorizeMeshBuffer(buf, &buffercolor);
+		}
 	}
 }
 
@@ -536,8 +541,7 @@ void WieldMeshSceneNode::setNodeLightColor(video::SColor color)
 			video::SMaterial &material = m_meshnode->getMaterial(i);
 			material.EmissiveColor = color;
 		}
-	}
-	else {
+	} else {
 		setColor(color);
 	}
 }
@@ -557,6 +561,12 @@ void WieldMeshSceneNode::changeToMesh(scene::IMesh *mesh)
 		dummymesh->drop();  // m_meshnode grabbed it
 	} else {
 		m_meshnode->setMesh(mesh);
+		// without shaders recolored often for lighting
+		// otherwise only once
+		if (m_enable_shaders)
+			mesh->setHardwareMappingHint(scene::EHM_STATIC);
+		else
+			mesh->setHardwareMappingHint(scene::EHM_DYNAMIC);
 	}
 
 	m_meshnode->forEachMaterial([this] (auto &mat) {
@@ -651,8 +661,7 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 		}
 		}
 
-		u32 mc = mesh->getMeshBufferCount();
-		for (u32 i = 0; i < mc; ++i) {
+		for (u32 i = 0; i < mesh->getMeshBufferCount(); ++i) {
 			scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
 			video::SMaterial &material = buf->getMaterial();
 			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
@@ -667,6 +676,12 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 
 		rotateMeshXZby(mesh, -45);
 		rotateMeshYZby(mesh, -30);
+	}
+
+	// might need to be re-colorized, this is done only when needed
+	if (mesh) {
+		mesh->setHardwareMappingHint(scene::EHM_DYNAMIC, scene::EBT_VERTEX);
+		mesh->setHardwareMappingHint(scene::EHM_STATIC, scene::EBT_INDEX);
 	}
 	result->mesh = mesh;
 }
@@ -722,11 +737,10 @@ void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
 	bool use_shaders, bool set_material, const video::E_MATERIAL_TYPE *mattype,
 	std::vector<ItemPartColor> *colors, bool apply_scale)
 {
-	u32 mc = mesh->getMeshBufferCount();
+	const u32 mc = mesh->getMeshBufferCount();
 	// Allocate colors for existing buffers
 	colors->clear();
-	for (u32 i = 0; i < mc; ++i)
-		colors->push_back(ItemPartColor());
+	colors->resize(mc);
 
 	for (u32 i = 0; i < mc; ++i) {
 		const TileSpec *tile = &(f.tiles[i]);
@@ -741,11 +755,11 @@ void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
 				mesh->addMeshBuffer(copy);
 				copy->drop();
 				buf = copy;
-				colors->push_back(
-					ItemPartColor(layer->has_color, layer->color));
+				colors->emplace_back(layer->has_color, layer->color);
 			} else {
 				(*colors)[i] = ItemPartColor(layer->has_color, layer->color);
 			}
+
 			video::SMaterial &material = buf->getMaterial();
 			if (set_material)
 				layer->applyMaterialOptions(material);
@@ -768,6 +782,7 @@ void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
 				}
 				material.setTexture(2, layer->flags_texture);
 			}
+
 			if (apply_scale && tile->world_aligned) {
 				u32 n = buf->getVertexCount();
 				for (u32 k = 0; k != n; ++k)

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -29,38 +29,54 @@ class ITextureSource;
 struct ContentFeatures;
 class ShadowRenderer;
 
-/*!
+/*
  * Holds color information of an item mesh's buffer.
  */
-struct ItemPartColor
+class ItemPartColor
 {
-	/*!
-	 * If this is false, the global base color of the item
-	 * will be used instead of the specific color of the
-	 * buffer.
+	/*
+	 * Optional color that overrides the global base color.
 	 */
-	bool override_base = false;
-	/*!
-	 * The color of the buffer.
+	video::SColor override_color;
+	/*
+	 * Stores the last color this mesh buffer was colorized as.
 	 */
-	video::SColor color = 0;
+	video::SColor last_colorized;
+
+	// saves some bytes compared to two std::optionals
+	bool override_color_set = false;
+	bool last_colorized_set = false;
+
+public:
 
 	ItemPartColor() = default;
 
 	ItemPartColor(bool override, video::SColor color) :
-			override_base(override), color(color)
-	{
+		override_color(color), override_color_set(override)
+	{}
+
+	void applyOverride(video::SColor &dest) const {
+		if (override_color_set)
+			dest = override_color;
+	}
+
+	bool needColorize(video::SColor target) {
+		if (last_colorized_set && target == last_colorized)
+			return false;
+		last_colorized_set = true;
+		last_colorized = target;
+		return true;
 	}
 };
 
 struct ItemMesh
 {
 	scene::IMesh *mesh = nullptr;
-	/*!
+	/*
 	 * Stores the color of each mesh buffer.
 	 */
 	std::vector<ItemPartColor> buffer_colors;
-	/*!
+	/*
 	 * If false, all faces of the item should have the same brightness.
 	 * Disables shading based on normal vectors.
 	 */

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -51,7 +51,6 @@ void set_default_settings()
 	settings->setDefault("enable_mesh_cache", "false");
 	settings->setDefault("mesh_generation_interval", "0");
 	settings->setDefault("mesh_generation_threads", "0");
-	settings->setDefault("enable_vbo", "true");
 	settings->setDefault("free_move", "false");
 	settings->setDefault("pitch_move", "false");
 	settings->setDefault("fast_move", "false");

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -407,7 +407,6 @@ void GUIEngine::cloudInit()
 void GUIEngine::drawClouds(float dtime)
 {
 	m_cloud.clouds->step(dtime*3);
-	m_cloud.clouds->render();
 	m_smgr->drawAll();
 }
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -391,7 +391,7 @@ GUIEngine::~GUIEngine()
 /******************************************************************************/
 void GUIEngine::cloudInit()
 {
-	m_cloud.clouds = make_irr<Clouds>(m_smgr, -1, rand());
+	m_cloud.clouds = make_irr<Clouds>(m_smgr, nullptr, -1, rand());
 	m_cloud.clouds->setHeight(100.0f);
 	m_cloud.clouds->update(v3f(0, 0, 0), video::SColor(255,240,240,255));
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -394,6 +394,9 @@ GUIEngine::~GUIEngine()
 /******************************************************************************/
 void GUIEngine::cloudInit()
 {
+	m_shader_source->addShaderConstantSetterFactory(
+		new FogShaderConstantSetterFactory());
+
 	m_cloud.clouds = make_irr<Clouds>(m_smgr, m_shader_source.get(), -1, rand());
 	m_cloud.clouds->setHeight(100.0f);
 	m_cloud.clouds->update(v3f(0, 0, 0), video::SColor(255,240,240,255));

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -285,10 +285,10 @@ bool GUIEngine::loadMainMenuScript()
 void GUIEngine::run()
 {
 	IrrlichtDevice *device = m_rendering_engine->get_raw_device();
+	video::IVideoDriver *driver = device->getVideoDriver();
+
 	// Always create clouds because they may or may not be
 	// needed based on the game selected
-	video::IVideoDriver *driver = m_rendering_engine->get_video_driver();
-
 	cloudInit();
 
 	unsigned int text_height = g_fontengine->getTextHeight();

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -19,25 +19,26 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "guiEngine.h"
 
-#include <IGUIStaticText.h>
-#include <ICameraSceneNode.h>
-#include "client/renderingengine.h"
-#include "scripting_mainmenu.h"
-#include "config.h"
-#include "version.h"
-#include "porting.h"
-#include "filesys.h"
-#include "settings.h"
-#include "guiMainMenu.h"
-#include "sound.h"
-#include "httpfetch.h"
-#include "log.h"
 #include "client/fontengine.h"
 #include "client/guiscalingfilter.h"
-#include "irrlicht_changes/static_text.h"
+#include "client/renderingengine.h"
+#include "client/shader.h"
 #include "client/tile.h"
+#include "config.h"
 #include "content/content.h"
 #include "content/mods.h"
+#include "filesys.h"
+#include "guiMainMenu.h"
+#include "httpfetch.h"
+#include "irrlicht_changes/static_text.h"
+#include "log.h"
+#include "porting.h"
+#include "scripting_mainmenu.h"
+#include "settings.h"
+#include "sound.h"
+#include "version.h"
+#include <ICameraSceneNode.h>
+#include <IGUIStaticText.h>
 
 #if USE_SOUND
 	#include "client/sound/sound_openal.h"
@@ -138,6 +139,10 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 
 	// create texture source
 	m_texture_source = std::make_unique<MenuTextureSource>(rendering_engine->get_video_driver());
+
+	// create shader source
+	// (currently only used by clouds)
+	m_shader_source.reset(createShaderSource());
 
 	// create soundmanager
 #if USE_SOUND
@@ -375,23 +380,21 @@ GUIEngine::~GUIEngine()
 
 	m_sound_manager.reset();
 
-	m_irr_toplefttext->setText(L"");
+	m_irr_toplefttext->remove();
 
-	//clean up texture pointers
+	m_cloud.clouds.reset();
+
+	// delete textures
 	for (image_definition &texture : m_textures) {
 		if (texture.texture)
 			m_rendering_engine->get_video_driver()->removeTexture(texture.texture);
 	}
-
-	m_texture_source.reset();
-
-	m_cloud.clouds.reset();
 }
 
 /******************************************************************************/
 void GUIEngine::cloudInit()
 {
-	m_cloud.clouds = make_irr<Clouds>(m_smgr, nullptr, -1, rand());
+	m_cloud.clouds = make_irr<Clouds>(m_smgr, m_shader_source.get(), -1, rand());
 	m_cloud.clouds->setHeight(100.0f);
 	m_cloud.clouds->update(v3f(0, 0, 0), video::SColor(255,240,240,255));
 

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -280,16 +280,10 @@ private:
 	/** initialize cloud subsystem */
 	void cloudInit();
 	/** do preprocessing for cloud subsystem */
-	void cloudPreProcess();
-	/** do postprocessing for cloud subsystem */
-	void cloudPostProcess(u32 frametime_min, IrrlichtDevice *device);
+	void drawClouds(float dtime);
 
 	/** internam data required for drawing clouds */
 	struct clouddata {
-		/** delta time since last cloud processing */
-		f32 dtime;
-		/** absolute time of last cloud processing */
-		u32 lasttime;
 		/** pointer to cloud class */
 		irr_ptr<Clouds> clouds;
 		/** camera required for drawing clouds */

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -203,6 +203,8 @@ private:
 	MainMenuData                         *m_data = nullptr;
 	/** texture source */
 	std::unique_ptr<ISimpleTextureSource> m_texture_source;
+	/** shader source*/
+	std::unique_ptr<IShaderSource>        m_shader_source;
 	/** sound manager*/
 	std::unique_ptr<ISoundManager>        m_sound_manager;
 

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -54,6 +54,7 @@ struct image_definition {
 class GUIEngine;
 class RenderingEngine;
 class MainMenuScripting;
+class IWritableShaderSource;
 struct MainMenuData;
 
 /******************************************************************************/
@@ -204,7 +205,7 @@ private:
 	/** texture source */
 	std::unique_ptr<ISimpleTextureSource> m_texture_source;
 	/** shader source */
-	std::unique_ptr<IShaderSource>        m_shader_source;
+	std::unique_ptr<IWritableShaderSource> m_shader_source;
 	/** sound manager */
 	std::unique_ptr<ISoundManager>        m_sound_manager;
 

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -203,9 +203,9 @@ private:
 	MainMenuData                         *m_data = nullptr;
 	/** texture source */
 	std::unique_ptr<ISimpleTextureSource> m_texture_source;
-	/** shader source*/
+	/** shader source */
 	std::unique_ptr<IShaderSource>        m_shader_source;
-	/** sound manager*/
+	/** sound manager */
 	std::unique_ptr<ISoundManager>        m_sound_manager;
 
 	/** representation of form source to be used in mainmenu formspec */

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -1046,6 +1046,7 @@ void CGUITTFont::createSharedPlane()
 	buf->append(vertices, 4, indices, 6);
 
 	shared_plane_.addMeshBuffer( buf );
+	shared_plane_.setHardwareMappingHint(EHM_STATIC);
 
 	shared_plane_ptr_ = &shared_plane_;
 	buf->drop(); //the addMeshBuffer method will grab it, so we can drop this ptr.

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -466,10 +466,6 @@ public:
 		if (!inventory_image.empty())
 			cc->inventory_texture = tsrc->getTexture(inventory_image);
 		getItemMesh(client, item, &(cc->wield_mesh));
-		// note: vertices are modified frequently (see hud.cpp) so only indices
-		// can be mapped
-		if (auto mesh = cc->wield_mesh.mesh)
-			mesh->setHardwareMappingHint(scene::EHM_STATIC, scene::EBT_INDEX);
 
 		cc->palette = tsrc->getPalette(def.palette_image);
 

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -462,11 +462,14 @@ public:
 		// Create new ClientCached
 		auto cc = std::make_unique<ClientCached>();
 
-		// Create an inventory texture
 		cc->inventory_texture = NULL;
 		if (!inventory_image.empty())
 			cc->inventory_texture = tsrc->getTexture(inventory_image);
 		getItemMesh(client, item, &(cc->wield_mesh));
+		// note: vertices are modified frequently (see hud.cpp) so only indices
+		// can be mapped
+		if (auto mesh = cc->wield_mesh.mesh)
+			mesh->setHardwareMappingHint(scene::EHM_STATIC, scene::EBT_INDEX);
 
 		cc->palette = tsrc->getPalette(def.palette_image);
 


### PR DESCRIPTION
~~:warning: requires https://github.com/minetest/irrlicht/pull/292~~

**goal**:
* use more VBOs (not constantly uploading data to the GPU is supposed to be good for performance)
* move cloud rendering away from immediate mode and use a shader for further optimization
* some code cleanup

**applicability**: dunno, but I had fun and learned stuff while working on the cloud code.

**note for second commit**:
We would need to wrap every call to `setHardwareMappingHint` (try ctrl+f) into an if that checks the setting and also cache that etc. All while there is essentially no reason to disable VBOs.
(Irrlicht won't use them if they are not supported for some reason.)

## How to merge

Keep all commits that start with upper-case letters
Squash others into one and name it `VBO-related optimizations and improvements (#14395)`

## To do

This PR is Ready for Review.

## How to test

1. check and make sure dynamic shadows still work
2. open main menu, observe clouds
3. use test script and enjoy rapidly changing cloud cover (join a mgv6 world or MTG will get in the way)
```lua
local passed = 0
core.register_globalstep(function(dtime)
	passed = passed + dtime
	if passed < 0.4 then
		return
	end
	passed = passed - 0.4

	local t = core.get_us_time() / (1000*1000)
	for _, player in ipairs(minetest.get_connected_players()) do
		player:set_clouds({
			density = (1 + math.sin(t)) / 2
		})
	end
end)
```
4. watch cloud colors at dusk (`/time 19:00`)
5. check if anything is actually faster than before?
