### PR TITLE
Fix #16601: Check if object is gone before calling `on_rightclick`

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1199,8 +1199,10 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 			}
 
 			// on_secondary_use might have removed the object
-			if (!pointed_object->isGone())
-				pointed_object->rightClick(playersao);
+			if (pointed_object->isGone())
+				return;
+
+			pointed_object->rightClick(playersao);
 		} else if (m_script->item_OnPlace(selected_item, playersao, pointed)) {
 			// Placement was handled in lua
 


### PR DESCRIPTION
Does what it says, see the issue for further discussion.

The only concern is that this changes behavior, which some mods may not like.
But the bug seems like the bigger problem.
