### PR TITLE
Main menu server tab search improvements

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -328,8 +328,8 @@ local function search_server_list(input)
 
 		-- Check if mods found
 		local mods_lower = {}
-		for i, mod in ipairs(server.mods or {}) do
-			mods_lower[i] = mod:lower()
+		for j, mod in ipairs(server.mods or {}) do
+			mods_lower[j] = mod:lower()
 		end
 		for _, mod in ipairs(query.mods) do
 			if table.indexof(mods_lower, mod) < 0 then
@@ -340,8 +340,8 @@ local function search_server_list(input)
 
 		-- Check if players found
 		local clients_list_lower = {}
-		for i, player in ipairs(server.clients_list or {}) do
-			clients_list_lower[i] = player:lower()
+		for j, player in ipairs(server.clients_list or {}) do
+			clients_list_lower[j] = player:lower()
 		end
 		for _, player in ipairs(query.players) do
 			if table.indexof(clients_list_lower, player) < 0 then

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -112,6 +112,7 @@ local function get_formspec(tabview, name, tabdata)
 	local retval =
 		-- Search
 		"field[0.25,0.25;7,0.75;te_search;;" .. core.formspec_escape(tabdata.search_for) .. "]" ..
+		"tooltip[te_search;" .. fgettext("Possible filters\ngame:<name>\nmod:<name>\nplayer:<name>") .. "]" ..
 		"field_enter_after_edit[te_search;true]" ..
 		"container[7.25,0.25]" ..
 		"image_button[0,0;0.75,0.75;" .. core.formspec_escape(defaulttexturedir .. "search.png") .. ";btn_mp_search;]" ..

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -285,14 +285,14 @@ local function parse_search_input(input)
 	-- Separate by space characters and handle special prefixes
 	-- (words with special prefixes need an exact match and none of them can contain spaces)
 	for word in input:gmatch("%S+") do
-		if word:sub(0, 4) == "mod:" then
-			table.insert(query.mods, word:sub(5))
-		elseif word:sub(0, 7) == "player:" then
-			table.insert(query.players, word:sub(8))
-		elseif word:sub(0, 5) == "game:" then
-			query.game = word:sub(6)
-		else
-			table.insert(query.keywords, word)
+		local mod = word:match("^mod:(.*)")
+		table.insert(query.mods, mod)
+		local player = word:match("^player:(.*)")
+		table.insert(query.players, player)
+		local game = word:match("^game:(.*)")
+		query.game = game
+		if not (mod or player or game) then
+			table.insert(query.keywords, word:lower())
 		end
 	end
 


### PR DESCRIPTION
This extends the search capabilities of the server list by:

- Quotation mark enclosements, e.g. `"Your Land"`
- Mods search, e.g. `mod:technic mod:terumet`
- Game search, e.g. `game:Exile` (if multiple, only uses the most recent (righter most) one)
- Player search, e.g. `player:cx384`

(Terms are separated by spaces and all need to match)
(To combine them with `or` just use multiple queries instead => Disjunctive Normal Form)
(It is currently not possible to negate terms.)

### Screenshots

<details> 
<summary>Click me</summary>

  ![s0](https://github.com/user-attachments/assets/68dc2688-2aa3-4496-8d6a-a58183b65752)
  ![s1](https://github.com/user-attachments/assets/6a01da4e-b511-4448-a303-564f79b43933)
  ![s2](https://github.com/user-attachments/assets/4f26b23f-0529-4b17-94a3-ef999b337aad)
  ![s3](https://github.com/user-attachments/assets/6fc96df8-d13a-4fb7-90bc-c63310830e89)
  ![s4](https://github.com/user-attachments/assets/1660843e-07da-4714-a077-7cf7003f58cb)
   
</details>

### Related / future work
#2568, #11083, #12858

## To do

Ready for review.

## How to test

- Open the server tab and search something e.g. the examples from above.