### PR TITLE
Optionally hide player names on the serverlist

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -819,6 +819,9 @@ server_url (Server URL) string https://minetest.net
 #    Automatically report to the serverlist.
 server_announce (Announce server) bool false
 
+#    Replace all player names send to tyhe server list with "anon#".
+server_anon_name (Hide player names on the serverlist) bool false
+
 #    Announce to this serverlist.
 serverlist_url (Serverlist URL) string servers.minetest.net
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -819,7 +819,7 @@ server_url (Server URL) string https://minetest.net
 #    Automatically report to the serverlist.
 server_announce (Announce server) bool false
 
-#    Replace all player names send to the server list with "anon#".
+#    Hide player names from the serverlist by not sending them.
 server_announce_anonymize_names (Hide player names on the serverlist) bool false
 
 #    Announce to this serverlist.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -819,8 +819,8 @@ server_url (Server URL) string https://minetest.net
 #    Automatically report to the serverlist.
 server_announce (Announce server) bool false
 
-#    Replace all player names send to tyhe server list with "anon#".
-server_anon_name (Hide player names on the serverlist) bool false
+#    Replace all player names send to the server list with "anon#".
+server_announce_anonymize_names (Hide player names on the serverlist) bool false
 
 #    Announce to this serverlist.
 serverlist_url (Serverlist URL) string servers.minetest.net

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -819,7 +819,7 @@ server_url (Server URL) string https://minetest.net
 #    Automatically report to the serverlist.
 server_announce (Announce server) bool false
 
-#    Send player names onto the serverlist.
+#    Send names of online players to the serverlist. If disabled only the player count is revealed.
 server_announce_send_players (Send player names to the server list) bool true
 
 #    Announce to this serverlist.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -534,6 +534,7 @@ void set_default_settings()
 	settings->setDefault("server_address", "");
 	settings->setDefault("server_name", "");
 	settings->setDefault("server_description", "");
+	settings->setDefault("server_anon_name", "false");
 
 	settings->setDefault("enable_console", "false");
 	settings->setDefault("display_density_factor", "1");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -534,7 +534,7 @@ void set_default_settings()
 	settings->setDefault("server_address", "");
 	settings->setDefault("server_name", "");
 	settings->setDefault("server_description", "");
-	settings->setDefault("server_anon_name", "false");
+	settings->setDefault("server_announce_anonymize_names", "false");
 
 	settings->setDefault("enable_console", "false");
 	settings->setDefault("display_density_factor", "1");

