### PR TITLE
Fix uninitialized shadow tint regression from #14610

### DIFF
--- a/src/lighting.h
+++ b/src/lighting.h
@@ -56,5 +56,5 @@ struct Lighting
 	float shadow_intensity {0.0f};
 	float saturation {1.0f};
 	float volumetric_light_strength {0.0f};
-	video::SColor shadow_tint;
+	video::SColor shadow_tint {255, 0, 0, 0};
 };

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -229,7 +229,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		[bump for 5.9.1]
 	PROTOCOL VERSION 46:
 		Move default hotbar from client-side C++ to server-side builtin Lua
-    Add shadow tint to Lighting packets
+		Add shadow tint to Lighting packets
 		Add shadow color to CloudParam packets
 		Move death screen to server and make it a regular formspec
 			The server no longer triggers the hardcoded client-side death
@@ -241,7 +241,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #define LATEST_PROTOCOL_VERSION 46
-
 #define LATEST_PROTOCOL_VERSION_STRING TOSTRING(LATEST_PROTOCOL_VERSION)
 
 // Server's supported network protocol range


### PR DESCRIPTION
Fixes a regression introduced by #14610. Also includes a commit to fix some formatting problems from that PR.

The shadow tint was uninitialized, resulting in different random shadow colors on my machine (Devtest with enable_shadows mod, nothing changed except restarting the game):

<img width="256" alt="screenshot 1" src="https://github.com/user-attachments/assets/6091d6cb-7363-434c-8e60-82b7470c48d2"> <img width="256" alt="screenshot 2" src="https://github.com/user-attachments/assets/878dfe6b-e6e7-4604-95fb-f90bc9f2a2d5"> <img width="256" alt="screenshot 3" src="https://github.com/user-attachments/assets/ff657e1c-0291-465a-8bf6-eab0ab5f2a80">

## To do

This PR is a Ready for Review.

## How to test

Shadows shouldn't randomly have a different color each time you start a game.
