### PR TITLE
Enable "FULL" debug info for Android build

### DIFF
--- a/android/native/build.gradle
+++ b/android/native/build.gradle
@@ -36,7 +36,7 @@ android {
 	buildTypes {
 		release {
 			ndk {
-				debugSymbolLevel 'SYMBOL_TABLE'
+				debugSymbolLevel 'FULL'
 			}
 		}
 	}


### PR DESCRIPTION
see https://github.com/minetest/minetest/issues/14632#issuecomment-2103501937

https://developer.android.com/build/shrink-code#native-crash-support

## To do

This PR is a Ready for Review.

## How to test


Verify that the APK size didn't increase.

Other than that: ???, I guess we'll see whether it worked after the 5.9.0 release ???