### PR TITLE
Allow sync HTTP fetches to be interrupted to fix hanging

### DIFF
--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -629,7 +629,8 @@ bool GUIEngine::downloadFile(const std::string &url, const std::string &target)
 	fetch_request.caller = HTTPFETCH_SYNC;
 	fetch_request.timeout = std::max(MIN_HTTPFETCH_TIMEOUT,
 		(long)g_settings->getS32("curl_file_download_timeout"));
-	httpfetch_sync(fetch_request, fetch_result);
+	if (!httpfetch_sync_interruptible(fetch_request, fetch_result))
+		return false;
 
 	if (!fetch_result.succeeded) {
 		target_file.close();

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -629,14 +629,15 @@ bool GUIEngine::downloadFile(const std::string &url, const std::string &target)
 	fetch_request.caller = HTTPFETCH_SYNC;
 	fetch_request.timeout = std::max(MIN_HTTPFETCH_TIMEOUT,
 		(long)g_settings->getS32("curl_file_download_timeout"));
-	if (!httpfetch_sync_interruptible(fetch_request, fetch_result))
-		return false;
+	bool completed = httpfetch_sync_interruptible(fetch_request, fetch_result);
 
-	if (!fetch_result.succeeded) {
+	if (!completed || !fetch_result.succeeded) {
 		target_file.close();
 		fs::DeleteSingleFileOrEmptyDirectory(target);
 		return false;
 	}
+	// TODO: directly stream the response data into the file instead of first
+	// storing the complete response in memory
 	target_file << fetch_result.data;
 
 	return true;

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -679,7 +679,7 @@ protected:
 				that the thread should be stopped.)
 			*/
 			if (m_all_ongoing.empty())
-				waitForRequest(5000);
+				waitForRequest(100000000);
 			else
 				waitForIO(100);
 

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -777,6 +777,7 @@ bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
 		do {
 			if (thread->stopRequested()) {
 				httpfetch_caller_free(req.caller);
+				fetch_result = HTTPFetchResult(fetch_request);
 				return false;
 			}
 			sleep_ms(interval);

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "exceptions.h"
 #include "debug.h"
 #include "log.h"
+#include "porting.h"
 #include "util/container.h"
 #include "util/thread.h"
 #include "version.h"
@@ -40,6 +41,15 @@ static std::mutex g_httpfetch_mutex;
 static std::unordered_map<u64, std::queue<HTTPFetchResult>>
 	g_httpfetch_results;
 static PcgRandom g_callerid_randomness;
+
+struct QueuedFree {
+	u64 caller;
+	Event *event;
+
+	QueuedFree(u64 caller, Event *event): caller(caller), event(event) {}
+};
+
+static MutexedQueue<QueuedFree> g_httpfetch_frees;
 
 HTTPFetchRequest::HTTPFetchRequest() :
 	timeout(g_settings->getS32("curl_timeout")),
@@ -60,6 +70,8 @@ static void httpfetch_deliver_result(const HTTPFetchResult &fetch_result)
 }
 
 static void httpfetch_request_clear(u64 caller);
+
+static Event *httpfetch_request_clear_async(u64 caller);
 
 u64 httpfetch_caller_alloc()
 {
@@ -119,6 +131,16 @@ void httpfetch_caller_free(u64 caller)
 		MutexAutoLock lock(g_httpfetch_mutex);
 		g_httpfetch_results.erase(caller);
 	}
+}
+
+void httpfetch_caller_free_async(u64 caller)
+{
+	verbosestream<<"httpfetch_caller_free_async: freeing "
+			<<caller<<std::endl;
+
+	Event *event = httpfetch_request_clear_async(caller);
+	if (event)
+		g_httpfetch_frees.push_back(QueuedFree(caller, event));
 }
 
 bool httpfetch_async_get(u64 caller, HTTPFetchResult &fetch_result)
@@ -678,7 +700,7 @@ protected:
 				that the thread should be stopped.)
 			*/
 			if (m_all_ongoing.empty())
-				waitForRequest(100000000);
+				waitForRequest(5000);
 			else
 				waitForIO(100);
 
@@ -701,7 +723,31 @@ protected:
 	}
 };
 
+class FreeThread : public Thread
+{
+public:
+	FreeThread(): Thread("FreeThread") {}
+
+protected:
+	void *run()
+	{
+		while (!stopRequested()) {
+			QueuedFree f = g_httpfetch_frees.pop_frontNoEx();
+			if (f.event) {
+				f.event->wait();
+				delete f.event;
+				if (f.caller != HTTPFETCH_DISCARD) {
+					MutexAutoLock lock(g_httpfetch_mutex);
+					g_httpfetch_results.erase(f.caller);
+				}
+			}
+		}
+		return NULL;
+	}
+};
+
 static std::unique_ptr<CurlFetchThread> g_httpfetch_thread;
