### PR TITLE
Sanitize invalid particle spawner time

### DIFF
--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -268,6 +268,7 @@ ParticleSpawner::ParticleSpawner(
 	}
 
 	size_t max_particles = 0; // maximum number of particles likely to be visible at any given time
+	assert(p.time >= 0);
 	if (p.time != 0) {
 		auto maxGenerations = p.time / std::min(p.exptime.start.min, p.exptime.end.min);
 		max_particles = p.amount / maxGenerations;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -4,6 +4,7 @@
 
 #include "client/client.h"
 
+#include "exceptions.h"
 #include "irr_v2d.h"
 #include "util/base64.h"
 #include "client/camera.h"
@@ -1007,6 +1008,8 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 
 	p.amount             = readU16(is);
 	p.time               = readF32(is);
+	if (p.time < 0)
+		throw SerializationError("particle spawner time < 0");
 
 	bool missing_end_values = false;
 	if (m_proto_ver >= 42) {

--- a/src/script/lua_api/l_particles.cpp
+++ b/src/script/lua_api/l_particles.cpp
@@ -3,6 +3,7 @@
 // Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
 
 #include "lua_api/l_particles.h"
+#include "common/c_types.h"
 #include "lua_api/l_object.h"
 #include "lua_api/l_internal.h"
 #include "lua_api/l_particleparams.h"
@@ -279,6 +280,9 @@ int ModApiParticles::l_add_particlespawner(lua_State *L)
 
 		p.node_tile = getintfield_default(L, 1, "node_tile", p.node_tile);
 	}
+
+	if (p.time < 0)
+		throw LuaError("particle spawner 'time' must be >= 0");
 
 	u32 id = getServer(L)->addParticleSpawner(p, attached, playername);
 	lua_pushnumber(L, id);


### PR DESCRIPTION
Some folks on the Discord figured out that negative particle spawner times cause a crash with 'Some exception: "vector"' on Windows. This seems to be because a vector is resized based on `max_particles` which is negative if `time` is negative. The conversion of this negative float to `size_t` is then UB, and probably leads to asking for an absurd amount of memory which the C++ stdlib in Windows probably rejects with an exception.

This PR properly throws a Lua error for `time < 0` and also sanitizes it in the client packet handler to protect against possible malicious servers, though the risk probably isn't high (note: client may still crash if the exception isn't caught, but at least nothing funky should happen). I've also added an assertion at the major place (which is probably responsible for the bug here) where we require `time >= 0`; if we wanted to be more rigorous we could encapsulate it fully.

## How to test

Try adding a particlespawner with a negative time, get a Lua error.
