### PR TITLE
Work around the SDL keybinding issue in a very hacky manner

### DIFF
--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -882,7 +882,8 @@ bool CIrrDeviceSDL::run()
 
 			// This is a GIANT HACK to fix the most common case of
 			// https://github.com/minetest/minetest/issues/14545 for the 5.9.0 release.
-			if (irrevent.KeyInput.Key == KEY_KEY_7 && irrevent.KeyInput.Shift)
+			if (irrevent.KeyInput.Key == KEY_KEY_7 && irrevent.KeyInput.Shift &&
+					SDL_GetScancodeFromKey(SDLK_SLASH) == SDL_SCANCODE_UNKNOWN)
 				irrevent.KeyInput.Char = L'/';
 
 			postEventFromUser(irrevent);

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -879,6 +879,12 @@ bool CIrrDeviceSDL::run()
 			irrevent.KeyInput.Control = (SDL_event.key.keysym.mod & KMOD_CTRL) != 0;
 			irrevent.KeyInput.Char = findCharToPassToIrrlicht(mp.SDLKey, key,
 					(SDL_event.key.keysym.mod & KMOD_NUM) != 0);
+
+			// This is a GIANT HACK to fix the most common case of
+			// https://github.com/minetest/minetest/issues/14545 for the 5.9.0 release.
+			if (irrevent.KeyInput.Key == KEY_KEY_7 && irrevent.KeyInput.Shift)
+				irrevent.KeyInput.Char = L'/';
+
 			postEventFromUser(irrevent);
 		} break;
 


### PR DESCRIPTION
As discussed on IRC, this is a hacky workaround for the most common case of #14545. Are there more common cases we should consider? Will this cause some serious breakage we haven't thought of so far?

Doing this kind of thing is an act of desperation.

## To do

This PR is a Ready for Review.

## How to test

Press shift+7. Notice that it opens the chat pre-filled with a `/` independently of your keyboard layout.