### PR TITLE
Avoid cloud jump when switching between mainmenu and loading screen

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -138,9 +138,11 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 
 	// Create the menu clouds
 	// This is only global so it can be used by RenderingEngine::draw_load_screen().
-	assert(!g_menucloudsmgr && !g_menuclouds);
+	assert(!g_menu_shader_source && !g_menucloudsmgr && !g_menuclouds);
+	g_menu_shader_source = createShaderSource();
+	g_menu_shader_source->addShaderConstantSetterFactory(new FogShaderConstantSetterFactory());
 	g_menucloudsmgr = m_rendering_engine->get_scene_manager()->createNewSceneManager();
-	g_menuclouds = new Clouds(g_menucloudsmgr, nullptr, -1, rand());
+	g_menuclouds = new Clouds(g_menucloudsmgr, g_menu_shader_source, -1, rand());
 	g_menuclouds->setHeight(100.0f);
 	g_menuclouds->update(v3f(0, 0, 0), video::SColor(255, 240, 240, 255));
 	scene::ICameraSceneNode* camera;
@@ -267,6 +269,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	assert(g_menuclouds->getReferenceCount() == 1);
 	g_menuclouds->drop();
 	g_menuclouds = nullptr;
+	delete g_menu_shader_source;
 
 	return retval;
 }

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -138,11 +138,11 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 
 	// Create the menu clouds
 	// This is only global so it can be used by RenderingEngine::draw_load_screen().
-	assert(!menu_shader_source && !g_menucloudsmgr && !g_menuclouds);
-	menu_shader_source = createShaderSource();
-	menu_shader_source->addShaderConstantSetterFactory(new FogShaderConstantSetterFactory());
+	assert(!g_menucloudsmgr && !g_menuclouds);
+	std::unique_ptr<IWritableShaderSource> ssrc(createShaderSource());
+	ssrc->addShaderConstantSetterFactory(new FogShaderConstantSetterFactory());
 	g_menucloudsmgr = m_rendering_engine->get_scene_manager()->createNewSceneManager();
-	g_menuclouds = new Clouds(g_menucloudsmgr, menu_shader_source, -1, rand());
+	g_menuclouds = new Clouds(g_menucloudsmgr, ssrc.get(), -1, rand());
 	g_menuclouds->setHeight(100.0f);
 	g_menuclouds->update(v3f(0, 0, 0), video::SColor(255, 240, 240, 255));
 	scene::ICameraSceneNode* camera;
@@ -269,7 +269,6 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	assert(g_menuclouds->getReferenceCount() == 1);
 	g_menuclouds->drop();
 	g_menuclouds = nullptr;
-	delete menu_shader_source;
 
 	return retval;
 }

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -138,11 +138,11 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 
 	// Create the menu clouds
 	// This is only global so it can be used by RenderingEngine::draw_load_screen().
-	assert(!g_menu_shader_source && !g_menucloudsmgr && !g_menuclouds);
-	g_menu_shader_source = createShaderSource();
-	g_menu_shader_source->addShaderConstantSetterFactory(new FogShaderConstantSetterFactory());
+	assert(!menu_shader_source && !g_menucloudsmgr && !g_menuclouds);
+	menu_shader_source = createShaderSource();
+	menu_shader_source->addShaderConstantSetterFactory(new FogShaderConstantSetterFactory());
 	g_menucloudsmgr = m_rendering_engine->get_scene_manager()->createNewSceneManager();
-	g_menuclouds = new Clouds(g_menucloudsmgr, g_menu_shader_source, -1, rand());
+	g_menuclouds = new Clouds(g_menucloudsmgr, menu_shader_source, -1, rand());
 	g_menuclouds->setHeight(100.0f);
 	g_menuclouds->update(v3f(0, 0, 0), video::SColor(255, 240, 240, 255));
 	scene::ICameraSceneNode* camera;
