### PR TITLE
[no sq] TouchScreenGUI: Grid menu improvement + fix

### DIFF
--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -66,7 +66,7 @@ local inv_style_fs = [[
 
 -- Some textures from textures/base/pack and Devtest, with many different sizes
 -- and aspect ratios.
-local image_column = "image,0=logo.png,1=rare_controls.png,2=checkbox_16.png," ..
+local image_column = "image,0=logo.png,1=crack_anylength.png^[invert:rgb,2=checkbox_16.png," ..
 		"3=checkbox_32.png,4=checkbox_64.png,5=default_lava.png," ..
 		"6=progress_bar.png,7=progress_bar_bg.png"
 local words = {

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gui/mainmenumanager.h"
 #include "gui/guiChatConsole.h"
 #include "gui/guiFormSpecMenu.h"
+#include "gui/touchcontrols.h"
 #include "util/enriched_string.h"
 #include "util/pointedthing.h"
 #include "client.h"
@@ -191,16 +192,27 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 		}
 	}
 
-	setStaticText(m_guitext_status, m_statustext.c_str());
-	m_guitext_status->setVisible(!m_statustext.empty());
+	IGUIStaticText *guitext_status;
+	bool overriden = g_touchcontrols && g_touchcontrols->isStatusTextOverriden();
+	if (overriden) {
+		guitext_status = g_touchcontrols->getStatusText();
+		m_guitext_status->setVisible(false);
+	} else {
+		guitext_status = m_guitext_status;
+		if (g_touchcontrols)
+			g_touchcontrols->getStatusText()->setVisible(false);
+	}
+
+	setStaticText(guitext_status, m_statustext.c_str());
+	guitext_status->setVisible(!m_statustext.empty());
 
 	if (!m_statustext.empty()) {
-		s32 status_width  = m_guitext_status->getTextWidth();
-		s32 status_height = m_guitext_status->getTextHeight();
-		s32 status_y = screensize.Y - 150;
+		s32 status_width  = guitext_status->getTextWidth();
+		s32 status_height = guitext_status->getTextHeight();
+		s32 status_y = screensize.Y  - (overriden ? 15 : 150);
 		s32 status_x = (screensize.X - status_width) / 2;
 
-		m_guitext_status->setRelativePosition(core::rect<s32>(status_x ,
+		guitext_status->setRelativePosition(core::rect<s32>(status_x ,
 			status_y - status_height, status_x + status_width, status_y));
 
 		// Fade out
@@ -208,8 +220,8 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 		final_color.setAlpha(0);
 		video::SColor fade_color = m_statustext_initial_color.getInterpolated_quadratic(
 			m_statustext_initial_color, final_color, m_statustext_time / statustext_time_max);
-		m_guitext_status->setOverrideColor(fade_color);
-		m_guitext_status->enableOverrideColor(true);
+		guitext_status->setOverrideColor(fade_color);
+		guitext_status->enableOverrideColor(true);
 	}
 
 	// Hide chat when disabled by server or when console is visible

--- a/src/gui/touchcontrols.cpp
+++ b/src/gui/touchcontrols.cpp
@@ -477,14 +477,11 @@ void TouchControls::handleReleaseEvent(size_t pointer_id)
 	m_pointer_downpos.erase(pointer_id);
 	m_pointer_pos.erase(pointer_id);
 
-	if (m_overflow_open) {
-		buttons_handleRelease(m_overflow_buttons, pointer_id, m_device->getVideoDriver(),
-				m_receiver, m_texturesource);
-		return;
-	}
-
 	// handle buttons
 	if (buttons_handleRelease(m_buttons, pointer_id, m_device->getVideoDriver(),
+			m_receiver, m_texturesource))
+		return;
+	if (buttons_handleRelease(m_overflow_buttons, pointer_id, m_device->getVideoDriver(),
 			m_receiver, m_texturesource))
 		return;
 
@@ -513,9 +510,7 @@ void TouchControls::handleReleaseEvent(size_t pointer_id)
 		m_joystick_status_aux1 = false;
 		applyJoystickStatus();
 
-		m_joystick_btn_off->setVisible(true);
-		m_joystick_btn_bg->setVisible(false);
-		m_joystick_btn_center->setVisible(false);
+		updateVisibility();
 	} else {
 		infostream << "TouchControls::translateEvent released unknown button: "
 				<< pointer_id << std::endl;
@@ -572,9 +567,6 @@ void TouchControls::translateEvent(const SEvent &event)
 			toggleOverflowMenu();
 			// refresh since visibility of buttons has changed
 		 	element = m_guienv->getRootGUIElement()->getElementFromPoint(touch_pos);
-			// restore after releaseAll in toggleOverflowMenu
-			m_pointer_downpos[pointer_id] = touch_pos;
-			m_pointer_pos[pointer_id] = touch_pos;
 			// continue processing, but avoid accidentally placing a node
 			// when closing the overflow menu
 			prevent_short_tap = true;
@@ -600,9 +592,7 @@ void TouchControls::translateEvent(const SEvent &event)
 				m_joystick_id               = pointer_id;
 				m_joystick_has_really_moved = false;
 
-				m_joystick_btn_off->setVisible(false);
-				m_joystick_btn_bg->setVisible(true);
-				m_joystick_btn_center->setVisible(true);
+				updateVisibility();
 
 				// If it's a fixed joystick, don't move the joystick "button".
 				if (!m_fixed_joystick)
@@ -632,9 +622,6 @@ void TouchControls::translateEvent(const SEvent &event)
 		handleReleaseEvent(event.TouchInput.ID);
 	} else {
 		assert(event.TouchInput.Event == ETIE_MOVED);
-
-		if (m_overflow_open)
-			return;
 
 		if (!(m_has_joystick_id && m_fixed_joystick) &&
 				m_pointer_pos[event.TouchInput.ID] == touch_pos)
@@ -721,13 +708,9 @@ void TouchControls::applyJoystickStatus()
 
 void TouchControls::step(float dtime)
 {
-	if (m_overflow_open) {
-		buttons_step(m_overflow_buttons, dtime, m_device->getVideoDriver(), m_receiver, m_texturesource);
-		return;
-	}
-
 	// simulate keyboard repeats
 	buttons_step(m_buttons, dtime, m_device->getVideoDriver(), m_receiver, m_texturesource);
+	buttons_step(m_overflow_buttons, dtime, m_device->getVideoDriver(), m_receiver, m_texturesource);
 
 	// joystick
 	applyJoystickStatus();
@@ -774,7 +757,6 @@ void TouchControls::setVisible(bool visible)
 		return;
 
 	m_visible = visible;
-	// order matters
 	if (!visible) {
 		releaseAll();
 		m_overflow_open = false;
@@ -784,7 +766,8 @@ void TouchControls::setVisible(bool visible)
 
 void TouchControls::toggleOverflowMenu()
 {
-	releaseAll(); // must be done first
+	// no releaseAll here so that you can e.g. continue holding the joystick
+	// while the overflow menu is open
 	m_overflow_open = !m_overflow_open;
 	updateVisibility();
 }
@@ -795,7 +778,10 @@ void TouchControls::updateVisibility()
 	for (auto &button : m_buttons)
 		button.gui_button->setVisible(regular_visible);
 	m_overflow_btn->setVisible(regular_visible);
-	m_joystick_btn_off->setVisible(regular_visible);
+
+	m_joystick_btn_off->setVisible(regular_visible && !m_has_joystick_id);
+	m_joystick_btn_bg->setVisible(regular_visible && m_has_joystick_id);
+	m_joystick_btn_center->setVisible(regular_visible && m_has_joystick_id);
 
 	bool overflow_visible = m_visible && m_overflow_open;
 	m_overflow_bg->setVisible(overflow_visible);

--- a/src/gui/touchcontrols.cpp
+++ b/src/gui/touchcontrols.cpp
@@ -412,6 +412,10 @@ TouchControls::TouchControls(IrrlichtDevice *device, ISimpleTextureSource *tsrc)
 
 		pos.X += spacing.X;
 	}
+
+	m_status_text = grab_gui_element<IGUIStaticText>(
+			m_guienv->addStaticText(L"", recti(), false, false));
+	m_status_text->setVisible(false);
 }
 
 void TouchControls::addButton(std::vector<button_info> &buttons, touch_gui_button_id id,

--- a/src/gui/touchcontrols.h
+++ b/src/gui/touchcontrols.h
@@ -177,6 +177,9 @@ public:
 	void registerHotbarRect(u16 index, const recti &rect);
 	std::optional<u16> getHotbarSelection();
 
+	bool isStatusTextOverriden() { return m_overflow_open; }
+	IGUIStaticText *getStatusText() { return m_status_text.get(); }
+
 private:
 	IrrlichtDevice *m_device = nullptr;
 	IGUIEnvironment *m_guienv = nullptr;
@@ -234,6 +237,8 @@ private:
 	std::vector<button_info> m_overflow_buttons;
 	std::vector<std::shared_ptr<IGUIStaticText>> m_overflow_button_titles;
 	std::vector<recti> m_overflow_button_rects;
+
+	std::shared_ptr<IGUIStaticText> m_status_text;
 
 	void toggleOverflowMenu();
 	void updateVisibility();


### PR DESCRIPTION
Commit 1: Fixes a bug reported in https://github.com/minetest/minetest/commit/013c6ee1663f2bdd93a6d30690a96a5914dc27dc#commitcomment-145293699:

> `/test_formspec` relies on `rare_controls.png`.

Commit 2: Implements a suggested improvement from https://github.com/minetest/minetest/pull/14918#issuecomment-2274555464:

> Still able to control the joystick if it has been pressed before opening the grid menu

Commit 3: Implements another suggestion from https://github.com/minetest/minetest/pull/14918#issuecomment-2274555464:

> Show the status text above the grid menu

## To do

This PR is a Ready for Review.

## How to test

Commit 1: Do `/test_formspec` in Devtest, verify that there are no missing textures.

Commit 2: Play Minetest on Android. Hold a button or the joystick, open the grid menu without releasing it and see it still works. (This also works the other way around, i.e. with buttons from the grid menu.)

Commit 3: Trigger some status messages via the grid menu, see that they show above the grid menu.