### PR TITLE
Take screenshot from back buffer when using double buffering

### DIFF
--- a/irr/src/COpenGLDriver.cpp
+++ b/irr/src/COpenGLDriver.cpp
@@ -3018,7 +3018,7 @@ IImage *COpenGLDriver::createScreenShot(video::ECOLOR_FORMAT format, video::E_RE
 	if (newImage)
 		pixels = static_cast<u8 *>(newImage->getData());
 	if (pixels) {
-		glReadBuffer(GL_FRONT);
+		glReadBuffer(Params.Doublebuffer ? GL_BACK : GL_FRONT);
 		glReadPixels(0, 0, ScreenSize.Width, ScreenSize.Height, fmt, type, pixels);
 		testGLError(__LINE__);
 		glReadBuffer(GL_BACK);


### PR DESCRIPTION
Fixes #14901 (black screenshots on Wayland).

This fix works with both `SDL_VIDEODRIVER` set to `wayland` and `x11` on my machine.

I am not knowledgeable in graphics programming, so I'm not 100% sure this is an appropriate solution.

## To do

This PR is Ready for Review.

## How to test

See #14901
