### PR TITLE
Fix crash if zip file cannot be opened

### DIFF
--- a/builtin/mainmenu/content/contentdb.lua
+++ b/builtin/mainmenu/content/contentdb.lua
@@ -71,7 +71,9 @@ local function download_and_extract(param)
 	os.remove(filename)
 	if tempfolder == "" then
 		return {
-			msg = fgettext_ne("Failed to extract \"$1\" (unsupported file type or broken archive)", package.title),
+			msg = fgettext_ne("Failed to extract \"$1\" " ..
+					"(insufficient disk space, unsupported file type or broken archive)",
+					package.title),
 		}
 	end
 

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -932,6 +932,8 @@ bool extractZipFile(io::IFileSystem *fs, const char *filename, const std::string
 	}
 
 	irr_ptr<io::IFileArchive> opened_zip(zip_loader->createArchive(filename, false, false));
+	if (!opened_zip)
+		return false;
 	const io::IFileList* files_in_zip = opened_zip->getFileList();
 
 	for (u32 i = 0; i < files_in_zip->getFileCount(); i++) {


### PR DESCRIPTION
Fixes #14632 and by coincidence also #11842

Thanks to @savilli for doing the hard work.

## To do

This PR is a Ready for Review.

- [ ] Should we store the temporary zip file somewhere else?

## How to test

Give an invalid file path to `core.extract_zip` here and see that it doesn't crash:

https://github.com/minetest/minetest/blob/0aa2ae910b6b2140cf5648f3a2c2ef83b90c291c/builtin/mainmenu/content/contentdb.lua#L68
