### PR TITLE
Do not link /latomic on MSVC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -321,11 +321,13 @@ endif()
 # Note that find_library does not reliably find it so we have to resort to this.
 # Also, passing -latomic is not always the same as adding atomic to the library list.
 include(CheckCSourceCompiles)
-set(CMAKE_REQUIRED_LIBRARIES "-latomic")
-check_c_source_compiles("int main(){}" HAVE_LINK_ATOMIC)
-set(CMAKE_REQUIRED_LIBRARIES "")
-if(HAVE_LINK_ATOMIC)
-	set(PLATFORM_LIBS ${PLATFORM_LIBS} "-latomic")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GCC")
+	set(CMAKE_REQUIRED_LIBRARIES "-latomic")
+	check_c_source_compiles("int main(){}" HAVE_LINK_ATOMIC)
+	set(CMAKE_REQUIRED_LIBRARIES "")
+	if(HAVE_LINK_ATOMIC)
+		set(PLATFORM_LIBS ${PLATFORM_LIBS} "-latomic")
+	endif()
 endif()
 
 include(CheckSymbolExists)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -321,7 +321,7 @@ endif()
 # Note that find_library does not reliably find it so we have to resort to this.
 # Also, passing -latomic is not always the same as adding atomic to the library list.
 include(CheckCSourceCompiles)
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GCC")
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 	set(CMAKE_REQUIRED_LIBRARIES "-latomic")
 	check_c_source_compiles("int main(){}" HAVE_LINK_ATOMIC)
 	set(CMAKE_REQUIRED_LIBRARIES "")


### PR DESCRIPTION
MSVC does not recognize /latomic.

## To do
Ready for Review.

## How to test

Compile on MSVC and observe that there is no longer any warning about an unrecognized `/latomic` option.
