### PR TITLE
Move std::tie out of headers

### DIFF
--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -246,3 +246,23 @@ void ObjectProperties::deSerialize(std::istream &is)
 		rotate_selectionbox = tmp;
 	} catch (SerializationError &e) {}
 }
+
+static auto tie(const ObjectProperties &o)
+{
+	// Make sure to add new members to this list!
+	return std::tie(
+	o.textures, o.colors, o.collisionbox, o.selectionbox, o.visual, o.mesh, o.damage_texture_modifier,
+	o.nametag, o.infotext, o.wield_item, o.visual_size, o.nametag_color, o.nametag_bgcolor,
+	o.spritediv, o.initial_sprite_basepos, o.stepheight, o.automatic_rotate,
+	o.automatic_face_movement_dir_offset, o.automatic_face_movement_max_rotation_per_sec,
+	o.eye_height, o.zoom_fov, o.hp_max, o.breath_max, o.glow, o.pointable, o.physical,
+	o.collideWithObjects, o.rotate_selectionbox, o.is_visible, o.makes_footstep_sound,
+	o.automatic_face_movement_dir, o.backface_culling, o.static_save, o.use_texture_alpha,
+	o.shaded, o.show_on_minimap
+	);
+}
+
+bool ObjectProperties::operator==(const ObjectProperties &other) const
+{
+	return tie(*this) == tie(other);
+}

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -85,6 +85,50 @@ std::string ObjectProperties::dump() const
 	return os.str();
 }
 
+bool ObjectProperties::operator==(const ObjectProperties &other) const
+{
+	// Make sure to add new members to this list!
+	return
+		textures                    == other.textures &&
+		colors                      == other.colors &&
+		collisionbox                == other.collisionbox &&
+		selectionbox                == other.selectionbox &&
+		visual                      == other.visual &&
+		mesh                        == other.mesh &&
+		damage_texture_modifier     == other.damage_texture_modifier &&
+		nametag                     == other.nametag &&
+		infotext                    == other.infotext &&
+		wield_item                  == other.wield_item &&
+		visual_size                 == other.visual_size &&
+		nametag_color               == other.nametag_color &&
+		nametag_bgcolor             == other.nametag_bgcolor &&
+		spritediv                   == other.spritediv &&
+		initial_sprite_basepos      == other.initial_sprite_basepos &&
+		stepheight                  == other.stepheight &&
+		automatic_rotate            == other.automatic_rotate &&
+		automatic_face_movement_dir_offset
+				== other.automatic_face_movement_dir_offset &&
+		automatic_face_movement_max_rotation_per_sec
+				== other.automatic_face_movement_max_rotation_per_sec &&
+		eye_height                  == other.eye_height &&
+		zoom_fov                    == other.zoom_fov &&
+		hp_max                      == other.hp_max &&
+		breath_max                  == other.breath_max &&
+		glow                        == other.glow &&
+		pointable                   == other.pointable &&
+		physical                    == other.physical &&
+		collideWithObjects          == other.collideWithObjects &&
+		rotate_selectionbox         == other.rotate_selectionbox &&
+		is_visible                  == other.is_visible &&
+		makes_footstep_sound        == other.makes_footstep_sound &&
+		automatic_face_movement_dir == other.automatic_face_movement_dir &&
+		backface_culling            == other.backface_culling &&
+		static_save                 == other.static_save &&
+		use_texture_alpha           == other.use_texture_alpha &&
+		shaded                      == other.shaded &&
+		show_on_minimap             == other.show_on_minimap;
+}
+
 bool ObjectProperties::validate()
 {
 	const char *func = "ObjectProperties::validate(): ";
@@ -245,24 +289,4 @@ void ObjectProperties::deSerialize(std::istream &is)
 			return;
 		rotate_selectionbox = tmp;
 	} catch (SerializationError &e) {}
