### PR TITLE
Allow requesting reconnect when mods kick player

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -6,14 +6,14 @@ local S = core.get_translator("__builtin")
 -- Misc. API functions
 --
 
--- @spec core.kick_player(String, String) :: Boolean
-function core.kick_player(player_name, reason)
+-- @spec core.kick_player(String, String, Boolean) :: Boolean
+function core.kick_player(player_name, reason, reconnect)
 	if type(reason) == "string" then
 		reason = "Kicked: " .. reason
 	else
 		reason = "Kicked."
 	end
-	return core.disconnect_player(player_name, reason)
+	return core.disconnect_player(player_name, reason, reconnect)
 end
 
 function core.check_player_privs(name, ...)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6936,10 +6936,11 @@ Bans
     * Returns boolean indicating success
 * `minetest.unban_player_or_ip(ip_or_name)`: remove ban record matching
   IP address or name
-* `minetest.kick_player(name, [reason])`: disconnect a player with an optional
+* `minetest.kick_player(name[, reason[, reconnect]])`: disconnect a player with an optional
   reason.
     * Returns boolean indicating success (false if player nonexistent)
-* `minetest.disconnect_player(name, [reason])`: disconnect a player with an
+    * If `reconnect` is true, allow the user to reconnect.
+* `minetest.disconnect_player(name[, reason[, reconnect]])`: disconnect a player with an
   optional reason, this will not prefix with 'Kicked: ' like kick_player.
   If no reason is given, it will default to 'Disconnected.'
     * Returns boolean indicating success (false if player nonexistent)

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -231,10 +231,10 @@ void Client::handleCommand_AccessDenied(NetworkPacket* pkt)
 		*pkt >> m_access_denied_reason;
 
 	if (m_access_denied_reason.empty()) {
-		if (denyCode != SERVER_ACCESSDENIED_CUSTOM_STRING) {
+		if (denyCode >= SERVER_ACCESSDENIED_MAX) {
+			m_access_denied_reason = gettext("Unknown disconnect reason.");
+		} else if (denyCode != SERVER_ACCESSDENIED_CUSTOM_STRING) {
 			m_access_denied_reason = gettext(accessDeniedStrings[denyCode]);
-		} else if (denyCode >= SERVER_ACCESSDENIED_MAX) {
-			m_access_denied_reason = "Unknown";
 		}
 	}
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -209,7 +209,6 @@ void Client::handleCommand_AccessDenied(NetworkPacket* pkt)
 	// to be processed even if the serialization format has
 	// not been agreed yet, the same as TOCLIENT_INIT.
 	m_access_denied = true;
-	m_access_denied_reason = "Unknown";
 
 	if (pkt->getCommand() != TOCLIENT_ACCESS_DENIED) {
 		// Legacy code from 0.4.12 and older but is still used
@@ -232,10 +231,10 @@ void Client::handleCommand_AccessDenied(NetworkPacket* pkt)
 		*pkt >> m_access_denied_reason;
 
 	if (m_access_denied_reason.empty()) {
-		if (denyCode >= SERVER_ACCESSDENIED_MAX) {
-			m_access_denied_reason = "Unknown";
-		} else if (denyCode != SERVER_ACCESSDENIED_CUSTOM_STRING) {
+		if (denyCode != SERVER_ACCESSDENIED_CUSTOM_STRING) {
 			m_access_denied_reason = gettext(accessDeniedStrings[denyCode]);
+		} else if (denyCode >= SERVER_ACCESSDENIED_MAX) {
+			m_access_denied_reason = "Unknown";
 		}
 	}
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -228,10 +228,9 @@ void Client::handleCommand_AccessDenied(NetworkPacket* pkt)
 	u8 denyCode;
 	*pkt >> denyCode;
 
-	if (pkt->getRemainingBytes() <= 0)
-		return;
+	if (pkt->getRemainingBytes() > 0)
+		*pkt >> m_access_denied_reason;
 
-	*pkt >> m_access_denied_reason;
 	if (m_access_denied_reason.empty()) {
 		if (denyCode >= SERVER_ACCESSDENIED_MAX) {
 			m_access_denied_reason = "Unknown";

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -365,7 +365,7 @@ int ModApiServer::l_ban_player(lua_State *L)
 	return 1;
 }
 
-// disconnect_player(name, [reason]) -> success
+// disconnect_player(name[, reason[, reconnect]]) -> success
 int ModApiServer::l_disconnect_player(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -388,7 +388,9 @@ int ModApiServer::l_disconnect_player(lua_State *L)
 		return 1;
 	}
 
-	server->DenyAccess(player->getPeerId(), SERVER_ACCESSDENIED_CUSTOM_STRING, message);
+	bool reconnect = readParam<bool>(L, 3, false);
+
+	server->DenyAccess(player->getPeerId(), SERVER_ACCESSDENIED_CUSTOM_STRING, message, reconnect);
 	lua_pushboolean(L, true);
 	return 1;
 }

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -106,7 +106,7 @@ private:
 	// unban_player_or_ip()
 	static int l_unban_player_or_ip(lua_State *L);
 
-	// disconnect_player(name, [reason]) -> success
+	// disconnect_player(name[, reason[, reconnect]]) -> success
 	static int l_disconnect_player(lua_State *L);
 
 	// remove_player(name)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2854,7 +2854,7 @@ void Server::DenySudoAccess(session_t peer_id)
 
 
 void Server::DenyAccess(session_t peer_id, AccessDeniedCode reason,
-		const std::string &custom_reason, bool reconnect)
+		std::string_view custom_reason, bool reconnect)
 {
 	SendAccessDenied(peer_id, reason, custom_reason, reconnect);
 	m_clients.event(peer_id, CSE_SetDenied);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1413,17 +1413,12 @@ void Server::SendBreath(session_t peer_id, u16 breath)
 }
 
 void Server::SendAccessDenied(session_t peer_id, AccessDeniedCode reason,
-		const std::string &custom_reason, bool reconnect)
+		std::string_view custom_reason, bool reconnect)
 {
 	assert(reason < SERVER_ACCESSDENIED_MAX);
 
 	NetworkPacket pkt(TOCLIENT_ACCESS_DENIED, 1, peer_id);
-	pkt << (u8)reason;
-	if (reason == SERVER_ACCESSDENIED_CUSTOM_STRING)
-		pkt << custom_reason;
-	else if (reason == SERVER_ACCESSDENIED_SHUTDOWN ||
-			reason == SERVER_ACCESSDENIED_CRASH)
-		pkt << custom_reason << (u8)reconnect;
+	pkt << (u8)reason << custom_reason << (u8)reconnect;
 	Send(&pkt);
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -485,7 +485,7 @@ private:
 	void SendHP(session_t peer_id, u16 hp, bool effect);
 	void SendBreath(session_t peer_id, u16 breath);
 	void SendAccessDenied(session_t peer_id, AccessDeniedCode reason,
-		const std::string &custom_reason, bool reconnect = false);
+		std::string_view custom_reason, bool reconnect = false);
 	void SendDeathscreen(session_t peer_id, bool set_camera_point_target,
 		v3f camera_point_target);
 	void SendItemDef(session_t peer_id, IItemDefManager *itemdef, u16 protocol_version);

--- a/src/server.h
+++ b/src/server.h
@@ -364,7 +364,7 @@ public:
 
 	void DenySudoAccess(session_t peer_id);
 	void DenyAccess(session_t peer_id, AccessDeniedCode reason,
-		const std::string &custom_reason = "", bool reconnect = false);
+		std::string_view custom_reason = "", bool reconnect = false);
 	void kickAllPlayers(AccessDeniedCode reason,
 		const std::string &str_reason, bool reconnect);
 	void acceptAuth(session_t peer_id, bool forSudoMode);


### PR DESCRIPTION
This PR allows mods to request disconnect when kicking players by reworking relevant networking codes.

## To do

This PR is Ready for Review.

## How to test

1. Run `minetest.disconnect_player(name, "test", true)`: "Reconnect" should be an option for that player.
2. Run `minetest.disconnect_player(name, "test", false / unset)`: A regular exit box should be shown.
3. Do anything that could disconnect the player: Things should work as they would
4. Run the above tests with 5.9 server or/and client: In (1), it would not show "Reconnect", otherwise everything should work fine
