### PR TITLE
Rework object attachment handling to fix bugs

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5108,12 +5108,15 @@ Callbacks:
       to the object (not necessarily an actual rightclick)
     * `clicker`: an `ObjectRef` (may or may not be a player)
 * `on_attach_child(self, child)`
-    * `child`: an `ObjectRef` of the child that attaches
+    * Called after another object is attached to this object.
+    * `child`: an `ObjectRef` of the child
 * `on_detach_child(self, child)`
-    * `child`: an `ObjectRef` of the child that detaches
+    * Called after another object has detached from this object.
+    * `child`: an `ObjectRef` of the child
 * `on_detach(self, parent)`
-    * `parent`: an `ObjectRef` (can be `nil`) from where it got detached
-    * This happens before the parent object is removed from the world
+    * Called after detaching from another object.
+    * `parent`: an `ObjectRef` from where it got detached
+    * Note: this is also called before removal from the world.
 * `get_staticdata(self)`
     * Should return a string that will be passed to `on_activate` when the
       object is instantiated the next time.

--- a/games/devtest/mods/unittests/entity.lua
+++ b/games/devtest/mods/unittests/entity.lua
@@ -40,12 +40,36 @@ core.register_entity("unittests:callbacks", {
 	end,
 	on_attach_child = function(self, child)
 		insert_log("on_attach_child(%s)", objref_str(self, child))
+		assert(child:get_attach() == self.object)
+		local ok = false
+		for _, obj in ipairs(self.object:get_children()) do
+			if obj == child then
+				ok = true
+			end
+		end
+		assert(ok, "Child not found in get_children")
 	end,
 	on_detach_child = function(self, child)
 		insert_log("on_detach_child(%s)", objref_str(self, child))
+		assert(child:get_attach() == nil)
+		local ok = true
+		for _, obj in ipairs(self.object:get_children()) do
+			if obj == child then
+				ok = false
+			end
+		end
+		assert(ok, "Former child found in get_children")
 	end,
 	on_detach = function(self, parent)
 		insert_log("on_detach(%s)", objref_str(self, parent))
+		assert(self.object:get_attach() == nil)
+		local ok = true
+		for _, obj in ipairs(parent:get_children()) do
+			if obj == self.object then
+				ok = false
+			end
+		end
+		assert(ok, "Former child found in get_children")
 	end,
 	get_staticdata = function(self)
 		assert(false)
@@ -118,18 +142,24 @@ local function test_entity_attach(player, pos)
 	-- attach player to entity
 	player:set_attach(obj)
 	check_log({"on_attach_child(player)"})
+	assert(player:get_attach() == obj)
 	player:set_detach()
 	check_log({"on_detach_child(player)"})
+	assert(player:get_attach() == nil)
 
 	-- attach entity to player
 	obj:set_attach(player)
 	check_log({})
+	assert(obj:get_attach() == player)
 	obj:set_detach()
 	check_log({"on_detach(player)"})
+	assert(obj:get_attach() == nil)
 
 	obj:remove()
 end
 unittests.register("test_entity_attach", test_entity_attach, {player=true, map=true})
+
+---------
 
 core.register_entity("unittests:dummy", {
 	initial_properties = {

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -201,6 +201,8 @@ public:
 			v3f *rotation, bool *force_visible) const {}
 	virtual void clearChildAttachments() {}
 	virtual void clearParentAttachment() {}
+
+	// To be be called from setAttachment() and descendants, but not manually!
 	virtual void addAttachmentChild(object_t child_id) {}
 	virtual void removeAttachmentChild(object_t child_id) {}
 

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -199,8 +199,13 @@ public:
 			v3f rotation, bool force_visible) {}
 	virtual void getAttachment(object_t *parent_id, std::string *bone, v3f *position,
 			v3f *rotation, bool *force_visible) const {}
+	// Detach all children
 	virtual void clearChildAttachments() {}
-	virtual void clearParentAttachment() {}
+	// Detach from parent
+	virtual void clearParentAttachment()
+	{
+		setAttachment(0, "", v3f(), v3f(), false);
+	}
 
 	// To be be called from setAttachment() and descendants, but not manually!
 	virtual void addAttachmentChild(object_t child_id) {}

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -152,17 +152,19 @@ typedef std::unordered_map<std::string, BoneOverride> BoneOverrideMap;
 class ActiveObject
 {
 public:
-	ActiveObject(u16 id):
+	typedef u16 object_t;
+
+	ActiveObject(object_t id):
 		m_id(id)
 	{
 	}
 
-	u16 getId() const
+	object_t getId() const
 	{
 		return m_id;
 	}
 
-	void setId(u16 id)
+	void setId(object_t id)
 	{
 		m_id = id;
 	}
@@ -193,14 +195,15 @@ public:
 	virtual bool collideWithObjects() const = 0;
 
 
-	virtual void setAttachment(int parent_id, const std::string &bone, v3f position,
+	virtual void setAttachment(object_t parent_id, const std::string &bone, v3f position,
 			v3f rotation, bool force_visible) {}
-	virtual void getAttachment(int *parent_id, std::string *bone, v3f *position,
+	virtual void getAttachment(object_t *parent_id, std::string *bone, v3f *position,
 			v3f *rotation, bool *force_visible) const {}
 	virtual void clearChildAttachments() {}
 	virtual void clearParentAttachment() {}
-	virtual void addAttachmentChild(int child_id) {}
-	virtual void removeAttachmentChild(int child_id) {}
+	virtual void addAttachmentChild(object_t child_id) {}
+	virtual void removeAttachmentChild(object_t child_id) {}
+
 protected:
-	u16 m_id; // 0 is invalid, "no id"
+	object_t m_id; // 0 is invalid, "no id"
 };

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -368,7 +368,7 @@ void ClientEnvironment::addActiveObject(u16 id, u8 type,
 void ClientEnvironment::removeActiveObject(u16 id)
 {
 	// Get current attachment childs to detach them visually
-	std::unordered_set<int> attachment_childs;
+	std::unordered_set<ClientActiveObject::object_t> attachment_childs;
 	if (auto *obj = getActiveObject(id))
 		attachment_childs = obj->getAttachmentChildIds();
 

--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -57,8 +57,8 @@ public:
 	virtual bool isLocalPlayer() const { return false; }
 
 	virtual ClientActiveObject *getParent() const { return nullptr; };
-	virtual const std::unordered_set<int> &getAttachmentChildIds() const
-	{ static std::unordered_set<int> rv; return rv; }
+	virtual const std::unordered_set<object_t> &getAttachmentChildIds() const
+	{ static std::unordered_set<object_t> rv; return rv; }
 	virtual void updateAttachments() {};
 
 	virtual bool doShowSelectionBox() { return true; }

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -527,6 +527,8 @@ void GenericCAO::clearChildAttachments()
 
 		if (auto *child = m_env->getActiveObject(child_id))
 			child->clearParentAttachment();
+		else
+			removeAttachmentChild(child_id);
 	}
 }
 

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -525,19 +525,9 @@ void GenericCAO::clearChildAttachments()
 	while (!m_attachment_child_ids.empty()) {
 		const auto child_id = *m_attachment_child_ids.begin();
 
-		if (ClientActiveObject *child = m_env->getActiveObject(child_id))
-			child->setAttachment(0, "", v3f(), v3f(), false);
-
-		removeAttachmentChild(child_id);
+		if (auto *child = m_env->getActiveObject(child_id))
+			child->clearParentAttachment();
 	}
-}
-
-void GenericCAO::clearParentAttachment()
-{
-	if (m_attachment_parent_id)
-		setAttachment(0, "", m_attachment_position, m_attachment_rotation, false);
-	else
-		setAttachment(0, "", v3f(), v3f(), false);
 }
 
 void GenericCAO::addAttachmentChild(object_t child_id)

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -465,7 +465,7 @@ scene::IAnimatedMeshSceneNode *GenericCAO::getAnimatedMeshSceneNode() const
 
 void GenericCAO::setChildrenVisible(bool toset)
 {
-	for (u16 cao_id : m_attachment_child_ids) {
+	for (object_t cao_id : m_attachment_child_ids) {
 		GenericCAO *obj = m_env->getGenericCAO(cao_id);
 		if (obj) {
 			// Check if the entity is forced to appear in first person.
@@ -474,10 +474,10 @@ void GenericCAO::setChildrenVisible(bool toset)
 	}
 }
 
-void GenericCAO::setAttachment(int parent_id, const std::string &bone,
+void GenericCAO::setAttachment(object_t parent_id, const std::string &bone,
 		v3f position, v3f rotation, bool force_visible)
 {
-	int old_parent = m_attachment_parent_id;
+	const auto old_parent = m_attachment_parent_id;
 	m_attachment_parent_id = parent_id;
 	m_attachment_bone = bone;
 	m_attachment_position = position;
@@ -509,7 +509,7 @@ void GenericCAO::setAttachment(int parent_id, const std::string &bone,
 	}
 }
 
-void GenericCAO::getAttachment(int *parent_id, std::string *bone, v3f *position,
+void GenericCAO::getAttachment(object_t *parent_id, std::string *bone, v3f *position,
 	v3f *rotation, bool *force_visible) const
 {
 	*parent_id = m_attachment_parent_id;
@@ -523,7 +523,7 @@ void GenericCAO::clearChildAttachments()
 {
 	// Cannot use for-loop here: setAttachment() modifies 'm_attachment_child_ids'!
 	while (!m_attachment_child_ids.empty()) {
-		int child_id = *m_attachment_child_ids.begin();
+		const auto child_id = *m_attachment_child_ids.begin();
 
 		if (ClientActiveObject *child = m_env->getActiveObject(child_id))
 			child->setAttachment(0, "", v3f(), v3f(), false);
@@ -540,12 +540,12 @@ void GenericCAO::clearParentAttachment()
 		setAttachment(0, "", v3f(), v3f(), false);
 }
 
-void GenericCAO::addAttachmentChild(int child_id)
+void GenericCAO::addAttachmentChild(object_t child_id)
 {
 	m_attachment_child_ids.insert(child_id);
 }
 
-void GenericCAO::removeAttachmentChild(int child_id)
+void GenericCAO::removeAttachmentChild(object_t child_id)
 {
 	m_attachment_child_ids.erase(child_id);
 }

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -231,7 +231,6 @@ public:
 	void getAttachment(object_t *parent_id, std::string *bone, v3f *position,
 			v3f *rotation, bool *force_visible) const override;
 	void clearChildAttachments() override;
-	void clearParentAttachment() override;
 	void addAttachmentChild(object_t child_id) override;
 	void removeAttachmentChild(object_t child_id) override;
 	ClientActiveObject *getParent() const override;

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -106,8 +106,8 @@ private:
 	// stores position and rotation for each bone name
 	BoneOverrideMap m_bone_override;
 
-	int m_attachment_parent_id = 0;
-	std::unordered_set<int> m_attachment_child_ids;
+	object_t m_attachment_parent_id = 0;
+	std::unordered_set<object_t> m_attachment_child_ids;
 	std::string m_attachment_bone = "";
 	v3f m_attachment_position;
 	v3f m_attachment_rotation;
@@ -226,16 +226,16 @@ public:
 	}
 
 	void setChildrenVisible(bool toset);
-	void setAttachment(int parent_id, const std::string &bone, v3f position,
+	void setAttachment(object_t parent_id, const std::string &bone, v3f position,
 			v3f rotation, bool force_visible) override;
-	void getAttachment(int *parent_id, std::string *bone, v3f *position,
+	void getAttachment(object_t *parent_id, std::string *bone, v3f *position,
 			v3f *rotation, bool *force_visible) const override;
 	void clearChildAttachments() override;
 	void clearParentAttachment() override;
-	void addAttachmentChild(int child_id) override;
-	void removeAttachmentChild(int child_id) override;
+	void addAttachmentChild(object_t child_id) override;
+	void removeAttachmentChild(object_t child_id) override;
 	ClientActiveObject *getParent() const override;
-	const std::unordered_set<int> &getAttachmentChildIds() const override
+	const std::unordered_set<object_t> &getAttachmentChildIds() const override
 	{ return m_attachment_child_ids; }
 	void updateAttachments() override;
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -100,9 +100,6 @@ int ObjectRef::l_remove(lua_State *L)
 	if (sao->getType() == ACTIVEOBJECT_TYPE_PLAYER)
 		return 0;
 
-	sao->clearChildAttachments();
-	sao->clearParentAttachment();
-
 	verbosestream << "ObjectRef::l_remove(): id=" << sao->getId() << std::endl;
 	sao->markForRemoval();
 	return 0;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -725,17 +725,10 @@ int ObjectRef::l_set_attach(lua_State *L)
 	if (sao == parent)
 		throw LuaError("ObjectRef::set_attach: attaching object to itself is not allowed.");
 
-	object_t parent_id;
 	std::string bone;
 	v3f position;
 	v3f rotation;
 	bool force_visible;
-
-	sao->getAttachment(&parent_id, &bone, &position, &rotation, &force_visible);
-	if (parent_id) {
-		ServerActiveObject *old_parent = env->getActiveObject(parent_id);
-		old_parent->removeAttachmentChild(sao->getId());
-	}
 
 	bone          = readParam<std::string>(L, 3, "");
 	position      = readParam<v3f>(L, 4, v3f(0, 0, 0));
@@ -743,7 +736,6 @@ int ObjectRef::l_set_attach(lua_State *L)
 	force_visible = readParam<bool>(L, 6, false);
 
 	sao->setAttachment(parent->getId(), bone, position, rotation, force_visible);
-	parent->addAttachmentChild(sao->getId());
 	return 0;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -37,10 +37,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server/serverinventorymgr.h"
 #include "server/unit_sao.h"
 
+using object_t = ServerActiveObject::object_t;
+
 /*
 	ObjectRef
 */
-
 
 ServerActiveObject* ObjectRef::getobject(ObjectRef *ref)
 {
@@ -724,7 +725,7 @@ int ObjectRef::l_set_attach(lua_State *L)
 	if (sao == parent)
 		throw LuaError("ObjectRef::set_attach: attaching object to itself is not allowed.");
 
-	int parent_id;
+	object_t parent_id;
 	std::string bone;
 	v3f position;
 	v3f rotation;
@@ -755,7 +756,7 @@ int ObjectRef::l_get_attach(lua_State *L)
 	if (sao == nullptr)
 		return 0;
 
-	int parent_id;
+	object_t parent_id;
 	std::string bone;
 	v3f position;
 	v3f rotation;
@@ -783,11 +784,11 @@ int ObjectRef::l_get_children(lua_State *L)
 	if (sao == nullptr)
 		return 0;
 
-	const std::unordered_set<int> child_ids = sao->getAttachmentChildIds();
+	const auto &child_ids = sao->getAttachmentChildIds();
 	int i = 0;
 
 	lua_createtable(L, child_ids.size(), 0);
-	for (const int id : child_ids) {
+	for (const object_t id : child_ids) {
 		ServerActiveObject *child = env->getActiveObject(id);
 		getScriptApiBase(L)->objectrefGetOrCreate(L, child);
 		lua_rawseti(L, -2, ++i);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2964,9 +2964,6 @@ void Server::DeleteClient(session_t peer_id, ClientDeletionReason reason)
 			PlayerSAO *playersao = player->getPlayerSAO();
 			assert(playersao);
 
-			playersao->clearChildAttachments();
-			playersao->clearParentAttachment();
-
 			// inform connected clients
 			const std::string &player_name = player->getName();
 			NetworkPacket notice(TOCLIENT_UPDATE_PLAYER_LIST, 0, PEER_ID_INEXISTENT);

--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -85,23 +85,13 @@ void RemoteClient::ResendBlockIfOnWire(v3s16 p)
 	}
 }
 
-LuaEntitySAO *getAttachedObject(PlayerSAO *sao, ServerEnvironment *env)
+static LuaEntitySAO *getAttachedObject(PlayerSAO *sao, ServerEnvironment *env)
 {
-	if (!sao->isAttached())
-		return nullptr;
+	ServerActiveObject *ao = sao;
+	while (ao->getParent())
+		ao = ao->getParent();
 
-	int id;
-	std::string bone;
-	v3f dummy;
-	bool force_visible;
-	sao->getAttachment(&id, &bone, &dummy, &dummy, &force_visible);
-	ServerActiveObject *ao = env->getActiveObject(id);
-	while (id && ao) {
-		ao->getAttachment(&id, &bone, &dummy, &dummy, &force_visible);
-		if (id)
-			ao = env->getActiveObject(id);
-	}
-	return dynamic_cast<LuaEntitySAO *>(ao);
+	return ao == sao ? nullptr : dynamic_cast<LuaEntitySAO*>(ao);
 }
 
 void RemoteClient::GetNextBlocks (

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -147,7 +147,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 	}
 
 	// If attached, check that our parent is still there. If it isn't, detach.
-	if (m_attachment_parent_id && !isAttached()) {
+	if (m_attachment_parent_id && !getParent()) {
 		// This is handled when objects are removed from the map
 		warningstream << "LuaEntitySAO::step() " << m_init_name << " at " << m_last_sent_position << ", id=" << m_id <<
 			" is attached to nonexistent parent. This is a bug." << std::endl;

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -415,8 +415,6 @@ void LuaEntitySAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
 	sendPunchCommand();
 
 	if (m_hp == 0 && !isGone()) {
-		clearParentAttachment();
-		clearChildAttachments();
 		if (m_registered) {
 			ServerActiveObject *killer = nullptr;
 			if (reason.type == PlayerHPChangeReason::PLAYER_PUNCH)

--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -81,8 +81,14 @@ public:
 
 protected:
 	void dispatchScriptDeactivate(bool removal);
-	virtual void onMarkedForDeactivation() { dispatchScriptDeactivate(false); }
-	virtual void onMarkedForRemoval() { dispatchScriptDeactivate(true); }
+	virtual void onMarkedForDeactivation() {
+		UnitSAO::onMarkedForDeactivation();
+		dispatchScriptDeactivate(false);
+	}
+	virtual void onMarkedForRemoval() {
+		UnitSAO::onMarkedForRemoval();
+		dispatchScriptDeactivate(true);
+	}
 
 private:
 	std::string getPropertyPacket();

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -233,13 +233,12 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 	}
 
 	// If attached, check that our parent is still there. If it isn't, detach.
-	if (m_attachment_parent_id && !isAttached()) {
+	if (m_attachment_parent_id && !getParent()) {
 		// This is handled when objects are removed from the map
 		warningstream << "PlayerSAO::step() id=" << m_id <<
 			" is attached to nonexistent parent. This is a bug." << std::endl;
 		clearParentAttachment();
-		setBasePosition(m_last_good_position);
-		m_env->getGameDef()->SendMovePlayer(this);
+		setPos(m_last_good_position);
 	}
 
 	//dstream<<"PlayerSAO::step: dtime: "<<dtime<<std::endl;

--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -171,8 +171,8 @@ public:
 	{ BoneOverride props; return props; }
 	virtual const BoneOverrideMap &getBoneOverrides() const
 	{ static BoneOverrideMap rv; return rv; }
-	virtual const std::unordered_set<int> &getAttachmentChildIds() const
-	{ static std::unordered_set<int> rv; return rv; }
+	virtual const std::unordered_set<object_t> &getAttachmentChildIds() const
+	{ static std::unordered_set<object_t> rv; return rv; }
 	virtual ServerActiveObject *getParent() const { return nullptr; }
 	virtual ObjectProperties *accessObjectProperties()
 	{ return NULL; }
@@ -240,8 +240,8 @@ protected:
 	virtual void onMarkedForDeactivation() {}
 	virtual void onMarkedForRemoval() {}
 
-	virtual void onAttach(int parent_id) {}
-	virtual void onDetach(int parent_id) {}
+	virtual void onAttach(object_t parent_id) {}
+	virtual void onDetach(object_t parent_id) {}
 
 	ServerEnvironment *m_env;
 	v3f m_base_position;

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -138,13 +138,6 @@ void UnitSAO::setAttachment(const object_t new_parent, const std::string &bone, 
 	const auto check_nesting = [&] (const char *descr) -> bool {
 		if (m_attachment_call_counter == call_count)
 			return false;
-		auto d = wrappedDifference(m_attachment_call_counter, call_count, (u8)U8_MAX);
-		if (d > 30) {
-			errorstream << "UnitSAO::setAttachment() id=" << m_id <<
-				" infinite callback loop detected." << std::endl;
-			throw ServerError("loop in UnitSAO::setAttachment");
-		}
-		assert(d > 0);
 		verbosestream << "UnitSAO::setAttachment() id=" << m_id <<
 			" nested call detected (" << descr << ")." << std::endl;
 		return true;

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -130,7 +130,7 @@ void UnitSAO::sendOutdatedData()
 	}
 }
 
-void UnitSAO::setAttachment(int parent_id, const std::string &bone, v3f position,
+void UnitSAO::setAttachment(object_t parent_id, const std::string &bone, v3f position,
 		v3f rotation, bool force_visible)
 {
 	auto *obj = parent_id ? m_env->getActiveObject(parent_id) : nullptr;
@@ -173,7 +173,7 @@ void UnitSAO::setAttachment(int parent_id, const std::string &bone, v3f position
 		onAttach(parent_id);
 }
 
-void UnitSAO::getAttachment(int *parent_id, std::string *bone, v3f *position,
+void UnitSAO::getAttachment(object_t *parent_id, std::string *bone, v3f *position,
 		v3f *rotation, bool *force_visible) const
 {
 	*parent_id = m_attachment_parent_id;
@@ -187,7 +187,7 @@ void UnitSAO::clearChildAttachments()
 {
 	// Cannot use for-loop here: setAttachment() modifies 'm_attachment_child_ids'!
 	while (!m_attachment_child_ids.empty()) {
-		int child_id = *m_attachment_child_ids.begin();
+		const auto child_id = *m_attachment_child_ids.begin();
 
 		// Child can be NULL if it was deleted earlier
 		if (ServerActiveObject *child = m_env->getActiveObject(child_id))
@@ -211,22 +211,17 @@ void UnitSAO::clearParentAttachment()
 		parent->removeAttachmentChild(m_id);
 }
 
-void UnitSAO::addAttachmentChild(int child_id)
+void UnitSAO::addAttachmentChild(object_t child_id)
 {
 	m_attachment_child_ids.insert(child_id);
 }
 
-void UnitSAO::removeAttachmentChild(int child_id)
+void UnitSAO::removeAttachmentChild(object_t child_id)
 {
 	m_attachment_child_ids.erase(child_id);
 }
 
-const std::unordered_set<int> &UnitSAO::getAttachmentChildIds() const
-{
-	return m_attachment_child_ids;
-}
-
-void UnitSAO::onAttach(int parent_id)
+void UnitSAO::onAttach(object_t parent_id)
 {
 	if (!parent_id)
 		return;
@@ -242,7 +237,7 @@ void UnitSAO::onAttach(int parent_id)
 	}
 }
 
-void UnitSAO::onDetach(int parent_id)
+void UnitSAO::onDetach(object_t parent_id)
 {
 	if (!parent_id)
 		return;

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -138,6 +138,10 @@ void UnitSAO::setAttachment(const object_t new_parent, const std::string &bone, 
 	// Do checks to avoid circular references
 	{
 		auto *obj = new_parent ? m_env->getActiveObject(new_parent) : nullptr;
+		if (obj == this) {
+			assert(false);
+			return;
+		}
 		bool problem = false;
 		if (obj) {
 			// The chain of wanted parent must not refer or contain "this"

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -224,11 +224,6 @@ void UnitSAO::clearChildAttachments()
 	}
 }
 
-void UnitSAO::clearParentAttachment()
-{
-	setAttachment(0, "", v3f(0, 0, 0), v3f(0, 0, 0), false);
-}
-
 void UnitSAO::addAttachmentChild(object_t child_id)
 {
 	m_attachment_child_ids.insert(child_id);

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -136,6 +136,8 @@ void UnitSAO::setAttachment(const object_t new_parent, const std::string &bone, 
 	const auto call_count = ++m_attachment_call_counter;
 
 	const auto check_nesting = [&] (const char *descr) -> bool {
+		// The counter is never decremented, so if it differs that means
+		// a nested call to setAttachment() has happened.
 		if (m_attachment_call_counter == call_count)
 			return false;
 		verbosestream << "UnitSAO::setAttachment() id=" << m_id <<

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -201,6 +201,17 @@ void UnitSAO::getAttachment(object_t *parent_id, std::string *bone, v3f *positio
 	*force_visible = m_force_visible;
 }
 
+void UnitSAO::clearAnyAttachments()
+{
+	// This is called before this SAO is marked for removal/deletion and unlinks
+	// any parent or child relationships.
+	// This is done at this point and not in ~UnitSAO() so attachments to
+	// "phantom objects" don't stay around while we're waiting to be actually deleted.
+	// (which can take several server steps)
+	clearParentAttachment();
+	clearChildAttachments();
+}
+
 void UnitSAO::clearChildAttachments()
 {
 	// Cannot use for-loop here: setAttachment() modifies 'm_attachment_child_ids'!
@@ -208,8 +219,8 @@ void UnitSAO::clearChildAttachments()
 		const auto child_id = *m_attachment_child_ids.begin();
 
 		// Child can be NULL if it was deleted earlier
-		if (ServerActiveObject *child = m_env->getActiveObject(child_id))
-			child->setAttachment(0, "", v3f(0, 0, 0), v3f(0, 0, 0), false);
+		if (auto *child = m_env->getActiveObject(child_id))
+			child->clearParentAttachment();
 	}
 }
 

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -138,8 +138,7 @@ void UnitSAO::setAttachment(const object_t new_parent, const std::string &bone, 
 	const auto check_nesting = [&] (const char *descr) -> bool {
 		if (m_attachment_call_counter == call_count)
 			return false;
-		auto d = wrappedDifference(m_attachment_call_counter, call_count,
-			std::numeric_limits<decltype(call_count)>::max());
+		auto d = wrappedDifference(m_attachment_call_counter, call_count, (u8)U8_MAX);
 		if (d > 30) {
 			errorstream << "UnitSAO::setAttachment() id=" << m_id <<
 				" infinite callback loop detected." << std::endl;

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -77,7 +77,7 @@ public:
 
 	// Attachments
 	ServerActiveObject *getParent() const;
-	inline bool isAttached() const { return getParent(); }
+	inline bool isAttached() const { return m_attachment_parent_id != 0; }
 	void setAttachment(object_t parent_id, const std::string &bone, v3f position,
 			v3f rotation, bool force_visible);
 	void getAttachment(object_t *parent_id, std::string *bone, v3f *position,
@@ -126,8 +126,8 @@ protected:
 	object_t m_attachment_parent_id = 0;
 
 private:
-	void onAttach(object_t parent_id);
-	void onDetach(object_t parent_id);
+	void onAttach(ServerActiveObject *parent);
+	void onDetach(ServerActiveObject *parent);
 
 	std::string generatePunchCommand(u16 result_hp) const;
 

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -78,15 +78,17 @@ public:
 	// Attachments
 	ServerActiveObject *getParent() const;
 	inline bool isAttached() const { return getParent(); }
-	void setAttachment(int parent_id, const std::string &bone, v3f position,
+	void setAttachment(object_t parent_id, const std::string &bone, v3f position,
 			v3f rotation, bool force_visible);
-	void getAttachment(int *parent_id, std::string *bone, v3f *position,
+	void getAttachment(object_t *parent_id, std::string *bone, v3f *position,
 			v3f *rotation, bool *force_visible) const;
 	void clearChildAttachments();
 	void clearParentAttachment();
-	void addAttachmentChild(int child_id);
-	void removeAttachmentChild(int child_id);
-	const std::unordered_set<int> &getAttachmentChildIds() const;
+	void addAttachmentChild(object_t child_id);
+	void removeAttachmentChild(object_t child_id);
+	const std::unordered_set<object_t> &getAttachmentChildIds() const {
+		return m_attachment_child_ids;
+	}
 
 	// Object properties
 	ObjectProperties *accessObjectProperties();
@@ -121,11 +123,11 @@ protected:
 	// Stores position and rotation for each bone name
 	std::unordered_map<std::string, BoneOverride> m_bone_override;
 
-	int m_attachment_parent_id = 0;
+	object_t m_attachment_parent_id = 0;
 
 private:
-	void onAttach(int parent_id);
-	void onDetach(int parent_id);
+	void onAttach(object_t parent_id);
+	void onDetach(object_t parent_id);
 
 	std::string generatePunchCommand(u16 result_hp) const;
 
@@ -144,7 +146,7 @@ private:
 	bool m_bone_override_sent = false;
 
 	// Attachments
-	std::unordered_set<int> m_attachment_child_ids;
+	std::unordered_set<object_t> m_attachment_child_ids;
 	std::string m_attachment_bone = "";
 	v3f m_attachment_position;
 	v3f m_attachment_rotation;

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -140,6 +140,10 @@ private:
 
 	std::string generatePunchCommand(u16 result_hp) const;
 
+	// Used to detect nested calls to setAttachments(), which can happen due to
+	// Lua callbacks
+	u8 m_attachment_call_counter = 0;
+
 	// Armor groups
 	bool m_armor_groups_sent = false;
 

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -125,6 +125,16 @@ protected:
 
 	object_t m_attachment_parent_id = 0;
 
+	void clearAnyAttachments();
+	virtual void onMarkedForDeactivation() {
+		ServerActiveObject::onMarkedForDeactivation();
+		clearAnyAttachments();
+	}
+	virtual void onMarkedForRemoval() {
+		ServerActiveObject::onMarkedForRemoval();
+		clearAnyAttachments();
+	}
+
 private:
 	void onAttach(ServerActiveObject *parent);
 	void onDetach(ServerActiveObject *parent);

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -82,10 +82,9 @@ public:
 			v3f rotation, bool force_visible);
 	void getAttachment(object_t *parent_id, std::string *bone, v3f *position,
 			v3f *rotation, bool *force_visible) const;
-	void clearChildAttachments();
-	void clearParentAttachment();
-	void addAttachmentChild(object_t child_id);
-	void removeAttachmentChild(object_t child_id);
+	void clearChildAttachments() override;
+	void addAttachmentChild(object_t child_id) override;
+	void removeAttachmentChild(object_t child_id) override;
 	const std::unordered_set<object_t> &getAttachmentChildIds() const {
 		return m_attachment_child_ids;
 	}

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -439,6 +439,17 @@ inline u32 npot2(u32 orig) {
 	return orig + 1;
 }
 
+// Distance between two values in a wrapped (circular) system
+template<typename T>
+inline unsigned wrappedDifference(T a, T b, const T maximum)
+{
+	if (a > b)
+		std::swap(a, b);
+	// now b >= a
+	unsigned s = b - a, l = static_cast<unsigned>(maximum - b) + a + 1;
+	return std::min(s, l);
+}
+
 // Gradual steps towards the target value in a wrapped (circular) system
 // using the shorter of both ways
 template<typename T>


### PR DESCRIPTION
fixes #14694
(root cause unfixed, but this fixes the crash)

to make all this work a behavior change was necessary:
* entity detach callbacks are called with detachment already done
  * before: objects were still linked
* if you do something like re-attach in `on_detach` it will now work properly and cause an infinite loop


## To do

This PR is Ready for Review.

Note: not tested much beyond MTG carts and the unit tests