### PR TITLE
Main menu: show favorite removal button for offline servers

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -83,6 +83,11 @@ local function find_selected_server()
 			return server
 		end
 	end
+	for _, server in ipairs(serverlistmgr.get_favorites()) do
+		if server.address == address and server.port == port then
+			return server
+		end
+	end
 end
 
 local function get_formspec(tabview, name, tabdata)


### PR DESCRIPTION
.. or such that are not announced in the first place. This fixes a regression from 6c324cb871d.

## To do

This PR is Ready for Review.

## How to test

1. Attempt to remove a favorite server that is not announced (any more)
