### PR TITLE
dev: add shell.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ build/.cmake/
 *.zsync
 appimage-build
 AppDir
+# Direnv
+.direnv/
+# Nix
+/result
 
 ## Files related to Minetest development cycle
 /*.patch

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,25 @@
+{ pkgs ? import <nixpkgs> {}, }:
+
+pkgs.mkShell {
+  LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
+  env.LANG = "C.UTF-8";
+  env.LC_ALL = "C.UTF-8";
+
+  packages = [
+    pkgs.gcc
+    pkgs.cmake
+    pkgs.zlib
+    pkgs.zstd
+    pkgs.libjpeg
+    pkgs.libpng
+    pkgs.libGL
+    pkgs.SDL2
+    pkgs.openal
+    pkgs.curl
+    pkgs.libvorbis
+    pkgs.libogg
+    pkgs.gettext
+    pkgs.freetype
+    pkgs.sqlite
+  ];
+}


### PR DESCRIPTION
This permit to have reproducible development environment across OS (Linuxes, but maybe Mac OSX too).

It makes minetest compilable directly in a nix-shell with Nix/Lix but also on NixOS

I have a .envrc file too, but i'm not sure if i should commit it or not