### PR TITLE
Chat console: Prevent input loss on double open

### DIFF
--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -106,9 +106,13 @@ GUIChatConsole::~GUIChatConsole()
 
 void GUIChatConsole::openConsole(f32 scale)
 {
+	if (m_open)
+		return;
+
 	assert(scale > 0.0f && scale <= 1.0f);
 
 	m_open = true;
+
 	m_desired_height_fraction = scale;
 	m_desired_height = scale * m_screensize.Y;
 	reformatConsole();

--- a/src/gui/mainmenumanager.h
+++ b/src/gui/mainmenumanager.h
@@ -48,14 +48,14 @@ class MainMenuManager : public IMenuManager
 public:
 	virtual void createdMenu(gui::IGUIElement *menu)
 	{
-#ifndef NDEBUG
-		for (gui::IGUIElement *i : m_stack) {
-			assert(i != menu);
+		for (gui::IGUIElement *e : m_stack) {
+			if (e == menu)
+				return;
 		}
-#endif
 
 		if(!m_stack.empty())
 			m_stack.back()->setVisible(false);
+
 		m_stack.push_back(menu);
 		guienv->setFocus(m_stack.back());
 	}


### PR DESCRIPTION
Fixes #14585

## To do

This PR is Ready for Review.

## How to test

1. `fps_max = 5`
2. Press `T` (chat) and `F10` (long chat history) at once
3. No more input loss

This PR fixes the issue twice. If the `NDEBUG` code should be kept as-is then I could undo that.