### PR TITLE
Reduce include count in headers

### DIFF
--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes.h"
 #include "inventory.h"
 #include "util/numeric.h"
 #include "client/localplayer.h"

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -52,6 +52,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "profiler.h"
 #include "shader.h"
 #include "gettext.h"
+#include "clientdynamicinfo.h"
 #include "clientmap.h"
 #include "clientmedia.h"
 #include "version.h"

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -20,22 +20,20 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "clientenvironment.h"
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes.h"
 #include <ostream>
 #include <map>
 #include <memory>
 #include <set>
 #include <vector>
 #include <unordered_set>
-#include "clientobject.h"
 #include "gamedef.h"
 #include "inventorymanager.h"
-#include "client/hud.h"
-#include "tileanimation.h"
 #include "network/address.h"
+#include "network/networkprotocol.h" // multiple enums
 #include "network/peerhandler.h"
 #include "gameparams.h"
-#include "clientdynamicinfo.h"
+#include "script/common/c_types.h" // LuaError
 #include "util/numeric.h"
 
 #ifdef SERVER
@@ -44,32 +42,33 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define CLIENT_CHAT_MESSAGE_LIMIT_PER_10S 10.0f
 
-struct ClientEvent;
-struct MeshMakeData;
-struct ChatMessage;
-class MapBlockMesh;
-class RenderingEngine;
-class IWritableTextureSource;
-class IWritableShaderSource;
-class IWritableItemDefManager;
-class ISoundManager;
-class NodeDefManager;
-//class IWritableCraftDefManager;
+class Camera;
 class ClientMediaDownloader;
-class SingleMediaDownloader;
-struct MapDrawControl;
+class ISoundManager;
+class IWritableItemDefManager;
+class IWritableShaderSource;
+class IWritableTextureSource;
+class MapBlockMesh;
+class MapDatabase;
+class MeshUpdateManager;
+class Minimap;
 class ModChannelMgr;
 class MtEventManager;
-struct PointedThing;
-struct MapNode;
-class MapDatabase;
-class Minimap;
-struct MinimapMapblock;
-class MeshUpdateManager;
-class ParticleManager;
-class Camera;
-struct PlayerControl;
 class NetworkPacket;
+class NodeDefManager;
+class ParticleManager;
+class RenderingEngine;
+class SingleMediaDownloader;
+struct ChatMessage;
+struct ClientDynamicInfo;
+struct ClientEvent;
+struct MapDrawControl;
+struct MapNode;
+struct MeshMakeData;
+struct MinimapMapblock;
+struct PlayerControl;
+struct PointedThing;
+
 namespace con {
 class IConnection;
 }

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -20,7 +20,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include <string>
-#include "irrlichttypes_bloated.h"
+#include "irrlichttypes.h"
+#include "client/hud.h" // HudElementStat
 
 struct ParticleParameters;
 struct ParticleSpawnerParameters;

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "player.h"
 #include "chat.h"
 #include "gettext.h"
+#include "inputhandler.h"
 #include "profiler.h"
 #include "gui/guiEngine.h"
 #include "fontengine.h"

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -19,11 +19,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
-#include "client/inputhandler.h"
-#include "gameparams.h"
+#include <string>
 
 class RenderingEngine;
