### PR TITLE
Fix temporary inventory in `InvRef:set_lists()` and type check `listname`

### DIFF
--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -272,7 +272,7 @@ int InvRef::l_set_lists(lua_State *L)
 	lua_pushnil(L);
 	luaL_checktype(L, 2, LUA_TTABLE);
 	while (lua_next(L, 2)) {
-		const char *listname = lua_tostring(L, -2);
+		const char *listname = luaL_checkstring(L, -2);
 		read_inventory_list(L, -1, &tempInv, listname, server);
 		lua_pop(L, 1);
 	}

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -264,8 +264,8 @@ int InvRef::l_set_lists(lua_State *L)
 	}
 
 	// Make a temporary inventory in case reading fails
-	Inventory *tempInv(inv);
-	tempInv->clear();
+	Inventory tempInv(*inv);
+	tempInv.clear();
 
 	Server *server = getServer(L);
 
@@ -273,10 +273,10 @@ int InvRef::l_set_lists(lua_State *L)
 	luaL_checktype(L, 2, LUA_TTABLE);
 	while (lua_next(L, 2)) {
 		const char *listname = lua_tostring(L, -2);
-		read_inventory_list(L, -1, tempInv, listname, server);
+		read_inventory_list(L, -1, &tempInv, listname, server);
 		lua_pop(L, 1);
 	}
-	inv = tempInv;
+	*inv = tempInv;
 	return 0;
 }
 


### PR DESCRIPTION
Currently when calling `InvRef:set_lists()` with a bad value (e.g. `{main=true}`), all lists are cleared. This PR fixes that by fixing the creation of a temporary inventory, so a new inventory is created instead of a reference. It also adds a missing type check to `listname`.

## How to test

Run this code:
```lua
local inv = minetest.create_detached_inventory("test")
inv:set_lists({main = {"air", ""})
print("Before error: ", dump(inv:get_lists()))
print(pcall(inv.set_lists, inv, {main=true}))
print("After error: ", dump(inv:get_lists()))
```
Without the fix in this PR, the output should be: (inventory empty after error)
```
Before error:   {
        main = {
                ItemStack("air"),
                ItemStack(""),
        }
}
false   bad argument #4 to '?' (table expected, got boolean)
After error:    {

}
```
With the fix, the output should be: (no change after error)
```
Before error:   {
        main = {
                ItemStack("air"),
                ItemStack(""),
        }
}
false   bad argument #4 to '?' (table expected, got boolean)
After error:    {
        main = {
                ItemStack("air"),
                ItemStack(""),
        }
}
```
