### PR TITLE
Expose profiler to core.instrument_function

### DIFF
--- a/builtin/profiler/init.lua
+++ b/builtin/profiler/init.lua
@@ -74,6 +74,21 @@ function profiler.init_chatcommand()
 	end
 end
 
+-- Instrument the given function (may be nil if profiler not loaded)
+-- def: table with the following keys
+-- def.func: Function to be wrapped
+-- def.mod: Mod of the function
+-- def.class: Group similar functions together
+-- def.label: Human-readable description
+-- def.func_name: Machine-readable function name
+function core.instrument_function(def)
+	assert(type(def) == "table", "Table expected in core.instrument_function")
+	if type(def.class) ~= "string" then
+		def.class = "Custom"
+	end
+	return profiler.instrument(def)
+end
+
 sampler.init()
 instrumentation.init()
 


### PR DESCRIPTION
Allows mods to register additional instrumentations by `core.instrument_function`. It is a wrapped version of `profiler.instrument` with additional checks.


## To do

This PR is Ready for Review.

- [x] `profiler.instrument` 
- [ ] (If needed) Move into the insecure environment

## How to test

After enabling profiler, create a mod with the following content:

```lua
if core.instrument_function then
    local func = core.instrument_function({
        func = function() return end,
        class = "Testcase",
    })
    minetest.register_globalstep(func)
end
```

You should see an entry under your mod's name in `/profiler print`.

### Real example

```lua
-- Copyright (C) 2024  1F616EMO
-- SPDX-License-Identifier: AGPL-3.0-or-later
if not core.instrument_function then return end

for _, name in ipairs({
    "train_ensure_init",
    "train_step_b",
    "train_step_c",
}) do
    advtrains[name] = core.instrument_function({
        func = advtrains[name],
        class = "Trainlogic",
        label = name
    })
end
```

`/profiler save` outputs:

```text
 instrumentation                              |    min µs |    max µs |    avg µs | min % | max % | avg %
--------------------------------------------- | --------- | --------- | --------- | ----- | ----- | ------
 advtrains_mod:                               |         6 |      2313 |        43 |   0.0 |  38.2 |   5.9
  - Trainlogic 'train_step_b' ..............  |         3 |      1882 |        21 |   0.0 |  29.6 |   2.9
  - Trainlogic 'train_ensure_init' .........  |         1 |       388 |         2 |   0.0 |  15.9 |   0.5
  - Trainlogic 'train_step_c' ..............  |         1 |       277 |        19 |   0.0 |  32.6 |   2.6
```
