### PR TITLE
KeyPress: Recognize chars that are not in the lookup table

### DIFF
--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -26,10 +26,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/basic_macros.h"
 
 struct table_key {
-	const char *Name;
+	std::string Name;
 	irr::EKEY_CODE Key;
 	wchar_t Char; // L'\0' means no character assigned
-	const char *LangName; // NULL means it doesn't have a human description
+	std::string LangName;
 };
 
 #define DEFINEKEY1(x, lang) /* Irrlicht key without character */ \
@@ -141,7 +141,7 @@ static std::vector<table_key> table = {
 	DEFINEKEY1(KEY_ADD, N_("Numpad +"))
 	DEFINEKEY1(KEY_SEPARATOR, N_("Numpad ."))
 	DEFINEKEY1(KEY_SUBTRACT, N_("Numpad -"))
-	DEFINEKEY1(KEY_DECIMAL, NULL)
+	DEFINEKEY1(KEY_DECIMAL, N_("Numpad decimal"))
 	DEFINEKEY1(KEY_DIVIDE, N_("Numpad /"))
 	DEFINEKEY4(1)
 	DEFINEKEY4(2)
@@ -242,7 +242,7 @@ static std::vector<table_key> table = {
 static const table_key &lookup_keyname(const char *name)
 {
 	for (const auto &table_key : table) {
-		if (strcmp(table_key.Name, name) == 0)
+		if (table_key.Name == name)
 			return table_key;
 	}
 
@@ -269,8 +269,7 @@ static const table_key &lookup_keychar(wchar_t Char)
 	}
 
 	// If the character doesn't have an entry, just make a new one
-	std::string tmp = wide_to_utf8(std::wstring(1, Char));
-	char *str = strdup(tmp.c_str());
+	std::string str = wide_to_utf8(std::wstring(1, Char));
 	table_key &key = table.emplace_back(table_key {
 		str, irr::KEY_KEY_CODES_COUNT, Char, str,
 	});
@@ -327,21 +326,21 @@ KeyPress::KeyPress(const irr::SEvent::SKeyInput &in, bool prefer_character)
 	};
 }
 
-const char *KeyPress::sym() const
+const std::string &KeyPress::sym() const
 {
-	return m_name.c_str();
+	return m_name;
 }
 
