### PR TITLE
Add missing setting callbacks for display_density_factor

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -72,6 +72,7 @@ ClientLauncher::~ClientLauncher()
 {
 	delete input;
 	g_settings->deregisterChangedCallback("dpi_change_notifier", setting_changed_callback, this);
+	g_settings->deregisterChangedCallback("display_density_factor", setting_changed_callback, this);
 	g_settings->deregisterChangedCallback("gui_scaling", setting_changed_callback, this);
 
 	delete g_fontengine;
@@ -133,6 +134,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	guienv = m_rendering_engine->get_gui_env();
 	config_guienv();
 	g_settings->registerChangedCallback("dpi_change_notifier", setting_changed_callback, this);
+	g_settings->registerChangedCallback("display_density_factor", setting_changed_callback, this);
 	g_settings->registerChangedCallback("gui_scaling", setting_changed_callback, this);
 
 	g_fontengine = new FontEngine(guienv);

--- a/src/client/fontengine.cpp
+++ b/src/client/fontengine.cpp
@@ -33,9 +33,19 @@ FontEngine *g_fontengine = nullptr;
 /** callback to be used on change of font size setting */
 static void font_setting_changed(const std::string &name, void *userdata)
 {
-	if (g_fontengine)
-		g_fontengine->readSettings();
+	static_cast<FontEngine *>(userdata)->readSettings();
 }
+
+static const char *settings[] = {
+	"font_size", "font_bold", "font_italic", "font_size_divisible_by",
+	"mono_font_size", "mono_font_size_divisible_by",
+	"font_shadow", "font_shadow_alpha",
+	"font_path", "font_path_bold", "font_path_italic", "font_path_bold_italic",
+	"mono_font_path", "mono_font_path_bold", "mono_font_path_italic",
+	"mono_font_path_bold_italic",
+	"fallback_font_path",
+	"dpi_change_notifier", "display_density_factor", "gui_scaling",
+};
 
 /******************************************************************************/
 FontEngine::FontEngine(gui::IGUIEnvironment* env) :
@@ -51,24 +61,16 @@ FontEngine::FontEngine(gui::IGUIEnvironment* env) :
 
 	readSettings();
 
-	const char *settings[] = {
-		"font_size", "font_bold", "font_italic", "font_size_divisible_by",
-		"mono_font_size", "mono_font_size_divisible_by",
-		"font_shadow", "font_shadow_alpha",
-		"font_path", "font_path_bold", "font_path_italic", "font_path_bold_italic",
-		"mono_font_path", "mono_font_path_bold", "mono_font_path_italic",
-		"mono_font_path_bold_italic",
-		"fallback_font_path",
-		"dpi_change_notifier", "display_density_factor", "gui_scaling",
-	};
-
 	for (auto name : settings)
-		g_settings->registerChangedCallback(name, font_setting_changed, NULL);
+		g_settings->registerChangedCallback(name, font_setting_changed, this);
 }
 
 /******************************************************************************/
 FontEngine::~FontEngine()
 {
+	for (auto name : settings)
+		g_settings->deregisterChangedCallback(name, font_setting_changed, this);
+
 	cleanCache();
 }
 

--- a/src/client/fontengine.cpp
+++ b/src/client/fontengine.cpp
@@ -59,7 +59,7 @@ FontEngine::FontEngine(gui::IGUIEnvironment* env) :
 		"mono_font_path", "mono_font_path_bold", "mono_font_path_italic",
 		"mono_font_path_bold_italic",
 		"fallback_font_path",
-		"dpi_change_notifier", "gui_scaling",
+		"dpi_change_notifier", "display_density_factor", "gui_scaling",
 	};
 
 	for (auto name : settings)

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -61,6 +61,7 @@ Hud::Hud(Client *client, LocalPlayer *player,
 
 	readScalingSetting();
 	g_settings->registerChangedCallback("dpi_change_notifier", setting_changed_callback, this);
+	g_settings->registerChangedCallback("display_density_factor", setting_changed_callback, this);
 	g_settings->registerChangedCallback("hud_scaling", setting_changed_callback, this);
 
 	for (auto &hbar_color : hbar_colors)
@@ -170,6 +171,7 @@ void Hud::readScalingSetting()
 Hud::~Hud()
 {
 	g_settings->deregisterChangedCallback("dpi_change_notifier", setting_changed_callback, this);
+	g_settings->deregisterChangedCallback("display_density_factor", setting_changed_callback, this);
 	g_settings->deregisterChangedCallback("hud_scaling", setting_changed_callback, this);
 
 	if (m_selection_mesh)


### PR DESCRIPTION
Adds missing setting callback registrations for `display_density_factor`

Triggering setting callbacks inside setting callbacks is prevented by `m_callback_mutex`. Otherwise, I could just make any change to `display_density_factor` trigger a change of `dpi_change_notifier` as well.

## To do

This PR is a Ready for Review.

## How to test

Set `display_density_factor`, see that fonts reacts immediately.