### PR TITLE
Trivial improvement to `get_item_group`

### DIFF
--- a/builtin/game/misc_s.lua
+++ b/builtin/game/misc_s.lua
@@ -26,7 +26,7 @@ end
 
 function core.get_item_group(name, group)
 	local def = core.registered_items[name]
-	return def and def.groups and def.groups[group] or 0
+	return def and def.groups[group] or 0
 end
 
 

--- a/builtin/game/misc_s.lua
+++ b/builtin/game/misc_s.lua
@@ -25,11 +25,8 @@ end
 
 
 function core.get_item_group(name, group)
-	if not core.registered_items[name] or not
-			core.registered_items[name].groups[group] then
-		return 0
-	end
-	return core.registered_items[name].groups[group]
+	local def = core.registered_items[name]
+	return def.groups and def.groups[group] or 0
 end
 
 

--- a/builtin/game/misc_s.lua
+++ b/builtin/game/misc_s.lua
@@ -26,7 +26,7 @@ end
 
 function core.get_item_group(name, group)
 	local def = core.registered_items[name]
-	return def.groups and def.groups[group] or 0
+	return def and def.groups and def.groups[group] or 0
 end
 
 


### PR DESCRIPTION
One hash table lookup is enough, and this is even easier for the JIT to inline, optimize, etc.

No, I will not add a benchmark code for such a trivial change.
It is a fairly frequently called method, and clearly the new version is easier and more readable, and not slower.