### PR TITLE
Convert `axisAlignedCollision` tasts to Catch2 and improve docs

### DIFF
--- a/src/collision.h
+++ b/src/collision.h
@@ -70,10 +70,19 @@ bool collision_check_intersection(Environment *env, IGameDef *gamedef,
 		const aabb3f &box_0, const v3f &pos_f, ActiveObject *self = nullptr,
 		bool collide_with_objects = true);
 
-// Helper function:
-// Checks for collision of a moving aabbox with a static aabbox
-// Returns -1 if no collision, 0 if X collision, 1 if Y collision, 2 if Z collision
-// dtime receives time until first collision, invalid if -1 is returned
+/**
+ * Helper function to check for collision of a moving aabbox with a static one.
+ *
+ * @param staticbox A stationary hitbox.
+ * @param movingbox A moving hitbox.
+ * @param speed     The velocity of the moving hitbox.
+ * @param dtime     Only collisions that occur within @dtime will be
+ *                  searched.
+ *
+ * @return Returns -1 if no collision, 0 if X collision, 1 if Y collision,
+ * 2 if Z collision. Sets @a dtime to the time until the first collision,
+ * or to -1 if no collision occurs.
+ */
 CollisionAxis axisAlignedCollision(
 		const aabb3f &staticbox, const aabb3f &movingbox,
 		v3f speed, f32 *dtime);


### PR DESCRIPTION
This is just cleanup. The content of the unit tests should not be changed, although one redundant test was removed. It looked like the author copy-pasted a test, intending to change the test parameters, but forgot to change them. Since I don't know what the author intended to change, I took it back out. I have not converted the `collisionMoveSimple` tests that were recently added, and I do not have time to in the near future.

I have also reworded the docstring of the function under test to clarify that `dtime` is an inout parameter. The original wording does not seem to mention its use as an input to the function. This information came from @appgurueu, and I observed it to be correct based on the unit test behavior; I have not read the code of the function under test.

## To do

Ready for Review.

## How to test

`minetest --run-unittests --test-module "[collision]"`
