### PR TITLE
Display background & moving progress bar on shutdown screen

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -140,6 +140,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	scene::ICameraSceneNode* camera;
 	camera = g_menucloudsmgr->addCameraSceneNode(NULL, v3f(0, 0, 0), v3f(0, 60, 100));
 	camera->setFarValue(10000);
+	g_menuclouds->getMaterial(0).FogEnable = false; // disable fog so far clouds are as bright as the others
 
 	/*
 		GUI stuff

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -140,7 +140,6 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	scene::ICameraSceneNode* camera;
 	camera = g_menucloudsmgr->addCameraSceneNode(NULL, v3f(0, 0, 0), v3f(0, 60, 100));
 	camera->setFarValue(10000);
-	g_menuclouds->getMaterial(0).FogEnable = false; // disable fog so far clouds are as bright as the others
 
 	/*
 		GUI stuff

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1238,8 +1238,6 @@ void Game::shutdown()
 	if (g_touchscreengui)
 		g_touchscreengui->hide();
 
-	showOverlayMessage(N_("Shutting down..."), 0, 0, false);
-
 	if (clouds)
 		clouds->drop();
 
@@ -1286,11 +1284,23 @@ void Game::shutdown()
 	FpsControl fps_control;
 	fps_control.reset();
 
+	f32 timer = 0;
+	float percentage = 0;
 	while (stop_thread->isRunning()) {
 		m_rendering_engine->run();
 		f32 dtime;
 		fps_control.limit(device, &dtime);
-		showOverlayMessage(N_("Shutting down..."), dtime, 0, false);
+		timer += dtime;
+
+		if(timer >= 0.1) {
+			timer = 0;
+			percentage += 5;
+			if (percentage > 100) {
+				percentage = 0;
+			}
+		}
+		
+		m_rendering_engine->draw_load_screen(utf8_to_wide(std::string(N_("Shutting down…"))) , guienv, texture_src, dtime, percentage);
 	}
 
 	stop_thread->rethrow();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1240,13 +1240,8 @@ void Game::shutdown()
 
 	if (clouds)
 		clouds->drop();
-
-	FpsControl fps_control;
-	fps_control.reset();
-	f32 dtime;
 	m_rendering_engine->run();
-	fps_control.limit(device, &dtime);
-	m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, dtime, 0, true, true);
+	m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, -1, 0, true);
 
 	if (gui_chat_console)
 		gui_chat_console->drop();
@@ -1288,10 +1283,13 @@ void Game::shutdown()
 		server = nullptr;
 	}, "ServerStop");
 
+	FpsControl fps_control;
+	fps_control.reset();
 	while (stop_thread->isRunning()) {
+		f32 dtime;
 		m_rendering_engine->run();
 		fps_control.limit(device, &dtime);
-		m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, dtime, 0, true, true);
+		m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, dtime, -1, true);
 	}
 
 	stop_thread->rethrow();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1225,7 +1225,6 @@ void Game::run()
 	RenderingEngine::autosaveScreensizeAndCo(initial_screen_size, initial_window_maximized);
 }
 
-
 void Game::shutdown()
 {
 	auto formspec = m_game_ui->getFormspecGUI();
@@ -1240,6 +1239,13 @@ void Game::shutdown()
 
 	if (clouds)
 		clouds->drop();
+
+	FpsControl fps_control;
+	fps_control.reset();
+	f32 dtime;
+	m_rendering_engine->run();
+	fps_control.limit(device, &dtime);
+	m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, dtime, 0, true, true);
 
 	if (gui_chat_console)
 		gui_chat_console->drop();
@@ -1281,12 +1287,8 @@ void Game::shutdown()
 		server = nullptr;
 	}, "ServerStop");
 
-	FpsControl fps_control;
-	fps_control.reset();
-
 	while (stop_thread->isRunning()) {
 		m_rendering_engine->run();
-		f32 dtime;
 		fps_control.limit(device, &dtime);
 		m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, dtime, 0, true, true);
 	}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1268,7 +1268,7 @@ void Game::shutdown()
 		client->Stop();
 
 		fps_control.reset();
-		f32 timer = 0;
+		f32 timer = 0.0f;
 
 		while (!client->isShutdown()) {
 			m_rendering_engine->run();
@@ -1277,12 +1277,12 @@ void Game::shutdown()
 			showOverlayMessage(N_("Shutting down..."), dtime, 0, &indef_pos);
 
 			timer += dtime;
-			if (timer >= 100) {
+			if (timer >= 0.1f) {
 				assert(texture_src != nullptr);
 				assert(shader_src != nullptr);
 				texture_src->processQueue();
 				shader_src->processQueue();
-				timer = 0;
+				timer = 0.0f;
 			}
 		}
 	}
@@ -1426,8 +1426,8 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 
 	FpsControl fps_control;
 	fps_control.reset();
-
 	float indef_pos = 0;
+
 	while (start_thread->isRunning()) {
 		if (!m_rendering_engine->run() || input->cancelPressed())
 			success = false;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1225,6 +1225,7 @@ void Game::run()
 	RenderingEngine::autosaveScreensizeAndCo(initial_screen_size, initial_window_maximized);
 }
 
+
 void Game::shutdown()
 {
 	auto formspec = m_game_ui->getFormspecGUI();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1239,6 +1239,7 @@ void Game::shutdown()
 		g_touchscreengui->hide();
 
 	float loading_pos = 0;
+	driver->setFog(RenderingEngine::MENU_SKY_COLOR);
 	m_rendering_engine->run();
 	m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, -1, 0, true, &loading_pos);
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1284,20 +1284,15 @@ void Game::shutdown()
 	FpsControl fps_control;
 	fps_control.reset();
 
-	f32 timer = 0;
 	float percentage = 0;
 	while (stop_thread->isRunning()) {
 		m_rendering_engine->run();
 		f32 dtime;
 		fps_control.limit(device, &dtime);
-		timer += dtime;
 
-		if(timer >= 0.1) {
-			timer = 0;
-			percentage += 5;
-			if (percentage > 100) {
-				percentage = 0;
-			}
+		percentage += 5 * (dtime / 0.1);
+		if (percentage >= 100) {
+			percentage = 0;
 		}
 		
 		m_rendering_engine->draw_load_screen(utf8_to_wide(std::string(N_("Shutting down…"))) , guienv, texture_src, dtime, percentage);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1238,11 +1238,12 @@ void Game::shutdown()
 	if (g_touchscreengui)
 		g_touchscreengui->hide();
 
+	float loading_pos = 0;
+	m_rendering_engine->run();
+	m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, -1, 0, true, &loading_pos);
+
 	if (clouds)
 		clouds->drop();
-	
-	m_rendering_engine->run();
-	m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, -1, 0, true);
 
 	if (gui_chat_console)
 		gui_chat_console->drop();
@@ -1273,7 +1274,7 @@ void Game::shutdown()
 			f32 dtime;
 			fps_control.limit(device, &dtime);
 			timer += dtime;
-			m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, dtime, -1, true);
+			m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, dtime, -1, true, &loading_pos);
 			if (timer >= 100) {
 				assert(texture_src != NULL);
 				assert(shader_src != NULL);
@@ -1299,7 +1300,7 @@ void Game::shutdown()
 		m_rendering_engine->run();
 		f32 dtime;
 		fps_control.limit(device, &dtime);
-		m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, dtime, -1, true);
+		m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, dtime, -1, true, &loading_pos);
 	}
 
 	stop_thread->rethrow();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -790,7 +790,7 @@ protected:
 
 	// Misc
 	void showOverlayMessage(const char *msg, float dtime, int percent,
-			bool draw_clouds = true, float *indef_pos = nullptr);
+			float *indef_pos = nullptr);
 
 	static void settingChangedCallback(const std::string &setting_name, void *data);
 	void readSettings();
@@ -1238,7 +1238,7 @@ void Game::shutdown()
 	if (g_touchscreengui)
 		g_touchscreengui->hide();
 
-	showOverlayMessage(N_("Shutting down..."), 0, 0, true);
+	showOverlayMessage(N_("Shutting down..."), 0, 0);
 
 	if (clouds)
 		clouds->drop();
@@ -1274,7 +1274,7 @@ void Game::shutdown()
 			m_rendering_engine->run();
 			f32 dtime;
 			fps_control.limit(device, &dtime);
-			showOverlayMessage(N_("Shutting down..."), dtime, 0, true, &indef_pos);
+			showOverlayMessage(N_("Shutting down..."), dtime, 0, &indef_pos);
 
 			timer += dtime;
 			if (timer >= 100) {
@@ -1304,7 +1304,7 @@ void Game::shutdown()
 		m_rendering_engine->run();
 		f32 dtime;
 		fps_control.limit(device, &dtime);
-		showOverlayMessage(N_("Shutting down..."), dtime, 0, true, &indef_pos);
+		showOverlayMessage(N_("Shutting down..."), dtime, 0, &indef_pos);
 	}
 
 	stop_thread->rethrow();
@@ -1437,7 +1437,7 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 		if (success)
 			showOverlayMessage(N_("Creating server..."), dtime, 5);
 		else
-			showOverlayMessage(N_("Shutting down..."), dtime, 0, true, &indef_pos);
+			showOverlayMessage(N_("Shutting down..."), dtime, 0, &indef_pos);
 	}
 
 	start_thread->rethrow();
@@ -4368,10 +4368,10 @@ void Game::drawScene(ProfilerGraph *graph, RunStats *stats)
  Misc
  ****************************************************************************/
 
