### PR TITLE
Add proof of concept for blocks callback

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6637,7 +6637,7 @@ Environment access
                             clear objects in unloaded mapblocks only when the
                             mapblocks are next activated.
 * `core.blocks_callback(options)`
-    * Call Lua function over all loaded or loadable blocks 
+    * Call Lua function over all loaded or loadable blocks
     * Takes an table as an argument with the fields:
         * `mode`
             * mode = "full": Load and go through every mapblock.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6640,8 +6640,8 @@ Environment access
     * Call Lua function over all loaded or loadable blocks 
     * Takes an table as an argument with the fields:
         * `mode`
-            * mode = "full": Load and go through every mapblock, clearing objects (default).
-            * mode = "quick": Clear objects immediately in loaded mapblocks, clear objects in unloaded mapblocks only when the mapblocks are next activated.
+            * mode = "full": Load and go through every mapblock.
+            * mode = "quick": Go only through loaded mapblock.
         * `callback`: Lua callback function function(name, staticdata, params.
             * `blockpos_hash`: block position hash compatible with `core.hash_node_position` and `core.get_position_from_hash`
             * `params`: Some Lua value.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6636,6 +6636,17 @@ Environment access
         * mode = `"quick"`: Clear objects immediately in loaded mapblocks,
                             clear objects in unloaded mapblocks only when the
                             mapblocks are next activated.
+* `core.blocks_callback(options)`
+    * Call Lua function over all loaded or loadable blocks 
+    * Takes an table as an argument with the fields:
+        * `mode`
+            * mode = "full": Load and go through every mapblock, clearing objects (default).
+            * mode = "quick": Clear objects immediately in loaded mapblocks, clear objects in unloaded mapblocks only when the mapblocks are next activated.
+        * `callback`: Lua callback function function(name, staticdata, params.
+            * `blockpos_hash`: block position hash compatible with `core.hash_node_position` and `core.get_position_from_hash`
+            * `params`: Some Lua value.
+        * `params`: Params for Lua callback functions.
+
 * `core.load_area(pos1[, pos2])`
     * Load the mapblocks containing the area from `pos1` to `pos2`.
       `pos2` defaults to `pos1` if not specified.

--- a/src/script/cpp_api/s_env.h
+++ b/src/script/cpp_api/s_env.h
@@ -41,6 +41,9 @@ public:
 	// Determines whether there are any on_mapblocks_changed callbacks
 	bool has_on_mapblocks_changed();
 
+	// Calll Lua callback for block
+	void block_callback(const v3s16 blockpos, ScriptCallbackState *state);
+
 	// Initializes environment and loads some definitions from Lua
 	void initializeEnvironment(ServerEnvironment *env);
 

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -195,6 +195,9 @@ private:
 	// clear all objects in the environment
 	static int l_clear_objects(lua_State *L);
 
+	// blocks_callback()
+	static int l_blocks_callback(lua_State *L);
+
 	// spawn_tree(pos, treedef)
 	static int l_spawn_tree(lua_State *L);
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -930,7 +930,7 @@ void ServerEnvironment::blocksCallback(BlocksCallbackConfig &config)
 			float percent = 100.0 * (float)num_blocks_processed /
 				loadable_blocks.size();
 			actionstream << "ServerEnvironment::blocksCallback(): "
-				<< "Processed" << num_blocks_processed << " blocks ("
+				<< "Processed " << num_blocks_processed << " blocks ("
 				<< percent << "%)" << std::endl;
 		}
 		if (num_blocks_processed % unload_interval == 0) {

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -252,7 +252,7 @@ public:
 	// Clear objects, loading and going through every MapBlock
 	void clearObjects(ClearObjectsMode mode);
 
-	// Call Lua functon for akk loaded or loadable MapBlock 
+	// Call Lua functon for akk loaded or loadable MapBlock
 	void blocksCallback(BlocksCallbackConfig &config);
 
 	// to be called before destructor

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -101,6 +101,16 @@ enum ClearObjectsMode {
 		CLEAR_OBJECTS_MODE_QUICK,
 };
 
+// blocksCallback
+typedef void (*BlocksCallback)(const v3s16 blockpos, void *param);
+
+struct BlocksCallbackConfig {
+	ClearObjectsMode mode;
+
+	BlocksCallback callback;
+	void *param;
+};
+
 class ServerEnvironment final : public Environment
 {
 public:
@@ -241,6 +251,9 @@ public:
 
 	// Clear objects, loading and going through every MapBlock
 	void clearObjects(ClearObjectsMode mode);
+
+	// Call Lua functon for akk loaded or loadable MapBlock 
+	void blocksCallback(BlocksCallbackConfig &config);
 
 	// to be called before destructor
 	void deactivateBlocksAndObjects();


### PR DESCRIPTION
Delivered from #14138.

Proof of concept for allowing modders to apply Lua callback to all loaded/loadable mapblocks.

Have the potential to be used for some updating, emulating some environment things like Exile game does.

@kromka-chleba

**Test:**

```
core.blocks_callback({
  mode = "quick",
  callback = function(blockpos)
    print("Block po hash: "..blockpos)
  end
)}
```
