### PR TITLE
Document alternative 'persist' key in noise parameter table

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4346,6 +4346,8 @@ the previous octave.
 This may need to be tuned when altering `lacunarity`; when doing so consider
 that a common medium value is 1 / lacunarity.
 
+Instead of `persistence`, the key `persist` may be used to the same effect.
+
 ### `lacunarity`
 
 Each additional octave has a 'wavelength' that is the 'wavelength' of the


### PR DESCRIPTION
This PR makes no changes to running code, but adds missing documentation to lua_api.md.

This PR adds a description of the 'persist' key in the noise parameters table definition.

Instead of the documented 'persistence' key, 'persist' can also be used to specify the same noise parameter, ref.: https://github.com/minetest/minetest/commit/3d4244cc75b7e75565476032851fbd30d5cd9306

Hat tip to @corarona for [pointing out](https://codeberg.org/mineclonia/mineclonia/pulls/1559#issuecomment-2032001) the equivalence.