### PR TITLE
Translation updater: Add support for function call without parantheses

### DIFF
--- a/util/mod_translation_updater.py
+++ b/util/mod_translation_updater.py
@@ -133,6 +133,19 @@ pattern_lua_bracketed = re.compile(
 	r'\[\[(.*?)\]\]' # [[ ... ]] string delimiters
 	r'[\s,\)]', # Same as for pattern_lua_quoted
 	re.DOTALL)
+# Handles like pattern_lua_quoted, but for single parameter (without parantheses)
+# See https://www.lua.org/pil/5.html for informations about single argument call
+pattern_lua_quoted_single = re.compile(
+	r'(?:^|[\.=,{\(\s])' # Same as for pattern_lua_quoted
+	r'N?F?S\s*' # Same as for pattern_lua_quoted, but without open parentheses
+	r'(["\'])((?:\\\1|(?:(?!\1)).)*)(\1)', # Quoted string
+	re.DOTALL)
+# Same as pattern_lua_quoted_single, but for [[ ... ]] string delimiters
+pattern_lua_bracketed_single = re.compile(
+	r'(?:^|[\.=,{\(\s])' # Same as for pattern_lua_quoted
+	r'N?F?S\s*' # Same as for pattern_lua_quoted_single
+	r'\[\[(.*?)\]\]', # [[ ... ]] string delimiters
+	re.DOTALL)
 
 # Handles "concatenation" .. " of strings"
 pattern_concat = re.compile(r'["\'][\s]*\.\.[\s]*["\']', re.DOTALL)
@@ -278,6 +291,10 @@ def read_lua_file_strings(lua_file):
 		for s in pattern_lua_quoted.findall(text):
 			strings.append(s[1])
 		for s in pattern_lua_bracketed.findall(text):
+			strings.append(s)
+		for s in pattern_lua_quoted_single.findall(text):
+			strings.append(s[1])
+		for s in pattern_lua_bracketed_single.findall(text):
 			strings.append(s)
 
 		for s in strings:

--- a/util/mod_translation_updater.py
+++ b/util/mod_translation_updater.py
@@ -118,34 +118,47 @@ def main():
 			else:
 				update_folder(os.path.abspath("./"))
 
-# Group 2 will be the string, groups 1 and 3 will be the delimiters (" or ')
+# Compile pattern for matching lua function call
+def compile_func_call_pattern(argument_pattern):
+	return re.compile(
+		# Look for beginning of file or anything that isn't a function identifier
+		r'(?:^|[\.=,{\(\s])' +
+		# Matches S, FS, NS, or NFS function call
+		r'N?F?S\s*' +
+		# The pattern to match argument
+		argument_pattern,
+		re.DOTALL)
+
+# Add parentheses around a pattern
+def parenthesize_pattern(pattern):
+	return (
+		# Start of argument: open parentheses and space (optional)
+		r'\(\s*' +
+		# The pattern to be parenthesized
+		pattern +
+		# End of argument or function call: space, comma, or close parentheses
+		r'[\s,\)]')
+
+# Quoted string
+# Group 2 will be the string, group 1 and group 3 will be the delimiters (" or ')
 # See https://stackoverflow.com/questions/46967465/regex-match-text-in-either-single-or-double-quote
-pattern_lua_quoted = re.compile(
-	r'(?:^|[\.=,{\(\s])' # Look for beginning of file or anything that isn't a function identifier
-	r'N?F?S\s*\(\s*' # Matches S, FS, NS or NFS function call
-	r'(["\'])((?:\\\1|(?:(?!\1)).)*)(\1)' # Quoted string
-	r'[\s,\)]', # End of call or argument
-	re.DOTALL)
+pattern_lua_quoted_string = r'(["\'])((?:\\\1|(?:(?!\1)).)*)(\1)'
+
+# Double square bracket string (multiline)
+pattern_lua_square_bracket_string = r'\[\[(.*?)\]\]'
+
+# Handles the " ... " or ' ... ' string delimiters
+pattern_lua_quoted = compile_func_call_pattern(parenthesize_pattern(pattern_lua_quoted_string))
+
 # Handles the [[ ... ]] string delimiters
