### PR TITLE
Log node/ore name when detecting deprecated fields

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1316,7 +1316,7 @@ void pushnode(lua_State *L, const MapNode &n)
 
 /******************************************************************************/
 void warn_if_field_exists(lua_State *L, int table, const char *fieldname,
-		const std::string_view name, const std::string_view message)
+		std::string_view name, std::string_view message)
 {
 	lua_getfield(L, table, fieldname);
 	if (!lua_isnil(L, -1)) {

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -760,7 +760,7 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 
 	f.setDefaultAlphaMode();
 
-	warn_if_field_exists(L, index, "alpha",
+	warn_if_field_exists(L, index, "alpha", "node " + f.name,
 		"Obsolete, only limited compatibility provided; "
 		"replaced by \"use_texture_alpha\"");
 	if (getintfield_default(L, index, "alpha", 255) != 255)
@@ -768,7 +768,7 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 
 	lua_getfield(L, index, "use_texture_alpha");
 	if (lua_isboolean(L, -1)) {
-		warn_if_field_exists(L, index, "use_texture_alpha",
+		warn_if_field_exists(L, index, "use_texture_alpha", "node " + f.name,
 			"Boolean values are deprecated; use the new choices");
 		if (lua_toboolean(L, -1))
 			f.alpha = (f.drawtype == NDT_NORMAL) ? ALPHAMODE_CLIP : ALPHAMODE_BLEND;
@@ -1315,12 +1315,12 @@ void pushnode(lua_State *L, const MapNode &n)
 }
 
 /******************************************************************************/
-void warn_if_field_exists(lua_State *L, int table,
-		const char *name, const std::string &message)
+void warn_if_field_exists(lua_State *L, int table, const char *name, 
+		const std::string &nodename, const std::string &message)
 {
 	lua_getfield(L, table, name);
 	if (!lua_isnil(L, -1)) {
-		warningstream << "Field \"" << name << "\": "
+		warningstream << "Field \"" << name << "\" on " << nodename << ": "
 				<< message << std::endl;
 		infostream << script_get_backtrace(L) << std::endl;
 	}

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1316,7 +1316,7 @@ void pushnode(lua_State *L, const MapNode &n)
 
 /******************************************************************************/
 void warn_if_field_exists(lua_State *L, int table, const char *name, 
-		const std::string &nodename, const std::string &message)
+		const std::string &name, const std::string &message)
 {
 	lua_getfield(L, table, name);
 	if (!lua_isnil(L, -1)) {

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1316,12 +1316,15 @@ void pushnode(lua_State *L, const MapNode &n)
 
 /******************************************************************************/
 void warn_if_field_exists(lua_State *L, int table, const char *fieldname,
-		const std::string &name, const std::string &message)
+		const std::string_view name, const std::string_view message)
 {
 	lua_getfield(L, table, fieldname);
 	if (!lua_isnil(L, -1)) {
-		warningstream << "Field \"" << fieldname << "\" on " << name << ": "
-				<< message << std::endl;
+		warningstream << "Field \"" << fieldname << "\"";
+		if (!name.empty()) {
+			warningstream << " on " << name;
+		}
+		warningstream << ": " << message << std::endl;
 		infostream << script_get_backtrace(L) << std::endl;
 	}
 	lua_pop(L, 1);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1320,7 +1320,7 @@ void warn_if_field_exists(lua_State *L, int table, const char *name,
 {
 	lua_getfield(L, table, name);
 	if (!lua_isnil(L, -1)) {
-		warningstream << "Field \"" << name << "\" on " << nodename << ": "
+		warningstream << "Field \"" << name << "\" on " << name << ": "
 				<< message << std::endl;
 		infostream << script_get_backtrace(L) << std::endl;
 	}

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1315,7 +1315,7 @@ void pushnode(lua_State *L, const MapNode &n)
 }
 
 /******************************************************************************/
-void warn_if_field_exists(lua_State *L, int table, const char *fieldname, 
+void warn_if_field_exists(lua_State *L, int table, const char *fieldname,
 		const std::string &name, const std::string &message)
 {
 	lua_getfield(L, table, fieldname);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1318,7 +1318,7 @@ void pushnode(lua_State *L, const MapNode &n)
 void warn_if_field_exists(lua_State *L, int table, const char *fieldname, 
 		const std::string &name, const std::string &message)
 {
-	lua_getfield(L, table, name);
+	lua_getfield(L, table, fieldname);
 	if (!lua_isnil(L, -1)) {
 		warningstream << "Field \"" << fieldname << "\" on " << name << ": "
 				<< message << std::endl;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1315,12 +1315,12 @@ void pushnode(lua_State *L, const MapNode &n)
 }
 
 /******************************************************************************/
-void warn_if_field_exists(lua_State *L, int table, const char *name, 
+void warn_if_field_exists(lua_State *L, int table, const char *fieldname, 
 		const std::string &name, const std::string &message)
 {
 	lua_getfield(L, table, name);
 	if (!lua_isnil(L, -1)) {
-		warningstream << "Field \"" << name << "\" on " << name << ": "
+		warningstream << "Field \"" << fieldname << "\" on " << name << ": "
 				<< message << std::endl;
 		infostream << script_get_backtrace(L) << std::endl;
 	}

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -120,8 +120,8 @@ void                push_aabb3f_vector  (lua_State *L, const std::vector<aabb3f>
 
 void                warn_if_field_exists(lua_State *L, int table,
                                          const char *fieldname,
-                                         const std::string &name,
-                                         const std::string &message);
+                                         const std::string_view name,
+                                         const std::string_view message);
 
 size_t write_array_slice_float(lua_State *L, int table_index, float *data,
 	v3u16 data_size, v3u16 slice_offset, v3u16 slice_size);

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -120,6 +120,7 @@ void                push_aabb3f_vector  (lua_State *L, const std::vector<aabb3f>
 
 void                warn_if_field_exists(lua_State *L, int table,
                                          const char *fieldname,
+                                         const std::string &name,
                                          const std::string &message);
 
 size_t write_array_slice_float(lua_State *L, int table_index, float *data,

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -120,8 +120,8 @@ void                push_aabb3f_vector  (lua_State *L, const std::vector<aabb3f>
 
 void                warn_if_field_exists(lua_State *L, int table,
                                          const char *fieldname,
-                                         const std::string_view name,
-                                         const std::string_view message);
+                                         std::string_view name,
+                                         std::string_view message);
 
 size_t write_array_slice_float(lua_State *L, int table_index, float *data,
 	v3u16 data_size, v3u16 slice_offset, v3u16 slice_size);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1354,7 +1354,7 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 	ore->flags          = 0;
 
 	//// Get noise_threshold
-	warn_if_field_exists(L, index, "noise_threshhold",
+	warn_if_field_exists(L, index, "noise_threshhold", "ore " + ore->name,
 		"Deprecated: new name is \"noise_threshold\".");
 
 	float nthresh;
@@ -1364,9 +1364,9 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 	ore->nthresh = nthresh;
 
 	//// Get y_min/y_max
-	warn_if_field_exists(L, index, "height_min",
+	warn_if_field_exists(L, index, "height_min", "ore " + ore->name,
 		"Deprecated: new name is \"y_min\".");
-	warn_if_field_exists(L, index, "height_max",
+	warn_if_field_exists(L, index, "height_max", "ore " + ore->name,
 		"Deprecated: new name is \"y_max\".");
 
 	int ymin, ymax;


### PR DESCRIPTION
This PR adds node/ore name into deprecated fields warning message, e.g. boolean value of alpha on node definitions. This enables modders to spot what codes are misusing the fields.

This PR does not fit into any [listed roadmaps](https://github.com/minetest/minetest/blob/master/doc/direction.md).

## To do

This PR is Ready for Review.

## How to test

Load a mod with deprecated fields on node or ore generation. Here are the test results of https://github.com/TumeniNodes/c_doors/commit/64d49a37538947658c59373e0a9c48f3756d4b4b, a mod registering nodes with boolean alpha:

```text
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:steel_Ldoor: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:steel_Ldoor_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:steel_Rdoor: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:steel_Rdoor_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:obsidian_glass_Ldoor: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:obsidian_glass_Ldoor_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:obsidian_glass_Rdoor: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:obsidian_glass_Rdoor_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:glass_Ldoor: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:glass_Ldoor_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:glass_Rdoor: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:glass_Rdoor_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:wood_Ldoor: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:wood_Ldoor_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:wood_Rdoor: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:wood_Rdoor_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_steel_win_sml: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_steel_win_sml_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_steel_win_lg: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_steel_win_lg_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_obsidian_glass_win_sml: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_obsidian_glass_win_sml_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_obsidian_glass_win_lg: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_obsidian_glass_win_lg_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_glass_win_sml: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_glass_win_sml_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_glass_win_lg: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_glass_win_lg_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_wood_win_sml: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_wood_win_sml_open: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_wood_win_lg: Boolean values are deprecated; use the new choices
WARNING[ServerStart]: Field "use_texture_alpha" on node c_doors:dbl_wood_win_lg_open: Boolean values are deprecated; use the new choices
```
