### PR TITLE
Reject most commands if sent via an unreliable packet

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1007,6 +1007,13 @@ void Client::ProcessData(NetworkPacket *pkt)
 		return;
 	}
 
+	if (!pkt->getWasReliable() && !toClientCommandTable[command].can_be_unreliable) {
+		infostream << "Client::ProcessData(): Recieved an unreliable packet,"
+			"but we can only process reliable packets for kind of packet: "
+			<< toClientCommandTable[command].name;
+		return;
+	}
+
 	/*
 	 * Those packets are handled before m_server_ser_ver is set, it's normal
 	 * But we must use the new ToClientConnectionState in the future,

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -22,13 +22,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/client.h"
 
 const static ToClientCommandHandler null_command_handler =
-	{"TOCLIENT_NULL", TOCLIENT_STATE_ALL, &Client::handleCommand_Null};
+	{"TOCLIENT_NULL", TOCLIENT_STATE_ALL, &Client::handleCommand_Null, true};
 
 const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 {
 	null_command_handler, // 0x00 (never use this)
 	null_command_handler, // 0x01
-	{ "TOCLIENT_HELLO",                   TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_Hello }, // 0x02
+	{ "TOCLIENT_HELLO",                   TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_Hello, true }, // 0x02
 	{ "TOCLIENT_AUTH_ACCEPT",             TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_AuthAccept }, // 0x03
 	{ "TOCLIENT_ACCEPT_SUDO_MODE",        TOCLIENT_STATE_CONNECTED, &Client::handleCommand_AcceptSudoMode}, // 0x04
 	{ "TOCLIENT_DENY_SUDO_MODE",          TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DenySudoMode}, // 0x05
@@ -36,7 +36,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_handler, // 0x07
 	null_command_handler, // 0x08
 	null_command_handler, // 0x09
-	{ "TOCLIENT_ACCESS_DENIED",           TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_AccessDenied }, // 0x0A
+	{ "TOCLIENT_ACCESS_DENIED",           TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_AccessDenied, true }, // 0x0A
 	null_command_handler, // 0x0B
 	null_command_handler, // 0x0C
 	null_command_handler, // 0x0D
@@ -59,28 +59,28 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_handler,
 	null_command_handler,
 	{ "TOCLIENT_BLOCKDATA",                TOCLIENT_STATE_CONNECTED, &Client::handleCommand_BlockData }, // 0x20
-	{ "TOCLIENT_ADDNODE",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_AddNode }, // 0x21
-	{ "TOCLIENT_REMOVENODE",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_RemoveNode }, // 0x22
+	{ "TOCLIENT_ADDNODE",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_AddNode, true }, // 0x21
+	{ "TOCLIENT_REMOVENODE",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_RemoveNode, true }, // 0x22
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,
 	{ "TOCLIENT_INVENTORY",                TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Inventory }, // 0x27
 	null_command_handler,
-	{ "TOCLIENT_TIME_OF_DAY",              TOCLIENT_STATE_CONNECTED, &Client::handleCommand_TimeOfDay }, // 0x29
+	{ "TOCLIENT_TIME_OF_DAY",              TOCLIENT_STATE_CONNECTED, &Client::handleCommand_TimeOfDay, true }, // 0x29
 	{ "TOCLIENT_CSM_RESTRICTION_FLAGS",    TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CSMRestrictionFlags }, // 0x2A
-	{ "TOCLIENT_PLAYER_SPEED",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_PlayerSpeed }, // 0x2B
+	{ "TOCLIENT_PLAYER_SPEED",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_PlayerSpeed, true }, // 0x2B
 	{ "TOCLIENT_MEDIA_PUSH",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MediaPush }, // 0x2C
 	null_command_handler,
 	null_command_handler,
 	{ "TOCLIENT_CHAT_MESSAGE",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ChatMessage }, // 0x2F
 	null_command_handler, // 0x30
 	{ "TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD", TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ActiveObjectRemoveAdd }, // 0x31
-	{ "TOCLIENT_ACTIVE_OBJECT_MESSAGES",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ActiveObjectMessages }, // 0x32
+	{ "TOCLIENT_ACTIVE_OBJECT_MESSAGES",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ActiveObjectMessages, true }, // 0x32
 	{ "TOCLIENT_HP",                       TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HP }, // 0x33
 	{ "TOCLIENT_MOVE_PLAYER",              TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MovePlayer }, // 0x34
 	{ "TOCLIENT_ACCESS_DENIED_LEGACY",     TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_AccessDenied }, // 0x35
-	{ "TOCLIENT_FOV",                      TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Fov }, // 0x36
+	{ "TOCLIENT_FOV",                      TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Fov, true }, // 0x36
 	{ "TOCLIENT_DEATHSCREEN",              TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeathScreen }, // 0x37
 	{ "TOCLIENT_MEDIA",                    TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Media }, // 0x38
 	null_command_handler,
@@ -89,43 +89,43 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_ANNOUNCE_MEDIA",           TOCLIENT_STATE_CONNECTED, &Client::handleCommand_AnnounceMedia }, // 0x3c
 	{ "TOCLIENT_ITEMDEF",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ItemDef }, // 0x3d
 	null_command_handler,
-	{ "TOCLIENT_PLAY_SOUND",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_PlaySound }, // 0x3f
-	{ "TOCLIENT_STOP_SOUND",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_StopSound }, // 0x40
+	{ "TOCLIENT_PLAY_SOUND",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_PlaySound, true }, // 0x3f
+	{ "TOCLIENT_STOP_SOUND",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_StopSound, true }, // 0x40
 	{ "TOCLIENT_PRIVILEGES",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Privileges }, // 0x41
 	{ "TOCLIENT_INVENTORY_FORMSPEC",       TOCLIENT_STATE_CONNECTED, &Client::handleCommand_InventoryFormSpec }, // 0x42
 	{ "TOCLIENT_DETACHED_INVENTORY",       TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DetachedInventory }, // 0x43
 	{ "TOCLIENT_SHOW_FORMSPEC",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ShowFormSpec }, // 0x44
 	{ "TOCLIENT_MOVEMENT",                 TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Movement }, // 0x45
-	{ "TOCLIENT_SPAWN_PARTICLE",           TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SpawnParticle }, // 0x46
-	{ "TOCLIENT_ADD_PARTICLESPAWNER",      TOCLIENT_STATE_CONNECTED, &Client::handleCommand_AddParticleSpawner }, // 0x47
+	{ "TOCLIENT_SPAWN_PARTICLE",           TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SpawnParticle, true }, // 0x46
+	{ "TOCLIENT_ADD_PARTICLESPAWNER",      TOCLIENT_STATE_CONNECTED, &Client::handleCommand_AddParticleSpawner, true }, // 0x47
 	null_command_handler,
-	{ "TOCLIENT_HUDADD",                   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudAdd }, // 0x49
-	{ "TOCLIENT_HUDRM",                    TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudRemove }, // 0x4a
-	{ "TOCLIENT_HUDCHANGE",                TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudChange }, // 0x4b
-	{ "TOCLIENT_HUD_SET_FLAGS",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetFlags }, // 0x4c
-	{ "TOCLIENT_HUD_SET_PARAM",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetParam }, // 0x4d
+	{ "TOCLIENT_HUDADD",                   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudAdd, true }, // 0x49
+	{ "TOCLIENT_HUDRM",                    TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudRemove, true }, // 0x4a
+	{ "TOCLIENT_HUDCHANGE",                TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudChange, true }, // 0x4b
+	{ "TOCLIENT_HUD_SET_FLAGS",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetFlags, true }, // 0x4c
+	{ "TOCLIENT_HUD_SET_PARAM",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetParam, true }, // 0x4d
 	{ "TOCLIENT_BREATH",                   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Breath }, // 0x4e
-	{ "TOCLIENT_SET_SKY",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetSky }, // 0x4f
-	{ "TOCLIENT_OVERRIDE_DAY_NIGHT_RATIO", TOCLIENT_STATE_CONNECTED, &Client::handleCommand_OverrideDayNightRatio }, // 0x50
-	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_LocalPlayerAnimations }, // 0x51
-	{ "TOCLIENT_EYE_OFFSET",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_EyeOffset }, // 0x52
-	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeleteParticleSpawner }, // 0x53
-	{ "TOCLIENT_CLOUD_PARAMS",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CloudParams }, // 0x54
-	{ "TOCLIENT_FADE_SOUND",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FadeSound }, // 0x55
+	{ "TOCLIENT_SET_SKY",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetSky, true }, // 0x4f
+	{ "TOCLIENT_OVERRIDE_DAY_NIGHT_RATIO", TOCLIENT_STATE_CONNECTED, &Client::handleCommand_OverrideDayNightRatio, true }, // 0x50
+	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_LocalPlayerAnimations, true }, // 0x51
+	{ "TOCLIENT_EYE_OFFSET",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_EyeOffset, true }, // 0x52
+	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeleteParticleSpawner, true }, // 0x53
+	{ "TOCLIENT_CLOUD_PARAMS",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CloudParams, true }, // 0x54
+	{ "TOCLIENT_FADE_SOUND",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FadeSound, true }, // 0x55
 	{ "TOCLIENT_UPDATE_PLAYER_LIST",       TOCLIENT_STATE_CONNECTED, &Client::handleCommand_UpdatePlayerList }, // 0x56
 	{ "TOCLIENT_MODCHANNEL_MSG",           TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ModChannelMsg }, // 0x57
 	{ "TOCLIENT_MODCHANNEL_SIGNAL",        TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ModChannelSignal }, // 0x58
 	{ "TOCLIENT_NODEMETA_CHANGED",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_NodemetaChanged }, // 0x59
-	{ "TOCLIENT_SET_SUN",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetSun }, // 0x5a
-	{ "TOCLIENT_SET_MOON",                 TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetMoon }, // 0x5b
-	{ "TOCLIENT_SET_STARS",                TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetStars }, // 0x5c
-	{ "TOCLIENT_MOVE_PLAYER_REL",          TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MovePlayerRel }, // 0x5d,
+	{ "TOCLIENT_SET_SUN",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetSun, true }, // 0x5a
+	{ "TOCLIENT_SET_MOON",                 TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetMoon, true }, // 0x5b
+	{ "TOCLIENT_SET_STARS",                TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetStars, true }, // 0x5c
+	{ "TOCLIENT_MOVE_PLAYER_REL",          TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MovePlayerRel, true }, // 0x5d,
 	null_command_handler,
 	null_command_handler,
 	{ "TOCLIENT_SRP_BYTES_S_B",            TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_SrpBytesSandB }, // 0x60
 	{ "TOCLIENT_FORMSPEC_PREPEND",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FormspecPrepend }, // 0x61,
-	{ "TOCLIENT_MINIMAP_MODES",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MinimapModes }, // 0x62,
-	{ "TOCLIENT_SET_LIGHTING",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SetLighting }, // 0x63,
+	{ "TOCLIENT_MINIMAP_MODES",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MinimapModes, true }, // 0x62,
+	{ "TOCLIENT_SET_LIGHTING",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SetLighting, true }, // 0x63,
 };
 
 const static ServerCommandFactory null_command_factory = { nullptr, 0, false };

--- a/src/network/clientopcodes.h
+++ b/src/network/clientopcodes.h
@@ -37,6 +37,7 @@ struct ToClientCommandHandler
 	const char* name;
 	ToClientConnectionState state;
 	void (Client::*handler)(NetworkPacket* pkt);
+	bool can_be_unreliable;
 };
 
 struct ServerCommandFactory

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -209,6 +209,8 @@ void Client::handleCommand_AccessDenied(NetworkPacket* pkt)
 	if (pkt->getCommand() != TOCLIENT_ACCESS_DENIED) {
 		// Legacy code from 0.4.12 and older but is still used
 		// in some places of the server code
+		// ^^^ that comment was highly optimistic,
+		// the server finally stopped using it in 2022 see commit a65f6f07f3a5601207b790edcc8cc945133112f7
 		if (pkt->getSize() >= 2) {
 			std::wstring wide_reason;
 			*pkt >> wide_reason;
@@ -1596,6 +1598,11 @@ void Client::handleCommand_SrpBytesSandB(NetworkPacket* pkt)
 
 	if ( !bytes_M ) {
 		errorstream << "Client: SRP-6a S_B safety check violation!" << std::endl;
+
+		m_access_denied = true;
+		m_access_denied_reason = gettext("Internal safety check was trigged during login, unable to continue!");
+		m_con->Disconnect();
+
 		return;
 	}
 

--- a/src/network/mtp/impl.cpp
+++ b/src/network/mtp/impl.cpp
@@ -1230,10 +1230,11 @@ ConnectionEventPtr ConnectionEvent::create(ConnectionEventType type)
 	return std::shared_ptr<ConnectionEvent>(new ConnectionEvent(type));
 }
 
-ConnectionEventPtr ConnectionEvent::dataReceived(session_t peer_id, const Buffer<u8> &data)
+ConnectionEventPtr ConnectionEvent::dataReceived(session_t peer_id, const Buffer<u8> &data, bool reliable)
 {
 	auto e = create(CONNEVENT_DATA_RECEIVED);
 	e->peer_id = peer_id;
+	e->reliable = reliable;
 	data.copyTo(e->data);
 	return e;
 }
@@ -1464,7 +1465,7 @@ bool Connection::ReceiveTimeoutMs(NetworkPacket *pkt, u32 timeout_ms)
 				continue;
 			}
 
-			pkt->putRawPacket(*e.data, e.data.getSize(), e.peer_id);
+			pkt->putRawPacket(*e.data, e.data.getSize(), e.peer_id, e.reliable);
 			return true;
 		case CONNEVENT_PEER_ADDED: {
 			UDPPeer tmp(e.peer_id, e.address, this);

--- a/src/network/mtp/impl.h
+++ b/src/network/mtp/impl.h
@@ -80,13 +80,14 @@ struct ConnectionEvent
 	session_t peer_id = 0;
 	Buffer<u8> data;
 	bool timeout = false;
+	bool reliable = false;
 	Address address;
 
 	// We don't want to copy "data"
 	DISABLE_CLASS_COPY(ConnectionEvent);
 
 	static ConnectionEventPtr create(ConnectionEventType type);
-	static ConnectionEventPtr dataReceived(session_t peer_id, const Buffer<u8> &data);
+	static ConnectionEventPtr dataReceived(session_t peer_id, const Buffer<u8> &data, bool reliable);
 	static ConnectionEventPtr peerAdded(session_t peer_id, Address address);
 	static ConnectionEventPtr peerRemoved(session_t peer_id, bool is_timeout, Address address);
 	static ConnectionEventPtr bindFailed();

--- a/src/network/mtp/threads.h
+++ b/src/network/mtp/threads.h
@@ -144,7 +144,7 @@ private:
 	*/
 	SharedBuffer<u8> processPacket(Channel *channel,
 			const SharedBuffer<u8> &packetdata, session_t peer_id,
-			u8 channelnum, bool reliable);
+			u8 channelnum, bool reliable, bool *was_reliable = nullptr);
 
 	SharedBuffer<u8> handlePacketType_Control(Channel *channel,
 			const SharedBuffer<u8> &packetdata, Peer *peer, u8 channelnum,

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -33,7 +33,7 @@ void NetworkPacket::checkReadOffset(u32 from_offset, u32 field_size) const
 	}
 }
 
