### PR TITLE
Remove SAO::onAttach() and SAO::onDetach()

### DIFF
--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -259,9 +259,6 @@ protected:
 	virtual void onMarkedForDeactivation() {}
 	virtual void onMarkedForRemoval() {}
 
-	virtual void onAttach(object_t parent_id) {}
-	virtual void onDetach(object_t parent_id) {}
-
 	ServerEnvironment *m_env;
 	v3f m_base_position;
 	std::unordered_set<u32> m_attached_particle_spawners;


### PR DESCRIPTION
Recently the attachment code was refactored by @sfan5. That changed the signature of UnitSAO::onDetach and onAttach, which cause a compiler warning, but no other issues, because SAO::onDetach was not changed.
I could have matched the signature in SAO, but since it caused no other problems and warnings, the methods can just as well be removed from SAO.

Add compact, short information about your PR for easier understanding:

- Goal of the PR
Fix compiler warnings:
```
In file included from /home/lars/dev/minetest/minetest/src/server/unit_sao.h:24,
from /home/lars/dev/minetest/minetest/src/server/player_sao.h:26,
from /home/lars/dev/minetest/minetest/src/database/database-files.cpp:26:
/home/lars/dev/minetest/minetest/src/server/serveractiveobject.h:263:22: warning: ‘virtual void ServerActiveObject::onDetach(ActiveObject::object_t)’ was hidden [-Woverloaded-virtual=]
263 |         virtual void onDetach(object_t parent_id) {}
|                      ^~~~~~~~
/home/lars/dev/minetest/minetest/src/server/unit_sao.h:139:14: note:   by ‘void UnitSAO::onDetach(ServerActiveObject*)’
139 |         void onDetach(ServerActiveObject *parent);
|              ^~~~~~~~
```

- How does the PR work?
Observe that onAttach and onDetach is only ever used in UnitSAO

- Does it resolve any reported issue?
no

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
no

- If not a bug fix, why is this PR needed? What usecases does it solve?
Code cleanliness

## To do

This PR Ready for Review.

## How to test

Compile and notice no warnings.
