### PR TITLE
Allow optional actor ObjectRef value in node interaction calls

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -39,6 +39,7 @@ core.features = {
 	dynamic_add_media_filepath = true,
 	lsystem_decoration_type = true,
 	item_meta_range = true,
+	node_interaction_actor = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5431,7 +5431,8 @@ Utilities
       lsystem_decoration_type = true,
       -- Overrideable pointing range using the itemstack meta key `"range"` (5.9.0)
       item_meta_range = true,
-      -- Allow passing in an optional "actor" ObjectRef into node interaction calls (5.9.0)
+      -- Allow passing in an optional "actor" ObjectRef into the following functions: (5.9.0)
+      -- minetest.place_node, minetest.dig_node, minetest.punch_node
       node_interaction_actor = true,
   }
   ```

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6068,8 +6068,9 @@ Environment access
     * Dig node with the same effects that a player would cause
     * `digger`: The ObjectRef that digs the node (optional)
     * Returns `true` if successful, `false` on failure (e.g. protected location)
-* `minetest.punch_node(pos)`
+* `minetest.punch_node(pos[, puncher])`
     * Punch node with the same effects that a player would cause
+    * `puncher`: The ObjectRef that punches the node (optional)
 * `minetest.spawn_falling_node(pos)`
     * Change node into falling node
     * Returns `true` and the ObjectRef of the spawned entity if successful, `false` on failure

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6061,8 +6061,9 @@ Environment access
     * Returns a number between `0` and `15`
     * Currently it's the same as `math.floor(param1 / 16)`, except that it
       ensures compatibility.
-* `minetest.place_node(pos, node)`
+* `minetest.place_node(pos, node[, placer])`
     * Place node with the same effects that a player would cause
+    * `placer`: The ObjectRef that places the node (optional)
 * `minetest.dig_node(pos[, digger])`
     * Dig node with the same effects that a player would cause
     * `digger`: The ObjectRef that digs the node (optional)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5431,6 +5431,8 @@ Utilities
       lsystem_decoration_type = true,
       -- Overrideable pointing range using the itemstack meta key `"range"` (5.9.0)
       item_meta_range = true,
+      -- Allow passing in an optional "actor" ObjectRef into node interaction calls (5.9.0)
+      node_interaction_actor = true,
   }
   ```
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5431,8 +5431,8 @@ Utilities
       lsystem_decoration_type = true,
       -- Overrideable pointing range using the itemstack meta key `"range"` (5.9.0)
       item_meta_range = true,
