### PR TITLE
Clarify behaviour of core.hypertext_escape

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6699,6 +6699,9 @@ Formspec
 * `core.hypertext_escape(string)`: returns a string
     * escapes the characters "\", "<", and ">" to show text in a hypertext element.
     * not safe for use with tag attributes.
+    * this function does not do formspec escaping, you will likely need to do
+      `core.formspec_escape(core.hypertext_escape(string))` if the hypertext is
+      not already being formspec escaped.
 * `core.explode_table_event(string)`: returns a table
     * returns e.g. `{type="CHG", row=1, column=2}`
     * `type` is one of:


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR

Makes it clear that you have to do `core.formspec_escape(core.hypertext_escape(string))`.

- How does the PR work?

By updating the documentation.

- Does it resolve any reported issue?

No

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?

No

- If not a bug fix, why is this PR needed? What usecases does it solve?

(A previous edit mentioned a possible bug, but now I don't think it was a bug because `fgettext` does the escaping, however I still think the documentation should be improved)

## To do

This PR is Ready for Review.

It will probably need rewording to make it more clear, I have not spent much time on this PR. Maybe it should also suggest doing formspec_escape at the end over all the hypertext, like the content dialog appears to do, instead of doing it along with hypertext_escape?

## How to test

<!-- Example code or instructions -->
Read documentation, maybe verify the behaviour of hypertext_escape?