### PR TITLE
Render clouds as flat when thickness is zero

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8409,7 +8409,8 @@ child will follow movement and rotation of that bone.
           ColorSpec (alpha ignored, default `#000000`)
         * `height`: cloud height, i.e. y of cloud base (default per conf,
           usually `120`)
-        * `thickness`: cloud thickness in nodes (default `16`)
+        * `thickness`: cloud thickness in nodes (default `16`).
+          if set to zero the clouds are rendered flat.
         * `speed`: 2D cloud speed + direction in nodes per second
           (default `{x=0, z=-2}`).
 * `get_clouds()`: returns a table with the current cloud parameters as in

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -127,7 +127,7 @@ void Clouds::updateMesh()
 	m_last_noise_center = center_of_drawing_in_noise_i;
 	m_mesh_valid = true;
 
-	const u32 num_faces_to_draw = m_enable_3d ? 6 : 1;
+	const u32 num_faces_to_draw = is3D() ? 6 : 1;
 
 	// The world position of the integer center point of drawing in the noise
 	v2f world_center_of_drawing_in_noise_f = v2f(
@@ -220,7 +220,7 @@ void Clouds::updateMesh()
 
 		const f32 rx = cloud_size / 2.0f;
 		// if clouds are flat, the top layer should be at the given height
-		const f32 ry = m_enable_3d ? m_params.thickness * BS : 0.0f;
+		const f32 ry = is3D() ? m_params.thickness * BS : 0.0f;
 		const f32 rz = cloud_size / 2;
 
 		for(u32 i = 0; i < num_faces_to_draw; i++)
@@ -363,7 +363,7 @@ void Clouds::render()
 		updateAbsolutePosition();
 	}
 
-	m_material.BackfaceCulling = m_enable_3d;
+	m_material.BackfaceCulling = is3D();
 	if (m_enable_shaders)
 		m_material.EmissiveColor = m_color.toSColor();
 
@@ -413,7 +413,7 @@ void Clouds::update(const v3f &camera_p, const video::SColorf &color_diffuse)
 	// is the camera inside the cloud mesh?
 	m_camera_pos = camera_p;
 	m_camera_inside_cloud = false; // default
-	if (m_enable_3d) {
+	if (is3D()) {
 		float camera_height = camera_p.Y - BS * m_camera_offset.Y;
 		if (camera_height >= m_box.MinEdge.Y &&
 				camera_height <= m_box.MaxEdge.Y) {

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -145,6 +145,11 @@ private:
 
 	bool gridFilled(int x, int y) const;
 
+	// Are the clouds 3D?
+	inline bool is3D() const {
+		return m_enable_3d && m_params.thickness >= 0.01f;
+	}
+
 	video::SMaterial m_material;
 	irr_ptr<scene::SMeshBuffer> m_meshbuffer;
 	// Value of m_origin at the time the mesh was last updated


### PR DESCRIPTION
This saves some vertices while rendering and this way games can request truly flat clouds by setting `thickness = 0`.

used here: https://github.com/sfan5/minetest_classic/commit/b430f67d13b905d8e64fe04388018e42ba545bd8