### PR TITLE
Fix minimap rendering regression

### DIFF
--- a/client/shaders/minimap_shader/opengl_fragment.glsl
+++ b/client/shaders/minimap_shader/opengl_fragment.glsl
@@ -1,4 +1,5 @@
 uniform sampler2D baseTexture;
+#define normalTexture texture1
 uniform sampler2D normalTexture;
 uniform vec3 yawVec;
 


### PR DESCRIPTION
The normal map was not bound properly, so the shading based on the height map had gone missing.

Based on the diff, I think this might've been introduced by 4756e23477e4c45a2dacb6387485101f60b2ac43 (didn't bother to compile before and after yet), so I figure the bug hasn't been released yet. Yay!

## How to test

Before:

<img width="275" height="271" alt="Screenshot From 2025-11-27 22-34-33" src="https://github.com/user-attachments/assets/ad17bbc9-f41d-4f73-a5d3-4651fbe76291" />

After:

<img width="275" height="271" alt="Screenshot From 2025-11-27 22-33-51" src="https://github.com/user-attachments/assets/b7cd9f29-57da-4db8-8bb1-a88100905d8b" />

