### PR TITLE
Fix get_translated_string returning nil during start up

### DIFF
--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1452,7 +1452,8 @@ int ModApiEnv::l_forceload_free_block(lua_State *L)
 // get_translated_string(lang_code, string)
 int ModApiEnv::l_get_translated_string(lua_State * L)
 {
-	GET_ENV_PTR;
+	NO_MAP_LOCK_REQUIRED;
+
 	std::string lang_code = luaL_checkstring(L, 1);
 	std::string string = luaL_checkstring(L, 2);
 


### PR DESCRIPTION
- minetest.get_translated_string returns nil on start up
- The C++ requires the env pointer but does not use it
- It may be intentional that get_translated_string doesn't work during start up as translation requires media files
  - This could be allowed for the source language (`en`) only
  - or it should at least be documented in lua_api.md and a code comment

## To do

This PR is Ready for Review

## How to test

```lua
local S = minetest.get_translator("transtest")

minetest.register_on_mods_loaded(function()
	local text = S("Hello @1!", "world")
	local str = minetest.get_translated_string("en", text)
	minetest.log("error", str)
end)
```