### PR TITLE
Hide `*_raw` functions

### DIFF
--- a/builtin/game/detached_inventory.lua
+++ b/builtin/game/detached_inventory.lua
@@ -2,6 +2,9 @@
 
 core.detached_inventories = {}
 
+local create_detached_inventory_raw = core.create_detached_inventory_raw
+core.create_detached_inventory_raw = nil
+
 function core.create_detached_inventory(name, callbacks, player_name)
 	local stuff = {}
 	stuff.name = name
@@ -15,10 +18,13 @@ function core.create_detached_inventory(name, callbacks, player_name)
 	end
 	stuff.mod_origin = core.get_current_modname() or "??"
 	core.detached_inventories[name] = stuff
-	return core.create_detached_inventory_raw(name, player_name)
+	return create_detached_inventory_raw(name, player_name)
 end
+
+local remove_detached_inventory_raw = core.remove_detached_inventory_raw
+core.remove_detached_inventory_raw = nil
 
 function core.remove_detached_inventory(name)
 	core.detached_inventories[name] = nil
-	return core.remove_detached_inventory_raw(name)
+	return remove_detached_inventory_raw(name)
 end


### PR DESCRIPTION
Removes `core.create_detached_inventory_raw()` and `core.remove_detached_inventory_raw()` from the global namespace, as is done with all other `*_raw` functions.