### PR TITLE
Font escape sequence for nametags

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -580,6 +580,10 @@ function core.get_background_escape_sequence(color)
 	return ESCAPE_CHAR .. "(b@" .. color .. ")"
 end
 
+function core.get_font_escape_sequence(font)
+	return ESCAPE_CHAR .. "(f@" .. font .. ")"
+end
+
 function core.colorize(color, message)
 	local lines = tostring(message):split("\n", true)
 	local color_code = core.get_color_escape_sequence(color)
@@ -602,6 +606,10 @@ end
 
 function core.strip_colors(str)
 	return (str:gsub(ESCAPE_CHAR .. "%([bc]@[^)]+%)", ""))
+end
+
+function core.strip_font(str)
+	return (str:gsub(ESCAPE_CHAR .. "%(f@[^)]+%)", ""))
 end
 
 function core.translate(textdomain, str, ...)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3735,6 +3735,13 @@ The following functions provide escape sequences:
     * Removes background colors added by `get_background_escape_sequence`.
 * `minetest.strip_colors(str)`
     * Removes all color escape sequences.
+* `minetest.get_font_escape_sequence(font_modifier)`
+	* Can currently only be used for nametags.
+    * `font_modifier` can be "mono", "unmono", "bold", "unbold", "italic" or "unitalic"
+    * The escape sequence modifies the font of the subsequent string.
+    * You can concatenate them, to for example get bold italic text.
+* `minetest.strip_font(str)`
+    * Removes all font escape sequences.
 
 
 
@@ -5456,6 +5463,8 @@ Utilities
       moveresult_new_pos = true,
       -- Allow removing definition fields in `minetest.override_item` (5.9.0)
       override_item_remove_fields = true,
