### PR TITLE
Change minetest.net to luanti.org in 'Further documentation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Table of Contents
 
 Further documentation
 ----------------------
-- Website: https://www.minetest.net/
+- Website: https://www.luanti.org/
 - Wiki: https://wiki.minetest.net/
 - Forum: https://forum.minetest.net/
 - GitHub: https://github.com/minetest/minetest/


### PR DESCRIPTION
This only changed a singular occurence of minetest.net to luanti.org in README.md

## To do

This PR is Ready for Review.
<!-- ^ delete one -->

- [x] Replace Occurence

## How to test

Open the changed link in README.md