### PR TITLE
parse_json: Always push JSON numbers as doubles

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2087,11 +2087,7 @@ static bool push_json_value_helper(lua_State *L, const Json::Value &value,
 			lua_pushvalue(L, nullindex);
 			break;
 		case Json::intValue:
-			lua_pushinteger(L, value.asLargestInt());
-			break;
 		case Json::uintValue:
-			lua_pushinteger(L, value.asLargestUInt());
-			break;
 		case Json::realValue:
 			lua_pushnumber(L, value.asDouble());
 			break;


### PR DESCRIPTION
Fixes #15277 by always pushing numbers as doubles as the title says.

Note that Lua numbers are doubles and so are JSON numbers (because JS) usually too, and that jsoncpp's `asDouble` casts integers to doubles, as we need to when converting to Lua numbers.