### PR TITLE
Add squared distance to vector api

### DIFF
--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -120,11 +120,15 @@ function vector.combine(a, b, func)
 	)
 end
 
-function vector.distance(a, b)
+function vector.sq_distance(a, b)
 	local x = a.x - b.x
 	local y = a.y - b.y
 	local z = a.z - b.z
-	return math.sqrt(x * x + y * y + z * z)
+	return x * x + y * y + z * z;
+end
+
+function vector.distance(a, b)
+	return math.sqrt(vector.squared_distance(a, b))
 end
 
 function vector.direction(pos1, pos2)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3846,6 +3846,9 @@ vectors are written like this: `(x, y, z)`:
     * If `p1` and `p2` are identical, returns `(0, 0, 0)`.
 * `vector.distance(p1, p2)`:
     * Returns zero or a positive number, the distance between `p1` and `p2`.
+* `vector.sq_distance(p1, p2)`:
+    * Returns zero or a positive number, the squared distance between `p1` and `p2`.
+      This is slightly faster than the full distance computation.
 * `vector.length(v)`:
     * Returns zero or a positive number, the length of vector `v`.
 * `vector.normalize(v)`:


### PR DESCRIPTION
Squared distances are useful in many trigonometric computations (think of the Pythagorean theorem).
But also for distance thresholds it is often possible to compare the squared values and save the square root computation (which may take several CPU cycles). In particular code such as `vector.distance(a,b)^2` should be replaced with the new squared distance function.