### PR TITLE
Add chat console scrollbar

### DIFF
--- a/src/chat.h
+++ b/src/chat.h
@@ -112,7 +112,8 @@ public:
 
 	void resize(u32 scrollback);
 
-protected:
+	// Get the current scroll position
+	s32 getScrollPosition() const { return m_scroll; }
 	s32 getTopScrollPos() const;
 	s32 getBottomScrollPos() const;
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1799,7 +1799,9 @@ void Game::processUserInput(f32 dtime)
 		m_game_focused = true;
 	}
 
-	if (!guienv->hasFocus(gui_chat_console.get()) && gui_chat_console->isOpen()) {
+	if (!guienv->hasFocus(gui_chat_console.get()) && gui_chat_console->isOpen()
+		&& !gui_chat_console->isMyChild(guienv->getFocus()))
+	{
 		gui_chat_console->closeConsoleAtOnce();
 	}
 

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -16,6 +16,7 @@
 #include "gettext.h"
 #include "irrlicht_changes/CGUITTFont.h"
 #include "util/string.h"
+#include "guiScrollBar.h"
 #include <string>
 
 inline u32 clamp_u8(s32 value)
@@ -26,6 +27,11 @@ inline u32 clamp_u8(s32 value)
 inline bool isInCtrlKeys(const irr::EKEY_CODE& kc)
 {
 	return kc == KEY_LCONTROL || kc == KEY_RCONTROL || kc == KEY_CONTROL;
+}
+
+inline u32 getScrollbarSize(IGUIEnvironment* env)
+{
+	return env->getSkin()->getSize(gui::EGDS_SCROLLBAR_SIZE);
 }
 
 GUIChatConsole::GUIChatConsole(
@@ -81,12 +87,20 @@ GUIChatConsole::GUIChatConsole(
 	// track ctrl keys for mouse event
 	m_is_ctrl_down = false;
 	m_cache_clickable_chat_weblinks = g_settings->getBool("clickable_chat_weblinks");
+
+	m_scrollbar = new GUIScrollBar(env, this, -1, core::rect<s32>(0, 0, 30, m_height), false, true, tsrc);
+	m_scrollbar->setSubElement(true);
+	m_scrollbar->setLargeStep(1);
+	m_scrollbar->setSmallStep(1);
 }
 
 GUIChatConsole::~GUIChatConsole()
 {
 	if (m_font)
 		m_font->drop();
+
+	if (m_scrollbar)
+		m_scrollbar->drop();
 }
 
 void GUIChatConsole::openConsole(f32 scale)
@@ -121,6 +135,7 @@ void GUIChatConsole::closeConsole()
 	m_open = false;
 	Environment->removeFocus(this);
 	m_menumgr->deletingMenu(this);
+	m_scrollbar->setVisible(false);
 }
 
 void GUIChatConsole::closeConsoleAtOnce()
@@ -180,6 +195,10 @@ void GUIChatConsole::draw()
 		m_screensize = screensize;
 		m_desired_height = m_desired_height_fraction * m_screensize.Y;
 		reformatConsole();
+	} else if (!m_scrollbar->getAbsolutePosition().isPointInside(core::vector2di(screensize.X, m_height))) {
+		// the height of the chat window is no longer the height of the scrollbar
+		// happens while opening/closing the window
+		updateScrollbar(true);
 	}
 
 	// Animation
@@ -204,6 +223,9 @@ void GUIChatConsole::reformatConsole()
 	s32 rows = m_desired_height / m_fontsize.Y - 1; // make room for the input prompt
 	if (cols <= 0 || rows <= 0)
 		cols = rows = 0;
+
+	updateScrollbar(true);
+
 	recalculateConsolePosition();
 	m_chat_backend->reformat(cols, rows);
 }
@@ -297,6 +319,13 @@ void GUIChatConsole::drawText()
 		return;
 
 	ChatBuffer& buf = m_chat_backend->getConsoleBuffer();
+
+	core::recti rect;
+	if (m_scrollbar->isVisible())
+		rect = core::rect<s32> (0, 0, m_screensize.X - getScrollbarSize(Environment), m_height);
+	else
+		rect = AbsoluteClippingRect;
+
 	for (u32 row = 0; row < buf.getRows(); ++row)
 	{
 		const ChatFormattedLine& line = buf.getFormattedLine(row);
@@ -321,7 +350,7 @@ void GUIChatConsole::drawText()
 					destrect,
 					false,
 					false,
-					&AbsoluteClippingRect);
+					&rect);
 			} else {
 				// Otherwise use standard text
 				m_font->draw(
@@ -330,10 +359,12 @@ void GUIChatConsole::drawText()
 					video::SColor(255, 255, 255, 255),
 					false,
 					false,
-					&AbsoluteClippingRect);
+					&rect);
 			}
 		}
 	}
+
+	updateScrollbar();
 }
 
 void GUIChatConsole::drawPrompt()
