### PR TITLE
Make jpeg-turbo as the default library for compiling in macOS

### DIFF
--- a/doc/compiling/macos.md
+++ b/doc/compiling/macos.md
@@ -8,7 +8,7 @@
 Install dependencies with homebrew:
 
 ```
-brew install cmake freetype gettext gmp hiredis jpeg jsoncpp leveldb libogg libpng libvorbis luajit zstd gettext
+brew install cmake freetype gettext gmp hiredis jpeg-turbo jsoncpp leveldb libogg libpng libvorbis luajit zstd gettext
 ```
 
 ## Download


### PR DESCRIPTION
Fix jpeg compiling by making it jpeg-turbo as the default

Add compact, short information about your PR for easier understanding:

- Goal of the PR
Fix macOS compiling
- How does the PR work?
changing library from jpeg to jpeg-turbo
- Does it resolve any reported issue?
Yes it resolves #14386 . At least I hope so.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
No, probably.

Ready for Review.

## How to test
Attempt to compile Minetest for macOS. I don't know if previously compiling was broken only to Apple Silicon or any MacBook. 