### PR TITLE
Formspec: Move tooltip above cursor when lacking space

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3610,10 +3610,25 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 	// Calculate and set the tooltip position
 	s32 tooltip_x = m_pointer.X + tooltip_offset_x;
 	s32 tooltip_y = m_pointer.Y + tooltip_offset_y;
-	if (tooltip_x + tooltip_width > (s32)screenSize.X)
-		tooltip_x = (s32)screenSize.X - tooltip_width  - m_btn_height;
-	if (tooltip_y + tooltip_height > (s32)screenSize.Y)
-		tooltip_y = (s32)screenSize.Y - tooltip_height - m_btn_height;
+	// Bottom/Left limited positions (if the tooltip is too far out)
+	s32 tooltip_x_alt = (s32)screenSize.X - tooltip_width  - m_btn_height;
+	s32 tooltip_y_alt = (s32)screenSize.Y - tooltip_height - m_btn_height;
+
+	int collision = (tooltip_x_alt < tooltip_x) + 2 * (tooltip_y_alt < tooltip_y);
+	switch (collision) {
+	case 1: // x
+		tooltip_x = tooltip_x_alt;
+		break;
+	case 2: // y
+		tooltip_y = tooltip_y_alt;
+		break;
+	case 3: // both
+		tooltip_x = tooltip_x_alt;
+		tooltip_y = (s32)screenSize.Y - 2 * tooltip_height - m_btn_height;
+		break;
+	default: // OK
+		break;
+	}
 
 	m_tooltip_element->setRelativePosition(
 		core::rect<s32>(


### PR DESCRIPTION
Fixes #15467

## To do

This PR is Ready for Review.

## How to test

Test script N° 174 (for my reference)

```Lua
local lorem = [[
Lorem ipsum dolor sit amet,
consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
dolore magna aliquyam erat,
sed diam voluptua.
At vero eos et accusam
et justo duo
dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem
ipsum dolor sit amet.
]]

core.register_chatcommand("t", {
	func = function(name)
		local function btn(x, y)
			return (
				("button[%.1f,%.1f;%d,%d;btn_%d_%d;%d %d]"):format(x*3.5,y*1.5, 3,1, x,y, x,y)
				..
				("tooltip[btn_%d_%d;%s;green;black]"):format(x,y, lorem)
			)
		end
		local fs = {
			"size[14,8;true]"
		}
		for y = 0, 4 do
		for x = 0, 4 do
			fs[#fs + 1] = btn(x, y)
		end
		end
		core.show_formspec(name, "lab:test", table.concat(fs))
	end
})
```

1. Open `/t`
2. Have a small game window
3. Look at the tooltip and try to click it