### PR TITLE
Do not stop ephemeral sounds attached to object with object remove

### DIFF
--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -890,7 +890,7 @@ void Client::handleCommand_PlaySound(NetworkPacket* pkt)
 			m_sounds_server_to_client[server_id] = client_id;
 			m_sounds_client_to_server[client_id] = server_id;
 		}
-		if (object_id != 0)
+		if (object_id != 0 && !ephemeral)
 			m_sounds_to_objects[client_id] = object_id;
 	}
 }


### PR DESCRIPTION
Do not stop ephemeral sounds attached to object with object remove. Related to #14422

- Does it resolve any reported issue?
Related to #14422.

## To do

This PR is a Ready for Review.

## How to test

See #14422.
