### PR TITLE
Make string to v3f parsing consistent, replace `core.setting_get_pos()` by `core.settings:get_pos()`

### DIFF
--- a/builtin/game/misc_s.lua
+++ b/builtin/game/misc_s.lua
@@ -36,7 +36,6 @@ end
 
 
 function core.setting_get_pos(name)
-	core.log("deprecated", "Deprecated usage of setting_get_pos, use core.settings:get_pos() instead")
     return core.settings:get_pos(name)
 end
 

--- a/builtin/game/misc_s.lua
+++ b/builtin/game/misc_s.lua
@@ -36,11 +36,8 @@ end
 
 
 function core.setting_get_pos(name)
-	local value = core.settings:get(name)
-	if not value then
-		return nil
-	end
-	return core.string_to_pos(value)
+	core.log("deprecated", "Deprecated usage of setting_get_pos, use core.settings:get_pos() instead")
+    return core.settings:get_pos(name)
 end
 
 

--- a/builtin/game/static_spawn.lua
+++ b/builtin/game/static_spawn.lua
@@ -1,7 +1,7 @@
 local static_spawnpoint_string = core.settings:get("static_spawnpoint")
 if static_spawnpoint_string and
 		static_spawnpoint_string ~= "" and
-		not core.setting_get_pos("static_spawnpoint") then
+		not core.settings:get_pos("static_spawnpoint") then
 	error('The static_spawnpoint setting is invalid: "' ..
 			static_spawnpoint_string .. '"')
 end

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9050,7 +9050,7 @@ means that no defaults will be returned for mod settings.
     * Returns `nil` if `key` is not found.
 * `get_pos(key)`:
     * Returns a `vector`
-    * Returns `nil` if no value is found of parsing failed.
+    * Returns `nil` if no value is found or parsing failed.
 * `set(key, value)`
     * Setting names can't contain whitespace or any of `="{}#`.
     * Setting values can't contain the sequence `\n"""`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9061,6 +9061,9 @@ means that no defaults will be returned for mod settings.
 * `set_np_group(key, value)`
     * `value` is a NoiseParams table.
     * Also, see documentation for `set()` above.
+* `set_pos(key, value)`
+    * `value` is a `vector`.
+    * Also, see documentation for `set()` above.
 * `remove(key)`: returns a boolean (`true` for success)
 * `get_names()`: returns `{key1,...}`
 * `has(key)`:

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6180,7 +6180,7 @@ Setting-related
 * `core.settings`: Settings object containing all of the settings from the
   main config file (`minetest.conf`). See [`Settings`].
 * `core.setting_get_pos(name)`: Loads a setting from the main settings and
-  parses it as a position (in the format `(1,2,3)`). Returns a position or nil.
+  parses it as a position (in the format `(1,2,3)`). Returns a position or nil. **Deprecated: use `core.settings:get_pos()` instead**
 
 Authentication
 --------------
@@ -9048,6 +9048,9 @@ means that no defaults will be returned for mod settings.
     * Is currently limited to mapgen flags `mg_flags` and mapgen-specific
       flags like `mgv5_spflags`.
     * Returns `nil` if `key` is not found.