-void NetworkPacket::putRawPacket(const u8 *data, u32 datasize, session_t peer_id)
+void NetworkPacket::putRawPacket(const u8 *data, u32 datasize, session_t peer_id, bool reliable)
 {
 	// If a m_command is already set, we are rewriting on same packet
 	// This is not permitted
@@ -42,6 +42,7 @@ void NetworkPacket::putRawPacket(const u8 *data, u32 datasize, session_t peer_id
 	assert(datasize >= 2);
 	m_datasize = datasize - 2;
 	m_peer_id = peer_id;
+	m_was_reliable = reliable;
 
 	m_data.resize(m_datasize);
 

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -40,7 +40,7 @@ public:
 
 	~NetworkPacket() = default;
 
-	void putRawPacket(const u8 *data, u32 datasize, session_t peer_id);
+	void putRawPacket(const u8 *data, u32 datasize, session_t peer_id, bool reliable);
 	void clear();
 
 	// Getters
@@ -49,6 +49,9 @@ public:
 	u16 getCommand() const { return m_command; }
 	u32 getRemainingBytes() const { return m_datasize - m_read_offset; }
 	const char *getRemainingString() { return getString(m_read_offset); }
+
+	// getters only valid for recieved packets
+	bool getWasReliable() const { return m_was_reliable; }
 
 	// Returns a c-string without copying.
 	// A better name for this would be getRawString()
@@ -140,4 +143,7 @@ private:
 	u32 m_read_offset = 0;
 	u16 m_command = 0;
 	session_t m_peer_id = 0;
+
+	// recieved packet
+	bool m_was_reliable = false;
 };

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -22,13 +22,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server.h"
 
 const static ToServerCommandHandler null_command_handler =
-	{ "TOSERVER_NULL", TOSERVER_STATE_ALL, &Server::handleCommand_Null };
+	{ "TOSERVER_NULL", TOSERVER_STATE_ALL, &Server::handleCommand_Null, true };
 
 const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 {
 	null_command_handler, // 0x00 (never use this)
 	null_command_handler, // 0x01
-	{ "TOSERVER_INIT",                     TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_Init }, // 0x02
+	{ "TOSERVER_INIT",                     TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_Init, true }, // 0x02
 	null_command_handler, // 0x03
 	null_command_handler, // 0x04
 	null_command_handler, // 0x05
@@ -61,9 +61,9 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_handler, // 0x20
 	null_command_handler, // 0x21
 	null_command_handler, // 0x22
-	{ "TOSERVER_PLAYERPOS",                TOSERVER_STATE_INGAME, &Server::handleCommand_PlayerPos }, // 0x23
-	{ "TOSERVER_GOTBLOCKS",                TOSERVER_STATE_STARTUP, &Server::handleCommand_GotBlocks }, // 0x24
-	{ "TOSERVER_DELETEDBLOCKS",            TOSERVER_STATE_INGAME, &Server::handleCommand_DeletedBlocks }, // 0x25
+	{ "TOSERVER_PLAYERPOS",                TOSERVER_STATE_INGAME, &Server::handleCommand_PlayerPos, true }, // 0x23
+	{ "TOSERVER_GOTBLOCKS",                TOSERVER_STATE_STARTUP, &Server::handleCommand_GotBlocks, true }, // 0x24
+	{ "TOSERVER_DELETEDBLOCKS",            TOSERVER_STATE_INGAME, &Server::handleCommand_DeletedBlocks, true }, // 0x25
 	null_command_handler, // 0x26
 	null_command_handler, // 0x27
 	null_command_handler, // 0x28
@@ -83,8 +83,8 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_handler, // 0x36
 	{ "TOSERVER_PLAYERITEM",               TOSERVER_STATE_INGAME, &Server::handleCommand_PlayerItem }, // 0x37
 	{ "TOSERVER_RESPAWN",                  TOSERVER_STATE_INGAME, &Server::handleCommand_Respawn }, // 0x38
-	{ "TOSERVER_INTERACT",                 TOSERVER_STATE_INGAME, &Server::handleCommand_Interact }, // 0x39
-	{ "TOSERVER_REMOVED_SOUNDS",           TOSERVER_STATE_INGAME, &Server::handleCommand_RemovedSounds }, // 0x3a
+	{ "TOSERVER_INTERACT",                 TOSERVER_STATE_INGAME, &Server::handleCommand_Interact, true }, // 0x39
+	{ "TOSERVER_REMOVED_SOUNDS",           TOSERVER_STATE_INGAME, &Server::handleCommand_RemovedSounds, true }, // 0x3a
 	{ "TOSERVER_NODEMETA_FIELDS",          TOSERVER_STATE_INGAME, &Server::handleCommand_NodeMetaFields }, // 0x3b
 	{ "TOSERVER_INVENTORY_FIELDS",         TOSERVER_STATE_INGAME, &Server::handleCommand_InventoryFields }, // 0x3c
 	null_command_handler, // 0x3d

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -36,6 +36,7 @@ struct ToServerCommandHandler
 	const char *name;
 	ToServerConnectionState state;
 	void (Server::*handler)(NetworkPacket* pkt);
+	bool can_be_unreliable;
 };
 
 struct ClientCommandFactory

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1197,6 +1197,19 @@ void Server::ProcessData(NetworkPacket *pkt)
 			return;
 		}
 
