### PR TITLE
Rename Perlin noise to (fractal) value noise

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -19,7 +19,7 @@ read_globals = {
 	"VoxelManip",
 	"profiler",
 	"Settings",
-	"PerlinNoise", "PerlinNoiseMap",
+	"ValueNoise", "ValueNoiseMap",
 
 	string = {fields = {"split", "trim"}},
 	table  = {fields = {"copy", "copy_with_metatables", "getn", "indexof", "keyof", "insert_all"}},

--- a/builtin/emerge/env.lua
+++ b/builtin/emerge/env.lua
@@ -33,7 +33,7 @@ function core.get_node(pos)
 	return core.vmanip:get_node_at(pos)
 end
 
-function core.get_perlin(seed, octaves, persist, spread)
+function core.get_value_noise(seed, octaves, persist, spread)
 	local params
 	if type(seed) == "table" then
 		params = table.copy(seed)
@@ -47,12 +47,18 @@ function core.get_perlin(seed, octaves, persist, spread)
 		}
 	end
 	params.seed = core.get_seed(params.seed) -- add mapgen seed
-	return PerlinNoise(params)
+	return ValueNoise(params)
 end
 
-
-function core.get_perlin_map(params, size)
+function core.get_value_noise_map(params, size)
 	local params2 = table.copy(params)
 	params2.seed = core.get_seed(params.seed) -- add mapgen seed
-	return PerlinNoiseMap(params2, size)
+	return ValueNoiseMap(params2, size)
 end
+
+-- deprecated as of 5.12, as it was not Perlin noise
+-- but with no warnings (yet) for compatibility
+core.get_perlin = core.get_value_noise
+core.get_perlin_map = core.get_value_noise_map
+PerlinNoise = ValueNoise
+PerlinNoiseMap = ValueNoiseMap

--- a/builtin/game/deprecated.lua
+++ b/builtin/game/deprecated.lua
@@ -61,3 +61,10 @@ function core.register_on_auth_fail(func)
 		end
 	end)
 end
+
+-- deprecated as of 5.12, as it was not Perlin noise
+-- but with no warnings (yet) for compatibility
+core.get_perlin = core.get_value_noise
+core.get_perlin_map = core.get_value_noise_map
+PerlinNoise = ValueNoise
+PerlinNoiseMap = ValueNoiseMap

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4520,22 +4520,25 @@ textdomain match the mod name, but this isn't required.
 
 
 
-Perlin noise
-============
+Fractal value noise
+===================
 
-Perlin noise creates a continuously-varying value depending on the input values.
+Value noise creates a continuously-varying value depending on the input values.
+It is similar to Perlin noise, but may exhibit more geometric artifacts,
+as it interpolates between values and not between gradients as in Perlin noise.
+
 Usually in Luanti the input values are either 2D or 3D coordinates in nodes.
 The result is used during map generation to create the terrain shape, vary heat
 and humidity to distribute biomes, vary the density of decorations or vary the
 structure of ores.
 
-Structure of perlin noise
--------------------------
+Structure of fractal value noise
+--------------------------------
 
 An 'octave' is a simple noise generator that outputs a value between -1 and 1.
 The smooth wavy noise it generates has a single characteristic scale, almost
 like a 'wavelength', so on its own does not create fine detail.
-Due to this perlin noise combines several octaves to create variation on
+Due to this fractal value noise combines several octaves to create variation on
 multiple scales. Each additional octave has a smaller 'wavelength' than the
 previous.
 
@@ -4543,7 +4546,7 @@ This combination results in noise varying very roughly between -2.0 and 2.0 and
 with an average value of 0.0, so `scale` and `offset` are then used to multiply
 and offset the noise variation.
 
