### PR TITLE
Add movement smoothing to CAOs when client and server disagree on positions

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1116,7 +1116,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 			m_velocity = p_velocity;
 
 			bool is_end_position = moveresult.collides;
-			pos_translator.update(m_position, is_end_position, dtime);
+			pos_translator.update(m_position, is_end_position, moveresult.collides ? dtime : dtime * 5.0f);
 		} else {
 			m_position += dtime * m_velocity + 0.5 * dtime * dtime * m_acceleration;
 			m_velocity += dtime * m_acceleration;
@@ -1546,7 +1546,7 @@ void GenericCAO::processMessage(const std::string &data)
 		m_rotation = wrapDegrees_0_360_v3f(m_rotation);
 		bool do_interpolate = readU8(is);
 		bool is_end_position = readU8(is);
-		float update_interval = readF32(is);
+		float update_interval = readF32(is) * 2.0f;
 
 		if(getParent() != NULL) // Just in case
 			return;


### PR DESCRIPTION
Another one of my perhaps controversial proposals.

This adds smoothing of two _server_ steps of rotation and position to _non-physical_ CAOs.
For _physical_ CAO, this smooths positions over 5 _client_ step, unless there was a collision, in which the change is applied in one step as before.

**Explanation:**
Specifically this only has an effect when client and server disagree on the position of an object (which happens due to slight rounding and different client and server step length). The server is the source of truth and this issue is about how we update the position on the client. Currently we jerk the position to what the server sends. This PR spreads this _correction_ out over a few frames (it's additive so no information is lost).
When the server detects a collision it'll force the update in the next frame on the client - as that's when it matters.

I have had this one for a bit now, and it really smooths things, without compromising immediacy in the case of a collision. The transition from client smoothing to no smoothing is not/barely visible with the numbers I picked.

This work well with #16501

## To do

This PR is a Work in Progress.

It needs testing. Please try it out!

## How to test

Attach to some moving entities (steampunk blimp, hot air balloon, whatever), notice how the world around you "stutters" far less as the entities moves with you attached.
Throw some object (f.e. drop them from your inventory with 'Q' and observer their trajectory).
Observe rotations, etc.

There should be no (or not noticeable) changes to movement and rotation, but position and rotation updates should be smoothed.
