### PR TITLE
Setting structure improvements

### DIFF
--- a/builtin/mainmenu/settings/components.lua
+++ b/builtin/mainmenu/settings/components.lua
@@ -67,6 +67,19 @@ function make.heading(text)
 end
 
 
+function make.note(text)
+	return {
+		full_width = true,
+		get_formspec = function(self, avail_w)
+			-- Assuming label height 0.4:
+			-- Position at y=0 to eat 0.2 of the padding above, leave 0.05.
+			-- The returned used_height doesn't include padding.
+			return ("label[0,0;%s]"):format(core.colorize("#bbb", core.formspec_escape(text))), 0.2
+		end,
+	}
+end
+
+
 --- Used for string and numeric style fields
 ---
 --- @param converter Function to coerce values from strings.

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -152,7 +152,7 @@ local function load()
 
 	table.insert(page_by_id.controls_keyboard_and_mouse.content, 1, change_keys)
 	do
-		local content = page_by_id.graphics_and_audio_shaders.content
+		local content = page_by_id.graphics_and_audio_effects.content
 		local idx = table.indexof(content, "enable_dynamic_shadows")
 		table.insert(content, idx, shadows_component)
 	end

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -155,6 +155,16 @@ local function load()
 		local content = page_by_id.graphics_and_audio_effects.content
 		local idx = table.indexof(content, "enable_dynamic_shadows")
 		table.insert(content, idx, shadows_component)
+
+		idx = table.indexof(content, "enable_auto_exposure") + 1
+		local note = component_funcs.note(fgettext_ne("(The game will need to enable automatic exposure as well)"))
+		note.requires = get_setting_info("enable_auto_exposure").requires
+		table.insert(content, idx, note)
+
+		idx = table.indexof(content, "enable_volumetric_lighting") + 1
+		note = component_funcs.note(fgettext_ne("(The game will need to enable volumetric lighting as well)"))
+		note.requires = get_setting_info("enable_volumetric_lighting").requires
+		table.insert(content, idx, note)
 	end
 
 	-- These must not be translated, as they need to show in the local

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -448,7 +448,7 @@ translucent_liquids (Translucent liquids) bool true
 
 #    Leaves style:
 #    -   Fancy:  all faces visible
-#    -   Simple: only outer faces, if defined special_tiles are used
+#    -   Simple: only outer faces
 #    -   Opaque: disable transparency
 leaves_style (Leaves style) enum fancy fancy,simple,opaque
 
@@ -456,7 +456,6 @@ leaves_style (Leaves style) enum fancy fancy,simple,opaque
 connected_glass (Connect glass) bool false
 
 #    Enable smooth lighting with simple ambient occlusion.
-#    Disable for speed or for different looks.
 smooth_lighting (Smooth lighting) bool true
 
 #    Enables tradeoffs that reduce CPU load or increase rendering performance

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -262,31 +262,6 @@ viewing_range (Viewing range) int 190 20 4000
 #    Higher values result in a less detailed image.
 undersampling (Undersampling) int 1 1 8
 
-[**Graphical Effects]
-
-#    Allows liquids to be translucent.
-translucent_liquids (Translucent liquids) bool true
-
-#    Leaves style:
-#    -   Fancy:  all faces visible
-#    -   Simple: only outer faces, if defined special_tiles are used
-#    -   Opaque: disable transparency
-leaves_style (Leaves style) enum fancy fancy,simple,opaque
-
-#    Connects glass if supported by node.
-connected_glass (Connect glass) bool false
-
-#    Enable smooth lighting with simple ambient occlusion.
-#    Disable for speed or for different looks.
-smooth_lighting (Smooth lighting) bool true
-
-#    Enables tradeoffs that reduce CPU load or increase rendering performance
-#    at the expense of minor visual glitches that do not impact game playability.
-performance_tradeoffs (Tradeoffs for performance) bool false
-
-#    Adds particles when digging a node.
-enable_particles (Digging particles) bool true
-
 [**3D]
 
 #    3D support.
@@ -466,7 +441,30 @@ enable_raytraced_culling (Enable Raytraced Culling) bool true
 
 
 
