### PR TITLE
Close buttonbars when hiding TouchScreenGUI

### DIFF
--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -857,8 +857,10 @@ void TouchScreenGUI::setVisible(bool visible)
 	if (!visible) {
 		while (!m_pointer_pos.empty())
 			handleReleaseEvent(m_pointer_pos.begin()->first);
-		for (AutoHideButtonBar &bar : m_buttonbars)
+		for (AutoHideButtonBar &bar : m_buttonbars) {
+			bar.deactivate();
 			bar.hide();
+		}
 	} else {
 		for (AutoHideButtonBar &bar : m_buttonbars)
 			bar.show();


### PR DESCRIPTION
To open the inventory or the pause menu, you first need to open the buttonbar containing the respective button. Before this commit, the buttonbar is still open after closing the menu, so you have to tap twice before you can continue playing. After this commit, the buttonbar is already closed after closing the menu, so you only have to tap once before you can continue playing.

## To do

This PR is a Ready for Review.

## How to test

Open the inventory, close it, see that the buttonbar is already closed too.