### PR TITLE
Make Luanti buildable for macOS 10.15 (fix missing includes)

### DIFF
--- a/src/client/sound/sound_data.h
+++ b/src/client/sound/sound_data.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "ogg_file.h"
 #include <memory>
 #include <tuple>
+#include <vector>
 
 namespace sound {
 

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_bloated.h"
 #include "networkprotocol.h"
 #include <SColor.h>
+#include <vector>
 
 class NetworkPacket
 {

--- a/src/objdef.h
+++ b/src/objdef.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "util/basic_macros.h"
 #include "porting.h"
+#include <vector>
 
 class IGameDef;
 class NodeDefManager;


### PR DESCRIPTION
Add include of `<vector>` to fix declaration errors of `std::vector` variables.

Related to issue #15065.

## To do

This PR is  Ready for Review.
