### PR TITLE
Show status text for screenshots in the main menu

### DIFF
--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -8,6 +8,7 @@
 #include <gettext.h>
 #include "gui/mainmenumanager.h"
 #include "gui/guiChatConsole.h"
+#include "gui/statusTextHelper.h"
 #include "gui/touchcontrols.h"
 #include "util/enriched_string.h"
 #include "util/pointedthing.h"
@@ -32,14 +33,6 @@ inline static const char *yawToDirectionString(int yaw)
 	return direction[yaw];
 }
 
-GameUI::GameUI()
-{
-	if (guienv && guienv->getSkin())
-		m_statustext_initial_color = guienv->getSkin()->getColor(gui::EGDC_BUTTON_TEXT);
-	else
-		m_statustext_initial_color = video::SColor(255, 0, 0, 0);
-
-}
 void GameUI::init()
 {
 	// First line of debug text
@@ -71,10 +64,9 @@ void GameUI::init()
 			(g_settings->getU16("recent_chat_messages") + 3)),
 			false, true, guiroot);
 
-	// Status text (displays info when showing and hiding GUI stuff, etc.)
-	m_guitext_status = gui::StaticText::add(guienv, L"<Status>",
-		core::recti(), false, false, guiroot);
-	m_guitext_status->setVisible(false);
+	// Status message for in-game notifications (fly/fast mode, volume changes, etc.)
+	m_status_text = std::make_unique<StatusTextHelper>(guienv, guiroot);
+	m_status_text->setGameStyle();
 
 	// Profiler text (size is updated when text is updated)
 	m_guitext_profiler = gui::StaticText::add(guienv, L"<Profiler>",
@@ -165,47 +157,19 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 	setStaticText(m_guitext_info, m_infotext.c_str());
 	m_guitext_info->setVisible(m_flags.show_hud && g_menumgr.menuCount() == 0);
 
-	static const float statustext_time_max = 1.5f;
-
-	if (!m_statustext.empty()) {
-		m_statustext_time += dtime;
-
-		if (m_statustext_time >= statustext_time_max) {
-			clearStatusText();
-			m_statustext_time = 0.0f;
+	// Update status message element
+	if (m_status_text) {
+		// Handle touch control override if needed
+		bool overridden = g_touchcontrols && g_touchcontrols->isStatusTextOverridden();
+		if (overridden) {
+			m_status_text->setVisible(false);
+			if (g_touchcontrols)
+				g_touchcontrols->getStatusText()->setVisible(true);
+		} else {
+			if (g_touchcontrols)
+				g_touchcontrols->getStatusText()->setVisible(false);
+			m_status_text->update(dtime);
 		}
-	}
-
-	IGUIStaticText *guitext_status;
-	bool overriden = g_touchcontrols && g_touchcontrols->isStatusTextOverriden();
-	if (overriden) {
-		guitext_status = g_touchcontrols->getStatusText();
-		m_guitext_status->setVisible(false);
-	} else {
-		guitext_status = m_guitext_status;
-		if (g_touchcontrols)
-			g_touchcontrols->getStatusText()->setVisible(false);
-	}
-
-	setStaticText(guitext_status, m_statustext.c_str());
-	guitext_status->setVisible(!m_statustext.empty());
-
-	if (!m_statustext.empty()) {
-		s32 status_width  = guitext_status->getTextWidth();
-		s32 status_height = guitext_status->getTextHeight();
-		s32 status_y = screensize.Y  - (overriden ? 15 : 150);
-		s32 status_x = (screensize.X - status_width) / 2;
-
-		guitext_status->setRelativePosition(core::rect<s32>(status_x ,
-			status_y - status_height, status_x + status_width, status_y));
-
-		// Fade out
-		video::SColor fade_color = m_statustext_initial_color;
-		f32 d = m_statustext_time / statustext_time_max;
-		fade_color.setAlpha(static_cast<u32>(
-			fade_color.getAlpha() * (1.0f - d * d)));
-		guitext_status->setOverrideColor(fade_color);
-		guitext_status->enableOverrideColor(true);
 	}
 
 	// Hide chat when disabled by server or when console is visible
@@ -352,10 +316,7 @@ void GameUI::clearText()
 		m_guitext_info = nullptr;
 	}
 
-	if (m_guitext_status) {
-		m_guitext_status->remove();
-		m_guitext_status = nullptr;
-	}
+	m_status_text.reset();
 
 	if (m_guitext_profiler) {
 		m_guitext_profiler->remove();

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -7,7 +7,9 @@
 
 #include "irrlichttypes.h"
 #include <IGUIEnvironment.h>
+#include <memory>
 #include "game.h"
+#include "gui/statusTextHelper.h"
 
 
 class Client;
@@ -33,7 +35,7 @@ class GameUI
 	friend class TestGameUI;
 
 public:
-	GameUI();
+	GameUI() = default;
 	~GameUI() = default;
 
 	// Flags that can, or may, change during main game loop
@@ -59,11 +61,15 @@ public:
 
 	inline void showStatusText(const std::wstring &str)
 	{
-		m_statustext = str;
-		m_statustext_time = 0.0f;
+		if (m_status_text)
+			m_status_text->showStatusText(str);
 	}
 	void showTranslatedStatusText(const char *str);
-	inline void clearStatusText() { m_statustext.clear(); }
+	inline void clearStatusText()
+	{
+		if (m_status_text)
+			m_status_text->clearStatusText();
+	}
 
 	bool isChatVisible()
 	{
@@ -91,10 +97,7 @@ private:
 	gui::IGUIStaticText *m_guitext_info = nullptr; // At the middle of the screen
 	std::wstring m_infotext;
 
-	gui::IGUIStaticText *m_guitext_status = nullptr;
-	std::wstring m_statustext;
-	float m_statustext_time = 0.0f;
-	video::SColor m_statustext_initial_color;
+	std::unique_ptr<StatusTextHelper> m_status_text = nullptr;
 
 	gui::IGUIStaticText *m_guitext_chat = nullptr; // Chat text
 	u32 m_recent_chat_count = 0;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -10,6 +10,7 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiButtonItemImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiButtonKey.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiChatConsole.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/statusTextHelper.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiEditBoxWithScrollbar.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiEngine.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiFormSpecMenu.cpp

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -3,6 +3,7 @@
 // Copyright (C) 2013 sapier
 
 #include "guiEngine.h"
+#include "statusTextHelper.h"
 
 #include "client/fontengine.h"
 #include "client/guiscalingfilter.h"
@@ -12,6 +13,7 @@
 #include "content/content.h"
 #include "content/mods.h"
 #include "filesys.h"
+#include "gettext.h"
 #include "guiMainMenu.h"
 #include "httpfetch.h"
 #include "irrlicht_changes/static_text.h"
@@ -177,6 +179,11 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 
 	m_menu->defaultAllowClose(false);
 	m_menu->lockSize(true,v2u32(800,600));
+
+	// Status message for main menu notifications
+	m_status_text = std::make_unique<StatusTextHelper>(
+		rendering_engine->get_gui_env(), m_parent);
+	m_status_text->setMainMenuStyle();
 
 	g_settings->registerChangedCallback("fullscreen", fullscreenChangedCallback, this);
 
@@ -378,7 +385,15 @@ void GUIEngine::run()
 			if (m_take_screenshot) {
 				m_take_screenshot = false;
 				std::string filename;
-				takeScreenshot(driver, filename);
+				if (takeScreenshot(driver, filename)) {
+					std::string msg = fmtgettext("Saved screenshot to \"%s\"", filename.c_str());
+					m_status_text->showStatusText(utf8_to_wide(msg));
+				}
+			}
+
+			// Update status message
+			if (m_status_text) {
+				m_status_text->update(dtime);
 			}
 
 			driver->endScene();

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -9,12 +9,14 @@
 /******************************************************************************/
 #include "irrlichttypes.h"
 #include "guiFormSpecMenu.h"
+#include "statusTextHelper.h"
 #include "client/clouds.h"
 #include "client/sound.h"
 #include "util/enriched_string.h"
 #include "translation.h"
 
 #include <csignal>
+#include <memory>
 
 /******************************************************************************/
 /* Structs and macros                                                         */
@@ -272,6 +274,9 @@ private:
 	gui::IGUIStaticText *m_irr_toplefttext = nullptr;
 	/** and text that is in it */
 	EnrichedString m_toplefttext;
+
+	/** status message element for menu notifications */
+	std::unique_ptr<StatusTextHelper> m_status_text;
 
 	/** do preprocessing for cloud subsystem */
 	void drawClouds(float dtime);

--- a/src/gui/statusTextHelper.cpp
+++ b/src/gui/statusTextHelper.cpp
@@ -1,0 +1,153 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+#include "statusTextHelper.h"
+
+#include <irrlicht_changes/static_text.h>
+
+#include "client/renderingengine.h"
+
+StatusTextHelper::StatusTextHelper(gui::IGUIEnvironment *guienv, gui::IGUIElement *parent)
+{
+	if (!guienv)
+		return;
+
+	gui::IGUIElement *root = parent ? parent : guienv->getRootGUIElement();
+
+	m_guitext_status = grab(gui::StaticText::add(guienv, L"",
+			core::recti(), false, false, root));
+	m_guitext_status->setVisible(false);
+
+	// Initialize text color from skin
+	if (guienv->getSkin())
+		m_text_color = guienv->getSkin()->getColor(gui::EGDC_BUTTON_TEXT);
+	else
+		m_text_color = video::SColor(255, 0, 0, 0);
+}
+
+StatusTextHelper::~StatusTextHelper()
+{
+	if (m_guitext_status) {
+		m_guitext_status->remove();
+		m_guitext_status.reset();
+	}
+}
+
+void StatusTextHelper::showStatusText(const std::wstring &str)
+{
+	m_statustext = str;
+	m_statustext_time = 0.0f;
+	m_fade_progress = 0.0f;
+}
+
+void StatusTextHelper::clearStatusText()
+{
+	m_statustext.clear();
+	m_statustext_time = 0.0f;
+	m_fade_progress = 0.0f;
+	if (m_guitext_status)
+		m_guitext_status->setVisible(false);
+}
+
+void StatusTextHelper::setVisible(bool visible)
+{
+	if (m_guitext_status)
+		m_guitext_status->setVisible(visible);
+}
+
+bool StatusTextHelper::isVisible() const
+{
+	return m_guitext_status && m_guitext_status->isVisible();
+}
+
+void StatusTextHelper::setGameStyle()
+{
+	m_display_duration = 1.5f;
+	m_background_enabled = false;
+	m_use_main_menu_position = false;
+	// in-game: top-anchored vertically
+	m_text_alignment_v = gui::EGUIA_UPPERLEFT;
+}
+
+void StatusTextHelper::setMainMenuStyle()
+{
+	m_display_duration = 3.0f;
+	m_background_color = video::SColor(220, 0, 0, 0);
+	m_background_enabled = true;
+	m_use_main_menu_position = true;
+	// main menu: centered vertically
+	m_text_alignment_v = gui::EGUIA_CENTER;
+}
+
+void StatusTextHelper::update(float dtime)
+{
+	if (!m_guitext_status || m_statustext.empty())
+		return;
+
+	m_statustext_time += dtime;
+
+	if (m_statustext_time >= m_display_duration) {
+		clearStatusText();
+		return;
+	}
+
+	m_fade_progress = m_statustext_time / m_display_duration;
+
+	// update() is the sole owner of the GUI element's visual state.
+	// showStatusText() only resets the timers; all setText / color /
+	// position work happens here.
+	m_guitext_status->setText(m_statustext.c_str());
+	m_guitext_status->setVisible(true);
+	m_guitext_status->setTextAlignment(gui::EGUIA_CENTER, m_text_alignment_v);
+
+	updatePosition();
+
+	// Quadratic fade feels a bit smoother than linear.
+	const f32 alpha_factor = 1.0f - m_fade_progress * m_fade_progress;
+
+	// Background (optional)
+	if (m_background_enabled) {
+		video::SColor bg_fade = m_background_color;
+		bg_fade.setAlpha(static_cast<u32>(bg_fade.getAlpha() * alpha_factor));
+		m_guitext_status->setBackgroundColor(bg_fade);
+		m_guitext_status->setDrawBackground(true);
+	} else {
+		m_guitext_status->setDrawBackground(false);
+	}
+
+	// Text color fade
+	video::SColor text_fade = m_text_color;
+	text_fade.setAlpha(static_cast<u32>(text_fade.getAlpha() * alpha_factor));
+	m_guitext_status->setOverrideColor(text_fade);
+	m_guitext_status->enableOverrideColor(true);
+}
+
+void StatusTextHelper::updatePosition()
+{
+	if (!m_guitext_status)
+		return;
+
+	v2u32 screensize = RenderingEngine::getWindowSize();
+	s32 text_width = m_guitext_status->getTextWidth();
+	s32 text_height = m_guitext_status->getTextHeight();
+
+	if (m_use_main_menu_position) {
+		// Full-width bar at bottom (main menu style)
+		const s32 bar_height = MAIN_MENU_BAR_HEIGHT;
+		m_guitext_status->setRelativePosition(core::rect<s32>(
+				0,
+				(s32)screensize.Y - bar_height,
+				(s32)screensize.X,
+				(s32)screensize.Y));
+	} else {
+		// Centered above bottom (game style)
+		const s32 status_y = (s32)screensize.Y - 150;
+		const s32 status_x = ((s32)screensize.X - text_width) / 2;
+		m_guitext_status->setRelativePosition(core::rect<s32>(
+				status_x,
+				status_y - text_height,
+				status_x + text_width,
+				status_y));
+	}
+}

--- a/src/gui/statusTextHelper.h
+++ b/src/gui/statusTextHelper.h
@@ -1,0 +1,74 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+#pragma once
+
+#include "irr_ptr.h"
+#include "irrlichttypes.h"
+
+#include <IGUIEnvironment.h>
+#include <IGUIStaticText.h>
+#include <IVideoDriver.h>
+
+#include <string>
+
+/*
+ * Helper for displaying temporary status texts with automatic fade-out.
+ *
+ * IMPORTANT:
+ * This is NOT an Irrlicht IGUIElement.
+ *
+ */
+class StatusTextHelper
+{
+public:
+	StatusTextHelper(gui::IGUIEnvironment *guienv, gui::IGUIElement *parent = nullptr);
+	~StatusTextHelper();
+
+	// Display a status text (will fade out after configured duration)
+	void showStatusText(const std::wstring &str);
+
+	// Update the element (call once per frame)
+	void update(float dtime);
+
+	// Style for in-game display (centered above bottom, no background)
+	void setGameStyle();
+
+	// Style for main menu display (full-width bar at bottom)
+	void setMainMenuStyle();
+
+	// Clear the current text immediately
+	void clearStatusText();
+
+	// Visibility control
+	void setVisible(bool visible);
+	bool isVisible() const;
+
+	// Getters for testing / debugging
+	const std::wstring &getStatusText() const { return m_statustext; }
+	float getStatusTextTime() const { return m_statustext_time; }
+
+private:
+	irr_ptr<gui::IGUIStaticText> m_guitext_status;
+
+	std::wstring m_statustext;
+	float m_statustext_time = 0.0f;
+	float m_display_duration = 1.5f;
+	float m_fade_progress = 0.0f;
+
+	video::SColor m_text_color;
+	video::SColor m_background_color = video::SColor(0, 0, 0, 0);
+
+	bool m_background_enabled = false;
+	bool m_use_main_menu_position = false;
+
+	// Height of the full-width bar at the bottom of the screen (main menu style)
+	static constexpr s32 MAIN_MENU_BAR_HEIGHT = 40;
+
+	// per-style vertical text alignment (horizontal is always centered)
+	gui::EGUI_ALIGNMENT m_text_alignment_v = gui::EGUIA_UPPERLEFT;
+
+	// Internal helper to update position based on screen size and style
+	void updatePosition();
+};

--- a/src/gui/touchcontrols.h
+++ b/src/gui/touchcontrols.h
@@ -117,7 +117,7 @@ public:
 	void registerHotbarRect(u16 index, const recti &rect);
 	std::optional<u16> getHotbarSelection();
 
-	bool isStatusTextOverriden() { return m_overflow_open; }
+	bool isStatusTextOverridden() { return m_overflow_open; }
 	IGUIStaticText *getStatusText() { return m_status_text.get(); }
 
 private:

--- a/src/unittest/test_gameui.cpp
+++ b/src/unittest/test_gameui.cpp
@@ -5,6 +5,7 @@
 #include "test.h"
 
 #include "client/gameui.h"
+#include "gui/statusTextHelper.h"
 
 class TestGameUI : public TestBase
 {
@@ -48,11 +49,18 @@ void TestGameUI::testInit()
 
 void TestGameUI::testStatusText()
 {
-	GameUI gui{};
-	gui.showStatusText(L"test status");
+	StatusTextHelper status_text(nullptr);
 
-	UASSERT(gui.m_statustext_time == 0.0f);
-	UASSERT(gui.m_statustext == L"test status");
+	UASSERT(status_text.getStatusText().empty());
+	UASSERT(status_text.getStatusTextTime() == 0.0f);
+
+	status_text.showStatusText(L"test status");
+	UASSERT(status_text.getStatusText() == L"test status");
+	UASSERT(status_text.getStatusTextTime() == 0.0f);
+
+	status_text.clearStatusText();
+	UASSERT(status_text.getStatusText().empty());
+	UASSERT(status_text.getStatusTextTime() == 0.0f);
 }
 
 void TestGameUI::testInfoText()


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

> [!NOTE]
> I used an LLM Chatbot/Assistant during development, but I take full responsibility for the submitted changes.

This is a follow-up PR of #16749.

- Goal of the PR
Display status messages in the main menu.
- How does the PR work?
Implements a new GUI component GUIStatusText for displaying temporary status messages.
- Does it resolve any reported issue?
Closes #16759
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Not directly, as far as I can tell.
- If not a bug fix, why is this PR needed? What usecases does it solve?
It hints to the user that a screenshot has been made.

## To do

This PR is ready for review.

- [ ] Styling of the status message?

## How to test

open luanti → press F12 / screenshot keybind → observe that a status message appears and fades out again

Make sure that:
- fading works properly
- status text in-game still looks the same

## Preview
<img width="953" height="574" alt="screenshot_20251222_213642" src="https://github.com/user-attachments/assets/5a06da6d-c8db-45c8-a070-054a7d89e247" />
