### PR TITLE
Chatcommand-based action confirmation (and use it on /clearobjects)

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -150,50 +150,65 @@ end
 --
 
 local waiting_confirm = {}
+local timeout_jobs = {}
+
+local function chat_confirm_run(name, reason)
+	local func = waiting_confirm[name]
+	if func then
+		waiting_confirm[name] = nil
+		timeout_jobs[name]:cancel()
+		timeout_jobs[name] = nil
+		return true, { func(reason) }
+	end
+	return false
+end
+
+local function chat_confirm_timeout(name)
+	chat_confirm_run(name, "timeout")
+end
 
 function core.chat_confirm(name, func)
 	if waiting_confirm[name] then
 		-- Drop the previously waiting function
-		waiting_confirm[name]("override")
+		chat_confirm_run(name, "override")
 	end
 
 	waiting_confirm[name] = func
+
+	local timeout = tonumber(core.settings:get("chat_confirm_timeout"))
+	if not timeout or timeout <= 0 then
+		timeout = 60
+	end
+	timeout_jobs[name] = core.after(timeout, chat_confirm_timeout, name)
 end
 
 core.register_chatcommand("confirm", {
 	description = S("Confirm a postponed action"),
 	func = function(name)
-		local func = waiting_confirm[name]
-		if not func then
+		local success, rtn = chat_confirm_run(name, "yes")
+		if not success then
 			return false, S("There is nothing to confirm.")
 		end
 
-		waiting_confirm[name] = nil
-		return func("yes")
+		return unpack(rtn)
 	end,
 })
 
 core.register_chatcommand("cancel", {
 	description = S("Cancel a postponed action"),
 	func = function(name)
-		local func = waiting_confirm[name]
-		if not func then
+		local success, rtn = chat_confirm_run(name, "no")
+		if not success then
 			return false, S("There is nothing to confirm.")
 		end
 
-		waiting_confirm[name] = nil
-		return func("no")
+		return unpack(rtn)
 	end,
 })
 
 core.register_on_leaveplayer(function(player)
 	local name = player:get_player_name()
-	local func = waiting_confirm[name]
-	waiting_confirm[name] = nil
-
-	if func then
-		func("left")
-	end
+	chat_confirm_run(name, "left")
 end)
 
 --

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -1333,6 +1333,7 @@ core.register_chatcommand("clearobjects", {
 				core.clear_objects(options)
 				core.log("action", "Object clearing done.")
 				core.chat_send_all("*** "..S("Cleared all objects."))
+				return true
 			end
 			return true, S("Operation canceled.")
 		end)

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -176,7 +176,7 @@ function core.chat_confirm(name, func, timeout)
 	waiting_confirm[name] = func
 
 	local final_timeout = tonumber(core.settings:get("chat_confirm_timeout"))
-	if not timeout or timeout <= 0 then
+	if not final_timeout or final_timeout <= 0 then
 		final_timeout = timeout or 60
 	end
 	timeout_jobs[name] = core.after(final_timeout, chat_confirm_timeout, name)

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -167,7 +167,7 @@ local function chat_confirm_timeout(name)
 	chat_confirm_run(name, "timeout")
 end
 
-function core.chat_confirm(name, func)
+function core.chat_confirm(name, func, timeout)
 	if waiting_confirm[name] then
 		-- Drop the previously waiting function
 		chat_confirm_run(name, "override")
@@ -175,11 +175,11 @@ function core.chat_confirm(name, func)
 
 	waiting_confirm[name] = func
 
-	local timeout = tonumber(core.settings:get("chat_confirm_timeout"))
+	local final_timeout = tonumber(core.settings:get("chat_confirm_timeout"))
 	if not timeout or timeout <= 0 then
-		timeout = 60
+		final_timeout = timeout or 60
 	end
-	timeout_jobs[name] = core.after(timeout, chat_confirm_timeout, name)
+	timeout_jobs[name] = core.after(final_timeout, chat_confirm_timeout, name)
 end
 
 core.register_chatcommand("confirm", {

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -1300,6 +1300,14 @@ core.register_chatcommand("clearobjects", {
 		end
 
 		core.chat_confirm(name, function(reason)
+			-- Check for privilege again
+			local has_privs, missing_privs = core.check_player_privs(name, { server = true })
+			if not has_privs then
+				return false, S("You don't have permission to run this command "
+					.. "(missing privileges: @1).",
+					table.concat(missing_privs, ", "))
+			end
+
 			if reason == "yes" then
 				core.log("action", name .. " clears objects ("
 				.. options.mode .. " mode).")
@@ -1310,10 +1318,8 @@ core.register_chatcommand("clearobjects", {
 				core.clear_objects(options)
 				core.log("action", "Object clearing done.")
 				core.chat_send_all("*** "..S("Cleared all objects."))
-			elseif reason == "no" then -- Only when reason == "no" we can send messages
-				return true, S("Operation canceled.")
 			end
-			return true
+			return true, S("Operation canceled.")
 		end)
 
 		return true, S("Type /confirm to confirm clearing all objects, " ..

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2030,6 +2030,9 @@ chat_message_format (Chat message format) string <@name> @message
 #    seconds, add the time information to the chat command message
 chatcommand_msg_time_threshold (Chat command time message threshold) float 0.1 0.0
 
+#    Seconds to wait before timing out an action waiting confirmation.
+chat_confirm_timeout (Time out of commands asking for confirmation) float 60.0 0.1
+
 #    A message to be displayed to all clients when the server shuts down.
 kick_msg_shutdown (Shutdown message) string Server shutting down.
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6045,6 +6045,14 @@ Chat
     * Takes player name and message, and returns the formatted string to be sent to players.
     * Can be redefined by mods if required, for things like colored names or messages.
     * **Only** the first occurrence of each placeholder will be replaced.
+* `minetest.chat_confirm(name, function(reason) end)`: Ask the player to confirm their action via chat command
+    * `name`: Name of the player
+    * `reason`: One of the following:
+        * `"yes"`: The user confirmed the action via the `/confirm` command.
+        * `"no"`: The user canceled the action via the `/cancel` command.
+        * `"override"`: The action got overridden because another `minetest.chat_confirm` call was done on the same player.
+        * `"left"`: The action gets canceled because the user left the game.
+        * If `reason` is either `"yes"` or `"no"`, the first returned value indicates success, and the second gets sent back to the player.
 
 Environment access
 ------------------

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6053,6 +6053,7 @@ Chat
         * `"override"`: The action got overridden because another `minetest.chat_confirm` call was done on the same player.
         * `"left"`: The action gets canceled because the user left the game.
         * If `reason` is either `"yes"` or `"no"`, the first returned value indicates success, and the second gets sent back to the player.
+    * **Warning**: Check for player privileges again in the callback! Player privilege may be changed while waiting for confirmation.
 
 Environment access
 ------------------

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6045,7 +6045,7 @@ Chat
     * Takes player name and message, and returns the formatted string to be sent to players.
     * Can be redefined by mods if required, for things like colored names or messages.
     * **Only** the first occurrence of each placeholder will be replaced.
-* `minetest.chat_confirm(name, function(reason) end)`: Ask the player to confirm their action via chat command
+* `minetest.chat_confirm(name, function(reason) end[, timeout])`: Ask the player to confirm their action via chat command
     * `name`: Name of the player
     * `reason`: One of the following:
         * `"yes"`: The user confirmed the action via the `/confirm` command.
@@ -6053,6 +6053,7 @@ Chat
         * `"override"`: The action got overridden because another `minetest.chat_confirm` call was done on the same player.
         * `"left"`: The action gets canceled because the user left the game.
         * If `reason` is either `"yes"` or `"no"`, the first returned value indicates success, and the second gets sent back to the player.
+    * `timeout` defaults to the value of setting `chat_confirm_timeout`.
     * **Warning**: Check for player privileges again in the callback! Player privilege may be changed while waiting for confirmation.
 
 Environment access


### PR DESCRIPTION
This PR adds built-in functions for chatcommand-based action confirmation. This PR adds a Lua API function, `minetest.chat_confirm`, and two chat commands, `/confirm` and /cancel`, for this purpose.

Using the added APIs, `/clearobjects` is wrapped with `minetest.chat_confirm` so server owners won't run the command accidentally.

This is the implementation of #6918, a concept-approved issue.

Closes #6918. 

## To do

This PR is Ready for Review.

## How to test

1. Try to use the `/clearobjects` command. Objects should get removed only after typing in `/confirm`.
2. Run the following code snippet: `minetest.chat_confirm(name, minetest.debug)`
    * If you typed `/confirm`, `yes` should be printed.
    * If you typed `/cancel`, `no` should be printed.
    * If you wait for 60 seconds (or whatever value you set in `chat_confirm_timeout`), `timeout` should be printed.
    * If you left the game, `left` should be printed.
    * If you run the snippet again, `override` should be printed.
 3. Test with `minetest.chat_confirm(name, minetest.debug, 1)`. The time-out time should be 1 second now.
