### PR TITLE
Mainmenu: Replace sync HTTP with async HTTP to fix hanging

### DIFF
--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -115,14 +115,12 @@ local time = 0.0
 local time_next = math.huge
 
 local register_step
-if INIT == "game" then
-	register_step = core.register_globalstep
-elseif INIT == "mainmenu" then
+if INIT == "mainmenu" then
 	register_step = function(callback)
 		core.step_handler = callback
 	end
 else
-	assert(false)
+	register_step = core.register_globalstep
 end
 
 register_step(function(dtime)

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -114,7 +114,18 @@ end
 local time = 0.0
 local time_next = math.huge
 
-core.register_globalstep(function(dtime)
+local register_step
+if INIT == "game" then
+	register_step = core.register_globalstep
+elseif INIT == "mainmenu" then
+	register_step = function(callback)
+		core.step_handler = callback
+	end
+else
+	assert(false)
+end
+
+register_step(function(dtime)
 	time = time + dtime
 
 	if time < time_next then

--- a/builtin/common/http.lua
+++ b/builtin/common/http.lua
@@ -1,0 +1,20 @@
+-- HTTP callback interface
+
+core.set_http_api_lua(function(httpenv)
+	httpenv.fetch = function(req, callback)
+		local handle = httpenv.fetch_async(req)
+
+		local function update_http_status()
+			local res = httpenv.fetch_async_get(handle)
+			if res.completed then
+				callback(res)
+			else
+				core.after(0, update_http_status)
+			end
+		end
+		core.after(0, update_http_status)
+	end
+
+	return httpenv
+end)
+core.set_http_api_lua = nil

--- a/builtin/game/init.lua
+++ b/builtin/game/init.lua
@@ -18,6 +18,7 @@ if core.settings:get_bool("profiler.load") then
 end
 
 dofile(commonpath .. "after.lua")
+dofile(commonpath .. "http.lua")
 dofile(commonpath .. "mod_storage.lua")
 dofile(gamepath .. "item_entity.lua")
 dofile(gamepath .. "deprecated.lua")

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -201,28 +201,6 @@ function core.raillike_group(name)
 end
 
 
--- HTTP callback interface
-
-core.set_http_api_lua(function(httpenv)
-	httpenv.fetch = function(req, callback)
-		local handle = httpenv.fetch_async(req)
-
-		local function update_http_status()
-			local res = httpenv.fetch_async_get(handle)
-			if res.completed then
-				callback(res)
-			else
-				core.after(0, update_http_status)
-			end
-		end
-		core.after(0, update_http_status)
-	end
-
-	return httpenv
-end)
-core.set_http_api_lua = nil
-
-
 function core.close_formspec(player_name, formname)
 	return core.show_formspec(player_name, formname, "")
 end

--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -648,7 +648,7 @@ local function fetch_pkgs(callback)
 	end
 
 	local http = core.get_http_api()
-	local response = http.fetch({ url = url }, function(response)
+	http.fetch({ url = url }, function(response)
 		if not response.succeeded then
 			return callback(nil)
 		end

--- a/builtin/mainmenu/content/dlg_contentstore.lua
+++ b/builtin/mainmenu/content/dlg_contentstore.lua
@@ -84,20 +84,20 @@ local function get_download_url(package, reason)
 	return ret
 end
 
-local function extract(filename)
+local function extract(param)
 	local tempfolder = core.get_temp_path()
 	if tempfolder ~= "" then
 		tempfolder = tempfolder .. DIR_DELIM .. "MT_" .. math.random(1, 1024000)
-		if not core.extract_zip(filename, tempfolder) then
+		if not core.extract_zip(param.filename, tempfolder) then
 			tempfolder = nil
 		end
 	else
 		tempfolder = nil
 	end
-	os.remove(filename)
+	os.remove(param.filename)
 	if not tempfolder then
 		return {
-			msg = fgettext_ne("Failed to extract \"$1\" (unsupported file type or broken archive)", package.title),
+			msg = fgettext_ne("Failed to extract \"$1\" (unsupported file type or broken archive)", param.package.title),
 		}
 	end
 
@@ -129,7 +129,7 @@ local function download_and_extract(package, url, callback)
 			return err_out()
 		end
 
-		if not core.handle_async(extract, filename, callback) then
+		if not core.handle_async(extract, {package = package, filename = filename}, callback) then
 			return err_out()
 		end
 	end)
@@ -658,7 +658,7 @@ local function fetch_pkgs(callback)
 			return callback(nil)
 		end
 		local aliases = {}
-	
+
 		for _, package in pairs(packages) do
 			local name_len = #package.name
 			-- This must match what store.update_paths() does!
@@ -668,9 +668,9 @@ local function fetch_pkgs(callback)
 			else
 				package.id = package.id .. package.name
 			end
-	
+
 			package.url_part = core.urlencode(package.author) .. "/" .. core.urlencode(package.name)
-	
+
 			if package.aliases then
 				for _, alias in ipairs(package.aliases) do
 					-- We currently don't support name changing
@@ -681,7 +681,7 @@ local function fetch_pkgs(callback)
 				end
 			end
 		end
-	
+
 		return callback({ packages = packages, aliases = aliases })
 	end)
 end

--- a/builtin/mainmenu/content/update_detector.lua
+++ b/builtin/mainmenu/content/update_detector.lua
@@ -37,27 +37,24 @@ do
 end
 
 
-local function fetch_latest_releases()
+--- Get a table from package key (author/name) to latest release id
+---
+--- @param callback function that takes a single argument, table or nil
+local function get_latest_releases(callback)
 	local version = core.get_version()
 	local base_url = core.settings:get("contentdb_url")
 	local url = base_url ..
 			"/api/updates/?type=mod&type=game&type=txp&protocol_version=" ..
 			core.get_max_supp_proto() .. "&engine_version=" .. core.urlencode(version.string)
+
 	local http = core.get_http_api()
-	local response = http.fetch_sync({ url = url })
-	if not response.succeeded then
-		return
-	end
+	http.fetch({ url = url }, function(response)
+		if not response.succeeded then
+			return callback(nil)
+		end
 
-	return core.parse_json(response.data)
-end
-
-
---- Get a table from package key (author/name) to latest release id
----
---- @param callback function that takes a single argument, table or nil
-local function get_latest_releases(callback)
-	core.handle_async(fetch_latest_releases, nil, callback)
+		return callback(core.parse_json(response.data))
+	end)
 end
 
 

--- a/builtin/mainmenu/dlg_version_info.lua
+++ b/builtin/mainmenu/dlg_version_info.lua
@@ -164,14 +164,12 @@ function check_new_version()
 
 	core.settings:set("update_last_checked", tostring(time_now))
 
-	core.handle_async(function(params)
-		local http = core.get_http_api()
-		return http.fetch_sync(params)
-	end, { url = url }, function(result)
-		local json = result.succeeded and core.parse_json(result.data)
+	local http = core.get_http_api()
+	http.fetch({ url = url }, function(response)
+		local json = response.succeeded and core.parse_json(response.data)
 		if type(json) ~= "table" or not json.latest then
 			core.log("error", "Failed to read JSON output from " .. url ..
-					", status code = " .. result.code)
+					", status code = " .. response.code)
 			return
 		end
 

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -30,6 +30,8 @@ defaulttexturedir = core.get_texturepath_share() .. DIR_DELIM .. "base" ..
 
 dofile(menupath .. DIR_DELIM .. "misc.lua")
 
+dofile(basepath .. "common" .. DIR_DELIM .. "after.lua")
+dofile(basepath .. "common" .. DIR_DELIM .. "http.lua")
 dofile(basepath .. "common" .. DIR_DELIM .. "filterlist.lua")
 dofile(basepath .. "fstk" .. DIR_DELIM .. "buttonbar.lua")
 dofile(basepath .. "fstk" .. DIR_DELIM .. "dialog.lua")

--- a/builtin/mainmenu/serverlistmgr.lua
+++ b/builtin/mainmenu/serverlistmgr.lua
@@ -140,7 +140,7 @@ function serverlistmgr.sync()
 			if not response.succeeded then
 				return
 			end
-	
+
 			local result = core.parse_json(response.data)
 			if not result or type(result.continent) ~= "string" then
 				return

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -10875,6 +10875,10 @@ Used by `HTTPApiTable.fetch` and `HTTPApiTable.fetch_async`.
 
     post_data = "Raw POST request data string" OR {field1 = "data1", field2 = "data2"},
     -- Deprecated, use `data` instead. Forces `method = "POST"`.
+
+    output_path = "/tmp/12ef1506-68d2-4ade-a984-34d09c3d0065",
+    -- Optional, if specified the response is written to the specified file path
+    -- instead of being put into `HTTPRequestResult.data`.
 }
 ```
 

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -104,9 +104,6 @@ Filesystem
 HTTP Requests
 -------------
 
-* `core.download_file(url, target)` (possible in async calls)
-    * `url` to download, and `target` to store to
-    * returns true/false
 * `core.get_http_api()` (possible in async calls)
     * returns `HTTPApiTable` containing http functions.
     * The returned table contains the functions `fetch_sync`, `fetch_async` and
@@ -149,6 +146,10 @@ Used by `HTTPApiTable.fetch` and `HTTPApiTable.fetch_async`.
     multipart = boolean
     -- Optional, if true performs a multipart HTTP request.
     -- Default is false.
+
+    output_path = "/tmp/12ef1506-68d2-4ade-a984-34d09c3d0065",
+    -- Optional, if specified the response is written to the specified file path
+    -- instead of being put into `HTTPRequestResult.data`.
 }
 ```
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -596,36 +596,6 @@ bool GUIEngine::setTexture(texture_layer layer, const std::string &texturepath,
 }
 
 /******************************************************************************/
-bool GUIEngine::downloadFile(const std::string &url, const std::string &target)
-{
-#if USE_CURL
-	std::ofstream target_file(target.c_str(), std::ios::out | std::ios::binary);
-	if (!target_file.good()) {
-		return false;
-	}
-
-	HTTPFetchRequest fetch_request;
-	HTTPFetchResult fetch_result;
-	fetch_request.url = url;
-	fetch_request.caller = HTTPFETCH_SYNC;
-	fetch_request.timeout = std::max(MIN_HTTPFETCH_TIMEOUT,
-		(long)g_settings->getS32("curl_file_download_timeout"));
-	httpfetch_sync(fetch_request, fetch_result);
-
-	if (!fetch_result.succeeded) {
-		target_file.close();
-		fs::DeleteSingleFileOrEmptyDirectory(target);
-		return false;
-	}
-	target_file << fetch_result.data;
-
-	return true;
-#else
-	return false;
-#endif
-}
-
-/******************************************************************************/
 void GUIEngine::setTopleftText(const std::string &text)
 {
 	m_toplefttext = translate_string(utf8_to_wide(text));

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -308,7 +308,7 @@ void GUIEngine::run()
 		dtime = static_cast<f32>(t_now - t_last_frame) * 1.0e-6f;
 		t_last_frame = t_now;
 
-		m_script->step();
+		m_script->step(dtime);
 
 		sound_volume_control(m_sound_manager.get(), device->isWindowActive());
 

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -240,13 +240,6 @@ private:
 	bool setTexture(texture_layer layer, const std::string &texturepath,
 			bool tile_image, unsigned int minsize);
 
-	/**
-	 * download a file using curl
-	 * @param url url to download
-	 * @param target file to store to
-	 */
-	static bool downloadFile(const std::string &url, const std::string &target);
-
 	/** array containing pointers to current specified texture layers */
 	image_definition m_textures[TEX_LAYER_MAX];
 

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -89,6 +89,10 @@ struct HTTPFetchRequest
 	// useragent to use
 	std::string useragent;
 
+	// If output_path is not empty, the result of the request is written to
+	// output_path instead of HTTPFetchResult::data.
+	std::string output_path = "";
+
 	HTTPFetchRequest();
 };
 

--- a/src/script/cpp_api/s_mainmenu.cpp
+++ b/src/script/cpp_api/s_mainmenu.cpp
@@ -91,3 +91,25 @@ void ScriptApiMainMenu::handleMainMenuButtons(const StringMap &fields)
 	PCALL_RES(lua_pcall(L, 1, 0, error_handler));
 	lua_pop(L, 1); // Pop error handler
 }
+
+void ScriptApiMainMenu::handleStep(float dtime)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
+	// Get handler function
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "step_handler");
+	lua_remove(L, -2); // Remove core
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 1); // Pop step function
+		return;
+	}
+	luaL_checktype(L, -1, LUA_TFUNCTION);
+
+	// Call it
+	lua_pushnumber(L, dtime);
+	PCALL_RES(lua_pcall(L, 1, 0, error_handler));
+	lua_pop(L, 1); // Pop error handler
+}

