### PR TITLE
Raise MAX_REGISTERED_CONTENT

### DIFF
--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -12,22 +12,17 @@
 class NodeDefManager;
 class Map;
 
-/*
-	Naming scheme:
-	- Material = irrlicht's Material class
-	- Content = (content_t) content of a node
-	- Tile = TileSpec at some side of a node of some content type
-*/
+// content_t denotes the content of a node
 typedef u16 content_t;
 #define CONTENT_MAX UINT16_MAX
 
 /*
-	The maximum node ID that can be registered by mods. This must
-	be significantly lower than the maximum content_t value, so that
-	there is enough room for dummy node IDs, which are created when
+	The maximum node ID that can be registered by mods. This is
+	somewhat lower than the maximum content_t value, so that
+	there is enough room for dummy node IDs. These are created when
 	a MapBlock containing unknown node names is loaded from disk.
 */
-#define MAX_REGISTERED_CONTENT 0x7fffU
+static constexpr content_t MAX_REGISTERED_CONTENT = CONTENT_MAX - CONTENT_MAX / 10;
 
 /*
 	A solid walkable node with the texture unknown_node.png.
@@ -97,9 +92,6 @@ enum Rotation {
  */
 #define LIQUID_LEVEL_MASK 0x07
 #define LIQUID_FLOW_DOWN_MASK 0x08
-
-//#define LIQUID_LEVEL_MASK 0x3f // better finite water
-//#define LIQUID_FLOW_DOWN_MASK 0x40 // not used when finite water
 
 /* maximum amount of liquid in a block */
 #define LIQUID_LEVEL_MAX LIQUID_LEVEL_MASK


### PR DESCRIPTION
this is now much safer after #16790

fixes #6101

## To do

This PR is a Ready for Review.

## How to test

```lua
for i = 1, 34210 do
	minetest.register_node("test2:dummy" .. i, {
		description = "dummy node " .. i,
		tiles = {"default_wood.png^[transformFY"},
		groups = {crumbly = 3},
	})
end
```

(the creative inventory will be kinda laggy and you also can't take items from the last few pages :thinking:)