### PR TITLE
Debloat IVideoDriver and IrrlichtDevice includes

### DIFF
--- a/irr/include/EVideoTypes.h
+++ b/irr/include/EVideoTypes.h
@@ -1,0 +1,75 @@
+// Copyright (C) 2002-2012 Nikolaus Gebhardt
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#pragma once
+
+#include "SMaterial.h" // MATERIAL_MAX_TEXTURES
+
+namespace irr::video
+{
+
+//! enumeration for geometry transformation states
+enum E_TRANSFORMATION_STATE
+{
+	//! View transformation
+	ETS_VIEW = 0,
+	//! World transformation
+	ETS_WORLD,
+	//! Projection transformation
+	ETS_PROJECTION,
+	//! Texture 0 transformation
+	//! Use E_TRANSFORMATION_STATE(ETS_TEXTURE_0 + texture_number) to access other texture transformations
+	ETS_TEXTURE_0,
+	//! Only used internally
+	ETS_COUNT = ETS_TEXTURE_0 + MATERIAL_MAX_TEXTURES
+};
+
+//! Special render targets, which usually map to dedicated hardware
+/** These render targets (besides 0 and 1) need not be supported by gfx cards */
+enum E_RENDER_TARGET
+{
+	//! Render target is the main color frame buffer
+	ERT_FRAME_BUFFER = 0,
+	//! Render target is a render texture
+	ERT_RENDER_TEXTURE,
+	//! Multi-Render target textures
+	ERT_MULTI_RENDER_TEXTURES,
+	//! Render target is the main color frame buffer
+	ERT_STEREO_LEFT_BUFFER,
+	//! Render target is the right color buffer (left is the main buffer)
+	ERT_STEREO_RIGHT_BUFFER,
+	//! Render to both stereo buffers at once
+	ERT_STEREO_BOTH_BUFFERS,
+	//! Auxiliary buffer 0
+	ERT_AUX_BUFFER0,
+	//! Auxiliary buffer 1
+	ERT_AUX_BUFFER1,
+	//! Auxiliary buffer 2
+	ERT_AUX_BUFFER2,
+	//! Auxiliary buffer 3
+	ERT_AUX_BUFFER3,
+	//! Auxiliary buffer 4
+	ERT_AUX_BUFFER4
+};
+
+//! Enum for the flags of clear buffer
+enum E_CLEAR_BUFFER_FLAG
+{
+	ECBF_NONE = 0,
+	ECBF_COLOR = 1,
+	ECBF_DEPTH = 2,
+	ECBF_STENCIL = 4,
+	ECBF_ALL = ECBF_COLOR | ECBF_DEPTH | ECBF_STENCIL
+};
+
+//! Enum for the types of fog distributions to choose from
+enum E_FOG_TYPE
+{
+	EFT_FOG_EXP = 0,
+	EFT_FOG_LINEAR,
+	EFT_FOG_EXP2
+};
+
+}; // irr::video
+

--- a/irr/include/EVideoTypes.h
+++ b/irr/include/EVideoTypes.h
@@ -71,5 +71,5 @@ enum E_FOG_TYPE
 	EFT_FOG_EXP2
 };
 
-}; // irr::video
+} // irr::video
 

--- a/irr/include/IVideoDriver.h
+++ b/irr/include/IVideoDriver.h
@@ -9,14 +9,16 @@
 #include "ITexture.h"
 #include "irrArray.h"
 #include "matrix4.h"
-#include "plane3d.h"
 #include "dimension2d.h"
 #include "position2d.h"
-#include "IMeshBuffer.h"
 #include "EDriverTypes.h"
 #include "EDriverFeatures.h"
+#include "EPrimitiveTypes.h"
+#include "EVideoTypes.h"
 #include "SExposedVideoData.h"
 #include "SOverrideMaterial.h"
