### PR TITLE
Irrlicht: Get rid of obsolete `setDebugName`

### DIFF
--- a/irr/include/CIndexBuffer.h
+++ b/irr/include/CIndexBuffer.h
@@ -24,12 +24,7 @@ class CIndexBuffer final : public IIndexBuffer
 {
 public:
 	//! Default constructor for empty buffer
-	CIndexBuffer()
-	{
-#ifdef _DEBUG
-		setDebugName("CIndexBuffer");
-#endif
-	}
+	CIndexBuffer() {}
 
 	video::E_INDEX_TYPE getType() const override
 	{

--- a/irr/include/CMeshBuffer.h
+++ b/irr/include/CMeshBuffer.h
@@ -22,9 +22,6 @@ public:
 	CMeshBuffer() :
 			PrimitiveType(EPT_TRIANGLES)
 	{
-#ifdef _DEBUG
-		setDebugName("CMeshBuffer");
-#endif
 		Vertices = new CVertexBuffer<T>();
 		Indices = new SIndexBuffer();
 	}

--- a/irr/include/CVertexBuffer.h
+++ b/irr/include/CVertexBuffer.h
@@ -24,12 +24,7 @@ class CVertexBuffer final : public IVertexBuffer
 {
 public:
 	//! Default constructor for empty buffer
-	CVertexBuffer()
-	{
-#ifdef _DEBUG
-		setDebugName("CVertexBuffer");
-#endif
-	}
+	CVertexBuffer() {}
 
 	const void *getData() const override
 	{

--- a/irr/include/IGUIElement.h
+++ b/irr/include/IGUIElement.h
@@ -34,10 +34,6 @@ public:
 			AlignLeft(EGUIA_UPPERLEFT), AlignRight(EGUIA_UPPERLEFT), AlignTop(EGUIA_UPPERLEFT), AlignBottom(EGUIA_UPPERLEFT),
 			Environment(environment), Type(type)
 	{
-#ifdef _DEBUG
-		setDebugName("IGUIElement");
-#endif
-
 		// if we were given a parent to attach to
 		if (parent) {
 			parent->addChildToEnd(this);

--- a/irr/include/IReferenceCounted.h
+++ b/irr/include/IReferenceCounted.h
@@ -136,31 +136,6 @@ public:
 		return ReferenceCounter;
 	}
 
-#ifdef _DEBUG
-	//! Returns the debug name of the object.
-	/** The Debugname may only be set and changed by the object
-	itself. This method should only be used in Debug mode.
-	\return Returns a string, previously set by setDebugName(); */
-	const c8 *getDebugName() const
-	{
-		return DebugName;
-	}
-
-protected:
-	//! Sets the debug name of the object.
-	/** The Debugname may only be set and changed by the object
-	itself. This method should only be used in Debug mode.
-	\param newName: New debug name to set. */
-	void setDebugName(const c8 *newName)
-	{
-		DebugName = newName;
-	}
-
-private:
-	//! The debug name.
-	const c8 *DebugName = nullptr;
-#endif
-
 private:
 
 	//! The reference counter. Mutable to do reference counting on const objects.

--- a/irr/include/SAnimatedMesh.h
+++ b/irr/include/SAnimatedMesh.h
@@ -21,9 +21,6 @@ struct SAnimatedMesh final : public IAnimatedMesh
 	SAnimatedMesh(scene::IMesh *mesh = 0, scene::E_ANIMATED_MESH_TYPE type = scene::EAMT_UNKNOWN) :
 			IAnimatedMesh(), FramesPerSecond(25.f), Type(type)
 	{
-#ifdef _DEBUG
-		setDebugName("SAnimatedMesh");
-#endif
 		addMesh(mesh);
 		recalculateBoundingBox();
 	}

--- a/irr/include/SMesh.h
+++ b/irr/include/SMesh.h
@@ -17,12 +17,7 @@ namespace scene
 struct SMesh final : public IMesh
 {
 	//! constructor
-	SMesh()
-	{
-#ifdef _DEBUG
-		setDebugName("SMesh");
-#endif
-	}
+	SMesh() {}
 
 	//! destructor
 	virtual ~SMesh()

--- a/irr/include/SSkinMeshBuffer.h
+++ b/irr/include/SSkinMeshBuffer.h
@@ -22,9 +22,6 @@ struct SSkinMeshBuffer final : public IMeshBuffer
 			VertexType(vt), PrimitiveType(EPT_TRIANGLES),
 			BoundingBoxNeedsRecalculated(true)
 	{
-#ifdef _DEBUG
-		setDebugName("SSkinMeshBuffer");
-#endif
 		Vertices_Tangents = new SVertexBufferTangents();
 		Vertices_2TCoords = new SVertexBufferLightMap();
 		Vertices_Standard = new SVertexBuffer();

--- a/irr/src/CAnimatedMeshSceneNode.cpp
+++ b/irr/src/CAnimatedMeshSceneNode.cpp
@@ -38,10 +38,6 @@ CAnimatedMeshSceneNode::CAnimatedMeshSceneNode(IAnimatedMesh *mesh,
 		Looping(true), ReadOnlyMaterials(false), RenderFromIdentity(false),
 		LoopCallBack(0), PassCount(0)
 {
-#ifdef _DEBUG
-	setDebugName("CAnimatedMeshSceneNode");
-#endif
-
 	setMesh(mesh);
 }
 

--- a/irr/src/CAnimatedMeshSceneNode.cpp
+++ b/irr/src/CAnimatedMeshSceneNode.cpp
@@ -223,7 +223,7 @@ void CAnimatedMeshSceneNode::render()
 		Box = m->getBoundingBox();
 	} else {
 #ifdef _DEBUG
-		os::Printer::log("Animated Mesh returned no mesh to render.", Mesh->getDebugName(), ELL_WARNING);
+		os::Printer::log("Animated Mesh returned no mesh to render.", ELL_WARNING);
 #endif
 		return;
 	}

--- a/irr/src/CAttributes.cpp
+++ b/irr/src/CAttributes.cpp
@@ -12,12 +12,7 @@ namespace irr
 namespace io
 {
 
-CAttributes::CAttributes()
-{
-#ifdef _DEBUG
-	setDebugName("CAttributes");
-#endif
-}
+CAttributes::CAttributes() {}
 
 CAttributes::~CAttributes()
 {

--- a/irr/src/CB3DMeshFileLoader.cpp
+++ b/irr/src/CB3DMeshFileLoader.cpp
@@ -29,11 +29,7 @@ namespace scene
 CB3DMeshFileLoader::CB3DMeshFileLoader(scene::ISceneManager *smgr) :
 		AnimatedMesh(0), B3DFile(0), VerticesStart(0), NormalsInFile(false),
 		HasVertexColors(false), ShowWarning(true)
-{
-#ifdef _DEBUG
-	setDebugName("CB3DMeshFileLoader");
-#endif
-}
+{}
 
 //! returns true if the file maybe is able to be loaded by this class
 //! based on the file extension (e.g. ".bsp")

--- a/irr/src/CBillboardSceneNode.cpp
+++ b/irr/src/CBillboardSceneNode.cpp
@@ -20,10 +20,6 @@ CBillboardSceneNode::CBillboardSceneNode(ISceneNode *parent, ISceneManager *mgr,
 		IBillboardSceneNode(parent, mgr, id, position),
 		Buffer(new SMeshBuffer())
 {
-#ifdef _DEBUG
-	setDebugName("CBillboardSceneNode");
-#endif
-
 	setSize(size);
 
 	auto &Vertices = Buffer->Vertices->Data;

--- a/irr/src/CBoneSceneNode.cpp
+++ b/irr/src/CBoneSceneNode.cpp
@@ -18,9 +18,6 @@ CBoneSceneNode::CBoneSceneNode(ISceneNode *parent, ISceneManager *mgr, s32 id,
 		BoneIndex(boneIndex),
 		AnimationMode(EBAM_AUTOMATIC), SkinningSpace(EBSS_LOCAL)
 {
-#ifdef _DEBUG
-	setDebugName("CBoneSceneNode");
-#endif
 	setName(boneName);
 }
 

--- a/irr/src/CCameraSceneNode.cpp
+++ b/irr/src/CCameraSceneNode.cpp
@@ -20,10 +20,6 @@ CCameraSceneNode::CCameraSceneNode(ISceneNode *parent, ISceneManager *mgr, s32 i
 		Target(lookat), UpVector(0.0f, 1.0f, 0.0f), ZNear(1.0f), ZFar(3000.0f),
 		InputReceiverEnabled(true), TargetAndRotationAreBound(false)
 {
-#ifdef _DEBUG
-	setDebugName("CCameraSceneNode");
-#endif
-
 	// set default projection
 	Fovy = core::PI / 2.5f; // Field of view, in radians.
 	Aspect = 4.0f / 3.0f;   // Aspect ratio.

--- a/irr/src/CDummyTransformationSceneNode.cpp
+++ b/irr/src/CDummyTransformationSceneNode.cpp
@@ -15,10 +15,6 @@ CDummyTransformationSceneNode::CDummyTransformationSceneNode(
 		ISceneNode *parent, ISceneManager *mgr, s32 id) :
 		IDummyTransformationSceneNode(parent, mgr, id)
 {
-#ifdef _DEBUG
-	setDebugName("CDummyTransformationSceneNode");
-#endif
-
 	setAutomaticCulling(scene::EAC_OFF);
 }
 

--- a/irr/src/CEGLManager.cpp
+++ b/irr/src/CEGLManager.cpp
@@ -18,11 +18,7 @@ namespace video
 CEGLManager::CEGLManager() :
 		IContextManager(), EglWindow(0), EglDisplay(EGL_NO_DISPLAY),
 		EglSurface(EGL_NO_SURFACE), EglContext(EGL_NO_CONTEXT), EglConfig(0), MajorVersion(0), MinorVersion(0)
-{
-#ifdef _DEBUG
-	setDebugName("CEGLManager");
-#endif
-}
+{}
 
 CEGLManager::~CEGLManager()
 {

--- a/irr/src/CEmptySceneNode.cpp
+++ b/irr/src/CEmptySceneNode.cpp
@@ -14,10 +14,6 @@ namespace scene
 CEmptySceneNode::CEmptySceneNode(ISceneNode *parent, ISceneManager *mgr, s32 id) :
 		ISceneNode(parent, mgr, id)
 {
-#ifdef _DEBUG
-	setDebugName("CEmptySceneNode");
-#endif
-
 	setAutomaticCulling(scene::EAC_OFF);
 }
 

--- a/irr/src/CFileList.cpp
+++ b/irr/src/CFileList.cpp
@@ -18,10 +18,6 @@ static const io::path emptyFileListEntry;
 CFileList::CFileList(const io::path &path, bool ignoreCase, bool ignorePaths) :
 		IgnorePaths(ignorePaths), IgnoreCase(ignoreCase), Path(path)
 {
-#ifdef _DEBUG
-	setDebugName("CFileList");
-#endif
-
 	Path.replace('\\', '/');
 }
 

--- a/irr/src/CFileSystem.cpp
+++ b/irr/src/CFileSystem.cpp
@@ -43,10 +43,6 @@ namespace io
 //! constructor
 CFileSystem::CFileSystem()
 {
-#ifdef _DEBUG
-	setDebugName("CFileSystem");
-#endif
-
 	setFileListSystem(FILESYSTEM_NATIVE);
 	//! reset current working directory
 	getWorkingDirectory();

--- a/irr/src/CGLXManager.cpp
+++ b/irr/src/CGLXManager.cpp
@@ -23,10 +23,6 @@ namespace video
 CGLXManager::CGLXManager(const SIrrlichtCreationParameters &params, const SExposedVideoData &videodata, int screennr) :
 		Params(params), PrimaryContext(videodata), VisualInfo(0), glxFBConfig(0), GlxWin(0)
 {
-#ifdef _DEBUG
-	setDebugName("CGLXManager");
-#endif
-
 	CurrentContext.OpenGLLinux.X11Display = PrimaryContext.OpenGLLinux.X11Display;
 
 	int major, minor;

--- a/irr/src/CGUIButton.cpp
+++ b/irr/src/CGUIButton.cpp
@@ -26,9 +26,6 @@ CGUIButton::CGUIButton(IGUIEnvironment *environment, IGUIElement *parent,
 		IsPushButton(false), Pressed(false),
 		UseAlphaChannel(false), DrawBorder(true), ScaleImage(false)
 {
-#ifdef _DEBUG
-	setDebugName("CGUIButton");
-#endif
 	setNotClipped(noclip);
 
 	// This element can be tabbed.

--- a/irr/src/CGUICheckBox.cpp
+++ b/irr/src/CGUICheckBox.cpp
@@ -19,10 +19,6 @@ namespace gui
 CGUICheckBox::CGUICheckBox(bool checked, IGUIEnvironment *environment, IGUIElement *parent, s32 id, core::rect<s32> rectangle) :
 		IGUICheckBox(environment, parent, id, rectangle), CheckTime(0), Pressed(false), Checked(checked), Border(false), Background(false)
 {
-#ifdef _DEBUG
-	setDebugName("CGUICheckBox");
-#endif
-
 	// this element can be tabbed into
 	setTabStop(true);
 	setTabOrder(-1);

--- a/irr/src/CGUIComboBox.cpp
+++ b/irr/src/CGUIComboBox.cpp
@@ -26,10 +26,6 @@ CGUIComboBox::CGUIComboBox(IGUIEnvironment *environment, IGUIElement *parent,
 		Selected(-1), HAlign(EGUIA_UPPERLEFT), VAlign(EGUIA_CENTER), MaxSelectionRows(5), HasFocus(false),
 		ActiveFont(nullptr)
 {
-#ifdef _DEBUG
-	setDebugName("CGUIComboBox");
-#endif
-
 	IGUISkin *skin = Environment->getSkin();
 
 	ListButton = Environment->addButton(core::recti(0, 0, 1, 1), this, -1, L"");

--- a/irr/src/CGUIEditBox.cpp
+++ b/irr/src/CGUIEditBox.cpp
@@ -39,10 +39,6 @@ CGUIEditBox::CGUIEditBox(const wchar_t *text, bool border,
 		PasswordChar(L'*'), HAlign(EGUIA_UPPERLEFT), VAlign(EGUIA_CENTER),
 		CurrentTextRect(0, 0, 1, 1), FrameRect(rectangle)
 {
-#ifdef _DEBUG
-	setDebugName("CGUIEditBox");
-#endif
-
 	Text = text;
 
 	if (Environment)

--- a/irr/src/CGUIEnvironment.cpp
+++ b/irr/src/CGUIEnvironment.cpp
@@ -50,10 +50,6 @@ CGUIEnvironment::CGUIEnvironment(io::IFileSystem *fs, video::IVideoDriver *drive
 	if (Operator)
 		Operator->grab();
 
-#ifdef _DEBUG
-	IGUIEnvironment::setDebugName("CGUIEnvironment");
-#endif
-
 	loadBuiltInFont();
 
 	IGUISkin *skin = createSkin(gui::EGST_WINDOWS_METALLIC);

--- a/irr/src/CGUIFileOpenDialog.cpp
+++ b/irr/src/CGUIFileOpenDialog.cpp
@@ -33,10 +33,6 @@ CGUIFileOpenDialog::CGUIFileOpenDialog(const wchar_t *title,
 						(parent->getAbsolutePosition().getHeight() - FOD_HEIGHT) / 2 + FOD_HEIGHT)),
 		FileNameText(0), FileList(0), Dragging(false)
 {
-#ifdef _DEBUG
-	IGUIElement::setDebugName("CGUIFileOpenDialog");
-#endif
-
 	Text = title;
 
 	FileSystem = Environment ? Environment->getFileSystem() : 0;

--- a/irr/src/CGUIFont.cpp
+++ b/irr/src/CGUIFont.cpp
@@ -21,10 +21,6 @@ CGUIFont::CGUIFont(IGUIEnvironment *env, const io::path &filename) :
 		Driver(0), SpriteBank(0), Environment(env), WrongCharacter(0),
 		MaxHeight(0), GlobalKerningWidth(0), GlobalKerningHeight(0)
 {
-#ifdef _DEBUG
-	setDebugName("CGUIFont");
-#endif
-
 	if (Environment) {
 		// don't grab environment, to avoid circular references
 		Driver = Environment->getVideoDriver();

--- a/irr/src/CGUIImage.cpp
+++ b/irr/src/CGUIImage.cpp
@@ -17,11 +17,7 @@ namespace gui
 CGUIImage::CGUIImage(IGUIEnvironment *environment, IGUIElement *parent, s32 id, core::rect<s32> rectangle) :
 		IGUIImage(environment, parent, id, rectangle), Texture(0), Color(255, 255, 255, 255),
 		UseAlphaChannel(false), ScaleImage(false), DrawBounds(0.f, 0.f, 1.f, 1.f), DrawBackground(true)
-{
-#ifdef _DEBUG
-	setDebugName("CGUIImage");
-#endif
-}
+{}
 
 //! destructor
 CGUIImage::~CGUIImage()

--- a/irr/src/CGUIImageList.cpp
+++ b/irr/src/CGUIImageList.cpp
@@ -18,10 +18,6 @@ CGUIImageList::CGUIImageList(video::IVideoDriver *driver) :
 		ImagesPerRow(0),
 		UseAlphaChannel(false)
 {
-#ifdef _DEBUG
-	setDebugName("CGUIImageList");
-#endif
-
 	if (Driver) {
 		Driver->grab();
 	}

--- a/irr/src/CGUIListBox.cpp
+++ b/irr/src/CGUIListBox.cpp
@@ -29,10 +29,6 @@ CGUIListBox::CGUIListBox(IGUIEnvironment *environment, IGUIElement *parent,
 		ScrollBar(0), selectTime(0), LastKeyTime(0), Selecting(false), DrawBack(drawBack),
 		MoveOverSelect(moveOverSelect), AutoScroll(true), HighlightWhenNotFocused(true)
 {
-#ifdef _DEBUG
-	setDebugName("CGUIListBox");
-#endif
-
 	IGUISkin *skin = Environment->getSkin();
 
 	ScrollBar = new CGUIScrollBar(false, Environment, this, -1,

--- a/irr/src/CGUIScrollBar.cpp
+++ b/irr/src/CGUIScrollBar.cpp
@@ -28,10 +28,6 @@ CGUIScrollBar::CGUIScrollBar(bool horizontal, IGUIEnvironment *environment,
 		DrawHeight(0), Min(0), Max(100), SmallStep(10), LargeStep(50), DesiredPos(0),
 		LastChange(0)
 {
-#ifdef _DEBUG
-	setDebugName("CGUIScrollBar");
-#endif
-
 	refreshControls();
 
 	setNotClipped(noclip);

--- a/irr/src/CGUISkin.cpp
+++ b/irr/src/CGUISkin.cpp
@@ -20,10 +20,6 @@ namespace gui
 CGUISkin::CGUISkin(EGUI_SKIN_TYPE type, video::IVideoDriver* driver)
 : SpriteBank(0), Driver(driver), Type(type)
 {
-	#ifdef _DEBUG
-	setDebugName("CGUISkin");
-	#endif
-
 	if ((Type == EGST_WINDOWS_CLASSIC) || (Type == EGST_WINDOWS_METALLIC))
 	{
 		Colors[EGDC_3D_DARK_SHADOW]     = video::SColor(101,50,50,50);

--- a/irr/src/CGUISpriteBank.cpp
+++ b/irr/src/CGUISpriteBank.cpp
@@ -16,10 +16,6 @@ namespace gui
 CGUISpriteBank::CGUISpriteBank(IGUIEnvironment *env) :
 		Environment(env), Driver(0)
 {
-#ifdef _DEBUG
-	setDebugName("CGUISpriteBank");
-#endif
-
 	if (Environment) {
 		Driver = Environment->getVideoDriver();
 		if (Driver)

--- a/irr/src/CGUIStaticText.cpp
+++ b/irr/src/CGUIStaticText.cpp
@@ -27,10 +27,6 @@ CGUIStaticText::CGUIStaticText(const wchar_t *text, bool border,
 		OverrideColor(video::SColor(101, 255, 255, 255)), BGColor(video::SColor(101, 210, 210, 210)),
 		OverrideFont(0), LastBreakFont(0)
 {
-#ifdef _DEBUG
-	setDebugName("CGUIStaticText");
-#endif
-
 	Text = text;
 	if (environment && environment->getSkin()) {
 		BGColor = environment->getSkin()->getColor(gui::EGDC_3D_FACE);

--- a/irr/src/CGUITabControl.cpp
+++ b/irr/src/CGUITabControl.cpp
@@ -29,10 +29,6 @@ CGUITab::CGUITab(IGUIEnvironment *environment,
 		BackColor(0, 0, 0, 0), OverrideTextColorEnabled(false), TextColor(255, 0, 0, 0),
 		DrawBackground(false)
 {
-#ifdef _DEBUG
-	setDebugName("CGUITab");
-#endif
-
 	const IGUISkin *const skin = environment->getSkin();
 	if (skin)
 		TextColor = skin->getColor(EGDC_BUTTON_TEXT);
@@ -104,10 +100,6 @@ CGUITabControl::CGUITabControl(IGUIEnvironment *environment,
 		Border(border), FillBackground(fillbackground), ScrollControl(false), TabHeight(0), VerticalAlignment(EGUIA_UPPERLEFT),
 		UpButton(0), DownButton(0), TabMaxWidth(0), CurrentScrollTabIndex(0), TabExtraWidth(20)
 {
-#ifdef _DEBUG
-	setDebugName("CGUITabControl");
-#endif
-
 	IGUISkin *skin = Environment->getSkin();
 	IGUISpriteBank *sprites = 0;
 

--- a/irr/src/CImageLoaderJPG.cpp
+++ b/irr/src/CImageLoaderJPG.cpp
@@ -19,9 +19,6 @@ namespace video
 //! constructor
 CImageLoaderJPG::CImageLoaderJPG()
 {
-#ifdef _DEBUG
-	setDebugName("CImageLoaderJPG");
-#endif
 }
 
 //! destructor

--- a/irr/src/CImageWriterJPG.cpp
+++ b/irr/src/CImageWriterJPG.cpp
@@ -169,11 +169,7 @@ IImageWriter *createImageWriterJPG()
 }
 
 CImageWriterJPG::CImageWriterJPG()
-{
-#ifdef _DEBUG
-	setDebugName("CImageWriterJPG");
-#endif
-}
+{}
 
 bool CImageWriterJPG::isAWriteableFileExtension(const io::path &filename) const
 {

--- a/irr/src/CImageWriterPNG.cpp
+++ b/irr/src/CImageWriterPNG.cpp
@@ -54,11 +54,7 @@ void PNGAPI user_write_data_fcn(png_structp png_ptr, png_bytep data, png_size_t 
 }
 
 CImageWriterPNG::CImageWriterPNG()
-{
-#ifdef _DEBUG
-	setDebugName("CImageWriterPNG");
-#endif
-}
+{}
 
 bool CImageWriterPNG::isAWriteableFileExtension(const io::path &filename) const
 {

--- a/irr/src/CIrrDeviceLinux.cpp
+++ b/irr/src/CIrrDeviceLinux.cpp
@@ -105,10 +105,6 @@ CIrrDeviceLinux::CIrrDeviceLinux(const SIrrlichtCreationParameters &param) :
 		WindowHasFocus(false), WindowMinimized(false), WindowMaximized(param.WindowMaximized),
 		ExternalWindow(false), AutorepeatSupport(0)
 {
-#ifdef _DEBUG
-	setDebugName("CIrrDeviceLinux");
-#endif
-
 	// print version, distribution etc.
 	// thx to LynxLuna for pointing me to the uname function
 	core::stringc linuxversion;

--- a/irr/src/CIrrDeviceOSX.mm
+++ b/irr/src/CIrrDeviceOSX.mm
@@ -524,10 +524,6 @@ CIrrDeviceMacOSX::CIrrDeviceMacOSX(const SIrrlichtCreationParameters &param) :
 {
 	struct utsname name;
 
-#ifdef _DEBUG
-	setDebugName("CIrrDeviceMacOSX");
-#endif
-
 	if (firstLaunch) {
 		firstLaunch = false;
 

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -253,10 +253,6 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters &param) :
 		Resizable(param.WindowResizable == 1 ? true : false), CurrentTouchCount(0),
 		IsInBackground(false)
 {
-#ifdef _DEBUG
-	setDebugName("CIrrDeviceSDL");
-#endif
-
 	if (++SDLDeviceInstances == 1) {
 #ifdef __ANDROID__
 		// Blocking on pause causes problems with multiplayer.

--- a/irr/src/CIrrDeviceWin32.cpp
+++ b/irr/src/CIrrDeviceWin32.cpp
@@ -713,10 +713,6 @@ CIrrDeviceWin32::CIrrDeviceWin32(const SIrrlichtCreationParameters &params) :
 		ExternalWindow(false), Win32CursorControl(0), JoyControl(0),
 		WindowMaximized(params.WindowMaximized)
 {
-#ifdef _DEBUG
-	setDebugName("CIrrDeviceWin32");
-#endif
-
 	// get windows version and create OS operator
 	core::stringc winversion;
 	getWindowsVersion(winversion);

--- a/irr/src/CLimitReadFile.cpp
+++ b/irr/src/CLimitReadFile.cpp
@@ -17,10 +17,6 @@ CLimitReadFile::CLimitReadFile(IReadFile *alreadyOpenedFile, long pos,
 		AreaStart(0), AreaEnd(0), Pos(0),
 		File(alreadyOpenedFile)
 {
-#ifdef _DEBUG
-	setDebugName("CLimitReadFile");
-#endif
-
 	if (File) {
 		File->grab();
 		AreaStart = pos;

--- a/irr/src/CLogger.cpp
+++ b/irr/src/CLogger.cpp
@@ -9,11 +9,7 @@ namespace irr
 
 CLogger::CLogger(IEventReceiver *r) :
 		LogLevel(ELL_INFORMATION), Receiver(r)
-{
-#ifdef _DEBUG
-	setDebugName("CLogger");
-#endif
-}
+{}
 
 //! Returns the current set log level.
 ELOG_LEVEL CLogger::getLogLevel() const

--- a/irr/src/CMemoryFile.cpp
+++ b/irr/src/CMemoryFile.cpp
@@ -12,11 +12,7 @@ namespace io
 
 CMemoryReadFile::CMemoryReadFile(const void *memory, long len, const io::path &fileName, bool d) :
 		Buffer(memory), Len(len), Pos(0), Filename(fileName), deleteMemoryWhenDropped(d)
-{
-#ifdef _DEBUG
-	setDebugName("CMemoryReadFile");
-#endif
-}
+{}
 
 CMemoryReadFile::~CMemoryReadFile()
 {
@@ -82,11 +78,7 @@ const io::path &CMemoryReadFile::getFileName() const
 
 CMemoryWriteFile::CMemoryWriteFile(void *memory, long len, const io::path &fileName, bool d) :
 		Buffer(memory), Len(len), Pos(0), Filename(fileName), deleteMemoryWhenDropped(d)
-{
-#ifdef _DEBUG
-	setDebugName("CMemoryWriteFile");
-#endif
-}
+{}
 
 CMemoryWriteFile::~CMemoryWriteFile()
 {

--- a/irr/src/CMeshSceneNode.cpp
+++ b/irr/src/CMeshSceneNode.cpp
@@ -23,10 +23,6 @@ CMeshSceneNode::CMeshSceneNode(IMesh *mesh, ISceneNode *parent, ISceneManager *m
 		Mesh(0),
 		PassCount(0), ReadOnlyMaterials(false)
 {
-#ifdef _DEBUG
-	setDebugName("CMeshSceneNode");
-#endif
-
 	setMesh(mesh);
 }
 

--- a/irr/src/CNSOGLManager.mm
+++ b/irr/src/CNSOGLManager.mm
@@ -16,11 +16,7 @@ namespace video
 
 CNSOGLManager::CNSOGLManager() :
 		PrimaryContext(SExposedVideoData(0)), PixelFormat(nil)
-{
-#ifdef _DEBUG
-	setDebugName("CNSOGLManager");
-#endif
-}
+{}
 
 CNSOGLManager::~CNSOGLManager()
 {

--- a/irr/src/CNullDriver.cpp
+++ b/irr/src/CNullDriver.cpp
@@ -53,10 +53,6 @@ CNullDriver::CNullDriver(io::IFileSystem *io, const core::dimension2d<u32> &scre
 		ViewPort(0, 0, 0, 0), ScreenSize(screenSize), MinVertexCountForVBO(500),
 		TextureCreationFlags(0), OverrideMaterial2DEnabled(false), AllowZWriteOnTransparent(false)
 {
-#ifdef _DEBUG
-	setDebugName("CNullDriver");
-#endif
-
 	DriverAttributes = new io::CAttributes();
 	DriverAttributes->addInt("MaxTextures", MATERIAL_MAX_TEXTURES);
 	DriverAttributes->addInt("MaxSupportedTextures", MATERIAL_MAX_TEXTURES);

--- a/irr/src/COBJMeshFileLoader.cpp
+++ b/irr/src/COBJMeshFileLoader.cpp
@@ -26,11 +26,7 @@ namespace scene
 //! Constructor
 COBJMeshFileLoader::COBJMeshFileLoader(scene::ISceneManager *smgr) :
 		SceneManager(smgr)
-{
-#ifdef _DEBUG
-	setDebugName("COBJMeshFileLoader");
-#endif
-}
+{}
 
 //! destructor
 COBJMeshFileLoader::~COBJMeshFileLoader()

--- a/irr/src/COSOperator.cpp
+++ b/irr/src/COSOperator.cpp
@@ -43,11 +43,7 @@ COSOperator::COSOperator(const core::stringc &osVersion, CIrrDeviceLinux *device
 // constructor
 COSOperator::COSOperator(const core::stringc &osVersion) :
 		OperatingSystem(osVersion)
-{
-#ifdef _DEBUG
-	setDebugName("COSOperator");
-#endif
-}
+{}
 
 COSOperator::~COSOperator()
 {

--- a/irr/src/COpenGLCoreRenderTarget.h
+++ b/irr/src/COpenGLCoreRenderTarget.h
@@ -28,10 +28,6 @@ public:
 			AssignedDepth(false), AssignedStencil(false), RequestTextureUpdate(false), RequestDepthStencilUpdate(false),
 			BufferID(0), ColorAttachment(0), MultipleRenderTarget(0), Driver(driver)
 	{
-#ifdef _DEBUG
-		setDebugName("COpenGLCoreRenderTarget");
-#endif
-
 		DriverType = Driver->getDriverType();
 
 		Size = Driver->getScreenSize();

--- a/irr/src/COpenGLDriver.cpp
+++ b/irr/src/COpenGLDriver.cpp
@@ -32,11 +32,7 @@ COpenGLDriver::COpenGLDriver(const SIrrlichtCreationParameters &params, io::IFil
 		CNullDriver(io, params.WindowSize), COpenGLExtensionHandler(), CacheHandler(0), CurrentRenderMode(ERM_NONE), ResetRenderStates(true),
 		Transformation3DChanged(true), AntiAlias(params.AntiAlias), ColorFormat(ECF_R8G8B8), FixedPipelineState(EOFPS_ENABLE), Params(params),
 		ContextManager(contextManager)
-{
-#ifdef _DEBUG
-	setDebugName("COpenGLDriver");
-#endif
-}
+{}
 
 bool COpenGLDriver::initDriver()
 {

--- a/irr/src/COpenGLSLMaterialRenderer.cpp
+++ b/irr/src/COpenGLSLMaterialRenderer.cpp
@@ -50,10 +50,6 @@ COpenGLSLMaterialRenderer::COpenGLSLMaterialRenderer(video::COpenGLDriver *drive
 		Driver(driver),
 		CallBack(callback), Alpha(false), Blending(false), AlphaTest(false), Program(0), Program2(0), UserData(userData)
 {
-#ifdef _DEBUG
-	setDebugName("COpenGLSLMaterialRenderer");
-#endif
-
 	switch (baseMaterial) {
 	case EMT_TRANSPARENT_VERTEX_ALPHA:
 	case EMT_TRANSPARENT_ALPHA_CHANNEL:

--- a/irr/src/CReadFile.cpp
+++ b/irr/src/CReadFile.cpp
@@ -12,10 +12,6 @@ namespace io
 CReadFile::CReadFile(const io::path &fileName) :
 		File(0), FileSize(0), Filename(fileName)
 {
-#ifdef _DEBUG
-	setDebugName("CReadFile");
-#endif
-
 	openFile();
 }
 

--- a/irr/src/CSDLManager.cpp
+++ b/irr/src/CSDLManager.cpp
@@ -15,11 +15,7 @@ namespace video
 
 CSDLManager::CSDLManager(CIrrDeviceSDL *device) :
 		IContextManager(), SDLDevice(device)
-{
-#ifdef _DEBUG
-	setDebugName("CSDLManager");
-#endif
-}
+{}
 
 bool CSDLManager::initialize(const SIrrlichtCreationParameters &params, const SExposedVideoData &data)
 {

--- a/irr/src/CSceneCollisionManager.cpp
+++ b/irr/src/CSceneCollisionManager.cpp
@@ -17,10 +17,6 @@ namespace scene
 CSceneCollisionManager::CSceneCollisionManager(ISceneManager *smanager, video::IVideoDriver *driver) :
 		SceneManager(smanager), Driver(driver)
 {
-#ifdef _DEBUG
-	setDebugName("CSceneCollisionManager");
-#endif
-
 	if (Driver)
 		Driver->grab();
 }

--- a/irr/src/CSceneManager.cpp
+++ b/irr/src/CSceneManager.cpp
@@ -44,11 +44,6 @@ CSceneManager::CSceneManager(video::IVideoDriver *driver,
 		ActiveCamera(0), Parameters(0),
 		MeshCache(cache), CurrentRenderPass(ESNRP_NONE)
 {
-#ifdef _DEBUG
-	ISceneManager::setDebugName("CSceneManager ISceneManager");
-	ISceneNode::setDebugName("CSceneManager ISceneNode");
-#endif
-
 	// root node's scene manager
 	SceneManager = this;
 

--- a/irr/src/CWGLManager.cpp
+++ b/irr/src/CWGLManager.cpp
@@ -19,9 +19,6 @@ namespace video
 CWGLManager::CWGLManager() :
 		PrimaryContext(SExposedVideoData(0)), PixelFormat(0), libHandle(NULL)
 {
-#ifdef _DEBUG
-	setDebugName("CWGLManager");
-#endif
 	memset(FunctionPointers, 0, sizeof(FunctionPointers));
 }
 

--- a/irr/src/CWriteFile.cpp
+++ b/irr/src/CWriteFile.cpp
@@ -13,10 +13,6 @@ namespace io
 CWriteFile::CWriteFile(const io::path &fileName, bool append) :
 		Filename(fileName), FileSize(0)
 {
-#ifdef _DEBUG
-	setDebugName("CWriteFile");
-#endif
-
 	openFile(append);
 }
 

--- a/irr/src/CXMeshFileLoader.cpp
+++ b/irr/src/CXMeshFileLoader.cpp
@@ -32,11 +32,7 @@ namespace scene
 CXMeshFileLoader::CXMeshFileLoader(scene::ISceneManager *smgr) :
 		AnimatedMesh(0), Buffer(0), P(0), End(0), BinaryNumCount(0), Line(0), ErrorState(false),
 		CurFrame(0), MajorVersion(0), MinorVersion(0), BinaryFormat(false), FloatSize(0)
-{
-#ifdef _DEBUG
-	setDebugName("CXMeshFileLoader");
-#endif
-}
+{}
 
 //! returns true if the file maybe is able to be loaded by this class
 //! based on the file extension (e.g. ".bsp")

--- a/irr/src/CZipReader.cpp
+++ b/irr/src/CZipReader.cpp
@@ -24,11 +24,7 @@ namespace io
 //! Constructor
 CArchiveLoaderZIP::CArchiveLoaderZIP(io::IFileSystem *fs) :
 		FileSystem(fs)
-{
-#ifdef _DEBUG
-	setDebugName("CArchiveLoaderZIP");
-#endif
-}
+{}
 
 //! returns true if the file maybe is able to be loaded by this class
 bool CArchiveLoaderZIP::isALoadableFileFormat(const io::path &filename) const
@@ -107,10 +103,6 @@ bool CArchiveLoaderZIP::isALoadableFileFormat(io::IReadFile *file) const
 CZipReader::CZipReader(IFileSystem *fs, IReadFile *file, bool ignoreCase, bool ignorePaths, bool isGZip) :
 		CFileList((file ? file->getFileName() : io::path("")), ignoreCase, ignorePaths), FileSystem(fs), File(file), IsGZip(isGZip)
 {
-#ifdef _DEBUG
-	setDebugName("CZipReader");
-#endif
-
 	if (File) {
 		File->grab();
 

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -155,10 +155,6 @@ COpenGL3DriverBase::COpenGL3DriverBase(const SIrrlichtCreationParameters &params
 		OGLES2ShaderPath(params.OGLES2ShaderPath),
 		ColorFormat(ECF_R8G8B8), ContextManager(contextManager), EnableErrorTest(params.DriverDebug)
 {
-#ifdef _DEBUG
-	setDebugName("Driver");
-#endif
-
 	if (!ContextManager)
 		return;
 

--- a/irr/src/OpenGL/MaterialRenderer.cpp
+++ b/irr/src/OpenGL/MaterialRenderer.cpp
@@ -30,10 +30,6 @@ COpenGL3MaterialRenderer::COpenGL3MaterialRenderer(COpenGL3DriverBase *driver,
 		Driver(driver),
 		CallBack(callback), Alpha(false), Blending(false), Program(0), UserData(userData)
 {
-#ifdef _DEBUG
-	setDebugName("MaterialRenderer");
-#endif
-
 	switch (baseMaterial) {
 	case EMT_TRANSPARENT_VERTEX_ALPHA:
 	case EMT_TRANSPARENT_ALPHA_CHANNEL:

--- a/irr/src/OpenGL/Renderer2D.cpp
+++ b/irr/src/OpenGL/Renderer2D.cpp
@@ -22,10 +22,6 @@ COpenGL3Renderer2D::COpenGL3Renderer2D(const c8 *vertexShaderProgram, const c8 *
 		COpenGL3MaterialRenderer(driver, 0, EMT_SOLID),
 		WithTexture(withTexture)
 {
-#ifdef _DEBUG
-	setDebugName("Renderer2D");
-#endif
-
 	int Temp = 0;
 
 	init(Temp, vertexShaderProgram, pixelShaderProgram, false);

--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -30,10 +30,6 @@ GUIEditBoxWithScrollBar::GUIEditBoxWithScrollBar(const wchar_t* text, bool borde
 	: GUIEditBox(environment, parent, id, rectangle, border, writable),
 	m_background(true), m_bg_color_used(false), m_tsrc(tsrc)
 {
-#ifdef _DEBUG
-	setDebugName("GUIEditBoxWithScrollBar");
-#endif
-
 
 	Text = text;
 

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -1015,10 +1015,6 @@ GUIHyperText::GUIHyperText(const wchar_t *text, IGUIEnvironment *environment,
 		m_drawer(text, client, environment, tsrc), m_text_scrollpos(0, 0)
 {
 
-#ifdef _DEBUG
-	setDebugName("GUIHyperText");
-#endif
-
 	IGUISkin *skin = 0;
 	if (Environment)
 		skin = Environment->getSkin();

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -254,9 +254,6 @@ CGUITTFont::CGUITTFont(IGUIEnvironment *env)
 batch_load_size(1), Device(0), Environment(env), Driver(0), GlobalKerningWidth(0), GlobalKerningHeight(0),
 shadow_offset(0), shadow_alpha(0), fallback(0)
 {
-	#ifdef _DEBUG
-	setDebugName("CGUITTFont");
-	#endif
 
 	if (Environment)
 	{

--- a/src/irrlicht_changes/static_text.cpp
+++ b/src/irrlicht_changes/static_text.cpp
@@ -30,10 +30,6 @@ StaticText::StaticText(const EnrichedString &text, bool border,
 	RestrainTextInside(true), RightToLeft(false),
 	OverrideFont(0), LastBreakFont(0)
 {
-	#ifdef _DEBUG
-	setDebugName("StaticText");
-	#endif
-
 	setText(text);
 }
 


### PR DESCRIPTION
Some more trivial Irrlicht plumbing. Nobody needs these debug names, they are just an eyesore. In a proper debugger you can view object types (note that Irrlicht is compiled with run-time type information now, which lets us do things like dynamic casts to begin with; this also renders some "tag methods" obsolete). And even if someone wanted to inspect typenames at runtime, they could do `typeid(...).name()`.

