### PR TITLE
Disable default password check in single player

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -261,7 +261,7 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 		}
 	} else {
 		std::string default_password = g_settings->get("default_password");
-		if (default_password.length() == 0) {
+		if (isSingleplayer() || default_password.length() == 0) {
 			auth_mechs |= AUTH_MECHANISM_FIRST_SRP;
 		} else {
 			// Take care of default passwords.


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

If a default password is provided, the game would try to auth in single player even though single player worlds have no passwords. We basically tell it to not auth if it's single player and a default password is provided.
Fixes #14457

## To do

This PR is Ready for Review.

## How to test

Provide a default password and create a world in single player and join. Should work.
