### PR TITLE
Fix the Minimap Radar Bug, keeping as much functionality as possible

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1876,13 +1876,11 @@ void Game::toggleMinimap(bool shift_pressed)
 	// -->
 	u32 hud_flags = client->getEnv().getLocalPlayer()->hud_flags;
 
-	if (hud_flags & HUD_FLAG_MINIMAP_VISIBLE) {
 	// If radar is disabled, try to find a non radar mode or fall back to 0
-		if (!(hud_flags & HUD_FLAG_MINIMAP_RADAR_VISIBLE))
-			while (mapper->getModeIndex() &&
-					mapper->getModeDef().type == MINIMAP_TYPE_RADAR)
-				mapper->nextMode();
-	}
+	if (!(hud_flags & HUD_FLAG_MINIMAP_RADAR_VISIBLE))
+		while (mapper->getModeIndex() &&
+				mapper->getModeDef().type == MINIMAP_TYPE_RADAR)
+			mapper->nextMode();
 	// <--
 	// End of 'not so satifying code'
 	if (hud && hud->hasElementOfType(HUD_ELEM_MINIMAP))


### PR DESCRIPTION
Fixes [#16508](https://github.com/luanti-org/luanti/issues/16508)

Ensures that the radar-map detection code runs every time the [minimap] key is pressed.  This causes the minimap modes to cycle within the allow range by HUD_FLAG_MINIMAP_RADAR_VISIBLE.  HUD_FLAG_MINIMAP_VISIBLE is no longer taken into account.

This PR is Ready for Review.

## Other options
It would break _some_ functionality if the minimap cycling was completely disabled when the minimap is hidden.  Current behavior:  Minimap cycling **allowed** while HUD_FLAG_MINIMAP_VISIBLE false.  However, it might make sense to block the cycling entirely while the minimap is hidden by pulling the mapper->nextMode() (client/game.cpp:1871) inside the if statment on line 1879.

## How to test
  - Open a Minetest Game Non-creative test world and acquire a map:mapping_kit
  - Press [minimap] (usually [V]) until showing the zoom X4 map
  - Drop the map:mapping_kit and wait for the minimap to disappear
  - Press [minimap]
  - Pick up the map:mapping_kit
  - The minimap is hidden (mapper->getModeIndex() == 0)

Alternatively:
  - Open a Minetest Game Non-creative test world and acquire a map:mapping_kit
  - Press [minimap] until showing the zoom X4 map
  - Drop the map:mapping_kit and wait for the minimap to disappear
  - Press [minimap] twice
  - Pick up the map:mapping_kit
  - Wait until the minimap appears
  - The minimap is at the zoom X1 level (mapper->getModeIndex() == 1)

## Bugged Behavior in current Luanti master:
  - Open a Minetest Game Non-creative test world and acquire a map:mapping_kit
  - Press [minimap] (usually [V]) until showing the zoom X4 map
  - Drop the map:mapping_kit and wait for the minimap to disappear
  - Press [minimap]
  - Pick up the map:mapping_kit
  - The minimap is on Radar zoom X1 mode  (mapper->getModeIndex() == 4)
