### PR TITLE
Add ability to transform scene color in shaders.

### DIFF
--- a/builtin/game/misc_s.lua
+++ b/builtin/game/misc_s.lua
@@ -130,6 +130,7 @@ core.protocol_versions = {
 	["5.10.0"] = 46,
 	["5.11.0"] = 47,
 	["5.12.0"] = 48,
+	["5.13.0"] = 49,
 }
 
 setmetatable(core.protocol_versions, {__newindex = function()

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -31,6 +31,8 @@ centroid varying vec2 varTexCoord;
 varying float exposure; // linear exposure factor, see vertex shader
 #endif
 
+uniform mat3 colorTransformMatrix;
+
 #ifdef ENABLE_BLOOM
 
 vec4 applyBloom(vec4 color, vec2 uv)
@@ -103,6 +105,12 @@ vec3 screen_space_dither(highp vec2 frag_coord) {
 }
 #endif
 
+vec4 applyColorVision(vec4 color)
+{
+	vec3 transformedColor = colorTransformMatrix * color.rgb;
+	return vec4(transformedColor, color.a);
+}
+
 void main(void)
 {
 	vec2 uv = varTexCoord.st;
@@ -133,6 +141,7 @@ void main(void)
 	color = applyBloom(color, uv);
 #endif
 
+	color = applyColorVision(color);
 
 	color.rgb = clamp(color.rgb, vec3(0.), vec3(1.));
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9064,6 +9064,23 @@ child will follow movement and rotation of that bone.
             * Currently, bloom `intensity` and `strength_factor` affect volumetric
               lighting `strength` and vice versa. This behavior is to be changed
               in the future, do not rely on it.
+      * `color_transform_matrix`: is a matrix with default value (identity matrix):
+        ```lua
+          { {1.0, 0.0, 0.0}, -- r
+            {0.0, 1.0, 0.0}, -- g
+            {0.0, 0.0, 1.0}} -- b
+        ```
+
+        * Work as `transformed_color_RGB = color_transform_matrix * color_RGB`
+        * Can be used for creation color blind effect, base for night vision effect etc.
+        * Request client with protocol version 49 or higger.
+
+        ```lua
+          -- example of night vision like transform
+          { {0.0, 0.0, 0.0},
+            {1.0, 9.0, 1.0},
+            {0.0, 0.0, 0.0}}
+        ```
 
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -231,6 +231,9 @@ class GameGlobalShaderUniformSetter : public IShaderUniformSetter
 	CachedPixelShaderSetting<float>
 		m_volumetric_light_strength_pixel{"volumetricLightStrength"};
 
+	CachedPixelShaderSetting<float, 9>
+		m_color_transform_matrix{"colorTransformMatrix"};
+
 	static constexpr std::array<const char*, 1> SETTING_CALLBACKS = {
 		"exposure_compensation",
 	};
@@ -320,6 +323,8 @@ public:
 			float radius = std::max(lighting.bloom_radius, 0.0f);
 			m_bloom_radius_pixel.set(&radius, services);
 		}
+
+		m_color_transform_matrix.set(lighting.vision_effects.color_transform_matrix.data(), services);
 
 		float saturation = lighting.saturation;
 		m_saturation_pixel.set(&saturation, services);

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -40,6 +40,18 @@ struct AutoExposure
 	{}
 };
 
+struct VisionEffects
+{
+	std::array<float, 9> color_transform_matrix;
+
+	constexpr VisionEffects()
+		: color_transform_matrix{
+				1.0f, 0.0f, 0.0f,
+				0.0f, 1.0f, 0.0f,
+				0.0f, 0.0f, 1.0f}
+	{}
+};
+
 /** Describes ambient light settings for a player
  */
 struct Lighting
@@ -52,4 +64,5 @@ struct Lighting
 	float bloom_intensity {0.05f};
 	float bloom_strength_factor {1.0f};
 	float bloom_radius {1.0f};
+	VisionEffects vision_effects;
 };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1794,4 +1794,9 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 				>> lighting.bloom_strength_factor
 				>> lighting.bloom_radius;
 	}
+	if (pkt->getRemainingBytes() >= 36) {
+		for (int i = 0; i < 9; ++i) {
+			*pkt >> lighting.vision_effects.color_transform_matrix[i];
+		}
+	}
 }

--- a/src/network/networkprotocol.cpp
+++ b/src/network/networkprotocol.cpp
@@ -65,10 +65,13 @@
 	PROTOCOL VERSION 48
 		Add compression to some existing packets
 		[scheduled bump for 5.12.0]
+	PROTOCOL VERSION 49
+		Add "vision_effects" to TOCLIENT_SET_LIGHTING packet
+		[scheduled bump for 5.13.0]
 */
 
 // Note: Also update core.protocol_versions in builtin when bumping
-const u16 LATEST_PROTOCOL_VERSION = 48;
+const u16 LATEST_PROTOCOL_VERSION = 49;
 
 // See also formspec [Version History] in doc/lua_api.md
 const u16 FORMSPEC_API_VERSION = 9;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1952,6 +1952,10 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 	pkt << lighting.bloom_intensity << lighting.bloom_strength_factor <<
 			lighting.bloom_radius;
 
+	for (int i = 0; i < 9; ++i) {
+		pkt << lighting.vision_effects.color_transform_matrix[i];
+	}
+
 	Send(&pkt);
 }
 


### PR DESCRIPTION
Add a color transform matrix to shaders, which can be used to transform scene color.

- Goal of the PR
  Allows modders to apply custom color transformation matrices for visual effects such as color blindness simulation and night vision.
- How does the PR work?
 `player:set_lighting` method table now reads table `vision_effects`. See more in the doc.
- Does it resolve any reported issue?
  It should help with the possibility of implementing #6509.

## To do

This PR is Ready for Review.


## How to test

Get `server` privilege and use the command `player_editor lighting` to change `vision_effects`.

![screenshot_20250614_121423](https://github.com/user-attachments/assets/032c7008-5181-4ece-a73a-911d8c1905f9)
![screenshot_20250614_121405](https://github.com/user-attachments/assets/ae7b4a85-26da-4db4-903f-ff1cc8b2f939)