### PR TITLE
Simplify minetest.strip_param2_color code

### DIFF
--- a/builtin/common/item_s.lua
+++ b/builtin/common/item_s.lua
@@ -166,20 +166,19 @@ function core.is_colored_paramtype(ptype)
 end
 
 function core.strip_param2_color(param2, paramtype2)
-	if not core.is_colored_paramtype(paramtype2) then
+	if paramtype2 == "color" then
+		return param2
+	elseif paramtype2 == "colorfacedir" then
+		return math.floor(param2 / 32) * 32
+	elseif paramtype2 == "color4dir" then
+		return math.floor(param2 / 4) * 4
+	elseif paramtype2 == "colorwallmounted" then
+		return math.floor(param2 / 8) * 8
+	elseif paramtype2 == "colordegrotate" then
+		return math.floor(param2 / 32) * 32
+	else
 		return nil
 	end
-	if paramtype2 == "colorfacedir" then
-		param2 = math.floor(param2 / 32) * 32
-	elseif paramtype2 == "color4dir" then
-		param2 = math.floor(param2 / 4) * 4
-	elseif paramtype2 == "colorwallmounted" then
-		param2 = math.floor(param2 / 8) * 8
-	elseif paramtype2 == "colordegrotate" then
-		param2 = math.floor(param2 / 32) * 32
-	end
-	-- paramtype2 == "color" requires no modification.
-	return param2
 end
 
 -- Content ID caching


### PR DESCRIPTION
No need to validate the paramtype2 twice.

Note: the name is IMHO misleading - it does not strip the color information, but it strips everything _but_ the color information?

No issue, this is just a trivial improvement seen when I was trying to figure out what "first bits" is mean (most significant or least significant)