### PR TITLE
Restore buggy texture overlay modifier

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -456,6 +456,9 @@ i.e. without gamma-correction.
 
 Textures can be overlaid by putting a `^` between them.
 
+Warning: If the lower and upper pixels are both semi-transparent, this operation
+does *not* do alpha blending, and it is *not* associative.
+
 Example:
 
     default_dirt.png^default_grass_side.png

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -457,7 +457,8 @@ i.e. without gamma-correction.
 Textures can be overlaid by putting a `^` between them.
 
 Warning: If the lower and upper pixels are both semi-transparent, this operation
-does *not* do alpha blending, and it is *not* associative.
+does *not* do alpha blending, and it is *not* associative. Otherwise it does
+alpha blending in srgb color space.
 
 Example:
 

--- a/src/client/imagesource.cpp
+++ b/src/client/imagesource.cpp
@@ -420,12 +420,11 @@ void blit_pixel(video::SColor src_col, video::SColor &dst_col)
 		return;
 	}
 	// A semi-transparent pixel is on top of a
-	// semi-transparent pixel -> general alpha compositing
-	u16 a_new_255 = src_a * 255 + (255 - src_a) * dst_a;
-	dst.r = (dst.r * (255 - src_a) * dst_a + src.r * src_a * 255) / a_new_255;
-	dst.g = (dst.g * (255 - src_a) * dst_a + src.g * src_a * 255) / a_new_255;
-	dst.b = (dst.b * (255 - src_a) * dst_a + src.b * src_a * 255) / a_new_255;
-	dst_a = (a_new_255 + 127) / 255;
+	// semi-transparent pixel -> weird overlaying
+	dst.r = (dst.r * (255 - src_a) + src.r * src_a) / 255;
+	dst.g = (dst.g * (255 - src_a) + src.g * src_a) / 255;
+	dst.b = (dst.b * (255 - src_a) + src.b * src_a) / 255;
+	dst_a = dst_a + (255 - dst_a) * src_a * src_a / (255 * 255);
 	dst_col.set(dst_a, dst.r, dst.g, dst.b);
 }
 


### PR DESCRIPTION
Should fix #14847.

## To do

This PR is a Ready for Review.

## How to test

I've exported the test texture from #14448 into the screenshort dir.

Here are the branches for reproduction:
* 5.8.0 https://github.com/Desour/minetest/tree/restore_weird_texture_overlay_tmp_texexport_5.8.0
* master https://github.com/Desour/minetest/tree/restore_weird_texture_overlay_tmp_texexport_master
* PR https://github.com/Desour/minetest/tree/restore_weird_texture_overlay_tmp_texexport

And here are the resulting images:
* 5.8.0 ![5_8](https://github.com/user-attachments/assets/8fab3db6-b094-4adc-976f-6f4a9421d571)
* master ![master](https://github.com/user-attachments/assets/8a130502-a99d-481b-933e-ac808b1720d0)
* PR ![pr](https://github.com/user-attachments/assets/e7bc9382-35b8-4a91-a360-74c522b4b027)

Results:
5.8.0 and PR look similar in my eyes. But sha256 hash values of the files, as well as `magick compare`, show that they're not exactly the same. I guess it's because of different rounding.