### PR TITLE
Fix newline rejection and whitespace trimming for chat messages 

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3091,8 +3091,8 @@ std::wstring Server::handleChat(const std::string &name,
 	if (message.empty())
 		return L"";
 
-	if (message.find_first_of("\n\r") != std::wstring::npos) {
-		return L"Newlines are not permitted in chat messages";
+	if (wmessage.find_first_of(CHAT_DISALLOWED_CHARS) != std::wstring::npos) {
+		return L"Your message contains disallowed characters.";
 	}
 
 	// Run script hook, exit if script ate the chat message

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3061,6 +3061,8 @@ std::wstring Server::handleChat(const std::string &name,
 	if (g_settings->getBool("strip_color_codes"))
 		wmessage = unescape_enriched(wmessage);
 
+	wmessage = trim(wmessage);
+
 	if (player) {
 		switch (player->canSendChatMessage()) {
 		case RPLAYER_CHATRESULT_FLOODING: {
@@ -3087,13 +3089,12 @@ std::wstring Server::handleChat(const std::string &name,
 				L"It was refused. Send a shorter message";
 	}
 
-	auto message = trim(wide_to_utf8(wmessage));
+	auto message = wide_to_utf8(wmessage);
 	if (message.empty())
 		return L"";
 
-	if (wmessage.find_first_of(CHAT_DISALLOWED_CHARS) != std::wstring::npos) {
+	if (message.find_first_of("\r\n") != std::string::npos)
 		return L"Your message contains disallowed characters.";
-	}
 
 	// Run script hook, exit if script ate the chat message
 	if (m_script->on_chat_message(name, message))
@@ -3115,8 +3116,7 @@ std::wstring Server::handleChat(const std::string &name,
 #ifdef __ANDROID__
 		line += L"<" + utf8_to_wide(name) + L"> " + wmessage;
 #else
-		line += utf8_to_wide(m_script->formatChatMessage(name,
-				wide_to_utf8(wmessage)));
+		line += utf8_to_wide(m_script->formatChatMessage(name, message));
 #endif
 	}
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3094,7 +3094,7 @@ std::wstring Server::handleChat(const std::string &name,
 		return L"";
 
 	if (message.find_first_of("\r\n") != std::string::npos)
-		return L"Your message contains disallowed characters.";
+		return L"Newlines are not permitted in chat messages";
 
 	// Run script hook, exit if script ate the chat message
 	if (m_script->on_chat_message(name, message))

--- a/src/server.h
+++ b/src/server.h
@@ -50,9 +50,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <shared_mutex>
 #include <condition_variable>
 
-// U+001B is the Escape character needed for color codes
-#define CHAT_DISALLOWED_CHARS L"\n\r\x1b"
-
 class ChatEvent;
 struct ChatEventChat;
 struct ChatInterface;

--- a/src/server.h
+++ b/src/server.h
@@ -50,6 +50,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <shared_mutex>
 #include <condition_variable>
 
+// U+001B is the Escape character needed for color codes
+#define CHAT_DISALLOWED_CHARS L"\n\r\x1b"
+
 class ChatEvent;
 struct ChatEventChat;
 struct ChatInterface;


### PR DESCRIPTION
Prior to this commit, the trimmed string was checked for the forbidden characters, which could lead to false negatives.

closes #13916

# Goal of the PR
- Enforce the use of allowed characters

## How does the PR work?
- Check the original wstring instead


**Ready for Review.**
<!-- ^ delete one -->


## How to test

**note**: outdated

- Load up both the latest master and this branch of minetest
- start singleplayer games or HOST a server in both versions
- send the following chat messages (replace \r and \x1b with the corresponding characters):

>  `\r\r\r\r\r\r\r\r\r\r\rHello, this message has multiple lines`
 `\x1b(c@#ff0000)This is a red chat message.`

- Verify that the current master happily accepts all of these and my branch does not.

## Screenshots

| Currently | With this PR |
|--------------|------------------|
| ![grafik](https://github.com/user-attachments/assets/1cb94638-8738-4088-999e-5f1579c6fdf9)  | ![grafik](https://github.com/user-attachments/assets/a469f23c-4009-4519-a017-613827c25bf2) |
| ![grafik](https://github.com/user-attachments/assets/118777c3-44e4-45a8-8ece-4abe1e11d849) |  ![grafik](https://github.com/user-attachments/assets/a469f23c-4009-4519-a017-613827c25bf2) |
| Yes, this is actually a single chat message, the formatting code can just screw up badly with carriage returns. ![grafik](https://github.com/user-attachments/assets/60dd1b2d-d1d6-4261-8617-81ca79cc4771) |  ![grafik](https://github.com/user-attachments/assets/a469f23c-4009-4519-a017-613827c25bf2) |

