### PR TITLE
Don't use bilinear/trilinear filter on small overlay if large base texture

### DIFF
--- a/games/devtest/mods/testitems/init.lua
+++ b/games/devtest/mods/testitems/init.lua
@@ -53,6 +53,13 @@ core.register_craftitem("testitems:overlay_global", {
 	color = GLOBAL_COLOR_ARG,
 })
 
+core.register_craftitem("testitems:overlay_size", {
+	description = S("Texture Overlay Test Item, Big Base Small Overlay") .. "\n" ..
+		S("Wield overlay should not be blurry."),
+	inventory_image = "[fill:1000x1000:#FFFFFF",
+	inventory_overlay = "testitems_overlay_overlay.png",
+})
+
 core.register_craftitem("testitems:image_meta", {
 	description = S("Image Override Meta Test Item"),
 	inventory_image = "default_apple.png",

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -350,8 +350,12 @@ void WieldMeshSceneNode::setExtruded(video::ITexture *texture,
 		material.MaterialTypeParam = 0.5f;
 		material.BackfaceCulling = true;
 		// don't filter low-res textures, makes them look blurry
-		bool f_ok = std::min(dim.Width, dim.Height) >= TEXTURE_FILTER_MIN_SIZE;
 		material.forEachTexture([=] (auto &tex) {
+			video::ITexture *t = tex.Texture;
+			if (!t)
+				return;
+			core::dimension2d<u32> d = t->getSize();
+			bool f_ok = std::min(d.Width, d.Height) >= TEXTURE_FILTER_MIN_SIZE;
 			setMaterialFilters(tex, m_bilinear_filter && f_ok,
 				m_trilinear_filter && f_ok, m_anisotropic_filter);
 		});


### PR DESCRIPTION
I noticed this while testing my animated item image PR.
If the base texture is big, e.g. because it's animated, and the overlay is not, the bilinear/trilinear filter will still be applied to the overlay.
This PR aims to fix this.

Before:
<img width="1065" height="529" alt="before" src="https://github.com/user-attachments/assets/fbb27844-349e-4a19-9e53-b39020640b63" />


With this PR:
<img width="999" height="573" alt="PR" src="https://github.com/user-attachments/assets/27ed6fbd-20c8-49f1-beef-7b908c02c034" />


## To do

Ready for Review.

## How to test
- Start devtest
- Look at `testitems:overlay_size` in your wield hand.
