### PR TITLE
Better UX when touch events aren't supported by Irrlicht device

### DIFF
--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -342,14 +342,16 @@ local function check_requirements(name, requires)
 
 	local video_driver = core.get_active_driver()
 	local shaders_support = video_driver == "opengl" or video_driver == "opengl3" or video_driver == "ogles2"
+	local touch_support = core.irrlicht_device_supports_touch()
 	local touch_controls = core.settings:get("touch_controls")
 	local special = {
 		android = PLATFORM == "Android",
 		desktop = PLATFORM ~= "Android",
+		touch_support = touch_support,
 		-- When touch_controls is "auto", we don't which input method will be used,
 		-- so we show settings for both.
-		touchscreen = touch_controls == "auto" or core.is_yes(touch_controls),
-		keyboard_mouse = touch_controls == "auto" or not core.is_yes(touch_controls),
+		touchscreen = touch_support and (touch_controls == "auto" or core.is_yes(touch_controls)),
+		keyboard_mouse = not touch_support or (touch_controls == "auto" or not core.is_yes(touch_controls)),
 		shaders_support = shaders_support,
 		shaders = core.settings:get_bool("enable_shaders") and shaders_support,
 		opengl = video_driver == "opengl",

--- a/builtin/mainmenu/settings/dlg_settings.lua
+++ b/builtin/mainmenu/settings/dlg_settings.lua
@@ -348,8 +348,8 @@ local function check_requirements(name, requires)
 		android = PLATFORM == "Android",
 		desktop = PLATFORM ~= "Android",
 		touch_support = touch_support,
-		-- When touch_controls is "auto", we don't which input method will be used,
-		-- so we show settings for both.
+		-- When touch_controls is "auto", we don't know which input method will
+		-- be used, so we show settings for both.
 		touchscreen = touch_support and (touch_controls == "auto" or core.is_yes(touch_controls)),
 		keyboard_mouse = not touch_support or (touch_controls == "auto" or not core.is_yes(touch_controls)),
 		shaders_support = shaders_support,

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -155,6 +155,8 @@ invert_hotbar_mouse_wheel (Hotbar: Invert mouse wheel direction) bool false
 #    Enables the touchscreen controls, allowing you to play the game with a touchscreen.
 #    "auto" means that the touchscreen controls will be enabled and disabled
 #    automatically depending on the last used input method.
+#
+#    Requires: touch_support
 touch_controls (Touchscreen controls) enum auto auto,true,false
 
 #    Touchscreen sensitivity multiplier.

--- a/irr/include/IrrlichtDevice.h
+++ b/irr/include/IrrlichtDevice.h
@@ -193,6 +193,11 @@ public:
 	/** If this returns false, you should not do any rendering. */
 	virtual bool isWindowVisible() const { return true; };
 
+	//! Checks if the Irrlicht device supports touch events.
+	/** Intentionally doesn't check whether a touch input device is available
+	or similar. */
+	virtual bool supportsTouchEvents() const { return false; }
+
 	//! Get the current color format of the window
 	/** \return Color format of the window. */
 	virtual video::ECOLOR_FORMAT getColorFormat() const = 0;

--- a/irr/src/CIrrDeviceLinux.cpp
+++ b/irr/src/CIrrDeviceLinux.cpp
@@ -1205,6 +1205,17 @@ bool CIrrDeviceLinux::isWindowMaximized() const
 	return WindowMaximized;
 }
 
+//! Checks if the Irrlicht device supports touch events.
+bool CIrrDeviceLinux::supportsTouchEvents() const
+{
+#if defined(_IRR_LINUX_X11_XINPUT2_)
+	return true;
+#else
+	return false;
+#endif
+}
+
+
 //! returns color format of the window.
 video::ECOLOR_FORMAT CIrrDeviceLinux::getColorFormat() const
 {

--- a/irr/src/CIrrDeviceLinux.h
+++ b/irr/src/CIrrDeviceLinux.h
@@ -66,6 +66,9 @@ public:
 	//! returns last state from maximizeWindow() and restoreWindow()
 	bool isWindowMaximized() const override;
 
+	//! Checks if the Irrlicht device supports touch events.
+	bool supportsTouchEvents() const override;
+
 	//! returns color format of the window.
 	video::ECOLOR_FORMAT getColorFormat() const override;
 

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -1293,6 +1293,7 @@ bool CIrrDeviceSDL::isWindowVisible() const
 	return !IsInBackground;
 }
 
+//! Checks if the Irrlicht device supports touch events.
 bool CIrrDeviceSDL::supportsTouchEvents() const
 {
 	return true;

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -1293,6 +1293,11 @@ bool CIrrDeviceSDL::isWindowVisible() const
 	return !IsInBackground;
 }
 
+bool CIrrDeviceSDL::supportsTouchEvents() const
+{
+	return true;
+}
+
 //! returns if window is active. if not, nothing need to be drawn
 bool CIrrDeviceSDL::isWindowActive() const
 {

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -93,6 +93,9 @@ public:
 	//! Checks if the window could possibly be visible.
 	bool isWindowVisible() const override;
 
+	//! Checks if the Irrlicht device supports touch events.
+	bool supportsTouchEvents() const override;
+
 	//! Get the position of this window on screen
 	core::position2di getWindowPosition() override;
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1576,6 +1576,9 @@ bool Game::createClient(const GameStartData &start_data)
 
 bool Game::shouldShowTouchControls()
 {
+	if (!device->supportsTouchEvents())
+		return false;
+
 	const std::string &touch_controls = g_settings->get("touch_controls");
 	if (touch_controls == "auto")
 		return RenderingEngine::getLastPointerType() == PointerType::Touch;

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -1027,6 +1027,14 @@ int ModApiMainMenu::l_get_active_irrlicht_device(lua_State *L)
 }
 
 /******************************************************************************/
+int ModApiMainMenu::l_irrlicht_device_supports_touch(lua_State *L)
+{
+	lua_pushboolean(L, RenderingEngine::get_raw_device()->supportsTouchEvents());
+	return 1;
+}
+
+
+/******************************************************************************/
 int ModApiMainMenu::l_get_min_supp_proto(lua_State *L)
 {
 	lua_pushinteger(L, CLIENT_PROTOCOL_VERSION_MIN);
@@ -1158,6 +1166,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(get_active_driver);
 	API_FCT(get_active_renderer);
 	API_FCT(get_active_irrlicht_device);
+	API_FCT(irrlicht_device_supports_touch);
 	API_FCT(get_min_supp_proto);
 	API_FCT(get_max_supp_proto);
 	API_FCT(get_formspec_version);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -116,6 +116,8 @@ private:
 
 	static int l_get_active_irrlicht_device(lua_State *L);
 
+	static int l_irrlicht_device_supports_touch(lua_State *L);
+
 	//filesystem
 
 	static int l_get_mainmenu_path(lua_State *L);


### PR DESCRIPTION
fixes #15005

when touch is not supported by the Irrlicht device, hide touchscreen settings and never enable touch controls

## To do

This PR is a Ready for Review.

## How to test

Use Minetest on Windows without SDL