### PR TITLE
Set SDL_HINT_APP_NAME to Minetest

### DIFF
--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -339,6 +339,8 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters &param) :
 		SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 		SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
 
+		SDL_SetHint(SDL_HINT_APP_NAME, "Minetest");
+
 		u32 flags = SDL_INIT_TIMER | SDL_INIT_EVENTS;
 		if (CreationParams.DriverType != video::EDT_NULL)
 			flags |= SDL_INIT_VIDEO;

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -339,7 +339,9 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters &param) :
 		SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 		SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
 
+#if defined(SDL_HINT_APP_NAME)
 		SDL_SetHint(SDL_HINT_APP_NAME, "Minetest");
+#endif
 
 		u32 flags = SDL_INIT_TIMER | SDL_INIT_EVENTS;
 		if (CreationParams.DriverType != video::EDT_NULL)


### PR DESCRIPTION
This PR sets the SDL app name to "Minetest". Previously, Minetest reported itself as "My SDL application".

## To do

This PR is Ready for Review.

~~For some reason, I cannot get this working on [GCC 7](https://github.com/minetest/minetest/actions/runs/9974821870/job/27563127817)/[clang 7](https://github.com/minetest/minetest/actions/runs/9974821870/job/27563126601).~~ Seems like the problem is the Ubuntu version our CIs use.

## How to test

I don't know how to query for the app name directly, but at least KDE Plasma shows it when Minetest blocks sleeping.

Before:
![螢幕截圖_20240717_210238](https://github.com/user-attachments/assets/b29e4d5c-2bb0-46d5-a5aa-068a5ed9e2bf)

After:

![螢幕截圖_20240717_210412](https://github.com/user-attachments/assets/f6e7715a-fc6c-43ab-b8c7-1fcd2c333c8a)