+* `get_pos(key)`:
+    * Returns a `vector`
+    * Returns `nil` if no value is found of parsing failed.
 * `set(key, value)`
     * Setting names can't contain whitespace or any of `="{}#`.
     * Setting values can't contain the sequence `\n"""`.

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -54,14 +54,14 @@ Hud::Hud(Client *client, LocalPlayer *player,
 
 	tsrc = client->getTextureSource();
 
-	v3f crosshair_color = g_settings->getV3F("crosshair_color");
+	v3f crosshair_color = g_settings->getV3F("crosshair_color").value_or(v3f());
 	u32 cross_r = rangelim(myround(crosshair_color.X), 0, 255);
 	u32 cross_g = rangelim(myround(crosshair_color.Y), 0, 255);
 	u32 cross_b = rangelim(myround(crosshair_color.Z), 0, 255);
 	u32 cross_a = rangelim(g_settings->getS32("crosshair_alpha"), 0, 255);
 	crosshair_argb = video::SColor(cross_a, cross_r, cross_g, cross_b);
 
-	v3f selectionbox_color = g_settings->getV3F("selectionbox_color");
+	v3f selectionbox_color = g_settings->getV3F("selectionbox_color").value_or(v3f());
 	u32 sbox_r = rangelim(myround(selectionbox_color.X), 0, 255);
 	u32 sbox_g = rangelim(myround(selectionbox_color.Y), 0, 255);
 	u32 sbox_b = rangelim(myround(selectionbox_color.Z), 0, 255);

--- a/src/database/database-files.cpp
+++ b/src/database/database-files.cpp
@@ -43,7 +43,7 @@ void PlayerDatabaseFiles::deSerialize(RemotePlayer *p, std::istream &is,
 		}
 
 		try {
-			sao->setBasePosition(args.getV3F("position"));
+			sao->setBasePosition(args.getV3F("position").value_or(v3f()));
 		} catch (SettingNotFoundException &e) {}
 
 		try {

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -55,7 +55,7 @@ GUIChatConsole::GUIChatConsole(
 		m_background_color.setGreen(255);
 		m_background_color.setBlue(255);
 	} else {
-		v3f console_color = g_settings->getV3F("console_color");
+		v3f console_color = g_settings->getV3F("console_color").value_or(v3f());
 		m_background_color.setRed(clamp_u8(myround(console_color.X)));
 		m_background_color.setGreen(clamp_u8(myround(console_color.Y)));
 		m_background_color.setBlue(clamp_u8(myround(console_color.Z)));

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3010,7 +3010,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	m_tabheader_upper_edge = 0;
 
 	{
-		v3f formspec_bgcolor = g_settings->getV3F("formspec_fullscreen_bg_color");
+		v3f formspec_bgcolor = g_settings->getV3F("formspec_fullscreen_bg_color").value_or(v3f());
 		m_fullscreen_bgcolor = video::SColor(
 			(u8) clamp_u8(g_settings->getS32("formspec_fullscreen_bg_opacity")),
 			clamp_u8(myround(formspec_bgcolor.X)),

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -295,10 +295,8 @@ std::string ItemStack::getWieldOverlay(const IItemDefManager *itemdef) const
 v3f ItemStack::getWieldScale(const IItemDefManager *itemdef) const
 {
 	std::string scale = metadata.getString("wield_scale");
-	if (scale.empty())
-		return getDefinition(itemdef).wield_scale;
 
-	return str_to_v3f(scale);
+	return str_to_v3f(scale).value_or(getDefinition(itemdef).wield_scale);
 }
 
 ItemStack ItemStack::addItem(ItemStack newitem, IItemDefManager *itemdef)

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -106,7 +106,7 @@ void MapgenFractalParams::readParams(const Settings *settings)
 
     std::optional<v3f> mgfractalScale;
     if (settings->getV3FNoEx("mgfractal_scale", mgfractalScale) && mgfractalScale.has_value()) {
-        scale = mgfractalScale.value();
+        scale = *mgfractalScale;
     }
 
     std::optional<v3f> mgfractalOffset;

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -103,8 +103,17 @@ void MapgenFractalParams::readParams(const Settings *settings)
 	settings->getS16NoEx("mgfractal_dungeon_ymax",         dungeon_ymax);
 	settings->getU16NoEx("mgfractal_fractal",              fractal);
 	settings->getU16NoEx("mgfractal_iterations",           iterations);
-	settings->getV3FNoEx("mgfractal_scale",                scale);
-	settings->getV3FNoEx("mgfractal_offset",               offset);
+
+    std::optional<v3f> mgfractalScale;
+    if (settings->getV3FNoEx("mgfractal_scale", mgfractalScale) && mgfractalScale.has_value()) {
+        scale = mgfractalScale.value();
+    }
+
+    std::optional<v3f> mgfractalOffset;
+    if (settings->getV3FNoEx("mgfractal_offset", mgfractalOffset) && mgfractalOffset.has_value()) {
+        offset = mgfractalOffset.value();
+    }
+
 	settings->getFloatNoEx("mgfractal_slice_w",            slice_w);
 	settings->getFloatNoEx("mgfractal_julia_x",            julia_x);
 	settings->getFloatNoEx("mgfractal_julia_y",            julia_y);

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -104,14 +104,14 @@ void MapgenFractalParams::readParams(const Settings *settings)
 	settings->getU16NoEx("mgfractal_fractal",              fractal);
 	settings->getU16NoEx("mgfractal_iterations",           iterations);
 
-    std::optional<v3f> mgfractalScale;
-    if (settings->getV3FNoEx("mgfractal_scale", mgfractalScale) && mgfractalScale.has_value()) {
-        scale = *mgfractalScale;
+    std::optional<v3f> mgfractal_scale;
+    if (settings->getV3FNoEx("mgfractal_scale", mgfractal_scale) && mgfractal_scale.has_value()) {
+        scale = *mgfractal_scale;
     }
 
-    std::optional<v3f> mgfractalOffset;
-    if (settings->getV3FNoEx("mgfractal_offset", mgfractalOffset) && mgfractalOffset.has_value()) {
-        offset = mgfractalOffset.value();
+    std::optional<v3f> mgfractal_offset;
+    if (settings->getV3FNoEx("mgfractal_offset", mgfractal_offset) && mgfractal_offset.has_value()) {
+        offset = *mgfractal_offset;
     }
 
 	settings->getFloatNoEx("mgfractal_slice_w",            slice_w);

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -186,7 +186,7 @@ int LuaSettings::l_get_pos(lua_State *L)
 
     std::optional<v3f> pos;
     if (o->m_settings->getV3FNoEx(key, pos) && pos.has_value())
-        push_v3f(L, pos.value());
+        push_v3f(L, *pos);
     else
         lua_pushnil(L);
     return 1;

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -248,7 +248,7 @@ int LuaSettings::l_set_pos(lua_State *L)
     NO_MAP_LOCK_REQUIRED;
     LuaSettings *o = checkObject<LuaSettings>(L, 1);
 
-    std::string key = std::string(luaL_checkstring(L, 2));
+    std::string key = luaL_checkstring(L, 2);
     v3f value = read_v3f(L, 3);
 
     CHECK_SETTING_SECURITY(L, key);

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -249,7 +249,7 @@ int LuaSettings::l_set_pos(lua_State *L)
     LuaSettings *o = checkObject<LuaSettings>(L, 1);
 
     std::string key = luaL_checkstring(L, 2);
-    v3f value = read_v3f(L, 3);
+    v3f value = check_v3f(L, 3);
 
     CHECK_SETTING_SECURITY(L, key);
 

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -242,6 +242,22 @@ int LuaSettings::l_set_np_group(lua_State *L)
 	return 0;
 }
 
+// set_pos(self, key, value)
+int LuaSettings::l_set_pos(lua_State *L)
+{
+    NO_MAP_LOCK_REQUIRED;
+    LuaSettings *o = checkObject<LuaSettings>(L, 1);
+
+    std::string key = std::string(luaL_checkstring(L, 2));
+    v3f value = read_v3f(L, 3);
+
+    CHECK_SETTING_SECURITY(L, key);
+
+    o->m_settings->setV3F(key, value);
+
+    return 0;
+}
+
 // remove(self, key) -> success
 int LuaSettings::l_remove(lua_State* L)
 {
@@ -375,6 +391,7 @@ const luaL_Reg LuaSettings::methods[] = {
 	luamethod(LuaSettings, set),
 	luamethod(LuaSettings, set_bool),
 	luamethod(LuaSettings, set_np_group),
+    luamethod(LuaSettings, set_pos),
 	luamethod(LuaSettings, remove),
 	luamethod(LuaSettings, get_names),
 	luamethod(LuaSettings, has),

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -178,17 +178,17 @@ int LuaSettings::l_get_flags(lua_State *L)
 }
 
 // get_pos(self, key) -> vector or nil
-int LuaSettings::l_get_pos(lua_State *L) {
+int LuaSettings::l_get_pos(lua_State *L)
+{
     NO_MAP_LOCK_REQUIRED;
     LuaSettings *o = checkObject<LuaSettings>(L, 1);
-    std::string key = std::string(luaL_checkstring(L, 2));
+    std::string key = luaL_checkstring(L, 2);
 
     std::optional<v3f> pos;
-    if (o->m_settings->getV3FNoEx(key, pos) && pos.has_value()) {
+    if (o->m_settings->getV3FNoEx(key, pos) && pos.has_value())
         push_v3f(L, pos.value());
-    } else {
+    else
         lua_pushnil(L);
-    }
     return 1;
 }
 

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -10,6 +10,7 @@
 #include "settings.h"
 #include "noise.h"
 #include "log.h"
+#include "common/c_converter.h"
 
 
 /* This protects the following from being set:
@@ -174,6 +175,21 @@ int LuaSettings::l_get_flags(lua_State *L)
 	}
 
 	return 1;
+}
+
+// get_pos(self, key) -> vector or nil
+int LuaSettings::l_get_pos(lua_State *L) {
+    NO_MAP_LOCK_REQUIRED;
+    LuaSettings *o = checkObject<LuaSettings>(L, 1);
+    std::string key = std::string(luaL_checkstring(L, 2));
+
+    std::optional<v3f> pos;
+    if (o->m_settings->getV3FNoEx(key, pos) && pos.has_value()) {
+        push_v3f(L, pos.value());
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
 }
 
 // set(self, key, value)
@@ -355,6 +371,7 @@ const luaL_Reg LuaSettings::methods[] = {
 	luamethod(LuaSettings, get_bool),
 	luamethod(LuaSettings, get_np_group),
 	luamethod(LuaSettings, get_flags),
+    luamethod(LuaSettings, get_pos),
 	luamethod(LuaSettings, set),
 	luamethod(LuaSettings, set_bool),
 	luamethod(LuaSettings, set_np_group),

--- a/src/script/lua_api/l_settings.h
+++ b/src/script/lua_api/l_settings.h
@@ -29,6 +29,9 @@ private:
 	// get_flags(self, key) -> key/value table
 	static int l_get_flags(lua_State *L);
 
+    // get_pos(self, key) -> vector or nil
+    static int l_get_pos(lua_State *L);
+
 	// set(self, key, value)
 	static int l_set(lua_State *L);
 

--- a/src/script/lua_api/l_settings.h
+++ b/src/script/lua_api/l_settings.h
@@ -41,6 +41,9 @@ private:
 	// set_np_group(self, key, value)
 	static int l_set_np_group(lua_State *L);
 
+    // set_pos(self, key, value)
+    static int l_set_pos(lua_State *L);
+
 	// remove(self, key) -> success
 	static int l_remove(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3873,8 +3873,10 @@ v3f Server::findSpawnPos()
 
     std::optional<v3f> staticSpawnPoint;
 	if (g_settings->getV3FNoEx("static_spawnpoint", staticSpawnPoint) && staticSpawnPoint.has_value())
+    {
         nodeposf = staticSpawnPoint.value();
-		return nodeposf * BS;
+        return nodeposf * BS;
+    }
 
 	bool is_good = false;
 	// Limit spawn range to mapgen edges (determined by 'mapgen_limit')

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3876,6 +3876,8 @@ v3f Server::findSpawnPos()
        return *staticSpawnPoint * BS;
     }
 
+    v3f nodeposf;
+
 	bool is_good = false;
 	// Limit spawn range to mapgen edges (determined by 'mapgen_limit')
 	s32 range_max = map.getMapgenParams()->getSpawnRangeMax();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3869,13 +3869,11 @@ void Server::addShutdownError(const ModError &e)
 v3f Server::findSpawnPos()
 {
 	ServerMap &map = m_env->getServerMap();
-	v3f nodeposf;
 
     std::optional<v3f> staticSpawnPoint;
 	if (g_settings->getV3FNoEx("static_spawnpoint", staticSpawnPoint) && staticSpawnPoint.has_value())
     {
        return *staticSpawnPoint * BS;
-        return nodeposf * BS;
     }
 
 	bool is_good = false;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3870,7 +3870,10 @@ v3f Server::findSpawnPos()
 {
 	ServerMap &map = m_env->getServerMap();
 	v3f nodeposf;
-	if (g_settings->getV3FNoEx("static_spawnpoint", nodeposf))
+
+    std::optional<v3f> staticSpawnPoint;
+	if (g_settings->getV3FNoEx("static_spawnpoint", staticSpawnPoint) && staticSpawnPoint.has_value())
+        nodeposf = staticSpawnPoint.value();
 		return nodeposf * BS;
 
 	bool is_good = false;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3874,7 +3874,7 @@ v3f Server::findSpawnPos()
     std::optional<v3f> staticSpawnPoint;
 	if (g_settings->getV3FNoEx("static_spawnpoint", staticSpawnPoint) && staticSpawnPoint.has_value())
     {
-        nodeposf = staticSpawnPoint.value();
+       return *staticSpawnPoint * BS;
         return nodeposf * BS;
     }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -629,7 +629,7 @@ bool Settings::getNoiseParamsFromGroup(const std::string &name,
 
     std::optional<v3f> spread;
 	if (group->getV3FNoEx("spread", spread) && spread.has_value())
-        np.spread = spread.value();
+        np.spread = *spread;
 
 	group->getS32NoEx("seed",          np.seed);
 	group->getU16NoEx("octaves",       np.octaves);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -541,7 +541,7 @@ v2f Settings::getV2F(const std::string &name) const
 }
 
 
-v3f Settings::getV3F(const std::string &name) const
+std::optional<v3f> Settings::getV3F(const std::string &name) const
 {
 	return str_to_v3f(get(name));
 }
@@ -626,7 +626,11 @@ bool Settings::getNoiseParamsFromGroup(const std::string &name,
 
 	group->getFloatNoEx("offset",      np.offset);
 	group->getFloatNoEx("scale",       np.scale);
-	group->getV3FNoEx("spread",        np.spread);
+
+    std::optional<v3f> spread;
+	if (group->getV3FNoEx("spread", spread) && spread.has_value())
+        np.spread = spread.value();
+
 	group->getS32NoEx("seed",          np.seed);
 	group->getU16NoEx("octaves",       np.octaves);
 	group->getFloatNoEx("persistence", np.persist);
@@ -783,7 +787,7 @@ bool Settings::getV2FNoEx(const std::string &name, v2f &val) const
 }
 
 
-bool Settings::getV3FNoEx(const std::string &name, v3f &val) const
+bool Settings::getV3FNoEx(const std::string &name, std::optional<v3f> &val) const
 {
 	try {
 		val = getV3F(name);

--- a/src/settings.h
+++ b/src/settings.h
@@ -150,7 +150,7 @@ public:
 	float getFloat(const std::string &name) const;
 	float getFloat(const std::string &name, float min, float max) const;
 	v2f getV2F(const std::string &name) const;
-	v3f getV3F(const std::string &name) const;
+	std::optional<v3f> getV3F(const std::string &name) const;
 	u32 getFlagStr(const std::string &name, const FlagDesc *flagdesc,
 			u32 *flagmask) const;
 	bool getNoiseParams(const std::string &name, NoiseParams &np) const;
@@ -179,7 +179,7 @@ public:
 	bool getU64NoEx(const std::string &name, u64 &val) const;
 	bool getFloatNoEx(const std::string &name, float &val) const;
 	bool getV2FNoEx(const std::string &name, v2f &val) const;
-	bool getV3FNoEx(const std::string &name, v3f &val) const;
+	bool getV3FNoEx(const std::string &name, std::optional<v3f> &val) const;
 
 	// Like other getters, but handling each flag individualy:
 	// 1) Read default flags (or 0)

--- a/src/unittest/test_settings.cpp
+++ b/src/unittest/test_settings.cpp
@@ -140,18 +140,18 @@ void TestSettings::testAllSettings()
 	// Not sure if 1.1 is an exact value as a float, but doesn't matter
 	UASSERT(fabs(s.getFloat("floaty_thing") - 1.1) < 0.001);
 	UASSERT(s.get("stringy_thing") == u8"asd /( ¤%&(/\" BLÖÄRP");
-	UASSERT(fabs(s.getV3F("coord").X - 1.0) < 0.001);
-	UASSERT(fabs(s.getV3F("coord").Y - 2.0) < 0.001);
-	UASSERT(fabs(s.getV3F("coord").Z - 4.5) < 0.001);
+	UASSERT(fabs(s.getV3F("coord").value().X - 1.0) < 0.001);
+	UASSERT(fabs(s.getV3F("coord").value().Y - 2.0) < 0.001);
+	UASSERT(fabs(s.getV3F("coord").value().Z - 4.5) < 0.001);
 
 	// Test the setting of settings too
 	s.setFloat("floaty_thing_2", 1.25);
 	s.setV3F("coord2", v3f(1, 2, 3.3));
 	UASSERT(s.get("floaty_thing_2").substr(0,4) == "1.25");
 	UASSERT(fabs(s.getFloat("floaty_thing_2") - 1.25) < 0.001);
-	UASSERT(fabs(s.getV3F("coord2").X - 1.0) < 0.001);
-	UASSERT(fabs(s.getV3F("coord2").Y - 2.0) < 0.001);
-	UASSERT(fabs(s.getV3F("coord2").Z - 3.3) < 0.001);
+	UASSERT(fabs(s.getV3F("coord2").value().X - 1.0) < 0.001);
+	UASSERT(fabs(s.getV3F("coord2").value().Y - 2.0) < 0.001);
+	UASSERT(fabs(s.getV3F("coord2").value().Z - 3.3) < 0.001);
 
 	// Test settings groups
 	Settings *group = s.getGroup("asdf");

--- a/src/unittest/test_settings.cpp
+++ b/src/unittest/test_settings.cpp
@@ -43,6 +43,12 @@ const char *TestSettings::config_text_before =
 	"stringy_thing = asd /( ¤%&(/\" BLÖÄRP\n"
 	"coord = (1, 2, 4.5)\n"
     "coord_invalid = (1,2,3\n"
+    "coord_invalid_2 = 1, 2, 3 test\n"
+    "coord_invalid_3 = (test, something, stupid)\n"
+    "coord_invalid_4 = (1, test, 3)\n"
+    "coord_invalid_5 = ()\n"
+    "coord_invalid_6 = (1, 2)\n"
+    "coord_invalid_7 = (1)\n"
     "coord_no_parenthesis = 1,2,3\n"
 	"      # this is just a comment\n"
 	"this is an invalid line\n"
@@ -98,6 +104,12 @@ const char *TestSettings::config_text_after =
 	"zoop = true\n"
 	"coord2 = (1,2,3.25)\n"
     "coord_invalid = (1,2,3\n"
+    "coord_invalid_2 = 1, 2, 3 test\n"
+    "coord_invalid_3 = (test, something, stupid)\n"
+    "coord_invalid_4 = (1, test, 3)\n"
+    "coord_invalid_5 = ()\n"
+    "coord_invalid_6 = (1, 2)\n"
+    "coord_invalid_7 = (1)\n"
     "coord_no_parenthesis = 1,2,3\n"
 	"floaty_thing_2 = 1.25\n"
 	"groupy_thing = {\n"
@@ -162,6 +174,12 @@ void TestSettings::testAllSettings()
     EXCEPTION_CHECK(SettingNotFoundException, s.getV3F("coord_not_exist"));
 
     UASSERT(!s.getV3F("coord_invalid").has_value());
+    UASSERT(!s.getV3F("coord_invalid_2").has_value());
+    UASSERT(!s.getV3F("coord_invalid_3").has_value());
+    UASSERT(!s.getV3F("coord_invalid_4").has_value());
+    UASSERT(!s.getV3F("coord_invalid_5").has_value());
+    UASSERT(!s.getV3F("coord_invalid_6").has_value());
+    UASSERT(!s.getV3F("coord_invalid_7").has_value());
 
     std::optional<v3f> testNoParenthesis = s.getV3F("coord_no_parenthesis");
     UASSERT(testNoParenthesis.value() == v3f(1, 2, 3));

--- a/src/unittest/test_settings.cpp
+++ b/src/unittest/test_settings.cpp
@@ -158,13 +158,13 @@ void TestSettings::testAllSettings()
 	UASSERT(fabs(s.getV3F("coord2").value().Z - 3.3) < 0.001);
 
     std::optional<v3f> testNotExist;
-    UASSERT(s.getV3FNoEx("coord_not_exist", testNotExist) == false);
+    UASSERT(!s.getV3FNoEx("coord_not_exist", testNotExist));
     EXCEPTION_CHECK(SettingNotFoundException, s.getV3F("coord_not_exist"));
 
-    UASSERT(s.getV3F("coord_invalid").has_value() == false);
+    UASSERT(!s.getV3F("coord_invalid").has_value());
 
     std::optional<v3f> testNoParenthesis = s.getV3F("coord_no_parenthesis");
-    UASSERT(testNoParenthesis.has_value() == true && testNoParenthesis.value() == v3f(1, 2, 3));
+    UASSERT(testNoParenthesis.value() == v3f(1, 2, 3));
 
 	// Test settings groups
 	Settings *group = s.getGroup("asdf");

--- a/src/unittest/test_settings.cpp
+++ b/src/unittest/test_settings.cpp
@@ -42,6 +42,8 @@ const char *TestSettings::config_text_before =
 	"floaty_thing = 1.1\n"
 	"stringy_thing = asd /( ¤%&(/\" BLÖÄRP\n"
 	"coord = (1, 2, 4.5)\n"
+    "coord_invalid = (1,2,3\n"
+    "coord_no_parenthesis = 1,2,3\n"
 	"      # this is just a comment\n"
 	"this is an invalid line\n"
 	"asdf = {\n"
@@ -95,6 +97,8 @@ const char *TestSettings::config_text_after =
 	"}\n"
 	"zoop = true\n"
 	"coord2 = (1,2,3.3)\n"
+    "coord_invalid = (1,2,3\n"
+    "coord_no_parenthesis = 1,2,3\n"
 	"floaty_thing_2 = 1.25\n"
 	"groupy_thing = {\n"
 	"	animals = cute\n"
@@ -152,6 +156,15 @@ void TestSettings::testAllSettings()
 	UASSERT(fabs(s.getV3F("coord2").value().X - 1.0) < 0.001);
 	UASSERT(fabs(s.getV3F("coord2").value().Y - 2.0) < 0.001);
 	UASSERT(fabs(s.getV3F("coord2").value().Z - 3.3) < 0.001);
+
+    std::optional<v3f> testNotExist;
+    UASSERT(s.getV3FNoEx("coord_not_exist", testNotExist) == false);
+    EXCEPTION_CHECK(SettingNotFoundException, s.getV3F("coord_not_exist"));
+
+    UASSERT(s.getV3F("coord_invalid").has_value() == false);
+
+    std::optional<v3f> testNoParenthesis = s.getV3F("coord_no_parenthesis");
+    UASSERT(testNoParenthesis.has_value() == true && testNoParenthesis.value() == v3f(1, 2, 3));
 
 	// Test settings groups
 	Settings *group = s.getGroup("asdf");

--- a/src/unittest/test_settings.cpp
+++ b/src/unittest/test_settings.cpp
@@ -96,7 +96,7 @@ const char *TestSettings::config_text_after =
 	"	spread = (250,250,250)\n"
 	"}\n"
 	"zoop = true\n"
-	"coord2 = (1,2,3.3)\n"
+	"coord2 = (1,2,3.25)\n"
     "coord_invalid = (1,2,3\n"
     "coord_no_parenthesis = 1,2,3\n"
 	"floaty_thing_2 = 1.25\n"
@@ -144,18 +144,18 @@ void TestSettings::testAllSettings()
 	// Not sure if 1.1 is an exact value as a float, but doesn't matter
 	UASSERT(fabs(s.getFloat("floaty_thing") - 1.1) < 0.001);
 	UASSERT(s.get("stringy_thing") == u8"asd /( ¤%&(/\" BLÖÄRP");
-	UASSERT(fabs(s.getV3F("coord").value().X - 1.0) < 0.001);
-	UASSERT(fabs(s.getV3F("coord").value().Y - 2.0) < 0.001);
-	UASSERT(fabs(s.getV3F("coord").value().Z - 4.5) < 0.001);
+	UASSERT(s.getV3F("coord").value().X == 1.0);
+	UASSERT(s.getV3F("coord").value().Y == 2.0);
+	UASSERT(s.getV3F("coord").value().Z == 4.5);
 
 	// Test the setting of settings too
 	s.setFloat("floaty_thing_2", 1.25);
-	s.setV3F("coord2", v3f(1, 2, 3.3));
+	s.setV3F("coord2", v3f(1, 2, 3.25));
 	UASSERT(s.get("floaty_thing_2").substr(0,4) == "1.25");
-	UASSERT(fabs(s.getFloat("floaty_thing_2") - 1.25) < 0.001);
-	UASSERT(fabs(s.getV3F("coord2").value().X - 1.0) < 0.001);
-	UASSERT(fabs(s.getV3F("coord2").value().Y - 2.0) < 0.001);
-	UASSERT(fabs(s.getV3F("coord2").value().Z - 3.3) < 0.001);
+	UASSERT(s.getFloat("floaty_thing_2") == 1.25);
+	UASSERT(s.getV3F("coord2").value().X == 1.0);
+	UASSERT(s.getV3F("coord2").value().Y == 2.0);
+	UASSERT(s.getV3F("coord2").value().Z == 3.25);
 
     std::optional<v3f> testNotExist;
     UASSERT(!s.getV3FNoEx("coord_not_exist", testNotExist));

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -1082,7 +1082,7 @@ std::optional<v3f> str_to_v3f(std::string_view str)
         str.remove_suffix(1);
     }
 
-    std::istringstream iss(std::string(str));
+    std::istringstream iss((std::string(str)));
 
     const auto expect_delimiter = [&]() {
         const auto c = iss.get();

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -1079,9 +1079,8 @@ std::optional<v3f> str_to_v3f(std::string_view str)
     if (str.front() == '(' && str.back() == ')') {
         str.remove_prefix(1);
         str.remove_suffix(1);
+        str = trim(str);
     }
-
-    str = trim(str);
 
     std::istringstream iss((std::string(str)));
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -14,7 +14,6 @@
 
 #include <algorithm>
 #include <array>
-#include <regex>
 #include <sstream>
 #include <iomanip>
 #include <unordered_map>

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -1096,5 +1096,7 @@ std::optional<v3f> str_to_v3f(std::string_view str)
     if (!expect_delimiter()) return std::nullopt;
     if (!(iss >> value.Z)) return std::nullopt;
 
+    while (!iss.eof()) if (!std::isspace(iss.get())) return std::nullopt;
+
     return value;
 }

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -1072,15 +1072,16 @@ std::optional<v3f> str_to_v3f(std::string_view str)
 {
     str = trim(str);
 
-    if (str.empty()) {
+    if (str.empty())
         return std::nullopt;
-    }
 
     // Strip parentheses if they exist
     if (str.front() == '(' && str.back() == ')') {
         str.remove_prefix(1);
         str.remove_suffix(1);
     }
+
+    str = trim(str);
 
     std::istringstream iss((std::string(str)));
 
@@ -1090,13 +1091,19 @@ std::optional<v3f> str_to_v3f(std::string_view str)
     };
 
     v3f value;
-    if (!(iss >> value.X)) return std::nullopt;
-    if (!expect_delimiter()) return std::nullopt;
-    if (!(iss >> value.Y)) return std::nullopt;
-    if (!expect_delimiter()) return std::nullopt;
-    if (!(iss >> value.Z)) return std::nullopt;
+    if (!(iss >> value.X))
+        return std::nullopt;
+    if (!expect_delimiter())
+        return std::nullopt;
+    if (!(iss >> value.Y))
+        return std::nullopt;
+    if (!expect_delimiter())
+        return std::nullopt;
+    if (!(iss >> value.Z))
+        return std::nullopt;
 
-    while (!iss.eof()) if (!std::isspace(iss.get())) return std::nullopt;
+    if (!iss.eof())
+        return std::nullopt;
 
     return value;
 }

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -1070,6 +1070,8 @@ void safe_print_string(std::ostream &os, std::string_view str)
 
 std::optional<v3f> str_to_v3f(std::string_view str)
 {
+    str = trim(str);
+
     if (str.empty()) {
         return std::nullopt;
     }

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -1069,25 +1069,28 @@ void safe_print_string(std::ostream &os, std::string_view str)
 	os.setf(flags);
 }
 
-const std::regex patternParenthesis(R"(^\((.*?)\)$)");
-const std::regex patternCoordinates(R"(^([\d.-]+)[,\s]\s*([\d.-]+)[,\s]\s*([\d.-]+)$)");
-
-v3f str_to_v3f(std::string_view str)
-{
+std::optional<v3f> str_to_v3f(std::string_view str) {
     v3f value;
-    std::cmatch matches;
 
-    // Strip parentheses
-    if (std::regex_search(str.data(), str.data() + str.size(), matches, patternParenthesis)) {
-        str = std::string_view(matches[1].first, matches[1].length());
+    // Strip parentheses if they exist
+    if (str.front() == '(' && str.back() == ')') {
+        str.remove_prefix(1);
+        str.remove_suffix(1);
     }
 
-    // Match coordinates
-    if (std::regex_search(str.data(), str.data() + str.size(), matches, patternCoordinates)) {
-        value.X = stof(matches[1].str());
-        value.Y = stof(matches[2].str());
-        value.Z = stof(matches[3].str());
+    // Replace commas with spaces
+    std::string str_copy(str);
+    for (char& ch : str_copy) {
+        if (ch == ',') {
+            ch = ' ';
+        }
     }
 
-    return value;
+    // Parse coordinates
+    std::istringstream iss(str_copy);
+    if (iss >> value.X >> value.Y >> value.Z) {
+        return value;
+    }
+
+    return std::nullopt;
 }

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -1069,8 +1069,13 @@ void safe_print_string(std::ostream &os, std::string_view str)
 	os.setf(flags);
 }
 
-std::optional<v3f> str_to_v3f(std::string_view str) {
+std::optional<v3f> str_to_v3f(std::string_view str)
+{
     v3f value;
+
+    if (str.empty()) {
+        return std::nullopt;
+    }
 
     // Strip parentheses if they exist
     if (str.front() == '(' && str.back() == ')') {

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -1082,7 +1082,7 @@ std::optional<v3f> str_to_v3f(std::string_view str)
         str.remove_suffix(1);
     }
 
-    std::istringstream iss((std::string(str)));
+    std::istringstream iss(std::string(str));
 
     const auto expect_delimiter = [&]() {
         const auto c = iss.get();

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -1070,8 +1070,6 @@ void safe_print_string(std::ostream &os, std::string_view str)
 
 std::optional<v3f> str_to_v3f(std::string_view str)
 {
-    v3f value;
-
     if (str.empty()) {
         return std::nullopt;
     }
@@ -1082,19 +1080,19 @@ std::optional<v3f> str_to_v3f(std::string_view str)
         str.remove_suffix(1);
     }
 
-    // Replace commas with spaces
-    std::string str_copy(str);
-    for (char& ch : str_copy) {
-        if (ch == ',') {
-            ch = ' ';
-        }
-    }
+    std::istringstream iss((std::string(str)));
 
-    // Parse coordinates
-    std::istringstream iss(str_copy);
-    if (iss >> value.X >> value.Y >> value.Z) {
-        return value;
-    }
+    const auto expect_delimiter = [&]() {
+        const auto c = iss.get();
+        return c == ' ' || c == ',';
+    };
 
-    return std::nullopt;
+    v3f value;
+    if (!(iss >> value.X)) return std::nullopt;
+    if (!expect_delimiter()) return std::nullopt;
+    if (!(iss >> value.Y)) return std::nullopt;
+    if (!expect_delimiter()) return std::nullopt;
+    if (!(iss >> value.Z)) return std::nullopt;
+
+    return value;
 }

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <array>
+#include <regex>
 #include <sstream>
 #include <iomanip>
 #include <unordered_map>
@@ -1068,14 +1069,25 @@ void safe_print_string(std::ostream &os, std::string_view str)
 	os.setf(flags);
 }
 
+const std::regex patternParenthesis(R"(^\((.*?)\)$)");
+const std::regex patternCoordinates(R"(^([\d.-]+)[,\s]\s*([\d.-]+)[,\s]\s*([\d.-]+)$)");
 
 v3f str_to_v3f(std::string_view str)
 {
-	v3f value;
-	Strfnd f(str);
-	f.next("(");
-	value.X = stof(f.next(","));
-	value.Y = stof(f.next(","));
-	value.Z = stof(f.next(")"));
-	return value;
+    v3f value;
+    std::cmatch matches;
+
+    // Strip parentheses
+    if (std::regex_search(str.data(), str.data() + str.size(), matches, patternParenthesis)) {
+        str = std::string_view(matches[1].first, matches[1].length());
+    }
+
+    // Match coordinates
+    if (std::regex_search(str.data(), str.data() + str.size(), matches, patternCoordinates)) {
+        value.X = stof(matches[1].str());
+        value.Y = stof(matches[2].str());
+        value.Z = stof(matches[3].str());
+    }
+
+    return value;
 }

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -790,7 +790,7 @@ std::string sanitize_untrusted(std::string_view str, bool keep_escapes = true);
 void safe_print_string(std::ostream &os, std::string_view str);
 
 /**
- * Parses a string of form `(1, 2, 3)` to a v3f
+ * Parses a string of form `(1, 2, 3)` or `1, 2, 4` to a v3f
  *
  * @param str string
  * @return float vector

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -20,6 +20,7 @@
 #include <cctype>
 #include <cwctype>
 #include <unordered_map>
+#include <optional>
 
 class Translations;
 
@@ -794,4 +795,4 @@ void safe_print_string(std::ostream &os, std::string_view str);
  * @param str string
  * @return float vector
  */
-v3f str_to_v3f(std::string_view str);
+std::optional<v3f> str_to_v3f(std::string_view str);


### PR DESCRIPTION
Fix #14033 and #6062

## To do

This PR is Ready for Review.

- [x] Reimplement `str_to_v3f` ~~using regex~~
- [x] How to handle invalid parsing? The Lua version returns nil.
- [x] Implement the `Settings` class method `get_pos`
- [x] Implement the `Settings` class method `set_pos`
- [x] Deprecate the old Lua function `core.setting_get_pos`
- [x] Documentation
- [x] Tests

## How to test

Put that in the main function, see the results in console.

```cpp
    auto t = str_to_v3f("(1,2,3)").value();
    printf("(1,2,3) => v3f: %f, %f, %f\n", t.X, t.Y, t.Z);
    auto t2 = str_to_v3f("(-1.467247,2.23,323.23)").value();
    printf("(-1.467247,2.23,323.23) => v3f: %f, %f, %f\n", t2.X, t2.Y, t2.Z);
    auto t3 = str_to_v3f("-1,2.23, 323.23").value();
    printf("-1,2.23, 323.23 => v3f: %f, %f, %f\n", t3.X, t3.Y, t3.Z);
    auto t4 = str_to_v3f("(-1,2.23,323.23");
    if (!t4.has_value()) {
        printf("(-1,2.23,323.23 => v3f: null\n");
    }

    auto t5 = str_to_v3f("");
    if (!t5.has_value()) {
        printf("\"\" => v3f: null\n");
    }

    exit(0);
```

t1 and t2 should pass with both the new and the old implementation
t3 should pass ONLY with the new implementation (space)
t4 returns a zero vector with the new implementation at the moment (the Lua version returns nil instead)

Later in the function (if placed at the start it segfault):
```cpp
    std::optional<v3f> ttt;
    ttt = g_settings->getV3F("static_spawnpoint");

    v3f tttt = ttt.value_or(v3f());

    printf("static_spawnpoint: %f, %f, %f\n", tttt.X, tttt.Y, tttt.Z); // should be equal to your static spawn point or 0,0,0
```

Try the Lua methods in builtin or a mod:

```lua
core.register_on_joinplayer(function(player)
	core.settings:set_pos("static_spawnpoint", vector.new(0, 25, 0))
        core.log("error", dump(core.settings:get_pos("static_spawnpoint")))
end)
```

Run unittests also.