--- a/src/server/serverlist.cpp
+++ b/src/server/serverlist.cpp
@@ -66,8 +66,12 @@ void sendAnnounce(AnnounceAction action,
 		server["clients"]      = (int) clients_names.size();
 		server["clients_max"]  = g_settings->getU16("max_users");
 		server["clients_list"] = Json::Value(Json::arrayValue);
-		for (const std::string &clients_name : clients_names) {
-			server["clients_list"].append(clients_name);
+		for (std::size_t i = 0; i < clients_names.size(); i++) {
+			if (g_settings->getBool("server_anon_name")) {
+				server["clients_list"].append("anon" + std::to_string(i));
+			} else {
+				server["clients_list"].append(clients_names[i]);
+			}
 		}
 		if (!gameid.empty())
 			server["gameid"] = gameid;

--- a/src/server/serverlist.cpp
+++ b/src/server/serverlist.cpp
@@ -68,7 +68,7 @@ void sendAnnounce(AnnounceAction action,
 		server["clients_list"] = Json::Value(Json::arrayValue);
 		for (std::size_t i = 0; i < clients_names.size(); i++) {
 			if (g_settings->getBool("server_anon_name")) {
-				server["clients_list"].append("anon" + std::to_string(i));
+				server["clients_list"].append("anon" + std::to_string(i + 1));
 			} else {
 				server["clients_list"].append(clients_names[i]);
 			}

--- a/src/server/serverlist.cpp
+++ b/src/server/serverlist.cpp
@@ -67,9 +67,8 @@ void sendAnnounce(AnnounceAction action,
 		server["clients_max"]  = g_settings->getU16("max_users");
 		if (!g_settings->getBool("server_announce_anonymize_names")) {
 			server["clients_list"] = Json::Value(Json::arrayValue);
-			for (const std::string &clients_name : clients_names) {
+			for (const std::string &clients_name : clients_names)
 				server["clients_list"].append(clients_name);
-			}
 		}
 		if (!gameid.empty())
 			server["gameid"] = gameid;

--- a/src/server/serverlist.cpp
+++ b/src/server/serverlist.cpp
@@ -65,12 +65,10 @@ void sendAnnounce(AnnounceAction action,
 		server["game_time"]    = game_time;
 		server["clients"]      = (int) clients_names.size();
 		server["clients_max"]  = g_settings->getU16("max_users");
-		server["clients_list"] = Json::Value(Json::arrayValue);
-		for (std::size_t i = 0; i < clients_names.size(); i++) {
-			if (g_settings->getBool("server_announce_anonymize_names")) {
-				server["clients_list"].append("anon" + std::to_string(i));
-			} else {
-				server["clients_list"].append(clients_names[i]);
+		if (g_settings->getBool("server_announce_anonymize_names")) {
+			server["clients_list"] = Json::Value(Json::arrayValue);
+			for (const std::string &clients_name : clients_names) {
+				server["clients_list"].append(clients_name);
 			}
 		}
 		if (!gameid.empty())

--- a/src/server/serverlist.cpp
+++ b/src/server/serverlist.cpp
@@ -65,7 +65,7 @@ void sendAnnounce(AnnounceAction action,
 		server["game_time"]    = game_time;
 		server["clients"]      = (int) clients_names.size();
 		server["clients_max"]  = g_settings->getU16("max_users");
-		if (g_settings->getBool("server_announce_anonymize_names")) {
+		if (!g_settings->getBool("server_announce_anonymize_names")) {
 			server["clients_list"] = Json::Value(Json::arrayValue);
 			for (const std::string &clients_name : clients_names) {
 				server["clients_list"].append(clients_name);

--- a/src/server/serverlist.cpp
+++ b/src/server/serverlist.cpp
@@ -67,7 +67,7 @@ void sendAnnounce(AnnounceAction action,
 		server["clients_max"]  = g_settings->getU16("max_users");
 		server["clients_list"] = Json::Value(Json::arrayValue);
 		for (std::size_t i = 0; i < clients_names.size(); i++) {
-			if (g_settings->getBool("server_anon_name")) {
+			if (g_settings->getBool("server_announce_anonymize_names")) {
 				server["clients_list"].append("anon" + std::to_string(i + 1));
 			} else {
 				server["clients_list"].append(clients_names[i]);

--- a/src/server/serverlist.cpp
+++ b/src/server/serverlist.cpp
@@ -68,7 +68,7 @@ void sendAnnounce(AnnounceAction action,
 		server["clients_list"] = Json::Value(Json::arrayValue);
 		for (std::size_t i = 0; i < clients_names.size(); i++) {
 			if (g_settings->getBool("server_announce_anonymize_names")) {
-				server["clients_list"].append("anon" + std::to_string(i + 1));
+				server["clients_list"].append("anon" + std::to_string(i));
 			} else {
 				server["clients_list"].append(clients_names[i]);
 			}


### PR DESCRIPTION
This PR adds a setting to anonymize player names when sending data to the server list.

For privacy concerns, some servers may not want their player names on the server list. For example, LinuxForks uses [their custom codes](https://git.bananach.space/minetest.git/commit/?h=gpcf&id=98021002253fd1646230c889bc0c8ff4dd1a48e8) to do so. This PR adds an opt-in feature to handle such needs.


## To do

This PR is Ready for Review.

## How to test

Create a server with `server_announce_send_players = false`. Check whether no players are listed.

Create a server with `server_announce_send_players = true / unset`. The player list should behave normally.
