### PR TITLE
Fix some Game members not being freed after some startup errors (regression)

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -173,8 +173,9 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 		m_rendering_engine->get_raw_device()->
 			setWindowCaption(utf8_to_wide(caption).c_str());
 
-		try {	// This is used for catching disconnects
-
+#ifdef NDEBUG
+		try {
+#endif
 			m_rendering_engine->get_gui_env()->clear();
 
 			/*
@@ -215,18 +216,8 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 				chat_backend,
 				&reconnect_requested
 			);
-		} //try
-		catch (con::PeerNotFoundException &e) {
-			error_message = gettext("Connection error (timed out?)");
-			errorstream << error_message << std::endl;
-		}
-		catch (ShaderException &e) {
-			error_message = e.what();
-			errorstream << error_message << std::endl;
-		}
-
 #ifdef NDEBUG
-		catch (std::exception &e) {
+		} catch (std::exception &e) {
 			error_message = "Some exception: ";
 			error_message.append(debug_describe_exc(e));
 			errorstream << error_message << std::endl;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4558,6 +4558,10 @@ void the_game(bool *kill,
 		error_message = std::string("ModError: ") + e.what() +
 				strgettext("\nCheck debug.txt for details.");
 		errorstream << error_message << std::endl;
+	} catch (...) {
+		// Game::shutdown must always be called.
+		game.shutdown();
+		throw;
 	}
 	game.shutdown();
 }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4558,10 +4558,6 @@ void the_game(bool *kill,
 		error_message = std::string("ModError: ") + e.what() +
 				strgettext("\nCheck debug.txt for details.");
 		errorstream << error_message << std::endl;
-	} catch (...) {
-		// Game::shutdown must always be called.
-		game.shutdown();
-		throw;
 	}
 	game.shutdown();
 }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1015,6 +1015,12 @@ Game::Game() :
 
 Game::~Game()
 {
+	delete client;
+	delete soundmaker;
+	sound_manager.reset();
+
+	delete server;
+
 	delete hud;
 	delete camera;
 	delete quicktune;
@@ -1265,11 +1271,14 @@ void Game::shutdown()
 	}
 
 	delete client;
+	client = nullptr;
 	delete soundmaker;
+	soundmaker = nullptr;
 	sound_manager.reset();
 
 	auto stop_thread = runInThread([=] {
 		delete server;
+		server = nullptr;
 	}, "ServerStop");
 
 	FpsControl fps_control;
@@ -4558,6 +4567,13 @@ void the_game(bool *kill,
 		error_message = std::string("ModError: ") + e.what() +
 				strgettext("\nCheck debug.txt for details.");
 		errorstream << error_message << std::endl;
+	} catch (con::PeerNotFoundException &e) {
+		error_message = gettext("Connection error (timed out?)");
+		errorstream << error_message << std::endl;
+	} catch (ShaderException &e) {
+		error_message = e.what();
+		errorstream << error_message << std::endl;
 	}
+
 	game.shutdown();
 }


### PR DESCRIPTION
This PR fixes a regression from fd8e02195ea1c44f93a18f18e1e850c71ff0d33b. In that commit, I moved some freeing from `Game::~Game` to `Game::shutdown`. Now I realize that `Game::shutdown` isn't called in all cases, for example when a shader compilation error occurs.

Behavior in case of a shader compilation error:

| Version                                                       | Behavior                                                                                                                         |
| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
| master with fd8e02195ea1c44f93a18f18e1e850c71ff0d33b reverted | Loading screen freezes for 5 seconds in "Initializing nodes..." phase while server shuts down. Shader error is shown afterwards. |
| master                                                        | Shader error is shown immediately. Server is not shut down and can be joined using a second client.                              |
| this PR                                                            | "Shutting down..." screen is shown for 5 seconds without freezing while server shuts down. Shader error is shown afterwards.      |

This PR works by always calling `Game::shutdown`. Somewhat related old PR: #9742

## To do

This PR is a Ready for Review.

Notes:

 - I think the stuff I moved from `Game::~Game` to `Game::shutdown` could actually be moved back. However, that would mean spawning a thread (StopThread) and rendering the shutdown screen in a destructor, which feels bad. What if one of these things throws an exception? Would this be a better solution?

 - Could always calling `Game::shutdown` introduce new bugs?

## How to test

Edit shaders to make shader compilation fail. Add this code to `builtin/game/init.lua`:

```lua
minetest.register_on_shutdown(function()
	print("wa wa wa waiting")
	local t = os.time() + 5
	while os.time() < t do
	end
	print("finished waiting")
end)
```

Verify that the behavior of different versions matches what I describe in the table above.
