### PR TITLE
Keybinds UI: Only show “reset” button if value differs from default

### DIFF
--- a/builtin/common/settings/components.lua
+++ b/builtin/common/settings/components.lua
@@ -487,7 +487,9 @@ function make.key(setting)
 		spacing = 0.1,
 
 		get_formspec = function(self, avail_w)
-			self.resettable = core.settings:has(setting.name)
+			local current_value = core.settings:get(setting.name) or ""
+			local default_value = setting.default or ""
+			self.resettable = core.settings:has(setting.name) and (current_value ~= default_value)
 			local btn_bind_width = math.max(2.5, avail_w / 2)
 			local value = core.settings:get(setting.name)
 			local fs = {


### PR DESCRIPTION
- Goal of the PR
The goal of this PR is to fix a UI bug in the settings menu where the "reset" button remains visible even when a setting has been set to its default value.
- How does the PR work?
It changes the reset button logic to "is the current value actually different from the default," preventing redundant icons when a setting matches its default state.
- Does it resolve any reported issue?
Fix [Removing key bindings for things that are unbound by default still displays the "reset" button #16752](https://github.com/luanti-org/luanti/issues/16752)
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Yes, it relates to UI Improvements. It aligns with the general goal of making the settings interface more intuitive and reducing visual clutter.
- If not a bug fix, why is this PR needed? What usecases does it solve?
N/A

## To do

This PR is Ready for Review.


## How to test

1.Open Luanti and go to Settings.
2.Find a keybinding and either clear one that has no default, or manually set one to match its default value.
3.The "Reset" button do not appear.