### PR TITLE
 Add object's own position for each collision to moveresult 

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -40,6 +40,7 @@ core.features = {
 	lsystem_decoration_type = true,
 	item_meta_range = true,
 	node_interaction_actor = true,
+	moveresult_new_pos = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/misc_s.lua
+++ b/builtin/game/misc_s.lua
@@ -103,7 +103,7 @@ if core.set_push_moveresult1 then
 	-- must match CollisionAxis in collision.h
 	local AXES = {"x", "y", "z"}
 	-- <=> script/common/c_content.cpp push_collision_move_result()
-	core.set_push_moveresult1(function(b0, b1, b2, axis, npx, npy, npz, v0x, v0y, v0z, v1x, v1y, v1z)
+	core.set_push_moveresult1(function(b0, b1, b2, axis, npx, npy, npz, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z)
 		return {
 			touching_ground = b0,
 			collides = b1,
@@ -112,8 +112,9 @@ if core.set_push_moveresult1 then
 				type = "node",
 				axis = AXES[axis],
 				node_pos = vector.new(npx, npy, npz),
-				old_velocity = vector.new(v0x, v0y, v0z),
-				new_velocity = vector.new(v1x, v1y, v1z),
+				new_pos = vector.new(v0x, v0y, v0z),
+				old_velocity = vector.new(v1x, v1y, v1z),
+				new_velocity = vector.new(v2x, v2y, v2z),
 			}},
 		}
 	end)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5124,6 +5124,7 @@ Collision info passed to `on_step` (`moveresult` argument):
             axis = string, -- "x", "y" or "z"
             node_pos = vector, -- if type is "node"
             object = ObjectRef, -- if type is "object"
+            new_pos = vector,
             old_velocity = vector,
             new_velocity = vector,
         },

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5124,6 +5124,8 @@ Collision info passed to `on_step` (`moveresult` argument):
             axis = string, -- "x", "y" or "z"
             node_pos = vector, -- if type is "node"
             object = ObjectRef, -- if type is "object"
+            -- The position of the entity when the collision occurred.
+            -- Available since feature "moveresult_new_pos".
             new_pos = vector,
             old_velocity = vector,
             new_velocity = vector,
@@ -5438,6 +5440,8 @@ Utilities
       -- Allow passing an optional "actor" ObjectRef to the following functions:
       -- minetest.place_node, minetest.dig_node, minetest.punch_node (5.9.0)
       node_interaction_actor = true,
+      -- "new_pos" field in entity moveresult (5.9.0)
+      moveresult_new_pos = true,
   }
   ```
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -510,6 +510,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 			info.node_p = nearest_info.position;
 			info.object = nearest_info.obj;
+			info.new_pos = *pos_f;
 			info.old_speed = *speed_f;
 			info.plane = nearest_collided;
 

--- a/src/collision.h
+++ b/src/collision.h
@@ -49,6 +49,7 @@ struct CollisionInfo
 	CollisionAxis axis = COLLISION_AXIS_NONE;
 	v3s16 node_p = v3s16(-32768,-32768,-32768); // COLLISION_NODE
 	ActiveObject *object = nullptr; // COLLISION_OBJECT
+	v3f new_pos;
 	v3f old_speed;
 	v3f new_speed;
 	int plane = -1;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2511,7 +2511,7 @@ void push_collision_move_result(lua_State *L, const collisionMoveResult &res)
 	lua_createtable(L, res.collisions.size(), 0);
 	int i = 1;
 	for (const auto &c : res.collisions) {
-		lua_createtable(L, 0, 5);
+		lua_createtable(L, 0, 6);
 
 		lua_pushstring(L, collision_type_str[c.type]);
 		lua_setfield(L, -2, "type");

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2492,12 +2492,12 @@ void push_collision_move_result(lua_State *L, const collisionMoveResult &res)
 		lua_pushinteger(L, c.node_p.X);
 		lua_pushinteger(L, c.node_p.Y);
 		lua_pushinteger(L, c.node_p.Z);
-		for (v3f v : {c.old_speed / BS, c.new_speed / BS}) {
+		for (v3f v : {c.new_pos / BS, c.old_speed / BS, c.new_speed / BS}) {
 			lua_pushnumber(L, v.X);
 			lua_pushnumber(L, v.Y);
 			lua_pushnumber(L, v.Z);
 		}
-		lua_call(L, 3 + 1 + 3 + 3 * 2, 1);
+		lua_call(L, 3 + 1 + 3 + 3 * 3, 1);
 		return;
 	}
 
@@ -2527,6 +2527,9 @@ void push_collision_move_result(lua_State *L, const collisionMoveResult &res)
 			push_objectRef(L, c.object->getId());
 			lua_setfield(L, -2, "object");
 		}
+
+		push_v3f(L, c.new_pos / BS);
+		lua_setfield(L, -2, "new_pos");
 
 		push_v3f(L, c.old_speed / BS);
 		lua_setfield(L, -2, "old_velocity");


### PR DESCRIPTION
For reasoning and use cases, see https://github.com/minetest/minetest/issues/9966, https://github.com/minetest/minetest/pull/9978#issuecomment-637705331, https://github.com/minetest/minetest/pull/9978#issuecomment-654981567. Closes #9966 

## To do

This PR is a  Ready for Review.

## How to test

Try this modpack: https://github.com/grorp/grenade-something

Throw grenades at a player and see that they explode exactly where they hit.
