### PR TITLE
Remove buggy premature `sendPlayerPos` optimization

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1371,9 +1371,8 @@ void Client::sendPlayerPos()
 	if (!player)
 		return;
 
-	// Save bandwidth by only updating position when
-	// player is not dead and something changed
-
+	// Don't send anything when player is dead:
+	// The server would ignore it anyways
 	if (m_activeobjects_received && player->isDead())
 		return;
 
@@ -1386,19 +1385,6 @@ void Client::sendPlayerPos()
 	bool camera_inverted = m_camera->getCameraMode() == CAMERA_MODE_THIRD_FRONT;
 	f32 movement_speed = player->control.movement_speed;
 	f32 movement_dir = player->control.movement_direction;
-
-	if (
-			player->last_position        == player->getPosition() &&
-			player->last_speed           == player->getSpeed()    &&
-			player->last_pitch           == player->getPitch()    &&
-			player->last_yaw             == player->getYaw()      &&
-			player->last_keyPressed      == keyPressed            &&
-			player->last_camera_fov      == camera_fov            &&
-			player->last_camera_inverted == camera_inverted       &&
-			player->last_wanted_range    == wanted_range          &&
-			player->last_movement_speed  == movement_speed        &&
-			player->last_movement_dir    == movement_dir)
-		return;
 
 	player->last_position        = player->getPosition();
 	player->last_speed           = player->getSpeed();


### PR DESCRIPTION
Untested attempt at fixing #15528 based on a theory of what could go wrong: Since this particular packet is sent unreliably, it may arrive out of order. Of course the client thinks it has sent the last values (which to the client haven't changed) and thus doesn't resend them. But on the server, an outdated packet ends up overriding the new packet.

This attempted fix is very simple: Just remove the early return. I don't think this is problematic. A server will have no problem processing 10 trivial packets from a client per second, and the network won't care much either. There will be plenty of other packets going around anyways.

Side note: I believe `get_player_control()` will be bogus for dead players, but I suppose it doesn't matter much.