### PR TITLE
Scale C++ menus down to fit the window

### DIFF
--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -107,17 +107,12 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 	removeAllChildren();
 	key_used_text = nullptr;
 
-	scaling_info info = getScalingInfo(v2u32(835, 430), screensize);
+	ScalingInfo info = getScalingInfo(screensize, v2u32(835, 430));
 	const float s = info.scale;
-	const v2u32 size = info.getSize();
-	DesiredRect = core::rect<s32>(
-		screensize.X / 2 - size.X / 2,
-		screensize.Y / 2 - size.Y / 2,
-		screensize.X / 2 + size.X / 2,
-		screensize.Y / 2 + size.Y / 2
-	);
+	DesiredRect = info.rect;
 	recalculateAbsolutePosition(false);
 
+	v2s32 size = DesiredRect.getSize();
 	v2s32 topleft(0, 0);
 
 	{

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -107,16 +107,17 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 	removeAllChildren();
 	key_used_text = nullptr;
 
-	const float s = m_gui_scale;
+	scaling_info info = getScalingInfo(v2u32(835, 430), screensize);
+	const float s = info.scale;
+	const v2u32 size = info.getSize();
 	DesiredRect = core::rect<s32>(
-		screensize.X / 2 - 835 * s / 2,
-		screensize.Y / 2 - 430 * s / 2,
-		screensize.X / 2 + 835 * s / 2,
-		screensize.Y / 2 + 430 * s / 2
+		screensize.X / 2 - size.X / 2,
+		screensize.Y / 2 - size.Y / 2,
+		screensize.X / 2 + size.X / 2,
+		screensize.Y / 2 + size.Y / 2
 	);
 	recalculateAbsolutePosition(false);
 
-	v2s32 size = DesiredRect.getSize();
 	v2s32 topleft(0, 0);
 
 	{

--- a/src/gui/guiOpenURL.cpp
+++ b/src/gui/guiOpenURL.cpp
@@ -66,16 +66,17 @@ void GUIOpenURLMenu::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-	const float s = m_gui_scale;
+	scaling_info info = getScalingInfo(v2u32(580, 250), screensize);
+	const float s = info.scale;
+	const v2u32 size = info.getSize();
 	DesiredRect = core::rect<s32>(
-		screensize.X / 2 - 580 * s / 2,
-		screensize.Y / 2 - 250 * s / 2,
-		screensize.X / 2 + 580 * s / 2,
-		screensize.Y / 2 + 250 * s / 2
+		screensize.X / 2 - size.X / 2,
+		screensize.Y / 2 - size.Y / 2,
+		screensize.X / 2 + size.X / 2,
+		screensize.Y / 2 + size.Y / 2
 	);
 	recalculateAbsolutePosition(false);
 
-	v2s32 size = DesiredRect.getSize();
 	v2s32 topleft_client(40 * s, 0);
 
 	/*

--- a/src/gui/guiOpenURL.cpp
+++ b/src/gui/guiOpenURL.cpp
@@ -66,17 +66,12 @@ void GUIOpenURLMenu::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-	scaling_info info = getScalingInfo(v2u32(580, 250), screensize);
+	ScalingInfo info = getScalingInfo(screensize, v2u32(580, 250));
 	const float s = info.scale;
-	const v2u32 size = info.getSize();
-	DesiredRect = core::rect<s32>(
-		screensize.X / 2 - size.X / 2,
-		screensize.Y / 2 - size.Y / 2,
-		screensize.X / 2 + size.X / 2,
-		screensize.Y / 2 + size.Y / 2
-	);
+	DesiredRect = info.rect;
 	recalculateAbsolutePosition(false);
 
+	v2s32 size = DesiredRect.getSize();
 	v2s32 topleft_client(40 * s, 0);
 
 	/*

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -62,17 +62,12 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-	scaling_info info = getScalingInfo(v2u32(580, 300), screensize);
+	ScalingInfo info = getScalingInfo(screensize, v2u32(580, 300));
 	const float s = info.scale;
-	const v2u32 size = info.getSize();
-	DesiredRect = core::rect<s32>(
-		screensize.X / 2 - size.X / 2,
-		screensize.Y / 2 - size.Y / 2,
-		screensize.X / 2 + size.X / 2,
-		screensize.Y / 2 + size.Y / 2
-	);
+	DesiredRect = info.rect;
 	recalculateAbsolutePosition(false);
 
+	v2s32 size = DesiredRect.getSize();
 	v2s32 topleft_client(40 * s, 0);
 
 	/*

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -62,17 +62,17 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-	const float s = m_gui_scale;
-
+	scaling_info info = getScalingInfo(v2u32(580, 300), screensize);
+	const float s = info.scale;
+	const v2u32 size = info.getSize();
 	DesiredRect = core::rect<s32>(
-		screensize.X / 2 - 580 * s / 2,
-		screensize.Y / 2 - 300 * s / 2,
-		screensize.X / 2 + 580 * s / 2,
-		screensize.Y / 2 + 300 * s / 2
+		screensize.X / 2 - size.X / 2,
+		screensize.Y / 2 - size.Y / 2,
+		screensize.X / 2 + size.X / 2,
+		screensize.Y / 2 + size.Y / 2
 	);
 	recalculateAbsolutePosition(false);
 
-	v2s32 size = DesiredRect.getSize();
 	v2s32 topleft_client(40 * s, 0);
 
 	/*

--- a/src/gui/guiVolumeChange.cpp
+++ b/src/gui/guiVolumeChange.cpp
@@ -54,16 +54,17 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-	const float s = m_gui_scale;
+	scaling_info info = getScalingInfo(v2u32(380, 200), screensize);
+	const float s = info.scale;
+	const v2u32 size = info.getSize();
 	DesiredRect = core::rect<s32>(
-		screensize.X / 2 - 380 * s / 2,
-		screensize.Y / 2 - 200 * s / 2,
-		screensize.X / 2 + 380 * s / 2,
-		screensize.Y / 2 + 200 * s / 2
+		screensize.X / 2 - size.X / 2,
+		screensize.Y / 2 - size.Y / 2,
+		screensize.X / 2 + size.X / 2,
+		screensize.Y / 2 + size.Y / 2
 	);
 	recalculateAbsolutePosition(false);
 
-	v2s32 size = DesiredRect.getSize();
 	int volume = (int)(g_settings->getFloat("sound_volume") * 100);
 
 	/*

--- a/src/gui/guiVolumeChange.cpp
+++ b/src/gui/guiVolumeChange.cpp
@@ -54,17 +54,12 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-	scaling_info info = getScalingInfo(v2u32(380, 200), screensize);
+	ScalingInfo info = getScalingInfo(screensize, v2u32(380, 200));
 	const float s = info.scale;
-	const v2u32 size = info.getSize();
-	DesiredRect = core::rect<s32>(
-		screensize.X / 2 - size.X / 2,
-		screensize.Y / 2 - size.Y / 2,
-		screensize.X / 2 + size.X / 2,
-		screensize.Y / 2 + size.Y / 2
-	);
+	DesiredRect = info.rect;
 	recalculateAbsolutePosition(false);
 
+	v2s32 size = DesiredRect.getSize();
 	int volume = (int)(g_settings->getFloat("sound_volume") * 100);
 
 	/*

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -398,3 +398,15 @@ porting::AndroidDialogState GUIModalMenu::getAndroidUIInputState()
 	return porting::getInputDialogState();
 }
 #endif
+
+GUIModalMenu::scaling_info GUIModalMenu::getScalingInfo(v2u32 base_size, v2u32 screensize)
+{
+	scaling_info info{m_gui_scale, base_size};
+	if (info.getSize().X > screensize.X) {
+		info.scale = (f32)screensize.X / (f32)base_size.X;
+	}
+	if (info.getSize().Y > screensize.Y) {
+		info.scale = (f32)screensize.Y / (f32)base_size.Y;
+	}
+	return info;
+}

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -399,14 +399,16 @@ porting::AndroidDialogState GUIModalMenu::getAndroidUIInputState()
 }
 #endif
 
-GUIModalMenu::scaling_info GUIModalMenu::getScalingInfo(v2u32 base_size, v2u32 screensize)
+GUIModalMenu::ScalingInfo GUIModalMenu::getScalingInfo(v2u32 screensize, v2u32 base_size)
 {
-	scaling_info info{m_gui_scale, base_size};
-	if (info.getSize().X > screensize.X) {
-		info.scale = (f32)screensize.X / (f32)base_size.X;
-	}
-	if (info.getSize().Y > screensize.Y) {
-		info.scale = (f32)screensize.Y / (f32)base_size.Y;
-	}
-	return info;
+	f32 scale = m_gui_scale;
+	scale = std::min(scale, (f32)screensize.X / (f32)base_size.X);
+	scale = std::min(scale, (f32)screensize.Y / (f32)base_size.Y);
+	s32 w = base_size.X * scale, h = base_size.Y * scale;
+	return {scale, core::rect<s32>(
+		screensize.X / 2 - w / 2,
+		screensize.Y / 2 - h / 2,
+		screensize.X / 2 + w / 2,
+		screensize.Y / 2 + h / 2
+	)};
 }

--- a/src/gui/modalMenu.h
+++ b/src/gui/modalMenu.h
@@ -94,6 +94,13 @@ protected:
 	std::string m_jni_field_name;
 #endif
 
+	struct scaling_info {
+		f32 scale;
+		v2u32 base_size;
+		v2u32 getSize() { return v2u32(base_size.X * scale, base_size.Y * scale); }
+	};
+	scaling_info getScalingInfo(v2u32 base_size, v2u32 screensize);
+
 	// This is set to true if the menu is currently processing a second-touch event.
 	bool m_second_touch = false;
 	// This is set to true if the menu is currently processing a mouse event

--- a/src/gui/modalMenu.h
+++ b/src/gui/modalMenu.h
@@ -94,12 +94,11 @@ protected:
 	std::string m_jni_field_name;
 #endif
 
-	struct scaling_info {
+	struct ScalingInfo {
 		f32 scale;
-		v2u32 base_size;
-		v2u32 getSize() { return v2u32(base_size.X * scale, base_size.Y * scale); }
+		core::rect<s32> rect;
 	};
-	scaling_info getScalingInfo(v2u32 base_size, v2u32 screensize);
+	ScalingInfo getScalingInfo(v2u32 screensize, v2u32 base_size);
 
 	// This is set to true if the menu is currently processing a second-touch event.
 	bool m_second_touch = false;


### PR DESCRIPTION
This PR makes sure that C++ menus are scaled down to fit the window if necessary. `GUIFileSelectMenu` is purposefully ignored since it's supposed to go away anyway.

Fixes this issue with `enable_touch = false` on my phone:

before (keychange dialog cut off => unusable)
<img alt="screenshot before" src="https://github.com/minetest/minetest/assets/82708541/fc3da1d0-31b0-4f8f-91c1-e3fb57cce71b" width="512" />

after
<img alt="screenshot after" src="https://github.com/minetest/minetest/assets/82708541/ccf02040-ad9d-4fd8-8cac-4e713755856d" width="512" />

## To do

This PR is a Ready for Review.

## How to test

Verify that the affected C++ menus still look exactly the same, except that they're now scaled down if they don't fit the window.