### PR TITLE
Include unistd.h header so other Unices can use getpid()

### DIFF
--- a/irr/src/CIrrDeviceLinux.cpp
+++ b/irr/src/CIrrDeviceLinux.cpp
@@ -29,6 +29,7 @@
 #include "IVideoDriver.h"
 #include <X11/XKBlib.h>
 #include <X11/Xatom.h>
+#include <unistd.h>
 
 #if defined(_IRR_LINUX_X11_XINPUT2_)
 #include <X11/extensions/XInput2.h>


### PR DESCRIPTION
What the commit says. some Unices, like OpenBSD for example, have `getpid()` as part of `unistd.h`, This should be portable back to Linux according to this manpage:

https://man7.org/linux/man-pages/man2/getpid.2.html

This fixes the build-time error where `getpid()` is not declared on these platforms.

(although I haven't the machines to test this on Linux)

OK?