### PR TITLE
Correctly render transparency in TGA type 1 with color format A1R5G5B5

### DIFF
--- a/irr/src/CImageLoaderTGA.cpp
+++ b/irr/src/CImageLoaderTGA.cpp
@@ -181,27 +181,16 @@ IImage *CImageLoaderTGA::loadImage(io::IReadFile *file) const
 						header.ImageWidth, header.ImageHeight,
 						0, 0, (header.ImageDescriptor & 0x20) == 0);
 		} else {
-			switch (header.ColorMapEntrySize) {
-			case 16:
-				image = new CImage(ECF_A1R5G5B5, core::dimension2d<u32>(header.ImageWidth, header.ImageHeight));
-				if (image)
-					CColorConverter::convert8BitTo16Bit((u8 *)data,
-							(s16 *)image->getData(),
-							header.ImageWidth, header.ImageHeight,
-							(s32 *)palette, 0,
-							(header.ImageDescriptor & 0x20) == 0);
-				break;
-			// Note: 24 bit with palette would need a 24 bit palette, too lazy doing that now (textures will prefer 32-bit later anyway)
-			default:
-				image = new CImage(ECF_A8R8G8B8, core::dimension2d<u32>(header.ImageWidth, header.ImageHeight));
-				if (image)
-					CColorConverter::convert8BitTo32Bit((u8 *)data,
-							(u8 *)image->getData(),
-							header.ImageWidth, header.ImageHeight,
-							(u8 *)palette, 0,
-							(header.ImageDescriptor & 0x20) == 0);
-				break;
-			}
+			// Colormap is converted to A8R8G8B8 at this point – thus the code can handle all color formats.
+			// This wastes some texture memory, but is less of a third of the code that does this optimally.
+			// If you want to refactor this: The possible color formats here are A1R5G5B5, B8G8R8, B8G8R8A8.
+			image = new CImage(ECF_A8R8G8B8, core::dimension2d<u32>(header.ImageWidth, header.ImageHeight));
+			if (image)
+				CColorConverter::convert8BitTo32Bit((u8 *)data,
+						(u8 *)image->getData(),
+						header.ImageWidth, header.ImageHeight,
+						(u8 *)palette, 0,
+						(header.ImageDescriptor & 0x20) == 0);
 		}
 	} break;
 	case 16:


### PR DESCRIPTION
I'm submitting this PR on behalf of erle. I've reviewed and tested it and find it to be a simple and straightforward fix, so it has my approval.

> The branch removed in this patch handled color format A1R5G5B5 specially when creating a texture from a TGA type 1 file, i.e. an image that has a colormap. It did not handle the 1-bit alpha channel correctly, rendering transparent pixels black instead.
> 
> Since the colormap is converted to A8R8G8B8 earlier anyways, the code for the general case is able to handle this scenario already – at the expense of making the created texture use twice as much GPU memory as necessary.

## How to test

1. Clone https://git.minetest.land/erle/tga_testnodes, https://git.minetest.land/erle/tga_encoder
2. Do `cd tga_testnodes; mkdir textures; cd ..; cd tga_encoder; git checkout features-table`
3. Enable the two mods, join devtest
4. Grab the two TGA type 1 color format A1R5G5B5 testnodes from the bag of everything and place them

They should look like this:

![Screenshot from 2024-11-06 02-14-39](https://github.com/user-attachments/assets/9195bef6-a382-42eb-885d-3dbf1523d12d)

Without this patch, they look like this:

![Screenshot from 2024-11-06 02-14-59](https://github.com/user-attachments/assets/bd1b952c-6837-45a2-80a0-171dc38b1202)

Before merging this, make sure the commit is correctly attributed to erle as author.