### PR TITLE
Remove <ctgmath> include from particles.h

### DIFF
--- a/src/particles.h
+++ b/src/particles.h
@@ -22,7 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <sstream>
 #include <vector>
-#include <ctgmath>
 #include <type_traits>
 #include "irrlicht_changes/printing.h"
 #include "irrlichttypes_bloated.h"


### PR DESCRIPTION
The header is deprecated, and we don't even use it.

## To do

Ready for Review.

## How to test

Check that the code compiles. I went through all the symbols in the `<tgmath.h>` `<complex.h>` and `<cmath>` headers and confirmed that `particles.h` does not use any of them.
