### PR TITLE
Fix inventory: Quickly picking up item and placing it again no longer works

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4625,11 +4625,6 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			if (!m_left_dragging)
 				break;
 
-			// Abort left-dragging
-			m_left_dragging = false;
-			m_client->inhibit_inventory_revert = false;
-			m_left_drag_stacks.clear();
-
 			// Both the selected item and the hovered item need to be checked
 			// because we don't know exactly when the double-click happened
 			ItemStack slct;
@@ -4658,6 +4653,12 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 						}
 
 						if (amount > 0) {
+							if (m_left_dragging) {
+								// Abort left-dragging
+								m_left_dragging = false;
+								m_client->inhibit_inventory_revert = false;
+								m_left_drag_stacks.clear();
+							}
 							IMoveAction *a = new IMoveAction();
 							a->count = amount;
 							a->from_inv = s.inventoryloc;


### PR DESCRIPTION
- Goal of the PR
Fix #14233
- How does the PR work?
Disable `left_dragging` only if there are items to pickup by double click.
- Does it resolve any reported issue?
#14233

## To do

Ready for Review.

## How to test

See #14233