@@ -680,6 +711,11 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		prompt.input(std::wstring(event.StringInput.Str->c_str()));
 		return true;
 	}
+	else if (event.EventType == EET_GUI_EVENT && event.GUIEvent.EventType == EGET_SCROLL_BAR_CHANGED &&
+			(void*) event.GUIEvent.Caller == (void*) m_scrollbar)
+	{
+		m_chat_backend->getConsoleBuffer().scrollAbsolute(m_scrollbar->getPos());
+	}
 
 	return Parent ? Parent->OnEvent(event) : false;
 }
@@ -692,6 +728,7 @@ void GUIChatConsole::setVisible(bool visible)
 		m_height = 0;
 		recalculateConsolePosition();
 	}
+	m_scrollbar->setVisible(visible);
 }
 
 bool GUIChatConsole::weblinkClick(s32 col, s32 row)
@@ -762,4 +799,19 @@ void GUIChatConsole::updatePrimarySelection()
 	std::wstring wselected = m_chat_backend->getPrompt().getSelection();
 	std::string selected = wide_to_utf8(wselected);
 	Environment->getOSOperator()->copyToPrimarySelection(selected.c_str());
+}
+
+void GUIChatConsole::updateScrollbar(bool update_size)
+{
+	ChatBuffer &buf = m_chat_backend->getConsoleBuffer();
+	m_scrollbar->setMin(buf.getTopScrollPos());
+	m_scrollbar->setMax(buf.getBottomScrollPos());
+	m_scrollbar->setPos(buf.getScrollPosition());
+	m_scrollbar->setPageSize(m_fontsize.Y * buf.getLineCount());
+	m_scrollbar->setVisible(m_scrollbar->getMin() != m_scrollbar->getMax());
+
+	if (update_size) {
+		const core::rect<s32> rect (m_screensize.X - getScrollbarSize(Environment), 0, m_screensize.X, m_height);
+		m_scrollbar->setRelativePosition(rect);
+	}
 }

--- a/src/gui/guiChatConsole.h
+++ b/src/gui/guiChatConsole.h
@@ -10,6 +10,7 @@
 #include "config.h"
 
 class Client;
+class GUIScrollBar;
 
 class GUIChatConsole : public gui::IGUIElement
 {
@@ -76,10 +77,13 @@ private:
 	// If the selected text changed, we need to update the (X11) primary selection.
 	void updatePrimarySelection();
 
+	void updateScrollbar(bool update_size = false);
+
 private:
 	ChatBackend* m_chat_backend;
 	Client* m_client;
 	IMenuManager* m_menumgr;
+	GUIScrollBar* m_scrollbar = nullptr;
 
 	// current screen size
 	v2u32 m_screensize;

--- a/src/gui/guiChatConsole.h
+++ b/src/gui/guiChatConsole.h
@@ -8,6 +8,7 @@
 #include "modalMenu.h"
 #include "chat.h"
 #include "config.h"
+#include "irr_ptr.h"
 
 class Client;
 class GUIScrollBar;
@@ -21,7 +22,6 @@ public:
 			ChatBackend* backend,
 			Client* client,
 			IMenuManager* menumgr);
-	virtual ~GUIChatConsole();
 
 	// Open the console (height = desired fraction of screen size)
 	// This doesn't open immediately but initiates an animation.
@@ -83,7 +83,7 @@ private:
 	ChatBackend* m_chat_backend;
 	Client* m_client;
 	IMenuManager* m_menumgr;
-	GUIScrollBar* m_scrollbar = nullptr;
+	irr_ptr<GUIScrollBar> m_scrollbar;
 
 	// current screen size
 	v2u32 m_screensize;
@@ -120,7 +120,7 @@ private:
 	video::SColor m_background_color = video::SColor(255, 0, 0, 0);
 
 	// font
-	gui::IGUIFont *m_font = nullptr;
+	irr_ptr<gui::IGUIFont> m_font;
 	v2u32 m_fontsize;
 
 	// Enable clickable chat weblinks


### PR DESCRIPTION
This pull request adds a scrollbar to the console window.
![image](https://github.com/user-attachments/assets/e8af17e3-2bef-4c17-ae71-f543a1c51bbc)


Works towards closing https://github.com/minetest/minetest/issues/14994


If not a bug fix, why is this PR needed? What usecases does it solve?
-

1. Mobile players gain the ability to scroll in chat
2. Serves as an indicator whilst scrolling

## To do

This PR is ready for review.
<!-- ^ delete one -->

- [x] Keep scroll up-to-date while console is opened

## How to test

- Clone and compile my branch like usual
- Open a game
- Fill your console/chat with text (spamming)
- Verify that upon a scrollbar appears upon it "overflowing"
- Verify that the scrollbar can indeed be used to scroll

**Don't forget the "big console window", which can be opened by pressing F10**
