### PR TITLE
Fix strange behavior when dragging&dropping from MTG creative inventory 

### DIFF
--- a/games/devtest/mods/chest/chest_limited.lua
+++ b/games/devtest/mods/chest/chest_limited.lua
@@ -1,0 +1,53 @@
+local function print_to_everything(msg)
+	minetest.log("action", "[chest] " .. msg)
+	minetest.chat_send_all(msg)
+end
+
+minetest.register_node("chest:chest_limited", {
+	description = "Chest Limited" .. "\n" ..
+		"32 inventory slots" .. "\n" ..
+		"Allowed items for put/take/move quals to slot index.",
+	tiles ={"chest_chest.png^[sheet:2x2:0,0", "chest_chest.png^[sheet:2x2:0,0",
+		"chest_chest.png^[sheet:2x2:1,0", "chest_chest.png^[sheet:2x2:1,0",
+		"chest_chest.png^[sheet:2x2:1,0", "chest_chest.png^[sheet:2x2:0,1"},
+	paramtype2 = "4dir",
+	groups = {dig_immediate=2,choppy=3,meta_is_privatizable=1},
+	is_ground_content = false,
+	on_construct = function(pos)
+		local meta = minetest.get_meta(pos)
+		meta:set_string("formspec",
+				"size[8,9]"..
+				"list[current_name;main;0,0;8,4;]"..
+				"list[current_player;main;0,5;8,4;]" ..
+				"listring[]")
+		meta:set_string("infotext", "Chest Limited")
+		local inv = meta:get_inventory()
+		inv:set_size("main", 8*4)
+	end,
+	can_dig = function(pos,player)
+		local meta = minetest.get_meta(pos);
+		local inv = meta:get_inventory()
+		return inv:is_empty("main")
+	end,
+	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
+		print_to_everything("Chest Limited: ".. player:get_player_name() .. " triggered 'allow put' ("..index..") event for " .. stack:to_string())
+		return index
+	end,
+	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
+		print_to_everything("Chest Limited: ".. player:get_player_name() .. " triggered 'allow take' ("..index..") event for " .. stack:to_string())
+		return index
+	end,
+	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
+		print_to_everything("Chest Limited: ".. player:get_player_name() .. " triggered 'allow move' ("..from_index..") event")
+		return from_index
+	end,
+	on_metadata_inventory_put = function(pos, listname, index, stack, player)
+		print_to_everything("Chest Limited: ".. player:get_player_name() .. " put " .. stack:to_string())
+	end,
+	on_metadata_inventory_take = function(pos, listname, index, stack, player)
+		print_to_everything("Chest Limited: ".. player:get_player_name() .. " took " .. stack:to_string())
+	end,
+	on_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
+		print_to_everything("Chest Limited: ".. player:get_player_name() .. " moved " .. count)
+	end,
+})

--- a/games/devtest/mods/chest/init.lua
+++ b/games/devtest/mods/chest/init.lua
@@ -1,2 +1,3 @@
 dofile(minetest.get_modpath("chest").."/chest.lua")
