### PR TITLE
Fix always waving semitransparent liquid regression

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -51,7 +51,7 @@ centroid varying float nightRatio;
 varying highp vec3 eyeVec;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
-#if (defined(ENABLE_WATER_REFLECTIONS) && MATERIAL_WAVING_LIQUID && ENABLE_WAVING_WATER)
+#if (defined(ENABLE_WATER_REFLECTIONS) && MATERIAL_WATER_REFLECTIONS && ENABLE_WAVING_WATER)
 vec4 perm(vec4 x)
 {
 	return mod(((x * 34.0) + 1.0) * x, 289.0);
@@ -502,7 +502,7 @@ void main(void)
 		vec3 viewVec = normalize(worldPosition + cameraOffset - cameraPosition);
 
 		// Water reflections
-#if (defined(ENABLE_WATER_REFLECTIONS) && MATERIAL_WAVING_LIQUID && ENABLE_WAVING_WATER)
+#if (defined(ENABLE_WATER_REFLECTIONS) && MATERIAL_WATER_REFLECTIONS && ENABLE_WAVING_WATER)
 		vec3 wavePos = worldPosition * vec3(2.0, 0.0, 2.0);
 		float off = animationTimer * WATER_WAVE_SPEED * 10.0;
 		wavePos.x /= WATER_WAVE_LENGTH * 3.0;
@@ -530,7 +530,7 @@ void main(void)
 		col.rgb += water_reflect_color * f_adj_shadow_strength * brightness_factor;
 #endif
 
-#if (defined(ENABLE_NODE_SPECULAR) && !MATERIAL_WAVING_LIQUID)
+#if (defined(ENABLE_NODE_SPECULAR) && !MATERIAL_WATER_REFLECTIONS)
 		// Apply specular to blocks.
 		if (dot(v_LightDirection, vNormal) < 0.0) {
 			float intensity = 2.0 * (1.0 - (base.r * varColor.r));

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -687,11 +687,21 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
 		case TILE_MATERIAL_WAVING_LIQUID_OPAQUE:
 		case TILE_MATERIAL_WAVING_LIQUID_BASIC:
-		case TILE_MATERIAL_LIQUID_TRANSPARENT:
 			shaders_header << "#define MATERIAL_WAVING_LIQUID 1\n";
 			break;
 		default:
 			shaders_header << "#define MATERIAL_WAVING_LIQUID 0\n";
+			break;
+	}
+	switch (material_type) {
+		case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
+		case TILE_MATERIAL_WAVING_LIQUID_OPAQUE:
+		case TILE_MATERIAL_WAVING_LIQUID_BASIC:
+		case TILE_MATERIAL_LIQUID_TRANSPARENT:
+			shaders_header << "#define MATERIAL_WATER_REFLECTIONS 1\n";
+			break;
+		default:
+			shaders_header << "#define MATERIAL_WATER_REFLECTIONS 0\n";
 			break;
 	}
 


### PR DESCRIPTION
See <https://github.com/minetest/minetest/commit/a6293b9861b7e9ab8bb6ce91663f363970ecc816>.

cc @sfan5 

## To do

This PR is a Ready for Review.

## How to test

* Look at mtg river water (which has `use_texture_alpha = "blend"`, but is not waving).
* It should not wave.
* Try with water reflections (setting depends on shadows), it still has to be gummi bear liquid.