### PR TITLE
`core.after`: Improve documentation details about how `time` is handled

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6927,10 +6927,9 @@ Timing
       started at least `time` seconds after the last time a server-step started,
       measured with globalstep dtime.
     * In particular this can result in relatively large delays if `time` is close
-      to the server-step dtime. For example, with a target server-step of 0.09 s
-      (the engine uses the target as a lower bound for the actual server-step
-      dtime), `minetest.after(0.09, ...)` usually waits two steps, resulting in
-      a delay of about 0.18 s.
+      to the server-step dtime. For example, with a target server-step of 0.09 s,
+      `minetest.after(0.09, ...)` usually waits two steps, resulting in a delay
+      of about 0.18 s.
     * If `time` is `0`, the job is executed in the next step.
 
 * `job:cancel()`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6928,7 +6928,7 @@ Timing
       measured with globalstep dtime.
     * In particular this can result in relatively large delays if `time` is close
       to the server-step dtime. For example, with a target server-step of 0.09 s,
-      `minetest.after(0.09, ...)` usually waits two steps, resulting in a delay
+      `minetest.after(0.09, ...)` often waits two steps, resulting in a delay
       of about 0.18 s.
     * If `time` is `0`, the job is executed in the next step.
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6923,9 +6923,10 @@ Timing
     * Optional: Variable number of arguments that are passed to `func`
     * Jobs set for earlier times are executed earlier. If multiple jobs expire
       at exactly the same time, then they are executed in registration order.
-    * `time` is a lower bound. The job is executed in the first globalstep that
-      started at least `time` seconds after the current globalstep started.
-      If `time` is `0`, it's executed in the next step.
+    * `time` is a lower bound. The job is executed in the first server-step that
+      started at least `time` seconds after the last time a server-step started,
+      measured with globalstep dtime.
+    * If `time` is `0`, the job is executed in the next step.
 
 * `job:cancel()`
     * Cancels the job function from being called

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6923,6 +6923,9 @@ Timing
     * Optional: Variable number of arguments that are passed to `func`
     * Jobs set for earlier times are executed earlier. If multiple jobs expire
       at exactly the same time, then they are executed in registration order.
+    * `time` is a lower bound. The job is executed in the first globalstep that
+      started at least `time` seconds after the current globalstep started.
+      If `time` is `0`, it's executed in the next step.
 
 * `job:cancel()`
     * Cancels the job function from being called

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6926,6 +6926,11 @@ Timing
     * `time` is a lower bound. The job is executed in the first server-step that
       started at least `time` seconds after the last time a server-step started,
       measured with globalstep dtime.
+      In particular this can result in relatively large delays if `time` is close
+      to the server-step dtime. For example, with a target server-step of 0.09 s
+      (the engine uses the target as a lower bound for the actual server-step
+      dtime), `minetest.after(0.09, ...)` usually waits two steps, resulting in
+      a delay of about 0.18 s.
     * If `time` is `0`, the job is executed in the next step.
 
 * `job:cancel()`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6928,8 +6928,8 @@ Timing
       measured with globalstep dtime.
     * In particular this can result in relatively large delays if `time` is close
       to the server-step dtime. For example, with a target server-step of 0.09 s,
-      `minetest.after(0.09, ...)` often waits two steps, resulting in a delay
-      of about 0.18 s.
+      `core.after(0.09, ...)` often waits two steps, resulting in a delay of about
+      0.18 s.
     * If `time` is `0`, the job is executed in the next step.
 
 * `job:cancel()`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6926,7 +6926,7 @@ Timing
     * `time` is a lower bound. The job is executed in the first server-step that
       started at least `time` seconds after the last time a server-step started,
       measured with globalstep dtime.
-      In particular this can result in relatively large delays if `time` is close
+    * In particular this can result in relatively large delays if `time` is close
       to the server-step dtime. For example, with a target server-step of 0.09 s
       (the engine uses the target as a lower bound for the actual server-step
       dtime), `minetest.after(0.09, ...)` usually waits two steps, resulting in


### PR DESCRIPTION
Fixes #15193?

cc @Zughy 

## To do

This PR is a Ready for Review.

## How to test

Read.
