### PR TITLE
Improve error messages for failed mesh loading

### DIFF
--- a/irr/src/CGLTFMeshFileLoader.cpp
+++ b/irr/src/CGLTFMeshFileLoader.cpp
@@ -669,7 +669,7 @@ void SelfType::MeshExtractor::loadAnimation(const std::size_t animIdx)
 
 		const auto &sampler = anim.samplers.at(channel.sampler);
 		if (sampler.interpolation != tiniergltf::AnimationSampler::Interpolation::LINEAR)
-			throw std::runtime_error("unsupported interpolation");
+			throw std::runtime_error("unsupported interpolation, only linear interpolation is supported");
 
 		const auto inputAccessor = Accessor<f32>::make(m_gltf_model, sampler.input);
 		const auto n_frames = inputAccessor.getCount();


### PR DESCRIPTION
People were getting confused by the error message which implies that the format isn't supported altogether, when rather the issue is about a specific feature being used.

## How to test

Try to load a gltf model which makes use of an unsupported feature or is otherwise invalid, check that the error message is intuitive, e.g.

```
2024-11-09 17:27:06: ERROR[Main]: Irrlicht: error converting gltf to irrlicht mesh: invalid normalized value
2024-11-09 17:27:06: ERROR[Main]: Irrlicht: Attempt to load mesh failed: npc_elizbeth.gltf
2024-11-09 17:27:06: ERROR[Main]: GenericCAO::addToScene(): Could not load mesh npc_elizbeth.gltf
```
