### PR TITLE
Remove built-in knockback from `punch()` in next major release

### DIFF
--- a/doc/breakages.md
+++ b/doc/breakages.md
@@ -22,4 +22,4 @@ This list is largely advisory and items may be reevaluated once the time comes.
 * remove `DIR_DELIM` from Lua
 * stop reading initial properties from bare entity def
 * change particle default blend mode to `clip`
-* remove built-in knockback from `PlayerSAO:punch()`
+* remove built-in knockback and related functions entirely

--- a/doc/breakages.md
+++ b/doc/breakages.md
@@ -22,3 +22,4 @@ This list is largely advisory and items may be reevaluated once the time comes.
 * remove `DIR_DELIM` from Lua
 * stop reading initial properties from bare entity def
 * change particle default blend mode to `clip`
+* remove built-in knockback from `obj:punch()`

--- a/doc/breakages.md
+++ b/doc/breakages.md
@@ -22,4 +22,4 @@ This list is largely advisory and items may be reevaluated once the time comes.
 * remove `DIR_DELIM` from Lua
 * stop reading initial properties from bare entity def
 * change particle default blend mode to `clip`
-* remove built-in knockback from `obj:punch()`
+* remove built-in knockback from `PlayerSAO:punch()`


### PR DESCRIPTION
It was confusing for me to see my weapons starting pushing people as soon as I increased their damage. I don't think Luanti should apply any knockback by default, surely not a knockback that increases according to the damage (also who knows what's my `hp_max`? If it's 1000, a damage of 30 is nothing). People can either manually apply a push on their own or use the `core.calculate_knockback(..)` function

- [ ] is `calculate_knockback` still useful if built-in knockback is removed?
