### PR TITLE
Fix crash when player leaves before breath removal job

### DIFF
--- a/builtin/game/hud.lua
+++ b/builtin/game/hud.lua
@@ -224,10 +224,10 @@ register_builtin_hud_element("breath", {
 				-- The breathbar stays for some time and then gets removed.
 				breathbar_removal_jobs[player_name] = core.after(1, function()
 					local player = core.get_player_by_name(player_name)
-					local id = hud_ids[player_name]
-					if player and id and id.breath then
-						player:hud_remove(id.breath)
-						hud_ids[player_name].breath = nil
+					local player_hud_ids = hud_ids[player_name]
+					if player and player_hud_ids and player_hud_ids.breath then
+						player:hud_remove(player_hud_ids.breath)
+						player_hud_ids.breath = nil
 					end
 					breathbar_removal_jobs[player_name] = nil
 				end)

--- a/builtin/game/hud.lua
+++ b/builtin/game/hud.lua
@@ -224,9 +224,9 @@ register_builtin_hud_element("breath", {
 				-- The breathbar stays for some time and then gets removed.
 				breathbar_removal_jobs[player_name] = core.after(1, function()
 					local player = core.get_player_by_name(player_name)
-					local id = hud_ids[player_name].breath
-					if player and id then
-						player:hud_remove(id)
+					local id = hud_ids[player_name]
+					if player and id and id.breath then
+						player:hud_remove(id.breath)
 						hud_ids[player_name].breath = nil
 					end
 					breathbar_removal_jobs[player_name] = nil


### PR DESCRIPTION
Should fix this:
```
2024-04-23 12:14:34: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod '*builtin*' in callback environment_Step(): /home/minetest/minetest/bin/../builtin/game/hud.lua:227: attempt to index a nil value
2024-04-23 12:14:34: ERROR[Main]: stack traceback:
2024-04-23 12:14:34: ERROR[Main]:     /home/minetest/minetest/bin/../builtin/game/hud.lua:227: in function 'func'
2024-04-23 12:14:34: ERROR[Main]:     /home/minetest/minetest/bin/../builtin/common/after.lua:140: in function </home/minetest/minetest/bin/../builtin/common/after.lua:117>
2024-04-23 12:14:34: ERROR[Main]:     /home/minetest/minetest/bin/../builtin/common/register.lua:26: in function </home/minetest/minetest/bin/../builtin/common/register.lua:12>
```
