### PR TITLE
Fix and clarify skybox texture order documentation

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8223,8 +8223,10 @@ child will follow movement and rotation of that bone.
             (default: `"regular"`)
         * `textures`: A table containing up to six textures in the following
             order: Y+ (top), Y- (bottom), X+ (east), X- (west), Z- (south), Z+ (north).
-            The top and bottom textures are aligned with the X+ (east) plane. Many top and bottom textures
-            (those which are front-aligned) will need to be rotated by -90 and 90 degrees, respectively.
+            The top and bottom textures are oriented in-line with the east (X+) face (the top edge of the
+            bottom texture and the bottom edge of the top texture touch the east face).
+            Some top and bottom textures expect to be aligned with the north face and will need to be rotated
+            by -90 and 90 degrees, respectively, to fit the eastward orientation.
         * `clouds`: Boolean for whether clouds appear. (default: `true`)
         * `sky_color`: A table used in `"regular"` type only, containing the
           following values (alpha is ignored):

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8222,7 +8222,9 @@ child will follow movement and rotation of that bone.
             * `"plain"`: Uses 0 textures, `base_color` used as both fog and sky.
             (default: `"regular"`)
         * `textures`: A table containing up to six textures in the following
-            order: Y+ (top), Y- (bottom), X- (west), X+ (east), Z+ (north), Z- (south).
+            order: Y+ (top), Y- (bottom), X+ (east), X- (west), Z- (south), Z+ (north).
+            The top and bottom textures are aligned with the X+ (east) plane. Many top and bottom textures
+            (those which are front-aligned) will need to be rotated by -90 and 90 degrees, respectively.
         * `clouds`: Boolean for whether clouds appear. (default: `true`)
         * `sky_color`: A table used in `"regular"` type only, containing the
           following values (alpha is ignored):


### PR DESCRIPTION
The order of skybox textures is currently listed as Y+ (top), Y- (bottom), X- (west), X+ (east), Z+ (north), Z- (south). Testing with simple T/B/W/E/N/S textures and comparing with F5 proves this is clearly not the case.

The original Irrlicht `CSkyBoxSceneNode` defines Z- as the "front" and a direction order of left/right/front/back, making the plane order X+/X-/Z-/Z+. The documentation was erroneously based on the direction order rather than the plane order.

Also, Irrlicht (now Minetest) aligns the top/bottom textures with the right (East) face (`─━┼─`), where most skybox textures are aligned with the front face (`─┿──`). I have clarified this accordingly.

Most people have probably used the order N/S/E/W, which effectively rotates the skybox such that the North texture is on the East face, which works fine as long as the texture doesn't need to be cardinally-aligned.

Aside: Don't make PRs when sleepy :D