### PR TITLE
Allow toggling fullscreen without restart and add keybind

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -723,6 +723,11 @@ local function eventhandler(event)
 		mm_game_theme.set_engine(true)
 		return true
 	end
+	if event == "FullscreenChange" then
+		-- Refresh the formspec to keep the fullscreen checkbox up to date.
+		ui.update()
+		return true
+	end
 
 	return false
 end

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2399,6 +2399,9 @@ keymap_minimap (Minimap key) key KEY_KEY_V
 #    Key for taking screenshots.
 keymap_screenshot (Screenshot) key KEY_F12
 
+#    Key for toggling fullscreen mode.
+keymap_fullscreen (Fullscreen key) key KEY_F11
+
 #    Key for dropping the currently selected item.
 keymap_drop (Drop item key) key KEY_KEY_Q
 

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -14,7 +14,8 @@ Callbacks
 * `core.button_handler(fields)`: called when a button is pressed.
   * `fields` = `{name1 = value1, name2 = value2, ...}`
 * `core.event_handler(event)`
-  * `event`: `"MenuQuit"`, `"KeyEnter"`, `"ExitButton"` or `"EditBoxEnter"`
+  * `event`: `"MenuQuit"`, `"KeyEnter"`, `"ExitButton"`, `"EditBoxEnter"` or
+    `"FullscreenChange"`
 
 
 Gamedata

--- a/irr/include/IrrlichtDevice.h
+++ b/irr/include/IrrlichtDevice.h
@@ -180,8 +180,9 @@ public:
 	virtual bool isFullscreen() const = 0;
 
 	//! Enables or disables fullscreen mode.
-	// Only works on SDL.
-	virtual void setFullscreen(bool fullscreen) {};
+	/** Only works on SDL.
+	\return True on success. */
+	virtual bool setFullscreen(bool fullscreen) { return false; }
 
 	//! Checks if the window could possibly be visible.
 	/** If this returns false, you should not do any rendering. */

--- a/irr/include/IrrlichtDevice.h
+++ b/irr/include/IrrlichtDevice.h
@@ -179,6 +179,10 @@ public:
 	/** \return True if window is fullscreen. */
 	virtual bool isFullscreen() const = 0;
 
+	//! Enables or disables fullscreen mode.
+	// Only works on SDL.
+	virtual void setFullscreen(bool fullscreen) {};
+
 	//! Checks if the window could possibly be visible.
 	/** If this returns false, you should not do any rendering. */
 	virtual bool isWindowVisible() const { return true; };

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -883,6 +883,14 @@ bool CIrrDeviceSDL::run()
 			IsInBackground = false;
 			break;
 
+		case SDL_RENDER_TARGETS_RESET:
+			os::Printer::log("Received SDL_RENDER_TARGETS_RESET. Rendering is probably broken.", ELL_ERROR);
+			break;
+
+		case SDL_RENDER_DEVICE_RESET:
+			os::Printer::log("Received SDL_RENDER_DEVICE_RESET. Rendering is probably broken.", ELL_ERROR);
+			break;
+
 		default:
 			break;
 		} // end switch

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -1169,12 +1169,15 @@ u32 CIrrDeviceSDL::getFullscreenFlag(bool fullscreen)
 #endif
 }
 
