### PR TITLE
Fix situation around aabbox3d default constructor

### DIFF
--- a/irr/include/CMeshBuffer.h
+++ b/irr/include/CMeshBuffer.h
@@ -134,7 +134,7 @@ public:
 	//! Index buffer
 	SIndexBuffer *Indices;
 	//! Bounding box of this meshbuffer.
-	core::aabbox3d<f32> BoundingBox;
+	core::aabbox3d<f32> BoundingBox{{0, 0, 0}};
 	//! Primitive type used for rendering (triangles, lines, ...)
 	E_PRIMITIVE_TYPE PrimitiveType;
 };

--- a/irr/include/IMeshManipulator.h
+++ b/irr/include/IMeshManipulator.h
@@ -108,7 +108,7 @@ public:
 		if (!mesh)
 			return true;
 		bool result = true;
-		core::aabbox3df bufferbox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+		core::aabbox3df bufferbox{{0, 0, 0}};
 		for (u32 i = 0; i < mesh->getMeshBufferCount(); ++i) {
 			result &= apply(func, mesh->getMeshBuffer(i), boundingBoxUpdate);
 			if (boundingBoxUpdate) {
@@ -136,7 +136,7 @@ protected:
 		if (!buffer)
 			return true;
 
-		core::aabbox3df bufferbox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+		core::aabbox3df bufferbox{{0, 0, 0}};
 		for (u32 i = 0; i < buffer->getVertexCount(); ++i) {
 			switch (buffer->getVertexType()) {
 			case video::EVT_STANDARD: {

--- a/irr/include/IMeshManipulator.h
+++ b/irr/include/IMeshManipulator.h
@@ -108,7 +108,7 @@ public:
 		if (!mesh)
 			return true;
 		bool result = true;
-		core::aabbox3df bufferbox;
+		core::aabbox3df bufferbox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 		for (u32 i = 0; i < mesh->getMeshBufferCount(); ++i) {
 			result &= apply(func, mesh->getMeshBuffer(i), boundingBoxUpdate);
 			if (boundingBoxUpdate) {
@@ -136,7 +136,7 @@ protected:
 		if (!buffer)
 			return true;
 
-		core::aabbox3df bufferbox;
+		core::aabbox3df bufferbox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 		for (u32 i = 0; i < buffer->getVertexCount(); ++i) {
 			switch (buffer->getVertexType()) {
 			case video::EVT_STANDARD: {

--- a/irr/include/SAnimatedMesh.h
+++ b/irr/include/SAnimatedMesh.h
@@ -154,7 +154,7 @@ struct SAnimatedMesh final : public IAnimatedMesh
 	std::vector<IMesh *> Meshes;
 
 	//! The bounding box of this mesh
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{{0.0f, 0.0f, 0.0f}};
 
 	//! Default animation speed of this mesh.
 	f32 FramesPerSecond;

--- a/irr/include/SMesh.h
+++ b/irr/include/SMesh.h
@@ -133,7 +133,7 @@ struct SMesh final : public IMesh
 	std::vector<u32> TextureSlots;
 
 	//! The bounding box of this mesh
-	core::aabbox3d<f32> BoundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	core::aabbox3d<f32> BoundingBox{{0, 0, 0}};
 };
 
 } // end namespace scene

--- a/irr/include/SMesh.h
+++ b/irr/include/SMesh.h
@@ -133,7 +133,7 @@ struct SMesh final : public IMesh
 	std::vector<u32> TextureSlots;
 
 	//! The bounding box of this mesh
-	core::aabbox3d<f32> BoundingBox;
+	core::aabbox3d<f32> BoundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 };
 
 } // end namespace scene

--- a/irr/include/SSkinMeshBuffer.h
+++ b/irr/include/SSkinMeshBuffer.h
@@ -228,7 +228,7 @@ public:
 	video::SMaterial Material;
 	video::E_VERTEX_TYPE VertexType;
 
-	core::aabbox3d<f32> BoundingBox;
+	core::aabbox3d<f32> BoundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 	//! Primitive type used for rendering (triangles, lines, ...)
 	E_PRIMITIVE_TYPE PrimitiveType;

--- a/irr/include/SSkinMeshBuffer.h
+++ b/irr/include/SSkinMeshBuffer.h
@@ -228,7 +228,7 @@ public:
 	video::SMaterial Material;
 	video::E_VERTEX_TYPE VertexType;
 
-	core::aabbox3d<f32> BoundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	core::aabbox3d<f32> BoundingBox{{0, 0, 0}};
 
 	//! Primitive type used for rendering (triangles, lines, ...)
 	E_PRIMITIVE_TYPE PrimitiveType;

--- a/irr/include/SViewFrustum.h
+++ b/irr/include/SViewFrustum.h
@@ -117,7 +117,7 @@ struct SViewFrustum
 	core::plane3d<f32> planes[VF_PLANE_COUNT];
 
 	//! bounding box around the view frustum
-	core::aabbox3d<f32> boundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	core::aabbox3d<f32> boundingBox{{0, 0, 0}};
 
 private:
 	//! Hold a copy of important transform matrices

--- a/irr/include/SViewFrustum.h
+++ b/irr/include/SViewFrustum.h
@@ -117,7 +117,7 @@ struct SViewFrustum
 	core::plane3d<f32> planes[VF_PLANE_COUNT];
 
 	//! bounding box around the view frustum
-	core::aabbox3d<f32> boundingBox;
+	core::aabbox3d<f32> boundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 private:
 	//! Hold a copy of important transform matrices

--- a/irr/include/SkinnedMesh.h
+++ b/irr/include/SkinnedMesh.h
@@ -137,7 +137,7 @@ public:
 	//! Moves the mesh into static position.
 	void resetAnimation();
 
-	virtual void updateBoundingBox();
+	void updateBoundingBox();
 
 	//! Recovers the joints from the mesh
 	void recoverJointsFromMesh(std::vector<IBoneSceneNode *> &jointChildSceneNodes);
@@ -370,7 +370,7 @@ protected:
 	// doesn't allow taking a reference to individual elements.
 	std::vector<std::vector<char>> Vertices_Moved;
 
-	core::aabbox3d<f32> BoundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	core::aabbox3d<f32> BoundingBox{{0, 0, 0}};
 
 	f32 EndFrame;
 	f32 FramesPerSecond;

--- a/irr/include/SkinnedMesh.h
+++ b/irr/include/SkinnedMesh.h
@@ -370,7 +370,7 @@ protected:
 	// doesn't allow taking a reference to individual elements.
 	std::vector<std::vector<char>> Vertices_Moved;
 
-	core::aabbox3d<f32> BoundingBox;
+	core::aabbox3d<f32> BoundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 	f32 EndFrame;
 	f32 FramesPerSecond;

--- a/irr/include/aabbox3d.h
+++ b/irr/include/aabbox3d.h
@@ -20,9 +20,7 @@ template <class T>
 class aabbox3d
 {
 public:
-	//! Default Constructor.
-	constexpr aabbox3d() :
-			MinEdge(-1, -1, -1), MaxEdge(1, 1, 1) {}
+	constexpr aabbox3d() = delete;
 	//! Constructor with min edge and max edge.
 	constexpr aabbox3d(const vector3d<T> &min, const vector3d<T> &max) :
 			MinEdge(min), MaxEdge(max) {}

--- a/irr/src/CAnimatedMeshSceneNode.h
+++ b/irr/src/CAnimatedMeshSceneNode.h
@@ -145,7 +145,7 @@ private:
 	void beginTransition();
 
 	core::array<video::SMaterial> Materials;
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{{0.0f, 0.0f, 0.0f}};
 	IAnimatedMesh *Mesh;
 
 	f32 StartFrame;

--- a/irr/src/CBillboardSceneNode.h
+++ b/irr/src/CBillboardSceneNode.h
@@ -104,7 +104,7 @@ private:
 	/** Note that we can't use the real boundingbox for culling because at that point
 		the camera which is used to calculate the billboard is not yet updated. So we only
 		know the real boundingbox after rendering - which is too late for culling. */
-	core::aabbox3d<f32> BBoxSafe;
+	core::aabbox3d<f32> BBoxSafe{{0.0f, 0.0f, 0.0f}};
 
 	scene::SMeshBuffer *Buffer;
 };

--- a/irr/src/CBoneSceneNode.h
+++ b/irr/src/CBoneSceneNode.h
@@ -60,7 +60,7 @@ private:
 
 	u32 BoneIndex;
 
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 	E_BONE_ANIMATION_MODE AnimationMode;
 	E_BONE_SKINNING_SPACE SkinningSpace;

--- a/irr/src/CDummyTransformationSceneNode.h
+++ b/irr/src/CDummyTransformationSceneNode.h
@@ -48,7 +48,7 @@ private:
 	void setPosition(const core::vector3df &newpos) override;
 
 	core::matrix4 RelativeTransformationMatrix;
-	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	core::aabbox3d<f32> Box{{0, 0, 0}};
 };
 
 } // end namespace scene

--- a/irr/src/CDummyTransformationSceneNode.h
+++ b/irr/src/CDummyTransformationSceneNode.h
@@ -48,7 +48,7 @@ private:
 	void setPosition(const core::vector3df &newpos) override;
 
 	core::matrix4 RelativeTransformationMatrix;
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 };
 
 } // end namespace scene

--- a/irr/src/CEmptySceneNode.h
+++ b/irr/src/CEmptySceneNode.h
@@ -33,7 +33,7 @@ public:
 	ISceneNode *clone(ISceneNode *newParent = 0, ISceneManager *newManager = 0) override;
 
 private:
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 };
 
 } // end namespace scene