-void Game::showOverlayMessage(const char *msg, float dtime, int percent, bool draw_sky, float *indef_pos)
+void Game::showOverlayMessage(const char *msg, float dtime, int percent, float *indef_pos)
 {
 	m_rendering_engine->draw_load_screen(wstrgettext(msg), guienv, texture_src,
-			dtime, percent, draw_sky, indef_pos);
+			dtime, percent, indef_pos);
 }
 
 void Game::settingChangedCallback(const std::string &setting_name, void *data)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1432,8 +1432,10 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 
 		if (success)
 			showOverlayMessage(N_("Creating server..."), dtime, 5);
-		else
-			showOverlayMessage(N_("Shutting down..."), dtime, 0, false);
+		else {
+			float loading_pos = 0;
+			m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, dtime, -1, true, &loading_pos);
+		}
 	}
 
 	start_thread->rethrow();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1240,6 +1240,7 @@ void Game::shutdown()
 
 	if (clouds)
 		clouds->drop();
+	
 	m_rendering_engine->run();
 	m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, -1, 0, true);
 
@@ -1285,9 +1286,10 @@ void Game::shutdown()
 
 	FpsControl fps_control;
 	fps_control.reset();
+
 	while (stop_thread->isRunning()) {
-		f32 dtime;
 		m_rendering_engine->run();
+		f32 dtime;
 		fps_control.limit(device, &dtime);
 		m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, dtime, -1, true);
 	}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1284,18 +1284,12 @@ void Game::shutdown()
 	FpsControl fps_control;
 	fps_control.reset();
 
