### PR TITLE
Use the <1ms left over server-step sleep time in next step

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -205,7 +205,11 @@ public:
 
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(float dtime, bool initial_step = false);
-	void Receive(float timeout);
+	// timeout: How long this function should take, in seconds. It waits this long
+	//          even if there are some incoming packets. (Negative values allowed.)
+	// Returns the remaining time from timeout (timeout minus time it actually
+	// took), can be negative (took too long) or positive (<1 ms remaining).
+	float Receive(float timeout);
 	void yieldToOtherThreads(float dtime);
 
 	PlayerSAO* StageTwoClientInit(session_t peer_id);


### PR DESCRIPTION
In master, the average of the actual dtime is 0-1ms lower than the target dtime. This is because `Server::Receive` can't sleep more fine grained than 1ms, and in master we just sleep shorter if <1 ms is left.
With this PR, if a step was shorter, the next one will sleep up to this time longer, and again carries the remaining time to the next step.

The check to yield to other threads, added by #15151, is also changed. It used to work fine with the `<`, because if there was no lag, the server steps were always shorter than target, but this is no longer the case.

## To do

This PR is a Ready for Review.

## How to test

* https://codeberg.org/Desour/test_tmp/src/branch/different_globalstep_15193/init.lua
  (Mostly taken from #15193.)

sfan5's, edited for globalstep dtime:
with `dedicated_server_step=0.1`
```
master:
realtime   : N=50 μ=194.856700 σ=19.338354 MIN=99.969000 MAX=200.761000
ingame time: N=50 μ=194.797759 σ=19.319432 MIN=100.013003 MAX=199.372999
dtime      : N=99 μ=98.382707 σ=9.940208 MIN=0.000000 MAX=100.310996
actualdtime: N=98 μ=99.429184 σ=0.397058 MIN=99.182000 MAX=102.767000
realtime   : N=50 μ=198.672880 σ=0.270490 MIN=198.367000 MAX=199.345000
ingame time: N=50 μ=198.662179 σ=0.265775 MIN=198.368996 MAX=199.264996
dtime      : N=100 μ=99.331090 σ=0.179224 MIN=99.170998 MAX=99.955998
actualdtime: N=100 μ=99.336430 σ=0.183156 MIN=99.174000 MAX=99.978000
realtime   : N=50 μ=198.876920 σ=0.261565 MIN=198.458000 MAX=199.411000
ingame time: N=50 μ=198.864579 σ=0.268155 MIN=198.413000 MAX=199.442998
dtime      : N=100 μ=99.432290 σ=0.170840 MIN=99.188000 MAX=99.811003
actualdtime: N=100 μ=99.438440 σ=0.168482 MIN=99.193000 MAX=99.818000
realtime   : N=50 μ=198.842640 σ=0.223919 MIN=198.446000 MAX=199.496000
ingame time: N=50 μ=198.830879 σ=0.224843 MIN=198.449001 MAX=199.478000
dtime      : N=100 μ=99.415440 σ=0.164264 MIN=99.194996 MAX=99.919997
actualdtime: N=100 μ=99.421310 σ=0.166612 MIN=99.186000 MAX=99.930000
realtime   : N=50 μ=196.802520 σ=13.826349 MIN=100.039000 MAX=199.640000
ingame time: N=50 μ=196.790420 σ=13.829278 MIN=100.005999 MAX=199.627005
dtime      : N=99 μ=99.389101 σ=0.189529 MIN=99.187002 MAX=100.073002
actualdtime: N=99 μ=99.395212 σ=0.192925 MIN=99.190000 MAX=100.094000

PR:
realtime   : N=50 μ=154.150840 σ=49.564909 MIN=100.201000 MAX=202.016000
ingame time: N=50 μ=154.095119 σ=49.521979 MIN=100.195996 MAX=200.497001
dtime      : N=78 μ=98.778923 σ=11.268945 MIN=0.000000 MAX=101.222001
actualdtime: N=77 μ=100.112143 σ=0.587600 MIN=99.229000 MAX=102.592000
realtime   : N=50 μ=152.095140 σ=49.605717 MIN=100.204000 MAX=200.392000
ingame time: N=50 μ=152.086900 σ=49.602426 MIN=100.206003 MAX=200.391993
dtime      : N=76 μ=100.057171 σ=0.515011 MIN=99.210002 MAX=100.920998
actualdtime: N=76 μ=100.062618 σ=0.518149 MIN=99.216000 MAX=100.951000
realtime   : N=50 μ=162.110480 σ=48.252553 MIN=100.210000 MAX=200.429000
ingame time: N=50 μ=162.100819 σ=48.259332 MIN=100.198001 MAX=200.417995
dtime      : N=81 μ=100.062234 σ=0.507737 MIN=99.216998 MAX=100.745998
actualdtime: N=81 μ=100.068173 σ=0.510182 MIN=99.207000 MAX=100.758000
realtime   : N=50 μ=150.073300 σ=49.746548 MIN=100.002000 MAX=200.535000
ingame time: N=50 μ=150.063939 σ=49.744950 MIN=100.009002 MAX=200.499997
dtime      : N=75 μ=100.042626 σ=0.497575 MIN=99.186003 MAX=101.053998
actualdtime: N=75 μ=100.048867 σ=0.496471 MIN=99.204000 MAX=101.037000
```
As you can see, a side effect is that if you have exactly the target server step as after time, you'll in half of the times wait 1 step and in the other half 2 steps.
This is not particularly nice if the modder wants consistently long waits.

An alternative (proposed by grorp) would be to always sleep a little bit (<1ms) too long. But then:
* The average would be wrong again.
* It would just move the value where it's exactly between by like 0.5ms. You can see this if you `after` in master with `0.0995`:
```
master, with sfan5::target=0.0995, setting/target=0.1:
realtime   : N=51 μ=128.830863 σ=45.223772 MIN=99.532000 MAX=201.046000
ingame time: N=51 μ=128.776333 σ=45.152801 MIN=99.527001 MAX=198.959000
dtime      : N=67 μ=98.023776 σ=12.067351 MIN=0.000000 MAX=100.253001
actualdtime: N=66 μ=99.569167 σ=0.469942 MIN=99.199000 MAX=103.023000
realtime   : N=51 μ=119.051059 σ=39.324804 MIN=99.475000 MAX=199.029000
ingame time: N=51 μ=119.042882 σ=39.331276 MIN=99.518001 MAX=198.976003
dtime      : N=61 μ=99.527655 σ=0.167477 MIN=99.179000 MAX=99.871002
actualdtime: N=61 μ=99.534492 σ=0.174442 MIN=99.151000 MAX=99.877000
realtime   : N=51 μ=124.903804 σ=43.234061 MIN=99.497000 MAX=199.121000
ingame time: N=51 μ=124.894490 σ=43.217724 MIN=99.523000 MAX=199.154004
dtime      : N=64 μ=99.525297 σ=0.179325 MIN=99.214002 MAX=100.230999
actualdtime: N=64 μ=99.532734 σ=0.176622 MIN=99.209000 MAX=100.238000
```