### PR TITLE
scrollcontainer: Add automatic scrollbar calculation

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2683,6 +2683,7 @@ Version History
 * Formspec version 7 (5.8.0):
   * style[]: Add focused state for buttons
   * Add field_enter_after_edit[] (experimental)
+* Formspec version 8 (5.9.0)
 
 Elements
 --------
@@ -2774,7 +2775,10 @@ Elements
     `scrollbar name` times `scroll factor` along the orientation `orientation` and
   * be clipped to the rectangle defined by `X`, `Y`, `W` and `H`.
 * `orientation`: possible values are `vertical` and `horizontal`.
-* `scroll factor`: optional, defaults to `0.1`.
+* `scroll factor`: (optional), multiplicator for the associated scrollbar scroll position.
+  * Defaults to `0.1`.
+  * `auto` will calculate the multiplicator based on the contents
+     * Requires formspec version >= 8.
 * Nesting is possible.
 * Some elements might work a little different if they are in a scroll_container.
 * Note: If you want the scroll_container to actually work, you also need to add a

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -363,8 +363,13 @@ void GUIFormSpecMenu::parseScrollContainer(parserData *data, const std::string &
 	std::string scrollbar_name = parts[2];
 	std::string orientation = parts[3];
 	f32 scroll_factor = 0.1f;
-	if (parts.size() >= 5 && !parts[4].empty())
-		scroll_factor = stof(parts[4]);
+	bool auto_scroll_factor = false;
+	if (parts.size() >= 5 && !parts[4].empty()) {
+		if (parts[4] == "auto")
+			auto_scroll_factor = true;
+		else
+			scroll_factor = stof(parts[4]);
+	}
 
 	MY_CHECKPOS("scroll_container", 0);
 	MY_CHECKGEOM("scroll_container", 1);
@@ -404,6 +409,7 @@ void GUIFormSpecMenu::parseScrollContainer(parserData *data, const std::string &
 
 	GUIScrollContainer *mover = new GUIScrollContainer(Environment,
 			clipper, spec_mover.fid, rect_mover, orientation, scroll_factor);
+	mover->setAutoScrollFactor(auto_scroll_factor);
 
 	data->current_parent = mover;
 
@@ -3405,6 +3411,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		for (const std::pair<FieldSpec, GUIScrollBar *> &b : m_scrollbars) {
 			if (c.first == b.first.fname) {
 				c.second->setScrollBar(b.second);
+				c.second->calculateAutoScrollFactor();
 				break;
 			}
 		}

--- a/src/gui/guiScrollContainer.cpp
+++ b/src/gui/guiScrollContainer.cpp
@@ -67,6 +67,32 @@ void GUIScrollContainer::draw()
 	}
 }
 
+void GUIScrollContainer::calculateAutoScrollFactor()
+{
+	if (!m_scrollbar || !m_auto_scrollfactor)
+		return;
+
+	core::rect<s32> size;
+	for (gui::IGUIElement *e : Children) {
+		core::rect<s32> abs_rect = e->getRelativePosition();
+		size.addInternalPoint(abs_rect.UpperLeftCorner);
+		size.addInternalPoint(abs_rect.LowerRightCorner);
+	}
+
+	// Cannot use RelativeRect because it is moved upwards as we scroll down
+	size.LowerRightCorner.X -= AbsoluteClippingRect.getWidth();
+	size.LowerRightCorner.Y -= AbsoluteClippingRect.getHeight();
+
+	f32 new_factor = 0;
+	if (m_orientation == VERTICAL)
+		new_factor = -size.getHeight();
+	else if (m_orientation == HORIZONTAL)
+		new_factor = -size.getWidth();
+
+	// This factor is always <= 0, or we would be scrolling in opposite direction
+	m_scrollfactor = std::min<f32>(new_factor / m_scrollbar->getMax(), 0.0f);
+}
+
 void GUIScrollContainer::updateScrolling()
 {
 	s32 pos = m_scrollbar->getPos();

--- a/src/gui/guiScrollContainer.h
+++ b/src/gui/guiScrollContainer.h
@@ -34,6 +34,15 @@ public:
 
 	virtual void draw() override;
 
+	inline void setAutoScrollFactor(bool enable)
+	{
+		m_auto_scrollfactor = enable;
+	}
+
+	/// Calculates the scroll factor based on the scrollbar limits
+	/// Call once after the scrollbar has been added and stylized.
+	void calculateAutoScrollFactor();
+
 	inline void onScrollEvent(gui::IGUIElement *caller)
 	{
 		if (caller == m_scrollbar)
@@ -57,6 +66,7 @@ private:
 	GUIScrollBar *m_scrollbar;
 	OrientationEnum m_orientation;
 	f32 m_scrollfactor;
+	bool m_auto_scrollfactor = false;
 
 	void updateScrolling();
 };

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -244,7 +244,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
                             // base64-encoded SHA-1 (27+\0).
 
 // See also formspec [Version History] in doc/lua_api.md
-#define FORMSPEC_API_VERSION 7
+#define FORMSPEC_API_VERSION 8
 
 #define TEXTURENAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
 


### PR DESCRIPTION
When specifying 'scroll factor'='auto', it will be calculated automatically based
on the associated scrollbar maximal value. Previously, calculating the exact value was mostly guesswork and try & error.

## To do

This PR is  Ready for Review.

## How to test

`/c 0` (factor 0.005) vs `/c 1` (automatic)
```Lua
minetest.register_chatcommand("c", {
	func = function(name, param)
		local player = minetest.get_player_by_name(name)
		local value = minetest.is_yes(param) and "auto" or (5 / 1000)
		minetest.show_formspec(name, "lab:scrollcontainer",
			"formspec_version[7]"..
			"size[12,8]"..
			"scroll_container[0,0;10,4;scrbar2;vertical;" .. value .. "]"..
				"label[0.5,0.5;nest]"..
				"list[current_player;main;0,1;8,4;]"..
			"scroll_container_end[]"..
			"scrollbar[10.1,0;0.5,4;vertical;scrbar2;0]"..
			-- Scale
			"button[11,0;1,1;;0]"..
			"button[11,1;1,1;;1]"..
			"button[11,2;1,1;;2]"..
			"button[11,3;1,1;;3]"..
			"button[11,4;1,1;;4]"..
			""
		)
	end
})
```
