### PR TITLE
[no squash] Ability to handle vertex and index VBOs separately

### DIFF
--- a/irr/include/CIndexBuffer.h
+++ b/irr/include/CIndexBuffer.h
@@ -13,7 +13,7 @@ namespace scene
 {
 //! Template implementation of the IIndexBuffer interface
 template <class T>
-class CIndexBuffer : public IIndexBuffer
+class CIndexBuffer final : public IIndexBuffer
 {
 public:
 	//! Default constructor for empty buffer

--- a/irr/include/CIndexBuffer.h
+++ b/irr/include/CIndexBuffer.h
@@ -24,7 +24,7 @@ public:
 #endif
 	}
 
-	video::E_INDEX_TYPE getType() const
+	video::E_INDEX_TYPE getType() const override
 	{
 		static_assert(sizeof(T) == 2 || sizeof(T) == 4, "invalid index type");
 		return sizeof(T) == 2 ? video::EIT_16BIT : video::EIT_32BIT;

--- a/irr/include/CIndexBuffer.h
+++ b/irr/include/CIndexBuffer.h
@@ -1,0 +1,89 @@
+// Copyright (C) 2002-2012 Nikolaus Gebhardt
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#pragma once
+
+#include <vector>
+#include "IIndexBuffer.h"
+
+namespace irr
+{
+namespace scene
+{
+//! Template implementation of the IIndexBuffer interface
+template <class T>
+class CIndexBuffer : public IIndexBuffer
+{
+public:
+	//! Default constructor for empty buffer
+	CIndexBuffer()
+	{
+#ifdef _DEBUG
+		setDebugName("CIndexBuffer");
+#endif
+	}
+
+	video::E_INDEX_TYPE getType() const
+	{
+		static_assert(sizeof(T) == 2 || sizeof(T) == 4, "invalid index type");
+		return sizeof(T) == 2 ? video::EIT_16BIT : video::EIT_32BIT;
+	}
+
+	const void *getData() const override
+	{
+		return Data.data();
+	}
+
+	void *getData() override
+	{
+		return Data.data();
+	}
+
+	u32 getCount() const override
+	{
+		return static_cast<u32>(Data.size());
+	}
+
+	E_HARDWARE_MAPPING getHardwareMappingHint() const override
+	{
+		return MappingHint;
+	}
+
+	void setHardwareMappingHint(E_HARDWARE_MAPPING NewMappingHint) override
+	{
+		MappingHint = NewMappingHint;
+	}
+
+	void setDirty() override
+	{
+		++ChangedID;
+	}
+
+	u32 getChangedID() const override { return ChangedID; }
+
+	void setHWBuffer(void *ptr) const override
+	{
+		HWBuffer = ptr;
+	}
+
+	void *getHWBuffer() const override
+	{
+		return HWBuffer;
+	}
+
+	u32 ChangedID = 1;
+
+	//! hardware mapping hint
+	E_HARDWARE_MAPPING MappingHint = EHM_NEVER;
+	mutable void *HWBuffer = nullptr;
+
+	//! Indices of this buffer
+	std::vector<T> Data;
+};
+
+//! Standard 16-bit buffer
+typedef CIndexBuffer<u16> SIndexBuffer;
+
+} // end namespace scene
+} // end namespace irr

--- a/irr/include/CMeshBuffer.h
+++ b/irr/include/CMeshBuffer.h
@@ -15,7 +15,7 @@ namespace scene
 {
 //! Template implementation of the IMeshBuffer interface
 template <class T>
-class CMeshBuffer : public IMeshBuffer
+class CMeshBuffer final : public IMeshBuffer
 {
 public:
 	//! Default constructor for empty meshbuffer

--- a/irr/include/CMeshBuffer.h
+++ b/irr/include/CMeshBuffer.h
@@ -49,59 +49,30 @@ public:
 		return Material;
 	}
 
-	//! Get pointer to vertices
-	/** \return Pointer to vertices. */
-	const void *getVertices() const override
+	const scene::IVertexBuffer *getVertexBuffer() const override
 	{
-		return Vertices->getData();
+		return Vertices;
 	}
 
-	//! Get pointer to vertices
-	/** \return Pointer to vertices. */
-	void *getVertices() override
+	scene::IVertexBuffer *getVertexBuffer() override
 	{
-		return Vertices->getData();
+		return Vertices;
 	}
 
-	//! Get number of vertices
-	/** \return Number of vertices. */
-	u32 getVertexCount() const override
+	const scene::IIndexBuffer *getIndexBuffer() const override
 	{
-		return Vertices->getCount();
+		return Indices;
+	}
+
+	scene::IIndexBuffer *getIndexBuffer() override
+	{
+		return Indices;
 	}
 
 	// TEMPORARY helper for direct buffer acess
 	inline auto &VertexBuffer()
 	{
 		return Vertices->Data;
-	}
-
-	//! Get type of index data which is stored in this meshbuffer.
-	/** \return Index type of this buffer. */
-	video::E_INDEX_TYPE getIndexType() const override
-	{
-		return Indices->getType();
-	}
-
-	//! Get pointer to indices
-	/** \return Pointer to indices. */
-	const u16 *getIndices() const override
-	{
-		return static_cast<const u16*>(Indices->getData());
-	}
-
-	//! Get pointer to indices
-	/** \return Pointer to indices. */
-	u16 *getIndices() override
-	{
-		return static_cast<u16*>(Indices->getData());
-	}
-
-	//! Get number of indices
-	/** \return Number of indices. */
-	u32 getIndexCount() const override
-	{
-		return Indices->getCount();
 	}
 
 	// TEMPORARY helper for direct buffer acess
@@ -138,49 +109,6 @@ public:
 			BoundingBox.reset(0, 0, 0);
 	}
 
-	//! Get type of vertex data stored in this buffer.
-	/** \return Type of vertex data. */
-	video::E_VERTEX_TYPE getVertexType() const override
-	{
-		return Vertices->getType();
-	}
-
-	//! returns position of vertex i
-	const core::vector3df &getPosition(u32 i) const override
-	{
-		return Vertices->getPosition(i);
-	}
-
-	//! returns position of vertex i
-	core::vector3df &getPosition(u32 i) override
-	{
-		return Vertices->getPosition(i);
-	}
-
-	//! returns normal of vertex i
-	const core::vector3df &getNormal(u32 i) const override
-	{
-		return Vertices->getNormal(i);
-	}
-
-	//! returns normal of vertex i
-	core::vector3df &getNormal(u32 i) override
-	{
-		return Vertices->getNormal(i);
-	}
-
-	//! returns texture coord of vertex i
-	const core::vector2df &getTCoords(u32 i) const override
-	{
-		return Vertices->getTCoords(i);
-	}
-
-	//! returns texture coord of vertex i
-	core::vector2df &getTCoords(u32 i) override
-	{
-		return Vertices->getTCoords(i);
-	}
-
 	//! Append the vertices and indices to the current buffer
 	void append(const void *const vertices, u32 numVertices, const u16 *const indices, u32 numIndices) override
 	{
@@ -202,27 +130,6 @@ public:
 		}
 	}
 
-	//! get the current hardware mapping hint
-	E_HARDWARE_MAPPING getHardwareMappingHint_Vertex() const override
-	{
-		return Vertices->getHardwareMappingHint();
-	}
-
-	//! get the current hardware mapping hint
-	E_HARDWARE_MAPPING getHardwareMappingHint_Index() const override
-	{
-		return Indices->getHardwareMappingHint();
-	}
-
-	//! set the hardware mapping hint, for driver
-	void setHardwareMappingHint(E_HARDWARE_MAPPING NewMappingHint, E_BUFFER_TYPE Buffer = EBT_VERTEX_AND_INDEX) override
-	{
-		if (Buffer == EBT_VERTEX_AND_INDEX || Buffer == EBT_VERTEX)
-			Vertices->setHardwareMappingHint(NewMappingHint);
-		if (Buffer == EBT_VERTEX_AND_INDEX || Buffer == EBT_INDEX)
-			Indices->setHardwareMappingHint(NewMappingHint);
-	}
-
 	//! Describe what kind of primitive geometry is used by the meshbuffer
 	void setPrimitiveType(E_PRIMITIVE_TYPE type) override
 	{
@@ -234,23 +141,6 @@ public:
 	{
 		return PrimitiveType;
 	}
-
-	//! flags the mesh as changed, reloads hardware buffers
-	void setDirty(E_BUFFER_TYPE Buffer = EBT_VERTEX_AND_INDEX) override
-	{
-		if (Buffer == EBT_VERTEX_AND_INDEX || Buffer == EBT_VERTEX)
-			Vertices->setDirty();
-		if (Buffer == EBT_VERTEX_AND_INDEX || Buffer == EBT_INDEX)
-			Indices->setDirty();
-	}
-
-	//! Get the currently used ID for identification of changes.
-	/** This shouldn't be used for anything outside the VideoDriver. */
-	u32 getChangedID_Vertex() const override { return Vertices->getChangedID(); }
-
-	//! Get the currently used ID for identification of changes.
-	/** This shouldn't be used for anything outside the VideoDriver. */
-	u32 getChangedID_Index() const override { return Indices->getChangedID(); }
 
 	void setHWBuffer(void *ptr) const override
 	{

--- a/irr/include/CMeshBuffer.h
+++ b/irr/include/CMeshBuffer.h
@@ -20,7 +20,7 @@ class CMeshBuffer : public IMeshBuffer
 public:
 	//! Default constructor for empty meshbuffer
 	CMeshBuffer() :
-			HWBuffer(NULL), PrimitiveType(EPT_TRIANGLES)
+			PrimitiveType(EPT_TRIANGLES)
 	{
 #ifdef _DEBUG
 		setDebugName("CMeshBuffer");
@@ -67,18 +67,6 @@ public:
 	scene::IIndexBuffer *getIndexBuffer() override
 	{
 		return Indices;
-	}
-
-	// TEMPORARY helper for direct buffer acess
-	inline auto &VertexBuffer()
-	{
-		return Vertices->Data;
-	}
-
-	// TEMPORARY helper for direct buffer acess
-	inline auto &IndexBuffer()
-	{
-		return Indices->Data;
 	}
 
 	//! Get the axis aligned bounding box
@@ -141,18 +129,6 @@ public:
 	{
 		return PrimitiveType;
 	}
-
-	void setHWBuffer(void *ptr) const override
-	{
-		HWBuffer = ptr;
-	}
-
-	void *getHWBuffer() const override
-	{
-		return HWBuffer;
-	}
-
-	mutable void *HWBuffer;
 
 	//! Material for this meshbuffer.
 	video::SMaterial Material;

--- a/irr/include/CVertexBuffer.h
+++ b/irr/include/CVertexBuffer.h
@@ -1,0 +1,122 @@
+// Copyright (C) 2002-2012 Nikolaus Gebhardt
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#pragma once
+
+#include <vector>
+#include "IVertexBuffer.h"
+
+namespace irr
+{
+namespace scene
+{
+//! Template implementation of the IVertexBuffer interface
+template <class T>
+class CVertexBuffer : public IVertexBuffer
+{
+public:
+	//! Default constructor for empty buffer
+	CVertexBuffer()
+	{
+#ifdef _DEBUG
+		setDebugName("CVertexBuffer");
+#endif
+	}
+
+	const void *getData() const override
+	{
+		return Data.data();
+	}
+
+	void *getData() override
+	{
+		return Data.data();
+	}
+
+	u32 getCount() const override
+	{
+		return static_cast<u32>(Data.size());
+	}
+
+	video::E_VERTEX_TYPE getType() const override
+	{
+		return T::getType();
+	}
+
+	const core::vector3df &getPosition(u32 i) const override
+	{
+		return Data[i].Pos;
+	}
+
+	core::vector3df &getPosition(u32 i) override
+	{
+		return Data[i].Pos;
+	}
+
+	const core::vector3df &getNormal(u32 i) const override
+	{
+		return Data[i].Normal;
+	}
+
+	core::vector3df &getNormal(u32 i) override
+	{
+		return Data[i].Normal;
+	}
+
+	const core::vector2df &getTCoords(u32 i) const override
+	{
+		return Data[i].TCoords;
+	}
+
+	core::vector2df &getTCoords(u32 i) override
+	{
+		return Data[i].TCoords;
+	}
+
+	E_HARDWARE_MAPPING getHardwareMappingHint() const override
+	{
+		return MappingHint;
+	}
+
+	void setHardwareMappingHint(E_HARDWARE_MAPPING NewMappingHint) override
+	{
+		MappingHint = NewMappingHint;
+	}
+
+	void setDirty() override
+	{
+		++ChangedID;
+	}
+
+	u32 getChangedID() const override { return ChangedID; }
+
+	void setHWBuffer(void *ptr) const override
+	{
+		HWBuffer = ptr;
+	}
+
+	void *getHWBuffer() const override
+	{
+		return HWBuffer;
+	}
+
+	u32 ChangedID = 1;
+
+	//! hardware mapping hint
+	E_HARDWARE_MAPPING MappingHint = EHM_NEVER;
+	mutable void *HWBuffer = nullptr;
+
+	//! Vertices of this buffer
+	std::vector<T> Data;
+};
+
+//! Standard buffer
+typedef CVertexBuffer<video::S3DVertex> SVertexBuffer;
+//! Buffer with two texture coords per vertex, e.g. for lightmaps
+typedef CVertexBuffer<video::S3DVertex2TCoords> SVertexBufferLightMap;
+//! Buffer with vertices having tangents stored, e.g. for normal mapping
+typedef CVertexBuffer<video::S3DVertexTangents> SVertexBufferTangents;
+
+} // end namespace scene
+} // end namespace irr

--- a/irr/include/CVertexBuffer.h
+++ b/irr/include/CVertexBuffer.h
@@ -13,7 +13,7 @@ namespace scene
 {
 //! Template implementation of the IVertexBuffer interface
 template <class T>
-class CVertexBuffer : public IVertexBuffer
+class CVertexBuffer final : public IVertexBuffer
 {
 public:
 	//! Default constructor for empty buffer

--- a/irr/include/IIndexBuffer.h
+++ b/irr/include/IIndexBuffer.h
@@ -7,6 +7,7 @@
 #include "IReferenceCounted.h"
 #include "irrArray.h"
 #include "EHardwareBufferFlags.h"
+#include "EPrimitiveTypes.h"
 #include "SVertexIndex.h"
 
 namespace irr
@@ -50,6 +51,31 @@ public:
 	//! Used by the VideoDriver to remember the buffer link.
 	virtual void setHWBuffer(void *ptr) const = 0;
 	virtual void *getHWBuffer() const = 0;
+
+	//! Calculate how many geometric primitives would be drawn
+	u32 getPrimitiveCount(E_PRIMITIVE_TYPE primitiveType) const
+	{
+		const u32 indexCount = getCount();
+		switch (primitiveType) {
+		case scene::EPT_POINTS:
+			return indexCount;
+		case scene::EPT_LINE_STRIP:
+			return indexCount - 1;
+		case scene::EPT_LINE_LOOP:
+			return indexCount;
+		case scene::EPT_LINES:
+			return indexCount / 2;
+		case scene::EPT_TRIANGLE_STRIP:
+			return (indexCount - 2);
+		case scene::EPT_TRIANGLE_FAN:
+			return (indexCount - 2);
+		case scene::EPT_TRIANGLES:
+			return indexCount / 3;
+		case scene::EPT_POINT_SPRITES:
+			return indexCount;
+		}
+		return 0;
+	}
 };
 
 } // end namespace scene

--- a/irr/include/IIndexBuffer.h
+++ b/irr/include/IIndexBuffer.h
@@ -12,40 +12,33 @@
 namespace irr
 {
 
-namespace video
-{
-
-}
-
 namespace scene
 {
 
 class IIndexBuffer : public virtual IReferenceCounted
 {
 public:
+	//! Get type of index data which is stored in this meshbuffer.
+	/** \return Index type of this buffer. */
+	virtual video::E_INDEX_TYPE getType() const = 0;
+
+	//! Get access to indices.
+	/** \return Pointer to indices array. */
+	virtual const void *getData() const = 0;
+
+	//! Get access to indices.
+	/** \return Pointer to indices array. */
 	virtual void *getData() = 0;
 
-	virtual video::E_INDEX_TYPE getType() const = 0;
-	virtual void setType(video::E_INDEX_TYPE IndexType) = 0;
-
-	virtual u32 stride() const = 0;
-
-	virtual u32 size() const = 0;
-	virtual void push_back(const u32 &element) = 0;
-	virtual u32 operator[](u32 index) const = 0;
-	virtual u32 getLast() = 0;
-	virtual void setValue(u32 index, u32 value) = 0;
-	virtual void set_used(u32 usedNow) = 0;
-	virtual void reallocate(u32 new_size) = 0;
-	virtual u32 allocated_size() const = 0;
-
-	virtual void *pointer() = 0;
+	//! Get amount of indices in this meshbuffer.
+	/** \return Number of indices in this buffer. */
+	virtual u32 getCount() const = 0;
 
 	//! get the current hardware mapping hint
 	virtual E_HARDWARE_MAPPING getHardwareMappingHint() const = 0;
 
 	//! set the hardware mapping hint, for driver
-	virtual void setHardwareMappingHint(E_HARDWARE_MAPPING NewMappingHint) = 0;
+	virtual void setHardwareMappingHint(E_HARDWARE_MAPPING newMappingHint) = 0;
 
 	//! flags the meshbuffer as changed, reloads hardware buffers
 	virtual void setDirty() = 0;
@@ -53,6 +46,10 @@ public:
 	//! Get the currently used ID for identification of changes.
 	/** This shouldn't be used for anything outside the VideoDriver. */
 	virtual u32 getChangedID() const = 0;
+
+	//! Used by the VideoDriver to remember the buffer link.
+	virtual void setHWBuffer(void *ptr) const = 0;
+	virtual void *getHWBuffer() const = 0;
 };
 
 } // end namespace scene

--- a/irr/include/IMeshBuffer.h
+++ b/irr/include/IMeshBuffer.h
@@ -176,18 +176,6 @@ public:
 		return getVertexBuffer()->getTCoords(i);
 	}
 
-	//! get the current hardware mapping hint
-	inline E_HARDWARE_MAPPING getHardwareMappingHint_Vertex() const
-	{
-		return getVertexBuffer()->getHardwareMappingHint();
-	}
-
-	//! get the current hardware mapping hint
-	inline E_HARDWARE_MAPPING getHardwareMappingHint_Index() const
-	{
-		return getIndexBuffer()->getHardwareMappingHint();
-	}
-
 	//! set the hardware mapping hint, for driver
 	inline void setHardwareMappingHint(E_HARDWARE_MAPPING newMappingHint, E_BUFFER_TYPE buffer = EBT_VERTEX_AND_INDEX)
 	{
@@ -206,25 +194,7 @@ public:
 			getIndexBuffer()->setDirty();
 	}
 
-	//! Get the currently used ID for identification of changes.
-	/** This shouldn't be used for anything outside the VideoDriver. */
-	inline u32 getChangedID_Vertex() const
-	{
-		return getVertexBuffer()->getChangedID();
-	}
-
-	//! Get the currently used ID for identification of changes.
-	/** This shouldn't be used for anything outside the VideoDriver. */
-	inline u32 getChangedID_Index() const
-	{
-		return getIndexBuffer()->getChangedID();
-	}
-
 	/* End helpers */
-
-	//! Used by the VideoDriver to remember the buffer link.
-	virtual void setHWBuffer(void *ptr) const = 0;
-	virtual void *getHWBuffer() const = 0;
 
 	//! Describe what kind of primitive geometry is used by the meshbuffer
 	/** Note: Default is EPT_TRIANGLES. Using other types is fine for rendering.
@@ -237,32 +207,13 @@ public:
 	virtual E_PRIMITIVE_TYPE getPrimitiveType() const = 0;
 
 	//! Calculate how many geometric primitives are used by this meshbuffer
-	virtual u32 getPrimitiveCount() const
+	u32 getPrimitiveCount() const
 	{
-		const u32 indexCount = getIndexCount();
-		switch (getPrimitiveType()) {
-		case scene::EPT_POINTS:
-			return indexCount;
-		case scene::EPT_LINE_STRIP:
-			return indexCount - 1;
-		case scene::EPT_LINE_LOOP:
-			return indexCount;
-		case scene::EPT_LINES:
-			return indexCount / 2;
-		case scene::EPT_TRIANGLE_STRIP:
-			return (indexCount - 2);
-		case scene::EPT_TRIANGLE_FAN:
-			return (indexCount - 2);
-		case scene::EPT_TRIANGLES:
-			return indexCount / 3;
-		case scene::EPT_POINT_SPRITES:
-			return indexCount;
-		}
-		return 0;
+		return getIndexBuffer()->getPrimitiveCount(getPrimitiveType());
 	}
 
 	//! Calculate size of vertices and indices in memory
-	virtual size_t getSize() const
+	size_t getSize() const
 	{
 		size_t ret = 0;
 		switch (getVertexType()) {

--- a/irr/include/IMeshBuffer.h
+++ b/irr/include/IMeshBuffer.h
@@ -7,8 +7,8 @@
 #include "IReferenceCounted.h"
 #include "SMaterial.h"
 #include "aabbox3d.h"
-#include "S3DVertex.h"
-#include "SVertexIndex.h"
+#include "IVertexBuffer.h"
+#include "IIndexBuffer.h"
 #include "EHardwareBufferFlags.h"
 #include "EPrimitiveTypes.h"
 
@@ -46,39 +46,17 @@ public:
 	/** \return Material of this buffer. */
 	virtual const video::SMaterial &getMaterial() const = 0;
 
-	//! Get type of vertex data which is stored in this meshbuffer.
-	/** \return Vertex type of this buffer. */
-	virtual video::E_VERTEX_TYPE getVertexType() const = 0;
+	/// Get the vertex buffer
+	virtual const scene::IVertexBuffer *getVertexBuffer() const = 0;
 
-	//! Get access to vertex data. The data is an array of vertices.
-	/** Which vertex type is used can be determined by getVertexType().
-	\return Pointer to array of vertices. */
-	virtual const void *getVertices() const = 0;
+	/// Get the vertex buffer
+	virtual scene::IVertexBuffer *getVertexBuffer() = 0;
 
-	//! Get access to vertex data. The data is an array of vertices.
-	/** Which vertex type is used can be determined by getVertexType().
-	\return Pointer to array of vertices. */
-	virtual void *getVertices() = 0;
+	/// Get the index buffer
+	virtual const scene::IIndexBuffer *getIndexBuffer() const = 0;
 
-	//! Get amount of vertices in meshbuffer.
-	/** \return Number of vertices in this buffer. */
-	virtual u32 getVertexCount() const = 0;
-
-	//! Get type of index data which is stored in this meshbuffer.
-	/** \return Index type of this buffer. */
-	virtual video::E_INDEX_TYPE getIndexType() const = 0;
-
-	//! Get access to indices.
-	/** \return Pointer to indices array. */
-	virtual const u16 *getIndices() const = 0;
-
-	//! Get access to indices.
-	/** \return Pointer to indices array. */
-	virtual u16 *getIndices() = 0;
-
-	//! Get amount of indices in this meshbuffer.
-	/** \return Number of indices in this buffer. */
-	virtual u32 getIndexCount() const = 0;
+	/// Get the index buffer
+	virtual scene::IIndexBuffer *getIndexBuffer() = 0;
 
 	//! Get the axis aligned bounding box of this meshbuffer.
 	/** \return Axis aligned bounding box of this buffer. */
@@ -92,24 +70,6 @@ public:
 	//! Recalculates the bounding box. Should be called if the mesh changed.
 	virtual void recalculateBoundingBox() = 0;
 
-	//! returns position of vertex i
-	virtual const core::vector3df &getPosition(u32 i) const = 0;
-
-	//! returns position of vertex i
-	virtual core::vector3df &getPosition(u32 i) = 0;
-
-	//! returns normal of vertex i
-	virtual const core::vector3df &getNormal(u32 i) const = 0;
-
-	//! returns normal of vertex i
-	virtual core::vector3df &getNormal(u32 i) = 0;
-
-	//! returns texture coord of vertex i
-	virtual const core::vector2df &getTCoords(u32 i) const = 0;
-
-	//! returns texture coord of vertex i
-	virtual core::vector2df &getTCoords(u32 i) = 0;
-
 	//! Append the vertices and indices to the current buffer
 	/** Only works for compatible vertex types.
 	\param vertices Pointer to a vertex array.
@@ -118,25 +78,149 @@ public:
 	\param numIndices Number of indices in array. */
 	virtual void append(const void *const vertices, u32 numVertices, const u16 *const indices, u32 numIndices) = 0;
 
-	//! get the current hardware mapping hint
-	virtual E_HARDWARE_MAPPING getHardwareMappingHint_Vertex() const = 0;
+	/* Leftover functions that are now just helpers for accessing the respective buffer. */
+
+	//! Get type of vertex data which is stored in this meshbuffer.
+	/** \return Vertex type of this buffer. */
+	inline video::E_VERTEX_TYPE getVertexType() const
+	{
+		return getVertexBuffer()->getType();
+	}
+
+	//! Get access to vertex data. The data is an array of vertices.
+	/** Which vertex type is used can be determined by getVertexType().
+	\return Pointer to array of vertices. */
+	inline const void *getVertices() const
+	{
+		return getVertexBuffer()->getData();
+	}
+
+	//! Get access to vertex data. The data is an array of vertices.
+	/** Which vertex type is used can be determined by getVertexType().
+	\return Pointer to array of vertices. */
+	inline void *getVertices()
+	{
+		return getVertexBuffer()->getData();
+	}
+
+	//! Get amount of vertices in meshbuffer.
+	/** \return Number of vertices in this buffer. */
+	inline u32 getVertexCount() const
+	{
+		return getVertexBuffer()->getCount();
+	}
+
+	//! Get type of index data which is stored in this meshbuffer.
+	/** \return Index type of this buffer. */
+	inline video::E_INDEX_TYPE getIndexType() const
+	{
+		return getIndexBuffer()->getType();
+	}
+
+	//! Get access to indices.
+	/** \return Pointer to indices array. */
+	inline const u16 *getIndices() const
+	{
+		_IRR_DEBUG_BREAK_IF(getIndexBuffer()->getType() != video::EIT_16BIT);
+		return static_cast<const u16*>(getIndexBuffer()->getData());
+	}
+
+	//! Get access to indices.
+	/** \return Pointer to indices array. */
+	inline u16 *getIndices()
+	{
+		_IRR_DEBUG_BREAK_IF(getIndexBuffer()->getType() != video::EIT_16BIT);
+		return static_cast<u16*>(getIndexBuffer()->getData());
+	}
+
+	//! Get amount of indices in this meshbuffer.
+	/** \return Number of indices in this buffer. */
+	inline u32 getIndexCount() const
+	{
+		return getIndexBuffer()->getCount();
+	}
+
+	//! returns position of vertex i
+	inline const core::vector3df &getPosition(u32 i) const
+	{
+		return getVertexBuffer()->getPosition(i);
+	}
+
+	//! returns position of vertex i
+	inline core::vector3df &getPosition(u32 i)
+	{
+		return getVertexBuffer()->getPosition(i);
+	}
+
+	//! returns normal of vertex i
+	inline const core::vector3df &getNormal(u32 i) const
+	{
+		return getVertexBuffer()->getNormal(i);
+	}
+
+	//! returns normal of vertex i
+	inline core::vector3df &getNormal(u32 i)
+	{
+		return getVertexBuffer()->getNormal(i);
+	}
+
+	//! returns texture coord of vertex i
+	inline const core::vector2df &getTCoords(u32 i) const
+	{
+		return getVertexBuffer()->getTCoords(i);
+	}
+
+	//! returns texture coord of vertex i
+	inline core::vector2df &getTCoords(u32 i)
+	{
+		return getVertexBuffer()->getTCoords(i);
+	}
 
 	//! get the current hardware mapping hint
-	virtual E_HARDWARE_MAPPING getHardwareMappingHint_Index() const = 0;
+	inline E_HARDWARE_MAPPING getHardwareMappingHint_Vertex() const
+	{
+		return getVertexBuffer()->getHardwareMappingHint();
+	}
+
+	//! get the current hardware mapping hint
+	inline E_HARDWARE_MAPPING getHardwareMappingHint_Index() const
+	{
+		return getIndexBuffer()->getHardwareMappingHint();
+	}
 
 	//! set the hardware mapping hint, for driver
-	virtual void setHardwareMappingHint(E_HARDWARE_MAPPING newMappingHint, E_BUFFER_TYPE buffer = EBT_VERTEX_AND_INDEX) = 0;
+	inline void setHardwareMappingHint(E_HARDWARE_MAPPING newMappingHint, E_BUFFER_TYPE buffer = EBT_VERTEX_AND_INDEX)
+	{
+		if (buffer == EBT_VERTEX_AND_INDEX || buffer == EBT_VERTEX)
+			getVertexBuffer()->setHardwareMappingHint(newMappingHint);
+		if (buffer == EBT_VERTEX_AND_INDEX || buffer == EBT_INDEX)
+			getIndexBuffer()->setHardwareMappingHint(newMappingHint);
+	}
 
 	//! flags the meshbuffer as changed, reloads hardware buffers
-	virtual void setDirty(E_BUFFER_TYPE buffer = EBT_VERTEX_AND_INDEX) = 0;
+	inline void setDirty(E_BUFFER_TYPE buffer = EBT_VERTEX_AND_INDEX)
+	{
+		if (buffer == EBT_VERTEX_AND_INDEX || buffer == EBT_VERTEX)
+			getVertexBuffer()->setDirty();
+		if (buffer == EBT_VERTEX_AND_INDEX || buffer == EBT_INDEX)
+			getIndexBuffer()->setDirty();
+	}
 
 	//! Get the currently used ID for identification of changes.
 	/** This shouldn't be used for anything outside the VideoDriver. */
-	virtual u32 getChangedID_Vertex() const = 0;
+	inline u32 getChangedID_Vertex() const
+	{
+		return getVertexBuffer()->getChangedID();
+	}
 
 	//! Get the currently used ID for identification of changes.
 	/** This shouldn't be used for anything outside the VideoDriver. */
-	virtual u32 getChangedID_Index() const = 0;
+	inline u32 getChangedID_Index() const
+	{
+		return getIndexBuffer()->getChangedID();
+	}
+
+	/* End helpers */
 
 	//! Used by the VideoDriver to remember the buffer link.
 	virtual void setHWBuffer(void *ptr) const = 0;

--- a/irr/include/IReferenceCounted.h
+++ b/irr/include/IReferenceCounted.h
@@ -51,6 +51,10 @@ public:
 	{
 	}
 
+	// Reference counted objects can be neither copied nor moved.
+	IReferenceCounted(const IReferenceCounted &) = delete;
+	IReferenceCounted &operator=(const IReferenceCounted &) = delete;
+
 	//! Grabs the object. Increments the reference counter by one.
 	/** Someone who calls grab() to an object, should later also
 	call drop() to it. If an object never gets as much drop() as

--- a/irr/include/IVertexBuffer.h
+++ b/irr/include/IVertexBuffer.h
@@ -17,24 +17,47 @@ namespace scene
 class IVertexBuffer : public virtual IReferenceCounted
 {
 public:
-	virtual void *getData() = 0;
+	//! Get type of vertex data which is stored in this meshbuffer.
+	/** \return Vertex type of this buffer. */
 	virtual video::E_VERTEX_TYPE getType() const = 0;
-	virtual void setType(video::E_VERTEX_TYPE vertexType) = 0;
-	virtual u32 stride() const = 0;
-	virtual u32 size() const = 0;
-	virtual void push_back(const video::S3DVertex &element) = 0;
-	virtual video::S3DVertex &operator[](const u32 index) const = 0;
-	virtual video::S3DVertex &getLast() = 0;
-	virtual void set_used(u32 usedNow) = 0;
-	virtual void reallocate(u32 new_size) = 0;
-	virtual u32 allocated_size() const = 0;
-	virtual video::S3DVertex *pointer() = 0;
+
+	//! Get access to vertex data. The data is an array of vertices.
+	/** Which vertex type is used can be determined by getVertexType().
+	\return Pointer to array of vertices. */
+	virtual const void *getData() const = 0;
+
+	//! Get access to vertex data. The data is an array of vertices.
+	/** Which vertex type is used can be determined by getVertexType().
+	\return Pointer to array of vertices. */
+	virtual void *getData() = 0;
+
+	//! Get amount of vertices in meshbuffer.
+	/** \return Number of vertices in this buffer. */
+	virtual u32 getCount() const = 0;
+
+	//! returns position of vertex i
+	virtual const core::vector3df &getPosition(u32 i) const = 0;
+
+	//! returns position of vertex i
+	virtual core::vector3df &getPosition(u32 i) = 0;
+
+	//! returns normal of vertex i
+	virtual const core::vector3df &getNormal(u32 i) const = 0;
+
+	//! returns normal of vertex i
+	virtual core::vector3df &getNormal(u32 i) = 0;
+
+	//! returns texture coord of vertex i
+	virtual const core::vector2df &getTCoords(u32 i) const = 0;
+
+	//! returns texture coord of vertex i
+	virtual core::vector2df &getTCoords(u32 i) = 0;
 
 	//! get the current hardware mapping hint
 	virtual E_HARDWARE_MAPPING getHardwareMappingHint() const = 0;
 
 	//! set the hardware mapping hint, for driver
-	virtual void setHardwareMappingHint(E_HARDWARE_MAPPING NewMappingHint) = 0;
+	virtual void setHardwareMappingHint(E_HARDWARE_MAPPING newMappingHint) = 0;
 
 	//! flags the meshbuffer as changed, reloads hardware buffers
 	virtual void setDirty() = 0;
@@ -42,6 +65,10 @@ public:
 	//! Get the currently used ID for identification of changes.
 	/** This shouldn't be used for anything outside the VideoDriver. */
 	virtual u32 getChangedID() const = 0;
+
+	//! Used by the VideoDriver to remember the buffer link.
+	virtual void setHWBuffer(void *ptr) const = 0;
+	virtual void *getHWBuffer() const = 0;
 };
 
 } // end namespace scene

--- a/irr/include/IVideoDriver.h
+++ b/irr/include/IVideoDriver.h
@@ -31,6 +31,8 @@ class IWriteFile;
 namespace scene
 {
 class IMeshBuffer;
+class IVertexBuffer;
+class IIndexBuffer;
 class IMesh;
 class IMeshManipulator;
 class ISceneNode;
@@ -299,7 +301,10 @@ public:
 	virtual void removeAllTextures() = 0;
 
 	//! Remove hardware buffer
-	virtual void removeHardwareBuffer(const scene::IMeshBuffer *mb) = 0;
+	virtual void removeHardwareBuffer(const scene::IVertexBuffer *vb) = 0;
+
+	//! Remove hardware buffer
+	virtual void removeHardwareBuffer(const scene::IIndexBuffer *ib) = 0;
 
 	//! Remove all hardware buffers
 	virtual void removeAllHardwareBuffers() = 0;
@@ -737,6 +742,17 @@ public:
 	//! Draws a mesh buffer
 	/** \param mb Buffer to draw */
 	virtual void drawMeshBuffer(const scene::IMeshBuffer *mb) = 0;
+
+	/**
+	 * Draws a mesh from individual vertex and index buffers.
+	 * @param vb vertices to use
+	 * @param ib indices to use
+	 * @param primCount amount of primitives
+	 * @param pType primitive type
+	 */
+	virtual void drawBuffers(const scene::IVertexBuffer *vb,
+		const scene::IIndexBuffer *ib, u32 primCount,
+		scene::E_PRIMITIVE_TYPE pType = scene::EPT_TRIANGLES) = 0;
 
 	//! Draws normals of a mesh buffer
 	/** \param mb Buffer to draw the normals of

--- a/irr/include/SAnimatedMesh.h
+++ b/irr/include/SAnimatedMesh.h
@@ -15,7 +15,7 @@ namespace scene
 {
 
 //! Simple implementation of the IAnimatedMesh interface.
-struct SAnimatedMesh : public IAnimatedMesh
+struct SAnimatedMesh final : public IAnimatedMesh
 {
 	//! constructor
 	SAnimatedMesh(scene::IMesh *mesh = 0, scene::E_ANIMATED_MESH_TYPE type = scene::EAMT_UNKNOWN) :

--- a/irr/include/SMesh.h
+++ b/irr/include/SMesh.h
@@ -14,7 +14,7 @@ namespace irr
 namespace scene
 {
 //! Simple implementation of the IMesh interface.
-struct SMesh : public IMesh
+struct SMesh final : public IMesh
 {
 	//! constructor
 	SMesh()

--- a/irr/include/SSkinMeshBuffer.h
+++ b/irr/include/SSkinMeshBuffer.h
@@ -16,7 +16,7 @@ namespace scene
 {
 
 //! A mesh buffer able to choose between S3DVertex2TCoords, S3DVertex and S3DVertexTangents at runtime
-struct SSkinMeshBuffer : public IMeshBuffer
+struct SSkinMeshBuffer final : public IMeshBuffer
 {
 	//! Default constructor
 	SSkinMeshBuffer(video::E_VERTEX_TYPE vt = video::EVT_STANDARD) :

--- a/irr/include/SSkinMeshBuffer.h
+++ b/irr/include/SSkinMeshBuffer.h
@@ -60,8 +60,7 @@ struct SSkinMeshBuffer : public IMeshBuffer
 		return Material;
 	}
 
-protected:
-	const scene::IVertexBuffer *getVertexBuffer() const
+	const scene::IVertexBuffer *getVertexBuffer() const override
 	{
 		switch (VertexType) {
 		case video::EVT_2TCOORDS:
@@ -84,7 +83,16 @@ protected:
 			return Vertices_Standard;
 		}
 	}
-public:
+
+	const scene::IIndexBuffer *getIndexBuffer() const override
+	{
+		return Indices;
+	}
+
+	scene::IIndexBuffer *getIndexBuffer() override
+	{
+		return Indices;
+	}
 
 	//! Get standard vertex at given index
 	virtual video::S3DVertex *getVertex(u32 index)
@@ -97,49 +105,6 @@ public:
 		default:
 			return &Vertices_Standard->Data[index];
 		}
-	}
-
-	//! Get pointer to vertex array
-	const void *getVertices() const override
-	{
-		return getVertexBuffer()->getData();
-	}
-
-	//! Get pointer to vertex array
-	void *getVertices() override
-	{
-		return getVertexBuffer()->getData();
-	}
-
-	//! Get vertex count
-	u32 getVertexCount() const override
-	{
-		return getVertexBuffer()->getCount();
-	}
-
-	//! Get type of index data which is stored in this meshbuffer.
-	/** \return Index type of this buffer. */
-	video::E_INDEX_TYPE getIndexType() const override
-	{
-		return Indices->getType();
-	}
-
-	//! Get pointer to index array
-	const u16 *getIndices() const override
-	{
-		return static_cast<const u16*>(Indices->getData());
-	}
-
-	//! Get pointer to index array
-	u16 *getIndices() override
-	{
-		return static_cast<u16*>(Indices->getData());
-	}
-
-	//! Get index count
-	u32 getIndexCount() const override
-	{
-		return Indices->getCount();
 	}
 
 	//! Get bounding box
@@ -199,12 +164,6 @@ public:
 		}
 	}
 
-	//! Get vertex type
-	video::E_VERTEX_TYPE getVertexType() const override
-	{
-		return VertexType;
-	}
-
 	//! Convert to 2tcoords vertex type
 	void convertTo2TCoords()
 	{
@@ -250,67 +209,10 @@ public:
 		}
 	}
 
