### PR TITLE
Fix deletePathFromFilename returning cutoff filenames

### DIFF
--- a/irr/include/coreutil.h
+++ b/irr/include/coreutil.h
@@ -65,7 +65,6 @@ inline io::path &getFileNameExtension(io::path &dest, const io::path &source)
 //! delete path from filename
 inline io::path deletePathFromFilename(const io::path &filename)
 {
-    io::path res;
 	// delete path from filename
 	const fschar_t *s = filename.c_str();
 	const fschar_t *p = s + filename.size();
@@ -74,11 +73,10 @@ inline io::path deletePathFromFilename(const io::path &filename)
 	while (*p != '/' && *p != '\\' && p != s)
 		p--;
 
-	if (p != s) {
+	if (p != s)
 		++p;
-		res = p;
-	}
-	return res;
+
+	return p;
 }
 
 //! trim paths

--- a/irr/include/coreutil.h
+++ b/irr/include/coreutil.h
@@ -63,8 +63,9 @@ inline io::path &getFileNameExtension(io::path &dest, const io::path &source)
 }
 
 //! delete path from filename
-inline io::path &deletePathFromFilename(io::path &filename)
+inline io::path deletePathFromFilename(const io::path &filename)
 {
+    io::path res;
 	// delete path from filename
 	const fschar_t *s = filename.c_str();
 	const fschar_t *p = s + filename.size();
@@ -75,9 +76,9 @@ inline io::path &deletePathFromFilename(io::path &filename)
 
 	if (p != s) {
 		++p;
-		filename = p;
+		res = p;
 	}
-	return filename;
+	return res;
 }
 
 //! trim paths

--- a/irr/src/CFileList.cpp
+++ b/irr/src/CFileList.cpp
@@ -80,7 +80,7 @@ u32 CFileList::addItem(const io::path &fullPath, u32 offset, u32 size, bool isDi
 
 	entry.FullName = entry.Name;
 
-	core::deletePathFromFilename(entry.Name);
+	entry.Name = core::deletePathFromFilename(entry.Name);
 
 	if (IgnorePaths)
 		entry.FullName = entry.Name;

--- a/irr/src/CFileList.cpp
+++ b/irr/src/CFileList.cpp
@@ -140,7 +140,7 @@ s32 CFileList::findFile(const io::path &filename, bool isDirectory = false) cons
 		entry.FullName.make_lower();
 
 	if (IgnorePaths)
-		core::deletePathFromFilename(entry.FullName);
+		entry.FullName = core::deletePathFromFilename(entry.FullName);
 
 	return Files.binary_search(entry);
 }

--- a/irr/src/CZipReader.cpp
+++ b/irr/src/CZipReader.cpp
@@ -192,7 +192,7 @@ bool CZipReader::scanGZipHeader()
 		} else {
 			// no file name?
 			ZipFileName = Path;
-			core::deletePathFromFilename(ZipFileName);
+			ZipFileName = core::deletePathFromFilename(ZipFileName);
 
 			// rename tgz to tar or remove gz extension
 			if (core::hasFileExtension(ZipFileName, "tgz")) {

--- a/irr/src/CZipReader.cpp
+++ b/irr/src/CZipReader.cpp
@@ -191,8 +191,7 @@ bool CZipReader::scanGZipHeader()
 			}
 		} else {
 			// no file name?
-			ZipFileName = Path;
-			ZipFileName = core::deletePathFromFilename(ZipFileName);
+			ZipFileName = core::deletePathFromFilename(Path);
 
 			// rename tgz to tar or remove gz extension
 			if (core::hasFileExtension(ZipFileName, "tgz")) {


### PR DESCRIPTION
### BEFORE (ignore heh)
![Screenshot 2024-09-29 133840](https://github.com/user-attachments/assets/5a3f9677-20c7-454c-b146-817d26ca0bcb)

(Please ignore the heh's, it was a test from an old screenshot. The real filename printed is before the heh's)

### AFTER

![image](https://github.com/user-attachments/assets/5cdda793-9483-49a1-8eb2-76d126bc3981)

- Goal of the PR: Challenge for the reader.
- How does the PR work? **It creates a new path AKA string based on the old string.** See below for some errata on the use-after-free I think. There are several ways I could've fixed this issue, and one of them involved allocating a new temporary string, otherwise, I was okay just returning a new string, which this function honestly should do, unless anyone can object to it.
- Does it resolve any reported issue? Yes ithink
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)? idc
- If not a bug fix, why is this PR needed? What usecases does it solve? It solves.

### Use after free nonsense

If someone can prove that this is related to a use-after-free I'd appreciate it, it could be bad i think? Otherwise this code just looked very sketchy. It is doing a move/copy on a string that is using its old data. I tested this by printing the before and after string from the pointer (that's set to the path) and the path's c_str(). This could be an issue further down the line.

This seemed to be Windows only likely because of the use-after-free thingy, but I am probably wrong.

NOTE: More proof of undefined behavior, the filenames ONLY get messed up/cut off whenever i am in the third to last directory, then things start getting weird.

Considering most OS's have filename/character limits, I'm sure nothing bad can happen from this if it does happen to be a use after free

## How to test

I like to go to Settings > Advanced > Shader_path > Browse to pull up the file picker.