### PR TITLE
Fix -Winconsistent-missing-override in unit_sao.h

### DIFF
--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -31,7 +31,7 @@ public:
 	UnitSAO(ServerEnvironment *env, v3f pos);
 	virtual ~UnitSAO() = default;
 
-	u16 getHP() const { return m_hp; }
+	u16 getHP() const override { return m_hp; }
 	// Use a function, if isDead can be defined by other conditions
 	bool isDead() const { return m_hp == 0; }
 
@@ -59,39 +59,39 @@ public:
 	{
 		return itemgroup_get(getArmorGroups(), "immortal");
 	}
-	void setArmorGroups(const ItemGroupList &armor_groups);
-	const ItemGroupList &getArmorGroups() const;
+	void setArmorGroups(const ItemGroupList &armor_groups) override;
+	const ItemGroupList &getArmorGroups() const override;
 
 	// Animation
 	void setAnimation(v2f frame_range, float frame_speed, float frame_blend,
-			bool frame_loop);
+			bool frame_loop) override;
 	void getAnimation(v2f *frame_range, float *frame_speed, float *frame_blend,
-			bool *frame_loop);
-	void setAnimationSpeed(float frame_speed);
+			bool *frame_loop) override;
+	void setAnimationSpeed(float frame_speed) override;
 
 	// Bone position
-	void setBoneOverride(const std::string &bone, const BoneOverride &props);
-	BoneOverride getBoneOverride(const std::string &bone);
+	void setBoneOverride(const std::string &bone, const BoneOverride &props) override;
+	BoneOverride getBoneOverride(const std::string &bone) override;
 	const std::unordered_map<std::string, BoneOverride>
-			&getBoneOverrides() const { return m_bone_override; };
+			&getBoneOverrides() const override { return m_bone_override; };
 
 	// Attachments
-	ServerActiveObject *getParent() const;
+	ServerActiveObject *getParent() const override;
 	inline bool isAttached() const { return m_attachment_parent_id != 0; }
 	void setAttachment(object_t parent_id, const std::string &bone, v3f position,
-			v3f rotation, bool force_visible);
+			v3f rotation, bool force_visible) override;
 	void getAttachment(object_t *parent_id, std::string *bone, v3f *position,
-			v3f *rotation, bool *force_visible) const;
+			v3f *rotation, bool *force_visible) const override;
 	void clearChildAttachments() override;
 	void addAttachmentChild(object_t child_id) override;
 	void removeAttachmentChild(object_t child_id) override;
