### PR TITLE
Client: fix unknown texture upon shift-move to full inventory list

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -758,8 +758,9 @@ void InventoryList::moveItemSomewhere(u32 i, InventoryList *dest, u32 count)
 
 	if (!leftover.empty()) {
 		// Add the remaining part back to the source item
-		ItemStack &source = getItem(i);
-		source.add(leftover.count); // do NOT use addItem to allow oversized stacks!
+		// do NOT use addItem to allow oversized stacks!
+		leftover.add(getItem(i).count);
+		changeItem(i, leftover);
 	}
 }
 


### PR DESCRIPTION
Fixes a regression caused by 4245a760
'moveItemSomewhere' attempted to add a leftover stack to an empty stack, resulting in an empty name with non-0 ItemStack count.

Fixes #14572

## To do

This PR is Ready for Review.

## How to test

1. Have a full crafting grid
2. Try to shift-move an ItemStack into it
3. No strange texture
