### PR TITLE
Corrected info about ObjectRef:set_attach() bone's `""` default value

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8525,7 +8525,7 @@ child will follow movement and rotation of that bone.
     * Attaches object to `parent`
     * See 'Attachments' section for details
     * `parent`: `ObjectRef` to attach to
-    * `bone`: Bone to attach to. Default is `""` which attaches to the model's origin.
+    * `bone`: Bone to attach to. Default is `""` which attaches to the parent object's origin.
     * `position`: relative position, default `{x=0, y=0, z=0}`
     * `rotation`: relative rotation in degrees, default `{x=0, y=0, z=0}`
     * `forced_visible`: Boolean to control whether the attached entity


### PR DESCRIPTION
The text was first introduced in #10602, which would correspond to release 5.4.0. I manually added Sam back to devtest 5.4.0. Anyways, in both videos, the child object on the left is attached to Sam's `Body` bone (the root bone in that model). My interpretation is that `""` attaches to the model's origin and not the root bone. missing bone names refuses to attach at all, meaning attaching to `""` is unique.

[5.4.0 with cube.webm](https://github.com/user-attachments/assets/94af12ac-c633-4099-81c2-98e063d52e3f)

[5.14.0 with spider.webm](https://github.com/user-attachments/assets/76ee0620-5a25-4578-b976-9d22b339c021)
