### PR TITLE
OpenGL3: Add subpixel offset for 2D image rendering

### DIFF
--- a/client/shaders/Irrlicht/Renderer2D.vsh
+++ b/client/shaders/Irrlicht/Renderer2D.vsh
@@ -18,7 +18,9 @@ varying vec4 vVertexColor;
 
 void main()
 {
-	// Subpixel offset to fix 2D image distortion
+	// Subpixel offset to render pixel-perfect 2D images
+	// This is a compromise that is expected to work well on most drivers.
+	// Explanation: https://jvm-gaming.org/t/pixel-perfect-rendering-in-2d/26261/4
 	gl_Position = uProjection * (inVertexPosition + vec4(0.375, 0.375, 0.0, 0.0));
 	gl_PointSize = uThickness;
 	vTextureCoord = inTexCoord0;


### PR DESCRIPTION
PR addresses 2D image rendering issues with the OpenGL 3 pipeline, specifically where we are calculating pixel coords precisly on pixel boundaries rather than to the center of pixels. The solution is to add an offset, identical to the one used in the shader code for the Fixed Function Pipeline. In this case, we move it to C++ Irrlicht code instead of infecting our Shader. 

Before on top, after on bottom. Refer to the issue below for details:

<img width="242" height="59" alt="image" src="https://github.com/user-attachments/assets/96fefa50-6075-459d-a14b-47dbf315954c" />

closes #15524

Longer explanation for this PR is provided in that issue as a comment at the bottom as for why this is the correct fix (or at least the same fix as the fixed function pipeline)

This PR is Ready for Review.

## How to test

1. Download soothing32, and minetest_game/devtest
2. open a new world with damage enabled, and the opengl3 pipeline enabled
3. Screen capture the hearts being rendered
      a. if you don't see a problem, restart 1-2 times, and you'll see it in one of them
4. Now rebuild with this change, retest, and issue should be gone. 