-	float percentage = 0;
 	while (stop_thread->isRunning()) {
 		m_rendering_engine->run();
 		f32 dtime;
 		fps_control.limit(device, &dtime);
-
-		percentage += 5 * (dtime / 0.1);
-		if (percentage >= 100) {
-			percentage = 0;
-		}
 		
-		m_rendering_engine->draw_load_screen(utf8_to_wide(std::string(N_("Shutting down…"))) , guienv, texture_src, dtime, percentage);
+		m_rendering_engine->draw_load_screen(utf8_to_wide(std::string(N_("Shutting down…"))) , guienv, texture_src, dtime, 0, true, true);
 	}
 
 	stop_thread->rethrow();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -959,6 +959,8 @@ private:
 #ifdef __ANDROID__
 	bool m_android_chat_open;
 #endif
+
+	float m_shutdown_progress = 0.0f;
 };
 
 Game::Game() :
@@ -1238,7 +1240,9 @@ void Game::shutdown()
 	if (g_touchscreengui)
 		g_touchscreengui->hide();
 
-	showOverlayMessage(N_("Shutting down..."), 0, 0);
+	// only if the shutdown progress bar isn't shown yet
+	if (m_shutdown_progress == 0.0f)
+		showOverlayMessage(N_("Shutting down..."), 0, 0);
 
 	if (clouds)
 		clouds->drop();