-pattern_lua_bracketed = re.compile(
-	r'(?:^|[\.=,{\(\s])' # Same as for pattern_lua_quoted
-	r'N?F?S\s*\(\s*' # Same as for pattern_lua_quoted
-	r'\[\[(.*?)\]\]' # [[ ... ]] string delimiters
-	r'[\s,\)]', # Same as for pattern_lua_quoted
-	re.DOTALL)
-# Handles like pattern_lua_quoted, but for single parameter (without parantheses)
+pattern_lua_bracketed = compile_func_call_pattern(parenthesize_pattern(pattern_lua_square_bracket_string))
+
+# Handles like pattern_lua_quoted, but for single parameter (without parentheses)
 # See https://www.lua.org/pil/5.html for informations about single argument call
-pattern_lua_quoted_single = re.compile(
-	r'(?:^|[\.=,{\(\s])' # Same as for pattern_lua_quoted
-	r'N?F?S\s*' # Same as for pattern_lua_quoted, but without open parentheses
-	r'(["\'])((?:\\\1|(?:(?!\1)).)*)(\1)', # Quoted string
-	re.DOTALL)
+pattern_lua_quoted_single = compile_func_call_pattern(pattern_lua_quoted_string)
+
 # Same as pattern_lua_quoted_single, but for [[ ... ]] string delimiters
-pattern_lua_bracketed_single = re.compile(
-	r'(?:^|[\.=,{\(\s])' # Same as for pattern_lua_quoted
-	r'N?F?S\s*' # Same as for pattern_lua_quoted_single
-	r'\[\[(.*?)\]\]', # [[ ... ]] string delimiters
-	re.DOTALL)
+pattern_lua_bracketed_single = compile_func_call_pattern(pattern_lua_square_bracket_string)
 
 # Handles "concatenation" .. " of strings"
 pattern_concat = re.compile(r'["\'][\s]*\.\.[\s]*["\']', re.DOTALL)

--- a/util/mod_translation_updater.py
+++ b/util/mod_translation_updater.py
@@ -285,16 +285,20 @@ def read_lua_file_strings(lua_file):
 	with open(lua_file, encoding='utf-8') as text_file:
 		text = text_file.read()
 
-		text = re.sub(pattern_concat, "", text)
-
 		strings = []
-		for s in pattern_lua_quoted.findall(text):
-			strings.append(s[1])
-		for s in pattern_lua_bracketed.findall(text):
-			strings.append(s)
+
 		for s in pattern_lua_quoted_single.findall(text):
 			strings.append(s[1])
 		for s in pattern_lua_bracketed_single.findall(text):
+			strings.append(s)
+
+		# Only concatenate strings after matching
+		# single parameter call (without parantheses)
+		text = re.sub(pattern_concat, "", text)
+
+		for s in pattern_lua_quoted.findall(text):
+			strings.append(s[1])
+		for s in pattern_lua_bracketed.findall(text):
 			strings.append(s)
 
 		for s in strings:


### PR DESCRIPTION
**Goal of the PR**
This PR adds support for Lua function call without parentheses (single parameter function call).

**How does the PR work?**
This PR adds two patterns for Lua function call without parentheses, both for `"single/double-quote"` and for `[[multiline]]`.

**Does it resolve any reported issue?**
This PR tries to fix #14494.

**If not a bug fix, why is this PR needed? What usecases does it solve?**
See the linked issue and https://www.lua.org/pil/5.html for informations about single argument call.

## To do

This PR is Ready for Review.

## How to test

1. Create a mod with some code using `S` (and its variants) and without parentheses.
2. Run the script.
3. Check that the string exists.

```lua
S("Double-quote with parentheses")
S"Double-quote without parentheses"
S('Single-quote with parentheses')
S'Single-quote without parentheses'
S([[Multiline with parentheses]])
S[[Multiline without parentheses]]
S
[[Multiline
without
parentheses]]
```