### PR TITLE
Move values the mainmenu caches to dedicated file(s)

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -18,6 +18,26 @@
 -- Global menu data
 menudata = {}
 
+-- located in user cache path, for remembering this like e.g. last update check
+cache_settings = Settings(core.get_cache_path() .. DIR_DELIM .. "common.conf")
+
+--- Checks if the given key contains a timestamp less than a certain age.
+--- Pair this with a call to `cache_settings:set(key, tostring(os.time()))`
+--- after successfully refreshing the cache.
+--- @param key Name of entry in cache_settings
+--- @param max_age Age to check against, in seconds
+--- @return true if the max age is not reached
+function check_cache_age(key, max_age)
+	local time_now = os.time()
+	local time_checked = tonumber(cache_settings:get(key)) or 0
+	return time_now - time_checked < max_age
+end
+
+function core.on_before_close()
+	-- called before the menu is closed, either exit or to join a game
+	cache_settings:write()
+end
+
 -- Local cached values
 local min_supp_proto, max_supp_proto
 
@@ -26,6 +46,16 @@ function common_update_cached_supp_proto()
 	max_supp_proto = core.get_max_supp_proto()
 end
 common_update_cached_supp_proto()
+
+-- Other global functions
+
+function core.sound_stop(handle, ...)
+	return handle:stop(...)
+end
+
+function os.tmpname()
+	error('do not use') -- instead: core.get_temp_path()
+end
 
 -- Menu helper functions
 
@@ -140,11 +170,6 @@ function render_serverlist_row(spec)
 
 	return table.concat(details, ",")
 end
----------------------------------------------------------------------------------
-os.tmpname = function()
-	error('do not use') -- instead use core.get_temp_path()
-end
---------------------------------------------------------------------------------
 
 function menu_render_worldlist()
 	local retval = {}

--- a/builtin/mainmenu/content/update_detector.lua
+++ b/builtin/mainmenu/content/update_detector.lua
@@ -26,13 +26,23 @@ if not core.get_http_api then
 end
 
 
+assert(core.create_dir(core.get_cache_path() .. DIR_DELIM .. "cdb"))
+local cache_file_path = core.get_cache_path() .. DIR_DELIM .. "cdb" .. DIR_DELIM .. "updates.json"
 local has_fetched = false
 local latest_releases
 do
-	local tmp = core.get_once("cdb_latest_releases")
-	if tmp then
-		latest_releases = core.deserialize(tmp, true)
-		has_fetched = latest_releases ~= nil
+	if check_cache_age("cdb_updates_last_checked", 3 * 3600) then
+		local f = io.open(cache_file_path, "r")
+		local data = ""
+		if f then
+			data = f:read("*a")
+			f:close()
+		end
+		data = data ~= "" and core.parse_json(data) or nil
+		if type(data) == "table" then
+			latest_releases = data
+			has_fetched = true
+		end
 	end
 end
 
@@ -97,7 +107,8 @@ local function fetch()
 			return
 		end
 		latest_releases = lowercase_keys(releases)
-		core.set_once("cdb_latest_releases", core.serialize(latest_releases))
+		core.safe_file_write(cache_file_path, core.write_json(latest_releases))
+		cache_settings:set("cdb_updates_last_checked", tostring(os.time()))
 
 		if update_detector.get_count() > 0 then
 			local maintab = ui.find_by_name("maintab")

--- a/builtin/mainmenu/dlg_reinstall_mtg.lua
+++ b/builtin/mainmenu/dlg_reinstall_mtg.lua
@@ -15,15 +15,30 @@
 --with this program; if not, write to the Free Software Foundation, Inc.,
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+---- IMPORTANT ----
+-- This whole file can be removed after a while.
+-- It was only directly useful for upgrades from 5.7.0 to 5.8.0, but
+-- maybe some odd fellow directly upgrades from 5.6.1 to 5.9.0 in the future...
+-- see <https://github.com/minetest/minetest/pull/13850> in case it's not obvious
+---- ----
+
+local SETTING_NAME = "no_mtg_notification"
+
 function check_reinstall_mtg()
-	if core.settings:get_bool("no_mtg_notification") then
+	-- used to be in minetest.conf
+	if core.settings:get_bool(SETTING_NAME) then
+		cache_settings:set_bool(SETTING_NAME, true)
+		core.settings:remove(SETTING_NAME)
+	end
+
+	if cache_settings:get_bool(SETTING_NAME) then
 		return
 	end
 
 	local games = core.get_games()
 	for _, game in ipairs(games) do
 		if game.id == "minetest" then
