### PR TITLE
ContentDB: Fix repeated Forum URL prepending

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,7 @@ endif()
 
 # Library pack
 find_package(GMP REQUIRED)
-find_package(Json REQUIRED)
+find_package(Json 1.0.0 REQUIRED)
 find_package(Lua REQUIRED)
 if(NOT USE_LUAJIT)
 	add_subdirectory(lib/bitop)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Further documentation
 ----------------------
 - Website: https://www.minetest.net/
 - Wiki: https://wiki.minetest.net/
-- Forum: https://forum.minetest.net/
+- Forum: https://forum.luanti.org/
 - GitHub: https://github.com/minetest/minetest/
 - [Developer documentation](doc/developing/)
 - [doc/](doc/) directory of source distribution

--- a/builtin/mainmenu/content/contentdb.lua
+++ b/builtin/mainmenu/content/contentdb.lua
@@ -563,30 +563,32 @@ function contentdb.filter_packages(query, by_type)
 	end
 
 	local keywords = {}
-	for word in query:lower():gmatch("%S+") do
-		table.insert(keywords, word)
+	for word in query:gmatch("%S+") do
+		table.insert(keywords, word:lower())
+	end
+
+	local function contains_all_keywords(str)
+		str = str:lower()
+		for _, keyword in ipairs(keywords) do
+			if not str:find(keyword, 1, true) then
+				return false
+			end
+		end
+		return true
 	end
 
 	local function matches_keywords(package)
-		for k = 1, #keywords do
-			local keyword = keywords[k]
-
-			if string.find(package.name:lower(), keyword, 1, true) or
-					string.find(package.title:lower(), keyword, 1, true) or
-					string.find(package.author:lower(), keyword, 1, true) or
-					string.find(package.short_description:lower(), keyword, 1, true) then
-				return true
-			end
-		end
-
-		return false
+		return contains_all_keywords(package.name) or
+				contains_all_keywords(package.title) or
+				contains_all_keywords(package.author) or
+				contains_all_keywords(package.short_description)
 	end
 
 	contentdb.packages = {}
 	for _, package in pairs(contentdb.packages_full) do
 		if (query == "" or matches_keywords(package)) and
 				(by_type == nil or package.type == by_type) then
