### PR TITLE
Add toggle sneak setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -119,6 +119,8 @@ repeat_place_time (Place repetition interval) float 0.25 0.16 2
 #    Automatically jump up single-node obstacles.
 autojump (Automatic jumping) bool false
 
+toggle_sneak (Toggle sneak) bool false
+
 #    Prevent digging and placing from repeating when holding the respective buttons.
 #    Enable this when you dig or place too often by accident.
 #    On touchscreens, this only affects digging.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -119,6 +119,7 @@ repeat_place_time (Place repetition interval) float 0.25 0.16 2
 #    Automatically jump up single-node obstacles.
 autojump (Automatic jumping) bool false
 
+#    Sneak button toggles sneaking instead of requiring it to be held down.
 toggle_sneak (Toggle sneak) bool false
 
 #    Prevent digging and placing from repeating when holding the respective buttons.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -709,6 +709,8 @@ struct GameRunData {
 	float time_from_last_punch;
 	ClientActiveObject *selected_object;
 
+	bool isSneaking = false;
+
 	float jump_timer_up;          // from key up until key down
 	float jump_timer_down;        // since last key down
 	float jump_timer_down_before; // from key down until key down again
@@ -1445,7 +1447,7 @@ void Game::copyServerClientCache()
 {
 	// It would be possible to let the client directly read the media files
 	// from where the server knows they are. But aside from being more complicated
-	// it would also *not* fill the media cache and cause slower joining of 
+	// it would also *not* fill the media cache and cause slower joining of
 	// remote servers.
 	// (Imagine that you launch a game once locally and then connect to a server.)
 
@@ -2689,6 +2691,14 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 
 	//TimeTaker tt("update player control", NULL, PRECISION_NANO);
 
+
+	if (g_settings->getBool("toggle_sneak")) {
+		if (wasKeyPressed(KeyType::SNEAK)) runData.isSneaking = !runData.isSneaking;
+	} else {
+		runData.isSneaking = isKeyDown(KeyType::SNEAK);
+	}
+
+
 	PlayerControl control(
 		isKeyDown(KeyType::FORWARD),
 		isKeyDown(KeyType::BACKWARD),
@@ -2696,7 +2706,7 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 		isKeyDown(KeyType::RIGHT),
 		isKeyDown(KeyType::JUMP) || player->getAutojump(),
 		isKeyDown(KeyType::AUX1),
-		isKeyDown(KeyType::SNEAK),
+		runData.isSneaking,
 		isKeyDown(KeyType::ZOOM),
 		isKeyDown(KeyType::DIG),
 		isKeyDown(KeyType::PLACE),

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -709,7 +709,7 @@ struct GameRunData {
 	float time_from_last_punch;
 	ClientActiveObject *selected_object;
 
-	bool isSneaking = false;
+	bool is_sneaking = false;
 
 	float jump_timer_up;          // from key up until key down
 	float jump_timer_down;        // since last key down
@@ -1447,7 +1447,7 @@ void Game::copyServerClientCache()
 {
 	// It would be possible to let the client directly read the media files
 	// from where the server knows they are. But aside from being more complicated
-	// it would also *not* fill the media cache and cause slower joining of
+	// it would also *not* fill the media cache and cause slower joining of 
 	// remote servers.
 	// (Imagine that you launch a game once locally and then connect to a server.)
 
@@ -2693,9 +2693,10 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 
 
 	if (g_settings->getBool("toggle_sneak")) {
-		if (wasKeyPressed(KeyType::SNEAK)) runData.isSneaking = !runData.isSneaking;
+		if (wasKeyPressed(KeyType::SNEAK))
+			runData.is_sneaking = !runData.is_sneaking;
 	} else {
-		runData.isSneaking = isKeyDown(KeyType::SNEAK);
+		runData.is_sneaking = isKeyDown(KeyType::SNEAK);
 	}
 
 
@@ -2706,7 +2707,7 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 		isKeyDown(KeyType::RIGHT),
 		isKeyDown(KeyType::JUMP) || player->getAutojump(),
 		isKeyDown(KeyType::AUX1),
-		runData.isSneaking,
+		runData.is_sneaking,
 		isKeyDown(KeyType::ZOOM),
 		isKeyDown(KeyType::DIG),
 		isKeyDown(KeyType::PLACE),

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -312,6 +312,7 @@ void set_default_settings()
 #else
 	settings->setDefault("autojump", "false");
 #endif
+	settings->setDefault("toggle_sneak", "false");
 	settings->setDefault("continuous_forward", "false");
 	settings->setDefault("enable_joysticks", "false");
 	settings->setDefault("joystick_id", "0");


### PR DESCRIPTION
A compact, short information about this PR for easier understanding:

- Goal: Add toggle sneak option, when enabled toggles sneak instead of requiring it to be held down.
- #2194

## To do

This PR is a ~~Work in Progress~~ / Ready for Review.
<!-- ^ delete one -->

- [x] Make code better (less ugly)
- [x] Add more info to the settings page

## How to test

Settings -> General -> Toggle sneak -> enable
Open a world and it should toggle sneak instead of requiring the button to be pressed continuously
<!-- Example code or instructions -->
