### PR TITLE
Refactor `matrix4.h`

### DIFF
--- a/irr/src/CB3DMeshFileLoader.cpp
+++ b/irr/src/CB3DMeshFileLoader.cpp
@@ -389,7 +389,7 @@ bool CB3DMeshFileLoader::readChunkVRTS(CSkinnedMesh::SJoint *inJoint)
 
 		// Transform the Vertex position by nested node...
 		inJoint->GlobalMatrix.transformVect(Vertex.Pos);
-		inJoint->GlobalMatrix.rotateVect(Vertex.Normal);
+		Vertex.Normal = inJoint->GlobalMatrix.rotateAndScaleVect(Vertex.Normal);
 
 		// Add it...
 		BaseVertices.push_back(Vertex);

--- a/irr/src/CGLTFMeshFileLoader.cpp
+++ b/irr/src/CGLTFMeshFileLoader.cpp
@@ -354,8 +354,7 @@ static void transformVertices(std::vector<video::S3DVertex> &vertices, const cor
 		// Apply scaling, rotation and rotation (in that order) to the position.
 		transform.transformVect(vertex.Pos);
 		// For the normal, we do not want to apply the translation.
-		// TODO note that this also applies scaling; the Irrlicht method is misnamed.
-		transform.rotateVect(vertex.Normal);
+		vertex.Normal = transform.rotateAndScaleVect(vertex.Normal);
 		// Renormalize (length might have been affected by scaling).
 		vertex.Normal.normalize();
 	}

--- a/irr/src/CSkinnedMesh.cpp
+++ b/irr/src/CSkinnedMesh.cpp
@@ -511,7 +511,7 @@ void CSkinnedMesh::skinJoint(SJoint *joint, SJoint *parentJoint)
 			jointVertexPull.transformVect(thisVertexMove, weight.StaticPos);
 
 			if (AnimateNormals)
-				jointVertexPull.rotateVect(thisNormalMove, weight.StaticNormal);
+				thisNormalMove = jointVertexPull.rotateAndScaleVect(weight.StaticNormal);
 
 			if (!(*(weight.Moved))) {
 				*(weight.Moved) = true;

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -405,10 +405,11 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 tool_reload_ratio)
 
 	// Compute absolute camera position and target
 	m_headnode->getAbsoluteTransformation().transformVect(m_camera_position, rel_cam_pos);
-	m_headnode->getAbsoluteTransformation().rotateVect(m_camera_direction, rel_cam_target - rel_cam_pos);
+	m_camera_direction = m_headnode->getAbsoluteTransformation()
+			.rotateAndScaleVect(rel_cam_target - rel_cam_pos);
 
