### PR TITLE
Print filenames in irrlicht png warnings

### DIFF
--- a/irr/src/CImageLoaderPNG.cpp
+++ b/irr/src/CImageLoaderPNG.cpp
@@ -19,8 +19,8 @@ namespace video
 static void png_cpexcept_error(png_structp png_ptr, png_const_charp msg)
 {
 	io::IReadFile *file = reinterpret_cast<io::IReadFile *>(png_get_error_ptr(png_ptr));
-	core::stringc logmsg = core::stringc("PNG fatal error for ") + file->getFileName()
-			+ ": " + msg;
+	std::string logmsg = std::string("PNG fatal error for ")
+			+ file->getFileName().c_str() + ": " + msg;
 	os::Printer::log(logmsg.c_str(), ELL_ERROR);
 	longjmp(png_jmpbuf(png_ptr), 1);
 }
@@ -29,8 +29,8 @@ static void png_cpexcept_error(png_structp png_ptr, png_const_charp msg)
 static void png_cpexcept_warn(png_structp png_ptr, png_const_charp msg)
 {
 	io::IReadFile *file = reinterpret_cast<io::IReadFile *>(png_get_error_ptr(png_ptr));
-	core::stringc logmsg = core::stringc("PNG warning for ") + file->getFileName()
-			+ ": " + msg;
+	std::string logmsg = std::string("PNG warning for ")
+			+ file->getFileName().c_str() + ": " + msg;
 	os::Printer::log(logmsg.c_str(), ELL_WARNING);
 }
 

--- a/irr/src/CImageLoaderPNG.cpp
+++ b/irr/src/CImageLoaderPNG.cpp
@@ -18,14 +18,20 @@ namespace video
 // PNG function for error handling
 static void png_cpexcept_error(png_structp png_ptr, png_const_charp msg)
 {
-	os::Printer::log("PNG fatal error", msg, ELL_ERROR);
+	io::IReadFile *file = reinterpret_cast<io::IReadFile *>(png_get_error_ptr(png_ptr));
+	core::stringc logmsg = core::stringc("PNG fatal error for ") + file->getFileName()
+			+ ": " + msg;
+	os::Printer::log(logmsg.c_str(), ELL_ERROR);
 	longjmp(png_jmpbuf(png_ptr), 1);
 }
 
 // PNG function for warning handling
 static void png_cpexcept_warn(png_structp png_ptr, png_const_charp msg)
 {
-	os::Printer::log("PNG warning", msg, ELL_WARNING);
+	io::IReadFile *file = reinterpret_cast<io::IReadFile *>(png_get_error_ptr(png_ptr));
+	core::stringc logmsg = core::stringc("PNG warning for ") + file->getFileName()
+			+ ": " + msg;
+	os::Printer::log(logmsg.c_str(), ELL_WARNING);
 }
 
 // PNG function for file reading
@@ -88,7 +94,7 @@ IImage *CImageLoaderPng::loadImage(io::IReadFile *file) const
 
 	// Allocate the png read struct
 	png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING,
