### PR TITLE
Fix distorted Sun, Moon and Star visuals based on Orbit Tilt

### DIFF
--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -661,7 +661,9 @@ void Sky::draw_stars(video::IVideoDriver * driver, float wicked_time_of_day)
 		return;
 	m_materials[0].ColorParam = color.toSColor();
 
-	auto sky_rotation = core::matrix4().setRotationAxisRadians(2.0f * M_PI * (wicked_time_of_day - 0.25f), v3f(0.0f, 0.0f, 1.0f));
+	auto day_rotation = core::matrix4().setRotationAxisRadians(2.0f * M_PI * (wicked_time_of_day - 0.25f), v3f(0.0f, 0.0f, 1.0f));
+	auto orbit_rotation = core::matrix4().setRotationAxisRadians(m_sky_params.body_orbit_tilt * M_PI / 180.0, v3f(1.0f, 0.0f, 0.0f));
+	auto sky_rotation = orbit_rotation * day_rotation;
 	auto world_matrix = driver->getTransform(video::ETS_WORLD);
 	driver->setTransform(video::ETS_WORLD, world_matrix * sky_rotation);
 	driver->setMaterial(m_materials[0]);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -695,13 +695,11 @@ void Sky::place_sky_body(
 	* day_position: turn the body around the Z axis, to place it depending of the time of the day
 	*/
 {
-	v3f centrum = getSkyBodyPosition(horizon_position, day_position, m_sky_params.body_orbit_tilt);
-	v3f untilted_centrum = getSkyBodyPosition(horizon_position, day_position, 0.f);
 	for (video::S3DVertex &vertex : vertices) {
 		// Body is directed to -Z (south) by default
 		vertex.Pos.rotateXZBy(horizon_position);
 		vertex.Pos.rotateXYBy(day_position);
-		vertex.Pos += centrum - untilted_centrum;
+		vertex.Pos.rotateYZBy(m_sky_params.body_orbit_tilt);
 	}
 }
 


### PR DESCRIPTION
Currently, the sun and moon get squished due to a translation of the skybox that draws them. Exchanging the translation with a rotation fixes that issue. Stars now respect the orbit tilt.

Before:

https://github.com/user-attachments/assets/c82b1d79-0e89-44a0-b557-8aac9b52589f

After:

https://github.com/user-attachments/assets/43d5b632-d84c-4de8-9a95-c5f8ad539a85

This PR is Ready for Review.
<!-- ^ delete one -->

- [x] Fix Sun & Moon being squished
- [x] Make Stars follow Orbit Tilt

## How to test

- Test different orbit tilts and games. I only tried Minetest Game with positive tilts.
- Test with custom sun and moon textures. Check if they are rotated correctly