-The final perlin noise variation is created as follows:
+The final fractal value noise variation is created as follows:
 
 noise = offset + scale * (octave1 +
                           octave2 * persistence +
@@ -4661,7 +4664,7 @@ with restraint.
 #### `absvalue`
 
 The absolute value of each octave's noise variation is used when combining the
-octaves. The final perlin noise variation is created as follows:
+octaves. The final value noise variation is created as follows:
 
 noise = offset + scale * (abs(octave1) +
                           abs(octave2) * persistence +
@@ -4671,7 +4674,7 @@ noise = offset + scale * (abs(octave1) +
 
 ### Format example
 
-For 2D or 3D perlin noise or perlin noise maps:
+For 2D or 3D value noise or value noise maps:
 
 ```lua
 np_terrain = {
@@ -4706,13 +4709,13 @@ All default ores are of the uniformly-distributed scatter type.
 
 Randomly chooses a location and generates a cluster of ore.
 
-If `noise_params` is specified, the ore will be placed if the 3D perlin noise
+If `noise_params` is specified, the ore will be placed if the 3D value noise
 at that point is greater than the `noise_threshold`, giving the ability to
 create a non-equal distribution of ore.
 
 ### `sheet`
 
-Creates a sheet of ore in a blob shape according to the 2D perlin noise
+Creates a sheet of ore in a blob shape according to the 2D value noise
 described by `noise_params` and `noise_threshold`. This is essentially an
 improved version of the so-called "stratus" ore seen in some unofficial mods.
 
@@ -4745,14 +4748,14 @@ noise parameters `np_puff_top` and `np_puff_bottom`, respectively.
 
 ### `blob`
 
-Creates a deformed sphere of ore according to 3d perlin noise described by
+Creates a deformed sphere of ore according to 3d value noise described by
 `noise_params`. The maximum size of the blob is `clust_size`, and
 `clust_scarcity` has the same meaning as with the `scatter` type.
 
 ### `vein`
 
 Creates veins of ore varying in density by according to the intersection of two
-instances of 3d perlin noise with different seeds, both described by
+instances of 3d value noise with different seeds, both described by
 `noise_params`.
 
 `random_factor` varies the influence random chance has on placement of an ore
@@ -4787,8 +4790,8 @@ computationally expensive than any other ore.
 Creates a single undulating ore stratum that is continuous across mapchunk
 borders and horizontally spans the world.
 
-The 2D perlin noise described by `noise_params` defines the Y coordinate of
-the stratum midpoint. The 2D perlin noise described by `np_stratum_thickness`
+The 2D value noise described by `noise_params` defines the Y coordinate of
+the stratum midpoint. The 2D value noise described by `np_stratum_thickness`
 defines the stratum's vertical thickness (in units of nodes). Due to being
 continuous across mapchunk borders the stratum's vertical thickness is
 unlimited.
@@ -5036,7 +5039,7 @@ and the array index for a position p contained completely in p1..p2 is:
 `(p.Z - p1.Z) * Ny * Nx + (p.Y - p1.Y) * Nx + (p.X - p1.X) + 1`
 
 Note that this is the same "flat 3D array" format as
-`PerlinNoiseMap:get3dMap_flat()`.
+`ValueNoiseMap:get3dMap_flat()`.
 VoxelArea objects (see section [`VoxelArea`]) can be used to simplify calculation
 of the index for a single point in a flat VoxelManip array.
 
@@ -5227,7 +5230,7 @@ The coordinates are *inclusive*, like most other things in Luanti.
     * The position (x, y, z) is not checked for being inside the area volume,
       being outside can cause an incorrect index result.
     * Useful for things like `VoxelManip`, raw Schematic specifiers,
-      `PerlinNoiseMap:get2d`/`3dMap`, and so on.
+      `ValueNoiseMap:get2d`/`3dMap`, and so on.
 * `indexp(p)`: same functionality as `index(x, y, z)` but takes a vector.
     * As with `index(x, y, z)`, the components of `p` must be integers, and `p`
       is not checked for being inside the area volume.
@@ -6518,12 +6521,18 @@ Environment access
     * `nodenames`: e.g. `{"ignore", "group:tree"}` or `"default:dirt"`
     * Return value: Table with all node positions with a node air above
     * Area volume is limited to 150,000,000 nodes
-* `core.get_perlin(noiseparams)`
-    * Return world-specific perlin noise.
+* `core.get_value_noise(noiseparams)`
+    * Return world-specific value noise.
     * The actual seed used is the noiseparams seed plus the world seed.
+* `core.get_value_noise(seeddiff, octaves, persistence, spread)`
+    * Deprecated: use `core.get_value_noise(noiseparams)` instead.
+    * Return world-specific value noise
+* `core.get_perlin(noiseparams)`
+    * Deprecated: use `core.get_value_noise(noiseparams)` instead.
+    * Return world-specific value noise (was not Perlin noise)
 * `core.get_perlin(seeddiff, octaves, persistence, spread)`
-    * Deprecated: use `core.get_perlin(noiseparams)` instead.
-    * Return world-specific perlin noise.
+    * Deprecated: use `core.get_value_noise(noiseparams)` instead.
+    * Return world-specific value noise (was not Perlin noise)
 * `core.get_voxel_manip([pos1, pos2])`
     * Return voxel manipulator object.
     * Loads the manipulator from the map if positions are passed.
@@ -7098,8 +7107,8 @@ Classes:
 
 * `AreaStore`
 * `ItemStack`
-* `PerlinNoise`
-* `PerlinNoiseMap`
+* `ValueNoise`
+* `ValueNoiseMap`
 * `PseudoRandom`
 * `PcgRandom`
 * `SecureRandom`
@@ -7111,8 +7120,8 @@ Classes:
 Class instances that can be transferred between environments:
 
 * `ItemStack`
-* `PerlinNoise`
-* `PerlinNoiseMap`
+* `ValueNoise`
+* `ValueNoiseMap`
 * `VoxelManip`
 
 Functions:
@@ -7178,8 +7187,8 @@ Classes:
 
 * `AreaStore`
 * `ItemStack`
-* `PerlinNoise`
-* `PerlinNoiseMap`
+* `ValueNoise`
+* `ValueNoiseMap`
 * `PseudoRandom`
 * `PcgRandom`
 * `SecureRandom`
@@ -9005,33 +9014,41 @@ offering very strong randomness.
 * `get_state()`: return generator state encoded in string
 * `set_state(state_string)`: restore generator state from encoded string
 
-`PerlinNoise`
+`ValueNoise`
 -------------
 
-A perlin noise generator.
-It can be created via `PerlinNoise()` or `core.get_perlin()`.
-For `core.get_perlin()`, the actual seed used is the noiseparams seed
+A value noise generator.
+It can be created via `ValueNoise()` or `core.get_value_noise()`.
+For legacy reasons, it can also be created via `PerlinNoise()` or `core.get_perlin()`,
+but the implemented noise is not Perlin noise.
+For `core.get_value_noise()`, the actual seed used is the noiseparams seed
 plus the world seed, to create world-specific noise.
 
-`PerlinNoise(noiseparams)`
-`PerlinNoise(seed, octaves, persistence, spread)` (Deprecated).
+* `ValueNoise(noiseparams)
+* `ValueNoise(seed, octaves, persistence, spread)` (Deprecated)
+* `PerlinNoise(noiseparams)` (Deprecated)
+* `PerlinNoise(seed, octaves, persistence, spread)` (Deprecated)
 
-`core.get_perlin(noiseparams)`
-`core.get_perlin(seeddiff, octaves, persistence, spread)` (Deprecated).
+* `core.get_value_noise(noiseparams)`
+* `core.get_value_noise(seeddiff, octaves, persistence, spread)` (Deprecated)
+* `core.get_perlin(noiseparams)` (Deprecated)
+* `core.get_perlin(seeddiff, octaves, persistence, spread)` (Deprecated)
 
 ### Methods
 
 * `get_2d(pos)`: returns 2D noise value at `pos={x=,y=}`
 * `get_3d(pos)`: returns 3D noise value at `pos={x=,y=,z=}`
 
-`PerlinNoiseMap`
+`ValueNoiseMap`
 ----------------
 
-A fast, bulk perlin noise generator.
+A fast, bulk noise generator.
 
-It can be created via `PerlinNoiseMap(noiseparams, size)` or
-`core.get_perlin_map(noiseparams, size)`.
-For `core.get_perlin_map()`, the actual seed used is the noiseparams seed
+It can be created via `ValueNoiseMap(noiseparams, size)` or
+`core.get_value_noise_map(noiseparams, size)`.
+For legacy reasons, it can also be created via `PerlinNoiseMap(noiseparams, size)`
+or `core.get_perlin_map(noiseparams, size)`, but it is not Perlin noise.
+For `core.get_value_noise_map()`, the actual seed used is the noiseparams seed
 plus the world seed, to create world-specific noise.
 
 Format of `size` is `{x=dimx, y=dimy, z=dimz}`. The `z` component is omitted
@@ -9058,7 +9075,7 @@ table.
 * `get_map_slice(slice_offset, slice_size, buffer)`: In the form of an array,
   returns a slice of the most recently computed noise results. The result slice
   begins at coordinates `slice_offset` and takes a chunk of `slice_size`.
-  E.g. to grab a 2-slice high horizontal 2d plane of noise starting at buffer
+  E.g., to grab a 2-slice high horizontal 2d plane of noise starting at buffer
   offset y = 20:
   `noisevals = noise:get_map_slice({y=20}, {y=2})`
   It is important to note that `slice_offset` offset coordinates begin at 1,
@@ -10746,7 +10763,7 @@ See [Ores] section above for essential information.
         octaves = 3,
         persistence = 0.7
     },
-    -- NoiseParams structure describing one of the perlin noises used for
+    -- NoiseParams structure describing one of the noises used for
     -- ore distribution.
     -- Needed by "sheet", "puff", "blob" and "vein" ores.
     -- Omit from "scatter" ore for a uniform ore distribution.
@@ -10933,7 +10950,7 @@ See [Decoration types]. Used by `core.register_decoration`.
         lacunarity = 2.0,
         flags = "absvalue"
     },
-    -- NoiseParams structure describing the perlin noise used for decoration
+    -- NoiseParams structure describing the noise used for decoration
     -- distribution.
     -- A noise value is calculated for each square division and determines
     -- 'decorations per surface node' within each division.

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -474,7 +474,7 @@ void Clouds::readSettings()
 bool Clouds::gridFilled(int x, int y) const
 {
 	float cloud_size_noise = cloud_size / (BS * 200.f);
-	float noise = noise2d_perlin(
+	float noise = noise2d_fractal(
 			(float)x * cloud_size_noise,
 			(float)y * cloud_size_noise,
 			m_seed, 3, 0.5);

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -61,8 +61,8 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 	assert(vm);
 	assert(biomemap);
 
-	noise_cave1->perlinMap3D(nmin.X, nmin.Y - 1, nmin.Z);
-	noise_cave2->perlinMap3D(nmin.X, nmin.Y - 1, nmin.Z);
+	noise_cave1->noiseMap3D(nmin.X, nmin.Y - 1, nmin.Z);
+	noise_cave2->noiseMap3D(nmin.X, nmin.Y - 1, nmin.Z);
 
 	const v3s32 &em = vm->m_area.getExtent();
 	u32 index2d = 0;  // Biomemap index
@@ -218,7 +218,7 @@ bool CavernsNoise::generateCaverns(MMVManip *vm, v3s16 nmin, v3s16 nmax)
 	assert(vm);
 
 	// Calculate noise
-	noise_cavern->perlinMap3D(nmin.X, nmin.Y - 1, nmin.Z);
+	noise_cavern->noiseMap3D(nmin.X, nmin.Y - 1, nmin.Z);
 
 	// Cache cavern_amp values
 	float *cavern_amp = new float[m_csize.Y + 1];
@@ -532,7 +532,7 @@ void CavesRandomWalk::carveRoute(v3f vec, float f, bool randomize_xz)
 			// If cave liquid not defined by biome, fallback to old hardcoded behavior.
 			// TODO 'np_caveliquids' is deprecated and should eventually be removed.
 			// Cave liquids are now defined and located using biome definitions.
-			float nval = NoisePerlin3D(np_caveliquids, startp.X,
+			float nval = NoiseFractal3D(np_caveliquids, startp.X,
 				startp.Y, startp.Z, seed);
 			liquidnode = (nval < 0.40f && node_max.Y < water_level - 256) ?
 				lavanode : waternode;

--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -114,7 +114,7 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 		u32 i = vm->m_area.index(nmin.X, y, z);
 		for (s16 x = nmin.X; x <= nmax.X; x++) {
 			if (vm->m_data[i].getContent() == dp.c_wall) {
-				if (NoisePerlin3D(&dp.np_alt_wall, x, y, z, blockseed) > 0.0f)
+				if (NoiseFractal3D(&dp.np_alt_wall, x, y, z, blockseed) > 0.0f)
 					vm->m_data[i].setContent(dp.c_alt_wall);
 			}
 			i++;

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -632,7 +632,7 @@ void MapgenBasic::generateBiomes()
 	const v3s32 &em = vm->m_area.getExtent();
 	u32 index = 0;
 
-	noise_filler_depth->perlinMap2D(node_min.X, node_min.Z);
+	noise_filler_depth->noiseMap2D(node_min.X, node_min.Z);
 
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, index++) {
@@ -897,7 +897,7 @@ void MapgenBasic::generateDungeons(s16 max_stone_y)
 		return;
 
 	u16 num_dungeons = std::fmax(std::floor(
-		NoisePerlin3D(&np_dungeons, node_min.X, node_min.Y, node_min.Z, seed)), 0.0f);
+		NoiseFractal3D(&np_dungeons, node_min.X, node_min.Y, node_min.Z, seed)), 0.0f);
 	if (num_dungeons == 0)
 		return;
 

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -329,34 +329,34 @@ int MapgenCarpathian::getSpawnLevelAtPoint(v2s16 p)
 {
 	// If rivers are enabled, first check if in a river channel
 	if (spflags & MGCARPATHIAN_RIVERS) {
-		float river = std::fabs(NoisePerlin2D(&noise_rivers->np, p.X, p.Y, seed)) -
+		float river = std::fabs(NoiseFractal2D(&noise_rivers->np, p.X, p.Y, seed)) -
 			river_width;
 		if (river < 0.0f)
 			return MAX_MAP_GENERATION_LIMIT; // Unsuitable spawn point
 	}
 
-	float height1 = NoisePerlin2D(&noise_height1->np, p.X, p.Y, seed);
-	float height2 = NoisePerlin2D(&noise_height2->np, p.X, p.Y, seed);
-	float height3 = NoisePerlin2D(&noise_height3->np, p.X, p.Y, seed);
-	float height4 = NoisePerlin2D(&noise_height4->np, p.X, p.Y, seed);
+	float height1 = NoiseFractal2D(&noise_height1->np, p.X, p.Y, seed);
+	float height2 = NoiseFractal2D(&noise_height2->np, p.X, p.Y, seed);
+	float height3 = NoiseFractal2D(&noise_height3->np, p.X, p.Y, seed);
+	float height4 = NoiseFractal2D(&noise_height4->np, p.X, p.Y, seed);
 
-	float hterabs = std::fabs(NoisePerlin2D(&noise_hills_terrain->np, p.X, p.Y, seed));
-	float n_hills = NoisePerlin2D(&noise_hills->np, p.X, p.Y, seed);
+	float hterabs = std::fabs(NoiseFractal2D(&noise_hills_terrain->np, p.X, p.Y, seed));
+	float n_hills = NoiseFractal2D(&noise_hills->np, p.X, p.Y, seed);
 	float hill_mnt = hterabs * hterabs * hterabs * n_hills * n_hills;
 
-	float rterabs = std::fabs(NoisePerlin2D(&noise_ridge_terrain->np, p.X, p.Y, seed));
-	float n_ridge_mnt = NoisePerlin2D(&noise_ridge_mnt->np, p.X, p.Y, seed);
+	float rterabs = std::fabs(NoiseFractal2D(&noise_ridge_terrain->np, p.X, p.Y, seed));
+	float n_ridge_mnt = NoiseFractal2D(&noise_ridge_mnt->np, p.X, p.Y, seed);
 	float ridge_mnt = rterabs * rterabs * rterabs * (1.0f - std::fabs(n_ridge_mnt));
 
-	float sterabs = std::fabs(NoisePerlin2D(&noise_step_terrain->np, p.X, p.Y, seed));
-	float n_step_mnt = NoisePerlin2D(&noise_step_mnt->np, p.X, p.Y, seed);
+	float sterabs = std::fabs(NoiseFractal2D(&noise_step_terrain->np, p.X, p.Y, seed));
+	float n_step_mnt = NoiseFractal2D(&noise_step_mnt->np, p.X, p.Y, seed);
 	float step_mnt = sterabs * sterabs * sterabs * getSteps(n_step_mnt);
 
 	float valley = 1.0f;
 	float river = 0.0f;
 
 	if ((spflags & MGCARPATHIAN_RIVERS) && node_max.Y >= water_level - 16) {
-		river = std::fabs(NoisePerlin2D(&noise_rivers->np, p.X, p.Y, seed)) - river_width;
+		river = std::fabs(NoiseFractal2D(&noise_rivers->np, p.X, p.Y, seed)) - river_width;
 		if (river <= valley_width) {
 			// Within river valley
 			if (river < 0.0f) {
@@ -376,7 +376,7 @@ int MapgenCarpathian::getSpawnLevelAtPoint(v2s16 p)
 	u8 cons_non_solid = 0; // consecutive non-solid nodes
 
 	for (s16 y = water_level; y <= water_level + 32; y++) {
-		float mnt_var = NoisePerlin3D(&noise_mnt_var->np, p.X, y, p.Y, seed);
+		float mnt_var = NoiseFractal3D(&noise_mnt_var->np, p.X, y, p.Y, seed);
 		float hill1 = getLerp(height1, height2, mnt_var);
 		float hill2 = getLerp(height3, height4, mnt_var);
 		float hill3 = getLerp(height3, height2, mnt_var);
@@ -429,20 +429,20 @@ int MapgenCarpathian::generateTerrain()
 	MapNode mn_water(c_water_source);
 
 	// Calculate noise for terrain generation
-	noise_height1->perlinMap2D(node_min.X, node_min.Z);
-	noise_height2->perlinMap2D(node_min.X, node_min.Z);
-	noise_height3->perlinMap2D(node_min.X, node_min.Z);
-	noise_height4->perlinMap2D(node_min.X, node_min.Z);
-	noise_hills_terrain->perlinMap2D(node_min.X, node_min.Z);
-	noise_ridge_terrain->perlinMap2D(node_min.X, node_min.Z);
-	noise_step_terrain->perlinMap2D(node_min.X, node_min.Z);
-	noise_hills->perlinMap2D(node_min.X, node_min.Z);
-	noise_ridge_mnt->perlinMap2D(node_min.X, node_min.Z);
-	noise_step_mnt->perlinMap2D(node_min.X, node_min.Z);
-	noise_mnt_var->perlinMap3D(node_min.X, node_min.Y - 1, node_min.Z);
+	noise_height1->noiseMap2D(node_min.X, node_min.Z);
+	noise_height2->noiseMap2D(node_min.X, node_min.Z);
+	noise_height3->noiseMap2D(node_min.X, node_min.Z);
+	noise_height4->noiseMap2D(node_min.X, node_min.Z);
+	noise_hills_terrain->noiseMap2D(node_min.X, node_min.Z);
+	noise_ridge_terrain->noiseMap2D(node_min.X, node_min.Z);
+	noise_step_terrain->noiseMap2D(node_min.X, node_min.Z);
+	noise_hills->noiseMap2D(node_min.X, node_min.Z);
+	noise_ridge_mnt->noiseMap2D(node_min.X, node_min.Z);
+	noise_step_mnt->noiseMap2D(node_min.X, node_min.Z);
+	noise_mnt_var->noiseMap3D(node_min.X, node_min.Y - 1, node_min.Z);
 
 	if (spflags & MGCARPATHIAN_RIVERS)
-		noise_rivers->perlinMap2D(node_min.X, node_min.Z);
+		noise_rivers->noiseMap2D(node_min.X, node_min.Z);
 
 	//// Place nodes
 	const v3s32 &em = vm->m_area.getExtent();

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -164,7 +164,7 @@ int MapgenFlat::getSpawnLevelAtPoint(v2s16 p)
 	s16 stone_level = ground_level;
 	float n_terrain =
 		((spflags & MGFLAT_LAKES) || (spflags & MGFLAT_HILLS)) ?
-		NoisePerlin2D(&noise_terrain->np, p.X, p.Y, seed) :
+		NoiseFractal2D(&noise_terrain->np, p.X, p.Y, seed) :
 		0.0f;
 
 	if ((spflags & MGFLAT_LAKES) && n_terrain < lake_threshold) {
@@ -284,7 +284,7 @@ s16 MapgenFlat::generateTerrain()
 
 	bool use_noise = (spflags & MGFLAT_LAKES) || (spflags & MGFLAT_HILLS);
 	if (use_noise)
-		noise_terrain->perlinMap2D(node_min.X, node_min.Z);
+		noise_terrain->noiseMap2D(node_min.X, node_min.Z);
 
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, ni2d++) {

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -177,7 +177,7 @@ int MapgenFractal::getSpawnLevelAtPoint(v2s16 p)
 
 	// If terrain present, don't start search below terrain or water level
 	if (noise_seabed) {
-		s16 seabed_level = NoisePerlin2D(&noise_seabed->np, p.X, p.Y, seed);
+		s16 seabed_level = NoiseFractal2D(&noise_seabed->np, p.X, p.Y, seed);
 		search_start = MYMAX(search_start, MYMAX(seabed_level, water_level));
 	}
 
@@ -409,7 +409,7 @@ s16 MapgenFractal::generateTerrain()
 	u32 index2d = 0;
 
 	if (noise_seabed)
-		noise_seabed->perlinMap2D(node_min.X, node_min.Z);
+		noise_seabed->noiseMap2D(node_min.X, node_min.Z);
 
 	for (s16 z = node_min.Z; z <= node_max.Z; z++) {
 		for (s16 y = node_min.Y - 1; y <= node_max.Y + 1; y++) {

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -150,12 +150,12 @@ void MapgenV5Params::setDefaultSettings(Settings *settings)
 int MapgenV5::getSpawnLevelAtPoint(v2s16 p)
 {
 
-	float f = 0.55 + NoisePerlin2D(&noise_factor->np, p.X, p.Y, seed);
+	float f = 0.55 + NoiseFractal2D(&noise_factor->np, p.X, p.Y, seed);
 	if (f < 0.01)
 		f = 0.01;
 	else if (f >= 1.0)
 		f *= 1.6;
-	float h = NoisePerlin2D(&noise_height->np, p.X, p.Y, seed);
+	float h = NoiseFractal2D(&noise_height->np, p.X, p.Y, seed);
 
 	// noise_height 'offset' is the average level of terrain. At least 50% of
 	// terrain will be below this.
@@ -166,7 +166,7 @@ int MapgenV5::getSpawnLevelAtPoint(v2s16 p)
 	// Starting spawn search at max_spawn_y + 128 ensures 128 nodes of open
 	// space above spawn position. Avoids spawning in possibly sealed voids.
 	for (s16 y = max_spawn_y + 128; y >= water_level; y--) {
-		float n_ground = NoisePerlin3D(&noise_ground->np, p.X, y, p.Y, seed);
+		float n_ground = NoiseFractal3D(&noise_ground->np, p.X, y, p.Y, seed);
 
 		if (n_ground * f > y - h) {  // If solid
 			if (y < water_level || y > max_spawn_y)
@@ -272,9 +272,9 @@ int MapgenV5::generateBaseTerrain()
 	u32 index2d = 0;
 	int stone_surface_max_y = -MAX_MAP_GENERATION_LIMIT;
 
-	noise_factor->perlinMap2D(node_min.X, node_min.Z);
-	noise_height->perlinMap2D(node_min.X, node_min.Z);
-	noise_ground->perlinMap3D(node_min.X, node_min.Y - 1, node_min.Z);
+	noise_factor->noiseMap2D(node_min.X, node_min.Z);
+	noise_height->noiseMap2D(node_min.X, node_min.Z);
+	noise_ground->noiseMap3D(node_min.X, node_min.Y - 1, node_min.Z);
 
 	for (s16 z=node_min.Z; z<=node_max.Z; z++) {
 		for (s16 y=node_min.Y - 1; y<=node_max.Y + 1; y++) {

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -289,13 +289,13 @@ float MapgenV6::baseTerrainLevelFromNoise(v2s16 p)
 	if (spflags & MGV6_FLAT)
 		return water_level;
 
-	float terrain_base   = NoisePerlin2D_PO(&noise_terrain_base->np,
+	float terrain_base   = NoiseFractal2D_PO(&noise_terrain_base->np,
 							p.X, 0.5, p.Y, 0.5, seed);
-	float terrain_higher = NoisePerlin2D_PO(&noise_terrain_higher->np,
+	float terrain_higher = NoiseFractal2D_PO(&noise_terrain_higher->np,
 							p.X, 0.5, p.Y, 0.5, seed);
-	float steepness      = NoisePerlin2D_PO(&noise_steepness->np,
+	float steepness      = NoiseFractal2D_PO(&noise_steepness->np,
 							p.X, 0.5, p.Y, 0.5, seed);
-	float height_select  = NoisePerlin2D_PO(&noise_height_select->np,
+	float height_select  = NoiseFractal2D_PO(&noise_height_select->np,
 							p.X, 0.5, p.Y, 0.5, seed);
 
 	return baseTerrainLevel(terrain_base, terrain_higher,
@@ -355,7 +355,7 @@ BiomeV6Type MapgenV6::getBiome(v2s16 p)
 
 float MapgenV6::getHumidity(v2s16 p)
 {
-	/*double noise = noise2d_perlin(
+	/*double noise = noise2d_fractal(
 		0.5+(float)p.X/500, 0.5+(float)p.Y/500,
 		seed+72384, 4, 0.66);
 	noise = (noise + 1.0)/2.0;*/
@@ -374,11 +374,11 @@ float MapgenV6::getHumidity(v2s16 p)
 
 float MapgenV6::getTreeAmount(v2s16 p)
 {
-	/*double noise = noise2d_perlin(
+	/*double noise = noise2d_fractal(
 			0.5+(float)p.X/125, 0.5+(float)p.Y/125,
 			seed+2, 4, 0.66);*/
 
-	float noise = NoisePerlin2D(np_trees, p.X, p.Y, seed);
+	float noise = NoiseFractal2D(np_trees, p.X, p.Y, seed);
 	float zeroval = -0.39;
 	if (noise < zeroval)
 		return 0;
@@ -389,11 +389,11 @@ float MapgenV6::getTreeAmount(v2s16 p)
 
 bool MapgenV6::getHaveAppleTree(v2s16 p)
 {
-	/*is_apple_tree = noise2d_perlin(
+	/*is_apple_tree = noise2d_fractal(
 		0.5+(float)p.X/100, 0.5+(float)p.Z/100,
 		data->seed+342902, 3, 0.45) > 0.2;*/
 
-	float noise = NoisePerlin2D(np_apple_trees, p.X, p.Y, seed);
+	float noise = NoiseFractal2D(np_apple_trees, p.X, p.Y, seed);
 
 	return noise > 0.2;
 }
@@ -404,7 +404,7 @@ float MapgenV6::getMudAmount(int index)
 	if (spflags & MGV6_FLAT)
 		return MGV6_AVERAGE_MUD_AMOUNT;
 
-	/*return ((float)AVERAGE_MUD_AMOUNT + 2.0 * noise2d_perlin(
+	/*return ((float)AVERAGE_MUD_AMOUNT + 2.0 * noise2d_fractal(
 			0.5+(float)p.X/200, 0.5+(float)p.Y/200,
 			seed+91013, 3, 0.55));*/
 
@@ -415,7 +415,7 @@ float MapgenV6::getMudAmount(int index)
 bool MapgenV6::getHaveBeach(int index)
 {
 	// Determine whether to have sand here
-	/*double sandnoise = noise2d_perlin(
+	/*double sandnoise = noise2d_fractal(
 			0.2+(float)p2d.X/250, 0.7+(float)p2d.Y/250,
 			seed+59420, 3, 0.50);*/
 
@@ -427,7 +427,7 @@ bool MapgenV6::getHaveBeach(int index)
 BiomeV6Type MapgenV6::getBiome(int index, v2s16 p)
 {
 	// Just do something very simple as for now
-	/*double d = noise2d_perlin(
+	/*double d = noise2d_fractal(
 			0.6+(float)p2d.X/250, 0.2+(float)p2d.Y/250,
 			seed+9130, 3, 0.50);*/
 
@@ -547,7 +547,7 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 	if ((flags & MG_DUNGEONS) && stone_surface_max_y >= node_min.Y &&
 			full_node_min.Y >= dungeon_ymin && full_node_max.Y <= dungeon_ymax) {
 		u16 num_dungeons = std::fmax(std::floor(
-			NoisePerlin3D(&np_dungeons, node_min.X, node_min.Y, node_min.Z, seed)), 0.0f);
+			NoiseFractal3D(&np_dungeons, node_min.X, node_min.Y, node_min.Z, seed)), 0.0f);
 
 		if (num_dungeons >= 1) {
 			PseudoRandom ps(blockseed + 4713);
@@ -633,17 +633,17 @@ void MapgenV6::calculateNoise()
 	int fz = full_node_min.Z;
 
 	if (!(spflags & MGV6_FLAT)) {
-		noise_terrain_base->perlinMap2D_PO(x, 0.5, z, 0.5);
-		noise_terrain_higher->perlinMap2D_PO(x, 0.5, z, 0.5);
-		noise_steepness->perlinMap2D_PO(x, 0.5, z, 0.5);
-		noise_height_select->perlinMap2D_PO(x, 0.5, z, 0.5);
-		noise_mud->perlinMap2D_PO(x, 0.5, z, 0.5);
+		noise_terrain_base->noiseMap2D_PO(x, 0.5, z, 0.5);
+		noise_terrain_higher->noiseMap2D_PO(x, 0.5, z, 0.5);
+		noise_steepness->noiseMap2D_PO(x, 0.5, z, 0.5);
+		noise_height_select->noiseMap2D_PO(x, 0.5, z, 0.5);
+		noise_mud->noiseMap2D_PO(x, 0.5, z, 0.5);
 	}
 
-	noise_beach->perlinMap2D_PO(x, 0.2, z, 0.7);
+	noise_beach->noiseMap2D_PO(x, 0.2, z, 0.7);
 
-	noise_biome->perlinMap2D_PO(fx, 0.6, fz, 0.2);
-	noise_humidity->perlinMap2D_PO(fx, 0.0, fz, 0.0);
+	noise_biome->noiseMap2D_PO(fx, 0.6, fz, 0.2);
+	noise_humidity->noiseMap2D_PO(fx, 0.0, fz, 0.0);
 	// Humidity map does not need range limiting 0 to 1,
 	// only humidity at point does
 }
@@ -1075,7 +1075,7 @@ void MapgenV6::growGrass() // Add surface nodes
 
 void MapgenV6::generateCaves(int max_stone_y)
 {
-	float cave_amount = NoisePerlin2D(np_cave, node_min.X, node_min.Y, seed);
+	float cave_amount = NoiseFractal2D(np_cave, node_min.X, node_min.Y, seed);
 	int volume_nodes = (node_max.X - node_min.X + 1) *
 					   (node_max.Y - node_min.Y + 1) * MAP_BLOCKSIZE;
 	cave_amount = MYMAX(0.0, cave_amount);

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -280,15 +280,15 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 int MapgenValleys::getSpawnLevelAtPoint(v2s16 p)
 {
 	// Check if in a river channel
-	float n_rivers = NoisePerlin2D(&noise_rivers->np, p.X, p.Y, seed);
+	float n_rivers = NoiseFractal2D(&noise_rivers->np, p.X, p.Y, seed);
 	if (std::fabs(n_rivers) <= river_size_factor)
 		// Unsuitable spawn point
 		return MAX_MAP_GENERATION_LIMIT;
 
-	float n_slope          = NoisePerlin2D(&noise_inter_valley_slope->np, p.X, p.Y, seed);
-	float n_terrain_height = NoisePerlin2D(&noise_terrain_height->np, p.X, p.Y, seed);
-	float n_valley         = NoisePerlin2D(&noise_valley_depth->np, p.X, p.Y, seed);
-	float n_valley_profile = NoisePerlin2D(&noise_valley_profile->np, p.X, p.Y, seed);
+	float n_slope          = NoiseFractal2D(&noise_inter_valley_slope->np, p.X, p.Y, seed);
+	float n_terrain_height = NoiseFractal2D(&noise_terrain_height->np, p.X, p.Y, seed);
+	float n_valley         = NoiseFractal2D(&noise_valley_depth->np, p.X, p.Y, seed);
+	float n_valley_profile = NoiseFractal2D(&noise_valley_profile->np, p.X, p.Y, seed);
 
 	float valley_d = n_valley * n_valley;
 	float base = n_terrain_height + valley_d;
@@ -309,7 +309,7 @@ int MapgenValleys::getSpawnLevelAtPoint(v2s16 p)
 	// Starting spawn search at max_spawn_y + 128 ensures 128 nodes of open
 	// space above spawn position. Avoids spawning in possibly sealed voids.
 	for (s16 y = max_spawn_y + 128; y >= water_level; y--) {
-		float n_fill = NoisePerlin3D(&noise_inter_valley_fill->np, p.X, y, p.Y, seed);
+		float n_fill = NoiseFractal3D(&noise_inter_valley_fill->np, p.X, y, p.Y, seed);
 		float surface_delta = (float)y - surface_y;
 		float density = slope * n_fill - surface_delta;
 
@@ -336,13 +336,13 @@ int MapgenValleys::generateTerrain()
 	MapNode n_stone(c_stone);
 	MapNode n_water(c_water_source);
 
-	noise_inter_valley_slope->perlinMap2D(node_min.X, node_min.Z);
-	noise_rivers->perlinMap2D(node_min.X, node_min.Z);
-	noise_terrain_height->perlinMap2D(node_min.X, node_min.Z);
-	noise_valley_depth->perlinMap2D(node_min.X, node_min.Z);
-	noise_valley_profile->perlinMap2D(node_min.X, node_min.Z);
+	noise_inter_valley_slope->noiseMap2D(node_min.X, node_min.Z);
+	noise_rivers->noiseMap2D(node_min.X, node_min.Z);
+	noise_terrain_height->noiseMap2D(node_min.X, node_min.Z);
+	noise_valley_depth->noiseMap2D(node_min.X, node_min.Z);
+	noise_valley_profile->noiseMap2D(node_min.X, node_min.Z);
 
-	noise_inter_valley_fill->perlinMap3D(node_min.X, node_min.Y - 1, node_min.Z);
+	noise_inter_valley_fill->noiseMap3D(node_min.X, node_min.Y - 1, node_min.Z);
 
 	const v3s32 &em = vm->m_area.getExtent();
 	s16 surface_max_y = -MAX_MAP_GENERATION_LIMIT;

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -165,14 +165,14 @@ BiomeGen *BiomeGenOriginal::clone(BiomeManager *biomemgr) const
 
 float BiomeGenOriginal::calcHeatAtPoint(v3s16 pos) const
 {
-	return NoisePerlin2D(&m_params->np_heat, pos.X, pos.Z, m_params->seed) +
-		NoisePerlin2D(&m_params->np_heat_blend, pos.X, pos.Z, m_params->seed);
+	return NoiseFractal2D(&m_params->np_heat, pos.X, pos.Z, m_params->seed) +
+		NoiseFractal2D(&m_params->np_heat_blend, pos.X, pos.Z, m_params->seed);
 }
 
 float BiomeGenOriginal::calcHumidityAtPoint(v3s16 pos) const
 {
-	return NoisePerlin2D(&m_params->np_humidity, pos.X, pos.Z, m_params->seed) +
-		NoisePerlin2D(&m_params->np_humidity_blend, pos.X, pos.Z, m_params->seed);
+	return NoiseFractal2D(&m_params->np_humidity, pos.X, pos.Z, m_params->seed) +
+		NoiseFractal2D(&m_params->np_humidity_blend, pos.X, pos.Z, m_params->seed);
 }
 
 Biome *BiomeGenOriginal::calcBiomeAtPoint(v3s16 pos) const
@@ -185,10 +185,10 @@ void BiomeGenOriginal::calcBiomeNoise(v3s16 pmin)
 {
 	m_pmin = pmin;
 
-	noise_heat->perlinMap2D(pmin.X, pmin.Z);
-	noise_humidity->perlinMap2D(pmin.X, pmin.Z);
-	noise_heat_blend->perlinMap2D(pmin.X, pmin.Z);
-	noise_humidity_blend->perlinMap2D(pmin.X, pmin.Z);
+	noise_heat->noiseMap2D(pmin.X, pmin.Z);
+	noise_humidity->noiseMap2D(pmin.X, pmin.Z);
+	noise_heat_blend->noiseMap2D(pmin.X, pmin.Z);
+	noise_humidity_blend->noiseMap2D(pmin.X, pmin.Z);
 
 	for (s32 i = 0; i < m_csize.X * m_csize.Z; i++) {
 		noise_heat->result[i]     += noise_heat_blend->result[i];

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -148,7 +148,7 @@ void Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 		bool cover = false;
 		// Amount of decorations
 		float nval = (flags & DECO_USE_NOISE) ?
-			NoisePerlin2D(&np, p2d_min.X + sidelen / 2, p2d_min.Y + sidelen / 2, mapseed) :
+			NoiseFractal2D(&np, p2d_min.X + sidelen / 2, p2d_min.Y + sidelen / 2, mapseed) :
 			fill_ratio;
 		u32 deco_count = 0;
 

--- a/src/mapgen/mg_ore.cpp
+++ b/src/mapgen/mg_ore.cpp
@@ -150,7 +150,7 @@ void OreScatter::generate(MMVManip *vm, int mapseed, u32 blockseed,
 		int z0 = pr.range(nmin.Z, nmax.Z - csize + 1);
 
 		if ((flags & OREFLAG_USE_NOISE) &&
-			(NoisePerlin3D(&np, x0, y0, z0, mapseed) < nthresh))
+			(NoiseFractal3D(&np, x0, y0, z0, mapseed) < nthresh))
 			continue;
 
 		if (biomemap && !biomes.empty()) {
@@ -212,7 +212,7 @@ void OreSheet::generate(MMVManip *vm, int mapseed, u32 blockseed,
 		noise = new Noise(&np, 0, sx, sz);
 	}
 	noise->seed = mapseed + y_start;
-	noise->perlinMap2D(nmin.X, nmin.Z);
+	noise->noiseMap2D(nmin.X, nmin.Z);
 
 	size_t index = 0;
 	for (int z = nmin.Z; z <= nmax.Z; z++)
@@ -286,7 +286,7 @@ void OrePuff::generate(MMVManip *vm, int mapseed, u32 blockseed,
 	}
 
 	noise->seed = mapseed + y_start;
-	noise->perlinMap2D(nmin.X, nmin.Z);
+	noise->noiseMap2D(nmin.X, nmin.Z);
 	bool noise_generated = false;
 
 	size_t index = 0;
@@ -304,8 +304,8 @@ void OrePuff::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 		if (!noise_generated) {
 			noise_generated = true;
-			noise_puff_top->perlinMap2D(nmin.X, nmin.Z);
-			noise_puff_bottom->perlinMap2D(nmin.X, nmin.Z);
+			noise_puff_top->noiseMap2D(nmin.X, nmin.Z);
+			noise_puff_bottom->noiseMap2D(nmin.X, nmin.Z);
 		}
 
 		float ntop    = noise_puff_top->result[index];
@@ -393,7 +393,7 @@ void OreBlob::generate(MMVManip *vm, int mapseed, u32 blockseed,
 			// This simple optimization makes calls 6x faster on average
 			if (!noise_generated) {
 				noise_generated = true;
-				noise->perlinMap3D(x0, y0, z0);
+				noise->noiseMap3D(x0, y0, z0);
 			}
 
 			float noiseval = noise->result[index];
@@ -443,7 +443,7 @@ void OreVein::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 	int sizex = nmax.X - nmin.X + 1;
 	int sizey = nmax.Y - nmin.Y + 1;
-	// Because this ore uses 3D noise the perlinmap Y size can be different in
+	// Because this ore uses 3D noise the noisemap Y size can be different in
 	// different mapchunks due to ore Y limits. So recreate the noise objects
 	// if Y size has changed.
 	// Because these noise objects are created multiple times for this ore type
@@ -478,8 +478,8 @@ void OreVein::generate(MMVManip *vm, int mapseed, u32 blockseed,
 		// Same lazy generation optimization as in OreBlob
 		if (!noise_generated) {
 			noise_generated = true;
-			noise->perlinMap3D(nmin.X, nmin.Y, nmin.Z);
-			noise2->perlinMap3D(nmin.X, nmin.Y, nmin.Z);
+			noise->noiseMap3D(nmin.X, nmin.Y, nmin.Z);
+			noise2->noiseMap3D(nmin.X, nmin.Y, nmin.Z);
 		}
 
 		// randval ranges from -1..1
@@ -532,7 +532,7 @@ void OreStratum::generate(MMVManip *vm, int mapseed, u32 blockseed,
 			int sz = nmax.Z - nmin.Z + 1;
 			noise = new Noise(&np, 0, sx, sz);
 		}
-		noise->perlinMap2D(nmin.X, nmin.Z);
+		noise->noiseMap2D(nmin.X, nmin.Z);
 	}
 
 	if (flags & OREFLAG_USE_NOISE2) {
@@ -541,7 +541,7 @@ void OreStratum::generate(MMVManip *vm, int mapseed, u32 blockseed,
 			int sz = nmax.Z - nmin.Z + 1;
 			noise_stratum_thickness = new Noise(&np_stratum_thickness, 0, sx, sz);
 		}
-		noise_stratum_thickness->perlinMap2D(nmin.X, nmin.Z);
+		noise_stratum_thickness->noiseMap2D(nmin.X, nmin.Z);
 	}
 
 	size_t index = 0;

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -234,7 +234,7 @@ inline float triLinearInterpolation(
 	return linearInterpolation(u, v, z);
 }
 
-float noise2d_gradient(float x, float y, s32 seed, bool eased)
+float noise2d_value(float x, float y, s32 seed, bool eased)
 {
 	// Calculate the integer coordinates
 	int x0 = myfloor(x);
@@ -252,7 +252,7 @@ float noise2d_gradient(float x, float y, s32 seed, bool eased)
 }
 
 
-float noise3d_gradient(float x, float y, float z, s32 seed, bool eased)
+float noise3d_value(float x, float y, float z, s32 seed, bool eased)
 {
 	// Calculate the integer coordinates
 	int x0 = myfloor(x);
@@ -280,7 +280,7 @@ float noise3d_gradient(float x, float y, float z, s32 seed, bool eased)
 }
 
 
-float noise2d_perlin(float x, float y, s32 seed,
+float noise2d_fractal(float x, float y, s32 seed,
 	int octaves, float persistence, bool eased)
 {
 	float a = 0;
@@ -288,7 +288,7 @@ float noise2d_perlin(float x, float y, s32 seed,
 	float g = 1.0;
 	for (int i = 0; i < octaves; i++)
 	{
-		a += g * noise2d_gradient(x * f, y * f, seed + i, eased);
+		a += g * noise2d_value(x * f, y * f, seed + i, eased);
 		f *= 2.0;
 		g *= persistence;
 	}
@@ -305,10 +305,10 @@ float contour(float v)
 }
 
 
-///////////////////////// [ New noise ] ////////////////////////////
+///////////////////////// [ Fractal value noise ] ////////////////////////////
 
 
-float NoisePerlin2D(const NoiseParams *np, float x, float y, s32 seed)
+float NoiseFractal2D(const NoiseParams *np, float x, float y, s32 seed)
 {
 	float a = 0;
 	float f = 1.0;
@@ -319,7 +319,7 @@ float NoisePerlin2D(const NoiseParams *np, float x, float y, s32 seed)
 	seed += np->seed;
 
 	for (size_t i = 0; i < np->octaves; i++) {
-		float noiseval = noise2d_gradient(x * f, y * f, seed + i,
+		float noiseval = noise2d_value(x * f, y * f, seed + i,
 			np->flags & (NOISE_FLAG_DEFAULTS | NOISE_FLAG_EASED));
 
 		if (np->flags & NOISE_FLAG_ABSVALUE)
@@ -334,7 +334,7 @@ float NoisePerlin2D(const NoiseParams *np, float x, float y, s32 seed)
 }
 
 
-float NoisePerlin3D(const NoiseParams *np, float x, float y, float z, s32 seed)
+float NoiseFractal3D(const NoiseParams *np, float x, float y, float z, s32 seed)
 {
 	float a = 0;
 	float f = 1.0;
@@ -346,7 +346,7 @@ float NoisePerlin3D(const NoiseParams *np, float x, float y, float z, s32 seed)
 	seed += np->seed;
 
 	for (size_t i = 0; i < np->octaves; i++) {
-		float noiseval = noise3d_gradient(x * f, y * f, z * f, seed + i,
+		float noiseval = noise3d_value(x * f, y * f, z * f, seed + i,
 			np->flags & NOISE_FLAG_EASED);
 
 		if (np->flags & NOISE_FLAG_ABSVALUE)
@@ -375,7 +375,7 @@ Noise::Noise(const NoiseParams *np_, s32 seed, u32 sx, u32 sy, u32 sz)
 
 Noise::~Noise()
 {
-	delete[] gradient_buf;
+	delete[] value_buf;
 	delete[] persist_buf;
 	delete[] noise_buf;
 	delete[] result;
@@ -394,15 +394,15 @@ void Noise::allocBuffers()
 	this->noise_buf = NULL;
 	resizeNoiseBuf(sz > 1);
 
-	delete[] gradient_buf;
+	delete[] value_buf;
 	delete[] persist_buf;
 	delete[] result;
 
 	try {
 		size_t bufsize = sx * sy * sz;
-		this->persist_buf  = NULL;
-		this->gradient_buf = new float[bufsize];
-		this->result       = new float[bufsize];
+		this->persist_buf = NULL;
+		this->value_buf = new float[bufsize];
+		this->result = new float[bufsize];
 	} catch (std::bad_alloc &e) {
 		throw InvalidNoiseParamsException();
 	}
@@ -490,7 +490,7 @@ void Noise::resizeNoiseBuf(bool is3d)
  * next octave.
  */
 #define idx(x, y) ((y) * nlx + (x))
-void Noise::gradientMap2D(
+void Noise::valueMap2D(
 		float x, float y,
 		float step_x, float step_y,
 		s32 seed)
@@ -527,7 +527,7 @@ void Noise::gradientMap2D(
 		u = orig_u;
 		noisex = 0;
 		for (i = 0; i != sx; i++) {
-			gradient_buf[index++] =
+			value_buf[index++] =
 				biLinearInterpolation(v00, v10, v01, v11, u, v, eased);
 
 			u += step_x;
@@ -552,7 +552,7 @@ void Noise::gradientMap2D(
 
 
 #define idx(x, y, z) ((z) * nly * nlx + (y) * nlx + (x))
-void Noise::gradientMap3D(
+void Noise::valueMap3D(
 		float x, float y, float z,
 		float step_x, float step_y, float step_z,
 		s32 seed)
@@ -605,7 +605,7 @@ void Noise::gradientMap3D(
 			u = orig_u;
 			noisex = 0;
 			for (i = 0; i != sx; i++) {
-				gradient_buf[index++] = triLinearInterpolation(
+				value_buf[index++] = triLinearInterpolation(
 					v000, v100, v010, v110,
 					v001, v101, v011, v111,
 					u, v, w,
@@ -643,7 +643,7 @@ void Noise::gradientMap3D(
 #undef idx
 
 
-float *Noise::perlinMap2D(float x, float y, float *persistence_map)
+float *Noise::noiseMap2D(float x, float y, float *persistence_map)
 {
 	float f = 1.0, g = 1.0;
 	size_t bufsize = sx * sy;
@@ -661,7 +661,7 @@ float *Noise::perlinMap2D(float x, float y, float *persistence_map)
 	}
 
 	for (size_t oct = 0; oct < np.octaves; oct++) {
-		gradientMap2D(x * f, y * f,
+		valueMap2D(x * f, y * f,
 			f / np.spread.X, f / np.spread.Y,
 			seed + np.seed + oct);
 
@@ -680,7 +680,7 @@ float *Noise::perlinMap2D(float x, float y, float *persistence_map)
 }
 
 
-float *Noise::perlinMap3D(float x, float y, float z, float *persistence_map)
+float *Noise::noiseMap3D(float x, float y, float z, float *persistence_map)
 {
 	float f = 1.0, g = 1.0;
 	size_t bufsize = sx * sy * sz;
@@ -699,7 +699,7 @@ float *Noise::perlinMap3D(float x, float y, float z, float *persistence_map)
 	}
 
 	for (size_t oct = 0; oct < np.octaves; oct++) {
-		gradientMap3D(x * f, y * f, z * f,
+		valueMap3D(x * f, y * f, z * f,
 			f / np.spread.X, f / np.spread.Y, f / np.spread.Z,
 			seed + np.seed + oct);
 
@@ -726,22 +726,22 @@ void Noise::updateResults(float g, float *gmap,
 	if (np.flags & NOISE_FLAG_ABSVALUE) {
 		if (persistence_map) {
 			for (size_t i = 0; i != bufsize; i++) {
-				result[i] += gmap[i] * std::fabs(gradient_buf[i]);
+				result[i] += gmap[i] * std::fabs(value_buf[i]);
 				gmap[i] *= persistence_map[i];
 			}
 		} else {
 			for (size_t i = 0; i != bufsize; i++)
-				result[i] += g * std::fabs(gradient_buf[i]);
+				result[i] += g * std::fabs(value_buf[i]);
 		}
 	} else {
 		if (persistence_map) {
 			for (size_t i = 0; i != bufsize; i++) {
-				result[i] += gmap[i] * gradient_buf[i];
+				result[i] += gmap[i] * value_buf[i];
 				gmap[i] *= persistence_map[i];
 			}
 		} else {
 			for (size_t i = 0; i != bufsize; i++)
-				result[i] += g * gradient_buf[i];
+				result[i] += g * value_buf[i];
 		}
 	}
 }

--- a/src/noise.h
+++ b/src/noise.h
@@ -151,7 +151,7 @@ public:
 	u32 sy;
 	u32 sz;
 	float *noise_buf = nullptr;
-	float *gradient_buf = nullptr;
+	float *value_buf = nullptr;
 	float *persist_buf = nullptr;
 	float *result = nullptr;
 
@@ -162,31 +162,31 @@ public:
 	void setSpreadFactor(v3f spread);
 	void setOctaves(int octaves);
 
-	void gradientMap2D(
+	void valueMap2D(
 		float x, float y,
 		float step_x, float step_y,
 		s32 seed);
-	void gradientMap3D(
+	void valueMap3D(
 		float x, float y, float z,
 		float step_x, float step_y, float step_z,
 		s32 seed);
 
-	float *perlinMap2D(float x, float y, float *persistence_map=NULL);
-	float *perlinMap3D(float x, float y, float z, float *persistence_map=NULL);
+	float *noiseMap2D(float x, float y, float *persistence_map=NULL);
+	float *noiseMap3D(float x, float y, float z, float *persistence_map=NULL);
 
-	inline float *perlinMap2D_PO(float x, float xoff, float y, float yoff,
+	inline float *noiseMap2D_PO(float x, float xoff, float y, float yoff,
 		float *persistence_map=NULL)
 	{
-		return perlinMap2D(
+		return noiseMap2D(
 			x + xoff * np.spread.X,
 			y + yoff * np.spread.Y,
 			persistence_map);
 	}
 
-	inline float *perlinMap3D_PO(float x, float xoff, float y, float yoff,
+	inline float *noiseMap3D_PO(float x, float xoff, float y, float yoff,
 		float z, float zoff, float *persistence_map=NULL)
 	{
-		return perlinMap3D(
+		return noiseMap3D(
 			x + xoff * np.spread.X,
 			y + yoff * np.spread.Y,
 			z + zoff * np.spread.Z,
@@ -201,22 +201,22 @@ private:
 
 };
 
-float NoisePerlin2D(const NoiseParams *np, float x, float y, s32 seed);
-float NoisePerlin3D(const NoiseParams *np, float x, float y, float z, s32 seed);
+float NoiseFractal2D(const NoiseParams *np, float x, float y, s32 seed);
+float NoiseFractal3D(const NoiseParams *np, float x, float y, float z, s32 seed);
 
-inline float NoisePerlin2D_PO(NoiseParams *np, float x, float xoff,
+inline float NoiseFractal2D_PO(NoiseParams *np, float x, float xoff,
 	float y, float yoff, s32 seed)
 {
-	return NoisePerlin2D(np,
+	return NoiseFractal2D(np,
 		x + xoff * np->spread.X,
 		y + yoff * np->spread.Y,
 		seed);
 }
 
-inline float NoisePerlin3D_PO(NoiseParams *np, float x, float xoff,
+inline float NoiseFractal3D_PO(NoiseParams *np, float x, float xoff,
 	float y, float yoff, float z, float zoff, s32 seed)
 {
-	return NoisePerlin3D(np,
+	return NoiseFractal3D(np,
 		x + xoff * np->spread.X,
 		y + yoff * np->spread.Y,
 		z + zoff * np->spread.Z,
@@ -227,10 +227,10 @@ inline float NoisePerlin3D_PO(NoiseParams *np, float x, float xoff,
 float noise2d(int x, int y, s32 seed);
 float noise3d(int x, int y, int z, s32 seed);
 
-float noise2d_gradient(float x, float y, s32 seed, bool eased=true);
-float noise3d_gradient(float x, float y, float z, s32 seed, bool eased=false);
+float noise2d_value(float x, float y, s32 seed, bool eased=true);
+float noise3d_value(float x, float y, float z, s32 seed, bool eased=false);
 
-float noise2d_perlin(float x, float y, s32 seed,
+float noise2d_fractal(float x, float y, s32 seed,
 		int octaves, float persistence, bool eased=true);
 
 inline float easeCurve(float t)

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1023,9 +1023,9 @@ int ModApiEnv::l_find_nodes_in_area_under_air(lua_State *L)
 	return findNodesInAreaUnderAir(L, minp, maxp, filter, getNode);
 }
 
-// get_perlin(seeddiff, octaves, persistence, scale)
-// returns world-specific PerlinNoise
-int ModApiEnv::l_get_perlin(lua_State *L)
+// get_value_noise(seeddiff, octaves, persistence, scale)
+// returns world-specific ValueNoise
+int ModApiEnv::l_get_value_noise(lua_State *L)
 {
 	GET_ENV_PTR_NO_MAP_LOCK;
 
@@ -1042,16 +1042,16 @@ int ModApiEnv::l_get_perlin(lua_State *L)
 
 	params.seed += (int)env->getServerMap().getSeed();
 
-	LuaPerlinNoise *n = new LuaPerlinNoise(&params);
+	LuaValueNoise *n = new LuaValueNoise(&params);
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = n;
-	luaL_getmetatable(L, "PerlinNoise");
+	luaL_getmetatable(L, "ValueNoise");
 	lua_setmetatable(L, -2);
 	return 1;
 }
 
-// get_perlin_map(noiseparams, size)
-// returns world-specific PerlinNoiseMap
-int ModApiEnv::l_get_perlin_map(lua_State *L)
+// get_value_noise_map(noiseparams, size)
+// returns world-specific ValueNoiseMap
+int ModApiEnv::l_get_value_noise_map(lua_State *L)
 {
 	GET_ENV_PTR_NO_MAP_LOCK;
 
@@ -1061,9 +1061,9 @@ int ModApiEnv::l_get_perlin_map(lua_State *L)
 	v3s16 size = read_v3s16(L, 2);
 
 	s32 seed = (s32)(env->getServerMap().getSeed());
-	LuaPerlinNoiseMap *n = new LuaPerlinNoiseMap(&np, seed, size);
+	LuaValueNoiseMap *n = new LuaValueNoiseMap(&np, seed, size);
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = n;
-	luaL_getmetatable(L, "PerlinNoiseMap");
+	luaL_getmetatable(L, "ValueNoiseMap");
 	lua_setmetatable(L, -2);
 	return 1;
 }
@@ -1415,8 +1415,8 @@ void ModApiEnv::Initialize(lua_State *L, int top)
 	API_FCT(load_area);
 	API_FCT(emerge_area);
 	API_FCT(delete_area);
-	API_FCT(get_perlin);
-	API_FCT(get_perlin_map);
+	API_FCT(get_value_noise);
+	API_FCT(get_value_noise_map);
 	API_FCT(get_voxel_manip);
 	API_FCT(clear_objects);
 	API_FCT(spawn_tree);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -179,13 +179,13 @@ private:
 	// delete_area(p1, p2) -> true/false
 	static int l_delete_area(lua_State *L);
 
-	// get_perlin(seeddiff, octaves, persistence, scale)
-	// returns world-specific PerlinNoise
-	static int l_get_perlin(lua_State *L);
+	// get_value_noise(seeddiff, octaves, persistence, scale)
+	// returns world-specific ValueNoise
+	static int l_get_value_noise(lua_State *L);
 
-	// get_perlin_map(noiseparams, size)
-	// returns world-specific PerlinNoiseMap
-	static int l_get_perlin_map(lua_State *L);
+	// get_value_noise_map(noiseparams, size)
+	// returns world-specific ValueNoiseMap
+	static int l_get_value_noise_map(lua_State *L);
 
 	// get_voxel_manip()
 	// returns world-specific voxel manipulator

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -13,38 +13,38 @@
 
 ///////////////////////////////////////
 /*
-  LuaPerlinNoise
+  LuaValueNoise
 */
 
-LuaPerlinNoise::LuaPerlinNoise(const NoiseParams *params) :
+LuaValueNoise::LuaValueNoise(const NoiseParams *params) :
 	np(*params)
 {
 }
 
 
-int LuaPerlinNoise::l_get_2d(lua_State *L)
+int LuaValueNoise::l_get_2d(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaPerlinNoise *o = checkObject<LuaPerlinNoise>(L, 1);
+	LuaValueNoise *o = checkObject<LuaValueNoise>(L, 1);
 	v2f p = readParam<v2f>(L, 2);
-	lua_Number val = NoisePerlin2D(&o->np, p.X, p.Y, 0);
+	lua_Number val = NoiseFractal2D(&o->np, p.X, p.Y, 0);
 	lua_pushnumber(L, val);
 	return 1;
 }
 
 
-int LuaPerlinNoise::l_get_3d(lua_State *L)
+int LuaValueNoise::l_get_3d(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaPerlinNoise *o = checkObject<LuaPerlinNoise>(L, 1);
+	LuaValueNoise *o = checkObject<LuaValueNoise>(L, 1);
 	v3f p = check_v3f(L, 2);
-	lua_Number val = NoisePerlin3D(&o->np, p.X, p.Y, p.Z, 0);
+	lua_Number val = NoiseFractal3D(&o->np, p.X, p.Y, p.Z, 0);
 	lua_pushnumber(L, val);
 	return 1;
 }
 
 
-int LuaPerlinNoise::create_object(lua_State *L)
+int LuaValueNoise::create_object(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
@@ -59,7 +59,7 @@ int LuaPerlinNoise::create_object(lua_State *L)
 		params.spread  = v3f(1, 1, 1) * readParam<float>(L, 4);
 	}
 
-	LuaPerlinNoise *o = new LuaPerlinNoise(&params);
+	LuaValueNoise *o = new LuaValueNoise(&params);
 
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
 	luaL_getmetatable(L, className);
@@ -68,25 +68,25 @@ int LuaPerlinNoise::create_object(lua_State *L)
 }
 
 
-int LuaPerlinNoise::gc_object(lua_State *L)
+int LuaValueNoise::gc_object(lua_State *L)
 {
-	LuaPerlinNoise *o = *(LuaPerlinNoise **)(lua_touserdata(L, 1));
+	LuaValueNoise *o = *(LuaValueNoise **)(lua_touserdata(L, 1));
 	delete o;
 	return 0;
 }
 
 
-void *LuaPerlinNoise::packIn(lua_State *L, int idx)
+void *LuaValueNoise::packIn(lua_State *L, int idx)
 {
-	LuaPerlinNoise *o = checkObject<LuaPerlinNoise>(L, idx);
+	LuaValueNoise *o = checkObject<LuaValueNoise>(L, idx);
 	return new NoiseParams(o->np);
 }
 
-void LuaPerlinNoise::packOut(lua_State *L, void *ptr)
+void LuaValueNoise::packOut(lua_State *L, void *ptr)
 {
 	NoiseParams *np = reinterpret_cast<NoiseParams*>(ptr);
 	if (L) {
-		LuaPerlinNoise *o = new LuaPerlinNoise(np);
+		LuaValueNoise *o = new LuaValueNoise(np);
 		*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
 		luaL_getmetatable(L, className);
 		lua_setmetatable(L, -2);
@@ -95,7 +95,7 @@ void LuaPerlinNoise::packOut(lua_State *L, void *ptr)
 }
 
 
-void LuaPerlinNoise::Register(lua_State *L)
+void LuaValueNoise::Register(lua_State *L)
 {
 	static const luaL_Reg metamethods[] = {
 		{"__gc", gc_object},
@@ -109,19 +109,19 @@ void LuaPerlinNoise::Register(lua_State *L)
 }
 
 
-const char LuaPerlinNoise::className[] = "PerlinNoise";
-luaL_Reg LuaPerlinNoise::methods[] = {
-	luamethod_aliased(LuaPerlinNoise, get_2d, get2d),
-	luamethod_aliased(LuaPerlinNoise, get_3d, get3d),
+const char LuaValueNoise::className[] = "ValueNoise";
+luaL_Reg LuaValueNoise::methods[] = {
+	luamethod_aliased(LuaValueNoise, get_2d, get2d),
+	luamethod_aliased(LuaValueNoise, get_3d, get3d),
 	{0,0}
 };
 
 ///////////////////////////////////////
 /*
-  LuaPerlinNoiseMap
+  LuaValueNoiseMap
 */
 
-LuaPerlinNoiseMap::LuaPerlinNoiseMap(const NoiseParams *np, s32 seed, v3s16 size)
+LuaValueNoiseMap::LuaValueNoiseMap(const NoiseParams *np, s32 seed, v3s16 size)
 {
 	try {
 		noise = new Noise(np, seed, size.X, size.Y, size.Z);
@@ -131,22 +131,22 @@ LuaPerlinNoiseMap::LuaPerlinNoiseMap(const NoiseParams *np, s32 seed, v3s16 size
 }
 
 
-LuaPerlinNoiseMap::~LuaPerlinNoiseMap()
+LuaValueNoiseMap::~LuaValueNoiseMap()
 {
 	delete noise;
 }
 
 
-int LuaPerlinNoiseMap::l_get_2d_map(lua_State *L)
+int LuaValueNoiseMap::l_get_2d_map(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	size_t i = 0;
 
-	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
+	LuaValueNoiseMap *o = checkObject<LuaValueNoiseMap>(L, 1);
 	v2f p = readParam<v2f>(L, 2);
 
 	Noise *n = o->noise;
-	n->perlinMap2D(p.X, p.Y);
+	n->noiseMap2D(p.X, p.Y);
 
 	lua_createtable(L, n->sy, 0);
 	for (u32 y = 0; y != n->sy; y++) {
@@ -161,16 +161,16 @@ int LuaPerlinNoiseMap::l_get_2d_map(lua_State *L)
 }
 
 
-int LuaPerlinNoiseMap::l_get_2d_map_flat(lua_State *L)
+int LuaValueNoiseMap::l_get_2d_map_flat(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
+	LuaValueNoiseMap *o = checkObject<LuaValueNoiseMap>(L, 1);
 	v2f p = readParam<v2f>(L, 2);
 	bool use_buffer = lua_istable(L, 3);
 
 	Noise *n = o->noise;
-	n->perlinMap2D(p.X, p.Y);
+	n->noiseMap2D(p.X, p.Y);
 
 	size_t maplen = n->sx * n->sy;
 
@@ -187,19 +187,19 @@ int LuaPerlinNoiseMap::l_get_2d_map_flat(lua_State *L)
 }
 
 
-int LuaPerlinNoiseMap::l_get_3d_map(lua_State *L)
+int LuaValueNoiseMap::l_get_3d_map(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	size_t i = 0;
 
-	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
+	LuaValueNoiseMap *o = checkObject<LuaValueNoiseMap>(L, 1);
 	v3f p = check_v3f(L, 2);
 
 	if (!o->is3D())
 		return 0;
 
 	Noise *n = o->noise;
-	n->perlinMap3D(p.X, p.Y, p.Z);
+	n->noiseMap3D(p.X, p.Y, p.Z);
 
 	lua_createtable(L, n->sz, 0);
 	for (u32 z = 0; z != n->sz; z++) {
@@ -218,11 +218,11 @@ int LuaPerlinNoiseMap::l_get_3d_map(lua_State *L)
 }
 
 
-int LuaPerlinNoiseMap::l_get_3d_map_flat(lua_State *L)
+int LuaValueNoiseMap::l_get_3d_map_flat(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
+	LuaValueNoiseMap *o = checkObject<LuaValueNoiseMap>(L, 1);
 	v3f p                = check_v3f(L, 2);
 	bool use_buffer      = lua_istable(L, 3);
 
@@ -230,7 +230,7 @@ int LuaPerlinNoiseMap::l_get_3d_map_flat(lua_State *L)
 		return 0;
 
 	Noise *n = o->noise;
-	n->perlinMap3D(p.X, p.Y, p.Z);
+	n->noiseMap3D(p.X, p.Y, p.Z);
 
 	size_t maplen = n->sx * n->sy * n->sz;
 
@@ -247,41 +247,41 @@ int LuaPerlinNoiseMap::l_get_3d_map_flat(lua_State *L)
 }
 
 
-int LuaPerlinNoiseMap::l_calc_2d_map(lua_State *L)
+int LuaValueNoiseMap::l_calc_2d_map(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
+	LuaValueNoiseMap *o = checkObject<LuaValueNoiseMap>(L, 1);
 	v2f p = readParam<v2f>(L, 2);
 
 	Noise *n = o->noise;
-	n->perlinMap2D(p.X, p.Y);
+	n->noiseMap2D(p.X, p.Y);
 
 	return 0;
 }
 
-int LuaPerlinNoiseMap::l_calc_3d_map(lua_State *L)
+int LuaValueNoiseMap::l_calc_3d_map(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
+	LuaValueNoiseMap *o = checkObject<LuaValueNoiseMap>(L, 1);
 	v3f p                = check_v3f(L, 2);
 
 	if (!o->is3D())
 		return 0;
 
 	Noise *n = o->noise;
-	n->perlinMap3D(p.X, p.Y, p.Z);
+	n->noiseMap3D(p.X, p.Y, p.Z);
 
 	return 0;
 }
 
 
-int LuaPerlinNoiseMap::l_get_map_slice(lua_State *L)
+int LuaValueNoiseMap::l_get_map_slice(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, 1);
+	LuaValueNoiseMap *o = checkObject<LuaValueNoiseMap>(L, 1);
 	v3s16 slice_offset   = read_v3s16(L, 2);
 	v3s16 slice_size     = read_v3s16(L, 3);
 	bool use_buffer      = lua_istable(L, 4);
@@ -302,14 +302,14 @@ int LuaPerlinNoiseMap::l_get_map_slice(lua_State *L)
 }
 
 
-int LuaPerlinNoiseMap::create_object(lua_State *L)
+int LuaValueNoiseMap::create_object(lua_State *L)
 {
 	NoiseParams np;
 	if (!read_noiseparams(L, 1, &np))
 		return 0;
 	v3s16 size = read_v3s16(L, 2);
 
-	LuaPerlinNoiseMap *o = new LuaPerlinNoiseMap(&np, 0, size);
+	LuaValueNoiseMap *o = new LuaValueNoiseMap(&np, 0, size);
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
 	luaL_getmetatable(L, className);
 	lua_setmetatable(L, -2);
@@ -317,9 +317,9 @@ int LuaPerlinNoiseMap::create_object(lua_State *L)
 }
 
 
-int LuaPerlinNoiseMap::gc_object(lua_State *L)
+int LuaValueNoiseMap::gc_object(lua_State *L)
 {
-	LuaPerlinNoiseMap *o = *(LuaPerlinNoiseMap **)(lua_touserdata(L, 1));
+	LuaValueNoiseMap *o = *(LuaValueNoiseMap **)(lua_touserdata(L, 1));
 	delete o;
 	return 0;
 }
@@ -331,9 +331,9 @@ struct NoiseMapParams {
 	v3s16 size;
 };
 
-void *LuaPerlinNoiseMap::packIn(lua_State *L, int idx)
+void *LuaValueNoiseMap::packIn(lua_State *L, int idx)
 {
-	LuaPerlinNoiseMap *o = checkObject<LuaPerlinNoiseMap>(L, idx);
+	LuaValueNoiseMap *o = checkObject<LuaValueNoiseMap>(L, idx);
 	NoiseMapParams *ret = new NoiseMapParams();
 	ret->np = o->noise->np;
 	ret->seed = o->noise->seed;
@@ -341,11 +341,11 @@ void *LuaPerlinNoiseMap::packIn(lua_State *L, int idx)
 	return ret;
 }
 
-void LuaPerlinNoiseMap::packOut(lua_State *L, void *ptr)
+void LuaValueNoiseMap::packOut(lua_State *L, void *ptr)
 {
 	NoiseMapParams *p = reinterpret_cast<NoiseMapParams*>(ptr);
 	if (L) {
-		LuaPerlinNoiseMap *o = new LuaPerlinNoiseMap(&p->np, p->seed, p->size);
+		LuaValueNoiseMap *o = new LuaValueNoiseMap(&p->np, p->seed, p->size);
 		*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
 		luaL_getmetatable(L, className);
 		lua_setmetatable(L, -2);
@@ -354,7 +354,7 @@ void LuaPerlinNoiseMap::packOut(lua_State *L, void *ptr)
 }
 
 
-void LuaPerlinNoiseMap::Register(lua_State *L)
+void LuaValueNoiseMap::Register(lua_State *L)
 {
 	static const luaL_Reg metamethods[] = {
 		{"__gc", gc_object},
@@ -368,15 +368,15 @@ void LuaPerlinNoiseMap::Register(lua_State *L)
 }
 
 
-const char LuaPerlinNoiseMap::className[] = "PerlinNoiseMap";
-luaL_Reg LuaPerlinNoiseMap::methods[] = {
-	luamethod_aliased(LuaPerlinNoiseMap, get_2d_map,      get2dMap),
-	luamethod_aliased(LuaPerlinNoiseMap, get_2d_map_flat, get2dMap_flat),
-	luamethod_aliased(LuaPerlinNoiseMap, calc_2d_map,     calc2dMap),
-	luamethod_aliased(LuaPerlinNoiseMap, get_3d_map,      get3dMap),
-	luamethod_aliased(LuaPerlinNoiseMap, get_3d_map_flat, get3dMap_flat),
-	luamethod_aliased(LuaPerlinNoiseMap, calc_3d_map,     calc3dMap),
-	luamethod_aliased(LuaPerlinNoiseMap, get_map_slice,   getMapSlice),
+const char LuaValueNoiseMap::className[] = "ValueNoiseMap";
+luaL_Reg LuaValueNoiseMap::methods[] = {
+	luamethod_aliased(LuaValueNoiseMap, get_2d_map,      get2dMap),
+	luamethod_aliased(LuaValueNoiseMap, get_2d_map_flat, get2dMap_flat),
+	luamethod_aliased(LuaValueNoiseMap, calc_2d_map,     calc2dMap),
+	luamethod_aliased(LuaValueNoiseMap, get_3d_map,      get3dMap),
+	luamethod_aliased(LuaValueNoiseMap, get_3d_map_flat, get3dMap_flat),
+	luamethod_aliased(LuaValueNoiseMap, calc_3d_map,     calc3dMap),
+	luamethod_aliased(LuaValueNoiseMap, get_map_slice,   getMapSlice),
 	{0,0}
 };
 

--- a/src/script/lua_api/l_noise.h
+++ b/src/script/lua_api/l_noise.h
@@ -9,9 +9,9 @@
 #include "noise.h"
 
 /*
-	LuaPerlinNoise
+	LuaValueNoise
 */
-class LuaPerlinNoise : public ModApiBase
+class LuaValueNoise : public ModApiBase
 {
 private:
 	NoiseParams np;
@@ -27,11 +27,11 @@ private:
 	static int l_get_3d(lua_State *L);
 
 public:
-	LuaPerlinNoise(const NoiseParams *params);
-	~LuaPerlinNoise() = default;
+	LuaValueNoise(const NoiseParams *params);
+	~LuaValueNoise() = default;
 
-	// LuaPerlinNoise(seed, octaves, persistence, scale)
-	// Creates an LuaPerlinNoise and leaves it on top of stack
+	// LuaValueNoise(seed, octaves, persistence, scale)
+	// Creates an LuaValueNoise and leaves it on top of stack
 	static int create_object(lua_State *L);
 
 	static void *packIn(lua_State *L, int idx);
@@ -43,9 +43,9 @@ public:
 };
 
 /*
-	LuaPerlinNoiseMap
+	LuaValueNoiseMap
 */
-class LuaPerlinNoiseMap : public ModApiBase
+class LuaValueNoiseMap : public ModApiBase
 {
 	Noise *noise;
 
@@ -66,13 +66,13 @@ class LuaPerlinNoiseMap : public ModApiBase
 	static int l_get_map_slice(lua_State *L);
 
 public:
-	LuaPerlinNoiseMap(const NoiseParams *np, s32 seed, v3s16 size);
-	~LuaPerlinNoiseMap();
+	LuaValueNoiseMap(const NoiseParams *np, s32 seed, v3s16 size);
+	~LuaValueNoiseMap();
 
 	inline bool is3D() const { return noise->sz > 1; }
 
-	// LuaPerlinNoiseMap(np, size)
-	// Creates an LuaPerlinNoiseMap and leaves it on top of stack
+	// LuaValueNoiseMap(np, size)
+	// Creates an LuaValueNoiseMap and leaves it on top of stack
 	static int create_object(lua_State *L);
 
 	static void *packIn(lua_State *L, int idx);

--- a/src/script/scripting_emerge.cpp
+++ b/src/script/scripting_emerge.cpp
@@ -60,8 +60,8 @@ void EmergeScripting::InitializeModApi(lua_State *L, int top)
 	ItemStackMetaRef::Register(L);
 	LuaAreaStore::Register(L);
 	LuaItemStack::Register(L);
-	LuaPerlinNoise::Register(L);
-	LuaPerlinNoiseMap::Register(L);
+	LuaValueNoise::Register(L);
+	LuaValueNoiseMap::Register(L);
 	LuaPseudoRandom::Register(L);
 	LuaPcgRandom::Register(L);
 	LuaSecureRandom::Register(L);

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -134,8 +134,8 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	ItemStackMetaRef::Register(L);
 	LuaAreaStore::Register(L);
 	LuaItemStack::Register(L);
-	LuaPerlinNoise::Register(L);
-	LuaPerlinNoiseMap::Register(L);
+	LuaValueNoise::Register(L);
+	LuaValueNoiseMap::Register(L);
 	LuaPseudoRandom::Register(L);
 	LuaPcgRandom::Register(L);
 	LuaRaycast::Register(L);
@@ -172,8 +172,8 @@ void ServerScripting::InitializeAsync(lua_State *L, int top)
 	ItemStackMetaRef::Register(L);
 	LuaAreaStore::Register(L);
 	LuaItemStack::Register(L);
-	LuaPerlinNoise::Register(L);
-	LuaPerlinNoiseMap::Register(L);
+	LuaValueNoise::Register(L);
+	LuaValueNoiseMap::Register(L);
 	LuaPseudoRandom::Register(L);
 	LuaPcgRandom::Register(L);
 	LuaSecureRandom::Register(L);

--- a/src/unittest/test_noise.cpp
+++ b/src/unittest/test_noise.cpp
@@ -78,7 +78,7 @@ void TestNoise::testNoise2dPoint()
 	u32 i = 0;
 	for (u32 y = 0; y != 10; y++)
 	for (u32 x = 0; x != 10; x++, i++) {
-		float actual   = NoisePerlin2D(&np_normal, x, y, 1337);
+		float actual   = NoiseFractal2D(&np_normal, x, y, 1337);
 		float expected = expected_2d_results[i];
 		UASSERT(std::fabs(actual - expected) <= 0.00001);
 	}
@@ -88,7 +88,7 @@ void TestNoise::testNoise2dBulk()
 {
 	NoiseParams np_normal(20, 40, v3f(50, 50, 50), 9,  5, 0.6, 2.0);
 	Noise noise_normal_2d(&np_normal, 1337, 10, 10);
-	float *noisevals = noise_normal_2d.perlinMap2D(0, 0, NULL);
+	float *noisevals = noise_normal_2d.noiseMap2D(0, 0, NULL);
 
 	for (u32 i = 0; i != 10 * 10; i++) {
 		float actual   = noisevals[i];
@@ -126,7 +126,7 @@ void TestNoise::testNoise3dPoint()
 	for (u32 z = 0; z != 10; z++)
 	for (u32 y = 0; y != 10; y++)
 	for (u32 x = 0; x != 10; x++, i++) {
-		float actual   = NoisePerlin3D(&np_normal, x, y, z, 1337);
+		float actual   = NoiseFractal3D(&np_normal, x, y, z, 1337);
 		float expected = expected_3d_results[i];
 		UASSERT(std::fabs(actual - expected) <= 0.00001);
 	}
@@ -136,7 +136,7 @@ void TestNoise::testNoise3dBulk()
 {
 	NoiseParams np_normal(20, 40, v3f(50, 50, 50), 9, 5, 0.6, 2.0);
 	Noise noise_normal_3d(&np_normal, 1337, 10, 10, 10);
-	float *noisevals = noise_normal_3d.perlinMap3D(0, 0, 0, NULL);
+	float *noisevals = noise_normal_3d.noiseMap3D(0, 0, 0, NULL);
 
 	for (u32 i = 0; i != 10 * 10 * 10; i++) {
 		float actual   = noisevals[i];
@@ -152,7 +152,7 @@ void TestNoise::testNoiseInvalidParams()
 	try {
 		NoiseParams np_highmem(4, 70, v3f(1, 1, 1), 5, 60, 0.7, 10.0);
 		Noise noise_highmem_3d(&np_highmem, 1337, 200, 200, 200);
-		noise_highmem_3d.perlinMap3D(0, 0, 0, NULL);
+		noise_highmem_3d.noiseMap3D(0, 0, 0, NULL);
 	} catch (InvalidNoiseParamsException &) {
 		exception_thrown = true;
 	}


### PR DESCRIPTION
Fixes #15775: rename Perlin noise to (fractal) value noise, which is what is actually implemented.

I tried to add aliases for the old names. But I'm not sure what is the best way to generate a deprecation warning for the global lua classes such as `PerlinNoise` and `PerlinNoiseMap`, don't want to break anything. But these old names are probably not going to be removed the next 5+ years anyway...
This needs to be fine-tuned by an expert on the Luanti Lua API.

In the future, actual Perlin noise or simplex noise could then be added for new mapgens.
For example the fast <https://github.com/Auburn/FastNoise2> library is C++ and MIT licensed.

See also:
- #11468
- #14635