### PR TITLE
Use std::mutex for the env lock (instead of ordered_mutex)

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -474,7 +474,7 @@ public:
 		EnvAutoLock(Server *server): m_lock(server->m_env_mutex) {}
 
 	private:
-		std::lock_guard<ordered_mutex> m_lock;
+		std::lock_guard<std::mutex> m_lock;
 	};
 
 protected:
@@ -662,7 +662,7 @@ private:
 	*/
 
 	// Environment mutex (envlock)
-	ordered_mutex m_env_mutex;
+	std::mutex m_env_mutex;
 
 	// World directory
 	std::string m_path_world;


### PR DESCRIPTION
I have been looking into why loading blocks from disk actually slows down with multiple emerge threads (while terrain generation speeds up. That is annoying, since now the optimal setting for loading vs generating are different.

As part of of #15151 we turned the env lock into an ordered lock. We also added yielding on busy servers to give emerge threads a chance to catch up.

I noticed that (most of) the extra time spent with multiple emerge threads is in the fair locking. When using std::mutex instead load speed is pretty much the same between 1, 4, and 8 emerge threads.
Whereas with the ordered_mutex 4 threads slow down somewhere 10 and 20% and 8 threads 25% and more.

See also https://irc.luanti.org/luanti-dev/2025-12-12#i_6303185, https://irc.luanti.org/luanti-dev/2025-12-12#i_6303239,  and https://github.com/luanti-org/luanti/pull/16634#issuecomment-3474560085

Add compact, short information about your PR for easier understanding:

- Goal of the PR
Allow fast loading from disk, regardless of how many emerge threads are used.

- How does the PR work?
See above. This is just a trivial change to change ordered_mutex to std::mutex.

## To do

This PR is for testing.
The server can be in various different situation with respect of loads (CPU, Disk, etc), and it is hard to foresee how exactly it will behave in many situation. So this needs to be tested.

Maybe @Warr1024 would be willing to give it a spin again.

## How to test

Join world at a location where the blocks already have been generated (so that they are only loaded from disk). Observe the load performance. Try to busy servers, busy disks, etc.
