### PR TITLE
[no squash] Get rid of the last remaining sync. HTTP requests on the main thread

### DIFF
--- a/builtin/mainmenu/content/contentdb.lua
+++ b/builtin/mainmenu/content/contentdb.lua
@@ -182,14 +182,26 @@ function contentdb.get_package_by_id(id)
 end
 
 
-local function get_raw_dependencies(package)
-	if package.type ~= "mod" then
-		return {}
-	end
-	if package.raw_deps then
-		return package.raw_deps
+-- Create a coroutine from `fn` and provide results to `callback` when complete (dead).
+-- Returns a resumer function.
+local function make_callback_coroutine(fn, callback)
+	local co = coroutine.create(fn)
+
+	local function resumer(...)
+		local ok, result = coroutine.resume(co, ...)
+
+		if not ok then
+			error(result)
+		elseif coroutine.status(co) == "dead" then
+			callback(result)
+		end
 	end
 
+	return resumer
+end
+
+
+local function get_raw_dependencies_async(package)
 	local url_fmt = "/api/packages/%s/dependencies/?only_hard=1&protocol_version=%s&engine_version=%s"
 	local version = core.get_version()
 	local base_url = core.settings:get("contentdb_url")
@@ -198,11 +210,25 @@ local function get_raw_dependencies(package)
 	local http = core.get_http_api()
 	local response = http.fetch_sync({ url = url })
 	if not response.succeeded then
-		core.log("error", "Unable to fetch dependencies for " .. package.url_part)
-		return
+		return nil
+	end
+	return core.parse_json(response.data) or {}
+end
+
+
+local function get_raw_dependencies_co(package, resumer)
+	if package.type ~= "mod" then
+		return {}
+	end
+	if package.raw_deps then
+		return package.raw_deps
 	end
 
-	local data = core.parse_json(response.data) or {}
+	core.handle_async(get_raw_dependencies_async, package, resumer)
+	local data = coroutine.yield()
+	if not data then
+		return nil
+	end
 
 	for id, raw_deps in pairs(data) do
 		local package2 = contentdb.package_by_id[id:lower()]
@@ -223,8 +249,8 @@ local function get_raw_dependencies(package)
 end
 
 
-function contentdb.has_hard_deps(package)
-	local raw_deps = get_raw_dependencies(package)
+local function has_hard_deps_co(package, resumer)
+	local raw_deps = get_raw_dependencies_co(package, resumer)
 	if not raw_deps then
 		return nil
 	end
@@ -239,8 +265,14 @@ function contentdb.has_hard_deps(package)
 end
 
 
+function contentdb.has_hard_deps(package, callback)
+	local resumer = make_callback_coroutine(has_hard_deps_co, callback)
+	resumer(package, resumer)
+end
+
+
 -- Recursively resolve dependencies, given the installed mods
-local function resolve_dependencies_2(raw_deps, installed_mods, out)
+local function resolve_dependencies_2_co(raw_deps, installed_mods, out, resumer)
 	local function resolve_dep(dep)
 		-- Check whether it's already installed
 		if installed_mods[dep.name] then
@@ -290,9 +322,9 @@ local function resolve_dependencies_2(raw_deps, installed_mods, out)
 			local result  = resolve_dep(dep)
 			out[dep.name] = result
 			if result and result.package and not result.installed then
-				local raw_deps2 = get_raw_dependencies(result.package)
+				local raw_deps2 = get_raw_dependencies_co(result.package, resumer)
 				if raw_deps2 then
-					resolve_dependencies_2(raw_deps2, installed_mods, out)
+					resolve_dependencies_2_co(raw_deps2, installed_mods, out, resumer)
 				end
 			end
 		end
@@ -302,11 +334,10 @@ local function resolve_dependencies_2(raw_deps, installed_mods, out)
 end
 
 
--- Resolve dependencies for a package, calls the recursive version.
-function contentdb.resolve_dependencies(package, game)
+local function resolve_dependencies_co(package, game, resumer)
 	assert(game)
 
-	local raw_deps = get_raw_dependencies(package)
+	local raw_deps = get_raw_dependencies_co(package, resumer)
 	local installed_mods = {}
 
 	local mods = {}
