### PR TITLE
Adopt #13446 server favorite button

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -62,17 +62,17 @@ local function is_selected_fav(server)
 	local port = tonumber(core.settings:get("remote_port"))
 
 	for _, fav in ipairs(serverlistmgr.get_favorites()) do
-			if address == fav.address and port == fav.port then
-				return true
-			end
+		if address == fav.address and port == fav.port then
+			return true
 		end
+	end
+	return false
 end
 
 local function set_selected_server(server)
 	local address = server.address
 	local port    = server.port
-
-	is_selected_fav()
+	gamedata.serverdescription = server.description
 
 	if address and port then
 		core.settings:set("address", address)

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -56,18 +56,23 @@ local function get_sorted_servers()
 end
 
 -- Persists the selected server in the "address" and "remote_port" settings
+
+local function is_selected_fav(server)
+	local address = core.settings:get("address")
+	local port = tonumber(core.settings:get("remote_port"))
+
+	for _, fav in ipairs(serverlistmgr.get_favorites()) do
+			if address == fav.address and port == fav.port then
+				return true
+			end
+		end
+end
+
 local function set_selected_server(server)
 	local address = server.address
 	local port    = server.port
-	gamedata.serverdescription = server.description
 
-	gamedata.fav = false
-	for _, fav in ipairs(serverlistmgr.get_favorites()) do
-		if address == fav.address and port == fav.port then
-			gamedata.fav = true
-			break
-		end
-	end
+	is_selected_fav()
 
 	if address and port then
 		core.settings:set("address", address)
@@ -164,7 +169,7 @@ local function get_formspec(tabview, name, tabdata)
 				"server_view_clients.png") .. ";btn_view_clients;]"
 		end
 
-		if gamedata.fav then
+		if is_selected_fav() then
 			retval = retval .. "tooltip[btn_delete_favorite;" .. fgettext("Remove favorite") .. "]"
 			retval = retval .. "style[btn_delete_favorite;padding=6]"
 			retval = retval .. "image_button[" .. (can_view_clients_list and "4.5" or "5") .. ",1.3;0.5,0.5;" ..
@@ -338,7 +343,6 @@ local function main_button_handler(tabview, fields, name, tabdata)
 
 	if fields.btn_add_favorite then
 		serverlistmgr.add_favorite(find_selected_server())
-		gamedata.fav = true
 		return true
 	end
 

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -165,19 +165,19 @@ local function get_formspec(tabview, name, tabdata)
 						fgettext("Clients:\n$1", table.concat(clients_list, "\n")) .. "]"
 			end
 			retval = retval .. "style[btn_view_clients;padding=6]"
