### PR TITLE
[no squash] Add object -> sound ID index & missing mutex

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2988,13 +2988,16 @@ void Server::DeleteClient(session_t peer_id, ClientDeletionReason reason)
 		/*
 			Clear references to playing sounds
 		*/
-		for (auto i = m_playing_sounds.begin(); i != m_playing_sounds.end();) {
-			ServerPlayingSound &psound = i->second;
-			psound.clients.erase(peer_id);
-			if (psound.clients.empty())
-				i = removeSoundReference(i).first;
-			else
-				++i;
+		{
+			MutexAutoLock env_lock(m_env_mutex);
+			for (auto i = m_playing_sounds.begin(); i != m_playing_sounds.end();) {
+				ServerPlayingSound &psound = i->second;
+				psound.clients.erase(peer_id);
+				if (psound.clients.empty())
+					i = removeSoundReference(i).first;
+				else
+					++i;
+			}
 		}
 
 		// clear formspec info so the next client can't abuse the current state

--- a/src/server.h
+++ b/src/server.h
@@ -44,7 +44,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <map>
 #include <vector>
 #include <unordered_set>
+#include <unordered_map>
 #include <optional>
+#include <utility>
 #include <string_view>
 
 class ChatEvent;
@@ -725,8 +727,14 @@ private:
 		Sounds
 	*/
 	std::unordered_map<s32, ServerPlayingSound> m_playing_sounds;
+	// Index for attached sound IDs by object ID. Must be kept in sync with m_playing_sounds.
+	std::unordered_multimap<u16, s32> m_attached_sound_ids;
 	s32 m_playing_sounds_id_last_used = 0; // positive values only
 	s32 nextSoundId();
+	std::pair<
+		std::unordered_map<s32, ServerPlayingSound>::iterator,
+		std::unordered_multimap<u16, s32>::iterator
+	> removeSoundReference(std::unordered_map<s32, ServerPlayingSound>::iterator it);
 
 	ModStorageDatabase *m_mod_storage_database = nullptr;
 	float m_mod_storage_save_timer = 10.0f;


### PR DESCRIPTION
1st commit: Improve performance (linear search -> constant time) using a multimap. Untested.

2nd commit is a mutex which should fix the hang (tested in n=2 trials).

Mineclone on a release build should be playable with this.