### PR TITLE
Require 'give' priv for /pulverize and /clearinv

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -902,6 +902,7 @@ core.register_chatcommand("spawnentity", {
 core.register_chatcommand("pulverize", {
 	params = "",
 	description = S("Destroy item in hand"),
+	privs = {give=true},
 	func = function(name, param)
 		local player = core.get_player_by_name(name)
 		if not player then
@@ -1302,6 +1303,7 @@ core.register_chatcommand("last-login", {
 core.register_chatcommand("clearinv", {
 	params = S("[<name>]"),
 	description = S("Clear the inventory of yourself or another player"),
+	privs = {give=true},
 	func = function(name, param)
 		local player
 		if param and param ~= "" and param ~= name then

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -71,7 +71,7 @@ core.register_privilege("kick", {
 	give_to_admin = true,
 })
 core.register_privilege("give", {
-	description = S("Can use /give and /giveme"),
+	description = S("Can use /give, /giveme, /pulverize and /clearinv"),
 	give_to_singleplayer = false,
 })
 core.register_privilege("password", {


### PR DESCRIPTION
This PR changes the `/pulverize` cmd so that only players with the `give` privilege can use it. (EDIT: Now also for `/clearinv`)

## Why?

The `/pulverize` command currently allows ALL players to delete an item for free.

This feature does not make sense in some games. Some games do not want players to be able to delete their own items, as it could lead the game into an invalid/broken state. This is true for puzzle games like Inside the Box and Lazarr!, and a few other games.

These games currently unregister this command.

I think the fact that players can delete their own items for free without any privs is surprising for game devs, so the default behavior should be that this is not the case.

## Why `give`?

It is the priv that creates items into your inventory, so `give` seems appropriate for also deleting item. I think of `give` as the "super creative inventory". I did not pick `server` because that's way too overkill.