-			retval = retval .. "image_button[5,1.3;0.5,0.5;" .. core.formspec_escape(defaulttexturedir ..
+			retval = retval .. "image_button[4.5,1.3;0.5,0.5;" .. core.formspec_escape(defaulttexturedir ..
 				"server_view_clients.png") .. ";btn_view_clients;]"
 		end
 
 		if is_selected_fav() then
 			retval = retval .. "tooltip[btn_delete_favorite;" .. fgettext("Remove favorite") .. "]"
 			retval = retval .. "style[btn_delete_favorite;padding=6]"
-			retval = retval .. "image_button[" .. (can_view_clients_list and "4.5" or "5") .. ",1.3;0.5,0.5;" ..
+			retval = retval .. "image_button[5,1.3;0.5,0.5;" ..
 				core.formspec_escape(defaulttexturedir .. "server_favorite_delete.png") .. ";btn_delete_favorite;]"
 		else
 			retval = retval .. "tooltip[btn_add_favorite;" .. fgettext("Add favorite") .. "]"
 			retval = retval .. "style[btn_add_favorite;padding=6]"
-			retval = retval .. "image_button[" .. (can_view_clients_list and "4.5" or "5") ..",1.3;0.5,0.5;" ..
+			retval = retval .. "image_button[5,1.3;0.5,0.5;" ..
 				core.formspec_escape(defaulttexturedir .. "server_favorite.png") .. ";btn_add_favorite;]"
 		end
 	end

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -55,8 +55,6 @@ local function get_sorted_servers()
 	return servers
 end
 
--- Persists the selected server in the "address" and "remote_port" settings
-
 local function is_selected_fav(server)
 	local address = core.settings:get("address")
 	local port = tonumber(core.settings:get("remote_port"))
@@ -68,6 +66,8 @@ local function is_selected_fav(server)
 	end
 	return false
 end
+
+-- Persists the selected server in the "address" and "remote_port" settings
 
 local function set_selected_server(server)
 	local address = server.address

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -169,6 +169,16 @@ local function get_formspec(tabview, name, tabdata)
 			retval = retval .. "style[btn_delete_favorite;padding=6]"
 			retval = retval .. "image_button[" .. (can_view_clients_list and "4.5" or "5") .. ",1.3;0.5,0.5;" ..
 				core.formspec_escape(defaulttexturedir .. "server_favorite_delete.png") .. ";btn_delete_favorite;]"
+		else
+			retval = retval .. "tooltip[btn_add_favorite;" .. fgettext("Add favorite") .. "]"
+			retval = retval .. "style[btn_add_favorite;padding=6]"
+			if not can_view_clients_list then
+				retval = retval .. "image_button[5,1.3;0.5,0.5;" .. core.formspec_escape(defaulttexturedir ..
+					"server_favorite.png") .. ";btn_add_favorite;]"
+			else
+				retval = retval .. "image_button[4.5,1.3;0.5,0.5;" .. core.formspec_escape(defaulttexturedir ..
+					"server_favorite.png") .. ";btn_add_favorite;]"
+			end
 		end
 	end
 
@@ -329,6 +339,14 @@ local function main_button_handler(tabview, fields, name, tabdata)
 				return true
 			end
 		end
+	end
+
+	if fields.btn_add_favorite then
+		local server = find_selected_server()
+
+		serverlistmgr.add_favorite(server)
+		set_selected_server(server)
+		return true
 	end
 
 	if fields.btn_delete_favorite then

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -172,13 +172,8 @@ local function get_formspec(tabview, name, tabdata)
 		else
 			retval = retval .. "tooltip[btn_add_favorite;" .. fgettext("Add favorite") .. "]"
 			retval = retval .. "style[btn_add_favorite;padding=6]"
-			if not can_view_clients_list then
-				retval = retval .. "image_button[5,1.3;0.5,0.5;" .. core.formspec_escape(defaulttexturedir ..
-					"server_favorite.png") .. ";btn_add_favorite;]"
-			else
-				retval = retval .. "image_button[4.5,1.3;0.5,0.5;" .. core.formspec_escape(defaulttexturedir ..
-					"server_favorite.png") .. ";btn_add_favorite;]"
-			end
+			retval = retval .. "image_button[" .. (can_view_clients_list and "4.5" or "5") ..",1.3;0.5,0.5;" ..
+				core.formspec_escape(defaulttexturedir .. "server_favorite.png") .. ";btn_add_favorite;]"
 		end
 	end
 
@@ -342,10 +337,8 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	end
 
 	if fields.btn_add_favorite then
-		local server = find_selected_server()
-
-		serverlistmgr.add_favorite(server)
-		set_selected_server(server)
+		serverlistmgr.add_favorite(find_selected_server())
+		gamedata.fav = true
 		return true
 	end
 


### PR DESCRIPTION
This PR adds a button for adding a server to the favorites.

- Goal of the PR
Add a button to mark server as favorite without needing to join.

- Does it resolve any reported issue?
Resolves #12647

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
2.3 I'd say.

- If not a bug fix, why is this PR needed? What usecases does it solve?
One won't need to connect to a server to mark it as favorite.

## Preview
![image](https://github.com/user-attachments/assets/e02cc260-d8a3-4696-a873-50c3dd751473)
![image](https://github.com/user-attachments/assets/dc04eab1-f9ba-470f-ac10-291054763ba1)


## How to test

Mark & remove as favorite, try while searching and check nothing else broke.
Check that the selection is updating.
