### PR TITLE
Fix register_ore ore_type error handling

### DIFF
--- a/src/mapgen/mg_ore.h
+++ b/src/mapgen/mg_ore.h
@@ -172,9 +172,8 @@ public:
 			return new OreVein;
 		case ORE_STRATUM:
 			return new OreStratum;
-		default:
-			return new OreScatter;
 		}
+		return nullptr;
 	}
 
 	void clear();

--- a/src/mapgen/mg_ore.h
+++ b/src/mapgen/mg_ore.h
@@ -173,7 +173,7 @@ public:
 		case ORE_STRATUM:
 			return new OreStratum;
 		default:
-			return nullptr;
+			return new OreScatter;
 		}
 	}
 

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1322,14 +1322,15 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 	BiomeManager *bmgr    = emerge->getWritableBiomeManager();
 	OreManager *oremgr    = emerge->getWritableOreManager();
 
-	enum OreType oretype = (OreType)getenumfield(L, index,
-				"ore_type", es_OreType, ORE_SCATTER);
-	Ore *ore = oremgr->create(oretype);
-	if (!ore) {
-		errorstream << "register_ore: ore_type " << oretype << " not implemented\n";
+	int oretype_int;
+	std::string oretype_string = getstringfield_default(L, index, "ore_type", "nil");
+	if (!string_to_enum(es_OreType, oretype_int, oretype_string)) {
+		errorstream << "register_ore: unknown oretype \"" << oretype_string << "\"" << std::endl;
 		return 0;
 	}
+	enum OreType oretype = (OreType) oretype_int;
 
+	Ore *ore = oremgr->create(oretype);
 	ore->name           = getstringfield_default(L, index, "name", "");
 	ore->ore_param2     = (u8)getintfield_default(L, index, "ore_param2", 0);
 	ore->clust_scarcity = getintfield_default(L, index, "clust_scarcity", 1);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1453,7 +1453,7 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 
 	ndef->pendNodeResolve(ore.get());
 
-	// Note that oremgr is responsible for the ore object now, not the NodeResolver.
+	// We passed ownership of the ore object to oremgr earlier.
 	ore.release();
 
 	lua_pushinteger(L, handle);


### PR DESCRIPTION
### Goal of the PR
This tries to solve #8294.

### How does the PR work?
It fixes what happens when the `ore_type` inside a `core.register_ore` definition is not valid.
It no longer defaults to `scatter`, this was a bug if I interpreted the previous code correctly.
There is no way how the previous error code could have been executed.
https://github.com/minetest/minetest/blob/a5e3fca40c8feb74c91cafca1aef1423e5375bb6/src/script/lua_api/l_mapgen.cpp#L1328-L1331

(I could change it back to default to `scatter` and only add an additional warning, but it is not part of the documentation.)

(I had to add an additional `oretype_int` since you can't easily get a `int&` from an arbitrary enum type, I think.)

### To do

Ready for Review.

### How to test

- See that ores still work.
- Check that the error code works e.g.
```lua
core.register_ore({
	ore_type = "test",
})
```