-      -- Allow passing in an optional "actor" ObjectRef into the following functions: (5.9.0)
-      -- minetest.place_node, minetest.dig_node, minetest.punch_node
+      -- Allow passing an optional "actor" ObjectRef to the following functions:
+      -- minetest.place_node, minetest.dig_node, minetest.punch_node (5.9.0)
       node_interaction_actor = true,
   }
   ```

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6063,8 +6063,9 @@ Environment access
       ensures compatibility.
 * `minetest.place_node(pos, node)`
     * Place node with the same effects that a player would cause
-* `minetest.dig_node(pos)`
+* `minetest.dig_node(pos[, digger])`
     * Dig node with the same effects that a player would cause
+    * `digger`: The ObjectRef that digs the node (optional)
     * Returns `true` if successful, `false` on failure (e.g. protected location)
 * `minetest.punch_node(pos)`
     * Punch node with the same effects that a player would cause

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -448,7 +448,7 @@ int ModApiEnv::l_place_node(lua_State *L)
 
 	ServerActiveObject *placer = nullptr;
 
-	if (! lua_isnoneornil(L, 3)) {
+	if (!lua_isnoneornil(L, 3)) {
 		ObjectRef *ref = checkObject<ObjectRef>(L, 3);
 		placer = ObjectRef::getobject(ref);
 	}
@@ -479,7 +479,7 @@ int ModApiEnv::l_dig_node(lua_State *L)
 
 	ServerActiveObject *digger = nullptr;
 
-	if (! lua_isnoneornil(L, 2)) {
+	if (!lua_isnoneornil(L, 2)) {
 		ObjectRef *ref = checkObject<ObjectRef>(L, 2);
 		digger = ObjectRef::getobject(ref);
 	}
@@ -511,7 +511,7 @@ int ModApiEnv::l_punch_node(lua_State *L)
 
 	ServerActiveObject *puncher = nullptr;
 
-	if (! lua_isnoneornil(L, 2)) {
+	if (!lua_isnoneornil(L, 2)) {
 		ObjectRef *ref = checkObject<ObjectRef>(L, 2);
 		puncher = ObjectRef::getobject(ref);
 	}

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -519,6 +519,7 @@ int ModApiEnv::l_punch_node(lua_State *L)
 	// Punch it with a NULL puncher
 	// (appears in Lua as a non-functional ObjectRef)
 	// or the given ObjectRef SAO
+	// TODO: custom PointedThing (requires a converter function)
 	bool success = scriptIfaceNode->node_on_punch(pos, n, puncher, PointedThing());
 	lua_pushboolean(L, success);
 	return 1;

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -504,7 +504,7 @@ int ModApiEnv::l_dig_node(lua_State *L)
 	return 1;
 }
 
-// punch_node(pos)
+// punch_node(pos, [puncher])
 // pos = {x=num, y=num, z=num}
 int ModApiEnv::l_punch_node(lua_State *L)
 {
@@ -520,6 +520,22 @@ int ModApiEnv::l_punch_node(lua_State *L)
 		lua_pushboolean(L, false);
 		return 1;
 	}
+
+	if (lua_gettop(L) >= 2 && (! lua_isnoneornil(L, 2))) {
+		ObjectRef *ref = checkObject<ObjectRef>(L, 2);
+		ServerActiveObject *puncher = ObjectRef::getobject(ref);
+
+		if (puncher != nullptr) {
+			// Puncher the node with the provided puncher
+			// TODO: Allow custom PointedThing w/ or w/o custom puncher
+			bool success = scriptIfaceNode->node_on_punch(pos, n, puncher, PointedThing());
+			lua_pushboolean(L, success);
+			return 1;
+		}
+		// Otherwise, fallback to NULL puncher SAO
+		// (Seems like Lua already handle invalid args but anyway)
+	}
+
 	// Punch it with a NULL puncher (appears in Lua as a non-functional
 	// ObjectRef)
 	bool success = scriptIfaceNode->node_on_punch(pos, n, NULL, PointedThing());

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -453,8 +453,8 @@ int ModApiEnv::l_place_node(lua_State *L)
 		placer = ObjectRef::getobject(ref);
 	}
 
-	// Place it with a NULL placer (appears in Lua as nil)
-	// or the given ObjectRef SAO
+	// Place it with a nullptr placer (appears in Lua as nil)
+	// or the given ObjectRef
 	bool success = scriptIfaceItem->item_OnPlace(item, placer, pointed);
 	lua_pushboolean(L, success);
 	return 1;
@@ -484,9 +484,9 @@ int ModApiEnv::l_dig_node(lua_State *L)
 		digger = ObjectRef::getobject(ref);
 	}
 
-	// Dig it out with a NULL digger
+	// Dig it out with a nullptr digger
 	// (appears in Lua as a non-functional ObjectRef)
-	// or the given ObjectRef SAO
+	// or the given ObjectRef
 	bool success = scriptIfaceNode->node_on_dig(pos, n, digger);
 	lua_pushboolean(L, success);
 	return 1;
@@ -516,9 +516,9 @@ int ModApiEnv::l_punch_node(lua_State *L)
 		puncher = ObjectRef::getobject(ref);
 	}
 
-	// Punch it with a NULL puncher
+	// Punch it with a nullptr puncher
 	// (appears in Lua as a non-functional ObjectRef)
-	// or the given ObjectRef SAO
+	// or the given ObjectRef
 	// TODO: custom PointedThing (requires a converter function)
 	bool success = scriptIfaceNode->node_on_punch(pos, n, puncher, PointedThing());
 	lua_pushboolean(L, success);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -446,22 +446,16 @@ int ModApiEnv::l_place_node(lua_State *L)
 	pointed.node_abovesurface = pos;
 	pointed.node_undersurface = pos + v3s16(0,-1,0);
 
+	ServerActiveObject *placer = nullptr;
+
 	if (! lua_isnoneornil(L, 3)) {
 		ObjectRef *ref = checkObject<ObjectRef>(L, 3);
-		ServerActiveObject *placer = ObjectRef::getobject(ref);
-
-		if (placer != nullptr) {
-			// Place the node with the provided placer
-			bool success = scriptIfaceItem->item_OnPlace(item, placer, pointed);
-			lua_pushboolean(L, success);
-			return 1;
-		}
-		// Otherwise, fallback to NULL placer SAO
-		// (Seems like Lua already handle invalid args but anyway)
+		placer = ObjectRef::getobject(ref);
 	}
 
 	// Place it with a NULL placer (appears in Lua as nil)
-	bool success = scriptIfaceItem->item_OnPlace(item, nullptr, pointed);
+	// or the given ObjectRef SAO
+	bool success = scriptIfaceItem->item_OnPlace(item, placer, pointed);
 	lua_pushboolean(L, success);
 	return 1;
 }
@@ -483,23 +477,17 @@ int ModApiEnv::l_dig_node(lua_State *L)
 		return 1;
 	}
 
-	if (lua_gettop(L) >= 2 && (! lua_isnoneornil(L, 2))) {
-		ObjectRef *ref = checkObject<ObjectRef>(L, 2);
-		ServerActiveObject *digger = ObjectRef::getobject(ref);
+	ServerActiveObject *digger = nullptr;
 
-		if (digger != nullptr) {
-			// Dig the node with the provided digger
-			bool success = scriptIfaceNode->node_on_dig(pos, n, digger);
-			lua_pushboolean(L, success);
-			return 1;
-		}
-		// Otherwise, fallback to NULL digger SAO
-		// (Seems like Lua already handle invalid args but anyway)
+	if (! lua_isnoneornil(L, 2)) {
+		ObjectRef *ref = checkObject<ObjectRef>(L, 2);
+		digger = ObjectRef::getobject(ref);
 	}
 
-	// Dig it out with a NULL digger (appears in Lua as a
-	// non-functional ObjectRef)
-	bool success = scriptIfaceNode->node_on_dig(pos, n, NULL);
+	// Dig it out with a NULL digger
+	// (appears in Lua as a non-functional ObjectRef)
+	// or the given ObjectRef SAO
+	bool success = scriptIfaceNode->node_on_dig(pos, n, digger);
 	lua_pushboolean(L, success);
 	return 1;
 }
@@ -521,24 +509,17 @@ int ModApiEnv::l_punch_node(lua_State *L)
 		return 1;
 	}
 
-	if (lua_gettop(L) >= 2 && (! lua_isnoneornil(L, 2))) {
-		ObjectRef *ref = checkObject<ObjectRef>(L, 2);
-		ServerActiveObject *puncher = ObjectRef::getobject(ref);
+	ServerActiveObject *puncher = nullptr;
 
-		if (puncher != nullptr) {
-			// Puncher the node with the provided puncher
-			// TODO: Allow custom PointedThing w/ or w/o custom puncher
-			bool success = scriptIfaceNode->node_on_punch(pos, n, puncher, PointedThing());
-			lua_pushboolean(L, success);
-			return 1;
-		}
-		// Otherwise, fallback to NULL puncher SAO
-		// (Seems like Lua already handle invalid args but anyway)
+	if (! lua_isnoneornil(L, 2)) {
+		ObjectRef *ref = checkObject<ObjectRef>(L, 2);
+		puncher = ObjectRef::getobject(ref);
 	}
 
-	// Punch it with a NULL puncher (appears in Lua as a non-functional
-	// ObjectRef)
-	bool success = scriptIfaceNode->node_on_punch(pos, n, NULL, PointedThing());
+	// Punch it with a NULL puncher
+	// (appears in Lua as a non-functional ObjectRef)
+	// or the given ObjectRef SAO
+	bool success = scriptIfaceNode->node_on_punch(pos, n, puncher, PointedThing());
 	lua_pushboolean(L, success);
 	return 1;
 }

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -451,7 +451,7 @@ int ModApiEnv::l_place_node(lua_State *L)
 		ServerActiveObject *placer = ObjectRef::getobject(ref);
 
 		if (placer != nullptr) {
-			// Dig the node with the provided placer
+			// Place the node with the provided placer
 			bool success = scriptIfaceItem->item_OnPlace(item, placer, pointed);
 			lua_pushboolean(L, success);
 			return 1;

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -417,7 +417,7 @@ int ModApiEnv::l_get_natural_light(lua_State *L)
 	return 1;
 }
 
-// place_node(pos, node)
+// place_node(pos, node, [placer])
 // pos = {x=num, y=num, z=num}
 int ModApiEnv::l_place_node(lua_State *L)
 {
@@ -437,6 +437,7 @@ int ModApiEnv::l_place_node(lua_State *L)
 		lua_pushboolean(L, false);
 		return 1;
 	}
+
 	// Create item to place
 	std::optional<ItemStack> item = ItemStack(ndef->get(n).name, 1, 0, idef);
 	// Make pointed position
@@ -444,6 +445,21 @@ int ModApiEnv::l_place_node(lua_State *L)
 	pointed.type = POINTEDTHING_NODE;
 	pointed.node_abovesurface = pos;
 	pointed.node_undersurface = pos + v3s16(0,-1,0);
+
+	if (! lua_isnoneornil(L, 3)) {
+		ObjectRef *ref = checkObject<ObjectRef>(L, 3);
+		ServerActiveObject *placer = ObjectRef::getobject(ref);
+
+		if (placer != nullptr) {
+			// Dig the node with the provided placer
+			bool success = scriptIfaceItem->item_OnPlace(item, placer, pointed);
+			lua_pushboolean(L, success);
+			return 1;
+		}
+		// Otherwise, fallback to NULL placer SAO
+		// (Seems like Lua already handle invalid args but anyway)
+	}
+
 	// Place it with a NULL placer (appears in Lua as nil)
 	bool success = scriptIfaceItem->item_OnPlace(item, nullptr, pointed);
 	lua_pushboolean(L, success);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -93,7 +93,7 @@ private:
 	// pos = {x=num, y=num, z=num}
 	static int l_place_node(lua_State *L);
 
-	// dig_node(pos)
+	// dig_node(pos, [digger])
 	// pos = {x=num, y=num, z=num}
 	static int l_dig_node(lua_State *L);
 

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -89,7 +89,7 @@ private:
 	// timeofday: nil = current time, 0 = night, 0.5 = day
 	static int l_get_natural_light(lua_State *L);
 
-	// place_node(pos, node)
+	// place_node(pos, node, [placer])
 	// pos = {x=num, y=num, z=num}
 	static int l_place_node(lua_State *L);
 

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -97,7 +97,7 @@ private:
 	// pos = {x=num, y=num, z=num}
 	static int l_dig_node(lua_State *L);
 
-	// punch_node(pos)
+	// punch_node(pos, [puncher])
 	// pos = {x=num, y=num, z=num}
 	static int l_punch_node(lua_State *L);
 


### PR DESCRIPTION
This PR adds an optional operator (ObjectRef) parameter to node interaction calls in `l_env.cpp`.

Previously, mimicking all the behaviors when a player digs a node was complex when specifying an ObjectRef. With this PR, the operator can be passed onto the callbacks.

This will be the true solution to programmed node interactions needing interaction checks, e.g. https://github.com/minetest-mods/areas/issues/54.

Fixes #13563
Related to #11336
Related to https://github.com/minetest/minetest/issues/14004#issuecomment-1826395019
Related to minetest-mods/areas#54

## To do

This PR is Ready for Review.

- [x] `minetest.place_node`
- [x] `minetest.dig_node` 
- [x] `minetest.punch_node`

## Potential to-dos and issues

- `minetest.punch_node` custom `pointed_thing` 
- Check code quality (I am new to C++)

## How to test

I use `//luatransform` in WorldEdit to test my modifications. For example, to test `dig_node`:

