### PR TITLE
Add setting to disable Content tab update indicator

### DIFF
--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -280,7 +280,7 @@ end
 return {
 	name = "content",
 	caption = function()
-		local update_count = update_detector.get_count()
+		local update_count = core.settings:get_bool("contentdb_enable_updates_indicator") and update_detector.get_count() or 0
 		if update_count == 0 then
 			return fgettext("Content")
 		else

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -764,6 +764,10 @@ chat_font_size (Chat font size) int 0 0 72
 #    The URL for the content repository
 contentdb_url (ContentDB URL) string https://content.minetest.net
 
+#    If enabled and you have ContentDB packages installed, Minetest may contact ContentDB to
+#    check for package updates when opening the mainmenu.
+contentdb_enable_updates_indicator (Enable updates available indicator on content tab) bool true
+
 #    Comma-separated list of flags to hide in the content repository.
 #    "nonfree" can be used to hide packages which do not qualify as 'free software',
 #    as defined by the Free Software Foundation.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -402,6 +402,7 @@ void set_default_settings()
 
 	// ContentDB
 	settings->setDefault("contentdb_url", "https://content.minetest.net");
+	settings->setDefault("contentdb_enable_updates_indicator", "true");
 	settings->setDefault("contentdb_max_concurrent_downloads", "3");
 
 #ifdef __ANDROID__


### PR DESCRIPTION
Adds a setting to disable the update indicator ("Content [6]") on the content tab header

ContentDB will still be contacted when opening the content tab or ContentDB

#14819

## To do

This PR is Ready for Review.
