### PR TITLE
DevTest: Change "Minetest" to "Luanti"

### DIFF
--- a/games/devtest/LICENSE.txt
+++ b/games/devtest/LICENSE.txt
@@ -1,4 +1,4 @@
 License information for Development Test
 ----------------------------------------
 
-The same license as for Minetest applies.
+The same license as for Luanti applies.

--- a/games/devtest/game.conf
+++ b/games/devtest/game.conf
@@ -1,4 +1,4 @@
 title = Development Test
-description = Testing environment to help with testing the engine features of Minetest. It can also be helpful in mod development.
+description = Testing environment to help with testing the engine features of Luanti. It can also be helpful in mod development.
 first_mod = first_mod
 last_mod = last_mod

--- a/games/devtest/mods/broken/init.lua
+++ b/games/devtest/mods/broken/init.lua
@@ -1,4 +1,4 @@
--- Register stuff with empty definitions to test if Minetest fallback options
+-- Register stuff with empty definitions to test if Luanti fallback options
 -- for these things work properly.
 
 -- The itemstrings are deliberately kept descriptive to keep them easy to

--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -1,5 +1,5 @@
 --[[ Drawtype Test: This file tests out and provides examples for
-all drawtypes in Minetest. It is attempted to keep the node
+all drawtypes in Luanti. It is attempted to keep the node
 definitions as simple and minimal as possible to keep
 side-effects to a minimum.
 

--- a/games/devtest/mods/testnodes/textures.lua
+++ b/games/devtest/mods/testnodes/textures.lua
@@ -255,17 +255,17 @@ data_ck = nil
 
 The following nodes can be used to demonstrate the TGA format support.
 
-Minetest supports TGA types 1, 2, 3 & 10. While adding the support for
+Luanti supports TGA types 1, 2, 3 & 10. While adding the support for
 TGA type 9 (RLE-compressed, color-mapped) is easy, it is not advisable
-to do so, as it is not backwards compatible with any Minetest pre-5.5;
+to do so, as it is not backwards compatible with any engine version pre-5.5;
 content creators should therefore either use TGA type 1 or 10, or PNG.
 
 TODO: Types 1, 2 & 10 should have two test nodes each (i.e. bottom-top
 and top-bottom) for 16bpp (A1R5G5B5), 24bpp (B8G8R8), 32bpp (B8G8R8A8)
 colors.
 
-Note: Minetest requires the optional TGA footer for a texture to load.
-If a TGA image does not load in Minetest, append eight (8) null bytes,
+Note: Luanti requires the optional TGA footer for a texture to load.
+If a TGA image does not load in Luanti, append eight (8) null bytes,
 then the string “TRUEVISION-XFILE.”, then another null byte.
 
 ]]--

--- a/games/devtest/mods/testpathfinder/mod.conf
+++ b/games/devtest/mods/testpathfinder/mod.conf
@@ -1,2 +1,2 @@
 name = testpathfinder
-description = Tool to test Minetest's pathfinder function
+description = Tool to test Luanti's pathfinder function

--- a/games/devtest/mods/unittests/crafting.lua
+++ b/games/devtest/mods/unittests/crafting.lua
@@ -87,7 +87,7 @@ local function test_get_craft_result()
 	minetest.log("info", "[unittests] repairable tool crafting output.item:to_table(): "..dump(output.item:to_table()))
 	assert(output.item:get_name() == "unittests:repairable_tool")
 	-- Test the wear value.
-	-- See src/craftdef.cpp in Minetest source code for the formula. The formula to calculate
+	-- See src/craftdef.cpp in Luanti source code for the formula. The formula to calculate
 	-- the value 51187 is:
 	--    65536 - ((65536-60000)+(65536-60000)) + floor(additonal_wear * 65536 + 0.5) = 51187
 	-- where additional_wear = 0.05


### PR DESCRIPTION
As part of the renaming of Minetest to Luanti, this changes the word "Minetest" to "Luanti" in DevTest.