### PR TITLE
Remove shadow direction quantization, increase shadow frames instead

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1899,7 +1899,7 @@ shadow_poisson_filter (Poisson filtering) bool true
 #    Minimum value: 1; maximum value: 16
 #
 #    Requires: enable_dynamic_shadows, opengl
-shadow_update_frames (Map shadows update frames) int 8 1 16
+shadow_update_frames (Map shadows update frames) int 16 1 32
 
 #    Set to true to render debugging breakdown of the bloom effect.
 #    In debug mode, the screen is split into 4 quadrants:

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1899,7 +1899,7 @@ shadow_poisson_filter (Poisson filtering) bool true
 #    Minimum value: 1; maximum value: 16
 #
 #    Requires: enable_dynamic_shadows, opengl
-shadow_update_frames (Map shadows update frames) int 16 1 32
+shadow_update_frames (Map shadows update frames) int 8 1 16
 
 #    Set to true to render debugging breakdown of the bloom effect.
 #    In debug mode, the screen is split into 4 quadrants:

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -13,18 +13,6 @@
 
 using m4f = core::matrix4;
 
-static v3f quantizeDirection(v3f direction, float step)
-{
-
-	float yaw = std::atan2(direction.Z, direction.X);
-	float pitch = std::asin(direction.Y); // assume look is normalized
-
-	yaw = std::floor(yaw / step) * step;
-	pitch = std::floor(pitch / step) * step;
-
-	return v3f(std::cos(yaw)*std::cos(pitch), std::sin(pitch), std::sin(yaw)*std::cos(pitch));
-}
-
 void DirectionalLight::createSplitMatrices(const Camera *cam)
 {
 	static const float COS_15_DEG = 0.965926f;
@@ -74,7 +62,7 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	v3f boundVec = (cam_pos_scene + farCorner * sfFar) - center_scene;
 	float radius = boundVec.getLength();
 	float length = radius * 3.0f;
-	v3f eye_displacement = quantizeDirection(direction, M_PI / 2880 /*15 seconds*/) * length;
+	v3f eye_displacement = direction * length;
 
 	// we must compute the viewmat with the position - the camera offset
 	// but the future_frustum position must be the actual world position

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -13,18 +13,6 @@
 
 using m4f = core::matrix4;
 
-static v3f quantizeDirection(v3f direction, float step)
-{
-
-	float yaw = std::atan2(direction.Z, direction.X);
-	float pitch = std::asin(direction.Y); // assume look is normalized
-
-	yaw = std::floor(yaw / step) * step;
-	pitch = std::floor(pitch / step) * step;
-
-	return v3f(std::cos(yaw)*std::cos(pitch), std::sin(pitch), std::sin(yaw)*std::cos(pitch));
-}
-
 void DirectionalLight::createSplitMatrices(const Camera *cam)
 {
 	static const float COS_15_DEG = 0.965926f;
@@ -96,23 +84,10 @@ DirectionalLight::DirectionalLight(const u32 shadowMapResolution,
 		farPlane(farValue), mapRes(shadowMapResolution), pos(position)
 {}
 
-void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool force, float timeoftheday)
+void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool force)
 {
 	if (dirty && !force)
 		return;
-
-	if (timeoftheday < 0.05 || timeoftheday > 0.95 || (timeoftheday > 0.45 && timeoftheday < 0.55)) {
-		/*
-		 * When we are close to noon or midnight shadows do not move much,
-		 * so shadow-jitter due to rounding is more visible.
-		 * At those times we update shadows less often.
-		 */
-		v3f q_direction  = quantizeDirection(direction, M_PI / 2880 /*15 seconds*/);
-		if (q_direction == last_quant_directin)
-			return;
-
-		last_quant_directin = q_direction;
-	}
 
 	float zNear = cam->getCameraNode()->getNearValue();
 	float zFar = getMaxFarValue();

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -13,6 +13,18 @@
 
 using m4f = core::matrix4;
 
+static v3f quantizeDirection(v3f direction, float step)
+{
+
+	float yaw = std::atan2(direction.Z, direction.X);
+	float pitch = std::asin(direction.Y); // assume look is normalized
+
+	yaw = std::floor(yaw / step) * step;
+	pitch = std::floor(pitch / step) * step;
+
+	return v3f(std::cos(yaw)*std::cos(pitch), std::sin(pitch), std::sin(yaw)*std::cos(pitch));
+}
+
 void DirectionalLight::createSplitMatrices(const Camera *cam)
 {
 	static const float COS_15_DEG = 0.965926f;
@@ -84,10 +96,23 @@ DirectionalLight::DirectionalLight(const u32 shadowMapResolution,
 		farPlane(farValue), mapRes(shadowMapResolution), pos(position)
 {}
 
-void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool force)
+void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool force, float timeoftheday)
 {
 	if (dirty && !force)
 		return;
+
+	if (timeoftheday < 0.05 || timeoftheday > 0.95 || (timeoftheday > 0.45 && timeoftheday < 0.55)) {
+		/*
+		 * When we are close to noon or midnight shadows do not move much,
+		 * so shadow-jitter due to rounding is more visible.
+		 * At those times we update shadows less often.
+		 */
+		v3f q_direction  = quantizeDirection(direction, M_PI / 2880 /*15 seconds*/);
+		if (q_direction == last_quant_directin)
+			return;
+
+		last_quant_directin = q_direction;
+	}
 
 	float zNear = cam->getCameraNode()->getNearValue();
 	float zFar = getMaxFarValue();

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -101,7 +101,7 @@ void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool fo
 	if (dirty && !force)
 		return;
 
-	if (timeoftheday < 0.05 || timeoftheday > 0.95 || (timeoftheday > 0.45 && timeoftheday < 0.55)) {
+	if (timeoftheday < 0.1 || timeoftheday > 0.9 || (timeoftheday > 0.4 && timeoftheday < 0.6)) {
 		/*
 		 * When we are close to noon or midnight shadows do not move much,
 		 * so shadow-jitter due to rounding is more visible.

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -101,7 +101,7 @@ void DirectionalLight::update_frustum(const Camera *cam, Client *client, bool fo
 	if (dirty && !force)
 		return;
 
-	if (timeoftheday < 0.1 || timeoftheday > 0.9 || (timeoftheday > 0.4 && timeoftheday < 0.6)) {
+	if (timeoftheday < 0.05 || timeoftheday > 0.95 || (timeoftheday > 0.45 && timeoftheday < 0.55)) {
 		/*
 		 * When we are close to noon or midnight shadows do not move much,
 		 * so shadow-jitter due to rounding is more visible.

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -36,7 +36,7 @@ public:
 
 	//DISABLE_CLASS_COPY(DirectionalLight)
 
-	void update_frustum(const Camera *cam, Client *client, bool force, float timeoftheday);
+	void update_frustum(const Camera *cam, Client *client, bool force = false);
 
 	// when set direction is updated to negative normalized(direction)
 	void setDirection(v3f dir);
@@ -102,7 +102,6 @@ private:
 
 	v3f last_cam_pos_world{0,0,0};
 	v3f last_look{0,1,0};
-	v3f last_quant_directin{0,0,0};
 
 	shadowFrustum shadow_frustum;
 	shadowFrustum future_frustum;

--- a/src/client/shadows/dynamicshadows.h
+++ b/src/client/shadows/dynamicshadows.h
@@ -36,7 +36,7 @@ public:
 
 	//DISABLE_CLASS_COPY(DirectionalLight)
 
-	void update_frustum(const Camera *cam, Client *client, bool force = false);
+	void update_frustum(const Camera *cam, Client *client, bool force, float timeoftheday);
 
 	// when set direction is updated to negative normalized(direction)
 	void setDirection(v3f dir);
@@ -102,6 +102,7 @@ private:
 
 	v3f last_cam_pos_world{0,0,0};
 	v3f last_look{0,1,0};
+	v3f last_quant_directin{0,0,0};
 
 	shadowFrustum shadow_frustum;
 	shadowFrustum future_frustum;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -341,7 +341,7 @@ void set_default_settings()
 	settings->setDefault("shadow_map_color", "false");
 	settings->setDefault("shadow_filters", "1");
 	settings->setDefault("shadow_poisson_filter", "true");
-	settings->setDefault("shadow_update_frames", "8");
+	settings->setDefault("shadow_update_frames", "16");
 	settings->setDefault("shadow_soft_radius", "5.0");
 	settings->setDefault("shadow_sky_body_orbit_tilt", "0.0");
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -341,7 +341,7 @@ void set_default_settings()
 	settings->setDefault("shadow_map_color", "false");
 	settings->setDefault("shadow_filters", "1");
 	settings->setDefault("shadow_poisson_filter", "true");
-	settings->setDefault("shadow_update_frames", "16");
+	settings->setDefault("shadow_update_frames", "8");
 	settings->setDefault("shadow_soft_radius", "5.0");
 	settings->setDefault("shadow_sky_body_orbit_tilt", "0.0");
 


### PR DESCRIPTION
Ever wondered why shadows are laggy even when you set `shadow_update_frames` to 1?
This most visible at dusk and dawn when shadows change quickly due to the angle of the sun.

This has bothered me for quite a while, so I finally tracked it down.
This was due to the direction quantization we do, which was added to reduce the jittering in the shadows (if it is updated less frequently you do not notice the jittering so much).

**I had an earlier version where I quantize less during dusk and dawn, but in the end I think we should just remove it.** If we really wanted to I can bring quantization back around midday and midnight whrere shadows move the least at the jittering would be most obvious)

The old logic shows a different shadow every PI/2880 change, at a day length of 20 minutes that comes to about **0.2s** (20*60/2/pi/2880 = 0.2083...), which matches my observation.

So we go through all the work calculating shadows, etc, just to not show them more than 5 times/s.

Instead we roughly get the same effect if `shadow_update_frames` is set to 16 (assuming 60 FPS).
For nice machines and larger shadow texture, folks now reduce this to get smooth shadow movement.

- Goal of the PR
Allow for smoothly changing shadows.

- How does the PR work?
Removing sun/moon direction quantization, replace it by increasing shadow update frames.
And that allows getting smooth shadow movements on better machine by reducing shadow update frames.

- Does it resolve any reported issue?
Nope

- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
Nope

- If not a bug fix, why is this PR needed? What usecases does it solve?
Shadows were laggy.

## To do

This PR is Ready for Review.

## How to test

Enable shadows. Pick a good view distance, set time to dusk/dawn and observe shadows moving in a choppy way.
Assuming 60FS this should be roughly the same before and after.

Now reduce `shadow_update_frames` to 1 and enjoy smoothly moving shadows.
