### PR TITLE
Use a new two-color vertex type for mapblock meshes

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -38,6 +38,7 @@ varying vec3 vPosition;
 // precision must be considered).
 varying vec3 worldPosition;
 varying lowp vec4 varColor;
+varying lowp vec3 hwColor;
 #ifdef GL_ES
 varying mediump vec2 varTexCoord;
 #else
@@ -375,7 +376,7 @@ void main(void)
 #endif
 
 	color = base.rgb;
-	vec4 col = vec4(color.rgb * varColor.rgb, 1.0);
+	vec4 col = vec4(color.rgb * varColor.rgb * hwColor.rgb, 1.0);
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	if (f_shadow_strength > 0.0) {

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -15,6 +15,7 @@ varying vec3 vPosition;
 // precision must be considered).
 varying vec3 worldPosition;
 varying lowp vec4 varColor;
+varying lowp vec3 hwColor;
 // The centroid keyword ensures that after interpolation the texture coordinates
 // lie within the same bounds when MSAA is en- and disabled.
 // This fixes the stripes problem with nearest-neighbor textures and MSAA.
@@ -222,6 +223,7 @@ void main(void)
 
 	varColor = clamp(color, 0.0, 1.0);
 
+	hwColor = inVertexColor2.rgb;
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	if (f_shadow_strength > 0.0) {
 #if MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS

--- a/irr/include/CMeshBuffer.h
+++ b/irr/include/CMeshBuffer.h
@@ -270,5 +270,7 @@ typedef CMeshBuffer<video::S3DVertex> SMeshBuffer;
 typedef CMeshBuffer<video::S3DVertex2TCoords> SMeshBufferLightMap;
 //! Meshbuffer with vertices having tangents stored, e.g. for normal mapping
 typedef CMeshBuffer<video::S3DVertexTangents> SMeshBufferTangents;
+//! Meshbuffer with two colors per vertex
+typedef CMeshBuffer<video::S3DVertex2Colors> SMeshBuffer2Colors;
 } // end namespace scene
 } // end namespace irr

--- a/irr/include/EMaterialTypes.h
+++ b/irr/include/EMaterialTypes.h
@@ -53,6 +53,10 @@ enum E_MATERIAL_TYPE
 	pack_textureBlendFunc (for 2D) or pack_textureBlendFuncSeparate (for 3D). */
 	EMT_ONETEXTURE_BLEND,
 
+	EMT_SOLID_2COLORS,
+	EMT_TRANSPARENT_ALPHA_CHANNEL_2COLORS,
+	EMT_TRANSPARENT_ALPHA_CHANNEL_REF_2COLORS,
+
 	//! This value is not used. It only forces this enumeration to compile to 32 bit.
 	EMT_FORCE_32BIT = 0x7fffffff
 };

--- a/irr/include/EVertexAttributes.h
+++ b/irr/include/EVertexAttributes.h
@@ -15,6 +15,7 @@ enum E_VERTEX_ATTRIBUTES
 	EVA_TCOORD1,
 	EVA_TANGENT,
 	EVA_BINORMAL,
+	EVA_COLOR2,
 	EVA_COUNT
 };
 
@@ -27,6 +28,7 @@ const char *const sBuiltInVertexAttributeNames[] = {
 		"inTexCoord1",
 		"inVertexTangent",
 		"inVertexBinormal",
+		"inVertexColor2",
 		0,
 	};
 

--- a/irr/include/IMeshBuffer.h
+++ b/irr/include/IMeshBuffer.h
@@ -191,6 +191,9 @@ public:
 			case video::EVT_TANGENTS:
 				ret += sizeof(video::S3DVertexTangents) * getVertexCount();
 				break;
+			case video::EVT_2COLORS:
+				ret += sizeof(video::S3DVertex2Colors) * getVertexCount();
+				break;
 		}
 		switch (getIndexType()) {
 			case video::EIT_16BIT:

--- a/irr/include/IMeshManipulator.h
+++ b/irr/include/IMeshManipulator.h
@@ -152,6 +152,10 @@ protected:
 				video::S3DVertexTangents *verts = (video::S3DVertexTangents *)buffer->getVertices();
 				func(verts[i]);
 			} break;
+			case video::EVT_2COLORS: {
+				video::S3DVertex2Colors *verts = (video::S3DVertex2Colors *)buffer->getVertices();
+				func(verts[i]);
+			} break;
 			}
 			if (boundingBoxUpdate) {
 				if (0 == i)

--- a/irr/include/IVideoDriver.h
+++ b/irr/include/IVideoDriver.h
@@ -39,6 +39,7 @@ namespace video
 struct S3DVertex;
 struct S3DVertex2TCoords;
 struct S3DVertexTangents;
+struct S3DVertex2Colors;
 class IImageLoader;
 class IImageWriter;
 class IMaterialRenderer;
@@ -605,6 +606,12 @@ public:
 		drawVertexPrimitiveList(vertices, vertexCount, indexList, triangleCount, EVT_TANGENTS, scene::EPT_TRIANGLES, EIT_16BIT);
 	}
 
+	void drawIndexedTriangleList(const S3DVertex2Colors *vertices,
+			u32 vertexCount, const u16 *indexList, u32 triangleCount)
+	{
+		drawVertexPrimitiveList(vertices, vertexCount, indexList, triangleCount, EVT_2COLORS, scene::EPT_TRIANGLES, EIT_16BIT);
+	}
+
 	//! Draws an indexed triangle fan.
 	/** Note that there may be at maximum 65536 vertices, because
 	the index list is an array of 16 bit values each with a maximum
@@ -648,6 +655,12 @@ public:
 			u32 vertexCount, const u16 *indexList, u32 triangleCount)
 	{
 		drawVertexPrimitiveList(vertices, vertexCount, indexList, triangleCount, EVT_TANGENTS, scene::EPT_TRIANGLE_FAN, EIT_16BIT);
+	}
+
+	void drawIndexedTriangleFan(const S3DVertex2Colors *vertices,
+			u32 vertexCount, const u16 *indexList, u32 triangleCount)
+	{
+		drawVertexPrimitiveList(vertices, vertexCount, indexList, triangleCount, EVT_2COLORS, scene::EPT_TRIANGLE_FAN, EIT_16BIT);
 	}
 
 	//! Draws a 3d line.

--- a/irr/include/S3DVertex.h
+++ b/irr/include/S3DVertex.h
@@ -27,7 +27,13 @@ enum E_VERTEX_TYPE
 	/** Usually used for tangent space normal mapping.
 		Usually tangent and binormal get send to shaders as texture coordinate sets 1 and 2.
 	*/
-	EVT_TANGENTS
+	EVT_TANGENTS,
+
+	//! Vertex with two colors, video::S3DVertex2Colors.
+	/** Used only for the MapblockMeshes buffers in order to separate
+		the light color from the hardware one.
+	*/
+	EVT_2COLORS
 };
 
 //! Array holding the built in vertex type names
@@ -35,6 +41,7 @@ const char *const sBuiltInVertexTypeNames[] = {
 		"standard",
 		"2tcoords",
 		"tangents",
+		"2colors",
 		0,
 	};
 
@@ -272,6 +279,59 @@ struct S3DVertexTangents : public S3DVertex
 	}
 };
 
+//! Vertex with two colors, video::S3DVertex2Colors.
+/** Used only for the MapblockMeshes buffers in order to separate
+	the light color from the hardware one.
+*/
+struct S3DVertex2Colors : public S3DVertex
+{
+	//! default constructor
+	S3DVertex2Colors() :
+			S3DVertex() {}
+
+	//! constructor
+	constexpr S3DVertex2Colors(f32 x, f32 y, f32 z, f32 nx = 0.0f, f32 ny = 0.0f, f32 nz = 0.0f,
+			SColor c = 0xFFFFFFFF, f32 tu = 0.0f, f32 tv = 0.0f, f32 c2r = 1.0f, f32 c2g = 1.0f, f32 c2b = 1.0f) :
+			S3DVertex(x, y, z, nx, ny, nz, c, tu, tv),
+			Color2(c2r, c2g, c2b) {}
+
+	//! constructor
+	constexpr S3DVertex2Colors(const core::vector3df &pos,
+			const core::vector3df &normal, SColor c,
+			const core::vector2df &tcoords, const core::vector3df &c2 = core::vector3df(1.0f)) :
+			S3DVertex(pos, normal, c, tcoords), Color2(c2) {}
+
+	//! constructor from S3DVertex
+	constexpr S3DVertex2Colors(const S3DVertex &o) :
+			S3DVertex(o) {}
+
+	//! Second (normalized) RGB color for the hardware ones
+	core::vector3df Color2;
+
+	constexpr bool operator==(const S3DVertex2Colors &other) const
+	{
+		return ((static_cast<S3DVertex>(*this) == static_cast<const S3DVertex &>(other)) &&
+				(Color2 == other.Color2));
+	}
+
+	constexpr bool operator!=(const S3DVertex2Colors &other) const
+	{
+		return ((static_cast<S3DVertex>(*this) != static_cast<const S3DVertex &>(other)) ||
+				(Color2 != other.Color2));
+	}
+
+	constexpr bool operator<(const S3DVertex2Colors &other) const
+	{
+		return ((static_cast<S3DVertex>(*this) < other) ||
+				((static_cast<S3DVertex>(*this) == static_cast<const S3DVertex &>(other)) && (Color2 < other.Color2)));
+	}
+
+	static E_VERTEX_TYPE getType()
+	{
+		return EVT_2COLORS;
+	}
+};
+
 inline u32 getVertexPitchFromType(E_VERTEX_TYPE vertexType)
 {
 	switch (vertexType) {
@@ -279,6 +339,8 @@ inline u32 getVertexPitchFromType(E_VERTEX_TYPE vertexType)
 		return sizeof(video::S3DVertex2TCoords);
 	case video::EVT_TANGENTS:
 		return sizeof(video::S3DVertexTangents);
+	case video::EVT_2COLORS:
+		return sizeof(video::S3DVertex2Colors);
 	default:
 		return sizeof(video::S3DVertex);
 	}

--- a/irr/include/SSkinMeshBuffer.h
+++ b/irr/include/SSkinMeshBuffer.h
@@ -48,6 +48,8 @@ struct SSkinMeshBuffer : public IMeshBuffer
 			return (video::S3DVertex *)&Vertices_2TCoords[index];
 		case video::EVT_TANGENTS:
 			return (video::S3DVertex *)&Vertices_Tangents[index];
+		case video::EVT_2COLORS:
+			return (video::S3DVertex *)&Vertices_2Colors[index];
 		default:
 			return &Vertices_Standard[index];
 		}
@@ -61,6 +63,8 @@ struct SSkinMeshBuffer : public IMeshBuffer
 			return Vertices_2TCoords.const_pointer();
 		case video::EVT_TANGENTS:
 			return Vertices_Tangents.const_pointer();
+		case video::EVT_2COLORS:
+			return Vertices_2Colors.const_pointer();
 		default:
 			return Vertices_Standard.const_pointer();
 		}
@@ -74,6 +78,8 @@ struct SSkinMeshBuffer : public IMeshBuffer
 			return Vertices_2TCoords.pointer();
 		case video::EVT_TANGENTS:
 			return Vertices_Tangents.pointer();
+		case video::EVT_2COLORS:
+			return Vertices_2Colors.pointer();
 		default:
 			return Vertices_Standard.pointer();
 		}
@@ -87,6 +93,8 @@ struct SSkinMeshBuffer : public IMeshBuffer
 			return Vertices_2TCoords.size();
 		case video::EVT_TANGENTS:
 			return Vertices_Tangents.size();
+		case video::EVT_2COLORS:
+			return Vertices_2Colors.size();
 		default:
 			return Vertices_Standard.size();
 		}
@@ -168,6 +176,16 @@ struct SSkinMeshBuffer : public IMeshBuffer
 			}
 			break;
 		}
+		case video::EVT_2COLORS: {
+			if (Vertices_2Colors.empty())
+				BoundingBox.reset(0, 0, 0);
+			else {
+				BoundingBox.reset(Vertices_2Colors[0].Pos);
+				for (u32 i = 1; i < Vertices_2Colors.size(); ++i)
+					BoundingBox.addInternalPoint(Vertices_2Colors[i].Pos);
+			}
+			break;
+		}
 		}
 	}
 
@@ -222,6 +240,45 @@ struct SSkinMeshBuffer : public IMeshBuffer
 		}
 	}
 
+	//! Convert to 2colors vertex type
+	void convertTo2Colors()
+	{
+		if (VertexType == video::EVT_STANDARD) {
+			for (u32 n = 0; n < Vertices_Standard.size(); ++n) {
+				video::S3DVertex2Colors Vertex;
+				Vertex.Color = Vertices_Standard[n].Color;
+				Vertex.Pos = Vertices_Standard[n].Pos;
+				Vertex.Normal = Vertices_Standard[n].Normal;
+				Vertex.TCoords = Vertices_Standard[n].TCoords;
+				Vertices_2Colors.push_back(Vertex);
+			}
+			Vertices_Standard.clear();
+			VertexType = video::EVT_2COLORS;
+		} else if (VertexType == video::EVT_2TCOORDS) {
+			for (u32 n = 0; n < Vertices_2TCoords.size(); ++n) {
+				video::S3DVertex2Colors Vertex;
+				Vertex.Color = Vertices_2TCoords[n].Color;
+				Vertex.Pos = Vertices_2TCoords[n].Pos;
+				Vertex.Normal = Vertices_2TCoords[n].Normal;
+				Vertex.TCoords = Vertices_2TCoords[n].TCoords;
+				Vertices_2Colors.push_back(Vertex);
+			}
+			Vertices_2TCoords.clear();
+			VertexType = video::EVT_2COLORS;
+		} else if (VertexType == video::EVT_TANGENTS) {
+			for (u32 n = 0; n < Vertices_Tangents.size(); ++n) {
+				video::S3DVertex2Colors Vertex;
+				Vertex.Color = Vertices_Tangents[n].Color;
+				Vertex.Pos = Vertices_Tangents[n].Pos;
+				Vertex.Normal = Vertices_Tangents[n].Normal;
+				Vertex.TCoords = Vertices_Tangents[n].TCoords;
+				Vertices_2Colors.push_back(Vertex);
+			}
+			Vertices_Tangents.clear();
+			VertexType = video::EVT_2COLORS;
+		}
+	}
+
 	//! returns position of vertex i
 	const core::vector3df &getPosition(u32 i) const override
 	{
@@ -230,6 +287,8 @@ struct SSkinMeshBuffer : public IMeshBuffer
 			return Vertices_2TCoords[i].Pos;
 		case video::EVT_TANGENTS:
 			return Vertices_Tangents[i].Pos;
+		case video::EVT_2COLORS:
+			return Vertices_2Colors[i].Pos;
 		default:
 			return Vertices_Standard[i].Pos;
 		}
