### PR TITLE
Sort clients in `minetest.get_server_status` and privs in `minetest.privs_to_string`

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -702,6 +702,7 @@ function core.privs_to_string(privs, delim)
 			list[#list + 1] = priv
 		end
 	end
+	table.sort(list)
 	return table.concat(list, delim)
 end
 

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -221,6 +221,7 @@ core.register_chatcommand("haspriv", {
 			return true, S("No online player has the \"@1\" privilege.",
 					param)
 		else
+			table.sort(players_with_priv)
 			return true, S("Players online with the \"@1\" privilege: @2",
 					param,
 					table.concat(players_with_priv, ", "))

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3181,29 +3181,18 @@ std::string Server::getStatusString()
 	bool first = true;
 	os << " | clients: ";
 	if (m_env) {
-		std::vector<session_t> clients = m_clients.getClientIDs();
-
-		// Create vector to store player names
-		std::vector<std::string> playerNames;
-
-		for (session_t client_id : clients) {
-			RemotePlayer *player = m_env->getPlayer(client_id);
-			// Get name of player and push into playerNames
-			if (player) {
-				playerNames.push_back(player->getName());
-			}
-		}
+		// Get the list of player names
+		std::vector<std::string> player_names = m_clients.getPlayerNames();
 
 		// Sort player names alphabetically
-		std::sort(playerNames.begin(), playerNames.end());
+		std::sort(player_names.begin(), player_names.end());
 
 		// Concatenate sorted names to the output string
-		for (const std::string& name : playerNames) {
-			if (!first) {
+		for (const std::string& name : player_names) {
+			if (!first)
 				os << ", ";
-			} else {
+			else
 				first = false;
-			}
 			os << name;
 		}
 	}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3182,17 +3182,28 @@ std::string Server::getStatusString()
 	os << " | clients: ";
 	if (m_env) {
 		std::vector<session_t> clients = m_clients.getClientIDs();
+
+		// Create vector to store player names
+		std::vector<std::string> playerNames;
+
 		for (session_t client_id : clients) {
 			RemotePlayer *player = m_env->getPlayer(client_id);
+			// Get name of player and push into playerNames
+			if (player) {
+				playerNames.push_back(player->getName());
+			}
+		}
 
-			// Get name of player
-			const std::string name = player ? player->getName() : "<unknown>";
+		// Sort player names alphabetically
+		std::sort(playerNames.begin(), playerNames.end());
 
-			// Add name to information string
-			if (!first)
+		// Concatenate sorted names to the output string
+		for (const std::string& name : playerNames) {
+			if (!first) {
 				os << ", ";
-			else
+			} else {
 				first = false;
+			}
 			os << name;
 		}
 	}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3181,7 +3181,6 @@ std::string Server::getStatusString()
 	bool first = true;
 	os << " | clients: ";
 	if (m_env) {
-		// Get the list of player names
 		std::vector<std::string> player_names = m_clients.getPlayerNames();
 
 		// Sort player names alphabetically

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3183,10 +3183,8 @@ std::string Server::getStatusString()
 	if (m_env) {
 		std::vector<std::string> player_names = m_clients.getPlayerNames();
 
-		// Sort player names alphabetically
 		std::sort(player_names.begin(), player_names.end());
 
-		// Concatenate sorted names to the output string
 		for (const std::string& name : player_names) {
 			if (!first)
 				os << ", ";


### PR DESCRIPTION
This PR applies alphabetical sorting to the `minetest.get_server_status` and `minetest.privs_to_string` functions and also to the output of `/haspriv` command.

## To do

This PR is Ready for Review.

## How to test

* Privs: test with using `/privs`, `/grant[me]`, `/revoke[me]` commands
* Clients: make some test server and connect some real or dummy clients with different names and check the ordering in the output of `/status` and `/haspriv` commands.