### PR TITLE
Add vector.random_direction()

### DIFF
--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -375,6 +375,24 @@ function vector.in_area(pos, min, max)
 		(pos.z >= min.z) and (pos.z <= max.z)
 end
 
+function vector.random_direction()
+	-- Generate a random direction of unit length, via rejection sampling
+	local x = math.random(-1,1)
+    local y = math.random(-1,1)
+	local z = math.random(-1,1)
+    local l2 = x*x + y*y + z*z -- squared length
+	-- expected less than two attempts on average
+    while (l2 > 1 or l2 == 0) do -- rejected, retry
+		x = math.random(-1,1)
+        y = math.random(-1,1)
+        z = math.random(-1,1)
+        l2 = x*x + y*y + z*z
+    end
+	-- normalize
+	local l = math.sqrt(l2)
+	return fast_new(x/l, y/l, z/l)
+end
+
 if rawget(_G, "core") and core.set_read_vector and core.set_push_vector then
 	local function read_vector(v)
 		return v.x, v.y, v.z

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -377,17 +377,11 @@ end
 
 function vector.random_direction()
 	-- Generate a random direction of unit length, via rejection sampling
-	local x = math.random(-1,1)
-    local y = math.random(-1,1)
-	local z = math.random(-1,1)
-    local l2 = x*x + y*y + z*z -- squared length
-	-- expected less than two attempts on average
-    while (l2 > 1 or l2 == 0) do -- rejected, retry
-		x = math.random(-1,1)
-        y = math.random(-1,1)
-        z = math.random(-1,1)
+	local x, y, z, l2
+	repeat -- expected less than two attempts on average (volume sphere vs. cube)
+		x, y, z = math.random() * 2 - 1, math.random() * 2 - 1, math.random() * 2 - 1
         l2 = x*x + y*y + z*z
-    end
+	until l2 <= 1 and l2 >= 1e-6
 	-- normalize
 	local l = math.sqrt(l2)
 	return fast_new(x/l, y/l, z/l)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3825,6 +3825,8 @@ vectors are written like this: `(x, y, z)`:
       `vector.new(v)` does the same as `vector.copy(v)`
 * `vector.zero()`:
     * Returns a new vector `(0, 0, 0)`.
+* `vector.random_direction()`:
+    * Returns a new vector of length 1, pointing into a direction chosen uniformly at random.
 * `vector.copy(v)`:
     * Returns a copy of the vector `v`.
 * `vector.from_string(s[, init])`:


### PR DESCRIPTION
Generate a random vector of unit length.
Useful for many mods.

Note: uniform on the sphere. Rejection sampling is very efficient, as it does not involve trigonometric operations.

It is also easy to get this wrong, for example by picking angles uniformly.
C.f., https://mathworld.wolfram.com/SpherePointPicking.html