### PR TITLE
VAO reference class with the replacement of the MapBlock's SMeshBuffer

### DIFF
--- a/irr/include/IVertexArrayRef.h
+++ b/irr/include/IVertexArrayRef.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "IReferenceCounted.h"
+#include "S3DVertex.h"
+#include "SVertexIndex.h"
+#include "EHardwareBufferFlags.h"
+#include "EPrimitiveTypes.h"
+#include "SMaterial.h"
+#include <cassert>
+
+namespace irr
+{
+
+namespace video
+{
+	class IVideoDriver;
+}
+
+namespace scene
+{
+
+class IVertexArrayRef : public virtual IReferenceCounted
+{
+public:
+	IVertexArrayRef(video::E_VERTEX_TYPE vertexType = video::EVT_STANDARD,
+		scene::E_HARDWARE_MAPPING mappingHintVertex = scene::EHM_STATIC,
+		video::E_INDEX_TYPE indexType = video::EIT_16BIT,
+		scene::E_HARDWARE_MAPPING mappingHintIndex = scene::EHM_STATIC)
+		  : VertexArrayId(0), VertexBufferId(0), IndexBufferId(0),
+			VertexType(vertexType), IndexType(indexType)
+	{
+		assert(mappingHintVertex != scene::EHM_NEVER);
+		MappingHint_Vertex = mappingHintVertex;
+
+		assert(mappingHintIndex != scene::EHM_NEVER);
+		MappingHint_Index = mappingHintIndex;
+	}
+
+	virtual ~IVertexArrayRef() {}
+
+	virtual void uploadData(u32 vertexCount, const void *vertexData,
+		u32 indexCount=0, const void *indexData=nullptr) = 0;
+
+	virtual void bind() const = 0;
+
+	virtual void unbind() const = 0;
+
+	virtual void setAttributes() = 0;
+
+	virtual void draw(video::IVideoDriver *driver, const video::SMaterial &last_material,
+		scene::E_PRIMITIVE_TYPE primitive_type = scene::EPT_TRIANGLES, const void* index_data=0) const  = 0;
+
+	bool operator==(const IVertexArrayRef *other_array)
+	{
+		return (this->VertexArrayId == other_array->VertexArrayId);
+	}
+
+protected:
+	u32 getPrimitiveCount(scene::E_PRIMITIVE_TYPE primitive_type) const {
+		switch (primitive_type) {
+		case scene::EPT_POINTS:
+			return IndexCount;
+		case scene::EPT_LINE_STRIP:
+			return IndexCount - 1;
+		case scene::EPT_LINE_LOOP:
+			return IndexCount;
+		case scene::EPT_LINES:
+			return IndexCount / 2;
+		case scene::EPT_TRIANGLE_STRIP:
+			return (IndexCount - 2);
+		case scene::EPT_TRIANGLE_FAN:
+			return (IndexCount - 2);
+		case scene::EPT_TRIANGLES:
+			return IndexCount / 3;
+		case scene::EPT_POINT_SPRITES:
+			return IndexCount;
+		}
+		return 0;
+	}
+
+	u32 VertexArrayId;
+	u32 VertexBufferId;
+	u32 IndexBufferId;
+
+	video::E_VERTEX_TYPE VertexType;
+	video::E_INDEX_TYPE IndexType;
+
+	E_HARDWARE_MAPPING MappingHint_Vertex;
+	E_HARDWARE_MAPPING MappingHint_Index;
+
+	u32 VertexCount;
+	u32 IndexCount;
+};
+
+} // end namespace scene
+} // end namespace scene

--- a/irr/include/IVideoDriver.h
+++ b/irr/include/IVideoDriver.h
@@ -19,6 +19,7 @@
 #include "SOverrideMaterial.h"
 #include "S3DVertex.h" // E_VERTEX_TYPE
 #include "SVertexIndex.h" // E_INDEX_TYPE
