### PR TITLE
Sounds: Partial revert of #14436 and #14341

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1103,7 +1103,6 @@ Table used to specify how a sound is played:
     -- its end in `-start_time` seconds.
     -- It is unspecified what happens if `loop` is false and `start_time` is
     -- smaller than minus the sound's length.
-
     -- Available since feature `sound_params_start_time`.
 
     loop = false,
@@ -1116,21 +1115,6 @@ Table used to specify how a sound is played:
     object = <an ObjectRef>,
     -- Attach the sound to an object.
     -- Can't be used together with `pos`.
-
-    -- For backward compatibility, sounds continue playing at the last location
-    -- of the object if an object is removed (for example if an entity dies).
-    -- It is not recommended to rely on this.
-    -- For death sounds, prefer playing a positional sound instead.
-
-    -- If you want to stop a sound when an entity dies or is deactivated,
-    -- store the handle and call `minetest.sound_stop` in `on_die` / `on_deactivate`.
-
-    -- Ephemeral sounds are entirely unaffected by the object being removed
-    -- or leaving the active object range.
-
-    -- Non-ephemeral sounds stop playing on clients if objects leave
-    -- the active object range; they should start playing again if objects
-    --- come back into range (but due to a known bug, they don't yet).
 
     to_player = name,
     -- Only play for this player.

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -471,6 +471,8 @@ void Client::handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt)
 		for (u16 i = 0; i < removed_count; i++) {
 			*pkt >> id;
 			m_env.removeActiveObject(id);
+			// Sounds MUST NOT be removed here as they might have started
+			// to play started immediately before the entity was removed.
 		}
 
 		// Read added objects

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -471,8 +471,8 @@ void Client::handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt)
 		for (u16 i = 0; i < removed_count; i++) {
 			*pkt >> id;
 			m_env.removeActiveObject(id);
-			// Sounds MUST NOT be removed here as they might have started
-			// to play started immediately before the entity was removed.
+			// Object-attached sounds MUST NOT be removed here because they might
+			// have started to play immediately before the entity was removed.
 		}
 
 		// Read added objects

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2066,8 +2066,8 @@ void Server::SendActiveObjectRemoveAdd(RemoteClient *client, PlayerSAO *playersa
 			obj->m_known_by_count--;
 	}
 
-	// Note: Do yet NOT stop or remove object-attached sounds for objects goes out of range
-	// (client side). Such sounds would need to be re-sent when coming into range.
+	// Note: Do yet NOT stop or remove object-attached sounds where the object goes out
+	// of range (client side). Such sounds would need to be re-sent when coming into range.
 	// Currently, the client will initiate m_playing_sounds clean ups indirectly by
 	// "Server::handleCommand_RemovedSounds".
 

--- a/src/server.h
+++ b/src/server.h
@@ -239,9 +239,6 @@ public:
 	s32 playSound(ServerPlayingSound &params, bool ephemeral=false);
 	void stopSound(s32 handle);
 	void fadeSound(s32 handle, float step, float gain);
-	// Stop all sounds attached to given objects, for a certain client
-	void stopAttachedSounds(session_t peer_id,
-		const std::vector<u16> &object_ids);
 
 	// Envlock
 	std::set<std::string> getPlayerEffectivePrivs(const std::string &name);


### PR DESCRIPTION
This reverts functional changes of:
 * commit bf52d1e6 (#14436)
 * commit 63a98538 (#14341)

Key functions for removing attached sounds are preserved for a proper implementation.

Fixes #14886
Unfixes #11521

I came to the conclusion that strictly reverting the PRs was not the perfect solution. Reasons:

 * The 2nd PR is a partial revert of the first (revertception).
 * Code clean-ups resulted in conflicts
 * We want to fix this in the future, thus removing the function entirely does not make sense
 * #14436 included a few helpful changes (notably the `gone` information), which is nice to have for future development.

## To do

This PR is Ready for Review.

## How to test

The following bug must reappear:

(copied from #11521)
```Lua
minetest.play_sound("some_sound", {loop=true, object=some_external_obj}
-- ...
-- at another place
some_external_obj:remove()
```