### PR TITLE
Fixed `Seeing through blocks glitch`

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3825,12 +3825,22 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 
 		// Don't place node when player would be inside new node
 		// NOTE: This is to be eventually implemented by a mod as client-side Lua
+		//-- Collision check --
+		/// check for the precise position of player
+		/// neighborpos is the pos for predicted node, right?
+		/// Do not allow placing node around player, when it can collide with player collision box. not just check for the pos of node.
+		bool isFullNodeCollided = false;
+		v3f position = player->getPosition();
+		aabb3f collisionbox = player->getCollisionbox();
+		v3s16 colpos_min = floatToInt(position + collisionbox.MinEdge * 0.99f,BS);
+		v3s16 colpos_max = floatToInt(position + collisionbox.MaxEdge * 0.99f,BS);
+		if (neighborpos.Z <= colpos_max.Z && neighborpos.Z >= colpos_min.Z && neighborpos.X <= colpos_max.X && neighborpos.X >= colpos_min.X && neighborpos.Y <= colpos_max.Y && neighborpos.Y >= colpos_min.Y)
+			isFullNodeCollided = true;
+
 		if (!predicted_f.walkable ||
 				g_settings->getBool("enable_build_where_you_stand") ||
 				(client->checkPrivilege("noclip") && g_settings->getBool("noclip")) ||
-				(predicted_f.walkable &&
-					neighborpos != player->getStandingNodePos() + v3s16(0, 1, 0) &&
-					neighborpos != player->getStandingNodePos() + v3s16(0, 2, 0))) {
+				(predicted_f.walkable && !isFullNodeCollided)) {
 			// This triggers the required mesh update too
 			client->addNode(p, predicted_node);
 			// Report to server


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
- Fix https://github.com/minetest/minetest/issues/12429
- How does the PR work?
- By precising the collision check when player tring to place node, simply makes this bug won't happen again this way.
- Does it resolve any reported issue?
- https://github.com/minetest/minetest/issues/12429
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
- IMHO yes, because #12429 is an in-game serious glitch confirmed atm, same as Xray resource pack in mc.
- If not a bug fix, why is this PR needed? What usecases does it solve?
- This is a bug fix.

## To do

This PR is a Ready for Review.
<!-- ^ delete one -->

- [ ] List
- [ ] Things
- [ ] To do

## How to test
See changes in the src, compile and test, or see the test video below.

<!-- Example code or instructions -->
This PR also solves the issue when player can place a node inside them in a reliable way, with the `enable_build_where_you_stand` disabled. That feature just don't work as expected atm IMO, also used a bad way to judge if there can be a collision between the new node and player.