-void CIrrDeviceSDL::setFullscreen(bool fullscreen)
+bool CIrrDeviceSDL::setFullscreen(bool fullscreen)
 {
 	// The SDL wiki says that this may trigger SDL_RENDER_TARGETS_RESET, but
 	// looking at the SDL source, this only happens with D3D, so it's not
 	// relevant to us.
-	SDL_SetWindowFullscreen(Window, getFullscreenFlag(fullscreen));
+	bool success = SDL_SetWindowFullscreen(Window, getFullscreenFlag(fullscreen)) == 0;
+	if (!success)
+		os::Printer::log("SDL_SetWindowFullscreen failed", SDL_GetError(), ELL_ERROR);
+	return success;
 }
 
 bool CIrrDeviceSDL::isWindowVisible() const

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -1171,6 +1171,8 @@ u32 CIrrDeviceSDL::getFullscreenFlag(bool fullscreen)
 
 bool CIrrDeviceSDL::setFullscreen(bool fullscreen)
 {
+	if (!Window)
+		return false;
 	// The SDL wiki says that this may trigger SDL_RENDER_TARGETS_RESET, but
 	// looking at the SDL source, this only happens with D3D, so it's not
 	// relevant to us.

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -86,6 +86,9 @@ public:
 	/** \return True if window is fullscreen. */
 	bool isFullscreen() const override;
 
+	//! Enables or disables fullscreen mode.
+	void setFullscreen(bool fullscreen) override;
+
 	//! Checks if the window could possibly be visible.
 	bool isWindowVisible() const override;
 
@@ -298,6 +301,8 @@ private:
 	u32 Width, Height;
 
 	bool Resizable;
+
+	u32 getFullscreenFlag(bool fullscreen);
 
 	core::rect<s32> lastElemPos;
 

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -87,7 +87,8 @@ public:
 	bool isFullscreen() const override;
 
 	//! Enables or disables fullscreen mode.
-	void setFullscreen(bool fullscreen) override;
+	/** \return True on success. */
+	bool setFullscreen(bool fullscreen) override;
 
 	//! Checks if the window could possibly be visible.
 	bool isWindowVisible() const override;

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -303,7 +303,7 @@ private:
 
 	bool Resizable;
 
-	u32 getFullscreenFlag(bool fullscreen);
+	static u32 getFullscreenFlag(bool fullscreen);
 
 	core::rect<s32> lastElemPos;
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1164,7 +1164,8 @@ void Game::run()
 			g_settings->getU16("screen_w"),
 			g_settings->getU16("screen_h")
 		);
-	const bool initial_window_maximized = g_settings->getBool("window_maximized");
+	const bool initial_window_maximized = !g_settings->getBool("fullscreen") &&
+			g_settings->getBool("window_maximized");
 
 	while (m_rendering_engine->run()
 			&& !(*kill || g_gamecallback->shutdown_requested

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -123,6 +123,7 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 				g_settings->setBool("fullscreen", !fullscreen);
 			}
 			is_down = event.KeyInput.PressedDown;
+			return true;
 		}
 	}
 

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -114,6 +114,7 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 		return true;
 	}
 
+	// This is separate from other keyboard handling so that it also works in menus.
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
 		const KeyPress keyCode(event.KeyInput);
 		if (keyCode == getKeySetting("keymap_fullscreen")) {

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -118,12 +118,11 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
 		const KeyPress keyCode(event.KeyInput);
 		if (keyCode == getKeySetting("keymap_fullscreen")) {
-			static bool is_down = false; // used to ignore key repeats
-			if (event.KeyInput.PressedDown && !is_down) {
+			if (event.KeyInput.PressedDown && !fullscreen_is_down) {
 				bool fullscreen = RenderingEngine::get_raw_device()->isFullscreen();
 				g_settings->setBool("fullscreen", !fullscreen);
 			}
-			is_down = event.KeyInput.PressedDown;
+			fullscreen_is_down = event.KeyInput.PressedDown;
 			return true;
 		}
 	}

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include "settings.h"
 #include "util/numeric.h"
 #include "inputhandler.h"
 #include "gui/mainmenumanager.h"
@@ -111,6 +112,17 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 		g_logger.log(irr_loglev_conv[event.LogEvent.Level],
 				std::string("Irrlicht: ") + event.LogEvent.Text);
 		return true;
+	}
+
+	if (event.EventType == EET_KEY_INPUT_EVENT) {
+		const KeyPress keyCode(event.KeyInput);
+		if (keyCode == getKeySetting("keymap_fullscreen")) {
+			static bool is_down = false; // used to ignore key repeats
+			if (event.KeyInput.PressedDown && !is_down) {
+				g_settings->setBool("fullscreen", !g_settings->getBool("fullscreen"));
+			}
+			is_down = event.KeyInput.PressedDown;
+		}
 	}
 
 	// Let the menu handle events, if one is active.

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -119,7 +119,8 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 		if (keyCode == getKeySetting("keymap_fullscreen")) {
 			static bool is_down = false; // used to ignore key repeats
 			if (event.KeyInput.PressedDown && !is_down) {
-				g_settings->setBool("fullscreen", !g_settings->getBool("fullscreen"));
+				bool fullscreen = RenderingEngine::get_raw_device()->isFullscreen();
+				g_settings->setBool("fullscreen", !fullscreen);
 			}
 			is_down = event.KeyInput.PressedDown;
 		}

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -220,6 +220,9 @@ private:
 	// often changing keys, and keysListenedFor is expected
 	// to change seldomly but contain lots of keys.
 	KeyList keysListenedFor;
