### PR TITLE
Add Minetest keyword to desktop file for backwards compatibility

### DIFF
--- a/misc/net.minetest.minetest.desktop
+++ b/misc/net.minetest.minetest.desktop
@@ -11,4 +11,4 @@ PrefersNonDefaultGPU=true
 Type=Application
 Categories=Game;Simulation;
 StartupNotify=false
-Keywords=sandbox;world;mining;crafting;blocks;nodes;multiplayer;roleplaying;
+Keywords=sandbox;world;mining;crafting;blocks;nodes;multiplayer;roleplaying;minetest;


### PR DESCRIPTION
This helps people looking for `minetest`. Many will still type `minetest` because of their muscle memory.
