### PR TITLE
Main menu: Fix server selection

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -55,6 +55,43 @@ local function get_sorted_servers()
 	return servers
 end
 
+-- The selected server is persisted in the "address" and "remote_port" settings.
+local function set_selected_server(server)
+	-- reset selection
+	if server == nil then
+		core.settings:set("address", "")
+		core.settings:set("remote_port", "30000")
+		return
+	end
+
+	local address = server.address
+	local port    = server.port
+	gamedata.serverdescription = server.description
+
+	gamedata.fav = false
+	for _, fav in ipairs(serverlistmgr.get_favorites()) do
+		if address == fav.address and port == fav.port then
+			gamedata.fav = true
+			break
+		end
+	end
+
+	if address and port then
+		core.settings:set("address", address)
+		core.settings:set("remote_port", port)
+	end
+end
+
+local function find_selected_server()
+	local address = core.settings:get("address")
+	local port = tonumber(core.settings:get("remote_port"))
+	for _, server in ipairs(serverlistmgr.servers) do
+		if server.address == address and server.port == port then
+			return server
+		end
+	end
+end
+
 local function get_formspec(tabview, name, tabdata)
 	-- Update the cached supported proto info,
 	-- it may have changed after a change by the settings menu.
@@ -107,15 +144,15 @@ local function get_formspec(tabview, name, tabdata)
 		retval = retval .. "button[0.25,6;2.5,0.75;btn_mp_register;" .. fgettext("Register") .. "]"
 	end
 
-	if tabdata.selected then
+	local selected_server = find_selected_server()
+
+	if selected_server then
 		if gamedata.serverdescription then
 			retval = retval .. "textarea[0.25,1.85;5.25,2.7;;;" ..
 				core.formspec_escape(gamedata.serverdescription) .. "]"
 		end
 
-		local server = tabdata.lookup[tabdata.selected]
-
-		local clients_list = server and server.clients_list
+		local clients_list = selected_server.clients_list
 		local can_view_clients_list = clients_list and #clients_list > 0
 		if can_view_clients_list then
 			table.sort(clients_list, function(a, b)
@@ -197,11 +234,17 @@ local function get_formspec(tabview, name, tabdata)
 
 	retval = retval .. table.concat(rows, ",")
 
-	if tabdata.selected then
-		retval = retval .. ";" .. tabdata.selected .. "]"
-	else
-		retval = retval .. ";0]"
+	local selected_row_idx = 0
+	if selected_server then
+		for i, server in pairs(tabdata.lookup) do
+			if selected_server.address == server.address and
+					selected_server.port == server.port then
+				selected_row_idx = i
+				break
+			end
+		end
 	end
+	retval = retval .. ";" .. selected_row_idx .. "]"
 
 	return retval
 end
@@ -253,35 +296,6 @@ local function search_server_list(input)
 	menudata.search_result = search_result
 end
 
-local function set_selected_server(tabdata, idx, server)
-	-- reset selection
-	if idx == nil or server == nil then
-		tabdata.selected = nil
-
-		core.settings:set("address", "")
-		core.settings:set("remote_port", "30000")
-		return
-	end
-
-	local address = server.address
-	local port    = server.port
-	gamedata.serverdescription = server.description
-
-	gamedata.fav = false
-	for _, fav in ipairs(serverlistmgr.get_favorites()) do
-		if address == fav.address and port == fav.port then
-			gamedata.fav = true
-			break
-		end
-	end
-
-	if address and port then
-		core.settings:set("address", address)
-		core.settings:set("remote_port", port)
-	end
-	tabdata.selected = idx
-end
-
 local function main_button_handler(tabview, fields, name, tabdata)
 	if fields.te_name then
 		gamedata.playername = fields.te_name
@@ -319,7 +333,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 				return true
 			end
 			if event.type == "CHG" then
-				set_selected_server(tabdata, event.row, server)
+				set_selected_server(server)
 				return true
 			end
 		end
@@ -332,13 +346,12 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		if not server then return end
 
 		serverlistmgr.delete_favorite(server)
-		-- the server at [idx+1] will be at idx once list is refreshed
-		set_selected_server(tabdata, idx, tabdata.lookup[idx+1])
+		set_selected_server(server)
 		return true
 	end
 
 	if fields.btn_view_clients then
-		local dlg = create_clientslist_dialog(tabdata.lookup[tabdata.selected])
+		local dlg = create_clientslist_dialog(find_selected_server())
 		dlg:set_parent(tabview)
 		tabview:hide()
 		dlg:show()
@@ -355,8 +368,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		tabdata.search_for = fields.te_search
 		search_server_list(fields.te_search:lower())
 		if menudata.search_result then
-			-- first server in row 2 due to header
-			set_selected_server(tabdata, 2, menudata.search_result[1])
+			set_selected_server(menudata.search_result[1])
 		end
 
 		return true
@@ -383,7 +395,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		local idx = core.get_table_index("servers")
 		local server = idx and tabdata.lookup[idx]
 
-		set_selected_server(tabdata)
+		set_selected_server(nil)
 
 		if server and server.address == gamedata.address and
 				server.port == gamedata.port then


### PR DESCRIPTION
Fixes the server tab part of #15456 (which might very well be the only part). Server selections are now always correct (no more arbitrarily changing selections if the order of the serverlist changes) and consistent with the address + port in the sidebar. This is achieved by identifying servers by address + port, which we already persist in settings rather than by an index into the table which may be easily invalidated e.g. if the serverlist is refreshed (which happens automatically when switching to it from another tab or when exiting a dialog).

## How to test

Select servers, switch to other tabs, open and close dialogs, open and close Luanti, note that the selection stays the same no matter what you do (and stays consistent with whichever address and port you enter into the sidebar). Also search for servers: The first result should be selected correctly. Play around with the server tab some more to make sure you like it and that there are no regressions.