### PR TITLE
Fix `The variable 'irrevent' is being used without being initialized` error in Debug build from MSVS

### DIFF
--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -705,6 +705,7 @@ bool CIrrDeviceSDL::run()
 
 	while (!Close && wrap_PollEvent(&SDL_event)) {
 		// os::Printer::log("event: ", core::stringc((int)SDL_event.type).c_str(),   ELL_INFORMATION);	// just for debugging
+		memset(&irrevent, 0, sizeof(irrevent));
 
 		switch (SDL_event.type) {
 		case SDL_MOUSEMOTION: {


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
- Fix https://github.com/minetest/minetest/issues/14779
- How does the PR work?
- By move the declaration into the while loop, like sfan5 said.
- Does it resolve any reported issue?
- https://github.com/minetest/minetest/issues/14779
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
- IMHO yes.
- If not a bug fix, why is this PR needed? What usecases does it solve?
- this is a bug fix, without this fixed, the MSVS debug build will not be able to run, can only use Release build.

## To do
see if members give me advise about other implementation of this functionality or code logic, and help of commiting about code format problems, especially the latter if there's code format problems in any reviewers's opinion. (I'm probably capable of doing the former myself)

This PR is Ready for Review.

## How to test
See the test video, or see changes in src.

<!-- Example code or instructions -->
