### PR TITLE
Formspec: Fix incorrect cell size when using non-default fonts

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1235,9 +1235,13 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 		item = wide_to_utf8(unescape_translate(utf8_to_wide(unescape_string(item))));
 	}
 
-	//now really show table
 	GUITable *e = new GUITable(Environment, data->current_parent, spec.fid,
 			rect, m_tsrc);
+
+	// Apply styling before calculating the cell sizes
+	auto style = getDefaultStyleForElement("table", name);
+	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+	e->setOverrideFont(style.getFont());
 
 	if (spec.fname == m_focused_element) {
 		Environment->setFocus(e);
@@ -1251,10 +1255,6 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 
 	if (!str_initial_selection.empty() && str_initial_selection != "0")
 		e->setSelected(stoi(str_initial_selection));
-
-	auto style = getDefaultStyleForElement("table", name);
-	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-	e->setOverrideFont(style.getFont());
 
 	m_tables.emplace_back(spec, e);
 	m_fields.push_back(spec);

--- a/src/gui/guiTable.h
+++ b/src/gui/guiTable.h
@@ -85,7 +85,7 @@ public:
 	void setTextList(const std::vector<std::string> &content,
 			bool transparent);
 
-	/* Set generic table options, columns and content */
+	/** Set generic table options, columns and content, calculate cell sizes */
 	// Adds empty strings to end of content if there is an incomplete row
 	void setTable(const TableOptions &options,
 			const TableColumns &columns,


### PR DESCRIPTION
Fixes #16177

With this PR:
![grafik](https://github.com/user-attachments/assets/c5eed690-c294-465b-b27c-8abfa0d9762d)


## To do

This PR is Ready for Review.

## How to test

```Lua
core.register_chatcommand("fs", {
	func = function(name, param)
		local player = core.get_player_by_name(name)
		if not player then return end -- ncurses
		core.show_formspec(name, "foobar",
			[[
			formspec_version[7]
			size[10,11]
			style_type[table;font=mono]
			tablecolumns[text;text;text]
			table[0,1;10,9;machines;Type,Position,Priority,sbz_resources:storinator,(2\, 9\, -10),100,pipeworks:accelerator_tube_3,(2\, 9\, -7),50;1]
			]])
	end
})
```