### PR TITLE
[no sq] Expose two helper functions to the Lua API

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5655,6 +5655,10 @@ Utilities
 * `minetest.colorspec_to_bytes(colorspec)`: Converts a ColorSpec to a raw
   string of four bytes in an RGBA layout, returned as a string.
   * `colorspec`: The ColorSpec to convert
+* `minetest.colorspec_to_table(colorspec)`: Converts a ColorSpec into RGBA table
+  form. If the ColorSpec is invalid, returns `nil`. You can use this to parse
+  ColorStrings.
+    * `colorspec`: The ColorSpec to convert
 * `minetest.encode_png(width, height, data, [compression])`: Encode a PNG
   image and return it in string form.
     * `width`: Width of the image

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5659,6 +5659,9 @@ Utilities
   form. If the ColorSpec is invalid, returns `nil`. You can use this to parse
   ColorStrings.
     * `colorspec`: The ColorSpec to convert
+* `minetest.time_to_day_night_ratio(time_of_day)`: Returns a "day-night ratio" value
+  (as accepted by `ObjectRef:override_day_night_ratio`) that is equivalent to
+  the given "time of day" value (as returned by `minetest.get_timeofday`).
 * `minetest.encode_png(width, height, data, [compression])`: Encode a PNG
   image and return it in string form.
     * `width`: Width of the image
@@ -8519,6 +8522,7 @@ child will follow movement and rotation of that bone.
     * `0`...`1`: Overrides day-night ratio, controlling sunlight to a specific
       amount.
     * Passing no arguments disables override, defaulting to sunlight based on day-night cycle
+    * See also `minetest.time_to_day_night_ratio`,
 * `get_day_night_ratio()`: returns the ratio or nil if it isn't overridden
 * `set_local_animation(idle, walk, dig, walk_while_dig, frame_speed)`:
   set animation for player model in third person view.

--- a/games/devtest/mods/unittests/color.lua
+++ b/games/devtest/mods/unittests/color.lua
@@ -1,0 +1,17 @@
+local function assert_colors_equal(c1, c2)
+    if type(c1) == "table" and type(c2) == "table" then
+        assert(c1.r == c2.r and c1.g == c2.g and c1.b == c2.b and c1.a == c2.a)
+    else
+        assert(c1 == c2)
+    end
+end
+
+local function test_color_conversion()
+    assert_colors_equal(core.colorspec_to_table("#fff"), {r = 255, g = 255, b = 255, a = 255})
+    assert_colors_equal(core.colorspec_to_table(0xFF00FF00), {r = 0, g = 255, b = 0, a = 255})
+    assert_colors_equal(core.colorspec_to_table("#00000000"), {r = 0, g = 0, b = 0, a = 0})
+    assert_colors_equal(core.colorspec_to_table("green"), {r = 0, g = 128, b = 0, a = 255})
+    assert_colors_equal(core.colorspec_to_table("gren"), nil)
+end
+
+unittests.register("test_color_conversion", test_color_conversion)

--- a/games/devtest/mods/unittests/init.lua
+++ b/games/devtest/mods/unittests/init.lua
@@ -187,6 +187,7 @@ dofile(modpath .. "/raycast.lua")
 dofile(modpath .. "/inventory.lua")
 dofile(modpath .. "/load_time.lua")
 dofile(modpath .. "/on_shutdown.lua")
+dofile(modpath .. "/color.lua")
 
 --------------
 

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -626,6 +626,20 @@ int ModApiUtil::l_colorspec_to_bytes(lua_State *L)
 	return 0;
 }
 