-}
-
-static auto tie(const ObjectProperties &o)
-{
-	// Make sure to add new members to this list!
-	return std::tie(
-	o.textures, o.colors, o.collisionbox, o.selectionbox, o.visual, o.mesh, o.damage_texture_modifier,
-	o.nametag, o.infotext, o.wield_item, o.visual_size, o.nametag_color, o.nametag_bgcolor,
-	o.spritediv, o.initial_sprite_basepos, o.stepheight, o.automatic_rotate,
-	o.automatic_face_movement_dir_offset, o.automatic_face_movement_max_rotation_per_sec,
-	o.eye_height, o.zoom_fov, o.hp_max, o.breath_max, o.glow, o.pointable, o.physical,
-	o.collideWithObjects, o.rotate_selectionbox, o.is_visible, o.makes_footstep_sound,
-	o.automatic_face_movement_dir, o.backface_culling, o.static_save, o.use_texture_alpha,
-	o.shaded, o.show_on_minimap
-	);
-}
-
-bool ObjectProperties::operator==(const ObjectProperties &other) const
-{
-	return tie(*this) == tie(other);
 }

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "util/serialize.h"
 #include <sstream>
+#include <tuple>
 
 static const video::SColor NULL_BGCOLOR{0, 1, 1, 1};
 
@@ -85,48 +86,25 @@ std::string ObjectProperties::dump() const
 	return os.str();
 }
 
-bool ObjectProperties::operator==(const ObjectProperties &other) const
+static auto tie(const ObjectProperties &o)
 {
 	// Make sure to add new members to this list!
-	return
-		textures                    == other.textures &&
-		colors                      == other.colors &&
-		collisionbox                == other.collisionbox &&
-		selectionbox                == other.selectionbox &&
-		visual                      == other.visual &&
-		mesh                        == other.mesh &&
-		damage_texture_modifier     == other.damage_texture_modifier &&
-		nametag                     == other.nametag &&
-		infotext                    == other.infotext &&
-		wield_item                  == other.wield_item &&
-		visual_size                 == other.visual_size &&
-		nametag_color               == other.nametag_color &&
-		nametag_bgcolor             == other.nametag_bgcolor &&
-		spritediv                   == other.spritediv &&
-		initial_sprite_basepos      == other.initial_sprite_basepos &&
-		stepheight                  == other.stepheight &&
-		automatic_rotate            == other.automatic_rotate &&
-		automatic_face_movement_dir_offset
-				== other.automatic_face_movement_dir_offset &&
-		automatic_face_movement_max_rotation_per_sec
-				== other.automatic_face_movement_max_rotation_per_sec &&
-		eye_height                  == other.eye_height &&
-		zoom_fov                    == other.zoom_fov &&
-		hp_max                      == other.hp_max &&
-		breath_max                  == other.breath_max &&
-		glow                        == other.glow &&
-		pointable                   == other.pointable &&
-		physical                    == other.physical &&
-		collideWithObjects          == other.collideWithObjects &&
-		rotate_selectionbox         == other.rotate_selectionbox &&
-		is_visible                  == other.is_visible &&
-		makes_footstep_sound        == other.makes_footstep_sound &&
-		automatic_face_movement_dir == other.automatic_face_movement_dir &&
-		backface_culling            == other.backface_culling &&
-		static_save                 == other.static_save &&
-		use_texture_alpha           == other.use_texture_alpha &&
-		shaded                      == other.shaded &&
-		show_on_minimap             == other.show_on_minimap;
+	return std::tie(
+	o.textures, o.colors, o.collisionbox, o.selectionbox, o.visual, o.mesh,
+	o.damage_texture_modifier, o.nametag, o.infotext, o.wield_item, o.visual_size,
+	o.nametag_color, o.nametag_bgcolor, o.spritediv, o.initial_sprite_basepos,
+	o.stepheight, o.automatic_rotate, o.automatic_face_movement_dir_offset,
+	o.automatic_face_movement_max_rotation_per_sec, o.eye_height, o.zoom_fov,
+	o.hp_max, o.breath_max, o.glow, o.pointable, o.physical, o.collideWithObjects,
+	o.rotate_selectionbox, o.is_visible, o.makes_footstep_sound,
+	o.automatic_face_movement_dir, o.backface_culling, o.static_save, o.use_texture_alpha,
+	o.shaded, o.show_on_minimap
+	);
+}
+
+bool ObjectProperties::operator==(const ObjectProperties &other) const
+{
+	return tie(*this) == tie(other);
 }
 
 bool ObjectProperties::validate()

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -20,11 +20,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include <optional>
-#include <tuple>
 #include <string>
 #include "irrlichttypes_bloated.h"
 #include <iostream>