--- a/src/script/cpp_api/s_mainmenu.h
+++ b/src/script/cpp_api/s_mainmenu.h
@@ -42,4 +42,10 @@ public:
 	 * @param fields data in field format
 	 */
 	void handleMainMenuButtons(const StringMap &fields);
+
+	/**
+	* call the Lua step function
+	* @param dtime time delta in seconds
+	*/
+	void handleStep(float dtime);
 };

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -193,10 +193,23 @@ int ModApiHttp::l_get_http_api(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_HTTP_API_LUA);
+	bool has_callback = lua_isfunction(L, -1);
+	// no callback in the async environment
+	if (!has_callback)
+		lua_pop(L, 1);
+
 	lua_newtable(L);
 	HTTP_API(fetch_async);
 	HTTP_API(fetch_async_get);
 	HTTP_API(fetch_sync);
+
+	if (has_callback) {
+		// Stack now looks like this:
+		// <function> <table with fetch_async, fetch_async_get, fetch_sync>
+		// Now call it to append .fetch(request, callback) to table
+		lua_call(L, 1, 1);
+	}
 
 	return 1;
 }
@@ -232,8 +245,8 @@ void ModApiHttp::Initialize(lua_State *L, int top)
 		API_FCT(get_http_api);
 	} else {
 		API_FCT(request_http_api);
-		API_FCT(set_http_api_lua);
 	}
