### PR TITLE
Translation updater: Add comment propagation

### DIFF
--- a/util/README_mod_translation_updater.md
+++ b/util/README_mod_translation_updater.md
@@ -174,6 +174,9 @@ files, associating them with the line that follows them. So for example:
     # are also supported
     Text as well=
 
+The script will also propagate comments from an existing `template.txt` to all `*.tr`
+files and write it above existing comments (if exist).
+
 There are also a couple of special comments that this script gives special treatment to.
 
 #### Source file comments

--- a/util/mod_translation_updater.py
+++ b/util/mod_translation_updater.py
@@ -21,7 +21,6 @@ params = {"recursive": False,
 	"break-long-lines": False,
 	"print-source": False,
 	"truncate-unused": False,
-	"propagate-comment": False,
 }
 # Available CLI options
 options = {"recursive": ['--recursive', '-r'],
@@ -31,7 +30,6 @@ options = {"recursive": ['--recursive', '-r'],
 	"break-long-lines": ['--break-long-lines', '-b'],
 	"print-source": ['--print-source', '-p'],
 	"truncate-unused": ['--truncate-unused', '-t'],
-	"propagate-comment": ['--propagate-comment', '-c'],
 }
 
 # Strings longer than this will have extra space added between
@@ -86,8 +84,6 @@ DESCRIPTION
 		add output information
 	{', '.join(options["truncate-unused"])}
 		delete unused strings from files
-	{', '.join(options["propagate-comment"])}
-		propagate comments from the template file into the translation files
 ''')
 
 def main():
@@ -444,9 +440,7 @@ def generate_template(folder, mod_name):
 
 	templ_file = os.path.join(folder, "locale/template.txt")
 	write_template(templ_file, dOut, mod_name)
-	new_template = None
-	if params["propagate-comment"]:
-		new_template = import_tr_file(templ_file) # re-import to get all new data
+	new_template = import_tr_file(templ_file) # re-import to get all new data
 	return (dOut, new_template)
 
 # Updates an existing .tr file, copying the old one to a ".old" file


### PR DESCRIPTION
**Goal of the PR**
This PR adds comment propagation into the mod translation updater script that propagates comments from the template file into the translation files.

**How does the PR work?**
The comments from the template file are written above the comments from the translation file itself. There is a simple check to make sure that the comments from the template file are not propagated twice.

**Does it resolve any reported issue?**
This PR tries to fix #13947.

**Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?**
Yes, I guess.

**If not a bug fix, why is this PR needed? What usecases does it solve?**
See #13947 

## To do

This PR is Ready for Review.

## How to test
1. Run the script in a mod with comments in the template file.
2. Make sure that comments in the template file are propagated/copied into the translation files.
3. In the translation files, add some comments below the propagated comment.
4. Rerun the script again.
5. The propagated comment should not change and should not copied twice.