### PR TITLE
Remove hardcoded color of infobox in /help

### DIFF
--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -15,8 +15,8 @@ local LIST_FORMSPEC_DESCRIPTION = [[
 		label[0,-0.1;%s]
 		tablecolumns[color;tree;text;text]
 		table[0,0.5;12.8,4.8;list;%s;%i]
-		box[0,5.5;12.8,1.5;#000]
-		textarea[0.3,5.5;13.05,1.9;;;%s]
+		box[0,5.5;12.8,1.5;]
+		textarea[0.35,5.55;12.9,1.7;;;%s]
 		button_exit[5,7;3,1;quit;%s]
 	]]
 


### PR DESCRIPTION
This PR removes the hardcoded box color in the `/help` window behind the textarea that describes the selected command. It also slightly shrinks the textarea.

## Why?

The short version is: Flexibility. Because it makes it easier to specify game styles without having to work around builtin limitations.

The long version is: IMO builtin formspecs like the `/help` dialog should be stylable as much as possible and respect the game's `set_formspec_prepend` options. Hardcoding any color makes styling them harder as it restricts the amount of possible font colors or formspec colors you can use by default. Currently, this forces game authors to only use bright font colors for text areas, because dark font colors make the text hard to read on the forced dark background in `/help`.

My simple solution is thus to remove the hardcoded box color. The Lua API documentation says that the box is only affected by `style_type` if no color is specified, otherwise the custom style is ignored and the color is hardcoded.

This means that the box by default is now invisible, but game/mod authors can override this box color with adding a `style_type[box;...]` in `set_formspec_prepend`. Don't worry, the default textarea is still easy to read.

I also subtly shrank the text area so that a few negative `borderwidths` values for the `box` style work.

## Context

I have noticed this problem when developing the game C.O.W. where I prefer a darker font color by default which clashes with the dark default box color in `/help`.

## To do

This PR is Ready for Review.

## How to test

1. Open `/help` in DevTest without any further config
2. Install and activate `luacmd` mod
3. In DevTest, enter the following command, then open `/help` in DevTest again:

```
/lua me:set_formspec_prepend("style_type[box;colors=#4080a0ff;borderwidths=-2;bordercolors=#cccccc]")
```

How it looks like after step 1 (this is how `/help` will now look by defaullt):

![nobox](https://github.com/user-attachments/assets/d9cc7ea0-d091-4c01-b70c-7b9888f0ba89)

How it looks like after step 3 (this is how `/help` will look with a `style_type` override by a game or mod):

![nobox2](https://github.com/user-attachments/assets/ddb3edb9-f50e-4df5-94cf-d63f996cf2b8)

You may also remove the borderwitdths and bordercolors or experiment with other style type arguments and colors and see what happens.

(There is no example for positive `borderwidths` argument because of #16437)

## Note to game authors: How to get the old style back

(this section is for reference only)

This PR changes the default looks of `/help` slightly. If you're a game author and for some reason like to have the *exact* looks from before back, you can use this code:

```
player:set_formspec_prepend("style_type[box;colors=#00000080]")
```

(But IMHO you're probably better off in designing your game style from scratch anyway instead of relying on the Luanti defaults.)