+class Settings;
+class MyEventReceiver;
+class InputHandler;
+struct GameStartData;
+struct MainMenuData;
 
 class ClientLauncher
 {

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes_bloated.h"
 #include "map.h"
 #include "camera.h"
 #include <set>
@@ -40,6 +40,16 @@ struct MapDrawControl
 class Client;
 class ITextureSource;
 class PartialMeshBuffer;
+
+namespace irr::scene
+{
+	class IMeshBuffer;
+}
+
+namespace irr::video
+{
+	class IVideoDriver;
+}
 
 /*
 	ClientMap

--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes_bloated.h"
 #include "activeobject.h"
 #include <memory>
 #include <unordered_map>
@@ -33,6 +33,13 @@ class IGameDef;
 class LocalPlayer;
 struct ItemStack;
 class WieldMeshSceneNode;
+
+namespace irr::scene
+{
+	class IAnimatedMeshSceneNode;
+	class ISceneNode;
+	class ISceneManager;
+}
 
 class ClientActiveObject : public ActiveObject
 {

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -19,13 +19,21 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "irrlichttypes_bloated.h"
 #include "constants.h"
 #include "irr_ptr.h"
-#include "irrlichttypes_extrabloated.h"
 #include "skyparams.h"
 #include <iostream>
+#include <ISceneNode.h>
+#include <SMaterial.h>
+#include <SMeshBuffer.h>
 
 class IShaderSource;
+
+namespace irr::scene
+{
+	class ISceneManager;
+}
 
 // Menu clouds
 class Clouds;

--- a/src/client/content_cso.cpp
+++ b/src/client/content_cso.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "content_cso.h"
 #include <IBillboardSceneNode.h>
+#include <ISceneManager.h>
 #include "client/texturesource.h"
 #include "clientenvironment.h"
 #include "client.h"

--- a/src/client/content_cso.h
+++ b/src/client/content_cso.h
@@ -19,8 +19,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes_bloated.h"
 #include "clientsimpleobject.h"
+
+namespace irr::scene
+{
+	class ISceneManager;
+}
 
 ClientSimpleObject* createSmokePuff(scene::ISceneManager *smgr,
 		ClientEnvironment *env, v3f pos, v2f size);

--- a/src/client/filecache.cpp
+++ b/src/client/filecache.cpp
@@ -20,7 +20,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "filecache.h"
 
-#include "network/networkprotocol.h"
 #include "log.h"
 #include "filesys.h"
 #include <string>

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -23,10 +23,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <gettext.h>
 #include "gui/mainmenumanager.h"
 #include "gui/guiChatConsole.h"
+#include "gui/guiFormSpecMenu.h"
+#include "util/enriched_string.h"
 #include "util/pointedthing.h"
 #include "client.h"
 #include "clientmap.h"
 #include "fontengine.h"
+#include "hud.h" // HUD_FLAG_*
 #include "nodedef.h"
 #include "profiler.h"
 #include "renderingengine.h"

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -22,15 +22,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "irrlichttypes.h"
 #include <IGUIEnvironment.h>
-#include "gui/guiFormSpecMenu.h"
-#include "util/enriched_string.h"
-#include "util/pointedthing.h"
 #include "game.h"
 
 using namespace irr;
 class Client;
+class EnrichedString;
 class GUIChatConsole;
+class GUIFormSpecMenu;
 struct MapDrawControl;
+struct PointedThing;
 
 /*
  * This object intend to contain the core UI elements

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -23,6 +23,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h"
 #include <cstdio>
 #include "client/renderingengine.h"
+#include <IImage.h>
+#include <ITexture.h>
+#include <IVideoDriver.h>
 
 /* Maintain a static cache to store the images that correspond to textures
  * in a format that's manipulable by code.  Some platforms exhibit issues

--- a/src/client/guiscalingfilter.h
+++ b/src/client/guiscalingfilter.h
@@ -18,7 +18,17 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes.h"
+#include <path.h>
+#include <rect.h>
+#include <SColor.h>
+
+namespace irr::video
+{
+	class IImage;
+	class ITexture;
+	class IVideoDriver;
+}
 
 /* Manually insert an image into the cache, useful to avoid texture-to-image
  * conversion whenever we can intercept it.

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -22,6 +22,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <vector>
 #include <IGUIFont.h>
+#include <SMaterial.h>
+#include <SMeshBuffer.h>
 #include "irr_aabb3d.h"
 #include "../hud.h"
 
@@ -31,6 +33,17 @@ class Inventory;
 class InventoryList;
 class LocalPlayer;
 struct ItemStack;
+
+namespace irr::scene
+{
+	class IMesh;
+}
+
+namespace irr::video
+{
+	class ITexture;
+	class IVideoDriver;
+}
 
 class Hud
 {

--- a/src/client/imagefilters.h
+++ b/src/client/imagefilters.h
@@ -18,7 +18,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes.h"
+#include <rect.h>
+
+namespace irr::video
+{
+	class IVideoDriver;
+	class IImage;
+}
 
 /* Fill in RGB values for transparent pixels, to correct for odd colors
  * appearing at borders when blending.  This is because many PNG optimizers

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes.h"
 #include "joystick_controller.h"
 #include <list>
 #include "keycode.h"

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -19,16 +19,22 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes_bloated.h"
 #include <ISceneNode.h>
+#include <SMeshBuffer.h>
 #include <array>
-#include "camera.h"
+#include "camera.h" // CameraMode
 #include "irr_ptr.h"
-#include "shader.h"
 #include "skyparams.h"
 
 #define SKY_MATERIAL_COUNT 12
 
+namespace irr::video
+{
+	class IVideoDriver;
+}
+
+class IShaderSource;
 class ITextureSource;
 
 // Skybox, rendered with zbuffer turned off, before all other nodes.

--- a/src/client/texturesource.h
+++ b/src/client/texturesource.h
@@ -20,9 +20,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "irrlichttypes.h"
-#include <ITexture.h>
+#include <SColor.h>
 #include <string>
 #include <vector>
+
+namespace irr::video
+{
+	class IImage;
+	class ITexture;
+}
 
 typedef std::vector<video::SColor> Palette;
 

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -21,7 +21,20 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <string>
 #include <vector>
-#include "irrlichttypes_extrabloated.h"
+#include "irr_aabb3d.h"
+#include "irr_v3d.h"
+#include <EMaterialTypes.h>
+#include <IMeshSceneNode.h>
+#include <SColor.h>
+
+namespace irr::scene
+{
+	class ISceneManager;
+	class IMesh;
+	struct SMesh;
+}
+
+using namespace irr;
 
 struct ItemStack;
 class Client;

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -17,16 +17,17 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#pragma once
+
 #include "client/texturesource.h"
 #include "client/fontengine.h"
 #include "debug.h"
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes_bloated.h"
 #include "util/string.h"
 #include <algorithm>
 #include <array>
 #include <vector>
 
-#pragma once
 
 class StyleSpec
 {

--- a/src/gui/guiBackgroundImage.cpp
+++ b/src/gui/guiBackgroundImage.cpp
@@ -19,6 +19,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "client/guiscalingfilter.h"
 #include "log.h"
 #include "client/texturesource.h"
+#include <ITexture.h>
 
 GUIBackgroundImage::GUIBackgroundImage(gui::IGUIEnvironment *env,
 	gui::IGUIElement *parent, s32 id, const core::rect<s32> &rectangle,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -38,6 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IGUIImage.h>
 #include <IAnimatedMeshSceneNode.h>
 #include "client/renderingengine.h"
+#include "client/joystick_controller.h"
 #include "log.h"
 #include "client/hud.h" // drawItemStack
 #include "filesys.h"

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <stack>
 #include <unordered_set>
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes_bloated.h"
 #include "irr_ptr.h"
 #include "inventory.h"
 #include "inventorymanager.h"
@@ -32,8 +32,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiInventoryList.h"
 #include "guiScrollBar.h"
 #include "guiTable.h"
-#include "network/networkprotocol.h"
-#include "client/joystick_controller.h"
 #include "util/string.h"
 #include "util/enriched_string.h"
 #include "StyleSpec.h"
@@ -45,6 +43,7 @@ class ISimpleTextureSource;
 class Client;
 class GUIScrollContainer;
 class ISoundManager;
+class JoystickController;
 
 enum FormspecFieldType {
 	f_Button,

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiHyperText.h"
 #include "guiScrollBar.h"
 #include "client/fontengine.h"
+#include "client/hud.h" // drawItemStack
 #include "IVideoDriver.h"
 #include "client/client.h"
 #include "client/renderingengine.h"

--- a/src/gui/guiItemImage.cpp
+++ b/src/gui/guiItemImage.cpp
@@ -19,7 +19,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "guiItemImage.h"
 #include "client/client.h"
+#include "client/hud.h" // drawItemStack
 #include "inventory.h"
+#include <IGUIFont.h>
 
 GUIItemImage::GUIItemImage(gui::IGUIEnvironment *env, gui::IGUIElement *parent,
 	s32 id, const core::rect<s32> &rectangle, const std::string &item_name,

--- a/src/gui/guiPathSelectMenu.cpp
+++ b/src/gui/guiPathSelectMenu.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "guiPathSelectMenu.h"
+#include "guiFormSpecMenu.h" //required because of TextDest only !!!
 
 GUIFileSelectMenu::GUIFileSelectMenu(gui::IGUIEnvironment* env,
 		gui::IGUIElement* parent, s32 id, IMenuManager *menumgr,

--- a/src/gui/guiPathSelectMenu.h
+++ b/src/gui/guiPathSelectMenu.h
@@ -23,7 +23,8 @@
 
 #include "modalMenu.h"
 #include "IGUIFileOpenDialog.h"
-#include "guiFormSpecMenu.h" //required because of TextDest only !!!
+
+struct TextDest;
 
 class GUIFileSelectMenu : public GUIModalMenu
 {

--- a/src/hud.h
+++ b/src/hud.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes_bloated.h"
 #include <string>
 #include "common/c_types.h"
 

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes_bloated.h"
 #include <string>
 #include <iostream>
 #include <optional>

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -17,7 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include "irrlichttypes_extrabloated.h"
+#include "irrlichttypes_bloated.h"
 #include "mapnode.h"
 #include "porting.h"
 #include "nodedef.h"

--- a/src/nameidmapping.h
+++ b/src/nameidmapping.h
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <iostream>
 #include <unordered_map>
 #include <cassert>
-#include "irrlichttypes_bloated.h"
+#include "irrlichttypes.h"
 
 typedef std::unordered_map<u16, std::string> IdToNameMap;
 typedef std::unordered_map<std::string, u16> NameToIdMap;

--- a/src/network/peerhandler.h
+++ b/src/network/peerhandler.h
@@ -19,8 +19,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include "networkprotocol.h"
-
 namespace con
 {
 

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -21,7 +21,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "server.h"
-#include "networkprotocol.h"
 
 class NetworkPacket;
 // Note: don't forward-declare Server here (#14324)

--- a/src/player.h
+++ b/src/player.h
@@ -22,7 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_bloated.h"
 #include "inventory.h"
 #include "constants.h"
-#include "network/networkprotocol.h"
 #include "util/basic_macros.h"
 #include "util/string.h"
 #include <list>

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "player.h"
 #include "skyparams.h"
 #include "lighting.h"
+#include "network/networkprotocol.h" // session_t
 
 class PlayerSAO;
 

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -34,6 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "content/subgames.h"
 #include "mapgen/mapgen.h"
 #include "settings.h"
+#include "clientdynamicinfo.h"
 #include "client/client.h"
 #include "client/renderingengine.h"
 #include "network/networkprotocol.h"


### PR DESCRIPTION
Sort of a follow-up on #15080

## To do

This PR is Ready for Review.

Next goal is to offload the often changed constants from `networkprotocol.h` to a source file. I did not want to break too many PRs, thus only include cleanup for now.

## How to test

1. It must compile.
