### PR TITLE
Clarify documentation regarding particlespawner's attract.strength parameter

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -11844,9 +11844,10 @@ Types used are defined in the previous section.
       surface `origin` designates a point in world coordinate space. use this
       for e.g. particles entering or emerging from a portal.
 
-  * float range `strength`: the speed with which particles will move towards
-    the attractor shape. If negative, the particles will instead move away from that
-    point.
+  * float range `strength`: a factor that determines the speed with which particles
+    will move towards the attractor shape. If negative, the particles will instead
+    move away from that point. The actual speed is the product of this parameter and
+    the particle's initial distance from the attractor's origin.
 
   * vec3 `origin`: the origin point of the attractor shape towards which particles will
     initially be oriented. functions as an offset if `origin_attached` is also


### PR DESCRIPTION
This PR clarifies the documentation regarding the role of the `attract.strength` parameter in particlespawner.

Currently (before this patch), the documentation doesn't mention important details about this parameter's role, and states that it specifies the particles'  initial speed, whereas the actual speed also depends on the distance from the origin.

## To do

This PR is a Ready for Review.
<!-- ^ delete one -->

## How to test

Check https://github.com/luanti-org/luanti/issues/16724
