### PR TITLE
Fix CSM help formspec's "/" instead of "." mistake

### DIFF
--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -69,7 +69,7 @@ local function build_chatcommands_formspec(name, sel, copy)
 				description = cmds[2].description
 				if copy then
 					local msg = S("Command: @1 @2",
-						core.colorize("#0FF", "/" .. cmds[1]), cmds[2].params)
+						core.colorize("#0FF", (INIT == "client" and "." or "/") .. cmds[1]), cmds[2].params)
 					if INIT == "client" then
 						core.display_chat_message(msg)
 					else


### PR DESCRIPTION
My previous PR (#13937) have the small mistake is that when you double-click on a command, it is copied to the chat with the prefix "/" instead of ".". This patch fixes it.

## To do

This PR is Ready for Review.


## How to test
* Set `enable_client_modding` to `true` in minetest.conf
* Install some client mods (optional)
* Join singleplayer or any server that allows to load client mods
* Type `.help` in the chat, select any command and double-click it. Look at the message in the chat

