### PR TITLE
Irrlicht 2D rendering: Avoid artifacts caused by bilinear downscaling + "repeat" texture wrapping

### DIFF
--- a/irr/src/CNullDriver.cpp
+++ b/irr/src/CNullDriver.cpp
@@ -108,13 +108,14 @@ CNullDriver::CNullDriver(io::IFileSystem *io, const core::dimension2d<u32> &scre
 	InitMaterial2D.ZBuffer = video::ECFN_DISABLED;
 	InitMaterial2D.UseMipMaps = false;
 	InitMaterial2D.forEachTexture([](auto &tex) {
-		// Using ETMINF_LINEAR_MIPMAP_NEAREST (bilinear) for 2D graphics looks
-		// much better and doesn't have any downsides (e.g. regarding pixel art).
+		// Using bilinear for downscaling for 2D graphics looks much better
+		// and doesn't blur pixel art (unlike bilinear for upscaling).
 		tex.MinFilter = video::ETMINF_LINEAR_MIPMAP_NEAREST;
 		tex.MagFilter = video::ETMAGF_NEAREST;
-		tex.TextureWrapU = video::ETC_REPEAT;
-		tex.TextureWrapV = video::ETC_REPEAT;
-		tex.TextureWrapW = video::ETC_REPEAT;
+		// Clamp to avoid artifacts caused by bilinear + repeat.
+		tex.TextureWrapU = video::ETC_CLAMP_TO_EDGE;
+		tex.TextureWrapV = video::ETC_CLAMP_TO_EDGE;
+		tex.TextureWrapW = video::ETC_CLAMP_TO_EDGE;
 	});
 	OverrideMaterial2D = InitMaterial2D;
 }


### PR DESCRIPTION
I saw a screenshot by erle on #minetest IRC (https://irc.minetest.net/minetest/2024-10-29#i_6212407) and it reminded of a similar rendering bug I saw with "PRANG!". This PR fixes that bug. It might also fix erle's problem, idk.

Bilinear filtering + "repeat" texture wrapping seems to cause artifacts at texture borders. This is probably because the pixel at the other side of the texture is considered for interpolation.

Screenshot on the "master" branch:
<img alt="screenshot before" src="https://github.com/user-attachments/assets/84bd8169-f7da-464e-b83c-62b1f887b270" width="512" />
There are artifacts at the borders of the light blue letter textures ("START", "INSTRUCTIONS", "CREDITS", "EXIT")

Screenshot with this PR:
<img alt="screenshot after" src="https://github.com/user-attachments/assets/f8ff959b-010a-4afe-ae72-f2025e97f44f" width="512" />

## To do

This PR is a Work in Progress.

- [ ] Figure out whether this breaks anything, i.e. whether Irrlicht was relying on "repeat" texture wrapping anywhere.

## How to test

Look at "PRANG!"