### PR TITLE
Remove EventReceiver

### DIFF
--- a/src/client/event_manager.h
+++ b/src/client/event_manager.h
@@ -10,11 +10,6 @@
 
 class EventManager : public MtEventManager
 {
-	static void receiverReceive(MtEvent *e, void *data)
-	{
-		MtEventReceiver *r = (MtEventReceiver *)data;
-		r->onEvent(e);
-	}
 	struct FuncSpec
 	{
 		event_receive_func f;

--- a/src/client/mtevent.h
+++ b/src/client/mtevent.h
@@ -36,13 +36,6 @@ public:
 	Type getType() const override { return type; }
 };
 
-class MtEventReceiver
-{
-public:
-	virtual ~MtEventReceiver() = default;
-	virtual void onEvent(MtEvent *e) = 0;
-};
-
 typedef void (*event_receive_func)(MtEvent *e, void *data);
 
 class MtEventManager


### PR DESCRIPTION
We don't use `EventReceiver`, instead we use `reg()` to register an event and `put()` to execute it.
Maybe `EventReceiver` was used in the past, but I don't think we need it.

## To do

Ready for Review.

## How to test

idk