-[*Shaders]
+[*Effects]
+
+#    Allows liquids to be translucent.
+translucent_liquids (Translucent liquids) bool true
+
+#    Leaves style:
+#    -   Fancy:  all faces visible
+#    -   Simple: only outer faces, if defined special_tiles are used
+#    -   Opaque: disable transparency
+leaves_style (Leaves style) enum fancy fancy,simple,opaque
+
+#    Connects glass if supported by node.
+connected_glass (Connect glass) bool false
+
+#    Enable smooth lighting with simple ambient occlusion.
+#    Disable for speed or for different looks.
+smooth_lighting (Smooth lighting) bool true
+
+#    Enables tradeoffs that reduce CPU load or increase rendering performance
+#    at the expense of minor visual glitches that do not impact game playability.
+performance_tradeoffs (Tradeoffs for performance) bool false
+
+#    Adds particles when digging a node.
+enable_particles (Digging particles) bool true
 
 [**Waving Nodes]
 
@@ -503,11 +501,6 @@ water_wave_length (Waving liquids wavelength) float 20.0 0.1
 #
 #    Requires: shaders, enable_waving_water
 water_wave_speed (Waving liquids wave speed) float 5.0
-
-#   When enabled, liquid reflections are simulated.
-#
-#   Requires: shaders, enable_waving_water, enable_dynamic_shadows
-enable_water_reflections (Liquid reflections) bool false
 
 [**Dynamic shadows]
 
@@ -632,14 +625,6 @@ debanding (Enable Debanding) bool true
 #    Requires: shaders, enable_post_processing
 enable_bloom (Enable Bloom) bool false
 
-#    Set to true to render debugging breakdown of the bloom effect.
-#    In debug mode, the screen is split into 4 quadrants:
-#    top-left - processed base image, top-right - final image
-#    bottom-left - raw base image, bottom-right - bloom texture.
-#
-#    Requires: shaders, enable_post_processing, enable_bloom
-enable_bloom_debug (Enable Bloom Debug) bool false
-
 #    Defines how much bloom is applied to the rendered image
 #    Smaller values make bloom more subtle
 #    Range: from 0.01 to 1.0, default: 0.05
@@ -676,6 +661,11 @@ enable_translucent_foliage (Translucent foliage) bool false
 #
 #   Requires: shaders, enable_dynamic_shadows
 enable_node_specular (Node specular) bool false
+
+#   When enabled, liquid reflections are simulated.
+#
+#   Requires: shaders, enable_waving_water, enable_dynamic_shadows
+enable_water_reflections (Liquid reflections) bool false
 
 [*Audio]
 
@@ -1939,6 +1929,14 @@ client_mesh_chunk (Client Mesh Chunksize) int 1 1 16
 
 #    Enables debug and error-checking in the OpenGL driver.
 opengl_debug (OpenGL debug) bool false
+
+#    Set to true to render debugging breakdown of the bloom effect.
+#    In debug mode, the screen is split into 4 quadrants:
+#    top-left - processed base image, top-right - final image
+#    bottom-left - raw base image, bottom-right - bloom texture.
+#
+#    Requires: shaders, enable_post_processing, enable_bloom
+enable_bloom_debug (Enable Bloom Debug) bool false
 
 [**Sound]
 #    Comma-separated list of AL and ALC extensions that should not be used.


### PR DESCRIPTION
- Section "Shaders" renamed to "Effects" and some effects from "Graphics" moved there
    
    Currently, there's two setting sections for visual effects: Some are in the "Graphics" section (those that don't require shaders) and most are in the "Shaders" section (those that require shaders).

     In the discussion in and around #15210, it was obvious that many people think of shaders as only necessary for visual effects, while they're actually a fundamental part of the rendering pipeline. Having a "Shaders" section that's actually a "Visual Effects" section somewhat supports this misconception.
   
    I think now is a good time to put all visual effects, shaders required or not, into one "Visual Effects" sections. I shortened the title to "Effects" since I couldn't decide between "Visual Effects" and "Graphical Effects", shorter titles are better anyway (consider translations and Android) and context should make it obvious enough that this is about graphics.

- `enable_bloom_debug` moved to advanced settings.
    
     I've seen users getting confused after enabling it by accident.

- `enable_water_reflections` moved below `enable_waving_water` and `enable_dynamic_shadows`.
    
    It depends on these two settings, so it will only be shown after the user has already enabled these two. This change allows you to simply scroll through the "Effects" section and enable all effects, without having to backtrack. Before this change, it was easy to miss that `enable_water_reflections` even exists.

- Add "requires game support" hints to `enable_auto_exposure` and `enable_volumetric_lighting`, just like the one for `enable_dynamic_shadows`.

## To do

This PR is a Ready for Review.

## How to test

Look at the settings.