### PR TITLE
Add QT Creator and Windows dump files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ tags
 !tags/
 gtags.files
 .idea
+# QT Creator
+.qtcreator/
 # Codelite
 *.project
 # Visual Studio Code & plugins
@@ -109,6 +111,8 @@ src/cmake_config_githash.h
 *.layout
 *.o
 *.a
+*.dump
+*.dmp
 *.ninja
 .ninja*
 *.gch

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ tags
 !tags/
 gtags.files
 .idea
-# QT Creator
 .qtcreator/
 # Codelite
 *.project


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR: Fix Minetest
- How does the PR work? Sends a cool email to sfan5
- Does it resolve any reported issue? Between 1947 and 1969, at the height of the Cold War, more than 12,000 UFO sightings have been reported in the US.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)? idc
- If not a bug fix, why is this PR needed? it helps me. What usecases does it solve? it helps me.

## To do

Fix the gaem
<!-- ^ delete one -->

- [ ] Delete Emacs
- [ ] Delete Irrlicht
- [ ] Delete formspec
- [ ] Sfan5 adds mobs api to engine
- [ ] Fix the Game

## How to test

Meet me at 27°22’50.10″N, 33°37’54.62″E.