### PR TITLE
Client: Only allow pointing with interact priv

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3324,22 +3324,26 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 		d = 0;
 		break;
 	}
-	shootline.end = shootline.start + camera_direction * BS * d;
 
-	if (g_touchscreengui && isTouchCrosshairDisabled()) {
-		shootline = g_touchscreengui->getShootline();
-		// Scale shootline to the acual distance the player can reach
-		shootline.end = shootline.start +
-				shootline.getVector().normalize() * BS * d;
-		shootline.start += intToFloat(camera_offset, BS);
-		shootline.end += intToFloat(camera_offset, BS);
+	PointedThing pointed;
+	if (client->checkPrivilege("interact")) {
+		shootline.end = shootline.start + camera_direction * BS * d;
+
+		if (g_touchscreengui && isTouchCrosshairDisabled()) {
+			shootline = g_touchscreengui->getShootline();
+			// Scale shootline to the acual distance the player can reach
+			shootline.end = shootline.start +
+					shootline.getVector().normalize() * BS * d;
+			shootline.start += intToFloat(camera_offset, BS);
+			shootline.end += intToFloat(camera_offset, BS);
+		}
+
+		pointed = updatePointedThing(shootline,
+				selected_def.liquids_pointable,
+				selected_def.pointabilities,
+				!runData.btn_down_for_dig,
+				camera_offset);
 	}
-
-	PointedThing pointed = updatePointedThing(shootline,
-			selected_def.liquids_pointable,
-			selected_def.pointabilities,
-			!runData.btn_down_for_dig,
-			camera_offset);
 
 	if (pointed != runData.pointed_old)
 		infostream << "Pointing at " << pointed.dump() << std::endl;
@@ -3567,8 +3571,7 @@ void Game::handlePointingAtNode(const PointedThing &pointed,
 	ClientMap &map = client->getEnv().getClientMap();
 
 	if (runData.nodig_delay_timer <= 0.0 && isKeyDown(KeyType::DIG)
-			&& !runData.digging_blocked
-			&& client->checkPrivilege("interact")) {
+			&& !runData.digging_blocked) {
 		handleDigging(pointed, nodepos, selected_item, hand_item, dtime);
 	}
 
@@ -3587,8 +3590,7 @@ void Game::handlePointingAtNode(const PointedThing &pointed,
 	}
 
 	if ((wasKeyPressed(KeyType::PLACE) ||
-			runData.repeat_place_timer >= m_repeat_place_time) &&
-			client->checkPrivilege("interact")) {
+			runData.repeat_place_timer >= m_repeat_place_time)) {
 		runData.repeat_place_timer = 0;
 		infostream << "Place button pressed while looking at ground" << std::endl;
 


### PR DESCRIPTION
Trivial UX improvement: When you don't have interact, you can't point at anything anymore, to signal that you are unable to interact with anything.

Previously, client prediction made it look as if you were still able to interact with things, even though the server ignores the interactions. You could still point at things, "dig" nodes (clientside), "punch" and "kill" entities clientside.

Provides a solution for part of the use case behind #14742: Simply revoking `interact` should now work well. Care needs to be taken to re-grant `interact` on player join, since privs are persisted.

The use case of tools that can't point at anything is however still valid, but a bit trickier to solve.

If we were to change behavior and make `range = 0` => no pointing, the fix would be trivial: Add `d > 0 &&` to the condition. (Oh also, it looks like you can still point at nodes you are inside of when you are in third person?)

(However, with a negative range or similar, it's a bit trickier: We already use a negative value (`-1`) as the default for "no value". This was what led me down the route of NaN back then, which in hindsight was a bad idea.)

## How to test

1. Host server
2. Join with second client (can't revoke interact from singleplayer / admin)
3. Revoke `interact` priv of second client
4. Notice that second client can't point at anything anymore
