### PR TITLE
Add `core.generate_biomes` and `core.generate_biome_dust` (2nd try)

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6784,6 +6784,19 @@ Environment access
        If set to true, decorations are placed in respect to the biome map of the current chunk.
        `pos1` and `pos2` must match the positions of the current chunk, or an error will be raised.
        default: `false`
+* `core.generate_biomes(vm, pos1, pos2[, noise_filler_depth])`
+    * Generate biome nodes according to the registered biomes and
+      temperature/humidity noises within the VoxelManip `vm` and in the area
+      from `pos1` to `pos2`.
+    * `noise_filler_depth` is an optional `ValueNoiseMap` to add an offset to
+      the `depth_filler` of the biomes (see [Biome definition]).
+    * Must be called during mapgen (`on_generated()` callback)
+    * `pos1` and `pos2` should have the same X and Z size as mapgen chunks.
+    * The initial data in `vm` should only contain air, stone, water and
+      river water nodes (see [Essential aliases]). Other nodes are ignored.
+    * Also populates the mapgen objects `heatmap`, `humiditymap` and `biomemap`
+      (see [Mapgen objects]), so that `core.generate_decorations` and
+      `core.generate_ores` will take them into account.
 * `core.clear_objects([options])`
     * Clear all objects in the environment
     * Takes an optional table as an argument with the field `mode`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6795,8 +6795,15 @@ Environment access
     * The initial data in `vm` should only contain air, stone, water and
       river water nodes (see [Essential aliases]). Other nodes are ignored.
     * Also populates the mapgen objects `heatmap`, `humiditymap` and `biomemap`
-      (see [Mapgen objects]), so that `core.generate_decorations` and
-      `core.generate_ores` will take them into account.
+      (see [Mapgen objects]), so that `core.generate_decorations`,
+      `core.generate_ores` and `core.generate_biome_dust` will take
+      them into account.
+* `core.generate_biome_dust(vm, pos1, pos2)`
+    * Generate the `node_dust` of the biome (see [Biome definition]) within the
+      VoxelManip `vm` and in the area from `pos1` to `pos2`.
+    * `pos1` and `pos2` should have the same X and Z size as mapgen chunks.
+    * Reads the mapgen object `biomemap` (see [Mapgen Objects]), that must be
+      already computed (ie. using `core.generate_biomes`).
 * `core.clear_objects([options])`
     * Clear all objects in the environment
     * Takes an optional table as an argument with the field `mode`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5203,9 +5203,16 @@ flowing. It is recommended to call this function only after having written all
 buffered data back to the VoxelManip object, save for special situations where
 the modder desires to only have certain liquid nodes begin flowing.
 
-The functions `core.generate_ores()` and `core.generate_decorations()`
-will generate all registered decorations and ores throughout the full area
-inside of the specified VoxelManip object.
+The functions `core.generate_biomes()`, `core.generate_ores()`,
+`core.generate_decorations()`, and `core.generate_biome_dust()` fill
+the entire area of a given VoxelManip with biomes, ores, decorations,
+and biome dust. They must be called inside the `on_generated()`
+callback.
+
+`core.generate_biomes()` must be called first, as it initializes the
+mapgen data (`heatmap`, `humiditymap`, `biomemap`) required by the
+subsequent functions for biome-aware placement of ores, decorations,
+and surface layers (e.g., snow).
 
 `core.place_schematic_on_vmanip()` is otherwise identical to
 `core.place_schematic()`, except instead of placing the specified schematic
@@ -6772,18 +6779,6 @@ Environment access
       active config.
 * `core.get_noiseparams(name)`
     * Returns a table of the noiseparams for name.
