### PR TITLE
Fix MSVC warning C4172 in ModifySafeMap::get

### DIFF
--- a/src/util/container.h
+++ b/src/util/container.h
@@ -369,7 +369,14 @@ public:
 				return it->second;
 		}
 		auto it = m_values.find(key);
-		return it == m_values.end() ? null_value : it->second;
+		// This conditional block was converted from a ternary to ensure no
+		// temporary values are created in evaluating the return expression,
+		// which could cause a dangling reference.
+		if (it != m_values.end()) {
+			return it->second;
+		} else {
+			return null_value;
+		}
 	}
 
 	void put(const K &key, const V &value) {


### PR DESCRIPTION
We may have been returning a reference to a temporary caused by a ternary expression. To be safe, this converts the ternary into an if conditional so that no conversions will happen during the evaluation of the return expression.

resolves #14569 
## To do

Ready for Review.

## How to test

Compile on MSVC and observe that the warning no longer appears.
