### PR TITLE
Update CMakeLists to use `add_compile_definitions`

### DIFF
--- a/irr/src/CMakeLists.txt
+++ b/irr/src/CMakeLists.txt
@@ -9,7 +9,7 @@ option(USE_SDL2 "Use the SDL2 backend" ${DEFAULT_SDL2})
 # Compiler flags
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-	add_definitions(-D_DEBUG)
+	add_compile_definitions(_DEBUG)
 endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
@@ -43,9 +43,7 @@ elseif(MSVC)
 endif()
 
 # Platform-independent configuration (hard-coded currently)
-add_definitions(
-	-DIRR_ENABLE_BUILTIN_FONT
-)
+add_compile_definitions(IRR_ENABLE_BUILTIN_FONT)
 
 # Platform-specific configuration
 
@@ -56,35 +54,35 @@ endif()
 # Device
 
 if(WIN32)
-	add_definitions(-D_IRR_WINDOWS_ -D_IRR_WINDOWS_API_)
+	add_compile_definitions(_IRR_WINDOWS_ _IRR_WINDOWS_API_)
 	set(DEVICE "WINDOWS")
 elseif(APPLE)
-	add_definitions(-D_IRR_OSX_PLATFORM_)
+	add_compile_definitions(_IRR_OSX_PLATFORM_)
 	set(DEVICE "OSX")
 elseif(ANDROID)
-	add_definitions(-D_IRR_ANDROID_PLATFORM_)
+	add_compile_definitions(_IRR_ANDROID_PLATFORM_)
 	if(NOT USE_SDL2)
 		message(FATAL_ERROR "The Android build requires SDL2")
 	endif()
 elseif(EMSCRIPTEN)
-	add_definitions(-D_IRR_EMSCRIPTEN_PLATFORM_ -D_IRR_COMPILE_WITH_EGL_MANAGER_)
+	add_compile_definitions(_IRR_EMSCRIPTEN_PLATFORM_ _IRR_COMPILE_WITH_EGL_MANAGER_)
 	set(LINUX_PLATFORM TRUE)
 	set(DEVICE "SDL")
 elseif(SOLARIS)
-	add_definitions(-D_IRR_SOLARIS_PLATFORM_ -D_IRR_POSIX_API_)
+	add_compile_definitions(_IRR_SOLARIS_PLATFORM_ _IRR_POSIX_API_)
 	set(DEVICE "X11")
 else()
-	add_definitions(-D_IRR_POSIX_API_)
+	add_compile_definitions(_IRR_POSIX_API_)
 	set(LINUX_PLATFORM TRUE)
 	set(DEVICE "X11")
 endif()
 
 if(LINUX_PLATFORM)
-	add_definitions(-D_IRR_LINUX_PLATFORM_)
+	add_compile_definitions(_IRR_LINUX_PLATFORM_)
 endif()
 
 if(MSVC)
-	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+	add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
 
 if(USE_SDL2)
@@ -93,7 +91,7 @@ elseif(DEVICE STREQUAL "SDL")
 	message(FATAL_ERROR "SDL was used but not enabled?!")
 endif()
 
-add_definitions("-D_IRR_COMPILE_WITH_${DEVICE}_DEVICE_")
+add_compile_definitions("_IRR_COMPILE_WITH_${DEVICE}_DEVICE_")
 
 # X11
 
@@ -114,7 +112,7 @@ endif()
 # Joystick
 
 if(NOT (BSD OR SOLARIS OR EMSCRIPTEN))
-	add_definitions(-D_IRR_COMPILE_WITH_JOYSTICK_EVENTS_)
+	add_compile_definitions(_IRR_COMPILE_WITH_JOYSTICK_EVENTS_)
 endif()
 
 # OpenGL
@@ -154,15 +152,15 @@ endif()
 
 if(ENABLE_OPENGL OR (ENABLE_OPENGL3 AND NOT USE_SDL2))
 	if(ENABLE_OPENGL)
-		add_definitions(-D_IRR_COMPILE_WITH_OPENGL_)
+		add_compile_definitions(_IRR_COMPILE_WITH_OPENGL_)
 		set(OPENGL_DIRECT_LINK TRUE) # driver relies on this
 	endif()
 	if(DEVICE STREQUAL "WINDOWS")
-		add_definitions(-D_IRR_COMPILE_WITH_WGL_MANAGER_)
+		add_compile_definitions(_IRR_COMPILE_WITH_WGL_MANAGER_)
 	elseif(DEVICE STREQUAL "X11")
-		add_definitions(-D_IRR_COMPILE_WITH_GLX_MANAGER_)
+		add_compile_definitions(_IRR_COMPILE_WITH_GLX_MANAGER_)
 	elseif(DEVICE STREQUAL "OSX")
-		add_definitions(-D_IRR_COMPILE_WITH_NSOGL_MANAGER_)
+		add_compile_definitions(_IRR_COMPILE_WITH_NSOGL_MANAGER_)
 	endif()
 endif()
 
@@ -177,14 +175,14 @@ if(ENABLE_OPENGL3)
 endif()
 
 if(ENABLE_GLES2)
