### PR TITLE
Main menu formspec escape world name

### DIFF
--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -126,7 +126,7 @@ local function get_formspec(data)
 	local retval =
 		"size[11.5,7.5,true]" ..
 		"label[0.5,0;" .. fgettext("World:") .. "]" ..
-		"label[1.75,0;" .. data.worldspec.name .. "]"
+		"label[1.75,0;" .. core.formspec_escape(data.worldspec.name) .. "]"
 
 	if mod.is_modpack or mod.type == "game" then
 		local info = core.formspec_escape(


### PR DESCRIPTION
This PR fixes a bug which I noticed while naming a world `[test] world1`.
The word name currently does not get escaped, and thus the formspec is wrong.
Maybe this is also a security problem, if someone uses a problematic world name.

## To do

Ready for Review.

## How to test

- Start minetest and name a world e.g. `te]st`
- Select the world and press the `Select Mods` button
- See that on master the formspec displays `te` and not `te]st` for the world name, and check that his PR fixes it.
