### PR TITLE
defaultsettings.cpp: drop the USEKEY2 macro

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -129,66 +129,65 @@ void set_default_settings()
 	settings->setDefault("chat_weblink_color", "#8888FF");
 
 	// Keymap
-#define USEKEY2(name, value, _) settings->setDefault(name, value)
-	USEKEY2("keymap_forward", "SYSTEM_SCANCODE_26", "KEY_KEY_W");
+	settings->setDefault("keymap_forward", "SYSTEM_SCANCODE_26"); // KEY_KEY_W
 	settings->setDefault("keymap_autoforward", "");
-	USEKEY2("keymap_backward", "SYSTEM_SCANCODE_22", "KEY_KEY_S");
-	USEKEY2("keymap_left", "SYSTEM_SCANCODE_4", "KEY_KEY_A");
-	USEKEY2("keymap_right", "SYSTEM_SCANCODE_7", "KEY_KEY_D");
-	USEKEY2("keymap_jump", "SYSTEM_SCANCODE_44", "KEY_SPACE");
-	USEKEY2("keymap_sneak", "SYSTEM_SCANCODE_225", "KEY_LSHIFT");
+	settings->setDefault("keymap_backward", "SYSTEM_SCANCODE_22"); // KEY_KEY_S
+	settings->setDefault("keymap_left", "SYSTEM_SCANCODE_4"); // KEY_KEY_A
+	settings->setDefault("keymap_right", "SYSTEM_SCANCODE_7"); // KEY_KEY_D
+	settings->setDefault("keymap_jump", "SYSTEM_SCANCODE_44"); // KEY_SPACE
+	settings->setDefault("keymap_sneak", "SYSTEM_SCANCODE_225"); // KEY_LSHIFT
 	settings->setDefault("keymap_dig", "KEY_LBUTTON");
 	settings->setDefault("keymap_place", "KEY_RBUTTON");
-	USEKEY2("keymap_drop", "SYSTEM_SCANCODE_20", "KEY_KEY_Q");
-	USEKEY2("keymap_zoom", "SYSTEM_SCANCODE_29", "KEY_KEY_Z");
-	USEKEY2("keymap_inventory", "SYSTEM_SCANCODE_12", "KEY_KEY_I");
-	USEKEY2("keymap_aux1", "SYSTEM_SCANCODE_8", "KEY_KEY_E");
-	USEKEY2("keymap_chat", "SYSTEM_SCANCODE_23", "KEY_KEY_T");
-	USEKEY2("keymap_cmd", "SYSTEM_SCANCODE_56", "/");
-	USEKEY2("keymap_cmd_local", "SYSTEM_SCANCODE_55", ".");
-	USEKEY2("keymap_minimap", "SYSTEM_SCANCODE_25", "KEY_KEY_V");
-	USEKEY2("keymap_console", "SYSTEM_SCANCODE_67", "KEY_F10");
+	settings->setDefault("keymap_drop", "SYSTEM_SCANCODE_20"); // KEY_KEY_Q
+	settings->setDefault("keymap_zoom", "SYSTEM_SCANCODE_29"); // KEY_KEY_Z
+	settings->setDefault("keymap_inventory", "SYSTEM_SCANCODE_12"); // KEY_KEY_I
+	settings->setDefault("keymap_aux1", "SYSTEM_SCANCODE_8"); // KEY_KEY_E
+	settings->setDefault("keymap_chat", "SYSTEM_SCANCODE_23"); // KEY_KEY_T
+	settings->setDefault("keymap_cmd", "SYSTEM_SCANCODE_56"); // /
+	settings->setDefault("keymap_cmd_local", "SYSTEM_SCANCODE_55"); // .
+	settings->setDefault("keymap_minimap", "SYSTEM_SCANCODE_25"); // KEY_KEY_V
+	settings->setDefault("keymap_console", "SYSTEM_SCANCODE_67"); // KEY_F10
 
 	// see <https://github.com/luanti-org/luanti/issues/12792>
-	USEKEY2("keymap_rangeselect", has_touch ? "SYSTEM_SCANCODE_21" : "", has_touch ? "KEY_KEY_R" : "");
+	settings->setDefault("keymap_rangeselect", has_touch ? "SYSTEM_SCANCODE_21" : ""); // KEY_KEY_R
 