-	const std::unordered_set<object_t> &getAttachmentChildIds() const {
+	const std::unordered_set<object_t> &getAttachmentChildIds() const override {
 		return m_attachment_child_ids;
 	}
 
 	// Object properties
-	ObjectProperties *accessObjectProperties();
-	void notifyObjectPropertiesModified();
+	ObjectProperties *accessObjectProperties() override;
+	void notifyObjectPropertiesModified() override;
 	void sendOutdatedData();
 
 	// Update packets
@@ -125,11 +125,11 @@ protected:
 	object_t m_attachment_parent_id = 0;
 
 	void clearAnyAttachments();
-	virtual void onMarkedForDeactivation() {
+	virtual void onMarkedForDeactivation() override {
 		ServerActiveObject::onMarkedForDeactivation();
 		clearAnyAttachments();
 	}
-	virtual void onMarkedForRemoval() {
+	virtual void onMarkedForRemoval() override {
 		ServerActiveObject::onMarkedForRemoval();
 		clearAnyAttachments();
 	}


### PR DESCRIPTION
fixes warning spam on Clang

<details><summary>Excerpt (the warnings continue like this for 2100 lines)</summary>
<pre>In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:34:6: warning: 'getHP' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   34 |         u16 getHP() const { return m_hp; }
      |             ^
/mt/src/server/serveractiveobject.h:156:14: note: overridden virtual function is here
  156 |         virtual u16 getHP() const
      |                     ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:62:7: warning: 'setArmorGroups' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   62 |         void setArmorGroups(const ItemGroupList &armor_groups);
      |              ^
/mt/src/server/serveractiveobject.h:159:15: note: overridden virtual function is here
  159 |         virtual void setArmorGroups(const ItemGroupList &armor_groups)
      |                      ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:63:23: warning: 'getArmorGroups' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   63 |         const ItemGroupList &getArmorGroups() const;
      |                              ^
/mt/src/server/serveractiveobject.h:161:31: note: overridden virtual function is here
  161 |         virtual const ItemGroupList &getArmorGroups() const
      |                                      ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:66:7: warning: 'setAnimation' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   66 |         void setAnimation(v2f frame_range, float frame_speed, float frame_blend,
      |              ^
/mt/src/server/serveractiveobject.h:163:15: note: overridden virtual function is here
  163 |         virtual void setAnimation(v2f frames, float frame_speed, float frame_blend, bool frame_loop)
      |                      ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:68:7: warning: 'getAnimation' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   68 |         void getAnimation(v2f *frame_range, float *frame_speed, float *frame_blend,
      |              ^
/mt/src/server/serveractiveobject.h:165:15: note: overridden virtual function is here
  165 |         virtual void getAnimation(v2f *frames, float *frame_speed, float *frame_blend, bool *frame_loop)
      |                      ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:70:7: warning: 'setAnimationSpeed' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   70 |         void setAnimationSpeed(float frame_speed);
      |              ^
/mt/src/server/serveractiveobject.h:167:15: note: overridden virtual function is here
  167 |         virtual void setAnimationSpeed(float frame_speed)
      |                      ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:73:7: warning: 'setBoneOverride' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   73 |         void setBoneOverride(const std::string &bone, const BoneOverride &props);
      |              ^
/mt/src/server/serveractiveobject.h:169:15: note: overridden virtual function is here
  169 |         virtual void setBoneOverride(const std::string &bone, const BoneOverride &props)
      |                      ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:74:15: warning: 'getBoneOverride' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   74 |         BoneOverride getBoneOverride(const std::string &bone);
      |                      ^
/mt/src/server/serveractiveobject.h:171:23: note: overridden virtual function is here
  171 |         virtual BoneOverride getBoneOverride(const std::string &bone)
      |                              ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:76:5: warning: 'getBoneOverrides' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   76 |                         &getBoneOverrides() const { return m_bone_override; };
      |                          ^
/mt/src/server/serveractiveobject.h:173:33: note: overridden virtual function is here
  173 |         virtual const BoneOverrideMap &getBoneOverrides() const
      |                                        ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:79:22: warning: 'getParent' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   79 |         ServerActiveObject *getParent() const;
      |                             ^
/mt/src/server/serveractiveobject.h:177:30: note: overridden virtual function is here
  177 |         virtual ServerActiveObject *getParent() const { return nullptr; }
      |                                     ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:81:7: warning: 'setAttachment' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   81 |         void setAttachment(object_t parent_id, const std::string &bone, v3f position,
      |              ^
/mt/src/activeobject.h:201:15: note: overridden virtual function is here
  201 |         virtual void setAttachment(object_t parent_id, const std::string &bone, v3f position,
      |                      ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:83:7: warning: 'getAttachment' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   83 |         void getAttachment(object_t *parent_id, std::string *bone, v3f *position,
      |              ^
/mt/src/activeobject.h:203:15: note: overridden virtual function is here
  203 |         virtual void getAttachment(object_t *parent_id, std::string *bone, v3f *position,
      |                      ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:88:38: warning: 'getAttachmentChildIds' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   88 |         const std::unordered_set<object_t> &getAttachmentChildIds() const {
      |                                             ^
/mt/src/server/serveractiveobject.h:175:46: note: overridden virtual function is here
  175 |         virtual const std::unordered_set<object_t> &getAttachmentChildIds() const
      |                                                     ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:93:20: warning: 'accessObjectProperties' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   93 |         ObjectProperties *accessObjectProperties();
      |                           ^
/mt/src/server/serveractiveobject.h:178:28: note: overridden virtual function is here
  178 |         virtual ObjectProperties *accessObjectProperties()
      |                                   ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:94:7: warning: 'notifyObjectPropertiesModified' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   94 |         void notifyObjectPropertiesModified();
      |              ^
/mt/src/server/serveractiveobject.h:180:15: note: overridden virtual function is here
  180 |         virtual void notifyObjectPropertiesModified()
      |                      ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:128:15: warning: 'onMarkedForDeactivation' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  128 |         virtual void onMarkedForDeactivation() {
      |                      ^
/mt/src/server/serveractiveobject.h:259:15: note: overridden virtual function is here
  259 |         virtual void onMarkedForDeactivation() {}
      |                      ^
In file included from /mt/src/network/serverpackethandler.cpp:37:
In file included from /mt/src/server/player_sao.h:26:
/mt/src/server/unit_sao.h:132:15: warning: 'onMarkedForRemoval' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  132 |         virtual void onMarkedForRemoval() {
      |                      ^
/mt/src/server/serveractiveobject.h:260:15: note: overridden virtual function is here
  260 |         virtual void onMarkedForRemoval() {}
      |                      ^
17 warnings generated.</pre>
</details>

## To do

This PR is a Ready for Review.

## How to test

Compile, see that the warnings are gone.