+static std::unique_ptr<FreeThread> g_httpfetch_free_thread;
 
 void httpfetch_init(int parallel_limit)
 {
@@ -715,6 +761,9 @@ void httpfetch_init(int parallel_limit)
 
 	g_httpfetch_thread = std::make_unique<CurlFetchThread>(parallel_limit);
 
+	g_httpfetch_free_thread = std::make_unique<FreeThread>();
+	g_httpfetch_free_thread->start();
+
 	// Initialize g_callerid_randomness for httpfetch_caller_alloc_secure
 	u64 randbuf[2];
 	porting::secure_rand_fill_buf(randbuf, sizeof(u64) * 2);
@@ -724,6 +773,13 @@ void httpfetch_init(int parallel_limit)
 void httpfetch_cleanup()
 {
 	verbosestream<<"httpfetch_cleanup: cleaning up"<<std::endl;
+
+	if (g_httpfetch_free_thread) {
+		g_httpfetch_free_thread->stop();
+		g_httpfetch_frees.push_back(QueuedFree(0, NULL));
+		g_httpfetch_free_thread->wait();
+		g_httpfetch_free_thread.reset();
+	}
 
 	if (g_httpfetch_thread) {
 		g_httpfetch_thread->stop();
@@ -753,6 +809,18 @@ static void httpfetch_request_clear(u64 caller)
 	}
 }
 
+static Event *httpfetch_request_clear_async(u64 caller)
+{
+	if (g_httpfetch_thread->isRunning()) {
+		Event *event = new Event();
+		g_httpfetch_thread->requestClear(caller, event);
+		return event;
+	} else {
+		g_httpfetch_thread->requestClear(caller, nullptr);
+		return nullptr;
+	}
+}
+
 void httpfetch_sync(const HTTPFetchRequest &fetch_request,
 		HTTPFetchResult &fetch_result)
 {
@@ -764,6 +832,27 @@ void httpfetch_sync(const HTTPFetchRequest &fetch_request,
 	CURLcode res = ongoing.start(nullptr);
 	// Update fetch result
 	fetch_result = *ongoing.complete(res);
+}
+
+bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
+		HTTPFetchResult &fetch_result, long interval)
+{
+	if (Thread *thread = Thread::getCurrentThread()) {
+		HTTPFetchRequest req = fetch_request;
+		req.caller = httpfetch_caller_alloc_secure();
+		httpfetch_async(req);
+		do {
+			if (thread->stopRequested()) {
+				httpfetch_caller_free_async(req.caller);
+				return false;
+			}
+			sleep_ms(interval);
+		} while (!httpfetch_async_get(req.caller, fetch_result));
+		httpfetch_caller_free_async(req.caller);
+	} else {
+		httpfetch_sync(fetch_request, fetch_result);
+	}
+	return true;
 }
 
 #else  // USE_CURL
@@ -795,6 +884,11 @@ static void httpfetch_request_clear(u64 caller)
 {
 }
 
+static Event *httpfetch_request_clear_async(u64 caller)
+{
+	return nullptr;
+}
+
 void httpfetch_sync(const HTTPFetchRequest &fetch_request,
 		HTTPFetchResult &fetch_result)
 {
@@ -802,6 +896,16 @@ void httpfetch_sync(const HTTPFetchRequest &fetch_request,
 			<< " because USE_CURL=0" << std::endl;
 
 	fetch_result = HTTPFetchResult(fetch_request); // sets succeeded = false etc.
+}
+
+bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
+		HTTPFetchResult &fetch_result, long interval)
+{
+	errorstream << "httpfetch_sync_interruptible: unable to fetch " << fetch_request.url
+			<< " because USE_CURL=0" << std::endl;
+
+	fetch_result = HTTPFetchResult(fetch_request); // sets succeeded = false etc.
+	return false;
 }
 
 #endif  // USE_CURL

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -754,7 +754,7 @@ static void httpfetch_request_clear(u64 caller)
 	}
 }
 
