### PR TITLE
Move fog into `set_fog` and `get_fog` functions

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8956,17 +8956,17 @@ child will follow movement and rotation of that bone.
                 `"default"` uses the classic Luanti sun and moon tinting.
                 Will use tonemaps, if set to `"default"`. (default: `"default"`)
         * `fog`: A table with following optional fields:
-            * `fog_distance`: integer, set an upper bound for the client's viewing_range.
+            * `distance`: integer, set an upper bound for the client's viewing_range.
                Any value >= 0 sets the desired upper bound for viewing_range,
                disables range_all and prevents disabling fog (F3 key by default).
                Any value < 0 resets the behavior to being client-controlled.
                (default: -1)
-            * `fog_start`: float, override the client's fog_start.
+            * `start`: float, override the client's fog_start.
                Fraction of the visible distance at which fog starts to be rendered.
                Any value between [0.0, 0.99] set the fog_start as a fraction of the viewing_range.
                Any value < 0, resets the behavior to being client-controlled.
                (default: -1)
-            * `fog_color`: ColorSpec, override the color of the fog.
+            * `color`: ColorSpec, override the color of the fog.
                Unlike `base_color` above this will apply regardless of the skybox type.
                (default: `"#00000000"`, which means no override)
 * `set_sky(base_color, type, {texture names}, clouds)`
@@ -8987,6 +8987,24 @@ child will follow movement and rotation of that bone.
 * `get_sky_color()`:
     * Deprecated: Use `get_sky(as_table)` instead.
     * returns a table with the `sky_color` parameters as in `set_sky`.
+* `set_fog(fog_parameters)`:
+    * Passing no arguments resets fog to its default values.
+    * `fog` is a table with the following optional fields:
+        * `distance`: integer, set an upper bound for the client's viewing_range.
+           Any value >= 0 sets the desired upper bound for viewing_range,
+           disables range_all and prevents disabling fog (F3 key by default).
+           Any value < 0 resets the behavior to being client-controlled.
+           (default: -1)
+        * `start`: float, override the client's fog_start.
+           Fraction of the visible distance at which fog starts to be rendered.
+           Any value between [0.0, 0.99] set the fog_start as a fraction of the viewing_range.
+           Any value < 0, resets the behavior to being client-controlled.
+           (default: -1)
+        * `color`: ColorSpec, override the color of the fog.
+           Unlike `base_color` in `set_sky`, this will apply regardless of the skybox type.
+           (default: `"#00000000"`, which means no override)
+* `get_fog()`: returns a table with the current fog parameters as in
+    `set_fog`.
 * `set_sun(sun_parameters)`:
     * Passing no arguments resets the sun to its default values.
     * `sun_parameters` is a table with the following optional fields:

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -203,6 +203,7 @@ public:
 	void handleCommand_HudSetFlags(NetworkPacket* pkt);
 	void handleCommand_HudSetParam(NetworkPacket* pkt);
 	void handleCommand_HudSetSky(NetworkPacket* pkt);
+	void handleCommand_HudSetFog(NetworkPacket* pkt);
 	void handleCommand_HudSetSun(NetworkPacket* pkt);
 	void handleCommand_HudSetMoon(NetworkPacket* pkt);
 	void handleCommand_HudSetStars(NetworkPacket* pkt);

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -11,6 +11,7 @@
 struct ParticleParameters;
 struct ParticleSpawnerParameters;
 struct SkyboxParams;
+struct FogParams;
 struct SunParams;
 struct MoonParams;
 struct StarParams;
@@ -31,6 +32,7 @@ enum ClientEventType : u8
 	CE_HUDRM,
 	CE_HUDCHANGE,
 	CE_SET_SKY,
+	CE_SET_FOG,
 	CE_SET_SUN,
 	CE_SET_MOON,
 	CE_SET_STARS,
@@ -124,6 +126,7 @@ struct ClientEvent
 			f32 speed_x;
 			f32 speed_y;
 		} cloud_params;
