### PR TITLE
[no squash] CI whitespace checks

### DIFF
--- a/.github/workflows/whitespace_checks.yml
+++ b/.github/workflows/whitespace_checks.yml
@@ -1,0 +1,45 @@
+name: whitespace_checks
+
+# Check whitespaces of the following file types
+# Not checked: .lua, .yml, .properties, .conf, .java, .py, .svg, .gradle, .xml, ...
+# (luacheck already checks .lua files)
+on:
+  push:
+    paths:
+      - '**.txt'
+      - '**.md'
+      - '**.[ch]'
+      - '**.cpp'
+      - '**.hpp'
+      - '**.sh'
+      - '**.cmake'
+      - '**.glsl'
+  pull_request:
+    paths:
+      - '**.txt'
+      - '**.md'
+      - '**.[ch]'
+      - '**.cpp'
+      - '**.hpp'
+      - '**.sh'
+      - '**.cmake'
+      - '**.glsl'
+
+jobs:
+  trailing_whitespaces:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Line endings are already ensured by .gitattributes
+      - name: Check trailing whitespaces
+        run: if git ls-files | grep -E '\.txt$|\.md$|\.[ch]$|\.cpp$|\.hpp$|\.sh$|\.cmake$|\.glsl$' | xargs grep -n '\s$'; then echo -e "\033[0;31mFound trailing whitespace"; (exit 1); else (exit 0); fi
+
+  tabs_lua_api_files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Some files should not contain tabs
+      - name: Check tabs in Lua API files
+        run: if grep -n $'\t' doc/lua_api.md doc/client_lua_api.md; then echo -e "\033[0;31mFound tab in markdown file"; (exit 1); else (exit 0); fi
+
+

--- a/client/shaders/fxaa/opengl_fragment.glsl
+++ b/client/shaders/fxaa/opengl_fragment.glsl
@@ -58,11 +58,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     #define FXAA_SPAN_MAX     8.0
 #endif
 
