### PR TITLE
Revert macOS workflow to run on x86

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,6 +10,7 @@ on:
       - 'src/**.cpp'
       - 'irr/**.[ch]'
       - 'irr/**.cpp'
+      - 'irr/**.mm' # Objective-C(++)
       - '**/CMakeLists.txt'
       - 'cmake/Modules/**'
       - '.github/workflows/macos.yml'
@@ -28,7 +29,8 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    # use macOS 13 since it's the last one that still runs on x86
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - name: Install deps
@@ -58,6 +60,7 @@ jobs:
       - name: CPack
         run: |
           cd build
+          rm -rf macos
           cmake .. -DINSTALL_DEVTEST=FALSE
           cpack -G ZIP -B macos
 


### PR DESCRIPTION
```
19:54 <+sfan5> I just found out that by github automatically changing the runner the macOS build we produce is now arm64 and not x86_64 like before
19:54 <+sfan5> I assume we want to still support both?
19:55 <+sfan5> support as in provide official builds
19:55 <[MTMatrix]> <Zughy> Isn't MacOS broken anyway?
19:55 <+sfan5> is it?
19:56 <[MTMatrix]> <Zughy> I thought it was, I haven't got Macs to check
19:57 <[MTMatrix]> <Zughy> Maybe I'm wrong 🤷
20:03 <+sfan5> according to SFENCE in #minetest the current build result doesn't run anyway
```

we had x86-based mac builds before and they apparently worked at least