### PR TITLE
Luacheck add VoxelManip to globals

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -15,6 +15,7 @@ read_globals = {
 	"fgettext", "fgettext_ne",
 	"vector",
 	"VoxelArea",
+	"VoxelManip",
 	"profiler",
 	"Settings",
 	"PerlinNoise", "PerlinNoiseMap",

--- a/games/devtest/.luacheckrc
+++ b/games/devtest/.luacheckrc
@@ -23,6 +23,7 @@ read_globals = {
 	"fgettext", "fgettext_ne",
 	"vector",
 	"VoxelArea",
+	"VoxelManip",
 	"profiler",
 	"Settings",
 	"check",


### PR DESCRIPTION
Just a trivial luacheck CI fix, it adds `VoxelManip` to read_globals. I noticed this in #15415.

Note that in MTG it is already added.
https://github.com/minetest/minetest_game/blob/093cd28a279f42592a53762e2a8452f29b2a31ba/.luacheckrc#L13

### How to test
Add `VoxelManip()` somewhere.
`luacheck --config=games/devtest/.luacheckrc games/devtest`
`luacheck builtin`
