### PR TITLE
Add support for ContentDB package translation

### DIFF
--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -646,7 +646,7 @@ local function fetch_pkgs()
 
 	local languages
 	local current_language = core.get_language()
-	if current_language ~= "" and current_language ~= "en" then
+	if current_language ~= "" then
 		languages = { current_language, "en;q=0.8" }
 	else
 		languages = { "en" }

--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -154,7 +154,9 @@ local function start_install(package, reason)
 
 				if conf_path then
 					local conf = Settings(conf_path)
-					conf:set("title", package.title)
+					if not conf:get("title") then
+						conf:set("title", package.title)
+					end
 					if not name_is_title then
 						conf:set("name", package.name)
 					end
@@ -642,8 +644,21 @@ local function fetch_pkgs()
 		end
 	end
 
+	local languages
+	local current_language = core.get_language()
+	if current_language ~= "" and current_language ~= "en" then
+		languages = { current_language, "en;q=0.8" }
+	else
+		languages = { "en" }
+	end
+
 	local http = core.get_http_api()
-	local response = http.fetch_sync({ url = url })
+	local response = http.fetch_sync({
+		url = url,
+		extra_headers = {
+			"Accept-Language: " .. table.concat(languages, ", ")
+		},
+	})
 	if not response.succeeded then
 		return
 	end

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -934,6 +934,17 @@ int ModApiMainMenu::l_get_video_drivers(lua_State *L)
 }
 
 /******************************************************************************/
+int ModApiMainMenu::l_get_language(lua_State *L)
+{
+	std::string lang = gettext("LANG_CODE");
+	if (lang == "LANG_CODE")
+		lang = "en";
+
+	lua_pushstring(L, lang.c_str());
+	return 1;
+}
+
+/******************************************************************************/
 int ModApiMainMenu::l_gettext(lua_State *L)
 {
 	const char *srctext = luaL_checkstring(L, 1);
@@ -1151,6 +1162,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(get_mainmenu_path);
 	API_FCT(show_path_select_dialog);
 	API_FCT(download_file);
+	API_FCT(get_language);
 	API_FCT(gettext);
 	API_FCT(get_video_drivers);
 	API_FCT(get_window_info);
@@ -1191,5 +1203,6 @@ void ModApiMainMenu::InitializeAsync(lua_State *L, int top)
 	API_FCT(download_file);
 	API_FCT(get_min_supp_proto);
 	API_FCT(get_max_supp_proto);
+	API_FCT(get_language);
 	API_FCT(gettext);
 }

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -938,7 +938,7 @@ int ModApiMainMenu::l_get_language(lua_State *L)
 {
 	std::string lang = gettext("LANG_CODE");
 	if (lang == "LANG_CODE")
-		lang = "en";
+		lang = "";
 
 	lua_pushstring(L, lang.c_str());
 	return 1;

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -74,6 +74,8 @@ private:
 
 	static int l_get_mapgen_names(lua_State *L);
 
+	static int l_get_language(lua_State *L);
+
 	static int l_gettext(lua_State *L);
 
 	//packages


### PR DESCRIPTION
Whilst not implemented by ContentDB yet, including "Accept-Language" will allow localizing the package list in the future.

- Roadmap: UI/UX

## To do

This PR is Ready for Review

## How to test

* Run `nc -l -p 8080`
* Set `contentdb_url = http://localhost:8080`
* Run Minetest in English, and open the ContentDB dialog
* See `Accept-Language: en` in request headers
* Run Minetest in another language (I recommend trying both env var `LANGUAGE` and the language setting), and open the ContentDB dialog
* See `Accept-Language: fr, en;q=0.8` in request headers

## Additional context

[Accept-Language on mdn](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language)

[ContentDB PR](https://github.com/minetest/contentdb/pull/517) (this PR can be merged before the CDB PR)