### PR TITLE
Fix  `Waving liquid render bug if solid block is above liquid`

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -364,7 +364,10 @@ void ClientMap::updateDrawList()
 				if (!m_control.range_all &&
 					mesh_sphere_center.getDistanceFrom(m_camera_position) >
 						m_control.wanted_range * BS + mesh_sphere_radius)
-					continue; // Out of range, skip.
+				{
+					block->setIsBeingDrawn(false);
+					continue;
+				} // Out of range, skip.
 
 				// Keep the block alive as long as it is in range.
 				block->resetUsageTimer();
@@ -377,6 +380,7 @@ void ClientMap::updateDrawList()
 				if (is_frustum_culled(mesh_sphere_center,
 						mesh_sphere_radius + frustum_cull_extra_radius)) {
 					blocks_frustum_culled++;
+					block->setIsBeingDrawn(false);
 					continue;
 				}
 
@@ -385,6 +389,7 @@ void ClientMap::updateDrawList()
 						mesh &&
 						isMeshOccluded(block, mesh_grid.cell_size, cam_pos_nodes)) {
 					blocks_occlusion_culled++;
+					block->setIsBeingDrawn(false);
 					continue;
 				}
 
@@ -400,6 +405,8 @@ void ClientMap::updateDrawList()
 					// without mesh chunking we can add the block to the drawlist
 					block->refGrab();
 					m_drawlist.emplace(block->getPos(), block);
+					block->setIsBeingDrawn(true);
+					block->setIsRecentlyDrawn(true);
 				}
 			}
 		}
@@ -467,7 +474,10 @@ void ClientMap::updateDrawList()
 			if (!m_control.range_all &&
 				mesh_sphere_center.getDistanceFrom(intToFloat(cam_pos_nodes, BS)) >
 					m_control.wanted_range * BS + mesh_sphere_radius)
-				continue; // Out of range, skip.
+				{
+					block->setIsBeingDrawn(false);
+					continue;
+				} // Out of range, skip.
 
 			// Frustum culling
 			// Only do coarse culling here, to account for fast camera movement.
@@ -476,6 +486,7 @@ void ClientMap::updateDrawList()
 			if (is_frustum_culled(mesh_sphere_center,
 					mesh_sphere_radius + frustum_cull_extra_radius)) {
 				blocks_frustum_culled++;
+				block->setIsBeingDrawn(false);
 				continue;
 			}
 
@@ -491,6 +502,7 @@ void ClientMap::updateDrawList()
 					block && mesh &&
 					visible_outer_sides != 0x07 && isMeshOccluded(block, mesh_grid.cell_size, cam_pos_nodes)) {
 				blocks_occlusion_culled++;
+				block->setIsBeingDrawn(false);
 				continue;
 			}
 
@@ -508,6 +520,8 @@ void ClientMap::updateDrawList()
 				// without mesh chunking we can add the block to the drawlist
 				block->refGrab();
 				m_drawlist.emplace(block_coord, block);
+				block->setIsBeingDrawn(true);
+				block->setIsRecentlyDrawn(true);
 			}
 
 			// Decide which sides to traverse next or to block away
@@ -620,6 +634,8 @@ void ClientMap::updateDrawList()
 		if (block) {
 			block->refGrab();
 			m_drawlist.emplace(pos, block);
+			block->setIsBeingDrawn(true);
+			block->setIsRecentlyDrawn(true);
 		}
 	}
 

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -365,7 +365,8 @@ void ClientMap::updateDrawList()
 					mesh_sphere_center.getDistanceFrom(m_camera_position) >
 						m_control.wanted_range * BS + mesh_sphere_radius)
 				{
-					block->setIsBeingDrawn(false);
+					if (block)
+						block->setIsBeingDrawn(false);
 					continue;
 				} // Out of range, skip.
 
@@ -380,7 +381,8 @@ void ClientMap::updateDrawList()
 				if (is_frustum_culled(mesh_sphere_center,
 						mesh_sphere_radius + frustum_cull_extra_radius)) {
 					blocks_frustum_culled++;
-					block->setIsBeingDrawn(false);
+					if (block)
+						block->setIsBeingDrawn(false);
 					continue;
 				}
 
