### PR TITLE
Delete default `aabbox3d` constructor

### DIFF
--- a/irr/include/CMeshBuffer.h
+++ b/irr/include/CMeshBuffer.h
@@ -137,7 +137,7 @@ public:
 	//! Index buffer
 	SIndexBuffer *Indices;
 	//! Bounding box of this meshbuffer.
-	core::aabbox3d<f32> BoundingBox;
+	core::aabbox3d<f32> BoundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	//! Primitive type used for rendering (triangles, lines, ...)
 	E_PRIMITIVE_TYPE PrimitiveType;
 };

--- a/irr/include/CMeshBuffer.h
+++ b/irr/include/CMeshBuffer.h
@@ -137,7 +137,7 @@ public:
 	//! Index buffer
 	SIndexBuffer *Indices;
 	//! Bounding box of this meshbuffer.
-	core::aabbox3d<f32> BoundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	core::aabbox3d<f32> BoundingBox{{0, 0, 0}};
 	//! Primitive type used for rendering (triangles, lines, ...)
 	E_PRIMITIVE_TYPE PrimitiveType;
 };

--- a/irr/include/IMeshManipulator.h
+++ b/irr/include/IMeshManipulator.h
@@ -108,7 +108,7 @@ public:
 		if (!mesh)
 			return true;
 		bool result = true;