-* `core.generate_ores(vm[, pos1, pos2])`
-    * Generate all registered ores within the VoxelManip `vm` and in the area
-      from `pos1` to `pos2`.
-    * `pos1` and `pos2` are optional and default to mapchunk minp and maxp.
-* `core.generate_decorations(vm[, pos1, pos2, [use_mapgen_biomes]])`
-    * Generate all registered decorations within the VoxelManip `vm` and in the
-      area from `pos1` to `pos2`.
-    * `pos1` and `pos2` are optional and default to mapchunk minp and maxp.
-    * `use_mapgen_biomes` (optional boolean). For use in on_generated callbacks only.
-       If set to true, decorations are placed in respect to the biome map of the current chunk.
-       `pos1` and `pos2` must match the positions of the current chunk, or an error will be raised.
-       default: `false`
 * `core.generate_biomes(vm, pos1, pos2[, noise_filler_depth])`
     * Generate biome nodes according to the registered biomes and
       temperature/humidity noises within the VoxelManip `vm` and in the area
@@ -6798,6 +6793,18 @@ Environment access
       (see [Mapgen objects]), so that `core.generate_decorations`,
       `core.generate_ores` and `core.generate_biome_dust` will take
       them into account.
+* `core.generate_ores(vm[, pos1, pos2])`
+    * Generate all registered ores within the VoxelManip `vm` and in the area
+      from `pos1` to `pos2`.
+    * `pos1` and `pos2` are optional and default to mapchunk minp and maxp.
+* `core.generate_decorations(vm[, pos1, pos2, [use_mapgen_biomes]])`
+    * Generate all registered decorations within the VoxelManip `vm` and in the
+      area from `pos1` to `pos2`.
+    * `pos1` and `pos2` are optional and default to mapchunk minp and maxp.
+    * `use_mapgen_biomes` (optional boolean). For use in on_generated callbacks only.
+       If set to true, decorations are placed in respect to the biome map of the current chunk.
+       `pos1` and `pos2` must match the positions of the current chunk, or an error will be raised.
+       default: `false`
 * `core.generate_biome_dust(vm, pos1, pos2)`
     * Generate the `node_dust` of the biome (see [Biome definition]) within the
       VoxelManip `vm` and in the area from `pos1` to `pos2`.

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -114,6 +114,12 @@ Mapgen::Mapgen(int mapgenid, MapgenParams *params, EmergeParams *emerge) :
 
 	m_emerge  = emerge;
 	ndef      = emerge->ndef;
+
+	//// Initialize biome generator
+	// Unused by non-MapgenBasic mapgens, but may be used from Lua
+	biomegen = emerge->biomegen;
+	biomegen->assertChunkSize(csize);
+	biomemap = biomegen->biomemap;
 }
 
 Mapgen::~Mapgen()
