### PR TITLE
LocalPlayer: Restore 2u height sneak jump

### DIFF
--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -360,7 +360,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 
 	collisionMoveResult result = collisionMoveSimple(env, m_client,
 		pos_max_d, m_collisionbox, player_stepheight, dtime,
-		&position, &m_speed, accel_f);
+		&position, &m_speed, accel_f, m_cao);
 
 	bool could_sneak = control.sneak && !free_move && !in_liquid &&
 		!is_climbing && physics_override.sneak;
@@ -990,7 +990,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 
 	collisionMoveResult result = collisionMoveSimple(env, m_client,
 		pos_max_d, m_collisionbox, player_stepheight, dtime,
-		&position, &m_speed, accel_f);
+		&position, &m_speed, accel_f, m_cao);
 
 	// Position was slightly changed; update standing node pos
 	if (touching_ground)
@@ -1254,7 +1254,7 @@ void LocalPlayer::handleAutojump(f32 dtime, Environment *env,
 
 	// try at peak of jump, zero step height
 	collisionMoveResult jump_result = collisionMoveSimple(env, m_client, pos_max_d,
-		m_collisionbox, 0.0f, dtime, &jump_pos, &jump_speed, v3f(0.0f));
+		m_collisionbox, 0.0f, dtime, &jump_pos, &jump_speed, v3f(0.0f), m_cao);
 
 	// see if we can get a little bit farther horizontally if we had
 	// jumped

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -444,7 +444,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 			v3f check_pos = position;
 			check_pos.Y += y_diff * dtime * 22.0f + BS * 0.01f;
 			if (y_diff < BS * 0.6f || (physics_override.sneak_glitch
-					&& !collision_check_intersection(env, m_client, m_collisionbox, check_pos))) {
+					&& !collision_check_intersection(env, m_client, m_collisionbox, check_pos, m_cao))) {
 				// Smoothen the movement (based on 'position.Y = bmax.Y')
 				position.Y = std::min(check_pos.Y, bmax.Y);
 				m_speed.Y = 0.0f;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -302,7 +302,7 @@ static void add_object_boxes(Environment *env,
 		// add collision with local player
 		LocalPlayer *lplayer = c_env->getLocalPlayer();
 		auto *obj = (ClientActiveObject*) lplayer->getCAO();
-		if (self != obj && self != obj->getParent()) {
+		if (!self || (self != obj && self != obj->getParent())) {
 			aabb3f lplayer_collisionbox = lplayer->getCollisionbox();
 			v3f lplayer_pos = lplayer->getPosition();
 			lplayer_collisionbox.MinEdge += lplayer_pos;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -292,7 +292,7 @@ static void add_object_boxes(Environment *env,
 		c_env->getActiveObjects(pos_f, distance, clientobjects);
 
 		for (auto &clientobject : clientobjects) {
-			// Do collide with everything but itself and the parent CAO
+			// Do collide with everything but itself and children
 			if (!self || (self != clientobject.obj &&
 					self != clientobject.obj->getParent())) {
 				process_object(clientobject.obj);
@@ -301,8 +301,8 @@ static void add_object_boxes(Environment *env,
 
 		// add collision with local player
 		LocalPlayer *lplayer = c_env->getLocalPlayer();
-		auto *obj = (ActiveObject*) lplayer->getCAO();
-		if (self != obj && !lplayer->getParent()) {
+		auto *obj = (ClientActiveObject*) lplayer->getCAO();
+		if (self != obj && self != obj->getParent()) {
 			aabb3f lplayer_collisionbox = lplayer->getCollisionbox();
 			v3f lplayer_pos = lplayer->getPosition();
 			lplayer_collisionbox.MinEdge += lplayer_pos;
@@ -315,7 +315,7 @@ static void add_object_boxes(Environment *env,
 	{
 		ServerEnvironment *s_env = dynamic_cast<ServerEnvironment*>(env);
 		if (s_env) {
-			// search for objects which are not us, or we are not its parent.
+			// search for objects which are not us and not our children.
 			// we directly process the object in this callback to avoid useless
 			// looping afterwards.
 			auto include_obj_cb = [self, &process_object] (ServerActiveObject *obj) {

--- a/src/collision.h
+++ b/src/collision.h
@@ -73,7 +73,9 @@ collisionMoveResult collisionMoveSimple(Environment *env,IGameDef *gamedef,
 		v3f accel_f, ActiveObject *self=NULL,
 		bool collide_with_objects=true);
 
-// check if box is in collision on actual position
+/// @param self (optional) ActiveObject to ignore in the calculation.
+/// @returns `true` when `box_0` truely intersects with a node or object.
+///          Touching faces are not counted as intersection.
 bool collision_check_intersection(Environment *env, IGameDef *gamedef,
 		const aabb3f &box_0, const v3f &pos_f, ActiveObject *self = nullptr,
 		bool collide_with_objects = true);

--- a/src/collision.h
+++ b/src/collision.h
@@ -65,7 +65,8 @@ struct collisionMoveResult
 	std::vector<CollisionInfo> collisions;
 };
 
-// Moves using a single iteration; speed should not exceed pos_max_d/dtime
+/// @brief Moves using a single iteration; speed should not exceed pos_max_d/dtime
+/// @param self (optional) ActiveObject to ignore in the collision detection.
 collisionMoveResult collisionMoveSimple(Environment *env,IGameDef *gamedef,
 		f32 pos_max_d, const aabb3f &box_0,
 		f32 stepheight, f32 dtime,
@@ -73,8 +74,10 @@ collisionMoveResult collisionMoveSimple(Environment *env,IGameDef *gamedef,
 		v3f accel_f, ActiveObject *self=NULL,
 		bool collide_with_objects=true);
 
-/// @param self (optional) ActiveObject to ignore in the calculation.
-/// @returns `true` when `box_0` truely intersects with a node or object.
+/// @brief A simpler version of "collisionMoveSimple" that only checks whether
+///        a collision occurs at the given position.
+/// @param self (optional) ActiveObject to ignore in the collision detection.
+/// @returns `true` when `box_0` truly intersects with a node or object.
 ///          Touching faces are not counted as intersection.
 bool collision_check_intersection(Environment *env, IGameDef *gamedef,
 		const aabb3f &box_0, const v3f &pos_f, ActiveObject *self = nullptr,


### PR DESCRIPTION
Fix 1: Do not consider LocalPlayer's CAO in the collision data.
Fix 2: work around the "aabbox3d::intersectsWithBox" edge-case.

Fixes #15008, caused by #14332

## To do

This PR is Ready for Review.

## How to test

1. https://content.minetest.net/packages/Krock/sneak_glitch/
2. Build a 2 node pillar
3. Hold jump, then hold sneak
4. Node pillar must be climbable
5. Ensure that the ceiling is still detected when using the sneak ladder. See https://github.com/minetest/minetest/pull/14332#issue-2110951340 for a demo.