### PR TITLE
[nosq] Android insets API for the ContentDB dialog

### DIFF
--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -40,6 +40,10 @@ import android.content.res.Configuration;
 import androidx.annotation.Keep;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.FileProvider;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import java.io.File;
 import java.util.Locale;
@@ -49,7 +53,7 @@ import java.util.Objects;
 // This annotation prevents the minifier/Proguard from mangling them.
 @Keep
 @SuppressWarnings("unused")
-public class GameActivity extends SDLActivity {
+public class GameActivity extends SDLActivity implements OnApplyWindowInsetsListener {
 	@Override
 	protected String getMainSharedObject() {
 		return getContext().getApplicationInfo().nativeLibraryDir + "/libminetest.so";
@@ -79,6 +83,12 @@ public class GameActivity extends SDLActivity {
 	private DialogState inputDialogState = DialogState.DIALOG_CANCELED;
 	private String messageReturnValue = "";
 	private int selectionReturnValue = 0;
+
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+		ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), this);
+	}
 
 	private native void saveSettings();
 
@@ -199,6 +209,18 @@ public class GameActivity extends SDLActivity {
 
 	public int getDisplayWidth() {
 		return getResources().getDisplayMetrics().widthPixels;
+	}
+
+	private Insets lastInsets = null;
+	private native void updateInsets(int bottom, int left, int right, int top);
+
+	public WindowInsetsCompat onApplyWindowInsets(View view, WindowInsetsCompat windowInsets) {
+		Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout());
+		if (!insets.equals(lastInsets)) {
+			updateInsets(insets.bottom, insets.left, insets.right, insets.top);
+			lastInsets = insets;
+		}
+		return ViewCompat.onApplyWindowInsets(view, windowInsets);
 	}
 
 	public void openURI(String uri) {

--- a/builtin/mainmenu/content/contentdb.lua
+++ b/builtin/mainmenu/content/contentdb.lua
@@ -643,10 +643,23 @@ function contentdb.get_full_package_info(package, callback)
 end
 
 
-function contentdb.get_formspec_padding()
-	-- Padding is increased on Android to account for notches
-	-- TODO: use Android API to determine size of cut outs
-	return { x = PLATFORM == "Android" and 1 or 0.5, y = PLATFORM == "Android" and 0.25 or 0.5 }
+function contentdb.get_formspec_insets()
+	local window = core.get_window_info()
+	local formspec_size = contentdb.get_formspec_size()
+
+	local min_padding = { x = 0.5, y = core.settings:get_bool("touch_gui") and 0.25 or 0.5 }
+	local insets = {
+		left   = window.insets.left   / window.size.x * formspec_size.x,
+		right  = window.insets.right  / window.size.x * formspec_size.x,
+		top    = window.insets.top    / window.size.y * formspec_size.y,
+		bottom = window.insets.bottom / window.size.y * formspec_size.y,
+	}
+	return {
+		left   = math.max(min_padding.x, insets.left),
+		right  = math.max(min_padding.x, insets.right),
+		top    = math.max(min_padding.y, insets.top),
+		bottom = math.max(min_padding.y, insets.bottom),
+	}
 end
 
 
@@ -656,7 +669,7 @@ function contentdb.get_formspec_size()
 
 	-- Minimum formspec size
 	local min_x = 15.5
-	local min_y = 10
+	local min_y = 9
 	if size.x < min_x or size.y < min_y then
 		local scale = math.max(min_x / size.x, min_y / size.y)
 		size.x = size.x * scale

--- a/builtin/mainmenu/content/dlg_contentdb.lua
+++ b/builtin/mainmenu/content/dlg_contentdb.lua
@@ -496,6 +496,11 @@ local function handle_events(event)
 		return true
 	end
 
+	if event == "WindowInfoChange" then
+		ui.update()
+		return true
+	end
+
 	return false
 end
 

--- a/builtin/mainmenu/content/dlg_contentdb.lua
+++ b/builtin/mainmenu/content/dlg_contentdb.lua
@@ -128,15 +128,15 @@ local function load()
 end
 
 
-local function get_info_formspec(size, padding, text)
+local function get_info_formspec(size, insets, text)
 	return table.concat({
 		"formspec_version[6]",
 		"size[", size.x, ",", size.y, "]",
 		"padding[0,0]",
 		"bgcolor[;true]",
 
-		"label[", padding.x + 3.625, ",4.35;", text, "]",
-		"container[", padding.x, ",", size.y - 0.8 - padding.y, "]",
+		"label[", insets.left + 3.625, ",4.35;", text, "]",
+		"container[", insets.left, ",", size.y - 0.8 - insets.bottom, "]",
 		"button[0,0;2,0.8;back;", fgettext("Back"), "]",
 		"container_end[]",
 	})
@@ -168,11 +168,11 @@ end
 
 local function calculate_num_per_page()
 	local size = contentdb.get_formspec_size()
-	local padding = contentdb.get_formspec_padding()
+	local insets = contentdb.get_formspec_insets()
 	local window = core.get_window_info()
 
-	size.x = size.x - padding.x * 2
-	size.y = size.y - padding.y * 2 - 1.425 - 0.25 - 0.8
+	size.x = size.x - insets.left - insets.right
+	size.y = size.y - insets.top - insets.bottom - 1.425 - 0.25 - 0.8
 
 	local coordToPx = window.size.x / window.max_formspec_size.x / window.real_gui_scaling
 
@@ -190,14 +190,14 @@ end
 
 
 local function get_formspec(dlgdata)
-	local window_padding = contentdb.get_formspec_padding()
+	local insets = contentdb.get_formspec_insets()
 	local size = contentdb.get_formspec_size()
 
 	if contentdb.loading then
-		return get_info_formspec(size, window_padding, fgettext("Loading..."))
+		return get_info_formspec(size, insets, fgettext("Loading..."))
 	end
 	if contentdb.load_error then
-		return get_info_formspec(size, window_padding, fgettext("No packages could be retrieved"))
+		return get_info_formspec(size, insets, fgettext("No packages could be retrieved"))
 	end
 	assert(contentdb.load_ok)
 
@@ -209,8 +209,8 @@ local function get_formspec(dlgdata)
 		cur_page = 1
 	end
 
-	local W = size.x - window_padding.x * 2
-	local H = size.y - window_padding.y * 2
+	local W = size.x - insets.left - insets.right
+	local H = size.y - insets.top - insets.bottom
 
 	local category_x = 0
 	local number_category_buttons = 4
@@ -234,7 +234,7 @@ local function get_formspec(dlgdata)
 		"padding[0,0]",
 		"bgcolor[;true]",
 
-		"container[", window_padding.x, ",", window_padding.y, "]",
+		"container[", insets.left, ",", insets.top, "]",
 
 		-- Top-left: categories
 		make_category_button("type_all", fgettext("All"), selected_type == nil),

--- a/builtin/mainmenu/content/dlg_package.lua
+++ b/builtin/mainmenu/content/dlg_package.lua
@@ -305,12 +305,23 @@ local function handle_submit(this, fields)
 end
 
 
+local function handle_events(event)
+	if event == "WindowInfoChange" then
+		ui.update()
+		return true
+	end
+
+	return false
+end
+
+
 function create_package_dialog(package)
 	assert(package)
 
 	local dlg = dialog_create("package_dialog_" .. package.id,
 			get_formspec,
-			handle_submit)
+			handle_submit,
+			handle_events)
 	local data = dlg.data
 
 	data.package = package

--- a/builtin/mainmenu/content/dlg_package.lua
+++ b/builtin/mainmenu/content/dlg_package.lua
@@ -16,7 +16,7 @@
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
-local function get_info_formspec(size, padding, text)
+local function get_info_formspec(size, insets, text)
 	return table.concat({
 		"formspec_version[6]",
 		"size[", size.x, ",", size.y, "]",
@@ -24,7 +24,7 @@ local function get_info_formspec(size, padding, text)
 		"bgcolor[;true]",
 
 		"label[4,4.35;", text, "]",
-		"container[", padding.x, ",", size.y - 0.8 - padding.y, "]",
+		"container[", insets.left, ",", size.y - 0.8 - insets.bottom, "]",
 		"button[0,0;2,0.8;back;", fgettext("Back"), "]",
 		"container_end[]",
 	})
@@ -32,11 +32,11 @@ end
 
 
 local function get_formspec(data)
-	local window_padding =  contentdb.get_formspec_padding()
+	local insets =  contentdb.get_formspec_insets()
 	local size = contentdb.get_formspec_size()
 	size.x = math.min(size.x, 20)
-	local W = size.x - window_padding.x * 2
-	local H = size.y - window_padding.y * 2
+	local W = size.x - insets.left - insets.right
+	local H = size.y - insets.top - insets.bottom
 
 	if not data.info then
 		if not data.loading and not data.loading_error then
@@ -65,9 +65,9 @@ local function get_formspec(data)
 		-- check to see if that happened
 		if not data.info then
 			if data.loading_error then
-				return get_info_formspec(size, window_padding, fgettext("No packages could be retrieved"))
+				return get_info_formspec(size, insets, fgettext("No packages could be retrieved"))
 			end
-			return get_info_formspec(size, window_padding, fgettext("Loading..."))
+			return get_info_formspec(size, insets, fgettext("Loading..."))
 		end
 	end
 
@@ -89,7 +89,7 @@ local function get_formspec(data)
 		"padding[0,0]",
 		"bgcolor[;true]",
 
-		"container[", window_padding.x, ",", window_padding.y, "]",
+		"container[", insets.left, ",", insets.top, "]",
 
 		"button[0,", bottom_buttons_y, ";2,0.8;back;", fgettext("Back"), "]",
 		"button[", W - 3, ",", bottom_buttons_y, ";3,0.8;open_contentdb;", fgettext("ContentDB page"), "]",

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2764,7 +2764,7 @@ Elements
 ### `size[<W>,<H>,<fixed_size>]`
 
 * Define the size of the menu in inventory slots
-* `fixed_size`: `true`/`false` (optional)
+* `fixed_size`: `true`/`false` (optional, defaults to `false`)
 * deprecated: `invsize[<W>,<H>;]`
 
 ### `position[<X>,<Y>]`
@@ -5587,6 +5587,7 @@ Utilities
   --
   -- Note that none of these things are constant, they are likely to change during a client
   -- connection as the player resizes the window and moves it between monitors
+  -- or rotates the phone screen.
   --
   -- real_gui_scaling and real_hud_scaling can be used instead of DPI.
   -- OSes don't necessarily give the physical DPI, as they may allow user configuration.
@@ -5601,9 +5602,28 @@ Utilities
           y = 577,
       },
 