@@ -588,11 +594,6 @@ MapgenBasic::MapgenBasic(int mapgenid, MapgenParams *params, EmergeParams *emerg
 	//// Allocate heightmap
 	this->heightmap = new s16[csize.X * csize.Z];
 
-	//// Initialize biome generator
-	biomegen = emerge->biomegen;
-	biomegen->assertChunkSize(csize);
-	biomemap = biomegen->biomemap;
-
 	//// Look up some commonly used content
 	c_stone              = ndef->getId("mapgen_stone");
 	c_water_source       = ndef->getId("mapgen_water_source");
@@ -616,7 +617,8 @@ MapgenBasic::MapgenBasic(int mapgenid, MapgenParams *params, EmergeParams *emerg
 
 MapgenBasic::~MapgenBasic()
 {
-	delete []heightmap;
+	if (heightmap)
+		delete []heightmap;
 }
 
 
@@ -629,7 +631,8 @@ void MapgenBasic::generateBiomes()
 	const v3s32 &em = vm->m_area.getExtent();
 	u32 index = 0;
 
-	noise_filler_depth->noiseMap2D(node_min.X, node_min.Z);
+	if (noise_filler_depth)
+	    noise_filler_depth->noiseMap2D(node_min.X, node_min.Z);
 
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, index++) {
@@ -655,6 +658,8 @@ void MapgenBasic::generateBiomes()
 		// If there is air or water above enable top/filler placement, otherwise force
 		// nplaced to stone level by setting a number exceeding any possible filler depth.
 		u16 nplaced = (air_above || water_above) ? 0 : U16_MAX;
+
+		float result = noise_filler_depth ? noise_filler_depth->result[index] : 0.0f;
 
 		for (s16 y = node_max.Y; y >= node_min.Y; y--) {
 			content_t c = vm->m_data[vi].getContent();
@@ -694,8 +699,7 @@ void MapgenBasic::generateBiomes()
 
 				depth_top = biome->depth_top;
 				base_filler = MYMAX(depth_top +
-					biome->depth_filler +
-					noise_filler_depth->result[index], 0.0f);
+					biome->depth_filler + result, 0.0f);
 				depth_water_top = biome->depth_water_top;
 				depth_riverbed = biome->depth_riverbed;
 			}

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -274,7 +274,9 @@ private:
 	inheriting MapgenBasic.
 */
 class MapgenBasic : public Mapgen {
+	friend class ModApiMapgen;
 public:
+	MapgenBasic() = default;
 	MapgenBasic(int mapgenid, MapgenParams *params, EmergeParams *emerge);
 	virtual ~MapgenBasic();
 

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -5,6 +5,7 @@
 #include "lua_api/l_mapgen.h"
 #include "lua_api/l_internal.h"
 #include "lua_api/l_vmanip.h"
+#include "lua_api/l_noise.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include "cpp_api/s_security.h"
@@ -13,6 +14,8 @@
 #include "servermap.h"
 #include "emerge_internal.h"
 #include "map_settings_manager.h"
+#include "emerge.h"
+#include "noise.h"
 #include "mapgen/mg_biome.h"
 #include "mapgen/mg_ore.h"
 #include "mapgen/mg_decoration.h"
@@ -1592,6 +1595,11 @@ int ModApiMapgen::l_generate_ores(lua_State *L)
 	mg.vm   = checkObject<LuaVoxelManip>(L, 1)->vm;
 	mg.ndef = emerge->ndef;
 
+	Mapgen *mg_current = emerge->getCurrentMapgen();
+	if (mg_current && mg_current->biomegen &&
+			mg_current->biomegen->getType() == BIOMEGEN_ORIGINAL)
+		mg.biomemap = mg_current->biomegen->biomemap;
+
 	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
 			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
 	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
@@ -1643,10 +1651,21 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 		mg.ndef = emerge->ndef;
 	}
 
-	const v3s16 default_pmin = vm->m_area.MinEdge + MAP_BLOCKSIZE,
-				default_pmax = vm->m_area.MaxEdge - MAP_BLOCKSIZE;
-	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) : default_pmin;
-	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) : default_pmax;
+	v3s16 pmin;
+	v3s16 pmax;
+	if (use_mapgen_biomes) {
+		assert(oldvm);
+		const v3s16 default_pmin = oldvm->m_area.MinEdge + MAP_BLOCKSIZE,
+			default_pmax = oldvm->m_area.MaxEdge - MAP_BLOCKSIZE;
+		pmin = lua_istable(L, 2) ? check_v3s16(L, 2) : default_pmin;
+		pmax = lua_istable(L, 3) ? check_v3s16(L, 3) : default_pmax;
+	} else {
+		const v3s16 default_pmin = vm->m_area.MinEdge + MAP_BLOCKSIZE,
+			default_pmax = vm->m_area.MaxEdge - MAP_BLOCKSIZE;
+		pmin = lua_istable(L, 2) ? check_v3s16(L, 2) : default_pmin;
+		pmax = lua_istable(L, 3) ? check_v3s16(L, 3) : default_pmax;
+	}
+
 	sortBoxVerticies(pmin, pmax);
 	if (use_mapgen_biomes) {
 		assert(oldvm);
@@ -1666,6 +1685,68 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 		throw;
 	}
 	mgp->vm = oldvm;
