### PR TITLE
Deprecate writing to mod directories

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -505,6 +505,28 @@ bool ScriptApiSecurity::safeLoadFile(lua_State *L, const char *path, const char 
 }
 
 
+bool checkModNameWhitelisted(const std::string &mod_name, const std::string &setting)
+{
+	assert(str_starts_with(setting, "secure."));
+
+	if (mod_name.empty())
+		return false;
+
+	std::string value = g_settings->get(setting);
+	value.erase(std::remove(value.begin(), value.end(), ' '), value.end());
+	auto mod_list = str_split(value, ',');
+
+	return CONTAINS(mod_list, mod_name);
+}
+
+
+bool ScriptApiSecurity::checkWhitelisted(lua_State *L, const std::string &setting)
+{
+	std::string mod_name = ScriptApiBase::getCurrentModName(L);
+	return checkModNameWhitelisted(mod_name, setting);
+}
+
+
 bool ScriptApiSecurity::checkPath(lua_State *L, const char *path,
 		bool write_required, bool *write_allowed)
 {
@@ -555,7 +577,6 @@ bool ScriptApiSecurity::checkPath(lua_State *L, const char *path,
 		return false;
 
 	// Get mod name
-	// FIXME: insecure = problem here?
 	std::string mod_name = ScriptApiBase::getCurrentModNameInsecure(L);
 	if (!mod_name.empty()) {
 		// Builtin can access anything
@@ -571,7 +592,29 @@ bool ScriptApiSecurity::checkPath(lua_State *L, const char *path,
 			if (mod) {
 				str = fs::AbsolutePath(mod->path);
 				if (!str.empty() && fs::PathStartsWith(abs_path, str)) {
-					if (write_allowed) *write_allowed = true;
+					bool is_trusted = checkModNameWhitelisted(mod_name, "secure.trusted_mods") ||
+							checkModNameWhitelisted(mod_name, "secure.http_mods");
+					std::string filename = lowercase(fs::GetFilenameFromPath(abs_path.c_str()));
+					bool is_dangerous_file = filename == "mod.conf" ||
+							filename == "modpack.conf" ||
+							filename == "modpack.txt";
+					if (write_required) {
+						if (is_trusted) {
+							throw LuaError(
+									"Unable to write to a trusted or http mod's directory. "
+									"Use minetest.get_mod_data_path() or minetest.get_worldpath() instead.");
+						} else if (is_dangerous_file) {
+							throw LuaError(
+									"Unable to write to special file for security reasons");
+						} else {
+							const char *message =
+									"Writing to mod directories is deprecated, as any changes "
+									"will be overwritten when updating content. "
+									"Use minetest.get_mod_data_path() or minetest.get_worldpath() instead.";
+							log_deprecated(L, message, 1);
+						}
+					}
+					if (write_allowed) *write_allowed = !is_trusted && !is_dangerous_file;
 					return true;
 				}
 			}
@@ -621,21 +664,6 @@ bool ScriptApiSecurity::checkPath(lua_State *L, const char *path,
 
 	// Default to disallowing
 	return false;
-}
-
-bool ScriptApiSecurity::checkWhitelisted(lua_State *L, const std::string &setting)
-{
-	assert(str_starts_with(setting, "secure."));
-
-	std::string mod_name = ScriptApiBase::getCurrentModName(L);
-	if (mod_name.empty())
-		return false;
-
-	std::string value = g_settings->get(setting);
-	value.erase(std::remove(value.begin(), value.end(), ' '), value.end());
-	auto mod_list = str_split(value, ',');
-
-	return CONTAINS(mod_list, mod_name);
 }
 
 

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -49,12 +49,12 @@ public:
 	static bool safeLoadString(lua_State *L, const std::string &code, const char *chunk_name);
 	// Loads a file as Lua code safely (doesn't allow bytecode).
 	static bool safeLoadFile(lua_State *L, const char *path, const char *display_name = NULL);
-	// Checks if mods are allowed to read (and optionally write) to the path
-	static bool checkPath(lua_State *L, const char *path, bool write_required,
-			bool *write_allowed=NULL);
 	// Check if mod is whitelisted in the given setting
 	// This additionally checks that the mod's main file scope is executing.
 	static bool checkWhitelisted(lua_State *L, const std::string &setting);
+	// Checks if mods are allowed to read (and optionally write) to the path
+	static bool checkPath(lua_State *L, const char *path, bool write_required,
+			bool *write_allowed=NULL);
 
 private:
 	int getThread(lua_State *L);


### PR DESCRIPTION
Requires #12315, but this can be merged first

Writable mod directories have numerous issues:

- It doesn't work when the mod/game is installed to a readonly file system, like system share
- Changes are lost when the mod/game is updated
- It's not secure

Instead, modders should use `minetest.get_worldpath()` or `minetest.get_mod_data_path()` added by #12315.

This patch:

1. Prevents writing to trusted mods (unless it uses an insecure env)
2. Deprecates writing to untrusted mods
3. Prevents writing to mod.conf, modpack.conf and modpack.txt files

When preventing, I throw an error to be more specific than the default "Blocked attempted write to" message. I'm open to changing this though as I feel like it may break the expectations of this function.

(3) breaks the usecase of updating mod.conf to depend on other mods. Modders could write to depends.txt instead, but this incurs a deprecation warning. Any suggestions for solutions to this?

## To do

This PR is a Ready for Review.

## How to test

```lua
local modname = minetest.get_current_modname()

local function save()
    -- This should work
    local file = io.open(minetest.get_mod_data_path() .. "/file.txt" , "w")
    file:write("Hello world in common dir!\n")
    file:close()

    -- This should emit a warning, or crash if this mod is trusted
    file = io.open(minetest.get_modpath(modname) .. "/file.txt", "w")
    file:write("Hello world in mod!\n")
    file:close()

    -- This should crash for all mods
    file = io.open(minetest.get_modpath(modname) .. "/mod.conf", "w")
    file:write("name = blah\n")
    file:close()
end

save()
```