-			core.settings:set_bool("no_mtg_notification", true)
+			cache_settings:set_bool(SETTING_NAME, true)
 			return
 		end
 	end
@@ -37,7 +52,7 @@ function check_reinstall_mtg()
 		end
 	end
 	if not mtg_world_found then
-		core.settings:set_bool("no_mtg_notification", true)
+		cache_settings:set_bool(SETTING_NAME, true)
 		return
 	end
 
@@ -87,7 +102,7 @@ local function buttonhandler(this, fields)
 	end
 
 	if fields.dismiss then
-		core.settings:set_bool("no_mtg_notification", true)
+		cache_settings:set_bool("no_mtg_notification", true)
 		this:delete()
 		return true
 	end

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -28,8 +28,6 @@ local basepath = core.get_builtin_path()
 defaulttexturedir = core.get_texturepath_share() .. DIR_DELIM .. "base" ..
 					DIR_DELIM .. "pack" .. DIR_DELIM
 
-dofile(menupath .. DIR_DELIM .. "misc.lua")
-
 dofile(basepath .. "common" .. DIR_DELIM .. "filterlist.lua")
 dofile(basepath .. "fstk" .. DIR_DELIM .. "buttonbar.lua")
 dofile(basepath .. "fstk" .. DIR_DELIM .. "dialog.lua")

--- a/builtin/mainmenu/misc.lua
+++ b/builtin/mainmenu/misc.lua
@@ -1,6 +1,0 @@
-
--- old non-method sound function
-
-function core.sound_stop(handle, ...)
-	return handle:stop(...)
-end

--- a/builtin/mainmenu/tests/serverlistmgr_spec.lua
+++ b/builtin/mainmenu/tests/serverlistmgr_spec.lua
@@ -1,5 +1,6 @@
-_G.core = {get_once = function(_) end}
+_G.core = {}
 _G.unpack = table.unpack
+_G.check_cache_age = function() return false end
 _G.serverlistmgr = {}
 
 dofile("builtin/common/vector.lua")

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -772,6 +772,7 @@ serverlist_url (Serverlist URL) string servers.minetest.net
 enable_split_login_register (Enable split login/register) bool true
 
 #    URL to JSON file which provides information about the newest Minetest release
+#    If this is empty the engine will never check for updates.
 update_information_url (Update information URL) string https://www.minetest.net/release_info.json
 
 [*Server]
@@ -2286,20 +2287,6 @@ show_advanced (Show advanced settings) bool false
 #    sound controls will be non-functional.
 #    Changing this setting requires a restart.
 enable_sound (Sound) bool true
-
-#    Unix timestamp (integer) of when the client last checked for an update
-#    Set this value to "disabled" to never check for updates.
-update_last_checked (Last update check) string
-
-#    Version number which was last seen during an update check.
-#
-#    Representation: MMMIIIPPP, where M=Major, I=Minor, P=Patch
-#    Ex: 5.5.0 is 005005000
-update_last_known (Last known version update) int 0
-
-#    If this is set to true, the user will never (again) be shown the
-#    "reinstall Minetest Game" notification.
-no_mtg_notification (Don't show "reinstall Minetest Game" notification) bool false
 
 #    Key for moving the player forward.
 keymap_forward (Forward key) key KEY_KEY_W

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -55,10 +55,6 @@ Functions
   * Android only. Shares file using the share popup
 * `core.get_version()` (possible in async calls)
   * returns current core version
-* `core.set_once(key, value)`:
-  * save a string value that persists even if menu is closed
-* `core.get_once(key)`:
-  * get a string value saved by above function, or `nil`
 
 
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -355,11 +355,10 @@ void set_default_settings()
 	settings->setDefault("contentdb_flag_blacklist", "nonfree, desktop_default");
 #endif
 
-	settings->setDefault("update_information_url", "https://www.minetest.net/release_info.json");
 #if ENABLE_UPDATE_CHECKER
-	settings->setDefault("update_last_checked", "");
+	settings->setDefault("update_information_url", "https://www.minetest.net/release_info.json");
 #else
-	settings->setDefault("update_last_checked", "disabled");
+	settings->setDefault("update_information_url", "");
 #endif
 
 	// Server

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -369,6 +369,8 @@ void GUIEngine::run()
 #endif
 	}
 
+	m_script->beforeClose();
+
 	RenderingEngine::autosaveScreensizeAndCo(initial_screen_size, initial_window_maximized);
 }
 

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -1086,44 +1086,6 @@ int ModApiMainMenu::l_do_async_callback(lua_State *L)
 }
 
 /******************************************************************************/