@@ -320,7 +351,7 @@ function contentdb.resolve_dependencies(package, game)
 	end
 
 	local out = {}
-	if not resolve_dependencies_2(raw_deps, installed_mods, out) then
+	if not resolve_dependencies_2_co(raw_deps, installed_mods, out, resumer) then
 		return nil
 	end
 
@@ -334,6 +365,13 @@ function contentdb.resolve_dependencies(package, game)
 	end)
 
 	return retval
+end
+
+
+-- Resolve dependencies for a package, calls the recursive version.
+function contentdb.resolve_dependencies(package, game, callback)
+	local resumer = make_callback_coroutine(resolve_dependencies_co, callback)
+	resumer(package, game, resumer)
 end
 
 

--- a/builtin/mainmenu/content/dlg_contentdb.lua
+++ b/builtin/mainmenu/content/dlg_contentdb.lua
@@ -63,21 +63,12 @@ local function install_or_update_package(this, package)
 	end
 
 	local function on_confirm()
-		local has_hard_deps = contentdb.has_hard_deps(package)
-		if has_hard_deps then
-			local dlg = create_install_dialog(package)
-			dlg:set_parent(this)
-			this:hide()
-			dlg:show()
-		elseif has_hard_deps == nil then
-			local dlg = messagebox("error_checking_deps",
-					fgettext("Error getting dependencies for package"))
-			dlg:set_parent(this)
-			this:hide()
-			dlg:show()
-		else
-			contentdb.queue_download(package, package.path and contentdb.REASON_UPDATE or contentdb.REASON_NEW)
-		end
+		local dlg = create_install_dialog(package)
+		dlg:set_parent(this)
+		this:hide()
+		dlg:show()
+
+		dlg:load_deps()
 	end
 
 	if package.type == "mod" and #pkgmgr.games == 0 then

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -749,19 +749,6 @@ static void httpfetch_request_clear(u64 caller)
 	}
 }
 
-static void httpfetch_sync(const HTTPFetchRequest &fetch_request,
-		HTTPFetchResult &fetch_result)
-{
-	// Create ongoing fetch data and make a cURL handle
-	// Set cURL options based on HTTPFetchRequest
-	CurlHandlePool pool;
-	HTTPFetchOngoing ongoing(fetch_request, &pool);
-	// Do the fetch (curl_easy_perform)
-	CURLcode res = ongoing.start(nullptr);
-	// Update fetch result
-	fetch_result = *ongoing.complete(res);
-}
-
 bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
 		HTTPFetchResult &fetch_result, long interval)
 {
@@ -779,7 +766,8 @@ bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
 		} while (!httpfetch_async_get(req.caller, fetch_result));
 		httpfetch_caller_free(req.caller);
 	} else {
-		httpfetch_sync(fetch_request, fetch_result);
+		throw ModError(std::string("You have tried to execute a synchronous HTTP request on the main thread! "
+				"This offense shall be punished. (").append(fetch_request.url).append(")"));
 	}
 	return true;
 }


### PR DESCRIPTION
Building upon the work in #13551 and #14412, this PR aims to make sure that there will never be ANRs related to HTTP requests again.

- Commit 1 moves the last remaining HTTP request from the main thread to `core.handle_async`. To reduce the amount of changes to existing code and to avoid callback hell, it uses coroutines.

    The HTTP request in question is the one that fetches a dependency list from CDB before attempting to install a package. While it's usually very fast, it can take long if you have a bad internet connection or if it times out.

- Commit 2 removes the ability to execute synchronous HTTP requests on the main thread from `httpfetch.cpp`. This doesn't break backwards compatibility because `fetch_sync` is only available in the mainmenu. Since any synchronous HTTP request on the main thread is a bug, we should avoid introducing one again in the future.

## To do

This PR is a Ready for Review.

- [x] Investigate whether more code can be removed from `httpfetch.cpp`.  
     There is probably more to remove, but I fear that I don't know the code well enough to avoid accidentally breaking things.

## How to test

Verify that Minetest doesn't freeze for a short while anymore after you press the install button on a package.

Try to install lots of different packages from CDB. Verify that dependencies are resolved correctly and that packages are installed correctly.