### PR TITLE
[nosquash] Transparency sort mesh radius fix, and other things

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -735,6 +735,12 @@ hud_scaling (HUD scaling) float 1.0 0.5 20
 #    Mods may still set a background.
 show_nametag_backgrounds (Show name tag backgrounds by default) bool true
 
+#    Whether to show the client debug info (has the same effect as hitting F5).
+show_debug (Show debug info) bool false
+
+#    Radius to use when the block bounds HUD feature is set to near blocks.
+show_block_bounds_radius_near (Block bounds HUD radius) int 4 0 1000
+
 [**Chat]
 
 #    Maximum number of recent chat messages to show
@@ -2008,9 +2014,6 @@ client_unload_unused_data_timeout (Mapblock unload timeout) float 600.0 0.0
 #    Maximum number of mapblocks for client to be kept in memory.
 #    Set to -1 for unlimited amount.
 client_mapblock_limit (Mapblock limit) int 7500 -1 2147483647
-
-#    Whether to show the client debug info (has the same effect as hitting F5).
-show_debug (Show debug info) bool false
 
 #    Maximum number of blocks that are simultaneously sent per client.
 #    The maximum total count is calculated dynamically:

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -137,6 +137,7 @@ private:
 	v3f m_selected_face_normal;
 
 	video::SMaterial m_selection_material;
+	video::SMaterial m_block_bounds_material;
 
 	scene::SMeshBuffer m_rotation_mesh_buffer;
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -302,6 +302,7 @@ void set_default_settings()
 	settings->setDefault("enable_particles", "true");
 	settings->setDefault("arm_inertia", "true");
 	settings->setDefault("show_nametag_backgrounds", "true");
+	settings->setDefault("show_block_bounds_radius_near", "4");
 	settings->setDefault("transparency_sorting_distance", "16");
 
 	settings->setDefault("enable_minimap", "true");

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -179,7 +179,9 @@ struct MeshGrid {
 	/// @brief Returns true if p is an origin of a cell in the grid.
 	bool isMeshPos(v3s16 &p) const
 	{
-		return ((p.X + p.Y + p.Z) % cell_size) == 0;
+		return p.X % cell_size == 0
+				&& p.Y % cell_size == 0
+				&& p.Z % cell_size == 0;
 	}
 
 	/// @brief Returns index of the given offset in a grid cell


### PR DESCRIPTION
The PR blew up a bit in scope because I bumped into stuff that I need to do first.

First commit:
Minimap has generated too many areas, probably overlapping, because there was a bugged helper function.

Second commit:
The block bounds hud feature is now better. See commit description.

Third commit:
* Transparency sorting is only done if not too far away. But it incorrectly used only one block, and a fixed block radius of 0.
  It now correctly uses the mesh bounding sphere.
  Note: The radius for transparency sorting is now effectively larger. This is correct, we need to take the mesh radius into account.
  Related: #12900 can now be reproduced more easily.
* There is some check for blocks being far away, and not animate them or so (idk what exactly it does). This was also incorrect. So I fixed it.

## To do

This PR is a Ready for Review.

## How to test

* First commit:
  * Enable minimap. See how no block is missing.
* Second commit:
  * Toggle block bounds HUD element, to show mesh chunk boarders.
  * Try out the new setting.
  * Try setting `node_highlighting` to none or halo.
* Third commit:
  * Change the `client_mesh_chunk` size value for testing.
  * For transparency sorting: Use devtest water (it has disabled backface culling), and let it flow down 1x1. Look at it from multiple sides.
    You might have to make sure you didn't place near to the lucky corner of the mesh chunk.
    You can also see an effect if you're reproducing #12900.
  * For animation faraway test: Modify the source to stop animation instantly if `faraway` is true. In devtest, place an animation node. If you placed it on a bad position, you can stand directly next to it and it won't be animated (in master).

master:
![master](https://github.com/user-attachments/assets/b0a7b0dd-3f7e-4b28-bebe-a9b063ff1f9b)
PR:
![pr](https://github.com/user-attachments/assets/94a0da95-4931-4b4f-972c-105628790fcd)
