### PR TITLE
Fix uninitialized SkyboxParams::fog_color

### DIFF
--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -46,7 +46,7 @@ struct SkyboxParams
 	float body_orbit_tilt { INVALID_SKYBOX_TILT };
 	s16 fog_distance { -1 };
 	float fog_start { -1.0f };
-	video::SColor fog_color; // override, only used if alpha > 0
+	video::SColor fog_color { 0 }; // override, only used if alpha > 0
 };
 
 struct SunParams


### PR DESCRIPTION
fixes a regression from #14296

what it should look like:
![](https://github.com/user-attachments/assets/6b6434f2-13b0-4950-ab70-bcda9f598a58)

what it does look like on my Android device (can't reproduce on desktop):
![](https://github.com/user-attachments/assets/c942665b-ea8b-4580-8118-d20b26cf3c31)

## To do

This PR is a Ready for Review.

## How to test

Example: Join a minigame on the A.E.S. server on Android, verify that the sky looks as it should.