### PR TITLE
Avoid bloom "flashes" with MSAA - Clamp pre-bloom color to valid range

### DIFF
--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -23,7 +23,7 @@ void main(void)
 	vec2 uv = varTexCoord.st;
 	vec3 color = texture2D(rendered, uv).rgb;
 	// translate to linear colorspace (approximate)
-	color = pow(color, vec3(2.2));
+	color = pow(clamp(color, 0.0, 1.0), vec3(2.2));
 
 	color *= exposureParams.compensationFactor * bloomStrength;
 


### PR DESCRIPTION
See https://github.com/minetest/minetest/pull/15392#issuecomment-2464435459

- Goal of the PR
Bloom on top MSAA produced flashing bright spots. This PR fixes that.
- How does the PR work?
Clamp the pre-bloom color to valid range
- Does it resolve any reported issue?
See comment above
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is Ready for Review.

## How to test

Enable FSAA (2 or 4), enable post processing and bloom/volumetric lighting. Move around a bit. Notice that without this PR there are exaggerated bloom artifacts, like bright flashes.

To Test:
- With this PR these flashes should be gone
- Bloom should still work
- there should be no other visible changes (to bloom, color, etc). With or without FSAA.
