### PR TITLE
minetest.conf.example: Document short setting name as fallback

### DIFF
--- a/builtin/common/settings/generate_from_settingtypes.lua
+++ b/builtin/common/settings/generate_from_settingtypes.lua
@@ -44,15 +44,18 @@ local function create_minetest_conf_example(settings)
 				insert(result, rep("#", entry.level))
 				insert(result, "# " .. entry.name .. "\n\n")
 			end
-		else
+		else -- any `type` as listed in `settingtypes.txt`
 			local group_format = false
 			if entry.noise_params and entry.values then
 				if entry.type == "noise_params_2d" or entry.type == "noise_params_3d" then
 					group_format = true
 				end
 			end
-			if entry.comment ~= "" then
-				for _, comment_line in ipairs(entry.comment:split("\n", true)) do
+
+			local comment = entry.comment ~= "" and entry.comment
+				or entry.readable_name -- fallback to the short description
+			if comment ~= "" then
+				for _, comment_line in ipairs(comment:split("\n", true)) do
 					if comment_line == "" then
 						insert(result, "#\n")
 					else


### PR DESCRIPTION
Fixes https://github.com/luanti-org/luanti/pull/16220#issuecomment-3038628016

## To do

This PR is Ready for Review.

## How to test

1. Enable `minetest.conf.example` generation by editing builtin/common/settings/init.lua
2. For out-of-tree builds, fix up the paths in `generate_from_settingtypes.lua` to write to a user directory (client, games, mods, textures, worlds)
3. Start Luanti
4. Inspect the result

With this PR:
```
#    Open inventory
#    See https://docs.luanti.org/for-players/controls/
#    type: key
# keymap_inventory = SYSTEM_SCANCODE_12

....

#    Hotbar: select next item
#    See https://docs.luanti.org/for-players/controls/
#    type: key
# keymap_hotbar_next = SYSTEM_SCANCODE_17

#    Hotbar: select previous item
#    See https://docs.luanti.org/for-players/controls/
#    type: key
# keymap_hotbar_previous = SYSTEM_SCANCODE_5

```
Before this PR: https://github.com/luanti-org/luanti/commit/4f02d9c624545eb48feb3b27c62bc875e32ac91b