### PR TITLE
Add Warm lighting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -665,6 +665,8 @@ smooth_lighting (Smooth lighting) bool true
 #    at the expense of minor visual glitches that do not impact game playability.
 performance_tradeoffs (Tradeoffs for performance) bool false
 
+#    Enable Warm Lighting on artificial light
+enable_warm_lighting (Warm Lighting) bool false
 
 [**Waving Nodes]
 

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -45,8 +45,6 @@ centroid varying float nightRatio;
 #endif
 
 varying highp vec3 eyeVec;
-// Color of the light emitted by the light sources.
-const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
 const float e = 2.718281828459;
 const float BS = 10.0;
 uniform float xyPerspectiveBias0;
@@ -141,8 +139,17 @@ float snoise(vec3 p)
 
 	return o4.y * d.y + o4.x * (1.0 - d.y);
 }
-
 #endif
+
+vec3 get_artificial_light(vec3 color)
+{
+#ifdef ENABLE_WARM_LIGHTING
+	return vec3(1.04, 0.64, 0.34) + color; // prevent artificial lighting making brighter areas appear darker
+#else
+	return vec3(1.04, 1.04, 1.04);
+#endif
+}
+
 
 
 
@@ -205,7 +212,7 @@ void main(void)
 	// The alpha gives the ratio of sunlight in the incoming light.
 	nightRatio = 1.0 - color.a;
 	color.rgb = color.rgb * (color.a * dayLight.rgb +
-		nightRatio * artificialLight.rgb) * 2.0;
+		nightRatio * get_artificial_light(color.rgb)) * 2.0;
 	color.a = 1.0;
 
 	// Emphase blue a bit in darker places

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -32,8 +32,6 @@ centroid varying vec2 varTexCoord;
 
 varying highp vec3 eyeVec;
 varying float nightRatio;
-// Color of the light emitted by the light sources.
-const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
 varying float vIDiff;
 const float e = 2.718281828459;
 const float BS = 10.0;
@@ -89,6 +87,18 @@ float directional_ambient(vec3 normal)
 	return dot(v, vec3(0.670820, 1.000000, 0.836660));
 }
 
+vec3 get_artificial_light(vec3 color)
+{
+#ifdef ENABLE_WARM_LIGHTING
+	vec3 warmLight = vec3(1.04, 0.64, 0.34);
+	return warmLight + color; // prevent artificial lighting making brighter areas appear darker
+#else
+	return vec3(1.04, 1.04, 1.04);
+#endif
+}
+
+
+
 void main(void)
 {
 	varTexCoord = (mTexture * vec4(inTexCoord0.xy, 1.0, 1.0)).st;
@@ -116,7 +126,7 @@ void main(void)
 	// The alpha gives the ratio of sunlight in the incoming light.
 	nightRatio = 1.0 - color.a;
 	color.rgb = color.rgb * (color.a * dayLight.rgb +
-		nightRatio * artificialLight.rgb) * 2.0;
+		nightRatio * get_artificial_light(color.rgb)) * 2.0;
 	color.a = 1.0;
 
 	// Emphase blue a bit in darker places

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -227,6 +227,9 @@ public:
 			constants["SOFTSHADOWRADIUS"] = shadow_soft_radius;
 		}
 
+		if (g_settings->getBool("enable_warm_lighting"))
+			constants["ENABLE_WARM_LIGHTING"] = 1;
+
 		if (g_settings->getBool("enable_bloom")) {
 			constants["ENABLE_BLOOM"] = 1;
 			if (g_settings->getBool("enable_bloom_debug"))

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -341,6 +341,7 @@ void set_default_settings()
 	settings->setDefault("enable_volumetric_lighting", "false");
 	settings->setDefault("enable_water_reflections", "false");
 	settings->setDefault("enable_translucent_foliage", "false");
+	settings->setDefault("enable_warm_lighting", "false");
 
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");


### PR DESCRIPTION
Goal of this PR is to enhance Luanti's shaders with Warm artificial lighting

This PR adds warm lighting to Luanti as a simple but great way to enhance Luanti's visuals

When enabled will make light sources emit warmer lighting giving a more realistic/cozy (this effect is not very noticeable if the area you put the light has a lot of sunlight)

Before/After images:
![showcase](https://github.com/user-attachments/assets/5a75e564-4b68-41e0-bae5-e2221e432d70)

![showcase2](https://github.com/user-attachments/assets/936a24b6-34ee-4d8a-b18a-3e0220c4a5ae)



Ready for Review

## How to test

1. go to settings -> Effects -> Enable "Warm Lighting" 
(optional but recommended is to enable "Filmic Tone mapping" under "Post Processing")
2. place some light sources in the dark