### PR TITLE
MacOS: make mute sound actually work

### DIFF
--- a/src/client/sound.cpp
+++ b/src/client/sound.cpp
@@ -101,7 +101,11 @@ void sound_volume_control(ISoundManager *sound_mgr, bool is_window_active)
 {
 	bool mute_sound = g_settings->getBool("mute_sound");
 	if (mute_sound) {
+#if defined(__APPLE__)
+		sound_mgr->setListenerGain(0.001f);
+#else
 		sound_mgr->setListenerGain(0.0f);
+#endif
 	} else {
 		// Check if volume is in the proper range, else fix it.
 		float old_volume = g_settings->getFloat("sound_volume");

--- a/src/client/sound.cpp
+++ b/src/client/sound.cpp
@@ -101,11 +101,7 @@ void sound_volume_control(ISoundManager *sound_mgr, bool is_window_active)
 {
 	bool mute_sound = g_settings->getBool("mute_sound");
 	if (mute_sound) {
-#if defined(__APPLE__)
-		sound_mgr->setListenerGain(0.001f);
-#else
 		sound_mgr->setListenerGain(0.0f);
-#endif
 	} else {
 		// Check if volume is in the proper range, else fix it.
 		float old_volume = g_settings->getFloat("sound_volume");

--- a/src/client/sound/sound_manager.cpp
+++ b/src/client/sound/sound_manager.cpp
@@ -29,6 +29,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "porting.h"
 
+#include <limits>
+
 namespace sound {
 
 void OpenALSoundManager::stepStreams(f32 dtime)
@@ -347,6 +349,13 @@ void OpenALSoundManager::updateListener(const v3f &pos_, const v3f &vel_,
 
 void OpenALSoundManager::setListenerGain(f32 gain)
 {
+#if defined(__APPLE__)
+	/* macOS OpenAL implementation ignore setting AL_GAIN to zero
+	 * so we use smallest possible value
+	 */
+	if (gain == 0.0f)
+		gain = std::numeric_limits<f32>::min();
+#endif
 	alListenerf(AL_GAIN, gain);
 }
 


### PR DESCRIPTION
For some reason on macOS OpenAL looks to ignore setting global gain to 0.0f, but setting it to the smallest float normalized value takes effect.

Ready for Review.

## How to test

Run on macOS and try to mute/unmute the game.
