### PR TITLE
Only apply "touch_punch_gesture" when item has no on_use callback

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9300,9 +9300,17 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
       -- If specified as a table, the field to be used is selected according to
       -- the current `pointed_thing`.
       -- There are three possible TouchInteractionMode values:
-      -- * "user"                 (meaning depends on client-side settings)
       -- * "long_dig_short_place" (long tap  = dig, short tap = place)
       -- * "short_dig_long_place" (short tap = dig, long tap  = place)
+      -- * "user":
+      --   * For `pointed_object`: Equivalent to "short_dig_long_place" if the
+      --     client-side setting "touch_punch_gesture" is "short_tap" (the
+      --     default value) and the item is able to punch (i.e. has no on_use
+      --     callback defined).
+      --     Equivalent to "long_dig_short_place" otherwise.
+      --   * For `pointed_node` and `pointed_nothing`:
+      --     Equivalent to "long_dig_short_place".
+      --   * The behavior of "user" may change in the future.
       -- The default value is "user".
 
     sound = {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3356,7 +3356,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 		infostream << "Pointing at " << pointed.dump() << std::endl;
 
 	if (g_touchcontrols) {
-		auto mode = selected_def.touch_interaction.getMode(pointed.type);
+		auto mode = selected_def.touch_interaction.getMode(selected_def, pointed.type);
 		g_touchcontrols->applyContextControls(mode);
 		// applyContextControls may change dig/place input.
 		// Update again so that TOSERVER_INTERACT packets have the correct controls set.

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -45,7 +45,8 @@ TouchInteraction::TouchInteraction()
 	pointed_object  = TouchInteractionMode_USER;
 }
 
-TouchInteractionMode TouchInteraction::getMode(PointedThingType pointed_type) const
+TouchInteractionMode TouchInteraction::getMode(const ItemDefinition &selected_def,
+		PointedThingType pointed_type) const
 {
 	TouchInteractionMode result;
 	switch (pointed_type) {
@@ -63,7 +64,9 @@ TouchInteractionMode TouchInteraction::getMode(PointedThingType pointed_type) co
 	}
 
 	if (result == TouchInteractionMode_USER) {
-		if (pointed_type == POINTEDTHING_OBJECT)
+		if (pointed_type == POINTEDTHING_OBJECT && !selected_def.usable)
+			// Only apply when we're actually able to punch the object, i.e. when
+			// the selected item has no on_use callback defined.
 			result = g_settings->get("touch_punch_gesture") == "long_tap" ?
 					LONG_DIG_SHORT_PLACE : SHORT_DIG_LONG_PLACE;
 		else

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -71,7 +71,8 @@ struct TouchInteraction
 	TouchInteraction();
 	// Returns the right mode for the pointed thing and resolves any occurrence
 	// of TouchInteractionMode_USER into an actual mode.
-	TouchInteractionMode getMode(PointedThingType pointed_type) const;
+	TouchInteractionMode getMode(const ItemDefinition &selected_def,
+			PointedThingType pointed_type) const;
 	void serialize(std::ostream &os) const;
 	void deSerialize(std::istream &is);
 };


### PR DESCRIPTION
fixes #15097

With this PR, "touch_punch_gesture" is only applied when the item is actually able to punch, i.e. has no on_use callback defined. Feedback/ideas welcome.

## To do

This PR is a Ready for Review.

## How to test

Verify that you can still punch with short tap. Verify that the cases mentioned in the issue are fixed:

1. Create a MTG world with Simple Shooter and Mobs Monster.
2. Use the SMG to shoot monsters (by doing a long tap and holding, which translates to holding LMB)
3. When the monsters get closer and you can point them, ~~the SMG stops working: Since you're pointing an object, you would have to do a short tap instead of a long tap to press LMB~~ the SMG continues working as usual

Another example:
1. Eat an apple without pointing an entity (long tap)
2. Eat an apple while pointing an entity (~~short tap~~ still long tap)