### PR TITLE
Make `core.get_node_raw` a public API

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -741,16 +741,13 @@ core.noneitemdef_default = {  -- This is used for the hand and unknown items
 -- get_node implementation
 --
 
-local get_node_raw = core.get_node_raw
-core.get_node_raw = nil
-
 function core.get_node(pos)
-	local content, param1, param2 = get_node_raw(pos.x, pos.y, pos.z)
+	local content, param1, param2 = core.get_node_raw(pos.x, pos.y, pos.z)
 	return {name = core.get_name_from_content_id(content), param1 = param1, param2 = param2}
 end
 
 function core.get_node_or_nil(pos)
-	local content, param1, param2, pos_ok = get_node_raw(pos.x, pos.y, pos.z)
+	local content, param1, param2, pos_ok = core.get_node_raw(pos.x, pos.y, pos.z)
 	return pos_ok and
 			{name = core.get_name_from_content_id(content), param1 = param1, param2 = param2}
 			or nil

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6297,6 +6297,11 @@ Environment access
 * `core.get_node_or_nil(pos)`
     * Same as `get_node` but returns `nil` for unloaded areas.
     * Note that even loaded areas can contain "ignore" nodes.
+* `core.get_node_raw(x, y, z)`
+    * Low-level API returning numbers, not tables
+    * Returns `content_id`, `param1`, `param2`, and `pos_ok`
+    * The `content_id` can be mapped to a node name via `core.get_name_from_content_id`
+    * If `pos_ok` is false, the node is not yet loaded and the `content_id` is that of "ignore" nodes
 * `core.get_node_light(pos[, timeofday])`
     * Gets the light value at the given position. Note that the light value
       "inside" the node at the given position is returned, so you usually want


### PR DESCRIPTION
Closes #15317

The `core.get_node_raw` function is well-tested, as it powers the `core.get_node` function.

For certain applications, there is little benefit from using lua tables, and these can benefit from this low-level API.
In some cases, the lua voxel manipulator may be best, but in others the exact range that needs to be processed may be unknown, and access patterns may be sparse.

For example, some code might want to find the nearest air above or below a certain position. A VoxelManip is not well suited, because we do not know how far we need to search. At the same time, the criterion - air node - can be trivially checked on the content_id without going through tables and strings.
A more complex example, where the performance difference may be larger, is a path finder in lua. We all know that the current core pathfinder is not sufficiently powerful (it cannot handle mobs taller than 1 node). It is hard to predict how much area a pathfinder needs to explore (quite often a straight line +- a few nodes may be sufficient). Current pathfinders often have to load an area of a bounding box + a safety margin into some kind of voxel array, even when they may not need all of these nodes. At the same time, they usually will read this data exactly once, and never write it!

These applications could benefit from being allowed to use a cheap low-level API such as this.