### PR TITLE
Android: Don't crash if there is no web browser installed

### DIFF
--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -206,7 +206,7 @@ public class GameActivity extends SDLActivity {
 		try {
 			startActivity(browserIntent);
 		} catch (ActivityNotFoundException e) {
-			runOnUiThread(() -> Toast.makeText(this, "No web browser found", Toast.LENGTH_SHORT).show());
+			runOnUiThread(() -> Toast.makeText(this, R.string.no_web_browser, Toast.LENGTH_SHORT).show());
 		}
 	}
 

--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -23,6 +23,7 @@ package net.minetest.minetest;
 import org.libsdl.app.SDLActivity;
 
 import android.content.Intent;
+import android.content.ActivityNotFoundException;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.InputType;
@@ -33,6 +34,7 @@ import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.LinearLayout;
+import android.widget.Toast;
 import android.content.res.Configuration;
 
 import androidx.annotation.Keep;
@@ -201,7 +203,11 @@ public class GameActivity extends SDLActivity {
 
 	public void openURI(String uri) {
 		Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
-		startActivity(browserIntent);
+		try {
+			startActivity(browserIntent);
+		} catch (ActivityNotFoundException e) {
+			runOnUiThread(() -> Toast.makeText(this, "No web browser found", Toast.LENGTH_SHORT).show());
+		}
 	}
 
 	public String getUserDataPath() {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -7,4 +7,5 @@
 	<string name="unzip_notification_title">Loading Minetest</string>
 	<string name="unzip_notification_description">Less than 1 minute&#8230;</string>
 	<string name="ime_dialog_done">Done</string>
+	<string name="no_web_browser">No web browser found</string>
 </resources>


### PR DESCRIPTION
Should fix another common ("common") crash reported by the Play Console:

```
No pending exception expected: android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.VIEW dat=https://content.minetest.net/... }
```

```
No pending exception expected: android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.VIEW dat=https://www.minetest.net/... }
```

## To do

This PR is a Ready for Review.

## How to test

Get yourself Android Studio, create a virtual device and uninstall all web browsers, try to open a link in Minetest and verify that there is no crash.