### PR TITLE
Fix false positive compiler warning

### DIFF
--- a/irr/src/CGLTFMeshFileLoader.cpp
+++ b/irr/src/CGLTFMeshFileLoader.cpp
@@ -791,7 +791,8 @@ std::optional<std::vector<u16>> SelfType::MeshExtractor::getIndices(
 			index = std::get<Accessor<u16>>(accessor).get(elemIdx);
 			if (index == std::numeric_limits<u16>::max())
 				throw std::runtime_error("invalid index");
-		} else if (std::holds_alternative<Accessor<u32>>(accessor)) {
+		} else {
+			_IRR_DEBUG_BREAK_IF(!std::holds_alternative<Accessor<u32>>(accessor));
 			u32 indexWide = std::get<Accessor<u32>>(accessor).get(elemIdx);
 			// Use >= here for consistency.
 			if (indexWide >= std::numeric_limits<u16>::max())


### PR DESCRIPTION
Fixes a false positive compiler warning on GCC by rewriting the code a slight bit to make it more obvious that the variable is initialized in all code paths (that is, the `else if` chain is exhaustive). This might also make the code a bit clearer to a human reader.

(I'm not quite sure why GCC throws this warning to begin with; it should be easy for it to see that we are exhaustively checking the possible variant contents (arguably the variant may be in an "error" state but that can't happen here).)

## How to test

:eye: 