### PR TITLE
Confirmation before clearing objects

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -1258,7 +1258,7 @@ core.register_chatcommand("clearobjects", {
 		elseif param == "confirm" or param == "cancel" then
 			local data = clearobjects_confirms[name]
 			if not data then
-				return false, S("There are no pending /clearobjects actions.")
+				return false, S("There is no pending /clearobjects action.")
 			end
 
 			clearobjects_confirms[name] = nil


### PR DESCRIPTION
This PR adds confirmation to `/clearobjects`. Typing `/clearobjects confirm` runs the job, and `/clearobjects cancel` cancels the job. The job is also canceled if the player leaves or does not respond for 60 seconds.

Re-implementation of #14854
Closes #6918

## To do

This PR is Ready for Review.

## How to test

1. Run `/clearobjects`. It will prompt you to type in either `/clearobjects confirm` or `/clearobjects cancel`.
2. Run `/clearobjects confirm` after step (1). Objects should be cleared.
3. Run `/clearobjects cancel` after step (1). The task is canceled.
4. Do step (2) and (3) without step (1). It should raise "There are no pending /clearobjects actions."
