### PR TITLE
Rename `minetest.register_async_metatable` to `minetest.register_portable_metatable`

### DIFF
--- a/builtin/common/metatable.lua
+++ b/builtin/common/metatable.lua
@@ -11,7 +11,7 @@ end
 core.known_metatables = known_metatables
 
 function core.register_async_metatable(...)
-	core.log("deprecated", "minetest.register_async_metatable is deprecated" ..
+	core.log("deprecated", "minetest.register_async_metatable is deprecated. " ..
 			"Use minetest.register_portable_metatable instead.")
 	return core.register_portable_metatable(...)
 end

--- a/builtin/common/metatable.lua
+++ b/builtin/common/metatable.lua
@@ -1,6 +1,6 @@
 -- Registered metatables, used by the C++ packer
 local known_metatables = {}
-function core.register_async_metatable(name, mt)
+function core.register_portable_metatable(name, mt)
 	assert(type(name) == "string", ("attempt to use %s value as metatable name"):format(type(name)))
 	assert(type(mt) == "table", ("attempt to register a %s value as metatable"):format(type(mt)))
 	assert(known_metatables[name] == nil or known_metatables[name] == mt,
@@ -10,4 +10,4 @@ function core.register_async_metatable(name, mt)
 end
 core.known_metatables = known_metatables
 
-core.register_async_metatable("__builtin:vector", vector.metatable)
+core.register_portable_metatable("__builtin:vector", vector.metatable)

--- a/builtin/common/metatable.lua
+++ b/builtin/common/metatable.lua
@@ -8,7 +8,12 @@ function core.register_portable_metatable(name, mt)
 	known_metatables[name] = mt
 	known_metatables[mt] = name
 end
-core.register_async_metatable = core.register_portable_metatable
 core.known_metatables = known_metatables
+
+function core.register_async_metatable(...)
+	core.log("deprecated", "minetest.register_async_metatable is deprecated" ..
+			"Use minetest.register_portable_metatable instead.")
+	return core.register_portable_metatable(...)
+end
 
 core.register_portable_metatable("__builtin:vector", vector.metatable)

--- a/builtin/common/metatable.lua
+++ b/builtin/common/metatable.lua
@@ -8,6 +8,7 @@ function core.register_portable_metatable(name, mt)
 	known_metatables[name] = mt
 	known_metatables[mt] = name
 end
+core.register_async_metatable = core.register_portable_metatable
 core.known_metatables = known_metatables
 
 core.register_portable_metatable("__builtin:vector", vector.metatable)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6731,7 +6731,7 @@ This allows you easy interoperability for delegating work to jobs.
     * Register a path to a Lua file to be imported when an async environment
       is initialized. You can use this to preload code which you can then call
       later using `minetest.handle_async()`.
-* `minetest.register_async_metatable(name, mt)`:
+* `minetest.register_portable_metatable(name, mt)`:
     * Register a metatable that should be preserved when data is transferred
     between the main thread and the async environment.
     * `name` is a string that identifies the metatable. It is recommended to
@@ -6771,7 +6771,7 @@ Functions:
 
 * Standalone helpers such as logging, filesystem, encoding,
   hashing or compression APIs
-* `minetest.register_async_metatable` (see above)
+* `minetest.register_portable_metatable` (see above)
 
 Variables:
 

--- a/games/devtest/mods/unittests/async_env.lua
+++ b/games/devtest/mods/unittests/async_env.lua
@@ -167,18 +167,18 @@ local function test_userdata_passing2(cb, _, pos)
 end
 unittests.register("test_userdata_passing2", test_userdata_passing2, {map=true, async=true})
 
-local function test_async_metatable_override()
-	assert(pcall(core.register_async_metatable, "__builtin:vector", vector.metatable),
+local function test_portable_metatable_override()
+	assert(pcall(core.register_portable_metatable, "__builtin:vector", vector.metatable),
 			"Metatable name aliasing throws an error when it should be allowed")
 
-	assert(not pcall(core.register_async_metatable, "__builtin:vector", {}),
+	assert(not pcall(core.register_portable_metatable, "__builtin:vector", {}),
 			"Illegal metatable overriding allowed")
 end
-unittests.register("test_async_metatable_override", test_async_metatable_override)
+unittests.register("test_portable_metatable_override", test_portable_metatable_override)
 
-local function test_async_metatable_registration(cb)
+local function test_portable_metatable_registration(cb)
 	local custom_metatable = {}
-	core.register_async_metatable("unittests:custom_metatable", custom_metatable)
+	core.register_portable_metatable("unittests:custom_metatable", custom_metatable)
 
 	core.handle_async(function(x)
 		-- unittests.custom_metatable is registered in inside_async_env.lua
@@ -193,7 +193,7 @@ local function test_async_metatable_registration(cb)
 		cb()
 	end, setmetatable({}, custom_metatable))
 end
-unittests.register("test_async_metatable_registration", test_async_metatable_registration, {async=true})
+unittests.register("test_portable_metatable_registration", test_portable_metatable_registration, {async=true})
 
 local function test_vector_preserve(cb)
 	local vec = vector.new(1, 2, 3)

--- a/games/devtest/mods/unittests/inside_async_env.lua
+++ b/games/devtest/mods/unittests/inside_async_env.lua
@@ -3,7 +3,7 @@ unittests = {}
 core.log("info", "Hello World")
 
 unittests.custom_metatable = {}
-core.register_async_metatable("unittests:custom_metatable", unittests.custom_metatable)
+core.register_portable_metatable("unittests:custom_metatable", unittests.custom_metatable)
 
 local function do_tests()
 	assert(core == minetest)


### PR DESCRIPTION
Renames `minetest.register_async_metatable` to `minetest.register_portable_metatable` as noted in https://github.com/minetest/minetest/pull/14369#issuecomment-2106317910

- Goal of the PR
  See above
- How does the PR work?
  This renames a single API function. A deprecation warning is not given since the renamed API function is not (yet) part of a release. An alias with a deprecation warning is kept for `core.register_async_metatable`.
- Does it resolve any reported issue?
  No.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
  No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  See linked comment.

## To do

This PR is a Ready for Review.

## How to test

* Check that all tests are passed.
* Check that the documentation is changed accordingly.