-		core::aabbox3df bufferbox;
+		core::aabbox3df bufferbox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 		for (u32 i = 0; i < mesh->getMeshBufferCount(); ++i) {
 			result &= apply(func, mesh->getMeshBuffer(i), boundingBoxUpdate);
 			if (boundingBoxUpdate) {
@@ -136,7 +136,7 @@ protected:
 		if (!buffer)
 			return true;
 
-		core::aabbox3df bufferbox;
+		core::aabbox3df bufferbox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 		for (u32 i = 0; i < buffer->getVertexCount(); ++i) {
 			switch (buffer->getVertexType()) {
 			case video::EVT_STANDARD: {

--- a/irr/include/SAnimatedMesh.h
+++ b/irr/include/SAnimatedMesh.h
@@ -157,7 +157,7 @@ struct SAnimatedMesh final : public IAnimatedMesh
 	std::vector<IMesh *> Meshes;
 
 	//! The bounding box of this mesh
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 	//! Default animation speed of this mesh.
 	f32 FramesPerSecond;

--- a/irr/include/SAnimatedMesh.h
+++ b/irr/include/SAnimatedMesh.h
@@ -157,7 +157,7 @@ struct SAnimatedMesh final : public IAnimatedMesh
 	std::vector<IMesh *> Meshes;
 
 	//! The bounding box of this mesh
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{{0.0f, 0.0f, 0.0f}};
 
 	//! Default animation speed of this mesh.
 	f32 FramesPerSecond;

--- a/irr/include/SAnimatedMesh.h
+++ b/irr/include/SAnimatedMesh.h
@@ -157,7 +157,7 @@ struct SAnimatedMesh final : public IAnimatedMesh
 	std::vector<IMesh *> Meshes;
 
 	//! The bounding box of this mesh
-	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	core::aabbox3d<f32> Box;
 
 	//! Default animation speed of this mesh.
 	f32 FramesPerSecond;

--- a/irr/include/SMesh.h
+++ b/irr/include/SMesh.h
@@ -138,7 +138,7 @@ struct SMesh final : public IMesh
 	std::vector<u32> TextureSlots;
 
 	//! The bounding box of this mesh
-	core::aabbox3d<f32> BoundingBox;
+	core::aabbox3d<f32> BoundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 };
 
 } // end namespace scene

--- a/irr/include/SSkinMeshBuffer.h
+++ b/irr/include/SSkinMeshBuffer.h
@@ -231,7 +231,7 @@ public:
 	video::SMaterial Material;
 	video::E_VERTEX_TYPE VertexType;
 
-	core::aabbox3d<f32> BoundingBox;
+	core::aabbox3d<f32> BoundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 	//! Primitive type used for rendering (triangles, lines, ...)
 	E_PRIMITIVE_TYPE PrimitiveType;

--- a/irr/include/SViewFrustum.h
+++ b/irr/include/SViewFrustum.h
@@ -117,7 +117,7 @@ struct SViewFrustum
 	core::plane3d<f32> planes[VF_PLANE_COUNT];
 
 	//! bounding box around the view frustum
-	core::aabbox3d<f32> boundingBox;
+	core::aabbox3d<f32> boundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 private:
 	//! Hold a copy of important transform matrices

--- a/irr/include/SkinnedMesh.h
+++ b/irr/include/SkinnedMesh.h
@@ -319,7 +319,7 @@ private:
 	// doesn't allow taking a reference to individual elements.
 	core::array<core::array<char>> Vertices_Moved;
 
-	core::aabbox3d<f32> BoundingBox;
+	core::aabbox3d<f32> BoundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 	f32 EndFrame;
 	f32 FramesPerSecond;

--- a/irr/include/aabbox3d.h
+++ b/irr/include/aabbox3d.h
@@ -21,8 +21,7 @@ class aabbox3d
 {
 public:
 	//! Default Constructor.
-	constexpr aabbox3d() :
-			MinEdge(-1, -1, -1), MaxEdge(1, 1, 1) {}
+	constexpr aabbox3d() = delete;
 	//! Constructor with min edge and max edge.
 	constexpr aabbox3d(const vector3d<T> &min, const vector3d<T> &max) :
 			MinEdge(min), MaxEdge(max) {}

--- a/irr/include/aabbox3d.h
+++ b/irr/include/aabbox3d.h
@@ -20,7 +20,7 @@ template <class T>
 class aabbox3d
 {
 public:
-	constexpr aabbox3d() {}
+	constexpr aabbox3d() = delete;
 	//! Constructor with min edge and max edge.
 	constexpr aabbox3d(const vector3d<T> &min, const vector3d<T> &max) :
 			MinEdge(min), MaxEdge(max) {}

--- a/irr/include/aabbox3d.h
+++ b/irr/include/aabbox3d.h
@@ -372,10 +372,10 @@ public:
 	}
 
 	//! The near edge
-	vector3d<T> MinEdge{};
+	vector3d<T> MinEdge;
 
 	//! The far edge
-	vector3d<T> MaxEdge{};
+	vector3d<T> MaxEdge;
 };
 
 //! Typedef for a f32 3d bounding box.

--- a/irr/include/aabbox3d.h
+++ b/irr/include/aabbox3d.h
@@ -20,8 +20,7 @@ template <class T>
 class aabbox3d
 {
 public:
-	//! Default Constructor.
-	constexpr aabbox3d() = delete;
+	constexpr aabbox3d() {}
 	//! Constructor with min edge and max edge.
 	constexpr aabbox3d(const vector3d<T> &min, const vector3d<T> &max) :
 			MinEdge(min), MaxEdge(max) {}
@@ -373,10 +372,10 @@ public:
 	}
 
 	//! The near edge
-	vector3d<T> MinEdge;
+	vector3d<T> MinEdge{};
 
 	//! The far edge
-	vector3d<T> MaxEdge;
+	vector3d<T> MaxEdge{};
 };
 
 //! Typedef for a f32 3d bounding box.

--- a/irr/src/CAnimatedMeshSceneNode.h
+++ b/irr/src/CAnimatedMeshSceneNode.h
@@ -145,7 +145,7 @@ private:
 	void beginTransition();
 
 	core::array<video::SMaterial> Materials;
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{{0.0f, 0.0f, 0.0f}};
 	IAnimatedMesh *Mesh;
 
 	f32 StartFrame;

--- a/irr/src/CAnimatedMeshSceneNode.h
+++ b/irr/src/CAnimatedMeshSceneNode.h
@@ -145,7 +145,7 @@ private:
 	void beginTransition();
 
 	core::array<video::SMaterial> Materials;
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	IAnimatedMesh *Mesh;
 
 	f32 StartFrame;

--- a/irr/src/CAnimatedMeshSceneNode.h
+++ b/irr/src/CAnimatedMeshSceneNode.h
@@ -145,7 +145,7 @@ private:
 	void beginTransition();
 
 	core::array<video::SMaterial> Materials;
-	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	core::aabbox3d<f32> Box;
 	IAnimatedMesh *Mesh;
 
 	f32 StartFrame;

--- a/irr/src/CBillboardSceneNode.h
+++ b/irr/src/CBillboardSceneNode.h
@@ -104,7 +104,7 @@ private:
 	/** Note that we can't use the real boundingbox for culling because at that point
 		the camera which is used to calculate the billboard is not yet updated. So we only
 		know the real boundingbox after rendering - which is too late for culling. */
-	core::aabbox3d<f32> BBoxSafe;
+	core::aabbox3d<f32> BBoxSafe{{0.0f, 0.0f, 0.0f}};
 
 	scene::SMeshBuffer *Buffer;
 };

--- a/irr/src/CBillboardSceneNode.h
+++ b/irr/src/CBillboardSceneNode.h
@@ -104,7 +104,7 @@ private:
 	/** Note that we can't use the real boundingbox for culling because at that point
 		the camera which is used to calculate the billboard is not yet updated. So we only
 		know the real boundingbox after rendering - which is too late for culling. */
-	core::aabbox3d<f32> BBoxSafe;
+	core::aabbox3d<f32> BBoxSafe{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 	scene::SMeshBuffer *Buffer;
 };

--- a/irr/src/CBillboardSceneNode.h
+++ b/irr/src/CBillboardSceneNode.h
@@ -104,7 +104,7 @@ private:
 	/** Note that we can't use the real boundingbox for culling because at that point
 		the camera which is used to calculate the billboard is not yet updated. So we only
 		know the real boundingbox after rendering - which is too late for culling. */
-	core::aabbox3d<f32> BBoxSafe{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	core::aabbox3d<f32> BBoxSafe;
 
 	scene::SMeshBuffer *Buffer;
 };

--- a/irr/src/CBoneSceneNode.h
+++ b/irr/src/CBoneSceneNode.h
@@ -60,7 +60,7 @@ private:
 
 	u32 BoneIndex;
 
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 	E_BONE_ANIMATION_MODE AnimationMode;
 	E_BONE_SKINNING_SPACE SkinningSpace;

--- a/irr/src/CDummyTransformationSceneNode.h
+++ b/irr/src/CDummyTransformationSceneNode.h
@@ -48,7 +48,7 @@ private:
 	void setPosition(const core::vector3df &newpos) override;
 
 	core::matrix4 RelativeTransformationMatrix;
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 };
 
 } // end namespace scene

