### PR TITLE
Allow to disable transparency sorting entirely

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1856,7 +1856,7 @@ video_driver (Video driver) enum  ,opengl,opengl3,ogles2
 
 #    Distance in nodes at which transparency depth sorting is enabled.
 #    Use this to limit the performance impact of transparency depth sorting.
-#    Set to 0 to disable transparency sorting entirely.
+#    Set to 0 to disable it entirely.
 transparency_sorting_distance (Transparency Sorting Distance) int 16 0 128
 
 #    Radius of cloud area stated in number of 64 node cloud squares.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1854,8 +1854,9 @@ shader_path (Shader path) path
 #    OpenGL is the default for desktop, and OGLES2 for Android.
 video_driver (Video driver) enum  ,opengl,opengl3,ogles2
 
-#    Distance in nodes at which transparency depth sorting is enabled
-#    Use this to limit the performance impact of transparency depth sorting
+#    Distance in nodes at which transparency depth sorting is enabled.
+#    Use this to limit the performance impact of transparency depth sorting.
+#    Set to 0 to disable transparency sorting entirely.
 transparency_sorting_distance (Transparency Sorting Distance) int 16 0 128
 
 #    Radius of cloud area stated in number of 64 node cloud squares.

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1311,8 +1311,8 @@ void ClientMap::updateTransparentMeshBuffers()
 	ScopeProfiler sp(g_profiler, "CM::updateTransparentMeshBuffers", SPT_AVG);
 	u32 sorted_blocks = 0;
 	u32 unsorted_blocks = 0;
+	bool transparency_sorting_enabled = m_cache_transparency_sorting_distance != 0.0f;
 	f32 sorting_distance = m_cache_transparency_sorting_distance * BS;
-
 
 	// Update the order of transparent mesh buffers in each mesh
 	for (auto it = m_drawlist.begin(); it != m_drawlist.end(); it++) {
@@ -1323,13 +1323,19 @@ void ClientMap::updateTransparentMeshBuffers()
 
 		if (m_needs_update_transparent_meshes ||
 				blockmesh->getTransparentBuffers().size() == 0) {
+			bool do_sort_block = transparency_sorting_enabled;
 
-			v3f mesh_sphere_center = intToFloat(block->getPosRelative(), BS)
-					+ blockmesh->getBoundingSphereCenter();
-			f32 mesh_sphere_radius = blockmesh->getBoundingRadius();
-			f32 distance_sq = m_camera_position.getDistanceFromSQ(mesh_sphere_center);
+			if (do_sort_block) {
+				v3f mesh_sphere_center = intToFloat(block->getPosRelative(), BS)
+						+ blockmesh->getBoundingSphereCenter();
+				f32 mesh_sphere_radius = blockmesh->getBoundingRadius();
+				f32 distance_sq = m_camera_position.getDistanceFromSQ(mesh_sphere_center);
 
-			if (distance_sq <= std::pow(sorting_distance + mesh_sphere_radius, 2.0f)) {
+				if (distance_sq > std::pow(sorting_distance + mesh_sphere_radius, 2.0f))
+					do_sort_block = false;
+			}
+
+			if (do_sort_block) {
 				blockmesh->updateTransparentBuffers(m_camera_position, block->getPos());
 				++sorted_blocks;
 			} else {

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1311,7 +1311,7 @@ void ClientMap::updateTransparentMeshBuffers()
 	ScopeProfiler sp(g_profiler, "CM::updateTransparentMeshBuffers", SPT_AVG);
 	u32 sorted_blocks = 0;
 	u32 unsorted_blocks = 0;
-	bool transparency_sorting_enabled = m_cache_transparency_sorting_distance != 0.0f;
+	bool transparency_sorting_enabled = m_cache_transparency_sorting_distance > 0;
 	f32 sorting_distance = m_cache_transparency_sorting_distance * BS;
 
 	// Update the order of transparent mesh buffers in each mesh


### PR DESCRIPTION
Before 0f7ee12, you could set `transparency_sorting_distance` to 0 to disable transparency sorting (in almost all cases, only not if you're *exactly* at the block origin). This PR restores this feature.

(Btw., 128 nodes is a weirdly low upper limit.)

## To do

This PR is a Ready for Review.

## How to test

* Stand next to a node with semi transparency.
* Notice how it's not sorted if you set `transparency_sorting_distance` to 0.
