### PR TITLE
Show warning in the settings menu when shaders are disabled

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -19,6 +19,8 @@
 local component_funcs =  dofile(core.get_mainmenu_path() .. DIR_DELIM ..
 		"settings" .. DIR_DELIM .. "components.lua")
 
+local shader_warning_component =  dofile(core.get_mainmenu_path() .. DIR_DELIM ..
+		"settings" .. DIR_DELIM .. "shader_warning_component.lua")
 local shadows_component =  dofile(core.get_mainmenu_path() .. DIR_DELIM ..
 		"settings" .. DIR_DELIM .. "shadows_component.lua")
 
@@ -152,7 +154,12 @@ local function load()
 
 	table.insert(page_by_id.controls_keyboard_and_mouse.content, 1, change_keys)
 	do
-		local content = page_by_id.graphics_and_audio_effects.content
+		local content = page_by_id.graphics_and_audio_graphics.content
+		table.insert(content, 1, shader_warning_component)
+
+		content = page_by_id.graphics_and_audio_effects.content
+		table.insert(content, 1, shader_warning_component)
+
 		local idx = table.indexof(content, "enable_dynamic_shadows")
 		table.insert(content, idx, shadows_component)
 
@@ -706,7 +713,7 @@ local function buttonhandler(this, fields)
 
 	local function after_setting_change(comp)
 		write_settings_early()
-		if comp.setting.name == "touch_controls" then
+		if comp.setting and comp.setting.name == "touch_controls" then
 			-- Changing the "touch_controls" setting may result in a different
 			-- page list.
 			regenerate_page_list(dialogdata)

--- a/builtin/mainmenu/settings/shader_warning_component.lua
+++ b/builtin/mainmenu/settings/shader_warning_component.lua
@@ -1,0 +1,40 @@
+--Minetest
+--Copyright (C) 2024 grorp
+--
+--This program is free software; you can redistribute it and/or modify
+--it under the terms of the GNU Lesser General Public License as published by
+--the Free Software Foundation; either version 2.1 of the License, or
+--(at your option) any later version.
+--
+--This program is distributed in the hope that it will be useful,
+--but WITHOUT ANY WARRANTY; without even the implied warranty of
+--MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--GNU Lesser General Public License for more details.
+--
+--You should have received a copy of the GNU Lesser General Public License along
+--with this program; if not, write to the Free Software Foundation, Inc.,
+--51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+return {
+	query_text = "Shaders",
+	requires = {
+		shaders_support = true,
+        shaders = false,
+	},
+    full_width = true,
+	get_formspec = function(self, avail_w)
+        local fs = {
+            "box[0,0;", avail_w, ",1.2;", mt_color_orange, "]",
+			"label[0.2,0.4;", fgettext("Shaders are disabled."), "]",
+			"label[0.2,0.8;", fgettext("This is not a recommended configuration."), "]",
+			"button[", avail_w - 2.2, ",0.2;2,0.8;fix_shader_warning;Enable]",
+        }
+		return table.concat(fs, ""), 1.2
+	end,
+	on_submit = function(self, fields)
+		if fields.fix_shader_warning then
+			core.settings:remove("enable_shaders") -- default value is true
+			return true
+		end
+	end,
+}

--- a/builtin/mainmenu/settings/shader_warning_component.lua
+++ b/builtin/mainmenu/settings/shader_warning_component.lua
@@ -1,19 +1,5 @@
---Minetest
---Copyright (C) 2024 grorp
---
---This program is free software; you can redistribute it and/or modify
---it under the terms of the GNU Lesser General Public License as published by
---the Free Software Foundation; either version 2.1 of the License, or
---(at your option) any later version.
---
---This program is distributed in the hope that it will be useful,
---but WITHOUT ANY WARRANTY; without even the implied warranty of
---MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
---GNU Lesser General Public License for more details.
---
---You should have received a copy of the GNU Lesser General Public License along
---with this program; if not, write to the Free Software Foundation, Inc.,
---51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-- Minetest
+-- SPDX-License-Identifier: LGPL-2.1-or-later
 
 return {
 	query_text = "Shaders",

--- a/builtin/mainmenu/settings/shader_warning_component.lua
+++ b/builtin/mainmenu/settings/shader_warning_component.lua
@@ -13,7 +13,7 @@ return {
             "box[0,0;", avail_w, ",1.2;", mt_color_orange, "]",
 			"label[0.2,0.4;", fgettext("Shaders are disabled."), "]",
 			"label[0.2,0.8;", fgettext("This is not a recommended configuration."), "]",
-			"button[", avail_w - 2.2, ",0.2;2,0.8;fix_shader_warning;Enable]",
+			"button[", avail_w - 2.2, ",0.2;2,0.8;fix_shader_warning;", fgettext("Enable"), "]",
         }
 		return table.concat(fs, ""), 1.2
 	end,


### PR DESCRIPTION
fixes #15270

screenshot:
<img alt="screenshot" src="https://github.com/user-attachments/assets/d5a80b95-69e1-497d-bb61-0a155bfce26b" width="512" />

## To do

This PR is a Ready for Review.

## How to test

Disable shaders. Verify that a warning asking you to enable them is shown in the "Graphics" and "Effects" setting sections. Verify that the warning disappears when you click "Enable".