### PR TITLE
Build minetest.app for Intel Mac and ARM Mac.

### DIFF
--- a/.github/workflows/macos_arm.yml
+++ b/.github/workflows/macos_arm.yml
@@ -1,4 +1,4 @@
-name: macos
+name: macos_arm
 
 # build on c/cpp changes or workflow changes
 on:
@@ -13,7 +13,7 @@ on:
       - 'irr/**.mm' # Objective-C(++)
       - '**/CMakeLists.txt'
       - 'cmake/Modules/**'
-      - '.github/workflows/macos.yml'
+      - '.github/workflows/macos_arm.yml'
   pull_request:
     paths:
       - 'lib/**.[ch]'
@@ -25,12 +25,11 @@ on:
       - 'irr/**.mm' # Objective-C(++)
       - '**/CMakeLists.txt'
       - 'cmake/Modules/**'
-      - '.github/workflows/macos.yml'
+      - '.github/workflows/macos_arm.yml'
 
 jobs:
   build:
-    # use macOS 13 since it's the last one that still runs on x86
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - name: Install deps
@@ -48,7 +47,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=../build/macos/ \
             -DRUN_IN_PLACE=FALSE -DENABLE_GETTEXT=TRUE \
             -DINSTALL_DEVTEST=TRUE
-          cmake --build . -j$(sysctl -n hw.logicalcpu)
+          make -j$(sysctl -n hw.logicalcpu)
           make install
 
       - name: Test
@@ -66,5 +65,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: minetest-macos
+          name: minetest-macos_arm
           path: ./build/macos/*.zip

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -1,0 +1,70 @@
+name: macos_intel
+
+# build on c/cpp changes or workflow changes
+on:
+  push:
+    paths:
+      - 'lib/**.[ch]'
+      - 'lib/**.cpp'
+      - 'src/**.[ch]'
+      - 'src/**.cpp'
+      - 'irr/**.[ch]'
+      - 'irr/**.cpp'
+      - 'irr/**.mm' # Objective-C(++)
+      - '**/CMakeLists.txt'
+      - 'cmake/Modules/**'
+      - '.github/workflows/macos_intel.yml'
+  pull_request:
+    paths:
+      - 'lib/**.[ch]'
+      - 'lib/**.cpp'
+      - 'src/**.[ch]'
+      - 'src/**.cpp'
+      - 'irr/**.[ch]'
+      - 'irr/**.cpp'
+      - 'irr/**.mm' # Objective-C(++)
+      - '**/CMakeLists.txt'
+      - 'cmake/Modules/**'
+      - '.github/workflows/macos_intel.yml'
+
+jobs:
+  build:
+    # use macOS 13 since it's the last one that still runs on x86
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: |
+          source ./util/ci/common.sh
+          install_macos_deps
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake .. \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
+            -DCMAKE_FIND_FRAMEWORK=LAST \
+            -DCMAKE_INSTALL_PREFIX=../build/macos/ \
+            -DRUN_IN_PLACE=FALSE -DENABLE_GETTEXT=TRUE \
+            -DINSTALL_DEVTEST=TRUE
+          cmake --build . -j$(sysctl -n hw.logicalcpu)
+          make install
+
+      - name: Test
+        run: |
+          ./build/macos/minetest.app/Contents/MacOS/minetest --run-unittests
+
+      # Zipping the built .app preserves permissions on the contained files,
+      #   which the GitHub artifact pipeline would otherwise strip away.
+      - name: CPack
+        run: |
+          cd build
+          rm -rf macos
+          cmake .. -DINSTALL_DEVTEST=FALSE
+          cpack -G ZIP -B macos
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: minetest-macos_intel
+          path: ./build/macos/*.zip


### PR DESCRIPTION
This adds separate action to build the Minetest for Mac Intel and ARM targets.

Universal build (including binary for Intel and Arm) looks impossible because not all dependencies support universal build.

## To do

This PR is a Ready for Review.

## How to test

Try the Minetest Mac application produced by workflow on a Mac computer.

Arm Mac: 

1. Download the Minetest application for Apple M processors here: https://github.com/minetest/minetest/actions/runs/10331271596/artifacts/1797800935
2. Open the Terminal and do the command `xattr -cr Minetest.app` in the directory where the app is located.
4. Run the command `codesign --force --deep -s - Minetest.app` too.
5. Open it and play...

Intel or Arm Mac: 

1. Download the Minetest application for Intel processors here: https://github.com/minetest/minetest/actions/runs/10331271604/artifacts/1797802981
2. Open application
3. If you get warning "Minetest cannot be opened because the developer cannot be verified." follow: https://support.apple.com/en-gb/guide/mac-help/mh40616/mac
