### PR TITLE
Fix missing newline before Markdown list

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3902,6 +3902,7 @@ Operators
 ---------
 
 Operators can be used if all of the involved vectors have metatables:
+
 * `v1 == v2`:
     * Returns whether `v1` and `v2` are identical.
 * `-v`:


### PR DESCRIPTION
Renders incorrectly on https://api.minetest.net/spatial-vectors/#operators
