### PR TITLE
[no squash] Fix node callbacks unit test

### DIFF
--- a/builtin/emerge/env.lua
+++ b/builtin/emerge/env.lua
@@ -31,11 +31,6 @@ function core.get_node(pos)
 	return core.vmanip:get_node_at(pos)
 end
 
-function core.get_node_or_nil(pos)
-	local node = core.vmanip:get_node_at(pos)
-	return node.name ~= "ignore" and node
-end
-
 function core.get_perlin(seed, octaves, persist, spread)
 	local params
 	if type(seed) == "table" then

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5919,6 +5919,7 @@ Environment access
       returns `{name="ignore", param1=0, param2=0}` for unloaded areas.
 * `minetest.get_node_or_nil(pos)`
     * Same as `get_node` but returns `nil` for unloaded areas.
+    * Note that areas may still contain "ignore" despite being loaded.
 * `minetest.get_node_light(pos[, timeofday])`
     * Gets the light value at the given position. Note that the light value
       "inside" the node at the given position is returned, so you usually want

--- a/games/devtest/mods/unittests/init.lua
+++ b/games/devtest/mods/unittests/init.lua
@@ -108,9 +108,9 @@ local function wait_for_player(callback)
 	end)
 end
 
-local function wait_for_map(player, callback)
+local function wait_for_map(pos, callback)
 	local function check()
-		if core.get_node_or_nil(player:get_pos()) ~= nil then
+		if core.get_node(pos).name ~= "ignore" then
 			callback()
 		else
 			core.after(0, check)
@@ -119,8 +119,8 @@ local function wait_for_map(player, callback)
 	check()
 end
 
+-- This runs in a coroutine so it uses await()
 function unittests.run_all()
-	-- This runs in a coroutine so it uses await().
 	local counters = { time = 0, total = 0, passed = 0 }
 
 	-- Run standalone tests first
@@ -143,10 +143,11 @@ function unittests.run_all()
 	end
 
 	-- Wait for the world to generate/load, run tests that require map access
+	local pos = player:get_pos():round():offset(0, 5, 0)
+	core.forceload_block(pos, true, -1)
 	await(function(cb)
-		wait_for_map(player, cb)
+		wait_for_map(pos, cb)
 	end)
-	local pos = vector.round(player:get_pos())
 	for idx = 1, #unittests.list do
 		local def = unittests.list[idx]
 		if not def.done then

--- a/games/devtest/mods/unittests/misc.lua
+++ b/games/devtest/mods/unittests/misc.lua
@@ -99,17 +99,24 @@ local function test_clear_meta(_, pos)
 end
 unittests.register("test_clear_meta", test_clear_meta, {map=true})
 
-local on_punch_called
-minetest.register_on_punchnode(function()
+local on_punch_called, on_place_called
+core.register_on_placenode(function()
+	on_place_called = true
+end)
+core.register_on_punchnode(function()
 	on_punch_called = true
 end)
-unittests.register("test_punch_node", function(_, pos)
-	minetest.place_node(pos, {name="basenodes:dirt"})
+local function test_node_callbacks(_, pos)
+	on_place_called = false
 	on_punch_called = false
-	minetest.punch_node(pos)
-	minetest.remove_node(pos)
-	-- currently failing: assert(on_punch_called)
-end, {map=true})
+
+	core.place_node(pos, {name="basenodes:dirt"})
+	assert(on_place_called, "on_place not called")
+	core.punch_node(pos)
+	assert(on_punch_called, "on_punch not called")
+	core.remove_node(pos)
+end
+unittests.register("test_node_callbacks", test_node_callbacks, {map=true})
 
 local function test_compress()
 	-- This text should be compressible, to make sure the results are... normal

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1544,6 +1544,19 @@ void ModApiEnv::InitializeClient(lua_State *L, int top)
 	if (!vm)                     \
 		return 0
 
+// get_node_or_nil(pos)
+int ModApiEnvVM::l_get_node_or_nil(lua_State *L)
+{
+	GET_VM_PTR;
+
+	v3s16 pos = read_v3s16(L, 1);
+	if (vm->exists(pos))
+		pushnode(L, vm->getNodeRefUnsafe(pos));
+	else
+		lua_pushnil(L);
+	return 1;
+}
+
 // get_node_max_level(pos)
 int ModApiEnvVM::l_get_node_max_level(lua_State *L)
 {
@@ -1713,6 +1726,7 @@ MMVManip *ModApiEnvVM::getVManip(lua_State *L)
 void ModApiEnvVM::InitializeEmerge(lua_State *L, int top)
 {
 	// other, more trivial functions are in builtin/emerge/env.lua
+	API_FCT(get_node_or_nil);
 	API_FCT(get_node_max_level);
 	API_FCT(get_node_level);
 	API_FCT(set_node_level);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -250,6 +250,9 @@ public:
 class ModApiEnvVM : public ModApiEnvBase {
 private:
 
+	// get_node_or_nil(pos)
+	static int l_get_node_or_nil(lua_State *L);
+
 	// get_node_max_level(pos)
 	static int l_get_node_max_level(lua_State *L);
 


### PR DESCRIPTION
first commit:
```
00:37 <+sfan5> >call get_node_or_nil
00:37 <+sfan5> >it returns "ignore" because the area is unloaded
00:37 <+sfan5> I am being trolled
00:51 <+sfan5> so apparently blocks get created when the mapgen is invoked but contents only appear once the mapgen finishes
00:51 <+sfan5> not sure if that's a bug
```