### PR TITLE
Various visual effects

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -384,6 +384,11 @@ enable_clouds (Clouds) bool true
 #    Requires: enable_clouds
 enable_3d_clouds (3D clouds) bool true
 
+#   Use smooth cloud shading.
+#
+#   Requires: enable_3d_clouds, enable_clouds
+soft_clouds (Soft clouds) bool false
+
 [**Filtering and Antialiasing]
 
 #    Use mipmaps when scaling textures. May slightly increase performance,
@@ -485,6 +490,11 @@ water_wave_length (Waving liquids wavelength) float 20.0 0.1
 #
 #    Requires: shaders, enable_waving_water
 water_wave_speed (Waving liquids wave speed) float 5.0
+
+#   When enabled, liquid reflections are simulated.
+#
+#   Requires: shaders, enable_waving_water, enable_dynamic_shadows
+enable_water_reflections (Liquid reflections) bool false
 
 [**Dynamic shadows]
 
@@ -590,6 +600,16 @@ enable_auto_exposure (Enable Automatic Exposure) bool false
 #    Requires: shaders, enable_post_processing, enable_auto_exposure
 exposure_compensation (Exposure compensation) float 0.0 -1.0 1.0
 
+#   Apply color grading to make brighter colors warmer and darker colors cooler.
+#
+#   Requires: shaders, enable_post_processing
+enable_color_grading (Color grading) bool false
+
+#   Apply vignette effect to darken the edges of the screen.
+#
+#   Requires: shaders, enable_post_processing
+enable_vignette (Vignette) bool false
+
 #    Apply dithering to reduce color banding artifacts.
 #    Dithering significantly increases the size of losslessly-compressed
 #    screenshots and it works incorrectly if the display or operating system
@@ -641,6 +661,23 @@ bloom_radius (Bloom Radius) float 1 0.1 8
 #
 #    Requires: shaders, enable_post_processing, enable_bloom
 enable_volumetric_lighting (Volumetric lighting) bool false
+
+[**Other Effects]
+
+#   Simulate translucency when looking at foliage in the sunlight.
+#
+#   Requires: enable_shaders, enable_dynamic_shadows
+enable_translucent_foliage (Translucent foliage) bool false
+
+#   Apply crude bump maps to nodes.
+#
+#   Requires: enable_shaders, enable_dynamic_shadows
+enable_bumpmaps (Bump maps) bool false
+
+#   Apply reflections to nodes.
+#
+#   Requires: enable_shaders, enable_dynamic_shadows
+enable_node_reflections (Node reflections) bool false
 
 [*Audio]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -268,6 +268,15 @@ performance_tradeoffs (Tradeoffs for performance) bool false
 #    Adds particles when digging a node.
 enable_particles (Digging particles) bool true
 
+#   Tint sunlight orange during dusk and dawn.
+tinted_sunlight (Tinted sunlight) bool false
+
+#   The color of light that sources like lamps, torches etc. give off.
+#   -   default: Neutral, white light.
+#   -   medium: Slightly warmer color than default.
+#   -   warm: Warm (yellowish-orangy) light.
+artificial_light (Artificial light color) enum default default,medium,warm
+
 [**3D]
 
 #    3D support.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -678,7 +678,7 @@ enable_volumetric_lighting (Volumetric lighting) bool false
 #   Requires: enable_shaders, enable_dynamic_shadows
 enable_translucent_foliage (Translucent foliage) bool false
 
-#   Apply crude bump maps to nodes.
+#   Apply crude bump maps to nodes. It is recommended to use a tilted sun orbit to go with this (Sky Body Orbit Tilt).
 #
 #   Requires: enable_shaders, enable_dynamic_shadows
 enable_bumpmaps (Bump maps) bool false

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -48,7 +48,7 @@ varying vec3 viewVec;
 varying vec3 eyeVec;
 varying float nightRatio;
 // Color of the light emitted by the light sources.
-const vec3 artificialLight = vec3(1.2, 0.95, 0.8);
+uniform vec3 artificialLight;
 const float e = 2.718281828459;
 const float BS = 10.0;
 uniform float xyPerspectiveBias0;

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -44,10 +44,11 @@ centroid varying vec2 varTexCoord;
 
 varying float area_enable_parallax;
 
+varying vec3 viewVec;
 varying vec3 eyeVec;
 varying float nightRatio;
 // Color of the light emitted by the light sources.
-const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
+const vec3 artificialLight = vec3(1.2, 0.95, 0.8);
 const float e = 2.718281828459;
 const float BS = 10.0;
 uniform float xyPerspectiveBias0;
@@ -232,6 +233,8 @@ void main(void)
 #else
 		vec4 shadow_pos = pos;
 #endif
+		viewVec = normalize(worldPosition + cameraOffset - eyePosition);
+
 		vec3 nNormal;
 		f_normal_length = length(vNormal);
 