-#include <map>
 #include <vector>
 #include "util/pointabilities.h"
 

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -77,28 +77,10 @@ struct ObjectProperties
 
 	std::string dump() const;
 
-private:
-	auto tie() const {
-		// Make sure to add new members to this list!
-		return std::tie(
-		textures, colors, collisionbox, selectionbox, visual, mesh, damage_texture_modifier,
-		nametag, infotext, wield_item, visual_size, nametag_color, nametag_bgcolor,
-		spritediv, initial_sprite_basepos, stepheight, automatic_rotate,
-		automatic_face_movement_dir_offset, automatic_face_movement_max_rotation_per_sec,
-		eye_height, zoom_fov, hp_max, breath_max, glow, pointable, physical,
-		collideWithObjects, rotate_selectionbox, is_visible, makes_footstep_sound,
-		automatic_face_movement_dir, backface_culling, static_save, use_texture_alpha,
-		shaded, show_on_minimap
-		);
-	}
-
-public:
-	bool operator==(const ObjectProperties &other) const {
-		return tie() == other.tie();
-	};
+	bool operator==(const ObjectProperties &other) const;
 	bool operator!=(const ObjectProperties &other) const {
-		return tie() != other.tie();
-	};
+		return !(*this == other);
+	}
 
 	/**
 	 * Check limits of some important properties that'd cause exceptions later on.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "log.h"
 #include "porting.h"  // strlcpy
+#include <tuple>
 
 
 bool is_valid_player_name(std::string_view name) {
@@ -230,24 +231,18 @@ void PlayerControl::unpackKeysPressed(u32 keypress_bits)
 	zoom  = keypress_bits & (1 << 9);
 }
 
-bool PlayerPhysicsOverride::operator==(const PlayerPhysicsOverride &other) const
+static auto tie(const PlayerPhysicsOverride &o)
 {
 	// Make sure to add new members to this list!
-	return
-		speed                  == other.speed &&
-		jump                   == other.jump &&
-		gravity                == other.gravity &&
-		sneak                  == other.sneak &&
-		sneak_glitch           == other.sneak_glitch &&
-		new_move               == other.new_move &&
-		speed_climb            == other.speed_climb &&
-		speed_crouch           == other.speed_crouch &&
-		liquid_fluidity        == other.liquid_fluidity &&
-		liquid_fluidity_smooth == other.liquid_fluidity_smooth &&
-		liquid_sink            == other.liquid_sink &&
-		acceleration_default   == other.acceleration_default &&
-		acceleration_air       == other.acceleration_air &&
-		speed_fast             == other.speed_fast &&
-		acceleration_fast      == other.acceleration_fast &&
-		speed_walk             == other.speed_walk;
-};
+	return std::tie(
+	o.speed, o.jump, o.gravity, o.sneak, o.sneak_glitch, o.new_move, o.speed_climb,
+	o.speed_crouch, o.liquid_fluidity, o.liquid_fluidity_smooth, o.liquid_sink,
+	o.acceleration_default, o.acceleration_air, o.speed_fast, o.acceleration_fast,
+	o.speed_walk
+	);
+}
+
+bool PlayerPhysicsOverride::operator==(const PlayerPhysicsOverride &other) const
+{
+	return tie(*this) == tie(other);
+}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -229,3 +229,16 @@ void PlayerControl::unpackKeysPressed(u32 keypress_bits)
 	place = keypress_bits & (1 << 8);
 	zoom  = keypress_bits & (1 << 9);
 }
+
+static auto tie(const PlayerPhysicsOverride &o) {
+	// Make sure to add new members to this list!
+	return std::tie(
+	o.speed, o.jump, o.gravity, o.sneak, o.sneak_glitch, o.new_move, o.speed_climb, o.speed_crouch,
+	o.liquid_fluidity, o.liquid_fluidity_smooth, o.liquid_sink, o.acceleration_default,
+	o.acceleration_air, o.speed_fast, o.acceleration_fast, o.speed_walk
+	);
+}
+
+bool PlayerPhysicsOverride::operator==(const PlayerPhysicsOverride &other) const {
+	return tie(*this) == tie(other);
+};

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -230,15 +230,24 @@ void PlayerControl::unpackKeysPressed(u32 keypress_bits)
 	zoom  = keypress_bits & (1 << 9);
 }
 
-static auto tie(const PlayerPhysicsOverride &o) {
+bool PlayerPhysicsOverride::operator==(const PlayerPhysicsOverride &other) const
+{
 	// Make sure to add new members to this list!
-	return std::tie(
-	o.speed, o.jump, o.gravity, o.sneak, o.sneak_glitch, o.new_move, o.speed_climb, o.speed_crouch,
-	o.liquid_fluidity, o.liquid_fluidity_smooth, o.liquid_sink, o.acceleration_default,
-	o.acceleration_air, o.speed_fast, o.acceleration_fast, o.speed_walk
-	);
-}
-
-bool PlayerPhysicsOverride::operator==(const PlayerPhysicsOverride &other) const {
-	return tie(*this) == tie(other);
+	return
+		speed                  == other.speed &&
+		jump                   == other.jump &&
+		gravity                == other.gravity &&
+		sneak                  == other.sneak &&
+		sneak_glitch           == other.sneak_glitch &&
+		new_move               == other.new_move &&
+		speed_climb            == other.speed_climb &&
+		speed_crouch           == other.speed_crouch &&
+		liquid_fluidity        == other.liquid_fluidity &&
+		liquid_fluidity_smooth == other.liquid_fluidity_smooth &&
+		liquid_sink            == other.liquid_sink &&
+		acceleration_default   == other.acceleration_default &&
+		acceleration_air       == other.acceleration_air &&
+		speed_fast             == other.speed_fast &&
+		acceleration_fast      == other.acceleration_fast &&
+		speed_walk             == other.speed_walk;
 };

--- a/src/player.h
+++ b/src/player.h
@@ -24,10 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "constants.h"
 #include "util/basic_macros.h"
 #include "util/string.h"
-#include <list>
 #include <mutex>
 #include <functional>
-#include <tuple>
 #include <string>
 
 #define PLAYERNAME_SIZE 20

--- a/src/player.h
+++ b/src/player.h
@@ -133,23 +133,10 @@ struct PlayerPhysicsOverride
 	float acceleration_fast = 1.f;
 	float speed_walk = 1.f;
 
-private:
-	auto tie() const {
-		// Make sure to add new members to this list!
-		return std::tie(
-		speed, jump, gravity, sneak, sneak_glitch, new_move, speed_climb, speed_crouch,
-		liquid_fluidity, liquid_fluidity_smooth, liquid_sink, acceleration_default,
-		acceleration_air, speed_fast, acceleration_fast, speed_walk
-		);
-	}
-
-public:
-	bool operator==(const PlayerPhysicsOverride &other) const {
-		return tie() == other.tie();
-	};
+	bool operator==(const PlayerPhysicsOverride &other) const;
 	bool operator!=(const PlayerPhysicsOverride &other) const {
-		return tie() != other.tie();
-	};
+		return !(*this == other);
+	}
 };
 
 class Map;


### PR DESCRIPTION
* `std::tie` with many arguments is expensive to instantiate (found with clang's `-ftime-trace`). => A bit faster build times with PR.
* ~~It copies the stuff, and then compares. This is unnecessarily expensive for the strings and vectors in `ObjectProperties`.~~

## To do

This PR is a Ready for Review.

## How to test

* Trivial change.
* Try to compile game.cpp for example. For me it's about 16.7 s (master) vs 16.4 s (PR), with clang++.
  (You can do this by copying the line from your `compile_commands.json` (see `-DCMAKE_EXPORT_COMPILE_COMMANDS=1`).)