### PR TITLE
Docs: Clean up docker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,15 @@ Compiling
 Docker
 ------
 
-Server Quick Start:
-```
+Quick Start:
+```bash
+# One-command server setup with VoxeLibre game
 mkdir -p ~/luanti/{data,conf,games} && \
 wget https://raw.githubusercontent.com/luanti-org/luanti/master/minetest.conf.example -O ~/luanti/conf/minetest.conf && \
 wget https://content.luanti.org/packages/Wuzzy/mineclone2/releases/30536/download/ -O ~/luanti/mineclone2.zip && \
 unzip ~/luanti/mineclone2.zip -d ~/luanti/games/ && \
 echo "name = AdminUser" >> ~/luanti/conf/minetest.conf && \
+sudo chown -R 30000:30000 ~/luanti/{data,conf,games} && \
 docker run -d \
   -v ~/luanti/data:/var/lib/minetest \
   -v ~/luanti/conf:/etc/minetest \
@@ -148,6 +150,7 @@ docker run -d \
   --gameid mineclone2 --port 30000
 ```
 
+For more details:
 - [Developing minetestserver with Docker](doc/developing/docker.md)
 - [Running a server with Docker](doc/docker_server.md)
 

--- a/doc/docker_server.md
+++ b/doc/docker_server.md
@@ -22,13 +22,12 @@ mkdir -p ~/luanti/{data,conf}
 # Download proper configuration file (REQUIRED)
 wget https://raw.githubusercontent.com/luanti-org/luanti/master/minetest.conf.example -O ~/luanti/conf/minetest.conf
 
-# Add your admin username to the configuration
-echo "name = AdminUser" >> ~/luanti/conf/minetest.conf
-
 # Download and extract a game (if you don't have one already)
 mkdir -p ~/luanti/games
 wget https://content.luanti.org/packages/Wuzzy/mineclone2/releases/30536/download/ -O ~/luanti/mineclone2.zip
 unzip ~/luanti/mineclone2.zip -d ~/luanti/games/
+
+sudo chown -R 30000:30000 ~/luanti/{data,conf,games}
 
 # Run the server
 docker run -d \


### PR DESCRIPTION
- Goal of the PR

Cleans up the documentation for the docker quickstart, and adds an explicit quickstart to the README.md. I was running into UID issues, "no game selected" issues, misunderstanding directories and locations, etc etc. I figured, why save the people after me the frustration?

- How does the PR work?

Just updates documentation in the docker_server.md file, and also in the main readme.md.

- Does it resolve any reported issue?

[At least one, after a quick search](https://github.com/luanti-org/luanti/issues/14768)

- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?

Not specifically, no.

- If not a bug fix, why is this PR needed? What usecases does it solve?

Just clarifies use of the docker image, and provides a 0-60 quickstart for users.

## How to test

- [ ] Run the quickstart, and see that it stands up a basic server
- [ ] Read the docker_server.md file, making sure that I didn't make any wild assertions or swear too much
- [ ] Check this third box
