### PR TITLE
Fix two common causes of "app isn't responding"

### DIFF
--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -83,7 +83,7 @@ bool ClientMediaDownloader::loadMedia(Client *client, const std::string &data,
 
 void ClientMediaDownloader::addFile(const std::string &name, const std::string &sha1)
 {
-	assert(!m_initial_step_done); // pre-condition
+	assert(!m_setup_done); // pre-condition
 
 	// if name was already announced, ignore the new announcement
 	if (m_files.count(name) != 0) {
@@ -118,7 +118,7 @@ void ClientMediaDownloader::addFile(const std::string &name, const std::string &
 
 void ClientMediaDownloader::addRemoteServer(const std::string &baseurl)
 {
-	assert(!m_initial_step_done);	// pre-condition
+	assert(!m_setup_done);	// pre-condition
 
 #ifdef USE_CURL
 
@@ -144,8 +144,8 @@ void ClientMediaDownloader::addRemoteServer(const std::string &baseurl)
 void ClientMediaDownloader::step(Client *client)
 {
 	if (!m_initial_step_done) {
-		initialStep(client);
-		m_initial_step_done = true;
+		m_initial_step_done = initialStep(client);
+		return;
 	}
 
 	// Remote media: check for completion of fetches
@@ -182,18 +182,40 @@ void ClientMediaDownloader::step(Client *client)
 	}
 }
 
-void ClientMediaDownloader::initialStep(Client *client)
+// Returns true if the initial step was completed, false if initialStep should
+// be called again next time.
+bool ClientMediaDownloader::initialStep(Client *client)
 {
+	u64 start_time = porting::getTimeMs();
+
 	// Check media cache
-	m_uncached_count = m_files.size();
-	for (auto &file_it : m_files) {
-		const std::string &name = file_it.first;
-		FileStatus *filestatus = file_it.second;
+	FileStatusMap::iterator it;
+	if (!m_setup_done) {
+		m_uncached_count = m_files.size();
+		it = m_files.begin();
+		m_setup_done = true;
+	} else {
+		it = m_file_iterator;
+	}
+
+	for (; it != m_files.end(); ++it) {
+		const std::string &name = it->first;
+		FileStatus *filestatus = it->second;
 		const std::string &sha1 = filestatus->sha1;
 
 		if (tryLoadFromCache(name, sha1, client)) {
 			filestatus->received = true;
 			m_uncached_count--;
+		}
+
+		// We load cached media in chunks to avoid freezing the window.
+		// However, this can actually make loading of cached media slower.
+		// The chunk_time_ms value has been chosen as a tradeoff between keeping
+		// the window somewhat responsive and avoiding a slowdown in media loading.
+		const u64 chunk_time_ms = 66;
+		if (porting::getDeltaMs(start_time, porting::getTimeMs()) >= chunk_time_ms) {
+			m_file_iterator = ++it;
+			return false;
 		}
 	}
 
@@ -274,6 +296,8 @@ void ClientMediaDownloader::initialStep(Client *client)
 			m_outstanding_hash_sets++;
 		}
 	}
+
+	return true;
 }
 
 void ClientMediaDownloader::remoteHashSetReceived(

--- a/src/client/clientmedia.h
+++ b/src/client/clientmedia.h
@@ -111,11 +111,11 @@ public:
 	}
 
 	bool isStarted() const override {
-		return m_initial_step_done;
+		return m_setup_done;
 	}
 
 	bool isDone() const override {
-		return m_initial_step_done &&
+		return m_setup_done && m_initial_step_done &&
 			m_uncached_received_count == m_uncached_count;
 	}
 
@@ -147,7 +147,8 @@ private:
 		s32 active_count;
 	};
 
-	void initialStep(Client *client);
+	void setup();
+	bool initialStep(Client *client);
 	void remoteHashSetReceived(const HTTPFetchResult &fetch_result);
 	void remoteMediaReceived(const HTTPFetchResult &fetch_result,
 			Client *client);
@@ -160,13 +161,16 @@ private:
 	std::string serializeRequiredHashSet();
 
 	// Maps filename to file status
-	std::map<std::string, FileStatus*> m_files;
+	using FileStatusMap = std::map<std::string, FileStatus*>;
+	FileStatusMap m_files;
 
 	// Array of remote media servers
 	std::vector<RemoteServerStatus*> m_remotes;
 
 	// Has an attempt been made to load media files from the file cache?
 	// Have hash sets been requested from remote servers?
+	bool m_setup_done = false;
+	FileStatusMap::iterator m_file_iterator;
 	bool m_initial_step_done = false;
 
 	// Total number of media files to load

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1381,6 +1381,8 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 			false, nullptr, error_message);
 	server->start();
 
+	input->clear();
+
 	FpsControl fps_control;
 	f32 dtime;
 	fps_control.reset();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1381,6 +1381,21 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 			false, nullptr, error_message);
 	server->start();
 
