### PR TITLE
Irrlicht: Get rid of `definitelyIdentityMatrix`

### DIFF
--- a/irr/include/matrix4.h
+++ b/irr/include/matrix4.h
@@ -13,11 +13,6 @@
 #include "rect.h"
 #include "IrrCompileConfig.h" // for IRRLICHT_API
 
-// enable this to keep track of changes to the matrix
-// and make simpler identity check for seldom changing matrices
-// otherwise identity check will always compare the elements
-// #define USE_MATRIX_TEST
-
 namespace irr
 {
 namespace core
@@ -81,9 +76,6 @@ public:
 	//! Simple operator for directly accessing every element of the matrix.
 	T &operator()(const s32 row, const s32 col)
 	{
-#if defined(USE_MATRIX_TEST)
-		definitelyIdentityMatrix = false;
-#endif
 		return M[row * 4 + col];
 	}
 
@@ -93,9 +85,6 @@ public:
 	//! Simple operator for linearly accessing every element of the matrix.
 	T &operator[](u32 index)
 	{
-#if defined(USE_MATRIX_TEST)
-		definitelyIdentityMatrix = false;
-#endif
 		return M[index];
 	}
 
@@ -112,19 +101,12 @@ public:
 	const T *pointer() const { return M; }
 	T *pointer()
 	{
-#if defined(USE_MATRIX_TEST)
-		definitelyIdentityMatrix = false;
-#endif
 		return M;
 	}
 
 	//! Returns true if other matrix is equal to this matrix.
 	constexpr bool operator==(const CMatrix4<T> &other) const
 	{
-#if defined(USE_MATRIX_TEST)
-		if (definitelyIdentityMatrix && other.definitelyIdentityMatrix)
-			return true;
-#endif
 		for (s32 i = 0; i < 16; ++i)
 			if (M[i] != other.M[i])
 				return false;
@@ -443,31 +425,17 @@ public:
 	//! Sets all matrix data members at once
 	CMatrix4<T> &setM(const T *data);
 
-	//! Sets if the matrix is definitely identity matrix
-	void setDefinitelyIdentityMatrix(bool isDefinitelyIdentityMatrix);
-
-	//! Gets if the matrix is definitely identity matrix
-	bool getDefinitelyIdentityMatrix() const;
-
 	//! Compare two matrices using the equal method
 	bool equals(const core::CMatrix4<T> &other, const T tolerance = (T)ROUNDING_ERROR_f64) const;
 
 private:
 	//! Matrix data, stored in row-major order
 	T M[16];
-#if defined(USE_MATRIX_TEST)
-	//! Flag is this matrix is identity matrix
-	mutable u32 definitelyIdentityMatrix;
-#endif
 };
 
 // Default constructor
 template <class T>
 inline CMatrix4<T>::CMatrix4(eConstructor constructor)
-#if defined(USE_MATRIX_TEST)
-		:
-		definitelyIdentityMatrix(BIT_UNTESTED)
-#endif
 {
 	switch (constructor) {
 	case EM4CONST_NOTHING:
@@ -484,10 +452,6 @@ inline CMatrix4<T>::CMatrix4(eConstructor constructor)
 // Copy constructor
 template <class T>
 inline CMatrix4<T>::CMatrix4(const CMatrix4<T> &other, eConstructor constructor)
-#if defined(USE_MATRIX_TEST)
-		:
-		definitelyIdentityMatrix(BIT_UNTESTED)
-#endif
 {
 	switch (constructor) {
 	case EM4CONST_IDENTITY:
@@ -713,9 +677,6 @@ inline CMatrix4<T> &CMatrix4<T>::setbyproduct_nocheck(const CMatrix4<T> &other_a
 	M[13] = m1[1] * m2[12] + m1[5] * m2[13] + m1[9] * m2[14] + m1[13] * m2[15];
 	M[14] = m1[2] * m2[12] + m1[6] * m2[13] + m1[10] * m2[14] + m1[14] * m2[15];
 	M[15] = m1[3] * m2[12] + m1[7] * m2[13] + m1[11] * m2[14] + m1[15] * m2[15];
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -787,9 +748,6 @@ inline CMatrix4<T> &CMatrix4<T>::setTranslation(const vector3d<T> &translation)
 	M[12] = translation.X;
 	M[13] = translation.Y;
 	M[14] = translation.Z;
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -799,9 +757,6 @@ inline CMatrix4<T> &CMatrix4<T>::setInverseTranslation(const vector3d<T> &transl
 	M[12] = -translation.X;
 	M[13] = -translation.Y;
 	M[14] = -translation.Z;
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -811,9 +766,6 @@ inline CMatrix4<T> &CMatrix4<T>::setScale(const vector3d<T> &scale)
 	M[0] = scale.X;
 	M[5] = scale.Y;
 	M[10] = scale.Z;
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -877,9 +829,6 @@ inline CMatrix4<T> &CMatrix4<T>::setRotationRadians(const vector3d<T> &rotation)
 	M[8] = (T)(cPitch_sYaw * cRoll + sPitch * sRoll);
 	M[9] = (T)(cPitch_sYaw * sRoll - sPitch * cRoll);
 	M[10] = (T)(cPitch * cYaw);
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -981,9 +930,6 @@ inline CMatrix4<T> &CMatrix4<T>::setInverseRotationRadians(const vector3d<T> &ro
 	M[2] = (T)(cPitch_sYaw * cRoll + sPitch * sRoll);
 	M[6] = (T)(cPitch_sYaw * sRoll - sPitch * cRoll);
 	M[10] = (T)(cPitch * cYaw);
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -1015,9 +961,6 @@ inline CMatrix4<T> &CMatrix4<T>::setRotationAxisRadians(const T &angle, const ve
 	M[9] = (T)(tz * axis.Y - sx);
 	M[10] = (T)(tz * axis.Z + c);
 
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -1028,9 +971,6 @@ inline CMatrix4<T> &CMatrix4<T>::makeIdentity()
 {
 	memset(M, 0, 16 * sizeof(T));
 	M[0] = M[5] = M[10] = M[15] = (T)1;
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = true;
-#endif
 	return *this;
 }
 
@@ -1041,10 +981,6 @@ inline CMatrix4<T> &CMatrix4<T>::makeIdentity()
 template <class T>
 inline bool CMatrix4<T>::isIdentity() const
 {
-#if defined(USE_MATRIX_TEST)
-	if (definitelyIdentityMatrix)
-		return true;
-#endif
 	if (!core::equals(M[12], (T)0) || !core::equals(M[13], (T)0) || !core::equals(M[14], (T)0) || !core::equals(M[15], (T)1))
 		return false;
 
@@ -1068,9 +1004,6 @@ inline bool CMatrix4<T>::isIdentity() const
 				if ((j != i) && (!iszero((*this)(i,j))))
 					return false;
 */
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = true;
-#endif
 	return true;
 }
 
@@ -1106,10 +1039,6 @@ inline bool CMatrix4<T>::isOrthogonal() const
 template <class T>
 inline bool CMatrix4<T>::isIdentity_integer_base() const
 {
-#if defined(USE_MATRIX_TEST)
-	if (definitelyIdentityMatrix)
-		return true;
-#endif
 	if (IR(M[0]) != F32_VALUE_1)
 		return false;
 	if (IR(M[1]) != 0)
@@ -1146,9 +1075,6 @@ inline bool CMatrix4<T>::isIdentity_integer_base() const
 	if (IR(M[15]) != F32_VALUE_1)
 		return false;
 
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = true;
-#endif
 	return true;
 }
 
@@ -1402,9 +1328,6 @@ inline bool CMatrix4<T>::getInverse(CMatrix4<T> &out) const
 						  m[1] * (m[6] * m[8] - m[4] * m[10]) +
 						  m[2] * (m[4] * m[9] - m[5] * m[8]));
 
-#if defined(USE_MATRIX_TEST)
-	out.definitelyIdentityMatrix = definitelyIdentityMatrix;
-#endif
 	return true;
 }
 
@@ -1433,9 +1356,6 @@ inline bool CMatrix4<T>::getInversePrimitive(CMatrix4<T> &out) const
 	out.M[14] = (T) - (M[12] * M[8] + M[13] * M[9] + M[14] * M[10]);
 	out.M[15] = 1;
 
-#if defined(USE_MATRIX_TEST)
-	out.definitelyIdentityMatrix = definitelyIdentityMatrix;
-#endif
 	return true;
 }
 
@@ -1444,10 +1364,6 @@ inline bool CMatrix4<T>::getInversePrimitive(CMatrix4<T> &out) const
 template <class T>
 inline bool CMatrix4<T>::makeInverse()
 {
-#if defined(USE_MATRIX_TEST)
-	if (definitelyIdentityMatrix)
-		return true;
-#endif
 	CMatrix4<T> temp(EM4CONST_NOTHING);
 
 	if (getInverse(temp)) {
@@ -1464,9 +1380,6 @@ inline CMatrix4<T> &CMatrix4<T>::operator=(const T &scalar)
 	for (s32 i = 0; i < 16; ++i)
 		M[i] = scalar;
 
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -1509,9 +1422,6 @@ inline CMatrix4<T> &CMatrix4<T>::buildProjectionMatrixPerspectiveFovRH(
 		M[14] = (T)(2.0f * zNear * zFar / (zNear - zFar));
 	}
 
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -1554,9 +1464,6 @@ inline CMatrix4<T> &CMatrix4<T>::buildProjectionMatrixPerspectiveFovLH(
 		M[14] = (T)(2.0f * zNear * zFar / (zNear - zFar));
 	}
 
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -1589,9 +1496,6 @@ inline CMatrix4<T> &CMatrix4<T>::buildProjectionMatrixPerspectiveFovInfinityLH(
 	M[14] = (T)(zNear * (epsilon - 1.f));
 	M[15] = 0;
 
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -1631,9 +1535,6 @@ inline CMatrix4<T> &CMatrix4<T>::buildProjectionMatrixOrthoLH(
 		M[14] = (T) - (zFar + zNear) / (zFar - zNear);
 	}
 
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -1673,9 +1574,6 @@ inline CMatrix4<T> &CMatrix4<T>::buildProjectionMatrixOrthoRH(
 		M[14] = (T) - (zFar + zNear) / (zFar - zNear);
 	}
 
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -1716,9 +1614,6 @@ inline CMatrix4<T> &CMatrix4<T>::buildProjectionMatrixPerspectiveRH(
 		M[14] = (T)(2.0f * zNear * zFar / (zNear - zFar));
 	}
 
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -1759,9 +1654,6 @@ inline CMatrix4<T> &CMatrix4<T>::buildProjectionMatrixPerspectiveLH(
 		M[14] = (T)(2.0f * zNear * zFar / (zNear - zFar));
 	}
 
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
 }
 
@@ -1791,9 +1683,7 @@ inline CMatrix4<T> &CMatrix4<T>::buildShadowMatrix(const core::vector3df &light,
 	M[13] = (T)(-plane.D * light.Y);
 	M[14] = (T)(-plane.D * light.Z);
 	M[15] = (T)(-plane.D * point + d);
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
+
 	return *this;
 }
 
@@ -1831,9 +1721,7 @@ inline CMatrix4<T> &CMatrix4<T>::buildCameraLookAtMatrixLH(
 	M[13] = (T)-yaxis.dotProduct(position);
 	M[14] = (T)-zaxis.dotProduct(position);
 	M[15] = 1;
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
+
 	return *this;
 }
 
@@ -1871,9 +1759,7 @@ inline CMatrix4<T> &CMatrix4<T>::buildCameraLookAtMatrixRH(
 	M[13] = (T)-yaxis.dotProduct(position);
 	M[14] = (T)-zaxis.dotProduct(position);
 	M[15] = 1;
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
+
 	return *this;
 }
 
@@ -1924,9 +1810,6 @@ inline void CMatrix4<T>::getTransposed(CMatrix4<T> &o) const
 	o[13] = M[7];
 	o[14] = M[11];
 	o[15] = M[15];
-#if defined(USE_MATRIX_TEST)
-	o.definitelyIdentityMatrix = definitelyIdentityMatrix;
-#endif
 }
 
 // used to scale <-1,-1><1,1> to viewport
@@ -2064,9 +1947,6 @@ inline void CMatrix4<T>::setRotationCenter(const core::vector3df &center, const 
 	M[13] = -M[1] * center.X - M[5] * center.Y - M[9] * center.Z + (center.Y - translation.Y);
 	M[14] = -M[2] * center.X - M[6] * center.Y - M[10] * center.Z + (center.Z - translation.Z);
 	M[15] = (T)1.0;
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 }
 
 /*!
@@ -2108,9 +1988,7 @@ inline CMatrix4<T> &CMatrix4<T>::buildTextureTransform(f32 rotateRad,
 	M[13] = 0;
 	M[14] = 0;
 	M[15] = 1;
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
+
 	return *this;
 }
 
@@ -2129,9 +2007,6 @@ inline CMatrix4<T> &CMatrix4<T>::setTextureRotationCenter(f32 rotateRad)
 	M[8] = (T)(0.5f * (s - c) + 0.5f);
 	M[9] = (T)(-0.5f * (s + c) + 0.5f);
 
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = definitelyIdentityMatrix && (rotateRad == 0.0f);
-#endif
 	return *this;
 }
 
@@ -2141,9 +2016,6 @@ inline CMatrix4<T> &CMatrix4<T>::setTextureTranslate(f32 x, f32 y)
 	M[8] = (T)x;
 	M[9] = (T)y;
 
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = definitelyIdentityMatrix && (x == 0.0f) && (y == 0.0f);
-#endif
 	return *this;
 }
 
@@ -2159,10 +2031,6 @@ inline CMatrix4<T> &CMatrix4<T>::setTextureTranslateTransposed(f32 x, f32 y)
 {
 	M[2] = (T)x;
 	M[6] = (T)y;
-
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = definitelyIdentityMatrix && (x == 0.0f) && (y == 0.0f);
-#endif
 	return *this;
 }
 
@@ -2171,9 +2039,6 @@ inline CMatrix4<T> &CMatrix4<T>::setTextureScale(f32 sx, f32 sy)
 {
 	M[0] = (T)sx;
 	M[5] = (T)sy;
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = definitelyIdentityMatrix && (sx == 1.0f) && (sy == 1.0f);
-#endif
 	return *this;
 }
 
@@ -2191,10 +2056,6 @@ inline CMatrix4<T> &CMatrix4<T>::setTextureScaleCenter(f32 sx, f32 sy)
 	M[5] = (T)sy;
 	M[8] = (T)(0.5f - 0.5f * sx);
 	M[9] = (T)(0.5f - 0.5f * sy);
-
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = definitelyIdentityMatrix && (sx == 1.0f) && (sy == 1.0f);
-#endif
 	return *this;
 }
 
@@ -2203,43 +2064,13 @@ template <class T>
 inline CMatrix4<T> &CMatrix4<T>::setM(const T *data)
 {
 	memcpy(M, data, 16 * sizeof(T));
-
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = false;
-#endif
 	return *this;
-}
-
-// sets if the matrix is definitely identity matrix
-template <class T>
-inline void CMatrix4<T>::setDefinitelyIdentityMatrix(bool isDefinitelyIdentityMatrix)
-{
-#if defined(USE_MATRIX_TEST)
-	definitelyIdentityMatrix = isDefinitelyIdentityMatrix;
-#else
-	(void)isDefinitelyIdentityMatrix; // prevent compiler warning
-#endif
-}
-
-// gets if the matrix is definitely identity matrix
-template <class T>
-inline bool CMatrix4<T>::getDefinitelyIdentityMatrix() const
-{
-#if defined(USE_MATRIX_TEST)
-	return definitelyIdentityMatrix;
-#else
-	return false;
-#endif
 }
 
 //! Compare two matrices using the equal method
 template <class T>
 inline bool CMatrix4<T>::equals(const core::CMatrix4<T> &other, const T tolerance) const
 {
-#if defined(USE_MATRIX_TEST)
-	if (definitelyIdentityMatrix && other.definitelyIdentityMatrix)
-		return true;
-#endif
 	for (s32 i = 0; i < 16; ++i)
 		if (!core::equals(M[i], other.M[i], tolerance))
 			return false;

--- a/irr/include/quaternion.h
+++ b/irr/include/quaternion.h
@@ -358,8 +358,6 @@ inline void quaternion::getMatrixFast(matrix4 &dest) const
 	dest[13] = 0.f;
 	dest[14] = 0.f;
 	dest[15] = 1.f;
-
-	dest.setDefinitelyIdentityMatrix(false);
 }
 
 /*!
@@ -397,8 +395,6 @@ inline void quaternion::getMatrix(matrix4 &dest,
 	dest[13] = center.Y;
 	dest[14] = center.Z;
 	dest[15] = 1.f;
-
-	dest.setDefinitelyIdentityMatrix(false);
 }
 
 /*!
@@ -471,8 +467,6 @@ inline void quaternion::getMatrix_transposed(matrix4 &dest) const
 	dest[7] = 0.f;
 	dest[11] = 0.f;
 	dest[15] = 1.f;
-
-	dest.setDefinitelyIdentityMatrix(false);
 }
 
 // Inverts this quaternion


### PR DESCRIPTION
Makes Irrlicht matrices a slight bit (~10%) saner.

This is just dead code that was never used; we never enabled this misguided premature optimization.

If some particular code is particularly likely to have identity matrices *and* this is relevant for performance, that code should use `std::optional<matrix4>` (or come up with its own matrix wrapper which maintains this bit).

It does not make sense to have this as a global compile-time option.

### How to test

Check that this only removes dead code related to `definitelyIdentityMatrix`.