### PR TITLE
Fix server steps shorter than dedicated_server_step since #13370

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2067,6 +2067,8 @@ ask_reconnect_on_crash (Ask to reconnect after crash) bool false
 #    Length of a server tick (the interval at which everything is generally updated),
 #    stated in seconds.
 #    Does not apply to sessions hosted from the client menu.
+#    This is a lower bound, i.e. server steps may not be shorter than this, but
+#    they are often longer.
 dedicated_server_step (Dedicated server step) float 0.09 0.0 1.0
 
 #    Whether players are shown to clients without any range limit.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6926,10 +6926,6 @@ Timing
     * `time` is a lower bound. The job is executed in the first server-step that
       started at least `time` seconds after the last time a server-step started,
       measured with globalstep dtime.
-    * In particular this can result in relatively large delays if `time` is close
-      to the server-step dtime. For example, with a target server-step of 0.09 s,
-      `core.after(0.09, ...)` often waits two steps, resulting in a delay of about
-      0.18 s.
     * If `time` is `0`, the job is executed in the next step.
 
 * `job:cancel()`

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1085,15 +1085,15 @@ void Server::AsyncRunStep(float dtime, bool initial_step)
 	m_shutdown_state.tick(dtime, this);
 }
 
-void Server::Receive(float timeout)
+void Server::Receive(float min_time)
 {
 	ZoneScoped;
 	auto framemarker = FrameMarker("Server::Receive()-frame").started();
 
 	const u64 t0 = porting::getTimeUs();
-	const float timeout_us = timeout * 1e6f;
+	const float min_time_us = min_time * 1e6f;
 	auto remaining_time_us = [&]() -> float {
-		return std::max(0.0f, timeout_us - (porting::getTimeUs() - t0));
+		return std::max(0.0f, min_time_us - (porting::getTimeUs() - t0));
 	};
 
 	NetworkPacket pkt;
@@ -1103,10 +1103,11 @@ void Server::Receive(float timeout)
 		peer_id = 0;
 		try {
 			// Round up since the target step length is the minimum step length,
-			// we only have millisecond precision and we don't want to busy-wait by calling
-			// ReceiveTimeoutMs(.., 0) repeatedly.
-			if (!m_con->ReceiveTimeoutMs(&pkt,
-					((u32)remaining_time_us() + 999) / 1000)) {
+			// we only have millisecond precision and we don't want to busy-wait
+			// by calling ReceiveTimeoutMs(.., 0) repeatedly.
+			const u32 cur_timeout_ms = std::ceil(remaining_time_us() / 1000.0f);
+
+			if (!m_con->ReceiveTimeoutMs(&pkt, cur_timeout_ms)) {
 				// No incoming data.
 				if (remaining_time_us() > 0.0f)
 					continue;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1104,12 +1104,10 @@ void Server::Receive(float timeout)
 			if (!m_con->ReceiveTimeoutMs(&pkt,
 					(u32)remaining_time_us() / 1000)) {
 				// No incoming data.
-				// Already break if there's 1ms left, as ReceiveTimeoutMs is too coarse
-				// and a faster server-step is better than busy waiting.
-				if (remaining_time_us() < 1000.0f)
-					break;
-				else
+				if (remaining_time_us() > 0.0f)
 					continue;
+				else
+					break;
 			}
 
 			peer_id = pkt.getPeerId();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1085,6 +1085,7 @@ void Server::AsyncRunStep(float dtime, bool initial_step)
 	m_shutdown_state.tick(dtime, this);
 }
 
+//! Receive all incoming packets and wait for at least `timeout` seconds.
 void Server::Receive(float timeout)
 {
 	ZoneScoped;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1085,7 +1085,6 @@ void Server::AsyncRunStep(float dtime, bool initial_step)
 	m_shutdown_state.tick(dtime, this);
 }
 
-//! Receive all incoming packets and wait for at least `timeout` seconds.
 void Server::Receive(float timeout)
 {
 	ZoneScoped;
@@ -1106,7 +1105,6 @@ void Server::Receive(float timeout)
 			// Round up since the target step length is the minimum step length,
 			// we only have millisecond precision and we don't want to busy-wait by calling
 			// ReceiveTimeoutMs(.., 0) repeatedly.
-			// Also be sure we don't wait if the remaining time is zero/negative.
 			if (!m_con->ReceiveTimeoutMs(&pkt,
 					((u32)remaining_time_us() + 999) / 1000)) {
 				// No incoming data.

--- a/src/server.h
+++ b/src/server.h
@@ -205,7 +205,7 @@ public:
 
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(float dtime, bool initial_step = false);
-	// Receive all incoming packets and wait for at least `timeout` seconds.
+	//! Receive all incoming packets and wait for at least `timeout` seconds.
 	void Receive(float timeout);
 	void yieldToOtherThreads(float dtime);
 

--- a/src/server.h
+++ b/src/server.h
@@ -205,6 +205,7 @@ public:
 
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(float dtime, bool initial_step = false);
+	// Receive all incoming packets and wait for at least `timeout` seconds.
 	void Receive(float timeout);
 	void yieldToOtherThreads(float dtime);
 

--- a/src/server.h
+++ b/src/server.h
@@ -205,8 +205,9 @@ public:
 
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(float dtime, bool initial_step = false);
-	// Receive all incoming packets and wait for at least `timeout` seconds.
-	void Receive(float timeout);
+	/// Receive and process all incoming packets. Sleep if the time goal isn't met.
+	/// @param min_time minimum time to take [s]
+	void Receive(float min_time);
 	void yieldToOtherThreads(float dtime);
 
 	PlayerSAO* StageTwoClientInit(session_t peer_id);

--- a/src/server.h
+++ b/src/server.h
@@ -205,7 +205,7 @@ public:
 
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(float dtime, bool initial_step = false);
-	//! Receive all incoming packets and wait for at least `timeout` seconds.
+	// Receive all incoming packets and wait for at least `timeout` seconds.
 	void Receive(float timeout);
 	void yieldToOtherThreads(float dtime);
 


### PR DESCRIPTION
Fixes #15193
Closes #15325

This is an alternative to #15325 (which does not fix #15193)

This PR makes `dedicated_server_step` a lower bound for step dtime on dedicated servers again. For explanation, see https://github.com/minetest/minetest/pull/15325#issuecomment-2436136992 and https://github.com/minetest/minetest/pull/15325#issuecomment-2436216151.

## To do

This PR is a Ready for Review.

## How to test

Confirm that this PR fixes #15193: Set `dedicated_server_step = 0.1`, download [the mod in question](https://content.minetest.net/packages/Zughy/block_league/) and see that the SMG shoots fast again on a dedicated server.

------

Or confirm that this PR does what it promises:

```lua
-- for dedicated_server_step = 0.1
core.register_globalstep(function(dtime)
  assert(dtime == 0 or dtime >= 0.1)
end)
```

The assertion succeeds on 5.8.0, fails on the master branch and succeeds again with this PR.

-----

Or use test code from https://codeberg.org/Desour/test_tmp/src/branch/different_globalstep_15193/init.lua to measure how the server step and `core.after` behave on a dedicated server. You'll see that `core.after` with the target server step as wait time works properly again. 
