### PR TITLE
Generate Android versionCode from Major.Minor.Patch

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,7 +8,8 @@ android {
 		compileSdk 34
 		targetSdkVersion 34
 		versionName "${versionMajor}.${versionMinor}.${versionPatch}"
-		versionCode project.versionCode
+		versionCode versionMajor * 100000 + versionMinor * 1000 + versionPatch * 10
+		// *10 to give space for all the ABIs
 	}
 
 	buildFeatures {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,8 +8,7 @@ android {
 		compileSdk 34
 		targetSdkVersion 34
 		versionName "${versionMajor}.${versionMinor}.${versionPatch}"
-		versionCode versionMajor * 100000 + versionMinor * 1000 + versionPatch * 10
-		// *10 to give space for all the ABIs
+		versionCode versionMajor * 1000000 + versionMinor * 10000 + versionPatch * 100 + versionBuild
 	}
 
 	buildFeatures {
@@ -115,18 +114,6 @@ prepareAssets.dependsOn ':native:getDeps'
 
 clean {
 	delete new File("src/main/assets", "Minetest.zip")
-}
-
-// Map for the version code that gives each ABI a value.
-import com.android.build.OutputFile
-
-def abiCodes = ['armeabi-v7a': 0, 'arm64-v8a': 1]
-android.applicationVariants.all { variant ->
-	variant.outputs.each {
-		output ->
-			def abiName = output.getFilter(OutputFile.ABI)
-			output.versionCodeOverride = abiCodes.get(abiName, 0) + variant.versionCode
-	}
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,10 +4,6 @@ project.ext.set("versionMajor", 5)      // Version Major
 project.ext.set("versionMinor", 10)      // Version Minor
 project.ext.set("versionPatch", 0)      // Version Patch
 // ^ keep in sync with cmake
-project.ext.set("versionCode", 48)      // Android Version Code
-// NOTE: +2 after each release!
-// +1 for ARM and +1 for ARM64 APK's, because
-// each APK must have a larger `versionCode` than the previous
 
 buildscript {
 	ext.ndk_version = '26.2.11394342'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,9 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 project.ext.set("versionMajor", 5)      // Version Major
-project.ext.set("versionMinor", 10)      // Version Minor
+project.ext.set("versionMinor", 10)     // Version Minor
 project.ext.set("versionPatch", 0)      // Version Patch
 // ^ keep in sync with cmake
+
+project.ext.set("versionBuild", 0)      // Version Build
+// ^ fourth version number to allow releasing Android-only fixes and beta versions
 
 buildscript {
 	ext.ndk_version = '26.2.11394342'

--- a/android/native/build.gradle
+++ b/android/native/build.gradle
@@ -8,7 +8,7 @@ android {
 		compileSdk 34
 		targetSdkVersion 34
 		externalNativeBuild {
-            cmake {
+			cmake {
 				arguments "-DANDROID_STL=c++_shared",
 					"-DENABLE_CURL=1", "-DENABLE_SOUND=1",
 					"-DENABLE_GETTEXT=1",

--- a/util/bump_version.sh
+++ b/util/bump_version.sh
@@ -16,20 +16,18 @@ prompt_for() {
 }
 
 # Reads current versions
-# out: VERSION_MAJOR VERSION_MINOR VERSION_PATCH VERSION_IS_DEV CURRENT_VERSION ANDROID_VERSION_CODE
+# out: VERSION_MAJOR VERSION_MINOR VERSION_PATCH VERSION_IS_DEV CURRENT_VERSION
 read_versions() {
 	VERSION_MAJOR=$(grep -oE '^set\(VERSION_MAJOR [0-9]+\)$' CMakeLists.txt | tr -dC 0-9)
 	VERSION_MINOR=$(grep -oE '^set\(VERSION_MINOR [0-9]+\)$' CMakeLists.txt | tr -dC 0-9)
 	VERSION_PATCH=$(grep -oE '^set\(VERSION_PATCH [0-9]+\)$' CMakeLists.txt | tr -dC 0-9)
 	VERSION_IS_DEV=$(grep -oE '^set\(DEVELOPMENT_BUILD [A-Z]+\)$' CMakeLists.txt)
-	ANDROID_VERSION_CODE=$(grep -oE '\("versionCode", [0-9]+\)' android/build.gradle | tr -dC 0-9)
 
 	# Make sure they all exist
 	[ -n "$VERSION_MAJOR" ]
 	[ -n "$VERSION_MINOR" ]
 	[ -n "$VERSION_PATCH" ]
 	[ -n "$VERSION_IS_DEV" ]
-	[ -n "$ANDROID_VERSION_CODE" ]
 
 	if echo "$VERSION_IS_DEV" | grep -q ' TRUE'; then
 		VERSION_IS_DEV=1
@@ -39,7 +37,6 @@ read_versions() {
 	CURRENT_VERSION="$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH"
 
 	echo "Current Minetest version: $CURRENT_VERSION"
-	echo "Current Android version code: $ANDROID_VERSION_CODE"
 }
 
 # Retrieves protocol version from header
@@ -47,18 +44,6 @@ read_versions() {
 read_proto_ver() {
 	local ref=$1
 	git show "$ref":src/network/networkprotocol.h | grep -oE 'LATEST_PROTOCOL_VERSION [0-9]+' | tr -dC 0-9
-}
-
-## Prompts for new android version code
-# in: ANDROID_VERSION_CODE
-# out: NEW_ANDROID_VERSION_CODE
-bump_android_ver() {
-	# +1 for ARM and +1 for ARM64 APKs
-	NEW_ANDROID_VERSION_CODE=$(expr $ANDROID_VERSION_CODE + 2)
-	NEW_ANDROID_VERSION_CODE=$(prompt_for "Set android version code" '[0-9]+' $NEW_ANDROID_VERSION_CODE)
-
-	echo
-	echo "New android version code: $NEW_ANDROID_VERSION_CODE"
 }
 
 ## Prompts for new version
@@ -106,14 +91,6 @@ set_dev_build() {
 	fi
 
 	git add -f CMakeLists.txt android/build.gradle
-}
-
-## Writes new android version code
-# in: NEW_ANDROID_VERSION_CODE
-write_android_version() {
-	sed -i -re "s/\"versionCode\", [0-9]+/\"versionCode\", $NEW_ANDROID_VERSION_CODE/" android/build.gradle
-
-	git add -f android/build.gradle
 }
 
 ## Writes new version to the right files
@@ -198,8 +175,6 @@ if [ "$DO_PATCH_REL" -eq 0 ]; then
 		exit 1
 	fi
 
-	bump_android_ver
-	write_android_version
 	set_dev_build 0
 
 	perform_release "$CURRENT_VERSION"
@@ -212,8 +187,6 @@ if [ "$DO_PATCH_REL" -eq 0 ]; then
 else
 	# On a patch release the version moves from 5.7.0 -> 5.7.1 (new tag)
 
-	bump_android_ver
-	write_android_version
 	bump_version
 	write_new_version
 


### PR DESCRIPTION
Let's never mess up the versionCode again

## To do

This PR is Ready for Review

- [x] Test bump_version.sh
- [x] Do different architectures still need different version codes with app bundles?

## How to test

<!-- Example code or instructions -->
