### PR TITLE
Fix flowing liquid waving into the floor

### DIFF
--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -179,9 +179,7 @@ void main(void)
 	wavePos.z += animationTimer * WATER_WAVE_SPEED * 10.0;
 	// Flowing liquid waveheight is scaled by node height, so it doesn't wave
 	// into the floor (only works for vertices on top).
-	float nodecorner_height = fract(pos.y * (1.0 / BS) + 0.5);
-	if (nodecorner_height < 0.001)
-		nodecorner_height = 1.0;
+	float nodecorner_height = fract(pos.y * (1.0 / BS) + 0.5 - 0.001);
 	pos.y += (snoise(wavePos) - 1.0) * WATER_WAVE_HEIGHT * 5.0 * nodecorner_height;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES
 	pos.x += disp_x;

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -182,9 +182,6 @@ void main(void)
 	float nodecorner_height = fract(pos.y * (1.0 / BS) + 0.5);
 	if (nodecorner_height < 0.001)
 		nodecorner_height = 1.0;
-	if ((abs(inVertexNormal.y) < 0.001 && varTexCoord.y > 0.95)
-			|| abs(inVertexNormal.x) + abs(inVertexNormal.y) + abs(inVertexNormal.z) < 0.001)
-		nodecorner_height = 0.0;
 	pos.y += (snoise(wavePos) - 1.0) * WATER_WAVE_HEIGHT * 5.0 * nodecorner_height;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES
 	pos.x += disp_x;

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -177,7 +177,15 @@ void main(void)
 	wavePos.x /= WATER_WAVE_LENGTH * 3.0;
 	wavePos.z /= WATER_WAVE_LENGTH * 2.0;
 	wavePos.z += animationTimer * WATER_WAVE_SPEED * 10.0;
-	pos.y += (snoise(wavePos) - 1.0) * WATER_WAVE_HEIGHT * 5.0;
+	// Flowing liquid waveheight is scaled by node height, so it doesn't wave
+	// into the floor.
+	float nodecorner_height = fract(pos.y * (1.0 / BS) + 0.5);
+	if (nodecorner_height < 0.001)
+		nodecorner_height = 1.0;
+	if ((abs(inVertexNormal.y) < 0.001 && varTexCoord.y > 0.95)
+			|| abs(inVertexNormal.x) + abs(inVertexNormal.y) + abs(inVertexNormal.z) < 0.001)
+		nodecorner_height = 0.0;
+	pos.y += (snoise(wavePos) - 1.0) * WATER_WAVE_HEIGHT * 5.0 * nodecorner_height;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES
 	pos.x += disp_x;
 	pos.y += disp_z * 0.1;

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -178,7 +178,7 @@ void main(void)
 	wavePos.z /= WATER_WAVE_LENGTH * 2.0;
 	wavePos.z += animationTimer * WATER_WAVE_SPEED * 10.0;
 	// Flowing liquid waveheight is scaled by node height, so it doesn't wave
-	// into the floor.
+	// into the floor (only works for vertices on top).
 	float nodecorner_height = fract(pos.y * (1.0 / BS) + 0.5);
 	if (nodecorner_height < 0.001)
 		nodecorner_height = 1.0;


### PR DESCRIPTION
In master, waving liquid can wave into the floor, and seems to appear. This is ugly, and bad gameplay-wise, because you can't see that there's liquid.

Weirdly, I haven't found an issue for this. (#8367 talks about it, and has screenshots, but is not about this issue.)

This PR scales the the wave y offset by the vertex height relative to the lower node border.

It's very simple, so is there a reason why we're not doing this already? Am I overlooking something.

Note: Liquids can still wave into the ground, just not the top faces. (=> Fixes not #14535.)

## To do

This PR is a Ready for Review.

## How to test

<!--
<details>
<summary>Click to expand. (Contains screenshots.)</summary>
-->

master:
![master](https://github.com/user-attachments/assets/12e7b3c5-e1c6-4a1b-9ed7-2cdc84494850)
pr:
![pr](https://github.com/user-attachments/assets/37435c57-3752-44ac-99d5-65b7dd0247bb)
master, waveheight=2:
![master_waveheight2](https://github.com/user-attachments/assets/693c0375-ca81-4282-b2cf-dcf0cb71c18d)
pr, waveheight=2:
![pr_waveheight2](https://github.com/user-attachments/assets/339bff13-8db4-4184-9fb0-2369392e4b1f)

<!--
</details>
-->