### PR TITLE
Fix set_fov-induced grayscreen

### DIFF
--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -241,7 +241,7 @@ private:
 
 	// Server-sent FOV variables
 	bool m_server_sent_fov = false;
-	f32 m_curr_fov_degrees, m_old_fov_degrees, m_target_fov_degrees;
+	f32 m_curr_fov_degrees, m_target_fov_degrees;
 
 	// FOV transition variables
 	bool m_fov_transition_active = false;


### PR DESCRIPTION
Fixes #14499, ready for review.

## How to test

* Read the code and confirm that the new logic (immediately updating `m_fov_transition_active`) makes more sense (and should fix the bug).
* Make sure that you can't reproduce the linked issue with this PR.
* Basic regression test: Alter the example code a bit to `user:set_fov(flip and 80 or 60,false, flip and .25 or 0)`. Confirm that the FOV change to a "wider" FOV ("zooming out") is smooth, whereas "zooming in" is instantaneous. Maybe also test multipliers.
