### PR TITLE
[no sq] Lua JSON util improvements

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7404,11 +7404,13 @@ Misc.
     * Gets the internal content ID of `name`
 * `minetest.get_name_from_content_id(content_id)`: returns a string
     * Gets the name of the content with that content ID
-* `minetest.parse_json(string[, nullvalue])`: returns something
+* `minetest.parse_json(string[, nullvalue, return_error])`: returns something
     * Convert a string containing JSON data into the Lua equivalent
     * `nullvalue`: returned in place of the JSON null; defaults to `nil`
     * On success returns a table, a string, a number, a boolean or `nullvalue`
-    * On failure outputs an error message and returns `nil`
+    * On failure: If `return_error` is not set or is `false`,
+      outputs an error message and returns `nil`.
+      Otherwise returns `nil, err` (error message).
     * Example: `parse_json("[10, {\"a\":false}]")`, returns `{10, {a = false}}`
 * `minetest.write_json(data[, styled])`: returns a string or `nil` and an error
   message.

--- a/games/devtest/mods/unittests/misc.lua
+++ b/games/devtest/mods/unittests/misc.lua
@@ -174,6 +174,21 @@ local function test_parse_json()
 end
 unittests.register("test_parse_json", test_parse_json)
 
+local function test_write_json()
+	-- deeply nested structures should be preserved
+	local leaf = 42
+	local data = leaf
+	for i = 1, 1000 do
+		data = {data}
+	end
+	local roundtripped = minetest.parse_json(minetest.write_json(data))
+	for i = 1, 1000 do
+		roundtripped = roundtripped[1]
+	end
+	assert(roundtripped == 42)
+end
+unittests.register("test_write_json", test_write_json)
+
 local function test_game_info()
 	local info = minetest.get_game_info()
 	local game_conf = Settings(info.path .. "/game.conf")

--- a/games/devtest/mods/unittests/misc.lua
+++ b/games/devtest/mods/unittests/misc.lua
@@ -155,13 +155,22 @@ unittests.register("test_urlencode", test_urlencode)
 
 local function test_parse_json()
 	local raw = "{\"how\\u0000weird\":\n\"yes\\u0000really\",\"n\":-1234567891011,\"z\":null}"
-	local data = core.parse_json(raw)
-	assert(data["how\000weird"] == "yes\000really")
-	assert(data.n == -1234567891011)
-	assert(data.z == nil)
-	local null = {}
-	data = core.parse_json(raw, null)
-	assert(data.z == null)
+	do
+		local data = core.parse_json(raw)
+		assert(data["how\000weird"] == "yes\000really")
+		assert(data.n == -1234567891011)
+		assert(data.z == nil)
+	end
+	do
+		local null = {}
+		local data = core.parse_json(raw, null)
+		assert(data.z == null)
+	end
+	do
+		local data, err = core.parse_json('"ceci n\'est pas un json', nil, true)
+		assert(data == nil)
+		assert(type(err) == "string")
+	end
 end
 unittests.register("test_parse_json", test_parse_json)
 

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -200,7 +200,7 @@ bool               push_json_value           (lua_State *L,
                                               const Json::Value &value,
                                               int nullindex);
 void               read_json_value           (lua_State *L, Json::Value &root,
-                                              int index, u8 recursion = 0);
+                                              int index, u16 max_depth);
 
 /*!
  * Pushes a Lua `pointed_thing` to the given Lua stack.


### PR DESCRIPTION
Currently modders can't handle JSON parsing errors themselves, we always log an error message. This PR changes that.

I'm not sure whether to consider this a bugfix or a feature. Personally I consider the "always log" behavior more of a quirk / bug but technically this PR might be a feature, since the previous behavior was documented and working as intended.

Also added another commit which fixes the low max stack depth for reading and makes the depths for reading and writing consistent.

## How to test

See the unit test.
