### PR TITLE
Allow sneak toggling when player does not have the fly privilege

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2016,7 +2016,7 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 	// In free move (fly), the "toggle_sneak_key" setting would prevent precise
 	// up/down movements. Hence, enable the feature only during 'normal' movement.
 	const bool allow_sneak_toggle = m_cache_toggle_sneak_key &&
-		!player->getPlayerSettings().free_move;
+		!(player->getPlayerSettings().free_move && client->checkPrivilege("fly"));
 
 	//TimeTaker tt("update player control", NULL, PRECISION_NANO);
 


### PR DESCRIPTION
Fixes #16780 by implementing the alternative solution.

This only affects the situation where fly mode is enabled but the player does not have the fly privilege. Sneak toggling remains disabled if the player has fly privilege and enables fly mode.

This PR is Ready for Review.

## How to test

* Revoke fly mode of the player.
* Enable fly mode.
* Enable sneak toggling.
* Enable sneaking.
* Oberserve that the player is sneaking.
* Grant fly mode to the player.
* Observe that the player is no longer sneaking.