### PR TITLE
Disable UDP connections when the ALL_PROXY environment variable is set

### DIFF
--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -35,6 +35,8 @@ typedef int socklen_t;
 #define SOCKET_ERR_STR(e) strerror(e)
 #endif
 
+#define ENV_ALL_PROXY "ALL_PROXY"
+
 static bool g_sockets_initialized = false;
 
 // Initialize sockets
@@ -132,6 +134,18 @@ void UDPSocket::Bind(Address addr)
 				<< "\nTry disabling ipv6_server to fix this." << std::endl;
 			throw SocketException(errmsg);
 		}
+	}
+
+	// UDP connections currenlty do not support proxies in Luanti
+	// Many socks5 procies do not support UDP
+	// Therefore, we disable UDP when the ALL_PROXY is set
+	// Use the http_proxy variable instead if you want unproxied UDP connections
+	if (std::getenv(ENV_ALL_PROXY)) {
+		auto msg = "UDP connections are not supported when " ENV_ALL_PROXY " environment variable is set. Use the http_proxy environment variable to not proxy UDP connections";
+		verbosestream << msg << std::endl;
+		if (noExceptions)
+			return false;
+		throw SocketException(msg);
 	}
 
 	int ret = 0;


### PR DESCRIPTION
This PR disables UDP connections when the ALL_PROXY environment variable is set. See https://github.com/luanti-org/luanti/issues/8343#issuecomment-2764331797 for explanation.

## To do

This PR is a Ready for Review.

## How to test

Set the `ALL_PROXY=socks5h://127.0.0.1:9050`. Trying to connect to a online game server should show the error message.