```text
# Specify the node position first

# These two pass no operator field and should work as how they would
//luatransform minetest.dig_node(pos)
//luatransform minetest.dig_node(pos, nil)

# This one passes the operator field and should:
# 1. Logged as the player's operation
# 2. Check for area protection
# 3. Add items into the player's inventory, if the game is coded so
//luatransform minetest.dig_node(pos, minetest.get_player_by_name("YOUR_USERNAME"))

# This should raise an error complaining about passing in non-ObjectRef
//luatransform minetest.dig_node(pos, "")
```

This code may help visualize the calls:

```lua
minetest.register_on_placenode(function(pos, newnode, placer, oldnode, itemstack, pointed_thing)
        minetest.log("action", "place; " .. minetest.pos_to_string(pos) .. "; " .. dump(newnode) .. "; " .. placer:get_player_name() .. "; " .. dump(oldnode) .. "; " .. itemstack:to_string() .. "; " .. dump(pointed_thing))
end)

minetest.register_on_dignode(function(pos, oldnode, digger)
        minetest.log("action", "dig; " .. minetest.pos_to_string(pos) .. "; " .. dump(oldnode) .. "; " .. digger:get_player_name())
end)

minetest.register_on_punchnode(function(pos, node, puncher, pointed_thing)
        minetest.log("action", "punch; " .. minetest.pos_to_string(pos) .. "; " .. dump(node) .. "; " .. puncher:get_player_name() .. "; " .. dump(pointed_thing))
end)
```

## Example

https://github.com/C-C-Minetest-Server/twi_mods/blob/2e658d0df4e404dccb43d48934b631762ac80055/func_areas_limitations/init.lua#L27-L37