-const char *KeyPress::name() const
+std::string KeyPress::name() const
 {
 	if (m_name.empty())
 		return "";
-	const char *ret;
+	std::string ret;
 	if (valid_kcode(Key))
 		ret = lookup_keykey(Key).LangName;
 	else
 		ret = lookup_keychar(Char).LangName;
-	return ret ? ret : "<Unnamed key>";
+	return ret.empty() ? "<Unnamed key>" : ret;
 }
 
 const KeyPress EscapeKey("KEY_ESCAPE");

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -28,8 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class UnknownKeycode : public BaseException
 {
 public:
-	UnknownKeycode(const char *s) :
-		BaseException(s) {};
+	UnknownKeycode(const std::string &s): BaseException(s) {}
 };
 
 /* A key press, consisting of either an Irrlicht keycode
@@ -49,8 +48,8 @@ public:
 		return (Char > 0 && Char == o.Char) || (valid_kcode(Key) && Key == o.Key);
 	}
 
-	const char *sym() const;
-	const char *name() const;
+	const std::string &sym() const;
+	std::string name() const;
 
 protected:
 	static bool valid_kcode(irr::EKEY_CODE k)

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -284,7 +284,7 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 
 		// Display Key already in use message
 		bool key_in_use = false;
-		if (strcmp(kp.sym(), "") != 0) {
+		if (kp.sym() != "") {
 			for (key_setting *ks : key_settings) {
 				if (ks != active_key && ks->key == kp) {
 					key_in_use = true;

--- a/src/unittest/test_keycode.cpp
+++ b/src/unittest/test_keycode.cpp
@@ -46,7 +46,7 @@ void TestKeycode::runTests(IGameDef *gamedef)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define UASSERTEQ_STR(one, two) UASSERT(strcmp(one, two) == 0)
+#define UASSERTEQ_STR(one, two) UASSERTEQ(const std::string &, one, two)
 
 void TestKeycode::testCreateFromString()
 {
@@ -55,31 +55,31 @@ void TestKeycode::testCreateFromString()
 	// Character key, from char
 	k = KeyPress("R");
 	UASSERTEQ_STR(k.sym(), "KEY_KEY_R");
-	UASSERTCMP(int, >, strlen(k.name()), 0); // should have human description
+	UASSERTCMP(int, >, k.name().length(), 0); // should have human description
 
 	// Character key, from identifier
 	k = KeyPress("KEY_KEY_B");
 	UASSERTEQ_STR(k.sym(), "KEY_KEY_B");
-	UASSERTCMP(int, >, strlen(k.name()), 0);
+	UASSERTCMP(int, >, k.name().length(), 0);
 
 	// Non-Character key, from identifier
 	k = KeyPress("KEY_UP");
 	UASSERTEQ_STR(k.sym(), "KEY_UP");
-	UASSERTCMP(int, >, strlen(k.name()), 0);
+	UASSERTCMP(int, >, k.name().length(), 0);
 
 	k = KeyPress("KEY_F6");
 	UASSERTEQ_STR(k.sym(), "KEY_F6");
-	UASSERTCMP(int, >, strlen(k.name()), 0);
+	UASSERTCMP(int, >, k.name().length(), 0);
 
 	// Irrlicht-unknown key, from char
 	k = KeyPress("/");
 	UASSERTEQ_STR(k.sym(), "/");
-	UASSERTCMP(int, >, strlen(k.name()), 0);
+	UASSERTCMP(int, >, k.name().length(), 0);
 
 	// Character key, not in the lookup table in keycode.cpp
 	k = KeyPress("ä");
 	UASSERTEQ_STR(k.sym(), "ä");
-	UASSERTCMP(int, >, strlen(k.name()), 0);
+	UASSERTCMP(int, >, k.name().length(), 0);
 }
 
 void TestKeycode::testCreateFromSKeyInput()

--- a/src/unittest/test_keycode.cpp
+++ b/src/unittest/test_keycode.cpp
@@ -75,6 +75,11 @@ void TestKeycode::testCreateFromString()
 	k = KeyPress("/");
 	UASSERTEQ_STR(k.sym(), "/");
 	UASSERTCMP(int, >, strlen(k.name()), 0);
+
+	// Character key, not in the lookup table in keycode.cpp
+	k = KeyPress("ä");
+	UASSERTEQ_STR(k.sym(), "ä");
+	UASSERTCMP(int, >, strlen(k.name()), 0);
 }
 
 void TestKeycode::testCreateFromSKeyInput()
@@ -99,6 +104,12 @@ void TestKeycode::testCreateFromSKeyInput()
 	in.Char = L'?';
 	k = KeyPress(in);
 	UASSERTEQ_STR(k.sym(), "?");
+
+	// Character key, not in the lookup table in keycode.cpp
+	in.Key = irr::KEY_KEY_CODES_COUNT;
+	in.Char = L'ä';
+	k = KeyPress(in);
+	UASSERTEQ_STR(k.sym(), "ä");
 
 	// prefer_character mode
 	in.Key = irr::KEY_COMMA;


### PR DESCRIPTION
(part of #14545)

This makes binding <kbd>ä</kbd>, <kbd>ö</kbd>, <kbd>ü</kbd> on German keyboards work ("again"). It should also make binding <kbd>`</kbd> on US keyboards work ("again").

Unfortunately this only makes character keybinds, not keycode keybinds, work for these keys. And MT's keybinding system is weird, maybe we can redo it after a full switch to SDL.

## To do

This PR is a Ready for Review.

## How to test

Try binding the mentioned keys when compiling with CIrrDeviceSDL.