+		if (!pkt->getWasReliable() && !toServerCommandTable[command].can_be_unreliable)
+		{
+			RemotePlayer* player = m_env->getPlayer(peer_id);
+			if (player)
+				actionstream << "Recieved unreliable packet from '" << player->getName() << "'";
+			else
+				actionstream << "Recieved unreliable packet from peer_id=" << peer_id;
+			actionstream << " for command type: '" << toServerCommandTable[command].name
+				<< "', but only a reliable packet would have been valid. "
+				"Possible blind packet injection attempt." << std::endl;
+			return;
+		}
+
 		if (toServerCommandTable[command].state == TOSERVER_STATE_NOT_CONNECTED) {
 			handleCommand(pkt);
 			return;

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -104,7 +104,7 @@ void TestConnection::testNetworkPacketSerialize()
 
 	{
 		NetworkPacket pkt;
-		pkt.putRawPacket(expected, sizeof(expected), 0);
+		pkt.putRawPacket(expected, sizeof(expected), 0, false);
 
 		// same for decoding
 		std::wstring pkt_s;


### PR DESCRIPTION
Almost all Minetest network packets are sent as reliable with the exception of the player location update. It seems *some* of these could also make sense as unreliable packets (and perhaps there should be a way to send them as such) but most only make sense if sent by reliable transport.

This commit was originally developed for the network encryption PR but it also stops blind injection attacks even without encryption.

Closes #14988

## How to test

Modify your client to send chat messages as unreliable packets and observe a server built with this PR will reject them, while a standard sever will (probably, it's an unreliable packet after all) handle them as a normal chat message.
