### PR TITLE
Fix hypertext action firing twice on touchscreen

### DIFF
--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -1146,7 +1146,7 @@ bool GUIHyperText::OnEvent(const SEvent &event)
 							}
 						}
 
-						break;
+						return true;
 					}
 				}
 			}


### PR DESCRIPTION
fixes #15025, a bug I discovered while testing #14510

Q: why is the event sent a second time when we don't return true?
A: grep for `simulateMouseEvent`. this makes perfect sense since returning false means the event was not handled.

## To do

This PR is a Ready for Review.

## How to test

Use Devtest's `/test_formspec` on Android, verify that clicking on a hypertext action only triggers it once (only logs one chat message)