### PR TITLE
Fix inventory items unresponsive after tab interaction until LMB click on formspec 

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4098,6 +4098,8 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 			skin->setFont(m_font);
 			bool retval = hovered->OnEvent(event);
 			skin->setFont(old_font);
+			// This is expected to be set to BET_OTHER with mouse UP event
+			m_held_mouse_button = BET_OTHER;
 			return retval;
 		}
 	}


### PR DESCRIPTION
- Goal of the PR
Fix #14250
- How does the PR work?
Set `m_held_mouse_button` to `BET_OTHER` when the mouse UP event happens over tab control.
- Does it resolve any reported issue?
#14250

## To do

Ready for Review.

## How to test
See #14250
