### PR TITLE
Print peer ID in some networking verbose logs

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1121,7 +1121,7 @@ bool UDPPeer::processReliableSendCommand(
 	u16 packets_available = toadd.size();
 	/* we didn't get a single sequence number no need to fill queue */
 	if (!have_initial_sequence_number) {
-		LOG(derr_con << m_connection->getDesc() << "Ran out of sequence numbers! (peer id: " << c_ptr->peer_id << ")" << std::endl);
+		verbosestream << m_connection->getDesc() << "Ran out of sequence numbers! (peer id: " << c_ptr->peer_id << ")" << std::endl;
 		return false;
 	}
 

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1121,7 +1121,7 @@ bool UDPPeer::processReliableSendCommand(
 	u16 packets_available = toadd.size();
 	/* we didn't get a single sequence number no need to fill queue */
 	if (!have_initial_sequence_number) {
-		LOG(derr_con << m_connection->getDesc() << "Ran out of sequence numbers!" << std::endl);
+		LOG(derr_con << m_connection->getDesc() << "Ran out of sequence numbers! (peer id: " << c_ptr->peer_id << ")" << std::endl);
 		return false;
 	}
 

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -1199,9 +1199,9 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Control(Channel *chan
 			if (channel->outgoing_reliables_sent.size() == 0)
 				m_connection->TriggerSend();
 		} catch (NotFoundException &e) {
-			LOG(derr_con << m_connection->getDesc()
+			verbosestream << m_connection->getDesc()
 				<< "WARNING: ACKed packet not in outgoing queue"
-				<< " seqnum=" << seqnum << std::endl);
+				<< ", peer_id=" << peer->id << ", seqnum=" << seqnum << std::endl;
 			channel->UpdatePacketTooLateCounter();
 		}
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2668,7 +2668,8 @@ void Server::sendRequestedMedia(session_t peer_id,
 	assert(client);
 
 	infostream << "Server::sendRequestedMedia(): Sending "
-		<< tosend.size() << " files to " << client->getName() << std::endl;
+		<< tosend.size() << " files to " << client->getName()
+		<< ", peer_id=" << peer_id << std::endl;
 
 	/* Read files and prepare bunches */
 
@@ -2691,7 +2692,8 @@ void Server::sendRequestedMedia(session_t peer_id,
 
 		if (it == m_media.end()) {
 			errorstream<<"Server::sendRequestedMedia(): Client asked for "
-					<<"unknown file \""<<(name)<<"\""<<std::endl;
+					<< "unknown file \"" << name << "\""
+					<< ", peer_id=" << peer_id <<std::endl;
 			continue;
 		}
 		const auto &m = it->second;
@@ -2700,8 +2702,9 @@ void Server::sendRequestedMedia(session_t peer_id,
 		// have duplicate filenames. So we can't check it.
 		if (!m.no_announce) {
 			if (!client->markMediaSent(name)) {
-				infostream << "Server::sendRequestedMedia(): Client asked has "
-					"requested \"" << name << "\" before, not sending it again."
+				infostream << "Server::sendRequestedMedia(): Client peer_id="
+					<< peer_id << " asked has requested \"" << name
+					<< "\" before, not sending it again."
 					<< std::endl;
 				continue;
 			}
@@ -2754,7 +2757,9 @@ void Server::sendRequestedMedia(session_t peer_id,
 		verbosestream << "Server::sendRequestedMedia(): bunch "
 				<< i << "/" << num_bunches
 				<< " files=" << bunch_size
-				<< " size="  << pkt.getSize() << std::endl;
+				<< " size="  << pkt.getSize()
+				<< " peer_id=" << peer_id
+				<< std::endl;
 		Send(&pkt);
 	}
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2702,7 +2702,6 @@ void Server::sendRequestedMedia(session_t peer_id,
 			if (!client->markMediaSent(name)) {
 				infostream << "Server::sendRequestedMedia(): Client asked has "
 					"requested \"" << name << "\" before, not sending it again."
-					<< "\" before, not sending it again."
 					<< std::endl;
 				continue;
 			}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2693,7 +2693,7 @@ void Server::sendRequestedMedia(session_t peer_id,
 		if (it == m_media.end()) {
 			errorstream<<"Server::sendRequestedMedia(): Client asked for "
 					<< "unknown file \"" << name << "\""
-					<< ", peer_id=" << peer_id <<std::endl;
+					<< ", peer_id=" << peer_id << std::endl;
 			continue;
 		}
 		const auto &m = it->second;
@@ -2703,7 +2703,7 @@ void Server::sendRequestedMedia(session_t peer_id,
 		if (!m.no_announce) {
 			if (!client->markMediaSent(name)) {
 				infostream << "Server::sendRequestedMedia(): Client peer_id="
-					<< peer_id << " asked has requested \"" << name
+					<< peer_id << " has requested \"" << name
 					<< "\" before, not sending it again."
 					<< std::endl;
 				continue;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2668,8 +2668,7 @@ void Server::sendRequestedMedia(session_t peer_id,
 	assert(client);
 
 	infostream << "Server::sendRequestedMedia(): Sending "
-		<< tosend.size() << " files to " << client->getName()
-		<< ", peer_id=" << peer_id << std::endl;
+		<< tosend.size() << " files to " << client->getName() << std::endl;
 
 	/* Read files and prepare bunches */
 
@@ -2692,8 +2691,7 @@ void Server::sendRequestedMedia(session_t peer_id,
 
 		if (it == m_media.end()) {
 			errorstream<<"Server::sendRequestedMedia(): Client asked for "
-					<< "unknown file \"" << name << "\""
-					<< ", peer_id=" << peer_id << std::endl;
+					<<"unknown file \""<<(name)<<"\""<<std::endl;
 			continue;
 		}
 		const auto &m = it->second;
@@ -2702,8 +2700,8 @@ void Server::sendRequestedMedia(session_t peer_id,
 		// have duplicate filenames. So we can't check it.
 		if (!m.no_announce) {
 			if (!client->markMediaSent(name)) {
-				infostream << "Server::sendRequestedMedia(): Client peer_id="
-					<< peer_id << " has requested \"" << name
+				infostream << "Server::sendRequestedMedia(): Client asked has "
+					"requested \"" << name << "\" before, not sending it again."
 					<< "\" before, not sending it again."
 					<< std::endl;
 				continue;
@@ -2757,9 +2755,7 @@ void Server::sendRequestedMedia(session_t peer_id,
 		verbosestream << "Server::sendRequestedMedia(): bunch "
 				<< i << "/" << num_bunches
 				<< " files=" << bunch_size
-				<< " size="  << pkt.getSize()
-				<< " peer_id=" << peer_id
-				<< std::endl;
+				<< " size="  << pkt.getSize() << std::endl;
 		Send(&pkt);
 	}
 }


### PR DESCRIPTION
This PR adds peer ID into "Ran out of sequence numbers" and other verbose logs. This helps to debug #14765.

Related persons: @KaylebJay @sfan5

## To do

This PR is ready for review.

## How to test

Start a Minetest server in verbose logging, and somehow encounter problems. Pray for being lucky - if we knew how to do that intentionally, we would have fixed the issue.
