### PR TITLE
[no squash] Fix texture matrix handling in our shaders

### DIFF
--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -91,7 +91,7 @@ float directional_ambient(vec3 normal)
 
 void main(void)
 {
-	varTexCoord = (mTexture * inTexCoord0).st;
+	varTexCoord = (mTexture * vec4(inTexCoord0.xy, 1.0, 1.0)).st;
 	gl_Position = mWorldViewProj * inVertexPosition;
 
 	vPosition = gl_Position.xyz;

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -1096,8 +1096,11 @@ void COpenGL3DriverBase::setMaterial(const SMaterial &material)
 	OverrideMaterial.apply(Material);
 
 	for (u32 i = 0; i < Feature.MaxTextureUnits; ++i) {
-		CacheHandler->getTextureCache().set(i, material.getTexture(i));
-		setTransform((E_TRANSFORMATION_STATE)(ETS_TEXTURE_0 + i), material.getTextureMatrix(i));
+		auto *texture = material.getTexture(i);
+		CacheHandler->getTextureCache().set(i, texture);
+		if (texture) {
+			setTransform((E_TRANSFORMATION_STATE)(ETS_TEXTURE_0 + i), material.getTextureMatrix(i));
+		}
 	}
 }
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -746,9 +746,6 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offs
 				material.MaterialType = m_shdrsrc->getShaderInfo(
 						p.layer.shader_id).material;
 				p.layer.applyMaterialOptionsWithShaders(material);
-				if (p.layer.normal_texture)
-					material.setTexture(1, p.layer.normal_texture);
-				material.setTexture(2, p.layer.flags_texture);
 			} else {
 				p.layer.applyMaterialOptions(material);
 			}
@@ -858,11 +855,6 @@ bool MapBlockMesh::animate(bool faraway, float time, int crack,
 
 		const FrameSpec &frame = (*tile.frames)[frameno];
 		buf->getMaterial().setTexture(0, frame.texture);
-		if (m_enable_shaders) {
-			if (frame.normal_texture)
-				buf->getMaterial().setTexture(1, frame.normal_texture);
-			buf->getMaterial().setTexture(2, frame.flags_texture);
-		}
 	}
 
 	// Day-night transition

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -249,7 +249,7 @@ public:
 		m_world_view_proj.set(worldViewProj, services);
 
 		if (driver->getDriverType() == video::EDT_OGLES2 || driver->getDriverType() == video::EDT_OPENGL3) {
-			core::matrix4 texture = driver->getTransform(video::ETS_TEXTURE_0);
+			auto &texture = driver->getTransform(video::ETS_TEXTURE_0);
 			m_world_view.set(worldView, services);
 			m_texture.set(texture, services);
 		}
@@ -573,6 +573,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		} else {
 			shaders_header << "#version 100\n";
 		}
+		// cf. EVertexAttributes.h for the predefined ones
 		vertex_header = R"(
 			precision mediump float;
 
@@ -582,7 +583,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 
 			attribute highp vec4 inVertexPosition;
 			attribute lowp vec4 inVertexColor;
-			attribute mediump vec4 inTexCoord0;
+			attribute mediump vec2 inTexCoord0;
 			attribute mediump vec3 inVertexNormal;
 			attribute mediump vec4 inVertexTangent;
 			attribute mediump vec4 inVertexBinormal;

--- a/src/client/texturesource.cpp
+++ b/src/client/texturesource.cpp
@@ -137,7 +137,6 @@ public:
 
 	video::ITexture* getNormalTexture(const std::string &name);
 	video::SColor getTextureAverageColor(const std::string &name);
-	video::ITexture *getShaderFlagsTexture(bool normamap_present);
 
 private:
 
@@ -540,26 +539,4 @@ video::SColor TextureSource::getTextureAverageColor(const std::string &name)
 	image->drop();
 
 	return c;
-}
-
-
-video::ITexture *TextureSource::getShaderFlagsTexture(bool normalmap_present)
-{
-	std::string tname = "__shaderFlagsTexture";
-	tname += normalmap_present ? "1" : "0";
-
-	if (isKnownSourceImage(tname)) {
-		return getTexture(tname);
-	}
-
-	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
-	video::IImage *flags_image = driver->createImage(
-		video::ECF_A8R8G8B8, core::dimension2d<u32>(1, 1));
-	sanity_check(flags_image);
-	video::SColor c(255, normalmap_present ? 255 : 0, 0, 0);
-	flags_image->setPixel(0, 0, c);
-	insertSourceImage(tname, flags_image);
-	flags_image->drop();
-	return getTexture(tname);
-
 }

