### PR TITLE
Remove or restrict some client settings

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -634,8 +634,7 @@ sound_volume (Volume) float 0.8 0.0 1.0
 #    Volume multiplier when the window is unfocused.
 sound_volume_unfocused (Volume when unfocused) float 0.3 0.0 1.0
 
-#    Whether to mute sounds. You can unmute sounds at any time, unless the
-#    sound system is disabled (enable_sound=false).
+#    Whether to mute sounds. You can unmute sounds at any time.
 #    In-game, you can toggle the mute state with the mute key or by using the
 #    pause menu.
 mute_sound (Mute sound) bool false
@@ -2310,12 +2309,6 @@ show_technical_names (Show technical names) bool false
 
 #    Controlled by a checkbox in the settings menu.
 show_advanced (Show advanced settings) bool false
-
-#    Enables the sound system.
-#    If disabled, this completely disables all sounds everywhere and the in-game
-#    sound controls will be non-functional.
-#    Changing this setting requires a restart.
-enable_sound (Sound) bool true
 
 #    Key for moving the player forward.
 keymap_forward (Forward key) key KEY_KEY_W

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -377,17 +377,12 @@ fog_start (Fog start) float 0.4 0.0 0.99
 
 [**Clouds]
 
-#    Clouds are a client-side effect.
-enable_clouds (Clouds) bool true
-
-#    Use 3D cloud look instead of flat.
-#
-#    Requires: enable_clouds
+#    Allow clouds to look 3D instead of flat.
 enable_3d_clouds (3D clouds) bool true
 
 #   Use smooth cloud shading.
 #
-#   Requires: enable_3d_clouds, enable_clouds
+#   Requires: enable_3d_clouds
 soft_clouds (Soft clouds) bool false
 
 [**Filtering and Antialiasing]
@@ -471,9 +466,6 @@ smooth_lighting (Smooth lighting) bool true
 #    Enables tradeoffs that reduce CPU load or increase rendering performance
 #    at the expense of minor visual glitches that do not impact game playability.
 performance_tradeoffs (Tradeoffs for performance) bool false
-
-#    Adds particles when digging a node.
-enable_particles (Digging particles) bool true
 
 
 [**Waving Nodes]
