### PR TITLE
Show full texture string in generateImage(): Failed to generate errors

### DIFF
--- a/src/client/imagesource.cpp
+++ b/src/client/imagesource.cpp
@@ -1908,7 +1908,8 @@ video::IImage* ImageSource::generateImage(std::string_view name,
 		video::IImage *tmp = generateImage(name2, source_image_names);
 		if (!tmp) {
 			errorstream << "generateImage(): "
-				"Failed to generate \"" << name2 << "\""
+				"Failed to generate \"" << name2 << "\" "
+				"(attempted to create texture \"" << name << "\")"
 				<< std::endl;
 			return NULL;
 		}
@@ -1923,7 +1924,8 @@ video::IImage* ImageSource::generateImage(std::string_view name,
 	} else if (!generateImagePart(last_part_of_name, baseimg, source_image_names)) {
 		// Generate image according to part of name
 		errorstream << "generateImage(): "
-				"Failed to generate \"" << last_part_of_name << "\""
+				"Failed to generate \"" << last_part_of_name << "\" "
+				"(attempted to create texture \"" << name << "\")"
 				<< std::endl;
 	}
 


### PR DESCRIPTION
This PR adds the full texture string to generateImage(): Failed to generate error messages. This helps in spotting texture generation errors.

## To do

This PR is Ready for Review.

## How to test

I got these texture error messages before applying this PR. I don't know how to reproduce them (that's why I am writing this code).

```text
ERROR[Main]: generateImagePart(): invalid tile position (X,Y) for part_of_name="[sheet:4x4:4,2", cancelling.
ERROR[Main]: generateImage(): Failed to generate "[sheet:4x4:4,2"
```
