### PR TITLE
Menu docs: clarify that images must be escaped to correctly render on Windows

### DIFF
--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -74,7 +74,7 @@ Filesystem
 To access specific subpaths, use `DIR_DELIM` as a directory delimiter instead
 of manually putting one, as different OSs use different delimiters. E.g.
 ```lua
-"my" .. DIR_DELIM .. "custom" .. DIR_DELIM .. "path"
+"my" .. DIR_DELIM .. "custom" .. DIR_DELIM .. "path" -- and not my/custom/path
 ```
 
 * `core.get_builtin_path()`

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -8,13 +8,13 @@ The main menu is defined as a formspec by Lua in `builtin/mainmenu/`
 Description of formspec language to show your menu is in `lua_api.md`
 
 
-Images
+Images and 3D models
 ------
 
 Directory delimiters change according to the OS (e.g. on Unix-like systems
-is `/`, on Windows is `\`). When putting an image inside a formspec, be sure
-to sanitize it first with `core.formspec_escape(img)`; otherwise, any image
-located in a subpath won't be displayed on OSs using `\` as delimiter.
+is `/`, on Windows is `\`). When putting an image or a 3D model inside a formspec,
+be sure to sanitize it first with `core.formspec_escape(img)`; otherwise,
+any resource located in a subpath won't be displayed on OSs using `\` as delimiter.
 
 
 Callbacks
@@ -70,6 +70,12 @@ Functions
 
 Filesystem
 ----------
+
+To access specific subpaths, use `DIR_DELIM` as a directory delimiter instead
+of manually putting one, as different OSs use different delimiters. E.g.
+```lua
+"my" .. DIR_DELIM .. "custom" .. DIR_DELIM .. "path"
+```
 
 * `core.get_builtin_path()`
   * returns path to builtin root

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -8,6 +8,15 @@ The main menu is defined as a formspec by Lua in `builtin/mainmenu/`
 Description of formspec language to show your menu is in `lua_api.md`
 
 
+Images
+------
+
+Directory delimiters change according to the OS (e.g. on Unix-like systems
+is `/`, on Windows is `\`). When putting an image inside a formspec, be sure
+to sanitize it first with `core.formspec_escape(img)`: otherwise, any image
+located in a subpath won't be displayed on OSs using `\` as delimiter.
+
+
 Callbacks
 ---------
 

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -13,7 +13,7 @@ Images
 
 Directory delimiters change according to the OS (e.g. on Unix-like systems
 is `/`, on Windows is `\`). When putting an image inside a formspec, be sure
-to sanitize it first with `core.formspec_escape(img)`: otherwise, any image
+to sanitize it first with `core.formspec_escape(img)`; otherwise, any image
 located in a subpath won't be displayed on OSs using `\` as delimiter.
 
 


### PR DESCRIPTION
I was pretty confused when a main menu of mine was rendering basically nothing on Windows, whilst perfectly displaying every picture on Linux. It took me a while to understand why, as I never use Windows ("understand" meaning "browsing MT main menu code after frustrating trial and errors")

## To do

This PR is Ready for Review.

## How to test
:eye: 
