### PR TITLE
Allow non-normalized weights in glTF models

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -309,17 +309,24 @@ it unlocks no special rendering features.
 Binary glTF (`.glb`) files are supported and recommended over `.gltf` files
 due to their space savings.
 
-This means that many glTF features are not supported *yet*, including:
+Bone weights should be normalized, e.g. using ["normalize all" in Blender](https://docs.blender.org/manual/en/4.2/grease_pencil/modes/weight_paint/weights_menu.html#normalize-all).
+
+You can use the [Khronos glTF validator](https://github.com/KhronosGroup/glTF-Validator)
+to check whether a model is a valid glTF file.
+
+Many glTF features are not supported *yet*, including:
 
 * Animations
   * Only a single animation is supported, use frame ranges within this animation.
+  * Only linear interpolation is supported.
 * Cameras
 * Materials
   * Only base color textures are supported
   * Backface culling is overridden
   * Double-sided materials don't work
 * Alternative means of supplying data
-  * Embedded images
+  * Embedded images. You can use `gltfutil.py` from the
+    [modding tools](https://github.com/minetest/modtools) to strip or extract embedded images.
   * References to files via URIs
 
 Textures are supplied solely via the same means as for the other model file formats:

--- a/irr/src/CGLTFMeshFileLoader.cpp
+++ b/irr/src/CGLTFMeshFileLoader.cpp
@@ -313,16 +313,16 @@ std::array<f32, N> SelfType::getNormalizedValues(
 	std::array<f32, N> values;
 	if (std::holds_alternative<Accessor<std::array<u8, N>>>(accessor)) {
 		const auto u8s = std::get<Accessor<std::array<u8, N>>>(accessor).get(i);
-		for (u8 j = 0; j < N; ++j)
+		for (std::size_t j = 0; j < N; ++j)
 			values[j] = static_cast<f32>(u8s[j]) / std::numeric_limits<u8>::max();
 	} else if (std::holds_alternative<Accessor<std::array<u16, N>>>(accessor)) {
 		const auto u16s = std::get<Accessor<std::array<u16, N>>>(accessor).get(i);
-		for (u8 j = 0; j < N; ++j)
+		for (std::size_t j = 0; j < N; ++j)
 			values[j] = static_cast<f32>(u16s[j]) / std::numeric_limits<u16>::max();
 	} else {
 		values = std::get<Accessor<std::array<f32, N>>>(accessor).get(i);
 		if constexpr (validate) {
-			for (u8 j = 0; j < N; ++j) {
+			for (std::size_t j = 0; j < N; ++j) {
 				if (values[j] < 0 || values[j] > 1)
 					throw std::runtime_error("invalid normalized value");
 			}

--- a/irr/src/CGLTFMeshFileLoader.h
+++ b/irr/src/CGLTFMeshFileLoader.h
@@ -91,7 +91,7 @@ private:
 			const tiniergltf::GlTF &model,
 			const std::size_t accessorIdx);
 
-	template <std::size_t N>
+	template <std::size_t N, bool validate = true>
 	static std::array<f32, N> getNormalizedValues(
 			const NormalizedValuesAccessor<N> &accessor,
 			const std::size_t i);
@@ -118,7 +118,7 @@ private:
 		std::size_t getPrimitiveCount(const std::size_t meshIdx) const;
 
 		void load();
-		const std::vector<std::string> &getWarnings() {
+		const std::unordered_set<std::string> &getWarnings() {
 			return warnings;
 		}
 
@@ -129,9 +129,9 @@ private:
 		std::vector<std::function<void()>> m_mesh_loaders;
 		std::vector<CSkinnedMesh::SJoint *> m_loaded_nodes;
 
-		std::vector<std::string> warnings;
+		std::unordered_set<std::string> warnings;
 		void warn(const std::string &warning) {
-			warnings.push_back(warning);
+			warnings.insert(warning);
 		}
 
 		void copyPositions(const std::size_t accessorIdx,


### PR DESCRIPTION
We are being lax here, but the glTF specification just requires that "when the weights are stored using float component type, their linear sum SHOULD be as close as reasonably possible to 1.0 for a given vertex"

In particular weights > 1 and weight sums well below or above 1 can be observed in models exported by Blender if they aren't manually normalized. These fail the glTF validator but Irrlicht normalizes weights itself so we can support them just fine.

The docs have been updated to recommend normalizing weights (as well as documenting the status of interpolation support).

Weights < 0, most of them close to 0, also occur. Consistent with Irrlicht, we ignore them, but we also raise a warning.