### PR TITLE
Fix broken default sneak keybind on macOS with SDL

### DIFF
--- a/src/cmake_config.h.in
+++ b/src/cmake_config.h.in
@@ -40,3 +40,4 @@
 #cmakedefine01 CURSES_HAVE_NCURSESW_CURSES_H
 #cmakedefine01 BUILD_UNITTESTS
 #cmakedefine01 BUILD_BENCHMARKS
+#cmakedefine01 USE_SDL2

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -539,8 +539,8 @@ void set_default_settings()
 	settings->setDefault("screen_dpi", "72");
 	settings->setDefault("display_density_factor", "1");
 
-	// Altered settings for macOS
-#if defined(__MACH__) && defined(__APPLE__)
+	// Altered settings for CIrrDeviceOSX
+#if !USE_SDL2 && defined(__MACH__) && defined(__APPLE__)
 	settings->setDefault("keymap_sneak", "KEY_SHIFT");
 #endif
 


### PR DESCRIPTION
(not tested)

## To do

This PR is a Ready for Review.

## How to test

Build Minetest on macOS.

Verify that sneaking still works by default when built with `-DUSE_SDL2=FALSE`.

Verify that sneaking now also works by default when built with `-DUSE_SDL2=TRUE`.