### PR TITLE
Stop sounds if objects get out of range, but not if objects are removed

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1095,6 +1095,7 @@ Table used to specify how a sound is played:
     -- its end in `-start_time` seconds.
     -- It is unspecified what happens if `loop` is false and `start_time` is
     -- smaller than minus the sound's length.
+
     -- Available since feature `sound_params_start_time`.
 
     loop = false,
@@ -1107,6 +1108,17 @@ Table used to specify how a sound is played:
     object = <an ObjectRef>,
     -- Attach the sound to an object.
     -- Can't be used together with `pos`.
+
+    -- For backwards compatibility, sounds continue playing
+    -- at the last location of the object if an object is removed
+    -- (for example if an entity dies).
+
+    -- It is not recommended to rely on this.
+    -- For death sounds, prefer playing a positional sound at the objects last location.
+
+    -- Sounds stop playing on clients if objects leave the active object range;
+    -- they should start playing again if objects come back into range
+    -- (but due to a known bug, they don't yet).
 
     to_player = name,
     -- Only play for this player.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1114,9 +1114,17 @@ Table used to specify how a sound is played:
     -- (for example if an entity dies).
 
     -- It is not recommended to rely on this.
-    -- For death sounds, prefer playing a positional sound at the objects last location.
+    -- For death sounds, prefer playing a positional sound at the object's last location.
 
-    -- Sounds stop playing on clients if objects leave the active object range;
+    -- If you want to stop a sound when an entity dies or is deactivated,
+    -- store the handle and call `minetest.sound_stop` in `on_die` / `on_deactivate`.
+
+    -- Ephemeral sounds are entirely unaffected
+    -- by the object being removed
+    -- or leaving the active object range.
+
+    -- Non-ephemeral sounds stop playing on clients
+    -- if objects leave the active object range;
     -- they should start playing again if objects come back into range
     -- (but due to a known bug, they don't yet).
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1109,24 +1109,20 @@ Table used to specify how a sound is played:
     -- Attach the sound to an object.
     -- Can't be used together with `pos`.
 
-    -- For backwards compatibility, sounds continue playing
-    -- at the last location of the object if an object is removed
-    -- (for example if an entity dies).
-
+    -- For backward compatibility, sounds continue playing at the last location
+    -- of the object if an object is removed (for example if an entity dies).
     -- It is not recommended to rely on this.
-    -- For death sounds, prefer playing a positional sound at the object's last location.
+    -- For death sounds, prefer playing a positional sound instead.
 
     -- If you want to stop a sound when an entity dies or is deactivated,
     -- store the handle and call `minetest.sound_stop` in `on_die` / `on_deactivate`.
 
-    -- Ephemeral sounds are entirely unaffected
-    -- by the object being removed
+    -- Ephemeral sounds are entirely unaffected by the object being removed
     -- or leaving the active object range.
 
-    -- Non-ephemeral sounds stop playing on clients
-    -- if objects leave the active object range;
-    -- they should start playing again if objects come back into range
-    -- (but due to a known bug, they don't yet).
+    -- Non-ephemeral sounds stop playing on clients if objects leave
+    -- the active object range; they should start playing again if objects
+    --- come back into range (but due to a known bug, they don't yet).
 
     to_player = name,
     -- Only play for this player.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -2123,11 +2123,3 @@ const std::string &Client::getFormspecPrepend() const
 {
 	return m_env.getLocalPlayer()->formspec_prepend;
 }
-
-void Client::removeActiveObjectSounds(u16 id)
-{
-	for (auto it : m_sounds_to_objects) {
-		if (it.second == id)
-			m_sound->stopSound(it.first);
-	}
-}

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -471,9 +471,6 @@ private:
 
 	bool canSendChatMessage() const;
 
-	// remove sounds attached to object
-	void removeActiveObjectSounds(u16 id);
-
 	float m_packetcounter_timer = 0.0f;
 	float m_connection_reinit_timer = 0.1f;
 	float m_avg_rtt_timer = 0.0f;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -471,7 +471,6 @@ void Client::handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt)
 		for (u16 i = 0; i < removed_count; i++) {
 			*pkt >> id;
 			m_env.removeActiveObject(id);
-			removeActiveObjectSounds(id);
 		}
 
 		// Read added objects

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2289,9 +2289,10 @@ void Server::fadeSound(s32 handle, float step, float gain)
 
 void Server::stopAttachedSounds(session_t peer_id, u16 object_id)
 {
+	assert(peer_id != PEER_ID_INEXISTENT);
 	assert(object_id);
 
-	for (auto it = m_playing_sounds.begin(); it != m_playing_sounds.end(); it++) {
+	for (auto it = m_playing_sounds.begin(); it != m_playing_sounds.end();) {
 		ServerPlayingSound &sound = it->second;
 
 		if (sound.object != object_id)
@@ -2307,7 +2308,9 @@ void Server::stopAttachedSounds(session_t peer_id, u16 object_id)
 
 		sound.clients.erase(clients_it);
 		if (sound.clients.empty())
-			m_playing_sounds.erase(it);
+			it = m_playing_sounds.erase(it);
+		else
+			++it;
 	}
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2043,11 +2043,16 @@ void Server::SendActiveObjectRemoveAdd(RemoteClient *client, PlayerSAO *playersa
 
 	std::queue<u16> removed_objects, added_objects;
 	m_env->getRemovedActiveObjects(playersao, my_radius, player_radius,
-		client->m_known_objects, [&](bool gone, u16 id) {
-		if (!gone)
-			stopAttachedSounds(client->peer_id, id);
-		removed_objects.push(id);
-	});
+		client->m_known_objects,
+		[&](bool gone, u16 id) {
+			// Stop sounds if objects go out of range.
+			// This fixes https://github.com/minetest/minetest/issues/8094.
+			// We may not remove sounds if an entity was removed on the server
+			// See https://github.com/minetest/minetest/issues/14422.
+			if (!gone)
+				stopAttachedSounds(client->peer_id, id);
+			removed_objects.push(id);
+		});
 	m_env->getAddedActiveObjects(playersao, my_radius, player_radius,
 		client->m_known_objects, added_objects);
 

--- a/src/server.h
+++ b/src/server.h
@@ -240,7 +240,7 @@ public:
 	void stopSound(s32 handle);
 	void fadeSound(s32 handle, float step, float gain);
 	// Stop all sounds attached to an object for a certain client
-	void stopAttachedSounds(session_t peer_id, u16 id);
+	void stopAttachedSounds(session_t peer_id, u16 object_id);
 
 	// Envlock
 	std::set<std::string> getPlayerEffectivePrivs(const std::string &name);

--- a/src/server.h
+++ b/src/server.h
@@ -239,7 +239,8 @@ public:
 	s32 playSound(ServerPlayingSound &params, bool ephemeral=false);
 	void stopSound(s32 handle);
 	void fadeSound(s32 handle, float step, float gain);
-	void stopAttachedSounds(u16 id);
+	// Stop all sounds attached to an object for a certain client
+	void stopAttachedSounds(session_t peer_id, u16 id);
 
 	// Envlock
 	std::set<std::string> getPlayerEffectivePrivs(const std::string &name);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1253,7 +1253,7 @@ void ServerEnvironment::clearObjects(ClearObjectsMode mode)
 			return false;
 		}
 
-		processActiveObjectRemove(obj, id);
+		processActiveObjectRemove(obj);
 
 		// Delete active object
 		return true;
@@ -1742,7 +1742,7 @@ void ServerEnvironment::getAddedActiveObjects(PlayerSAO *playersao, s16 radius,
 void ServerEnvironment::getRemovedActiveObjects(PlayerSAO *playersao, s16 radius,
 	s16 player_radius,
 	std::set<u16> &current_objects,
-	std::queue<u16> &removed_objects)
+	const std::function<void(bool /* gone? */, u16 /* id */)> &callback)
 {
 	f32 radius_f = radius * BS;
 	f32 player_radius_f = player_radius * BS;
@@ -1763,12 +1763,12 @@ void ServerEnvironment::getRemovedActiveObjects(PlayerSAO *playersao, s16 radius
 		if (object == NULL) {
 			infostream << "ServerEnvironment::getRemovedActiveObjects():"
 				<< " object in current_objects is NULL" << std::endl;
-			removed_objects.push(id);
+			callback(true, id);
 			continue;
 		}
 
 		if (object->isGone()) {
-			removed_objects.push(id);
+			callback(true, id);
 			continue;
 		}
 
@@ -1780,7 +1780,7 @@ void ServerEnvironment::getRemovedActiveObjects(PlayerSAO *playersao, s16 radius
 			continue;
 
 		// Object is no longer visible
-		removed_objects.push(id);
+		callback(false, id);
 	}
 }
 
@@ -1973,7 +1973,7 @@ void ServerEnvironment::removeRemovedObjects()
 			}
 		}
 
-		processActiveObjectRemove(obj, id);
+		processActiveObjectRemove(obj);
 
 		// Delete
 		return true;
@@ -2210,7 +2210,7 @@ void ServerEnvironment::deactivateFarObjects(bool _force_delete)
 			return false;
 		}
 
-		processActiveObjectRemove(obj, id);
+		processActiveObjectRemove(obj);
 
 		// Delete active object
 		return true;
@@ -2273,14 +2273,13 @@ bool ServerEnvironment::saveStaticToBlock(
 	return true;
 }
 
-void ServerEnvironment::processActiveObjectRemove(ServerActiveObject *obj, u16 id)
+void ServerEnvironment::processActiveObjectRemove(ServerActiveObject *obj)
 {
+	u16 id = obj->getId();
 	// Tell the object about removal
 	obj->removingFromEnvironment();
 	// Deregister in scripting api
 	m_script->removeObjectReference(obj);
-	// stop attached sounds
-	m_server->stopAttachedSounds(id);
 }
 
 PlayerDatabase *ServerEnvironment::openPlayerDatabase(const std::string &name,

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <algorithm>
 #include <stack>
+#include <utility>
 #include "serverenvironment.h"
 #include "settings.h"
 #include "log.h"
@@ -1742,7 +1743,7 @@ void ServerEnvironment::getAddedActiveObjects(PlayerSAO *playersao, s16 radius,
 void ServerEnvironment::getRemovedActiveObjects(PlayerSAO *playersao, s16 radius,
 	s16 player_radius,
 	std::set<u16> &current_objects,
-	const std::function<void(bool /* gone? */, u16 /* id */)> &callback)
+	std::queue<std::pair<bool /* gone? */, u16>> &removed_objects)
 {
 	f32 radius_f = radius * BS;
 	f32 player_radius_f = player_radius * BS;
@@ -1763,12 +1764,12 @@ void ServerEnvironment::getRemovedActiveObjects(PlayerSAO *playersao, s16 radius
 		if (object == NULL) {
 			infostream << "ServerEnvironment::getRemovedActiveObjects():"
 				<< " object in current_objects is NULL" << std::endl;
-			callback(true, id);
+			removed_objects.emplace(true, id);
 			continue;
 		}
 
 		if (object->isGone()) {
-			callback(true, id);
+			removed_objects.emplace(true, id);
 			continue;
 		}
 
@@ -1780,7 +1781,7 @@ void ServerEnvironment::getRemovedActiveObjects(PlayerSAO *playersao, s16 radius
 			continue;
 
 		// Object is no longer visible
-		callback(false, id);
+		removed_objects.emplace(false, id);
 	}
 }
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -2275,7 +2275,6 @@ bool ServerEnvironment::saveStaticToBlock(
 
 void ServerEnvironment::processActiveObjectRemove(ServerActiveObject *obj)
 {
-	u16 id = obj->getId();
 	// Tell the object about removal
 	obj->removingFromEnvironment();
 	// Deregister in scripting api

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -303,7 +303,7 @@ public:
 	void getRemovedActiveObjects(PlayerSAO *playersao, s16 radius,
 		s16 player_radius,
 		std::set<u16> &current_objects,
-		std::queue<u16> &removed_objects);
+		const std::function<void(bool /* gone? */, u16 /* id */)> &callback);
 
 	/*
 		Get the next message emitted by some active object.
@@ -454,7 +454,7 @@ private:
 	bool saveStaticToBlock(v3s16 blockpos, u16 store_id,
 			ServerActiveObject *obj, const StaticObject &s_obj, u32 mod_reason);
 
-	void processActiveObjectRemove(ServerActiveObject *obj, u16 id);
+	void processActiveObjectRemove(ServerActiveObject *obj);
 
 	/*
 		Member variables

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -19,6 +19,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <set>
+#include <random>
+#include <utility>
+
 #include "activeobject.h"
 #include "environment.h"
 #include "map.h"
@@ -26,8 +30,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server/activeobjectmgr.h"
 #include "util/numeric.h"
 #include "util/metricsbackend.h"
-#include <set>
-#include <random>
 
 class IGameDef;
 struct GameParams;
@@ -303,7 +305,7 @@ public:
 	void getRemovedActiveObjects(PlayerSAO *playersao, s16 radius,
 		s16 player_radius,
 		std::set<u16> &current_objects,
-		const std::function<void(bool /* gone? */, u16 /* id */)> &callback);
+		std::queue<std::pair<bool /* gone? */, u16>> &removed_objects);
 
 	/*
 		Get the next message emitted by some active object.


### PR DESCRIPTION
- Goal of the PR: Preserve backwards compatibility while preserving the fix for the bug as outlined in https://github.com/minetest/minetest/issues/14422#issuecomment-1978887147
- How does the PR work? See the comment there
- Does it resolve any reported issue? Should close #14422

## To do

This PR is Ready for Review.

## How to test

1. Spawn `soundstuff:bigfoot`
2. Use branding iron to get identifier for big foot
3. Use jukebox to play (looping) sound (for example sinus) attached to big foot
4. Distance yourself from big foot (until it is unloaded / disappears) - the sound should stop. If you approach big foot again, the sound does not restart. (That will require sfence's PR for sending sounds if objects come into range.)
5. Murder big foot. The sound should not stop.

Also test with an ephemeral sound, which should be entirely unaffected: It should not stop, no matter whether you murder big foot or distance yourself.