### PR TITLE
Send key updates to the server immediately (to fix presses shorter than 100ms being missed)

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -578,8 +578,7 @@ void Client::step(float dtime)
 		Send player position to server
 	*/
 	{
-		float &counter = m_playerpos_send_timer;
-		counter += dtime;
+		m_playerpos_send_timer += dtime;
 		if (m_state == LC_Ready) {
 			sendPlayerPos();
 		}
@@ -1454,7 +1453,7 @@ void Client::sendPlayerPos()
 		if (m_playerpos_repeat_count >= 5)
 			return;
 	} else {
-		// keys changed, send package directly (even if the recommended send interval is not reached yet)
+		// something changed, send package directly (even if the recommended send interval is not reached yet)
 		m_playerpos_repeat_count = 0;
 	}
 	m_playerpos_send_timer = 0;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -580,8 +580,7 @@ void Client::step(float dtime)
 	{
 		float &counter = m_playerpos_send_timer;
 		counter += dtime;
-		if (m_state == LC_Ready && counter >= m_recommended_send_interval) {
-			counter = 0;
+		if (m_state == LC_Ready) {
 			sendPlayerPos();
 		}
 	}
@@ -1443,6 +1442,10 @@ void Client::sendPlayerPos()
 			player->last_movement_dir    == movement_dir);
 
 	if (identical) {
+		if (m_playerpos_send_timer < m_recommended_send_interval) {
+			// do not send package with identical information yet (recommended send interval not reached yet)
+			return;
+		}
 		// Since the movement info is sent non-reliable an unfortunate desync might
 		// occur if we stop sending and the last packet gets lost or re-ordered.
 		// To make this situation less likely we stop sending duplicate packets
@@ -1451,8 +1454,10 @@ void Client::sendPlayerPos()
 		if (m_playerpos_repeat_count >= 5)
 			return;
 	} else {
+		// keys changed, send package directly (even if the recommended send interval is not reached yet)
 		m_playerpos_repeat_count = 0;
 	}
+	m_playerpos_send_timer = 0;
 
 	player->last_position        = player->getPosition();
 	player->last_speed           = player->getSpeed();

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1442,7 +1442,7 @@ void Client::sendPlayerPos()
 
 	if (identical) {
 		if (m_playerpos_send_timer < m_recommended_send_interval) {
-			// do not send package with identical information yet (recommended send interval not reached yet)
+			// do not send packet with identical information yet (recommended send interval not reached yet)
 			return;
 		}
 		// Since the movement info is sent non-reliable an unfortunate desync might
@@ -1453,7 +1453,7 @@ void Client::sendPlayerPos()
 		if (m_playerpos_repeat_count >= 5)
 			return;
 	} else {
-		// something changed, send package directly (even if the recommended send interval is not reached yet)
+		// something changed, send packet directly (even if the recommended send interval is not reached yet)
 		m_playerpos_repeat_count = 0;
 	}
 	m_playerpos_send_timer = 0;


### PR DESCRIPTION
- Goal of the PR
Fast/short key presses should always result in a change to the result of `player.get_player_control()` - for at least one game step.

- How does the PR work?
In client.cpp, `sendPlayerPos()` is only called if `counter >= m_recommended_send_interval`, which is fine for sending repeated packets to the server. Checking if any pressed keys changed is already done in `sendPlayerPos()`.
This PR moves the `counter >= m_recommended_send_interval` check to `sendPlayerPos()`, into the `if (identical)` branch. This way, a package with new key state is directly send when a key is pressed.
Without this change, a short key press is lost if the m_recommended_send_interval (by default 100ms) just started, a key is pressed and released before the timer ends. After 100ms, the position and pressed keys are sent again, but the already released key press is lost.

- Does it resolve any reported issue?
This one.

- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
No

## To do

This PR is Ready for Review.

## How to test

Example how to reproduce in singleplayer mode, short press aux1 or jump (or other keys):
```
local previous_control = {}
core.register_globalstep(function()
	for _, player in pairs(core.get_connected_players()) do
		local name = player:get_player_name()
		local control = player:get_player_control()
		for key, value in pairs(control) do
			if previous_control[key] ~= value then
				print(name .. ":" .. key .. ":" .. tostring(value))
			end
		end
		previous_control = control
		return
	end
end)
```