### PR TITLE
Revert "Rename getGameMinetestConfig to getGameConfig"

### DIFF
--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -22,8 +22,9 @@
 namespace
 {
 
-bool getGameConfig(const std::string &game_path, Settings &conf)
+bool getGameMinetestConfig(const std::string &game_path, Settings &conf)
 {
+	// TODO: rename this
 	std::string conf_path = game_path + DIR_DELIM + "minetest.conf";
 	return conf.readConfigFile(conf_path.c_str());
 }
@@ -354,7 +355,7 @@ void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 		game_settings = Settings::createLayer(SL_GAME);
 	}
 
-	getGameConfig(gamespec.path, *game_settings);
+	getGameMinetestConfig(gamespec.path, *game_settings);
 	game_settings->removeSecureSettings();
 
 	infostream << "Initializing world at " << final_path << std::endl;


### PR DESCRIPTION
Two problems:

- The name `getGameConfig` implies that it reads `game.conf`. It actually reads the game's `minetest.conf` and the old name `getGameMinetestConfig` correctly reflects this.
- The removed `// TODO: rename this` comment wasn't (only) about the name of the function, but also about the `minetest.conf` filename used below.

A proper refactoring would have had to:

- Rename the function to `getGameLuantiConfig` or similar
- Keep the to-do comment until the config file is renamed

In general, doing this refactor would make more sense after the config file is renamed. I think the old code is fine and the change should simply be reverted.

(I probably shouldn't have bothered to open a revert PR since the change is so small... If a core dev disagrees with my assessment, we can just close this to avoid time spent on discussion...)

## To do

This PR is a Ready for Review.

## How to test

See