### PR TITLE
Fixes to Docker GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -25,6 +25,12 @@ on:
       - '.dockerignore'
       - '.github/workflows/docker_image.yml'
   workflow_dispatch:
+    inputs:
+      use_cache:
+        description: "Use build cache"
+        required: true
+        type: boolean
+        default: true
 
 env:
   REGISTRY: ghcr.io
@@ -80,7 +86,7 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
+          cache-from: ${{ (inputs.use_cache || !startsWith(github.ref, 'refs/tags/')) && 'type=gha' || '' }}
           cache-to: type=gha,mode=max
 
       - name: Test Docker Image

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -88,7 +88,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          no-cache: ${{ !inputs.use_cache || startsWith(github.ref, 'refs/tags/') }}
+          no-cache: ${{ (github.event_name == 'workflow_dispatch' && !inputs.use_cache) || startsWith(github.ref, 'refs/tags/') }}
 
       - name: Test Docker Image
         run: |

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -86,8 +86,9 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: ${{ (inputs.use_cache && !startsWith(github.ref, 'refs/tags/')) && 'type=gha' || '' }}
+          cache-from: type=gha
           cache-to: type=gha,mode=max
+          no-cache: ${{ !inputs.use_cache || !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Test Docker Image
         run: |

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: [ "master" ]
     # Publish semver tags as releases.
-    tags: [ "*.*.*" ]
+    tags: [ "*" ]
   pull_request:
     # Build docker image on pull requests. (but do not publish)
     paths:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -86,7 +86,7 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: ${{ (inputs.use_cache || !startsWith(github.ref, 'refs/tags/')) && 'type=gha' || '' }}
+          cache-from: ${{ (inputs.use_cache && !startsWith(github.ref, 'refs/tags/')) && 'type=gha' || '' }}
           cache-to: type=gha,mode=max
 
       - name: Test Docker Image

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -88,7 +88,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          no-cache: ${{ !inputs.use_cache || !startsWith(github.ref, 'refs/tags/') }}
+          no-cache: ${{ !inputs.use_cache || startsWith(github.ref, 'refs/tags/') }}
 
       - name: Test Docker Image
         run: |


### PR DESCRIPTION
Two fixes to the Docker image workflow.

- [x] Fix the workflow run on tags (was untested in my first PR, my bad)
- [x] Do not use Docker cache for tag builds, also add a parameter to workflow_dispatch to allow building without cache

## To do

This PR is Ready for Review.

## How to test

Get these commits in the master branch of a Minetest fork.

Try to run the workflow with workflow_dispatch, with and without the "Use build cache" checkbox.

Push a tag to the fork, see the workflow run in the Actions tab (unlike with the current workflow).

For these runs check the parameters of the `Build and push Docker image` step (in the first folding section of the log), see the `no-cache`  parameter. It should be true on tags, false on normal push, false on PRs, true or false depending of the workflow_dispatch input.

**This PR fixes the build on tags, so it should probably be merged for 5.9.0 (yet the official image could be build after the release using workflow_dispatch)**