### PR TITLE
TouchScreenGUI: Fix shootline not being updated if press and release happen in the same step

### DIFF
--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -703,6 +703,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 				m_move_pos                 = touch_pos;
 				// DON'T reset m_tap_state here, otherwise many short taps
 				// will be ignored if you tap very fast.
+				m_had_move_id              = true;
 			}
 		}
 	}
@@ -821,13 +822,14 @@ void TouchScreenGUI::step(float dtime)
 	// Note that the shootline isn't used if touch_use_crosshair is enabled.
 	// Only updating when m_has_move_id means that the shootline will stay at
 	// it's last in-world position when the player doesn't need it.
-	if (!m_draw_crosshair && m_has_move_id) {
+	if (!m_draw_crosshair && (m_has_move_id || m_had_move_id)) {
 		v2s32 pointer_pos = getPointerPos();
 		m_shootline = m_device
 				->getSceneManager()
 				->getSceneCollisionManager()
 				->getRayFromScreenCoordinates(pointer_pos);
 	}
+	m_had_move_id = false;
 }
 
 void TouchScreenGUI::resetHotbarRects()

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -259,6 +259,9 @@ private:
 	u64 m_move_downtime = 0;
 	// m_move_pos stays valid even after m_move_id has been released.
 	v2s32 m_move_pos;
+	// This is needed so that we don't miss if m_has_move_id is true for less
+	// than one client step, i.e. press and release happen in the same step.
+	bool m_had_move_id = false;
 
 	bool m_has_joystick_id = false;
 	size_t m_joystick_id;


### PR DESCRIPTION
This should be impossible to trigger, but I have a weird USB touchscreen setup that sometimes likes to buffer press events until the corresponding release event occurs.

## To do

This PR is a Ready for Review.

## How to test

Idea: With a touchscreen, set `fps_max` to 5 and verify that you can place nodes.