### PR TITLE
Simplify `TOSERVER_INIT` and `TOCLIENT_HELLO`

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1140,10 +1140,7 @@ void Client::sendInit(const std::string &playerName)
 {
 	NetworkPacket pkt(TOSERVER_INIT, 1 + 2 + 2 + (1 + playerName.size()));
 
-	// we don't support network compression yet
-	u16 supp_comp_modes = NETPROTO_COMPRESSION_NONE;
-
-	pkt << (u8) SER_FMT_VER_HIGHEST_READ << (u16) supp_comp_modes;
+	pkt << (u8) SER_FMT_VER_HIGHEST_READ << (u16) 0;
 	pkt << (u16) CLIENT_PROTOCOL_VERSION_MIN << (u16) CLIENT_PROTOCOL_VERSION_MAX;
 	pkt << playerName;
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -78,11 +78,11 @@ void Client::handleCommand_Hello(NetworkPacket* pkt)
 
 	u8 serialization_ver;
 	u16 proto_ver;
-	u16 compression_mode;
+	u16 unused_compression_mode;
 	u32 auth_mechs;
-	std::string username_legacy; // for case insensitivity
-	*pkt >> serialization_ver >> compression_mode >> proto_ver
-		>> auth_mechs >> username_legacy;
+	std::string unused;
+	*pkt >> serialization_ver >> unused_compression_mode >> proto_ver
+		>> auth_mechs >> unused;
 
 	// Chose an auth method we support
 	AuthMechanism chosen_auth_mechanism = choseAuthMech(auth_mechs);
@@ -91,7 +91,6 @@ void Client::handleCommand_Hello(NetworkPacket* pkt)
 			<< "serialization_ver=" << (u32)serialization_ver
 			<< ", auth_mechs=" << auth_mechs
 			<< ", proto_ver=" << proto_ver
-			<< ", compression_mode=" << compression_mode
 			<< ". Doing auth with mech " << chosen_auth_mechanism << std::endl;
 
 	if (!ser_ver_supported(serialization_ver)) {
@@ -102,10 +101,6 @@ void Client::handleCommand_Hello(NetworkPacket* pkt)
 
 	m_server_ser_ver = serialization_ver;
 	m_proto_ver = proto_ver;
-
-	//TODO verify that username_legacy matches sent username, only
-	// differs in casing (make both uppercase and compare)
-	// This is only necessary though when we actually want to add casing support
 
 	if (m_chosen_auth_mech != AUTH_MECHANISM_NONE) {
 		// we received a TOCLIENT_HELLO while auth was already going on

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -257,7 +257,7 @@ enum ToClientCommand : u16
 		Sent after TOSERVER_INIT.
 
 		u8 deployed serialization version
-		u16 deployed network compression mode (unused)
+		u16 unused (network compression, never implemeneted)
 		u16 deployed protocol version
 		u32 supported auth methods
 		std::string unused (used to be username)

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -243,9 +243,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define CLIENT_PROTOCOL_VERSION_MIN 37
 #define CLIENT_PROTOCOL_VERSION_MAX LATEST_PROTOCOL_VERSION
 
-#define PASSWORD_SIZE 28    // Maximum password length. Allows for
-                            // base64-encoded SHA-1 (27+\0).
-
 // See also formspec [Version History] in doc/lua_api.md
 #define FORMSPEC_API_VERSION 7
 
@@ -260,10 +257,10 @@ enum ToClientCommand : u16
 		Sent after TOSERVER_INIT.
 
 		u8 deployed serialization version
-		u16 deployed network compression mode
+		u16 deployed network compression mode (unused)
 		u16 deployed protocol version
 		u32 supported auth methods
-		std::string username that should be used for legacy hash (for proper casing)
+		std::string unused (used to be username)
 	*/
 	TOCLIENT_AUTH_ACCEPT = 0x03,
 	/*
@@ -914,7 +911,7 @@ enum ToServerCommand : u16
 		Sent first after connected.
 
 		u8 serialization version (=SER_FMT_VER_HIGHEST_READ)
-		u16 supported network compression modes
+		u16 supported network compression modes (unused)
 		u16 minimum supported network protocol version
 		u16 maximum supported network protocol version
 		std::string player name
@@ -1147,10 +1144,6 @@ enum AccessDeniedCode : u8 {
 	SERVER_ACCESSDENIED_SHUTDOWN,
 	SERVER_ACCESSDENIED_CRASH,
 	SERVER_ACCESSDENIED_MAX,
-};
-
-enum NetProtoCompressionMode {
-	NETPROTO_COMPRESSION_NONE = 0,
 };
 
 enum PlayerListModifer : u8

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -911,7 +911,7 @@ enum ToServerCommand : u16
 		Sent first after connected.
 
 		u8 serialization version (=SER_FMT_VER_HIGHEST_READ)
-		u16 supported network compression modes (unused)
+		u16 unused (supported network compression mode, never implemeneted)
 		u16 minimum supported network protocol version
 		u16 maximum supported network protocol version
 		std::string player name

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -911,7 +911,7 @@ enum ToServerCommand : u16
 		Sent first after connected.
 
 		u8 serialization version (=SER_FMT_VER_HIGHEST_READ)
-		u16 unused (supported network compression mode, never implemeneted)
+		u16 unused (supported network compression modes, never implemeneted)
 		u16 minimum supported network protocol version
 		u16 maximum supported network protocol version
 		std::string player name

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -101,12 +101,12 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 	// First byte after command is maximum supported
 	// serialization version
 	u8 client_max;
-	u16 supp_compr_modes;
+	u16 unused;
 	u16 min_net_proto_version = 0;
 	u16 max_net_proto_version;
 	std::string playerName;
 
-	*pkt >> client_max >> supp_compr_modes >> min_net_proto_version
+	*pkt >> client_max >> unused >> min_net_proto_version
 			>> max_net_proto_version >> playerName;
 
 	u8 our_max = SER_FMT_VER_HIGHEST_READ;
@@ -190,9 +190,6 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 	}
 
 	m_clients.setPlayerName(peer_id, playername);
-	//TODO (later) case insensitivity
-
-	std::string legacyPlayerNameCasing = playerName;
 
 	if (!isSingleplayer() && strcasecmp(playername, "singleplayer") == 0) {
 		actionstream << "Server: Player with the name \"singleplayer\" tried "
@@ -280,16 +277,14 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 		<< auth_mechs << std::endl;
 
 	NetworkPacket resp_pkt(TOCLIENT_HELLO,
-		1 + 4 + legacyPlayerNameCasing.size(), peer_id);
+		1 + 2 + 2 + 4 + 2, peer_id);
 
-	u16 depl_compress_mode = NETPROTO_COMPRESSION_NONE;
-	resp_pkt << depl_serial_v << depl_compress_mode << net_proto_version
-		<< auth_mechs << legacyPlayerNameCasing;
+	resp_pkt << depl_serial_v << u16(0) << net_proto_version
+		<< auth_mechs << std::string_view();
 
 	Send(&resp_pkt);
 
 	client->allowed_auth_mechs = auth_mechs;
-	client->setDeployedCompressionMode(depl_compress_mode);
 
 	m_clients.event(peer_id, CSE_Hello);
 }

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -276,8 +276,7 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 	verbosestream << "Sending TOCLIENT_HELLO with auth method field: "
 		<< auth_mechs << std::endl;
 
-	NetworkPacket resp_pkt(TOCLIENT_HELLO,
-		1 + 2 + 2 + 4 + 2, peer_id);
+	NetworkPacket resp_pkt(TOCLIENT_HELLO, 0, peer_id);
 
 	resp_pkt << depl_serial_v << u16(0) << net_proto_version
 		<< auth_mechs << std::string_view();

--- a/src/server/clientiface.h
+++ b/src/server/clientiface.h
@@ -321,9 +321,6 @@ public:
 	void setPendingSerializationVersion(u8 version)
 		{ m_pending_serialization_version = version; }
 
-	void setDeployedCompressionMode(u16 byteFlag)
-		{ m_deployed_compression = byteFlag; }
-
 	void confirmSerializationVersion()
 		{ serialization_version = m_pending_serialization_version; }
 
@@ -448,8 +445,6 @@ private:
 	u8 m_version_patch = 0;
 
 	std::string m_full_version = "unknown";
-
-	u16 m_deployed_compression = 0;
 
 	/*
 		time this client was created


### PR DESCRIPTION
Clean up some network code.

- Network compression support was never added.
- Client hasn't used the returned playername since at least 0.4-stable.


## How to test

See if it compiles and if you can connect using the oldest supported client.