+      -- Window insets that can be used to avoid display cutouts on mobile (pixels).
+      --
+      -- When creating a fullscreen formspec using `max_formspec_size` (see below),
+      -- you shouldn't place any content in the area occupied by these insets.
+      -- In this case, you can convert each inset value into formspec coordinates
+      -- using `insets.<side> / size.<axis> * max_formspec_size.<axis>`.
+      insets = {
+          bottom = 0,
+          left = 110,
+          right = 0,
+          top = 0,
+      },
+
       -- Estimated maximum formspec size before Minetest will start shrinking the
-      -- formspec to fit. For a fullscreen formspec, use this formspec size and
-      -- `padding[0,0]`. `bgcolor[;true]` is also recommended.
+      -- formspec to fit. Only correct for formspecs that do not have `fixed_size`
+      -- enabled in their `size[]` element.
+      --
+      -- For a fullscreen formspec, use this formspec size and `padding[0,0]`.
+      -- `bgcolor[;true]` is also recommended.
+      --
+      -- Remember to take window insets (see above) into account for the layout
+      -- of your fullscreen formspec.
       max_formspec_size = {
           x = 20,
           y = 11.25

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1457,6 +1457,7 @@ void Client::sendUpdateClientInfo(const ClientDynamicInfo& info)
 	pkt << info.real_hud_scaling;
 	pkt << (f32)info.max_fs_size.X << (f32)info.max_fs_size.Y;
 	pkt << info.touch_controls;
+	pkt << info.insets.UpperLeftCorner << info.insets.LowerRightCorner;
 
 	Send(&pkt);
 }

