### PR TITLE
Different algorithm for imageCleanTransparent

### DIFF
--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -316,7 +316,7 @@ static void imageCleanTransparentNew(video::IImage *src, u32 threshold)
 	// If a pixel's alpha is < threshold, we sample the smaller level with bilinear
 	// interpolation.
 
-	for (ssize_t lvl = levels.size() - 1; lvl >= 0; --lvl) {
+	for (ssize_t lvl = levels.size() - 2; lvl >= 0; --lvl) {
 		u32 *const data_large = levels[lvl].first;
 		u32 *const data_small = levels[lvl+1].first;
 		const core::dimension2d<u32> dim_large = levels[lvl].second;
@@ -355,12 +355,6 @@ static void imageCleanTransparentNew(video::IImage *src, u32 threshold)
 				data_large[idx_large] = col.color;
 			}
 		};
-		//~ for (auto [idx_small, idx_large] : {
-				//~ std::pair{0, 0},
-				//~ {dim_small.Width - 1, dim_large.Width - 1},
-				//~ {dim_small.Width * (dim_small.Height - 1), dim_large.Width * (dim_large.Height - 1)},
-				//~ {dim_small.Width * dim_small.Height - 1, dim_large.Width * dim_large.Height - 1},
-			//~ }) {}
 		handle_pixel_from_1(0, 0); // (0,0)
 		if (even_width)
 			handle_pixel_from_1(dim_large.Width - 1, dim_small.Width - 1); // (b,0)
@@ -396,7 +390,7 @@ static void imageCleanTransparentNew(video::IImage *src, u32 threshold)
 			}
 		}
 		// bottom row
-		{
+		if (even_height) {
 			u32 idx_large = dim_large.Width * (dim_large.Height - 1) + 1; // (1,b)
 			u32 idx_small = dim_small.Width * (dim_small.Height - 1); // (0,b)
 			for (u32 x_small = 0; x_small + 1 < dim_small.Width; ++x_small) {
@@ -424,7 +418,7 @@ static void imageCleanTransparentNew(video::IImage *src, u32 threshold)
 			}
 		}
 		// right column
-		{
+		if (even_width) {
 			u32 idx_large = dim_large.Width * 2 - 1; // (b,1)
 			u32 idx_small = dim_small.Width - 1; // (b,0)
 			for (u32 y_small = 0; y_small + 1 < dim_small.Height; ++y_small) {
@@ -483,7 +477,10 @@ static void imageCleanTransparentNew(video::IImage *src, u32 threshold)
 							idx_small + 1,
 							idx_small
 						);
+					idx_small += 1;
+					idx_large += 1;
 				}
+				idx_large += dim_large.Width;
 			}
 		}
 	}

--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -320,7 +320,7 @@ static void imageCleanTransparentNew(video::IImage *src, u32 threshold)
 	// If a pixel's alpha is < threshold, we sample the smaller level with bilinear
 	// interpolation.
 
-	for (ssize_t lvl = levels.size() - 2; lvl >= 0; --lvl) {
+	for (int lvl = levels.size() - 2; lvl >= 0; --lvl) {
 		u32 *const data_large = levels[lvl].first;
 		u32 *const data_small = levels[lvl+1].first;
 		const core::dimension2d<u32> dim_large = levels[lvl].second;

--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -214,23 +214,41 @@ static void imageCleanTransparentNew(video::IImage *src, u32 threshold)
 	// Step 1: Scale down
 
 	auto mix4cols = [](std::array<video::SColor, 4> colors) -> video::SColor {
-		u32 r = 0, g = 0, b = 0, a = 0;
+		u32 sr = 0, sg = 0, sb = 0, sa = 0;
 		auto add_color = [&](video::SColor c) {
 			u32 alph = c.getAlpha();
-			r += alph * c.getRed();
-			g += alph * c.getGreen();
-			b += alph * c.getBlue();
-			a += alph;
+			sr += alph * c.getRed();
+			sg += alph * c.getGreen();
+			sb += alph * c.getBlue();
+			sa += alph;
 		};
 		for (auto c : colors)
 			add_color(c);
-		if (a == 0)
+		if (sa == 0)
 			return 0;
-		r /= a;
-		g /= a;
-		b /= a;
-		a = (a + 1) / 4; // +1 for better rounding // TODO: maybe always round up, to make sure colors are preserved? (+3)
-		return video::SColor(a, r, g, b);
+		//~ if (sa == 255 * 4) { // common case
+			//~ sr = 0, sg = 0, sb = 0;
+			//~ for (auto c : colors) {
+				//~ sr += c.getRed();
+				//~ sg += c.getGreen();
+				//~ sb += c.getBlue();
+			//~ }
+			//~ sr /= 4;
+			//~ sg /= 4;
+			//~ sb /= 4;
+			//~ return video::SColor(255, sr, sg, sb);
+		//~ }
+		//~ u64 d = (1 << 16) / sa;
+		//~ sr = (sr * d) >> 16;
+		//~ sg = (sg * d) >> 16;
+		//~ sb = (sb * d) >> 16;
+		//~ sa = ((sa + 1) * d) >> 16;
+
+		sr /= sa;
+		sg /= sa;
+		sb /= sa;
+		sa = (sa + 1) / 4; // +1 for better rounding // TODO: maybe always round up, to make sure colors are preserved? (+3)
+		return video::SColor(sa, sr, sg, sb);
 	};
 
 	for (size_t lvl = 0; lvl + 1 < levels.size(); ++lvl) {

--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cassert>
 #include <vector>
 #include <algorithm>
+#include <array>
 
 // Simple 2D bitmap class with just the functionality needed here
 class Bitmap {


### PR DESCRIPTION
- Goal of the PR: Make imageCleanTransparent faster.
- How does the PR work: First scale the image down, to all levels, up to 1x1. Then go the other direction, and bilinear sample the lower-resolution texture where the higher-resolution texture has alpha below threshold.
- See #14322.

### Results

Performance is noticeably better. But it's not optimal.

Left is master, right is PR:
![left_master_right_PR](https://github.com/minetest/minetest/assets/7613443/13ed252f-5897-4b28-93f0-35c08e0e5988)

## To do

This PR is a Work in Progress.

- [ ] Make threshold always 0.
- [ ] Convert images to argb8, to remove old code.
- [ ] Clean up code.

## How to test

* Test mod: https://codeberg.org/Desour/test_tmp/src/branch/imagecleantransparent_test (This branch, not master.)
* See #14322 for performance testing.