### PR TITLE
Fix API "dtime" not clarified

### DIFF
--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -314,7 +314,7 @@ Minetest namespace reference
 Call these functions only at load time!
 
 * `minetest.register_globalstep(function(dtime))`
-    * Called every server step, usually interval of 0.1s.
+    * Called every client environment step, usually interval of 0.1s
 	* `dtime` is the time since last execution in seconds.
 * `minetest.register_on_mods_loaded(function())`
     * Called just after mods have finished loading.

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -314,7 +314,7 @@ Minetest namespace reference
 Call these functions only at load time!
 
 * `minetest.register_globalstep(function(dtime))`
-    * Called every client environment step, usually interval of 0.1s
+    * Called every client environment step
 	* `dtime` is the time since last execution in seconds.
 * `minetest.register_on_mods_loaded(function())`
     * Called just after mods have finished loading.

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -314,7 +314,8 @@ Minetest namespace reference
 Call these functions only at load time!
 
 * `minetest.register_globalstep(function(dtime))`
-    * Called every client environment step, usually interval of 0.1s
+    * Called every server step, usually interval of 0.1s.
+	* `dtime` is the time since last execution in seconds.
 * `minetest.register_on_mods_loaded(function())`
     * Called just after mods have finished loading.
 * `minetest.register_on_shutdown(function())`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5714,7 +5714,8 @@ Global callback registration functions
 Call these functions only at load time!
 
 * `minetest.register_globalstep(function(dtime))`
-    * Called every server step, usually interval of 0.1s
+    * Called every server step, usually interval of 0.1s.
+	* `dtime` is the time since last execution in seconds.
 * `minetest.register_on_mods_loaded(function())`
     * Called after mods have finished loading and before the media is cached or the
       aliases handled.


### PR DESCRIPTION
Fix https://github.com/minetest/minetest/issues/14222

This PR documents that "dtime" in minetest.register_globalstep is the time measured in seconds in the Lua API.

This PR is Ready for Review.

## How to test

Read the Lua API.