@@ -389,7 +391,8 @@ void ClientMap::updateDrawList()
 						mesh &&
 						isMeshOccluded(block, mesh_grid.cell_size, cam_pos_nodes)) {
 					blocks_occlusion_culled++;
-					block->setIsBeingDrawn(false);
+					if (block)
+						block->setIsBeingDrawn(false);
 					continue;
 				}
 
@@ -405,8 +408,11 @@ void ClientMap::updateDrawList()
 					// without mesh chunking we can add the block to the drawlist
 					block->refGrab();
 					m_drawlist.emplace(block->getPos(), block);
-					block->setIsBeingDrawn(true);
-					block->setIsRecentlyDrawn(true);
+					if (block)
+					{
+						block->setIsBeingDrawn(true);
+						block->setIsRecentlyDrawn(true);
+					}
 				}
 			}
 		}
@@ -475,7 +481,8 @@ void ClientMap::updateDrawList()
 				mesh_sphere_center.getDistanceFrom(intToFloat(cam_pos_nodes, BS)) >
 					m_control.wanted_range * BS + mesh_sphere_radius)
 				{
-					block->setIsBeingDrawn(false);
+					if (block)
+						block->setIsBeingDrawn(false);
 					continue;
 				} // Out of range, skip.
 
@@ -486,7 +493,8 @@ void ClientMap::updateDrawList()
 			if (is_frustum_culled(mesh_sphere_center,
 					mesh_sphere_radius + frustum_cull_extra_radius)) {
 				blocks_frustum_culled++;
-				block->setIsBeingDrawn(false);
+				if (block)
+					block->setIsBeingDrawn(false);
 				continue;
 			}
 
@@ -502,7 +510,8 @@ void ClientMap::updateDrawList()
 					block && mesh &&
 					visible_outer_sides != 0x07 && isMeshOccluded(block, mesh_grid.cell_size, cam_pos_nodes)) {
 				blocks_occlusion_culled++;
-				block->setIsBeingDrawn(false);
+				if (block)
+					block->setIsBeingDrawn(false);
 				continue;
 			}
 
@@ -520,8 +529,11 @@ void ClientMap::updateDrawList()
 				// without mesh chunking we can add the block to the drawlist
 				block->refGrab();
 				m_drawlist.emplace(block_coord, block);
-				block->setIsBeingDrawn(true);
-				block->setIsRecentlyDrawn(true);
+				if (block)
+				{
+					block->setIsBeingDrawn(true);
+					block->setIsRecentlyDrawn(true);
+				}
 			}
 
 			// Decide which sides to traverse next or to block away

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/meshgen/collector.h"
 #include "client/renderingengine.h"
 #include "client.h"
+#include "map.h"
 #include "noise.h"
 
 // Distance of light extrapolation (for oversized nodes)
@@ -689,8 +690,19 @@ void MapblockMeshGenerator::drawLiquidSides()
 
 		const ContentFeatures &neighbor_features = nodedef->get(neighbor.content);
 		// Don't draw face if neighbor is blocking the view
-		if (neighbor_features.solidness == 2)
+		// to fix: blocking rendering with flowing liquid. Still don't know why top is not rendered... To test.
+		// Don't draw only when no flowing liquid enabled and cur_node is happened to not be the source node and cur_node is rendering at the same time.
+		// Now : This is not what cause the top render to lose. move to other part
+		if (g_settings->getBool("enable_waving_water"))
+		{
+			MapBlock *b = client->getEnv().getMap().getBlockNoCreateNoEx(cur_node.p);
+			if (b != nullptr && b->getIsBeingDrawn() || neighbor_features.solidness == 2 && cur_liquid.c_source != cur_node.n.getContent())
+				continue;
+		}
+		else if (neighbor_features.solidness == 2)
 			continue;
