### PR TITLE
Meshgen: Don't get lights for not drawn solid faces

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -463,6 +463,8 @@ void MapblockMeshGenerator::drawSolidNode()
 	if (data->m_smooth_lighting) {
 		LightPair lights[6][4];
 		for (int face = 0; face < 6; ++face) {
+			if (mask & (1 << face))
+				continue;
 			for (int k = 0; k < 4; k++) {
 				v3s16 corner = light_dirs[light_indices[face][k]];
 				lights[face][k] = LightPair(getSmoothLightSolid(


### PR DESCRIPTION
`drawCuboid()` doesn't call the face lighter function for masked faces, so we don't need these values.

This makes meshgen of solid nodes cheaper.
`getSmoothLightSolid()` makes up a big part of the meshgen cost if there's mostly solid nodes (see profiler). So we shouldn't call it unnecessarily often.


## To do

This PR is a Ready for Review.

## How to test

* Start a world, and see how lighting is not broken.
* Use hotspot and record data while flying around, meshgening some bare world. See how the `getSmoothLightSolid()` part is significantly reduced in PR.
