### PR TITLE
`get_sky()`: return `fog_color` as well

### DIFF
--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2297,6 +2297,8 @@ int ObjectRef::l_get_sky(lua_State *L)
 	lua_setfield(L, -2, "fog_distance");
 	lua_pushnumber(L, skybox_params.fog_start >= 0 ? skybox_params.fog_start : -1.0f);
 	lua_setfield(L, -2, "fog_start");
+	push_ARGB8(L, skybox_params.fog_color);
+	lua_setfield(L, -2, "fog_color");
 	lua_setfield(L, -2, "fog");
 
 	return 1;


### PR DESCRIPTION
Trivial fix extrapolated from #16725 

## To do

This PR is Ready for Review.

## How to test

```lua
core.register_on_joinplayer(function(player)
	core.chat_send_all(dump(player:get_sky(true).fog))
	
	core.after(0.5, function()
		player:set_sky({fog = {fog_distance = 10, fog_start = 0.9, fog_color = "red"}})
		core.chat_send_all(dump(player:get_sky(true).fog))
	end)
end)
```

Before the PR: no `fog_color` returned. After: returned
