### PR TITLE
Minimize data sent in the default user agent

### DIFF
--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -40,10 +40,17 @@ static std::unordered_map<u64, std::queue<HTTPFetchResult>>
 	g_httpfetch_results;
 static PcgRandom g_callerid_randomness;
 
+static std::string default_user_agent()
+{
+	std::string ret(PROJECT_NAME_C "/");
+	ret.append(g_version_string).append(" (").append(porting::get_sysinfo()).append(")");
+	return ret;
+}
+
 HTTPFetchRequest::HTTPFetchRequest() :
 	timeout(g_settings->getS32("curl_timeout")),
 	connect_timeout(10 * 1000),
-	useragent(std::string(PROJECT_NAME_C "/") + g_version_hash + " (" + porting::get_sysinfo() + ")")
+	useragent(default_user_agent())
 {
 	timeout = std::max(timeout, MIN_HTTPFETCH_TIMEOUT_INTERACTIVE);
 }

--- a/src/porting.h
+++ b/src/porting.h
@@ -138,7 +138,7 @@ void initializePaths();
 	Return system information
 	e.g. "Linux/3.12.7 x86_64"
 */
-std::string get_sysinfo();
+const std::string &get_sysinfo();
 
 
 // Monotonic timer


### PR DESCRIPTION
adresses #14830

* shorter kernel version `Linux/6.9.7-arch1-1` -> `Linux/6.9.7`
* no more git hash `5.9.0-dev-2f4f36696-dirty` -> `5.9.0-dev`
* entirely different on android `Linux/5.10.168-android12-9-00002-gf3c080171fd5-ab10346004 aarch64` -> `Android/32 aarch64`
  * this is a real example, 32 is the [api level](https://apilevels.com/).