### PR TITLE
Reenable fog toggle unless server restricts fog distance

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -381,8 +381,7 @@ crosshair_alpha (Crosshair alpha) int 255 0 255
 
 [**Fog]
 
-#    Whether to fog out the end of the visible area. This option only works
-#    with the 'debug' privilege.
+#    Whether to fog out the end of the visible area.
 enable_fog (Fog) bool true
 
 #    Make fog and sky colors depend on daytime (dawn/sunset) and view direction.
@@ -2508,7 +2507,7 @@ keymap_toggle_chat (Chat toggle key) key KEY_F2
 #    Key for toggling the display of the large chat console.
 keymap_console (Large chat console key) key KEY_F10
 
-#    Key for toggling the display of fog. Only usable with 'debug' privilege.
+#    Key for toggling the display of fog.
 keymap_toggle_fog (Fog toggle key) key KEY_F3
 
 #    Key for toggling the camera update. Only usable with 'debug' privilege.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8257,14 +8257,13 @@ child will follow movement and rotation of that bone.
                 `"default"` uses the classic Minetest sun and moon tinting.
                 Will use tonemaps, if set to `"default"`. (default: `"default"`)
         * `fog`: A table with following optional fields:
-            * `fog_distance`: integer, set an upper bound the client's viewing_range (inluding range_all).
-               By default, fog_distance is controlled by the client's viewing_range, and this field is not set.
-               Any value >= 0 sets the desired upper bound for the client's viewing_range and disables range_all.
-               Any value < 0, resets the behavior to being client-controlled.
+            * `fog_distance`: integer, set an upper bound for the client's viewing_range.
+               Any value >= 0 sets the desired upper bound for viewing_range,
+               disables range_all and prevents disabling fog (F3 key by default).
+               Any value < 0 resets the behavior to being client-controlled.
                (default: -1)
             * `fog_start`: float, override the client's fog_start.
                Fraction of the visible distance at which fog starts to be rendered.
-               By default, fog_start is controlled by the client's `fog_start` setting, and this field is not set.
                Any value between [0.0, 0.99] set the fog_start as a fraction of the viewing_range.
                Any value < 0, resets the behavior to being client-controlled.
                (default: -1)

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -172,11 +172,10 @@ void set_default_settings()
 	settings->setDefault("keymap_toggle_block_bounds", "");
 	settings->setDefault("keymap_toggle_hud", "KEY_F1");
 	settings->setDefault("keymap_toggle_chat", "KEY_F2");
-#ifndef NDEBUG
 	settings->setDefault("keymap_toggle_fog", "KEY_F3");
+#ifndef NDEBUG
 	settings->setDefault("keymap_toggle_update_camera", "KEY_F4");
 #else
-	settings->setDefault("keymap_toggle_fog", "");
 	settings->setDefault("keymap_toggle_update_camera", "");
 #endif
 	settings->setDefault("keymap_toggle_debug", "KEY_F5");


### PR DESCRIPTION
IMO disabling fog is still stupid even visually, compare these two:

| ![grafik](https://github.com/minetest/minetest/assets/1042418/bf8ac189-2c91-49c1-bfb8-e7f9bd453fc2) | ![grafik](https://github.com/minetest/minetest/assets/1042418/362f3fd5-a2b1-4c5e-99dc-f9a94085fdb6) | 
| -- | -- |
| fog_start=0.99 | fog disabled |

## To do

This PR is Ready for Review.


## How to test

should be obvious
