### PR TITLE
Add new hotbar_slot_selected lua callback

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -618,6 +618,7 @@ core.registered_allow_player_inventory_actions, core.register_allow_player_inven
 core.registered_on_rightclickplayers, core.register_on_rightclickplayer = make_registration()
 core.registered_on_liquid_transformed, core.register_on_liquid_transformed = make_registration()
 core.registered_on_mapblocks_changed, core.register_on_mapblocks_changed = make_registration()
+core.registered_on_hotbar_slot_selected, core.register_on_hotbar_slot_selected = make_registration()
 
 -- A bunch of registrations are read by the C++ side once on env init, so we cannot
 -- allow them to change afterwards (see s_env.cpp).

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6331,6 +6331,14 @@ Call these functions only at load time!
       The set is a table where the keys are hashes and the values are `true`.
     * `modified_block_count` is the number of entries in the set.
     * Note: callbacks must be registered at mod load time.
+* `core.register_on_hotbar_slot_selected(function(player, inventory, list_name, hotbar_slot, prev_hotbar_slot, is_from_scrolling))`
+    * Called when the player selects a hotbar slot, including re-selecting current slot
+    * `player`: `ObjectRef` - Player that selected their hotbar slot
+    * `inventory`: type `InvRef`
+    * `list_name`: string - the name of the hotbar list
+    * `hotbar_slot`: integer - the newly selected hotbar slot
+    * `prev_hotbar_slot`: integer - the previously selected hotbar slot, can be the same as `hotbar_slot` if the player selected the same slot
+    * `is_from_scrolling`: boolean - true if the input came from a scroll action, or the prev/next slot input keys
 
 Setting-related
 ---------------
@@ -7890,6 +7898,7 @@ For historical reasons, the use of an -s suffix in these names is inconsistent.
 * `core.registered_on_modchannel_message`
 * `core.registered_on_liquid_transformed`
 * `core.registered_on_mapblocks_changed`
+* `core.registered_on_hotbar_slot_selected`
 
 Class reference
 ===============

--- a/src/inventorymanager.h
+++ b/src/inventorymanager.h
@@ -109,7 +109,8 @@ public:
 enum class IAction : u16 {
 	Move,
 	Drop,
-	Craft
+	Craft,
+	HotbarSlotSelected,
 };
 
 struct InventoryAction
@@ -247,3 +248,35 @@ struct ICraftAction : public InventoryAction
 bool getCraftingResult(Inventory *inv, ItemStack &result,
 		std::vector<ItemStack> &output_replacements,
 		bool decrementInput, IGameDef *gamedef);
+
+struct IHotbarSlotSelectedAction : public InventoryAction
+{
+	InventoryLocation inv;
+	std::string list;
+	s16 selected_slot = -1;
+	s16 prev_selected_slot = -1;
+	bool from_scroll = false;
+
+	IHotbarSlotSelectedAction() = default;
+
+	IHotbarSlotSelectedAction(std::istream& is);
+
+	IAction getType() const
+	{
+		return IAction::HotbarSlotSelected;
+	}
+
+	void serialize(std::ostream& os) const
+	{
+		os<<"HotbarSlotSelected ";
+		os<<inv.dump()<<" ";
+		os<<list<<" ";
+		os<<selected_slot<<" ";
+		os<<prev_selected_slot<<" ";
+		os<<(from_scroll ? "1" : "0");
+	}
+
+	void apply(InventoryManager* mgr, ServerActiveObject* player, IGameDef* gamedef);
+
+	void clientApply(InventoryManager* mgr, IGameDef* gamedef);
+};

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -734,6 +734,14 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 
 		if (!check_inv_access(ca->craft_inv))
 			return;
