### PR TITLE
Driver: Handle errors during texture creation

### DIFF
--- a/irr/src/COpenGLDriver.cpp
+++ b/irr/src/COpenGLDriver.cpp
@@ -2672,7 +2672,8 @@ bool COpenGLDriver::setRenderTargetEx(IRenderTarget *target, u16 clearFlag, SCol
 		// Update mip-map of the generated texture, if enabled.
 		auto textures = CurrentRenderTarget->getTexture();
 		for (size_t i = 0; i < textures.size(); ++i)
-			textures[i]->regenerateMipMapLevels();
+			if (textures[i])
+				textures[i]->regenerateMipMapLevels();
 	}
 
 	bool supportForFBO = (Feature.ColorAttachment > 0);

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -1704,8 +1704,10 @@ bool COpenGL3DriverBase::setRenderTargetEx(IRenderTarget *target, u16 clearFlag,
 	if (CurrentRenderTarget) {
 		// Update mip-map of the generated texture, if enabled.
 		auto textures = CurrentRenderTarget->getTexture();
-		for (size_t i = 0; i < textures.size(); ++i)
-			textures[i]->regenerateMipMapLevels();
+		for (size_t i = 0; i < textures.size(); ++i) {
+			if (textures[i])
+				textures[i]->regenerateMipMapLevels();
+		}
 	}
 
 	core::dimension2d<u32> destRenderTargetSize(0, 0);

--- a/src/client/render/pipeline.cpp
+++ b/src/client/render/pipeline.cpp
@@ -5,6 +5,7 @@
 #include "pipeline.h"
 #include "client/client.h"
 #include "client/hud.h"
+#include "gettext.h"
 #include "IRenderTarget.h"
 #include "SColor.h"
 
@@ -85,7 +86,12 @@ void TextureBuffer::reset(PipelineContext &context)
 	for (u32 i = 0; i < m_definitions.size(); i++) {
 		video::ITexture **ptr = &m_textures[i];
 
-		ensureTexture(ptr, m_definitions[i], context);
+		if (!ensureTexture(ptr, m_definitions[i], context)) {
+			throw ShaderException(
+				fmtgettext("Failed to create the texture \"%s\" for the rendering pipeline.",
+					m_definitions[i].name.c_str()) +
+				strgettext("\nCheck debug.txt for details."));
+		}
 		m_definitions[i].dirty = false;
 	}
 


### PR DESCRIPTION
The driver(s) do accept 'nullptr' textures, however the recent Mip-Mapping change did not respect that.
Furthermore, errors during texture creation for the pipeline are now properly handled and shown as an error to the user.

This may happen in cases where the resulting texture is too large. (see testing instructions)
Example log output:
```
Failed to create texture "3d_render": exceeds limit 17600x11200
Failed to create texture "3d_depthmap": exceeds limit 17600x11200
Failed to create texture "fxaa": exceeds limit 17600x11200
```

## To do

This PR is Ready for Review.

## How to test

1. Apply #16555
2. `minetest.conf` settings:
```
video_driver = opengl3

enable_post_processing = true
antialiasing = ssaa
fxaa = true
# Either increase this or the window size.
fsaa = 32
```
3. Join a world without this PR --> SIGSEGV
4. Join a world with this PR --> More friendly error message
5. Undo the changes in `pipeline.cpp` to ensure that the crash is fixed too. (the world will appear black)
