### PR TITLE
Fix artifacts with bloom + tonemapping on ogles2

### DIFF
--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -61,7 +61,7 @@ vec4 applyBloom(vec4 color, vec2 uv)
 	equation used:  ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - E / F
 */
 
-vec3 uncharted2Tonemap(vec3 x)
+highp vec3 uncharted2Tonemap(highp vec3 x)
 {
 	return ((x * (0.22 * x + 0.03) + 0.002) / (x * (0.22 * x + 0.3) + 0.06)) - 0.03333;
 }

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -61,6 +61,7 @@ vec4 applyBloom(vec4 color, vec2 uv)
 	equation used:  ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - E / F
 */
 
+// see https://github.com/minetest/minetest/pull/14688
 highp vec3 uncharted2Tonemap(highp vec3 x)
 {
 	return ((x * (0.22 * x + 0.03) + 0.002) / (x * (0.22 * x + 0.3) + 0.06)) - 0.03333;


### PR DESCRIPTION
This PR fixes some artifacts that occur on my phone when enabling bloom and tonemapping at the same time. I first noticed this bug in https://github.com/minetest/minetest/pull/14641#pullrequestreview-2051340546.

before (black lines on close acacia leaves in the sun)
<img alt="screenshot 1 before" src="https://github.com/minetest/minetest/assets/82708541/6b3d479e-fba4-400f-86f4-e1216bfaa7d9" width="512" />

after
<img alt="screenshot 1 after" src="https://github.com/minetest/minetest/assets/82708541/06c26c84-8ba5-403a-99ff-e2062477a8ed" width="512" />

before (black rectangles on flowing water in the darkness)
<img alt="screenshot 2 before" src="https://github.com/minetest/minetest/assets/82708541/4f101ced-b143-450f-aaae-4f726a734ca0" width="512" />

after
<img alt="screenshot 2 after" src="https://github.com/minetest/minetest/assets/82708541/d02e8c3d-a0ea-43c3-96ff-36831c4bc822" width="512" />

I arrived at this solution by ...
1. ... verifying that the bug is a precision problem
2. ... narrowing it down to the fragment stage
3. ... narrowing it down to the "second_stage" shader
4. ... narrowing it down to the `uncharted2Tonemap` function

If you know a better approach to debugging this kind of bugs, please share.

## To do

This PR is a Ready for Review.

## How to test

Replicate one of the situations shown above, verify that there are no artifacts.