-			NULL, (png_error_ptr)png_cpexcept_error, (png_error_ptr)png_cpexcept_warn);
+			file, (png_error_ptr)png_cpexcept_error, (png_error_ptr)png_cpexcept_warn);
 	if (!png_ptr) {
 		os::Printer::log("LOAD PNG: Internal PNG create read struct failure", file->getFileName(), ELL_ERROR);
 		return 0;

--- a/irr/src/CImageWriterPNG.cpp
+++ b/irr/src/CImageWriterPNG.cpp
@@ -25,14 +25,20 @@ IImageWriter *createImageWriterPNG()
 // PNG function for error handling
 static void png_cpexcept_error(png_structp png_ptr, png_const_charp msg)
 {
-	os::Printer::log("PNG fatal error", msg, ELL_ERROR);
+	io::IWriteFile *file = reinterpret_cast<io::IWriteFile *>(png_get_error_ptr(png_ptr));
+	core::stringc logmsg = core::stringc("PNG fatal error for ") + file->getFileName()
+			+ ": " + msg;
+	os::Printer::log(logmsg.c_str(), ELL_ERROR);
 	longjmp(png_jmpbuf(png_ptr), 1);
 }
 
 // PNG function for warning handling
 static void png_cpexcept_warning(png_structp png_ptr, png_const_charp msg)
 {
-	os::Printer::log("PNG warning", msg, ELL_WARNING);
+	io::IWriteFile *file = reinterpret_cast<io::IWriteFile *>(png_get_error_ptr(png_ptr));
+	core::stringc logmsg = core::stringc("PNG warning for ") + file->getFileName()
+			+ ": " + msg;
+	os::Printer::log(logmsg.c_str(), ELL_WARNING);
 }
 
 // PNG function for file writing
@@ -66,7 +72,7 @@ bool CImageWriterPNG::writeImage(io::IWriteFile *file, IImage *image, u32 param)
 
 	// Allocate the png write struct
 	png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING,
-			NULL, (png_error_ptr)png_cpexcept_error, (png_error_ptr)png_cpexcept_warning);
+			file, (png_error_ptr)png_cpexcept_error, (png_error_ptr)png_cpexcept_warning);
 	if (!png_ptr) {
 		os::Printer::log("PNGWriter: Internal PNG create write struct failure", file->getFileName(), ELL_ERROR);
 		return false;

--- a/irr/src/CImageWriterPNG.cpp
+++ b/irr/src/CImageWriterPNG.cpp
@@ -26,8 +26,8 @@ IImageWriter *createImageWriterPNG()
 static void png_cpexcept_error(png_structp png_ptr, png_const_charp msg)
 {
 	io::IWriteFile *file = reinterpret_cast<io::IWriteFile *>(png_get_error_ptr(png_ptr));
-	core::stringc logmsg = core::stringc("PNG fatal error for ") + file->getFileName()
-			+ ": " + msg;
+	std::string logmsg = std::string("PNG fatal error for ")
+			+ file->getFileName().c_str() + ": " + msg;
 	os::Printer::log(logmsg.c_str(), ELL_ERROR);
 	longjmp(png_jmpbuf(png_ptr), 1);
 }
@@ -36,8 +36,8 @@ static void png_cpexcept_error(png_structp png_ptr, png_const_charp msg)
 static void png_cpexcept_warning(png_structp png_ptr, png_const_charp msg)
 {
 	io::IWriteFile *file = reinterpret_cast<io::IWriteFile *>(png_get_error_ptr(png_ptr));
-	core::stringc logmsg = core::stringc("PNG warning for ") + file->getFileName()
-			+ ": " + msg;
+	std::string logmsg = std::string("PNG warning for ")
+			+ file->getFileName().c_str() + ": " + msg;
 	os::Printer::log(logmsg.c_str(), ELL_WARNING);
 }
 

--- a/irr/src/CNullDriver.cpp
+++ b/irr/src/CNullDriver.cpp
@@ -983,6 +983,11 @@ IImage *CNullDriver::createImageFromFile(io::IReadFile *file)
 			continue;
 
 		file->seek(0); // reset file position which might have changed due to previous loadImage calls
+		// avoid warnings if extension is wrong
+		if (!SurfaceLoader[i]->isALoadableFileFormat(file))
+			continue;
+
+		file->seek(0);
 		if (IImage *image = SurfaceLoader[i]->loadImage(file))
 			return image;
 	}

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -799,7 +799,7 @@ bool Client::loadMedia(const std::string &data, const std::string &filename,
 		video::IVideoDriver *vdrv = m_rendering_engine->get_video_driver();
 
 		io::IReadFile *rfile = irrfs->createMemoryReadFile(
-				data.c_str(), data.size(), "_tempreadfile");
+				data.c_str(), data.size(), filename.c_str());
 
 		FATAL_ERROR_IF(!rfile, "Could not create irrlicht memory file.");
 

--- a/src/client/imagesource.cpp
+++ b/src/client/imagesource.cpp
@@ -1704,7 +1704,7 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 			auto *device = RenderingEngine::get_raw_device();
 			auto *fs = device->getFileSystem();
 			auto *vd = device->getVideoDriver();
-			auto *memfile = fs->createMemoryReadFile(png.data(), png.size(), "__temp_png");
+			auto *memfile = fs->createMemoryReadFile(png.data(), png.size(), "[png_tmpfile");
 			video::IImage* pngimg = vd->createImageFromFile(memfile);
 			memfile->drop();
 


### PR DESCRIPTION
Warnings like these are useless, because you don't know which file causes it:
`WARNING[Main]: Irrlicht: PNG warning: iCCP: known incorrect sRGB profile`
With PR, it looks like this:
`WARNING[Main]: Irrlicht: PNG warning for abriglass_clearglass.png: iCCP: known incorrect sRGB profile`

(libpng docs: <http://www.libpng.org/pub/png/libpng-manual.txt>)

The change in `CNullDriver::createImageFromFile` is needed because the jpg loader complains with an error if the file doesn't have the jpg signature.
`isALoadableFileFormat` only has false negatives in the case of "very old tgas", according to tga loader code comment.
Do we support those?

## To do

This PR is a Ready for Review.

## How to test

* Add mod with a texture that causes a warning, e.g. this old version of abriglass:
  https://github.com/mt-mods/abriglass/blob/2e8968dc0f72952c9d8ace1fed397f5c4e985168/textures/abriglass_clearglass.png
* Start the game.
* Look into warning log.
