### PR TITLE
[no squash] Group sparse mesh buffers over entire scene for rendering

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1856,6 +1856,10 @@ mesh_generation_interval (Mapblock mesh generation delay) int 0 0 50
 #    Value of 0 (default) will let Luanti autodetect the number of available threads.
 mesh_generation_threads (Mapblock mesh generation threads) int 0 0 8
 
+#    All mesh buffers with less than this number of vertices will be merged
+#    during map rendering. This improves rendering performance.
+mesh_buffer_min_vertices (Minimum vertex count for mesh buffers) int 100 0 1000
+
 #    True = 256
 #    False = 128
 #    Usable to make minimap smoother on slower machines.

--- a/irr/include/IVideoDriver.h
+++ b/irr/include/IVideoDriver.h
@@ -310,6 +310,18 @@ public:
 	0 or another texture first. */
 	virtual void removeAllTextures() = 0;
 
+	//! Eagerly upload buffer to hardware
+	/** This can be a good idea if you have a newly created or modified buffer,
+	which you know you will draw in the near future (e.g. end of same frame,
+	or next frame), because it gives the GPU driver to copy the contents. */
+	virtual void updateHardwareBuffer(const scene::IVertexBuffer *vb) = 0;
+
+	//! Eagerly upload buffer to hardware
+	/** This can be a good idea if you have a newly created or modified buffer,
+	which you know you will draw in the near future (e.g. end of same frame,
+	or next frame), because it gives the GPU driver to copy the contents. */
+	virtual void updateHardwareBuffer(const scene::IIndexBuffer *ib) = 0;
+
 	//! Remove hardware buffer
 	virtual void removeHardwareBuffer(const scene::IVertexBuffer *vb) = 0;
 

--- a/irr/src/CMakeLists.txt
+++ b/irr/src/CMakeLists.txt
@@ -348,6 +348,7 @@ if(ENABLE_OPENGL3 OR ENABLE_GLES2)
 		OpenGL/FixedPipelineRenderer.cpp
 		OpenGL/MaterialRenderer.cpp
 		OpenGL/Renderer2D.cpp
+		OpenGL/VBO.cpp
 	)
 endif()
 

--- a/irr/src/CNullDriver.cpp
+++ b/irr/src/CNullDriver.cpp
@@ -1167,6 +1167,24 @@ void CNullDriver::deleteHardwareBuffer(SHWBufferLink *HWBuffer)
 	delete HWBuffer;
 }
 
