### PR TITLE
Show IME candidate list in Windows

### DIFF
--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -345,7 +345,6 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters &param) :
 
 		// Set IME hints
 		SDL_SetHint(SDL_HINT_IME_INTERNAL_EDITING, "1");
-		SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
 
 		u32 flags = SDL_INIT_TIMER | SDL_INIT_EVENTS;
 		if (CreationParams.DriverType != video::EDT_NULL)

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -345,6 +345,9 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters &param) :
 
 		// Set IME hints
 		SDL_SetHint(SDL_HINT_IME_INTERNAL_EDITING, "1");
+#if defined(SDL_HINT_IME_SHOW_UI)
+		SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
+#endif
 
 		u32 flags = SDL_INIT_TIMER | SDL_INIT_EVENTS;
 		if (CreationParams.DriverType != video::EDT_NULL)

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -343,6 +343,10 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters &param) :
 		SDL_SetHint(SDL_HINT_APP_NAME, "Minetest");
 #endif
 
+		// Set IME hints
+		SDL_SetHint(SDL_HINT_IME_INTERNAL_EDITING, "1");
+		SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
+
 		u32 flags = SDL_INIT_TIMER | SDL_INIT_EVENTS;
 		if (CreationParams.DriverType != video::EDT_NULL)
 			flags |= SDL_INIT_VIDEO;


### PR DESCRIPTION
This PR sets the appropriate SDL hints to make Windows show the candidate list when an IM is active.

- Goal of the PR
  See description.
- How does the PR work?
  `SDL_SetHint`
- Does it resolve any reported issue?
  No.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
  No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  This is a bugfix as some IMs require a candidate list (or a similar feature) to be reasonably usable.

## To do

This PR is Ready for Review.

## How to test

In Windows, check that a candidate list is shown when an IM is used and text input is active.