### PR TITLE
Fix upright sprite entities not animating

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1264,6 +1264,16 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 	}
 }
 
+static void setMeshBufferTextureCoords(scene::IMeshBuffer *buf, const v2f *uv, u32 count)
+{
+	assert(buf->getVertexType() == video::EVT_STANDARD);
+	assert(buf->getVertexCount() == count);
+	auto *vertices = static_cast<video::S3DVertex *>(buf->getVertices());
+	for (u32 i = 0; i < count; i++)
+		vertices[i].TCoords = uv[i];
+	buf->setDirty(scene::EBT_VERTEX);
+}
+
 void GenericCAO::updateTexturePos()
 {
 	if(m_spritenode)

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -198,16 +198,6 @@ void setMeshColor(scene::IMesh *mesh, const video::SColor &color)
 		setMeshBufferColor(mesh->getMeshBuffer(j), color);
 }
 
-void setMeshBufferTextureCoords(scene::IMeshBuffer *buf, const v2f *uv, u32 count)
-{
-	assert(buf->getVertexType() == video::EVT_STANDARD);
-	assert(buf->getVertexCount() >= count);
-	auto *vertices = static_cast<video::S3DVertex *>(buf->getVertices());
-	for (u32 i = 0; i < count; i++)
-		vertices[i].TCoords = uv[i];
-	buf->setDirty(scene::EBT_VERTEX);
-}
-
 template <typename F>
 static void applyToMesh(scene::IMesh *mesh, const F &fn)
 {

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "mesh.h"
+#include "S3DVertex.h"
 #include "debug.h"
 #include "log.h"
 #include <cmath>
@@ -199,11 +200,12 @@ void setMeshColor(scene::IMesh *mesh, const video::SColor &color)
 
 void setMeshBufferTextureCoords(scene::IMeshBuffer *buf, const v2f *uv, u32 count)
 {
-	const u32 stride = getVertexPitchFromType(buf->getVertexType());
+	assert(buf->getVertexType() == video::EVT_STANDARD);
 	assert(buf->getVertexCount() >= count);
-	u8 *vertices = (u8 *) buf->getVertices();
+	auto *vertices = static_cast<video::S3DVertex *>(buf->getVertices());
 	for (u32 i = 0; i < count; i++)
-		((video::S3DVertex*) (vertices + i * stride))->TCoords = uv[i];
+		vertices[i].TCoords = uv[i];
+	buf->setDirty(scene::EBT_VERTEX);
 }
 
 template <typename F>

--- a/src/client/mesh.h
+++ b/src/client/mesh.h
@@ -59,13 +59,6 @@ void setMeshBufferColor(scene::IMeshBuffer *buf, const video::SColor &color);
 */
 void setMeshColor(scene::IMesh *mesh, const video::SColor &color);
 
-
-/*
-	Sets texture coords for vertices in the mesh buffer.
-	`uv[]` must have `count` elements
-*/
-void setMeshBufferTextureCoords(scene::IMeshBuffer *buf, const v2f *uv, u32 count);
-
 /*
 	Set a constant color for an animated mesh
 */


### PR DESCRIPTION
Fixes #15105. We just need to mark the mesh buffers as dirty after manipulating the vertices so that they get reuploaded to the GPU.