--- a/irr/src/CEmptySceneNode.h
+++ b/irr/src/CEmptySceneNode.h
@@ -33,7 +33,7 @@ public:
 	ISceneNode *clone(ISceneNode *newParent = 0, ISceneManager *newManager = 0) override;
 
 private:
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 };
 
 } // end namespace scene

--- a/irr/src/CMeshSceneNode.h
+++ b/irr/src/CMeshSceneNode.h
@@ -72,7 +72,7 @@ protected:
 	void copyMaterials();
 
 	core::array<video::SMaterial> Materials;
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	video::SMaterial ReadOnlyMaterial;
 
 	IMesh *Mesh;

--- a/irr/src/CSceneManager.cpp
+++ b/irr/src/CSceneManager.cpp
@@ -312,7 +312,7 @@ const core::aabbox3d<f32> &CSceneManager::getBoundingBox() const
 {
 	_IRR_DEBUG_BREAK_IF(true) // Bounding Box of Scene Manager should never be used.
 
-	static const core::aabbox3d<f32> dummy;
+	static const core::aabbox3d<f32> dummy{{0.0f, 0.0f, 0.0f}};
 	return dummy;
 }
 

--- a/irr/src/CSceneManager.cpp
+++ b/irr/src/CSceneManager.cpp
@@ -312,7 +312,7 @@ const core::aabbox3d<f32> &CSceneManager::getBoundingBox() const
 {
 	_IRR_DEBUG_BREAK_IF(true) // Bounding Box of Scene Manager should never be used.
 
-	static const core::aabbox3d<f32> dummy;
+	static const core::aabbox3d<f32> dummy{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	return dummy;
 }
 

--- a/irr/src/CSceneManager.cpp
+++ b/irr/src/CSceneManager.cpp
@@ -312,7 +312,7 @@ const core::aabbox3d<f32> &CSceneManager::getBoundingBox() const
 {
 	_IRR_DEBUG_BREAK_IF(true) // Bounding Box of Scene Manager should never be used.
 
-	static const core::aabbox3d<f32> dummy{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	static const core::aabbox3d<f32> dummy;
 	return dummy;
 }
 

--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -101,7 +101,7 @@ std::vector<DistanceSortedActiveObject> ActiveObjectMgr::getActiveSelectableObje
 		if (!obj)
 			continue;
 
-		aabb3f selection_box;
+		aabb3f selection_box{{0.0f, 0.0f, 0.0f}};
 		if (!obj->getSelectionBox(&selection_box))
 			continue;
 

--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -101,7 +101,7 @@ std::vector<DistanceSortedActiveObject> ActiveObjectMgr::getActiveSelectableObje
 		if (!obj)
 			continue;
 
-		aabb3f selection_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+		aabb3f selection_box;
 		if (!obj->getSelectionBox(&selection_box))
 			continue;
 

--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -101,7 +101,7 @@ std::vector<DistanceSortedActiveObject> ActiveObjectMgr::getActiveSelectableObje
 		if (!obj)
 			continue;
 
-		aabb3f selection_box;
+		aabb3f selection_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 		if (!obj->getSelectionBox(&selection_box))
 			continue;
 

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -430,7 +430,7 @@ void ClientEnvironment::getSelectedActiveObjects(
 
 	for (const auto &allObject : allObjects) {
 		ClientActiveObject *obj = allObject.obj;
-		aabb3f selection_box;
+		aabb3f selection_box{{0.0f, 0.0f, 0.0f}};
 		if (!obj->getSelectionBox(&selection_box))
 			continue;
 

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -430,7 +430,7 @@ void ClientEnvironment::getSelectedActiveObjects(
 
 	for (const auto &allObject : allObjects) {
 		ClientActiveObject *obj = allObject.obj;
-		aabb3f selection_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+		aabb3f selection_box;
 		if (!obj->getSelectionBox(&selection_box))
 			continue;
 

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -430,7 +430,7 @@ void ClientEnvironment::getSelectedActiveObjects(
 
 	for (const auto &allObject : allObjects) {
 		ClientActiveObject *obj = allObject.obj;
-		aabb3f selection_box;
+		aabb3f selection_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 		if (!obj->getSelectionBox(&selection_box))
 			continue;
 

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -160,7 +160,7 @@ private:
 	// Was the mesh ever generated?
 	bool m_mesh_valid = false;
 
-	aabb3f m_box;
+	aabb3f m_box{{0.0f, 0.0f, 0.0f}};
 	v2f m_origin;
 	u16 m_cloud_radius_i;
 	u32 m_seed;

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -160,7 +160,7 @@ private:
 	// Was the mesh ever generated?
 	bool m_mesh_valid = false;
 
-	aabb3f m_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	aabb3f m_box;
 	v2f m_origin;
 	u16 m_cloud_radius_i;
 	u32 m_seed;

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -160,7 +160,7 @@ private:
 	// Was the mesh ever generated?
 	bool m_mesh_valid = false;
 
-	aabb3f m_box;
+	aabb3f m_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	v2f m_origin;
 	u16 m_cloud_radius_i;
 	u32 m_seed;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3496,7 +3496,7 @@ PointedThing Game::updatePointedThing(
 		hud->pointing_at_object = true;
 
 		runData.selected_object = client->getEnv().getActiveObject(result.object_id);
-		aabb3f selection_box;
+		aabb3f selection_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 		if (show_entity_selectionbox && runData.selected_object->doShowSelectionBox() &&
 				runData.selected_object->getSelectionBox(&selection_box)) {
 			v3f pos = runData.selected_object->getPosition();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3496,7 +3496,7 @@ PointedThing Game::updatePointedThing(
 		hud->pointing_at_object = true;
 
 		runData.selected_object = client->getEnv().getActiveObject(result.object_id);
-		aabb3f selection_box;
+		aabb3f selection_box{{0.0f, 0.0f, 0.0f}};
 		if (show_entity_selectionbox && runData.selected_object->doShowSelectionBox() &&
 				runData.selected_object->getSelectionBox(&selection_box)) {
 			v3f pos = runData.selected_object->getPosition();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3496,7 +3496,7 @@ PointedThing Game::updatePointedThing(
 		hud->pointing_at_object = true;
 
 		runData.selected_object = client->getEnv().getActiveObject(result.object_id);
-		aabb3f selection_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+		aabb3f selection_box;
 		if (show_entity_selectionbox && runData.selected_object->doShowSelectionBox() &&
 				runData.selected_object->getSelectionBox(&selection_box)) {
 			v3f pos = runData.selected_object->getPosition();

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -75,7 +75,7 @@ static aabb3f getNodeBoundingBox(const std::vector<aabb3f> &nodeboxes)
 	if (nodeboxes.empty())
 		return aabb3f(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
 
-	aabb3f b_max;
+	aabb3f b_max{{0.0f, 0.0f, 0.0f}};
 
 	std::vector<aabb3f>::const_iterator it = nodeboxes.begin();
 	b_max = aabb3f(it->MinEdge, it->MaxEdge);

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -75,7 +75,7 @@ static aabb3f getNodeBoundingBox(const std::vector<aabb3f> &nodeboxes)
 	if (nodeboxes.empty())
 		return aabb3f(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
 
-	aabb3f b_max;
+	aabb3f b_max{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 	std::vector<aabb3f>::const_iterator it = nodeboxes.begin();
 	b_max = aabb3f(it->MinEdge, it->MaxEdge);

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -75,10 +75,8 @@ static aabb3f getNodeBoundingBox(const std::vector<aabb3f> &nodeboxes)
 	if (nodeboxes.empty())
 		return aabb3f(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
 
-	aabb3f b_max{{0.0f, 0.0f, 0.0f}};
-
-	std::vector<aabb3f>::const_iterator it = nodeboxes.begin();
-	b_max = aabb3f(it->MinEdge, it->MaxEdge);
+	auto it = nodeboxes.begin();
+	aabb3f b_max(it->MinEdge, it->MaxEdge);
 
 	++it;
 	for (; it != nodeboxes.end(); ++it)

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -75,7 +75,7 @@ static aabb3f getNodeBoundingBox(const std::vector<aabb3f> &nodeboxes)
 	if (nodeboxes.empty())
 		return aabb3f(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
 
-	aabb3f b_max{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	aabb3f b_max;
 
 	std::vector<aabb3f>::const_iterator it = nodeboxes.begin();
 	b_max = aabb3f(it->MinEdge, it->MaxEdge);

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -105,8 +105,7 @@ void scaleMesh(scene::IMesh *mesh, v3f scale)
 	if (mesh == NULL)
 		return;
 
-	aabb3f bbox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
-	bbox.reset(0, 0, 0);
+	aabb3f bbox{{0.0f, 0.0f, 0.0f}};
 
 	u32 mc = mesh->getMeshBufferCount();
 	for (u32 j = 0; j < mc; j++) {
@@ -134,8 +133,7 @@ void translateMesh(scene::IMesh *mesh, v3f vec)
 	if (mesh == NULL)
 		return;
 
-	aabb3f bbox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
-	bbox.reset(0, 0, 0);
+	aabb3f bbox{{0.0f, 0.0f, 0.0f}};
 
 	u32 mc = mesh->getMeshBufferCount();
 	for (u32 j = 0; j < mc; j++) {
@@ -292,8 +290,7 @@ void rotateMeshBy6dFacedir(scene::IMesh *mesh, int facedir)
 
 void recalculateBoundingBox(scene::IMesh *src_mesh)
 {
-	aabb3f bbox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
-	bbox.reset(0,0,0);
+	aabb3f bbox{{0.0f, 0.0f, 0.0f}};
 	for (u16 j = 0; j < src_mesh->getMeshBufferCount(); j++) {
 		scene::IMeshBuffer *buf = src_mesh->getMeshBuffer(j);
 		buf->recalculateBoundingBox();

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -105,7 +105,7 @@ void scaleMesh(scene::IMesh *mesh, v3f scale)
 	if (mesh == NULL)
 		return;
 
-	aabb3f bbox;
+	aabb3f bbox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	bbox.reset(0, 0, 0);
 
 	u32 mc = mesh->getMeshBufferCount();
@@ -134,7 +134,7 @@ void translateMesh(scene::IMesh *mesh, v3f vec)
 	if (mesh == NULL)
 		return;
 
-	aabb3f bbox;
+	aabb3f bbox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	bbox.reset(0, 0, 0);
 
 	u32 mc = mesh->getMeshBufferCount();
@@ -292,7 +292,7 @@ void rotateMeshBy6dFacedir(scene::IMesh *mesh, int facedir)
 
 void recalculateBoundingBox(scene::IMesh *src_mesh)
 {
-	aabb3f bbox;
+	aabb3f bbox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	bbox.reset(0,0,0);
 	for (u16 j = 0; j < src_mesh->getMeshBufferCount(); j++) {
 		scene::IMeshBuffer *buf = src_mesh->getMeshBuffer(j);

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -619,7 +619,7 @@ const core::aabbox3df &ParticleBuffer::getBoundingBox() const
 	if (!m_bounding_box_dirty)
 		return m_mesh_buffer->BoundingBox;
 
-	core::aabbox3df box;
+	core::aabbox3df box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	for (u16 i = 0; i < m_count; i++) {
 		// check if this index is used
 		static_assert(quad_indices[1] != 0);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -50,8 +50,6 @@ Sky::Sky(s32 id, RenderingEngine *rendering_engine, ITextureSource *tsrc, IShade
 	m_seed = (u64)myrand() << 32 | myrand();
 
 	setAutomaticCulling(scene::EAC_OFF);
-	m_box.MaxEdge.set(0, 0, 0);
-	m_box.MinEdge.set(0, 0, 0);
 
 	m_sky_params = SkyboxDefaults::getSkyDefaults();
 	m_sun_params = SkyboxDefaults::getSunDefaults();

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -122,7 +122,7 @@ public:
 	}
 
 private:
-	aabb3f m_box;
+	aabb3f m_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	video::SMaterial m_materials[SKY_MATERIAL_COUNT];
 	// How much sun & moon transition should affect horizon color
 	float m_horizon_blend()

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -122,7 +122,7 @@ public:
 	}
 
 private:
-	aabb3f m_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	aabb3f m_box{{0.0f, 0.0f, 0.0f}};
 	video::SMaterial m_materials[SKY_MATERIAL_COUNT];
 	// How much sun & moon transition should affect horizon color
 	float m_horizon_blend()

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -134,7 +134,7 @@ private:
 	// Bounding box culling is disabled for this type of scene node,
 	// so this variable is just required so we can implement
 	// getBoundingBox() and is set to an empty box.
-	aabb3f m_bounding_box;
+	aabb3f m_bounding_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 	ShadowRenderer *m_shadow;
 };

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -262,7 +262,7 @@ static void add_object_boxes(Environment *env,
 {
 	auto process_object = [&cinfo] (ActiveObject *object) {
 		if (object && object->collideWithObjects()) {
-			aabb3f box;
+			aabb3f box{{0.0f, 0.0f, 0.0f}};
 			if (object->getCollisionBox(&box))
 				cinfo.emplace_back(object, 0, box);
 		}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -262,7 +262,7 @@ static void add_object_boxes(Environment *env,
 {
 	auto process_object = [&cinfo] (ActiveObject *object) {
 		if (object && object->collideWithObjects()) {
-			aabb3f box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+			aabb3f box;
 			if (object->getCollisionBox(&box))
 				cinfo.emplace_back(object, 0, box);
 		}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -262,7 +262,7 @@ static void add_object_boxes(Environment *env,
 {
 	auto process_object = [&cinfo] (ActiveObject *object) {
 		if (object && object->collideWithObjects()) {
-			aabb3f box;
+			aabb3f box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 			if (object->getCollisionBox(&box))
 				cinfo.emplace_back(object, 0, box);
 		}

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -120,7 +120,7 @@ void NodeBox::deSerialize(std::istream &is)
 		case NODEBOX_LEVELED: {
 			u16 fixed_count = readU16(is);
 			while(fixed_count--) {
-				aabb3f box;
+				aabb3f box{{0.0f, 0.0f, 0.0f}};
 				box.MinEdge = readV3F32(is);
 				box.MaxEdge = readV3F32(is);
 				fixed.push_back(box);

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -120,7 +120,7 @@ void NodeBox::deSerialize(std::istream &is)
 		case NODEBOX_LEVELED: {
 			u16 fixed_count = readU16(is);
 			while(fixed_count--) {
-				aabb3f box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+				aabb3f box;
 				box.MinEdge = readV3F32(is);
 				box.MaxEdge = readV3F32(is);
 				fixed.push_back(box);

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -120,7 +120,7 @@ void NodeBox::deSerialize(std::istream &is)
 		case NODEBOX_LEVELED: {
 			u16 fixed_count = readU16(is);
 			while(fixed_count--) {
-				aabb3f box;
+				aabb3f box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 				box.MinEdge = readV3F32(is);
 				box.MaxEdge = readV3F32(is);
 				fixed.push_back(box);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -115,9 +115,9 @@ struct NodeBox
 	// NODEBOX_FIXED
 	std::vector<aabb3f> fixed;
 	// NODEBOX_WALLMOUNTED
-	aabb3f wall_top;
-	aabb3f wall_bottom;
-	aabb3f wall_side; // being at the -X side
+	aabb3f wall_top{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	aabb3f wall_bottom{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	aabb3f wall_side{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f}; // being at the -X side
 	// NODEBOX_CONNECTED
 	// (kept externally to not bloat the structure)
 	std::shared_ptr<NodeBoxConnected> connected;
@@ -809,14 +809,14 @@ private:
 	 * The union of all nodes' selection boxes.
 	 * Might be larger if big nodes are removed from the manager.
 	 */
-	aabb3f m_selection_box_union;
+	aabb3f m_selection_box_union{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 	/*!
 	 * The smallest box in integer node coordinates that
 	 * contains all nodes' selection boxes.
 	 * Might be larger if big nodes are removed from the manager.
 	 */
-	core::aabbox3d<s16> m_selection_box_int_union;
+	core::aabbox3d<s16> m_selection_box_int_union{-1, -1, -1, 1, 1, 1};
 
 	/*!
 	 * NodeResolver instances to notify once node registration has finished.

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -809,14 +809,14 @@ private:
 	 * The union of all nodes' selection boxes.
 	 * Might be larger if big nodes are removed from the manager.
 	 */
-	aabb3f m_selection_box_union{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	aabb3f m_selection_box_union;
 
 	/*!
 	 * The smallest box in integer node coordinates that
 	 * contains all nodes' selection boxes.
 	 * Might be larger if big nodes are removed from the manager.
 	 */
-	core::aabbox3d<s16> m_selection_box_int_union{-1, -1, -1, 1, 1, 1};
+	core::aabbox3d<s16> m_selection_box_int_union;
 
 	/*!
 	 * NodeResolver instances to notify once node registration has finished.

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -809,14 +809,14 @@ private:
 	 * The union of all nodes' selection boxes.
 	 * Might be larger if big nodes are removed from the manager.
 	 */
-	aabb3f m_selection_box_union;
+	aabb3f m_selection_box_union{{0.0f, 0.0f, 0.0f}};
 
 	/*!
 	 * The smallest box in integer node coordinates that
 	 * contains all nodes' selection boxes.
 	 * Might be larger if big nodes are removed from the manager.
 	 */
-	core::aabbox3d<s16> m_selection_box_int_union;
+	core::aabbox3d<s16> m_selection_box_int_union{{0, 0, 0}};
 
 	/*!
 	 * NodeResolver instances to notify once node registration has finished.

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -302,7 +302,7 @@ private:
 	v3s16 m_start;                /**< source position                          */
 	v3s16 m_destination;          /**< destination position                     */
 
-	core::aabbox3d<s16> m_limits; /**< position limits in real map coordinates  */
+	core::aabbox3d<s16> m_limits{-1, -1, -1, 1, 1, 1}; /**< position limits in real map coordinates  */
 
 	/** contains all map data already collected and analyzed.
 		Access it via the getIndexElement/getIdxElem methods. */

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -326,6 +326,7 @@ bool is_color_table(lua_State *L, int index)
 
 aabb3f read_aabb3f(lua_State *L, int index, f32 scale)
 {
+	// default value for accidental/historical reasons
 	aabb3f box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	if(lua_istable(L, index)){
 		lua_rawgeti(L, index, 1);

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -326,7 +326,7 @@ bool is_color_table(lua_State *L, int index)
 
 aabb3f read_aabb3f(lua_State *L, int index, f32 scale)
 {
-	aabb3f box;
+	aabb3f box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	if(lua_istable(L, index)){
 		lua_rawgeti(L, index, 1);
 		box.MinEdge.X = lua_tonumber(L, -1) * scale;

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -16,6 +16,7 @@ extern "C" {
 #include "constants.h"
 #include <set>
 #include <cmath>
+#include <ostream>
 
 
 #define CHECK_TYPE(index, name, type) do { \
@@ -346,6 +347,8 @@ aabb3f read_aabb3f(lua_State *L, int index, f32 scale)
 		lua_rawgeti(L, index, 6);
 		box.MaxEdge.Z = lua_tonumber(L, -1) * scale;
 		lua_pop(L, 1);
+	} else {
+		warningstream << "read_aabb3f: not a table, returning default 2x2x2 box." << std::endl;
 	}
 	box.repair();
 	return box;

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -16,7 +16,6 @@ extern "C" {
 #include "constants.h"
 #include <set>
 #include <cmath>
-#include <ostream>
 
 
 #define CHECK_TYPE(index, name, type) do { \
@@ -347,8 +346,6 @@ aabb3f read_aabb3f(lua_State *L, int index, f32 scale)
 		lua_rawgeti(L, index, 6);
 		box.MaxEdge.Z = lua_tonumber(L, -1) * scale;
 		lua_pop(L, 1);
-	} else {
-		warningstream << "read_aabb3f: not a table, returning default 2x2x2 box." << std::endl;
 	}
 	box.repair();
 	return box;

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -86,7 +86,7 @@ bool                read_color          (lua_State *L, int index,
 bool                is_color_table      (lua_State *L, int index);
 
 /**
- * Read a floating point bounding box from a lua state.
+ * Read a floating-point bounding box from a Lua state.
  *
  * @param  L The Lua state.
  * @param  index The index of the Lua variable to read the box from. The

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -85,6 +85,18 @@ bool                read_color          (lua_State *L, int index,
                                          video::SColor *color);
 bool                is_color_table      (lua_State *L, int index);
 
+/**
+ * Read a floating point bounding box from a lua state.
+ *
+ * @param  L The Lua state.
+ * @param  index The index of the Lua variable to read the box from. The
+ *         variable must contain a table of the form
+ *         {minx, miny, minz, maxx, maxy, maxz}.
+ * @param  scale Factor to scale the bounding box by.
+ *
+ * @return Returns the bounding box corresponding to lua table. If the
+ *         variable is not a table, the result is undefined.
+ */
 aabb3f              read_aabb3f         (lua_State *L, int index, f32 scale);
 v3s16               read_v3s16          (lua_State *L, int index);
 std::vector<aabb3f> read_aabb3f_vector  (lua_State *L, int index, f32 scale);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1857,7 +1857,7 @@ void ServerEnvironment::getSelectedActiveObjects(
 	auto process = [&] (ServerActiveObject *obj) -> bool {
 		if (obj->isGone())
 			return false;
-		aabb3f selection_box;
+		aabb3f selection_box{{0.0f, 0.0f, 0.0f}};
 		if (!obj->getSelectionBox(&selection_box))
 			return false;
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1857,7 +1857,7 @@ void ServerEnvironment::getSelectedActiveObjects(
 	auto process = [&] (ServerActiveObject *obj) -> bool {
 		if (obj->isGone())
 			return false;
-		aabb3f selection_box;
+		aabb3f selection_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 		if (!obj->getSelectionBox(&selection_box))
 			return false;
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1857,7 +1857,7 @@ void ServerEnvironment::getSelectedActiveObjects(
 	auto process = [&] (ServerActiveObject *obj) -> bool {
 		if (obj->isGone())
 			return false;
-		aabb3f selection_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+		aabb3f selection_box;
 		if (!obj->getSelectionBox(&selection_box))
 			return false;
 


### PR DESCRIPTION
This is a behavior-preserving change (but note that the bounding box of empty mesh buffers has changed). It also documents the precondition for `read_aabb3f` that the Lua variable must contain a table.

## To do

Ready for Review.

## How to test

CI should pass.
