### PR TITLE
Add shared mods path to get_modpaths

### DIFF
--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -675,6 +675,11 @@ int ModApiMainMenu::l_get_modpaths(lua_State *L)
 	ModApiMainMenu::l_get_modpath(L);
 	lua_setfield(L, -2, "mods");
 
+	std::string modpath = fs::RemoveRelativePathComponents(
+		porting::path_share + DIR_DELIM + "mods" + DIR_DELIM);
+	lua_pushstring(L, modpath.c_str());
+	lua_setfield(L, -2, "share");
+
 	for (const std::string &component : getEnvModPaths()) {
 		lua_pushstring(L, component.c_str());
 		lua_setfield(L, -2, fs::AbsolutePath(component).c_str());


### PR DESCRIPTION
Intended to fix #14392

I copied and adapted the code from ``ModApiMainMenu::l_get_modpath``, hoping that that is the right thing to do.

I've used it in my local client build for several months and it seems to work without problems. (My local server built from this version also works fine, but AFAICT this doesn't affect the server at all.)

It adds the ``<shared path>/mods`` to the list of paths exposed by ``get_modpaths()`` to the mainmenu using the virtual path name ``share`` as the documentation implies and the server is already supporting when loading mods.

Please review.

Test it by putting some mods into the shared path and start the client:

- [ ] the main menu lists these mods and handles them separately from mods of the same name installed in the user path
- [ ] the main menu creates working ``world.mt`` files when adding mods from the shared path in the world configurator and dependency checking works as expected

The content db dialog could handle mods (and games) installed in the shared path better, but that is outside the scope of this PR.