--- a/irr/src/CEmptySceneNode.h
+++ b/irr/src/CEmptySceneNode.h
@@ -33,7 +33,7 @@ public:
 	ISceneNode *clone(ISceneNode *newParent = 0, ISceneManager *newManager = 0) override;
 
 private:
-	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	core::aabbox3d<f32> Box{{0, 0, 0}};
 };
 
 } // end namespace scene

--- a/irr/src/CMeshSceneNode.h
+++ b/irr/src/CMeshSceneNode.h
@@ -72,7 +72,7 @@ protected:
 	void copyMaterials();
 
 	core::array<video::SMaterial> Materials;
-	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	core::aabbox3d<f32> Box{{0, 0, 0}};
 	video::SMaterial ReadOnlyMaterial;
 
 	IMesh *Mesh;

--- a/irr/src/CMeshSceneNode.h
+++ b/irr/src/CMeshSceneNode.h
@@ -72,7 +72,7 @@ protected:
 	void copyMaterials();
 
 	core::array<video::SMaterial> Materials;
-	core::aabbox3d<f32> Box;
+	core::aabbox3d<f32> Box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	video::SMaterial ReadOnlyMaterial;
 
 	IMesh *Mesh;

--- a/irr/src/CSceneManager.cpp
+++ b/irr/src/CSceneManager.cpp
@@ -307,7 +307,7 @@ const core::aabbox3d<f32> &CSceneManager::getBoundingBox() const
 {
 	_IRR_DEBUG_BREAK_IF(true) // Bounding Box of Scene Manager should never be used.
 
-	static const core::aabbox3d<f32> dummy;
+	static const core::aabbox3d<f32> dummy{{0.0f, 0.0f, 0.0f}};
 	return dummy;
 }
 

