### PR TITLE
Show warning in mainmenu when debug build

### DIFF
--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -47,7 +47,6 @@ local tabs = {
 	play_online = dofile(menupath .. DIR_DELIM .. "tab_online.lua")
 }
 
---------------------------------------------------------------------------------
 local function main_event_handler(tabview, event)
 	if event == "MenuQuit" then
 		local show_dialog = core.settings:get_bool("enable_esc_dialog")
@@ -64,8 +63,17 @@ local function main_event_handler(tabview, event)
 	return true
 end
 
---------------------------------------------------------------------------------
 local function init_globals()
+	-- Permanent warning if on an unoptimized debug build
+	if core.is_debug_build() then
+		local set_topleft_text = core.set_topleft_text
+		core.set_topleft_text = function(s)
+			s = (s or "") .. "\n"
+			s = s .. core.colorize("#f22", core.gettext("Debug build, expect worse performance"))
+			set_topleft_text(s)
+		end
+	end
+
 	-- Init gamedata
 	gamedata.worldindex = 0
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -29,6 +29,7 @@
 	#include "client/sound/sound_openal.h"
 #endif
 
+#include <algorithm>
 #include <csignal>
 
 
@@ -638,9 +639,13 @@ void GUIEngine::setTopleftText(const std::string &text)
 /******************************************************************************/
 void GUIEngine::updateTopLeftTextSize()
 {
-	core::rect<s32> rect(0, 0, g_fontengine->getTextWidth(m_toplefttext.c_str()),
-		g_fontengine->getTextHeight());
-	rect += v2s32(4, 0);
+	const auto &str = m_toplefttext.getString();
+	u32 lines = std::count(str.begin(), str.end(), L'\n') + 1;
+	core::rect<s32> rect(0, 0,
+		g_fontengine->getTextWidth(str.c_str()),
+		g_fontengine->getTextHeight() * lines
+	);
+	rect += v2s32(4, 4);
 
 	m_irr_toplefttext->remove();
 	m_irr_toplefttext = gui::StaticText::add(m_rendering_engine->get_gui_env(),

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -5,6 +5,7 @@
 #include "lua_api/l_mainmenu.h"
 #include "lua_api/l_internal.h"
 #include "common/c_content.h"
+#include "config.h"
 #include "scripting_mainmenu.h"
 #include "gui/guiEngine.h"
 #include "gui/guiMainMenu.h"
@@ -657,11 +658,10 @@ int ModApiMainMenu::l_delete_world(lua_State *L)
 int ModApiMainMenu::l_set_topleft_text(lua_State *L)
 {
 	GUIEngine* engine = getGuiEngine(L);
-	sanity_check(engine != NULL);
+	sanity_check(engine);
 
 	std::string text;
-
-	if (!lua_isnone(L,1) &&	!lua_isnil(L,1))
+	if (!lua_isnoneornil(L, 1))
 		text = luaL_checkstring(L, 1);
 
 	engine->setTopleftText(text);
@@ -964,12 +964,11 @@ int ModApiMainMenu::l_get_active_irrlicht_device(lua_State *L)
 		}
 	}();
 	if (auto version = device->getVersionString(); !version.empty())
-		device_name.append(" " + version);
+		device_name.append(" ").append(version);
 	lua_pushstring(L, device_name.c_str());
 	return 1;
 }
 
-/******************************************************************************/
 int ModApiMainMenu::l_get_min_supp_proto(lua_State *L)
 {
 	lua_pushinteger(L, CLIENT_PROTOCOL_VERSION_MIN);
@@ -982,14 +981,25 @@ int ModApiMainMenu::l_get_max_supp_proto(lua_State *L)
 	return 1;
 }
 
-/******************************************************************************/
 int ModApiMainMenu::l_get_formspec_version(lua_State  *L)
 {
 	lua_pushinteger(L, FORMSPEC_API_VERSION);
 	return 1;
 }
 
-/******************************************************************************/
+int ModApiMainMenu::l_is_debug_build(lua_State  *L)
+{
+	bool ret = false;
+	// We can't know for sure, but as far as our own build types go the following
+	// two use -O0. Check NDEBUG too to definitely exclude release builds.
+#ifndef NDEBUG
+	if (strcmp(BUILD_TYPE, "Debug") == 0 || strcmp(BUILD_TYPE, "None") == 0)
+		ret = true;
+#endif
+	lua_pushboolean(L, ret);
+	return 1;
+}
+
 int ModApiMainMenu::l_open_url(lua_State *L)
 {
 	std::string url = luaL_checkstring(L, 1);
@@ -1109,6 +1119,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(get_min_supp_proto);
 	API_FCT(get_max_supp_proto);
 	API_FCT(get_formspec_version);
+	API_FCT(is_debug_build);
 	API_FCT(open_url);
 	API_FCT(open_url_dialog);
 	API_FCT(open_dir);
@@ -1141,8 +1152,9 @@ void ModApiMainMenu::InitializeAsync(lua_State *L, int top)
 	API_FCT(extract_zip);
 	API_FCT(may_modify_path);
 	API_FCT(download_file);
+	API_FCT(get_language);
 	API_FCT(get_min_supp_proto);
 	API_FCT(get_max_supp_proto);
 	API_FCT(get_formspec_version);
-	API_FCT(get_language);
+	API_FCT(is_debug_build);
 }

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -133,6 +133,8 @@ private:
 
 	static int l_get_formspec_version(lua_State  *L);
 
+	static int l_is_debug_build(lua_State  *L);
+
 	// other
 	static int l_open_url(lua_State *L);
 


### PR DESCRIPTION
closes #16619

Note this warning only applies to "real" debug builds, that is ones which are actually entirely unoptimized (`-O0`).
You can use `-DCMAKE_BUILD_TYPE=SemiDebug` or `RelWithDebInfo` for a better experience *and* debuggability.

## To do

This PR is Ready for Review.

## How to test

1. use debug build
2. observe red text
