### PR TITLE
Remove excessive touchscreengui.h includes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -368,6 +368,7 @@ set(common_SRCS
 	${server_SRCS}
 	${content_SRCS}
 	chat.cpp
+	clientdynamicinfo.cpp
 	collision.cpp
 	content_mapnode.cpp
 	content_nodemeta.cpp

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "gui/mainmenumanager.h"
 #include "clouds.h"
+#include "gui/touchscreengui.h"
 #include "server.h"
 #include "filesys.h"
 #include "gui/guiMainMenu.h"

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -211,8 +211,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 				break;
 
 			if (g_settings->getBool("enable_touch")) {
-				receiver->m_touchscreengui = new TouchScreenGUI(m_rendering_engine->get_raw_device(), receiver);
-				g_touchscreengui = receiver->m_touchscreengui;
+				g_touchscreengui = new TouchScreenGUI(m_rendering_engine->get_raw_device(), receiver);
 			}
 
 			the_game(
@@ -247,7 +246,6 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 		if (g_touchscreengui) {
 			delete g_touchscreengui;
 			g_touchscreengui = NULL;
-			receiver->m_touchscreengui = NULL;
 		}
 
 		/* Save the settings when leaving the game.

--- a/src/client/content_cso.cpp
+++ b/src/client/content_cso.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "content_cso.h"
 #include <IBillboardSceneNode.h>
+#include "client/texturesource.h"
 #include "clientenvironment.h"
 #include "client.h"
 #include "map.h"

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -40,6 +40,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "content/subgames.h"
 #include "client/event_manager.h"
 #include "fontengine.h"
+#include "gui/touchscreengui.h"
 #include "itemdef.h"
 #include "log.h"
 #include "filesys.h"

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -236,7 +236,7 @@ float RealInputHandler::getMovementDirection()
 		x -= 1;
 
 	if (x != 0 || z != 0) /* If there is a keyboard event, it takes priority */
-		return atan2(x, z);
+		return std::atan2(x, z);
 	else if (g_touchscreengui && g_touchscreengui->getMovementDirection())
 		return g_touchscreengui->getMovementDirection();
 	return joystick.getMovementDirection();

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -103,8 +103,8 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 		React to nothing here if a menu is active
 	*/
 	if (isMenuActive()) {
-		if (m_touchscreengui) {
-			m_touchscreengui->setVisible(false);
+		if (g_touchscreengui) {
+			g_touchscreengui->setVisible(false);
 		}
 		return g_menumgr.preprocessEvent(event);
 	}
@@ -129,9 +129,9 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 			return true;
 		}
 
-	} else if (m_touchscreengui && event.EventType == irr::EET_TOUCH_INPUT_EVENT) {
+	} else if (g_touchscreengui && event.EventType == irr::EET_TOUCH_INPUT_EVENT) {
 		// In case of touchscreengui, we have to handle different events
-		m_touchscreengui->translateEvent(event);
+		g_touchscreengui->translateEvent(event);
 		return true;
 
 	} else if (event.EventType == irr::EET_JOYSTICK_INPUT_EVENT) {
@@ -216,8 +216,8 @@ float RealInputHandler::getMovementSpeed()
 			return 0.0f;
 		return 1.0f; // If there is a keyboard event, assume maximum speed
 	}
-	if (m_receiver->m_touchscreengui && m_receiver->m_touchscreengui->getMovementSpeed())
-		return m_receiver->m_touchscreengui->getMovementSpeed();
+	if (g_touchscreengui && g_touchscreengui->getMovementSpeed())
+		return g_touchscreengui->getMovementSpeed();
 	return joystick.getMovementSpeed();
 }
 
@@ -237,8 +237,8 @@ float RealInputHandler::getMovementDirection()
 
 	if (x != 0 || z != 0) /* If there is a keyboard event, it takes priority */
 		return atan2(x, z);
-	else if (m_receiver->m_touchscreengui && m_receiver->m_touchscreengui->getMovementDirection())
-		return m_receiver->m_touchscreengui->getMovementDirection();
+	else if (g_touchscreengui && g_touchscreengui->getMovementDirection())
+		return g_touchscreengui->getMovementDirection();
 	return joystick.getMovementDirection();
 }
 

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -197,14 +197,7 @@ public:
 		keyWasReleased.clear();
 	}
 
-	MyEventReceiver()
-	{
-		m_touchscreengui = NULL;
-	}
-
 	JoystickController *joystick = nullptr;
-
-	TouchScreenGUI *m_touchscreengui;
 
 private:
 	s32 mouse_wheel = 0;

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -24,7 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <list>
 #include "keycode.h"
 #include "renderingengine.h"
-#include "gui/touchscreengui.h"
 
 class InputHandler;
 
@@ -308,48 +307,9 @@ public:
 		return m_receiver->WasKeyReleased(keycache.key[k]) || joystick.wasKeyReleased(k);
 	}
 
-	virtual float getMovementSpeed()
-	{
-		bool f = m_receiver->IsKeyDown(keycache.key[KeyType::FORWARD]),
-			b = m_receiver->IsKeyDown(keycache.key[KeyType::BACKWARD]),
-			l = m_receiver->IsKeyDown(keycache.key[KeyType::LEFT]),
-			r = m_receiver->IsKeyDown(keycache.key[KeyType::RIGHT]);
-		if (f || b || l || r)
-		{
-			// if contradictory keys pressed, stay still
-			if (f && b && l && r)
-				return 0.0f;
-			else if (f && b && !l && !r)
-				return 0.0f;
-			else if (!f && !b && l && r)
-				return 0.0f;
-			return 1.0f; // If there is a keyboard event, assume maximum speed
-		}
-		if (m_receiver->m_touchscreengui && m_receiver->m_touchscreengui->getMovementSpeed())
-			return m_receiver->m_touchscreengui->getMovementSpeed();
-		return joystick.getMovementSpeed();
-	}
+	virtual float getMovementSpeed();
 
