### PR TITLE
[no squash] Touch things

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -153,15 +153,20 @@ invert_hotbar_mouse_wheel (Hotbar: Invert mouse wheel direction) bool false
 #    Requires: !android
 enable_touch (Enable touchscreen) bool true
 
-#    The length in pixels it takes for touchscreen interaction to start.
-#
-#    Requires: touchscreen_gui
-touchscreen_threshold (Touchscreen threshold) int 20 0 100
-
 #    Touchscreen sensitivity multiplier.
 #
 #    Requires: touchscreen_gui
 touchscreen_sensitivity (Touchscreen sensitivity) float 0.2 0.001 10.0
+
+#    The length in pixels after which a touch interaction is considered movement.
+#
+#    Requires: touchscreen_gui
+touchscreen_threshold (Movement threshold) int 20 0 100
+
+#    The delay in milliseconds after which a touch interaction is considered a long tap.
+#
+#    Requires: touchscreen_gui
+touch_long_tap_delay (Threshold for long taps) int 400 100 1000
 
 #    Use crosshair to select object instead of whole screen.
 #    If enabled, a crosshair will be shown and will be used for selecting object.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -181,6 +181,19 @@ fixed_virtual_joystick (Fixed virtual joystick) bool false
 #    Requires: touchscreen_gui
 virtual_joystick_triggers_aux1 (Virtual joystick triggers Aux1 button) bool false
 
+#    The gesture for for punching players/entities.
+#    This can be overridden by games and mods.
+#
+#    * short_tap
+#      Easy to use and well-known from other games that shall not be named.
+#
+#    * long_tap
+#      Known from the classic Minetest mobile controls.
+#      Combat is more or less impossible.
+#
+#    Requires: touchscreen_gui
+touch_punch_gesture (Punch gesture) enum short_tap short_tap,long_tap
+
 
 [Graphics and Audio]
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9095,20 +9095,20 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
     -- Otherwise should be name of node which the client immediately places
     -- upon digging. Server will always update with actual result shortly.
 
