### PR TITLE
Fix warning about getVertexTypeDescription reaching its end

### DIFF
--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -95,8 +95,6 @@ static const VertexType vtTangents = {
 };
 
 #pragma GCC diagnostic pop
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wreturn-type"
 
 static const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type)
 {
@@ -109,10 +107,9 @@ static const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type)
 		return vtTangents;
 	default:
 		assert(false);
+		std::abort();
 	}
 }
-
-#pragma GCC diagnostic pop
 
 static const VertexType vt2DImage = {
 		sizeof(S3DVertex),

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -95,6 +95,8 @@ static const VertexType vtTangents = {
 };
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wreturn-type"
 
 static const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type)
 {
@@ -109,6 +111,8 @@ static const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type)
 		assert(false);
 	}
 }
+
+#pragma GCC diagnostic pop
 
 static const VertexType vt2DImage = {
 		sizeof(S3DVertex),

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -107,12 +107,7 @@ static const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type)
 		return vtTangents;
 	default:
 		assert(false);
-		std::abort();
-#ifdef __GNUC__
-		__builtin_unreachable();
-#elif defined(_MSC_VER)
-		__assume(false);
-#endif	
+		UNREACHABLE;
 	}
 }
 

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -107,7 +107,7 @@ static const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type)
 		return vtTangents;
 	default:
 		assert(false);
-		UNREACHABLE();
+		CODE_UNREACHABLE();
 	}
 }
 

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -108,6 +108,7 @@ static const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type)
 	default:
 		assert(false);
 		std::abort();
+		__builtin_unreachable();
 	}
 }
 

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -108,7 +108,11 @@ static const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type)
 	default:
 		assert(false);
 		std::abort();
+#ifdef __GNUC__
 		__builtin_unreachable();
+#elif defined(_MSC_VER)
+		__assume(false);
+#endif	
 	}
 }
 

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -107,7 +107,7 @@ static const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type)
 		return vtTangents;
 	default:
 		assert(false);
-		UNREACHABLE;
+		UNREACHABLE();
 	}
 }
 

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -11,7 +11,7 @@
 #include "ITimer.h"
 
 // CODE_UNREACHABLE(): Invokes undefined behavior for unreachable code optimization
-#if __cplusplus >= 202302L
+#if defined(__cpp_lib_unreachable)
 #define CODE_UNREACHABLE() std::unreachable();
 #elif defined(__has_builtin)
 #if __has_builtin(__builtin_unreachable)

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -12,17 +12,17 @@
 
 // CODE_UNREACHABLE(): Invokes undefined behavior for unreachable code optimization
 #if defined(__cpp_lib_unreachable)
-#define CODE_UNREACHABLE() std::unreachable();
+#define CODE_UNREACHABLE() std::unreachable()
 #elif defined(__has_builtin)
 #if __has_builtin(__builtin_unreachable)
-#define CODE_UNREACHABLE() __builtin_unreachable();
+#define CODE_UNREACHABLE() __builtin_unreachable()
 #endif
 #elif defined(_MSC_VER)
-#define CODE_UNREACHABLE() __assume(false);
+#define CODE_UNREACHABLE() __assume(false)
 #endif
 
 #ifndef CODE_UNREACHABLE
-void CODE_UNREACHABLE [[noreturn]] ();
+void CODE_UNREACHABLE [[noreturn]] () { std::abort(); };
 #endif
 
 namespace irr

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -12,6 +12,7 @@
 
 // CODE_UNREACHABLE(): Invokes undefined behavior for unreachable code optimization
 #if defined(__cpp_lib_unreachable)
+#include <utility>
 #define CODE_UNREACHABLE() std::unreachable()
 #elif defined(__has_builtin)
 #if __has_builtin(__builtin_unreachable)
@@ -22,7 +23,7 @@
 #endif
 
 #ifndef CODE_UNREACHABLE
-#define CODE_UNREACHABLE() std::abort()
+#define CODE_UNREACHABLE()
 #endif
 
 namespace irr

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -10,6 +10,7 @@
 #include "ILogger.h"
 #include "ITimer.h"
 
+// CODE_UNREACHABLE(): Invokes undefined behavior for unreachable code optimization
 #if __cplusplus >= 202302L
 #define CODE_UNREACHABLE() std::unreachable();
 #elif defined(__has_builtin)
@@ -20,8 +21,8 @@
 #define CODE_UNREACHABLE() __assume(false);
 #endif
 
