### PR TITLE
Android: Add Indonesian language

### DIFF
--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="label">Minetest</string>
+    <string name="loading">Memuat&#8230;</string>
+    <string name="notification_channel_name">Pemberitahuan umum</string>
+    <string name="notification_channel_description">Pemberitahuan dari Minetest</string>
+    <string name="unzip_notification_title">Memuat Minetest</string>
+    <string name="unzip_notification_description">Kurang dari 1 menit&#8230;</string>
+    <string name="ime_dialog_done">Selesai</string>
+    <string name="no_web_browser">Tidak ditemukan peramban web</string>
+</resources>


### PR DESCRIPTION
**Goal of the PR**
This PR adds Indonesian language for Android strings.

**How does the PR work?**
_(see changes)_

**Does it resolve any reported issue?**
The main app/game has been translated into Indonesian, but not for Android-specific strings.

## To do

This PR is Ready for Review.

## How to test

1. Run Minetest on Android using Indonesian language.
2. Make sure that it is correctly shown in Indonesian, e.g. the first-load (asset copy) notification.
3. Spellcheck the translations.

![Minetest-notification-in-Indonesian](https://github.com/user-attachments/assets/d550112f-c247-40ce-81f8-3994123e267e)
