### PR TITLE
Add SDL2 options to compiling README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Command-line options
 Compiling
 ---------
 
+- [Compiling - common informations](doc/compiling/README.md)
 - [Compiling on GNU/Linux](doc/compiling/linux.md)
 - [Compiling on Windows](doc/compiling/windows.md)
 - [Compiling on MacOS](doc/compiling/macos.md)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Command-line options
 Compiling
 ---------
 
-- [Compiling - common informations](doc/compiling/README.md)
+- [Compiling - common information](doc/compiling/README.md)
 - [Compiling on GNU/Linux](doc/compiling/linux.md)
 - [Compiling on Windows](doc/compiling/windows.md)
 - [Compiling on MacOS](doc/compiling/macos.md)

--- a/doc/compiling/README.md
+++ b/doc/compiling/README.md
@@ -44,9 +44,9 @@ General options and their default values:
 
 Library specific options:
 
-    SDL2_DLL                        - Only if building with SDL2 on Windows; path to libsdl2.dll
-    SDL2_INCLUDE_DIR                - Only if building with SDL2; directory where sdl.h is located
-    SDL2_LIBRARY                    - Only if building with SDL2; path to libsdl.a/libsdl.so/libsdl.lib
+    SDL2_DLL                        - Only if building with SDL2 on Windows; path to libSDL2.dll
+    SDL2_INCLUDE_DIRS               - Only if building with SDL2; directory where SDL.h is located
+    SDL2_LIBRARIES                  - Only if building with SDL2; path to libSDL2.a/libSDL2.so/libSDL2.lib
     CURL_DLL                        - Only if building with cURL on Windows; path to libcurl.dll
     CURL_INCLUDE_DIR                - Only if building with cURL; directory where curl.h is located
     CURL_LIBRARY                    - Only if building with cURL; path to libcurl.a/libcurl.so/libcurl.lib

--- a/doc/compiling/README.md
+++ b/doc/compiling/README.md
@@ -22,6 +22,7 @@ General options and their default values:
         MinSizeRel             - Release build with -Os passed to compiler to make executable as small as possible
     PRECOMPILE_HEADERS=FALSE   - Precompile some headers (experimental; requires CMake 3.16 or later)
     PRECOMPILED_HEADERS_PATH=  - Path to a file listing all headers to precompile (default points to src/precompiled_headers.txt)
+    USE_SDL2=TRUE              - Build with SDL2; Enables IrrlichtMt device SDL2
     ENABLE_CURL=ON             - Build with cURL; Enables use of online mod repo, public serverlist and remote media fetching via http
     ENABLE_CURSES=ON           - Build with (n)curses; Enables a server side terminal (command line option: --terminal)
     ENABLE_GETTEXT=ON          - Build with Gettext; Allows using translations
@@ -43,6 +44,9 @@ General options and their default values:
 
 Library specific options:
 
+    SDL2_DLL                        - Only if building with SDL2 on Windows; path to libsdl2.dll
+    SDL2_INCLUDE_DIR                - Only if building with SDL2; directory where sdl.h is located
+    SDL2_LIBRARY                    - Only if building with SDL2; path to libsdl.a/libsdl.so/libsdl.lib
     CURL_DLL                        - Only if building with cURL on Windows; path to libcurl.dll
     CURL_INCLUDE_DIR                - Only if building with cURL; directory where curl.h is located
     CURL_LIBRARY                    - Only if building with cURL; path to libcurl.a/libcurl.so/libcurl.lib


### PR DESCRIPTION
Just improve compiling README doc.

So if somebody has no idea that the `USE_SDL2` option exists, he can find it easily.

## To do

This PR is a Ready for Review.

