### PR TITLE
Fix mods folder being read read twice with RUN_IN_PLACE=1

### DIFF
--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -282,7 +282,7 @@ Package - content which is downloadable from the content db, may or may not be i
       ```lua
       {
           mods = "/home/user/.minetest/mods",
-          share = "/usr/share/minetest/mods",
+          share = "/usr/share/minetest/mods", -- only provided when RUN_IN_PLACE=0
 
           -- Custom dirs can be specified by the MINETEST_MOD_DIR env variable
           ["/path/to/custom/dir"] = "/path/to/custom/dir",

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -675,10 +675,12 @@ int ModApiMainMenu::l_get_modpaths(lua_State *L)
 	ModApiMainMenu::l_get_modpath(L);
 	lua_setfield(L, -2, "mods");
 
-	std::string modpath = fs::RemoveRelativePathComponents(
-		porting::path_share + DIR_DELIM + "mods" + DIR_DELIM);
-	lua_pushstring(L, modpath.c_str());
-	lua_setfield(L, -2, "share");
+	if (porting::path_share != porting::path_user) {
+		std::string modpath = fs::RemoveRelativePathComponents(
+			porting::path_share + DIR_DELIM + "mods" + DIR_DELIM);
+		lua_pushstring(L, modpath.c_str());
+		lua_setfield(L, -2, "share");
+	}
 
 	for (const std::string &component : getEnvModPaths()) {
 		lua_pushstring(L, component.c_str());


### PR DESCRIPTION
should fix #15004

## To do

This PR is a Ready for Review.

## How to test

Use a RUN_IN_PLACE=1 build, have some mods installed, see that the mainmenu works again.