+	}
+	/*
+		Handle HotbarSlotSelected action special cases
+	*/
+	else if (a->getType() == IAction::HotbarSlotSelected) {
+		IHotbarSlotSelectedAction *ha = (IHotbarSlotSelectedAction*)a.get();
+		ha->inv.applyCurrentPlayer(player->getName());
+		// Note: `IHotbarSlotSelectedAction::clientApply` is empty, thus nothing to revert.
 	} else {
 		// Unknown action. Ignored.
 		return;

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -236,6 +236,35 @@ void ScriptApiPlayer::on_authplayer(const std::string &name, const std::string &
 	runCallbacks(3, RUN_CALLBACKS_MODE_FIRST);
 }
 
+void ScriptApiPlayer::on_hotbar_slot_selected(
+	ServerActiveObject* player,
+	InventoryLocation& loc,
+	const std::string &list,
+	int hotbar_slot,
+	int prev_hotbar_slot,
+	bool is_from_scroll
+)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_hotbar_slot_selected");
+	// param 1
+	objectrefGetOrCreate(L, player);
+	// param 2
+	InvRef::create(L, loc);
+	// param 3
+	lua_pushstring(L, list.c_str());
+	// param 4
+	lua_pushinteger(L, hotbar_slot + 1);
+	// param 5
+	lua_pushinteger(L, prev_hotbar_slot + 1);
+	// param 6
+	lua_pushboolean(L, is_from_scroll);
+
+	runCallbacks(6, RUN_CALLBACKS_MODE_LAST);
+}
+
 void ScriptApiPlayer::pushMoveArguments(
 		const MoveAction &ma, int count,
 		ServerActiveObject *player)

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -38,6 +38,14 @@ public:
 	void on_playerReceiveFields(ServerActiveObject *player,
 			const std::string &formname, const StringMap &fields);
 	void on_authplayer(const std::string &name, const std::string &ip, bool is_success);
+	void on_hotbar_slot_selected(
+		ServerActiveObject* player,
+		InventoryLocation& loc,
+		const std::string& list,
+		int hotbar_slot,
+		int prev_hotbar_slot,
+		bool is_from_scroll
+	);
 
 	// Player inventory callbacks
 	// Return number of accepted items to be moved


### PR DESCRIPTION
## Goal of the PR
The goal here is to allow a way for items in the hotbar to be activated the same way hotbar spells/skills are activated in some other games - via a single key press / screen tap on mobile.

Currently this is only possible by first selecting an item and then having to use/place that item, thus requiring a key press (or scroll) and then a mouse click - or alternatively two taps on mobile.

This PR aims to allow a way to only activate an item in the hotbar via single-key press (or screen tap on mobile).

This would allow, as an example, games to be written where hotbar items can be treated as skills or spells to be activated, rather than items to be used.

Specifically to note, the difference between this and polling `player:get_wielded_item()` or `player:get_wield_index()` is that that method will not detect if the user taps/uses keyboard shortcut to select the exact same slot again, while this PR allows for this to be done.

## How does the PR work?
- Adds a new Inventory Action to denote when a hotbar item has been selected
- Adds a new global callback called `register_on_hotbar_slot_selected`

## Does it resolve any reported issue?
No, this is not resolving any issue that I'm aware of. It instead aims to introduce a fairly minor change to allow a new way of interacting with items.

## Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
It does not contradict any goals, and only adds a new method of interaction which may be used to build more games.

## If not a bug fix, why is this PR needed? What usecases does it solve?
Please see `Goal of the PR` above

## To do
Ready for Review.

- [ ] Get feedback on whether using Inventory Action is the right way to do this
- [ ] Get feedback on whether placing the updates directly in `processItemSelection` is the right way to do this

## How to test
The functionality of the PR can be verified by registering a new callback, for example:
```lua
if core.register_on_hotbar_slot_selected then
  core.register_on_hotbar_slot_selected(function(player, inventory, list_name, hotbar_slot, prev_hotbar_slot, is_from_scrolling)
    if not player or not player:is_player() then return end
    local wieldItem = player:get_wielded_item()
    local wieldList = list_name
    core.log("prev hotbar = "..prev_hotbar_slot..", curr_hotbar = "..hotbar_slot)
    core.log("- player:get_wielded_item() = "..dump(wieldItem))
    core.log("- is_from_scrolling = "..dump(is_from_scrolling))
    core.log("- wieldList + curr_wield_index = "..dump(inventory:get_stack(wieldList, hotbar_slot)))
    core.log("----")
  end)
end

```
