### PR TITLE
Get rid of now obsolete workaround for collision detection bugs

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1663,11 +1663,6 @@ void GenericCAO::processMessage(const std::string &data)
 		bool is_end_position = readU8(is);
 		float update_interval = readF32(is);
 
-		// Place us a bit higher if we're physical, to not sink into
-		// the ground due to sucky collision detection...
-		if(m_prop.physical)
-			m_position += v3f(0,0.002,0);
-
 		if(getParent() != NULL) // Just in case
 			return;
 


### PR DESCRIPTION
Came across this gem while doing some code reading and felt compelled to fix it.

I believe that since TheTermos collision fixes some years ago (e.g. #9343), this workaround should be obsolete: There is a "clipping recovery" with way more tolerance, so even if the position was (say, due to float errors) slightly inside the node, the collision code wouldn't poop its pants. This piece of code has been around for more than a decade and most likely was just forgotten when collisions were fixed.

I believe that just dropping items on the ground (which still works as expected) should suffice to smoke test this, since positions are sent periodically.

(Also worth noting that even if we assume sucky collision detection, this isn't a proper fix but rather an ugly hack. In particular, if there was no clipping recovery, this offset would end up moving upwards-moving objects into the ceiling, letting them clip through the ceiling.)