+      -- Nametags support color escaped sequences and new font escape sequences. (5.10.0)
+      nametag_font_escape_sequences = true,
   }
   ```
 
@@ -8885,6 +8894,8 @@ Player properties need to be saved manually.
 
     nametag_color = <ColorSpec>,
     -- Sets text color of nametag
+    -- If the text contains color escape sequences, only the part before the first
+    -- color escape sequences will have the `nametag_color`.
 
     nametag_bgcolor = <ColorSpec>,
     -- Sets background color of nametag

--- a/games/devtest/mods/testentities/visuals.lua
+++ b/games/devtest/mods/testentities/visuals.lua
@@ -148,3 +148,89 @@ minetest.register_entity("testentities:nametag", {
 		return minetest.serialize({ color = self.color, bgcolor = self.bgcolor })
 	end,
 })
+
+-- Enriched nametag strings
+do
+
+local bold = minetest.get_font_escape_sequence("bold")
+local unbold = minetest.get_font_escape_sequence("unbold")
+local italic = minetest.get_font_escape_sequence("italic")
+local unitalic = minetest.get_font_escape_sequence("unitalic")
+local mono = minetest.get_font_escape_sequence("mono")
+local unmono = minetest.get_font_escape_sequence("unmono")
+local all_off = unbold..unitalic..unmono
+
+local nametags = {
+	"normal "..bold.."bold "..unbold..italic.."italic "..unitalic..mono.."mono",
+	bold..italic.."bold+italic"..unitalic..mono.." bold+mono"..unbold..italic.." mono+italic",
+	bold..italic..mono.."bold+mono+italic",
+	bold.."bold colored"..minetest.colorize("red", " red").." text",
+	"colored"..minetest.colorize("red", " red"..bold.." bold"..unbold).." text",
+	minetest.strip_font(bold.."striped"..italic.." font fomats"),
+	minetest.get_background_escape_sequence("green").."background is not supported",
+	"colored"..minetest.colorize("gray", " gray"..bold.." bold multi\nline").." text",
+	bold..unbold.."\nempty lines"..italic.." before and after\n"..unitalic,
+	"m"..mono.."m"..unmono.."m"..mono.."m"..unmono.."m"..mono.."m"..unmono.."m"..mono.."m",
+	"i"..italic.."i"..unitalic.."i"..italic.."i"..unitalic.."i"..italic.."i"..unitalic.."i"..
+		italic.."i",
+	"b"..bold.."b"..unbold.."b"..bold.."b"..unbold.."b"..bold.."b"..unbold.."b"..bold.."b",
+}
+
+-- Remove this if you want to look them separately
+local all_lines = "Enriched nametag text:"
+for _, nametag in ipairs(nametags) do
+	all_lines = all_lines.."\n"..all_off..nametag
+end
+nametags = {all_lines}
+
+local nametag_iterator = 0
+minetest.register_entity("testentities:nametag_enriched_text", {
+	initial_properties = {
+		visual = "sprite",
+		textures = { "testentities_sprite.png" },
+	},
+
+	on_activate = function(self, staticdata)
+		local color
+		local bgcolor
+		if (nametag_iterator/#nametags) % 2 < 1 then
+			color = {r = 0, g = 0, b = 255}
+			bgcolor = {r = 200, g = 200, b = 10,a = 150}
+		end
+
+		local nametag = nametags[(nametag_iterator % #nametags)+1]
+		nametag_iterator = nametag_iterator + 1
+
+		self.object:set_properties({
+			nametag = nametag,
+			nametag_color = color,
+			nametag_bgcolor = bgcolor,
+		})
+	end,
+
+})
+
+-- Who doesn't like ascii art
+minetest.register_entity("testentities:nametag_ascii_art", {
+	initial_properties = {
+		visual = "sprite",
+		textures = { "testentities_sprite.png" },
+	},
+	on_activate = function(self, staticdata)
+		local nametag = mono..
+			"         __.               __.                 __.  \n" ..
+			"  _____ |__| ____   _____ /  |_  _____  _____ /  |_ \n" ..
+			" /     \\|  |/    \\ /  __ \\    _\\/  __ \\/   __>    _\\\n" ..
+			"|  Y Y  \\  |   |  \\   ___/|  | |   ___/\\___  \\|  |  \n" ..
+			"|__|_|  /  |___|  /\\______>  |  \\______>_____/|  |  \n" ..
+			"      \\/ \\/     \\/         \\/                  \\/   "
+		self.object:set_properties({
+			nametag = nametag,
+			nametag_color = "green",
+			nametag_bgcolor = "black",
+		})
+	end,
+
+})
+
+end

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -38,6 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "script/scripting_client.h"
 #include "gettext.h"
 #include <SViewFrustum.h>
+#include "util/font_enriched_string_composite.h"
 
 #define CAMERA_OFFSET_STEP 200
 #define WIELDMESH_OFFSET_X 55.0f
@@ -644,7 +645,6 @@ void Camera::drawNametags()
 	core::matrix4 trans = m_cameranode->getProjectionMatrix();
 	trans *= m_cameranode->getViewMatrix();
 
-	gui::IGUIFont *font = g_fontengine->getFont();
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
 	v2u32 screensize = driver->getScreenSize();
 
@@ -655,10 +655,10 @@ void Camera::drawNametags()
 		f32 transformed_pos[4] = { pos.X, pos.Y, pos.Z, 1.0f };
 		trans.multiplyWith1x4Matrix(transformed_pos);
 		if (transformed_pos[3] > 0) {
-			std::wstring nametag_colorless =
-				unescape_translate(utf8_to_wide(nametag->text));
-			core::dimension2d<u32> textsize = font->getDimension(
-				nametag_colorless.c_str());
+			FontEnrichedStringComposite fesc(translate_string(utf8_to_wide(nametag->text)).c_str(),
+				nametag->textcolor);
+
+			core::dimension2d<u32> textsize = fesc.getDimension();
 			f32 zDiv = transformed_pos[3] == 0.0f ? 1.0f :
 				core::reciprocal(transformed_pos[3]);
 			v2s32 screen_pos;
@@ -673,10 +673,7 @@ void Camera::drawNametags()
 				core::rect<s32> bg_size(-2, 0, textsize.Width + 2, textsize.Height);
 				driver->draw2DRectangle(bgcolor, bg_size + screen_pos);
 			}
-
-			font->draw(
-				translate_string(utf8_to_wide(nametag->text)).c_str(),
-				size + screen_pos, nametag->textcolor);
+			fesc.draw(size + screen_pos);
 		}
 	}
 }

--- a/src/client/fontengine.h
+++ b/src/client/fontengine.h
@@ -30,6 +30,17 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define FONT_SIZE_UNSPECIFIED 0xFFFFFFFF
 
+using namespace irr;
+
+enum class FontModifier {
+	Mono,
+	Unmono,
+	Bold,
+	Unbold,
+	Italic,
+	Unitalic,
+};
+
 enum FontMode : u8 {
 	FM_Standard = 0,
 	FM_Mono,
@@ -48,6 +59,31 @@ struct FontSpec {
 	u16 getHash() const
 	{
 		return (mode << 2) | (static_cast<u8>(bold) << 1) | static_cast<u8>(italic);
+	}
+
+	void applyFontModifier(FontModifier modifier) {
+		switch(modifier) {
+			case FontModifier::Mono :
+				mode = FM_Mono;
+				break;
+			case FontModifier::Unmono :
+				mode = FM_Standard;
+				break;
+			case FontModifier::Bold :
+				bold = true;
+				break;
+			case FontModifier::Unbold :
+				bold = false;
+				break;
+			case FontModifier::Italic :
+				italic = true;
+				break;
+			case FontModifier::Unitalic :
+				italic = false;
+				break;
+			default:
+				break;
+		}
 	}
 
 	unsigned int size;

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -5,6 +5,7 @@ set(UTIL_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/base64.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/directiontables.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/enriched_string.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/font_enriched_string_composite.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/ieee_float.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/metricsbackend.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/numeric.cpp

--- a/src/util/font_enriched_string_composite.cpp
+++ b/src/util/font_enriched_string_composite.cpp
@@ -1,0 +1,164 @@
+/*
+Minetest
+Copyright (C) 2024 cx384
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "font_enriched_string_composite.h"
+#include "irrlicht_changes/CGUITTFont.h"
+
+static bool parseFontModifier(std::string_view s, FontModifier &modifier) {
+	if (s == "mono")
+		modifier = FontModifier::Mono;
+	else if (s == "unmono")
+		modifier = FontModifier::Unmono;
+	else if (s == "bold")
+		modifier = FontModifier::Bold;
+	else if (s == "unbold")
+		modifier = FontModifier::Unbold;
+	else if (s == "italic")
+		modifier = FontModifier::Italic;
+	else if (s == "unitalic")
+		modifier = FontModifier::Unitalic;
+	else
+		return false;
+	return true;
+};
+
+FontEnrichedStringComposite::FontEnrichedStringComposite(const std::wstring &s,
+		const video::SColor &initial_color, const FontSpec &initial_font) {
+
+	FontSpec font = initial_font;
+	video::SColor color = initial_color;
+
+	// Handle font escape sequence like in EnrichedString and translate_string
+	Line line;
+	size_t fragmen_start = 0;
+	size_t i = 0;
+	while (i < s.length()) {
+		if (s[i] == L'\n') {
+			// Split lines
+
+			EnrichedString fragment(std::wstring(s, fragmen_start, i-fragmen_start), color);
+			line.push_back(std::make_pair(fragment, font));
+
+			auto colors = fragment.getColors();
+			if (!colors.empty())
+				color =	colors.back();
+
+			if (!line.empty()) {
+				m_lines.emplace_back(std::move(line));
+				line = Line();
+			}
+			i++;
+			fragmen_start = i;
+			continue;
+		} else if (s[i] != L'\x1b') {
+			i++;
+			continue;
+		}
+		i++;
+		size_t start_index = i;
+		size_t length;
+		if (i == s.length())
+			break;
+		if (s[i] == L'(') {
+			++i;
+			++start_index;
+			while (i < s.length() && s[i] != L')') {
+				if (s[i] == L'\\') {
+					++i;
+				}
+				++i;
+			}
+			length = i - start_index;
+			++i;
+		} else {
+			++i;
+			length = 1;
+		}
+		std::wstring escape_sequence(s, start_index, length);
+		std::vector<std::wstring> parts = split(escape_sequence, L'@');
+		if (parts[0] == L"f") {
+			if (parts.size() < 2) {
+				continue;
+			}
+			FontModifier modifier;
+			if (parseFontModifier(wide_to_utf8(parts[1]), modifier)) {
+				EnrichedString fragment(std::wstring(s, fragmen_start, start_index-fragmen_start), color);
+				line.push_back(std::make_pair(fragment, font));
+
+				fragmen_start = start_index + length + 1;
+				font.applyFontModifier(modifier);
+
+				auto colors = fragment.getColors();
+				if (!colors.empty())
+					color =	colors.back();
+			}
+		}
+	}
+	if (fragmen_start < s.length()) {
+		EnrichedString fragment(std::wstring(s, fragmen_start), color);
+		line.push_back(std::make_pair(fragment, font));
+	}
+
+	if (!line.empty())
+		m_lines.push_back(line);
+
+};
+
+void FontEnrichedStringComposite::draw(core::rect<s32> position) const {
+	u32 start_pos_x = position.UpperLeftCorner.X;
+	for (auto line : m_lines) {
+		position.UpperLeftCorner.X = start_pos_x;
+		u32 max_h = 0;
+		for (auto [es, spec] : line) {
+			gui::IGUIFont *font = g_fontengine->getFont(spec);
+			gui::CGUITTFont *ttfont = dynamic_cast<gui::CGUITTFont*>(font);
+			if (ttfont) { // Don't draw other fonts
+				ttfont->draw(es, position);
+
+				auto frag_dim = ttfont->getDimension(es.c_str());
+				position.UpperLeftCorner.X += frag_dim.Width;
+				if (frag_dim.Height > max_h)
+					max_h = frag_dim.Height;
+			}
+		}
+		position.UpperLeftCorner.Y += max_h;
+	}
+};
+
+core::dimension2d<u32> FontEnrichedStringComposite::getDimension() const {
+	core::dimension2d<u32> dim(0, 0);
+	for (auto line : m_lines) {
+		u32 max_h = 0;
+		u32 sum_w = 0;
+		for (auto [es, spec] : line) {
+			gui::IGUIFont *font = g_fontengine->getFont(spec);
+			gui::CGUITTFont *ttfont = dynamic_cast<gui::CGUITTFont*>(font);
+			if (ttfont) {
+				auto frag_dim = ttfont->getDimension(es.c_str());
+				sum_w += frag_dim.Width;
+				if (frag_dim.Height > max_h)
+					max_h = frag_dim.Height;
+			}
+		}
+		dim.Height += max_h;
+		if (dim.Width < sum_w)
+			dim.Width = sum_w;
+	}
+	return dim;
+};

--- a/src/util/font_enriched_string_composite.h
+++ b/src/util/font_enriched_string_composite.h
@@ -1,0 +1,41 @@
+/*
+Minetest
+Copyright (C) 2024 cx384
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "enriched_string.h"
+#include <utility>
+#include "client/fontengine.h"
+
+// Note this is client code, because of the draw function.
+
+// A text consisting of multiple enriched strings which are drawn with different fonts
+struct FontEnrichedStringComposite {
+	FontEnrichedStringComposite(const std::wstring &s,
+		const video::SColor &initial_color = video::SColor(255, 255, 255, 255),
+		const FontSpec &initial_font = FontSpec(FONT_SIZE_UNSPECIFIED, FM_Standard, false, false));
+
+	void draw(core::rect<s32> position) const;
+
+	core::dimension2d<u32> getDimension() const;
+
+private:
+	using Line = std::vector<std::pair<EnrichedString, FontSpec>>;
+	std::vector<Line> m_lines;
+};


### PR DESCRIPTION
### Goal of the PR
- This is a probably better solution than #14866
- It resolves #13673, and paves the way for #14913 and similar.

### How does the PR work?
![font_nametag_text](https://github.com/user-attachments/assets/7cb755c0-5e3f-4871-aa81-5d3a7594b388)


- It adds font escape sequences, which for now can only be used for nametags. (Future PRs could use them for the chat, hud, tooltips, ...)
- Nametags now also support color escape sequences, because of the use of enriched strings. The `nametag_color` basically acts like as a prefixed color escape sequence.
- The font escape sequences act like the color escape sequences, meaning that everything after them is drawn differently. (mods could always introduce their own system on top)
- Some design decisions:
  - A font escape sequence only changes one aspect at once. This should be the most convenient.
  - The font specs did not become a part of the `EnrichedString` like the colors, because internal the way how text is drawn is coupled very closely together with the used font (see `GUITTFont` or `CGUITTFont`), so it makes no sense to draw it as a single string without completely changing what a `GUITTFont` is and drawing it separately shouldn't make a big difference.
  - I know the enriched string situation is not optimal, but formspec texts and nametag/chat texts are used very different anyway. It could be improved by refactorung large parts of the irrlicht and formspec code, but I think it should also be fine this way, at least for now.

## To do

This PR is Ready for Review.

## How to test

- Start devtest and spawn some `testentities:nametag`, `testentities:nametag_enriched_text`, and `testentities:nametag_ascii_art`.
- See that normal nametags still look the same, the enriched text looks fine, and that mono text is useful.