+	API_FCT(set_http_api_lua);
 
 #else
 

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -194,22 +194,17 @@ int ModApiHttp::l_get_http_api(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_HTTP_API_LUA);
-	bool has_callback = lua_isfunction(L, -1);
-	// no callback in the async environment
-	if (!has_callback)
-		lua_pop(L, 1);
+	assert(lua_isfunction(L, -1));
 
 	lua_newtable(L);
 	HTTP_API(fetch_async);
 	HTTP_API(fetch_async_get);
 	HTTP_API(fetch_sync);
 
-	if (has_callback) {
-		// Stack now looks like this:
-		// <function> <table with fetch_async, fetch_async_get, fetch_sync>
-		// Now call it to append .fetch(request, callback) to table
-		lua_call(L, 1, 1);
-	}
+	// Stack now looks like this:
+	// <function> <table with fetch_async, fetch_async_get, fetch_sync>
+	// Now call it to append .fetch(request, callback) to table
+	lua_call(L, 1, 1);
 
 	return 1;
 }
@@ -253,12 +248,5 @@ void ModApiHttp::Initialize(lua_State *L, int top)
 	// Define this function anyway so builtin can call it without checking
 	API_FCT(set_http_api_lua);
 
-#endif
-}
-
-void ModApiHttp::InitializeAsync(lua_State *L, int top)
-{
-#if USE_CURL
-	API_FCT(get_http_api);
 #endif
 }

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -41,6 +41,8 @@ void ModApiHttp::read_http_fetch_request(lua_State *L, HTTPFetchRequest &req)
 
 	req.caller = httpfetch_caller_alloc_secure();
 	getstringfield(L, 1, "url", req.url);
