### PR TITLE
#14452 if node is source, code should use source_id, not flowing_id

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -590,7 +590,7 @@ void ServerMap::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 		switch (liquid_type) {
 			case LIQUID_SOURCE:
 				liquid_level = LIQUID_LEVEL_SOURCE;
-				liquid_kind = cf.liquid_alternative_flowing_id;
+				liquid_kind = cf.liquid_alternative_source_id;
 				break;
 			case LIQUID_FLOWING:
 				liquid_level = (n0.param2 & LIQUID_LEVEL_MASK);


### PR DESCRIPTION
a small change to the code to make it clearer. Since a node is a source, it is worth naming it like a source, not a flowing one. I tested it for my needs and it worked - resolve my issue #14452. If possible, it would be nice to release this as a patch also for previous versions that are supported by Mineclonia. Now that I have found the solution to the problem myself, I would like to be able to implement it and make my life easier - 5.5.1, 5.6, 5.7, 5.8 @rubenwardy @sfan5 @appgurueu   

## To do

Ready for Review.

## How to test
use the example from #14452, put "basenodes:water_pointable" and some "basenodes:water_source" near. "basenodes:water_pointable" will no longer be replaced with "basenodes:water_source" by flowing water. Flowing water will connect correctly to both, the new source will be according to the entry from flowing - "basenodes:water_source".