### PR TITLE
Added the option to hold objects in the left hand

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -730,6 +730,9 @@ show_debug (Show debug info) bool false
 #    Radius to use when the block bounds HUD feature is set to near blocks.
 show_block_bounds_radius_near (Block bounds HUD radius) int 4 0 1000
 
+#    Enables left-hand mode for wielded items in the HUD.
+enable_left_hand (Enable Left-Hand Mode) bool false
+
 [**Chat]
 
 #    Maximum number of recent chat messages to show

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -516,9 +516,22 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 tool_reload_ratio)
 	if (m_arm_inertia)
 		addArmInertia(yaw);
 
+	// Read left-handed mode from the settings
+	bool left_hand_mode = false;
+	if (g_settings->exists("enable_left_hand")) {
+	    left_hand_mode = g_settings->getBool("enable_left_hand");
+	}
+
 	// Position the wielded item
 	v3f wield_position = v3f(m_wieldmesh_offset.X, m_wieldmesh_offset.Y, 65);
 	v3f wield_rotation = v3f(-100, 120, -100);
+
+	// Invert the X position when left-handed mode is active
+	if (left_hand_mode) {
+	    wield_position.X = -wield_position.X;
+	    wield_rotation.Y = -wield_rotation.Y + 270;
+	}
+
 	wield_position.Y += std::abs(m_wield_change_timer)*320 - 40;
 	if(m_digging_anim < 0.05 || m_digging_anim > 0.5)
 	{


### PR DESCRIPTION
# Left-handed mode

![Unbenannt](https://github.com/user-attachments/assets/7ba8b752-4b5e-4138-99be-667644a23a9c)

- left-handed-mode added
- added an entry in the settings menu

Add compact, short information about your PR for easier understanding:

- Goal of the PR: Add the option to use Minetest immersively even as a left-hander
- How does the PR work? Customise the camera.cpp
- Does it resolve any reported issue? No.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)? From my point of view, yes
- If not a bug fix, why is this PR needed? What usecases does it solve? See Goal

## To do

This PR is a Work in Progress

- [ ] Add left-handed-mode in 3d-person-view
- [x] Add an option in the settings menu to activate left-handed mode more easily
- [ ] Rewriting into a Lua-based implementation

## How to test

Activate the option "Enable Left-Hand Mode under "Settings -> Graphics and sound -> User interfaces -> HUD