### PR TITLE
Add texel anti-aliasing

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -643,6 +643,11 @@ antialiasing (Antialiasing method) enum none none,fsaa,ssaa
 #    Value of 2 means taking 2x2 = 4 samples.
 fsaa (Anti-aliasing scale) enum 2 2,4,8,16
 
+#    Anti-alias texel edges by using bilinear texture sampling together with a
+#    sample coordinate transformation in the shader.
+#    This setting is ONLY applied if bilinear_filter or trilinear_filter is enabled.
+texel_antialiasing (Texel anti-aliasing) bool false
+
 #    Applies a post-processing filter to detect and smoothen high-contrast edges.
 #    Provides balance between speed and image quality.
 #    fxaa can used in combination with the other anti-aliasing methods
@@ -2085,13 +2090,17 @@ autoscale_mode (Autoscaling mode) enum disable disable,enable,force
 #    This is only useful for debugging.
 array_texture_max (Array texture max layers) int 65535 0 65535
 
-#    When using bilinear/trilinear filtering, low-resolution textures
-#    can be blurred, so this option automatically upscales them to preserve
+#    When using bilinear/trilinear filtering and no UV coordinate transformation
+#    (no texel_antialiasing), low-resolution textures can be blurred,
+#    so this option automatically upscales them to preserve
 #    crisp pixels. This defines the minimum texture size for the upscaled textures;
 #    higher values look sharper, but require more memory.
-#    This setting is ONLY applied if any of the mentioned filters are enabled.
+#    This setting is ONLY applied if any of the mentioned filters are enabled and
+#    texel_antialiasing is disabled.
 #    This is also used as the base node texture size for world-aligned
 #    texture autoscaling.
+#
+#    Requires: !texel_antialiasing
 texture_min_size (Base texture size) int 192 192 16384
 
 #    Side length of a cube of map blocks that the client will consider together

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -3,6 +3,10 @@
 #else
 	uniform sampler2D baseTexture;
 #endif
+#ifdef TEXEL_ANTIALIASING
+	uniform vec2 texelSize0;
+	uniform vec2 texelSizeCrack;
+#endif
 #define crackTexture texture1
 uniform sampler2D crackTexture;
 
@@ -435,15 +439,48 @@ vec2 uv_repeat(vec2 v)
 	return v;
 }
 
+#ifdef TEXEL_ANTIALIASING
+// Move the uv coordinates within the texel such that when sampling the texture
+// with bilinear filtering, the result looks like nearest neighbour sampling
+// with anti-aliased texels.
+// Based on t3ssel8r's code from https://www.patreon.com/posts/83276362.
+vec2 uv_texel_antialias(vec2 uv, vec2 texel_size)
+{
+	float filter_scale = 0.7;
+	vec2 box_size = clamp(filter_scale * fwidth(uv) / texel_size, 1e-5, 1.0);
+	vec2 tx = uv / texel_size - 0.5 * box_size;
+	vec2 tx_off = clamp((fract(tx) - (1.0 - box_size)) / box_size, 0.0, 1.0);
+	return (floor(tx) + 0.5 + tx_off) * texel_size;
+}
+#endif
+
+vec4 sample_base_texture(vec2 uv)
+{
+#ifdef TEXEL_ANTIALIASING
+	vec2 uv_moved = uv_texel_antialias(uv, texelSize0);
+#ifdef USE_ARRAY_TEXTURE
+	return textureGrad(baseTexture, vec3(uv_moved, float(varTexLayer)),
+		dFdx(uv), dFdy(uv)).rgba;
+#elif (!defined GL_ES && __VERSION__ >= 130) || (defined GL_ES && __VERSION__ >= 300)
+	return textureGrad(baseTexture, uv_moved, dFdx(uv), dFdy(uv)).rgba;
+#else
+	// For the deprecated texture2D there is no texture2DGrad
+	return texture2D(baseTexture, uv_moved).rgba;
+#endif
+#else
+#ifdef USE_ARRAY_TEXTURE
+	return texture(baseTexture, vec3(uv, float(varTexLayer))).rgba;
+#else
+	return texture2D(baseTexture, uv).rgba;
+#endif
+#endif
+}
+
+
 void main(void)
 {
 	vec2 uv = varTexCoord.st;
-
-#ifdef USE_ARRAY_TEXTURE
-	vec4 base = texture(baseTexture, vec3(uv, float(varTexLayer))).rgba;
-#else
-	vec4 base = texture2D(baseTexture, uv).rgba;
-#endif
+	vec4 base = sample_base_texture(uv);
 
 	// Handle transparency by discarding pixel as appropriate.
 #ifdef USE_DISCARD
@@ -463,7 +500,18 @@ void main(void)
 
 		vec2 cuv_offset = vec2(0.0, crack_progress / crackAnimationLength);
 		vec2 cuv_factor = vec2(1.0, 1.0 / crackAnimationLength);
-		vec4 crack = texture2D(crackTexture, cuv_offset + orig_uv * cuv_factor);
+#ifdef TEXEL_ANTIALIASING
+		vec2 orig_uv_unmoved = orig_uv;
+		orig_uv = uv_texel_antialias(orig_uv, texelSizeCrack / cuv_factor);
+#endif
+		vec2 sample_pos = cuv_offset + orig_uv * cuv_factor;
+#if defined TEXEL_ANTIALIASING && ((!defined GL_ES && __VERSION__ >= 130) || (defined GL_ES && __VERSION__ >= 300))
+		vec4 crack = textureGrad(crackTexture, sample_pos,
+			dFdx(orig_uv_unmoved) * cuv_factor,
+			dFdy(orig_uv_unmoved) * cuv_factor);
+#else
+		vec4 crack = texture2D(crackTexture, sample_pos);
+#endif
 		base = mix(base, crack, crack.a);
 	}
 

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -3,6 +3,9 @@
 #else
 	uniform sampler2D baseTexture;
 #endif
