### PR TITLE
[NO SQUASH] Collision fixes

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -439,7 +439,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 		if (nearest_collided == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
-			*pos_f += truncate(aspeed_f * dtime, 100.0f);
+			*pos_f += aspeed_f * dtime;
 			// Final speed:
 			*speed_f += accel_f * dtime;
 			// Limit speed for avoiding hangs
@@ -489,7 +489,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		} else if (nearest_dtime > 0) {
 			// updated average speed for the sub-interval up to nearest_dtime
 			aspeed_f = *speed_f + accel_f * 0.5f * nearest_dtime;
-			*pos_f += truncate(aspeed_f * nearest_dtime, 100.0f);
+			*pos_f += aspeed_f * nearest_dtime;
 			// Speed at (approximated) collision:
 			*speed_f += accel_f * nearest_dtime;
 			// Limit speed for avoiding hangs
@@ -542,11 +542,11 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				accel_f.Z = 0;
 			}
 			result.collides = true;
+		} else {
+			is_collision = false;
 		}
 
 		info.new_speed = *speed_f;
-		if (info.new_speed.getDistanceFrom(info.old_speed) < 0.1f * BS)
-			is_collision = false;
 
 		if (is_collision) {
 			info.axis = nearest_collided;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -107,6 +107,8 @@ CollisionAxis axisAlignedCollision(
 
 	if (speed.Y) {
 		distance = relbox.MaxEdge.Y - relbox.MinEdge.Y;
+		// FIXME: The dtime calculation is inaccurate without acceleration information.
+		// Exact formula: `dtime = (-vel ± sqrt(vel² + 2 * acc * distance)) / acc`
 		*dtime = distance / std::abs(speed.Y);
 		time = std::max(*dtime, 0.0f);
 
@@ -400,7 +402,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	// Collect object boxes in movement range
 	if (collide_with_objects) {
 		add_object_boxes(env, box_0, dtime, *pos_f, aspeed_f, self, cinfo);
-    }
+	}
 
 	// Collision detection
 	f32 d = 0.0f;
@@ -523,15 +525,22 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				speed_f->X *= bounce;
 			} else {
 				speed_f->X = 0;
-				accel_f.X = 0;
+				accel_f.X = 0; // avoid colliding in the next interations
 			}
 			result.collides = true;
 		} else if (nearest_collided == COLLISION_AXIS_Y) {
-			if(bounce < -1e-4 && fabsf(speed_f->Y) > BS * 3) {
+			if (bounce < -1e-4 && fabsf(speed_f->Y) > BS * 3) {
 				speed_f->Y *= bounce;
 			} else {
+				if (speed_f->Y < 0.0f) {
+					// FIXME: This code is necessary until `axisAlignedCollision` takes acceleration
+					// into consideration for the time calculation. Otherwise, the colliding faces
+					// never line up, especially at high step (dtime) intervals.
+					result.touching_ground = true;
+					result.standing_on_object = nearest_info.isObject();
+				}
 				speed_f->Y = 0;
-				accel_f.Y = 0;
+				accel_f.Y = 0; // avoid colliding in the next interations
 			}
 			result.collides = true;
 		} else if (nearest_collided == COLLISION_AXIS_Z) {
@@ -539,7 +548,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				speed_f->Z *= bounce;
 			} else {
 				speed_f->Z = 0;
-				accel_f.Z = 0;
+				accel_f.Z = 0; // avoid colliding in the next interations
 			}
 			result.collides = true;
 		} else {
@@ -589,10 +598,10 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				box.MaxEdge += *pos_f;
 			}
 			if (std::fabs(cbox.MaxEdge.Y - box.MinEdge.Y) < 0.05f) {
+				// This is code is technically only required if `box_info.is_step_up == true`.
+				// However, players rely on this check/condition to climb stairs faster. See PR #10587.
 				result.touching_ground = true;
-
-				if (box_info.isObject())
-					result.standing_on_object = true;
+				result.standing_on_object = box_info.isObject();
 			}
 		}
 	}


### PR DESCRIPTION
Fixes a regression from cb6c8eb2f / #15029

Commit 1: Fixes #15375
Commit 2: Fixes #15381

## To do

This PR is Ready for Review.

## How to test

**Commit 1**
1. Mod and setup here: https://github.com/minetest/minetest/issues/15375#issuecomment-2453397673
2. The distances do not entirely match. I suppose that's a result of the changed speed calculations.

**Commit 2**
1. Add debugging info
```diff
diff --git a/builtin/game/falling.lua b/builtin/game/falling.lua
index bb6ca1a64..80c32d4e4 100644
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -365,10 +365,12 @@ core.register_entity(":__builtin:falling_node", {
                if not moveresult.collides then
                        return -- Nothing to do :)
                end
+               print("NODE: collide!")
 
                local bcp, bcn
                local player_collision
                if moveresult.touching_ground then
+                       print("NODE: touching ground!")
                        for _, info in ipairs(moveresult.collisions) do
                                if info.type == "object" then
                                        if info.axis == "y" and info.object:is_player() then
@@ -437,6 +439,9 @@ core.register_entity(":__builtin:falling_node", {
                        end
                end
                self.object:remove()
+       end,
+       on_punch = function(self)
+               self.object:remove()
        end
 })
```
2. `dedicated_server_step = 0.6` or similar
3. `./luanti --server --worldname MYCOOLWORLD`
4. Join the world with any client
5. Drop a sand node. It must turn solid and "touching ground!" must appear in stdout.

**Further tests**
1. Sinking in liquids must work
2. Holding sneak on ground, inside a ladder node must not create footstep spam sounds.
3. Holding sneak on ground, inside a liquid node must not create footstep spam sounds.