@@ -269,7 +269,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	assert(g_menuclouds->getReferenceCount() == 1);
 	g_menuclouds->drop();
 	g_menuclouds = nullptr;
-	delete g_menu_shader_source;
+	delete menu_shader_source;
 
 	return retval;
 }

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -27,6 +27,7 @@ class MyEventReceiver;
 class InputHandler;
 struct GameStartData;
 struct MainMenuData;
+class IWritableShaderSource;
 
 class ClientLauncher
 {
@@ -55,4 +56,5 @@ private:
 	RenderingEngine *m_rendering_engine = nullptr;
 	InputHandler *input = nullptr;
 	MyEventReceiver *receiver = nullptr;
+	IWritableShaderSource *menu_shader_source = nullptr;
 };

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -27,7 +27,6 @@ class MyEventReceiver;
 class InputHandler;
 struct GameStartData;
 struct MainMenuData;
-class IWritableShaderSource;
 
 class ClientLauncher
 {
@@ -56,5 +55,4 @@ private:
 	RenderingEngine *m_rendering_engine = nullptr;
 	InputHandler *input = nullptr;
 	MyEventReceiver *receiver = nullptr;
-	IWritableShaderSource *menu_shader_source = nullptr;
 };

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -28,11 +28,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include <cmath>
 
-
-// Menu clouds are created later
 class Clouds;
-Clouds *g_menuclouds = NULL;
+IWritableShaderSource *g_menu_shader_source = NULL;
 scene::ISceneManager *g_menucloudsmgr = NULL;
+Clouds *g_menuclouds = NULL;
 
 // Constant for now
 static constexpr const float cloud_size = BS * 64.0f;
