### PR TITLE
Add meta item image override functions

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8400,6 +8400,13 @@ Can be obtained via `item:get_meta()`.
     * Overrides the item's wear bar parameters (see "Wear Bar Color" section)
     * A nil value will clear the override data and restore the original
       behavior.
+* `set_inventory_image(<Item image definition>)`
+* `set_inventory_overlay(<Item image definition>)`
+* `set_wield_image(<Item image definition>)`
+* `set_wield_overlay(<Item image definition>)`
+    * Overrides the item image definitions
+    * Takes precedence over the overwritten image names from [Item Metadata](#item-metadata)
+    * A nil value will clear the override data and restore the original behavior.
 
 `MetaDataRef`
 -------------

--- a/games/devtest/mods/testitems/init.lua
+++ b/games/devtest/mods/testitems/init.lua
@@ -268,7 +268,7 @@ local function update_animation(meta, mode, speed, name)
 		meta:set_wield_overlay(animated_overlay_accelerated(speed_factor))
 		msg = S"Wield overlay animated"
 	end
-	core.chat_send_player(name, msg .. S", speed " .. speed)
+	core.chat_send_player(name, msg .. S", speed " .. speed+1)
 end
 
 local function toggle_red_string_meta_inventory_image(itemstack)

--- a/src/client/item_visuals_manager.cpp
+++ b/src/client/item_visuals_manager.cpp
@@ -49,13 +49,13 @@ ItemVisualsManager::ItemVisuals *ItemVisualsManager::createItemVisuals( const It
 	ItemImageDef inventory_overlay = item.getInventoryOverlay(idef);
 
 	std::ostringstream os(def.name);
-	if (!inventory_image.name.empty()) {
+	if (!inventory_image.empty()) {
 		os << "/";
-		inventory_image.serializeJson(os);
+		inventory_image.serialize(os, LATEST_PROTOCOL_VERSION);
 	}
-	if (!inventory_overlay.name.empty()) {
+	if (!inventory_overlay.empty()) {
 		os << ":";
-		inventory_overlay.serializeJson(os);
+		inventory_overlay.serialize(os, LATEST_PROTOCOL_VERSION);
 	}
 
 	std::string cache_key = os.str();

--- a/src/client/item_visuals_manager.cpp
+++ b/src/client/item_visuals_manager.cpp
@@ -48,13 +48,17 @@ ItemVisualsManager::ItemVisuals *ItemVisualsManager::createItemVisuals( const It
 	ItemImageDef inventory_image = item.getInventoryImage(idef);
 	ItemImageDef inventory_overlay = item.getInventoryOverlay(idef);
 
-	// Key only consists of item name + image name,
-	// because animation currently cannot be overridden by meta
-	std::string cache_key = def.name;
-	if (!inventory_image.name.empty())
-		cache_key.append("/").append(inventory_image.name);
-	if (!inventory_overlay.name.empty())
-		cache_key.append(":").append(inventory_overlay.name);
+	std::ostringstream os(def.name);
+	if (!inventory_image.name.empty()) {
+		os << "/";
+		inventory_image.serializeJson(os);
+	}
+	if (!inventory_overlay.name.empty()) {
+		os << ":";
+		inventory_overlay.serializeJson(os);
+	}
+
+	std::string cache_key = os.str();
 
 
 	// Skip if already in cache

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -450,7 +450,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 	const v3f wield_scale = item.getWieldScale(idef);
 
 	// If wield_image needs to be checked and is defined, it overrides everything else
-	if (!wield_image.name.empty() && check_wield_image) {
+	if (!wield_image.empty() && check_wield_image) {
 		video::ITexture *wield_texture;
 		video::ITexture *wield_overlay_texture = nullptr;
 
@@ -468,7 +468,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		}
 
 		// Overlay
-		if (!wield_overlay.name.empty()) {
+		if (!wield_overlay.empty()) {
 			int overlay_frame_length_ms;
 			m_wield_overlay_frames = createAnimationFrames(tsrc,
 					wield_overlay.name, wield_overlay.animation, overlay_frame_length_ms);

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -257,6 +257,10 @@ std::string ItemStack::getShortDescription(const IItemDefManager *itemdef) const
 
 ItemImageDef ItemStack::getInventoryImage(const IItemDefManager *itemdef) const
 {
+	const auto &override_image = metadata.getInventoryImageOverride();
+	if (override_image)
+		return override_image.value();
+
 	ItemImageDef image = getDefinition(itemdef).inventory_image;
 	std::string meta_image = metadata.getString("inventory_image");
 	if (!meta_image.empty())
@@ -267,6 +271,10 @@ ItemImageDef ItemStack::getInventoryImage(const IItemDefManager *itemdef) const
 
 ItemImageDef ItemStack::getInventoryOverlay(const IItemDefManager *itemdef) const
 {
+	const auto &override_image = metadata.getInventoryOverlayOverride();
+	if (override_image)
+		return override_image.value();
+
 	ItemImageDef image = getDefinition(itemdef).inventory_overlay;
 	std::string meta_image = metadata.getString("inventory_overlay");
 	if (!meta_image.empty())
@@ -277,6 +285,10 @@ ItemImageDef ItemStack::getInventoryOverlay(const IItemDefManager *itemdef) cons
 
 ItemImageDef ItemStack::getWieldImage(const IItemDefManager *itemdef) const
 {
+	const auto &override_image = metadata.getWieldImageOverride();
+	if (override_image)
+		return override_image.value();
+
 	ItemImageDef image = getDefinition(itemdef).wield_image;
 	std::string meta_image = metadata.getString("wield_image");
 	if (!meta_image.empty())
@@ -287,6 +299,10 @@ ItemImageDef ItemStack::getWieldImage(const IItemDefManager *itemdef) const
 
 ItemImageDef ItemStack::getWieldOverlay(const IItemDefManager *itemdef) const
 {
+	const auto &override_image = metadata.getWieldOverlayOverride();
+	if (override_image)
+		return override_image.value();
+
 	ItemImageDef image = getDefinition(itemdef).wield_overlay;
 	std::string meta_image = metadata.getString("wield_overlay");
 	if (!meta_image.empty())

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -43,6 +43,10 @@ struct ItemStack
 	ItemImageDef getWieldImage(const IItemDefManager *itemdef) const;
 	ItemImageDef getWieldOverlay(const IItemDefManager *itemdef) const;
 	v3f getWieldScale(const IItemDefManager *itemdef) const;
+	const TileAnimationParams getInventoryImageAnimation(const IItemDefManager *itemdef) const;
+	const TileAnimationParams getInventoryOverlayAnimation(const IItemDefManager *itemdef) const;
+	const TileAnimationParams getWieldImageAnimation(const IItemDefManager *itemdef) const;
+	const TileAnimationParams getWieldOverlayAnimation(const IItemDefManager *itemdef) const;
 
 	/*
 		Quantity methods

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -13,6 +13,8 @@
 #include "util/pointedthing.h"
 #include <map>
 #include <set>
+#include "convert_json.h"
+#include <json/json.h>
 
 TouchInteraction::TouchInteraction()
 {
@@ -93,6 +95,29 @@ void ItemImageDef::deSerialize(std::istream &is, u16 protocol_version)
 	if (protocol_version < 51)
 		return;
 	animation.deSerialize(is, protocol_version);
+}
+
+void ItemImageDef::serializeJson(std::ostream &os) const
+{
+	Json::Value root;
+	root["name"] = name;
+	root["animation"] = animation.serializeJson();
+
+	fastWriteJson(root, os);
+}
+
+std::optional<ItemImageDef> ItemImageDef::deserializeJson(std::istream &is)
+{
+	Json::Value root;
+	is >> root;
+	if (!root.isObject() || !root["name"].isString()) {
+		return std::nullopt;
+	}
+
+	ItemImageDef def;
+	def.name = root["name"].asString();
+	def.animation.deserializeJson(root["animation"]);
+	return def;
 }
 
 /*

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -75,6 +75,11 @@ struct ItemImageDef
 		name.clear();
 	}
 
+	bool empty() const
+	{
+		return name.empty();
+	}
+
 	void serialize(std::ostream &os, u16 protocol_version) const;
 	void deSerialize(std::istream &is, u16 protocol_version);
 

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -77,6 +77,9 @@ struct ItemImageDef
 
 	void serialize(std::ostream &os, u16 protocol_version) const;
 	void deSerialize(std::istream &is, u16 protocol_version);
+
+	void serializeJson(std::ostream &os) const;
+	static std::optional<ItemImageDef> deserializeJson(std::istream &is);
 };
 
 struct ItemDefinition

--- a/src/itemstackmetadata.h
+++ b/src/itemstackmetadata.h
@@ -6,6 +6,7 @@
 
 #include "metadata.h"
 #include "tool.h"
+#include "itemdef.h"
 
 #include <optional>
 
@@ -39,10 +40,50 @@ public:
 	void setWearBarParams(const WearBarParams &params);
 	void clearWearBarParams();
 
+	// Item image overrides
+
+	const std::optional<ItemImageDef> &getInventoryImageOverride() const
+	{
+		return inventory_image_override;
+	}
+	void setInventoryImage(const ItemImageDef &params);
+	void clearInventoryImage();
+
+	const std::optional<ItemImageDef> &getInventoryOverlayOverride() const
+	{
+		return inventory_overlay_override;
+	}
+	void setOverlayImage(const ItemImageDef &params);
+	void clearOverlayImage();
+
+	const std::optional<ItemImageDef> &getWieldImageOverride() const
+	{
+		return wield_image_override;
+	}
+	void setWieldImage(const ItemImageDef &params);
+	void clearWieldImage();
+
+	const std::optional<ItemImageDef> &getWieldOverlayOverride() const
+	{
+		return wield_overlay_override;
+	}
+	void setWieldOverlay(const ItemImageDef &params);
+	void clearWieldOverlay();
+
 private:
 	void updateToolCapabilities();
 	void updateWearBarParams();
+	void updateInventoryImage();
+	void updateOverlayImage();
+	void updateWieldImage();
+	void updateWieldOverlay();
+
+	void updateAll();
 
 	std::optional<ToolCapabilities> toolcaps_override;
 	std::optional<WearBarParams> wear_bar_override;
+	std::optional<ItemImageDef> inventory_image_override;
+	std::optional<ItemImageDef> inventory_overlay_override;
+	std::optional<ItemImageDef> wield_image_override;
+	std::optional<ItemImageDef> wield_overlay_override;
 };

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -58,6 +58,26 @@ int ItemStackMetaRef::l_set_wear_bar_params(lua_State *L)
 	return 0;
 }
 
+#define ITEM_IMAGE_FUNCTIONS(NAME, FUNCTION) \
+int ItemStackMetaRef::FUNCTION(lua_State *L) \
+{ \
+	ItemStackMetaRef *metaref = checkObject<ItemStackMetaRef>(L, 1); \
+	if (lua_isnoneornil(L, 2)) { \
+		metaref->clear##NAME(); \
+	} else if (lua_istable(L, 2)) { \
+		metaref->set##NAME(read_item_image_definition(L, 2)); \
+	} else { \
+		luaL_typerror(L, 2, "table, or nil"); \
+	} \
+	return 0; \
+}
+
+ITEM_IMAGE_FUNCTIONS(InventoryImage, l_set_inventory_image)
+ITEM_IMAGE_FUNCTIONS(OverlayImage, l_set_inventory_overlay)
+ITEM_IMAGE_FUNCTIONS(WieldImage, l_set_wield_image)
+ITEM_IMAGE_FUNCTIONS(WieldOverlay, l_set_wield_overlay)
+#undef ITEM_IMAGE_FUNCTIONS
+
 ItemStackMetaRef::ItemStackMetaRef(LuaItemStack *istack): istack(istack)
 {
 	istack->grab();
@@ -99,5 +119,9 @@ const luaL_Reg ItemStackMetaRef::methods[] = {
 	luamethod(MetaDataRef, equals),
 	luamethod(ItemStackMetaRef, set_tool_capabilities),
 	luamethod(ItemStackMetaRef, set_wear_bar_params),
+	luamethod(ItemStackMetaRef, set_inventory_image),
+	luamethod(ItemStackMetaRef, set_inventory_overlay),
+	luamethod(ItemStackMetaRef, set_wield_image),
+	luamethod(ItemStackMetaRef, set_wield_overlay),
 	{0,0}
 };

--- a/src/script/lua_api/l_itemstackmeta.h
+++ b/src/script/lua_api/l_itemstackmeta.h
@@ -43,9 +43,29 @@ private:
 		istack->getItem().metadata.clearWearBarParams();
 	}
 
+#define ITEM_IMAGE_FUNCTIONS(NAME) \
+	void set##NAME(const ItemImageDef &image) \
+	{ \
+		istack->getItem().metadata.set##NAME(image); \
+	} \
+	void clear##NAME() \
+	{ \
+		istack->getItem().metadata.clear##NAME(); \
+	}
+	ITEM_IMAGE_FUNCTIONS(InventoryImage)
+	ITEM_IMAGE_FUNCTIONS(OverlayImage)
+	ITEM_IMAGE_FUNCTIONS(WieldImage)
+	ITEM_IMAGE_FUNCTIONS(WieldOverlay)
+#undef ITEM_IMAGE_FUNCTIONS
+
+
 	// Exported functions
 	static int l_set_tool_capabilities(lua_State *L);
 	static int l_set_wear_bar_params(lua_State *L);
+	static int l_set_inventory_image(lua_State *L);
+	static int l_set_inventory_overlay(lua_State *L);
+	static int l_set_wield_image(lua_State *L);
+	static int l_set_wield_overlay(lua_State *L);
 public:
 	// takes a reference
 	ItemStackMetaRef(LuaItemStack *istack);

--- a/src/tileanimation.h
+++ b/src/tileanimation.h
@@ -7,6 +7,8 @@
 #include <iostream>
 #include "irrlichttypes_bloated.h"
 
+namespace Json { class Value; }
+
 enum TileAnimationType : u8
 {
 	TAT_NONE = 0,
@@ -37,6 +39,9 @@ struct TileAnimationParams
 
 	void serialize(std::ostream &os, u16 protocol_ver) const;
 	void deSerialize(std::istream &is, u16 protocol_ver);
+
+	Json::Value serializeJson() const;
+	void deserializeJson(const Json::Value root);
 
 	void determineParams(v2u32 texture_size, int *frame_count, int *frame_length_ms,
 			v2u32 *frame_size) const;


### PR DESCRIPTION
Makes the whole item image definition table (introduced in #16538) overrideable via meta.
Takes precedence over the already overrideable string image names.
Future-proof in case we want to add new fields to `Item Image Definition`, e.g. mesh

Should have sufficient use cases as described in the previous PRs,
e.g. enchanted items that have an animated inventory image.

Compatibility is not a problem, because for older clients the image will just not be overridden (no animation texture bugs).
 
## To do

Ready for Review

## How to test

- Start devtest
- Use `testitems:inventory_image_animation_meta`