### PR TITLE
Fix aabbox3d constructor regression

### DIFF
--- a/irr/include/SMesh.h
+++ b/irr/include/SMesh.h
@@ -133,7 +133,7 @@ struct SMesh final : public IMesh
 	std::vector<u32> TextureSlots;
 
 	//! The bounding box of this mesh
-	core::aabbox3d<f32> BoundingBox{{0, 0, 0}};
+	core::aabbox3d<f32> BoundingBox{-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
 };
 
 } // end namespace scene


### PR DESCRIPTION
Tries to fix #15616

I was able to reproduce this bug with the` testentities:item` object.
This gets fixed, but I don't know if there are more problems.


