### PR TITLE
Fix CFileSystem::FileSystemType related UB

### DIFF
--- a/irr/src/CFileSystem.h
+++ b/irr/src/CFileSystem.h
@@ -91,7 +91,7 @@ public:
 
 private:
 	//! Currently used FileSystemType
-	EFileSystemType FileSystemType;
+	EFileSystemType FileSystemType = FILESYSTEM_NATIVE;
 	//! WorkingDirectory for Native and Virtual filesystems
 	io::path WorkingDirectory[2];
 	//! currently attached ArchiveLoaders


### PR DESCRIPTION
```

==1644281== Memcheck, a memory error detector                                                                                                                                           
==1644281== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.                                                                                                             
==1644281== Using Valgrind-3.23.0 and LibVEX; rerun with -h for copyright info                                                                                                          
==1644281== Command: ./bin/luanti                                                                                                                                                       
==1644281==                                                                                                                                                                             
==1644281== Conditional jump or move depends on uninitialised value(s)                                                                                                                  
==1644281==    at 0x582EEA0: irr::io::CFileSystem::setFileListSystem(irr::io::EFileSystemTyp                                                                                            
e) (CFileSystem.cpp:374)                                                                                                                                                                
==1644281==    by 0x582AAF2: irr::io::CFileSystem::CFileSystem() (CFileSystem.cpp:46)                                                                                                   
==1644281==    by 0x58302A4: irr::io::createFileSystem() (CFileSystem.cpp:488)                                                                                                          
==1644281==    by 0x51E3C49: irr::CIrrDeviceStub::CIrrDeviceStub(irr::SIrrlichtCreationParam                                                                                            
eters const&) (CIrrDeviceStub.cpp:77)                                                                                                                                                   
==1644281==    by 0x517812E: irr::CIrrDeviceLinux::CIrrDeviceLinux(irr::SIrrlichtCreationPar                                                                                            
ameters const&) (CIrrDeviceLinux.cpp:106)                                                                                                                                               
==1644281==    by 0x5173FA8: createDeviceEx (Irrlicht.cpp:66)                                                                                                                           
==1644281==    by 0x3AE21E7: createDevice(irr::SIrrlichtCreationParameters, std::optional<ir                                                                                            
r::video::E_DRIVER_TYPE>) (renderingengine.cpp:151)                                                                                                                                     
==1644281==    by 0x3AE3389: RenderingEngine::RenderingEngine(MyEventReceiver*) (renderingen                                                                                            
gine.cpp:209)                                                                                                                                                                           
==1644281==    by 0x35E8676: ClientLauncher::init_engine() (clientlauncher.cpp:290)                                                                                                     
==1644281==    by 0x35E3E74: ClientLauncher::run(GameStartData&, Settings const&) (clientlau                                                                                            
ncher.cpp:98)                                                                                                                                                                           
==1644281==    by 0x4A6C43A: main (main.cpp:265)                                                                                                                                        
==1644281==



```
