### PR TITLE
Expose target server step dtime to Lua API

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5934,6 +5934,8 @@ Call these functions only at load time!
 * `core.register_globalstep(function(dtime))`
     * Called every server step, usually interval of 0.1s.
     * `dtime` is the time since last execution in seconds.
+    * You can get the target interval via `core.get_target_dtime()`.
+    * This is usually true: `dtime >= core.get_target_dtime()`
 * `core.register_on_mods_loaded(function())`
     * Called after mods have finished loading and before the media is cached or the
       aliases handled.
@@ -6378,6 +6380,12 @@ Environment access
 * `core.get_day_count()`: returns number days elapsed since world was
   created.
     * Time changes are accounted for.
+* `core.get_target_dtime()`: returns the target server step `dtime` in seconds.
+    * This is a lower bound, i.e. server steps may not be shorter than this,
+      but they are often longer.
+    * On dedicated servers, this value can be configured via the
+      `dedicated_server_step` setting in minetest.conf.
+    * See `core.register_globalstep`.
 * `core.find_node_near(pos, radius, nodenames, [search_center])`: returns
   pos or `nil`.
     * `radius`: using a maximum metric

--- a/games/devtest/mods/unittests/init.lua
+++ b/games/devtest/mods/unittests/init.lua
@@ -186,6 +186,7 @@ dofile(modpath .. "/metadata.lua")
 dofile(modpath .. "/raycast.lua")
 dofile(modpath .. "/inventory.lua")
 dofile(modpath .. "/load_time.lua")
+dofile(modpath .. "/step.lua")
 dofile(modpath .. "/on_shutdown.lua")
 dofile(modpath .. "/color.lua")
 

--- a/games/devtest/mods/unittests/step.lua
+++ b/games/devtest/mods/unittests/step.lua
@@ -1,0 +1,8 @@
+local last_target
+
+core.register_globalstep(function(dtime)
+	local target = core.get_target_dtime()
+	-- dtime only changes in the next step
+	assert(dtime == 0 or dtime >= target or dtime >= last_target)
+	last_target = target
+end)

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -781,6 +781,16 @@ int ModApiEnv::l_get_gametime(lua_State *L)
 	return 1;
 }
 
+// get_target_dtime()
+int ModApiEnv::l_get_target_dtime(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	auto server = getServer(L);
+	lua_pushnumber(L, server->getStepSettings().steplen);
+	return 1;
+}
+
 void ModApiEnvBase::collectNodeIds(lua_State *L, int idx, const NodeDefManager *ndef,
 	std::vector<content_t> &filter)
 {
@@ -1413,6 +1423,7 @@ void ModApiEnv::Initialize(lua_State *L, int top)
 	API_FCT(get_timeofday);
 	API_FCT(get_gametime);
 	API_FCT(get_day_count);
+	API_FCT(get_target_dtime);
 	API_FCT(find_node_near);
 	API_FCT(find_nodes_in_area);
 	API_FCT(find_nodes_in_area_under_air);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -155,6 +155,9 @@ private:
 	// get_day_count() -> int
 	static int l_get_day_count(lua_State *L);
 
+	// get_target_dtime()
+	static int l_get_target_dtime(lua_State *L);
+
 	// find_node_near(pos, radius, nodenames, search_center) -> pos or nil
 	// nodenames: eg. {"ignore", "group:tree"} or "default:dirt"
 	static int l_find_node_near(lua_State *L);


### PR DESCRIPTION
In https://github.com/minetest/minetest/issues/15193#issuecomment-2438924282, Desour suggested adding a way to get the target server step time. This PR implements that.

I like the idea because it allows me to add a regression test for #15330, but to be honest I don't know what other use cases would be ...? CC @Desour 

Also, I'm not sure if we're comfortable making this a part of the API since it means we can't change it anymore.

## To do

This PR is a Ready for Review.

## How to test

Run Devtest, see that there is no assertion failure.