--- a/src/clientdynamicinfo.cpp
+++ b/src/clientdynamicinfo.cpp
@@ -26,6 +26,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gui/guiFormSpecMenu.h"
 #include "gui/touchcontrols.h"
 
+#ifdef __ANDROID__
+#include "porting.h"
+#endif
+
 ClientDynamicInfo ClientDynamicInfo::getCurrent()
 {
     v2u32 screen_size = RenderingEngine::getWindowSize();
@@ -36,8 +40,15 @@ ClientDynamicInfo ClientDynamicInfo::getCurrent()
     f32 real_hud_scaling = hud_scaling * density;
     bool touch_controls = g_touchcontrols;
 
+#ifdef __ANDROID__
+    core::rect<s32> insets = porting::getDisplayInsets();
+#else
+    core::rect<s32> insets;
+#endif
+
     return {
-        screen_size, real_gui_scaling, real_hud_scaling,
+        screen_size, insets,
+        real_gui_scaling, real_hud_scaling,
         ClientDynamicInfo::calculateMaxFSSize(screen_size, density, gui_scaling),
         touch_controls
     };

--- a/src/clientdynamicinfo.h
+++ b/src/clientdynamicinfo.h
@@ -20,12 +20,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "irrlichttypes_bloated.h"
+#include "rect.h"
 
 
 struct ClientDynamicInfo
 {
 public:
 	v2u32 render_target_size;
+	core::rect<s32> insets;
 	f32 real_gui_scaling;
 	f32 real_hud_scaling;
 	v2f32 max_fs_size;
@@ -33,6 +35,7 @@ public:
 
 	bool equal(const ClientDynamicInfo &other) const {
 		return render_target_size == other.render_target_size &&
+				insets == other.insets &&
 				std::abs(real_gui_scaling - other.real_gui_scaling) < 0.001f &&
 				std::abs(real_hud_scaling - other.real_hud_scaling) < 0.001f &&
 				touch_controls == other.touch_controls;

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/renderingengine.h"
 #include "client/shader.h"
 #include "client/tile.h"
+#include "clientdynamicinfo.h"
 #include "config.h"
 #include "content/content.h"
 #include "content/mods.h"
@@ -316,6 +317,7 @@ void GUIEngine::run()
 		);
 	const bool initial_window_maximized = !g_settings->getBool("fullscreen") &&
 			g_settings->getBool("window_maximized");
+	auto last_window_info = ClientDynamicInfo::getCurrent();
 
 	FpsControl fps_control;
 	f32 dtime = 0.0f;
@@ -334,6 +336,11 @@ void GUIEngine::run()
 			if (text_height != g_fontengine->getTextHeight()) {
 				updateTopLeftTextSize();
 				text_height = g_fontengine->getTextHeight();
+			}
+			auto window_info = ClientDynamicInfo::getCurrent();
+			if (!window_info.equal(last_window_info)) {
+				m_script->handleMainMenuEvent("WindowInfoChange");
+				last_window_info = window_info;
 			}
 
 			driver->beginScene(true, true, RenderingEngine::MENU_SKY_COLOR);

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1859,12 +1859,14 @@ void Server::handleCommand_UpdateClientInfo(NetworkPacket *pkt)
 	*pkt >> info.real_hud_scaling;
 	*pkt >> info.max_fs_size.X;
 	*pkt >> info.max_fs_size.Y;
+
+	info.touch_controls = false;
+	info.insets = core::rect<s32>();
 	try {
 		// added in 5.9.0
 		*pkt >> info.touch_controls;
-	} catch (PacketError &e) {
-		info.touch_controls = false;
-	}
+		*pkt >> info.insets.UpperLeftCorner >> info.insets.LowerRightCorner;
+	} catch (PacketError &e) {}
 
 	session_t peer_id = pkt->getPeerId();
 	RemoteClient *client = getClient(peer_id, CS_Invalid);

--- a/src/porting_android.cpp
+++ b/src/porting_android.cpp
@@ -51,6 +51,16 @@ Java_net_minetest_minetest_GameActivity_saveSettings(JNIEnv* env, jobject /* thi
 }
 
 namespace porting {
+	static core::rect<s32> display_insets;
+};
+
+extern "C" JNIEXPORT void JNICALL
+Java_net_minetest_minetest_GameActivity_updateInsets(JNIEnv* env, jobject /* this */,
+		jint bottom, jint left, jint right, jint top) {
+	porting::display_insets = core::rect<s32>(left, top, right, bottom);
+}
+
+namespace porting {
 	// used here:
 	void cleanupAndroid();
 	std::string getLanguageAndroid();
@@ -279,7 +289,7 @@ v2u32 getDisplaySize()
 				"getDisplayWidth", "()I");
 
 		FATAL_ERROR_IF(getDisplayWidth == nullptr,
-			"porting::getDisplayWidth unable to find Java getDisplayWidth method");
+			"porting::getDisplaySize unable to find Java getDisplayWidth method");
 
 		retval.X = jnienv->CallIntMethod(activity,
 				getDisplayWidth);