-    touch_interaction = {
-        -- Only affects touchscreen clients.
-        -- Defines the meaning of short and long taps with the item in hand.
-        -- The fields in this table can be set to the following values:
-        -- * "user"                 (meaning depends on client-side settings)
-        -- * "long_dig_short_place" (long tap  = dig, short tap = place)
-        -- * "short_dig_long_place" (short tap = dig, long tap  = place)
-        -- The field to be used is selected according to the current
-        -- `pointed_thing`.
-
-        pointed_nothing = "user",
-        pointed_node    = "user",
-        pointed_object  = "user",
+    touch_interaction = <TouchInteractionMode> OR {
+        pointed_nothing = <TouchInteractionMode>,
+        pointed_node    = <TouchInteractionMode>,
+        pointed_object  = <TouchInteractionMode>,
     },
+      -- Only affects touchscreen clients.
+      -- Defines the meaning of short and long taps with the item in hand.
+      -- If specified as a table, the field to be used is selected according to
+      -- the current `pointed_thing`.
+      -- There are three possible TouchInteractionMode values:
+      -- * "user"                 (meaning depends on client-side settings)
+      -- * "long_dig_short_place" (long tap  = dig, short tap = place)
+      -- * "short_dig_long_place" (short tap = dig, long tap  = place)
+      -- The default value is "user".
 
     sound = {
         -- Definition of item sounds to be played at various events.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9098,15 +9098,16 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
     touch_interaction = {
         -- Only affects touchscreen clients.
         -- Defines the meaning of short and long taps with the item in hand.
-        -- The fields in this table have two valid values:
+        -- The fields in this table can be set to the following values:
+        -- * "user"                 (meaning depends on client-side settings)
         -- * "long_dig_short_place" (long tap  = dig, short tap = place)
         -- * "short_dig_long_place" (short tap = dig, long tap  = place)
         -- The field to be used is selected according to the current
         -- `pointed_thing`.
 
-        pointed_nothing = "long_dig_short_place",
-        pointed_node    = "long_dig_short_place",
-        pointed_object  = "short_dig_long_place",
+        pointed_nothing = "user",
+        pointed_node    = "user",
+        pointed_object  = "user",
     },
 
     sound = {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3279,8 +3279,10 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	if (pointed != runData.pointed_old)
 		infostream << "Pointing at " << pointed.dump() << std::endl;
 
-	if (g_touchscreengui)
-		g_touchscreengui->applyContextControls(selected_def.touch_interaction.getMode(pointed));
+	if (g_touchscreengui) {
+		auto mode = selected_def.touch_interaction.getMode(pointed.type);
+		g_touchscreengui->applyContextControls(mode);
+	}
 
 	// Note that updating the selection mesh every frame is not particularly efficient,
 	// but the halo rendering code is already inefficient so there's no point in optimizing it here

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -490,6 +490,7 @@ void set_default_settings()
 	settings->setDefault("touch_use_crosshair", "false");
 	settings->setDefault("fixed_virtual_joystick", "false");
 	settings->setDefault("virtual_joystick_triggers_aux1", "false");
+	settings->setDefault("touch_punch_gesture", "short_tap");
 #ifdef ENABLE_TOUCH
 	settings->setDefault("clickable_chat_weblinks", "false");
 #else

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -485,8 +485,9 @@ void set_default_settings()
 	settings->setDefault("keymap_sneak", "KEY_SHIFT");
 #endif
 
-	settings->setDefault("touchscreen_threshold", "20");
 	settings->setDefault("touchscreen_sensitivity", "0.2");
+	settings->setDefault("touchscreen_threshold", "20");
+	settings->setDefault("touch_long_tap_delay", "400");
 	settings->setDefault("touch_use_crosshair", "false");
 	settings->setDefault("fixed_virtual_joystick", "false");
 	settings->setDefault("virtual_joystick_triggers_aux1", "false");

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -414,6 +414,7 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, IEventReceiver *receiver)
 	}
 
 	m_touchscreen_threshold = g_settings->getU16("touchscreen_threshold");
+	m_long_tap_delay = g_settings->getU16("touch_long_tap_delay");
 	m_fixed_joystick = g_settings->getBool("fixed_virtual_joystick");
 	m_joystick_triggers_aux1 = g_settings->getBool("virtual_joystick_triggers_aux1");
 	m_screensize = m_device->getVideoDriver()->getScreenSize();
@@ -999,7 +1000,7 @@ void TouchScreenGUI::step(float dtime)
 	if (m_has_move_id && !m_move_has_really_moved && m_tap_state == TapState::None) {
 		u64 delta = porting::getDeltaMs(m_move_downtime, porting::getTimeMs());
 
-		if (delta > MIN_DIG_TIME_MS) {
+		if (delta > m_long_tap_delay) {
 			m_tap_state = TapState::LongTap;
 		}
 	}

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -1105,10 +1105,10 @@ void TouchScreenGUI::applyContextControls(const TouchInteractionMode &mode)
 	// Since the pointed thing has already been determined when this function
 	// is called, we cannot use this function to update the shootline.
 
+	sanity_check(mode != TouchInteractionMode_USER);
+	u64 now = porting::getTimeMs();
 	bool target_dig_pressed = false;
 	bool target_place_pressed = false;
-
-	u64 now = porting::getTimeMs();
 
 	// If the meanings of short and long taps have been swapped, abort any ongoing
 	// short taps because they would do something else than the player expected.

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -79,7 +79,6 @@ typedef enum
 	AHBB_Dir_Right_Left
 } autohide_button_bar_dir;
 
-#define MIN_DIG_TIME_MS 500
 #define BUTTON_REPEAT_DELAY 0.2f
 #define SETTINGS_BAR_Y_OFFSET 5
 #define RARE_CONTROLS_BAR_Y_OFFSET 5
@@ -225,6 +224,7 @@ private:
 	v2u32 m_screensize;
 	s32 button_size;
 	double m_touchscreen_threshold;
+	u16 m_long_tap_delay;
 	bool m_visible; // is the whole touch screen gui visible
 
 	std::unordered_map<u16, rect<s32>> m_hotbar_rects;

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -40,24 +40,37 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 TouchInteraction::TouchInteraction()
 {
-	pointed_nothing = LONG_DIG_SHORT_PLACE;
-	pointed_node    = LONG_DIG_SHORT_PLACE;
-	// Map punching to single tap by default.
-	pointed_object  = SHORT_DIG_LONG_PLACE;
+	pointed_nothing = TouchInteractionMode_USER;
+	pointed_node    = TouchInteractionMode_USER;
+	pointed_object  = TouchInteractionMode_USER;
 }
 
-TouchInteractionMode TouchInteraction::getMode(const PointedThing &pointed) const
+TouchInteractionMode TouchInteraction::getMode(PointedThingType pointed_type) const
 {
-	switch (pointed.type) {
+	TouchInteractionMode result;
+	switch (pointed_type) {
 	case POINTEDTHING_NOTHING:
-		return pointed_nothing;
+		result = pointed_nothing;
+		break;
 	case POINTEDTHING_NODE:
-		return pointed_node;
+		result = pointed_node;
+		break;
 	case POINTEDTHING_OBJECT:
-		return pointed_object;
+		result = pointed_object;
+		break;
 	default:
 		FATAL_ERROR("Invalid PointedThingType given to TouchInteraction::getMode");
 	}
+
+	if (result == TouchInteractionMode_USER) {
+		if (pointed_type == POINTEDTHING_OBJECT)
+			result = g_settings->get("touch_punch_gesture") == "long_tap" ?
+					LONG_DIG_SHORT_PLACE : SHORT_DIG_LONG_PLACE;
+		else
+			result = LONG_DIG_SHORT_PLACE;
+	}
+
+	return result;
 }
 
 void TouchInteraction::serialize(std::ostream &os) const

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -30,10 +30,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "texture_override.h" // TextureOverride
 #include "tool.h"
 #include "util/pointabilities.h"
+#include "util/pointedthing.h"
+
 class IGameDef;
 class Client;
 struct ToolCapabilities;
-struct PointedThing;
 #ifndef SERVER
 #include "client/texturesource.h"
 struct ItemMesh;
@@ -57,6 +58,7 @@ enum TouchInteractionMode : u8
 {
 	LONG_DIG_SHORT_PLACE,
 	SHORT_DIG_LONG_PLACE,
+	TouchInteractionMode_USER, // Meaning depends on client-side settings
 	TouchInteractionMode_END, // Dummy for validity check
 };
 
@@ -67,7 +69,9 @@ struct TouchInteraction
 	TouchInteractionMode pointed_object;
 
 	TouchInteraction();
-	TouchInteractionMode getMode(const PointedThing &pointed) const;
+	// Returns the right mode for the pointed thing and resolves any occurrence
+	// of TouchInteractionMode_USER into an actual mode.
+	TouchInteractionMode getMode(PointedThingType pointed_type) const;
 	void serialize(std::ostream &os) const;
 	void deSerialize(std::istream &is);
 };

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -156,17 +156,24 @@ void read_item_definition(lua_State* L, int index,
 
 	getboolfield(L, index, "wallmounted_rotate_vertical", def.wallmounted_rotate_vertical);
 
+	TouchInteraction &inter = def.touch_interaction;
 	lua_getfield(L, index, "touch_interaction");
-	if (!lua_isnil(L, -1)) {
-		luaL_checktype(L, -1, LUA_TTABLE);
-
-		TouchInteraction &inter = def.touch_interaction;
+	if (lua_istable(L, -1)) {
 		inter.pointed_nothing = (TouchInteractionMode)getenumfield(L, -1, "pointed_nothing",
 				es_TouchInteractionMode, inter.pointed_nothing);
 		inter.pointed_node = (TouchInteractionMode)getenumfield(L, -1, "pointed_node",
 				es_TouchInteractionMode, inter.pointed_node);
 		inter.pointed_object = (TouchInteractionMode)getenumfield(L, -1, "pointed_object",
 				es_TouchInteractionMode, inter.pointed_object);
+	} else if (lua_isstring(L, -1)) {
+		int value;
+		if (string_to_enum(es_TouchInteractionMode, value, lua_tostring(L, -1))) {
+			inter.pointed_nothing = (TouchInteractionMode)value;
+			inter.pointed_node    = (TouchInteractionMode)value;
+			inter.pointed_object  = (TouchInteractionMode)value;
+		}
+	} else if (!lua_isnil(L, -1)) {
+		throw LuaError("invalid type for 'touch_interaction'");
 	}
 	lua_pop(L, 1);
 }

--- a/src/script/common/c_types.cpp
+++ b/src/script/common/c_types.cpp
@@ -37,5 +37,6 @@ struct EnumString es_TouchInteractionMode[] =
 	{
 		{LONG_DIG_SHORT_PLACE, "long_dig_short_place"},
 		{SHORT_DIG_LONG_PLACE, "short_dig_long_place"},
+		{TouchInteractionMode_USER, "user"},
 		{0, NULL},
 	};


### PR DESCRIPTION
1. **Re-add "long tap to punch" as a client-side setting**
    
    Fixes the part of #14393 that I consider acceptable. The setting doesn't seem useful to me, but it will hopefully make @j-r happy ¯\\_(ツ)_/¯

   Typical Minetest workflow:
   1. Make a behavior change requested for years by many users
   2. One user complains
   3. Add a setting

2. **Make long tap delay customizable and change default to 400ms**
    
    For comparison:
    - current Minetest: 500 ms
    - Rollertest: 400 ms
    - PojavLauncher: 300 ms & configurable
    - new Minetest: 400 ms & configurable

3. **Add shorthand form for touch_interaction**
    
    Allows replacing this
    
    ```lua
    touch_interaction = {
        pointed_nothing = "short_dig_long_place",
        pointed_node    = "short_dig_long_place",
        pointed_object  = "short_dig_long_place",
    },
    ```
    
    with this
    
    ```lua
    touch_interaction = "short_dig_long_place",
    ```

## To do

This PR is a Ready for Review.

## How to test

1. Verify that "short tap to punch" is still the default. Verify that the `touch_punch_gesture` setting can be used to restore the pre-5.9 behavior of "long tap to punch".

2. Try different values for the `touch_long_tap_delay` setting.

3. Add this code to Mineclon* and verify that it works:
    
    ```lua
    minetest.register_on_mods_loaded(function()
        for name in pairs(minetest.registered_items) do
            if name:find("grenade") or name:find("bow") or name:find("shield") then
                print("overriding " .. name)
                minetest.override_item(name, {
                    touch_interaction = "short_dig_long_place",
                })
            end
        end
    end)
    ```