### PR TITLE
Add missing documentation for 'name' key in decoration definition

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -10275,6 +10275,12 @@ See [Decoration types]. Used by `minetest.register_decoration`.
 
 ```lua
 {
+    name = "my_decoration",
+    -- Used by `minetest.get_decoration_id` to return the `deco_id`s to be
+    -- used as parameter to `minetest.set_gen_notify`.
+    -- If not specified, the value is set to the object handle returned by
+    -- `minetest.register_decoration`.
+
     deco_type = "simple",
     -- Type. "simple", "schematic" or "lsystem" supported
 


### PR DESCRIPTION
This PR makes no changes to running code, but adds missing documentation to lua_api.md.

This PR adds a description of the 'name' key in the decoration registration table definition.

The 'name' key in the decoration registration table is hardly documented, apart from a [side mention](https://github.com/minetest/minetest/blob/85878d894ae944e9044c7f29b5285d96b19f5a1f/doc/lua_api.md?plain=1#L7336) in the list of global tables. An explicit description in the proper place makes its use in `minetest.get_decoration_id` and subsequently the use of `minetest.set_gen_notify` a little more clear.