+		FogParams *fog_params;
 		SunParams *sun_params;
 		MoonParams *moon_params;
 		StarParams *star_params;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2149,6 +2149,7 @@ const ClientEventHandler Game::clientEventHandler[CLIENTEVENT_MAX] = {
 	{&Game::handleClientEvent_HudRemove},
 	{&Game::handleClientEvent_HudChange},
 	{&Game::handleClientEvent_SetSky},
+	{&Game::handleClientEvent_SetFog},
 	{&Game::handleClientEvent_SetSun},
 	{&Game::handleClientEvent_SetMoon},
 	{&Game::handleClientEvent_SetStars},
@@ -2396,23 +2397,24 @@ void Game::handleClientEvent_SetSky(ClientEvent *event, CameraOrientation *cam)
 
 	// Orbit Tilt:
 	sky->setBodyOrbitTilt(event->set_sky->body_orbit_tilt);
+	delete event->set_sky;
+}
 
-	// fog
-	// do not override a potentially smaller client setting.
-	sky->setFogDistance(event->set_sky->fog_distance);
+void Game::handleClientEvent_SetFog(ClientEvent *event, CameraOrientation *cam)
+{
+	sky->setFogDistance(event->fog_params->distance);
 
 	// if the fog distance is reset, switch back to the client's viewing_range
-	if (event->set_sky->fog_distance < 0)
+	if (event->fog_params->distance < 0)
 		draw_control->wanted_range = g_settings->getS16("viewing_range");
 
-	if (event->set_sky->fog_start >= 0)
-		sky->setFogStart(rangelim(event->set_sky->fog_start, 0.0f, 0.99f));
+	if (event->fog_params->start >= 0)
+		sky->setFogStart(rangelim(event->fog_params->start, 0.0f, 0.99f));
 	else
 		sky->setFogStart(rangelim(g_settings->getFloat("fog_start"), 0.0f, 0.99f));
 
-	sky->setFogColor(event->set_sky->fog_color);
-
-	delete event->set_sky;
+	sky->setFogColor(event->fog_params->color);
+	delete event->fog_params;
 }
 
 void Game::handleClientEvent_SetSun(ClientEvent *event, CameraOrientation *cam)

--- a/src/client/game_internal.h
+++ b/src/client/game_internal.h
@@ -270,6 +270,7 @@ private:
 	void handleClientEvent_HudRemove(ClientEvent *event, CameraOrientation *cam);
 	void handleClientEvent_HudChange(ClientEvent *event, CameraOrientation *cam);
 	void handleClientEvent_SetSky(ClientEvent *event, CameraOrientation *cam);
+	void handleClientEvent_SetFog(ClientEvent *event, CameraOrientation *cam);
 	void handleClientEvent_SetSun(ClientEvent *event, CameraOrientation *cam);
 	void handleClientEvent_SetMoon(ClientEvent *event, CameraOrientation *cam);
 	void handleClientEvent_SetStars(ClientEvent *event, CameraOrientation *cam);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -54,6 +54,7 @@ Sky::Sky(s32 id, RenderingEngine *rendering_engine, ITextureSource *tsrc, IShade
 	setAutomaticCulling(scene::EAC_OFF);
 
 	m_sky_params = SkyboxDefaults::getSkyDefaults();
+	m_fog_params = SkyboxDefaults::getFogDefaults();
 	m_sun_params = SkyboxDefaults::getSunDefaults();
 	m_moon_params = SkyboxDefaults::getMoonDefaults();
 	m_star_params = SkyboxDefaults::getStarDefaults();
@@ -82,7 +83,7 @@ Sky::Sky(s32 id, RenderingEngine *rendering_engine, ITextureSource *tsrc, IShade
 
 	m_directional_colored_fog = g_settings->getBool("directional_colored_fog");
 	m_sky_params.body_orbit_tilt = g_settings->getFloat("shadow_sky_body_orbit_tilt", -60., 60.);
-	m_sky_params.fog_start = rangelim(g_settings->getFloat("fog_start"), 0.0f, 0.99f);
+	m_fog_params.start = rangelim(g_settings->getFloat("fog_start"), 0.0f, 0.99f);
 
 	setStarCount(1000);
 }

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -109,16 +109,16 @@ public:
 		ITextureSource *tsrc);
 
 	// Note: the Sky class doesn't use these values. It just stores them.
