### PR TITLE
Fix animation blending

### DIFF
--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -136,6 +136,8 @@ private:
 
 	bool visualExpiryRequired(const ObjectProperties &newprops) const;
 
+	void fixBones();
+
 public:
 	GenericCAO(Client *client, ClientEnvironment *env);
 


### PR DESCRIPTION
Should fix #14817, not tested yet. @hecktest @emperorgenshin

This is not exactly a very clean solution, but it's better than jank. I'm working on a major refactor of skeletal animations (which is somewhat necessary to do them on the GPU) and everything surrounding them eventually, but I don't want to delay this bugfix.

(Ideally I also plan to do some larger Irrlicht refactors first, e.g. to remove unnecessary `I*` interfaces (for example `ISkinnedMesh` is obsolete: `CSkinnedMesh` can be used directly), and maybe getting rid of `core::array` and `core::string`.)

See also my comment on https://github.com/minetest/minetest/issues/14817#issuecomment-2346695144 for why this should fix animation blending.

## How to test

See the linked issue. Animations should not "snap instantly" with this change.