+#include "S3DVertex.h" // E_VERTEX_TYPE
+#include "SVertexIndex.h" // E_INDEX_TYPE
 
 namespace irr
 {
@@ -36,76 +38,11 @@ class ISceneNode;
 
 namespace video
 {
-struct S3DVertex;
-struct S3DVertex2TCoords;
-struct S3DVertexTangents;
 class IImageLoader;
 class IImageWriter;
 class IMaterialRenderer;
 class IGPUProgrammingServices;
 class IRenderTarget;
-
-//! enumeration for geometry transformation states
-enum E_TRANSFORMATION_STATE
-{
-	//! View transformation
-	ETS_VIEW = 0,
-	//! World transformation
-	ETS_WORLD,
-	//! Projection transformation
-	ETS_PROJECTION,
-	//! Texture 0 transformation
-	//! Use E_TRANSFORMATION_STATE(ETS_TEXTURE_0 + texture_number) to access other texture transformations
-	ETS_TEXTURE_0,
-	//! Only used internally
-	ETS_COUNT = ETS_TEXTURE_0 + MATERIAL_MAX_TEXTURES
-};
-
-//! Special render targets, which usually map to dedicated hardware
-/** These render targets (besides 0 and 1) need not be supported by gfx cards */
-enum E_RENDER_TARGET
-{
-	//! Render target is the main color frame buffer
-	ERT_FRAME_BUFFER = 0,
-	//! Render target is a render texture
-	ERT_RENDER_TEXTURE,
-	//! Multi-Render target textures
-	ERT_MULTI_RENDER_TEXTURES,
-	//! Render target is the main color frame buffer
-	ERT_STEREO_LEFT_BUFFER,
-	//! Render target is the right color buffer (left is the main buffer)
-	ERT_STEREO_RIGHT_BUFFER,
-	//! Render to both stereo buffers at once
-	ERT_STEREO_BOTH_BUFFERS,
-	//! Auxiliary buffer 0
-	ERT_AUX_BUFFER0,
-	//! Auxiliary buffer 1
-	ERT_AUX_BUFFER1,
-	//! Auxiliary buffer 2
-	ERT_AUX_BUFFER2,
-	//! Auxiliary buffer 3
-	ERT_AUX_BUFFER3,
-	//! Auxiliary buffer 4
-	ERT_AUX_BUFFER4
-};
-
-//! Enum for the flags of clear buffer
-enum E_CLEAR_BUFFER_FLAG
-{
-	ECBF_NONE = 0,
-	ECBF_COLOR = 1,
-	ECBF_DEPTH = 2,
-	ECBF_STENCIL = 4,
-	ECBF_ALL = ECBF_COLOR | ECBF_DEPTH | ECBF_STENCIL
-};
-
-//! Enum for the types of fog distributions to choose from
-enum E_FOG_TYPE
-{
-	EFT_FOG_EXP = 0,
-	EFT_FOG_LINEAR,
-	EFT_FOG_EXP2
-};
 
 const c8 *const FogTypeNames[] = {
 		"FogExp",

--- a/irr/include/IrrlichtDevice.h
+++ b/irr/include/IrrlichtDevice.h
@@ -6,14 +6,16 @@
 
 #include "IReferenceCounted.h"
 #include "dimension2d.h"
-#include "IVideoDriver.h"
 #include "EDriverTypes.h"
 #include "EDeviceTypes.h"
 #include "IEventReceiver.h"
 #include "ICursorControl.h"
 #include "ITimer.h"
 #include "IOSOperator.h"
+#include "irrArray.h"
 #include "IrrCompileConfig.h"
+#include "position2d.h"
+#include "SColor.h" // video::ECOLOR_FORMAT
 
 namespace irr
 {
@@ -38,6 +40,9 @@ class ISceneManager;
 namespace video
 {
 class IContextManager;
+class IImage;
+class ITexture;
+class IVideoDriver;
 extern "C" IRRLICHT_API bool IRRCALLCONV isDriverSupported(E_DRIVER_TYPE driver);
 } // end namespace video
 

--- a/irr/include/SViewFrustum.h
+++ b/irr/include/SViewFrustum.h
@@ -9,7 +9,7 @@
 #include "line3d.h"
 #include "aabbox3d.h"
 #include "matrix4.h"
-#include "IVideoDriver.h"
+#include "EVideoTypes.h"
 
 namespace irr
 {

--- a/irr/src/CIrrDeviceLinux.cpp
+++ b/irr/src/CIrrDeviceLinux.cpp
@@ -26,6 +26,7 @@
 #include "IGUISpriteBank.h"
 #include "IImageLoader.h"
 #include "IFileSystem.h"
+#include "IVideoDriver.h"
 #include <X11/XKBlib.h>
 #include <X11/Xatom.h>
 

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -10,6 +10,7 @@
 #include "IGUIEnvironment.h"
 #include "IImageLoader.h"
 #include "IFileSystem.h"
+#include "IVideoDriver.h"
 #include "os.h"
 #include "CTimer.h"
 #include "irrString.h"

--- a/irr/src/CIrrDeviceStub.cpp
+++ b/irr/src/CIrrDeviceStub.cpp
@@ -8,6 +8,7 @@
 #include "IFileSystem.h"
 #include "IGUIElement.h"
 #include "IGUIEnvironment.h"
+#include "IVideoDriver.h"
 #include "os.h"
 #include "CTimer.h"
 #include "CLogger.h"

--- a/irr/src/CIrrDeviceWin32.cpp
+++ b/irr/src/CIrrDeviceWin32.cpp
@@ -17,6 +17,7 @@
 #include "COSOperator.h"
 #include "dimension2d.h"
 #include "IGUISpriteBank.h"
+#include "IVideoDriver.h"
 #include <winuser.h>
 #include "SExposedVideoData.h"
 

--- a/irr/src/CSceneCollisionManager.cpp
+++ b/irr/src/CSceneCollisionManager.cpp
@@ -6,7 +6,6 @@
 #include "ICameraSceneNode.h"
 #include "SViewFrustum.h"
 
-#include "os.h"
 #include "irrMath.h"
 
 namespace irr

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -38,6 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "script/scripting_client.h"
 #include "gettext.h"
 #include <SViewFrustum.h>
+#include <IVideoDriver.h>
 
 #define CAMERA_OFFSET_STEP 200
 #define WIELDMESH_OFFSET_X 55.0f

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/mesh.h"
 #include "mapblock_mesh.h"
 #include <IMaterialRenderer.h>
+#include <IVideoDriver.h>
 #include <matrix4.h>
 #include "mapsector.h"
 #include "mapblock.h"
@@ -190,6 +191,13 @@ void ClientMap::OnRegisterSceneNode()
 	ISceneNode::OnRegisterSceneNode();
 	// It's not needed to register this node to the shadow renderer
 	// we have other way to find it
+}
+
+void ClientMap::render()
+{
+	video::IVideoDriver* driver = SceneManager->getVideoDriver();
+	driver->setTransform(video::ETS_WORLD, AbsoluteTransformation);
+	renderMap(driver, SceneManager->getSceneNodeRenderPass());
 }
 
 void ClientMap::getBlocksInViewRange(v3s16 cam_pos_nodes,

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -75,12 +75,7 @@ public:
 
 	virtual void OnRegisterSceneNode() override;
 
-	virtual void render() override
-	{
-		video::IVideoDriver* driver = SceneManager->getVideoDriver();
-		driver->setTransform(video::ETS_WORLD, AbsoluteTransformation);
-		renderMap(driver, SceneManager->getSceneNodeRenderPass());
-	}
+	virtual void render() override;
 
 	virtual const aabb3f &getBoundingBox() const override
 	{

--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cassert>
 #include <vector>
 #include <algorithm>
+#include <IVideoDriver.h>
 
 // Simple 2D bitmap class with just the functionality needed here
 class Bitmap {

--- a/src/client/render/anaglyph.cpp
+++ b/src/client/render/anaglyph.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "anaglyph.h"
 #include "client/camera.h"
+#include <IrrlichtDevice.h>
 
 
 /// SetColorMaskStep step

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace irr
 {
 	class IrrlichtDevice;
-};
+}
 
 class ShadowRenderer;
 class Camera;

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -21,6 +21,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 #include "irrlichttypes_extrabloated.h"
 
+namespace irr
+{
+	class IrrlichtDevice;
+};
+
 class ShadowRenderer;
 class Camera;
 class Client;

--- a/src/client/render/pipeline.h
+++ b/src/client/render/pipeline.h
@@ -36,7 +36,7 @@ class ShadowRenderer;
 namespace irr::video
 {
 	class IRenderTarget;
-};
+}
 
 struct PipelineContext
 {

--- a/src/client/render/pipeline.h
+++ b/src/client/render/pipeline.h
@@ -19,6 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "irrlichttypes_extrabloated.h"
+#include <IrrlichtDevice.h> // used in all render/*.cpp
+#include <IVideoDriver.h> // used in all render/*.cpp
 
 #include <vector>
 #include <memory>
@@ -30,6 +32,11 @@ class RenderStep;
 class Client;
 class Hud;
 class ShadowRenderer;
+
+namespace irr::video
+{
+	class IRenderTarget;
+};
 
 struct PipelineContext
 {

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/render/core.h"
 // include the shadow mapper classes too
 #include "client/shadows/dynamicshadowsrender.h"
+#include <IVideoDriver.h>
 
 #ifdef SERVER
 #error Do not include in server builds

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/clientenvironment.h"
 #include "client/clientmap.h"
 #include "client/camera.h"
+#include <IVideoDriver.h>
 
 using m4f = core::matrix4;
 

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -32,6 +32,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "EShaderTypes.h"
 #include "IGPUProgrammingServices.h"
 #include "IMaterialRenderer.h"
+#include <IVideoDriver.h>
 
 ShadowRenderer::ShadowRenderer(IrrlichtDevice *device, Client *client) :
 		m_smgr(device->getSceneManager()), m_driver(device->getVideoDriver()),

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <string>
 #include <vector>
+#include <IrrlichtDevice.h>
 #include "irrlichttypes_extrabloated.h"
 #include "client/shadows/dynamicshadows.h"
 

--- a/src/client/shadows/shadowsScreenQuad.cpp
+++ b/src/client/shadows/shadowsScreenQuad.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "shadowsScreenQuad.h"
+#include <IVideoDriver.h>
 
 shadowScreenQuad::shadowScreenQuad()
 {

--- a/src/gui/guiAnimatedImage.cpp
+++ b/src/gui/guiAnimatedImage.cpp
@@ -6,6 +6,7 @@
 #include "util/string.h"
 #include <string>
 #include <vector>
+#include <ITexture.h>
 
 GUIAnimatedImage::GUIAnimatedImage(gui::IGUIEnvironment *env, gui::IGUIElement *parent,
 	s32 id, const core::rect<s32> &rectangle) :

--- a/src/gui/guiBox.cpp
+++ b/src/gui/guiBox.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "guiBox.h"
+#include <IVideoDriver.h>
 
 GUIBox::GUIBox(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
 	const core::rect<s32> &rectangle,

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -37,6 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h"
 #include "util/enriched_string.h"
 #include "StyleSpec.h"
+#include <ICursorControl.h> // gui::ECURSOR_ICON
 #include <IGUIStaticText.h>
 
 class InventoryManager;

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiFormSpecMenu.h"
 #include "client/hud.h"
 #include "client/client.h"
+#include <IVideoDriver.h>
 
 GUIInventoryList::GUIInventoryList(gui::IGUIEnvironment *env,
 	gui::IGUIElement *parent,

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -29,6 +29,7 @@
 #include <IGUIButton.h>
 #include <IGUIStaticText.h>
 #include <IGUIFont.h>
+#include <IVideoDriver.h>
 #include "settings.h"
 #include <algorithm>
 

--- a/src/gui/guiOpenURL.cpp
+++ b/src/gui/guiOpenURL.cpp
@@ -20,6 +20,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "guiEditBoxWithScrollbar.h"
 #include <IGUIEditBox.h>
 #include <IGUIFont.h>
+#include <IVideoDriver.h>
 #include "client/renderingengine.h"
 #include "porting.h"
 #include "gettext.h"

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -24,6 +24,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <IGUIButton.h>
 #include <IGUIStaticText.h>
 #include <IGUIFont.h>
+#include <IVideoDriver.h>
 
 #include "porting.h"
 #include "gettext.h"

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <SViewFrustum.h>
 #include <IAnimatedMeshSceneNode.h>
+#include <IVideoDriver.h>
 #include "porting.h"
 
 GUIScene::GUIScene(gui::IGUIEnvironment *env, scene::ISceneManager *smgr,

--- a/src/gui/guiVolumeChange.cpp
+++ b/src/gui/guiVolumeChange.cpp
@@ -27,6 +27,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <IGUIButton.h>
 #include <IGUIStaticText.h>
 #include <IGUIFont.h>
+#include <IVideoDriver.h>
 #include "settings.h"
 
 #include "gettext.h"

--- a/src/gui/profilergraph.cpp
+++ b/src/gui/profilergraph.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "porting.h"
 #include "profilergraph.h"
+#include "IVideoDriver.h"
 #include "util/string.h"
 
 void ProfilerGraph::put(const Profiler::GraphValues &values)

--- a/src/gui/profilergraph.h
+++ b/src/gui/profilergraph.h
@@ -23,8 +23,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <deque>
 #include <utility>
 #include <IGUIFont.h>
-#include <IVideoDriver.h>
 #include "profiler.h"
+
+namespace irr::video {
+	class IVideoDriver;
+};
 
 /* Profiler display */
 class ProfilerGraph

--- a/src/gui/profilergraph.h
+++ b/src/gui/profilergraph.h
@@ -27,7 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 namespace irr::video {
 	class IVideoDriver;
-};
+}
 
 /* Profiler display */
 class ProfilerGraph

--- a/src/gui/touchcontrols.cpp
+++ b/src/gui/touchcontrols.cpp
@@ -34,6 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gettext.h"
 #include "IGUIStaticText.h"
 #include "IGUIFont.h"
+#include <IrrlichtDevice.h>
 #include <ISceneCollisionManager.h>
 
 #include <iostream>

--- a/src/gui/touchcontrols.h
+++ b/src/gui/touchcontrols.h
@@ -25,7 +25,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IEventReceiver.h>
 #include <IGUIImage.h>
 #include <IGUIEnvironment.h>
-#include <IrrlichtDevice.h>
 
 #include <memory>
 #include <optional>
@@ -34,6 +33,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "itemdef.h"
 #include "client/game.h"
+
+namespace irr
+{
+	class IrrlichtDevice;
+};
 
 using namespace irr;
 using namespace irr::core;

--- a/src/gui/touchcontrols.h
+++ b/src/gui/touchcontrols.h
@@ -37,7 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace irr
 {
 	class IrrlichtDevice;
-};
+}
 
 using namespace irr;
 using namespace irr::core;

--- a/src/irrlichttypes_extrabloated.h
+++ b/src/irrlichttypes_extrabloated.h
@@ -24,7 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef SERVER
 #include <IMesh.h>
 #include <IImage.h>
-#include <IrrlichtDevice.h>
 #include <IMeshSceneNode.h>
 #include <IDummyTransformationSceneNode.h>
 #include <SMesh.h>


### PR DESCRIPTION
As the project grows, compile time will not go down unless the header mess is cleaned up one by one to only include exactly what's needed. This PR begins by offloading `IVideoDriver` and `IrrlichtDevice` to source files in several places.

`irrlichttypes_extrabloated.h` should be banned in long-term.

## To do

This PR is Ready for Review.

## How to test

1. It must compile