-	USEKEY2("keymap_freemove", "SYSTEM_SCANCODE_14", "KEY_KEY_K");
+	settings->setDefault("keymap_freemove", "SYSTEM_SCANCODE_14"); // KEY_KEY_K
 	settings->setDefault("keymap_pitchmove", "");
-	USEKEY2("keymap_fastmove", "SYSTEM_SCANCODE_13", "KEY_KEY_J");
-	USEKEY2("keymap_noclip", "SYSTEM_SCANCODE_11", "KEY_KEY_H");
-	USEKEY2("keymap_hotbar_next", "SYSTEM_SCANCODE_17", "KEY_KEY_N");
-	USEKEY2("keymap_hotbar_previous", "SYSTEM_SCANCODE_5", "KEY_KEY_B");
-	USEKEY2("keymap_mute", "SYSTEM_SCANCODE_16", "KEY_KEY_M");
+	settings->setDefault("keymap_fastmove", "SYSTEM_SCANCODE_13"); // KEY_KEY_J
+	settings->setDefault("keymap_noclip", "SYSTEM_SCANCODE_11"); // KEY_KEY_H
+	settings->setDefault("keymap_hotbar_next", "SYSTEM_SCANCODE_17"); // KEY_KEY_N
+	settings->setDefault("keymap_hotbar_previous", "SYSTEM_SCANCODE_5"); // KEY_KEY_B
+	settings->setDefault("keymap_mute", "SYSTEM_SCANCODE_16"); // KEY_KEY_M
 	settings->setDefault("keymap_increase_volume", "");
 	settings->setDefault("keymap_decrease_volume", "");
 	settings->setDefault("keymap_cinematic", "");
 	settings->setDefault("keymap_toggle_block_bounds", "");
-	USEKEY2("keymap_toggle_hud", "SYSTEM_SCANCODE_58", "KEY_F1");
-	USEKEY2("keymap_toggle_chat", "SYSTEM_SCANCODE_59", "KEY_F2");
-	USEKEY2("keymap_toggle_fog", "SYSTEM_SCANCODE_60", "KEY_F3");
+	settings->setDefault("keymap_toggle_hud", "SYSTEM_SCANCODE_58"); // KEY_F1
+	settings->setDefault("keymap_toggle_chat", "SYSTEM_SCANCODE_59"); // KEY_F2
+	settings->setDefault("keymap_toggle_fog", "SYSTEM_SCANCODE_60"); // KEY_F3
 #ifndef NDEBUG
-	USEKEY2("keymap_toggle_update_camera", "SYSTEM_SCANCODE_61", "KEY_F4");
+	settings->setDefault("keymap_toggle_update_camera", "SYSTEM_SCANCODE_61"); // KEY_F4
 #else
 	settings->setDefault("keymap_toggle_update_camera", "");
 #endif
-	USEKEY2("keymap_toggle_debug", "SYSTEM_SCANCODE_62", "KEY_F5");
-	USEKEY2("keymap_toggle_profiler", "SYSTEM_SCANCODE_63", "KEY_F6");
-	USEKEY2("keymap_camera_mode", "SYSTEM_SCANCODE_6", "KEY_KEY_C");
-	USEKEY2("keymap_screenshot", "SYSTEM_SCANCODE_69", "KEY_F12");
-	USEKEY2("keymap_fullscreen", "SYSTEM_SCANCODE_68", "KEY_F11");
-	USEKEY2("keymap_increase_viewing_range_min", "SYSTEM_SCANCODE_46", "+");
-	USEKEY2("keymap_decrease_viewing_range_min", "SYSTEM_SCANCODE_45", "-");
+	settings->setDefault("keymap_toggle_debug", "SYSTEM_SCANCODE_62"); // KEY_F5
+	settings->setDefault("keymap_toggle_profiler", "SYSTEM_SCANCODE_63"); // KEY_F6
+	settings->setDefault("keymap_camera_mode", "SYSTEM_SCANCODE_6"); // KEY_KEY_C
+	settings->setDefault("keymap_screenshot", "SYSTEM_SCANCODE_69"); // KEY_F12
+	settings->setDefault("keymap_fullscreen", "SYSTEM_SCANCODE_68"); // KEY_F11
+	settings->setDefault("keymap_increase_viewing_range_min", "SYSTEM_SCANCODE_46"); // +
+	settings->setDefault("keymap_decrease_viewing_range_min", "SYSTEM_SCANCODE_45"); // -
 	settings->setDefault("keymap_close_world", "");
