### PR TITLE
Add physics overrides for walk speed and Fast Mode (adoption)

### DIFF
--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -705,6 +705,7 @@ Methods:
             speed_climb = float,
             speed_crouch = float,
             speed_fast = float,
+            speed_walk = float,
             acceleration_default = float,
             acceleration_air = float,
             acceleration_fast = float,

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -702,8 +702,17 @@ Methods:
         ```lua
         {
             speed = float,
+            speed_climb = float,
+            speed_crouch = float,
+            speed_fast = float,
+            acceleration_default = float,
+            acceleration_air = float,
+            acceleration_fast = float,
             jump = float,
             gravity = float,
+            liquid_fluidity = float,
+            liquid_fluidity_smooth = float,
+            liquid_sink = float,
             sneak = boolean,
             sneak_glitch = boolean,
             new_move = boolean,
@@ -719,7 +728,8 @@ Methods:
 * `get_breath()`
     * returns the player's breath
 * `get_movement_acceleration()`
-    * returns acceleration of the player in different environments:
+    * returns acceleration of the player in different environments
+      (note: does not take physics overrides into account):
 
         ```lua
         {
@@ -730,7 +740,8 @@ Methods:
         ```
 
 * `get_movement_speed()`
-    * returns player's speed in different environments:
+    * returns player's speed in different environments
+      (note: does not take physics overrides into account):
 
         ```lua
         {
@@ -743,7 +754,8 @@ Methods:
         ```
 
 * `get_movement()`
-    * returns player's movement in different environments:
+    * returns player's movement in different environments
+      (note: does not take physics overrides into account):
 
         ```lua
         {

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8009,7 +8009,7 @@ child will follow movement and rotation of that bone.
     * Overrides the physics attributes of the player
     * `override_table` is a table with the following fields:
         * `speed`: multiplier to *all* movement speed (`speed_*`) and
-                   acceleration (`accelleration_*`) values (default: `1`)
+                   acceleration (`acceleration_*`) values (default: `1`)
         * `speed_walk`: multiplier to default walk speed value (default: `1`)
             * Note: The actual walk speed is the product of `speed` and `speed_walk`
         * `speed_climb`: multiplier to default climb speed value (default: `1`)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8008,9 +8008,10 @@ child will follow movement and rotation of that bone.
 * `set_physics_override(override_table)`
     * Overrides the physics attributes of the player
     * `override_table` is a table with the following fields:
-        * `speed`: multiplier to *all* movement speed and acceleration values (default: `1`)
-                   (see note below)
+        * `speed`: multiplier to *all* movement speed (`speed_*`) and
+                   acceleration (`accelleration_*`) values (default: `1`)
         * `speed_walk`: multiplier to default walk speed value (default: `1`)
+            * Note: The actual walk speed is the product of `speed` and `speed_walk`
         * `speed_climb`: multiplier to default climb speed value (default: `1`)
             * Note: The actual climb speed is the product of `speed` and `speed_climb`
         * `speed_crouch`: multiplier to default sneak speed value (default: `1`)
@@ -8045,10 +8046,6 @@ child will follow movement and rotation of that bone.
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behavior (default: `true`)
     * Note: All numeric fields above modify a corresponding `movement_*` setting.
-    * Note: `speed` and the other `speed_*` modifiers will be multiplied with
-      each other. Example: If `speed=2`, `speed_walk=3` and everything else is default,
-      walking speed factor is 6, while climbing, sneaking and Fast Mode speed has
-      a factor of 2.
     * For games, we recommend for simpler code to first modify the `movement_*`
       settings (e.g. via the game's `minetest.conf`) to set a global base value
       for all players and only use `set_physics_override` when you need to change

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8008,15 +8008,17 @@ child will follow movement and rotation of that bone.
 * `set_physics_override(override_table)`
     * Overrides the physics attributes of the player
     * `override_table` is a table with the following fields:
-        * `speed`: multiplier to default movement speed and acceleration values (default: `1`)
-        * `jump`: multiplier to default jump value (default: `1`)
-        * `gravity`: multiplier to default gravity value (default: `1`)
+        * `speed`: multiplier to *all* movement speed and acceleration values (default: `1`)
+                   (see note below)
+        * `speed_walk`: multiplier to default walk speed value (default: `1`)
         * `speed_climb`: multiplier to default climb speed value (default: `1`)
             * Note: The actual climb speed is the product of `speed` and `speed_climb`
         * `speed_crouch`: multiplier to default sneak speed value (default: `1`)
             * Note: The actual sneak speed is the product of `speed` and `speed_crouch`
         * `speed_fast`: multiplier to default speed value in Fast Mode (default: `1`)
             * Note: The actual fast speed is the product of `speed` and `speed_fast`
+        * `jump`: multiplier to default jump value (default: `1`)
+        * `gravity`: multiplier to default gravity value (default: `1`)
         * `liquid_fluidity`: multiplier to liquid movement resistance value
           (for nodes with `liquid_move_physics`); the higher this value, the lower the
           resistance to movement. At `math.huge`, the resistance is zero and you can
@@ -8043,6 +8045,10 @@ child will follow movement and rotation of that bone.
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behavior (default: `true`)
     * Note: All numeric fields above modify a corresponding `movement_*` setting.
+    * Note: `speed` and the other `speed_*` modifiers will be multiplied with
+      each other. Example: If `speed=2`, `speed_walk=3` and everything else is default,
+      walking speed factor is 6, while climbing, sneaking and Fast Mode speed has
+      a factor of 2.
     * For games, we recommend for simpler code to first modify the `movement_*`
       settings (e.g. via the game's `minetest.conf`) to set a global base value
       for all players and only use `set_physics_override` when you need to change

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8035,7 +8035,7 @@ child will follow movement and rotation of that bone.
           when jumping or falling (default: `1`)
             * Note: The actual acceleration is the product of `speed` and `acceleration_air`
         * `acceleration_fast`: multiplier to acceleration in Fast Mode (default: `1`)
-            * Note: The actual acceleration is the product of `speed_fast` and `acceleration_fast`
+            * Note: The actual acceleration is the product of `speed` and `acceleration_fast`
         * `sneak`: whether player can sneak (default: `true`)
         * `sneak_glitch`: whether player can use the new move code replications
           of the old sneak side-effects: sneak ladders and 2 node sneak jump

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8015,6 +8015,8 @@ child will follow movement and rotation of that bone.
             * Note: The actual climb speed is the product of `speed` and `speed_climb`
         * `speed_crouch`: multiplier to default sneak speed value (default: `1`)
             * Note: The actual sneak speed is the product of `speed` and `speed_crouch`
+        * `speed_fast`: multiplier to default speed value in Fast Mode (default: `1`)
+            * Note: The actual fast speed is the product of `speed` and `speed_fast`
         * `liquid_fluidity`: multiplier to liquid movement resistance value
           (for nodes with `liquid_move_physics`); the higher this value, the lower the
           resistance to movement. At `math.huge`, the resistance is zero and you can
@@ -8032,6 +8034,8 @@ child will follow movement and rotation of that bone.
         * `acceleration_air`: multiplier to acceleration
           when jumping or falling (default: `1`)
             * Note: The actual acceleration is the product of `speed` and `acceleration_air`
+        * `acceleration_fast`: multiplier to acceleration in Fast Mode (default: `1`)
+            * Note: The actual acceleration is the product of `speed_fast` and `acceleration_fast`
         * `sneak`: whether player can sneak (default: `true`)
         * `sneak_glitch`: whether player can use the new move code replications
           of the old sneak side-effects: sneak ladders and 2 node sneak jump

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1816,6 +1816,7 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_speed_walk = readF32(is);
 		// fallback for new overrides (since 5.8.0)
 		if (is.eof()) {
+			// since 5.8.0
 			override_speed_climb = 1.0f;
 			override_speed_crouch = 1.0f;
 			override_liquid_fluidity = 1.0f;
@@ -1823,6 +1824,7 @@ void GenericCAO::processMessage(const std::string &data)
 			override_liquid_sink = 1.0f;
 			override_acceleration_default = 1.0f;
 			override_acceleration_air = 1.0f;
+			// since 5.9.0
 			override_speed_fast = 1.0f;
 			override_acceleration_fast = 1.0f;
 			override_speed_walk = 1.0f;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1813,6 +1813,7 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_acceleration_air = readF32(is);
 		float override_speed_fast = readF32(is);
 		float override_acceleration_fast = readF32(is);
+		float override_speed_walk = readF32(is);
 		// fallback for new overrides (since 5.8.0)
 		if (is.eof()) {
 			override_speed_climb = 1.0f;
@@ -1824,6 +1825,7 @@ void GenericCAO::processMessage(const std::string &data)
 			override_acceleration_air = 1.0f;
 			override_speed_fast = 1.0f;
 			override_acceleration_fast = 1.0f;
+			override_speed_walk = 1.0f;
 		}
 
 		if (m_is_local_player) {
@@ -1843,6 +1845,7 @@ void GenericCAO::processMessage(const std::string &data)
 			phys.acceleration_air = override_acceleration_air;
 			phys.speed_fast = override_speed_fast;
 			phys.acceleration_fast = override_acceleration_fast;
+			phys.speed_walk = override_speed_walk;
 		}
 	} else if (cmd == AO_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1811,6 +1811,8 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_liquid_sink = readF32(is);
 		float override_acceleration_default = readF32(is);
 		float override_acceleration_air = readF32(is);
+		float override_speed_fast = readF32(is);
+		float override_acceleration_fast = readF32(is);
 		// fallback for new overrides (since 5.8.0)
 		if (is.eof()) {
 			override_speed_climb = 1.0f;
@@ -1820,6 +1822,8 @@ void GenericCAO::processMessage(const std::string &data)
 			override_liquid_sink = 1.0f;
 			override_acceleration_default = 1.0f;
 			override_acceleration_air = 1.0f;
+			override_speed_fast = 1.0f;
+			override_acceleration_fast = 1.0f;
 		}
 
 		if (m_is_local_player) {
@@ -1837,6 +1841,8 @@ void GenericCAO::processMessage(const std::string &data)
 			phys.liquid_sink = override_liquid_sink;
 			phys.acceleration_default = override_acceleration_default;
 			phys.acceleration_air = override_acceleration_air;
+			phys.speed_fast = override_speed_fast;
+			phys.acceleration_fast = override_acceleration_fast;
 		}
 	} else if (cmd == AO_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1804,6 +1804,7 @@ void GenericCAO::processMessage(const std::string &data)
 		bool sneak_glitch = !readU8(is);
 		bool new_move = !readU8(is);
 
+		// new overrides since 5.8.0
 		float override_speed_climb = readF32(is);
 		float override_speed_crouch = readF32(is);
 		float override_liquid_fluidity = readF32(is);
@@ -1811,12 +1812,7 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_liquid_sink = readF32(is);
 		float override_acceleration_default = readF32(is);
 		float override_acceleration_air = readF32(is);
-		float override_speed_fast = readF32(is);
-		float override_acceleration_fast = readF32(is);
-		float override_speed_walk = readF32(is);
-		// fallback for new overrides (since 5.8.0)
 		if (is.eof()) {
-			// since 5.8.0
 			override_speed_climb = 1.0f;
 			override_speed_crouch = 1.0f;
 			override_liquid_fluidity = 1.0f;
@@ -1824,7 +1820,13 @@ void GenericCAO::processMessage(const std::string &data)
 			override_liquid_sink = 1.0f;
 			override_acceleration_default = 1.0f;
 			override_acceleration_air = 1.0f;
-			// since 5.9.0
+		}
+
+		// new overrides since 5.9.0
+		float override_speed_fast = readF32(is);
+		float override_acceleration_fast = readF32(is);
+		float override_speed_walk = readF32(is);
+		if (is.eof()) {
 			override_speed_fast = 1.0f;
 			override_acceleration_fast = 1.0f;
 			override_speed_walk = 1.0f;

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -586,6 +586,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	// Whether superspeed mode is used or not
 	bool superspeed = false;
 
+	f32 speed_walk = movement_speed_walk * physics_override.speed_walk;
 	f32 speed_fast = movement_speed_fast * physics_override.speed_fast;
 
 	if (always_fly_fast && free_move && fast_move)
@@ -604,9 +605,9 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				if (fast_move)
 					speedV.Y = -speed_fast;
 				else
-					speedV.Y = -movement_speed_walk;
+					speedV.Y = -speed_walk;
 			} else if ((in_liquid || in_liquid_stable) && !m_disable_descend) {
-				speedV.Y = -movement_speed_walk;
+				speedV.Y = -speed_walk;
 				swimming_vertical = true;
 			} else if (is_climbing && !m_disable_descend) {
 				speedV.Y = -movement_speed_climb * physics_override.speed_climb;
@@ -636,12 +637,12 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				if (fast_move && (control.aux1 || always_fly_fast))
 					speedV.Y = -speed_fast;
 				else
-					speedV.Y = -movement_speed_walk;
+					speedV.Y = -speed_walk;
 			} else if ((in_liquid || in_liquid_stable) && !m_disable_descend) {
 				if (fast_climb)
 					speedV.Y = -speed_fast;
 				else
-					speedV.Y = -movement_speed_walk;
+					speedV.Y = -speed_walk;
 				swimming_vertical = true;
 			} else if (is_climbing && !m_disable_descend) {
 				if (fast_climb)
@@ -670,12 +671,12 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 					if (fast_move)
 						speedV.Y = speed_fast;
 					else
-						speedV.Y = movement_speed_walk;
+						speedV.Y = speed_walk;
 				} else {
 					if (fast_move && control.aux1)
 						speedV.Y = speed_fast;
 					else
-						speedV.Y = movement_speed_walk;
+						speedV.Y = speed_walk;
 				}
 			}
 		} else if (m_can_jump) {
@@ -694,7 +695,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			if (fast_climb)
 				speedV.Y = speed_fast;
 			else
-				speedV.Y = movement_speed_walk;
+				speedV.Y = speed_walk;
 			swimming_vertical = true;
 		} else if (is_climbing && !m_disable_jump && !control.sneak) {
 			if (fast_climb)
@@ -711,7 +712,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	else if (control.sneak && !free_move && !in_liquid && !in_liquid_stable)
 		speedH = speedH.normalize() * movement_speed_crouch * physics_override.speed_crouch;
 	else
-		speedH = speedH.normalize() * movement_speed_walk;
+		speedH = speedH.normalize() * speed_walk;
 
 	speedH *= control.movement_speed; /* Apply analog input */
 

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -600,7 +600,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			if (free_move) {
 				// In free movement mode, aux1 descends
 				if (fast_move)
-					speedV.Y = -movement_speed_fast;
+					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 			} else if ((in_liquid || in_liquid_stable) && !m_disable_descend) {
@@ -632,18 +632,18 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			if (free_move) {
 				// In free movement mode, sneak descends
 				if (fast_move && (control.aux1 || always_fly_fast))
-					speedV.Y = -movement_speed_fast;
+					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 			} else if ((in_liquid || in_liquid_stable) && !m_disable_descend) {
 				if (fast_climb)
-					speedV.Y = -movement_speed_fast;
+					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 				swimming_vertical = true;
 			} else if (is_climbing && !m_disable_descend) {
 				if (fast_climb)
-					speedV.Y = -movement_speed_fast;
+					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
 				else
 					speedV.Y = -movement_speed_climb * physics_override.speed_climb;
 			}
@@ -666,12 +666,12 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				// Don't fly up if sneak key is pressed
 				if (player_settings.aux1_descends || always_fly_fast) {
 					if (fast_move)
-						speedV.Y = movement_speed_fast;
+						speedV.Y = movement_speed_fast * physics_override.speed_fast;
 					else
 						speedV.Y = movement_speed_walk;
 				} else {
 					if (fast_move && control.aux1)
-						speedV.Y = movement_speed_fast;
+						speedV.Y = movement_speed_fast * physics_override.speed_fast;
 					else
 						speedV.Y = movement_speed_walk;
 				}
@@ -690,13 +690,13 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			}
 		} else if (in_liquid && !m_disable_jump && !control.sneak) {
 			if (fast_climb)
-				speedV.Y = movement_speed_fast;
+				speedV.Y = movement_speed_fast * physics_override.speed_fast;
 			else
 				speedV.Y = movement_speed_walk;
 			swimming_vertical = true;
 		} else if (is_climbing && !m_disable_jump && !control.sneak) {
 			if (fast_climb)
-				speedV.Y = movement_speed_fast;
+				speedV.Y = movement_speed_fast * physics_override.speed_fast;
 			else
 				speedV.Y = movement_speed_climb * physics_override.speed_climb;
 		}
@@ -705,7 +705,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	// The speed of the player (Y is ignored)
 	if (superspeed || (is_climbing && fast_climb) ||
 			((in_liquid || in_liquid_stable) && fast_climb))
-		speedH = speedH.normalize() * movement_speed_fast;
+		speedH = speedH.normalize() * movement_speed_fast * physics_override.speed_fast;
 	else if (control.sneak && !free_move && !in_liquid && !in_liquid_stable)
 		speedH = speedH.normalize() * movement_speed_crouch * physics_override.speed_crouch;
 	else
@@ -720,13 +720,13 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			(!free_move && m_can_jump && control.jump)) {
 		// Jumping and falling
 		if (superspeed || (fast_move && control.aux1))
-			incH = movement_acceleration_fast * BS * dtime;
+			incH = movement_acceleration_fast * physics_override.acceleration_fast * BS * dtime;
 		else
 			incH = movement_acceleration_air * physics_override.acceleration_air * BS * dtime;
 		incV = 0.0f; // No vertical acceleration in air
 	} else if (superspeed || (is_climbing && fast_climb) ||
 			((in_liquid || in_liquid_stable) && fast_climb)) {
-		incH = incV = movement_acceleration_fast * BS * dtime;
+		incH = incV = movement_acceleration_fast * physics_override.acceleration_fast * BS * dtime;
 	} else {
 		incH = incV = movement_acceleration_default * physics_override.acceleration_default * BS * dtime;
 	}

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -586,6 +586,8 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	// Whether superspeed mode is used or not
 	bool superspeed = false;
 
+	f32 speed_fast = movement_speed_fast * physics_override.speed_fast;
+
 	if (always_fly_fast && free_move && fast_move)
 		superspeed = true;
 
@@ -600,7 +602,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			if (free_move) {
 				// In free movement mode, aux1 descends
 				if (fast_move)
-					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
+					speedV.Y = -speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 			} else if ((in_liquid || in_liquid_stable) && !m_disable_descend) {
@@ -632,18 +634,18 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			if (free_move) {
 				// In free movement mode, sneak descends
 				if (fast_move && (control.aux1 || always_fly_fast))
-					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
+					speedV.Y = -speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 			} else if ((in_liquid || in_liquid_stable) && !m_disable_descend) {
 				if (fast_climb)
-					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
+					speedV.Y = -speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 				swimming_vertical = true;
 			} else if (is_climbing && !m_disable_descend) {
 				if (fast_climb)
-					speedV.Y = -movement_speed_fast * physics_override.speed_fast;
+					speedV.Y = -speed_fast;
 				else
 					speedV.Y = -movement_speed_climb * physics_override.speed_climb;
 			}
@@ -666,12 +668,12 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				// Don't fly up if sneak key is pressed
 				if (player_settings.aux1_descends || always_fly_fast) {
 					if (fast_move)
-						speedV.Y = movement_speed_fast * physics_override.speed_fast;
+						speedV.Y = speed_fast;
 					else
 						speedV.Y = movement_speed_walk;
 				} else {
 					if (fast_move && control.aux1)
-						speedV.Y = movement_speed_fast * physics_override.speed_fast;
+						speedV.Y = speed_fast;
 					else
 						speedV.Y = movement_speed_walk;
 				}
@@ -690,13 +692,13 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			}
 		} else if (in_liquid && !m_disable_jump && !control.sneak) {
 			if (fast_climb)
-				speedV.Y = movement_speed_fast * physics_override.speed_fast;
+				speedV.Y = speed_fast;
 			else
 				speedV.Y = movement_speed_walk;
 			swimming_vertical = true;
 		} else if (is_climbing && !m_disable_jump && !control.sneak) {
 			if (fast_climb)
-				speedV.Y = movement_speed_fast * physics_override.speed_fast;
+				speedV.Y = speed_fast;
 			else
 				speedV.Y = movement_speed_climb * physics_override.speed_climb;
 		}
@@ -705,7 +707,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	// The speed of the player (Y is ignored)
 	if (superspeed || (is_climbing && fast_climb) ||
 			((in_liquid || in_liquid_stable) && fast_climb))
-		speedH = speedH.normalize() * movement_speed_fast * physics_override.speed_fast;
+		speedH = speedH.normalize() * speed_fast;
 	else if (control.sneak && !free_move && !in_liquid && !in_liquid_stable)
 		speedH = speedH.normalize() * movement_speed_crouch * physics_override.speed_crouch;
 	else

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -586,8 +586,8 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	// Whether superspeed mode is used or not
 	bool superspeed = false;
 
-	f32 speed_walk = movement_speed_walk * physics_override.speed_walk;
-	f32 speed_fast = movement_speed_fast * physics_override.speed_fast;
+	const f32 speed_walk = movement_speed_walk * physics_override.speed_walk;
+	const f32 speed_fast = movement_speed_fast * physics_override.speed_fast;
 
 	if (always_fly_fast && free_move && fast_move)
 		superspeed = true;

--- a/src/player.h
+++ b/src/player.h
@@ -126,6 +126,8 @@ struct PlayerPhysicsOverride
 	float liquid_sink = 1.f;
 	float acceleration_default = 1.f;
 	float acceleration_air = 1.f;
+	float speed_fast = 1.f;
+	float acceleration_fast = 1.f;
 
 private:
 	auto tie() const {
@@ -133,7 +135,7 @@ private:
 		return std::tie(
 		speed, jump, gravity, sneak, sneak_glitch, new_move, speed_climb, speed_crouch,
 		liquid_fluidity, liquid_fluidity_smooth, liquid_sink, acceleration_default,
-		acceleration_air
+		acceleration_air, speed_fast, acceleration_fast
 		);
 	}
 

--- a/src/player.h
+++ b/src/player.h
@@ -128,6 +128,7 @@ struct PlayerPhysicsOverride
 	float acceleration_air = 1.f;
 	float speed_fast = 1.f;
 	float acceleration_fast = 1.f;
+	float speed_walk = 1.f;
 
 private:
 	auto tie() const {
@@ -135,7 +136,7 @@ private:
 		return std::tie(
 		speed, jump, gravity, sneak, sneak_glitch, new_move, speed_climb, speed_crouch,
 		liquid_fluidity, liquid_fluidity_smooth, liquid_sink, acceleration_default,
-		acceleration_air, speed_fast, acceleration_fast
+		acceleration_air, speed_fast, acceleration_fast, speed_walk
 		);
 	}
 

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -206,6 +206,7 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 
 	lua_pushnumber(L, phys.speed_walk);
 	lua_setfield(L, -2, "speed_walk");
+
 	return 1;
 }
 

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -198,6 +198,12 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushnumber(L, phys.acceleration_air);
 	lua_setfield(L, -2, "acceleration_air");
 
+	lua_pushnumber(L, phys.speed_fast);
+	lua_setfield(L, -2, "speed_fast");
+
+	lua_pushnumber(L, phys.acceleration_fast);
+	lua_setfield(L, -2, "acceleration_fast");
+
 	return 1;
 }
 

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -204,6 +204,8 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushnumber(L, phys.acceleration_fast);
 	lua_setfield(L, -2, "acceleration_fast");
 