-	void setFogDistance(s16 fog_distance) { m_sky_params.fog_distance = fog_distance; }
-	s16 getFogDistance() const { return m_sky_params.fog_distance; }
+	void setFogDistance(s16 fog_distance) { m_fog_params.distance = fog_distance; }
+	s16 getFogDistance() const { return m_fog_params.distance; }
 
-	void setFogStart(float fog_start) { m_sky_params.fog_start = fog_start; }
-	float getFogStart() const { return m_sky_params.fog_start; }
+	void setFogStart(float fog_start) { m_fog_params.start = fog_start; }
+	float getFogStart() const { return m_fog_params.start; }
 
-	void setFogColor(video::SColor v) { m_sky_params.fog_color = v; }
+	void setFogColor(video::SColor v) { m_fog_params.color = v; }
 	video::SColor getFogColor() const {
-		if (m_sky_params.fog_color.getAlpha() > 0)
-			return m_sky_params.fog_color;
+		if (m_fog_params.color.getAlpha() > 0)
+			return m_fog_params.color;
 		return getBgColor();
 	}
 
@@ -193,6 +193,7 @@ private:
 	);
 
 	SkyboxParams m_sky_params;
+	FogParams m_fog_params;
 	SunParams m_sun_params;
 	MoonParams m_moon_params;
 	StarParams m_star_params;

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -104,14 +104,15 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_SET_SUN",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetSun }, // 0x5a
 	{ "TOCLIENT_SET_MOON",                 TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetMoon }, // 0x5b
 	{ "TOCLIENT_SET_STARS",                TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetStars }, // 0x5c
-	{ "TOCLIENT_MOVE_PLAYER_REL",          TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MovePlayerRel }, // 0x5d,
+	{ "TOCLIENT_MOVE_PLAYER_REL",          TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MovePlayerRel }, // 0x5d
 	null_command_handler,
 	null_command_handler,
 	{ "TOCLIENT_SRP_BYTES_S_B",            TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_SrpBytesSandB }, // 0x60
-	{ "TOCLIENT_FORMSPEC_PREPEND",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FormspecPrepend }, // 0x61,
-	{ "TOCLIENT_MINIMAP_MODES",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MinimapModes }, // 0x62,
-	{ "TOCLIENT_SET_LIGHTING",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SetLighting }, // 0x63,
-	{ "TOCLIENT_SPAWN_PARTICLE_BATCH",     TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SpawnParticleBatch }, // 0x64,
+	{ "TOCLIENT_FORMSPEC_PREPEND",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FormspecPrepend }, // 0x61
+	{ "TOCLIENT_MINIMAP_MODES",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MinimapModes }, // 0x62
+	{ "TOCLIENT_SET_LIGHTING",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SetLighting }, // 0x63
+	{ "TOCLIENT_SPAWN_PARTICLE_BATCH",     TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SpawnParticleBatch }, // 0x64
+	{ "TOCLIENT_SET_FOG",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetFog }, // 0x65
 };
 
 const static ServerCommandFactory null_command_factory = { nullptr, 0, false };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1397,17 +1397,21 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 		*pkt >> skybox.body_orbit_tilt;
 	}
 
-	if (pkt->getRemainingBytes() >= 6) {
-		*pkt >> skybox.fog_distance >> skybox.fog_start;
-	}
-
-	if (pkt->getRemainingBytes() >= 4) {
-		*pkt >> skybox.fog_color;
-	}
-
 	ClientEvent *event = new ClientEvent();
 	event->type = CE_SET_SKY;
 	event->set_sky = new SkyboxParams(skybox);
+	m_client_event_queue.push(event);
+}
+
+void Client::handleCommand_HudSetFog(NetworkPacket *pkt)
+{
+	FogParams fog;
+
+	*pkt >> fog.distance >> fog.start >> fog.color;
+
+	ClientEvent *event = new ClientEvent();
+	event->type        = CE_SET_FOG;
+	event->fog_params  = new FogParams(fog);
 	m_client_event_queue.push(event);
 }
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -701,7 +701,14 @@ enum ToClientCommand : u16
 			u8[len] serialized ParticleParameters
 	*/
 