-#ifndef UNREACHABLE
-void CODE_UNREACHABLE() [[noreturn]] {}
+#ifndef CODE_UNREACHABLE
+void CODE_UNREACHABLE [[noreturn]] ();
 #endif
 
 namespace irr

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -10,8 +10,9 @@
 #include "ILogger.h"
 #include "ITimer.h"
 
-
-#if defined(__has_builtin)
+#if __cplusplus >= 202302L
+#define UNREACHABLE() std::unreachable();
+#elif defined(__has_builtin)
 #if __has_builtin(__builtin_unreachable)
 #define UNREACHABLE() __builtin_unreachable();
 #endif

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -11,17 +11,17 @@
 #include "ITimer.h"
 
 #if __cplusplus >= 202302L
-#define UNREACHABLE() std::unreachable();
+#define CODE_UNREACHABLE() std::unreachable();
 #elif defined(__has_builtin)
 #if __has_builtin(__builtin_unreachable)
-#define UNREACHABLE() __builtin_unreachable();
+#define CODE_UNREACHABLE() __builtin_unreachable();
 #endif
 #elif defined(_MSC_VER)
-#define UNREACHABLE() __assume(false);
+#define CODE_UNREACHABLE() __assume(false);
 #endif
 
 #ifndef UNREACHABLE
-void UNREACHABLE() [[noreturn]] {}
+void CODE_UNREACHABLE() [[noreturn]] {}
 #endif
 
 namespace irr

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -22,7 +22,7 @@
 #endif
 
 #ifndef CODE_UNREACHABLE
-void CODE_UNREACHABLE [[noreturn]] () { std::abort(); };
+#define CODE_UNREACHABLE() std::abort()
 #endif
 
 namespace irr

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -23,7 +23,7 @@
 #endif
 
 #ifndef CODE_UNREACHABLE
-#define CODE_UNREACHABLE()
+#define CODE_UNREACHABLE() (void)0
 #endif
 
 namespace irr

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -13,14 +13,14 @@
 
 #if defined(__has_builtin)
 #if __has_builtin(__builtin_unreachable)
-#define UNREACHABLE __builtin_unreachable();
+#define UNREACHABLE() __builtin_unreachable();
 #endif
 #elif defined(_MSC_VER)
-#define UNREACHABLE __assume(false);
+#define UNREACHABLE() __assume(false);
 #endif
 
 #ifndef UNREACHABLE
-#define UNREACHABLE std::abort();
+void UNREACHABLE() [[noreturn]] {}
 #endif
 
 namespace irr

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -10,11 +10,16 @@
 #include "ILogger.h"
 #include "ITimer.h"
 
-#if (defined(__GNUC__) || defined(__clang__)) && __has_builtin(__builtin_unreachable)
+
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_unreachable)
 #define UNREACHABLE __builtin_unreachable();
+#endif
 #elif defined(_MSC_VER)
 #define UNREACHABLE __assume(false);
-#else
+#endif
+
+#ifndef UNREACHABLE
 #define UNREACHABLE std::abort();
 #endif
 

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -10,7 +10,7 @@
 #include "ILogger.h"
 #include "ITimer.h"
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #define UNREACHABLE __builtin_unreachable();
 #elif defined(_MSC_VER)
 #define UNREACHABLE __assume(false);

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -10,7 +10,7 @@
 #include "ILogger.h"
 #include "ITimer.h"
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && __has_builtin(__builtin_unreachable)
 #define UNREACHABLE __builtin_unreachable();
 #elif defined(_MSC_VER)
 #define UNREACHABLE __assume(false);

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -10,6 +10,14 @@
 #include "ILogger.h"
 #include "ITimer.h"
 
+#if defined(__GNUC__)
+#define UNREACHABLE __builtin_unreachable();
+#elif defined(_MSC_VER)
+#define UNREACHABLE __assume(false);
+#else
+#define UNREACHABLE std::abort();
+#endif
+
 namespace irr
 {
 


### PR DESCRIPTION
This PR adds GCC diagnostic pragmas to ignore return type warnings in the function getVertexTypeDescription. Before this, this warning emits:

```text
[##/##] Building CXX object irr/src/CMakeFiles/IRRVIDEOOBJ.dir/OpenGL/Driver.cpp.o
/my/home/minetest/irr/src/OpenGL/Driver.cpp: In function 'const irr::video::VertexType& irr::video::getVertexTypeDescription(E_VERTEX_TYPE)':
/my/home/minetest/irr/src/OpenGL/Driver.cpp:110:9: warning: control reaches end of non-void function [-Wreturn-type]
  110 |         default:
      |         ^~~~~~~
```

## To do

This PR is Ready for Review.

## How to test

Compile Minetest with and without the patch.
