### PR TITLE
Fix 4dir nodebox sometimes not rendering face

### DIFF
--- a/games/devtest/mods/testnodes/param2.lua
+++ b/games/devtest/mods/testnodes/param2.lua
@@ -78,6 +78,32 @@ minetest.register_node("testnodes:4dir_nodebox", {
 	groups = {dig_immediate=3},
 })
 
+minetest.register_node("testnodes:4dir_nodebox_stair", {
+	description = S("4dir Nodebox Stair Test Node").."\n"..
+		S("param2 = 4dir rotation (0..3)"),
+	tiles = {
+		"testnodes_1f.png",
+		"testnodes_2f.png",
+		"testnodes_3f.png",
+		"testnodes_4f.png",
+		"testnodes_5f.png",
+		"testnodes_6f.png",
+	},
+	drawtype = "nodebox",
+	paramtype = "light",
+	paramtype2 = "4dir",
+	node_box = {
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, 0, 0.5},
+			{-0.5, 0, 0, 0.5, 0.5, 0.5},
+		},
+	},
+
+	groups = { dig_immediate = 3 },
+})
+
+
 minetest.register_node("testnodes:wallmounted", {
 	description = S("Wallmounted Test Node").."\n"..
 		S("param2 = wallmounted rotation (0..7)"),

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1534,8 +1534,10 @@ void MapblockMeshGenerator::drawNodeboxNode()
 	bool param2_is_rotation =
 			cur_node.f->param_type_2 == CPT2_COLORED_FACEDIR ||
 			cur_node.f->param_type_2 == CPT2_COLORED_WALLMOUNTED ||
+			cur_node.f->param_type_2 == CPT2_COLORED_4DIR ||
 			cur_node.f->param_type_2 == CPT2_FACEDIR ||
-			cur_node.f->param_type_2 == CPT2_WALLMOUNTED;
+			cur_node.f->param_type_2 == CPT2_WALLMOUNTED ||
+			cur_node.f->param_type_2 == CPT2_4DIR;
 
 	bool param2_is_level =
 			cur_node.f->param_type_2 == CPT2_LEVELED;


### PR DESCRIPTION
Fixes #14532. Faces of 4dir nodebox nodes should now correctly render. This PR also adds a test node in DevTest so future regressions can be caught.

## To do

This PR is ready for review.

## How to test

* Give yourself a `testnodes:4dir_nodebox_stair` node in DevTest
* With that node, do the steps to reproduce in #14532 and check if it still happens

No matter how you place or rotate the node, all faces should render correctly.