### PR TITLE
IrrlichtMt: Move OpenGL 3+ transformation matrix to shaders

### DIFF
--- a/client/shaders/Irrlicht/Renderer2D.vsh
+++ b/client/shaders/Irrlicht/Renderer2D.vsh
@@ -9,6 +9,7 @@ attribute vec2 inTexCoord0;
 /* Uniforms */
 
 uniform float uThickness;
+uniform mat4 uProjection;
 
 /* Varyings */
 
@@ -17,7 +18,7 @@ varying vec4 vVertexColor;
 
 void main()
 {
-	gl_Position = inVertexPosition;
+	gl_Position = uProjection * inVertexPosition;
 	gl_PointSize = uThickness;
 	vTextureCoord = inTexCoord0;
 	vVertexColor = inVertexColor.bgra;

--- a/irr/src/OpenGL/Driver.h
+++ b/irr/src/OpenGL/Driver.h
@@ -316,6 +316,9 @@ protected:
 	void drawElements(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount, const u16 *indices, int indexCount);
 	void drawElements(GLenum primitiveType, const VertexType &vertexType, uintptr_t vertices, uintptr_t indices, int indexCount);
 
+	void renderArray(const void *vertices, const void *indexList, u32 primitiveCount,
+		E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType);
+
 	void beginDraw(const VertexType &vertexType, uintptr_t verticesBase);
 	void endDraw(const VertexType &vertexType);
 

--- a/irr/src/OpenGL/Driver.h
+++ b/irr/src/OpenGL/Driver.h
@@ -316,7 +316,7 @@ protected:
 	void drawElements(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount, const u16 *indices, int indexCount);
 	void drawElements(GLenum primitiveType, const VertexType &vertexType, uintptr_t vertices, uintptr_t indices, int indexCount);
 
-	void renderArray(const void *vertices, const void *indexList, u32 primitiveCount,
+	void drawGeneric(const void *vertices, const void *indexList, u32 primitiveCount,
 		E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType);
 
 	void beginDraw(const VertexType &vertexType, uintptr_t verticesBase);

--- a/irr/src/OpenGL/Renderer2D.cpp
+++ b/irr/src/OpenGL/Renderer2D.cpp
@@ -32,6 +32,7 @@ COpenGL3Renderer2D::COpenGL3Renderer2D(const c8 *vertexShaderProgram, const c8 *
 
 	// These states don't change later.
 
+	ProjectionID = getPixelShaderConstantID("uProjection");
 	ThicknessID = getPixelShaderConstantID("uThickness");
 	if (WithTexture) {
 		TextureUsageID = getPixelShaderConstantID("uTextureUsage");
@@ -63,8 +64,7 @@ void COpenGL3Renderer2D::OnSetMaterial(const video::SMaterial &material,
 	setPixelShaderConstant(ThicknessID, &Thickness, 1);
 
 	{
-		ProjectionID = getPixelShaderConstantID("uProjection");
-
+		// Update projection matrix
 		const core::dimension2d<u32> renderTargetSize = Driver->getCurrentRenderTargetSize();
 		core::matrix4 proj;
 		float xInv2 = 2.0f / renderTargetSize.Width;

--- a/irr/src/OpenGL/Renderer2D.cpp
+++ b/irr/src/OpenGL/Renderer2D.cpp
@@ -62,6 +62,18 @@ void COpenGL3Renderer2D::OnSetMaterial(const video::SMaterial &material,
 	f32 Thickness = (material.Thickness > 0.f) ? material.Thickness : 1.f;
 	setPixelShaderConstant(ThicknessID, &Thickness, 1);
 
+	{
+		ProjectionID = getPixelShaderConstantID("uProjection");
+
+		const core::dimension2d<u32> renderTargetSize = Driver->getCurrentRenderTargetSize();
+		core::matrix4 proj;
+		float xInv2 = 2.0f / renderTargetSize.Width;
+		float yInv2 = 2.0f / renderTargetSize.Height;
+		proj.setScale({ xInv2, -yInv2, 0.0f });
+		proj.setTranslation({ -1.0f, 1.0f, 0.0f });
+		setPixelShaderConstant(ProjectionID, proj.pointer(), 4 * 4);
+	}
+
 	if (WithTexture) {
 		s32 TextureUsage = material.TextureLayers[0].Texture ? 1 : 0;
 		setPixelShaderConstant(TextureUsageID, &TextureUsage, 1);

--- a/irr/src/OpenGL/Renderer2D.h
+++ b/irr/src/OpenGL/Renderer2D.h
@@ -24,6 +24,7 @@ public:
 
 protected:
 	bool WithTexture;
+	s32 ProjectionID;
 	s32 ThicknessID;
 	s32 TextureUsageID;
 };


### PR DESCRIPTION
This replaces annoying calculations on C++-side and eases the implementation of 2D geometry batch rendering a lot.

## To do

This PR is Ready for Review.

## How to test

1. Open `/test_formspec`  (devtest game) with a `video_driver = opengl` instance
2. The same as 1. but with `video_driver = opengl3`
3. Compare the output
4. There must be no difference

How to test the batch rendering:
1. Implement a feature that makes use of it. I did however test it briefly in another project.