### PR TITLE
Fix empty tables / text lists emitting row events

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1188,7 +1188,9 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 	std::vector<std::string> v_pos = split(parts[0],',');
 	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string name = parts[2];
-	std::vector<std::string> items = split(parts[3],',');
+	std::vector<std::string> items;
+	if (!parts[3].empty())
+		items = split(parts[3],',');
 	std::string str_initial_selection;
 
 	if (parts.size() >= 5)
@@ -1258,7 +1260,9 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 	std::vector<std::string> v_pos = split(parts[0],',');
 	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string name = parts[2];
-	std::vector<std::string> items = split(parts[3],',');
+	std::vector<std::string> items;
+	if (!parts[3].empty())
+		items = split(parts[3],',');
 	std::string str_initial_selection;
 	std::string str_transparent = "false";
 


### PR DESCRIPTION
Fixes #14936.

## How to test

Without this PR, an empty table (for example the "installed content") table should look like this, and emit row events for a nonexistant row 1 (like DCL), causing the crash reported in that issue:

![Screenshot from 2024-08-11 15-56-07](https://github.com/user-attachments/assets/ed96d193-2dc3-462c-a74b-a0af4747db17)

With this PR, it looks like this, and there are no row selection events; the crash shouldn't occur:

![Screenshot from 2024-08-11 15-55-31](https://github.com/user-attachments/assets/88dcf1c0-20ec-461c-a28e-d4847e0a7c57)

I have also confirmed that `guiTable.cpp` is written in such a way that zero rows are handled correctly by looking at all usages of `m_rows`.