### PR TITLE
Revert 2D texture filtering change

### DIFF
--- a/irr/src/CNullDriver.cpp
+++ b/irr/src/CNullDriver.cpp
@@ -108,9 +108,7 @@ CNullDriver::CNullDriver(io::IFileSystem *io, const core::dimension2d<u32> &scre
 	InitMaterial2D.ZBuffer = video::ECFN_DISABLED;
 	InitMaterial2D.UseMipMaps = false;
 	InitMaterial2D.forEachTexture([](auto &tex) {
-		// Using ETMINF_LINEAR_MIPMAP_NEAREST (bilinear) for 2D graphics looks
-		// much better and doesn't have any downsides (e.g. regarding pixel art).
-		tex.MinFilter = video::ETMINF_LINEAR_MIPMAP_NEAREST;
+		tex.MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
 		tex.MagFilter = video::ETMAGF_NEAREST;
 		tex.TextureWrapU = video::ETC_REPEAT;
 		tex.TextureWrapV = video::ETC_REPEAT;


### PR DESCRIPTION
This PR reverts minetest/irrlicht@fb7a0e4298356a2d339c5ebf23152b441dc06a8f to fix #15384.

~~It also reverts c14e4d1795b97b55cf3a23aa347a9eabe0d722ea because I originally thought of it as depending on minetest/irrlicht@fb7a0e4298356a2d339c5ebf23152b441dc06a8f, but I'm not sure whether that one should actually be reverted.~~

This is an alternative to #15362. Compared to #15362, it is less risky: since it merely reverts to a previous state, there should be no potential for new regressions. This should save a lot of additional time I'd otherwise waste on Irrlicht texture filtering. 

## To do

This PR is a Ready for Review.

Question for reviewers: Should c14e4d1795b97b55cf3a23aa347a9eabe0d722ea be reverted?

## How to test

Test one of the cases in #15384, see that there are no artifacts anymore