### PR TITLE
[no sq] Use polygon offset to fix z-fighting for overlay tiles

### DIFF
--- a/irr/include/SMaterial.h
+++ b/irr/include/SMaterial.h
@@ -304,11 +304,7 @@ public:
 
 	//! A constant z-buffer offset for a polygon/line/point
 	/** The range of the value is driver specific.
-	On OpenGL you get units which are multiplied by the smallest value that is guaranteed to produce a resolvable offset.
-	On D3D9 you can pass a range between -1 and 1. But you should likely divide it by the range of the depthbuffer.
-	Like dividing by 65535.0 for a 16 bit depthbuffer. Thought it still might produce too large of a bias.
-	Some article (https://aras-p.info/blog/2008/06/12/depth-bias-and-the-power-of-deceiving-yourself/)
-	recommends multiplying by 2.0*4.8e-7 (and strangely on both 16 bit and 24 bit).	*/
+	On OpenGL you get units which are multiplied by the smallest value that is guaranteed to produce a resolvable offset. */
 	f32 PolygonOffsetDepthBias;
 
 	//! Variable Z-Buffer offset based on the slope of the polygon.

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -1313,7 +1313,17 @@ void COpenGL3DriverBase::setBasicRenderStates(const SMaterial &material, const S
 				getGLBlend(srcAlphaFact), getGLBlend(dstAlphaFact));
 	}
 
-	// TODO: Polygon Offset. Not sure if it was left out deliberately or if it won't work with this driver.
+	// Polygon Offset
+	if (resetAllRenderStates ||
+			lastmaterial.PolygonOffsetDepthBias != material.PolygonOffsetDepthBias ||
+			lastmaterial.PolygonOffsetSlopeScale != material.PolygonOffsetSlopeScale) {
+		if (material.PolygonOffsetDepthBias || material.PolygonOffsetSlopeScale) {
+			GL.Enable(GL.POLYGON_OFFSET_FILL);
+			GL.PolygonOffset(material.PolygonOffsetSlopeScale, material.PolygonOffsetDepthBias);
+		} else {
+			GL.Disable(GL.POLYGON_OFFSET_FILL);
+		}
+	}
 
 	if (resetAllRenderStates || lastmaterial.Thickness != material.Thickness)
 		GL.LineWidth(core::clamp(static_cast<GLfloat>(material.Thickness), DimAliasedLine[0], DimAliasedLine[1]));

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -702,6 +702,16 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offs
 				tex.MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
 				tex.MagFilter = video::ETMAGF_NEAREST;
 			});
+			/*
+			 * The second layer is for overlays, but uses the same vertex positions
+			 * as the first, which quickly leads to z-fighting.
+			 * To fix this we can offset the polygons in the direction of the camera.
+			 * This only affects the depth buffer and leads to no visual gaps in geometry.
+			 */
+			if (layer == 1) {
+				material.PolygonOffsetSlopeScale = -1;
+				material.PolygonOffsetDepthBias = -1;
+			}
 
 			{
 				material.MaterialType = m_shdrsrc->getShaderInfo(

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -50,6 +50,11 @@ struct FrameSpec
 	video::ITexture *texture = nullptr;
 };
 
+/**
+ * We have two tile layers:
+ * layer 0 = base
+ * layer 1 = overlay
+ */
 #define MAX_TILE_LAYERS 2
 
 //! Defines a layer of a tile.

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -244,6 +244,7 @@ void WieldMeshSceneNode::setCube(const ContentFeatures &f,
 	scene::SMesh *copy = cloneMesh(cubemesh);
 	cubemesh->drop();
 	postProcessNodeMesh(copy, f, false, &m_material_type, &m_colors, true);
+	copy->recalculateBoundingBox();
 	changeToMesh(copy);
 	copy->drop();
 	m_meshnode->setScale(wield_scale * WIELD_SCALE_FACTOR);
@@ -279,6 +280,7 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 		mesh->addMeshBuffer(copy);
 		copy->drop();
 	}
+	mesh->recalculateBoundingBox();
 	changeToMesh(mesh);
 	mesh->drop();
 
@@ -355,6 +357,7 @@ static scene::SMesh *createSpecialNodeMesh(Client *client, MapNode n,
 			colors->emplace_back(p.layer.has_color, p.layer.color);
 		}
 	}
+	mesh->recalculateBoundingBox();
 	return mesh;
 }
 

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -143,14 +143,3 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result);
 
 scene::SMesh *getExtrudedMesh(ITextureSource *tsrc, const std::string &imagename,
 		const std::string &overlay_name);
-
-/*!
- * Applies overlays, textures and optionally materials to the given mesh and
- * extracts tile colors for colorization.
- * \param mattype overrides the buffer's material type, but can also
- * be NULL to leave the original material.
- * \param colors returns the colors of the mesh buffers in the mesh.
- */
-void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
-		bool set_material, const video::E_MATERIAL_TYPE *mattype,
-		std::vector<ItemPartColor> *colors, bool apply_scale = false);


### PR DESCRIPTION
fixes #15632

(third commit unrelated)

## To do

This PR is Ready for Review.

## How to test

1. join MTG world with the following code:
```lua
core.override_item("default:dirt_with_grass", {
	tiles = {"default_grass.png", "default_dirt.png"},
	overlay_tiles = {"", "", {name = "default_grass_side.png", tileable_vertical = false}},
})
```
2. look at grass at various distances (ideally you have a scene that showed z-fighting before)
