### PR TITLE
Fixed naming conventions for CMatrix4::setRotationRadians() and setInverseRotationRadians()

### DIFF
--- a/irr/include/matrix4.h
+++ b/irr/include/matrix4.h
@@ -857,27 +857,27 @@ inline CMatrix4<T> &CMatrix4<T>::setInverseRotationDegrees(const vector3d<T> &ro
 template <class T>
 inline CMatrix4<T> &CMatrix4<T>::setRotationRadians(const vector3d<T> &rotation)
 {
-	const f64 cp = cos(rotation.X);
-	const f64 sp = sin(rotation.X);
-	const f64 cy = cos(rotation.Y);
-	const f64 sy = sin(rotation.Y);
-	const f64 cr = cos(rotation.Z);
-	const f64 sr = sin(rotation.Z);
+	const f64 cPitch = cos(rotation.X);
+	const f64 sPitch = sin(rotation.X);
+	const f64 cYaw = cos(rotation.Y);
+	const f64 sYaw = sin(rotation.Y);
+	const f64 cRoll = cos(rotation.Z);
+	const f64 sRoll = sin(rotation.Z);
 
-	M[0] = (T)(cy * cr);
-	M[1] = (T)(cy * sr);
-	M[2] = (T)(-sy);
+	M[0] = (T)(cYaw * cRoll);
+	M[1] = (T)(cYaw * sRoll);
+	M[2] = (T)(-sYaw);
 
-	const f64 spsy = sp * sy;
-	const f64 cpsy = cp * sy;
+	const f64 sPitch_sYaw = sPitch * sYaw;
+	const f64 cPitch_sYaw = cPitch * sYaw;
 
-	M[4] = (T)(spsy * cr - cp * sr);
-	M[5] = (T)(spsy * sr + cp * cr);
-	M[6] = (T)(sp * cy);
+	M[4] = (T)(sPitch_sYaw * cRoll - cPitch * sRoll);
+	M[5] = (T)(sPitch_sYaw * sRoll + cPitch * cRoll);
+	M[6] = (T)(sPitch * cYaw);
 
-	M[8] = (T)(cpsy * cr + sp * sr);
-	M[9] = (T)(cpsy * sr - sp * cr);
-	M[10] = (T)(cp * cy);
+	M[8] = (T)(cPitch_sYaw * cRoll + sPitch * sRoll);
+	M[9] = (T)(cPitch_sYaw * sRoll - sPitch * cRoll);
+	M[10] = (T)(cPitch * cYaw);
 #if defined(USE_MATRIX_TEST)
 	definitelyIdentityMatrix = false;
 #endif
@@ -961,27 +961,27 @@ inline core::vector3d<T> CMatrix4<T>::getRotationDegrees() const
 template <class T>
 inline CMatrix4<T> &CMatrix4<T>::setInverseRotationRadians(const vector3d<T> &rotation)
 {
-	f64 cp = cos(rotation.X);
-	f64 sp = sin(rotation.X);
-	f64 cy = cos(rotation.Y);
-	f64 sy = sin(rotation.Y);
-	f64 cr = cos(rotation.Z);
-	f64 sr = sin(rotation.Z);
+	f64 cPitch = cos(rotation.X);
+	f64 sPitch = sin(rotation.X);
+	f64 cYaw = cos(rotation.Y);
+	f64 sYaw = sin(rotation.Y);
+	f64 cRoll = cos(rotation.Z);
+	f64 sRoll = sin(rotation.Z);
 
-	M[0] = (T)(cy * cr);
-	M[4] = (T)(cy * sr);
-	M[8] = (T)(-sy);
+	M[0] = (T)(cYaw * cRoll);
+	M[4] = (T)(cYaw * sRoll);
+	M[8] = (T)(-sYaw);
 
-	f64 spsy = sp * sy;
-	f64 cpsy = cp * sy;
+	f64 sPitch_sYaw = sPitch * sYaw;
+	f64 cPitch_sYaw = cPitch * sYaw;
 
-	M[1] = (T)(spsy * cr - cp * sr);
-	M[5] = (T)(spsy * sr + cp * cr);
-	M[9] = (T)(sp * cy);
+	M[1] = (T)(sPitch_sYaw * cRoll - cPitch * sRoll);
+	M[5] = (T)(sPitch_sYaw * sRoll + cPitch * cRoll);
+	M[9] = (T)(sPitch * cYaw);
 
-	M[2] = (T)(cpsy * cr + sp * sr);
-	M[6] = (T)(cpsy * sr - sp * cr);
-	M[10] = (T)(cp * cy);
+	M[2] = (T)(cPitch_sYaw * cRoll + sPitch * sRoll);
+	M[6] = (T)(cPitch_sYaw * sRoll - sPitch * cRoll);
+	M[10] = (T)(cPitch * cYaw);
 #if defined(USE_MATRIX_TEST)
 	definitelyIdentityMatrix = false;
 #endif

--- a/irr/include/matrix4.h
+++ b/irr/include/matrix4.h
@@ -868,15 +868,15 @@ inline CMatrix4<T> &CMatrix4<T>::setRotationRadians(const vector3d<T> &rotation)
 	M[1] = (T)(cy * sr);
 	M[2] = (T)(-sy);
 
-	const f64 srsp = sp * sy;
-	const f64 crsp = cp * sy;
+	const f64 spsy = sp * sy;
+	const f64 cpsy = cp * sy;
 
-	M[4] = (T)(srsp * cr - cp * sr);
-	M[5] = (T)(srsp * sr + cp * cr);
+	M[4] = (T)(spsy * cr - cp * sr);
+	M[5] = (T)(spsy * sr + cp * cr);
 	M[6] = (T)(sp * cy);
 
-	M[8] = (T)(crsp * cr + sp * sr);
-	M[9] = (T)(crsp * sr - sp * cr);
+	M[8] = (T)(cpsy * cr + sp * sr);
+	M[9] = (T)(cpsy * sr - sp * cr);
 	M[10] = (T)(cp * cy);
 #if defined(USE_MATRIX_TEST)
 	definitelyIdentityMatrix = false;
@@ -972,15 +972,15 @@ inline CMatrix4<T> &CMatrix4<T>::setInverseRotationRadians(const vector3d<T> &ro
 	M[4] = (T)(cy * sr);
 	M[8] = (T)(-sy);
 
-	f64 srsp = sp * sy;
-	f64 crsp = cp * sy;
+	f64 spsy = sp * sy;
+	f64 cpsy = cp * sy;
 
-	M[1] = (T)(srsp * cr - cp * sr);
-	M[5] = (T)(srsp * sr + cp * cr);
+	M[1] = (T)(spsy * cr - cp * sr);
+	M[5] = (T)(spsy * sr + cp * cr);
 	M[9] = (T)(sp * cy);
 
-	M[2] = (T)(crsp * cr + sp * sr);
-	M[6] = (T)(crsp * sr - sp * cr);
+	M[2] = (T)(cpsy * cr + sp * sr);
+	M[6] = (T)(cpsy * sr - sp * cr);
 	M[10] = (T)(cp * cy);
 #if defined(USE_MATRIX_TEST)
 	definitelyIdentityMatrix = false;

--- a/irr/include/matrix4.h
+++ b/irr/include/matrix4.h
@@ -857,27 +857,27 @@ inline CMatrix4<T> &CMatrix4<T>::setInverseRotationDegrees(const vector3d<T> &ro
 template <class T>
 inline CMatrix4<T> &CMatrix4<T>::setRotationRadians(const vector3d<T> &rotation)
 {
-	const f64 cr = cos(rotation.X);
-	const f64 sr = sin(rotation.X);
-	const f64 cp = cos(rotation.Y);
-	const f64 sp = sin(rotation.Y);
-	const f64 cy = cos(rotation.Z);
-	const f64 sy = sin(rotation.Z);
+	const f64 cp = cos(rotation.X);
+	const f64 sp = sin(rotation.X);
+	const f64 cy = cos(rotation.Y);
+	const f64 sy = sin(rotation.Y);
+	const f64 cr = cos(rotation.Z);
+	const f64 sr = sin(rotation.Z);
 
-	M[0] = (T)(cp * cy);
-	M[1] = (T)(cp * sy);
-	M[2] = (T)(-sp);
+	M[0] = (T)(cy * cr);
+	M[1] = (T)(cy * sr);
+	M[2] = (T)(-sy);
 
-	const f64 srsp = sr * sp;
-	const f64 crsp = cr * sp;
+	const f64 srsp = sp * sy;
+	const f64 crsp = cp * sy;
 
-	M[4] = (T)(srsp * cy - cr * sy);
-	M[5] = (T)(srsp * sy + cr * cy);
-	M[6] = (T)(sr * cp);
+	M[4] = (T)(srsp * cr - cp * sr);
+	M[5] = (T)(srsp * sr + cp * cr);
+	M[6] = (T)(sp * cy);
 
-	M[8] = (T)(crsp * cy + sr * sy);
-	M[9] = (T)(crsp * sy - sr * cy);
-	M[10] = (T)(cr * cp);
+	M[8] = (T)(crsp * cr + sp * sr);
+	M[9] = (T)(crsp * sr - sp * cr);
+	M[10] = (T)(cp * cy);
 #if defined(USE_MATRIX_TEST)
 	definitelyIdentityMatrix = false;
 #endif
@@ -961,27 +961,27 @@ inline core::vector3d<T> CMatrix4<T>::getRotationDegrees() const
 template <class T>
 inline CMatrix4<T> &CMatrix4<T>::setInverseRotationRadians(const vector3d<T> &rotation)
 {
-	f64 cr = cos(rotation.X);
-	f64 sr = sin(rotation.X);
-	f64 cp = cos(rotation.Y);
-	f64 sp = sin(rotation.Y);
-	f64 cy = cos(rotation.Z);
-	f64 sy = sin(rotation.Z);
+	f64 cp = cos(rotation.X);
+	f64 sp = sin(rotation.X);
+	f64 cy = cos(rotation.Y);
+	f64 sy = sin(rotation.Y);
+	f64 cr = cos(rotation.Z);
+	f64 sr = sin(rotation.Z);
 
-	M[0] = (T)(cp * cy);
-	M[4] = (T)(cp * sy);
-	M[8] = (T)(-sp);
+	M[0] = (T)(cy * cr);
+	M[4] = (T)(cy * sr);
+	M[8] = (T)(-sy);
 
-	f64 srsp = sr * sp;
-	f64 crsp = cr * sp;
+	f64 srsp = sp * sy;
+	f64 crsp = cp * sy;
 
-	M[1] = (T)(srsp * cy - cr * sy);
-	M[5] = (T)(srsp * sy + cr * cy);
-	M[9] = (T)(sr * cp);
+	M[1] = (T)(srsp * cr - cp * sr);
+	M[5] = (T)(srsp * sr + cp * cr);
+	M[9] = (T)(sp * cy);
 
-	M[2] = (T)(crsp * cy + sr * sy);
-	M[6] = (T)(crsp * sy - sr * cy);
-	M[10] = (T)(cr * cp);
+	M[2] = (T)(crsp * cr + sp * sr);
+	M[6] = (T)(crsp * sr - sp * cr);
+	M[10] = (T)(cp * cy);
 #if defined(USE_MATRIX_TEST)
 	definitelyIdentityMatrix = false;
 #endif


### PR DESCRIPTION

- Goal: Address issue #15202. Old naming conventions used in [minetest/irr/include/matrix4.h](https://github.com/minetest/minetest/blob/700fbc803d7fb393863074beb9e6c86e6883f003/irr/include/matrix4.h#L858) were confusing and did not properly correspond to the right rotations (cosine pitch, sine pitch, cosine yaw, sine yaw, cosine roll, sine roll). The goal is to clarify the naming conventions used in functions CMatrix4:setRotationRadians() and CMatrix4:setRotationDegrees() so that they properly reflect the right rotation.

- What I did:
  - set variable names properly for both CMatrix4:setRotationRadians() and CMatrix4:setRotationDegrees(): 
    - cp = cos(rotation.X)
    - sp = sin(rotation.X)
    - cy = cos(rotation.Y)
    - sy = sin(rotation.Y)
    - cr = cos(rotation.Z)
    - sr = sin(rotation.Z) 

### To do
This PR is ready to be reviewed
### How to test
It builds