+	FpsControl fps_control;
+	f32 dtime;
+	fps_control.reset();
+
+	while (!server->isInitialized()) {
+		if (!m_rendering_engine->run())
+			return false;
+		if (input->cancelPressed())
+			return false;
+
+		fps_control.limit(device, &dtime);
+		showOverlayMessage(N_("Creating server..."), dtime, 5);
+	}
+
+	// TODO: This is IO on the main thread, can we move it to the server thread?
 	copyServerClientCache();
 
 	return true;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -103,6 +103,8 @@ void *ServerThread::run()
 {
 	BEGIN_DEBUG_EXCEPTION_HANDLER
 
+	m_server->initialize();
+
 	/*
 	 * The real business of the server happens on the ServerThread.
 	 * How this works:
@@ -417,8 +419,10 @@ Server::~Server()
 	}
 }
 
-void Server::init()
+void Server::initialize()
 {
+	sanity_check(!m_initialized);
+
 	infostream << "Server created for gameid \"" << m_gamespec.id << "\"";
 	if (m_simple_singleplayer_mode)
 		infostream << " in simple singleplayer mode" << std::endl;
@@ -542,24 +546,6 @@ void Server::init()
 	m_max_chatmessage_length = g_settings->getU16("chat_message_max_size");
 	m_csm_restriction_flags = g_settings->getU64("csm_restriction_flags");
 	m_csm_restriction_noderange = g_settings->getU32("csm_restriction_noderange");
-}
-
-void Server::start()
-{
-	init();
-
-	infostream << "Starting server on " << m_bind_addr.serializeString()
-			<< "..." << std::endl;
-
-	// Stop thread if already running
-	m_thread->stop();
-
-	// Initialize connection
-	m_con->SetTimeoutMs(30);
-	m_con->Serve(m_bind_addr);
-
-	// Start thread
-	m_thread->start();
 
 	// ASCII art for the win!
 	const char *art[] = {
@@ -583,6 +569,24 @@ void Server::start()
 			<< "\" listening on ";
 	m_bind_addr.print(actionstream);
 	actionstream << "." << std::endl;
+
+	m_initialized = true;
+}
+
+void Server::start()
+{
+	infostream << "Starting server on " << m_bind_addr.serializeString()
+			<< "..." << std::endl;
+
+	// Stop thread if already running
+	m_thread->stop();
+
+	// Initialize connection
+	m_con->SetTimeoutMs(30);
+	m_con->Serve(m_bind_addr);
+
+	// Start thread
+	m_thread->start();
 }
 
 void Server::stop()
@@ -612,6 +616,8 @@ void Server::step()
 
 void Server::AsyncRunStep(float dtime, bool initial_step)
 {
+	sanity_check(m_initialized);
+
 	{
 		// Send blocks to clients
 		SendBlocks(dtime);

--- a/src/server.h
+++ b/src/server.h
@@ -166,6 +166,9 @@ public:
 	// Actual processing is done in another thread.
 	// This just checks if there was an error in that thread.
 	void step();
+	// This is run by ServerThread
+	void initialize();
+	bool isInitialized() const { return m_initialized; }
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(float dtime, bool initial_step = false);
 	void Receive(float timeout);
@@ -482,8 +485,6 @@ private:
 
 	typedef std::unordered_map<std::pair<v3s16, u16>, std::string, SBCHash> SerializedBlockCache;
 
-	void init();
-
 	void SendMovement(session_t peer_id);
 	void SendHP(session_t peer_id, u16 hp, bool effect);
 	void SendBreath(session_t peer_id, u16 breath);
@@ -665,6 +666,7 @@ private:
 	/*
 		Threads
 	*/
+	std::atomic<bool> m_initialized = false;
 	// Set by Game
 	std::atomic<StepSettings> m_step_settings{{0.1f, false}};
 


### PR DESCRIPTION
- Server startup blocks the main thread.  
    -> Solution: Server startup has been moved to the server thread.

- Loading of cached media blocks the main thread because all cached media is loaded at once.  
    -> Solution: Loading of cached media is now done in chunks.  
    (Loading of non-cached media is already unproblematic.)

See #14440

## To do

This PR is a Ready for Review.

Note: I have only tested this on Linux so far. It still needs to be tested on Android.

## How to test

Start a singleplayer session with a heavy game (e.g. MeseCraft or MineClone 2). Verify that the main thread is not blocked in the "Creating server..." and "Media..." phases, e.g. by resizing the window, pressing ESC, trying to close the window, ...