@@ -262,14 +265,14 @@ void main(void)
 
 		if (f_timeofday < 0.2) {
 			adj_shadow_strength = f_shadow_strength * 0.5 *
-				(1.0 - mtsmoothstep(0.18, 0.2, f_timeofday));
+				(1.0 - mtsmoothstep(0.15, 0.2, f_timeofday));
 		} else if (f_timeofday >= 0.8) {
 			adj_shadow_strength = f_shadow_strength * 0.5 *
-				mtsmoothstep(0.8, 0.83, f_timeofday);
+				mtsmoothstep(0.8, 0.85, f_timeofday);
 		} else {
 			adj_shadow_strength = f_shadow_strength *
 				mtsmoothstep(0.20, 0.25, f_timeofday) *
-				(1.0 - mtsmoothstep(0.7, 0.8, f_timeofday));
+				(1.0 - mtsmoothstep(0.75, 0.8, f_timeofday));
 		}
 	}
 #endif

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -450,7 +450,9 @@ void main(void)
 	// Note: clarity = (1 - fogginess)
 	float clarity = clamp(fogShadingParameter
 		- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
-	col = mix(fogColor, col, clarity);
+	float fogColorMax = max(max(fogColor.r, fogColor.g), fogColor.b);
+	if (fogColorMax < 0.0000001) fogColorMax = 1.;
+	col = mix(fogColor * pow(fogColor / fogColorMax, vec4(2. * clarity)), col, clarity);
 	col = vec4(col.rgb, base.a);
 
 	gl_FragData[0] = col;

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -21,6 +21,7 @@ uniform float animationTimer;
 	uniform vec4 CameraPos;
 	uniform float xyPerspectiveBias0;
 	uniform float xyPerspectiveBias1;
+	uniform vec3 shadow_tint;
 
 	varying float adj_shadow_strength;
 	varying float cosLight;
@@ -433,7 +434,7 @@ void main(void)
 		col.rgb =
 				adjusted_night_ratio * col.rgb + // artificial light
 				(1.0 - adjusted_night_ratio) * ( // natural light
-						col.rgb * (1.0 - shadow_int * (1.0 - shadow_color)) +  // filtered texture color
+						col.rgb * (1.0 - shadow_int * (1.0 - shadow_color) * (1. - shadow_tint)) +  // filtered texture color
 						dayLight * shadow_color * shadow_int);                 // reflected filtered sunlight/moonlight
 	}
 #endif

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -36,7 +36,7 @@ centroid varying vec2 varTexCoord;
 varying vec3 eyeVec;
 varying float nightRatio;
 // Color of the light emitted by the light sources.
-const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
+const vec3 artificialLight = vec3(1.2, 0.95, 0.8);
 varying float vIDiff;
 const float e = 2.718281828459;
 const float BS = 10.0;

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -36,7 +36,7 @@ centroid varying vec2 varTexCoord;
 varying vec3 eyeVec;
 varying float nightRatio;
 // Color of the light emitted by the light sources.
-const vec3 artificialLight = vec3(1.2, 0.95, 0.8);
+uniform vec3 artificialLight;
 varying float vIDiff;
 const float e = 2.718281828459;
 const float BS = 10.0;

--- a/client/shaders/volumetric_light/opengl_fragment.glsl
+++ b/client/shaders/volumetric_light/opengl_fragment.glsl
@@ -46,7 +46,7 @@ float sampleVolumetricLight(vec2 uv, vec3 lightVec, float rawDepth)
 		if (min(samplepos.x, samplepos.y) > 0. && max(samplepos.x, samplepos.y) < 1.)
 			result += texture2D(depthmap, samplepos).r < 1. ? 0.0 : 1.0;
 	}
-	return result / samples;
+	return result / samples * pow(texture2D(depthmap, uv).r, 128.);
 }
 
 vec3 getDirectLightScatteringAtGround(vec3 v_LightDirection)
@@ -58,7 +58,7 @@ vec3 getDirectLightScatteringAtGround(vec3 v_LightDirection)
 	// for Nitrogen at 532nm (green), 2e25 molecules/m3 in atmosphere
 	const vec3 beta_r0_l = vec3(3.3362176e-01, 8.75378289198826e-01, 1.95342379700656) * beta_r0; // wavelength-dependent scattering
 
-	const float atmosphere_height = 15000.; // height of the atmosphere in meters
+	const float atmosphere_height = 50000.; // height of the atmosphere in meters
 	// sun/moon light at the ground level, after going through the atmosphere
 	return exp(-beta_r0_l * atmosphere_height / (1e-5 - dot(v_LightDirection, vec3(0., 1., 0.))));
 }

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -136,6 +136,7 @@ struct ClientEvent
 			f32 density;
 			u32 color_bright;
 			u32 color_ambient;