--- a/src/client/texturesource.h
+++ b/src/client/texturesource.h
@@ -71,7 +71,6 @@ public:
 	virtual bool isKnownSourceImage(const std::string &name)=0;
 	virtual video::ITexture* getNormalTexture(const std::string &name)=0;
 	virtual video::SColor getTextureAverageColor(const std::string &name)=0;
-	virtual video::ITexture *getShaderFlagsTexture(bool normalmap_present)=0;
 };
 
 class IWritableTextureSource : public ITextureSource
@@ -93,7 +92,6 @@ public:
 	virtual void rebuildImagesAndTextures()=0;
 	virtual video::ITexture* getNormalTexture(const std::string &name)=0;
 	virtual video::SColor getTextureAverageColor(const std::string &name)=0;
-	virtual video::ITexture *getShaderFlagsTexture(bool normalmap_present)=0;
 };
 
 IWritableTextureSource *createTextureSource();

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -62,8 +62,6 @@ struct FrameSpec
 
 	u32 texture_id = 0;
 	video::ITexture *texture = nullptr;
-	video::ITexture *normal_texture = nullptr;
-	video::ITexture *flags_texture = nullptr;
 };
 
 #define MAX_TILE_LAYERS 2
@@ -114,8 +112,6 @@ struct TileLayer
 	// Ordered for size, please do not reorder
 
 	video::ITexture *texture = nullptr;
-	video::ITexture *normal_texture = nullptr;
-	video::ITexture *flags_texture = nullptr;
 
 	u32 shader_id = 0;
 

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -306,9 +306,6 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 		});
 		// mipmaps cause "thin black line" artifacts
 		material.UseMipMaps = false;
-		if (m_enable_shaders) {
-			material.setTexture(2, tsrc->getShaderFlagsTexture(false));
-		}
 	}
 }
 
@@ -343,7 +340,6 @@ static scene::SMesh *createSpecialNodeMesh(Client *client, MapNode n,
 			if (p.layer.material_flags & MATERIAL_FLAG_ANIMATION) {
 				const FrameSpec &frame = (*p.layer.frames)[0];
 				p.layer.texture = frame.texture;
-				p.layer.normal_texture = frame.normal_texture;
 			}
 			for (video::S3DVertex &v : p.vertices) {
 				v.Color.setAlpha(255);
@@ -771,16 +767,6 @@ void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
 				material.setTexture(0, animation_frame.texture);
 			} else {
 				material.setTexture(0, layer->texture);
-			}
-			if (use_shaders) {
-				if (layer->normal_texture) {
-					if (layer->animation_frame_count > 1) {
-						const FrameSpec &animation_frame = (*layer->frames)[0];
-						material.setTexture(1, animation_frame.normal_texture);
-					} else
-						material.setTexture(1, layer->normal_texture);
-				}
-				material.setTexture(2, layer->flags_texture);
 			}
 
 			if (apply_scale && tile->world_aligned) {

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -712,8 +712,6 @@ static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 	if (!tile.world_aligned)
 		layer->scale = 1;
 
-	layer->flags_texture = tsrc->getShaderFlagsTexture(layer->normal_texture ? true : false);
-
 	// Material flags
 	layer->material_flags = 0;
 	if (backface_culling)
@@ -753,18 +751,13 @@ static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 
 		std::ostringstream os(std::ios::binary);
 		for (int i = 0; i < frame_count; i++) {
-			FrameSpec frame;
-
 			os.str("");
 			os << tiledef.name;
 			tiledef.animation.getTextureModifer(os,
 					layer->texture->getOriginalSize(), i);
 
+			FrameSpec &frame = (*layer->frames)[i];
 			frame.texture = tsrc->getTextureForMesh(os.str(), &frame.texture_id);
-			if (layer->normal_texture)
-				frame.normal_texture = tsrc->getNormalTexture(os.str());
-			frame.flags_texture = layer->flags_texture;
-			(*layer->frames)[i] = frame;
 		}
 	}
 }


### PR DESCRIPTION
context: https://stackoverflow.com/questions/7747566/can-you-use-glvertexattribpointer-to-assign-a-smaller-vector-to-a-larger-one

fixes #13580

second commit is unrelated but it was convenient here

## To do

This PR is Ready for Review.


## How to test

see other issue
