### PR TITLE
GUITable: Scale images with display density / row height

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3245,7 +3245,7 @@ Elements
 * Types: `text`, `image`, `color`, `indent`, `tree`
     * `text`:   show cell contents as text
     * `image`:  cell contents are an image index, use column options to define
-                images.
+                images. images are scaled down to fit the row height if necessary.
     * `color`:  cell contents are a ColorString and define color of following
                 cell.
     * `indent`: cell contents are a number and define indentation of following
@@ -3266,7 +3266,7 @@ Elements
         * `0=<value>` sets image for image index 0
         * `1=<value>` sets image for image index 1
         * `2=<value>` sets image for image index 2
-        * and so on; defined indices need not be contiguous empty or
+        * and so on; defined indices need not be contiguous. empty or
           non-numeric cells are treated as `0`.
     * `color` column options:
         * `span=<value>`: number of following columns to affect

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -64,6 +64,35 @@ local inv_style_fs = [[
 	list[current_player;main;.5,7;8,4]
 ]]
 
+-- Some textures from textures/base/pack and Devtest, with many different sizes
+-- and aspect ratios.
+local image_column = "image,0=logo.png,1=rare_controls.png,2=checkbox_16.png," ..
+		"3=checkbox_32.png,4=checkbox_64.png,5=default_lava.png," ..
+		"6=progress_bar.png,7=progress_bar_bg.png"
+local words = {
+	"esciunt", "repudiandae", "repellat", "voluptatem", "autem", "vitae", "et",
+	"minima", "quasi", "facere", "nihil", "ea", "nemo", "rem", "non", "eos",
+	"laudantium", "eveniet", "veritatis",
+}
+local table_content = {}
+for i = 1, 100 do
+	table.insert(table_content, words[math.random(#words)])
+	table.insert(table_content, words[math.random(#words)])
+	table.insert(table_content, words[math.random(#words)])
+	table.insert(table_content, math.random(0, 7))
+	table.insert(table_content, math.random(0, 7))
+	table.insert(table_content, math.random(0, 7))
+	table.insert(table_content, words[math.random(#words)])
+end
+
+local table_fs = table.concat({
+	"tablecolumns[text,align=left;text,align=right;text,align=center;",
+			image_column, ",align=left;",
+			image_column, ",align=right;",
+			image_column, ",align=center;text,align=right]",
+	"table[0,0;17,12;the_table;", table.concat(table_content, ","), ";1]"
+})
+
 local hypertext_basic = [[A hypertext element
 <bigger>Normal test</bigger>
 This is a normal text.
@@ -350,6 +379,10 @@ local pages = {
 		"label[11,0.5;Noclip]" ..
 		"container[11.5,1]" .. clip_fs:gsub("%%c", "true") .. "container_end[]",
 
+	-- Table
+		"size[18,13]real_coordinates[true]" ..
+		"container[0.5,0.5]" .. table_fs.. "container_end[]",
+
 	-- Hypertext
 		"size[12,13]real_coordinates[true]" ..
 		"container[0.5,0.5]" .. hypertext_fs .. "container_end[]",
@@ -477,7 +510,7 @@ local function show_test_formspec(pname)
 		page = page()
 	end
 
-	local fs = page .. "tabheader[0,0;11,0.65;maintabs;Real Coord,Styles,Noclip,Hypertext,Tabs,Invs,Window,Anim,Model,ScrollC,Sound,Background,Unsized;" .. page_id .. ";false;false]"
+	local fs = page .. "tabheader[0,0;11,0.65;maintabs;Real Coord,Styles,Noclip,Table,Hypertext,Tabs,Invs,Window,Anim,Model,ScrollC,Sound,Background,Unsized;" .. page_id .. ";false;false]"
 
 	minetest.show_formspec(pname, "testformspec:formspec", fs)
 end

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -74,6 +74,10 @@ local words = {
 	"minima", "quasi", "facere", "nihil", "ea", "nemo", "rem", "non", "eos",
 	"laudantium", "eveniet", "veritatis",
 }
+
+local reseed = math.random(2^31-1)
+math.randomseed(1337)
+
 local table_content = {}
 for i = 1, 100 do
 	table.insert(table_content, words[math.random(#words)])
@@ -84,6 +88,8 @@ for i = 1, 100 do
 	table.insert(table_content, math.random(0, 7))
 	table.insert(table_content, words[math.random(#words)])
 end
+
+math.randomseed(reseed)
 
 local table_fs = table.concat({
 	"tablecolumns[text,align=left;text,align=right;text,align=center;",

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -227,6 +227,8 @@ void GUITable::setTable(const TableOptions &options,
 		s32 content_index;
 		// Next cell: Width in pixels
 		s32 content_width;
+		// Next cell: Image scale (only for "image" column type)
+		f32 image_scale;
 		// Vector of completed cells in this row
 		std::vector<Cell> cells;
 		// Stores colors and how long they last (maximum column index)
@@ -236,6 +238,7 @@ void GUITable::setTable(const TableOptions &options,
 	};
 	TempRow *rows = new TempRow[rowcount];
 
+	f32 density = RenderingEngine::getDisplayDensity();
 	// Get em width. Pedantically speaking, the width of "M" is not
 	// necessarily the same as the em width, but whatever, close enough.
 	s32 em = 6;
@@ -373,8 +376,18 @@ void GUITable::setTable(const TableOptions &options,
 				if (row->content_index >= 0)
 					image = m_images[row->content_index];
 
+				row->image_scale = 1.0f;
+				row->content_width = 0;
+				if (image) {
+					f32 max_image_scale = (f32)m_rowheight / (f32)image->getOriginalSize().Height;
+					// Scale with display density and make sure it fits into the row
+					row->image_scale = std::min(density, max_image_scale);
+					// When upscaling, only allow integer multiples
+					if (row->image_scale > 1.0f)
+						row->image_scale = std::floor(row->image_scale);
+					row->content_width = image->getOriginalSize().Width * row->image_scale;
+				}
 				// Get content width and update xmax
-				row->content_width = image ? image->getOriginalSize().Width : 0;
 				row->content_width = MYMAX(row->content_width, width);
 				s32 row_xmax = row->x + padding + row->content_width;
 				xmax = MYMAX(xmax, row_xmax);
@@ -384,6 +397,7 @@ void GUITable::setTable(const TableOptions &options,
 				newcell.xmin = rows[i].x + padding;
 				alignContent(&newcell, xmax, rows[i].content_width, align);
 				newcell.content_index = rows[i].content_index;
+				newcell.image_scale = rows[i].image_scale;
 				rows[i].cells.push_back(newcell);
 				rows[i].x = newcell.xmax;
 			}
@@ -740,23 +754,23 @@ void GUITable::drawCell(const Cell *cell, video::SColor color,
 		video::ITexture *image = m_images[cell->content_index];
 
 		if (image) {
-			core::position2d<s32> dest_pos =
-					row_rect.UpperLeftCorner;
-			dest_pos.X += cell->xpos;
 			core::rect<s32> source_rect(
 					core::position2d<s32>(0, 0),
 					image->getOriginalSize());
-			s32 imgh = source_rect.LowerRightCorner.Y;
+			core::rect<s32> dest_rect(
+					0, 0,
+					image->getOriginalSize().Width * cell->image_scale,
+					image->getOriginalSize().Height * cell->image_scale);
+			dest_rect += row_rect.UpperLeftCorner + v2s32(cell->xpos, 0);
+
+			s32 imgh = dest_rect.getHeight();
 			s32 rowh = row_rect.getHeight();
+			// Center vertically if needed
 			if (imgh < rowh)
-				dest_pos.Y += (rowh - imgh) / 2;
-			else
-				source_rect.LowerRightCorner.Y = rowh;
+				dest_rect += v2s32(0, (rowh - imgh) / 2);
 
-			video::SColor color(255, 255, 255, 255);
-
-			driver->draw2DImage(image, dest_pos, source_rect,
-					&client_clip, color, true);
+			driver->draw2DImage(image, dest_rect, source_rect,
+					&client_clip, nullptr, true);
 		}
 	}
 }

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -382,7 +382,7 @@ void GUITable::setTable(const TableOptions &options,
 					f32 max_image_scale = (f32)m_rowheight / (f32)image->getOriginalSize().Height;
 					// Scale with display density and make sure it fits into the row
 					row->image_scale = std::min(density, max_image_scale);
-					// When upscaling, only allow integer multiples
+					// When upscaling, fractional factors would cause artifacts
 					if (row->image_scale > 1.0f)
 						row->image_scale = std::floor(row->image_scale);
 					row->content_width = image->getOriginalSize().Width * row->image_scale;

--- a/src/gui/guiTable.h
+++ b/src/gui/guiTable.h
@@ -166,6 +166,7 @@ protected:
 		video::SColor color;
 		bool color_defined;
 		s32 reported_column;
+		f32 image_scale; // only for "image" type columns
 	};
 
 	struct Row {


### PR DESCRIPTION
Fixes #3403, opened in 2015

5.8.1
<img src="https://github.com/minetest/minetest/assets/82708541/d9099ea7-fa3f-4540-a3e0-ab547544c4cf" alt="screenshot on 5.8.1" width="512" />

this PR
<img src="https://github.com/minetest/minetest/assets/82708541/a974b6ed-b7f7-4c45-ae28-9a684bd89b68" alt="screenshot on this PR" width="512" />

<details>
<summary>Offtopic complaints</summary>

<p>Something you can also see very well on these screenshots is that the mainmenu is way too small by default on Android, at least on my device. With proper scaling, the serverlist would be much more readable. This PR with <code>gui_scaling = 1.3</code>:</p>

<p><img src="https://github.com/minetest/minetest/assets/82708541/bd146666-5f08-4824-824f-404440ae9434" alt="screenshot on this PR, but with better scaling" width="512" /></p>

<p>While you can set <code>gui_scaling</code> manually to get reasonable scaling (except for the scrollbars, which are too big now), you shouldn't have to do that. Minetest should use a reasonable fraction of the screen by default.</p>
</details>

## To do

This PR is a Ready for Review.

If you find a case where this PR makes an existing formspec look worse, please tell me. However, this isn't very likely to happen anymore with the latest commit. Zipgrep: https://web.archive.org/web/20240530091120/https://content.minetest.net/zipgrep/62090fd0-3f2e-4806-b04c-53cd5e8a20f1/

## How to test

Look at the Devtest test formspec, "Table" tab. Verify that what you see matches what the code requests.

Look at the serverlist on a device with a high display density.
