### PR TITLE
Fix animations not being restartable

### DIFF
--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -55,10 +55,6 @@ const ItemGroupList &UnitSAO::getArmorGroups() const
 void UnitSAO::setAnimation(
 		v2f frame_range, float frame_speed, float frame_blend, bool frame_loop)
 {
-	if (std::tie(m_animation_range, m_animation_speed, m_animation_blend,
-			m_animation_loop) ==
-			std::tie(frame_range, frame_speed, frame_blend, frame_loop))
-		return; // no change
 	m_animation_range = frame_range;
 	m_animation_speed = frame_speed;
 	m_animation_blend = frame_blend;


### PR DESCRIPTION
Fixes a regression introduced by #14419.

We must always resend the animation, because this is how you restart the same animation with the same parameters. (See e.g. the code in https://github.com/minetest/minetest/issues/14122#issuecomment-1859924004. This does *not* mean that this PR fixes that issue at well, but it fixes the ability to restart animations at all, which masks the issue reported there.)

## How to test

Restart an animation, looped or not, after it has ended or not. It should work.

Also check `AO_CMD_SET_ANIMATION` handling in `GenericCAO::processMessage` to convince yourself that the client should actually restart the animation (modulo weird local player animation code).