-	v3f abs_cam_up;
-	m_headnode->getAbsoluteTransformation().rotateVect(abs_cam_up, rel_cam_up);
+	v3f abs_cam_up = m_headnode->getAbsoluteTransformation()
+			.rotateAndScaleVect(rel_cam_up);
 
 	// Separate camera position for calculation
 	v3f my_cp = m_camera_position;

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1015,8 +1015,7 @@ int ClientMap::getBackgroundBrightness(float max_d, u32 daylight_factor,
 		v3f z_dir = z_directions[i];
 		core::CMatrix4<f32> a;
 		a.buildRotateFromTo(v3f(0,1,0), z_dir);
-		v3f dir = m_camera_direction;
-		a.rotateVect(dir);
+		v3f dir = a.rotateAndScaleVect(m_camera_direction);
 		int br = 0;
 		float step = BS*1.5;
 		if(max_d > 35*BS)

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -536,9 +536,9 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 					return; // Avoid zero divides
 
 				// Angle according to camera view
-				v3f fore(0.f, 0.f, 1.f);
 				scene::ICameraSceneNode *cam = client->getSceneManager()->getActiveCamera();
-				cam->getAbsoluteTransformation().rotateVect(fore);
+				v3f fore = cam->getAbsoluteTransformation()
+						.rotateAndScaleVect(v3f(0.f, 0.f, 1.f));
 				int angle = - fore.getHorizontalAngle().Y;
 
 				// Limit angle and ajust with given offset

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -357,16 +357,18 @@ void ParticleSpawner::spawnParticle(ClientEnvironment *env, float radius,
 
 	if (attached_absolute_pos_rot_matrix) {
 		// Apply attachment rotation
-		attached_absolute_pos_rot_matrix->rotateVect(pp.vel);
-		attached_absolute_pos_rot_matrix->rotateVect(pp.acc);
+		pp.vel = attached_absolute_pos_rot_matrix->rotateAndScaleVect(pp.vel);
+		pp.acc = attached_absolute_pos_rot_matrix->rotateAndScaleVect(pp.acc);
 	}
 
 	if (attractor_obj)
 		attractor_origin += attractor_obj->getPosition() / BS;
 	if (attractor_direction_obj) {
 		auto *attractor_absolute_pos_rot_matrix = attractor_direction_obj->getAbsolutePosRotMatrix();
-		if (attractor_absolute_pos_rot_matrix)
-			attractor_absolute_pos_rot_matrix->rotateVect(attractor_direction);
+		if (attractor_absolute_pos_rot_matrix) {
+			attractor_direction = attractor_absolute_pos_rot_matrix
+					->rotateAndScaleVect(attractor_direction);
+		}
 	}
 
 	pp.expirationtime = r_exp.pickWithin();

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -137,8 +137,8 @@ void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool fo
 	// when camera offset changes, adjust the current frustum view matrix to avoid flicker
 	v3s16 cam_offset = cam->getOffset();
 	if (cam_offset != shadow_frustum.camera_offset) {
-		v3f rotated_offset;
-		shadow_frustum.ViewMat.rotateVect(rotated_offset, intToFloat(cam_offset - shadow_frustum.camera_offset, BS));
+		v3f rotated_offset = shadow_frustum.ViewMat.rotateAndScaleVect(
+				intToFloat(cam_offset - shadow_frustum.camera_offset, BS));
 		shadow_frustum.ViewMat.setTranslation(shadow_frustum.ViewMat.getTranslation() + rotated_offset);
 		shadow_frustum.player += intToFloat(shadow_frustum.camera_offset - cam->getOffset(), BS);
 		shadow_frustum.camera_offset = cam_offset;

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -838,14 +838,10 @@ void Sky::updateStars()
 		);
 		core::CMatrix4<f32> a;
 		a.buildRotateFromTo(v3f(0, 1, 0), r);
-		v3f p = v3f(-d, 1, -d);
-		v3f p1 = v3f(d, 1, -d);
-		v3f p2 = v3f(d, 1, d);
-		v3f p3 = v3f(-d, 1, d);
-		a.rotateVect(p);
-		a.rotateVect(p1);
-		a.rotateVect(p2);
-		a.rotateVect(p3);
+		v3f p = a.rotateAndScaleVect(v3f(-d, 1, -d));
+		v3f p1 = a.rotateAndScaleVect(v3f(d, 1, -d));
+		v3f p2 = a.rotateAndScaleVect(v3f(d, 1, d));
+		v3f p3 = a.rotateAndScaleVect(v3f(-d, 1, d));
 		vertices.push_back(video::S3DVertex(p, {}, {}, {}));
 		vertices.push_back(video::S3DVertex(p1, {}, {}, {}));
 		vertices.push_back(video::S3DVertex(p2, {}, {}, {}));

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -225,8 +225,7 @@ void GUIScene::setCameraRotation(v3f rot)
 	core::matrix4 mat;
 	mat.setRotationDegrees(rot);
 
-	m_cam_pos = v3f(0.f, 0.f, m_cam_distance);
-	mat.rotateVect(m_cam_pos);
+	m_cam_pos = mat.rotateAndScaleVect(v3f(0.f, 0.f, m_cam_distance));
 
 	m_cam_pos += m_target_pos;
 	m_cam->setPosition(m_cam_pos);


### PR DESCRIPTION
Fixes a comment which incorrectly claims row-major order. The order is actually column-major, which is crucial to know. This can be easily verified by looking at setTranslation: It assigns to the 4th column. The assignments are contiguous.

Renames rotateVect to rotateAndScaleVect:
If the matrix also scales, that is applied as well by the method. Obsolete rotateVect variants are removed.
The inverseRotateVect method is also renamed accordingly. Note that this applies the transpose of the product of the scale and rotation matrices, which inverts just the rotation.

This is a split-off from #14685.