### PR TITLE
Allow detection of damage greater than HP

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5838,8 +5838,13 @@ Call these functions only at load time!
     * `clicker`: ObjectRef - Object that acted upon `player`, may or may not be a player
 * `minetest.register_on_player_hpchange(function(player, hp_change, reason), modifier)`
     * Called when the player gets damaged or healed
+    * When `hp == 0`, damage doesn't trigger this callback.
+    * When `hp == hp_max`, healing does still trigger this callback.
     * `player`: ObjectRef of the player
     * `hp_change`: the amount of change. Negative when it is damage.
+      * Historically, the new HP value was clamped to [0, 65535] before
+        calculating the HP change. This clamping has been removed as of
+        Minetest 5.10.0
     * `reason`: a PlayerHPChangeReason table.
         * The `type` field will have one of the following values:
             * `set_hp`: A mod or the engine called `set_hp` without

--- a/games/devtest/mods/unittests/player.lua
+++ b/games/devtest/mods/unittests/player.lua
@@ -66,7 +66,7 @@ local function run_hp_difference_tests(player)
 	player:set_hp(22)
 	assert(player:get_hp() == 22)
 
-	-- HP change is rangelim from -U16_MAX to U16_MAX 
+	-- HP change is rangelim from -U16_MAX to U16_MAX
 	expected_diff = -65535 - 22
 	player:set_hp(-1000000)
 	-- and actual final HP value is clamped to 0

--- a/games/devtest/mods/unittests/player.lua
+++ b/games/devtest/mods/unittests/player.lua
@@ -84,9 +84,9 @@ local function hp_diference_test(player, hp_max)
 	assert(hpchange_counter == 2)
 	assert(die_counter == 1)
 
-	-- HP change allowed minimum is -U16_MAX
-	expected_diff = -65535 - 22
-	player:set_hp(-1000000)
+	-- HP change allowed minimum is S32_MIN+U16_MAX
+	expected_diff = -2147483648 + 65535 - 22
+	player:set_hp(-3000000000)
 	-- actual final HP value is clamped to >= 0
 	assert(player:get_hp() == 0)
 	assert(hpchange_counter == 3)

--- a/games/devtest/mods/unittests/player.lua
+++ b/games/devtest/mods/unittests/player.lua
@@ -54,7 +54,9 @@ core.register_on_dieplayer(function()
 	die_counter = die_counter + 1
 end)
 
-local function run_hp_difference_tests(player)
+local function hp_diference_test(player, hp_max)
+	assert(hp_max >= 22)
+
 	local old_hp = player:get_hp()
 	local old_hp_max = player:get_properties().hp_max
 
@@ -62,14 +64,16 @@ local function run_hp_difference_tests(player)
 	die_counter = 0
 
 	expected_diff = nil
-	player:set_properties({hp_max = 30})
+	player:set_properties({hp_max = hp_max})
 	player:set_hp(22)
+	assert(player:get_hp() == 22)
 	assert(hpchange_counter == 0)
 	assert(die_counter == 0)
 
+	-- HP difference is not clamped
 	expected_diff = -25
 	player:set_hp(-3)
-	-- and actual final HP value is clamped to >= 0 too
+	-- actual final HP value is clamped to >= 0
 	assert(player:get_hp() == 0)
 	assert(hpchange_counter == 1)
 	assert(die_counter == 1)
@@ -83,16 +87,16 @@ local function run_hp_difference_tests(player)
 	-- HP change allowed minimum is -U16_MAX
 	expected_diff = -65535 - 22
 	player:set_hp(-1000000)
-	-- and actual final HP value is clamped to 0
+	-- actual final HP value is clamped to >= 0
 	assert(player:get_hp() == 0)
 	assert(hpchange_counter == 3)
 	assert(die_counter == 2)
 
