### PR TITLE
doc: Add antivirus interference warning to Windows compilation guide

### DIFF
--- a/doc/compiling/windows.md
+++ b/doc/compiling/windows.md
@@ -17,6 +17,8 @@ After you successfully built vcpkg you can easily install the required libraries
 vcpkg install zlib zstd curl[ssl] openal-soft libvorbis libogg libjpeg-turbo sqlite3 freetype luajit gmp jsoncpp gettext[tools] sdl2 --triplet x64-windows
 ```
 
+⚠️ **IMPORTANT**: Add your vcpkg root directory to your antivirus exclusion list **before** running the install command. Otherwise, temporary files may be falsely detected as threats and deleted, causing silent installation failures.
+
 - `curl` is optional, but required to read the serverlist, `curl[ssl]` is required to use the content store.
 - `openal-soft`, `libvorbis` and `libogg` are optional, but required to use sound.
 - `luajit` is optional, it replaces the integrated Lua interpreter with a faster just-in-time interpreter.


### PR DESCRIPTION
## Add compact, short information about your PR for easier understanding:

- **Goal of the PR**: Warn Windows users about antivirus interference during vcpkg dependency installation to prevent silent failures.
- **How does the PR work?**: Adds a clear ⚠️ warning box in `doc/compiling/windows.md` advising users to add the vcpkg directory to their antivirus exclusion list before running `vcpkg install`.
- **Does it resolve any reported issue?**: Yes, resolves #16658 - Users experience silent vcpkg installation failures when antivirus software deletes temporary build files.
- **Does this relate to a goal in the roadmap?**: No - this is a documentation quality-of-life improvement, not a feature or gameplay change.
- **If not a bug fix, why is this PR needed? What usecases does it solve?**: This prevents frustrating silent failures where antivirus software (e.g., Huorong Security, Windows Defender) deletes temporary build files like `conftest.exe` during gettext compilation. New users cannot diagnose this easily as PowerShell terminates without visible errors. The warning saves hours of debugging and improves first-time contributor experience.

---

## To do

This PR is **Ready for Review**.

- [x] Drafted the warning text to be concise and actionable
- [x] Identified the correct location in `windows.md` (under "Compiling and installing the dependencies")
- [x] Verified the Markdown syntax renders correctly
- [x] Linked to the reported issue #16658
- [ ] Wait for maintainer review and approval

---

## How to test

1. Open the modified `doc/compiling/windows.md` file in a Markdown previewer
2. Verify the warning box displays correctly with proper formatting
3. Confirm the warning is placed prominently before the `vcpkg install` command section
4. Check that users following the guide will see the warning before encountering the failure