-	TOCLIENT_NUM_MSG_TYPES = 0x65,
+	TOCLIENT_SET_FOG = 0x65,
+	/*
+		u16 distance
+		f32 start
+		u8[4] color
+	*/
+
+	TOCLIENT_NUM_MSG_TYPES = 0x66,
 };
 
 enum ToServerCommand : u16

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -213,4 +213,6 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_MINIMAP_MODES",            0, true }, // 0x62
 	{ "TOCLIENT_SET_LIGHTING",             0, true }, // 0x63
 	{ "TOCLIENT_SPAWN_PARTICLE_BATCH",     0, true }, // 0x64
+
+	{ "TOCLIENT_SET_FOG",                  0, true }, // 0x65
 };

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -46,6 +46,7 @@ RemotePlayer::RemotePlayer(const std::string &name, IItemDefManager *idef):
 	// Skybox defaults:
 	m_cloud_params  = SkyboxDefaults::getCloudDefaults();
 	m_skybox_params = SkyboxDefaults::getSkyDefaults();
+	m_fog_params	= SkyboxDefaults::getFogDefaults();
 	m_sun_params    = SkyboxDefaults::getSunDefaults();
 	m_moon_params   = SkyboxDefaults::getMoonDefaults();
 	m_star_params   = SkyboxDefaults::getStarDefaults();

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -76,6 +76,10 @@ public:
 
 	const SkyboxParams &getSkyParams() const { return m_skybox_params; }
 
+	void setFog(const FogParams &fog_params) { m_fog_params = fog_params; }
+
+	const FogParams &getFogParams() const { return m_fog_params; }
+
 	void setSun(const SunParams &sun_params) { m_sun_params = sun_params; }
 
 	const SunParams &getSunParams() const { return m_sun_params; }
@@ -152,6 +156,7 @@ private:
 	CloudParams m_cloud_params;
 
 	SkyboxParams m_skybox_params;
+	FogParams m_fog_params;
 	SunParams m_sun_params;
 	MoonParams m_moon_params;
 	StarParams m_star_params;

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -343,6 +343,12 @@ private:
 	// get_sky_color(self)
 	static int l_get_sky_color(lua_State* L);
 
+	// set_fog(self, fog_parameters)
+	static int l_set_fog(lua_State *L);
+
+	// get_fog(self)
+	static int l_get_fog(lua_State *L);
+
 	// set_sun(self, sun_parameters)
 	static int l_set_sun(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1928,13 +1928,19 @@ void Server::SendSetSky(session_t peer_id, const SkyboxParams &params)
 				<< c.night_sky << c.night_horizon << c.indoors;
 		}
 
-		pkt << params.body_orbit_tilt << params.fog_distance << params.fog_start
-			<< params.fog_color;
+		pkt << params.body_orbit_tilt;
 	}
 
 	Send(&pkt);
 }
 
+void Server::SendSetFog(session_t peer_id, const FogParams &params)
+{
+	NetworkPacket pkt(TOCLIENT_SET_FOG, 0, peer_id);
+	pkt << params.distance << params.start << params.color;
+
+	Send(&pkt);
+}
 void Server::SendSetSun(session_t peer_id, const SunParams &params)
 {
 	NetworkPacket pkt(TOCLIENT_SET_SUN, 0, peer_id);
@@ -3599,6 +3605,13 @@ void Server::setSky(RemotePlayer *player, const SkyboxParams &params)
 	sanity_check(player);
 	player->setSky(params);
 	SendSetSky(player->getPeerId(), params);
+}
+
+void Server::setFog(RemotePlayer *player, const FogParams &params)
+{
+	sanity_check(player);
+	player->setFog(params);
+	SendSetFog(player->getPeerId(), params);
 }
 
 void Server::setSun(RemotePlayer *player, const SunParams &params)

--- a/src/server.h
+++ b/src/server.h
@@ -66,6 +66,7 @@ struct SkyboxParams;
 struct SoundSpec;
 struct StarParams;
 struct SunParams;
