### PR TITLE
VoxelManip low-level API get/set_node_raw

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4942,10 +4942,14 @@ Methods
   the `VoxelManip` at that position
 * `get_node_raw(x, y, z)`: Returns `content_id`, `param1`, `param2` of the node
   currently loaded in the `VoxelManip` at that position
+* `get_node_raw_i(index)`: Returns `content_id`, `param1`, `param2` of the node
+  currently loaded in the `VoxelManip` at that index
 * `set_node_at(pos, node)`: Sets a specific `MapNode` in the `VoxelManip` at
   that position.
 * `set_node_raw(x, y, z, content_id, param1, param2)`: Sets the content of a node
   in the `VoxelManip` at that position.
+* `set_node_raw_i(index, content_id, param1, param2)`: Sets the content of a node
+  in the `VoxelManip` at that index.
 * `get_data([buffer])`: Retrieves the node content data loaded into the
   `VoxelManip` object.
     * returns raw node data in the form of an array of node content IDs

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4940,8 +4940,12 @@ Methods
       more lighting bugs.
 * `get_node_at(pos)`: Returns a `MapNode` table of the node currently loaded in
   the `VoxelManip` at that position
+* `get_node_raw(x, y, z)`: Returns `content_id`, `param1`, `param2` of the node
+  currently loaded in the `VoxelManip` at that position
 * `set_node_at(pos, node)`: Sets a specific `MapNode` in the `VoxelManip` at
   that position.
+* `set_node_raw(x, y, z, content_id, param1, param2)`: Sets the content of a node
+  in the `VoxelManip` at that position.
 * `get_data([buffer])`: Retrieves the node content data loaded into the
   `VoxelManip` object.
     * returns raw node data in the form of an array of node content IDs

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -172,6 +172,21 @@ int LuaVoxelManip::l_get_node_raw(lua_State *L)
 	return 3;
 }
 
