### PR TITLE
Update credits for 5.9.0

### DIFF
--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -30,6 +30,7 @@ local core_developers = {
 	"Desour/DS",
 	"srifqi",
 	"Gregor Parzefall (grorp)",
+	"Lars Müller (luatic)",
 }
 
 -- currently only https://github.com/orgs/minetest/teams/triagers/members
@@ -43,19 +44,24 @@ local core_team = {
 -- For updating active/previous contributors, see the script in ./util/gather_git_credits.py
 
 local active_contributors = {
-	"Wuzzy [Features, translations, documentation]",
-	"numzero [Optimizations, work on OpenGL driver]",
-	"ROllerozxa [Bugfixes, Mainmenu]",
-	"Lars Müller [Bugfixes]",
-	"AFCMS [Documentation]",
-	"savilli [Bugfixes]",
-	"fluxionary [Bugfixes]",
-	"Bradley Pierce (Thresher) [Documentation]",
-	"Stvk imension [Android]",
-	"JosiahWI [Code cleanups]",
-	"OgelGames [UI, Bugfixes]",
-	"ndren [Bugfixes]",
-	"Abdou-31 [Documentation]",
+	"cx384",
+	"numzero",
+	"AFCMS",
+	"sfence",
+	"Wuzzy",
+	"ROllerozxa",
+	"JosiahWI",
+	"OgelGames",
+	"David Heidelberg",
+	"1F616EMO",
+	"HybridDog",
+	"Bradley Pierce (Thresher)",
+	"savilli",
+	"Stvk imension",
+	"y5nw",
+	"chmodsayshello",
+	"jordan4ibanez",
+	"superfloh247",
 }
 
 local previous_core_developers = {

--- a/util/gather_git_credits.py
+++ b/util/gather_git_credits.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 codefiles = r"(\.[ch](pp)?|\.lua|\.md|\.cmake|\.java|\.gradle|Makefile|CMakeLists\.txt)$"
 
 # two minor versions back, for "Active Contributors"
-REVS_ACTIVE = "5.6.0..HEAD"
+REVS_ACTIVE = "5.7.0..HEAD"
 # all time, for "Previous Contributors"
 REVS_PREVIOUS = "HEAD"
 
@@ -46,7 +46,8 @@ def load(revs):
 	p.wait()
 
 	# Some authors duplicate? Don't add manual workarounds here, edit the .mailmap!
-	for author in ("updatepo.sh <script@mt>", "Weblate <42@minetest.ru>"):
+	for author in ("updatepo.sh <script@mt>", "Weblate <42@minetest.ru>",
+		"import <script@mt>", "minetest <minetest@minetest.net>"):
 		points.pop(author, None)
 	return points
 


### PR DESCRIPTION
I got tired of finding out which changes active contributors have actually done, so unless someone volunteers we won't have that info anymore.