### PR TITLE
Fix MSAA and bloom flashing artifacts

### DIFF
--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -23,7 +23,12 @@ void main(void)
 	vec2 uv = varTexCoord.st;
 	vec3 color = texture2D(rendered, uv).rgb;
 	// translate to linear colorspace (approximate)
+#ifdef GL_ES
+	// clamp color to [0,1] range in lieu of centroids
+	color = pow(clamp(color, 0.0, 1.0), vec3(2.2));
+#else
 	color = pow(color, vec3(2.2));
+#endif
 
 	color *= exposureParams.compensationFactor * bloomStrength;
 

--- a/client/shaders/extract_bloom/opengl_fragment.glsl
+++ b/client/shaders/extract_bloom/opengl_fragment.glsl
@@ -23,7 +23,7 @@ void main(void)
 	vec2 uv = varTexCoord.st;
 	vec3 color = texture2D(rendered, uv).rgb;
 	// translate to linear colorspace (approximate)
-	color = pow(clamp(color, 0.0, 1.0), vec3(2.2));
+	color = pow(color, vec3(2.2));
 
 	color *= exposureParams.compensationFactor * bloomStrength;
 

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -42,12 +42,13 @@ varying vec3 worldPosition;
 #ifdef GL_ES
 varying lowp vec4 varColor;
 varying mediump vec2 varTexCoord;
+varying float nightRatio;
 #else
 centroid varying lowp vec4 varColor;
 centroid varying vec2 varTexCoord;
+centroid varying float nightRatio;
 #endif
 varying highp vec3 eyeVec;
-varying float nightRatio;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 #if (defined(ENABLE_WATER_REFLECTIONS) && MATERIAL_WAVING_LIQUID && ENABLE_WAVING_WATER)

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -39,10 +39,11 @@ varying vec3 vPosition;
 // cameraOffset + worldPosition (for large coordinates the limits of float
 // precision must be considered).
 varying vec3 worldPosition;
-varying lowp vec4 varColor;
 #ifdef GL_ES
+varying lowp vec4 varColor;
 varying mediump vec2 varTexCoord;
 #else
+centroid varying lowp vec4 varColor;
 centroid varying vec2 varTexCoord;
 #endif
 varying highp vec3 eyeVec;

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -20,9 +20,11 @@ varying vec3 worldPosition;
 #ifdef GL_ES
 varying lowp vec4 varColor;
 varying mediump vec2 varTexCoord;
+varying float nightRatio;
 #else
 centroid varying lowp vec4 varColor;
 centroid varying vec2 varTexCoord;
+centroid varying float nightRatio;
 #endif
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	// shadow uniforms
@@ -45,7 +47,6 @@ centroid varying vec2 varTexCoord;
 varying float area_enable_parallax;
 
 varying highp vec3 eyeVec;
-varying float nightRatio;
 // Color of the light emitted by the light sources.
 const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
 const float e = 2.718281828459;

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -14,13 +14,14 @@ varying vec3 vPosition;
 // cameraOffset + worldPosition (for large coordinates the limits of float
 // precision must be considered).
 varying vec3 worldPosition;
-varying lowp vec4 varColor;
 // The centroid keyword ensures that after interpolation the texture coordinates
 // lie within the same bounds when MSAA is en- and disabled.
 // This fixes the stripes problem with nearest-neighbor textures and MSAA.
 #ifdef GL_ES
+varying lowp vec4 varColor;
 varying mediump vec2 varTexCoord;
 #else
+centroid varying lowp vec4 varColor;
 centroid varying vec2 varTexCoord;
 #endif
 #ifdef ENABLE_DYNAMIC_SHADOWS


### PR DESCRIPTION
While looking into https://github.com/minetest/minetest/pull/15417#issuecomment-2566166133 I realized that the real reason for the bloom flashing is out-of-bounds sampling with MSAA. The fix that is to use centroids.

- Goal of the PR
Fix bloom flashing artifacts with MSAA the right way

- How does the PR work?
Use centroid to sample the fragment color (and nightratio) at the centroid rather than the center (which might be out of the primitive)

- Does it resolve any reported issue?
Fixed #15453 the right way

## To do

This PR is work in progress.

Need to investigate the remaining flashes.


## How to test
See instructions in #15453 

