### PR TITLE
Gate disabling of fog or camera update behind 'debug' priv

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -381,7 +381,8 @@ crosshair_alpha (Crosshair alpha) int 255 0 255
 
 [**Fog]
 
-#    Whether to fog out the end of the visible area.
+#    Whether to fog out the end of the visible area. This option only works
+#    with the 'debug' privilege.
 enable_fog (Fog) bool true
 
 #    Make fog and sky colors depend on daytime (dawn/sunset) and view direction.
@@ -2507,10 +2508,10 @@ keymap_toggle_chat (Chat toggle key) key KEY_F2
 #    Key for toggling the display of the large chat console.
 keymap_console (Large chat console key) key KEY_F10
 
-#    Key for toggling the display of fog.
-keymap_toggle_force_fog_off (Fog toggle key) key KEY_F3
+#    Key for toggling the display of fog. Only usable with 'debug' privilege.
+keymap_toggle_fog (Fog toggle key) key KEY_F3
 
-#    Key for toggling the camera update. Only used for development
+#    Key for toggling the camera update. Only usable with 'debug' privilege.
 keymap_toggle_update_camera (Camera update toggle key) key
 
 #    Key for toggling the display of debug info.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -818,7 +818,6 @@ protected:
 
 private:
 	struct Flags {
-		bool force_fog_off = false;
 		bool disable_camera_update = false;
 	};
 
@@ -1888,8 +1887,10 @@ void Game::updateDebugState()
 	}
 	if (!has_basic_debug)
 		hud->disableBlockBounds();
-	if (!has_debug)
+	if (!has_debug) {
 		draw_control->show_wireframe = false;
+		m_flags.disable_camera_update = false;
+	}
 
 	// noclip
 	draw_control->allow_noclip = m_cache_enable_noclip && client->checkPrivilege("noclip");
@@ -2454,12 +2455,18 @@ void Game::toggleMinimap(bool shift_pressed)
 
 void Game::toggleFog()
 {
-	bool fog_enabled = g_settings->getBool("enable_fog");
-	g_settings->setBool("enable_fog", !fog_enabled);
-	if (fog_enabled)
-		m_game_ui->showTranslatedStatusText("Fog disabled");
-	else
+	bool flag;
+	// do not modify setting if no privilege
+	if (!client->checkPrivilege("debug")) {
+		flag = true;
+	} else {
+		flag = !g_settings->getBool("enable_fog");
+		g_settings->setBool("enable_fog", flag);
+	}
+	if (flag)
 		m_game_ui->showTranslatedStatusText("Fog enabled");
+	else
+		m_game_ui->showTranslatedStatusText("Fog disabled");
 }
 
 
@@ -2513,8 +2520,9 @@ void Game::toggleDebug()
 
 void Game::toggleUpdateCamera()
 {
-	m_flags.disable_camera_update = !m_flags.disable_camera_update;
-	if (m_flags.disable_camera_update)
+	auto &flag = m_flags.disable_camera_update;
+	flag = client->checkPrivilege("debug") ? !flag : false;
+	if (flag)
 		m_game_ui->showTranslatedStatusText("Camera update disabled");
 	else
 		m_game_ui->showTranslatedStatusText("Camera update enabled");
@@ -4210,7 +4218,8 @@ void Game::updateClouds(float dtime)
 		camera_node_position.Y   = camera_node_position.Y + camera_offset.Y * BS;
 		camera_node_position.Z   = camera_node_position.Z + camera_offset.Z * BS;
 		this->clouds->update(camera_node_position, this->sky->getCloudColor());
-		if (this->clouds->isCameraInsideCloud() && this->m_cache_enable_fog) {
+		bool enable_fog = this->m_cache_enable_fog || !client->checkPrivilege("debug");
+		if (this->clouds->isCameraInsideCloud() && enable_fog) {
 			// If camera is inside cloud and fog is enabled, use cloud's colors as sky colors.
 			video::SColor clouds_dark = this->clouds->getColor().getInterpolated(
 					video::SColor(255, 0, 0, 0), 0.9);
@@ -4270,7 +4279,7 @@ void Game::drawScene(ProfilerGraph *graph, RunStats *stats)
 	/*
 		Fog
 	*/
-	if (this->m_cache_enable_fog) {
+	if (this->m_cache_enable_fog || !client->checkPrivilege("debug")) {
 		this->driver->setFog(
 				fog_color,
 				video::EFT_FOG_LINEAR,

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -113,10 +113,11 @@ void set_default_settings()
 	settings->setDefault("keymap_toggle_block_bounds", "");
 	settings->setDefault("keymap_toggle_hud", "KEY_F1");
 	settings->setDefault("keymap_toggle_chat", "KEY_F2");
-	settings->setDefault("keymap_toggle_fog", "KEY_F3");
 #ifndef NDEBUG
+	settings->setDefault("keymap_toggle_fog", "KEY_F3");
 	settings->setDefault("keymap_toggle_update_camera", "KEY_F4");
 #else
+	settings->setDefault("keymap_toggle_fog", "");
 	settings->setDefault("keymap_toggle_update_camera", "");
 #endif
 	settings->setDefault("keymap_toggle_debug", "KEY_F5");


### PR DESCRIPTION
fixes #14163

"camera update" stops updating the render list depending on the camera position, which allows you to see through block edges (and sometimes the world disappears entirely). This is basically a wallhack.

also unbinds both keys by default