### PR TITLE
[no squash] Split touch controls from UI

### DIFF
--- a/builtin/fstk/buttonbar.lua
+++ b/builtin/fstk/buttonbar.lua
@@ -19,7 +19,7 @@
 
 local BASE_SPACING = 0.1
 local function get_scroll_btn_width()
-	return core.settings:get_bool("enable_touch") and 0.8 or 0.5
+	return core.settings:get_bool("touch_gui") and 0.8 or 0.5
 end
 
 local function buttonbar_formspec(self)

--- a/builtin/mainmenu/content/dlg_contentdb.lua
+++ b/builtin/mainmenu/content/dlg_contentdb.lua
@@ -181,7 +181,7 @@ local function get_info_formspec(text)
 	return table.concat({
 		"formspec_version[6]",
 		"size[15.75,9.5]",
-		core.settings:get_bool("enable_touch") and "padding[0.01,0.01]" or "position[0.5,0.55]",
+		core.settings:get_bool("touch_gui") and "padding[0.01,0.01]" or "position[0.5,0.55]",
 
 		"label[4,4.35;", text, "]",
 		"container[0,", H - 0.8 - 0.375, "]",
@@ -212,7 +212,7 @@ local function get_formspec(dlgdata)
 	local formspec = {
 		"formspec_version[6]",
 		"size[15.75,9.5]",
-		core.settings:get_bool("enable_touch") and "padding[0.01,0.01]" or "position[0.5,0.55]",
+		core.settings:get_bool("touch_gui") and "padding[0.01,0.01]" or "position[0.5,0.55]",
 
 		"style[status,downloading,queued;border=false]",
 
@@ -463,7 +463,7 @@ end
 local function handle_events(event)
 	if event == "DialogShow" then
 		-- On touchscreen, don't show the "MINETEST" header behind the dialog.
-		mm_game_theme.set_engine(core.settings:get_bool("enable_touch"))
+		mm_game_theme.set_engine(core.settings:get_bool("touch_gui"))
 
 		-- If ContentDB is already loaded, auto-install packages here.
 		do_auto_install()

--- a/builtin/mainmenu/content/dlg_install.lua
+++ b/builtin/mainmenu/content/dlg_install.lua
@@ -22,13 +22,13 @@ end
 
 
 local function get_loading_formspec()
-	local ENABLE_TOUCH = core.settings:get_bool("enable_touch")
-	local w = ENABLE_TOUCH and 14 or 7
+	local TOUCH_GUI = core.settings:get_bool("touch_gui")
+	local w = TOUCH_GUI and 14 or 7
 
 	local formspec = {
 		"formspec_version[3]",
 		"size[", w, ",9.05]",
-		ENABLE_TOUCH and "padding[0.01,0.01]" or "position[0.5,0.55]",
+		TOUCH_GUI and "padding[0.01,0.01]" or "position[0.5,0.55]",
 		"label[3,4.525;", fgettext("Loading..."), "]",
 	}
 	return table.concat(formspec)
@@ -110,18 +110,18 @@ local function get_formspec(data)
 		message_bg = mt_color_orange
 	end
 
-	local ENABLE_TOUCH = core.settings:get_bool("enable_touch")
+	local TOUCH_GUI = core.settings:get_bool("touch_gui")
 
-	local w = ENABLE_TOUCH and 14 or 7
+	local w = TOUCH_GUI and 14 or 7
 	local padded_w = w - 2*0.375
-	local dropdown_w = ENABLE_TOUCH and 10.2 or 4.25
+	local dropdown_w = TOUCH_GUI and 10.2 or 4.25
 	local button_w = (padded_w - 0.25) / 3
 	local button_pad = button_w / 2
 
 	local formspec = {
 		"formspec_version[3]",
 		"size[", w, ",9.05]",
-		ENABLE_TOUCH and "padding[0.01,0.01]" or "position[0.5,0.55]",
+		TOUCH_GUI and "padding[0.01,0.01]" or "position[0.5,0.55]",
 		"style[title;border=false]",
 		"box[0,0;", w, ",0.8;#3333]",
 		"button[0,0;", w, ",0.8;title;", fgettext("Install $1", package.title) , "]",

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -110,7 +110,7 @@ local function load()
 	local change_keys = {
 		query_text = "Controls",
 		requires = {
-			keyboard_mouse = true,
+			touch_controls = false,
 		},
 		get_formspec = function(self, avail_w)
 			local btn_w = math.min(avail_w, 3)
@@ -324,8 +324,6 @@ local function check_requirements(name, requires)
 	local special = {
 		android = PLATFORM == "Android",
 		desktop = PLATFORM ~= "Android",
-		touchscreen_gui = core.settings:get_bool("enable_touch"),
-		keyboard_mouse = not core.settings:get_bool("enable_touch"),
 		shaders_support = shaders_support,
 		shaders = core.settings:get_bool("enable_shaders") and shaders_support,
 		opengl = video_driver == "opengl",
@@ -457,13 +455,13 @@ local function get_formspec(dialogdata)
 
 	local extra_h = 1 -- not included in tabsize.height
 	local tabsize = {
-		width = core.settings:get_bool("enable_touch") and 16.5 or 15.5,
-		height = core.settings:get_bool("enable_touch") and (10 - extra_h) or 12,
+		width = core.settings:get_bool("touch_gui") and 16.5 or 15.5,
+		height = core.settings:get_bool("touch_gui") and (10 - extra_h) or 12,
 	}
 
-	local scrollbar_w = core.settings:get_bool("enable_touch") and 0.6 or 0.4
+	local scrollbar_w = core.settings:get_bool("touch_gui") and 0.6 or 0.4
 
-	local left_pane_width = core.settings:get_bool("enable_touch") and 4.5 or 4.25
+	local left_pane_width = core.settings:get_bool("touch_gui") and 4.5 or 4.25
 	local left_pane_padding = 0.25
 	local search_width = left_pane_width + scrollbar_w - (0.75 * 2)
 
@@ -477,7 +475,7 @@ local function get_formspec(dialogdata)
 	local fs = {
 		"formspec_version[6]",
 		"size[", tostring(tabsize.width), ",", tostring(tabsize.height + extra_h), "]",
-		core.settings:get_bool("enable_touch") and "padding[0.01,0.01]" or "",
+		core.settings:get_bool("touch_gui") and "padding[0.01,0.01]" or "",
 		"bgcolor[#0000]",
 
 		-- HACK: this is needed to allow resubmitting the same formspec
@@ -652,15 +650,15 @@ local function buttonhandler(this, fields)
 		write_settings_early()
 	end
 
-	-- enable_touch is a checkbox in a setting component. We handle this
+	-- touch_controls is a checkbox in a setting component. We handle this
 	-- setting differently so we can hide/show pages using the next if-statement
-	if fields.enable_touch ~= nil then
-		local value = core.is_yes(fields.enable_touch)
-		core.settings:set_bool("enable_touch", value)
+	if fields.touch_controls ~= nil then
+		local value = core.is_yes(fields.touch_controls)
+		core.settings:set_bool("touch_controls", value)
 		write_settings_early()
 	end
 
-	if fields.show_advanced ~= nil or fields.enable_touch ~= nil then
+	if fields.show_advanced ~= nil or fields.touch_controls ~= nil then
 		local suggested_page_id = update_filtered_pages(dialogdata.query)
 
 		dialogdata.components = nil

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -94,7 +94,7 @@ function singleplayer_refresh_gamebar()
 
 	local btnbar = buttonbar_create(
 			"game_button_bar",
-			core.settings:get_bool("enable_touch") and {x = 0, y = 7.25} or {x = 0, y = 7.475},
+			core.settings:get_bool("touch_gui") and {x = 0, y = 7.25} or {x = 0, y = 7.475},
 			{x = 15.5, y = 1.25},
 			"#000000",
 			game_buttonbar_button_handler)

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -61,7 +61,7 @@
 #
 #    # This is a comment
 #    #
-#    # Requires: shaders, enable_dynamic_shadows, !touchscreen_gui
+#    # Requires: shaders, enable_dynamic_shadows, !touch_controls
 #    name (Readable name) type type_args
 #
 # A requirement can be the name of a boolean setting or an engine-defined value.
@@ -72,7 +72,6 @@
 #     * shaders_support (a video driver that supports shaders, may not be enabled)
 #     * shaders (both enable_shaders and shaders_support)
 #     * desktop / android
-#     * touchscreen_gui / keyboard_mouse
 #     * opengl / gles
 # * You can negate any requirement by prepending with !
 #
@@ -92,7 +91,7 @@ camera_smoothing (Camera smoothing) float 0.0 0.0 0.99
 
 #    Smooths rotation of camera when in cinematic mode, 0 to disable. Enter cinematic mode by using the key set in Controls.
 #
-#    Requires: keyboard_mouse
+#    Requires: !touch_controls
 cinematic_camera_smoothing (Camera smoothing in cinematic mode) float 0.7 0.0 0.99
 
 #    If enabled, you can place nodes at the position (feet + eye level) where you stand.
@@ -113,7 +112,7 @@ always_fly_fast (Always fly fast) bool true
 #    The time in seconds it takes between repeated node placements when holding
 #    the place button.
 #
-#    Requires: keyboard_mouse
+#    Requires: !touch_controls
 repeat_place_time (Place repetition interval) float 0.25 0.16 2.0
 
 #    The minimum time in seconds it takes between digging nodes when holding
@@ -132,62 +131,62 @@ safe_dig_and_place (Safe digging and placing) bool false
 
 #    Invert vertical mouse movement.
 #
-#    Requires: keyboard_mouse
+#    Requires: !touch_controls
 invert_mouse (Invert mouse) bool false
 
 #    Mouse sensitivity multiplier.
 #
-#    Requires: keyboard_mouse
+#    Requires: !touch_controls
 mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
 
 #    Enable mouse wheel (scroll) for item selection in hotbar.
 #
-#    Requires: keyboard_mouse
+#    Requires: !touch_controls
 enable_hotbar_mouse_wheel (Hotbar: Enable mouse wheel for selection) bool true
 
 #    Invert mouse wheel (scroll) direction for item selection in hotbar.
 #
-#    Requires: keyboard_mouse
+#    Requires: !touch_controls
 invert_hotbar_mouse_wheel (Hotbar: Invert mouse wheel direction) bool false
 
 [*Touchscreen]
 
-#    Enables touchscreen mode, allowing you to play the game with a touchscreen.
+#    Enables the touchscreen controls, allowing you to play the game with a touchscreen.
 #
 #    Requires: !android
-enable_touch (Enable touchscreen) bool true
+touch_controls (Enable touchscreen controls) bool true
 
 #    Touchscreen sensitivity multiplier.
 #
-#    Requires: touchscreen_gui
+#    Requires: touch_controls
 touchscreen_sensitivity (Touchscreen sensitivity) float 0.2 0.001 10.0
 
 #    The length in pixels after which a touch interaction is considered movement.
 #
-#    Requires: touchscreen_gui
+#    Requires: touch_controls
 touchscreen_threshold (Movement threshold) int 20 0 100
 
 #    The delay in milliseconds after which a touch interaction is considered a long tap.
 #
-#    Requires: touchscreen_gui
+#    Requires: touch_controls
 touch_long_tap_delay (Threshold for long taps) int 400 100 1000
 
 #    Use crosshair to select object instead of whole screen.
 #    If enabled, a crosshair will be shown and will be used for selecting object.
 #
-#    Requires: touchscreen_gui
+#    Requires: touch_controls
 touch_use_crosshair (Use crosshair for touch screen) bool false
 
 #    Fixes the position of virtual joystick.
 #    If disabled, virtual joystick will center to first-touch's position.
 #
-#    Requires: touchscreen_gui
+#    Requires: touch_controls
 fixed_virtual_joystick (Fixed virtual joystick) bool false
 
 #    Use virtual joystick to trigger "Aux1" button.
 #    If enabled, virtual joystick will also tap "Aux1" button when out of main circle.
 #
-#    Requires: touchscreen_gui
+#    Requires: touch_controls
 virtual_joystick_triggers_aux1 (Virtual joystick triggers Aux1 button) bool false
 
 #    The gesture for punching players/entities.
@@ -200,7 +199,7 @@ virtual_joystick_triggers_aux1 (Virtual joystick triggers Aux1 button) bool fals
 #      Known from the classic Minetest mobile controls.
 #      Combat is more or less impossible.
 #
-#    Requires: touchscreen_gui
+#    Requires: touch_controls
 touch_punch_gesture (Punch gesture) enum short_tap short_tap,long_tap
 
 
@@ -686,6 +685,10 @@ mute_sound (Mute sound) bool false
 language (Language) enum   ,be,bg,ca,cs,da,de,el,en,eo,es,et,eu,fi,fr,gd,gl,hu,id,it,ja,jbo,kk,ko,lt,lv,ms,nb,nl,nn,pl,pt,pt_BR,ro,ru,sk,sl,sr_Cyrl,sr_Latn,sv,sw,tr,uk,vi,zh_CN,zh_TW
 
 [**GUI]
+
+#    When enabled, the GUI is optimized to be more usable on touchscreens.
+#    Whether this is enabled by default depends on your hardware form-factor.
+touch_gui (Optimize GUI for touchscreens) bool false
 
 #    Scale GUI by a user specified value.
 #    Use a nearest-neighbor-anti-alias filter to scale the GUI.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -152,8 +152,6 @@ invert_hotbar_mouse_wheel (Hotbar: Invert mouse wheel direction) bool false
 [*Touchscreen]
 
 #    Enables the touchscreen controls, allowing you to play the game with a touchscreen.
-#
-#    Requires: !android
 touch_controls (Enable touchscreen controls) bool true
 
 #    Touchscreen sensitivity multiplier.

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "gui/mainmenumanager.h"
 #include "clouds.h"
-#include "gui/touchscreengui.h"
+#include "gui/touchcontrols.h"
 #include "server.h"
 #include "filesys.h"
 #include "gui/guiMainMenu.h"
@@ -230,9 +230,9 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 
 		m_rendering_engine->get_scene_manager()->clear();
 
-		if (g_touchscreengui) {
-			delete g_touchscreengui;
-			g_touchscreengui = NULL;
+		if (g_touchcontrols) {
+			delete g_touchcontrols;
+			g_touchcontrols = NULL;
 		}
 
 		/* Save the settings when leaving the game.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1578,7 +1578,7 @@ bool Game::initGui()
 	gui_chat_console = new GUIChatConsole(guienv, guienv->getRootGUIElement(),
 			-1, chat_backend, client, &g_menumgr);
 
-	if (g_settings->getBool("enable_touch"))
+	if (g_settings->getBool("touch_controls"))
 		g_touchcontrols = new TouchControls(device, texture_src);
 
 	return true;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -40,7 +40,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "content/subgames.h"
 #include "client/event_manager.h"
 #include "fontengine.h"
-#include "gui/touchscreengui.h"
+#include "gui/touchcontrols.h"
 #include "itemdef.h"
 #include "log.h"
 #include "filesys.h"
@@ -1245,8 +1245,8 @@ void Game::shutdown()
 	// Clear text when exiting.
 	m_game_ui->clearText();
 
-	if (g_touchscreengui)
-		g_touchscreengui->hide();
+	if (g_touchcontrols)
+		g_touchcontrols->hide();
 
 	// only if the shutdown progress bar isn't shown yet
 	if (m_shutdown_progress == 0.0f)
@@ -1510,8 +1510,8 @@ bool Game::createClient(const GameStartData &start_data)
 		client->getScript()->on_camera_ready(camera);
 	client->setCamera(camera);
 
-	if (g_touchscreengui) {
-		g_touchscreengui->setUseCrosshair(!isTouchCrosshairDisabled());
+	if (g_touchcontrols) {
+		g_touchcontrols->setUseCrosshair(!isTouchCrosshairDisabled());
 	}
 
 	/* Clouds
@@ -1579,7 +1579,7 @@ bool Game::initGui()
 			-1, chat_backend, client, &g_menumgr);
 
 	if (g_settings->getBool("enable_touch"))
-		g_touchscreengui = new TouchScreenGUI(device, texture_src);
+		g_touchcontrols = new TouchControls(device, texture_src);
 
 	return true;
 }
@@ -2022,15 +2022,15 @@ void Game::processUserInput(f32 dtime)
 			input->clear();
 		}
 
-		if (g_touchscreengui)
-			g_touchscreengui->hide();
+		if (g_touchcontrols)
+			g_touchcontrols->hide();
 
 	} else {
-		if (g_touchscreengui) {
-			/* on touchscreengui step may generate own input events which ain't
+		if (g_touchcontrols) {
+			/* on touchcontrols step may generate own input events which ain't
 			 * what we want in case we just did clear them */
-			g_touchscreengui->show();
-			g_touchscreengui->step(dtime);
+			g_touchcontrols->show();
+			g_touchcontrols->step(dtime);
 		}
 
 		m_game_focused = true;
@@ -2225,8 +2225,8 @@ void Game::processItemSelection(u16 *new_playeritem)
 		}
 	}
 
-	if (g_touchscreengui) {
-		std::optional<u16> selection = g_touchscreengui->getHotbarSelection();
+	if (g_touchcontrols) {
+		std::optional<u16> selection = g_touchcontrols->getHotbarSelection();
 		if (selection)
 			*new_playeritem = *selection;
 	}
@@ -2631,7 +2631,7 @@ void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 	this results in duplicated input. To avoid that, we don't enable relative
 	mouse mode if we're in touchscreen mode. */
 	if (cur_control)
-		cur_control->setRelativeMode(!g_touchscreengui && !isMenuActive());
+		cur_control->setRelativeMode(!g_touchcontrols && !isMenuActive());
 
 	if ((device->isWindowActive() && device->isWindowFocused()
 			&& !isMenuActive()) || input->isRandom()) {
@@ -2674,9 +2674,9 @@ f32 Game::getSensitivityScaleFactor() const
 
 void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 {
-	if (g_touchscreengui) {
-		cam->camera_yaw   += g_touchscreengui->getYawChange();
-		cam->camera_pitch += g_touchscreengui->getPitchChange();
+	if (g_touchcontrols) {
+		cam->camera_yaw   += g_touchcontrols->getYawChange();
+		cam->camera_pitch += g_touchcontrols->getPitchChange();
 	} else {
 		v2s32 center(driver->getScreenSize().Width / 2, driver->getScreenSize().Height / 2);
 		v2s32 dist = input->getMousePos() - center;
@@ -2741,7 +2741,7 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 	 * touch then its meaning is inverted (i.e. holding aux1 means walk and
 	 * not fast)
 	 */
-	if (g_touchscreengui && m_touch_simulate_aux1) {
+	if (g_touchcontrols && m_touch_simulate_aux1) {
 		control.aux1 = control.aux1 ^ true;
 	}
 
@@ -3230,8 +3230,8 @@ void Game::updateCamera(f32 dtime)
 
 		camera->toggleCameraMode();
 
-		if (g_touchscreengui)
-			g_touchscreengui->setUseCrosshair(!isTouchCrosshairDisabled());
+		if (g_touchcontrols)
+			g_touchcontrols->setUseCrosshair(!isTouchCrosshairDisabled());
 
 		// Make the player visible depending on camera mode.
 		playercao->updateMeshCulling();
@@ -3332,8 +3332,8 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	}
 	shootline.end = shootline.start + camera_direction * BS * d;
 
-	if (g_touchscreengui && isTouchCrosshairDisabled()) {
-		shootline = g_touchscreengui->getShootline();
+	if (g_touchcontrols && isTouchCrosshairDisabled()) {
+		shootline = g_touchcontrols->getShootline();
 		// Scale shootline to the acual distance the player can reach
 		shootline.end = shootline.start +
 				shootline.getVector().normalize() * BS * d;
@@ -3350,9 +3350,9 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	if (pointed != runData.pointed_old)
 		infostream << "Pointing at " << pointed.dump() << std::endl;
 
-	if (g_touchscreengui) {
+	if (g_touchcontrols) {
 		auto mode = selected_def.touch_interaction.getMode(pointed.type);
-		g_touchscreengui->applyContextControls(mode);
+		g_touchcontrols->applyContextControls(mode);
 	}
 
 	// Note that updating the selection mesh every frame is not particularly efficient,
@@ -4343,7 +4343,7 @@ void Game::drawScene(ProfilerGraph *graph, RunStats *stats)
 			(player->hud_flags & HUD_FLAG_CROSSHAIR_VISIBLE) &&
 			(this->camera->getCameraMode() != CAMERA_MODE_THIRD_FRONT));
 
-	if (g_touchscreengui && isTouchCrosshairDisabled())
+	if (g_touchcontrols && isTouchCrosshairDisabled())
 		draw_crosshair = false;
 
 	this->m_rendering_engine->draw_scene(sky_color, this->m_game_ui->m_flags.show_hud,
@@ -4454,7 +4454,7 @@ void Game::showPauseMenu()
 {
 	std::string control_text;
 
-	if (g_touchscreengui) {
+	if (g_touchcontrols) {
 		control_text = strgettext("Controls:\n"
 			"No menu open:\n"
 			"- slide finger: look around\n"

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -39,7 +39,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "wieldmesh.h"
 #include "client/renderingengine.h"
 #include "client/minimap.h"
-#include "gui/touchscreengui.h"
+#include "gui/touchcontrols.h"
 #include "util/enriched_string.h"
 #include "irrlicht_changes/CGUITTFont.h"
 
@@ -308,8 +308,8 @@ void Hud::drawItems(v2s32 upperleftpos, v2s32 screen_offset, s32 itemcount,
 
 		drawItem(mainlist->getItem(i), item_rect, (i + 1) == selectitem);
 
-		if (is_hotbar && g_touchscreengui)
-			g_touchscreengui->registerHotbarRect(i, item_rect);
+		if (is_hotbar && g_touchcontrols)
+			g_touchcontrols->registerHotbarRect(i, item_rect);
 	}
 }
 
@@ -773,8 +773,8 @@ void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir,
 
 void Hud::drawHotbar(u16 playeritem)
 {
-	if (g_touchscreengui)
-		g_touchscreengui->resetHotbarRects();
+	if (g_touchcontrols)
+		g_touchcontrols->resetHotbarRects();
 
 	InventoryList *mainlist = inventory->getList("main");
 	if (mainlist == NULL) {

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h"
 #include "inputhandler.h"
 #include "gui/mainmenumanager.h"
-#include "gui/touchscreengui.h"
+#include "gui/touchcontrols.h"
 #include "hud.h"
 
 void KeyCache::populate_nonchanging()
@@ -143,8 +143,8 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 
 	// Let the menu handle events, if one is active.
 	if (isMenuActive()) {
-		if (g_touchscreengui)
-			g_touchscreengui->setVisible(false);
+		if (g_touchcontrols)
+			g_touchcontrols->setVisible(false);
 		return g_menumgr.preprocessEvent(event);
 	}
 
@@ -168,9 +168,9 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 			return true;
 		}
 
-	} else if (g_touchscreengui && event.EventType == irr::EET_TOUCH_INPUT_EVENT) {
-		// In case of touchscreengui, we have to handle different events
-		g_touchscreengui->translateEvent(event);
+	} else if (g_touchcontrols && event.EventType == irr::EET_TOUCH_INPUT_EVENT) {
+		// In case of touchcontrols, we have to handle different events
+		g_touchcontrols->translateEvent(event);
 		return true;
 	} else if (event.EventType == irr::EET_JOYSTICK_INPUT_EVENT) {
 		// joystick may be nullptr if game is launched with '--random-input' parameter
@@ -237,8 +237,8 @@ float RealInputHandler::getMovementSpeed()
 			return 0.0f;
 		return 1.0f; // If there is a keyboard event, assume maximum speed
 	}
-	if (g_touchscreengui && g_touchscreengui->getMovementSpeed())
-		return g_touchscreengui->getMovementSpeed();
+	if (g_touchcontrols && g_touchcontrols->getMovementSpeed())
+		return g_touchcontrols->getMovementSpeed();
 	return joystick.getMovementSpeed();
 }
 
@@ -260,8 +260,8 @@ float RealInputHandler::getMovementDirection()
 		return std::atan2(x, z);
 	// `getMovementDirection() == 0` means forward, so we cannot use
 	// `getMovementDirection()` as a condition.
-	else if (g_touchscreengui && g_touchscreengui->getMovementSpeed())
-		return g_touchscreengui->getMovementDirection();
+	else if (g_touchcontrols && g_touchcontrols->getMovementSpeed())
+		return g_touchcontrols->getMovementDirection();
 	return joystick.getMovementDirection();
 }
 

--- a/src/clientdynamicinfo.cpp
+++ b/src/clientdynamicinfo.cpp
@@ -44,7 +44,7 @@ ClientDynamicInfo ClientDynamicInfo::getCurrent()
 
 v2f32 ClientDynamicInfo::calculateMaxFSSize(v2u32 render_target_size, f32 gui_scaling)
 {
-    f32 factor = (g_settings->getBool("enable_touch") ? 10 : 15) / gui_scaling;
+    f32 factor = (g_settings->getBool("touch_gui") ? 10 : 15) / gui_scaling;
     f32 ratio = (f32)render_target_size.X / (f32)render_target_size.Y;
     if (ratio < 1)
         return { factor, factor / ratio };

--- a/src/clientdynamicinfo.cpp
+++ b/src/clientdynamicinfo.cpp
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "settings.h"
 #include "client/renderingengine.h"
-#include "gui/touchscreengui.h"
+#include "gui/touchcontrols.h"
 
 ClientDynamicInfo ClientDynamicInfo::getCurrent()
 {
@@ -33,7 +33,7 @@ ClientDynamicInfo ClientDynamicInfo::getCurrent()
     f32 hud_scaling = g_settings->getFloat("hud_scaling", 0.5f, 20.0f);
     f32 real_gui_scaling = gui_scaling * density;
     f32 real_hud_scaling = hud_scaling * density;
-    bool touch_controls = g_touchscreengui;
+    bool touch_controls = g_touchcontrols;
 
     return {
         screen_size, real_gui_scaling, real_hud_scaling,

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -104,7 +104,8 @@ void set_default_settings()
 	// Client
 	settings->setDefault("address", "");
 	settings->setDefault("enable_sound", "true");
-	settings->setDefault("enable_touch", bool_to_cstr(has_touch));
+	settings->setDefault("touch_controls", bool_to_cstr(has_touch));
+	settings->setDefault("touch_gui", bool_to_cstr(has_touch));
 	settings->setDefault("sound_volume", "0.8");
 	settings->setDefault("sound_volume_unfocused", "0.3");
 	settings->setDefault("mute_sound", "false");

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -25,6 +25,6 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiVolumeChange.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/modalMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/profilergraph.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/touchscreengui.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/touchcontrols.cpp
 	PARENT_SCOPE
 )

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -315,7 +315,7 @@ void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 		data->invsize.Y = MYMAX(0, stof(parts[1]));
 
 		lockSize(false);
-		if (!g_settings->getBool("enable_touch") && parts.size() == 3) {
+		if (!g_settings->getBool("touch_gui") && parts.size() == 3) {
 			if (parts[2] == "true") {
 				lockSize(true,v2u32(800,600));
 			}
@@ -3166,7 +3166,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			s32 min_screen_dim = std::min(padded_screensize.X, padded_screensize.Y);
 
 			double prefer_imgsize;
-			if (g_settings->getBool("enable_touch")) {
+			if (g_settings->getBool("touch_gui")) {
 				// The preferred imgsize should be larger to accommodate the
 				// smaller screensize.
 				prefer_imgsize = min_screen_dim / 10 * gui_scaling;

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -377,7 +377,7 @@ void GUIKeyChangeMenu::add_key(int id, std::wstring button_name, const std::stri
 	key_settings.push_back(k);
 }
 
-// compare with button_titles in touchscreengui.cpp
+// compare with button_titles in touchcontrols.cpp
 void GUIKeyChangeMenu::init_keys()
 {
 	this->add_key(GUI_ID_KEY_FORWARD_BUTTON,      wstrgettext("Forward"),          "keymap_forward");

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -28,7 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gui/guiInventoryList.h"
 #include "porting.h"
 #include "settings.h"
-#include "touchscreengui.h"
+#include "touchcontrols.h"
 
 PointerAction PointerAction::fromEvent(const SEvent &event) {
 	switch (event.EventType) {
@@ -111,8 +111,8 @@ void GUIModalMenu::quitMenu()
 	Environment->removeFocus(this);
 	m_menumgr->deletingMenu(this);
 	this->remove();
-	if (g_touchscreengui)
-		g_touchscreengui->show();
+	if (g_touchcontrols)
+		g_touchcontrols->show();
 }
 
 static bool isChild(gui::IGUIElement *tocheck, gui::IGUIElement *parent)

--- a/src/gui/touchcontrols.cpp
+++ b/src/gui/touchcontrols.cpp
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include "touchscreengui.h"
+#include "touchcontrols.h"
 
 #include "gettime.h"
 #include "irr_v2d.h"
@@ -39,7 +39,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <iostream>
 #include <algorithm>
 
-TouchScreenGUI *g_touchscreengui;
+TouchControls *g_touchcontrols;
 
 static const char *button_image_names[] = {
 	"jump_btn.png",
@@ -266,14 +266,14 @@ static EKEY_CODE id_to_keycode(touch_gui_button_id id)
 		code = keyname_to_keycode(resolved.c_str());
 	} catch (UnknownKeycode &e) {
 		code = KEY_UNKNOWN;
-		warningstream << "TouchScreenGUI: Unknown key '" << resolved
+		warningstream << "TouchControls: Unknown key '" << resolved
 			      << "' for '" << key << "', hiding button." << std::endl;
 	}
 	return code;
 }
 
 
-TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsrc):
+TouchControls::TouchControls(IrrlichtDevice *device, ISimpleTextureSource *tsrc):
 		m_device(device),
 		m_guienv(device->getGUIEnvironment()),
 		m_receiver(device->getEventReceiver()),
@@ -413,7 +413,7 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsr
 	}
 }
 
-void TouchScreenGUI::addButton(std::vector<button_info> &buttons, touch_gui_button_id id,
+void TouchControls::addButton(std::vector<button_info> &buttons, touch_gui_button_id id,
 		const std::string &image, const recti &rect, bool visible)
 {
 	IGUIImage *btn_gui_button = m_guienv->addImage(rect, nullptr, id);
@@ -426,7 +426,7 @@ void TouchScreenGUI::addButton(std::vector<button_info> &buttons, touch_gui_butt
 	btn.gui_button = grab_gui_element<IGUIImage>(btn_gui_button);
 }
 
-void TouchScreenGUI::addToggleButton(std::vector<button_info> &buttons, touch_gui_button_id id,
+void TouchControls::addToggleButton(std::vector<button_info> &buttons, touch_gui_button_id id,
 		const std::string &image_1, const std::string &image_2, const recti &rect, bool visible)
 {
 	addButton(buttons, id, image_1, rect, visible);
@@ -436,7 +436,7 @@ void TouchScreenGUI::addToggleButton(std::vector<button_info> &buttons, touch_gu
 	btn.toggle_textures[1] = image_2;
 }
 
-IGUIImage *TouchScreenGUI::makeButtonDirect(touch_gui_button_id id,
+IGUIImage *TouchControls::makeButtonDirect(touch_gui_button_id id,
 		const recti &rect, bool visible)
 {
 	IGUIImage *btn_gui_button = m_guienv->addImage(rect, nullptr, id);
@@ -447,7 +447,7 @@ IGUIImage *TouchScreenGUI::makeButtonDirect(touch_gui_button_id id,
 	return btn_gui_button;
 }
 
-bool TouchScreenGUI::isHotbarButton(const SEvent &event)
+bool TouchControls::isHotbarButton(const SEvent &event)
 {
 	const v2s32 touch_pos = v2s32(event.TouchInput.X, event.TouchInput.Y);
 	// check if hotbar item is pressed
@@ -462,14 +462,14 @@ bool TouchScreenGUI::isHotbarButton(const SEvent &event)
 	return false;
 }
 
-std::optional<u16> TouchScreenGUI::getHotbarSelection()
+std::optional<u16> TouchControls::getHotbarSelection()
 {
 	auto selection = m_hotbar_selection;
 	m_hotbar_selection = std::nullopt;
 	return selection;
 }
 
-void TouchScreenGUI::handleReleaseEvent(size_t pointer_id)
+void TouchControls::handleReleaseEvent(size_t pointer_id)
 {
 	// By the way: Android reuses pointer IDs, so m_pointer_pos[pointer_id]
 	// will be overwritten soon anyway.
@@ -516,15 +516,15 @@ void TouchScreenGUI::handleReleaseEvent(size_t pointer_id)
 		m_joystick_btn_bg->setVisible(false);
 		m_joystick_btn_center->setVisible(false);
 	} else {
-		infostream << "TouchScreenGUI::translateEvent released unknown button: "
+		infostream << "TouchControls::translateEvent released unknown button: "
 				<< pointer_id << std::endl;
 	}
 }
 
-void TouchScreenGUI::translateEvent(const SEvent &event)
+void TouchControls::translateEvent(const SEvent &event)
 {
 	if (!m_visible) {
-		infostream << "TouchScreenGUI::translateEvent got event but is not visible!"
+		infostream << "TouchControls::translateEvent got event but is not visible!"
 				<< std::endl;
 		return;
 	}
@@ -702,7 +702,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 	}
 }
 
-void TouchScreenGUI::applyJoystickStatus()
+void TouchControls::applyJoystickStatus()
 {
 	if (m_joystick_triggers_aux1) {
 		SEvent translated{};
@@ -718,7 +718,7 @@ void TouchScreenGUI::applyJoystickStatus()
 	}
 }
 
-void TouchScreenGUI::step(float dtime)
+void TouchControls::step(float dtime)
 {
 	if (m_overflow_open) {
 		buttons_step(m_overflow_buttons, dtime, m_device->getVideoDriver(), m_receiver, m_texturesource);
@@ -757,17 +757,17 @@ void TouchScreenGUI::step(float dtime)
 	m_had_move_id = false;
 }
 
-void TouchScreenGUI::resetHotbarRects()
+void TouchControls::resetHotbarRects()
 {
 	m_hotbar_rects.clear();
 }
 
-void TouchScreenGUI::registerHotbarRect(u16 index, const recti &rect)
+void TouchControls::registerHotbarRect(u16 index, const recti &rect)
 {
 	m_hotbar_rects[index] = rect;
 }
 
-void TouchScreenGUI::setVisible(bool visible)
+void TouchControls::setVisible(bool visible)
 {
 	if (m_visible == visible)
 		return;
@@ -781,14 +781,14 @@ void TouchScreenGUI::setVisible(bool visible)
 	updateVisibility();
 }
 
-void TouchScreenGUI::toggleOverflowMenu()
+void TouchControls::toggleOverflowMenu()
 {
 	releaseAll(); // must be done first
 	m_overflow_open = !m_overflow_open;
 	updateVisibility();
 }
 
-void TouchScreenGUI::updateVisibility()
+void TouchControls::updateVisibility()
 {
 	bool regular_visible = m_visible && !m_overflow_open;
 	for (auto &button : m_buttons)
@@ -804,7 +804,7 @@ void TouchScreenGUI::updateVisibility()
 		text->setVisible(overflow_visible);
 }
 
-void TouchScreenGUI::releaseAll()
+void TouchControls::releaseAll()
 {
 	while (!m_pointer_pos.empty())
 		handleReleaseEvent(m_pointer_pos.begin()->first);
@@ -821,17 +821,17 @@ void TouchScreenGUI::releaseAll()
 	}
 }
 
-void TouchScreenGUI::hide()
+void TouchControls::hide()
 {
 	setVisible(false);
 }
 
-void TouchScreenGUI::show()
+void TouchControls::show()
 {
 	setVisible(true);
 }
 
-v2s32 TouchScreenGUI::getPointerPos()
+v2s32 TouchControls::getPointerPos()
 {
 	if (m_draw_crosshair)
 		return v2s32(m_screensize.X / 2, m_screensize.Y / 2);
@@ -840,7 +840,7 @@ v2s32 TouchScreenGUI::getPointerPos()
 	return m_move_pos;
 }
 
-void TouchScreenGUI::emitMouseEvent(EMOUSE_INPUT_EVENT type)
+void TouchControls::emitMouseEvent(EMOUSE_INPUT_EVENT type)
 {
 	v2s32 pointer_pos = getPointerPos();
 
@@ -855,7 +855,7 @@ void TouchScreenGUI::emitMouseEvent(EMOUSE_INPUT_EVENT type)
 	m_receiver->OnEvent(event);
 }
 
-void TouchScreenGUI::applyContextControls(const TouchInteractionMode &mode)
+void TouchControls::applyContextControls(const TouchInteractionMode &mode)
 {
 	// Since the pointed thing has already been determined when this function
 	// is called, we cannot use this function to update the shootline.

--- a/src/gui/touchcontrols.h
+++ b/src/gui/touchcontrols.h
@@ -128,10 +128,10 @@ struct button_info
 };
 
 
-class TouchScreenGUI
+class TouchControls
 {
 public:
-	TouchScreenGUI(IrrlichtDevice *device, ISimpleTextureSource *tsrc);
+	TouchControls(IrrlichtDevice *device, ISimpleTextureSource *tsrc);
 
 	void translateEvent(const SEvent &event);
 	void applyContextControls(const TouchInteractionMode &mode);
@@ -182,7 +182,7 @@ private:
 	s32 m_button_size;
 	double m_touchscreen_threshold;
 	u16 m_long_tap_delay;
-	bool m_visible = true; // is the whole touch screen gui visible
+	bool m_visible = true;
 
 	std::unordered_map<u16, recti> m_hotbar_rects;
 	std::optional<u16> m_hotbar_selection = std::nullopt;
@@ -273,4 +273,4 @@ private:
 	u64 m_place_pressed_until = 0;
 };
 
-extern TouchScreenGUI *g_touchscreengui;
+extern TouchControls *g_touchcontrols;

--- a/src/migratesettings.h
+++ b/src/migratesettings.h
@@ -11,4 +11,12 @@ void migrate_settings()
 				g_settings->getBool("opaque_water") ? "false" : "true");
 		g_settings->remove("opaque_water");
 	}
+
+	// Converts enable_touch to touch_controls/touch_gui
+	if (g_settings->existsLocal("enable_touch")) {
+		bool value = g_settings->getBool("enable_touch");
+		g_settings->setBool("touch_controls", value);
+		g_settings->setBool("touch_gui", value);
+		g_settings->remove("enable_touch");
+	}
 }


### PR DESCRIPTION
- Goal of the PR

Prepare for touch screen autodetection.

- How does the PR work?

Split touchscreen controls from UI adjustment for touch screen devices.

- Does it resolve any reported issue?

No. But prepares ground for auto-detection of touch input, where changes in UI would be undesired.

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?

Yes, it does improve touchscreen experience and clarity of the TS code.

- If not a bug fix, why is this PR needed? What usecases does it solve?

## How to test

Check the UI settings, check the touchscreen settings.

<!-- Example code or instructions -->
