### PR TITLE
Add padding to settings tab buttons

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -456,7 +456,7 @@ local function get_formspec(dialogdata)
 	local scrollbar_w = core.settings:get_bool("enable_touch") and 0.6 or 0.4
 
 	local left_pane_width = core.settings:get_bool("enable_touch") and 4.5 or 4.25
-	local left_pane_padding = 0.2
+	local left_pane_padding = 0.25
 	local search_width = left_pane_width + scrollbar_w - (0.75 * 2)
 
 	local back_w = 3

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -456,6 +456,7 @@ local function get_formspec(dialogdata)
 	local scrollbar_w = core.settings:get_bool("enable_touch") and 0.6 or 0.4
 
 	local left_pane_width = core.settings:get_bool("enable_touch") and 4.5 or 4.25
+	local left_pane_padding = 0.2
 	local search_width = left_pane_width + scrollbar_w - (0.75 * 2)
 
 	local back_w = 3
@@ -516,9 +517,9 @@ local function get_formspec(dialogdata)
 			y = y + 0.82
 		end
 		fs[#fs + 1] = ("box[0,%f;%f,0.8;%s]"):format(
-			y, left_pane_width, other_page.id == page_id and "#467832FF" or "#3339")
+			y, left_pane_width-left_pane_padding, other_page.id == page_id and "#467832FF" or "#3339")
 		fs[#fs + 1] = ("button[0,%f;%f,0.8;page_%s;%s]")
-			:format(y, left_pane_width, other_page.id, fgettext(other_page.title))
+			:format(y, left_pane_width-left_pane_padding, other_page.id, fgettext(other_page.title))
 		y = y + 0.82
 	end
 


### PR DESCRIPTION
compact, short information about this PR for easier understanding:

- Goal of the PR is to make Minetest ever so slightly less ugly and not as a pain to use.
- How does the PR work? It's simple, add padding to buttons where it's obviously and objectively needed.
- Does it resolve any reported issue? No, there does not need to be a report for a such a glaring issue to fix it.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)? idk I haven't seen it
- If not a bug fix, why is this PR needed? What usecases does it solve? It solves the massive and big issue everyone who I paid attention to has been complaining about, lack of padding.

## To do

This PR is a ~~Work in Progress~~ / Ready for Review.
<!-- ^ delete one -->

## How to test

<!-- Example code or instructions -->
idk, figure it out.

## Complains

if you have any complains please send them to my spam folder: spam@kotek900.com