+	// TODO: mainmenu / mod security!!!
+	getstringfield(L, 1, "output_path", req.output_path);
 	getstringfield(L, 1, "user_agent", req.useragent);
 	req.multipart = getboolfield_default(L, 1, "multipart", false);
 	if (getintfield(L, 1, "timeout", req.timeout))

--- a/src/script/lua_api/l_http.h
+++ b/src/script/lua_api/l_http.h
@@ -54,5 +54,4 @@ private:
 
 public:
 	static void Initialize(lua_State *L, int top);
-	static void InitializeAsync(lua_State *L, int top);
 };

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -869,28 +869,6 @@ int ModApiMainMenu::l_show_path_select_dialog(lua_State *L)
 }
 
 /******************************************************************************/
-int ModApiMainMenu::l_download_file(lua_State *L)
-{
-	const char *url    = luaL_checkstring(L, 1);
-	const char *target = luaL_checkstring(L, 2);
-
-	//check path
-	std::string absolute_destination = fs::RemoveRelativePathComponents(target);
-
-	if (ModApiMainMenu::mayModifyPath(absolute_destination)) {
-		if (GUIEngine::downloadFile(url,absolute_destination)) {
-			lua_pushboolean(L,true);
-			return 1;
-		}
-	} else {
-		errorstream << "DOWNLOAD denied: " << absolute_destination
-				<< " isn't an allowed path" << std::endl;
-	}
-	lua_pushboolean(L,false);
-	return 1;
-}
-
-/******************************************************************************/
 int ModApiMainMenu::l_get_video_drivers(lua_State *L)
 {
 	auto drivers = RenderingEngine::getSupportedVideoDrivers();
@@ -1127,7 +1105,6 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(may_modify_path);
 	API_FCT(get_mainmenu_path);
 	API_FCT(show_path_select_dialog);
-	API_FCT(download_file);
 	API_FCT(gettext);
 	API_FCT(get_video_drivers);
 	API_FCT(get_window_info);
@@ -1165,7 +1142,6 @@ void ModApiMainMenu::InitializeAsync(lua_State *L, int top)
 	API_FCT(is_dir);
 	API_FCT(extract_zip);
 	API_FCT(may_modify_path);
-	API_FCT(download_file);
 	API_FCT(get_min_supp_proto);
 	API_FCT(get_max_supp_proto);
 	API_FCT(gettext);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -146,8 +146,6 @@ private:
 
 	static int l_may_modify_path(lua_State *L);
 
-	static int l_download_file(lua_State *L);
-
 	static int l_get_video_drivers(lua_State *L);
 
 	//version compatibility

--- a/src/script/scripting_mainmenu.cpp
+++ b/src/script/scripting_mainmenu.cpp
@@ -87,8 +87,9 @@ void MainMenuScripting::registerLuaClasses(lua_State *L, int top)
 }
 
 /******************************************************************************/