-	USEKEY2("keymap_slot1", "SYSTEM_SCANCODE_30", "KEY_KEY_1");
-	USEKEY2("keymap_slot2", "SYSTEM_SCANCODE_31", "KEY_KEY_2");
-	USEKEY2("keymap_slot3", "SYSTEM_SCANCODE_32", "KEY_KEY_3");
-	USEKEY2("keymap_slot4", "SYSTEM_SCANCODE_33", "KEY_KEY_4");
-	USEKEY2("keymap_slot5", "SYSTEM_SCANCODE_34", "KEY_KEY_5");
-	USEKEY2("keymap_slot6", "SYSTEM_SCANCODE_35", "KEY_KEY_6");
-	USEKEY2("keymap_slot7", "SYSTEM_SCANCODE_36", "KEY_KEY_7");
-	USEKEY2("keymap_slot8", "SYSTEM_SCANCODE_37", "KEY_KEY_8");
-	USEKEY2("keymap_slot9", "SYSTEM_SCANCODE_38", "KEY_KEY_9");
-	USEKEY2("keymap_slot10", "SYSTEM_SCANCODE_39", "KEY_KEY_0");
+	settings->setDefault("keymap_slot1", "SYSTEM_SCANCODE_30"); // KEY_KEY_1
+	settings->setDefault("keymap_slot2", "SYSTEM_SCANCODE_31"); // KEY_KEY_2
+	settings->setDefault("keymap_slot3", "SYSTEM_SCANCODE_32"); // KEY_KEY_3
+	settings->setDefault("keymap_slot4", "SYSTEM_SCANCODE_33"); // KEY_KEY_4
+	settings->setDefault("keymap_slot5", "SYSTEM_SCANCODE_34"); // KEY_KEY_5
+	settings->setDefault("keymap_slot6", "SYSTEM_SCANCODE_35"); // KEY_KEY_6
+	settings->setDefault("keymap_slot7", "SYSTEM_SCANCODE_36"); // KEY_KEY_7
+	settings->setDefault("keymap_slot8", "SYSTEM_SCANCODE_37"); // KEY_KEY_8
+	settings->setDefault("keymap_slot9", "SYSTEM_SCANCODE_38"); // KEY_KEY_9
+	settings->setDefault("keymap_slot10", "SYSTEM_SCANCODE_39"); // KEY_KEY_0
 	settings->setDefault("keymap_slot11", "");
 	settings->setDefault("keymap_slot12", "");
 	settings->setDefault("keymap_slot13", "");
@@ -214,17 +213,16 @@ void set_default_settings()
 
 #ifndef NDEBUG
 	// Default keybinds for quicktune in debug builds
-	USEKEY2("keymap_quicktune_prev", "SYSTEM_SCANCODE_74", "KEY_HOME");
-	USEKEY2("keymap_quicktune_next", "SYSTEM_SCANCODE_77", "KEY_END");
-	USEKEY2("keymap_quicktune_dec", "SYSTEM_SCANCODE_81", "KEY_NEXT");
-	USEKEY2("keymap_quicktune_inc", "SYSTEM_SCANCODE_82", "KEY_PRIOR");
+	settings->setDefault("keymap_quicktune_prev", "SYSTEM_SCANCODE_74"); // KEY_HOME
+	settings->setDefault("keymap_quicktune_next", "SYSTEM_SCANCODE_77"); // KEY_END
+	settings->setDefault("keymap_quicktune_dec", "SYSTEM_SCANCODE_81"); // KEY_NEXT
+	settings->setDefault("keymap_quicktune_inc", "SYSTEM_SCANCODE_82"); // KEY_PRIOR
 #else
 	settings->setDefault("keymap_quicktune_prev", "");
 	settings->setDefault("keymap_quicktune_next", "");
 	settings->setDefault("keymap_quicktune_dec", "");
 	settings->setDefault("keymap_quicktune_inc", "");
 #endif
-#undef USEKEY2
 
 	// Visuals
 #ifdef NDEBUG


### PR DESCRIPTION
Follow-up of #16580. Mostly `%s/USEKEY2(\("[^"]\+"\),\s*\("[^"]\+"\),\s*"\([^"]\+\)");/settings->setDefault(\1, \2); \/\/ \3/` in (n)vim with some minor manual adjustments.

---

With #16583 merged we could consider a followup that replaces numeric scancodes with named ones.