### PR TITLE
Fix macos runner issue

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,8 +29,8 @@ on:
 
 jobs:
   build:
-    # use lowest possible macOS running on x86_64 to support more users
-    runs-on: macos-12
+    # use lowest possible macOS running on x86_64 supported by brew to support more users
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - name: Install deps


### PR DESCRIPTION
Apple released a new MacOS version and Brew drops support for macOS 12.
So, we are forced to move up.


Ready for Review.