### PR TITLE
[no sq] Refactor Meshgen, and fix black plantlike_rooted

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -62,7 +62,7 @@ const std::string MapblockMeshGenerator::raillike_groupname = "connect_to_railli
 MapblockMeshGenerator::MapblockMeshGenerator(MeshMakeData *input, MeshCollector *output):
 	data(input),
 	collector(output),
-	nodedef(data->nodedef),
+	nodedef(data->m_nodedef),
 	blockpos_nodes(data->m_blockpos * MAP_BLOCKSIZE)
 {
 }
@@ -1773,9 +1773,9 @@ void MapblockMeshGenerator::generate()
 {
 	ZoneScoped;
 
-	for (cur_node.p.Z = 0; cur_node.p.Z < data->side_length; cur_node.p.Z++)
-	for (cur_node.p.Y = 0; cur_node.p.Y < data->side_length; cur_node.p.Y++)
-	for (cur_node.p.X = 0; cur_node.p.X < data->side_length; cur_node.p.X++) {
+	for (cur_node.p.Z = 0; cur_node.p.Z < data->m_side_length; cur_node.p.Z++)
+	for (cur_node.p.Y = 0; cur_node.p.Y < data->m_side_length; cur_node.p.Y++)
+	for (cur_node.p.X = 0; cur_node.p.X < data->m_side_length; cur_node.p.X++) {
 		cur_node.n = data->m_vmanip.getNodeNoEx(blockpos_nodes + cur_node.p);
 		cur_node.f = &nodedef->get(cur_node.n);
 		drawNode();

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1267,7 +1267,8 @@ void MapblockMeshGenerator::drawPlantlikeRootedNode()
 		getSmoothLightFrame();
 	} else {
 		MapNode ntop = data->m_vmanip.getNodeNoEx(blockpos_nodes + cur_node.p);
-		cur_node.light = LightPair(getInteriorLight(ntop, 0, nodedef)); // FIXME: unused write
+		cur_node.light = LightPair(getInteriorLight(ntop, 0, nodedef));
+		cur_node.color = encode_light(cur_node.light, cur_node.f->light_source);
 	}
 	drawPlantlike(tile, true);
 	cur_node.p.Y--;

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -127,7 +127,7 @@ void MapblockMeshGenerator::drawQuad(const TileSpec &tile, v3f *coords, const v3
 		if (data->m_smooth_lighting)
 			vertices[j].Color = blendLightColor(coords[j]);
 		else
-			vertices[j].Color = cur_node.color;
+			vertices[j].Color = cur_node.lcolor;
 		if (shade_face)
 			applyFacesShading(vertices[j].Color, normal2);
 		vertices[j].TCoords = tcoords[j];
@@ -239,16 +239,16 @@ void MapblockMeshGenerator::drawCuboid(const aabb3f &box,
 void MapblockMeshGenerator::getSmoothLightFrame()
 {
 	for (int k = 0; k < 8; ++k)
-		cur_node.frame.sunlight[k] = false;
+		cur_node.lframe.sunlight[k] = false;
 	for (int k = 0; k < 8; ++k) {
 		LightPair light(getSmoothLightTransparent(blockpos_nodes + cur_node.p, light_dirs[k], data));
-		cur_node.frame.lightsDay[k] = light.lightDay;
-		cur_node.frame.lightsNight[k] = light.lightNight;
+		cur_node.lframe.lightsDay[k] = light.lightDay;
+		cur_node.lframe.lightsNight[k] = light.lightNight;
 		// If there is direct sunlight and no ambient occlusion at some corner,
 		// mark the vertical edge (top and bottom corners) containing it.
 		if (light.lightDay == 255) {
-			cur_node.frame.sunlight[k] = true;
-			cur_node.frame.sunlight[k ^ 2] = true;
+			cur_node.lframe.sunlight[k] = true;
+			cur_node.lframe.sunlight[k ^ 2] = true;
 		}
 	}
 }
@@ -271,9 +271,9 @@ LightInfo MapblockMeshGenerator::blendLight(const v3f &vertex_pos)
 		f32 dy = (k & 2) ? y : 1 - y;
 		f32 dz = (k & 1) ? z : 1 - z;
 		// Use direct sunlight (255), if any; use daylight otherwise.
-		f32 light_boosted = cur_node.frame.sunlight[k] ? 255 : cur_node.frame.lightsDay[k];
-		lightDay += dx * dy * dz * cur_node.frame.lightsDay[k];
-		lightNight += dx * dy * dz * cur_node.frame.lightsNight[k];
+		f32 light_boosted = cur_node.lframe.sunlight[k] ? 255 : cur_node.lframe.lightsDay[k];
+		lightDay += dx * dy * dz * cur_node.lframe.lightsDay[k];
+		lightNight += dx * dy * dz * cur_node.lframe.lightsNight[k];
 		lightBoosted += dx * dy * dz * light_boosted;
 	}
 	return LightInfo{lightDay, lightNight, lightBoosted};
@@ -379,7 +379,7 @@ void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box,
 		});
 	} else {
 		drawCuboid(box, tiles, tile_count, txc, mask, [&] (int face, video::S3DVertex vertices[4]) {
-			video::SColor color = cur_node.color;
+			video::SColor color = cur_node.lcolor;
 			if (!cur_node.f->light_source)
 				applyFacesShading(color, vertices[0].Normal);
 			for (int j = 0; j < 4; j++) {
@@ -555,7 +555,7 @@ void MapblockMeshGenerator::prepareLiquidNodeDrawing()
 	}
 
 	cur_liquid.color_top = encode_light(light, cur_node.f->light_source);
-	cur_node.color = encode_light(light, cur_node.f->light_source);
+	cur_node.lcolor = encode_light(light, cur_node.f->light_source);
 }
 
 void MapblockMeshGenerator::getLiquidNeighborhood()
@@ -702,7 +702,7 @@ void MapblockMeshGenerator::drawLiquidSides()
 			if (data->m_smooth_lighting)
 				color = blendLightColor(pos);
 			else
-				color = cur_node.color;
+				color = cur_node.lcolor;
 
 			pos += cur_node.origin;
 
@@ -1269,7 +1269,7 @@ void MapblockMeshGenerator::drawPlantlikeRootedNode()
 	} else {
 		MapNode ntop = data->m_vmanip.getNodeNoEx(blockpos_nodes + cur_node.p);
 		auto light = LightPair(getInteriorLight(ntop, 0, nodedef));
-		cur_node.color = encode_light(light, cur_node.f->light_source);
+		cur_node.lcolor = encode_light(light, cur_node.f->light_source);
 	}
 	drawPlantlike(tile, true);
 	cur_node.p.Y--;
@@ -1713,7 +1713,7 @@ void MapblockMeshGenerator::drawMeshNode()
 			bool is_light_source = cur_node.f->light_source != 0;
 			for (u32 k = 0; k < vertex_count; k++) {
 				video::S3DVertex &vertex = vertices[k];
-				video::SColor color = cur_node.color;
+				video::SColor color = cur_node.lcolor;
 				if (!is_light_source)
 					applyFacesShading(color, vertex.Normal);
 				vertex.Color = color;
@@ -1750,7 +1750,7 @@ void MapblockMeshGenerator::drawNode()
 		getSmoothLightFrame();
 	} else {
 		auto light = LightPair(getInteriorLight(cur_node.n, 0, nodedef));
-		cur_node.color = encode_light(light, cur_node.f->light_source);
+		cur_node.lcolor = encode_light(light, cur_node.f->light_source);
 	}
 	switch (cur_node.f->drawtype) {
 		case NDT_FLOWINGLIQUID:     drawLiquidNode(); break;

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1108,7 +1108,7 @@ void MapblockMeshGenerator::drawSignlikeNode()
 void MapblockMeshGenerator::drawPlantlikeQuad(const TileSpec &tile,
 		float rotation, float quad_offset, bool offset_top_only)
 {
-	const f32 scale = cur_node.scale;
+	const f32 scale = cur_plant.scale;
 	v3f vertices[4] = {
 		v3f(-scale, -BS / 2 + 2.0 * scale * cur_plant.plant_height, 0),
 		v3f( scale, -BS / 2 + 2.0 * scale * cur_plant.plant_height, 0),
@@ -1164,8 +1164,8 @@ void MapblockMeshGenerator::drawPlantlikeQuad(const TileSpec &tile,
 void MapblockMeshGenerator::drawPlantlike(const TileSpec &tile, bool is_rooted)
 {
 	cur_plant.draw_style = PLANT_STYLE_CROSS;
-	cur_node.scale = BS / 2 * cur_node.f->visual_scale;
 	cur_plant.offset = v3f(0, 0, 0);
+	cur_plant.scale = BS / 2 * cur_node.f->visual_scale;
 	cur_plant.rotate_degree = 0.0f;
 	cur_plant.random_offset_Y = false;
 	cur_plant.face_num = 0;
@@ -1175,7 +1175,7 @@ void MapblockMeshGenerator::drawPlantlike(const TileSpec &tile, bool is_rooted)
 	case CPT2_MESHOPTIONS:
 		cur_plant.draw_style = PlantlikeStyle(cur_node.n.param2 & MO_MASK_STYLE);
 		if (cur_node.n.param2 & MO_BIT_SCALE_SQRT2)
-			cur_node.scale *= 1.41421;
+			cur_plant.scale *= 1.41421;
 		if (cur_node.n.param2 & MO_BIT_RANDOM_OFFSET) {
 			PseudoRandom rng(cur_node.p.X << 8 | cur_node.p.Z | cur_node.p.Y << 16);
 			cur_plant.offset.X = BS * ((rng.next() % 16 / 16.0) * 0.29 - 0.145);
@@ -1274,7 +1274,7 @@ void MapblockMeshGenerator::drawPlantlikeRootedNode()
 void MapblockMeshGenerator::drawFirelikeQuad(const TileSpec &tile, float rotation,
 		float opening_angle, float offset_h, float offset_v)
 {
-	const f32 scale = cur_node.scale;
+	const f32 scale = BS / 2 * cur_node.f->visual_scale;
 	v3f vertices[4] = {
 		v3f(-scale, -BS / 2 + scale * 2, 0),
 		v3f( scale, -BS / 2 + scale * 2, 0),
@@ -1295,7 +1295,6 @@ void MapblockMeshGenerator::drawFirelikeNode()
 {
 	TileSpec tile;
 	useTile(&tile);
-	cur_node.scale = BS / 2 * cur_node.f->visual_scale;
 
 	// Check for adjacent nodes
 	bool neighbors = false;

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -63,8 +63,7 @@ MapblockMeshGenerator::MapblockMeshGenerator(MeshMakeData *input, MeshCollector 
 	data(input),
 	collector(output),
 	nodedef(data->nodedef),
-	blockpos_nodes(data->m_blockpos * MAP_BLOCKSIZE),
-	smooth_liquids(g_settings->getBool("enable_water_reflections"))
+	blockpos_nodes(data->m_blockpos * MAP_BLOCKSIZE)
 {
 }
 
@@ -733,7 +732,7 @@ void MapblockMeshGenerator::drawLiquidTop()
 		int u = corner_resolve[i][0];
 		int w = corner_resolve[i][1];
 
-		if (smooth_liquids) {
+		if (data->m_enable_water_reflections) {
 			int x = vertices[i].Pos.X > 0;
 			int z = vertices[i].Pos.Z > 0;
 
@@ -785,7 +784,7 @@ void MapblockMeshGenerator::drawLiquidTop()
 
 		vertex.TCoords += tcoord_translate;
 
-		if (!smooth_liquids) {
+		if (!data->m_enable_water_reflections) {
 			vertex.Normal = v3f(dx, 1., dz).normalize();
 		}
 	}

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -542,19 +542,20 @@ void MapblockMeshGenerator::prepareLiquidNodeDrawing()
 	if (data->m_smooth_lighting)
 		return; // don't need to pre-compute anything in this case
 
+	auto light = LightPair(getInteriorLight(cur_node.n, 0, nodedef));
 	if (cur_node.f->light_source != 0) {
 		// If this liquid emits light and doesn't contain light, draw
 		// it at what it emits, for an increased effect
 		u8 e = decode_light(cur_node.f->light_source);
-		cur_node.light = LightPair(std::max(e, cur_node.light.lightDay),
-				std::max(e, cur_node.light.lightNight));
+		light = LightPair(std::max(e, light.lightDay),
+				std::max(e, light.lightNight));
 	} else if (nodedef->getLightingFlags(ntop).has_light) {
 		// Otherwise, use the light of the node on top if possible
-		cur_node.light = LightPair(getInteriorLight(ntop, 0, nodedef));
+		light = LightPair(getInteriorLight(ntop, 0, nodedef));
 	}
 
-	cur_liquid.color_top = encode_light(cur_node.light, cur_node.f->light_source);
-	cur_node.color = encode_light(cur_node.light, cur_node.f->light_source);
+	cur_liquid.color_top = encode_light(light, cur_node.f->light_source);
+	cur_node.color = encode_light(light, cur_node.f->light_source);
 }
 
 void MapblockMeshGenerator::getLiquidNeighborhood()
@@ -1267,8 +1268,8 @@ void MapblockMeshGenerator::drawPlantlikeRootedNode()
 		getSmoothLightFrame();
 	} else {
 		MapNode ntop = data->m_vmanip.getNodeNoEx(blockpos_nodes + cur_node.p);
-		cur_node.light = LightPair(getInteriorLight(ntop, 0, nodedef));
-		cur_node.color = encode_light(cur_node.light, cur_node.f->light_source);
+		auto light = LightPair(getInteriorLight(ntop, 0, nodedef));
+		cur_node.color = encode_light(light, cur_node.f->light_source);
 	}
 	drawPlantlike(tile, true);
 	cur_node.p.Y--;
@@ -1748,8 +1749,8 @@ void MapblockMeshGenerator::drawNode()
 	if (data->m_smooth_lighting) {
 		getSmoothLightFrame();
 	} else {
-		cur_node.light = LightPair(getInteriorLight(cur_node.n, 0, nodedef));
-		cur_node.color = encode_light(cur_node.light, cur_node.f->light_source);
+		auto light = LightPair(getInteriorLight(cur_node.n, 0, nodedef));
+		cur_node.color = encode_light(light, cur_node.f->light_source);
 	}
 	switch (cur_node.f->drawtype) {
 		case NDT_FLOWINGLIQUID:     drawLiquidNode(); break;

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -112,7 +112,6 @@ private:
 		f32 corner_levels[2][2];
 	};
 	LiquidData cur_liquid;
-	bool smooth_liquids = false;
 
 	void prepareLiquidNodeDrawing();
 	void getLiquidNeighborhood();

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -63,7 +63,6 @@ private:
 		v3f origin;
 		MapNode n;
 		const ContentFeatures *f;
-		LightPair light;
 		LightFrame frame;
 		video::SColor color;
 	} cur_node;

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -66,7 +66,6 @@ private:
 		LightPair light;
 		LightFrame frame;
 		video::SColor color;
-		TileSpec tile;
 		f32 scale;
 	} cur_node;
 
@@ -76,21 +75,23 @@ private:
 	video::SColor blendLightColor(const v3f &vertex_pos);
 	video::SColor blendLightColor(const v3f &vertex_pos, const v3f &vertex_normal);
 
-	void useTile(int index = 0, u8 set_flags = MATERIAL_FLAG_CRACK_OVERLAY,
+	void useTile(TileSpec *tile_ret, int index = 0, u8 set_flags = MATERIAL_FLAG_CRACK_OVERLAY,
 		u8 reset_flags = 0, bool special = false);
-	void getTile(int index, TileSpec *tile);
-	void getTile(v3s16 direction, TileSpec *tile);
-	void getSpecialTile(int index, TileSpec *tile, bool apply_crack = false);
+	void getTile(int index, TileSpec *tile_ret);
+	void getTile(v3s16 direction, TileSpec *tile_ret);
+	void getSpecialTile(int index, TileSpec *tile_ret, bool apply_crack = false);
 
 // face drawing
-	void drawQuad(v3f *vertices, const v3s16 &normal = v3s16(0, 0, 0),
+	void drawQuad(const TileSpec &tile, v3f *vertices, const v3s16 &normal = v3s16(0, 0, 0),
 		float vertical_tiling = 1.0);
 
 // cuboid drawing!
 	template <typename Fn>
-	void drawCuboid(const aabb3f &box, TileSpec *tiles, int tilecount, const f32 *txc, u8 mask, Fn &&face_lighter);
+	void drawCuboid(const aabb3f &box, const TileSpec *tiles, int tilecount,
+			const f32 *txc, u8 mask, Fn &&face_lighter);
 	void generateCuboidTextureCoords(aabb3f const &box, f32 *coords);
-	void drawAutoLightedCuboid(aabb3f box, f32 const *txc = nullptr, TileSpec *tiles = nullptr, int tile_count = 0, u8 mask = 0);
+	void drawAutoLightedCuboid(aabb3f box, const TileSpec &tile, f32 const *txc	= nullptr, u8 mask = 0);
+	void drawAutoLightedCuboid(aabb3f box, const TileSpec *tiles, int tile_count, f32 const *txc = nullptr, u8 mask = 0);
 	u8 getNodeBoxMask(aabb3f box, u8 solid_neighbors, u8 sametype_neighbors) const;
 
 // liquid-specific
@@ -143,12 +144,12 @@ private:
 	};
 	PlantlikeData cur_plant;
 
-	void drawPlantlikeQuad(float rotation, float quad_offset = 0,
+	void drawPlantlikeQuad(const TileSpec &tile, float rotation, float quad_offset = 0,
 		bool offset_top_only = false);
-	void drawPlantlike(bool is_rooted = false);
+	void drawPlantlike(const TileSpec &tile, bool is_rooted = false);
 
 // firelike-specific
-	void drawFirelikeQuad(float rotation, float opening_angle,
+	void drawFirelikeQuad(const TileSpec &tile, float rotation, float opening_angle,
 		float offset_h, float offset_v = 0.0);
 
 // drawtypes

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -66,7 +66,6 @@ private:
 		LightPair light;
 		LightFrame frame;
 		video::SColor color;
-		f32 scale;
 	} cur_node;
 
 // lighting
@@ -137,6 +136,7 @@ private:
 	struct PlantlikeData {
 		PlantlikeStyle draw_style;
 		v3f offset;
+		float scale;
 		float rotate_degree;
 		bool random_offset_Y;
 		int face_num;

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -59,12 +59,12 @@ private:
 
 // current node
 	struct {
-		v3s16 p;
-		v3f origin;
+		v3s16 p; // relative to blockpos_nodes
+		v3f origin; // p in BS space
 		MapNode n;
 		const ContentFeatures *f;
-		LightFrame frame;
-		video::SColor color;
+		LightFrame lframe; // smooth lighting
+		video::SColor lcolor; // unsmooth lighting
 	} cur_node;
 
 // lighting

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -58,11 +58,6 @@ void MeshMakeData::setCrack(int crack_level, v3s16 crack_pos)
 		m_crack_pos_relative = crack_pos - m_blockpos*MAP_BLOCKSIZE;
 }
 
-void MeshMakeData::setSmoothLighting(bool smooth_lighting)
-{
-	m_smooth_lighting = smooth_lighting;
-}
-
 /*
 	Light and vertex color functions
 */

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -26,9 +26,11 @@
 	MeshMakeData
 */
 
-MeshMakeData::MeshMakeData(const NodeDefManager *ndef, u16 side_length):
-	side_length(side_length),
-	nodedef(ndef)
+MeshMakeData::MeshMakeData(const NodeDefManager *ndef,
+		u16 side_length, MeshGrid mesh_grid) :
+	m_side_length(side_length),
+	m_mesh_grid(mesh_grid),
+	m_nodedef(ndef)
 {}
 
 void MeshMakeData::fillBlockDataBegin(const v3s16 &blockpos)
@@ -38,8 +40,9 @@ void MeshMakeData::fillBlockDataBegin(const v3s16 &blockpos)
 	v3s16 blockpos_nodes = m_blockpos*MAP_BLOCKSIZE;
 
 	m_vmanip.clear();
+	// extra 1 block thick layer around the mesh
 	VoxelArea voxel_area(blockpos_nodes - v3s16(1,1,1) * MAP_BLOCKSIZE,
-			blockpos_nodes + v3s16(1,1,1) * (side_length + MAP_BLOCKSIZE /* extra layer of blocks around the mesh */) - v3s16(1,1,1));
+			blockpos_nodes + v3s16(1,1,1) * (m_side_length + MAP_BLOCKSIZE) - v3s16(1,1,1));
 	m_vmanip.addArea(voxel_area);
 }
 
@@ -128,7 +131,7 @@ u16 getFaceLight(MapNode n, MapNode n2, const NodeDefManager *ndef)
 static u16 getSmoothLightCombined(const v3s16 &p,
 	const std::array<v3s16,8> &dirs, MeshMakeData *data)
 {
-	const NodeDefManager *ndef = data->nodedef;
+	const NodeDefManager *ndef = data->m_nodedef;
 
 	u16 ambient_occlusion = 0;
 	u16 light_count = 0;
@@ -316,7 +319,7 @@ void final_color_blend(video::SColor *result,
 */
 void getNodeTileN(MapNode mn, const v3s16 &p, u8 tileindex, MeshMakeData *data, TileSpec &tile)
 {
-	const NodeDefManager *ndef = data->nodedef;
+	const NodeDefManager *ndef = data->m_nodedef;
 	const ContentFeatures &f = ndef->get(mn);
 	tile = f.tiles[tileindex];
 	bool has_crack = p == data->m_crack_pos_relative;
@@ -336,7 +339,7 @@ void getNodeTileN(MapNode mn, const v3s16 &p, u8 tileindex, MeshMakeData *data, 
 */
 void getNodeTile(MapNode mn, const v3s16 &p, const v3s16 &dir, MeshMakeData *data, TileSpec &tile)
 {
-	const NodeDefManager *ndef = data->nodedef;
+	const NodeDefManager *ndef = data->m_nodedef;
 
 	// Direction must be (1,0,0), (-1,0,0), (0,1,0), (0,-1,0),
 	// (0,0,1), (0,0,-1) or (0,0,0)
@@ -588,7 +591,7 @@ void PartialMeshBuffer::draw(video::IVideoDriver *driver) const
 MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offset):
 	m_tsrc(client->getTextureSource()),
 	m_shdrsrc(client->getShaderSource()),
-	m_bounding_sphere_center((data->side_length * 0.5f - 0.5f) * BS),
+	m_bounding_sphere_center((data->m_side_length * 0.5f - 0.5f) * BS),
 	m_animation_force_timer(0), // force initial animation
 	m_last_crack(-1)
 {
@@ -597,10 +600,12 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offs
 	for (auto &m : m_mesh)
 		m = make_irr<scene::SMesh>();
 
-	auto mesh_grid = client->getMeshGrid();
+	auto mesh_grid = data->m_mesh_grid;
 	v3s16 bp = data->m_blockpos;
-	// Only generate minimap mapblocks at even coordinates.
-	if (mesh_grid.isMeshPos(bp) && client->getMinimap()) {
+	// Only generate minimap mapblocks at grid aligned coordinates.
+	// FIXME: ^ doesn't really make sense. and in practice, bp is always aligned
+	if (mesh_grid.isMeshPos(bp) && data->m_generate_minimap) {
+		// meshgen area always fits into a grid cell
 		m_minimap_mapblocks.resize(mesh_grid.getCellVolume(), nullptr);
 		v3s16 ofs;
 
@@ -617,15 +622,10 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offs
 		}
 	}
 
+	// algin vertices to mesh grid, not meshgen area
 	v3f offset = intToFloat((data->m_blockpos - mesh_grid.getMeshPos(data->m_blockpos)) * MAP_BLOCKSIZE, BS);
+
 	MeshCollector collector(m_bounding_sphere_center, offset);
-	/*
-		Add special graphics:
-		- torches
-		- flowing water
-		- fences
-		- whatever
-	*/
 
 	{
 		MapblockMeshGenerator(data, &collector).generate();
@@ -743,7 +743,7 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offs
 		}
 	}
 
-	m_bsp_tree.buildTree(&m_transparent_triangles, data->side_length);
+	m_bsp_tree.buildTree(&m_transparent_triangles, data->m_side_length);
 
 	// Check if animation is required for this mesh
 	m_has_animation =
@@ -954,19 +954,19 @@ u8 get_solid_sides(MeshMakeData *data)
 {
 	std::unordered_map<v3s16, u8> results;
 	v3s16 blockpos_nodes = data->m_blockpos * MAP_BLOCKSIZE;
-	const NodeDefManager *ndef = data->nodedef;
+	const NodeDefManager *ndef = data->m_nodedef;
 
 	u8 result = 0x3F; // all sides solid;
 
-	for (s16 i = 0; i < data->side_length && result != 0; i++)
-	for (s16 j = 0; j < data->side_length && result != 0; j++) {
+	for (s16 i = 0; i < data->m_side_length && result != 0; i++)
+	for (s16 j = 0; j < data->m_side_length && result != 0; j++) {
 		v3s16 positions[6] = {
 			v3s16(0, i, j),
-			v3s16(data->side_length - 1, i, j),
+			v3s16(data->m_side_length - 1, i, j),
 			v3s16(i, 0, j),
-			v3s16(i, data->side_length - 1, j),
+			v3s16(i, data->m_side_length - 1, j),
 			v3s16(i, j, 0),
-			v3s16(i, j, data->side_length - 1)
+			v3s16(i, j, data->m_side_length - 1)
 		};
 
 		for (u8 k = 0; k < 6; k++) {

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -36,15 +36,25 @@ struct MinimapMapblock;
 struct MeshMakeData
 {
 	VoxelManipulator m_vmanip;
+
+	// base pos of meshgen area, in blocks
 	v3s16 m_blockpos = v3s16(-1337,-1337,-1337);
+	// size of meshgen area, in nodes.
+	// vmanip will have at least an extra 1 node onion layer.
+	// area is expected to fit into mesh grid cell.
+	u16 m_side_length;
+	// vertex positions will be relative to this grid
+	MeshGrid m_mesh_grid;
+
+	// relative to blockpos
 	v3s16 m_crack_pos_relative = v3s16(-1337,-1337,-1337);
+	bool m_generate_minimap = false;
 	bool m_smooth_lighting = false;
 	bool m_enable_water_reflections = false;
-	u16 side_length;
 
-	const NodeDefManager *nodedef;
+	const NodeDefManager *m_nodedef;
 
-	MeshMakeData(const NodeDefManager *ndef, u16 side_length);
+	MeshMakeData(const NodeDefManager *ndef, u16 side_lingth, MeshGrid mesh_grid);
 
 	/*
 		Copy block data manually (to allow optimizations by the caller)

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -39,6 +39,7 @@ struct MeshMakeData
 	v3s16 m_blockpos = v3s16(-1337,-1337,-1337);
 	v3s16 m_crack_pos_relative = v3s16(-1337,-1337,-1337);
 	bool m_smooth_lighting = false;
+	bool m_enable_water_reflections = false;
 	u16 side_length;
 
 	const NodeDefManager *nodedef;
@@ -55,11 +56,6 @@ struct MeshMakeData
 		Set the (node) position of a crack
 	*/
 	void setCrack(int crack_level, v3s16 crack_pos);
-
-	/*
-		Enable or disable smooth lighting
-	*/
-	void setSmoothLighting(bool smooth_lighting);
 };
 
 // represents a triangle as indexes into the vertex buffer in SMeshBuffer

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -40,6 +40,7 @@ MeshUpdateQueue::MeshUpdateQueue(Client *client):
 	m_client(client)
 {
 	m_cache_smooth_lighting = g_settings->getBool("smooth_lighting");
+	m_cache_enable_water_reflections = g_settings->getBool("enable_water_reflections");
 }
 
 MeshUpdateQueue::~MeshUpdateQueue()
@@ -191,7 +192,8 @@ void MeshUpdateQueue::fillDataFromMapBlocks(QueuedMeshUpdate *q)
 	}
 
 	data->setCrack(q->crack_level, q->crack_pos);
-	data->setSmoothLighting(m_cache_smooth_lighting);
+	data->m_smooth_lighting = m_cache_smooth_lighting;
+	data->m_enable_water_reflections = m_cache_enable_water_reflections;
 }
 
 /*

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -177,7 +177,8 @@ void MeshUpdateQueue::done(v3s16 pos)
 void MeshUpdateQueue::fillDataFromMapBlocks(QueuedMeshUpdate *q)
 {
 	auto mesh_grid = m_client->getMeshGrid();
-	MeshMakeData *data = new MeshMakeData(m_client->ndef(), MAP_BLOCKSIZE * mesh_grid.cell_size);
+	MeshMakeData *data = new MeshMakeData(m_client->ndef(),
+			MAP_BLOCKSIZE * mesh_grid.cell_size, mesh_grid);
 	q->data = data;
 
 	data->fillBlockDataBegin(q->p);
@@ -192,6 +193,7 @@ void MeshUpdateQueue::fillDataFromMapBlocks(QueuedMeshUpdate *q)
 	}
 
 	data->setCrack(q->crack_level, q->crack_pos);
+	data->m_generate_minimap = !!m_client->getMinimap();
 	data->m_smooth_lighting = m_cache_smooth_lighting;
 	data->m_enable_water_reflections = m_cache_enable_water_reflections;
 }

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -69,8 +69,9 @@ private:
 	std::unordered_set<v3s16> m_inflight_blocks;
 	std::mutex m_mutex;
 
-	// TODO: Add callback to update these when g_settings changes
+	// TODO: Add callback to update these when g_settings changes, and update all meshes
 	bool m_cache_smooth_lighting;
+	bool m_cache_enable_water_reflections;
 
 	void fillDataFromMapBlocks(QueuedMeshUpdate *q);
 };

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -41,45 +41,6 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 		p.indices.push_back(indices[i] + vertex_count);
 }
 
-void MeshCollector::append(const TileSpec &tile, const video::S3DVertex *vertices,
-		u32 numVertices, const u16 *indices, u32 numIndices, v3f pos,
-		video::SColor c, u8 light_source)
-{
-	for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
-		const TileLayer *layer = &tile.layers[layernum];
-		if (layer->texture_id == 0)
-			continue;
-		append(*layer, vertices, numVertices, indices, numIndices, pos, c,
-				light_source, layernum, tile.world_aligned);
-	}
-}
-
-void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *vertices,
-		u32 numVertices, const u16 *indices, u32 numIndices, v3f pos,
-		video::SColor c, u8 light_source, u8 layernum, bool use_scale)
-{
-	PreMeshBuffer &p = findBuffer(layer, layernum, numVertices);
-
-	f32 scale = 1.0f;
-	if (use_scale)
-		scale = 1.0f / layer.scale;
-
-	u32 vertex_count = p.vertices.size();
-	for (u32 i = 0; i < numVertices; i++) {
-		video::SColor color = c;
-		if (!light_source)
-			applyFacesShading(color, vertices[i].Normal);
-		auto vpos = vertices[i].Pos + pos + offset;
-		p.vertices.emplace_back(vpos, vertices[i].Normal, color,
-				scale * vertices[i].TCoords);
-		m_bounding_radius_sq = std::max(m_bounding_radius_sq,
-				(vpos - m_center_pos).getLengthSQ());
-	}
-
-	for (u32 i = 0; i < numIndices; i++)
-		p.indices.push_back(indices[i] + vertex_count);
-}
-
 PreMeshBuffer &MeshCollector::findBuffer(
 		const TileLayer &layer, u8 layernum, u32 numVertices)
 {

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -35,20 +35,11 @@ struct MeshCollector
 	void append(const TileSpec &material,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices);
-	void append(const TileSpec &material,
-			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices,
-			v3f pos, video::SColor c, u8 light_source);
 
 private:
 	void append(const TileLayer &material,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices,
-			u8 layernum, bool use_scale = false);
-	void append(const TileLayer &material,
-			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices,
-			v3f pos, video::SColor c, u8 light_source,
 			u8 layernum, bool use_scale = false);
 
 	PreMeshBuffer &findBuffer(const TileLayer &layer, u8 layernum, u32 numVertices);

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -309,8 +309,9 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 static scene::SMesh *createSpecialNodeMesh(Client *client, MapNode n,
 	std::vector<ItemPartColor> *colors, const ContentFeatures &f)
 {
-	MeshMakeData mesh_make_data(client->ndef(), 1);
+	MeshMakeData mesh_make_data(client->ndef(), 1, client->getMeshGrid());
 	MeshCollector collector(v3f(0.0f * BS), v3f());
+	mesh_make_data.m_generate_minimap = false;
 	mesh_make_data.m_smooth_lighting = false;
 	mesh_make_data.m_enable_water_reflections = false;
 	MapblockMeshGenerator gen(&mesh_make_data, &collector);

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -311,7 +311,8 @@ static scene::SMesh *createSpecialNodeMesh(Client *client, MapNode n,
 {
 	MeshMakeData mesh_make_data(client->ndef(), 1);
 	MeshCollector collector(v3f(0.0f * BS), v3f());
-	mesh_make_data.setSmoothLighting(false);
+	mesh_make_data.m_smooth_lighting = false;
+	mesh_make_data.m_enable_water_reflections = false;
 	MapblockMeshGenerator gen(&mesh_make_data, &collector);
 
 	if (n.getParam2()) {

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -179,130 +179,52 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 	if (nodebox.type == NODEBOX_FIXED || nodebox.type == NODEBOX_LEVELED) {
 		const auto &fixed = nodebox.fixed;
 		int facedir = n.getFaceDir(nodemgr, true);
-		u8 axisdir = facedir>>2;
-		facedir&=0x03;
+		u8 axisdir = facedir >> 2;
+		facedir &= 0x03;
 
 		boxes.reserve(boxes.size() + fixed.size());
 		for (aabb3f box : fixed) {
 			if (nodebox.type == NODEBOX_LEVELED)
 				box.MaxEdge.Y = (-0.5f + n.getLevel(nodemgr) / 64.0f) * BS;
 
+			if(facedir == 1) {
+				box.MinEdge.rotateXZBy(-90);
+				box.MaxEdge.rotateXZBy(-90);
+			} else if(facedir == 2) {
+				box.MinEdge.rotateXZBy(180);
+				box.MaxEdge.rotateXZBy(180);
+			} else if(facedir == 3) {
+				box.MinEdge.rotateXZBy(90);
+				box.MaxEdge.rotateXZBy(90);
+			}
+
 			switch (axisdir) {
 			case 0:
-				if(facedir == 1)
-				{
-					box.MinEdge.rotateXZBy(-90);
-					box.MaxEdge.rotateXZBy(-90);
-				}
-				else if(facedir == 2)
-				{
-					box.MinEdge.rotateXZBy(180);
-					box.MaxEdge.rotateXZBy(180);
-				}
-				else if(facedir == 3)
-				{
-					box.MinEdge.rotateXZBy(90);
-					box.MaxEdge.rotateXZBy(90);
-				}
 				break;
 			case 1: // z+
 				box.MinEdge.rotateYZBy(90);
 				box.MaxEdge.rotateYZBy(90);
-				if(facedir == 1)
-				{
-					box.MinEdge.rotateXYBy(90);
-					box.MaxEdge.rotateXYBy(90);
-				}
-				else if(facedir == 2)
-				{
-					box.MinEdge.rotateXYBy(180);
-					box.MaxEdge.rotateXYBy(180);
-				}
-				else if(facedir == 3)
-				{
-					box.MinEdge.rotateXYBy(-90);
-					box.MaxEdge.rotateXYBy(-90);
-				}
 				break;
 			case 2: //z-
 				box.MinEdge.rotateYZBy(-90);
 				box.MaxEdge.rotateYZBy(-90);
-				if(facedir == 1)
-				{
-					box.MinEdge.rotateXYBy(-90);
-					box.MaxEdge.rotateXYBy(-90);
-				}
-				else if(facedir == 2)
-				{
-					box.MinEdge.rotateXYBy(180);
-					box.MaxEdge.rotateXYBy(180);
-				}
-				else if(facedir == 3)
-				{
-					box.MinEdge.rotateXYBy(90);
-					box.MaxEdge.rotateXYBy(90);
-				}
 				break;
 			case 3:  //x+
 				box.MinEdge.rotateXYBy(-90);
 				box.MaxEdge.rotateXYBy(-90);
-				if(facedir == 1)
-				{
-					box.MinEdge.rotateYZBy(90);
-					box.MaxEdge.rotateYZBy(90);
-				}
-				else if(facedir == 2)
-				{
-					box.MinEdge.rotateYZBy(180);
-					box.MaxEdge.rotateYZBy(180);
-				}
-				else if(facedir == 3)
-				{
-					box.MinEdge.rotateYZBy(-90);
-					box.MaxEdge.rotateYZBy(-90);
-				}
 				break;
 			case 4:  //x-
 				box.MinEdge.rotateXYBy(90);
 				box.MaxEdge.rotateXYBy(90);
-				if(facedir == 1)
-				{
-					box.MinEdge.rotateYZBy(-90);
-					box.MaxEdge.rotateYZBy(-90);
-				}
-				else if(facedir == 2)
-				{
-					box.MinEdge.rotateYZBy(180);
-					box.MaxEdge.rotateYZBy(180);
-				}
-				else if(facedir == 3)
-				{
-					box.MinEdge.rotateYZBy(90);
-					box.MaxEdge.rotateYZBy(90);
-				}
 				break;
 			case 5:
 				box.MinEdge.rotateXYBy(-180);
 				box.MaxEdge.rotateXYBy(-180);
-				if(facedir == 1)
-				{
-					box.MinEdge.rotateXZBy(90);
-					box.MaxEdge.rotateXZBy(90);
-				}
-				else if(facedir == 2)
-				{
-					box.MinEdge.rotateXZBy(180);
-					box.MaxEdge.rotateXZBy(180);
-				}
-				else if(facedir == 3)
-				{
-					box.MinEdge.rotateXZBy(-90);
-					box.MaxEdge.rotateXZBy(-90);
-				}
 				break;
 			default:
 				break;
 			}
+
 			box.repair();
 			boxes.push_back(box);
 		}

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -419,57 +419,47 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 
 		boxes.reserve(boxes_size);
 
-#define BOXESPUSHBACK(c) \
-		for (std::vector<aabb3f>::const_iterator \
-				it = (c).begin(); \
-				it != (c).end(); ++it) \
-			(boxes).push_back(*it);
+		auto boxes_insert = [&](const std::vector<aabb3f> &boxes_src) {
+			boxes.insert(boxes.end(), boxes_src.begin(), boxes_src.end());
+		};
 
-		BOXESPUSHBACK(nodebox.fixed);
+		boxes_insert(nodebox.fixed);
 
-		if (neighbors & 1) {
-			BOXESPUSHBACK(c.connect_top);
-		} else {
-			BOXESPUSHBACK(c.disconnected_top);
-		}
+		if (neighbors & 1)
+			boxes_insert(c.connect_top);
+		else
+			boxes_insert(c.disconnected_top);
 
-		if (neighbors & 2) {
-			BOXESPUSHBACK(c.connect_bottom);
-		} else {
-			BOXESPUSHBACK(c.disconnected_bottom);
-		}
+		if (neighbors & 2)
+			boxes_insert(c.connect_bottom);
+		else
+			boxes_insert(c.disconnected_bottom);
 
-		if (neighbors & 4) {
-			BOXESPUSHBACK(c.connect_front);
-		} else {
-			BOXESPUSHBACK(c.disconnected_front);
-		}
+		if (neighbors & 4)
+			boxes_insert(c.connect_front);
+		else
+			boxes_insert(c.disconnected_front);
 
-		if (neighbors & 8) {
-			BOXESPUSHBACK(c.connect_left);
-		} else {
-			BOXESPUSHBACK(c.disconnected_left);
-		}
+		if (neighbors & 8)
+			boxes_insert(c.connect_left);
+		else
+			boxes_insert(c.disconnected_left);
 
-		if (neighbors & 16) {
-			BOXESPUSHBACK(c.connect_back);
-		} else {
-			BOXESPUSHBACK(c.disconnected_back);
-		}
+		if (neighbors & 16)
+			boxes_insert(c.connect_back);
+		else
+			boxes_insert(c.disconnected_back);
 
-		if (neighbors & 32) {
-			BOXESPUSHBACK(c.connect_right);
-		} else {
-			BOXESPUSHBACK(c.disconnected_right);
-		}
+		if (neighbors & 32)
+			boxes_insert(c.connect_right);
+		else
+			boxes_insert(c.disconnected_right);
 
-		if (neighbors == 0) {
-			BOXESPUSHBACK(c.disconnected);
-		}
+		if (neighbors == 0)
+			boxes_insert(c.disconnected);
 
-		if (neighbors < 4) {
-			BOXESPUSHBACK(c.disconnected_sides);
-		}
+		if (neighbors < 4)
+			boxes_insert(c.disconnected_sides);
 
 	}
 	else // NODEBOX_REGULAR

--- a/src/unittest/test_content_mapblock.cpp
+++ b/src/unittest/test_content_mapblock.cpp
@@ -38,7 +38,8 @@ public:
 
 	MeshMakeData makeSingleNodeMMD(bool smooth_lighting = true)
 	{
-		MeshMakeData data{ndef(), 1};
+		MeshMakeData data{ndef(), 1, MeshGrid{1}};
+		data.m_generate_minimap = false;
 		data.m_smooth_lighting = smooth_lighting;
 		data.m_enable_water_reflections = false;
 		data.m_blockpos = {0, 0, 0};

--- a/src/unittest/test_content_mapblock.cpp
+++ b/src/unittest/test_content_mapblock.cpp
@@ -39,7 +39,8 @@ public:
 	MeshMakeData makeSingleNodeMMD(bool smooth_lighting = true)
 	{
 		MeshMakeData data{ndef(), 1};
-		data.setSmoothLighting(smooth_lighting);
+		data.m_smooth_lighting = smooth_lighting;
+		data.m_enable_water_reflections = false;
 		data.m_blockpos = {0, 0, 0};
 		for (s16 x = -1; x <= 1; x++)
 		for (s16 y = -1; y <= 1; y++)


### PR DESCRIPTION
* Commits are pretty self-explanatory.
* Makes some code simpler.
* Makes the meshgen class less statefull.
* Fixes a bug where plantlike rooted is not lighted as expected with smoothlighting off.

## To do

This PR is a Ready for Review.

(If you want, feel free to squash some commits before merge where it makes sense. :shrug:)

## How to test

* Black `plantlike_rooted` fix: Change a devtest plantlike rooted node to not paramtype light, and disable smooth lighting.
* For other changes: Look at nodes. (Also test with disabled smoothlighting.)