### PR TITLE
Hide world buttons when a world is not selected

### DIFF
--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -173,7 +173,7 @@ local function get_formspec(tabview, name, tabdata)
 	local game
 
 	local is_world_selected = list and list[core.get_textlist_index("sp_worlds") or index]
-	
+
 	if world then
 		game = pkgmgr.find_by_gameid(world.gameid)
 	else


### PR DESCRIPTION
this PR removes the "Delete", "Select Mods" and the "Play" buttons and the "Creative Mode", "Enable Damage" and "Host Server" checkboxes when a world is not selected

fixes #16405

note: if the empty space left by the buttons is too large i can remove it

This PR is Ready for Review.