### PR TITLE
Fix two problems with toggling fullscreen at runtime

### DIFF
--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -118,8 +118,14 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 		const KeyPress keyCode(event.KeyInput);
 		if (keyCode == getKeySetting("keymap_fullscreen")) {
 			if (event.KeyInput.PressedDown && !fullscreen_is_down) {
-				bool fullscreen = RenderingEngine::get_raw_device()->isFullscreen();
-				g_settings->setBool("fullscreen", !fullscreen);
+				IrrlichtDevice *device = RenderingEngine::get_raw_device();
+
+				bool new_fullscreen = !device->isFullscreen();
+				// Only update the setting if toggling succeeds - it always fails
+				// if Minetest was built without SDL.
+				if (device->setFullscreen(new_fullscreen)) {
+					g_settings->setBool("fullscreen", new_fullscreen);
+				}
 			}
 			fullscreen_is_down = event.KeyInput.PressedDown;
 			return true;

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -489,11 +489,14 @@ void RenderingEngine::autosaveScreensizeAndCo(
 	// we do not want to save the thing. This allows users to also manually change
 	// the settings.
 
+	// Don't save the fullscreen size, we want the windowed size.
+	bool fullscreen = RenderingEngine::get_raw_device()->isFullscreen();
 	// Screen size
 	const irr::core::dimension2d<u32> current_screen_size =
 		RenderingEngine::get_video_driver()->getScreenSize();
 	// Don't replace good value with (0, 0)
-	if (current_screen_size != irr::core::dimension2d<u32>(0, 0) &&
+	if (!fullscreen &&
+			current_screen_size != irr::core::dimension2d<u32>(0, 0) &&
 			current_screen_size != initial_screen_size) {
 		g_settings->setU16("screen_w", current_screen_size.Width);
 		g_settings->setU16("screen_h", current_screen_size.Height);


### PR DESCRIPTION
"Don't save the fullscreen size, we want the windowed size" fixes the following problem on Windows:

1. Have a non-maximized non-fullscreen Minetest window on Windows, close Minetest to save window info to minetest.conf
2. Start Minetest again, enable fullscreen via F11, close Minetest to save window info to minetest.conf
3. Start Minetest again, disable fullscreen via F11

before PR => the window is still fullscreen because it's so large
after PR => the window is un-fullscreened correctly

## To do

This PR is a Ready for Review.

## How to test

^ see above ^

For the other change, verify that pressing F11 doesn't toggle the fullscreen setting if you compile with `-DUSE_SDL2=FALSE`.