-	//! returns position of vertex i
-	const core::vector3df &getPosition(u32 i) const override
-	{
-		return getVertexBuffer()->getPosition(i);
-	}
-
-	//! returns position of vertex i
-	core::vector3df &getPosition(u32 i) override
-	{
-		return getVertexBuffer()->getPosition(i);
-	}
-
-	//! returns normal of vertex i
-	const core::vector3df &getNormal(u32 i) const override
-	{
-		return getVertexBuffer()->getNormal(i);
-	}
-
-	//! returns normal of vertex i
-	core::vector3df &getNormal(u32 i) override
-	{
-		return getVertexBuffer()->getNormal(i);
-	}
-
-	//! returns texture coords of vertex i
-	const core::vector2df &getTCoords(u32 i) const override
-	{
-		return getVertexBuffer()->getTCoords(i);
-	}
-
-	//! returns texture coords of vertex i
-	core::vector2df &getTCoords(u32 i) override
-	{
-		return getVertexBuffer()->getTCoords(i);
-	}
-
 	//! append the vertices and indices to the current buffer
 	void append(const void *const vertices, u32 numVertices, const u16 *const indices, u32 numIndices) override
 	{
 		_IRR_DEBUG_BREAK_IF(true);
-	}
-
-	//! get the current hardware mapping hint for vertex buffers
-	E_HARDWARE_MAPPING getHardwareMappingHint_Vertex() const override
-	{
-		return getVertexBuffer()->getHardwareMappingHint();
-	}
-
-	//! get the current hardware mapping hint for index buffers
-	E_HARDWARE_MAPPING getHardwareMappingHint_Index() const override
-	{
-		return Indices->getHardwareMappingHint();
-	}
-
-	//! set the hardware mapping hint, for driver
-	void setHardwareMappingHint(E_HARDWARE_MAPPING NewMappingHint, E_BUFFER_TYPE Buffer = EBT_VERTEX_AND_INDEX) override
-	{
-		if (Buffer == EBT_VERTEX || Buffer == EBT_VERTEX_AND_INDEX)
-			getVertexBuffer()->setHardwareMappingHint(NewMappingHint);
-		if (Buffer == EBT_INDEX || Buffer == EBT_VERTEX_AND_INDEX)
-			Indices->setHardwareMappingHint(NewMappingHint);
 	}
 
 	//! Describe what kind of primitive geometry is used by the meshbuffer
