### PR TITLE
Fix CMatrix<T>::getScale returning negative scale

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1459,34 +1459,6 @@ void GenericCAO::updateBones(f32 dtime)
 		bone->setScale(props.getScale(bone->getScale()));
 	}
 
-	// search through bones to find mistakenly rotated bones due to bug in Irrlicht
-	for (u32 i = 0; i < m_animated_meshnode->getJointCount(); ++i) {
-		scene::IBoneSceneNode *bone = m_animated_meshnode->getJointNode(i);
-		if (!bone)
-			continue;
-
-		//If bone is manually positioned there is no need to perform the bug check
-		bool skip = false;
-		for (auto &it : m_bone_override) {
-			if (it.first == bone->getName()) {
-				skip = true;
-				break;
-			}
-		}
-		if (skip)
-			continue;
-
-		// Workaround for Irrlicht bug
-		// We check each bone to see if it has been rotated ~180deg from its expected position due to a bug in Irricht
-		// when using EJUOR_CONTROL joint control. If the bug is detected we update the bone to the proper position
-		// and update the bones transformation.
-		v3f bone_rot = bone->getRelativeTransformation().getRotationDegrees();
-		float offset = fabsf(bone_rot.X - bone->getRotation().X);
-		if (offset > 179.9f && offset < 180.1f) {
-			bone->setRotation(bone_rot);
-			bone->updateAbsolutePosition();
-		}
-	}
 	// The following is needed for set_bone_pos to propagate to
 	// attached objects correctly.
 	// Irrlicht ought to do this, but doesn't when using EJUOR_CONTROL.

--- a/src/unittest/test_irr_matrix4.cpp
+++ b/src/unittest/test_irr_matrix4.cpp
@@ -66,4 +66,21 @@ SECTION("setRotationRadians") {
     }
 }
 
+SECTION("getScale") {
+    SECTION("correctly gets the length of each row of the 3x3 submatrix") {
+        matrix4 A(
+            1, 2, 3, 0,
+            4, 5, 6, 0,
+            7, 8, 9, 0,
+            0, 0, 0, 1
+        );
+        v3f scale = A.getScale();
+        CHECK(scale.equals(v3f(
+            v3f(1, 2, 3).getLength(),
+            v3f(4, 5, 6).getLength(),
+            v3f(7, 8, 9).getLength()
+        )));
+    }
+}
+
 }


### PR DESCRIPTION
`CMatrix<T>::getScale` could previously, due to an "optimization" of dubious value, return negative values straight from the diagonal. This fixes that and simplifies the implementation a bit, removing the "optimization" entirely. (We could also `std::abs` it, but I don't see much of a point in that.)

After this fix, getting matrix rotations is a bit simpler, and a workaround which was only needed because we blindly shoveled a possibly negative scale into bone scene nodes (and thus had a rotation which didn't match that) can go.

There will be follow-up PRs.

## To do

This PR is Ready for Review.

## How to test

Play a bit with 3rd person with mods such as headanim that trigger the `EJUOR_CONTROL` code path, check that the bug the workaround fixed isn't back.

(As for how I conjecture the workaround ever worked to begin with: I believe the recalculation might create an error large enough that the flawed optimization doesn't trigger anymore.)
