### PR TITLE
Don't memset SEvent 3

### DIFF
--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -713,7 +713,7 @@ bool CIrrDeviceSDL::run()
 
 	while (!Close && wrap_PollEvent(&SDL_event)) {
 		// os::Printer::log("event: ", core::stringc((int)SDL_event.type).c_str(),   ELL_INFORMATION);	// just for debugging
-		memset(&irrevent, 0, sizeof(irrevent));
+		irrevent = {};
 
 		switch (SDL_event.type) {
 		case SDL_MOUSEMOTION: {


### PR DESCRIPTION
This is a part of #15344 that was not carried over to #15359 for some reason.

Now that #15359 has been merged, this should be fine?

Compiler warning fixed by this PR:

```
/mt/irr/src/CIrrDeviceSDL.cpp: In member function 'virtual bool irr::CIrrDeviceSDL::run()':
/mt/irr/src/CIrrDeviceSDL.cpp:716:23: warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct irr::SEvent'; use assignment or value-initialization instead [-Wclass-memaccess]
  716 |                 memset(&irrevent, 0, sizeof(irrevent));
      |                 ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /mt/irr/include/IrrlichtDevice.h:11,
                 from /mt/irr/src/CIrrDeviceSDL.h:11,
                 from /mt/irr/src/CIrrDeviceSDL.cpp:7:
/mt/irr/include/IEventReceiver.h:301:8: note: 'struct irr::SEvent' declared here
  301 | struct SEvent
      |        ^~~~~~
```

## To do

This PR is a Ready for Review.

## How to test

...