--- a/irr/src/SkinnedMesh.cpp
+++ b/irr/src/SkinnedMesh.cpp
@@ -573,7 +573,7 @@ SkinnedMesh *SkinnedMeshBuilder::finalize()
 	return this;
 }
 
-void SkinnedMesh::updateBoundingBox(void)
+void SkinnedMesh::updateBoundingBox()
 {
 	if (!SkinningBuffers)
 		return;

--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -101,7 +101,7 @@ std::vector<DistanceSortedActiveObject> ActiveObjectMgr::getActiveSelectableObje
 		if (!obj)
 			continue;
 
-		aabb3f selection_box;
+		aabb3f selection_box{{0.0f, 0.0f, 0.0f}};
 		if (!obj->getSelectionBox(&selection_box))
 			continue;
 

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -430,7 +430,7 @@ void ClientEnvironment::getSelectedActiveObjects(
 
 	for (const auto &allObject : allObjects) {
 		ClientActiveObject *obj = allObject.obj;
-		aabb3f selection_box;
+		aabb3f selection_box{{0.0f, 0.0f, 0.0f}};
 		if (!obj->getSelectionBox(&selection_box))
 			continue;
 

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -160,7 +160,7 @@ private:
 	// Was the mesh ever generated?
 	bool m_mesh_valid = false;
 
-	aabb3f m_box;
+	aabb3f m_box{{0.0f, 0.0f, 0.0f}};
 	v2f m_origin;
 	u16 m_cloud_radius_i;
 	u32 m_seed;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3496,7 +3496,7 @@ PointedThing Game::updatePointedThing(
 		hud->pointing_at_object = true;
 
 		runData.selected_object = client->getEnv().getActiveObject(result.object_id);
-		aabb3f selection_box;
+		aabb3f selection_box{{0.0f, 0.0f, 0.0f}};
 		if (show_entity_selectionbox && runData.selected_object->doShowSelectionBox() &&
 				runData.selected_object->getSelectionBox(&selection_box)) {
 			v3f pos = runData.selected_object->getPosition();

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -75,10 +75,8 @@ static aabb3f getNodeBoundingBox(const std::vector<aabb3f> &nodeboxes)
 	if (nodeboxes.empty())
 		return aabb3f(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
 
-	aabb3f b_max;
-
-	std::vector<aabb3f>::const_iterator it = nodeboxes.begin();
-	b_max = aabb3f(it->MinEdge, it->MaxEdge);
+	auto it = nodeboxes.begin();
+	aabb3f b_max(it->MinEdge, it->MaxEdge);
 
 	++it;
 	for (; it != nodeboxes.end(); ++it)

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -105,8 +105,7 @@ void scaleMesh(scene::IMesh *mesh, v3f scale)
 	if (mesh == NULL)
 		return;
 
-	aabb3f bbox;
-	bbox.reset(0, 0, 0);
+	aabb3f bbox{{0.0f, 0.0f, 0.0f}};
 
 	u32 mc = mesh->getMeshBufferCount();
 	for (u32 j = 0; j < mc; j++) {
@@ -134,8 +133,7 @@ void translateMesh(scene::IMesh *mesh, v3f vec)
 	if (mesh == NULL)
 		return;
 
-	aabb3f bbox;
-	bbox.reset(0, 0, 0);
+	aabb3f bbox{{0.0f, 0.0f, 0.0f}};
 
 	u32 mc = mesh->getMeshBufferCount();
 	for (u32 j = 0; j < mc; j++) {
@@ -296,8 +294,7 @@ void rotateMeshBy6dFacedir(scene::IMesh *mesh, u8 facedir)
 
 void recalculateBoundingBox(scene::IMesh *src_mesh)
 {
-	aabb3f bbox;
-	bbox.reset(0,0,0);
+	aabb3f bbox{{0.0f, 0.0f, 0.0f}};
 	for (u16 j = 0; j < src_mesh->getMeshBufferCount(); j++) {
 		scene::IMeshBuffer *buf = src_mesh->getMeshBuffer(j);
 		buf->recalculateBoundingBox();

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -619,15 +619,22 @@ const core::aabbox3df &ParticleBuffer::getBoundingBox() const
 	if (!m_bounding_box_dirty)
 		return m_mesh_buffer->BoundingBox;
 
-	core::aabbox3df box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	core::aabbox3df box{{0, 0, 0}};
+	bool first = true;
 	for (u16 i = 0; i < m_count; i++) {
 		// check if this index is used
 		static_assert(quad_indices[1] != 0);
 		if (m_mesh_buffer->getIndices()[6 * i + 1] == 0)
 			continue;
 
-		for (u16 j = 0; j < 4; j++)
-			box.addInternalPoint(m_mesh_buffer->getPosition(i * 4 + j));
+		for (u16 j = 0; j < 4; j++) {
+			const auto pos = m_mesh_buffer->getPosition(i * 4 + j);
+			if (first)
+				box.reset(pos);
+			else
+				box.addInternalPoint(pos);
+			first = false;
+		}
 	}
 
 	m_mesh_buffer->BoundingBox = box;

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -619,7 +619,7 @@ const core::aabbox3df &ParticleBuffer::getBoundingBox() const
 	if (!m_bounding_box_dirty)
 		return m_mesh_buffer->BoundingBox;
 
-	core::aabbox3df box;
+	core::aabbox3df box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	for (u16 i = 0; i < m_count; i++) {
 		// check if this index is used
 		static_assert(quad_indices[1] != 0);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -50,8 +50,6 @@ Sky::Sky(s32 id, RenderingEngine *rendering_engine, ITextureSource *tsrc, IShade
 	m_seed = (u64)myrand() << 32 | myrand();
 
 	setAutomaticCulling(scene::EAC_OFF);
-	m_box.MaxEdge.set(0, 0, 0);
-	m_box.MinEdge.set(0, 0, 0);
 
 	m_sky_params = SkyboxDefaults::getSkyDefaults();
 	m_sun_params = SkyboxDefaults::getSunDefaults();

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -122,7 +122,7 @@ public:
 	}
 
 private:
-	aabb3f m_box;
+	aabb3f m_box{{0.0f, 0.0f, 0.0f}};
 	video::SMaterial m_materials[SKY_MATERIAL_COUNT];
 	// How much sun & moon transition should affect horizon color
 	float m_horizon_blend()

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -195,9 +195,7 @@ WieldMeshSceneNode::WieldMeshSceneNode(scene::ISceneManager *mgr, s32 id):
 	else
 		g_extrusion_mesh_cache->grab();
 
-	// Disable bounding box culling for this scene node
-	// since we won't calculate the bounding box.
-	// FIXME: why not?
+	// This class doesn't render anything, so disable culling.
 	setAutomaticCulling(scene::EAC_OFF);
 
 	// Create the child scene node

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -197,6 +197,7 @@ WieldMeshSceneNode::WieldMeshSceneNode(scene::ISceneManager *mgr, s32 id):
 
 	// Disable bounding box culling for this scene node
 	// since we won't calculate the bounding box.
+	// FIXME: why not?
 	setAutomaticCulling(scene::EAC_OFF);
 
 	// Create the child scene node

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -134,7 +134,7 @@ private:
 	// Bounding box culling is disabled for this type of scene node,
 	// so this variable is just required so we can implement
 	// getBoundingBox() and is set to an empty box.
-	aabb3f m_bounding_box;
+	aabb3f m_bounding_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 
 	ShadowRenderer *m_shadow;
 };

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -134,7 +134,7 @@ private:
 	// Bounding box culling is disabled for this type of scene node,
 	// so this variable is just required so we can implement
 	// getBoundingBox() and is set to an empty box.
-	aabb3f m_bounding_box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	aabb3f m_bounding_box{{0, 0, 0}};
 
 	ShadowRenderer *m_shadow;
 };

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -262,7 +262,7 @@ static void add_object_boxes(Environment *env,
 {
 	auto process_object = [&cinfo] (ActiveObject *object) {
 		if (object && object->collideWithObjects()) {
-			aabb3f box;
+			aabb3f box{{0.0f, 0.0f, 0.0f}};
 			if (object->getCollisionBox(&box))
 				cinfo.emplace_back(object, 0, box);
 		}

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -121,7 +121,7 @@ void NodeBox::deSerialize(std::istream &is)
 		case NODEBOX_LEVELED: {
 			u16 fixed_count = readU16(is);
 			while(fixed_count--) {
-				aabb3f box;
+				aabb3f box{{0.0f, 0.0f, 0.0f}};
 				box.MinEdge = readV3F32(is);
 				box.MaxEdge = readV3F32(is);
 				fixed.push_back(box);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -115,9 +115,9 @@ struct NodeBox
 	// NODEBOX_FIXED
 	std::vector<aabb3f> fixed;
 	// NODEBOX_WALLMOUNTED
-	aabb3f wall_top;
-	aabb3f wall_bottom;
-	aabb3f wall_side; // being at the -X side
+	aabb3f wall_top{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	aabb3f wall_bottom{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+	aabb3f wall_side{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f}; // being at the -X side
 	// NODEBOX_CONNECTED
 	// (kept externally to not bloat the structure)
 	std::shared_ptr<NodeBoxConnected> connected;
@@ -810,14 +810,14 @@ private:
 	 * The union of all nodes' selection boxes.
 	 * Might be larger if big nodes are removed from the manager.
 	 */
-	aabb3f m_selection_box_union;
+	aabb3f m_selection_box_union{{0.0f, 0.0f, 0.0f}};
 
 	/*!
 	 * The smallest box in integer node coordinates that
 	 * contains all nodes' selection boxes.
 	 * Might be larger if big nodes are removed from the manager.
 	 */
-	core::aabbox3d<s16> m_selection_box_int_union;
+	core::aabbox3d<s16> m_selection_box_int_union{{0, 0, 0}};
 
 	/*!
 	 * NodeResolver instances to notify once node registration has finished.

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -115,9 +115,9 @@ struct NodeBox
 	// NODEBOX_FIXED
 	std::vector<aabb3f> fixed;
 	// NODEBOX_WALLMOUNTED
-	aabb3f wall_top{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
-	aabb3f wall_bottom{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
-	aabb3f wall_side{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f}; // being at the -X side
+	aabb3f wall_top = dummybox;
+	aabb3f wall_bottom = dummybox;
+	aabb3f wall_side = dummybox; // being at the -X side
 	// NODEBOX_CONNECTED
 	// (kept externally to not bloat the structure)
 	std::shared_ptr<NodeBoxConnected> connected;
@@ -139,6 +139,10 @@ struct NodeBox
 	void reset();
 	void serialize(std::ostream &os, u16 protocol_version) const;
 	void deSerialize(std::istream &is);
+
+private:
+	/// @note the actual defaults are in reset(), see nodedef.cpp
+	static constexpr aabb3f dummybox = aabb3f({0, 0, 0});
 };
 
 struct MapNode;

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -302,7 +302,7 @@ private:
 	v3s16 m_start;                /**< source position                          */
 	v3s16 m_destination;          /**< destination position                     */
 
-	core::aabbox3d<s16> m_limits; /**< position limits in real map coordinates  */
+	core::aabbox3d<s16> m_limits{-1, -1, -1, 1, 1, 1}; /**< position limits in real map coordinates  */
 
 	/** contains all map data already collected and analyzed.
 		Access it via the getIndexElement/getIdxElem methods. */

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -302,7 +302,7 @@ private:
 	v3s16 m_start;                /**< source position                          */
 	v3s16 m_destination;          /**< destination position                     */
 
-	core::aabbox3d<s16> m_limits{-1, -1, -1, 1, 1, 1}; /**< position limits in real map coordinates  */
+	core::aabbox3d<s16> m_limits{{0, 0, 0}}; /**< position limits in real map coordinates  */
 
 	/** contains all map data already collected and analyzed.
 		Access it via the getIndexElement/getIdxElem methods. */

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -326,7 +326,8 @@ bool is_color_table(lua_State *L, int index)
 
 aabb3f read_aabb3f(lua_State *L, int index, f32 scale)
 {
-	aabb3f box;
+	// default value for accidental/historical reasons
+	aabb3f box{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 	if(lua_istable(L, index)){
 		lua_rawgeti(L, index, 1);
 		box.MinEdge.X = lua_tonumber(L, -1) * scale;

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -85,6 +85,18 @@ bool                read_color          (lua_State *L, int index,
                                          video::SColor *color);
 bool                is_color_table      (lua_State *L, int index);
 
+/**
+ * Read a floating-point bounding box from a Lua state.
+ *
+ * @param  L The Lua state.
+ * @param  index The index of the Lua variable to read the box from. The
+ *         variable must contain a table of the form
+ *         {minx, miny, minz, maxx, maxy, maxz}.
+ * @param  scale Factor to scale the bounding box by.
+ *
+ * @return Returns the bounding box corresponding to lua table. If the
+ *         variable is not a table, the result is undefined.
+ */
 aabb3f              read_aabb3f         (lua_State *L, int index, f32 scale);
 v3s16               read_v3s16          (lua_State *L, int index);
 std::vector<aabb3f> read_aabb3f_vector  (lua_State *L, int index, f32 scale);

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -86,18 +86,18 @@ bool                read_color          (lua_State *L, int index,
 bool                is_color_table      (lua_State *L, int index);
 
 /**
- * Read a floating-point bounding box from a Lua state.
+ * Read a floating-point axis-aligned box from Lua.
  *
- * @param  L The Lua state.
- * @param  index The index of the Lua variable to read the box from. The
+ * @param  L the Lua state
+ * @param  index the index of the Lua variable to read the box from. The
  *         variable must contain a table of the form
  *         {minx, miny, minz, maxx, maxy, maxz}.
- * @param  scale Factor to scale the bounding box by.
+ * @param  scale factor to scale the bounding box by
  *
- * @return Returns the bounding box corresponding to lua table. If the
- *         variable is not a table, the result is undefined.
+ * @return the box corresponding to lua table
  */
 aabb3f              read_aabb3f         (lua_State *L, int index, f32 scale);
+
 v3s16               read_v3s16          (lua_State *L, int index);
 std::vector<aabb3f> read_aabb3f_vector  (lua_State *L, int index, f32 scale);
 size_t              read_stringlist     (lua_State *L, int index,

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1857,7 +1857,7 @@ void ServerEnvironment::getSelectedActiveObjects(
 	auto process = [&] (ServerActiveObject *obj) -> bool {
 		if (obj->isGone())
 			return false;
-		aabb3f selection_box;
+		aabb3f selection_box{{0.0f, 0.0f, 0.0f}};
 		if (!obj->getSelectionBox(&selection_box))
 			return false;
 


### PR DESCRIPTION
adoption of #15508 and #15507

note: `aabb3f({0, 0, 0})` is a valid box (albeit with no volume), so it would *not* be culled if `(0, 0, 0)` is in view.
it's only used as a fallback value so "fixing" that too isn't worth it.

## To do

This PR is Ready for Review.

## How to test

1. make sure nothing is incorrectly culled (most likely visible effect if there's a bug)