+	lua_pushnumber(L, phys.speed_walk);
+	lua_setfield(L, -2, "speed_walk");
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1605,6 +1605,9 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 	getfloatfield(L, 2, "liquid_sink", phys.liquid_sink);
 	getfloatfield(L, 2, "acceleration_default", phys.acceleration_default);
 	getfloatfield(L, 2, "acceleration_air", phys.acceleration_air);
+	getfloatfield(L, 2, "speed_fast", phys.speed_fast);
+	getfloatfield(L, 2, "acceleration_fast", phys.acceleration_fast);
+	getfloatfield(L, 2, "speed_walk", phys.speed_walk);
 
 	if (phys != old)
 		playersao->m_physics_override_sent = false;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1652,6 +1652,8 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "speed_fast");
 	lua_pushnumber(L, phys.acceleration_fast);
 	lua_setfield(L, -2, "acceleration_fast");
+	lua_pushnumber(L, phys.speed_walk);
+	lua_setfield(L, -2, "speed_walk");
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1648,6 +1648,10 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "acceleration_default");
 	lua_pushnumber(L, phys.acceleration_air);
 	lua_setfield(L, -2, "acceleration_air");
+	lua_pushnumber(L, phys.speed_fast);
+	lua_setfield(L, -2, "speed_fast");
+	lua_pushnumber(L, phys.acceleration_fast);
+	lua_setfield(L, -2, "acceleration_fast");
 	return 1;
 }
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -338,6 +338,7 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeF32(os, phys.acceleration_air);
 	writeF32(os, phys.speed_fast);
 	writeF32(os, phys.acceleration_fast);
