### PR TITLE
shell.nix: replace SDL2 with SDL3

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -14,7 +14,6 @@ pkgs.mkShell {
     pkgs.libpng
     pkgs.libGL
     pkgs.luajit
-    pkgs.SDL2
     pkgs.sdl3
     pkgs.openal
     pkgs.curl


### PR DESCRIPTION
https://github.com/luanti-org/luanti/pull/16583#pullrequestreview-3468096675

The diff should be self-explanatory.