### PR TITLE
Fix collisions with long dtime, in particular with bouncing

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -85,6 +85,14 @@ inline v3f truncate(const v3f vec, const f32 factor)
 	);
 }
 
+inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
+{
+	return v3f(
+		rangelim(vec.X, low, high),
+		rangelim(vec.Y, low, high),
+		rangelim(vec.Z, low, high)
+	);
+}
 }
 
 // Helper function:
@@ -369,10 +377,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	// Average speed
 	v3f aspeed_f = *speed_f + accel_f * 0.5f * dtime;
 	// Limit speed for avoiding hangs
-	aspeed_f.Y = rangelim(aspeed_f.Y, -5000, 5000);
-	aspeed_f.X = rangelim(aspeed_f.X, -5000, 5000);
-	aspeed_f.Z = rangelim(aspeed_f.Z, -5000, 5000);
-	aspeed_f = truncate(aspeed_f, 10000.0f);
+	aspeed_f = truncate(rangelimv(aspeed_f, -5000.0f, 5000.0f), 10000.0f);
 
 	// Collect node boxes in movement range
 
@@ -414,7 +419,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 	// Collision detection
 	f32 d = 0.0f;
-	for (int loopcount = 0; loopcount <= 100; loopcount++) {
+	for (int loopcount = 0;; loopcount++) {
 		if (loopcount >= 100) {
 			warningstream << "collisionMoveSimple: Loop count exceeded, aborting to avoid infinite loop" << std::endl;
 			break;
@@ -453,10 +458,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			// Final speed:
 			*speed_f += accel_f * dtime;
 			// Limit speed for avoiding hangs
-			speed_f->Y = rangelim(speed_f->Y, -5000, 5000);
-			speed_f->X = rangelim(speed_f->X, -5000, 5000);
-			speed_f->Z = rangelim(speed_f->Z, -5000, 5000);
-			*speed_f = truncate(*speed_f, 10000.0f);
+			*speed_f = truncate(rangelimv(*speed_f, -5000.0f, 5000.0f), 10000.0f);
 			break;
 		}
 		// Otherwise, a collision occurred.
@@ -468,6 +470,8 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		if (nearest_collided != COLLISION_AXIS_Y) {
 			aabb3f stepbox = movingbox;
 			// Look slightly ahead  for checking the height when stepping
+			// to ensure we also check above the node we collided with
+			// otherwise, might allow glitches such as a stack of stairs
 			float extra_dtime = nearest_dtime + 0.1f * fabsf(dtime - nearest_dtime);
 			stepbox.MinEdge.X += aspeed_f.X * extra_dtime;
 			stepbox.MinEdge.Z += aspeed_f.Z * extra_dtime;
@@ -498,15 +502,13 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 					pos_f->Z += aspeed_f.Z * nearest_dtime;
 			}
 		} else if (nearest_dtime > 0) {
+			// updated average speed for the sub-interval up to nearest_dtime
 			aspeed_f = *speed_f + accel_f * 0.5f * nearest_dtime;
 			*pos_f += truncate(aspeed_f * nearest_dtime, 100.0f);
 			// Speed at (approximated) collision:
 			*speed_f += accel_f * nearest_dtime;
 			// Limit speed for avoiding hangs
-			speed_f->Y = rangelim(speed_f->Y, -5000, 5000);
-			speed_f->X = rangelim(speed_f->X, -5000, 5000);
-			speed_f->Z = rangelim(speed_f->Z, -5000, 5000);
-			*speed_f = truncate(*speed_f, 10000.0f);
+			*speed_f = truncate(rangelimv(*speed_f, -5000.0f, 5000.0f), 10000.0f);
 			dtime -= nearest_dtime;
 		}
 
@@ -572,10 +574,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		// Speed for finding the next collision
 		aspeed_f = *speed_f + accel_f * 0.5f * dtime;
 		// Limit speed for avoiding hangs
-		aspeed_f.Y = rangelim(aspeed_f.Y, -5000, 5000);
-		aspeed_f.X = rangelim(aspeed_f.X, -5000, 5000);
-		aspeed_f.Z = rangelim(aspeed_f.Z, -5000, 5000);
-		aspeed_f = truncate(aspeed_f, 10000.0f);
+		aspeed_f = truncate(rangelimv(aspeed_f, -5000.0f, 5000.0f), 10000.0f);
 	}
 
 	/*


### PR DESCRIPTION
Closes #15027

When there is lag in the server (generating map chunks, spawning structures, mobs...) and it misses some steps and we have a large dtime, entities can bounce badly on beds. Seen for example in Voxelibre and Mineclonia.

The main issue is that `speed_f` is the speed at the end of the movement, not at collision time. For a large timestep, this speed can be much too large (consider a mob just over a bed, accelerated by gravity for a long timestep).

This patch (A) introduces `aspeed_f`, which is the average movement speed not the maximum (B) on collision, the speed is updated according to the estimated dtime until collision.

For the villager example above, in particular (B) means a much smaller velocity when bouncing.

For further detail, see #15027