### PR TITLE
Try to fix autojump behavior, just code review first

### DIFF
--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Minetest
 Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
 
@@ -1223,6 +1223,28 @@ void LocalPlayer::handleAutojump(f32 dtime, Environment *env,
 	// must be running against something to trigger autojumping
 	if (!horizontal_collision)
 		return;
+
+	bool vertical_collision = false; // change after implement
+	//todo: must be only one block ahead to trigger autojumping, in other words there must not be a vertical collision
+	v3f jump_dir = initial_speed; // jump direction means the mostly right horizontal direction and also 1 block above player position
+	if (jump_dir.X>jump_dir.Z){
+		jump_dir.Z=0;
+		jump_dir.X=jump_dir.Y=1;
+	}
+	else{
+		jump_dir.X=0;
+		jump_dir.Z=jump_dir.Y=1;
+	}
+	//only need 1 block ahead of the mostly right horizontal direction and 1 block above player position
+	v3s16 block_ahead_position = floatToInt(m_position, BS) + floatToInt(jump_dir, BS);
+	MapNode block_ahead = env->getMap().getNode(block_ahead_position);
+	const NodeDefManager *ndef_temp = env->getGameDef()->ndef();
+	const ContentFeatures &f_temp = ndef_temp->get(block_ahead);
+	if (f_temp.walkable)
+		vertical_collision = true;
+	if (vertical_collision)
+		return;
+
 
 	// check for nodes above
 	v3f headpos_min = m_position + m_collisionbox.MinEdge * 0.99f;


### PR DESCRIPTION
- Goal of the PR
- solve https://github.com/minetest/minetest/issues/14612
- How does the PR work?
- it detects whether the block of player moving direction is a wall (meaning there's at least 2 blocks in the main moving dir) which blocks autojump and makes it lose its sense, if so stop auto jump
- Does it resolve any reported issue?
- https://github.com/minetest/minetest/issues/14612
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
- IMHO yes

## To do

As a freshman here I actually don't know much about engine struct itself, even if I checked the src carefully for tool functions I may use, there can still be some better options.
And I just roughly wrote these code too, so I wanna ask pro devs who have been in this project for a while for code improvement help.
After that I'll go compile and test, see if this change works.

This PR is a Work in Progress.

## How to test

view the changed src
