### PR TITLE
Add server list sort filter

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -104,7 +104,7 @@ local function get_formspec(tabview, name, tabdata)
 				"game:<name>",
 				"mod:<name>",
 				"player:<name>",
-				"sort:{-}name|relevance|players|mods|uptime|ping|lag",
+				"sort:[-](name|relevance|players|mods|uptime|ping|lag)",
 		}, "\n") .. "]" ..
 		"field_enter_after_edit[te_search;true]" ..
 		"container[7.25,0.25]" ..


### PR DESCRIPTION
Closes #11083 and part of #12858

Supports sorting by `name`, `relevance`, `players`, `mods`, `uptime`, `ping`, `lag` and  `-` reverses the order.

The default order for each option (descending or ascending) is chosen by what you would typically prefer.

Only each section gets sorted, i.e. the favorites and public servers section get sorted separately.
We probably want to separate them into tabs in the future anyway, so I don't think it matters now.


## To do

Ready for Review.

## How to test

Search the serverlist enter for example:
`sort:players`
`sort:-players`
`sort:-relevance`
`sort:name`
`sort:mods`
`sort:ping`
`sort:lag`
`sort:uptime`