+#include "IVertexArrayRef.h"
 
 namespace irr
 {
@@ -149,6 +150,9 @@ public:
 	world, or projection.
 	\param mat Matrix describing the transformation. */
 	virtual void setTransform(E_TRANSFORMATION_STATE state, const core::matrix4 &mat) = 0;
+
+	//! create the vertex array object reference
+	virtual scene::IVertexArrayRef *createVertexArrayRef() const = 0;
 
 	//! Returns the transformation set by setTransform
 	/** \param state Transformation type to query
@@ -458,6 +462,9 @@ public:
 	//! Gets the area of the current viewport.
 	/** \return Rectangle of the current viewport. */
 	virtual const core::rect<s32> &getViewPort() const = 0;
+
+	//! Draws VAO content (vertex and index buffers).
+	virtual void drawVertexArray(const scene::IVertexArrayRef *varray, const void *index_data=0) = 0;
 
 	//! Draws a vertex primitive list
 	/** Note that, depending on the index type, some vertices might be not

--- a/irr/include/SVertexIndex.h
+++ b/irr/include/SVertexIndex.h
@@ -16,5 +16,17 @@ enum E_INDEX_TYPE
 	EIT_32BIT
 };
 
+inline u32 getIndexPitchFromType(video::E_INDEX_TYPE indexType)
+{
+	switch(indexType) {
+	case video::EIT_16BIT:
+		return sizeof(u16);
+	case video::EIT_32BIT:
+		return sizeof(u32);
+	default:
+		return 0;
+	}
+}
+
 } // end namespace video
 } // end namespace irr

--- a/irr/src/CMakeLists.txt
+++ b/irr/src/CMakeLists.txt
@@ -359,6 +359,8 @@ if(ENABLE_OPENGL3 OR ENABLE_GLES2)
 		OpenGL/FixedPipelineRenderer.cpp
 		OpenGL/MaterialRenderer.cpp
 		OpenGL/Renderer2D.cpp
+		OpenGL/VertexArrayRef.cpp
+		OpenGL/VertexType.cpp
 	)
 endif()
 

--- a/irr/src/CNullDriver.cpp
+++ b/irr/src/CNullDriver.cpp
@@ -262,6 +262,12 @@ const core::matrix4 &CNullDriver::getTransform(E_TRANSFORMATION_STATE state) con
 	return TransformationMatrix;
 }
 
+//! create the vertex array object reference
+scene::IVertexArrayRef *CNullDriver::createVertexArrayRef() const
+{
+	return nullptr;
+}
+
 //! sets a material
 void CNullDriver::setMaterial(const SMaterial &material)
 {
@@ -597,6 +603,11 @@ void CNullDriver::setViewPort(const core::rect<s32> &area)
 const core::rect<s32> &CNullDriver::getViewPort() const
 {
 	return ViewPort;
+}
+
+//! Draws VAO content (vertex and index buffers).
+void CNullDriver::drawVertexArray(const scene::IVertexArrayRef *varray, const void *index_data)
+{
 }
 
 //! draws a vertex primitive list

--- a/irr/src/CNullDriver.h
+++ b/irr/src/CNullDriver.h
@@ -57,6 +57,9 @@ public:
 	//! sets transformation
 	void setTransform(E_TRANSFORMATION_STATE state, const core::matrix4 &mat) override;
 
+	//! create the vertex array object reference
+	scene::IVertexArrayRef *createVertexArrayRef() const override;
+
 	//! Retrieve the number of image loaders
 	u32 getImageLoaderCount() const override;
 
@@ -101,6 +104,9 @@ public:
 
 	//! gets the area of the current viewport
 	const core::rect<s32> &getViewPort() const override;
+
+	//! Draws VAO content (vertex and index buffers).
+	void drawVertexArray(const scene::IVertexArrayRef *varray, const void *index_data=0) override;
 
 	//! draws a vertex primitive list
 	virtual void drawVertexPrimitiveList(const void *vertices, u32 vertexCount,

--- a/irr/src/OpenGL/Driver.h
+++ b/irr/src/OpenGL/Driver.h
@@ -53,6 +53,9 @@ public:
 		u32 vbo_Size = 0;
 	};
 
+	//! create the vertex array object reference
+	scene::IVertexArrayRef *createVertexArrayRef() const override;
+
 	bool updateVertexHardwareBuffer(SHWBufferLink_opengl *HWBuffer);
 	bool updateIndexHardwareBuffer(SHWBufferLink_opengl *HWBuffer);
 
@@ -71,6 +74,9 @@ public:
 	void drawBuffers(const scene::IVertexBuffer *vb,
 		const scene::IIndexBuffer *ib, u32 primCount,
 		scene::E_PRIMITIVE_TYPE pType = scene::EPT_TRIANGLES) override;
+
+	//! Draws VAO content (vertex and index buffers).
+	void drawVertexArray(const scene::IVertexArrayRef *varray, const void *index_data=0) override;
 
 	IRenderTarget *addRenderTarget() override;
 

--- a/irr/src/OpenGL/VertexArrayRef.cpp
+++ b/irr/src/OpenGL/VertexArrayRef.cpp
@@ -1,0 +1,179 @@
+#include "OpenGL/VertexArrayRef.h"
+#include "OpenGL/VertexType.h"
+#include "vendor/gl.h"
+#include "mt_opengl.h"
+#include "os.h"
+
+namespace irr
+{
+namespace scene
+{
+
+inline GLenum to_gl_usage(E_HARDWARE_MAPPING mapping)
+{
+	GLenum usage = GL_STATIC_DRAW;
+	if (mapping == scene::EHM_STREAM)
+		usage = GL_STREAM_DRAW;
+	else if (mapping == scene::EHM_DYNAMIC)
+		usage = GL_DYNAMIC_DRAW;
+
+	return usage;
+}
+
+inline GLenum to_gl_indextype(video::E_INDEX_TYPE index_type)
+{
+	GLenum indexType = 0;
+
+	switch (index_type) {
+    case (video::EIT_16BIT): {
+		indexType = GL_UNSIGNED_SHORT;
+		break;
+	}
+    case (video::EIT_32BIT): {
+		indexType = GL_UNSIGNED_INT;
+		break;
+	}
+	}
+
+	return indexType;
+}
+
+COpenGL3VertexArrayRef::COpenGL3VertexArrayRef()
+	: IVertexArrayRef()
+{
+	GL.GenVertexArrays(1, &VertexArrayId);
+	GL.GenBuffers(1, &VertexBufferId);
+}
+
+COpenGL3VertexArrayRef::~COpenGL3VertexArrayRef()
+{
+	GL.DeleteVertexArrays(1, &VertexArrayId);
+	GL.DeleteBuffers(1, &VertexBufferId);
+
+	if (IndexBufferId != 0)
+		GL.DeleteBuffers(1, &IndexBufferId);
+}
+
+void COpenGL3VertexArrayRef::uploadData(u32 vertexCount, const void *vertexData,
+	u32 indexCount, const void *indexData)
+{
+	bool vdata_valid = vertexCount > 0 && vertexData != nullptr;
+	bool idata_valid = indexCount > 0 && indexData != nullptr;
+
+	if (!vdata_valid && !idata_valid) {
+		os::Printer::log("Failed to upload the data in the vertex and index buffer (either vertices nor indices provided)");
+		return;
+	}
+
+	os::Printer::log("uploadData() 1");
+	GL.BindVertexArray(VertexArrayId);
+	os::Printer::log("uploadData() 2");
+	if (vdata_valid) {
+		VertexCount = vertexCount;
+
+		GL.BindBuffer(GL_ARRAY_BUFFER, VertexBufferId);
+
+		size_t bufferSize = VertexCount * video::getVertexPitchFromType(VertexType);
+
+		GL.BufferData(GL_ARRAY_BUFFER, bufferSize, vertexData, to_gl_usage(MappingHint_Vertex));
+	}
+	os::Printer::log("uploadData() 3");
+
+	if (VertexCount > 0 && idata_valid) {
+		if (IndexBufferId == 0)
+			GL.GenBuffers(1, &IndexBufferId);
+
+		IndexCount = indexCount;
+
+		GL.BindBuffer(GL_ELEMENT_ARRAY_BUFFER, IndexBufferId);
+
+		size_t bufferSize = IndexCount * video::getIndexPitchFromType(IndexType);
+
+		GL.BufferData(GL_ELEMENT_ARRAY_BUFFER, bufferSize, indexData, to_gl_usage(MappingHint_Index));
+	}
+	os::Printer::log("uploadData() 4");
+
+	setAttributes();
+	os::Printer::log("uploadData() 5");
+
+	GL.BindVertexArray(0);
+	os::Printer::log("uploadData() 6");
+}
+
+void COpenGL3VertexArrayRef::bind() const
+{
+	GL.BindVertexArray(VertexArrayId);
+}
+
+void COpenGL3VertexArrayRef::unbind() const
+{
+	GL.BindVertexArray(0);
+}
+
+void COpenGL3VertexArrayRef::setAttributes()
+{
+	auto &vertexAttribs = video::getVertexTypeDescription(VertexType);
+	for (auto &attr : vertexAttribs.Attributes) {
+		GL.EnableVertexAttribArray(attr.Index);
+		switch (attr.mode) {
+		case video::VertexAttribute::Mode::Regular:
+			GL.VertexAttribPointer(attr.Index, attr.ComponentCount, (u32)attr.ComponentType, GL_FALSE, vertexAttribs.VertexSize, (void*)attr.Offset);
+			break;
+		case video::VertexAttribute::Mode::Normalized:
+			GL.VertexAttribPointer(attr.Index, attr.ComponentCount, (u32)attr.ComponentType, GL_TRUE, vertexAttribs.VertexSize, (void*)attr.Offset);
+			break;
+		case video::VertexAttribute::Mode::Integral:
+			GL.VertexAttribIPointer(attr.Index, attr.ComponentCount, (u32)attr.ComponentType, vertexAttribs.VertexSize, (void*)attr.Offset);
+			break;
+		}
+	}
+}
+
+void COpenGL3VertexArrayRef::draw(video::IVideoDriver *driver, const video::SMaterial &last_material,
+	scene::E_PRIMITIVE_TYPE primitive_type, const void* index_data) const
+{
+	if (VertexCount == 0 || IndexCount == 0) {
+		os::Printer::log("Failed to draw the VAO (the vertex or index data wasn't loaded)");
+		return;
+	}
+
+	GLenum indexType = to_gl_indextype(IndexType);
+
+	u32 primitiveCount = getPrimitiveCount(primitive_type);
+
+	std::string log1 = "VertexCount " + std::to_string(VertexCount);
+	os::Printer::log(log1.c_str());
+	std::string log2 = "IndexCount " + std::to_string(IndexCount);
+	os::Printer::log(log2.c_str());
+
+	switch (primitive_type) {
+	case scene::EPT_POINTS:
+	case scene::EPT_POINT_SPRITES:
+		GL.DrawArrays(GL_POINTS, 0, primitiveCount);
+		break;
+	case scene::EPT_LINE_STRIP:
+		GL.DrawElements(GL_LINE_STRIP, primitiveCount + 1, indexType, index_data);
+		break;
+	case scene::EPT_LINE_LOOP:
+		GL.DrawElements(GL_LINE_LOOP, primitiveCount, indexType, index_data);
+		break;
+	case scene::EPT_LINES:
+		GL.DrawElements(GL_LINES, primitiveCount * 2, indexType, index_data);
+		break;
+	case scene::EPT_TRIANGLE_STRIP:
+		GL.DrawElements(GL_TRIANGLE_STRIP, primitiveCount + 2, indexType, index_data);
+		break;
+	case scene::EPT_TRIANGLE_FAN:
+		GL.DrawElements(GL_TRIANGLE_FAN, primitiveCount + 2, indexType, index_data);
+		break;
+	case scene::EPT_TRIANGLES:
+		GL.DrawElements((last_material.Wireframe) ? GL_LINES : (last_material.PointCloud) ? GL_POINTS
+			: GL_TRIANGLES, primitiveCount * 3, indexType, index_data);
+		break;
+	default:
+		break;
+	}
+}
+
+} // end namespace scene
+} // end namespace irr

--- a/irr/src/OpenGL/VertexArrayRef.h
+++ b/irr/src/OpenGL/VertexArrayRef.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "IVertexArrayRef.h"
+
+namespace irr
+{
+namespace scene
+{
+
+class COpenGL3VertexArrayRef : public IVertexArrayRef
+{
+public:
+	COpenGL3VertexArrayRef();
+
+	~COpenGL3VertexArrayRef();
+
+    void uploadData(u32 vertexCount, const void *vertexData,
+		u32 indexCount=0, const void *indexData=nullptr) override;
+
+	void bind() const override;
+
+	void unbind() const override;
+
+	void setAttributes() override;
+
+	void draw(video::IVideoDriver *driver, const video::SMaterial &last_material,
+		scene::E_PRIMITIVE_TYPE primitive_type = scene::EPT_TRIANGLES, const void* index_data=0) const override;
+};
+
+} // end namespace scene
+} // end namespace irr

--- a/irr/src/OpenGL/VertexType.cpp
+++ b/irr/src/OpenGL/VertexType.cpp
@@ -1,0 +1,90 @@
+#include "OpenGL/VertexType.h"
+#include "EVertexAttributes.h"
+#include <cassert>
+
+namespace irr
+{
+namespace video
+{
+
+const VertexAttribute *begin(const VertexType &type)
+{
+	return type.Attributes.data();
+}
+
+const VertexAttribute *end(const VertexType &type)
+{
+	return type.Attributes.data() + type.Attributes.size();
+}
+
+VertexType vtStandard = {
+	sizeof(S3DVertex),
+	{
+		{video::EVA_POSITION, 3, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Pos)},
+		{video::EVA_NORMAL, 3, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Normal)},
+		{video::EVA_COLOR, 4, VertexAttribute::Type::UByte, VertexAttribute::Mode::Normalized, offsetof(S3DVertex, Color)},
+		{video::EVA_TCOORD0, 2, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertex, TCoords)}
+	}
+};
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+
+VertexType vt2TCoords = {
+	sizeof(S3DVertex2TCoords),
+	{
+		{video::EVA_POSITION, 3, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertex2TCoords, Pos)},
+		{video::EVA_NORMAL, 3, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertex2TCoords, Normal)},
+		{video::EVA_COLOR, 4, VertexAttribute::Type::UByte, VertexAttribute::Mode::Normalized, offsetof(S3DVertex2TCoords, Color)},
+		{video::EVA_TCOORD0, 2, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertex2TCoords, TCoords)},
+		{video::EVA_TCOORD1, 2, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertex2TCoords, TCoords2)},
+	},
+};
+
+VertexType vtTangents = {
+	sizeof(S3DVertexTangents),
+	{
+		{video::EVA_POSITION, 3, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertexTangents, Pos)},
+		{video::EVA_NORMAL, 3, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertexTangents, Normal)},
+		{video::EVA_COLOR, 4, VertexAttribute::Type::UByte, VertexAttribute::Mode::Normalized, offsetof(S3DVertexTangents, Color)},
+		{video::EVA_TCOORD0, 2, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertexTangents, TCoords)},
+		{video::EVA_TANGENT, 3, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertexTangents, Tangent)},
+		{video::EVA_BINORMAL, 3, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertexTangents, Binormal)},
+	},
+};
+
+#pragma GCC diagnostic pop
+
+const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type)
+{
+	switch (type) {
+	case EVT_STANDARD:
+		return vtStandard;
+	case EVT_2TCOORDS:
+		return vt2TCoords;
+	case EVT_TANGENTS:
+		return vtTangents;
+	default:
+		assert(false);
+	}
+}
+
+VertexType vt2DImage = {
+		sizeof(S3DVertex),
+		{
+			{video::EVA_POSITION, 3, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Pos)},
+			{video::EVA_COLOR, 4, VertexAttribute::Type::UByte, VertexAttribute::Mode::Normalized, offsetof(S3DVertex, Color)},
+			{video::EVA_TCOORD0, 2, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertex, TCoords)},
+		},
+};
+
+VertexType vtPrimitive = {
+		sizeof(S3DVertex),
+		{
+			{video::EVA_POSITION, 3, VertexAttribute::Type::Float, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Pos)},
+			{video::EVA_COLOR, 4, VertexAttribute::Type::UByte, VertexAttribute::Mode::Normalized, offsetof(S3DVertex, Color)},
+		},
+};
+
+}
+}

--- a/irr/src/OpenGL/VertexType.h
+++ b/irr/src/OpenGL/VertexType.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <vector>
+#include <cstddef>
+#include "S3DVertex.h"
+
+namespace irr
+{
+namespace video
+{
+struct VertexAttribute
+{
+	enum class Mode
+	{
+		Regular,
+		Normalized,
+		Integral,
+	};
+
+	enum class Type
+	{
+		Byte = 0x1400,
+		UByte,
+		Short,
+		UShort,
+		Int,
+		UInt,
+		Float,
+		TwoBytes,
+		ThreeBytes,
+		FourBytes,
+		Double
+	};
+
+	int Index;
+	int ComponentCount;
+	Type ComponentType;
+	Mode mode;
+	size_t Offset;
+};
+
+struct VertexType
+{
+	int VertexSize;
+	std::vector<VertexAttribute> Attributes;
+};
+
+const VertexAttribute *begin(const VertexType &type);
+
+const VertexAttribute *end(const VertexType &type);
+
+extern VertexType vtStandard;
+
+extern VertexType vt2TCoords;
+
+extern VertexType vtTangents;
+
+const VertexType &getVertexTypeDescription(E_VERTEX_TYPE type);
+
+extern VertexType vt2DImage;
+
+extern VertexType vtPrimitive;
+}
+}

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -601,12 +601,7 @@ void Client::step(float dtime)
 					if (minimap_mapblocks.empty())
 						do_mapper_update = false;
 
-					bool is_empty = true;
-					for (int l = 0; l < MAX_TILE_LAYERS; l++)
-						if (r.mesh->getMesh(l)->getMeshBufferCount() != 0)
-							is_empty = false;
-
-					if (is_empty)
+					if (r.mesh->isEmpty())
 						delete r.mesh;
 					else {
 						// Replace with the new mesh

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_bloated.h"
 #include "map.h"
 #include "camera.h"
+#include "mapblock_mesh.h"
 #include <set>
 #include <map>
 
@@ -39,12 +40,6 @@ struct MapDrawControl
 
 class Client;
 class ITextureSource;
-class PartialMeshBuffer;
-
-namespace irr::scene
-{
-	class IMeshBuffer;
-}
 
 namespace irr::video
 {
@@ -100,8 +95,12 @@ public:
 	void updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length);
 	// Returns true if draw list needs updating before drawing the next frame.
 	bool needsUpdateDrawList() { return m_needs_update_drawlist; }
+
+	void setupMaterial(video::IVideoDriver *driver, const video::SMaterial &mat);
 	void renderMap(video::IVideoDriver* driver, s32 pass);
 
+	void setupShadowMaterial(video::IVideoDriver *driver, const video::SMaterial &mat,
+		const video::SMaterial &override_mat, bool is_transparent_pass) const;
 	void renderMapShadows(video::IVideoDriver *driver,
 			const video::SMaterial &material, s32 pass, int frame, int total_frames);
 
@@ -149,29 +148,6 @@ private:
 	};
 
 
-	// reference to a mesh buffer used when rendering the map.
-	struct DrawDescriptor {
-		v3s16 m_pos;
-		union {
-			scene::IMeshBuffer *m_buffer;
-			const PartialMeshBuffer *m_partial_buffer;
-		};
-		bool m_reuse_material:1;
-		bool m_use_partial_buffer:1;
-
-		DrawDescriptor(v3s16 pos, scene::IMeshBuffer *buffer, bool reuse_material) :
-			m_pos(pos), m_buffer(buffer), m_reuse_material(reuse_material), m_use_partial_buffer(false)
-		{}
-
-		DrawDescriptor(v3s16 pos, const PartialMeshBuffer *buffer) :
-			m_pos(pos), m_partial_buffer(buffer), m_reuse_material(false), m_use_partial_buffer(true)
-		{}
-
-		video::SMaterial &getMaterial();
-		/// @return index count
-		u32 draw(video::IVideoDriver* driver);
-	};
-
 	Client *m_client;
 	RenderingEngine *m_rendering_engine;
 
@@ -194,6 +170,7 @@ private:
 
 	std::set<v2s16> m_last_drawn_sectors;
 
+	bool m_enable_shaders;
 	bool m_cache_trilinear_filter;
 	bool m_cache_bilinear_filter;
 	bool m_cache_anistropic_filter;
@@ -201,4 +178,7 @@ private:
 
 	bool m_loops_occlusion_culler;
 	bool m_enable_raytraced_culling;
+
+	bool m_enable_translucent_foliage;
+	video::E_MATERIAL_TYPE m_leaves_material;
 };

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -37,15 +37,17 @@ struct PreMeshBuffer
 
 struct MeshCollector
 {
-	std::array<std::vector<PreMeshBuffer>, MAX_TILE_LAYERS> prebuffers;
+	std::vector<PreMeshBuffer> prebuffers;
 	// bounding sphere radius and center
-	f32 m_bounding_radius_sq = 0.0f;
-	v3f m_center_pos;
+	f32 bounding_radius_sq = 0.0f;
+	v3f center_pos;
+	v3f translation;
 	v3f offset;
 
 	// center_pos: pos to use for bounding-sphere, in BS-space
 	// offset: offset added to vertices
-	MeshCollector(const v3f center_pos, v3f offset = v3f()) : m_center_pos(center_pos), offset(offset) {}
+	MeshCollector(const v3f _center_pos, v3f _translation = v3f(), v3f _offset = v3f())
+		: center_pos(_center_pos), translation(_translation), offset(_offset) {}
 
 	void append(const TileSpec &material,
 			const video::S3DVertex *vertices, u32 numVertices,
@@ -56,15 +58,6 @@ struct MeshCollector
 			v3f pos, video::SColor c, u8 light_source);
 
 private:
-	void append(const TileLayer &material,
-			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices,
-			u8 layernum, bool use_scale = false);
-	void append(const TileLayer &material,
-			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices,
-			v3f pos, video::SColor c, u8 light_source,
-			u8 layernum, bool use_scale = false);
 
-	PreMeshBuffer &findBuffer(const TileLayer &layer, u8 layernum, u32 numVertices);
+	PreMeshBuffer &findBuffer(const TileLayer &layer, u32 numVertices);
 };

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -334,25 +334,24 @@ static scene::SMesh *createSpecialNodeMesh(Client *client, MapNode n,
 
 	colors->clear();
 	scene::SMesh *mesh = new scene::SMesh();
-	for (auto &prebuffers : collector.prebuffers)
-		for (PreMeshBuffer &p : prebuffers) {
-			if (p.layer.material_flags & MATERIAL_FLAG_ANIMATION) {
-				const FrameSpec &frame = (*p.layer.frames)[0];
-				p.layer.texture = frame.texture;
-			}
-			for (video::S3DVertex &v : p.vertices) {
-				v.Color.setAlpha(255);
-			}
-			scene::SMeshBuffer *buf = new scene::SMeshBuffer();
-			buf->Material.setTexture(0, p.layer.texture);
-			p.layer.applyMaterialOptions(buf->Material);
-			mesh->addMeshBuffer(buf);
-			buf->append(&p.vertices[0], p.vertices.size(),
-					&p.indices[0], p.indices.size());
-			buf->drop();
-			colors->push_back(
-				ItemPartColor(p.layer.has_color, p.layer.color));
+	for (PreMeshBuffer &p : collector.prebuffers) {
+		if (p.layer.material_flags & MATERIAL_FLAG_ANIMATION) {
+			const FrameSpec &frame = (*p.layer.frames)[0];
+			p.layer.texture = frame.texture;
 		}
+		for (video::S3DVertex &v : p.vertices)
+			v.Color.setAlpha(255);
+
+		scene::SMeshBuffer *buf = new scene::SMeshBuffer();
+		buf->Material.setTexture(0, p.layer.texture);
+		p.layer.applyMaterialOptions(buf->Material);
+		mesh->addMeshBuffer(buf);
+		buf->append(&p.vertices[0], p.vertices.size(),
+				&p.indices[0], p.indices.size());
+		buf->drop();
+		colors->push_back(
+			ItemPartColor(p.layer.has_color, p.layer.color));
+	}
 	return mesh;
 }
 

--- a/src/unittest/test_content_mapblock.cpp
+++ b/src/unittest/test_content_mapblock.cpp
@@ -192,10 +192,9 @@ void TestMapblockMeshGenerator::testSimpleNode()
 	MeshCollector col{{}};
 	MapblockMeshGenerator mg{&data, &col, nullptr};
 	mg.generate();
-	UASSERTEQ(std::size_t, col.prebuffers[0].size(), 1);
-	UASSERTEQ(std::size_t, col.prebuffers[1].size(), 0);
+	UASSERTEQ(std::size_t, col.prebuffers.size(), 1);
 
-	auto &&buf = col.prebuffers[0][0];
+	auto &&buf = col.prebuffers[0];
 	UASSERTEQ(u32, buf.layer.texture_id, 42);
 	UASSERT(checkMeshEqual(buf.vertices, buf.indices, {quad::xn, quad::xp, quad::yn, quad::yp, quad::zn, quad::zp}));
 }
@@ -214,10 +213,9 @@ void TestMapblockMeshGenerator::testSurroundedNode()
 	MeshCollector col{{}};
 	MapblockMeshGenerator mg{&data, &col, nullptr};
 	mg.generate();
-	UASSERTEQ(std::size_t, col.prebuffers[0].size(), 1);
-	UASSERTEQ(std::size_t, col.prebuffers[1].size(), 0);
+	UASSERTEQ(std::size_t, col.prebuffers.size(), 1);
 
-	auto &&buf = col.prebuffers[0][0];
+	auto &&buf = col.prebuffers[0];
 	UASSERTEQ(u32, buf.layer.texture_id, 42);
 	UASSERT(checkMeshEqual(buf.vertices, buf.indices, {quad::xn, quad::yn, quad::yp, quad::zn, quad::zp}));
 }
@@ -235,10 +233,9 @@ void TestMapblockMeshGenerator::testInterliquidSame()
 	MeshCollector col{{}};
 	MapblockMeshGenerator mg{&data, &col, nullptr};
 	mg.generate();
-	UASSERTEQ(std::size_t, col.prebuffers[0].size(), 1);
-	UASSERTEQ(std::size_t, col.prebuffers[1].size(), 0);
+	UASSERTEQ(std::size_t, col.prebuffers.size(), 1);
 
-	auto &&buf = col.prebuffers[0][0];
+	auto &&buf = col.prebuffers[0];
 	UASSERTEQ(u32, buf.layer.texture_id, 42);
 	UASSERT(checkMeshEqual(buf.vertices, buf.indices, {quad::xn, quad::yn, quad::yp, quad::zn, quad::zp}));
 }
@@ -257,10 +254,9 @@ void TestMapblockMeshGenerator::testInterliquidDifferent()
 	MeshCollector col{{}};
 	MapblockMeshGenerator mg{&data, &col, nullptr};
 	mg.generate();
-	UASSERTEQ(std::size_t, col.prebuffers[0].size(), 1);
-	UASSERTEQ(std::size_t, col.prebuffers[1].size(), 0);
+	UASSERTEQ(std::size_t, col.prebuffers.size(), 1);
 
-	auto &&buf = col.prebuffers[0][0];
+	auto &&buf = col.prebuffers[0];
 	UASSERTEQ(u32, buf.layer.texture_id, 42);
 	UASSERT(checkMeshEqual(buf.vertices, buf.indices, {quad::xn, quad::xp, quad::yn, quad::yp, quad::zn, quad::zp}));
 }


### PR DESCRIPTION
This PR brings into Irrlicht an implementation of the VAO class handling the references to the VBO, EBO and VAO objects with loading in them the correponding data. It provides a more modern and transparent handling on the chunk of the vertex data without their direct caching inside instead of the entangled and ancient IMeshBuffer interface. Also, it suggests a replacement of the SMeshBuffer in the mapblocks meshes. Instead it keeps the separate vertex & index data which (index buffers) are also split up into the buffers both for the solid & transparent submeshes.

Note: currently this is based on OpenGL3+ standard. So, due to the vertex array objects were added since this version, `opengl` Irrlicht driver won't work. So, it is necessary to test it with either `opengl3` or `ogles2`.

## How to test

Just select any game and load a  world with it, probably with some mods enabled. Test the performance and framerate with many mapblocks drawn per a frame.
