### PR TITLE
Automatically choose multiple emerge threads for singlenode

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2367,17 +2367,12 @@ emergequeue_limit_diskonly (Per-player limit of queued blocks load from disk) in
 #    This limit is enforced per player.
 emergequeue_limit_generate (Per-player limit of queued blocks to generate) int 128 1 1000000
 
-#    Number of emerge threads to use.
-#    Value 0:
-#    -    Automatic selection. The number of emerge threads will be
-#    -    'number of processors - 2', with a lower limit of 1.
-#    Any other value:
-#    -    Specifies the number of emerge threads, with a lower limit of 1.
-#    WARNING: Increasing the number of emerge threads increases engine mapgen
-#    speed, but this may harm game performance by interfering with other
-#    processes, especially in singleplayer and/or when running Lua code in
-#    'on_generated'. For many users the optimum setting may be '1'.
-num_emerge_threads (Number of emerge threads) int 1 0 32767
+#    Number of emerge threads (responsible for map generation and loading) to use.
+#    If 0 then the engine will automatically choose a suitable value depending
+#    on the hardware and type of map generator.
+#    WARNING: There are known bugs in the default map generators (v6, v7, ...)
+#    when using more than 1 thread. The automatic choice will avoid this.
+num_emerge_threads (Number of emerge threads) int 0 0 32767
 
 [**cURL] [common]
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -490,7 +490,7 @@ void set_default_settings()
 	settings->setDefault("emergequeue_limit_total", "1024");
 	settings->setDefault("emergequeue_limit_diskonly", "128");
 	settings->setDefault("emergequeue_limit_generate", "128");
-	settings->setDefault("num_emerge_threads", "1");
+	settings->setDefault("num_emerge_threads", "0");
 	settings->setDefault("secure.enable_security", "true");
 	settings->setDefault("secure.trusted_mods", "");
 	settings->setDefault("secure.http_mods", "");

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -165,7 +165,6 @@ public:
 
 	void startThreads();
 	void stopThreads();
-	bool isRunning();
 
 	bool enqueueBlockEmerge(
 		session_t peer_id,
@@ -193,10 +192,14 @@ public:
 	static v3s16 getContainingChunk(v3s16 blockpos, v3s16 chunksize);
 
 private:
+	void initThreads(bool should_multithread);
+
 	std::vector<Mapgen *> m_mapgens;
 	std::vector<EmergeThread *> m_threads;
 	bool m_threads_active = false;
 
+	// Server reference
+	Server *m_server = nullptr;
 	// The map database
 	MapDatabaseAccessor *m_db = nullptr;
 

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -144,7 +144,9 @@ const char *Mapgen::getMapgenName(MapgenType mgtype)
 	if (index == MAPGEN_INVALID || index >= ARRLEN(g_reg_mapgens))
 		return "invalid";
 
-	return g_reg_mapgens[index].name;
+	auto &it = g_reg_mapgens[index];
+	assert(it.name);
+	return it.name;
 }
 
 

--- a/src/porting.h
+++ b/src/porting.h
@@ -127,6 +127,12 @@ void initializePaths();
 const std::string &get_sysinfo();
 
 
+/*
+	Return size of system RAM in MB
+	(or 0 if unavailable/error)
+*/
+u32 getMemorySizeMB();
+
 // Monotonic timer
 
 #ifdef _WIN32 // Windows

--- a/src/unittest/test_utilities.cpp
+++ b/src/unittest/test_utilities.cpp
@@ -50,6 +50,7 @@ public:
 	void testSanitizeUntrusted();
 	void testReadSeed();
 	void testMyDoubleStringConversions();
+	void testGetMemorySize();
 };
 
 static TestUtilities g_test_instance;
@@ -87,6 +88,7 @@ void TestUtilities::runTests(IGameDef *gamedef)
 	TEST(testSanitizeUntrusted);
 	TEST(testReadSeed);
 	TEST(testMyDoubleStringConversions);
+	TEST(testGetMemorySize);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -804,4 +806,24 @@ void TestUtilities::testMyDoubleStringConversions()
 	test_round_trip(-std::numeric_limits<double>::infinity());
 	test_round_trip(0.3);
 	test_round_trip(0.1 + 0.2);
+}
+
+void TestUtilities::testGetMemorySize()
+{
+#if defined(_WIN32) || defined(__linux__) || defined(__APPLE__)
+	const bool fail_ok = false;
+#else
+	const bool fail_ok = true;
+#endif
+
+	u32 total = porting::getMemorySizeMB();
+	UASSERT(total != 0 || fail_ok);
+	if (total != 0) {
+		infostream << "memory size in MB = " << total << std::endl;
+		// should be a sane value
+		UASSERTCMP(u32, >=, total, 130);
+		UASSERTCMP(u32, <, total, 8 * 1024 * 1024);
+	} else {
+		warningstream << "testGetMemorySize: retrieving failed" << std::endl;
+	}
 }


### PR DESCRIPTION
implements https://github.com/luanti-org/luanti/issues/16633#issuecomment-3471996302

The new default for `num_emerge_threads` becomes an automatic choice, but users can still override this with something else.

## To do

This PR is Ready for Review.

