### PR TITLE
 Resolve some quirks with (wield) item meshes for nodes 

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1781,11 +1781,3 @@ void MapblockMeshGenerator::generate()
 		drawNode();
 	}
 }
-
-void MapblockMeshGenerator::renderSingle(content_t node, u8 param2)
-{
-	cur_node.p = {0, 0, 0};
-	cur_node.n = MapNode(node, 0xff, param2);
-	cur_node.f = &nodedef->get(cur_node.n);
-	drawNode();
-}

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -47,7 +47,6 @@ class MapblockMeshGenerator
 public:
 	MapblockMeshGenerator(MeshMakeData *input, MeshCollector *output);
 	void generate();
-	void renderSingle(content_t node, u8 param2 = 0x00);
 
 private:
 	MeshMakeData *const data;

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -63,6 +63,11 @@ struct MeshMakeData
 	void fillBlockData(const v3s16 &bp, MapNode *data);
 
 	/*
+		Prepare block data for rendering a single node located at (0,0,0).
+	*/
+	void fillSingleNode(MapNode data, MapNode padding = MapNode(CONTENT_AIR));
+
+	/*
 		Set the (node) position of a crack
 	*/
 	void setCrack(int crack_level, v3s16 crack_pos);

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -92,7 +92,6 @@ public:
 	WieldMeshSceneNode(scene::ISceneManager *mgr, s32 id = -1);
 	virtual ~WieldMeshSceneNode();
 
-	void setCube(const ContentFeatures &f, v3f wield_scale);
 	void setExtruded(const std::string &imagename, const std::string &overlay_image,
 			v3f wield_scale, ITextureSource *tsrc, u8 num_frames);
 	void setItem(const ItemStack &item, Client *client,

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -474,21 +474,6 @@ struct ContentFeatures
 		}
 	}
 
-	bool needsBackfaceCulling() const
-	{
-		switch (drawtype) {
-		case NDT_TORCHLIKE:
-		case NDT_SIGNLIKE:
-		case NDT_FIRELIKE:
-		case NDT_RAILLIKE:
-		case NDT_PLANTLIKE:
-		case NDT_PLANTLIKE_ROOTED:
-		case NDT_MESH:
-			return false;
-		default:
-			return true;
-		}
-	}
 
 	bool isLiquid() const{
 		return (liquid_type != LIQUID_NONE);

--- a/src/voxel.h
+++ b/src/voxel.h
@@ -459,7 +459,9 @@ public:
 	{
 		if(!m_area.contains(p))
 			return false;
-		m_data[m_area.index(p)] = n;
+		const s32 index = m_area.index(p);
+		m_data[index] = n;
+		m_flags[index] &= ~VOXELFLAG_NO_DATA;
 		return true;
 	}
 


### PR DESCRIPTION
by just deleting some code, isn't that great?

what initially bothered me is that we use 6 drawcalls to a render a node (because a cube has 6 sides).
but also there are some subtle inconsistencies with actual node rendering

*note*: this does not fix the transparency/opaque ignorance

## To do

This PR is Ready for Review.

## How to test

Scroll through devtests inventory and look at stuff.