### PR TITLE
Reduce translations log spam

### DIFF
--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -25,7 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #ifndef SERVER
 // Client translations
-Translations client_translations;
+static Translations client_translations;
 Translations *g_client_translations = &client_translations;
 #endif
 
@@ -36,19 +36,13 @@ void Translations::clear()
 }
 
 const std::wstring &Translations::getTranslation(
-		const std::wstring &textdomain, const std::wstring &s)
+		const std::wstring &textdomain, const std::wstring &s) const
 {
 	std::wstring key = textdomain + L"|" + s;
-	try {
-		return m_translations.at(key);
-	} catch (const std::out_of_range &) {
-		verbosestream << "Translations: can't find translation for string \""
-		              << wide_to_utf8(s) << "\" in textdomain \""
-		              << wide_to_utf8(textdomain) << "\"" << std::endl;
-		// Silence that warning in the future
-		m_translations[key] = s;
-		return s;
-	}
+	auto it = m_translations.find(key);
+	if (it != m_translations.end())
+		return it->second;
+	return s;
 }
 
 void Translations::loadTranslation(const std::string &data)
@@ -155,10 +149,7 @@ void Translations::loadTranslation(const std::string &data)
 		if (!oword2.empty()) {
 			std::wstring translation_index = textdomain + L"|";
 			translation_index.append(oword1);
-			m_translations[translation_index] = oword2;
-		} else {
-			infostream << "Ignoring empty translation for \""
-				<< wide_to_utf8(oword1) << "\"" << std::endl;
+			m_translations.emplace(std::move(translation_index), std::move(oword2));
 		}
 	}
 }

--- a/src/translation.h
+++ b/src/translation.h
@@ -32,8 +32,8 @@ class Translations
 public:
 	void loadTranslation(const std::string &data);
 	void clear();
-	const std::wstring &getTranslation(
-			const std::wstring &textdomain, const std::wstring &s);
+	const std::wstring &getTranslation(const std::wstring &textdomain,
+		const std::wstring &s) const;
 
 private:
 	std::unordered_map<std::wstring, std::wstring> m_translations;


### PR DESCRIPTION
```
20:27 <+sfan5> unrelated: the "Ignoring empty translation for" and "Translations: can't find translation for string" are very annoying looks at verbose output
```

exists in mainmenu since f4eba3bfba998d14f8a95e832beae40b03eacf8a