### PR TITLE
Revert "Optimize raycast performance"

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9948,8 +9948,6 @@ Used by `core.register_node`.
 
     selection_box = {
         -- see [Node boxes] for possibilities
-        -- Selection boxes that oversize node size can cause
-        -- significant performance drop of Raycasts.
     },
     -- Custom selection box definition. Multiple boxes can be defined.
     -- If "nodebox" drawtype is used and selection_box is nil, then node_box

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -163,8 +163,6 @@ void Environment::continueRaycast(RaycastState *state, PointedThing *result_p)
 			break; // About to go out of bounds
 		}
 
-		const v3s16 pos_on_ray = state->m_iterator.m_current_node_pos;
-
 		// For each untested node
 		for (s16 z = new_nodes.MinEdge.Z; z <= new_nodes.MaxEdge.Z; z++)
 		for (s16 y = new_nodes.MinEdge.Y; y <= new_nodes.MaxEdge.Y; y++)
@@ -175,10 +173,6 @@ void Environment::continueRaycast(RaycastState *state, PointedThing *result_p)
 
 			n = map.getNode(np, &is_valid_position);
 			if (!is_valid_position)
-				continue;
-
-			// Optimization: Skip non-oversized selection boxes for other positions.
-			if ((pos_on_ray != np) && !nodedef->get(n).has_big_selection_box)
 				continue;
 
 			PointabilityType pointable = isPointableNode(n, nodedef,

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1257,15 +1257,6 @@ inline void NodeDefManager::fixSelectionBoxIntUnion()
 		m_selection_box_union.MaxEdge.Z / BS - 0.5f);
 }
 
-inline void NodeDefManager::calcBigSelectionBox(content_t id, const ContentFeatures &def)
-{
-	aabb3f box_union;
-	getNodeBoxUnion(def.selection_box, def, &box_union);
-	m_content_features[id].has_big_selection_box =
-			(box_union.MinEdge.X < -BS/2) || (box_union.MaxEdge.X > BS/2) ||
-			(box_union.MinEdge.Y < -BS/2) || (box_union.MaxEdge.Y > BS/2) ||
-			(box_union.MinEdge.Z < -BS/2) || (box_union.MaxEdge.Z > BS/2);
-}
 
 void NodeDefManager::eraseIdFromGroups(content_t id)
 {
@@ -1321,7 +1312,6 @@ content_t NodeDefManager::set(const std::string &name, const ContentFeatures &de
 	getNodeBoxUnion(def.selection_box, def, &m_selection_box_union);
 	fixSelectionBoxIntUnion();
 
-	calcBigSelectionBox(id, def);
 	// Add this content to the list of all groups it belongs to
 	for (const auto &group : def.groups) {
 		const std::string &group_name = group.first;
@@ -1535,8 +1525,6 @@ void NodeDefManager::deSerialize(std::istream &is, u16 protocol_version)
 
 		getNodeBoxUnion(f.selection_box, f, &m_selection_box_union);
 		fixSelectionBoxIntUnion();
-
-		calcBigSelectionBox(i, f);
 	}
 
 	// Since liquid_alternative_flowing_id and liquid_alternative_source_id

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -425,8 +425,6 @@ struct ContentFeatures
 	NodeBox node_box;
 	NodeBox selection_box;
 	NodeBox collision_box;
-	//! Whether any selection box extent is > BS/2.
-	bool has_big_selection_box;
 
 	// --- SOUND PROPERTIES ---
 
@@ -775,9 +773,6 @@ private:
 	 * m_selection_box_union.
 	 */
 	void fixSelectionBoxIntUnion();
-
-	//! Calculates ContentFeatures::&has_big_selection_box
-	void calcBigSelectionBox(content_t id, const ContentFeatures &def);
 
 	//! Features indexed by ID.
 	std::vector<ContentFeatures> m_content_features;


### PR DESCRIPTION
Reverts minetest/minetest#15233. I think this is the best option unfortunately as I see no easy way to fix the major regressions. I think the new optimization effectively conflicts with the "only check new nodes" optimization: If the next voxel hit by the ray is not among the "new nodes", both the previous iteration and the next iteration will skip it, the former because it is not the *current* pos on the ray (it is a future one), and the latter because it thinks it was already visited in a past iteration (which it was not).