### PR TITLE
Clamp hotbar selection to slots that exist

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8227,7 +8227,7 @@ child will follow movement and rotation of that bone.
     * `count`: number of items, must be between `1` and `32`
     * If `count` exceeds the `"main"` list size, the list size will be used instead.
 * `hud_get_hotbar_itemcount()`: returns number of visible items
-    * This value is not clamped by the `"main"` list size.
+    * This value is also clamped by the `"main"` list size.
 * `hud_set_hotbar_image(texturename)`
     * sets background image for hotbar
 * `hud_get_hotbar_image()`: returns texturename

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8225,7 +8225,9 @@ child will follow movement and rotation of that bone.
     * See `hud_set_flags` for a list of flags that can be toggled.
 * `hud_set_hotbar_itemcount(count)`: sets number of items in builtin hotbar
     * `count`: number of items, must be between `1` and `32`
+    * If `count` exceeds the `"main"` list size, the list size will be used instead.
 * `hud_get_hotbar_itemcount()`: returns number of visible items
+    * This value is not clamped by the `"main"` list size.
 * `hud_set_hotbar_image(texturename)`
     * sets background image for hotbar
 * `hud_get_hotbar_image()`: returns texturename

--- a/games/devtest/mods/unittests/player.lua
+++ b/games/devtest/mods/unittests/player.lua
@@ -90,6 +90,7 @@ unittests.register("test_player_add_pos", run_player_add_pos_tests, {player=true
 local function run_player_hotbar_clamp_tests(player)
 	local inv = player:get_inventory()
 	local old_inv_size = inv:get_size("main")
+	local old_inv_list = inv:get_list("main") -- Avoid accidentally removing item
 	local old_bar_size = player:hud_get_hotbar_itemcount()
 
 	inv:set_size("main", 5)
@@ -101,6 +102,7 @@ local function run_player_hotbar_clamp_tests(player)
 	assert(player:hud_get_hotbar_itemcount() == 5)
 
 	inv:set_size("main", old_inv_size)
+	inv:set_list("main", old_inv_list)
 	player:hud_set_hotbar_itemcount(old_bar_size)
 end
 unittests.register("test_player_hotbar_clamp", run_player_hotbar_clamp_tests, {player=true})

--- a/games/devtest/mods/unittests/player.lua
+++ b/games/devtest/mods/unittests/player.lua
@@ -84,3 +84,23 @@ local function run_player_add_pos_tests(player)
 end
 unittests.register("test_player_add_pos", run_player_add_pos_tests, {player=true})
 
+--
+-- Hotbar selection clamp
+--
+local function run_player_hotbar_clamp_tests(player)
+	local inv = player:get_inventory()
+	local old_inv_size = inv:get_size("main")
+	local old_bar_size = player:hud_get_hotbar_itemcount()
+
+	inv:set_size("main", 5)
+
+	player:hud_set_hotbar_itemcount(2)
+	assert(player:hud_get_hotbar_itemcount() == 2)
+
+	player:hud_set_hotbar_itemcount(6)
+	assert(player:hud_get_hotbar_itemcount() == 5)
+
+	inv:set_size("main", old_inv_size)
+	player:hud_set_hotbar_itemcount(old_bar_size)
+end
+unittests.register("test_player_hotbar_clamp", run_player_hotbar_clamp_tests, {player=true})

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2192,9 +2192,10 @@ void Game::processItemSelection(u16 *new_playeritem)
 	 */
 	Inventory *inventory = &player->inventory;
 	InventoryList *mainlist = inventory->getList("main");
-	s32 mainlist_size = (mainlist == nullptr) ? PLAYER_INVENTORY_SIZE : mainlist->getSize();
+	if (mainlist == nullptr)
+		return;
 	*new_playeritem = player->getWieldIndex();
-	u16 max_item = MYMIN(mainlist_size - 1,
+	u16 max_item = MYMIN((s32) mainlist->getSize() - 1,
 		    player->hud_hotbar_itemcount - 1);
 
 	s32 wheel = input->getMouseWheel();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2190,8 +2190,10 @@ void Game::processItemSelection(u16 *new_playeritem)
 
 	/* Item selection using mouse wheel
 	 */
+	Inventory *inventory = &player->inventory;
+	InventoryList *mainlist = inventory->getList("main");
 	*new_playeritem = player->getWieldIndex();
-	u16 max_item = MYMIN(PLAYER_INVENTORY_SIZE - 1,
+	u16 max_item = MYMIN((s32) mainlist->getSize() - 1,
 		    player->hud_hotbar_itemcount - 1);
 
 	s32 wheel = input->getMouseWheel();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2192,8 +2192,9 @@ void Game::processItemSelection(u16 *new_playeritem)
 	 */
 	Inventory *inventory = &player->inventory;
 	InventoryList *mainlist = inventory->getList("main");
+	s32 mainlist_size = (mainlist == nullptr) ? PLAYER_INVENTORY_SIZE : mainlist->getSize();
 	*new_playeritem = player->getWieldIndex();
-	u16 max_item = MYMIN((s32) mainlist->getSize() - 1,
+	u16 max_item = MYMIN(mainlist_size - 1,
 		    player->hud_hotbar_itemcount - 1);
 
 	s32 wheel = input->getMouseWheel();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2188,15 +2188,14 @@ void Game::processItemSelection(u16 *new_playeritem)
 {
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
 
+	*new_playeritem = player->getWieldIndex();
+	u16 max_item = player->getMaxHotbarItemcount();
+	if (max_item == 0)
+		return;
+	max_item -= 1;
+
 	/* Item selection using mouse wheel
 	 */
-	InventoryList *mainlist = player->inventory.getList("main");
-	if (!mainlist)
-		return;
-	*new_playeritem = player->getWieldIndex();
-	u16 max_item = MYMIN((s32) mainlist->getSize() - 1,
-		    player->hud_hotbar_itemcount - 1);
-
 	s32 wheel = input->getMouseWheel();
 	if (!m_enable_hotbar_mouse_wheel)
 		wheel = 0;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2190,9 +2190,8 @@ void Game::processItemSelection(u16 *new_playeritem)
 
 	/* Item selection using mouse wheel
 	 */
-	Inventory *inventory = &player->inventory;
-	InventoryList *mainlist = inventory->getList("main");
-	if (mainlist == nullptr)
+	InventoryList *mainlist = player->inventory.getList("main");
+	if (!mainlist)
 		return;
 	*new_playeritem = player->getWieldIndex();
 	u16 max_item = MYMIN((s32) mainlist->getSize() - 1,

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -783,7 +783,7 @@ void Hud::drawHotbar(u16 playeritem)
 
 	v2s32 centerlowerpos(m_displaycenter.X, m_screensize.Y);
 
-	s32 hotbar_itemcount = MYMIN(player->hud_hotbar_itemcount, (s32) mainlist->getSize());
+	s32 hotbar_itemcount = player->getMaxHotbarItemcount();
 	s32 width = hotbar_itemcount * (m_hotbar_imagesize + m_padding * 2);
 	v2s32 pos = centerlowerpos - v2s32(width / 2, m_hotbar_imagesize + m_padding * 3);
 

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -783,7 +783,7 @@ void Hud::drawHotbar(u16 playeritem)
 
 	v2s32 centerlowerpos(m_displaycenter.X, m_screensize.Y);
 
-	s32 hotbar_itemcount = player->hud_hotbar_itemcount;
+	s32 hotbar_itemcount = MYMIN(player->hud_hotbar_itemcount, (s32) mainlist->getSize());
 	s32 width = hotbar_itemcount * (m_hotbar_imagesize + m_padding * 2);
 	v2s32 pos = centerlowerpos - v2s32(width / 2, m_hotbar_imagesize + m_padding * 3);
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -861,6 +861,18 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 		return;
 	}
 
+	Inventory *inventory = &player->inventory;
+	InventoryList *mainlist = inventory->getList("main");
+	u32 mainlist_size = (mainlist == nullptr) ? PLAYER_INVENTORY_SIZE : mainlist->getSize();
+	if (item > mainlist_size) {
+		actionstream << "Player: " << player->getName()
+			<< " tried to access item=" << item
+			<< " out of main list size="
+			<< mainlist_size
+			<< "; ignoring." << std::endl;
+		return;
+	}
+
 	playersao->getPlayer()->setWieldIndex(item);
 }
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -863,7 +863,7 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 
 	Inventory *inventory = &player->inventory;
 	InventoryList *mainlist = inventory->getList("main");
-	u32 mainlist_size = (mainlist == nullptr) ? PLAYER_INVENTORY_SIZE : mainlist->getSize();
+	u32 mainlist_size = (mainlist == nullptr) ? 0 : mainlist->getSize();
 	if (item > mainlist_size) {
 		actionstream << "Player: " << player->getName()
 			<< " tried to access item=" << item

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -862,8 +862,8 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 	}
 
 	Inventory *inventory = &player->inventory;
-	InventoryList *mainlist = inventory->getList("main");
-	u32 mainlist_size = (mainlist == nullptr) ? 0 : mainlist->getSize();
+	auto *mainlist = player->inventory.getList("main");
+	u32 mainlist_size = mainlist ? mainlist->getSize() : 0;
 	if (item > mainlist_size) {
 		actionstream << "Player: " << player->getName()
 			<< " tried to access item=" << item

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -852,23 +852,11 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 
 	*pkt >> item;
 
-	if (item >= player->getHotbarItemcount()) {
+	if (item >= player->getMaxHotbarItemcount()) {
 		actionstream << "Player: " << player->getName()
 			<< " tried to access item=" << item
 			<< " out of hotbar_itemcount="
-			<< player->getHotbarItemcount()
-			<< "; ignoring." << std::endl;
-		return;
-	}
-
-	Inventory *inventory = &player->inventory;
-	auto *mainlist = player->inventory.getList("main");
-	u32 mainlist_size = mainlist ? mainlist->getSize() : 0;
-	if (item > mainlist_size) {
-		actionstream << "Player: " << player->getName()
-			<< " tried to access item=" << item
-			<< " out of main list size="
-			<< mainlist_size
+			<< player->getMaxHotbarItemcount()
 			<< "; ignoring." << std::endl;
 		return;
 	}
@@ -995,11 +983,11 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 
 	// Update wielded item
 
-	if (item_i >= player->getHotbarItemcount()) {
+	if (item_i >= player->getMaxHotbarItemcount()) {
 		actionstream << "Player: " << player->getName()
 			<< " tried to access item=" << item_i
 			<< " out of hotbar_itemcount="
-			<< player->getHotbarItemcount()
+			<< player->getMaxHotbarItemcount()
 			<< "; ignoring." << std::endl;
 		return;
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -165,7 +165,7 @@ void Player::clearHud()
 u16 Player::getMaxHotbarItemcount()
 {
 	InventoryList *mainlist = inventory.getList("main");
-	return mainlist ? std::min(mainlist->getSize(), (u16) hud_hotbar_itemcount) : 0;
+	return mainlist ? std::min(mainlist->getSize(), (u32) hud_hotbar_itemcount) : 0;
 }
 
 #ifndef SERVER

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -165,7 +165,7 @@ void Player::clearHud()
 u16 Player::getMaxHotbarItemcount()
 {
 	InventoryList *mainlist = inventory.getList("main");
-	return mainlist ? std::min((s32) mainlist->getSize(), hud_hotbar_itemcount) : 0;
+	return mainlist ? std::min(mainlist->getSize(), (u16) hud_hotbar_itemcount) : 0;
 }
 
 #ifndef SERVER

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -88,6 +88,12 @@ void Player::setWieldIndex(u16 index)
 	m_wield_index = MYMIN(index, mlist ? mlist->getSize() : 0);
 }
 
+u16 Player::getWieldIndex()
+{
+	const InventoryList *mlist = inventory.getList("main");
+	return MYMIN(m_wield_index, mlist ? mlist->getSize() : 0);
+}
+
 ItemStack &Player::getWieldedItem(ItemStack *selected, ItemStack *hand) const
 {
 	assert(selected);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -90,8 +90,7 @@ void Player::setWieldIndex(u16 index)
 
 u16 Player::getWieldIndex()
 {
-	const InventoryList *mlist = inventory.getList("main");
-	return MYMIN(m_wield_index, mlist ? mlist->getSize() : 0);
+	return std::min(m_wield_index, getMaxHotbarItemcount());
 }
 
 ItemStack &Player::getWieldedItem(ItemStack *selected, ItemStack *hand) const

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -94,7 +94,7 @@ u16 Player::getWieldIndex()
 	return MYMIN(m_wield_index, mlist ? mlist->getSize() : 0);
 }
 
-getMaxHotbarItemcountItemStack &Player::getWieldedItem(ItemStack *selected, ItemStack *hand) const
+ItemStack &Player::getWieldedItem(ItemStack *selected, ItemStack *hand) const
 {
 	assert(selected);
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -94,7 +94,7 @@ u16 Player::getWieldIndex()
 	return MYMIN(m_wield_index, mlist ? mlist->getSize() : 0);
 }
 
-ItemStack &Player::getWieldedItem(ItemStack *selected, ItemStack *hand) const
+getMaxHotbarItemcountItemStack &Player::getWieldedItem(ItemStack *selected, ItemStack *hand) const
 {
 	assert(selected);
 
@@ -161,6 +161,14 @@ void Player::clearHud()
 		delete hud.back();
 		hud.pop_back();
 	}
+}
+
+u16 Player::getMaxHotbarItemcount()
+{
+	InventoryList *mainlist = inventory.getList("main");
+	if (mainlist == nullptr)
+		return 0;
+	return std::min((s32) mainlist->getSize(), hud_hotbar_itemcount);
 }
 
 #ifndef SERVER

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -166,9 +166,7 @@ void Player::clearHud()
 u16 Player::getMaxHotbarItemcount()
 {
 	InventoryList *mainlist = inventory.getList("main");
-	if (mainlist == nullptr)
-		return 0;
-	return std::min((s32) mainlist->getSize(), hud_hotbar_itemcount);
+	return mainlist ? std::min((s32) mainlist->getSize(), hud_hotbar_itemcount) : 0;
 }
 
 #ifndef SERVER

--- a/src/player.h
+++ b/src/player.h
@@ -223,7 +223,7 @@ public:
 	// Returns non-empty `selected` ItemStack. `hand` is a fallback, if specified
 	ItemStack &getWieldedItem(ItemStack *selected, ItemStack *hand) const;
 	void setWieldIndex(u16 index);
-	u16 getWieldIndex() const { return m_wield_index; }
+	u16 getWieldIndex();
 
 	bool setFov(const PlayerFovSpec &spec)
 	{

--- a/src/player.h
+++ b/src/player.h
@@ -247,7 +247,7 @@ public:
 	u32 hud_flags;
 	s32 hud_hotbar_itemcount;
 
-	// Get proper max HUD itemcount
+	// Get actual usable number of hotbar items (clamped to size of "main" list)
 	u16 getMaxHotbarItemcount();
 
 protected:

--- a/src/player.h
+++ b/src/player.h
@@ -247,6 +247,9 @@ public:
 	u32 hud_flags;
 	s32 hud_hotbar_itemcount;
 
+	// Get proper max HUD itemcount
+	u16 getMaxHotbarItemcount();
+
 protected:
 	char m_name[PLAYERNAME_SIZE];
 	v3f m_speed; // velocity; in BS-space

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1852,7 +1852,11 @@ int ObjectRef::l_hud_get_hotbar_itemcount(lua_State *L)
 	if (player == nullptr)
 		return 0;
 
-	lua_pushinteger(L, player->getHotbarItemcount());
+	Inventory *inventory = &player->inventory;
+	InventoryList *mainlist = inventory->getList("main");
+
+	lua_pushinteger(L, (mainlist == nullptr) ? 0 :
+		MYMIN(player->getHotbarItemcount(), (s32) mainlist->getSize()));
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1852,11 +1852,7 @@ int ObjectRef::l_hud_get_hotbar_itemcount(lua_State *L)
 	if (player == nullptr)
 		return 0;
 
-	Inventory *inventory = &player->inventory;
-	InventoryList *mainlist = inventory->getList("main");
-
-	lua_pushinteger(L, (mainlist == nullptr) ? 0 :
-		MYMIN(player->getHotbarItemcount(), (s32) mainlist->getSize()));
+	lua_pushinteger(L, player->getMaxHotbarItemcount());
 	return 1;
 }
 


### PR DESCRIPTION
Limits the wield index to existing slots (i.e. <= main list size).

Fixes #11525

## To do

This PR is Ready for Review.
<!-- ^ delete one -->

- [x] Client-side checks
- [x] Server-side checks

## How to test

### Client-side

Run the following Lua snippet:

```lua
local player = minetest.get_player_by_name("singleplayer")
player:get_inventory():set_size("main", 1)
player:hud_set_hotbar_itemcount(10)
```

Your selection range should be limited to 1 instead of 10.

### Server-side network checking

Undo the changes to `client/game.cpp` and run the above script.

When you roll your mouse wheel so the selection is beyond the list size, the server will print a log saying "tried to access item=# out of main list size=#; ignoring."

### Server-side `hud_get_hotbar_itemcount()`

Run the devtest unittests. `"test_player_hotbar_clamp"` should pass.

