### PR TITLE
Add order check in unittest for `privs_to_string`

### DIFF
--- a/builtin/common/tests/misc_helpers_spec.lua
+++ b/builtin/common/tests/misc_helpers_spec.lua
@@ -57,7 +57,9 @@ describe("privs", function()
 		assert.equal("one", core.privs_to_string({ one=true }))
 
 		local ret = core.privs_to_string({ a=true, b=true })
-		assert(ret == "a,b" or ret == "b,a")
+		assert(ret == "a,b")
+		ret = core.privs_to_string({ e=true, c=true, d=true, a=true, b=true })
+		assert(ret == "a,b,c,d,e")
 	end)
 end)
 


### PR DESCRIPTION
Order guarantee was added in: https://github.com/luanti-org/luanti/pull/15023 (b2f6a65)
But it added no test. This PR fixes that.

The unittest used to wrongly depend on order, fixed by: https://github.com/luanti-org/luanti/pull/9184 (1173ff0)

(Found this via forum: <https://forum.luanti.org/viewtopic.php?t=32193>)

## To do

This PR is a Ready for Review.

## How to test

* `busted builtin`