+		
+
 
 		video::S3DVertex vertices[4];
 		for (int j = 0; j < 4; j++) {

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -432,7 +432,17 @@ void MapblockMeshGenerator::drawSolidNode()
 			continue;
 		if (n2 != CONTENT_AIR) {
 			const ContentFeatures &f2 = nodedef->get(n2);
-			if (f2.solidness == 2)
+			//if (f2.solidness == 2)//fork : probable reason
+			//	continue;
+			// fork : to fix: blocking rendering with flowing liquid. Still don't know why top is not rendered... To test.
+			// draw when flowing liquid enabled and cur_node is happened to be the source node and cur_node is rendering and cur_node is liquid at the same time.
+			if (g_settings->getBool("enable_waving_water")&&cur_node.f->drawtype == NDT_LIQUID)
+			{
+				MapBlock *b = client->getEnv().getMap().getBlockNoCreateNoEx(cur_node.p);
+				if (b != nullptr && b->getIsBeingDrawn() || f2.solidness == 2 && cur_liquid.c_source != n1)
+					continue;
+			}
+			else if (f2.solidness == 2)
 				continue;
 			if (cur_node.f->drawtype == NDT_LIQUID) {
 				if (cur_node.f->sameLiquidRender(f2))
@@ -690,7 +700,7 @@ void MapblockMeshGenerator::drawLiquidSides()
 
 		const ContentFeatures &neighbor_features = nodedef->get(neighbor.content);
 		// Don't draw face if neighbor is blocking the view
-		// to fix: blocking rendering with flowing liquid. Still don't know why top is not rendered... To test.
+		// fork : to fix: blocking rendering with flowing liquid. Still don't know why top is not rendered... To test.
 		// Don't draw only when no flowing liquid enabled and cur_node is happened to not be the source node and cur_node is rendering at the same time.
 		// Now : This is not what cause the top render to lose. move to other part
 		if (g_settings->getBool("enable_waving_water"))
@@ -1725,7 +1735,7 @@ void MapblockMeshGenerator::drawNode()
 	switch (cur_node.f->drawtype) {
 		case NDT_AIRLIKE:  // Not drawn at all
 			return;
-		case NDT_LIQUID:
+		case NDT_LIQUID: // fork: Might for this that the full liquid node keeps rendering the top.
 		case NDT_NORMAL: // solid nodes don’t need the usual setup
 			drawSolidNode();
 			return;

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "nodedef.h"
 #include <IMeshManipulator.h>
+#include "mapblock.h"
 
 struct MeshMakeData;
 struct MeshCollector;
@@ -65,6 +66,7 @@ public:
 			scene::IMeshManipulator *mm);
 	void generate();
 	void renderSingle(content_t node, u8 param2 = 0x00);
+	inline void setClient(Client *c) { client = c; }
 
 private:
 	MeshMakeData *const data;
@@ -75,7 +77,9 @@ private:
 
 	const v3s16 blockpos_nodes;
 
-// options
+	Client *client;
+
+	// options
 	const bool enable_mesh_cache;
 
 // current node

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -652,8 +652,10 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offs
 	*/
 
 	{
-		MapblockMeshGenerator(data, &collector,
-			client->getSceneManager()->getMeshManipulator()).generate();
+		MapblockMeshGenerator m = MapblockMeshGenerator(data, &collector,
+			client->getSceneManager()->getMeshManipulator());
+		m.setClient(client);
+		m.generate();
 	}
 
 	/*

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -285,21 +285,6 @@ struct TimeOrderedMapBlock {
 	};
 };
 
-struct DistanceOrderedMapBlock {
-	MapSector *sect;
-	MapBlock *block;
-
-	DistanceOrderedMapBlock(MapSector *sect = nullptr, MapBlock *block= nullptr) :
-		sect(sect ),
-		block(block )
-	{}
-
-	bool operator<(const DistanceOrderedMapBlock &b) const
-	{
-		return block->getPosRelative().getLengthSQ() < b.block->getPosRelative().getLengthSQ();
-	};
-};
-
 /*
 	Updates usage timers
 */
@@ -316,10 +301,6 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 	u32 saved_blocks_count = 0;
 	u32 block_count_all = 0;
 	u32 locked_blocks = 0;
-	u32 recently_drawn_blocks_skipped = 0;
-	u32 recently_drawn_blocks_dropped = 0;
-	u32 possibly_culled_blocks_skipped = 0;
-	u32 possibly_culled_blocks_dropped = 0;
 
 	const auto start_time = porting::getTimeUs();
 	beginSave();
@@ -370,11 +351,6 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 		}
 	} else {
 		std::priority_queue<TimeOrderedMapBlock> mapblock_queue;
-		std::priority_queue<DistanceOrderedMapBlock> mapblock_queue_d_recently_drawn;
-		std::priority_queue<DistanceOrderedMapBlock> mapblock_queue_d_rest;
-		s32 overload_block_count = 0;
-		bool was_overload = false;
-		const float radiusSQ = g_settings->getFloat("viewing_range") * g_settings->getFloat("viewing_range");
 		for (auto &sector_it : m_sectors) {
 			MapSector *sector = sector_it.second;
 
@@ -383,126 +359,14 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 
 			for (MapBlock *block : blocks) {
 				block->incrementUsageTimer(dtime);
-				// no way if a block which is outside viewing range can be seen, also if it's recently drown makes no sense.
-				if (block->getPosRelative().getLengthSQ() > radiusSQ)
-					block->setIsRecentlyDrawn(false);
-				if (block->getIsRecentlyDrawn())
-				{
-					mapblock_queue_d_recently_drawn.push(DistanceOrderedMapBlock(sector, block));
-					mapblock_queue.push(TimeOrderedMapBlock(sector, block));
-					continue;
-				}
 				mapblock_queue.push(TimeOrderedMapBlock(sector, block));
-				mapblock_queue_d_rest.push(DistanceOrderedMapBlock(sector, block));
 			}
-
 		}
-		// todo: release recently drawn blocks only after all culled blocks have been released.
-		// is refGet()!=0 equals when the block is being drawn?
 		block_count_all = mapblock_queue.size();
-		overload_block_count = (s32)block_count_all - max_loaded_blocks;
-		was_overload = overload_block_count > 0;
-		// execute block dumping by distance first if there's an overload of blocks.
-		// possibly culled blocks are dumped first, by distance.
-		while (overload_block_count > 0)
-		{
-			DistanceOrderedMapBlock b;
-			bool is_block_recently_drown;
-			if (!mapblock_queue_d_rest.empty())
-			{
-				b = mapblock_queue_d_rest.top();
-				mapblock_queue_d_rest.pop();
-			}
-			else if (!mapblock_queue_d_recently_drawn.empty())
-			{
-				b = mapblock_queue_d_recently_drawn.top();
-				mapblock_queue_d_recently_drawn.pop();
-			}
-			MapBlock *block = b.block;
-			is_block_recently_drown = block->getIsRecentlyDrawn();
-			if (block->refGet() != 0)
-			{
-				locked_blocks++;
-				if (is_block_recently_drown)
-				{
-					recently_drawn_blocks_skipped++;
-				}
-				else
-				{
-					possibly_culled_blocks_skipped++;
-				}
-				continue;
-			}
-			v3s16 p = block->getPos();
-			// Save if modified
-			if (block->getModified() != MOD_STATE_CLEAN && save_before_unloading)
-			{
-				modprofiler.add(block->getModifiedReasonString(), 1);
-				if (!saveBlock(block))
-				{
-					if (is_block_recently_drown)
-					{
-						recently_drawn_blocks_skipped++;
-					}
-					else
-					{
-						possibly_culled_blocks_skipped++;
-					}
-					continue;
-				}
-				saved_blocks_count++;
-			}
-			if (is_block_recently_drown)
-			{
-				recently_drawn_blocks_dropped++;
-			}
-			else
-			{
-				possibly_culled_blocks_dropped++;
-			}
-			// Delete from memory
-			b.sect->deleteBlock(block);
 
-			if (unloaded_blocks)
-				unloaded_blocks->push_back(p);
-
-			deleted_blocks_count++;
-			block_count_all--;
-			overload_block_count--;
-			continue;
-		}
-		// refresh the time ordered map block queue, for later use of timed block dumping.
-		if (was_overload)
-		{
-			std::priority_queue<TimeOrderedMapBlock> q;
-			while (!mapblock_queue_d_rest.empty())
-			{
-				q.push(TimeOrderedMapBlock(mapblock_queue_d_rest.top().sect, mapblock_queue_d_rest.top().block));
-				mapblock_queue_d_rest.pop();
-			}
-			while (!mapblock_queue_d_recently_drawn.empty())
-			{
-				q.push(TimeOrderedMapBlock(mapblock_queue_d_recently_drawn.top().sect, mapblock_queue_d_recently_drawn.top().block));
-				mapblock_queue_d_recently_drawn.pop();
-			}
-			mapblock_queue = q;
-		}
-		else
-		{
-			// without overflow, these two queues are useless.
-			while (!mapblock_queue_d_rest.empty())
-			{
-				mapblock_queue_d_rest.pop();
-			}
-			while (!mapblock_queue_d_recently_drawn.empty())
-			{
-				mapblock_queue_d_recently_drawn.pop();
-			}
-		}
-
-		// Delete old blocks from the memory
-		while (mapblock_queue.top().block->getUsageTimer() > unload_timeout)
-		{
+		// Delete old blocks, and blocks over the limit from the memory
+		while (!mapblock_queue.empty() && ((s32)mapblock_queue.size() > max_loaded_blocks
+				|| mapblock_queue.top().block->getUsageTimer() > unload_timeout)) {
 			TimeOrderedMapBlock b = mapblock_queue.top();
 			mapblock_queue.pop();
 
@@ -531,7 +395,6 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 
 			deleted_blocks_count++;
 			block_count_all--;
-			overload_block_count--;
 		}
 
 		// Delete empty sectors
@@ -559,12 +422,7 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 			infostream<<", of which "<<saved_blocks_count<<" were written";
 		infostream<<", "<<block_count_all<<" blocks in memory, " << locked_blocks << " locked";
 		infostream<<"."<<std::endl;
-		infostream << recently_drawn_blocks_dropped << " recently drown blocks unloaded by distance." << std::endl
-				   << recently_drawn_blocks_skipped << " skipped." << std::endl
-				   << possibly_culled_blocks_dropped << " possibly culled blocks unloaded by distance." << std::endl
-				   << possibly_culled_blocks_skipped << " skipped." << std::endl;
-		if (saved_blocks_count != 0)
-		{
+		if(saved_blocks_count != 0){
 			PrintInfo(infostream); // ServerMap/ClientMap:
 			infostream<<"Blocks modified by: "<<std::endl;
 			modprofiler.print(infostream);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -413,7 +413,7 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 				b = mapblock_queue_d_rest.top();
 				mapblock_queue_d_rest.pop();
 			}
-			else
+			else if (!mapblock_queue_d_recently_drawn.empty())
 			{
 				b = mapblock_queue_d_recently_drawn.top();
 				mapblock_queue_d_recently_drawn.pop();
@@ -487,6 +487,18 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 			}
 			mapblock_queue = q;
 		}
+		else
+		{
+			// without overflow, these two queues are useless.
+			while (!mapblock_queue_d_rest.empty())
+			{
+				mapblock_queue_d_rest.pop();
+			}
+			while (!mapblock_queue_d_recently_drawn.empty())
+			{
+				mapblock_queue_d_recently_drawn.pop();
+			}
+		}
 
 		// Delete old blocks from the memory
 		while (mapblock_queue.top().block->getUsageTimer() > unload_timeout)
@@ -548,9 +560,9 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 		infostream<<", "<<block_count_all<<" blocks in memory, " << locked_blocks << " locked";
 		infostream<<"."<<std::endl;
 		infostream << recently_drawn_blocks_dropped << " recently drown blocks unloaded by distance." << std::endl
-				   << recently_drawn_blocks_skipped << "skipped." << std::endl
-				   << possibly_culled_blocks_dropped << "possibly culled blocks unloaded by distance." << std::endl
-				   << possibly_culled_blocks_skipped << "skipped." << std::endl;
+				   << recently_drawn_blocks_skipped << " skipped." << std::endl
+				   << possibly_culled_blocks_dropped << " possibly culled blocks unloaded by distance." << std::endl
+				   << possibly_culled_blocks_skipped << " skipped." << std::endl;
 		if (saved_blocks_count != 0)
 		{
 			PrintInfo(infostream); // ServerMap/ClientMap:

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -289,9 +289,9 @@ struct DistanceOrderedMapBlock {
 	MapSector *sect;
 	MapBlock *block;
 
-	DistanceOrderedMapBlock(MapSector *sect, MapBlock *block) :
-		sect(sect),
-		block(block)
+	DistanceOrderedMapBlock(MapSector *sect = nullptr, MapBlock *block= nullptr) :
+		sect(sect ),
+		block(block )
 	{}
 
 	bool operator<(const DistanceOrderedMapBlock &b) const
@@ -316,6 +316,10 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 	u32 saved_blocks_count = 0;
 	u32 block_count_all = 0;
 	u32 locked_blocks = 0;
+	u32 recently_drawn_blocks_skipped = 0;
+	u32 recently_drawn_blocks_dropped = 0;
+	u32 possibly_culled_blocks_skipped = 0;
+	u32 possibly_culled_blocks_dropped = 0;
 
 	const auto start_time = porting::getTimeUs();
 	beginSave();
@@ -366,7 +370,11 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 		}
 	} else {
 		std::priority_queue<TimeOrderedMapBlock> mapblock_queue;
-		std::priority_queue<DistanceOrderedMapBlock> mapblock_queue_d;
+		std::priority_queue<DistanceOrderedMapBlock> mapblock_queue_d_recently_drawn;
+		std::priority_queue<DistanceOrderedMapBlock> mapblock_queue_d_rest;
+		s32 overload_block_count = 0;
+		bool was_overload = false;
+		const float radiusSQ = g_settings->getFloat("viewing_range") * g_settings->getFloat("viewing_range");
 		for (auto &sector_it : m_sectors) {
 			MapSector *sector = sector_it.second;
 
@@ -375,18 +383,113 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 
 			for (MapBlock *block : blocks) {
 				block->incrementUsageTimer(dtime);
+				// no way if a block which is outside viewing range can be seen, also if it's recently drown makes no sense.
+				if (block->getPosRelative().getLengthSQ() > radiusSQ)
+					block->setIsRecentlyDrawn(false);
+				if (block->getIsRecentlyDrawn())
+				{
+					mapblock_queue_d_recently_drawn.push(DistanceOrderedMapBlock(sector, block));
+					mapblock_queue.push(TimeOrderedMapBlock(sector, block));
+					continue;
+				}
 				mapblock_queue.push(TimeOrderedMapBlock(sector, block));
+				mapblock_queue_d_rest.push(DistanceOrderedMapBlock(sector, block));
 			}
 
-			for (MapBlock *block : blocks) {
-				mapblock_queue_d.push(DistanceOrderedMapBlock(sector, block));
-			}
 		}
+		// todo: release recently drawn blocks only after all culled blocks have been released.
+		// is refGet()!=0 equals when the block is being drawn?
 		block_count_all = mapblock_queue.size();
-		const float radiusSQ = g_settings->getFloat("viewing_range") * g_settings->getFloat("viewing_range");
+		overload_block_count = (s32)block_count_all - max_loaded_blocks;
+		was_overload = overload_block_count > 0;
+		// execute block dumping by distance first if there's an overload of blocks.
+		// possibly culled blocks are dumped first, by distance.
+		while (overload_block_count > 0)
+		{
+			DistanceOrderedMapBlock b;
+			bool is_block_recently_drown;
+			if (!mapblock_queue_d_rest.empty())
+			{
+				b = mapblock_queue_d_rest.top();
+				mapblock_queue_d_rest.pop();
+			}
+			else
+			{
+				b = mapblock_queue_d_recently_drawn.top();
+				mapblock_queue_d_recently_drawn.pop();
+			}
+			MapBlock *block = b.block;
+			is_block_recently_drown = block->getIsRecentlyDrawn();
+			if (block->refGet() != 0)
+			{
+				locked_blocks++;
+				if (is_block_recently_drown)
+				{
+					recently_drawn_blocks_skipped++;
+				}
+				else
+				{
+					possibly_culled_blocks_skipped++;
+				}
+				continue;
+			}
+			v3s16 p = block->getPos();
+			// Save if modified
+			if (block->getModified() != MOD_STATE_CLEAN && save_before_unloading)
+			{
+				modprofiler.add(block->getModifiedReasonString(), 1);
+				if (!saveBlock(block))
+				{
+					if (is_block_recently_drown)
+					{
+						recently_drawn_blocks_skipped++;
+					}
+					else
+					{
+						possibly_culled_blocks_skipped++;
+					}
+					continue;
+				}
+				saved_blocks_count++;
+			}
+			if (is_block_recently_drown)
+			{
+				recently_drawn_blocks_dropped++;
+			}
+			else
+			{
+				possibly_culled_blocks_dropped++;
+			}
+			// Delete from memory
+			b.sect->deleteBlock(block);
 
-		// Delete old blocks, and blocks over the limit from the memory
-		while (!mapblock_queue.empty() && ((s32)mapblock_queue.size() > max_loaded_blocks || mapblock_queue.top().block->getUsageTimer() > unload_timeout && mapblock_queue.top().block->getPosRelative().getLengthSQ() > radiusSQ))
+			if (unloaded_blocks)
+				unloaded_blocks->push_back(p);
+
+			deleted_blocks_count++;
+			block_count_all--;
+			overload_block_count--;
+			continue;
+		}
+		// refresh the time ordered map block queue, for later use of timed block dumping.
+		if (was_overload)
+		{
+			std::priority_queue<TimeOrderedMapBlock> q;
+			while (!mapblock_queue_d_rest.empty())
+			{
+				q.push(TimeOrderedMapBlock(mapblock_queue_d_rest.top().sect, mapblock_queue_d_rest.top().block));
+				mapblock_queue_d_rest.pop();
+			}
+			while (!mapblock_queue_d_recently_drawn.empty())
+			{
+				q.push(TimeOrderedMapBlock(mapblock_queue_d_recently_drawn.top().sect, mapblock_queue_d_recently_drawn.top().block));
+				mapblock_queue_d_recently_drawn.pop();
+			}
+			mapblock_queue = q;
+		}
+
+		// Delete old blocks from the memory
+		while (mapblock_queue.top().block->getUsageTimer() > unload_timeout)
 		{
 			TimeOrderedMapBlock b = mapblock_queue.top();
 			mapblock_queue.pop();
@@ -416,6 +519,7 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 
 			deleted_blocks_count++;
 			block_count_all--;
+			overload_block_count--;
 		}
 
 		// Delete empty sectors
@@ -443,7 +547,12 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 			infostream<<", of which "<<saved_blocks_count<<" were written";
 		infostream<<", "<<block_count_all<<" blocks in memory, " << locked_blocks << " locked";
 		infostream<<"."<<std::endl;
-		if(saved_blocks_count != 0){
+		infostream << recently_drawn_blocks_dropped << " recently drown blocks unloaded by distance." << std::endl
+				   << recently_drawn_blocks_skipped << "skipped." << std::endl
+				   << possibly_culled_blocks_dropped << "possibly culled blocks unloaded by distance." << std::endl
+				   << possibly_culled_blocks_skipped << "skipped." << std::endl;
+		if (saved_blocks_count != 0)
+		{
 			PrintInfo(infostream); // ServerMap/ClientMap:
 			infostream<<"Blocks modified by: "<<std::endl;
 			modprofiler.print(infostream);

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -202,6 +202,28 @@ public:
 		}
 	}
 
+	inline bool getIsRecentlyDrawn()
+	{
+		return is_recently_drawn;
+	}
+
+	inline void setIsRecentlyDrawn(bool b)
+	{
+		if (b != is_recently_drawn)
+			is_recently_drawn = b;
+	}
+
+	inline bool getIsBeingDrawn()
+	{
+		return is_being_drawn;
+	}
+
+	inline void setIsBeingDrawn(bool b)
+	{
+		if (b != is_being_drawn)
+			is_being_drawn = b;
+	}
+
 	////
 	//// Position stuff
 	////
@@ -557,6 +579,18 @@ private:
 		caves.
 	*/
 	bool is_underground = false;
+
+	/*
+		When entering the draw list, this will be set to true.
+		It will be set to false again only when it fails the distance check.
+	*/
+	bool is_recently_drawn = false;
+
+	/*
+		When entering the draw list, this will be set to true.
+		It will be set to false again once it fails the draw check.
+	*/
+	bool is_being_drawn = false;
 
 public:
 	NodeMetadataList m_node_metadata;


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
- Fix #3075 
- How does the PR work?
- While the liquid block is rendering, add the top mesh to render. (Make it not skipped).
- Does it resolve any reported issue?
- #3075 
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
- IDK. Whatever you say.
- If not a bug fix, why is this PR needed? What usecases does it solve?
- This is a bug fix?

## To do

This PR is a Ready for Review.
<!-- ^ delete one -->

- [ ] List
- [ ] Things
- [ ] To do
- [ ] Make it follow the code format rule, and delete what is useless.

## How to test
See changes in the src, or compile and test. Any help commit for code format conventions is welcomed, for I'm really bad at it.
<!-- Example code or instructions -->
