### PR TITLE
Improve sleep accuracy on FPS limiter

### DIFF
--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -50,15 +50,7 @@ void FpsControl::limit(IrrlichtDevice *device, f32 *dtime, bool assume_paused)
 
 	if (busy_time < frametime_min) {
 		sleep_time = frametime_min - busy_time;
-		if (sleep_time > 0)
-		{
-			u64 target_time = time + sleep_time;
-			if (sleep_time > SLEEP_ACCURACY)
-				sleep_us(sleep_time-SLEEP_ACCURACY);
-
-			// Busy-wait the remaining time to adjust for sleep inaccuracies
-			porting::preciseSleepUntil(target_time);
-		}
+		porting::preciseSleepUs(sleep_time);
 	} else {
 		sleep_time = 0;
 	}

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -57,7 +57,7 @@ void FpsControl::limit(IrrlichtDevice *device, f32 *dtime, bool assume_paused)
 				sleep_us(sleep_time-SLEEP_ACCURACY);
 
 			// Busy-wait the remaining time to adjust for sleep inaccuracies
-			while ((s64)(target_time - porting::getTimeUs()) > 0);
+			porting::preciseSleepUntil(target_time);
 		}
 	} else {
 		sleep_time = 0;

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -51,7 +51,14 @@ void FpsControl::limit(IrrlichtDevice *device, f32 *dtime, bool assume_paused)
 	if (busy_time < frametime_min) {
 		sleep_time = frametime_min - busy_time;
 		if (sleep_time > 0)
-			sleep_us(sleep_time);
+		{
+			u64 target_time = time + sleep_time;
+			if (sleep_time > SLEEP_ACCURACY)
+				sleep_us(sleep_time-SLEEP_ACCURACY);
+
+			// Busy-wait the remaining time to adjust for sleep inaccuracies
+			while ((s64)(target_time - porting::getTimeUs()) > 0);
+		}
 	} else {
 		sleep_time = 0;
 	}

--- a/src/porting.h
+++ b/src/porting.h
@@ -235,7 +235,7 @@ inline void preciseSleepUs(u64 sleep_time)
 		// Busy-wait the remaining time to adjust for sleep inaccuracies
 		// The target - now > 0 construct will handle overflow gracefully (even though it should
 		// never happen)
-		while ((s64)(target_time - porting::getTimeUs()) > 0);
+		while ((s64)(target_time - porting::getTimeUs()) > 0) {}
 	}
 }
 

--- a/src/porting.h
+++ b/src/porting.h
@@ -32,11 +32,15 @@
 	#define sleep_ms(x) Sleep(x)
 	#define sleep_us(x) Sleep((x)/1000)
 
+	#define SLEEP_ACCURACY 2000
+
 	#define setenv(n,v,o) _putenv_s(n,v)
 	#define unsetenv(n) _putenv_s(n,"")
 #else
 	#include <unistd.h>
 	#include <cstdlib> // setenv
+
+	#define SLEEP_ACCURACY 200
 
 	#define sleep_ms(x) usleep((x)*1000)
 	#define sleep_us(x) usleep(x)

--- a/src/porting.h
+++ b/src/porting.h
@@ -224,6 +224,11 @@ inline u64 getDeltaMs(u64 old_time_ms, u64 new_time_ms)
 	return (old_time_ms - new_time_ms);
 }
 
+inline void preciseSleepUntil(u64 target_time)
+{
+	while ((s64)(target_time - porting::getTimeUs()) > 0);
+}
+
 inline const char *getPlatformName()
 {
 	return

--- a/src/porting.h
+++ b/src/porting.h
@@ -32,7 +32,7 @@
 	#define sleep_ms(x) Sleep(x)
 	#define sleep_us(x) Sleep((x)/1000)
 
-	#define SLEEP_ACCURACY 2000
+	#define SLEEP_ACCURACY_US 2000
 
 	#define setenv(n,v,o) _putenv_s(n,v)
 	#define unsetenv(n) _putenv_s(n,"")
@@ -40,7 +40,7 @@
 	#include <unistd.h>
 	#include <cstdlib> // setenv
 
-	#define SLEEP_ACCURACY 200
+	#define SLEEP_ACCURACY_US 200
 
 	#define sleep_ms(x) usleep((x)*1000)
 	#define sleep_us(x) usleep(x)
@@ -229,8 +229,8 @@ inline void preciseSleepUs(u64 sleep_time)
 	if (sleep_time > 0)
 	{
 		u64 target_time = porting::getTimeUs() + sleep_time;
-		if (sleep_time > SLEEP_ACCURACY)
-			sleep_us(sleep_time - SLEEP_ACCURACY);
+		if (sleep_time > SLEEP_ACCURACY_US)
+			sleep_us(sleep_time - SLEEP_ACCURACY_US);
 
 		// Busy-wait the remaining time to adjust for sleep inaccuracies
 		// The target - now > 0 construct will handle overflow gracefully (even though it should

--- a/src/porting.h
+++ b/src/porting.h
@@ -224,9 +224,18 @@ inline u64 getDeltaMs(u64 old_time_ms, u64 new_time_ms)
 	return (old_time_ms - new_time_ms);
 }
 
-inline void preciseSleepUntil(u64 target_time)
+inline void preciseSleepUs(u64 sleep_time)
 {
-	while ((s64)(target_time - porting::getTimeUs()) > 0);
+	if (sleep_time > 0)
+	{
+		u64 time = porting::getTimeUs();
+		u64 target_time = time + sleep_time;
+		if (sleep_time > SLEEP_ACCURACY)
+			sleep_us(sleep_time-SLEEP_ACCURACY);
+
+		// Busy-wait the remaining time to adjust for sleep inaccuracies
+		while ((s64)(target_time - porting::getTimeUs()) > 0);
+	}
 }
 
 inline const char *getPlatformName()

--- a/src/porting.h
+++ b/src/porting.h
@@ -228,12 +228,13 @@ inline void preciseSleepUs(u64 sleep_time)
 {
 	if (sleep_time > 0)
 	{
-		u64 time = porting::getTimeUs();
-		u64 target_time = time + sleep_time;
+		u64 target_time = porting::getTimeUs() + sleep_time;
 		if (sleep_time > SLEEP_ACCURACY)
-			sleep_us(sleep_time-SLEEP_ACCURACY);
+			sleep_us(sleep_time - SLEEP_ACCURACY);
 
 		// Busy-wait the remaining time to adjust for sleep inaccuracies
+		// The target - now > 0 construct will handle overflow gracefully (even though it should
+		// never happen)
 		while ((s64)(target_time - porting::getTimeUs()) > 0);
 	}
 }


### PR DESCRIPTION
This patch resolves issues with inaccurate sleep for FPS limiting, particularly on Windows.

The core problem with sleeping in general is that it's not as accurate as you would've liked it to be. Because of this, it's unfortunately not possible to achieve accurate sleeping with OS sleep functions alone - you also need to busy-wait to fine-tune the last sleep time. On Linux, sleep accuracy is normally at around 50 µs, with spikes that can be as high as 150µs, while Windows normally residing on 1-2 ms accuracy. Other OSes are unknown to me, but they generally tend to be around or more accurate than Linux from what I know.

fixes #13399

## To do

This PR is Ready for Review.

## How to test

Simply run the game with the FPS capped, being sure to test both high values like 200 and low like 30, and observe the actual framerate, either with a tool like MangoHUD or simply using the debug info.