@@ -243,6 +302,8 @@ struct SSkinMeshBuffer : public IMeshBuffer
 			return Vertices_2TCoords[i].Pos;
 		case video::EVT_TANGENTS:
 			return Vertices_Tangents[i].Pos;
+		case video::EVT_2COLORS:
+			return Vertices_2Colors[i].Pos;
 		default:
 			return Vertices_Standard[i].Pos;
 		}
@@ -256,6 +317,8 @@ struct SSkinMeshBuffer : public IMeshBuffer
 			return Vertices_2TCoords[i].Normal;
 		case video::EVT_TANGENTS:
 			return Vertices_Tangents[i].Normal;
+		case video::EVT_2COLORS:
+			return Vertices_2Colors[i].Normal;
 		default:
 			return Vertices_Standard[i].Normal;
 		}
@@ -269,6 +332,8 @@ struct SSkinMeshBuffer : public IMeshBuffer
 			return Vertices_2TCoords[i].Normal;
 		case video::EVT_TANGENTS:
 			return Vertices_Tangents[i].Normal;
+		case video::EVT_2COLORS:
+			return Vertices_2Colors[i].Normal;
 		default:
 			return Vertices_Standard[i].Normal;
 		}
@@ -282,6 +347,8 @@ struct SSkinMeshBuffer : public IMeshBuffer
 			return Vertices_2TCoords[i].TCoords;
 		case video::EVT_TANGENTS:
 			return Vertices_Tangents[i].TCoords;
+		case video::EVT_2COLORS:
+			return Vertices_2Colors[i].TCoords;
 		default:
 			return Vertices_Standard[i].TCoords;
 		}
@@ -295,6 +362,8 @@ struct SSkinMeshBuffer : public IMeshBuffer
 			return Vertices_2TCoords[i].TCoords;
 		case video::EVT_TANGENTS:
 			return Vertices_Tangents[i].TCoords;
+		case video::EVT_2COLORS:
+			return Vertices_2Colors[i].TCoords;
 		default:
 			return Vertices_Standard[i].TCoords;
 		}
@@ -366,6 +435,7 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	//! Call this after changing the positions of any vertex.
 	void boundingBoxNeedsRecalculated(void) { BoundingBoxNeedsRecalculated = true; }
 
+	core::array<video::S3DVertex2Colors> Vertices_2Colors;
 	core::array<video::S3DVertexTangents> Vertices_Tangents;
 	core::array<video::S3DVertex2TCoords> Vertices_2TCoords;
 	core::array<video::S3DVertex> Vertices_Standard;

--- a/irr/src/CMakeLists.txt
+++ b/irr/src/CMakeLists.txt
@@ -356,6 +356,7 @@ if(ENABLE_OPENGL)
 		COpenGLCacheHandler.cpp
 		COpenGLDriver.cpp
 		COpenGLSLMaterialRenderer.cpp
+		COpenGLCommonCallbacks.cpp
 		COpenGLExtensionHandler.cpp
 	)
 endif()
@@ -375,7 +376,7 @@ if(ENABLE_OPENGL3 OR ENABLE_GLES2)
 		${IRRDRVROBJ}
 		OpenGL/Driver.cpp
 		OpenGL/ExtensionHandler.cpp
-		OpenGL/FixedPipelineRenderer.cpp
+		COpenGLCommonCallbacks.cpp
 		OpenGL/MaterialRenderer.cpp
 		OpenGL/Renderer2D.cpp
 	)

--- a/irr/src/COGLESDriver.cpp
+++ b/irr/src/COGLESDriver.cpp
@@ -252,6 +252,13 @@ bool COGLES1Driver::updateVertexHardwareBuffer(SHWBufferLink_opengl *HWBuffer)
 			po[i].Color.toOpenGLColor((u8 *)&(pb[i].Color.color));
 		}
 	} break;
+	case EVT_2COLORS: {
+		S3DVertex2Colors *pb = reinterpret_cast<S3DVertex2Colors *>(buffer.pointer());
+		const S3DVertex2Colors *po = static_cast<const S3DVertex2Colors *>(vertices);
+		for (u32 i = 0; i < vertexCount; i++) {
+			po[i].Color.toOpenGLColor((u8 *)&(pb[i].Color.color));
+		}
+	} break;
 	default: {
 		return false;
 	}
@@ -519,6 +526,14 @@ void COGLES1Driver::drawVertexPrimitiveList2d3d(const void *vertices, u32 vertex
 				++p;
 			}
 		} break;
+		case EVT_2COLORS: {
+			Color2Buffer.set_used(vertexCount);
+			const S3DVertex2Colors *p = static_cast<const S3DVertex2Colors *>(vertices);
+			for (i = 0; i < vertexCount; i += 4) {
+				p->Color.toOpenGLColor(&ColorBuffer[i]);
+				++p;
+			}
+		} break;
 		}
 	}
 
@@ -610,6 +625,28 @@ void COGLES1Driver::drawVertexPrimitiveList2d3d(const void *vertices, u32 vertex
 				glTexCoordPointer(3, GL_FLOAT, sizeof(S3DVertexTangents), &(static_cast<const S3DVertexTangents *>(vertices))[0].Binormal);
 			else
 				glTexCoordPointer(3, GL_FLOAT, sizeof(S3DVertexTangents), buffer_offset(48));
+		}
+		break;
+	case EVT_2COLORS:
+		if (vertices) {
+			if (threed)
+				glNormalPointer(GL_FLOAT, sizeof(S3DVertex2Colors), &(static_cast<const S3DVertex2Colors *>(vertices))[0].Normal);
+			glTexCoordPointer(2, GL_FLOAT, sizeof(S3DVertex2Colors), &(static_cast<const S3DVertex2Colors *>(vertices))[0].TCoords);
+			glVertexPointer((threed ? 3 : 2), GL_FLOAT, sizeof(S3DVertex2Colors), &(static_cast<const S3DVertex2Colors *>(vertices))[0].Pos);
+		} else {
+			glNormalPointer(GL_FLOAT, sizeof(S3DVertex2Colors), buffer_offset(12));
+			glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(S3DVertex2Colors), buffer_offset(24));
+			glTexCoordPointer(2, GL_FLOAT, sizeof(S3DVertex2Colors), buffer_offset(28));
+			glVertexPointer(3, GL_FLOAT, sizeof(S3DVertex2Colors), buffer_offset(0));
+		}
+
+		if (Feature.MaxTextureUnits > 0) {
+			glClientActiveTexture(GL_TEXTURE0 + 1);
+			glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+			if (vertices)
+				glTexCoordPointer(3, GL_FLOAT, sizeof(S3DVertex2Colors), &(static_cast<const S3DVertexTangents *>(vertices))[0].Color2);
+			else
+				glTexCoordPointer(3, GL_FLOAT, sizeof(S3DVertex2Colors), buffer_offset(36));
 		}
 		break;
 	}

--- a/irr/src/COpenGLCommonCallbacks.cpp
+++ b/irr/src/COpenGLCommonCallbacks.cpp
@@ -3,7 +3,7 @@
 // This file is part of the "Irrlicht Engine".
 // For conditions of distribution and use, see copyright notice in Irrlicht.h
 
-#include "FixedPipelineRenderer.h"
+#include "COpenGLCommonCallbacks.h"
 
 #include "IVideoDriver.h"
 
@@ -14,7 +14,7 @@ namespace video
 
 // Base callback
 
-COpenGL3MaterialBaseCB::COpenGL3MaterialBaseCB() :
+COpenGLMaterialBaseCB::COpenGLMaterialBaseCB() :
 		FirstUpdateBase(true), WVPMatrixID(-1), WVMatrixID(-1), NMatrixID(-1),
 		FogEnableID(-1), FogTypeID(-1), FogColorID(-1), FogStartID(-1),
 		FogEndID(-1), FogDensityID(-1), ThicknessID(-1), LightEnable(false), MaterialAmbient(SColorf(0.f, 0.f, 0.f)), MaterialDiffuse(SColorf(0.f, 0.f, 0.f)), MaterialEmissive(SColorf(0.f, 0.f, 0.f)), MaterialSpecular(SColorf(0.f, 0.f, 0.f)),
@@ -22,7 +22,7 @@ COpenGL3MaterialBaseCB::COpenGL3MaterialBaseCB() :
 {
 }
 
-void COpenGL3MaterialBaseCB::OnSetMaterial(const SMaterial &material)
+void COpenGLMaterialBaseCB::OnSetMaterial(const SMaterial &material)
 {
 	LightEnable = material.Lighting;
 	MaterialAmbient = SColorf(material.AmbientColor);
@@ -36,7 +36,7 @@ void COpenGL3MaterialBaseCB::OnSetMaterial(const SMaterial &material)
 	Thickness = (material.Thickness > 0.f) ? material.Thickness : 1.f;
 }
 
