### PR TITLE
Client: Fix crash in 'plantlike' nodes with no textures

### DIFF
--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -130,7 +130,7 @@ static video::ITexture *extractTexture(const TileDef &def, const TileLayer &laye
 		assert(ret->getType() == video::ETT_2D);
 		return ret;
 	}
-	return tsrc->getTextureForMesh(def.name.size() ? def.name : "no_texture.png");
+	return tsrc->getTextureForMesh(def.name.empty() ? "no_texture.png" : def.name);
 }
 
 void getAdHocNodeShader(video::SMaterial &mat, IShaderSource *shdsrc,


### PR DESCRIPTION
This fixes a regression introduced by 293544fb.

Fixes #16791 --> see https://github.com/luanti-org/luanti/issues/16791#issuecomment-3700268011 for defails.

## To do

This PR is Ready for Review.

## How to test

```diff
diff --git a/mods/default/nodes.lua b/mods/default/nodes.lua
index c18fb0a..33c98e9 100644
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -720,9 +720,9 @@ minetest.register_node("default:wood", {
 minetest.register_node("default:sapling", {
 	description = S("Apple Tree Sapling"),
 	drawtype = "plantlike",
-	tiles = {"default_sapling.png"},
-	inventory_image = "default_sapling.png",
-	wield_image = "default_sapling.png",
+	tiles = {},
+	inventory_image = "",
+	wield_image = "",
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
```

Open up sfinv and search for "sapling" to trigger the crash. Otherwise have a stack in your inventory and try to wield it.
