### PR TITLE
Avoid infinite recursion with unhandled second touch

### DIFF
--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -319,6 +319,11 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 	}
 #endif
 
+	// If the second touch arrives here again, that means nobody handled it.
+	// Abort to avoid infinite recursion.
+	if (m_second_touch)
+		return true;
+
 	// Convert touch events into mouse events.
 	if (event.EventType == EET_TOUCH_INPUT_EVENT) {
 		irr_ptr<GUIModalMenu> holder;


### PR DESCRIPTION
Fixes #14914. I'm not sure this is the best approach, but it seems to work.

cc @srifqi

## To do

This PR is a Ready for Review.

## How to test

Open the keychange menu or the password change menu on Android. Put two fingers on the screen. Verify that there is no crash.

Verify that splitting item stacks using a second finger still works.