### PR TITLE
Work around driver bug causing shaders to not work

### DIFF
--- a/irr/src/COpenGLSLMaterialRenderer.cpp
+++ b/irr/src/COpenGLSLMaterialRenderer.cpp
@@ -401,8 +401,10 @@ bool COpenGLSLMaterialRenderer::linkProgram()
 #endif
 
 		if (maxlen == 0) {
-			os::Printer::log("GLSL (> 2.x): failed to retrieve uniform information", ELL_ERROR);
-			return false;
+			// Intel driver bug that seems to primarily happen on Win 8.1 or older:
+			// There are >0 uniforms yet the driver reports a max name length of 0.
+			os::Printer::log("GLSL (> 2.x): failed to retrieve uniform information", ELL_WARNING);
+			maxlen = 256; // hope that this is enough
 		}
 
 		// seems that some implementations use an extra null terminator
@@ -471,8 +473,10 @@ bool COpenGLSLMaterialRenderer::linkProgram()
 #endif
 
 		if (maxlen == 0) {
-			os::Printer::log("GLSL: failed to retrieve uniform information", ELL_ERROR);
-			return false;
+			// Intel driver bug that seems to primarily happen on Win 8.1 or older:
+			// There are >0 uniforms yet the driver reports a max name length of 0.
+			os::Printer::log("GLSL: failed to retrieve uniform information", ELL_WARNING);
+			maxlen = 256; // hope that this is enough
 		}
 
 		// seems that some implementations use an extra null terminator


### PR DESCRIPTION
Fixes #10844.

Tested by someone affected, fixes the bug by falling back to `glGetActiveUniformName`. The simpler fallback also works.
