### PR TITLE
[#14906 1/2] Clarify that indexof() does not work on arrays with holes

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4034,8 +4034,8 @@ Helper functions
     * returns a deep copy of `table`
 * `table.indexof(list, val)`: returns the smallest numerical index containing
       the value `val` in the table `list`. Non-numerical indices are ignored.
-      If `val` could not be found, `-1` is returned. `list` must not have
-      negative indices, and must not have holes.
+      If `val` could not be found, `-1` is returned. `list` must be a sequence,
+      i.e. table with keys from 1 to n, while none of the values are `nil`.
 * `table.insert_all(table, other_table)`:
     * Appends all values in `other_table` to `table` - uses `#table + 1` to
       find new indices.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4035,7 +4035,7 @@ Helper functions
 * `table.indexof(list, val)`: returns the smallest numerical index containing
       the value `val` in the table `list`. Non-numerical indices are ignored.
       If `val` could not be found, `-1` is returned. `list` must not have
-      negative indices.
+      negative indices, and must not have holes.
 * `table.insert_all(table, other_table)`:
     * Appends all values in `other_table` to `table` - uses `#table + 1` to
       find new indices.


### PR DESCRIPTION
This PR clarifies the documentation of `table.indexof()` so modders know they should not pass in "arrays" with holes.

Closes #14906
This one is separated from #14910 because we are in FF.

## To do

This PR is  Ready for Review.

## How to test

N/A
