### PR TITLE
Run place/secondary_use functions also when dig is held down

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2749,6 +2749,13 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 		if (wasKeyPressed(KeyType::DIG) && (!client->modsLoaded() ||
 				!client->getScript()->on_item_use(selected_item, pointed)))
 			client->interact(INTERACT_USE, pointed);
+
+		if (wasKeyPressed(KeyType::PLACE)) {
+			if (pointed.type == POINTEDTHING_NODE)
+				handlePointingAtNode(pointed, selected_item, hand_item, dtime);
+			else
+				handlePointingAtNothing(selected_item);
+		}
 	} else if (pointed.type == POINTEDTHING_NODE) {
 		handlePointingAtNode(pointed, selected_item, hand_item, dtime);
 	} else if (pointed.type == POINTEDTHING_OBJECT) {
@@ -2762,6 +2769,13 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 		// Run callback even though item is not usable
 		if (wasKeyPressed(KeyType::DIG) && client->modsLoaded())
 			client->getScript()->on_item_use(selected_item, pointed);
+
+		if (wasKeyPressed(KeyType::PLACE)) {
+			if (pointed.type == POINTEDTHING_NODE)
+				handlePointingAtNode(pointed, selected_item, hand_item, dtime);
+			else
+				handlePointingAtNothing(selected_item);
+		}
 	} else if (wasKeyPressed(KeyType::PLACE)) {
 		handlePointingAtNothing(selected_item);
 	}


### PR DESCRIPTION
Fixes #13581

## To do

This PR is Ready for Review.

## How to test

1. Snippet in the linked issue (items with `on_use`)
2. Edit a devtest pickaxe (items without `on_use`) adding
```lua
on_secondary_use = function(itemstack, user, pointed_thing)
    core.chat_send_all("On secondary use")
end,
	   
on_place = function(itemstack, user, pointed_thing)
    core.chat_send_all("On place")
end
```

3. Right-click around whilst digging (in the air or not), they should now work