### PR TITLE
Use CMake `list` directives where appropriate

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -274,7 +274,7 @@ set(PLATFORM_LIBS Threads::Threads)
 if(WIN32)
 	# Windows
 	if(MSVC) # MSVC Specifics
-		set(PLATFORM_LIBS dbghelp.lib ${PLATFORM_LIBS})
+		list(INSERT PLATFORM_LIBS 0 dbghelp.lib)
 		# Surpress some useless warnings
 		add_definitions ( /D "_CRT_SECURE_NO_DEPRECATE" /W1 )
 		# Get M_PI to work
@@ -282,7 +282,7 @@ if(WIN32)
 		# Don't define min/max macros in minwindef.h
 		add_definitions(/D "NOMINMAX")
 	endif()
-	set(PLATFORM_LIBS ws2_32.lib version.lib shlwapi.lib winmm.lib ${PLATFORM_LIBS})
+	list(INSERT PLATFORM_LIBS 0 ws2_32.lib version.lib shlwapi.lib winmm.lib)
 
 	set(EXTRA_DLL "" CACHE FILEPATH "Optional paths to additional DLLs that should be packaged")
 
@@ -309,28 +309,28 @@ if(WIN32)
 	endif()
 else()
 	# Unix probably
-	set(PLATFORM_LIBS ${PLATFORM_LIBS} ${CMAKE_DL_LIBS})
+	list(APPEND PLATFORM_LIBS ${CMAKE_DL_LIBS})
 	if(APPLE)
-		set(PLATFORM_LIBS "-framework CoreFoundation" ${PLATFORM_LIBS})
+		list(INSERT PLATFORM_LIBS 0 "-framework CoreFoundation")
 	else()
 		check_library_exists(rt clock_gettime "" HAVE_LIBRT)
 		if (HAVE_LIBRT)
-			set(PLATFORM_LIBS -lrt ${PLATFORM_LIBS})
+			list(INSERT PLATFORM_LIBS 0 -lrt)
 		endif(HAVE_LIBRT)
 	endif(APPLE)
 
 	find_library(ICONV_LIBRARY iconv)
 	mark_as_advanced(ICONV_LIBRARY)
 	if (ICONV_LIBRARY)
-		set(PLATFORM_LIBS ${PLATFORM_LIBS} ${ICONV_LIBRARY})
+		list(APPEND PLATFORM_LIBS ${ICONV_LIBRARY})
 	endif()
 
 	if (HAIKU)
-		set(PLATFORM_LIBS ${PLATFORM_LIBS} network)
+		list(APPEND PLATFORM_LIBS network)
 	endif()
 
 	if (ANDROID)
-		set(PLATFORM_LIBS ${PLATFORM_LIBS} android log)
+		list(APPEND PLATFORM_LIBS android log)
 	endif()
 endif()
 
@@ -344,7 +344,7 @@ if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 	check_c_source_compiles("int main(){}" HAVE_LINK_ATOMIC)
 	set(CMAKE_REQUIRED_LIBRARIES "")
 	if(HAVE_LINK_ATOMIC)
-		set(PLATFORM_LIBS ${PLATFORM_LIBS} "-latomic")
+		list(APPEND PLATFORM_LIBS "-latomic")
 	endif()
 endif()
 
@@ -468,21 +468,21 @@ set(common_SRCS
 )
 
 if(ANDROID)
-	set(common_SRCS ${common_SRCS} porting_android.cpp)
+	list(APPEND common_SRCS porting_android.cpp)
 endif()
 
 if(BUILD_UNITTESTS)
 	add_subdirectory(unittest)
-	set(common_SRCS ${common_SRCS} ${UNITTEST_SRCS})
+	list(APPEND common_SRCS ${UNITTEST_SRCS})
 endif()
 
 if(BUILD_BENCHMARKS)
 	add_subdirectory(benchmark)
-	set(common_SRCS ${common_SRCS} ${BENCHMARK_SRCS})
+	list(APPEND common_SRCS ${BENCHMARK_SRCS})
 endif()
 
 if(BUILD_UNITTESTS OR BUILD_BENCHMARKS)
-	set(common_SRCS ${common_SRCS} catch.cpp)
+	list(APPEND common_SRCS catch.cpp)
 endif()
 
 # This gives us the icon and file version information
@@ -513,8 +513,7 @@ if (BUILD_CLIENT)
 	add_subdirectory(irrlicht_changes)
 endif(BUILD_CLIENT)
 
-set(client_SRCS
-	${client_SRCS}
+list(APPEND client_SRCS
 	${common_SRCS}
 	${gui_SRCS}
 	${client_network_SRCS}
@@ -523,11 +522,11 @@ set(client_SRCS
 )
 
 if(BUILD_UNITTESTS)
-	set(client_SRCS ${client_SRCS} ${UNITTEST_CLIENT_SRCS})
+	list(APPEND client_SRCS ${UNITTEST_CLIENT_SRCS})
 endif()
 
 if(BUILD_BENCHMARKS)
-	set(client_SRCS ${client_SRCS} ${BENCHMARK_CLIENT_SRCS})
+	list(APPEND client_SRCS ${BENCHMARK_CLIENT_SRCS})
 endif()
 
 # Server sources
@@ -1103,7 +1102,7 @@ elseif (USE_GETTEXT)
 			COMMENT "mo-update [${LOCALE}]: Creating mo file."
 			)
 
-		set(MO_FILES ${MO_FILES} ${MO_FILE_PATH})
+		list(APPEND MO_FILES ${MO_FILE_PATH})
 	endforeach()
 
 	add_custom_target(translations ALL COMMENT "mo update" DEPENDS ${MO_FILES})

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(sound_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/sound.cpp)
 
 if(USE_SOUND)
-	set(sound_SRCS ${sound_SRCS}
+	list(APPEND sound_SRCS
 		${CMAKE_CURRENT_SOURCE_DIR}/sound/al_extensions.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/sound/al_helpers.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/sound/ogg_file.cpp


### PR DESCRIPTION
I think this communicates the intent a little better than using a `set` directive, and it makes the code a little less verbose, too. This is just another build maintenance and has no behavioral change for the build.

## To do

Ready for Review.

## How to test

CI should pass.
