### PR TITLE
Fix CMeshBuffer::append reallocating too eagerly

### DIFF
--- a/irr/include/CMeshBuffer.h
+++ b/irr/include/CMeshBuffer.h
@@ -169,19 +169,30 @@ public:
 		if (vertices == getVertices())
 			return;
 
-		const u32 vertexCount = getVertexCount();
-		u32 i;
+		//~ // Only reallocate if there are enough new vertices. Otherwise append()
+		//~ // will be slow when called in a loop.
+		//~ const u32 newVertexCount = getVertexCount() + numVertices;
+		//~ if (newVertexCount > Vertices.allocated_size() * 3 / 2)
+			//~ Vertices.reallocate(newVertexCount);
 
-		Vertices.reallocate(vertexCount + numVertices);
-		for (i = 0; i < numVertices; ++i) {
-			Vertices.push_back(static_cast<const T *>(vertices)[i]);
+		Vertices.insertEnd(static_cast<const T *>(vertices),
+				static_cast<const T *>(vertices) + numVertices);
+
+		for (u32 i = 0; i < numVertices; ++i) {
+			//~ Vertices.push_back(static_cast<const T *>(vertices)[i]);
 			BoundingBox.addInternalPoint(static_cast<const T *>(vertices)[i].Pos);
 		}
 
-		Indices.reallocate(getIndexCount() + numIndices);
-		for (i = 0; i < numIndices; ++i) {
-			Indices.push_back(indices[i] + vertexCount);
-		}
+		Indices.insertEnd(static_cast<const T *>(indices),
+				static_cast<const T *>(indices) + numIndices);
+
+		//~ const u32 newIndexCount = getIndexCount() + numIndices;
+		//~ if (newIndexCount > Indices.allocated_size() * 3 / 2)
+			//~ Indices.reallocate(newIndexCount);
+
+		//~ for (u32 i = 0; i < numIndices; ++i) {
+			//~ Indices.push_back(indices[i] + vertexCount);
+		//~ }
 	}
 
 	//! get the current hardware mapping hint

--- a/irr/include/CMeshBuffer.h
+++ b/irr/include/CMeshBuffer.h
@@ -169,30 +169,24 @@ public:
 		if (vertices == getVertices())
 			return;
 
-		//~ // Only reallocate if there are enough new vertices. Otherwise append()
-		//~ // will be slow when called in a loop.
-		//~ const u32 newVertexCount = getVertexCount() + numVertices;
-		//~ if (newVertexCount > Vertices.allocated_size() * 3 / 2)
-			//~ Vertices.reallocate(newVertexCount);
+		const u32 vertexCount = getVertexCount();
 
-		Vertices.insertEnd(static_cast<const T *>(vertices),
-				static_cast<const T *>(vertices) + numVertices);
+		// Only reallocate if there are enough new vertices. Otherwise append()
+		// will be slow when called in a loop.
+		if (vertexCount + numVertices > Vertices.allocated_size() * 3 / 2)
+			Vertices.reallocate(vertexCount + numVertices);
 
 		for (u32 i = 0; i < numVertices; ++i) {
-			//~ Vertices.push_back(static_cast<const T *>(vertices)[i]);
+			Vertices.push_back(static_cast<const T *>(vertices)[i]);
 			BoundingBox.addInternalPoint(static_cast<const T *>(vertices)[i].Pos);
 		}
 
-		Indices.insertEnd(static_cast<const T *>(indices),
-				static_cast<const T *>(indices) + numIndices);
+		if (getIndexCount() + numIndices > Indices.allocated_size() * 3 / 2)
+			Indices.reallocate(getIndexCount() + numIndices);
 
-		//~ const u32 newIndexCount = getIndexCount() + numIndices;
-		//~ if (newIndexCount > Indices.allocated_size() * 3 / 2)
-			//~ Indices.reallocate(newIndexCount);
-
-		//~ for (u32 i = 0; i < numIndices; ++i) {
-			//~ Indices.push_back(indices[i] + vertexCount);
-		//~ }
+		for (u32 i = 0; i < numIndices; ++i) {
+			Indices.push_back(indices[i] + vertexCount);
+		}
 	}
 
 	//! get the current hardware mapping hint

--- a/irr/include/irrArray.h
+++ b/irr/include/irrArray.h
@@ -94,6 +94,17 @@ public:
 		is_sorted = false;
 	}
 
+	//! Adds multiple elements to the end of the array.
+	/**
+	\param first: Iterator to first element to be added.
+	\param last: Past-the-end iterator for elements to be added. */
+	template <typename InputIt>
+	void insertEnd(InputIt &&first, InputIt &&last)
+	{
+		m_data.insert(m_data.end(), std::forward(first), std::forward(last));
+		is_sorted = false;
+	}
+
 	//! Insert item into array at specified position.
 	/**
 	\param element: Element to be inserted

--- a/irr/include/irrArray.h
+++ b/irr/include/irrArray.h
@@ -94,17 +94,6 @@ public:
 		is_sorted = false;
 	}
 
-	//! Adds multiple elements to the end of the array.
-	/**
-	\param first: Iterator to first element to be added.
-	\param last: Past-the-end iterator for elements to be added. */
-	template <typename InputIt>
-	void insertEnd(InputIt &&first, InputIt &&last)
-	{
-		m_data.insert(m_data.end(), std::forward(first), std::forward(last));
-		is_sorted = false;
-	}
-
 	//! Insert item into array at specified position.
 	/**
 	\param element: Element to be inserted


### PR DESCRIPTION
* This fixes performance when many particles are spawned at once (see How to test).
* The particle implementation calls `CMeshBuffer::append` often with small arrays of 4 vertices.
  `CMeshBuffer::append` reallocates it's vertex array (`irr::array` wrapper around `std::vector`).
  Calling `std::vector::reserve` with linearly increasing size in a loop is slow, because it results in quadratic runtime.
* This PR makes it so that the realloc only happens if it makes sense.
* Idk if other features of the engine profit from this.

## To do

This PR is a Ready for Review.

## How to test

* Install this mod: https://codeberg.org/Desour/lavaplop
  (Sorry, not minimal. But the mod is quite small.)
* In the settings menu, set `lavaplop.rate` to `50` (and disable `lavaplop.particle_collisiondetection`).
* In game, stand next to a lava lake.
* Rejoin.
* There will be many particles spawned in a short amount of time.
* In master: Big lag for some seconds after joining. With PR: No big client lag.