### PR TITLE
JsonCPP: restore '1.0.0+' compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,7 @@ endif()
 
 # Library pack
 find_package(GMP REQUIRED)
-find_package(Json REQUIRED)
+find_package(Json 1.0.0 REQUIRED)
 find_package(Lua REQUIRED)
 if(NOT USE_LUAJIT)
 	add_subdirectory(lib/bitop)

--- a/lib/tiniergltf/tiniergltf.hpp
+++ b/lib/tiniergltf/tiniergltf.hpp
@@ -13,9 +13,16 @@
 #include <array>
 #include <optional>
 #include <limits>
+#include <memory> // unique_ptr
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
+
+#if JSONCPP_VERSION_HEXA < 0x01090000 /* 1.9.0 */
+namespace Json {
+	using String = JSONCPP_STRING; // Polyfill
+}
+#endif
 
 namespace tiniergltf {
 
@@ -1381,7 +1388,7 @@ static Json::Value readJson(Span<const char> span) {
 	Json::CharReaderBuilder builder;
 	const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
 	Json::Value json;
-	JSONCPP_STRING err;
+	Json::String err;
 	if (!reader->parse(span.ptr, span.end(), &json, &err))
 		throw std::runtime_error(std::string("invalid JSON: ") + err);
 	return json;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2048,9 +2048,6 @@ bool read_tree_def(lua_State *L, int idx, const NodeDefManager *ndef,
 }
 
 /******************************************************************************/
-#if defined(JSONCPP_STRING) || !(JSONCPP_VERSION_MAJOR < 1 || JSONCPP_VERSION_MINOR < 9)
-#define HAVE_JSON_STRING
-#endif
 
 // Returns depth of json value tree
 static int push_json_value_getdepth(const Json::Value &value)
@@ -2079,7 +2076,7 @@ static bool push_json_value_helper(lua_State *L, const Json::Value &value,
 			lua_pushnumber(L, value.asDouble());
 			break;
 		case Json::stringValue: {
-#ifdef HAVE_JSON_STRING
+#if JSONCPP_VERSION_HEXA >= 0x01000000 /* 1.0.0 */
 			const auto &str = value.asString();
 			lua_pushlstring(L, str.c_str(), str.size());
 #else
@@ -2101,7 +2098,7 @@ static bool push_json_value_helper(lua_State *L, const Json::Value &value,
 		case Json::objectValue:
 			lua_createtable(L, 0, value.size());
 			for (auto it = value.begin(); it != value.end(); ++it) {
-#ifdef HAVE_JSON_STRING
+#if JSONCPP_VERSION_HEXA >= 0x01060000 /* 1.6.0 */
 				const auto &str = it.name();
 				lua_pushlstring(L, str.c_str(), str.size());
 #else

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2049,6 +2049,10 @@ bool read_tree_def(lua_State *L, int idx, const NodeDefManager *ndef,
 
 /******************************************************************************/
 
+#if JSONCPP_VERSION_HEXA < 0x01000000 /* 1.0.0 */
+#warning "Your JsonCPP version is too old and might not be compatible."
+#endif
+
 // Returns depth of json value tree
 static int push_json_value_getdepth(const Json::Value &value)
 {
@@ -2076,13 +2080,8 @@ static bool push_json_value_helper(lua_State *L, const Json::Value &value,
 			lua_pushnumber(L, value.asDouble());
 			break;
 		case Json::stringValue: {
-#if JSONCPP_VERSION_HEXA >= 0x01000000 /* 1.0.0 */
 			const auto &str = value.asString();
 			lua_pushlstring(L, str.c_str(), str.size());
-#else
-			const char *str = value.asCString();
-			lua_pushstring(L, str ? str : "");
-#endif
 			break;
 		}
 		case Json::booleanValue:

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2049,10 +2049,6 @@ bool read_tree_def(lua_State *L, int idx, const NodeDefManager *ndef,
 
 /******************************************************************************/
 
-#if JSONCPP_VERSION_HEXA < 0x01000000 /* 1.0.0 */
-#warning "Your JsonCPP version is too old and might not be compatible."
-#endif
-
 // Returns depth of json value tree
 static int push_json_value_getdepth(const Json::Value &value)
 {


### PR DESCRIPTION
Previously, compiling on Ubuntu 20.04 would fail with the system-provided JsonCPP version (1.7.4). Which would satisfy the documented requirement of "1.0.0+".

Reported by thomas15 on IRC.

## To do

This PR is Ready for Review.

## How to test

```sh
git clone https://github.com/open-source-parsers/jsoncpp --depth 2 --branch 1.7.4
cd jsoncpp
cmake . -DJSONCPP_WITH_PKGCONFIG_SUPPORT=0 -DBUILD_SHARED_LIBS=1
make -j5
cmake --install . --prefix "$PWD/__install"

# Change the CMake configuration of Minetest/Luanti.
# Use the system-provided library and set the include and library path to the newly "installed" location.
```

To check whether the correct library was used for compiling:

```sh
# In the minetest/minetest clone root
ldd bin/luanti | grep jsoncpp
``` 
