### PR TITLE
L-System trees fix fruit node resolver

### DIFF
--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -23,8 +23,7 @@ void TreeDef::resolveNodeNames()
 	getIdFromNrBacklog(&leavesnode.param0, "", CONTENT_IGNORE);
 	if (leaves2_chance)
 		getIdFromNrBacklog(&leaves2node.param0, "", CONTENT_IGNORE);
-	if (fruit_chance)
-		getIdFromNrBacklog(&fruitnode.param0, "", CONTENT_IGNORE);
+	getIdFromNrBacklog(&fruitnode.param0, "", CONTENT_IGNORE);
 }
 
 /*

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2033,11 +2033,11 @@ bool read_tree_def(lua_State *L, int idx, const NodeDefManager *ndef,
 	getboolfield(L, idx, "thin_branches", tree_def.thin_branches);
 	tree_def.fruit_chance = 0;
 	getstringfield(L, idx, "fruit", fruit);
-	if (!fruit.empty()) {
+	if (fruit.empty())
+		fruit = "air";
+	else
 		getintfield(L, idx, "fruit_chance", tree_def.fruit_chance);
-		if (tree_def.fruit_chance)
-			tree_def.m_nodenames.push_back(fruit);
-	}
+	tree_def.m_nodenames.push_back(fruit);
 	tree_def.explicit_seed = getintfield(L, idx, "seed", tree_def.seed);
 
 	// Resolves the node IDs for trunk, leaves, leaves2 and fruit at runtime,

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2032,10 +2032,9 @@ bool read_tree_def(lua_State *L, int idx, const NodeDefManager *ndef,
 	getstringfield(L, idx, "trunk_type", tree_def.trunk_type);
 	getboolfield(L, idx, "thin_branches", tree_def.thin_branches);
 	tree_def.fruit_chance = 0;
+	fruit = "air";
 	getstringfield(L, idx, "fruit", fruit);
-	if (fruit.empty())
-		fruit = "air";
-	else
+	if (!fruit.empty())
 		getintfield(L, idx, "fruit_chance", tree_def.fruit_chance);
 	tree_def.m_nodenames.push_back(fruit);
 	tree_def.explicit_seed = getintfield(L, idx, "seed", tree_def.seed);


### PR DESCRIPTION
Fixes #15506

Sorry for the inconvenience, I must have though `fruit` works just like `leaves2`.

Also note, `fruit` defaults to `"air"` to not trigger node resolver errors when it is not defined.
(Unlike `trunk` and `leaves` which will trigger an error in any case if they are not defined.)

There should be proper error handling when parsing tree defs, but this would be too much for this PR.

## How to test

``` lua
core.register_chatcommand("t", {
    func = function(name)
        local player = core.get_player_by_name(name)
        core.spawn_tree(player:get_pos(), {
		axiom = "TRT",
		trunk = "mapgen_tree",
		fruit = "mapgen_apple",
		leaves = "mapgen_stone"
	})
    end,
})
```
