### PR TITLE
Mainmenu: Unify gamedata.errormessage and messagebox formspecs

### DIFF
--- a/builtin/fstk/dialog.lua
+++ b/builtin/fstk/dialog.lua
@@ -81,12 +81,7 @@ end
 function messagebox(name, message)
 	return dialog_create(name,
 			function()
-				return ([[
-					formspec_version[3]
-					size[8,3]
-					textarea[0.375,0.375;7.25,1.2;;;%s]
-					button[3,1.825;2,0.8;ok;%s]
-				]]):format(message, fgettext("OK"))
+				return ui.get_message_formspec("", message, "ok")
 			end,
 			function(this, fields)
 				if fields.ok then

--- a/builtin/fstk/dialog.lua
+++ b/builtin/fstk/dialog.lua
@@ -78,6 +78,8 @@ function dialog_create(name,get_formspec,buttonhandler,eventhandler)
 	return self
 end
 
+-- "message" must already be formspec-escaped, e.g. via fgettext or
+-- core.formspec_escape.
 function messagebox(name, message)
 	return dialog_create(name,
 			function()

--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -51,6 +51,8 @@ function ui.find_by_name(name)
 end
 
 --------------------------------------------------------------------------------
+-- "title" and "message" must already be formspec-escaped, e.g. via fgettext or
+-- core.formspec_escape.
 function ui.get_message_formspec(title, message, btn_id)
 	return table.concat({
 		"size[14,8]",
@@ -88,6 +90,9 @@ function ui.update()
 		}
 		ui.overridden = true
 	elseif gamedata ~= nil and gamedata.errormessage ~= nil then
+		-- Note to API users:
+		-- "gamedata.errormessage" must not be formspec-escaped yet.
+		-- For translations, fgettext_ne should be used.
 		local error_message = core.formspec_escape(gamedata.errormessage)
 
 		local error_title

--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -51,6 +51,18 @@ function ui.find_by_name(name)
 end
 
 --------------------------------------------------------------------------------
+function ui.get_message_formspec(title, message, btn_id)
+	return table.concat({
+		"size[14,8]",
+		"real_coordinates[true]",
+		"set_focus[", btn_id, ";true]",
+		"box[0.5,1.2;13,5;#000]",
+		("textarea[0.5,1.2;13,5;;%s;%s]"):format(title, message),
+		"button[5,6.6;4,1;", btn_id, ";" .. fgettext("OK") .. "]",
+	})
+end
+
+--------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Internal functions not to be called from user
 --------------------------------------------------------------------------------
@@ -84,15 +96,7 @@ function ui.update()
 		else
 			error_title = fgettext("An error occurred:")
 		end
-		formspec = {
-			"size[14,8]",
-			"real_coordinates[true]",
-			"set_focus[btn_error_confirm;true]",
-			"box[0.5,1.2;13,5;#000]",
-			("textarea[0.5,1.2;13,5;;%s;%s]"):format(
-				error_title, error_message),
-			"button[5,6.6;4,1;btn_error_confirm;" .. fgettext("OK") .. "]"
-		}
+		formspec = {ui.get_message_formspec(error_title, error_message, "btn_error_confirm")}
 		ui.overridden = true
 	else
 		local active_toplevel_ui_elements = 0

--- a/builtin/mainmenu/content/dlg_contentdb.lua
+++ b/builtin/mainmenu/content/dlg_contentdb.lua
@@ -117,7 +117,7 @@ local function resolve_auto_install_spec()
 	end
 
 	if not resolved then
-		gamedata.errormessage = fgettext("The package $1 was not found.", auto_install_spec)
+		gamedata.errormessage = fgettext_ne("The package $1 was not found.", auto_install_spec)
 		ui.update()
 
 		auto_install_spec = nil


### PR DESCRIPTION
Problem: The existing `messagebox` formspec is small and unreadable on mobile.

Solution 1: Remove it and replace with `gamedata.errormessage`  
=> Not possible, `create_contentdb_dlg` needs it so that it can return a dialog in all cases.

Solution 2: Unify their formspec implementation so that both use the good formspec from `gamedata.errormessage` 

## To do

This PR is a Ready for Review.

## How to test

Verify that both kinds of mainmenu error dialogs still work.