-	-- no damage is delivered if player is death, hp == 0
-	-- no hpchange call, no ondie call
-	expected_diff = 0
+	-- Damage is ignored if player is already dead (hp == 0)
+	expected_diff = "never equal"
 	player:set_hp(-11)
 	assert(player:get_hp() == 0)
+	-- no on_player_hpchange or on_dieplayer call expected
 	assert(hpchange_counter == 3)
 	assert(die_counter == 2)
 
@@ -102,18 +106,19 @@ local function run_hp_difference_tests(player)
 	assert(hpchange_counter == 4)
 	assert(die_counter == 2)
 
-	-- Hp change is not limited here
+	-- HP difference is not clamped
 	expected_diff = 1000000 - 11
 	player:set_hp(1000000)
-	-- and actual final HP value is clamped to <= hp_max
-	assert(player:get_hp() == 30)
+	-- actual final HP value is clamped to <= hp_max
+	assert(player:get_hp() == hp_max)
 	assert(hpchange_counter == 5)
 	assert(die_counter == 2)
 
-	-- another "heal"
-	expected_diff = 70
-	player:set_hp(100)
-	assert(player:get_hp() == 30)
+	-- "Healing" is not ignored when hp == hp_max
+	expected_diff = 80000 - hp_max
+	player:set_hp(80000)
+	assert(player:get_hp() == hp_max)
+	-- on_player_hpchange_call expected
 	assert(hpchange_counter == 6)
 	assert(die_counter == 2)
 
@@ -121,6 +126,11 @@ local function run_hp_difference_tests(player)
 	player:set_properties({hp_max = old_hp_max})
 	player:set_hp(old_hp)
 	core.close_formspec(player:get_player_name(), "") -- hide death screen
+end
+local function run_hp_difference_tests(player)
+	hp_diference_test(player, 22)
+	hp_diference_test(player, 30)
+	hp_diference_test(player, 65535) -- U16_MAX
 end
 unittests.register("test_hp_difference", run_hp_difference_tests, {player=true})
 

--- a/games/devtest/mods/unittests/player.lua
+++ b/games/devtest/mods/unittests/player.lua
@@ -84,8 +84,8 @@ local function hp_diference_test(player, hp_max)
 	assert(hpchange_counter == 2)
 	assert(die_counter == 1)
 
-	-- HP change allowed minimum is S32_MIN+U16_MAX
-	expected_diff = -2147483648 + 65535 - 22
+	-- Integer overflow is prevented
+	expected_diff = -2147483648 -- S32_MIN
 	player:set_hp(-3000000000)
 	-- actual final HP value is clamped to >= 0
 	assert(player:get_hp() == 0)

--- a/games/devtest/mods/unittests/player.lua
+++ b/games/devtest/mods/unittests/player.lua
@@ -57,7 +57,7 @@ local function run_hp_difference_tests(player)
 	player:set_hp(22)
 
 	-- final HP value is clamped to >= 0 before difference calculation
-	expected_diff = -22
+	expected_diff = -25
 	player:set_hp(-3)
 	-- and actual final HP value is clamped to >= 0 too
 	assert(player:get_hp() == 0)
@@ -66,8 +66,17 @@ local function run_hp_difference_tests(player)
 	player:set_hp(22)
 	assert(player:get_hp() == 22)
 
-	-- final HP value is clamped to <= U16_MAX before difference calculation
-	expected_diff = 65535 - 22
+	-- HP change is rangelim from -U16_MAX to U16_MAX 
+	expected_diff = -65535 - 22
+	player:set_hp(-1000000)
+	-- and actual final HP value is clamped to 0
+	assert(player:get_hp() == 0)
+
+	expected_diff = 11
+	player:set_hp(11)
+	assert(player:get_hp() == 11)
+
+	expected_diff = 65535 - 11
 	player:set_hp(1000000)
 	-- and actual final HP value is clamped to <= hp_max
 	assert(player:get_hp() == 30)

