### PR TITLE
Remove game_ui from Client

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -14,7 +14,6 @@
 #include "network/networkpacket.h"
 #include "threading/mutex_auto_lock.h"
 #include "client/clientevent.h"
-#include "client/gameui.h"
 #include "client/renderingengine.h"
 #include "client/sound.h"
 #include "client/texturepaths.h"
@@ -94,7 +93,6 @@ Client::Client(
 		ISoundManager *sound,
 		MtEventManager *event,
 		RenderingEngine *rendering_engine,
-		GameUI *game_ui,
 		ELoginRegister allow_login_or_register
 ):
 	m_tsrc(tsrc),
@@ -117,7 +115,6 @@ Client::Client(
 	m_chosen_auth_mech(AUTH_MECHANISM_NONE),
 	m_media_downloader(new ClientMediaDownloader()),
 	m_state(LC_Created),
-	m_game_ui(game_ui),
 	m_modchannel_mgr(new ModChannelMgr())
 {
 	// Add local player

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -99,7 +99,6 @@ private:
 };
 
 class ClientScripting;
-class GameUI;
 
 class Client : public con::PeerHandler, public InventoryManager, public IGameDef
 {
@@ -119,7 +118,6 @@ public:
 			ISoundManager *sound,
 			MtEventManager *event,
 			RenderingEngine *rendering_engine,
-			GameUI *game_ui,
 			ELoginRegister allow_login_or_register
 	);
 
@@ -571,8 +569,6 @@ private:
 
 	// own state
 	LocalClientState m_state;
-
-	GameUI *m_game_ui;
 
 	// Used for saving server map to disk client-side
 	MapDatabase *m_localdb = nullptr;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1614,7 +1614,7 @@ bool Game::connectToServer(const GameStartData &start_data,
 				start_data.password,
 				*draw_control, texture_src, shader_src,
 				itemdef_manager, nodedef_manager, sound_manager.get(), eventmgr,
-				m_rendering_engine, m_game_ui.get(),
+				m_rendering_engine,
 				start_data.allow_login_or_register);
 	} catch (const BaseException &e) {
 		*error_message = fmtgettext("Error creating client: %s", e.what());


### PR DESCRIPTION
This removes the `m_game_ui` member variable from `Client`, since it is a private member and completely unused.

## To do

Ready for Review.

## How to test

See that it compiles