-void COpenGL3MaterialBaseCB::OnSetConstants(IMaterialRendererServices *services, s32 userData)
+void COpenGLMaterialBaseCB::OnSetConstants(IMaterialRendererServices *services, s32 userData)
 {
 	IVideoDriver *driver = services->getVideoDriver();
 
@@ -94,22 +94,22 @@ void COpenGL3MaterialBaseCB::OnSetConstants(IMaterialRendererServices *services,
 
 // EMT_SOLID + EMT_TRANSPARENT_ALPHA_CHANNEL + EMT_TRANSPARENT_VERTEX_ALPHA
 
-COpenGL3MaterialSolidCB::COpenGL3MaterialSolidCB() :
+COpenGLMaterialSolidCB::COpenGLMaterialSolidCB() :
 		FirstUpdate(true), TMatrix0ID(-1), AlphaRefID(-1), TextureUsage0ID(-1), TextureUnit0ID(-1), AlphaRef(0.5f), TextureUsage0(0), TextureUnit0(0)
 {
 }
 
-void COpenGL3MaterialSolidCB::OnSetMaterial(const SMaterial &material)
+void COpenGLMaterialSolidCB::OnSetMaterial(const SMaterial &material)
 {
-	COpenGL3MaterialBaseCB::OnSetMaterial(material);
+	COpenGLMaterialBaseCB::OnSetMaterial(material);
 
 	AlphaRef = material.MaterialTypeParam;
 	TextureUsage0 = (material.TextureLayers[0].Texture) ? 1 : 0;
 }
 
-void COpenGL3MaterialSolidCB::OnSetConstants(IMaterialRendererServices *services, s32 userData)
+void COpenGLMaterialSolidCB::OnSetConstants(IMaterialRendererServices *services, s32 userData)
 {
-	COpenGL3MaterialBaseCB::OnSetConstants(services, userData);
+	COpenGLMaterialBaseCB::OnSetConstants(services, userData);
 
 	IVideoDriver *driver = services->getVideoDriver();
 
@@ -132,14 +132,14 @@ void COpenGL3MaterialSolidCB::OnSetConstants(IMaterialRendererServices *services
 
 // EMT_ONETEXTURE_BLEND
 
-COpenGL3MaterialOneTextureBlendCB::COpenGL3MaterialOneTextureBlendCB() :
+COpenGLMaterialOneTextureBlendCB::COpenGLMaterialOneTextureBlendCB() :
 		FirstUpdate(true), TMatrix0ID(-1), BlendTypeID(-1), TextureUsage0ID(-1), TextureUnit0ID(-1), BlendType(0), TextureUsage0(0), TextureUnit0(0)
 {
 }
 
-void COpenGL3MaterialOneTextureBlendCB::OnSetMaterial(const SMaterial &material)
+void COpenGLMaterialOneTextureBlendCB::OnSetMaterial(const SMaterial &material)
 {
-	COpenGL3MaterialBaseCB::OnSetMaterial(material);
+	COpenGLMaterialBaseCB::OnSetMaterial(material);
 
 	BlendType = 0;
 
@@ -159,9 +159,9 @@ void COpenGL3MaterialOneTextureBlendCB::OnSetMaterial(const SMaterial &material)
 	TextureUsage0 = (material.TextureLayers[0].Texture) ? 1 : 0;
 }
 
-void COpenGL3MaterialOneTextureBlendCB::OnSetConstants(IMaterialRendererServices *services, s32 userData)
+void COpenGLMaterialOneTextureBlendCB::OnSetConstants(IMaterialRendererServices *services, s32 userData)
 {
-	COpenGL3MaterialBaseCB::OnSetConstants(services, userData);
+	COpenGLMaterialBaseCB::OnSetConstants(services, userData);
 
 	IVideoDriver *driver = services->getVideoDriver();
 

--- a/irr/src/COpenGLCommonCallbacks.h
+++ b/irr/src/COpenGLCommonCallbacks.h
@@ -13,10 +13,10 @@ namespace irr
 namespace video
 {
 
-class COpenGL3MaterialBaseCB : public IShaderConstantSetCallBack
+class COpenGLMaterialBaseCB : public IShaderConstantSetCallBack
 {
 public:
-	COpenGL3MaterialBaseCB();
+	COpenGLMaterialBaseCB();
 
 	virtual void OnSetMaterial(const SMaterial &material);
 	virtual void OnSetConstants(IMaterialRendererServices *services, s32 userData);
@@ -55,10 +55,10 @@ protected:
 	f32 Thickness;
 };
 
-class COpenGL3MaterialSolidCB : public COpenGL3MaterialBaseCB
+class COpenGLMaterialSolidCB : public COpenGLMaterialBaseCB
 {
 public:
-	COpenGL3MaterialSolidCB();
+	COpenGLMaterialSolidCB();
 
 	virtual void OnSetMaterial(const SMaterial &material);
 	virtual void OnSetConstants(IMaterialRendererServices *services, s32 userData);
@@ -76,10 +76,10 @@ protected:
 	s32 TextureUnit0;
 };
 
-class COpenGL3MaterialOneTextureBlendCB : public COpenGL3MaterialBaseCB
+class COpenGLMaterialOneTextureBlendCB : public COpenGLMaterialBaseCB
 {
 public:
-	COpenGL3MaterialOneTextureBlendCB();
+	COpenGLMaterialOneTextureBlendCB();
 
 	virtual void OnSetMaterial(const SMaterial &material);
 	virtual void OnSetConstants(IMaterialRendererServices *services, s32 userData);

--- a/irr/src/COpenGLSLMaterialRenderer.cpp
+++ b/irr/src/COpenGLSLMaterialRenderer.cpp
@@ -57,12 +57,14 @@ COpenGLSLMaterialRenderer::COpenGLSLMaterialRenderer(video::COpenGLDriver *drive
 	switch (baseMaterial) {
 	case EMT_TRANSPARENT_VERTEX_ALPHA:
 	case EMT_TRANSPARENT_ALPHA_CHANNEL:
+	case EMT_TRANSPARENT_ALPHA_CHANNEL_2COLORS:
 		Alpha = true;
 		break;
 	case EMT_ONETEXTURE_BLEND:
 		Blending = true;
 		break;
 	case EMT_TRANSPARENT_ALPHA_CHANNEL_REF:
+	case EMT_TRANSPARENT_ALPHA_CHANNEL_REF_2COLORS:
 		AlphaTest = true;
 		break;
 	default:

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -14,7 +14,7 @@
 #include "COpenGLCoreCacheHandler.h"
 
 #include "MaterialRenderer.h"
-#include "FixedPipelineRenderer.h"
+#include "COpenGLCommonCallbacks.h"
 #include "Renderer2D.h"
 
 #include "EVertexAttributes.h"
@@ -391,41 +391,246 @@ void COpenGL3DriverBase::createMaterialRenderers()
 {
 	// Create callbacks.
 
-	COpenGL3MaterialSolidCB *SolidCB = new COpenGL3MaterialSolidCB();
-	COpenGL3MaterialSolidCB *TransparentAlphaChannelCB = new COpenGL3MaterialSolidCB();
-	COpenGL3MaterialSolidCB *TransparentAlphaChannelRefCB = new COpenGL3MaterialSolidCB();
-	COpenGL3MaterialSolidCB *TransparentVertexAlphaCB = new COpenGL3MaterialSolidCB();
-	COpenGL3MaterialOneTextureBlendCB *OneTextureBlendCB = new COpenGL3MaterialOneTextureBlendCB();
+	COpenGLMaterialSolidCB *SolidCB = new COpenGLMaterialSolidCB();
+	COpenGLMaterialSolidCB *TransparentAlphaChannelCB = new COpenGLMaterialSolidCB();
+	COpenGLMaterialSolidCB *TransparentAlphaChannelRefCB = new COpenGLMaterialSolidCB();
+	COpenGLMaterialSolidCB *TransparentVertexAlphaCB = new COpenGLMaterialSolidCB();
+	COpenGLMaterialOneTextureBlendCB *OneTextureBlendCB = new COpenGLMaterialOneTextureBlendCB();
 
 	// Create built-in materials.
 	// The addition order must be the same as in the E_MATERIAL_TYPE enumeration. Thus the
 
-	const core::stringc VertexShader = OGLES2ShaderPath + "Solid.vsh";
+	std::string shaders_header = "#version 100\n";
+
+	std::string vs_attributes = R"(
+		/* Attributes */
+		attribute vec3 inVertexPosition;
+		attribute vec3 inVertexNormal;
+		attribute vec4 inVertexColor;
+		attribute vec2 inTexCoord0;
+	)";
+
+	std::string vs_uniforms = R"(
+		/* Uniforms */
+
+		uniform mat4 uWVPMatrix;
+		uniform mat4 uWVMatrix;
+		uniform mat4 uTMatrix0;
+
+		uniform float uThickness;
+	)";
+
+	std::string varyings = R"(
+		/* Varyings */
+
+		varying vec2 vTextureCoord0;
+		varying vec4 vVertexColor;
+		varying float vFogCoord;
+	)";
+
+	std::string fs_uniforms = R"(
+		/* Uniforms */
+
+		uniform int uTextureUsage0;
+		uniform sampler2D uTextureUnit0;
+		uniform int uFogEnable;
+		uniform int uFogType;
+		uniform vec4 uFogColor;
+		uniform float uFogStart;
+		uniform float uFogEnd;
+		uniform float uFogDensity;
+	)";
+
+	std::string vs_main1 = R"(
+		void main()
+		{
+			gl_Position = uWVPMatrix * vec4(inVertexPosition, 1.0);
+			gl_PointSize = uThickness;
+
+			vec4 TextureCoord0 = vec4(inTexCoord0.x, inTexCoord0.y, 1.0, 1.0);
+			vTextureCoord0 = vec4(uTMatrix0 * TextureCoord0).xy;
+
+			vVertexColor = inVertexColor.bgra;
+	)";
+
+	std::string vs_main2 = R"(
+			vec3 Position = (uWVMatrix * vec4(inVertexPosition, 1.0)).xyz;
+
+			vFogCoord = length(Position);
+		}
+	)";
+
+	std::string fog = R"(
+		float computeFog()
+		{
+			const float LOG2 = 1.442695;
+			float FogFactor = 0.0;
+
+			if (uFogType == 0) // Exp
+			{
+				FogFactor = exp2(-uFogDensity * vFogCoord * LOG2);
+			}
+			else if (uFogType == 1) // Linear
+			{
+				float Scale = 1.0 / (uFogEnd - uFogStart);
+				FogFactor = (uFogEnd - vFogCoord) * Scale;
+			}
+			else if (uFogType == 2) // Exp2
+			{
+				FogFactor = exp2(-uFogDensity * uFogDensity * vFogCoord * vFogCoord * LOG2);
+			}
+
+			FogFactor = clamp(FogFactor, 0.0, 1.0);
+
+			return FogFactor;
+		}
+	)";
+
+	std::string fs_main1 = R"(
+		void main()
+		{
+			vec4 Color = vVertexColor;
+	)";
+
+	std::string fs_solid = R"(
+			if (bool(uTextureUsage0))
+				Color *= texture2D(uTextureUnit0, vTextureCoord0);
+	)";
+
+	std::string fs_trans = R"(
+			if (bool(uTextureUsage0))
+			{
+				Color *= texture2D(uTextureUnit0, vTextureCoord0);
+
+				// TODO: uAlphaRef should rather control sharpness of alpha, don't know how to do that right now and this works in most cases.
+				if (Color.a < uAlphaRef)
+					discard;
+			}
+	)";
+
+	std::string fs_trans_ref = R"(
+			if (bool(uTextureUsage0))
+				Color *= texture2D(uTextureUnit0, vTextureCoord0);
+
+			if (Color.a < uAlphaRef)
+				discard;
+	)";
+
+	std::string fs_main2 = R"(
+			if (bool(uFogEnable))
+			{
+				float FogFactor = computeFog();
+				vec4 FogColor = uFogColor;
+				FogColor.a = 1.0;
+				Color = mix(FogColor, Color, FogFactor);
+			}
+
+			gl_FragColor = Color;
+		}
+	)";
+
+	std::string fs_ontexblend = R"(
+		void main()
+		{
+			vec4 Color0 = vVertexColor;
+			vec4 Color1 = vec4(1.0, 1.0, 1.0, 1.0);
+
+			if (bool(uTextureUsage0))
+				Color1 = texture2D(uTextureUnit0, vTextureCoord0);
+
+			vec4 FinalColor = Color0 * Color1;
+
+			if (uBlendType == 1)
+			{
+				FinalColor.w = Color0.w;
+			}
+			else if (uBlendType == 2)
+			{
+				FinalColor.w = Color1.w;
+			}
+
+			if (bool(uFogEnable))
+			{
+				float FogFactor = computeFog();
+				vec4 FogColor = uFogColor;
+				FogColor.a = 1.0;
+				FinalColor = mix(FogColor, FinalColor, FogFactor);
+			}
+
+			gl_FragColor = FinalColor;
+		}
+	)";
+
+	std::string vs_shader = shaders_header +
+		vs_attributes + vs_uniforms + varyings +
+		vs_main1 + vs_main2;
 
 	// EMT_SOLID
-	core::stringc FragmentShader = OGLES2ShaderPath + "Solid.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, "main", EVST_VS_2_0, FragmentShader, "main", EPST_PS_2_0, "", "main",
+	std::string solid_shader = shaders_header +
+		"precision mediump float;\n" + fs_uniforms + varyings +
+		fog + fs_main1 + fs_solid + fs_main2;
+
+	addHighLevelShaderMaterial(vs_shader.c_str(), "main", EVST_VS_2_0, solid_shader.c_str(), "main", EPST_PS_2_0, "", "main",
 			EGST_GS_4_0, scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, SolidCB, EMT_SOLID, 0);
 
 	// EMT_TRANSPARENT_ALPHA_CHANNEL
-	FragmentShader = OGLES2ShaderPath + "TransparentAlphaChannel.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, "main", EVST_VS_2_0, FragmentShader, "main", EPST_PS_2_0, "", "main",
+	std::string trans_shader = shaders_header +
+		"precision mediump float;\n" + fs_uniforms + "uniform float uAlphaRef;\n" +
+		varyings + fog + fs_main1 + fs_trans + fs_main2;
+
+	addHighLevelShaderMaterial(vs_shader.c_str(), "main", EVST_VS_2_0, trans_shader.c_str(), "main", EPST_PS_2_0, "", "main",
 			EGST_GS_4_0, scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, TransparentAlphaChannelCB, EMT_TRANSPARENT_ALPHA_CHANNEL, 0);
 
 	// EMT_TRANSPARENT_ALPHA_CHANNEL_REF
-	FragmentShader = OGLES2ShaderPath + "TransparentAlphaChannelRef.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, "main", EVST_VS_2_0, FragmentShader, "main", EPST_PS_2_0, "", "main",
+	std::string trans_ref_shader = shaders_header +
+		"precision mediump float;\n" + fs_uniforms + "uniform float uAlphaRef;\n" +
+		varyings + fog + fs_main1 + fs_trans_ref + fs_main2;
+
+	addHighLevelShaderMaterial(vs_shader.c_str(), "main", EVST_VS_2_0, trans_ref_shader.c_str(), "main", EPST_PS_2_0, "", "main",
 			EGST_GS_4_0, scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, TransparentAlphaChannelRefCB, EMT_SOLID, 0);
 
 	// EMT_TRANSPARENT_VERTEX_ALPHA
-	FragmentShader = OGLES2ShaderPath + "TransparentVertexAlpha.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, "main", EVST_VS_2_0, FragmentShader, "main", EPST_PS_2_0, "", "main",
+	addHighLevelShaderMaterial(vs_shader.c_str(), "main", EVST_VS_2_0, solid_shader.c_str(), "main", EPST_PS_2_0, "", "main",
 			EGST_GS_4_0, scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, TransparentVertexAlphaCB, EMT_TRANSPARENT_ALPHA_CHANNEL, 0);
 
 	// EMT_ONETEXTURE_BLEND
-	FragmentShader = OGLES2ShaderPath + "OneTextureBlend.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, "main", EVST_VS_2_0, FragmentShader, "main", EPST_PS_2_0, "", "main",
+	std::string ontexalpha_shader = shaders_header +
+		"precision mediump float;\n" + fs_uniforms + "uniform int uBlendType;\n" +
+		varyings + fog + fs_ontexblend;
+
+
+	addHighLevelShaderMaterial(vs_shader.c_str(), "main", EVST_VS_2_0, ontexalpha_shader.c_str(), "main", EPST_PS_2_0, "", "main",
 			EGST_GS_4_0, scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, OneTextureBlendCB, EMT_ONETEXTURE_BLEND, 0);
+
+	varyings += "varying vec3 vVertexColor2;\n";
+	std::string vs_2c_shader = shaders_header +
+		vs_attributes + "attribute vec3 inVertexColor2;\n" + vs_uniforms + varyings +
+		vs_main1 + "vVertexColor2 = inVertexColor2;\n" + vs_main2;
+
+	fs_main1 += "Color.rgb *= vVertexColor2;\n";
+	// EMT_SOLID_2COLORS
+	std::string solid_2c_shader = shaders_header +
+		"precision mediump float;\n" + fs_uniforms + varyings +
+		fog + fs_main1 + fs_solid + fs_main2;
+
+	addHighLevelShaderMaterial(vs_2c_shader.c_str(), "main", EVST_VS_2_0, solid_2c_shader.c_str(), "main", EPST_PS_2_0, "", "main",
+			EGST_GS_4_0, scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, SolidCB, EMT_SOLID_2COLORS, 0);
+
+	// EMT_TRANSPARENT_ALPHA_CHANNEL_2COLORS
+	std::string trans_2c_shader = shaders_header +
+		"precision mediump float;\n" + fs_uniforms + "uniform float uAlphaRef;\n" +
+		varyings + fog + fs_main1 + fs_trans + fs_main2;
+
+	addHighLevelShaderMaterial(vs_2c_shader.c_str(), "main", EVST_VS_2_0, trans_2c_shader.c_str(), "main", EPST_PS_2_0, "", "main",
+			EGST_GS_4_0, scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, TransparentAlphaChannelCB, EMT_TRANSPARENT_ALPHA_CHANNEL_2COLORS, 0);
+
+	// EMT_TRANSPARENT_ALPHA_CHANNEL_REF_2COLORS
+	std::string trans_ref_2c_shader = shaders_header +
+		"precision mediump float;\n" + fs_uniforms + "uniform float uAlphaRef;\n" +
+		varyings + fog + fs_main1 + fs_trans_ref + fs_main2;
+
+	addHighLevelShaderMaterial(vs_2c_shader.c_str(), "main", EVST_VS_2_0, trans_ref_2c_shader.c_str(), "main", EPST_PS_2_0, "", "main",
+			EGST_GS_4_0, scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, TransparentAlphaChannelRefCB, EMT_TRANSPARENT_ALPHA_CHANNEL_REF_2COLORS, 0);
 
 	// Drop callbacks.
 

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -94,6 +94,17 @@ static const VertexType vtTangents = {
 		},
 };
 
+static const VertexType vt2Colors = {
+		sizeof(S3DVertex2Colors),
+		{
+				{EVA_POSITION, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex2Colors, Pos)},
+				{EVA_NORMAL, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex2Colors, Normal)},
+				{EVA_COLOR, 4, GL_UNSIGNED_BYTE, VertexAttribute::Mode::Normalized, offsetof(S3DVertex2Colors, Color)},
+				{EVA_TCOORD0, 2, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex2Colors, TCoords)},
+				{EVA_COLOR2, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex2Colors, Color2)},
+		},
+};
+
 #pragma GCC diagnostic pop
 
 static const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type)
@@ -105,6 +116,8 @@ static const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type)
 		return vt2TCoords;
 	case EVT_TANGENTS:
 		return vtTangents;
+	case EVT_2COLORS:
+		return vt2Colors;
 	default:
 		assert(false);
 	}

