### PR TITLE
TouchControls: Fix outdated player controls in TOSERVER_INTERACT

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3358,6 +3358,9 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	if (g_touchcontrols) {
 		auto mode = selected_def.touch_interaction.getMode(pointed.type);
 		g_touchcontrols->applyContextControls(mode);
+		// update again so that TOSERVER_INTERACT packets have the correct controls set
+		client->getEnv().getLocalPlayer()->control.dig = isKeyDown(KeyType::DIG);
+		client->getEnv().getLocalPlayer()->control.place = isKeyDown(KeyType::PLACE);
 	}
 
 	// Note that updating the selection mesh every frame is not particularly efficient,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3358,9 +3358,10 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	if (g_touchcontrols) {
 		auto mode = selected_def.touch_interaction.getMode(pointed.type);
 		g_touchcontrols->applyContextControls(mode);
-		// update again so that TOSERVER_INTERACT packets have the correct controls set
-		client->getEnv().getLocalPlayer()->control.dig = isKeyDown(KeyType::DIG);
-		client->getEnv().getLocalPlayer()->control.place = isKeyDown(KeyType::PLACE);
+		// applyContextControls may change dig/place input.
+		// Update again so that TOSERVER_INTERACT packets have the correct controls set.
+		player->control.dig = isKeyDown(KeyType::DIG);
+		player->control.place = isKeyDown(KeyType::PLACE);
 	}
 
 	// Note that updating the selection mesh every frame is not particularly efficient,


### PR DESCRIPTION
**Problem**

I noticed that with 5.9.0 on Android in A.E.S. Block League, the SMG is buggy: Sometimes, it only does a single shot.

**Apparent reason**

`TouchControls::applyContextControls` changes player controls after `Game::updatePlayerControl` has run. This means that `TOSERVER_INTERACT` contains outdated player controls. With a bad connection, this may result in the up-to-date player controls only arriving after the repeat loop has already been canceled.

This is a regression from #14087.

Relevant code:
https://gitlab.com/zughy-friends-minetest/weapons_lib/-/blob/f8b6ade5ed1a39cbe4ff356028940a6d5f742ea9/src/api/weapons.lua#L625-647
https://gitlab.com/zughy-friends-minetest/block_league/-/blob/ee8070da0d8476b0ff99969ecaa589dffecdffda/block_league/src/weapons/smg.lua#L45-69

## To do

This PR is a Ready for Review.

## How to test

Join the A.E.S. server on Android with a bad connection, see that the SMG isn't buggy.

**OR**

On desktop:
1. `sudo iptables -A INPUT -i <interface> -p udp --destination-port 30000  -m statistic --mode random --probability 0.15 -j DROP`
2. Start a server with the block league mod
3. Optional: Set up some logging: https://gist.github.com/grorp/7e354cb77b22b41ebc3ab3d848cb7e92. Example output with bug: [unsuccessful.txt](https://github.com/user-attachments/files/16824134/unsuccessful.txt). Example output without bug: [successful.txt](https://github.com/user-attachments/files/16824140/successful.txt).

On Android:
1. Join the server you just created
2. Take an SMG from the creative inventory
3. Shoot

Master: Sometimes, the SMG only does a single shot.
This PR: The SMG works fine.