-void httpfetch_sync(const HTTPFetchRequest &fetch_request,
+static void httpfetch_sync(const HTTPFetchRequest &fetch_request,
 		HTTPFetchResult &fetch_result)
 {
 	// Create ongoing fetch data and make a cURL handle
@@ -815,15 +815,6 @@ void httpfetch_async(const HTTPFetchRequest &fetch_request)
 
 static void httpfetch_request_clear(u64 caller)
 {
-}
-
-void httpfetch_sync(const HTTPFetchRequest &fetch_request,
-		HTTPFetchResult &fetch_result)
-{
-	errorstream << "httpfetch_sync: unable to fetch " << fetch_request.url
-			<< " because USE_CURL=0" << std::endl;
-
-	fetch_result = HTTPFetchResult(fetch_request); // sets succeeded = false etc.
 }
 
 bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -135,6 +135,15 @@ u64 httpfetch_caller_alloc_secure();
 // to stop any ongoing fetches for the given caller.
 void httpfetch_caller_free(u64 caller);
 
+// This does the same thing but returns before the caller has been freed.
+void httpfetch_caller_free_async(u64 caller);
+
 // Performs a synchronous HTTP request. This blocks and therefore should
 // only be used from background threads.
 void httpfetch_sync(const HTTPFetchRequest &fetch_request, HTTPFetchResult &fetch_result);
+
+// Performs a synchronous HTTP request that is interruptible if the current
+// thread is a Thread object. interval is the completion check interval in ms.
+// Returned is whether the request completed without interruption.
+bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
+		HTTPFetchResult &fetch_result, long interval = 100);

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -135,12 +135,9 @@ u64 httpfetch_caller_alloc_secure();
 // to stop any ongoing fetches for the given caller.
 void httpfetch_caller_free(u64 caller);
 
-// Performs a synchronous HTTP request. This blocks and therefore should
-// only be used from background threads.
-void httpfetch_sync(const HTTPFetchRequest &fetch_request, HTTPFetchResult &fetch_result);
-
 // Performs a synchronous HTTP request that is interruptible if the current
 // thread is a Thread object. interval is the completion check interval in ms.
+// This blocks and therefore should only be used from background threads.
 // Returned is whether the request completed without interruption.
 bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
 		HTTPFetchResult &fetch_result, long interval = 100);

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -135,9 +135,6 @@ u64 httpfetch_caller_alloc_secure();
 // to stop any ongoing fetches for the given caller.
 void httpfetch_caller_free(u64 caller);
 
-// This does the same thing but returns before the caller has been freed.
-void httpfetch_caller_free_async(u64 caller);
-
 // Performs a synchronous HTTP request. This blocks and therefore should
 // only be used from background threads.
 void httpfetch_sync(const HTTPFetchRequest &fetch_request, HTTPFetchResult &fetch_result);

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -114,9 +114,9 @@ int ModApiHttp::l_http_fetch_sync(lua_State *L)
 	infostream << "Mod performs HTTP request with URL " << req.url << std::endl;
 
 	HTTPFetchResult res;
-	httpfetch_sync(req, res);
+	bool completed = httpfetch_sync_interruptible(req, res);
 
-	push_http_fetch_result(L, res, true);
+	push_http_fetch_result(L, res, completed);
 
 	return 1;
 }

--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -62,6 +62,9 @@ DEALINGS IN THE SOFTWARE.
 // See https://msdn.microsoft.com/en-us/library/hh920601.aspx#thread__native_handle_method
 #define win32_native_handle() ((HANDLE) getThreadHandle())
 
+thread_local Thread *current_thread = nullptr;
+
+
 Thread::Thread(const std::string &name) :
 	m_name(name),
 	m_request_stop(false),
@@ -177,6 +180,8 @@ void Thread::threadProc(Thread *thr)
 	thr->m_kernel_thread_id = thread_self();
 #endif
 
+	current_thread = thr;
+
 	thr->setName(thr->m_name);
 
 	g_logger.registerThread(thr->m_name);
@@ -194,6 +199,12 @@ void Thread::threadProc(Thread *thr)
 	// released. We try to unlock it from caller thread and it's refused by system.
 	sf_lock.unlock();
 	g_logger.deregisterThread();
+}
+
+
+Thread *Thread::getCurrentThread()
+{
+	return current_thread;
 }
 
 

--- a/src/threading/thread.h
+++ b/src/threading/thread.h
@@ -120,6 +120,11 @@ public:
 	bool setPriority(int prio);
 
 	/*
+	 * Returns the current thread object if it exists.
+	 */
+	static Thread *getCurrentThread();
+
+	/*
 	 * Sets the currently executing thread's name to where supported; useful
 	 * for debugging.
 	 */

--- a/src/threading/thread.h
+++ b/src/threading/thread.h
@@ -120,7 +120,7 @@ public:
 	bool setPriority(int prio);
 
 	/*
-	 * Returns the current thread object if it exists.
+	 * Returns the thread object of the current thread if it exists.
 	 */
 	static Thread *getCurrentThread();
 


### PR DESCRIPTION
Fixes #12815, "if I try to start a game while I'm downloading a mod, Minetest hangs", "if I try to close Minetest while I'm downloading a mod, Minetest hangs", etc. This issue is a common cause of ANRs on Android.

This PR is an adoption of #12983. It works by making sync HTTP fetches interruptible if they are not on the main thread. I removed the `FreeThread` thing which was included in the original PR because of a suggestion to make this simpler and it still seems to work, but I have no idea what I'm doing here. Please review this carefully.

Alternative PR: #14411

**Pros of this PR**

- simpler
- allows keeping stuff like JSON decoding, ZIP unpacking, etc. in a worker thread without extra effort

**Cons of this PR**

- I don't know what I'm doing

## To do

This PR is a Ready for Review.

- [x] Decide whether this or the alternative PR is the right approach
- [x] Fix attribution to TurkeyMcMac

## How to test

Start downloading a package from ContentDB and try to close Minetest. Verify that it doesn't hang.
