### PR TITLE
Fix wireframe mode in opengl3 irr driver

### DIFF
--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -1197,17 +1197,6 @@ void COpenGL3DriverBase::setRenderStates3DMode()
 //! Can be called by an IMaterialRenderer to make its work easier.
 void COpenGL3DriverBase::setBasicRenderStates(const SMaterial &material, const SMaterial &lastmaterial, bool resetAllRenderStates)
 {
-	// fillmode
-	if (Version.Spec != OpenGLSpec::ES && // not supported in gles
-			(resetAllRenderStates ||
-			(lastmaterial.Wireframe != material.Wireframe) ||
-			(lastmaterial.PointCloud != material.PointCloud))) {
-		GL.PolygonMode(GL_FRONT_AND_BACK,
-				material.Wireframe ? GL_LINE :
-				material.PointCloud ? GL_POINT :
-				GL_FILL);
-	}
-
 	// ZBuffer
 	switch (material.ZBuffer) {
 	case ECFN_DISABLED:
@@ -1320,6 +1309,17 @@ void COpenGL3DriverBase::setBasicRenderStates(const SMaterial &material, const S
 
 		CacheHandler->setBlendFuncSeparate(getGLBlend(srcRGBFact), getGLBlend(dstRGBFact),
 				getGLBlend(srcAlphaFact), getGLBlend(dstAlphaFact));
+	}
+
+	// fillmode
+	if (Version.Spec != OpenGLSpec::ES && // not supported in gles
+			(resetAllRenderStates ||
+			(lastmaterial.Wireframe != material.Wireframe) ||
+			(lastmaterial.PointCloud != material.PointCloud))) {
+		GL.PolygonMode(GL_FRONT_AND_BACK,
+				material.Wireframe ? GL_LINE :
+				material.PointCloud ? GL_POINT :
+				GL_FILL);
 	}
 
 	// Polygon Offset

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -1032,9 +1032,7 @@ void COpenGL3DriverBase::drawGeneric(const void *vertices, const void *indexList
 		GL.DrawElements(GL_TRIANGLE_FAN, primitiveCount + 2, indexSize, indexList);
 		break;
 	case scene::EPT_TRIANGLES:
-		GL.DrawElements((LastMaterial.Wireframe) ? GL_LINES : (LastMaterial.PointCloud) ? GL_POINTS
-																						: GL_TRIANGLES,
-				primitiveCount * 3, indexSize, indexList);
+		GL.DrawElements(GL_TRIANGLES, primitiveCount * 3, indexSize, indexList);
 		break;
 	default:
 		break;
@@ -1199,6 +1197,17 @@ void COpenGL3DriverBase::setRenderStates3DMode()
 //! Can be called by an IMaterialRenderer to make its work easier.
 void COpenGL3DriverBase::setBasicRenderStates(const SMaterial &material, const SMaterial &lastmaterial, bool resetAllRenderStates)
 {
+	// fillmode
+	if (Version.Spec != OpenGLSpec::ES && // not supported in gles
+			(resetAllRenderStates ||
+			(lastmaterial.Wireframe != material.Wireframe) ||
+			(lastmaterial.PointCloud != material.PointCloud))) {
+		GL.PolygonMode(GL_FRONT_AND_BACK,
+				material.Wireframe ? GL_LINE :
+				material.PointCloud ? GL_POINT :
+				GL_FILL);
+	}
+
 	// ZBuffer
 	switch (material.ZBuffer) {
 	case ECFN_DISABLED:

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -1314,8 +1314,8 @@ void COpenGL3DriverBase::setBasicRenderStates(const SMaterial &material, const S
 	// fillmode
 	if (Version.Spec != OpenGLSpec::ES && // not supported in gles
 			(resetAllRenderStates ||
-			(lastmaterial.Wireframe != material.Wireframe) ||
-			(lastmaterial.PointCloud != material.PointCloud))) {
+			lastmaterial.Wireframe != material.Wireframe ||
+			lastmaterial.PointCloud != material.PointCloud)) {
 		GL.PolygonMode(GL_FRONT_AND_BACK,
 				material.Wireframe ? GL_LINE :
 				material.PointCloud ? GL_POINT :

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2261,7 +2261,9 @@ void Game::toggleDebug()
 	else if (state == 2)
 		m_game_ui->showTranslatedStatusText("Profiler graph shown");
 	else if (state == 3)
-		m_game_ui->showTranslatedStatusText("Wireframe shown");
+		m_game_ui->showTranslatedStatusText(driver->getDriverType() == video::EDT_OGLES2 ?
+				"Wireframe shown, but not supported in OpenGL ES" :
+				"Wireframe shown");
 	else if (state == 4)
 		m_game_ui->showTranslatedStatusText("Bounding boxes shown");
 	else

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2256,18 +2256,20 @@ void Game::toggleDebug()
 	smgr->setGlobalDebugData(state == 4 ? bbox_debug_flag : 0,
 			state == 4 ? 0 : bbox_debug_flag);
 
-	if (state == 1)
+	if (state == 1) {
 		m_game_ui->showTranslatedStatusText("Debug info shown");
-	else if (state == 2)
+	} else if (state == 2) {
 		m_game_ui->showTranslatedStatusText("Profiler graph shown");
-	else if (state == 3)
-		m_game_ui->showTranslatedStatusText(driver->getDriverType() == video::EDT_OGLES2 ?
-				"Wireframe shown, but not supported in OpenGL ES" :
-				"Wireframe shown");
-	else if (state == 4)
+	} else if (state == 3) {
+		if (driver->getDriverType() == video::EDT_OGLES2)
+			m_game_ui->showTranslatedStatusText("Wireframe not supported by video driver");
+		else
+			m_game_ui->showTranslatedStatusText("Wireframe shown");
+	} else if (state == 4) {
 		m_game_ui->showTranslatedStatusText("Bounding boxes shown");
-	else
+	} else {
 		m_game_ui->showTranslatedStatusText("All debug info hidden");
+	}
 }
 
 


### PR DESCRIPTION
`GL_LINES` isn't suitable, because it makes lines between pairs of 2 vertices, not loops around 3 vertices.
Support for OpenGL ES isn't simple, as it has no `glPolygonMode`. And showing broken wireframe (i.e. with `GL_LINES`) would cause confusion.

## To do

This PR is a Ready for Review.

## How to test

* Use wireframe mode.
* Try with `video_driver` `opengl3` and `ogles2` (`-DENABLE_GLES2=1`).