### PR TITLE
Add minetest.register_on_item_drop callback

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -360,6 +360,12 @@ function core.item_secondary_use(itemstack, placer)
 end
 
 function core.item_drop(itemstack, dropper, pos)
+	for _, callback in ipairs(core.registered_on_item_drops) do
+		local result = callback(itemstack, dropper, pos)
+		if result then
+			return ItemStack(result)
+		end
+	end
 	local dropper_is_player = dropper and dropper:is_player()
 	local p = table.copy(pos)
 	local cnt = itemstack:get_count()

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -553,6 +553,7 @@ core.registered_craft_predicts, core.register_craft_predict = make_registration(
 core.registered_on_protection_violation, core.register_on_protection_violation = make_registration()
 core.registered_on_item_eats, core.register_on_item_eat = make_registration()
 core.registered_on_item_pickups, core.register_on_item_pickup = make_registration()
+core.registered_on_item_drops, core.register_on_item_drop = make_registration()
 core.registered_on_punchplayers, core.register_on_punchplayer = make_registration()
 core.registered_on_priv_grant, core.register_on_priv_grant = make_registration()
 core.registered_on_priv_revoke, core.register_on_priv_revoke = make_registration()

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5914,6 +5914,12 @@ Call these functions only at load time!
     * Parameters are the same as in the `on_pickup` callback.
     * Return an itemstack to cancel the default item pick-up response (i.e.: adding
       the item into inventory).
+* `minetest.register_on_item_drop(function(itemstack, dropper, pos))`
+    * Called by `minetest.item_drop` before an item is dropped.
+    * Function is added to `minetest.registered_on_item_drops`.
+    * Oldest functions are called first.
+    * Parameters are the same as in the `on_drop` callback.
+    * Return an itemstack to cancel the default item drop response.
 * `minetest.register_on_priv_grant(function(name, granter, priv))`
     * Called when `granter` grants the priv `priv` to `name`.
     * Note that the callback will be called twice if it's done by a player,


### PR DESCRIPTION
This PR adds the callback that have been called when player(or other entity) drops the itemstack.
Thanks to this PR, modders won't have to override the minetest.item_drop function manually to implement the desired feature.

## To do

This PR is Ready for Review.

## How to test

Write the simple mod which will use minetest.register_on_item_drop callback and test the behaviour.
For example,
```lua
minetest.register_on_item_drop(function(itemstack, dropper, pos)
  if dropper:is_player() then
    minetest.chat_send_all(dropper:get_player_name().." tried to drop "..itemstack:get_name().." at "..minetest.pos_to_string(pos))
    if itemstack:get_count() > 50 then
      itemstack:set_count(10)
      return itemstack
    end
  end
end)
```
