### PR TITLE
Don't memset SEvent

### DIFF
--- a/irr/src/CIrrDeviceLinux.cpp
+++ b/irr/src/CIrrDeviceLinux.cpp
@@ -1581,7 +1581,7 @@ bool CIrrDeviceLinux::activateJoysticks(core::array<SJoystickInfo> &joystickInfo
 		fcntl(info.fd, F_SETFL, O_NONBLOCK);
 #endif
 
-		(void)memset(&info.persistentData, 0, sizeof(info.persistentData));
+		info.persistentData = {};
 		info.persistentData.EventType = irr::EET_JOYSTICK_INPUT_EVENT;
 		info.persistentData.JoystickEvent.Joystick = ActiveJoysticks.size();
 

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -713,7 +713,7 @@ bool CIrrDeviceSDL::run()
 
 	while (!Close && wrap_PollEvent(&SDL_event)) {
 		// os::Printer::log("event: ", core::stringc((int)SDL_event.type).c_str(),   ELL_INFORMATION);	// just for debugging
-		memset(&irrevent, 0, sizeof(irrevent));
+		irrevent = {};
 
 		switch (SDL_event.type) {
 		case SDL_MOUSEMOTION: {

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -1121,8 +1121,7 @@ void GUITable::sendTableEvent(s32 column, bool doubleclick)
 	m_sel_column = column;
 	m_sel_doubleclick = doubleclick;
 	if (Parent) {
-		SEvent e;
-		memset(&e, 0, sizeof e);
+		SEvent e{};
 		e.EventType = EET_GUI_EVENT;
 		e.GUIEvent.Caller = this;
 		e.GUIEvent.Element = 0;


### PR DESCRIPTION
Fixes a compiler warning reported by Desour:

> This is giving me `-Wclass-memaccess` warnings in `src/gui/guiTable.cpp` (it tries to memset an object of this now nontrivial type to 0).
> https://github.com/minetest/minetest/commit/4952f17df4546e580dcc6033be433e47e4a6615e#r147840504

## To do

This PR is a Ready for Review.

## How to test

Read, confirm that it is equivalent to the old version, I guess.
