### PR TITLE
Fix incorrect SMaterial::operator!= (regression from #15165)

### DIFF
--- a/irr/include/SMaterial.h
+++ b/irr/include/SMaterial.h
@@ -410,6 +410,7 @@ public:
 	{
 		bool different =
 				MaterialType != b.MaterialType ||
+				ColorParam != b.ColorParam ||
 				MaterialTypeParam != b.MaterialTypeParam ||
 				Thickness != b.Thickness ||
 				Wireframe != b.Wireframe ||


### PR DESCRIPTION
I hope that this will fox #15212

I can't reproduce that issue reliably, so testing would be appreciated

## To do

This PR is a Ready for Review.

## How to test

Check whether #15212 is fixed
