### PR TITLE
Do not make inventory_items_animations setting static thread_local

### DIFF
--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1046,8 +1046,7 @@ void drawItemStack(
 		return;
 	}
 
-	const static thread_local bool enable_animations =
-		g_settings->getBool("inventory_items_animations");
+	const bool enable_animations = g_settings->getBool("inventory_items_animations");
 
 	auto *idef = client->idef();
 	const ItemDefinition &def = item.getDefinition(idef);


### PR DESCRIPTION
**Goal of the PR**
This PR removes restart requirement when toggling the setting after the first play/run.

**How does the PR work?**
This PR removes `static` and `thread_local` from `enable_animations` variable.

**Does it resolve any reported issue?**
This PR tries to fix #13754.

## To do

This PR is Ready for Review.

## How to test

1. Enable `inventory_items_animations`.
2. Play a world/join a server.
3. Check that inventory items are animated.
4. Exit to main menu.
5. Disable `inventory_items_animations`.
6. Play a world/join a server.
7. Check that inventory items are **not** animated.
8. Exit to main menu.
9. Repeat step 1 to 4.