### PR TITLE
[for 5.9.1 only] Revert "Set VBO hints in more places"

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -809,18 +809,6 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 				<<"\" not supported"<<std::endl;
 	}
 
-	/* Set VBO hint */
-	// - if shaders are disabled we modify the mesh often
-	// - sprites are also modified often
-	// - the wieldmesh sets its own hint
-	// - bone transformations do not need to modify the vertex data
-	if (m_enable_shaders && (m_meshnode || m_animated_meshnode)) {
-		if (m_meshnode)
-			m_meshnode->getMesh()->setHardwareMappingHint(scene::EHM_STATIC);
-		if (m_animated_meshnode)
-			m_animated_meshnode->getMesh()->setHardwareMappingHint(scene::EHM_STATIC);
-	}
-
 	/* don't update while punch texture modifier is active */
 	if (m_reset_textures_timer < 0)
 		updateTextures(m_current_texture_modifier);

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -157,7 +157,6 @@ Hud::Hud(Client *client, LocalPlayer *player,
 
 	b->getMaterial().Lighting = false;
 	b->getMaterial().MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-	b->setHardwareMappingHint(scene::EHM_STATIC);
 }
 
 void Hud::readScalingSetting()

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -573,7 +573,6 @@ scene::SMeshBuffer *Minimap::getMinimapMeshBuffer()
 	indices[4] = 3;
 	indices[5] = 0;
 
-	buf->setHardwareMappingHint(scene::EHM_STATIC);
 	return buf;
 }
 

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -1049,7 +1049,6 @@ void CGUITTFont::createSharedPlane()
 	buf->append(vertices, 4, indices, 6);
 
 	shared_plane_.addMeshBuffer( buf );
-	shared_plane_.setHardwareMappingHint(EHM_STATIC);
 
 	shared_plane_ptr_ = &shared_plane_;
 	buf->drop(); //the addMeshBuffer method will grab it, so we can drop this ptr.

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -474,7 +474,6 @@ public:
 		// Create new ClientCached
 		auto cc = std::make_unique<ClientCached>();
 
-		// Create an inventory texture
 		cc->inventory_texture = NULL;
 		if (!inventory_image.empty())
 			cc->inventory_texture = tsrc->getTexture(inventory_image);

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -474,6 +474,7 @@ public:
 		// Create new ClientCached
 		auto cc = std::make_unique<ClientCached>();
 
+		// Create an inventory texture
 		cc->inventory_texture = NULL;
 		if (!inventory_image.empty())
 			cc->inventory_texture = tsrc->getTexture(inventory_image);


### PR DESCRIPTION
Fixes #14999 for 5.9.1 as discussed on IRC (https://irc.minetest.net/minetest-dev/2024-09-10#i_6200329)

This revert is equivalent to what @wsor4035 did in https://github.com/minetest/minetest/issues/14999#issuecomment-2336503895

## To do

This PR is a Ready for Review.

## How to test

Verify that the issue is gone if you can reproduce it (I can't)

@wsor4035 @nininik0 @TechnoWolfTV feel free to test