### PR TITLE
Use consistent dtime_limit

### DIFF
--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -109,8 +109,8 @@ void ClientEnvironment::step(float dtime)
 		dtime_max_increment = 0.01;
 
 	// Don't allow overly huge dtime
-	if(dtime > 0.5)
-		dtime = 0.5;
+	if(dtime > DTIME_LIMIT)
+		dtime = DTIME_LIMIT;
 
 	/*
 		Stuff that has a maximum time increment


### PR DESCRIPTION
Trivial left-over from #13093 
That PR made sure we use the same dtime limit on client and server (in the server and client loop, as well as collision detection), however I forgot the limit check in `ClientEnvironment::step`, this just fixes that.

Without this the whole change in #13093 is somewhat pointless - making sure that client and server use the same dtime limits.

## To do

This PR Ready for Review.

## How to test

Look at the change... :)
I don't think that can be easily reproduced in actuality, it would require a client-dtime of more than 0.5s.