### PR TITLE
Clean up MSVC warnings in CIrrDeviceSDL.{h,cc}

### DIFF
--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -647,8 +647,9 @@ bool CIrrDeviceSDL::createWindowWithContext()
 	if (ScaleX != 1.0f || ScaleY != 1.0f) {
 		// The given window size is in pixels, not in screen coordinates.
 		// We can only do the conversion now since we didn't know the scale before.
-		SDL_SetWindowSize(Window, CreationParams.WindowSize.Width / ScaleX,
-				CreationParams.WindowSize.Height / ScaleY);
+		SDL_SetWindowSize(Window,
+				static_cast<int>(CreationParams.WindowSize.Width / ScaleX),
+				static_cast<int>(CreationParams.WindowSize.Height / ScaleY));
 		// Re-center, otherwise large, non-maximized windows go offscreen.
 		SDL_SetWindowPosition(Window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 		updateSizeAndScale();
@@ -716,10 +717,12 @@ bool CIrrDeviceSDL::run()
 
 			irrevent.EventType = irr::EET_MOUSE_INPUT_EVENT;
 			irrevent.MouseInput.Event = irr::EMIE_MOUSE_MOVED;
-			MouseX = irrevent.MouseInput.X = SDL_event.motion.x * ScaleX;
-			MouseY = irrevent.MouseInput.Y = SDL_event.motion.y * ScaleY;
-			MouseXRel = SDL_event.motion.xrel * ScaleX;
-			MouseYRel = SDL_event.motion.yrel * ScaleY;
+			MouseX = irrevent.MouseInput.X =
+				static_cast<s32>(SDL_event.motion.x * ScaleX);
+			MouseY = irrevent.MouseInput.Y =
+				static_cast<s32>(SDL_event.motion.y * ScaleY);
+			MouseXRel = static_cast<s32>(SDL_event.motion.xrel * ScaleX);
+			MouseYRel = static_cast<s32>(SDL_event.motion.yrel * ScaleY);
 			irrevent.MouseInput.ButtonStates = MouseButtonStates;
 			irrevent.MouseInput.Shift = (keymod & KMOD_SHIFT) != 0;
 			irrevent.MouseInput.Control = (keymod & KMOD_CTRL) != 0;
@@ -751,8 +754,8 @@ bool CIrrDeviceSDL::run()
 			SDL_Keymod keymod = SDL_GetModState();
 
 			irrevent.EventType = irr::EET_MOUSE_INPUT_EVENT;
-			irrevent.MouseInput.X = SDL_event.button.x * ScaleX;
-			irrevent.MouseInput.Y = SDL_event.button.y * ScaleY;
+			irrevent.MouseInput.X = static_cast<s32>(SDL_event.button.x * ScaleX);
+			irrevent.MouseInput.Y = static_cast<s32>(SDL_event.button.y * ScaleY);
 			irrevent.MouseInput.Shift = (keymod & KMOD_SHIFT) != 0;
 			irrevent.MouseInput.Control = (keymod & KMOD_CTRL) != 0;
 
@@ -917,8 +920,8 @@ bool CIrrDeviceSDL::run()
 			irrevent.EventType = EET_TOUCH_INPUT_EVENT;
 			irrevent.TouchInput.Event = ETIE_PRESSED_DOWN;
 			irrevent.TouchInput.ID = SDL_event.tfinger.fingerId;
-			irrevent.TouchInput.X = SDL_event.tfinger.x * Width;
-			irrevent.TouchInput.Y = SDL_event.tfinger.y * Height;
+			irrevent.TouchInput.X = static_cast<s32>(SDL_event.tfinger.x * Width);
+			irrevent.TouchInput.Y = static_cast<s32>(SDL_event.tfinger.y * Height);
 			CurrentTouchCount++;
 			irrevent.TouchInput.touchedCount = CurrentTouchCount;
 
@@ -929,8 +932,8 @@ bool CIrrDeviceSDL::run()
 			irrevent.EventType = EET_TOUCH_INPUT_EVENT;
 			irrevent.TouchInput.Event = ETIE_MOVED;
 			irrevent.TouchInput.ID = SDL_event.tfinger.fingerId;
-			irrevent.TouchInput.X = SDL_event.tfinger.x * Width;
-			irrevent.TouchInput.Y = SDL_event.tfinger.y * Height;
+			irrevent.TouchInput.X = static_cast<s32>(SDL_event.tfinger.x * Width);
+			irrevent.TouchInput.Y = static_cast<s32>(SDL_event.tfinger.y * Height);
 			irrevent.TouchInput.touchedCount = CurrentTouchCount;
 
 			postEventFromUser(irrevent);
@@ -940,8 +943,8 @@ bool CIrrDeviceSDL::run()
 			irrevent.EventType = EET_TOUCH_INPUT_EVENT;
 			irrevent.TouchInput.Event = ETIE_LEFT_UP;
 			irrevent.TouchInput.ID = SDL_event.tfinger.fingerId;
-			irrevent.TouchInput.X = SDL_event.tfinger.x * Width;
-			irrevent.TouchInput.Y = SDL_event.tfinger.y * Height;
+			irrevent.TouchInput.X = static_cast<s32>(SDL_event.tfinger.x * Width);
+			irrevent.TouchInput.Y = static_cast<s32>(SDL_event.tfinger.y * Height);
 			// To match Android behavior, still count the pointer that was
 			// just released.
 			irrevent.TouchInput.touchedCount = CurrentTouchCount;

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -159,7 +159,8 @@ public:
 		void setPosition(s32 x, s32 y) override
 		{
 			SDL_WarpMouseInWindow(Device->Window,
-					x / Device->ScaleX, y / Device->ScaleY);
+					static_cast<int>(x / Device->ScaleX),
+					static_cast<int>(y / Device->ScaleY));
 
 			if (SDL_GetRelativeMouseMode()) {
 				// There won't be an event for this warp (details on libsdl-org/SDL/issues/6034)
@@ -192,7 +193,7 @@ public:
 		virtual void setRelativeMode(bool relative) _IRR_OVERRIDE_
 		{
 			// Only change it when necessary, as it flushes mouse motion when enabled
-			if (relative != SDL_GetRelativeMouseMode()) {
+			if (relative != static_cast<bool>(SDL_GetRelativeMouseMode())) {
 				if (relative)
 					SDL_SetRelativeMouseMode(SDL_TRUE);
 				else


### PR DESCRIPTION
The only changes are to add a number of `static_cast`s to make implicit type conversions explicit.

## To do

Ready for Review.

## How to test

The change is straightforward to check by code inspection.