### PR TITLE
Allow Allfaces drawtypes to have 6 textures

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1470,7 +1470,8 @@ Look for examples in `games/devtest` or `games/minetest_game`.
       'Connected Glass'.
 * `allfaces`
     * Often used for partially-transparent nodes.
-    * External sides of textures are visible.
+    * External sides of textures, unlike other drawtypes, the external sides
+      of other blocks, are visible from the inside.
 * `allfaces_optional`
     * Often used for leaves nodes.
     * This switches between `normal`, `glasslike` and `allfaces` according to

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1470,12 +1470,7 @@ Look for examples in `games/devtest` or `games/minetest_game`.
       'Connected Glass'.
 * `allfaces`
     * Often used for partially-transparent nodes.
-    * External and internal sides of textures are visible.
-    * For This drawtype textures are as follows in the exact order:
-    ```
-        tiles = {tile definition 1, def2, def3, def4, def5, def6},
-        Textures of node;       -Y,  +Z,   +X,   -Z,   +Y,   -X
-    ```
+    * External sides of textures are visible.
 * `allfaces_optional`
     * Often used for leaves nodes.
     * This switches between `normal`, `glasslike` and `allfaces` according to

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1474,7 +1474,7 @@ Look for examples in `games/devtest` or `games/minetest_game`.
     * For This drawtype textures are as follows in the exact order:
     ```
         tiles = {tile definition 1, def2, def3, def4, def5, def6},
-        Textures of node;       -Y,  +Z,   +X,   -Z,   -Y,   -X
+        Textures of node;       -Y,  +Z,   +X,   -Z,   +Y,   -X
     ```
 * `allfaces_optional`
     * Often used for leaves nodes.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1471,6 +1471,11 @@ Look for examples in `games/devtest` or `games/minetest_game`.
 * `allfaces`
     * Often used for partially-transparent nodes.
     * External and internal sides of textures are visible.
+    * For This drawtype textures are as follows in the exact order:
+    ```
+        tiles = {tile definition 1, def2, def3, def4, def5, def6},
+        Textures of node;       -Y,  +Z,   +X,   -Z,   -Y,   -X
+    ```
 * `allfaces_optional`
     * Often used for leaves nodes.
     * This switches between `normal`, `glasslike` and `allfaces` according to

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1470,7 +1470,7 @@ Look for examples in `games/devtest` or `games/minetest_game`.
       'Connected Glass'.
 * `allfaces`
     * Often used for partially-transparent nodes.
-    * External sides of textures, unlike other drawtypes, the external sides
+    * External sides of textures, and unlike other drawtypes, the external sides
       of other blocks, are visible from the inside.
 * `allfaces_optional`
     * Often used for leaves nodes.