+// colorspec_to_table(colorspec)
+int ModApiUtil::l_colorspec_to_table(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	video::SColor color(0);
+	if (read_color(L, 1, &color)) {
+		push_ARGB8(L, color);
+		return 1;
+	}
+
+	return 0;
+}
+
 // encode_png(w, h, data, level)
 int ModApiUtil::l_encode_png(lua_State *L)
 {
@@ -726,6 +740,7 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 	API_FCT(sha256);
 	API_FCT(colorspec_to_colorstring);
 	API_FCT(colorspec_to_bytes);
+	API_FCT(colorspec_to_table);
 
 	API_FCT(encode_png);
 
@@ -761,6 +776,7 @@ void ModApiUtil::InitializeClient(lua_State *L, int top)
 	API_FCT(sha256);
 	API_FCT(colorspec_to_colorstring);
 	API_FCT(colorspec_to_bytes);
+	API_FCT(colorspec_to_table);
 
 	API_FCT(get_last_run_mod);
 	API_FCT(set_last_run_mod);
@@ -805,6 +821,7 @@ void ModApiUtil::InitializeAsync(lua_State *L, int top)
 	API_FCT(sha256);
 	API_FCT(colorspec_to_colorstring);
 	API_FCT(colorspec_to_bytes);
+	API_FCT(colorspec_to_table);
 
 	API_FCT(encode_png);
 

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -45,6 +45,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "my_sha256.h"
 #include "util/png.h"
 #include "player.h"
+#include "daynightratio.h"
 #include <cstdio>
 
 // only available in zstd 1.3.5+
@@ -640,6 +641,17 @@ int ModApiUtil::l_colorspec_to_table(lua_State *L)
 	return 0;
 }
 
+// time_to_day_night_ratio(time_of_day)
+int ModApiUtil::l_time_to_day_night_ratio(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	float time_of_day = lua_tonumber(L, 1) * 24000;
+	u32 dnr = time_to_daynight_ratio(time_of_day, true);
+	lua_pushnumber(L, dnr / 1000.0f);
+	return 1;
+}
+
 // encode_png(w, h, data, level)
 int ModApiUtil::l_encode_png(lua_State *L)
 {
@@ -741,6 +753,7 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 	API_FCT(colorspec_to_colorstring);
 	API_FCT(colorspec_to_bytes);
 	API_FCT(colorspec_to_table);
+	API_FCT(time_to_day_night_ratio);
 
 	API_FCT(encode_png);
 
@@ -777,6 +790,7 @@ void ModApiUtil::InitializeClient(lua_State *L, int top)
 	API_FCT(colorspec_to_colorstring);
 	API_FCT(colorspec_to_bytes);
 	API_FCT(colorspec_to_table);
+	API_FCT(time_to_day_night_ratio);
 
 	API_FCT(get_last_run_mod);
 	API_FCT(set_last_run_mod);
@@ -822,6 +836,7 @@ void ModApiUtil::InitializeAsync(lua_State *L, int top)
 	API_FCT(colorspec_to_colorstring);
 	API_FCT(colorspec_to_bytes);
 	API_FCT(colorspec_to_table);
+	API_FCT(time_to_day_night_ratio);
 
 	API_FCT(encode_png);
 

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -122,6 +122,9 @@ private:
 	// colorspec_to_bytes(colorspec)
 	static int l_colorspec_to_bytes(lua_State *L);
 
+	// colorspec_to_table(colorspec)
+	static int l_colorspec_to_table(lua_State *L);
+
 	// encode_png(w, h, data, level)
 	static int l_encode_png(lua_State *L);
 

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -125,6 +125,9 @@ private:
 	// colorspec_to_table(colorspec)
 	static int l_colorspec_to_table(lua_State *L);
 
+	// time_to_day_night_ratio(time_of_day)
+	static int l_time_to_day_night_ratio(lua_State *L);
+
 	// encode_png(w, h, data, level)
 	static int l_encode_png(lua_State *L);
 


### PR DESCRIPTION
This PR exposes two small helper functions to the Lua API:

1. `minetest.colorspec_to_table` for parsing ColorStrings.

2. `minetest.time_to_day_night_ratio` for converting a value from the format used by `minetest.get_timeofday` to the format used by `ObjectRef:override_day_night_ratio`. My use case is that I want to interpolate brightness, starting at the current brightness and ending at 0.

## To do

This PR is a Ready for Review.

## How to test

1. See unittests.

2. Set `time_speed = 0` and add this code to a mod:
	```lua
	core.register_chatcommand("t", {
		func = function(name)
			local cur_ratio = minetest.time_to_day_night_ratio(minetest.get_timeofday())
			print("time of day = " .. minetest.get_timeofday())
			print("ratio       = " .. cur_ratio)
			local p = minetest.get_player_by_name(name)
			p:override_day_night_ratio(cur_ratio)
			core.after(1, function()
				p:override_day_night_ratio()
				print("reset")
			end)
		end,
	})
	```
	Try executing `/t` at different times of the day. The sky should not change.