### PR TITLE
Android: Fix back button sometimes not working as ESC

### DIFF
--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -1254,7 +1254,8 @@ void CIrrDeviceSDL::createKeyMap()
 
 	// buttons missing
 
-	KeyMap.push_back(SKeyMap(SDLK_AC_BACK, KEY_CANCEL));
+	// Android back button = ESC
+	KeyMap.push_back(SKeyMap(SDLK_AC_BACK, KEY_ESCAPE));
 
 	KeyMap.push_back(SKeyMap(SDLK_BACKSPACE, KEY_BACK));
 	KeyMap.push_back(SKeyMap(SDLK_TAB, KEY_TAB));

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -94,7 +94,6 @@ void KeyCache::populate()
 			handler->listenForKey(k);
 		}
 		handler->listenForKey(EscapeKey);
-		handler->listenForKey(CancelKey);
 	}
 }
 

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -309,7 +309,7 @@ public:
 
 	virtual bool cancelPressed()
 	{
-		return wasKeyDown(KeyType::ESC) || m_receiver->WasKeyDown(CancelKey);
+		return wasKeyDown(KeyType::ESC);
 	}
 
 	virtual void clearWasKeyPressed()

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -348,7 +348,6 @@ const char *KeyPress::name() const
 }
 
 const KeyPress EscapeKey("KEY_ESCAPE");
-const KeyPress CancelKey("KEY_CANCEL");
 
 const KeyPress LMBKey("KEY_LBUTTON");
 const KeyPress MMBKey("KEY_MBUTTON");

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -66,7 +66,6 @@ protected:
 // Global defines for convenience
 
 extern const KeyPress EscapeKey;
-extern const KeyPress CancelKey;
 
 extern const KeyPress LMBKey;
 extern const KeyPress MMBKey; // Middle Mouse Button

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4105,7 +4105,7 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 	// Fix Esc/Return key being eaten by checkboxen and tables
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
 			KeyPress kp(event.KeyInput);
-		if (kp == EscapeKey || kp == CancelKey
+		if (kp == EscapeKey
 				|| kp == getKeySetting("keymap_inventory")
 				|| event.KeyInput.Key==KEY_RETURN) {
 			gui::IGUIElement *focused = Environment->getFocus();
@@ -4173,7 +4173,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 	if (event.EventType==EET_KEY_INPUT_EVENT) {
 		KeyPress kp(event.KeyInput);
 		if (event.KeyInput.PressedDown && (
-				(kp == EscapeKey) || (kp == CancelKey) ||
+				(kp == EscapeKey) ||
 				((m_client != NULL) && (kp == getKeySetting("keymap_inventory"))))) {
 			tryClose();
 			return true;

--- a/src/gui/guiOpenURL.cpp
+++ b/src/gui/guiOpenURL.cpp
@@ -160,9 +160,7 @@ void GUIOpenURLMenu::drawMenu()
 bool GUIOpenURLMenu::OnEvent(const SEvent &event)
 {
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
-		if ((event.KeyInput.Key == KEY_ESCAPE ||
-				event.KeyInput.Key == KEY_CANCEL) &&
-				event.KeyInput.PressedDown) {
+		if (event.KeyInput.Key == KEY_ESCAPE && event.KeyInput.PressedDown) {
 			quitMenu();
 			return true;
 		}

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -187,9 +187,7 @@ bool GUIPasswordChange::processInput()
 bool GUIPasswordChange::OnEvent(const SEvent &event)
 {
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
-		if ((event.KeyInput.Key == KEY_ESCAPE ||
-				event.KeyInput.Key == KEY_CANCEL) &&
-				event.KeyInput.PressedDown) {
+		if (event.KeyInput.Key == KEY_ESCAPE && event.KeyInput.PressedDown) {
 			quitMenu();
 			return true;
 		}


### PR DESCRIPTION
The old `CIrrDeviceAndroid` mapped the Android back button to `KEY_CANCEL`, so the initial Android port (1cc40c0a7c260f0562572bc99f39a666a12f1b09) included code to treat `KEY_CANCEL` like `KEY_ESCAPE`. Having to handle two different keys for the same purpose is obviously annoying, but it also causes bugs because it isn't done consistenly. For example, the key change dialog doesn't react to `KEY_CANCEL` and list boxes and text fields break `KEY_CANCEL` by absorbing it in some cases.

This PR maps the Android back button to `KEY_ESCAPE` instead and removes special handling for `KEY_CANCEL`.

EDIT: Actually, it looks like using `KEY_CANCEL` was a MT patch and Irrlicht originally used `KEY_BACK`/backspace.

## To do

This PR is a Ready for Review.

## How to test

Verify that the Android back button works as ESC, also in the mentioned cases where it didn't work before.
