### PR TITLE
[no sq] Fix ECF_D32 support in ogles2 video driver

### DIFF
--- a/irr/src/COGLESCoreExtensionHandler.h
+++ b/irr/src/COGLESCoreExtensionHandler.h
@@ -24,39 +24,21 @@ public:
 	enum EOGLESFeatures
 	{
 		// If you update this enum also update the corresponding OGLESFeatureStrings string-array
-		IRR_GL_APPLE_texture_2D_limited_npot,
 		IRR_GL_APPLE_texture_format_BGRA8888,
 		IRR_GL_EXT_blend_minmax,
-		IRR_GL_EXT_read_format_bgra,
-		IRR_GL_EXT_texture_filter_anisotropic,
 		IRR_GL_EXT_texture_format_BGRA8888,
-		IRR_GL_EXT_texture_lod_bias,
 		IRR_GL_EXT_texture_rg,
-		IRR_GL_IMG_read_format,
-		IRR_GL_IMG_texture_format_BGRA8888,
-		IRR_GL_IMG_user_clip_plane,
-		IRR_GL_OES_blend_func_separate,
-		IRR_GL_OES_blend_subtract,
 		IRR_GL_OES_depth_texture,
-		IRR_GL_OES_depth24,
-		IRR_GL_OES_depth32,
 		IRR_GL_OES_element_index_uint,
-		IRR_GL_OES_framebuffer_object,
 		IRR_GL_OES_packed_depth_stencil,
-		IRR_GL_OES_point_size_array,
-		IRR_GL_OES_point_sprite,
-		IRR_GL_OES_read_format,
-		IRR_GL_OES_stencil_wrap,
 		IRR_GL_OES_texture_float,
 		IRR_GL_OES_texture_half_float,
-		IRR_GL_OES_texture_mirrored_repeat,
-		IRR_GL_OES_texture_npot,
 
 		IRR_OGLES_Feature_Count
 	};
 
 	COGLESCoreExtensionHandler() :
-			Version(0), MaxAnisotropy(1), MaxIndices(0xffff),
+			MaxAnisotropy(1), MaxIndices(0xffff),
 			MaxTextureSize(1), MaxTextureLODBias(0.f), StencilBuffer(false)
 	{
 		for (u32 i = 0; i < IRR_OGLES_Feature_Count; ++i)
@@ -81,99 +63,27 @@ public:
 			os::Printer::log(getFeatureString(i), FeatureAvailable[i] ? " true" : " false");
 	}
 
-	bool queryGLESFeature(EOGLESFeatures feature) const
-	{
-		return FeatureAvailable[feature];
-	}
-
 protected:
 	const char *getFeatureString(size_t index) const
 	{
 		// One for each EOGLESFeatures
 		static const char *const OGLESFeatureStrings[IRR_OGLES_Feature_Count] = {
-				"GL_APPLE_texture_2D_limited_npot",
 				"GL_APPLE_texture_format_BGRA8888",
 				"GL_EXT_blend_minmax",
-				"GL_EXT_read_format_bgra",
-				"GL_EXT_texture_filter_anisotropic",
 				"GL_EXT_texture_format_BGRA8888",
-				"GL_EXT_texture_lod_bias",
 				"GL_EXT_texture_rg",
-				"GL_IMG_read_format",
-				"GL_IMG_texture_format_BGRA8888",
-				"GL_IMG_user_clip_plane",
-				"GL_OES_blend_func_separate",
-				"GL_OES_blend_subtract",
 				"GL_OES_depth_texture",
-				"GL_OES_depth24",
-				"GL_OES_depth32",
 				"GL_OES_element_index_uint",
-				"GL_OES_framebuffer_object",
 				"GL_OES_packed_depth_stencil",
-				"GL_OES_point_size_array",
-				"GL_OES_point_sprite",
-				"GL_OES_read_format",
-				"GL_OES_stencil_wrap",
 				"GL_OES_texture_float",
 				"GL_OES_texture_half_float",
-				"GL_OES_texture_mirrored_repeat",
-				"GL_OES_texture_npot",
 			};
 
 		return OGLESFeatureStrings[index];
 	}
 
