### PR TITLE
Cache grouped sparse buffers

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1841,7 +1841,7 @@ mesh_generation_threads (Mapblock mesh generation threads) int 0 0 8
 
 #    All mesh buffers with less than this number of vertices will be merged
 #    during map rendering. This improves rendering performance.
-mesh_buffer_min_vertices (Minimum vertex count for mesh buffers) int 100 0 1000
+mesh_buffer_min_vertices (Minimum vertex count for mesh buffers) int 300 0 1000
 
 #    True = 256
 #    False = 128

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -590,6 +590,7 @@ void Client::step(float dtime)
 						if (r.mesh->getMesh(l)->getMeshBufferCount() != 0)
 							is_empty = false;
 
+					// <- invalidate here?
 					if (is_empty)
 						delete r.mesh;
 					else {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -564,7 +564,8 @@ void Client::step(float dtime)
 			std::vector<MinimapMapblock*> minimap_mapblocks;
 			bool do_mapper_update = true;
 
-			MapSector *sector = m_env.getMap().emergeSector(v2s16(r.p.X, r.p.Z));
+			ClientMap &map = m_env.getClientMap();
+			MapSector *sector = map.emergeSector(v2s16(r.p.X, r.p.Z));
 
 			MapBlock *block = sector->getBlockNoCreateNoEx(r.p.Y);
 
@@ -576,6 +577,8 @@ void Client::step(float dtime)
 
 			if (block) {
 				// Delete the old mesh
+				if (block->mesh)
+					map.invalidateMapBlockMesh(block->mesh);
 				delete block->mesh;
 				block->mesh = nullptr;
 				block->solid_sides = r.solid_sides;
@@ -590,10 +593,9 @@ void Client::step(float dtime)
 						if (r.mesh->getMesh(l)->getMeshBufferCount() != 0)
 							is_empty = false;
 
-					// <- invalidate here?
-					if (is_empty)
+					if (is_empty) {
 						delete r.mesh;
-					else {
+					} else {
 						// Replace with the new mesh
 						block->mesh = r.mesh;
 						if (r.urgent)

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -103,6 +103,8 @@ public:
 
 	void renderPostFx(CameraMode cam_mode);
 
+	void invalidateMapBlockMesh(MapBlockMesh *mesh);
+
 	// For debug printing
 	void PrintInfo(std::ostream &out) override;
 

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -36,6 +36,14 @@ namespace irr::video
 	class IVideoDriver;
 }
 
+struct CachedMeshBuffer {
+	std::vector<scene::IMeshBuffer*> buf;
+	u8 age = 0;
+};
+
+using CachedMeshBuffers = std::unordered_map<std::string, CachedMeshBuffer>;
+
+
 /*
 	ClientMap
 
@@ -151,6 +159,7 @@ private:
 	std::vector<MapBlock*> m_keeplist;
 	std::map<v3s16, MapBlock*> m_drawlist_shadow;
 	bool m_needs_update_drawlist;
+	CachedMeshBuffers m_dynamic_buffers;
 
 	bool m_cache_trilinear_filter;
 	bool m_cache_bilinear_filter;

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -39,6 +39,8 @@ namespace irr::video
 struct CachedMeshBuffer {
 	std::vector<scene::IMeshBuffer*> buf;
 	u8 age = 0;
+
+	void drop();
 };
 
 using CachedMeshBuffers = std::unordered_map<std::string, CachedMeshBuffer>;

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -159,13 +159,11 @@ private:
 /*
 	Holds a mesh for a mapblock.
 
-	Besides the SMesh*, this contains information used for animating
-	the vertex positions, colors and texture coordinates of the mesh.
+	Besides the SMesh*, this contains information used fortransparency sorting
+	and texture animation.
 	For example:
-	- cracks [implemented]
-	- day/night transitions [implemented]
-	- animated flowing liquids [not implemented]
-	- animating vertex positions for e.g. axles [not implemented]
+	- cracks
+	- day/night transitions
 */
 class MapBlockMesh
 {
@@ -182,13 +180,17 @@ public:
 	// Returns true if anything has been changed.
 	bool animate(bool faraway, float time, int crack, u32 daynight_ratio);
 
+	/// @warning ClientMap requires that the vertex and index data is not modified
 	scene::IMesh *getMesh()
 	{
 		return m_mesh[0].get();
 	}
 
+	/// @param layer layer index
+	/// @warning ClientMap requires that the vertex and index data is not modified
 	scene::IMesh *getMesh(u8 layer)
 	{
+		assert(layer < MAX_TILE_LAYERS);
 		return m_mesh[layer].get();
 	}
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -103,7 +103,7 @@ void set_default_settings()
 	settings->setDefault("sound_extensions_blacklist", "");
 	settings->setDefault("mesh_generation_interval", "0");
 	settings->setDefault("mesh_generation_threads", "0");
-	settings->setDefault("mesh_buffer_min_vertices", "100");
+	settings->setDefault("mesh_buffer_min_vertices", "300");
 	settings->setDefault("free_move", "false");
 	settings->setDefault("pitch_move", "false");
 	settings->setDefault("fast_move", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -210,7 +210,7 @@ void set_default_settings()
 	settings->setDefault("keymap_slot31", "");
 	settings->setDefault("keymap_slot32", "");
 
-#ifndef NDEBUG
+#if 1
 	// Default keybinds for quicktune in debug builds
 	settings->setDefault("keymap_quicktune_prev", "KEY_HOME");
 	settings->setDefault("keymap_quicktune_next", "KEY_END");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -210,7 +210,7 @@ void set_default_settings()
 	settings->setDefault("keymap_slot31", "");
 	settings->setDefault("keymap_slot32", "");
 
-#if 1
+#ifndef NDEBUG
 	// Default keybinds for quicktune in debug builds
 	settings->setDefault("keymap_quicktune_prev", "KEY_HOME");
 	settings->setDefault("keymap_quicktune_next", "KEY_END");


### PR DESCRIPTION
continuation of #15531

note: there are definitely cases after the previous merged PR where the performance was *lower* than before.
with this PR the impact of the entire optimization should be a clear net positive.

## To do

This PR is Ready for Review.

## How to test

go back to the test scene from #15531

you can revert the last commit for test purposes
1. with `USE_CACHE=1` the fps should be further improved
2. `renderMap(SOLID): drawcalls [#]` should be very close to `renderMap(SOLID): merged buffers [#]`
3. confirm that `CM::transformBuffersToDO: cache hit rate` is 0.999

:warning: if there is animation in your scene e.g. mtg fireflies this won't work exactly. consider devtest.