### PR TITLE
Hotfix for pause singleplayer game in Settings menu.

### DIFF
--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -806,6 +806,8 @@ else
 			-- only needed for the "fields.back" case, in the "fields.quit"
 			-- case it's a no-op
 			core.show_formspec("__builtin:settings", "")
+			-- FIXME: hotfix for #15779
+			core.delete_settings_menu()
 		end
 
 		core.show_formspec("__builtin:settings", get_formspec(dialog.data))

--- a/src/client/game_formspec.cpp
+++ b/src/client/game_formspec.cpp
@@ -522,6 +522,8 @@ bool GameFormSpec::handleCallbacks()
 
 	if (g_gamecallback->settings_requested) {
 		m_pause_script->open_settings();
+		// FIXME: hotfix for #15779
+		g_gamecallback->paused = true;
 		g_gamecallback->settings_requested = false;
 	}
 

--- a/src/gui/mainmenumanager.h
+++ b/src/gui/mainmenumanager.h
@@ -34,6 +34,76 @@ public:
 extern gui::IGUIEnvironment *guienv;
 extern gui::IGUIStaticText *guiroot;
 
+class MainGameCallback : public IGameCallback
+{
+public:
+	MainGameCallback() = default;
+	virtual ~MainGameCallback() = default;
+
+	void exitToOS() override
+	{
+		shutdown_requested = true;
+	}
+
+	void openSettings() override
+	{
+		settings_requested = true;
+	}
+
+	void disconnect() override
+	{
+		disconnect_requested = true;
+	}
+
+	void changePassword() override
+	{
+		changepassword_requested = true;
+	}
+
+	void changeVolume() override
+	{
+		changevolume_requested = true;
+	}
+
+	void keyConfig() override
+	{
+		keyconfig_requested = true;
+	}
+
+	void signalKeyConfigChange() override
+	{
+		keyconfig_changed = true;
+	}
+
+	void touchscreenLayout() override
+	{
+		touchscreenlayout_requested = true;
+	}
+
+	void showOpenURLDialog(const std::string &url) override
+	{
+		show_open_url_dialog = url;
+	}
+
+	void unpause()
+	{
+		paused = false;
+	}
+
+	bool disconnect_requested = false;
+	bool settings_requested = false;
+	bool changepassword_requested = false;
+	bool changevolume_requested = false;
+	bool keyconfig_requested = false;
+	bool touchscreenlayout_requested = false;
+	bool shutdown_requested = false;
+	bool keyconfig_changed = false;
+	std::string show_open_url_dialog = "";
+	bool paused = false;
+};
+
+extern MainGameCallback *g_gamecallback;
+
 // Handler for the modal menus
 
 class MainMenuManager : public IMenuManager
@@ -91,6 +161,9 @@ public:
 			if (mm && mm->pausesGame())
 				return true;
 		}
+		// FIXME: hotfix for #15779
+		if (g_gamecallback && g_gamecallback->paused)
+			return true;
 		return false;
 	}
 
@@ -104,67 +177,3 @@ static inline bool isMenuActive()
 {
 	return g_menumgr.menuCount() != 0;
 }
-
-class MainGameCallback : public IGameCallback
-{
-public:
-	MainGameCallback() = default;
-	virtual ~MainGameCallback() = default;
-
-	void exitToOS() override
-	{
-		shutdown_requested = true;
-	}
-
-	void openSettings() override
-	{
-		settings_requested = true;
-	}
-
-	void disconnect() override
-	{
-		disconnect_requested = true;
-	}
-
-	void changePassword() override
-	{
-		changepassword_requested = true;
-	}
-
-	void changeVolume() override
-	{
-		changevolume_requested = true;
-	}
-
-	void keyConfig() override
-	{
-		keyconfig_requested = true;
-	}
-
-	void signalKeyConfigChange() override
-	{
-		keyconfig_changed = true;
-	}
-
-	void touchscreenLayout() override
-	{
-		touchscreenlayout_requested = true;
-	}
-
-	void showOpenURLDialog(const std::string &url) override
-	{
-		show_open_url_dialog = url;
-	}
-
-	bool disconnect_requested = false;
-	bool settings_requested = false;
-	bool changepassword_requested = false;
-	bool changevolume_requested = false;
-	bool keyconfig_requested = false;
-	bool touchscreenlayout_requested = false;
-	bool shutdown_requested = false;
-	bool keyconfig_changed = false;
-	std::string show_open_url_dialog = "";
-};
-
-extern MainGameCallback *g_gamecallback;

--- a/src/script/lua_api/l_pause_menu.cpp
+++ b/src/script/lua_api/l_pause_menu.cpp
@@ -20,9 +20,16 @@ int ModApiPauseMenu::l_show_touchscreen_layout(lua_State *L)
 	return 0;
 }
 
+// FIXME: hotfix for #15779
+int ModApiPauseMenu::l_delete_settings_menu(lua_State *L)
+{
+	g_gamecallback->unpause();
+	return 0;
+}
 
 void ModApiPauseMenu::Initialize(lua_State *L, int top)
 {
 	API_FCT(show_keys_menu);
 	API_FCT(show_touchscreen_layout);
+	API_FCT(delete_settings_menu);
 }

--- a/src/script/lua_api/l_pause_menu.h
+++ b/src/script/lua_api/l_pause_menu.h
@@ -11,6 +11,8 @@ class ModApiPauseMenu: public ModApiBase
 private:
 	static int l_show_keys_menu(lua_State *L);
 	static int l_show_touchscreen_layout(lua_State *L);
+	// FIXME: hotfix for #15779
+	static int l_delete_settings_menu(lua_State *L);
 
 public:
 	static void Initialize(lua_State *L, int top);


### PR DESCRIPTION
Fix the single-player game not paused in the Settings menu.

- Does it resolve any reported issue?
#15779

## To do

This PR is a Ready for Review.

## How to test

Try single-player and multiplayer games and check if the game is paused/unpaused as expected if you are in the Settings menu.