-//optimized version for mobile, where dependent 
+//optimized version for mobile, where dependent
 //texture reads can be a bottleneck
 vec4 fxaa(sampler2D tex, vec2 fragCoord, vec2 inverseVP,
-            vec2 v_rgbNW, vec2 v_rgbNE, 
-            vec2 v_rgbSW, vec2 v_rgbSE, 
+            vec2 v_rgbNW, vec2 v_rgbNE,
+            vec2 v_rgbSW, vec2 v_rgbSE,
             vec2 v_rgbM) {
     vec4 color;
     vec3 rgbNW = texture2D(tex, v_rgbNW).xyz;
@@ -111,6 +111,6 @@ void main(void)
 {
 	vec2 uv = varTexCoord.st;
 
-	gl_FragColor = fxaa(rendered, uv, texelSize0, 
+	gl_FragColor = fxaa(rendered, uv, texelSize0,
 		sampleNW, sampleNE, sampleSW, sampleSE, uv);
 }

--- a/client/shaders/fxaa/opengl_vertex.glsl
+++ b/client/shaders/fxaa/opengl_vertex.glsl
@@ -12,7 +12,7 @@ varying vec2 sampleSW;
 varying vec2 sampleSE;
 
 /*
-Based on 
+Based on
 https://github.com/mattdesl/glsl-fxaa/
 Portions Copyright (c) 2011 by Armin Ronacher.
 */

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -315,7 +315,7 @@ Call these functions only at load time!
 
 * `minetest.register_globalstep(function(dtime))`
     * Called every client environment step
-	* `dtime` is the time since last execution in seconds.
+    * `dtime` is the time since last execution in seconds.
 * `minetest.register_on_mods_loaded(function())`
     * Called just after mods have finished loading.
 * `minetest.register_on_shutdown(function())`
@@ -586,9 +586,9 @@ Call these functions only at load time!
 * `minetest.camera`
     * Reference to the camera object. See [`Camera`](#camera) class reference for methods.
 * `minetest.show_formspec(formname, formspec)` : returns true on success
-	* Shows a formspec to the player
+    * Shows a formspec to the player
 * `minetest.display_chat_message(message)` returns true on success
-	* Shows a chat message to the current player.
+    * Shows a chat message to the current player.
 
 Setting-related
 ---------------
@@ -866,9 +866,9 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
 -----------------
 ### Definitions
 * `minetest.get_node_def(nodename)`
-	* Returns [node definition](#node-definition) table of `nodename`
+    * Returns [node definition](#node-definition) table of `nodename`
 * `minetest.get_item_def(itemstring)`
-	* Returns item definition table of `itemstring`
+    * Returns item definition table of `itemstring`
 
 #### Node Definition
 
@@ -971,10 +971,10 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
 
 ```lua
 {
-	address = "minetest.example.org", -- The domain name/IP address of a remote server or "" for a local server.
-	ip = "203.0.113.156",             -- The IP address of the server.
-	port = 30000,                     -- The port the client is connected to.
-	protocol_version = 30             -- Will not be accurate at start up as the client might not be connected to the server yet, in that case it will be 0.
+    address = "minetest.example.org", -- The domain name/IP address of a remote server or "" for a local server.
+    ip = "203.0.113.156",             -- The IP address of the server.
+    port = 30000,                     -- The port the client is connected to.
+    protocol_version = 30             -- Will not be accurate at start up as the client might not be connected to the server yet, in that case it will be 0.
 }
 ```
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3658,7 +3658,7 @@ Player Inventory lists
 * `hand`: list containing an override for the empty hand
     * Is not created automatically, use `InvRef:set_size`
     * Is only used to enhance the empty hand's tool capabilities
- 
+
 Custom lists can be added and deleted with `InvRef:set_size(name, size)` like
 any other inventory.
 
@@ -3854,8 +3854,8 @@ vectors are written like this: `(x, y, z)`:
     * Returns a vector where the function `func` has been applied to each
       component.
 * `vector.combine(v, w, func)`:
-	* Returns a vector where the function `func` has combined both components of `v` and `w`
-	  for each component
+    * Returns a vector where the function `func` has combined both components of `v` and `w`
+      for each component
 * `vector.equals(v1, v2)`:
     * Returns a boolean, `true` if the vectors are identical.
 * `vector.sort(v1, v2)`:
@@ -3873,10 +3873,10 @@ vectors are written like this: `(x, y, z)`:
       by a `vector.*` function.
     * Returns `false` for anything else, including tables like `{x=3,y=1,z=4}`.
 * `vector.in_area(pos, min, max)`:
-	* Returns a boolean value indicating if `pos` is inside area formed by `min` and `max`.
-	* `min` and `max` are inclusive.
-	* If `min` is bigger than `max` on some axis, function always returns false.
-	* You can use `vector.sort` if you have two vectors and don't know which are the minimum and the maximum.
+    * Returns a boolean value indicating if `pos` is inside area formed by `min` and `max`.
+    * `min` and `max` are inclusive.
+    * If `min` is bigger than `max` on some axis, function always returns false.
+    * You can use `vector.sort` if you have two vectors and don't know which are the minimum and the maximum.
 
 For the following functions `x` can be either a vector or a number:
 
@@ -5076,12 +5076,12 @@ Callbacks:
       used for updating the entity state.
 * `on_deactivate(self, removal)`
     * Called when the object is about to get removed or unloaded.
-	* `removal`: boolean indicating whether the object is about to get removed.
-	  Calling `object:remove()` on an active object will call this with `removal=true`.
-	  The mapblock the entity resides in being unloaded will call this with `removal=false`.
-	* Note that this won't be called if the object hasn't been activated in the first place.
-	  In particular, `minetest.clear_objects({mode = "full"})` won't call this,
-	  whereas `minetest.clear_objects({mode = "quick"})` might call this.
+    * `removal`: boolean indicating whether the object is about to get removed.
+      Calling `object:remove()` on an active object will call this with `removal=true`.
+      The mapblock the entity resides in being unloaded will call this with `removal=false`.
+    * Note that this won't be called if the object hasn't been activated in the first place.
+      In particular, `minetest.clear_objects({mode = "full"})` won't call this,
+      whereas `minetest.clear_objects({mode = "quick"})` might call this.
 * `on_step(self, dtime, moveresult)`
     * Called on every server tick, after movement and collision processing.
     * `dtime`: elapsed time since last call
@@ -5723,7 +5723,7 @@ Call these functions only at load time!
 
 * `minetest.register_globalstep(function(dtime))`
     * Called every server step, usually interval of 0.1s.
-	* `dtime` is the time since last execution in seconds.
+    * `dtime` is the time since last execution in seconds.
 * `minetest.register_on_mods_loaded(function())`
     * Called after mods have finished loading and before the media is cached or the
       aliases handled.
@@ -6151,7 +6151,7 @@ Environment access
     * **Warning**: The same warning as for `minetest.get_objects_inside_radius` applies.
       Use `minetest.objects_in_area` instead to iterate only valid objects.
 * `minetest.objects_in_area(min_pos, max_pos)`
-	* returns an iterator of valid objects
+    * returns an iterator of valid objects
 * `minetest.set_timeofday(val)`: set time of day
     * `val` is between `0` and `1`; `0` for midnight, `0.5` for midday
 * `minetest.get_timeofday()`: get time of day
@@ -7959,13 +7959,13 @@ child will follow movement and rotation of that bone.
     object.
 * `set_detach()`: Detaches object. No-op if object was not attached.
 * `set_bone_position([bone, position, rotation])`
-	* Shorthand for `set_bone_override(bone, {position = position, rotation = rotation:apply(math.rad)})` using absolute values.
-	* **Note:** Rotation is in degrees, not radians.
-	* **Deprecated:** Use `set_bone_override` instead.
+    * Shorthand for `set_bone_override(bone, {position = position, rotation = rotation:apply(math.rad)})` using absolute values.
+    * **Note:** Rotation is in degrees, not radians.
+    * **Deprecated:** Use `set_bone_override` instead.
 * `get_bone_position(bone)`: returns the previously set position and rotation of the bone
-	* Shorthand for `get_bone_override(bone).position.vec, get_bone_override(bone).rotation.vec:apply(math.deg)`.
-	* **Note:** Returned rotation is in degrees, not radians.
-	* **Deprecated:** Use `get_bone_override` instead.
+    * Shorthand for `get_bone_override(bone).position.vec, get_bone_override(bone).rotation.vec:apply(math.deg)`.
+    * **Note:** Returned rotation is in degrees, not radians.
+    * **Deprecated:** Use `get_bone_override` instead.
 * `set_bone_override(bone, override)`
     * `bone`: string
     * `override`: `{ position = property, rotation = property, scale = property }` or `nil`
@@ -7982,7 +7982,7 @@ child will follow movement and rotation of that bone.
     * Compatibility note: Clients prior to 5.9.0 only support absolute position and rotation.
       All values are treated as absolute and are set immediately (no interpolation).
 * `get_bone_override(bone)`: returns `override` in the above format
-	* **Note:** Unlike `get_bone_position`, the returned rotation is in radians, not degrees.
+    * **Note:** Unlike `get_bone_position`, the returned rotation is in radians, not degrees.
 * `get_bone_overrides()`: returns all bone overrides as table `{[bonename] = override, ...}`
 * `set_properties(object property table)`
 * `get_properties()`: returns a table of all object properties
@@ -8056,8 +8056,8 @@ child will follow movement and rotation of that bone.
         * Fifth column:  subject viewed from above
         * Sixth column:  subject viewed from below
 * `get_luaentity()`:
-	* Returns the object's associated luaentity table, if there is one
-	* Otherwise returns `nil` (e.g. for players)
+    * Returns the object's associated luaentity table, if there is one
+    * Otherwise returns `nil` (e.g. for players)
 * `get_entity_name()`:
     * **Deprecated**: Will be removed in a future version,
       use `:get_luaentity().name` instead.

--- a/doc/world_format.md
+++ b/doc/world_format.md
@@ -394,7 +394,7 @@ Timestamp and node ID mappings were introduced in map format version 29.
 
 * `u8` `name_id_mapping_version`
     * Should be zero for map format version 29.
-  
+
 * `u16` `num_name_id_mappings`
     * foreach `num_name_id_mappings`:
         * `u16` `id`

--- a/irr/README.md
+++ b/irr/README.md
@@ -25,7 +25,7 @@ Aside from standard search options (`ZLIB_INCLUDE_DIR`, `ZLIB_LIBRARY`, ...) the
 * `USE_SDL2` (default: platform-dependent, usually `ON`) - Use SDL2 instead of older native device code
 
 However, IrrlichtMt cannot be built or installed separately.
-	
+
 Platforms
 ---------
 

--- a/lib/gmp/mini-gmp.c
+++ b/lib/gmp/mini-gmp.c
@@ -55,7 +55,7 @@ see https://www.gnu.org/licenses/.  */
 #include <float.h>
 #endif
 
-
+
 /* Macros */
 #define GMP_LIMB_BITS (sizeof(mp_limb_t) * CHAR_BIT)
 
@@ -283,7 +283,7 @@ see https://www.gnu.org/licenses/.  */
 
 const int mp_bits_per_limb = GMP_LIMB_BITS;
 
-
+
 /* Memory allocation and other helper functions. */
 static void
 gmp_die (const char *msg)
@@ -384,7 +384,7 @@ gmp_free_limbs (mp_ptr old, mp_size_t size)
   gmp_free (old, size * sizeof (mp_limb_t));
 }
 
-
+
 /* MPN interface */
 
 void
@@ -777,7 +777,7 @@ mpn_neg (mp_ptr rp, mp_srcptr up, mp_size_t n)
   return 1;
 }
 
-
+
 /* MPN division interface. */
 
 /* The 3/2 inverse is defined as
@@ -1169,7 +1169,7 @@ mpn_div_qr (mp_ptr qp, mp_ptr np, mp_size_t nn, mp_srcptr dp, mp_size_t dn)
     gmp_free_limbs (tp, dn);
 }
 
-
+
 /* MPN base conversion. */
 static unsigned
 mpn_base_power_of_two_p (unsigned b)
@@ -1425,7 +1425,7 @@ mpn_set_str (mp_ptr rp, const unsigned char *sp, size_t sn, int base)
     }
 }
 
-
+
 /* MPZ interface */
 void
 mpz_init (mpz_t r)
@@ -1480,7 +1480,7 @@ mpz_realloc (mpz_t r, mp_size_t size)
 #define MPZ_REALLOC(z,n) ((n) > (z)->_mp_alloc			\
 			  ? mpz_realloc(z,n)			\
 			  : (z)->_mp_d)
