### PR TITLE
Lua API: fix OOB array access in find_nodes_near

### DIFF
--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -970,8 +970,8 @@ int ModApiEnvBase::findNodesInArea(lua_State *L, const NodeDefManager *ndef,
 		});
 
 		// last filter table is at top of stack
-		u32 i = filter.size() - 1;
-		do {
+		s32 i = filter.size();
+		while (i --> 0) {
 			if (idx[i] == 0) {
 				// No such node found -> drop the empty table
 				lua_pop(L, 1);
@@ -979,7 +979,7 @@ int ModApiEnvBase::findNodesInArea(lua_State *L, const NodeDefManager *ndef,
 				// This node was found -> put table into the return table
 				lua_setfield(L, base, ndef->get(filter[i]).name.c_str());
 			}
-		} while (i-- != 0);
+		}
 
 		assert(lua_gettop(L) == base);
 		return 1;

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -970,7 +970,7 @@ int ModApiEnvBase::findNodesInArea(lua_State *L, const NodeDefManager *ndef,
 		});
 
 		// last filter table is at top of stack
-		s32 i = filter.size();
+		u32 i = filter.size();
 		while (i --> 0) {
 			if (idx[i] == 0) {
 				// No such node found -> drop the empty table


### PR DESCRIPTION
Fixes #14946. Thanks to sfan5 for the backtrace.

## To do

This PR is Ready for Review.

## How to test

```Lua
minetest.register_chatcommand("p", {
	func = function(name, param)
		local pos = minetest.get_player_by_name(name):get_pos()
		local minp = vector.add(pos, -5)
		local maxp = vector.add(pos,  5)

		--local groupname = "group:stone"
		local groupname = "group:invalidgroupname"
		local names_positions = minetest.find_nodes_in_area(minp, maxp, groupname, true)
		for name, pos in pairs(names_positions) do
			print(name, #pos)
		end
		local positions, counts = minetest.find_nodes_in_area(minp, maxp, groupname, false)
		print(#positions, dump(counts))
		return true, "OK!"
	end
})
```

master: segfault
PR: empty table(s)

Re-tested with `group:stone` and got the identical output for master and diff.
