### PR TITLE
Add version to override_item_remove_fields feature flag doc

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5442,7 +5442,7 @@ Utilities
       node_interaction_actor = true,
       -- "new_pos" field in entity moveresult (5.9.0)
       moveresult_new_pos = true,
-      -- Allow removing definition fields in `minetest.override_item`
+      -- Allow removing definition fields in `minetest.override_item` (5.9.0)
       override_item_remove_fields = true,
   }
   ```


### PR DESCRIPTION
This is just a trivial documentation fix.

I noticed that the `override_item_remove_fields` feature flag documentation doesn't have a version indicator, but as far as I know it will still be part of version 5.9.0.

(Fault of https://github.com/minetest/minetest/commit/50092594732dbdfc519a12e48ec837ec88c6e031)