### PR TITLE
Set `CMAKE_POLICY_VERSION_MINIMUM=3.5` to make MSVC CI work again

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -106,10 +106,12 @@ jobs:
           vcpkgTriplet: ${{ matrix.config.vcpkg_triplet }}
 
       - name: CMake
+        # Note: See #15976 for why CMAKE_POLICY_VERSION_MINIMUM=3.5 is set.
         run: |
           cmake ${{matrix.config.generator}}  `
           -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake"  `
           -DCMAKE_BUILD_TYPE=Release  `
+          -DCMAKE_POLICY_VERSION_MINIMUM=3.5  `
           -DENABLE_POSTGRESQL=OFF  `
           -DENABLE_LUAJIT=TRUE  `
           -DREQUIRE_LUAJIT=TRUE  `


### PR DESCRIPTION
Closes #15976. Thanks @JosiahWI for the suggestion.