### PR TITLE
[no sq] Make OpenGL 3 the preferred (default) video driver

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -36,13 +36,6 @@ body:
       required: true
   - type: input
     attributes:
-      label: Irrlicht device
-      description:
-      placeholder: "Example: X11"
-    validations:
-      required: false
-  - type: input
-    attributes:
       label: Operating system and version
       description: It is recommended to upgrade your operating system to see if the problem persists.
       placeholder: "Example: Ubuntu 22.04"
@@ -69,7 +62,7 @@ body:
     attributes:
       label: Active renderer
       description: You can find this in the "About" tab in the main menu.
-      placeholder: "Example: OpenGL 4.6.0"
+      placeholder: "Example: ES 3.2 / ogles2 / X11"
     validations:
       required: false
   - type: textarea

--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -32,6 +32,27 @@ local function get_credits()
 	return json
 end
 
+local function get_renderer_info()
+	local ret = {}
+
+	-- OpenGL version, stripped to just the important part
+	local s1 = core.get_active_renderer()
+	if s1:sub(1, 7) == "OpenGL " then
+		s1 = s1:sub(8)
+	end
+	local m = s1:match("^[%d.]+")
+	if not m then
+		m = s1:match("^ES [%d.]+")
+	end
+	ret[#ret+1] = m or s1
+	-- video driver
+	ret[#ret+1] = core.get_active_driver():lower()
+	-- irrlicht device
+	ret[#ret+1] = core.get_active_irrlicht_device():upper()
+
+	return table.concat(ret, " / ")
+end
+
 return {
 	name = "about",
 	caption = fgettext("About"),
@@ -81,19 +102,11 @@ return {
 			"button_url[1.5,4.1;2.5,0.8;homepage;luanti.org;https://www.luanti.org/]" ..
 			"hypertext[5.5,0.25;9.75,6.6;credits;" .. core.formspec_escape(hypertext) .. "]"
 
-		-- Render information
-		local active_renderer_info = fgettext("Active renderer:") .. " " ..
-			core.formspec_escape(core.get_active_renderer())
+		local active_renderer_info = fgettext("Active renderer:") .. "\n" ..
+			core.formspec_escape(get_renderer_info())
 		fs = fs .. "style[label_button2;border=false]" ..
-			"button[0.1,6;5.3,0.5;label_button2;" .. active_renderer_info .. "]"..
+			"button[0.1,6;5.3,1;label_button2;" .. active_renderer_info .. "]"..
 			"tooltip[label_button2;" .. active_renderer_info .. "]"
-
-		-- Irrlicht device information
-		local irrlicht_device_info = fgettext("Irrlicht device:") .. " " ..
-			core.formspec_escape(core.get_active_irrlicht_device())
-		fs = fs .. "style[label_button3;border=false]" ..
-			"button[0.1,6.5;5.3,0.5;label_button3;" .. irrlicht_device_info .. "]"..
-			"tooltip[label_button3;" .. irrlicht_device_info .. "]"
 
 		if PLATFORM == "Android" then
 			fs = fs .. "button[0.5,5.1;4.5,0.8;share_debug;" .. fgettext("Share debug log") .. "]"

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -135,7 +135,7 @@ static irr::IrrlichtDevice *createDevice(SIrrlichtCreationParameters params, std
 {
 	if (requested_driver) {
 		params.DriverType = *requested_driver;
-		verbosestream << "Trying video driver " << getVideoDriverName(params.DriverType) << std::endl;
+		infostream << "Trying video driver " << getVideoDriverName(params.DriverType) << std::endl;
 		if (auto *device = createDeviceEx(params))
 			return device;
 		errorstream << "Failed to initialize the " << getVideoDriverName(params.DriverType) << " video driver" << std::endl;
@@ -147,7 +147,7 @@ static irr::IrrlichtDevice *createDevice(SIrrlichtCreationParameters params, std
 		if (fallback_driver == video::EDT_NULL || fallback_driver == requested_driver)
 			continue;
 		params.DriverType = fallback_driver;
-		verbosestream << "Trying video driver " << getVideoDriverName(params.DriverType) << std::endl;
+		infostream << "Trying video driver " << getVideoDriverName(params.DriverType) << std::endl;
 		if (auto *device = createDeviceEx(params))
 			return device;
 	}
@@ -374,16 +374,16 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 std::vector<video::E_DRIVER_TYPE> RenderingEngine::getSupportedVideoDrivers()
 {
 	// Only check these drivers. We do not support software and D3D in any capacity.
-	// Order by preference (best first)
+	// ordered by preference (best first)
 	static const video::E_DRIVER_TYPE glDrivers[] = {
-		video::EDT_OPENGL,
 		video::EDT_OPENGL3,
+		video::EDT_OPENGL,
 		video::EDT_OGLES2,
 		video::EDT_NULL,
 	};
 	std::vector<video::E_DRIVER_TYPE> drivers;
 
-	for (video::E_DRIVER_TYPE driver: glDrivers) {
+	for (auto driver : glDrivers) {
 		if (IrrlichtDevice::isDriverSupported(driver))
 			drivers.push_back(driver);
 	}


### PR DESCRIPTION
This could be considered a bold move, but I think it's quite natural to prefer the more modern codebase when possible.
Over time this will enable moving away from the legacy GL driver (though there are no concrete plans).
This also reduces the chances that we accidentally write a feature that is somehow broken on OpenGL ES, as has happened in the past.

**What happens to people who don't have OpenGL 3.2?**
effectively nothing, Luanti transparently falls back to the legacy driver
Unfortunately this comes with a few empty flashing windows, some warning messages in the log and higher startup delay.
I tried to implement not recreating the window in CIrrDeviceSDL but it was too hairy and I gave up.
A clever solution would be to remember that GL3 doesn't work and not try it again next time. I can implement this if wanted.