+	writeF32(os, phys.speed_walk);
 	return os.str();
 }
 
@@ -651,14 +652,15 @@ bool PlayerSAO::checkMovementCheat()
 	float player_max_walk = 0; // horizontal movement
 	float player_max_jump = 0; // vertical upwards movement
 
-	float speed_walk = m_player->movement_speed_walk * m_player->physics_override.speed;
+	float speed_walk = m_player->movement_speed_walk * m_player->physics_override.speed_walk;
 	float speed_fast = m_player->movement_speed_fast * m_player->physics_override.speed_fast;
 	float speed_crouch = m_player->movement_speed_crouch * m_player->physics_override.speed_crouch;
-	float speed_climb  = m_player->movement_speed_climb  * m_player->physics_override.speed_climb;
-	speed_walk   *= m_player->physics_override.speed;
-	speed_fast   *= m_player->physics_override.speed;
+	float speed_climb = m_player->movement_speed_climb * m_player->physics_override.speed_climb;
+
+	speed_walk *= m_player->physics_override.speed;
+	speed_fast *= m_player->physics_override.speed;
 	speed_crouch *= m_player->physics_override.speed;
-	speed_climb  *= m_player->physics_override.speed;
+	speed_climb *= m_player->physics_override.speed;
 
 	// Get permissible max. speed
 	if (m_privs.count("fast") != 0) {

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -336,6 +336,8 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeF32(os, phys.liquid_sink);
 	writeF32(os, phys.acceleration_default);
 	writeF32(os, phys.acceleration_air);
+	writeF32(os, phys.speed_fast);
+	writeF32(os, phys.acceleration_fast);
 	return os.str();
 }
 