+int LuaVoxelManip::l_get_node_raw_i(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
+	s32 pos = lua_tointeger(L, 1);
+
+	MapNode n = o->vm->getNodeNoExNoEmerge(pos);
+	// Return node (CONTENT_IGNORE if out of area)
+	lua_pushinteger(L, n.getContent());
+	lua_pushinteger(L, n.getParam1());
+	lua_pushinteger(L, n.getParam2());
+	return 3;
+}
+
 int LuaVoxelManip::l_set_node_at(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -198,6 +213,21 @@ int LuaVoxelManip::l_set_node_raw(lua_State *L)
 	u8 param2 = lua_tointeger(L, 6);
 
 	v3s16 pos = doubleToInt(v3d(x, y, z), 1.0);
+	MapNode n = MapNode(content, param1, param2);
+
+	lua_pushboolean(L, o->vm->setNodeNoEmerge(pos, n));
+	return 1;
+}
+
+int LuaVoxelManip::l_set_node_raw_i(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
+	s32 pos = lua_tointeger(L, 1);
+	content_t content = lua_tointeger(L, 2);
+	u8 param1 = lua_tointeger(L, 3);
+	u8 param2 = lua_tointeger(L, 4);
 	MapNode n = MapNode(content, param1, param2);
 
 	lua_pushboolean(L, o->vm->setNodeNoEmerge(pos, n));
@@ -486,8 +516,10 @@ const luaL_Reg LuaVoxelManip::methods[] = {
 	luamethod(LuaVoxelManip, set_data),
 	luamethod(LuaVoxelManip, get_node_at),
 	luamethod(LuaVoxelManip, get_node_raw),
+	luamethod(LuaVoxelManip, get_node_raw_i),
 	luamethod(LuaVoxelManip, set_node_at),
 	luamethod(LuaVoxelManip, set_node_raw),
+	luamethod(LuaVoxelManip, set_node_raw_i),
 	luamethod(LuaVoxelManip, write_to_map),
 	luamethod(LuaVoxelManip, update_map),
 	luamethod(LuaVoxelManip, update_liquids),

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -153,6 +153,25 @@ int LuaVoxelManip::l_get_node_at(lua_State *L)
 	return 1;
 }
 
+int LuaVoxelManip::l_get_node_raw(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
+	// mirrors implementation of read_v3s16 (with the exact same rounding)
+	double x = lua_tonumber(L, 1);
+	double y = lua_tonumber(L, 2);
+	double z = lua_tonumber(L, 3);
+	v3s16 pos = doubleToInt(v3d(x, y, z), 1.0);
+
+	MapNode n = o->vm->getNodeNoExNoEmerge(pos);
+	// Return node (CONTENT_IGNORE if out of area)
+	lua_pushinteger(L, n.getContent());
+	lua_pushinteger(L, n.getParam1());
+	lua_pushinteger(L, n.getParam2());
+	return 3;
+}
+
 int LuaVoxelManip::l_set_node_at(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -160,6 +179,26 @@ int LuaVoxelManip::l_set_node_at(lua_State *L)
 	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
 	v3s16 pos        = check_v3s16(L, 2);
 	MapNode n        = readnode(L, 3);
+
+	lua_pushboolean(L, o->vm->setNodeNoEmerge(pos, n));
+	return 1;
+}
+
+int LuaVoxelManip::l_set_node_raw(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaVoxelManip *o = checkObject<LuaVoxelManip>(L, 1);
+	// mirrors implementation of read_v3s16 (with the exact same rounding)
+	double x = lua_tonumber(L, 1);
+	double y = lua_tonumber(L, 2);
+	double z = lua_tonumber(L, 3);
+	content_t content = lua_tointeger(L, 4);
+	u8 param1 = lua_tointeger(L, 5);
+	u8 param2 = lua_tointeger(L, 6);
+
+	v3s16 pos = doubleToInt(v3d(x, y, z), 1.0);
+	MapNode n = MapNode(content, param1, param2);
 
 	lua_pushboolean(L, o->vm->setNodeNoEmerge(pos, n));
 	return 1;
@@ -446,7 +485,9 @@ const luaL_Reg LuaVoxelManip::methods[] = {
 	luamethod(LuaVoxelManip, get_data),
 	luamethod(LuaVoxelManip, set_data),
 	luamethod(LuaVoxelManip, get_node_at),
+	luamethod(LuaVoxelManip, get_node_raw),
 	luamethod(LuaVoxelManip, set_node_at),
+	luamethod(LuaVoxelManip, set_node_raw),
 	luamethod(LuaVoxelManip, write_to_map),
 	luamethod(LuaVoxelManip, update_map),
 	luamethod(LuaVoxelManip, update_liquids),

--- a/src/script/lua_api/l_vmanip.h
+++ b/src/script/lua_api/l_vmanip.h
@@ -45,8 +45,10 @@ private:
 
 	static int l_get_node_at(lua_State *L);
 	static int l_get_node_raw(lua_State *L);
+	static int l_get_node_raw_i(lua_State *L);
 	static int l_set_node_at(lua_State *L);
 	static int l_set_node_raw(lua_State *L);
+	static int l_set_node_raw_i(lua_State *L);
 
 	static int l_update_map(lua_State *L);
 	static int l_update_liquids(lua_State *L);

--- a/src/script/lua_api/l_vmanip.h
+++ b/src/script/lua_api/l_vmanip.h
@@ -44,7 +44,9 @@ private:
 	static int l_write_to_map(lua_State *L);
 
 	static int l_get_node_at(lua_State *L);
+	static int l_get_node_raw(lua_State *L);
 	static int l_set_node_at(lua_State *L);
+	static int l_set_node_raw(lua_State *L);
 
 	static int l_update_map(lua_State *L);
 	static int l_update_liquids(lua_State *L);

--- a/src/voxel.h
+++ b/src/voxel.h
@@ -423,6 +423,14 @@ public:
 			return {CONTENT_IGNORE};
 		return m_data[index];
 	}
+	MapNode getNodeNoExNoEmerge(s32 index)
+	{
+		if (!m_area.contains(index))
+			return {CONTENT_IGNORE};
+		if (m_flags[index] & VOXELFLAG_NO_DATA)
+			return {CONTENT_IGNORE};
+		return m_data[index];
+	}
 	// Stuff explodes if non-emerged area is touched with this.
 	// Emerge first, and check VOXELFLAG_NO_DATA if appropriate.
 	MapNode & getNodeRefUnsafe(const v3s16 &p)
@@ -473,6 +481,14 @@ public:
 		if(!m_area.contains(p))
 			return false;
 		m_data[m_area.index(p)] = n;
+		return true;
+	}
+
+	bool setNodeNoEmerge(s32 index, MapNode n)
+	{
+		if(!m_area.contains(index))
+			return false;
+		m_data[index] = n;
 		return true;
 	}
 


### PR DESCRIPTION
This tries to bring the benefits of #14384 to voxel manipulators.

It adds the low level API
* `get_node_raw(x, y, z)`: Returns `content_id`, `param1`, `param2` of the node
  currently loaded in the `VoxelManip` at that position
* `get_node_raw_i(index)`: Returns `content_id`, `param1`, `param2` of the node
  currently loaded in the `VoxelManip` at that index
* `set_node_raw(x, y, z, content_id, param1, param2)`: Sets the content of a node
  in the `VoxelManip` at that position.
* `set_node_raw_i(index, content_id, param1, param2)`: Sets the content of a node
  in the `VoxelManip` at that index.

which avoid creating Lua tables, and hence garbage collection and are supposedly easier for the JIT.

I tried replacing `get_node_at` with a wrapper calling `get_node_raw` in Lua (to have the table creation handled by JIT), but I could not do this, this needs a Lua API wizard. Supposedly for security reasons, the `VoxelManip` class metatable is made inaccessible, so I left `get_node_at` unchanged.

Sorry, no benchmarks yet.