-
+
 /* MPZ assignment and basic conversions. */
 void
 mpz_set_si (mpz_t r, signed long int x)
@@ -1704,7 +1704,7 @@ mpz_roinit_n (mpz_t x, mp_srcptr xp, mp_size_t xs)
   return x;
 }
 
-
+
 /* Conversions and comparison to double. */
 void
 mpz_set_d (mpz_t r, double x)
@@ -1862,7 +1862,7 @@ mpz_cmp_d (const mpz_t x, double d)
     }
 }
 
-
+
 /* MPZ comparisons and the like. */
 int
 mpz_sgn (const mpz_t u)
@@ -1950,7 +1950,7 @@ mpz_swap (mpz_t u, mpz_t v)
   MPN_PTR_SWAP (u->_mp_d, u->_mp_size, v->_mp_d, v->_mp_size);
 }
 
-
+
 /* MPZ addition and subtraction */
 
 
@@ -2050,7 +2050,7 @@ mpz_sub (mpz_t r, const mpz_t a, const mpz_t b)
   r->_mp_size = a->_mp_size >= 0 ? rn : - rn;
 }
 
-
+
 /* MPZ multiplication */
 void
 mpz_mul_si (mpz_t r, const mpz_t u, long int v)
@@ -2186,7 +2186,7 @@ mpz_submul (mpz_t r, const mpz_t u, const mpz_t v)
   mpz_clear (t);
 }
 
