### PR TITLE
Disallow formspec debug if the player does not have the debug privilege

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1914,6 +1914,10 @@ void Game::updateDebugState()
 	if (!has_debug) {
 		draw_control->show_wireframe = false;
 		m_flags.disable_camera_update = false;
+		auto formspec = m_game_ui->getFormspecGUI();
+		if (formspec) {
+			formspec->setDebugView(false);
+		}
 	}
 
 	// noclip

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4186,7 +4186,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 		// Allows the user to disable debug mode regardless of privilege
 		if ((event.KeyInput.PressedDown && kp == getKeySetting("keymap_toggle_debug")) &&
-				(m_show_debug || (m_client != NULL && m_client->checkPrivilege("debug")))) {
+				(m_client != NULL && m_client->checkPrivilege("debug"))) {
 			m_show_debug = !m_show_debug;
 		}
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4184,7 +4184,6 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			m_client->makeScreenshot();
 		}
 
-		// Allows the user to disable debug mode regardless of privilege
 		if ((event.KeyInput.PressedDown && kp == getKeySetting("keymap_toggle_debug")) &&
 				(m_client != NULL && m_client->checkPrivilege("debug"))) {
 			m_show_debug = !m_show_debug;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4184,8 +4184,9 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			m_client->makeScreenshot();
 		}
 
-		if (event.KeyInput.PressedDown && kp == getKeySetting("keymap_toggle_debug") &&
-				(m_client != NULL && m_client->checkPrivilege("debug"))) {
+		// Allows the user to disable debug mode regardless of privilege
+		if ((event.KeyInput.PressedDown && kp == getKeySetting("keymap_toggle_debug")) &&
+				(m_show_debug || (m_client != NULL && m_client->checkPrivilege("debug")))) {
 			m_show_debug = !m_show_debug;
 		}
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4184,9 +4184,9 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			m_client->makeScreenshot();
 		}
 
-		if ((event.KeyInput.PressedDown && kp == getKeySetting("keymap_toggle_debug")) &&
-				(m_client == NULL || m_client->checkPrivilege("debug"))) {
-			m_show_debug = !m_show_debug;
+		if (event.KeyInput.PressedDown && kp == getKeySetting("keymap_toggle_debug")) {
+			if (!m_client || m_client->checkPrivilege("debug"))
+				m_show_debug = !m_show_debug;
 		}
 
 		if (event.KeyInput.PressedDown &&

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4184,8 +4184,10 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			m_client->makeScreenshot();
 		}
 
-		if (event.KeyInput.PressedDown && kp == getKeySetting("keymap_toggle_debug"))
+		if (event.KeyInput.PressedDown && kp == getKeySetting("keymap_toggle_debug") &&
+				(m_client != NULL && m_client->checkPrivilege("debug"))) {
 			m_show_debug = !m_show_debug;
+		}
 
 		if (event.KeyInput.PressedDown &&
 			(event.KeyInput.Key==KEY_RETURN ||

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4185,7 +4185,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 		}
 
 		if ((event.KeyInput.PressedDown && kp == getKeySetting("keymap_toggle_debug")) &&
-				(m_client != NULL && m_client->checkPrivilege("debug"))) {
+				(m_client == NULL || m_client->checkPrivilege("debug"))) {
 			m_show_debug = !m_show_debug;
 		}
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -223,6 +223,11 @@ public:
 		m_allowclose = value;
 	}
 
+	void setDebugView(bool value)
+	{
+		m_show_debug = value;
+	}
+
 	void lockSize(bool lock,v2u32 basescreensize=v2u32(0,0))
 	{
 		m_lock = lock;


### PR DESCRIPTION
- Goal of the PR
Disallow players that do not have the "debug" privilege from viewing formspec debug info.
- How does the PR work?
It adds a check for the "debug" privilege before toggling the formspec debug view.
- Does it resolve any reported issue?
Fixes #11689

## To do

Ready for Review.

## How to test

Open the inventory (or any other formspec), press F5 with and without the "debug" privilege.
The debug view should only be toggled with the "debug" privilege.