+
+	return 0;
+}
+
+
+// generate_biomes(vm, p1, p2, [noise_filler_depth])
+int ModApiMapgen::l_generate_biomes(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	EmergeManager *emerge = getServer(L)->getEmergeManager();
+	if (!emerge)
+		return 0;
+
+	Mapgen *mg_current = emerge->getCurrentMapgen();
+	if (!mg_current || !mg_current->biomegen ||
+			mg_current->biomegen->getType() != BIOMEGEN_ORIGINAL)
+		return 0;
+
+	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
+
+	MapgenBasic mg;
+
+	mg.c_stone              = ndef->getId("mapgen_stone");
+	mg.c_water_source       = ndef->getId("mapgen_water_source");
+	mg.c_river_water_source = ndef->getId("mapgen_river_water_source");
+
+	mg.vm   = checkObject<LuaVoxelManip>(L, 1)->vm;
+	mg.ndef = ndef;
+	mg.biomegen = mg_current->biomegen;
+	mg.biomemap = mg_current->biomegen->biomemap;
+	mg.water_level = mg_current->water_level;
+
+	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
+			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
+	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
+			mg.vm->m_area.MaxEdge - v3s16(1,1,1) * MAP_BLOCKSIZE;
+	sortBoxVerticies(pmin, pmax);
+	v3s16 psize = pmax - pmin + v3s16(1,1,1);
+
+	if (psize.X != (s16)mg_current->csize.X ||
+			psize.Z > (s16)mg_current->csize.Z) {
+		errorstream << "generate_biomes: X/Z extent must match"
+				" mapgen chunk size" << std::endl;
+		return 0;
+	}
+
+	mg.biomegen->calcBiomeNoise(pmin);
+
+	if (lua_isuserdata(L, 4)) {
+		LuaValueNoiseMap *nmap = checkObject<LuaValueNoiseMap>(L, 4);
+		Noise *noise = nmap->noise;
+		if ((s16)noise->sx == psize.X && (s16)noise->sz >= psize.Z)
+			mg.noise_filler_depth = noise;
+		else
+			warningstream << "generate_biomes: size of noisemap is inconsistent with chunk size,"
+					" noise will not be used" << std::endl;
+	}
+
+	mg.node_min = pmin;
+	mg.node_max = pmax;
+	mg.generateBiomes();
 
 	return 0;
 }
@@ -2102,6 +2183,7 @@ void ModApiMapgen::Initialize(lua_State *L, int top)
 
 	API_FCT(generate_ores);
 	API_FCT(generate_decorations);
+	API_FCT(generate_biomes);
 	API_FCT(create_schematic);
 	API_FCT(place_schematic);
 	API_FCT(place_schematic_on_vmanip);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1752,6 +1752,47 @@ int ModApiMapgen::l_generate_biomes(lua_State *L)
 }
 
 
+// generate_biome_dust(vm, p1, p2)
+int ModApiMapgen::l_generate_biome_dust(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	EmergeManager *emerge = getServer(L)->getEmergeManager();
+	if (!emerge)
+		return 0;
+
+	Mapgen *mg_current = emerge->getCurrentMapgen();
+	if (!mg_current || !mg_current->biomegen ||
+			mg_current->biomegen->getType() != BIOMEGEN_ORIGINAL)
+		return 0;
+
+	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
+
+	MapgenBasic mg;
+
+	mg.vm   = checkObject<LuaVoxelManip>(L, 1)->vm;
+	mg.m_bmgr = mg_current->m_emerge->biomemgr;
+	mg.ndef = ndef;
+	mg.biomegen = mg_current->biomegen;
+	mg.biomemap = mg_current->biomegen->biomemap;
+	mg.water_level = mg_current->water_level;
+
+	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
+			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
+	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
+			mg.vm->m_area.MaxEdge - v3s16(1,1,1) * MAP_BLOCKSIZE;
+	sortBoxVerticies(pmin, pmax);
+
+	mg.node_min = pmin;
+	mg.node_max = pmax;
+	mg.full_node_min = mg.vm->m_area.MinEdge;
+	mg.full_node_max = mg.vm->m_area.MaxEdge;
+	mg.dustTopNodes();
+
+	return 0;
+}
+
+
 // create_schematic(p1, p2, probability_list, filename, y_slice_prob_list)
 int ModApiMapgen::l_create_schematic(lua_State *L)
 {
@@ -2184,6 +2225,7 @@ void ModApiMapgen::Initialize(lua_State *L, int top)
 	API_FCT(generate_ores);
 	API_FCT(generate_decorations);
 	API_FCT(generate_biomes);
+	API_FCT(generate_biome_dust);
 	API_FCT(create_schematic);
 	API_FCT(place_schematic);
 	API_FCT(place_schematic_on_vmanip);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1721,8 +1721,8 @@ int ModApiMapgen::l_generate_biomes(lua_State *L)
 	mg.biomemap = bgen->biomemap;
 	mg.water_level = mg_current->water_level;
 
-	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
-			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
+	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) - v3s16(0,1,0) :
+			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE - v3s16(0,1,0);
 	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
 			mg.vm->m_area.MaxEdge - v3s16(1,1,1) * MAP_BLOCKSIZE;
 	sortBoxVerticies(pmin, pmax);
