### PR TITLE
Fix z-fighting between nodebox and liquid faces

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -422,7 +422,7 @@ void MapblockMeshGenerator::drawSolidNode()
 			if (cur_node.f->drawtype == NDT_LIQUID) {
 				if (cur_node.f->sameLiquidRender(f2))
 					continue;
-				backface_culling = f2.solidness || f2.visual_solidness;
+				backface_culling = f2.solidness || f2.visual_solidness || f2.drawtype == NDT_NODEBOX;
 			}
 		}
 		faces |= 1 << face;


### PR DESCRIPTION
## Background

Fixes #15778. It is common for nodeboxes to define sides ±0.5 to align with other nodes. If these nodes are placed underwater, it will cause annoying z-fighting since these faces overlap with the liquid faces.

## Solution

I noticed that this is solved for glass and leaves by culling the face which is pointing towards the player. This seems to work pretty well for nodeboxes as well.

It does have one quirk though, and that is when looking up over a nodebox node at the edge of the water. This will result in what appears to be a "hole" in the water. This also happens for leaves and glass.

I have attached screenshots. The first two show how it looks if you look down on the node for this branch and master respectively. The second two show the quirk I was talking about when looking up. I have included leaves and glass in the screenshot to show that the same issue exists for those nodes.

I think the quirk is acceptable since the same issue exists for leaves and grass. It is better than the annoying flickering z-fighting that is present on master. I also think it makes sense to handle glass, leaves and nodeboxes in the same way for consistency.

![mpv-shot0002](https://github.com/user-attachments/assets/71a4dbe5-d69e-4ad6-8661-5861c80a3335)
![mpv-shot0001](https://github.com/user-attachments/assets/f23b7cb0-ea06-49f9-8357-37ab5ee118b4)
![mpv-shot0004](https://github.com/user-attachments/assets/52c805c8-b438-496a-88d5-86d0afb182b5)
![mpv-shot0003](https://github.com/user-attachments/assets/9eb5b0bc-2ac5-4624-96e7-6cbac1b4f23f)

## To do

This PR should be ready for review.

## How to test

- Start the devtest game and place some of the test nodebox nodes underwater
