### PR TITLE
Consistent width for internal scrollbars of formspec elements

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -343,7 +343,7 @@ void ClientLauncher::init_guienv(gui::IGUIEnvironment *guienv)
 	float density = rangelim(g_settings->getFloat("gui_scaling"), 0.5f, 20) *
 		RenderingEngine::getDisplayDensity();
 	skin->setSize(gui::EGDS_CHECK_BOX_WIDTH, (s32)(17.0f * density));
-	skin->setSize(gui::EGDS_SCROLLBAR_SIZE, (s32)(14.0f * density));
+	skin->setSize(gui::EGDS_SCROLLBAR_SIZE, (s32)(21.0f * density));
 	skin->setSize(gui::EGDS_WINDOW_BUTTON_WIDTH, (s32)(15.0f * density));
 	if (density > 1.5f) {
 		std::string sprite_path = porting::path_share + "/textures/base/pack/";

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -274,10 +274,10 @@ void GUIScrollBar::setPosRaw(const s32 &pos)
 	s32 thumb_min = 0;
 
 	if (is_horizontal) {
-		thumb_min = RelativeRect.getHeight();
+		thumb_min = std::min(RelativeRect.getHeight(), RelativeRect.getWidth() / 2);
 		thumb_area = RelativeRect.getWidth() - border_size * 2;
 	} else {
-		thumb_min = RelativeRect.getWidth();
+		thumb_min = std::min(RelativeRect.getWidth(), RelativeRect.getHeight() / 2);
 		thumb_area = RelativeRect.getHeight() - border_size * 2;
 	}
 

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -60,7 +60,7 @@ GUITable::GUITable(gui::IGUIEnvironment *env,
 		m_rowheight = MYMAX(m_rowheight, 1);
 	}
 
-	const s32 s = skin->getSize(gui::EGDS_SCROLLBAR_SIZE) * 1.5f;
+	const s32 s = skin->getSize(gui::EGDS_SCROLLBAR_SIZE);
 	m_scrollbar = new GUIScrollBar(Environment, this, -1,
 			core::rect<s32>(RelativeRect.getWidth() - s,
 					0,


### PR DESCRIPTION
I originally proposed this as a part of #14510, but now that the other PR isn't going into 5.9.0...

This is mainly intended to improve UX on Android, since it's hard to use very thin scrollbars there.

## To do

This PR is a Ready for Review.

## How to test

Verify that all scrollbars in the mainmenu are about the same width.