-	void getGLVersion()
-	{
-		Version = 0;
-		s32 multiplier = 100;
-
-		core::stringc version(glGetString(GL_VERSION));
-
-		for (u32 i = 0; i < version.size(); ++i) {
-			if (version[i] >= '0' && version[i] <= '9') {
-				if (multiplier > 1) {
-					Version += static_cast<u16>(core::floor32(atof(&(version[i]))) * multiplier);
-					multiplier /= 10;
-				} else {
-					break;
-				}
-			}
-		}
-	}
-
-	void getGLExtensions()
-	{
-		core::stringc extensions = glGetString(GL_EXTENSIONS);
-		os::Printer::log(extensions.c_str());
-
-		const u32 size = extensions.size() + 1;
-		c8 *str = new c8[size];
-		strncpy(str, extensions.c_str(), extensions.size());
-		str[extensions.size()] = ' ';
-		c8 *p = str;
-
-		for (u32 i = 0; i < size; ++i) {
-			if (str[i] == ' ') {
-				str[i] = 0;
-				if (*p)
-					for (size_t j = 0; j < IRR_OGLES_Feature_Count; ++j) {
-						if (!strcmp(getFeatureString(j), p)) {
-							FeatureAvailable[j] = true;
-							break;
-						}
-					}
-
-				p = p + strlen(p) + 1;
-			}
-		}
-
-		delete[] str;
-	}
-
 	COpenGLCoreFeature Feature;
 
-	u16 Version;
 	u8 MaxAnisotropy;
 	u32 MaxIndices;
 	u32 MaxTextureSize;

--- a/irr/src/COpenGLCoreTexture.h
+++ b/irr/src/COpenGLCoreTexture.h
@@ -297,6 +297,7 @@ public:
 					delete[] tmpBuffer;
 				}
 #elif defined(IRR_COMPILE_GLES2_COMMON)
+				// TODO: revive this code
 				COpenGLCoreTexture *tmpTexture = new COpenGLCoreTexture("OGL_CORE_LOCK_TEXTURE", Size, ETT_2D, ColorFormat, Driver);
 
 				GLuint tmpFBO = 0;

--- a/irr/src/OpenGLES2/Driver.cpp
+++ b/irr/src/OpenGLES2/Driver.cpp
@@ -57,8 +57,12 @@ void COpenGLES2Driver::initFeatures()
 		else if (FeatureAvailable[IRR_GL_APPLE_texture_format_BGRA8888])
 			TextureFormats[ECF_A8R8G8B8] = {BGRA8_EXT, GL_BGRA, GL_UNSIGNED_BYTE};
 
-		if (FeatureAvailable[IRR_GL_OES_depth32])
-			TextureFormats[ECF_D32] = {GL_DEPTH_COMPONENT32, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT};
+		// OpenGL ES 3 doesn't include a GL_DEPTH_COMPONENT32, so still use
+		// OES_depth_texture for 32-bit depth texture support.
+		// OpenGL ES 3 would allow {GL_DEPTH_COMPONENT32F, GL_DEPTH_COMPONENT, GL_FLOAT},
+		// but I guess that would have to be called ECF_D32F...
+		if (FeatureAvailable[IRR_GL_OES_depth_texture])
+			TextureFormats[ECF_D32] = {GL_DEPTH_COMPONENT, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT};
 	} else {
 		// NOTE These are *texture* formats. They may or may not be suitable
 		// for render targets. The specs only talks on *sized* formats for the
@@ -98,8 +102,9 @@ void COpenGLES2Driver::initFeatures()
 
 		if (FeatureAvailable[IRR_GL_OES_depth_texture]) {
 			TextureFormats[ECF_D16] = {GL_DEPTH_COMPONENT, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT};
-			if (FeatureAvailable[IRR_GL_OES_depth32])
-				TextureFormats[ECF_D32] = {GL_DEPTH_COMPONENT, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT};
+			// OES_depth_texture includes 32-bit depth texture support.
+			TextureFormats[ECF_D32] = {GL_DEPTH_COMPONENT, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT};
+
 			if (FeatureAvailable[IRR_GL_OES_packed_depth_stencil])
 				TextureFormats[ECF_D24S8] = {GL_DEPTH_STENCIL, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8};
 		}


### PR DESCRIPTION
fixes #15395

OES_depth32 only talks about support for render buffers, not textures, so it's not relevant here: https://github.com/KhronosGroup/OpenGL-Registry/blob/main/extensions/OES/OES_depth32.txt

This fixes the scene being black with "video_driver = ogles2" and "enable_post_processing = true" on my desktop computer.

## To do

This PR is a Ready for Review.

## How to test

ogles2 on Android: things should work
ogles2 on desktop: things should work