### PR TITLE
Fix new texture properties not being sent for minetest.add_particle

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -10649,7 +10649,10 @@ Used by `minetest.add_particle`.
     texture = "image.png",
     -- The texture of the particle
     -- v5.6.0 and later: also supports the table format described in the
-    -- following section
+    -- following section, but due to a bug this did not take effect
+    -- (beyond the texture name).
+    -- v5.9.0 and later: fixes the bug.
+    -- Note: "texture.animation" is ignored here. Use "animation" below instead.
 
     playername = "singleplayer",
     -- Optional, if specified spawns particle only on the player's client

--- a/src/particles.h
+++ b/src/particles.h
@@ -276,8 +276,10 @@ struct ParticleTexture
 struct ServerParticleTexture : public ParticleTexture
 {
 	std::string string;
-	void serialize(std::ostream &os, u16 protocol_ver, bool newPropertiesOnly = false) const;
-	void deSerialize(std::istream &is, u16 protocol_ver, bool newPropertiesOnly = false);
+	void serialize(std::ostream &os, u16 protocol_ver, bool newPropertiesOnly = false,
+			bool skipAnimation = false) const;
+	void deSerialize(std::istream &is, u16 protocol_ver, bool newPropertiesOnly = false,
+			bool skipAnimation = false);
 };
 
 struct CommonParticleParams


### PR DESCRIPTION
This is the pure bugfix part of #14353 by @appgurueu.

## To do

This PR is a Ready for Review.

## How to test

```lua
minetest.register_on_joinplayer(function(player)
	minetest.after(1, function()
		local yawrot = vector.new(0, vector.dir_to_rotation(player:get_look_dir()).y, 0)
		minetest.add_particle({
			pos = player:get_pos() + vector.new(0, 1, 5):rotate(yawrot),
			velocity = vector.new(3, 0, 0):rotate(yawrot),
			expirationtime = 5,
			drag = vector.new(3, 3, 3),
			size = 20,
			animation = {
				type = "vertical_frames",
				aspect_w = 16,
				aspect_h = 16,
				length = 1
			},
			texture = { name = "fire_basic_flame_animated.png", scale = 0.5, alpha_tween = {1, 0}},
		})
	end)
end)
```

**Expected results**

5.8.0 server + 5.8.0 client: flame animated, but it's too big and doesn't fade out
5.8.0 server + PR client: flame animated, but it's too big and doesn't fade out

PR server + 5.8.0 client: flame animated, but it's too big and doesn't fade out
PR server + PR client: flame animated, smaller, fades out