### PR TITLE
Allow nametags to support formatted text

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -42,6 +42,7 @@ core.features = {
 	node_interaction_actor = true,
 	moveresult_new_pos = true,
 	override_item_remove_fields = true,
+	nametag_formatted_text = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5455,6 +5455,8 @@ Utilities
       moveresult_new_pos = true,
       -- Allow removing definition fields in `minetest.override_item`
       override_item_remove_fields = true,
+      -- Nametags can be bold, italic and have a monospace font
+      nametag_formatted_text = true,
   }
   ```
 
@@ -7989,6 +7991,9 @@ child will follow movement and rotation of that bone.
           text = "",
           color = {a=0..255, r=0..255, g=0..255, b=0..255},
           bgcolor = {a=0..255, r=0..255, g=0..255, b=0..255},
+          font = "normal",
+          bold = true,
+          italic = false,
       }
       ```
 * `set_nametag_attributes(attributes)`
@@ -8003,6 +8008,12 @@ child will follow movement and rotation of that bone.
           -- ^ Sets background color of nametag
           -- `false` will cause the background to be set automatically based on user settings
           -- Default: false
+          font = "normal",
+          -- ^ Can be `"normal"` for the default font and `"mono"` for the monospaced font
+          bold = true,
+          -- ^ If true the text is bold
+          italic = false,
+          -- ^ If true the text is italic
       }
       ```
 
@@ -8881,6 +8892,17 @@ Player properties need to be saved manually.
     -- Sets background color of nametag
     -- `false` will cause the background to be set automatically based on user settings.
     -- Default: false
+
+    nametag_font = "mono",
+    -- Sets the font of the nametag
+    -- can be `"normal"` for the default font
+    -- or `"mono"` for the monospaced font.
+
+    nametag_bold = false,
+    -- If true the nametag text is bold.
+
+    nametag_italic = false,
+    -- If true the nametag text is italic.
 
     infotext = "",
     -- Same as infotext for nodes. Empty by default

--- a/games/devtest/mods/testentities/visuals.lua
+++ b/games/devtest/mods/testentities/visuals.lua
@@ -106,6 +106,9 @@ minetest.register_entity("testentities:nametag", {
 			local data = minetest.deserialize(staticdata)
 			self.color = data.color
 			self.bgcolor = data.bgcolor
+			self.font = data.font
+			self.bold = data.bold
+			self.italic = data.italic
 		else
 			self.color = {
 				r = math.random(0, 255),
@@ -121,6 +124,10 @@ minetest.register_entity("testentities:nametag", {
 					a = math.random(0, 255),
 				}
 			end
+
+			self.font = math.random() < 0.5 and "normal" or "mono"
+			self.bold = math.random() < 0.5
+			self.italic = math.random() < 0.5
 		end
 
 		assert(self.color)
@@ -128,7 +135,29 @@ minetest.register_entity("testentities:nametag", {
 			nametag = tostring(math.random(1000, 10000)),
 			nametag_color = self.color,
 			nametag_bgcolor = self.bgcolor,
+			nametag_font = self.font,
+			nametag_bold = self.bold,
+			nametag_italic = self.italic,
 		})
+	end,
+
+	on_punch = function(self, puncher)
+		local prop = self.object:get_properties()
+		-- flip attributes
+		local rotator = prop.nametag_color.r%3
+		if rotator == 0 then
+			self.object:set_nametag_attributes({
+				font = prop.nametag_font == "normal" and "mono" or "normal",
+			})
+		elseif rotator == 1 then
+			self.object:set_nametag_attributes({
+				bold = not prop.nametag_bold,
+			})
+		elseif rotator == 2 then
+			self.object:set_nametag_attributes({
+				italic = not prop.nametag_italic,
+			})
+		end
 	end,
 
 	get_staticdata = function(self)

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -644,7 +644,6 @@ void Camera::drawNametags()
 	core::matrix4 trans = m_cameranode->getProjectionMatrix();
 	trans *= m_cameranode->getViewMatrix();
 
-	gui::IGUIFont *font = g_fontengine->getFont();
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
 	v2u32 screensize = driver->getScreenSize();
 
@@ -655,6 +654,8 @@ void Camera::drawNametags()
 		f32 transformed_pos[4] = { pos.X, pos.Y, pos.Z, 1.0f };
 		trans.multiplyWith1x4Matrix(transformed_pos);
 		if (transformed_pos[3] > 0) {
+			gui::IGUIFont *font = nametag->getFont();
+
 			std::wstring nametag_colorless =
 				unescape_translate(utf8_to_wide(nametag->text));
 			core::dimension2d<u32> textsize = font->getDimension(
@@ -683,9 +684,10 @@ void Camera::drawNametags()
 
 Nametag *Camera::addNametag(scene::ISceneNode *parent_node,
 		const std::string &text, video::SColor textcolor,
-		std::optional<video::SColor> bgcolor, const v3f &pos)
+		std::optional<video::SColor> bgcolor, const v3f &pos,
+		const FontSpec &font_spec)
 {
-	Nametag *nametag = new Nametag(parent_node, text, textcolor, bgcolor, pos);
+	Nametag *nametag = new Nametag(parent_node, text, textcolor, bgcolor, pos, font_spec);
 	m_nametags.push_back(nametag);
 	return nametag;
 }

--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "inventory.h"
 #include "util/numeric.h"
 #include "client/localplayer.h"
+#include "fontengine.h"
 #include <ICameraSceneNode.h>
 #include <ISceneNode.h>
 #include <plane3d.h>
@@ -43,17 +44,20 @@ struct Nametag
 	video::SColor textcolor;
 	std::optional<video::SColor> bgcolor;
 	v3f pos;
+	FontSpec font_spec;
 
 	Nametag(scene::ISceneNode *a_parent_node,
 			const std::string &text,
 			const video::SColor &textcolor,
 			const std::optional<video::SColor> &bgcolor,
-			const v3f &pos):
+			const v3f &pos,
+			const FontSpec &font_spec):
 		parent_node(a_parent_node),
 		text(text),
 		textcolor(textcolor),
 		bgcolor(bgcolor),
-		pos(pos)
+		pos(pos),
+		font_spec(font_spec)
 	{
 	}
 
@@ -69,6 +73,10 @@ struct Nametag
 		else
 			// Light background for dark text
 			return video::SColor(50, 255, 255, 255);
+	}
+
+	gui::IGUIFont *getFont() const {
+		return g_fontengine->getFont(font_spec);
 	}
 };
 
@@ -201,7 +209,8 @@ public:
 
 	Nametag *addNametag(scene::ISceneNode *parent_node,
 		const std::string &text, video::SColor textcolor,
-		std::optional<video::SColor> bgcolor, const v3f &pos);
+		std::optional<video::SColor> bgcolor, const v3f &pos,
+		const FontSpec &font_spec);
 
 	void removeNametag(Nametag *nametag);
 

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1009,13 +1009,17 @@ void GenericCAO::updateNametag()
 		// Add nametag
 		m_nametag = m_client->getCamera()->addNametag(node,
 			m_prop.nametag, m_prop.nametag_color,
-			m_prop.nametag_bgcolor, pos);
+			m_prop.nametag_bgcolor, pos,
+			FontSpec(FONT_SIZE_UNSPECIFIED, (FontMode) m_prop.nametag_font,
+					m_prop.nametag_bold, m_prop.nametag_italic));
 	} else {
 		// Update nametag
 		m_nametag->text = m_prop.nametag;
 		m_nametag->textcolor = m_prop.nametag_color;
 		m_nametag->bgcolor = m_prop.nametag_bgcolor;
 		m_nametag->pos = pos;
+		m_nametag->font_spec = FontSpec(FONT_SIZE_UNSPECIFIED, (FontMode) m_prop.nametag_font,
+					m_prop.nametag_bold, m_prop.nametag_italic);
 	}
 }
 

--- a/src/client/fontengine.h
+++ b/src/client/fontengine.h
@@ -50,6 +50,11 @@ struct FontSpec {
 		return (mode << 2) | (static_cast<u8>(bold) << 1) | static_cast<u8>(italic);
 	}
 
+	bool operator==(const FontSpec& other) const {
+		return size == other.size && mode == other.mode &&
+				bold == other.bold && italic == other.italic;
+	}
+
 	unsigned int size;
 	FontMode mode;
 	bool bold;

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -72,6 +72,9 @@ std::string ObjectProperties::dump() const
 	else
 		os << ", nametag_bgcolor=null ";
 
+	os << ", nametag_font=" << nametag_font;
+	os << ", nametag_bold=" << nametag_bold;
+	os << ", nametag_italic=" << nametag_italic;
 	os << ", selectionbox=" << selectionbox.MinEdge << "," << selectionbox.MaxEdge;
 	os << ", rotate_selectionbox=" << rotate_selectionbox;
 	os << ", pointable=" << Pointabilities::toStringPointabilityType(pointable);
@@ -172,6 +175,9 @@ void ObjectProperties::serialize(std::ostream &os) const
 		writeARGB8(os, nametag_bgcolor.value());
 
 	writeU8(os, rotate_selectionbox);
+	writeU8(os, nametag_font);
+	writeU8(os, nametag_bold);
+	writeU8(os, nametag_italic);
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
 }
@@ -244,5 +250,15 @@ void ObjectProperties::deSerialize(std::istream &is)
 		if (is.eof())
 			return;
 		rotate_selectionbox = tmp;
+
+		tmp = readU8(is);
+		u8 tmp2 = readU8(is);
+		u8 tmp3 = readU8(is);
+		if (is.eof())
+			return;
+		nametag_font = tmp;
+		nametag_bold = tmp2;
+		nametag_italic = tmp3;
+
 	} catch (SerializationError &e) {}
 }

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -48,6 +48,9 @@ struct ObjectProperties
 	v3f visual_size = v3f(1, 1, 1);
 	video::SColor nametag_color = video::SColor(255, 255, 255, 255);
 	std::optional<video::SColor> nametag_bgcolor;
+	u8 nametag_font = 0;
+	bool nametag_bold = false;
+	bool nametag_italic = false;
 	v2s16 spritediv = v2s16(1, 1);
 	v2s16 initial_sprite_basepos;
 	f32 stepheight = 0.0f;
@@ -82,8 +85,8 @@ private:
 		// Make sure to add new members to this list!
 		return std::tie(
 		textures, colors, collisionbox, selectionbox, visual, mesh, damage_texture_modifier,
-		nametag, infotext, wield_item, visual_size, nametag_color, nametag_bgcolor,
-		spritediv, initial_sprite_basepos, stepheight, automatic_rotate,
+		nametag, infotext, wield_item, visual_size, nametag_color, nametag_bgcolor, nametag_font,
+		nametag_bold, nametag_italic, spritediv, initial_sprite_basepos, stepheight, automatic_rotate,
 		automatic_face_movement_dir_offset, automatic_face_movement_max_rotation_per_sec,
 		eye_height, zoom_fov, hp_max, breath_max, glow, pointable, physical,
 		collideWithObjects, rotate_selectionbox, is_visible, makes_footstep_sound,

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -449,6 +449,18 @@ void read_object_properties(lua_State *L, int index,
 	}
 	lua_pop(L, 1);
 
+
+	std::string font_mode;
+	if (getstringfield(L, -1, "nametag_font", font_mode)) {
+		if (font_mode == "mono") {
+			prop->nametag_font = 1;
+		} else {
+			prop->nametag_font = 0; // for font_mode == "normal" or else
+		}
+	}
+	getboolfield(L, -1, "nametag_bold", prop->nametag_bold);
+	getboolfield(L, -1, "nametag_italic", prop->nametag_italic);
+
 	getstringfield(L, -1, "infotext", prop->infotext);
 	getboolfield(L, -1, "static_save", prop->static_save);
 
@@ -547,6 +559,18 @@ void push_object_properties(lua_State *L, const ObjectProperties *prop)
 		lua_pushboolean(L, false);
 		lua_setfield(L, -2, "nametag_bgcolor");
 	}
+	if(prop->nametag_font == 1) {
+		lua_pushstring(L, "mono");
+	} else if (prop->nametag_font == 0) {
+		lua_pushstring(L, "normal");
+	} else {
+		lua_pushstring(L, "unknown");
+	}
+	lua_setfield(L, -2, "nametag_font");
+	lua_pushboolean(L, prop->nametag_bold);
+	lua_setfield(L, -2, "nametag_bold");
+	lua_pushboolean(L, prop->nametag_italic);
+	lua_setfield(L, -2, "nametag_italic");
 	lua_pushlstring(L, prop->infotext.c_str(), prop->infotext.size());
 	lua_setfield(L, -2, "infotext");
 	lua_pushboolean(L, prop->static_save);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -892,6 +892,17 @@ int ObjectRef::l_set_nametag_attributes(lua_State *L)
 
 	prop->nametag = getstringfield_default(L, 2, "text", prop->nametag);
 
+	std::string font_mode;
+	if (getstringfield(L, 2, "font", font_mode)) {
+		if (font_mode == "mono") {
+			prop->nametag_font = 1;
+		} else {
+			prop->nametag_font = 0; // for font_mode == "normal" or else
+		}
+	}
+	prop->nametag_bold = getboolfield_default(L, 2, "bold", prop->nametag_bold);
+	prop->nametag_italic = getboolfield_default(L, 2, "italic", prop->nametag_italic);
+
 	prop->validate();
 	sao->notifyObjectPropertiesModified();
 	return 0;
@@ -926,7 +937,19 @@ int ObjectRef::l_get_nametag_attributes(lua_State *L)
 	lua_pushstring(L, prop->nametag.c_str());
 	lua_setfield(L, -2, "text");
 
+	if(prop->nametag_font == 1) {
+		lua_pushstring(L, "mono");
+	} else if (prop->nametag_font == 0) {
+		lua_pushstring(L, "normal");
+	} else {
+		lua_pushstring(L, "unknown");
+	}
+	lua_setfield(L, -2, "font");
 
+	lua_pushboolean(L, prop->nametag_bold);
+	lua_setfield(L, -2, "bold");
+	lua_pushboolean(L, prop->nametag_italic);
+	lua_setfield(L, -2, "italic");
 
 	return 1;
 }


### PR DESCRIPTION
### Goal of the PR

Resolves #13673 to get some money from Zughy.

### How does the PR work?

![font_test](https://github.com/user-attachments/assets/9d749bb3-fad3-48f7-a005-c3d169f9bd34)


- It uses the existing font system, which is used by formspecs, so you can use the font type `mono` or `normal`, and make it `bold` and/or `italic`.
- The whole text only uses one font, so you can't combine different fonts in one nametag, like it is for any other text in Minetest. (It wouldn't be a problem to draw text with multiple fonts, but we don't have a standard for font escape sequences yet, and I don't know if anyone would actually want this.)

## To do

This PR is Ready for Review.
- get some reviews

## How to test

Start devtest, spawn some `testentities:nametag`, and punch them.
