### PR TITLE
Fix some compiler warnings

### DIFF
--- a/irr/src/os.cpp
+++ b/irr/src/os.cpp
@@ -160,11 +160,12 @@ void Printer::print(const c8 *message, ELOG_LEVEL ll)
 
 	// Android logcat restricts log-output and cuts the rest of the message away. But we want it all.
 	// On my device max-len is 1023 (+ 0 byte). Some websites claim a limit of 4096 so maybe different numbers on different devices.
-	const size_t maxLogLen = 1023;
+	constexpr size_t maxLogLen = 1023;
 	size_t msgLen = strlen(message);
 	size_t start = 0;
 	while (msgLen - start > maxLogLen) {
-		__android_log_print(LogLevel, "Irrlicht", "%.*s\n", maxLogLen, &message[start]);
+		__android_log_print(LogLevel, "Irrlicht", "%.*s\n",
+				static_cast<int>(maxLogLen), &message[start]);
 		start += maxLogLen;
 	}
 	__android_log_print(LogLevel, "Irrlicht", "%s\n", &message[start]);

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -13,7 +13,6 @@
 #include "nodedef.h"
 #include "client/tile.h"
 #include "mesh.h"
-#include <IMeshManipulator.h>
 #include "client/meshgen/collector.h"
 #include "client/renderingengine.h"
 #include "client.h"
@@ -60,12 +59,10 @@ static const auto &quad_indices = quad_indices_02;
 
 const std::string MapblockMeshGenerator::raillike_groupname = "connect_to_raillike";
 
-MapblockMeshGenerator::MapblockMeshGenerator(MeshMakeData *input, MeshCollector *output,
-		scene::IMeshManipulator *mm):
+MapblockMeshGenerator::MapblockMeshGenerator(MeshMakeData *input, MeshCollector *output):
 	data(input),
 	collector(output),
 	nodedef(data->nodedef),
-	meshmanip(mm),
 	blockpos_nodes(data->m_blockpos * MAP_BLOCKSIZE),
 	smooth_liquids(g_settings->getBool("enable_water_reflections"))
 {

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "nodedef.h"
-#include <IMeshManipulator.h>
 
 struct MeshMakeData;
 struct MeshCollector;
@@ -46,8 +45,7 @@ struct LightFrame {
 class MapblockMeshGenerator
 {
 public:
-	MapblockMeshGenerator(MeshMakeData *input, MeshCollector *output,
-			scene::IMeshManipulator *mm);
+	MapblockMeshGenerator(MeshMakeData *input, MeshCollector *output);
 	void generate();
 	void renderSingle(content_t node, u8 param2 = 0x00);
 
@@ -56,7 +54,6 @@ private:
 	MeshCollector *const collector;
 
 	const NodeDefManager *const nodedef;
-	scene::IMeshManipulator *const meshmanip;
 
 	const v3s16 blockpos_nodes;
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -633,8 +633,7 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offs
 	*/
 
 	{
-		MapblockMeshGenerator(data, &collector,
-			client->getSceneManager()->getMeshManipulator()).generate();
+		MapblockMeshGenerator(data, &collector).generate();
 	}
 
 	/*

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -299,8 +299,7 @@ static scene::SMesh *createSpecialNodeMesh(Client *client, MapNode n,
 	MeshMakeData mesh_make_data(client->ndef(), 1);
 	MeshCollector collector(v3f(0.0f * BS), v3f());
 	mesh_make_data.setSmoothLighting(false);
-	MapblockMeshGenerator gen(&mesh_make_data, &collector,
-		client->getSceneManager()->getMeshManipulator());
+	MapblockMeshGenerator gen(&mesh_make_data, &collector);
 
 	if (n.getParam2()) {
 		// keep it

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -105,7 +105,7 @@ void AndroidLogOutput::logRaw(LogLevel lev, std::string_view line)
 	static_assert(ARRLEN(g_level_to_android) == LL_MAX,
 		"mismatch between android and internal loglevels");
 	__android_log_print(g_level_to_android[lev], PROJECT_NAME_C, "%.*s",
-		line.size(), line.data());
+		static_cast<int>(line.size()), line.data());
 }
 #endif
 

--- a/src/unittest/test_content_mapblock.cpp
+++ b/src/unittest/test_content_mapblock.cpp
@@ -175,7 +175,7 @@ void TestMapblockMeshGenerator::testSimpleNode()
 	data.m_vmanip.setNode({0, 0, 0}, {stone, 0, 0});
 
 	MeshCollector col{{}};
-	MapblockMeshGenerator mg{&data, &col, nullptr};
+	MapblockMeshGenerator mg{&data, &col};
 	mg.generate();
 	UASSERTEQ(std::size_t, col.prebuffers[0].size(), 1);
 	UASSERTEQ(std::size_t, col.prebuffers[1].size(), 0);
@@ -197,7 +197,7 @@ void TestMapblockMeshGenerator::testSurroundedNode()
 	data.m_vmanip.setNode({1, 0, 0}, {wood, 0, 0});
 
 	MeshCollector col{{}};
-	MapblockMeshGenerator mg{&data, &col, nullptr};
+	MapblockMeshGenerator mg{&data, &col};
 	mg.generate();
 	UASSERTEQ(std::size_t, col.prebuffers[0].size(), 1);
 	UASSERTEQ(std::size_t, col.prebuffers[1].size(), 0);
@@ -218,7 +218,7 @@ void TestMapblockMeshGenerator::testInterliquidSame()
 	data.m_vmanip.setNode({1, 0, 0}, {water, 0, 0});
 
 	MeshCollector col{{}};
-	MapblockMeshGenerator mg{&data, &col, nullptr};
+	MapblockMeshGenerator mg{&data, &col};
 	mg.generate();
 	UASSERTEQ(std::size_t, col.prebuffers[0].size(), 1);
 	UASSERTEQ(std::size_t, col.prebuffers[1].size(), 0);
@@ -240,7 +240,7 @@ void TestMapblockMeshGenerator::testInterliquidDifferent()
 	data.m_vmanip.setNode({0, 0, 1}, {lava, 0, 0});
 
 	MeshCollector col{{}};
-	MapblockMeshGenerator mg{&data, &col, nullptr};
+	MapblockMeshGenerator mg{&data, &col};
 	mg.generate();
 	UASSERTEQ(std::size_t, col.prebuffers[0].size(), 1);
 	UASSERTEQ(std::size_t, col.prebuffers[1].size(), 0);


### PR DESCRIPTION
Android builds take a while and I was getting bored so I fixed the warnings.

`printf` precision specifiers must be `int`s as the compiler and the `man` page will tell you:

> An  optional  precision,  in  the  form  of a period ('.')  followed by an optional decimal digit string.  Instead of a decimal digit string one may write `*` or `*m$` (for some decimal integer m) to specify that the precision is given in the next argument, or in the m-th argument, respectively, **which must be of type int**.

The `meshmanip` private member was entirely unused, which triggered a warning. Removing it also lets us save an include. Yay.
