### PR TITLE
Fix wrong normal shading (apply transform)

### DIFF
--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -104,9 +104,9 @@ void main(void)
 #else
 	// This is intentional comparison with zero without any margin.
 	// If normal is not equal to zero exactly, then we assume it's a valid, just not normalized vector
-	vIDiff = length(inVertexNormal) == 0.0
+	vIDiff = length(vNormal) == 0.0
 		? 1.0
-		: directional_ambient(normalize(inVertexNormal));
+		: directional_ambient(normalize(vNormal));
 #endif
 
 	vec4 color = inVertexColor;


### PR DESCRIPTION
Currently, model transforms do not apply to the normals used for calculating shading, even though they should. This results in wrong shading.

Without this PR (wtf is this), a few cubes with randomized rotations, normals highlighted:

<img width="1016" height="525" alt="Screenshot From 2025-10-26 15-25-31" src="https://github.com/user-attachments/assets/8bf4fe91-1e67-4634-86a1-9775ae79e8ca" />

With this PR:

<img width="1016" height="525" alt="Screenshot From 2025-10-26 15-25-05" src="https://github.com/user-attachments/assets/07203fee-a8d4-47d8-b989-afbe7a3a0653" />

## How to test

Sumi kindly provided the following test mod: 
[sumi_test.zip](https://github.com/user-attachments/files/23150511/sumi_test.zip)

Correct shading means the shading of the faces changes as the entity is rotated. (You can also use `automatic_rotate` to test.)

This already works correctly for bone transforms, because there the transformation is done on the C++ side.