### PR TITLE
Use `add_compile_options` where appropriate

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -893,12 +893,12 @@ if(MSVC)
 	# Flags that cannot be shared between cl and clang-cl
 	# https://clang.llvm.org/docs/UsersManual.html#clang-cl
 	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=lld")
+		add_compile_options(-fuse-ld=lld)
 
 		# Disable pragma-pack warning
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-pragma-pack")
 	else()
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+		add_compile_options(/MP)
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /TP /FD /GL")
 		set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LTCG")
 	endif()


### PR DESCRIPTION
This is a trivial build maintenance. I had observed in the past that setting `CMAKE_CXX_FLAGS` from the command line with MSVC could break the entire project such that it would no longer build. That does not seem to be the case anymore, but to ensure things continue to work, it seems wise not to manually mess with the variable when it's not necessary to do so. This cannot be done for the `CMAKE_<LANG>_FLAGS_<CONFIG>` options, because some generators (e.g. Visual Studio) can choose a config at build-time. I think we cannot decide what options to use based on Debug/Release/etc. during configuration without breaking that current behavior.

## To do

Ready for Review.

## How to test

CI should pass.