@@ -323,25 +225,6 @@ public:
 	E_PRIMITIVE_TYPE getPrimitiveType() const override
 	{
 		return PrimitiveType;
-	}
-
-	//! flags the mesh as changed, reloads hardware buffers
-	void setDirty(E_BUFFER_TYPE Buffer = EBT_VERTEX_AND_INDEX) override
-	{
-		if (Buffer == EBT_VERTEX_AND_INDEX || Buffer == EBT_VERTEX)
-			getVertexBuffer()->setDirty();
-		if (Buffer == EBT_VERTEX_AND_INDEX || Buffer == EBT_INDEX)
-			Indices->setDirty();
-	}
-
-	u32 getChangedID_Vertex() const override
-	{
-		return getVertexBuffer()->getChangedID();
-	}
-
-	u32 getChangedID_Index() const override
-	{
-		return Indices->getChangedID();
 	}
 
 	void setHWBuffer(void *ptr) const override

--- a/irr/src/CB3DMeshFileLoader.cpp
+++ b/irr/src/CB3DMeshFileLoader.cpp
@@ -259,14 +259,15 @@ bool CB3DMeshFileLoader::readChunkMESH(CSkinnedMesh::SJoint *inJoint)
 			if (!NormalsInFile) {
 				s32 i;
 
-				for (i = 0; i < (s32)meshBuffer->Indices.size(); i += 3) {
-					core::plane3df p(meshBuffer->getVertex(meshBuffer->Indices[i + 0])->Pos,
-							meshBuffer->getVertex(meshBuffer->Indices[i + 1])->Pos,
-							meshBuffer->getVertex(meshBuffer->Indices[i + 2])->Pos);
+				auto &indices = meshBuffer->Indices->Data;
+				for (i = 0; i < (s32)indices.size(); i += 3) {
+					core::plane3df p(meshBuffer->getVertex(indices[i + 0])->Pos,
+							meshBuffer->getVertex(indices[i + 1])->Pos,
+							meshBuffer->getVertex(indices[i + 2])->Pos);
 
-					meshBuffer->getVertex(meshBuffer->Indices[i + 0])->Normal += p.Normal;
-					meshBuffer->getVertex(meshBuffer->Indices[i + 1])->Normal += p.Normal;
-					meshBuffer->getVertex(meshBuffer->Indices[i + 2])->Normal += p.Normal;
+					meshBuffer->getVertex(indices[i + 0])->Normal += p.Normal;
+					meshBuffer->getVertex(indices[i + 1])->Normal += p.Normal;
+					meshBuffer->getVertex(indices[i + 2])->Normal += p.Normal;
 				}
 
 				for (i = 0; i < (s32)meshBuffer->getVertexCount(); ++i) {
@@ -433,7 +434,7 @@ bool CB3DMeshFileLoader::readChunkTRIS(scene::SSkinMeshBuffer *meshBuffer, u32 m
 	}
 
 	const s32 memoryNeeded = B3dStack.getLast().length / sizeof(s32);
-	meshBuffer->Indices.reserve(memoryNeeded + meshBuffer->Indices.size() + 1);
+	meshBuffer->Indices->Data.reserve(memoryNeeded + meshBuffer->Indices->Data.size() + 1);
 
 	while ((B3dStack.getLast().startposition + B3dStack.getLast().length) > B3DFile->getPos()) // this chunk repeats
 	{
@@ -471,9 +472,9 @@ bool CB3DMeshFileLoader::readChunkTRIS(scene::SSkinMeshBuffer *meshBuffer, u32 m
 
 				// Add the vertex to the meshbuffer:
 				if (meshBuffer->VertexType == video::EVT_STANDARD)
-					meshBuffer->Vertices_Standard.push_back(BaseVertices[vertex_id[i]]);
+					meshBuffer->Vertices_Standard->Data.push_back(BaseVertices[vertex_id[i]]);
 				else
-					meshBuffer->Vertices_2TCoords.push_back(BaseVertices[vertex_id[i]]);
+					meshBuffer->Vertices_2TCoords->Data.push_back(BaseVertices[vertex_id[i]]);
 
 				// create vertex id to meshbuffer index link:
 				AnimatedVertices_VertexID[vertex_id[i]] = meshBuffer->getVertexCount() - 1;
@@ -504,9 +505,9 @@ bool CB3DMeshFileLoader::readChunkTRIS(scene::SSkinMeshBuffer *meshBuffer, u32 m
 			}
 		}
 
-		meshBuffer->Indices.push_back(AnimatedVertices_VertexID[vertex_id[0]]);
-		meshBuffer->Indices.push_back(AnimatedVertices_VertexID[vertex_id[1]]);
-		meshBuffer->Indices.push_back(AnimatedVertices_VertexID[vertex_id[2]]);
+		meshBuffer->Indices->Data.push_back(AnimatedVertices_VertexID[vertex_id[0]]);
+		meshBuffer->Indices->Data.push_back(AnimatedVertices_VertexID[vertex_id[1]]);
+		meshBuffer->Indices->Data.push_back(AnimatedVertices_VertexID[vertex_id[2]]);
 	}
 
 	B3dStack.erase(B3dStack.size() - 1);

--- a/irr/src/CBillboardSceneNode.cpp
+++ b/irr/src/CBillboardSceneNode.cpp
@@ -26,7 +26,9 @@ CBillboardSceneNode::CBillboardSceneNode(ISceneNode *parent, ISceneManager *mgr,
 
 	setSize(size);
 
-	Buffer->Vertices.resize(4);
+	auto &Vertices = Buffer->Vertices->Data;
+
+	Vertices.resize(4);
 	Buffer->Indices.resize(6);
 
 	Buffer->Indices[0] = 0;
@@ -36,17 +38,17 @@ CBillboardSceneNode::CBillboardSceneNode(ISceneNode *parent, ISceneManager *mgr,
 	Buffer->Indices[4] = 3;
 	Buffer->Indices[5] = 2;
 
-	Buffer->Vertices[0].TCoords.set(1.0f, 1.0f);
-	Buffer->Vertices[0].Color = colorBottom;
+	Vertices[0].TCoords.set(1.0f, 1.0f);
+	Vertices[0].Color = colorBottom;
 
-	Buffer->Vertices[1].TCoords.set(1.0f, 0.0f);
-	Buffer->Vertices[1].Color = colorTop;
+	Vertices[1].TCoords.set(1.0f, 0.0f);
+	Vertices[1].Color = colorTop;
 
-	Buffer->Vertices[2].TCoords.set(0.0f, 0.0f);
-	Buffer->Vertices[2].Color = colorTop;
+	Vertices[2].TCoords.set(0.0f, 0.0f);
+	Vertices[2].Color = colorTop;
 
-	Buffer->Vertices[3].TCoords.set(0.0f, 1.0f);
-	Buffer->Vertices[3].Color = colorBottom;
+	Vertices[3].TCoords.set(0.0f, 1.0f);
+	Vertices[3].Color = colorBottom;
 }
 
 CBillboardSceneNode::~CBillboardSceneNode()
@@ -114,7 +116,7 @@ void CBillboardSceneNode::updateMesh(const irr::scene::ICameraSceneNode *camera)
 
 	view *= -1.0f;
 
-	auto *vertices = Buffer->Vertices.data();
+	auto &vertices = Buffer->Vertices->Data;
 
 	for (s32 i = 0; i < 4; ++i)
 		vertices[i].Normal = view;
@@ -211,8 +213,9 @@ void CBillboardSceneNode::getSize(f32 &height, f32 &bottomEdgeWidth,
 //! \param overallColor: the color to set
 void CBillboardSceneNode::setColor(const video::SColor &overallColor)
 {
+	auto &vertices = Buffer->Vertices->Data;
 	for (u32 vertex = 0; vertex < 4; ++vertex)
-		Buffer->Vertices[vertex].Color = overallColor;
+		vertices[vertex].Color = overallColor;
 }
 
 //! Set the color of the top and bottom vertices of the billboard
@@ -221,10 +224,11 @@ void CBillboardSceneNode::setColor(const video::SColor &overallColor)
 void CBillboardSceneNode::setColor(const video::SColor &topColor,
 		const video::SColor &bottomColor)
 {
-	Buffer->Vertices[0].Color = bottomColor;
-	Buffer->Vertices[1].Color = topColor;
-	Buffer->Vertices[2].Color = topColor;
-	Buffer->Vertices[3].Color = bottomColor;
+	auto &vertices = Buffer->Vertices->Data;
+	vertices[0].Color = bottomColor;
+	vertices[1].Color = topColor;
+	vertices[2].Color = topColor;
+	vertices[3].Color = bottomColor;
 }
 
 //! Gets the color of the top and bottom vertices of the billboard
@@ -233,8 +237,9 @@ void CBillboardSceneNode::setColor(const video::SColor &topColor,
 void CBillboardSceneNode::getColor(video::SColor &topColor,
 		video::SColor &bottomColor) const
 {
-	bottomColor = Buffer->Vertices[0].Color;
-	topColor = Buffer->Vertices[1].Color;
+	auto &vertices = Buffer->Vertices->Data;
+	bottomColor = vertices[0].Color;
+	topColor = vertices[1].Color;
 }
 
 //! Creates a clone of this scene node and its children.

--- a/irr/src/CBillboardSceneNode.cpp
+++ b/irr/src/CBillboardSceneNode.cpp
@@ -27,16 +27,17 @@ CBillboardSceneNode::CBillboardSceneNode(ISceneNode *parent, ISceneManager *mgr,
 	setSize(size);
 
 	auto &Vertices = Buffer->Vertices->Data;
+	auto &Indices = Buffer->Indices->Data;
 
 	Vertices.resize(4);
-	Buffer->Indices.resize(6);
+	Indices.resize(6);
 
-	Buffer->Indices[0] = 0;
-	Buffer->Indices[1] = 2;
-	Buffer->Indices[2] = 1;
-	Buffer->Indices[3] = 0;
-	Buffer->Indices[4] = 3;
-	Buffer->Indices[5] = 2;
+	Indices[0] = 0;
+	Indices[1] = 2;
+	Indices[2] = 1;
+	Indices[3] = 0;
+	Indices[4] = 3;
+	Indices[5] = 2;
 
 	Vertices[0].TCoords.set(1.0f, 1.0f);
 	Vertices[0].Color = colorBottom;

--- a/irr/src/CFileSystem.h
+++ b/irr/src/CFileSystem.h
@@ -17,7 +17,7 @@ class CZipReader;
 /*!
 	FileSystem which uses normal files and one zipfile
 */
-class CFileSystem : public IFileSystem
+class CFileSystem final : public IFileSystem
 {
 public:
 	//! constructor

--- a/irr/src/CImage.h
+++ b/irr/src/CImage.h
@@ -21,7 +21,7 @@ inline bool checkImageDimensions(u32 width, u32 height)
 
 //! IImage implementation with a lot of special image operations for
 //! 16 bit A1R5G5B5/32 Bit A8R8G8B8 images, which are used by the SoftwareDevice.
-class CImage : public IImage
+class CImage final : public IImage
 {
 public:
 	//! constructor from raw image data

--- a/irr/src/CLimitReadFile.h
+++ b/irr/src/CLimitReadFile.h
@@ -20,7 +20,7 @@ namespace io
 	This can be useful, for example for reading uncompressed files
 	in an archive (zip, tar).
 !*/
-class CLimitReadFile : public IReadFile
+class CLimitReadFile final : public IReadFile
 {
 public:
 	CLimitReadFile(IReadFile *alreadyOpenedFile, long pos, long areaSize, const io::path &name);

--- a/irr/src/CMemoryFile.h
+++ b/irr/src/CMemoryFile.h
@@ -17,7 +17,7 @@ namespace io
 /*!
 	Class for reading from memory.
 */
-class CMemoryReadFile : public IMemoryReadFile
+class CMemoryReadFile final : public IMemoryReadFile
 {
 public:
 	//! Constructor

--- a/irr/src/CMeshManipulator.cpp
+++ b/irr/src/CMeshManipulator.cpp
@@ -133,7 +133,7 @@ SMesh *CMeshManipulator::createMeshCopy(scene::IMesh *mesh) const
 			SMeshBuffer *buffer = new SMeshBuffer();
 			buffer->Material = mb->getMaterial();
 			auto *vt = static_cast<const video::S3DVertex*>(mb->getVertices());
-			buffer->Vertices.insert(buffer->Vertices.end(), vt, vt + mb->getVertexCount());
+			buffer->VertexBuffer().insert(buffer->VertexBuffer().end(), vt, vt + mb->getVertexCount());
 			auto *indices = mb->getIndices();
 			buffer->Indices.insert(buffer->Indices.end(), indices, indices + mb->getIndexCount());
 			clone->addMeshBuffer(buffer);
@@ -143,7 +143,7 @@ SMesh *CMeshManipulator::createMeshCopy(scene::IMesh *mesh) const
 			SMeshBufferLightMap *buffer = new SMeshBufferLightMap();
 			buffer->Material = mb->getMaterial();
 			auto *vt = static_cast<const video::S3DVertex2TCoords*>(mb->getVertices());
-			buffer->Vertices.insert(buffer->Vertices.end(), vt, vt + mb->getVertexCount());
+			buffer->VertexBuffer().insert(buffer->VertexBuffer().end(), vt, vt + mb->getVertexCount());
 			auto *indices = mb->getIndices();
 			buffer->Indices.insert(buffer->Indices.end(), indices, indices + mb->getIndexCount());
 			clone->addMeshBuffer(buffer);
@@ -153,7 +153,7 @@ SMesh *CMeshManipulator::createMeshCopy(scene::IMesh *mesh) const
 			SMeshBufferTangents *buffer = new SMeshBufferTangents();
 			buffer->Material = mb->getMaterial();
 			auto *vt = static_cast<const video::S3DVertexTangents*>(mb->getVertices());
-			buffer->Vertices.insert(buffer->Vertices.end(), vt, vt + mb->getVertexCount());
+			buffer->VertexBuffer().insert(buffer->VertexBuffer().end(), vt, vt + mb->getVertexCount());
 			auto *indices = mb->getIndices();
 			buffer->Indices.insert(buffer->Indices.end(), indices, indices + mb->getIndexCount());
 			clone->addMeshBuffer(buffer);

--- a/irr/src/CMeshManipulator.cpp
+++ b/irr/src/CMeshManipulator.cpp
@@ -135,7 +135,7 @@ SMesh *CMeshManipulator::createMeshCopy(scene::IMesh *mesh) const
 			auto *vt = static_cast<const video::S3DVertex*>(mb->getVertices());
 			buffer->VertexBuffer().insert(buffer->VertexBuffer().end(), vt, vt + mb->getVertexCount());
 			auto *indices = mb->getIndices();
-			buffer->Indices.insert(buffer->Indices.end(), indices, indices + mb->getIndexCount());
+			buffer->IndexBuffer().insert(buffer->IndexBuffer().end(), indices, indices + mb->getIndexCount());
 			clone->addMeshBuffer(buffer);
 			buffer->drop();
 		} break;
@@ -145,7 +145,7 @@ SMesh *CMeshManipulator::createMeshCopy(scene::IMesh *mesh) const
 			auto *vt = static_cast<const video::S3DVertex2TCoords*>(mb->getVertices());
 			buffer->VertexBuffer().insert(buffer->VertexBuffer().end(), vt, vt + mb->getVertexCount());
 			auto *indices = mb->getIndices();
-			buffer->Indices.insert(buffer->Indices.end(), indices, indices + mb->getIndexCount());
+			buffer->IndexBuffer().insert(buffer->IndexBuffer().end(), indices, indices + mb->getIndexCount());
 			clone->addMeshBuffer(buffer);
 			buffer->drop();
 		} break;
@@ -155,7 +155,7 @@ SMesh *CMeshManipulator::createMeshCopy(scene::IMesh *mesh) const
 			auto *vt = static_cast<const video::S3DVertexTangents*>(mb->getVertices());
 			buffer->VertexBuffer().insert(buffer->VertexBuffer().end(), vt, vt + mb->getVertexCount());
 			auto *indices = mb->getIndices();
-			buffer->Indices.insert(buffer->Indices.end(), indices, indices + mb->getIndexCount());
+			buffer->IndexBuffer().insert(buffer->IndexBuffer().end(), indices, indices + mb->getIndexCount());
 			clone->addMeshBuffer(buffer);
 			buffer->drop();
 		} break;

--- a/irr/src/CMeshManipulator.cpp
+++ b/irr/src/CMeshManipulator.cpp
@@ -67,7 +67,7 @@ void recalculateNormalsT(IMeshBuffer *buffer, bool smooth, bool angleWeighted)
 
 			core::vector3df weight(1.f, 1.f, 1.f);
 			if (angleWeighted)
-				weight = irr::scene::getAngleWeight(v1, v2, v3); // writing irr::scene:: necessary for borland
+				weight = getAngleWeight(v1, v2, v3);
 
 			buffer->getNormal(idx[i + 0]) += weight.X * normal;
 			buffer->getNormal(idx[i + 1]) += weight.Y * normal;
@@ -115,6 +115,21 @@ void CMeshManipulator::recalculateNormals(scene::IMesh *mesh, bool smooth, bool 
 	}
 }
 
+template <typename T>
+void copyVertices(const scene::IVertexBuffer *src, scene::CVertexBuffer<T> *dst)
+{
+	_IRR_DEBUG_BREAK_IF(T::getType() != src->getType());
+	auto *data = static_cast<const T*>(src->getData());
+	dst->Data.assign(data, data + src->getCount());
+}
+
+static void copyIndices(const scene::IIndexBuffer *src, scene::SIndexBuffer *dst)
+{
+	_IRR_DEBUG_BREAK_IF(src->getType() != video::EIT_16BIT);
+	auto *data = static_cast<const u16*>(src->getData());
+	dst->Data.assign(data, data + src->getCount());
+}
+
 //! Clones a static IMesh into a modifyable SMesh.
 // not yet 32bit
 SMesh *CMeshManipulator::createMeshCopy(scene::IMesh *mesh) const
@@ -132,30 +147,24 @@ SMesh *CMeshManipulator::createMeshCopy(scene::IMesh *mesh) const
 		case video::EVT_STANDARD: {
 			SMeshBuffer *buffer = new SMeshBuffer();
 			buffer->Material = mb->getMaterial();
-			auto *vt = static_cast<const video::S3DVertex*>(mb->getVertices());
-			buffer->VertexBuffer().insert(buffer->VertexBuffer().end(), vt, vt + mb->getVertexCount());
-			auto *indices = mb->getIndices();
-			buffer->IndexBuffer().insert(buffer->IndexBuffer().end(), indices, indices + mb->getIndexCount());
+			copyVertices(mb->getVertexBuffer(), buffer->Vertices);
+			copyIndices(mb->getIndexBuffer(), buffer->Indices);
 			clone->addMeshBuffer(buffer);
 			buffer->drop();
 		} break;
 		case video::EVT_2TCOORDS: {
 			SMeshBufferLightMap *buffer = new SMeshBufferLightMap();
 			buffer->Material = mb->getMaterial();
-			auto *vt = static_cast<const video::S3DVertex2TCoords*>(mb->getVertices());
-			buffer->VertexBuffer().insert(buffer->VertexBuffer().end(), vt, vt + mb->getVertexCount());
-			auto *indices = mb->getIndices();
-			buffer->IndexBuffer().insert(buffer->IndexBuffer().end(), indices, indices + mb->getIndexCount());
+			copyVertices(mb->getVertexBuffer(), buffer->Vertices);
+			copyIndices(mb->getIndexBuffer(), buffer->Indices);
 			clone->addMeshBuffer(buffer);
 			buffer->drop();
 		} break;
 		case video::EVT_TANGENTS: {
 			SMeshBufferTangents *buffer = new SMeshBufferTangents();
 			buffer->Material = mb->getMaterial();
-			auto *vt = static_cast<const video::S3DVertexTangents*>(mb->getVertices());
-			buffer->VertexBuffer().insert(buffer->VertexBuffer().end(), vt, vt + mb->getVertexCount());
-			auto *indices = mb->getIndices();
-			buffer->IndexBuffer().insert(buffer->IndexBuffer().end(), indices, indices + mb->getIndexCount());
+			copyVertices(mb->getVertexBuffer(), buffer->Vertices);
+			copyIndices(mb->getIndexBuffer(), buffer->Indices);
 			clone->addMeshBuffer(buffer);
 			buffer->drop();
 		} break;

--- a/irr/src/COBJMeshFileLoader.cpp
+++ b/irr/src/COBJMeshFileLoader.cpp
@@ -247,15 +247,16 @@ IAnimatedMesh *COBJMeshFileLoader::createMesh(io::IReadFile *file)
 			}
 
 			// triangulate the face
+			auto &Indices = currMtl->Meshbuffer->IndexBuffer();
 			const int c = faceCorners[0];
 			for (u32 i = 1; i < faceCorners.size() - 1; ++i) {
 				// Add a triangle
 				const int a = faceCorners[i + 1];
 				const int b = faceCorners[i];
 				if (a != b && a != c && b != c) { // ignore degenerated faces. We can get them when we merge vertices above in the VertMap.
-					currMtl->Meshbuffer->Indices.push_back(a);
-					currMtl->Meshbuffer->Indices.push_back(b);
-					currMtl->Meshbuffer->Indices.push_back(c);
+					Indices.push_back(a);
+					Indices.push_back(b);
+					Indices.push_back(c);
 				} else {
 					++degeneratedFaces;
 				}

--- a/irr/src/COBJMeshFileLoader.cpp
+++ b/irr/src/COBJMeshFileLoader.cpp
@@ -228,8 +228,8 @@ IAnimatedMesh *COBJMeshFileLoader::createMesh(io::IReadFile *file)
 				if (n != currMtl->VertMap.end()) {
 					vertLocation = n->second;
 				} else {
-					currMtl->Meshbuffer->Vertices.push_back(v);
-					vertLocation = currMtl->Meshbuffer->Vertices.size() - 1;
+					currMtl->Meshbuffer->VertexBuffer().push_back(v);
+					vertLocation = currMtl->Meshbuffer->VertexBuffer().size() - 1;
 					currMtl->VertMap.emplace(v, vertLocation);
 				}
 

--- a/irr/src/COBJMeshFileLoader.cpp
+++ b/irr/src/COBJMeshFileLoader.cpp
@@ -192,6 +192,7 @@ IAnimatedMesh *COBJMeshFileLoader::createMesh(io::IReadFile *file)
 			faceCorners.set_used(0); // fast clear
 
 			// read in all vertices
+			auto &Vertices = currMtl->Meshbuffer->Vertices->Data;
 			linePtr = goNextWord(linePtr, endPtr);
 			while (0 != linePtr[0]) {
 				// Array to communicate with retrieveVertexIndices()
@@ -228,8 +229,8 @@ IAnimatedMesh *COBJMeshFileLoader::createMesh(io::IReadFile *file)
 				if (n != currMtl->VertMap.end()) {
 					vertLocation = n->second;
 				} else {
-					currMtl->Meshbuffer->VertexBuffer().push_back(v);
-					vertLocation = currMtl->Meshbuffer->VertexBuffer().size() - 1;
+					Vertices.push_back(v);
+					vertLocation = Vertices.size() - 1;
 					currMtl->VertMap.emplace(v, vertLocation);
 				}
 
@@ -247,7 +248,7 @@ IAnimatedMesh *COBJMeshFileLoader::createMesh(io::IReadFile *file)
 			}
 
 			// triangulate the face
-			auto &Indices = currMtl->Meshbuffer->IndexBuffer();
+			auto &Indices = currMtl->Meshbuffer->Indices->Data;
 			const int c = faceCorners[0];
 			for (u32 i = 1; i < faceCorners.size() - 1; ++i) {
 				// Add a triangle

--- a/irr/src/COpenGLDriver.h
+++ b/irr/src/COpenGLDriver.h
@@ -58,27 +58,28 @@ public:
 
 	struct SHWBufferLink_opengl : public SHWBufferLink
 	{
-		SHWBufferLink_opengl(const scene::IMeshBuffer *_MeshBuffer) :
-				SHWBufferLink(_MeshBuffer), vbo_verticesID(0), vbo_indicesID(0) {}
+		SHWBufferLink_opengl(const scene::IVertexBuffer *vb) : SHWBufferLink(vb) {}
+		SHWBufferLink_opengl(const scene::IIndexBuffer *ib) : SHWBufferLink(ib) {}
 
-		GLuint vbo_verticesID; // tmp
-		GLuint vbo_indicesID;  // tmp
-
-		GLuint vbo_verticesSize; // tmp
-		GLuint vbo_indicesSize;  // tmp
+		GLuint vbo_ID = 0;
+		u32 vbo_Size = 0;
 	};
 
 	//! updates hardware buffer if needed
 	bool updateHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
-	//! Create hardware buffer from mesh
-	SHWBufferLink *createHardwareBuffer(const scene::IMeshBuffer *mb) override;
+	//! Create hardware buffer from vertex buffer
+	SHWBufferLink *createHardwareBuffer(const scene::IVertexBuffer *vb) override;
+
+	//! Create hardware buffer from index buffer
+	SHWBufferLink *createHardwareBuffer(const scene::IIndexBuffer *ib) override;
 
 	//! Delete hardware buffer (only some drivers can)
 	void deleteHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
-	//! Draw hardware buffer
-	void drawHardwareBuffer(SHWBufferLink *HWBuffer) override;
+	void drawBuffers(const scene::IVertexBuffer *vb,
+		const scene::IIndexBuffer *ib, u32 primCount,
+		scene::E_PRIMITIVE_TYPE pType = scene::EPT_TRIANGLES) override;
 
 	//! Create occlusion query.
 	/** Use node for identification and mesh for occlusion test. */

--- a/irr/src/CReadFile.h
+++ b/irr/src/CReadFile.h
@@ -17,7 +17,7 @@ namespace io
 /*!
 	Class for reading a real file from disk.
 */
-class CReadFile : public IReadFile
+class CReadFile final : public IReadFile
 {
 public:
 	CReadFile(const io::path &fileName);

--- a/irr/src/CSceneManager.h
+++ b/irr/src/CSceneManager.h
@@ -25,7 +25,7 @@ class IMeshCache;
 /*!
 	The Scene Manager manages scene nodes, mesh resources, cameras and all the other stuff.
 */
-class CSceneManager : public ISceneManager, public ISceneNode
+class CSceneManager final : public ISceneManager, public ISceneNode
 {
 public:
 	//! constructor

--- a/irr/src/CXMeshFileLoader.cpp
+++ b/irr/src/CXMeshFileLoader.cpp
@@ -273,12 +273,12 @@ bool CXMeshFileLoader::load(io::IReadFile *file)
 				}
 				if (mesh->TCoords2.size()) {
 					for (i = 0; i != mesh->Buffers.size(); ++i) {
-						mesh->Buffers[i]->Vertices_2TCoords.reserve(vCountArray[i]);
+						mesh->Buffers[i]->Vertices_2TCoords->Data.reserve(vCountArray[i]);
 						mesh->Buffers[i]->VertexType = video::EVT_2TCOORDS;
 					}
 				} else {
 					for (i = 0; i != mesh->Buffers.size(); ++i)
-						mesh->Buffers[i]->Vertices_Standard.reserve(vCountArray[i]);
+						mesh->Buffers[i]->Vertices_Standard->Data.reserve(vCountArray[i]);
 				}
 
 				verticesLinkIndex.set_used(mesh->Vertices.size());
@@ -290,14 +290,14 @@ bool CXMeshFileLoader::load(io::IReadFile *file)
 					scene::SSkinMeshBuffer *buffer = mesh->Buffers[verticesLinkBuffer[i]];
 
 					if (mesh->TCoords2.size()) {
-						verticesLinkIndex[i] = buffer->Vertices_2TCoords.size();
-						buffer->Vertices_2TCoords.emplace_back(mesh->Vertices[i]);
+						verticesLinkIndex[i] = buffer->Vertices_2TCoords->getCount();
+						buffer->Vertices_2TCoords->Data.emplace_back(mesh->Vertices[i]);
 						// We have a problem with correct tcoord2 handling here
 						// crash fixed for now by checking the values
-						buffer->Vertices_2TCoords.back().TCoords2 = (i < mesh->TCoords2.size()) ? mesh->TCoords2[i] : mesh->Vertices[i].TCoords;
+						buffer->Vertices_2TCoords->Data.back().TCoords2 = (i < mesh->TCoords2.size()) ? mesh->TCoords2[i] : mesh->Vertices[i].TCoords;
 					} else {
-						verticesLinkIndex[i] = buffer->Vertices_Standard.size();
-						buffer->Vertices_Standard.push_back(mesh->Vertices[i]);
+						verticesLinkIndex[i] = buffer->Vertices_Standard->getCount();
+						buffer->Vertices_Standard->Data.push_back(mesh->Vertices[i]);
 					}
 				}
 
@@ -306,13 +306,13 @@ bool CXMeshFileLoader::load(io::IReadFile *file)
 				for (i = 0; i < mesh->FaceMaterialIndices.size(); ++i)
 					++vCountArray[mesh->FaceMaterialIndices[i]];
 				for (i = 0; i != mesh->Buffers.size(); ++i)
-					mesh->Buffers[i]->Indices.reserve(vCountArray[i]);
+					mesh->Buffers[i]->Indices->Data.reserve(vCountArray[i]);
 				delete[] vCountArray;
 				// create indices per buffer
 				for (i = 0; i < mesh->FaceMaterialIndices.size(); ++i) {
 					scene::SSkinMeshBuffer *buffer = mesh->Buffers[mesh->FaceMaterialIndices[i]];
 					for (u32 id = i * 3 + 0; id != i * 3 + 3; ++id) {
-						buffer->Indices.push_back(verticesLinkIndex[mesh->Indices[id]]);
+						buffer->Indices->Data.push_back(verticesLinkIndex[mesh->Indices[id]]);
 					}
 				}
 			}

--- a/irr/src/OpenGL/Driver.h
+++ b/irr/src/OpenGL/Driver.h
@@ -46,16 +46,11 @@ public:
 
 	struct SHWBufferLink_opengl : public SHWBufferLink
 	{
-		SHWBufferLink_opengl(const scene::IMeshBuffer *meshBuffer) :
-				SHWBufferLink(meshBuffer), vbo_verticesID(0), vbo_indicesID(0), vbo_verticesSize(0), vbo_indicesSize(0)
-		{
-		}
+		SHWBufferLink_opengl(const scene::IVertexBuffer *vb) : SHWBufferLink(vb) {}
+		SHWBufferLink_opengl(const scene::IIndexBuffer *ib) : SHWBufferLink(ib) {}
 
-		u32 vbo_verticesID; // tmp
-		u32 vbo_indicesID;  // tmp
-
-		u32 vbo_verticesSize; // tmp
-		u32 vbo_indicesSize;  // tmp
+		GLuint vbo_ID = 0;
+		u32 vbo_Size = 0;
 	};
 
 	bool updateVertexHardwareBuffer(SHWBufferLink_opengl *HWBuffer);
@@ -64,14 +59,18 @@ public:
 	//! updates hardware buffer if needed
 	bool updateHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
-	//! Create hardware buffer from mesh
-	SHWBufferLink *createHardwareBuffer(const scene::IMeshBuffer *mb) override;
+	//! Create hardware buffer from vertex buffer
+	SHWBufferLink *createHardwareBuffer(const scene::IVertexBuffer *vb) override;
+
+	//! Create hardware buffer from index buffer
+	SHWBufferLink *createHardwareBuffer(const scene::IIndexBuffer *ib) override;
 
 	//! Delete hardware buffer (only some drivers can)
 	void deleteHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
-	//! Draw hardware buffer
-	void drawHardwareBuffer(SHWBufferLink *HWBuffer) override;
+	void drawBuffers(const scene::IVertexBuffer *vb,
+		const scene::IIndexBuffer *ib, u32 primCount,
+		scene::E_PRIMITIVE_TYPE pType = scene::EPT_TRIANGLES) override;
 
 	IRenderTarget *addRenderTarget() override;
 
@@ -291,10 +290,7 @@ protected:
 		LockRenderStateMode = false;
 	}
 
-	void draw2D3DVertexPrimitiveList(const void *vertices,
-			u32 vertexCount, const void *indexList, u32 primitiveCount,
-			E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType,
-			E_INDEX_TYPE iType, bool is3D);
+	bool updateHardwareBuffer(SHWBufferLink_opengl *b, const void *buffer, size_t bufferSize, scene::E_HARDWARE_MAPPING hint);
 
 	void createMaterialRenderers();
 

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1358,11 +1358,8 @@ video::SMaterial &ClientMap::DrawDescriptor::getMaterial()
 u32 ClientMap::DrawDescriptor::draw(video::IVideoDriver* driver)
 {
 	if (m_use_partial_buffer) {
-		m_partial_buffer->beforeDraw();
-		driver->drawMeshBuffer(m_partial_buffer->getBuffer());
-		auto count = m_partial_buffer->getBuffer()->getVertexCount();
-		m_partial_buffer->afterDraw();
-		return count;
+		m_partial_buffer->draw(driver);
+		return m_partial_buffer->getBuffer()->getVertexCount();
 	} else {
 		driver->drawMeshBuffer(m_buffer);
 		return m_buffer->getVertexCount();

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -178,13 +178,14 @@ void Clouds::updateMesh()
 
 
 	auto *mb = m_meshbuffer.get();
+	auto &vertices = mb->Vertices->Data;
 	{
 		const u32 vertex_count = num_faces_to_draw * 16 * m_cloud_radius_i * m_cloud_radius_i;
 		const u32 quad_count = vertex_count / 4;
 		const u32 index_count = quad_count * 6;
 
 		// reserve memory
-		mb->Vertices.reserve(vertex_count);
+		vertices.reserve(vertex_count);
 		mb->Indices.reserve(index_count);
 	}
 
@@ -192,7 +193,7 @@ void Clouds::updateMesh()
 #define INAREA(x, z, radius) \
 	((x) >= -(radius) && (x) < (radius) && (z) >= -(radius) && (z) < (radius))
 
-	mb->Vertices.clear();
+	vertices.clear();
 	for (s16 zi0= -m_cloud_radius_i; zi0 < m_cloud_radius_i; zi0++)
 	for (s16 xi0= -m_cloud_radius_i; xi0 < m_cloud_radius_i; xi0++)
 	{
@@ -312,7 +313,7 @@ void Clouds::updateMesh()
 
 			for (video::S3DVertex &vertex : v) {
 				vertex.Pos += pos;
-				mb->Vertices.push_back(vertex);
+				vertices.push_back(vertex);
 			}
 		}
 	}

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -179,6 +179,7 @@ void Clouds::updateMesh()
 
 	auto *mb = m_meshbuffer.get();
 	auto &vertices = mb->Vertices->Data;
+	auto &indices = mb->Indices->Data;
 	{
 		const u32 vertex_count = num_faces_to_draw * 16 * m_cloud_radius_i * m_cloud_radius_i;
 		const u32 quad_count = vertex_count / 4;
@@ -186,7 +187,7 @@ void Clouds::updateMesh()
 
 		// reserve memory
 		vertices.reserve(vertex_count);
-		mb->Indices.reserve(index_count);
+		indices.reserve(index_count);
 	}
 
 #define GETINDEX(x, z, radius) (((z)+(radius))*(radius)*2 + (x)+(radius))
@@ -323,18 +324,18 @@ void Clouds::updateMesh()
 	const u32 index_count = quad_count * 6;
 	// rewrite index array as needed
 	if (mb->getIndexCount() > index_count) {
-		mb->Indices.resize(index_count);
+		indices.resize(index_count);
 		mb->setDirty(scene::EBT_INDEX);
 	} else if (mb->getIndexCount() < index_count) {
 		const u32 start = mb->getIndexCount() / 6;
 		assert(start * 6 == mb->getIndexCount());
 		for (u32 k = start; k < quad_count; k++) {
-			mb->Indices.push_back(4 * k + 0);
-			mb->Indices.push_back(4 * k + 1);
-			mb->Indices.push_back(4 * k + 2);
-			mb->Indices.push_back(4 * k + 2);
-			mb->Indices.push_back(4 * k + 3);
-			mb->Indices.push_back(4 * k + 0);
+			indices.push_back(4 * k + 0);
+			indices.push_back(4 * k + 1);
+			indices.push_back(4 * k + 2);
+			indices.push_back(4 * k + 2);
+			indices.push_back(4 * k + 3);
+			indices.push_back(4 * k + 0);
 		}
 		mb->setDirty(scene::EBT_INDEX);
 	}

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -154,7 +154,7 @@ Hud::Hud(Client *client, LocalPlayer *player,
 
 	b.getMaterial().Lighting = false;
 	b.getMaterial().MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-	b.setHardwareMappingHint(scene::EHM_STATIC);
+	//b.setHardwareMappingHint(scene::EHM_STATIC); // FIXME: incorrectly stack allocated, not safe!
 }
 
 void Hud::readScalingSetting()

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -133,9 +133,10 @@ Hud::Hud(Client *client, LocalPlayer *player,
 			rangelim(g_settings->getS16("selectionbox_width"), 1, 5);
 
 	// Prepare mesh for compass drawing
-	auto &b = m_rotation_mesh_buffer;
-	auto &vertices = b.Vertices->Data;
-	auto &indices = b.Indices->Data;
+	m_rotation_mesh_buffer.reset(new scene::SMeshBuffer());
+	auto *b = m_rotation_mesh_buffer.get();
+	auto &vertices = b->Vertices->Data;
+	auto &indices = b->Indices->Data;
 	vertices.resize(4);
 	indices.resize(6);
 
@@ -154,9 +155,9 @@ Hud::Hud(Client *client, LocalPlayer *player,
 	indices[4] = 3;
 	indices[5] = 0;
 
-	b.getMaterial().Lighting = false;
-	b.getMaterial().MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-	//b.setHardwareMappingHint(scene::EHM_STATIC); // FIXME: incorrectly stack allocated, not safe!
+	b->getMaterial().Lighting = false;
+	b->getMaterial().MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+	b->setHardwareMappingHint(scene::EHM_STATIC);
 }
 
 void Hud::readScalingSetting()
@@ -658,10 +659,10 @@ void Hud::drawCompassRotate(HudElement *e, video::ITexture *texture,
 	driver->setTransform(video::ETS_VIEW, core::matrix4());
 	driver->setTransform(video::ETS_WORLD, Matrix);
 
-	video::SMaterial &material = m_rotation_mesh_buffer.getMaterial();
+	auto &material = m_rotation_mesh_buffer->getMaterial();
 	material.TextureLayers[0].Texture = texture;
 	driver->setMaterial(material);
-	driver->drawMeshBuffer(&m_rotation_mesh_buffer);
+	driver->drawMeshBuffer(m_rotation_mesh_buffer.get());
 
 	driver->setTransform(video::ETS_WORLD, core::matrix4());
 	driver->setTransform(video::ETS_VIEW, oldViewMat);

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -135,8 +135,9 @@ Hud::Hud(Client *client, LocalPlayer *player,
 	// Prepare mesh for compass drawing
 	auto &b = m_rotation_mesh_buffer;
 	auto &vertices = b.Vertices->Data;
+	auto &indices = b.Indices->Data;
 	vertices.resize(4);
-	b.Indices.resize(6);
+	indices.resize(6);
 
 	video::SColor white(255, 255, 255, 255);
 	v3f normal(0.f, 0.f, 1.f);
@@ -146,12 +147,12 @@ Hud::Hud(Client *client, LocalPlayer *player,
 	vertices[2] = video::S3DVertex(v3f( 1.f,  1.f, 0.f), normal, white, v2f(1.f, 0.f));
 	vertices[3] = video::S3DVertex(v3f( 1.f, -1.f, 0.f), normal, white, v2f(1.f, 1.f));
 
-	b.Indices[0] = 0;
-	b.Indices[1] = 1;
-	b.Indices[2] = 2;
-	b.Indices[3] = 2;
-	b.Indices[4] = 3;
-	b.Indices[5] = 0;
+	indices[0] = 0;
+	indices[1] = 1;
+	indices[2] = 2;
+	indices[3] = 2;
+	indices[4] = 3;
+	indices[5] = 0;
 
 	b.getMaterial().Lighting = false;
 	b.getMaterial().MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -134,16 +134,17 @@ Hud::Hud(Client *client, LocalPlayer *player,
 
 	// Prepare mesh for compass drawing
 	auto &b = m_rotation_mesh_buffer;
-	b.Vertices.resize(4);
+	auto &vertices = b.Vertices->Data;
+	vertices.resize(4);
 	b.Indices.resize(6);
 
 	video::SColor white(255, 255, 255, 255);
 	v3f normal(0.f, 0.f, 1.f);
 
-	b.Vertices[0] = video::S3DVertex(v3f(-1.f, -1.f, 0.f), normal, white, v2f(0.f, 1.f));
-	b.Vertices[1] = video::S3DVertex(v3f(-1.f,  1.f, 0.f), normal, white, v2f(0.f, 0.f));
-	b.Vertices[2] = video::S3DVertex(v3f( 1.f,  1.f, 0.f), normal, white, v2f(1.f, 0.f));
-	b.Vertices[3] = video::S3DVertex(v3f( 1.f, -1.f, 0.f), normal, white, v2f(1.f, 1.f));
+	vertices[0] = video::S3DVertex(v3f(-1.f, -1.f, 0.f), normal, white, v2f(0.f, 1.f));
+	vertices[1] = video::S3DVertex(v3f(-1.f,  1.f, 0.f), normal, white, v2f(0.f, 0.f));
+	vertices[2] = video::S3DVertex(v3f( 1.f,  1.f, 0.f), normal, white, v2f(1.f, 0.f));
+	vertices[3] = video::S3DVertex(v3f( 1.f, -1.f, 0.f), normal, white, v2f(1.f, 1.f));
 
 	b.Indices[0] = 0;
 	b.Indices[1] = 1;

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IGUIFont.h>
 #include <SMaterial.h>
 #include <SMeshBuffer.h>
+#include "irr_ptr.h"
 #include "irr_aabb3d.h"
 #include "../hud.h"
 
@@ -152,7 +153,7 @@ private:
 	video::SMaterial m_selection_material;
 	video::SMaterial m_block_bounds_material;
 
-	scene::SMeshBuffer m_rotation_mesh_buffer;
+	irr_ptr<scene::SMeshBuffer> m_rotation_mesh_buffer;
 
 	enum
 	{

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -269,11 +269,12 @@ public:
 	JoystickController joystick;
 	KeyCache keycache;
 };
+
 /*
-	Separated input handler
+	Separated input handler implementations
 */
 
-class RealInputHandler : public InputHandler
+class RealInputHandler final : public InputHandler
 {
 public:
 	RealInputHandler(MyEventReceiver *receiver) : m_receiver(receiver)
@@ -372,7 +373,7 @@ private:
 	v2s32 m_mousepos;
 };
 
-class RandomInputHandler : public InputHandler
+class RandomInputHandler final : public InputHandler
 {
 public:
 	RandomInputHandler() = default;

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -592,17 +592,14 @@ void MapBlockBspTree::traverse(s32 node, v3f viewpoint, std::vector<s32> &output
 	PartialMeshBuffer
 */
 
-void PartialMeshBuffer::beforeDraw() const
+void PartialMeshBuffer::draw(video::IVideoDriver *driver) const
 {
-	// Patch the indexes in the mesh buffer before draw
-	m_buffer->Indices = std::move(m_vertex_indexes);
-	m_buffer->setDirty(scene::EBT_INDEX);
-}
-
-void PartialMeshBuffer::afterDraw() const
-{
-	// Take the data back
-	m_vertex_indexes = std::move(m_buffer->Indices);
+	// Swap out the index buffer before drawing the mesh
+	auto *old = m_buffer->Indices;
+	m_buffer->Indices = m_indices.get();
+	m_buffer->setDirty(scene::EBT_INDEX); // TODO remove
+	driver->drawMeshBuffer(m_buffer);
+	m_buffer->Indices = old;
 }
 
 /*
@@ -789,6 +786,7 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offs
 	}
 
 	// Transparent parts have changing indices
+	// TODO: remove
 	for (auto &it : m_transparent_triangles)
 		it.buffer->setHardwareMappingHint(scene::EHM_STREAM, scene::EBT_INDEX);
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -594,12 +594,9 @@ void MapBlockBspTree::traverse(s32 node, v3f viewpoint, std::vector<s32> &output
 
 void PartialMeshBuffer::draw(video::IVideoDriver *driver) const
 {
-	// Swap out the index buffer before drawing the mesh
-	auto *old = m_buffer->Indices;
-	m_buffer->Indices = m_indices.get();
-	m_buffer->setDirty(scene::EBT_INDEX); // TODO remove
-	driver->drawMeshBuffer(m_buffer);
-	m_buffer->Indices = old;
+	const auto pType = m_buffer->getPrimitiveType();
+	driver->drawBuffers(m_buffer->getVertexBuffer(), m_indices.get(),
+		m_indices->getPrimitiveCount(pType), pType);
 }
 
 /*
@@ -784,11 +781,6 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offs
 			mesh->setHardwareMappingHint(scene::EHM_STATIC);
 		}
 	}
-
-	// Transparent parts have changing indices
-	// TODO: remove
-	for (auto &it : m_transparent_triangles)
-		it.buffer->setHardwareMappingHint(scene::EHM_STREAM, scene::EBT_INDEX);
 
 	m_bsp_tree.buildTree(&m_transparent_triangles, data->side_length);
 

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "irrlichttypes_extrabloated.h"
+#include "irr_ptr.h"
 #include "util/numeric.h"
 #include "client/tile.h"
 #include "voxel.h"
@@ -145,25 +146,24 @@ private:
  * Attach alternate `Indices` to an existing mesh buffer, to make it possible to use different
  * indices with the same vertex buffer.
  *
- * Irrlicht does not currently support this: `CMeshBuffer` ties together a single vertex buffer
- * and a single index buffer. There's no way to share these between mesh buffers.
- *
  */
 class PartialMeshBuffer
 {
 public:
-	PartialMeshBuffer(scene::SMeshBuffer *buffer, std::vector<u16> &&vertex_indexes) :
-			m_buffer(buffer), m_vertex_indexes(std::move(vertex_indexes))
-	{}
+	PartialMeshBuffer(scene::SMeshBuffer *buffer, std::vector<u16> &&vertex_indices) :
+			m_buffer(buffer)
+	{
+		m_indices.reset(new scene::SIndexBuffer());
+		m_indices->Data = std::move(vertex_indices);
+	}
 
 	scene::IMeshBuffer *getBuffer() const { return m_buffer; }
-	const std::vector<u16> &getVertexIndexes() const { return m_vertex_indexes; }
 
-	void beforeDraw() const;
-	void afterDraw() const;
+	void draw(video::IVideoDriver *driver) const;
+
 private:
 	scene::SMeshBuffer *m_buffer;
-	mutable std::vector<u16> m_vertex_indexes;
+	irr_ptr<scene::SIndexBuffer> m_indices;
 };
 
 /*

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -145,19 +145,18 @@ private:
  *
  * Attach alternate `Indices` to an existing mesh buffer, to make it possible to use different
  * indices with the same vertex buffer.
- *
  */
 class PartialMeshBuffer
 {
 public:
 	PartialMeshBuffer(scene::SMeshBuffer *buffer, std::vector<u16> &&vertex_indices) :
-			m_buffer(buffer)
+			m_buffer(buffer), m_indices(make_irr<scene::SIndexBuffer>())
 	{
-		m_indices.reset(new scene::SIndexBuffer());
 		m_indices->Data = std::move(vertex_indices);
+		m_indices->setHardwareMappingHint(scene::EHM_STATIC);
 	}
 
-	scene::IMeshBuffer *getBuffer() const { return m_buffer; }
+	auto *getBuffer() const { return m_buffer; }
 
 	void draw(video::IVideoDriver *driver) const;
 

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -556,8 +556,9 @@ scene::SMeshBuffer *Minimap::getMinimapMeshBuffer()
 {
 	scene::SMeshBuffer *buf = new scene::SMeshBuffer();
 	auto &vertices = buf->Vertices->Data;
+	auto &indices = buf->Indices->Data;
 	vertices.resize(4);
-	buf->Indices.resize(6);
+	indices.resize(6);
 	static const video::SColor c(255, 255, 255, 255);
 
 	vertices[0] = video::S3DVertex(-1, -1, 0, 0, 0, 1, c, 0, 1);
@@ -565,12 +566,12 @@ scene::SMeshBuffer *Minimap::getMinimapMeshBuffer()
 	vertices[2] = video::S3DVertex( 1,  1, 0, 0, 0, 1, c, 1, 0);
 	vertices[3] = video::S3DVertex( 1, -1, 0, 0, 0, 1, c, 1, 1);
 
-	buf->Indices[0] = 0;
-	buf->Indices[1] = 1;
-	buf->Indices[2] = 2;
-	buf->Indices[3] = 2;
-	buf->Indices[4] = 3;
-	buf->Indices[5] = 0;
+	indices[0] = 0;
+	indices[1] = 1;
+	indices[2] = 2;
+	indices[3] = 2;
+	indices[4] = 3;
+	indices[5] = 0;
 
 	buf->setHardwareMappingHint(scene::EHM_STATIC);
 	return buf;

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -555,14 +555,15 @@ v3f Minimap::getYawVec()
 scene::SMeshBuffer *Minimap::getMinimapMeshBuffer()
 {
 	scene::SMeshBuffer *buf = new scene::SMeshBuffer();
-	buf->Vertices.resize(4);
+	auto &vertices = buf->Vertices->Data;
+	vertices.resize(4);
 	buf->Indices.resize(6);
 	static const video::SColor c(255, 255, 255, 255);
 
-	buf->Vertices[0] = video::S3DVertex(-1, -1, 0, 0, 0, 1, c, 0, 1);
-	buf->Vertices[1] = video::S3DVertex(-1,  1, 0, 0, 0, 1, c, 0, 0);
-	buf->Vertices[2] = video::S3DVertex( 1,  1, 0, 0, 0, 1, c, 1, 0);
-	buf->Vertices[3] = video::S3DVertex( 1, -1, 0, 0, 0, 1, c, 1, 1);
+	vertices[0] = video::S3DVertex(-1, -1, 0, 0, 0, 1, c, 0, 1);
+	vertices[1] = video::S3DVertex(-1,  1, 0, 0, 0, 1, c, 0, 0);
+	vertices[2] = video::S3DVertex( 1,  1, 0, 0, 0, 1, c, 1, 0);
+	vertices[3] = video::S3DVertex( 1, -1, 0, 0, 0, 1, c, 1, 1);
 
 	buf->Indices[0] = 0;
 	buf->Indices[1] = 1;

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -830,7 +830,8 @@ void Sky::updateStars()
 		warningstream << "Requested " << m_star_params.count << " stars but " << 0x4000 << " is the max\n";
 		m_star_params.count = 0x4000;
 	}
-	m_stars->Vertices.reserve(4 * m_star_params.count);
+	auto &vertices = m_stars->Vertices->Data;
+	vertices.reserve(4 * m_star_params.count);
 	m_stars->Indices.reserve(6 * m_star_params.count);
 
 	video::SColor fallback_color = m_star_params.starcolor; // used on GLES 2 “without shaders”
@@ -852,10 +853,10 @@ void Sky::updateStars()
 		a.rotateVect(p1);
 		a.rotateVect(p2);
 		a.rotateVect(p3);
-		m_stars->Vertices.push_back(video::S3DVertex(p, {}, fallback_color, {}));
-		m_stars->Vertices.push_back(video::S3DVertex(p1, {}, fallback_color, {}));
-		m_stars->Vertices.push_back(video::S3DVertex(p2, {}, fallback_color, {}));
-		m_stars->Vertices.push_back(video::S3DVertex(p3, {}, fallback_color, {}));
+		vertices.push_back(video::S3DVertex(p, {}, fallback_color, {}));
+		vertices.push_back(video::S3DVertex(p1, {}, fallback_color, {}));
+		vertices.push_back(video::S3DVertex(p2, {}, fallback_color, {}));
+		vertices.push_back(video::S3DVertex(p3, {}, fallback_color, {}));
 	}
 	for (u16 i = 0; i < m_star_params.count; i++) {
 		m_stars->Indices.push_back(i * 4 + 0);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -831,8 +831,9 @@ void Sky::updateStars()
 		m_star_params.count = 0x4000;
 	}
 	auto &vertices = m_stars->Vertices->Data;
+	auto &indices = m_stars->Indices->Data;
 	vertices.reserve(4 * m_star_params.count);
-	m_stars->Indices.reserve(6 * m_star_params.count);
+	indices.reserve(6 * m_star_params.count);
 
 	video::SColor fallback_color = m_star_params.starcolor; // used on GLES 2 “without shaders”
 	PcgRandom rgen(m_seed);
@@ -859,12 +860,12 @@ void Sky::updateStars()
 		vertices.push_back(video::S3DVertex(p3, {}, fallback_color, {}));
 	}
 	for (u16 i = 0; i < m_star_params.count; i++) {
-		m_stars->Indices.push_back(i * 4 + 0);
-		m_stars->Indices.push_back(i * 4 + 1);
-		m_stars->Indices.push_back(i * 4 + 2);
-		m_stars->Indices.push_back(i * 4 + 2);
-		m_stars->Indices.push_back(i * 4 + 3);
-		m_stars->Indices.push_back(i * 4 + 0);
+		indices.push_back(i * 4 + 0);
+		indices.push_back(i * 4 + 1);
+		indices.push_back(i * 4 + 2);
+		indices.push_back(i * 4 + 2);
+		indices.push_back(i * 4 + 3);
+		indices.push_back(i * 4 + 0);
 	}
 	m_stars->setHardwareMappingHint(scene::EHM_STATIC);
 }

--- a/src/client/texturesource.cpp
+++ b/src/client/texturesource.cpp
@@ -39,7 +39,7 @@ struct TextureInfo
 };
 
 // TextureSource
-class TextureSource : public IWritableTextureSource
+class TextureSource final : public IWritableTextureSource
 {
 public:
 	TextureSource();

--- a/src/network/mtp/impl.h
+++ b/src/network/mtp/impl.h
@@ -234,7 +234,7 @@ class Peer : public IPeer {
 
 class UDPPeer;
 
-class Connection : public IConnection
+class Connection final : public IConnection
 {
 public:
 	friend class ConnectionSendThread;

--- a/src/util/pointer.h
+++ b/src/util/pointer.h
@@ -273,9 +273,7 @@ public:
 	void grab() noexcept { ++m_refcount; }
 	void drop() noexcept { if (--m_refcount == 0) delete this; }
 
-	// Preserve own reference count.
-	IntrusiveReferenceCounted(const IntrusiveReferenceCounted &) {}
-	IntrusiveReferenceCounted &operator=(const IntrusiveReferenceCounted &) { return *this; }
+	DISABLE_CLASS_COPY(IntrusiveReferenceCounted)
 private:
 	u32 m_refcount = 1;
 };


### PR DESCRIPTION
To do transparency sorting (#11696) we want to draw the same vertex buffer with different indices (= changing the order in which stuff gets drawn).
Irrlicht marries vertex data and index data together in its `IMeshBuffer` type.
This means to do that we need to invalidate the indices every time transparent part(s) of a MapBlock are drawn, which precludes them from being stored efficiently on the GPU.
This PR changes the way Irrlicht handles mesh buffers to consider vertex and index buffers as separate parts that can then be arbitrarily combined without downsides. (This also matches how OpenGL works anyway.)

#### Ok, but when does this actually make a difference?

To be honest I started working on this PR because it would be clear that the end result would be *somehow* better.
If you have a not so high end GPU and/or a scene with lots of transparent nodes it should make a difference in FPS. But I haven't done any stress testing.
The value to look for in the profiler is "Irr: buffers uploaded". It should be smaller with this PR.

#### About commits

Each commit is an independent unit of work and compiles and works fine.
Therefore this PR should **not** be squashed.

#### Should we backport this?

the first commit: absolutely
the rest: absolutely not

## To do

This PR is Ready for Review.

## How to test

1. MT should not crash before it reaches the main menu
2. normal world rendering should still work
3. transparency sorting should still work
4. performance should definitely not be worse than before