### PR TITLE
HUD: Text element color support

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1719,6 +1719,8 @@ Displays text on the HUD.
 * `scale`: Defines the bounding rectangle of the text.
   A value such as `{x=100, y=100}` should work.
 * `text`: The text to be displayed in the HUD element.
+  Supports `minetest.translate` (always)
+  and `minetest.colorize` (since protocol version 44)
 * `number`: An integer containing the RGB value of the color used to draw the
   text. Specify `0xFFFFFF` for white text, `0xFF0000` for red, and so on.
 * `alignment`: The alignment of the text.

--- a/games/devtest/mods/testhud/init.lua
+++ b/games/devtest/mods/testhud/init.lua
@@ -8,6 +8,8 @@ local font_states = {
 	{4, "Monospace font"},
 	{5, "Bold and monospace font"},
 	{7, "ZOMG all the font styles"},
+	{7, "Colors test! " .. minetest.colorize("green", "Green") ..
+		minetest.colorize("red", "\nRed") .. " END"},
 }
 
 

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -40,6 +40,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/renderingengine.h"
 #include "client/minimap.h"
 #include "gui/touchscreengui.h"
+#include "util/enriched_string.h"
+#include "irrlicht_changes/CGUITTFont.h"
 
 #define OBJECT_CROSSHAIR_LINE_SIZE 8
 #define CROSSHAIR_LINE_SIZE 10
@@ -377,10 +379,14 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 					(e->style & HUD_STYLE_MONO) ? FM_Mono : FM_Unspecified,
 					e->style & HUD_STYLE_BOLD, e->style & HUD_STYLE_ITALIC));
 
+				irr::gui::CGUITTFont *ttfont = nullptr;
+				if (textfont->getType() == irr::gui::EGFT_CUSTOM)
+					ttfont = static_cast<irr::gui::CGUITTFont *>(textfont);
+
 				video::SColor color(255, (e->number >> 16) & 0xFF,
 										 (e->number >> 8)  & 0xFF,
 										 (e->number >> 0)  & 0xFF);
-				std::wstring text = unescape_translate(utf8_to_wide(e->text));
+				EnrichedString text(unescape_string(utf8_to_wide(e->text)), color);
 				core::dimension2d<u32> textsize = textfont->getDimension(text.c_str());
 
 				v2s32 offset(0, (e->align.Y - 1.0) * (textsize.Height / 2));
@@ -388,13 +394,19 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 						text_height * e->scale.Y * m_scale_factor);
 				v2s32 offs(e->offset.X * m_scale_factor,
 						e->offset.Y * m_scale_factor);
-				std::wstringstream wss(text);
-				std::wstring line;
-				while (std::getline(wss, line, L'\n'))
-				{
+
+				// Draw each line
+				// See also: GUIFormSpecMenu::parseLabel
+				size_t str_pos = 0;
+				while (str_pos < text.size()) {
+					EnrichedString line = text.getNextLine(&str_pos);
+
 					core::dimension2d<u32> linesize = textfont->getDimension(line.c_str());
 					v2s32 line_offset((e->align.X - 1.0) * (linesize.Width / 2), 0);
-					textfont->draw(line.c_str(), size + pos + offset + offs + line_offset, color);
+					if (ttfont)
+						ttfont->draw(line, size + pos + offset + offs + line_offset);
+					else
+						textfont->draw(line.c_str(), size + pos + offset + offs + line_offset, color);
 					offset.Y += linesize.Height;
 				}
 				break; }

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1771,12 +1771,7 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 	size_t str_pos = 0;
 
 	for (size_t i = 0; str_pos < str.size(); ++i) {
-		// Split per line
-		size_t str_nl = str.getString().find(L'\n', str_pos);
-		if (str_nl == std::wstring::npos)
-			str_nl = str.getString().size();
-		EnrichedString line = str.substr(str_pos, str_nl - str_pos);
-		str_pos += line.size() + 1;
+		EnrichedString line = str.getNextLine(&str_pos);
 
 		core::rect<s32> rect;
 

--- a/src/util/enriched_string.cpp
+++ b/src/util/enriched_string.cpp
@@ -166,6 +166,21 @@ void EnrichedString::operator+=(const EnrichedString &other)
 	}
 }
 
+EnrichedString EnrichedString::getNextLine(size_t *pos) const
+{
+	size_t str_pos = *pos;
+
+	// Split per line
+	size_t str_nl = getString().find(L'\n', str_pos);
+	if (str_nl == std::wstring::npos)
+		str_nl = getString().size();
+	EnrichedString line = substr(str_pos, str_nl - str_pos);
+	str_pos += line.size() + 1;
+
+	*pos = str_pos;
+	return line;
+}
+
 EnrichedString EnrichedString::substr(size_t pos, size_t len) const
 {
 	if (pos >= m_string.length())

--- a/src/util/enriched_string.h
+++ b/src/util/enriched_string.h
@@ -49,6 +49,7 @@ public:
 	// color. The color used will be the one from the last character.
 	void addCharNoColor(wchar_t c);
 
+	EnrichedString getNextLine(size_t *pos) const;
 	EnrichedString substr(size_t pos = 0, size_t len = std::string::npos) const;
 	EnrichedString operator+(const EnrichedString &other) const;
 	void operator+=(const EnrichedString &other);


### PR DESCRIPTION
Fixes #14552

## To do

This PR is Ready for Review.

## How to test

1. devtest
2. `/hudfonts`
3. Wait for the last entry. Expected result:
![color test result example](https://github.com/minetest/minetest/assets/1497498/8683a9f3-09a6-40f2-a7c2-9c0a2e411d44)

