### PR TITLE
Fix `Waving waters are passing through slab blocks`

### DIFF
--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -177,7 +177,7 @@ void main(void)
 	wavePos.x /= WATER_WAVE_LENGTH * 3.0;
 	wavePos.z /= WATER_WAVE_LENGTH * 2.0;
 	wavePos.z += animationTimer * WATER_WAVE_SPEED * 10.0;
-	pos.y += (snoise(wavePos) - 1.0) * WATER_WAVE_HEIGHT * 5.0;
+	pos.y += -(snoise(wavePos) - 1.0) * WATER_WAVE_HEIGHT * 5.0;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES
 	pos.x += disp_x;
 	pos.y += disp_z * 0.1;


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
- Fix https://github.com/minetest/minetest/issues/14535
- How does the PR work?
- By changing the y pos of wave to positive ( whereas previously the y pos was always negative )
- Does it resolve any reported issue?
- https://github.com/minetest/minetest/issues/14535
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
- IMHO yes.
- If not a bug fix, why is this PR needed? What usecases does it solve?
- This is a bug fix.

## To do

This PR is Ready for Review

## How to test
Compile and run, turn on the waving liquid option, put down a river water node or any flowing liquid node similar
Or just checkout the change in src.

<!-- Example code or instructions -->
I've tried implementing this bug fix without changing how the wave itself behaves, only stopping rendering in the part where there's a rendering overlap.

But it looks like changes like this will also cause the liquid node to be rendered strangely. The liquid side will go upward and leave an empty space where it originally was, which seems like a worse behaviour than the bug itself.

After thinking it over, I just changed the y pos of wave to positive in `opengl_vertex.glsl`. If there's a better option, I'll try to take care of that.
