### PR TITLE
Add `get_elapsed_time()` to retrieve the elapsed time of a job

### DIFF
--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -174,10 +174,8 @@ function core.after(after, func, ...)
 		get_elapsed_time = function(self)
 			if self.expired then
 				return after
-			else
-				if self.expiring_time then
-					return time - self.start_time
-				end
+			elseif self.expiring_time then
+				return time - self.start_time
 			end
 		end
 	}

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -168,7 +168,7 @@ function core.after(after, func, ...)
 	local new_job = {
 		mod_origin = core.get_last_run_mod(),
 		func = func,
-		elapsed_time = time,
+		elapsed_time = 0,
 		args = {
 			n = select("#", ...),
 			...

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6701,6 +6701,8 @@ Timing
 
 * `job:get_elapsed_time()`
     * Returns the game time passed since the job was launched, in `dtime_s`.
+    * If the job has finished, it returns the duration of the job as declared
+    in `minetest.after`.
     * Returns `nil` if the job is cancelled.
 * `job:cancel()`
     * Cancels the job function from being called

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6699,6 +6699,9 @@ Timing
     * Jobs set for earlier times are executed earlier. If multiple jobs expire
       at exactly the same time, then they are executed in registration order.
 
+* `job:get_elapsed_time()`
+    * Returns the game time passed since the job was launched, in `dtime_s`.
+    * Returns `nil` if the job is cancelled.
 * `job:cancel()`
     * Cancels the job function from being called
 


### PR DESCRIPTION

## To do

This PR is Ready for Review.

## How to test
```lua
local after = minetest.after(3, function() end)

minetest.register_on_joinplayer(function(player)
	minetest.after(1, function()
		minetest.chat_send_all(after:get_elapsed_time())
	end)
	minetest.after(1.5, function()
		minetest.chat_send_all(after:get_elapsed_time())
	end)
	minetest.after(2.3, function()
		minetest.chat_send_all(after:get_elapsed_time())
	end)
	minetest.after(3.8, function()
		minetest.chat_send_all(after:get_elapsed_time()) -- should be equal to 3
	end)
end)
```
