### PR TITLE
zstd: Fix minetest.decompress lockup when data ends too early

### DIFF
--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -262,6 +262,8 @@ void decompressZstd(std::istream &is, std::ostream &os)
 			is.read(input_buffer, bufsize);
 			input.size = is.gcount();
 			input.pos = 0;
+			if (input.size == 0)
+				throw SerializationError("decompressZstd: data ended too early");
 		}
 
 		ret = ZSTD_decompressStream(stream.get(), &output, &input);


### PR DESCRIPTION
Fixes #15042

## To do

This PR is Ready for Review.

## How to test

```
minetest.decompress(" ", "zstd")
```

Or with an empty string.
Unittests must pass.
