### PR TITLE
Send facedir in place of 4dir for clients < 5.7.0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1288,7 +1288,7 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 			oss.str("");
 			oss.clear();
 			writeU8(oss, serialize_as_ver);
-			mb.serialize(oss, serialize_as_ver, true, -1);
+			mb.serialize(oss, serialize_as_ver, 0, -1);
 		}
 
 		db->saveBlock(*it, oss.str());

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -320,7 +320,7 @@ static void correctBlockNodeIds(const NameIdMapping *nimap, MapNode *nodes,
 	}
 }
 
-void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int compression_level)
+void MapBlock::serialize(std::ostream &os_compressed, u8 version, u16 protocol_version, int compression_level)
 {
 	if(!ser_ver_supported(version))
 		throw VersionMismatchException("ERROR: MapBlock format not supported");
@@ -355,6 +355,7 @@ void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int
 	Buffer<u8> buf;
 	const u8 content_width = 2;
 	const u8 params_width = 2;
+	const bool disk = (protocol_version == 0);
  	if(disk)
 	{
 		MapNode *tmp_nodes = new MapNode[nodecount];
@@ -362,7 +363,7 @@ void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int
 		getBlockNodeIdMapping(&nimap, tmp_nodes, m_gamedef->ndef());
 
 		buf = MapNode::serializeBulk(version, tmp_nodes, nodecount,
-				content_width, params_width);
+				content_width, params_width, 0, nullptr);
 		delete[] tmp_nodes;
 
 		// write timestamp and node/id mapping first
@@ -375,7 +376,7 @@ void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int
 	else
 	{
 		buf = MapNode::serializeBulk(version, data, nodecount,
-				content_width, params_width);
+				content_width, params_width, protocol_version, m_gamedef->ndef());
 	}
 
 	writeU8(os, content_width);

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -426,9 +426,9 @@ public:
 	///
 
 	// These don't write or read version by itself
-	// Set disk to true for on-disk format, false for over-the-network format
+	// Set protocol_version to 0 for on-disk format, otherwise for over-the-network format
 	// Precondition: version >= SER_FMT_VER_LOWEST_WRITE
-	void serialize(std::ostream &result, u8 version, bool disk, int compression_level);
+	void serialize(std::ostream &result, u8 version, u16 protocol_version, int compression_level);
 	// If disk == true: In addition to doing other things, will add
 	// unknown blocks from id-name mapping to wndef
 	void deSerialize(std::istream &is, u8 version, bool disk);

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -387,7 +387,7 @@ bool Schematic::serializeToMts(std::ostream *os) const
 
 	// compressed bulk node data
 	auto buf = MapNode::serializeBulk(MTSCHEM_MAPNODE_SER_FMT_VER,
-		schemdata, size.X * size.Y * size.Z, 2, 2);
+		schemdata, size.X * size.Y * size.Z, 2, 2, 0, nullptr);
 	compress(buf, ss, MTSCHEM_MAPNODE_SER_FMT_VER);
 
 	return true;

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -318,7 +318,9 @@ struct alignas(u32) MapNode
 	//   compressed = true to zlib-compress output
 	static Buffer<u8> serializeBulk(int version,
 			const MapNode *nodes, u32 nodecount,
-			u8 content_width, u8 params_width);
+			u8 content_width, u8 params_width,
+			u16 protocol_version,
+			const NodeDefManager *nodemgr);
 	static void deSerializeBulk(std::istream &is, int version,
 			MapNode *nodes, u32 nodecount,
 			u8 content_width, u8 params_width);

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -467,8 +467,18 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 			writeS16(os, group.second);
 		}
 	}
+
 	writeU8(os, param_type);
-	writeU8(os, param_type_2);
+
+	// Try to compact with older clients
+	if (param_type_2 == CPT2_4DIR && protocol_version < 42) {
+		// 4dir was added in 5.7.0
+		// Older clients can use facedir if we send only the 2 RHS bits
+		writeU8(os, CPT2_FACEDIR);
+	} else {
+		writeU8(os, param_type_2);
+	}
+	
 
 	// visual
 	writeU8(os, drawtype);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2411,7 +2411,7 @@ void Server::SendBlockNoLock(session_t peer_id, MapBlock *block, u8 ver,
 	// Serialize the block in the right format
 	if (!sptr) {
 		std::ostringstream os(std::ios_base::binary);
-		block->serialize(os, ver, false, net_compression_level);
+		block->serialize(os, ver, net_proto_version, net_compression_level);
 		block->serializeNetworkSpecific(os);
 		s = os.str();
 		sptr = &s;

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -623,7 +623,7 @@ bool ServerMap::saveBlock(MapBlock *block, MapDatabase *db, int compression_leve
 	*/
 	std::ostringstream o(std::ios_base::binary);
 	o.write((char*) &version, 1);
-	block->serialize(o, version, true, compression_level);
+	block->serialize(o, version, 0, compression_level);
 
 	// FIXME: zero copy possible in c++20 or with custom rdbuf
 	bool ret = db->saveBlock(p3d, o.str());

--- a/src/unittest/test_mapblock.cpp
+++ b/src/unittest/test_mapblock.cpp
@@ -75,7 +75,7 @@ void TestMapBlock::testSaveLoad(IGameDef *gamedef, const u8 version)
 		}
 
 		// Serialize
-		block.serialize(ss, version, true, -1);
+		block.serialize(ss, version, 0, -1);
 	}
 
 	{
@@ -108,7 +108,7 @@ void TestMapBlock::testSave29(IGameDef *gamedef)
 			block.getData()[i] = MapNode(CONTENT_AIR);
 		block.setNode({0, 0, 0}, MapNode(t_CONTENT_STONE));
 
-		block.serialize(ss, 29, true, -1);
+		block.serialize(ss, 29, 0, -1);
 	}
 
 	// Pick it apart a bit:


### PR DESCRIPTION
This PR adds a condition in node serialization so older clients receive "facedir" and a trimmed-down param2 in place of "4dir" nodes.

On the 4dir drawtype, only the last 2 bits are meaningful to the client. Therefore, only those two bits are sent to clients older than 5.7.0.

## To do

This PR is Ready for Review.

## How to test

Run a Development Test server with this PR, then join the server with MultiCraft. Notice how 4dir nodes are behaving correctly despite being an unsupported param2 type.

I tested it with param2 = 5 in 4dir, corresponding to param2 = 5 mod 4 = 1 in facedir:

| Before | After |
|---|---|
| ![screenshot_20240716_163707](https://github.com/user-attachments/assets/effa8dc6-ac54-441e-b3f0-d4efb81e0445) | ![screenshot_20240716_163946](https://github.com/user-attachments/assets/bfcc2699-7798-4f14-9998-08d7516a9ced) |
