### PR TITLE
Hypertext: Fix missing space after single letter word

### DIFF
--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -64,7 +64,7 @@ local inv_style_fs = [[
 	list[current_player;main;.5,7;8,4]
 ]]
 
-local hypertext_basic = [[
+local hypertext_basic = [[A hypertext element
 <bigger>Normal test</bigger>
 This is a normal text.
 

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -293,8 +293,8 @@ void ParsedText::pushChar(wchar_t c)
 		else
 			return;
 	} else {
-		m_empty_paragraph = false;
 		enterElement(ELEMENT_TEXT);
+		m_empty_paragraph = false;
 	}
 	m_element->text += c;
 }


### PR DESCRIPTION
Fixes #11727

Before:

![image](https://github.com/minetest/minetest/assets/2122943/84eeac2d-f5d6-41d1-8d92-e525c6058dd0)

After:

![image](https://github.com/minetest/minetest/assets/2122943/994802ce-c8c6-441e-8207-dc6e1df8794d)

## To do

This PR is Ready for Review.

## How to test

See /test_formspec hypertext tab