### PR TITLE
Convert nodedef tests to Catch2

### DIFF
--- a/src/unittest/test_nodedef.cpp
+++ b/src/unittest/test_nodedef.cpp
@@ -17,51 +17,33 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include "test.h"
-
-#include <sstream>
-
 #include "gamedef.h"
 #include "nodedef.h"
 #include "network/networkprotocol.h"
 
-class TestNodeDef : public TestBase
-{
-public:
-	TestNodeDef() { TestManager::registerTestModule(this); }
-	const char *getName() { return "TestNodeDef"; }
+#include <catch.h>
 
-	void runTests(IGameDef *gamedef);
+#include <ios>
+#include <sstream>
 
-	void testContentFeaturesSerialization();
-};
 
-static TestNodeDef g_test_instance;
-
-void TestNodeDef::runTests(IGameDef *gamedef)
-{
-	TEST(testContentFeaturesSerialization);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-void TestNodeDef::testContentFeaturesSerialization()
+TEST_CASE("Given a node definition, "
+		"when we serialize and then deserealize it, "
+		"the deserialized one should be equal to the original.",
+		"[nodedef]")
 {
 	ContentFeatures f;
-
 	f.name = "default:stone";
-	for (TileDef &tiledef : f.tiledef)
+	for (TileDef &tiledef : f.tiledef) {
 		tiledef.name = "default_stone.png";
-	f.is_ground_content = true;
+	}
 
 	std::ostringstream os(std::ios::binary);
 	f.serialize(os, LATEST_PROTOCOL_VERSION);
-	// verbosestream<<"Test ContentFeatures size: "<<os.str().size()<<std::endl;
-
 	std::istringstream is(os.str(), std::ios::binary);
 	ContentFeatures f2;
 	f2.deSerialize(is, LATEST_PROTOCOL_VERSION);
 
-	UASSERT(f.walkable == f2.walkable);
-	UASSERT(f.node_box.type == f2.node_box.type);
+	CHECK(f.walkable == f2.walkable);
+	CHECK(f.node_box.type == f2.node_box.type);
 }


### PR DESCRIPTION
This does not add or remove any tests or change the implementation of the test.

## To do

Ready for Review.

## How to test

`minetest --run-unittests --test-module "[nodedef]"`