@@ -288,7 +298,7 @@ v2u32 getDisplaySize()
 				"getDisplayHeight", "()I");
 
 		FATAL_ERROR_IF(getDisplayHeight == nullptr,
-			"porting::getDisplayHeight unable to find Java getDisplayHeight method");
+			"porting::getDisplaySize unable to find Java getDisplayHeight method");
 
 		retval.Y = jnienv->CallIntMethod(activity,
 				getDisplayHeight);
@@ -297,6 +307,13 @@ v2u32 getDisplaySize()
 	}
 
 	return retval;
+}
+
+// This works via a Java -> C++ callback instead of the other way around so that
+// we can react to changes without having to poll.
+core::rect<s32> getDisplayInsets()
+{
+	return display_insets;
 }
 
 std::string getLanguageAndroid()

--- a/src/porting_android.h
+++ b/src/porting_android.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 
 #include "irrlichttypes_bloated.h"
+#include "rect.h"
 #include <string>
 
 namespace porting {
@@ -100,6 +101,7 @@ bool hasPhysicalKeyboardAndroid();
 #ifndef SERVER
 float getDisplayDensity();
 v2u32 getDisplaySize();
+core::rect<s32> getDisplayInsets();
 #endif
 
 }

--- a/src/script/common/CMakeLists.txt
+++ b/src/script/common/CMakeLists.txt
@@ -4,6 +4,7 @@ set(common_SCRIPT_COMMON_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/c_types.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/c_internal.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/c_packer.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/c_window_info.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/helper.cpp
 	PARENT_SCOPE)
 