-
+
 /* MPZ division */
 enum mpz_div_round_mode { GMP_DIV_FLOOR, GMP_DIV_CEIL, GMP_DIV_TRUNC };
 
@@ -2661,7 +2661,7 @@ mpz_divisible_ui_p (const mpz_t n, unsigned long d)
   return mpz_div_qr_ui (NULL, NULL, n, d, GMP_DIV_TRUNC) == 0;
 }
 
-
+
 /* GCD */
 static mp_limb_t
 mpn_gcd_11 (mp_limb_t u, mp_limb_t v)
@@ -3054,7 +3054,7 @@ mpz_invert (mpz_t r, const mpz_t u, const mpz_t m)
   return invertible;
 }
 
-
+
 /* Higher level operations (sqrt, pow and root) */
 
 void
@@ -3334,7 +3334,7 @@ mpn_sqrtrem (mp_ptr sp, mp_ptr rp, mp_srcptr p, mp_size_t n)
   mpz_clear (r);
   return res;
 }
-
+
 /* Combinatorics */
 
 void
@@ -3378,7 +3378,7 @@ mpz_bin_uiui (mpz_t r, unsigned long n, unsigned long k)
   mpz_clear (t);
 }
 
-
+
 /* Primality testing */
 
 /* Computes Kronecker (a/b) with odd b, a!=0 and GCD(a,b) = 1 */