+#ifdef TEXEL_ANTIALIASING
+	uniform vec2 texelSize0;
+#endif
 
 uniform vec3 dayLight;
 uniform lowp vec4 fogColor;
@@ -364,16 +367,44 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 #endif
 #endif
 
+#ifdef TEXEL_ANTIALIASING
+// Copied from the nodes fragment shader
+vec2 uv_texel_antialias(vec2 uv, vec2 texel_size)
+{
+	float filter_scale = 0.7;
+	vec2 box_size = clamp(filter_scale * fwidth(uv) / texel_size, 1e-5, 1.0);
+	vec2 tx = uv / texel_size - 0.5 * box_size;
+	vec2 tx_off = clamp((fract(tx) - (1.0 - box_size)) / box_size, 0.0, 1.0);
+	return (floor(tx) + 0.5 + tx_off) * texel_size;
+}
+#endif
+
+vec4 sample_base_texture(vec2 uv)
+{
+#ifdef TEXEL_ANTIALIASING
+	vec2 uv_moved = uv_texel_antialias(uv, texelSize0);
+#ifdef USE_ARRAY_TEXTURE
+	return textureGrad(baseTexture, vec3(uv_moved, float(varTexLayer)),
+		dFdx(uv), dFdy(uv)).rgba;
+#elif (!defined GL_ES && __VERSION__ >= 130) || (defined GL_ES && __VERSION__ >= 300)
+	return textureGrad(baseTexture, uv_moved, dFdx(uv), dFdy(uv)).rgba;
+#else
+	// For the deprecated texture2D there is no texture2DGrad
+	return texture2D(baseTexture, uv_moved).rgba;
+#endif
+#else
+#ifdef USE_ARRAY_TEXTURE
+	return texture(baseTexture, vec3(uv, float(varTexLayer))).rgba;
+#else
+	return texture2D(baseTexture, uv).rgba;
+#endif
+#endif
+}
+
 
 void main(void)
 {
-	vec2 uv = varTexCoord.st;
-
-#ifdef USE_ARRAY_TEXTURE
-	vec4 base = texture(baseTexture, vec3(uv, float(varTexLayer))).rgba;
-#else
-	vec4 base = texture2D(baseTexture, uv).rgba;
-#endif
+	vec4 base = sample_base_texture(varTexCoord.st);
 
 	// Handle transparency by discarding pixel as appropriate.
 #ifdef USE_DISCARD

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -149,6 +149,7 @@ static bool setMaterialTextureAndFilters(video::SMaterial &material,
 {
 	bool use_trilinear_filter = g_settings->getBool("trilinear_filter");
 	bool use_bilinear_filter = g_settings->getBool("bilinear_filter");
+	bool use_texel_antialiasing = g_settings->getBool("texel_antialiasing");
 	bool use_anisotropic_filter = g_settings->getBool("anisotropic_filter");
 
 	video::ITexture *texture = tsrc->getTextureForMesh(texturestring);
@@ -157,10 +158,13 @@ static bool setMaterialTextureAndFilters(video::SMaterial &material,
 
 	material.setTexture(0, texture);
 
-	// don't filter low-res textures, makes them look blurry
-	const core::dimension2d<u32> &size = texture->getOriginalSize();
-	if (std::min(size.Width, size.Height) < TEXTURE_FILTER_MIN_SIZE)
-		use_trilinear_filter = use_bilinear_filter = false;
+	if (!use_texel_antialiasing) {
+		// Don't filter low-res textures without texel anti-aliasing, makes them
+		// look blurry
+		const core::dimension2d<u32> &size = texture->getOriginalSize();
+		if (std::min(size.Width, size.Height) < TEXTURE_FILTER_MIN_SIZE)
+			use_trilinear_filter = use_bilinear_filter = false;
+	}
 
 	material.forEachTexture([=] (auto &tex) {
 		setMaterialFilters(tex, use_bilinear_filter, use_trilinear_filter,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -85,7 +85,9 @@ class GameGlobalShaderUniformSetter : public IShaderUniformSetter
 	CachedVertexShaderSetting<float, 3> m_camera_position_vertex{"cameraPosition"};
 	CachedVertexShaderSetting<float, 2> m_texel_size0_vertex{"texelSize0"};
 	CachedPixelShaderSetting<float, 2> m_texel_size0_pixel{"texelSize0"};
+	CachedPixelShaderSetting<float, 2> m_texel_size_crack_pixel{"texelSizeCrack"};
 	v2f m_texel_size0;
+	v2f m_texel_size_crack;
 
 	CachedStructPixelShaderSetting<float, 7> m_exposure_params_pixel{
 		"exposureParams",
@@ -177,6 +179,7 @@ public:
 
 		m_texel_size0_vertex.set(m_texel_size0, services);
 		m_texel_size0_pixel.set(m_texel_size0, services);
+		m_texel_size_crack_pixel.set(m_texel_size_crack, services);
 
 		{
 			float tmp = m_crack_animation_length_i;
@@ -271,6 +274,13 @@ public:
 			m_texel_size0 = v2f(1.f / size.Width, 1.f / size.Height);
 		} else {
 			m_texel_size0 = v2f();
+		}
+		video::ITexture *texture_crack = material.getTexture(1);
+		if (texture_crack) {
+			core::dimension2du size = texture_crack->getSize();
+			m_texel_size_crack = v2f(1.f / size.Width, 1.f / size.Height);
+		} else {
+			m_texel_size_crack = v2f();
 		}
 	}
 };
@@ -367,6 +377,11 @@ public:
 
 		constants["ENABLE_WAVING_LEAVES"] = g_settings->getBool("enable_waving_leaves") ? 1 : 0;
 		constants["ENABLE_WAVING_PLANTS"] = g_settings->getBool("enable_waving_plants") ? 1 : 0;
+
+		if (g_settings->getBool("texel_antialiasing")
+				&& (g_settings->getBool("trilinear_filter")
+				|| g_settings->getBool("bilinear_filter")))
+			constants["TEXEL_ANTIALIASING"] = 1;
 	}
 };
 

--- a/src/client/imagesource.cpp
+++ b/src/client/imagesource.cpp
@@ -1493,6 +1493,9 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 			 * low-res textures BECOME high-res ones. This is helpful for worlds that
 			 * mix high- and low-res textures, or for mods with least-common-denominator
 			 * textures that don't have the resources to offer high-res alternatives.
+			 * With texel_antialiasing, the shader moves the UV coordinates such that the
+			 * output looks like nearest neighbour sampling with anti-aliased texel edges;
+			 * in this case the upscaling is redundant and therefore disabled.
 			 *
 			 * Q: why not just enable/disable filtering depending on texture size?
 			 * A: large texture resolutions apparently allow getting rid of the Moire
@@ -1500,8 +1503,8 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 			 *    see <https://github.com/luanti-org/luanti/issues/15604> and related
 			 *    linked discussions.
 			 */
-			const bool filter = m_setting_trilinear_filter || m_setting_bilinear_filter;
-			if (filter) {
+			if (!m_setting_texel_antialiasing &&
+					(m_setting_trilinear_filter || m_setting_bilinear_filter)) {
 				const f32 scaleto = rangelim(g_settings->getU16("texture_min_size"),
 					TEXTURE_FILTER_MIN_SIZE, 16384);
 
@@ -1803,7 +1806,8 @@ ImageSource::ImageSource() :
 		m_setting_mipmap{g_settings->getBool("mip_map")},
 		m_setting_trilinear_filter{g_settings->getBool("trilinear_filter")},
 		m_setting_bilinear_filter{g_settings->getBool("bilinear_filter")},
-		m_setting_anisotropic_filter{g_settings->getBool("anisotropic_filter")}
+		m_setting_anisotropic_filter{g_settings->getBool("anisotropic_filter")},
+		m_setting_texel_antialiasing{g_settings->getBool("texel_antialiasing")}
 {}
 
 video::IImage* ImageSource::generateImage(std::string_view name,

--- a/src/client/imagesource.h
+++ b/src/client/imagesource.h
@@ -65,6 +65,7 @@ private:
 	bool m_setting_trilinear_filter;
 	bool m_setting_bilinear_filter;
 	bool m_setting_anisotropic_filter;
+	bool m_setting_texel_antialiasing;
 
 	// Cache of source images
 	SourceImageCache m_sourcecache;

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -234,6 +234,7 @@ WieldMeshSceneNode::WieldMeshSceneNode(scene::ISceneManager *mgr, s32 id):
 	m_anisotropic_filter = g_settings->getBool("anisotropic_filter");
 	m_bilinear_filter = g_settings->getBool("bilinear_filter");
 	m_trilinear_filter = g_settings->getBool("trilinear_filter");
+	m_texel_antialiasing = g_settings->getBool("texel_antialiasing");
 
 	// If this is the first wield mesh scene node, create a cache
 	// for extrusion meshes (and a cube mesh), otherwise reuse it
@@ -321,13 +322,15 @@ void WieldMeshSceneNode::setExtruded(video::ITexture *texture,
 		material.MaterialType = m_material_type;
 		material.MaterialTypeParam = 0.5f;
 		material.BackfaceCulling = true;
-		// don't filter low-res textures, makes them look blurry
+		// Don't filter low-res textures without texel anti-aliasing,
+		// makes them look blurry
 		material.forEachTexture([=] (auto &tex) {
 			video::ITexture *t = tex.Texture;
 			if (!t)
 				return;
 			core::dimension2d<u32> d = t->getSize();
-			bool f_ok = std::min(d.Width, d.Height) >= TEXTURE_FILTER_MIN_SIZE;
+			bool f_ok = m_texel_antialiasing ||
+				std::min(d.Width, d.Height) >= TEXTURE_FILTER_MIN_SIZE;
 			setMaterialFilters(tex, m_bilinear_filter && f_ok,
 				m_trilinear_filter && f_ok, m_anisotropic_filter);
 		});

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -151,6 +151,7 @@ private:
 	bool m_anisotropic_filter;
 	bool m_bilinear_filter;
 	bool m_trilinear_filter;
+	bool m_texel_antialiasing;
 	/*!
 	 * Stores the colors and animation data of the mesh's mesh buffers.
 	 * This does not include lighting.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -239,6 +239,7 @@ void set_default_settings()
 	settings->setDefault("opengl_debug", "true");
 #endif
 	settings->setDefault("fsaa", "2");
+	settings->setDefault("texel_antialiasing", "false");
 	settings->setDefault("undersampling", "1");
 	settings->setDefault("world_aligned_mode", "enable");
 	settings->setDefault("autoscale_mode", "disable");


### PR DESCRIPTION
Nearest neighbour sampling causes aliasing on texel boundaries. With bilinear filtering and a nonlinear transformation of UV coordinates, we can render textures such that it looks like nearest neighbour sampling with anti-aliased texel edges.

This is an implementation of what has been linked at: https://github.com/luanti-org/luanti/issues/13108#issuecomment-3126743438

Example image with enabled texel_antialias and bilinear filtering, and strong undersampling:
<img width="1190" height="813" alt="texel_antialias,bilinear" src="https://github.com/user-attachments/assets/f20b156e-ebd9-4aa7-9ebb-18138ee1e0f9" />
(taken at 2025-12-31)


## Limitations

These limitations are not something newly introduced by this PR but have an impact on the  anti-aliasing quality nonetheless.

### Seams due to tiling

Like with current bilinear filtering, texel colours reach the opposite side of the node.
Example, where a stripe of blue from the right side of the A appears on the left side of the texture, among other such stripes: 
<img width="1190" height="813" alt="screenshot_20251231_174313" src="https://github.com/user-attachments/assets/672f649d-fa18-431d-ad1e-7db5159ad1ab" />

### Darkening due to gamma-incorrect rendering

Like with mip mapping, since rendering happens without gamma correction, pixels can be darkened. In this example, green and red mix to dark pixels because of the non-linearity of sRGB:
<img width="1190" height="813" alt="screenshot_20251231_173856" src="https://github.com/user-attachments/assets/a0944a4a-dfe4-4032-94df-d6ee0e8c0fd8" />

### Transparent texels

The texel anti-aliasing does not apply at edges between opaque and fully transparent texels since this would require expensive alpha compositing, or alpha to coverage, which isn't implemented yet and needs MSAA.

### Formspec, particles and sky

Texel anti-aliasing doesn't work in cases where nearest sampling happens even if bi-/trilinear filter is enabled. See the table below for details.

## Sampling behaviour

|Case|Trilinear (master, commit 9e06189a188)|Trilinear + Texel antialias (21.01.2026, commit 6cb8fce79)|
|--|--|--|
|nodes|blur|texel aa|
|crack|blur|texel aa|
|formspec image|crisp|crisp|
|formspec background|crisp|crisp|
|formspec model|crisp|crisp|
|formspec item_image stone|crisp|crisp|
|formspec item_image pickaxe|crisp|crisp|
|formspec item animated stone|crisp|crisp|
|formspec item animated pickaxe|crisp|crisp|
|wielded cobble|blur|texel aa|
|wielded pickaxe|blur|texel aa|
|object dropped cobble|blur|texel aa|
|object dropped pickaxe|blur|texel aa|
|object boat|blur|texel aa|
|particles (devtest spawner)|crisp|crisp|
|sky skybox|blur|very blur|
|sky sun sunrise|blur|very blur|
|sky sun texture|crisp|crisp|
|sky moon texture|crisp|crisp|

|Value|Meaning|
|--|--|
|crisp|sampled with nearest neighbour|
|texel aa|texel anti-aliased, i.e. sampled with bilinear or trilinear and with transformed UV coordinates|
|blur|sampled with bilinear or trilinear after upscaling to texture_min_size|
|very blur|sampled with bilinear or trilinear without the upscaling|

The skybox and sunrise textures are "very blur" with disabled bi-/trilinear filter in the master branch, too, so there's probably a bug in the master branch where texture_min_size applies to these textures although it shouldn't.


## To do

* Find an example where textureGrad() instead of texture2D() is needed to justify the code complexity.

## How to test

Enable bilinear or trilinear filtering. Enabling undersampling can help to investigate the effect.

Chat commands to set sykbox, sunrise, sun and moon textures with [luacmd](https://github.com/HybridDog/luacmd/) and minetest_game:
```
/lua me:set_sky{type="skybox", textures={"default_cobble.png","default_cobble.png","default_cobble.png","default_cobble.png","default_cobble.png","default_cobble.png"}}
/lua me:set_sun{texture="default_wood.png", sunrise="default_stone.png"}
/lua me:set_moon{texture="default_wood.png"}
```
Chat commands to show formspec image, background, model, item_image with stone and item_image with a pick:
```
/lua core.show_formspec(me:get_player_name(), "", "size[8,10]image[1,0;6,5;default_cobble.png]background[0,0;1,2;default_wood.png]")
/lua core.show_formspec(me:get_player_name(), "", "size[8,10]model[0,0;6,6;bla;boats_boat.obj;default_wood.png;;;;;]")
/lua core.show_formspec(me:get_player_name(), "", "size[8,10]item_image[0,0;8,5;default:stone]item_image[0,5;8,5;default:pick_mese]")
```


### Quadratic kernel

In the video and additional notes at https://www.patreon.com/posts/83276362, t3ssel8r has shown a different way to smooth the edge. 
To me the result with my code looked almost the same, so I have kept the simpler code.
Here's my code which should use the quadratic kernel if I didn't make a mistake:
```glsl
vec2 smoothstep_impl(vec2 edge0, vec2 edge1, vec2 x) {
	vec2 t = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
	return t * t * (3.0 - 2.0 * t);
}

vec2 uv_texel_antialias()
{
	vec2 box_size = clamp(fwidth(varTexCoord.st) / texelSize0, 1e-5, 1.0);
	vec2 tx = varTexCoord.st / texelSize0 - 0.5 * box_size;
	vec2 tx_off = smoothstep_impl(1.0 - box_size, vec2(1.0), fract(tx));
	return (floor(tx) + 0.5 + tx_off) * texelSize0;
}
```

### Effect of textureGrad()

I couldn't find an example where using textureGrad() instead of texture() in the shader fixes artifacts. It'd be nice to have an example to justify the change.
