### PR TITLE
Use forward-slash (/) for path separator in translation files

### DIFF
--- a/util/mod_translation_updater.py
+++ b/util/mod_translation_updater.py
@@ -425,6 +425,7 @@ def generate_template(folder, mod_name):
 		sources = sorted(list(sources), key=str.lower)
 		newSources = []
 		for i in sources:
+			i = "/".join(os.path.split(i)).lstrip("/")
 			newSources.append(f"{symbol_source_prefix} {i} {symbol_source_suffix}")
 		dOut[d] = newSources
 


### PR DESCRIPTION
**Goal of the PR**
This PR aims to make file path separators (in `*.tr` files) uniform across platforms (`/`).

**How does the PR work?**
This PR adds string replacement by splitting the path (depends on OS) and joining it again using forward-slash (`/`). The `lstrip` (left trim) call is to make sure that there are no slashes at the beginning of file paths.

**Does it resolve any reported issue?**
This PR tries to fix #14089.

## To do

This PR is Ready for Review.

## How to test

1. On Windows, run the script with `-p` flag for a mod with scripts inside folders.
2. Check that the file path separators are forward-slash (`/`).
3. Try step 1 to 2 on other platforms/operating systems.