### PR TITLE
Add --terminal-silent flag to minetest

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -442,6 +442,7 @@ set(common_SRCS
 	settings.cpp
 	staticobject.cpp
 	terminal_chat_console.cpp
+	terminal_chat_console_silent.cpp
 	texture_override.cpp
 	tileanimation.cpp
 	tool.cpp

--- a/src/terminal_chat_console_silent.cpp
+++ b/src/terminal_chat_console_silent.cpp
@@ -1,0 +1,126 @@
+/*
+Minetest
+Copyright (C) 2015 est31 <MTest31@outlook.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <inttypes.h>
+#include "config.h"
+#if USE_CURSES
+#include "version.h"
+#include "terminal_chat_console_silent.h"
+#include "porting.h"
+#include "settings.h"
+#include "util/numeric.h"
+#include "util/string.h"
+#include "chat_interface.h"
+#include <fcntl.h>
+
+TerminalChatConsoleSilent g_term_console_silent;
+
+void TerminalChatConsoleSilent::initOfCurses()
+{
+	// Make cin non-blocking.
+	int flags = fcntl(0, F_GETFL, 0);
+	fcntl(0, F_SETFL, flags | O_NONBLOCK);
+}
+
+void TerminalChatConsoleSilent::deInitOfCurses()
+{
+	// no-op
+}
+
+void *TerminalChatConsoleSilent::run()
+{
+	BEGIN_DEBUG_EXCEPTION_HANDLER
+
+	// Inform the server of our nick
+	m_chat_interface->command_queue.push_back(
+		new ChatEventNick(CET_NICK_ADD, m_nick));
+
+	{
+		// Ensures that curses is deinitialized even on an exception being thrown
+		CursesInitHelper helper(this);
+
+		while (!stopRequested()) {
+
+			if (stopRequested())
+				break;
+
+			step();
+
+			// 10 / 1000 means you can only run 100 commands per second, the horror.
+			// If you are running 100 commands per second, you might want to 
+			// redesign the program interfacing with the server.
+			// This keeps the thread from maxing out the cpu core.
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+			
+		}
+	}
+
+	if (m_kill_requested)
+		*m_kill_requested = true;
+
+
+	END_DEBUG_EXCEPTION_HANDLER
+
+	return NULL;
+}
+
+void TerminalChatConsoleSilent::typeChatMessage(const std::wstring &msg)
+{
+	// Discard empty line
+	if (msg.empty())
+		return;
+
+	// Send to server
+	m_chat_interface->command_queue.push_back(
+		new ChatEventChat(m_nick, msg));
+
+	// Print if its a command (gets eaten by server otherwise)
+	if (msg[0] == L'/') {
+		m_chat_backend.addMessage(L"", (std::wstring)L"Issued command: " + msg);
+	}
+}
+
+void TerminalChatConsoleSilent::step()
+{
+
+	// C++ hello world comes back for round 2.
+	std::string str;
+	std::getline(std::cin, str);
+
+	// The string is not null terminated so we cannot use length().
+	if (str.length() > 0) {
+
+		std::wstring test(str.begin(), str.end());
+
+		typeChatMessage(test);
+	}
+
+	// Needs to be outside check.
+	std::cin.clear();
+}
+
+
+void TerminalChatConsoleSilent::stopAndWaitforThread()
+{
+	clearKillStatus();
+	stop();
+	wait();
+}
+
+#endif

--- a/src/terminal_chat_console_silent.h
+++ b/src/terminal_chat_console_silent.h
@@ -1,0 +1,106 @@
+/*
+Minetest
+Copyright (C) 2015 est31 <MTest31@outlook.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "chat.h"
+#include "threading/thread.h"
+#include "util/container.h"
+#include "log.h"
+#include <set>
+#include <sstream>
+
+
+struct ChatInterface;
+
+class TermLogOutputSilent : public ILogOutput {
+public:
+
+	void logRaw(LogLevel lev, const std::string &line)
+	{
+		queue.push_back(std::make_pair(lev, line));
+	}
+
+	virtual void log(LogLevel lev, const std::string &combined,
+		const std::string &time, const std::string &thread_name,
+		const std::string &payload_text)
+	{
+		std::ostringstream os(std::ios_base::binary);
+		os << time << ": [" << thread_name << "] " << payload_text;
+
+		queue.push_back(std::make_pair(lev, os.str()));
+	}
+
+	MutexedQueue<std::pair<LogLevel, std::string> > queue;
+};
+
+class TerminalChatConsoleSilent : public Thread {
+public:
+
+	TerminalChatConsoleSilent() :
+		Thread("TerminalThread")
+	{}
+
+	void setup(
+		ChatInterface *iface,
+		bool *kill_requested,
+		const std::string &nick)
+	{
+		m_nick = nick;
+		m_kill_requested = kill_requested;
+		m_chat_interface = iface;
+	}
+
+	virtual void *run();
+
+	// Highly required!
+	void clearKillStatus() { m_kill_requested = nullptr; }
+
+	void stopAndWaitforThread();
+
+private:
+	// these have stupid names so that nobody missclassifies them
+	// as curses functions. Oh, curses has stupid names too?
+	// Well, at least it was worth a try...
+	void initOfCurses();
+	void deInitOfCurses();
+
+	void typeChatMessage(const std::wstring &m);
+
+	void step();
+
+	// Used to ensure the deinitialisation is always called.
+	struct CursesInitHelper {
+		TerminalChatConsoleSilent *cons;
+		CursesInitHelper(TerminalChatConsoleSilent * a_console)
+			: cons(a_console)
+		{ cons->initOfCurses(); }
+		~CursesInitHelper() { cons->deInitOfCurses(); }
+	};
+
+	std::string m_nick;
+
+
+	bool *m_kill_requested = nullptr;
+	ChatBackend m_chat_backend;
+	ChatInterface *m_chat_interface;
+
+};
+
+extern TerminalChatConsoleSilent g_term_console_silent;


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

It allows you to hook in GUIs and also as a side effect you can type straight into the regular terminal.

- Goal of the PR
Some way to directly talk to minetest through the command line.
- How does the PR work?
It uses cin nonblocking with std::thread::sleep_for() (thanks Lars && ExeVirus) on another thread via the ILogOutput and Thread parent classes to get this pipe dream functioning.
- Does it resolve any reported issue?
I have no idea.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
Still no idea.
- If not a bug fix, why is this PR needed? What usecases does it solve?
Because you should be able to talk to your local server through the terminal when it's being handled by other apps.

## To do
- Think of a better pr name.

This PR is a Ready for Review.
<!-- ^ delete one -->

- [x] Cry because ncurses is so painful to work with.
- [x] Give up and try 50 other approaches.
- [x] Find a solution.

## How to test

First, make sure your minetest.conf has
 ```
name = blah
```

Next, build with this pr, launch ``minetestserver`` or ``minetest --server`` with the flag ``--terminal-silent`` and then type straight into the terminal.