### PR TITLE
add a way to add chat placeholders

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -27,10 +27,6 @@ function core.unregister_placeholder(name)
 	core.registered_placeholders[name] = nil
 end
 
-core.register_placeholder("message", function(name, message)
-	return message
-end)
-
 core.register_placeholder("name", function(name, message)
 	return name
 end)
@@ -45,6 +41,11 @@ function core.format_chat_message(name, message)
 	for placeholder, placeholder_callback in pairs(core.registered_placeholders) do
 		str = safe_gsub(str, "@" .. placeholder, placeholder_callback(name, message))
 	end
+
+	-- replacing the @message placeholder last
+	-- to prevent potential abuse from users that
+	-- put unused placeholders in their message
+	str = safe_gsub(str, "@message", message)
 
 	return str
 end

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -17,28 +17,28 @@ end
 -- Chat message formatter
 --
 
-core.registered_placeholders = {}
+core.registered_chat_format_placeholders = {}
 
-function core.register_placeholder(name, func)
-	core.registered_placeholders[name] = func
+function core.register_chat_format_placeholder(name, func)
+	core.registered_chat_format_placeholders[name] = func
 end
 
-function core.unregister_placeholder(name)
-	core.registered_placeholders[name] = nil
+function core.unregister_chat_format_placeholder(name)
+	core.registered_chat_format_placeholders[name] = nil
 end
 
-core.register_placeholder("name", function(name, message)
+core.register_chat_format_placeholder("name", function(name, message)
 	return name
 end)
 
-core.register_placeholder("timestamp", function(name, message)
+core.register_chat_format_placeholder("timestamp", function(name, message)
 	return os.date("%H:%M:%S", os.time())
 end)
 
 function core.format_chat_message(name, message)
 	local str = minetest.settings:get("chat_message_format")
 
-	for placeholder, placeholder_callback in pairs(core.registered_placeholders) do
+	for placeholder, placeholder_callback in pairs(core.registered_chat_format_placeholders) do
 		str = safe_gsub(str, "@" .. placeholder, placeholder_callback(name, message))
 	end
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6030,10 +6030,17 @@ Chat
     * `name`: Name of the player
 * `minetest.format_chat_message(name, message)`
     * Used by the server to format a chat message, based on the setting `chat_message_format`.
-      Refer to the documentation of the setting for a list of valid placeholders.
+      By Default @name, @message and @timestamp are valid placeholders, but more can be defined
+	  by mods using `minetest.register_placeholder`
     * Takes player name and message, and returns the formatted string to be sent to players.
-    * Can be redefined by mods if required, for things like colored names or messages.
     * **Only** the first occurrence of each placeholder will be replaced.
+* `minetest.register_placeholder(name, func)`
+	* Registers a placeholder for `minetest.format_chat_message`
+	* `func` is a function that takes player's name and message as an argument.
+	The function should return a replacement for that placeholder
+* `minetest.unregister_placeholder(name, func)`
+	* Unregisters a placeholder for `minetest.format_chat_message`
+
 
 Environment access
 ------------------
@@ -7385,6 +7392,7 @@ For historical reasons, the use of an -s suffix in these names is inconsistent.
 * `minetest.registered_on_cheats`
 * `minetest.registered_on_crafts`
 * `minetest.registered_craft_predicts`
+* `minetest.registered_placeholders`
 * `minetest.registered_on_item_eats`
 * `minetest.registered_on_item_pickups`
 * `minetest.registered_on_punchplayers`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6031,14 +6031,14 @@ Chat
 * `minetest.format_chat_message(name, message)`
     * Used by the server to format a chat message, based on the setting `chat_message_format`.
       By Default @name, @message and @timestamp are valid placeholders, but more can be defined
-	  by mods using `minetest.register_placeholder`
+	  by mods using `minetest.register_chat_format_placeholder`
     * Takes player name and message, and returns the formatted string to be sent to players.
     * **Only** the first occurrence of each placeholder will be replaced.
-* `minetest.register_placeholder(name, func)`
+* `minetest.register_chat_format_placeholder(name, func)`
 	* Registers a placeholder for `minetest.format_chat_message`
 	* `func` is a function that takes player's name and message as an argument.
 	The function should return a replacement for that placeholder
-* `minetest.unregister_placeholder(name, func)`
+* `minetest.unregister_chat_format_placeholder(name, func)`
 	* Unregisters a placeholder for `minetest.format_chat_message`
 
 
@@ -7392,7 +7392,7 @@ For historical reasons, the use of an -s suffix in these names is inconsistent.
 * `minetest.registered_on_cheats`
 * `minetest.registered_on_crafts`
 * `minetest.registered_craft_predicts`
-* `minetest.registered_placeholders`
+* `minetest.registered_chat_format_placeholders`
 * `minetest.registered_on_item_eats`
 * `minetest.registered_on_item_pickups`
 * `minetest.registered_on_punchplayers`


### PR DESCRIPTION
implements #14930 

## To Do

This PR is Ready for Review.

## How to test

1. define a placeholder
```lua
minetest.register_placeholder("rank", function(name, message)
	return "admin"
end)
```

2. set `chat_message_format` to `[@rank] <@name> @message`

3. send a chat message and observe the change

