### PR TITLE
Allow calling minetest.set_mapgen_setting after initialization

### DIFF
--- a/src/map_settings_manager.cpp
+++ b/src/map_settings_manager.cpp
@@ -67,9 +67,6 @@ bool MapSettingsManager::getMapSettingNoiseParams(
 bool MapSettingsManager::setMapSetting(
 	const std::string &name, const std::string &value, bool override_meta)
 {
-	if (mapgen_params)
-		return false;
-
 	if (override_meta)
 		m_map_settings->set(name, value);
 	else

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -927,10 +927,7 @@ int ModApiMapgen::l_set_mapgen_setting(lua_State *L)
 	const char *value  = luaL_checkstring(L, 2);
 	bool override_meta = readParam<bool>(L, 3, false);
 
-	if (!settingsmgr->setMapSetting(name, value, override_meta)) {
-		errorstream << "set_mapgen_setting: cannot set '"
-			<< name << "' after initialization" << std::endl;
-	}
+	settingsmgr->setMapSetting(name, value, override_meta);
 
 	return 0;
 }

--- a/src/unittest/test_map_settings_manager.cpp
+++ b/src/unittest/test_map_settings_manager.cpp
@@ -168,7 +168,7 @@ void TestMapSettingsManager::testMapSettingsManager()
 	check_noise_params(&v5params->np_height, &meta_np_height);
 	check_noise_params(&v5params->np_ground, &user_np_ground);
 
-	UASSERT(mgr.setMapSetting("foobar", "25") == false);
+	UASSERT(mgr.setMapSetting("foobar", "25") != false);
 
 	// Pretend the ServerMap is shutting down
 	UASSERT(mgr.saveMapMeta());


### PR DESCRIPTION
This PR removes a few lines of checks that enforce calling `minetest.set_mapgen_setting` only during initialization. After a surface-level reading of the code and some testing, it looks like no further changes are needed to add support for this.

These changes allow mods to influence terrain generation dynamically, by passing the mapgen environment arbitrary values at any time. Among all the options considered, this is the one that requires the least changes to the code, and is fully backwards-compatible.

Edit: only custom mapgen code can make use of this, it won't affect hardcoded mapgens.

## To do

This PR is Ready for Review.

## How to test

Call the function during initialization and then get the values back via `minetest.get_mapgen_setting`.

For a more complete example, I've created a branch in the Nodeverse repo that makes use of these changes: https://github.com/aerkiaga/nodeverse/tree/parallel_mapgen.
