### PR TITLE
Document negative saturation

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8542,6 +8542,7 @@ child will follow movement and rotation of that bone.
       * `saturation` sets the saturation (vividness; default: `1.0`).
         * values > 1 increase the saturation
         * values in [0,1] decrease the saturation
+        * values < 0 invert the colors
       * `shadows` is a table that controls ambient shadows
         * `intensity` sets the intensity of the shadows from 0 (no shadows, default) to 1 (blackness)
             * This value has no effect on clients who have the "Dynamic Shadows" shader disabled.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8546,11 +8546,11 @@ child will follow movement and rotation of that bone.
           * `s` is the saturation set here
         * The resulting color always has the same luma (perceived brightness) as the original.
         * This means that:
-          * value of 1 (default) doesn't change the saturation
-          * values > 1 increase the saturation
-          * values between 0 and 1 decrease the saturation
-          * value of 0 makes the world greyscale
-          * values < 0 alter the hue severely, causing an effect similar to inversion, but keeping original luma and being symmetrical in terms of saturation (eg. -1 and 1 is the same saturation and luma, but different hues)
+          * values > 1 oversaturate
+          * values < 1 down to 0 desaturate, 0 being entirely greyscale
+          * values < 0 cause an effect similar to inversion,
+            but keeping original luma and being symmetrical in terms of saturation
+            (eg. -1 and 1 is the same saturation and luma, but different hues)
       * `shadows` is a table that controls ambient shadows
         * `intensity` sets the intensity of the shadows from 0 (no shadows, default) to 1 (blackness)
             * This value has no effect on clients who have the "Dynamic Shadows" shader disabled.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8540,9 +8540,17 @@ child will follow movement and rotation of that bone.
     * Passing no arguments resets lighting to its default values.
     * `light_definition` is a table with the following optional fields:
       * `saturation` sets the saturation (vividness; default: `1.0`).
-        * values > 1 increase the saturation
-        * values in [0,1] decrease the saturation
-        * values < 0 invert the colors
+        * It is applied according to the function `result = b*(1-s) + c*s`, where:
+          * `c` is the original color
+          * `b` is the greyscale version of the color with the same luma
+          * `s` is the saturation set here
+        * The resulting color always has the same luma (perceived brightness) as the original.
+        * This means that:
+          * value of 1 (default) doesn't change the saturation
+          * values > 1 increase the saturation
+          * values in [0,1] decrease the saturation
+          * value of 0 makes the world greyscale
+          * values < 0 alter the hue severely, causing an effect similar to inversion, but keeping original luma and being symmetrical in terms of saturation (eg. -1 and 1 is the same saturation and luma, but different hues)
       * `shadows` is a table that controls ambient shadows
         * `intensity` sets the intensity of the shadows from 0 (no shadows, default) to 1 (blackness)
             * This value has no effect on clients who have the "Dynamic Shadows" shader disabled.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8548,7 +8548,7 @@ child will follow movement and rotation of that bone.
         * This means that:
           * value of 1 (default) doesn't change the saturation
           * values > 1 increase the saturation
-          * values in [0,1] decrease the saturation
+          * values between 0 and 1 decrease the saturation
           * value of 0 makes the world greyscale
           * values < 0 alter the hue severely, causing an effect similar to inversion, but keeping original luma and being symmetrical in terms of saturation (eg. -1 and 1 is the same saturation and luma, but different hues)
       * `shadows` is a table that controls ambient shadows


### PR DESCRIPTION
Improved the description of the `saturation` field in the table argument to `player:set_lighting()`. Described how the value is in fact applied. Described what different values do.

Negative values are described to alter the hue severely. What this actually means is actual hue inversion in about 1/3 of cases (180 deg change), 60deg change in another 1/3 of cases, and something in between in the rest of cases (somewhat uniformly distributed).

We're using this behaviour in VoxeLibre, and I've noticed it's undocumented.

## To do

This PR is Ready for Review.

## How to test

Try setting saturation to a negative value in game.

Or use this C++ code to test out the results of the operation on a random sample:
https://gist.github.com/nauta-turbidus/60950e069b15094e08c6678a24af45e1

<details><summary>Screenshot of feature in use:</summary>
<p>
Normal saturation:

![screenshot_20240907_011931](https://github.com/user-attachments/assets/aa48b4e1-7cab-462e-9cde-3c491c0c487b)

Same shot with `saturation == -1`:

![screenshot_20240907_011944](https://github.com/user-attachments/assets/076d8a81-505c-47b7-8325-158c71c61526)

</p>
</details> 