### PR TITLE
Minor rendering code fixes

### DIFF
--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -730,19 +730,18 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		shaders_header << "#define VOLUMETRIC_LIGHT 1\n";
 	}
 
-	shaders_header << "#line 0\n"; // reset the line counter for meaningful diagnostics
-
 	std::string common_header = shaders_header.str();
+	const char *final_header = "#line 0\n"; // reset the line counter for meaningful diagnostics
 
 	std::string vertex_shader = m_sourcecache.getOrLoad(name, "opengl_vertex.glsl");
 	std::string fragment_shader = m_sourcecache.getOrLoad(name, "opengl_fragment.glsl");
 	std::string geometry_shader = m_sourcecache.getOrLoad(name, "opengl_geometry.glsl");
 
-	vertex_shader = common_header + vertex_header + vertex_shader;
-	fragment_shader = common_header + fragment_header + fragment_shader;
+	vertex_shader = common_header + vertex_header + final_header + vertex_shader;
+	fragment_shader = common_header + fragment_header + final_header + fragment_shader;
 	const char *geometry_shader_ptr = nullptr; // optional
 	if (!geometry_shader.empty()) {
-		geometry_shader = common_header + geometry_header + geometry_shader;
+		geometry_shader = common_header + geometry_header + final_header + geometry_shader;
 		geometry_shader_ptr = geometry_shader.c_str();
 	}
 

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -21,8 +21,9 @@
 
 ShadowRenderer::ShadowRenderer(IrrlichtDevice *device, Client *client) :
 		m_smgr(device->getSceneManager()), m_driver(device->getVideoDriver()),
