### PR TITLE
Add option for random mod load order

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1760,6 +1760,9 @@ deprecated_lua_api_handling (Deprecated Lua API handling) enum log none,log,erro
 #    Enable random user input (only used for testing).
 random_input (Random input) bool false
 
+#    Enable random mod loading (mainly used for testing).
+random_mod_load_order (Random mod load order) bool false
+
 #    Enable mod channels support.
 enable_mod_channels (Mod channels) bool false
 

--- a/src/content/mod_configuration.cpp
+++ b/src/content/mod_configuration.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "gettext.h"
 #include "exceptions.h"
+#include "util/numeric.h"
 
 
 std::string ModConfiguration::getUnsatisfiedModsError() const
@@ -224,6 +225,17 @@ void ModConfiguration::resolveDependencies()
 	std::set<std::string> modnames;
 	for (const ModSpec &mod : m_unsatisfied_mods) {
 		modnames.insert(mod.name);
+	}
+
+	// Step 1.5 (optional): shuffle unsatisfied mods so non declared depends get found by their devs
+	if (g_settings->getBool("random_mod_load_order")) {
+		//std::random_shuffle would be better here, but it has been removed in C++17
+		//see https://en.cppreference.com/w/cpp/algorithm/random_shuffle
+		MyRandGenerator rg;
+		std::shuffle(m_unsatisfied_mods.begin(),
+			m_unsatisfied_mods.end(),
+			rg
+		);
 	}
 
 	// Step 2: get dependencies (including optional dependencies)

--- a/src/content/mod_configuration.cpp
+++ b/src/content/mod_configuration.cpp
@@ -229,8 +229,6 @@ void ModConfiguration::resolveDependencies()
 
 	// Step 1.5 (optional): shuffle unsatisfied mods so non declared depends get found by their devs
 	if (g_settings->getBool("random_mod_load_order")) {
-		//std::random_shuffle would be better here, but it has been removed in C++17
-		//see https://en.cppreference.com/w/cpp/algorithm/random_shuffle
 		MyRandGenerator rg;
 		std::shuffle(m_unsatisfied_mods.begin(),
 			m_unsatisfied_mods.end(),

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -418,6 +418,11 @@ void set_default_settings()
 	// Server
 	settings->setDefault("disable_escape_sequences", "false");
 	settings->setDefault("strip_color_codes", "false");
+#ifndef NDEBUG
+	settings->setDefault("random_mod_load_order", "true");
+#else
+	settings->setDefault("random_mod_load_order", "false");
+#endif
 #if USE_PROMETHEUS
 	settings->setDefault("prometheus_listener_address", "127.0.0.1:30000");
 #endif


### PR DESCRIPTION
This is a small PR which adds the option for the load order of mods to be randomized, like #14618 suggested.
The goal of the PR is to load mods at random in debug builds (can be enabled via setting in release too), while still paying attention to dependencies… That way, undeclared dependencies are easier to find, and mod developers HAVE to pay attention to them.
**How does the PR work?**
The PR shuffles all mods before they get sorted by decencies.

**Does it resolve any reported issue?**
Yes, merging this would close #14618

This PR is Ready for Review.

## How to test

- Start up the game
- Download a huge game (I can highly recommend MineClone2, it has countless mods and suffers greatly from the problem described in the issue this PR tries to resolve)
- Verify that the game does not start up (well, it's possible, but given the amount of undeclared decency problems in mcl VERY unlikely)
- Check that the mod that causes the crash does not specify the mod it is missing as a decency
