### PR TITLE
Add zstd to Void Linux dependencies (fixes #14746)

### DIFF
--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -41,7 +41,7 @@ For Alpine users:
 
 For Void users:
 
-    sudo xbps-install cmake libpng-devel jpeg-devel mesa sqlite-devel libogg-devel libvorbis-devel libopenal-devel libcurl-devel freetype-devel zlib-devel gmp-devel jsoncpp-devel LuaJIT-devel libzstd-devel gettext SDL2-devel
+    sudo xbps-install cmake libpng-devel jpeg-devel mesa sqlite-devel libogg-devel libvorbis-devel libopenal-devel libcurl-devel freetype-devel zlib-devel gmp-devel jsoncpp-devel LuaJIT-devel zstd libzstd-devel gettext SDL2-devel
 
 ## Download
 


### PR DESCRIPTION
Previously, the dependency install command for Void Linux was missing the `zstd` package. Now it doesn't. (https://github.com/minetest/minetest/issues/14746#issuecomment-2161078798)

## To do

This PR is a Ready for Review.

## How to test

Try compiling Minetest from Void Linux using the instructions from the documentation.
(although you will fail either way, just not on the dependency check step, AHEM)