--- a/games/devtest/mods/unittests/player.lua
+++ b/games/devtest/mods/unittests/player.lua
@@ -42,44 +42,56 @@ unittests.register("test_hpchangereason", run_hpchangereason_tests, {player=true
 --
 
 local expected_diff = nil
+local die_counter = 0
 core.register_on_player_hpchange(function(player, hp_change, reason)
 	if expected_diff then
 		assert(hp_change == expected_diff)
 	end
+end)
+core.register_on_dieplayer(function()
+	die_counter = die_counter + 1
 end)
 
 local function run_hp_difference_tests(player)
 	local old_hp = player:get_hp()
 	local old_hp_max = player:get_properties().hp_max
 
+	die_counter = 0
+
 	expected_diff = nil
 	player:set_properties({hp_max = 30})
 	player:set_hp(22)
+	assert(die_counter == 0)
 
 	-- final HP value is clamped to >= 0 before difference calculation
 	expected_diff = -25
 	player:set_hp(-3)
 	-- and actual final HP value is clamped to >= 0 too
 	assert(player:get_hp() == 0)
+	assert(die_counter == 1)
 
 	expected_diff = 22
 	player:set_hp(22)
 	assert(player:get_hp() == 22)
+	assert(die_counter == 1)
 
 	-- HP change is rangelim from -U16_MAX to U16_MAX
 	expected_diff = -65535 - 22
 	player:set_hp(-1000000)
 	-- and actual final HP value is clamped to 0
 	assert(player:get_hp() == 0)
+	assert(die_counter == 2)
 
 	expected_diff = 11
 	player:set_hp(11)
 	assert(player:get_hp() == 11)
+	assert(die_counter == 2)
 
 	expected_diff = 65535 - 11
 	player:set_hp(1000000)
 	-- and actual final HP value is clamped to <= hp_max
 	assert(player:get_hp() == 30)
+	assert(die_counter == 2)
 
 	expected_diff = nil
 	player:set_properties({hp_max = old_hp_max})

--- a/games/devtest/mods/unittests/player.lua
+++ b/games/devtest/mods/unittests/player.lua
@@ -63,7 +63,6 @@ local function run_hp_difference_tests(player)
 	player:set_hp(22)
 	assert(die_counter == 0)
 
-	-- final HP value is clamped to >= 0 before difference calculation
 	expected_diff = -25
 	player:set_hp(-3)
 	-- and actual final HP value is clamped to >= 0 too
@@ -75,7 +74,7 @@ local function run_hp_difference_tests(player)
 	assert(player:get_hp() == 22)
 	assert(die_counter == 1)
 
-	-- HP change is rangelim from -U16_MAX to U16_MAX
+	-- HP change allowed minimum is -U16_MAX
 	expected_diff = -65535 - 22
 	player:set_hp(-1000000)
 	-- and actual final HP value is clamped to 0
@@ -87,7 +86,8 @@ local function run_hp_difference_tests(player)
 	assert(player:get_hp() == 11)
 	assert(die_counter == 2)
 
-	expected_diff = 65535 - 11
+	-- Hp change is not limited here
+	expected_diff = 1000000 - 11
 	player:set_hp(1000000)
 	-- and actual final HP value is clamped to <= hp_max
 	assert(player:get_hp() == 30)

--- a/games/devtest/mods/unittests/player.lua
+++ b/games/devtest/mods/unittests/player.lua
@@ -85,8 +85,9 @@ local function hp_diference_test(player, hp_max)
 	assert(die_counter == 1)
 
 	-- Integer overflow is prevented
-	expected_diff = -2147483648 -- S32_MIN
-	player:set_hp(-3000000000)
+	-- so result is S32_MIN, not S32_MIN - 22
+	expected_diff = -2147483648
+	player:set_hp(-2147483648)
 	-- actual final HP value is clamped to >= 0
 	assert(player:get_hp() == 0)
 	assert(hpchange_counter == 3)

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -519,10 +519,11 @@ void PlayerSAO::rightClick(ServerActiveObject *clicker)
 
 void PlayerSAO::setHP(s32 target_hp, const PlayerHPChangeReason &reason, bool from_client)
 {
-	s32 hp_change = std::max<s32>(target_hp, S32_MIN+U16_MAX) - (s32)m_hp;
-
-	if ((target_hp == m_hp) || (m_hp == 0 && target_hp < 0))
+	if (target_hp == m_hp || (m_hp == 0 && target_hp < 0))
 		return; // Nothing to do
+
+	// Protect against overflow.
+	s32 hp_change = std::max<s64>((s64)target_hp - (s64)m_hp, S32_MIN);
 
 	hp_change = m_env->getScriptIface()->on_player_hpchange(this, hp_change, reason);
 	hp_change = std::min<s32>(hp_change, U16_MAX); // Protect against overflow

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -519,12 +519,13 @@ void PlayerSAO::rightClick(ServerActiveObject *clicker)
 
 void PlayerSAO::setHP(s32 target_hp, const PlayerHPChangeReason &reason, bool from_client)
 {
+	s32 hp_change = target_hp - (s32)m_hp;
 	target_hp = rangelim(target_hp, 0, U16_MAX);
 
 	if (target_hp == m_hp)
 		return; // Nothing to do
 
-	s32 hp_change = m_env->getScriptIface()->on_player_hpchange(this, target_hp - (s32)m_hp, reason);
+	hp_change = m_env->getScriptIface()->on_player_hpchange(this, hp_change, reason);
 	hp_change = std::min<s32>(hp_change, U16_MAX); // Protect against overflow
 
 	s32 hp = (s32)m_hp + hp_change;

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -519,7 +519,9 @@ void PlayerSAO::rightClick(ServerActiveObject *clicker)
 
 void PlayerSAO::setHP(s32 target_hp, const PlayerHPChangeReason &reason, bool from_client)
 {
+	target_hp = rangelim(target_hp, -U16_MAX, U16_MAX);
 	s32 hp_change = target_hp - (s32)m_hp;
+
 	target_hp = rangelim(target_hp, 0, U16_MAX);
 
 	if (target_hp == m_hp)

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -519,11 +519,9 @@ void PlayerSAO::rightClick(ServerActiveObject *clicker)
 
 void PlayerSAO::setHP(s32 target_hp, const PlayerHPChangeReason &reason, bool from_client)
 {
-	s32 hp_change = std::max<s32>(target_hp, -U16_MAX) - (s32)m_hp;
+	s32 hp_change = std::max<s32>(target_hp, S32_MIN+U16_MAX) - (s32)m_hp;
 
-	target_hp = rangelim(target_hp, 0, U16_MAX);
-
-	if (target_hp == m_hp)
+	if ((target_hp == m_hp) || (m_hp == 0 && target_hp < 0))
 		return; // Nothing to do
 
 	hp_change = m_env->getScriptIface()->on_player_hpchange(this, hp_change, reason);

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -519,8 +519,7 @@ void PlayerSAO::rightClick(ServerActiveObject *clicker)
 
 void PlayerSAO::setHP(s32 target_hp, const PlayerHPChangeReason &reason, bool from_client)
 {
-	target_hp = rangelim(target_hp, -U16_MAX, U16_MAX);
-	s32 hp_change = target_hp - (s32)m_hp;
+	s32 hp_change = std::max<s32>(target_hp, -U16_MAX) - (s32)m_hp;
 
 	target_hp = rangelim(target_hp, 0, U16_MAX);
 


### PR DESCRIPTION
- Fix #14344

## To do

This PR is a Ready for Review.

## How to test

Run Devtest unittests.

Add somewhere something like:
```
core.register_on_dieplayer(function()
  print("DIE")
end)
```
And kill yourself to see, that `on_dieplayer` is called only once.
