### PR TITLE
Fix connected_players on_shutdown

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5720,6 +5720,8 @@ Call these functions only at load time!
       aliases handled.
 * `minetest.register_on_shutdown(function())`
     * Called before server shutdown
+    * Players that were kicked by the shutdown procedure are still fully accessible
+     in `minetest.get_connected_players()`.
     * **Warning**: If the server terminates abnormally (i.e. crashes), the
       registered callbacks **will likely not be run**. Data should be saved at
       semi-frequent intervals as well as on server shutdown.

--- a/games/devtest/mods/unittests/init.lua
+++ b/games/devtest/mods/unittests/init.lua
@@ -186,6 +186,7 @@ dofile(modpath .. "/metadata.lua")
 dofile(modpath .. "/raycast.lua")
 dofile(modpath .. "/inventory.lua")
 dofile(modpath .. "/load_time.lua")
+dofile(modpath .. "/on_shutdown.lua")
 
 --------------
 

--- a/games/devtest/mods/unittests/on_shutdown.lua
+++ b/games/devtest/mods/unittests/on_shutdown.lua
@@ -1,0 +1,22 @@
+-- Test whether players still exist on shutdown
+local players = {}
+
+core.register_on_joinplayer(function(player)
+	players[player:get_player_name()] = true
+end)
+
+core.register_on_leaveplayer(function(player)
+	local name = player:get_player_name();
+	assert(players[name], "Unrecorded player join.")
+	players[name] = nil
+end)
+
+core.register_on_shutdown(function()
+	for _, player in pairs(core.get_connected_players()) do
+		local name = player:get_player_name()
+		assert(players[name], "Unrecorded player join or left too early.")
+		players[name] = nil
+	end
+
+	assert(not next(players), "Invalid connected players on shutdown.")
+end)


### PR DESCRIPTION
### Goal
Fixes #14736

### How it works:
- Reorderes what happens in `Server::~Server()`.
  (It should be safe, to first stop the ServerThread before kicking the players, as far as I can tell.
  As before, the EmergeManager threads are stopped before the on_shutdown callback happens.)
- Adds a test to devtest.
  (I'm not sure if I added it at the right place, but it is similar to the `mods/unittests/load_time.lua` file.)

## To do

This PR is Ready for Review.

## How to test

Start devtest and exit devtest.
(The test gets executed every time, similar to what happens in `mods/unittests/load_time.lua`.)
