### PR TITLE
Fix model[] being lit wrongly if shaders are disabled

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -917,6 +917,9 @@ void GenericCAO::setNodeLight(const video::SColor &light_color)
 			return;
 		setColorParam(node, light_color);
 	} else {
+		// TODO refactor vertex colors to be separate from the other vertex attributes
+		// instead of mutating meshes / buffers for everyone via setMeshColor.
+		// (Note: There are a couple more places here where setMeshColor is used.)
 		if (m_meshnode) {
 			setMeshColor(m_meshnode->getMesh(), light_color);
 		} else if (m_animated_meshnode) {

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -9,6 +9,8 @@
 #include <IVideoDriver.h>
 #include "IAttributes.h"
 #include "porting.h"
+#include "client/mesh.h"
+#include "settings.h"
 
 GUIScene::GUIScene(gui::IGUIEnvironment *env, scene::ISceneManager *smgr,
 		   gui::IGUIElement *parent, core::recti rect, s32 id)
@@ -95,6 +97,10 @@ void GUIScene::draw()
 	// Continuous rotation
 	if (m_inf_rot)
 		rotateCamera(v3f(0.f, -0.03f * (float)dtime_ms, 0.f));
+
+	// Restore mesh color to full brightness
+	if (!g_settings->getBool("enable_shaders"))
+		setMeshColor(m_mesh->getMesh(), irr::video::SColor(0xFFFFFFFF));
 
 	m_smgr->drawAll();
 

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -98,7 +98,8 @@ void GUIScene::draw()
 	if (m_inf_rot)
 		rotateCamera(v3f(0.f, -0.03f * (float)dtime_ms, 0.f));
 
-	// Restore mesh color to full brightness
+	// HACK restore mesh vertex colors to full brightness:
+	// They may have been mutated in entity rendering code before.
 	if (!g_settings->getBool("enable_shaders"))
 		setMeshColor(m_mesh->getMesh(), irr::video::SColor(0xFFFFFFFF));
 


### PR DESCRIPTION
1. Install MTG, [i3](https://content.luanti.org/packages/mt-mods/i3/).
2. `/time 0`.
3. Voilà: 
![Screenshot from 2024-10-31 20-05-22](https://github.com/user-attachments/assets/df79d034-a949-42c4-8078-328eb43a141a)
4. This goes away pretty easily e.g. if you click into the text field.

The problem is that if shaders are disabled, we mutate mesh vertex colors so the model[] element inherits the same colors that were set before when rendering the player.

This PR fixes that by resetting the colors before rendering if shaders are disabled.

## How to test

With this PR, it should look like this on first open.

![Screenshot from 2024-10-31 20-05-32](https://github.com/user-attachments/assets/379d0893-9030-4280-8424-6144cee1b76d)

