### PR TITLE
update Lua BitOp's stdint.h check for MSVC

### DIFF
--- a/lib/bitop/bit.cpp
+++ b/lib/bitop/bit.cpp
@@ -37,8 +37,8 @@ extern "C" {
 #include "lauxlib.h"
 }
 
-#ifdef _MSC_VER
-/* MSVC is stuck in the last century and doesn't have C99's stdint.h. */
+#if defined(_MSC_VER) && (_MSC_VER < 1700)
+/* Old MSVC is stuck in the last century and doesn't have C99's stdint.h. */
 typedef __int32 int32_t;
 typedef unsigned __int32 uint32_t;
 typedef unsigned __int64 uint64_t;


### PR DESCRIPTION
This simply updates a check present in [Lua BitOp](https://bitop.luajit.org/) when compiling to realize that newer MSVC compilers include a more proper stdint.h
This is based on a commit from [LuaJIT](https://luajit.org/): https://github.com/LuaJIT/LuaJIT/commit/3ece3a3e3a448ecc54e317fd5743d1f4c19db28b

This PR is Ready for Review.