### PR TITLE
Do not bother to assert that a u8 is >= 0

### DIFF
--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -167,7 +167,7 @@ public:
 	inline void setLightingComplete(LightBank bank, u8 direction,
 		bool is_complete)
 	{
-		assert(direction >= 0 && direction <= 5);
+		assert(direction <= 5);
 		if (bank == LIGHTBANK_NIGHT) {
 			direction += 6;
 		}
@@ -182,7 +182,7 @@ public:
 
 	inline bool isLightingComplete(LightBank bank, u8 direction)
 	{
-		assert(direction >= 0 && direction <= 5);
+		assert(direction <= 5);
 		if (bank == LIGHTBANK_NIGHT) {
 			direction += 6;
 		}


### PR DESCRIPTION
This fixes a warning seen in GCC 7 on CI about a comparison in mapblock.h that is always true.

## To do

Ready for Review.

## How to test

The warning should now be gone in CI.
