### PR TITLE
Store `metadata:set_int` value as C++ `long`

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8282,8 +8282,10 @@ of the `${k}` syntax in formspecs is not deprecated.
 * `set_string(key, value)`: Value of `""` will delete the key.
 * `get_string(key)`: Returns `""` if key not present.
 * `set_int(key, value)`
-    * The range for the value is system-dependent (usually 32 bits).
-      The value will be converted into a string when stored.
+    * The range for the value is [`-2147483648`...`2147483647`]
+    * Some systems may support larger ranges, but this
+      isn't portable and you shouldn't rely on it
+    * The value will be converted into a string when stored.
 * `get_int(key)`: Returns `0` if key not present.
 * `set_float(key, value)`
     * Store a number (a 64-bit float) exactly.

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -138,7 +138,7 @@ int MetaDataRef::l_set_int(lua_State *L)
 
 	MetaDataRef *ref = checkAnyMetadata(L, 1);
 	std::string name = luaL_checkstring(L, 2);
-	int a = luaL_checkint(L, 3);
+	long a = luaL_checklong(L, 3);
 	std::string str = itos(a);
 
 	IMetadata *meta = ref->getmeta(true);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -398,7 +398,7 @@ inline bool is_yes(std::string_view str)
  * Converts the string \p str to a signed 32-bit integer. The converted value
  * is constrained so that min <= value <= max.
  *
- * @see atoi(3) for limitations
+ * @see atol(3) for limitations
  *
  * @param str
  * @param min Range minimum
@@ -408,7 +408,7 @@ inline bool is_yes(std::string_view str)
  */
 inline s32 mystoi(const std::string &str, s32 min, s32 max)
 {
-	s32 i = atoi(str.c_str());
+	s32 i = atol(str.c_str());
 
 	if (i < min)
 		i = min;
@@ -420,11 +420,11 @@ inline s32 mystoi(const std::string &str, s32 min, s32 max)
 
 /**
  * Returns a 32-bit value reprensented by the string \p str (decimal).
- * @see atoi(3) for further limitations
+ * @see atol(3) for further limitations
  */
 inline s32 mystoi(const std::string &str)
 {
-	return atoi(str.c_str());
+	return atol(str.c_str());
 }
 
 /**


### PR DESCRIPTION
Changes the internal C++ type used to store the number when you call `some_metadata:set_int(some_integer)` from `int` to `long`.

Updates the documentation stating the 32-bit unsigned integer range.

The utility macro `stoi` (which is used by `get_int`) in `string.h` was switched from internally using `atoi` to `atol`.

## Why?

Theoretically, an `int` may only be 16-bit large in the worst case according to the C++ spec. But `long` guarantees 32-bit. The documentation already mentioned 32-bit before but was less clear.

Larger ranges are still possible but Lua devs are instructed to avoid going out of the 32-bit bounds for portable code.

This probably doesn't have a large practical effect, this is more about correctness of the code and more important, make the 32-bit size for `set_int` more explicit in the docs.

`stoi` was switched from using `atoi` to `atol` because they explicitly are intended for 32-bit, not 16-bit.

## To do

This PR is Ready for Review.

## How to test

Get a MetaStorageRef, then run in Lua:

```
meta:set_int("mynumber", 2147483647)
core.log("error", meta:get_int("mynumber"))
```

should print 2147483647.

And:

```
meta:set_int("mynumber", -2147483648)
core.log("error", meta:get_int("mynumber"))
```

should print -2147483648.

## See also

#16735