### PR TITLE
Pin cmake to 3.28 because of regression in 3.29.1

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -97,6 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Workaround for regression, see https://github.com/minetest/minetest/pull/14536
       - name: Pin CMake to 3.28
         uses: lukka/get-cmake@latest
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -97,6 +97,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Pin CMake to 3.28
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.28.0"
+
       - name: Restore from cache and run vcpkg
         uses: lukka/run-vcpkg@v7
         with:


### PR DESCRIPTION
Github recently upgraded CMake from 3.29.0 to 3.29.1 on the Windows runner image: https://github.com/actions/runner-images/releases/tag/win19%2F20240407.1

This version of cmake has a regression, causing vcpkg to produce invalid cmake configs: https://gitlab.kitware.com/cmake/cmake/-/issues/25873

This leads to the SDL2 test failing, because it can't find SDL_version.h

This change pins cmake to 3.28 to fix the build. It is only needed temporarily, because this regression is fixed in cmake 3.29.2.

In order to take effect, the vcpkg cache must also be cleared. This consists of keys starting with "localGitId=" in https://github.com/minetest/minetest/actions/caches. Only the two latest keys need to be cleared.
