### PR TITLE
Warn contributors about not to run updatepo.sh manually

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,6 +36,7 @@ Contributions are welcome! Here's how you can help:
     - Follow the [C/C++](http://dev.minetest.net/Code_style_guidelines) and
       [Lua](http://dev.minetest.net/Lua_code_style_guidelines) code style guidelines.
     - Check your code works as expected and document any changes to the Lua API.
+    - Do not run `updatepo.sh` even if your code adds new translatable strings. Running the script manually results in conflicting changes.
 
 4. Commit & [push](https://help.github.com/articles/pushing-to-a-remote/) your changes to a new branch (not `master`, one change per branch)
     - Commit messages should:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,9 @@ Contributions are welcome! Here's how you can help:
     - Follow the [C/C++](http://dev.minetest.net/Code_style_guidelines) and
       [Lua](http://dev.minetest.net/Lua_code_style_guidelines) code style guidelines.
     - Check your code works as expected and document any changes to the Lua API.
-    - Do not run `updatepo.sh` even if your code adds new translatable strings. Running the script manually results in conflicting changes.
+    - To avoid conflicting changes between contributions, do not do the following manually. They will be done before each release.
+      - Run `updatepo.sh` or update `minetest.po{,t}` even if your code adds new translatable strings.
+      - Update `minetest.conf.example` and `settings_translation_file.cpp` even if you code adds new core settings.
 
 4. Commit & [push](https://help.github.com/articles/pushing-to-a-remote/) your changes to a new branch (not `master`, one change per branch)
     - Commit messages should:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Contributions are welcome! Here's how you can help:
     - Check your code works as expected and document any changes to the Lua API.
     - To avoid conflicting changes between contributions, do not do the following manually. They will be done before each release.
       - Run `updatepo.sh` or update `minetest.po{,t}` even if your code adds new translatable strings.
-      - Update `minetest.conf.example` and `settings_translation_file.cpp` even if you code adds new core settings.
+      - Update `minetest.conf.example` and `settings_translation_file.cpp` even if your code adds new core settings.
 
 4. Commit & [push](https://help.github.com/articles/pushing-to-a-remote/) your changes to a new branch (not `master`, one change per branch)
     - Commit messages should:


### PR DESCRIPTION
This PR adds one line in `.github/CONTRIBUTING.md` warning contributors not to run `updatepo.sh`.

I was confused while contributing in #14842 on whether I should be responsible for updating the translation files. Though [running the script was a disaster](https://github.com/minetest/minetest/pull/14842#issuecomment-2222969963), I found nothing that warned me not to update.

## To do

This PR is Ready for Review.

## How to test

Navigate to the file on GitHub.