-			contentdb.packages[#contentdb.packages + 1] = package
+			table.insert(contentdb.packages, package)
 		end
 	end
 end

--- a/builtin/mainmenu/content/dlg_package.lua
+++ b/builtin/mainmenu/content/dlg_package.lua
@@ -51,7 +51,7 @@ local function get_formspec(data)
 					return
 				end
 
-				if info.forums then
+				if type(info.forums) == "number" then
 					info.forums = "https://forum.minetest.net/viewtopic.php?t=" .. info.forums
 				end
 

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -195,8 +195,7 @@ local function search_server_list(input)
 	-- setup the keyword list
 	local keywords = {}
 	for word in input:gmatch("%S+") do
-		word = word:gsub("(%W)", "%%%1")
-		table.insert(keywords, word)
+		table.insert(keywords, word:lower())
 	end
 
 	if #keywords == 0 then
@@ -207,26 +206,17 @@ local function search_server_list(input)
 
 	-- Search the serverlist
 	local search_result = {}
-	for i = 1, #serverlistmgr.servers do
-		local server = serverlistmgr.servers[i]
-		local found = 0
-		for k = 1, #keywords do
-			local keyword = keywords[k]
-			if server.name then
-				local sername = server.name:lower()
-				local _, count = sername:gsub(keyword, keyword)
-				found = found + count * 4
-			end
-
-			if server.description then
-				local desc = server.description:lower()
-				local _, count = desc:gsub(keyword, keyword)
-				found = found + count * 2
-			end
+	for i, server in ipairs(serverlistmgr.servers) do
+		local name_matches, description_matches = true, true
+		for _, keyword in ipairs(keywords) do
+			name_matches = name_matches and not not
+					(server.name or ""):lower():find(keyword, 1, true)
+			description_matches = description_matches and not not
+					(server.description or ""):lower():find(keyword, 1, true)
 		end
-		if found > 0 then
-			local points = (#serverlistmgr.servers - i) / 5 + found
-			server.points = points
+		if name_matches or description_matches then
+			server.points = #serverlistmgr.servers - i
+					+ (name_matches and 50 or 0)
 			table.insert(search_result, server)
 		end
 	end

--- a/doc/direction.md
+++ b/doc/direction.md
@@ -6,9 +6,9 @@ The long-term roadmaps, aims, and guiding philosophies are set out using the
 following documents:
 
 * [What is Minetest?](http://c55.me/blog/?p=1491)
-* [celeron55's roadmap](https://forum.minetest.net/viewtopic.php?t=9177)
+* [celeron55's roadmap](https://forum.luanti.org/viewtopic.php?t=9177)
 * [celeron55's comment in "A clear mission statement for Minetest is missing"](https://github.com/minetest/minetest/issues/3476#issuecomment-167399287)
-* [Core developer to-do/wish lists](https://forum.minetest.net/viewforum.php?f=7)
+* [Core developer to-do/wish lists](https://forum.luanti.org/viewforum.php?f=7)
 
 ## 2. Medium-term Roadmap
 

--- a/lib/tiniergltf/tiniergltf.hpp
+++ b/lib/tiniergltf/tiniergltf.hpp
@@ -13,9 +13,16 @@
 #include <array>
 #include <optional>
 #include <limits>
+#include <memory> // unique_ptr
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
+
+#if JSONCPP_VERSION_HEXA < 0x01090000 /* 1.9.0 */
+namespace Json {
+	using String = JSONCPP_STRING; // Polyfill
+}
+#endif
 
 namespace tiniergltf {
 
@@ -1381,7 +1388,7 @@ static Json::Value readJson(Span<const char> span) {
 	Json::CharReaderBuilder builder;
 	const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
 	Json::Value json;
-	JSONCPP_STRING err;
+	Json::String err;
 	if (!reader->parse(span.ptr, span.end(), &json, &err))
 		throw std::runtime_error(std::string("invalid JSON: ") + err);
 	return json;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -917,6 +917,9 @@ void GenericCAO::setNodeLight(const video::SColor &light_color)
 			return;
 		setColorParam(node, light_color);
 	} else {
+		// TODO refactor vertex colors to be separate from the other vertex attributes
+		// instead of mutating meshes / buffers for everyone via setMeshColor.
+		// (Note: There are a couple more places here where setMeshColor is used.)
 		if (m_meshnode) {
 			setMeshColor(m_meshnode->getMesh(), light_color);
 		} else if (m_animated_meshnode) {

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -9,6 +9,8 @@
 #include <IVideoDriver.h>
 #include "IAttributes.h"
 #include "porting.h"
+#include "client/mesh.h"
+#include "settings.h"
 
 GUIScene::GUIScene(gui::IGUIEnvironment *env, scene::ISceneManager *smgr,
 		   gui::IGUIElement *parent, core::recti rect, s32 id)
@@ -95,6 +97,11 @@ void GUIScene::draw()
 	// Continuous rotation
 	if (m_inf_rot)
 		rotateCamera(v3f(0.f, -0.03f * (float)dtime_ms, 0.f));
+
+	// HACK restore mesh vertex colors to full brightness:
+	// They may have been mutated in entity rendering code before.
+	if (!g_settings->getBool("enable_shaders"))
+		setMeshColor(m_mesh->getMesh(), irr::video::SColor(0xFFFFFFFF));
 
 	m_smgr->drawAll();
 

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -5,7 +5,7 @@ Copyright (C) 2016-2019 Duane Robertson <duane@duanerobertson.com>
 Copyright (C) 2016-2019 paramat
 
 Based on Valleys Mapgen by Gael de Sailly
-(https://forum.minetest.net/viewtopic.php?f=9&t=11430)
+(https://forum.luanti.org/viewtopic.php?f=9&t=11430)
 and mapgen_v7, mapgen_flat by kwolekr and paramat.
 
 Licensing changed by permission of Gael de Sailly.

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -5,7 +5,7 @@ Copyright (C) 2016-2019 Duane Robertson <duane@duanerobertson.com>
 Copyright (C) 2016-2019 paramat
 
 Based on Valleys Mapgen by Gael de Sailly
-(https://forum.minetest.net/viewtopic.php?f=9&t=11430)
+(https://forum.luanti.org/viewtopic.php?f=9&t=11430)
 and mapgen_v7, mapgen_flat by kwolekr and paramat.
 
 Licensing changed by permission of Gael de Sailly.

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -932,7 +932,7 @@ double perf_freq = get_perf_freq();
  * This appears to be a combination of unfortunate allocation order/fragmentation
  * and the fact that glibc does not call madvise(MADV_DONTNEED) on its own.
  * Some other allocators were also affected, jemalloc and musl libc were not.
- * read more: <https://forum.minetest.net/viewtopic.php?t=30509>
+ * read more: <https://forum.luanti.org/viewtopic.php?t=30509>
  *
  * As a workaround we track freed memory coarsely and call malloc_trim() once a
  * certain amount is reached.

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2048,9 +2048,6 @@ bool read_tree_def(lua_State *L, int idx, const NodeDefManager *ndef,
 }
 
 /******************************************************************************/
-#if defined(JSONCPP_STRING) || !(JSONCPP_VERSION_MAJOR < 1 || JSONCPP_VERSION_MINOR < 9)
-#define HAVE_JSON_STRING
-#endif
 
 // Returns depth of json value tree
 static int push_json_value_getdepth(const Json::Value &value)
@@ -2079,13 +2076,8 @@ static bool push_json_value_helper(lua_State *L, const Json::Value &value,
 			lua_pushnumber(L, value.asDouble());
 			break;
 		case Json::stringValue: {
-#ifdef HAVE_JSON_STRING
 			const auto &str = value.asString();
 			lua_pushlstring(L, str.c_str(), str.size());
-#else
-			const char *str = value.asCString();
-			lua_pushstring(L, str ? str : "");
-#endif
 			break;
 		}
 		case Json::booleanValue:
@@ -2101,7 +2093,7 @@ static bool push_json_value_helper(lua_State *L, const Json::Value &value,
 		case Json::objectValue:
 			lua_createtable(L, 0, value.size());
 			for (auto it = value.begin(); it != value.end(); ++it) {
-#ifdef HAVE_JSON_STRING
+#if JSONCPP_VERSION_HEXA >= 0x01060000 /* 1.6.0 */
 				const auto &str = it.name();
 				lua_pushlstring(L, str.c_str(), str.size());
 #else


### PR DESCRIPTION
When clicking on an content db item over and over again, the forum url would keep being prepended with `https://forum.minetest.net/viewtopic.php?t=`, so it would become, for example:

`https://forum.minetest.net/viewtopic.php?t=https://forum.minetest.net/viewtopic.php?t=1234`

> [!NOTE]
> This PR fixes the issue but right now assumes that **info.forums is always of type "number"**

Note that the renaming is addressed in #15372 

## To do

This PR is a Ready for Review.
<!-- ^ delete one -->

- [x] Fix Prepending of URL

## How to test

Repeatedly open and close the same ContentDB item (e. g. Minetest Game) and then click on "Forum Topic" 
