### PR TITLE
Allow keybindings with modifiers

### DIFF
--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -28,8 +28,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class UnknownKeycode : public BaseException
 {
 public:
-	UnknownKeycode(const char *s) :
-		BaseException(s) {};
+	UnknownKeycode(const std::string_view &s):
+		BaseException(std::string(s)) {}
 };
 
 /* A key press, consisting of either an Irrlicht keycode
@@ -40,19 +40,33 @@ class KeyPress
 public:
 	KeyPress() = default;
 
-	KeyPress(const char *name);
+	KeyPress(const std::string_view &name);
+
+	KeyPress(const char *name): KeyPress(std::string_view(name)) {};
 
 	KeyPress(const irr::SEvent::SKeyInput &in, bool prefer_character = false);
 
 	bool operator==(const KeyPress &o) const
 	{
+		return basic_equals(o) && shift == o.shift && control == o.control;
+	}
+
+	bool basic_equals(const KeyPress &o) const
+	{
 		return (Char > 0 && Char == o.Char) || (valid_kcode(Key) && Key == o.Key);
 	}
+
+	int matches(const KeyPress &p) const;
 
 	const char *sym() const;
 	const char *name() const;
 
+	bool shift = false;
+	bool control = false;
+
 protected:
+	std::string_view parseModifiers(const std::string_view &);
+
 	static bool valid_kcode(irr::EKEY_CODE k)
 	{
 		return k > 0 && k < irr::KEY_KEY_CODES_COUNT;

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -53,7 +53,8 @@ public:
 
 	bool basic_equals(const KeyPress &o) const
 	{
-		return (Char > 0 && Char == o.Char) || (valid_kcode(Key) && Key == o.Key);
+		return (Char > 0 && Char == o.Char) || (valid_kcode(Key) && Key == o.Key)
+			|| (Char == o.Char && Key == o.Key);
 	}
 
 	int matches(const KeyPress &p) const;

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -58,8 +58,8 @@ public:
 
 	int matches(const KeyPress &p) const;
 
-	const char *sym() const;
-	const char *name() const;
+	const std::string sym() const;
+	const std::string name() const;
 
 	bool shift = false;
 	bool control = false;

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -284,7 +284,7 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 
 		// Display Key already in use message
 		bool key_in_use = false;
-		if (kp.sym().empty()) {
+		if (!kp.sym().empty()) {
 			for (key_setting *ks : key_settings) {
 				if (ks != active_key && ks->key == kp) {
 					key_in_use = true;

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -142,7 +142,7 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 			core::rect<s32> rect(0, 0, 100 * s, 30 * s);
 			rect += topleft + v2s32(offset.X + 150 * s, offset.Y - 5 * s);
 			k->button = GUIButton::addButton(Environment, rect, m_tsrc, this, k->id,
-					wstrgettext(k->key.name()).c_str());
+					utf8_to_wide(k->key.name()).c_str());
 		}
 		if ((i + 1) % KMaxButtonPerColumns == 0) {
 			offset.X += 260 * s;
@@ -256,7 +256,7 @@ bool GUIKeyChangeMenu::acceptInput()
 bool GUIKeyChangeMenu::resetMenu()
 {
 	if (active_key) {
-		active_key->button->setText(wstrgettext(active_key->key.name()).c_str());
+		active_key->button->setText(utf8_to_wide(active_key->key.name()).c_str());
 		active_key = nullptr;
 		return false;
 	}
@@ -284,7 +284,7 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 
 		// Display Key already in use message
 		bool key_in_use = false;
-		if (strcmp(kp.sym(), "") != 0) {
+		if (kp.sym().empty()) {
 			for (key_setting *ks : key_settings) {
 				if (ks != active_key && ks->key == kp) {
 					key_in_use = true;
@@ -307,7 +307,7 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 		// But go on
 		{
 			active_key->key = kp;
-			active_key->button->setText(wstrgettext(kp.name()).c_str());
+			active_key->button->setText(utf8_to_wide(kp.name()).c_str());
 
 			// Allow characters made with shift
 			if (shift_went_down){

--- a/src/unittest/test_keycode.cpp
+++ b/src/unittest/test_keycode.cpp
@@ -46,7 +46,7 @@ void TestKeycode::runTests(IGameDef *gamedef)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define UASSERTEQ_STR(one, two) UASSERT(strcmp(one, two) == 0)
+#define UASSERT_HAS_NAME(key) UASSERTCMP(size_t, >, key.name().size(), 0)
 
 void TestKeycode::testCreateFromString()
 {
@@ -54,27 +54,31 @@ void TestKeycode::testCreateFromString()
 
 	// Character key, from char
 	k = KeyPress("R");
-	UASSERTEQ_STR(k.sym(), "KEY_KEY_R");
-	UASSERTCMP(int, >, strlen(k.name()), 0); // should have human description
+	UASSERT(k.sym() == "KEY_KEY_R");
+	UASSERT_HAS_NAME(k); // should have human description
 
 	// Character key, from identifier
 	k = KeyPress("KEY_KEY_B");
-	UASSERTEQ_STR(k.sym(), "KEY_KEY_B");
-	UASSERTCMP(int, >, strlen(k.name()), 0);
+	UASSERT(k.sym() == "KEY_KEY_B");
+	UASSERT_HAS_NAME(k);
 
 	// Non-Character key, from identifier
 	k = KeyPress("KEY_UP");
-	UASSERTEQ_STR(k.sym(), "KEY_UP");
-	UASSERTCMP(int, >, strlen(k.name()), 0);
+	UASSERT(k.sym() == "KEY_UP");
+	UASSERT_HAS_NAME(k);
 
 	k = KeyPress("KEY_F6");
-	UASSERTEQ_STR(k.sym(), "KEY_F6");
-	UASSERTCMP(int, >, strlen(k.name()), 0);
+	UASSERT(k.sym() == "KEY_F6");
+	UASSERT_HAS_NAME(k);
 
 	// Irrlicht-unknown key, from char
 	k = KeyPress("/");
-	UASSERTEQ_STR(k.sym(), "/");
-	UASSERTCMP(int, >, strlen(k.name()), 0);
+	UASSERT(k.sym() == "/");
+	UASSERT_HAS_NAME(k);
+
+	// Key with modifier
+	k = KeyPress("KEY_SHIFT-KEY_CONTROL-2");
+	UASSERT(k.sym() == "KEY_CONTROL-KEY_SHIFT-KEY_KEY_2");
 }
 
 void TestKeycode::testCreateFromSKeyInput()
@@ -86,25 +90,25 @@ void TestKeycode::testCreateFromSKeyInput()
 	in.Key = irr::KEY_KEY_3;
 	in.Char = L'3';
 	k = KeyPress(in);
-	UASSERTEQ_STR(k.sym(), "KEY_KEY_3");
+	UASSERT(k.sym() == "KEY_KEY_3");
 
 	// Non-Character key
 	in.Key = irr::KEY_RSHIFT;
 	in.Char = L'\0';
 	k = KeyPress(in);
-	UASSERTEQ_STR(k.sym(), "KEY_RSHIFT");
+	UASSERT(k.sym() == "KEY_RSHIFT");
 
 	// Irrlicht-unknown key
 	in.Key = irr::KEY_KEY_CODES_COUNT;
 	in.Char = L'?';
 	k = KeyPress(in);
-	UASSERTEQ_STR(k.sym(), "?");
+	UASSERT(k.sym() == "?");
 
 	// prefer_character mode
 	in.Key = irr::KEY_COMMA;
 	in.Char = L'G';
 	k = KeyPress(in, true);
-	UASSERTEQ_STR(k.sym(), "KEY_KEY_G");
+	UASSERT(k.sym() == "KEY_KEY_G");
 }
 
 void TestKeycode::testCompare()

--- a/src/unittest/test_keycode.cpp
+++ b/src/unittest/test_keycode.cpp
@@ -113,6 +113,15 @@ void TestKeycode::testCompare()
 	UASSERT(KeyPress("5") == KeyPress("KEY_KEY_5"));
 	UASSERT(!(KeyPress("5") == KeyPress("KEY_NUMPAD5")));
 
+	// Test modifiers
+	UASSERT(KeyPress("KEY_CONTROL-KEY_SHIFT-5") == KeyPress("KEY_SHIFT-KEY_CONTROL-KEY_KEY_5"));
+	UASSERT(KeyPress("KEY_SHIFT--") == KeyPress("KEY_SHIFT-KEY_MINUS"));
+
+	// Test matching
+	UASSERT(!KeyPress("5").matches(KeyPress("KEY_CONTROL-5")));
+	UASSERT(KeyPress("KEY_SHIFT-5").matches(KeyPress("5")));
+	UASSERT(KeyPress("KEY_SHIFT-5").matches(KeyPress("KEY_SHIFT-5")) > KeyPress("KEY_SHIFT-5").matches("5"));
+
 	// Matching char suffices
 	// note: This is a real-world example, Irrlicht maps XK_equal to irr::KEY_PLUS on Linux
 	irr::SEvent::SKeyInput in;

--- a/src/unittest/test_keycode.cpp
+++ b/src/unittest/test_keycode.cpp
@@ -85,6 +85,7 @@ void TestKeycode::testCreateFromSKeyInput()
 {
 	KeyPress k;
 	irr::SEvent::SKeyInput in;
+	in.Control = in.Shift = false;
 
 	// Character key
 	in.Key = irr::KEY_KEY_3;
@@ -93,12 +94,14 @@ void TestKeycode::testCreateFromSKeyInput()
 	UASSERT(k.sym() == "KEY_KEY_3");
 
 	// Non-Character key
+	in.Shift = true;
 	in.Key = irr::KEY_RSHIFT;
 	in.Char = L'\0';
 	k = KeyPress(in);
-	UASSERT(k.sym() == "KEY_RSHIFT");
+	UASSERT(k.sym() == "KEY_SHIFT");
 
 	// Irrlicht-unknown key
+	in.Shift = false;
 	in.Key = irr::KEY_KEY_CODES_COUNT;
 	in.Char = L'?';
 	k = KeyPress(in);
@@ -120,15 +123,20 @@ void TestKeycode::testCompare()
 	// Test modifiers
 	UASSERT(KeyPress("KEY_CONTROL-KEY_SHIFT-5") == KeyPress("KEY_SHIFT-KEY_CONTROL-KEY_KEY_5"));
 	UASSERT(KeyPress("KEY_SHIFT--") == KeyPress("KEY_SHIFT-KEY_MINUS"));
+	UASSERT(KeyPress("KEY_CONTROL-KEY_LSHIFT") == KeyPress("KEY_SHIFT-KEY_RCONTROL"));
+	UASSERT(KeyPress("KEY_RSHIFT") == KeyPress("KEY_SHIFT-"));
 
 	// Test matching
 	UASSERT(!KeyPress("5").matches(KeyPress("KEY_CONTROL-5")));
+	UASSERT(!KeyPress("5").matches(KeyPress("KEY_CONTROL")));
+	UASSERT(KeyPress("KEY_SHIFT-5").matches(KeyPress("KEY_SHIFT")));
 	UASSERT(KeyPress("KEY_SHIFT-5").matches(KeyPress("5")));
 	UASSERT(KeyPress("KEY_SHIFT-5").matches(KeyPress("KEY_SHIFT-5")) > KeyPress("KEY_SHIFT-5").matches("5"));
 
 	// Matching char suffices
 	// note: This is a real-world example, Irrlicht maps XK_equal to irr::KEY_PLUS on Linux
 	irr::SEvent::SKeyInput in;
+	in.Shift = in.Control = false;
 	in.Key = irr::KEY_PLUS;
 	in.Char = L'=';
 	UASSERT(KeyPress("=") == KeyPress(in));
@@ -136,6 +144,7 @@ void TestKeycode::testCompare()
 	// Matching keycode suffices
 	irr::SEvent::SKeyInput in2;
 	in.Key = in2.Key = irr::KEY_OEM_CLEAR;
+	in2.Shift = in2.Control = false;
 	in.Char = L'\0';
 	in2.Char = L';';
 	UASSERT(KeyPress(in) == KeyPress(in2));


### PR DESCRIPTION
- Goal of the PR
This PR allows users to create keybindings with modifier keys, such as Control-F10 or Shift-5.
- How does the PR work?
This PR extends the `KeyPress` class to include information on the state of modifier keys.
- Does it resolve any reported issue?
This is a _partial_ workaround for #14545 by allowing (also: requiring) users to use e.g. Shift-7 instead of `/` for keybindings.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
No
- If not a bug fix, why is this PR needed? What usecases does it solve?
See above.

## Notes
- This PR now treats Left Shift and Right Shift as the same key.
- This PR removes the incompatible feature where Shift+key binds to the scancode. However, my testing shows that this removed feature did not fully work anyway.

## To do

This PR is a Work in Progress.
- [ ] Resolve keybindings to perform the action with the "closest" keybinding.
- Fix bugs
  - [ ] Cannot stop sneaking after pressing Shift once.

## How to test
The testcases are complemented to reflect the changes made in this PR.

(I will add further information on manual testing when this is ready)