### PR TITLE
Script API: introduce an API version number

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -1,5 +1,8 @@
 -- Minetest: builtin/features.lua
 
+-- The changelog is located in doc/lua_api.md
+core.api_version = 1
+
 core.features = {
 	glasslike_framed = true,
 	nodebox_as_selectionbox = true,

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5277,6 +5277,23 @@ Minetest includes the following settings to control behavior of privileges:
 'minetest' namespace reference
 ==============================
 
+API Version
+-----------
+
+* `minetest.api_version`: numeric value
+   * Describes the modding API capabilities and behavior. This value
+     depends on the server version and can be used to achieve backwards
+     compatibility in mods.
+   * This supersedes the concept of `minetest.features`.
+   * Exists since Minetest version 5.9.0. Use the expression
+     `(minetest.api_version or 0)` as a fallback.
+
+**API Version History**
+
+ * API version 1 (5.9.0):
+    * All of `minetest.features`
+
+
 Utilities
 ---------
 
@@ -5401,6 +5418,8 @@ Utilities
       lsystem_decoration_type = true,
       -- Overrideable pointing range using the itemstack meta key `"range"` (5.9.0)
       item_meta_range = true,
+
+      -- All the features above are present if `(minetest.api_version or 0) >= 1`
   }
   ```
 


### PR DESCRIPTION
As the list of minetest.features.* grows, it seems to be more future-proof to use a numeric value to refer to in the documentation.

**Pro arguments:**

1. Similar concepts are already in use: formspec version, protocol version
2. Higher versions ensure that the other feature (flags) are still present, thus no need for (almost) duplicate checks.

**Con arguments:**

1. way less readable than names

I opened this PR to collect opinions from different developers.

## To do

This PR is Ready for Opinions.

## How to test

1. not
