### PR TITLE
Android CI: Additionally make an AAB for uploading to the Play Store

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -34,8 +34,17 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends gettext openjdk-11-jdk-headless
-    - name: Build with Gradle
+    - name: Build AAB with Gradle
+      # We build an AAB as well for uploading to the the Play Store.
+      run: cd android; ./gradlew bundlerelease
+    - name: Build APKs with Gradle
+      # "assemblerelease" is very fast after "bundlerelease".
       run: cd android; ./gradlew assemblerelease
+    - name: Save AAB artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Minetest-release.aab
+        path: android/app/build/outputs/bundle/release/app-release.aab
     - name: Save armeabi artifact
       uses: actions/upload-artifact@v4
       with:

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -132,7 +132,7 @@ struct BoneOverride
 		return scale.vector.getInterpolated(scale.previous, progress)
 				* (scale.absolute ? v3f(1) : anim_scale);
 	}
- 
+
 	f32 dtime_passed = 0;
 
 	bool isIdentity() const

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -132,7 +132,7 @@ struct BoneOverride
 		return scale.vector.getInterpolated(scale.previous, progress)
 				* (scale.absolute ? v3f(1) : anim_scale);
 	}
-
+ 
 	f32 dtime_passed = 0;
 
 	bool isIdentity() const


### PR DESCRIPTION
This PR makes the Android CI produce an AAB file in addition to APKs.

- Reduces work required for releasing.
- Avoids mistakes (5.8.0 on the Play Store was built with the wrong Irrlicht version, see https://github.com/minetest/minetest/pull/14211#issuecomment-1901255818)

Note that I have never released anything on the Play Store. @rubenwardy

***Oh no, doesn't this make Android CI a lot slower than it already is?***

Looks like it doesn't. Gradle seems to do some caching.

## To do

This PR is a Ready for Review.

## How to test

Look at the CI artifacts.
