### PR TITLE
Fix chance/probability wording in lua_doc.md

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8972,7 +8972,7 @@ Used by `minetest.register_abm`.
     -- Operation interval in seconds
 
     chance = 50,
-    -- Chance of triggering `action` per-node per-interval is 1.0 / chance
+    -- Probabilitiy of triggering `action` per-node per-interval is 1.0 / chance (integers only)
 
     min_y = -32768,
     max_y = 32767,

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8972,7 +8972,7 @@ Used by `minetest.register_abm`.
     -- Operation interval in seconds
 
     chance = 50,
-    -- Probabilitiy of triggering `action` per-node per-interval is 1.0 / chance (integers only)
+    -- Probability of triggering `action` per-node per-interval is 1.0 / chance (integers only)
 
     min_y = -32768,
     max_y = 32767,


### PR DESCRIPTION
Documentation improvement. The probability is 1/chance, not "the chance is 1/chance".

Also, unfortunately, only integers are currently possible (why not float?)