### PR TITLE
Keep empty servers at bottom of list

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -490,6 +490,9 @@ end
 
 
 function table.insert_all(t, other)
+	if table.move then -- LuaJIT
+		return table.move(other, 1, #other, #t + 1, t)
+	end
 	for i=1, #other do
 		t[#t + 1] = other[i]
 	end


### PR DESCRIPTION
fixes #14504

## To do

This PR is Ready for Review.

## How to test

1. edit `cache/common.conf` to say `geoip = OC`
2. view online tab in main menu
3. list should visibly *not* be sorted by player count
4. all empty servers should be reliably at the bottom