@@ -649,8 +651,8 @@ bool PlayerSAO::checkMovementCheat()
 	float player_max_walk = 0; // horizontal movement
 	float player_max_jump = 0; // vertical upwards movement
 
-	float speed_walk   = m_player->movement_speed_walk;
-	float speed_fast   = m_player->movement_speed_fast;
+	float speed_walk = m_player->movement_speed_walk * m_player->physics_override.speed;
+	float speed_fast = m_player->movement_speed_fast * m_player->physics_override.speed_fast;
 	float speed_crouch = m_player->movement_speed_crouch * m_player->physics_override.speed_crouch;
 	float speed_climb  = m_player->movement_speed_climb  * m_player->physics_override.speed_climb;
 	speed_walk   *= m_player->physics_override.speed;


### PR DESCRIPTION
This PR is an adoption of #13815 by Wuzzy2. I rebased and fixed a bug in the backwards compatibility code.

This PR adds the following new fields to `set_physics_override`:

* `speed_walk`: Normal walking speed
* `speed_fast`: Speed in Fast Mode
* `acceleration_fast`: Acceleration in Fast Mode

With this PR, every player physics value (`movement_` settings) will be overridable by Lua.

## To do

This PR is a Ready for Review.

## How to test

Quoting Wuzzy2:

>  I recommend you to use `luacmd` and `orienteering` mods. Get yourself a speedometer with `/giveme orienteering:speedometer` and put it in the hotbar. This displays your speed at the top which is very useful for testing.
> 
> Now, in DevTest, call `me:set_physics_override(table_of_physics_you_want_to_test)`. Test the normal walk speed and Fast Mode. Also test sneaking and climbing if you want to, just to make sure those still work as expected.
Then check if it does what you expect to / what the documentation promises.

Also test backwards compatibility with all different client/server combinations: this PR / 5.8.0 / pre-5.8.0 on the client + this PR / 5.8.0 / pre-5.8.0 on the server