### PR TITLE
TouchControls: Fix setUseCrosshair not being called

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1510,10 +1510,6 @@ bool Game::createClient(const GameStartData &start_data)
 		client->getScript()->on_camera_ready(camera);
 	client->setCamera(camera);
 
-	if (g_touchcontrols) {
-		g_touchcontrols->setUseCrosshair(!isTouchCrosshairDisabled());
-	}
-
 	/* Clouds
 	 */
 	if (m_cache_enable_clouds)
@@ -1578,8 +1574,10 @@ bool Game::initGui()
 	gui_chat_console = new GUIChatConsole(guienv, guienv->getRootGUIElement(),
 			-1, chat_backend, client, &g_menumgr);
 
-	if (g_settings->getBool("touch_controls"))
+	if (g_settings->getBool("touch_controls")) {
 		g_touchcontrols = new TouchControls(device, texture_src);
+		g_touchcontrols->setUseCrosshair(!isTouchCrosshairDisabled());
+	}
 
 	return true;
 }


### PR DESCRIPTION
Because of a change in initialization order in #14472, `g_touchcontrols` was always nullptr and `setUseCrosshair` wasn't called. Looks like this didn't cause any problems (so doesn't seem necessary for 5.9.1), but it will cause problems for #14933 in the future.

## To do

This PR is a Ready for Review

## How to test

Read