-	virtual float getMovementDirection()
-	{
-		float x = 0, z = 0;
-
-		/* Check keyboard for input */
-		if (m_receiver->IsKeyDown(keycache.key[KeyType::FORWARD]))
-			z += 1;
-		if (m_receiver->IsKeyDown(keycache.key[KeyType::BACKWARD]))
-			z -= 1;
-		if (m_receiver->IsKeyDown(keycache.key[KeyType::RIGHT]))
-			x += 1;
-		if (m_receiver->IsKeyDown(keycache.key[KeyType::LEFT]))
-			x -= 1;
-
-		if (x != 0 || z != 0) /* If there is a keyboard event, it takes priority */
-			return atan2(x, z);
-		else if (m_receiver->m_touchscreengui && m_receiver->m_touchscreengui->getMovementDirection())
-			return m_receiver->m_touchscreengui->getMovementDirection();
-		return joystick.getMovementDirection();
-	}
+	virtual float getMovementDirection();
 
 	virtual bool cancelPressed()
 	{

--- a/src/clientdynamicinfo.cpp
+++ b/src/clientdynamicinfo.cpp
@@ -1,3 +1,22 @@
+/*
+Minetest
+Copyright (C) 2022-3 rubenwardy <rw@rubenwardy.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
 #ifndef SERVER
 
 #include "clientdynamicinfo.h"

--- a/src/clientdynamicinfo.cpp
+++ b/src/clientdynamicinfo.cpp
@@ -1,0 +1,36 @@
+#ifndef SERVER
+
+#include "clientdynamicinfo.h"
+
+#include "settings.h"
+#include "client/renderingengine.h"
+#include "gui/touchscreengui.h"
+
+ClientDynamicInfo ClientDynamicInfo::getCurrent()
+{
+    v2u32 screen_size = RenderingEngine::getWindowSize();
+    f32 density = RenderingEngine::getDisplayDensity();
+    f32 gui_scaling = g_settings->getFloat("gui_scaling", 0.5f, 20.0f);
+    f32 hud_scaling = g_settings->getFloat("hud_scaling", 0.5f, 20.0f);
+    f32 real_gui_scaling = gui_scaling * density;
+    f32 real_hud_scaling = hud_scaling * density;
+    bool touch_controls = g_touchscreengui;
+
+    return {
+        screen_size, real_gui_scaling, real_hud_scaling,
+        ClientDynamicInfo::calculateMaxFSSize(screen_size, gui_scaling),
+        touch_controls
+    };
+}
+
+v2f32 ClientDynamicInfo::calculateMaxFSSize(v2u32 render_target_size, f32 gui_scaling)
+{
+    f32 factor = (g_settings->getBool("enable_touch") ? 10 : 15) / gui_scaling;
+    f32 ratio = (f32)render_target_size.X / (f32)render_target_size.Y;
+    if (ratio < 1)
+        return { factor, factor / ratio };
+    else
+        return { factor * ratio, factor };
+}
+
+#endif

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -20,11 +20,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "irrlichttypes_bloated.h"
-#ifndef SERVER
-#include "settings.h"
-#include "client/renderingengine.h"
-#include "gui/touchscreengui.h"
-#endif
 
 
 struct ClientDynamicInfo
@@ -44,32 +39,9 @@ public:
 	}
 
 #ifndef SERVER
-	static ClientDynamicInfo getCurrent() {
-		v2u32 screen_size = RenderingEngine::getWindowSize();
-		f32 density = RenderingEngine::getDisplayDensity();
-		f32 gui_scaling = g_settings->getFloat("gui_scaling", 0.5f, 20.0f);
-		f32 hud_scaling = g_settings->getFloat("hud_scaling", 0.5f, 20.0f);
-		f32 real_gui_scaling = gui_scaling * density;
-		f32 real_hud_scaling = hud_scaling * density;
-		bool touch_controls = g_touchscreengui;
-
-		return {
-			screen_size, real_gui_scaling, real_hud_scaling,
-			ClientDynamicInfo::calculateMaxFSSize(screen_size, gui_scaling),
-			touch_controls
-		};
-	}
-#endif
+	static ClientDynamicInfo getCurrent();
 
 private:
-#ifndef SERVER
-	static v2f32 calculateMaxFSSize(v2u32 render_target_size, f32 gui_scaling) {
-		f32 factor = (g_settings->getBool("enable_touch") ? 10 : 15) / gui_scaling;
-		f32 ratio = (f32)render_target_size.X / (f32)render_target_size.Y;
-		if (ratio < 1)
-			return { factor, factor / ratio };
-		else
-			return { factor * ratio, factor };
-	}
+	static v2f32 calculateMaxFSSize(v2u32 render_target_size, f32 gui_scaling);
 #endif
 };


### PR DESCRIPTION
While working on #14456, I noticed that recompiling after changes to `touchscreengui.h` takes way too long.

To fix that, this PR ...
1. ... moves some code depending on `touchscreengui.h` from header files to cpp files.
2. ... removes the redundant `MyEventReceiver::m_touchscreengui` member.

## To do

This PR is a Ready for Review.

## How to test

See that the touch controls still work.

See that I didn't change the code while moving it. See that it compiles.