### PR TITLE
Client: Don't allow dropping items while dead

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1841,7 +1841,9 @@ void Game::processUserInput(f32 dtime)
 
 void Game::processKeyInput()
 {
-	if (wasKeyDown(KeyType::DROP)) {
+	const auto *player = client->getEnv().getLocalPlayer();
+	const bool dead = player->getCAO() && player->isDead();
+	if (wasKeyDown(KeyType::DROP) && !dead) {
 		dropSelectedItem(isKeyDown(KeyType::SNEAK));
 	} else if (wasKeyDown(KeyType::AUTOFORWARD)) {
 		toggleAutoforward();


### PR DESCRIPTION
Should fix #15728 in ~95%? of cases, effectively going back to the previous state (where the formspec prevented this), and should be something we definitely want to do, no matter whether we fix it fully in the future.

There might technically still be a possible race condition if items are dropped in the very moment the player dies, but that should be relatively unlikely to happen.

Ideally we would also want to disable other controls, but as it turns out that requires different changes in different places and I don't want to pollute this trivial PR.

## How to test

As described in the issue. Observe that you simply can't drop things while dead anymore.