### PR TITLE
Enable RTTI for Irrlicht on MSVC

### DIFF
--- a/irr/src/CMakeLists.txt
+++ b/irr/src/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
 elseif(MSVC)
 	string(APPEND CMAKE_CXX_STANDARD_LIBRARIES " msvcrt.lib") # ???? fuck off
 
-	add_compile_options(/GR- /Zl)
+	add_compile_options(/Zl)
 
 	# Enable SSE for floating point math on 32-bit x86 by default
 	# reasoning see minetest issue #11810 and https://gcc.gnu.org/wiki/FloatingPointMath


### PR DESCRIPTION
This PR enables RTTI for Irrlicht on MSVC. This was probably forgotten in https://github.com/minetest/irrlicht/pull/268 because of the different option name.

Fixes #14672

## To do

This PR is a Ready for Review.

## How to test

> Open a formspec with a `field` element (e.g. a sign), and click outside of it.

Verify that there is no crash.