### PR TITLE
Fix building tests and benchmarks together

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -425,6 +425,7 @@ set(common_SRCS
 	terminal_chat_console.cpp
 	texture_override.cpp
 	tileanimation.cpp
+	test_runner.cpp
 	tool.cpp
 	translation.cpp
 	version.cpp

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -1,5 +1,4 @@
 set (BENCHMARK_SRCS
-	${CMAKE_CURRENT_SOURCE_DIR}/benchmark.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/benchmark_activeobjectmgr.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/benchmark_lighting.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/benchmark_serialize.cpp

--- a/src/benchmark/benchmark.cpp
+++ b/src/benchmark/benchmark.cpp
@@ -18,13 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "benchmark/benchmark.h"
-#include "cmake_config.h"
 
-// This must be set in just this file. If building both unittests and
-// benchmarks, it will be set in unittests.
-#if !BUILD_UNITTESTS
-#define CATCH_CONFIG_RUNNER
-#endif
 #include "benchmark_setup.h"
 
 bool run_benchmarks(const char *arg)

--- a/src/benchmark/benchmark.cpp
+++ b/src/benchmark/benchmark.cpp
@@ -18,9 +18,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "benchmark/benchmark.h"
+#include "cmake_config.h"
 
-// This must be set in just this file
+// This must be set in just this file. If building both unittests and
+// benchmarks, it will be set in unittests.
+#if !BUILD_UNITTESTS
 #define CATCH_CONFIG_RUNNER
+#endif
 #include "benchmark_setup.h"
 
 bool run_benchmarks(const char *arg)

--- a/src/test_runner.cpp
+++ b/src/test_runner.cpp
@@ -17,13 +17,19 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include "cmake_config.h"
+
+#if BUILD_UNITTESTS || BUILD_BENCHMARKS
 // This must be set in only one place
 #define CATCH_CONFIG_RUNNER
 // we want to have catch write to rawstream (stderr) instead of stdout
 #define CATCH_CONFIG_NOSTDOUT
 #include <catch.hpp>
+#endif
 
-#include "test.h"
+#if BUILD_UNITTESTS
+
+#include "unittest/test.h"
 
 #include "nodedef.h"
 #include "itemdef.h"
@@ -725,4 +731,24 @@ struct TestMapSector: public TestBase
 
 	}
 };
+#endif
+
+#endif
+
+#if BUILD_BENCHMARKS
+
+#include "benchmark/benchmark.h"
+
+#include "benchmark/benchmark_setup.h"
+
+bool run_benchmarks(const char *arg)
+{
+	const char *const argv[] = {
+		"MinetestBenchmark", arg, nullptr
+	};
+	const int argc = arg ? 2 : 1;
+	int errCount = Catch::Session().run(argc, argv);
+	return errCount == 0;
+}
+
 #endif

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -1,5 +1,4 @@
 set (UNITTEST_SRCS
-	${CMAKE_CURRENT_SOURCE_DIR}/test.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_address.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_authdatabase.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_activeobject.cpp

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+// This must be set in only one place
 #define CATCH_CONFIG_RUNNER
 // we want to have catch write to rawstream (stderr) instead of stdout
 #define CATCH_CONFIG_NOSTDOUT


### PR DESCRIPTION
Fixes #14692

The cause of the failure was defining CATCH_CONFIG_RUNNER in two places. This fixes the issue by defining it only in unittests if both tests and benchmarks are to be built, or in the correct executable of only one of them is to be built.


Ready for Review.

## How to test

Build with both `BUILD_UNITTESTS` and `BUILD_BENCHMARKS` set to a truthy value and observe that there are no redefinition errors during linking. Note: this test is only useful on a system known to have previously failed at the linking stage. There are systems which may not reproduce the original issue (including my MSVC setup).