-	add_definitions(-D_IRR_COMPILE_WITH_OGLES2_)
+	add_compile_definitions(_IRR_COMPILE_WITH_OGLES2_)
 	if(DEVICE MATCHES "^(WINDOWS|X11)$" OR EMSCRIPTEN)
-		add_definitions(-D_IRR_COMPILE_WITH_EGL_MANAGER_)
+		add_compile_definitions(_IRR_COMPILE_WITH_EGL_MANAGER_)
 	endif()
 endif()
 
 if(ENABLE_WEBGL1)
-	add_definitions(-D_IRR_COMPILE_WITH_WEBGL1_)
+	add_compile_definitions(_IRR_COMPILE_WITH_WEBGL1_)
 endif()
 
 # Misc
@@ -192,7 +190,7 @@ endif()
 include(TestBigEndian)
 TEST_BIG_ENDIAN(BIG_ENDIAN)
 if(BIG_ENDIAN)
-	add_definitions(-D__BIG_ENDIAN__)
+	add_compile_definitions(__BIG_ENDIAN__)
 endif()
 
 # Configuration report
@@ -263,7 +261,7 @@ if(ENABLE_OPENGL AND DEVICE STREQUAL "SDL")
 #endif\n\
 int main() {}" CHECK_GL_VERSION_4_5)
 	if(CHECK_GL_VERSION_4_5)
-		add_definitions(-DIRR_PREFER_SDL_GL_HEADER)
+		add_compile_definitions(IRR_PREFER_SDL_GL_HEADER)
 	endif()
 endif()
 
@@ -275,7 +273,7 @@ elseif(APPLE)
 	find_library(COCOA_LIB Cocoa REQUIRED)
 	find_library(IOKIT_LIB IOKit REQUIRED)
 
-	add_definitions(-DGL_SILENCE_DEPRECATION)
+	add_compile_definitions(GL_SILENCE_DEPRECATION)
 elseif(NOT USE_SDL2)
 	# Unix probably
 	find_package(X11 REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -260,12 +260,11 @@ endif()
 
 # Haiku endian support
 if(HAIKU)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_BSD_SOURCE")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_BSD_SOURCE")
+	add_compile_definitions(_BSD_SOURCE)
 endif()
 
 # Use cmake_config.h
-add_definitions(-DUSE_CMAKE_CONFIG_H)
+add_compile_definitions(USE_CMAKE_CONFIG_H)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
@@ -276,11 +275,15 @@ if(WIN32)
 	if(MSVC) # MSVC Specifics
 		set(PLATFORM_LIBS dbghelp.lib ${PLATFORM_LIBS})
 		# Surpress some useless warnings
-		add_definitions ( /D "_CRT_SECURE_NO_DEPRECATE" /W1 )
-		# Get M_PI to work
-		add_definitions(/D "_USE_MATH_DEFINES")
-		# Don't define min/max macros in minwindef.h
-		add_definitions(/D "NOMINMAX")
+		add_compile_options(/W1)
+		add_compile_definitions(
+			# Suppress some useless warnings
+			_CRT_SECURE_NO_DEPRECATE
+			# Get M_PI to work
+			_USE_MATH_DEFINES
+			# Don't define min/max macros in minwindef.h
+			NOMINMAX
+		)
 	endif()
 	set(PLATFORM_LIBS ws2_32.lib version.lib shlwapi.lib winmm.lib ${PLATFORM_LIBS})
 
@@ -871,7 +874,7 @@ endif()
 
 if(MSVC)
 	# Visual Studio
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D _WIN32_WINNT=0x0601 /D WIN32_LEAN_AND_MEAN /D _CRT_SECURE_NO_WARNINGS")
+	add_compile_definitions(_WIN32_WINNT=0x0601 WIN32_LEAN_AND_MEAN _CRT_SECURE_NO_WARNINGS)
 	# EHa enables SEH exceptions (used for catching segfaults)
 	set(CMAKE_CXX_FLAGS_RELEASE "/EHa /Ox /MD /GS- /Zi /fp:fast /D NDEBUG /D _HAS_ITERATOR_DEBUGGING=0")
 	if(CMAKE_SIZEOF_VOID_P EQUAL 4)
@@ -915,7 +918,7 @@ else()
 		if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 			set(OTHER_FLAGS "${OTHER_FLAGS} -mthreads")
 		endif()
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_WIN32_WINNT=0x0601 -DWIN32_LEAN_AND_MEAN")
+		add_compile_definitions(_WIN32_WINNT=0x0601 WIN32_LEAN_AND_MEAN)
 	endif()
 
 	# Use a safe subset of flags to speed up math calculations:


### PR DESCRIPTION
This is a newer feature introduced in CMake 3.12, which is now our minimum version. It supercedes `add_definitions`. I've also replaced some calls to set `CMAKE_<LANG>_FLAGS` that were used to set definitions. This is a fairly trivial routine build maintenance that is not intended to have any behavioral effects.

## To do

Ready for Review.

## How to test

If no typos were introduced, then CI should pass.