### PR TITLE
Fix `If player receives a formspec while in the death screen, the death screen disappears, breaking the game`

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1218,7 +1218,7 @@ void Game::run()
 			dtime = 0.0f;
 
 		step(dtime);
-
+//fork
 		processClientEvents(&cam_view_target);
 		updateDebugState();
 		updateCamera(dtime);
@@ -2902,6 +2902,8 @@ void Game::handleClientEvent_ShowFormSpec(ClientEvent *event, CameraOrientation 
 		if (formspec && (event->show_formspec.formname->empty()
 				|| *(event->show_formspec.formname) == m_game_ui->getFormspecName())) {
 			formspec->quitMenu();
+			if (client->getHP()<=0)
+				showDeathFormspec();
 		}
 	} else {
 		FormspecFormSource *fs_src =
@@ -4425,7 +4427,7 @@ void Game::readSettings()
  Shutdown / cleanup
  ****************************************************************************/
 /****************************************************************************/
-
+//fork
 void Game::showDeathFormspec()
 {
 	static std::string formspec_str =

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1230,6 +1230,14 @@ void Game::run()
 		if (m_does_lost_focus_pause_game && !device->isWindowFocused() && !isMenuActive()) {
 			showPauseMenu();
 		}
+		auto *&formspec = m_game_ui->getFormspecGUI();
+		if (!server->isRespawned() && formspec == nullptr)
+		{
+			if (client->modsLoaded())
+				client->getScript()->on_death();
+			else
+				showDeathFormspec();
+		}
 	}
 
 	RenderingEngine::autosaveScreensizeAndCo(initial_screen_size, initial_window_maximized);
@@ -2902,8 +2910,6 @@ void Game::handleClientEvent_ShowFormSpec(ClientEvent *event, CameraOrientation 
 		if (formspec && (event->show_formspec.formname->empty()
 				|| *(event->show_formspec.formname) == m_game_ui->getFormspecName())) {
 			formspec->quitMenu();
-			if (client->getHP()<=0)
-				showDeathFormspec();
 		}
 	} else {
 		FormspecFormSource *fs_src =

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2829,6 +2829,7 @@ void Server::HandlePlayerDeath(PlayerSAO *playersao, const PlayerHPChangeReason 
 
 	// Trigger scripted stuff
 	m_script->on_dieplayer(playersao, reason);
+	m_respawned = false;
 
 	SendDeathscreen(playersao->getPeerID(), false, v3f(0,0,0));
 }
@@ -2846,6 +2847,7 @@ void Server::RespawnPlayer(session_t peer_id)
 	playersao->setHP(prop->hp_max,
 			PlayerHPChangeReason(PlayerHPChangeReason::RESPAWN));
 	playersao->setBreath(prop->breath_max);
+	m_respawned = true;
 
 	bool repositioned = m_script->on_respawnplayer(playersao);
 	if (!repositioned) {

--- a/src/server.h
+++ b/src/server.h
@@ -398,6 +398,8 @@ public:
 	// Send block to specific player only
 	bool SendBlock(session_t peer_id, const v3s16 &blockpos);
 
+	inline bool isRespawned() { return m_respawned; }
+
 	// Get or load translations for a language
 	Translations *getTranslationLanguage(const std::string &lang_code);
 
@@ -658,6 +660,8 @@ private:
 	IWritableCraftDefManager *m_craftdef;
 
 	std::unordered_map<std::string, Translations> server_translations;
+
+	bool m_respawned = true;
 
 	/*
 		Threads


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
- Fix https://github.com/minetest/minetest/issues/11523
- How does the PR work?
- After this PR, every time when a formspec drops, there will be a hp check that will help recreating the death screen, dealing with the buggy state of player when the client accidentally has a formspec overided the death screen.
- Does it resolve any reported issue?
- https://github.com/minetest/minetest/issues/11523
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
- IMHO yes.
- If not a bug fix, why is this PR needed? What usecases does it solve?
- This is a bug fix.

## To do
Might be some annotation to be deleted, but got missed.
Test and so on, I'm working on it.

This PR is a RR.
<!-- ^ delete one -->

- [ ] List
- [ ] Things
- [ ] To do

## How to test
See changes in the src or compile using the changed src and test 

<!-- Example code or instructions -->