@@ -3646,7 +3646,7 @@ mpz_probab_prime_p (const mpz_t n, int reps)
   return is_prime;
 }
 
-
+
 /* Logical operations and bit manipulation. */
 
 /* Numbers are treated as if represented in two's complement (and
@@ -4183,7 +4183,7 @@ mpz_scan0 (const mpz_t u, mp_bitcnt_t starting_bit)
   return mpn_common_scan (limb, i, up, un, ux);
 }
 
-
+
 /* MPZ base conversion. */
 
 size_t
@@ -4443,7 +4443,7 @@ mpz_out_str (FILE *stream, int base, const mpz_t x)
   return n;
 }
 
-
+
 static int
 gmp_detect_endian (void)
 {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1446,7 +1446,7 @@ void Game::copyServerClientCache()
 {
 	// It would be possible to let the client directly read the media files
 	// from where the server knows they are. But aside from being more complicated
-	// it would also *not* fill the media cache and cause slower joining of 
+	// it would also *not* fill the media cache and cause slower joining of
 	// remote servers.
 	// (Imagine that you launch a game once locally and then connect to a server.)
 

--- a/src/client/mesh.h
+++ b/src/client/mesh.h
@@ -139,5 +139,5 @@ bool checkMeshNormals(scene::IMesh *mesh);
 	Set the MinFilter, MagFilter and AnisotropicFilter properties of a texture
 	layer according to the three relevant boolean values found in the Minetest
 	settings.
-*/ 
+*/
 void setMaterialFilters(video::SMaterialLayer &tex, bool bilinear, bool trilinear, bool anisotropic);

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -140,7 +140,7 @@ void ShadowRenderer::initialize()
 	}
 
 	createShaders();
-	
+
 
 	m_texture_format = m_shadow_map_texture_32bit
 					   ? video::ECOLOR_FORMAT::ECF_R32F

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -542,9 +542,9 @@ int LuaPcgRandom::l_set_state(lua_State *L)
 	u64 state[2];
 	s_state_0 >> std::hex >> state[0];
 	s_state_1 >> std::hex >> state[1];
-	
+
 	o->m_rnd.setState(state);
-	
+
 	return 0;
 }
 

--- a/src/server/activeobjectmgr.cpp
+++ b/src/server/activeobjectmgr.cpp
@@ -91,7 +91,7 @@ bool ActiveObjectMgr::registerObject(std::unique_ptr<ServerActiveObject> obj)
 		return false;
 	}
 
-	auto obj_id = obj->getId(); 
+	auto obj_id = obj->getId();
 	m_active_objects.put(obj_id, std::move(obj));
 
 	auto new_size = m_active_objects.size();

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -52,7 +52,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 
 /*
-	ServerMap	
+	ServerMap
 */
 
 ServerMap::ServerMap(const std::string &savedir, IGameDef *gamedef,


### PR DESCRIPTION
This PR adds a CI workflow to check for trailing whitespaces in the most affected files, and for tabs in the Lua API files. (Other markdown files are not checked.)

I noticed that we repeatedly had problems with whitespaces, so I hope this makes the reviewing of PRs a little bit easier.
The checks are not exhaustive, but most common things should be caught. Other filetypes/checks could be added later if deemed necessary.

(I'm not sure if clang tidy could check for trailing whitespaces, but other files need to be checked too anyway.)

## To do

This PR is Ready for Review.

## How to test
See that trailing whitespaces, and tabs in Lua API files got removed. (They are usually invisible.)

Execute the commands of the workflow on current master, to see how it fails, or check the CI pipeline directly.
``` bash
if git ls-files | grep -E '\.txt$|\.md$|\.[ch]$|\.cpp$|\.hpp$|\.sh$|\.cmake$|\.glsl$' | xargs grep -n '\s$'; then echo -e "\033[0;31mFound trailing whitespace"; (exit 1); else (exit 0); fi
```
``` bash
if grep -n $'\t' doc/lua_api.md doc/client_lua_api.md; then echo -e "\033[0;31mFound tab in markdown file"; (exit 1); else (exit 0); fi
```