### PR TITLE
Send modified blocks selectively and as soon as possible

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1166,7 +1166,6 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 		else
 			client->ResendBlockIfOnWire(blockpos);
 
-		getClient(peer_id)->m_time_from_building = 0;
 		return;
 	} // action == INTERACT_DIGGING_COMPLETED
 

--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -246,6 +246,7 @@ void RemoteClient::GetNextBlocks (
 	//bool queue_is_full = false;
 
 	// add modified blocks to the beginning of the queue
+	g_profiler->avg("Server::modified blocks [#]", m_blocks_modified.size());
 	for (v3s16 p : m_blocks_modified) {
 		dest.emplace_back(0.0f, p, peer_id);
 	}
@@ -440,24 +441,8 @@ void RemoteClient::SetBlockNotSent(v3s16 p)
 
 	// remove the block from sending and sent sets,
 	// and reset the scan loop if found
-	if (m_blocks_sending.erase(p) + m_blocks_sent.erase(p) > 0) {
+	if (m_blocks_sending.erase(p) + m_blocks_sent.erase(p) > 0)
 		m_blocks_modified.insert(p);
-
-		// if the player just built, also reset the unsent distance
-		if (m_time_from_building < m_min_time_from_building) {
-			// Note that we do NOT use the euclidean distance here.
-			// getNextBlocks builds successive cube-surfaces in the send loop.
-			// This resets the distance to the maximum cube size that
-			// still guarantees that this block will be scanned again right away.
-			//
-			// Using m_last_center is OK, as a change in center
-			// will reset m_nearest_unsent_d to 0 anyway (see getNextBlocks).
-			p -= m_last_center;
-			s16 this_d = std::max({std::abs(p.X), std::abs(p.Y), std::abs(p.Z)});
-			m_nearest_unsent_d = std::min(m_nearest_unsent_d, this_d);
-		}
-
-	}
 }
 
 void RemoteClient::SetBlocksNotSent(const std::vector<v3s16> &blocks)


### PR DESCRIPTION
This sends changed blocks, _which the client has already seen_, as soon as possible.

This is has four effects:
1. The client actually gets changed blocks more quickly
2. The send loop no longer has to be reset, thus initial map loading is dramatically faster. (over 2x in some tests).
3. The whole "nonsense" of the non-euclidean distance check is no longer necessary.
4. Fewer CPU cycles consumed, as not all blocks have to be rechecked whether they need to be sent or not

Potential disadvantages:
- A changed block that has been sent to the client previously will be sent with priority anyway, if it not currently visible
- A block that is changed to be transparent will not immediately reveal blocks behind it if they are further away from the viewpoint of the client. Those blocks will revealed during the next send loop.

Slightly related #16771

## To do

This PR is a Ready for Review.

## How to test

- Load any map, notice how it loads faster.
- Place a water source, confirm that it spreads water at the expected rate.
- Mine/change blocks in any way, make they the changes are reflected on the client.
- Mine some nodes, so you can look through them, make sure blocks behind are eventually loaded.
- Generally make sure that there are not behavioral changes in any situations... ABMs, etc, etc.