### PR TITLE
Change `NS` symbol for `core.translate_n` to `PS` to avoid clash with old code

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4183,14 +4183,14 @@ Two functions are provided to translate strings: `core.translate` and
 
 * `core.get_translator(textdomain)` is a simple wrapper around
   `core.translate` and `core.translate_n`.
-  After `local S, NS = core.get_translator(textdomain)`, we have
+  After `local S, PS = core.get_translator(textdomain)`, we have
   `S(str, ...)` equivalent to `core.translate(textdomain, str, ...)`, and
-  `NS(str, str_plural, n, ...)` to `core.translate_n(textdomain, str, str_plural, n, ...)`.
+  `PS(str, str_plural, n, ...)` to `core.translate_n(textdomain, str, str_plural, n, ...)`.
   It is intended to be used in the following way, so that it avoids verbose
   repetitions of `core.translate`:
 
   ```lua
-  local S, NS = core.get_translator(textdomain)
+  local S, PS = core.get_translator(textdomain)
   S(str, ...)
   ```
 
@@ -4224,7 +4224,7 @@ command that shows the amount of time since the player joined. We can do the
 following:
 
 ```lua
-local S, NS = core.get_translator("hello")
+local S, PS = core.get_translator("hello")
 core.register_on_joinplayer(function(player)
     local name = player:get_player_name()
     core.chat_send_player(name, S("Hello @1, how are you today?", name))
@@ -4233,7 +4233,7 @@ core.register_chatcommand("playtime", {
     func = function(name)
         local last_login = core.get_auth_handler().get_auth(name).last_login
         local playtime = math.floor((last_login-os.time())/60)
-        return true, NS(
+        return true, PS(
             "You have been playing for @1 minute.",
             "You have been playing for @1 minutes.",
             minutes, tostring(minutes))
@@ -4280,7 +4280,7 @@ After creating the `locale` directory, a translation template for the above
 example using the following command:
 
 ```sh
-xgettext -L lua -kS -kNS:1,2 -kcore.translate:1c,2 -kcore.translate_n:1c,2,3 \
+xgettext -L lua -kS -kPS:1,2 -kcore.translate:1c,2 -kcore.translate_n:1c,2,3 \
   -d hello -o locale/hello.pot *.lua
 ```
 


### PR DESCRIPTION
## Context

`lua_api.md` unilaterally decided to change the meaning of the `NS` symbol commonly used in code for translations. As you probably know, it is consensus that `S` is the symbol used in Luanti games to mark a simple translation string.

In some mods, you also find `NS`. Traditionally, the `NS` symbol meant "translate no-op", i.e., it will be collected by a string-collecting utility but not be translated by Luanti at *this* place. This has been tradition in the old hacky utility scripts the community wrote to deal with the TR files. A bunch of games use this convention.

However, Luanti has decided for some reason the meaning of `NS` is different. In the `lua_api.md`, `NS` means "S, but with plural forms". This is different and misleadding! If devs follow the advice of the documentation, they will break with tradition and add a lot of confusing inconsistencies.

In particular, the documentation suggests a `xgettext` invocation where the `NS` appears.

## This PR

The solution is simple: Just change the `NS` symbol in the documentation to `PS`. The “P” stands for “Plural”. This is the only thing this PR does.

`PS` does not have an established meaning in translation scripts, as far I know, so it should be safe.
