### PR TITLE
Remove an unnecessary copy of a big data structure.

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -73,7 +73,7 @@ struct MapEditEvent
 		modified_blocks.push_back(getNodeBlockPos(pos));
 	}
 
-	void setModifiedBlocks(const std::map<v3s16, MapBlock *> blocks)
+	void setModifiedBlocks(const std::map<v3s16, MapBlock *>& blocks)
 	{
 		assert(modified_blocks.empty()); // only meant for initialization (once)
 		modified_blocks.reserve(blocks.size());


### PR DESCRIPTION
Get rid of an unnecessary copy of a big map<>.

---
BTW: I think this function is very unlucky, because the pointer to `MapBlock` is collected everywhere just to be dropped here, without any purpose. Then the position (`v3s16`) is used later just to find the `MapBlock` again, which is also mostly a waste.
I would suggest using `MapBlock` with a `shared_ptr`. I've tested that, and it doesn't seam to make a performance difference when used with `make_shared()`. Then use `std::shared_ptr<MapBlock>` directly instead of the fake pointer that is `v3s16`, which requires a heavy lookup every time.