### PR TITLE
Remove enable_touch special case for C++ menu scaling

### DIFF
--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -59,14 +59,8 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
 		m_menumgr(menumgr),
 		m_remap_click_outside(remap_click_outside)
 {
-	m_gui_scale = std::max(g_settings->getFloat("gui_scaling"), 0.5f);
-	const float screen_dpi_scale = RenderingEngine::getDisplayDensity();
-
-	if (g_settings->getBool("enable_touch")) {
-		m_gui_scale *= 1.1f - 0.3f * screen_dpi_scale + 0.2f * screen_dpi_scale * screen_dpi_scale;
-	} else {
-		m_gui_scale *= screen_dpi_scale;
-	}
+	m_gui_scale = g_settings->getFloat("gui_scaling", 0.5f, 20.0f) *
+			RenderingEngine::getDisplayDensity();
 
 	setVisible(true);
 	m_menumgr->createdMenu(this);


### PR DESCRIPTION
C++ menus are currently less affected by display density / GUI scaling if `enable_touch` is true. I noticed that scaling is actually better without that special case on my Android device, so this PR removes it.

screenshot before (as you can see, some text is cut off)
![screenshot before](https://github.com/minetest/minetest/assets/82708541/31695690-fe84-48fc-b8dc-abad80cd00fe)

screenshot after
![screenshot after](https://github.com/minetest/minetest/assets/82708541/0ea86e20-132a-4394-8237-c56fca12898d)

Since #14690 has been merged, there's not the risk of C++ menus getting too big and going outside the window (except for the Irrlicht file picker, but it's disabled on Android and horribly broken on touchscreens anyway).

## To do

This PR is a Ready for Review.

## How to test

Verify that C++ menu scaling is still the same on desktop.

Verify that C++ menu scaling is better than before on mobile.