@@ -1778,8 +1778,8 @@ int ModApiMapgen::l_generate_biome_dust(lua_State *L)
 
 	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
 			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
-	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
-			mg.vm->m_area.MaxEdge - v3s16(1,1,1) * MAP_BLOCKSIZE;
+	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) - v3s16(0,1,0) :
+			mg.vm->m_area.MaxEdge - v3s16(1,1,1) * MAP_BLOCKSIZE - v3s16(0,1,0);
 	sortBoxVerticies(pmin, pmax);
 
 	mg.node_min = pmin;

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -123,6 +123,9 @@ private:
 	// generate_biomes(vm, p1, p2, [noise_filler_depth])
 	static int l_generate_biomes(lua_State *L);
 
+	// generate_biome_dust(vm, p1, p2)
+	static int l_generate_biome_dust(lua_State *L);
+
 	// clear_registered_ores
 	static int l_clear_registered_ores(lua_State *L);
 

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -120,6 +120,9 @@ private:
 	// generate_decorations(vm, p1, p2)
 	static int l_generate_decorations(lua_State *L);
 
+	// generate_biomes(vm, p1, p2, [noise_filler_depth])
+	static int l_generate_biomes(lua_State *L);
+
 	// clear_registered_ores
 	static int l_clear_registered_ores(lua_State *L);
 

--- a/src/script/lua_api/l_noise.h
+++ b/src/script/lua_api/l_noise.h
@@ -47,6 +47,7 @@ public:
 */
 class LuaValueNoiseMap : public ModApiBase
 {
+	friend class ModApiMapgen;
 	Noise *noise;
 
 	static luaL_Reg methods[];


### PR DESCRIPTION
Attempted revival of https://github.com/luanti-org/luanti/pull/14260
Fixes #8329 
Keep in mind that I have no C++ experience so this may be funny and could take some time.

### Description of the PR:

As in the original: https://github.com/luanti-org/luanti/pull/14260

## To do

This PR is READY

- [x] Rebase (surprisingly resolving the conflict was trivial)
- [x] Test and see that it still works
- [x] Test it with the mapgen env
- [x] Address reviewers' concerns from the original PR

I'm not sure about this https://github.com/luanti-org/luanti/pull/14260#issuecomment-2060919126 but otherwise I hopefully addressed all review things.

EDIT: I think I fixed it here https://github.com/luanti-org/luanti/pull/15730/commits/05e4b7a7f940749cfef48bce3bc6ed4db31fd785

## How to test

1. Clone this [mod](https://github.com/kromka-chleba/lvm_example) to your `minetest/mods/`
2. Enter the directory, switch to the `use_core_biomegen` branch
3. Make a new MTG world
4. Enable the `lvm_example` mod
5. Witness it working
6. Optionally switch to the `master` branch of `lvm_example` and see that it doesn't place biomes and dust.

Testing it in the mapgen env:
1. Create a `flatgen` directory in your `minetest/mods/`
2. Download the [flatgen fork](https://gist.github.com/kromka-chleba/cadf00452eff5cb972de59269e2ea026) and put the files into `flatgen`
3. Make a new MTG world
4. Enable the `flatgen` mod
5. Witness it working