### PR TITLE
Properly escape Markdown markups at minetest.string_to_area

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4008,8 +4008,8 @@ Helper functions
     * `relative_to`: Optional. If set to a position, each coordinate
       can use the tilde notation for relative positions
     * Tilde notation
-      * "\~": Relative coordinate
-      * "\~<number>": Relative coordinate plus \<number\>
+      * `"~"`: Relative coordinate
+      * `"~<number>"`: Relative coordinate plus \<number\>
     * Example: `minetest.string_to_area("(1,2,3) (~5,~-5,~)", {x=10,y=10,z=10})`
       returns `{x=1,y=2,z=3}, {x=15,y=5,z=10}`
 * `minetest.formspec_escape(string)`: returns a string

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4009,7 +4009,7 @@ Helper functions
       can use the tilde notation for relative positions
     * Tilde notation
       * `"~"`: Relative coordinate
-      * `"~<number>"`: Relative coordinate plus \<number\>
+      * `"~<number>"`: Relative coordinate plus `<number>`
     * Example: `minetest.string_to_area("(1,2,3) (~5,~-5,~)", {x=10,y=10,z=10})`
       returns `{x=1,y=2,z=3}, {x=15,y=5,z=10}`
 * `minetest.formspec_escape(string)`: returns a string

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4007,8 +4007,9 @@ Helper functions
     * X1, Y1, ... Z2 are coordinates
     * `relative_to`: Optional. If set to a position, each coordinate
       can use the tilde notation for relative positions
-    * Tilde notation: "~": Relative coordinate
-                      "~<number>": Relative coordinate plus <number>
+    * Tilde notation
+      * "\~": Relative coordinate
+      * "\~<number>": Relative coordinate plus \<number\>
     * Example: `minetest.string_to_area("(1,2,3) (~5,~-5,~)", {x=10,y=10,z=10})`
       returns `{x=1,y=2,z=3}, {x=15,y=5,z=10}`
 * `minetest.formspec_escape(string)`: returns a string


### PR DESCRIPTION
This PR adds necessary escapes to literals that were treated as Markdown markups and caused weird visual effects.

## To do

This PR is a Ready for Review.

## How to test

View it on my fork: https://github.com/Emojigit/minetest/blob/fork-20240624-relative-coord-doc-fix/doc/lua_api.md