### PR TITLE
Allow quoting hypertext attribute values

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3538,7 +3538,7 @@ Tags can have attributes, in that case, attributes are in the opening tag in
 form of a key/value separated with equal signs.
 Attribute values should be quoted using either " or '.
 
-If you want to insert a literal greater-than sign or a backslash into the text,
+If you want to insert a literal greater-than, less-than, or a backslash into the text,
 you must escape it by preceding it with a backslash. In a quoted attribute value, you
 can insert a literal quote mark by preceding it with a backslash.
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3535,10 +3535,12 @@ Markup language used in `hypertext[]` elements uses tags that look like HTML tag
 The markup language is currently unstable and subject to change. Use with caution.
 Some tags can enclose text, they open with `<tagname>` and close with `</tagname>`.
 Tags can have attributes, in that case, attributes are in the opening tag in
-form of a key/value separated with equal signs. Attribute values should not be quoted.
+form of a key/value separated with equal signs.
+Attribute values should be quoted using either " or '.
 
 If you want to insert a literal greater-than sign or a backslash into the text,
-you must escape it by preceding it with a backslash.
+you must escape it by preceding it with a backslash. In a quoted attribute value, you
+can insert a literal quote mark by preceding it with a backslash.
 
 These are the technically basic tags but see below for usual tags. Base tags are:
 

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -69,9 +69,9 @@ local hypertext_basic = [[A hypertext element
 This is a normal text.
 
 <bigger><mono>style</mono> test</bigger>
-<style color=#FFFF00>Yellow text.</style> <style color=#FF0000>Red text.</style>
-<style size=24>Size 24.</style> <style size=16>Size 16</style>. <style size=12>Size 12.</style>
-<style font=normal>Normal font.</style> <style font=mono>Mono font.</style>
+<style color="#FFFF00">Yellow text.</style> <style color='#FF0000'>Red text.</style>
+<style size="24">Size 24.</style> <style size=16>Size 16</style>. <style size=12>Size 12.</style>
+<style font="normal">Normal font.</style> <style font=mono>Mono font.</style>
 
 <bigger>Tag test</bigger>
 <normal>normal</normal>
@@ -88,20 +88,20 @@ This is a normal text.
 
 <bigger>Custom tag test</bigger>
 <tag name=t_green color=green>
-<tag name=t_hover hovercolor=yellow>
-<tag name=t_size size=24>
-<tag name=t_mono font=mono>
-<tag name=t_multi color=green font=mono size=24>
+<tag name="t_hover" hovercolor=yellow>
+<tag name="t_size" size=24>
+<tag name="t_mono" font=mono>
+<tag name="t_multi" color=green font=mono size=24>
 <t_green>color=green</t_green>
-Action: <action name=color><t_green>color=green</t_green></action>
-Action: <action name=hovercolor><t_hover>hovercolor=yellow</t_hover></action>
-Action URL: <action name=open url=https://example.com/?a=b#c>open URL</action>
+Action: <action name="color"><t_green>color=green</t_green></action>
+Action: <action name="hovercolor"><t_hover>hovercolor=yellow</t_hover></action>
+Action URL: <action name="open" url="https://example.com/?a=b#c">open URL</action>
 <t_size>size=24</t_size>
 <t_mono>font=mono</t_mono>
 <t_multi>color=green font=mono size=24</t_multi>
 
 <bigger><mono>action</mono> test</bigger>
-<action name=action_test>action</action>
+<action name="action_test">action</action>
 
 <bigger><mono>img</mono> test</bigger>
 Normal:

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -421,7 +421,7 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 	AttrsList attrs;
 	while (c != L'>') {
 		std::string attr_name = "";
-		core::stringw attr_val = L"";
+		std::wstring attr_val = L"";
 
 		// Consume whitespace
 		while (c == ' ') {
@@ -453,7 +453,7 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 			return 0;
 
 		// Read optional quote
-		wchar_t quote_used;
+		wchar_t quote_used = 0;
 		if (c == L'"' || c == L'\'') {
 			quote_used = c;
 			c = text[++cursor];
@@ -482,7 +482,7 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 			c = text[++cursor];
 		}
 
-		attrs[attr_name] = stringw_to_utf8(attr_val);
+		attrs[attr_name] = wide_to_utf8(attr_val);
 	}
 
 	++cursor; // Last ">"

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -464,7 +464,7 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 		// Read attribute value
 		bool escape = false;
 		while (escape || (quote_used && c != quote_used) || (!quote_used && c != L'>' && c != L' ')) {
-			if (!escape && c == L'\\') {
+			if (quote_used && !escape && c == L'\\') {
 				escape = true;
 			} else {
 				escape = false;


### PR DESCRIPTION
Hypertext markup attributes cannot contain spaces currently. This is a huge limitation, especially when showing images in the main menu - if the path to the image contains a space then it cannot be shown in current `master`.

This PR allows quoting hypertext attribute values, like in HTML.

## To do

This PR is Ready for Review.

Should we deprecate unquoted attribute values? Or should we immediately remove support for unquoted attributes as hypertext is experimental? HTML supports unquoted attribute values

## How to test

* Checkout the ContentDB redesign. Build/install minetest on a path with space.
* Open NodeCore in the CDB dialog, see broken img tags
* Apply this PR and the following patch. The img tags should now work

```lua.patch
diff --git a/builtin/mainmenu/content/dlg_package.lua b/builtin/mainmenu/content/dlg_package.lua
index ed1ab97ff..63b59a0cf 100644
--- a/builtin/mainmenu/content/dlg_package.lua
+++ b/builtin/mainmenu/content/dlg_package.lua
@@ -165,11 +165,11 @@ local function get_formspec(data)
                        local fs_to_px = winfo.size.x / winfo.max_formspec_size.x
                        for i, ss in ipairs(info.screenshots) do
                                local path = get_screenshot(data.package, ss.url, 2)
-                               hypertext = hypertext .. "<action name=ss_" .. i .. "><img name=" ..
-                                               core.hypertext_escape(path) .. " width=" .. (3 * fs_to_px) ..
+                               hypertext = hypertext .. "<action name=ss_" .. i .. "><img name=\"" ..
+                                               core.hypertext_escape(path) .. "\" width=" .. (3 * fs_to_px) ..
                                                " height=" .. (2 * fs_to_px) .. "></action>"
                                if i ~= #info.screenshots then
-                                       hypertext = hypertext .. "<img name=blank.png width=" .. (0.25 * fs_to_px) ..
+                                       hypertext = hypertext .. "<img name=\"blank.png\" width=" .. (0.25 * fs_to_px) ..
                                                        " height=" .. (2.25 * fs_to_px).. ">"
                                end
                        end
@@ -177,7 +177,7 @@ local function get_formspec(data)
                                        info.long_description.body
 
                        hypertext = hypertext:gsub("<img name=blank.png ",
-                                       "<img name=" .. core.hypertext_escape(defaulttexturedir) .. "blank.png ")
+                                       "<img name=\"" .. core.hypertext_escape(defaulttexturedir) .. "blank.png\" ")
 
                        table.insert_all(formspec, {
                                "hypertext[0.375,0;",
```