--- a/src/script/common/c_window_info.cpp
+++ b/src/script/common/c_window_info.cpp
@@ -1,0 +1,50 @@
+#include "c_window_info.h"
+#include "c_converter.h"
+
+void push_window_info(lua_State *L, const ClientDynamicInfo &info)
+{
+	lua_newtable(L);
+	int top = lua_gettop(L);
+
+	lua_pushstring(L, "size");
+	push_v2u32(L, info.render_target_size);
+	lua_settable(L, top);
+
+	lua_pushstring(L, "insets");
+	lua_newtable(L);
+	int top2 = lua_gettop(L);
+
+	lua_pushstring(L, "bottom");
+	lua_pushinteger(L, info.insets.LowerRightCorner.Y);
+	lua_settable(L, top2);
+
+	lua_pushstring(L, "left");
+	lua_pushinteger(L, info.insets.UpperLeftCorner.X);
+	lua_settable(L, top2);
+
+	lua_pushstring(L, "right");
+	lua_pushinteger(L, info.insets.LowerRightCorner.X);
+	lua_settable(L, top2);
+
+	lua_pushstring(L, "top");
+	lua_pushinteger(L, info.insets.UpperLeftCorner.Y);
+	lua_settable(L, top2);
+
+	lua_settable(L, top);
+
+	lua_pushstring(L, "max_formspec_size");
+	push_v2f(L, info.max_fs_size);
+	lua_settable(L, top);
+
+	lua_pushstring(L, "real_gui_scaling");
+	lua_pushnumber(L, info.real_gui_scaling);
+	lua_settable(L, top);
+
+	lua_pushstring(L, "real_hud_scaling");
+	lua_pushnumber(L, info.real_hud_scaling);
+	lua_settable(L, top);
+
+	lua_pushstring(L, "touch_controls");
+	lua_pushboolean(L, info.touch_controls);
+	lua_settable(L, top);
+}

