### PR TITLE
Restore vector type check

### DIFF
--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -58,6 +58,7 @@ extern "C" {
  */
 static void read_v3_aux(lua_State *L, int index)
 {
+	CHECK_POS_TAB(index);
 	lua_pushvalue(L, index);
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_READ_VECTOR);
 	lua_insert(L, -2);


### PR DESCRIPTION
Restores the type check for vectors that was lost in https://github.com/minetest/minetest/commit/b38ffdec279bcded98e34f5116c8d676aa9f73a7.

Example error messages, without and with the type check:
```
ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod 'test' in callback ScriptApiEnv::environment_Step(): ...\builtin\common\vector.lua:380: attempt to index local 'v' (a nil value)
ERROR[Main]: stack traceback:
ERROR[Main]:       ...\builtin\common\vector.lua:380: in function <...\builtin\common\vector.lua:379>
ERROR[Main]:       [C]: in function 'set_pos'
ERROR[Main]:       ...\mods\test\init.lua:3: in function 'func'
```
```
ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod 'test' in callback ScriptApiEnv::environment_Step(): "Invalid vector (expected table got nil)."
ERROR[Main]: stack traceback:
ERROR[Main]:       [C]: in function 'set_pos'
ERROR[Main]:       ...\mods\test\init.lua:3: in function 'func'
```