--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -103,12 +103,12 @@ minetest.register_node("testnodes:allfaces_6", {
 		S("Transparent node with visible internal backfaces"),
 	drawtype = "allfaces",
 	paramtype = "light",
-	tiles = { 
-			"testnodes_allfaces.png^[colorize:red", 
-			"testnodes_allfaces.png^[colorize:orange", 
-			"testnodes_allfaces.png^[colorize:yellow", 
-			"testnodes_allfaces.png^[colorize:green", 
-			"testnodes_allfaces.png^[colorize:blue", 
+	tiles = {
+			"testnodes_allfaces.png^[colorize:red",
+			"testnodes_allfaces.png^[colorize:orange",
+			"testnodes_allfaces.png^[colorize:yellow",
+			"testnodes_allfaces.png^[colorize:green",
+			"testnodes_allfaces.png^[colorize:blue",
 			"testnodes_allfaces.png^[colorize:purple"
 		},
 

--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -98,6 +98,16 @@ minetest.register_node("testnodes:allfaces", {
 	groups = { dig_immediate = 3 },
 })
 
+minetest.register_node("testnodes:allfaces_6", {
+	description = S("\"allfaces 6 Textures\" Drawtype Test Node").."\n"..
+		S("Transparent node with visible internal backfaces"),
+	drawtype = "allfaces",
+	paramtype = "light",
+	tiles = { "testnodes_allfaces.png^[colorize:red", "testnodes_allfaces.png^[colorize:orange", "testnodes_allfaces.png^[colorize:yellow", "testnodes_allfaces.png^[colorize:green", "testnodes_allfaces.png^[colorize:blue", "testnodes_allfaces.png^[colorize:purple" },
+
+	groups = { dig_immediate = 3 },
+})
+
 local allfaces_optional_tooltip = ""..
 	S("Rendering depends on 'leaves_style' setting:").."\n"..
 	S("* 'fancy': transparent with visible internal backfaces").."\n"..

--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -103,7 +103,14 @@ minetest.register_node("testnodes:allfaces_6", {
 		S("Transparent node with visible internal backfaces"),
 	drawtype = "allfaces",
 	paramtype = "light",
-	tiles = { "testnodes_allfaces.png^[colorize:red", "testnodes_allfaces.png^[colorize:orange", "testnodes_allfaces.png^[colorize:yellow", "testnodes_allfaces.png^[colorize:green", "testnodes_allfaces.png^[colorize:blue", "testnodes_allfaces.png^[colorize:purple" },
+	tiles = { 
+			"testnodes_allfaces.png^[colorize:red", 
+			"testnodes_allfaces.png^[colorize:orange", 
+			"testnodes_allfaces.png^[colorize:yellow", 
+			"testnodes_allfaces.png^[colorize:green", 
+			"testnodes_allfaces.png^[colorize:blue", 
+			"testnodes_allfaces.png^[colorize:purple"
+		},
 
 	groups = { dig_immediate = 3 },
 })

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1001,8 +1001,12 @@ void MapblockMeshGenerator::drawGlasslikeFramedNode()
 void MapblockMeshGenerator::drawAllfacesNode()
 {
 	static const aabb3f box(-BS / 2, -BS / 2, -BS / 2, BS / 2, BS / 2, BS / 2);
-	useTile(0, 0, 0);
-	drawAutoLightedCuboid(box);
+	TileSpec tiles[6];
+	for (int face = 0; face < 6; face++)
+		getTile(g_6dirs[face], &tiles[face]);
+	if (data->m_smooth_lighting)
+		getSmoothLightFrame();
+	drawAutoLightedCuboid(box, nullptr, tiles, 6);
 }
 
 void MapblockMeshGenerator::drawTorchlikeNode()

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1001,9 +1001,17 @@ void MapblockMeshGenerator::drawGlasslikeFramedNode()
 void MapblockMeshGenerator::drawAllfacesNode()
 {
 	static const aabb3f box(-BS / 2, -BS / 2, -BS / 2, BS / 2, BS / 2, BS / 2);
+	static const v3s16 tile_dirs[6] = {
+		v3s16(0, 1, 0),
+		v3s16(0, -1, 0),
+		v3s16(1, 0, 0),
+		v3s16(-1, 0, 0),
+		v3s16(0, 0, 1),
+		v3s16(0, 0, -1)
+	};
 	TileSpec tiles[6];
 	for (int face = 0; face < 6; face++)
-		getTile(g_6dirs[face], &tiles[face]);
+		getTile(tile_dirs[face], &tiles[face]);
 	if (data->m_smooth_lighting)
 		getSmoothLightFrame();
 	drawAutoLightedCuboid(box, nullptr, tiles, 6);

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -998,25 +998,6 @@ void MapblockMeshGenerator::drawGlasslikeFramedNode()
 	}
 }
 
-void MapblockMeshGenerator::drawAllfacesNode()
-{
-	static const aabb3f box(-BS / 2, -BS / 2, -BS / 2, BS / 2, BS / 2, BS / 2);
-	static const v3s16 tile_dirs[6] = {
-		v3s16(0, 1, 0),
-		v3s16(0, -1, 0),
-		v3s16(1, 0, 0),
-		v3s16(-1, 0, 0),
-		v3s16(0, 0, 1),
-		v3s16(0, 0, -1)
-	};
-	TileSpec tiles[6];
-	for (int face = 0; face < 6; face++)
-		getTile(tile_dirs[face], &tiles[face]);
-	if (data->m_smooth_lighting)
-		getSmoothLightFrame();
-	drawAutoLightedCuboid(box, nullptr, tiles, 6);
-}
-
 void MapblockMeshGenerator::drawTorchlikeNode()
 {
 	u8 wall = cur_node.n.getWallMounted(nodedef);
@@ -1537,6 +1518,17 @@ namespace {
 		v3s16( 0,  0,  1), // back
 		v3s16( 1,  0,  0), // right
 	};
+}
+
+void MapblockMeshGenerator::drawAllfacesNode()
+{
+	static const aabb3f box(-BS / 2, -BS / 2, -BS / 2, BS / 2, BS / 2, BS / 2);
+	TileSpec tiles[6];
+	for (int face = 0; face < 6; face++)
+		getTile(nodebox_tile_dirs[face], &tiles[face]);
+	if (data->m_smooth_lighting)
+		getSmoothLightFrame();
+	drawAutoLightedCuboid(box, nullptr, tiles, 6);
 }
 
 void MapblockMeshGenerator::drawNodeboxNode()


### PR DESCRIPTION
- Goal of the PR
Allow for allfaces drawtypes to have 6 textures
- How does the PR work?
It adds merely changes to the allfaces drawtype registry to allow it have 6 textures instead of one
- Does it resolve any reported issue?
Yes: 
https://github.com/minetest/minetest/issues/9210
https://github.com/minetest/minetest/issues/6929

Of which #9210 was marked concept approved.

## To do

Ready for Review.

## How to test

Compile, make an allfaces node following the documentation to layout the textures, and ensure it works without side-effects
