### PR TITLE
Fix path splitting in translation updater script

### DIFF
--- a/util/mod_translation_updater.py
+++ b/util/mod_translation_updater.py
@@ -394,6 +394,14 @@ def sorted_os_walk(folder):
 			f = f + 1
 	return paths_and_files
 
+def path_split_all(path):
+	all_parts = []
+	while len(path) > 0:
+		head, tail = os.path.split(path)
+		all_parts.insert(0, tail)
+		path = head
+	return all_parts
+
 # Walks all lua files in the mod folder, collects translatable strings,
 # and writes it to a template.txt file
 # Returns a dictionary of localized strings to source file lists
@@ -425,7 +433,7 @@ def generate_template(folder, mod_name):
 		sources = sorted(list(sources), key=str.lower)
 		newSources = []
 		for i in sources:
-			i = "/".join(os.path.split(i)).lstrip("/")
+			i = "/".join(path_split_all(i)).lstrip("/")
 			newSources.append(f"{symbol_source_prefix} {i} {symbol_source_suffix}")
 		dOut[d] = newSources
 

--- a/util/mod_translation_updater.py
+++ b/util/mod_translation_updater.py
@@ -394,14 +394,6 @@ def sorted_os_walk(folder):
 			f = f + 1
 	return paths_and_files
 
-def path_split_all(path):
-	all_parts = []
-	while len(path) > 0:
-		head, tail = os.path.split(path)
-		all_parts.insert(0, tail)
-		path = head
-	return all_parts
-
 # Walks all lua files in the mod folder, collects translatable strings,
 # and writes it to a template.txt file
 # Returns a dictionary of localized strings to source file lists
@@ -433,7 +425,7 @@ def generate_template(folder, mod_name):
 		sources = sorted(list(sources), key=str.lower)
 		newSources = []
 		for i in sources:
-			i = "/".join(path_split_all(i)).lstrip("/")
+			i = i.replace("\\", "/")
 			newSources.append(f"{symbol_source_prefix} {i} {symbol_source_suffix}")
 		dOut[d] = newSources
 


### PR DESCRIPTION
**Goal of the PR**
This PR aims to fix bug in writing file path separators.

**How does the PR work?**
This PR uses simple string replacement to replace `\` with `/` in file paths.
~`os.path.split()` only splits file path into file name and folder path, so that function needs to be repeated until full path are separated into all parts.~

**Does it resolve any reported issue?**
This PR tries to fix #14447.

## To do

This PR is Ready for Review.

## How to test

1. On Windows, run the script with `-p` flag for a mod with scripts inside folders (two or more levels deep).
2. Check that the file path separators are forward-slash (`/`).
3. Try step 1 to 2 on other platforms/operating systems.