### PR TITLE
Documentation: Clarify set_yaw() behaviour

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8651,7 +8651,9 @@ child will follow movement and rotation of that bone.
     * Does not reset rotation incurred through `automatic_rotate`.
       Remove & re-add your objects to force a certain rotation.
 * `get_rotation()`: returns the rotation, a vector (radians)
-* `set_yaw(yaw)`: sets the yaw in radians (heading).
+* `set_yaw(yaw)`
+    * Sets the yaw in radians (heading).
+    * Also resets pitch and roll to 0.
 * `get_yaw()`: returns number in radians
 * `set_texture_mod(mod)`
     * Set a texture modifier to the base texture, for sprites and meshes.


### PR DESCRIPTION
`set_yaw` not only sets the yaw, but also resets pitch and roll to 0, as can be seen in the code: https://github.com/luanti-org/luanti/blob/d834c45d1c1d7e43513481fea0249821963e1dfc/src/script/lua_api/l_object.cpp#L1194

Right now, this behaviour is not obvious from the documentation.

This topic was previously discussed in #10662, where it was [suggested to adjust the documentation](https://github.com/luanti-org/luanti/pull/10662#issuecomment-732384958).