### PR TITLE
Fading clouds

### DIFF
--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -134,7 +134,7 @@ void Clouds::updateMesh()
 	m_last_noise_center = center_of_drawing_in_noise_i;
 	m_mesh_valid = true;
 
-	const u32 num_faces_to_draw = m_enable_3d ? 6 : 1;
+	const u32 num_faces_to_draw = is3D() ? 6 : 1;
 
 	// The world position of the integer center point of drawing in the noise
 	v2f world_center_of_drawing_in_noise_f = v2f(

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -399,7 +399,7 @@ void Clouds::updateMesh()
 	const u32 quad_count = mb->getVertexCount() / 4;
 	const u32 index_count = quad_count * 6;
 	// Rewrite index array as needed
-	
+
 	if (mb->getIndexCount() > index_count) {
 		mb->Indices.resize(index_count);
 		mb->setDirty(scene::EBT_INDEX);

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -198,7 +198,7 @@ void Clouds::updateMesh()
 	m_last_noise_center = center_of_drawing_in_noise_i;
 	m_mesh_valid = true;
 
-	const u32 num_faces_to_draw = m_enable_3d ? 6 : 1;
+	const u32 num_faces_to_draw = is3D() ? 6 : 1;
 
 	// The world position of the integer center point of drawing in the noise
 	v2f world_center_of_drawing_in_noise_f = v2f(
@@ -442,7 +442,7 @@ void Clouds::render()
 		updateAbsolutePosition();
 	}
 
-	m_material.BackfaceCulling = m_enable_3d;
+	m_material.BackfaceCulling = is3D();
 	if (m_enable_shaders)
 		m_material.EmissiveColor = m_color.toSColor();
 
@@ -492,7 +492,7 @@ void Clouds::update(const v3f &camera_p, const video::SColorf &color_diffuse)
 	// is the camera inside the cloud mesh?
 	m_camera_pos = camera_p;
 	m_camera_inside_cloud = false; // default
-	if (m_enable_3d) {
+	if (is3D()) {
 		float camera_height = camera_p.Y - BS * m_camera_offset.Y;
 		if (camera_height >= m_box.MinEdge.Y &&
 				camera_height <= m_box.MaxEdge.Y) {

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -198,7 +198,7 @@ void Clouds::updateMesh()
 
 	mb->Vertices.clear();
 	for (s16 zi0 = -m_cloud_radius_i; zi0 < m_cloud_radius_i; zi0++)
-	for (s16 xi0 = -m_cloud_radius_i; xi0 < m_cloud_radius_i; xi0++) 
+	for (s16 xi0 = -m_cloud_radius_i; xi0 < m_cloud_radius_i; xi0++)
 	{
  			s16 zi = zi0;
 			s16 xi = xi0;
@@ -329,14 +329,13 @@ void Clouds::updateMesh()
 				}
 			}
 		}
-	//}
 
 	mb->setDirty(scene::EBT_VERTEX);
 
 	const u32 quad_count = mb->getVertexCount() / 4;
 	const u32 index_count = quad_count * 6;
 	// Rewrite index array as needed
-	
+
 	if (mb->getIndexCount() > index_count) {
 		mb->Indices.resize(index_count);
 		mb->setDirty(scene::EBT_INDEX);


### PR DESCRIPTION
- Goal of the PR
Make clouds fade as the player gets further away rather than abruptly vanishing.
- How does the PR work?
It changes the render function, so that now whenever a player is further away from the clouds they start fading, and they slowly come back into view if a player gets closer. And it doesn't need fog.
- What this pr doesn't do.
It doesn't make clouds slowly fade in as they grow in size or fade out as they get smaller.
- Does it resolve any reported issue?
No.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
Could be considered part of 2.1

This PR is a Work in Progress

## To do

- [ ] Make a setting for it.
- [ ] make a configurable distance.

## How to test
Compile. Go into your world, look up, and follow the clouds. You'll see the clouds slowly become visible as you near them, and they slowly fade as you walk away.

Here's a comparison

![Screenshot from 2024-07-03 07-30-06](https://github.com/minetest/minetest/assets/146014546/cf3dff81-c170-419f-a015-5c9b0ecd4566)
Current.
![Screenshot from 2024-07-03 07-28-45](https://github.com/minetest/minetest/assets/146014546/5777193a-324f-4406-a40c-0a080e2138a6)
This PR.

If you go compare in both worlds you'll see that currently the  clouds vanish very abruptly. Removing a few sections at a time. While this pr fades them out more.

