### PR TITLE
Bring back max runstep profiler entry

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -136,6 +136,7 @@ void *ServerThread::run()
 
 	while (!stopRequested()) {
 		framemarker.start();
+		ScopeProfiler spm(g_profiler, "Server::RunStep() (max)", SPT_MAX);
 
 		u64 t0 = porting::getTimeUs();
 


### PR DESCRIPTION
Removed in #16716 (and I missed that when I reviewed).

This brings back the "Server::RunStep() (max)" profiler entry.
It's an important highly variable metric to track separately and prominently.

## To do

This PR is Ready for Review.

## How to test

Check that "Server::RunStep() (max)" is back in the profiler pane.