-		m_client(client), m_current_frame(0),
-		m_perspective_bias_xy(0.8), m_perspective_bias_z(0.5)
+		m_client(client), m_shadow_strength(0.0f), m_shadow_tint(255, 0, 0, 0),
+		m_time_day(0.0f), m_force_update_shadow_map(false), m_current_frame(0),
+		m_perspective_bias_xy(0.8f), m_perspective_bias_z(0.5f)
 {
 	(void) m_client;
 

--- a/src/client/shadows/dynamicshadowsrender.h
+++ b/src/client/shadows/dynamicshadowsrender.h
@@ -118,11 +118,11 @@ private:
 	std::vector<NodeToApply> m_shadow_node_array;
 
 	float m_shadow_strength;
-	video::SColor m_shadow_tint{ 255, 0, 0, 0 };
+	video::SColor m_shadow_tint;
 	float m_shadow_strength_gamma;
 	float m_shadow_map_max_distance;
 	float m_shadow_map_texture_size;
-	float m_time_day{0.0f};
+	float m_time_day;
 	int m_shadow_samples;
 	bool m_shadow_map_texture_32bit;
 	bool m_shadows_enabled;
@@ -130,7 +130,7 @@ private:
 	bool m_shadow_map_colored;
 	bool m_force_update_shadow_map;
 	u8 m_map_shadow_update_frames; /* Use this number of frames to update map shaodw */
-	u8 m_current_frame{0}; /* Current frame */
+	u8 m_current_frame; /* Current frame */
 	f32 m_perspective_bias_xy;
 	f32 m_perspective_bias_z;
 


### PR DESCRIPTION
Commits:

1. Fixes wrong line numbers in shader error messages.
    
    While going down the rabbit hole of rendering bugs, I also got a few shader compilation errors and was annoyed by wrong line numbers. "#line 0" was appended before the vertex/fragment/geometry-specific shader header was appended.

2. Fixes uninitialized values in the shadow code found with Valgrind.
     
     An old commit from September, re-tested.

<details>
<summary>Valgrind problems this fixes</summary>
<pre>
==6952== Conditional jump or move depends on uninitialised value(s)
==6952==    at 0x5D44CE: equal<float*, float const*> (stl_algobase.h:1193)
==6952==    by 0x5D44CE: __equal_aux1<float*, float const*> (stl_algobase.h:1242)
==6952==    by 0x5D44CE: __equal_aux<float*, float const*> (stl_algobase.h:1250)
==6952==    by 0x5D44CE: equal<float*, float const*> (stl_algobase.h:1586)
==6952==    by 0x5D44CE: set (shader.h:80)
==6952==    by 0x5D44CE: ShadowConstantSetter::onSetConstants(irr::video::IMaterialRendererServices*) (shadowsshadercallbacks.cpp:26)
==6952==    by 0x5C4F1E: ShaderCallback::OnSetConstants(irr::video::IMaterialRendererServices*, int) (shader.cpp:180)
==6952==    by 0xB2EA23: irr::video::COpenGLSLMaterialRenderer::OnRender(irr::video::IMaterialRendererServices*, irr::video::E_VERTEX_TYPE) (COpenGLSLMaterialRenderer.cpp:199)
==6952==    by 0xB22A62: irr::video::COpenGLDriver::setRenderStates3DMode() (COpenGLDriver.cpp:1731)
==6952==    by 0xB26219: irr::video::COpenGLDriver::drawVertexPrimitiveList(void const*, unsigned int, void const*, unsigned int, irr::video::E_VERTEX_TYPE, irr::scene::E_PRIMITIVE_TYPE, irr::video::E_INDEX_TYPE) [clone .part.0] (COpenGLDriver.cpp:677)
==6952==    by 0x5B1DD3: PostProcessingStep::run(PipelineContext&) (secondstage.cpp:74)
==6952==    by 0x5ADE1F: RenderPipeline::run(PipelineContext&) (pipeline.cpp:271)
==6952==    by 0x5ADDB8: RenderPipeline::run(PipelineContext&) (pipeline.cpp:271)
==6952==    by 0x5AC345: RenderingCore::draw(irr::video::SColor, bool, bool, bool) (core.cpp:36)
==6952==    by 0x52EFF2: Game::drawScene(ProfilerGraph*, RunStats*) (game.cpp:4361)
==6952==    by 0x532024: Game::updateFrame(ProfilerGraph*, RunStats*, float, CameraOrientation const&) (game.cpp:4232)
==6952==    by 0x534864: Game::run() (game.cpp:1184)
==6952==  Uninitialised value was created by a heap allocation
==6952==    at 0x4843FEC: operator new(unsigned long) (vg_replace_malloc.c:487)
==6952==    by 0x5D2446: createShadowRenderer(irr::IrrlichtDevice*, Client*) (dynamicshadowsrender.cpp:716)
==6952==    by 0x5AC3C1: createPipeline(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, irr::IrrlichtDevice*, Client*, Hud*, CreatePipelineResult&) (factory.cpp:35)
==6952==    by 0x5ACAEB: createRenderingCore(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, irr::IrrlichtDevice*, Client*, Hud*) (factory.cpp:28)
==6952==    by 0x5B79D9: RenderingEngine::initialize(Client*, Hud*) (renderingengine.cpp:394)
==6952==    by 0x529D39: Game::startup(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool*, ChatBackend*) (game.cpp:1084)
==6952==    by 0x5355A3: the_game(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, ChatBackend&, bool*) (game.cpp:4600)
==6952==    by 0x4C3E24: ClientLauncher::run(GameStartData&, Settings const&) (clientlauncher.cpp:204)
==6952==    by 0x49076B: main (main.cpp:264)
==6952== 
==6952== Conditional jump or move depends on uninitialised value(s)
==6952==    at 0x1BE3E2B0: ??? (in /usr/lib64/libnvidia-glcore.so.560.35.03)
==6952==    by 0xB2F11D: extGlUniform1fv (COpenGLExtensionHandler.h:1645)
==6952==    by 0xB2F11D: irr::video::COpenGLSLMaterialRenderer::setPixelShaderConstant(int, float const*, int) (COpenGLSLMaterialRenderer.cpp:550)
==6952==    by 0x5D4D1C: set (shader.h:85)
==6952==    by 0x5D4D1C: ShadowConstantSetter::onSetConstants(irr::video::IMaterialRendererServices*) (shadowsshadercallbacks.cpp:26)
==6952==    by 0x5C4F1E: ShaderCallback::OnSetConstants(irr::video::IMaterialRendererServices*, int) (shader.cpp:180)
==6952==    by 0xB2EA23: irr::video::COpenGLSLMaterialRenderer::OnRender(irr::video::IMaterialRendererServices*, irr::video::E_VERTEX_TYPE) (COpenGLSLMaterialRenderer.cpp:199)
==6952==    by 0xB22A62: irr::video::COpenGLDriver::setRenderStates3DMode() (COpenGLDriver.cpp:1731)
==6952==    by 0xB26219: irr::video::COpenGLDriver::drawVertexPrimitiveList(void const*, unsigned int, void const*, unsigned int, irr::video::E_VERTEX_TYPE, irr::scene::E_PRIMITIVE_TYPE, irr::video::E_INDEX_TYPE) [clone .part.0] (COpenGLDriver.cpp:677)
==6952==    by 0xB269F1: drawVertexPrimitiveList (COpenGLDriver.cpp:665)
==6952==    by 0xB269F1: drawBuffers (COpenGLDriver.cpp:524)
==6952==    by 0xB269F1: irr::video::COpenGLDriver::drawBuffers(irr::scene::IVertexBuffer const*, irr::scene::IIndexBuffer const*, unsigned int, irr::scene::E_PRIMITIVE_TYPE) (COpenGLDriver.cpp:499)
==6952==    by 0xB64800: irr::scene::CMeshSceneNode::render() (CMeshSceneNode.cpp:110)
==6952==    by 0xB0C30D: irr::scene::CSceneManager::drawAll() (CSceneManager.cpp:532)
==6952==    by 0x5ADDC9: RenderPipeline::run(PipelineContext&) (pipeline.cpp:271)
==6952==    by 0x5AC345: RenderingCore::draw(irr::video::SColor, bool, bool, bool) (core.cpp:36)
==6952==  Uninitialised value was created by a heap allocation
==6952==    at 0x4843FEC: operator new(unsigned long) (vg_replace_malloc.c:487)
==6952==    by 0x5D2446: createShadowRenderer(irr::IrrlichtDevice*, Client*) (dynamicshadowsrender.cpp:716)
==6952==    by 0x5AC3C1: createPipeline(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, irr::IrrlichtDevice*, Client*, Hud*, CreatePipelineResult&) (factory.cpp:35)
==6952==    by 0x5ACAEB: createRenderingCore(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, irr::IrrlichtDevice*, Client*, Hud*) (factory.cpp:28)
==6952==    by 0x5B79D9: RenderingEngine::initialize(Client*, Hud*) (renderingengine.cpp:394)
==6952==    by 0x529D39: Game::startup(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool*, ChatBackend*) (game.cpp:1084)
==6952==    by 0x5355A3: the_game(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, ChatBackend&, bool*) (game.cpp:4600)
==6952==    by 0x4C3E24: ClientLauncher::run(GameStartData&, Settings const&) (clientlauncher.cpp:204)
==6952==    by 0x49076B: main (main.cpp:264)
==6952== 
==6952== Conditional jump or move depends on uninitialised value(s)
==6952==    at 0x5CB7EE: ShadowRenderer::renderShadowMap(irr::video::ITexture*, DirectionalLight&, irr::scene::E_SCENE_NODE_RENDER_PASS) (dynamicshadowsrender.cpp:458)
==6952==    by 0x5CC2C7: ShadowRenderer::updateSMTextures() (dynamicshadowsrender.cpp:303)
==6952==    by 0x5CF8F3: ShadowRenderer::update(irr::video::ITexture*) (dynamicshadowsrender.cpp:345)
==6952==    by 0x5ADDA7: RenderPipeline::run(PipelineContext&) (pipeline.cpp:271)
==6952==    by 0x5AC345: RenderingCore::draw(irr::video::SColor, bool, bool, bool) (core.cpp:36)
==6952==    by 0x52EFF2: Game::drawScene(ProfilerGraph*, RunStats*) (game.cpp:4361)
==6952==    by 0x532024: Game::updateFrame(ProfilerGraph*, RunStats*, float, CameraOrientation const&) (game.cpp:4232)
==6952==    by 0x534864: Game::run() (game.cpp:1184)
==6952==    by 0x5355D7: the_game(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, ChatBackend&, bool*) (game.cpp:4602)
==6952==    by 0x4C3E24: ClientLauncher::run(GameStartData&, Settings const&) (clientlauncher.cpp:204)
==6952==    by 0x49076B: main (main.cpp:264)
==6952==  Uninitialised value was created by a heap allocation
==6952==    at 0x4843FEC: operator new(unsigned long) (vg_replace_malloc.c:487)
==6952==    by 0x5D2446: createShadowRenderer(irr::IrrlichtDevice*, Client*) (dynamicshadowsrender.cpp:716)
==6952==    by 0x5AC3C1: createPipeline(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, irr::IrrlichtDevice*, Client*, Hud*, CreatePipelineResult&) (factory.cpp:35)
==6952==    by 0x5ACAEB: createRenderingCore(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, irr::IrrlichtDevice*, Client*, Hud*) (factory.cpp:28)
==6952==    by 0x5B79D9: RenderingEngine::initialize(Client*, Hud*) (renderingengine.cpp:394)
==6952==    by 0x529D39: Game::startup(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool*, ChatBackend*) (game.cpp:1084)
==6952==    by 0x5355A3: the_game(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, ChatBackend&, bool*) (game.cpp:4600)
==6952==    by 0x4C3E24: ClientLauncher::run(GameStartData&, Settings const&) (clientlauncher.cpp:204)
==6952==    by 0x49076B: main (main.cpp:264)
==6952== 
==6952== Conditional jump or move depends on uninitialised value(s)
==6952==    at 0x5CC2E8: ShadowRenderer::updateSMTextures() (dynamicshadowsrender.cpp:307)
==6952==    by 0x5CF8F3: ShadowRenderer::update(irr::video::ITexture*) (dynamicshadowsrender.cpp:345)
==6952==    by 0x5ADDA7: RenderPipeline::run(PipelineContext&) (pipeline.cpp:271)
==6952==    by 0x5AC345: RenderingCore::draw(irr::video::SColor, bool, bool, bool) (core.cpp:36)
==6952==    by 0x52EFF2: Game::drawScene(ProfilerGraph*, RunStats*) (game.cpp:4361)
==6952==    by 0x532024: Game::updateFrame(ProfilerGraph*, RunStats*, float, CameraOrientation const&) (game.cpp:4232)
==6952==    by 0x534864: Game::run() (game.cpp:1184)
==6952==    by 0x5355D7: the_game(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, ChatBackend&, bool*) (game.cpp:4602)
==6952==    by 0x4C3E24: ClientLauncher::run(GameStartData&, Settings const&) (clientlauncher.cpp:204)
==6952==    by 0x49076B: main (main.cpp:264)
==6952==  Uninitialised value was created by a heap allocation
==6952==    at 0x4843FEC: operator new(unsigned long) (vg_replace_malloc.c:487)
==6952==    by 0x5D2446: createShadowRenderer(irr::IrrlichtDevice*, Client*) (dynamicshadowsrender.cpp:716)
==6952==    by 0x5AC3C1: createPipeline(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, irr::IrrlichtDevice*, Client*, Hud*, CreatePipelineResult&) (factory.cpp:35)
==6952==    by 0x5ACAEB: createRenderingCore(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, irr::IrrlichtDevice*, Client*, Hud*) (factory.cpp:28)
==6952==    by 0x5B79D9: RenderingEngine::initialize(Client*, Hud*) (renderingengine.cpp:394)
==6952==    by 0x529D39: Game::startup(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool*, ChatBackend*) (game.cpp:1084)
==6952==    by 0x5355A3: the_game(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, ChatBackend&, bool*) (game.cpp:4600)
==6952==    by 0x4C3E24: ClientLauncher::run(GameStartData&, Settings const&) (clientlauncher.cpp:204)
==6952==    by 0x49076B: main (main.cpp:264)
==6952== 
==6952== Conditional jump or move depends on uninitialised value(s)
==6952==    at 0x5CC528: ShadowRenderer::updateSMTextures() (dynamicshadowsrender.cpp:327)
==6952==    by 0x5CF8F3: ShadowRenderer::update(irr::video::ITexture*) (dynamicshadowsrender.cpp:345)
==6952==    by 0x5ADDA7: RenderPipeline::run(PipelineContext&) (pipeline.cpp:271)
==6952==    by 0x5AC345: RenderingCore::draw(irr::video::SColor, bool, bool, bool) (core.cpp:36)
==6952==    by 0x52EFF2: Game::drawScene(ProfilerGraph*, RunStats*) (game.cpp:4361)
==6952==    by 0x532024: Game::updateFrame(ProfilerGraph*, RunStats*, float, CameraOrientation const&) (game.cpp:4232)
==6952==    by 0x534864: Game::run() (game.cpp:1184)
==6952==    by 0x5355D7: the_game(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, ChatBackend&, bool*) (game.cpp:4602)
==6952==    by 0x4C3E24: ClientLauncher::run(GameStartData&, Settings const&) (clientlauncher.cpp:204)
==6952==    by 0x49076B: main (main.cpp:264)
==6952==  Uninitialised value was created by a heap allocation
==6952==    at 0x4843FEC: operator new(unsigned long) (vg_replace_malloc.c:487)
==6952==    by 0x5D2446: createShadowRenderer(irr::IrrlichtDevice*, Client*) (dynamicshadowsrender.cpp:716)
==6952==    by 0x5AC3C1: createPipeline(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, irr::IrrlichtDevice*, Client*, Hud*, CreatePipelineResult&) (factory.cpp:35)
==6952==    by 0x5ACAEB: createRenderingCore(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, irr::IrrlichtDevice*, Client*, Hud*) (factory.cpp:28)
==6952==    by 0x5B79D9: RenderingEngine::initialize(Client*, Hud*) (renderingengine.cpp:394)
==6952==    by 0x529D39: Game::startup(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool*, ChatBackend*) (game.cpp:1084)
==6952==    by 0x5355A3: the_game(bool*, InputHandler*, RenderingEngine*, GameStartData const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, ChatBackend&, bool*) (game.cpp:4600)
==6952==    by 0x4C3E24: ClientLauncher::run(GameStartData&, Settings const&) (clientlauncher.cpp:204)
==6952==    by 0x49076B: main (main.cpp:264)
==6952== 
</pre>
</details>

## To do

This PR is a Ready for Review.

## How to test

1. Put a syntax error in some shader, verify that the error message you get has a correct line number.

2. (Run Luanti with Valgrind and dynamic shadows, see errors before, see less errors after)