### PR TITLE
Fix out-of-bounds read in getDimension

### DIFF
--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -721,7 +721,7 @@ core::dimension2d<u32> CGUITTFont::getDimension(const std::u32string& text) cons
 		if (p == '\r')	// Mac or Windows line breaks.
 		{
 			lineBreak = true;
-			if (*(iter + 1) == '\n')
+			if (iter + 1 != text.end() && *(iter + 1) == '\n')
 			{
 				++iter;
 				p = *iter;


### PR DESCRIPTION
This PR fixes an edge case where parameter `text` has `\r` at the end of itself but does not have `\n` after it.

Before changes:
![image](https://github.com/user-attachments/assets/65685e2c-685f-496f-a7c1-f2178bdf0891)

I encountered this issue accidentally when I logged into a random server and just opened a book.

## To do

This PR is Ready for Review.
<!-- ^ delete one -->

## How to test
Open a book which has a text with `\r` at the end of it without any `\n` after it.
Or, put a breakpoint before calling `CGUITTFont.getDimension` and add `\r` at the end of it.
Before this change, you will get the shown error; after it, no error will be shown and the text will get rendered correctly.