### PR TITLE
Remove the hud_hotbar_max_width setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -758,6 +758,10 @@ show_debug (Show debug info) bool false
 #    Radius to use when the block bounds HUD feature is set to near blocks.
 show_block_bounds_radius_near (Block bounds HUD radius) int 4 0 1000
 
+#    Maximum proportion of current window to be used for hotbar.
+#    Deprecated, use the setting hud_scaling instead.
+hud_hotbar_max_width (Maximum hotbar width) float 1.0 0.001 1.0
+
 [**Chat]
 
 #    Maximum number of recent chat messages to show
@@ -771,10 +775,6 @@ console_color (Console color) string (0,0,0)
 
 #    In-game chat console background alpha (opaqueness, between 0 and 255).
 console_alpha (Console alpha) int 200 0 255
-
-#    Maximum proportion of current window to be used for hotbar.
-#    Useful if there's something to be displayed right or left of hotbar.
-hud_hotbar_max_width (Maximum hotbar width) float 1.0 0.001 1.0
 
 #    Clickable weblinks (middle-click or Ctrl+left-click) enabled in chat console output.
 clickable_chat_weblinks (Chat weblinks) bool true

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -665,6 +665,11 @@
 #    type: bool
 # show_nametag_backgrounds = true
 
+#    Maximum proportion of current window to be used for hotbar.
+#    Deprecated, use the setting hud_scaling instead.
+#    type: float min: 0.001 max: 1
+# hud_hotbar_max_width = 1.0
+
 ### Chat
 
 #    Maximum number of recent chat messages to show
@@ -682,11 +687,6 @@
 #    In-game chat console background alpha (opaqueness, between 0 and 255).
 #    type: int min: 0 max: 255
 # console_alpha = 200
-
-#    Maximum proportion of current window to be used for hotbar.
-#    Useful if there's something to be displayed right or left of hotbar.
-#    type: float min: 0.001 max: 1
-# hud_hotbar_max_width = 1.0
 
 #    Clickable weblinks (middle-click or Ctrl+left-click) enabled in chat console output.
 #    type: bool

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -802,42 +802,20 @@ void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir,
 		}
 	}
 }
+
 void Hud::drawHotbar(const v2s32 &pos, const v2f &offset, u16 dir, const v2f &align)
 {
 	if (g_touchcontrols)
 		g_touchcontrols->resetHotbarRects();
 
 	InventoryList *mainlist = inventory->getList("main");
-	if (mainlist == NULL) {
+	if (mainlist == nullptr) {
 		// Silently ignore this. We may not be initialized completely.
 		return;
 	}
 
-	u16 playeritem = player->getWieldIndex();
-	v2s32 screen_offset(offset.X, offset.Y);
-
-	v2s32 centerlowerpos(m_displaycenter.X, m_screensize.Y);
-
-	s32 hotbar_itemcount = player->getMaxHotbarItemcount();
-	s32 width = hotbar_itemcount * (m_hotbar_imagesize + m_padding * 2);
-
-	const v2u32 &window_size = RenderingEngine::getWindowSize();
-	if ((float) width / (float) window_size.X <=
-			g_settings->getFloat("hud_hotbar_max_width")) {
-		drawItems(pos, screen_offset, hotbar_itemcount, align, 0,
-			mainlist, playeritem + 1, dir, true);
-	} else {
-		v2s32 firstpos = pos;
-		firstpos.X += width/4;
-
-		v2s32 secondpos = firstpos;
-		firstpos = firstpos - v2s32(0, m_hotbar_imagesize + m_padding);
-
-		drawItems(firstpos, screen_offset, hotbar_itemcount / 2, align, 0,
-			mainlist, playeritem + 1, dir, true);
-		drawItems(secondpos, screen_offset, hotbar_itemcount, align,
-			hotbar_itemcount / 2, mainlist, playeritem + 1, dir, true);
-	}
+	drawItems(pos, v2s32(offset.X, offset.Y), player->getMaxHotbarItemcount(), align, 0,
+		mainlist, player->getWieldIndex() + 1, dir, true);
 }
 
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -296,7 +296,6 @@ void set_default_settings()
 	settings->setDefault("gui_scaling_filter_txr2img", "true");
 	settings->setDefault("smooth_scrolling", "true");
 	settings->setDefault("desynchronize_mapblock_texture_animation", "false");
-	settings->setDefault("hud_hotbar_max_width", "1.0");
 	settings->setDefault("enable_local_map_saving", "false");
 	settings->setDefault("show_entity_selectionbox", "false");
 	settings->setDefault("ambient_occlusion_gamma", "1.8");


### PR DESCRIPTION
## Goal of the PR

Remove (deprecate) the `hud_hotbar_max_width` setting and refer to `hud_scaling` instead.

## Reasons
When the `hud_hotbar_max_width` setting takes effect, the hotbar is split into exactly two lines, but this only causes problems.
- It overlaps with other elements. (the healthbar)
- It doesn't work properly with the hotbar background image. (test it in MTG)
- The alignment is not right anymore since #14321.
- There is currently no good way to automatically adjust the positions of other elements, when the hotbar splits.

So IMO it would be best to just remove it. We already have the `hud_scaling` setting, and I doubt that anyone actually uses `hud_hotbar_max_width`.

## To do

This PR is Ready for Review.

## How to test

Make your window width very small and see that the hotbar stays in one line.

(Note that there is an old bug, when a HUD item image does not fit into the screen anymore, it gets rendered over the whole screen, but this is something to fix for another PR.)
