### PR TITLE
[Trivial] Doc: Add missing packages for Arch Linux

### DIFF
--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -33,7 +33,7 @@ For openSUSE users:
 
 For Arch users:
 
-    sudo pacman -S --needed base-devel libcurl-gnutls cmake libpng libjpeg sqlite libogg libvorbis libxi openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext sdl2
+    sudo pacman -S --needed base-devel libcurl-gnutls cmake libpng libjpeg sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext sdl2
 
 For Alpine users:
 

--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -33,7 +33,7 @@ For openSUSE users:
 
 For Arch users:
 
-    sudo pacman -S --needed base-devel libcurl-gnutls cmake libpng libjpeg sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext sdl2
+    sudo pacman -S --needed base-devel libcurl-gnutls cmake libpng libjpeg-turbo sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext sdl2
 
 For Alpine users:
 

--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -33,7 +33,7 @@ For openSUSE users:
 
 For Arch users:
 
-    sudo pacman -S --needed base-devel libcurl-gnutls cmake libpng sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext sdl2
+    sudo pacman -S --needed base-devel libcurl-gnutls cmake libpng libjpeg sqlite libogg libvorbis libxi openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext sdl2
 
 For Alpine users:
 


### PR DESCRIPTION
Adds missing required packages to build and run Luanti on Arch Linux. I determined this from a [Distrobox](https://github.com/89luca89/distrobox) container. See the steps below.

Please note that this PR only targets instructions for Arch Linux specifically. Debian, Fedora, openSUSE, Alpine and Void Linux are out of scope of this PR.

## Output

```
distrobox-create --image docker.io/archlinux/archlinux:latest --home $HOME/Box/luanti --name luanti
sudo pacman -S --needed base-devel libcurl-gnutls cmake libpng sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext sdl2
sudo pacman -S git
git clone --depth 1 https://github.com/minetest/minetest.git
cd minetest
cmake . -DRUN_IN_PLACE=TRUE
```

```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find JPEG (missing: JPEG_LIBRARY JPEG_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake/Modules/FindJPEG.cmake:107 (find_package_handle_standard_args)
  irr/src/CMakeLists.txt:215 (find_package)
```

```
sudo pacman -S libjpeg
cmake . -DRUN_IN_PLACE=TRUE
make -j$(nproc)
./bin/luanti
```

```
./bin/luanti: error while loading shared libraries: libXi.so.6: cannot open shared object file: No such file or directory
```

```
sudo pacman -S libxi
```

After that, Luanti started normally.

As a side note: In this specific Box I got a segmentation fault while running (didn't inspect, out of scope), hence I used another container where I have a working Luanti build to exceute `<othercontainer>/minetest/bin/luanti`. The other container uses the same base image so it should not matter, as I remember doing the same in the other container.

## To do

This PR is Ready for Review.

- [x] Add packages

## How to test

Is distrobox a valid way to determine this? Ensure these packages are actually needed. Execute the build steps with the added and not added packages from a minimal environment / installation.