-void MainMenuScripting::step()
+void MainMenuScripting::step(float dtime)
 {
+	handleStep(dtime);
 	asyncEngine.step(getStack());
 }
 

--- a/src/script/scripting_mainmenu.cpp
+++ b/src/script/scripting_mainmenu.cpp
@@ -72,7 +72,6 @@ void MainMenuScripting::initializeModApi(lua_State *L, int top)
 	asyncEngine.registerStateInitializer(registerLuaClasses);
 	asyncEngine.registerStateInitializer(ModApiMainMenu::InitializeAsync);
 	asyncEngine.registerStateInitializer(ModApiUtil::InitializeAsync);
-	asyncEngine.registerStateInitializer(ModApiHttp::InitializeAsync);
 
 	// Initialize async environment
 	//TODO possibly make number of async threads configurable

--- a/src/script/scripting_mainmenu.h
+++ b/src/script/scripting_mainmenu.h
@@ -35,7 +35,7 @@ public:
 	MainMenuScripting(GUIEngine* guiengine);
 
 	// Global step handler to pass back async events
-	void step();
+	void step(float dtime);
 
 	// Pass async events from engine to async threads
 	u32 queueAsync(std::string &&serialized_func,


### PR DESCRIPTION
Fixes #12815, "if I try to start a game while I'm downloading a mod, Minetest hangs", "if I try to close Minetest while I'm downloading a mod, Minetest hangs", etc. This issue is a common cause of ANRs on Android.

This PR works by making the callback-based async HTTP API usable in the mainmenu and using it instead of the sync HTTP API.

Alternative PR: #14412

**Pros of this PR**

- I know what I'm doing

**Cons of this PR**

- touches a lot of code
- requires additional effort to keep stuff like JSON decoding, ZIP unpacking, etc. in a worker thread

## To do

This PR is a Work in Progress.

- [ ] Decide whether this or the alternative PR is the right approach
- [ ] Fix mod security

## How to test

Start downloading a package from ContentDB and try to close Minetest. Verify that it doesn't hang.