@@ -1285,13 +1289,12 @@ void Game::shutdown()
 
 	FpsControl fps_control;
 	fps_control.reset();
-	float indef_pos = 0;
 
 	while (stop_thread->isRunning()) {
 		m_rendering_engine->run();
 		f32 dtime;
 		fps_control.limit(device, &dtime);
-		showOverlayMessage(N_("Shutting down..."), dtime, 0, &indef_pos);
+		showOverlayMessage(N_("Shutting down..."), dtime, 0, &m_shutdown_progress);
 	}
 
 	stop_thread->rethrow();
@@ -1413,7 +1416,6 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 
 	FpsControl fps_control;
 	fps_control.reset();
-	float indef_pos = 0;
 
 	while (start_thread->isRunning()) {
 		if (!m_rendering_engine->run() || input->cancelPressed())
@@ -1424,7 +1426,7 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 		if (success)
 			showOverlayMessage(N_("Creating server..."), dtime, 5);
 		else
-			showOverlayMessage(N_("Shutting down..."), dtime, 0, &indef_pos);
+			showOverlayMessage(N_("Shutting down..."), dtime, 0, &m_shutdown_progress);
 	}
 
 	start_thread->rethrow();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1288,8 +1288,7 @@ void Game::shutdown()
 		m_rendering_engine->run();
 		f32 dtime;
 		fps_control.limit(device, &dtime);
-		
-		m_rendering_engine->draw_load_screen(utf8_to_wide(std::string(N_("Shutting down…"))) , guienv, texture_src, dtime, 0, true, true);
+		m_rendering_engine->draw_load_screen(wstrgettext("Shutting down..."), guienv, texture_src, dtime, 0, true, true);
 	}
 
 	stop_thread->rethrow();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1261,29 +1261,14 @@ void Game::shutdown()
 	chat_backend->addMessage(L"", L"");
 	m_chat_log_buf.clear();
 
-	FpsControl fps_control;
-	float indef_pos = 0;
-
 	if (client) {
 		client->Stop();
-
-		fps_control.reset();
-		f32 timer = 0.0f;
-
 		while (!client->isShutdown()) {
-			m_rendering_engine->run();
-			f32 dtime;
-			fps_control.limit(device, &dtime);
-			showOverlayMessage(N_("Shutting down..."), dtime, 0, &indef_pos);
-
-			timer += dtime;
-			if (timer >= 0.1f) {
-				assert(texture_src != nullptr);
-				assert(shader_src != nullptr);
-				texture_src->processQueue();
-				shader_src->processQueue();
-				timer = 0.0f;
-			}
+			assert(texture_src != NULL);
+			assert(shader_src != NULL);
+			texture_src->processQueue();
+			shader_src->processQueue();
+			sleep_ms(100);
 		}
 	}
 
@@ -1298,7 +1283,9 @@ void Game::shutdown()
 		server = nullptr;
 	}, "ServerStop");
 
