### PR TITLE
Fix key bindings with modifier keys on Windows

### DIFF
--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -189,7 +189,7 @@ bool CIrrDeviceSDL::keyIsKnownSpecial(EKEY_CODE irrlichtKey)
 	}
 }
 
-int CIrrDeviceSDL::findCharToPassToIrrlicht(uint32_t sdlKey, EKEY_CODE irrlichtKey, bool numlock)
+int CIrrDeviceSDL::findCharToPassToIrrlicht(const SDL_Keysym &SDL_keysym, EKEY_CODE irrlichtKey)
 {
 	switch (irrlichtKey) {
 	// special cases that always return a char regardless of how the SDL keycode
@@ -214,8 +214,8 @@ int CIrrDeviceSDL::findCharToPassToIrrlicht(uint32_t sdlKey, EKEY_CODE irrlichtK
 	default:
 		break;
 	}
-
-	if (numlock) {
+	bool numlock_pressed = ((SDL_keysym.mod & KMOD_NUM) != 0);
+	if (numlock_pressed) {
 		// Number keys on the numpad are also affected, but we only want them
 		// to produce number chars when numlock is enabled.
 		switch (irrlichtKey) {
@@ -247,7 +247,7 @@ int CIrrDeviceSDL::findCharToPassToIrrlicht(uint32_t sdlKey, EKEY_CODE irrlichtK
 	// SDL in-place ORs values with no character representation with 1<<30
 	// https://wiki.libsdl.org/SDL2/SDLKeycodeLookup
 	// This also affects the numpad keys btw.
-	if (sdlKey & (1 << 30))
+	if (SDL_keysym.sym & (1 << 30))
 		return 0;
 
 	switch (irrlichtKey) {
@@ -262,7 +262,7 @@ int CIrrDeviceSDL::findCharToPassToIrrlicht(uint32_t sdlKey, EKEY_CODE irrlichtK
 	case KEY_NUMLOCK:
 		return 0;
 	default:
-		return sdlKey;
+		return SDL_keysym.sym;
 	}
 }
 
@@ -877,8 +877,7 @@ bool CIrrDeviceSDL::run()
 			irrevent.KeyInput.PressedDown = (SDL_event.type == SDL_KEYDOWN);
 			irrevent.KeyInput.Shift = (SDL_event.key.keysym.mod & KMOD_SHIFT) != 0;
 			irrevent.KeyInput.Control = (SDL_event.key.keysym.mod & KMOD_CTRL) != 0;
-			irrevent.KeyInput.Char = findCharToPassToIrrlicht(mp.SDLKey, key,
-					(SDL_event.key.keysym.mod & KMOD_NUM) != 0);
+			irrevent.KeyInput.Char = findCharToPassToIrrlicht(SDL_event.key.keysym, key);
 			postEventFromUser(irrevent);
 		} break;
 

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -11,6 +11,7 @@
 #include "IImageLoader.h"
 #include "IFileSystem.h"
 #include "os.h"
+#include "scancode.h"
 #include "CTimer.h"
 #include "irrString.h"
 #include "Keycodes.h"
@@ -77,6 +78,7 @@ static IVideoDriver *createWebGL1Driver(const SIrrlichtCreationParameters &param
 
 namespace irr
 {
+
 #ifdef _IRR_EMSCRIPTEN_PLATFORM_
 EM_BOOL CIrrDeviceSDL::MouseUpDownCallback(int eventType, const EmscriptenMouseEvent *event, void *userData)
 {
@@ -189,7 +191,7 @@ bool CIrrDeviceSDL::keyIsKnownSpecial(EKEY_CODE irrlichtKey)
 	}
 }
 
-int CIrrDeviceSDL::findCharToPassToIrrlicht(const SDL_Keysym &SDL_keysym, EKEY_CODE irrlichtKey)
+wchar_t CIrrDeviceSDL::findCharToPassToIrrlicht(const SDL_Keysym &SDL_keysym, EKEY_CODE irrlichtKey)
 {
 	switch (irrlichtKey) {
 	// special cases that always return a char regardless of how the SDL keycode
@@ -262,9 +264,10 @@ int CIrrDeviceSDL::findCharToPassToIrrlicht(const SDL_Keysym &SDL_keysym, EKEY_C
 	case KEY_NUMLOCK:
 		return 0;
 	default:
-		return SDL_keysym.sym;
+		return get_modified_char_from_scancode(SDL_keysym.scancode);
 	}
 }
+
 
 void CIrrDeviceSDL::resetReceiveTextInputEvents()
 {

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -277,7 +277,7 @@ private:
 	static bool keyIsKnownSpecial(EKEY_CODE irrlichtKey);
 
 	// Return the Char that should be sent to Irrlicht for the given key (either the one passed in or 0).
-	static int findCharToPassToIrrlicht(const SDL_Keysym &SDL_keysym, EKEY_CODE irrlichtKey);
+	static wchar_t findCharToPassToIrrlicht(const SDL_Keysym &SDL_keysym, EKEY_CODE irrlichtKey);
 
 	// Check if a text box is in focus. Enable or disable SDL_TEXTINPUT events only if in focus.
 	void resetReceiveTextInputEvents();

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -277,7 +277,7 @@ private:
 	static bool keyIsKnownSpecial(EKEY_CODE irrlichtKey);
 
 	// Return the Char that should be sent to Irrlicht for the given key (either the one passed in or 0).
-	static int findCharToPassToIrrlicht(uint32_t sdlKey, EKEY_CODE irrlichtKey, bool numlock);
+	static int findCharToPassToIrrlicht(const SDL_Keysym &SDL_keysym, EKEY_CODE irrlichtKey);
 
 	// Check if a text box is in focus. Enable or disable SDL_TEXTINPUT events only if in focus.
 	void resetReceiveTextInputEvents();

--- a/irr/src/CMakeLists.txt
+++ b/irr/src/CMakeLists.txt
@@ -432,6 +432,7 @@ add_library(IRROTHEROBJ OBJECT
 	COSOperator.cpp
 	Irrlicht.cpp
 	os.cpp
+	scancode.cpp
 )
 
 if(ENABLE_OPENGL3)

--- a/irr/src/scancode.cpp
+++ b/irr/src/scancode.cpp
@@ -1,0 +1,157 @@
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#include "os.h"
+#include "scancode.h"
+
+#ifndef _WIN32
+#include <SDL_keyboard.h>
+#endif
+#include <SDL_scancode.h>
+
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winuser.h>
+
+#include <array>
+#endif
+
+namespace {
+
+constexpr unsigned int windows_to_unicode_flag_no_side_effects{2};
+
+} // end anonymous namespace
+
+wchar_t irr::get_modified_char_from_scancode(SDL_Scancode SDL_scancode)
+{
+#ifdef _WIN32
+	std::array<unsigned char, 256> keyStates;
+	if (!GetKeyboardState(keyStates.data())) {
+		os::Printer::log("[get_modified_char_from_scancode] Failed to get Windows keyboard state.", ELL_ERROR);
+	}
+
+	unsigned int windowsScancode{convert_to_windows_scancode(SDL_scancode)};
+	unsigned int windowsVirtualKey{MapVirtualKeyA(windowsScancode, MAPVK_VSC_TO_VK)};
+	wchar_t      result{};
+	int          written{ToUnicode(windowsVirtualKey, windowsScancode, keyStates.data(), &result, 1, windows_to_unicode_flag_no_side_effects)};
+
+	if (written <= 0) {
+		os::Printer::log("[get_modified_char_from_scancode] Failed to get char from scancode.", ELL_ERROR);
+	}
+
+	return result;
+#else
+	return SDL_GetKeyFromScancode(SDL_scancode);
+#endif
+}
+
+#ifdef _WIN32
+unsigned int irr::convert_to_windows_scancode(SDL_Scancode SDL_scancode)
+{
+	switch (SDL_scancode) {
+	case SDL_SCANCODE_A:
+		return 30;
+	case SDL_SCANCODE_B:
+		return 48;
+	case SDL_SCANCODE_C:
+		return 46;
+	case SDL_SCANCODE_D:
+		return 32;
+	case SDL_SCANCODE_E:
+		return 18;
+	case SDL_SCANCODE_F:
+		return 33;
+	case SDL_SCANCODE_G:
+		return 34;
+	case SDL_SCANCODE_H:
+		return 35;
+	case SDL_SCANCODE_I:
+		return 23;
+	case SDL_SCANCODE_J:
+		return 36;
+	case SDL_SCANCODE_K:
+		return 37;
+	case SDL_SCANCODE_L:
+		return 38;
+	case SDL_SCANCODE_M:
+		return 50;
+	case SDL_SCANCODE_N:
+		return 49;
+	case SDL_SCANCODE_O:
+		return 24;
+	case SDL_SCANCODE_P:
+		return 25;
+	case SDL_SCANCODE_Q:
+		return 16;
+	case SDL_SCANCODE_R:
+		return 19;
+	case SDL_SCANCODE_S:
+		return 31;
+	case SDL_SCANCODE_T:
+		return 20;
+	case SDL_SCANCODE_U:
+		return 22;
+	case SDL_SCANCODE_V:
+		return 47;
+	case SDL_SCANCODE_W:
+		return 17;
+	case SDL_SCANCODE_X:
+		return 45;
+	case SDL_SCANCODE_Y:
+		return 21;
+	case SDL_SCANCODE_Z:
+		return 44;
+	case SDL_SCANCODE_1:
+	case SDL_SCANCODE_2:
+	case SDL_SCANCODE_3:
+	case SDL_SCANCODE_4:
+	case SDL_SCANCODE_5:
+	case SDL_SCANCODE_6:
+	case SDL_SCANCODE_7:
+	case SDL_SCANCODE_8:
+	case SDL_SCANCODE_9:
+	case SDL_SCANCODE_0:
+		return SDL_scancode - 28;
+	case SDL_SCANCODE_SPACE:
+		return 61; // seems this may be the wrong code
+	case SDL_SCANCODE_LEFTBRACKET:
+		return 26;
+	case SDL_SCANCODE_RIGHTBRACKET:
+		return 27;
+	case SDL_SCANCODE_BACKSLASH:
+		return 28;
+	case SDL_SCANCODE_SEMICOLON:
+		return 39;
+	case SDL_SCANCODE_APOSTROPHE:
+		return 40;
+	case SDL_SCANCODE_GRAVE:
+		return 1;
+	case SDL_SCANCODE_COMMA:
+		return 51;
+	case SDL_SCANCODE_PERIOD:
+		return 52;
+	case SDL_SCANCODE_SLASH:
+		return 53;
+	case SDL_SCANCODE_CAPSLOCK:
+		return 29;
+	case SDL_SCANCODE_F1:
+	case SDL_SCANCODE_F2:
+	case SDL_SCANCODE_F3:
+	case SDL_SCANCODE_F4:
+	case SDL_SCANCODE_F5:
+	case SDL_SCANCODE_F6:
+	case SDL_SCANCODE_F7:
+	case SDL_SCANCODE_F8:
+	case SDL_SCANCODE_F9:
+	case SDL_SCANCODE_F10:
+	case SDL_SCANCODE_F11:
+	case SDL_SCANCODE_F12:
+		return SDL_scancode + 54;
+
+	default:
+		os::Printer::log("[convert_to_windows_scancode] unsupported scancode", ELL_ERROR);
+		return 0;
+	}
+}
+#endif // _WIN32

--- a/irr/src/scancode.h
+++ b/irr/src/scancode.h
@@ -1,0 +1,33 @@
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#pragma once
+
+#include <SDL_scancode.h>
+
+namespace irr {
+
+/**
+ * Convert a scancode to to a character taking modifiers into account.
+ *
+ * On Windows, modifiers will be applied. On all other platforms modifiers
+ * will not be applied. Generating more than one wchar_t for a single scancode
+ * is not supported.
+ *
+ * @param SDL_scancode The SDL scancode.
+ * @return Returns the modified character on Windows, the unmodified character
+ * otherwise.
+ */
+wchar_t get_modified_char_from_scancode(SDL_Scancode SDL_scancode);
+
+#ifdef _WIN32
+/**
+ * Get the Win32 scancode corresponding to the given SDL scancode.
+ *
+ * @param SDL_scancode The SDL scancode.
+ * @returns The Win32 scancode if a mapping exists, 0 otherwise.
+ */
+unsigned int convert_to_windows_scancode(SDL_Scancode SDL_scancode);
+#endif
+
+} // end namespace irr


### PR DESCRIPTION
This is a partial solution to #14545. Since SDL2 has no way to do this, we have to get the information from the OS ourselves. It's very hacky and annoying, but after discussing it on IRC this seems to be the only correct solution to fixing the SDL2 driver.

Querying the keyboard state works the same way it does in the Win32 driver.

## To do

This PR is a Work in Progress

## How to test

Test that it resolves #14545 on Windows. Note that this requires a keyboard layout that places the / character above the 7. Any layout with a similar issue also works for testing. In combination with #14874 you can bind any modified key, and test that way on any layout.