### PR TITLE
Fix singleplayer lockout when changing password

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1661,7 +1661,7 @@ void Server::handleCommand_SrpBytesM(NetworkPacket* pkt)
 	srp_verifier_verify_session((SRPVerifier *) client->auth_data,
 		(unsigned char *)bytes_M.c_str(), &bytes_HAMK);
 
-	// only do this if not in singleplayer mode.
+	// skip authentication check for singleplayer world.
 	const bool is_true_singleplayer = isSingleplayer() && (strcasecmp(playername.c_str(), "singleplayer") == 0);
 	if (!bytes_HAMK && !is_true_singleplayer) {
 		if (wantSudo) {


### PR DESCRIPTION
- How does the PR work?
allows to join a server with the playername "singleplayer" and to set a passwd for servers. If in singleplayer mode (no server hosted / isSingleplayer() == true) the user singleplayer is allowed to join always. 
- Does it resolve any reported issue?
fixes https://github.com/luanti-org/luanti/issues/16599

This PR is Ready for Review.

## How to test
1. Create world like mentioned in the bug.
2.  Close the game.
3.  Rebuild with this fix.
4.  Join the world in singleplayer --> join success 
5.  Join the world with "host server" enabled without/incorrect/correct password --> join failed