+			u32 color_shadow;
 			f32 height;
 			f32 thickness;
 			f32 speed_x;

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -149,15 +149,6 @@ void Clouds::updateMesh()
 		// shader mixes the base color, set via EmissiveColor
 		c_top_f = c_side_1_f = c_side_2_f = c_bottom_f = video::SColorf(1.0f, 1.0f, 1.0f, 1.0f);
 	}
-	/*c_side_1_f.r *= 0.90f;
-	c_side_1_f.g *= 0.95f;
-	c_side_1_f.b *= 1.00f;
-	c_side_2_f.r *= 0.70f;
-	c_side_2_f.g *= 0.80f;
-	c_side_2_f.b *= 0.95f;
-	c_bottom_f.r *= 0.50f;
-	c_bottom_f.g *= 0.70f;
-	c_bottom_f.b *= 0.90f;*/
 
 	video::SColorf shadow = m_params.color_shadow;
 	
@@ -338,6 +329,7 @@ void Clouds::updateMesh()
 				}
 			}
 		}
+		// Standard clouds
 		else {
 			for (u32 i = 0; i < num_faces_to_draw; i++)
 			{

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -101,6 +101,11 @@ public:
 		m_params.color_ambient = color_ambient;
 	}
 
+	void setColorShadow(video::SColor color_shadow)
+	{
+		m_params.color_shadow = color_shadow;
+	}
+
 	void setHeight(float height)
 	{
 		if (m_params.height == height)

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -713,8 +713,9 @@ void MapblockMeshGenerator::drawLiquidSides()
 			if (data->m_smooth_lighting)
 				cur_node.color = blendLightColor(pos);
 			pos += cur_node.origin;
-			vertices[j] = video::S3DVertex(pos.X, pos.Y, pos.Z, 0, 0, 0, cur_node.color, vertex.u, v);
+			vertices[j] = video::S3DVertex(pos.X, pos.Y, pos.Z, face.dir.X, face.dir.Y, face.dir.Z, cur_node.color, vertex.u, v);
 		};
+
 		collector->append(cur_liquid.tile, vertices, 4, quad_indices, 6);
 	}
 }
@@ -775,6 +776,7 @@ void MapblockMeshGenerator::drawLiquidTop()
 		vertex.TCoords += tcoord_center;
 
 		vertex.TCoords += tcoord_translate;
+		vertex.Normal = v3f(dx, 1., dz).normalize();
 	}
 
 	std::swap(vertices[0].TCoords, vertices[2].TCoords);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -381,6 +381,7 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<float>
 		m_animation_timer_delta_pixel{"animationTimerDelta"};
 	CachedPixelShaderSetting<float, 3> m_day_light{"dayLight"};
+	CachedPixelShaderSetting<float, 3> m_artificial_light{"artificialLight"};
 	CachedPixelShaderSetting<float, 3> m_eye_position_pixel{"eyePosition"};
 	CachedVertexShaderSetting<float, 3> m_eye_position_vertex{"eyePosition"};
 	CachedPixelShaderSetting<float, 3> m_minimap_yaw{"yawVec"};
@@ -574,6 +575,11 @@ public:
 			float volumetric_light_strength = lighting.volumetric_light_strength;
 			m_volumetric_light_strength_pixel.set(&volumetric_light_strength, services);
 		}