+void CNullDriver::updateHardwareBuffer(const scene::IVertexBuffer *vb)
+{
+	if (!vb)
+		return;
+	auto *link = getBufferLink(vb);
+	if (link)
+		updateHardwareBuffer(link);
+}
+
+void CNullDriver::updateHardwareBuffer(const scene::IIndexBuffer *ib)
+{
+	if (!ib)
+		return;
+	auto *link = getBufferLink(ib);
+	if (link)
+		updateHardwareBuffer(link);
+}
+
 void CNullDriver::removeHardwareBuffer(const scene::IVertexBuffer *vb)
 {
 	if (!vb)

--- a/irr/src/CNullDriver.cpp
+++ b/irr/src/CNullDriver.cpp
@@ -1144,6 +1144,10 @@ CNullDriver::SHWBufferLink *CNullDriver::getBufferLink(const scene::IIndexBuffer
 //! Update all hardware buffers, remove unused ones
 void CNullDriver::updateAllHardwareBuffers()
 {
+	// FIXME: this method can take a lot of time just doing the refcount
+	// checks and iteration (too much pointer chasing?) for
+	// large buffer counts (e.g. 50000)
+
 	auto it = HWBufferList.begin();
 	while (it != HWBufferList.end()) {
 		SHWBufferLink *Link = *it;

--- a/irr/src/CNullDriver.h
+++ b/irr/src/CNullDriver.h
@@ -348,6 +348,10 @@ protected:
 	virtual SHWBufferLink *createHardwareBuffer(const scene::IIndexBuffer *ib) { return 0; }
 
 public:
+	virtual void updateHardwareBuffer(const scene::IVertexBuffer *vb) override;
+
+	virtual void updateHardwareBuffer(const scene::IIndexBuffer *ib) override;
+
 	//! Remove hardware buffer
 	void removeHardwareBuffer(const scene::IVertexBuffer *vb) override;
 

--- a/irr/src/OpenGL/Common.h
+++ b/irr/src/OpenGL/Common.h
@@ -40,6 +40,8 @@ typedef COpenGLCoreTexture<COpenGL3DriverBase> COpenGL3Texture;
 typedef COpenGLCoreRenderTarget<COpenGL3DriverBase, COpenGL3Texture> COpenGL3RenderTarget;
 typedef COpenGLCoreCacheHandler<COpenGL3DriverBase, COpenGL3Texture> COpenGL3CacheHandler;
 
+class OpenGLVBO;
+
 enum OpenGLSpec : u8
 {
 	Core,

--- a/irr/src/OpenGL/Driver.h
+++ b/irr/src/OpenGL/Driver.h
@@ -8,6 +8,7 @@
 
 #include "SIrrCreationParameters.h"
 #include "Common.h"
+#include "VBO.h"
 #include "CNullDriver.h"
 #include "IMaterialRendererServices.h"
 #include "EDriverFeatures.h"
@@ -49,8 +50,7 @@ public:
 		SHWBufferLink_opengl(const scene::IVertexBuffer *vb) : SHWBufferLink(vb) {}
 		SHWBufferLink_opengl(const scene::IIndexBuffer *ib) : SHWBufferLink(ib) {}
 
-		GLuint vbo_ID = 0;
-		u32 vbo_Size = 0;
+		OpenGLVBO Vbo;
 	};
 
 	bool updateVertexHardwareBuffer(SHWBufferLink_opengl *HWBuffer);
@@ -300,7 +300,7 @@ protected:
 		LockRenderStateMode = false;
 	}
 
-	bool updateHardwareBuffer(SHWBufferLink_opengl *b, const void *buffer, size_t bufferSize, scene::E_HARDWARE_MAPPING hint);
+	bool uploadHardwareBuffer(OpenGLVBO &vbo, const void *buffer, size_t bufferSize, scene::E_HARDWARE_MAPPING hint);
 
 	void createMaterialRenderers();
 
@@ -372,9 +372,8 @@ private:
 
 	bool EnableErrorTest;
 
-	unsigned QuadIndexCount;
-	GLuint QuadIndexBuffer = 0;
-	void initQuadsIndices(int max_vertex_count = 65536);
+	OpenGLVBO QuadIndexVBO;
+	void initQuadsIndices(u32 max_vertex_count = 65536);
 
 	void debugCb(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message);
 	static void APIENTRY debugCb(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const void *userParam);

--- a/irr/src/OpenGL/VBO.cpp
+++ b/irr/src/OpenGL/VBO.cpp
@@ -16,13 +16,13 @@ void OpenGLVBO::upload(const void *data, size_t size, size_t offset,
 		GLenum usage, bool mustShrink)
 {
 	bool newBuffer = false;
+	assert(!(mustShrink && offset > 0)); // forbidden usage
 	if (!m_name) {
 		GL.GenBuffers(1, &m_name);
 		if (!m_name)
 			return;
 		newBuffer = true;
 	} else if (size > m_size || mustShrink) {
-		// note: mustShrink && offset > 0 is forbidden
 		newBuffer = size != m_size;
 	}
 

--- a/irr/src/OpenGL/VBO.cpp
+++ b/irr/src/OpenGL/VBO.cpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2024 sfan5
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#include "VBO.h"
+
+#include <cassert>
+#include <mt_opengl.h>
+
+namespace irr
+{
+namespace video
+{
+
+void OpenGLVBO::upload(const void *data, size_t size, size_t offset,
+		GLenum usage, bool mustShrink)
+{
+	bool newBuffer = false;
+	if (!m_name) {
+		GL.GenBuffers(1, &m_name);
+		if (!m_name)
+			return;
+		newBuffer = true;
+	} else if (size > m_size || mustShrink) {
+		// note: mustShrink && offset > 0 is forbidden
+		newBuffer = size != m_size;
+	}
+
+	GL.BindBuffer(GL_ARRAY_BUFFER, m_name);
+
+	if (newBuffer) {
+		assert(offset == 0);
+		GL.BufferData(GL_ARRAY_BUFFER, size, data, usage);
+		m_size = size;
+	} else {
+		GL.BufferSubData(GL_ARRAY_BUFFER, offset, size, data);
+	}
+
+	GL.BindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void OpenGLVBO::destroy()
+{
+	if (m_name)
+		GL.DeleteBuffers(1, &m_name);
+	m_name = 0;
+	m_size = 0;
+}
+
+}
+}

--- a/irr/src/OpenGL/VBO.h
+++ b/irr/src/OpenGL/VBO.h
@@ -1,0 +1,57 @@
+// Copyright (C) 2024 sfan5
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#pragma once
+
+#include "Common.h"
+#include <cstddef>
+
+namespace irr
+{
+namespace video
+{
+
+class OpenGLVBO
+{
+public:
+	/// @note does not create on GL side
+	OpenGLVBO() = default;
+	/// @note does not free on GL side
+	~OpenGLVBO() = default;
+
+	/// @return "name" (ID) of this buffer in GL
+	GLuint getName() const { return m_name; }
+	/// @return does this refer to an existing GL buffer?
+	bool exists() const { return m_name != 0; }
+
+	/// @return size of this buffer in bytes
+	size_t getSize() const { return m_size; }
+
+	/**
+	 * Upload buffer data to GL.
+	 *
+	 * Changing the size of the buffer is only possible when `offset == 0`.
+	 * @param data data pointer
+	 * @param size number of bytes
+	 * @param offset offset to upload at
+	 * @param usage usage pattern passed to GL (only if buffer is new)
+	 * @param mustShrink force re-create of buffer if it became smaller
+	 * @note modifies GL_ARRAY_BUFFER binding
+	 */
+	void upload(const void *data, size_t size, size_t offset,
+		GLenum usage, bool mustShrink = false);
+
+	/**
+	 * Free buffer in GL.
+	 * @note modifies GL_ARRAY_BUFFER binding
+	 */
+	void destroy();
+
+private:
+	GLuint m_name = 0;
+	size_t m_size = 0;
+};
+
+}
+}

--- a/irr/src/OpenGL3/Driver.h
+++ b/irr/src/OpenGL3/Driver.h
@@ -13,7 +13,7 @@ namespace video
 /// OpenGL 3+ driver
 ///
 /// For OpenGL 3.2 and higher. Compatibility profile is required currently.
-class COpenGL3Driver : public COpenGL3DriverBase
+class COpenGL3Driver final : public COpenGL3DriverBase
 {
 	friend IVideoDriver *createOpenGL3Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
 

--- a/irr/src/OpenGLES2/Driver.h
+++ b/irr/src/OpenGLES2/Driver.h
@@ -13,7 +13,7 @@ namespace video
 /// OpenGL ES 2+ driver
 ///
 /// For OpenGL ES 2.0 and higher.
-class COpenGLES2Driver : public COpenGL3DriverBase
+class COpenGLES2Driver final : public COpenGL3DriverBase
 {
 	friend IVideoDriver *createOGLES2Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
 

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -115,7 +115,6 @@ private:
 	// update the vertex order in transparent mesh buffers
 	void updateTransparentMeshBuffers();
 
-
 	// Orders blocks by distance to the camera
 	class MapBlockComparer
 	{
@@ -131,30 +130,6 @@ private:
 
 	private:
 		v3s16 m_camera_block;
-	};
-
-
-	// reference to a mesh buffer used when rendering the map.
-	struct DrawDescriptor {
-		v3s16 m_pos;
-		union {
-			scene::IMeshBuffer *m_buffer;
-			const PartialMeshBuffer *m_partial_buffer;
-		};
-		bool m_reuse_material:1;
-		bool m_use_partial_buffer:1;
-
-		DrawDescriptor(v3s16 pos, scene::IMeshBuffer *buffer, bool reuse_material) :
-			m_pos(pos), m_buffer(buffer), m_reuse_material(reuse_material), m_use_partial_buffer(false)
-		{}
-
-		DrawDescriptor(v3s16 pos, const PartialMeshBuffer *buffer) :
-			m_pos(pos), m_partial_buffer(buffer), m_reuse_material(false), m_use_partial_buffer(true)
-		{}
-
-		video::SMaterial &getMaterial();
-		/// @return index count
-		u32 draw(video::IVideoDriver* driver);
 	};
 
 	Client *m_client;
@@ -176,8 +151,6 @@ private:
 	std::vector<MapBlock*> m_keeplist;
 	std::map<v3s16, MapBlock*> m_drawlist_shadow;
 	bool m_needs_update_drawlist;
-
-	std::set<v2s16> m_last_drawn_sectors;
 
 	bool m_cache_trilinear_filter;
 	bool m_cache_bilinear_filter;

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -105,11 +105,11 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 		os << std::fixed
 			<< PROJECT_NAME_C " " << g_version_hash
 			<< " | FPS: " << fps
-			<< std::setprecision(0)
+			<< std::setprecision(fps >= 100 ? 1 : 0)
 			<< " | drawtime: " << m_drawtime_avg << "ms"
 			<< std::setprecision(1)
 			<< " | dtime jitter: "
-			<< (stats.dtime_jitter.max_fraction * 100.0) << "%"
+			<< (stats.dtime_jitter.max_fraction * 100.0f) << "%"
 			<< std::setprecision(1)
 			<< " | view range: "
 			<< (draw_control->range_all ? "All" : itos(draw_control->wanted_range))

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -82,10 +82,13 @@ struct TileLayer
 
 	void applyMaterialOptionsWithShaders(video::SMaterial &material) const;
 
+	/// @return is this layer semi-transparent?
 	bool isTransparent() const
 	{
+		// see also: the mapping in ShaderSource::generateShader()
 		switch (material_type) {
 		case TILE_MATERIAL_ALPHA:
+		case TILE_MATERIAL_PLAIN_ALPHA:
 		case TILE_MATERIAL_LIQUID_TRANSPARENT:
 		case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
 			return true;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -104,6 +104,7 @@ void set_default_settings()
 	settings->setDefault("sound_extensions_blacklist", "");
 	settings->setDefault("mesh_generation_interval", "0");
 	settings->setDefault("mesh_generation_threads", "0");
+	settings->setDefault("mesh_buffer_min_vertices", "100");
 	settings->setDefault("free_move", "false");
 	settings->setDefault("pitch_move", "false");
 	settings->setDefault("fast_move", "false");

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -121,7 +121,7 @@ int Profiler::print(std::ostream &o, u32 page, u32 pagecount)
 {
 	GraphValues values;
 	getPage(values, page, pagecount);
-	char buffer[50];
+	char buffer[128];
 
 	for (const auto &i : values) {
 		o << "  " << i.first << " ";
@@ -132,7 +132,7 @@ int Profiler::print(std::ostream &o, u32 page, u32 pagecount)
 
 		{
 			// Padding
-			s32 space = std::max(0, 44 - (s32)i.first.size());
+			s32 space = std::max(0, 46 - (s32)i.first.size());
 			memset(buffer, '_', space);
 			buffer[space] = '\0';
 			o << buffer;

--- a/src/util/quicktune.h
+++ b/src/util/quicktune.h
@@ -37,19 +37,21 @@
 #include <map>
 #include <vector>
 
-enum QuicktuneValueType{
+enum QuicktuneValueType {
 	QVT_NONE,
-	QVT_FLOAT
+	QVT_FLOAT,
+	QVT_INT
 };
 struct QuicktuneValue
 {
 	QuicktuneValueType type = QVT_NONE;
-	union{
-		struct{
-			float current;
-			float min;
-			float max;
+	union {
+		struct {
+			float current, min, max;
 		} value_QVT_FLOAT;
+		struct {
+			int current, min, max;
+		} value_QVT_INT;
 	};
 	bool modified = false;
 
@@ -65,19 +67,15 @@ void setQuicktuneValue(const std::string &name, const QuicktuneValue &val);
 
 void updateQuicktuneValue(const std::string &name, QuicktuneValue &val);
 
-#ifndef NDEBUG
-	#define QUICKTUNE(type_, var, min_, max_, name){\
-		QuicktuneValue qv;\
-		qv.type = type_;\
-		qv.value_##type_.current = var;\
-		qv.value_##type_.min = min_;\
-		qv.value_##type_.max = max_;\
-		updateQuicktuneValue(name, qv);\
-		var = qv.value_##type_.current;\
-	}
-#else // NDEBUG
-	#define QUICKTUNE(type, var, min_, max_, name){}
-#endif
+#define QUICKTUNE(type_, var, min_, max_, name) do { \
+	QuicktuneValue qv; \
+	qv.type = type_; \
+	qv.value_##type_.current = var; \
+	qv.value_##type_.min = min_; \
+	qv.value_##type_.max = max_; \
+	updateQuicktuneValue(name, qv); \
+	var = qv.value_##type_.current; \
+	} while (0)
 
 #define QUICKTUNE_AUTONAME(type_, var, min_, max_)\
 	QUICKTUNE(type_, var, min_, max_, #var)


### PR DESCRIPTION
implements the following suggestion from #10647:
> Dynamic batching for sparse tiles : Tiles with counts below a certain threshold do not get meshed, ~~but are instead culled as individual objects~~, then batched into per-frame non-VBO drawcalls. An optimal batch size is selected to balance the amount of data sent over the bus with the overhead of a drawcall by itself, ideally neither half waits for the other. ~~Precise culling reduces the data being sent overall.~~

in MTG landscape scenes this can save 20-40% drawcalls, which is not a noticeable performance uplift unless you have *lots* of terrain.
look for `renderMap(SOLID): buf merged count [#]` in the profiler.

## To do

This PR is ready.

## How to test

aside from general testing here's a stress test illustrating that the optimization works:
```lua
local function foo(pos0, set)
	local m = math.ceil(math.log(#set) / math.log(3))
	local n = 1
	for x1 = 1, m do
	for y1 = 1, m do
	for z1 = 1, m do
		core.swap_node(vector.new(pos0.x + x1 - 1, pos0.y + y1 - 1,
			pos0.z + z1 - 1), {name = set[n]})
		n = n + 1
		if n > #set then
			return
		end
	end
	end
	end
end

core.set_mapgen_setting("mg_name", "singlenode", true)

local variety = {}
core.register_on_mods_loaded(function()
	for name, def in pairs(core.registered_nodes) do
		if def.drawtype == "plantlike" then
			table.insert(variety, name)
		end
	end
end)

local wanted_area = VoxelArea(vector.new(-100, -40, -100), vector.new(100, 40, 100))
core.register_on_generated(function(minp, maxp, blockseed)
	assert(minp.x % core.MAP_BLOCKSIZE == 0)
	for x0 = minp.x, maxp.x, core.MAP_BLOCKSIZE do
	for y0 = minp.y, maxp.y, core.MAP_BLOCKSIZE do
	for z0 = minp.z, maxp.z, core.MAP_BLOCKSIZE do
		local pos0 = vector.new(x0, y0, z0)
		if wanted_area:containsp(pos0) then
			foo(pos0, variety)
		end
	end
	end
	end
end)
```

1. join a *new* world
2. get all blocks into view
3. enjoy acceptable fps
4. set `mesh_buffer_min_vertices = 0` and rejoin
5. enjoy terrible fps

(note: I think it'd be a good idea to collect such test scenes into a devtest mod but I am too lazy to be the person to do it)