+dofile(minetest.get_modpath("chest").."/chest_limited.lua")
 dofile(minetest.get_modpath("chest").."/detached.lua")

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4785,7 +4785,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			}
 
 			if (move_amount > 0) {
-				infostream << "Handing IAction::Move to manager" << std::endl;
+				infostream << "Handing IAction::Move to manager (move)" << std::endl;
 				IMoveAction *a = new IMoveAction();
 				a->count = move_amount;
 				a->from_inv = m_selected_item->inventoryloc;
@@ -4820,7 +4820,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			if (pickup_amount > 0) {
 				m_selected_amount += pickup_amount;
 
-				infostream << "Handing IAction::Move to manager" << std::endl;
+				infostream << "Handing IAction::Move to manager (pickup)" << std::endl;
 				IMoveAction *a = new IMoveAction();
 				a->count = pickup_amount;
 				a->from_inv = s.inventoryloc;
@@ -4855,7 +4855,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 				if (shift_move_amount == 0)
 					break;
 
-				infostream << "Handing IAction::Move to manager" << std::endl;
+				infostream << "Handing IAction::Move to manager (shift-move)" << std::endl;
 				IMoveAction *a = new IMoveAction();
 				a->count = shift_move_amount;
 				a->from_inv = s.inventoryloc;
@@ -4879,7 +4879,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			assert(drop_amount > 0 && drop_amount <= m_selected_amount);
 			m_selected_amount -= drop_amount;
 
-			infostream << "Handing IAction::Drop to manager" << std::endl;
+			infostream << "Handing IAction::Drop to manager (drop)" << std::endl;
 			IDropAction *a = new IDropAction();
 			a->count = drop_amount;
 			a->from_inv = m_selected_item->inventoryloc;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3799,10 +3799,6 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 
 void GUIFormSpecMenu::updateSelectedItem()
 {
-	// Don't update when dragging an item
-	if (m_selected_item && (m_left_dragging && (m_left_drag_stacks.size() > 1)))
-		return;
-
 	verifySelectedItem();
 
 	// If craftresult is not empty and nothing else is selected,
@@ -4474,7 +4470,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 					m_client->inhibit_inventory_revert = true;
 					m_left_drag_stack = list_selected->getItem(m_selected_item->i);
 					m_left_drag_amount = m_selected_amount;
-					m_left_drag_stacks.emplace_back(s, list_s->getItem(s.i));
+					m_left_drag_stacks.emplace_back(s, list_s->getItem(s.i).count);
 					move_amount = 0;
 
 				} else if (identical) {
@@ -4535,7 +4531,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 						Inventory *inv_to = m_invmgr->getInventory(ds.first.inventoryloc);
 						InventoryList *list_to = inv_to->getList(ds.first.listname);
 						ItemStack stack_to = list_to->getItem(ds.first.i);
-						u16 amount = stack_to.count - ds.second.count;
+						u16 amount = stack_to.count - ds.second;
 
 						IMoveAction *a = new IMoveAction();
 						a->count = amount;
@@ -4597,7 +4593,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 						}
 					}
 					if (!found) {
-						m_left_drag_stacks.emplace_back(s, list_s->getItem(s.i));
+						m_left_drag_stacks.emplace_back(s, list_s->getItem(s.i).count);
 					}
 
 				} else if (m_selected_dragging && matching && !identical) {
@@ -4726,7 +4722,9 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 				} else {
 					// Reset the stack to its original state
-					list_to->changeItem(ds.first.i, ds.second);
+					ItemStack orig_stack = list_to->getItem(ds.first.i);
+					orig_stack.count = ds.second;
+					list_to->changeItem(ds.first.i, orig_stack);
 
 					// Add the new split to the stack
 					ItemStack add_stack = stack_from;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3800,7 +3800,7 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 void GUIFormSpecMenu::updateSelectedItem()
 {
 	// Don't update when dragging an item
-	if (m_selected_item && (m_selected_dragging || m_left_dragging))
+	if (m_selected_item && (m_left_dragging && (m_left_drag_stacks.size() > 1)))
 		return;
 
 	verifySelectedItem();

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -363,7 +363,7 @@ protected:
 
 	u16 m_left_drag_amount = 0;
 	ItemStack m_left_drag_stack;
-	std::vector<std::pair<GUIInventoryList::ItemSpec, ItemStack>> m_left_drag_stacks;
+	std::vector<std::pair<GUIInventoryList::ItemSpec, u16>> m_left_drag_stacks;
 	bool m_left_dragging = false;
 
 	gui::IGUIStaticText *m_tooltip_element = nullptr;

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -460,8 +460,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		if (from_inv.type == InventoryLocation::PLAYER)
 			list_from->setModified();
 
-		if (to_inv.type == InventoryLocation::PLAYER)
-			list_to->setModified();
+		list_to->setModified();
 
 		infostream<<"IMoveAction::apply(): move was completely disallowed:"
 				<<" move_count="<<old_move_count


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
Fix #13961
- How does the PR work?
Update inventory in case move is not allowed and update `m_selected_amount`
- Does it resolve any reported issue?
#13961
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?

## To do

Ready for Review.

## How to test

See #13961
