### PR TITLE
Properly initialize `ButtonStates` for `EMIE_MOUSE_WHEEL`

### DIFF
--- a/irr/include/IEventReceiver.h
+++ b/irr/include/IEventReceiver.h
@@ -331,16 +331,19 @@ struct SEvent
 
 		//! A bitmap of button states. You can use isButtonPressed() to determine
 		//! if a button is pressed or not.
-		//! Currently only valid if the event was EMIE_MOUSE_MOVED
+		//! Currently only valid if the event was EMIE_MOUSE_MOVED or EMIE_MOUSE_WHEEL
 		u32 ButtonStates;
 
 		//! Is the left button pressed down?
+		//! Currently only valid if the event was EMIE_MOUSE_MOVED or EMIE_MOUSE_WHEEL
 		bool isLeftPressed() const { return 0 != (ButtonStates & EMBSM_LEFT); }
 
 		//! Is the right button pressed down?
+		//! Currently only valid if the event was EMIE_MOUSE_MOVED or EMIE_MOUSE_WHEEL
 		bool isRightPressed() const { return 0 != (ButtonStates & EMBSM_RIGHT); }
 
 		//! Is the middle button pressed down?
+		//! Currently only valid if the event was EMIE_MOUSE_MOVED or EMIE_MOUSE_WHEEL
 		bool isMiddlePressed() const { return 0 != (ButtonStates & EMBSM_MIDDLE); }
 
 		//! Type of mouse event

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -673,6 +673,7 @@ bool CIrrDeviceSDL::run()
 #else
 			irrevent.MouseInput.Wheel = SDL_event.wheel.y;
 #endif
+			irrevent.MouseInput.ButtonStates = MouseButtonStates;
 			irrevent.MouseInput.Shift = (keymod & KMOD_SHIFT) != 0;
 			irrevent.MouseInput.Control = (keymod & KMOD_CTRL) != 0;
 			irrevent.MouseInput.X = MouseX;


### PR DESCRIPTION
Should fix #14517; since this is a highly platform and compiler-specific issue, I am hesitant to claim that it always works, so make sure to test this thoroughly.

It seems `ButtonStates` was not initialized for scroll events. With optimizations enabled this resulted in a mess: The scroll container sometimes falsely believed that the button was held down.

## How to test

Compile a release build with GCC on Linux. Verify that scrolling is choppy. Verify that with this PR applied, it isn't anymore. The following diff might help for testing:

<details>
```diff
diff --git a/irr/src/CIrrDeviceSDL.cpp b/irr/src/CIrrDeviceSDL.cpp
index 1a7fe0c5a..6437e8107 100644
--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -19,6 +19,7 @@
 #include <cstdlib>
 #include "SIrrCreationParameters.h"
 #include <SDL_video.h>
+#include <iostream>
 
 #ifdef _IRR_EMSCRIPTEN_PLATFORM_
 #include <emscripten.h>
@@ -666,6 +667,8 @@ bool CIrrDeviceSDL::run()
                case SDL_MOUSEWHEEL: {
                        SDL_Keymod keymod = SDL_GetModState();
 
+                       std::cout << "sdl says we scrollin" << std::endl;
+
                        irrevent.EventType = irr::EET_MOUSE_INPUT_EVENT;
                        irrevent.MouseInput.Event = irr::EMIE_MOUSE_WHEEL;
 #if SDL_VERSION_ATLEAST(2, 0, 18)
diff --git a/src/gui/guiScrollContainer.cpp b/src/gui/guiScrollContainer.cpp
index 2d71f3453..7015ed9c3 100644
--- a/src/gui/guiScrollContainer.cpp
+++ b/src/gui/guiScrollContainer.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */

 #include "guiScrollContainer.h"
+#include <iostream>
 
 GUIScrollContainer::GUIScrollContainer(gui::IGUIEnvironment *env,
                gui::IGUIElement *parent, s32 id, const core::rect<s32> &rectangle,
@@ -41,6 +42,8 @@ bool GUIScrollContainer::OnEvent(const SEvent &event)
                Environment->setFocus(m_scrollbar);
                bool retval = m_scrollbar->OnEvent(event);
 
+               std::cout << "scrollin" << std::endl;
+
                // a hacky fix for updating the hovering and co.
                IGUIElement *hovered_elem = getElementFromPoint(core::position2d<s32>(
                                event.MouseInput.X, event.MouseInput.Y));
```
 </details>

Without the fix, not all SDL events "come through", even though you're not pressing any mouse buttons: You see "SDL says we scrollin" without "scrollin". After the fix, each "SDL says we scrollin" triggered inside the scroll container, without the mouse button being pressed, should be followed by a "scrollin".