--- a/src/script/common/c_window_info.h
+++ b/src/script/common/c_window_info.h
@@ -1,0 +1,9 @@
+#pragma once
+
+extern "C" {
+#include <lua.h>
+}
+
+#include "clientdynamicinfo.h"
+
+void push_window_info(lua_State *L, const ClientDynamicInfo &info);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_mainmenu.h"
 #include "lua_api/l_internal.h"
 #include "common/c_content.h"
+#include "common/c_window_info.h"
 #include "cpp_api/s_async.h"
 #include "scripting_mainmenu.h"
 #include "gui/guiEngine.h"
@@ -966,31 +967,7 @@ int ModApiMainMenu::l_gettext(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_get_window_info(lua_State *L)
 {
-	lua_newtable(L);
-	int top = lua_gettop(L);
-
-	auto info = ClientDynamicInfo::getCurrent();
-
-	lua_pushstring(L, "size");
-	push_v2u32(L, info.render_target_size);
-	lua_settable(L, top);
-
-	lua_pushstring(L, "max_formspec_size");
-	push_v2f(L, info.max_fs_size);
-	lua_settable(L, top);
-
-	lua_pushstring(L, "real_gui_scaling");
-	lua_pushnumber(L, info.real_gui_scaling);
-	lua_settable(L, top);
-
-	lua_pushstring(L, "real_hud_scaling");
-	lua_pushnumber(L, info.real_hud_scaling);
-	lua_settable(L, top);
-
-	lua_pushstring(L, "touch_controls");
-	lua_pushboolean(L, info.touch_controls);
-	lua_settable(L, top);
-
+	push_window_info(L, ClientDynamicInfo::getCurrent());
 	return 1;
 }
 

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include "common/c_packer.h"
+#include "common/c_window_info.h"
 #include "cpp_api/s_base.h"
 #include "cpp_api/s_security.h"
 #include "scripting_server.h"
@@ -300,29 +301,7 @@ int ModApiServer::l_get_player_window_information(lua_State *L)
 	if (!dynamic || dynamic->render_target_size == v2u32())
 		return 0;
 
-	lua_newtable(L);
-	int dyn_table = lua_gettop(L);
-
-	lua_pushstring(L, "size");
-	push_v2u32(L, dynamic->render_target_size);
-	lua_settable(L, dyn_table);
-
-	lua_pushstring(L, "max_formspec_size");
-	push_v2f(L, dynamic->max_fs_size);
-	lua_settable(L, dyn_table);
-
-	lua_pushstring(L, "real_gui_scaling");
-	lua_pushnumber(L, dynamic->real_gui_scaling);
-	lua_settable(L, dyn_table);
-
-	lua_pushstring(L, "real_hud_scaling");
-	lua_pushnumber(L, dynamic->real_hud_scaling);
-	lua_settable(L, dyn_table);
-
-	lua_pushstring(L, "touch_controls");
-	lua_pushboolean(L, dynamic->touch_controls);
-	lua_settable(L, dyn_table);
-
+	push_window_info(L, *dynamic);
 	return 1;
 }
 


### PR DESCRIPTION
As discussed in #14510, this PR replaces the hardcoded extra padding in the ContentDB dialog on Android, which may waste valuable screen space depending on your device, with an API to retrieve display inset values

## To do

This PR is a Ready for Review.

(I wrote this code back in May)

## How to test

ContentDB dialog on desktop => should look the same as before
ContentDB dialog on Android => should respect the camera cutout, and should update in real time when you turn the screen upside-down

The same should apply for `/testfullscreenfs` in Devtest. 