+	FpsControl fps_control;
 	fps_control.reset();
+	float indef_pos = 0;
 
 	while (stop_thread->isRunning()) {
 		m_rendering_engine->run();

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -308,7 +308,7 @@ bool RenderingEngine::setWindowIcon()
 */
 void RenderingEngine::draw_load_screen(const std::wstring &text,
 		gui::IGUIEnvironment *guienv, ITextureSource *tsrc, float dtime,
-		int percent, bool sky)
+		int percent, bool sky, float* indef_pos)
 {
 	v2u32 screensize = getWindowSize();
 
@@ -335,10 +335,10 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 	int percent_min = 0;
 	int percent_max = percent;
 	if (percent == -1) {
-		thread_local float indef_pos = 0;
-		indef_pos = fmodf(indef_pos + (dtime * 50.0f), 140.0f);
-		percent_max = std::min((int) indef_pos, 100);
-		percent_min = std::max((int) indef_pos - 40, 0);
+		if (!indef_pos) { return; }
+		*indef_pos = fmodf(*indef_pos + (dtime * 50.0f), 140.0f);
+		percent_max = std::min((int) *indef_pos, 100);
+		percent_min = std::max((int) *indef_pos - 40, 0);
 	}
 	// draw progress bar
 	if ((percent_min >= 0) && (percent_max <= 100)) {

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -308,7 +308,7 @@ bool RenderingEngine::setWindowIcon()
 */
 void RenderingEngine::draw_load_screen(const std::wstring &text,
 		gui::IGUIEnvironment *guienv, ITextureSource *tsrc, float dtime,
-		int percent, bool sky, float* indef_pos)
+		int percent, bool sky, float *indef_pos)
 {
 	v2u32 screensize = getWindowSize();
 
@@ -323,6 +323,7 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 	auto *driver = get_video_driver();
 
 	if (sky) {
+		driver->setFog(RenderingEngine::MENU_SKY_COLOR);
 		driver->beginScene(true, true, RenderingEngine::MENU_SKY_COLOR);
 		if (g_settings->getBool("menu_clouds")) {
 			g_menuclouds->step(dtime * 3);
@@ -334,8 +335,7 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 
 	int percent_min = 0;
 	int percent_max = percent;
-	if (percent == -1) {
-		if (!indef_pos) { return; }
+	if (indef_pos) {
 		*indef_pos = fmodf(*indef_pos + (dtime * 50.0f), 140.0f);
 		percent_max = std::min((int) *indef_pos, 100);
 		percent_min = std::max((int) *indef_pos - 40, 0);

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -308,7 +308,7 @@ bool RenderingEngine::setWindowIcon()
 */
 void RenderingEngine::draw_load_screen(const std::wstring &text,
 		gui::IGUIEnvironment *guienv, ITextureSource *tsrc, float dtime,
-		int percent, bool sky)
+		int percent, bool sky, bool indefinite)
 {
 	v2u32 screensize = getWindowSize();
 
@@ -332,8 +332,20 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 		driver->beginScene(true, true, video::SColor(255, 0, 0, 0));
 	}
 
+	int percent_min = 0;
+	int percent_max = percent;
+	if (indefinite) {
+		static float indef_pos = 0;
+		indef_pos += 5 * (dtime / 0.1);
+		if (indef_pos >= 120) {
+			indef_pos = 0;
+		}
+		percent_max = std::min((int) indef_pos, 100);
+		percent_min = std::max((int) indef_pos - 20, 0);
+	}
+
 	// draw progress bar
-	if ((percent >= 0) && (percent <= 100)) {
+	if ((percent_max >= 0) && (percent_max <= 100)) {
 		video::ITexture *progress_img = tsrc->getTexture("progress_bar.png");
 		video::ITexture *progress_img_bg =
 				tsrc->getTexture("progress_bar_bg.png");
@@ -364,11 +376,11 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 					0, 0, true);
 
 			draw2DImageFilterScaled(get_video_driver(), progress_img,
-					core::rect<s32>(img_pos.X, img_pos.Y,
-							img_pos.X + (percent * imgW) / 100,
+					core::rect<s32>(img_pos.X + (percent_min * imgW) / 100, img_pos.Y,
+							img_pos.X + (percent_max * imgW) / 100,
 							img_pos.Y + imgH),
-					core::rect<s32>(0, 0,
-							(percent * img_size.Width) / 100,
+					core::rect<s32>(percent_min, 0,
+							((percent_max - percent_min) * img_size.Width) / 100,
 							img_size.Height),
 					0, 0, true);
 		}

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -308,7 +308,7 @@ bool RenderingEngine::setWindowIcon()
 */
 void RenderingEngine::draw_load_screen(const std::wstring &text,
 		gui::IGUIEnvironment *guienv, ITextureSource *tsrc, float dtime,
-		int percent, bool sky, float *indef_pos)
+		int percent, float *indef_pos)
 {
 	v2u32 screensize = getWindowSize();
 
@@ -322,15 +322,11 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 
 	auto *driver = get_video_driver();
 
-	if (sky) {
-		driver->setFog(RenderingEngine::MENU_SKY_COLOR);
-		driver->beginScene(true, true, RenderingEngine::MENU_SKY_COLOR);
-		if (g_settings->getBool("menu_clouds")) {
-			g_menuclouds->step(dtime * 3);
-			g_menucloudsmgr->drawAll();
-		}
-	} else {
-		driver->beginScene(true, true, video::SColor(255, 0, 0, 0));
+	driver->setFog(RenderingEngine::MENU_SKY_COLOR);
+	driver->beginScene(true, true, RenderingEngine::MENU_SKY_COLOR);
+	if (g_settings->getBool("menu_clouds")) {
+		g_menuclouds->step(dtime * 3);
+		g_menucloudsmgr->drawAll();
 	}
 
 	int percent_min = 0;

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -308,7 +308,7 @@ bool RenderingEngine::setWindowIcon()
 */
 void RenderingEngine::draw_load_screen(const std::wstring &text,
 		gui::IGUIEnvironment *guienv, ITextureSource *tsrc, float dtime,
-		int percent, bool sky, bool indefinite)
+		int percent, bool sky)
 {
 	v2u32 screensize = getWindowSize();
 
@@ -334,18 +334,14 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 
 	int percent_min = 0;
 	int percent_max = percent;
-	if (indefinite) {
-		static float indef_pos = 0;
-		indef_pos += 5 * (dtime / 0.1);
-		if (indef_pos >= 120) {
-			indef_pos = 0;
-		}
+	if (percent == -1) {
+		thread_local float indef_pos = 0;
+		indef_pos = fmodf(indef_pos + (dtime * 50.0f), 140.0f);
 		percent_max = std::min((int) indef_pos, 100);
-		percent_min = std::max((int) indef_pos - 20, 0);
+		percent_min = std::max((int) indef_pos - 40, 0);
 	}
-
 	// draw progress bar
-	if ((percent_max >= 0) && (percent_max <= 100)) {
+	if ((percent_min >= 0) && (percent_max <= 100)) {
 		video::ITexture *progress_img = tsrc->getTexture("progress_bar.png");
 		video::ITexture *progress_img_bg =
 				tsrc->getTexture("progress_bar_bg.png");
@@ -379,8 +375,8 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 					core::rect<s32>(img_pos.X + (percent_min * imgW) / 100, img_pos.Y,
 							img_pos.X + (percent_max * imgW) / 100,
 							img_pos.Y + imgH),
-					core::rect<s32>(percent_min, 0,
-							((percent_max - percent_min) * img_size.Width) / 100,
+					core::rect<s32>(percent_min * img_size.Width / 100, 0,
+							percent_max * img_size.Width / 100,
 							img_size.Height),
 					0, 0, true);
 		}

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -141,7 +141,7 @@ public:
 	// progress bar is drawn.
 	void draw_load_screen(const std::wstring &text,
 			gui::IGUIEnvironment *guienv, ITextureSource *tsrc,
-			float dtime = 0, int percent = 0, bool sky = true, float *indef_pos = nullptr);
+			float dtime = 0, int percent = 0, float *indef_pos = nullptr);
 
 	void draw_scene(video::SColor skycolor, bool show_hud,
 			bool draw_wield_tool, bool draw_crosshair);

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -137,10 +137,10 @@ public:
 		return m_device->getGUIEnvironment();
 	}
 
-	// Note that percent is ignored in case indefinite is true
+	// Note that a pertance of -1 gets interpreted as indefinete loading
 	void draw_load_screen(const std::wstring &text,
 			gui::IGUIEnvironment *guienv, ITextureSource *tsrc,
-			float dtime = 0, int percent = 0, bool sky = true, bool indefinite = false);
+			float dtime = 0, int percent = 0, bool sky = true);
 
 	void draw_scene(video::SColor skycolor, bool show_hud,
 			bool draw_wield_tool, bool draw_crosshair);

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -137,10 +137,10 @@ public:
 		return m_device->getGUIEnvironment();
 	}
 
-	// Note that a pertance of -1 gets interpreted as indefinete loading
+	// Note that a pertance of -1 gets interpreted as indefinete loading; pass a pointer to an initialized float in that case
 	void draw_load_screen(const std::wstring &text,
 			gui::IGUIEnvironment *guienv, ITextureSource *tsrc,
-			float dtime = 0, int percent = 0, bool sky = true);
+			float dtime = 0, int percent = 0, bool sky = true, float* indef_pos=nullptr);
 
 	void draw_scene(video::SColor skycolor, bool show_hud,
 			bool draw_wield_tool, bool draw_crosshair);

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -137,10 +137,11 @@ public:
 		return m_device->getGUIEnvironment();
 	}
 
-	// Note that a pertance of -1 gets interpreted as indefinete loading; pass a pointer to an initialized float in that case
+	// If "indef_pos" is given, the value of "percent" is ignored and an indefinite
+	// progress bar is drawn.
 	void draw_load_screen(const std::wstring &text,
 			gui::IGUIEnvironment *guienv, ITextureSource *tsrc,
-			float dtime = 0, int percent = 0, bool sky = true, float* indef_pos=nullptr);
+			float dtime = 0, int percent = 0, bool sky = true, float *indef_pos = nullptr);
 
 	void draw_scene(video::SColor skycolor, bool show_hud,
 			bool draw_wield_tool, bool draw_crosshair);

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -137,9 +137,10 @@ public:
 		return m_device->getGUIEnvironment();
 	}
 
+	// Note that percent is ignored in case indefinite is true
 	void draw_load_screen(const std::wstring &text,
 			gui::IGUIEnvironment *guienv, ITextureSource *tsrc,
-			float dtime = 0, int percent = 0, bool sky = true);
+			float dtime = 0, int percent = 0, bool sky = true, bool indefinite = false);
 
 	void draw_scene(video::SColor skycolor, bool show_hud,
 			bool draw_wield_tool, bool draw_crosshair);


### PR DESCRIPTION
This Pull Request adds the main menu background to the shutdown screen, and makes the progress bar constantly refill itself indefinitely as long as the game is still shutting down. It does so by using a load screen instead of an overlayMessage.
Fixes #14571



**Ready for Review.**

[shutdown.webm](https://github.com/minetest/minetest/assets/95762086/dd7b0cfc-8d63-4664-95ab-9aed6c413af1)


## How to test

1. launch the game
2. join either a server or a singleplayer world
3. quit
4. verify that said changes apply to the shutdown screen

<!-- Example code or instructions -->