+struct FogParams;
 
 namespace con {
 	class IConnection;
@@ -386,6 +387,7 @@ public:
 	void setPlayerEyeOffset(RemotePlayer *player, v3f first, v3f third, v3f third_front);
 
 	void setSky(RemotePlayer *player, const SkyboxParams &params);
+	void setFog(RemotePlayer *player, const FogParams &params);
 	void setSun(RemotePlayer *player, const SunParams &params);
 	void setMoon(RemotePlayer *player, const MoonParams &params);
 	void setStars(RemotePlayer *player, const StarParams &params);
@@ -555,6 +557,7 @@ private:
 	void SendHUDSetFlags(session_t peer_id, u32 flags, u32 mask);
 	void SendHUDSetParam(session_t peer_id, u16 param, std::string_view value);
 	void SendSetSky(session_t peer_id, const SkyboxParams &params);
+	void SendSetFog(session_t peer_id, const FogParams &params);
 	void SendSetSun(session_t peer_id, const SunParams &params);
 	void SendSetMoon(session_t peer_id, const MoonParams &params);
 	void SendSetStars(session_t peer_id, const StarParams &params);

--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -177,7 +177,7 @@ void RemoteClient::GetNextBlocks (
 	s32 new_nearest_unsent_d = -1;
 
 	// Get view range and camera fov (radians) from the client
-	s16 fog_distance = sao->getPlayer()->getSkyParams().fog_distance;
+	s16 fog_distance = sao->getPlayer()->getFogParams().distance;
 	s16 wanted_range = sao->getWantedRange() + 1;
 	if (fog_distance >= 0) {
 		// enforce if limited by mod

--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -34,9 +34,14 @@ struct SkyboxParams
 	video::SColor fog_moon_tint;
 	std::string fog_tint_type;
 	float body_orbit_tilt { INVALID_SKYBOX_TILT };
-	s16 fog_distance { -1 };
-	float fog_start { -1.0f };
-	video::SColor fog_color { 0 }; // override, only used if alpha > 0
+};
+
+struct FogParams
+{
+	// TODO: visible?
+	s16 distance { -1 };
+	float start { -1.0f };
+	video::SColor color { 0 }; // override, only used if alpha > 0
 };
 
 struct SunParams
@@ -94,7 +99,6 @@ public:
 		sky.fog_sun_tint = video::SColor(255, 244, 125, 29);
 		sky.fog_moon_tint = video::SColorf(0.5, 0.6, 0.8, 1).toSColor();
 		sky.fog_tint_type = "default";
-		sky.fog_color = video::SColor(0);
 		return sky;
 	}
 
@@ -111,6 +115,15 @@ public:
 		sky.dawn_sky = video::SColor(255, 180, 186, 250);
 		sky.night_sky = video::SColor(255, 0, 107, 255);
 		return sky;
+	}
+
+	static const FogParams getFogDefaults()
+	{
+		FogParams fog;
+		fog.distance = -1;
+		fog.start = -1;
+		fog.color = video::SColor(0);
+		return fog;
 	}
 
 	static const SunParams getSunDefaults()


### PR DESCRIPTION
Implements part of #14176. Also, fog color wasn't printed with `get_sky`, so I've fixed that.

I've got no experience with the networking code of the engine, so I hope I haven't messed it up. Also, I haven't probably got the time (and the experience?) to implement the issue in full, but time will tell. I think this can be a good start.

I'm applying "Supported by core dev" due to the comments in the original issue.

## To do

This PR is Ready for Review.

## How to test
```lua
core.register_on_joinplayer(function(player)
	core.after(0.5, function()
                -- compatibility should work
		player:set_sky({fog = {fog_distance = 10, fog_start = 0.9, fog_color = "red"}})
		core.after(1, function()
			player:set_sky({fog = {fog_distance = 30}})
			player:set_sky({fog = {fog_start = 0.1}})
			player:set_sky({fog = {fog_color = "blue"}})

			core.chat_send_all(dump(player:get_sky(true).fog))

			core.after(1, function()
				player:set_sky({fog = {}})
			end)
		end)
		
                -- new implementation (decomment)
		--[[player:set_fog({distance = 10, start = 0.9, color = "red"})
		core.after(1, function()
			player:set_fog({distance = 30})
			player:set_fog({start = 0.1})
			player:set_fog({color = "blue"})
			
			core.chat_send_all(dump(player:get_fog()))
			
			core.after(1, function()
				player:set_fog()
			end)
		end)]]
	end)
end)
```
