### PR TITLE
Windows/vcpkg instructions: enable i18n by default

### DIFF
--- a/doc/compiling/windows.md
+++ b/doc/compiling/windows.md
@@ -52,7 +52,7 @@ Use `--triplet` to specify the target triplet, e.g. `x64-windows` or `x86-window
 Run the following script in PowerShell:
 
 ```powershell
-cmake . -G"Visual Studio 15 2017 Win64" -DCMAKE_TOOLCHAIN_FILE=D:/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_GETTEXT=OFF -DENABLE_CURSES=OFF
+cmake . -G"Visual Studio 15 2017 Win64" -DCMAKE_TOOLCHAIN_FILE=D:/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_CURSES=OFF
 cmake --build . --config Release
 ```
 Make sure that the right compiler is selected and the path to the vcpkg toolchain is correct.

--- a/doc/compiling/windows.md
+++ b/doc/compiling/windows.md
@@ -52,7 +52,7 @@ Use `--triplet` to specify the target triplet, e.g. `x64-windows` or `x86-window
 Run the following script in PowerShell:
 
 ```powershell
-cmake . -G"Visual Studio 15 2017 Win64" -DCMAKE_TOOLCHAIN_FILE=D:/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_CURSES=OFF
+cmake . -G"Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE=D:/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_CURSES=OFF
 cmake --build . --config Release
 ```
 Make sure that the right compiler is selected and the path to the vcpkg toolchain is correct.

--- a/doc/compiling/windows.md
+++ b/doc/compiling/windows.md
@@ -14,7 +14,7 @@ It is highly recommended to use vcpkg as package manager.
 
 After you successfully built vcpkg you can easily install the required libraries:
 ```powershell
-vcpkg install zlib zstd curl[winssl] openal-soft libvorbis libogg libjpeg-turbo sqlite3 freetype luajit gmp jsoncpp gettext sdl2 --triplet x64-windows
+vcpkg install zlib zstd curl[winssl] openal-soft libvorbis libogg libjpeg-turbo sqlite3 freetype luajit gmp jsoncpp gettext[tools] sdl2 --triplet x64-windows
 ```
 
 - `curl` is optional, but required to read the serverlist, `curl[winssl]` is required to use the content store.


### PR DESCRIPTION
I have no idea why gettext wasn't enabled by default on Windows; in fact, building resulted in a version not supporting internationalisation of any kind. The first commit where the whole powershell line appears (`-DENABLE_GETTEXT=OFF` included) is from 5 years ago, so.. :woman_shrugging: 

Setting the flag to `TRUE` fixes it, which is `TRUE` by default if the client is built, according to https://github.com/minetest/minetest/blob/1298d6c0206a964f4f5cb5a94b8463340c7dbbf4/src/CMakeLists.txt#L93

## To do

This PR is Ready for Review.

## How to test
Two options:
1. Either..
  * Have fun trying compiling on Windows by setting up vcpkg yourself
  * Compile and check
 
or

2. Trust me
