### PR TITLE
[no squash] Divorce map database locking from env lock

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -316,6 +316,12 @@ bool EmergeManager::enqueueBlockEmergeEx(
 }
 
 
+size_t EmergeManager::getQueueSize()
+{
+	MutexAutoLock queuelock(m_queue_mutex);
+	return m_blocks_enqueued.size();
+}
+
 bool EmergeManager::isBlockInQueue(v3s16 pos)
 {
 	MutexAutoLock queuelock(m_queue_mutex);
@@ -540,7 +546,9 @@ bool EmergeThread::popBlockEmerge(v3s16 *pos, BlockEmergeData *bedata)
 EmergeAction EmergeThread::getBlockOrStartGen(const v3s16 pos, bool allow_gen,
 	 const std::string *from_db, MapBlock **block, BlockMakeData *bmdata)
 {
+	//TimeTaker tt("", nullptr, PRECISION_MICRO);
 	Server::EnvAutoLock envlock(m_server);
+	//g_profiler->avg("EmergeThread: lock wait time [us]", tt.stop());
 
 	auto block_ok = [] (MapBlock *b) {
 		return b && b->isGenerated();

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -540,7 +540,7 @@ bool EmergeThread::popBlockEmerge(v3s16 *pos, BlockEmergeData *bedata)
 EmergeAction EmergeThread::getBlockOrStartGen(const v3s16 pos, bool allow_gen,
 	 const std::string *from_db, MapBlock **block, BlockMakeData *bmdata)
 {
-	MutexAutoLock envlock(m_server->m_env_mutex);
+	Server::EnvAutoLock envlock(m_server);
 
 	auto block_ok = [] (MapBlock *b) {
 		return b && b->isGenerated();
@@ -581,7 +581,7 @@ EmergeAction EmergeThread::getBlockOrStartGen(const v3s16 pos, bool allow_gen,
 MapBlock *EmergeThread::finishGen(v3s16 pos, BlockMakeData *bmdata,
 	std::map<v3s16, MapBlock *> *modified_blocks)
 {
-	MutexAutoLock envlock(m_server->m_env_mutex);
+	Server::EnvAutoLock envlock(m_server);
 	ScopeProfiler sp(g_profiler,
 		"EmergeThread: after Mapgen::makeChunk", SPT_AVG);
 
@@ -762,7 +762,7 @@ void *EmergeThread::run()
 			MapEditEvent event;
 			event.type = MEET_OTHER;
 			event.setModifiedBlocks(modified_blocks);
-			MutexAutoLock envlock(m_server->m_env_mutex);
+			Server::EnvAutoLock envlock(m_server);
 			m_map->dispatchEvent(event);
 		}
 		modified_blocks.clear();

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -31,6 +31,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "log.h"
 #include "servermap.h"
+#include "database/database.h"
 #include "mapblock.h"
 #include "mapgen/mg_biome.h"
 #include "mapgen/mg_ore.h"
@@ -185,10 +186,22 @@ SchematicManager *EmergeManager::getWritableSchematicManager()
 	return schemmgr;
 }
 
+void EmergeManager::initMap(MapDatabaseAccessor *holder)
+{
+	FATAL_ERROR_IF(m_db, "Map database already initialized.");
+	assert(holder->dbase);
+	m_db = holder;
+}
+
+void EmergeManager::resetMap()
+{
+	FATAL_ERROR_IF(m_threads_active, "Threads are still active.");
+	m_db = nullptr;
+}
 
 void EmergeManager::initMapgens(MapgenParams *params)
 {
-	FATAL_ERROR_IF(!m_mapgens.empty(), "Mapgen already initialised.");
+	FATAL_ERROR_IF(!m_mapgens.empty(), "Mapgen already initialized.");
 
 	mgparams = params;
 
@@ -466,7 +479,7 @@ void EmergeThread::signal()
 }
 
 
-bool EmergeThread::pushBlock(const v3s16 &pos)
+bool EmergeThread::pushBlock(v3s16 pos)
 {
 	m_block_queue.push(pos);
 	return true;
@@ -491,7 +504,7 @@ void EmergeThread::cancelPendingItems()
 }
 
 
-void EmergeThread::runCompletionCallbacks(const v3s16 &pos, EmergeAction action,
+void EmergeThread::runCompletionCallbacks(v3s16 pos, EmergeAction action,
 	const EmergeCallbackList &callbacks)
 {
 	m_emerge->reportCompletedEmerge(action);
@@ -524,21 +537,36 @@ bool EmergeThread::popBlockEmerge(v3s16 *pos, BlockEmergeData *bedata)
 }
 
 
-EmergeAction EmergeThread::getBlockOrStartGen(
-	const v3s16 &pos, bool allow_gen, MapBlock **block, BlockMakeData *bmdata)
+EmergeAction EmergeThread::getBlockOrStartGen(const v3s16 pos, bool allow_gen,
+	 const std::string *from_db, MapBlock **block, BlockMakeData *bmdata)
 {
 	MutexAutoLock envlock(m_server->m_env_mutex);
+
+	auto block_ok = [] (MapBlock *b) {
+		return b && b->isGenerated();
+	};
 
 	// 1). Attempt to fetch block from memory
 	*block = m_map->getBlockNoCreateNoEx(pos);
 	if (*block) {
-		if ((*block)->isGenerated())
+		if (block_ok(*block)) {
+			// if we just read it from the db but the block exists that means
+			// someone else was faster. don't touch it to prevent data loss.
+			if (from_db)
+				verbosestream << "getBlockOrStartGen: block loading raced" << std::endl;
 			return EMERGE_FROM_MEMORY;
+		}
 	} else {
-		// 2). Attempt to load block from disk if it was not in the memory
-		*block = m_map->loadBlock(pos);
-		if (*block && (*block)->isGenerated())
+		if (!from_db) {
+			// 2). We should attempt loading it
 			return EMERGE_FROM_DISK;
+		}
+		// 2). Second invocation, we have the data
+		if (!from_db->empty()) {
+			*block = m_map->loadBlock(*from_db, pos);
+			if (block_ok(*block))
+				return EMERGE_FROM_DISK;
+		}
 	}
 
 	// 3). Attempt to start generation
@@ -643,7 +671,8 @@ void *EmergeThread::run()
 	BEGIN_DEBUG_EXCEPTION_HANDLER
 
 	v3s16 pos;
-	std::map<v3s16, MapBlock *> modified_blocks;
+	std::map<v3s16, MapBlock*> modified_blocks;
+	std::string databuf;
 
 	m_map    = &m_server->m_env->getServerMap();
 	m_emerge = m_server->getEmergeManager();
@@ -669,13 +698,30 @@ void *EmergeThread::run()
 			continue;
 		}
 
+		g_profiler->add(m_name + ": processed [#]", 1);
+
 		if (blockpos_over_max_limit(pos))
 			continue;
 
 		bool allow_gen = bedata.flags & BLOCK_EMERGE_ALLOW_GEN;
 		EMERGE_DBG_OUT("pos=" << pos << " allow_gen=" << allow_gen);
 
-		action = getBlockOrStartGen(pos, allow_gen, &block, &bmdata);
+		action = getBlockOrStartGen(pos, allow_gen, nullptr, &block, &bmdata);
+
+		/* Try to load it */
+		if (action == EMERGE_FROM_DISK) {
+			auto &m_db = *m_emerge->m_db;
+			{
+				ScopeProfiler sp(g_profiler, "EmergeThread: load block - async (sum)");
+				MutexAutoLock dblock(m_db.mutex);
+				m_db.loadBlock(pos, databuf);
+			}
+			// actually load it, then decide again
+			action = getBlockOrStartGen(pos, allow_gen, &databuf, &block, &bmdata);
+			databuf.clear();
+		}
+
+		/* Generate it */
 		if (action == EMERGE_GENERATED) {
 			bool error = false;
 			m_trans_liquid = &bmdata.transforming_liquid;

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -196,6 +196,7 @@ public:
 		EmergeCompletionCallback callback,
 		void *callback_param);
 
+	size_t getQueueSize();
 	bool isBlockInQueue(v3s16 pos);
 
 	Mapgen *getCurrentMapgen();

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -46,6 +46,7 @@ class DecorationManager;
 class SchematicManager;
 class Server;
 class ModApiMapgen;
+struct MapDatabaseAccessor;
 
 // Structure containing inputs/outputs for chunk generation
 struct BlockMakeData {
@@ -173,6 +174,10 @@ public:
 	SchematicManager *getWritableSchematicManager();
 
 	void initMapgens(MapgenParams *mgparams);
+	/// @param holder non-owned reference that must stay alive
+	void initMap(MapDatabaseAccessor *holder);
+	/// resets the reference
+	void resetMap();
 
 	void startThreads();
 	void stopThreads();
@@ -205,6 +210,9 @@ private:
 	std::vector<Mapgen *> m_mapgens;
 	std::vector<EmergeThread *> m_threads;
 	bool m_threads_active = false;
+
+	// The map database
+	MapDatabaseAccessor *m_db = nullptr;
 
 	std::mutex m_queue_mutex;
 	std::map<v3s16, BlockEmergeData> m_blocks_enqueued;

--- a/src/emerge_internal.h
+++ b/src/emerge_internal.h
@@ -40,7 +40,7 @@ class EmergeScripting;
 class EmergeThread : public Thread {
 public:
 	bool enable_mapgen_debug_info;
-	int id;
+	const int id; // Index of this thread
 
 	EmergeThread(Server *server, int ethreadid);
 	~EmergeThread() = default;
@@ -49,7 +49,7 @@ public:
 	void signal();
 
 	// Requires queue mutex held
-	bool pushBlock(const v3s16 &pos);
+	bool pushBlock(v3s16 pos);
 
 	void cancelPendingItems();
 
@@ -59,7 +59,7 @@ public:
 protected:
 
 	void runCompletionCallbacks(
-		const v3s16 &pos, EmergeAction action,
+		v3s16 pos, EmergeAction action,
 		const EmergeCallbackList &callbacks);
 
 private:
@@ -79,8 +79,20 @@ private:
 
 	bool popBlockEmerge(v3s16 *pos, BlockEmergeData *bedata);
 
-	EmergeAction getBlockOrStartGen(
-		const v3s16 &pos, bool allow_gen, MapBlock **block, BlockMakeData *data);
+	/**
+	 * Try to get a block from memory and decide what to do.
+	 *
+	 * @param pos block position
+	 * @param from_db serialized block data, optional
+	 *                (for second call after EMERGE_FROM_DISK was returned)
+	 * @param allow_gen allow invoking mapgen?
+	 * @param block output pointer for block
+	 * @param data info for mapgen
+	 * @return what to do for this block
+	 */
+	EmergeAction getBlockOrStartGen(v3s16 pos, bool allow_gen,
+		const std::string *from_db,  MapBlock **block, BlockMakeData *data);
+
 	MapBlock *finishGen(v3s16 pos, BlockMakeData *bmdata,
 		std::map<v3s16, MapBlock *> *modified_blocks);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1278,8 +1278,7 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 
 		{
 			MapBlock mb(v3s16(0,0,0), &server);
-			u8 ver = readU8(iss);
-			mb.deSerialize(iss, ver, true);
+			ServerMap::deSerializeBlock(&mb, iss);
 
 			oss.str("");
 			oss.clear();

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -160,7 +160,7 @@ void LuaEmergeAreaCallback(v3s16 blockpos, EmergeAction action, void *param)
 
 	// state must be protected by envlock
 	Server *server = state->script->getServer();
-	MutexAutoLock envlock(server->m_env_mutex);
+	Server::EnvAutoLock envlock(server);
 
 	state->refcount--;
 

--- a/src/server.h
+++ b/src/server.h
@@ -35,6 +35,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/metricsbackend.h"
 #include "serverenvironment.h"
 #include "server/clientiface.h"
+#include "threading/ordered_mutex.h"
 #include "chatmessage.h"
 #include "sound.h"
 #include "translation.h"
@@ -430,7 +431,7 @@ public:
 		EnvAutoLock(Server *server): m_lock(server->m_env_mutex) {}
 
 	private:
-		MutexAutoLock m_lock;
+		std::lock_guard<ordered_mutex> m_lock;
 	};
 
 protected:
@@ -608,7 +609,7 @@ private:
 	*/
 
 	// Environment mutex (envlock)
-	std::mutex m_env_mutex;
+	ordered_mutex m_env_mutex;
 
 	// World directory
 	std::string m_path_world;

--- a/src/server.h
+++ b/src/server.h
@@ -167,9 +167,12 @@ public:
 	// Actual processing is done in another thread.
 	// This just checks if there was an error in that thread.
 	void step();
+
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(float dtime, bool initial_step = false);
 	void Receive(float timeout);
+	void yieldToOtherThreads(float dtime);
+
 	PlayerSAO* StageTwoClientInit(session_t peer_id);
 
 	/*
@@ -601,8 +604,6 @@ private:
 		Call with env and con locked.
 	*/
 	PlayerSAO *emergePlayer(const char *name, session_t peer_id, u16 proto_version);
-
-	void handlePeerChanges();
 
 	/*
 		Variables

--- a/src/server.h
+++ b/src/server.h
@@ -424,8 +424,14 @@ public:
 	// Bind address
 	Address m_bind_addr;
 
-	// Environment mutex (envlock)
-	std::mutex m_env_mutex;
+	// Public helper for taking the envlock in a scope
+	class EnvAutoLock {
+	public:
+		EnvAutoLock(Server *server): m_lock(server->m_env_mutex) {}
+
+	private:
+		MutexAutoLock m_lock;
+	};
 
 protected:
 	/* Do not add more members here, this is only required to make unit tests work. */
@@ -600,6 +606,10 @@ private:
 	/*
 		Variables
 	*/
+
+	// Environment mutex (envlock)
+	std::mutex m_env_mutex;
+
 	// World directory
 	std::string m_path_world;
 	std::string m_path_mod_data;

--- a/src/servermap.h
+++ b/src/servermap.h
@@ -33,8 +33,21 @@ class IRollbackManager;
 class EmergeManager;
 class ServerEnvironment;
 struct BlockMakeData;
-
 class MetricsBackend;
+
+// TODO: this could wrap all calls to MapDatabase, including locking
+struct MapDatabaseAccessor {
+	/// Lock, to be taken for any operation
+	std::mutex mutex;
+	/// Main database
+	MapDatabase *dbase = nullptr;
+	/// Fallback database for read operations
+	MapDatabase *dbase_ro = nullptr;
+
+	/// Load a block, taking dbase_ro into account.
+	/// @note call locked
+	void loadBlock(v3s16 blockpos, std::string &ret);
+};
 
 /*
 	ServerMap
@@ -75,7 +88,7 @@ public:
 	MapBlock *createBlock(v3s16 p);
 
 	/*
-		Forcefully get a block from somewhere.
+		Forcefully get a block from somewhere (blocking!).
 		- Memory
 		- Load from disk
 		- Create blank filled with CONTENT_IGNORE
@@ -114,9 +127,16 @@ public:
 
 	bool saveBlock(MapBlock *block) override;
 	static bool saveBlock(MapBlock *block, MapDatabase *db, int compression_level = -1);
-	MapBlock* loadBlock(v3s16 p);
-	// Database version
-	void loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool save_after_load=false);
+
+	// Load block in a synchronous fashion
+	MapBlock *loadBlock(v3s16 p);
+	/// Load a block that was already read from disk. Used by EmergeManager.
+	/// @return non-null block (but can be blank)
+	MapBlock *loadBlock(const std::string &blob, v3s16 p, bool save_after_load=false);
+
+	// Helper for deserializing blocks from disk
+	// @throws SerializationError
+	static void deSerializeBlock(MapBlock *block, std::istream &is);
 
 	// Blocks are removed from the map but not deleted from memory until
 	// deleteDetachedBlocks() is called, since pointers to them may still exist
@@ -185,8 +205,8 @@ private:
 		This is reset to false when written on disk.
 	*/
 	bool m_map_metadata_changed = true;
-	MapDatabase *dbase = nullptr;
-	MapDatabase *dbase_ro = nullptr;
+
+	MapDatabaseAccessor m_db;
 
 	// Map metrics
 	MetricGaugePtr m_loaded_blocks_gauge;

--- a/src/threading/ordered_mutex.h
+++ b/src/threading/ordered_mutex.h
@@ -1,0 +1,46 @@
+// Minetest
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <cstdint>
+#include <condition_variable>
+
+/*
+	Fair mutex based on ticketing approach.
+	Satisfies `Mutex` C++11 requirements.
+*/
+class ordered_mutex {
+public:
+	ordered_mutex() : next_ticket(0), counter(0) {}
+
+	void lock()
+	{
+		std::unique_lock autolock(cv_lock);
+		const auto ticket = next_ticket++;
+		cv.wait(autolock, [&] { return counter == ticket; });
+	}
+
+	bool try_lock()
+	{
+		std::lock_guard autolock(cv_lock);
+		if (counter != next_ticket)
+			return false;
+		next_ticket++;
+		return true;
+	}
+
+	void unlock()
+	{
+		{
+			std::lock_guard autolock(cv_lock);
+			counter++;
+		}
+		cv.notify_all(); // intentionally outside lock
+	}
+
+private:
+	std::condition_variable cv;
+	std::mutex cv_lock;
+	uint_fast32_t next_ticket, counter;
+};

--- a/src/util/timetaker.cpp
+++ b/src/util/timetaker.cpp
@@ -35,7 +35,7 @@ u64 TimeTaker::stop(bool quiet)
 		if (m_result != nullptr) {
 			(*m_result) += dtime;
 		} else {
-			if (!quiet) {
+			if (!quiet && !m_name.empty()) {
 				infostream << m_name << " took "
 					<< dtime << TimePrecision_units[m_precision] << std::endl;
 			}


### PR DESCRIPTION
this means the whole server isn't blocked by map loading

for the record: map saving still happens in the server thread

addresses a big point brought up in #15125

## To do

This PR is Ready for Review.

## How to test

```diff
diff --git a/src/database/database-sqlite3.cpp b/src/database/database-sqlite3.cpp
--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -289,6 +289,8 @@ void MapDatabaseSQLite3::loadBlock(const v3s16 &pos, std::string *block)
        sqlite3_step(m_stmt_read);
        // We should never get more than 1 row, so ok to reset
        sqlite3_reset(m_stmt_read);
+
+       usleep(50*1000);
 }
 
 void MapDatabaseSQLite3::listAllLoadableBlocks(std::vector<v3s16> &dst)
```
1. apply patch, notice how loading is slow as shit but you can still interact with the world

2. check that map loading/saving works correctly generally

```diff
diff --git a/src/script/cpp_api/s_env.cpp b/src/script/cpp_api/s_env.cpp
--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -54,6 +54,8 @@ void ScriptApiEnv::environment_Step(float dtime)
        // Call callbacks
        lua_pushnumber(L, dtime);
        runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
+
+       usleep(50*1000);
 }
 
 void ScriptApiEnv::player_event(ServerActiveObject *player, const std::string &type)
```
3. apply different patch, notice how the server is laggy but the world still loads reasonably fast