-// this is intentionally a global and not part of MainMenuScripting or such
-namespace {
-	std::unordered_map<std::string, std::string> once_values;
-	std::mutex once_mutex;
-}
-
-int ModApiMainMenu::l_set_once(lua_State *L)
-{
-	std::string key = readParam<std::string>(L, 1);
-	if (lua_isnil(L, 2))
-		return 0;
-	std::string value = readParam<std::string>(L, 2);
-
-	{
-		MutexAutoLock lock(once_mutex);
-		once_values[key] = value;
-	}
-
-	return 0;
-}
-
-int ModApiMainMenu::l_get_once(lua_State *L)
-{
-	std::string key = readParam<std::string>(L, 1);
-
-	{
-		MutexAutoLock lock(once_mutex);
-		auto it = once_values.find(key);
-		if (it == once_values.end())
-			lua_pushnil(L);
-		else
-			lua_pushstring(L, it->second.c_str());
-	}
-
-	return 1;
-}
-
-/******************************************************************************/
 void ModApiMainMenu::Initialize(lua_State *L, int top)
 {
 	API_FCT(update_formspec);
@@ -1175,8 +1137,6 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(open_dir);
 	API_FCT(share_file);
 	API_FCT(do_async_callback);
-	API_FCT(set_once);
-	API_FCT(get_once);
 }
 
 /******************************************************************************/

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -166,10 +166,6 @@ private:
 
 	static int l_share_file(lua_State *L);
 
-	static int l_set_once(lua_State *L);
-
-	static int l_get_once(lua_State *L);
-
 	// async
 	static int l_do_async_callback(lua_State *L);
 

--- a/src/script/scripting_mainmenu.cpp
+++ b/src/script/scripting_mainmenu.cpp
@@ -58,7 +58,6 @@ MainMenuScripting::MainMenuScripting(GUIEngine* guiengine):
 	infostream << "SCRIPTAPI: Initialized main menu modules" << std::endl;
 }
 
-/******************************************************************************/
 void MainMenuScripting::initializeModApi(lua_State *L, int top)
 {
 	registerLuaClasses(L, top);
@@ -79,20 +78,31 @@ void MainMenuScripting::initializeModApi(lua_State *L, int top)
 	asyncEngine.initialize(MAINMENU_NUM_ASYNC_THREADS);
 }
 
-/******************************************************************************/
 void MainMenuScripting::registerLuaClasses(lua_State *L, int top)
 {
 	LuaSettings::Register(L);
 	MainMenuSoundHandle::Register(L);
 }
 
-/******************************************************************************/
+void MainMenuScripting::beforeClose()
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "on_before_close");
+
+	PCALL_RES(lua_pcall(L, 0, 0, error_handler));
+
+	lua_pop(L, 2); // Pop core, error handler
+}
+
 void MainMenuScripting::step()
 {
 	asyncEngine.step(getStack());
 }
 
-/******************************************************************************/
 u32 MainMenuScripting::queueAsync(std::string &&serialized_func,
 		std::string &&serialized_param)
 {

--- a/src/script/scripting_mainmenu.h
+++ b/src/script/scripting_mainmenu.h
@@ -37,6 +37,9 @@ public:
 	// Global step handler to pass back async events
 	void step();
 
+	// Calls core.on_before_close()
+	void beforeClose();
+
 	// Pass async events from engine to async threads
 	u32 queueAsync(std::string &&serialized_func,
 		std::string &&serialized_param);


### PR DESCRIPTION
It always bothered me a bit that Minetest was keeping information like the last update check in the *user* configuration file, but now I have a better solution to offer.
This PR moves such values to a dedicated conf file in the user's cache path.

#### Benefits:
* Server list geoip and CDB update json can be cached
* Clearing the cache makes MT recheck such things, which is reasonable behaviour
* The settings disappear from minetest.conf.example and the settings tab. They weren't meant to be user-configurable anyway
* Less load on CDB due to Minetest clients checking for package updates

#### Technical:
`$path_cache/common.conf` e.g.:
<pre>
geoip_last_checked = 1709577888
cdb_updates_last_checked = 1709577712
no_mtg_notification = true
update_last_checked = 1709577794
geoip = EU
</pre>
`$path_cache/cdb/updates.json`: contains the API response

## To do

This PR is Ready for Review.

## How to test

1. launch Minetest with `--verbose` to see HTTP requests made
2. look at files in cache path
