### PR TITLE
Fix show_debug setting causing inconsistency between debug control and shown debug info

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -896,6 +896,10 @@ bool Game::startup(bool *kill,
 	runData.time_from_last_punch = 10.0;
 
 	m_game_ui->initFlags();
+	if (g_settings->getBool("show_debug")) {
+		m_flags.debug_state = 1;
+		m_game_ui->m_flags.show_minimal_debug = true;
+	}
 
 	m_first_loop_after_window_activation = true;
 

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -215,7 +215,6 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 void GameUI::initFlags()
 {
 	m_flags = GameUI::Flags();
-	m_flags.show_minimal_debug = g_settings->getBool("show_debug");
 }
 
 void GameUI::showTranslatedStatusText(const char *str)


### PR DESCRIPTION
Fixes a mini bug from #15622.
cc @sfan5 

## To do

This PR is a Ready for Review.

## How to test

* use `show_debug=true`
* press F5
* Expected: it shows profiler graph. Bug: it says "debug info shown"