--- a/irr/src/OpenGL/MaterialRenderer.cpp
+++ b/irr/src/OpenGL/MaterialRenderer.cpp
@@ -37,6 +37,7 @@ COpenGL3MaterialRenderer::COpenGL3MaterialRenderer(COpenGL3DriverBase *driver,
 	switch (baseMaterial) {
 	case EMT_TRANSPARENT_VERTEX_ALPHA:
 	case EMT_TRANSPARENT_ALPHA_CHANNEL:
+	case EMT_TRANSPARENT_ALPHA_CHANNEL_2COLORS:
 		Alpha = true;
 		break;
 	case EMT_ONETEXTURE_BLEND:
@@ -61,6 +62,7 @@ COpenGL3MaterialRenderer::COpenGL3MaterialRenderer(COpenGL3DriverBase *driver,
 	switch (baseMaterial) {
 	case EMT_TRANSPARENT_VERTEX_ALPHA:
 	case EMT_TRANSPARENT_ALPHA_CHANNEL:
+	case EMT_TRANSPARENT_ALPHA_CHANNEL_2COLORS:
 		Alpha = true;
 		break;
 	case EMT_ONETEXTURE_BLEND:

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -139,7 +139,7 @@ void Camera::step(f32 dtime)
 
 	if (m_wield_change_timer >= 0 && was_under_zero) {
 		m_wieldnode->setItem(m_wield_item_next, m_client);
-		m_wieldnode->setNodeLightColor(m_player_light_color);
+		m_wieldnode->setColor(m_player_light_color);
 	}
 
 	if (m_view_bobbing_state != 0)
@@ -552,7 +552,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 tool_reload_ratio)
 	m_wieldnode->setRotation(wield_rotation);
 
 	m_player_light_color = player->light_color;
-	m_wieldnode->setNodeLightColor(m_player_light_color);
+	m_wieldnode->setColor(m_player_light_color);
 
 	// Set render distance
 	updateViewingRange();

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -921,7 +921,7 @@ void GenericCAO::setNodeLight(const video::SColor &light_color)
 {
 	if (m_prop.visual == "wielditem" || m_prop.visual == "item") {
 		if (m_wield_meshnode)
-			m_wield_meshnode->setNodeLightColor(light_color);
+			m_wield_meshnode->setColor(light_color);
 		return;
 	}
 

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -136,7 +136,7 @@ void MapblockMeshGenerator::drawQuad(v3f *coords, const v3s16 &normal,
 {
 	const v2f tcoords[4] = {v2f(0.0, 0.0), v2f(1.0, 0.0),
 		v2f(1.0, vertical_tiling), v2f(0.0, vertical_tiling)};
-	video::S3DVertex vertices[4];
+	video::S3DVertex2Colors vertices[4];
 	bool shade_face = !cur_node.f->light_source && (normal != v3s16(0, 0, 0));
 	v3f normal2(normal.X, normal.Y, normal.Z);
 	for (int j = 0; j < 4; j++) {
@@ -153,48 +153,48 @@ void MapblockMeshGenerator::drawQuad(v3f *coords, const v3s16 &normal,
 	collector->append(cur_node.tile, vertices, 4, quad_indices, 6);
 }
 
-static std::array<video::S3DVertex, 24> setupCuboidVertices(const aabb3f &box, const f32 *txc, TileSpec *tiles, int tilecount) {
+static std::array<video::S3DVertex2Colors, 24> setupCuboidVertices(const aabb3f &box, const f32 *txc, TileSpec *tiles, int tilecount) {
 	v3f min = box.MinEdge;
 	v3f max = box.MaxEdge;
 
-	std::array<video::S3DVertex, 24> vertices = {{
+	std::array<video::S3DVertex2Colors, 24> vertices = {{
 		// top
-		video::S3DVertex(min.X, max.Y, max.Z, 0, 1, 0, {}, txc[0], txc[1]),
-		video::S3DVertex(max.X, max.Y, max.Z, 0, 1, 0, {}, txc[2], txc[1]),
-		video::S3DVertex(max.X, max.Y, min.Z, 0, 1, 0, {}, txc[2], txc[3]),
-		video::S3DVertex(min.X, max.Y, min.Z, 0, 1, 0, {}, txc[0], txc[3]),
+		video::S3DVertex2Colors(min.X, max.Y, max.Z, 0, 1, 0, {}, txc[0], txc[1]),
+		video::S3DVertex2Colors(max.X, max.Y, max.Z, 0, 1, 0, {}, txc[2], txc[1]),
+		video::S3DVertex2Colors(max.X, max.Y, min.Z, 0, 1, 0, {}, txc[2], txc[3]),
+		video::S3DVertex2Colors(min.X, max.Y, min.Z, 0, 1, 0, {}, txc[0], txc[3]),
 		// bottom
-		video::S3DVertex(min.X, min.Y, min.Z, 0, -1, 0, {}, txc[4], txc[5]),
-		video::S3DVertex(max.X, min.Y, min.Z, 0, -1, 0, {}, txc[6], txc[5]),
-		video::S3DVertex(max.X, min.Y, max.Z, 0, -1, 0, {}, txc[6], txc[7]),
-		video::S3DVertex(min.X, min.Y, max.Z, 0, -1, 0, {}, txc[4], txc[7]),
+		video::S3DVertex2Colors(min.X, min.Y, min.Z, 0, -1, 0, {}, txc[4], txc[5]),
+		video::S3DVertex2Colors(max.X, min.Y, min.Z, 0, -1, 0, {}, txc[6], txc[5]),
+		video::S3DVertex2Colors(max.X, min.Y, max.Z, 0, -1, 0, {}, txc[6], txc[7]),
+		video::S3DVertex2Colors(min.X, min.Y, max.Z, 0, -1, 0, {}, txc[4], txc[7]),
 		// right
-		video::S3DVertex(max.X, max.Y, min.Z, 1, 0, 0, {}, txc[ 8], txc[9]),
-		video::S3DVertex(max.X, max.Y, max.Z, 1, 0, 0, {}, txc[10], txc[9]),
-		video::S3DVertex(max.X, min.Y, max.Z, 1, 0, 0, {}, txc[10], txc[11]),
-		video::S3DVertex(max.X, min.Y, min.Z, 1, 0, 0, {}, txc[ 8], txc[11]),
+		video::S3DVertex2Colors(max.X, max.Y, min.Z, 1, 0, 0, {}, txc[ 8], txc[9]),
+		video::S3DVertex2Colors(max.X, max.Y, max.Z, 1, 0, 0, {}, txc[10], txc[9]),
+		video::S3DVertex2Colors(max.X, min.Y, max.Z, 1, 0, 0, {}, txc[10], txc[11]),
+		video::S3DVertex2Colors(max.X, min.Y, min.Z, 1, 0, 0, {}, txc[ 8], txc[11]),
 		// left
-		video::S3DVertex(min.X, max.Y, max.Z, -1, 0, 0, {}, txc[12], txc[13]),
-		video::S3DVertex(min.X, max.Y, min.Z, -1, 0, 0, {}, txc[14], txc[13]),
-		video::S3DVertex(min.X, min.Y, min.Z, -1, 0, 0, {}, txc[14], txc[15]),
-		video::S3DVertex(min.X, min.Y, max.Z, -1, 0, 0, {}, txc[12], txc[15]),
+		video::S3DVertex2Colors(min.X, max.Y, max.Z, -1, 0, 0, {}, txc[12], txc[13]),
+		video::S3DVertex2Colors(min.X, max.Y, min.Z, -1, 0, 0, {}, txc[14], txc[13]),
+		video::S3DVertex2Colors(min.X, min.Y, min.Z, -1, 0, 0, {}, txc[14], txc[15]),
+		video::S3DVertex2Colors(min.X, min.Y, max.Z, -1, 0, 0, {}, txc[12], txc[15]),
 		// back
-		video::S3DVertex(max.X, max.Y, max.Z, 0, 0, 1, {}, txc[16], txc[17]),
-		video::S3DVertex(min.X, max.Y, max.Z, 0, 0, 1, {}, txc[18], txc[17]),
-		video::S3DVertex(min.X, min.Y, max.Z, 0, 0, 1, {}, txc[18], txc[19]),
-		video::S3DVertex(max.X, min.Y, max.Z, 0, 0, 1, {}, txc[16], txc[19]),
+		video::S3DVertex2Colors(max.X, max.Y, max.Z, 0, 0, 1, {}, txc[16], txc[17]),
+		video::S3DVertex2Colors(min.X, max.Y, max.Z, 0, 0, 1, {}, txc[18], txc[17]),
+		video::S3DVertex2Colors(min.X, min.Y, max.Z, 0, 0, 1, {}, txc[18], txc[19]),
+		video::S3DVertex2Colors(max.X, min.Y, max.Z, 0, 0, 1, {}, txc[16], txc[19]),
 		// front
-		video::S3DVertex(min.X, max.Y, min.Z, 0, 0, -1, {}, txc[20], txc[21]),
-		video::S3DVertex(max.X, max.Y, min.Z, 0, 0, -1, {}, txc[22], txc[21]),
-		video::S3DVertex(max.X, min.Y, min.Z, 0, 0, -1, {}, txc[22], txc[23]),
-		video::S3DVertex(min.X, min.Y, min.Z, 0, 0, -1, {}, txc[20], txc[23]),
+		video::S3DVertex2Colors(min.X, max.Y, min.Z, 0, 0, -1, {}, txc[20], txc[21]),
+		video::S3DVertex2Colors(max.X, max.Y, min.Z, 0, 0, -1, {}, txc[22], txc[21]),
+		video::S3DVertex2Colors(max.X, min.Y, min.Z, 0, 0, -1, {}, txc[22], txc[23]),
+		video::S3DVertex2Colors(min.X, min.Y, min.Z, 0, 0, -1, {}, txc[20], txc[23]),
 	}};
 
 	for (int face = 0; face < 6; face++) {
 		int tileindex = MYMIN(face, tilecount - 1);
 		const TileSpec &tile = tiles[tileindex];
 		for (int j = 0; j < 4; j++) {
-			video::S3DVertex &vertex = vertices[face * 4 + j];
+			video::S3DVertex2Colors &vertex = vertices[face * 4 + j];
 			v2f &tcoords = vertex.TCoords;
 			switch (tile.rotation) {
 			case TileRotation::None:
@@ -379,10 +379,10 @@ void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box, const f32 *txc,
 			lights[j] = blendLight(d);
 		}
 
-		drawCuboid(box, tiles, tile_count, txc, mask, [&] (int face, video::S3DVertex vertices[4]) {
+		drawCuboid(box, tiles, tile_count, txc, mask, [&] (int face, video::S3DVertex2Colors vertices[4]) {
 			LightPair final_lights[4];
 			for (int j = 0; j < 4; j++) {
-				video::S3DVertex &vertex = vertices[j];
+				video::S3DVertex2Colors &vertex = vertices[j];
 				final_lights[j] = lights[light_indices[face][j]].getPair(MYMAX(0.0f, vertex.Normal.Y));
 				vertex.Color = encode_light(final_lights[j], cur_node.f->light_source);
 				if (!cur_node.f->light_source)
@@ -393,12 +393,12 @@ void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box, const f32 *txc,
 			return QuadDiagonal::Diag02;
 		});
 	} else {
-		drawCuboid(box, tiles, tile_count, txc, mask, [&] (int face, video::S3DVertex vertices[4]) {
+		drawCuboid(box, tiles, tile_count, txc, mask, [&] (int face, video::S3DVertex2Colors vertices[4]) {
 			video::SColor color = encode_light(cur_node.light, cur_node.f->light_source);
 			if (!cur_node.f->light_source)
 				applyFacesShading(color, vertices[0].Normal);
 			for (int j = 0; j < 4; j++) {
-				video::S3DVertex &vertex = vertices[j];
+				video::S3DVertex2Colors &vertex = vertices[j];
 				vertex.Color = color;
 			}
 			return QuadDiagonal::Diag02;
@@ -470,10 +470,10 @@ void MapblockMeshGenerator::drawSolidNode()
 			}
 		}
 
-		drawCuboid(box, tiles, 6, texture_coord_buf, mask, [&] (int face, video::S3DVertex vertices[4]) {
+		drawCuboid(box, tiles, 6, texture_coord_buf, mask, [&] (int face, video::S3DVertex2Colors vertices[4]) {
 			auto final_lights = lights[face];
 			for (int j = 0; j < 4; j++) {
-				video::S3DVertex &vertex = vertices[j];
+				video::S3DVertex2Colors &vertex = vertices[j];
 				vertex.Color = encode_light(final_lights[j], cur_node.f->light_source);
 				if (!cur_node.f->light_source)
 					applyFacesShading(vertex.Color, vertex.Normal);
@@ -483,12 +483,12 @@ void MapblockMeshGenerator::drawSolidNode()
 			return QuadDiagonal::Diag02;
 		});
 	} else {
-		drawCuboid(box, tiles, 6, texture_coord_buf, mask, [&] (int face, video::S3DVertex vertices[4]) {
+		drawCuboid(box, tiles, 6, texture_coord_buf, mask, [&] (int face, video::S3DVertex2Colors vertices[4]) {
 			video::SColor color = encode_light(lights[face], cur_node.f->light_source);
 			if (!cur_node.f->light_source)
 				applyFacesShading(color, vertices[0].Normal);
 			for (int j = 0; j < 4; j++) {
-				video::S3DVertex &vertex = vertices[j];
+				video::S3DVertex2Colors &vertex = vertices[j];
 				vertex.Color = color;
 			}
 			return QuadDiagonal::Diag02;
@@ -692,7 +692,7 @@ void MapblockMeshGenerator::drawLiquidSides()
 		if (neighbor_features.solidness == 2)
 			continue;
 
-		video::S3DVertex vertices[4];
+		video::S3DVertex2Colors vertices[4];
 		for (int j = 0; j < 4; j++) {
 			const UV &vertex = liquid_base_vertices[j];
 			const v3s16 &base = face.p[vertex.u];
@@ -713,7 +713,7 @@ void MapblockMeshGenerator::drawLiquidSides()
 			if (data->m_smooth_lighting)
 				cur_node.color = blendLightColor(pos);
 			pos += cur_node.origin;
-			vertices[j] = video::S3DVertex(pos.X, pos.Y, pos.Z, 0, 0, 0, cur_node.color, vertex.u, v);
+			vertices[j] = video::S3DVertex2Colors(pos.X, pos.Y, pos.Z, 0, 0, 0, cur_node.color, vertex.u, v);
 		};
 		collector->append(cur_liquid.tile, vertices, 4, quad_indices, 6);
 	}
@@ -726,11 +726,11 @@ void MapblockMeshGenerator::drawLiquidTop()
 	// calculate corner levels in exact reverse order.
 	static const int corner_resolve[4][2] = {{0, 1}, {1, 1}, {1, 0}, {0, 0}};
 
-	video::S3DVertex vertices[4] = {
-		video::S3DVertex(-BS / 2, 0,  BS / 2, 0, 0, 0, cur_liquid.color_top, 0, 1),
-		video::S3DVertex( BS / 2, 0,  BS / 2, 0, 0, 0, cur_liquid.color_top, 1, 1),
-		video::S3DVertex( BS / 2, 0, -BS / 2, 0, 0, 0, cur_liquid.color_top, 1, 0),
-		video::S3DVertex(-BS / 2, 0, -BS / 2, 0, 0, 0, cur_liquid.color_top, 0, 0),
+	video::S3DVertex2Colors vertices[4] = {
+		video::S3DVertex2Colors(-BS / 2, 0,  BS / 2, 0, 0, 0, cur_liquid.color_top, 0, 1),
+		video::S3DVertex2Colors( BS / 2, 0,  BS / 2, 0, 0, 0, cur_liquid.color_top, 1, 1),
+		video::S3DVertex2Colors( BS / 2, 0, -BS / 2, 0, 0, 0, cur_liquid.color_top, 1, 0),
+		video::S3DVertex2Colors(-BS / 2, 0, -BS / 2, 0, 0, 0, cur_liquid.color_top, 0, 0),
 	};
 
 	for (int i = 0; i < 4; i++) {
@@ -766,7 +766,7 @@ void MapblockMeshGenerator::drawLiquidTop()
 	tcoord_translate.X -= floor(tcoord_translate.X);
 	tcoord_translate.Y -= floor(tcoord_translate.Y);
 
-	for (video::S3DVertex &vertex : vertices) {
+	for (video::S3DVertex2Colors &vertex : vertices) {
 		// Rotate vertex.TCoords around tcoord_center. The X axis turns to dir.
 		vertex.TCoords -= tcoord_center;
 		vertex.TCoords.set(
@@ -784,11 +784,11 @@ void MapblockMeshGenerator::drawLiquidTop()
 
 void MapblockMeshGenerator::drawLiquidBottom()
 {
-	video::S3DVertex vertices[4] = {
-		video::S3DVertex(-BS / 2, -BS / 2, -BS / 2, 0, 0, 0, cur_liquid.color_top, 0, 0),
-		video::S3DVertex( BS / 2, -BS / 2, -BS / 2, 0, 0, 0, cur_liquid.color_top, 1, 0),
-		video::S3DVertex( BS / 2, -BS / 2,  BS / 2, 0, 0, 0, cur_liquid.color_top, 1, 1),
-		video::S3DVertex(-BS / 2, -BS / 2,  BS / 2, 0, 0, 0, cur_liquid.color_top, 0, 1),
+	video::S3DVertex2Colors vertices[4] = {
+		video::S3DVertex2Colors(-BS / 2, -BS / 2, -BS / 2, 0, 0, 0, cur_liquid.color_top, 0, 0),
+		video::S3DVertex2Colors( BS / 2, -BS / 2, -BS / 2, 0, 0, 0, cur_liquid.color_top, 1, 0),
+		video::S3DVertex2Colors( BS / 2, -BS / 2,  BS / 2, 0, 0, 0, cur_liquid.color_top, 1, 1),
+		video::S3DVertex2Colors(-BS / 2, -BS / 2,  BS / 2, 0, 0, 0, cur_liquid.color_top, 0, 1),
 	};
 
 	for (int i = 0; i < 4; i++) {
@@ -1676,14 +1676,14 @@ void MapblockMeshGenerator::drawMeshNode()
 	for (int j = 0; j < mesh_buffer_count; j++) {
 		useTile(j);
 		scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
-		video::S3DVertex *vertices = (video::S3DVertex *)buf->getVertices();
+		video::S3DVertex2Colors *vertices = (video::S3DVertex2Colors *)buf->getVertices();
 		int vertex_count = buf->getVertexCount();
 
 		if (data->m_smooth_lighting) {
 			// Mesh is always private here. So the lighting is applied to each
 			// vertex right here.
 			for (int k = 0; k < vertex_count; k++) {
-				video::S3DVertex &vertex = vertices[k];
+				video::S3DVertex2Colors &vertex = vertices[k];
 				vertex.Color = blendLightColor(vertex.Pos, vertex.Normal);
 				vertex.Pos += cur_node.origin;
 			}

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1139,9 +1139,9 @@ void drawItemStack(
 			if (p.needColorize(c)) {
 				buf->setDirty(scene::EBT_VERTEX);
 				if (imesh->needs_shading)
-					colorizeMeshBuffer(buf, &c);
+					colorizeMeshBuffer2Colors(buf, c);
 				else
-					setMeshBufferColor(buf, c);
+					setMeshBuffer2Colors(buf, c);
 			}
 
 			video::SMaterial &material = buf->getMaterial();

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -1145,7 +1145,7 @@ void drawItemStack(
 			}
 
 			video::SMaterial &material = buf->getMaterial();
-			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF_2COLORS;
 			material.Lighting = false;
 			driver->setMaterial(material);
 			driver->drawMeshBuffer(buf);

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -74,7 +74,7 @@ struct MeshMakeData
 class MeshTriangle
 {
 public:
-	scene::SMeshBuffer *buffer;
+	scene::SMeshBuffer2Colors *buffer;
 	u16 p1, p2, p3;
 	v3f centroid;
 	float areaSQ;
@@ -152,7 +152,7 @@ private:
 class PartialMeshBuffer
 {
 public:
-	PartialMeshBuffer(scene::SMeshBuffer *buffer, std::vector<u16> &&vertex_indexes) :
+	PartialMeshBuffer(scene::SMeshBuffer2Colors *buffer, std::vector<u16> &&vertex_indexes) :
 			m_buffer(buffer), m_vertex_indexes(std::move(vertex_indexes))
 	{}
 
@@ -162,7 +162,7 @@ public:
 	void beforeDraw() const;
 	void afterDraw() const;
 private:
-	scene::SMeshBuffer *m_buffer;
+	scene::SMeshBuffer2Colors *m_buffer;
 	mutable std::vector<u16> m_vertex_indexes;
 };
 

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -135,7 +135,7 @@ scene::IAnimatedMesh* createCubeMesh2Colors(v3f scale)
 		buf->append(&vertices[0] + 4 * i, 4, indices, 6);
 		// Set default material
 		buf->getMaterial().Lighting = false;
-		buf->getMaterial().MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+		buf->getMaterial().MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF_2COLORS;
 		buf->getMaterial().forEachTexture([] (auto &tex) {
 			tex.MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
 			tex.MagFilter = video::ETMAGF_NEAREST;

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -53,50 +53,86 @@ void applyFacesShading(video::SColor &color, const v3f &normal)
 		applyShadeFactor(color, 0.670820f * x2 + 1.000000f * y2 + 0.836660f * z2);
 }
 
+template<typename T>
+std::array<T, 24> getCubeVertices(video::SColor c)
+{
+
+	return std::array<T, 24>{
+		// Up
+		T(-0.5,+0.5,-0.5, 0,1,0, c, 0,1),
+		T(-0.5,+0.5,+0.5, 0,1,0, c, 0,0),
+		T(+0.5,+0.5,+0.5, 0,1,0, c, 1,0),
+		T(+0.5,+0.5,-0.5, 0,1,0, c, 1,1),
+		// Down
+		T(-0.5,-0.5,-0.5, 0,-1,0, c, 0,0),
+		T(+0.5,-0.5,-0.5, 0,-1,0, c, 1,0),
+		T(+0.5,-0.5,+0.5, 0,-1,0, c, 1,1),
+		T(-0.5,-0.5,+0.5, 0,-1,0, c, 0,1),
+		// Right
+		T(+0.5,-0.5,-0.5, 1,0,0, c, 0,1),
+		T(+0.5,+0.5,-0.5, 1,0,0, c, 0,0),
+		T(+0.5,+0.5,+0.5, 1,0,0, c, 1,0),
+		T(+0.5,-0.5,+0.5, 1,0,0, c, 1,1),
+		// Left
+		T(-0.5,-0.5,-0.5, -1,0,0, c, 1,1),
+		T(-0.5,-0.5,+0.5, -1,0,0, c, 0,1),
+		T(-0.5,+0.5,+0.5, -1,0,0, c, 0,0),
+		T(-0.5,+0.5,-0.5, -1,0,0, c, 1,0),
+		// Back
+		T(-0.5,-0.5,+0.5, 0,0,1, c, 1,1),
+		T(+0.5,-0.5,+0.5, 0,0,1, c, 0,1),
+		T(+0.5,+0.5,+0.5, 0,0,1, c, 0,0),
+		T(-0.5,+0.5,+0.5, 0,0,1, c, 1,0),
+		// Front
+		T(-0.5,-0.5,-0.5, 0,0,-1, c, 0,1),
+		T(-0.5,+0.5,-0.5, 0,0,-1, c, 0,0),
+		T(+0.5,+0.5,-0.5, 0,0,-1, c, 1,0),
+		T(+0.5,-0.5,-0.5, 0,0,-1, c, 1,1),
+	};
+}
+
 scene::IAnimatedMesh* createCubeMesh(v3f scale)
 {
 	video::SColor c(255,255,255,255);
-	video::S3DVertex vertices[24] =
-	{
-		// Up
-		video::S3DVertex(-0.5,+0.5,-0.5, 0,1,0, c, 0,1),
-		video::S3DVertex(-0.5,+0.5,+0.5, 0,1,0, c, 0,0),
-		video::S3DVertex(+0.5,+0.5,+0.5, 0,1,0, c, 1,0),
-		video::S3DVertex(+0.5,+0.5,-0.5, 0,1,0, c, 1,1),
-		// Down
-		video::S3DVertex(-0.5,-0.5,-0.5, 0,-1,0, c, 0,0),
-		video::S3DVertex(+0.5,-0.5,-0.5, 0,-1,0, c, 1,0),
-		video::S3DVertex(+0.5,-0.5,+0.5, 0,-1,0, c, 1,1),
-		video::S3DVertex(-0.5,-0.5,+0.5, 0,-1,0, c, 0,1),
-		// Right
-		video::S3DVertex(+0.5,-0.5,-0.5, 1,0,0, c, 0,1),
-		video::S3DVertex(+0.5,+0.5,-0.5, 1,0,0, c, 0,0),
-		video::S3DVertex(+0.5,+0.5,+0.5, 1,0,0, c, 1,0),
-		video::S3DVertex(+0.5,-0.5,+0.5, 1,0,0, c, 1,1),
-		// Left
-		video::S3DVertex(-0.5,-0.5,-0.5, -1,0,0, c, 1,1),
-		video::S3DVertex(-0.5,-0.5,+0.5, -1,0,0, c, 0,1),
-		video::S3DVertex(-0.5,+0.5,+0.5, -1,0,0, c, 0,0),
-		video::S3DVertex(-0.5,+0.5,-0.5, -1,0,0, c, 1,0),
-		// Back
-		video::S3DVertex(-0.5,-0.5,+0.5, 0,0,1, c, 1,1),
-		video::S3DVertex(+0.5,-0.5,+0.5, 0,0,1, c, 0,1),
-		video::S3DVertex(+0.5,+0.5,+0.5, 0,0,1, c, 0,0),
-		video::S3DVertex(-0.5,+0.5,+0.5, 0,0,1, c, 1,0),
-		// Front
-		video::S3DVertex(-0.5,-0.5,-0.5, 0,0,-1, c, 0,1),
-		video::S3DVertex(-0.5,+0.5,-0.5, 0,0,-1, c, 0,0),
-		video::S3DVertex(+0.5,+0.5,-0.5, 0,0,-1, c, 1,0),
-		video::S3DVertex(+0.5,-0.5,-0.5, 0,0,-1, c, 1,1),
-	};
 
+	std::array<video::S3DVertex, 24> vertices = getCubeVertices<video::S3DVertex>(c);
 	u16 indices[6] = {0,1,2,2,3,0};
 
 	scene::SMesh *mesh = new scene::SMesh();
 	for (u32 i=0; i<6; ++i)
 	{
 		scene::IMeshBuffer *buf = new scene::SMeshBuffer();
-		buf->append(vertices + 4 * i, 4, indices, 6);
+		buf->append(&vertices[0] + 4 * i, 4, indices, 6);
+		// Set default material
+		buf->getMaterial().Lighting = false;
+		buf->getMaterial().MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+		buf->getMaterial().forEachTexture([] (auto &tex) {
+			tex.MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
+			tex.MagFilter = video::ETMAGF_NEAREST;
+		});
+		// Add mesh buffer to mesh
+		mesh->addMeshBuffer(buf);
+		buf->drop();
+	}
+
+	scene::SAnimatedMesh *anim_mesh = new scene::SAnimatedMesh(mesh);
+	mesh->drop();
+	scaleMesh(anim_mesh, scale);  // also recalculates bounding box
+	return anim_mesh;
+}
+
+scene::IAnimatedMesh* createCubeMesh2Colors(v3f scale)
+{
+	video::SColor c(255,255,255,255);
+
+	std::array<video::S3DVertex2Colors, 24> vertices = getCubeVertices<video::S3DVertex2Colors>(c);
+	u16 indices[6] = {0,1,2,2,3,0};
+
+	scene::SMesh *mesh = new scene::SMesh();
+	for (u32 i=0; i<6; ++i)
+	{
+		scene::IMeshBuffer *buf = new scene::SMeshBuffer2Colors();
+		buf->append(&vertices[0] + 4 * i, 4, indices, 6);
 		// Set default material
 		buf->getMaterial().Lighting = false;
 		buf->getMaterial().MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
@@ -117,20 +153,27 @@ scene::IAnimatedMesh* createCubeMesh(v3f scale)
 
 void scaleMesh(scene::IMesh *mesh, v3f scale)
 {
-	if (mesh == NULL)
+	if (!mesh)
 		return;
 
 	aabb3f bbox;
 	bbox.reset(0, 0, 0);
 
-	u32 mc = mesh->getMeshBufferCount();
-	for (u32 j = 0; j < mc; j++) {
+	for (u32 j = 0; j < mesh->getMeshBufferCount(); j++) {
 		scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
-		const u32 stride = getVertexPitchFromType(buf->getVertexType());
-		u32 vertex_count = buf->getVertexCount();
-		u8 *vertices = (u8 *)buf->getVertices();
-		for (u32 i = 0; i < vertex_count; i++)
-			((video::S3DVertex *)(vertices + i * stride))->Pos *= scale;
+
+		if (buf->getVertexType() == video::EVT_2COLORS) {
+			video::S3DVertex2Colors *vertices = static_cast<video::S3DVertex2Colors *>(buf->getVertices());
+
+			for (u32 i = 0; i < buf->getVertexCount(); i++)
+				vertices[i].Pos *= scale;
+		}
+		else {
+			video::S3DVertex *vertices = static_cast<video::S3DVertex *>(buf->getVertices());
+
+			for (u32 i = 0; i < buf->getVertexCount(); i++)
+				vertices[i].Pos *= scale;
+		}
 
 		buf->recalculateBoundingBox();
 
@@ -143,22 +186,54 @@ void scaleMesh(scene::IMesh *mesh, v3f scale)
 	mesh->setBoundingBox(bbox);
 }
 
-void translateMesh(scene::IMesh *mesh, v3f vec)
+/*void scaleMesh2Colors(scene::IMesh *mesh, v3f scale)
 {
-	if (mesh == NULL)
+	if (!mesh)
 		return;
 
 	aabb3f bbox;
 	bbox.reset(0, 0, 0);
 
-	u32 mc = mesh->getMeshBufferCount();
-	for (u32 j = 0; j < mc; j++) {
+	for (u32 j = 0; j < mesh->getMeshBufferCount(); j++) {
 		scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
-		const u32 stride = getVertexPitchFromType(buf->getVertexType());
-		u32 vertex_count = buf->getVertexCount();
-		u8 *vertices = (u8 *)buf->getVertices();
-		for (u32 i = 0; i < vertex_count; i++)
-			((video::S3DVertex *)(vertices + i * stride))->Pos += vec;
+		video::S3DVertex2Colors *vertices = static_cast<video::S3DVertex2Colors*>(buf->getVertices());
+		for (u32 i = 0; i < buf->getVertexCount(); i++)
+			vertices[i].Pos *= scale;
+
+		buf->recalculateBoundingBox();
+
+		// calculate total bounding box
+		if (j == 0)
+			bbox = buf->getBoundingBox();
+		else
+			bbox.addInternalBox(buf->getBoundingBox());
+	}
+	mesh->setBoundingBox(bbox);
+}*/
+
+void translateMesh(scene::IMesh *mesh, v3f vec)
+{
+	if (!mesh)
+		return;
+
+	aabb3f bbox;
+	bbox.reset(0, 0, 0);
+
+	for (u32 j = 0; j < mesh->getMeshBufferCount(); j++) {
+		scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
+
+		if (buf->getVertexType() == video::EVT_2COLORS) {
+			video::S3DVertex2Colors *vertices = static_cast<video::S3DVertex2Colors *>(buf->getVertices());
+
+			for (u32 i = 0; i < buf->getVertexCount(); i++)
+				vertices[i].Pos += vec;
+		}
+		else {
+			video::S3DVertex *vertices = static_cast<video::S3DVertex *>(buf->getVertices());
+
+			for (u32 i = 0; i < buf->getVertexCount(); i++)
+				vertices[i].Pos += vec;
+		}
 
 		buf->recalculateBoundingBox();
 
@@ -173,11 +248,19 @@ void translateMesh(scene::IMesh *mesh, v3f vec)
 
 void setMeshBufferColor(scene::IMeshBuffer *buf, const video::SColor &color)
 {
-	const u32 stride = getVertexPitchFromType(buf->getVertexType());
-	u32 vertex_count = buf->getVertexCount();
-	u8 *vertices = (u8 *) buf->getVertices();
-	for (u32 i = 0; i < vertex_count; i++)
-		((video::S3DVertex *) (vertices + i * stride))->Color = color;
+	video::S3DVertex *vertices = static_cast<video::S3DVertex *>(buf->getVertices());
+	for (u32 i = 0; i < buf->getVertexCount(); i++)
+		vertices[i].Color = color;
+}
+
+void setMeshBuffer2Colors(scene::IMeshBuffer *buf,
+	const video::SColor &color, const core::vector3df &color2)
+{
+	video::S3DVertex2Colors *vertices = static_cast<video::S3DVertex2Colors *>(buf->getVertices());
+	for (u32 i = 0; i < buf->getVertexCount(); i++) {
+		vertices[i].Color = color;
+		vertices[i].Color2 = color2;
+	}
 }
 
 void setAnimatedMeshColor(scene::IAnimatedMeshSceneNode *node, const video::SColor &color)
@@ -189,71 +272,45 @@ void setAnimatedMeshColor(scene::IAnimatedMeshSceneNode *node, const video::SCol
 
 void setMeshColor(scene::IMesh *mesh, const video::SColor &color)
 {
-	if (mesh == NULL)
+	if (!mesh)
 		return;
 
-	u32 mc = mesh->getMeshBufferCount();
-	for (u32 j = 0; j < mc; j++)
+	for (u32 j = 0; j < mesh->getMeshBufferCount(); j++)
 		setMeshBufferColor(mesh->getMeshBuffer(j), color);
 }
 
 void setMeshBufferTextureCoords(scene::IMeshBuffer *buf, const v2f *uv, u32 count)
 {
-	const u32 stride = getVertexPitchFromType(buf->getVertexType());
 	assert(buf->getVertexCount() >= count);
-	u8 *vertices = (u8 *) buf->getVertices();
+	video::S3DVertex *vertices = static_cast<video::S3DVertex *>(buf->getVertices());
 	for (u32 i = 0; i < count; i++)
-		((video::S3DVertex*) (vertices + i * stride))->TCoords = uv[i];
+		vertices[i].TCoords = uv[i];
 }
 
-template <typename F>
+template <typename T, typename F>
 static void applyToMesh(scene::IMesh *mesh, const F &fn)
 {
-	u16 mc = mesh->getMeshBufferCount();
-	for (u16 j = 0; j < mc; j++) {
+	for (u16 j = 0; j < mesh->getMeshBufferCount(); j++) {
 		scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
-		const u32 stride = getVertexPitchFromType(buf->getVertexType());
-		u32 vertex_count = buf->getVertexCount();
-		char *vertices = reinterpret_cast<char *>(buf->getVertices());
-		for (u32 i = 0; i < vertex_count; i++)
-			fn(reinterpret_cast<video::S3DVertex *>(vertices + i * stride));
+
+		T *vertices = static_cast<T *>(buf->getVertices());
+
+		for (u32 i = 0; i < buf->getVertexCount(); i++)
+			fn(vertices[i]);
 	}
 }
 
-void colorizeMeshBuffer(scene::IMeshBuffer *buf, const video::SColor *buffercolor)
+void colorizeMeshBuffer2Colors(scene::IMeshBuffer *buf,
+	const video::SColor &color, const core::vector3df &color2)
 {
-	const u32 stride = getVertexPitchFromType(buf->getVertexType());
-	u32 vertex_count = buf->getVertexCount();
-	u8 *vertices = (u8 *) buf->getVertices();
-	for (u32 i = 0; i < vertex_count; i++) {
-		video::S3DVertex *vertex = (video::S3DVertex *) (vertices + i * stride);
-		video::SColor *vc = &(vertex->Color);
+	video::S3DVertex2Colors *vertices = static_cast<video::S3DVertex2Colors *>(buf->getVertices());
+	for (u32 i = 0; i < buf->getVertexCount(); i++) {
 		// Reset color
-		*vc = *buffercolor;
+		vertices[i].Color = color;
+		vertices[i].Color2 = color2;
 		// Apply shading
-		applyFacesShading(*vc, vertex->Normal);
+		applyFacesShading(vertices[i].Color, vertices[i].Normal);
 	}
-}
-
-void setMeshColorByNormalXYZ(scene::IMesh *mesh,
-		const video::SColor &colorX,
-		const video::SColor &colorY,
-		const video::SColor &colorZ)
-{
-	if (!mesh)
-		return;
-	auto colorizator = [=] (video::S3DVertex *vertex) {
-		f32 x = fabs(vertex->Normal.X);
-		f32 y = fabs(vertex->Normal.Y);
-		f32 z = fabs(vertex->Normal.Z);
-		if (x >= y && x >= z)
-			vertex->Color = colorX;
-		else if (y >= z)
-			vertex->Color = colorY;
-		else
-			vertex->Color = colorZ;
-	};
-	applyToMesh(mesh, colorizator);
 }
 
 void setMeshColorByNormal(scene::IMesh *mesh, const v3f &normal,
@@ -261,41 +318,51 @@ void setMeshColorByNormal(scene::IMesh *mesh, const v3f &normal,
 {
 	if (!mesh)
 		return;
-	auto colorizator = [normal, color] (video::S3DVertex *vertex) {
-		if (vertex->Normal == normal)
-			vertex->Color = color;
+	auto colorizator = [normal, color] (video::S3DVertex &vertex) {
+		if (vertex.Normal == normal)
+			vertex.Color = color;
 	};
-	applyToMesh(mesh, colorizator);
+	applyToMesh<video::S3DVertex>(mesh, colorizator);
 }
 
-template <float v3f::*U, float v3f::*V>
+template <typename T, float v3f::*U, float v3f::*V>
 static void rotateMesh(scene::IMesh *mesh, float degrees)
 {
 	degrees *= M_PI / 180.0f;
 	float c = std::cos(degrees);
 	float s = std::sin(degrees);
-	auto rotator = [c, s] (video::S3DVertex *vertex) {
-		float u = vertex->Pos.*U;
-		float v = vertex->Pos.*V;
-		vertex->Pos.*U = c * u - s * v;
-		vertex->Pos.*V = s * u + c * v;
+
+	auto rotator = [c, s] (T &vertex) {
+		float u = vertex.Pos.*U;
+		float v = vertex.Pos.*V;
+		vertex.Pos.*U = c * u - s * v;
+		vertex.Pos.*V = s * u + c * v;
 	};
-	applyToMesh(mesh, rotator);
+	applyToMesh<T>(mesh, rotator);
 }
 
 void rotateMeshXYby(scene::IMesh *mesh, f64 degrees)
 {
-	rotateMesh<&v3f::X, &v3f::Y>(mesh, degrees);
+	if (mesh->getMeshBuffer(0)->getVertexType() == video::EVT_2COLORS)
+		rotateMesh<video::S3DVertex2Colors, &v3f::X, &v3f::Y>(mesh, degrees);
+	else
+		rotateMesh<video::S3DVertex, &v3f::X, &v3f::Y>(mesh, degrees);
 }
 
 void rotateMeshXZby(scene::IMesh *mesh, f64 degrees)
 {
-	rotateMesh<&v3f::X, &v3f::Z>(mesh, degrees);
+	if (mesh->getMeshBuffer(0)->getVertexType() == video::EVT_2COLORS)
+		rotateMesh<video::S3DVertex2Colors, &v3f::X, &v3f::Z>(mesh, degrees);
+	else
+		rotateMesh<video::S3DVertex, &v3f::X, &v3f::Z>(mesh, degrees);
 }
 
 void rotateMeshYZby(scene::IMesh *mesh, f64 degrees)
 {
-	rotateMesh<&v3f::Y, &v3f::Z>(mesh, degrees);
+	if (mesh->getMeshBuffer(0)->getVertexType() == video::EVT_2COLORS)
+		rotateMesh<video::S3DVertex2Colors, &v3f::Y, &v3f::Z>(mesh, degrees);
+	else
+		rotateMesh<video::S3DVertex, &v3f::Y, &v3f::Z>(mesh, degrees);
 }
 
 void rotateMeshBy6dFacedir(scene::IMesh *mesh, int facedir)
@@ -353,34 +420,62 @@ bool checkMeshNormals(scene::IMesh *mesh)
 	return true;
 }
 
+scene::SMesh *convertMeshTo2Colors(scene::IMesh *mesh)
+{
+	scene::SMesh *new_mesh = new scene::SMesh();
+
+	for (u32 i = 0; i < mesh->getMeshBufferCount(); i++) {
+		scene::IMeshBuffer *mb = mesh->getMeshBuffer(i);
+		video::S3DVertex *v = static_cast<video::S3DVertex *>(mb->getVertices());
+
+		scene::SMeshBuffer2Colors *new_mb = new scene::SMeshBuffer2Colors();
+		core::array<video::S3DVertex2Colors> new_vertices;
+
+		for (u32 j = 0; j < mb->getVertexCount(); j++)
+			new_vertices.push_back(video::S3DVertex2Colors(v[j].Pos, v[j].Normal, v[j].Color, v[j].TCoords));
+
+		new_mb->append(new_vertices.pointer(), new_vertices.size(), mb->getIndices(), mb->getIndexCount());
+		new_mesh->addMeshBuffer(new_mb);
+		new_mb->drop();
+	}
+
+	return new_mesh;
+}
+
 scene::IMeshBuffer* cloneMeshBuffer(scene::IMeshBuffer *mesh_buffer)
 {
 	switch (mesh_buffer->getVertexType()) {
 	case video::EVT_STANDARD: {
-		video::S3DVertex *v = (video::S3DVertex *) mesh_buffer->getVertices();
-		u16 *indices = mesh_buffer->getIndices();
+		video::S3DVertex *v = static_cast<video::S3DVertex *>(mesh_buffer->getVertices());
 		scene::SMeshBuffer *cloned_buffer = new scene::SMeshBuffer();
-		cloned_buffer->append(v, mesh_buffer->getVertexCount(), indices,
+		cloned_buffer->append(v, mesh_buffer->getVertexCount(), mesh_buffer->getIndices(),
 			mesh_buffer->getIndexCount());
 		return cloned_buffer;
 	}
 	case video::EVT_2TCOORDS: {
 		video::S3DVertex2TCoords *v =
-			(video::S3DVertex2TCoords *) mesh_buffer->getVertices();
-		u16 *indices = mesh_buffer->getIndices();
+			static_cast<video::S3DVertex2TCoords *>(mesh_buffer->getVertices());
 		scene::SMeshBufferLightMap *cloned_buffer =
 			new scene::SMeshBufferLightMap();
-		cloned_buffer->append(v, mesh_buffer->getVertexCount(), indices,
+		cloned_buffer->append(v, mesh_buffer->getVertexCount(), mesh_buffer->getIndices(),
 			mesh_buffer->getIndexCount());
 		return cloned_buffer;
 	}
 	case video::EVT_TANGENTS: {
 		video::S3DVertexTangents *v =
-			(video::S3DVertexTangents *) mesh_buffer->getVertices();
-		u16 *indices = mesh_buffer->getIndices();
+			static_cast<video::S3DVertexTangents *>(mesh_buffer->getVertices());
 		scene::SMeshBufferTangents *cloned_buffer =
 			new scene::SMeshBufferTangents();
-		cloned_buffer->append(v, mesh_buffer->getVertexCount(), indices,
+		cloned_buffer->append(v, mesh_buffer->getVertexCount(), mesh_buffer->getIndices(),
+			mesh_buffer->getIndexCount());
+		return cloned_buffer;
+	}
+	case video::EVT_2COLORS: {
+		video::S3DVertex2Colors *v =
+			static_cast<video::S3DVertex2Colors *>(mesh_buffer->getVertices());
+		scene::SMeshBuffer2Colors *cloned_buffer =
+			new scene::SMeshBuffer2Colors();
+		cloned_buffer->append(v, mesh_buffer->getVertexCount(), mesh_buffer->getIndices(),
 			mesh_buffer->getIndexCount());
 		return cloned_buffer;
 	}

--- a/src/client/mesh.h
+++ b/src/client/mesh.h
@@ -38,6 +38,8 @@ void applyFacesShading(video::SColor &color, const v3f &normal);
 */
 scene::IAnimatedMesh* createCubeMesh(v3f scale);
 
+scene::IAnimatedMesh* createCubeMesh2Colors(v3f scale);
+
 /*
 	Multiplies each vertex coordinate by the specified scaling factors
 	(componentwise vector multiplication).
@@ -53,11 +55,16 @@ void translateMesh(scene::IMesh *mesh, v3f vec);
  * Sets a constant color for all vertices in the mesh buffer.
  */
 void setMeshBufferColor(scene::IMeshBuffer *buf, const video::SColor &color);
+void setMeshBuffer2Colors(scene::IMeshBuffer *buf,
+	const video::SColor &color, const core::vector3df &color2=core::vector3df(1.0f));
 
 /*
 	Set a constant color for all vertices in the mesh
 */
 void setMeshColor(scene::IMesh *mesh, const video::SColor &color);
+
+//void setMesh2ColorsColor(scene::IMesh *mesh, const video::SColor &color,
+//	const video::SColor &hw_color=video::SColor(0xFFFFFFFF));
 
 
 /*
@@ -75,18 +82,8 @@ void setAnimatedMeshColor(scene::IAnimatedMeshSceneNode *node, const video::SCol
  * Overwrites the color of a mesh buffer.
  * The color is darkened based on the normal vector of the vertices.
  */
-void colorizeMeshBuffer(scene::IMeshBuffer *buf, const video::SColor *buffercolor);
-
-/*
-	Set the color of all vertices in the mesh.
-	For each vertex, determine the largest absolute entry in
-	the normal vector, and choose one of colorX, colorY or
-	colorZ accordingly.
-*/
-void setMeshColorByNormalXYZ(scene::IMesh *mesh,
-		const video::SColor &colorX,
-		const video::SColor &colorY,
-		const video::SColor &colorZ);
+void colorizeMeshBuffer2Colors(scene::IMeshBuffer *buf,
+	const video::SColor &color, const core::vector3df &color2=core::vector3df(1.0f));
 
 void setMeshColorByNormal(scene::IMesh *mesh, const v3f &normal,
 		const video::SColor &color);
@@ -135,9 +132,11 @@ void recalculateBoundingBox(scene::IMesh *src_mesh);
  */
 bool checkMeshNormals(scene::IMesh *mesh);
 
+scene::SMesh *convertMeshTo2Colors(scene::IMesh *mesh);
+
 /*
 	Set the MinFilter, MagFilter and AnisotropicFilter properties of a texture
 	layer according to the three relevant boolean values found in the Minetest
 	settings.
-*/ 
+*/
 void setMaterialFilters(video::SMaterialLayer &tex, bool bilinear, bool trilinear, bool anisotropic);

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "client/mesh.h"
 
-void MeshCollector::append(const TileSpec &tile, const video::S3DVertex *vertices,
+void MeshCollector::append(const TileSpec &tile, const video::S3DVertex2Colors *vertices,
 		u32 numVertices, const u16 *indices, u32 numIndices)
 {
 	for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
@@ -34,7 +34,7 @@ void MeshCollector::append(const TileSpec &tile, const video::S3DVertex *vertice
 	}
 }
 
-void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *vertices,
+void MeshCollector::append(const TileLayer &layer, const video::S3DVertex2Colors *vertices,
 		u32 numVertices, const u16 *indices, u32 numIndices, u8 layernum,
 		bool use_scale)
 {
@@ -47,7 +47,7 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 	u32 vertex_count = p.vertices.size();
 	for (u32 i = 0; i < numVertices; i++) {
 		p.vertices.emplace_back(vertices[i].Pos + offset, vertices[i].Normal,
-				vertices[i].Color, scale * vertices[i].TCoords);
+				vertices[i].Color, scale * vertices[i].TCoords, v3f(1.0f));
 		m_bounding_radius_sq = std::max(m_bounding_radius_sq,
 				(vertices[i].Pos - m_center_pos).getLengthSQ());
 	}
@@ -56,7 +56,7 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 		p.indices.push_back(indices[i] + vertex_count);
 }
 
-void MeshCollector::append(const TileSpec &tile, const video::S3DVertex *vertices,
+void MeshCollector::append(const TileSpec &tile, const video::S3DVertex2Colors *vertices,
 		u32 numVertices, const u16 *indices, u32 numIndices, v3f pos,
 		video::SColor c, u8 light_source)
 {
@@ -69,7 +69,7 @@ void MeshCollector::append(const TileSpec &tile, const video::S3DVertex *vertice
 	}
 }
 
-void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *vertices,
+void MeshCollector::append(const TileLayer &layer, const video::S3DVertex2Colors *vertices,
 		u32 numVertices, const u16 *indices, u32 numIndices, v3f pos,
 		video::SColor c, u8 light_source, u8 layernum, bool use_scale)
 {
@@ -86,7 +86,7 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 			applyFacesShading(color, vertices[i].Normal);
 		auto vpos = vertices[i].Pos + pos + offset;
 		p.vertices.emplace_back(vpos, vertices[i].Normal, color,
-				scale * vertices[i].TCoords);
+				scale * vertices[i].TCoords, v3f(1.0f));
 		m_bounding_radius_sq = std::max(m_bounding_radius_sq,
 				(vpos - m_center_pos).getLengthSQ());
 	}

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -29,7 +29,7 @@ struct PreMeshBuffer
 {
 	TileLayer layer;
 	std::vector<u16> indices;
-	std::vector<video::S3DVertex> vertices;
+	std::vector<video::S3DVertex2Colors> vertices;
 
 	PreMeshBuffer() = default;
 	explicit PreMeshBuffer(const TileLayer &layer) : layer(layer) {}
@@ -48,20 +48,20 @@ struct MeshCollector
 	MeshCollector(const v3f center_pos, v3f offset = v3f()) : m_center_pos(center_pos), offset(offset) {}
 
 	void append(const TileSpec &material,
-			const video::S3DVertex *vertices, u32 numVertices,
+			const video::S3DVertex2Colors *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices);
 	void append(const TileSpec &material,
-			const video::S3DVertex *vertices, u32 numVertices,
+			const video::S3DVertex2Colors *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices,
 			v3f pos, video::SColor c, u8 light_source);
 
 private:
 	void append(const TileLayer &material,
-			const video::S3DVertex *vertices, u32 numVertices,
+			const video::S3DVertex2Colors *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices,
 			u8 layernum, bool use_scale = false);
 	void append(const TileLayer &material,
-			const video::S3DVertex *vertices, u32 numVertices,
+			const video::S3DVertex2Colors *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices,
 			v3f pos, video::SColor c, u8 light_source,
 			u8 layernum, bool use_scale = false);

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -530,20 +530,22 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 	case TILE_MATERIAL_OPAQUE:
 	case TILE_MATERIAL_LIQUID_OPAQUE:
 	case TILE_MATERIAL_WAVING_LIQUID_OPAQUE:
-		shaderinfo.base_material = video::EMT_SOLID;
+		shaderinfo.base_material = name == "nodes_shader" ? video::EMT_SOLID_2COLORS : video::EMT_SOLID;
 		break;
 	case TILE_MATERIAL_ALPHA:
 	case TILE_MATERIAL_PLAIN_ALPHA:
 	case TILE_MATERIAL_LIQUID_TRANSPARENT:
 	case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
-		shaderinfo.base_material = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+		shaderinfo.base_material = name == "nodes_shader" ? video::EMT_TRANSPARENT_ALPHA_CHANNEL_2COLORS :
+			video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 		break;
 	case TILE_MATERIAL_BASIC:
 	case TILE_MATERIAL_PLAIN:
 	case TILE_MATERIAL_WAVING_LEAVES:
 	case TILE_MATERIAL_WAVING_PLANTS:
 	case TILE_MATERIAL_WAVING_LIQUID_BASIC:
-		shaderinfo.base_material = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+		shaderinfo.base_material = name == "nodes_shader" ? video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF_2COLORS :
+			video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
 		break;
 	}
 	shaderinfo.material = shaderinfo.base_material;
@@ -635,9 +637,13 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 	if (strstr(renderer, "GC7000"))
 		use_discard = true;
 	if (use_discard) {
-		if (shaderinfo.base_material == video::EMT_TRANSPARENT_ALPHA_CHANNEL)
+		if (shaderinfo.base_material == video::EMT_TRANSPARENT_ALPHA_CHANNEL ||
+			shaderinfo.base_material == video::EMT_TRANSPARENT_ALPHA_CHANNEL_2COLORS
+		)
 			shaders_header << "#define USE_DISCARD 1\n";
-		else if (shaderinfo.base_material == video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF)
+		else if (shaderinfo.base_material == video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF ||
+			shaderinfo.base_material == video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF_2COLORS
+		)
 			shaders_header << "#define USE_DISCARD_REF 1\n";
 	}
 

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -584,9 +584,14 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 			attribute lowp vec4 inVertexColor;
 			attribute mediump vec4 inTexCoord0;
 			attribute mediump vec3 inVertexNormal;
-			attribute mediump vec4 inVertexTangent;
 			attribute mediump vec4 inVertexBinormal;
 		)";
+
+		if (name == "nodes_shader")
+			vertex_header += "attribute mediump vec3 inVertexColor2;\n";
+		else
+			vertex_header += "attribute mediump vec4 inVertexTangent;\n";
+
 		fragment_header = R"(
 			precision mediump float;
 		)";
@@ -606,11 +611,17 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 			#define inVertexColor gl_Color
 			#define inTexCoord0 gl_MultiTexCoord0
 			#define inVertexNormal gl_Normal
-			#define inVertexTangent gl_MultiTexCoord1
-			#define inVertexBinormal gl_MultiTexCoord2
 		)";
+
+		if (name == "nodes_shader")
+			vertex_header += "#define inVertexColor2 gl_MultiTexCoord1\n";
+		else
+			vertex_header += "#define inVertexTangent gl_MultiTexCoord1\n";
+
+		vertex_header += "#define inVertexBinormal gl_MultiTexCoord2\n";
 	}
 
+	infostream << "vertex_header: " << vertex_header << std::endl;
 	// map legacy semantic texture names to texture identifiers
 	fragment_header += R"(
 		#define baseTexture texture0

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -26,19 +26,19 @@ void TileLayer::applyMaterialOptions(video::SMaterial &material) const
 	case TILE_MATERIAL_OPAQUE:
 	case TILE_MATERIAL_LIQUID_OPAQUE:
 	case TILE_MATERIAL_WAVING_LIQUID_OPAQUE:
-		material.MaterialType = video::EMT_SOLID;
+		material.MaterialType = video::EMT_SOLID_2COLORS;
 		break;
 	case TILE_MATERIAL_BASIC:
 	case TILE_MATERIAL_WAVING_LEAVES:
 	case TILE_MATERIAL_WAVING_PLANTS:
 	case TILE_MATERIAL_WAVING_LIQUID_BASIC:
 		material.MaterialTypeParam = 0.5;
-		material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+		material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF_2COLORS;
 		break;
 	case TILE_MATERIAL_ALPHA:
 	case TILE_MATERIAL_LIQUID_TRANSPARENT:
 	case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
-		material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+		material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_2COLORS;
 		break;
 	default:
 		break;

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -45,23 +45,23 @@ static scene::IMesh *createExtrusionMesh(int resolution_x, int resolution_y)
 {
 	const f32 r = 0.5;
 
-	scene::IMeshBuffer *buf = new scene::SMeshBuffer();
+	scene::IMeshBuffer *buf = new scene::SMeshBuffer2Colors();
 	video::SColor c(255,255,255,255);
 	v3f scale(1.0, 1.0, 0.1);
 
 	// Front and back
 	{
-		video::S3DVertex vertices[8] = {
+		video::S3DVertex2Colors vertices[8] = {
 			// z-
-			video::S3DVertex(-r,+r,-r, 0,0,-1, c, 0,0),
-			video::S3DVertex(+r,+r,-r, 0,0,-1, c, 1,0),
-			video::S3DVertex(+r,-r,-r, 0,0,-1, c, 1,1),
-			video::S3DVertex(-r,-r,-r, 0,0,-1, c, 0,1),
+			video::S3DVertex2Colors(-r,+r,-r, 0,0,-1, c, 0,0),
+			video::S3DVertex2Colors(+r,+r,-r, 0,0,-1, c, 1,0),
+			video::S3DVertex2Colors(+r,-r,-r, 0,0,-1, c, 1,1),
+			video::S3DVertex2Colors(-r,-r,-r, 0,0,-1, c, 0,1),
 			// z+
-			video::S3DVertex(-r,+r,+r, 0,0,+1, c, 0,0),
-			video::S3DVertex(-r,-r,+r, 0,0,+1, c, 0,1),
-			video::S3DVertex(+r,-r,+r, 0,0,+1, c, 1,1),
-			video::S3DVertex(+r,+r,+r, 0,0,+1, c, 1,0),
+			video::S3DVertex2Colors(-r,+r,+r, 0,0,+1, c, 0,0),
+			video::S3DVertex2Colors(-r,-r,+r, 0,0,+1, c, 0,1),
+			video::S3DVertex2Colors(+r,-r,+r, 0,0,+1, c, 1,1),
+			video::S3DVertex2Colors(+r,+r,+r, 0,0,+1, c, 1,0),
 		};
 		u16 indices[12] = {0,1,2,2,3,0,4,5,6,6,7,4};
 		buf->append(vertices, 8, indices, 12);
@@ -76,17 +76,17 @@ static scene::IMesh *createExtrusionMesh(int resolution_x, int resolution_y)
 		f32 x1 = pixelpos_x + pixelsize_x;
 		f32 tex0 = (i + 0.1) * pixelsize_x;
 		f32 tex1 = (i + 0.9) * pixelsize_x;
-		video::S3DVertex vertices[8] = {
+		video::S3DVertex2Colors vertices[8] = {
 			// x-
-			video::S3DVertex(x0,-r,-r, -1,0,0, c, tex0,1),
-			video::S3DVertex(x0,-r,+r, -1,0,0, c, tex1,1),
-			video::S3DVertex(x0,+r,+r, -1,0,0, c, tex1,0),
-			video::S3DVertex(x0,+r,-r, -1,0,0, c, tex0,0),
+			video::S3DVertex2Colors(x0,-r,-r, -1,0,0, c, tex0,1),
+			video::S3DVertex2Colors(x0,-r,+r, -1,0,0, c, tex1,1),
+			video::S3DVertex2Colors(x0,+r,+r, -1,0,0, c, tex1,0),
+			video::S3DVertex2Colors(x0,+r,-r, -1,0,0, c, tex0,0),
 			// x+
-			video::S3DVertex(x1,-r,-r, +1,0,0, c, tex0,1),
-			video::S3DVertex(x1,+r,-r, +1,0,0, c, tex0,0),
-			video::S3DVertex(x1,+r,+r, +1,0,0, c, tex1,0),
-			video::S3DVertex(x1,-r,+r, +1,0,0, c, tex1,1),
+			video::S3DVertex2Colors(x1,-r,-r, +1,0,0, c, tex0,1),
+			video::S3DVertex2Colors(x1,+r,-r, +1,0,0, c, tex0,0),
+			video::S3DVertex2Colors(x1,+r,+r, +1,0,0, c, tex1,0),
+			video::S3DVertex2Colors(x1,-r,+r, +1,0,0, c, tex1,1),
 		};
 		u16 indices[12] = {0,1,2,2,3,0,4,5,6,6,7,4};
 		buf->append(vertices, 8, indices, 12);
@@ -97,17 +97,17 @@ static scene::IMesh *createExtrusionMesh(int resolution_x, int resolution_y)
 		f32 y1 = -pixelpos_y;
 		f32 tex0 = (i + 0.1) * pixelsize_y;
 		f32 tex1 = (i + 0.9) * pixelsize_y;
-		video::S3DVertex vertices[8] = {
+		video::S3DVertex2Colors vertices[8] = {
 			// y-
-			video::S3DVertex(-r,y0,-r, 0,-1,0, c, 0,tex0),
-			video::S3DVertex(+r,y0,-r, 0,-1,0, c, 1,tex0),
-			video::S3DVertex(+r,y0,+r, 0,-1,0, c, 1,tex1),
-			video::S3DVertex(-r,y0,+r, 0,-1,0, c, 0,tex1),
+			video::S3DVertex2Colors(-r,y0,-r, 0,-1,0, c, 0,tex0),
+			video::S3DVertex2Colors(+r,y0,-r, 0,-1,0, c, 1,tex0),
+			video::S3DVertex2Colors(+r,y0,+r, 0,-1,0, c, 1,tex1),
+			video::S3DVertex2Colors(-r,y0,+r, 0,-1,0, c, 0,tex1),
 			// y+
-			video::S3DVertex(-r,y1,-r, 0,+1,0, c, 0,tex0),
-			video::S3DVertex(-r,y1,+r, 0,+1,0, c, 0,tex1),
-			video::S3DVertex(+r,y1,+r, 0,+1,0, c, 1,tex1),
-			video::S3DVertex(+r,y1,-r, 0,+1,0, c, 1,tex0),
+			video::S3DVertex2Colors(-r,y1,-r, 0,+1,0, c, 0,tex0),
+			video::S3DVertex2Colors(-r,y1,+r, 0,+1,0, c, 0,tex1),
+			video::S3DVertex2Colors(+r,y1,+r, 0,+1,0, c, 1,tex1),
+			video::S3DVertex2Colors(+r,y1,-r, 0,+1,0, c, 1,tex0),
 		};
 		u16 indices[12] = {0,1,2,2,3,0,4,5,6,6,7,4};
 		buf->append(vertices, 8, indices, 12);
@@ -144,7 +144,7 @@ public:
 			m_extrusion_meshes[resolution] =
 				createExtrusionMesh(resolution, resolution);
 		}
-		m_cube = createCubeMesh(v3f(1.0, 1.0, 1.0));
+		m_cube = createCubeMesh2Colors(v3f(1.0, 1.0, 1.0));
 	}
 	// Destructor
 	virtual ~ExtrusionMeshCache()
@@ -345,15 +345,15 @@ static scene::SMesh *createSpecialNodeMesh(Client *client, MapNode n,
 				p.layer.texture = frame.texture;
 				p.layer.normal_texture = frame.normal_texture;
 			}
-			for (video::S3DVertex &v : p.vertices) {
+			for (video::S3DVertex2Colors &v : p.vertices)
 				v.Color.setAlpha(255);
-			}
-			scene::SMeshBuffer *buf = new scene::SMeshBuffer();
+
+			scene::SMeshBuffer2Colors *buf = new scene::SMeshBuffer2Colors();
 			buf->Material.setTexture(0, p.layer.texture);
 			p.layer.applyMaterialOptions(buf->Material);
-			mesh->addMeshBuffer(buf);
 			buf->append(&p.vertices[0], p.vertices.size(),
 					&p.indices[0], p.indices.size());
+			mesh->addMeshBuffer(buf);
 			buf->drop();
 			colors->push_back(
 				ItemPartColor(p.layer.has_color, p.layer.color));
@@ -374,7 +374,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 	scene::SMesh *mesh = nullptr;
 
 	if (m_enable_shaders) {
-		u32 shader_id = shdrsrc->getShader("object_shader", TILE_MATERIAL_BASIC, NDT_NORMAL);
+		u32 shader_id = shdrsrc->getShader("nodes_shader", TILE_MATERIAL_BASIC, NDT_NORMAL);
 		m_material_type = shdrsrc->getShaderInfo(shader_id).material;
 	}
 
@@ -505,33 +505,35 @@ void WieldMeshSceneNode::setColor(video::SColor c)
 	if (!mesh)
 		return;
 
-	u8 red = c.getRed();
-	u8 green = c.getGreen();
-	u8 blue = c.getBlue();
-
 	const u32 mc = mesh->getMeshBufferCount();
 	if (mc > m_colors.size())
 		m_colors.resize(mc);
 	for (u32 j = 0; j < mc; j++) {
-		video::SColor bc(m_base_color);
-		m_colors[j].applyOverride(bc);
+		video::SColor hwcolor(m_base_color);
+		m_colors[j].applyOverride(hwcolor);
+
+		hwcolor.setRed(hwcolor.getRed() / 255);
+		hwcolor.setGreen(hwcolor.getGreen() / 255);
+		hwcolor.setBlue(hwcolor.getBlue() / 255);
+
 		video::SColor buffercolor(255,
-			bc.getRed() * red / 255,
-			bc.getGreen() * green / 255,
-			bc.getBlue() * blue / 255);
+			hwcolor.getRed() * c.getRed(),
+			hwcolor.getGreen() * c.getGreen(),
+			hwcolor.getBlue() * c.getBlue());
+
 		scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
 
 		if (m_colors[j].needColorize(buffercolor)) {
 			buf->setDirty(scene::EBT_VERTEX);
 			if (m_enable_shaders)
-				setMeshBufferColor(buf, buffercolor);
+				setMeshBuffer2Colors(buf, c, v3f(hwcolor.getRed(), hwcolor.getGreen(), hwcolor.getBlue()));
 			else
-				colorizeMeshBuffer(buf, &buffercolor);
+				colorizeMeshBuffer2Colors(buf, c, v3f(hwcolor.getRed(), hwcolor.getGreen(), hwcolor.getBlue()));
 		}
 	}
 }
 
-void WieldMeshSceneNode::setNodeLightColor(video::SColor color)
+/*void WieldMeshSceneNode::setNodeLightColor(video::SColor color)
 {
 	if (!m_meshnode)
 		return;
@@ -544,7 +546,7 @@ void WieldMeshSceneNode::setNodeLightColor(video::SColor color)
 	} else {
 		setColor(color);
 	}
-}
+}*/
 
 void WieldMeshSceneNode::render()
 {

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -196,7 +196,7 @@ static ExtrusionMeshCache *g_extrusion_mesh_cache = nullptr;
 
 WieldMeshSceneNode::WieldMeshSceneNode(scene::ISceneManager *mgr, s32 id, bool lighting):
 	scene::ISceneNode(mgr->getRootSceneNode(), mgr, id),
-	m_material_type(video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF),
+	m_material_type(video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF_2COLORS),
 	m_lighting(lighting)
 {
 	m_enable_shaders = g_settings->getBool("enable_shaders");
@@ -666,7 +666,7 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 		for (u32 i = 0; i < mesh->getMeshBufferCount(); ++i) {
 			scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
 			video::SMaterial &material = buf->getMaterial();
-			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_2COLORS;
 			material.MaterialTypeParam = 0.5f;
 			material.forEachTexture([] (auto &tex) {
 				tex.MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
@@ -727,7 +727,7 @@ scene::SMesh *getExtrudedMesh(ITextureSource *tsrc,
 		});
 		material.BackfaceCulling = true;
 		material.Lighting = false;
-		material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+		material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_2COLORS;
 		material.MaterialTypeParam = 0.5f;
 	}
 	scaleMesh(mesh, v3f(2.0, 2.0, 2.0));

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -973,7 +973,9 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 	if (drawtype == NDT_MESH && !mesh.empty()) {
 		// Meshnode drawtype
 		// Read the mesh and apply scale
-		mesh_ptr[0] = client->getMesh(mesh);
+		scene::IMesh *loaded_mesh = client->getMesh(mesh);
+		mesh_ptr[0] = convertMeshTo2Colors(loaded_mesh);
+		loaded_mesh->drop();
 		if (mesh_ptr[0]){
 			v3f scale = v3f(1.0, 1.0, 1.0) * BS * visual_scale;
 			scaleMesh(mesh_ptr[0], scale);

--- a/src/unittest/mesh_compare.cpp
+++ b/src/unittest/mesh_compare.cpp
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <map>
 #include <stdexcept>
 
-static std::vector<Triangle> expandMesh(const std::vector<video::S3DVertex> &vertices, const std::vector<u16> &indices)
+static std::vector<Triangle> expandMesh(const std::vector<video::S3DVertex2Colors> &vertices, const std::vector<u16> &indices)
 {
 	const int n_indices = indices.size();
 	const int n_triangles = n_indices / 3;
@@ -50,7 +50,7 @@ static Triangle sortTriangle(Triangle t)
 	throw std::invalid_argument("got bad triangle");
 }
 
-static std::vector<Triangle> canonicalizeMesh(const std::vector<video::S3DVertex> &vertices, const std::vector<u16> &indices)
+static std::vector<Triangle> canonicalizeMesh(const std::vector<video::S3DVertex2Colors> &vertices, const std::vector<u16> &indices)
 {
 	std::vector<Triangle> mesh = expandMesh(vertices, indices);
 	for (auto &triangle: mesh)
@@ -59,13 +59,13 @@ static std::vector<Triangle> canonicalizeMesh(const std::vector<video::S3DVertex
 	return mesh;
 }
 
-bool checkMeshEqual(const std::vector<video::S3DVertex> &vertices, const std::vector<u16> &indices, const std::vector<Triangle> &expected)
+bool checkMeshEqual(const std::vector<video::S3DVertex2Colors> &vertices, const std::vector<u16> &indices, const std::vector<Triangle> &expected)
 {
 	auto actual = canonicalizeMesh(vertices, indices);
 	return actual == expected;
 }
 
-bool checkMeshEqual(const std::vector<video::S3DVertex> &vertices, const std::vector<u16> &indices, const std::vector<Quad> &expected)
+bool checkMeshEqual(const std::vector<video::S3DVertex2Colors> &vertices, const std::vector<u16> &indices, const std::vector<Quad> &expected)
 {
 	using QuadRefCount = std::array<int, 4>;
 	struct QuadRef {

--- a/src/unittest/mesh_compare.h
+++ b/src/unittest/mesh_compare.h
@@ -25,18 +25,18 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 /// Represents a triangle as three vertices.
 /// “Smallest” (according to <) vertex is expected to be first, others should follow in the counter-clockwise order.
-using Triangle = std::array<video::S3DVertex, 3>;
+using Triangle = std::array<video::S3DVertex2Colors, 3>;
 
 /// Represents a quad as four vertices.
 /// Vertices should be in the counter-clockwise order.
-using Quad = std::array<video::S3DVertex, 4>;
+using Quad = std::array<video::S3DVertex2Colors, 4>;
 
 /// Compare two meshes for equality.
 /// @param vertices Vertices of the first mesh. Order doesn’t matter.
 /// @param indices Indices of the first mesh. Triangle order doesn’t matter. Vertex order in a triangle only matters for winding.
 /// @param expected The second mesh, in an expanded form. Must be sorted.
 /// @returns Whether the two meshes are equal.
-[[nodiscard]] bool checkMeshEqual(const std::vector<video::S3DVertex> &vertices, const std::vector<u16> &indices, const std::vector<Triangle> &expected);
+[[nodiscard]] bool checkMeshEqual(const std::vector<video::S3DVertex2Colors> &vertices, const std::vector<u16> &indices, const std::vector<Triangle> &expected);
 
 /// Compare two meshes for equality.
 /// @param vertices Vertices of the first mesh. Order doesn’t matter.
@@ -44,4 +44,4 @@ using Quad = std::array<video::S3DVertex, 4>;
 /// @param expected The second mesh, in a quad form.
 /// @returns Whether the two meshes are equal.
 /// @note There are two ways to split a quad into 2 triangles; either is allowed.
-[[nodiscard]] bool checkMeshEqual(const std::vector<video::S3DVertex> &vertices, const std::vector<u16> &indices, const std::vector<Quad> &expected);
+[[nodiscard]] bool checkMeshEqual(const std::vector<video::S3DVertex2Colors> &vertices, const std::vector<u16> &indices, const std::vector<Quad> &expected);


### PR DESCRIPTION
Fixes #14343 , #14091 and also it is necessary for the colored lighting support in the future.

What this does:

- Adds a new vertex type `video::S3DVertex2Colors` with two color attributes.
- Replaces the current vertex type of the mapblock meshes, wield and inv stacks meshes to that new type. The first color is used as the half-baked color (artificial), the second one is as the hardware one.
- Adapts all current mesh.cpp functions for working with the meshbuffers of the new type.
- Adds a direct reading the standard Irrlicht material shaders code from the substrings instead of the files in order to avoid duplicating the most part of the code.
- Forces the opengl driver to use the shader-based pipeline for the Irrlicht materials to support passing the second color as the `GL_TEXTURE1` UV. 

## To do

This PR is a Work in Progress.

- [ ] Fix the compilation errors of the Irrlicht shaders for `COpenGLDriver`.
- [ ] Support the shaders-based material rendering for  `OGLES1`/`OGLES2`.

## How to test
Test any own nodes with the paramtype2 `color`, `colorwallmounted`, `colorfacedir` and `color4dir` with various video drivers enabled.