@@ -683,12 +675,6 @@ formspec_fullscreen_bg_color (Formspec Full-Screen Background Color) string (0,0
 #    filtered in software, but some images are generated directly
 #    to hardware (e.g. render-to-texture for nodes in inventory).
 gui_scaling_filter (GUI scaling filter) bool false
-
-#    When gui_scaling_filter_txr2img is true, copy those images
-#    from hardware to software for scaling.  When false, fall back
-#    to the old scaling method, for video drivers that don't
-#    properly support downloading textures back from hardware.
-gui_scaling_filter_txr2img (GUI scaling filter txr2img) bool true
 
 #    Delay showing tooltips, stated in milliseconds.
 tooltip_show_delay (Tooltip delay) int 400 0 18446744073709551615
@@ -1844,10 +1830,7 @@ transparency_sorting_group_by_buffers (Transparency Sorting Group by Buffers) bo
 
 #    Radius of cloud area stated in number of 64 node cloud squares.
 #    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.
-cloud_radius (Cloud radius) int 12 1 62
-
-#    Whether node texture animations should be desynchronized per mapblock.
-desynchronize_mapblock_texture_animation (Desynchronize block animation) bool false
+cloud_radius (Cloud radius) int 12 8 62
 
 #    Delay between mesh updates on the client in ms. Increasing this will slow
 #    down the rate of mesh updates, thus reducing jitter on slower clients.
@@ -2101,9 +2084,6 @@ max_block_send_distance (Max block send distance) int 12 1 65535
 #    Set this to -1 to disable the limit.
 max_forceloaded_blocks (Maximum forceloaded blocks) int 16 -1
 
-#    Interval of sending time of day to clients, stated in seconds.
-time_send_interval (Time send interval) float 5.0 0.001
-
 #    Interval of saving important changes in the world, stated in seconds.
 server_map_save_interval (Map save interval) float 5.3 0.001
 
@@ -2112,7 +2092,7 @@ server_map_save_interval (Map save interval) float 5.3 0.001
 server_unload_unused_data_timeout (Unload unused server data) int 29 0 4294967295
 
 #    Maximum number of statically stored objects in a block.
-max_objects_per_block (Maximum objects per block) int 256 1 65535
+max_objects_per_block (Maximum objects per block) int 256 256 65535
 
 #    Length of time between active block management cycles, stated in seconds.
 active_block_mgmt_interval (Active block management interval) float 2.0 0.0

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -91,8 +91,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	init_args(start_data, cmd_args);
 
 #if USE_SOUND
-	if (g_settings->getBool("enable_sound"))
-		g_sound_manager_singleton = createSoundManagerSingleton();
+	g_sound_manager_singleton = createSoundManagerSingleton();
 #endif
 
 	if (!init_engine())

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -445,8 +445,8 @@ void Clouds::readSettings()
 	// chosen to avoid exactly that.
 	// refer to vertex_count in updateMesh()
 	m_enable_3d = g_settings->getBool("enable_3d_clouds");
-	const u16 maximum = m_enable_3d ? 62 : 25;
-	m_cloud_radius_i = rangelim(g_settings->getU16("cloud_radius"), 1, maximum);
+	const u16 maximum = !m_enable_3d ? 62 : 25;
+	m_cloud_radius_i = rangelim(g_settings->getU16("cloud_radius"), 8, maximum);
 
 	invalidateMesh();
 }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1125,7 +1125,7 @@ bool Game::init(
 bool Game::initSound()
 {
 #if USE_SOUND
-	if (g_settings->getBool("enable_sound") && g_sound_manager_singleton.get()) {
+	if (g_sound_manager_singleton.get()) {
 		infostream << "Attempting to use OpenAL audio" << std::endl;
 		sound_manager = createOpenALSoundManager(g_sound_manager_singleton.get(),
 				std::make_unique<SoundFallbackPathProvider>());
@@ -1859,34 +1859,22 @@ void Game::processKeyInput()
 		toggleNoClip();
 #if USE_SOUND
 	} else if (wasKeyDown(KeyType::MUTE)) {
-		if (g_settings->getBool("enable_sound")) {
-			bool new_mute_sound = !g_settings->getBool("mute_sound");
-			g_settings->setBool("mute_sound", new_mute_sound);
-			if (new_mute_sound)
-				m_game_ui->showTranslatedStatusText("Sound muted");
-			else
-				m_game_ui->showTranslatedStatusText("Sound unmuted");
-		} else {
-			m_game_ui->showTranslatedStatusText("Sound system is disabled");
-		}
+		bool new_mute_sound = !g_settings->getBool("mute_sound");
+		g_settings->setBool("mute_sound", new_mute_sound);
+		if (new_mute_sound)
+			m_game_ui->showTranslatedStatusText("Sound muted");
+		else
+			m_game_ui->showTranslatedStatusText("Sound unmuted");
 	} else if (wasKeyDown(KeyType::INC_VOLUME)) {
-		if (g_settings->getBool("enable_sound")) {
-			float new_volume = g_settings->getFloat("sound_volume", 0.0f, 0.9f) + 0.1f;
-			g_settings->setFloat("sound_volume", new_volume);
-			std::wstring msg = fwgettext("Volume changed to %d%%", myround(new_volume * 100));
-			m_game_ui->showStatusText(msg);
-		} else {
-			m_game_ui->showTranslatedStatusText("Sound system is disabled");
-		}
+		float new_volume = g_settings->getFloat("sound_volume", 0.0f, 0.9f) + 0.1f;
+		g_settings->setFloat("sound_volume", new_volume);
+		std::wstring msg = fwgettext("Volume changed to %d%%", myround(new_volume * 100));
+		m_game_ui->showStatusText(msg);
 	} else if (wasKeyDown(KeyType::DEC_VOLUME)) {
-		if (g_settings->getBool("enable_sound")) {
-			float new_volume = g_settings->getFloat("sound_volume", 0.1f, 1.0f) - 0.1f;
-			g_settings->setFloat("sound_volume", new_volume);
-			std::wstring msg = fwgettext("Volume changed to %d%%", myround(new_volume * 100));
-			m_game_ui->showStatusText(msg);
-		} else {
-			m_game_ui->showTranslatedStatusText("Sound system is disabled");
-		}
+		float new_volume = g_settings->getFloat("sound_volume", 0.1f, 1.0f) - 0.1f;
+		g_settings->setFloat("sound_volume", new_volume);
+		std::wstring msg = fwgettext("Volume changed to %d%%", myround(new_volume * 100));
+		m_game_ui->showStatusText(msg);
 #else
 	} else if (wasKeyDown(KeyType::MUTE) || wasKeyDown(KeyType::INC_VOLUME)
 			|| wasKeyDown(KeyType::DEC_VOLUME)) {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -741,7 +741,6 @@ private:
 	 *       (as opposed to the this local caching). This can be addressed in
 	 *       a later release.
 	 */
-	bool m_cache_disable_escape_sequences;
 	bool m_cache_doubletap_jump;
 	bool m_cache_enable_joysticks;
 	bool m_cache_enable_fog;
@@ -784,8 +783,6 @@ Game::Game() :
 	m_game_ui(new GameUI())
 {
 	g_settings->registerChangedCallback("chat_log_level",
-		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("disable_escape_sequences",
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("doubletap_jump",
 		&settingChangedCallback, this);
@@ -2880,10 +2877,7 @@ void Game::updateChat(f32 dtime)
 	std::vector<LogEntry> entries = m_chat_log_buf.take();
 	for (const auto& entry : entries) {
 		std::string line;
-		if (!m_cache_disable_escape_sequences) {
-			line.append(color_for(entry.level));
-		}
-		line.append(entry.combined);
+		line.append(color_for(entry.level)).append(entry.combined);
 		chat_backend->addMessage(L"", utf8_to_wide(line));
 	}
 
@@ -4067,7 +4061,6 @@ void Game::readSettings()
 	}
 	m_chat_log_buf.setLogLevel(chat_log_level);
 
-	m_cache_disable_escape_sequences     = g_settings->getBool("disable_escape_sequences");
 	m_cache_doubletap_jump               = g_settings->getBool("doubletap_jump");
 	m_cache_enable_joysticks             = g_settings->getBool("enable_joysticks");
 	m_cache_enable_fog                   = g_settings->getBool("enable_fog");

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -743,9 +743,7 @@ private:
 	 */
 	bool m_cache_disable_escape_sequences;
 	bool m_cache_doubletap_jump;
-	bool m_cache_enable_clouds;
 	bool m_cache_enable_joysticks;
-	bool m_cache_enable_particles;
 	bool m_cache_enable_fog;
 	bool m_cache_enable_noclip;
 	bool m_cache_enable_free_move;
@@ -791,11 +789,7 @@ Game::Game() :
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("doubletap_jump",
 		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("enable_clouds",
-		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("enable_joysticks",
-		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("enable_particles",
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("enable_fog",
 		&settingChangedCallback, this);
@@ -1292,8 +1286,7 @@ bool Game::createClient(const GameStartData &start_data)
 
 	/* Clouds
 	 */
-	if (m_cache_enable_clouds)
-		clouds = make_irr<Clouds>(smgr, shader_src, -1, rand());
+	clouds = make_irr<Clouds>(smgr, shader_src, -1, myrand());
 
 	/* Skybox
 	 */
@@ -2851,9 +2844,6 @@ void Game::handleClientEvent_OverrideDayNigthRatio(ClientEvent *event,
 
 void Game::handleClientEvent_CloudParams(ClientEvent *event, CameraOrientation *cam)
 {
-	if (!clouds)
-		return;
-
 	clouds->setDensity(event->cloud_params.density);
 	clouds->setColorBright(video::SColor(event->cloud_params.color_bright));
 	clouds->setColorAmbient(video::SColor(event->cloud_params.color_ambient));
@@ -2978,8 +2968,7 @@ void Game::updateCamera(f32 dtime)
 			client->updateCameraOffset(camera_offset);
 			client->getEnv().updateCameraOffset(camera_offset);
 
-			if (clouds)
-				clouds->updateCameraOffset(camera_offset);
+			clouds->updateCameraOffset(camera_offset);
 		}
 	}
 }
@@ -3638,10 +3627,8 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 	} else {
 		runData.dig_time_complete = params.time;
 
-		if (m_cache_enable_particles) {
-			client->getParticleManager()->addNodeParticle(client,
-					player, nodepos, n, features);
-		}
+		client->getParticleManager()->addNodeParticle(client,
+				player, nodepos, n, features);
 	}
 
 	if (!runData.digging) {
@@ -3726,11 +3713,8 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 
 		client->interact(INTERACT_DIGGING_COMPLETED, pointed);
 
-		if (m_cache_enable_particles) {
-			client->getParticleManager()->addDiggingParticles(client,
-				player, nodepos, n, features);
-		}
-
+		client->getParticleManager()->addDiggingParticles(client,
+			player, nodepos, n, features);
 
 		// Send event to trigger sound
 		client->getEventManager()->put(new NodeDugEvent(nodepos, n));
@@ -3821,8 +3805,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	/*
 		Update clouds
 	*/
-	if (clouds)
-		updateClouds(dtime);
+	updateClouds(dtime);
 
 	/*
 		Update particles
@@ -4086,9 +4069,7 @@ void Game::readSettings()
 
 	m_cache_disable_escape_sequences     = g_settings->getBool("disable_escape_sequences");
 	m_cache_doubletap_jump               = g_settings->getBool("doubletap_jump");
-	m_cache_enable_clouds                = g_settings->getBool("enable_clouds");
 	m_cache_enable_joysticks             = g_settings->getBool("enable_joysticks");
-	m_cache_enable_particles             = g_settings->getBool("enable_particles");
 	m_cache_enable_fog                   = g_settings->getBool("enable_fog");
 	m_cache_mouse_sensitivity            = g_settings->getFloat("mouse_sensitivity", 0.001f, 10.0f);
 	m_cache_joystick_frustum_sensitivity = std::max(g_settings->getFloat("joystick_frustum_sensitivity"), 0.001f);

--- a/src/client/game_formspec.cpp
+++ b/src/client/game_formspec.cpp
@@ -333,12 +333,11 @@ void GameFormSpec::showPauseMenu()
 
 #ifndef __ANDROID__
 #if USE_SOUND
-	if (g_settings->getBool("enable_sound")) {
-		os << "button_exit[4," << (ypos++) << ";3,0.5;btn_sound;"
-			<< strgettext("Sound Volume") << "]";
-	}
+	os << "button_exit[4," << (ypos++) << ";3,0.5;btn_sound;"
+		<< strgettext("Sound Volume") << "]";
 #endif
 #endif
+
 	if (g_touchcontrols) {
 		os << "button_exit[4," << (ypos++) << ";3,0.5;btn_touchscreen_layout;"
 			<< strgettext("Touchscreen Layout")  << "]";

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -94,8 +94,7 @@ video::ITexture *guiScalingResizeCached(video::IVideoDriver *driver,
 	auto it_img = g_imgCache.find(origname);
 	video::IImage *srcimg = (it_img != g_imgCache.end()) ? it_img->second : nullptr;
 	if (!srcimg) {
-		if (!g_settings->getBool("gui_scaling_filter_txr2img"))
-			return src;
+		// Download image from GPU
 		srcimg = driver->createImageFromData(src->getColorFormat(),
 			src->getSize(), src->lock(video::ETLM_READ_ONLY), false);
 		src->unlock();

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -640,9 +640,6 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offs
 		Convert MeshCollector to SMesh
 	*/
 
-	const bool desync_animations = g_settings->getBool(
-		"desynchronize_mapblock_texture_animation");
-
 	m_bounding_radius = std::sqrt(collector.m_bounding_radius_sq);
 
 	for (int layer = 0; layer < MAX_TILE_LAYERS; layer++) {
@@ -679,16 +676,7 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offs
 				auto &info = m_animation_info[{layer, i}];
 				info.tile = p.layer;
 				info.frame = 0;
-				if (desync_animations) {
-					// Get starting position from noise
-					info.frame_offset =
-							100000 * (2.0 + noise3d(
-							data->m_blockpos.X, data->m_blockpos.Y,
-							data->m_blockpos.Z, 0));
-				} else {
-					// Play all synchronized
-					info.frame_offset = 0;
-				}
+				info.frame_offset = 0;
 				// Replace tile texture with the first animation frame
 				p.layer.texture = (*p.layer.frames)[0].texture;
 			}

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -31,7 +31,8 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 
 	u32 vertex_count = p.vertices.size();
 	for (u32 i = 0; i < numVertices; i++) {
-		p.vertices.emplace_back(vertices[i].Pos + offset, vertices[i].Normal,
+		auto lo = layernum == 1 ? (vertices[i].Normal * 1e-2f) : v3f();
+		p.vertices.emplace_back(vertices[i].Pos + offset + lo, vertices[i].Normal,
 				vertices[i].Color, scale * vertices[i].TCoords);
 		m_bounding_radius_sq = std::max(m_bounding_radius_sq,
 				(vertices[i].Pos - m_center_pos).getLengthSQ());
@@ -69,7 +70,8 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 		video::SColor color = c;
 		if (!light_source)
 			applyFacesShading(color, vertices[i].Normal);
-		auto vpos = vertices[i].Pos + pos + offset;
+		auto lo = layernum == 1 ? (vertices[i].Normal * 1e-2f) : v3f();
+		auto vpos = vertices[i].Pos + pos + offset + lo;
 		p.vertices.emplace_back(vpos, vertices[i].Normal, color,
 				scale * vertices[i].TCoords);
 		m_bounding_radius_sq = std::max(m_bounding_radius_sq,

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -31,8 +31,7 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 
 	u32 vertex_count = p.vertices.size();
 	for (u32 i = 0; i < numVertices; i++) {
-		auto lo = layernum == 1 ? (vertices[i].Normal * 1e-2f) : v3f();
-		p.vertices.emplace_back(vertices[i].Pos + offset + lo, vertices[i].Normal,
+		p.vertices.emplace_back(vertices[i].Pos + offset, vertices[i].Normal,
 				vertices[i].Color, scale * vertices[i].TCoords);
 		m_bounding_radius_sq = std::max(m_bounding_radius_sq,
 				(vertices[i].Pos - m_center_pos).getLengthSQ());
@@ -70,8 +69,7 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 		video::SColor color = c;
 		if (!light_source)
 			applyFacesShading(color, vertices[i].Normal);
-		auto lo = layernum == 1 ? (vertices[i].Normal * 1e-2f) : v3f();
-		auto vpos = vertices[i].Pos + pos + offset + lo;
+		auto vpos = vertices[i].Pos + pos + offset;
 		p.vertices.emplace_back(vpos, vertices[i].Normal, color,
 				scale * vertices[i].TCoords);
 		m_bounding_radius_sq = std::max(m_bounding_radius_sq,

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -411,7 +411,6 @@ void set_default_settings()
 #endif
 
 	// Server
-	settings->setDefault("disable_escape_sequences", "false");
 	settings->setDefault("strip_color_codes", "false");
 #ifndef NDEBUG
 	settings->setDefault("random_mod_load_order", "true");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -82,7 +82,6 @@ void set_default_settings()
 
 	// Client
 	settings->setDefault("address", "");
-	settings->setDefault("enable_sound", "true");
 #if defined(__unix__) && !defined(__APPLE__) && !defined (__ANDROID__)
 	// On Linux+X11 (not Linux+Wayland or Linux+XWayland), I've encountered a bug
 	// where fake mouse events were generated from touch events if in relative

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -270,7 +270,6 @@ void set_default_settings()
 	settings->setDefault("cinematic", "false");
 	settings->setDefault("camera_smoothing", "0.0");
 	settings->setDefault("cinematic_camera_smoothing", "0.7");
-	settings->setDefault("enable_clouds", "true");
 	settings->setDefault("view_bobbing_amount", "1.0");
 	settings->setDefault("fall_bobbing_amount", "0.03");
 	settings->setDefault("enable_3d_clouds", "true");
@@ -292,14 +291,11 @@ void set_default_settings()
 	settings->setDefault("hud_scaling", "1.0");
 	settings->setDefault("gui_scaling", "1.0");
 	settings->setDefault("gui_scaling_filter", "false");
-	settings->setDefault("gui_scaling_filter_txr2img", "true");
 	settings->setDefault("smooth_scrolling", "true");
-	settings->setDefault("desynchronize_mapblock_texture_animation", "false");
 	settings->setDefault("hud_hotbar_max_width", "1.0");
 	settings->setDefault("enable_local_map_saving", "false");
 	settings->setDefault("show_entity_selectionbox", "false");
 	settings->setDefault("ambient_occlusion_gamma", "1.8");
-	settings->setDefault("enable_particles", "true");
 	settings->setDefault("arm_inertia", "true");
 	settings->setDefault("show_nametag_backgrounds", "true");
 	settings->setDefault("show_block_bounds_radius_near", "4");
@@ -435,7 +431,6 @@ void set_default_settings()
 	settings->setDefault("protocol_version_min", "1");
 	settings->setDefault("player_transfer_distance", "0");
 	settings->setDefault("max_simultaneous_block_sends_per_client", "40");
-	settings->setDefault("time_send_interval", "5");
 
 	settings->setDefault("motd", "");
 	settings->setDefault("max_users", "15");

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -130,7 +130,7 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 
 	// create soundmanager
 #if USE_SOUND
-	if (g_settings->getBool("enable_sound") && g_sound_manager_singleton.get()) {
+	if (g_sound_manager_singleton.get()) {
 		m_sound_manager = createOpenALSoundManager(g_sound_manager_singleton.get(),
 				std::make_unique<MenuMusicFetcher>());
 	}

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -73,6 +73,12 @@ MapBlock::~MapBlock()
 	porting::TrackFreedMemory(sizeof(MapNode) * nodecount);
 }
 
+static inline size_t get_max_objects_per_block()
+{
+	u16 ret = g_settings->getU16("max_objects_per_block");
+	return MYMAX(256, ret);
+}
+
 bool MapBlock::onObjectsActivation()
 {
 	// Ignore if no stored objects (to not set changed flag)
@@ -84,7 +90,7 @@ bool MapBlock::onObjectsActivation()
 			<< "activating " << count << " objects in block " << getPos()
 			<< std::endl;
 
-	if (count > g_settings->getU16("max_objects_per_block")) {
+	if (count > get_max_objects_per_block()) {
 		errorstream << "suspiciously large amount of objects detected: "
 			<< count << " in " << getPos() << "; removing all of them."
 			<< std::endl;
@@ -99,7 +105,7 @@ bool MapBlock::onObjectsActivation()
 
 bool MapBlock::saveStaticObject(u16 id, const StaticObject &obj, u32 reason)
 {
-	if (m_static_objects.getStoredSize() >= g_settings->getU16("max_objects_per_block")) {
+	if (m_static_objects.getStoredSize() >= get_max_objects_per_block()) {
 		warningstream << "MapBlock::saveStaticObject(): Trying to store id = " << id
 				<< " statically but block " << getPos() << " already contains "
 				<< m_static_objects.getStoredSize() << " objects."

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -650,9 +650,10 @@ void Server::AsyncRunStep(float dtime, bool initial_step)
 		Send to clients at constant intervals
 	*/
 
+	static const float time_send_interval = 5.0f;
 	m_time_of_day_send_timer -= dtime;
-	if (m_time_of_day_send_timer < 0.0) {
-		m_time_of_day_send_timer = g_settings->getFloat("time_send_interval");
+	if (m_time_of_day_send_timer < 0) {
+		m_time_of_day_send_timer = time_send_interval;
 		u16 time = m_env->getTimeOfDay();
 		float time_speed = g_settings->getFloat("time_speed");
 		SendTimeOfDay(PEER_ID_INEXISTENT, time, time_speed);


### PR DESCRIPTION
removed:
* enable_clouds: shouldn't be user choice, no reason to disable
* enable_particles: misnamed (only affects dig particles), shouldn't be user choice, no reason to disable
* gui_scaling_filter_txr2img: no reason to disable
* desynchronize_mapblock_texture_animation: shouldn't be user choice, bad effects
  * this fixes #13999
* time_send_interval: pointless to customize as the engine knows best
* enable_sound: no reason to disable (can mute instead)
* disable_escape_sequences: misnamed (affects colored log pushed to client chat), undocumented
  * added in #15255. who needs this?

restricted:
* max_objects_per_block: minimum of 256
* cloud_radius: minimum of 8 so user can't disable clouds entirely