### PR TITLE
Update documentation to reflect player constant values

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9101,11 +9101,11 @@ Player properties need to be saved manually.
     -- Defines the maximum and default HP of the object
     -- For Lua entities the maximum is not enforced.
     -- For players this defaults to `core.PLAYER_MAX_HP_DEFAULT` (20).
-    
+
     breath_max = 0,
     -- Defines the maximum amount of "breath" for the object.
     -- For players only. Defaults to `core.PLAYER_MAX_BREATH_DEFAULT` (10).
-    
+
     zoom_fov = 0.0,
     -- For players only. Zoom FOV in degrees.
     -- Note that zoom loads and/or generates world beyond the server's

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9101,9 +9101,11 @@ Player properties need to be saved manually.
     -- Defines the maximum and default HP of the object
     -- For Lua entities the maximum is not enforced.
     -- For players this defaults to `core.PLAYER_MAX_HP_DEFAULT` (20).
+    
     breath_max = 0,
     -- Defines the maximum amount of "breath" for the object.
     -- For players only. Defaults to `core.PLAYER_MAX_BREATH_DEFAULT` (10).
+    
     zoom_fov = 0.0,
     -- For players only. Zoom FOV in degrees.
     -- Note that zoom loads and/or generates world beyond the server's

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9101,6 +9101,7 @@ Player properties need to be saved manually.
     -- Defines the maximum and default HP of the object
     -- For Lua entities the maximum is not enforced.
     -- For players this defaults to `core.PLAYER_MAX_HP_DEFAULT` (20).
+    -- For other entities this is overridden to a value of 10.
 
     breath_max = 0,
     -- Defines the maximum amount of "breath" for the object.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9100,11 +9100,13 @@ Player properties need to be saved manually.
     hp_max = 10,
     -- Defines the maximum and default HP of the entity
     -- For Lua entities the maximum is not enforced.
-    -- For players this defaults to `core.PLAYER_MAX_HP_DEFAULT`.
+    -- For players this defaults to `core.PLAYER_MAX_HP_DEFAULT` (20).
+    -- `core.PLAYER_MAX_HP_DEFAULT` is defined in `builtin/game/constants.lua`
 
     breath_max = 0,
-    -- For players only. Defaults to `core.PLAYER_MAX_BREATH_DEFAULT`.
-
+    -- Defines the maximum amount of "breath" for the entity.
+    -- For players only. Defaults to `core.PLAYER_MAX_BREATH_DEFAULT` (10).
+    -- `core.PLAYER_MAX_BREATH_DEFAULT` is defined in `builtin/game/constants.lua`
     zoom_fov = 0.0,
     -- For players only. Zoom FOV in degrees.
     -- Note that zoom loads and/or generates world beyond the server's

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9098,14 +9098,14 @@ Player properties need to be saved manually.
 ```lua
 {
     hp_max = 10,
-    -- Defines the maximum and default HP of the object
-    -- For Lua entities the maximum is not enforced.
-    -- For players this defaults to `core.PLAYER_MAX_HP_DEFAULT` (20).
-    -- For other entities this is overridden to a value of 10.
+    -- Defines the maximum and default HP of the object.
+    -- For Lua entities, the maximum is not enforced.
+    -- For players, this defaults to `core.PLAYER_MAX_HP_DEFAULT` (20).
+    -- For Lua entities, the default is 10.
 
     breath_max = 0,
-    -- Defines the maximum amount of "breath" for the object.
-    -- For players only. Defaults to `core.PLAYER_MAX_BREATH_DEFAULT` (10).
+    -- For players only. Defines the maximum amount of "breath" for the player.
+    -- Defaults to `core.PLAYER_MAX_BREATH_DEFAULT` (10).
 
     zoom_fov = 0.0,
     -- For players only. Zoom FOV in degrees.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9098,15 +9098,12 @@ Player properties need to be saved manually.
 ```lua
 {
     hp_max = 10,
-    -- Defines the maximum and default HP of the entity
+    -- Defines the maximum and default HP of the object
     -- For Lua entities the maximum is not enforced.
     -- For players this defaults to `core.PLAYER_MAX_HP_DEFAULT` (20).
-    -- `core.PLAYER_MAX_HP_DEFAULT` is defined in `builtin/game/constants.lua`
-
     breath_max = 0,
-    -- Defines the maximum amount of "breath" for the entity.
+    -- Defines the maximum amount of "breath" for the object.
     -- For players only. Defaults to `core.PLAYER_MAX_BREATH_DEFAULT` (10).
-    -- `core.PLAYER_MAX_BREATH_DEFAULT` is defined in `builtin/game/constants.lua`
     zoom_fov = 0.0,
     -- For players only. Zoom FOV in degrees.
     -- Note that zoom loads and/or generates world beyond the server's


### PR DESCRIPTION

- Goal
  - This PR is intended to make it more clear in the api documentation what the default values are for players.
- How does the PR work?
  - It simply updates the documentation in lua_api.md.
- Does it resolve any reported issue?
 #14880 
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
  - Not directly I don't think? Just a documentation update :)
- If not a bug fix, why is this PR needed? What usecases does it solve?
  - It puts the current information in a more accessible location to the people who want to access it. Also mentions where this information is coming from at all so someone utilizing it doesn't have to rely on the comment in the documentation as the source of truth.
  

This PR is Ready for Review!