+
+	// Intentionally not reset by clearInput/releaseAllKeys.
+	bool fullscreen_is_down = false;
 };
 
 class InputHandler

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -279,10 +279,11 @@ void RenderingEngine::settingChangedCallback(const std::string &name, void *data
 {
 	IrrlichtDevice *device = static_cast<RenderingEngine*>(data)->m_device;
 	if (name == "fullscreen") {
-		device->setFullscreen(g_settings->getBool("fullscreen"));
+		bool fullscreen = g_settings->getBool("fullscreen");
+		device->setFullscreen(fullscreen);
 		// When leaving fullscreen, apply window_maximized again. In theory,
 		// setFullscreen can fail, so check via isFullscreen.
-		if (!device->isFullscreen())
+		if (!fullscreen && !device->isFullscreen())
 			applyWindowMaximized(device, g_settings->getBool("window_maximized"));
 	} else if (name == "window_maximized") {
 		if (!device->isFullscreen())

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -280,10 +280,9 @@ void RenderingEngine::settingChangedCallback(const std::string &name, void *data
 	IrrlichtDevice *device = static_cast<RenderingEngine*>(data)->m_device;
 	if (name == "fullscreen") {
 		bool fullscreen = g_settings->getBool("fullscreen");
-		device->setFullscreen(fullscreen);
-		// When leaving fullscreen, apply window_maximized again. In theory,
-		// setFullscreen can fail, so check via isFullscreen.
-		if (!fullscreen && !device->isFullscreen())
+		bool success = device->setFullscreen(fullscreen);
+		// When leaving fullscreen, apply window_maximized again.
+		if (!fullscreen && success)
 			applyWindowMaximized(device, g_settings->getBool("window_maximized"));
 	} else if (name == "window_maximized") {
 		if (!device->isFullscreen())

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -207,7 +207,12 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 #else
 	u16 screen_w = std::max<u16>(g_settings->getU16("screen_w"), 1);
 	u16 screen_h = std::max<u16>(g_settings->getU16("screen_h"), 1);
-	bool window_maximized = g_settings->getBool("window_maximized");
+	// If I…
+	// 1. … set fullscreen = true and window_maximized = true on startup
+	// 2. … set fullscreen = false later
+	// on Linux with SDL, everything breaks.
+	// => Don't do it.
+	bool window_maximized = !fullscreen && g_settings->getBool("window_maximized");
 #endif
 
 	// bpp, fsaa, vsync

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -272,26 +272,19 @@ RenderingEngine::~RenderingEngine()
 	s_singleton = nullptr;
 }
 
-static void applyWindowMaximized(IrrlichtDevice *device, bool maximized)
-{
-	if (maximized && !device->isWindowMaximized())
-		device->maximizeWindow();
-	else if (!maximized && device->isWindowMaximized())
-		device->restoreWindow();
-}
-
 void RenderingEngine::settingChangedCallback(const std::string &name, void *data)
 {
 	IrrlichtDevice *device = static_cast<RenderingEngine*>(data)->m_device;
 	if (name == "fullscreen") {
-		bool fullscreen = g_settings->getBool("fullscreen");
-		bool success = device->setFullscreen(fullscreen);
-		// When leaving fullscreen, apply window_maximized again.
-		if (!fullscreen && success)
-			applyWindowMaximized(device, g_settings->getBool("window_maximized"));
+		device->setFullscreen(g_settings->getBool("fullscreen"));
+
 	} else if (name == "window_maximized") {
-		if (!device->isFullscreen())
-			applyWindowMaximized(device, g_settings->getBool("window_maximized"));
+		if (!device->isFullscreen()) {
+			if (g_settings->getBool("window_maximized"))
+				device->maximizeWindow();
+			else
+				device->restoreWindow();
+		}
 	}
 }
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -249,16 +249,29 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 			gui::EGST_WINDOWS_METALLIC, driver);
 	m_device->getGUIEnvironment()->setSkin(skin);
 	skin->drop();
+
+	g_settings->registerChangedCallback("fullscreen", settingChangedCallback, this);
 }
 
 RenderingEngine::~RenderingEngine()
 {
 	sanity_check(s_singleton == this);
 
+	g_settings->deregisterChangedCallback("fullscreen", settingChangedCallback, this);
 	core.reset();
 	m_device->closeDevice();
 	m_device->drop();
 	s_singleton = nullptr;
+}
+
+void RenderingEngine::settingChangedCallback(const std::string &name, void *data)
+{
+	static_cast<RenderingEngine*>(data)->applyFullscreenSetting();
+}
+
+void RenderingEngine::applyFullscreenSetting()
+{
+	m_device->setFullscreen(g_settings->getBool("fullscreen"));
 }
 
 v2u32 RenderingEngine::_getWindowSize() const

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -168,6 +168,8 @@ public:
 			const bool initial_window_maximized);
 
 private:
+	static void settingChangedCallback(const std::string &name, void *data);
+	void applyFullscreenSetting();
 	v2u32 _getWindowSize() const;
 
 	std::unique_ptr<RenderingCore> core;

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -169,7 +169,6 @@ public:
 
 private:
 	static void settingChangedCallback(const std::string &name, void *data);
-	void applyFullscreenSetting();
 	v2u32 _getWindowSize() const;
 
 	std::unique_ptr<RenderingCore> core;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -182,6 +182,7 @@ void set_default_settings()
 	settings->setDefault("keymap_toggle_profiler", "KEY_F6");
 	settings->setDefault("keymap_camera_mode", "KEY_KEY_C");
 	settings->setDefault("keymap_screenshot", "KEY_F12");
+	settings->setDefault("keymap_fullscreen", "KEY_F11");
 	settings->setDefault("keymap_increase_viewing_range_min", "+");
 	settings->setDefault("keymap_decrease_viewing_range_min", "-");
 	settings->setDefault("keymap_slot1", "KEY_KEY_1");

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -193,6 +193,8 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 
 	m_script = std::make_unique<MainMenuScripting>(this);
 
+	g_settings->registerChangedCallback("fullscreen", fullscreenChangedCallback, this);
+
 	try {
 		m_script->setMainMenuData(&m_data->script_data);
 		m_data->script_data.errormessage.clear();
@@ -377,6 +379,8 @@ void GUIEngine::run()
 /******************************************************************************/
 GUIEngine::~GUIEngine()
 {
+	g_settings->deregisterChangedCallback("fullscreen", fullscreenChangedCallback, this);
+
 	// deinitialize script first. gc destructors might depend on other stuff
 	infostream << "GUIEngine: Deinitializing scripting" << std::endl;
 	m_script.reset();
@@ -665,4 +669,10 @@ void GUIEngine::updateTopLeftTextSize()
 	m_irr_toplefttext->remove();
 	m_irr_toplefttext = gui::StaticText::add(m_rendering_engine->get_gui_env(),
 			m_toplefttext, rect, false, true, 0, -1);
+}
+
+/******************************************************************************/
+void GUIEngine::fullscreenChangedCallback(const std::string &name, void *data)
+{
+	static_cast<GUIEngine*>(data)->getScriptIface()->handleMainMenuEvent("FullscreenChange");
 }

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -321,7 +321,8 @@ void GUIEngine::run()
 			g_settings->getU16("screen_w"),
 			g_settings->getU16("screen_h")
 		);
-	const bool initial_window_maximized = g_settings->getBool("window_maximized");
+	const bool initial_window_maximized = !g_settings->getBool("fullscreen") &&
+			g_settings->getBool("window_maximized");
 
 	FpsControl fps_control;
 	f32 dtime = 0.0f;

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -296,4 +296,6 @@ private:
 	bool        m_clouds_enabled = true;
 	/** data used to draw clouds */
 	clouddata   m_cloud;
+
+	static void fullscreenChangedCallback(const std::string &name, void *data);
 };


### PR DESCRIPTION
Fixes #2732, opened in 2015, closed as non-trivial in 2017 (because there was no Irrlicht fork and no SDL device back then)

New users can easily think that the `fullscreen` setting is broken because it's only applied after a restart and this isn't even documented.

This PR allows toggling `fullscreen` via the settings menu without a restart. For convenience, there's also a new keybind called `keymap_fullscreen` (F11 by default). As a bonus, `window_maximized` is now applied immediately too.

## To do

This PR is a Ready for Review.

## How to test

Change the `fullscreen` and `window_maximized` settings. See that Minetest reacts immediately.

Press F11. See that fullscreen mode is toggled and that the fullscreen checkbox in the settings is updated too.
