### PR TITLE
Don't write overgenerated stone to fix overwritten Y-slices with num_emerge_threads > 1

### DIFF
--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -769,6 +769,18 @@ void MapgenBasic::generateBiomes()
 }
 
 
+void MapgenBasic::removeOvergeneratedCStone()
+{
+	for (s16 z = node_min.Z; z <= node_max.Z; z++)
+	for (s16 x = node_min.X; x <= node_max.X; x++) {
+		u32 vi = vm->m_area.index(x, node_max.Y + 1, z); // top
+		vm->m_data[vi].setContent(CONTENT_IGNORE);
+		vi = vm->m_area.index(x, node_min.Y - 1, z);     // bottom
+		vm->m_data[vi].setContent(CONTENT_IGNORE);
+	}
+}
+
+
 void MapgenBasic::dustTopNodes()
 {
 	if (node_max.Y < water_level)
@@ -954,7 +966,6 @@ void MapgenBasic::generateDungeons(s16 max_stone_y)
 	DungeonGen dgen(ndef, &gennotify, &dp);
 	dgen.generate(vm, blockseed, full_node_min, full_node_max);
 }
-
 
 ////
 //// GenerateNotifier

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -774,9 +774,13 @@ void MapgenBasic::removeOvergeneratedCStone()
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++) {
 		u32 vi = vm->m_area.index(x, node_max.Y + 1, z); // top
-		vm->m_data[vi].setContent(CONTENT_IGNORE);
+		if (vm->m_data[vi].getContent() == c_stone) {
+			vm->m_data[vi].setContent(CONTENT_IGNORE);
+		}
 		vi = vm->m_area.index(x, node_min.Y - 1, z);     // bottom
-		vm->m_data[vi].setContent(CONTENT_IGNORE);
+		if (vm->m_data[vi].getContent() == c_stone) {
+			vm->m_data[vi].setContent(CONTENT_IGNORE);
+		}
 	}
 }
 

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -289,6 +289,7 @@ public:
 	virtual void generateCavesRandomWalk(s16 max_stone_y, s16 large_cave_ymax);
 	virtual bool generateCavernsNoise(s16 max_stone_y);
 	virtual void generateDungeons(s16 max_stone_y);
+	virtual void removeOvergeneratedCStone();
 
 protected:
 	BiomeManager *m_bmgr;

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -318,6 +318,8 @@ void MapgenCarpathian::makeChunk(BlockMakeData *data)
 				full_node_min, full_node_max);
 	}
 
+	removeOvergeneratedCStone();
+
 	this->generating = false;
 }
 

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -268,6 +268,8 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 	//setLighting(node_min - v3s16(1, 0, 1) * MAP_BLOCKSIZE,
 	//			node_max + v3s16(1, 0, 1) * MAP_BLOCKSIZE, 0xFF);
 
+	removeOvergeneratedCStone();
+
 	this->generating = false;
 }
 

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -263,6 +263,8 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 		calcLighting(node_min - v3s16(0, 1, 0), node_max + v3s16(0, 1, 0),
 			full_node_min, full_node_max);
 
+	removeOvergeneratedCStone();
+
 	this->generating = false;
 
 	//printf("makeChunk: %lums\n", t.stop());

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -262,6 +262,8 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 			full_node_min, full_node_max);
 	}
 
+	removeOvergeneratedCStone();
+
 	this->generating = false;
 }
 

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -620,8 +620,21 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 		calcLighting(node_min - v3s16(1, 1, 1) * MAP_BLOCKSIZE,
 			node_max + v3s16(1, 0, 1) * MAP_BLOCKSIZE,
 			full_node_min, full_node_max);
+	
+	removeOvergeneratedCStone();
 
 	this->generating = false;
+}
+
+void MapgenV6::removeOvergeneratedCStone()
+{
+	for (s16 z = node_min.Z; z <= node_max.Z; z++)
+	for (s16 x = node_min.X; x <= node_max.X; x++) {
+		u32 vi = vm->m_area.index(x, node_max.Y + 1, z); // top
+		vm->m_data[vi].setContent(CONTENT_IGNORE);
+		vi = vm->m_area.index(x, node_min.Y - 1, z);     // bottom
+		vm->m_data[vi].setContent(CONTENT_IGNORE);
+	}
 }
 
 

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -631,9 +631,13 @@ void MapgenV6::removeOvergeneratedCStone()
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++) {
 		u32 vi = vm->m_area.index(x, node_max.Y + 1, z); // top
-		vm->m_data[vi].setContent(CONTENT_IGNORE);
+		if (vm->m_data[vi].getContent() == c_stone) {
+			vm->m_data[vi].setContent(CONTENT_IGNORE);
+		}
 		vi = vm->m_area.index(x, node_min.Y - 1, z);     // bottom
-		vm->m_data[vi].setContent(CONTENT_IGNORE);
+		if (vm->m_data[vi].getContent() == c_stone) {
+			vm->m_data[vi].setContent(CONTENT_IGNORE);
+		}
 	}
 }
 

--- a/src/mapgen/mapgen_v6.h
+++ b/src/mapgen/mapgen_v6.h
@@ -125,6 +125,7 @@ public:
 	void makeChunk(BlockMakeData *data);
 	int getGroundLevelAtPoint(v2s16 p);
 	int getSpawnLevelAtPoint(v2s16 p);
+	virtual void removeOvergeneratedCStone();
 
 	float baseTerrainLevel(float terrain_base, float terrain_higher,
 		float steepness, float height_select);

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -379,6 +379,8 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 		calcLighting(node_min - v3s16(0, 1, 0), node_max + v3s16(0, 1, 0),
 			full_node_min, full_node_max, propagate_shadow);
 
+	removeOvergeneratedCStone();
+
 	this->generating = false;
 
 	//printf("makeChunk: %lums\n", t.stop());

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -271,6 +271,8 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 		calcLighting(node_min - v3s16(0, 1, 0), node_max + v3s16(0, 1, 0),
 			full_node_min, full_node_max);
 
+	removeOvergeneratedCStone();
+
 	this->generating = false;
 
 	//printf("makeChunk: %lums\n", t.stop());


### PR DESCRIPTION
## Goal

Allow reliable multi-threaded mapgen (outside pure lua mapgen) by removing issues arising from race conditions related to Y direction overgeneration and more than one emerge thread, Solved in this PR by always setting those two overgenerated layers back to `CONTENT_IGNORE` after using it to generate dust/biome/etc.

Resolves #9357 

## To do

- [ ] Not probably following coding standards
- [ ] The removeOvergeneratedCStone() function probably needs a better name
- [ ] The removeOvergeneratedCStone() function also probably needs to be made more effecient - I'm rusty on Vmanip. 

This PR is Ready for Review.

## How to test

Load up a new world, with num_emerge_threads > 1 in your favorite game (mtg or devtest, or otherwise), toggle on fly,fast and start flying around. Look for bad y-slices in master vs this branch.

#### Other ways to test:
You can use this especially made "game" just for hunting this bug:

https://codeberg.org/perfect_city_game_studio/mapgen_test

I'm not the author, this is from the [original issue thread](https://github.com/luanti-org/luanti/issues/9357#issuecomment-2332494544)

OR 

You can load up any game, with a world seed of "2" and select mapgen v7, have a high num emerge threads, and teleport to 50,50,500. 