+
+		std::string artificial_light_enum = g_settings->get("artificial_light");
+		if (artificial_light_enum == "warm") m_artificial_light.set(v3f( 1.2, 0.95, 0.8 ), services);
+		else if (artificial_light_enum == "medium") m_artificial_light.set(v3f(1.1, 1., 0.95), services);
+		else m_artificial_light.set(v3f(1.04), services);
 	}
 
 	void onSetMaterial(const video::SMaterial &material) override

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1385,7 +1385,7 @@ void Game::copyServerClientCache()
 {
 	// It would be possible to let the client directly read the media files
 	// from where the server knows they are. But aside from being more complicated
-	// it would also *not* fill the media cache and cause slower joining of 
+	// it would also *not* fill the media cache and cause slower joining of
 	// remote servers.
 	// (Imagine that you launch a game once locally and then connect to a server.)
 
@@ -3084,6 +3084,7 @@ void Game::handleClientEvent_CloudParams(ClientEvent *event, CameraOrientation *
 	clouds->setDensity(event->cloud_params.density);
 	clouds->setColorBright(video::SColor(event->cloud_params.color_bright));
 	clouds->setColorAmbient(video::SColor(event->cloud_params.color_ambient));
+	clouds->setColorShadow(video::SColor(event->cloud_params.color_shadow));
 	clouds->setHeight(event->cloud_params.height);
 	clouds->setThickness(event->cloud_params.thickness);
 	clouds->setSpeed(v2f(event->cloud_params.speed_x, event->cloud_params.speed_y));
@@ -4201,7 +4202,9 @@ void Game::updateShadows()
 	float timeoftheday = getWickedTimeOfDay(in_timeofday);
 	bool is_day = timeoftheday > 0.25 && timeoftheday < 0.75;
 	bool is_shadow_visible = is_day ? sky->getSunVisible() : sky->getMoonVisible();
+	bool clouds_enabled = g_settings->getBool("enable_clouds");
 	shadow->setShadowIntensity(is_shadow_visible ? client->getEnv().getLocalPlayer()->getLighting().shadow_intensity : 0.0f);
+	shadow->setShadowTint(client->getEnv().getLocalPlayer()->getLighting().shadow_tint);
 
 	timeoftheday = std::fmod(timeoftheday + 0.75f, 0.5f) + 0.25f;
 	const float offset_constant = 10000.0f;

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -282,11 +282,22 @@ u16 getSmoothLightTransparent(const v3s16 &p, const v3s16 &corner, MeshMakeData 
 }
 
 void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio){
-	f32 rg = daynight_ratio / 1000.0f - 0.04f;
-	f32 b = (0.98f * daynight_ratio) / 1000.0f + 0.078f;
-	sunlight->r = rg;
-	sunlight->g = rg;
-	sunlight->b = b;
+	//f32 rg = daynight_ratio / 1000.0f - 0.04f;
+	//f32 b = (0.98f * daynight_ratio) / 1000.0f + 0.078f;
+	//sunlight->r = rg;
+	//sunlight->g = rg;
+	//sunlight->b = b;
+
+	f32 daynight_ratio_float = (daynight_ratio - 175) / 825.f;
+	sunlight->r = 1.f;
+	sunlight->g = core::clamp(std::pow(daynight_ratio_float, 0.7f), 0.f, 1.f);
+	sunlight->b = core::clamp(daynight_ratio_float * 1.5f - 0.5f, 0.f, 1.f);
+
+	f32 fade_factor = clamp((0.6f - daynight_ratio_float) / 0.6f, 0.f, 1.f);
+
+	sunlight->r = sunlight->r * (1.f - fade_factor) + 0.171f * fade_factor;
+	sunlight->g = sunlight->g * (1.f - fade_factor) + 0.171f * fade_factor;
+	sunlight->b = sunlight->b * (1.f - fade_factor) + 0.253f * fade_factor;
 }
 
 void final_color_blend(video::SColor *result,

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -282,22 +282,25 @@ u16 getSmoothLightTransparent(const v3s16 &p, const v3s16 &corner, MeshMakeData 
 }
 
 void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio){
-	//f32 rg = daynight_ratio / 1000.0f - 0.04f;
-	//f32 b = (0.98f * daynight_ratio) / 1000.0f + 0.078f;
-	//sunlight->r = rg;
-	//sunlight->g = rg;
-	//sunlight->b = b;
+	if (g_settings->getBool("tinted_sunlight")) {
+		f32 daynight_ratio_float = (daynight_ratio - 175) / 825.f;
+		sunlight->r = 1.f;
+		sunlight->g = core::clamp(std::pow(daynight_ratio_float, 0.7f), 0.f, 1.f);
+		sunlight->b = core::clamp(daynight_ratio_float * 1.5f - 0.5f, 0.f, 1.f);
 
-	f32 daynight_ratio_float = (daynight_ratio - 175) / 825.f;
-	sunlight->r = 1.f;
-	sunlight->g = core::clamp(std::pow(daynight_ratio_float, 0.7f), 0.f, 1.f);
-	sunlight->b = core::clamp(daynight_ratio_float * 1.5f - 0.5f, 0.f, 1.f);
+		f32 fade_factor = clamp((0.6f - daynight_ratio_float) / 0.6f, 0.f, 1.f);
 
-	f32 fade_factor = clamp((0.6f - daynight_ratio_float) / 0.6f, 0.f, 1.f);
-
-	sunlight->r = sunlight->r * (1.f - fade_factor) + 0.171f * fade_factor;
-	sunlight->g = sunlight->g * (1.f - fade_factor) + 0.171f * fade_factor;
-	sunlight->b = sunlight->b * (1.f - fade_factor) + 0.253f * fade_factor;
+		sunlight->r = sunlight->r * (1.f - fade_factor) + 0.171f * fade_factor;
+		sunlight->g = sunlight->g * (1.f - fade_factor) + 0.171f * fade_factor;
+		sunlight->b = sunlight->b * (1.f - fade_factor) + 0.253f * fade_factor;
+	}
+	else {
+		f32 rg = daynight_ratio / 1000.0f - 0.04f;
+		f32 b = (0.98f * daynight_ratio) / 1000.0f + 0.078f;
+		sunlight->r = rg;
+		sunlight->g = rg;
+		sunlight->b = b;
+	}
 }
 
 void final_color_blend(video::SColor *result,

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -288,7 +288,7 @@ void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio){
 		sunlight->g = core::clamp(std::pow(daynight_ratio_float, 0.7f), 0.f, 1.f);
 		sunlight->b = core::clamp(daynight_ratio_float * 1.5f - 0.5f, 0.f, 1.f);
 
-		f32 fade_factor = clamp((0.6f - daynight_ratio_float) / 0.6f, 0.f, 1.f);
+		f32 fade_factor = core::clamp((0.6f - daynight_ratio_float) / 0.6f, 0.f, 1.f);
 
 		sunlight->r = sunlight->r * (1.f - fade_factor) + 0.171f * fade_factor;
 		sunlight->g = sunlight->g * (1.f - fade_factor) + 0.171f * fade_factor;

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -368,6 +368,7 @@ ShaderSource::~ShaderSource()
 {
 	MutexAutoLock lock(m_shaderinfo_cache_mutex);
 
+#if IRRLICHT_VERSION_MT_REVISION >= 15
 	// Delete materials
 	video::IGPUProgrammingServices *gpu = RenderingEngine::get_video_driver()->
 		getGPUProgrammingServices();
@@ -376,6 +377,7 @@ ShaderSource::~ShaderSource()
 			gpu->deleteShaderMaterial(i.material);
 	}
 	m_shaderinfo_cache.clear();
+#endif
 }
 
 u32 ShaderSource::getShader(const std::string &name,
@@ -499,6 +501,7 @@ void ShaderSource::rebuildShaders()
 {
 	MutexAutoLock lock(m_shaderinfo_cache_mutex);
 
+#if IRRLICHT_VERSION_MT_REVISION >= 15
 	// Delete materials
 	video::IGPUProgrammingServices *gpu = RenderingEngine::get_video_driver()->
 		getGPUProgrammingServices();
@@ -508,6 +511,7 @@ void ShaderSource::rebuildShaders()
 			i.material = video::EMT_SOLID; // invalidate
 		}
 	}
+#endif
 
 	// Recreate shaders
 	for (ShaderInfo &i : m_shaderinfo_cache) {
@@ -688,6 +692,18 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		if (g_settings->getBool("shadow_poisson_filter"))
 			shaders_header << "#define POISSON_FILTER 1\n";
 
+		if (g_settings->getBool("enable_water_reflections"))
+			shaders_header << "#define ENABLE_WATER_REFLECTIONS 1\n";
+
+		if (g_settings->getBool("enable_translucent_foliage"))
+			shaders_header << "#define ENABLE_TRANSLUCENT_FOLIAGE 1\n";
+
+		if (g_settings->getBool("enable_bumpmaps"))
+			shaders_header << "#define ENABLE_BUMPMAPS 1\n";
+
+		if (g_settings->getBool("enable_node_reflections"))
+			shaders_header << "#define ENABLE_NODE_REFLECTIONS 1\n";
+
 		s32 shadow_filter = g_settings->getS32("shadow_filters");
 		shaders_header << "#define SHADOW_FILTER " << shadow_filter << "\n";
 
@@ -705,6 +721,12 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 
 	if (g_settings->getBool("enable_auto_exposure"))
 		shaders_header << "#define ENABLE_AUTO_EXPOSURE 1\n";
+
+	if (g_settings->getBool("enable_color_grading"))
+		shaders_header << "#define ENABLE_COLOR_GRADING 1\n";
+
+	if (g_settings->getBool("enable_vignette"))
+		shaders_header << "#define ENABLE_VIGNETTE 1\n";
 
 	if (g_settings->get("antialiasing") == "ssaa") {
 		shaders_header << "#define ENABLE_SSAA 1\n";

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -187,6 +187,11 @@ void ShadowRenderer::setShadowIntensity(float shadow_intensity)
 		disable();
 }
 
+void ShadowRenderer::setShadowTint(video::SColor shadow_tint)
+{
+	m_shadow_tint = shadow_tint;
+}
+
 void ShadowRenderer::addNodeToShadowList(
 		scene::ISceneNode *node, E_SHADOW_MODE shadowMode)
 {

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -93,9 +93,11 @@ public:
 	bool is_active() const { return m_shadows_enabled && shadowMapTextureFinal != nullptr; }
 	void setTimeOfDay(float isDay) { m_time_day = isDay; };
 	void setShadowIntensity(float shadow_intensity);
+	void setShadowTint(video::SColor shadow_intensity);
 
 	s32 getShadowSamples() const { return m_shadow_samples; }
 	float getShadowStrength() const { return m_shadows_enabled ? m_shadow_strength : 0.0f; }
+	video::SColor getShadowTint() const { return m_shadow_tint; }
 	float getTimeOfDay() const { return m_time_day; }
 
 	f32 getPerspectiveBiasXY() { return m_perspective_bias_xy; }
@@ -130,6 +132,7 @@ private:
 	std::vector<NodeToApply> m_shadow_node_array;
 
 	float m_shadow_strength;
+	video::SColor m_shadow_tint{255, 0, 38, 128};
 	float m_shadow_strength_gamma;
 	float m_shadow_map_max_distance;
 	float m_shadow_map_texture_size;

--- a/src/client/shadows/shadowsshadercallbacks.cpp
+++ b/src/client/shadows/shadowsshadercallbacks.cpp
@@ -40,6 +40,9 @@ void ShadowConstantSetter::onSetConstants(video::IMaterialRendererServices *serv
 	f32 ShadowStrength = shadow->getShadowStrength();
 	m_shadow_strength.set(&ShadowStrength, services);
 
+	video::SColor ShadowTint = shadow->getShadowTint();
+	m_shadow_tint.set(ShadowTint, services);
+
 	f32 timeOfDay = shadow->getTimeOfDay();
 	m_time_of_day.set(&timeOfDay, services);
 

--- a/src/client/shadows/shadowsshadercallbacks.h
+++ b/src/client/shadows/shadowsshadercallbacks.h
@@ -31,6 +31,7 @@ class ShadowConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<f32, 3> m_light_direction{"v_LightDirection"};
 	CachedPixelShaderSetting<f32> m_texture_res{"f_textureresolution"};
 	CachedPixelShaderSetting<f32> m_shadow_strength{"f_shadow_strength"};
+	CachedPixelShaderSetting<f32, 3> m_shadow_tint{ "shadow_tint" };
 	CachedPixelShaderSetting<f32> m_time_of_day{"f_timeofday"};
 	CachedPixelShaderSetting<f32> m_shadowfar{"f_shadowfar"};
 	CachedPixelShaderSetting<f32, 4> m_camera_pos{"CameraPos"};

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -207,6 +207,8 @@ void set_default_settings()
 	settings->setDefault("connected_glass", "false");
 	settings->setDefault("smooth_lighting", "true");
 	settings->setDefault("performance_tradeoffs", "false");
+	settings->setDefault("tinted_sunlight", "false");
+	settings->setDefault("artificial_light", "default");
 	settings->setDefault("lighting_alpha", "0.0");
 	settings->setDefault("lighting_beta", "1.5");
 	settings->setDefault("display_gamma", "1.0");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -223,6 +223,7 @@ void set_default_settings()
 	settings->setDefault("view_bobbing_amount", "1.0");
 	settings->setDefault("fall_bobbing_amount", "0.03");
 	settings->setDefault("enable_3d_clouds", "true");
+	settings->setDefault("soft_clouds", "false");
 	settings->setDefault("cloud_radius", "12");
 	settings->setDefault("menu_clouds", "true");
 	settings->setDefault("opaque_water", "false");
@@ -273,6 +274,8 @@ void set_default_settings()
 	settings->setDefault("enable_waving_plants", "false");
 	settings->setDefault("exposure_compensation", "0.0");
 	settings->setDefault("enable_auto_exposure", "false");
+	settings->setDefault("enable_color_grading", "false");
+	settings->setDefault("enable_vignette", "false");
 	settings->setDefault("debanding", "true");
 	settings->setDefault("antialiasing", "none");
 	settings->setDefault("enable_bloom", "false");
@@ -281,6 +284,10 @@ void set_default_settings()
 	settings->setDefault("bloom_intensity", "0.05");
 	settings->setDefault("bloom_radius", "1");
 	settings->setDefault("enable_volumetric_lighting", "false");
+	settings->setDefault("enable_water_reflections", "false");
+	settings->setDefault("enable_translucent_foliage", "false");
+	settings->setDefault("enable_bumpmaps", "false");
+	settings->setDefault("enable_node_reflections", "false");
 
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -18,7 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #pragma once
-
+#include "irrlichttypes_extrabloated.h"
 
 /**
  * Parameters for automatic exposure compensation
@@ -54,4 +54,5 @@ struct Lighting
 	float shadow_intensity {0.0f};
 	float saturation {1.0f};
 	float volumetric_light_strength {0.0f};
+	video::SColor shadow_tint;
 };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1475,8 +1475,10 @@ void Client::handleCommand_CloudParams(NetworkPacket* pkt)
 	f32 thickness;
 	v2f speed;
 
-	*pkt >> density >> color_bright >> color_ambient >> color_shadow
-			>> height >> thickness >> speed;
+	*pkt >> density >> color_bright >> color_ambient
+	>> height >> thickness >> speed;
+
+	if (pkt->getRemainingBytes() >= 4) *pkt >> color_shadow;
 
 	ClientEvent *event = new ClientEvent();
 	event->type                       = CE_CLOUD_PARAMS;
@@ -1808,11 +1810,6 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.saturation;
 	u32 tint[3];
-	if (pkt->getRemainingBytes() >= 12)
-		*pkt >> tint[0]
-			>> tint[1]
-			>> tint[2];
-	lighting.shadow_tint.set(255, tint[0], tint[1], tint[2]);
 	if (pkt->getRemainingBytes() >= 24) {
 		*pkt >> lighting.exposure.luminance_min
 				>> lighting.exposure.luminance_max
@@ -1823,4 +1820,6 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 	}
 	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.volumetric_light_strength;
+	if (pkt->getRemainingBytes() >= 4)
+		*pkt >> lighting.shadow_tint;
 }

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1470,11 +1470,12 @@ void Client::handleCommand_CloudParams(NetworkPacket* pkt)
 	f32 density;
 	video::SColor color_bright;
 	video::SColor color_ambient;
+	video::SColor color_shadow;
 	f32 height;
 	f32 thickness;
 	v2f speed;
 
-	*pkt >> density >> color_bright >> color_ambient
+	*pkt >> density >> color_bright >> color_ambient >> color_shadow
 			>> height >> thickness >> speed;
 
 	ClientEvent *event = new ClientEvent();
@@ -1485,6 +1486,7 @@ void Client::handleCommand_CloudParams(NetworkPacket* pkt)
 	// we avoid using new() and delete() for no good reason
 	event->cloud_params.color_bright  = color_bright.color;
 	event->cloud_params.color_ambient = color_ambient.color;
+	event->cloud_params.color_shadow = color_shadow.color;
 	event->cloud_params.height        = height;
 	event->cloud_params.thickness     = thickness;
 	// same here: deconstruct to skip constructor
@@ -1805,6 +1807,12 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 		*pkt >> lighting.shadow_intensity;
 	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.saturation;
+	u32 tint[3];
+	if (pkt->getRemainingBytes() >= 12)
+		*pkt >> tint[0]
+			>> tint[1]
+			>> tint[2];
+	lighting.shadow_tint.set(255, tint[0], tint[1], tint[2]);
 	if (pkt->getRemainingBytes() >= 24) {
 		*pkt >> lighting.exposure.luminance_min
 				>> lighting.exposure.luminance_max

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1809,7 +1809,6 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 		*pkt >> lighting.shadow_intensity;
 	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> lighting.saturation;
-	u32 tint[3];
 	if (pkt->getRemainingBytes() >= 24) {
 		*pkt >> lighting.exposure.luminance_min
 				>> lighting.exposure.luminance_max

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -223,6 +223,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		AO_CMD_SET_BONE_POSITION extended
 		Add TOCLIENT_MOVE_PLAYER_REL
 		Move default minimap from client-side C++ to server-side builtin Lua
+		Add shadow tint to Lighting packets
+		Add shadow color to CloudParam packets
 		[scheduled bump for 5.9.0]
 */
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2354,6 +2354,10 @@ int ObjectRef::l_set_clouds(lua_State *L)
 		if (!lua_isnil(L, -1))
 			read_color(L, -1, &cloud_params.color_ambient);
 		lua_pop(L, 1);
+		lua_getfield(L, 2, "shadow");
+		if (!lua_isnil(L, -1))
+			read_color(L, -1, &cloud_params.color_shadow);
+		lua_pop(L, 1);
 
 		cloud_params.height    = getfloatfield_default(L, 2, "height",    cloud_params.height);
 		cloud_params.thickness = getfloatfield_default(L, 2, "thickness", cloud_params.thickness);
@@ -2389,6 +2393,8 @@ int ObjectRef::l_get_clouds(lua_State *L)
 	lua_setfield(L, -2, "color");
 	push_ARGB8(L, cloud_params.color_ambient);
 	lua_setfield(L, -2, "ambient");
+	push_ARGB8(L, cloud_params.color_shadow);
+	lua_setfield(L, -2, "shadow");
 	lua_pushnumber(L, cloud_params.height);
 	lua_setfield(L, -2, "height");
 	lua_pushnumber(L, cloud_params.thickness);
@@ -2522,6 +2528,9 @@ int ObjectRef::l_set_lighting(lua_State *L)
 
 		getfloatfield(L, -1, "saturation", lighting.saturation);
 
+		lua_getfield(L, -1, "shadow_tint");
+		read_color(L, -1, &lighting.shadow_tint);
+
 		lua_getfield(L, 2, "exposure");
 		if (lua_istable(L, -1)) {
 			lighting.exposure.luminance_min       = getfloatfield_default(L, -1, "luminance_min",       lighting.exposure.luminance_min);
@@ -2563,6 +2572,8 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_setfield(L, -2, "shadows");
 	lua_pushnumber(L, lighting.saturation);
 	lua_setfield(L, -2, "saturation");
+	push_ARGB8(L, lighting.shadow_tint);
+	lua_setfield(L, -2, "shdadow_tint");
 	lua_newtable(L); // "exposure"
 	lua_pushnumber(L, lighting.exposure.luminance_min);
 	lua_setfield(L, -2, "luminance_min");

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1864,7 +1864,7 @@ void Server::SendSetStars(session_t peer_id, const StarParams &params)
 void Server::SendCloudParams(session_t peer_id, const CloudParams &params)
 {
 	NetworkPacket pkt(TOCLIENT_CLOUD_PARAMS, 0, peer_id);
-	pkt << params.density << params.color_bright << params.color_ambient
+	pkt << params.density << params.color_bright << params.color_ambient << params.color_shadow
 			<< params.height << params.thickness << params.speed;
 	Send(&pkt);
 }
@@ -1887,6 +1887,9 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 
 	pkt << lighting.shadow_intensity;
 	pkt << lighting.saturation;
+	pkt << lighting.shadow_tint.getRed();
+	pkt << lighting.shadow_tint.getGreen();
+	pkt << lighting.shadow_tint.getBlue();
 
 	pkt << lighting.exposure.luminance_min
 			<< lighting.exposure.luminance_max

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1864,8 +1864,8 @@ void Server::SendSetStars(session_t peer_id, const StarParams &params)
 void Server::SendCloudParams(session_t peer_id, const CloudParams &params)
 {
 	NetworkPacket pkt(TOCLIENT_CLOUD_PARAMS, 0, peer_id);
-	pkt << params.density << params.color_bright << params.color_ambient << params.color_shadow
-			<< params.height << params.thickness << params.speed;
+	pkt << params.density << params.color_bright << params.color_ambient
+			<< params.height << params.thickness << params.speed << params.color_shadow;
 	Send(&pkt);
 }
 
@@ -1887,9 +1887,6 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 
 	pkt << lighting.shadow_intensity;
 	pkt << lighting.saturation;
-	pkt << lighting.shadow_tint.getRed();
-	pkt << lighting.shadow_tint.getGreen();
-	pkt << lighting.shadow_tint.getBlue();
 
 	pkt << lighting.exposure.luminance_min
 			<< lighting.exposure.luminance_max
@@ -1899,6 +1896,8 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 			<< lighting.exposure.center_weight_power;
 
 	pkt << lighting.volumetric_light_strength;
+
+	pkt << lighting.shadow_tint;
 
 	Send(&pkt);
 }

--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -81,6 +81,7 @@ struct CloudParams
 	float density;
 	video::SColor color_bright;
 	video::SColor color_ambient;
+	video::SColor color_shadow;
 	float thickness;
 	float height;
 	v2f speed;
@@ -160,6 +161,7 @@ public:
 		clouds.density = 0.4f;
 		clouds.color_bright = video::SColor(229, 240, 240, 255);
 		clouds.color_ambient = video::SColor(255, 0, 0, 0);
+		clouds.color_shadow = video::SColor(255, 204, 204, 204);
 		clouds.thickness = 16.0f;
 		clouds.height = 120;
 		clouds.speed = v2f(0.0f, -2.0f);


### PR DESCRIPTION
This PR adds various effects intended to improve the visual experience. This includes changes to the shader code, as well as the engine source code, Lua API and settings.

<details>
<summary>List of Features and Changes</summary>

- Tinted sunlight during dusk and dawn
- Options for warmer artificial light colors
- "soft" clouds look
- Slight overall changes to the post processing shaders
- Crude water reflections (sky and sun) and waves
- Color grading
- Vignette
- Translucent foliage
- Bump maps
- Node "reflections" (just reflections of sunlight)
- Adjusted fog color (more saturated where the fog is lighter)

### Lua API additions
- Cloud parameters: `shadow` field controls the color of the cloud's base
- Lighting: `shadow_tint` controls shadow color
    - default would be black `{ r = 0, g = 0, b = 0}`
    - ambient light from the sky could be emulated by a blue color like `{ r = 0, g = 50, b = 180 }`

### Settings
| Name | Technical Name | Location | Type | Default |
|---|---|---|---|---|
| Tinted sunlight | tinted_sunlight | Graphics>Graphics Effects | bool | false |
| Artificial light color | artificial_light | Graphics>Graphics Effects | enum | "default" |
| Soft clouds | soft_clouds | Graphics>Clouds | bool | false |
| Liquid reflections | enable_water_reflections | Shaders>Waving Nodes | bool | false |
| Color grading | enable_color_grading | Shaders>Post Processing | bool | false |
| Vignette | enable_vignette | Shaders>Post Processing | bool | false |
| Translucent Foliage | enable_translucent_foliage | Shaders>Other Effects | bool | false |
| Bump maps | enable_bump_maps | Shaders>Other Effects | bool | false |
| Node reflections | enable_node_reflections | Shaders>Other Effects | bool | false |
</details>

## To do

This PR is Ready for Review.

## How to test

For most features, simply change the game settings. Of course, the game you use should support dynamic shadows and volumetrics.
The added Lua properties can be used like so:
```Lua
player:set_clouds({shadow = { r = 120, g = 160, b = 240 }})
player:set_lighting({shadow_tint = { r = 0, g = 50, b = 180 }})
```
