### PR TITLE
Eliminate superfluous null check in `CGUIEnvironment::getNextElement`

### DIFF
--- a/irr/src/CGUIEnvironment.cpp
+++ b/irr/src/CGUIEnvironment.cpp
@@ -948,7 +948,7 @@ IGUIElement *CGUIEnvironment::getNextElement(bool reverse, bool group)
 			// this element is not part of the tab cycle,
 			// but its parent might be...
 			IGUIElement *el = Focus;
-			while (el && el->getParent() && startOrder == -1) {
+			while (el->getParent() && startOrder == -1) {
 				el = el->getParent();
 				startOrder = el->getTabOrder();
 			}


### PR DESCRIPTION
The variable `Focus` was already checked before `el` was initialized to `Focus`, so `el` can not be null.

Coverity CID 1033005

## To do

Ready for Review.