@@ -49,9 +48,8 @@ Clouds::Clouds(scene::ISceneManager* mgr, IShaderSource *ssrc,
 	scene::ISceneNode(mgr->getRootSceneNode(), mgr, id),
 	m_seed(seed)
 {
+	assert(ssrc);
 	m_enable_shaders = g_settings->getBool("enable_shaders");
-	// menu clouds use shader-less clouds for simplicity (ssrc == NULL)
-	m_enable_shaders = m_enable_shaders && ssrc;
 
 	m_material.Lighting = false;
 	m_material.BackfaceCulling = true;

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -29,9 +29,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cmath>
 
 class Clouds;
-IWritableShaderSource *g_menu_shader_source = NULL;
-scene::ISceneManager *g_menucloudsmgr = NULL;
-Clouds *g_menuclouds = NULL;
+scene::ISceneManager *g_menucloudsmgr = nullptr;
+Clouds *g_menuclouds = nullptr;
 
 // Constant for now
 static constexpr const float cloud_size = BS * 64.0f;

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "irrlichttypes_bloated.h"
+#include "client/shader.h"
 #include "constants.h"
 #include "irr_ptr.h"
 #include "skyparams.h"
@@ -36,11 +37,12 @@ namespace irr::scene
 }
 
 // Menu clouds
+// The mainmenu and the loading screen use the same Clouds object so that the
+// clouds don't jump when switching between the two.
 class Clouds;
-extern Clouds *g_menuclouds;
-
-// Scene manager used for menu clouds
+extern IWritableShaderSource *g_menu_shader_source;
 extern scene::ISceneManager *g_menucloudsmgr;
+extern Clouds *g_menuclouds;
 
 class Clouds : public scene::ISceneNode
 {

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -20,7 +20,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "irrlichttypes_bloated.h"
-#include "client/shader.h"
 #include "constants.h"
 #include "irr_ptr.h"
 #include "skyparams.h"
@@ -40,7 +39,6 @@ namespace irr::scene
 // The mainmenu and the loading screen use the same Clouds object so that the
 // clouds don't jump when switching between the two.
 class Clouds;
-extern IWritableShaderSource *g_menu_shader_source;
 extern scene::ISceneManager *g_menucloudsmgr;
 extern Clouds *g_menuclouds;
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -141,10 +141,6 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 	// create texture source
 	m_texture_source = std::make_unique<MenuTextureSource>(rendering_engine->get_video_driver());
 
-	// create shader source
-	// (currently only used by clouds)
-	m_shader_source.reset(createShaderSource());
-
 	// create soundmanager
 #if USE_SOUND
 	if (g_settings->getBool("enable_sound") && g_sound_manager_singleton.get()) {
@@ -295,10 +291,6 @@ void GUIEngine::run()
 	IrrlichtDevice *device = m_rendering_engine->get_raw_device();
 	video::IVideoDriver *driver = device->getVideoDriver();
 
-	// Always create clouds because they may or may not be
-	// needed based on the game selected
-	cloudInit();
-
 	unsigned int text_height = g_fontengine->getTextHeight();
 
 	// Reset fog color
@@ -390,8 +382,6 @@ GUIEngine::~GUIEngine()
 
 	m_irr_toplefttext->remove();
 
-	m_cloud.clouds.reset();
-
 	// delete textures
 	for (image_definition &texture : m_textures) {
 		if (texture.texture)
@@ -400,25 +390,10 @@ GUIEngine::~GUIEngine()
 }
 
 /******************************************************************************/
-void GUIEngine::cloudInit()
-{
-	m_shader_source->addShaderConstantSetterFactory(
-		new FogShaderConstantSetterFactory());
-
-	m_cloud.clouds = make_irr<Clouds>(m_smgr, m_shader_source.get(), -1, rand());
-	m_cloud.clouds->setHeight(100.0f);
-	m_cloud.clouds->update(v3f(0, 0, 0), video::SColor(255,240,240,255));
-
-	m_cloud.camera = m_smgr->addCameraSceneNode(0,
-				v3f(0,0,0), v3f(0, 60, 100));
-	m_cloud.camera->setFarValue(10000);
-}
-
-/******************************************************************************/
 void GUIEngine::drawClouds(float dtime)
 {
-	m_cloud.clouds->step(dtime*3);
-	m_smgr->drawAll();
+	g_menuclouds->step(dtime * 3);
+	g_menucloudsmgr->drawAll();
 }
 
 /******************************************************************************/

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -203,8 +203,6 @@ private:
 	MainMenuData                         *m_data = nullptr;
 	/** texture source */
 	std::unique_ptr<ISimpleTextureSource> m_texture_source;
-	/** shader source */
-	std::unique_ptr<IWritableShaderSource> m_shader_source;
 	/** sound manager */
 	std::unique_ptr<ISoundManager>        m_sound_manager;
 
@@ -279,23 +277,11 @@ private:
 	/** and text that is in it */
 	EnrichedString m_toplefttext;
 
-	/** initialize cloud subsystem */
-	void cloudInit();
 	/** do preprocessing for cloud subsystem */
 	void drawClouds(float dtime);
 
-	/** internam data required for drawing clouds */
-	struct clouddata {
-		/** pointer to cloud class */
-		irr_ptr<Clouds> clouds;
-		/** camera required for drawing clouds */
-		scene::ICameraSceneNode *camera = nullptr;
-	};
-
 	/** is drawing of clouds enabled atm */
-	bool        m_clouds_enabled = true;
-	/** data used to draw clouds */
-	clouddata   m_cloud;
+	bool m_clouds_enabled = true;
 
 	static void fullscreenChangedCallback(const std::string &name, void *data);
 };


### PR DESCRIPTION
This PR prevents the clouds from jumping when switching between mainmenu and loading screen by using the same Clouds object for both.

The mainmenu clouds already used shaders before. I had to choose between both or neither, so now both the mainmenu clouds and the loading screen clouds use shaders if available.

## To do

This PR is a Ready for Review.

## How to test

Look at clouds in the mainmenu and on the loading screen, verify that they work with and without shaders.

See that there's no cloud jump anymore when switching between mainmenu and loading screen.
