### PR TITLE
TouchScreenGUI dehardcoding refactor

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -206,10 +206,6 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 			if (!m_rendering_engine->run() || *kill)
 				break;
 
-			if (g_settings->getBool("enable_touch")) {
-				g_touchscreengui = new TouchScreenGUI(m_rendering_engine->get_raw_device(), receiver);
-			}
-
 			the_game(
 				kill,
 				input,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1555,8 +1555,8 @@ bool Game::initGui()
 	gui_chat_console = new GUIChatConsole(guienv, guienv->getRootGUIElement(),
 			-1, chat_backend, client, &g_menumgr);
 
-	if (g_touchscreengui)
-		g_touchscreengui->init(texture_src);
+	if (g_settings->getBool("enable_touch"))
+		g_touchscreengui = new TouchScreenGUI(device, texture_src);
 
 	return true;
 }

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -36,8 +36,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <iostream>
 #include <algorithm>
 
-using namespace irr::core;
-
 TouchScreenGUI *g_touchscreengui;
 
 const std::string button_image_names[] = {
@@ -68,7 +66,7 @@ const std::string button_image_names[] = {
 };
 
 static void load_button_texture(IGUIButton *gui_button, const std::string &path,
-		const rect<s32> &button_rect, ISimpleTextureSource *tsrc, video::IVideoDriver *driver)
+		const recti &button_rect, ISimpleTextureSource *tsrc, video::IVideoDriver *driver)
 {
 	video::ITexture *texture = guiScalingImageButton(driver,
 			tsrc->getTexture(path), button_rect.getWidth(),
@@ -76,7 +74,7 @@ static void load_button_texture(IGUIButton *gui_button, const std::string &path,
 	if (texture) {
 		gui_button->setUseAlphaChannel(true);
 		if (g_settings->getBool("gui_scaling_filter")) {
-			rect<s32> txr_rect(0, 0, button_rect.getWidth(), button_rect.getHeight());
+			recti txr_rect(0, 0, button_rect.getWidth(), button_rect.getHeight());
 			gui_button->setImage(texture, txr_rect);
 			gui_button->setPressedImage(texture, txr_rect);
 			gui_button->setScaleImage(false);
@@ -96,7 +94,7 @@ void button_info::emitAction(bool action, video::IVideoDriver *driver,
 		return;
 
 	SEvent translated{};
-	translated.EventType        = irr::EET_KEY_INPUT_EVENT;
+	translated.EventType        = EET_KEY_INPUT_EVENT;
 	translated.KeyInput.Key     = keycode;
 	translated.KeyInput.Control = false;
 	translated.KeyInput.Shift   = false;
@@ -259,7 +257,7 @@ static EKEY_CODE id_to_keycode(touch_gui_button_id id)
 
 AutoHideButtonBar::AutoHideButtonBar(IrrlichtDevice *device, ISimpleTextureSource *tsrc,
 		touch_gui_button_id starter_id, const std::string &starter_img,
-		core::recti starter_rect, autohide_button_bar_dir dir) :
+		recti starter_rect, autohide_button_bar_dir dir) :
 			m_driver(device->getVideoDriver()),
 			m_guienv(device->getGUIEnvironment()),
 			m_receiver(device->getEventReceiver()),
@@ -286,7 +284,7 @@ void AutoHideButtonBar::addButton(touch_gui_button_id id, const std::string &ima
 	else
 		button_size = m_lower_right.Y - m_upper_left.Y;
 
-	irr::core::rect<int> current_button;
+	recti current_button;
 
 	if (m_dir == AHBB_Dir_Right_Left || m_dir == AHBB_Dir_Left_Right) {
 		int x_start = 0;
@@ -302,7 +300,7 @@ void AutoHideButtonBar::addButton(touch_gui_button_id id, const std::string &ima
 			x_start = x_end - button_size;
 		}
 
-		current_button = rect<s32>(x_start, m_upper_left.Y, x_end, m_lower_right.Y);
+		current_button = recti(x_start, m_upper_left.Y, x_end, m_lower_right.Y);
 	} else {
 		double y_start = 0;
 		double y_end = 0;
@@ -317,7 +315,7 @@ void AutoHideButtonBar::addButton(touch_gui_button_id id, const std::string &ima
 			y_start = y_end - button_size;
 		}
 
-		current_button = rect<s32>(m_upper_left.X, y_start, m_lower_right.Y, y_end);
+		current_button = recti(m_upper_left.X, y_start, m_lower_right.Y, y_end);
 	}
 
 	IGUIButton *btn_gui_button = m_guienv->addButton(current_button, nullptr, id);
@@ -440,45 +438,44 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsr
 	// Joystick is placed on the bottom left of screen.
 	if (m_fixed_joystick) {
 		m_joystick_btn_off.grab(makeJoystickButton(joystick_off_id,
-				rect<s32>(m_button_size,
+				recti(m_button_size,
 						m_screensize.Y - m_button_size * 4,
 						m_button_size * 4,
 						m_screensize.Y - m_button_size), true));
 	} else {
 		m_joystick_btn_off.grab(makeJoystickButton(joystick_off_id,
-				rect<s32>(m_button_size,
+				recti(m_button_size,
 						m_screensize.Y - m_button_size * 3,
 						m_button_size * 3,
 						m_screensize.Y - m_button_size), true));
 	}
 
 	m_joystick_btn_bg.grab(makeJoystickButton(joystick_bg_id,
-			rect<s32>(m_button_size,
+			recti(m_button_size,
 					m_screensize.Y - m_button_size * 4,
 					m_button_size * 4,
 					m_screensize.Y - m_button_size), false));
 
 	m_joystick_btn_center.grab(makeJoystickButton(joystick_center_id,
-			rect<s32>(0, 0, m_button_size, m_button_size), false));
+			recti(0, 0, m_button_size, m_button_size), false));
 
 	// init jump button
 	addButton(jump_id, button_image_names[jump_id],
-			rect<s32>(m_screensize.X - 1.75f * m_button_size,
+			recti(m_screensize.X - 1.75f * m_button_size,
 					m_screensize.Y - m_button_size,
 					m_screensize.X - 0.25f * m_button_size,
 					m_screensize.Y));
 
-
 	// init sneak button
 	addButton(sneak_id, button_image_names[sneak_id],
-			rect<s32>(m_screensize.X - 3.25f * m_button_size,
+			recti(m_screensize.X - 3.25f * m_button_size,
 					m_screensize.Y - m_button_size,
 					m_screensize.X - 1.75f * m_button_size,
 					m_screensize.Y));
 
 	// init zoom button
 	addButton(zoom_id, button_image_names[zoom_id],
-			rect<s32>(m_screensize.X - 1.25f * m_button_size,
+			recti(m_screensize.X - 1.25f * m_button_size,
 					m_screensize.Y - 4 * m_button_size,
 					m_screensize.X - 0.25f * m_button_size,
 					m_screensize.Y - 3 * m_button_size));
@@ -486,14 +483,14 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsr
 	// init aux1 button
 	if (!m_joystick_triggers_aux1)
 		addButton(aux1_id, button_image_names[aux1_id],
-				rect<s32>(m_screensize.X - 1.25f * m_button_size,
+				recti(m_screensize.X - 1.25f * m_button_size,
 						m_screensize.Y - 2.5f * m_button_size,
 						m_screensize.X - 0.25f * m_button_size,
 						m_screensize.Y - 1.5f * m_button_size));
 
 	AutoHideButtonBar &settings_bar = m_buttonbars.emplace_back(m_device, m_texturesource,
 			settings_starter_id, button_image_names[settings_starter_id],
-			core::recti(m_screensize.X - 1.25f * m_button_size,
+			recti(m_screensize.X - 1.25f * m_button_size,
 					m_screensize.Y - (SETTINGS_BAR_Y_OFFSET + 1.0f) * m_button_size
 							+ 0.5f * m_button_size,
 					m_screensize.X - 0.25f * m_button_size,
@@ -516,7 +513,7 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsr
 
 	AutoHideButtonBar &rare_controls_bar = m_buttonbars.emplace_back(m_device, m_texturesource,
 			rare_controls_starter_id, button_image_names[rare_controls_starter_id],
-			core::recti(0.25f * m_button_size,
+			recti(0.25f * m_button_size,
 					m_screensize.Y - (RARE_CONTROLS_BAR_Y_OFFSET + 1.0f) * m_button_size
 							+ 0.5f * m_button_size,
 					0.75f * m_button_size,
@@ -534,7 +531,7 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsr
 	}
 }
 
-void TouchScreenGUI::addButton(touch_gui_button_id id, const std::string &image, const rect<s32> &rect)
+void TouchScreenGUI::addButton(touch_gui_button_id id, const std::string &image, const recti &rect)
 {
 	IGUIButton *btn_gui_button = m_guienv->addButton(rect, nullptr, id);
 	load_button_texture(btn_gui_button, image, rect,
@@ -546,7 +543,7 @@ void TouchScreenGUI::addButton(touch_gui_button_id id, const std::string &image,
 }
 
 IGUIButton *TouchScreenGUI::makeJoystickButton(touch_gui_button_id id,
-		const rect<s32> &button_rect, bool visible)
+		const recti &button_rect, bool visible)
 {
 	IGUIButton *btn_gui_button = m_guienv->addButton(button_rect, nullptr, id);
 	btn_gui_button->setVisible(visible);
@@ -802,7 +799,7 @@ void TouchScreenGUI::applyJoystickStatus()
 {
 	if (m_joystick_triggers_aux1) {
 		SEvent translated{};
-		translated.EventType            = irr::EET_KEY_INPUT_EVENT;
+		translated.EventType            = EET_KEY_INPUT_EVENT;
 		translated.KeyInput.Key         = id_to_keycode(aux1_id);
 		translated.KeyInput.PressedDown = false;
 		m_receiver->OnEvent(translated);
@@ -854,7 +851,7 @@ void TouchScreenGUI::resetHotbarRects()
 	m_hotbar_rects.clear();
 }
 
-void TouchScreenGUI::registerHotbarRect(u16 index, const rect<s32> &rect)
+void TouchScreenGUI::registerHotbarRect(u16 index, const recti &rect)
 {
 	m_hotbar_rects[index] = rect;
 }
@@ -1001,7 +998,7 @@ void TouchScreenGUI::applyContextControls(const TouchInteractionMode &mode)
 		m_place_pressed = true;
 
 	} else if (!target_place_pressed && m_place_pressed) {
-		emitMouseEvent(irr::EMIE_RMOUSE_LEFT_UP);
+		emitMouseEvent(EMIE_RMOUSE_LEFT_UP);
 		m_place_pressed = false;
 	}
 }

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -65,26 +65,14 @@ const std::string button_image_names[] = {
 	"joystick_center.png",
 };
 
-static void load_button_texture(IGUIButton *gui_button, const std::string &path,
+static void load_button_texture(IGUIImage *gui_button, const std::string &path,
 		const recti &button_rect, ISimpleTextureSource *tsrc, video::IVideoDriver *driver)
 {
 	video::ITexture *texture = guiScalingImageButton(driver,
 			tsrc->getTexture(path), button_rect.getWidth(),
 			button_rect.getHeight());
-	if (texture) {
-		gui_button->setUseAlphaChannel(true);
-		if (g_settings->getBool("gui_scaling_filter")) {
-			recti txr_rect(0, 0, button_rect.getWidth(), button_rect.getHeight());
-			gui_button->setImage(texture, txr_rect);
-			gui_button->setPressedImage(texture, txr_rect);
-			gui_button->setScaleImage(false);
-		} else {
-			gui_button->setImage(texture);
-			gui_button->setPressedImage(texture);
-			gui_button->setScaleImage(true);
-		}
-		gui_button->setDrawBorder(false);
-	}
+	gui_button->setImage(texture);
+	gui_button->setScaleImage(true);
 }
 
 void button_info::emitAction(bool action, video::IVideoDriver *driver,
@@ -266,12 +254,12 @@ AutoHideButtonBar::AutoHideButtonBar(IrrlichtDevice *device, ISimpleTextureSourc
 	m_upper_left = starter_rect.UpperLeftCorner;
 	m_lower_right = starter_rect.LowerRightCorner;
 
-	IGUIButton *starter_gui_button = m_guienv->addButton(starter_rect, nullptr,
+	IGUIImage *starter_gui_button = m_guienv->addImage(starter_rect, nullptr,
 			starter_id);
 	load_button_texture(starter_gui_button, starter_img, starter_rect,
 			m_texturesource, m_driver);
 
-	m_starter = grab_gui_element<IGUIButton>(starter_gui_button);
+	m_starter = grab_gui_element<IGUIImage>(starter_gui_button);
 	m_dir = dir;
 }
 
@@ -318,14 +306,14 @@ void AutoHideButtonBar::addButton(touch_gui_button_id id, const std::string &ima
 		current_button = recti(m_upper_left.X, y_start, m_lower_right.Y, y_end);
 	}
 
-	IGUIButton *btn_gui_button = m_guienv->addButton(current_button, nullptr, id);
+	IGUIImage *btn_gui_button = m_guienv->addImage(current_button, nullptr, id);
 	btn_gui_button->setVisible(false);
 	btn_gui_button->setEnabled(false);
 	load_button_texture(btn_gui_button, image, current_button, m_texturesource, m_driver);
 
 	button_info btn{};
 	btn.keycode = id_to_keycode(id);
-	btn.gui_button = grab_gui_element<IGUIButton>(btn_gui_button);
+	btn.gui_button = grab_gui_element<IGUIImage>(btn_gui_button);
 	m_buttons.push_back(btn);
 }
 
@@ -437,26 +425,26 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsr
 	// Initialize joystick display "button".
 	// Joystick is placed on the bottom left of screen.
 	if (m_fixed_joystick) {
-		m_joystick_btn_off = grab_gui_element<IGUIButton>(makeJoystickButton(joystick_off_id,
+		m_joystick_btn_off = grab_gui_element<IGUIImage>(makeJoystickButton(joystick_off_id,
 				recti(m_button_size,
 						m_screensize.Y - m_button_size * 4,
 						m_button_size * 4,
 						m_screensize.Y - m_button_size), true));
 	} else {
-		m_joystick_btn_off = grab_gui_element<IGUIButton>(makeJoystickButton(joystick_off_id,
+		m_joystick_btn_off = grab_gui_element<IGUIImage>(makeJoystickButton(joystick_off_id,
 				recti(m_button_size,
 						m_screensize.Y - m_button_size * 3,
 						m_button_size * 3,
 						m_screensize.Y - m_button_size), true));
 	}
 
-	m_joystick_btn_bg = grab_gui_element<IGUIButton>(makeJoystickButton(joystick_bg_id,
+	m_joystick_btn_bg = grab_gui_element<IGUIImage>(makeJoystickButton(joystick_bg_id,
 			recti(m_button_size,
 					m_screensize.Y - m_button_size * 4,
 					m_button_size * 4,
 					m_screensize.Y - m_button_size), false));
 
-	m_joystick_btn_center = grab_gui_element<IGUIButton>(makeJoystickButton(joystick_center_id,
+	m_joystick_btn_center = grab_gui_element<IGUIImage>(makeJoystickButton(joystick_center_id,
 			recti(0, 0, m_button_size, m_button_size), false));
 
 	// init jump button
@@ -533,19 +521,19 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsr
 
 void TouchScreenGUI::addButton(touch_gui_button_id id, const std::string &image, const recti &rect)
 {
-	IGUIButton *btn_gui_button = m_guienv->addButton(rect, nullptr, id);
+	IGUIImage *btn_gui_button = m_guienv->addImage(rect, nullptr, id);
 	load_button_texture(btn_gui_button, image, rect,
 			m_texturesource, m_device->getVideoDriver());
 
 	button_info &btn = m_buttons.emplace_back();
 	btn.keycode = id_to_keycode(id);
-	btn.gui_button = grab_gui_element<IGUIButton>(btn_gui_button);
+	btn.gui_button = grab_gui_element<IGUIImage>(btn_gui_button);
 }
 
-IGUIButton *TouchScreenGUI::makeJoystickButton(touch_gui_button_id id,
+IGUIImage *TouchScreenGUI::makeJoystickButton(touch_gui_button_id id,
 		const recti &button_rect, bool visible)
 {
-	IGUIButton *btn_gui_button = m_guienv->addButton(button_rect, nullptr, id);
+	IGUIImage *btn_gui_button = m_guienv->addImage(button_rect, nullptr, id);
 	btn_gui_button->setVisible(visible);
 	load_button_texture(btn_gui_button, button_image_names[id], button_rect,
 			m_texturesource, m_device->getVideoDriver());

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -38,7 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 TouchScreenGUI *g_touchscreengui;
 
-const std::string button_image_names[] = {
+static const char *button_image_names[] = {
 	"jump_btn.png",
 	"down.png",
 	"zoom.png",
@@ -403,10 +403,6 @@ void AutoHideButtonBar::hide()
 	updateVisibility();
 }
 
-bool AutoHideButtonBar::operator!=(const AutoHideButtonBar &other) {
-	return m_starter.get() != other.m_starter.get();
-}
-
 TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsrc):
 		m_device(device),
 		m_guienv(device->getGUIEnvironment()),
@@ -486,7 +482,7 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsr
 							+ 0.5f * m_button_size),
 			AHBB_Dir_Right_Left);
 
-	const static std::vector<touch_gui_button_id> settings_bar_buttons {
+	const static touch_gui_button_id settings_bar_buttons[] {
 		fly_id, noclip_id, fast_id, debug_id, camera_id, range_id, minimap_id,
 	};
 	for (auto id : settings_bar_buttons) {
@@ -509,7 +505,7 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsr
 							+ 0.5f * m_button_size),
 			AHBB_Dir_Left_Right);
 
-	const static std::vector<touch_gui_button_id> rare_controls_bar_buttons {
+	const static touch_gui_button_id rare_controls_bar_buttons[] {
 		chat_id, inventory_id, drop_id, exit_id,
 	};
 	for (auto id : rare_controls_bar_buttons) {

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -160,8 +160,7 @@ AutoHideButtonBar::AutoHideButtonBar(IrrlichtDevice *device, ISimpleTextureSourc
 	IGUIButton *starter_gui_button = m_guienv->addButton(starter_rect, nullptr,
 			starter_id, L"", nullptr);
 
-	m_starter.gui_button        = starter_gui_button;
-	m_starter.gui_button->grab();
+	m_starter.gui_button.grab(starter_gui_button);
 	m_starter.repeat_counter    = -1.0f;
 	m_starter.keycode           = KEY_OEM_8; // use invalid keycode as it's not relevant
 	m_starter.immediate_release = true;
@@ -172,22 +171,6 @@ AutoHideButtonBar::AutoHideButtonBar(IrrlichtDevice *device, ISimpleTextureSourc
 
 	m_dir = dir;
 	m_timeout_value = timeout;
-}
-
-AutoHideButtonBar::~AutoHideButtonBar()
-{
-	if (m_starter.gui_button) {
-		m_starter.gui_button->setVisible(false);
-		m_starter.gui_button->drop();
-		m_starter.gui_button = nullptr;
-	}
-
-	for (auto &button : m_buttons) {
-		if (button.gui_button) {
-			button.gui_button->drop();
-			button.gui_button = nullptr;
-		}
-	}
 }
 
 void AutoHideButtonBar::addButton(touch_gui_button_id button_id, const wchar_t *caption,
@@ -238,8 +221,7 @@ void AutoHideButtonBar::addButton(touch_gui_button_id button_id, const wchar_t *
 			caption, nullptr);
 
 	button_info btn;
-	btn.gui_button        = btn_gui_button;
-	btn.gui_button->grab();
+	btn.gui_button.grab(btn_gui_button);
 	btn.gui_button->setVisible(false);
 	btn.gui_button->setEnabled(false);
 	btn.repeat_counter    = -1.0f;
@@ -278,7 +260,7 @@ bool AutoHideButtonBar::isButton(const SEvent &event)
 	if (m_active) {
 		// check for all buttons in vector
 		for (auto &button : m_buttons) {
-			if (button.gui_button == element) {
+			if (button.gui_button.get() == element) {
 				SEvent translated{};
 				translated.EventType        = irr::EET_KEY_INPUT_EVENT;
 				translated.KeyInput.Key     = button.keycode;
@@ -315,7 +297,7 @@ bool AutoHideButtonBar::isButton(const SEvent &event)
 		}
 	} else {
 		// check for starter button only
-		if (element == m_starter.gui_button) {
+		if (element == m_starter.gui_button.get()) {
 			m_starter.ids.push_back(event.TouchInput.ID);
 			m_starter.gui_button->setVisible(false);
 			m_starter.gui_button->setEnabled(false);
@@ -532,8 +514,7 @@ void TouchScreenGUI::initButton(touch_gui_button_id id, const rect<s32> &button_
 	IGUIButton *btn_gui_button = m_guienv->addButton(button_rect, nullptr, id, caption.c_str());
 
 	button_info &btn      = m_buttons[id];
-	btn.gui_button        = btn_gui_button;
-	btn.gui_button->grab();
+	btn.gui_button.grab(btn_gui_button);
 	btn.repeat_counter    = -1.0f;
 	btn.repeat_delay      = repeat_delay;
 	btn.keycode           = id_to_keycode(id);
@@ -550,9 +531,8 @@ button_info TouchScreenGUI::initJoystickButton(touch_gui_button_id id,
 	IGUIButton *btn_gui_button = m_guienv->addButton(button_rect, nullptr, id, L"O");
 
 	button_info btn;
-	btn.gui_button = btn_gui_button;
+	btn.gui_button.grab(btn_gui_button);
 	btn.gui_button->setVisible(visible);
-	btn.gui_button->grab();
 	btn.ids.clear();
 
 	load_button_texture(btn, joystick_image_names[texture_id], button_rect,
@@ -571,7 +551,7 @@ touch_gui_button_id TouchScreenGUI::getButtonID(s32 x, s32 y)
 
 		if (element)
 			for (unsigned int i = 0; i < after_last_element_id; i++)
-				if (element == m_buttons[i].gui_button)
+				if (element == m_buttons[i].gui_button.get())
 					return (touch_gui_button_id) i;
 	}
 
@@ -919,31 +899,6 @@ void TouchScreenGUI::applyJoystickStatus()
 			translated.KeyInput.PressedDown = true;
 			m_receiver->OnEvent(translated);
 		}
-	}
-}
-
-TouchScreenGUI::~TouchScreenGUI()
-{
-	for (auto &button : m_buttons) {
-		if (button.gui_button) {
-			button.gui_button->drop();
-			button.gui_button = nullptr;
-		}
-	}
-
-	if (m_joystick_btn_off.gui_button) {
-		m_joystick_btn_off.gui_button->drop();
-		m_joystick_btn_off.gui_button = nullptr;
-	}
-
-	if (m_joystick_btn_bg.gui_button) {
-		m_joystick_btn_bg.gui_button->drop();
-		m_joystick_btn_bg.gui_button = nullptr;
-	}
-
-	if (m_joystick_btn_center.gui_button) {
-		m_joystick_btn_center.gui_button->drop();
-		m_joystick_btn_center.gui_button = nullptr;
 	}
 }
 

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -271,7 +271,7 @@ AutoHideButtonBar::AutoHideButtonBar(IrrlichtDevice *device, ISimpleTextureSourc
 	load_button_texture(starter_gui_button, starter_img, starter_rect,
 			m_texturesource, m_driver);
 
-	m_starter.grab(starter_gui_button);
+	m_starter = grab_gui_element<IGUIButton>(starter_gui_button);
 	m_dir = dir;
 }
 
@@ -325,7 +325,7 @@ void AutoHideButtonBar::addButton(touch_gui_button_id id, const std::string &ima
 
 	button_info btn{};
 	btn.keycode = id_to_keycode(id);
-	btn.gui_button.grab(btn_gui_button);
+	btn.gui_button = grab_gui_element<IGUIButton>(btn_gui_button);
 	m_buttons.push_back(btn);
 }
 
@@ -437,26 +437,26 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsr
 	// Initialize joystick display "button".
 	// Joystick is placed on the bottom left of screen.
 	if (m_fixed_joystick) {
-		m_joystick_btn_off.grab(makeJoystickButton(joystick_off_id,
+		m_joystick_btn_off = grab_gui_element<IGUIButton>(makeJoystickButton(joystick_off_id,
 				recti(m_button_size,
 						m_screensize.Y - m_button_size * 4,
 						m_button_size * 4,
 						m_screensize.Y - m_button_size), true));
 	} else {
-		m_joystick_btn_off.grab(makeJoystickButton(joystick_off_id,
+		m_joystick_btn_off = grab_gui_element<IGUIButton>(makeJoystickButton(joystick_off_id,
 				recti(m_button_size,
 						m_screensize.Y - m_button_size * 3,
 						m_button_size * 3,
 						m_screensize.Y - m_button_size), true));
 	}
 
-	m_joystick_btn_bg.grab(makeJoystickButton(joystick_bg_id,
+	m_joystick_btn_bg = grab_gui_element<IGUIButton>(makeJoystickButton(joystick_bg_id,
 			recti(m_button_size,
 					m_screensize.Y - m_button_size * 4,
 					m_button_size * 4,
 					m_screensize.Y - m_button_size), false));
 
-	m_joystick_btn_center.grab(makeJoystickButton(joystick_center_id,
+	m_joystick_btn_center = grab_gui_element<IGUIButton>(makeJoystickButton(joystick_center_id,
 			recti(0, 0, m_button_size, m_button_size), false));
 
 	// init jump button
@@ -539,7 +539,7 @@ void TouchScreenGUI::addButton(touch_gui_button_id id, const std::string &image,
 
 	button_info &btn = m_buttons.emplace_back();
 	btn.keycode = id_to_keycode(id);
-	btn.gui_button.grab(btn_gui_button);
+	btn.gui_button = grab_gui_element<IGUIButton>(btn_gui_button);
 }
 
 IGUIButton *TouchScreenGUI::makeJoystickButton(touch_gui_button_id id,

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -65,7 +65,7 @@ static EKEY_CODE id_to_keycode(touch_gui_button_id id)
 		case jump_id:
 			key = "jump";
 			break;
-		case crunch_id:
+		case sneak_id:
 			key = "sneak";
 			break;
 		case zoom_id:
@@ -425,8 +425,8 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsr
 					m_screensize.Y),
 			L"x", false);
 
-	// init crunch button
-	initButton(crunch_id,
+	// init sneak button
+	initButton(sneak_id,
 			rect<s32>(m_screensize.X - 3.25f * m_button_size,
 					m_screensize.Y - m_button_size,
 					m_screensize.X - 1.75f * m_button_size,

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -75,9 +75,6 @@ typedef enum
 	joystick_off_id,
 	joystick_bg_id,
 	joystick_center_id,
-
-	// invalid value
-	touch_gui_button_invalid,
 } touch_gui_button_id;
 
 typedef enum
@@ -98,9 +95,6 @@ typedef enum
 // chance to detect them via l_get_player_control.
 // If you tap faster than this value, the simulated clicks are of course shorter.
 #define SIMULATED_CLICK_DURATION_MS 50
-
-extern const std::string button_image_names[];
-extern const std::string joystick_image_names[];
 
 struct button_info
 {
@@ -255,9 +249,6 @@ private:
 	irr_ptr<IGUIButton> m_joystick_btn_center;
 
 	std::vector<button_info> m_buttons;
-
-	// check if a button has changed
-	void handleChangedButton(const SEvent &event);
 
 	// initialize a button
 	void addButton(touch_gui_button_id id, const std::string &image,

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -111,11 +111,9 @@ struct button_info
 class AutoHideButtonBar
 {
 public:
-	AutoHideButtonBar(IrrlichtDevice *device, IEventReceiver *receiver);
-
-	void init(ISimpleTextureSource *tsrc, const std::string &starter_img, int button_id,
-			const v2s32 &UpperLeft, const v2s32 &LowerRight,
-			autohide_button_bar_dir dir, float timeout);
+	AutoHideButtonBar(IrrlichtDevice *device, ISimpleTextureSource *tsrc,
+			const std::string &starter_img, touch_gui_button_id starter_id,
+			core::recti starter_rect, autohide_button_bar_dir dir, float timeout);
 
 	~AutoHideButtonBar();
 
@@ -148,10 +146,10 @@ public:
 	bool operator!=(const AutoHideButtonBar &other);
 
 private:
+	irr::video::IVideoDriver *m_driver = nullptr;
+	IGUIEnvironment *m_guienv = nullptr;
+	IEventReceiver *m_receiver = nullptr;
 	ISimpleTextureSource *m_texturesource = nullptr;
-	irr::video::IVideoDriver *m_driver;
-	IGUIEnvironment *m_guienv;
-	IEventReceiver *m_receiver;
 	button_info m_starter;
 	std::vector<button_info> m_buttons;
 
@@ -165,20 +163,17 @@ private:
 	// button bar timeout
 	float m_timeout = 0.0f;
 	float m_timeout_value = 3.0f;
-	bool m_initialized = false;
 	autohide_button_bar_dir m_dir = AHBB_Dir_Right_Left;
 };
 
 class TouchScreenGUI
 {
 public:
-	TouchScreenGUI(IrrlichtDevice *device, IEventReceiver *receiver);
+	TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsrc);
 	~TouchScreenGUI();
 
 	void translateEvent(const SEvent &event);
 	void applyContextControls(const TouchInteractionMode &mode);
-
-	void init(ISimpleTextureSource *tsrc);
 
 	double getYawChange()
 	{
@@ -218,16 +213,15 @@ public:
 	std::optional<u16> getHotbarSelection();
 
 private:
-	bool m_initialized = false;
-	IrrlichtDevice *m_device;
-	IGUIEnvironment *m_guienv;
-	IEventReceiver *m_receiver;
-	ISimpleTextureSource *m_texturesource;
+	IrrlichtDevice *m_device = nullptr;
+	IGUIEnvironment *m_guienv = nullptr;
+	IEventReceiver *m_receiver = nullptr;
+	ISimpleTextureSource *m_texturesource = nullptr;
 	v2u32 m_screensize;
-	s32 button_size;
+	s32 m_button_size;
 	double m_touchscreen_threshold;
 	u16 m_long_tap_delay;
-	bool m_visible; // is the whole touch screen gui visible
+	bool m_visible = true; // is the whole touch screen gui visible
 
 	std::unordered_map<u16, rect<s32>> m_hotbar_rects;
 	std::optional<u16> m_hotbar_selection = std::nullopt;

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -153,7 +153,7 @@ private:
 	IGUIEnvironment *m_guienv;
 	IEventReceiver *m_receiver;
 	button_info m_starter;
-	std::vector<std::shared_ptr<button_info>> m_buttons;
+	std::vector<button_info> m_buttons;
 
 	v2s32 m_upper_left;
 	v2s32 m_lower_right;
@@ -259,9 +259,9 @@ private:
 	bool m_fixed_joystick = false;
 	bool m_joystick_triggers_aux1 = false;
 	bool m_draw_crosshair = false;
-	std::shared_ptr<button_info> m_joystick_btn_off = nullptr;
-	std::shared_ptr<button_info> m_joystick_btn_bg = nullptr;
-	std::shared_ptr<button_info> m_joystick_btn_center = nullptr;
+	button_info m_joystick_btn_off;
+	button_info m_joystick_btn_bg;
+	button_info m_joystick_btn_center;
 
 	button_info m_buttons[after_last_element_id];
 
@@ -280,7 +280,7 @@ private:
 			float repeat_delay = BUTTON_REPEAT_DELAY);
 
 	// initialize a joystick button
-	std::shared_ptr<button_info> initJoystickButton(touch_gui_button_id id,
+	button_info initJoystickButton(touch_gui_button_id id,
 			const rect<s32> &button_rect, int texture_id,
 			bool visible = true);
 

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -251,9 +251,9 @@ private:
 	bool m_fixed_joystick = false;
 	bool m_joystick_triggers_aux1 = false;
 	bool m_draw_crosshair = false;
-	button_info m_joystick_btn_off;
-	button_info m_joystick_btn_bg;
-	button_info m_joystick_btn_center;
+	irr_ptr<IGUIButton> m_joystick_btn_off;
+	irr_ptr<IGUIButton> m_joystick_btn_bg;
+	irr_ptr<IGUIButton> m_joystick_btn_center;
 
 	button_info m_buttons[after_last_element_id];
 
@@ -272,9 +272,8 @@ private:
 			float repeat_delay = BUTTON_REPEAT_DELAY);
 
 	// initialize a joystick button
-	button_info initJoystickButton(touch_gui_button_id id,
-			const rect<s32> &button_rect, int texture_id,
-			bool visible = true);
+	IGUIButton *initJoystickButton(touch_gui_button_id id,
+			const rect<s32> &button_rect, bool visible);
 
 	// handle a button event
 	void handleButtonEvent(touch_gui_button_id id, size_t pointer_id, bool action);

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "irr_ptr.h"
 #include "irrlichttypes.h"
 #include <IEventReceiver.h>
 #include <IGUIButton.h>
@@ -97,7 +98,7 @@ struct button_info
 	float repeat_delay;
 	EKEY_CODE keycode;
 	std::vector<size_t> ids;
-	IGUIButton *gui_button = nullptr;
+	irr_ptr<IGUIButton> gui_button = nullptr;
 	bool immediate_release;
 
 	enum {
@@ -114,8 +115,6 @@ public:
 	AutoHideButtonBar(IrrlichtDevice *device, ISimpleTextureSource *tsrc,
 			const std::string &starter_img, touch_gui_button_id starter_id,
 			core::recti starter_rect, autohide_button_bar_dir dir, float timeout);
-
-	~AutoHideButtonBar();
 
 	// add button to be shown
 	void addButton(touch_gui_button_id id, const wchar_t *caption,
@@ -170,7 +169,6 @@ class TouchScreenGUI
 {
 public:
 	TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsrc);
-	~TouchScreenGUI();
 
 	void translateEvent(const SEvent &event);
 	void applyContextControls(const TouchInteractionMode &mode);

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -49,7 +49,7 @@ enum class TapState
 typedef enum
 {
 	jump_id = 0,
-	crunch_id,
+	sneak_id,
 	zoom_id,
 	aux1_id,
 	after_last_element_id,

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -68,7 +68,7 @@ enum class TapState
 	LongTap,
 };
 
-typedef enum
+enum touch_gui_button_id
 {
 	jump_id = 0,
 	sneak_id,
@@ -97,15 +97,15 @@ typedef enum
 	joystick_off_id,
 	joystick_bg_id,
 	joystick_center_id,
-} touch_gui_button_id;
+};
 
-typedef enum
+enum autohide_button_bar_dir
 {
 	AHBB_Dir_Top_Bottom,
 	AHBB_Dir_Bottom_Top,
 	AHBB_Dir_Left_Right,
 	AHBB_Dir_Right_Left
-} autohide_button_bar_dir;
+};
 
 #define BUTTON_REPEAT_DELAY 0.5f
 #define BUTTON_REPEAT_INTERVAL 0.333f
@@ -159,7 +159,10 @@ public:
 	void show();
 	void hide();
 
-	bool operator!=(const AutoHideButtonBar &other);
+	bool operator==(const AutoHideButtonBar &other)
+			{ return m_starter.get() == other.m_starter.get(); }
+	bool operator!=(const AutoHideButtonBar &other)
+			{ return m_starter.get() != other.m_starter.get(); }
 
 private:
 	irr::video::IVideoDriver *m_driver = nullptr;

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -90,6 +90,7 @@ typedef enum
 
 #define BUTTON_REPEAT_DELAY 0.5f
 #define BUTTON_REPEAT_INTERVAL 0.333f
+#define BUTTONBAR_HIDE_DELAY 3.0f
 #define SETTINGS_BAR_Y_OFFSET 5
 #define RARE_CONTROLS_BAR_Y_OFFSET 5
 
@@ -123,21 +124,16 @@ class AutoHideButtonBar
 {
 public:
 	AutoHideButtonBar(IrrlichtDevice *device, ISimpleTextureSource *tsrc,
-			const std::string &starter_img, touch_gui_button_id starter_id,
-			core::recti starter_rect, autohide_button_bar_dir dir, float timeout);
+			touch_gui_button_id starter_id, const std::string &starter_image,
+			core::recti starter_rect, autohide_button_bar_dir dir);
 
-	// add button to be shown
-	void addButton(touch_gui_button_id id, const wchar_t *caption,
-			const std::string &btn_image);
-
-	// add toggle button to be shown
-	void addToggleButton(touch_gui_button_id id, const wchar_t *caption,
-			const std::string &btn_image_1, const std::string &btn_image_2);
+	void addButton(touch_gui_button_id id, const std::string &image);
+	void addToggleButton(touch_gui_button_id id,
+			const std::string &image_1, const std::string &image_2);
 
 	bool handlePress(size_t pointer_id, IGUIElement *element);
 	bool handleRelease(size_t pointer_id);
 
-	// step handler
 	void step(float dtime);
 
 	void activate();
@@ -154,19 +150,15 @@ private:
 	IGUIEnvironment *m_guienv = nullptr;
 	IEventReceiver *m_receiver = nullptr;
 	ISimpleTextureSource *m_texturesource = nullptr;
-	button_info m_starter;
+	irr_ptr<IGUIButton> m_starter;
 	std::vector<button_info> m_buttons;
 
 	v2s32 m_upper_left;
 	v2s32 m_lower_right;
 
-	// show button bar
 	bool m_active = false;
 	bool m_visible = true;
-
-	// button bar timeout
 	float m_timeout = 0.0f;
-	float m_timeout_value = 3.0f;
 	autohide_button_bar_dir m_dir = AHBB_Dir_Right_Left;
 
 	void updateVisibility();
@@ -268,13 +260,12 @@ private:
 	void handleChangedButton(const SEvent &event);
 
 	// initialize a button
-	void initButton(touch_gui_button_id id, const rect<s32> &button_rect,
-			const std::wstring &caption, bool immediate_release,
-			float repeat_delay = BUTTON_REPEAT_DELAY);
+	void addButton(touch_gui_button_id id, const std::string &image,
+			const rect<s32> &rect);
 
 	// initialize a joystick button
-	IGUIButton *initJoystickButton(touch_gui_button_id id,
-			const rect<s32> &button_rect, bool visible);
+	IGUIButton *makeJoystickButton(touch_gui_button_id id,
+			const rect<s32> &rect, bool visible);
 
 	// handle pressing hotbar items
 	bool isHotbarButton(const SEvent &event);

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -97,7 +97,7 @@ struct button_info
 	float repeat_counter;
 	float repeat_delay;
 	EKEY_CODE keycode;
-	std::vector<size_t> ids;
+	std::vector<size_t> pointer_ids;
 	irr_ptr<IGUIButton> gui_button = nullptr;
 	bool immediate_release;
 
@@ -260,8 +260,8 @@ private:
 	// gui button detection
 	touch_gui_button_id getButtonID(s32 x, s32 y);
 
-	// gui button by eventID
-	touch_gui_button_id getButtonID(size_t eventID);
+	// gui button by pointer ID
+	touch_gui_button_id getButtonID(size_t pointer_id);
 
 	// check if a button has changed
 	void handleChangedButton(const SEvent &event);
@@ -277,13 +277,13 @@ private:
 			bool visible = true);
 
 	// handle a button event
-	void handleButtonEvent(touch_gui_button_id bID, size_t eventID, bool action);
+	void handleButtonEvent(touch_gui_button_id id, size_t pointer_id, bool action);
 
 	// handle pressing hotbar items
 	bool isHotbarButton(const SEvent &event);
 
 	// handle release event
-	void handleReleaseEvent(size_t evt_id);
+	void handleReleaseEvent(size_t pointer_id);
 
 	// apply joystick status
 	void applyJoystickStatus();

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -119,7 +119,7 @@ class AutoHideButtonBar
 public:
 	AutoHideButtonBar(IrrlichtDevice *device, ISimpleTextureSource *tsrc,
 			touch_gui_button_id starter_id, const std::string &starter_image,
-			core::recti starter_rect, autohide_button_bar_dir dir);
+			recti starter_rect, autohide_button_bar_dir dir);
 
 	void addButton(touch_gui_button_id id, const std::string &image);
 	void addToggleButton(touch_gui_button_id id,
@@ -200,7 +200,7 @@ public:
 	void show();
 
 	void resetHotbarRects();
-	void registerHotbarRect(u16 index, const rect<s32> &rect);
+	void registerHotbarRect(u16 index, const recti &rect);
 	std::optional<u16> getHotbarSelection();
 
 private:
@@ -214,7 +214,7 @@ private:
 	u16 m_long_tap_delay;
 	bool m_visible = true; // is the whole touch screen gui visible
 
-	std::unordered_map<u16, rect<s32>> m_hotbar_rects;
+	std::unordered_map<u16, recti> m_hotbar_rects;
 	std::optional<u16> m_hotbar_selection = std::nullopt;
 
 	// value in degree
@@ -252,11 +252,11 @@ private:
 
 	// initialize a button
 	void addButton(touch_gui_button_id id, const std::string &image,
-			const rect<s32> &rect);
+			const recti &rect);
 
 	// initialize a joystick button
 	IGUIButton *makeJoystickButton(touch_gui_button_id id,
-			const rect<s32> &rect, bool visible);
+			const recti &rect, bool visible);
 
 	// handle pressing hotbar items
 	bool isHotbarButton(const SEvent &event);

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -145,6 +145,8 @@ public:
 	// unhide the button bar
 	void show();
 
+	bool operator!=(const AutoHideButtonBar &other);
+
 private:
 	ISimpleTextureSource *m_texturesource = nullptr;
 	irr::video::IVideoDriver *m_driver;
@@ -299,11 +301,7 @@ private:
 	// map to store the IDs and positions of currently pressed pointers
 	std::unordered_map<size_t, v2s32> m_pointer_pos;
 
-	// settings bar
-	AutoHideButtonBar m_settings_bar;
-
-	// rare controls bar
-	AutoHideButtonBar m_rare_controls_bar;
+	std::vector<AutoHideButtonBar> m_buttonbars;
 
 	v2s32 getPointerPos();
 	void emitMouseEvent(EMOUSE_INPUT_EVENT type);

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "irrlichttypes.h"
 #include <IEventReceiver.h>
-#include <IGUIButton.h>
+#include <IGUIImage.h>
 #include <IGUIEnvironment.h>
 #include <IrrlichtDevice.h>
 
@@ -123,7 +123,7 @@ struct button_info
 	float repeat_counter;
 	EKEY_CODE keycode;
 	std::vector<size_t> pointer_ids;
-	std::shared_ptr<IGUIButton> gui_button = nullptr;
+	std::shared_ptr<IGUIImage> gui_button = nullptr;
 
 	enum {
 		NOT_TOGGLEABLE,
@@ -166,7 +166,7 @@ private:
 	IGUIEnvironment *m_guienv = nullptr;
 	IEventReceiver *m_receiver = nullptr;
 	ISimpleTextureSource *m_texturesource = nullptr;
-	std::shared_ptr<IGUIButton> m_starter;
+	std::shared_ptr<IGUIImage> m_starter;
 	std::vector<button_info> m_buttons;
 
 	v2s32 m_upper_left;
@@ -266,9 +266,9 @@ private:
 	bool m_fixed_joystick = false;
 	bool m_joystick_triggers_aux1 = false;
 	bool m_draw_crosshair = false;
-	std::shared_ptr<IGUIButton> m_joystick_btn_off;
-	std::shared_ptr<IGUIButton> m_joystick_btn_bg;
-	std::shared_ptr<IGUIButton> m_joystick_btn_center;
+	std::shared_ptr<IGUIImage> m_joystick_btn_off;
+	std::shared_ptr<IGUIImage> m_joystick_btn_bg;
+	std::shared_ptr<IGUIImage> m_joystick_btn_center;
 
 	std::vector<button_info> m_buttons;
 
@@ -277,7 +277,7 @@ private:
 			const recti &rect);
 
 	// initialize a joystick button
-	IGUIButton *makeJoystickButton(touch_gui_button_id id,
+	IGUIImage *makeJoystickButton(touch_gui_button_id id,
 			const recti &rect, bool visible);
 
 	// handle pressing hotbar items


### PR DESCRIPTION
Some TouchScreenGUI refactoring is required to make customizable touchscreen controls (#14456) possible. This PR changes the following things from being hardcoded at compile time to being determined at runtime:

- which / how many buttons are on the main screen
- which / how many buttons are inside buttonbars
- which / how many buttonbars exist

Other things achieved by this PR:

- elimination of behavior differences between buttons on the main screen and in buttonbars
- less code duplication
- removal of separate "initialize" functions -> no "uninitialized" state causing crashes like #13522
- `std::shared_ptr` with a custom deleter (`irr_ptr` doesn't work with GUI elements) instead of manual refcounting
- overall ~200 lines of code less (as of 03/17/2024)

buttonbar = a row of buttons that can be expanded and collapsed

## To do

This PR is a Ready for Review.

Hiding whitespace changes is recommend.

## How to test

Beginner: Verify that the touch controls still work.

Intermediate: Verify that the dehardcoding was successful by changing some stuff in the TouchScreenGUI constructor.
Example: [diff.txt](https://github.com/minetest/minetest/files/14628603/diff.txt)
