### PR TITLE
Restore server description in menu

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -141,11 +141,9 @@ local function get_formspec(tabview, name, tabdata)
 	end
 
 	local selected_server = find_selected_server()
-	if selected_server and selected_server.description then
-		gamedata.serverdescription = selected_server.description
-	end
 
 	if selected_server then
+		gamedata.serverdescription = selected_server.description
 		if gamedata.serverdescription then
 			retval = retval .. "textarea[0.25,1.85;5.25,2.7;;;" ..
 				core.formspec_escape(gamedata.serverdescription) .. "]"


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
Restore the server description.
- How does the PR work?
It restores the description from the server object returned by `find_selected_server()`.
- Does it resolve any reported issue?
Closes #16737
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Not directly, maybe 2.3?

## To do

This PR is ready for review.

- [x] Discuss approach / alternatives

## How to test
Select a server → reopen luanti → observe presence of server description
