### PR TITLE
Don't bundle Development Test on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -55,6 +55,7 @@ jobs:
       - name: CPack
         run: |
           cd build
+          cmake .. -DINSTALL_DEVTEST=FALSE
           cpack -G ZIP -B macos
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR removes devtest from the macOS app bundle.

When devtest was originally no longer installed it caused macOS unit tests to fail, as the unit tests required devtest to be present and macOS needs the engine to be installed first to run the unit tests. So it was enabled there in CI to make the problem go away. This unfortunately made it be still be bundled with the engine on macOS as the CI artifacts are used as releases, which has probably caused some confusion for 5.8 when MTG was debundled.

This PR does, what I probably should have done originally, and disable installing devtest again between when the engine is installed for unit tests and an app bundle is packaged.

## To do
This PR is a Ready for Review.

## How to test
Check the resulting CI artifact in this PR, compare to the 5.8.0 one and see that devtest is no longer present.

![image](https://github.com/minetest/minetest/assets/60856959/a0a6263a-563a-4201-bb36-5e51b29a2f3e)
